### PR TITLE
Extract translatable strings from Obj-C++ files (.mm) also

### DIFF
--- a/locale/Makefile
+++ b/locale/Makefile
@@ -34,6 +34,7 @@ wxstd.pot:
 	touch $@
 	find ../include -name "*.h" | $(XARGS) $(XGETTEXT) $(XGETTEXT_ARGS) -o wxstd.pot
 	find ../src -name "*.cpp" | $(XARGS) $(XGETTEXT) $(XGETTEXT_ARGS) -o wxstd.pot
+	find ../src -name "*.mm" | $(XARGS) $(XGETTEXT) $(XGETTEXT_ARGS) -o wxstd.pot
 
 allpo: force-update
 	@-for t in $(WX_LINGUAS_UPDATE); do $(MAKE) $$t.po; done

--- a/locale/af.po
+++ b/locale/af.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-21 14:25+0200\n"
+"POT-Creation-Date: 2020-10-18 23:11+0300\n"
 "PO-Revision-Date: 2013-11-04 10:21+0200\n"
 "Last-Translator: F Wolff <friedel@translate.org.za>\n"
 "Language-Team: translate-discuss-af@lists.sourceforge.net\n"
@@ -15,7 +15,7 @@ msgstr ""
 "X-Generator: Virtaal 0.9.0-rc1\n"
 "X-Project-Style: kde\n"
 
-#: ../src/common/debugrpt.cpp:586
+#: ../src/common/debugrpt.cpp:587
 msgid ""
 "\n"
 "Please send this report to the program maintainer, thank you!\n"
@@ -23,8 +23,8 @@ msgstr ""
 "\n"
 "Stuur asb. die verslag aan wie ook al die program onderhou. Dankie!\n"
 
-#: ../src/richtext/richtextstyledlg.cpp:210
-#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:206
+#: ../src/richtext/richtextstyledlg.cpp:218
 msgid " "
 msgstr " "
 
@@ -32,70 +32,96 @@ msgstr " "
 msgid "              Thank you and we're sorry for the inconvenience!\n"
 msgstr "              Dankie, en jammer vir die ongerief!\n"
 
-#: ../src/common/prntbase.cpp:573
+#: ../src/common/prntbase.cpp:568
 #, c-format
 msgid " (copy %d of %d)"
 msgstr " (kopie %d van %d)"
 
-#: ../src/common/log.cpp:421
+#: ../src/common/log.cpp:440
 #, c-format
 msgid " (error %ld: %s)"
 msgstr " (fout %ld: %s)"
 
-#: ../src/common/imagtiff.cpp:72
+#: ../src/common/imagtiff.cpp:69
 #, c-format
 msgid " (in module \"%s\")"
 msgstr " (in module \"%s\")"
 
-#: ../src/osx/core/secretstore.cpp:138
-msgid " (while overwriting an existing item)"
-msgstr ""
-
-#: ../src/common/docview.cpp:1642
+#: ../src/common/docview.cpp:1636
 msgid " - "
 msgstr " - "
 
-#: ../src/richtext/richtextprint.cpp:593 ../src/html/htmprint.cpp:714
+#: ../src/html/htmprint.cpp:712 ../src/richtext/richtextprint.cpp:589
 msgid " Preview"
 msgstr " Voorskou"
 
-#: ../src/common/fontcmn.cpp:824
+#: ../src/common/fontcmn.cpp:973
 msgid " bold"
 msgstr " vetdruk"
 
-#: ../src/common/fontcmn.cpp:840
+#: ../src/common/fontcmn.cpp:977
+#, fuzzy
+msgid " extra bold"
+msgstr " vetdruk"
+
+#: ../src/common/fontcmn.cpp:985
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:957
+#, fuzzy
+msgid " extra light"
+msgstr " lig"
+
+#: ../src/common/fontcmn.cpp:981
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1001
 msgid " italic"
 msgstr " kursief"
 
-#: ../src/common/fontcmn.cpp:820
+#: ../src/common/fontcmn.cpp:961
 msgid " light"
 msgstr " lig"
 
-#: ../src/common/fontcmn.cpp:807
+#: ../src/common/fontcmn.cpp:965
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:969
+#, fuzzy
+msgid " semi bold"
+msgstr " vetdruk"
+
+#: ../src/common/fontcmn.cpp:940
 msgid " strikethrough"
 msgstr " deurhaal"
 
-#: ../src/common/paper.cpp:117
+#: ../src/common/fontcmn.cpp:953
+msgid " thin"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
 msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
 msgstr "Koevert nr.10, 4 1/8 x 9 1/2 duim"
 
-#: ../src/common/paper.cpp:118
+#: ../src/common/paper.cpp:115
 msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
 msgstr "Koevert nr.11, 4 1/2 x 10 3/8 duim"
 
-#: ../src/common/paper.cpp:119
+#: ../src/common/paper.cpp:116
 msgid "#12 Envelope, 4 3/4 x 11 in"
 msgstr "Koevert nr.12, 4 3/4 x 11 duim"
 
-#: ../src/common/paper.cpp:120
+#: ../src/common/paper.cpp:117
 msgid "#14 Envelope, 5 x 11 1/2 in"
 msgstr "Koevert nr.14, 5 x 11 1/2 duim"
 
-#: ../src/common/paper.cpp:116
+#: ../src/common/paper.cpp:113
 msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
 msgstr "Koevert nr.9, 3 7/8 x 8 7/8 duim"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:341
 #: ../src/richtext/richtextsizepage.cpp:340
 #: ../src/richtext/richtextsizepage.cpp:374
 #: ../src/richtext/richtextsizepage.cpp:401
@@ -106,81 +132,82 @@ msgstr "Koevert nr.9, 3 7/8 x 8 7/8 duim"
 #: ../src/richtext/richtextsizepage.cpp:591
 #: ../src/richtext/richtextsizepage.cpp:626
 #: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextbackgroundpage.cpp:341
 msgid "%"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1031
+#: ../src/html/helpwnd.cpp:1029
 #, c-format
 msgid "%d of %lu"
 msgstr "%d van %lu"
 
-#: ../src/html/helpwnd.cpp:1678
+#: ../src/html/helpwnd.cpp:1676
 #, fuzzy, c-format
 msgid "%i of %u"
 msgstr "%i van %i"
 
-#: ../src/generic/filectrlg.cpp:279
+#: ../src/generic/filectrlg.cpp:275
 #, c-format
 msgid "%ld byte"
 msgid_plural "%ld bytes"
 msgstr[0] "%ld greep"
 msgstr[1] "%ld grepe"
 
-#: ../src/html/helpwnd.cpp:1033
+#: ../src/html/helpwnd.cpp:1031
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu van %lu"
 
-#: ../src/generic/datavgen.cpp:6028
+#: ../src/generic/datavgen.cpp:6833
 #, fuzzy, c-format
 msgid "%s (%d items)"
 msgstr "%s (of %s)"
 
-#: ../src/common/cmdline.cpp:1221
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (of %s)"
 
-#: ../src/generic/logg.cpp:224
+#: ../src/generic/logg.cpp:221
 #, c-format
 msgid "%s Error"
 msgstr "%s-fout"
 
-#: ../src/generic/logg.cpp:236
+#: ../src/generic/logg.cpp:233
 #, c-format
 msgid "%s Information"
 msgstr "%s-inligting"
 
-#: ../src/generic/preferencesg.cpp:113
+#: ../src/generic/preferencesg.cpp:110
 #, c-format
 msgid "%s Preferences"
 msgstr "%s-voorkeure"
 
-#: ../src/generic/logg.cpp:228
+#: ../src/generic/logg.cpp:225
 #, c-format
 msgid "%s Warning"
 msgstr "%s-waarskuwing"
 
-#: ../src/common/tarstrm.cpp:1319
+#: ../src/common/tarstrm.cpp:1313
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr ""
 
-#: ../src/common/fldlgcmn.cpp:124
+#: ../src/common/fldlgcmn.cpp:121
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s lêers (%s)|%s"
 
-#: ../src/html/helpwnd.cpp:1716
+#: ../src/html/helpwnd.cpp:1714
 #, fuzzy, c-format
 msgid "%u of %u"
 msgstr "%lu van %lu"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "&About"
 msgstr "&Aangaande"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "&Actual Size"
 msgstr "&Werklike grootte"
 
@@ -188,28 +215,28 @@ msgstr "&Werklike grootte"
 msgid "&After a paragraph:"
 msgstr "N&a 'n paragraaf:"
 
-#: ../src/richtext/richtextindentspage.cpp:128
 #: ../src/richtext/richtextliststylepage.cpp:319
+#: ../src/richtext/richtextindentspage.cpp:128
 msgid "&Alignment"
 msgstr "&Belyning"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "&Apply"
 msgstr "P&as toe"
 
-#: ../src/richtext/richtextstyledlg.cpp:251
+#: ../src/richtext/richtextstyledlg.cpp:247
 msgid "&Apply Style"
 msgstr "P&as styl toe"
 
-#: ../src/msw/mdi.cpp:179
+#: ../src/msw/mdi.cpp:174
 msgid "&Arrange Icons"
 msgstr "R&angskik ikone"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "&Ascending"
 msgstr "&Stygend"
 
-#: ../src/common/stockitem.cpp:142
+#: ../src/common/stockitem.cpp:139
 msgid "&Back"
 msgstr "&Terug"
 
@@ -229,24 +256,24 @@ msgstr "&Agtergrondkleur:"
 msgid "&Blur distance:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:143
+#: ../src/common/stockitem.cpp:140
 msgid "&Bold"
 msgstr "&Vet"
 
-#: ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141
 msgid "&Bottom"
 msgstr "&Onder"
 
+#: ../src/richtext/richtextsizepage.cpp:637
+#: ../src/richtext/richtextsizepage.cpp:644
 #: ../src/richtext/richtextborderspage.cpp:345
 #: ../src/richtext/richtextborderspage.cpp:513
 #: ../src/richtext/richtextmarginspage.cpp:259
 #: ../src/richtext/richtextmarginspage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:637
-#: ../src/richtext/richtextsizepage.cpp:644
 msgid "&Bottom:"
 msgstr "&Onderkant:"
 
-#: ../include/wx/richtext/richtextbuffer.h:3866
+#: ../include/wx/richtext/richtextbuffer.h:3861
 msgid "&Box"
 msgstr "&Boks"
 
@@ -255,38 +282,38 @@ msgstr "&Boks"
 msgid "&Bullet style:"
 msgstr "&Koeëltjiestyl:"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "&CD-Rom"
 msgstr "&CD-ROM"
 
-#: ../src/generic/wizard.cpp:434 ../src/generic/fontdlgg.cpp:470
-#: ../src/generic/fontdlgg.cpp:489 ../src/osx/carbon/fontdlg.cpp:402
-#: ../src/common/dlgcmn.cpp:279 ../src/common/stockitem.cpp:145
+#: ../src/osx/carbon/fontdlg.cpp:399 ../src/common/stockitem.cpp:142
+#: ../src/generic/wizard.cpp:433 ../src/generic/fontdlgg.cpp:466
+#: ../src/generic/fontdlgg.cpp:485 ../src/osx/cocoa/button.mm:200
 msgid "&Cancel"
 msgstr "&Kanselleer"
 
-#: ../src/msw/mdi.cpp:175
+#: ../src/msw/mdi.cpp:170
 msgid "&Cascade"
 msgstr "&Trapsgewys"
 
-#: ../include/wx/richtext/richtextbuffer.h:5960
+#: ../include/wx/richtext/richtextbuffer.h:5955
 msgid "&Cell"
 msgstr "&Sel"
 
-#: ../src/richtext/richtextsymboldlg.cpp:439
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "&Character code:"
 msgstr "&Karakterkode:"
 
-#: ../src/common/stockitem.cpp:147
+#: ../src/common/stockitem.cpp:144
 msgid "&Clear"
 msgstr "&Maak skoon"
 
-#: ../src/generic/logg.cpp:516 ../src/common/stockitem.cpp:148
-#: ../src/common/prntbase.cpp:1600 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/stockitem.cpp:145 ../src/common/prntbase.cpp:1625
+#: ../src/univ/themes/win32.cpp:3753 ../src/generic/logg.cpp:513
 msgid "&Close"
 msgstr "Maak &toe"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "&Color"
 msgstr "&Kleur"
 
@@ -294,20 +321,20 @@ msgstr "&Kleur"
 msgid "&Colour:"
 msgstr "&Kleur:"
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "&Convert"
 msgstr "S&kakel om"
 
-#: ../src/richtext/richtextctrl.cpp:333 ../src/osx/textctrl_osx.cpp:577
-#: ../src/common/stockitem.cpp:150 ../src/msw/textctrl.cpp:2508
+#: ../src/osx/textctrl_osx.cpp:595 ../src/common/stockitem.cpp:147
+#: ../src/msw/textctrl.cpp:2773 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Kopieer"
 
-#: ../src/generic/hyperlinkg.cpp:156
+#: ../src/generic/hyperlinkg.cpp:153
 msgid "&Copy URL"
 msgstr "&Kopieer URL"
 
-#: ../src/common/headerctrlcmn.cpp:306
+#: ../src/common/headerctrlcmn.cpp:304
 msgid "&Customize..."
 msgstr "&Pasmaak..."
 
@@ -315,53 +342,54 @@ msgstr "&Pasmaak..."
 msgid "&Debug report preview:"
 msgstr ""
 
-#: ../src/richtext/richtexttabspage.cpp:138
-#: ../src/richtext/richtextctrl.cpp:335 ../src/osx/textctrl_osx.cpp:579
-#: ../src/common/stockitem.cpp:152 ../src/msw/textctrl.cpp:2510
+#: ../src/osx/textctrl_osx.cpp:597 ../src/common/stockitem.cpp:149
+#: ../src/msw/textctrl.cpp:2775 ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtextctrl.cpp:334
 msgid "&Delete"
 msgstr "&Skrap"
 
-#: ../src/richtext/richtextstyledlg.cpp:269
+#: ../src/richtext/richtextstyledlg.cpp:265
 msgid "&Delete Style..."
 msgstr "&Skrap styl..."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "&Descending"
 msgstr "&Dalend"
 
-#: ../src/generic/logg.cpp:682
+#: ../src/generic/logg.cpp:679
 msgid "&Details"
 msgstr "&Besonderhede"
 
-#: ../src/common/stockitem.cpp:153
+#: ../src/common/stockitem.cpp:150
 msgid "&Down"
 msgstr "&Af"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "&Edit"
 msgstr "R&edigeer"
 
-#: ../src/richtext/richtextstyledlg.cpp:263
+#: ../src/richtext/richtextstyledlg.cpp:259
 msgid "&Edit Style..."
 msgstr "R&edigeer styl..."
 
-#: ../src/common/stockitem.cpp:155
+#: ../src/common/stockitem.cpp:152
 msgid "&Execute"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/common/stockitem.cpp:154
 msgid "&File"
 msgstr "&Lêer"
 
-#: ../src/common/stockitem.cpp:158
-msgid "&Find"
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "&Find..."
 msgstr "&Soek"
 
-#: ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:430
 msgid "&Finish"
 msgstr "&Voltooi"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:156
 msgid "&First"
 msgstr "&Eerste"
 
@@ -369,16 +397,16 @@ msgstr "&Eerste"
 msgid "&Floating mode:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 #, fuzzy
 msgid "&Floppy"
 msgstr "&Kopieer "
 
-#: ../src/common/stockitem.cpp:194
+#: ../src/common/stockitem.cpp:191
 msgid "&Font"
 msgstr "&Lettertipe"
 
-#: ../src/generic/fontdlgg.cpp:371
+#: ../src/generic/fontdlgg.cpp:367
 msgid "&Font family:"
 msgstr "&Lettertipe-familie"
 
@@ -386,21 +414,21 @@ msgstr "&Lettertipe-familie"
 msgid "&Font for Level..."
 msgstr ""
 
+#: ../src/richtext/richtextsymboldlg.cpp:397
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:400
 #, fuzzy
 msgid "&Font:"
 msgstr "Lettertipe-grootte:"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "&Forward"
 msgstr "&Vorentoe"
 
-#: ../src/richtext/richtextsymboldlg.cpp:451
+#: ../src/richtext/richtextsymboldlg.cpp:448
 msgid "&From:"
 msgstr "&Van:"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "&Harddisk"
 msgstr "&Hardeskyf"
 
@@ -409,9 +437,9 @@ msgstr "&Hardeskyf"
 msgid "&Height:"
 msgstr "&Hoogte:"
 
-#: ../src/generic/wizard.cpp:441 ../src/richtext/richtextstyledlg.cpp:303
-#: ../src/richtext/richtextsymboldlg.cpp:479 ../src/osx/menu_osx.cpp:734
-#: ../src/common/stockitem.cpp:163
+#: ../src/common/stockitem.cpp:160 ../src/generic/wizard.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextstyledlg.cpp:299 ../src/osx/cocoa/menu.mm:226
 msgid "&Help"
 msgstr "&Hulp"
 
@@ -419,7 +447,7 @@ msgstr "&Hulp"
 msgid "&Hide details"
 msgstr "&Versteek besonderhede"
 
-#: ../src/common/stockitem.cpp:164
+#: ../src/common/stockitem.cpp:161
 msgid "&Home"
 msgstr "&Tuis"
 
@@ -427,54 +455,54 @@ msgstr "&Tuis"
 msgid "&Horizontal offset:"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:184
 #: ../src/richtext/richtextliststylepage.cpp:372
+#: ../src/richtext/richtextindentspage.cpp:184
 msgid "&Indentation (tenths of a mm)"
 msgstr "&Inkeep (tiendes van 'n mm.)"
 
-#: ../src/richtext/richtextindentspage.cpp:167
 #: ../src/richtext/richtextliststylepage.cpp:356
+#: ../src/richtext/richtextindentspage.cpp:167
 msgid "&Indeterminate"
 msgstr "N&ie gespesifiseer nie"
 
-#: ../src/common/stockitem.cpp:166
+#: ../src/common/stockitem.cpp:163
 msgid "&Index"
 msgstr "&Indeks"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "&Info"
 msgstr "&Inligting"
 
-#: ../src/common/stockitem.cpp:168
+#: ../src/common/stockitem.cpp:165
 msgid "&Italic"
 msgstr "&Kursief"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "&Jump to"
 msgstr "&Spring na"
 
-#: ../src/richtext/richtextindentspage.cpp:153
 #: ../src/richtext/richtextliststylepage.cpp:342
+#: ../src/richtext/richtextindentspage.cpp:153
 msgid "&Justified"
 msgstr "Al&kantbelyn"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "&Last"
 msgstr "&Laaste"
 
-#: ../src/richtext/richtextindentspage.cpp:139
 #: ../src/richtext/richtextliststylepage.cpp:328
+#: ../src/richtext/richtextindentspage.cpp:139
 msgid "&Left"
 msgstr "&Links"
 
-#: ../src/richtext/richtextindentspage.cpp:195
+#: ../src/richtext/richtextsizepage.cpp:532
+#: ../src/richtext/richtextsizepage.cpp:539
 #: ../src/richtext/richtextborderspage.cpp:243
 #: ../src/richtext/richtextborderspage.cpp:411
 #: ../src/richtext/richtextliststylepage.cpp:381
+#: ../src/richtext/richtextindentspage.cpp:195
 #: ../src/richtext/richtextmarginspage.cpp:186
 #: ../src/richtext/richtextmarginspage.cpp:300
-#: ../src/richtext/richtextsizepage.cpp:532
-#: ../src/richtext/richtextsizepage.cpp:539
 msgid "&Left:"
 msgstr "&Links:"
 
@@ -482,11 +510,11 @@ msgstr "&Links:"
 msgid "&List level:"
 msgstr "&Lysvlak:"
 
-#: ../src/generic/logg.cpp:517
+#: ../src/generic/logg.cpp:514
 msgid "&Log"
 msgstr "&Boekstawing"
 
-#: ../src/univ/themes/win32.cpp:3748
+#: ../src/univ/themes/win32.cpp:3745
 msgid "&Move"
 msgstr "&Verskuif"
 
@@ -494,20 +522,19 @@ msgstr "&Verskuif"
 msgid "&Move the object to:"
 msgstr "&Skuif die objek na:"
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "&Network"
 msgstr "&Netwerk"
 
-#: ../src/richtext/richtexttabspage.cpp:132 ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173 ../src/richtext/richtexttabspage.cpp:132
 msgid "&New"
 msgstr "&Nuwe"
 
-#: ../src/aui/tabmdi.cpp:111 ../src/generic/mdig.cpp:100
-#: ../src/msw/mdi.cpp:180
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
 msgid "&Next"
 msgstr "&Volgende"
 
-#: ../src/generic/wizard.cpp:432 ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:429
 msgid "&Next >"
 msgstr "&Volgende >"
 
@@ -515,7 +542,7 @@ msgstr "&Volgende >"
 msgid "&Next Paragraph"
 msgstr "Volge&nde paragraaf"
 
-#: ../src/generic/tipdlg.cpp:240
+#: ../src/generic/tipdlg.cpp:237
 msgid "&Next Tip"
 msgstr "&Volgende wenk"
 
@@ -523,11 +550,11 @@ msgstr "&Volgende wenk"
 msgid "&Next style:"
 msgstr "&Volgende styl:"
 
-#: ../src/common/stockitem.cpp:177 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:174 ../src/msw/msgdlg.cpp:435
 msgid "&No"
 msgstr "&Nee"
 
-#: ../src/generic/dbgrptg.cpp:356
+#: ../src/generic/dbgrptg.cpp:360
 msgid "&Notes:"
 msgstr "&Notas:"
 
@@ -535,12 +562,12 @@ msgstr "&Notas:"
 msgid "&Number:"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:475 ../src/generic/fontdlgg.cpp:482
-#: ../src/osx/carbon/fontdlg.cpp:408 ../src/common/stockitem.cpp:178
+#: ../src/osx/carbon/fontdlg.cpp:405 ../src/common/stockitem.cpp:175
+#: ../src/generic/fontdlgg.cpp:471 ../src/generic/fontdlgg.cpp:478
 msgid "&OK"
 msgstr "G&oed"
 
-#: ../src/generic/dbgrptg.cpp:342 ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176 ../src/generic/dbgrptg.cpp:342
 msgid "&Open..."
 msgstr "&Open..."
 
@@ -552,16 +579,16 @@ msgstr ""
 msgid "&Page Break"
 msgstr "&Bladsybreuk"
 
-#: ../src/richtext/richtextctrl.cpp:334 ../src/osx/textctrl_osx.cpp:578
-#: ../src/common/stockitem.cpp:180 ../src/msw/textctrl.cpp:2509
+#: ../src/osx/textctrl_osx.cpp:596 ../src/common/stockitem.cpp:177
+#: ../src/msw/textctrl.cpp:2774 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&Plak"
 
-#: ../include/wx/richtext/richtextbuffer.h:5010
+#: ../include/wx/richtext/richtextbuffer.h:5005
 msgid "&Picture"
 msgstr "&Prent"
 
-#: ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:419
 msgid "&Point size:"
 msgstr "&Puntgrootte:"
 
@@ -573,12 +600,11 @@ msgstr "&Posisie (tiendes van 'n mm.):"
 msgid "&Position mode:"
 msgstr "&Posisiemodus:"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178
 msgid "&Preferences"
 msgstr "&Voorkeure"
 
-#: ../src/aui/tabmdi.cpp:112 ../src/generic/mdig.cpp:101
-#: ../src/msw/mdi.cpp:181
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
 msgid "&Previous"
 msgstr "Vo&rige"
 
@@ -586,78 +612,74 @@ msgstr "Vo&rige"
 msgid "&Previous Paragraph"
 msgstr "Vorige &paragraaf"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "&Print..."
 msgstr "&Druk..."
 
-#: ../src/richtext/richtextctrl.cpp:339 ../src/richtext/richtextctrl.cpp:5514
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtextctrl.cpp:338
+#: ../src/richtext/richtextctrl.cpp:5512
 msgid "&Properties"
 msgstr "&Eienskappe"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "&Quit"
 msgstr "&Sluit af"
 
-#: ../src/richtext/richtextctrl.cpp:330 ../src/osx/textctrl_osx.cpp:574
-#: ../src/common/stockitem.cpp:185 ../src/common/cmdproc.cpp:293
-#: ../src/common/cmdproc.cpp:300 ../src/msw/textctrl.cpp:2505
+#: ../src/osx/textctrl_osx.cpp:592 ../src/common/stockitem.cpp:182
+#: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
+#: ../src/msw/textctrl.cpp:2770 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "He&rdoen"
 
-#: ../src/common/cmdproc.cpp:289 ../src/common/cmdproc.cpp:309
+#: ../src/common/cmdproc.cpp:282 ../src/common/cmdproc.cpp:302
 msgid "&Redo "
 msgstr "He&rdoen "
 
-#: ../src/richtext/richtextstyledlg.cpp:257
+#: ../src/richtext/richtextstyledlg.cpp:253
 msgid "&Rename Style..."
 msgstr "He&rnoem styl..."
 
-#: ../src/generic/fdrepdlg.cpp:179
+#: ../src/generic/fdrepdlg.cpp:176
 msgid "&Replace"
 msgstr "Ve&rvang"
 
-#: ../src/richtext/richtextstyledlg.cpp:287
+#: ../src/richtext/richtextstyledlg.cpp:283
 msgid "&Restart numbering"
 msgstr "He&rbegin nommering"
 
-#: ../src/univ/themes/win32.cpp:3747
+#: ../src/univ/themes/win32.cpp:3744
 msgid "&Restore"
 msgstr "He&rstel"
 
-#: ../src/richtext/richtextindentspage.cpp:146
 #: ../src/richtext/richtextliststylepage.cpp:335
+#: ../src/richtext/richtextindentspage.cpp:146
 msgid "&Right"
 msgstr "&Regs"
 
-#: ../src/richtext/richtextindentspage.cpp:213
+#: ../src/richtext/richtextsizepage.cpp:602
+#: ../src/richtext/richtextsizepage.cpp:609
 #: ../src/richtext/richtextborderspage.cpp:277
 #: ../src/richtext/richtextborderspage.cpp:445
 #: ../src/richtext/richtextliststylepage.cpp:399
+#: ../src/richtext/richtextindentspage.cpp:213
 #: ../src/richtext/richtextmarginspage.cpp:211
 #: ../src/richtext/richtextmarginspage.cpp:325
-#: ../src/richtext/richtextsizepage.cpp:602
-#: ../src/richtext/richtextsizepage.cpp:609
 msgid "&Right:"
 msgstr "&Regs:"
 
-#: ../src/common/stockitem.cpp:190
+#: ../src/common/stockitem.cpp:187
 msgid "&Save"
 msgstr "&Stoor"
-
-#: ../src/common/stockitem.cpp:191
-msgid "&Save as"
-msgstr "&Stoor as"
 
 #: ../include/wx/richmsgdlg.h:29
 msgid "&See details"
 msgstr "&Wys besonderhede"
 
-#: ../src/generic/tipdlg.cpp:236
+#: ../src/generic/tipdlg.cpp:233
 msgid "&Show tips at startup"
 msgstr "&Wys wenke as program begin"
 
-#: ../src/univ/themes/win32.cpp:3750
+#: ../src/univ/themes/win32.cpp:3747
 msgid "&Size"
 msgstr "&Grootte"
 
@@ -665,36 +687,36 @@ msgstr "&Grootte"
 msgid "&Size:"
 msgstr "&Grootte:"
 
-#: ../src/generic/progdlgg.cpp:252
+#: ../src/generic/progdlgg.cpp:249
 msgid "&Skip"
 msgstr "&Slaan oor"
 
-#: ../src/richtext/richtextindentspage.cpp:242
 #: ../src/richtext/richtextliststylepage.cpp:417
+#: ../src/richtext/richtextindentspage.cpp:242
 msgid "&Spacing (tenths of a mm)"
 msgstr "&Spasiëring (tiendes van 'n mm.):"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "&Spell Check"
 msgstr "&Speltoets"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "&Stop"
 msgstr "&Stop"
 
-#: ../src/richtext/richtextfontpage.cpp:275 ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196 ../src/richtext/richtextfontpage.cpp:275
 msgid "&Strikethrough"
 msgstr "&Deurhaal"
 
-#: ../src/generic/fontdlgg.cpp:382 ../src/richtext/richtextstylepage.cpp:106
+#: ../src/generic/fontdlgg.cpp:378 ../src/richtext/richtextstylepage.cpp:106
 msgid "&Style:"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:194
 msgid "&Styles:"
 msgstr "&Style:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:413
+#: ../src/richtext/richtextsymboldlg.cpp:410
 msgid "&Subset:"
 msgstr "&Substel:"
 
@@ -708,24 +730,24 @@ msgstr "&Simbool:"
 msgid "&Synchronize values"
 msgstr ""
 
-#: ../include/wx/richtext/richtextbuffer.h:6069
+#: ../include/wx/richtext/richtextbuffer.h:6064
 msgid "&Table"
 msgstr "&Tabel"
 
-#: ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197
 msgid "&Top"
 msgstr "Bokan&t"
 
+#: ../src/richtext/richtextsizepage.cpp:567
+#: ../src/richtext/richtextsizepage.cpp:574
 #: ../src/richtext/richtextborderspage.cpp:311
 #: ../src/richtext/richtextborderspage.cpp:479
 #: ../src/richtext/richtextmarginspage.cpp:234
 #: ../src/richtext/richtextmarginspage.cpp:348
-#: ../src/richtext/richtextsizepage.cpp:567
-#: ../src/richtext/richtextsizepage.cpp:574
 msgid "&Top:"
 msgstr "Bokan&t:"
 
-#: ../src/generic/fontdlgg.cpp:444 ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199 ../src/generic/fontdlgg.cpp:441
 msgid "&Underline"
 msgstr "&Onderstreep"
 
@@ -733,21 +755,21 @@ msgstr "&Onderstreep"
 msgid "&Underlining:"
 msgstr "&Onderstreep:"
 
-#: ../src/richtext/richtextctrl.cpp:329 ../src/osx/textctrl_osx.cpp:573
-#: ../src/common/stockitem.cpp:203 ../src/common/cmdproc.cpp:271
-#: ../src/msw/textctrl.cpp:2504
+#: ../src/osx/textctrl_osx.cpp:591 ../src/common/stockitem.cpp:200
+#: ../src/common/cmdproc.cpp:264 ../src/msw/textctrl.cpp:2769
+#: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Ontdoen"
 
-#: ../src/common/cmdproc.cpp:265
+#: ../src/common/cmdproc.cpp:258
 msgid "&Undo "
 msgstr "&Ontdoen"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "&Unindent"
 msgstr "Keep &uit"
 
-#: ../src/common/stockitem.cpp:205
+#: ../src/common/stockitem.cpp:202
 msgid "&Up"
 msgstr "&Op"
 
@@ -764,7 +786,7 @@ msgstr "&Vertikale belyning:"
 msgid "&View..."
 msgstr "&Bekyk..."
 
-#: ../src/generic/fontdlgg.cpp:393
+#: ../src/generic/fontdlgg.cpp:389
 msgid "&Weight:"
 msgstr "Ge&wig:"
 
@@ -773,88 +795,58 @@ msgstr "Ge&wig:"
 msgid "&Width:"
 msgstr "&Wydte:"
 
-#: ../src/aui/tabmdi.cpp:311 ../src/aui/tabmdi.cpp:327
-#: ../src/aui/tabmdi.cpp:329 ../src/generic/mdig.cpp:294
-#: ../src/generic/mdig.cpp:310 ../src/generic/mdig.cpp:314
-#: ../src/msw/mdi.cpp:78
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
 msgid "&Window"
 msgstr "&Venster"
 
-#: ../src/common/stockitem.cpp:206 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:203 ../src/msw/msgdlg.cpp:435
 msgid "&Yes"
 msgstr "&Ja"
 
-#: ../src/common/valtext.cpp:256
+#: ../src/common/valtext.cpp:197
 #, fuzzy, c-format
-msgid "'%s' contains illegal characters"
+msgid "'%s' contains invalid character(s)"
 msgstr "'%s' mag slegs letters bevat."
 
-#: ../src/common/valtext.cpp:254
-#, fuzzy, c-format
-msgid "'%s' doesn't consist only of valid characters"
-msgstr "'%s' mag slegs letters bevat."
-
-#: ../src/common/config.cpp:519 ../src/msw/regconf.cpp:258
+#: ../src/common/config.cpp:515 ../src/msw/regconf.cpp:255
 #, c-format
 msgid "'%s' has extra '..', ignored."
 msgstr "'%s' het ekstra '..', geïgnoreer."
 
-#: ../src/common/cmdline.cpp:1113 ../src/common/cmdline.cpp:1131
+#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' is nie 'n geldige numeriese waarde vir opsie '%s' nie."
 
-#: ../src/common/translation.cpp:1100
+#: ../src/common/translation.cpp:1142
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' is nie 'n geldige boodskapkatalogus."
 
-#: ../src/common/valtext.cpp:165
+#: ../src/common/valtext.cpp:188
 #, fuzzy, c-format
 msgid "'%s' is not one of the valid strings"
 msgstr "'%s' is nie 'n geldige boodskapkatalogus."
 
-#: ../src/common/valtext.cpp:167
+#: ../src/common/valtext.cpp:186
 #, fuzzy, c-format
 msgid "'%s' is one of the invalid strings"
 msgstr "'%s' is ongeldig"
 
-#: ../src/common/textbuf.cpp:237
+#: ../src/common/textbuf.cpp:233
 #, c-format
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' is waarskynlik 'n binêre buffer."
-
-#: ../src/common/valtext.cpp:252
-#, c-format
-msgid "'%s' should be numeric."
-msgstr "'%s' moet numeries wees."
-
-#: ../src/common/valtext.cpp:244
-#, c-format
-msgid "'%s' should only contain ASCII characters."
-msgstr "'%s' mag slegs ASCII-tekens bevat."
-
-#: ../src/common/valtext.cpp:246
-#, c-format
-msgid "'%s' should only contain alphabetic characters."
-msgstr "'%s' mag slegs letters bevat."
-
-#: ../src/common/valtext.cpp:248
-#, c-format
-msgid "'%s' should only contain alphabetic or numeric characters."
-msgstr "'%s' mag alleen alfa-numerieke tekens bevat."
-
-#: ../src/common/valtext.cpp:250
-#, fuzzy, c-format
-msgid "'%s' should only contain digits."
-msgstr "'%s' mag slegs ASCII-tekens bevat."
 
 #: ../src/richtext/richtextliststylepage.cpp:229
 #: ../src/richtext/richtextbulletspage.cpp:166
 msgid "(*)"
 msgstr "(*)"
 
-#: ../src/html/helpwnd.cpp:963
+#: ../src/html/helpwnd.cpp:961
 msgid "(Help)"
 msgstr "(Help)"
 
@@ -863,27 +855,32 @@ msgstr "(Help)"
 msgid "(None)"
 msgstr "(Geen)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:504
+#: ../src/richtext/richtextsymboldlg.cpp:503
 msgid "(Normal text)"
 msgstr "(Normale teks)"
 
-#: ../src/html/helpwnd.cpp:419 ../src/html/helpwnd.cpp:1106
-#: ../src/html/helpwnd.cpp:1742
+#: ../src/html/helpwnd.cpp:417 ../src/html/helpwnd.cpp:1104
+#: ../src/html/helpwnd.cpp:1740
 msgid "(bookmarks)"
 msgstr "(gunstelinge)"
 
+#: ../src/msw/dlmsw.cpp:167
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (fout %ld: %s)"
+
+#: ../src/richtext/richtextformatdlg.cpp:876
+#: ../src/richtext/richtextliststylepage.cpp:448
+#: ../src/richtext/richtextliststylepage.cpp:460
+#: ../src/richtext/richtextliststylepage.cpp:461
 #: ../src/richtext/richtextindentspage.cpp:274
 #: ../src/richtext/richtextindentspage.cpp:286
 #: ../src/richtext/richtextindentspage.cpp:287
 #: ../src/richtext/richtextindentspage.cpp:311
 #: ../src/richtext/richtextindentspage.cpp:326
-#: ../src/richtext/richtextformatdlg.cpp:884
 #: ../src/richtext/richtextfontpage.cpp:349
 #: ../src/richtext/richtextfontpage.cpp:353
 #: ../src/richtext/richtextfontpage.cpp:357
-#: ../src/richtext/richtextliststylepage.cpp:448
-#: ../src/richtext/richtextliststylepage.cpp:460
-#: ../src/richtext/richtextliststylepage.cpp:461
 msgid "(none)"
 msgstr "(geen)"
 
@@ -902,7 +899,7 @@ msgstr "*)"
 msgid "+"
 msgstr "+"
 
-#: ../src/msw/utils.cpp:1152
+#: ../src/msw/utils.cpp:1143
 msgid ", 64-bit edition"
 msgstr ", 64-bisweergawe"
 
@@ -911,169 +908,169 @@ msgstr ", 64-bisweergawe"
 msgid "-"
 msgstr "-"
 
-#: ../src/generic/filepickerg.cpp:66
+#: ../src/generic/filepickerg.cpp:63
 msgid "..."
 msgstr "..."
 
-#: ../src/richtext/richtextindentspage.cpp:276
 #: ../src/richtext/richtextliststylepage.cpp:450
+#: ../src/richtext/richtextindentspage.cpp:276
 msgid "1.1"
 msgstr "1,1"
 
-#: ../src/richtext/richtextindentspage.cpp:277
 #: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextindentspage.cpp:277
 msgid "1.2"
 msgstr "1,2"
 
-#: ../src/richtext/richtextindentspage.cpp:278
 #: ../src/richtext/richtextliststylepage.cpp:452
+#: ../src/richtext/richtextindentspage.cpp:278
 msgid "1.3"
 msgstr "1,3"
 
-#: ../src/richtext/richtextindentspage.cpp:279
 #: ../src/richtext/richtextliststylepage.cpp:453
+#: ../src/richtext/richtextindentspage.cpp:279
 msgid "1.4"
 msgstr "1,4"
 
-#: ../src/richtext/richtextindentspage.cpp:280
 #: ../src/richtext/richtextliststylepage.cpp:454
+#: ../src/richtext/richtextindentspage.cpp:280
 msgid "1.5"
 msgstr "1,5"
 
-#: ../src/richtext/richtextindentspage.cpp:281
 #: ../src/richtext/richtextliststylepage.cpp:455
+#: ../src/richtext/richtextindentspage.cpp:281
 msgid "1.6"
 msgstr "1,6"
 
-#: ../src/richtext/richtextindentspage.cpp:282
 #: ../src/richtext/richtextliststylepage.cpp:456
+#: ../src/richtext/richtextindentspage.cpp:282
 msgid "1.7"
 msgstr "1,7"
 
-#: ../src/richtext/richtextindentspage.cpp:283
 #: ../src/richtext/richtextliststylepage.cpp:457
+#: ../src/richtext/richtextindentspage.cpp:283
 msgid "1.8"
 msgstr "1,8"
 
-#: ../src/richtext/richtextindentspage.cpp:284
 #: ../src/richtext/richtextliststylepage.cpp:458
+#: ../src/richtext/richtextindentspage.cpp:284
 msgid "1.9"
 msgstr "1,9"
 
-#: ../src/common/paper.cpp:140
+#: ../src/common/paper.cpp:137
 msgid "10 x 11 in"
 msgstr "10 x 11 duim"
 
-#: ../src/common/paper.cpp:113
+#: ../src/common/paper.cpp:110
 msgid "10 x 14 in"
 msgstr "10 x 14 duim"
 
-#: ../src/common/paper.cpp:114
+#: ../src/common/paper.cpp:111
 msgid "11 x 17 in"
 msgstr "11 x 17 duim"
 
-#: ../src/common/paper.cpp:184
+#: ../src/common/paper.cpp:181
 msgid "12 x 11 in"
 msgstr "12 x 11 duim"
 
-#: ../src/common/paper.cpp:141
+#: ../src/common/paper.cpp:138
 msgid "15 x 11 in"
 msgstr "15 x 11 duim"
 
-#: ../src/richtext/richtextindentspage.cpp:285
 #: ../src/richtext/richtextliststylepage.cpp:459
+#: ../src/richtext/richtextindentspage.cpp:285
 msgid "2"
 msgstr "2"
 
-#: ../src/common/paper.cpp:132
+#: ../src/common/paper.cpp:129
 msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
 msgstr "6 3/4 koevert, 3 5/8 x 6 1/2 duim"
 
-#: ../src/common/paper.cpp:139
+#: ../src/common/paper.cpp:136
 msgid "9 x 11 in"
 msgstr "9 x 11 duim"
 
-#: ../src/html/htmprint.cpp:431
+#: ../src/html/htmprint.cpp:443
 msgid ": file does not exist!"
 msgstr ": lêer bestaan nie!"
 
-#: ../src/common/fontmap.cpp:199
+#: ../src/common/fontmap.cpp:196
 msgid ": unknown charset"
 msgstr ": onbekende karakterstel"
 
-#: ../src/common/fontmap.cpp:413
+#: ../src/common/fontmap.cpp:410
 msgid ": unknown encoding"
 msgstr ": onbekende kodering"
 
-#: ../src/generic/wizard.cpp:443
+#: ../src/generic/wizard.cpp:438
 msgid "< &Back"
 msgstr "< &Terug"
 
-#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:628
-#: ../src/osx/carbon/fontdlg.cpp:648
+#: ../src/osx/carbon/fontdlg.cpp:419 ../src/osx/carbon/fontdlg.cpp:625
+#: ../src/osx/carbon/fontdlg.cpp:645
 #, fuzzy
 msgid "<Any Decorative>"
 msgstr "Dekoratief"
 
-#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:630
-#: ../src/osx/carbon/fontdlg.cpp:650
+#: ../src/osx/carbon/fontdlg.cpp:420 ../src/osx/carbon/fontdlg.cpp:627
+#: ../src/osx/carbon/fontdlg.cpp:647
 #, fuzzy
 msgid "<Any Modern>"
 msgstr "Modern"
 
-#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:626
-#: ../src/osx/carbon/fontdlg.cpp:646
+#: ../src/osx/carbon/fontdlg.cpp:418 ../src/osx/carbon/fontdlg.cpp:623
+#: ../src/osx/carbon/fontdlg.cpp:643
 #, fuzzy
 msgid "<Any Roman>"
 msgstr "Roman"
 
-#: ../src/osx/carbon/fontdlg.cpp:424 ../src/osx/carbon/fontdlg.cpp:632
-#: ../src/osx/carbon/fontdlg.cpp:652
+#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:629
+#: ../src/osx/carbon/fontdlg.cpp:649
 #, fuzzy
 msgid "<Any Script>"
 msgstr "Skrif-letter"
 
-#: ../src/osx/carbon/fontdlg.cpp:425 ../src/osx/carbon/fontdlg.cpp:637
-#: ../src/osx/carbon/fontdlg.cpp:656
+#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:634
+#: ../src/osx/carbon/fontdlg.cpp:653
 #, fuzzy
 msgid "<Any Swiss>"
 msgstr "Switsers"
 
-#: ../src/osx/carbon/fontdlg.cpp:426 ../src/osx/carbon/fontdlg.cpp:634
-#: ../src/osx/carbon/fontdlg.cpp:654
+#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:631
+#: ../src/osx/carbon/fontdlg.cpp:651
 #, fuzzy
 msgid "<Any Teletype>"
 msgstr "<Enige teletipe>"
 
-#: ../src/osx/carbon/fontdlg.cpp:420
+#: ../src/osx/carbon/fontdlg.cpp:417
 msgid "<Any>"
 msgstr "<Enige>"
 
-#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
 msgid "<DIR>"
 msgstr "<GIDS>"
 
-#: ../src/generic/filectrlg.cpp:254 ../src/generic/filectrlg.cpp:277
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
 msgid "<DRIVE>"
 msgstr "<AANDRYWER>"
 
-#: ../src/generic/filectrlg.cpp:252 ../src/generic/filectrlg.cpp:275
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
 msgid "<LINK>"
 msgstr "<SKAKEL>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1264
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Vet en kursief.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1270
+#: ../src/html/helpwnd.cpp:1268
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>vet kursief <u>onderstreep</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1265
+#: ../src/html/helpwnd.cpp:1263
 msgid "<b>Bold face.</b> "
 msgstr "<b>Vetdruk.</b> "
 
-#: ../src/html/helpwnd.cpp:1264
+#: ../src/html/helpwnd.cpp:1262
 msgid "<i>Italic face.</i> "
 msgstr "<i>Kursief.</i> "
 
@@ -1082,15 +1079,15 @@ msgstr "<i>Kursief.</i> "
 msgid ">"
 msgstr ">"
 
-#: ../src/generic/dbgrptg.cpp:318
+#: ../src/generic/dbgrptg.cpp:317
 msgid "A debug report has been generated in the directory\n"
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:573
+#: ../src/common/debugrpt.cpp:574
 msgid "A debug report has been generated. It can be found in"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:418
+#: ../src/common/xtixml.cpp:414
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "'n Nie-leë versameling moet bestaan uit 'element'-nodes"
 
@@ -1101,110 +1098,110 @@ msgstr "'n Nie-leë versameling moet bestaan uit 'element'-nodes"
 msgid "A standard bullet name."
 msgstr ""
 
-#: ../src/common/paper.cpp:217
+#: ../src/common/paper.cpp:214
 msgid "A0 sheet, 841 x 1189 mm"
 msgstr "A0, 841 x 1189 mm"
 
-#: ../src/common/paper.cpp:218
+#: ../src/common/paper.cpp:215
 msgid "A1 sheet, 594 x 841 mm"
 msgstr "A1, 594 x 841 mm"
 
-#: ../src/common/paper.cpp:159
+#: ../src/common/paper.cpp:156
 msgid "A2 420 x 594 mm"
 msgstr "A2 420 x 594 mm"
 
-#: ../src/common/paper.cpp:156
+#: ../src/common/paper.cpp:153
 msgid "A3 Extra 322 x 445 mm"
 msgstr "A3 ekstra 322 x 445 mm"
 
-#: ../src/common/paper.cpp:161
+#: ../src/common/paper.cpp:158
 #, fuzzy
 msgid "A3 Extra Transverse 322 x 445 mm"
 msgstr "C3 Koevert, 324 x 458 mm"
 
-#: ../src/common/paper.cpp:170
+#: ../src/common/paper.cpp:167
 msgid "A3 Rotated 420 x 297 mm"
 msgstr "A3 geroteer 420 x 297 mm"
 
-#: ../src/common/paper.cpp:160
+#: ../src/common/paper.cpp:157
 #, fuzzy
 msgid "A3 Transverse 297 x 420 mm"
 msgstr "A3, 297 x 420 mm"
 
-#: ../src/common/paper.cpp:106
+#: ../src/common/paper.cpp:103
 msgid "A3 sheet, 297 x 420 mm"
 msgstr "A3, 297 x 420 mm"
 
-#: ../src/common/paper.cpp:146
+#: ../src/common/paper.cpp:143
 msgid "A4 Extra 9.27 x 12.69 in"
 msgstr "A4 ekstra 9.27 x 12.69 duim"
 
-#: ../src/common/paper.cpp:153
+#: ../src/common/paper.cpp:150
 msgid "A4 Plus 210 x 330 mm"
 msgstr "A4 plus 210 x 330 mm"
 
-#: ../src/common/paper.cpp:171
+#: ../src/common/paper.cpp:168
 msgid "A4 Rotated 297 x 210 mm"
 msgstr "A4 geroteer 297 x 210 mm"
 
-#: ../src/common/paper.cpp:148
+#: ../src/common/paper.cpp:145
 msgid "A4 Transverse 210 x 297 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:97
+#: ../src/common/paper.cpp:94
 msgid "A4 sheet, 210 x 297 mm"
 msgstr "A4, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:107
+#: ../src/common/paper.cpp:104
 msgid "A4 small sheet, 210 x 297 mm"
 msgstr "A4 klein, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:157
+#: ../src/common/paper.cpp:154
 msgid "A5 Extra 174 x 235 mm"
 msgstr "A5 ekstra 174 x 235 mm"
 
-#: ../src/common/paper.cpp:172
+#: ../src/common/paper.cpp:169
 msgid "A5 Rotated 210 x 148 mm"
 msgstr "A5 geroteer 210 x 148 mm"
 
-#: ../src/common/paper.cpp:154
+#: ../src/common/paper.cpp:151
 #, fuzzy
 msgid "A5 Transverse 148 x 210 mm"
 msgstr "A5, 148 x 210 mm"
 
-#: ../src/common/paper.cpp:108
+#: ../src/common/paper.cpp:105
 msgid "A5 sheet, 148 x 210 mm"
 msgstr "A5, 148 x 210 mm"
 
-#: ../src/common/paper.cpp:164
+#: ../src/common/paper.cpp:161
 #, fuzzy
 msgid "A6 105 x 148 mm"
 msgstr "A6 105 x 148 mm"
 
-#: ../src/common/paper.cpp:177
+#: ../src/common/paper.cpp:174
 msgid "A6 Rotated 148 x 105 mm"
 msgstr "A6 geroteer 148 x 105 mm"
 
-#: ../src/generic/fontdlgg.cpp:83 ../src/richtext/richtextformatdlg.cpp:529
-#: ../src/osx/carbon/fontdlg.cpp:153
+#: ../src/osx/carbon/fontdlg.cpp:150 ../src/generic/fontdlgg.cpp:79
+#: ../src/richtext/richtextformatdlg.cpp:521
 msgid "ABCDEFGabcdefg12345"
 msgstr "ABCDEÊÉFGabcdeêéfg12345"
 
-#: ../src/richtext/richtextsymboldlg.cpp:458 ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
 msgid "ASCII"
 msgstr "ASCII"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "About"
 msgstr "Aangaande"
 
-#: ../src/generic/aboutdlgg.cpp:140 ../src/osx/menu_osx.cpp:558
-#: ../src/msw/aboutdlg.cpp:64
+#: ../src/osx/menu_osx.cpp:450 ../src/generic/aboutdlgg.cpp:137
+#: ../src/msw/aboutdlg.cpp:61
 #, c-format
 msgid "About %s"
 msgstr "Aangaande %s"
 
-#: ../src/osx/menu_osx.cpp:560
+#: ../src/osx/menu_osx.cpp:452
 #, fuzzy
 msgid "About..."
 msgstr "Aangaande"
@@ -1214,38 +1211,38 @@ msgid "Absolute"
 msgstr "Absoluut"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:873
+#: ../src/propgrid/advprops.cpp:774
 #, fuzzy
 msgid "ActiveBorder"
 msgstr "Modern"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:874
+#: ../src/propgrid/advprops.cpp:775
 msgid "ActiveCaption"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "Actual Size"
 msgstr "Werklike grootte"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:140 ../src/common/accelcmn.cpp:81
+#: ../src/common/stockitem.cpp:137 ../src/common/accelcmn.cpp:78
 msgid "Add"
 msgstr "Voeg by"
 
-#: ../src/richtext/richtextbuffer.cpp:11455
+#: ../src/richtext/richtextbuffer.cpp:11454
 msgid "Add Column"
 msgstr "Voeg kolom by"
 
-#: ../src/richtext/richtextbuffer.cpp:11392
+#: ../src/richtext/richtextbuffer.cpp:11391
 msgid "Add Row"
 msgstr "Voeg ry by"
 
-#: ../src/html/helpwnd.cpp:432
+#: ../src/html/helpwnd.cpp:430
 msgid "Add current page to bookmarks"
 msgstr "Voeg huidige bladsy by gunstelinge"
 
-#: ../src/generic/colrdlgg.cpp:366
+#: ../src/generic/colrdlgg.cpp:386
 msgid "Add to custom colours"
 msgstr "Voeg by aangepaste kleure"
 
@@ -1257,12 +1254,12 @@ msgstr "AddToPropertyCollection is geroep op 'n generiese toegangsmetode"
 msgid "AddToPropertyCollection called w/o valid adder"
 msgstr "AddToPropertyCollection is geroep sonder geldige byvoeger"
 
-#: ../src/html/helpctrl.cpp:159
+#: ../src/html/helpctrl.cpp:155
 #, c-format
 msgid "Adding book %s"
 msgstr "Besig om boek %s by te voeg"
 
-#: ../src/common/preferencescmn.cpp:43
+#: ../src/common/preferencescmn.cpp:40
 msgid "Advanced"
 msgstr "Gevorderd"
 
@@ -1270,11 +1267,11 @@ msgstr "Gevorderd"
 msgid "After a paragraph:"
 msgstr "Na 'n paragraaf:"
 
-#: ../src/common/stockitem.cpp:172
+#: ../src/common/stockitem.cpp:169
 msgid "Align Left"
 msgstr "Belyn links"
 
-#: ../src/common/stockitem.cpp:173
+#: ../src/common/stockitem.cpp:170
 msgid "Align Right"
 msgstr "Belyn regs"
 
@@ -1282,41 +1279,41 @@ msgstr "Belyn regs"
 msgid "Alignment"
 msgstr "Belyning"
 
-#: ../src/generic/prntdlgg.cpp:215
+#: ../src/generic/prntdlgg.cpp:208
 msgid "All"
 msgstr "Almal"
 
-#: ../src/generic/filectrlg.cpp:1197 ../src/common/fldlgcmn.cpp:107
+#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1186
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Alle lêers (%s)|%s"
 
-#: ../include/wx/defs.h:2886
+#: ../include/wx/defs.h:2582
 msgid "All files (*)|*"
 msgstr "Alle lêers (*)|*"
 
-#: ../include/wx/defs.h:2883
+#: ../include/wx/defs.h:2579
 msgid "All files (*.*)|*.*"
 msgstr "Alle lêers (*.*)|*.*"
 
-#: ../src/richtext/richtextstyles.cpp:1061
+#: ../src/richtext/richtextstyles.cpp:1058
 msgid "All styles"
 msgstr "Alle style"
 
-#: ../src/propgrid/manager.cpp:1528
+#: ../src/propgrid/manager.cpp:1544
 msgid "Alphabetic Mode"
 msgstr "Alfabetiese modus"
 
-#: ../src/common/xtistrm.cpp:425
+#: ../src/common/xtistrm.cpp:422
 msgid "Already Registered Object passed to SetObjectClassInfo"
 msgstr ""
 "Die objek wat aangestuur is vir SetObjectClassInfo is alreeds geregistreer"
 
-#: ../src/unix/dialup.cpp:353
+#: ../src/unix/dialup.cpp:352
 msgid "Already dialling ISP."
 msgstr "Reeds besig om ISP te bel."
 
-#: ../src/common/accelcmn.cpp:331 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/accelcmn.cpp:345 ../src/univ/themes/win32.cpp:3753
 msgid "Alt+"
 msgstr "Alt+"
 
@@ -1325,34 +1322,34 @@ msgstr "Alt+"
 msgid "An optional corner radius for adding rounded corners."
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:576
+#: ../src/common/debugrpt.cpp:577
 msgid "And includes the following files:\n"
 msgstr ""
 
-#: ../src/generic/animateg.cpp:162
+#: ../src/generic/animateg.cpp:145
 #, fuzzy, c-format
 msgid "Animation file is not of type %ld."
 msgstr "Beeldlêer is nie van die tipe %d."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:872
+#: ../src/propgrid/advprops.cpp:773
 msgid "AppWorkspace"
 msgstr ""
 
-#: ../src/generic/logg.cpp:1014
+#: ../src/generic/logg.cpp:1011
 #, c-format
 msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
 msgstr "Voeg log by lêer '%s' (kies [Nee] om te oorskryf)?"
 
-#: ../src/osx/menu_osx.cpp:577 ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:469 ../src/osx/menu_osx.cpp:477
 msgid "Application"
 msgstr "Toepassing"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "Apply"
 msgstr "Pas toe"
 
-#: ../src/propgrid/advprops.cpp:1609
+#: ../src/propgrid/advprops.cpp:1515
 msgid "Aqua"
 msgstr ""
 
@@ -1361,30 +1358,30 @@ msgstr ""
 msgid "Arabic"
 msgstr "Arabies (gewone syfers)"
 
-#: ../src/common/fmapbase.cpp:153
+#: ../src/common/fmapbase.cpp:150
 msgid "Arabic (ISO-8859-6)"
 msgstr "Arabies (ISO-8859-6)"
 
-#: ../src/msw/ole/automtn.cpp:672
+#: ../src/msw/ole/automtn.cpp:663
 #, fuzzy, c-format
 msgid "Argument %u not found."
 msgstr "katalogus-lêer vir domein '%s' nie gevind nie."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1753
+#: ../src/propgrid/advprops.cpp:1654
 #, fuzzy
 msgid "Arrow"
 msgstr "môre"
 
-#: ../src/generic/aboutdlgg.cpp:184
+#: ../src/generic/aboutdlgg.cpp:181
 msgid "Artists"
 msgstr "Kunstenaars"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "Ascending"
 msgstr "Stygend"
 
-#: ../src/generic/filectrlg.cpp:433
+#: ../src/generic/filectrlg.cpp:429
 msgid "Attributes"
 msgstr "Eienskappe"
 
@@ -1394,91 +1391,91 @@ msgstr "Eienskappe"
 msgid "Available fonts."
 msgstr "Beskikbare lettertipes."
 
-#: ../src/common/paper.cpp:137
+#: ../src/common/paper.cpp:134
 msgid "B4 (ISO) 250 x 353 mm"
 msgstr "B4 (ISO) 250 x 353 mm"
 
-#: ../src/common/paper.cpp:173
+#: ../src/common/paper.cpp:170
 msgid "B4 (JIS) Rotated 364 x 257 mm"
 msgstr "B4 (JIS) geroteer 364 x 257 mm"
 
-#: ../src/common/paper.cpp:127
+#: ../src/common/paper.cpp:124
 msgid "B4 Envelope, 250 x 353 mm"
 msgstr "B4 Koevert, 250 x 353 mm"
 
-#: ../src/common/paper.cpp:109
+#: ../src/common/paper.cpp:106
 msgid "B4 sheet, 250 x 354 mm"
 msgstr "B4, 250 x 354 mm"
 
-#: ../src/common/paper.cpp:158
+#: ../src/common/paper.cpp:155
 msgid "B5 (ISO) Extra 201 x 276 mm"
 msgstr "B5 (ISO) ekstra 201 x 276 mm"
 
-#: ../src/common/paper.cpp:174
+#: ../src/common/paper.cpp:171
 msgid "B5 (JIS) Rotated 257 x 182 mm"
 msgstr "B5 (JIS) geroteer 257 x 182 mm"
 
-#: ../src/common/paper.cpp:155
+#: ../src/common/paper.cpp:152
 #, fuzzy
 msgid "B5 (JIS) Transverse 182 x 257 mm"
 msgstr "B5, 182, 257 mm"
 
-#: ../src/common/paper.cpp:128
+#: ../src/common/paper.cpp:125
 msgid "B5 Envelope, 176 x 250 mm"
 msgstr "B5 Koevert, 176 x 250 mm"
 
-#: ../src/common/paper.cpp:110
+#: ../src/common/paper.cpp:107
 msgid "B5 sheet, 182 x 257 millimeter"
 msgstr "B5, 182, 257 mm"
 
-#: ../src/common/paper.cpp:182
+#: ../src/common/paper.cpp:179
 msgid "B6 (JIS) 128 x 182 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:183
+#: ../src/common/paper.cpp:180
 msgid "B6 (JIS) Rotated 182 x 128 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:129
+#: ../src/common/paper.cpp:126
 msgid "B6 Envelope, 176 x 125 mm"
 msgstr "B6 Koevert, 176 x 125 mm"
 
-#: ../src/common/imagbmp.cpp:531 ../src/common/imagbmp.cpp:561
-#: ../src/common/imagbmp.cpp:576
+#: ../src/common/imagbmp.cpp:528 ../src/common/imagbmp.cpp:558
+#: ../src/common/imagbmp.cpp:573
 msgid "BMP: Couldn't allocate memory."
 msgstr "BMP: kon geen geheue toeken nie."
 
-#: ../src/common/imagbmp.cpp:100
+#: ../src/common/imagbmp.cpp:97
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: kon nie ongeldige beeld stoor nie"
 
-#: ../src/common/imagbmp.cpp:356
+#: ../src/common/imagbmp.cpp:353
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: Kon nie RGB-kleurkaart skryf nie."
 
-#: ../src/common/imagbmp.cpp:490
+#: ../src/common/imagbmp.cpp:487
 msgid "BMP: Couldn't write data."
 msgstr "BMP: kon nie data skryf nie"
 
-#: ../src/common/imagbmp.cpp:246
+#: ../src/common/imagbmp.cpp:243
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: kon nie die lêerkopreëls (Bitmap) skryf nie"
 
-#: ../src/common/imagbmp.cpp:269
+#: ../src/common/imagbmp.cpp:266
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: Kon nie die lêerkopreëls (BitmapInfo) skryf nie."
 
-#: ../src/common/imagbmp.cpp:140
+#: ../src/common/imagbmp.cpp:137
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage het nie 'n eie wxPalette nie."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:142 ../src/common/accelcmn.cpp:52
+#: ../src/common/stockitem.cpp:139 ../src/common/accelcmn.cpp:49
 msgid "Back"
 msgstr "Terug"
 
+#: ../src/richtext/richtextformatdlg.cpp:377
 #: ../src/richtext/richtextbackgroundpage.cpp:148
-#: ../src/richtext/richtextformatdlg.cpp:384
 msgid "Background"
 msgstr "Agtergrond"
 
@@ -1486,21 +1483,21 @@ msgstr "Agtergrond"
 msgid "Background &colour:"
 msgstr "Agtergrond&kleur:"
 
-#: ../src/osx/carbon/fontdlg.cpp:220
+#: ../src/osx/carbon/fontdlg.cpp:217
 msgid "Background colour"
 msgstr "Agtergrondkleur"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:52
+#: ../src/common/accelcmn.cpp:49
 #, fuzzy
 msgid "Backspace"
 msgstr "Terug"
 
-#: ../src/common/fmapbase.cpp:160
+#: ../src/common/fmapbase.cpp:157
 msgid "Baltic (ISO-8859-13)"
 msgstr "Balties (ISO-8859-13)"
 
-#: ../src/common/fmapbase.cpp:151
+#: ../src/common/fmapbase.cpp:148
 msgid "Baltic (old) (ISO-8859-4)"
 msgstr "Balties (oud) (ISO-8859-4)"
 
@@ -1513,25 +1510,25 @@ msgstr "Voor 'n paragraaf:"
 msgid "Bitmap"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1594
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Black"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1755
+#: ../src/propgrid/advprops.cpp:1656
 msgid "Blank"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1603
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Blue"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:345
+#: ../src/generic/colrdlgg.cpp:365
 msgid "Blue:"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:333 ../src/richtext/richtextfontpage.cpp:355
-#: ../src/osx/carbon/fontdlg.cpp:354 ../src/common/stockitem.cpp:143
+#: ../src/osx/carbon/fontdlg.cpp:351 ../src/common/stockitem.cpp:140
+#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:355
 msgid "Bold"
 msgstr "Vet"
 
@@ -1541,32 +1538,36 @@ msgstr "Vet"
 msgid "Border"
 msgstr "Modern"
 
-#: ../src/richtext/richtextformatdlg.cpp:379
+#: ../src/richtext/richtextformatdlg.cpp:372
 #, fuzzy
 msgid "Borders"
 msgstr "Modern"
 
-#: ../src/richtext/richtextsizepage.cpp:288 ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141 ../src/richtext/richtextsizepage.cpp:288
 msgid "Bottom"
 msgstr "Onder"
 
-#: ../src/generic/prntdlgg.cpp:893
+#: ../src/generic/prntdlgg.cpp:886
 msgid "Bottom margin (mm):"
 msgstr "Onderste kantlyn (mm):"
 
-#: ../src/richtext/richtextbuffer.cpp:9383
+#: ../src/richtext/richtextbuffer.cpp:9380
 msgid "Box Properties"
 msgstr "Boks-eienskappe"
 
-#: ../src/richtext/richtextstyles.cpp:1065
+#: ../src/richtext/richtextstyles.cpp:1062
 msgid "Box styles"
 msgstr "Boksstyle"
 
-#: ../src/propgrid/advprops.cpp:1602
+#: ../src/osx/cocoa/menu.mm:292
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Brown"
 msgstr ""
 
-#: ../src/common/filepickercmn.cpp:43 ../src/common/filepickercmn.cpp:44
+#: ../src/common/filepickercmn.cpp:40 ../src/common/filepickercmn.cpp:41
 msgid "Browse"
 msgstr ""
 
@@ -1579,73 +1580,73 @@ msgstr "Koeëltjie&belyning:"
 msgid "Bullet style"
 msgstr "Koeëltjiestyl"
 
-#: ../src/richtext/richtextformatdlg.cpp:359
+#: ../src/richtext/richtextformatdlg.cpp:352
 msgid "Bullets"
 msgstr "Koeëltjies"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1756
+#: ../src/propgrid/advprops.cpp:1657
 #, fuzzy
 msgid "Bullseye"
 msgstr "Koeëltjiestyl"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:875
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonFace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:876
+#: ../src/propgrid/advprops.cpp:777
 msgid "ButtonHighlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:877
+#: ../src/propgrid/advprops.cpp:778
 msgid "ButtonShadow"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:878
+#: ../src/propgrid/advprops.cpp:779
 msgid "ButtonText"
 msgstr ""
 
-#: ../src/common/paper.cpp:98
+#: ../src/common/paper.cpp:95
 msgid "C sheet, 17 x 22 in"
 msgstr "C, 17 x 22 duim"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "C&lear"
 msgstr "&Vee uit"
 
-#: ../src/generic/fontdlgg.cpp:406
+#: ../src/generic/fontdlgg.cpp:403
 msgid "C&olour:"
 msgstr ""
 
-#: ../src/common/paper.cpp:123
+#: ../src/common/paper.cpp:120
 msgid "C3 Envelope, 324 x 458 mm"
 msgstr "C3 Koevert, 324 x 458 mm"
 
-#: ../src/common/paper.cpp:124
+#: ../src/common/paper.cpp:121
 msgid "C4 Envelope, 229 x 324 mm"
 msgstr "C4 Koevert, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:122
+#: ../src/common/paper.cpp:119
 msgid "C5 Envelope, 162 x 229 mm"
 msgstr "C5 Koevert, 162 x 229 mm"
 
-#: ../src/common/paper.cpp:125
+#: ../src/common/paper.cpp:122
 msgid "C6 Envelope, 114 x 162 mm"
 msgstr "C6 Koevert, 114 x 162 mm"
 
-#: ../src/common/paper.cpp:126
+#: ../src/common/paper.cpp:123
 msgid "C65 Envelope, 114 x 229 mm"
 msgstr "C65 Koevert, 114 x 229 mm"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "CD-Rom"
 msgstr "CD-ROM"
 
-#: ../src/html/chm.cpp:815 ../src/html/chm.cpp:874
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:865
 msgid "CHM handler currently supports only local files!"
 msgstr "CHM-hanteerder ondersteun tans slegs plaaslike lêers!"
 
@@ -1653,193 +1654,197 @@ msgstr "CHM-hanteerder ondersteun tans slegs plaaslike lêers!"
 msgid "Ca&pitals"
 msgstr "Hoof&letters"
 
-#: ../src/common/cmdproc.cpp:267
+#: ../src/common/cmdproc.cpp:260
 msgid "Can't &Undo "
 msgstr "Kan nie &ontdoen nie "
 
-#: ../src/common/image.cpp:2824
+#: ../src/common/image.cpp:2924
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 
-#: ../src/msw/registry.cpp:506
+#: ../src/msw/registry.cpp:495
 #, c-format
 msgid "Can't close registry key '%s'"
 msgstr "Kan registersleutel '%s' nie toemaak nie"
 
-#: ../src/msw/registry.cpp:584
+#: ../src/msw/registry.cpp:573
 #, c-format
 msgid "Can't copy values of unsupported type %d."
 msgstr "Kan geen waardes van nie-ondersteunde tipe %d kopieer nie."
 
-#: ../src/msw/registry.cpp:487
+#: ../src/msw/registry.cpp:476
 #, c-format
 msgid "Can't create registry key '%s'"
 msgstr "Kan registersleutel '%s' nie skep nie"
 
-#: ../src/msw/thread.cpp:665
+#: ../src/msw/thread.cpp:657
 msgid "Can't create thread"
 msgstr "Kan uitvoerdraad nie skep nie"
 
-#: ../src/msw/window.cpp:3691
-#, c-format
-msgid "Can't create window of class %s"
-msgstr "Kan venster van klas '%s' nie skep nie"
-
-#: ../src/msw/registry.cpp:777
+#: ../src/msw/registry.cpp:765
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Kan sleutel '%s' nie skrap nie"
 
-#: ../src/msw/iniconf.cpp:458
+#: ../src/msw/iniconf.cpp:455
 #, c-format
 msgid "Can't delete the INI file '%s'"
 msgstr "Kan INI-lêer '%s' nie uitvee nie"
 
-#: ../src/msw/registry.cpp:805
+#: ../src/msw/registry.cpp:793
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Kan waarde '%s' nie uit sleutel '%s' verwyder nie."
 
-#: ../src/msw/registry.cpp:1171
+#: ../src/msw/registry.cpp:1159
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Kan subsleutels van sleutel '%s' nie opsom nie"
 
-#: ../src/msw/registry.cpp:1132
+#: ../src/msw/registry.cpp:1120
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Kan waarden van sleutel '%s' nie opsom nie"
 
-#: ../src/msw/registry.cpp:1389
+#: ../src/msw/registry.cpp:1377
 #, fuzzy, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Kan geen waardes van nie-ondersteunde tipe %d kopieer nie."
 
-#: ../src/common/ffile.cpp:254
+#: ../src/common/ffile.cpp:253
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Kan nie huidige posisie in lêer '%s' vind nie"
 
-#: ../src/msw/registry.cpp:418
+#: ../src/msw/registry.cpp:407
 #, c-format
 msgid "Can't get info about registry key '%s'"
 msgstr "Kan geen informasie kry oor registersleutel '%s'"
 
-#: ../src/common/zstream.cpp:346
+#: ../src/msw/webview_ie.cpp:1024
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "Kan thread-prioriteit nie instellen"
+
+#: ../src/common/zstream.cpp:343
 msgid "Can't initialize zlib deflate stream."
 msgstr "Kan nie zlib-afblaasstroom inisialiseer nie."
 
-#: ../src/common/zstream.cpp:185
+#: ../src/common/zstream.cpp:182
 msgid "Can't initialize zlib inflate stream."
 msgstr "Kan nie zlib-opblaasstroom inisialiseer nie."
 
-#: ../src/msw/fswatcher.cpp:476
+#: ../src/msw/fswatcher.cpp:475
 #, c-format
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "Kan nie veranderinge moniteer aan niebestaande gids \"%s\" nie."
 
-#: ../src/msw/registry.cpp:454
+#: ../src/msw/registry.cpp:443
 #, c-format
 msgid "Can't open registry key '%s'"
 msgstr "Kan registersleutel '%s' nie open nie"
 
-#: ../src/common/zstream.cpp:252
+#: ../src/common/zstream.cpp:249
 #, c-format
 msgid "Can't read from inflate stream: %s"
 msgstr "Kan nie van opblaasstroom lees nie: %s"
 
-#: ../src/common/zstream.cpp:244
+#: ../src/common/zstream.cpp:241
 msgid "Can't read inflate stream: unexpected EOF in underlying stream."
 msgstr ""
 "Kan nie opblaasstroom lees nie: onverwagte EOF in onderliggende stroom."
 
-#: ../src/msw/registry.cpp:1064
+#: ../src/msw/registry.cpp:1052
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Kan waarde van '%s' nie lees nie"
 
-#: ../src/msw/registry.cpp:878 ../src/msw/registry.cpp:910
-#: ../src/msw/registry.cpp:975
+#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
+#: ../src/msw/registry.cpp:963
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Kan waarde van sleutel '%s' nie lees nie"
 
-#: ../src/common/image.cpp:2620
+#: ../src/msw/webview_ie.cpp:1017
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/common/image.cpp:2715
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "Kan beeld nie stoor na lêer '%s': Onbekende uitgang."
 
-#: ../src/generic/logg.cpp:573 ../src/generic/logg.cpp:976
+#: ../src/generic/logg.cpp:570 ../src/generic/logg.cpp:973
 msgid "Can't save log contents to file."
 msgstr "Boekstawing kan nie in lêer gestoor word nie."
 
-#: ../src/msw/thread.cpp:629
+#: ../src/msw/thread.cpp:621
 msgid "Can't set thread priority"
 msgstr "Kan thread-prioriteit nie instellen"
 
-#: ../src/msw/registry.cpp:896 ../src/msw/registry.cpp:938
-#: ../src/msw/registry.cpp:1081
+#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
+#: ../src/msw/registry.cpp:1069
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Kan waarde van '%s' nie verstel nie"
 
-#: ../src/unix/utilsunx.cpp:351
+#: ../src/unix/utilsunx.cpp:353
 #, fuzzy
 msgid "Can't write to child process's stdin"
 msgstr "Process %d kon nie doodgemaak word nie"
 
-#: ../src/common/zstream.cpp:427
+#: ../src/common/zstream.cpp:424
 #, c-format
 msgid "Can't write to deflate stream: %s"
 msgstr "Kan nie skryf na afblaasstroom nie: %s"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:279 ../src/richtext/richtextstyledlg.cpp:300
-#: ../src/common/stockitem.cpp:145 ../src/common/accelcmn.cpp:71
-#: ../src/msw/msgdlg.cpp:454 ../src/msw/progdlg.cpp:673
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:142
+#: ../src/common/accelcmn.cpp:68 ../src/motif/msgdlg.cpp:196
+#: ../src/gtk1/fontdlg.cpp:144 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/progdlg.cpp:940 ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Kanselleer"
 
-#: ../src/common/filefn.cpp:1261
+#: ../src/common/filefn.cpp:1149
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Kan lêers in gids '%s' nie opsom nie"
 
-#: ../src/msw/dir.cpp:263
+#: ../src/msw/dir.cpp:260
 #, c-format
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Kan lêers in gids '%s' nie opsom nie"
 
-#: ../src/msw/dialup.cpp:523
+#: ../src/msw/dialup.cpp:517
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Kan geen aktiewe inbelverbinding vind nie: %s"
 
-#: ../src/msw/dialup.cpp:827
+#: ../src/msw/dialup.cpp:821
 msgid "Cannot find the location of address book file"
 msgstr "Kan stoorplek van adresboeklêer nie vind nie"
 
-#: ../src/msw/ole/automtn.cpp:562
+#: ../src/msw/ole/automtn.cpp:553
 #, fuzzy, c-format
 msgid "Cannot get an active instance of \"%s\""
 msgstr "Kan geen actiewe inbelverbinding vind nie: %s"
 
-#: ../src/unix/threadpsx.cpp:1035
+#: ../src/unix/threadpsx.cpp:1053
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr ""
 "Kan nie die omvang van prioriteite bepaal vir skeduleringsbeleid %d nie."
 
-#: ../src/unix/utilsunx.cpp:987
+#: ../src/unix/utilsunx.cpp:989
 msgid "Cannot get the hostname"
 msgstr "Kan masjiennaam nie vasstel nie"
 
-#: ../src/unix/utilsunx.cpp:1023
+#: ../src/unix/utilsunx.cpp:1025
 msgid "Cannot get the official hostname"
 msgstr "Kan die amptelike masjiennaam nie vasstel nie."
 
-#: ../src/msw/dialup.cpp:928
+#: ../src/msw/dialup.cpp:922
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Kan nie neersit nie - geen aktiewe inbelverbinding"
 
@@ -1847,128 +1852,128 @@ msgstr "Kan nie neersit nie - geen aktiewe inbelverbinding"
 msgid "Cannot initialize OLE"
 msgstr "Kan OLE nie inisialiseer nie"
 
-#: ../src/common/socket.cpp:853
+#: ../src/common/socket.cpp:850
 #, fuzzy
 msgid "Cannot initialize sockets"
 msgstr "Kan OLE nie inisialiseer nie"
 
-#: ../src/msw/volume.cpp:619
+#: ../src/msw/volume.cpp:627
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Kan ikoon nie laai van '%s'."
 
-#: ../src/xrc/xmlres.cpp:360
+#: ../src/xrc/xmlres.cpp:358
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Kan hulpbronne nie uit '%s' laai nie."
 
-#: ../src/xrc/xmlres.cpp:742
+#: ../src/xrc/xmlres.cpp:740
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Kan hulpbronne nie uit lêer '%s' laai nie."
 
-#: ../src/html/htmlfilt.cpp:137
+#: ../src/html/htmlfilt.cpp:134
 #, c-format
 msgid "Cannot open HTML document: %s"
 msgstr "Kan HTML-dokument '%s' nie oopmaak nie"
 
-#: ../src/html/helpdata.cpp:667
+#: ../src/html/helpdata.cpp:660
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Kan nie HTML-hulplêer oopmaak nie: %s"
 
-#: ../src/html/helpdata.cpp:299
+#: ../src/html/helpdata.cpp:296
 #, c-format
 msgid "Cannot open contents file: %s"
 msgstr "Kan inhoudsopgawe-lêer nie oopmaak nie: %s"
 
-#: ../src/generic/dcpsg.cpp:1667
+#: ../src/generic/dcpsg.cpp:1665
 msgid "Cannot open file for PostScript printing!"
 msgstr "Kan nie lêer vir PostScript-drukwerk oopmaak nie!"
 
-#: ../src/html/helpdata.cpp:313
+#: ../src/html/helpdata.cpp:310
 #, c-format
 msgid "Cannot open index file: %s"
 msgstr "Kan indekslêer nie oopmaak nie: %s"
 
-#: ../src/xrc/xmlres.cpp:724
+#: ../src/xrc/xmlres.cpp:722
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Kan hulpbronlêer '%s' nie laai nie."
 
-#: ../src/html/helpwnd.cpp:1534
+#: ../src/html/helpwnd.cpp:1532
 msgid "Cannot print empty page."
 msgstr "Kan nie leë bladsy druk nie."
 
-#: ../src/msw/volume.cpp:507
+#: ../src/msw/volume.cpp:515
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Kan nie die tipenaam van '%s' lees nie!"
 
-#: ../src/msw/thread.cpp:888
+#: ../src/msw/thread.cpp:894
 #, fuzzy, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Kan uitvoerdraad %x nie laat voortgaan nie"
 
-#: ../src/unix/threadpsx.cpp:1016
+#: ../src/unix/threadpsx.cpp:1028
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Kan nie die uitvoerdraadskeduleringsbeleid verkry nie."
 
-#: ../src/common/intl.cpp:558
+#: ../src/common/intl.cpp:365
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "Kan nie landinstelling na taal \"%s\" stel nie."
 
-#: ../src/unix/threadpsx.cpp:831 ../src/msw/thread.cpp:546
+#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
 msgid "Cannot start thread: error writing TLS."
 msgstr "Kan uitvoerdraad nie laat begin nie: fout met skryf van TLS."
 
-#: ../src/msw/thread.cpp:872
+#: ../src/msw/thread.cpp:864
 #, fuzzy, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Kan uitvoerdraad %x nie opskort nie"
 
-#: ../src/msw/thread.cpp:794
+#: ../src/msw/thread.cpp:786
 msgid "Cannot wait for thread termination"
 msgstr "Kan nie wag vir uitvoerdraad-beëindiging nie"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:75
+#: ../src/common/accelcmn.cpp:72
 #, fuzzy
 msgid "Capital"
 msgstr "Hoof&letters"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:879
+#: ../src/propgrid/advprops.cpp:780
 msgid "CaptionText"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:531
 msgid "Case sensitive"
 msgstr "Kassensitief"
 
-#: ../src/propgrid/manager.cpp:1509
+#: ../src/propgrid/manager.cpp:1527
 msgid "Categorized Mode"
 msgstr "Gekategoriseerde modus"
 
-#: ../src/richtext/richtextbuffer.cpp:9968
+#: ../src/richtext/richtextbuffer.cpp:9965
 msgid "Cell Properties"
 msgstr "Seleienskappe"
 
-#: ../src/common/fmapbase.cpp:161
+#: ../src/common/fmapbase.cpp:158
 msgid "Celtic (ISO-8859-14)"
 msgstr "Kelties (ISO-8859-14)"
 
-#: ../src/richtext/richtextindentspage.cpp:160
 #: ../src/richtext/richtextliststylepage.cpp:349
+#: ../src/richtext/richtextindentspage.cpp:160
 msgid "Cen&tred"
 msgstr "Gesen&treer"
 
-#: ../src/common/stockitem.cpp:170
+#: ../src/common/stockitem.cpp:167
 msgid "Centered"
 msgstr "Gesentreer"
 
-#: ../src/common/fmapbase.cpp:149
+#: ../src/common/fmapbase.cpp:146
 msgid "Central European (ISO-8859-2)"
 msgstr "Sentraal-Europees (ISO-8859-2)"
 
@@ -1977,10 +1982,10 @@ msgstr "Sentraal-Europees (ISO-8859-2)"
 msgid "Centre"
 msgstr "Gesentreer"
 
-#: ../src/richtext/richtextindentspage.cpp:162
-#: ../src/richtext/richtextindentspage.cpp:164
 #: ../src/richtext/richtextliststylepage.cpp:351
 #: ../src/richtext/richtextliststylepage.cpp:353
+#: ../src/richtext/richtextindentspage.cpp:162
+#: ../src/richtext/richtextindentspage.cpp:164
 msgid "Centre text."
 msgstr "Sentreer teks."
 
@@ -1993,24 +1998,24 @@ msgstr "Gesentreer"
 msgid "Ch&oose..."
 msgstr "&Kies..."
 
-#: ../src/richtext/richtextbuffer.cpp:4354
+#: ../src/richtext/richtextbuffer.cpp:4351
 msgid "Change List Style"
 msgstr "Verander lysstyl"
 
-#: ../src/richtext/richtextbuffer.cpp:3709
+#: ../src/richtext/richtextbuffer.cpp:3706
 msgid "Change Object Style"
 msgstr "Verander objekstyl"
 
-#: ../src/richtext/richtextbuffer.cpp:3982
-#: ../src/richtext/richtextbuffer.cpp:8129
+#: ../src/richtext/richtextbuffer.cpp:3979
+#: ../src/richtext/richtextbuffer.cpp:8125
 msgid "Change Properties"
 msgstr "Verander eienskappe"
 
-#: ../src/richtext/richtextbuffer.cpp:3526
+#: ../src/richtext/richtextbuffer.cpp:3523
 msgid "Change Style"
 msgstr "Verander styl"
 
-#: ../src/common/fileconf.cpp:341
+#: ../src/common/fileconf.cpp:335
 #, c-format
 msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
 msgstr ""
@@ -2021,12 +2026,12 @@ msgid "Changing current directory to \"%s\" failed"
 msgstr "Gids \"%s\" kon nie geskep word nie"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1757
+#: ../src/propgrid/advprops.cpp:1658
 #, fuzzy
 msgid "Character"
 msgstr "&Karakterkode:"
 
-#: ../src/richtext/richtextstyles.cpp:1063
+#: ../src/richtext/richtextstyles.cpp:1060
 msgid "Character styles"
 msgstr "Karakterstyle"
 
@@ -2064,20 +2069,20 @@ msgstr "Merk om die koeëltjie in hakies te sit."
 msgid "Check to indicate right-to-left text layout."
 msgstr "Klik om die tekskleur te verander."
 
-#: ../src/osx/carbon/fontdlg.cpp:356 ../src/osx/carbon/fontdlg.cpp:358
+#: ../src/osx/carbon/fontdlg.cpp:353 ../src/osx/carbon/fontdlg.cpp:355
 msgid "Check to make the font bold."
 msgstr "Merk om die lettertipe vet te maak."
 
-#: ../src/osx/carbon/fontdlg.cpp:363 ../src/osx/carbon/fontdlg.cpp:365
+#: ../src/osx/carbon/fontdlg.cpp:360 ../src/osx/carbon/fontdlg.cpp:362
 msgid "Check to make the font italic."
 msgstr "Merk om die lettertipe kursief te maak."
 
-#: ../src/osx/carbon/fontdlg.cpp:372 ../src/osx/carbon/fontdlg.cpp:374
+#: ../src/osx/carbon/fontdlg.cpp:369 ../src/osx/carbon/fontdlg.cpp:371
 msgid "Check to make the font underlined."
 msgstr "Merk om die lettertipe te onderstreep."
 
-#: ../src/richtext/richtextstyledlg.cpp:289
-#: ../src/richtext/richtextstyledlg.cpp:291
+#: ../src/richtext/richtextstyledlg.cpp:285
+#: ../src/richtext/richtextstyledlg.cpp:287
 msgid "Check to restart numbering."
 msgstr "Merk om nommering te herbegin."
 
@@ -2111,52 +2116,52 @@ msgstr "Merk om die teks as boskrif te wys."
 msgid "Check to suppress hyphenation."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:763
+#: ../src/msw/dialup.cpp:757
 msgid "Choose ISP to dial"
 msgstr "Kies ISP om te bel"
 
-#: ../src/propgrid/props.cpp:1922
+#: ../src/propgrid/props.cpp:1904
 msgid "Choose a directory:"
 msgstr "Kies 'n gids:"
 
-#: ../src/propgrid/props.cpp:1975
+#: ../src/propgrid/props.cpp:2199
 msgid "Choose a file"
 msgstr "Kies 'n lêer"
 
-#: ../src/generic/colrdlgg.cpp:158 ../src/gtk/colordlg.cpp:54
+#: ../src/generic/colrdlgg.cpp:156 ../src/gtk/colordlg.cpp:49
 #, fuzzy
 msgid "Choose colour"
 msgstr "Kies lettertipe"
 
-#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/gtk1/fontdlg.cpp:125 ../src/generic/fontpickerg.cpp:47
+#: ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Kies lettertipe"
 
-#: ../src/common/module.cpp:74
+#: ../src/common/module.cpp:71
 #, c-format
 msgid "Circular dependency involving module \"%s\" detected."
 msgstr ""
 
-#: ../src/aui/tabmdi.cpp:108 ../src/generic/mdig.cpp:97
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
 msgid "Cl&ose"
 msgstr "Maak &toe"
 
-#: ../src/msw/ole/automtn.cpp:684
+#: ../src/msw/ole/automtn.cpp:675
 msgid "Class not registered."
 msgstr "Klas nie geregistreer nie."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:147 ../src/common/accelcmn.cpp:72
+#: ../src/common/stockitem.cpp:144 ../src/common/accelcmn.cpp:69
 msgid "Clear"
 msgstr "Maak skoon"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "Clear the log contents"
 msgstr "Maak boekstawing skoon"
 
-#: ../src/richtext/richtextstyledlg.cpp:252
-#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:248
+#: ../src/richtext/richtextstyledlg.cpp:250
 msgid "Click to apply the selected style."
 msgstr "Klik om die gekose styl toe te pas."
 
@@ -2167,15 +2172,15 @@ msgstr "Klik om die gekose styl toe te pas."
 msgid "Click to browse for a symbol."
 msgstr "Klik om te soek vir 'n simbool."
 
-#: ../src/osx/carbon/fontdlg.cpp:403 ../src/osx/carbon/fontdlg.cpp:405
+#: ../src/osx/carbon/fontdlg.cpp:400 ../src/osx/carbon/fontdlg.cpp:402
 msgid "Click to cancel changes to the font."
 msgstr "Klik om veranderinge aan die lettertipe te kanselleer."
 
-#: ../src/generic/fontdlgg.cpp:472 ../src/generic/fontdlgg.cpp:491
+#: ../src/generic/fontdlgg.cpp:468 ../src/generic/fontdlgg.cpp:487
 msgid "Click to cancel the font selection."
 msgstr "Klik om dei lettertipekeuse te kanselleer."
 
-#: ../src/osx/carbon/fontdlg.cpp:384 ../src/osx/carbon/fontdlg.cpp:386
+#: ../src/osx/carbon/fontdlg.cpp:381 ../src/osx/carbon/fontdlg.cpp:383
 msgid "Click to change the font colour."
 msgstr "Klik om die tekskleur te verander."
 
@@ -2194,37 +2199,37 @@ msgstr "Klik om die tekskleur te verander."
 msgid "Click to choose the font for this level."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:279
-#: ../src/richtext/richtextstyledlg.cpp:281
+#: ../src/richtext/richtextstyledlg.cpp:275
+#: ../src/richtext/richtextstyledlg.cpp:277
 msgid "Click to close this window."
 msgstr "Klik om dié venster te sluit."
 
-#: ../src/osx/carbon/fontdlg.cpp:410 ../src/osx/carbon/fontdlg.cpp:412
+#: ../src/osx/carbon/fontdlg.cpp:407 ../src/osx/carbon/fontdlg.cpp:409
 msgid "Click to confirm changes to the font."
 msgstr "Klik om veranderinge aan die lettertipe te bevestig."
 
-#: ../src/generic/fontdlgg.cpp:477 ../src/generic/fontdlgg.cpp:479
-#: ../src/generic/fontdlgg.cpp:484 ../src/generic/fontdlgg.cpp:486
+#: ../src/generic/fontdlgg.cpp:473 ../src/generic/fontdlgg.cpp:475
+#: ../src/generic/fontdlgg.cpp:480 ../src/generic/fontdlgg.cpp:482
 msgid "Click to confirm the font selection."
 msgstr "Klik om dei lettertipekeuse te bevestig."
 
-#: ../src/richtext/richtextstyledlg.cpp:244
-#: ../src/richtext/richtextstyledlg.cpp:246
+#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:242
 msgid "Click to create a new box style."
 msgstr "Klik om 'n nuwe boksstyl te skep."
 
-#: ../src/richtext/richtextstyledlg.cpp:226
-#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:224
 msgid "Click to create a new character style."
 msgstr "Klik om 'n nuwe karakterstyl te skep."
 
-#: ../src/richtext/richtextstyledlg.cpp:238
-#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:236
 msgid "Click to create a new list style."
 msgstr "Klik om 'n nuwe lysstyl te skep."
 
-#: ../src/richtext/richtextstyledlg.cpp:232
-#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:230
 msgid "Click to create a new paragraph style."
 msgstr "Klik om 'n nuwe paragraafstyl te skep."
 
@@ -2238,8 +2243,8 @@ msgstr "Klik om 'n nuwe oortjieposisie te skep."
 msgid "Click to delete all tab positions."
 msgstr "Skrap om alle oortjieposisies te skrap."
 
-#: ../src/richtext/richtextstyledlg.cpp:270
-#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:268
 msgid "Click to delete the selected style."
 msgstr "Klik om die gekose styl te skrap."
 
@@ -2248,25 +2253,25 @@ msgstr "Klik om die gekose styl te skrap."
 msgid "Click to delete the selected tab position."
 msgstr "Klik om die gekose oortjieposisie te skrap."
 
-#: ../src/richtext/richtextstyledlg.cpp:264
-#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:262
 msgid "Click to edit the selected style."
 msgstr "Klik om die gekose styl te redigeer."
 
-#: ../src/richtext/richtextstyledlg.cpp:258
-#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:256
 msgid "Click to rename the selected style."
 msgstr "Klik om die gekose styl te hernoem."
 
-#: ../src/generic/dbgrptg.cpp:97 ../src/generic/progdlgg.cpp:759
-#: ../src/richtext/richtextstyledlg.cpp:277
-#: ../src/richtext/richtextsymboldlg.cpp:476 ../src/common/stockitem.cpp:148
-#: ../src/msw/progdlg.cpp:170 ../src/msw/progdlg.cpp:679
-#: ../src/html/helpdlg.cpp:90
+#: ../src/common/stockitem.cpp:145 ../src/generic/dbgrptg.cpp:94
+#: ../src/generic/progdlgg.cpp:781 ../src/msw/progdlg.cpp:211
+#: ../src/msw/progdlg.cpp:946 ../src/html/helpdlg.cpp:87
+#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextstyledlg.cpp:273
 msgid "Close"
 msgstr "Maak toe"
 
-#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:98
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
 msgid "Close All"
 msgstr "Maak alles toe"
 
@@ -2274,65 +2279,65 @@ msgstr "Maak alles toe"
 msgid "Close current document"
 msgstr "Sluit huidige dokument"
 
-#: ../src/generic/logg.cpp:516
+#: ../src/generic/logg.cpp:513
 msgid "Close this window"
 msgstr "Maak hierdie venster toe"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6006
+#: ../src/generic/datavgen.cpp:6811
 msgid "Collapse"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "Color"
 msgstr "Kleur"
 
-#: ../src/richtext/richtextformatdlg.cpp:776
+#: ../src/richtext/richtextformatdlg.cpp:768
 msgid "Colour"
 msgstr "Kleur"
 
-#: ../src/msw/colordlg.cpp:158
+#: ../src/msw/colordlg.cpp:227
 #, c-format
 msgid "Colour selection dialog failed with error %0lx."
 msgstr "Kleurseleksiedialoog het misluk met fout %0lx."
 
-#: ../src/osx/carbon/fontdlg.cpp:380
+#: ../src/osx/carbon/fontdlg.cpp:377
 msgid "Colour:"
 msgstr "Kleur:"
 
-#: ../src/generic/datavgen.cpp:6077
+#: ../src/generic/datavgen.cpp:6882
 #, fuzzy, c-format
 msgid "Column %u"
 msgstr "Voeg kolom by"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:114
+#: ../src/common/accelcmn.cpp:112
 msgid "Command"
 msgstr ""
 
-#: ../src/common/init.cpp:196
+#: ../src/common/init.cpp:193
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
 "ignored."
 msgstr ""
 
-#: ../src/msw/fontdlg.cpp:120
+#: ../src/msw/fontdlg.cpp:170
 #, c-format
 msgid "Common dialog failed with error code %0lx."
 msgstr "Algemene dialoog het misluk met foutkode %0lx."
 
-#: ../src/gtk/window.cpp:4649
+#: ../src/gtk/window.cpp:5653
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:1549
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Saamgeperste HTML-hulplêer (*.chm)|*.chm|"
 
-#: ../src/generic/dirctrlg.cpp:444
+#: ../src/generic/dirctrlg.cpp:410
 msgid "Computer"
 msgstr "Rekenaar"
 
@@ -2341,53 +2346,57 @@ msgstr "Rekenaar"
 msgid "Config entry name cannot start with '%c'."
 msgstr "Naam van konfigurasie-inskrywing mag nie begin met '%c' nie."
 
-#: ../src/generic/filedlgg.cpp:349 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
 msgid "Confirm"
 msgstr "Bevestig"
 
-#: ../src/html/htmlwin.cpp:566
+#: ../src/html/htmlwin.cpp:569
 msgid "Connecting..."
 msgstr "Koppel tans..."
 
-#: ../src/html/helpwnd.cpp:475
+#: ../src/html/helpwnd.cpp:473
 msgid "Contents"
 msgstr "Inhoud"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:880
+#: ../src/propgrid/advprops.cpp:781
 msgid "ControlDark"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:881
+#: ../src/propgrid/advprops.cpp:782
 msgid "ControlLight"
 msgstr ""
 
-#: ../src/common/strconv.cpp:2262
+#: ../src/common/strconv.cpp:2208
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Omskakeling na karakterstel '%s' werk nie."
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "Convert"
 msgstr "Skakel om"
 
-#: ../src/html/htmlwin.cpp:1079
+#: ../src/html/htmlwin.cpp:1020
 #, c-format
 msgid "Copied to clipboard:\"%s\""
 msgstr "Gekopieer na knipbord:\"%s\""
 
-#: ../src/generic/prntdlgg.cpp:247
+#: ../src/generic/prntdlgg.cpp:240
 msgid "Copies:"
 msgstr "Kopieë:"
 
-#: ../src/common/stockitem.cpp:150 ../src/stc/stc_i18n.cpp:18
+#: ../src/common/stockitem.cpp:147 ../src/stc/stc_i18n.cpp:18
 msgid "Copy"
 msgstr "Kopieer"
 
-#: ../src/common/stockitem.cpp:258
+#: ../src/common/stockitem.cpp:255
 msgid "Copy selection"
 msgstr "Kopieer seleksie"
+
+#: ../src/generic/grid.cpp:5945
+msgid "Copying more than one selected block to clipboard is not supported."
+msgstr ""
 
 #: ../src/richtext/richtextborderspage.cpp:566
 #: ../src/richtext/richtextborderspage.cpp:601
@@ -2398,202 +2407,196 @@ msgstr ""
 msgid "Corner &radius:"
 msgstr ""
 
-#: ../src/html/chm.cpp:718
+#: ../src/html/chm.cpp:711
 #, c-format
 msgid "Could not create temporary file '%s'"
 msgstr "Kon nie tydelike lêer '%s' skep nie"
 
-#: ../src/html/chm.cpp:273
+#: ../src/html/chm.cpp:270
 #, c-format
 msgid "Could not extract %s into %s: %s"
 msgstr "Kon nie %s binne-in %s uitpak nie: %s"
 
-#: ../src/generic/tabg.cpp:1048
+#: ../src/generic/tabg.cpp:1045
 msgid "Could not find tab for id"
 msgstr "Kon nie die etiket vir die id vind nie"
 
-#: ../src/gtk/notifmsg.cpp:108
-#, fuzzy
-msgid "Could not initalize libnotify."
-msgstr "Kon nie begin met drukwerk nie."
-
-#: ../src/html/chm.cpp:444
+#: ../src/html/chm.cpp:437
 #, c-format
 msgid "Could not locate file '%s'."
 msgstr "Kon nie lêer '%s' opspoor nie."
 
-#: ../src/common/filefn.cpp:1403
+#: ../src/msw/graphicsd2d.cpp:604
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/common/filefn.cpp:1291
 #, fuzzy
 msgid "Could not set current working directory"
 msgstr "Die werkgids kon nie verkry word nie"
 
-#: ../src/common/prntbase.cpp:2015
+#: ../src/common/prntbase.cpp:2037
 msgid "Could not start document preview."
 msgstr "Kon drukvoorskou nie begin nie."
 
-#: ../src/generic/printps.cpp:178 ../src/msw/printwin.cpp:210
-#: ../src/gtk/print.cpp:1132
+#: ../src/generic/printps.cpp:159 ../src/msw/printwin.cpp:184
+#: ../src/gtk/print.cpp:1129
 msgid "Could not start printing."
 msgstr "Kon nie begin met drukwerk nie."
 
-#: ../src/common/wincmn.cpp:2125
+#: ../src/common/wincmn.cpp:2126
 msgid "Could not transfer data to window"
 msgstr "Kon data nie na venster oordra nie"
 
-#: ../src/msw/imaglist.cpp:187 ../src/msw/imaglist.cpp:224
-#: ../src/msw/imaglist.cpp:249 ../src/msw/dragimag.cpp:185
-#: ../src/msw/dragimag.cpp:220
+#: ../src/msw/imaglist.cpp:223 ../src/msw/imaglist.cpp:245
+#: ../src/msw/imaglist.cpp:270 ../src/msw/dragimag.cpp:182
+#: ../src/msw/dragimag.cpp:217
 msgid "Couldn't add an image to the image list."
 msgstr "Kon geen beeld by die lys voeg nie."
 
-#: ../src/osx/glcanvas_osx.cpp:414 ../src/unix/glx11.cpp:558
-#: ../src/msw/glcanvas.cpp:616
+#: ../src/osx/glcanvas_osx.cpp:411 ../src/msw/glcanvas.cpp:631
+#: ../src/unix/glegl.cpp:315 ../src/unix/glx11.cpp:559
 #, fuzzy
 msgid "Couldn't create OpenGL context"
 msgstr "Kon nie 'n tydhouer skep nie"
 
-#: ../src/msw/timer.cpp:134
+#: ../src/msw/timer.cpp:131
 msgid "Couldn't create a timer"
 msgstr "Kon nie 'n tydhouer skep nie"
 
-#: ../src/osx/carbon/overlay.cpp:122
-#, fuzzy
-msgid "Couldn't create the overlay window"
-msgstr "Kon nie 'n tydhouer skep nie"
-
-#: ../src/common/translation.cpp:2024
+#: ../src/common/translation.cpp:2074
 #, fuzzy
 msgid "Couldn't enumerate translations"
 msgstr "Kon uitvoerdraad nie beëindig nie"
 
-#: ../src/common/dynlib.cpp:120
+#: ../src/common/dynlib.cpp:110
 #, c-format
 msgid "Couldn't find symbol '%s' in a dynamic library"
 msgstr "Kon nie simbool %s vind in 'n dinamiese biblioteek nie"
 
-#: ../src/msw/thread.cpp:915
+#: ../src/msw/thread.cpp:921
 msgid "Couldn't get the current thread pointer"
 msgstr "Kon nie wyser na die huidige uitvoerdraad verkry nie"
 
-#: ../src/osx/carbon/overlay.cpp:129
-#, fuzzy
-msgid "Couldn't init the context on the overlay window"
-msgstr "Kon nie wyser na die huidige uitvoerdraad verkry nie"
-
-#: ../src/common/imaggif.cpp:244
+#: ../src/common/imaggif.cpp:241
 #, fuzzy
 msgid "Couldn't initialize GIF hash table."
 msgstr "Kan nie zlib-afblaasstroom inisialiseer nie."
 
-#: ../src/common/imagpng.cpp:409
+#: ../src/common/imagpng.cpp:437
 msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
 msgstr "Kon PNG-beeld nie laai nie: lêer is korrup of geheue is onvoldoende."
 
-#: ../src/unix/sound.cpp:470
+#: ../src/unix/sound.cpp:459
 #, c-format
 msgid "Couldn't load sound data from '%s'."
 msgstr "Kon nie klankdata vanaf '%s' laai nie."
 
-#: ../src/msw/dirdlg.cpp:435
+#: ../src/msw/dirdlg.cpp:287
 msgid "Couldn't obtain folder name"
 msgstr "Kon nie gidsnaam kry nie"
 
-#: ../src/unix/sound_sdl.cpp:229
+#: ../src/unix/sound_sdl.cpp:226
 #, c-format
 msgid "Couldn't open audio: %s"
 msgstr "Kan nie oudio oopmaak nie: %s"
 
-#: ../src/msw/ole/dataobj.cpp:377
+#: ../src/msw/ole/dataobj.cpp:385
 #, c-format
 msgid "Couldn't register clipboard format '%s'."
 msgstr "Kon nie knipbord-formaat '%s' registreer nie."
 
-#: ../src/msw/listctrl.cpp:869
+#: ../src/msw/listctrl.cpp:933
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "Kon geen inligting oor lys-item %d kry nie."
 
-#: ../src/common/imagpng.cpp:498 ../src/common/imagpng.cpp:509
-#: ../src/common/imagpng.cpp:519
+#: ../src/common/imagpng.cpp:511 ../src/common/imagpng.cpp:522
+#: ../src/common/imagpng.cpp:532
 msgid "Couldn't save PNG image."
 msgstr "Kon PNG-beeld nie stoor nie."
 
-#: ../src/msw/thread.cpp:684
+#: ../src/msw/thread.cpp:676
 msgid "Couldn't terminate thread"
 msgstr "Kon uitvoerdraad nie beëindig nie"
 
-#: ../src/common/xtistrm.cpp:166
+#: ../src/common/xtistrm.cpp:163
 #, fuzzy, c-format
 msgid "Create Parameter %s not found in declared RTTI Parameters"
 msgstr "Create-parameter nie gevind in die verklaarde RTTI parameters nie"
 
-#: ../src/generic/dirdlgg.cpp:288
+#: ../src/generic/dirdlgg.cpp:285
 msgid "Create directory"
 msgstr "Maak gids"
 
-#: ../src/generic/filedlgg.cpp:212 ../src/generic/dirdlgg.cpp:111
+#: ../src/generic/filedlgg.cpp:209 ../src/generic/dirdlgg.cpp:108
 msgid "Create new directory"
 msgstr "Maak nuwe gids"
 
-#: ../src/xrc/xmlres.cpp:2460
+#: ../src/common/stockitem.cpp:264
+#, fuzzy
+msgid "Create new document"
+msgstr "Maak nuwe gids"
+
+#: ../src/xrc/xmlres.cpp:2515
 #, fuzzy, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Uitpak van '%s' binne-in '%s' het misluk."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1758
+#: ../src/propgrid/advprops.cpp:1659
 msgid "Cross"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:333
+#: ../src/common/accelcmn.cpp:347
 msgid "Ctrl+"
 msgstr "Ctrl+"
 
-#: ../src/richtext/richtextctrl.cpp:332 ../src/osx/textctrl_osx.cpp:576
-#: ../src/common/stockitem.cpp:151 ../src/msw/textctrl.cpp:2507
+#: ../src/osx/textctrl_osx.cpp:594 ../src/common/stockitem.cpp:148
+#: ../src/msw/textctrl.cpp:2772 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "Kn&ip"
 
-#: ../src/generic/filectrlg.cpp:940
+#: ../src/generic/filectrlg.cpp:936
 msgid "Current directory:"
 msgstr "Huidige gids:"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:896 ../src/propgrid/advprops.cpp:1574
-#: ../src/propgrid/advprops.cpp:1612
+#: ../src/propgrid/advprops.cpp:797 ../src/propgrid/advprops.cpp:1475
+#: ../src/propgrid/advprops.cpp:1518
 #, fuzzy
 msgid "Custom"
 msgstr "Pasgemaakte grootte"
 
-#: ../src/gtk/print.cpp:217
+#: ../src/gtk/print.cpp:211
 msgid "Custom size"
 msgstr "Pasgemaakte grootte"
 
-#: ../src/common/headerctrlcmn.cpp:60
+#: ../src/common/headerctrlcmn.cpp:58
 msgid "Customize Columns"
 msgstr "Pasmaak kolomme"
 
-#: ../src/common/stockitem.cpp:151 ../src/stc/stc_i18n.cpp:17
+#: ../src/common/stockitem.cpp:148 ../src/stc/stc_i18n.cpp:17
 msgid "Cut"
 msgstr "Knip"
 
-#: ../src/common/stockitem.cpp:259
+#: ../src/common/stockitem.cpp:256
 msgid "Cut selection"
 msgstr "Knip seleksie"
 
-#: ../src/common/fmapbase.cpp:152
+#: ../src/common/fmapbase.cpp:149
 msgid "Cyrillic (ISO-8859-5)"
 msgstr "Cyrillic (ISO-8859-5)"
 
-#: ../src/common/paper.cpp:99
+#: ../src/common/paper.cpp:96
 msgid "D sheet, 22 x 34 in"
 msgstr "D, 22 x34 duim"
 
-#: ../src/msw/dde.cpp:703
+#: ../src/msw/dde.cpp:698
 msgid "DDE poke request failed"
 msgstr "DDE 'poke'-versoek het misluk"
 
-#: ../src/common/imagbmp.cpp:1169
+#: ../src/common/imagbmp.cpp:1181
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr "DIB Opskrif: Kodering kom nie ooreen met bis-diepte nie."
 
@@ -2613,7 +2616,7 @@ msgstr "DIB Opskrif: Onbekende bisdiepte in lêer."
 msgid "DIB Header: Unknown encoding in file."
 msgstr "DIB Opskrif: Onbekende kodering in lêer."
 
-#: ../src/common/paper.cpp:121
+#: ../src/common/paper.cpp:118
 msgid "DL Envelope, 110 x 220 mm"
 msgstr "Koevert DL, 110 x 220 mm"
 
@@ -2621,56 +2624,56 @@ msgstr "Koevert DL, 110 x 220 mm"
 msgid "Dashed"
 msgstr "Strepies"
 
-#: ../src/generic/dbgrptg.cpp:300
+#: ../src/generic/dbgrptg.cpp:301
 #, c-format
 msgid "Debug report \"%s\""
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:210
+#: ../src/common/debugrpt.cpp:211
 #, fuzzy
 msgid "Debug report couldn't be created."
 msgstr "Gids '%s' kon nie geskep word nie"
 
-#: ../src/common/debugrpt.cpp:553
+#: ../src/common/debugrpt.cpp:554
 msgid "Debug report generation has failed."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:84
+#: ../src/common/accelcmn.cpp:81
 msgid "Decimal"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:323
+#: ../src/generic/fontdlgg.cpp:319
 msgid "Decorative"
 msgstr "Dekoratief"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1752
+#: ../src/propgrid/advprops.cpp:1653
 #, fuzzy
 msgid "Default"
 msgstr "standaard"
 
-#: ../src/common/fmapbase.cpp:796
+#: ../src/common/fmapbase.cpp:792
 msgid "Default encoding"
 msgstr "Standaard-enkodering"
 
-#: ../src/dfb/fontmgr.cpp:180
+#: ../src/dfb/fontmgr.cpp:177
 msgid "Default font"
 msgstr "Versteklettertipe"
 
-#: ../src/generic/prntdlgg.cpp:510
+#: ../src/generic/prntdlgg.cpp:503
 msgid "Default printer"
 msgstr "Verstekdrukker"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:51
+#: ../src/common/accelcmn.cpp:48
 #, fuzzy
 msgid "Del"
 msgstr "Skrap"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextbuffer.cpp:8221 ../src/common/stockitem.cpp:152
-#: ../src/common/accelcmn.cpp:50 ../src/stc/stc_i18n.cpp:20
+#: ../src/common/stockitem.cpp:149 ../src/common/accelcmn.cpp:47
+#: ../src/richtext/richtextbuffer.cpp:8217 ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Skrap"
 
@@ -2678,68 +2681,68 @@ msgstr "Skrap"
 msgid "Delete A&ll"
 msgstr "Skrap &almal"
 
-#: ../src/richtext/richtextbuffer.cpp:11341
+#: ../src/richtext/richtextbuffer.cpp:11340
 msgid "Delete Column"
 msgstr "Skrap kolom"
 
-#: ../src/richtext/richtextbuffer.cpp:11291
+#: ../src/richtext/richtextbuffer.cpp:11290
 msgid "Delete Row"
 msgstr "Skrap ry"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 msgid "Delete Style"
 msgstr "Skrap styl"
 
-#: ../src/richtext/richtextctrl.cpp:1345 ../src/richtext/richtextctrl.cpp:1584
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
 msgid "Delete Text"
 msgstr "Skrap teks"
 
-#: ../src/generic/editlbox.cpp:170
+#: ../src/generic/editlbox.cpp:147
 msgid "Delete item"
 msgstr "Skrap item"
 
-#: ../src/common/stockitem.cpp:260
+#: ../src/common/stockitem.cpp:257
 msgid "Delete selection"
 msgstr "Skrap seleksie"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 #, c-format
 msgid "Delete style %s?"
 msgstr "Skrap styl %s?"
 
-#: ../src/unix/snglinst.cpp:301
+#: ../src/unix/snglinst.cpp:298
 #, c-format
 msgid "Deleted stale lock file '%s'."
 msgstr "Verouderde slot-lêer '%s' is geskrap."
 
-#: ../src/common/secretstore.cpp:220
+#: ../src/common/secretstore.cpp:234
 #, fuzzy, c-format
-msgid "Deleting password for \"%s/%s\" failed: %s."
+msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Uitpak van '%s' binne-in '%s' het misluk."
 
-#: ../src/common/module.cpp:124
+#: ../src/common/module.cpp:121
 #, c-format
 msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "Descending"
 msgstr "Dalend"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:526 ../src/propgrid/advprops.cpp:882
+#: ../src/generic/dirctrlg.cpp:492 ../src/propgrid/advprops.cpp:783
 msgid "Desktop"
 msgstr "Werkarea"
 
-#: ../src/generic/aboutdlgg.cpp:70
+#: ../src/generic/aboutdlgg.cpp:67
 msgid "Developed by "
 msgstr "Ontwikkel deur "
 
-#: ../src/generic/aboutdlgg.cpp:176
+#: ../src/generic/aboutdlgg.cpp:173
 msgid "Developers"
 msgstr "Programmeerders"
 
-#: ../src/msw/dialup.cpp:374
+#: ../src/msw/dialup.cpp:368
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -2747,11 +2750,11 @@ msgstr ""
 "Inbel-funksies is nie beskikbaar nie omdat die afstandtoegangsdiens (RAS) "
 "nie op hierdie masjien geïnstalleer is nie. Installeer dit asb."
 
-#: ../src/generic/tipdlg.cpp:211
+#: ../src/generic/tipdlg.cpp:208
 msgid "Did you know..."
 msgstr "Het u geweet..."
 
-#: ../src/dfb/wrapdfb.cpp:63
+#: ../src/dfb/wrapdfb.cpp:60
 #, c-format
 msgid "DirectFB error %d occurred."
 msgstr ""
@@ -2760,74 +2763,74 @@ msgstr ""
 msgid "Directories"
 msgstr "Gidse"
 
-#: ../src/common/filefn.cpp:1183
+#: ../src/common/filefn.cpp:1071
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Gids '%s' kon nie geskep word nie"
 
-#: ../src/common/filefn.cpp:1197
+#: ../src/common/filefn.cpp:1085
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "Gids '%s' kon nie geskrap word nie"
 
-#: ../src/generic/dirdlgg.cpp:204
+#: ../src/generic/dirdlgg.cpp:201
 msgid "Directory does not exist"
 msgstr "Gids bestaan nie"
 
-#: ../src/generic/filectrlg.cpp:1399
+#: ../src/generic/filectrlg.cpp:1388
 msgid "Directory doesn't exist."
 msgstr "Gids bestaan nie."
 
-#: ../src/common/docview.cpp:457
+#: ../src/common/docview.cpp:450
 msgid "Discard changes and reload the last saved version?"
 msgstr "Verwerp veranderinge en herlaai die laaste gestoorde weergawe?"
 
-#: ../src/html/helpwnd.cpp:502
+#: ../src/html/helpwnd.cpp:500
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
 msgstr ""
 "Wys alle indeks-items wat die gegewe substring bevat. (Nie kassensitief nie.)"
 
-#: ../src/html/helpwnd.cpp:679
+#: ../src/html/helpwnd.cpp:677
 msgid "Display options dialog"
 msgstr "Wys opsies-dialoog"
 
-#: ../src/html/helpwnd.cpp:322
+#: ../src/html/helpwnd.cpp:320
 msgid "Displays help as you browse the books on the left."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:85
+#: ../src/common/accelcmn.cpp:83
 msgid "Divide"
 msgstr ""
 
-#: ../src/common/docview.cpp:533
+#: ../src/common/docview.cpp:526
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Wil u die veranderinge aan %s stoor?"
 
-#: ../src/common/prntbase.cpp:542
+#: ../src/common/prntbase.cpp:537
 msgid "Document:"
 msgstr "Dokument:"
 
-#: ../src/generic/aboutdlgg.cpp:73
+#: ../src/generic/aboutdlgg.cpp:70
 msgid "Documentation by "
 msgstr "Dokumentasie deur "
 
-#: ../src/generic/aboutdlgg.cpp:180
+#: ../src/generic/aboutdlgg.cpp:177
 msgid "Documentation writers"
 msgstr "Dokumentasieskrywers"
 
-#: ../src/common/sizer.cpp:2799
+#: ../src/common/sizer.cpp:2916
 msgid "Don't Save"
 msgstr "Moenie stoor nie"
 
-#: ../src/html/htmlwin.cpp:633
+#: ../src/html/htmlwin.cpp:643
 msgid "Done"
 msgstr "Klaar"
 
-#: ../src/generic/progdlgg.cpp:448 ../src/msw/progdlg.cpp:407
+#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
 msgid "Done."
 msgstr "Klaar."
 
@@ -2839,43 +2842,43 @@ msgstr "Stippels"
 msgid "Double"
 msgstr "Dubbel"
 
-#: ../src/common/paper.cpp:176
+#: ../src/common/paper.cpp:173
 msgid "Double Japanese Postcard Rotated 148 x 200 mm"
 msgstr "Dubbele Japannese poskaart, geroteer 148 x 200 mm"
 
-#: ../src/common/xtixml.cpp:273
+#: ../src/common/xtixml.cpp:269
 #, c-format
 msgid "Doubly used id : %d"
 msgstr "Dubbelgebruikte id: %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:153
-#: ../src/common/accelcmn.cpp:64
+#: ../src/common/stockitem.cpp:150 ../src/common/accelcmn.cpp:61
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Down"
 msgstr "Af"
 
-#: ../src/richtext/richtextctrl.cpp:865
+#: ../src/richtext/richtextctrl.cpp:864
 msgid "Drag"
 msgstr "Sleep"
 
-#: ../src/common/paper.cpp:100
+#: ../src/common/paper.cpp:97
 msgid "E sheet, 34 x 44 in"
 msgstr "E, 34 x 44 duim"
 
-#: ../src/unix/fswatcher_inotify.cpp:561
+#: ../src/unix/fswatcher_inotify.cpp:558
 #, fuzzy
 msgid "EOF while reading from inotify descriptor"
 msgstr "kan nie lees van lêeretiket %d"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "Edit"
 msgstr "Redigeer"
 
-#: ../src/generic/editlbox.cpp:168
+#: ../src/generic/editlbox.cpp:131
 msgid "Edit item"
 msgstr "Redigeer item"
 
-#: ../include/wx/generic/progdlgg.h:84
+#: ../include/wx/generic/progdlgg.h:85
 msgid "Elapsed time:"
 msgstr "Tydsduur sovêr:"
 
@@ -2947,51 +2950,51 @@ msgid "Enables the shadow spread."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:66
+#: ../src/common/accelcmn.cpp:63
 msgid "End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:55
+#: ../src/common/accelcmn.cpp:52
 #, fuzzy
 msgid "Enter"
 msgstr "Drukker"
 
-#: ../src/richtext/richtextstyledlg.cpp:934
+#: ../src/richtext/richtextstyledlg.cpp:930
 msgid "Enter a box style name"
 msgstr "Tik 'n naam vir die boksstyl"
 
-#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:602
 msgid "Enter a character style name"
 msgstr "Tik 'n naam vir die karakterstyl"
 
-#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:816
 msgid "Enter a list style name"
 msgstr "Tik 'n naam vir die lysstyl"
 
-#: ../src/richtext/richtextstyledlg.cpp:893
+#: ../src/richtext/richtextstyledlg.cpp:889
 msgid "Enter a new style name"
 msgstr "Tik 'n nuwe naam vir die styl"
 
-#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:650
 msgid "Enter a paragraph style name"
 msgstr "Tik 'n naam vir die paragraafstyl"
 
-#: ../src/generic/dbgrptg.cpp:174
+#: ../src/generic/dbgrptg.cpp:171
 #, c-format
 msgid "Enter command to open file \"%s\":"
 msgstr "Gee opdrag om die lêer \"%s\" mee te open:"
 
-#: ../src/generic/helpext.cpp:459
+#: ../src/generic/helpext.cpp:457
 msgid "Entries found"
 msgstr "Inskrywings gevind"
 
-#: ../src/common/paper.cpp:142
+#: ../src/common/paper.cpp:139
 #, fuzzy
 msgid "Envelope Invite 220 x 220 mm"
 msgstr "Koevert DL, 110 x 220 mm"
 
-#: ../src/common/config.cpp:469
+#: ../src/common/config.cpp:465
 #, fuzzy, c-format
 msgid ""
 "Environment variables expansion failed: missing '%c' at position %u in '%s'."
@@ -2999,13 +3002,13 @@ msgstr ""
 "Uitbreiding van omgewingsveranderlikes het misluk: ontbrekende '%c' op "
 "posisie %d in '%s'."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/generic/dirctrlg.cpp:570
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/dirctrlg.cpp:599
-#: ../src/generic/dirdlgg.cpp:323 ../src/generic/filectrlg.cpp:642
-#: ../src/generic/filectrlg.cpp:756 ../src/generic/filectrlg.cpp:770
-#: ../src/generic/filectrlg.cpp:786 ../src/generic/filectrlg.cpp:1368
-#: ../src/generic/filectrlg.cpp:1399 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/gtk1/fontdlg.cpp:74 ../src/generic/dirctrlg.cpp:536
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/dirctrlg.cpp:565
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1357 ../src/generic/filectrlg.cpp:1388
+#: ../src/generic/filedlgg.cpp:354 ../src/generic/dirdlgg.cpp:320
+#: ../src/gtk/filedlg.cpp:74
 msgid "Error"
 msgstr "Fout"
 
@@ -3014,241 +3017,262 @@ msgstr "Fout"
 msgid "Error closing epoll descriptor"
 msgstr "Fout tydens skepping van gids"
 
-#: ../src/unix/fswatcher_kqueue.cpp:114
+#: ../src/unix/fswatcher_kqueue.cpp:131
 #, fuzzy
 msgid "Error closing kqueue instance"
 msgstr "Fout tydens skepping van gids"
 
-#: ../src/common/filefn.cpp:1049
+#: ../src/common/filefn.cpp:938
 #, fuzzy, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Kopiëring van lêer '%s' na '%s' het misluk"
 
-#: ../src/generic/dirdlgg.cpp:222
+#: ../src/generic/dirdlgg.cpp:219
 msgid "Error creating directory"
 msgstr "Fout tydens skep van gids"
 
-#: ../src/common/imagbmp.cpp:1181
+#: ../src/common/imagbmp.cpp:1193
 #, fuzzy
 msgid "Error in reading image DIB."
 msgstr "Fout tydens lees van DIB-beeld."
 
-#: ../src/propgrid/propgrid.cpp:6696
+#: ../src/propgrid/propgrid.cpp:6665
 #, c-format
 msgid "Error in resource: %s"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:422
+#: ../src/common/fileconf.cpp:421
 msgid "Error reading config options."
 msgstr "Fout met lees van konfigurasie-opsies."
+
+#: ../src/msw/webview_ie.cpp:1057 ../src/msw/webview_edge.cpp:850
+#: ../src/gtk/webview_webkit2.cpp:1262 ../src/osx/webview_webkit.mm:383
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
 
 #: ../src/common/fileconf.cpp:1029
 #, fuzzy
 msgid "Error saving user configuration data."
 msgstr "Fout met lees van konfigurasie-opsies."
 
-#: ../src/gtk/print.cpp:722
+#: ../src/gtk/print.cpp:720
 msgid "Error while printing: "
 msgstr "Fout tydens drukwerk: "
 
-#: ../src/common/log.cpp:219
+#: ../src/common/log.cpp:237
 msgid "Error: "
 msgstr "Fout: "
 
+#: ../src/common/webrequest.cpp:98
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Fout: "
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:69
+#: ../src/common/accelcmn.cpp:66
 msgid "Esc"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:70
+#: ../src/common/accelcmn.cpp:67
 #, fuzzy
 msgid "Escape"
 msgstr "Dwars"
 
-#: ../src/common/fmapbase.cpp:150
+#: ../src/common/fmapbase.cpp:147
 msgid "Esperanto (ISO-8859-3)"
 msgstr "Esperanto (ISO-8859-3)"
 
-#: ../include/wx/generic/progdlgg.h:85
+#: ../include/wx/generic/progdlgg.h:86
 msgid "Estimated time:"
 msgstr "Geskatte tyd:"
 
-#: ../src/generic/dbgrptg.cpp:234
+#: ../src/generic/dbgrptg.cpp:231
 #, fuzzy
 msgid "Executable files (*.exe)|*.exe|"
 msgstr "Alle lêers (*.*)|*.*"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:155 ../src/common/accelcmn.cpp:78
+#: ../src/common/stockitem.cpp:152 ../src/common/accelcmn.cpp:75
 msgid "Execute"
 msgstr ""
 
-#: ../src/msw/utilsexc.cpp:876
+#: ../src/msw/utilsexc.cpp:873
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Uitvoering van opdrag '%s' het misluk"
 
-#: ../src/common/paper.cpp:105
+#: ../src/common/paper.cpp:102
 msgid "Executive, 7 1/4 x 10 1/2 in"
 msgstr "VSA Executive, 7 1/4 x 10 1/2 duim"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6009
+#: ../src/generic/datavgen.cpp:6814
 msgid "Expand"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1240
+#: ../src/msw/registry.cpp:1228
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:195
+#: ../src/common/fmapbase.cpp:192
 msgid "Extended Unix Codepage for Japanese (EUC-JP)"
 msgstr "Extended Unix Codepage vir Japannees (EUC-JP)"
 
-#: ../src/html/chm.cpp:725
+#: ../src/html/chm.cpp:718
 #, c-format
 msgid "Extraction of '%s' into '%s' failed."
 msgstr "Uitpak van '%s' binne-in '%s' het misluk."
 
-#: ../src/common/accelcmn.cpp:249 ../src/common/accelcmn.cpp:344
+#: ../src/common/accelcmn.cpp:259 ../src/common/accelcmn.cpp:358
 msgid "F"
 msgstr "F"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:672
+#: ../src/propgrid/advprops.cpp:582
 #, fuzzy
 msgid "Face Name"
 msgstr "Nuwe gids"
 
-#: ../src/unix/snglinst.cpp:269
+#: ../src/unix/snglinst.cpp:266
 msgid "Failed to access lock file."
 msgstr "Toegang na slotlêer het misluk."
+
+#: ../src/gtk/font.cpp:572
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Lees van dokument vanuit lêer \"%s\" het misluk."
 
 #: ../src/unix/epolldispatcher.cpp:116
 #, fuzzy, c-format
 msgid "Failed to add descriptor %d to epoll descriptor %d"
 msgstr "kan nie skryf na lêeretiket %d nie"
 
-#: ../src/msw/dib.cpp:489
+#: ../src/msw/dib.cpp:535
 #, fuzzy, c-format
 msgid "Failed to allocate %luKb of memory for bitmap data."
 msgstr "Kon nie %luKb geheue toeken vir bitmap-data nie."
 
-#: ../src/common/glcmn.cpp:115
+#: ../src/common/glcmn.cpp:112
 #, fuzzy
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Wyser kon nie geskep word nie."
 
-#: ../src/unix/displayx11.cpp:236
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Wyser kon nie geskep word nie."
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Wyser kon nie geskep word nie."
+
+#: ../include/wx/unix/private/displayx11.h:89
 msgid "Failed to change video mode"
 msgstr "Videomodus kon nie verander word nie"
 
-#: ../src/common/image.cpp:3277
+#: ../src/common/image.cpp:3396
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:239
+#: ../src/common/debugrpt.cpp:240
 #, fuzzy, c-format
 msgid "Failed to clean up debug report directory \"%s\""
 msgstr "Die gids %s/.gnome kon nie geskep word nie."
 
-#: ../src/common/filename.cpp:192
+#: ../src/common/filename.cpp:189
 msgid "Failed to close file handle"
 msgstr "Toemaak van lêer het misluk."
 
-#: ../src/unix/snglinst.cpp:340
+#: ../src/unix/snglinst.cpp:337
 #, c-format
 msgid "Failed to close lock file '%s'"
 msgstr "Toemaak van slotlêer '%s' het misluk"
 
-#: ../src/msw/clipbrd.cpp:112
+#: ../src/msw/clipbrd.cpp:110
 msgid "Failed to close the clipboard."
 msgstr "Toemaak van knipbord het misluk."
 
-#: ../src/x11/utils.cpp:208
+#: ../src/x11/utils.cpp:170
 #, fuzzy, c-format
 msgid "Failed to close the display \"%s\""
 msgstr "Toemaak van knibord het misluk."
 
-#: ../src/msw/dialup.cpp:797
+#: ../src/msw/dialup.cpp:791
 msgid "Failed to connect: missing username/password."
 msgstr "Verbinding het misluk: gebruikersnaam/wagwoord ontbreek."
 
-#: ../src/msw/dialup.cpp:743
+#: ../src/msw/dialup.cpp:737
 msgid "Failed to connect: no ISP to dial."
 msgstr "Verbinding het misluk: geen ISP om te bel."
 
-#: ../src/common/textfile.cpp:203
-#, c-format
-msgid "Failed to convert file \"%s\" to Unicode."
-msgstr "Omskakel van lêer \"%s\" na Unicode het misluk."
-
-#: ../src/generic/logg.cpp:956
+#: ../src/generic/logg.cpp:953
 #, fuzzy
 msgid "Failed to copy dialog contents to the clipboard."
 msgstr "Kopieer van dialooginhoud na knipbord het misluk."
 
-#: ../src/msw/registry.cpp:692
+#: ../src/msw/registry.cpp:681
 #, c-format
 msgid "Failed to copy registry value '%s'"
 msgstr "Kopiëring van registerwaarde '%s' het misluk"
 
-#: ../src/msw/registry.cpp:701
+#: ../src/msw/registry.cpp:690
 #, c-format
 msgid "Failed to copy the contents of registry key '%s' to '%s'."
 msgstr "Kopiëring van registersleutel '%s' na '%s' het misluk."
 
-#: ../src/common/filefn.cpp:1015
+#: ../src/common/filefn.cpp:904
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Kopiëring van lêer '%s' na '%s' het misluk"
 
-#: ../src/msw/registry.cpp:679
+#: ../src/msw/registry.cpp:668
 #, c-format
 msgid "Failed to copy the registry subkey '%s' to '%s'."
 msgstr "Kopiëring van registersleutel '%s' na '%s' het misluk"
 
-#: ../src/msw/dde.cpp:1070
+#: ../src/msw/dde.cpp:1134
 msgid "Failed to create DDE string"
 msgstr "Skepping van DDE-string het misluk"
 
-#: ../src/msw/mdi.cpp:616
+#: ../src/msw/mdi.cpp:621
 msgid "Failed to create MDI parent frame."
 msgstr "Skepping van MDI-hoofvenster het misluk."
 
-#: ../src/common/filename.cpp:1027
+#: ../src/common/filename.cpp:1024
 msgid "Failed to create a temporary file name"
 msgstr "'n Tydelyke lêernaam kon nie geskep word nie"
 
-#: ../src/msw/utilsexc.cpp:228
+#: ../src/msw/utilsexc.cpp:225
 msgid "Failed to create an anonymous pipe"
 msgstr "'n Anonieme pyp kon nie geskep word nie"
 
-#: ../src/msw/ole/automtn.cpp:522
+#: ../src/msw/ole/automtn.cpp:513
 #, fuzzy, c-format
 msgid "Failed to create an instance of \"%s\""
 msgstr "Die gids %s/.gnome kon nie geskep word nie."
 
-#: ../src/msw/dde.cpp:437
+#: ../src/msw/dde.cpp:432
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr ""
 "'n Verbinding met bediener '%s' vir onderwerp '%s' kon nie gemaak word nie"
 
-#: ../src/msw/cursor.cpp:204
+#: ../src/msw/cursor.cpp:195
 msgid "Failed to create cursor."
 msgstr "Wyser kon nie geskep word nie."
 
-#: ../src/common/debugrpt.cpp:209
+#: ../src/common/debugrpt.cpp:210
 #, c-format
 msgid "Failed to create directory \"%s\""
 msgstr "Gids \"%s\" kon nie geskep word nie"
 
-#: ../src/generic/dirdlgg.cpp:220
+#: ../src/generic/dirdlgg.cpp:217
 #, c-format
 msgid ""
 "Failed to create directory '%s'\n"
@@ -3262,117 +3286,136 @@ msgstr ""
 msgid "Failed to create epoll descriptor"
 msgstr "Wyser kon nie geskep word nie."
 
-#: ../src/msw/mimetype.cpp:238
+#: ../src/gtk/font.cpp:562
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "kan gebruikers-konfigurasielêer nie oopmaak nie."
+
+#: ../src/msw/mimetype.cpp:235
 #, c-format
 msgid "Failed to create registry entry for '%s' files."
 msgstr "Die registersleutel vir '%s'-lêers kon nie geskep word nie."
 
-#: ../src/msw/fdrepdlg.cpp:409
+#: ../src/msw/fdrepdlg.cpp:408
 #, c-format
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr ""
 "Die standaard soek/vervang-dialoog kon nie geskep word nie (foutkode %d)"
 
-#: ../src/unix/wakeuppipe.cpp:52
+#: ../src/unix/wakeuppipe.cpp:49
 #, fuzzy
 msgid "Failed to create wake up pipe used by event loop."
 msgstr "Skepping van stasb.lk het misluk."
 
-#: ../src/html/winpars.cpp:730
+#: ../src/html/winpars.cpp:727
 #, c-format
 msgid "Failed to display HTML document in %s encoding"
 msgstr "Weergee van HTML-document in %s-kodering het misluk"
 
-#: ../src/msw/clipbrd.cpp:124
+#: ../src/msw/clipbrd.cpp:122
 msgid "Failed to empty the clipboard."
 msgstr "Skoonmaak van knipbord het misluk."
 
-#: ../src/unix/displayx11.cpp:212
+#: ../include/wx/unix/private/displayx11.h:65
 msgid "Failed to enumerate video modes"
 msgstr "Videomodusse kon nie gelys word nie"
 
-#: ../src/msw/dde.cpp:722
+#: ../src/msw/dde.cpp:717
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "Opstelling van advies-lus met die DDE-server het misluk"
 
-#: ../src/msw/dialup.cpp:629 ../src/msw/dialup.cpp:863
+#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "'n Inbelverbinding kon nie gemaak word nie: %s"
 
-#: ../src/unix/utilsunx.cpp:611
+#: ../src/unix/utilsunx.cpp:613
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Uitvoering van '%s' het misluk\n"
 
-#: ../src/common/debugrpt.cpp:720
+#: ../src/common/debugrpt.cpp:730
 msgid "Failed to execute curl, please install it in PATH."
 msgstr "Kon nie curl laat loop nie. Installeer dit asb. in PATH."
 
-#: ../src/msw/ole/automtn.cpp:505
+#: ../src/msw/ole/automtn.cpp:496
 #, fuzzy, c-format
 msgid "Failed to find CLSID of \"%s\""
 msgstr "Opening van '%s' vir %s het misluk"
 
-#: ../src/common/regex.cpp:431 ../src/common/regex.cpp:479
+#: ../src/common/regex.cpp:428 ../src/common/regex.cpp:476
 #, fuzzy, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "'%s' kon nie in reëlmatige uitdrukking '%s' gevind word nie"
 
-#: ../src/msw/dialup.cpp:695
+#: ../src/msw/webview_ie.cpp:978
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:689
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "ISP name %s kon nie verkry word nie"
 
-#: ../src/msw/ole/automtn.cpp:574
+#: ../src/msw/ole/automtn.cpp:565
 #, fuzzy, c-format
 msgid "Failed to get OLE automation interface for \"%s\""
 msgstr "Die gids %s/.gnome kon nie geskep word nie."
 
-#: ../src/msw/clipbrd.cpp:711
+#: ../src/msw/clipbrd.cpp:731
 msgid "Failed to get data from the clipboard"
 msgstr "Data kon nie vanaf die knipbord verkry word nie"
 
-#: ../src/common/time.cpp:223
+#: ../src/common/time.cpp:216
 msgid "Failed to get the local system time"
 msgstr "Die plaaslike stelseltyd kon nie verkry word nie"
 
-#: ../src/common/filefn.cpp:1345
+#: ../src/common/filefn.cpp:1233
 msgid "Failed to get the working directory"
 msgstr "Die werkgids kon nie verkry word nie"
 
-#: ../src/univ/theme.cpp:114
+#: ../src/univ/theme.cpp:111
 msgid "Failed to initialize GUI: no built-in themes found."
 msgstr "Initialisering van GUI het misluk: Geen ingeboude tema gevind nie."
 
-#: ../src/msw/helpchm.cpp:63
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:60
 msgid "Failed to initialize MS HTML Help."
 msgstr "Inisialisering van MS HTML Help het misluk."
 
-#: ../src/msw/glcanvas.cpp:1381
+#: ../src/msw/glcanvas.cpp:1391
 msgid "Failed to initialize OpenGL"
 msgstr "Inisialisering van OpenGL het misluk."
 
-#: ../src/msw/dialup.cpp:858
+#: ../src/msw/dialup.cpp:852
 #, fuzzy, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Verbreking van inbelverbinding het misluk: %s"
 
-#: ../src/gtk/textctrl.cpp:1128
+#: ../src/gtk/textctrl.cpp:1209
 msgid "Failed to insert text in the control."
 msgstr "Kon nie teks in die tekskontrole invoeg nie."
 
-#: ../src/unix/snglinst.cpp:241
+#: ../src/unix/snglinst.cpp:238
 #, fuzzy, c-format
 msgid "Failed to inspect the lock file '%s'"
 msgstr "Sluiting van die slotlêer '%s' het misluk"
 
-#: ../src/unix/appunix.cpp:182
+#: ../src/unix/appunix.cpp:179
 #, fuzzy
 msgid "Failed to install signal handler"
 msgstr "Toemaak van lêer het misluk."
 
-#: ../src/unix/threadpsx.cpp:1167
+#: ../src/unix/threadpsx.cpp:1216
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -3380,71 +3423,71 @@ msgstr ""
 "Aansluiting by 'n uitvoerdraad het misluk, moontlik 'n geheuelekkasie "
 "teëgekom - herbegin die programma asb."
 
-#: ../src/msw/utils.cpp:629
+#: ../src/msw/utils.cpp:619
 #, c-format
 msgid "Failed to kill process %d"
 msgstr "Process %d kon nie doodgemaak word nie"
 
-#: ../src/common/image.cpp:2500
+#: ../src/common/image.cpp:2595
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Laai van beeld \"%s\" vanuit hulpbronne het misluk."
 
-#: ../src/common/image.cpp:2509
+#: ../src/common/image.cpp:2604
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Laai van ikoon \"%s\" vanuit hulpbronne het misluk."
 
-#: ../src/common/iconbndl.cpp:225
+#: ../src/common/iconbndl.cpp:224
 #, fuzzy, c-format
 msgid "Failed to load icons from resource '%s'."
 msgstr "Laai van ikoon \"%s\" vanuit hulpbronne het misluk."
 
-#: ../src/common/iconbndl.cpp:200
+#: ../src/common/iconbndl.cpp:198
 #, fuzzy, c-format
 msgid "Failed to load image %%d from file '%s'."
 msgstr "Laaiing van beeld %d vanuit lêer '%s' het misluk."
 
-#: ../src/common/iconbndl.cpp:208
+#: ../src/common/iconbndl.cpp:206
 #, fuzzy, c-format
 msgid "Failed to load image %d from stream."
 msgstr "Laaiing van beeld %d vanuit lêer '%s' het misluk."
 
-#: ../src/common/image.cpp:2587 ../src/common/image.cpp:2606
+#: ../src/common/image.cpp:2682 ../src/common/image.cpp:2701
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Laai van beeld vanuit lêer \"%s\" het misluk."
 
-#: ../src/msw/enhmeta.cpp:97
+#: ../src/msw/enhmeta.cpp:94
 #, c-format
 msgid "Failed to load metafile from file \"%s\"."
 msgstr "Laai van metalêer vanuit lêer \"%s\" het misluk."
 
-#: ../src/msw/volume.cpp:327
+#: ../src/msw/volume.cpp:335
 msgid "Failed to load mpr.dll."
 msgstr "Laai van mpr.dll het misluk."
 
-#: ../src/msw/utils.cpp:953
+#: ../src/msw/utils.cpp:943
 #, c-format
 msgid "Failed to load resource \"%s\"."
 msgstr "Kon nie hulpbron \"%s\" laai nie."
 
-#: ../src/common/dynlib.cpp:92
+#: ../src/common/dynlib.cpp:86
 #, c-format
 msgid "Failed to load shared library '%s'"
 msgstr "Laai van gedeelde biblioteek '%s' het misluk"
 
-#: ../src/osx/core/sound.cpp:145
+#: ../src/osx/core/sound.cpp:143
 #, fuzzy, c-format
 msgid "Failed to load sound from \"%s\" (error %d)."
 msgstr "Kon nie hulpbron \"%s\" laai nie."
 
-#: ../src/msw/utils.cpp:960
+#: ../src/msw/utils.cpp:950
 #, c-format
 msgid "Failed to lock resource \"%s\"."
 msgstr "Kon nie hulpbron \"%s\" vassluit nie."
 
-#: ../src/unix/snglinst.cpp:198
+#: ../src/unix/snglinst.cpp:195
 #, c-format
 msgid "Failed to lock the lock file '%s'"
 msgstr "Sluiting van die slotlêer '%s' het misluk"
@@ -3454,33 +3497,38 @@ msgstr "Sluiting van die slotlêer '%s' het misluk"
 msgid "Failed to modify descriptor %d in epoll descriptor %d"
 msgstr ""
 
-#: ../src/common/filename.cpp:2575
+#: ../src/common/filename.cpp:2658
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Verandering van lêertye van '%s' het misluk"
 
-#: ../src/common/selectdispatcher.cpp:258
+#: ../src/common/selectdispatcher.cpp:255
 msgid "Failed to monitor I/O channels"
 msgstr ""
 
-#: ../src/common/filename.cpp:175
+#: ../src/common/filename.cpp:172
 #, fuzzy, c-format
 msgid "Failed to open '%s' for reading"
 msgstr "Opening van '%s' vir %s het misluk"
 
-#: ../src/common/filename.cpp:180
+#: ../src/common/filename.cpp:177
 #, fuzzy, c-format
 msgid "Failed to open '%s' for writing"
 msgstr "Opening van '%s' vir %s het misluk"
 
-#: ../src/html/chm.cpp:141
+#: ../src/html/chm.cpp:138
 #, c-format
 msgid "Failed to open CHM archive '%s'."
 msgstr "CHM-argief '%s' kon nie oopgemaak word nie."
 
-#: ../src/common/utilscmn.cpp:1126
+#: ../src/common/utilscmn.cpp:1140
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Opening van URL \"%s\" in verstekblaaier het misluk."
+
+#: ../src/common/hyperlnkcmn.cpp:133
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Opening van URL \"%s\" in verstekblaaier het misluk."
 
 #: ../include/wx/msw/private/fswatcher.h:92
@@ -3488,212 +3536,231 @@ msgstr "Opening van URL \"%s\" in verstekblaaier het misluk."
 msgid "Failed to open directory \"%s\" for monitoring."
 msgstr "Opening van gids \"%s\" vir monitering het misluk."
 
-#: ../src/x11/utils.cpp:227
+#: ../src/x11/utils.cpp:189
 #, fuzzy, c-format
 msgid "Failed to open display \"%s\"."
 msgstr "Opening van '%s' vir %s het misluk"
 
-#: ../src/common/filename.cpp:1062
+#: ../src/common/filename.cpp:1059
 msgid "Failed to open temporary file."
 msgstr "Opening van tydelyk lêer het misluk."
 
-#: ../src/msw/clipbrd.cpp:91
+#: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Open van knipbord het misluk."
 
-#: ../src/common/translation.cpp:1184
+#: ../src/common/translation.cpp:1226
 #, fuzzy, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Kan nie meervoudvorme ontleed nie: `%s'"
 
-#: ../src/unix/mediactrl.cpp:1214
+#: ../src/unix/mediactrl.cpp:1239
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Voorbereiding vir speel van \"%s\" het misluk."
 
-#: ../src/msw/clipbrd.cpp:600
+#: ../src/msw/clipbrd.cpp:610
 msgid "Failed to put data on the clipboard"
 msgstr "Stoor van data op knipbord het misluk"
 
-#: ../src/unix/snglinst.cpp:278
+#: ../src/unix/snglinst.cpp:275
 msgid "Failed to read PID from lock file."
 msgstr "Inlees van PID vanuit slotlêer het misluk."
 
-#: ../src/common/fileconf.cpp:433
+#: ../src/common/fileconf.cpp:432
 #, fuzzy
 msgid "Failed to read config options."
 msgstr "Fout met lees van konfigurasie-opsies."
 
-#: ../src/common/docview.cpp:681
+#: ../src/common/docview.cpp:676
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Lees van dokument vanuit lêer \"%s\" het misluk."
 
-#: ../src/dfb/evtloop.cpp:98
+#: ../src/dfb/evtloop.cpp:99
 #, fuzzy
 msgid "Failed to read event from DirectFB pipe"
 msgstr "Inlees van PID vanuit slotlêer het misluk."
 
-#: ../src/unix/wakeuppipe.cpp:120
+#: ../src/unix/wakeuppipe.cpp:117
 #, fuzzy
 msgid "Failed to read from wake-up pipe"
 msgstr "Inlees van PID vanuit slotlêer het misluk."
 
-#: ../src/unix/utilsunx.cpp:679
+#: ../src/common/textfile.cpp:96
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Lees van dokument vanuit lêer \"%s\" het misluk."
+
+#: ../src/unix/utilsunx.cpp:681
 msgid "Failed to redirect child process input/output"
 msgstr "Herleiding van toevoer/afvoer van subproses het misluk"
 
-#: ../src/msw/utilsexc.cpp:701
+#: ../src/msw/utilsexc.cpp:698
 msgid "Failed to redirect the child process IO"
 msgstr "Herleiding van toevoer/afvoer van subproses het misluk"
 
-#: ../src/msw/dde.cpp:288
+#: ../src/msw/dde.cpp:283
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Registrasie van DDE-bediener '%s' het misluk"
 
-#: ../src/common/fontmap.cpp:245
+#: ../src/gtk/font.cpp:580
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "kan gebruikers-konfigurasielêer nie oopmaak nie."
+
+#: ../src/common/fontmap.cpp:242
 #, c-format
 msgid "Failed to remember the encoding for the charset '%s'."
 msgstr "Die kodering vir karakterstel '%s' kon nie onthou word nie."
 
-#: ../src/common/debugrpt.cpp:227
+#: ../src/common/debugrpt.cpp:228
 #, fuzzy, c-format
 msgid "Failed to remove debug report file \"%s\""
 msgstr "Verwydering van slotlêer '%s' het misluk"
 
-#: ../src/unix/snglinst.cpp:328
+#: ../src/unix/snglinst.cpp:325
 #, c-format
 msgid "Failed to remove lock file '%s'"
 msgstr "Verwydering van slotlêer '%s' het misluk"
 
-#: ../src/unix/snglinst.cpp:288
+#: ../src/unix/snglinst.cpp:285
 #, c-format
 msgid "Failed to remove stale lock file '%s'."
 msgstr "Verwydering van verouderd slotlêer '%s' het misluk."
 
-#: ../src/msw/registry.cpp:529
+#: ../src/msw/registry.cpp:518
 #, c-format
 msgid "Failed to rename registry value '%s' to '%s'."
 msgstr "Hernoeming van registerwaarde '%s' na '%s' het misluk"
 
-#: ../src/common/filefn.cpp:1122
+#: ../src/common/filefn.cpp:1011
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
 "exists."
 msgstr ""
 
-#: ../src/msw/registry.cpp:634
+#: ../src/msw/registry.cpp:623
 #, c-format
 msgid "Failed to rename the registry key '%s' to '%s'."
 msgstr "Hernoeming van registersleutel '%s' na '%s' het misluk"
 
-#: ../src/common/filename.cpp:2671
+#: ../src/msw/webview_ie.cpp:995
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/common/filename.cpp:2754
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Verkryging van lêertye vir '%s' het misluk"
 
-#: ../src/msw/dialup.cpp:468
+#: ../src/msw/dialup.cpp:462
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Verkryging van teks van inbel-foutmelding het misluk"
 
-#: ../src/msw/clipbrd.cpp:748
+#: ../src/msw/clipbrd.cpp:768
 msgid "Failed to retrieve the supported clipboard formats"
 msgstr "Verkryging van ondersteunde knipbord-formate het misluk"
 
-#: ../src/common/docview.cpp:652
+#: ../src/common/docview.cpp:647
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Kon nie dokument stoor na die lêer \"%s\" nie."
 
-#: ../src/msw/dib.cpp:269
+#: ../src/msw/dib.cpp:312
 #, c-format
 msgid "Failed to save the bitmap image to file \"%s\"."
 msgstr "Die bitmap-beeld kon nie na lêer \"%s\" gestoor word nie."
 
-#: ../src/msw/dde.cpp:763
+#: ../src/msw/dde.cpp:811
 msgid "Failed to send DDE advise notification"
 msgstr "DDE-advieskennisgewing kon nie gestuur word nie"
 
-#: ../src/common/ftp.cpp:402
+#: ../src/common/ftp.cpp:399
 #, c-format
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Kon nie FTP-oordragmodus na %s stel nie."
 
-#: ../src/msw/clipbrd.cpp:427
+#: ../src/msw/clipbrd.cpp:443
 msgid "Failed to set clipboard data."
 msgstr "Opstelling van knipborddata het misluk."
 
-#: ../src/unix/snglinst.cpp:181
+#: ../src/unix/snglinst.cpp:178
 #, fuzzy, c-format
 msgid "Failed to set permissions on lock file '%s'"
 msgstr "Onmoontlik om magtigings vir lêer '%s' op te stel"
 
-#: ../src/unix/utilsunx.cpp:668
+#: ../src/unix/utilsunx.cpp:670
 #, fuzzy
 msgid "Failed to set process priority"
 msgstr "Opstelling van prioriteit van thread %d het misluk."
 
-#: ../src/common/file.cpp:559
+#: ../src/common/ffile.cpp:355 ../src/common/file.cpp:586
 msgid "Failed to set temporary file permissions"
 msgstr "Opstelling van magtigings van tydelyke lêer het misluk"
 
-#: ../src/gtk/textctrl.cpp:1072
-msgid "Failed to set text in the text control."
-msgstr "Kon nie teks in die tekskontrole stel nie."
-
-#: ../src/unix/threadpsx.cpp:1298
+#: ../src/unix/threadpsx.cpp:1347
 #, fuzzy, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Opstelling van prioriteit van thread %d het misluk."
 
-#: ../src/unix/threadpsx.cpp:1424
+#: ../src/unix/threadpsx.cpp:1473
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Opstelling van prioriteit van thread %d het misluk."
 
-#: ../src/unix/utilsunx.cpp:783
+#: ../src/unix/utilsunx.cpp:785
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 
-#: ../src/common/fs_mem.cpp:261
+#: ../src/msw/webview_ie.cpp:987
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:256
 #, c-format
 msgid "Failed to store image '%s' to memory VFS!"
 msgstr "Stoor van beeld '%s' na VFS in geheue het misluk!"
 
-#: ../src/dfb/evtloop.cpp:170
+#: ../src/dfb/evtloop.cpp:171
 msgid "Failed to switch DirectFB pipe to non-blocking mode"
 msgstr ""
 
-#: ../src/unix/wakeuppipe.cpp:59
+#: ../src/unix/wakeuppipe.cpp:56
 msgid "Failed to switch wake up pipe to non-blocking mode"
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1605
+#: ../src/unix/threadpsx.cpp:1654
 msgid "Failed to terminate a thread."
 msgstr "Beëindiging van uitvoerdraad het misluk."
 
-#: ../src/msw/dde.cpp:741
+#: ../src/msw/dde.cpp:736
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "Beëindiging van advies-lus met die DDE-server het misluk"
 
-#: ../src/msw/dialup.cpp:938
+#: ../src/msw/dialup.cpp:932
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Verbreking van inbelverbinding het misluk: %s"
 
-#: ../src/common/filename.cpp:2590
+#: ../src/common/filename.cpp:2673
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Aanraking van lêer '%s' het misluk"
 
-#: ../src/unix/snglinst.cpp:334
+#: ../src/unix/dlunix.cpp:90
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "Laai van gedeelde biblioteek '%s' het misluk"
+
+#: ../src/unix/snglinst.cpp:331
 #, c-format
 msgid "Failed to unlock lock file '%s'"
 msgstr "Oopsluit van die slotlêer '%s' het misluk"
 
-#: ../src/msw/dde.cpp:309
+#: ../src/msw/dde.cpp:304
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Deregistrering van DDE-bediener '%s' het misluk"
@@ -3708,78 +3775,88 @@ msgstr "Onttrekking van data uit knipbord het misluk"
 msgid "Failed to update user configuration file."
 msgstr "kan gebruikers-konfigurasielêer nie oopmaak nie."
 
-#: ../src/common/debugrpt.cpp:733
+#: ../src/common/debugrpt.cpp:743
 #, fuzzy, c-format
 msgid "Failed to upload the debug report (error code %d)."
 msgstr ""
 "Die standaard soek/vervang-dialoog kon nie geskep word nie (foutkode %d)"
 
-#: ../src/unix/snglinst.cpp:168
+#: ../src/unix/snglinst.cpp:165
 #, c-format
 msgid "Failed to write to lock file '%s'"
 msgstr "Skryfbewerking na slotlêer '%s' het misluk"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:209
+#: ../src/propgrid/propgrid.cpp:190
 msgid "False"
 msgstr "Vals"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:694
+#: ../src/propgrid/advprops.cpp:604
 msgid "Family"
 msgstr "Familie"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/gtk/glcanvas.cpp:176 ../src/gtk/glcanvas.cpp:187
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Fatale fout"
+
+#: ../src/common/stockitem.cpp:154
 msgid "File"
 msgstr "Lêer"
 
-#: ../src/common/docview.cpp:669
+#: ../src/common/docview.cpp:664
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Opening van \"%s\" vir leeswerk het misluk."
 
-#: ../src/common/docview.cpp:646
+#: ../src/common/docview.cpp:641
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Opening van \"%s\" vir skryfwerk het misluk."
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "Lêer '%s' bestaan al. Moet dit oorskryf word?"
 
-#: ../src/common/filefn.cpp:1156
+#: ../src/common/filefn.cpp:1044
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Lêer '%s' kon nie verwyd word nie"
 
-#: ../src/common/filefn.cpp:1139
+#: ../src/common/filefn.cpp:1028
 #, fuzzy, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Gids '%s' kon nie geskep word nie"
 
-#: ../src/richtext/richtextctrl.cpp:3081 ../src/common/textcmn.cpp:953
+#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
 msgid "File couldn't be loaded."
 msgstr "Lêer kon nie gelaai word nie."
 
-#: ../src/msw/filedlg.cpp:393
+#: ../src/msw/filedlg.cpp:414
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Lêerdialoog het misluk met foutkode %0lx."
 
-#: ../src/common/docview.cpp:1789
+#: ../src/common/docview.cpp:1783
 msgid "File error"
 msgstr "Lêerfout"
 
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/filectrlg.cpp:770
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/filectrlg.cpp:766
 msgid "File name exists already."
 msgstr "Lêernaam bestaan al."
+
+#: ../src/osx/cocoa/filedlg.mm:264
+#, fuzzy
+msgid "File type:"
+msgstr "Nie-proporsioneel (Teletype)"
 
 #: ../src/motif/filedlg.cpp:220
 msgid "Files"
 msgstr "Lêers"
 
-#: ../src/common/filefn.cpp:1591
+#: ../src/common/filefn.cpp:1479
 #, fuzzy, c-format
 msgid "Files (%s)"
 msgstr "Lêers (%s)|%s"
@@ -3788,15 +3865,29 @@ msgstr "Lêers (%s)|%s"
 msgid "Filter"
 msgstr "Filter"
 
-#: ../src/common/stockitem.cpp:158 ../src/html/helpwnd.cpp:490
+#: ../src/html/helpwnd.cpp:488
 msgid "Find"
 msgstr "Soek"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:259
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:258
+#, fuzzy
+msgid "Find in document"
+msgstr "Maak HTML-dokument oop"
+
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "Find..."
+msgstr "Soek"
+
+#: ../src/common/stockitem.cpp:156
 msgid "First"
 msgstr "Eerste"
 
-#: ../src/common/prntbase.cpp:1548
+#: ../src/common/prntbase.cpp:1573
 msgid "First page"
 msgstr "Eerste bladsy"
 
@@ -3804,11 +3895,11 @@ msgstr "Eerste bladsy"
 msgid "Fixed"
 msgstr "Vas"
 
-#: ../src/html/helpwnd.cpp:1206
+#: ../src/html/helpwnd.cpp:1204
 msgid "Fixed font:"
 msgstr "Nie-proporsionele lettertipe:"
 
-#: ../src/html/helpwnd.cpp:1269
+#: ../src/html/helpwnd.cpp:1267
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Vaste lettergrootte.<br> <b>vetdruk</b> <i>kursief</i> "
 
@@ -3816,17 +3907,17 @@ msgstr "Vaste lettergrootte.<br> <b>vetdruk</b> <i>kursief</i> "
 msgid "Floating"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 #, fuzzy
 msgid "Floppy"
 msgstr "&Kopieer "
 
-#: ../src/common/paper.cpp:111
+#: ../src/common/paper.cpp:108
 msgid "Folio, 8 1/2 x 13 in"
 msgstr "Folio, 8 1/2 x 13 duim"
 
-#: ../src/richtext/richtextformatdlg.cpp:344 ../src/osx/carbon/fontdlg.cpp:287
-#: ../src/common/stockitem.cpp:194
+#: ../src/osx/carbon/fontdlg.cpp:284 ../src/common/stockitem.cpp:191
+#: ../src/richtext/richtextformatdlg.cpp:337
 msgid "Font"
 msgstr "Lettertipe"
 
@@ -3835,7 +3926,24 @@ msgstr "Lettertipe"
 msgid "Font &weight:"
 msgstr "agtste"
 
-#: ../src/html/helpwnd.cpp:1207
+#: ../src/osx/fontutil.cpp:89
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
+"\"."
+msgstr ""
+
+#: ../src/msw/font.cpp:1126
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Lêer kon nie gelaai word nie."
+
+#: ../src/osx/fontutil.cpp:81
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "Lêer %s bestaan nie."
+
+#: ../src/html/helpwnd.cpp:1205
 msgid "Font size:"
 msgstr "Lettergrootte:"
 
@@ -3844,54 +3952,54 @@ msgstr "Lettergrootte:"
 msgid "Font st&yle:"
 msgstr "Lettertipe-grootte:"
 
-#: ../src/osx/carbon/fontdlg.cpp:329
+#: ../src/osx/carbon/fontdlg.cpp:326
 msgid "Font:"
 msgstr "Lettertipe:"
 
-#: ../src/dfb/fontmgr.cpp:198
+#: ../src/dfb/fontmgr.cpp:195
 #, c-format
 msgid "Fonts index file %s disappeared while loading fonts."
 msgstr ""
 "Indekslêer vir lettertipes %s het verdwyn terwyl lettertipes gelaai is."
 
-#: ../src/unix/utilsunx.cpp:645
+#: ../src/unix/utilsunx.cpp:647
 msgid "Fork failed"
 msgstr "'Fork' het misluk"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "Forward"
 msgstr "Vorentoe"
 
-#: ../src/common/xtixml.cpp:235
+#: ../src/common/xtixml.cpp:231
 msgid "Forward hrefs are not supported"
 msgstr "Voorwaartse 'href'-verwysings word nie ondersteun nie"
 
-#: ../src/html/helpwnd.cpp:875
+#: ../src/html/helpwnd.cpp:873
 #, c-format
 msgid "Found %i matches"
 msgstr "%i ooreenkomste gevind"
 
-#: ../src/generic/prntdlgg.cpp:238
+#: ../src/generic/prntdlgg.cpp:231
 msgid "From:"
 msgstr "Van:"
 
-#: ../src/propgrid/advprops.cpp:1604
+#: ../src/propgrid/advprops.cpp:1510
 msgid "Fuchsia"
 msgstr ""
 
-#: ../src/common/imaggif.cpp:138
+#: ../src/common/imaggif.cpp:135
 msgid "GIF: data stream seems to be truncated."
 msgstr "GIF: datastroom lyk afgekap."
 
-#: ../src/common/imaggif.cpp:128
+#: ../src/common/imaggif.cpp:125
 msgid "GIF: error in GIF image format."
 msgstr "GIF: fout in GIF-lêerformaat."
 
-#: ../src/common/imaggif.cpp:133
+#: ../src/common/imaggif.cpp:130
 msgid "GIF: not enough memory."
 msgstr "GIF: onvoldoende geheue."
 
-#: ../src/gtk/window.cpp:4631
+#: ../src/gtk/window.cpp:5635
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -3899,23 +4007,23 @@ msgstr ""
 "Die weergawe van GTK+ wat op dié rekenaar geïnstalleer is, is te oud om "
 "skermsaamstelling te ondersteun. Installeer asb. GTK+ 2.12 of later."
 
-#: ../src/univ/themes/gtk.cpp:525
+#: ../src/univ/themes/gtk.cpp:522
 msgid "GTK+ theme"
 msgstr "GTK+ tema"
 
-#: ../src/common/preferencescmn.cpp:40
+#: ../src/common/preferencescmn.cpp:37
 msgid "General"
 msgstr "Algemeen"
 
-#: ../src/common/prntbase.cpp:258
+#: ../src/common/prntbase.cpp:253
 msgid "Generic PostScript"
 msgstr "Generiese PostScript"
 
-#: ../src/common/paper.cpp:135
+#: ../src/common/paper.cpp:132
 msgid "German Legal Fanfold, 8 1/2 x 13 in"
 msgstr "Duitse Legal Fanfold, 8 1/2 x 13 duim"
 
-#: ../src/common/paper.cpp:134
+#: ../src/common/paper.cpp:131
 msgid "German Std Fanfold, 8 1/2 x 12 in"
 msgstr "Duitse Std Fanfold, 8 1/2 x 12 duim"
 
@@ -3931,49 +4039,49 @@ msgstr "GetPropertyCollection is geroep vir 'n generiese toegangsmetode"
 msgid "GetPropertyCollection called w/o valid collection getter"
 msgstr "GetPropertyCollection is geroep sonder geldige metode"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:658
 msgid "Go back"
 msgstr "Gaan terug"
 
-#: ../src/html/helpwnd.cpp:661
+#: ../src/html/helpwnd.cpp:659
 msgid "Go forward"
 msgstr "Gaan vorentoe"
 
-#: ../src/html/helpwnd.cpp:663
+#: ../src/html/helpwnd.cpp:661
 msgid "Go one level up in document hierarchy"
 msgstr "Gaan een vlak hoër in dokument-hiërargie"
 
-#: ../src/generic/filedlgg.cpp:208 ../src/generic/dirdlgg.cpp:116
+#: ../src/generic/filedlgg.cpp:205 ../src/generic/dirdlgg.cpp:113
 msgid "Go to home directory"
 msgstr "Gaan na tuisgids"
 
-#: ../src/generic/filedlgg.cpp:205
+#: ../src/generic/filedlgg.cpp:202
 msgid "Go to parent directory"
 msgstr "Gaan na moedergids"
 
-#: ../src/generic/aboutdlgg.cpp:76
+#: ../src/generic/aboutdlgg.cpp:73
 msgid "Graphics art by "
 msgstr "Grafiese kuns deur "
 
-#: ../src/propgrid/advprops.cpp:1599
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Gray"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:883
+#: ../src/propgrid/advprops.cpp:784
 msgid "GrayText"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:154
+#: ../src/common/fmapbase.cpp:151
 msgid "Greek (ISO-8859-7)"
 msgstr "Grieks (ISO-8859-7)"
 
-#: ../src/propgrid/advprops.cpp:1600
+#: ../src/propgrid/advprops.cpp:1506
 #, fuzzy
 msgid "Green"
 msgstr "MacGreek"
 
-#: ../src/generic/colrdlgg.cpp:342
+#: ../src/generic/colrdlgg.cpp:362
 #, fuzzy
 msgid "Green:"
 msgstr "MacGreek"
@@ -3982,109 +4090,109 @@ msgstr "MacGreek"
 msgid "Groove"
 msgstr ""
 
-#: ../src/common/zstream.cpp:158 ../src/common/zstream.cpp:318
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
 msgid "Gzip not supported by this version of zlib"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1549
+#: ../src/html/helpwnd.cpp:1547
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "HTML-hulpprojek (*.hhp)|*.hhp|"
 
-#: ../src/html/htmlwin.cpp:681
+#: ../src/html/htmlwin.cpp:691
 #, c-format
 msgid "HTML anchor %s does not exist."
 msgstr "HTML-anker %s bestaan nie."
 
-#: ../src/html/helpwnd.cpp:1547
+#: ../src/html/helpwnd.cpp:1545
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "HTML-lêers (*.html;*.htm)|*.html;*.htm|"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1759
+#: ../src/propgrid/advprops.cpp:1660
 msgid "Hand"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "Harddisk"
 msgstr "Hardeskyf"
 
-#: ../src/common/fmapbase.cpp:155
+#: ../src/common/fmapbase.cpp:152
 msgid "Hebrew (ISO-8859-8)"
 msgstr "Hebreeus (ISO-8859-8)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:280 ../src/osx/button_osx.cpp:39
-#: ../src/common/stockitem.cpp:163 ../src/common/accelcmn.cpp:80
-#: ../src/html/helpdlg.cpp:66 ../src/html/helpfrm.cpp:111
+#: ../include/wx/msgdlg.h:282 ../src/osx/button_osx.cpp:39
+#: ../src/common/stockitem.cpp:160 ../src/common/accelcmn.cpp:77
+#: ../src/html/helpfrm.cpp:108 ../src/html/helpdlg.cpp:63
 msgid "Help"
 msgstr "Hulp"
 
-#: ../src/html/helpwnd.cpp:1200
+#: ../src/html/helpwnd.cpp:1198
 msgid "Help Browser Options"
 msgstr "Hulpblaaier-opsies"
 
-#: ../src/generic/helpext.cpp:454 ../src/generic/helpext.cpp:455
+#: ../src/generic/helpext.cpp:452 ../src/generic/helpext.cpp:453
 msgid "Help Index"
 msgstr "Hulpindeks"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1529
 msgid "Help Printing"
 msgstr "Hulpdrukwerk"
 
-#: ../src/html/helpwnd.cpp:801
+#: ../src/html/helpwnd.cpp:799
 msgid "Help Topics"
 msgstr "Hulponderwerpe"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1546
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Hulpboeke (*.htb)|*.htb|Hulpboeke (*.zip)|*.zip|"
 
-#: ../src/generic/helpext.cpp:267
+#: ../src/generic/helpext.cpp:265
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:275
+#: ../src/generic/helpext.cpp:273
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "Hulplêer \"%s\" nie gevind nie."
 
-#: ../src/html/helpctrl.cpp:63
+#: ../src/html/helpctrl.cpp:59
 #, c-format
 msgid "Help: %s"
 msgstr "Hulp: %s"
 
-#: ../src/osx/menu_osx.cpp:577
+#: ../src/osx/menu_osx.cpp:469
 #, c-format
 msgid "Hide %s"
 msgstr "Versteek %s"
 
-#: ../src/osx/menu_osx.cpp:579
+#: ../src/osx/menu_osx.cpp:471
 msgid "Hide Others"
 msgstr "Versteek ander"
 
-#: ../src/generic/infobar.cpp:84
+#: ../src/generic/infobar.cpp:81
 msgid "Hide this notification message."
 msgstr "Versteek dié kennisgewing."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:884
+#: ../src/propgrid/advprops.cpp:785
 #, fuzzy
 msgid "Highlight"
 msgstr "lig"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:885
+#: ../src/propgrid/advprops.cpp:786
 #, fuzzy
 msgid "HighlightText"
 msgstr "Belyn teks regs."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:164 ../src/common/accelcmn.cpp:65
+#: ../src/common/stockitem.cpp:161 ../src/common/accelcmn.cpp:62
 msgid "Home"
 msgstr "Tuis"
 
-#: ../src/generic/dirctrlg.cpp:524
+#: ../src/generic/dirctrlg.cpp:490
 msgid "Home directory"
 msgstr "Tuisgids"
 
@@ -4094,55 +4202,55 @@ msgid "How the object will float relative to the text."
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1760
+#: ../src/propgrid/advprops.cpp:1661
 msgid "I-Beam"
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1196
+#: ../src/common/imagbmp.cpp:1208
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: Fout by inlees van masker DIB."
 
-#: ../src/common/imagbmp.cpp:1290 ../src/common/imagbmp.cpp:1390
-#: ../src/common/imagbmp.cpp:1405 ../src/common/imagbmp.cpp:1416
-#: ../src/common/imagbmp.cpp:1430 ../src/common/imagbmp.cpp:1478
-#: ../src/common/imagbmp.cpp:1493 ../src/common/imagbmp.cpp:1507
-#: ../src/common/imagbmp.cpp:1518
+#: ../src/common/imagbmp.cpp:1302 ../src/common/imagbmp.cpp:1402
+#: ../src/common/imagbmp.cpp:1417 ../src/common/imagbmp.cpp:1428
+#: ../src/common/imagbmp.cpp:1442 ../src/common/imagbmp.cpp:1490
+#: ../src/common/imagbmp.cpp:1505 ../src/common/imagbmp.cpp:1519
+#: ../src/common/imagbmp.cpp:1530
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: Fout tydens wegskryf van die beeld!"
 
-#: ../src/common/imagbmp.cpp:1255
+#: ../src/common/imagbmp.cpp:1267
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: Beeld is te hoog vir 'n ikoon."
 
-#: ../src/common/imagbmp.cpp:1263
+#: ../src/common/imagbmp.cpp:1275
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: Beeld is te breed vir 'n ikoon."
 
-#: ../src/common/imagbmp.cpp:1603
+#: ../src/common/imagbmp.cpp:1615
 msgid "ICO: Invalid icon index."
 msgstr "ICO: Ongeldige ikoonindeks."
 
-#: ../src/common/imagiff.cpp:758
+#: ../src/common/imagiff.cpp:755
 msgid "IFF: data stream seems to be truncated."
 msgstr "IFFF: datastroom lyk afgekap."
 
-#: ../src/common/imagiff.cpp:742
+#: ../src/common/imagiff.cpp:739
 msgid "IFF: error in IFF image format."
 msgstr "IFF: fout in IFF lêerformaat."
 
-#: ../src/common/imagiff.cpp:745
+#: ../src/common/imagiff.cpp:742
 msgid "IFF: not enough memory."
 msgstr "IFF: onvoldoende geheue."
 
-#: ../src/common/imagiff.cpp:748
+#: ../src/common/imagiff.cpp:745
 msgid "IFF: unknown error!!!"
 msgstr "IFF: onbekende fout!!!"
 
-#: ../src/common/fmapbase.cpp:197
+#: ../src/common/fmapbase.cpp:194
 msgid "ISO-2022-JP"
 msgstr "ISO-2022-JP"
 
-#: ../src/html/htmprint.cpp:282
+#: ../src/html/htmprint.cpp:294
 msgid ""
 "If possible, try changing the layout parameters to make the printout more "
 "narrow."
@@ -4150,7 +4258,7 @@ msgstr ""
 "Indien moontlik, probeer om die uitlegparameters te verander om die drukstuk "
 "maerder te maak."
 
-#: ../src/generic/dbgrptg.cpp:358
+#: ../src/generic/dbgrptg.cpp:362
 msgid ""
 "If you have any additional information pertaining to this bug\n"
 "report, please enter it here and it will be joined to it:"
@@ -4164,46 +4272,50 @@ msgid ""
 "at all possible please do continue with the report generation.\n"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1405
+#: ../src/common/zipstrm.cpp:1043
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1393
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:295
+#: ../src/common/xtistrm.cpp:292
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Ongeldige objekklas (Non-wxEvtHandler) as bron van gebeurtenis"
 
-#: ../src/common/xti.cpp:513
+#: ../src/common/xti.cpp:510
 msgid "Illegal Parameter Count for ConstructObject Method"
 msgstr "Ongeldige aantal parameters vir ConstructObject-metode"
 
-#: ../src/common/xti.cpp:501
+#: ../src/common/xti.cpp:498
 msgid "Illegal Parameter Count for Create Method"
 msgstr "Ongeldige aantal parameters vir Createt-metode"
 
-#: ../src/generic/dirctrlg.cpp:570 ../src/generic/filectrlg.cpp:756
+#: ../src/generic/dirctrlg.cpp:536 ../src/generic/filectrlg.cpp:752
 msgid "Illegal directory name."
 msgstr "Ongeldige gidsnaam."
 
-#: ../src/generic/filectrlg.cpp:1367
+#: ../src/generic/filectrlg.cpp:1356
 msgid "Illegal file specification."
 msgstr "Ongeldige lêerspesifikasie."
 
-#: ../src/common/image.cpp:2269
+#: ../src/common/image.cpp:2363
 msgid "Image and mask have different sizes."
 msgstr "Beeld en masker het verskillende groottes."
 
-#: ../src/common/image.cpp:2746
+#: ../src/common/image.cpp:2841
 #, fuzzy, c-format
 msgid "Image file is not of type %d."
 msgstr "Beeldlêer is nie van die tipe %d."
 
-#: ../src/common/image.cpp:2877
+#: ../src/common/image.cpp:2995
 #, fuzzy, c-format
 msgid "Image is not of type %s."
 msgstr "Beeldlêer is nie van die tipe %d."
 
-#: ../src/msw/textctrl.cpp:488
+#: ../src/msw/textctrl.cpp:534
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -4211,102 +4323,102 @@ msgstr ""
 "Onmoontlik om Rich Edit beheerelement te skep, gewone teks word gebruik. "
 "Herinstalleer riched32.dll asb."
 
-#: ../src/unix/utilsunx.cpp:301
+#: ../src/unix/utilsunx.cpp:303
 msgid "Impossible to get child process input"
 msgstr "Onmoontlik om subproses-toevoer te verkry"
 
-#: ../src/common/filefn.cpp:1028
+#: ../src/common/filefn.cpp:917
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Onmoontlik om magtigings vir lêer '%s' te kry"
 
-#: ../src/common/filefn.cpp:1042
+#: ../src/common/filefn.cpp:931
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Onmoontlik om lêer '%s' te oorskryf"
 
-#: ../src/common/filefn.cpp:1097
+#: ../src/common/filefn.cpp:986
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Onmoontlik om magtigings vir lêer '%s' op te stel"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:886
+#: ../src/propgrid/advprops.cpp:787
 #, fuzzy
 msgid "InactiveBorder"
 msgstr "Modern"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:887
+#: ../src/propgrid/advprops.cpp:788
 msgid "InactiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:888
+#: ../src/propgrid/advprops.cpp:789
 msgid "InactiveCaptionText"
 msgstr ""
 
-#: ../src/common/gifdecod.cpp:792
+#: ../src/common/gifdecod.cpp:826
 #, c-format
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:635
+#: ../src/msw/ole/automtn.cpp:626
 msgid "Incorrect number of arguments."
 msgstr "Verkeerde aantal argumente."
 
-#: ../src/common/stockitem.cpp:165
+#: ../src/common/stockitem.cpp:162
 msgid "Indent"
 msgstr "Keep in"
 
-#: ../src/richtext/richtextformatdlg.cpp:349
+#: ../src/richtext/richtextformatdlg.cpp:342
 msgid "Indents && Spacing"
 msgstr "Inkepe en spasiëring"
 
-#: ../src/common/stockitem.cpp:166 ../src/html/helpwnd.cpp:515
+#: ../src/common/stockitem.cpp:163 ../src/html/helpwnd.cpp:513
 msgid "Index"
 msgstr "Indeks"
 
-#: ../src/common/fmapbase.cpp:159
+#: ../src/common/fmapbase.cpp:156
 msgid "Indian (ISO-8859-12)"
 msgstr "Indies (ISO-8859-12)"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "Info"
 msgstr "Inligting"
 
-#: ../src/common/init.cpp:287
+#: ../src/common/init.cpp:284
 msgid "Initialization failed in post init, aborting."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:54
+#: ../src/common/accelcmn.cpp:51
 #, fuzzy
 msgid "Ins"
 msgstr "Indeks"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextsymboldlg.cpp:472 ../src/common/accelcmn.cpp:53
+#: ../src/common/accelcmn.cpp:50 ../src/richtext/richtextsymboldlg.cpp:469
 msgid "Insert"
 msgstr "Voeg in"
 
-#: ../src/richtext/richtextbuffer.cpp:8067
+#: ../src/richtext/richtextbuffer.cpp:8063
 msgid "Insert Field"
 msgstr "Voeg veld in"
 
-#: ../src/richtext/richtextbuffer.cpp:7978
-#: ../src/richtext/richtextbuffer.cpp:8936
+#: ../src/richtext/richtextbuffer.cpp:7974
+#: ../src/richtext/richtextbuffer.cpp:8934
 msgid "Insert Image"
 msgstr "Voeg beeld in"
 
-#: ../src/richtext/richtextbuffer.cpp:8025
+#: ../src/richtext/richtextbuffer.cpp:8021
 msgid "Insert Object"
 msgstr "Voeg objek in"
 
-#: ../src/richtext/richtextctrl.cpp:1286 ../src/richtext/richtextctrl.cpp:1494
-#: ../src/richtext/richtextbuffer.cpp:7822
-#: ../src/richtext/richtextbuffer.cpp:7852
-#: ../src/richtext/richtextbuffer.cpp:7894
+#: ../src/richtext/richtextbuffer.cpp:7818
+#: ../src/richtext/richtextbuffer.cpp:7848
+#: ../src/richtext/richtextbuffer.cpp:7890
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
 msgid "Insert Text"
 msgstr "Voeg teks in"
 
@@ -4320,16 +4432,11 @@ msgstr "Voeg 'n bladsybreuk in voor die paragraaf."
 msgid "Inset"
 msgstr "Indeks"
 
-#: ../src/gtk/app.cpp:425
-#, c-format
-msgid "Invalid GTK+ command line option, use \"%s --help\""
-msgstr "Ongeldige opdraglynkeuse vir GTK+. Gebruik \"%s --help\""
-
-#: ../src/common/imagtiff.cpp:311
+#: ../src/common/imagtiff.cpp:308
 msgid "Invalid TIFF image index."
 msgstr "Ongeldige TIFF-beeldindeks."
 
-#: ../src/common/appcmn.cpp:273
+#: ../src/common/appcmn.cpp:294
 #, c-format
 msgid "Invalid display mode specification '%s'."
 msgstr "Spesifikasie '%s' vir vertoonskermmodus is ongeldig."
@@ -4339,255 +4446,259 @@ msgstr "Spesifikasie '%s' vir vertoonskermmodus is ongeldig."
 msgid "Invalid geometry specification '%s'"
 msgstr "Ongeldige geometrie-spesifikasie '%s'"
 
-#: ../src/unix/fswatcher_inotify.cpp:323
+#: ../src/unix/fswatcher_inotify.cpp:320
 #, c-format
 msgid "Invalid inotify event for \"%s\""
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:312
+#: ../src/unix/snglinst.cpp:309
 #, c-format
 msgid "Invalid lock file '%s'."
 msgstr "Ongeldig slotlêer '%s'."
 
-#: ../src/common/translation.cpp:1125
+#: ../src/common/translation.cpp:1167
 #, fuzzy
 msgid "Invalid message catalog."
 msgstr "'%s' is nie 'n geldige boodskapkatalogus."
 
-#: ../src/common/xtistrm.cpp:405 ../src/common/xtistrm.cpp:420
+#: ../src/common/xtistrm.cpp:402 ../src/common/xtistrm.cpp:417
 msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
 msgstr "Ongeldige- of Null-objek ID is aangestuur vir GetObjectClassInfo"
 
-#: ../src/common/xtistrm.cpp:435
+#: ../src/common/xtistrm.cpp:432
 msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
 msgstr "Ongeldige- of Null-objek ID is aangestuur vir HasObjectClassInfo"
 
-#: ../src/common/regex.cpp:310
+#: ../src/common/regex.cpp:307
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Ongeldige reëlmatige uitdrukking '%s': %s"
 
-#: ../src/common/config.cpp:226
+#: ../src/common/config.cpp:222
 #, c-format
 msgid "Invalid value %ld for a boolean key \"%s\" in config file."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:351
-#: ../src/osx/carbon/fontdlg.cpp:361 ../src/common/stockitem.cpp:168
+#: ../src/osx/carbon/fontdlg.cpp:358 ../src/common/stockitem.cpp:165
+#: ../src/generic/fontdlgg.cpp:325 ../src/richtext/richtextfontpage.cpp:351
 msgid "Italic"
 msgstr "Kursief"
 
-#: ../src/common/paper.cpp:130
+#: ../src/common/paper.cpp:127
 msgid "Italy Envelope, 110 x 230 mm"
 msgstr "Koevert 'Italy', 110 x 230 mm"
 
-#: ../src/common/imagjpeg.cpp:270
+#: ../src/common/imagjpeg.cpp:257
 msgid "JPEG: Couldn't load - file is probably corrupted."
 msgstr "JPEG: kon nie laai nie - lêer is waarskynlik korrup."
 
-#: ../src/common/imagjpeg.cpp:449
+#: ../src/common/imagjpeg.cpp:436
 msgid "JPEG: Couldn't save image."
 msgstr "JPEG: kon beeld nie stoor nie."
 
-#: ../src/common/paper.cpp:163
+#: ../src/common/paper.cpp:160
 msgid "Japanese Double Postcard 200 x 148 mm"
 msgstr "Japannese dubbele poskaart 200 x 148 mm"
 
-#: ../src/common/paper.cpp:167
+#: ../src/common/paper.cpp:164
 msgid "Japanese Envelope Chou #3"
 msgstr ""
 
-#: ../src/common/paper.cpp:180
+#: ../src/common/paper.cpp:177
 msgid "Japanese Envelope Chou #3 Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:168
+#: ../src/common/paper.cpp:165
 msgid "Japanese Envelope Chou #4"
 msgstr ""
 
-#: ../src/common/paper.cpp:181
+#: ../src/common/paper.cpp:178
 msgid "Japanese Envelope Chou #4 Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:165
+#: ../src/common/paper.cpp:162
 msgid "Japanese Envelope Kaku #2"
 msgstr ""
 
-#: ../src/common/paper.cpp:178
+#: ../src/common/paper.cpp:175
 msgid "Japanese Envelope Kaku #2 Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:166
+#: ../src/common/paper.cpp:163
 msgid "Japanese Envelope Kaku #3"
 msgstr ""
 
-#: ../src/common/paper.cpp:179
+#: ../src/common/paper.cpp:176
 msgid "Japanese Envelope Kaku #3 Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:185
+#: ../src/common/paper.cpp:182
 msgid "Japanese Envelope You #4"
 msgstr ""
 
-#: ../src/common/paper.cpp:186
+#: ../src/common/paper.cpp:183
 msgid "Japanese Envelope You #4 Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:138
+#: ../src/common/paper.cpp:135
 msgid "Japanese Postcard 100 x 148 mm"
 msgstr "Japannese poskaart 100 x 148 mm"
 
-#: ../src/common/paper.cpp:175
+#: ../src/common/paper.cpp:172
 msgid "Japanese Postcard Rotated 148 x 100 mm"
 msgstr "Japannese poskaart, geroteer 148 x 100 mm"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "Jump to"
 msgstr "Spring na"
 
-#: ../src/common/stockitem.cpp:171
+#: ../src/common/stockitem.cpp:168
 msgid "Justified"
 msgstr "Alkantbelyn"
 
-#: ../src/richtext/richtextindentspage.cpp:155
-#: ../src/richtext/richtextindentspage.cpp:157
 #: ../src/richtext/richtextliststylepage.cpp:344
 #: ../src/richtext/richtextliststylepage.cpp:346
+#: ../src/richtext/richtextindentspage.cpp:155
+#: ../src/richtext/richtextindentspage.cpp:157
 msgid "Justify text left and right."
 msgstr "Belyn teks links en regs."
 
-#: ../src/common/fmapbase.cpp:163
+#: ../src/common/fmapbase.cpp:160
 msgid "KOI8-R"
 msgstr "KOI8-R"
 
-#: ../src/common/fmapbase.cpp:164
+#: ../src/common/fmapbase.cpp:161
 msgid "KOI8-U"
 msgstr "KOI8-U"
 
-#: ../src/common/accelcmn.cpp:265 ../src/common/accelcmn.cpp:347
+#: ../src/common/accelcmn.cpp:279 ../src/common/accelcmn.cpp:364
 msgid "KP_"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "KP_Add"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "KP_Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "KP_Decimal"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 #, fuzzy
 msgid "KP_Delete"
 msgstr "Skrap"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "KP_Divide"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 #, fuzzy
 msgid "KP_Down"
 msgstr "Af"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "KP_End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 #, fuzzy
 msgid "KP_Enter"
 msgstr "Drukker"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "KP_Equal"
 msgstr ""
 
+#: ../src/common/accelcmn.cpp:276 ../src/common/accelcmn.cpp:361
+msgid "KP_F"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 #, fuzzy
 msgid "KP_Home"
 msgstr "Tuis"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 #, fuzzy
 msgid "KP_Insert"
 msgstr "Voeg in"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 #, fuzzy
 msgid "KP_Left"
 msgstr "Links"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "KP_Multiply"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:99
+#: ../src/common/accelcmn.cpp:97
 #, fuzzy
 msgid "KP_Next"
 msgstr "Volgende"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "KP_PageDown"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "KP_PageUp"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:98
+#: ../src/common/accelcmn.cpp:96
 msgid "KP_Prior"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 #, fuzzy
 msgid "KP_Right"
 msgstr "Regs"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "KP_Separator"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "KP_Space"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "KP_Subtract"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "KP_Tab"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "KP_Up"
 msgstr ""
 
@@ -4595,112 +4706,127 @@ msgstr ""
 msgid "L&ine spacing:"
 msgstr "&Lynspasiëring:"
 
-#: ../src/generic/prntdlgg.cpp:613 ../src/generic/prntdlgg.cpp:868
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "inpakfout"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "uitpakfout"
+
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:861
 msgid "Landscape"
 msgstr "Dwars"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "Last"
 msgstr "Laaste"
 
-#: ../src/common/prntbase.cpp:1572
+#: ../src/common/prntbase.cpp:1597
 msgid "Last page"
 msgstr "Laaste bladsy"
 
-#: ../src/common/log.cpp:305
+#: ../src/common/log.cpp:324
 #, c-format
 msgid "Last repeated message (\"%s\", %u time) wasn't output"
 msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/common/paper.cpp:103
+#: ../src/common/paper.cpp:100
 msgid "Ledger, 17 x 11 in"
 msgstr "VSA Ledger, 17 x 11 duim"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6146
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:58 ../src/generic/datavgen.cpp:6951
+#: ../src/richtext/richtextsizepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:252
 #: ../src/richtext/richtextliststylepage.cpp:253
 #: ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
-#: ../src/richtext/richtextsizepage.cpp:249 ../src/common/accelcmn.cpp:61
 msgid "Left"
 msgstr "Links"
 
-#: ../src/richtext/richtextindentspage.cpp:204
 #: ../src/richtext/richtextliststylepage.cpp:390
+#: ../src/richtext/richtextindentspage.cpp:204
 msgid "Left (&first line):"
 msgstr "Links (&eerste lyn):"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1761
+#: ../src/propgrid/advprops.cpp:1662
 msgid "Left Button"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:880
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Left margin (mm):"
 msgstr "Linkerkantlyn (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:141
-#: ../src/richtext/richtextindentspage.cpp:143
 #: ../src/richtext/richtextliststylepage.cpp:330
 #: ../src/richtext/richtextliststylepage.cpp:332
+#: ../src/richtext/richtextindentspage.cpp:141
+#: ../src/richtext/richtextindentspage.cpp:143
 msgid "Left-align text."
 msgstr "Belyn teks links."
 
-#: ../src/common/paper.cpp:144
+#: ../src/common/paper.cpp:141
 msgid "Legal Extra 9 1/2 x 15 in"
 msgstr "VSA Legal ekstra 9 1/2 x 15 duim"
 
-#: ../src/common/paper.cpp:96
+#: ../src/common/paper.cpp:93
 msgid "Legal, 8 1/2 x 14 in"
 msgstr "VSA Legal, 8 1/2 x 14 duim"
 
-#: ../src/common/paper.cpp:143
+#: ../src/common/paper.cpp:140
 msgid "Letter Extra 9 1/2 x 12 in"
 msgstr "VSA Letter ekstra 9 1/2 x 12 duim"
 
-#: ../src/common/paper.cpp:149
+#: ../src/common/paper.cpp:146
 msgid "Letter Extra Transverse 9.275 x 12 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:152
+#: ../src/common/paper.cpp:149
 msgid "Letter Plus 8 1/2 x 12.69 in"
 msgstr "VSA Letter plus 8 1/2 x 12.69 duim"
 
-#: ../src/common/paper.cpp:169
+#: ../src/common/paper.cpp:166
 msgid "Letter Rotated 11 x 8 1/2 in"
 msgstr "VSA Letter geroteer 11 x 8 1/2 duim"
 
-#: ../src/common/paper.cpp:101
+#: ../src/common/paper.cpp:98
 msgid "Letter Small, 8 1/2 x 11 in"
 msgstr "VSA Letter Small, 8 1/2 x 11 duim"
 
-#: ../src/common/paper.cpp:147
+#: ../src/common/paper.cpp:144
 msgid "Letter Transverse 8 1/2 x 11 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:95
+#: ../src/common/paper.cpp:92
 msgid "Letter, 8 1/2 x 11 in"
 msgstr "VSA Letter, 8 1/2 x 11 duim"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "License"
 msgstr "Lisensie"
 
-#: ../src/generic/fontdlgg.cpp:332
+#: ../src/generic/fontdlgg.cpp:328
 msgid "Light"
 msgstr "Lig"
 
-#: ../src/propgrid/advprops.cpp:1608
+#: ../src/propgrid/advprops.cpp:1514
 msgid "Lime"
 msgstr ""
 
-#: ../src/generic/helpext.cpp:294
+#: ../src/generic/helpext.cpp:292
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr ""
@@ -4709,15 +4835,15 @@ msgstr ""
 msgid "Line spacing:"
 msgstr "Lynspasiëring:"
 
-#: ../src/html/chm.cpp:838
+#: ../src/html/chm.cpp:829
 msgid "Link contained '//', converted to absolute link."
 msgstr "Skakel het '//' bevat; dit is omskep in 'n absolute skakel."
 
-#: ../src/richtext/richtextformatdlg.cpp:364
+#: ../src/richtext/richtextformatdlg.cpp:357
 msgid "List Style"
 msgstr "Lysstyl"
 
-#: ../src/richtext/richtextstyles.cpp:1064
+#: ../src/richtext/richtextstyles.cpp:1061
 msgid "List styles"
 msgstr "Lysstyle"
 
@@ -4732,26 +4858,26 @@ msgstr ""
 msgid "Lists the available fonts."
 msgstr "Wenke is nie beskikbaar nie, jammer!"
 
-#: ../src/common/fldlgcmn.cpp:340
+#: ../src/common/fldlgcmn.cpp:337
 #, c-format
 msgid "Load %s file"
 msgstr "Laai %s-lêer"
 
-#: ../src/html/htmlwin.cpp:597
+#: ../src/html/htmlwin.cpp:600
 msgid "Loading : "
 msgstr "Laai tans: "
 
-#: ../src/unix/snglinst.cpp:246
+#: ../src/unix/snglinst.cpp:243
 #, fuzzy, c-format
 msgid "Lock file '%s' has incorrect owner."
 msgstr "Klanklêer '%s' se formaat word nie ondersteun nie."
 
-#: ../src/unix/snglinst.cpp:251
+#: ../src/unix/snglinst.cpp:248
 #, c-format
 msgid "Lock file '%s' has incorrect permissions."
 msgstr ""
 
-#: ../src/generic/logg.cpp:576
+#: ../src/generic/logg.cpp:573
 #, c-format
 msgid "Log saved to the file '%s'."
 msgstr "Boekstawing geskryf na lêer '%s'."
@@ -4766,11 +4892,11 @@ msgstr "Kleinletters"
 msgid "Lower case roman numerals"
 msgstr "Klein romeinse syfers"
 
-#: ../src/gtk/mdi.cpp:422 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk1/mdi.cpp:431 ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "MDI-subvenster"
 
-#: ../src/msw/helpchm.cpp:56
+#: ../src/msw/helpchm.cpp:53
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -4778,189 +4904,189 @@ msgstr ""
 "MS HTML Help-funksies is nie beskikbaar nie omdat die MS HTML Help-"
 "biblioteek nie op hierdie masjien geïnstalleer is nie. Installeer dit asb."
 
-#: ../src/univ/themes/win32.cpp:3754
+#: ../src/univ/themes/win32.cpp:3751
 msgid "Ma&ximize"
 msgstr "Ma&ksimaliseer"
 
-#: ../src/common/fmapbase.cpp:203
+#: ../src/common/fmapbase.cpp:200
 msgid "MacArabic"
 msgstr "MacArabic"
 
-#: ../src/common/fmapbase.cpp:222
+#: ../src/common/fmapbase.cpp:219
 msgid "MacArmenian"
 msgstr "MacArmenian"
 
-#: ../src/common/fmapbase.cpp:211
+#: ../src/common/fmapbase.cpp:208
 msgid "MacBengali"
 msgstr "MacBengali"
 
-#: ../src/common/fmapbase.cpp:217
+#: ../src/common/fmapbase.cpp:214
 msgid "MacBurmese"
 msgstr "MacBurmese"
 
-#: ../src/common/fmapbase.cpp:236
+#: ../src/common/fmapbase.cpp:233
 msgid "MacCeltic"
 msgstr "MacCeltic"
 
-#: ../src/common/fmapbase.cpp:227
+#: ../src/common/fmapbase.cpp:224
 msgid "MacCentralEurRoman"
 msgstr "MacCentralEurRoman"
 
-#: ../src/common/fmapbase.cpp:223
+#: ../src/common/fmapbase.cpp:220
 msgid "MacChineseSimp"
 msgstr "MacChineseSimp"
 
-#: ../src/common/fmapbase.cpp:201
+#: ../src/common/fmapbase.cpp:198
 msgid "MacChineseTrad"
 msgstr "MacChineseTrad"
 
-#: ../src/common/fmapbase.cpp:233
+#: ../src/common/fmapbase.cpp:230
 msgid "MacCroatian"
 msgstr "MacCroatian"
 
-#: ../src/common/fmapbase.cpp:206
+#: ../src/common/fmapbase.cpp:203
 msgid "MacCyrillic"
 msgstr "MacCyrillic"
 
-#: ../src/common/fmapbase.cpp:207
+#: ../src/common/fmapbase.cpp:204
 msgid "MacDevanagari"
 msgstr "MacDevanagari"
 
-#: ../src/common/fmapbase.cpp:231
+#: ../src/common/fmapbase.cpp:228
 msgid "MacDingbats"
 msgstr "MacDingbats"
 
-#: ../src/common/fmapbase.cpp:226
+#: ../src/common/fmapbase.cpp:223
 msgid "MacEthiopic"
 msgstr "MacEthiopic"
 
-#: ../src/common/fmapbase.cpp:229
+#: ../src/common/fmapbase.cpp:226
 msgid "MacExtArabic"
 msgstr "MacExtArabic"
 
-#: ../src/common/fmapbase.cpp:237
+#: ../src/common/fmapbase.cpp:234
 msgid "MacGaelic"
 msgstr "MacGaelic"
 
-#: ../src/common/fmapbase.cpp:221
+#: ../src/common/fmapbase.cpp:218
 msgid "MacGeorgian"
 msgstr "MacGeorgian"
 
-#: ../src/common/fmapbase.cpp:205
+#: ../src/common/fmapbase.cpp:202
 msgid "MacGreek"
 msgstr "MacGreek"
 
-#: ../src/common/fmapbase.cpp:209
+#: ../src/common/fmapbase.cpp:206
 msgid "MacGujarati"
 msgstr "MacGujarati"
 
-#: ../src/common/fmapbase.cpp:208
+#: ../src/common/fmapbase.cpp:205
 msgid "MacGurmukhi"
 msgstr "MacGurmukhi"
 
-#: ../src/common/fmapbase.cpp:204
+#: ../src/common/fmapbase.cpp:201
 msgid "MacHebrew"
 msgstr "MacHebrew"
 
-#: ../src/common/fmapbase.cpp:234
+#: ../src/common/fmapbase.cpp:231
 msgid "MacIcelandic"
 msgstr "MacIcelandic"
 
-#: ../src/common/fmapbase.cpp:200
+#: ../src/common/fmapbase.cpp:197
 msgid "MacJapanese"
 msgstr "MacJapanese"
 
-#: ../src/common/fmapbase.cpp:214
+#: ../src/common/fmapbase.cpp:211
 msgid "MacKannada"
 msgstr "MacKannada"
 
-#: ../src/common/fmapbase.cpp:238
+#: ../src/common/fmapbase.cpp:235
 msgid "MacKeyboardGlyphs"
 msgstr "MacKeyboardGlyphs"
 
-#: ../src/common/fmapbase.cpp:218
+#: ../src/common/fmapbase.cpp:215
 msgid "MacKhmer"
 msgstr "MacKhmer"
 
-#: ../src/common/fmapbase.cpp:202
+#: ../src/common/fmapbase.cpp:199
 msgid "MacKorean"
 msgstr "MacKorean"
 
-#: ../src/common/fmapbase.cpp:220
+#: ../src/common/fmapbase.cpp:217
 msgid "MacLaotian"
 msgstr "MacLaotian"
 
-#: ../src/common/fmapbase.cpp:215
+#: ../src/common/fmapbase.cpp:212
 msgid "MacMalayalam"
 msgstr "MacMalayalam"
 
-#: ../src/common/fmapbase.cpp:225
+#: ../src/common/fmapbase.cpp:222
 msgid "MacMongolian"
 msgstr "MacMongolian"
 
-#: ../src/common/fmapbase.cpp:210
+#: ../src/common/fmapbase.cpp:207
 msgid "MacOriya"
 msgstr "MacOriya"
 
-#: ../src/common/fmapbase.cpp:199
+#: ../src/common/fmapbase.cpp:196
 msgid "MacRoman"
 msgstr "MacRoman"
 
-#: ../src/common/fmapbase.cpp:235
+#: ../src/common/fmapbase.cpp:232
 msgid "MacRomanian"
 msgstr "MacRomanian"
 
-#: ../src/common/fmapbase.cpp:216
+#: ../src/common/fmapbase.cpp:213
 msgid "MacSinhalese"
 msgstr "MacSinhalese"
 
-#: ../src/common/fmapbase.cpp:230
+#: ../src/common/fmapbase.cpp:227
 msgid "MacSymbol"
 msgstr "MacSymbol"
 
-#: ../src/common/fmapbase.cpp:212
+#: ../src/common/fmapbase.cpp:209
 msgid "MacTamil"
 msgstr "MacTamil"
 
-#: ../src/common/fmapbase.cpp:213
+#: ../src/common/fmapbase.cpp:210
 msgid "MacTelugu"
 msgstr "MacTelugu"
 
-#: ../src/common/fmapbase.cpp:219
+#: ../src/common/fmapbase.cpp:216
 msgid "MacThai"
 msgstr "MacThai"
 
-#: ../src/common/fmapbase.cpp:224
+#: ../src/common/fmapbase.cpp:221
 msgid "MacTibetan"
 msgstr "MacTibetan"
 
-#: ../src/common/fmapbase.cpp:232
+#: ../src/common/fmapbase.cpp:229
 msgid "MacTurkish"
 msgstr "MacTurkish"
 
-#: ../src/common/fmapbase.cpp:228
+#: ../src/common/fmapbase.cpp:225
 msgid "MacVietnamese"
 msgstr "MacVietnamese"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1762
+#: ../src/propgrid/advprops.cpp:1663
 msgid "Magnifier"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:2143
+#: ../src/propgrid/advprops.cpp:2050
 msgid "Make a selection:"
 msgstr "Maak 'n keuse:"
 
-#: ../src/richtext/richtextformatdlg.cpp:374
+#: ../src/richtext/richtextformatdlg.cpp:367
 #: ../src/richtext/richtextmarginspage.cpp:171
 msgid "Margins"
 msgstr "Kantlyne"
 
-#: ../src/propgrid/advprops.cpp:1595
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Maroon"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:147
+#: ../src/generic/fdrepdlg.cpp:144
 msgid "Match case"
 msgstr "Kassensitief"
 
@@ -4973,40 +5099,40 @@ msgstr "agtste"
 msgid "Max width:"
 msgstr "Maksimum wydte:"
 
-#: ../src/unix/mediactrl.cpp:947
+#: ../src/unix/mediactrl.cpp:972
 #, c-format
 msgid "Media playback error: %s"
 msgstr ""
 
-#: ../src/common/fs_mem.cpp:175
+#: ../src/common/fs_mem.cpp:170
 #, c-format
 msgid "Memory VFS already contains file '%s'!"
 msgstr "VFS in geheue bevat reeds die lêer '%s'!"
 
 #. TRANSLATORS: Name of keyboard key
 #. TRANSLATORS: Keyword of system colour
-#: ../src/common/accelcmn.cpp:73 ../src/propgrid/advprops.cpp:889
+#: ../src/common/accelcmn.cpp:70 ../src/propgrid/advprops.cpp:790
 msgid "Menu"
 msgstr "Kieslys"
 
-#: ../src/common/msgout.cpp:124
+#: ../src/common/msgout.cpp:121
 msgid "Message"
 msgstr "Boodskap"
 
-#: ../src/univ/themes/metal.cpp:168
+#: ../src/univ/themes/metal.cpp:165
 msgid "Metal theme"
 msgstr "Metaaltema"
 
-#: ../src/msw/ole/automtn.cpp:652
+#: ../src/msw/ole/automtn.cpp:643
 msgid "Method or property not found."
 msgstr ""
 
-#: ../src/univ/themes/win32.cpp:3752
+#: ../src/univ/themes/win32.cpp:3749
 msgid "Mi&nimize"
 msgstr "Mi&nimaliseer"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1763
+#: ../src/propgrid/advprops.cpp:1664
 msgid "Middle Button"
 msgstr ""
 
@@ -5018,38 +5144,43 @@ msgstr "Minimum hoogte:"
 msgid "Min width:"
 msgstr "Minimum wydte:"
 
-#: ../src/msw/ole/automtn.cpp:668
+#: ../src/osx/cocoa/menu.mm:281
+#, fuzzy
+msgid "Minimize"
+msgstr "Mi&nimaliseer"
+
+#: ../src/msw/ole/automtn.cpp:659
 msgid "Missing a required parameter."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:324
+#: ../src/generic/fontdlgg.cpp:320
 msgid "Modern"
 msgstr "Modern"
 
-#: ../src/generic/filectrlg.cpp:427
+#: ../src/generic/filectrlg.cpp:423
 msgid "Modified"
 msgstr "Verander"
 
-#: ../src/common/module.cpp:133
+#: ../src/common/module.cpp:130
 #, c-format
 msgid "Module \"%s\" initialization failed"
 msgstr ""
 
-#: ../src/common/paper.cpp:131
+#: ../src/common/paper.cpp:128
 msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
 msgstr "Koevert 'Monarch', 3 7/8 x 7 1/2 duim"
 
-#: ../src/msw/fswatcher.cpp:143
+#: ../src/msw/fswatcher.cpp:140
 msgid "Monitoring individual files for changes is not supported currently."
 msgstr ""
 "Die monitering van veranderinge aan individuele lêers word nie tans "
 "ondersteun nie."
 
-#: ../src/generic/editlbox.cpp:172
+#: ../src/generic/editlbox.cpp:160
 msgid "Move down"
 msgstr "Skuif af"
 
-#: ../src/generic/editlbox.cpp:171
+#: ../src/generic/editlbox.cpp:155
 msgid "Move up"
 msgstr "Skuif op"
 
@@ -5063,98 +5194,103 @@ msgstr "Skuif die objek na die volgende paragraaf."
 msgid "Moves the object to the previous paragraph."
 msgstr "Skuif die objek na die vorige paragraaf."
 
-#: ../src/richtext/richtextbuffer.cpp:9966
+#: ../src/richtext/richtextbuffer.cpp:9963
 #, fuzzy
 msgid "Multiple Cell Properties"
 msgstr "Veelvuldige sel-eienskappe"
 
-#: ../src/generic/filectrlg.cpp:424
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:82
+msgid "Multiply"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:420
 msgid "Name"
 msgstr "Naam"
 
-#: ../src/propgrid/advprops.cpp:1596
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Navy"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "Network"
 msgstr "Netwerk"
 
-#: ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173
 msgid "New"
 msgstr "Nuwe"
 
-#: ../src/richtext/richtextstyledlg.cpp:243
+#: ../src/richtext/richtextstyledlg.cpp:239
 msgid "New &Box Style..."
 msgstr "Nuwe &boxstyl..."
 
-#: ../src/richtext/richtextstyledlg.cpp:225
+#: ../src/richtext/richtextstyledlg.cpp:221
 msgid "New &Character Style..."
 msgstr "Nuwe &karakterstyl..."
 
-#: ../src/richtext/richtextstyledlg.cpp:237
+#: ../src/richtext/richtextstyledlg.cpp:233
 msgid "New &List Style..."
 msgstr "Nuwe &lysstyl..."
 
-#: ../src/richtext/richtextstyledlg.cpp:231
+#: ../src/richtext/richtextstyledlg.cpp:227
 msgid "New &Paragraph Style..."
 msgstr "Nuwe &paragraafstyl..."
 
-#: ../src/richtext/richtextstyledlg.cpp:606
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:654
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:820
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:893
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:934
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:602
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:650
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:816
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:889
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:930
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "New Style"
 msgstr "Nuwe styl"
 
-#: ../src/generic/editlbox.cpp:169
+#: ../src/generic/editlbox.cpp:139
 msgid "New item"
 msgstr "Nuwe item"
 
-#: ../src/generic/dirdlgg.cpp:297 ../src/generic/dirdlgg.cpp:307
-#: ../src/generic/filectrlg.cpp:618 ../src/generic/filectrlg.cpp:627
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+#: ../src/generic/dirdlgg.cpp:294 ../src/generic/dirdlgg.cpp:304
 msgid "NewName"
 msgstr "Nuwe gids"
 
-#: ../src/common/prntbase.cpp:1567 ../src/html/helpwnd.cpp:665
+#: ../src/common/prntbase.cpp:1592 ../src/html/helpwnd.cpp:663
 msgid "Next page"
 msgstr "Volgende bladsy"
 
-#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:177
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:174
 #: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Nee"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1764
+#: ../src/propgrid/advprops.cpp:1665
 msgid "No Entry"
 msgstr ""
 
-#: ../src/generic/animateg.cpp:150
+#: ../src/generic/animateg.cpp:133
 #, fuzzy, c-format
 msgid "No animation handler for type %ld defined."
 msgstr "Geen beeldhanteerder is vir die tipe %d gedefinieer nie."
 
-#: ../src/dfb/bitmap.cpp:642 ../src/dfb/bitmap.cpp:676
+#: ../src/dfb/bitmap.cpp:639 ../src/dfb/bitmap.cpp:673
 #, fuzzy, c-format
 msgid "No bitmap handler for type %d defined."
 msgstr "Geen beeldhanteerder is vir die tipe %d gedefinieer nie."
 
-#: ../src/common/utilscmn.cpp:1077
+#: ../src/common/utilscmn.cpp:1095
 msgid "No default application configured for HTML files."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:445
+#: ../src/generic/helpext.cpp:443
 msgid "No entries found."
 msgstr "Geen inskrywings gevind."
 
-#: ../src/common/fontmap.cpp:421
+#: ../src/common/fontmap.cpp:418
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found,\n"
@@ -5166,7 +5302,7 @@ msgstr ""
 "maar 'n alternatiewe enkodering '%s' is beskikbaar.\n"
 "Wil jy hierdie enkodering gebruik (Anders moet jy 'n ander een kies)?"
 
-#: ../src/common/fontmap.cpp:426
+#: ../src/common/fontmap.cpp:423
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found.\n"
@@ -5177,209 +5313,208 @@ msgstr ""
 "Wil jy 'n lettertipe kies vir hierdie enkodering\n"
 "(anders sal die teks in hierdie kodering nie korrek weergegee word nie)?"
 
-#: ../src/generic/animateg.cpp:142
+#: ../src/generic/animateg.cpp:125
 #, fuzzy
 msgid "No handler found for animation type."
 msgstr "Geen hanteerder is gevind vir beeldtipe."
 
-#: ../src/common/image.cpp:2728
+#: ../src/common/image.cpp:2823
 msgid "No handler found for image type."
 msgstr "Geen hanteerder is gevind vir beeldtipe."
 
-#: ../src/common/image.cpp:2736 ../src/common/image.cpp:2848
-#: ../src/common/image.cpp:2901
+#: ../src/common/image.cpp:2831 ../src/common/image.cpp:2954
+#: ../src/common/image.cpp:3020
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "Geen beeldhanteerder is vir die tipe %d gedefinieer nie."
 
-#: ../src/common/image.cpp:2871 ../src/common/image.cpp:2915
+#: ../src/common/image.cpp:2986 ../src/common/image.cpp:3034
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "Geen beeldhanteerder is vir die tipe %s gedefinieer nie."
 
-#: ../src/html/helpwnd.cpp:858
+#: ../src/html/helpwnd.cpp:856
 msgid "No matching page found yet"
 msgstr "Nog geen ooreenstemmende bladsy is gevind nie"
 
-#: ../src/unix/sound.cpp:81
+#: ../src/unix/sound.cpp:78
 msgid "No sound"
 msgstr "Geen klank"
 
-#: ../src/common/image.cpp:2277 ../src/common/image.cpp:2318
+#: ../src/common/image.cpp:2371 ../src/common/image.cpp:2412
 #, fuzzy
 msgid "No unused colour in image being masked."
 msgstr "Daar word geen ongebruikte kleur in die beeld uitgemasker nie"
 
-#: ../src/common/image.cpp:3374
-#, fuzzy
-msgid "No unused colour in image."
-msgstr "Daar word geen ongebruikte kleur in die beeld uitgemasker nie"
-
-#: ../src/generic/helpext.cpp:302
+#: ../src/generic/helpext.cpp:300
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr ""
 
-#: ../src/richtext/richtextborderspage.cpp:610
 #: ../src/richtext/richtextsizepage.cpp:248
 #: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:610
 msgid "None"
 msgstr "Geen"
 
-#: ../src/common/fmapbase.cpp:157
+#: ../src/common/fmapbase.cpp:154
 msgid "Nordic (ISO-8859-10)"
 msgstr "Noors (ISO-8859-10)"
 
-#: ../src/generic/fontdlgg.cpp:328 ../src/generic/fontdlgg.cpp:331
+#: ../src/generic/fontdlgg.cpp:324 ../src/generic/fontdlgg.cpp:327
 msgid "Normal"
 msgstr "Normaal"
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1261
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Normaal en<br><u>onderstreep</u>. "
 
-#: ../src/html/helpwnd.cpp:1205
+#: ../src/html/helpwnd.cpp:1203
 msgid "Normal font:"
 msgstr "Normale lettertipe:"
 
-#: ../src/propgrid/props.cpp:1128
+#: ../src/propgrid/props.cpp:1115
 #, c-format
 msgid "Not %s"
 msgstr "Nie %s nie"
 
-#: ../include/wx/filename.h:573 ../include/wx/filename.h:578
-msgid "Not available"
-msgstr "Nie beskikbaar nie"
+#: ../src/common/secretstore.cpp:168
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/webrequest.cpp:605
+msgid "Not enough free disk space for download."
+msgstr ""
 
 #: ../src/richtext/richtextfontpage.cpp:358
 msgid "Not underlined"
 msgstr "Nie onderstreep nie"
 
-#: ../src/common/paper.cpp:115
+#: ../src/common/paper.cpp:112
 msgid "Note, 8 1/2 x 11 in"
 msgstr "Nota, 8 1/2 x 11 duim"
 
-#: ../src/generic/notifmsgg.cpp:132
+#: ../src/generic/notifmsgg.cpp:129
 msgid "Notice"
 msgstr "Kennisgewing"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "Num *"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "Num +"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "Num ,"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "Num -"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "Num ."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "Num /"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "Num ="
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "Num Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 #, fuzzy
 msgid "Num Delete"
 msgstr "Skrap"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 #, fuzzy
 msgid "Num Down"
 msgstr "Af"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "Num End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "Num Enter"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 #, fuzzy
 msgid "Num Home"
 msgstr "Tuis"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 #, fuzzy
 msgid "Num Insert"
 msgstr "Voeg in"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num Lock"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "Num Page Down"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "Num Page Up"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 #, fuzzy
 msgid "Num Right"
 msgstr "Regs"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "Num Space"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "Num Tab"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "Num Up"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "Num left"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num_lock"
 msgstr ""
 
@@ -5388,13 +5523,13 @@ msgstr ""
 msgid "Numbered outline"
 msgstr ""
 
-#: ../include/wx/msgdlg.h:278 ../src/richtext/richtextstyledlg.cpp:297
-#: ../src/common/stockitem.cpp:178 ../src/msw/msgdlg.cpp:454
-#: ../src/msw/msgdlg.cpp:747 ../src/gtk1/fontdlg.cpp:138
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:175
+#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/msgdlg.cpp:741 ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "Goed"
 
-#: ../src/msw/ole/automtn.cpp:692
+#: ../src/msw/ole/automtn.cpp:683
 #, c-format
 msgid "OLE Automation error in %s: %s"
 msgstr "OLE-outomasiefout in %s: %s"
@@ -5403,15 +5538,15 @@ msgstr "OLE-outomasiefout in %s: %s"
 msgid "Object Properties"
 msgstr "Objek-eienskappe"
 
-#: ../src/msw/ole/automtn.cpp:660
+#: ../src/msw/ole/automtn.cpp:651
 msgid "Object implementation does not support named arguments."
 msgstr ""
 
-#: ../src/common/xtixml.cpp:264
+#: ../src/common/xtixml.cpp:260
 msgid "Objects must have an id attribute"
 msgstr "Objekte moet elkeen 'n id-attribuut hê"
 
-#: ../src/propgrid/advprops.cpp:1601
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Olive"
 msgstr ""
 
@@ -5419,64 +5554,69 @@ msgstr ""
 msgid "Opaci&ty:"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:354
+#: ../src/generic/colrdlgg.cpp:374
 msgid "Opacity:"
 msgstr ""
 
-#: ../src/common/docview.cpp:1773 ../src/common/docview.cpp:1815
+#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
 msgid "Open File"
 msgstr "Open Lêer"
 
-#: ../src/html/helpwnd.cpp:671 ../src/html/helpwnd.cpp:1554
+#: ../src/html/helpwnd.cpp:669 ../src/html/helpwnd.cpp:1552
 msgid "Open HTML document"
 msgstr "Maak HTML-dokument oop"
 
-#: ../src/generic/dbgrptg.cpp:163
+#: ../src/common/stockitem.cpp:265
+#, fuzzy
+msgid "Open an existing document"
+msgstr "Maak HTML-dokument oop"
+
+#: ../src/generic/dbgrptg.cpp:160
 #, c-format
 msgid "Open file \"%s\""
 msgstr "Open lêer \"%s\""
 
-#: ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176
 msgid "Open..."
 msgstr "Open..."
 
-#: ../src/unix/glx11.cpp:506 ../src/msw/glcanvas.cpp:592
+#: ../src/msw/glcanvas.cpp:607 ../src/unix/glx11.cpp:513
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr ""
 
-#: ../src/generic/dirctrlg.cpp:599 ../src/generic/dirdlgg.cpp:323
-#: ../src/generic/filectrlg.cpp:642 ../src/generic/filectrlg.cpp:786
+#: ../src/generic/dirctrlg.cpp:565 ../src/generic/filectrlg.cpp:638
+#: ../src/generic/filectrlg.cpp:782 ../src/generic/dirdlgg.cpp:320
 msgid "Operation not permitted."
 msgstr "Bewerking nie toelaatbaar."
 
-#: ../src/common/cmdline.cpp:900
+#: ../src/common/cmdline.cpp:896
 #, fuzzy, c-format
 msgid "Option '%s' can't be negated"
 msgstr "Gids '%s' kon nie geskep word nie"
 
-#: ../src/common/cmdline.cpp:1064
+#: ../src/common/cmdline.cpp:1060
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "Opsie '%s' vereis 'n waarde."
 
-#: ../src/common/cmdline.cpp:1147
+#: ../src/common/cmdline.cpp:1143
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Opsie '%s': '%s' kan nie na 'n datum omgeskakel word nie."
 
-#: ../src/generic/prntdlgg.cpp:618
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Opstellings"
 
-#: ../src/propgrid/advprops.cpp:1606
+#: ../src/propgrid/advprops.cpp:1512
 msgid "Orange"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:615 ../src/generic/prntdlgg.cpp:869
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:862
 msgid "Orientation"
 msgstr "Oriëntasie"
 
-#: ../src/common/windowid.cpp:242
+#: ../src/common/windowid.cpp:237
 msgid "Out of window IDs.  Recommend shutting down application."
 msgstr ""
 
@@ -5489,167 +5629,167 @@ msgstr ""
 msgid "Outset"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:656
+#: ../src/msw/ole/automtn.cpp:647
 msgid "Overflow while coercing argument values."
 msgstr ""
 
-#: ../src/common/imagpcx.cpp:457 ../src/common/imagpcx.cpp:480
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:479
 msgid "PCX: couldn't allocate memory"
 msgstr "PCX: kon geen geheue reserveer"
 
-#: ../src/common/imagpcx.cpp:456
+#: ../src/common/imagpcx.cpp:455
 msgid "PCX: image format unsupported"
 msgstr "PCX: lêerformaat word nie ondersteun nie"
 
-#: ../src/common/imagpcx.cpp:479
+#: ../src/common/imagpcx.cpp:478
 msgid "PCX: invalid image"
 msgstr "PCX: ongeldige beeld"
 
-#: ../src/common/imagpcx.cpp:442
+#: ../src/common/imagpcx.cpp:441
 msgid "PCX: this is not a PCX file."
 msgstr "PCX: dit is nie 'n PCX-lêer nie."
 
-#: ../src/common/imagpcx.cpp:459 ../src/common/imagpcx.cpp:481
+#: ../src/common/imagpcx.cpp:458 ../src/common/imagpcx.cpp:480
 msgid "PCX: unknown error !!!"
 msgstr "PCX: onbekende fout!"
 
-#: ../src/common/imagpcx.cpp:458
+#: ../src/common/imagpcx.cpp:457
 msgid "PCX: version number too low"
 msgstr "PCX: weergawenommer te laag"
 
-#: ../src/common/imagpnm.cpp:91
+#: ../src/common/imagpnm.cpp:89
 msgid "PNM: Couldn't allocate memory."
 msgstr "PNM: kon nie geheue reserveer nie."
 
-#: ../src/common/imagpnm.cpp:73
+#: ../src/common/imagpnm.cpp:71
 msgid "PNM: File format is not recognized."
 msgstr "PNM: lêerformaat onbekend."
 
-#: ../src/common/imagpnm.cpp:112 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
 #: ../src/common/imagpnm.cpp:156
 msgid "PNM: File seems truncated."
 msgstr "PNM: lêer lyk afgekap."
 
-#: ../src/common/paper.cpp:187
+#: ../src/common/paper.cpp:184
 msgid "PRC 16K 146 x 215 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:200
+#: ../src/common/paper.cpp:197
 msgid "PRC 16K Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:188
+#: ../src/common/paper.cpp:185
 msgid "PRC 32K 97 x 151 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:201
+#: ../src/common/paper.cpp:198
 msgid "PRC 32K Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:189
+#: ../src/common/paper.cpp:186
 msgid "PRC 32K(Big) 97 x 151 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:202
+#: ../src/common/paper.cpp:199
 msgid "PRC 32K(Big) Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:190
+#: ../src/common/paper.cpp:187
 #, fuzzy
 msgid "PRC Envelope #1 102 x 165 mm"
 msgstr "C6 Koevert, 114 x 162 mm"
 
-#: ../src/common/paper.cpp:203
+#: ../src/common/paper.cpp:200
 #, fuzzy
 msgid "PRC Envelope #1 Rotated 165 x 102 mm"
 msgstr "C6 Koevert, 114 x 162 mm"
 
-#: ../src/common/paper.cpp:199
+#: ../src/common/paper.cpp:196
 #, fuzzy
 msgid "PRC Envelope #10 324 x 458 mm"
 msgstr "C3 Koevert, 324 x 458 mm"
 
-#: ../src/common/paper.cpp:212
+#: ../src/common/paper.cpp:209
 #, fuzzy
 msgid "PRC Envelope #10 Rotated 458 x 324 mm"
 msgstr "C4 Koevert, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:191
+#: ../src/common/paper.cpp:188
 #, fuzzy
 msgid "PRC Envelope #2 102 x 176 mm"
 msgstr "C6 Koevert, 114 x 162 mm"
 
-#: ../src/common/paper.cpp:204
+#: ../src/common/paper.cpp:201
 #, fuzzy
 msgid "PRC Envelope #2 Rotated 176 x 102 mm"
 msgstr "B6 Koevert, 176 x 125 mm"
 
-#: ../src/common/paper.cpp:192
+#: ../src/common/paper.cpp:189
 #, fuzzy
 msgid "PRC Envelope #3 125 x 176 mm"
 msgstr "C6 Koevert, 114 x 162 mm"
 
-#: ../src/common/paper.cpp:205
+#: ../src/common/paper.cpp:202
 #, fuzzy
 msgid "PRC Envelope #3 Rotated 176 x 125 mm"
 msgstr "B6 Koevert, 176 x 125 mm"
 
-#: ../src/common/paper.cpp:193
+#: ../src/common/paper.cpp:190
 #, fuzzy
 msgid "PRC Envelope #4 110 x 208 mm"
 msgstr "Koevert DL, 110 x 220 mm"
 
-#: ../src/common/paper.cpp:206
+#: ../src/common/paper.cpp:203
 #, fuzzy
 msgid "PRC Envelope #4 Rotated 208 x 110 mm"
 msgstr "C6 Koevert, 114 x 162 mm"
 
-#: ../src/common/paper.cpp:194
+#: ../src/common/paper.cpp:191
 #, fuzzy
 msgid "PRC Envelope #5 110 x 220 mm"
 msgstr "Koevert DL, 110 x 220 mm"
 
-#: ../src/common/paper.cpp:207
+#: ../src/common/paper.cpp:204
 #, fuzzy
 msgid "PRC Envelope #5 Rotated 220 x 110 mm"
 msgstr "C4 Koevert, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:195
+#: ../src/common/paper.cpp:192
 #, fuzzy
 msgid "PRC Envelope #6 120 x 230 mm"
 msgstr "C5 Koevert, 162 x 229 mm"
 
-#: ../src/common/paper.cpp:208
+#: ../src/common/paper.cpp:205
 #, fuzzy
 msgid "PRC Envelope #6 Rotated 230 x 120 mm"
 msgstr "C5 Koevert, 162 x 229 mm"
 
-#: ../src/common/paper.cpp:196
+#: ../src/common/paper.cpp:193
 #, fuzzy
 msgid "PRC Envelope #7 160 x 230 mm"
 msgstr "B5 Koevert, 176 x 250 mm"
 
-#: ../src/common/paper.cpp:209
+#: ../src/common/paper.cpp:206
 #, fuzzy
 msgid "PRC Envelope #7 Rotated 230 x 160 mm"
 msgstr "C6 Koevert, 114 x 162 mm"
 
-#: ../src/common/paper.cpp:197
+#: ../src/common/paper.cpp:194
 #, fuzzy
 msgid "PRC Envelope #8 120 x 309 mm"
 msgstr "C5 Koevert, 162 x 229 mm"
 
-#: ../src/common/paper.cpp:210
+#: ../src/common/paper.cpp:207
 #, fuzzy
 msgid "PRC Envelope #8 Rotated 309 x 120 mm"
 msgstr "C4 Koevert, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:198
+#: ../src/common/paper.cpp:195
 #, fuzzy
 msgid "PRC Envelope #9 229 x 324 mm"
 msgstr "C4 Koevert, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:211
+#: ../src/common/paper.cpp:208
 #, fuzzy
 msgid "PRC Envelope #9 Rotated 324 x 229 mm"
 msgstr "C5 Koevert, 162 x 229 mm"
@@ -5659,92 +5799,96 @@ msgstr "C5 Koevert, 162 x 229 mm"
 msgid "Padding"
 msgstr "besig om te lees"
 
-#: ../src/common/prntbase.cpp:2074
+#: ../src/common/prntbase.cpp:2096
 #, c-format
 msgid "Page %d"
 msgstr "Bladsy %d"
 
-#: ../src/common/prntbase.cpp:2072
+#: ../src/common/prntbase.cpp:2094
 #, c-format
 msgid "Page %d of %d"
 msgstr "Bladsy %d van %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 #, fuzzy
 msgid "Page Down"
 msgstr "Bladsy %d"
 
-#: ../src/gtk/print.cpp:826
+#: ../src/gtk/print.cpp:829
 msgid "Page Setup"
 msgstr "Bladsy-opstelling"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 #, fuzzy
 msgid "Page Up"
 msgstr "Bladsy %d"
 
-#: ../src/generic/prntdlgg.cpp:828 ../src/common/prntbase.cpp:484
+#: ../src/common/prntbase.cpp:479 ../src/generic/prntdlgg.cpp:821
 msgid "Page setup"
 msgstr "Bladsy-opstelling"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 #, fuzzy
 msgid "PageDown"
 msgstr "Af"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 #, fuzzy
 msgid "PageUp"
 msgstr "Bladsye"
 
-#: ../src/generic/prntdlgg.cpp:216
+#: ../src/generic/prntdlgg.cpp:209
 msgid "Pages"
 msgstr "Bladsye"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1765
+#: ../src/propgrid/advprops.cpp:1666
 msgid "Paint Brush"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:602 ../src/generic/prntdlgg.cpp:801
-#: ../src/generic/prntdlgg.cpp:842 ../src/generic/prntdlgg.cpp:855
-#: ../src/generic/prntdlgg.cpp:1052 ../src/generic/prntdlgg.cpp:1057
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:794
+#: ../src/generic/prntdlgg.cpp:835 ../src/generic/prntdlgg.cpp:848
+#: ../src/generic/prntdlgg.cpp:1045 ../src/generic/prntdlgg.cpp:1050
 msgid "Paper size"
 msgstr "Papiergrootte"
 
-#: ../src/richtext/richtextstyles.cpp:1062
+#: ../src/richtext/richtextstyles.cpp:1059
 msgid "Paragraph styles"
 msgstr "Paragraafstyle"
 
-#: ../src/common/xtistrm.cpp:465
+#: ../src/common/xtistrm.cpp:462
 msgid "Passing a already registered object to SetObject"
 msgstr "'n Reedsgeregistreerde objek word aangestuur vir SetObject"
 
-#: ../src/common/xtistrm.cpp:476
+#: ../src/common/xtistrm.cpp:473
 #, fuzzy
 msgid "Passing an unknown object to GetObject"
 msgstr "'n Onbekende objek word aangestuur vir GetObject"
 
-#: ../src/richtext/richtextctrl.cpp:3513 ../src/common/stockitem.cpp:180
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:177 ../src/richtext/richtextctrl.cpp:3514
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Plak"
 
-#: ../src/common/stockitem.cpp:262
+#: ../src/common/stockitem.cpp:260
 msgid "Paste selection"
 msgstr "Plak seleksie"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:74
+#: ../src/common/accelcmn.cpp:71
 msgid "Pause"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1766
+#: ../src/propgrid/advprops.cpp:1667
 msgid "Pencil"
 msgstr ""
 
@@ -5753,21 +5897,21 @@ msgstr ""
 msgid "Peri&od"
 msgstr "P&unt"
 
-#: ../src/generic/filectrlg.cpp:430
+#: ../src/generic/filectrlg.cpp:426
 msgid "Permissions"
 msgstr "Magtigings"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:60
+#: ../src/common/accelcmn.cpp:57
 msgid "PgDn"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:59
+#: ../src/common/accelcmn.cpp:56
 msgid "PgUp"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:12868
+#: ../src/richtext/richtextbuffer.cpp:12863
 msgid "Picture Properties"
 msgstr "Prent-eienskappe"
 
@@ -5779,45 +5923,45 @@ msgstr "Opstel van pyp het misluk"
 msgid "Please choose a valid font."
 msgstr "Kies asb. 'n geldige lettertipe."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
 msgid "Please choose an existing file."
 msgstr "Kies asb. 'n bestaande lêer."
 
-#: ../src/html/helpwnd.cpp:800
+#: ../src/html/helpwnd.cpp:798
 msgid "Please choose the page to display:"
 msgstr "Kies die bladsy om te vertoon:"
 
-#: ../src/msw/dialup.cpp:764
+#: ../src/msw/dialup.cpp:758
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Kies asb. 'n internetdiensverskaffer om mee te koppel"
 
-#: ../src/common/headerctrlcmn.cpp:59
+#: ../src/common/headerctrlcmn.cpp:57
 msgid "Please select the columns to show and define their order:"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:538
+#: ../src/common/prntbase.cpp:533
 msgid "Please wait while printing..."
 msgstr "Wag asb. tydens drukwerk..."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1767
+#: ../src/propgrid/advprops.cpp:1668
 #, fuzzy
 msgid "Point Left"
 msgstr "Lettertipe-grootte:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1768
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgid "Point Right"
 msgstr "Belyn regs"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:662
+#: ../src/propgrid/advprops.cpp:572
 #, fuzzy
 msgid "Point Size"
 msgstr "Lettertipe-grootte:"
 
-#: ../src/generic/prntdlgg.cpp:612 ../src/generic/prntdlgg.cpp:867
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:860
 msgid "Portrait"
 msgstr "Regop"
 
@@ -5825,257 +5969,266 @@ msgstr "Regop"
 msgid "Position"
 msgstr "Posisie"
 
-#: ../src/generic/prntdlgg.cpp:298
+#: ../src/generic/prntdlgg.cpp:291
 msgid "PostScript file"
 msgstr "PostScript-lêer"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178 ../src/osx/cocoa/preferences.mm:303
 msgid "Preferences"
 msgstr "Voorkeure"
 
-#: ../src/osx/menu_osx.cpp:568
+#: ../src/osx/menu_osx.cpp:460
 msgid "Preferences..."
 msgstr "Voorkeure..."
 
-#: ../src/common/prntbase.cpp:546
+#: ../src/common/prntbase.cpp:541
 msgid "Preparing"
 msgstr "Berei tans voor"
 
-#: ../src/generic/fontdlgg.cpp:455 ../src/osx/carbon/fontdlg.cpp:390
-#: ../src/html/helpwnd.cpp:1222
+#: ../src/osx/carbon/fontdlg.cpp:387 ../src/generic/fontdlgg.cpp:452
+#: ../src/html/helpwnd.cpp:1220
 msgid "Preview:"
 msgstr "Drukvoorskou:"
 
-#: ../src/common/prntbase.cpp:1553 ../src/html/helpwnd.cpp:664
+#: ../src/common/prntbase.cpp:1578 ../src/html/helpwnd.cpp:662
 msgid "Previous page"
 msgstr "Vorige bladsy"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/prntdlgg.cpp:143 ../src/generic/prntdlgg.cpp:157
-#: ../src/common/prntbase.cpp:426 ../src/common/prntbase.cpp:1541
-#: ../src/common/accelcmn.cpp:77 ../src/gtk/print.cpp:620
-#: ../src/gtk/print.cpp:638
+#: ../src/common/prntbase.cpp:421 ../src/common/prntbase.cpp:1566
+#: ../src/common/accelcmn.cpp:74 ../src/generic/prntdlgg.cpp:136
+#: ../src/generic/prntdlgg.cpp:150 ../src/gtk/print.cpp:616
+#: ../src/gtk/print.cpp:634
 msgid "Print"
 msgstr "Druk"
 
-#: ../include/wx/prntbase.h:399 ../src/common/docview.cpp:1268
+#: ../src/common/docview.cpp:1262
 msgid "Print Preview"
 msgstr "Drukvoorskou"
 
-#: ../src/common/prntbase.cpp:2015 ../src/common/prntbase.cpp:2057
-#: ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2037 ../src/common/prntbase.cpp:2079
+#: ../src/common/prntbase.cpp:2087
 msgid "Print Preview Failure"
 msgstr "Drukvoorskou het misluk"
 
-#: ../src/generic/prntdlgg.cpp:224
+#: ../src/generic/prntdlgg.cpp:217
 msgid "Print Range"
 msgstr "Drukomvang"
 
-#: ../src/generic/prntdlgg.cpp:449
+#: ../src/generic/prntdlgg.cpp:442
 msgid "Print Setup"
 msgstr "Drukopstelling"
 
-#: ../src/generic/prntdlgg.cpp:621
+#: ../src/generic/prntdlgg.cpp:614
 msgid "Print in colour"
 msgstr "Druk in kleur"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/osx/webview_webkit.mm:260
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "Kan vertoonskerm nie inisialiseer nie."
+
+#: ../src/common/stockitem.cpp:179
 msgid "Print previe&w..."
 msgstr "&Drukvoorskou..."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1256
 #, fuzzy
 msgid "Print preview creation failed."
 msgstr "Opstel van pyp het misluk"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/common/stockitem.cpp:179
 msgid "Print preview..."
 msgstr "Drukvoorskou..."
 
-#: ../src/generic/prntdlgg.cpp:630
+#: ../src/generic/prntdlgg.cpp:623
 msgid "Print spooling"
 msgstr "Drukwerkskedulering"
 
-#: ../src/html/helpwnd.cpp:675
+#: ../src/html/helpwnd.cpp:673
 msgid "Print this page"
 msgstr "Druk hierdie bladsy"
 
-#: ../src/generic/prntdlgg.cpp:185
+#: ../src/generic/prntdlgg.cpp:178
 msgid "Print to File"
 msgstr "Druk na 'n lêer"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "Print..."
 msgstr "Druk..."
 
-#: ../src/generic/prntdlgg.cpp:493
+#: ../src/generic/prntdlgg.cpp:486
 msgid "Printer"
 msgstr "Drukker"
 
-#: ../src/generic/prntdlgg.cpp:633
+#: ../src/generic/prntdlgg.cpp:626
 msgid "Printer command:"
 msgstr "Drukkerbevel:"
 
-#: ../src/generic/prntdlgg.cpp:180
+#: ../src/generic/prntdlgg.cpp:173
 msgid "Printer options"
 msgstr "Drukker-opsies"
 
-#: ../src/generic/prntdlgg.cpp:645
+#: ../src/generic/prntdlgg.cpp:638
 msgid "Printer options:"
 msgstr "Drukkeropsies:"
 
-#: ../src/generic/prntdlgg.cpp:916
+#: ../src/generic/prntdlgg.cpp:909
 msgid "Printer..."
 msgstr "Drukker..."
 
-#: ../src/generic/prntdlgg.cpp:196
+#: ../src/generic/prntdlgg.cpp:189
 msgid "Printer:"
 msgstr "Drukker:"
 
-#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:535
-#: ../src/html/htmprint.cpp:277
+#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:530
+#: ../src/html/htmprint.cpp:289
 #, fuzzy
 msgid "Printing"
 msgstr "Besig met drukwerk"
 
-#: ../src/common/prntbase.cpp:612
+#: ../src/common/prntbase.cpp:607
 msgid "Printing "
 msgstr "Druk tans "
 
-#: ../src/common/prntbase.cpp:347
+#: ../src/common/prntbase.cpp:342
 msgid "Printing Error"
 msgstr "Drukwerkfout"
 
-#: ../src/common/prntbase.cpp:565
+#: ../src/osx/webview_webkit.mm:251
+msgid "Printing is not supported by the system web control"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:560
 #, fuzzy, c-format
 msgid "Printing page %d"
 msgstr "Druk tans bladsy %d..."
 
-#: ../src/common/prntbase.cpp:570
+#: ../src/common/prntbase.cpp:565
 #, c-format
 msgid "Printing page %d of %d"
 msgstr "Druk tans bladsy %d van %d"
 
-#: ../src/generic/printps.cpp:201
+#: ../src/generic/printps.cpp:182
 #, c-format
 msgid "Printing page %d..."
 msgstr "Druk tans bladsy %d..."
 
-#: ../src/generic/printps.cpp:161
+#: ../src/generic/printps.cpp:142
 msgid "Printing..."
 msgstr "Druk tans..."
 
-#: ../include/wx/richtext/richtextprint.h:109 ../include/wx/prntbase.h:267
-#: ../src/common/docview.cpp:2132
+#: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
+#: ../src/common/docview.cpp:2137
 #, fuzzy
 msgid "Printout"
 msgstr "Druk"
 
-#: ../src/common/debugrpt.cpp:560
+#: ../src/common/debugrpt.cpp:561
 #, c-format
 msgid ""
 "Processing debug report has failed, leaving the files in \"%s\" directory."
 msgstr ""
 
-#: ../src/common/prntbase.cpp:545
+#: ../src/common/prntbase.cpp:540
 msgid "Progress:"
 msgstr "Vordering:"
 
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181
 msgid "Properties"
 msgstr "Eienskappe"
 
-#: ../src/propgrid/manager.cpp:237
+#: ../src/propgrid/manager.cpp:223
 msgid "Property"
 msgstr "Eienskap"
 
 #. TRANSLATORS: Caption of message box displaying any property error
-#: ../src/propgrid/propgrid.cpp:3185 ../src/propgrid/propgrid.cpp:3318
+#: ../src/propgrid/propgrid.cpp:3162 ../src/propgrid/propgrid.cpp:3299
 #, fuzzy
 msgid "Property Error"
 msgstr "Drukwerkfout"
 
-#: ../src/propgrid/advprops.cpp:1597
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Purple"
 msgstr ""
 
-#: ../src/common/paper.cpp:112
+#: ../src/common/paper.cpp:109
 msgid "Quarto, 215 x 275 mm"
 msgstr "Kwarto, 215 x 275 mm"
 
-#: ../src/generic/logg.cpp:1016
+#: ../src/generic/logg.cpp:1013
 msgid "Question"
 msgstr "Vraag"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1769
+#: ../src/propgrid/advprops.cpp:1670
 #, fuzzy
 msgid "Question Arrow"
 msgstr "Vraag"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "Quit"
 msgstr "Sluit af"
 
-#: ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:477
 #, c-format
 msgid "Quit %s"
 msgstr "Sluit %s af"
 
-#: ../src/common/stockitem.cpp:263
+#: ../src/common/stockitem.cpp:261
 msgid "Quit this program"
 msgstr "Sluit die program af"
 
-#: ../src/common/accelcmn.cpp:338
+#: ../src/common/accelcmn.cpp:352
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/ffile.cpp:109 ../src/common/ffile.cpp:133
+#: ../src/common/ffile.cpp:107 ../src/common/ffile.cpp:132
 #, c-format
 msgid "Read error on file '%s'"
 msgstr "Leesfout by lêer '%s'"
 
-#: ../src/common/secretstore.cpp:199
+#: ../src/common/secretstore.cpp:211
 #, fuzzy, c-format
-msgid "Reading password for \"%s/%s\" failed: %s."
+msgid "Reading password for \"%s\" failed: %s."
 msgstr "Uitpak van '%s' binne-in '%s' het misluk."
 
-#: ../src/common/prntbase.cpp:272
+#: ../src/common/prntbase.cpp:267
 msgid "Ready"
 msgstr "Gereed"
 
-#: ../src/propgrid/advprops.cpp:1605
+#: ../src/propgrid/advprops.cpp:1511
 #, fuzzy
 msgid "Red"
 msgstr "Herdoen"
 
-#: ../src/generic/colrdlgg.cpp:339
+#: ../src/generic/colrdlgg.cpp:359
 msgid "Red:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:185 ../src/stc/stc_i18n.cpp:16
+#: ../src/common/stockitem.cpp:182 ../src/stc/stc_i18n.cpp:16
 msgid "Redo"
 msgstr "Herdoen"
 
-#: ../src/common/stockitem.cpp:264
+#: ../src/common/stockitem.cpp:262
 msgid "Redo last action"
 msgstr "Herdoen laaste aksie"
 
-#: ../src/common/stockitem.cpp:186
+#: ../src/common/stockitem.cpp:183
 msgid "Refresh"
 msgstr "Verfris"
 
-#: ../src/msw/registry.cpp:626
+#: ../src/msw/registry.cpp:615
 #, c-format
 msgid "Registry key '%s' already exists."
 msgstr "Registersleutel '%s' bestaan al."
 
-#: ../src/msw/registry.cpp:595
+#: ../src/msw/registry.cpp:584
 #, c-format
 msgid "Registry key '%s' does not exist, cannot rename it."
 msgstr "Registersleutel '%s' bestaan nie, kan dit dus nie hernoem nie."
 
-#: ../src/msw/registry.cpp:727
+#: ../src/msw/registry.cpp:716
 #, c-format
 msgid ""
 "Registry key '%s' is needed for normal system operation,\n"
@@ -6086,22 +6239,22 @@ msgstr ""
 "as jy dit uitvee word jou stelsel onbruikbaar:\n"
 "bewerking is laat vaar."
 
-#: ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:942
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:917
+#: ../src/msw/registry.cpp:905
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1003
+#: ../src/msw/registry.cpp:991
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:521
+#: ../src/msw/registry.cpp:510
 #, c-format
 msgid "Registry value '%s' already exists."
 msgstr "Registerwaarde '%s' bestaan al."
@@ -6115,71 +6268,77 @@ msgstr "Gewoon"
 msgid "Relative"
 msgstr "Relatief"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:456
 msgid "Relevant entries:"
 msgstr "Relevante inskrywings:"
 
-#: ../include/wx/generic/progdlgg.h:86
+#: ../include/wx/generic/progdlgg.h:87
 msgid "Remaining time:"
 msgstr "Oorblywende tyd:"
 
-#: ../src/common/stockitem.cpp:187
+#: ../src/common/stockitem.cpp:184
 msgid "Remove"
 msgstr "Verwyder"
 
-#: ../src/richtext/richtextctrl.cpp:1562
+#: ../src/richtext/richtextctrl.cpp:1563
 msgid "Remove Bullet"
 msgstr "Verwyder koeëltjie"
 
-#: ../src/html/helpwnd.cpp:433
+#: ../src/html/helpwnd.cpp:431
 msgid "Remove current page from bookmarks"
 msgstr "Verwyder huidige bladsy uit gunstelinge"
 
-#: ../src/common/rendcmn.cpp:194
+#: ../src/common/rendcmn.cpp:191
 #, c-format
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 "Renderer \"%s\" het onversoenbare weergawe %d.%d en kon nie gelaai word nie."
 
-#: ../src/richtext/richtextbuffer.cpp:4527
+#: ../src/richtext/richtextbuffer.cpp:4524
 msgid "Renumber List"
 msgstr "Hernommeer lys"
 
-#: ../src/common/stockitem.cpp:188
-msgid "Rep&lace"
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Rep&lace..."
 msgstr "&Vervang"
 
-#: ../src/richtext/richtextctrl.cpp:3673 ../src/common/stockitem.cpp:188
+#: ../src/richtext/richtextctrl.cpp:3674
 msgid "Replace"
 msgstr "Vervang"
 
-#: ../src/generic/fdrepdlg.cpp:182
+#: ../src/generic/fdrepdlg.cpp:179
 msgid "Replace &all"
 msgstr "Vervang &almal"
 
-#: ../src/common/stockitem.cpp:261
-msgid "Replace selection"
-msgstr "Vervang seleksie"
-
-#: ../src/generic/fdrepdlg.cpp:124
+#: ../src/generic/fdrepdlg.cpp:121
 msgid "Replace with:"
 msgstr "Vervang met:"
 
-#: ../src/common/valtext.cpp:163
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Replace..."
+msgstr "Vervang"
+
+#: ../src/common/valtext.cpp:184
 msgid "Required information entry is empty."
 msgstr ""
 
-#: ../src/common/translation.cpp:1975
+#: ../src/common/translation.cpp:2025
 #, fuzzy, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "'%s' is nie 'n geldige boodskapkatalogus."
 
+#: ../src/gtk/webview_webkit.cpp:985
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:56
+#: ../src/common/accelcmn.cpp:53
 msgid "Return"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:189
+#: ../src/common/stockitem.cpp:186
 #, fuzzy
 msgid "Revert to Saved"
 msgstr "Keer terug na gestoorde weergawe"
@@ -6192,42 +6351,42 @@ msgstr "Rif"
 msgid "Rig&ht-to-left"
 msgstr ""
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6149
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:59 ../src/generic/datavgen.cpp:6954
+#: ../src/richtext/richtextsizepage.cpp:250
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextbulletspage.cpp:188
-#: ../src/richtext/richtextsizepage.cpp:250 ../src/common/accelcmn.cpp:62
 msgid "Right"
 msgstr "Regs"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1754
+#: ../src/propgrid/advprops.cpp:1655
 #, fuzzy
 msgid "Right Arrow"
 msgstr "Regs"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1770
+#: ../src/propgrid/advprops.cpp:1671
 msgid "Right Button"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:892
+#: ../src/generic/prntdlgg.cpp:885
 msgid "Right margin (mm):"
 msgstr "Regterkantlyn (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:148
-#: ../src/richtext/richtextindentspage.cpp:150
 #: ../src/richtext/richtextliststylepage.cpp:337
 #: ../src/richtext/richtextliststylepage.cpp:339
+#: ../src/richtext/richtextindentspage.cpp:148
+#: ../src/richtext/richtextindentspage.cpp:150
 msgid "Right-align text."
 msgstr "Belyn teks regs."
 
-#: ../src/generic/fontdlgg.cpp:322
+#: ../src/generic/fontdlgg.cpp:318
 msgid "Roman"
 msgstr "Roman"
 
-#: ../src/generic/datavgen.cpp:5916
+#: ../src/generic/datavgen.cpp:6721
 #, c-format
 msgid "Row %i"
 msgstr ""
@@ -6237,30 +6396,31 @@ msgstr ""
 msgid "S&tandard bullet name:"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:268 ../src/common/accelcmn.cpp:350
+#: ../src/common/accelcmn.cpp:282 ../src/common/accelcmn.cpp:367
 msgid "SPECIAL"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:190 ../src/common/sizer.cpp:2797
+#: ../src/common/stockitem.cpp:187 ../src/common/sizer.cpp:2914
 msgid "Save"
 msgstr "Stoor"
 
-#: ../src/common/fldlgcmn.cpp:342
+#: ../src/common/fldlgcmn.cpp:339
 #, c-format
 msgid "Save %s file"
 msgstr "Stoor %s-lêer"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/common/stockitem.cpp:188 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Stoor &as..."
 
-#: ../src/common/docview.cpp:366
+#: ../src/common/docview.cpp:359
 msgid "Save As"
 msgstr "Stoor as"
 
-#: ../src/common/stockitem.cpp:191
-msgid "Save as"
-msgstr "Stoor as"
+#: ../src/common/stockitem.cpp:188
+#, fuzzy
+msgid "Save As..."
+msgstr "Stoor &as..."
 
 #: ../src/common/stockitem.cpp:267
 msgid "Save current document"
@@ -6270,40 +6430,40 @@ msgstr "Stoor huidige dokument"
 msgid "Save current document with a different filename"
 msgstr "Stoor huidige dokument met 'n ander lêernaam"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/generic/logg.cpp:509
 msgid "Save log contents to file"
 msgstr "Stoor boekstawing-inhoud na lêer"
 
-#: ../src/common/secretstore.cpp:179
+#: ../src/common/secretstore.cpp:189
 #, fuzzy, c-format
-msgid "Saving password for \"%s/%s\" failed: %s."
+msgid "Saving password for \"%s\" failed: %s."
 msgstr "Uitpak van '%s' binne-in '%s' het misluk."
 
-#: ../src/generic/fontdlgg.cpp:325
+#: ../src/generic/fontdlgg.cpp:321
 msgid "Script"
 msgstr "Skrif-letter"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll Lock"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll_lock"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:890
+#: ../src/propgrid/advprops.cpp:791
 msgid "Scrollbar"
 msgstr ""
 
-#: ../src/generic/srchctlg.cpp:56 ../src/html/helpwnd.cpp:535
-#: ../src/html/helpwnd.cpp:550
+#: ../src/generic/srchctlg.cpp:55 ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:548 ../src/gtk/srchctrl.cpp:182
 msgid "Search"
 msgstr "Soek"
 
-#: ../src/html/helpwnd.cpp:537
+#: ../src/html/helpwnd.cpp:535
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
@@ -6311,56 +6471,56 @@ msgstr ""
 "Soek in inhoudsopgawe van hulplêer(s) vir alle voorkomste van die teks wat "
 "bó getik is"
 
-#: ../src/generic/fdrepdlg.cpp:160
+#: ../src/generic/fdrepdlg.cpp:157
 msgid "Search direction"
 msgstr "Soekrigting"
 
-#: ../src/generic/fdrepdlg.cpp:112
+#: ../src/generic/fdrepdlg.cpp:109
 msgid "Search for:"
 msgstr "Soek na:"
 
-#: ../src/html/helpwnd.cpp:1052
+#: ../src/html/helpwnd.cpp:1050
 msgid "Search in all books"
 msgstr "Soek in alle boeke"
 
-#: ../src/html/helpwnd.cpp:857
+#: ../src/html/helpwnd.cpp:855
 msgid "Searching..."
 msgstr "Soek tans..."
 
-#: ../src/generic/dirctrlg.cpp:446
+#: ../src/generic/dirctrlg.cpp:412
 msgid "Sections"
 msgstr "Seksies"
 
-#: ../src/common/ffile.cpp:238
+#: ../src/common/ffile.cpp:237
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Soekfout by lêer '%s'"
 
-#: ../src/common/ffile.cpp:228
+#: ../src/common/ffile.cpp:227
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:76
+#: ../src/common/accelcmn.cpp:73
 #, fuzzy
 msgid "Select"
 msgstr "Seleksie"
 
-#: ../src/richtext/richtextctrl.cpp:337 ../src/osx/textctrl_osx.cpp:581
-#: ../src/common/stockitem.cpp:192 ../src/msw/textctrl.cpp:2512
+#: ../src/osx/textctrl_osx.cpp:599 ../src/common/stockitem.cpp:189
+#: ../src/msw/textctrl.cpp:2777 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Kies &alles"
 
-#: ../src/common/stockitem.cpp:192 ../src/stc/stc_i18n.cpp:21
+#: ../src/common/stockitem.cpp:189 ../src/stc/stc_i18n.cpp:21
 msgid "Select All"
 msgstr "Kies alles"
 
-#: ../src/common/docview.cpp:1895
+#: ../src/common/docview.cpp:1900
 msgid "Select a document template"
 msgstr "Kies 'n dokumentsjabloon"
 
-#: ../src/common/docview.cpp:1969
+#: ../src/common/docview.cpp:1974
 msgid "Select a document view"
 msgstr "Kies 'n dokumentweergawe"
 
@@ -6389,20 +6549,20 @@ msgid "Selects the list level to edit."
 msgstr "Kies watter lysvlak om te redigeer."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:82
+#: ../src/common/accelcmn.cpp:79
 msgid "Separator"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1083
+#: ../src/common/cmdline.cpp:1079
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Skeidingsteken is verwag na die opsie '%s'."
 
-#: ../src/osx/menu_osx.cpp:572
+#: ../src/osx/menu_osx.cpp:464
 msgid "Services"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11217
+#: ../src/richtext/richtextbuffer.cpp:11216
 #, fuzzy
 msgid "Set Cell Style"
 msgstr "Verwyder item"
@@ -6411,11 +6571,11 @@ msgstr "Verwyder item"
 msgid "SetProperty called w/o valid setter"
 msgstr "SetProperty is geroep sonder geldige 'set'-metode"
 
-#: ../src/generic/prntdlgg.cpp:188
+#: ../src/generic/prntdlgg.cpp:181
 msgid "Setup..."
 msgstr "Opstelling..."
 
-#: ../src/msw/dialup.cpp:544
+#: ../src/msw/dialup.cpp:538
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr ""
 "Meer as een aktiewe inbelverbindings gevind, willekeurige keuse is gemaak."
@@ -6433,40 +6593,40 @@ msgstr ""
 msgid "Shadow c&olour:"
 msgstr "Kies lettertipe"
 
-#: ../src/common/accelcmn.cpp:335
+#: ../src/common/accelcmn.cpp:349
 msgid "Shift+"
 msgstr "Shift+"
 
-#: ../src/generic/dirdlgg.cpp:147
+#: ../src/generic/dirdlgg.cpp:144
 msgid "Show &hidden directories"
 msgstr "Wys &verborge gidse"
 
-#: ../src/generic/filectrlg.cpp:983
+#: ../src/generic/filectrlg.cpp:979
 msgid "Show &hidden files"
 msgstr "Wys &verborge lêers"
 
-#: ../src/osx/menu_osx.cpp:580
+#: ../src/osx/menu_osx.cpp:472
 msgid "Show All"
 msgstr "Wys almal"
 
-#: ../src/common/stockitem.cpp:257
+#: ../src/common/stockitem.cpp:254
 msgid "Show about dialog"
 msgstr "Wys \"Aangaande\"-dialoog"
 
-#: ../src/html/helpwnd.cpp:492
+#: ../src/html/helpwnd.cpp:490
 msgid "Show all"
 msgstr "Wys alles"
 
-#: ../src/html/helpwnd.cpp:503
+#: ../src/html/helpwnd.cpp:501
 msgid "Show all items in index"
 msgstr "Wys alle items in die indeks"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:656
 msgid "Show/hide navigation panel"
 msgstr "Wys/verberg navigasiepaneel"
 
-#: ../src/richtext/richtextsymboldlg.cpp:421
-#: ../src/richtext/richtextsymboldlg.cpp:423
+#: ../src/richtext/richtextsymboldlg.cpp:418
+#: ../src/richtext/richtextsymboldlg.cpp:420
 msgid "Shows a Unicode subset."
 msgstr "Wys 'n Unicode-substel."
 
@@ -6482,7 +6642,7 @@ msgstr ""
 msgid "Shows a preview of the font settings."
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:394 ../src/osx/carbon/fontdlg.cpp:396
+#: ../src/osx/carbon/fontdlg.cpp:391 ../src/osx/carbon/fontdlg.cpp:393
 msgid "Shows a preview of the font."
 msgstr "Wys 'n voorskou van die lettertipe."
 
@@ -6491,62 +6651,62 @@ msgstr "Wys 'n voorskou van die lettertipe."
 msgid "Shows a preview of the paragraph settings."
 msgstr "Wys 'n voorskou van die paragraafinstellings."
 
-#: ../src/generic/fontdlgg.cpp:460 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:456 ../src/generic/fontdlgg.cpp:458
 msgid "Shows the font preview."
 msgstr "Wys die lettertipevoorskou."
 
-#: ../src/propgrid/advprops.cpp:1607
+#: ../src/propgrid/advprops.cpp:1513
 msgid "Silver"
 msgstr ""
 
-#: ../src/univ/themes/mono.cpp:516
+#: ../src/univ/themes/mono.cpp:513
 msgid "Simple monochrome theme"
 msgstr "Eenvoudige monochroomtema"
 
-#: ../src/richtext/richtextindentspage.cpp:275
 #: ../src/richtext/richtextliststylepage.cpp:449
+#: ../src/richtext/richtextindentspage.cpp:275
 msgid "Single"
 msgstr "Enkel"
 
-#: ../src/generic/filectrlg.cpp:425 ../src/richtext/richtextformatdlg.cpp:369
-#: ../src/richtext/richtextsizepage.cpp:299
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextsizepage.cpp:299
+#: ../src/richtext/richtextformatdlg.cpp:362
 msgid "Size"
 msgstr "Grootte"
 
-#: ../src/osx/carbon/fontdlg.cpp:339
+#: ../src/osx/carbon/fontdlg.cpp:336
 msgid "Size:"
 msgstr "Grootte:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1775
+#: ../src/propgrid/advprops.cpp:1676
 msgid "Sizing"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1772
+#: ../src/propgrid/advprops.cpp:1673
 msgid "Sizing N-S"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1771
+#: ../src/propgrid/advprops.cpp:1672
 msgid "Sizing NE-SW"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1773
+#: ../src/propgrid/advprops.cpp:1674
 msgid "Sizing NW-SE"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1774
+#: ../src/propgrid/advprops.cpp:1675
 msgid "Sizing W-E"
 msgstr ""
 
-#: ../src/msw/progdlg.cpp:801
+#: ../src/msw/progdlg.cpp:1088
 msgid "Skip"
 msgstr "Slaan oor"
 
-#: ../src/generic/fontdlgg.cpp:330
+#: ../src/generic/fontdlgg.cpp:326
 msgid "Slant"
 msgstr "Skuins"
 
@@ -6555,7 +6715,7 @@ msgid "Small C&apitals"
 msgstr "&Klein hoofletters"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:79
+#: ../src/common/accelcmn.cpp:76
 msgid "Snapshot"
 msgstr ""
 
@@ -6563,37 +6723,37 @@ msgstr ""
 msgid "Solid"
 msgstr "Solied"
 
-#: ../src/common/docview.cpp:1791
+#: ../src/common/docview.cpp:1785
 msgid "Sorry, could not open this file."
 msgstr "Jammer, hierdie lêer kon nie oopgemaak word nie."
 
-#: ../src/common/prntbase.cpp:2057 ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2079 ../src/common/prntbase.cpp:2087
 msgid "Sorry, not enough memory to create a preview."
 msgstr "Jammer, onvoldoende geheue vir drukvoorskou."
 
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "Sorry, that name is taken. Please choose another."
 msgstr "Jammer, daardie naam is gevat. Kies gerus 'n ander een."
 
-#: ../src/common/docview.cpp:1814
+#: ../src/common/docview.cpp:1819
 msgid "Sorry, the format for this file is unknown."
 msgstr "Jammer, die lêer het 'n onbekende formaat."
 
-#: ../src/unix/sound.cpp:492
+#: ../src/unix/sound.cpp:481
 msgid "Sound data are in unsupported format."
 msgstr "Klankdata se formaat word nie ondersteun nie."
 
-#: ../src/unix/sound.cpp:477
+#: ../src/unix/sound.cpp:466
 #, c-format
 msgid "Sound file '%s' is in unsupported format."
 msgstr "Klanklêer '%s' se formaat word nie ondersteun nie."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:67
+#: ../src/common/accelcmn.cpp:64
 #, fuzzy
 msgid "Space"
 msgstr "Spasiëring"
@@ -6602,12 +6762,12 @@ msgstr "Spasiëring"
 msgid "Spacing"
 msgstr "Spasiëring"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "Spell Check"
 msgstr "Speltoets"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1776
+#: ../src/propgrid/advprops.cpp:1677
 msgid "Spraycan"
 msgstr ""
 
@@ -6616,7 +6776,7 @@ msgstr ""
 msgid "Standard"
 msgstr "Standaard"
 
-#: ../src/common/paper.cpp:104
+#: ../src/common/paper.cpp:101
 msgid "Statement, 5 1/2 x 8 1/2 in"
 msgstr "VSA Statement, 5 1/2 x 8 1/2 duim"
 
@@ -6625,34 +6785,30 @@ msgstr "VSA Statement, 5 1/2 x 8 1/2 duim"
 msgid "Static"
 msgstr "Staties"
 
-#: ../src/generic/prntdlgg.cpp:204
+#: ../src/generic/prntdlgg.cpp:197
 msgid "Status:"
 msgstr "Status:"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "Stop"
 msgstr "Stop"
 
-#: ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196
 msgid "Strikethrough"
 msgstr "Deurhaal"
 
-#: ../src/common/colourcmn.cpp:45
+#: ../src/common/colourcmn.cpp:42
 #, c-format
 msgid "String To Colour : Incorrect colour specification : %s"
 msgstr "String-na-kleur : Verkeerde kleurspesifikasie : %s"
 
 #. TRANSLATORS: Label of font style
-#: ../src/richtext/richtextformatdlg.cpp:339 ../src/propgrid/advprops.cpp:680
+#: ../src/propgrid/advprops.cpp:590 ../src/richtext/richtextformatdlg.cpp:332
 #, fuzzy
 msgid "Style"
 msgstr "Styl"
 
-#: ../include/wx/richtext/richtextstyledlg.h:46
-msgid "Style Organiser"
-msgstr "Stylorganiseerder"
-
-#: ../src/osx/carbon/fontdlg.cpp:348
+#: ../src/osx/carbon/fontdlg.cpp:345
 msgid "Style:"
 msgstr "Styl:"
 
@@ -6661,7 +6817,7 @@ msgid "Subscrip&t"
 msgstr "Onde&rskrif"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:83
+#: ../src/common/accelcmn.cpp:80
 msgid "Subtract"
 msgstr ""
 
@@ -6669,11 +6825,11 @@ msgstr ""
 msgid "Supe&rscript"
 msgstr "Bosk&rif"
 
-#: ../src/common/paper.cpp:150
+#: ../src/common/paper.cpp:147
 msgid "SuperA/SuperA/A4 227 x 356 mm"
 msgstr "SuperA/SuperA/A4 227 x 356 mm"
 
-#: ../src/common/paper.cpp:151
+#: ../src/common/paper.cpp:148
 msgid "SuperB/SuperB/A3 305 x 487 mm"
 msgstr "SuperB/SuperB/A3 305 x 487 mm"
 
@@ -6681,7 +6837,7 @@ msgstr "SuperB/SuperB/A3 305 x 487 mm"
 msgid "Suppress hyphe&nation"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:326
+#: ../src/generic/fontdlgg.cpp:322
 msgid "Swiss"
 msgstr "Switsers"
 
@@ -6700,74 +6856,74 @@ msgstr "Normale lettertipe:"
 msgid "Symbols"
 msgstr "Simbole"
 
-#: ../src/common/imagtiff.cpp:369 ../src/common/imagtiff.cpp:382
-#: ../src/common/imagtiff.cpp:741
+#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
+#: ../src/common/imagtiff.cpp:738
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: kon nie geheue reserveer nie."
 
-#: ../src/common/imagtiff.cpp:301
+#: ../src/common/imagtiff.cpp:298
 msgid "TIFF: Error loading image."
 msgstr "TIFF: fout by laai van beeld."
 
-#: ../src/common/imagtiff.cpp:468
+#: ../src/common/imagtiff.cpp:465
 msgid "TIFF: Error reading image."
 msgstr "TIFF: fout by lees van beeld."
 
-#: ../src/common/imagtiff.cpp:608
+#: ../src/common/imagtiff.cpp:605
 msgid "TIFF: Error saving image."
 msgstr "TIFF: fout by stoor van beeld."
 
-#: ../src/common/imagtiff.cpp:846
+#: ../src/common/imagtiff.cpp:843
 msgid "TIFF: Error writing image."
 msgstr "TIFF: fout by skryf van beeld."
 
-#: ../src/common/imagtiff.cpp:355
+#: ../src/common/imagtiff.cpp:352
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: beeldgrootte is abnormaal groot."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:68
+#: ../src/common/accelcmn.cpp:65
 #, fuzzy
 msgid "Tab"
 msgstr "&Tabel"
 
-#: ../src/richtext/richtextbuffer.cpp:11498
+#: ../src/richtext/richtextbuffer.cpp:11497
 msgid "Table Properties"
 msgstr "Tabel-eienskappe"
 
-#: ../src/common/paper.cpp:145
+#: ../src/common/paper.cpp:142
 msgid "Tabloid Extra 11.69 x 18 in"
 msgstr "VSA Tabloid ekstra 11.69 x 18 duim"
 
-#: ../src/common/paper.cpp:102
+#: ../src/common/paper.cpp:99
 msgid "Tabloid, 11 x 17 in"
 msgstr "VSA Tabloid, 11 x 17 duim"
 
-#: ../src/richtext/richtextformatdlg.cpp:354
+#: ../src/richtext/richtextformatdlg.cpp:347
 msgid "Tabs"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1598
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Teal"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:327
+#: ../src/generic/fontdlgg.cpp:323
 msgid "Teletype"
 msgstr "Nie-proporsioneel (Teletype)"
 
-#: ../src/common/docview.cpp:1896
+#: ../src/common/docview.cpp:1901
 msgid "Templates"
 msgstr "Sjablone"
 
-#: ../src/common/fmapbase.cpp:158
+#: ../src/common/fmapbase.cpp:155
 msgid "Thai (ISO-8859-11)"
 msgstr "Thais (ISO-8859-11)"
 
-#: ../src/common/ftp.cpp:619
+#: ../src/common/ftp.cpp:622
 msgid "The FTP server doesn't support passive mode."
 msgstr "Die FTP-bediener ondersteun nie passiewe modus nie."
 
-#: ../src/common/ftp.cpp:605
+#: ../src/common/ftp.cpp:608
 msgid "The FTP server doesn't support the PORT command."
 msgstr "Die FTP-bediener ondersteun nie die PORT-opdrag nie."
 
@@ -6778,8 +6934,8 @@ msgstr "Die FTP-bediener ondersteun nie die PORT-opdrag nie."
 msgid "The available bullet styles."
 msgstr "Die beskikbare koeëltjiestyle."
 
-#: ../src/richtext/richtextstyledlg.cpp:202
-#: ../src/richtext/richtextstyledlg.cpp:204
+#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:200
 msgid "The available styles."
 msgstr "Die beskikbare style."
 
@@ -6839,12 +6995,12 @@ msgstr "fontgrootte"
 msgid "The bullet character."
 msgstr "Die koeëltjiekarakter."
 
-#: ../src/richtext/richtextsymboldlg.cpp:443
-#: ../src/richtext/richtextsymboldlg.cpp:445
+#: ../src/richtext/richtextsymboldlg.cpp:440
+#: ../src/richtext/richtextsymboldlg.cpp:442
 msgid "The character code."
 msgstr "Die karakterkode."
 
-#: ../src/common/fontmap.cpp:203
+#: ../src/common/fontmap.cpp:200
 #, c-format
 msgid ""
 "The charset '%s' is unknown. You may select\n"
@@ -6855,7 +7011,7 @@ msgstr ""
 "karakterstel kies om te vervang of kies [Kanselleer]\n"
 "as dit nie vervang kan word nie"
 
-#: ../src/msw/ole/dataobj.cpp:394
+#: ../src/msw/ole/dataobj.cpp:402
 #, c-format
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "Die knipbord-formaat '%d' bestaan nie."
@@ -6865,7 +7021,7 @@ msgstr "Die knipbord-formaat '%d' bestaan nie."
 msgid "The default style for the next paragraph."
 msgstr "Die verstekstyl vir die volgende paragraaf."
 
-#: ../src/generic/dirdlgg.cpp:202
+#: ../src/generic/dirdlgg.cpp:199
 #, c-format
 msgid ""
 "The directory '%s' does not exist\n"
@@ -6874,7 +7030,7 @@ msgstr ""
 "Die gids '%s' bestaan nie\n"
 "Moet dit nou gemaak word?"
 
-#: ../src/html/htmprint.cpp:271
+#: ../src/html/htmprint.cpp:283
 #, c-format
 msgid ""
 "The document \"%s\" doesn't fit on the page horizontally and will be "
@@ -6887,7 +7043,7 @@ msgstr ""
 "\n"
 "Wil u nogtans voortgaan om te druk?"
 
-#: ../src/common/docview.cpp:1202
+#: ../src/common/docview.cpp:1196
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -6896,36 +7052,36 @@ msgstr ""
 "Die lêer '%s' bestaan nie en kon nie oopgemaak word nie.\n"
 "Dit is verwyder van die lys van 'onlangse lêers'."
 
-#: ../src/richtext/richtextindentspage.cpp:208
-#: ../src/richtext/richtextindentspage.cpp:210
 #: ../src/richtext/richtextliststylepage.cpp:394
 #: ../src/richtext/richtextliststylepage.cpp:396
+#: ../src/richtext/richtextindentspage.cpp:208
+#: ../src/richtext/richtextindentspage.cpp:210
 msgid "The first line indent."
 msgstr "Die eerste lyn se keep."
 
-#: ../src/gtk/utilsgtk.cpp:481
-msgid "The following standard GTK+ options are also supported:\n"
-msgstr "Die volgende standaard-GTK+-keuses word ook ondersteun:\n"
+#: ../src/generic/dbgrptg.cpp:318
+msgid "The following debug report will be generated\n"
+msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:414 ../src/generic/fontdlgg.cpp:416
+#: ../src/generic/fontdlgg.cpp:411 ../src/generic/fontdlgg.cpp:413
 msgid "The font colour."
 msgstr "Die tekskleur."
 
-#: ../src/generic/fontdlgg.cpp:375 ../src/generic/fontdlgg.cpp:377
+#: ../src/generic/fontdlgg.cpp:371 ../src/generic/fontdlgg.cpp:373
 msgid "The font family."
 msgstr "Die lettertipe se familie."
 
-#: ../src/richtext/richtextsymboldlg.cpp:405
-#: ../src/richtext/richtextsymboldlg.cpp:407
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "The font from which to take the symbol."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:427 ../src/generic/fontdlgg.cpp:429
-#: ../src/generic/fontdlgg.cpp:434 ../src/generic/fontdlgg.cpp:436
+#: ../src/generic/fontdlgg.cpp:424 ../src/generic/fontdlgg.cpp:426
+#: ../src/generic/fontdlgg.cpp:430 ../src/generic/fontdlgg.cpp:432
 msgid "The font point size."
 msgstr "Die puntgrootte van die lettertipe."
 
-#: ../src/osx/carbon/fontdlg.cpp:343 ../src/osx/carbon/fontdlg.cpp:345
+#: ../src/osx/carbon/fontdlg.cpp:340 ../src/osx/carbon/fontdlg.cpp:342
 msgid "The font size in points."
 msgstr "Lettergrootte in punte."
 
@@ -6935,15 +7091,15 @@ msgstr "Lettergrootte in punte."
 msgid "The font size units, points or pixels."
 msgstr "fontgrootte"
 
-#: ../src/generic/fontdlgg.cpp:386 ../src/generic/fontdlgg.cpp:388
+#: ../src/generic/fontdlgg.cpp:382 ../src/generic/fontdlgg.cpp:384
 msgid "The font style."
 msgstr "Die lettertipestyl."
 
-#: ../src/generic/fontdlgg.cpp:397 ../src/generic/fontdlgg.cpp:399
+#: ../src/generic/fontdlgg.cpp:393 ../src/generic/fontdlgg.cpp:395
 msgid "The font weight."
 msgstr "Die lettertipegewig."
 
-#: ../src/common/docview.cpp:1483
+#: ../src/common/docview.cpp:1477
 #, fuzzy, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Gids '%s' kon nie geskep word nie"
@@ -6954,10 +7110,10 @@ msgstr "Gids '%s' kon nie geskep word nie"
 msgid "The horizontal offset."
 msgstr "Teël &horisontaal"
 
-#: ../src/richtext/richtextindentspage.cpp:199
-#: ../src/richtext/richtextindentspage.cpp:201
 #: ../src/richtext/richtextliststylepage.cpp:385
 #: ../src/richtext/richtextliststylepage.cpp:387
+#: ../src/richtext/richtextindentspage.cpp:199
+#: ../src/richtext/richtextindentspage.cpp:201
 msgid "The left indent."
 msgstr "Die linkerkeep"
 
@@ -6981,10 +7137,10 @@ msgstr "fontgrootte"
 msgid "The left position."
 msgstr "fontgrootte"
 
-#: ../src/richtext/richtextindentspage.cpp:288
-#: ../src/richtext/richtextindentspage.cpp:290
 #: ../src/richtext/richtextliststylepage.cpp:462
 #: ../src/richtext/richtextliststylepage.cpp:464
+#: ../src/richtext/richtextindentspage.cpp:288
+#: ../src/richtext/richtextindentspage.cpp:290
 msgid "The line spacing."
 msgstr "Die lynspasiëring."
 
@@ -6993,7 +7149,7 @@ msgstr "Die lynspasiëring."
 msgid "The list item number."
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:664
+#: ../src/msw/ole/automtn.cpp:655
 msgid "The locale ID is unknown."
 msgstr ""
 
@@ -7035,19 +7191,19 @@ msgstr "Die objekwydte."
 msgid "The outline level."
 msgstr "fontgrootte"
 
-#: ../src/common/log.cpp:277
+#: ../src/common/log.cpp:296
 #, fuzzy, c-format
 msgid "The previous message repeated %u time."
 msgid_plural "The previous message repeated %u times."
 msgstr[0] "Die vorige boodskap het %lu keer herhaal."
 msgstr[1] "Die vorige boodskap het %lu keer herhaal."
 
-#: ../src/common/log.cpp:270
+#: ../src/common/log.cpp:289
 msgid "The previous message repeated once."
 msgstr "Die vorige boodskap het een keer herhaal."
 
-#: ../src/richtext/richtextsymboldlg.cpp:462
-#: ../src/richtext/richtextsymboldlg.cpp:464
+#: ../src/richtext/richtextsymboldlg.cpp:459
+#: ../src/richtext/richtextsymboldlg.cpp:461
 msgid "The range to show."
 msgstr "Die omvang om te wys."
 
@@ -7058,15 +7214,15 @@ msgid ""
 "please uncheck them and they will be removed from the report.\n"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1254
+#: ../src/common/cmdline.cpp:1250
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "Die vereiste parameter '%s' is nie gespesifiseer nie."
 
-#: ../src/richtext/richtextindentspage.cpp:217
-#: ../src/richtext/richtextindentspage.cpp:219
 #: ../src/richtext/richtextliststylepage.cpp:403
 #: ../src/richtext/richtextliststylepage.cpp:405
+#: ../src/richtext/richtextindentspage.cpp:217
+#: ../src/richtext/richtextindentspage.cpp:219
 msgid "The right indent."
 msgstr "Die regterkeep."
 
@@ -7111,16 +7267,16 @@ msgstr ""
 msgid "The shadow spread."
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:267
 #: ../src/richtext/richtextliststylepage.cpp:439
 #: ../src/richtext/richtextliststylepage.cpp:441
+#: ../src/richtext/richtextindentspage.cpp:267
 msgid "The spacing after the paragraph."
 msgstr "Die spasiëring ná die paragraaf."
 
-#: ../src/richtext/richtextindentspage.cpp:257
-#: ../src/richtext/richtextindentspage.cpp:259
 #: ../src/richtext/richtextliststylepage.cpp:430
 #: ../src/richtext/richtextliststylepage.cpp:432
+#: ../src/richtext/richtextindentspage.cpp:257
+#: ../src/richtext/richtextindentspage.cpp:259
 msgid "The spacing before the paragraph."
 msgstr "Die spasiëring voor die paragraaf."
 
@@ -7134,12 +7290,12 @@ msgstr "Die stylnaam."
 msgid "The style on which this style is based."
 msgstr "Die styl waarop hierdie styl gebaseer is."
 
-#: ../src/richtext/richtextstyledlg.cpp:214
-#: ../src/richtext/richtextstyledlg.cpp:216
+#: ../src/richtext/richtextstyledlg.cpp:210
+#: ../src/richtext/richtextstyledlg.cpp:212
 msgid "The style preview."
 msgstr "Die stylvoorskou."
 
-#: ../src/msw/ole/automtn.cpp:680
+#: ../src/msw/ole/automtn.cpp:671
 msgid "The system cannot find the file specified."
 msgstr "Die stelsel kan nie die gespesifiseerde lêer kry nie."
 
@@ -7152,7 +7308,7 @@ msgstr "Die oortjieposisie."
 msgid "The tab positions."
 msgstr "Die oortjieposisies."
 
-#: ../src/richtext/richtextctrl.cpp:3098
+#: ../src/richtext/richtextctrl.cpp:3099
 msgid "The text couldn't be saved."
 msgstr "Die teks kon nie gestoor word nie."
 
@@ -7176,7 +7332,7 @@ msgstr "fontgrootte"
 msgid "The top position."
 msgstr "fontgrootte"
 
-#: ../src/common/cmdline.cpp:1232
+#: ../src/common/cmdline.cpp:1228
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "Die waarde voor die opsie '%s' moet gespesifiseer word."
@@ -7186,7 +7342,7 @@ msgstr "Die waarde voor die opsie '%s' moet gespesifiseer word."
 msgid "The value of the corner radius."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:433
+#: ../src/msw/dialup.cpp:427
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -7201,14 +7357,14 @@ msgstr ""
 msgid "The vertical offset."
 msgstr "Aktiveer vertikale belyning."
 
-#: ../src/richtext/richtextprint.cpp:619 ../src/html/htmprint.cpp:745
+#: ../src/html/htmprint.cpp:749 ../src/richtext/richtextprint.cpp:615
 msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr ""
 "Daar was 'n probleem tydens bladsy-opstelling: Jy moet dalk 'n "
 "standaarddrukker opstel."
 
-#: ../src/html/htmprint.cpp:255
+#: ../src/html/htmprint.cpp:267
 msgid ""
 "This document doesn't fit on the page horizontally and will be truncated "
 "when it is printed."
@@ -7216,22 +7372,30 @@ msgstr ""
 "Hierdie dokument pas nie horisontaal op die bladsy nie en sal afgekap word "
 "as dit gedruk word."
 
-#: ../src/common/image.cpp:2854
+#: ../src/common/image.cpp:2963
 #, fuzzy, c-format
 msgid "This is not a %s."
 msgstr "PCX: dit is nie 'n PCX-lêer nie."
 
-#: ../src/common/wincmn.cpp:1653
+#: ../src/common/wincmn.cpp:1654
 msgid "This platform does not support background transparency."
 msgstr ""
 
-#: ../src/gtk/window.cpp:4660
+#: ../src/gtk/window.cpp:5664
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
 
-#: ../src/msw/thread.cpp:1240
+#: ../src/gtk/glcanvas.cpp:176
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/msw/thread.cpp:1246
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -7239,13 +7403,13 @@ msgstr ""
 "Inisialisasie van uitvoerdraadmodule het misluk: kan geen waarde in lokale "
 "uitvoerdraad-geheueruimte stoor nie."
 
-#: ../src/unix/threadpsx.cpp:1794
+#: ../src/unix/threadpsx.cpp:1843
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 "Inisialisasie van uitvoerdraadmodule het misluk: 'n uitvoerdraad-sleutel kon "
 "nie geskep word nie"
 
-#: ../src/msw/thread.cpp:1228
+#: ../src/msw/thread.cpp:1234
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -7253,83 +7417,83 @@ msgstr ""
 "Inisialisasie van uitvoerdraadmodule het misluk: onmoontlik om 'n indeks te "
 "reserveer in lokale uitvoerdraad-geheueruimte."
 
-#: ../src/unix/threadpsx.cpp:1043
+#: ../src/unix/threadpsx.cpp:1061
 msgid "Thread priority setting is ignored."
 msgstr "Uitvoerdraad-prioriteitstelling is geïgnoreer."
 
-#: ../src/msw/mdi.cpp:176
+#: ../src/msw/mdi.cpp:171
 msgid "Tile &Horizontally"
 msgstr "Teël &horisontaal"
 
-#: ../src/msw/mdi.cpp:177
+#: ../src/msw/mdi.cpp:172
 msgid "Tile &Vertically"
 msgstr "Teël &vertikaal"
 
-#: ../src/common/ftp.cpp:200
+#: ../src/common/ftp.cpp:197
 msgid "Timeout while waiting for FTP server to connect, try passive mode."
 msgstr ""
 "Wagtyd vir FTP-bediener om te koppel het uitgetel. Probeer passiewe modus."
 
-#: ../src/generic/tipdlg.cpp:201
+#: ../src/generic/tipdlg.cpp:198
 msgid "Tip of the Day"
 msgstr "Wenk van die dag"
 
-#: ../src/generic/tipdlg.cpp:140
+#: ../src/generic/tipdlg.cpp:137
 msgid "Tips not available, sorry!"
 msgstr "Wenke is nie beskikbaar nie, jammer!"
 
-#: ../src/generic/prntdlgg.cpp:242
+#: ../src/generic/prntdlgg.cpp:235
 msgid "To:"
 msgstr "Aan:"
 
-#: ../src/richtext/richtextbuffer.cpp:8363
+#: ../src/richtext/richtextbuffer.cpp:8361
 msgid "Too many EndStyle calls!"
 msgstr "Te veel EndStyle-roepe!"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:891
+#: ../src/propgrid/advprops.cpp:792
 msgid "Tooltip"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:892
+#: ../src/propgrid/advprops.cpp:793
 msgid "TooltipText"
 msgstr ""
 
-#: ../src/richtext/richtextsizepage.cpp:286
-#: ../src/richtext/richtextsizepage.cpp:290 ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197 ../src/richtext/richtextsizepage.cpp:286
+#: ../src/richtext/richtextsizepage.cpp:290
 msgid "Top"
 msgstr "Bokant"
 
-#: ../src/generic/prntdlgg.cpp:881
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Top margin (mm):"
 msgstr "Boonste kantlyn (mm):"
 
-#: ../src/generic/aboutdlgg.cpp:79
+#: ../src/generic/aboutdlgg.cpp:76
 msgid "Translations by "
 msgstr "Vertalings deur "
 
-#: ../src/generic/aboutdlgg.cpp:188
+#: ../src/generic/aboutdlgg.cpp:185
 msgid "Translators"
 msgstr "Vertalers"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:211
+#: ../src/propgrid/propgrid.cpp:192
 msgid "True"
 msgstr "Waar"
 
-#: ../src/common/fs_mem.cpp:227
+#: ../src/common/fs_mem.cpp:222
 #, c-format
 msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
 msgstr ""
 "Poging om lêer '%s' uit VFS in geheue te verwyder, maar dit is nie gelaai "
 "nie!"
 
-#: ../src/common/fmapbase.cpp:156
+#: ../src/common/fmapbase.cpp:153
 msgid "Turkish (ISO-8859-9)"
 msgstr "Turks (ISO-8859-9)"
 
-#: ../src/generic/filectrlg.cpp:426
+#: ../src/generic/filectrlg.cpp:422
 msgid "Type"
 msgstr "Tipe"
 
@@ -7343,36 +7507,36 @@ msgstr ""
 msgid "Type a size in points."
 msgstr "Tik 'n grootte in punte."
 
-#: ../src/msw/ole/automtn.cpp:676
+#: ../src/msw/ole/automtn.cpp:667
 #, c-format
 msgid "Type mismatch in argument %u."
 msgstr ""
 
-#: ../src/common/xtixml.cpp:356 ../src/common/xtixml.cpp:509
-#: ../src/common/xtistrm.cpp:318
+#: ../src/common/xtixml.cpp:352 ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315
 msgid "Type must have enum - long conversion"
 msgstr "Tipe moet 'n enum - long omskakeling bevat"
 
-#: ../src/propgrid/propgridiface.cpp:401
+#: ../src/propgrid/propgridiface.cpp:385
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
 "\"%s\"."
 msgstr ""
 
-#: ../src/common/paper.cpp:133
+#: ../src/common/paper.cpp:130
 msgid "US Std Fanfold, 14 7/8 x 11 in"
 msgstr "VSA Std Fanfold, 14 7/8 x 11 duim"
 
-#: ../src/common/fmapbase.cpp:196
+#: ../src/common/fmapbase.cpp:193
 msgid "US-ASCII"
 msgstr "US-ASCII"
 
-#: ../src/unix/fswatcher_inotify.cpp:109
+#: ../src/unix/fswatcher_inotify.cpp:106
 msgid "Unable to add inotify watch"
 msgstr ""
 
-#: ../src/unix/fswatcher_kqueue.cpp:136
+#: ../src/unix/fswatcher_kqueue.cpp:153
 msgid "Unable to add kqueue watch"
 msgstr ""
 
@@ -7385,7 +7549,7 @@ msgstr ""
 msgid "Unable to close I/O completion port handle"
 msgstr "Toemaak van T/A-voltooipoort het misluk"
 
-#: ../src/unix/fswatcher_inotify.cpp:97
+#: ../src/unix/fswatcher_inotify.cpp:94
 #, fuzzy
 msgid "Unable to close inotify instance"
 msgstr "Toemaak van lêer het misluk."
@@ -7405,17 +7569,17 @@ msgstr "Toemaak van lêer het misluk."
 msgid "Unable to create I/O completion port"
 msgstr "Wyser kon nie geskep word nie."
 
-#: ../src/msw/fswatcher.cpp:84
+#: ../src/msw/fswatcher.cpp:81
 #, fuzzy
 msgid "Unable to create IOCP worker thread"
 msgstr "Skepping van MDI-hoofvenster het misluk."
 
-#: ../src/unix/fswatcher_inotify.cpp:74
+#: ../src/unix/fswatcher_inotify.cpp:71
 #, fuzzy
 msgid "Unable to create inotify instance"
 msgstr "Skepping van DDE-string het misluk"
 
-#: ../src/unix/fswatcher_kqueue.cpp:97
+#: ../src/unix/fswatcher_kqueue.cpp:114
 #, fuzzy
 msgid "Unable to create kqueue instance"
 msgstr "Skepping van DDE-string het misluk"
@@ -7424,11 +7588,11 @@ msgstr "Skepping van DDE-string het misluk"
 msgid "Unable to dequeue completion packet"
 msgstr ""
 
-#: ../src/unix/fswatcher_kqueue.cpp:185
+#: ../src/unix/fswatcher_kqueue.cpp:202
 msgid "Unable to get events from kqueue"
 msgstr ""
 
-#: ../src/gtk/app.cpp:435
+#: ../src/gtk/app.cpp:431
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "Kan nie GTK+ inisialiseer nie. Is DISPLAY reg ingestel?"
 
@@ -7437,12 +7601,12 @@ msgstr "Kan nie GTK+ inisialiseer nie. Is DISPLAY reg ingestel?"
 msgid "Unable to open path '%s'"
 msgstr "Kan nie die pad '%s' open nie"
 
-#: ../src/html/htmlwin.cpp:583
+#: ../src/html/htmlwin.cpp:586
 #, c-format
 msgid "Unable to open requested HTML document: %s"
 msgstr "Kan gevraagde HTML-dokument nie oopmaak nie: %s"
 
-#: ../src/unix/sound.cpp:368
+#: ../src/unix/sound.cpp:365
 msgid "Unable to play sound asynchronously."
 msgstr "Klank kan nie asinkronies gespeel word nie."
 
@@ -7450,63 +7614,63 @@ msgstr "Klank kan nie asinkronies gespeel word nie."
 msgid "Unable to post completion status"
 msgstr ""
 
-#: ../src/unix/fswatcher_inotify.cpp:556
+#: ../src/unix/fswatcher_inotify.cpp:553
 #, fuzzy
 msgid "Unable to read from inotify descriptor"
 msgstr "kan nie lees van lêeretiket %d"
 
-#: ../src/unix/fswatcher_inotify.cpp:141
+#: ../src/unix/fswatcher_inotify.cpp:138
 #, fuzzy, c-format
 msgid "Unable to remove inotify watch %i"
 msgstr "Skepping van DDE-string het misluk"
 
-#: ../src/unix/fswatcher_kqueue.cpp:153
+#: ../src/unix/fswatcher_kqueue.cpp:170
 msgid "Unable to remove kqueue watch"
 msgstr ""
 
-#: ../src/msw/fswatcher.cpp:168
+#: ../src/msw/fswatcher.cpp:165
 #, fuzzy, c-format
 msgid "Unable to set up watch for '%s'"
 msgstr "Aanraking van lêer '%s' het misluk"
 
-#: ../src/msw/fswatcher.cpp:91
+#: ../src/msw/fswatcher.cpp:88
 msgid "Unable to start IOCP worker thread"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:201
+#: ../src/common/stockitem.cpp:198
 #, fuzzy
 msgid "Undelete"
 msgstr "Ontskrap"
 
-#: ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199
 msgid "Underline"
 msgstr "Onderstreep"
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/richtext/richtextfontpage.cpp:359 ../src/osx/carbon/fontdlg.cpp:370
-#: ../src/propgrid/advprops.cpp:690
+#: ../src/osx/carbon/fontdlg.cpp:367 ../src/propgrid/advprops.cpp:600
+#: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Onderstreep"
 
-#: ../src/common/stockitem.cpp:203 ../src/stc/stc_i18n.cpp:15
+#: ../src/common/stockitem.cpp:200 ../src/stc/stc_i18n.cpp:15
 msgid "Undo"
 msgstr "Ontdoen"
 
-#: ../src/common/stockitem.cpp:265
+#: ../src/common/stockitem.cpp:263
 msgid "Undo last action"
 msgstr "Ontdoen laaste aksie"
 
-#: ../src/common/cmdline.cpp:1029
+#: ../src/common/cmdline.cpp:1025
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Onverwagte karakters wat volg op opsie '%s'."
 
-#: ../src/unix/fswatcher_inotify.cpp:274
+#: ../src/unix/fswatcher_inotify.cpp:271
 #, c-format
 msgid "Unexpected event for \"%s\": no matching watch descriptor."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1195
+#: ../src/common/cmdline.cpp:1191
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Onverwagte parameter '%s'"
@@ -7515,50 +7679,50 @@ msgstr "Onverwagte parameter '%s'"
 msgid "Unexpectedly new I/O completion port was created"
 msgstr ""
 
-#: ../src/msw/fswatcher.cpp:70
+#: ../src/msw/fswatcher.cpp:67
 #, fuzzy
 msgid "Ungraceful worker thread termination"
 msgstr "Kan nie wag vir uitvoerdraad-beëindiging nie"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:460
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:456
+#: ../src/richtext/richtextsymboldlg.cpp:457
+#: ../src/richtext/richtextsymboldlg.cpp:458
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../src/common/fmapbase.cpp:185 ../src/common/fmapbase.cpp:191
+#: ../src/common/fmapbase.cpp:182 ../src/common/fmapbase.cpp:188
 msgid "Unicode 16 bit (UTF-16)"
 msgstr "Unicode 16 bis (UTF-16)"
 
-#: ../src/common/fmapbase.cpp:190
+#: ../src/common/fmapbase.cpp:187
 msgid "Unicode 16 bit Big Endian (UTF-16BE)"
 msgstr "Unicode 16 bis Big Endian (UTF-16BE)"
 
-#: ../src/common/fmapbase.cpp:186
+#: ../src/common/fmapbase.cpp:183
 msgid "Unicode 16 bit Little Endian (UTF-16LE)"
 msgstr "Unicode 16 bis Little Endian (UTF-16LE)"
 
-#: ../src/common/fmapbase.cpp:187 ../src/common/fmapbase.cpp:193
+#: ../src/common/fmapbase.cpp:184 ../src/common/fmapbase.cpp:190
 msgid "Unicode 32 bit (UTF-32)"
 msgstr "Unicode 32 bis (UTF-32)"
 
-#: ../src/common/fmapbase.cpp:192
+#: ../src/common/fmapbase.cpp:189
 msgid "Unicode 32 bit Big Endian (UTF-32BE)"
 msgstr "Unicode 32 bis Big Endian (UTF-32BE)"
 
-#: ../src/common/fmapbase.cpp:188
+#: ../src/common/fmapbase.cpp:185
 msgid "Unicode 32 bit Little Endian (UTF-32LE)"
 msgstr "Unicode 32 bis Little Endian (UTF-32LE)"
 
-#: ../src/common/fmapbase.cpp:182
+#: ../src/common/fmapbase.cpp:179
 msgid "Unicode 7 bit (UTF-7)"
 msgstr "Unicode 7-bis (UTF-7)"
 
-#: ../src/common/fmapbase.cpp:183
+#: ../src/common/fmapbase.cpp:180
 msgid "Unicode 8 bit (UTF-8)"
 msgstr "Unicode 8-bis (UTF-8)"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "Unindent"
 msgstr "Keep uit"
 
@@ -7716,99 +7880,104 @@ msgstr "Kan nie wag vir uitvoerdraad-beëindiging nie"
 msgid "Units for this value."
 msgstr "Kan nie wag vir uitvoerdraad-beëindiging nie"
 
-#: ../src/generic/progdlgg.cpp:353 ../src/generic/progdlgg.cpp:622
+#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
 msgid "Unknown"
 msgstr "Onbekend"
 
-#: ../src/msw/dde.cpp:1174
+#: ../src/msw/dde.cpp:1238
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Onbekende DDE-fout %08x"
 
-#: ../src/common/xtistrm.cpp:410
+#: ../src/common/xtistrm.cpp:407
 msgid "Unknown Object passed to GetObjectClassInfo"
 msgstr "Onbekende objek is aangestuur vir GetObjectClassInfo"
 
-#: ../src/common/imagpng.cpp:366
+#: ../src/common/imagpng.cpp:383
 #, fuzzy, c-format
 msgid "Unknown PNG resolution unit %d"
 msgstr "Onbekende opsie '%s'"
 
-#: ../src/common/xtixml.cpp:327
+#: ../src/common/xtixml.cpp:323
 #, fuzzy, c-format
 msgid "Unknown Property %s"
 msgstr "Onbekende eienskap %s"
 
-#: ../src/common/imagtiff.cpp:529
+#: ../src/common/imagtiff.cpp:526
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr ""
 
-#: ../src/unix/dlunix.cpp:160
+#: ../src/propgrid/props.cpp:155
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/unix/dlunix.cpp:118
 msgid "Unknown dynamic library error"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:810
+#: ../src/common/fmapbase.cpp:806
 #, c-format
 msgid "Unknown encoding (%d)"
 msgstr "Onbekende kodering (%d)"
 
-#: ../src/msw/ole/automtn.cpp:688
+#: ../src/msw/ole/automtn.cpp:679
 #, c-format
 msgid "Unknown error %08x"
 msgstr "Onbekende fout %08x"
 
-#: ../src/msw/ole/automtn.cpp:647
+#: ../src/msw/ole/automtn.cpp:638
 #, fuzzy
 msgid "Unknown exception"
 msgstr "Onbekende opsie '%s'"
 
-#: ../src/common/image.cpp:2839
+#: ../src/common/image.cpp:2942
 #, fuzzy
 msgid "Unknown image data format."
 msgstr "fout in dataformaat."
 
-#: ../src/common/cmdline.cpp:914
+#: ../src/common/cmdline.cpp:910
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Onbekende lang opsie '%s'"
 
-#: ../src/msw/ole/automtn.cpp:631
+#: ../src/msw/ole/automtn.cpp:622
 msgid "Unknown name or named argument."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:929 ../src/common/cmdline.cpp:951
+#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Onbekende opsie '%s'"
 
-#: ../src/common/mimecmn.cpp:225
+#: ../src/common/mimecmn.cpp:221
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "On-afgeslote '{' in mime-tipe %s inskrywing."
 
-#: ../src/common/cmdproc.cpp:262 ../src/common/cmdproc.cpp:288
-#: ../src/common/cmdproc.cpp:308
+#: ../src/common/cmdproc.cpp:255 ../src/common/cmdproc.cpp:281
+#: ../src/common/cmdproc.cpp:301
 msgid "Unnamed command"
 msgstr "Naamlose bevel"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:413
+#: ../src/propgrid/propgrid.cpp:392
 msgid "Unspecified"
 msgstr "Nie gespesifiseer nie"
 
-#: ../src/msw/clipbrd.cpp:311
+#: ../src/msw/clipbrd.cpp:325
 msgid "Unsupported clipboard format."
 msgstr "Nie-ondersteunde knipbord-formaat."
 
-#: ../src/common/appcmn.cpp:256
+#: ../src/common/appcmn.cpp:277
 #, c-format
 msgid "Unsupported theme '%s'."
 msgstr "Nie-ondersteunde tema '%s'."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:205
-#: ../src/common/accelcmn.cpp:63
+#: ../src/common/stockitem.cpp:202 ../src/common/accelcmn.cpp:60
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Up"
 msgstr "Op"
 
@@ -7822,7 +7991,7 @@ msgstr "Hoofletters"
 msgid "Upper case roman numerals"
 msgstr "Groot romeinse syfers"
 
-#: ../src/common/cmdline.cpp:1326
+#: ../src/common/cmdline.cpp:1322
 #, c-format
 msgid "Usage: %s"
 msgstr "Gebruik: %s"
@@ -7831,38 +8000,47 @@ msgstr "Gebruik: %s"
 msgid "Use &shadow"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:169
-#: ../src/richtext/richtextindentspage.cpp:171
 #: ../src/richtext/richtextliststylepage.cpp:358
 #: ../src/richtext/richtextliststylepage.cpp:360
+#: ../src/richtext/richtextindentspage.cpp:169
+#: ../src/richtext/richtextindentspage.cpp:171
 msgid "Use the current alignment setting."
 msgstr "Gebruik die huidige instelling vir belyning."
 
-#: ../src/common/valtext.cpp:179
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/gtk/font.cpp:552
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/common/valtext.cpp:142
 msgid "Validation conflict"
 msgstr "Geldigheidskonflik"
 
-#: ../src/propgrid/manager.cpp:238
+#: ../src/propgrid/manager.cpp:224
 msgid "Value"
 msgstr "Waarde"
 
-#: ../src/propgrid/props.cpp:386 ../src/propgrid/props.cpp:500
+#: ../src/propgrid/props.cpp:309
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "Waarde moet %s of meer wees."
 
-#: ../src/propgrid/props.cpp:417 ../src/propgrid/props.cpp:531
+#: ../src/propgrid/props.cpp:336
 #, c-format
 msgid "Value must be %s or less."
 msgstr "Waarde moet %s of minder wees."
 
-#: ../src/propgrid/props.cpp:393 ../src/propgrid/props.cpp:424
-#: ../src/propgrid/props.cpp:507 ../src/propgrid/props.cpp:538
+#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "Waarde moet tussen %s en %s wees."
 
-#: ../src/generic/aboutdlgg.cpp:128
+#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Weergawe "
 
@@ -7871,25 +8049,32 @@ msgstr "Weergawe "
 msgid "Vertical alignment."
 msgstr "Vertikale belyning"
 
-#: ../src/generic/filedlgg.cpp:202
+#: ../src/generic/filedlgg.cpp:199
 msgid "View files as a detailed view"
 msgstr "Wys lêers in detail-aansig"
 
-#: ../src/generic/filedlgg.cpp:200
+#: ../src/generic/filedlgg.cpp:197
 msgid "View files as a list view"
 msgstr "Wys lêers in lys-aansig"
 
-#: ../src/common/docview.cpp:1970
+#: ../src/common/docview.cpp:1975
 msgid "Views"
 msgstr "Aansigte"
 
+#: ../src/gtk/app.cpp:348
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1777
+#: ../src/propgrid/advprops.cpp:1678
 msgid "Wait"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1779
+#: ../src/propgrid/advprops.cpp:1680
 msgid "Wait Arrow"
 msgstr ""
 
@@ -7898,247 +8083,243 @@ msgstr ""
 msgid "Waiting for IO on epoll descriptor %d failed"
 msgstr "Kon nie wag vir beëindiging van subproses nie"
 
-#: ../src/common/log.cpp:223
+#: ../src/common/log.cpp:241
 msgid "Warning: "
 msgstr "Waarskuwing: "
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1778
+#: ../src/propgrid/advprops.cpp:1679
 msgid "Watch"
 msgstr ""
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:685
+#: ../src/propgrid/advprops.cpp:595
 msgid "Weight"
 msgstr "Gewig"
 
-#: ../src/common/fmapbase.cpp:148
+#: ../src/common/fmapbase.cpp:145
 msgid "Western European (ISO-8859-1)"
 msgstr "Wes-Europees (ISO-8859-1)"
 
-#: ../src/common/fmapbase.cpp:162
+#: ../src/common/fmapbase.cpp:159
 msgid "Western European with Euro (ISO-8859-15)"
 msgstr "Wes-Europees met Euro teken (ISO-8859-15)"
 
-#: ../src/generic/fontdlgg.cpp:446 ../src/generic/fontdlgg.cpp:448
+#: ../src/generic/fontdlgg.cpp:443 ../src/generic/fontdlgg.cpp:445
 msgid "Whether the font is underlined."
 msgstr "Of die lettertipe onderstreep word."
 
-#: ../src/propgrid/advprops.cpp:1611
+#: ../src/propgrid/advprops.cpp:1517
 msgid "White"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:144
+#: ../src/generic/fdrepdlg.cpp:141
 msgid "Whole word"
 msgstr "Heelwoorde"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:532
 msgid "Whole words only"
 msgstr "Slegs heelwoorde"
 
-#: ../src/univ/themes/win32.cpp:1102
+#: ../src/univ/themes/win32.cpp:1099
 msgid "Win32 theme"
 msgstr "Win32-tema"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:893
+#: ../src/propgrid/advprops.cpp:794
 #, fuzzy
 msgid "Window"
 msgstr "&Venster"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:894
+#: ../src/propgrid/advprops.cpp:795
 #, fuzzy
 msgid "WindowFrame"
 msgstr "&Venster"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:895
+#: ../src/propgrid/advprops.cpp:796
 #, fuzzy
 msgid "WindowText"
 msgstr "&Venster"
 
-#: ../src/common/fmapbase.cpp:177
+#: ../src/common/fmapbase.cpp:174
 msgid "Windows Arabic (CP 1256)"
 msgstr "Windows Arabies (CP 1256)"
 
-#: ../src/common/fmapbase.cpp:178
+#: ../src/common/fmapbase.cpp:175
 msgid "Windows Baltic (CP 1257)"
 msgstr "Windows Balties (CP 1257)"
 
-#: ../src/common/fmapbase.cpp:171
+#: ../src/common/fmapbase.cpp:168
 msgid "Windows Central European (CP 1250)"
 msgstr "Windows Sentraal Europees (CP 1250)"
 
-#: ../src/common/fmapbase.cpp:168
+#: ../src/common/fmapbase.cpp:165
 msgid "Windows Chinese Simplified (CP 936) or GB-2312"
 msgstr "Windows Vereenvoudigde Sjinees (CP 936) of GB-2312"
 
-#: ../src/common/fmapbase.cpp:170
+#: ../src/common/fmapbase.cpp:167
 msgid "Windows Chinese Traditional (CP 950) or Big-5"
 msgstr "Windows Tradisionele Sjinees (CP 950) of Big-5"
 
-#: ../src/common/fmapbase.cpp:172
+#: ../src/common/fmapbase.cpp:169
 msgid "Windows Cyrillic (CP 1251)"
 msgstr "Windows Cyrillies (CP 1251)"
 
-#: ../src/common/fmapbase.cpp:174
+#: ../src/common/fmapbase.cpp:171
 msgid "Windows Greek (CP 1253)"
 msgstr "Windows Grieks (CP 1253)"
 
-#: ../src/common/fmapbase.cpp:176
+#: ../src/common/fmapbase.cpp:173
 msgid "Windows Hebrew (CP 1255)"
 msgstr "Windows Hebreeus (CP 1255)"
 
-#: ../src/common/fmapbase.cpp:167
+#: ../src/common/fmapbase.cpp:164
 msgid "Windows Japanese (CP 932) or Shift-JIS"
 msgstr "Windows Japannees (CP 932) of Shift-JIS"
 
-#: ../src/common/fmapbase.cpp:180
+#: ../src/common/fmapbase.cpp:177
 #, fuzzy
 msgid "Windows Johab (CP 1361)"
 msgstr "Windows Johab (CP 1361)"
 
-#: ../src/common/fmapbase.cpp:169
+#: ../src/common/fmapbase.cpp:166
 msgid "Windows Korean (CP 949)"
 msgstr "Windows Koreaans (CP 949)"
 
-#: ../src/common/fmapbase.cpp:166
+#: ../src/common/fmapbase.cpp:163
 msgid "Windows Thai (CP 874)"
 msgstr "Windows Thai (CP 874)"
 
-#: ../src/common/fmapbase.cpp:175
+#: ../src/common/fmapbase.cpp:172
 msgid "Windows Turkish (CP 1254)"
 msgstr "Windows Turks (CP 1254)"
 
-#: ../src/common/fmapbase.cpp:179
+#: ../src/common/fmapbase.cpp:176
 msgid "Windows Vietnamese (CP 1258)"
 msgstr "Windows Viëtnamees (CP 1258)"
 
-#: ../src/common/fmapbase.cpp:173
+#: ../src/common/fmapbase.cpp:170
 msgid "Windows Western European (CP 1252)"
 msgstr "Windows Wes Europees (CP 1252)"
 
-#: ../src/common/fmapbase.cpp:181
+#: ../src/common/fmapbase.cpp:178
 msgid "Windows/DOS OEM (CP 437)"
 msgstr "Windows/DOS OEM (CP 437)"
 
-#: ../src/common/fmapbase.cpp:165
+#: ../src/common/fmapbase.cpp:162
 msgid "Windows/DOS OEM Cyrillic (CP 866)"
 msgstr "Windows/DOS OEM Cyrillies (CP 866)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:111
+#: ../src/common/accelcmn.cpp:109
 #, fuzzy
 msgid "Windows_Left"
 msgstr "Windows 7"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:113
+#: ../src/common/accelcmn.cpp:111
 #, fuzzy
 msgid "Windows_Menu"
 msgstr "Windows ME"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:112
+#: ../src/common/accelcmn.cpp:110
 #, fuzzy
 msgid "Windows_Right"
 msgstr "Windows Vista"
 
-#: ../src/common/ffile.cpp:150
+#: ../src/common/ffile.cpp:149
 #, c-format
 msgid "Write error on file '%s'"
 msgstr "Skryffout by lêer '%s'"
 
-#: ../src/xml/xml.cpp:914
+#: ../src/xml/xml.cpp:925
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "XML-ontledingsfout: '%s' in lyn %d"
 
-#: ../src/common/xpmdecod.cpp:796
+#: ../src/common/xpmdecod.cpp:794
 msgid "XPM: Malformed pixel data!"
 msgstr "XPM: Misvormde pixel data!"
 
-#: ../src/common/xpmdecod.cpp:705
+#: ../src/common/xpmdecod.cpp:702
 #, c-format
 msgid "XPM: incorrect colour description in line %d"
 msgstr "XPM: verkeerde kleurbeskrywing in lyn %d"
 
-#: ../src/common/xpmdecod.cpp:680
+#: ../src/common/xpmdecod.cpp:677
 msgid "XPM: incorrect header format!"
 msgstr ""
 
-#: ../src/common/xpmdecod.cpp:716 ../src/common/xpmdecod.cpp:725
+#: ../src/common/xpmdecod.cpp:714 ../src/common/xpmdecod.cpp:723
 #, fuzzy, c-format
 msgid "XPM: malformed colour definition '%s' at line %d!"
 msgstr "XPM: Misvormde kleurdefinisie '%s'!"
 
-#: ../src/common/xpmdecod.cpp:755
+#: ../src/common/xpmdecod.cpp:753
 msgid "XPM: no colors left to use for mask!"
 msgstr ""
 
-#: ../src/common/xpmdecod.cpp:782
+#: ../src/common/xpmdecod.cpp:780
 #, c-format
 msgid "XPM: truncated image data at line %d!"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1610
+#: ../src/propgrid/advprops.cpp:1516
 msgid "Yellow"
 msgstr ""
 
-#: ../include/wx/msgdlg.h:276 ../src/common/stockitem.cpp:206
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:203
 #: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Ja"
 
-#: ../src/osx/carbon/overlay.cpp:155
-#, fuzzy
-msgid "You cannot Clear an overlay that is not inited"
-msgstr "Jy kan nie 'n nuwe gids by hierdie seksie voeg nie."
-
-#: ../src/osx/carbon/overlay.cpp:107 ../src/dfb/overlay.cpp:61
-msgid "You cannot Init an overlay twice"
-msgstr ""
-
-#: ../src/generic/dirdlgg.cpp:287
+#: ../src/generic/dirdlgg.cpp:284
 msgid "You cannot add a new directory to this section."
 msgstr "Jy kan nie 'n nuwe gids by hierdie seksie voeg nie."
 
-#: ../src/propgrid/propgrid.cpp:3299
+#: ../src/propgrid/propgrid.cpp:3276
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:209
+#: ../src/osx/cocoa/menu.mm:286
+#, fuzzy
+msgid "Zoom"
+msgstr "Zoem in"
+
+#: ../src/common/stockitem.cpp:206
 msgid "Zoom &In"
 msgstr "Zoem &in"
 
-#: ../src/common/stockitem.cpp:210
+#: ../src/common/stockitem.cpp:207
 msgid "Zoom &Out"
 msgstr "Zoem &uit"
 
-#: ../src/common/stockitem.cpp:209 ../src/common/prntbase.cpp:1594
+#: ../src/common/stockitem.cpp:206 ../src/common/prntbase.cpp:1619
 msgid "Zoom In"
 msgstr "Zoem in"
 
-#: ../src/common/stockitem.cpp:210 ../src/common/prntbase.cpp:1580
+#: ../src/common/stockitem.cpp:207 ../src/common/prntbase.cpp:1605
 msgid "Zoom Out"
 msgstr "Zoem uit"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 #, fuzzy
 msgid "Zoom to &Fit"
 msgstr "Zoem om te &pas"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to Fit"
 msgstr "Zoem om te pas"
 
-#: ../src/msw/dde.cpp:1141
+#: ../src/msw/dde.cpp:1205
 msgid "a DDEML application has created a prolonged race condition."
 msgstr ""
 "'n DDEML-toepassing het deur 'n wedrentoestand geheuegebrek veroorsaak."
 
-#: ../src/msw/dde.cpp:1129
+#: ../src/msw/dde.cpp:1193
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -8148,40 +8329,40 @@ msgstr ""
 "'n DDEML-funksie is geroep sonder om eers die DdeInitialize-funksie te roep\n"
 "of 'n ongeldige proses-ID is deurgegee aan 'n DDEML-funksie."
 
-#: ../src/msw/dde.cpp:1147
+#: ../src/msw/dde.cpp:1211
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "Kliënt se poging om 'n gesprek te begin, het misluk."
 
-#: ../src/msw/dde.cpp:1144
+#: ../src/msw/dde.cpp:1208
 msgid "a memory allocation failed."
 msgstr "'n geheuereservering het misluk."
 
-#: ../src/msw/dde.cpp:1138
+#: ../src/msw/dde.cpp:1202
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "'n parameter kon nie deur die DDEML gevalideer word nie."
 
-#: ../src/msw/dde.cpp:1120
+#: ../src/msw/dde.cpp:1184
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "'n versoek vir 'n sinkrone advies-transaksie se tyd is verstreke."
 
-#: ../src/msw/dde.cpp:1126
+#: ../src/msw/dde.cpp:1190
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "'n versoek vir 'n sinkrone data-transaksie se tyd is verstreke."
 
-#: ../src/msw/dde.cpp:1135
+#: ../src/msw/dde.cpp:1199
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "'n versoek vir 'n sinkrone uitvoer-transaksie se tyd is verstreke."
 
-#: ../src/msw/dde.cpp:1153
+#: ../src/msw/dde.cpp:1217
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "'n versoek vir 'n sinkrone 'poke'-transaksie se tyd is verstreke."
 
-#: ../src/msw/dde.cpp:1168
+#: ../src/msw/dde.cpp:1232
 msgid "a request to end an advise transaction has timed out."
 msgstr ""
 "'n versoek vir beëindiging van 'n advies-transaksie se tyd is verstreke."
 
-#: ../src/msw/dde.cpp:1162
+#: ../src/msw/dde.cpp:1226
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -8191,15 +8372,15 @@ msgstr ""
 "wat deur die kliënt beëindig is of deur die bediener laat vaar is\n"
 "voordat die transaksie voltooi is."
 
-#: ../src/msw/dde.cpp:1150
+#: ../src/msw/dde.cpp:1214
 msgid "a transaction failed."
 msgstr "'n transaksie het misluk."
 
-#: ../src/common/accelcmn.cpp:189
+#: ../src/common/accelcmn.cpp:188
 msgid "alt"
 msgstr "alt"
 
-#: ../src/msw/dde.cpp:1132
+#: ../src/msw/dde.cpp:1196
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -8210,15 +8391,15 @@ msgstr ""
 "'n DDE-transaksie uit te voer of 'n toepassing wat as APPCMD_CLIENTONLY \n"
 "begin is, het probeer om 'n bediener-transaksie uit te voer."
 
-#: ../src/msw/dde.cpp:1156
+#: ../src/msw/dde.cpp:1220
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "'n interne oproep van die PostMessage-funksie het misluk."
 
-#: ../src/msw/dde.cpp:1165
+#: ../src/msw/dde.cpp:1229
 msgid "an internal error has occurred in the DDEML."
 msgstr "'n interne fout het voorgekom in die DDEML."
 
-#: ../src/msw/dde.cpp:1171
+#: ../src/msw/dde.cpp:1235
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -8228,56 +8409,56 @@ msgstr ""
 "As die toepassing verdergaan na 'n XTYP_XACT_COMPLETE-callback dan is\n"
 "die transaksie-id vir die callback nie meer geldig nie."
 
-#: ../src/common/zipstrm.cpp:1483
+#: ../src/common/zipstrm.cpp:1522
 msgid "assuming this is a multi-part zip concatenated"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1847
+#: ../src/common/fileconf.cpp:1849
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "poging tot wysiging van onveranderbare sleutel '%s' geïgnoreer."
 
-#: ../src/html/chm.cpp:329
+#: ../src/html/chm.cpp:326
 msgid "bad arguments to library function"
 msgstr "verkeerde argumente vir biblioteekfunksie"
 
-#: ../src/html/chm.cpp:341
+#: ../src/html/chm.cpp:338
 msgid "bad signature"
 msgstr "slegte handtekening"
 
-#: ../src/common/zipstrm.cpp:1918
+#: ../src/common/zipstrm.cpp:1988
 msgid "bad zipfile offset to entry"
 msgstr ""
 
-#: ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400
 msgid "binary"
 msgstr "binêr"
 
-#: ../src/common/fontcmn.cpp:996
+#: ../src/common/fontcmn.cpp:1195
 msgid "bold"
 msgstr "vet"
 
-#: ../src/msw/utils.cpp:1144
+#: ../src/msw/utils.cpp:1135
 #, c-format
 msgid "build %lu"
 msgstr ""
 
-#: ../src/common/ffile.cpp:75
+#: ../src/common/ffile.cpp:73
 #, c-format
 msgid "can't close file '%s'"
 msgstr "kan lêer '%s' nie toemaak nie"
 
-#: ../src/common/file.cpp:245
+#: ../src/common/file.cpp:242
 #, c-format
 msgid "can't close file descriptor %d"
 msgstr "kan lêeretiket %d nie toemaak nie"
 
-#: ../src/common/file.cpp:586
+#: ../src/common/ffile.cpp:382 ../src/common/file.cpp:613
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "kan verandering nie deurvoer na lêer '%s' nie"
 
-#: ../src/common/file.cpp:178
+#: ../src/common/file.cpp:175
 #, c-format
 msgid "can't create file '%s'"
 msgstr "kan lêer '%s' nie maak nie"
@@ -8287,50 +8468,50 @@ msgstr "kan lêer '%s' nie maak nie"
 msgid "can't delete user configuration file '%s'"
 msgstr "kan lêer met gebruikersopstelling '%s' nie uitvee nie"
 
-#: ../src/common/file.cpp:495
+#: ../src/common/file.cpp:522
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr "kan nie bepaal of lêereinde bereik is vir lêeretiket %d nie"
 
-#: ../src/common/zipstrm.cpp:1692
+#: ../src/common/zipstrm.cpp:1747
 #, fuzzy
 msgid "can't find central directory in zip"
 msgstr "Kan nie huidige posisie in lêer '%s' vind nie"
 
-#: ../src/common/file.cpp:465
+#: ../src/common/file.cpp:492
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "kan lêerlengte nie vind vir lêeretiket %d nie"
 
-#: ../src/msw/utils.cpp:341
+#: ../src/msw/utils.cpp:336
 msgid "can't find user's HOME, using current directory."
 msgstr "kan gebruiker se tuisgids nie vind nie, gebruik dus huidige gids."
 
-#: ../src/common/file.cpp:366
+#: ../src/common/file.cpp:407
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "kan lêeretiket %d nie leegmaak nie"
 
-#: ../src/common/file.cpp:422
+#: ../src/common/file.cpp:463
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "kan nie soekposisie verkry by lêeretiket %d nie"
 
-#: ../src/common/fontmap.cpp:325
+#: ../src/common/fontmap.cpp:322
 msgid "can't load any font, aborting"
 msgstr "kan geen lettertipe laai nie, besig om te laat vaar"
 
-#: ../src/common/file.cpp:231 ../src/common/ffile.cpp:59
+#: ../src/common/ffile.cpp:57 ../src/common/file.cpp:228
 #, c-format
 msgid "can't open file '%s'"
 msgstr "kan lêer '%s' nie oopmaak nie"
 
-#: ../src/common/fileconf.cpp:320
+#: ../src/common/fileconf.cpp:314
 #, c-format
 msgid "can't open global configuration file '%s'."
 msgstr "kan globale konfigurasielêer '%s' nie oopmaak nie."
 
-#: ../src/common/fileconf.cpp:336
+#: ../src/common/fileconf.cpp:330
 #, c-format
 msgid "can't open user configuration file '%s'."
 msgstr "kan gebruikers-konfigurasielêer '%s' nie oopmaak nie."
@@ -8339,42 +8520,42 @@ msgstr "kan gebruikers-konfigurasielêer '%s' nie oopmaak nie."
 msgid "can't open user configuration file."
 msgstr "kan gebruikers-konfigurasielêer nie oopmaak nie."
 
-#: ../src/common/zipstrm.cpp:579
+#: ../src/common/zipstrm.cpp:572
 #, fuzzy
 msgid "can't re-initialize zlib deflate stream"
 msgstr "Kan nie zlib-afblaasstroom inisialiseer nie."
 
-#: ../src/common/zipstrm.cpp:604
+#: ../src/common/zipstrm.cpp:597
 #, fuzzy
 msgid "can't re-initialize zlib inflate stream"
 msgstr "Kan nie zlib-opblaasstroom inisialiseer nie."
 
-#: ../src/common/file.cpp:304
+#: ../src/common/file.cpp:345
 #, c-format
 msgid "can't read from file descriptor %d"
 msgstr "kan nie lees van lêeretiket %d"
 
-#: ../src/common/file.cpp:581
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:608
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "kan lêer '%s' nie verwyder nie"
 
-#: ../src/common/file.cpp:598
+#: ../src/common/ffile.cpp:394 ../src/common/file.cpp:625
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "kan tydelike lêer '%s' nie verwyder nie"
 
-#: ../src/common/file.cpp:408
+#: ../src/common/file.cpp:449
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "kan nie 'n soekbewerking doen op lêeretiket %d nie"
 
-#: ../src/common/textfile.cpp:273
+#: ../src/common/textfile.cpp:161
 #, c-format
 msgid "can't write buffer '%s' to disk."
 msgstr "kan buffer '%s' nie na skyf skryf nie."
 
-#: ../src/common/file.cpp:323
+#: ../src/common/file.cpp:364
 #, c-format
 msgid "can't write to file descriptor %d"
 msgstr "kan nie skryf na lêeretiket %d nie"
@@ -8384,22 +8565,28 @@ msgid "can't write user configuration file."
 msgstr "kan gebruikers-konfigurasielêer nie skryf nie."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:482 ../src/generic/datavgen.cpp:1261
+#: ../src/common/datavcmn.cpp:2064 ../src/generic/datavgen.cpp:1384
 msgid "checked"
 msgstr ""
 
-#: ../src/html/chm.cpp:345
+#: ../src/html/chm.cpp:342
 msgid "checksum error"
 msgstr "toetssomfout"
 
-#: ../src/common/tarstrm.cpp:820
+#: ../src/common/tarstrm.cpp:814
 msgid "checksum failure reading tar header block"
 msgstr ""
 
-#: ../src/richtext/richtextbackgroundpage.cpp:226
-#: ../src/richtext/richtextbackgroundpage.cpp:249
-#: ../src/richtext/richtextbackgroundpage.cpp:289
-#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
 #: ../src/richtext/richtextborderspage.cpp:254
 #: ../src/richtext/richtextborderspage.cpp:288
 #: ../src/richtext/richtextborderspage.cpp:322
@@ -8417,106 +8604,129 @@ msgstr ""
 #: ../src/richtext/richtextmarginspage.cpp:340
 #: ../src/richtext/richtextmarginspage.cpp:363
 #: ../src/richtext/richtextmarginspage.cpp:388
-#: ../src/richtext/richtextsizepage.cpp:339
-#: ../src/richtext/richtextsizepage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:400
-#: ../src/richtext/richtextsizepage.cpp:427
-#: ../src/richtext/richtextsizepage.cpp:454
-#: ../src/richtext/richtextsizepage.cpp:481
-#: ../src/richtext/richtextsizepage.cpp:555
-#: ../src/richtext/richtextsizepage.cpp:590
-#: ../src/richtext/richtextsizepage.cpp:625
-#: ../src/richtext/richtextsizepage.cpp:660
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
 msgid "cm"
 msgstr "cm"
 
-#: ../src/html/chm.cpp:347
+#: ../src/html/chm.cpp:344
 msgid "compression error"
 msgstr "inpakfout"
 
-#: ../src/common/regex.cpp:236
+#: ../src/common/regex.cpp:233
 msgid "conversion to 8-bit encoding failed"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:187
+#: ../src/common/accelcmn.cpp:186
 msgid "ctrl"
 msgstr "ctrl"
 
-#: ../src/common/cmdline.cpp:1500
+#: ../src/common/cmdline.cpp:1496
 msgid "date"
 msgstr "datum"
 
-#: ../src/html/chm.cpp:349
+#: ../src/html/chm.cpp:346
 msgid "decompression error"
 msgstr "uitpakfout"
 
-#: ../src/richtext/richtextstyles.cpp:780 ../src/common/fmapbase.cpp:820
+#: ../src/common/fmapbase.cpp:816 ../src/richtext/richtextstyles.cpp:777
 msgid "default"
 msgstr "standaard"
 
-#: ../src/common/cmdline.cpp:1496
+#: ../src/common/cmdline.cpp:1492
 msgid "double"
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:538
+#: ../src/common/debugrpt.cpp:539
 msgid "dump of the process state (binary)"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1969
+#: ../src/common/datetimefmt.cpp:1992
 msgid "eighteenth"
 msgstr "agtiende"
 
-#: ../src/common/datetimefmt.cpp:1959
+#: ../src/common/datetimefmt.cpp:1982
 msgid "eighth"
 msgstr "agtste"
 
-#: ../src/common/datetimefmt.cpp:1962
+#: ../src/common/datetimefmt.cpp:1985
 msgid "eleventh"
 msgstr "elfde"
 
-#: ../src/common/fileconf.cpp:1833
+#: ../src/common/fileconf.cpp:1835
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "inskrywing '%s' kom meer as één keer voor in groep '%s'"
 
-#: ../src/html/chm.cpp:343
+#: ../src/html/chm.cpp:340
 msgid "error in data format"
 msgstr "fout in dataformaat"
 
-#: ../src/html/chm.cpp:331
+#: ../src/html/chm.cpp:328
 msgid "error opening file"
 msgstr "fout tydens oopmaak van lêer"
 
-#: ../src/common/zipstrm.cpp:1778
+#: ../src/common/zipstrm.cpp:1836
 #, fuzzy
 msgid "error reading zip central directory"
 msgstr "Fout tydens skepping van gids"
 
-#: ../src/common/zipstrm.cpp:1870
+#: ../src/common/zipstrm.cpp:1940
 msgid "error reading zip local header"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2531
+#: ../src/common/zipstrm.cpp:2615
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr ""
 
-#: ../src/common/ffile.cpp:188
+#: ../src/common/zipstrm.cpp:2608
+#, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1205
+#, fuzzy
+msgid "extrabold"
+msgstr "vet"
+
+#: ../src/common/fontcmn.cpp:1223
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1167
+#, fuzzy
+msgid "extralight"
+msgstr "lig"
+
+#: ../src/msw/webview_ie.cpp:1036
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "Uitvoering van '%s' het misluk\n"
+
+#: ../src/common/ffile.cpp:187
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "leegmaak van lêer '%s' het misluk"
 
+#: ../src/msw/webview_ie.cpp:1045
+#, fuzzy
+msgid "failed to retrieve execution result"
+msgstr "Verkryging van teks van inbel-foutmelding het misluk"
+
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1030
+#: ../src/generic/datavgen.cpp:1150
 #, fuzzy
 msgid "false"
 msgstr "Vals"
 
-#: ../src/common/datetimefmt.cpp:1966
+#: ../src/common/datetimefmt.cpp:1989
 msgid "fifteenth"
 msgstr "vyftiende"
 
-#: ../src/common/datetimefmt.cpp:1956
+#: ../src/common/datetimefmt.cpp:1979
 msgid "fifth"
 msgstr "vyfde"
 
@@ -8545,131 +8755,150 @@ msgstr "lêer '%s', reël %d: waarde vir onveranderbare sleutel '%s' geïgnoreer
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "lêer '%s': onverwagte teken %c in reël %d."
 
-#: ../src/richtext/richtextbuffer.cpp:8738
+#: ../src/richtext/richtextbuffer.cpp:8736
 msgid "files"
 msgstr "lêers"
 
-#: ../src/common/datetimefmt.cpp:1952
+#: ../src/common/datetimefmt.cpp:1975
 msgid "first"
 msgstr "eerste"
 
-#: ../src/html/helpwnd.cpp:1252
+#: ../src/html/helpwnd.cpp:1250
 msgid "font size"
 msgstr "lettergrootte"
 
-#: ../src/common/datetimefmt.cpp:1965
+#: ../src/common/datetimefmt.cpp:1988
 msgid "fourteenth"
 msgstr "veertiende"
 
-#: ../src/common/datetimefmt.cpp:1955
+#: ../src/common/datetimefmt.cpp:1978
 msgid "fourth"
 msgstr "vierde"
 
-#: ../src/common/appbase.cpp:783
+#: ../src/common/appbase.cpp:784
 msgid "generate verbose log messages"
 msgstr "genereer uitgebreide boekstaafboodskappe"
 
-#: ../src/richtext/richtextbuffer.cpp:13138
-#: ../src/richtext/richtextbuffer.cpp:13248
+#: ../src/common/fontcmn.cpp:1215
+msgid "heavy"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:13133
+#: ../src/richtext/richtextbuffer.cpp:13243
 msgid "image"
 msgstr "beeld"
 
-#: ../src/common/tarstrm.cpp:796
+#: ../src/common/tarstrm.cpp:790
 msgid "incomplete header block in tar"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:489
+#: ../src/common/xtixml.cpp:485
 msgid "incorrect event handler string, missing dot"
 msgstr "verkeerde gebeurtenishanteerder, punt ontbreek"
 
-#: ../src/common/tarstrm.cpp:1381
+#: ../src/common/tarstrm.cpp:1375
 msgid "incorrect size given for tar entry"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:993
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:987
 msgid "invalid data in extended tar header"
 msgstr ""
 
-#: ../src/generic/logg.cpp:1030
+#: ../src/generic/logg.cpp:1027
 msgid "invalid message box return value"
 msgstr "ongeldige teruggee-waarde van boodskapvenster"
 
-#: ../src/common/zipstrm.cpp:1647
+#: ../src/common/zipstrm.cpp:1688
 msgid "invalid zip file"
 msgstr "ongeldig ZIP-lêer"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:1228
 msgid "italic"
 msgstr "kursief"
 
-#: ../src/common/fontcmn.cpp:991
+#: ../src/common/webrequest_curl.cpp:374
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "Lêer kon nie gelaai word nie."
+
+#: ../src/common/fontcmn.cpp:1172
 msgid "light"
 msgstr "lig"
 
-#: ../src/common/intl.cpp:303
-#, c-format
-msgid "locale '%s' cannot be set."
-msgstr "landinstelling '%s' kan nie opgestel word nie."
+#: ../src/common/fontcmn.cpp:1185
+msgid "medium"
+msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2125
+#: ../src/common/datetimefmt.cpp:2148
 msgid "midnight"
 msgstr "middernag"
 
-#: ../src/common/datetimefmt.cpp:1970
+#: ../src/common/datetimefmt.cpp:1993
 msgid "nineteenth"
 msgstr "negentiende"
 
-#: ../src/common/datetimefmt.cpp:1960
+#: ../src/common/datetimefmt.cpp:1983
 msgid "ninth"
 msgstr "negende"
 
-#: ../src/msw/dde.cpp:1116
+#: ../src/msw/dde.cpp:1180
 msgid "no DDE error."
 msgstr "geen DDE-fout."
 
-#: ../src/html/chm.cpp:327
+#: ../src/html/chm.cpp:324
 msgid "no error"
 msgstr "geen fout"
 
-#: ../src/dfb/fontmgr.cpp:174
+#: ../src/dfb/fontmgr.cpp:171
 #, c-format
 msgid "no fonts found in %s, using builtin font"
 msgstr "Geen lettertipes in %s gevind nie. Gebruik ingeboude een."
 
-#: ../src/html/helpdata.cpp:657
+#: ../src/html/helpdata.cpp:650
 msgid "noname"
 msgstr "naamloos"
 
-#: ../src/common/datetimefmt.cpp:2124
+#: ../src/common/datetimefmt.cpp:2147
 msgid "noon"
 msgstr "middag"
 
-#: ../src/richtext/richtextstyles.cpp:779
+#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "normaal"
 
-#: ../src/common/cmdline.cpp:1492
+#: ../src/common/cmdline.cpp:1488
 msgid "num"
 msgstr "num"
 
-#: ../src/common/xtixml.cpp:259
+#: ../src/common/accelcmn.cpp:194
+msgid "num "
+msgstr ""
+
+#: ../src/common/xtixml.cpp:255
 msgid "objects cannot have XML Text Nodes"
 msgstr "objekte kan nie XML-teksnodusse bevat nie"
 
-#: ../src/html/chm.cpp:339
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
 msgid "out of memory"
 msgstr "te min geheue"
 
-#: ../src/common/debugrpt.cpp:514
+#: ../src/common/debugrpt.cpp:515
 msgid "process context description"
 msgstr ""
 
-#: ../src/richtext/richtextbackgroundpage.cpp:227
-#: ../src/richtext/richtextbackgroundpage.cpp:250
-#: ../src/richtext/richtextbackgroundpage.cpp:290
-#: ../src/richtext/richtextbackgroundpage.cpp:317
-#: ../src/richtext/richtextfontpage.cpp:177
-#: ../src/richtext/richtextfontpage.cpp:180
 #: ../src/richtext/richtextborderspage.cpp:255
 #: ../src/richtext/richtextborderspage.cpp:289
 #: ../src/richtext/richtextborderspage.cpp:323
@@ -8679,22 +8908,45 @@ msgstr ""
 #: ../src/richtext/richtextborderspage.cpp:491
 #: ../src/richtext/richtextborderspage.cpp:525
 #: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextfontpage.cpp:180
 msgid "pt"
 msgstr "pt"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:225
-#: ../src/richtext/richtextbackgroundpage.cpp:228
-#: ../src/richtext/richtextbackgroundpage.cpp:229
-#: ../src/richtext/richtextbackgroundpage.cpp:248
-#: ../src/richtext/richtextbackgroundpage.cpp:251
-#: ../src/richtext/richtextbackgroundpage.cpp:252
-#: ../src/richtext/richtextbackgroundpage.cpp:288
-#: ../src/richtext/richtextbackgroundpage.cpp:291
-#: ../src/richtext/richtextbackgroundpage.cpp:292
-#: ../src/richtext/richtextbackgroundpage.cpp:315
-#: ../src/richtext/richtextbackgroundpage.cpp:318
-#: ../src/richtext/richtextbackgroundpage.cpp:319
-#: ../src/richtext/richtextfontpage.cpp:178
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:659
+#: ../src/richtext/richtextsizepage.cpp:662
+#: ../src/richtext/richtextsizepage.cpp:663
 #: ../src/richtext/richtextborderspage.cpp:253
 #: ../src/richtext/richtextborderspage.cpp:256
 #: ../src/richtext/richtextborderspage.cpp:257
@@ -8746,263 +8998,273 @@ msgstr "pt"
 #: ../src/richtext/richtextmarginspage.cpp:387
 #: ../src/richtext/richtextmarginspage.cpp:389
 #: ../src/richtext/richtextmarginspage.cpp:390
-#: ../src/richtext/richtextsizepage.cpp:338
-#: ../src/richtext/richtextsizepage.cpp:341
-#: ../src/richtext/richtextsizepage.cpp:342
-#: ../src/richtext/richtextsizepage.cpp:372
-#: ../src/richtext/richtextsizepage.cpp:375
-#: ../src/richtext/richtextsizepage.cpp:376
-#: ../src/richtext/richtextsizepage.cpp:399
-#: ../src/richtext/richtextsizepage.cpp:402
-#: ../src/richtext/richtextsizepage.cpp:403
-#: ../src/richtext/richtextsizepage.cpp:426
-#: ../src/richtext/richtextsizepage.cpp:429
-#: ../src/richtext/richtextsizepage.cpp:430
-#: ../src/richtext/richtextsizepage.cpp:453
-#: ../src/richtext/richtextsizepage.cpp:456
-#: ../src/richtext/richtextsizepage.cpp:457
-#: ../src/richtext/richtextsizepage.cpp:480
-#: ../src/richtext/richtextsizepage.cpp:483
-#: ../src/richtext/richtextsizepage.cpp:484
-#: ../src/richtext/richtextsizepage.cpp:554
-#: ../src/richtext/richtextsizepage.cpp:557
-#: ../src/richtext/richtextsizepage.cpp:558
-#: ../src/richtext/richtextsizepage.cpp:589
-#: ../src/richtext/richtextsizepage.cpp:592
-#: ../src/richtext/richtextsizepage.cpp:593
-#: ../src/richtext/richtextsizepage.cpp:624
-#: ../src/richtext/richtextsizepage.cpp:627
-#: ../src/richtext/richtextsizepage.cpp:628
-#: ../src/richtext/richtextsizepage.cpp:659
-#: ../src/richtext/richtextsizepage.cpp:662
-#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextfontpage.cpp:178
 msgid "px"
 msgstr "px"
 
-#: ../src/common/accelcmn.cpp:193
+#: ../src/common/accelcmn.cpp:192
 #, fuzzy
 msgid "rawctrl"
 msgstr "ctrl"
 
-#: ../src/html/chm.cpp:333
+#: ../src/html/chm.cpp:330
 msgid "read error"
 msgstr "leesfout"
 
-#: ../src/common/zipstrm.cpp:2085
+#: ../src/common/zipstrm.cpp:2155
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2080
+#: ../src/common/zipstrm.cpp:2150
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr ""
 
-#: ../src/msw/dde.cpp:1159
+#: ../src/msw/dde.cpp:1223
 msgid "reentrancy problem."
 msgstr "probleem met hertoetreding."
 
-#: ../src/common/datetimefmt.cpp:1953
+#: ../src/common/datetimefmt.cpp:1976
 msgid "second"
 msgstr "tweede"
 
-#: ../src/html/chm.cpp:337
+#: ../src/html/chm.cpp:334
 msgid "seek error"
 msgstr "soekfout"
 
-#: ../src/common/datetimefmt.cpp:1968
+#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#, fuzzy
+msgid "semibold"
+msgstr "vet"
+
+#: ../src/common/datetimefmt.cpp:1991
 msgid "seventeenth"
 msgstr "sewentiende"
 
-#: ../src/common/datetimefmt.cpp:1958
+#: ../src/common/datetimefmt.cpp:1981
 msgid "seventh"
 msgstr "sewende"
 
-#: ../src/common/accelcmn.cpp:191
+#: ../src/common/accelcmn.cpp:190
 msgid "shift"
 msgstr "shift"
 
-#: ../src/common/appbase.cpp:773
+#: ../src/common/appbase.cpp:774
 msgid "show this help message"
 msgstr "Wys hierdie hulpboodskap"
 
-#: ../src/common/datetimefmt.cpp:1967
+#: ../src/common/datetimefmt.cpp:1990
 msgid "sixteenth"
 msgstr "sestiende"
 
-#: ../src/common/datetimefmt.cpp:1957
+#: ../src/common/datetimefmt.cpp:1980
 msgid "sixth"
 msgstr "sesde"
 
-#: ../src/common/appcmn.cpp:234
+#: ../src/common/appcmn.cpp:255
 msgid "specify display mode to use (e.g. 640x480-16)"
 msgstr "Kies die vertoonskerm modus (bv. 640x480-16) om te gebruik"
 
-#: ../src/common/appcmn.cpp:220
+#: ../src/common/appcmn.cpp:241
 msgid "specify the theme to use"
 msgstr "Kies die tema om te gebruik"
 
-#: ../src/richtext/richtextbuffer.cpp:9340
+#: ../src/richtext/richtextbuffer.cpp:9337
 msgid "standard/circle"
 msgstr "standaard/sirkel"
 
-#: ../src/richtext/richtextbuffer.cpp:9341
+#: ../src/richtext/richtextbuffer.cpp:9338
 msgid "standard/circle-outline"
 msgstr "standaard/sirkelbuitelyn"
 
-#: ../src/richtext/richtextbuffer.cpp:9343
+#: ../src/richtext/richtextbuffer.cpp:9340
 msgid "standard/diamond"
 msgstr "standaard/diamant"
 
-#: ../src/richtext/richtextbuffer.cpp:9342
+#: ../src/richtext/richtextbuffer.cpp:9339
 msgid "standard/square"
 msgstr "standaard/vierkant"
 
-#: ../src/richtext/richtextbuffer.cpp:9344
+#: ../src/richtext/richtextbuffer.cpp:9341
 msgid "standard/triangle"
 msgstr "standaard/driehoek"
 
-#: ../src/common/zipstrm.cpp:1985
+#: ../src/common/zipstrm.cpp:2055
 msgid "stored file length not in Zip header"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1488
+#: ../src/common/cmdline.cpp:1484
 msgid "str"
 msgstr "str"
 
-#: ../src/common/fontcmn.cpp:982
+#: ../src/common/fontcmn.cpp:1145
 msgid "strikethrough"
 msgstr "deurhaal"
 
-#: ../src/common/tarstrm.cpp:1003 ../src/common/tarstrm.cpp:1025
-#: ../src/common/tarstrm.cpp:1507 ../src/common/tarstrm.cpp:1529
+#: ../src/common/tarstrm.cpp:997 ../src/common/tarstrm.cpp:1019
+#: ../src/common/tarstrm.cpp:1501 ../src/common/tarstrm.cpp:1523
 msgid "tar entry not open"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1961
+#: ../src/common/datetimefmt.cpp:1984
 msgid "tenth"
 msgstr "tiende"
 
-#: ../src/msw/dde.cpp:1123
+#: ../src/msw/dde.cpp:1187
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "die antwoord op die transaksie het die DDE_FBUSY-bit na 1 gestel."
 
-#: ../src/common/datetimefmt.cpp:1954
+#: ../src/common/fontcmn.cpp:1154
+msgid "thin"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:1977
 msgid "third"
 msgstr "derde"
 
-#: ../src/common/datetimefmt.cpp:1964
+#: ../src/common/datetimefmt.cpp:1987
 msgid "thirteenth"
 msgstr "dertiende"
 
-#: ../src/common/datetimefmt.cpp:1758
+#: ../src/common/datetimefmt.cpp:1781
 msgid "today"
 msgstr "vandag"
 
-#: ../src/common/datetimefmt.cpp:1760
+#: ../src/common/datetimefmt.cpp:1783
 msgid "tomorrow"
 msgstr "môre"
 
-#: ../src/common/fileconf.cpp:1944
+#: ../src/common/fileconf.cpp:1946
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr ""
 
-#: ../src/gtk/aboutdlg.cpp:218
+#: ../src/gtk/aboutdlg.cpp:216
 msgid "translator-credits"
 msgstr ""
 "Petri Jooste\n"
 "Friedel Wolff"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1028
+#: ../src/generic/datavgen.cpp:1148
 msgid "true"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1963
+#: ../src/common/datetimefmt.cpp:1986
 msgid "twelfth"
 msgstr "twaalfde"
 
-#: ../src/common/datetimefmt.cpp:1971
+#: ../src/common/datetimefmt.cpp:1994
 msgid "twentieth"
 msgstr "twintigste"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:486 ../src/generic/datavgen.cpp:1263
+#: ../src/common/datavcmn.cpp:2068 ../src/generic/datavgen.cpp:1386
 msgid "unchecked"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:802 ../src/common/fontcmn.cpp:978
+#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
 msgid "underlined"
 msgstr "onderstreep"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:490
+#: ../src/common/datavcmn.cpp:2072
 #, fuzzy
 msgid "undetermined"
 msgstr "onderstreep"
 
-#: ../src/common/fileconf.cpp:1979
+#: ../src/common/fileconf.cpp:1981
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "onverwagte \" op posisie %d in '%s'."
 
-#: ../src/common/tarstrm.cpp:1045
+#: ../src/common/tarstrm.cpp:1039
 msgid "unexpected end of file"
 msgstr ""
 
-#: ../src/generic/progdlgg.cpp:370 ../src/common/tarstrm.cpp:371
-#: ../src/common/tarstrm.cpp:394 ../src/common/tarstrm.cpp:425
+#: ../src/common/tarstrm.cpp:366 ../src/common/tarstrm.cpp:389
+#: ../src/common/tarstrm.cpp:420 ../src/generic/progdlgg.cpp:376
 msgid "unknown"
 msgstr "onbekend"
 
-#: ../src/msw/registry.cpp:150
+#: ../src/msw/registry.cpp:139
 #, fuzzy, c-format
 msgid "unknown (%lu)"
 msgstr "onbekend"
 
-#: ../src/common/xtixml.cpp:253
+#: ../src/common/xtixml.cpp:249
 #, c-format
 msgid "unknown class %s"
 msgstr "onbekende klas %s"
 
-#: ../src/common/regex.cpp:258 ../src/html/chm.cpp:351
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "inpakfout"
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "uitpakfout"
+
+#: ../src/common/regex.cpp:255 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "onbekende fout"
 
-#: ../src/msw/dialup.cpp:471
+#: ../src/msw/dialup.cpp:465
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "onbekende fout (foutnommer %08x)."
 
-#: ../src/common/fmapbase.cpp:834
+#: ../src/common/fmapbase.cpp:830
 #, c-format
 msgid "unknown-%d"
 msgstr "onbekend-%d"
 
-#: ../src/common/docview.cpp:509
+#: ../src/common/docview.cpp:502
 msgid "unnamed"
 msgstr "naamloos"
 
-#: ../src/common/docview.cpp:1624
+#: ../src/common/docview.cpp:1618
 #, c-format
 msgid "unnamed%d"
 msgstr "naamloos%d"
 
-#: ../src/common/zipstrm.cpp:1999 ../src/common/zipstrm.cpp:2319
+#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
 msgid "unsupported Zip compression method"
 msgstr ""
 
-#: ../src/common/translation.cpp:1892
+#: ../src/common/translation.cpp:1942
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "katalogus '%s' van '%s' word gebruik."
 
-#: ../src/html/chm.cpp:335
+#: ../src/html/chm.cpp:332
 msgid "write error"
 msgstr "skryffout"
 
-#: ../src/common/time.cpp:292
+#: ../src/gtk/glcanvas.cpp:187
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/common/time.cpp:285
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay het misluk."
 
@@ -9015,15 +9277,15 @@ msgstr "wxWidgets kon vertoonskerm nie oopmaak vir '%s' nie: gaan afsluit."
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets kon vertoonskerm nie oopmaak nie. Gaan dus uit."
 
-#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:431
 msgid "xxxx"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1759
+#: ../src/common/datetimefmt.cpp:1782
 msgid "yesterday"
 msgstr "gister"
 
-#: ../src/common/zstream.cpp:251 ../src/common/zstream.cpp:426
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
 #, c-format
 msgid "zlib error %d"
 msgstr "zlib fout %d"
@@ -9033,9 +9295,78 @@ msgstr "zlib fout %d"
 msgid "~"
 msgstr "~"
 
+#~ msgid "&Save as"
+#~ msgstr "&Stoor as"
+
 #, fuzzy
-#~ msgid "Column could not be added."
-#~ msgstr "Lêer kon nie gelaai word nie."
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' mag slegs letters bevat."
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' moet numeries wees."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' mag slegs ASCII-tekens bevat."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' mag slegs letters bevat."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' mag alleen alfa-numerieke tekens bevat."
+
+#, fuzzy
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' mag slegs ASCII-tekens bevat."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "Kan venster van klas '%s' nie skep nie"
+
+#, fuzzy
+#~ msgid "Could not initalize libnotify."
+#~ msgstr "Kon nie begin met drukwerk nie."
+
+#, fuzzy
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "Kon nie 'n tydhouer skep nie"
+
+#, fuzzy
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "Kon nie wyser na die huidige uitvoerdraad verkry nie"
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "Omskakel van lêer \"%s\" na Unicode het misluk."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "Kon nie teks in die tekskontrole stel nie."
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr "Ongeldige opdraglynkeuse vir GTK+. Gebruik \"%s --help\""
+
+#, fuzzy
+#~ msgid "No unused colour in image."
+#~ msgstr "Daar word geen ongebruikte kleur in die beeld uitgemasker nie"
+
+#~ msgid "Not available"
+#~ msgstr "Nie beskikbaar nie"
+
+#~ msgid "Replace selection"
+#~ msgstr "Vervang seleksie"
+
+#~ msgid "Save as"
+#~ msgstr "Stoor as"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Stylorganiseerder"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "Die volgende standaard-GTK+-keuses word ook ondersteun:\n"
+
+#, fuzzy
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "Jy kan nie 'n nuwe gids by hierdie seksie voeg nie."
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "landinstelling '%s' kan nie opgestel word nie."
 
 #, fuzzy
 #~ msgid "Column index not found."
@@ -9254,10 +9585,6 @@ msgstr "~"
 
 #~ msgid "unknown seek origin"
 #~ msgstr "onbekende beginpunt vir soektog"
-
-#, fuzzy
-#~ msgid "wxWidget's control not initialized."
-#~ msgstr "Kan vertoonskerm nie inisialiseer nie."
 
 #~ msgid "Cannot create mutex."
 #~ msgstr "Kan nie wedersydse slot skep nie."
@@ -9571,9 +9898,6 @@ msgstr "~"
 #~ msgid "Fatal error: "
 #~ msgstr "Fatale fout: "
 
-#~ msgid "Fatal error"
-#~ msgstr "Fatale fout"
-
 #, fuzzy
 #~ msgid "Failed to register OpenGL window class."
 #~ msgstr "Inisialisering van OpenGL het misluk."
@@ -9641,9 +9965,6 @@ msgstr "~"
 
 #~ msgid "Mode %ix%i-%i not available."
 #~ msgstr "Modus %ix%i-%i nie beskikbaar nie."
-
-#~ msgid "File %s does not exist."
-#~ msgstr "Lêer %s bestaan nie."
 
 #~ msgid "Directory '%s' doesn't exist!"
 #~ msgstr "Gids '%s' bestaan nie!"

--- a/locale/an.po
+++ b/locale/an.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-21 14:25+0200\n"
+"POT-Creation-Date: 2020-10-18 23:11+0300\n"
 "PO-Revision-Date: 2014-04-13 17:41+0100\n"
 "Last-Translator: Jorge Pérez Pérez <jorgtum@gmail.com>\n"
 "Language-Team: softaragonés\n"
@@ -19,7 +19,7 @@ msgstr ""
 "X-Generator: Poedit 1.6.4\n"
 "X-Poedit-Bookmarks: -1,752,-1,-1,-1,-1,-1,-1,-1,-1\n"
 
-#: ../src/common/debugrpt.cpp:586
+#: ../src/common/debugrpt.cpp:587
 msgid ""
 "\n"
 "Please send this report to the program maintainer, thank you!\n"
@@ -27,8 +27,8 @@ msgstr ""
 "\n"
 "Por favor, ninvia iste reporte a lo mantenedor d'o programa, gracias!\n"
 
-#: ../src/richtext/richtextstyledlg.cpp:210
-#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:206
+#: ../src/richtext/richtextstyledlg.cpp:218
 msgid " "
 msgstr " "
 
@@ -36,70 +36,96 @@ msgstr " "
 msgid "              Thank you and we're sorry for the inconvenience!\n"
 msgstr "              Gracias y desincuse as molestias!\n"
 
-#: ../src/common/prntbase.cpp:573
+#: ../src/common/prntbase.cpp:568
 #, c-format
 msgid " (copy %d of %d)"
 msgstr " (copiar %d de %d)"
 
-#: ../src/common/log.cpp:421
+#: ../src/common/log.cpp:440
 #, c-format
 msgid " (error %ld: %s)"
 msgstr " (error %ld: %s)"
 
-#: ../src/common/imagtiff.cpp:72
+#: ../src/common/imagtiff.cpp:69
 #, c-format
 msgid " (in module \"%s\")"
 msgstr " (en o modulo \"%s\")"
 
-#: ../src/osx/core/secretstore.cpp:138
-msgid " (while overwriting an existing item)"
-msgstr ""
-
-#: ../src/common/docview.cpp:1642
+#: ../src/common/docview.cpp:1636
 msgid " - "
 msgstr " - "
 
-#: ../src/richtext/richtextprint.cpp:593 ../src/html/htmprint.cpp:714
+#: ../src/html/htmprint.cpp:712 ../src/richtext/richtextprint.cpp:589
 msgid " Preview"
 msgstr " Anvista previa"
 
-#: ../src/common/fontcmn.cpp:824
+#: ../src/common/fontcmn.cpp:973
 msgid " bold"
 msgstr " negreta"
 
-#: ../src/common/fontcmn.cpp:840
+#: ../src/common/fontcmn.cpp:977
+#, fuzzy
+msgid " extra bold"
+msgstr " negreta"
+
+#: ../src/common/fontcmn.cpp:985
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:957
+#, fuzzy
+msgid " extra light"
+msgstr " lichera"
+
+#: ../src/common/fontcmn.cpp:981
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1001
 msgid " italic"
 msgstr " cursiva"
 
-#: ../src/common/fontcmn.cpp:820
+#: ../src/common/fontcmn.cpp:961
 msgid " light"
 msgstr " lichera"
 
-#: ../src/common/fontcmn.cpp:807
+#: ../src/common/fontcmn.cpp:965
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:969
+#, fuzzy
+msgid " semi bold"
+msgstr " negreta"
+
+#: ../src/common/fontcmn.cpp:940
 msgid " strikethrough"
 msgstr " rayau"
 
-#: ../src/common/paper.cpp:117
+#: ../src/common/fontcmn.cpp:953
+msgid " thin"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
 msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
 msgstr "Sobre #10, 4 1/8 x 9 1/2 in"
 
-#: ../src/common/paper.cpp:118
+#: ../src/common/paper.cpp:115
 msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
 msgstr "Sobre #11, 4 1/2 x 10 3/8 in"
 
-#: ../src/common/paper.cpp:119
+#: ../src/common/paper.cpp:116
 msgid "#12 Envelope, 4 3/4 x 11 in"
 msgstr "Sobre #12, 4 3/4 x 11 in"
 
-#: ../src/common/paper.cpp:120
+#: ../src/common/paper.cpp:117
 msgid "#14 Envelope, 5 x 11 1/2 in"
 msgstr "Sobre #14, 5 x 11 1/2 in"
 
-#: ../src/common/paper.cpp:116
+#: ../src/common/paper.cpp:113
 msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
 msgstr "Sobre #9, 3 7/8 x 8 7/8 in"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:341
 #: ../src/richtext/richtextsizepage.cpp:340
 #: ../src/richtext/richtextsizepage.cpp:374
 #: ../src/richtext/richtextsizepage.cpp:401
@@ -110,81 +136,82 @@ msgstr "Sobre #9, 3 7/8 x 8 7/8 in"
 #: ../src/richtext/richtextsizepage.cpp:591
 #: ../src/richtext/richtextsizepage.cpp:626
 #: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextbackgroundpage.cpp:341
 msgid "%"
 msgstr "%"
 
-#: ../src/html/helpwnd.cpp:1031
+#: ../src/html/helpwnd.cpp:1029
 #, c-format
 msgid "%d of %lu"
 msgstr "%d de %lu"
 
-#: ../src/html/helpwnd.cpp:1678
+#: ../src/html/helpwnd.cpp:1676
 #, fuzzy, c-format
 msgid "%i of %u"
 msgstr "%i de %i"
 
-#: ../src/generic/filectrlg.cpp:279
+#: ../src/generic/filectrlg.cpp:275
 #, c-format
 msgid "%ld byte"
 msgid_plural "%ld bytes"
 msgstr[0] "%ld byte"
 msgstr[1] "%ld bytes"
 
-#: ../src/html/helpwnd.cpp:1033
+#: ../src/html/helpwnd.cpp:1031
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu de %lu"
 
-#: ../src/generic/datavgen.cpp:6028
+#: ../src/generic/datavgen.cpp:6833
 #, fuzzy, c-format
 msgid "%s (%d items)"
 msgstr "%s (u %s)"
 
-#: ../src/common/cmdline.cpp:1221
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (u %s)"
 
-#: ../src/generic/logg.cpp:224
+#: ../src/generic/logg.cpp:221
 #, c-format
 msgid "%s Error"
 msgstr "%s Error"
 
-#: ../src/generic/logg.cpp:236
+#: ../src/generic/logg.cpp:233
 #, c-format
 msgid "%s Information"
 msgstr "%s Información"
 
-#: ../src/generic/preferencesg.cpp:113
+#: ../src/generic/preferencesg.cpp:110
 #, c-format
 msgid "%s Preferences"
 msgstr "%s Preferencias"
 
-#: ../src/generic/logg.cpp:228
+#: ../src/generic/logg.cpp:225
 #, c-format
 msgid "%s Warning"
 msgstr "%s Alvertencia"
 
-#: ../src/common/tarstrm.cpp:1319
+#: ../src/common/tarstrm.cpp:1313
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s no encaixaba en o capitero tar ta la dentrada '%s'"
 
-#: ../src/common/fldlgcmn.cpp:124
+#: ../src/common/fldlgcmn.cpp:121
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "Fichers %s (%s)|%s"
 
-#: ../src/html/helpwnd.cpp:1716
+#: ../src/html/helpwnd.cpp:1714
 #, fuzzy, c-format
 msgid "%u of %u"
 msgstr "%lu de %lu"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "&About"
 msgstr "&Arredol de"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "&Actual Size"
 msgstr "Grandaria &real"
 
@@ -192,28 +219,28 @@ msgstr "Grandaria &real"
 msgid "&After a paragraph:"
 msgstr "&Dimpués d'un paragrafo:"
 
-#: ../src/richtext/richtextindentspage.cpp:128
 #: ../src/richtext/richtextliststylepage.cpp:319
+#: ../src/richtext/richtextindentspage.cpp:128
 msgid "&Alignment"
 msgstr "&Aliniación"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "&Apply"
 msgstr "&Aplicar"
 
-#: ../src/richtext/richtextstyledlg.cpp:251
+#: ../src/richtext/richtextstyledlg.cpp:247
 msgid "&Apply Style"
 msgstr "&Aplicar Estilo"
 
-#: ../src/msw/mdi.cpp:179
+#: ../src/msw/mdi.cpp:174
 msgid "&Arrange Icons"
 msgstr "&Organizar os iconos"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "&Ascending"
 msgstr "&Ascendent"
 
-#: ../src/common/stockitem.cpp:142
+#: ../src/common/stockitem.cpp:139
 msgid "&Back"
 msgstr "&Dezaga"
 
@@ -233,24 +260,24 @@ msgstr "&Color de fondo:"
 msgid "&Blur distance:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:143
+#: ../src/common/stockitem.cpp:140
 msgid "&Bold"
 msgstr "&Negreta"
 
-#: ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141
 msgid "&Bottom"
 msgstr "&Inferior"
 
+#: ../src/richtext/richtextsizepage.cpp:637
+#: ../src/richtext/richtextsizepage.cpp:644
 #: ../src/richtext/richtextborderspage.cpp:345
 #: ../src/richtext/richtextborderspage.cpp:513
 #: ../src/richtext/richtextmarginspage.cpp:259
 #: ../src/richtext/richtextmarginspage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:637
-#: ../src/richtext/richtextsizepage.cpp:644
 msgid "&Bottom:"
 msgstr "&Inferior:"
 
-#: ../include/wx/richtext/richtextbuffer.h:3866
+#: ../include/wx/richtext/richtextbuffer.h:3861
 msgid "&Box"
 msgstr "&Caixa"
 
@@ -259,38 +286,38 @@ msgstr "&Caixa"
 msgid "&Bullet style:"
 msgstr "Estilo de &vinyeta:"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "&CD-Rom"
 msgstr "&CD-Rom"
 
-#: ../src/generic/wizard.cpp:434 ../src/generic/fontdlgg.cpp:470
-#: ../src/generic/fontdlgg.cpp:489 ../src/osx/carbon/fontdlg.cpp:402
-#: ../src/common/dlgcmn.cpp:279 ../src/common/stockitem.cpp:145
+#: ../src/osx/carbon/fontdlg.cpp:399 ../src/common/stockitem.cpp:142
+#: ../src/generic/wizard.cpp:433 ../src/generic/fontdlgg.cpp:466
+#: ../src/generic/fontdlgg.cpp:485 ../src/osx/cocoa/button.mm:200
 msgid "&Cancel"
 msgstr "&Cancelar"
 
-#: ../src/msw/mdi.cpp:175
+#: ../src/msw/mdi.cpp:170
 msgid "&Cascade"
 msgstr "&Cascada"
 
-#: ../include/wx/richtext/richtextbuffer.h:5960
+#: ../include/wx/richtext/richtextbuffer.h:5955
 msgid "&Cell"
 msgstr "&Celda"
 
-#: ../src/richtext/richtextsymboldlg.cpp:439
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "&Character code:"
 msgstr "&Codigo de caracter:"
 
-#: ../src/common/stockitem.cpp:147
+#: ../src/common/stockitem.cpp:144
 msgid "&Clear"
 msgstr "&Limpiar"
 
-#: ../src/generic/logg.cpp:516 ../src/common/stockitem.cpp:148
-#: ../src/common/prntbase.cpp:1600 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/stockitem.cpp:145 ../src/common/prntbase.cpp:1625
+#: ../src/univ/themes/win32.cpp:3753 ../src/generic/logg.cpp:513
 msgid "&Close"
 msgstr "&Zarrar"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "&Color"
 msgstr "&Color"
 
@@ -298,20 +325,20 @@ msgstr "&Color"
 msgid "&Colour:"
 msgstr "&Color:"
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "&Convert"
 msgstr "&Convertir"
 
-#: ../src/richtext/richtextctrl.cpp:333 ../src/osx/textctrl_osx.cpp:577
-#: ../src/common/stockitem.cpp:150 ../src/msw/textctrl.cpp:2508
+#: ../src/osx/textctrl_osx.cpp:595 ../src/common/stockitem.cpp:147
+#: ../src/msw/textctrl.cpp:2773 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Copiar"
 
-#: ../src/generic/hyperlinkg.cpp:156
+#: ../src/generic/hyperlinkg.cpp:153
 msgid "&Copy URL"
 msgstr "&Copiar URL"
 
-#: ../src/common/headerctrlcmn.cpp:306
+#: ../src/common/headerctrlcmn.cpp:304
 msgid "&Customize..."
 msgstr "&Personalizar..."
 
@@ -319,53 +346,54 @@ msgstr "&Personalizar..."
 msgid "&Debug report preview:"
 msgstr "&Anvista previa d'o reporte de depuración:"
 
-#: ../src/richtext/richtexttabspage.cpp:138
-#: ../src/richtext/richtextctrl.cpp:335 ../src/osx/textctrl_osx.cpp:579
-#: ../src/common/stockitem.cpp:152 ../src/msw/textctrl.cpp:2510
+#: ../src/osx/textctrl_osx.cpp:597 ../src/common/stockitem.cpp:149
+#: ../src/msw/textctrl.cpp:2775 ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtextctrl.cpp:334
 msgid "&Delete"
 msgstr "&Eliminar"
 
-#: ../src/richtext/richtextstyledlg.cpp:269
+#: ../src/richtext/richtextstyledlg.cpp:265
 msgid "&Delete Style..."
 msgstr "&Eliminar o estilo..."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "&Descending"
 msgstr "&Descendent"
 
-#: ../src/generic/logg.cpp:682
+#: ../src/generic/logg.cpp:679
 msgid "&Details"
 msgstr "&Detalles"
 
-#: ../src/common/stockitem.cpp:153
+#: ../src/common/stockitem.cpp:150
 msgid "&Down"
 msgstr "A&baixo"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "&Edit"
 msgstr "&Editar"
 
-#: ../src/richtext/richtextstyledlg.cpp:263
+#: ../src/richtext/richtextstyledlg.cpp:259
 msgid "&Edit Style..."
 msgstr "&Editar o Estilo..."
 
-#: ../src/common/stockitem.cpp:155
+#: ../src/common/stockitem.cpp:152
 msgid "&Execute"
 msgstr "&Executar"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/common/stockitem.cpp:154
 msgid "&File"
 msgstr "&Fichero"
 
-#: ../src/common/stockitem.cpp:158
-msgid "&Find"
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "&Find..."
 msgstr "&Mirar"
 
-#: ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:430
 msgid "&Finish"
 msgstr "&Finalizar"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:156
 msgid "&First"
 msgstr "&Primer"
 
@@ -373,15 +401,15 @@ msgstr "&Primer"
 msgid "&Floating mode:"
 msgstr "Modo &flotant:"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "&Floppy"
 msgstr "&Disquet"
 
-#: ../src/common/stockitem.cpp:194
+#: ../src/common/stockitem.cpp:191
 msgid "&Font"
 msgstr "&Fuent"
 
-#: ../src/generic/fontdlgg.cpp:371
+#: ../src/generic/fontdlgg.cpp:367
 msgid "&Font family:"
 msgstr "Tipo de &fuent:"
 
@@ -389,20 +417,20 @@ msgstr "Tipo de &fuent:"
 msgid "&Font for Level..."
 msgstr "&Fuent ta o libel..."
 
+#: ../src/richtext/richtextsymboldlg.cpp:397
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:400
 msgid "&Font:"
 msgstr "&Fuent:"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "&Forward"
 msgstr "Abanz"
 
-#: ../src/richtext/richtextsymboldlg.cpp:451
+#: ../src/richtext/richtextsymboldlg.cpp:448
 msgid "&From:"
 msgstr "&Dende:"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "&Harddisk"
 msgstr "&Disco duro"
 
@@ -411,9 +439,9 @@ msgstr "&Disco duro"
 msgid "&Height:"
 msgstr "&Altura:"
 
-#: ../src/generic/wizard.cpp:441 ../src/richtext/richtextstyledlg.cpp:303
-#: ../src/richtext/richtextsymboldlg.cpp:479 ../src/osx/menu_osx.cpp:734
-#: ../src/common/stockitem.cpp:163
+#: ../src/common/stockitem.cpp:160 ../src/generic/wizard.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextstyledlg.cpp:299 ../src/osx/cocoa/menu.mm:226
 msgid "&Help"
 msgstr "&Aduya"
 
@@ -421,7 +449,7 @@ msgstr "&Aduya"
 msgid "&Hide details"
 msgstr "&Amagar os detalles"
 
-#: ../src/common/stockitem.cpp:164
+#: ../src/common/stockitem.cpp:161
 msgid "&Home"
 msgstr "&Inicio"
 
@@ -429,54 +457,54 @@ msgstr "&Inicio"
 msgid "&Horizontal offset:"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:184
 #: ../src/richtext/richtextliststylepage.cpp:372
+#: ../src/richtext/richtextindentspage.cpp:184
 msgid "&Indentation (tenths of a mm)"
 msgstr "&Escalonau (decenas de mm)"
 
-#: ../src/richtext/richtextindentspage.cpp:167
 #: ../src/richtext/richtextliststylepage.cpp:356
+#: ../src/richtext/richtextindentspage.cpp:167
 msgid "&Indeterminate"
 msgstr "&Indeterminau"
 
-#: ../src/common/stockitem.cpp:166
+#: ../src/common/stockitem.cpp:163
 msgid "&Index"
 msgstr "Ind&iz"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "&Info"
 msgstr "&Información"
 
-#: ../src/common/stockitem.cpp:168
+#: ../src/common/stockitem.cpp:165
 msgid "&Italic"
 msgstr "Curs&iva"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "&Jump to"
 msgstr "&Blincar ta"
 
-#: ../src/richtext/richtextindentspage.cpp:153
 #: ../src/richtext/richtextliststylepage.cpp:342
+#: ../src/richtext/richtextindentspage.cpp:153
 msgid "&Justified"
 msgstr "&Chustificau"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "&Last"
 msgstr "&Zaguer"
 
-#: ../src/richtext/richtextindentspage.cpp:139
 #: ../src/richtext/richtextliststylepage.cpp:328
+#: ../src/richtext/richtextindentspage.cpp:139
 msgid "&Left"
 msgstr "&Cucha"
 
-#: ../src/richtext/richtextindentspage.cpp:195
+#: ../src/richtext/richtextsizepage.cpp:532
+#: ../src/richtext/richtextsizepage.cpp:539
 #: ../src/richtext/richtextborderspage.cpp:243
 #: ../src/richtext/richtextborderspage.cpp:411
 #: ../src/richtext/richtextliststylepage.cpp:381
+#: ../src/richtext/richtextindentspage.cpp:195
 #: ../src/richtext/richtextmarginspage.cpp:186
 #: ../src/richtext/richtextmarginspage.cpp:300
-#: ../src/richtext/richtextsizepage.cpp:532
-#: ../src/richtext/richtextsizepage.cpp:539
 msgid "&Left:"
 msgstr "&Cucha:"
 
@@ -484,11 +512,11 @@ msgstr "&Cucha:"
 msgid "&List level:"
 msgstr "Libel de &Lista:"
 
-#: ../src/generic/logg.cpp:517
+#: ../src/generic/logg.cpp:514
 msgid "&Log"
 msgstr "&Rechistro"
 
-#: ../src/univ/themes/win32.cpp:3748
+#: ../src/univ/themes/win32.cpp:3745
 msgid "&Move"
 msgstr "&Mover"
 
@@ -496,20 +524,19 @@ msgstr "&Mover"
 msgid "&Move the object to:"
 msgstr "&Mover l'obecto ta:"
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "&Network"
 msgstr "&Ret"
 
-#: ../src/richtext/richtexttabspage.cpp:132 ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173 ../src/richtext/richtexttabspage.cpp:132
 msgid "&New"
 msgstr "&Nuevo"
 
-#: ../src/aui/tabmdi.cpp:111 ../src/generic/mdig.cpp:100
-#: ../src/msw/mdi.cpp:180
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
 msgid "&Next"
 msgstr "&Siguient"
 
-#: ../src/generic/wizard.cpp:432 ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:429
 msgid "&Next >"
 msgstr "&Siguient >"
 
@@ -517,7 +544,7 @@ msgstr "&Siguient >"
 msgid "&Next Paragraph"
 msgstr "&Siguient paragrafo"
 
-#: ../src/generic/tipdlg.cpp:240
+#: ../src/generic/tipdlg.cpp:237
 msgid "&Next Tip"
 msgstr "&Siguient Sucherencia"
 
@@ -525,11 +552,11 @@ msgstr "&Siguient Sucherencia"
 msgid "&Next style:"
 msgstr "&Siguient estilo:"
 
-#: ../src/common/stockitem.cpp:177 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:174 ../src/msw/msgdlg.cpp:435
 msgid "&No"
 msgstr "&No"
 
-#: ../src/generic/dbgrptg.cpp:356
+#: ../src/generic/dbgrptg.cpp:360
 msgid "&Notes:"
 msgstr "&Notas:"
 
@@ -537,12 +564,12 @@ msgstr "&Notas:"
 msgid "&Number:"
 msgstr "&Numero:"
 
-#: ../src/generic/fontdlgg.cpp:475 ../src/generic/fontdlgg.cpp:482
-#: ../src/osx/carbon/fontdlg.cpp:408 ../src/common/stockitem.cpp:178
+#: ../src/osx/carbon/fontdlg.cpp:405 ../src/common/stockitem.cpp:175
+#: ../src/generic/fontdlgg.cpp:471 ../src/generic/fontdlgg.cpp:478
 msgid "&OK"
 msgstr "&Acceptar"
 
-#: ../src/generic/dbgrptg.cpp:342 ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176 ../src/generic/dbgrptg.cpp:342
 msgid "&Open..."
 msgstr "U&brir..."
 
@@ -554,16 +581,16 @@ msgstr "Libel d'&esquema:"
 msgid "&Page Break"
 msgstr "Blinco de &pachina"
 
-#: ../src/richtext/richtextctrl.cpp:334 ../src/osx/textctrl_osx.cpp:578
-#: ../src/common/stockitem.cpp:180 ../src/msw/textctrl.cpp:2509
+#: ../src/osx/textctrl_osx.cpp:596 ../src/common/stockitem.cpp:177
+#: ../src/msw/textctrl.cpp:2774 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&Apegar"
 
-#: ../include/wx/richtext/richtextbuffer.h:5010
+#: ../include/wx/richtext/richtextbuffer.h:5005
 msgid "&Picture"
 msgstr "&Imachen"
 
-#: ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:419
 msgid "&Point size:"
 msgstr "Grandaria de &punto:"
 
@@ -575,12 +602,11 @@ msgstr "&Posición (decenas de mm):"
 msgid "&Position mode:"
 msgstr "Modo de &posición:"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178
 msgid "&Preferences"
 msgstr "&Preferencias"
 
-#: ../src/aui/tabmdi.cpp:112 ../src/generic/mdig.cpp:101
-#: ../src/msw/mdi.cpp:181
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
 msgid "&Previous"
 msgstr "&Anterior"
 
@@ -588,78 +614,74 @@ msgstr "&Anterior"
 msgid "&Previous Paragraph"
 msgstr "Anterior &paragrafo"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "&Print..."
 msgstr "Im&prentar..."
 
-#: ../src/richtext/richtextctrl.cpp:339 ../src/richtext/richtextctrl.cpp:5514
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtextctrl.cpp:338
+#: ../src/richtext/richtextctrl.cpp:5512
 msgid "&Properties"
 msgstr "&Propiedatz"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "&Quit"
 msgstr "&Salir"
 
-#: ../src/richtext/richtextctrl.cpp:330 ../src/osx/textctrl_osx.cpp:574
-#: ../src/common/stockitem.cpp:185 ../src/common/cmdproc.cpp:293
-#: ../src/common/cmdproc.cpp:300 ../src/msw/textctrl.cpp:2505
+#: ../src/osx/textctrl_osx.cpp:592 ../src/common/stockitem.cpp:182
+#: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
+#: ../src/msw/textctrl.cpp:2770 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Refer"
 
-#: ../src/common/cmdproc.cpp:289 ../src/common/cmdproc.cpp:309
+#: ../src/common/cmdproc.cpp:282 ../src/common/cmdproc.cpp:302
 msgid "&Redo "
 msgstr "&Refer "
 
-#: ../src/richtext/richtextstyledlg.cpp:257
+#: ../src/richtext/richtextstyledlg.cpp:253
 msgid "&Rename Style..."
 msgstr "&Renombrar o Estilo..."
 
-#: ../src/generic/fdrepdlg.cpp:179
+#: ../src/generic/fdrepdlg.cpp:176
 msgid "&Replace"
 msgstr "&Substituir"
 
-#: ../src/richtext/richtextstyledlg.cpp:287
+#: ../src/richtext/richtextstyledlg.cpp:283
 msgid "&Restart numbering"
 msgstr "&Rempecipiar a numeración"
 
-#: ../src/univ/themes/win32.cpp:3747
+#: ../src/univ/themes/win32.cpp:3744
 msgid "&Restore"
 msgstr "&Restaurar"
 
-#: ../src/richtext/richtextindentspage.cpp:146
 #: ../src/richtext/richtextliststylepage.cpp:335
+#: ../src/richtext/richtextindentspage.cpp:146
 msgid "&Right"
 msgstr "&Dreita"
 
-#: ../src/richtext/richtextindentspage.cpp:213
+#: ../src/richtext/richtextsizepage.cpp:602
+#: ../src/richtext/richtextsizepage.cpp:609
 #: ../src/richtext/richtextborderspage.cpp:277
 #: ../src/richtext/richtextborderspage.cpp:445
 #: ../src/richtext/richtextliststylepage.cpp:399
+#: ../src/richtext/richtextindentspage.cpp:213
 #: ../src/richtext/richtextmarginspage.cpp:211
 #: ../src/richtext/richtextmarginspage.cpp:325
-#: ../src/richtext/richtextsizepage.cpp:602
-#: ../src/richtext/richtextsizepage.cpp:609
 msgid "&Right:"
 msgstr "&Dreita:"
 
-#: ../src/common/stockitem.cpp:190
+#: ../src/common/stockitem.cpp:187
 msgid "&Save"
 msgstr "&Alzar"
-
-#: ../src/common/stockitem.cpp:191
-msgid "&Save as"
-msgstr "&Alzar como"
 
 #: ../include/wx/richmsgdlg.h:29
 msgid "&See details"
 msgstr "&Veyer os detalles"
 
-#: ../src/generic/tipdlg.cpp:236
+#: ../src/generic/tipdlg.cpp:233
 msgid "&Show tips at startup"
 msgstr "&Amostrar as sucherencias a l'inicio"
 
-#: ../src/univ/themes/win32.cpp:3750
+#: ../src/univ/themes/win32.cpp:3747
 msgid "&Size"
 msgstr "&Grandaria"
 
@@ -667,36 +689,36 @@ msgstr "&Grandaria"
 msgid "&Size:"
 msgstr "&Grandaria:"
 
-#: ../src/generic/progdlgg.cpp:252
+#: ../src/generic/progdlgg.cpp:249
 msgid "&Skip"
 msgstr "&Privar"
 
-#: ../src/richtext/richtextindentspage.cpp:242
 #: ../src/richtext/richtextliststylepage.cpp:417
+#: ../src/richtext/richtextindentspage.cpp:242
 msgid "&Spacing (tenths of a mm)"
 msgstr "&Espaciau (decenas de mm)"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "&Spell Check"
 msgstr "&Revisar ortografía"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "&Stop"
 msgstr "&Aturar"
 
-#: ../src/richtext/richtextfontpage.cpp:275 ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196 ../src/richtext/richtextfontpage.cpp:275
 msgid "&Strikethrough"
 msgstr "&Rayau"
 
-#: ../src/generic/fontdlgg.cpp:382 ../src/richtext/richtextstylepage.cpp:106
+#: ../src/generic/fontdlgg.cpp:378 ../src/richtext/richtextstylepage.cpp:106
 msgid "&Style:"
 msgstr "E&stilo:"
 
-#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:194
 msgid "&Styles:"
 msgstr "E&stilos:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:413
+#: ../src/richtext/richtextsymboldlg.cpp:410
 msgid "&Subset:"
 msgstr "&Subconchunto:"
 
@@ -710,24 +732,24 @@ msgstr "&Simbolo:"
 msgid "&Synchronize values"
 msgstr "&Sincronizar as valors"
 
-#: ../include/wx/richtext/richtextbuffer.h:6069
+#: ../include/wx/richtext/richtextbuffer.h:6064
 msgid "&Table"
 msgstr "&Tabla"
 
-#: ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197
 msgid "&Top"
 msgstr "&Superior"
 
+#: ../src/richtext/richtextsizepage.cpp:567
+#: ../src/richtext/richtextsizepage.cpp:574
 #: ../src/richtext/richtextborderspage.cpp:311
 #: ../src/richtext/richtextborderspage.cpp:479
 #: ../src/richtext/richtextmarginspage.cpp:234
 #: ../src/richtext/richtextmarginspage.cpp:348
-#: ../src/richtext/richtextsizepage.cpp:567
-#: ../src/richtext/richtextsizepage.cpp:574
 msgid "&Top:"
 msgstr "&Superior:"
 
-#: ../src/generic/fontdlgg.cpp:444 ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199 ../src/generic/fontdlgg.cpp:441
 msgid "&Underline"
 msgstr "S&ubrayau"
 
@@ -735,21 +757,21 @@ msgstr "S&ubrayau"
 msgid "&Underlining:"
 msgstr "S&ubrayau:"
 
-#: ../src/richtext/richtextctrl.cpp:329 ../src/osx/textctrl_osx.cpp:573
-#: ../src/common/stockitem.cpp:203 ../src/common/cmdproc.cpp:271
-#: ../src/msw/textctrl.cpp:2504
+#: ../src/osx/textctrl_osx.cpp:591 ../src/common/stockitem.cpp:200
+#: ../src/common/cmdproc.cpp:264 ../src/msw/textctrl.cpp:2769
+#: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Desfer"
 
-#: ../src/common/cmdproc.cpp:265
+#: ../src/common/cmdproc.cpp:258
 msgid "&Undo "
 msgstr "&Desfer "
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "&Unindent"
 msgstr "&No escalonau"
 
-#: ../src/common/stockitem.cpp:205
+#: ../src/common/stockitem.cpp:202
 msgid "&Up"
 msgstr "&Alto"
 
@@ -766,7 +788,7 @@ msgstr "Aliniación &vertical:"
 msgid "&View..."
 msgstr "An&vista..."
 
-#: ../src/generic/fontdlgg.cpp:393
+#: ../src/generic/fontdlgg.cpp:389
 msgid "&Weight:"
 msgstr "&Peso:"
 
@@ -775,88 +797,58 @@ msgstr "&Peso:"
 msgid "&Width:"
 msgstr "&Amplaria:"
 
-#: ../src/aui/tabmdi.cpp:311 ../src/aui/tabmdi.cpp:327
-#: ../src/aui/tabmdi.cpp:329 ../src/generic/mdig.cpp:294
-#: ../src/generic/mdig.cpp:310 ../src/generic/mdig.cpp:314
-#: ../src/msw/mdi.cpp:78
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
 msgid "&Window"
 msgstr "&Finestra"
 
-#: ../src/common/stockitem.cpp:206 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:203 ../src/msw/msgdlg.cpp:435
 msgid "&Yes"
 msgstr "&Sí"
 
-#: ../src/common/valtext.cpp:256
-#, c-format
-msgid "'%s' contains illegal characters"
+#: ../src/common/valtext.cpp:197
+#, fuzzy, c-format
+msgid "'%s' contains invalid character(s)"
 msgstr "'%s' contién caracters no validos"
 
-#: ../src/common/valtext.cpp:254
-#, c-format
-msgid "'%s' doesn't consist only of valid characters"
-msgstr "'%s' no consiste nomás de caracters validos"
-
-#: ../src/common/config.cpp:519 ../src/msw/regconf.cpp:258
+#: ../src/common/config.cpp:515 ../src/msw/regconf.cpp:255
 #, c-format
 msgid "'%s' has extra '..', ignored."
 msgstr "'%s' tien bell '..' adicional, será ignorau."
 
-#: ../src/common/cmdline.cpp:1113 ../src/common/cmdline.cpp:1131
+#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' no ye una valor numerica correcta ta lo parametro '%s'."
 
-#: ../src/common/translation.cpp:1100
+#: ../src/common/translation.cpp:1142
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' no ye un catalogo de mensaches valiu."
 
-#: ../src/common/valtext.cpp:165
+#: ../src/common/valtext.cpp:188
 #, c-format
 msgid "'%s' is not one of the valid strings"
 msgstr "'%s' no ye una d'as cadenas validas"
 
-#: ../src/common/valtext.cpp:167
+#: ../src/common/valtext.cpp:186
 #, c-format
 msgid "'%s' is one of the invalid strings"
 msgstr "'%s' ye una d'as cadenas invalidas"
 
-#: ../src/common/textbuf.cpp:237
+#: ../src/common/textbuf.cpp:233
 #, c-format
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' ye prebablement un fichero binario."
-
-#: ../src/common/valtext.cpp:252
-#, c-format
-msgid "'%s' should be numeric."
-msgstr "'%s' ha d'estar numerico."
-
-#: ../src/common/valtext.cpp:244
-#, c-format
-msgid "'%s' should only contain ASCII characters."
-msgstr "'%s' debe contener nomás caracters ASCII."
-
-#: ../src/common/valtext.cpp:246
-#, c-format
-msgid "'%s' should only contain alphabetic characters."
-msgstr "'%s' debe contener nomás caracters alfabeticos."
-
-#: ../src/common/valtext.cpp:248
-#, c-format
-msgid "'%s' should only contain alphabetic or numeric characters."
-msgstr "'%s' ha de contener nomás caracters alfanumericos."
-
-#: ../src/common/valtext.cpp:250
-#, c-format
-msgid "'%s' should only contain digits."
-msgstr "'%s' debe contener nomás numeros."
 
 #: ../src/richtext/richtextliststylepage.cpp:229
 #: ../src/richtext/richtextbulletspage.cpp:166
 msgid "(*)"
 msgstr "(*)"
 
-#: ../src/html/helpwnd.cpp:963
+#: ../src/html/helpwnd.cpp:961
 msgid "(Help)"
 msgstr "(Aduya)"
 
@@ -865,27 +857,32 @@ msgstr "(Aduya)"
 msgid "(None)"
 msgstr "(Garra)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:504
+#: ../src/richtext/richtextsymboldlg.cpp:503
 msgid "(Normal text)"
 msgstr "(Texto normal)"
 
-#: ../src/html/helpwnd.cpp:419 ../src/html/helpwnd.cpp:1106
-#: ../src/html/helpwnd.cpp:1742
+#: ../src/html/helpwnd.cpp:417 ../src/html/helpwnd.cpp:1104
+#: ../src/html/helpwnd.cpp:1740
 msgid "(bookmarks)"
 msgstr "(marcapachinas)"
 
+#: ../src/msw/dlmsw.cpp:167
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (error %ld: %s)"
+
+#: ../src/richtext/richtextformatdlg.cpp:876
+#: ../src/richtext/richtextliststylepage.cpp:448
+#: ../src/richtext/richtextliststylepage.cpp:460
+#: ../src/richtext/richtextliststylepage.cpp:461
 #: ../src/richtext/richtextindentspage.cpp:274
 #: ../src/richtext/richtextindentspage.cpp:286
 #: ../src/richtext/richtextindentspage.cpp:287
 #: ../src/richtext/richtextindentspage.cpp:311
 #: ../src/richtext/richtextindentspage.cpp:326
-#: ../src/richtext/richtextformatdlg.cpp:884
 #: ../src/richtext/richtextfontpage.cpp:349
 #: ../src/richtext/richtextfontpage.cpp:353
 #: ../src/richtext/richtextfontpage.cpp:357
-#: ../src/richtext/richtextliststylepage.cpp:448
-#: ../src/richtext/richtextliststylepage.cpp:460
-#: ../src/richtext/richtextliststylepage.cpp:461
 msgid "(none)"
 msgstr "(garra)"
 
@@ -904,7 +901,7 @@ msgstr "*)"
 msgid "+"
 msgstr "+"
 
-#: ../src/msw/utils.cpp:1152
+#: ../src/msw/utils.cpp:1143
 msgid ", 64-bit edition"
 msgstr ", edición de 64 bits"
 
@@ -913,163 +910,163 @@ msgstr ", edición de 64 bits"
 msgid "-"
 msgstr "-"
 
-#: ../src/generic/filepickerg.cpp:66
+#: ../src/generic/filepickerg.cpp:63
 msgid "..."
 msgstr "..."
 
-#: ../src/richtext/richtextindentspage.cpp:276
 #: ../src/richtext/richtextliststylepage.cpp:450
+#: ../src/richtext/richtextindentspage.cpp:276
 msgid "1.1"
 msgstr "1.1"
 
-#: ../src/richtext/richtextindentspage.cpp:277
 #: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextindentspage.cpp:277
 msgid "1.2"
 msgstr "1.2"
 
-#: ../src/richtext/richtextindentspage.cpp:278
 #: ../src/richtext/richtextliststylepage.cpp:452
+#: ../src/richtext/richtextindentspage.cpp:278
 msgid "1.3"
 msgstr "1.3"
 
-#: ../src/richtext/richtextindentspage.cpp:279
 #: ../src/richtext/richtextliststylepage.cpp:453
+#: ../src/richtext/richtextindentspage.cpp:279
 msgid "1.4"
 msgstr "1.4"
 
-#: ../src/richtext/richtextindentspage.cpp:280
 #: ../src/richtext/richtextliststylepage.cpp:454
+#: ../src/richtext/richtextindentspage.cpp:280
 msgid "1.5"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:281
 #: ../src/richtext/richtextliststylepage.cpp:455
+#: ../src/richtext/richtextindentspage.cpp:281
 msgid "1.6"
 msgstr "1.6"
 
-#: ../src/richtext/richtextindentspage.cpp:282
 #: ../src/richtext/richtextliststylepage.cpp:456
+#: ../src/richtext/richtextindentspage.cpp:282
 msgid "1.7"
 msgstr "1.7"
 
-#: ../src/richtext/richtextindentspage.cpp:283
 #: ../src/richtext/richtextliststylepage.cpp:457
+#: ../src/richtext/richtextindentspage.cpp:283
 msgid "1.8"
 msgstr "1.8"
 
-#: ../src/richtext/richtextindentspage.cpp:284
 #: ../src/richtext/richtextliststylepage.cpp:458
+#: ../src/richtext/richtextindentspage.cpp:284
 msgid "1.9"
 msgstr "1.9"
 
-#: ../src/common/paper.cpp:140
+#: ../src/common/paper.cpp:137
 msgid "10 x 11 in"
 msgstr "10 x 11 in"
 
-#: ../src/common/paper.cpp:113
+#: ../src/common/paper.cpp:110
 msgid "10 x 14 in"
 msgstr "10 x 14 in"
 
-#: ../src/common/paper.cpp:114
+#: ../src/common/paper.cpp:111
 msgid "11 x 17 in"
 msgstr "11 x 17 in"
 
-#: ../src/common/paper.cpp:184
+#: ../src/common/paper.cpp:181
 msgid "12 x 11 in"
 msgstr "12 x 11 in"
 
-#: ../src/common/paper.cpp:141
+#: ../src/common/paper.cpp:138
 msgid "15 x 11 in"
 msgstr "15 x 11 in"
 
-#: ../src/richtext/richtextindentspage.cpp:285
 #: ../src/richtext/richtextliststylepage.cpp:459
+#: ../src/richtext/richtextindentspage.cpp:285
 msgid "2"
 msgstr "2"
 
-#: ../src/common/paper.cpp:132
+#: ../src/common/paper.cpp:129
 msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
 msgstr "Sobre 6 3/4, 3 5/8 x 6 1/2 in"
 
-#: ../src/common/paper.cpp:139
+#: ../src/common/paper.cpp:136
 msgid "9 x 11 in"
 msgstr "9 x 11 in"
 
-#: ../src/html/htmprint.cpp:431
+#: ../src/html/htmprint.cpp:443
 msgid ": file does not exist!"
 msgstr ": o fichero no existe!"
 
-#: ../src/common/fontmap.cpp:199
+#: ../src/common/fontmap.cpp:196
 msgid ": unknown charset"
 msgstr ": conchunto de caracters desconoixiu"
 
-#: ../src/common/fontmap.cpp:413
+#: ../src/common/fontmap.cpp:410
 msgid ": unknown encoding"
 msgstr ": codificación desconoixida"
 
-#: ../src/generic/wizard.cpp:443
+#: ../src/generic/wizard.cpp:438
 msgid "< &Back"
 msgstr "< &Dezaga"
 
-#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:628
-#: ../src/osx/carbon/fontdlg.cpp:648
+#: ../src/osx/carbon/fontdlg.cpp:419 ../src/osx/carbon/fontdlg.cpp:625
+#: ../src/osx/carbon/fontdlg.cpp:645
 msgid "<Any Decorative>"
 msgstr "<Cualsiquier Decorativo>"
 
-#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:630
-#: ../src/osx/carbon/fontdlg.cpp:650
+#: ../src/osx/carbon/fontdlg.cpp:420 ../src/osx/carbon/fontdlg.cpp:627
+#: ../src/osx/carbon/fontdlg.cpp:647
 msgid "<Any Modern>"
 msgstr "<Cualsiquier Moderno>"
 
-#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:626
-#: ../src/osx/carbon/fontdlg.cpp:646
+#: ../src/osx/carbon/fontdlg.cpp:418 ../src/osx/carbon/fontdlg.cpp:623
+#: ../src/osx/carbon/fontdlg.cpp:643
 msgid "<Any Roman>"
 msgstr "<Cualsiquier Román>"
 
-#: ../src/osx/carbon/fontdlg.cpp:424 ../src/osx/carbon/fontdlg.cpp:632
-#: ../src/osx/carbon/fontdlg.cpp:652
+#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:629
+#: ../src/osx/carbon/fontdlg.cpp:649
 msgid "<Any Script>"
 msgstr "<Cualsiquier Script>"
 
-#: ../src/osx/carbon/fontdlg.cpp:425 ../src/osx/carbon/fontdlg.cpp:637
-#: ../src/osx/carbon/fontdlg.cpp:656
+#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:634
+#: ../src/osx/carbon/fontdlg.cpp:653
 msgid "<Any Swiss>"
 msgstr "<Cualsiquier Swiss>"
 
-#: ../src/osx/carbon/fontdlg.cpp:426 ../src/osx/carbon/fontdlg.cpp:634
-#: ../src/osx/carbon/fontdlg.cpp:654
+#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:631
+#: ../src/osx/carbon/fontdlg.cpp:651
 msgid "<Any Teletype>"
 msgstr "<Cualsiquier Teletipo>"
 
-#: ../src/osx/carbon/fontdlg.cpp:420
+#: ../src/osx/carbon/fontdlg.cpp:417
 msgid "<Any>"
 msgstr "<Cualsiquiera>"
 
-#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
 msgid "<DIR>"
 msgstr "<DIR>"
 
-#: ../src/generic/filectrlg.cpp:254 ../src/generic/filectrlg.cpp:277
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
 msgid "<DRIVE>"
 msgstr "<UNIDAT>"
 
-#: ../src/generic/filectrlg.cpp:252 ../src/generic/filectrlg.cpp:275
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
 msgid "<LINK>"
 msgstr "<VINCLO>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1264
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Negreta cursiva.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1270
+#: ../src/html/helpwnd.cpp:1268
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>negreta cursiva <u>subrayada</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1265
+#: ../src/html/helpwnd.cpp:1263
 msgid "<b>Bold face.</b> "
 msgstr "<b>Negreta.</b> "
 
-#: ../src/html/helpwnd.cpp:1264
+#: ../src/html/helpwnd.cpp:1262
 msgid "<i>Italic face.</i> "
 msgstr "<i>Cursiva.</i> "
 
@@ -1078,15 +1075,15 @@ msgstr "<i>Cursiva.</i> "
 msgid ">"
 msgstr ">"
 
-#: ../src/generic/dbgrptg.cpp:318
+#: ../src/generic/dbgrptg.cpp:317
 msgid "A debug report has been generated in the directory\n"
 msgstr "S'ha chenerau un reporte de depuración en o directorio\n"
 
-#: ../src/common/debugrpt.cpp:573
+#: ../src/common/debugrpt.cpp:574
 msgid "A debug report has been generated. It can be found in"
 msgstr "S'ha chenerau un reporte de depuración. Se puet trobar en"
 
-#: ../src/common/xtixml.cpp:418
+#: ../src/common/xtixml.cpp:414
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Una colección no vueda ha de consistir en nodos d'a clase 'elemento'"
 
@@ -1097,106 +1094,106 @@ msgstr "Una colección no vueda ha de consistir en nodos d'a clase 'elemento'"
 msgid "A standard bullet name."
 msgstr "Un nombre de vinyeta estandar."
 
-#: ../src/common/paper.cpp:217
+#: ../src/common/paper.cpp:214
 msgid "A0 sheet, 841 x 1189 mm"
 msgstr "Fuella A0, 841 x 1189 mm"
 
-#: ../src/common/paper.cpp:218
+#: ../src/common/paper.cpp:215
 msgid "A1 sheet, 594 x 841 mm"
 msgstr "Fuella A1, 594 x 841 mm"
 
-#: ../src/common/paper.cpp:159
+#: ../src/common/paper.cpp:156
 msgid "A2 420 x 594 mm"
 msgstr "A2 420 x 594 mm"
 
-#: ../src/common/paper.cpp:156
+#: ../src/common/paper.cpp:153
 msgid "A3 Extra 322 x 445 mm"
 msgstr "A3 Extra 322 x 445 mm"
 
-#: ../src/common/paper.cpp:161
+#: ../src/common/paper.cpp:158
 msgid "A3 Extra Transverse 322 x 445 mm"
 msgstr "A3 Extra Transversal 322 x 445 mm"
 
-#: ../src/common/paper.cpp:170
+#: ../src/common/paper.cpp:167
 msgid "A3 Rotated 420 x 297 mm"
 msgstr "A3 Chirada 420 x 297 mm"
 
-#: ../src/common/paper.cpp:160
+#: ../src/common/paper.cpp:157
 msgid "A3 Transverse 297 x 420 mm"
 msgstr "A3 Transversal 297 x 420 mm"
 
-#: ../src/common/paper.cpp:106
+#: ../src/common/paper.cpp:103
 msgid "A3 sheet, 297 x 420 mm"
 msgstr "Fuella A3, 297 x 420 mm"
 
-#: ../src/common/paper.cpp:146
+#: ../src/common/paper.cpp:143
 msgid "A4 Extra 9.27 x 12.69 in"
 msgstr "A4 Extra 9.27 x 12.69 in"
 
-#: ../src/common/paper.cpp:153
+#: ../src/common/paper.cpp:150
 msgid "A4 Plus 210 x 330 mm"
 msgstr "A4 Plus 210 x 330 mm"
 
-#: ../src/common/paper.cpp:171
+#: ../src/common/paper.cpp:168
 msgid "A4 Rotated 297 x 210 mm"
 msgstr "A4 Chirada 297 x 210 mm"
 
-#: ../src/common/paper.cpp:148
+#: ../src/common/paper.cpp:145
 msgid "A4 Transverse 210 x 297 mm"
 msgstr "A4 Transversal 210 x 297 mm"
 
-#: ../src/common/paper.cpp:97
+#: ../src/common/paper.cpp:94
 msgid "A4 sheet, 210 x 297 mm"
 msgstr "Fuella A4, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:107
+#: ../src/common/paper.cpp:104
 msgid "A4 small sheet, 210 x 297 mm"
 msgstr "Fuella chicota A4, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:157
+#: ../src/common/paper.cpp:154
 msgid "A5 Extra 174 x 235 mm"
 msgstr "A5 Extra 174 x 235 mm"
 
-#: ../src/common/paper.cpp:172
+#: ../src/common/paper.cpp:169
 msgid "A5 Rotated 210 x 148 mm"
 msgstr "A5 Chirada 210 x 148 mm"
 
-#: ../src/common/paper.cpp:154
+#: ../src/common/paper.cpp:151
 msgid "A5 Transverse 148 x 210 mm"
 msgstr "A5 Transversal 148 x 210 mm"
 
-#: ../src/common/paper.cpp:108
+#: ../src/common/paper.cpp:105
 msgid "A5 sheet, 148 x 210 mm"
 msgstr "Fuella A5, 148 x 210 mm"
 
-#: ../src/common/paper.cpp:164
+#: ../src/common/paper.cpp:161
 msgid "A6 105 x 148 mm"
 msgstr "A6 105 x 148 mm"
 
-#: ../src/common/paper.cpp:177
+#: ../src/common/paper.cpp:174
 msgid "A6 Rotated 148 x 105 mm"
 msgstr "A6 Chirada 148 x 105 mm"
 
-#: ../src/generic/fontdlgg.cpp:83 ../src/richtext/richtextformatdlg.cpp:529
-#: ../src/osx/carbon/fontdlg.cpp:153
+#: ../src/osx/carbon/fontdlg.cpp:150 ../src/generic/fontdlgg.cpp:79
+#: ../src/richtext/richtextformatdlg.cpp:521
 msgid "ABCDEFGabcdefg12345"
 msgstr "ABCDEFGabcdefg12345"
 
-#: ../src/richtext/richtextsymboldlg.cpp:458 ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
 msgid "ASCII"
 msgstr "ASCII"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "About"
 msgstr "Arredol de"
 
-#: ../src/generic/aboutdlgg.cpp:140 ../src/osx/menu_osx.cpp:558
-#: ../src/msw/aboutdlg.cpp:64
+#: ../src/osx/menu_osx.cpp:450 ../src/generic/aboutdlgg.cpp:137
+#: ../src/msw/aboutdlg.cpp:61
 #, c-format
 msgid "About %s"
 msgstr "Arredol de %s"
 
-#: ../src/osx/menu_osx.cpp:560
+#: ../src/osx/menu_osx.cpp:452
 msgid "About..."
 msgstr "Arredol de..."
 
@@ -1205,38 +1202,38 @@ msgid "Absolute"
 msgstr "Absoluto"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:873
+#: ../src/propgrid/advprops.cpp:774
 #, fuzzy
 msgid "ActiveBorder"
 msgstr "Canto"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:874
+#: ../src/propgrid/advprops.cpp:775
 msgid "ActiveCaption"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "Actual Size"
 msgstr "Grandaria real"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:140 ../src/common/accelcmn.cpp:81
+#: ../src/common/stockitem.cpp:137 ../src/common/accelcmn.cpp:78
 msgid "Add"
 msgstr "Adhibir"
 
-#: ../src/richtext/richtextbuffer.cpp:11455
+#: ../src/richtext/richtextbuffer.cpp:11454
 msgid "Add Column"
 msgstr "Adhibir unacolumna"
 
-#: ../src/richtext/richtextbuffer.cpp:11392
+#: ../src/richtext/richtextbuffer.cpp:11391
 msgid "Add Row"
 msgstr "Adhibir una ringlera"
 
-#: ../src/html/helpwnd.cpp:432
+#: ../src/html/helpwnd.cpp:430
 msgid "Add current page to bookmarks"
 msgstr "Adhibir a pachina actual a los marcapachinas"
 
-#: ../src/generic/colrdlgg.cpp:366
+#: ../src/generic/colrdlgg.cpp:386
 msgid "Add to custom colours"
 msgstr "Adhibir a las colors personalizadas"
 
@@ -1248,12 +1245,12 @@ msgstr "S'ha clamau a AddToPropertyCollection sobre un accedente chenerico"
 msgid "AddToPropertyCollection called w/o valid adder"
 msgstr "S'ha clamau a AddToPropertyCollection sin un adhibidor valiu"
 
-#: ../src/html/helpctrl.cpp:159
+#: ../src/html/helpctrl.cpp:155
 #, c-format
 msgid "Adding book %s"
 msgstr "Adhibindo lo libro %s"
 
-#: ../src/common/preferencescmn.cpp:43
+#: ../src/common/preferencescmn.cpp:40
 msgid "Advanced"
 msgstr "Abanzau"
 
@@ -1261,11 +1258,11 @@ msgstr "Abanzau"
 msgid "After a paragraph:"
 msgstr "Dimpués d'un paragrafo:"
 
-#: ../src/common/stockitem.cpp:172
+#: ../src/common/stockitem.cpp:169
 msgid "Align Left"
 msgstr "Aliniar a la cucha"
 
-#: ../src/common/stockitem.cpp:173
+#: ../src/common/stockitem.cpp:170
 msgid "Align Right"
 msgstr "Aliniar a la dreita"
 
@@ -1273,40 +1270,40 @@ msgstr "Aliniar a la dreita"
 msgid "Alignment"
 msgstr "Aliniación"
 
-#: ../src/generic/prntdlgg.cpp:215
+#: ../src/generic/prntdlgg.cpp:208
 msgid "All"
 msgstr "Tot"
 
-#: ../src/generic/filectrlg.cpp:1197 ../src/common/fldlgcmn.cpp:107
+#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1186
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Totz os fichers (%s)|%s"
 
-#: ../include/wx/defs.h:2886
+#: ../include/wx/defs.h:2582
 msgid "All files (*)|*"
 msgstr "Totz os fichers (*)|*"
 
-#: ../include/wx/defs.h:2883
+#: ../include/wx/defs.h:2579
 msgid "All files (*.*)|*.*"
 msgstr "Totz os fichers (*.*)|*"
 
-#: ../src/richtext/richtextstyles.cpp:1061
+#: ../src/richtext/richtextstyles.cpp:1058
 msgid "All styles"
 msgstr "Totz os estilos"
 
-#: ../src/propgrid/manager.cpp:1528
+#: ../src/propgrid/manager.cpp:1544
 msgid "Alphabetic Mode"
 msgstr "Modo alfabetico"
 
-#: ../src/common/xtistrm.cpp:425
+#: ../src/common/xtistrm.cpp:422
 msgid "Already Registered Object passed to SetObjectClassInfo"
 msgstr "S'ha pasau un Obchecto Ya Rechistrau a SetObjectClassInfo"
 
-#: ../src/unix/dialup.cpp:353
+#: ../src/unix/dialup.cpp:352
 msgid "Already dialling ISP."
 msgstr "Ya se ye gritando a l'ISP."
 
-#: ../src/common/accelcmn.cpp:331 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/accelcmn.cpp:345 ../src/univ/themes/win32.cpp:3753
 msgid "Alt+"
 msgstr "Alt+"
 
@@ -1315,36 +1312,36 @@ msgstr "Alt+"
 msgid "An optional corner radius for adding rounded corners."
 msgstr "Un radio de cantonada opcional ta adhibir cantonadas redondiadas."
 
-#: ../src/common/debugrpt.cpp:576
+#: ../src/common/debugrpt.cpp:577
 msgid "And includes the following files:\n"
 msgstr "Y incluye os siguients fichers:\n"
 
-#: ../src/generic/animateg.cpp:162
+#: ../src/generic/animateg.cpp:145
 #, c-format
 msgid "Animation file is not of type %ld."
 msgstr "O fichero d'animación no ye de tipo %ld."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:872
+#: ../src/propgrid/advprops.cpp:773
 msgid "AppWorkspace"
 msgstr ""
 
-#: ../src/generic/logg.cpp:1014
+#: ../src/generic/logg.cpp:1011
 #, c-format
 msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
 msgstr ""
 "Adhibir o rechistro a lo fichero '%s'? (si triga [No] se sobrescribirá o "
 "fichero)"
 
-#: ../src/osx/menu_osx.cpp:577 ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:469 ../src/osx/menu_osx.cpp:477
 msgid "Application"
 msgstr "Aplicación"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "Apply"
 msgstr "Aplicar"
 
-#: ../src/propgrid/advprops.cpp:1609
+#: ../src/propgrid/advprops.cpp:1515
 msgid "Aqua"
 msgstr ""
 
@@ -1353,30 +1350,30 @@ msgstr ""
 msgid "Arabic"
 msgstr "Arabe"
 
-#: ../src/common/fmapbase.cpp:153
+#: ../src/common/fmapbase.cpp:150
 msgid "Arabic (ISO-8859-6)"
 msgstr "Arabe (ISO-8859-6)"
 
-#: ../src/msw/ole/automtn.cpp:672
+#: ../src/msw/ole/automtn.cpp:663
 #, c-format
 msgid "Argument %u not found."
 msgstr "No s'ha trobau l'argumento %u."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1753
+#: ../src/propgrid/advprops.cpp:1654
 #, fuzzy
 msgid "Arrow"
 msgstr "maitín"
 
-#: ../src/generic/aboutdlgg.cpp:184
+#: ../src/generic/aboutdlgg.cpp:181
 msgid "Artists"
 msgstr "Artistas"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "Ascending"
 msgstr "Ascendent"
 
-#: ../src/generic/filectrlg.cpp:433
+#: ../src/generic/filectrlg.cpp:429
 msgid "Attributes"
 msgstr "Atributos"
 
@@ -1386,90 +1383,90 @@ msgstr "Atributos"
 msgid "Available fonts."
 msgstr "Fuents disponibles."
 
-#: ../src/common/paper.cpp:137
+#: ../src/common/paper.cpp:134
 msgid "B4 (ISO) 250 x 353 mm"
 msgstr "B4 (ISO) 250 x 353 mm"
 
-#: ../src/common/paper.cpp:173
+#: ../src/common/paper.cpp:170
 msgid "B4 (JIS) Rotated 364 x 257 mm"
 msgstr "B4 (JIS) Chirada 364 x 257 mm"
 
-#: ../src/common/paper.cpp:127
+#: ../src/common/paper.cpp:124
 msgid "B4 Envelope, 250 x 353 mm"
 msgstr "Sobre B4, 250 x 353 mm"
 
-#: ../src/common/paper.cpp:109
+#: ../src/common/paper.cpp:106
 msgid "B4 sheet, 250 x 354 mm"
 msgstr "Fuella B4, 250 x 354 mm"
 
-#: ../src/common/paper.cpp:158
+#: ../src/common/paper.cpp:155
 msgid "B5 (ISO) Extra 201 x 276 mm"
 msgstr "B5 (ISO) Extra 201 x 276 mm"
 
-#: ../src/common/paper.cpp:174
+#: ../src/common/paper.cpp:171
 msgid "B5 (JIS) Rotated 257 x 182 mm"
 msgstr "B5 (JIS) Chirada 257 x 182 mm"
 
-#: ../src/common/paper.cpp:155
+#: ../src/common/paper.cpp:152
 msgid "B5 (JIS) Transverse 182 x 257 mm"
 msgstr "B5 (JIS) Transversal 182 x 257 mm"
 
-#: ../src/common/paper.cpp:128
+#: ../src/common/paper.cpp:125
 msgid "B5 Envelope, 176 x 250 mm"
 msgstr "Sobre B5, 176 x 250 mm"
 
-#: ../src/common/paper.cpp:110
+#: ../src/common/paper.cpp:107
 msgid "B5 sheet, 182 x 257 millimeter"
 msgstr "Fuella B5, 182 x 257 mm"
 
-#: ../src/common/paper.cpp:182
+#: ../src/common/paper.cpp:179
 msgid "B6 (JIS) 128 x 182 mm"
 msgstr "B6 (JIS) 128 x 182 mm"
 
-#: ../src/common/paper.cpp:183
+#: ../src/common/paper.cpp:180
 msgid "B6 (JIS) Rotated 182 x 128 mm"
 msgstr "B6 (JIS) Chirada 182 x 128 mm"
 
-#: ../src/common/paper.cpp:129
+#: ../src/common/paper.cpp:126
 msgid "B6 Envelope, 176 x 125 mm"
 msgstr "Sobre B6, 176 x 125 mm"
 
-#: ../src/common/imagbmp.cpp:531 ../src/common/imagbmp.cpp:561
-#: ../src/common/imagbmp.cpp:576
+#: ../src/common/imagbmp.cpp:528 ../src/common/imagbmp.cpp:558
+#: ../src/common/imagbmp.cpp:573
 msgid "BMP: Couldn't allocate memory."
 msgstr "BMP: No s'ha puesto reservar memoria."
 
-#: ../src/common/imagbmp.cpp:100
+#: ../src/common/imagbmp.cpp:97
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: No s'ha puesto alzar a imachen no valida."
 
-#: ../src/common/imagbmp.cpp:356
+#: ../src/common/imagbmp.cpp:353
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: No s'ha puesto escribir o mapa de color RGB."
 
-#: ../src/common/imagbmp.cpp:490
+#: ../src/common/imagbmp.cpp:487
 msgid "BMP: Couldn't write data."
 msgstr "BMP: No s'han puesto escribir datos."
 
-#: ../src/common/imagbmp.cpp:246
+#: ../src/common/imagbmp.cpp:243
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: No s'ha puesto escribir o capitero (Bitmap) d'o fichero."
 
-#: ../src/common/imagbmp.cpp:269
+#: ../src/common/imagbmp.cpp:266
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: No s'ha puesto escribir o capitero (BitmapInfo) d'o fichero."
 
-#: ../src/common/imagbmp.cpp:140
+#: ../src/common/imagbmp.cpp:137
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage no tien a suya propia wxPalette."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:142 ../src/common/accelcmn.cpp:52
+#: ../src/common/stockitem.cpp:139 ../src/common/accelcmn.cpp:49
 msgid "Back"
 msgstr "Dezaga"
 
+#: ../src/richtext/richtextformatdlg.cpp:377
 #: ../src/richtext/richtextbackgroundpage.cpp:148
-#: ../src/richtext/richtextformatdlg.cpp:384
 msgid "Background"
 msgstr "Fondo"
 
@@ -1477,21 +1474,21 @@ msgstr "Fondo"
 msgid "Background &colour:"
 msgstr "&Color de fondo:"
 
-#: ../src/osx/carbon/fontdlg.cpp:220
+#: ../src/osx/carbon/fontdlg.cpp:217
 msgid "Background colour"
 msgstr "Color de fondo"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:52
+#: ../src/common/accelcmn.cpp:49
 #, fuzzy
 msgid "Backspace"
 msgstr "Dezaga"
 
-#: ../src/common/fmapbase.cpp:160
+#: ../src/common/fmapbase.cpp:157
 msgid "Baltic (ISO-8859-13)"
 msgstr "Baltico (ISO-8859-13)"
 
-#: ../src/common/fmapbase.cpp:151
+#: ../src/common/fmapbase.cpp:148
 msgid "Baltic (old) (ISO-8859-4)"
 msgstr "Baltico (antigo) (ISO-8859-4)"
 
@@ -1504,25 +1501,25 @@ msgstr "Antis d'un paragrafo:"
 msgid "Bitmap"
 msgstr "Mapa de bits"
 
-#: ../src/propgrid/advprops.cpp:1594
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Black"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1755
+#: ../src/propgrid/advprops.cpp:1656
 msgid "Blank"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1603
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Blue"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:345
+#: ../src/generic/colrdlgg.cpp:365
 msgid "Blue:"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:333 ../src/richtext/richtextfontpage.cpp:355
-#: ../src/osx/carbon/fontdlg.cpp:354 ../src/common/stockitem.cpp:143
+#: ../src/osx/carbon/fontdlg.cpp:351 ../src/common/stockitem.cpp:140
+#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:355
 msgid "Bold"
 msgstr "Negreta"
 
@@ -1531,32 +1528,36 @@ msgstr "Negreta"
 msgid "Border"
 msgstr "Canto"
 
-#: ../src/richtext/richtextformatdlg.cpp:379
+#: ../src/richtext/richtextformatdlg.cpp:372
 msgid "Borders"
 msgstr "Cantos"
 
-#: ../src/richtext/richtextsizepage.cpp:288 ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141 ../src/richtext/richtextsizepage.cpp:288
 msgid "Bottom"
 msgstr "Inferior"
 
-#: ../src/generic/prntdlgg.cpp:893
+#: ../src/generic/prntdlgg.cpp:886
 msgid "Bottom margin (mm):"
 msgstr "Marguin inferior (mm):"
 
-#: ../src/richtext/richtextbuffer.cpp:9383
+#: ../src/richtext/richtextbuffer.cpp:9380
 msgid "Box Properties"
 msgstr "Propiedatz d'a caixa"
 
-#: ../src/richtext/richtextstyles.cpp:1065
+#: ../src/richtext/richtextstyles.cpp:1062
 msgid "Box styles"
 msgstr "Estilos de caixa"
 
-#: ../src/propgrid/advprops.cpp:1602
+#: ../src/osx/cocoa/menu.mm:292
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1508
 #, fuzzy
 msgid "Brown"
 msgstr "Examinar"
 
-#: ../src/common/filepickercmn.cpp:43 ../src/common/filepickercmn.cpp:44
+#: ../src/common/filepickercmn.cpp:40 ../src/common/filepickercmn.cpp:41
 msgid "Browse"
 msgstr "Examinar"
 
@@ -1569,73 +1570,73 @@ msgstr "&Aliniación de vinyeta:"
 msgid "Bullet style"
 msgstr "Estilo de vinyeta"
 
-#: ../src/richtext/richtextformatdlg.cpp:359
+#: ../src/richtext/richtextformatdlg.cpp:352
 msgid "Bullets"
 msgstr "Vinyetas"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1756
+#: ../src/propgrid/advprops.cpp:1657
 #, fuzzy
 msgid "Bullseye"
 msgstr "Estilo de vinyeta"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:875
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonFace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:876
+#: ../src/propgrid/advprops.cpp:777
 msgid "ButtonHighlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:877
+#: ../src/propgrid/advprops.cpp:778
 msgid "ButtonShadow"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:878
+#: ../src/propgrid/advprops.cpp:779
 msgid "ButtonText"
 msgstr ""
 
-#: ../src/common/paper.cpp:98
+#: ../src/common/paper.cpp:95
 msgid "C sheet, 17 x 22 in"
 msgstr "Fuella C, 17 x 22 in"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "C&lear"
 msgstr "&Limpiar"
 
-#: ../src/generic/fontdlgg.cpp:406
+#: ../src/generic/fontdlgg.cpp:403
 msgid "C&olour:"
 msgstr "C&olor:"
 
-#: ../src/common/paper.cpp:123
+#: ../src/common/paper.cpp:120
 msgid "C3 Envelope, 324 x 458 mm"
 msgstr "Sobre C3, 324 x 458 mm"
 
-#: ../src/common/paper.cpp:124
+#: ../src/common/paper.cpp:121
 msgid "C4 Envelope, 229 x 324 mm"
 msgstr "Sobre C4, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:122
+#: ../src/common/paper.cpp:119
 msgid "C5 Envelope, 162 x 229 mm"
 msgstr "Sobre C5, 162 x 229 mm"
 
-#: ../src/common/paper.cpp:125
+#: ../src/common/paper.cpp:122
 msgid "C6 Envelope, 114 x 162 mm"
 msgstr "Sobre C6, 114 x 162 mm"
 
-#: ../src/common/paper.cpp:126
+#: ../src/common/paper.cpp:123
 msgid "C65 Envelope, 114 x 229 mm"
 msgstr "Sobre C65, 114 x 229 mm"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "CD-Rom"
 msgstr "CD-Rom"
 
-#: ../src/html/chm.cpp:815 ../src/html/chm.cpp:874
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:865
 msgid "CHM handler currently supports only local files!"
 msgstr "O maniador CHM actualment nomás permite fichers locals!"
 
@@ -1643,196 +1644,200 @@ msgstr "O maniador CHM actualment nomás permite fichers locals!"
 msgid "Ca&pitals"
 msgstr "&Mayusclas"
 
-#: ../src/common/cmdproc.cpp:267
+#: ../src/common/cmdproc.cpp:260
 msgid "Can't &Undo "
 msgstr "No se puet desfer "
 
-#: ../src/common/image.cpp:2824
+#: ../src/common/image.cpp:2924
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 "No se puet determinar automaticament o formato d'a imachen a causa d'una "
 "dentrada no localizable."
 
-#: ../src/msw/registry.cpp:506
+#: ../src/msw/registry.cpp:495
 #, c-format
 msgid "Can't close registry key '%s'"
 msgstr "No se puet zarrar a clau d'o rechistro '%s'"
 
-#: ../src/msw/registry.cpp:584
+#: ../src/msw/registry.cpp:573
 #, c-format
 msgid "Can't copy values of unsupported type %d."
 msgstr "No se pueden copiar valuras d'un tipo no suportau %d."
 
-#: ../src/msw/registry.cpp:487
+#: ../src/msw/registry.cpp:476
 #, c-format
 msgid "Can't create registry key '%s'"
 msgstr "No se puet creyar a clau d'o rechistro '%s'"
 
-#: ../src/msw/thread.cpp:665
+#: ../src/msw/thread.cpp:657
 msgid "Can't create thread"
 msgstr "No se puet creyar o filo d'execución"
 
-#: ../src/msw/window.cpp:3691
-#, c-format
-msgid "Can't create window of class %s"
-msgstr "No se puet creyar a finestra de clase %s"
-
-#: ../src/msw/registry.cpp:777
+#: ../src/msw/registry.cpp:765
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "No se puet eliminar a clau '%s'"
 
-#: ../src/msw/iniconf.cpp:458
+#: ../src/msw/iniconf.cpp:455
 #, c-format
 msgid "Can't delete the INI file '%s'"
 msgstr "No se puet elimininar o fichero INI '%s'"
 
-#: ../src/msw/registry.cpp:805
+#: ../src/msw/registry.cpp:793
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "No se puet eliminar a valor '%s' d'a clau '%s'"
 
-#: ../src/msw/registry.cpp:1171
+#: ../src/msw/registry.cpp:1159
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "No se pueden enumerar as subclaus d'a clau '%s'"
 
-#: ../src/msw/registry.cpp:1132
+#: ../src/msw/registry.cpp:1120
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "No se pueden enumerar as valors d'a clau '%s'"
 
-#: ../src/msw/registry.cpp:1389
+#: ../src/msw/registry.cpp:1377
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "No se puet exportar una valura d'un tipo no suportau %d."
 
-#: ../src/common/ffile.cpp:254
+#: ../src/common/ffile.cpp:253
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "No se puet trobar a posición actual en o fichero '%s'"
 
-#: ../src/msw/registry.cpp:418
+#: ../src/msw/registry.cpp:407
 #, c-format
 msgid "Can't get info about registry key '%s'"
 msgstr "No s'ha puesto obtener información d'a clau d'o rechistro '%s'"
 
-#: ../src/common/zstream.cpp:346
+#: ../src/msw/webview_ie.cpp:1024
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "No se puet establir a prioridat d'o filo d'execución"
+
+#: ../src/common/zstream.cpp:343
 msgid "Can't initialize zlib deflate stream."
 msgstr "No se puet inicializar o fluxo de compresión de zlib."
 
-#: ../src/common/zstream.cpp:185
+#: ../src/common/zstream.cpp:182
 msgid "Can't initialize zlib inflate stream."
 msgstr "No se puet inicializar o fluxo de descompresión de zlib."
 
-#: ../src/msw/fswatcher.cpp:476
+#: ../src/msw/fswatcher.cpp:475
 #, c-format
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "No se pueden monitorizar os cambeos d'o directorio no existent \"%s\"."
 
-#: ../src/msw/registry.cpp:454
+#: ../src/msw/registry.cpp:443
 #, c-format
 msgid "Can't open registry key '%s'"
 msgstr "No se puet ubrir a clau d'o rechistro '%s'"
 
-#: ../src/common/zstream.cpp:252
+#: ../src/common/zstream.cpp:249
 #, c-format
 msgid "Can't read from inflate stream: %s"
 msgstr "No se puet leyer dende o fluxo de descompresión %s"
 
-#: ../src/common/zstream.cpp:244
+#: ../src/common/zstream.cpp:241
 msgid "Can't read inflate stream: unexpected EOF in underlying stream."
 msgstr ""
 "Ye imposible leyer o fluxo de descompresión: Fin de fichero inasperau en o "
 "fluxo subchacent."
 
-#: ../src/msw/registry.cpp:1064
+#: ../src/msw/registry.cpp:1052
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "No se puet leyer a valor de '%s'"
 
-#: ../src/msw/registry.cpp:878 ../src/msw/registry.cpp:910
-#: ../src/msw/registry.cpp:975
+#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
+#: ../src/msw/registry.cpp:963
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "No se puet leyer a valor d'a clau '%s'"
 
-#: ../src/common/image.cpp:2620
+#: ../src/msw/webview_ie.cpp:1017
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/common/image.cpp:2715
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr ""
 "No se puet alzar a imachen en o fichero '%s': a extensión ye desconoixida."
 
-#: ../src/generic/logg.cpp:573 ../src/generic/logg.cpp:976
+#: ../src/generic/logg.cpp:570 ../src/generic/logg.cpp:973
 msgid "Can't save log contents to file."
 msgstr "No se pueden alzar os contenius d'o rechistro en un fichero."
 
-#: ../src/msw/thread.cpp:629
+#: ../src/msw/thread.cpp:621
 msgid "Can't set thread priority"
 msgstr "No se puet establir a prioridat d'o filo d'execución"
 
-#: ../src/msw/registry.cpp:896 ../src/msw/registry.cpp:938
-#: ../src/msw/registry.cpp:1081
+#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
+#: ../src/msw/registry.cpp:1069
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "No se puet establir a valor de '%s'"
 
-#: ../src/unix/utilsunx.cpp:351
+#: ../src/unix/utilsunx.cpp:353
 msgid "Can't write to child process's stdin"
 msgstr "No se puet escribir en a dentrada estandar d'o proceso fillo"
 
-#: ../src/common/zstream.cpp:427
+#: ../src/common/zstream.cpp:424
 #, c-format
 msgid "Can't write to deflate stream: %s"
 msgstr "No se puet escribir en o fluxo de compresión %s"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:279 ../src/richtext/richtextstyledlg.cpp:300
-#: ../src/common/stockitem.cpp:145 ../src/common/accelcmn.cpp:71
-#: ../src/msw/msgdlg.cpp:454 ../src/msw/progdlg.cpp:673
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:142
+#: ../src/common/accelcmn.cpp:68 ../src/motif/msgdlg.cpp:196
+#: ../src/gtk1/fontdlg.cpp:144 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/progdlg.cpp:940 ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: ../src/common/filefn.cpp:1261
+#: ../src/common/filefn.cpp:1149
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "No se pueden enumerar os fichers '%s'"
 
-#: ../src/msw/dir.cpp:263
+#: ../src/msw/dir.cpp:260
 #, c-format
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "No se pueden enumerar os fichers en a carpeta '%s'"
 
-#: ../src/msw/dialup.cpp:523
+#: ../src/msw/dialup.cpp:517
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "No se puet trobar a connexión activa: %s"
 
-#: ../src/msw/dialup.cpp:827
+#: ../src/msw/dialup.cpp:821
 msgid "Cannot find the location of address book file"
 msgstr "No se puet trobar o fichero de libreta d'adrezas"
 
-#: ../src/msw/ole/automtn.cpp:562
+#: ../src/msw/ole/automtn.cpp:553
 #, c-format
 msgid "Cannot get an active instance of \"%s\""
 msgstr "No se puet obtener una instancia activa de \"%s\""
 
-#: ../src/unix/threadpsx.cpp:1035
+#: ../src/unix/threadpsx.cpp:1053
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr ""
 "No se puet obtener un rango de prioridatz ta la politica de planificación %d."
 
-#: ../src/unix/utilsunx.cpp:987
+#: ../src/unix/utilsunx.cpp:989
 msgid "Cannot get the hostname"
 msgstr "No se puet obtener o nombre d'a maquina"
 
-#: ../src/unix/utilsunx.cpp:1023
+#: ../src/unix/utilsunx.cpp:1025
 msgid "Cannot get the official hostname"
 msgstr "No se puet obtener o nombre oficial d'a maquina"
 
-#: ../src/msw/dialup.cpp:928
+#: ../src/msw/dialup.cpp:922
 msgid "Cannot hang up - no active dialup connection."
 msgstr "No se puet penchar - no bi ha connexions activas."
 
@@ -1840,129 +1845,129 @@ msgstr "No se puet penchar - no bi ha connexions activas."
 msgid "Cannot initialize OLE"
 msgstr "No se puet inicializar l'OLE"
 
-#: ../src/common/socket.cpp:853
+#: ../src/common/socket.cpp:850
 msgid "Cannot initialize sockets"
 msgstr "No se pueden inicializar os zocalos"
 
-#: ../src/msw/volume.cpp:619
+#: ../src/msw/volume.cpp:627
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "No se puet cargar l'icono de '%s'."
 
-#: ../src/xrc/xmlres.cpp:360
+#: ../src/xrc/xmlres.cpp:358
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "No se pueden cargar recursos dende '%s'."
 
-#: ../src/xrc/xmlres.cpp:742
+#: ../src/xrc/xmlres.cpp:740
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "No se pueden cargar os recursos dende o fichero '%s'."
 
-#: ../src/html/htmlfilt.cpp:137
+#: ../src/html/htmlfilt.cpp:134
 #, c-format
 msgid "Cannot open HTML document: %s"
 msgstr "No se puet ubrir o documento HTML: %s"
 
-#: ../src/html/helpdata.cpp:667
+#: ../src/html/helpdata.cpp:660
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "No se puet ubrir o libro d'aduya HTML: %s"
 
-#: ../src/html/helpdata.cpp:299
+#: ../src/html/helpdata.cpp:296
 #, c-format
 msgid "Cannot open contents file: %s"
 msgstr "No se puet ubrir o fichero de contenius: %s"
 
-#: ../src/generic/dcpsg.cpp:1667
+#: ../src/generic/dcpsg.cpp:1665
 msgid "Cannot open file for PostScript printing!"
 msgstr "No se puet ubrir o fichero ta impresión PostScript!"
 
-#: ../src/html/helpdata.cpp:313
+#: ../src/html/helpdata.cpp:310
 #, c-format
 msgid "Cannot open index file: %s"
 msgstr "No se puet ubrir o fichero indiz: %s"
 
-#: ../src/xrc/xmlres.cpp:724
+#: ../src/xrc/xmlres.cpp:722
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "No se puet ubrir o fichero de recursos '%s'."
 
-#: ../src/html/helpwnd.cpp:1534
+#: ../src/html/helpwnd.cpp:1532
 msgid "Cannot print empty page."
 msgstr "No se puet imprentar una pachina vueda."
 
-#: ../src/msw/volume.cpp:507
+#: ../src/msw/volume.cpp:515
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "No se puet leyer o tipo dende '%s'!"
 
-#: ../src/msw/thread.cpp:888
+#: ../src/msw/thread.cpp:894
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "No se puet reprener o filo d'execución %lx"
 
-#: ../src/unix/threadpsx.cpp:1016
+#: ../src/unix/threadpsx.cpp:1028
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "No se puet recuperar a politica de planificación de filos d'execución."
 
-#: ../src/common/intl.cpp:558
+#: ../src/common/intl.cpp:365
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "No se puet establir a localización ta l'idioma \"%s\"."
 
-#: ../src/unix/threadpsx.cpp:831 ../src/msw/thread.cpp:546
+#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
 msgid "Cannot start thread: error writing TLS."
 msgstr ""
 "No se puet empecipiar o filo d'execución: S'ha produciu una error en "
 "escribir TLS."
 
-#: ../src/msw/thread.cpp:872
+#: ../src/msw/thread.cpp:864
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "No se puet suspender o filo d'execución %lx"
 
-#: ../src/msw/thread.cpp:794
+#: ../src/msw/thread.cpp:786
 msgid "Cannot wait for thread termination"
 msgstr "No se puet asperar a la finalización d'o filo d'execución"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:75
+#: ../src/common/accelcmn.cpp:72
 #, fuzzy
 msgid "Capital"
 msgstr "&Mayusclas"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:879
+#: ../src/propgrid/advprops.cpp:780
 msgid "CaptionText"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:531
 msgid "Case sensitive"
 msgstr "Sensible a las mayusclas y minusclas"
 
-#: ../src/propgrid/manager.cpp:1509
+#: ../src/propgrid/manager.cpp:1527
 msgid "Categorized Mode"
 msgstr "Modo categorizau"
 
-#: ../src/richtext/richtextbuffer.cpp:9968
+#: ../src/richtext/richtextbuffer.cpp:9965
 msgid "Cell Properties"
 msgstr "Propiedatz de celda"
 
-#: ../src/common/fmapbase.cpp:161
+#: ../src/common/fmapbase.cpp:158
 msgid "Celtic (ISO-8859-14)"
 msgstr "Celtico (ISO-8859-14)"
 
-#: ../src/richtext/richtextindentspage.cpp:160
 #: ../src/richtext/richtextliststylepage.cpp:349
+#: ../src/richtext/richtextindentspage.cpp:160
 msgid "Cen&tred"
 msgstr "Cen&trau"
 
-#: ../src/common/stockitem.cpp:170
+#: ../src/common/stockitem.cpp:167
 msgid "Centered"
 msgstr "Centrau"
 
-#: ../src/common/fmapbase.cpp:149
+#: ../src/common/fmapbase.cpp:146
 msgid "Central European (ISO-8859-2)"
 msgstr "Europa Central (ISO-8859-2)"
 
@@ -1971,10 +1976,10 @@ msgstr "Europa Central (ISO-8859-2)"
 msgid "Centre"
 msgstr "Centrar"
 
-#: ../src/richtext/richtextindentspage.cpp:162
-#: ../src/richtext/richtextindentspage.cpp:164
 #: ../src/richtext/richtextliststylepage.cpp:351
 #: ../src/richtext/richtextliststylepage.cpp:353
+#: ../src/richtext/richtextindentspage.cpp:162
+#: ../src/richtext/richtextindentspage.cpp:164
 msgid "Centre text."
 msgstr "Texto centrau."
 
@@ -1987,24 +1992,24 @@ msgstr "Centrau"
 msgid "Ch&oose..."
 msgstr "&Trigar..."
 
-#: ../src/richtext/richtextbuffer.cpp:4354
+#: ../src/richtext/richtextbuffer.cpp:4351
 msgid "Change List Style"
 msgstr "Cambiar o Estilo de Lista"
 
-#: ../src/richtext/richtextbuffer.cpp:3709
+#: ../src/richtext/richtextbuffer.cpp:3706
 msgid "Change Object Style"
 msgstr "Cambiar o estilo de l'obchecto"
 
-#: ../src/richtext/richtextbuffer.cpp:3982
-#: ../src/richtext/richtextbuffer.cpp:8129
+#: ../src/richtext/richtextbuffer.cpp:3979
+#: ../src/richtext/richtextbuffer.cpp:8125
 msgid "Change Properties"
 msgstr "Cambiar as propiedatz"
 
-#: ../src/richtext/richtextbuffer.cpp:3526
+#: ../src/richtext/richtextbuffer.cpp:3523
 msgid "Change Style"
 msgstr "Cambiar o Estilo"
 
-#: ../src/common/fileconf.cpp:341
+#: ../src/common/fileconf.cpp:335
 #, c-format
 msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
 msgstr ""
@@ -2016,12 +2021,12 @@ msgid "Changing current directory to \"%s\" failed"
 msgstr "S'ha produciu una error en creyar o directorio \"%s\""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1757
+#: ../src/propgrid/advprops.cpp:1658
 #, fuzzy
 msgid "Character"
 msgstr "&Codigo de caracter:"
 
-#: ../src/richtext/richtextstyles.cpp:1063
+#: ../src/richtext/richtextstyles.cpp:1060
 msgid "Character styles"
 msgstr "Estilos de caracter"
 
@@ -2058,20 +2063,20 @@ msgstr "Marcar ta enzarrar a vinyeta entre parentesi."
 msgid "Check to indicate right-to-left text layout."
 msgstr "Mirar d'indicar a distribución d'o texto de dreita ta cucha."
 
-#: ../src/osx/carbon/fontdlg.cpp:356 ../src/osx/carbon/fontdlg.cpp:358
+#: ../src/osx/carbon/fontdlg.cpp:353 ../src/osx/carbon/fontdlg.cpp:355
 msgid "Check to make the font bold."
 msgstr "Marcar ta fer negreta la fuent."
 
-#: ../src/osx/carbon/fontdlg.cpp:363 ../src/osx/carbon/fontdlg.cpp:365
+#: ../src/osx/carbon/fontdlg.cpp:360 ../src/osx/carbon/fontdlg.cpp:362
 msgid "Check to make the font italic."
 msgstr "Marcar ta fer cursiva la fuent."
 
-#: ../src/osx/carbon/fontdlg.cpp:372 ../src/osx/carbon/fontdlg.cpp:374
+#: ../src/osx/carbon/fontdlg.cpp:369 ../src/osx/carbon/fontdlg.cpp:371
 msgid "Check to make the font underlined."
 msgstr "Marcar ta fer subrayada a fuent."
 
-#: ../src/richtext/richtextstyledlg.cpp:289
-#: ../src/richtext/richtextstyledlg.cpp:291
+#: ../src/richtext/richtextstyledlg.cpp:285
+#: ../src/richtext/richtextstyledlg.cpp:287
 msgid "Check to restart numbering."
 msgstr "Marcar ta reiniciar a numeración."
 
@@ -2105,51 +2110,51 @@ msgstr "Prebar a amostrar o texto en superindiz."
 msgid "Check to suppress hyphenation."
 msgstr "Mirar d'eliminar as deseparacions de guions."
 
-#: ../src/msw/dialup.cpp:763
+#: ../src/msw/dialup.cpp:757
 msgid "Choose ISP to dial"
 msgstr "Trigar l'ISP a lo que connectar"
 
-#: ../src/propgrid/props.cpp:1922
+#: ../src/propgrid/props.cpp:1904
 msgid "Choose a directory:"
 msgstr "Triga un directorio:"
 
-#: ../src/propgrid/props.cpp:1975
+#: ../src/propgrid/props.cpp:2199
 msgid "Choose a file"
 msgstr "Triga un fichero"
 
-#: ../src/generic/colrdlgg.cpp:158 ../src/gtk/colordlg.cpp:54
+#: ../src/generic/colrdlgg.cpp:156 ../src/gtk/colordlg.cpp:49
 msgid "Choose colour"
 msgstr "Trigar a color"
 
-#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/gtk1/fontdlg.cpp:125 ../src/generic/fontpickerg.cpp:47
+#: ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Trigar a fuent"
 
-#: ../src/common/module.cpp:74
+#: ../src/common/module.cpp:71
 #, c-format
 msgid "Circular dependency involving module \"%s\" detected."
 msgstr "S'ha detectau una dependencia circular tocant a lo modulo \"%s\"."
 
-#: ../src/aui/tabmdi.cpp:108 ../src/generic/mdig.cpp:97
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
 msgid "Cl&ose"
 msgstr "&Zarrar"
 
-#: ../src/msw/ole/automtn.cpp:684
+#: ../src/msw/ole/automtn.cpp:675
 msgid "Class not registered."
 msgstr "&Clase no rechistrada."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:147 ../src/common/accelcmn.cpp:72
+#: ../src/common/stockitem.cpp:144 ../src/common/accelcmn.cpp:69
 msgid "Clear"
 msgstr "Limpiar"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "Clear the log contents"
 msgstr "Eliminar os contenius d'o rechistro"
 
-#: ../src/richtext/richtextstyledlg.cpp:252
-#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:248
+#: ../src/richtext/richtextstyledlg.cpp:250
 msgid "Click to apply the selected style."
 msgstr "Fe clic ta aplicar o estilo seleccionau."
 
@@ -2160,15 +2165,15 @@ msgstr "Fe clic ta aplicar o estilo seleccionau."
 msgid "Click to browse for a symbol."
 msgstr "Fe click ta mirar un simbolo."
 
-#: ../src/osx/carbon/fontdlg.cpp:403 ../src/osx/carbon/fontdlg.cpp:405
+#: ../src/osx/carbon/fontdlg.cpp:400 ../src/osx/carbon/fontdlg.cpp:402
 msgid "Click to cancel changes to the font."
 msgstr "Fe clic ta cancelar os cambeos en a fuent."
 
-#: ../src/generic/fontdlgg.cpp:472 ../src/generic/fontdlgg.cpp:491
+#: ../src/generic/fontdlgg.cpp:468 ../src/generic/fontdlgg.cpp:487
 msgid "Click to cancel the font selection."
 msgstr "Fe clic ta cancelar a selección de fuent."
 
-#: ../src/osx/carbon/fontdlg.cpp:384 ../src/osx/carbon/fontdlg.cpp:386
+#: ../src/osx/carbon/fontdlg.cpp:381 ../src/osx/carbon/fontdlg.cpp:383
 msgid "Click to change the font colour."
 msgstr "Fe clic ta cambiar a color d'a fuent."
 
@@ -2187,37 +2192,37 @@ msgstr "Fe clic ta cambiar a color d'o texto."
 msgid "Click to choose the font for this level."
 msgstr "Fe clic ta trigar a fuent ta iste libel."
 
-#: ../src/richtext/richtextstyledlg.cpp:279
-#: ../src/richtext/richtextstyledlg.cpp:281
+#: ../src/richtext/richtextstyledlg.cpp:275
+#: ../src/richtext/richtextstyledlg.cpp:277
 msgid "Click to close this window."
 msgstr "Fe clic ta zarrar ista finestra."
 
-#: ../src/osx/carbon/fontdlg.cpp:410 ../src/osx/carbon/fontdlg.cpp:412
+#: ../src/osx/carbon/fontdlg.cpp:407 ../src/osx/carbon/fontdlg.cpp:409
 msgid "Click to confirm changes to the font."
 msgstr "Fe clic ta confirmar os cambeos en a fuent."
 
-#: ../src/generic/fontdlgg.cpp:477 ../src/generic/fontdlgg.cpp:479
-#: ../src/generic/fontdlgg.cpp:484 ../src/generic/fontdlgg.cpp:486
+#: ../src/generic/fontdlgg.cpp:473 ../src/generic/fontdlgg.cpp:475
+#: ../src/generic/fontdlgg.cpp:480 ../src/generic/fontdlgg.cpp:482
 msgid "Click to confirm the font selection."
 msgstr "Fe clic ta confirmar a selección de fuent."
 
-#: ../src/richtext/richtextstyledlg.cpp:244
-#: ../src/richtext/richtextstyledlg.cpp:246
+#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:242
 msgid "Click to create a new box style."
 msgstr "Fe clic ta creyar un nuevo estilo de caixa."
 
-#: ../src/richtext/richtextstyledlg.cpp:226
-#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:224
 msgid "Click to create a new character style."
 msgstr "Fe click ta creyar un nuevo estilo de caracter."
 
-#: ../src/richtext/richtextstyledlg.cpp:238
-#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:236
 msgid "Click to create a new list style."
 msgstr "Fe clic ta creyar una nueva lista d'estilo."
 
-#: ../src/richtext/richtextstyledlg.cpp:232
-#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:230
 msgid "Click to create a new paragraph style."
 msgstr "Fe click ta creyar un nuevo estilo de paragrafo."
 
@@ -2231,8 +2236,8 @@ msgstr "Fe clic ta creyar una nueva posición de tabulador."
 msgid "Click to delete all tab positions."
 msgstr "Fe clic ta esborrar todas as posicions de tabulador."
 
-#: ../src/richtext/richtextstyledlg.cpp:270
-#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:268
 msgid "Click to delete the selected style."
 msgstr "Fe clic ta esborrar o estilo seleccionau."
 
@@ -2241,25 +2246,25 @@ msgstr "Fe clic ta esborrar o estilo seleccionau."
 msgid "Click to delete the selected tab position."
 msgstr "Fe clic ta esborrar a posición de tabulador seleccionada."
 
-#: ../src/richtext/richtextstyledlg.cpp:264
-#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:262
 msgid "Click to edit the selected style."
 msgstr "Fe clic ta editar o estilo seleccionau."
 
-#: ../src/richtext/richtextstyledlg.cpp:258
-#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:256
 msgid "Click to rename the selected style."
 msgstr "Fe clic ta renombrar o estilo seleccionau."
 
-#: ../src/generic/dbgrptg.cpp:97 ../src/generic/progdlgg.cpp:759
-#: ../src/richtext/richtextstyledlg.cpp:277
-#: ../src/richtext/richtextsymboldlg.cpp:476 ../src/common/stockitem.cpp:148
-#: ../src/msw/progdlg.cpp:170 ../src/msw/progdlg.cpp:679
-#: ../src/html/helpdlg.cpp:90
+#: ../src/common/stockitem.cpp:145 ../src/generic/dbgrptg.cpp:94
+#: ../src/generic/progdlgg.cpp:781 ../src/msw/progdlg.cpp:211
+#: ../src/msw/progdlg.cpp:946 ../src/html/helpdlg.cpp:87
+#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextstyledlg.cpp:273
 msgid "Close"
 msgstr "Zarrar"
 
-#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:98
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
 msgid "Close All"
 msgstr "Zarrar-lo Tot"
 
@@ -2267,43 +2272,43 @@ msgstr "Zarrar-lo Tot"
 msgid "Close current document"
 msgstr "Zarrar o documento actual"
 
-#: ../src/generic/logg.cpp:516
+#: ../src/generic/logg.cpp:513
 msgid "Close this window"
 msgstr "Zarrar ista finestra"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6006
+#: ../src/generic/datavgen.cpp:6811
 msgid "Collapse"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "Color"
 msgstr "Color"
 
-#: ../src/richtext/richtextformatdlg.cpp:776
+#: ../src/richtext/richtextformatdlg.cpp:768
 msgid "Colour"
 msgstr "Color"
 
-#: ../src/msw/colordlg.cpp:158
+#: ../src/msw/colordlg.cpp:227
 #, c-format
 msgid "Colour selection dialog failed with error %0lx."
 msgstr "O dialogo de selección de color ha fallau con a error %0lx."
 
-#: ../src/osx/carbon/fontdlg.cpp:380
+#: ../src/osx/carbon/fontdlg.cpp:377
 msgid "Colour:"
 msgstr "Color:"
 
-#: ../src/generic/datavgen.cpp:6077
+#: ../src/generic/datavgen.cpp:6882
 #, fuzzy, c-format
 msgid "Column %u"
 msgstr "Adhibir unacolumna"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:114
+#: ../src/common/accelcmn.cpp:112
 msgid "Command"
 msgstr ""
 
-#: ../src/common/init.cpp:196
+#: ../src/common/init.cpp:193
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
@@ -2312,12 +2317,12 @@ msgstr ""
 "No se puet convertir l'argumento %d d'a linia de comandos ta Unicode y será "
 "ignorau."
 
-#: ../src/msw/fontdlg.cpp:120
+#: ../src/msw/fontdlg.cpp:170
 #, c-format
 msgid "Common dialog failed with error code %0lx."
 msgstr "O dialogo común ha fallau con o codigo d'error %0lx."
 
-#: ../src/gtk/window.cpp:4649
+#: ../src/gtk/window.cpp:5653
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
@@ -2325,11 +2330,11 @@ msgstr ""
 "A composición no ye suportada por iste sistema, por favor activa-la en o "
 "tuyo administrador de finestras."
 
-#: ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:1549
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Fichero d'aduya HTML comprimiu (*.chm)|*.chm|"
 
-#: ../src/generic/dirctrlg.cpp:444
+#: ../src/generic/dirctrlg.cpp:410
 msgid "Computer"
 msgstr "Ordinador"
 
@@ -2338,53 +2343,57 @@ msgstr "Ordinador"
 msgid "Config entry name cannot start with '%c'."
 msgstr "Un nombre de dentrada de configuración no puet empecipiar por '%c'."
 
-#: ../src/generic/filedlgg.cpp:349 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
 msgid "Confirm"
 msgstr "Confirmar"
 
-#: ../src/html/htmlwin.cpp:566
+#: ../src/html/htmlwin.cpp:569
 msgid "Connecting..."
 msgstr "Connectando..."
 
-#: ../src/html/helpwnd.cpp:475
+#: ../src/html/helpwnd.cpp:473
 msgid "Contents"
 msgstr "Contenius"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:880
+#: ../src/propgrid/advprops.cpp:781
 msgid "ControlDark"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:881
+#: ../src/propgrid/advprops.cpp:782
 msgid "ControlLight"
 msgstr ""
 
-#: ../src/common/strconv.cpp:2262
+#: ../src/common/strconv.cpp:2208
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "A conversión t'o chuego de caracters '%s' no funciona."
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "Convert"
 msgstr "Convertir"
 
-#: ../src/html/htmlwin.cpp:1079
+#: ../src/html/htmlwin.cpp:1020
 #, c-format
 msgid "Copied to clipboard:\"%s\""
 msgstr "Copiau en o portafuellas:\"%s\""
 
-#: ../src/generic/prntdlgg.cpp:247
+#: ../src/generic/prntdlgg.cpp:240
 msgid "Copies:"
 msgstr "Copias:"
 
-#: ../src/common/stockitem.cpp:150 ../src/stc/stc_i18n.cpp:18
+#: ../src/common/stockitem.cpp:147 ../src/stc/stc_i18n.cpp:18
 msgid "Copy"
 msgstr "Copiar"
 
-#: ../src/common/stockitem.cpp:258
+#: ../src/common/stockitem.cpp:255
 msgid "Copy selection"
 msgstr "Copiar a selección"
+
+#: ../src/generic/grid.cpp:5945
+msgid "Copying more than one selected block to clipboard is not supported."
+msgstr ""
 
 #: ../src/richtext/richtextborderspage.cpp:566
 #: ../src/richtext/richtextborderspage.cpp:601
@@ -2395,200 +2404,196 @@ msgstr "Cantonada"
 msgid "Corner &radius:"
 msgstr "&Radio d'a cantonada"
 
-#: ../src/html/chm.cpp:718
+#: ../src/html/chm.cpp:711
 #, c-format
 msgid "Could not create temporary file '%s'"
 msgstr "No se puet creyar o fichero temporal '%s'"
 
-#: ../src/html/chm.cpp:273
+#: ../src/html/chm.cpp:270
 #, c-format
 msgid "Could not extract %s into %s: %s"
 msgstr "No s'ha puesto extrayer %s en %s: %s"
 
-#: ../src/generic/tabg.cpp:1048
+#: ../src/generic/tabg.cpp:1045
 msgid "Could not find tab for id"
 msgstr "No se puet trobar a pestanya pa l'identificador"
 
-#: ../src/gtk/notifmsg.cpp:108
-#, fuzzy
-msgid "Could not initalize libnotify."
-msgstr "No s'ha puesto establir l'aliniación."
-
-#: ../src/html/chm.cpp:444
+#: ../src/html/chm.cpp:437
 #, c-format
 msgid "Could not locate file '%s'."
 msgstr "No s'ha puesto trobar o fichero '%s'."
 
-#: ../src/common/filefn.cpp:1403
+#: ../src/msw/graphicsd2d.cpp:604
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/common/filefn.cpp:1291
 msgid "Could not set current working directory"
 msgstr "No s'ha puesto establir o directorio de treballo actual"
 
-#: ../src/common/prntbase.cpp:2015
+#: ../src/common/prntbase.cpp:2037
 msgid "Could not start document preview."
 msgstr "No se puet encetar l'anvista previa d'o documento."
 
-#: ../src/generic/printps.cpp:178 ../src/msw/printwin.cpp:210
-#: ../src/gtk/print.cpp:1132
+#: ../src/generic/printps.cpp:159 ../src/msw/printwin.cpp:184
+#: ../src/gtk/print.cpp:1129
 msgid "Could not start printing."
 msgstr "No se puet encetar a impresión."
 
-#: ../src/common/wincmn.cpp:2125
+#: ../src/common/wincmn.cpp:2126
 msgid "Could not transfer data to window"
 msgstr "No se pueden transferir datos ta la finestra"
 
-#: ../src/msw/imaglist.cpp:187 ../src/msw/imaglist.cpp:224
-#: ../src/msw/imaglist.cpp:249 ../src/msw/dragimag.cpp:185
-#: ../src/msw/dragimag.cpp:220
+#: ../src/msw/imaglist.cpp:223 ../src/msw/imaglist.cpp:245
+#: ../src/msw/imaglist.cpp:270 ../src/msw/dragimag.cpp:182
+#: ../src/msw/dragimag.cpp:217
 msgid "Couldn't add an image to the image list."
 msgstr "No se puet adhibir a imachen a la lista d'imachens."
 
-#: ../src/osx/glcanvas_osx.cpp:414 ../src/unix/glx11.cpp:558
-#: ../src/msw/glcanvas.cpp:616
+#: ../src/osx/glcanvas_osx.cpp:411 ../src/msw/glcanvas.cpp:631
+#: ../src/unix/glegl.cpp:315 ../src/unix/glx11.cpp:559
 #, fuzzy
 msgid "Couldn't create OpenGL context"
 msgstr "No se puet creyar un temporizador"
 
-#: ../src/msw/timer.cpp:134
+#: ../src/msw/timer.cpp:131
 msgid "Couldn't create a timer"
 msgstr "No se puet creyar un temporizador"
 
-#: ../src/osx/carbon/overlay.cpp:122
-msgid "Couldn't create the overlay window"
-msgstr "No s'ha puesto creyar a finestra de superposición"
-
-#: ../src/common/translation.cpp:2024
+#: ../src/common/translation.cpp:2074
 msgid "Couldn't enumerate translations"
 msgstr "No s'han puesto enumerar as traduccions"
 
-#: ../src/common/dynlib.cpp:120
+#: ../src/common/dynlib.cpp:110
 #, c-format
 msgid "Couldn't find symbol '%s' in a dynamic library"
 msgstr "No s'ha puesto trobar o simbolo '%s' en a librería dinamica"
 
-#: ../src/msw/thread.cpp:915
+#: ../src/msw/thread.cpp:921
 msgid "Couldn't get the current thread pointer"
 msgstr "No s'ha puesto obtener o puntero a lo filo d'execución actual"
 
-#: ../src/osx/carbon/overlay.cpp:129
-msgid "Couldn't init the context on the overlay window"
-msgstr "No s'ha puesto inicializar o contexto en a finestra de superposición"
-
-#: ../src/common/imaggif.cpp:244
+#: ../src/common/imaggif.cpp:241
 msgid "Couldn't initialize GIF hash table."
 msgstr "No s'ha puesto inicializar a tabla hash d'o GIF."
 
-#: ../src/common/imagpng.cpp:409
+#: ../src/common/imagpng.cpp:437
 msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
 msgstr ""
 "No s'ha puesto ubrir a imachen PNG - o fichero ye corrupto u no bi ha "
 "suficient memoria."
 
-#: ../src/unix/sound.cpp:470
+#: ../src/unix/sound.cpp:459
 #, c-format
 msgid "Couldn't load sound data from '%s'."
 msgstr "No s'han puesto cargar os datos de son dende '%s'."
 
-#: ../src/msw/dirdlg.cpp:435
+#: ../src/msw/dirdlg.cpp:287
 msgid "Couldn't obtain folder name"
 msgstr "No s'ha puesto obtener o nombre d'o directorio"
 
-#: ../src/unix/sound_sdl.cpp:229
+#: ../src/unix/sound_sdl.cpp:226
 #, c-format
 msgid "Couldn't open audio: %s"
 msgstr "No s'ha puesto ubrir l'audio: %s"
 
-#: ../src/msw/ole/dataobj.cpp:377
+#: ../src/msw/ole/dataobj.cpp:385
 #, c-format
 msgid "Couldn't register clipboard format '%s'."
 msgstr "No se puet rechistrar o formato de portafuellas '%s'."
 
-#: ../src/msw/listctrl.cpp:869
+#: ../src/msw/listctrl.cpp:933
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "No se puet recuperar información sobre l'elemento %d d'a lista."
 
-#: ../src/common/imagpng.cpp:498 ../src/common/imagpng.cpp:509
-#: ../src/common/imagpng.cpp:519
+#: ../src/common/imagpng.cpp:511 ../src/common/imagpng.cpp:522
+#: ../src/common/imagpng.cpp:532
 msgid "Couldn't save PNG image."
 msgstr "No se puet alzar a imachen PNG."
 
-#: ../src/msw/thread.cpp:684
+#: ../src/msw/thread.cpp:676
 msgid "Couldn't terminate thread"
 msgstr "No se puet rematar o filo d'execución"
 
-#: ../src/common/xtistrm.cpp:166
+#: ../src/common/xtistrm.cpp:163
 #, c-format
 msgid "Create Parameter %s not found in declared RTTI Parameters"
 msgstr ""
 "No s'ha trobau creyar parametro %s not found en os parametrosRTTI declaraus"
 
-#: ../src/generic/dirdlgg.cpp:288
+#: ../src/generic/dirdlgg.cpp:285
 msgid "Create directory"
 msgstr "Creyar un directorio"
 
-#: ../src/generic/filedlgg.cpp:212 ../src/generic/dirdlgg.cpp:111
+#: ../src/generic/filedlgg.cpp:209 ../src/generic/dirdlgg.cpp:108
 msgid "Create new directory"
 msgstr "Creyar un nuevo directorio"
 
-#: ../src/xrc/xmlres.cpp:2460
+#: ../src/common/stockitem.cpp:264
+#, fuzzy
+msgid "Create new document"
+msgstr "Creyar un nuevo directorio"
+
+#: ../src/xrc/xmlres.cpp:2515
 #, fuzzy, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Ha fallau a extracción de '%s' en '%s'."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1758
+#: ../src/propgrid/advprops.cpp:1659
 msgid "Cross"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:333
+#: ../src/common/accelcmn.cpp:347
 msgid "Ctrl+"
 msgstr "Ctrl+"
 
-#: ../src/richtext/richtextctrl.cpp:332 ../src/osx/textctrl_osx.cpp:576
-#: ../src/common/stockitem.cpp:151 ../src/msw/textctrl.cpp:2507
+#: ../src/osx/textctrl_osx.cpp:594 ../src/common/stockitem.cpp:148
+#: ../src/msw/textctrl.cpp:2772 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "&Tallar"
 
-#: ../src/generic/filectrlg.cpp:940
+#: ../src/generic/filectrlg.cpp:936
 msgid "Current directory:"
 msgstr "Directorio actual:"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:896 ../src/propgrid/advprops.cpp:1574
-#: ../src/propgrid/advprops.cpp:1612
+#: ../src/propgrid/advprops.cpp:797 ../src/propgrid/advprops.cpp:1475
+#: ../src/propgrid/advprops.cpp:1518
 #, fuzzy
 msgid "Custom"
 msgstr "Grandaria personalizada"
 
-#: ../src/gtk/print.cpp:217
+#: ../src/gtk/print.cpp:211
 msgid "Custom size"
 msgstr "Grandaria personalizada"
 
-#: ../src/common/headerctrlcmn.cpp:60
+#: ../src/common/headerctrlcmn.cpp:58
 msgid "Customize Columns"
 msgstr "Columnas personalizadas"
 
-#: ../src/common/stockitem.cpp:151 ../src/stc/stc_i18n.cpp:17
+#: ../src/common/stockitem.cpp:148 ../src/stc/stc_i18n.cpp:17
 msgid "Cut"
 msgstr "Tallar"
 
-#: ../src/common/stockitem.cpp:259
+#: ../src/common/stockitem.cpp:256
 msgid "Cut selection"
 msgstr "Tallar a selección"
 
-#: ../src/common/fmapbase.cpp:152
+#: ../src/common/fmapbase.cpp:149
 msgid "Cyrillic (ISO-8859-5)"
 msgstr "Cirilico (ISO-8859-5)"
 
-#: ../src/common/paper.cpp:99
+#: ../src/common/paper.cpp:96
 msgid "D sheet, 22 x 34 in"
 msgstr "Fuella D, 22 x 34 in"
 
-#: ../src/msw/dde.cpp:703
+#: ../src/msw/dde.cpp:698
 msgid "DDE poke request failed"
 msgstr "Ha fallau a petición de rastreo DDE"
 
-#: ../src/common/imagbmp.cpp:1169
+#: ../src/common/imagbmp.cpp:1181
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr "Capitero DIB: A codificación no coincide con a profundidat de bits."
 
@@ -2608,7 +2613,7 @@ msgstr "Capitero DIB: Profundidat de color desconoixida en o fichero."
 msgid "DIB Header: Unknown encoding in file."
 msgstr "Capitero DIB: Codificación desconoixida en o fichero."
 
-#: ../src/common/paper.cpp:121
+#: ../src/common/paper.cpp:118
 msgid "DL Envelope, 110 x 220 mm"
 msgstr "Sobre DL, 110 x 220 mm"
 
@@ -2616,55 +2621,55 @@ msgstr "Sobre DL, 110 x 220 mm"
 msgid "Dashed"
 msgstr "Discontina"
 
-#: ../src/generic/dbgrptg.cpp:300
+#: ../src/generic/dbgrptg.cpp:301
 #, c-format
 msgid "Debug report \"%s\""
 msgstr "Reporte de depuración \"%s\""
 
-#: ../src/common/debugrpt.cpp:210
+#: ../src/common/debugrpt.cpp:211
 msgid "Debug report couldn't be created."
 msgstr "No s'ha puesto creyar o reporte de depuración."
 
-#: ../src/common/debugrpt.cpp:553
+#: ../src/common/debugrpt.cpp:554
 msgid "Debug report generation has failed."
 msgstr "A cheneración de o reporte de depuración ha fallau."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:84
+#: ../src/common/accelcmn.cpp:81
 msgid "Decimal"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:323
+#: ../src/generic/fontdlgg.cpp:319
 msgid "Decorative"
 msgstr "Decorativo"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1752
+#: ../src/propgrid/advprops.cpp:1653
 #, fuzzy
 msgid "Default"
 msgstr "predeterminau"
 
-#: ../src/common/fmapbase.cpp:796
+#: ../src/common/fmapbase.cpp:792
 msgid "Default encoding"
 msgstr "Codificación predeterminada"
 
-#: ../src/dfb/fontmgr.cpp:180
+#: ../src/dfb/fontmgr.cpp:177
 msgid "Default font"
 msgstr "Fuent predeterminada"
 
-#: ../src/generic/prntdlgg.cpp:510
+#: ../src/generic/prntdlgg.cpp:503
 msgid "Default printer"
 msgstr "Impresora predeterminada"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:51
+#: ../src/common/accelcmn.cpp:48
 #, fuzzy
 msgid "Del"
 msgstr "Eliminar"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextbuffer.cpp:8221 ../src/common/stockitem.cpp:152
-#: ../src/common/accelcmn.cpp:50 ../src/stc/stc_i18n.cpp:20
+#: ../src/common/stockitem.cpp:149 ../src/common/accelcmn.cpp:47
+#: ../src/richtext/richtextbuffer.cpp:8217 ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Eliminar"
 
@@ -2672,68 +2677,68 @@ msgstr "Eliminar"
 msgid "Delete A&ll"
 msgstr "Eliminar-lo &Tot"
 
-#: ../src/richtext/richtextbuffer.cpp:11341
+#: ../src/richtext/richtextbuffer.cpp:11340
 msgid "Delete Column"
 msgstr "Eliminar a columna"
 
-#: ../src/richtext/richtextbuffer.cpp:11291
+#: ../src/richtext/richtextbuffer.cpp:11290
 msgid "Delete Row"
 msgstr "Eliminar a ringlera"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 msgid "Delete Style"
 msgstr "Eliminar o Estilo"
 
-#: ../src/richtext/richtextctrl.cpp:1345 ../src/richtext/richtextctrl.cpp:1584
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
 msgid "Delete Text"
 msgstr "Eliminar o Texto"
 
-#: ../src/generic/editlbox.cpp:170
+#: ../src/generic/editlbox.cpp:147
 msgid "Delete item"
 msgstr "Eliminar l'elemento"
 
-#: ../src/common/stockitem.cpp:260
+#: ../src/common/stockitem.cpp:257
 msgid "Delete selection"
 msgstr "Esborrar a selección"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 #, c-format
 msgid "Delete style %s?"
 msgstr "Eliminar o estilo %s?"
 
-#: ../src/unix/snglinst.cpp:301
+#: ../src/unix/snglinst.cpp:298
 #, c-format
 msgid "Deleted stale lock file '%s'."
 msgstr "Fichero antigo de bloqueyo '%s' eliminau."
 
-#: ../src/common/secretstore.cpp:220
+#: ../src/common/secretstore.cpp:234
 #, fuzzy, c-format
-msgid "Deleting password for \"%s/%s\" failed: %s."
+msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Ha fallau a extracción de '%s' en '%s'."
 
-#: ../src/common/module.cpp:124
+#: ../src/common/module.cpp:121
 #, c-format
 msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
 msgstr "No existe a dependencia \"%s\" d'o modulo \"%s\"."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "Descending"
 msgstr "Descendent"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:526 ../src/propgrid/advprops.cpp:882
+#: ../src/generic/dirctrlg.cpp:492 ../src/propgrid/advprops.cpp:783
 msgid "Desktop"
 msgstr "Escritorio"
 
-#: ../src/generic/aboutdlgg.cpp:70
+#: ../src/generic/aboutdlgg.cpp:67
 msgid "Developed by "
 msgstr "Desembolicau por "
 
-#: ../src/generic/aboutdlgg.cpp:176
+#: ../src/generic/aboutdlgg.cpp:173
 msgid "Developers"
 msgstr "Desembolicadors"
 
-#: ../src/msw/dialup.cpp:374
+#: ../src/msw/dialup.cpp:368
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -2741,11 +2746,11 @@ msgstr ""
 "As funcions de marcau no son disponibles porque os servicios d'acceso remoto "
 "(RAS) no son instalaus en ista maquina. Por favor instala-los."
 
-#: ../src/generic/tipdlg.cpp:211
+#: ../src/generic/tipdlg.cpp:208
 msgid "Did you know..."
 msgstr "Sabebas que...?"
 
-#: ../src/dfb/wrapdfb.cpp:63
+#: ../src/dfb/wrapdfb.cpp:60
 #, c-format
 msgid "DirectFB error %d occurred."
 msgstr "S'ha produciu a error %d de DirectFB."
@@ -2754,29 +2759,29 @@ msgstr "S'ha produciu a error %d de DirectFB."
 msgid "Directories"
 msgstr "Directorios"
 
-#: ../src/common/filefn.cpp:1183
+#: ../src/common/filefn.cpp:1071
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "No s'ha puesto creyar o directorio '%s'"
 
-#: ../src/common/filefn.cpp:1197
+#: ../src/common/filefn.cpp:1085
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "No se puet esborrar o directorio '%s'"
 
-#: ../src/generic/dirdlgg.cpp:204
+#: ../src/generic/dirdlgg.cpp:201
 msgid "Directory does not exist"
 msgstr "O directorio no existe"
 
-#: ../src/generic/filectrlg.cpp:1399
+#: ../src/generic/filectrlg.cpp:1388
 msgid "Directory doesn't exist."
 msgstr "O directorio no existe."
 
-#: ../src/common/docview.cpp:457
+#: ../src/common/docview.cpp:450
 msgid "Discard changes and reload the last saved version?"
 msgstr "Descartar os cambeos y recargar a zaguera versión alzada?"
 
-#: ../src/html/helpwnd.cpp:502
+#: ../src/html/helpwnd.cpp:500
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -2784,45 +2789,45 @@ msgstr ""
 "Amostrar totz os elementos de l'indiz que contiengan a subcadena dada. A "
 "busca ye Insensitiva."
 
-#: ../src/html/helpwnd.cpp:679
+#: ../src/html/helpwnd.cpp:677
 msgid "Display options dialog"
 msgstr "Amostrar o dialogo d'opcions"
 
-#: ../src/html/helpwnd.cpp:322
+#: ../src/html/helpwnd.cpp:320
 msgid "Displays help as you browse the books on the left."
 msgstr "Amuestra l'aduya con o navegador de libros a la cucha."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:85
+#: ../src/common/accelcmn.cpp:83
 msgid "Divide"
 msgstr ""
 
-#: ../src/common/docview.cpp:533
+#: ../src/common/docview.cpp:526
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Quiers alzar os cambeos ta %s?"
 
-#: ../src/common/prntbase.cpp:542
+#: ../src/common/prntbase.cpp:537
 msgid "Document:"
 msgstr "Documento:"
 
-#: ../src/generic/aboutdlgg.cpp:73
+#: ../src/generic/aboutdlgg.cpp:70
 msgid "Documentation by "
 msgstr "Documentau por "
 
-#: ../src/generic/aboutdlgg.cpp:180
+#: ../src/generic/aboutdlgg.cpp:177
 msgid "Documentation writers"
 msgstr "Escritors de documentos"
 
-#: ../src/common/sizer.cpp:2799
+#: ../src/common/sizer.cpp:2916
 msgid "Don't Save"
 msgstr "No alzar-lo"
 
-#: ../src/html/htmlwin.cpp:633
+#: ../src/html/htmlwin.cpp:643
 msgid "Done"
 msgstr "Feito"
 
-#: ../src/generic/progdlgg.cpp:448 ../src/msw/progdlg.cpp:407
+#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
 msgid "Done."
 msgstr "Feito."
 
@@ -2834,42 +2839,42 @@ msgstr "Puntiau"
 msgid "Double"
 msgstr "Dople"
 
-#: ../src/common/paper.cpp:176
+#: ../src/common/paper.cpp:173
 msgid "Double Japanese Postcard Rotated 148 x 200 mm"
 msgstr "Tarcheta Chaponesa Dople Chirada 148 x 200 mm"
 
-#: ../src/common/xtixml.cpp:273
+#: ../src/common/xtixml.cpp:269
 #, c-format
 msgid "Doubly used id : %d"
 msgstr "Identificador duplicau: %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:153
-#: ../src/common/accelcmn.cpp:64
+#: ../src/common/stockitem.cpp:150 ../src/common/accelcmn.cpp:61
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Down"
 msgstr "Abaixo"
 
-#: ../src/richtext/richtextctrl.cpp:865
+#: ../src/richtext/richtextctrl.cpp:864
 msgid "Drag"
 msgstr "Arrocegar"
 
-#: ../src/common/paper.cpp:100
+#: ../src/common/paper.cpp:97
 msgid "E sheet, 34 x 44 in"
 msgstr "Fuella E, 34 x 44 in"
 
-#: ../src/unix/fswatcher_inotify.cpp:561
+#: ../src/unix/fswatcher_inotify.cpp:558
 msgid "EOF while reading from inotify descriptor"
 msgstr "Fin de fichero mientras se leyeba dende o descriptor inotify"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "Edit"
 msgstr "Editar"
 
-#: ../src/generic/editlbox.cpp:168
+#: ../src/generic/editlbox.cpp:131
 msgid "Edit item"
 msgstr "Editar l'elemento"
 
-#: ../include/wx/generic/progdlgg.h:84
+#: ../include/wx/generic/progdlgg.h:85
 msgid "Elapsed time:"
 msgstr "Tiempo transcorriu:"
 
@@ -2941,50 +2946,50 @@ msgid "Enables the shadow spread."
 msgstr "Activar a valor de l'amplaria."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:66
+#: ../src/common/accelcmn.cpp:63
 msgid "End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:55
+#: ../src/common/accelcmn.cpp:52
 #, fuzzy
 msgid "Enter"
 msgstr "Impresora"
 
-#: ../src/richtext/richtextstyledlg.cpp:934
+#: ../src/richtext/richtextstyledlg.cpp:930
 msgid "Enter a box style name"
 msgstr "Introduz un nombre d'estilo de caixa"
 
-#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:602
 msgid "Enter a character style name"
 msgstr "Introduz un nombre d'estilo de caracter"
 
-#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:816
 msgid "Enter a list style name"
 msgstr "Introduz un nombre d'estilo de lista"
 
-#: ../src/richtext/richtextstyledlg.cpp:893
+#: ../src/richtext/richtextstyledlg.cpp:889
 msgid "Enter a new style name"
 msgstr "Introduz un nuevo nombre d'estilo"
 
-#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:650
 msgid "Enter a paragraph style name"
 msgstr "Introduz un nombre d'estilo de paragrafo"
 
-#: ../src/generic/dbgrptg.cpp:174
+#: ../src/generic/dbgrptg.cpp:171
 #, c-format
 msgid "Enter command to open file \"%s\":"
 msgstr "Introduz o comando ta ubrir o fichero \"%s\":"
 
-#: ../src/generic/helpext.cpp:459
+#: ../src/generic/helpext.cpp:457
 msgid "Entries found"
 msgstr "Dentradas trobadas"
 
-#: ../src/common/paper.cpp:142
+#: ../src/common/paper.cpp:139
 msgid "Envelope Invite 220 x 220 mm"
 msgstr "Sobre Invite 220 x 220 mm"
 
-#: ../src/common/config.cpp:469
+#: ../src/common/config.cpp:465
 #, c-format
 msgid ""
 "Environment variables expansion failed: missing '%c' at position %u in '%s'."
@@ -2992,13 +2997,13 @@ msgstr ""
 "A expansión de variable d'entorno ha fallau: falta '%c' en a posición %u en "
 "'%s'."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/generic/dirctrlg.cpp:570
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/dirctrlg.cpp:599
-#: ../src/generic/dirdlgg.cpp:323 ../src/generic/filectrlg.cpp:642
-#: ../src/generic/filectrlg.cpp:756 ../src/generic/filectrlg.cpp:770
-#: ../src/generic/filectrlg.cpp:786 ../src/generic/filectrlg.cpp:1368
-#: ../src/generic/filectrlg.cpp:1399 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/gtk1/fontdlg.cpp:74 ../src/generic/dirctrlg.cpp:536
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/dirctrlg.cpp:565
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1357 ../src/generic/filectrlg.cpp:1388
+#: ../src/generic/filedlgg.cpp:354 ../src/generic/dirdlgg.cpp:320
+#: ../src/gtk/filedlg.cpp:74
 msgid "Error"
 msgstr "Error"
 
@@ -3006,88 +3011,99 @@ msgstr "Error"
 msgid "Error closing epoll descriptor"
 msgstr "S'ha produciu una error en zarrar o descriptor epoll"
 
-#: ../src/unix/fswatcher_kqueue.cpp:114
+#: ../src/unix/fswatcher_kqueue.cpp:131
 msgid "Error closing kqueue instance"
 msgstr "S'ha produciu una error en zarrar a instancia de kqueu"
 
-#: ../src/common/filefn.cpp:1049
+#: ../src/common/filefn.cpp:938
 #, fuzzy, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "S'ha produciu una error en copiar o fichero '%s' ta '%s'"
 
-#: ../src/generic/dirdlgg.cpp:222
+#: ../src/generic/dirdlgg.cpp:219
 msgid "Error creating directory"
 msgstr "S'ha produciu una error en creyar o directorio"
 
-#: ../src/common/imagbmp.cpp:1181
+#: ../src/common/imagbmp.cpp:1193
 msgid "Error in reading image DIB."
 msgstr "S'ha produciu una error en leyer a imachen DIB."
 
-#: ../src/propgrid/propgrid.cpp:6696
+#: ../src/propgrid/propgrid.cpp:6665
 #, c-format
 msgid "Error in resource: %s"
 msgstr "S'ha produciu una error en o recurso: %s"
 
-#: ../src/common/fileconf.cpp:422
+#: ../src/common/fileconf.cpp:421
 msgid "Error reading config options."
 msgstr "S'ha produciu una error en leyer as opcions de configuración."
+
+#: ../src/msw/webview_ie.cpp:1057 ../src/msw/webview_edge.cpp:850
+#: ../src/gtk/webview_webkit2.cpp:1262 ../src/osx/webview_webkit.mm:383
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
 
 #: ../src/common/fileconf.cpp:1029
 msgid "Error saving user configuration data."
 msgstr ""
 "S'ha produciu una error en alzar os datos de configuración de l'usuario."
 
-#: ../src/gtk/print.cpp:722
+#: ../src/gtk/print.cpp:720
 msgid "Error while printing: "
 msgstr "S'ha produciu una error en imprentar: "
 
-#: ../src/common/log.cpp:219
+#: ../src/common/log.cpp:237
 msgid "Error: "
 msgstr "Error: "
 
+#: ../src/common/webrequest.cpp:98
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Error: "
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:69
+#: ../src/common/accelcmn.cpp:66
 msgid "Esc"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:70
+#: ../src/common/accelcmn.cpp:67
 #, fuzzy
 msgid "Escape"
 msgstr "Horizontal"
 
-#: ../src/common/fmapbase.cpp:150
+#: ../src/common/fmapbase.cpp:147
 msgid "Esperanto (ISO-8859-3)"
 msgstr "Esperanto (ISO-8859-3)"
 
-#: ../include/wx/generic/progdlgg.h:85
+#: ../include/wx/generic/progdlgg.h:86
 msgid "Estimated time:"
 msgstr "Tiempo estimau:"
 
-#: ../src/generic/dbgrptg.cpp:234
+#: ../src/generic/dbgrptg.cpp:231
 msgid "Executable files (*.exe)|*.exe|"
 msgstr "Fichers executables (*.exe)|*.exe|"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:155 ../src/common/accelcmn.cpp:78
+#: ../src/common/stockitem.cpp:152 ../src/common/accelcmn.cpp:75
 msgid "Execute"
 msgstr "Executar"
 
-#: ../src/msw/utilsexc.cpp:876
+#: ../src/msw/utilsexc.cpp:873
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Ha fallau a execución d'o comando '%s'"
 
-#: ../src/common/paper.cpp:105
+#: ../src/common/paper.cpp:102
 msgid "Executive, 7 1/4 x 10 1/2 in"
 msgstr "Executivo, 7 1/4 x 10 1/2 in"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6009
+#: ../src/generic/datavgen.cpp:6814
 msgid "Expand"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1240
+#: ../src/msw/registry.cpp:1228
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
@@ -3095,27 +3111,32 @@ msgstr ""
 "Se ye exportando a clau de rechistro: o fichero \"%s\" ya existe y no se "
 "sobrescribirá."
 
-#: ../src/common/fmapbase.cpp:195
+#: ../src/common/fmapbase.cpp:192
 msgid "Extended Unix Codepage for Japanese (EUC-JP)"
 msgstr "Pachina de Codigos Unix Extendida ta lo Chaponés (EUC-JP)"
 
-#: ../src/html/chm.cpp:725
+#: ../src/html/chm.cpp:718
 #, c-format
 msgid "Extraction of '%s' into '%s' failed."
 msgstr "Ha fallau a extracción de '%s' en '%s'."
 
-#: ../src/common/accelcmn.cpp:249 ../src/common/accelcmn.cpp:344
+#: ../src/common/accelcmn.cpp:259 ../src/common/accelcmn.cpp:358
 msgid "F"
 msgstr "F"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:672
+#: ../src/propgrid/advprops.cpp:582
 msgid "Face Name"
 msgstr "Nombre d'a fuent"
 
-#: ../src/unix/snglinst.cpp:269
+#: ../src/unix/snglinst.cpp:266
 msgid "Failed to access lock file."
 msgstr "S'ha produciu un fallo en accedir a lo fichero de bloqueyo."
+
+#: ../src/gtk/font.cpp:572
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "No s'ha puesto leyer o documento dende \"%s\"."
 
 #: ../src/unix/epolldispatcher.cpp:116
 #, c-format
@@ -3123,127 +3144,132 @@ msgid "Failed to add descriptor %d to epoll descriptor %d"
 msgstr ""
 "S'ha produciu una error en adhibir o descriptor %d a lo descriptor epoll %d"
 
-#: ../src/msw/dib.cpp:489
+#: ../src/msw/dib.cpp:535
 #, c-format
 msgid "Failed to allocate %luKb of memory for bitmap data."
 msgstr ""
 "S'ha produciu una error en asignar %luKb de memoria ta lo mapa de bits."
 
-#: ../src/common/glcmn.cpp:115
+#: ../src/common/glcmn.cpp:112
 msgid "Failed to allocate colour for OpenGL"
 msgstr "S'ha produciu una error en asignar a color ta l'OpenGL"
 
-#: ../src/unix/displayx11.cpp:236
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "S'ha produciu una error en asignar a color ta l'OpenGL"
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "S'ha produciu una error en asignar a color ta l'OpenGL"
+
+#: ../include/wx/unix/private/displayx11.h:89
 msgid "Failed to change video mode"
 msgstr "S'ha produciu una error en cambiar o modo de video"
 
-#: ../src/common/image.cpp:3277
+#: ../src/common/image.cpp:3396
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr ""
 "S'ha produciu una error en comprebar o formato d'o fichero d'imachen \"%s\"."
 
-#: ../src/common/debugrpt.cpp:239
+#: ../src/common/debugrpt.cpp:240
 #, c-format
 msgid "Failed to clean up debug report directory \"%s\""
 msgstr "No s'ha puesto vuedar o directorio de reportes de depuración \"%s\""
 
-#: ../src/common/filename.cpp:192
+#: ../src/common/filename.cpp:189
 msgid "Failed to close file handle"
 msgstr "S'ha produciu una error en zarrar o maniador d'o fichero"
 
-#: ../src/unix/snglinst.cpp:340
+#: ../src/unix/snglinst.cpp:337
 #, c-format
 msgid "Failed to close lock file '%s'"
 msgstr "No s'ha puesto zarrar o fichero de bloqueyo '%s'"
 
-#: ../src/msw/clipbrd.cpp:112
+#: ../src/msw/clipbrd.cpp:110
 msgid "Failed to close the clipboard."
 msgstr "S'ha produciu una error en zarrar o portafuellas."
 
-#: ../src/x11/utils.cpp:208
+#: ../src/x11/utils.cpp:170
 #, c-format
 msgid "Failed to close the display \"%s\""
 msgstr "S'ha produciu una error en zarrar o display \"%s\""
 
-#: ../src/msw/dialup.cpp:797
+#: ../src/msw/dialup.cpp:791
 msgid "Failed to connect: missing username/password."
 msgstr "S'ha produciu una error en connectar: falta o nombre d'usuario/clau."
 
-#: ../src/msw/dialup.cpp:743
+#: ../src/msw/dialup.cpp:737
 msgid "Failed to connect: no ISP to dial."
 msgstr "S'ha produciu una error en connectar: no bi ha un ISP a lo que gritar."
 
-#: ../src/common/textfile.cpp:203
-#, c-format
-msgid "Failed to convert file \"%s\" to Unicode."
-msgstr "S'ha produciu una error en convertir o fichero \"%s\" ta Unicode."
-
-#: ../src/generic/logg.cpp:956
+#: ../src/generic/logg.cpp:953
 msgid "Failed to copy dialog contents to the clipboard."
 msgstr ""
 "S'ha produciu una error en copiar os contenius d'o dialogo en o portafuellas."
 
-#: ../src/msw/registry.cpp:692
+#: ../src/msw/registry.cpp:681
 #, c-format
 msgid "Failed to copy registry value '%s'"
 msgstr "S'ha produciu un a error en copiar a valor '%s' d'o rechistro"
 
-#: ../src/msw/registry.cpp:701
+#: ../src/msw/registry.cpp:690
 #, c-format
 msgid "Failed to copy the contents of registry key '%s' to '%s'."
 msgstr ""
 "S'ha produciu una error en copiar os contenius d'a clau d'o rechistro '%s' "
 "ta '%s'."
 
-#: ../src/common/filefn.cpp:1015
+#: ../src/common/filefn.cpp:904
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "S'ha produciu una error en copiar o fichero '%s' ta '%s'"
 
-#: ../src/msw/registry.cpp:679
+#: ../src/msw/registry.cpp:668
 #, c-format
 msgid "Failed to copy the registry subkey '%s' to '%s'."
 msgstr ""
 "S'ha produciu una error en copiar a subclau d'o rechistro '%s' en '%s'."
 
-#: ../src/msw/dde.cpp:1070
+#: ../src/msw/dde.cpp:1134
 msgid "Failed to create DDE string"
 msgstr "S'ha produciu una error en creyar a cadena DDE"
 
-#: ../src/msw/mdi.cpp:616
+#: ../src/msw/mdi.cpp:621
 msgid "Failed to create MDI parent frame."
 msgstr "S'ha produciu una error en creyar o panel MDI pai."
 
-#: ../src/common/filename.cpp:1027
+#: ../src/common/filename.cpp:1024
 msgid "Failed to create a temporary file name"
 msgstr "S'ha produciu una error en creyar un nombre temporal de fichero"
 
-#: ../src/msw/utilsexc.cpp:228
+#: ../src/msw/utilsexc.cpp:225
 msgid "Failed to create an anonymous pipe"
 msgstr "S'ha produciu una error en creyar una canal anonima"
 
-#: ../src/msw/ole/automtn.cpp:522
+#: ../src/msw/ole/automtn.cpp:513
 #, c-format
 msgid "Failed to create an instance of \"%s\""
 msgstr "S'ha produciu una error en creyar una instancia de \"%s\""
 
-#: ../src/msw/dde.cpp:437
+#: ../src/msw/dde.cpp:432
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr ""
 "S'ha produciu una error en creyar a connexión enta lo servidor '%s' en '%s'"
 
-#: ../src/msw/cursor.cpp:204
+#: ../src/msw/cursor.cpp:195
 msgid "Failed to create cursor."
 msgstr "S'ha produciu una error en creyar o cursor."
 
-#: ../src/common/debugrpt.cpp:209
+#: ../src/common/debugrpt.cpp:210
 #, c-format
 msgid "Failed to create directory \"%s\""
 msgstr "S'ha produciu una error en creyar o directorio \"%s\""
 
-#: ../src/generic/dirdlgg.cpp:220
+#: ../src/generic/dirdlgg.cpp:217
 #, c-format
 msgid ""
 "Failed to create directory '%s'\n"
@@ -3256,127 +3282,146 @@ msgstr ""
 msgid "Failed to create epoll descriptor"
 msgstr "S'ha produciu una error en creyar o descriptor epoll"
 
-#: ../src/msw/mimetype.cpp:238
+#: ../src/gtk/font.cpp:562
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "No s'ha puesto esviellar o fichero de configuración d'usuario."
+
+#: ../src/msw/mimetype.cpp:235
 #, c-format
 msgid "Failed to create registry entry for '%s' files."
 msgstr ""
 "S'ha produciu una error en creyar a dentrada d'o rechistro ta os fichers "
 "'%s'."
 
-#: ../src/msw/fdrepdlg.cpp:409
+#: ../src/msw/fdrepdlg.cpp:408
 #, c-format
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr ""
 "S'ha produciu una error en creyar o dialogo estandar de mirar u "
 "substituir(codigo d'error %d)"
 
-#: ../src/unix/wakeuppipe.cpp:52
+#: ../src/unix/wakeuppipe.cpp:49
 msgid "Failed to create wake up pipe used by event loop."
 msgstr ""
 "S'ha produciu una error en creyar a canyería de dispertar que fa servir o "
 "bucle d'eventos."
 
-#: ../src/html/winpars.cpp:730
+#: ../src/html/winpars.cpp:727
 #, c-format
 msgid "Failed to display HTML document in %s encoding"
 msgstr ""
 "S'ha produciu una error en amostrar o documento HTML con codificación %s"
 
-#: ../src/msw/clipbrd.cpp:124
+#: ../src/msw/clipbrd.cpp:122
 msgid "Failed to empty the clipboard."
 msgstr "S'ha produciu una error en vuedar o portafuellas."
 
-#: ../src/unix/displayx11.cpp:212
+#: ../include/wx/unix/private/displayx11.h:65
 msgid "Failed to enumerate video modes"
 msgstr "S'ha produciu una error en enumerar os modos de video"
 
-#: ../src/msw/dde.cpp:722
+#: ../src/msw/dde.cpp:717
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "S'ha produciu una error en establir un lazo d'aviso con o servidor DDE"
 
-#: ../src/msw/dialup.cpp:629 ../src/msw/dialup.cpp:863
+#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "S'ha produciu una error en establir a connexión de marcau: %s"
 
-#: ../src/unix/utilsunx.cpp:611
+#: ../src/unix/utilsunx.cpp:613
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "S'ha produciu una error en executar '%s'\n"
 
-#: ../src/common/debugrpt.cpp:720
+#: ../src/common/debugrpt.cpp:730
 msgid "Failed to execute curl, please install it in PATH."
 msgstr ""
 "S'ha produciu una error en executar o curl, por favor, instala-lo en PATH."
 
-#: ../src/msw/ole/automtn.cpp:505
+#: ../src/msw/ole/automtn.cpp:496
 #, c-format
 msgid "Failed to find CLSID of \"%s\""
 msgstr "No s'ha puesto trobar o CLSID de \"%s\""
 
-#: ../src/common/regex.cpp:431 ../src/common/regex.cpp:479
+#: ../src/common/regex.cpp:428 ../src/common/regex.cpp:476
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr ""
 "S'ha produciu una error en mirar as coincidencias ta la expresión regular: %s"
 
-#: ../src/msw/dialup.cpp:695
+#: ../src/msw/webview_ie.cpp:978
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:689
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "S'ha produciu una error en obtener os nombres d'ISP: %s"
 
-#: ../src/msw/ole/automtn.cpp:574
+#: ../src/msw/ole/automtn.cpp:565
 #, c-format
 msgid "Failed to get OLE automation interface for \"%s\""
 msgstr ""
 "S'ha produciu una error en obtener a interficie OLE d'automatización ta \"%s"
 "\""
 
-#: ../src/msw/clipbrd.cpp:711
+#: ../src/msw/clipbrd.cpp:731
 msgid "Failed to get data from the clipboard"
 msgstr "S'ha produciu una error en obtener os datos d'o portafuellas"
 
-#: ../src/common/time.cpp:223
+#: ../src/common/time.cpp:216
 msgid "Failed to get the local system time"
 msgstr "S'ha produciu una error en obtener o sistema horario local"
 
-#: ../src/common/filefn.cpp:1345
+#: ../src/common/filefn.cpp:1233
 msgid "Failed to get the working directory"
 msgstr "S'ha produciu una error en obtener o directorio de treballo"
 
-#: ../src/univ/theme.cpp:114
+#: ../src/univ/theme.cpp:111
 msgid "Failed to initialize GUI: no built-in themes found."
 msgstr ""
 "S'ha produciu una error en inicializar a interfaz grafica d'usuario: no "
 "s'han trobau temas integraus."
 
-#: ../src/msw/helpchm.cpp:63
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:60
 msgid "Failed to initialize MS HTML Help."
 msgstr "S'ha produciu una error en inicializar l'Aduya MS HTML."
 
-#: ../src/msw/glcanvas.cpp:1381
+#: ../src/msw/glcanvas.cpp:1391
 msgid "Failed to initialize OpenGL"
 msgstr "No s'ha puesto inicializar l'OpenGL"
 
-#: ../src/msw/dialup.cpp:858
+#: ../src/msw/dialup.cpp:852
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "No s'ha puesto encetar a connexión d'acceso telefonico: %s"
 
-#: ../src/gtk/textctrl.cpp:1128
+#: ../src/gtk/textctrl.cpp:1209
 msgid "Failed to insert text in the control."
 msgstr "No s'ha puesto ficar texto en o control."
 
-#: ../src/unix/snglinst.cpp:241
+#: ../src/unix/snglinst.cpp:238
 #, c-format
 msgid "Failed to inspect the lock file '%s'"
 msgstr "S'ha produciu una error a l'inspeccionar o fichero de bloqueyo '%s'"
 
-#: ../src/unix/appunix.cpp:182
+#: ../src/unix/appunix.cpp:179
 msgid "Failed to install signal handler"
 msgstr "No s'ha puesto instalar o maniador de sinyal"
 
-#: ../src/unix/threadpsx.cpp:1167
+#: ../src/unix/threadpsx.cpp:1216
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -3384,71 +3429,71 @@ msgstr ""
 "No s'ha puesto sincronizar con un filo d'execución, perda potencial de "
 "memoria detectada - por favor reenchega o programa"
 
-#: ../src/msw/utils.cpp:629
+#: ../src/msw/utils.cpp:619
 #, c-format
 msgid "Failed to kill process %d"
 msgstr "No s'ha puesto amortar o proceso %d"
 
-#: ../src/common/image.cpp:2500
+#: ../src/common/image.cpp:2595
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "No s'ha puesto cargar o mapa de bits \"%s\" dende os recursos."
 
-#: ../src/common/image.cpp:2509
+#: ../src/common/image.cpp:2604
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "No s'ha puesto cargar l'icono \"%s\" dende os recursos."
 
-#: ../src/common/iconbndl.cpp:225
+#: ../src/common/iconbndl.cpp:224
 #, fuzzy, c-format
 msgid "Failed to load icons from resource '%s'."
 msgstr "No s'ha puesto cargar l'icono \"%s\" dende os recursos."
 
-#: ../src/common/iconbndl.cpp:200
+#: ../src/common/iconbndl.cpp:198
 #, c-format
 msgid "Failed to load image %%d from file '%s'."
 msgstr "No s'ha puesto cargar a imachen %%d dende o fichero '%s'."
 
-#: ../src/common/iconbndl.cpp:208
+#: ../src/common/iconbndl.cpp:206
 #, c-format
 msgid "Failed to load image %d from stream."
 msgstr "No s'ha puesto cargar a imachen %d dende o fluxo."
 
-#: ../src/common/image.cpp:2587 ../src/common/image.cpp:2606
+#: ../src/common/image.cpp:2682 ../src/common/image.cpp:2701
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "No s'ha puesto cargar a imachen dende o fichero \"%s\"."
 
-#: ../src/msw/enhmeta.cpp:97
+#: ../src/msw/enhmeta.cpp:94
 #, c-format
 msgid "Failed to load metafile from file \"%s\"."
 msgstr "No s'ha puesto ubrir o metafichero dende o fichero \"%s\"."
 
-#: ../src/msw/volume.cpp:327
+#: ../src/msw/volume.cpp:335
 msgid "Failed to load mpr.dll."
 msgstr "No s'ha puesto cargar o mpr.dll."
 
-#: ../src/msw/utils.cpp:953
+#: ../src/msw/utils.cpp:943
 #, c-format
 msgid "Failed to load resource \"%s\"."
 msgstr "No s'ha puesto cargar o recurso \"%s\"."
 
-#: ../src/common/dynlib.cpp:92
+#: ../src/common/dynlib.cpp:86
 #, c-format
 msgid "Failed to load shared library '%s'"
 msgstr "No s'ha puesto cargar a biblioteca compartida '%s'"
 
-#: ../src/osx/core/sound.cpp:145
+#: ../src/osx/core/sound.cpp:143
 #, fuzzy, c-format
 msgid "Failed to load sound from \"%s\" (error %d)."
 msgstr "No s'ha puesto cargar o recurso \"%s\"."
 
-#: ../src/msw/utils.cpp:960
+#: ../src/msw/utils.cpp:950
 #, c-format
 msgid "Failed to lock resource \"%s\"."
 msgstr "No s'ha puesto blocar o recurso \"%s\"."
 
-#: ../src/unix/snglinst.cpp:198
+#: ../src/unix/snglinst.cpp:195
 #, c-format
 msgid "Failed to lock the lock file '%s'"
 msgstr "No s'ha puesto blocar o fichero de bloqueyo '%s'"
@@ -3458,33 +3503,38 @@ msgstr "No s'ha puesto blocar o fichero de bloqueyo '%s'"
 msgid "Failed to modify descriptor %d in epoll descriptor %d"
 msgstr "No s'ha puesto modificar o descriptor %d en o descriptor %d"
 
-#: ../src/common/filename.cpp:2575
+#: ../src/common/filename.cpp:2658
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "No s'ha puesto modificar as horas d'o fichero ta '%s'"
 
-#: ../src/common/selectdispatcher.cpp:258
+#: ../src/common/selectdispatcher.cpp:255
 msgid "Failed to monitor I/O channels"
 msgstr "No s'ha puesto monitorizar as canals de dentrada/salida"
 
-#: ../src/common/filename.cpp:175
+#: ../src/common/filename.cpp:172
 #, c-format
 msgid "Failed to open '%s' for reading"
 msgstr "No s'ha puesto ubrir '%s' ta lectura"
 
-#: ../src/common/filename.cpp:180
+#: ../src/common/filename.cpp:177
 #, c-format
 msgid "Failed to open '%s' for writing"
 msgstr "No s'ha puesto ubrir '%s' ta escritura"
 
-#: ../src/html/chm.cpp:141
+#: ../src/html/chm.cpp:138
 #, c-format
 msgid "Failed to open CHM archive '%s'."
 msgstr "No s'ha puesto ubrir o fichero CHM '%s'."
 
-#: ../src/common/utilscmn.cpp:1126
+#: ../src/common/utilscmn.cpp:1140
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
+msgstr "No s'ha puesto ubrir a URL \"%s\" en o navegador predeterminau."
+
+#: ../src/common/hyperlnkcmn.cpp:133
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "No s'ha puesto ubrir a URL \"%s\" en o navegador predeterminau."
 
 #: ../include/wx/msw/private/fswatcher.h:92
@@ -3492,95 +3542,105 @@ msgstr "No s'ha puesto ubrir a URL \"%s\" en o navegador predeterminau."
 msgid "Failed to open directory \"%s\" for monitoring."
 msgstr "No s'ha puesto ubrir o directorio \"%s\" ta monitorizar-lo."
 
-#: ../src/x11/utils.cpp:227
+#: ../src/x11/utils.cpp:189
 #, c-format
 msgid "Failed to open display \"%s\"."
 msgstr "No s'ha puesto ubrir o display \"%s\"."
 
-#: ../src/common/filename.cpp:1062
+#: ../src/common/filename.cpp:1059
 msgid "Failed to open temporary file."
 msgstr "No s'ha puesto ubrir o fichero temporal."
 
-#: ../src/msw/clipbrd.cpp:91
+#: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "No s'ha puesto ubrir o portafuellas."
 
-#: ../src/common/translation.cpp:1184
+#: ../src/common/translation.cpp:1226
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "No s'ha puesto analisar as formas plurals: '%s'"
 
-#: ../src/unix/mediactrl.cpp:1214
+#: ../src/unix/mediactrl.cpp:1239
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "No s'ha puesto parar a reproducción \"%s\"."
 
-#: ../src/msw/clipbrd.cpp:600
+#: ../src/msw/clipbrd.cpp:610
 msgid "Failed to put data on the clipboard"
 msgstr "No s'ha puesto meter datos en o portafuellas"
 
-#: ../src/unix/snglinst.cpp:278
+#: ../src/unix/snglinst.cpp:275
 msgid "Failed to read PID from lock file."
 msgstr "No s'ha puesto leyer o PID d'o fichero de bloqueyo."
 
-#: ../src/common/fileconf.cpp:433
+#: ../src/common/fileconf.cpp:432
 msgid "Failed to read config options."
 msgstr "No s'ha puesto leyer as opcions de configuración."
 
-#: ../src/common/docview.cpp:681
+#: ../src/common/docview.cpp:676
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "No s'ha puesto leyer o documento dende \"%s\"."
 
-#: ../src/dfb/evtloop.cpp:98
+#: ../src/dfb/evtloop.cpp:99
 msgid "Failed to read event from DirectFB pipe"
 msgstr "No s'ha puesto leyer l'evento dende a canal DirectFB"
 
-#: ../src/unix/wakeuppipe.cpp:120
+#: ../src/unix/wakeuppipe.cpp:117
 msgid "Failed to read from wake-up pipe"
 msgstr "No s'ha puesto leyer d'una tubería de dispertar"
 
-#: ../src/unix/utilsunx.cpp:679
+#: ../src/common/textfile.cpp:96
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "No s'ha puesto leyer o documento dende \"%s\"."
+
+#: ../src/unix/utilsunx.cpp:681
 msgid "Failed to redirect child process input/output"
 msgstr "No s'ha puesto reendrezar a dentrada/salida d'o proceso fillo"
 
-#: ../src/msw/utilsexc.cpp:701
+#: ../src/msw/utilsexc.cpp:698
 msgid "Failed to redirect the child process IO"
 msgstr "No s'ha puesto reendrezar a dentrada/salida d'o proceso fillo"
 
-#: ../src/msw/dde.cpp:288
+#: ../src/msw/dde.cpp:283
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "No s'ha puesto rechistrar o servidor DDE '%s'"
 
-#: ../src/common/fontmap.cpp:245
+#: ../src/gtk/font.cpp:580
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "No s'ha puesto esviellar o fichero de configuración d'usuario."
+
+#: ../src/common/fontmap.cpp:242
 #, c-format
 msgid "Failed to remember the encoding for the charset '%s'."
 msgstr ""
 "S'ha produciu una error a lo remerar a codificación ta lo conchunto de "
 "caracters '%s'."
 
-#: ../src/common/debugrpt.cpp:227
+#: ../src/common/debugrpt.cpp:228
 #, c-format
 msgid "Failed to remove debug report file \"%s\""
 msgstr "No s'ha puesto eliminar o fichero de reporte de depuración \"%s\""
 
-#: ../src/unix/snglinst.cpp:328
+#: ../src/unix/snglinst.cpp:325
 #, c-format
 msgid "Failed to remove lock file '%s'"
 msgstr "No s'ha puesto sacar o fichero de bloqueyo '%s'"
 
-#: ../src/unix/snglinst.cpp:288
+#: ../src/unix/snglinst.cpp:285
 #, c-format
 msgid "Failed to remove stale lock file '%s'."
 msgstr "No s'ha puesto eliminar l'antigo fichero de bloqueyo '%s'."
 
-#: ../src/msw/registry.cpp:529
+#: ../src/msw/registry.cpp:518
 #, c-format
 msgid "Failed to rename registry value '%s' to '%s'."
 msgstr "No s'ha puesto renombrar a valor d'o rechistro '%s' a '%s'."
 
-#: ../src/common/filefn.cpp:1122
+#: ../src/common/filefn.cpp:1011
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -3589,118 +3649,127 @@ msgstr ""
 "No s'ha puesto renombrar o fichero '%s' a '%s' porque o fichero de destín ya "
 "existe."
 
-#: ../src/msw/registry.cpp:634
+#: ../src/msw/registry.cpp:623
 #, c-format
 msgid "Failed to rename the registry key '%s' to '%s'."
 msgstr "No s'ha puesto renombrar a clau d'o rechistro '%s' a '%s'."
 
-#: ../src/common/filename.cpp:2671
+#: ../src/msw/webview_ie.cpp:995
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/common/filename.cpp:2754
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "No s'ha puesto recuperar horas d'o fichero ta '%s'"
 
-#: ../src/msw/dialup.cpp:468
+#: ../src/msw/dialup.cpp:462
 msgid "Failed to retrieve text of RAS error message"
 msgstr "No s'ha puesto recuperar o mensache d'error de RAS"
 
-#: ../src/msw/clipbrd.cpp:748
+#: ../src/msw/clipbrd.cpp:768
 msgid "Failed to retrieve the supported clipboard formats"
 msgstr "No s'ha puesto recuperar os formatos suportaus d'o portafuellas"
 
-#: ../src/common/docview.cpp:652
+#: ../src/common/docview.cpp:647
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "No s'ha puesto alzar o documento en o fichero \"%s\"."
 
-#: ../src/msw/dib.cpp:269
+#: ../src/msw/dib.cpp:312
 #, c-format
 msgid "Failed to save the bitmap image to file \"%s\"."
 msgstr "No s'ha puesto alzar a imachen de mapa de bits en o fichero \"%s\"."
 
-#: ../src/msw/dde.cpp:763
+#: ../src/msw/dde.cpp:811
 msgid "Failed to send DDE advise notification"
 msgstr "No s'ha puesto ninviar a notificación d'alvertencia DDE"
 
-#: ../src/common/ftp.cpp:402
+#: ../src/common/ftp.cpp:399
 #, c-format
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "No s'ha puesto establir o modo de transferencia FTP a %s."
 
-#: ../src/msw/clipbrd.cpp:427
+#: ../src/msw/clipbrd.cpp:443
 msgid "Failed to set clipboard data."
 msgstr "No s'ha puesto meter datos en o portafuellas."
 
-#: ../src/unix/snglinst.cpp:181
+#: ../src/unix/snglinst.cpp:178
 #, c-format
 msgid "Failed to set permissions on lock file '%s'"
 msgstr "No s'ha puesto establir os permisos d'o fichero de bloqueyo '%s'"
 
-#: ../src/unix/utilsunx.cpp:668
+#: ../src/unix/utilsunx.cpp:670
 msgid "Failed to set process priority"
 msgstr "No s'ha puesto establir a prioridat d'o proceso"
 
-#: ../src/common/file.cpp:559
+#: ../src/common/ffile.cpp:355 ../src/common/file.cpp:586
 msgid "Failed to set temporary file permissions"
 msgstr "No s'ha puesto cambiar os permisos d'o fichero temporal"
 
-#: ../src/gtk/textctrl.cpp:1072
-msgid "Failed to set text in the text control."
-msgstr "No s'ha puesto colocar texto en o control de texto."
-
-#: ../src/unix/threadpsx.cpp:1298
+#: ../src/unix/threadpsx.cpp:1347
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "No s'ha puesto establir o libel de concurrencia en %lu"
 
-#: ../src/unix/threadpsx.cpp:1424
+#: ../src/unix/threadpsx.cpp:1473
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "No s'ha puesto establir a prioridat d'o filo d'execución %d."
 
-#: ../src/unix/utilsunx.cpp:783
+#: ../src/unix/utilsunx.cpp:785
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 "No s'ha puesto configurar a canyería sin bloqueyo, o programa puet bloqueyar-"
 "se."
 
-#: ../src/common/fs_mem.cpp:261
+#: ../src/msw/webview_ie.cpp:987
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:256
 #, c-format
 msgid "Failed to store image '%s' to memory VFS!"
 msgstr "No s'ha puesto almagazenar a imachen '%s' en a memoria VFS."
 
-#: ../src/dfb/evtloop.cpp:170
+#: ../src/dfb/evtloop.cpp:171
 msgid "Failed to switch DirectFB pipe to non-blocking mode"
 msgstr "No s'ha puesto cambiar a canyería ta lo modo de no bloqueyo"
 
-#: ../src/unix/wakeuppipe.cpp:59
+#: ../src/unix/wakeuppipe.cpp:56
 msgid "Failed to switch wake up pipe to non-blocking mode"
 msgstr ""
 "No s'ha puesto cambiar a canyería de dispertar ta lo modo de no bloqueyo"
 
-#: ../src/unix/threadpsx.cpp:1605
+#: ../src/unix/threadpsx.cpp:1654
 msgid "Failed to terminate a thread."
 msgstr "No s'ha puesto rematar un filo d'execución."
 
-#: ../src/msw/dde.cpp:741
+#: ../src/msw/dde.cpp:736
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "No s'ha puesto rematar o bucle d'alvertencia con o servidor DDE"
 
-#: ../src/msw/dialup.cpp:938
+#: ../src/msw/dialup.cpp:932
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "No s'ha puesto rematar a connexión: %s"
 
-#: ../src/common/filename.cpp:2590
+#: ../src/common/filename.cpp:2673
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "No s'ha puesto retocar o fichero '%s'"
 
-#: ../src/unix/snglinst.cpp:334
+#: ../src/unix/dlunix.cpp:90
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "No s'ha puesto cargar a biblioteca compartida '%s'"
+
+#: ../src/unix/snglinst.cpp:331
 #, c-format
 msgid "Failed to unlock lock file '%s'"
 msgstr "No s'ha puesto desbloquiar o fichero de bloqueyo '%s'"
 
-#: ../src/msw/dde.cpp:309
+#: ../src/msw/dde.cpp:304
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "No s'ha puesto desrechistrar o servidor DDE '%s'"
@@ -3714,77 +3783,87 @@ msgstr "No s'ha puesto anular o rechistro descriptor%d d'o descriptor epoll%d"
 msgid "Failed to update user configuration file."
 msgstr "No s'ha puesto esviellar o fichero de configuración d'usuario."
 
-#: ../src/common/debugrpt.cpp:733
+#: ../src/common/debugrpt.cpp:743
 #, c-format
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "No s'ha puesto ninviar o reporte de depuración (codigo d'error %d)."
 
-#: ../src/unix/snglinst.cpp:168
+#: ../src/unix/snglinst.cpp:165
 #, c-format
 msgid "Failed to write to lock file '%s'"
 msgstr "No s'ha puesto escribir en blocar o fichero '%s'"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:209
+#: ../src/propgrid/propgrid.cpp:190
 msgid "False"
 msgstr "Falso"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:694
+#: ../src/propgrid/advprops.cpp:604
 msgid "Family"
 msgstr "Familia"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/gtk/glcanvas.cpp:176 ../src/gtk/glcanvas.cpp:187
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Error de fichero"
+
+#: ../src/common/stockitem.cpp:154
 msgid "File"
 msgstr "Fichero"
 
-#: ../src/common/docview.cpp:669
+#: ../src/common/docview.cpp:664
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "No s'ha puesto ubrir o fichero \"%s\" ta leyer."
 
-#: ../src/common/docview.cpp:646
+#: ../src/common/docview.cpp:641
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "No s'ha puesto ubrir o fichero \"%s\" ta escribir."
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "O fichero '%s' ya existe, realment quiers sobrescribir-lo?"
 
-#: ../src/common/filefn.cpp:1156
+#: ../src/common/filefn.cpp:1044
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "No s'ha puesto esborrar o fichero '%s'"
 
-#: ../src/common/filefn.cpp:1139
+#: ../src/common/filefn.cpp:1028
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "No s'ha puesto renombrar o fichero '%s' como '%s'"
 
-#: ../src/richtext/richtextctrl.cpp:3081 ../src/common/textcmn.cpp:953
+#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
 msgid "File couldn't be loaded."
 msgstr "No s'ha puesto cargar o fichero."
 
-#: ../src/msw/filedlg.cpp:393
+#: ../src/msw/filedlg.cpp:414
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "O dialogo de fichero ha fallau con o codigo d'error %0lx."
 
-#: ../src/common/docview.cpp:1789
+#: ../src/common/docview.cpp:1783
 msgid "File error"
 msgstr "Error de fichero"
 
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/filectrlg.cpp:770
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/filectrlg.cpp:766
 msgid "File name exists already."
 msgstr "Ya existe un fichero con o mesmo nombre."
+
+#: ../src/osx/cocoa/filedlg.mm:264
+#, fuzzy
+msgid "File type:"
+msgstr "Teletipo"
 
 #: ../src/motif/filedlg.cpp:220
 msgid "Files"
 msgstr "Fichers"
 
-#: ../src/common/filefn.cpp:1591
+#: ../src/common/filefn.cpp:1479
 #, c-format
 msgid "Files (%s)"
 msgstr "Fichers (%s)"
@@ -3793,15 +3872,29 @@ msgstr "Fichers (%s)"
 msgid "Filter"
 msgstr "Filtro"
 
-#: ../src/common/stockitem.cpp:158 ../src/html/helpwnd.cpp:490
+#: ../src/html/helpwnd.cpp:488
 msgid "Find"
 msgstr "Mirar"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:259
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:258
+#, fuzzy
+msgid "Find in document"
+msgstr "Ubrir un documento HTML"
+
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "Find..."
+msgstr "Mirar"
+
+#: ../src/common/stockitem.cpp:156
 msgid "First"
 msgstr "Primeºr"
 
-#: ../src/common/prntbase.cpp:1548
+#: ../src/common/prntbase.cpp:1573
 msgid "First page"
 msgstr "Primera pachina"
 
@@ -3809,11 +3902,11 @@ msgstr "Primera pachina"
 msgid "Fixed"
 msgstr "Fixa"
 
-#: ../src/html/helpwnd.cpp:1206
+#: ../src/html/helpwnd.cpp:1204
 msgid "Fixed font:"
 msgstr "Fuent fixa:"
 
-#: ../src/html/helpwnd.cpp:1269
+#: ../src/html/helpwnd.cpp:1267
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Monoespaciau.<br> <b>negreta</b> <i>cursiva</i> "
 
@@ -3821,16 +3914,16 @@ msgstr "Monoespaciau.<br> <b>negreta</b> <i>cursiva</i> "
 msgid "Floating"
 msgstr "Flotant"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "Floppy"
 msgstr "Disquet"
 
-#: ../src/common/paper.cpp:111
+#: ../src/common/paper.cpp:108
 msgid "Folio, 8 1/2 x 13 in"
 msgstr "Folio, 8 1/2 x 13 in"
 
-#: ../src/richtext/richtextformatdlg.cpp:344 ../src/osx/carbon/fontdlg.cpp:287
-#: ../src/common/stockitem.cpp:194
+#: ../src/osx/carbon/fontdlg.cpp:284 ../src/common/stockitem.cpp:191
+#: ../src/richtext/richtextformatdlg.cpp:337
 msgid "Font"
 msgstr "Fuent"
 
@@ -3838,7 +3931,24 @@ msgstr "Fuent"
 msgid "Font &weight:"
 msgstr "&Peso d'a fuent:"
 
-#: ../src/html/helpwnd.cpp:1207
+#: ../src/osx/fontutil.cpp:89
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
+"\"."
+msgstr ""
+
+#: ../src/msw/font.cpp:1126
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "No s'ha puesto cargar o fichero."
+
+#: ../src/osx/fontutil.cpp:81
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr ": o fichero no existe!"
+
+#: ../src/html/helpwnd.cpp:1205
 msgid "Font size:"
 msgstr "Grandaria d'a fuent:"
 
@@ -3846,54 +3956,54 @@ msgstr "Grandaria d'a fuent:"
 msgid "Font st&yle:"
 msgstr "&Estilo d'a fuent:"
 
-#: ../src/osx/carbon/fontdlg.cpp:329
+#: ../src/osx/carbon/fontdlg.cpp:326
 msgid "Font:"
 msgstr "Fuent:"
 
-#: ../src/dfb/fontmgr.cpp:198
+#: ../src/dfb/fontmgr.cpp:195
 #, c-format
 msgid "Fonts index file %s disappeared while loading fonts."
 msgstr ""
 "O fichero indiz de fuents %s ha desapareixiu entre que se cargaban fuents."
 
-#: ../src/unix/utilsunx.cpp:645
+#: ../src/unix/utilsunx.cpp:647
 msgid "Fork failed"
 msgstr "No s'ha puesto a bifurcación d'o proceso"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "Forward"
 msgstr "Recular"
 
-#: ../src/common/xtixml.cpp:235
+#: ../src/common/xtixml.cpp:231
 msgid "Forward hrefs are not supported"
 msgstr "As referencias de tipo forward no son suportadas"
 
-#: ../src/html/helpwnd.cpp:875
+#: ../src/html/helpwnd.cpp:873
 #, c-format
 msgid "Found %i matches"
 msgstr "Trobadas %i coincidencias"
 
-#: ../src/generic/prntdlgg.cpp:238
+#: ../src/generic/prntdlgg.cpp:231
 msgid "From:"
 msgstr "De:"
 
-#: ../src/propgrid/advprops.cpp:1604
+#: ../src/propgrid/advprops.cpp:1510
 msgid "Fuchsia"
 msgstr ""
 
-#: ../src/common/imaggif.cpp:138
+#: ../src/common/imaggif.cpp:135
 msgid "GIF: data stream seems to be truncated."
 msgstr "GIF: O fluxo de datos pareix haber-se truncau."
 
-#: ../src/common/imaggif.cpp:128
+#: ../src/common/imaggif.cpp:125
 msgid "GIF: error in GIF image format."
 msgstr "GIF: error en o formato d'imachen GIF."
 
-#: ../src/common/imaggif.cpp:133
+#: ../src/common/imaggif.cpp:130
 msgid "GIF: not enough memory."
 msgstr "GIF: memoria insuficient."
 
-#: ../src/gtk/window.cpp:4631
+#: ../src/gtk/window.cpp:5635
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -3901,23 +4011,23 @@ msgstr ""
 "O GTK+ instalau en iste ordinador ye masiau antigo ta suportar a composición "
 "de pantalla, por favor instala o GTK+ 2.12 u superior."
 
-#: ../src/univ/themes/gtk.cpp:525
+#: ../src/univ/themes/gtk.cpp:522
 msgid "GTK+ theme"
 msgstr "Tema GTK+"
 
-#: ../src/common/preferencescmn.cpp:40
+#: ../src/common/preferencescmn.cpp:37
 msgid "General"
 msgstr "Cheneral"
 
-#: ../src/common/prntbase.cpp:258
+#: ../src/common/prntbase.cpp:253
 msgid "Generic PostScript"
 msgstr "PostScript chenerico"
 
-#: ../src/common/paper.cpp:135
+#: ../src/common/paper.cpp:132
 msgid "German Legal Fanfold, 8 1/2 x 13 in"
 msgstr "Legal alemana en aventador, 8 1/2 x 13 in"
 
-#: ../src/common/paper.cpp:134
+#: ../src/common/paper.cpp:131
 msgid "German Std Fanfold, 8 1/2 x 12 in"
 msgstr "Estandar alemana en aventador, 8 1/2 x 12 in"
 
@@ -3934,49 +4044,49 @@ msgid "GetPropertyCollection called w/o valid collection getter"
 msgstr ""
 "S'ha clamau a GetPropertyCollection sin un obtenedor de colección valido"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:658
 msgid "Go back"
 msgstr "Ir ta zaga"
 
-#: ../src/html/helpwnd.cpp:661
+#: ../src/html/helpwnd.cpp:659
 msgid "Go forward"
 msgstr "Ir ta debant"
 
-#: ../src/html/helpwnd.cpp:663
+#: ../src/html/helpwnd.cpp:661
 msgid "Go one level up in document hierarchy"
 msgstr "Puyar un libel en a hierarquía d'o documento"
 
-#: ../src/generic/filedlgg.cpp:208 ../src/generic/dirdlgg.cpp:116
+#: ../src/generic/filedlgg.cpp:205 ../src/generic/dirdlgg.cpp:113
 msgid "Go to home directory"
 msgstr "Ir ta lo directorio prencipal"
 
-#: ../src/generic/filedlgg.cpp:205
+#: ../src/generic/filedlgg.cpp:202
 msgid "Go to parent directory"
 msgstr "Ir ta lo directorio pai"
 
-#: ../src/generic/aboutdlgg.cpp:76
+#: ../src/generic/aboutdlgg.cpp:73
 msgid "Graphics art by "
 msgstr "Graficos por "
 
-#: ../src/propgrid/advprops.cpp:1599
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Gray"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:883
+#: ../src/propgrid/advprops.cpp:784
 msgid "GrayText"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:154
+#: ../src/common/fmapbase.cpp:151
 msgid "Greek (ISO-8859-7)"
 msgstr "Griego (ISO-8859-7)"
 
-#: ../src/propgrid/advprops.cpp:1600
+#: ../src/propgrid/advprops.cpp:1506
 #, fuzzy
 msgid "Green"
 msgstr "Mac Griego"
 
-#: ../src/generic/colrdlgg.cpp:342
+#: ../src/generic/colrdlgg.cpp:362
 #, fuzzy
 msgid "Green:"
 msgstr "Mac Griego"
@@ -3985,109 +4095,109 @@ msgstr "Mac Griego"
 msgid "Groove"
 msgstr "Acanalau"
 
-#: ../src/common/zstream.cpp:158 ../src/common/zstream.cpp:318
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
 msgid "Gzip not supported by this version of zlib"
 msgstr "Gzip no ye suportau por ista versión de zlib"
 
-#: ../src/html/helpwnd.cpp:1549
+#: ../src/html/helpwnd.cpp:1547
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "Prochecto d'aduya HTML (*.hhp)|*.hhp|"
 
-#: ../src/html/htmlwin.cpp:681
+#: ../src/html/htmlwin.cpp:691
 #, c-format
 msgid "HTML anchor %s does not exist."
 msgstr "L'ancorache HTML %s no existe."
 
-#: ../src/html/helpwnd.cpp:1547
+#: ../src/html/helpwnd.cpp:1545
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "Fichers HTML (*.html;*.htm)|*.html;*.htm|"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1759
+#: ../src/propgrid/advprops.cpp:1660
 msgid "Hand"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "Harddisk"
 msgstr "Disco duro"
 
-#: ../src/common/fmapbase.cpp:155
+#: ../src/common/fmapbase.cpp:152
 msgid "Hebrew (ISO-8859-8)"
 msgstr "Hebreu (ISO-8859-8)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:280 ../src/osx/button_osx.cpp:39
-#: ../src/common/stockitem.cpp:163 ../src/common/accelcmn.cpp:80
-#: ../src/html/helpdlg.cpp:66 ../src/html/helpfrm.cpp:111
+#: ../include/wx/msgdlg.h:282 ../src/osx/button_osx.cpp:39
+#: ../src/common/stockitem.cpp:160 ../src/common/accelcmn.cpp:77
+#: ../src/html/helpfrm.cpp:108 ../src/html/helpdlg.cpp:63
 msgid "Help"
 msgstr "Aduya"
 
-#: ../src/html/helpwnd.cpp:1200
+#: ../src/html/helpwnd.cpp:1198
 msgid "Help Browser Options"
 msgstr "Opcions d'o Navegador de l'Aduya"
 
-#: ../src/generic/helpext.cpp:454 ../src/generic/helpext.cpp:455
+#: ../src/generic/helpext.cpp:452 ../src/generic/helpext.cpp:453
 msgid "Help Index"
 msgstr "Indiz de l'Aduya"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1529
 msgid "Help Printing"
 msgstr "Aduya d'Impresión"
 
-#: ../src/html/helpwnd.cpp:801
+#: ../src/html/helpwnd.cpp:799
 msgid "Help Topics"
 msgstr "Temas d'aduya"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1546
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Libros d'aduya (*.htb)|*.htb|Libros d'aduya (*.zip)|*.zip|"
 
-#: ../src/generic/helpext.cpp:267
+#: ../src/generic/helpext.cpp:265
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "Directorio d'aduya \"%s\" no trobau."
 
-#: ../src/generic/helpext.cpp:275
+#: ../src/generic/helpext.cpp:273
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "Fichero d'aduya \"%s\" no trobau."
 
-#: ../src/html/helpctrl.cpp:63
+#: ../src/html/helpctrl.cpp:59
 #, c-format
 msgid "Help: %s"
 msgstr "Aduya: %s"
 
-#: ../src/osx/menu_osx.cpp:577
+#: ../src/osx/menu_osx.cpp:469
 #, c-format
 msgid "Hide %s"
 msgstr "Amagar %s"
 
-#: ../src/osx/menu_osx.cpp:579
+#: ../src/osx/menu_osx.cpp:471
 msgid "Hide Others"
 msgstr "Amagar atros"
 
-#: ../src/generic/infobar.cpp:84
+#: ../src/generic/infobar.cpp:81
 msgid "Hide this notification message."
 msgstr "Amagar iste mensache de notificación."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:884
+#: ../src/propgrid/advprops.cpp:785
 #, fuzzy
 msgid "Highlight"
 msgstr "lichera"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:885
+#: ../src/propgrid/advprops.cpp:786
 #, fuzzy
 msgid "HighlightText"
 msgstr "Texto aliniau a la dreita."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:164 ../src/common/accelcmn.cpp:65
+#: ../src/common/stockitem.cpp:161 ../src/common/accelcmn.cpp:62
 msgid "Home"
 msgstr "Inicio"
 
-#: ../src/generic/dirctrlg.cpp:524
+#: ../src/generic/dirctrlg.cpp:490
 msgid "Home directory"
 msgstr "Directorio prencipal"
 
@@ -4097,55 +4207,55 @@ msgid "How the object will float relative to the text."
 msgstr "Como flotará l'obchecto en relación a lo texto."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1760
+#: ../src/propgrid/advprops.cpp:1661
 msgid "I-Beam"
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1196
+#: ../src/common/imagbmp.cpp:1208
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: Error en leyer a mascareta DIB."
 
-#: ../src/common/imagbmp.cpp:1290 ../src/common/imagbmp.cpp:1390
-#: ../src/common/imagbmp.cpp:1405 ../src/common/imagbmp.cpp:1416
-#: ../src/common/imagbmp.cpp:1430 ../src/common/imagbmp.cpp:1478
-#: ../src/common/imagbmp.cpp:1493 ../src/common/imagbmp.cpp:1507
-#: ../src/common/imagbmp.cpp:1518
+#: ../src/common/imagbmp.cpp:1302 ../src/common/imagbmp.cpp:1402
+#: ../src/common/imagbmp.cpp:1417 ../src/common/imagbmp.cpp:1428
+#: ../src/common/imagbmp.cpp:1442 ../src/common/imagbmp.cpp:1490
+#: ../src/common/imagbmp.cpp:1505 ../src/common/imagbmp.cpp:1519
+#: ../src/common/imagbmp.cpp:1530
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: Error en escribir o fichero d'imachen!"
 
-#: ../src/common/imagbmp.cpp:1255
+#: ../src/common/imagbmp.cpp:1267
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: Imachen masiau alta ta un icono."
 
-#: ../src/common/imagbmp.cpp:1263
+#: ../src/common/imagbmp.cpp:1275
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: Imachen masiau ampla ta un icono."
 
-#: ../src/common/imagbmp.cpp:1603
+#: ../src/common/imagbmp.cpp:1615
 msgid "ICO: Invalid icon index."
 msgstr "ICO: Indiz d'icono no valido."
 
-#: ../src/common/imagiff.cpp:758
+#: ../src/common/imagiff.cpp:755
 msgid "IFF: data stream seems to be truncated."
 msgstr "IFF: o fluxo de datos pareix truncau."
 
-#: ../src/common/imagiff.cpp:742
+#: ../src/common/imagiff.cpp:739
 msgid "IFF: error in IFF image format."
 msgstr "IFF: error en o formato d'imachen IFF."
 
-#: ../src/common/imagiff.cpp:745
+#: ../src/common/imagiff.cpp:742
 msgid "IFF: not enough memory."
 msgstr "IFF: memoria insuficient."
 
-#: ../src/common/imagiff.cpp:748
+#: ../src/common/imagiff.cpp:745
 msgid "IFF: unknown error!!!"
 msgstr "IFF: error desconoixida!!!"
 
-#: ../src/common/fmapbase.cpp:197
+#: ../src/common/fmapbase.cpp:194
 msgid "ISO-2022-JP"
 msgstr "ISO-2022-JP"
 
-#: ../src/html/htmprint.cpp:282
+#: ../src/html/htmprint.cpp:294
 msgid ""
 "If possible, try changing the layout parameters to make the printout more "
 "narrow."
@@ -4153,7 +4263,7 @@ msgstr ""
 "Si ye posible, preba a cambiar a distribución d'os parametros ta fer a "
 "impresión mas estreita."
 
-#: ../src/generic/dbgrptg.cpp:358
+#: ../src/generic/dbgrptg.cpp:362
 msgid ""
 "If you have any additional information pertaining to this bug\n"
 "report, please enter it here and it will be joined to it:"
@@ -4173,46 +4283,50 @@ msgstr ""
 "pero saba que isto no aduya a la millora d'o programa, por tanto, si\n"
 "ye posible, por favor, contina con a cheneración d'o reporte.\n"
 
-#: ../src/msw/registry.cpp:1405
+#: ../src/common/zipstrm.cpp:1043
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1393
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "S'ignorará a valura \"%s\" d'a clau \"%s\"."
 
-#: ../src/common/xtistrm.cpp:295
+#: ../src/common/xtistrm.cpp:292
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Clase d'obchecto (Non-wxEvtHandler) como Event Source ilegal"
 
-#: ../src/common/xti.cpp:513
+#: ../src/common/xti.cpp:510
 msgid "Illegal Parameter Count for ConstructObject Method"
 msgstr "Numero ilegal de parametros ta lo metodo ConstructObject"
 
-#: ../src/common/xti.cpp:501
+#: ../src/common/xti.cpp:498
 msgid "Illegal Parameter Count for Create Method"
 msgstr "Numero ilegal de parametros ta lo metodo Create"
 
-#: ../src/generic/dirctrlg.cpp:570 ../src/generic/filectrlg.cpp:756
+#: ../src/generic/dirctrlg.cpp:536 ../src/generic/filectrlg.cpp:752
 msgid "Illegal directory name."
 msgstr "Nombre de directorio ilegal."
 
-#: ../src/generic/filectrlg.cpp:1367
+#: ../src/generic/filectrlg.cpp:1356
 msgid "Illegal file specification."
 msgstr "Especificación de fichero ilegal."
 
-#: ../src/common/image.cpp:2269
+#: ../src/common/image.cpp:2363
 msgid "Image and mask have different sizes."
 msgstr "A imachen y a mascareta tienen grandarias diferents."
 
-#: ../src/common/image.cpp:2746
+#: ../src/common/image.cpp:2841
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "O fichero de imachen no ye d'a mena %d."
 
-#: ../src/common/image.cpp:2877
+#: ../src/common/image.cpp:2995
 #, c-format
 msgid "Image is not of type %s."
 msgstr "A imachen no ye d'a mena %s."
 
-#: ../src/msw/textctrl.cpp:488
+#: ../src/msw/textctrl.cpp:534
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -4220,102 +4334,102 @@ msgstr ""
 "Ye imposible de creyar o control 'rich edit', s'usará o control de texto "
 "simple. Por favor instala riched32.dll"
 
-#: ../src/unix/utilsunx.cpp:301
+#: ../src/unix/utilsunx.cpp:303
 msgid "Impossible to get child process input"
 msgstr "Ye imposible obtener a dentrada d'o proceso fillo"
 
-#: ../src/common/filefn.cpp:1028
+#: ../src/common/filefn.cpp:917
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Ye imposible obtener permisos ta lo fichero '%s'"
 
-#: ../src/common/filefn.cpp:1042
+#: ../src/common/filefn.cpp:931
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Ye imposible sobrescribir o fichero '%s'"
 
-#: ../src/common/filefn.cpp:1097
+#: ../src/common/filefn.cpp:986
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Ye imposible establir permisos ta lo fichero '%s'"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:886
+#: ../src/propgrid/advprops.cpp:787
 #, fuzzy
 msgid "InactiveBorder"
 msgstr "Canto"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:887
+#: ../src/propgrid/advprops.cpp:788
 msgid "InactiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:888
+#: ../src/propgrid/advprops.cpp:789
 msgid "InactiveCaptionText"
 msgstr ""
 
-#: ../src/common/gifdecod.cpp:792
+#: ../src/common/gifdecod.cpp:826
 #, c-format
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "Grandaria de marco GIF incorrecta (%u, %d) pa lo marco #%u"
 
-#: ../src/msw/ole/automtn.cpp:635
+#: ../src/msw/ole/automtn.cpp:626
 msgid "Incorrect number of arguments."
 msgstr "Numero incorrecto d'argumentos."
 
-#: ../src/common/stockitem.cpp:165
+#: ../src/common/stockitem.cpp:162
 msgid "Indent"
 msgstr "Escalonau"
 
-#: ../src/richtext/richtextformatdlg.cpp:349
+#: ../src/richtext/richtextformatdlg.cpp:342
 msgid "Indents && Spacing"
 msgstr "Espaciau && Escalonaus"
 
-#: ../src/common/stockitem.cpp:166 ../src/html/helpwnd.cpp:515
+#: ../src/common/stockitem.cpp:163 ../src/html/helpwnd.cpp:513
 msgid "Index"
 msgstr "Indiz"
 
-#: ../src/common/fmapbase.cpp:159
+#: ../src/common/fmapbase.cpp:156
 msgid "Indian (ISO-8859-12)"
 msgstr "Indico (ISO-8859-12)"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "Info"
 msgstr "Información"
 
-#: ../src/common/init.cpp:287
+#: ../src/common/init.cpp:284
 msgid "Initialization failed in post init, aborting."
 msgstr "Ha fallau a inicialización en post init, abortando-la."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:54
+#: ../src/common/accelcmn.cpp:51
 #, fuzzy
 msgid "Ins"
 msgstr "Interno"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextsymboldlg.cpp:472 ../src/common/accelcmn.cpp:53
+#: ../src/common/accelcmn.cpp:50 ../src/richtext/richtextsymboldlg.cpp:469
 msgid "Insert"
 msgstr "Ficar"
 
-#: ../src/richtext/richtextbuffer.cpp:8067
+#: ../src/richtext/richtextbuffer.cpp:8063
 msgid "Insert Field"
 msgstr "Ficar un campo"
 
-#: ../src/richtext/richtextbuffer.cpp:7978
-#: ../src/richtext/richtextbuffer.cpp:8936
+#: ../src/richtext/richtextbuffer.cpp:7974
+#: ../src/richtext/richtextbuffer.cpp:8934
 msgid "Insert Image"
 msgstr "Ficar una imachen"
 
-#: ../src/richtext/richtextbuffer.cpp:8025
+#: ../src/richtext/richtextbuffer.cpp:8021
 msgid "Insert Object"
 msgstr "Ficar un obchecto"
 
-#: ../src/richtext/richtextctrl.cpp:1286 ../src/richtext/richtextctrl.cpp:1494
-#: ../src/richtext/richtextbuffer.cpp:7822
-#: ../src/richtext/richtextbuffer.cpp:7852
-#: ../src/richtext/richtextbuffer.cpp:7894
+#: ../src/richtext/richtextbuffer.cpp:7818
+#: ../src/richtext/richtextbuffer.cpp:7848
+#: ../src/richtext/richtextbuffer.cpp:7890
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
 msgid "Insert Text"
 msgstr "Ficar Texto"
 
@@ -4328,16 +4442,11 @@ msgstr "Ficar un blinco de pachina antis d'o paragrafo."
 msgid "Inset"
 msgstr "Interno"
 
-#: ../src/gtk/app.cpp:425
-#, c-format
-msgid "Invalid GTK+ command line option, use \"%s --help\""
-msgstr "Opción GTK+ de linia de comandos invalida, Fe servir \"%s --help\""
-
-#: ../src/common/imagtiff.cpp:311
+#: ../src/common/imagtiff.cpp:308
 msgid "Invalid TIFF image index."
 msgstr "Indiz d'imachen TIFF no valido."
 
-#: ../src/common/appcmn.cpp:273
+#: ../src/common/appcmn.cpp:294
 #, c-format
 msgid "Invalid display mode specification '%s'."
 msgstr "Especificación de 'display' no valida: '%s'."
@@ -4347,258 +4456,262 @@ msgstr "Especificación de 'display' no valida: '%s'."
 msgid "Invalid geometry specification '%s'"
 msgstr "Especificación de cheometría no valida: '%s'"
 
-#: ../src/unix/fswatcher_inotify.cpp:323
+#: ../src/unix/fswatcher_inotify.cpp:320
 #, c-format
 msgid "Invalid inotify event for \"%s\""
 msgstr "Evento inotify invalido ta \"%s\""
 
-#: ../src/unix/snglinst.cpp:312
+#: ../src/unix/snglinst.cpp:309
 #, c-format
 msgid "Invalid lock file '%s'."
 msgstr "Fichero de bloqueyo '%s' no valido."
 
-#: ../src/common/translation.cpp:1125
+#: ../src/common/translation.cpp:1167
 msgid "Invalid message catalog."
 msgstr "Catalogo de mensaches invalido."
 
-#: ../src/common/xtistrm.cpp:405 ../src/common/xtistrm.cpp:420
+#: ../src/common/xtistrm.cpp:402 ../src/common/xtistrm.cpp:417
 msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
 msgstr "Identificador d'obchecto pasau a GetObjectClassInfo nulo u invalido"
 
-#: ../src/common/xtistrm.cpp:435
+#: ../src/common/xtistrm.cpp:432
 msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
 msgstr "Identificador d'obchecto pasau a HasObjectClassInfo nulo u invalido"
 
-#: ../src/common/regex.cpp:310
+#: ../src/common/regex.cpp:307
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Expresión regular no valida '%s': %s"
 
-#: ../src/common/config.cpp:226
+#: ../src/common/config.cpp:222
 #, c-format
 msgid "Invalid value %ld for a boolean key \"%s\" in config file."
 msgstr ""
 "Valor invalida %ld ta una clau booleana \"%s\" en o fichero de configuración."
 
-#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:351
-#: ../src/osx/carbon/fontdlg.cpp:361 ../src/common/stockitem.cpp:168
+#: ../src/osx/carbon/fontdlg.cpp:358 ../src/common/stockitem.cpp:165
+#: ../src/generic/fontdlgg.cpp:325 ../src/richtext/richtextfontpage.cpp:351
 msgid "Italic"
 msgstr "Cursiva"
 
-#: ../src/common/paper.cpp:130
+#: ../src/common/paper.cpp:127
 msgid "Italy Envelope, 110 x 230 mm"
 msgstr "Sobre Italián, 110 x 230 mm"
 
-#: ../src/common/imagjpeg.cpp:270
+#: ../src/common/imagjpeg.cpp:257
 msgid "JPEG: Couldn't load - file is probably corrupted."
 msgstr "JPEG: No s'ha puesto ubrir - o fichero ye prebablement corrupto."
 
-#: ../src/common/imagjpeg.cpp:449
+#: ../src/common/imagjpeg.cpp:436
 msgid "JPEG: Couldn't save image."
 msgstr "JPEG: No s'ha puesto alzar a imachen."
 
-#: ../src/common/paper.cpp:163
+#: ../src/common/paper.cpp:160
 msgid "Japanese Double Postcard 200 x 148 mm"
 msgstr "Tarcheta Chaponesa Dople 200 x 148 mm"
 
-#: ../src/common/paper.cpp:167
+#: ../src/common/paper.cpp:164
 msgid "Japanese Envelope Chou #3"
 msgstr "Sobre chaponés Chou #3"
 
-#: ../src/common/paper.cpp:180
+#: ../src/common/paper.cpp:177
 msgid "Japanese Envelope Chou #3 Rotated"
 msgstr "Sobre chaponés Chou #3 Chirau"
 
-#: ../src/common/paper.cpp:168
+#: ../src/common/paper.cpp:165
 msgid "Japanese Envelope Chou #4"
 msgstr "Sobre chaponés Chou #4"
 
-#: ../src/common/paper.cpp:181
+#: ../src/common/paper.cpp:178
 msgid "Japanese Envelope Chou #4 Rotated"
 msgstr "Sobre chaponés Chou #4 Chirau"
 
-#: ../src/common/paper.cpp:165
+#: ../src/common/paper.cpp:162
 msgid "Japanese Envelope Kaku #2"
 msgstr "Sobre chaponés Kaku #2"
 
-#: ../src/common/paper.cpp:178
+#: ../src/common/paper.cpp:175
 msgid "Japanese Envelope Kaku #2 Rotated"
 msgstr "Sobre chaponés Kaku #2 Chirau"
 
-#: ../src/common/paper.cpp:166
+#: ../src/common/paper.cpp:163
 msgid "Japanese Envelope Kaku #3"
 msgstr "Sobre chaponés Kaku #3"
 
-#: ../src/common/paper.cpp:179
+#: ../src/common/paper.cpp:176
 msgid "Japanese Envelope Kaku #3 Rotated"
 msgstr "Sobre chaponés Kaku #3 Chirau"
 
-#: ../src/common/paper.cpp:185
+#: ../src/common/paper.cpp:182
 msgid "Japanese Envelope You #4"
 msgstr "Sobre chaponés You #4"
 
-#: ../src/common/paper.cpp:186
+#: ../src/common/paper.cpp:183
 msgid "Japanese Envelope You #4 Rotated"
 msgstr "Sobre chaponés You #4 Chirau"
 
-#: ../src/common/paper.cpp:138
+#: ../src/common/paper.cpp:135
 msgid "Japanese Postcard 100 x 148 mm"
 msgstr "Tarcheta Chaponesa 100 x 148 mm"
 
-#: ../src/common/paper.cpp:175
+#: ../src/common/paper.cpp:172
 msgid "Japanese Postcard Rotated 148 x 100 mm"
 msgstr "Tarcheta Chaponesa Chirada 148 x 100 mm"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "Jump to"
 msgstr "Blincar ta"
 
-#: ../src/common/stockitem.cpp:171
+#: ../src/common/stockitem.cpp:168
 msgid "Justified"
 msgstr "Chustificau"
 
-#: ../src/richtext/richtextindentspage.cpp:155
-#: ../src/richtext/richtextindentspage.cpp:157
 #: ../src/richtext/richtextliststylepage.cpp:344
 #: ../src/richtext/richtextliststylepage.cpp:346
+#: ../src/richtext/richtextindentspage.cpp:155
+#: ../src/richtext/richtextindentspage.cpp:157
 msgid "Justify text left and right."
 msgstr "Chustificar o texto a cucha y dreita."
 
-#: ../src/common/fmapbase.cpp:163
+#: ../src/common/fmapbase.cpp:160
 msgid "KOI8-R"
 msgstr "KOI8-R"
 
-#: ../src/common/fmapbase.cpp:164
+#: ../src/common/fmapbase.cpp:161
 msgid "KOI8-U"
 msgstr "KOI8-U"
 
-#: ../src/common/accelcmn.cpp:265 ../src/common/accelcmn.cpp:347
+#: ../src/common/accelcmn.cpp:279 ../src/common/accelcmn.cpp:364
 msgid "KP_"
 msgstr "KP_"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 #, fuzzy
 msgid "KP_Add"
 msgstr "KP_SUMAR"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "KP_Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "KP_Decimal"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 #, fuzzy
 msgid "KP_Delete"
 msgstr "Eliminar"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "KP_Divide"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 #, fuzzy
 msgid "KP_Down"
 msgstr "Abaixo"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 #, fuzzy
 msgid "KP_End"
 msgstr "KP_FIN"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 #, fuzzy
 msgid "KP_Enter"
 msgstr "Impresora"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "KP_Equal"
 msgstr ""
 
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
-#, fuzzy
-msgid "KP_Home"
-msgstr "Inicio"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
-#, fuzzy
-msgid "KP_Insert"
-msgstr "Ficar"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
-#, fuzzy
-msgid "KP_Left"
-msgstr "Cucha"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
-msgid "KP_Multiply"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:99
-#, fuzzy
-msgid "KP_Next"
-msgstr "Siguient"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
-msgid "KP_PageDown"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
-msgid "KP_PageUp"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:98
-msgid "KP_Prior"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
-#, fuzzy
-msgid "KP_Right"
-msgstr "Dreita"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
-msgid "KP_Separator"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
-msgid "KP_Space"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
-msgid "KP_Subtract"
+#: ../src/common/accelcmn.cpp:276 ../src/common/accelcmn.cpp:361
+msgid "KP_F"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
 #: ../src/common/accelcmn.cpp:89
 #, fuzzy
+msgid "KP_Home"
+msgstr "Inicio"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:100
+#, fuzzy
+msgid "KP_Insert"
+msgstr "Ficar"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:90
+#, fuzzy
+msgid "KP_Left"
+msgstr "Cucha"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:103
+msgid "KP_Multiply"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:97
+#, fuzzy
+msgid "KP_Next"
+msgstr "Siguient"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:95
+msgid "KP_PageDown"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:94
+msgid "KP_PageUp"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:96
+msgid "KP_Prior"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:92
+#, fuzzy
+msgid "KP_Right"
+msgstr "Dreita"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:105
+msgid "KP_Separator"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:86
+msgid "KP_Space"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:106
+msgid "KP_Subtract"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:87
+#, fuzzy
 msgid "KP_Tab"
 msgstr "KP_TAB"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 #, fuzzy
 msgid "KP_Up"
 msgstr "KP_ALTO"
@@ -4607,112 +4720,127 @@ msgstr "KP_ALTO"
 msgid "L&ine spacing:"
 msgstr "Espaciau de l&inia:"
 
-#: ../src/generic/prntdlgg.cpp:613 ../src/generic/prntdlgg.cpp:868
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "s'ha produciu una error de compresión"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "s'ha produciu una error de descompresión"
+
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:861
 msgid "Landscape"
 msgstr "Horizontal"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "Last"
 msgstr "Zaguer"
 
-#: ../src/common/prntbase.cpp:1572
+#: ../src/common/prntbase.cpp:1597
 msgid "Last page"
 msgstr "Zaguera pachina"
 
-#: ../src/common/log.cpp:305
+#: ../src/common/log.cpp:324
 #, fuzzy, c-format
 msgid "Last repeated message (\"%s\", %u time) wasn't output"
 msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
 msgstr[0] "O zaguer mensache repetiu (\"%s\", %lu vegada) no yera a salida."
 msgstr[1] "O zaguer mensache repetiu (\"%s\", %lu vegadas) no yera a salida."
 
-#: ../src/common/paper.cpp:103
+#: ../src/common/paper.cpp:100
 msgid "Ledger, 17 x 11 in"
 msgstr "Libro de contos, 17 x 11 in"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6146
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:58 ../src/generic/datavgen.cpp:6951
+#: ../src/richtext/richtextsizepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:252
 #: ../src/richtext/richtextliststylepage.cpp:253
 #: ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
-#: ../src/richtext/richtextsizepage.cpp:249 ../src/common/accelcmn.cpp:61
 msgid "Left"
 msgstr "Cucha"
 
-#: ../src/richtext/richtextindentspage.cpp:204
 #: ../src/richtext/richtextliststylepage.cpp:390
+#: ../src/richtext/richtextindentspage.cpp:204
 msgid "Left (&first line):"
 msgstr "Cucha (&primera linia):"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1761
+#: ../src/propgrid/advprops.cpp:1662
 msgid "Left Button"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:880
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Left margin (mm):"
 msgstr "Marguin cucha (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:141
-#: ../src/richtext/richtextindentspage.cpp:143
 #: ../src/richtext/richtextliststylepage.cpp:330
 #: ../src/richtext/richtextliststylepage.cpp:332
+#: ../src/richtext/richtextindentspage.cpp:141
+#: ../src/richtext/richtextindentspage.cpp:143
 msgid "Left-align text."
 msgstr "Texto aliniau a la cucha."
 
-#: ../src/common/paper.cpp:144
+#: ../src/common/paper.cpp:141
 msgid "Legal Extra 9 1/2 x 15 in"
 msgstr "Legal Extra 9 1/2 x 15 in"
 
-#: ../src/common/paper.cpp:96
+#: ../src/common/paper.cpp:93
 msgid "Legal, 8 1/2 x 14 in"
 msgstr "Legal, 8 1/2 x 14 in"
 
-#: ../src/common/paper.cpp:143
+#: ../src/common/paper.cpp:140
 msgid "Letter Extra 9 1/2 x 12 in"
 msgstr "Carta extra 9 1/2 x 12 in"
 
-#: ../src/common/paper.cpp:149
+#: ../src/common/paper.cpp:146
 msgid "Letter Extra Transverse 9.275 x 12 in"
 msgstr "Carta extra transversal 9.275 x 12 in"
 
-#: ../src/common/paper.cpp:152
+#: ../src/common/paper.cpp:149
 msgid "Letter Plus 8 1/2 x 12.69 in"
 msgstr "Carta Plus 8 1/2 x 12.69 in"
 
-#: ../src/common/paper.cpp:169
+#: ../src/common/paper.cpp:166
 msgid "Letter Rotated 11 x 8 1/2 in"
 msgstr "Carta chirada 11 x 8 1/2 in"
 
-#: ../src/common/paper.cpp:101
+#: ../src/common/paper.cpp:98
 msgid "Letter Small, 8 1/2 x 11 in"
 msgstr "Carta chicota, 8 1/2 x 11 in"
 
-#: ../src/common/paper.cpp:147
+#: ../src/common/paper.cpp:144
 msgid "Letter Transverse 8 1/2 x 11 in"
 msgstr "Carta transversal 8 1/2 x 11 in"
 
-#: ../src/common/paper.cpp:95
+#: ../src/common/paper.cpp:92
 msgid "Letter, 8 1/2 x 11 in"
 msgstr "Carta, 8 1/2 x 11 in"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "License"
 msgstr "Licencia"
 
-#: ../src/generic/fontdlgg.cpp:332
+#: ../src/generic/fontdlgg.cpp:328
 msgid "Light"
 msgstr "Lichera"
 
-#: ../src/propgrid/advprops.cpp:1608
+#: ../src/propgrid/advprops.cpp:1514
 msgid "Lime"
 msgstr ""
 
-#: ../src/generic/helpext.cpp:294
+#: ../src/generic/helpext.cpp:292
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr ""
@@ -4723,15 +4851,15 @@ msgstr ""
 msgid "Line spacing:"
 msgstr "Espaciau de linia:"
 
-#: ../src/html/chm.cpp:838
+#: ../src/html/chm.cpp:829
 msgid "Link contained '//', converted to absolute link."
 msgstr "O vinclo contién '//', convertiu a vinclo absoluto."
 
-#: ../src/richtext/richtextformatdlg.cpp:364
+#: ../src/richtext/richtextformatdlg.cpp:357
 msgid "List Style"
 msgstr "Estilo de Lista"
 
-#: ../src/richtext/richtextstyles.cpp:1064
+#: ../src/richtext/richtextstyles.cpp:1061
 msgid "List styles"
 msgstr "Estilos de lista"
 
@@ -4745,26 +4873,26 @@ msgstr "Grandarias de fuent de listas en puntos."
 msgid "Lists the available fonts."
 msgstr "Lista las fuents disponibles."
 
-#: ../src/common/fldlgcmn.cpp:340
+#: ../src/common/fldlgcmn.cpp:337
 #, c-format
 msgid "Load %s file"
 msgstr "Cargar o fichero %s"
 
-#: ../src/html/htmlwin.cpp:597
+#: ../src/html/htmlwin.cpp:600
 msgid "Loading : "
 msgstr "Cargando : "
 
-#: ../src/unix/snglinst.cpp:246
+#: ../src/unix/snglinst.cpp:243
 #, c-format
 msgid "Lock file '%s' has incorrect owner."
 msgstr "O fichero de bloqueyo '%s' tién un propietario incorrecto."
 
-#: ../src/unix/snglinst.cpp:251
+#: ../src/unix/snglinst.cpp:248
 #, c-format
 msgid "Lock file '%s' has incorrect permissions."
 msgstr "O fichero de bloqueyo '%s' tién permisos incorrectos."
 
-#: ../src/generic/logg.cpp:576
+#: ../src/generic/logg.cpp:573
 #, c-format
 msgid "Log saved to the file '%s'."
 msgstr "Rechistro alzau en o fichero '%s'."
@@ -4779,11 +4907,11 @@ msgstr "Letras minusclas"
 msgid "Lower case roman numerals"
 msgstr "Numeros romanos en minuscla"
 
-#: ../src/gtk/mdi.cpp:422 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk1/mdi.cpp:431 ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "Finestra filla MDI"
 
-#: ../src/msw/helpchm.cpp:56
+#: ../src/msw/helpchm.cpp:53
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -4791,189 +4919,189 @@ msgstr ""
 "As funcions d'Aduya MS HTML no son disponibles porque a librería d'Aduya MS "
 "HTML no ye instalada. Por favor instala-la."
 
-#: ../src/univ/themes/win32.cpp:3754
+#: ../src/univ/themes/win32.cpp:3751
 msgid "Ma&ximize"
 msgstr "Ma&ximizar"
 
-#: ../src/common/fmapbase.cpp:203
+#: ../src/common/fmapbase.cpp:200
 msgid "MacArabic"
 msgstr "Mac Arabe"
 
-#: ../src/common/fmapbase.cpp:222
+#: ../src/common/fmapbase.cpp:219
 msgid "MacArmenian"
 msgstr "Mac Armenio"
 
-#: ../src/common/fmapbase.cpp:211
+#: ../src/common/fmapbase.cpp:208
 msgid "MacBengali"
 msgstr "Mac Bengalí"
 
-#: ../src/common/fmapbase.cpp:217
+#: ../src/common/fmapbase.cpp:214
 msgid "MacBurmese"
 msgstr "Mac Burmese"
 
-#: ../src/common/fmapbase.cpp:236
+#: ../src/common/fmapbase.cpp:233
 msgid "MacCeltic"
 msgstr "Mac Celtico"
 
-#: ../src/common/fmapbase.cpp:227
+#: ../src/common/fmapbase.cpp:224
 msgid "MacCentralEurRoman"
 msgstr "Mac Román Centroeuropeu"
 
-#: ../src/common/fmapbase.cpp:223
+#: ../src/common/fmapbase.cpp:220
 msgid "MacChineseSimp"
 msgstr "Mac Chino Simplificau"
 
-#: ../src/common/fmapbase.cpp:201
+#: ../src/common/fmapbase.cpp:198
 msgid "MacChineseTrad"
 msgstr "Mac Chino Tradicional"
 
-#: ../src/common/fmapbase.cpp:233
+#: ../src/common/fmapbase.cpp:230
 msgid "MacCroatian"
 msgstr "Mac Crovata"
 
-#: ../src/common/fmapbase.cpp:206
+#: ../src/common/fmapbase.cpp:203
 msgid "MacCyrillic"
 msgstr "Mac Cirilico"
 
-#: ../src/common/fmapbase.cpp:207
+#: ../src/common/fmapbase.cpp:204
 msgid "MacDevanagari"
 msgstr "Mac Devanagari"
 
-#: ../src/common/fmapbase.cpp:231
+#: ../src/common/fmapbase.cpp:228
 msgid "MacDingbats"
 msgstr "Mac pictogramas"
 
-#: ../src/common/fmapbase.cpp:226
+#: ../src/common/fmapbase.cpp:223
 msgid "MacEthiopic"
 msgstr "Mac Etiope"
 
-#: ../src/common/fmapbase.cpp:229
+#: ../src/common/fmapbase.cpp:226
 msgid "MacExtArabic"
 msgstr "Mac Arabe Ext"
 
-#: ../src/common/fmapbase.cpp:237
+#: ../src/common/fmapbase.cpp:234
 msgid "MacGaelic"
 msgstr "Mac Gaelico"
 
-#: ../src/common/fmapbase.cpp:221
+#: ../src/common/fmapbase.cpp:218
 msgid "MacGeorgian"
 msgstr "Mac Cheorchiano"
 
-#: ../src/common/fmapbase.cpp:205
+#: ../src/common/fmapbase.cpp:202
 msgid "MacGreek"
 msgstr "Mac Griego"
 
-#: ../src/common/fmapbase.cpp:209
+#: ../src/common/fmapbase.cpp:206
 msgid "MacGujarati"
 msgstr "Mac gujarati"
 
-#: ../src/common/fmapbase.cpp:208
+#: ../src/common/fmapbase.cpp:205
 msgid "MacGurmukhi"
 msgstr "Mac gurmukhi"
 
-#: ../src/common/fmapbase.cpp:204
+#: ../src/common/fmapbase.cpp:201
 msgid "MacHebrew"
 msgstr "Mac Hebreu"
 
-#: ../src/common/fmapbase.cpp:234
+#: ../src/common/fmapbase.cpp:231
 msgid "MacIcelandic"
 msgstr "Mac Islandés"
 
-#: ../src/common/fmapbase.cpp:200
+#: ../src/common/fmapbase.cpp:197
 msgid "MacJapanese"
 msgstr "Mac Chaponés"
 
-#: ../src/common/fmapbase.cpp:214
+#: ../src/common/fmapbase.cpp:211
 msgid "MacKannada"
 msgstr "Mac Canadá"
 
-#: ../src/common/fmapbase.cpp:238
+#: ../src/common/fmapbase.cpp:235
 msgid "MacKeyboardGlyphs"
 msgstr "Mac Caracters Especials"
 
-#: ../src/common/fmapbase.cpp:218
+#: ../src/common/fmapbase.cpp:215
 msgid "MacKhmer"
 msgstr "Mac Camboyano"
 
-#: ../src/common/fmapbase.cpp:202
+#: ../src/common/fmapbase.cpp:199
 msgid "MacKorean"
 msgstr "Mac Coreán"
 
-#: ../src/common/fmapbase.cpp:220
+#: ../src/common/fmapbase.cpp:217
 msgid "MacLaotian"
 msgstr "Mac Laosián"
 
-#: ../src/common/fmapbase.cpp:215
+#: ../src/common/fmapbase.cpp:212
 msgid "MacMalayalam"
 msgstr "Mac Malayo"
 
-#: ../src/common/fmapbase.cpp:225
+#: ../src/common/fmapbase.cpp:222
 msgid "MacMongolian"
 msgstr "Mac mongol"
 
-#: ../src/common/fmapbase.cpp:210
+#: ../src/common/fmapbase.cpp:207
 msgid "MacOriya"
 msgstr "MacOriya"
 
-#: ../src/common/fmapbase.cpp:199
+#: ../src/common/fmapbase.cpp:196
 msgid "MacRoman"
 msgstr "Mac Román"
 
-#: ../src/common/fmapbase.cpp:235
+#: ../src/common/fmapbase.cpp:232
 msgid "MacRomanian"
 msgstr "Mac Rumán"
 
-#: ../src/common/fmapbase.cpp:216
+#: ../src/common/fmapbase.cpp:213
 msgid "MacSinhalese"
 msgstr "Mac cingalés"
 
-#: ../src/common/fmapbase.cpp:230
+#: ../src/common/fmapbase.cpp:227
 msgid "MacSymbol"
 msgstr "Mac Simbolos"
 
-#: ../src/common/fmapbase.cpp:212
+#: ../src/common/fmapbase.cpp:209
 msgid "MacTamil"
 msgstr "Mac tamil"
 
-#: ../src/common/fmapbase.cpp:213
+#: ../src/common/fmapbase.cpp:210
 msgid "MacTelugu"
 msgstr "Mac telugu"
 
-#: ../src/common/fmapbase.cpp:219
+#: ../src/common/fmapbase.cpp:216
 msgid "MacThai"
 msgstr "Mac Tailandés"
 
-#: ../src/common/fmapbase.cpp:224
+#: ../src/common/fmapbase.cpp:221
 msgid "MacTibetan"
 msgstr "Mac Tibetán"
 
-#: ../src/common/fmapbase.cpp:232
+#: ../src/common/fmapbase.cpp:229
 msgid "MacTurkish"
 msgstr "Mac Turco"
 
-#: ../src/common/fmapbase.cpp:228
+#: ../src/common/fmapbase.cpp:225
 msgid "MacVietnamese"
 msgstr "Mac Vietnamita"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1762
+#: ../src/propgrid/advprops.cpp:1663
 msgid "Magnifier"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:2143
+#: ../src/propgrid/advprops.cpp:2050
 msgid "Make a selection:"
 msgstr "Selecciona una opción:"
 
-#: ../src/richtext/richtextformatdlg.cpp:374
+#: ../src/richtext/richtextformatdlg.cpp:367
 #: ../src/richtext/richtextmarginspage.cpp:171
 msgid "Margins"
 msgstr "Marguins"
 
-#: ../src/propgrid/advprops.cpp:1595
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Maroon"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:147
+#: ../src/generic/fdrepdlg.cpp:144
 msgid "Match case"
 msgstr "Coincidir as mayusclas y minusclas"
 
@@ -4985,40 +5113,40 @@ msgstr "Altura maxima:"
 msgid "Max width:"
 msgstr "Amplaria maxima:"
 
-#: ../src/unix/mediactrl.cpp:947
+#: ../src/unix/mediactrl.cpp:972
 #, c-format
 msgid "Media playback error: %s"
 msgstr "S'ha produciu una error en a reproducción multimedia: %s"
 
-#: ../src/common/fs_mem.cpp:175
+#: ../src/common/fs_mem.cpp:170
 #, c-format
 msgid "Memory VFS already contains file '%s'!"
 msgstr "VFS en memoria ya contién o fichero '%s'!"
 
 #. TRANSLATORS: Name of keyboard key
 #. TRANSLATORS: Keyword of system colour
-#: ../src/common/accelcmn.cpp:73 ../src/propgrid/advprops.cpp:889
+#: ../src/common/accelcmn.cpp:70 ../src/propgrid/advprops.cpp:790
 msgid "Menu"
 msgstr "Menú"
 
-#: ../src/common/msgout.cpp:124
+#: ../src/common/msgout.cpp:121
 msgid "Message"
 msgstr "Mensache"
 
-#: ../src/univ/themes/metal.cpp:168
+#: ../src/univ/themes/metal.cpp:165
 msgid "Metal theme"
 msgstr "Tema metal"
 
-#: ../src/msw/ole/automtn.cpp:652
+#: ../src/msw/ole/automtn.cpp:643
 msgid "Method or property not found."
 msgstr "No s'ha trobau o metodo u propiedatz."
 
-#: ../src/univ/themes/win32.cpp:3752
+#: ../src/univ/themes/win32.cpp:3749
 msgid "Mi&nimize"
 msgstr "Mi&nimizar"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1763
+#: ../src/propgrid/advprops.cpp:1664
 msgid "Middle Button"
 msgstr ""
 
@@ -5030,38 +5158,43 @@ msgstr "Altura minima:"
 msgid "Min width:"
 msgstr "Amplaria minima:"
 
-#: ../src/msw/ole/automtn.cpp:668
+#: ../src/osx/cocoa/menu.mm:281
+#, fuzzy
+msgid "Minimize"
+msgstr "Mi&nimizar"
+
+#: ../src/msw/ole/automtn.cpp:659
 msgid "Missing a required parameter."
 msgstr "Se requier un parametro."
 
-#: ../src/generic/fontdlgg.cpp:324
+#: ../src/generic/fontdlgg.cpp:320
 msgid "Modern"
 msgstr "Moderno"
 
-#: ../src/generic/filectrlg.cpp:427
+#: ../src/generic/filectrlg.cpp:423
 msgid "Modified"
 msgstr "Modificau"
 
-#: ../src/common/module.cpp:133
+#: ../src/common/module.cpp:130
 #, c-format
 msgid "Module \"%s\" initialization failed"
 msgstr "No s'ha puesto inicializar o modulo \"%s\""
 
-#: ../src/common/paper.cpp:131
+#: ../src/common/paper.cpp:128
 msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
 msgstr "Sobre Monarch, 3 7/8 x 7 1/2 in"
 
-#: ../src/msw/fswatcher.cpp:143
+#: ../src/msw/fswatcher.cpp:140
 msgid "Monitoring individual files for changes is not supported currently."
 msgstr ""
 "Actualment no se suporta a monitorización d'os cambios d'os fichers "
 "individuals."
 
-#: ../src/generic/editlbox.cpp:172
+#: ../src/generic/editlbox.cpp:160
 msgid "Move down"
 msgstr "Mover enta baixo"
 
-#: ../src/generic/editlbox.cpp:171
+#: ../src/generic/editlbox.cpp:155
 msgid "Move up"
 msgstr "Mover enta alto"
 
@@ -5075,97 +5208,102 @@ msgstr "Mueve l'obchecto ta lo siguient paragrafo."
 msgid "Moves the object to the previous paragraph."
 msgstr "Mueve l'obchecto ta l'anterior paragrafo."
 
-#: ../src/richtext/richtextbuffer.cpp:9966
+#: ../src/richtext/richtextbuffer.cpp:9963
 msgid "Multiple Cell Properties"
 msgstr "Propiedatz de celda multiple"
 
-#: ../src/generic/filectrlg.cpp:424
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:82
+msgid "Multiply"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:420
 msgid "Name"
 msgstr "Nombre"
 
-#: ../src/propgrid/advprops.cpp:1596
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Navy"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "Network"
 msgstr "Ret"
 
-#: ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173
 msgid "New"
 msgstr "Nuevo"
 
-#: ../src/richtext/richtextstyledlg.cpp:243
+#: ../src/richtext/richtextstyledlg.cpp:239
 msgid "New &Box Style..."
 msgstr "Nuevo estilo de &caixa..."
 
-#: ../src/richtext/richtextstyledlg.cpp:225
+#: ../src/richtext/richtextstyledlg.cpp:221
 msgid "New &Character Style..."
 msgstr "Nuevo Estilo de &Caracter..."
 
-#: ../src/richtext/richtextstyledlg.cpp:237
+#: ../src/richtext/richtextstyledlg.cpp:233
 msgid "New &List Style..."
 msgstr "Nuevo Estilo de &Lista..."
 
-#: ../src/richtext/richtextstyledlg.cpp:231
+#: ../src/richtext/richtextstyledlg.cpp:227
 msgid "New &Paragraph Style..."
 msgstr "Nuevo Estilo de &Paragrafo..."
 
-#: ../src/richtext/richtextstyledlg.cpp:606
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:654
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:820
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:893
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:934
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:602
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:650
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:816
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:889
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:930
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "New Style"
 msgstr "Nuevo Estilo"
 
-#: ../src/generic/editlbox.cpp:169
+#: ../src/generic/editlbox.cpp:139
 msgid "New item"
 msgstr "Nuevo elemento"
 
-#: ../src/generic/dirdlgg.cpp:297 ../src/generic/dirdlgg.cpp:307
-#: ../src/generic/filectrlg.cpp:618 ../src/generic/filectrlg.cpp:627
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+#: ../src/generic/dirdlgg.cpp:294 ../src/generic/dirdlgg.cpp:304
 msgid "NewName"
 msgstr "Nuevo Nombre"
 
-#: ../src/common/prntbase.cpp:1567 ../src/html/helpwnd.cpp:665
+#: ../src/common/prntbase.cpp:1592 ../src/html/helpwnd.cpp:663
 msgid "Next page"
 msgstr "Pachina siguient"
 
-#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:177
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:174
 #: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "No"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1764
+#: ../src/propgrid/advprops.cpp:1665
 msgid "No Entry"
 msgstr ""
 
-#: ../src/generic/animateg.cpp:150
+#: ../src/generic/animateg.cpp:133
 #, c-format
 msgid "No animation handler for type %ld defined."
 msgstr "No bi ha definiu garra maniador d'animación ta la mena%ld."
 
-#: ../src/dfb/bitmap.cpp:642 ../src/dfb/bitmap.cpp:676
+#: ../src/dfb/bitmap.cpp:639 ../src/dfb/bitmap.cpp:673
 #, c-format
 msgid "No bitmap handler for type %d defined."
 msgstr "No bi ha garra maniador de mapa de bits ta la mena %d definida."
 
-#: ../src/common/utilscmn.cpp:1077
+#: ../src/common/utilscmn.cpp:1095
 msgid "No default application configured for HTML files."
 msgstr "No bi ha garra aplicación configurada ta os documentos HTML."
 
-#: ../src/generic/helpext.cpp:445
+#: ../src/generic/helpext.cpp:443
 msgid "No entries found."
 msgstr "No s'han trobau dentradas."
 
-#: ../src/common/fontmap.cpp:421
+#: ../src/common/fontmap.cpp:418
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found,\n"
@@ -5178,7 +5316,7 @@ msgstr ""
 "Te fería goyo fer servir ista codificación (d'atra traza habrás a trigar "
 "unatra)?"
 
-#: ../src/common/fontmap.cpp:426
+#: ../src/common/fontmap.cpp:423
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found.\n"
@@ -5190,206 +5328,206 @@ msgstr ""
 "codificación\n"
 "(d'atra traza o texto con ista codificación no s'amostrará correctament)?"
 
-#: ../src/generic/animateg.cpp:142
+#: ../src/generic/animateg.cpp:125
 msgid "No handler found for animation type."
 msgstr "No s'ha trobau garra maniador ta la mena d'animación."
 
-#: ../src/common/image.cpp:2728
+#: ../src/common/image.cpp:2823
 msgid "No handler found for image type."
 msgstr "No s'ha trobau garra maniador ta la mena d'imachen."
 
-#: ../src/common/image.cpp:2736 ../src/common/image.cpp:2848
-#: ../src/common/image.cpp:2901
+#: ../src/common/image.cpp:2831 ../src/common/image.cpp:2954
+#: ../src/common/image.cpp:3020
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "No bi ha definiu garra maniador d'imachen ta la mena %d."
 
-#: ../src/common/image.cpp:2871 ../src/common/image.cpp:2915
+#: ../src/common/image.cpp:2986 ../src/common/image.cpp:3034
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "No s'ha definiu garra maniador d'imachen ta la mena %s."
 
-#: ../src/html/helpwnd.cpp:858
+#: ../src/html/helpwnd.cpp:856
 msgid "No matching page found yet"
 msgstr "Encara no s'ha trobau garra pachina con coincidencias"
 
-#: ../src/unix/sound.cpp:81
+#: ../src/unix/sound.cpp:78
 msgid "No sound"
 msgstr "No bi ha garra son"
 
-#: ../src/common/image.cpp:2277 ../src/common/image.cpp:2318
+#: ../src/common/image.cpp:2371 ../src/common/image.cpp:2412
 msgid "No unused colour in image being masked."
 msgstr "No bi ha garra color sin usar en a imachen que se ye enmascarando."
 
-#: ../src/common/image.cpp:3374
-msgid "No unused colour in image."
-msgstr "No bi ha garra color sin usar en a imachen."
-
-#: ../src/generic/helpext.cpp:302
+#: ../src/generic/helpext.cpp:300
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "No s'han trobau mapiaus validos en o fichero \"%s\"."
 
-#: ../src/richtext/richtextborderspage.cpp:610
 #: ../src/richtext/richtextsizepage.cpp:248
 #: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:610
 msgid "None"
 msgstr "Garra"
 
-#: ../src/common/fmapbase.cpp:157
+#: ../src/common/fmapbase.cpp:154
 msgid "Nordic (ISO-8859-10)"
 msgstr "Nordico (ISO-8859-10)"
 
-#: ../src/generic/fontdlgg.cpp:328 ../src/generic/fontdlgg.cpp:331
+#: ../src/generic/fontdlgg.cpp:324 ../src/generic/fontdlgg.cpp:327
 msgid "Normal"
 msgstr "Normal"
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1261
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Nnormal<br>y <u>subrayau</u>. "
 
-#: ../src/html/helpwnd.cpp:1205
+#: ../src/html/helpwnd.cpp:1203
 msgid "Normal font:"
 msgstr "Fuent normal:"
 
-#: ../src/propgrid/props.cpp:1128
+#: ../src/propgrid/props.cpp:1115
 #, c-format
 msgid "Not %s"
 msgstr "No bi ha %s"
 
-#: ../include/wx/filename.h:573 ../include/wx/filename.h:578
-msgid "Not available"
-msgstr "No disponible"
+#: ../src/common/secretstore.cpp:168
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/webrequest.cpp:605
+msgid "Not enough free disk space for download."
+msgstr ""
 
 #: ../src/richtext/richtextfontpage.cpp:358
 msgid "Not underlined"
 msgstr "No subrayau"
 
-#: ../src/common/paper.cpp:115
+#: ../src/common/paper.cpp:112
 msgid "Note, 8 1/2 x 11 in"
 msgstr "Nota, 8 1/2 x 11 in"
 
-#: ../src/generic/notifmsgg.cpp:132
+#: ../src/generic/notifmsgg.cpp:129
 msgid "Notice"
 msgstr "Aviso"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "Num *"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "Num +"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "Num ,"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "Num -"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "Num ."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "Num /"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "Num ="
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "Num Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 #, fuzzy
 msgid "Num Delete"
 msgstr "Eliminar"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 #, fuzzy
 msgid "Num Down"
 msgstr "Abaixo"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "Num End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "Num Enter"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 #, fuzzy
 msgid "Num Home"
 msgstr "Inicio"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 #, fuzzy
 msgid "Num Insert"
 msgstr "Ficar"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num Lock"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "Num Page Down"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "Num Page Up"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 #, fuzzy
 msgid "Num Right"
 msgstr "Dreita"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "Num Space"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "Num Tab"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "Num Up"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "Num left"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num_lock"
 msgstr ""
 
@@ -5398,13 +5536,13 @@ msgstr ""
 msgid "Numbered outline"
 msgstr "Esquema numerau"
 
-#: ../include/wx/msgdlg.h:278 ../src/richtext/richtextstyledlg.cpp:297
-#: ../src/common/stockitem.cpp:178 ../src/msw/msgdlg.cpp:454
-#: ../src/msw/msgdlg.cpp:747 ../src/gtk1/fontdlg.cpp:138
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:175
+#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/msgdlg.cpp:741 ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "Acceptar"
 
-#: ../src/msw/ole/automtn.cpp:692
+#: ../src/msw/ole/automtn.cpp:683
 #, c-format
 msgid "OLE Automation error in %s: %s"
 msgstr "S'ha produciu una error d'automatización d'OLE en %s: %s"
@@ -5413,15 +5551,15 @@ msgstr "S'ha produciu una error d'automatización d'OLE en %s: %s"
 msgid "Object Properties"
 msgstr "Propiedatz d'obchecto"
 
-#: ../src/msw/ole/automtn.cpp:660
+#: ../src/msw/ole/automtn.cpp:651
 msgid "Object implementation does not support named arguments."
 msgstr "A implementación de l'obchecto no suporta argumentos nombraus."
 
-#: ../src/common/xtixml.cpp:264
+#: ../src/common/xtixml.cpp:260
 msgid "Objects must have an id attribute"
 msgstr "Os obchectos han a tener un atributo d'identificación"
 
-#: ../src/propgrid/advprops.cpp:1601
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Olive"
 msgstr ""
 
@@ -5429,64 +5567,69 @@ msgstr ""
 msgid "Opaci&ty:"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:354
+#: ../src/generic/colrdlgg.cpp:374
 msgid "Opacity:"
 msgstr ""
 
-#: ../src/common/docview.cpp:1773 ../src/common/docview.cpp:1815
+#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
 msgid "Open File"
 msgstr "Ubrir un fichero"
 
-#: ../src/html/helpwnd.cpp:671 ../src/html/helpwnd.cpp:1554
+#: ../src/html/helpwnd.cpp:669 ../src/html/helpwnd.cpp:1552
 msgid "Open HTML document"
 msgstr "Ubrir un documento HTML"
 
-#: ../src/generic/dbgrptg.cpp:163
+#: ../src/common/stockitem.cpp:265
+#, fuzzy
+msgid "Open an existing document"
+msgstr "Ubrir un documento HTML"
+
+#: ../src/generic/dbgrptg.cpp:160
 #, c-format
 msgid "Open file \"%s\""
 msgstr "Ubrir o fichero \"%s\""
 
-#: ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176
 msgid "Open..."
 msgstr "Ubrir..."
 
-#: ../src/unix/glx11.cpp:506 ../src/msw/glcanvas.cpp:592
+#: ../src/msw/glcanvas.cpp:607 ../src/unix/glx11.cpp:513
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr ""
 
-#: ../src/generic/dirctrlg.cpp:599 ../src/generic/dirdlgg.cpp:323
-#: ../src/generic/filectrlg.cpp:642 ../src/generic/filectrlg.cpp:786
+#: ../src/generic/dirctrlg.cpp:565 ../src/generic/filectrlg.cpp:638
+#: ../src/generic/filectrlg.cpp:782 ../src/generic/dirdlgg.cpp:320
 msgid "Operation not permitted."
 msgstr "Operación no permitida."
 
-#: ../src/common/cmdline.cpp:900
+#: ../src/common/cmdline.cpp:896
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "A opción '%s' no puet estar negada"
 
-#: ../src/common/cmdline.cpp:1064
+#: ../src/common/cmdline.cpp:1060
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "A opción '%s' ameneste una valor."
 
-#: ../src/common/cmdline.cpp:1147
+#: ../src/common/cmdline.cpp:1143
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "A opción '%s': '%s' no puet convertir-se en una calendata."
 
-#: ../src/generic/prntdlgg.cpp:618
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Opcions"
 
-#: ../src/propgrid/advprops.cpp:1606
+#: ../src/propgrid/advprops.cpp:1512
 msgid "Orange"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:615 ../src/generic/prntdlgg.cpp:869
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:862
 msgid "Orientation"
 msgstr "Orientación"
 
-#: ../src/common/windowid.cpp:242
+#: ../src/common/windowid.cpp:237
 msgid "Out of window IDs.  Recommend shutting down application."
 msgstr ""
 "Difuera d'os identificadors de finestra.  Ye recomendable zarrar "
@@ -5501,148 +5644,148 @@ msgstr "Esquema"
 msgid "Outset"
 msgstr "Externo"
 
-#: ../src/msw/ole/automtn.cpp:656
+#: ../src/msw/ole/automtn.cpp:647
 msgid "Overflow while coercing argument values."
 msgstr "S'ha sobreixiu en aforzar as valors d'os argumentos."
 
-#: ../src/common/imagpcx.cpp:457 ../src/common/imagpcx.cpp:480
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:479
 msgid "PCX: couldn't allocate memory"
 msgstr "PCX: no s'ha puesto reservar memoria"
 
-#: ../src/common/imagpcx.cpp:456
+#: ../src/common/imagpcx.cpp:455
 msgid "PCX: image format unsupported"
 msgstr "PCX: formato d'imachen no suportau"
 
-#: ../src/common/imagpcx.cpp:479
+#: ../src/common/imagpcx.cpp:478
 msgid "PCX: invalid image"
 msgstr "PCX: imachen invalida"
 
-#: ../src/common/imagpcx.cpp:442
+#: ../src/common/imagpcx.cpp:441
 msgid "PCX: this is not a PCX file."
 msgstr "PCX: iste no ye un fichero PCX."
 
-#: ../src/common/imagpcx.cpp:459 ../src/common/imagpcx.cpp:481
+#: ../src/common/imagpcx.cpp:458 ../src/common/imagpcx.cpp:480
 msgid "PCX: unknown error !!!"
 msgstr "PCX: error desconoixida!!!"
 
-#: ../src/common/imagpcx.cpp:458
+#: ../src/common/imagpcx.cpp:457
 msgid "PCX: version number too low"
 msgstr "PCX: numero de versión masiau antiga"
 
-#: ../src/common/imagpnm.cpp:91
+#: ../src/common/imagpnm.cpp:89
 msgid "PNM: Couldn't allocate memory."
 msgstr "PNM: No s'ha puesto reservar memoria."
 
-#: ../src/common/imagpnm.cpp:73
+#: ../src/common/imagpnm.cpp:71
 msgid "PNM: File format is not recognized."
 msgstr "PNM: Formato de fichero no reconoixiu."
 
-#: ../src/common/imagpnm.cpp:112 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
 #: ../src/common/imagpnm.cpp:156
 msgid "PNM: File seems truncated."
 msgstr "PNM: O fichero pareix estar truncau."
 
-#: ../src/common/paper.cpp:187
+#: ../src/common/paper.cpp:184
 msgid "PRC 16K 146 x 215 mm"
 msgstr "PRC 16K 146 x 215 mm"
 
-#: ../src/common/paper.cpp:200
+#: ../src/common/paper.cpp:197
 msgid "PRC 16K Rotated"
 msgstr "PRC 16K Chirau"
 
-#: ../src/common/paper.cpp:188
+#: ../src/common/paper.cpp:185
 msgid "PRC 32K 97 x 151 mm"
 msgstr "PRC 32K 97 x 151 mm"
 
-#: ../src/common/paper.cpp:201
+#: ../src/common/paper.cpp:198
 msgid "PRC 32K Rotated"
 msgstr "PRC 32K Chirau"
 
-#: ../src/common/paper.cpp:189
+#: ../src/common/paper.cpp:186
 msgid "PRC 32K(Big) 97 x 151 mm"
 msgstr "PRC 32K(Gran) 97 x 151 mm"
 
-#: ../src/common/paper.cpp:202
+#: ../src/common/paper.cpp:199
 msgid "PRC 32K(Big) Rotated"
 msgstr "PRC 32K(Gran) Chirau"
 
-#: ../src/common/paper.cpp:190
+#: ../src/common/paper.cpp:187
 msgid "PRC Envelope #1 102 x 165 mm"
 msgstr "Sobre PRC #1 102 x 165 mm"
 
-#: ../src/common/paper.cpp:203
+#: ../src/common/paper.cpp:200
 msgid "PRC Envelope #1 Rotated 165 x 102 mm"
 msgstr "Sobre PRC #1 Chirau 165 x 102 mm"
 
-#: ../src/common/paper.cpp:199
+#: ../src/common/paper.cpp:196
 msgid "PRC Envelope #10 324 x 458 mm"
 msgstr "Sobre PRC #10 324 x 458 mm"
 
-#: ../src/common/paper.cpp:212
+#: ../src/common/paper.cpp:209
 msgid "PRC Envelope #10 Rotated 458 x 324 mm"
 msgstr "Sobre PRC#10 Chirau 458 x 324 mm"
 
-#: ../src/common/paper.cpp:191
+#: ../src/common/paper.cpp:188
 msgid "PRC Envelope #2 102 x 176 mm"
 msgstr "Sobre PRC#2 102 x 176 mm"
 
-#: ../src/common/paper.cpp:204
+#: ../src/common/paper.cpp:201
 msgid "PRC Envelope #2 Rotated 176 x 102 mm"
 msgstr "Sobre PRC#2 Chirau 176 x 102 mm"
 
-#: ../src/common/paper.cpp:192
+#: ../src/common/paper.cpp:189
 msgid "PRC Envelope #3 125 x 176 mm"
 msgstr "Sobre PRC#3 125 x 176 mm"
 
-#: ../src/common/paper.cpp:205
+#: ../src/common/paper.cpp:202
 msgid "PRC Envelope #3 Rotated 176 x 125 mm"
 msgstr "Sobre PRC#3 Chirau 176 x 125 mm"
 
-#: ../src/common/paper.cpp:193
+#: ../src/common/paper.cpp:190
 msgid "PRC Envelope #4 110 x 208 mm"
 msgstr "Sobre PRC#4 110 x 208 mm"
 
-#: ../src/common/paper.cpp:206
+#: ../src/common/paper.cpp:203
 msgid "PRC Envelope #4 Rotated 208 x 110 mm"
 msgstr "Sobre PRC#4 Chirau 208 x 110 mm"
 
-#: ../src/common/paper.cpp:194
+#: ../src/common/paper.cpp:191
 msgid "PRC Envelope #5 110 x 220 mm"
 msgstr "Sobre PRC#5 110 x 220 mm"
 
-#: ../src/common/paper.cpp:207
+#: ../src/common/paper.cpp:204
 msgid "PRC Envelope #5 Rotated 220 x 110 mm"
 msgstr "Sobre PRC#5 Chirau 220 x 110 mm"
 
-#: ../src/common/paper.cpp:195
+#: ../src/common/paper.cpp:192
 msgid "PRC Envelope #6 120 x 230 mm"
 msgstr "Sobre PRC#6 120 x 230 mm"
 
-#: ../src/common/paper.cpp:208
+#: ../src/common/paper.cpp:205
 msgid "PRC Envelope #6 Rotated 230 x 120 mm"
 msgstr "Sobre PRC#6 Chirau 230 x 120 mm"
 
-#: ../src/common/paper.cpp:196
+#: ../src/common/paper.cpp:193
 msgid "PRC Envelope #7 160 x 230 mm"
 msgstr "Sobre PRC#7 160 x 230 mm"
 
-#: ../src/common/paper.cpp:209
+#: ../src/common/paper.cpp:206
 msgid "PRC Envelope #7 Rotated 230 x 160 mm"
 msgstr "Sobre PRC#7 Chirau 230 x 160 mm"
 
-#: ../src/common/paper.cpp:197
+#: ../src/common/paper.cpp:194
 msgid "PRC Envelope #8 120 x 309 mm"
 msgstr "Sobre PRC#8 120 x 309 mm"
 
-#: ../src/common/paper.cpp:210
+#: ../src/common/paper.cpp:207
 msgid "PRC Envelope #8 Rotated 309 x 120 mm"
 msgstr "Sobre PRC#8 Chirau 309 x 120 mm"
 
-#: ../src/common/paper.cpp:198
+#: ../src/common/paper.cpp:195
 msgid "PRC Envelope #9 229 x 324 mm"
 msgstr "Sobre PRC#9 229 x 324 mm"
 
-#: ../src/common/paper.cpp:211
+#: ../src/common/paper.cpp:208
 msgid "PRC Envelope #9 Rotated 324 x 229 mm"
 msgstr "Sobre PRC#9 Chirau 324 x 229 mm"
 
@@ -5650,91 +5793,95 @@ msgstr "Sobre PRC#9 Chirau 324 x 229 mm"
 msgid "Padding"
 msgstr "Repleno"
 
-#: ../src/common/prntbase.cpp:2074
+#: ../src/common/prntbase.cpp:2096
 #, c-format
 msgid "Page %d"
 msgstr "Pachina %d"
 
-#: ../src/common/prntbase.cpp:2072
+#: ../src/common/prntbase.cpp:2094
 #, c-format
 msgid "Page %d of %d"
 msgstr "Pachina %d de %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 #, fuzzy
 msgid "Page Down"
 msgstr "Pachina %d"
 
-#: ../src/gtk/print.cpp:826
+#: ../src/gtk/print.cpp:829
 msgid "Page Setup"
 msgstr "Configurar a Pachina"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 #, fuzzy
 msgid "Page Up"
 msgstr "Pachina %d"
 
-#: ../src/generic/prntdlgg.cpp:828 ../src/common/prntbase.cpp:484
+#: ../src/common/prntbase.cpp:479 ../src/generic/prntdlgg.cpp:821
 msgid "Page setup"
 msgstr "Configurar a pachina"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 #, fuzzy
 msgid "PageDown"
 msgstr "Abaixo"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 #, fuzzy
 msgid "PageUp"
 msgstr "Pachinas"
 
-#: ../src/generic/prntdlgg.cpp:216
+#: ../src/generic/prntdlgg.cpp:209
 msgid "Pages"
 msgstr "Pachinas"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1765
+#: ../src/propgrid/advprops.cpp:1666
 msgid "Paint Brush"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:602 ../src/generic/prntdlgg.cpp:801
-#: ../src/generic/prntdlgg.cpp:842 ../src/generic/prntdlgg.cpp:855
-#: ../src/generic/prntdlgg.cpp:1052 ../src/generic/prntdlgg.cpp:1057
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:794
+#: ../src/generic/prntdlgg.cpp:835 ../src/generic/prntdlgg.cpp:848
+#: ../src/generic/prntdlgg.cpp:1045 ../src/generic/prntdlgg.cpp:1050
 msgid "Paper size"
 msgstr "Grandaria d'o paper"
 
-#: ../src/richtext/richtextstyles.cpp:1062
+#: ../src/richtext/richtextstyles.cpp:1059
 msgid "Paragraph styles"
 msgstr "Estilos de paragrafo"
 
-#: ../src/common/xtistrm.cpp:465
+#: ../src/common/xtistrm.cpp:462
 msgid "Passing a already registered object to SetObject"
 msgstr "Paso d'un obchecto ya rechistrau a SetObject"
 
-#: ../src/common/xtistrm.cpp:476
+#: ../src/common/xtistrm.cpp:473
 msgid "Passing an unknown object to GetObject"
 msgstr "Pasando-le un obchecto desconoixiu a GetObject"
 
-#: ../src/richtext/richtextctrl.cpp:3513 ../src/common/stockitem.cpp:180
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:177 ../src/richtext/richtextctrl.cpp:3514
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Apegar"
 
-#: ../src/common/stockitem.cpp:262
+#: ../src/common/stockitem.cpp:260
 msgid "Paste selection"
 msgstr "Apegar a selección"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:74
+#: ../src/common/accelcmn.cpp:71
 msgid "Pause"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1766
+#: ../src/propgrid/advprops.cpp:1667
 msgid "Pencil"
 msgstr ""
 
@@ -5743,21 +5890,21 @@ msgstr ""
 msgid "Peri&od"
 msgstr "Peri&odo"
 
-#: ../src/generic/filectrlg.cpp:430
+#: ../src/generic/filectrlg.cpp:426
 msgid "Permissions"
 msgstr "Permisos"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:60
+#: ../src/common/accelcmn.cpp:57
 msgid "PgDn"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:59
+#: ../src/common/accelcmn.cpp:56
 msgid "PgUp"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:12868
+#: ../src/richtext/richtextbuffer.cpp:12863
 msgid "Picture Properties"
 msgstr "Propiedatz d'a imachen"
 
@@ -5769,45 +5916,45 @@ msgstr "S'ha produciu una error en a creyación d'a canyería"
 msgid "Please choose a valid font."
 msgstr "Por favor triga una fuent valida."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
 msgid "Please choose an existing file."
 msgstr "Por favor triga un fichero existent."
 
-#: ../src/html/helpwnd.cpp:800
+#: ../src/html/helpwnd.cpp:798
 msgid "Please choose the page to display:"
 msgstr "Por favor triga la pachina que quiers presentar:"
 
-#: ../src/msw/dialup.cpp:764
+#: ../src/msw/dialup.cpp:758
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Por favor triga l'ISP a lo que te quiers connectar"
 
-#: ../src/common/headerctrlcmn.cpp:59
+#: ../src/common/headerctrlcmn.cpp:57
 msgid "Please select the columns to show and define their order:"
 msgstr ""
 "Por favor selecciona as columnas que amostrar y define l'orden d'ellas:"
 
-#: ../src/common/prntbase.cpp:538
+#: ../src/common/prntbase.cpp:533
 msgid "Please wait while printing..."
 msgstr "Por favor aguarda entre que s'imprenta..."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1767
+#: ../src/propgrid/advprops.cpp:1668
 #, fuzzy
 msgid "Point Left"
 msgstr "Grandaria de punto"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1768
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgid "Point Right"
 msgstr "Aliniar a la dreita"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:662
+#: ../src/propgrid/advprops.cpp:572
 msgid "Point Size"
 msgstr "Grandaria de punto"
 
-#: ../src/generic/prntdlgg.cpp:612 ../src/generic/prntdlgg.cpp:867
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:860
 msgid "Portrait"
 msgstr "Vertical"
 
@@ -5815,150 +5962,160 @@ msgstr "Vertical"
 msgid "Position"
 msgstr "Posición"
 
-#: ../src/generic/prntdlgg.cpp:298
+#: ../src/generic/prntdlgg.cpp:291
 msgid "PostScript file"
 msgstr "Fichero PostScript"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178 ../src/osx/cocoa/preferences.mm:303
 msgid "Preferences"
 msgstr "Preferencias"
 
-#: ../src/osx/menu_osx.cpp:568
+#: ../src/osx/menu_osx.cpp:460
 msgid "Preferences..."
 msgstr "Preferencias..."
 
-#: ../src/common/prntbase.cpp:546
+#: ../src/common/prntbase.cpp:541
 msgid "Preparing"
 msgstr "Parando"
 
-#: ../src/generic/fontdlgg.cpp:455 ../src/osx/carbon/fontdlg.cpp:390
-#: ../src/html/helpwnd.cpp:1222
+#: ../src/osx/carbon/fontdlg.cpp:387 ../src/generic/fontdlgg.cpp:452
+#: ../src/html/helpwnd.cpp:1220
 msgid "Preview:"
 msgstr "Anvista previa:"
 
-#: ../src/common/prntbase.cpp:1553 ../src/html/helpwnd.cpp:664
+#: ../src/common/prntbase.cpp:1578 ../src/html/helpwnd.cpp:662
 msgid "Previous page"
 msgstr "Pachina anterior"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/prntdlgg.cpp:143 ../src/generic/prntdlgg.cpp:157
-#: ../src/common/prntbase.cpp:426 ../src/common/prntbase.cpp:1541
-#: ../src/common/accelcmn.cpp:77 ../src/gtk/print.cpp:620
-#: ../src/gtk/print.cpp:638
+#: ../src/common/prntbase.cpp:421 ../src/common/prntbase.cpp:1566
+#: ../src/common/accelcmn.cpp:74 ../src/generic/prntdlgg.cpp:136
+#: ../src/generic/prntdlgg.cpp:150 ../src/gtk/print.cpp:616
+#: ../src/gtk/print.cpp:634
 msgid "Print"
 msgstr "Imprentar"
 
-#: ../include/wx/prntbase.h:399 ../src/common/docview.cpp:1268
+#: ../src/common/docview.cpp:1262
 msgid "Print Preview"
 msgstr "Anvista previa d'a impresión"
 
-#: ../src/common/prntbase.cpp:2015 ../src/common/prntbase.cpp:2057
-#: ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2037 ../src/common/prntbase.cpp:2079
+#: ../src/common/prntbase.cpp:2087
 msgid "Print Preview Failure"
 msgstr "S'ha produciu una error en l'anvista previa d'impresión"
 
-#: ../src/generic/prntdlgg.cpp:224
+#: ../src/generic/prntdlgg.cpp:217
 msgid "Print Range"
 msgstr "Rango d'Impresión"
 
-#: ../src/generic/prntdlgg.cpp:449
+#: ../src/generic/prntdlgg.cpp:442
 msgid "Print Setup"
 msgstr "Configuración d'Impresión"
 
-#: ../src/generic/prntdlgg.cpp:621
+#: ../src/generic/prntdlgg.cpp:614
 msgid "Print in colour"
 msgstr "Impresión en color"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/osx/webview_webkit.mm:260
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "No s'ha puesto inicializar a descripción de columna."
+
+#: ../src/common/stockitem.cpp:179
 msgid "Print previe&w..."
 msgstr "An&vista previa d'imprentau..."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1256
 msgid "Print preview creation failed."
 msgstr "S'ha produciu una error en creyar l'anvista previa d'impresión."
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/common/stockitem.cpp:179
 msgid "Print preview..."
 msgstr "Anvista previa d'imprentau..."
 
-#: ../src/generic/prntdlgg.cpp:630
+#: ../src/generic/prntdlgg.cpp:623
 msgid "Print spooling"
 msgstr "Coda d'impresión"
 
-#: ../src/html/helpwnd.cpp:675
+#: ../src/html/helpwnd.cpp:673
 msgid "Print this page"
 msgstr "Imprentar ista pachina"
 
-#: ../src/generic/prntdlgg.cpp:185
+#: ../src/generic/prntdlgg.cpp:178
 msgid "Print to File"
 msgstr "Imprentar-lo en un Fichero"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "Print..."
 msgstr "Imprentar..."
 
-#: ../src/generic/prntdlgg.cpp:493
+#: ../src/generic/prntdlgg.cpp:486
 msgid "Printer"
 msgstr "Impresora"
 
-#: ../src/generic/prntdlgg.cpp:633
+#: ../src/generic/prntdlgg.cpp:626
 msgid "Printer command:"
 msgstr "Comando d'impresión:"
 
-#: ../src/generic/prntdlgg.cpp:180
+#: ../src/generic/prntdlgg.cpp:173
 msgid "Printer options"
 msgstr "Opcions d'impresión"
 
-#: ../src/generic/prntdlgg.cpp:645
+#: ../src/generic/prntdlgg.cpp:638
 msgid "Printer options:"
 msgstr "Opcions d'impresora:"
 
-#: ../src/generic/prntdlgg.cpp:916
+#: ../src/generic/prntdlgg.cpp:909
 msgid "Printer..."
 msgstr "Impresora..."
 
-#: ../src/generic/prntdlgg.cpp:196
+#: ../src/generic/prntdlgg.cpp:189
 msgid "Printer:"
 msgstr "Impresora:"
 
-#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:535
-#: ../src/html/htmprint.cpp:277
+#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:530
+#: ../src/html/htmprint.cpp:289
 msgid "Printing"
 msgstr "Imprentando"
 
-#: ../src/common/prntbase.cpp:612
+#: ../src/common/prntbase.cpp:607
 msgid "Printing "
 msgstr "Imprentando "
 
-#: ../src/common/prntbase.cpp:347
+#: ../src/common/prntbase.cpp:342
 msgid "Printing Error"
 msgstr "S'ha produciu una error d'impresión"
 
-#: ../src/common/prntbase.cpp:565
+#: ../src/osx/webview_webkit.mm:251
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "Gzip no ye suportau por ista versión de zlib"
+
+#: ../src/common/prntbase.cpp:560
 #, fuzzy, c-format
 msgid "Printing page %d"
 msgstr "Imprentando a pachina %d..."
 
-#: ../src/common/prntbase.cpp:570
+#: ../src/common/prntbase.cpp:565
 #, c-format
 msgid "Printing page %d of %d"
 msgstr "Imprentando a pachina %d de %d"
 
-#: ../src/generic/printps.cpp:201
+#: ../src/generic/printps.cpp:182
 #, c-format
 msgid "Printing page %d..."
 msgstr "Imprentando a pachina %d..."
 
-#: ../src/generic/printps.cpp:161
+#: ../src/generic/printps.cpp:142
 msgid "Printing..."
 msgstr "Imprentando..."
 
-#: ../include/wx/richtext/richtextprint.h:109 ../include/wx/prntbase.h:267
-#: ../src/common/docview.cpp:2132
+#: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
+#: ../src/common/docview.cpp:2137
 msgid "Printout"
 msgstr "Impresión"
 
-#: ../src/common/debugrpt.cpp:560
+#: ../src/common/debugrpt.cpp:561
 #, c-format
 msgid ""
 "Processing debug report has failed, leaving the files in \"%s\" directory."
@@ -5966,104 +6123,104 @@ msgstr ""
 "O procesau d'o reporte de depuración ha fallau, os fichers quedan en o "
 "directorio \"%s\"."
 
-#: ../src/common/prntbase.cpp:545
+#: ../src/common/prntbase.cpp:540
 msgid "Progress:"
 msgstr "Progreso:"
 
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181
 msgid "Properties"
 msgstr "Propiedatz"
 
-#: ../src/propgrid/manager.cpp:237
+#: ../src/propgrid/manager.cpp:223
 msgid "Property"
 msgstr "Propiedat"
 
 #. TRANSLATORS: Caption of message box displaying any property error
-#: ../src/propgrid/propgrid.cpp:3185 ../src/propgrid/propgrid.cpp:3318
+#: ../src/propgrid/propgrid.cpp:3162 ../src/propgrid/propgrid.cpp:3299
 msgid "Property Error"
 msgstr "Error de propiedat"
 
-#: ../src/propgrid/advprops.cpp:1597
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Purple"
 msgstr ""
 
-#: ../src/common/paper.cpp:112
+#: ../src/common/paper.cpp:109
 msgid "Quarto, 215 x 275 mm"
 msgstr "Quarto, 215 x 275 mm"
 
-#: ../src/generic/logg.cpp:1016
+#: ../src/generic/logg.cpp:1013
 msgid "Question"
 msgstr "Pregunta"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1769
+#: ../src/propgrid/advprops.cpp:1670
 #, fuzzy
 msgid "Question Arrow"
 msgstr "Pregunta"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "Quit"
 msgstr "Salir"
 
-#: ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:477
 #, c-format
 msgid "Quit %s"
 msgstr "Salir de %s"
 
-#: ../src/common/stockitem.cpp:263
+#: ../src/common/stockitem.cpp:261
 msgid "Quit this program"
 msgstr "Salir d'iste programa"
 
-#: ../src/common/accelcmn.cpp:338
+#: ../src/common/accelcmn.cpp:352
 msgid "RawCtrl+"
 msgstr "Ctrl+"
 
-#: ../src/common/ffile.cpp:109 ../src/common/ffile.cpp:133
+#: ../src/common/ffile.cpp:107 ../src/common/ffile.cpp:132
 #, c-format
 msgid "Read error on file '%s'"
 msgstr "S'ha produciu una error de lectura en o fichero '%s'"
 
-#: ../src/common/secretstore.cpp:199
+#: ../src/common/secretstore.cpp:211
 #, fuzzy, c-format
-msgid "Reading password for \"%s/%s\" failed: %s."
+msgid "Reading password for \"%s\" failed: %s."
 msgstr "Ha fallau a extracción de '%s' en '%s'."
 
-#: ../src/common/prntbase.cpp:272
+#: ../src/common/prntbase.cpp:267
 msgid "Ready"
 msgstr "Presto"
 
-#: ../src/propgrid/advprops.cpp:1605
+#: ../src/propgrid/advprops.cpp:1511
 #, fuzzy
 msgid "Red"
 msgstr "Refer"
 
-#: ../src/generic/colrdlgg.cpp:339
+#: ../src/generic/colrdlgg.cpp:359
 msgid "Red:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:185 ../src/stc/stc_i18n.cpp:16
+#: ../src/common/stockitem.cpp:182 ../src/stc/stc_i18n.cpp:16
 msgid "Redo"
 msgstr "Refer"
 
-#: ../src/common/stockitem.cpp:264
+#: ../src/common/stockitem.cpp:262
 msgid "Redo last action"
 msgstr "Refer a zaguera acción"
 
-#: ../src/common/stockitem.cpp:186
+#: ../src/common/stockitem.cpp:183
 msgid "Refresh"
 msgstr "Refrescar"
 
-#: ../src/msw/registry.cpp:626
+#: ../src/msw/registry.cpp:615
 #, c-format
 msgid "Registry key '%s' already exists."
 msgstr "A clau d'o rechistro '%s' ya existe."
 
-#: ../src/msw/registry.cpp:595
+#: ../src/msw/registry.cpp:584
 #, c-format
 msgid "Registry key '%s' does not exist, cannot rename it."
 msgstr "A clau d'o rechistro '%s' no existe, no se'n puet renombrar."
 
-#: ../src/msw/registry.cpp:727
+#: ../src/msw/registry.cpp:716
 #, c-format
 msgid ""
 "Registry key '%s' is needed for normal system operation,\n"
@@ -6075,22 +6232,22 @@ msgstr ""
 "si se'n elimina puede deixar o sistema en un estau inestable:\n"
 "operación abortada."
 
-#: ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:942
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:917
+#: ../src/msw/registry.cpp:905
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1003
+#: ../src/msw/registry.cpp:991
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:521
+#: ../src/msw/registry.cpp:510
 #, c-format
 msgid "Registry value '%s' already exists."
 msgstr "A clau d'o rechistro '%s' ya existe."
@@ -6104,72 +6261,78 @@ msgstr "Normal"
 msgid "Relative"
 msgstr "Relativo"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:456
 msgid "Relevant entries:"
 msgstr "Dentradas relevants:"
 
-#: ../include/wx/generic/progdlgg.h:86
+#: ../include/wx/generic/progdlgg.h:87
 msgid "Remaining time:"
 msgstr "Tiempo restant:"
 
-#: ../src/common/stockitem.cpp:187
+#: ../src/common/stockitem.cpp:184
 msgid "Remove"
 msgstr "Eliminar"
 
-#: ../src/richtext/richtextctrl.cpp:1562
+#: ../src/richtext/richtextctrl.cpp:1563
 msgid "Remove Bullet"
 msgstr "Esborrar a vinyeta"
 
-#: ../src/html/helpwnd.cpp:433
+#: ../src/html/helpwnd.cpp:431
 msgid "Remove current page from bookmarks"
 msgstr "Eliminar a pachina actual d'os marcapachinas"
 
-#: ../src/common/rendcmn.cpp:194
+#: ../src/common/rendcmn.cpp:191
 #, c-format
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 "O renderizador \"%s\" tién una versión %d.%d incompatible y no s'ha puesto "
 "ubrir."
 
-#: ../src/richtext/richtextbuffer.cpp:4527
+#: ../src/richtext/richtextbuffer.cpp:4524
 msgid "Renumber List"
 msgstr "Renumerar a Lista"
 
-#: ../src/common/stockitem.cpp:188
-msgid "Rep&lace"
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Rep&lace..."
 msgstr "&Substituir"
 
-#: ../src/richtext/richtextctrl.cpp:3673 ../src/common/stockitem.cpp:188
+#: ../src/richtext/richtextctrl.cpp:3674
 msgid "Replace"
 msgstr "Substituir"
 
-#: ../src/generic/fdrepdlg.cpp:182
+#: ../src/generic/fdrepdlg.cpp:179
 msgid "Replace &all"
 msgstr "Substituir-lo &tot"
 
-#: ../src/common/stockitem.cpp:261
-msgid "Replace selection"
-msgstr "Substituir a selección"
-
-#: ../src/generic/fdrepdlg.cpp:124
+#: ../src/generic/fdrepdlg.cpp:121
 msgid "Replace with:"
 msgstr "Substituir por:"
 
-#: ../src/common/valtext.cpp:163
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Replace..."
+msgstr "Substituir"
+
+#: ../src/common/valtext.cpp:184
 msgid "Required information entry is empty."
 msgstr "A dentrada d'información requerida ye vueda."
 
-#: ../src/common/translation.cpp:1975
+#: ../src/common/translation.cpp:2025
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "O recurso '%s' no ye un catalogo valido de mensaches."
 
+#: ../src/gtk/webview_webkit.cpp:985
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:56
+#: ../src/common/accelcmn.cpp:53
 msgid "Return"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:189
+#: ../src/common/stockitem.cpp:186
 msgid "Revert to Saved"
 msgstr "Recuperar a versión alzada"
 
@@ -6181,42 +6344,42 @@ msgstr "Cresta"
 msgid "Rig&ht-to-left"
 msgstr "De dreita ta cuc&ha"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6149
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:59 ../src/generic/datavgen.cpp:6954
+#: ../src/richtext/richtextsizepage.cpp:250
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextbulletspage.cpp:188
-#: ../src/richtext/richtextsizepage.cpp:250 ../src/common/accelcmn.cpp:62
 msgid "Right"
 msgstr "Dreita"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1754
+#: ../src/propgrid/advprops.cpp:1655
 #, fuzzy
 msgid "Right Arrow"
 msgstr "Dreita"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1770
+#: ../src/propgrid/advprops.cpp:1671
 msgid "Right Button"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:892
+#: ../src/generic/prntdlgg.cpp:885
 msgid "Right margin (mm):"
 msgstr "Marguin dreita (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:148
-#: ../src/richtext/richtextindentspage.cpp:150
 #: ../src/richtext/richtextliststylepage.cpp:337
 #: ../src/richtext/richtextliststylepage.cpp:339
+#: ../src/richtext/richtextindentspage.cpp:148
+#: ../src/richtext/richtextindentspage.cpp:150
 msgid "Right-align text."
 msgstr "Texto aliniau a la dreita."
 
-#: ../src/generic/fontdlgg.cpp:322
+#: ../src/generic/fontdlgg.cpp:318
 msgid "Roman"
 msgstr "Román"
 
-#: ../src/generic/datavgen.cpp:5916
+#: ../src/generic/datavgen.cpp:6721
 #, c-format
 msgid "Row %i"
 msgstr ""
@@ -6226,30 +6389,31 @@ msgstr ""
 msgid "S&tandard bullet name:"
 msgstr "Nombre de vinyeta es&tandar:"
 
-#: ../src/common/accelcmn.cpp:268 ../src/common/accelcmn.cpp:350
+#: ../src/common/accelcmn.cpp:282 ../src/common/accelcmn.cpp:367
 msgid "SPECIAL"
 msgstr "ESPECIAL"
 
-#: ../src/common/stockitem.cpp:190 ../src/common/sizer.cpp:2797
+#: ../src/common/stockitem.cpp:187 ../src/common/sizer.cpp:2914
 msgid "Save"
 msgstr "Alzar"
 
-#: ../src/common/fldlgcmn.cpp:342
+#: ../src/common/fldlgcmn.cpp:339
 #, c-format
 msgid "Save %s file"
 msgstr "Alzar o fichero %s"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/common/stockitem.cpp:188 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "&Alzar como..."
 
-#: ../src/common/docview.cpp:366
+#: ../src/common/docview.cpp:359
 msgid "Save As"
 msgstr "Alzar como"
 
-#: ../src/common/stockitem.cpp:191
-msgid "Save as"
-msgstr "Alzar como"
+#: ../src/common/stockitem.cpp:188
+#, fuzzy
+msgid "Save As..."
+msgstr "&Alzar como..."
 
 #: ../src/common/stockitem.cpp:267
 msgid "Save current document"
@@ -6259,40 +6423,40 @@ msgstr "Alzar o documento actual"
 msgid "Save current document with a different filename"
 msgstr "Alzar o documento actual con unatro nombre"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/generic/logg.cpp:509
 msgid "Save log contents to file"
 msgstr "Alzar os contenius d'o log en un fichero"
 
-#: ../src/common/secretstore.cpp:179
+#: ../src/common/secretstore.cpp:189
 #, fuzzy, c-format
-msgid "Saving password for \"%s/%s\" failed: %s."
+msgid "Saving password for \"%s\" failed: %s."
 msgstr "Ha fallau a extracción de '%s' en '%s'."
 
-#: ../src/generic/fontdlgg.cpp:325
+#: ../src/generic/fontdlgg.cpp:321
 msgid "Script"
 msgstr "Script"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll Lock"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll_lock"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:890
+#: ../src/propgrid/advprops.cpp:791
 msgid "Scrollbar"
 msgstr ""
 
-#: ../src/generic/srchctlg.cpp:56 ../src/html/helpwnd.cpp:535
-#: ../src/html/helpwnd.cpp:550
+#: ../src/generic/srchctlg.cpp:55 ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:548 ../src/gtk/srchctrl.cpp:182
 msgid "Search"
 msgstr "Mirar"
 
-#: ../src/html/helpwnd.cpp:537
+#: ../src/html/helpwnd.cpp:535
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
@@ -6300,57 +6464,57 @@ msgstr ""
 "Mirar contenius d'o(s) libro(s) d'aduya ta todas as aparicions d'o texto que "
 "has escrito mas alto"
 
-#: ../src/generic/fdrepdlg.cpp:160
+#: ../src/generic/fdrepdlg.cpp:157
 msgid "Search direction"
 msgstr "Adreza d'a busca"
 
-#: ../src/generic/fdrepdlg.cpp:112
+#: ../src/generic/fdrepdlg.cpp:109
 msgid "Search for:"
 msgstr "Mirar por:"
 
-#: ../src/html/helpwnd.cpp:1052
+#: ../src/html/helpwnd.cpp:1050
 msgid "Search in all books"
 msgstr "Mirar en totz os libros"
 
-#: ../src/html/helpwnd.cpp:857
+#: ../src/html/helpwnd.cpp:855
 msgid "Searching..."
 msgstr "Mirando..."
 
-#: ../src/generic/dirctrlg.cpp:446
+#: ../src/generic/dirctrlg.cpp:412
 msgid "Sections"
 msgstr "Seccions"
 
-#: ../src/common/ffile.cpp:238
+#: ../src/common/ffile.cpp:237
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Mirar a error en o fichero '%s'"
 
-#: ../src/common/ffile.cpp:228
+#: ../src/common/ffile.cpp:227
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
 "Mirar a error en o fichero '%s' (os fichers grans no son suportaus por stdio)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:76
+#: ../src/common/accelcmn.cpp:73
 #, fuzzy
 msgid "Select"
 msgstr "Selección"
 
-#: ../src/richtext/richtextctrl.cpp:337 ../src/osx/textctrl_osx.cpp:581
-#: ../src/common/stockitem.cpp:192 ../src/msw/textctrl.cpp:2512
+#: ../src/osx/textctrl_osx.cpp:599 ../src/common/stockitem.cpp:189
+#: ../src/msw/textctrl.cpp:2777 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Seleccionar-lo &Tot"
 
-#: ../src/common/stockitem.cpp:192 ../src/stc/stc_i18n.cpp:21
+#: ../src/common/stockitem.cpp:189 ../src/stc/stc_i18n.cpp:21
 msgid "Select All"
 msgstr "Seleccionar-lo tot"
 
-#: ../src/common/docview.cpp:1895
+#: ../src/common/docview.cpp:1900
 msgid "Select a document template"
 msgstr "Seleccionar una plantilla de documento"
 
-#: ../src/common/docview.cpp:1969
+#: ../src/common/docview.cpp:1974
 msgid "Select a document view"
 msgstr "Seleccionar una anvista de documento"
 
@@ -6379,20 +6543,20 @@ msgid "Selects the list level to edit."
 msgstr "Selecciona o libel de lista que editar."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:82
+#: ../src/common/accelcmn.cpp:79
 msgid "Separator"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1083
+#: ../src/common/cmdline.cpp:1079
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "S'asperaba un separador dimpués d'opción '%s'."
 
-#: ../src/osx/menu_osx.cpp:572
+#: ../src/osx/menu_osx.cpp:464
 msgid "Services"
 msgstr "Servicios"
 
-#: ../src/richtext/richtextbuffer.cpp:11217
+#: ../src/richtext/richtextbuffer.cpp:11216
 msgid "Set Cell Style"
 msgstr "Establir o estilo de celda"
 
@@ -6400,11 +6564,11 @@ msgstr "Establir o estilo de celda"
 msgid "SetProperty called w/o valid setter"
 msgstr "S'ha clamau a SetProperty sin un establidor valido"
 
-#: ../src/generic/prntdlgg.cpp:188
+#: ../src/generic/prntdlgg.cpp:181
 msgid "Setup..."
 msgstr "Configuración..."
 
-#: ../src/msw/dialup.cpp:544
+#: ../src/msw/dialup.cpp:538
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr ""
 "S'han trobau quantas connexions activas, se ye trigando una aleatoriament."
@@ -6422,40 +6586,40 @@ msgstr ""
 msgid "Shadow c&olour:"
 msgstr "Trigar a color"
 
-#: ../src/common/accelcmn.cpp:335
+#: ../src/common/accelcmn.cpp:349
 msgid "Shift+"
 msgstr "Mayus+"
 
-#: ../src/generic/dirdlgg.cpp:147
+#: ../src/generic/dirdlgg.cpp:144
 msgid "Show &hidden directories"
 msgstr "Amostrar os directorios &amagaus"
 
-#: ../src/generic/filectrlg.cpp:983
+#: ../src/generic/filectrlg.cpp:979
 msgid "Show &hidden files"
 msgstr "Amostrar os fichers &amagaus"
 
-#: ../src/osx/menu_osx.cpp:580
+#: ../src/osx/menu_osx.cpp:472
 msgid "Show All"
 msgstr "Amostrar-lo tot"
 
-#: ../src/common/stockitem.cpp:257
+#: ../src/common/stockitem.cpp:254
 msgid "Show about dialog"
 msgstr "Amostrar o dialogo Sobre"
 
-#: ../src/html/helpwnd.cpp:492
+#: ../src/html/helpwnd.cpp:490
 msgid "Show all"
 msgstr "Amostrar-lo tot"
 
-#: ../src/html/helpwnd.cpp:503
+#: ../src/html/helpwnd.cpp:501
 msgid "Show all items in index"
 msgstr "Amostrar totz os datos en l'indiz"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:656
 msgid "Show/hide navigation panel"
 msgstr "Amostrar/amagar o panel de navegación"
 
-#: ../src/richtext/richtextsymboldlg.cpp:421
-#: ../src/richtext/richtextsymboldlg.cpp:423
+#: ../src/richtext/richtextsymboldlg.cpp:418
+#: ../src/richtext/richtextsymboldlg.cpp:420
 msgid "Shows a Unicode subset."
 msgstr "Amuestra un subchuego Unicode."
 
@@ -6471,7 +6635,7 @@ msgstr "Amuestra una anvista previa d'as opcions de vinyeta."
 msgid "Shows a preview of the font settings."
 msgstr "Amuestra una anvista previa d'as opcions d'a fuent."
 
-#: ../src/osx/carbon/fontdlg.cpp:394 ../src/osx/carbon/fontdlg.cpp:396
+#: ../src/osx/carbon/fontdlg.cpp:391 ../src/osx/carbon/fontdlg.cpp:393
 msgid "Shows a preview of the font."
 msgstr "Amuestra una anvista previa d'a fuent."
 
@@ -6480,62 +6644,62 @@ msgstr "Amuestra una anvista previa d'a fuent."
 msgid "Shows a preview of the paragraph settings."
 msgstr "Amuestra una anvista previa d'as opcions de paragrafo."
 
-#: ../src/generic/fontdlgg.cpp:460 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:456 ../src/generic/fontdlgg.cpp:458
 msgid "Shows the font preview."
 msgstr "Amuestra l'anvista previa d'a fuent."
 
-#: ../src/propgrid/advprops.cpp:1607
+#: ../src/propgrid/advprops.cpp:1513
 msgid "Silver"
 msgstr ""
 
-#: ../src/univ/themes/mono.cpp:516
+#: ../src/univ/themes/mono.cpp:513
 msgid "Simple monochrome theme"
 msgstr "Tema monocromo simple"
 
-#: ../src/richtext/richtextindentspage.cpp:275
 #: ../src/richtext/richtextliststylepage.cpp:449
+#: ../src/richtext/richtextindentspage.cpp:275
 msgid "Single"
 msgstr "Sencillo"
 
-#: ../src/generic/filectrlg.cpp:425 ../src/richtext/richtextformatdlg.cpp:369
-#: ../src/richtext/richtextsizepage.cpp:299
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextsizepage.cpp:299
+#: ../src/richtext/richtextformatdlg.cpp:362
 msgid "Size"
 msgstr "Grandaria"
 
-#: ../src/osx/carbon/fontdlg.cpp:339
+#: ../src/osx/carbon/fontdlg.cpp:336
 msgid "Size:"
 msgstr "Grandaria:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1775
+#: ../src/propgrid/advprops.cpp:1676
 msgid "Sizing"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1772
+#: ../src/propgrid/advprops.cpp:1673
 msgid "Sizing N-S"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1771
+#: ../src/propgrid/advprops.cpp:1672
 msgid "Sizing NE-SW"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1773
+#: ../src/propgrid/advprops.cpp:1674
 msgid "Sizing NW-SE"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1774
+#: ../src/propgrid/advprops.cpp:1675
 msgid "Sizing W-E"
 msgstr ""
 
-#: ../src/msw/progdlg.cpp:801
+#: ../src/msw/progdlg.cpp:1088
 msgid "Skip"
 msgstr "Blincar"
 
-#: ../src/generic/fontdlgg.cpp:330
+#: ../src/generic/fontdlgg.cpp:326
 msgid "Slant"
 msgstr "Cursiva"
 
@@ -6544,7 +6708,7 @@ msgid "Small C&apitals"
 msgstr "M&ayusclas chicotas"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:79
+#: ../src/common/accelcmn.cpp:76
 msgid "Snapshot"
 msgstr ""
 
@@ -6552,37 +6716,37 @@ msgstr ""
 msgid "Solid"
 msgstr "Soliu"
 
-#: ../src/common/docview.cpp:1791
+#: ../src/common/docview.cpp:1785
 msgid "Sorry, could not open this file."
 msgstr "No s'ha puesto ubrir iste fichero."
 
-#: ../src/common/prntbase.cpp:2057 ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2079 ../src/common/prntbase.cpp:2087
 msgid "Sorry, not enough memory to create a preview."
 msgstr "Memoria insuficient ta creyar l'anvista previa."
 
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "Sorry, that name is taken. Please choose another."
 msgstr "Ixe nombre ya ye en uso. Por favor, en triga unatro."
 
-#: ../src/common/docview.cpp:1814
+#: ../src/common/docview.cpp:1819
 msgid "Sorry, the format for this file is unknown."
 msgstr "O formato d'iste fichero ye desconoixiu."
 
-#: ../src/unix/sound.cpp:492
+#: ../src/unix/sound.cpp:481
 msgid "Sound data are in unsupported format."
 msgstr "Os datos de son son en un formato no suportau."
 
-#: ../src/unix/sound.cpp:477
+#: ../src/unix/sound.cpp:466
 #, c-format
 msgid "Sound file '%s' is in unsupported format."
 msgstr "O fichero de son '%s' ye en un formato no suportau."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:67
+#: ../src/common/accelcmn.cpp:64
 #, fuzzy
 msgid "Space"
 msgstr "Espaciau"
@@ -6591,12 +6755,12 @@ msgstr "Espaciau"
 msgid "Spacing"
 msgstr "Espaciau"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "Spell Check"
 msgstr "Ortografía"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1776
+#: ../src/propgrid/advprops.cpp:1677
 msgid "Spraycan"
 msgstr ""
 
@@ -6605,7 +6769,7 @@ msgstr ""
 msgid "Standard"
 msgstr "Estandar"
 
-#: ../src/common/paper.cpp:104
+#: ../src/common/paper.cpp:101
 msgid "Statement, 5 1/2 x 8 1/2 in"
 msgstr "Statement, 5 1/2 x 8 1/2 in"
 
@@ -6614,33 +6778,29 @@ msgstr "Statement, 5 1/2 x 8 1/2 in"
 msgid "Static"
 msgstr "Estatico"
 
-#: ../src/generic/prntdlgg.cpp:204
+#: ../src/generic/prntdlgg.cpp:197
 msgid "Status:"
 msgstr "Estau:"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "Stop"
 msgstr "Aturar"
 
-#: ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196
 msgid "Strikethrough"
 msgstr "Rayau"
 
-#: ../src/common/colourcmn.cpp:45
+#: ../src/common/colourcmn.cpp:42
 #, c-format
 msgid "String To Colour : Incorrect colour specification : %s"
 msgstr "Cadena a Color: Especificación de color '%s' incorrecta"
 
 #. TRANSLATORS: Label of font style
-#: ../src/richtext/richtextformatdlg.cpp:339 ../src/propgrid/advprops.cpp:680
+#: ../src/propgrid/advprops.cpp:590 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Estilo"
 
-#: ../include/wx/richtext/richtextstyledlg.h:46
-msgid "Style Organiser"
-msgstr "Organizador d'Estilos"
-
-#: ../src/osx/carbon/fontdlg.cpp:348
+#: ../src/osx/carbon/fontdlg.cpp:345
 msgid "Style:"
 msgstr "Estilo:"
 
@@ -6649,7 +6809,7 @@ msgid "Subscrip&t"
 msgstr "S&ubindiz"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:83
+#: ../src/common/accelcmn.cpp:80
 msgid "Subtract"
 msgstr ""
 
@@ -6657,11 +6817,11 @@ msgstr ""
 msgid "Supe&rscript"
 msgstr "Supe&rindiz"
 
-#: ../src/common/paper.cpp:150
+#: ../src/common/paper.cpp:147
 msgid "SuperA/SuperA/A4 227 x 356 mm"
 msgstr "SUPERA/SUPERA/A4 227 x 356 mm"
 
-#: ../src/common/paper.cpp:151
+#: ../src/common/paper.cpp:148
 msgid "SuperB/SuperB/A3 305 x 487 mm"
 msgstr "SuperB/SuperB/A3 305 x 487 mm"
 
@@ -6669,7 +6829,7 @@ msgstr "SuperB/SuperB/A3 305 x 487 mm"
 msgid "Suppress hyphe&nation"
 msgstr "Eliminar as deseparacions de guio&ns"
 
-#: ../src/generic/fontdlgg.cpp:326
+#: ../src/generic/fontdlgg.cpp:322
 msgid "Swiss"
 msgstr "Swiss"
 
@@ -6687,74 +6847,74 @@ msgstr "&Fuent de simbolos:"
 msgid "Symbols"
 msgstr "Simbolos"
 
-#: ../src/common/imagtiff.cpp:369 ../src/common/imagtiff.cpp:382
-#: ../src/common/imagtiff.cpp:741
+#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
+#: ../src/common/imagtiff.cpp:738
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: No s'ha puesto reservar memoria."
 
-#: ../src/common/imagtiff.cpp:301
+#: ../src/common/imagtiff.cpp:298
 msgid "TIFF: Error loading image."
 msgstr "TIFF: S'ha produciu una error en ubrir a imachen."
 
-#: ../src/common/imagtiff.cpp:468
+#: ../src/common/imagtiff.cpp:465
 msgid "TIFF: Error reading image."
 msgstr "TIFF: S'ha produciu una error en leyer a imachen."
 
-#: ../src/common/imagtiff.cpp:608
+#: ../src/common/imagtiff.cpp:605
 msgid "TIFF: Error saving image."
 msgstr "TIFF: S'ha produciu una error en alzar a imachen."
 
-#: ../src/common/imagtiff.cpp:846
+#: ../src/common/imagtiff.cpp:843
 msgid "TIFF: Error writing image."
 msgstr "TIFF: S'ha produciu una error en escribir a imachen."
 
-#: ../src/common/imagtiff.cpp:355
+#: ../src/common/imagtiff.cpp:352
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIF: A grandaria d'a imachen ye anormalment gran."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:68
+#: ../src/common/accelcmn.cpp:65
 #, fuzzy
 msgid "Tab"
 msgstr "Tabulacions"
 
-#: ../src/richtext/richtextbuffer.cpp:11498
+#: ../src/richtext/richtextbuffer.cpp:11497
 msgid "Table Properties"
 msgstr "Propiedatz d'a tabla"
 
-#: ../src/common/paper.cpp:145
+#: ../src/common/paper.cpp:142
 msgid "Tabloid Extra 11.69 x 18 in"
 msgstr "Tabloide Extra 11.69 x 18 in"
 
-#: ../src/common/paper.cpp:102
+#: ../src/common/paper.cpp:99
 msgid "Tabloid, 11 x 17 in"
 msgstr "Tabloide, 11 x 17 in"
 
-#: ../src/richtext/richtextformatdlg.cpp:354
+#: ../src/richtext/richtextformatdlg.cpp:347
 msgid "Tabs"
 msgstr "Tabulacions"
 
-#: ../src/propgrid/advprops.cpp:1598
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Teal"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:327
+#: ../src/generic/fontdlgg.cpp:323
 msgid "Teletype"
 msgstr "Teletipo"
 
-#: ../src/common/docview.cpp:1896
+#: ../src/common/docview.cpp:1901
 msgid "Templates"
 msgstr "Plantillas"
 
-#: ../src/common/fmapbase.cpp:158
+#: ../src/common/fmapbase.cpp:155
 msgid "Thai (ISO-8859-11)"
 msgstr "Tailandés (ISO-8859-11)"
 
-#: ../src/common/ftp.cpp:619
+#: ../src/common/ftp.cpp:622
 msgid "The FTP server doesn't support passive mode."
 msgstr "O servidor FTP no suporta o modo pasivo."
 
-#: ../src/common/ftp.cpp:605
+#: ../src/common/ftp.cpp:608
 msgid "The FTP server doesn't support the PORT command."
 msgstr "O servidor FTP no suporta o comando PORT."
 
@@ -6765,8 +6925,8 @@ msgstr "O servidor FTP no suporta o comando PORT."
 msgid "The available bullet styles."
 msgstr "Os estilos disponibles de vinyeta."
 
-#: ../src/richtext/richtextstyledlg.cpp:202
-#: ../src/richtext/richtextstyledlg.cpp:204
+#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:200
 msgid "The available styles."
 msgstr "Os estilos disponibles."
 
@@ -6822,12 +6982,12 @@ msgstr "A posición inferior."
 msgid "The bullet character."
 msgstr "O caracter vinyeta."
 
-#: ../src/richtext/richtextsymboldlg.cpp:443
-#: ../src/richtext/richtextsymboldlg.cpp:445
+#: ../src/richtext/richtextsymboldlg.cpp:440
+#: ../src/richtext/richtextsymboldlg.cpp:442
 msgid "The character code."
 msgstr "O codigo de caracter."
 
-#: ../src/common/fontmap.cpp:203
+#: ../src/common/fontmap.cpp:200
 #, c-format
 msgid ""
 "The charset '%s' is unknown. You may select\n"
@@ -6838,7 +6998,7 @@ msgstr ""
 "seleccionar unatro conchunto ta substituir-lo u trigar\n"
 "[Cancelar] si no puet estar substituiu"
 
-#: ../src/msw/ole/dataobj.cpp:394
+#: ../src/msw/ole/dataobj.cpp:402
 #, c-format
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "O formato %d d'o portafuellas no existe."
@@ -6848,7 +7008,7 @@ msgstr "O formato %d d'o portafuellas no existe."
 msgid "The default style for the next paragraph."
 msgstr "O estilo predeterminau ta lo siguient paragrafo."
 
-#: ../src/generic/dirdlgg.cpp:202
+#: ../src/generic/dirdlgg.cpp:199
 #, c-format
 msgid ""
 "The directory '%s' does not exist\n"
@@ -6857,7 +7017,7 @@ msgstr ""
 "O directorio '%s' no existe\n"
 "Creyar-lo agora?"
 
-#: ../src/html/htmprint.cpp:271
+#: ../src/html/htmprint.cpp:283
 #, c-format
 msgid ""
 "The document \"%s\" doesn't fit on the page horizontally and will be "
@@ -6870,7 +7030,7 @@ msgstr ""
 "\n"
 "Deseyas continar con a impresión de todas trazas?"
 
-#: ../src/common/docview.cpp:1202
+#: ../src/common/docview.cpp:1196
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -6879,36 +7039,36 @@ msgstr ""
 "O fichero '%s' no existe y no puet ubrir-se.\n"
 "Tamién ye estau eliminau d'a lista de fichers recients."
 
-#: ../src/richtext/richtextindentspage.cpp:208
-#: ../src/richtext/richtextindentspage.cpp:210
 #: ../src/richtext/richtextliststylepage.cpp:394
 #: ../src/richtext/richtextliststylepage.cpp:396
+#: ../src/richtext/richtextindentspage.cpp:208
+#: ../src/richtext/richtextindentspage.cpp:210
 msgid "The first line indent."
 msgstr "O escalonau d'a primera linia."
 
-#: ../src/gtk/utilsgtk.cpp:481
-msgid "The following standard GTK+ options are also supported:\n"
-msgstr "As siguients opcions GTK+ estandar tamién son suportadas:\n"
+#: ../src/generic/dbgrptg.cpp:318
+msgid "The following debug report will be generated\n"
+msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:414 ../src/generic/fontdlgg.cpp:416
+#: ../src/generic/fontdlgg.cpp:411 ../src/generic/fontdlgg.cpp:413
 msgid "The font colour."
 msgstr "A color de fuent."
 
-#: ../src/generic/fontdlgg.cpp:375 ../src/generic/fontdlgg.cpp:377
+#: ../src/generic/fontdlgg.cpp:371 ../src/generic/fontdlgg.cpp:373
 msgid "The font family."
 msgstr "O tipo de fuent."
 
-#: ../src/richtext/richtextsymboldlg.cpp:405
-#: ../src/richtext/richtextsymboldlg.cpp:407
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "The font from which to take the symbol."
 msgstr "A fuent d'a que prener o simbolo."
 
-#: ../src/generic/fontdlgg.cpp:427 ../src/generic/fontdlgg.cpp:429
-#: ../src/generic/fontdlgg.cpp:434 ../src/generic/fontdlgg.cpp:436
+#: ../src/generic/fontdlgg.cpp:424 ../src/generic/fontdlgg.cpp:426
+#: ../src/generic/fontdlgg.cpp:430 ../src/generic/fontdlgg.cpp:432
 msgid "The font point size."
 msgstr "A grandaria d'a fuent en puntos."
 
-#: ../src/osx/carbon/fontdlg.cpp:343 ../src/osx/carbon/fontdlg.cpp:345
+#: ../src/osx/carbon/fontdlg.cpp:340 ../src/osx/carbon/fontdlg.cpp:342
 msgid "The font size in points."
 msgstr "A grandaria de fuent en puntos."
 
@@ -6917,15 +7077,15 @@ msgstr "A grandaria de fuent en puntos."
 msgid "The font size units, points or pixels."
 msgstr "As unidatz d'a grandaria de fuent, puntos u pixels."
 
-#: ../src/generic/fontdlgg.cpp:386 ../src/generic/fontdlgg.cpp:388
+#: ../src/generic/fontdlgg.cpp:382 ../src/generic/fontdlgg.cpp:384
 msgid "The font style."
 msgstr "O estilo de fuent."
 
-#: ../src/generic/fontdlgg.cpp:397 ../src/generic/fontdlgg.cpp:399
+#: ../src/generic/fontdlgg.cpp:393 ../src/generic/fontdlgg.cpp:395
 msgid "The font weight."
 msgstr "O peso d'a fuent."
 
-#: ../src/common/docview.cpp:1483
+#: ../src/common/docview.cpp:1477
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "No s'ha puestodeterminar o formato d'o fichero '%s'."
@@ -6936,10 +7096,10 @@ msgstr "No s'ha puestodeterminar o formato d'o fichero '%s'."
 msgid "The horizontal offset."
 msgstr "Mosaico &Horizontal"
 
-#: ../src/richtext/richtextindentspage.cpp:199
-#: ../src/richtext/richtextindentspage.cpp:201
 #: ../src/richtext/richtextliststylepage.cpp:385
 #: ../src/richtext/richtextliststylepage.cpp:387
+#: ../src/richtext/richtextindentspage.cpp:199
+#: ../src/richtext/richtextindentspage.cpp:201
 msgid "The left indent."
 msgstr "O escalonau cucho."
 
@@ -6960,10 +7120,10 @@ msgstr "A grandaria d'o repleno cucho."
 msgid "The left position."
 msgstr "A posición cucha."
 
-#: ../src/richtext/richtextindentspage.cpp:288
-#: ../src/richtext/richtextindentspage.cpp:290
 #: ../src/richtext/richtextliststylepage.cpp:462
 #: ../src/richtext/richtextliststylepage.cpp:464
+#: ../src/richtext/richtextindentspage.cpp:288
+#: ../src/richtext/richtextindentspage.cpp:290
 msgid "The line spacing."
 msgstr "O espaciau de linia."
 
@@ -6972,7 +7132,7 @@ msgstr "O espaciau de linia."
 msgid "The list item number."
 msgstr "O numero d'elemento d'a lista."
 
-#: ../src/msw/ole/automtn.cpp:664
+#: ../src/msw/ole/automtn.cpp:655
 msgid "The locale ID is unknown."
 msgstr "L'identificador d'a localización ye desconoixiu."
 
@@ -7011,19 +7171,19 @@ msgstr "L'amplaria de l'obchecto."
 msgid "The outline level."
 msgstr "O libel d'esquema."
 
-#: ../src/common/log.cpp:277
+#: ../src/common/log.cpp:296
 #, fuzzy, c-format
 msgid "The previous message repeated %u time."
 msgid_plural "The previous message repeated %u times."
 msgstr[0] "L'anterior mensache repetiu %lu vegada."
 msgstr[1] "L'anterior mensache repetiu %lu vegadas."
 
-#: ../src/common/log.cpp:270
+#: ../src/common/log.cpp:289
 msgid "The previous message repeated once."
 msgstr "L'anterior mensache repetiu una vegada."
 
-#: ../src/richtext/richtextsymboldlg.cpp:462
-#: ../src/richtext/richtextsymboldlg.cpp:464
+#: ../src/richtext/richtextsymboldlg.cpp:459
+#: ../src/richtext/richtextsymboldlg.cpp:461
 msgid "The range to show."
 msgstr "O rango que amostrar."
 
@@ -7037,15 +7197,15 @@ msgstr ""
 "contién información privada,\n"
 "por favor, desmarca-los y serán eliminaus d'o reporte.\n"
 
-#: ../src/common/cmdline.cpp:1254
+#: ../src/common/cmdline.cpp:1250
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "No s'ha especificau o parametro requeriu '%s'."
 
-#: ../src/richtext/richtextindentspage.cpp:217
-#: ../src/richtext/richtextindentspage.cpp:219
 #: ../src/richtext/richtextliststylepage.cpp:403
 #: ../src/richtext/richtextliststylepage.cpp:405
+#: ../src/richtext/richtextindentspage.cpp:217
+#: ../src/richtext/richtextindentspage.cpp:219
 msgid "The right indent."
 msgstr "O escalonau dreito."
 
@@ -7087,16 +7247,16 @@ msgstr ""
 msgid "The shadow spread."
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:267
 #: ../src/richtext/richtextliststylepage.cpp:439
 #: ../src/richtext/richtextliststylepage.cpp:441
+#: ../src/richtext/richtextindentspage.cpp:267
 msgid "The spacing after the paragraph."
 msgstr "O espaciau dimpués d'o paragrafo."
 
-#: ../src/richtext/richtextindentspage.cpp:257
-#: ../src/richtext/richtextindentspage.cpp:259
 #: ../src/richtext/richtextliststylepage.cpp:430
 #: ../src/richtext/richtextliststylepage.cpp:432
+#: ../src/richtext/richtextindentspage.cpp:257
+#: ../src/richtext/richtextindentspage.cpp:259
 msgid "The spacing before the paragraph."
 msgstr "O espaciau antis de paragrafo."
 
@@ -7110,12 +7270,12 @@ msgstr "O nombre d'o estilo."
 msgid "The style on which this style is based."
 msgstr "O estilo en que se basa iste estilo."
 
-#: ../src/richtext/richtextstyledlg.cpp:214
-#: ../src/richtext/richtextstyledlg.cpp:216
+#: ../src/richtext/richtextstyledlg.cpp:210
+#: ../src/richtext/richtextstyledlg.cpp:212
 msgid "The style preview."
 msgstr "L'anvista previa d'o estilo."
 
-#: ../src/msw/ole/automtn.cpp:680
+#: ../src/msw/ole/automtn.cpp:671
 msgid "The system cannot find the file specified."
 msgstr "O sistema no puet trobar o fichero especificau."
 
@@ -7128,7 +7288,7 @@ msgstr "A posición d'o tabulador."
 msgid "The tab positions."
 msgstr "As posicions d'o tabulador."
 
-#: ../src/richtext/richtextctrl.cpp:3098
+#: ../src/richtext/richtextctrl.cpp:3099
 msgid "The text couldn't be saved."
 msgstr "No s'ha puesto alzar o texto."
 
@@ -7149,7 +7309,7 @@ msgstr "A grandaria d'o repleno superior."
 msgid "The top position."
 msgstr "A posición superior."
 
-#: ../src/common/cmdline.cpp:1232
+#: ../src/common/cmdline.cpp:1228
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "Cal especificar a valor ta lo parametro '%s'."
@@ -7159,7 +7319,7 @@ msgstr "Cal especificar a valor ta lo parametro '%s'."
 msgid "The value of the corner radius."
 msgstr "A valor d'o radio de cantonada"
 
-#: ../src/msw/dialup.cpp:433
+#: ../src/msw/dialup.cpp:427
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -7175,14 +7335,14 @@ msgstr ""
 msgid "The vertical offset."
 msgstr "Activar l'aliniación vertical."
 
-#: ../src/richtext/richtextprint.cpp:619 ../src/html/htmprint.cpp:745
+#: ../src/html/htmprint.cpp:749 ../src/richtext/richtextprint.cpp:615
 msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr ""
 "S'ha produciu un problema en configurar a pachina: s'ameneste una impresora "
 "predeterminada."
 
-#: ../src/html/htmprint.cpp:255
+#: ../src/html/htmprint.cpp:267
 msgid ""
 "This document doesn't fit on the page horizontally and will be truncated "
 "when it is printed."
@@ -7190,16 +7350,16 @@ msgstr ""
 "Iste documento no culle en a pachina horizontalment y se truncará si "
 "s'imprenta."
 
-#: ../src/common/image.cpp:2854
+#: ../src/common/image.cpp:2963
 #, c-format
 msgid "This is not a %s."
 msgstr "Isto no ye un %s."
 
-#: ../src/common/wincmn.cpp:1653
+#: ../src/common/wincmn.cpp:1654
 msgid "This platform does not support background transparency."
 msgstr "Ista plataforma no suporta a transparencia d'o fondo."
 
-#: ../src/gtk/window.cpp:4660
+#: ../src/gtk/window.cpp:5664
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
@@ -7207,7 +7367,15 @@ msgstr ""
 "Iste programa estió compilau con una versión de GTK+ masiau antiga, por "
 "favor recomplila-lo con o GR+ 2.12 u superior."
 
-#: ../src/msw/thread.cpp:1240
+#: ../src/gtk/glcanvas.cpp:176
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/msw/thread.cpp:1246
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -7215,13 +7383,13 @@ msgstr ""
 "S'ha produciu una error en a inicialización d'o modulo de filos d'execución: "
 "no s'ha puesto almagazenar a valor en l'almagazén local de filos"
 
-#: ../src/unix/threadpsx.cpp:1794
+#: ../src/unix/threadpsx.cpp:1843
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 "S'ha produciu una error en a inicialización d'o modulo de filos d'execución: "
 "error en creyar a clau de filo"
 
-#: ../src/msw/thread.cpp:1228
+#: ../src/msw/thread.cpp:1234
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -7229,84 +7397,84 @@ msgstr ""
 "S'ha produciu una error en a inicialización d'o modulo de filos d'execución: "
 "ye imposible reservar l'indiz en l'almagazén local de filos"
 
-#: ../src/unix/threadpsx.cpp:1043
+#: ../src/unix/threadpsx.cpp:1061
 msgid "Thread priority setting is ignored."
 msgstr "S'ha ignorau a configuración d'a prioridat d'o filo d'execución."
 
-#: ../src/msw/mdi.cpp:176
+#: ../src/msw/mdi.cpp:171
 msgid "Tile &Horizontally"
 msgstr "Mosaico &Horizontal"
 
-#: ../src/msw/mdi.cpp:177
+#: ../src/msw/mdi.cpp:172
 msgid "Tile &Vertically"
 msgstr "Mosaico &Vertical"
 
-#: ../src/common/ftp.cpp:200
+#: ../src/common/ftp.cpp:197
 msgid "Timeout while waiting for FTP server to connect, try passive mode."
 msgstr ""
 "Tiempo d'aspera d'a connexión d'o servidor FTP acotolau, preba a establir o "
 "modo pasivo."
 
-#: ../src/generic/tipdlg.cpp:201
+#: ../src/generic/tipdlg.cpp:198
 msgid "Tip of the Day"
 msgstr "Sucherencia d'o Día"
 
-#: ../src/generic/tipdlg.cpp:140
+#: ../src/generic/tipdlg.cpp:137
 msgid "Tips not available, sorry!"
 msgstr "As sucherencias no son disponibles!"
 
-#: ../src/generic/prntdlgg.cpp:242
+#: ../src/generic/prntdlgg.cpp:235
 msgid "To:"
 msgstr "Dica:"
 
-#: ../src/richtext/richtextbuffer.cpp:8363
+#: ../src/richtext/richtextbuffer.cpp:8361
 msgid "Too many EndStyle calls!"
 msgstr "Masiadas clamadas EndStyle!"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:891
+#: ../src/propgrid/advprops.cpp:792
 msgid "Tooltip"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:892
+#: ../src/propgrid/advprops.cpp:793
 msgid "TooltipText"
 msgstr ""
 
-#: ../src/richtext/richtextsizepage.cpp:286
-#: ../src/richtext/richtextsizepage.cpp:290 ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197 ../src/richtext/richtextsizepage.cpp:286
+#: ../src/richtext/richtextsizepage.cpp:290
 msgid "Top"
 msgstr "Superior"
 
-#: ../src/generic/prntdlgg.cpp:881
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Top margin (mm):"
 msgstr "Marguin superior (mm):"
 
-#: ../src/generic/aboutdlgg.cpp:79
+#: ../src/generic/aboutdlgg.cpp:76
 msgid "Translations by "
 msgstr "Traduccions por "
 
-#: ../src/generic/aboutdlgg.cpp:188
+#: ../src/generic/aboutdlgg.cpp:185
 msgid "Translators"
 msgstr "Traductors"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:211
+#: ../src/propgrid/propgrid.cpp:192
 msgid "True"
 msgstr "Verdadero"
 
-#: ../src/common/fs_mem.cpp:227
+#: ../src/common/fs_mem.cpp:222
 #, c-format
 msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
 msgstr ""
 "Se ye mirando d'eliminar o fichero '%s' de VFS de memoria, pero no'n ye "
 "ubierto!"
 
-#: ../src/common/fmapbase.cpp:156
+#: ../src/common/fmapbase.cpp:153
 msgid "Turkish (ISO-8859-9)"
 msgstr "Turco (ISO-8859-9)"
 
-#: ../src/generic/filectrlg.cpp:426
+#: ../src/generic/filectrlg.cpp:422
 msgid "Type"
 msgstr "Tipo"
 
@@ -7320,17 +7488,17 @@ msgstr "Escribe un nombre de fuent."
 msgid "Type a size in points."
 msgstr "Escribe una grandaria en puntos."
 
-#: ../src/msw/ole/automtn.cpp:676
+#: ../src/msw/ole/automtn.cpp:667
 #, c-format
 msgid "Type mismatch in argument %u."
 msgstr "No coincide o tipo en l'argumento %u."
 
-#: ../src/common/xtixml.cpp:356 ../src/common/xtixml.cpp:509
-#: ../src/common/xtistrm.cpp:318
+#: ../src/common/xtixml.cpp:352 ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315
 msgid "Type must have enum - long conversion"
 msgstr "O tipo ha de tener conversión d'enum ta long"
 
-#: ../src/propgrid/propgridiface.cpp:401
+#: ../src/propgrid/propgridiface.cpp:385
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
@@ -7339,19 +7507,19 @@ msgstr ""
 "S'ha produciu una error en a operación de tipos \"%s\".: A propiedat "
 "etiquetada \"%s\" ye de tipo \"%s\" y no pas \"%s\"."
 
-#: ../src/common/paper.cpp:133
+#: ../src/common/paper.cpp:130
 msgid "US Std Fanfold, 14 7/8 x 11 in"
 msgstr "US Estandar en aventador, 14 7/8 x 11 in"
 
-#: ../src/common/fmapbase.cpp:196
+#: ../src/common/fmapbase.cpp:193
 msgid "US-ASCII"
 msgstr "US-ASCII"
 
-#: ../src/unix/fswatcher_inotify.cpp:109
+#: ../src/unix/fswatcher_inotify.cpp:106
 msgid "Unable to add inotify watch"
 msgstr "No s'ha puesto adhibir un observador de inotify"
 
-#: ../src/unix/fswatcher_kqueue.cpp:136
+#: ../src/unix/fswatcher_kqueue.cpp:153
 msgid "Unable to add kqueue watch"
 msgstr "No s'ha puesto adhibir un observador de kqueue"
 
@@ -7366,7 +7534,7 @@ msgid "Unable to close I/O completion port handle"
 msgstr ""
 "No s'ha puesto zarrar o maniador d'o puerto de dentrada/salida de rematanza"
 
-#: ../src/unix/fswatcher_inotify.cpp:97
+#: ../src/unix/fswatcher_inotify.cpp:94
 msgid "Unable to close inotify instance"
 msgstr "No s'ha puesto zarrar a instancia d'inotify"
 
@@ -7384,15 +7552,15 @@ msgstr "No s'ha puesto zarrar o maniador ta '%s'"
 msgid "Unable to create I/O completion port"
 msgstr "No s'ha puesto creyar o puerto de dentrada/salida de rematanza"
 
-#: ../src/msw/fswatcher.cpp:84
+#: ../src/msw/fswatcher.cpp:81
 msgid "Unable to create IOCP worker thread"
 msgstr "No s'ha puesto creyar o filo d'execución IOCP"
 
-#: ../src/unix/fswatcher_inotify.cpp:74
+#: ../src/unix/fswatcher_inotify.cpp:71
 msgid "Unable to create inotify instance"
 msgstr "No s'ha puesto creyar una instancia d'inotify"
 
-#: ../src/unix/fswatcher_kqueue.cpp:97
+#: ../src/unix/fswatcher_kqueue.cpp:114
 msgid "Unable to create kqueue instance"
 msgstr "No s'ha puesto creyar una instancia de kqueue"
 
@@ -7400,11 +7568,11 @@ msgstr "No s'ha puesto creyar una instancia de kqueue"
 msgid "Unable to dequeue completion packet"
 msgstr "No s'ha puesto sacar d'a coda o paquet de rematanza"
 
-#: ../src/unix/fswatcher_kqueue.cpp:185
+#: ../src/unix/fswatcher_kqueue.cpp:202
 msgid "Unable to get events from kqueue"
 msgstr "No s'ha puesto obtener eventos de kqueue"
 
-#: ../src/gtk/app.cpp:435
+#: ../src/gtk/app.cpp:431
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "No s'ha puesto enchegar o GTK+, ye a pantalla bien achustada?"
 
@@ -7413,12 +7581,12 @@ msgstr "No s'ha puesto enchegar o GTK+, ye a pantalla bien achustada?"
 msgid "Unable to open path '%s'"
 msgstr "No s'ha puesto ubrir a rota '%s'"
 
-#: ../src/html/htmlwin.cpp:583
+#: ../src/html/htmlwin.cpp:586
 #, c-format
 msgid "Unable to open requested HTML document: %s"
 msgstr "No s'ha puesto ubrir o documento HTML demandau: %s"
 
-#: ../src/unix/sound.cpp:368
+#: ../src/unix/sound.cpp:365
 msgid "Unable to play sound asynchronously."
 msgstr "No s'ha puesto reproducir o son de traza asincrona."
 
@@ -7426,63 +7594,63 @@ msgstr "No s'ha puesto reproducir o son de traza asincrona."
 msgid "Unable to post completion status"
 msgstr "No s'ha puesto publicar o estau de rematanza"
 
-#: ../src/unix/fswatcher_inotify.cpp:556
+#: ../src/unix/fswatcher_inotify.cpp:553
 msgid "Unable to read from inotify descriptor"
 msgstr "No s'ha puesto leyer d'o descriptor inotify"
 
-#: ../src/unix/fswatcher_inotify.cpp:141
+#: ../src/unix/fswatcher_inotify.cpp:138
 #, fuzzy, c-format
 msgid "Unable to remove inotify watch %i"
 msgstr "No s'ha puesto eliminar un observador inotify"
 
-#: ../src/unix/fswatcher_kqueue.cpp:153
+#: ../src/unix/fswatcher_kqueue.cpp:170
 msgid "Unable to remove kqueue watch"
 msgstr "No s'ha puesto eliminar un observador kqueue"
 
-#: ../src/msw/fswatcher.cpp:168
+#: ../src/msw/fswatcher.cpp:165
 #, c-format
 msgid "Unable to set up watch for '%s'"
 msgstr "No s'ha puesto configurar un observador ta '%s'"
 
-#: ../src/msw/fswatcher.cpp:91
+#: ../src/msw/fswatcher.cpp:88
 msgid "Unable to start IOCP worker thread"
 msgstr "No s'ha puesto encetar o fillo d'execución d'IOCP"
 
-#: ../src/common/stockitem.cpp:201
+#: ../src/common/stockitem.cpp:198
 msgid "Undelete"
 msgstr "Restaurar"
 
-#: ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199
 msgid "Underline"
 msgstr "Subrayau"
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/richtext/richtextfontpage.cpp:359 ../src/osx/carbon/fontdlg.cpp:370
-#: ../src/propgrid/advprops.cpp:690
+#: ../src/osx/carbon/fontdlg.cpp:367 ../src/propgrid/advprops.cpp:600
+#: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Subrayau"
 
-#: ../src/common/stockitem.cpp:203 ../src/stc/stc_i18n.cpp:15
+#: ../src/common/stockitem.cpp:200 ../src/stc/stc_i18n.cpp:15
 msgid "Undo"
 msgstr "Desfer"
 
-#: ../src/common/stockitem.cpp:265
+#: ../src/common/stockitem.cpp:263
 msgid "Undo last action"
 msgstr "Desfer a zaguera acción"
 
-#: ../src/common/cmdline.cpp:1029
+#: ../src/common/cmdline.cpp:1025
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Caracters no asperaus dezaga d'a opción '%s'."
 
-#: ../src/unix/fswatcher_inotify.cpp:274
+#: ../src/unix/fswatcher_inotify.cpp:271
 #, c-format
 msgid "Unexpected event for \"%s\": no matching watch descriptor."
 msgstr ""
 "Evento no asperau de \"%s\": no bi ha garra descriptor d'observador que "
 "coincida."
 
-#: ../src/common/cmdline.cpp:1195
+#: ../src/common/cmdline.cpp:1191
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Parametro '%s' inasperau"
@@ -7491,49 +7659,49 @@ msgstr "Parametro '%s' inasperau"
 msgid "Unexpectedly new I/O completion port was created"
 msgstr "S'ha creyau un nuevo puerto de dentrada/salida inasperadament"
 
-#: ../src/msw/fswatcher.cpp:70
+#: ../src/msw/fswatcher.cpp:67
 msgid "Ungraceful worker thread termination"
 msgstr "Rematanza incorrecta de fillos d'execución"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:460
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:456
+#: ../src/richtext/richtextsymboldlg.cpp:457
+#: ../src/richtext/richtextsymboldlg.cpp:458
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../src/common/fmapbase.cpp:185 ../src/common/fmapbase.cpp:191
+#: ../src/common/fmapbase.cpp:182 ../src/common/fmapbase.cpp:188
 msgid "Unicode 16 bit (UTF-16)"
 msgstr "Unicode 16 bits (UTF-16)"
 
-#: ../src/common/fmapbase.cpp:190
+#: ../src/common/fmapbase.cpp:187
 msgid "Unicode 16 bit Big Endian (UTF-16BE)"
 msgstr "Unicode 16 bits Endian Gran (UTF-16BE)"
 
-#: ../src/common/fmapbase.cpp:186
+#: ../src/common/fmapbase.cpp:183
 msgid "Unicode 16 bit Little Endian (UTF-16LE)"
 msgstr "Unicode 16 bits Endian Chicot (UTF-16LE)"
 
-#: ../src/common/fmapbase.cpp:187 ../src/common/fmapbase.cpp:193
+#: ../src/common/fmapbase.cpp:184 ../src/common/fmapbase.cpp:190
 msgid "Unicode 32 bit (UTF-32)"
 msgstr "Unicode 32 bits (UTF-32)"
 
-#: ../src/common/fmapbase.cpp:192
+#: ../src/common/fmapbase.cpp:189
 msgid "Unicode 32 bit Big Endian (UTF-32BE)"
 msgstr "Unicode 32 bits Endian Gran (UTF-32BE)"
 
-#: ../src/common/fmapbase.cpp:188
+#: ../src/common/fmapbase.cpp:185
 msgid "Unicode 32 bit Little Endian (UTF-32LE)"
 msgstr "Unicode 32 bits Endian Chicot (UTF-32LE)"
 
-#: ../src/common/fmapbase.cpp:182
+#: ../src/common/fmapbase.cpp:179
 msgid "Unicode 7 bit (UTF-7)"
 msgstr "Unicode 7 bit (UTF-7)"
 
-#: ../src/common/fmapbase.cpp:183
+#: ../src/common/fmapbase.cpp:180
 msgid "Unicode 8 bit (UTF-8)"
 msgstr "Unicode 8 bit (UTF-8)"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "Unindent"
 msgstr "Sin escalonau"
 
@@ -7684,97 +7852,102 @@ msgstr "Unidatz ta la posición superior."
 msgid "Units for this value."
 msgstr "Unidatz ta la marguin cucha."
 
-#: ../src/generic/progdlgg.cpp:353 ../src/generic/progdlgg.cpp:622
+#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
 msgid "Unknown"
 msgstr "Desconoixiu"
 
-#: ../src/msw/dde.cpp:1174
+#: ../src/msw/dde.cpp:1238
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "S'ha produciu una error DDE desconoixiu %08x"
 
-#: ../src/common/xtistrm.cpp:410
+#: ../src/common/xtistrm.cpp:407
 msgid "Unknown Object passed to GetObjectClassInfo"
 msgstr "Obchecto desconoixiu pasau a GetObjectClassInfo"
 
-#: ../src/common/imagpng.cpp:366
+#: ../src/common/imagpng.cpp:383
 #, c-format
 msgid "Unknown PNG resolution unit %d"
 msgstr "Unidat de resolución de PNG desconoixida %d"
 
-#: ../src/common/xtixml.cpp:327
+#: ../src/common/xtixml.cpp:323
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Propiedat desconoixida %s"
 
-#: ../src/common/imagtiff.cpp:529
+#: ../src/common/imagtiff.cpp:526
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "Unidat de resolución de TIF desconoixida %d ignorada"
 
-#: ../src/unix/dlunix.cpp:160
+#: ../src/propgrid/props.cpp:155
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/unix/dlunix.cpp:118
 msgid "Unknown dynamic library error"
 msgstr "S'ha produciu una error desconoixida d'a biblioteca dinamica"
 
-#: ../src/common/fmapbase.cpp:810
+#: ../src/common/fmapbase.cpp:806
 #, c-format
 msgid "Unknown encoding (%d)"
 msgstr "Codificación desconoixida (%d)"
 
-#: ../src/msw/ole/automtn.cpp:688
+#: ../src/msw/ole/automtn.cpp:679
 #, c-format
 msgid "Unknown error %08x"
 msgstr "Error desconoixida %08x"
 
-#: ../src/msw/ole/automtn.cpp:647
+#: ../src/msw/ole/automtn.cpp:638
 msgid "Unknown exception"
 msgstr "Excepción desconoixida"
 
-#: ../src/common/image.cpp:2839
+#: ../src/common/image.cpp:2942
 msgid "Unknown image data format."
 msgstr "Formato de datos d'imachen desconoixiu."
 
-#: ../src/common/cmdline.cpp:914
+#: ../src/common/cmdline.cpp:910
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "O parametro '%s' entero luengo ye desconoixiu"
 
-#: ../src/msw/ole/automtn.cpp:631
+#: ../src/msw/ole/automtn.cpp:622
 msgid "Unknown name or named argument."
 msgstr "Nombre u argumento nombrau desconoixiu."
 
-#: ../src/common/cmdline.cpp:929 ../src/common/cmdline.cpp:951
+#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "O parametro '%s' ye desconoixiu"
 
-#: ../src/common/mimecmn.cpp:225
+#: ../src/common/mimecmn.cpp:221
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "Bi ha una '{' no emparellada en una dentrada ta o tipo mime %s."
 
-#: ../src/common/cmdproc.cpp:262 ../src/common/cmdproc.cpp:288
-#: ../src/common/cmdproc.cpp:308
+#: ../src/common/cmdproc.cpp:255 ../src/common/cmdproc.cpp:281
+#: ../src/common/cmdproc.cpp:301
 msgid "Unnamed command"
 msgstr "Comando sin nombre"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:413
+#: ../src/propgrid/propgrid.cpp:392
 msgid "Unspecified"
 msgstr "Sin especificar"
 
-#: ../src/msw/clipbrd.cpp:311
+#: ../src/msw/clipbrd.cpp:325
 msgid "Unsupported clipboard format."
 msgstr "Formato de portafuellas no suportau."
 
-#: ../src/common/appcmn.cpp:256
+#: ../src/common/appcmn.cpp:277
 #, c-format
 msgid "Unsupported theme '%s'."
 msgstr "Tema no suportau '%s'."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:205
-#: ../src/common/accelcmn.cpp:63
+#: ../src/common/stockitem.cpp:202 ../src/common/accelcmn.cpp:60
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Up"
 msgstr "Alto"
 
@@ -7788,7 +7961,7 @@ msgstr "Letras mayusclas"
 msgid "Upper case roman numerals"
 msgstr "Numeros romanos en mayusclas"
 
-#: ../src/common/cmdline.cpp:1326
+#: ../src/common/cmdline.cpp:1322
 #, c-format
 msgid "Usage: %s"
 msgstr "Uso: %s"
@@ -7797,38 +7970,47 @@ msgstr "Uso: %s"
 msgid "Use &shadow"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:169
-#: ../src/richtext/richtextindentspage.cpp:171
 #: ../src/richtext/richtextliststylepage.cpp:358
 #: ../src/richtext/richtextliststylepage.cpp:360
+#: ../src/richtext/richtextindentspage.cpp:169
+#: ../src/richtext/richtextindentspage.cpp:171
 msgid "Use the current alignment setting."
 msgstr "Fer servir l'aliniau actual."
 
-#: ../src/common/valtext.cpp:179
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/gtk/font.cpp:552
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/common/valtext.cpp:142
 msgid "Validation conflict"
 msgstr "Conflicto de validación"
 
-#: ../src/propgrid/manager.cpp:238
+#: ../src/propgrid/manager.cpp:224
 msgid "Value"
 msgstr "Valor"
 
-#: ../src/propgrid/props.cpp:386 ../src/propgrid/props.cpp:500
+#: ../src/propgrid/props.cpp:309
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "A valor cal estar %s u mas alta."
 
-#: ../src/propgrid/props.cpp:417 ../src/propgrid/props.cpp:531
+#: ../src/propgrid/props.cpp:336
 #, c-format
 msgid "Value must be %s or less."
 msgstr "A valor cal estar %s u mas baixa."
 
-#: ../src/propgrid/props.cpp:393 ../src/propgrid/props.cpp:424
-#: ../src/propgrid/props.cpp:507 ../src/propgrid/props.cpp:538
+#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "A valor cal estar entre %s y %s."
 
-#: ../src/generic/aboutdlgg.cpp:128
+#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Versión "
 
@@ -7837,25 +8019,32 @@ msgstr "Versión "
 msgid "Vertical alignment."
 msgstr "Aliniación vertical."
 
-#: ../src/generic/filedlgg.cpp:202
+#: ../src/generic/filedlgg.cpp:199
 msgid "View files as a detailed view"
 msgstr "Veyer os fichers en anvista de detalle"
 
-#: ../src/generic/filedlgg.cpp:200
+#: ../src/generic/filedlgg.cpp:197
 msgid "View files as a list view"
 msgstr "Veyer os fichers en anvista de lista"
 
-#: ../src/common/docview.cpp:1970
+#: ../src/common/docview.cpp:1975
 msgid "Views"
 msgstr "Anvistas"
 
+#: ../src/gtk/app.cpp:348
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1777
+#: ../src/propgrid/advprops.cpp:1678
 msgid "Wait"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1779
+#: ../src/propgrid/advprops.cpp:1680
 msgid "Wait Arrow"
 msgstr ""
 
@@ -7865,243 +8054,240 @@ msgid "Waiting for IO on epoll descriptor %d failed"
 msgstr ""
 "S'ha produciu una error en laspera de dentrada/salida d'o descriptor epool %d"
 
-#: ../src/common/log.cpp:223
+#: ../src/common/log.cpp:241
 msgid "Warning: "
 msgstr "Alvertencia: "
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1778
+#: ../src/propgrid/advprops.cpp:1679
 msgid "Watch"
 msgstr ""
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:685
+#: ../src/propgrid/advprops.cpp:595
 msgid "Weight"
 msgstr "Peso"
 
-#: ../src/common/fmapbase.cpp:148
+#: ../src/common/fmapbase.cpp:145
 msgid "Western European (ISO-8859-1)"
 msgstr "Europa Occidental (ISO-8859-1)"
 
-#: ../src/common/fmapbase.cpp:162
+#: ../src/common/fmapbase.cpp:159
 msgid "Western European with Euro (ISO-8859-15)"
 msgstr "Europa Occidental con Euro (ISO-8859-15)"
 
-#: ../src/generic/fontdlgg.cpp:446 ../src/generic/fontdlgg.cpp:448
+#: ../src/generic/fontdlgg.cpp:443 ../src/generic/fontdlgg.cpp:445
 msgid "Whether the font is underlined."
 msgstr "Si a fuent ye subrayada."
 
-#: ../src/propgrid/advprops.cpp:1611
+#: ../src/propgrid/advprops.cpp:1517
 msgid "White"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:144
+#: ../src/generic/fdrepdlg.cpp:141
 msgid "Whole word"
 msgstr "Parola completa"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:532
 msgid "Whole words only"
 msgstr "Nomás parolas completas"
 
-#: ../src/univ/themes/win32.cpp:1102
+#: ../src/univ/themes/win32.cpp:1099
 msgid "Win32 theme"
 msgstr "Tema Win32"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:893
+#: ../src/propgrid/advprops.cpp:794
 #, fuzzy
 msgid "Window"
 msgstr "&Finestra"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:894
+#: ../src/propgrid/advprops.cpp:795
 #, fuzzy
 msgid "WindowFrame"
 msgstr "&Finestra"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:895
+#: ../src/propgrid/advprops.cpp:796
 #, fuzzy
 msgid "WindowText"
 msgstr "&Finestra"
 
-#: ../src/common/fmapbase.cpp:177
+#: ../src/common/fmapbase.cpp:174
 msgid "Windows Arabic (CP 1256)"
 msgstr "Windows Arabe (CP 1256)"
 
-#: ../src/common/fmapbase.cpp:178
+#: ../src/common/fmapbase.cpp:175
 msgid "Windows Baltic (CP 1257)"
 msgstr "Windows Baltico (CP 1257)"
 
-#: ../src/common/fmapbase.cpp:171
+#: ../src/common/fmapbase.cpp:168
 msgid "Windows Central European (CP 1250)"
 msgstr "Windows Centro Europeu (CP 1250)"
 
-#: ../src/common/fmapbase.cpp:168
+#: ../src/common/fmapbase.cpp:165
 msgid "Windows Chinese Simplified (CP 936) or GB-2312"
 msgstr "Windows chino simplificau (CP 936) u GB-2312"
 
-#: ../src/common/fmapbase.cpp:170
+#: ../src/common/fmapbase.cpp:167
 msgid "Windows Chinese Traditional (CP 950) or Big-5"
 msgstr "Windows chino Tradicional (CP 950) u big-5"
 
-#: ../src/common/fmapbase.cpp:172
+#: ../src/common/fmapbase.cpp:169
 msgid "Windows Cyrillic (CP 1251)"
 msgstr "Windows Cirilico (CP 1251)"
 
-#: ../src/common/fmapbase.cpp:174
+#: ../src/common/fmapbase.cpp:171
 msgid "Windows Greek (CP 1253)"
 msgstr "Windows Griego (CP 1253)"
 
-#: ../src/common/fmapbase.cpp:176
+#: ../src/common/fmapbase.cpp:173
 msgid "Windows Hebrew (CP 1255)"
 msgstr "Windows Hebreu (CP 1255)"
 
-#: ../src/common/fmapbase.cpp:167
+#: ../src/common/fmapbase.cpp:164
 msgid "Windows Japanese (CP 932) or Shift-JIS"
 msgstr "Windows Chaponés (CP 932) u Shift-JIS"
 
-#: ../src/common/fmapbase.cpp:180
+#: ../src/common/fmapbase.cpp:177
 msgid "Windows Johab (CP 1361)"
 msgstr "Windows Johab (CP 1361)"
 
-#: ../src/common/fmapbase.cpp:169
+#: ../src/common/fmapbase.cpp:166
 msgid "Windows Korean (CP 949)"
 msgstr "Windows Coreán (CP 949)"
 
-#: ../src/common/fmapbase.cpp:166
+#: ../src/common/fmapbase.cpp:163
 msgid "Windows Thai (CP 874)"
 msgstr "Windows Tailandés (CP 874)"
 
-#: ../src/common/fmapbase.cpp:175
+#: ../src/common/fmapbase.cpp:172
 msgid "Windows Turkish (CP 1254)"
 msgstr "Windows Turco (CP 1254)"
 
-#: ../src/common/fmapbase.cpp:179
+#: ../src/common/fmapbase.cpp:176
 msgid "Windows Vietnamese (CP 1258)"
 msgstr "Windows Vietnamita (CP 1258)"
 
-#: ../src/common/fmapbase.cpp:173
+#: ../src/common/fmapbase.cpp:170
 msgid "Windows Western European (CP 1252)"
 msgstr "Windows Europeu Occidental (CP 1252)"
 
-#: ../src/common/fmapbase.cpp:181
+#: ../src/common/fmapbase.cpp:178
 msgid "Windows/DOS OEM (CP 437)"
 msgstr "Windows/DOS OEM (CP 437)"
 
-#: ../src/common/fmapbase.cpp:165
+#: ../src/common/fmapbase.cpp:162
 msgid "Windows/DOS OEM Cyrillic (CP 866)"
 msgstr "Windows/DOS OEM Cyrilico (CP 866)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:111
+#: ../src/common/accelcmn.cpp:109
 #, fuzzy
 msgid "Windows_Left"
 msgstr "Windows 7"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:113
+#: ../src/common/accelcmn.cpp:111
 #, fuzzy
 msgid "Windows_Menu"
 msgstr "Windows ME"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:112
+#: ../src/common/accelcmn.cpp:110
 #, fuzzy
 msgid "Windows_Right"
 msgstr "Windows Vista"
 
-#: ../src/common/ffile.cpp:150
+#: ../src/common/ffile.cpp:149
 #, c-format
 msgid "Write error on file '%s'"
 msgstr "S'ha produciu una error d'escritura en o fichero '%s'"
 
-#: ../src/xml/xml.cpp:914
+#: ../src/xml/xml.cpp:925
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "S'ha produciu una error d'analisi de XML: '%s' en a linia %d"
 
-#: ../src/common/xpmdecod.cpp:796
+#: ../src/common/xpmdecod.cpp:794
 msgid "XPM: Malformed pixel data!"
 msgstr "XPM: Datos de pixel erronios!"
 
-#: ../src/common/xpmdecod.cpp:705
+#: ../src/common/xpmdecod.cpp:702
 #, c-format
 msgid "XPM: incorrect colour description in line %d"
 msgstr "XPM: definición de color erronia en a linia %d"
 
-#: ../src/common/xpmdecod.cpp:680
+#: ../src/common/xpmdecod.cpp:677
 msgid "XPM: incorrect header format!"
 msgstr "XPM: formato de capitero incorrecto!"
 
-#: ../src/common/xpmdecod.cpp:716 ../src/common/xpmdecod.cpp:725
+#: ../src/common/xpmdecod.cpp:714 ../src/common/xpmdecod.cpp:723
 #, c-format
 msgid "XPM: malformed colour definition '%s' at line %d!"
 msgstr "XPM: definición de color erronia '%s' en a linia %d!"
 
-#: ../src/common/xpmdecod.cpp:755
+#: ../src/common/xpmdecod.cpp:753
 msgid "XPM: no colors left to use for mask!"
 msgstr "XPM: No s'han deixau colors ta fer-las servir en a mascara!"
 
-#: ../src/common/xpmdecod.cpp:782
+#: ../src/common/xpmdecod.cpp:780
 #, c-format
 msgid "XPM: truncated image data at line %d!"
 msgstr "XPM: datos d'imachen truncaus en a linia %d!"
 
-#: ../src/propgrid/advprops.cpp:1610
+#: ../src/propgrid/advprops.cpp:1516
 msgid "Yellow"
 msgstr ""
 
-#: ../include/wx/msgdlg.h:276 ../src/common/stockitem.cpp:206
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:203
 #: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Sí"
 
-#: ../src/osx/carbon/overlay.cpp:155
-msgid "You cannot Clear an overlay that is not inited"
-msgstr "No puetz sacar una superposición que no ye estada inicializada"
-
-#: ../src/osx/carbon/overlay.cpp:107 ../src/dfb/overlay.cpp:61
-msgid "You cannot Init an overlay twice"
-msgstr "No puetz Inicializar una superposición dos vegadas"
-
-#: ../src/generic/dirdlgg.cpp:287
+#: ../src/generic/dirdlgg.cpp:284
 msgid "You cannot add a new directory to this section."
 msgstr "No puetz adhibir un nuevo directorio a ista sección."
 
-#: ../src/propgrid/propgrid.cpp:3299
+#: ../src/propgrid/propgrid.cpp:3276
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr "Has introduciu una valor no valida. Preta l'ESC ta cancelar a edición."
 
-#: ../src/common/stockitem.cpp:209
+#: ../src/osx/cocoa/menu.mm:286
+#, fuzzy
+msgid "Zoom"
+msgstr "Agrandir"
+
+#: ../src/common/stockitem.cpp:206
 msgid "Zoom &In"
 msgstr "A&manar"
 
-#: ../src/common/stockitem.cpp:210
+#: ../src/common/stockitem.cpp:207
 msgid "Zoom &Out"
 msgstr "A&luenyar"
 
-#: ../src/common/stockitem.cpp:209 ../src/common/prntbase.cpp:1594
+#: ../src/common/stockitem.cpp:206 ../src/common/prntbase.cpp:1619
 msgid "Zoom In"
 msgstr "Agrandir"
 
-#: ../src/common/stockitem.cpp:210 ../src/common/prntbase.cpp:1580
+#: ../src/common/stockitem.cpp:207 ../src/common/prntbase.cpp:1605
 msgid "Zoom Out"
 msgstr "Achiquir"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to &Fit"
 msgstr "&Achustar a la grandaria"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to Fit"
 msgstr "Achustar l'anvista"
 
-#: ../src/msw/dde.cpp:1141
+#: ../src/msw/dde.cpp:1205
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "una aplicación DDEML ha creyau una condición accelerada prolongada."
 
-#: ../src/msw/dde.cpp:1129
+#: ../src/msw/dde.cpp:1193
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -8113,40 +8299,40 @@ msgstr ""
 "u s'ha pasau un identificador d'instancia no valido\n"
 "a una función DDEML."
 
-#: ../src/msw/dde.cpp:1147
+#: ../src/msw/dde.cpp:1211
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "l'intento d'un client d'estableixer conversación ha fallau."
 
-#: ../src/msw/dde.cpp:1144
+#: ../src/msw/dde.cpp:1208
 msgid "a memory allocation failed."
 msgstr "ha fallau a reserva de memoria."
 
-#: ../src/msw/dde.cpp:1138
+#: ../src/msw/dde.cpp:1202
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "ha fallau un parametro a lo validar-se por o DDEML."
 
-#: ../src/msw/dde.cpp:1120
+#: ../src/msw/dde.cpp:1184
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "una petición ta una transacción sincrona d'alvertencia ha caducau."
 
-#: ../src/msw/dde.cpp:1126
+#: ../src/msw/dde.cpp:1190
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "una petición ta una transacción de datos sincrona ha caducau."
 
-#: ../src/msw/dde.cpp:1135
+#: ../src/msw/dde.cpp:1199
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "una petición ta una transación d'execución sincrona ha caducau."
 
-#: ../src/msw/dde.cpp:1153
+#: ../src/msw/dde.cpp:1217
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "una petición ta una transacción sincrona de revisión ha caducau."
 
-#: ../src/msw/dde.cpp:1168
+#: ../src/msw/dde.cpp:1232
 msgid "a request to end an advise transaction has timed out."
 msgstr ""
 "una petición ta rematar una transacción sincrona d'alvertencia ha caducau."
 
-#: ../src/msw/dde.cpp:1162
+#: ../src/msw/dde.cpp:1226
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -8156,15 +8342,15 @@ msgstr ""
 "que estió rematada por o client, u lo servidor\n"
 "remató antes de completar una transacción."
 
-#: ../src/msw/dde.cpp:1150
+#: ../src/msw/dde.cpp:1214
 msgid "a transaction failed."
 msgstr "ha fallau una transacción."
 
-#: ../src/common/accelcmn.cpp:189
+#: ../src/common/accelcmn.cpp:188
 msgid "alt"
 msgstr "alt"
 
-#: ../src/msw/dde.cpp:1132
+#: ../src/msw/dde.cpp:1196
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -8176,15 +8362,15 @@ msgstr ""
 "u una aplicación inicializada como APPCMD_CLIENTONLY ha\n"
 "prebau a realizar transaccions de servidor."
 
-#: ../src/msw/dde.cpp:1156
+#: ../src/msw/dde.cpp:1220
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "ha fallau una clamada interna a la función PostMessage. "
 
-#: ../src/msw/dde.cpp:1165
+#: ../src/msw/dde.cpp:1229
 msgid "an internal error has occurred in the DDEML."
 msgstr "s'ha produciu una error interna en o DDEML."
 
-#: ../src/msw/dde.cpp:1171
+#: ../src/msw/dde.cpp:1235
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -8195,56 +8381,56 @@ msgstr ""
 "XTYP_XACT_COMPLETE,\n"
 "l'identificador d'a transacción ta ixa gritada deixa d'estar valido."
 
-#: ../src/common/zipstrm.cpp:1483
+#: ../src/common/zipstrm.cpp:1522
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "se suposa que ye un fichero zip multiparti concatenau"
 
-#: ../src/common/fileconf.cpp:1847
+#: ../src/common/fileconf.cpp:1849
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "intento de cambiar clau immutable '%s', ignorau."
 
-#: ../src/html/chm.cpp:329
+#: ../src/html/chm.cpp:326
 msgid "bad arguments to library function"
 msgstr "argumentos erronios ta la función de biblioteca"
 
-#: ../src/html/chm.cpp:341
+#: ../src/html/chm.cpp:338
 msgid "bad signature"
 msgstr "sinyatura erronia"
 
-#: ../src/common/zipstrm.cpp:1918
+#: ../src/common/zipstrm.cpp:1988
 msgid "bad zipfile offset to entry"
 msgstr "desplazamiento erronio ta l'elemento d'o fichero zip"
 
-#: ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400
 msgid "binary"
 msgstr "binario"
 
-#: ../src/common/fontcmn.cpp:996
+#: ../src/common/fontcmn.cpp:1195
 msgid "bold"
 msgstr "negreta"
 
-#: ../src/msw/utils.cpp:1144
+#: ../src/msw/utils.cpp:1135
 #, c-format
 msgid "build %lu"
 msgstr "construir %lu"
 
-#: ../src/common/ffile.cpp:75
+#: ../src/common/ffile.cpp:73
 #, c-format
 msgid "can't close file '%s'"
 msgstr "no se puet zarrar o fichero '%s'"
 
-#: ../src/common/file.cpp:245
+#: ../src/common/file.cpp:242
 #, c-format
 msgid "can't close file descriptor %d"
 msgstr "no se puet zarrar o descriptor de fichero %d"
 
-#: ../src/common/file.cpp:586
+#: ../src/common/ffile.cpp:382 ../src/common/file.cpp:613
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "no se pueden fer efectivos os cambeos en o fichero '%s'"
 
-#: ../src/common/file.cpp:178
+#: ../src/common/file.cpp:175
 #, c-format
 msgid "can't create file '%s'"
 msgstr "no se puet creyar o fichero '%s'"
@@ -8254,53 +8440,53 @@ msgstr "no se puet creyar o fichero '%s'"
 msgid "can't delete user configuration file '%s'"
 msgstr "no se puet eliminar o fichero de configuración d'usuario '%s'"
 
-#: ../src/common/file.cpp:495
+#: ../src/common/file.cpp:522
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr ""
 "no se puet determinar si o final d'o fichero con descriptor %d s'ha "
 "aconseguiu"
 
-#: ../src/common/zipstrm.cpp:1692
+#: ../src/common/zipstrm.cpp:1747
 msgid "can't find central directory in zip"
 msgstr "no se puet trobar o directorio central en o zip"
 
-#: ../src/common/file.cpp:465
+#: ../src/common/file.cpp:492
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "no se puet obtener a grandaria d'o fichero con descriptor %d"
 
-#: ../src/msw/utils.cpp:341
+#: ../src/msw/utils.cpp:336
 msgid "can't find user's HOME, using current directory."
 msgstr ""
 "no s'ha puesto trobar l'HOME de l'usuario, se ye usando o directorio actual."
 
-#: ../src/common/file.cpp:366
+#: ../src/common/file.cpp:407
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "no se puet vuedar o descriptor de fichero %d"
 
-#: ../src/common/file.cpp:422
+#: ../src/common/file.cpp:463
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr ""
 "no se puet aconseguir a posición de busca en o descriptor de fichero %d"
 
-#: ../src/common/fontmap.cpp:325
+#: ../src/common/fontmap.cpp:322
 msgid "can't load any font, aborting"
 msgstr "no se puet cargar garra fuent, se ye abortando"
 
-#: ../src/common/file.cpp:231 ../src/common/ffile.cpp:59
+#: ../src/common/ffile.cpp:57 ../src/common/file.cpp:228
 #, c-format
 msgid "can't open file '%s'"
 msgstr "no se puet ubrir o fichero '%s'"
 
-#: ../src/common/fileconf.cpp:320
+#: ../src/common/fileconf.cpp:314
 #, c-format
 msgid "can't open global configuration file '%s'."
 msgstr "no se puet ubrir o fichero de configuración global '%s'."
 
-#: ../src/common/fileconf.cpp:336
+#: ../src/common/fileconf.cpp:330
 #, c-format
 msgid "can't open user configuration file '%s'."
 msgstr "no se puet ubrir o fichero de configuración d'usuario '%s'."
@@ -8309,40 +8495,40 @@ msgstr "no se puet ubrir o fichero de configuración d'usuario '%s'."
 msgid "can't open user configuration file."
 msgstr "no se puet ubrir o fichero de configuración d'usuario."
 
-#: ../src/common/zipstrm.cpp:579
+#: ../src/common/zipstrm.cpp:572
 msgid "can't re-initialize zlib deflate stream"
 msgstr "no se puet reinicializar o fluxo de compresión de zlib."
 
-#: ../src/common/zipstrm.cpp:604
+#: ../src/common/zipstrm.cpp:597
 msgid "can't re-initialize zlib inflate stream"
 msgstr "no se puet reinicializar o fluxo de descompresión de zlib"
 
-#: ../src/common/file.cpp:304
+#: ../src/common/file.cpp:345
 #, c-format
 msgid "can't read from file descriptor %d"
 msgstr "no se puet leyer dende o descriptor de fichero %d"
 
-#: ../src/common/file.cpp:581
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:608
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "no se puet eliminar o fichero '%s'"
 
-#: ../src/common/file.cpp:598
+#: ../src/common/ffile.cpp:394 ../src/common/file.cpp:625
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "no se puet eliminar o fichero temporal '%s'"
 
-#: ../src/common/file.cpp:408
+#: ../src/common/file.cpp:449
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "no se puet mirar en o descriptor de fichero %d"
 
-#: ../src/common/textfile.cpp:273
+#: ../src/common/textfile.cpp:161
 #, c-format
 msgid "can't write buffer '%s' to disk."
 msgstr "no se puet alzar o buffer '%s' en o disco."
 
-#: ../src/common/file.cpp:323
+#: ../src/common/file.cpp:364
 #, c-format
 msgid "can't write to file descriptor %d"
 msgstr "no se puet escribir o descriptor de fichero %d"
@@ -8352,24 +8538,30 @@ msgid "can't write user configuration file."
 msgstr "no se puet escribir o fichero de configuración de l'usuario."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:482 ../src/generic/datavgen.cpp:1261
+#: ../src/common/datavcmn.cpp:2064 ../src/generic/datavgen.cpp:1384
 msgid "checked"
 msgstr ""
 
-#: ../src/html/chm.cpp:345
+#: ../src/html/chm.cpp:342
 msgid "checksum error"
 msgstr "s'ha produciu una error de suma de comprebación"
 
-#: ../src/common/tarstrm.cpp:820
+#: ../src/common/tarstrm.cpp:814
 msgid "checksum failure reading tar header block"
 msgstr ""
 "s'ha produciu una error de suma de comprebación leyendo lo bloque de "
 "capitero de tar"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:226
-#: ../src/richtext/richtextbackgroundpage.cpp:249
-#: ../src/richtext/richtextbackgroundpage.cpp:289
-#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
 #: ../src/richtext/richtextborderspage.cpp:254
 #: ../src/richtext/richtextborderspage.cpp:288
 #: ../src/richtext/richtextborderspage.cpp:322
@@ -8387,107 +8579,132 @@ msgstr ""
 #: ../src/richtext/richtextmarginspage.cpp:340
 #: ../src/richtext/richtextmarginspage.cpp:363
 #: ../src/richtext/richtextmarginspage.cpp:388
-#: ../src/richtext/richtextsizepage.cpp:339
-#: ../src/richtext/richtextsizepage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:400
-#: ../src/richtext/richtextsizepage.cpp:427
-#: ../src/richtext/richtextsizepage.cpp:454
-#: ../src/richtext/richtextsizepage.cpp:481
-#: ../src/richtext/richtextsizepage.cpp:555
-#: ../src/richtext/richtextsizepage.cpp:590
-#: ../src/richtext/richtextsizepage.cpp:625
-#: ../src/richtext/richtextsizepage.cpp:660
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
 msgid "cm"
 msgstr "cm"
 
-#: ../src/html/chm.cpp:347
+#: ../src/html/chm.cpp:344
 msgid "compression error"
 msgstr "s'ha produciu una error de compresión"
 
-#: ../src/common/regex.cpp:236
+#: ../src/common/regex.cpp:233
 msgid "conversion to 8-bit encoding failed"
 msgstr "ha fallau a conversión en codificación de 8 bits"
 
-#: ../src/common/accelcmn.cpp:187
+#: ../src/common/accelcmn.cpp:186
 msgid "ctrl"
 msgstr "ctrl"
 
-#: ../src/common/cmdline.cpp:1500
+#: ../src/common/cmdline.cpp:1496
 msgid "date"
 msgstr "calendata"
 
-#: ../src/html/chm.cpp:349
+#: ../src/html/chm.cpp:346
 msgid "decompression error"
 msgstr "s'ha produciu una error de descompresión"
 
-#: ../src/richtext/richtextstyles.cpp:780 ../src/common/fmapbase.cpp:820
+#: ../src/common/fmapbase.cpp:816 ../src/richtext/richtextstyles.cpp:777
 msgid "default"
 msgstr "predeterminau"
 
-#: ../src/common/cmdline.cpp:1496
+#: ../src/common/cmdline.cpp:1492
 msgid "double"
 msgstr "dople"
 
-#: ../src/common/debugrpt.cpp:538
+#: ../src/common/debugrpt.cpp:539
 msgid "dump of the process state (binary)"
 msgstr "vulcau d'estau de proceso (binario)"
 
-#: ../src/common/datetimefmt.cpp:1969
+#: ../src/common/datetimefmt.cpp:1992
 msgid "eighteenth"
 msgstr "deciuiteno"
 
-#: ../src/common/datetimefmt.cpp:1959
+#: ../src/common/datetimefmt.cpp:1982
 msgid "eighth"
 msgstr "uiteno"
 
-#: ../src/common/datetimefmt.cpp:1962
+#: ../src/common/datetimefmt.cpp:1985
 msgid "eleventh"
 msgstr "onceno"
 
-#: ../src/common/fileconf.cpp:1833
+#: ../src/common/fileconf.cpp:1835
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "a dentrada '%s' amaneix mas d'una vegada en o grupo '%s'"
 
-#: ../src/html/chm.cpp:343
+#: ../src/html/chm.cpp:340
 msgid "error in data format"
 msgstr "s'ha produciu una error en o formato de datos"
 
-#: ../src/html/chm.cpp:331
+#: ../src/html/chm.cpp:328
 msgid "error opening file"
 msgstr "s'ha produciu una error en ubrir o fichero"
 
-#: ../src/common/zipstrm.cpp:1778
+#: ../src/common/zipstrm.cpp:1836
 msgid "error reading zip central directory"
 msgstr "s'ha produciu una error en leyer o directorio central d'o zip"
 
-#: ../src/common/zipstrm.cpp:1870
+#: ../src/common/zipstrm.cpp:1940
 msgid "error reading zip local header"
 msgstr "s'ha produciu una error en leyer o capitero local d'o fichero zip"
 
-#: ../src/common/zipstrm.cpp:2531
+#: ../src/common/zipstrm.cpp:2615
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr ""
 "s'ha produciu una error en escribir l'elemento de zip '%s': crc u longaria "
 "erronios"
 
-#: ../src/common/ffile.cpp:188
+#: ../src/common/zipstrm.cpp:2608
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr ""
+"s'ha produciu una error en escribir l'elemento de zip '%s': crc u longaria "
+"erronios"
+
+#: ../src/common/fontcmn.cpp:1205
+#, fuzzy
+msgid "extrabold"
+msgstr "negreta"
+
+#: ../src/common/fontcmn.cpp:1223
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1167
+#, fuzzy
+msgid "extralight"
+msgstr "lichera"
+
+#: ../src/msw/webview_ie.cpp:1036
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "S'ha produciu una error en executar '%s'\n"
+
+#: ../src/common/ffile.cpp:187
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "s'ha produciu una error en limpiar o fichero '%s'"
 
+#: ../src/msw/webview_ie.cpp:1045
+#, fuzzy
+msgid "failed to retrieve execution result"
+msgstr "No s'ha puesto recuperar o mensache d'error de RAS"
+
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1030
+#: ../src/generic/datavgen.cpp:1150
 #, fuzzy
 msgid "false"
 msgstr "Falso"
 
-#: ../src/common/datetimefmt.cpp:1966
+#: ../src/common/datetimefmt.cpp:1989
 msgid "fifteenth"
 msgstr "quinceno"
 
-#: ../src/common/datetimefmt.cpp:1956
+#: ../src/common/datetimefmt.cpp:1979
 msgid "fifth"
 msgstr "cinqueno"
 
@@ -8518,131 +8735,150 @@ msgstr "fichero '%s', linia %d: valor ignorada ta la clau immutable '%s'."
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "fichero '%s': caracter %c inasperau en a linia %d."
 
-#: ../src/richtext/richtextbuffer.cpp:8738
+#: ../src/richtext/richtextbuffer.cpp:8736
 msgid "files"
 msgstr "fichers"
 
-#: ../src/common/datetimefmt.cpp:1952
+#: ../src/common/datetimefmt.cpp:1975
 msgid "first"
 msgstr "primer"
 
-#: ../src/html/helpwnd.cpp:1252
+#: ../src/html/helpwnd.cpp:1250
 msgid "font size"
 msgstr "grandaria de fuent"
 
-#: ../src/common/datetimefmt.cpp:1965
+#: ../src/common/datetimefmt.cpp:1988
 msgid "fourteenth"
 msgstr "catorceno"
 
-#: ../src/common/datetimefmt.cpp:1955
+#: ../src/common/datetimefmt.cpp:1978
 msgid "fourth"
 msgstr "quatreno"
 
-#: ../src/common/appbase.cpp:783
+#: ../src/common/appbase.cpp:784
 msgid "generate verbose log messages"
 msgstr "chenerar mensaches de log explicitos"
 
-#: ../src/richtext/richtextbuffer.cpp:13138
-#: ../src/richtext/richtextbuffer.cpp:13248
+#: ../src/common/fontcmn.cpp:1215
+msgid "heavy"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:13133
+#: ../src/richtext/richtextbuffer.cpp:13243
 msgid "image"
 msgstr "imachen"
 
-#: ../src/common/tarstrm.cpp:796
+#: ../src/common/tarstrm.cpp:790
 msgid "incomplete header block in tar"
 msgstr "bloque de capitero incompleto en tar"
 
-#: ../src/common/xtixml.cpp:489
+#: ../src/common/xtixml.cpp:485
 msgid "incorrect event handler string, missing dot"
 msgstr "cadena d'identificador d'evento incorrecta, i falta o punto"
 
-#: ../src/common/tarstrm.cpp:1381
+#: ../src/common/tarstrm.cpp:1375
 msgid "incorrect size given for tar entry"
 msgstr "grandaria incorrecta ta la dentrada de tar"
 
-#: ../src/common/tarstrm.cpp:993
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:987
 msgid "invalid data in extended tar header"
 msgstr "datos no validos en o capitero de tar extendiu"
 
-#: ../src/generic/logg.cpp:1030
+#: ../src/generic/logg.cpp:1027
 msgid "invalid message box return value"
 msgstr "avalor de retorno de servilla de dentrada no ye valida"
 
-#: ../src/common/zipstrm.cpp:1647
+#: ../src/common/zipstrm.cpp:1688
 msgid "invalid zip file"
 msgstr "fichero zip no valido"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:1228
 msgid "italic"
 msgstr "cursiva"
 
-#: ../src/common/fontcmn.cpp:991
+#: ../src/common/webrequest_curl.cpp:374
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "No s'ha puesto inicializar a descripción de columna."
+
+#: ../src/common/fontcmn.cpp:1172
 msgid "light"
 msgstr "lichera"
 
-#: ../src/common/intl.cpp:303
-#, c-format
-msgid "locale '%s' cannot be set."
-msgstr "no s'ha puesto establir a localización '%s'."
+#: ../src/common/fontcmn.cpp:1185
+msgid "medium"
+msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2125
+#: ../src/common/datetimefmt.cpp:2148
 msgid "midnight"
 msgstr "meyanueit"
 
-#: ../src/common/datetimefmt.cpp:1970
+#: ../src/common/datetimefmt.cpp:1993
 msgid "nineteenth"
 msgstr "decinueno"
 
-#: ../src/common/datetimefmt.cpp:1960
+#: ../src/common/datetimefmt.cpp:1983
 msgid "ninth"
 msgstr "nueno"
 
-#: ../src/msw/dde.cpp:1116
+#: ../src/msw/dde.cpp:1180
 msgid "no DDE error."
 msgstr "sin error DDE."
 
-#: ../src/html/chm.cpp:327
+#: ../src/html/chm.cpp:324
 msgid "no error"
 msgstr "sin error"
 
-#: ../src/dfb/fontmgr.cpp:174
+#: ../src/dfb/fontmgr.cpp:171
 #, c-format
 msgid "no fonts found in %s, using builtin font"
 msgstr "no s'han trobau fuents en %s, se ye usando a fuent integrada"
 
-#: ../src/html/helpdata.cpp:657
+#: ../src/html/helpdata.cpp:650
 msgid "noname"
 msgstr "sin nombre"
 
-#: ../src/common/datetimefmt.cpp:2124
+#: ../src/common/datetimefmt.cpp:2147
 msgid "noon"
 msgstr "meyodiya"
 
-#: ../src/richtext/richtextstyles.cpp:779
+#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "normal"
 
-#: ../src/common/cmdline.cpp:1492
+#: ../src/common/cmdline.cpp:1488
 msgid "num"
 msgstr "núm"
 
-#: ../src/common/xtixml.cpp:259
+#: ../src/common/accelcmn.cpp:194
+msgid "num "
+msgstr ""
+
+#: ../src/common/xtixml.cpp:255
 msgid "objects cannot have XML Text Nodes"
 msgstr "os obchectos no pueden tener nodos XML de texto"
 
-#: ../src/html/chm.cpp:339
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
 msgid "out of memory"
 msgstr "memoria acotolada"
 
-#: ../src/common/debugrpt.cpp:514
+#: ../src/common/debugrpt.cpp:515
 msgid "process context description"
 msgstr "descripción d'o contexto d'o proceso"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:227
-#: ../src/richtext/richtextbackgroundpage.cpp:250
-#: ../src/richtext/richtextbackgroundpage.cpp:290
-#: ../src/richtext/richtextbackgroundpage.cpp:317
-#: ../src/richtext/richtextfontpage.cpp:177
-#: ../src/richtext/richtextfontpage.cpp:180
 #: ../src/richtext/richtextborderspage.cpp:255
 #: ../src/richtext/richtextborderspage.cpp:289
 #: ../src/richtext/richtextborderspage.cpp:323
@@ -8652,22 +8888,45 @@ msgstr "descripción d'o contexto d'o proceso"
 #: ../src/richtext/richtextborderspage.cpp:491
 #: ../src/richtext/richtextborderspage.cpp:525
 #: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextfontpage.cpp:180
 msgid "pt"
 msgstr "pt"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:225
-#: ../src/richtext/richtextbackgroundpage.cpp:228
-#: ../src/richtext/richtextbackgroundpage.cpp:229
-#: ../src/richtext/richtextbackgroundpage.cpp:248
-#: ../src/richtext/richtextbackgroundpage.cpp:251
-#: ../src/richtext/richtextbackgroundpage.cpp:252
-#: ../src/richtext/richtextbackgroundpage.cpp:288
-#: ../src/richtext/richtextbackgroundpage.cpp:291
-#: ../src/richtext/richtextbackgroundpage.cpp:292
-#: ../src/richtext/richtextbackgroundpage.cpp:315
-#: ../src/richtext/richtextbackgroundpage.cpp:318
-#: ../src/richtext/richtextbackgroundpage.cpp:319
-#: ../src/richtext/richtextfontpage.cpp:178
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:659
+#: ../src/richtext/richtextsizepage.cpp:662
+#: ../src/richtext/richtextsizepage.cpp:663
 #: ../src/richtext/richtextborderspage.cpp:253
 #: ../src/richtext/richtextborderspage.cpp:256
 #: ../src/richtext/richtextborderspage.cpp:257
@@ -8719,260 +8978,270 @@ msgstr "pt"
 #: ../src/richtext/richtextmarginspage.cpp:387
 #: ../src/richtext/richtextmarginspage.cpp:389
 #: ../src/richtext/richtextmarginspage.cpp:390
-#: ../src/richtext/richtextsizepage.cpp:338
-#: ../src/richtext/richtextsizepage.cpp:341
-#: ../src/richtext/richtextsizepage.cpp:342
-#: ../src/richtext/richtextsizepage.cpp:372
-#: ../src/richtext/richtextsizepage.cpp:375
-#: ../src/richtext/richtextsizepage.cpp:376
-#: ../src/richtext/richtextsizepage.cpp:399
-#: ../src/richtext/richtextsizepage.cpp:402
-#: ../src/richtext/richtextsizepage.cpp:403
-#: ../src/richtext/richtextsizepage.cpp:426
-#: ../src/richtext/richtextsizepage.cpp:429
-#: ../src/richtext/richtextsizepage.cpp:430
-#: ../src/richtext/richtextsizepage.cpp:453
-#: ../src/richtext/richtextsizepage.cpp:456
-#: ../src/richtext/richtextsizepage.cpp:457
-#: ../src/richtext/richtextsizepage.cpp:480
-#: ../src/richtext/richtextsizepage.cpp:483
-#: ../src/richtext/richtextsizepage.cpp:484
-#: ../src/richtext/richtextsizepage.cpp:554
-#: ../src/richtext/richtextsizepage.cpp:557
-#: ../src/richtext/richtextsizepage.cpp:558
-#: ../src/richtext/richtextsizepage.cpp:589
-#: ../src/richtext/richtextsizepage.cpp:592
-#: ../src/richtext/richtextsizepage.cpp:593
-#: ../src/richtext/richtextsizepage.cpp:624
-#: ../src/richtext/richtextsizepage.cpp:627
-#: ../src/richtext/richtextsizepage.cpp:628
-#: ../src/richtext/richtextsizepage.cpp:659
-#: ../src/richtext/richtextsizepage.cpp:662
-#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextfontpage.cpp:178
 msgid "px"
 msgstr "px"
 
-#: ../src/common/accelcmn.cpp:193
+#: ../src/common/accelcmn.cpp:192
 msgid "rawctrl"
 msgstr "rawctrl"
 
-#: ../src/html/chm.cpp:333
+#: ../src/html/chm.cpp:330
 msgid "read error"
 msgstr "s'ha produciu una error de lectura"
 
-#: ../src/common/zipstrm.cpp:2085
+#: ../src/common/zipstrm.cpp:2155
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "a lo leyer o fluxo de zip (elemento %s): crc erronio"
 
-#: ../src/common/zipstrm.cpp:2080
+#: ../src/common/zipstrm.cpp:2150
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "a lo leyer o fluxo de zip (elemento %s): longaria erronia"
 
-#: ../src/msw/dde.cpp:1159
+#: ../src/msw/dde.cpp:1223
 msgid "reentrancy problem."
 msgstr "problema de reentrada."
 
-#: ../src/common/datetimefmt.cpp:1953
+#: ../src/common/datetimefmt.cpp:1976
 msgid "second"
 msgstr "segundo"
 
-#: ../src/html/chm.cpp:337
+#: ../src/html/chm.cpp:334
 msgid "seek error"
 msgstr "error de busca"
 
-#: ../src/common/datetimefmt.cpp:1968
+#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#, fuzzy
+msgid "semibold"
+msgstr "negreta"
+
+#: ../src/common/datetimefmt.cpp:1991
 msgid "seventeenth"
 msgstr "deciseteno"
 
-#: ../src/common/datetimefmt.cpp:1958
+#: ../src/common/datetimefmt.cpp:1981
 msgid "seventh"
 msgstr "seteno"
 
-#: ../src/common/accelcmn.cpp:191
+#: ../src/common/accelcmn.cpp:190
 msgid "shift"
 msgstr "mayusclas"
 
-#: ../src/common/appbase.cpp:773
+#: ../src/common/appbase.cpp:774
 msgid "show this help message"
 msgstr "amostrar iste mensache d'aduya"
 
-#: ../src/common/datetimefmt.cpp:1967
+#: ../src/common/datetimefmt.cpp:1990
 msgid "sixteenth"
 msgstr "setzeno"
 
-#: ../src/common/datetimefmt.cpp:1957
+#: ../src/common/datetimefmt.cpp:1980
 msgid "sixth"
 msgstr "seiseno"
 
-#: ../src/common/appcmn.cpp:234
+#: ../src/common/appcmn.cpp:255
 msgid "specify display mode to use (e.g. 640x480-16)"
 msgstr "especifica lo modo que fer servir (eix.: 640x480-16)"
 
-#: ../src/common/appcmn.cpp:220
+#: ../src/common/appcmn.cpp:241
 msgid "specify the theme to use"
 msgstr "especifica lo tema que fer servir"
 
-#: ../src/richtext/richtextbuffer.cpp:9340
+#: ../src/richtext/richtextbuffer.cpp:9337
 msgid "standard/circle"
 msgstr "estandar/cerclo"
 
-#: ../src/richtext/richtextbuffer.cpp:9341
+#: ../src/richtext/richtextbuffer.cpp:9338
 msgid "standard/circle-outline"
 msgstr "estandar/cerclo - esquema"
 
-#: ../src/richtext/richtextbuffer.cpp:9343
+#: ../src/richtext/richtextbuffer.cpp:9340
 msgid "standard/diamond"
 msgstr "estandar/diamant"
 
-#: ../src/richtext/richtextbuffer.cpp:9342
+#: ../src/richtext/richtextbuffer.cpp:9339
 msgid "standard/square"
 msgstr "estandar/quadrau"
 
-#: ../src/richtext/richtextbuffer.cpp:9344
+#: ../src/richtext/richtextbuffer.cpp:9341
 msgid "standard/triangle"
 msgstr "estandar/trianglo"
 
-#: ../src/common/zipstrm.cpp:1985
+#: ../src/common/zipstrm.cpp:2055
 msgid "stored file length not in Zip header"
 msgstr "a longaria d'o fichero almagazenau no ye en o capitero d'o Zip"
 
-#: ../src/common/cmdline.cpp:1488
+#: ../src/common/cmdline.cpp:1484
 msgid "str"
 msgstr "cad"
 
-#: ../src/common/fontcmn.cpp:982
+#: ../src/common/fontcmn.cpp:1145
 msgid "strikethrough"
 msgstr "rayau"
 
-#: ../src/common/tarstrm.cpp:1003 ../src/common/tarstrm.cpp:1025
-#: ../src/common/tarstrm.cpp:1507 ../src/common/tarstrm.cpp:1529
+#: ../src/common/tarstrm.cpp:997 ../src/common/tarstrm.cpp:1019
+#: ../src/common/tarstrm.cpp:1501 ../src/common/tarstrm.cpp:1523
 msgid "tar entry not open"
 msgstr "dentrada tar no ubierta"
 
-#: ../src/common/datetimefmt.cpp:1961
+#: ../src/common/datetimefmt.cpp:1984
 msgid "tenth"
 msgstr "deceno"
 
-#: ../src/msw/dde.cpp:1123
+#: ../src/msw/dde.cpp:1187
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "a respuesta a la transacción causó que s'activase o bit DDE_FBUSY."
 
-#: ../src/common/datetimefmt.cpp:1954
+#: ../src/common/fontcmn.cpp:1154
+msgid "thin"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:1977
 msgid "third"
 msgstr "tercer"
 
-#: ../src/common/datetimefmt.cpp:1964
+#: ../src/common/datetimefmt.cpp:1987
 msgid "thirteenth"
 msgstr "treceno"
 
-#: ../src/common/datetimefmt.cpp:1758
+#: ../src/common/datetimefmt.cpp:1781
 msgid "today"
 msgstr "hue"
 
-#: ../src/common/datetimefmt.cpp:1760
+#: ../src/common/datetimefmt.cpp:1783
 msgid "tomorrow"
 msgstr "maitín"
 
-#: ../src/common/fileconf.cpp:1944
+#: ../src/common/fileconf.cpp:1946
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "s'ha ignorau a barra inversa sobrant en '%s'"
 
-#: ../src/gtk/aboutdlg.cpp:218
+#: ../src/gtk/aboutdlg.cpp:216
 msgid "translator-credits"
 msgstr "traductor-creditos"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1028
+#: ../src/generic/datavgen.cpp:1148
 msgid "true"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1963
+#: ../src/common/datetimefmt.cpp:1986
 msgid "twelfth"
 msgstr "doceno"
 
-#: ../src/common/datetimefmt.cpp:1971
+#: ../src/common/datetimefmt.cpp:1994
 msgid "twentieth"
 msgstr "vinteno"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:486 ../src/generic/datavgen.cpp:1263
+#: ../src/common/datavcmn.cpp:2068 ../src/generic/datavgen.cpp:1386
 msgid "unchecked"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:802 ../src/common/fontcmn.cpp:978
+#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
 msgid "underlined"
 msgstr "subrayau"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:490
+#: ../src/common/datavcmn.cpp:2072
 #, fuzzy
 msgid "undetermined"
 msgstr "subrayau"
 
-#: ../src/common/fileconf.cpp:1979
+#: ../src/common/fileconf.cpp:1981
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "\" inasperau en a posición %d en '%s'."
 
-#: ../src/common/tarstrm.cpp:1045
+#: ../src/common/tarstrm.cpp:1039
 msgid "unexpected end of file"
 msgstr "fin de fichero inasperau"
 
-#: ../src/generic/progdlgg.cpp:370 ../src/common/tarstrm.cpp:371
-#: ../src/common/tarstrm.cpp:394 ../src/common/tarstrm.cpp:425
+#: ../src/common/tarstrm.cpp:366 ../src/common/tarstrm.cpp:389
+#: ../src/common/tarstrm.cpp:420 ../src/generic/progdlgg.cpp:376
 msgid "unknown"
 msgstr "desconoixiu"
 
-#: ../src/msw/registry.cpp:150
+#: ../src/msw/registry.cpp:139
 #, fuzzy, c-format
 msgid "unknown (%lu)"
 msgstr "desconoixiu"
 
-#: ../src/common/xtixml.cpp:253
+#: ../src/common/xtixml.cpp:249
 #, c-format
 msgid "unknown class %s"
 msgstr "clase %s desconoixida"
 
-#: ../src/common/regex.cpp:258 ../src/html/chm.cpp:351
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "s'ha produciu una error de compresión"
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "s'ha produciu una error de descompresión"
+
+#: ../src/common/regex.cpp:255 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "s'ha produciu una error desconoixida"
 
-#: ../src/msw/dialup.cpp:471
+#: ../src/msw/dialup.cpp:465
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "s'ha produciu una error desconoixida (codigo d'error %08x)."
 
-#: ../src/common/fmapbase.cpp:834
+#: ../src/common/fmapbase.cpp:830
 #, c-format
 msgid "unknown-%d"
 msgstr "desconoixiu-%d"
 
-#: ../src/common/docview.cpp:509
+#: ../src/common/docview.cpp:502
 msgid "unnamed"
 msgstr "sin nombre"
 
-#: ../src/common/docview.cpp:1624
+#: ../src/common/docview.cpp:1618
 #, c-format
 msgid "unnamed%d"
 msgstr "sin nombre%d"
 
-#: ../src/common/zipstrm.cpp:1999 ../src/common/zipstrm.cpp:2319
+#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
 msgid "unsupported Zip compression method"
 msgstr "metodo de compresión de Zip no suportau"
 
-#: ../src/common/translation.cpp:1892
+#: ../src/common/translation.cpp:1942
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "usando lo catalogo '%s' de '%s'."
 
-#: ../src/html/chm.cpp:335
+#: ../src/html/chm.cpp:332
 msgid "write error"
 msgstr "s'ha produciu una error d'escritura"
 
-#: ../src/common/time.cpp:292
+#: ../src/gtk/glcanvas.cpp:187
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/common/time.cpp:285
 msgid "wxGetTimeOfDay failed."
 msgstr "Ha fallau o wxGetTimeOfDay."
 
@@ -8985,15 +9254,15 @@ msgstr "o wxWidgets no ha puesto ubrir o 'display' ta '%s': Se'n ye salindo."
 msgid "wxWidgets could not open display. Exiting."
 msgstr "Os wxWidgets no ha puesto ubrir o 'display'. Se'n ye salindo."
 
-#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:431
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/common/datetimefmt.cpp:1759
+#: ../src/common/datetimefmt.cpp:1782
 msgid "yesterday"
 msgstr "ahiere"
 
-#: ../src/common/zstream.cpp:251 ../src/common/zstream.cpp:426
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
 #, c-format
 msgid "zlib error %d"
 msgstr "s'ha produciu a error de zlib %d"
@@ -9002,6 +9271,77 @@ msgstr "s'ha produciu a error de zlib %d"
 #: ../src/richtext/richtextbulletspage.cpp:288
 msgid "~"
 msgstr "~"
+
+#~ msgid "&Save as"
+#~ msgstr "&Alzar como"
+
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' no consiste nomás de caracters validos"
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' ha d'estar numerico."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' debe contener nomás caracters ASCII."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' debe contener nomás caracters alfabeticos."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' ha de contener nomás caracters alfanumericos."
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' debe contener nomás numeros."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "No se puet creyar a finestra de clase %s"
+
+#, fuzzy
+#~ msgid "Could not initalize libnotify."
+#~ msgstr "No s'ha puesto establir l'aliniación."
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "No s'ha puesto creyar a finestra de superposición"
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr ""
+#~ "No s'ha puesto inicializar o contexto en a finestra de superposición"
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "S'ha produciu una error en convertir o fichero \"%s\" ta Unicode."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "No s'ha puesto colocar texto en o control de texto."
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr "Opción GTK+ de linia de comandos invalida, Fe servir \"%s --help\""
+
+#~ msgid "No unused colour in image."
+#~ msgstr "No bi ha garra color sin usar en a imachen."
+
+#~ msgid "Not available"
+#~ msgstr "No disponible"
+
+#~ msgid "Replace selection"
+#~ msgstr "Substituir a selección"
+
+#~ msgid "Save as"
+#~ msgstr "Alzar como"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Organizador d'Estilos"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "As siguients opcions GTK+ estandar tamién son suportadas:\n"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "No puetz sacar una superposición que no ye estada inicializada"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "No puetz Inicializar una superposición dos vegadas"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "no s'ha puesto establir a localización '%s'."
 
 #~ msgid "Adding flavor TEXT failed"
 #~ msgstr "S'ha produciu una error en adhibir a decoración de texto"
@@ -9022,9 +9362,6 @@ msgstr "~"
 
 #~ msgid "Column could not be added."
 #~ msgstr "No s'ha puesto adhibir a columna."
-
-#~ msgid "Column description could not be initialized."
-#~ msgstr "No s'ha puesto inicializar a descripción de columna."
 
 #~ msgid "Column index not found."
 #~ msgstr "No s'ha trobau l'indiz d'a columna."

--- a/locale/ar.po
+++ b/locale/ar.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-21 14:25+0200\n"
+"POT-Creation-Date: 2020-10-18 23:11+0300\n"
 "PO-Revision-Date: 2012-03-22 18:41+0200\n"
 "Last-Translator: Fatma Mehanna <fatma.mehanna@gmail.com>\n"
 "Language-Team: arabictranslationteam@googlegroups.com\n"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n>99)?1:(n > 2 && n < 11)?2:0;\n"
 
 # PluralForms -> Arabeyes (Final classical plural form)
-#: ../src/common/debugrpt.cpp:586
+#: ../src/common/debugrpt.cpp:587
 msgid ""
 "\n"
 "Please send this report to the program maintainer, thank you!\n"
@@ -27,8 +27,8 @@ msgstr ""
 "\n"
 "من فضلك إرسل هذا التقرير للمسؤل عن صيانة البرنامج، شكرا\n"
 
-#: ../src/richtext/richtextstyledlg.cpp:210
-#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:206
+#: ../src/richtext/richtextstyledlg.cpp:218
 msgid " "
 msgstr ""
 
@@ -36,70 +36,96 @@ msgstr ""
 msgid "              Thank you and we're sorry for the inconvenience!\n"
 msgstr "نعتذر عن الإزعاج غير المقصود ، شكرا              \n"
 
-#: ../src/common/prntbase.cpp:573
+#: ../src/common/prntbase.cpp:568
 #, c-format
 msgid " (copy %d of %d)"
 msgstr ""
 
-#: ../src/common/log.cpp:421
+#: ../src/common/log.cpp:440
 #, c-format
 msgid " (error %ld: %s)"
 msgstr "(خطأ %ld: %s)"
 
-#: ../src/common/imagtiff.cpp:72
+#: ../src/common/imagtiff.cpp:69
 #, c-format
 msgid " (in module \"%s\")"
 msgstr ""
 
-#: ../src/osx/core/secretstore.cpp:138
-msgid " (while overwriting an existing item)"
-msgstr ""
-
-#: ../src/common/docview.cpp:1642
+#: ../src/common/docview.cpp:1636
 msgid " - "
 msgstr " - "
 
-#: ../src/richtext/richtextprint.cpp:593 ../src/html/htmprint.cpp:714
+#: ../src/html/htmprint.cpp:712 ../src/richtext/richtextprint.cpp:589
 msgid " Preview"
 msgstr "معاينة"
 
-#: ../src/common/fontcmn.cpp:824
+#: ../src/common/fontcmn.cpp:973
 msgid " bold"
 msgstr "عريض"
 
-#: ../src/common/fontcmn.cpp:840
+#: ../src/common/fontcmn.cpp:977
+#, fuzzy
+msgid " extra bold"
+msgstr "عريض"
+
+#: ../src/common/fontcmn.cpp:985
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:957
+#, fuzzy
+msgid " extra light"
+msgstr "فاتح"
+
+#: ../src/common/fontcmn.cpp:981
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1001
 msgid " italic"
 msgstr "مائل"
 
-#: ../src/common/fontcmn.cpp:820
+#: ../src/common/fontcmn.cpp:961
 msgid " light"
 msgstr "فاتح"
 
-#: ../src/common/fontcmn.cpp:807
+#: ../src/common/fontcmn.cpp:965
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:969
+#, fuzzy
+msgid " semi bold"
+msgstr "عريض"
+
+#: ../src/common/fontcmn.cpp:940
 msgid " strikethrough"
 msgstr " يتوسطه خط"
 
-#: ../src/common/paper.cpp:117
+#: ../src/common/fontcmn.cpp:953
+msgid " thin"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
 msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
 msgstr "#10 Envelope, 4 1/8 x 9 1/2 in"
 
-#: ../src/common/paper.cpp:118
+#: ../src/common/paper.cpp:115
 msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
 msgstr "#11 Envelope, 4 1/2 x 10 3/8 in"
 
-#: ../src/common/paper.cpp:119
+#: ../src/common/paper.cpp:116
 msgid "#12 Envelope, 4 3/4 x 11 in"
 msgstr "#12 Envelope, 4 3/4 x 11 in"
 
-#: ../src/common/paper.cpp:120
+#: ../src/common/paper.cpp:117
 msgid "#14 Envelope, 5 x 11 1/2 in"
 msgstr "#14 Envelope, 5 x 11 1/2 in"
 
-#: ../src/common/paper.cpp:116
+#: ../src/common/paper.cpp:113
 msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
 msgstr "#9 Envelope, 3 7/8 x 8 7/8 in"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:341
 #: ../src/richtext/richtextsizepage.cpp:340
 #: ../src/richtext/richtextsizepage.cpp:374
 #: ../src/richtext/richtextsizepage.cpp:401
@@ -110,20 +136,21 @@ msgstr "#9 Envelope, 3 7/8 x 8 7/8 in"
 #: ../src/richtext/richtextsizepage.cpp:591
 #: ../src/richtext/richtextsizepage.cpp:626
 #: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextbackgroundpage.cpp:341
 msgid "%"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1031
+#: ../src/html/helpwnd.cpp:1029
 #, fuzzy, c-format
 msgid "%d of %lu"
 msgstr "%i من %i"
 
-#: ../src/html/helpwnd.cpp:1678
+#: ../src/html/helpwnd.cpp:1676
 #, fuzzy, c-format
 msgid "%i of %u"
 msgstr "%i من %i"
 
-#: ../src/generic/filectrlg.cpp:279
+#: ../src/generic/filectrlg.cpp:275
 #, c-format
 msgid "%ld byte"
 msgid_plural "%ld bytes"
@@ -131,61 +158,61 @@ msgstr[0] "%ld byte"
 msgstr[1] "%ld bytes"
 msgstr[2] "%ld bytes"
 
-#: ../src/html/helpwnd.cpp:1033
+#: ../src/html/helpwnd.cpp:1031
 #, fuzzy, c-format
 msgid "%lu of %lu"
 msgstr "%i من %i"
 
-#: ../src/generic/datavgen.cpp:6028
+#: ../src/generic/datavgen.cpp:6833
 #, fuzzy, c-format
 msgid "%s (%d items)"
 msgstr "%s (أو %s)"
 
-#: ../src/common/cmdline.cpp:1221
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (أو %s)"
 
-#: ../src/generic/logg.cpp:224
+#: ../src/generic/logg.cpp:221
 #, c-format
 msgid "%s Error"
 msgstr "%s خطأ"
 
-#: ../src/generic/logg.cpp:236
+#: ../src/generic/logg.cpp:233
 #, c-format
 msgid "%s Information"
 msgstr "%s معلومات"
 
-#: ../src/generic/preferencesg.cpp:113
+#: ../src/generic/preferencesg.cpp:110
 #, fuzzy, c-format
 msgid "%s Preferences"
 msgstr "&التفضيلات"
 
-#: ../src/generic/logg.cpp:228
+#: ../src/generic/logg.cpp:225
 #, c-format
 msgid "%s Warning"
 msgstr "%s تحذير"
 
-#: ../src/common/tarstrm.cpp:1319
+#: ../src/common/tarstrm.cpp:1313
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s did not fit the tar header for entry '%s'"
 
-#: ../src/common/fldlgcmn.cpp:124
+#: ../src/common/fldlgcmn.cpp:121
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s ملفات(%s)|%s"
 
-#: ../src/html/helpwnd.cpp:1716
+#: ../src/html/helpwnd.cpp:1714
 #, fuzzy, c-format
 msgid "%u of %u"
 msgstr "%i من %i"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "&About"
 msgstr "&عن"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "&Actual Size"
 msgstr "&المقاس الحقيقي"
 
@@ -193,28 +220,28 @@ msgstr "&المقاس الحقيقي"
 msgid "&After a paragraph:"
 msgstr "&بعد فقرة:"
 
-#: ../src/richtext/richtextindentspage.cpp:128
 #: ../src/richtext/richtextliststylepage.cpp:319
+#: ../src/richtext/richtextindentspage.cpp:128
 msgid "&Alignment"
 msgstr "&محاذاة"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "&Apply"
 msgstr "&تطبيق"
 
-#: ../src/richtext/richtextstyledlg.cpp:251
+#: ../src/richtext/richtextstyledlg.cpp:247
 msgid "&Apply Style"
 msgstr "&تطبيق نمط"
 
-#: ../src/msw/mdi.cpp:179
+#: ../src/msw/mdi.cpp:174
 msgid "&Arrange Icons"
 msgstr "&ترتيب الأيقونات"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "&Ascending"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:142
+#: ../src/common/stockitem.cpp:139
 msgid "&Back"
 msgstr "&رجوع"
 
@@ -235,24 +262,24 @@ msgstr "&لون:"
 msgid "&Blur distance:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:143
+#: ../src/common/stockitem.cpp:140
 msgid "&Bold"
 msgstr "&عريض:"
 
-#: ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141
 msgid "&Bottom"
 msgstr ""
 
+#: ../src/richtext/richtextsizepage.cpp:637
+#: ../src/richtext/richtextsizepage.cpp:644
 #: ../src/richtext/richtextborderspage.cpp:345
 #: ../src/richtext/richtextborderspage.cpp:513
 #: ../src/richtext/richtextmarginspage.cpp:259
 #: ../src/richtext/richtextmarginspage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:637
-#: ../src/richtext/richtextsizepage.cpp:644
 msgid "&Bottom:"
 msgstr ""
 
-#: ../include/wx/richtext/richtextbuffer.h:3866
+#: ../include/wx/richtext/richtextbuffer.h:3861
 #, fuzzy
 msgid "&Box"
 msgstr "&عريض:"
@@ -262,39 +289,39 @@ msgstr "&عريض:"
 msgid "&Bullet style:"
 msgstr "&نمط نقاط النص"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "&CD-Rom"
 msgstr ""
 
-#: ../src/generic/wizard.cpp:434 ../src/generic/fontdlgg.cpp:470
-#: ../src/generic/fontdlgg.cpp:489 ../src/osx/carbon/fontdlg.cpp:402
-#: ../src/common/dlgcmn.cpp:279 ../src/common/stockitem.cpp:145
+#: ../src/osx/carbon/fontdlg.cpp:399 ../src/common/stockitem.cpp:142
+#: ../src/generic/wizard.cpp:433 ../src/generic/fontdlgg.cpp:466
+#: ../src/generic/fontdlgg.cpp:485 ../src/osx/cocoa/button.mm:200
 msgid "&Cancel"
 msgstr "&إلغاء"
 
-#: ../src/msw/mdi.cpp:175
+#: ../src/msw/mdi.cpp:170
 msgid "&Cascade"
 msgstr "&متتالي"
 
-#: ../include/wx/richtext/richtextbuffer.h:5960
+#: ../include/wx/richtext/richtextbuffer.h:5955
 #, fuzzy
 msgid "&Cell"
 msgstr "&إلغاء"
 
-#: ../src/richtext/richtextsymboldlg.cpp:439
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "&Character code:"
 msgstr "&ترميز الحرف"
 
-#: ../src/common/stockitem.cpp:147
+#: ../src/common/stockitem.cpp:144
 msgid "&Clear"
 msgstr "&واضح"
 
-#: ../src/generic/logg.cpp:516 ../src/common/stockitem.cpp:148
-#: ../src/common/prntbase.cpp:1600 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/stockitem.cpp:145 ../src/common/prntbase.cpp:1625
+#: ../src/univ/themes/win32.cpp:3753 ../src/generic/logg.cpp:513
 msgid "&Close"
 msgstr "&إغلاق"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 #, fuzzy
 msgid "&Color"
 msgstr "&لون:"
@@ -303,21 +330,21 @@ msgstr "&لون:"
 msgid "&Colour:"
 msgstr "&لون:"
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 #, fuzzy
 msgid "&Convert"
 msgstr "محتويات"
 
-#: ../src/richtext/richtextctrl.cpp:333 ../src/osx/textctrl_osx.cpp:577
-#: ../src/common/stockitem.cpp:150 ../src/msw/textctrl.cpp:2508
+#: ../src/osx/textctrl_osx.cpp:595 ../src/common/stockitem.cpp:147
+#: ../src/msw/textctrl.cpp:2773 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&نسخ"
 
-#: ../src/generic/hyperlinkg.cpp:156
+#: ../src/generic/hyperlinkg.cpp:153
 msgid "&Copy URL"
 msgstr "&نسخ URL"
 
-#: ../src/common/headerctrlcmn.cpp:306
+#: ../src/common/headerctrlcmn.cpp:304
 msgid "&Customize..."
 msgstr ""
 
@@ -325,53 +352,54 @@ msgstr ""
 msgid "&Debug report preview:"
 msgstr "&تقرير معاينة الخطأ البرمجي:"
 
-#: ../src/richtext/richtexttabspage.cpp:138
-#: ../src/richtext/richtextctrl.cpp:335 ../src/osx/textctrl_osx.cpp:579
-#: ../src/common/stockitem.cpp:152 ../src/msw/textctrl.cpp:2510
+#: ../src/osx/textctrl_osx.cpp:597 ../src/common/stockitem.cpp:149
+#: ../src/msw/textctrl.cpp:2775 ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtextctrl.cpp:334
 msgid "&Delete"
 msgstr "&حذف"
 
-#: ../src/richtext/richtextstyledlg.cpp:269
+#: ../src/richtext/richtextstyledlg.cpp:265
 msgid "&Delete Style..."
 msgstr "&حذف نمط..."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "&Descending"
 msgstr ""
 
-#: ../src/generic/logg.cpp:682
+#: ../src/generic/logg.cpp:679
 msgid "&Details"
 msgstr "&تفاصيل"
 
-#: ../src/common/stockitem.cpp:153
+#: ../src/common/stockitem.cpp:150
 msgid "&Down"
 msgstr "&أسفل"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "&Edit"
 msgstr "&تحرير"
 
-#: ../src/richtext/richtextstyledlg.cpp:263
+#: ../src/richtext/richtextstyledlg.cpp:259
 msgid "&Edit Style..."
 msgstr "&تحرير نمط..."
 
-#: ../src/common/stockitem.cpp:155
+#: ../src/common/stockitem.cpp:152
 msgid "&Execute"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/common/stockitem.cpp:154
 msgid "&File"
 msgstr "&ملف"
 
-#: ../src/common/stockitem.cpp:158
-msgid "&Find"
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "&Find..."
 msgstr "&بحث"
 
-#: ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:430
 msgid "&Finish"
 msgstr "&إنهاء"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:156
 #, fuzzy
 msgid "&First"
 msgstr "&إنهاء"
@@ -380,17 +408,17 @@ msgstr "&إنهاء"
 msgid "&Floating mode:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 #, fuzzy
 msgid "&Floppy"
 msgstr "&نسخ"
 
-#: ../src/common/stockitem.cpp:194
+#: ../src/common/stockitem.cpp:191
 #, fuzzy
 msgid "&Font"
 msgstr "&خط"
 
-#: ../src/generic/fontdlgg.cpp:371
+#: ../src/generic/fontdlgg.cpp:367
 msgid "&Font family:"
 msgstr "&عائلة خط:"
 
@@ -398,20 +426,20 @@ msgstr "&عائلة خط:"
 msgid "&Font for Level..."
 msgstr "&خط للمستوى..."
 
+#: ../src/richtext/richtextsymboldlg.cpp:397
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:400
 msgid "&Font:"
 msgstr "&خط"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "&Forward"
 msgstr "&تقديم"
 
-#: ../src/richtext/richtextsymboldlg.cpp:451
+#: ../src/richtext/richtextsymboldlg.cpp:448
 msgid "&From:"
 msgstr "&من:"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "&Harddisk"
 msgstr ""
 
@@ -421,9 +449,9 @@ msgstr ""
 msgid "&Height:"
 msgstr "&يمين:"
 
-#: ../src/generic/wizard.cpp:441 ../src/richtext/richtextstyledlg.cpp:303
-#: ../src/richtext/richtextsymboldlg.cpp:479 ../src/osx/menu_osx.cpp:734
-#: ../src/common/stockitem.cpp:163
+#: ../src/common/stockitem.cpp:160 ../src/generic/wizard.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextstyledlg.cpp:299 ../src/osx/cocoa/menu.mm:226
 msgid "&Help"
 msgstr "&مساعدة"
 
@@ -432,7 +460,7 @@ msgstr "&مساعدة"
 msgid "&Hide details"
 msgstr "&تفاصيل"
 
-#: ../src/common/stockitem.cpp:164
+#: ../src/common/stockitem.cpp:161
 msgid "&Home"
 msgstr "&رئيسة"
 
@@ -440,55 +468,55 @@ msgstr "&رئيسة"
 msgid "&Horizontal offset:"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:184
 #: ../src/richtext/richtextliststylepage.cpp:372
+#: ../src/richtext/richtextindentspage.cpp:184
 msgid "&Indentation (tenths of a mm)"
 msgstr "&فراغ أول الفقرة(يقاس بعُشر المم)"
 
-#: ../src/richtext/richtextindentspage.cpp:167
 #: ../src/richtext/richtextliststylepage.cpp:356
+#: ../src/richtext/richtextindentspage.cpp:167
 msgid "&Indeterminate"
 msgstr "&غير محدد"
 
-#: ../src/common/stockitem.cpp:166
+#: ../src/common/stockitem.cpp:163
 msgid "&Index"
 msgstr "&كشاف"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "&Info"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:168
+#: ../src/common/stockitem.cpp:165
 msgid "&Italic"
 msgstr "&مائل"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "&Jump to"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:153
 #: ../src/richtext/richtextliststylepage.cpp:342
+#: ../src/richtext/richtextindentspage.cpp:153
 msgid "&Justified"
 msgstr "&مساوي"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 #, fuzzy
 msgid "&Last"
 msgstr "&لصق"
 
-#: ../src/richtext/richtextindentspage.cpp:139
 #: ../src/richtext/richtextliststylepage.cpp:328
+#: ../src/richtext/richtextindentspage.cpp:139
 msgid "&Left"
 msgstr "&سيار"
 
-#: ../src/richtext/richtextindentspage.cpp:195
+#: ../src/richtext/richtextsizepage.cpp:532
+#: ../src/richtext/richtextsizepage.cpp:539
 #: ../src/richtext/richtextborderspage.cpp:243
 #: ../src/richtext/richtextborderspage.cpp:411
 #: ../src/richtext/richtextliststylepage.cpp:381
+#: ../src/richtext/richtextindentspage.cpp:195
 #: ../src/richtext/richtextmarginspage.cpp:186
 #: ../src/richtext/richtextmarginspage.cpp:300
-#: ../src/richtext/richtextsizepage.cpp:532
-#: ../src/richtext/richtextsizepage.cpp:539
 msgid "&Left:"
 msgstr "&يسار:"
 
@@ -496,11 +524,11 @@ msgstr "&يسار:"
 msgid "&List level:"
 msgstr "&قائمة المستوى:"
 
-#: ../src/generic/logg.cpp:517
+#: ../src/generic/logg.cpp:514
 msgid "&Log"
 msgstr "&تقرير"
 
-#: ../src/univ/themes/win32.cpp:3748
+#: ../src/univ/themes/win32.cpp:3745
 msgid "&Move"
 msgstr "&تحريك"
 
@@ -508,21 +536,20 @@ msgstr "&تحريك"
 msgid "&Move the object to:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 #, fuzzy
 msgid "&Network"
 msgstr "&جديد"
 
-#: ../src/richtext/richtexttabspage.cpp:132 ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173 ../src/richtext/richtexttabspage.cpp:132
 msgid "&New"
 msgstr "&جديد"
 
-#: ../src/aui/tabmdi.cpp:111 ../src/generic/mdig.cpp:100
-#: ../src/msw/mdi.cpp:180
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
 msgid "&Next"
 msgstr "&التالي"
 
-#: ../src/generic/wizard.cpp:432 ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:429
 msgid "&Next >"
 msgstr "&التالي<"
 
@@ -531,7 +558,7 @@ msgstr "&التالي<"
 msgid "&Next Paragraph"
 msgstr "&بعد فقرة:"
 
-#: ../src/generic/tipdlg.cpp:240
+#: ../src/generic/tipdlg.cpp:237
 msgid "&Next Tip"
 msgstr "&النصيحة التالية"
 
@@ -539,11 +566,11 @@ msgstr "&النصيحة التالية"
 msgid "&Next style:"
 msgstr "&النمط التالي:"
 
-#: ../src/common/stockitem.cpp:177 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:174 ../src/msw/msgdlg.cpp:435
 msgid "&No"
 msgstr "&لا"
 
-#: ../src/generic/dbgrptg.cpp:356
+#: ../src/generic/dbgrptg.cpp:360
 msgid "&Notes:"
 msgstr "&ملحوظات:"
 
@@ -551,12 +578,12 @@ msgstr "&ملحوظات:"
 msgid "&Number:"
 msgstr "&رقم:"
 
-#: ../src/generic/fontdlgg.cpp:475 ../src/generic/fontdlgg.cpp:482
-#: ../src/osx/carbon/fontdlg.cpp:408 ../src/common/stockitem.cpp:178
+#: ../src/osx/carbon/fontdlg.cpp:405 ../src/common/stockitem.cpp:175
+#: ../src/generic/fontdlgg.cpp:471 ../src/generic/fontdlgg.cpp:478
 msgid "&OK"
 msgstr "&موافق"
 
-#: ../src/generic/dbgrptg.cpp:342 ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176 ../src/generic/dbgrptg.cpp:342
 msgid "&Open..."
 msgstr "&فتح..."
 
@@ -568,16 +595,16 @@ msgstr "&مستوى التخطيط:"
 msgid "&Page Break"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:334 ../src/osx/textctrl_osx.cpp:578
-#: ../src/common/stockitem.cpp:180 ../src/msw/textctrl.cpp:2509
+#: ../src/osx/textctrl_osx.cpp:596 ../src/common/stockitem.cpp:177
+#: ../src/msw/textctrl.cpp:2774 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&لصق"
 
-#: ../include/wx/richtext/richtextbuffer.h:5010
+#: ../include/wx/richtext/richtextbuffer.h:5005
 msgid "&Picture"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:419
 msgid "&Point size:"
 msgstr "&درجة الحجم"
 
@@ -590,12 +617,11 @@ msgstr "&وضع(أعشار المليمترات):"
 msgid "&Position mode:"
 msgstr "سؤال"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178
 msgid "&Preferences"
 msgstr "&التفضيلات"
 
-#: ../src/aui/tabmdi.cpp:112 ../src/generic/mdig.cpp:101
-#: ../src/msw/mdi.cpp:181
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
 msgid "&Previous"
 msgstr "&سابق"
 
@@ -604,80 +630,75 @@ msgstr "&سابق"
 msgid "&Previous Paragraph"
 msgstr "&سابق"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "&Print..."
 msgstr "&طباعة..."
 
-#: ../src/richtext/richtextctrl.cpp:339 ../src/richtext/richtextctrl.cpp:5514
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtextctrl.cpp:338
+#: ../src/richtext/richtextctrl.cpp:5512
 msgid "&Properties"
 msgstr "&الخصائص"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "&Quit"
 msgstr "&إنهاء"
 
-#: ../src/richtext/richtextctrl.cpp:330 ../src/osx/textctrl_osx.cpp:574
-#: ../src/common/stockitem.cpp:185 ../src/common/cmdproc.cpp:293
-#: ../src/common/cmdproc.cpp:300 ../src/msw/textctrl.cpp:2505
+#: ../src/osx/textctrl_osx.cpp:592 ../src/common/stockitem.cpp:182
+#: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
+#: ../src/msw/textctrl.cpp:2770 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&تكرار الفعل"
 
-#: ../src/common/cmdproc.cpp:289 ../src/common/cmdproc.cpp:309
+#: ../src/common/cmdproc.cpp:282 ../src/common/cmdproc.cpp:302
 msgid "&Redo "
 msgstr "&تكرار الفعل"
 
-#: ../src/richtext/richtextstyledlg.cpp:257
+#: ../src/richtext/richtextstyledlg.cpp:253
 msgid "&Rename Style..."
 msgstr "&إعادة تسمية نمط..."
 
-#: ../src/generic/fdrepdlg.cpp:179
+#: ../src/generic/fdrepdlg.cpp:176
 msgid "&Replace"
 msgstr "&إستبدال"
 
-#: ../src/richtext/richtextstyledlg.cpp:287
+#: ../src/richtext/richtextstyledlg.cpp:283
 msgid "&Restart numbering"
 msgstr "إعادة الترقيم"
 
-#: ../src/univ/themes/win32.cpp:3747
+#: ../src/univ/themes/win32.cpp:3744
 msgid "&Restore"
 msgstr "&استرجاع"
 
-#: ../src/richtext/richtextindentspage.cpp:146
 #: ../src/richtext/richtextliststylepage.cpp:335
+#: ../src/richtext/richtextindentspage.cpp:146
 msgid "&Right"
 msgstr "&يمين"
 
-#: ../src/richtext/richtextindentspage.cpp:213
+#: ../src/richtext/richtextsizepage.cpp:602
+#: ../src/richtext/richtextsizepage.cpp:609
 #: ../src/richtext/richtextborderspage.cpp:277
 #: ../src/richtext/richtextborderspage.cpp:445
 #: ../src/richtext/richtextliststylepage.cpp:399
+#: ../src/richtext/richtextindentspage.cpp:213
 #: ../src/richtext/richtextmarginspage.cpp:211
 #: ../src/richtext/richtextmarginspage.cpp:325
-#: ../src/richtext/richtextsizepage.cpp:602
-#: ../src/richtext/richtextsizepage.cpp:609
 msgid "&Right:"
 msgstr "&يمين:"
 
-#: ../src/common/stockitem.cpp:190
+#: ../src/common/stockitem.cpp:187
 msgid "&Save"
 msgstr "&حفظ"
-
-#: ../src/common/stockitem.cpp:191
-#, fuzzy
-msgid "&Save as"
-msgstr "حفظ بإسم"
 
 #: ../include/wx/richmsgdlg.h:29
 #, fuzzy
 msgid "&See details"
 msgstr "&تفاصيل"
 
-#: ../src/generic/tipdlg.cpp:236
+#: ../src/generic/tipdlg.cpp:233
 msgid "&Show tips at startup"
 msgstr "إ&ظهار التنبيهات عند بدأ التشغيل"
 
-#: ../src/univ/themes/win32.cpp:3750
+#: ../src/univ/themes/win32.cpp:3747
 msgid "&Size"
 msgstr "&حجم"
 
@@ -685,36 +706,36 @@ msgstr "&حجم"
 msgid "&Size:"
 msgstr "&حجم:"
 
-#: ../src/generic/progdlgg.cpp:252
+#: ../src/generic/progdlgg.cpp:249
 msgid "&Skip"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:242
 #: ../src/richtext/richtextliststylepage.cpp:417
+#: ../src/richtext/richtextindentspage.cpp:242
 msgid "&Spacing (tenths of a mm)"
 msgstr "إ&زاحة (أعشار المليمتر)"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "&Spell Check"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "&Stop"
 msgstr "&إيقاف"
 
-#: ../src/richtext/richtextfontpage.cpp:275 ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196 ../src/richtext/richtextfontpage.cpp:275
 msgid "&Strikethrough"
 msgstr "&يتوسطه خط"
 
-#: ../src/generic/fontdlgg.cpp:382 ../src/richtext/richtextstylepage.cpp:106
+#: ../src/generic/fontdlgg.cpp:378 ../src/richtext/richtextstylepage.cpp:106
 msgid "&Style:"
 msgstr "&نمط:"
 
-#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:194
 msgid "&Styles:"
 msgstr "&أنماط:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:413
+#: ../src/richtext/richtextsymboldlg.cpp:410
 msgid "&Subset:"
 msgstr "&فرعي:"
 
@@ -728,26 +749,26 @@ msgstr "&رمز:"
 msgid "&Synchronize values"
 msgstr ""
 
-#: ../include/wx/richtext/richtextbuffer.h:6069
+#: ../include/wx/richtext/richtextbuffer.h:6064
 msgid "&Table"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197
 #, fuzzy
 msgid "&Top"
 msgstr "&نسخ"
 
+#: ../src/richtext/richtextsizepage.cpp:567
+#: ../src/richtext/richtextsizepage.cpp:574
 #: ../src/richtext/richtextborderspage.cpp:311
 #: ../src/richtext/richtextborderspage.cpp:479
 #: ../src/richtext/richtextmarginspage.cpp:234
 #: ../src/richtext/richtextmarginspage.cpp:348
-#: ../src/richtext/richtextsizepage.cpp:567
-#: ../src/richtext/richtextsizepage.cpp:574
 #, fuzzy
 msgid "&Top:"
 msgstr "&نسخ"
 
-#: ../src/generic/fontdlgg.cpp:444 ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199 ../src/generic/fontdlgg.cpp:441
 msgid "&Underline"
 msgstr "&خط سفلي"
 
@@ -755,21 +776,21 @@ msgstr "&خط سفلي"
 msgid "&Underlining:"
 msgstr "&وضع خط تحته"
 
-#: ../src/richtext/richtextctrl.cpp:329 ../src/osx/textctrl_osx.cpp:573
-#: ../src/common/stockitem.cpp:203 ../src/common/cmdproc.cpp:271
-#: ../src/msw/textctrl.cpp:2504
+#: ../src/osx/textctrl_osx.cpp:591 ../src/common/stockitem.cpp:200
+#: ../src/common/cmdproc.cpp:264 ../src/msw/textctrl.cpp:2769
+#: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&تراجع"
 
-#: ../src/common/cmdproc.cpp:265
+#: ../src/common/cmdproc.cpp:258
 msgid "&Undo "
 msgstr "&تراجع"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "&Unindent"
 msgstr "&عدم إزاحة"
 
-#: ../src/common/stockitem.cpp:205
+#: ../src/common/stockitem.cpp:202
 msgid "&Up"
 msgstr "أ&على"
 
@@ -788,7 +809,7 @@ msgstr "&محاذاة"
 msgid "&View..."
 msgstr "&فتح..."
 
-#: ../src/generic/fontdlgg.cpp:393
+#: ../src/generic/fontdlgg.cpp:389
 msgid "&Weight:"
 msgstr "&وزن:"
 
@@ -797,88 +818,58 @@ msgstr "&وزن:"
 msgid "&Width:"
 msgstr ""
 
-#: ../src/aui/tabmdi.cpp:311 ../src/aui/tabmdi.cpp:327
-#: ../src/aui/tabmdi.cpp:329 ../src/generic/mdig.cpp:294
-#: ../src/generic/mdig.cpp:310 ../src/generic/mdig.cpp:314
-#: ../src/msw/mdi.cpp:78
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
 msgid "&Window"
 msgstr "&نافذة"
 
-#: ../src/common/stockitem.cpp:206 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:203 ../src/msw/msgdlg.cpp:435
 msgid "&Yes"
 msgstr "&نعم"
 
-#: ../src/common/valtext.cpp:256
+#: ../src/common/valtext.cpp:197
 #, fuzzy, c-format
-msgid "'%s' contains illegal characters"
+msgid "'%s' contains invalid character(s)"
 msgstr "'%s' ينبغي أن يحتوي على أحرف أبجدية."
 
-#: ../src/common/valtext.cpp:254
-#, fuzzy, c-format
-msgid "'%s' doesn't consist only of valid characters"
-msgstr "'%s' ينبغي أن يحتوي على أحرف أبجدية."
-
-#: ../src/common/config.cpp:519 ../src/msw/regconf.cpp:258
+#: ../src/common/config.cpp:515 ../src/msw/regconf.cpp:255
 #, c-format
 msgid "'%s' has extra '..', ignored."
 msgstr "'%s' به مزيد'..', تم تجاهله."
 
-#: ../src/common/cmdline.cpp:1113 ../src/common/cmdline.cpp:1131
+#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' ليس قيمة رقمية صحيحة للخيار'%s'."
 
-#: ../src/common/translation.cpp:1100
+#: ../src/common/translation.cpp:1142
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' ليست رسالة صحيحة بالفهرس."
 
-#: ../src/common/valtext.cpp:165
+#: ../src/common/valtext.cpp:188
 #, fuzzy, c-format
 msgid "'%s' is not one of the valid strings"
 msgstr "'%s' ليست رسالة صحيحة بالفهرس."
 
-#: ../src/common/valtext.cpp:167
+#: ../src/common/valtext.cpp:186
 #, fuzzy, c-format
 msgid "'%s' is one of the invalid strings"
 msgstr "'%s' خطأ"
 
-#: ../src/common/textbuf.cpp:237
+#: ../src/common/textbuf.cpp:233
 #, c-format
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' من المحتمل أن تكون ذاكرة ثنائية."
-
-#: ../src/common/valtext.cpp:252
-#, c-format
-msgid "'%s' should be numeric."
-msgstr "'%s' ينبغي أن يكون رقمي."
-
-#: ../src/common/valtext.cpp:244
-#, c-format
-msgid "'%s' should only contain ASCII characters."
-msgstr "'%s' ينبغي أن يحتوي على أحرف لها مكافئ رقمي."
-
-#: ../src/common/valtext.cpp:246
-#, c-format
-msgid "'%s' should only contain alphabetic characters."
-msgstr "'%s' ينبغي أن يحتوي على أحرف أبجدية."
-
-#: ../src/common/valtext.cpp:248
-#, c-format
-msgid "'%s' should only contain alphabetic or numeric characters."
-msgstr "'%s' ينبغي أن يحتوي على أحرف أبجدية أو رقمية."
-
-#: ../src/common/valtext.cpp:250
-#, fuzzy, c-format
-msgid "'%s' should only contain digits."
-msgstr "'%s' ينبغي أن يحتوي على أحرف لها مكافئ رقمي."
 
 #: ../src/richtext/richtextliststylepage.cpp:229
 #: ../src/richtext/richtextbulletspage.cpp:166
 msgid "(*)"
 msgstr "(*)"
 
-#: ../src/html/helpwnd.cpp:963
+#: ../src/html/helpwnd.cpp:961
 msgid "(Help)"
 msgstr "(مساعدة)"
 
@@ -887,27 +878,32 @@ msgstr "(مساعدة)"
 msgid "(None)"
 msgstr "(لاشئ)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:504
+#: ../src/richtext/richtextsymboldlg.cpp:503
 msgid "(Normal text)"
 msgstr "(نص عادي)"
 
-#: ../src/html/helpwnd.cpp:419 ../src/html/helpwnd.cpp:1106
-#: ../src/html/helpwnd.cpp:1742
+#: ../src/html/helpwnd.cpp:417 ../src/html/helpwnd.cpp:1104
+#: ../src/html/helpwnd.cpp:1740
 msgid "(bookmarks)"
 msgstr "(إشارات مرجعية)"
 
+#: ../src/msw/dlmsw.cpp:167
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr "(خطأ %ld: %s)"
+
+#: ../src/richtext/richtextformatdlg.cpp:876
+#: ../src/richtext/richtextliststylepage.cpp:448
+#: ../src/richtext/richtextliststylepage.cpp:460
+#: ../src/richtext/richtextliststylepage.cpp:461
 #: ../src/richtext/richtextindentspage.cpp:274
 #: ../src/richtext/richtextindentspage.cpp:286
 #: ../src/richtext/richtextindentspage.cpp:287
 #: ../src/richtext/richtextindentspage.cpp:311
 #: ../src/richtext/richtextindentspage.cpp:326
-#: ../src/richtext/richtextformatdlg.cpp:884
 #: ../src/richtext/richtextfontpage.cpp:349
 #: ../src/richtext/richtextfontpage.cpp:353
 #: ../src/richtext/richtextfontpage.cpp:357
-#: ../src/richtext/richtextliststylepage.cpp:448
-#: ../src/richtext/richtextliststylepage.cpp:460
-#: ../src/richtext/richtextliststylepage.cpp:461
 msgid "(none)"
 msgstr "(لاشئ)"
 
@@ -926,7 +922,7 @@ msgstr "*)"
 msgid "+"
 msgstr "+"
 
-#: ../src/msw/utils.cpp:1152
+#: ../src/msw/utils.cpp:1143
 msgid ", 64-bit edition"
 msgstr ""
 
@@ -935,172 +931,172 @@ msgstr ""
 msgid "-"
 msgstr "-"
 
-#: ../src/generic/filepickerg.cpp:66
+#: ../src/generic/filepickerg.cpp:63
 #, fuzzy
 msgid "..."
 msgstr "&فتح..."
 
-#: ../src/richtext/richtextindentspage.cpp:276
 #: ../src/richtext/richtextliststylepage.cpp:450
+#: ../src/richtext/richtextindentspage.cpp:276
 #, fuzzy
 msgid "1.1"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:277
 #: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextindentspage.cpp:277
 #, fuzzy
 msgid "1.2"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:278
 #: ../src/richtext/richtextliststylepage.cpp:452
+#: ../src/richtext/richtextindentspage.cpp:278
 #, fuzzy
 msgid "1.3"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:279
 #: ../src/richtext/richtextliststylepage.cpp:453
+#: ../src/richtext/richtextindentspage.cpp:279
 #, fuzzy
 msgid "1.4"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:280
 #: ../src/richtext/richtextliststylepage.cpp:454
+#: ../src/richtext/richtextindentspage.cpp:280
 msgid "1.5"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:281
 #: ../src/richtext/richtextliststylepage.cpp:455
+#: ../src/richtext/richtextindentspage.cpp:281
 #, fuzzy
 msgid "1.6"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:282
 #: ../src/richtext/richtextliststylepage.cpp:456
+#: ../src/richtext/richtextindentspage.cpp:282
 #, fuzzy
 msgid "1.7"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:283
 #: ../src/richtext/richtextliststylepage.cpp:457
+#: ../src/richtext/richtextindentspage.cpp:283
 #, fuzzy
 msgid "1.8"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:284
 #: ../src/richtext/richtextliststylepage.cpp:458
+#: ../src/richtext/richtextindentspage.cpp:284
 #, fuzzy
 msgid "1.9"
 msgstr "1.5"
 
-#: ../src/common/paper.cpp:140
+#: ../src/common/paper.cpp:137
 msgid "10 x 11 in"
 msgstr "10 x 11 in"
 
-#: ../src/common/paper.cpp:113
+#: ../src/common/paper.cpp:110
 msgid "10 x 14 in"
 msgstr "10 x 14 in"
 
-#: ../src/common/paper.cpp:114
+#: ../src/common/paper.cpp:111
 msgid "11 x 17 in"
 msgstr "11 x 17 in"
 
-#: ../src/common/paper.cpp:184
+#: ../src/common/paper.cpp:181
 msgid "12 x 11 in"
 msgstr "12 x 11 in"
 
-#: ../src/common/paper.cpp:141
+#: ../src/common/paper.cpp:138
 msgid "15 x 11 in"
 msgstr "15 x 11 in"
 
-#: ../src/richtext/richtextindentspage.cpp:285
 #: ../src/richtext/richtextliststylepage.cpp:459
+#: ../src/richtext/richtextindentspage.cpp:285
 msgid "2"
 msgstr "2"
 
-#: ../src/common/paper.cpp:132
+#: ../src/common/paper.cpp:129
 msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
 msgstr "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
 
-#: ../src/common/paper.cpp:139
+#: ../src/common/paper.cpp:136
 msgid "9 x 11 in"
 msgstr "9 x 11 in"
 
-#: ../src/html/htmprint.cpp:431
+#: ../src/html/htmprint.cpp:443
 msgid ": file does not exist!"
 msgstr ": الملف غير موجود!"
 
-#: ../src/common/fontmap.cpp:199
+#: ../src/common/fontmap.cpp:196
 msgid ": unknown charset"
 msgstr ": حرف مجهول"
 
-#: ../src/common/fontmap.cpp:413
+#: ../src/common/fontmap.cpp:410
 msgid ": unknown encoding"
 msgstr ": تشفير مجهول"
 
-#: ../src/generic/wizard.cpp:443
+#: ../src/generic/wizard.cpp:438
 msgid "< &Back"
 msgstr "< &Back"
 
-#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:628
-#: ../src/osx/carbon/fontdlg.cpp:648
+#: ../src/osx/carbon/fontdlg.cpp:419 ../src/osx/carbon/fontdlg.cpp:625
+#: ../src/osx/carbon/fontdlg.cpp:645
 msgid "<Any Decorative>"
 msgstr "<Any Decorative>"
 
-#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:630
-#: ../src/osx/carbon/fontdlg.cpp:650
+#: ../src/osx/carbon/fontdlg.cpp:420 ../src/osx/carbon/fontdlg.cpp:627
+#: ../src/osx/carbon/fontdlg.cpp:647
 msgid "<Any Modern>"
 msgstr "<Any Modern>"
 
-#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:626
-#: ../src/osx/carbon/fontdlg.cpp:646
+#: ../src/osx/carbon/fontdlg.cpp:418 ../src/osx/carbon/fontdlg.cpp:623
+#: ../src/osx/carbon/fontdlg.cpp:643
 msgid "<Any Roman>"
 msgstr "<Any Roman>"
 
-#: ../src/osx/carbon/fontdlg.cpp:424 ../src/osx/carbon/fontdlg.cpp:632
-#: ../src/osx/carbon/fontdlg.cpp:652
+#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:629
+#: ../src/osx/carbon/fontdlg.cpp:649
 msgid "<Any Script>"
 msgstr "<Any Script>"
 
-#: ../src/osx/carbon/fontdlg.cpp:425 ../src/osx/carbon/fontdlg.cpp:637
-#: ../src/osx/carbon/fontdlg.cpp:656
+#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:634
+#: ../src/osx/carbon/fontdlg.cpp:653
 msgid "<Any Swiss>"
 msgstr "<Any Swiss>"
 
-#: ../src/osx/carbon/fontdlg.cpp:426 ../src/osx/carbon/fontdlg.cpp:634
-#: ../src/osx/carbon/fontdlg.cpp:654
+#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:631
+#: ../src/osx/carbon/fontdlg.cpp:651
 msgid "<Any Teletype>"
 msgstr "<Any Teletype>"
 
-#: ../src/osx/carbon/fontdlg.cpp:420
+#: ../src/osx/carbon/fontdlg.cpp:417
 msgid "<Any>"
 msgstr "<Any>"
 
-#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
 msgid "<DIR>"
 msgstr "<DIR>"
 
-#: ../src/generic/filectrlg.cpp:254 ../src/generic/filectrlg.cpp:277
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
 msgid "<DRIVE>"
 msgstr "<DRIVE>"
 
-#: ../src/generic/filectrlg.cpp:252 ../src/generic/filectrlg.cpp:275
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
 msgid "<LINK>"
 msgstr "<LINK>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1264
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Bold italic face.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1270
+#: ../src/html/helpwnd.cpp:1268
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>bold italic <u>underlined</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1265
+#: ../src/html/helpwnd.cpp:1263
 msgid "<b>Bold face.</b> "
 msgstr "<b>Bold face.</b> "
 
-#: ../src/html/helpwnd.cpp:1264
+#: ../src/html/helpwnd.cpp:1262
 msgid "<i>Italic face.</i> "
 msgstr "<i>Italic face.</i> "
 
@@ -1109,15 +1105,15 @@ msgstr "<i>Italic face.</i> "
 msgid ">"
 msgstr ">"
 
-#: ../src/generic/dbgrptg.cpp:318
+#: ../src/generic/dbgrptg.cpp:317
 msgid "A debug report has been generated in the directory\n"
 msgstr "تم توليد خطأ برمجي بالمجلد\n"
 
-#: ../src/common/debugrpt.cpp:573
+#: ../src/common/debugrpt.cpp:574
 msgid "A debug report has been generated. It can be found in"
 msgstr "تم توليد خطأ برمجي. يمكن العثور عليه في"
 
-#: ../src/common/xtixml.cpp:418
+#: ../src/common/xtixml.cpp:414
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "نجمع غير فارغ يجب أن يتكون من 'عنصر' فروع"
 
@@ -1128,109 +1124,109 @@ msgstr "نجمع غير فارغ يجب أن يتكون من 'عنصر' فروع
 msgid "A standard bullet name."
 msgstr "اسم نقطي معروف."
 
-#: ../src/common/paper.cpp:217
+#: ../src/common/paper.cpp:214
 #, fuzzy
 msgid "A0 sheet, 841 x 1189 mm"
 msgstr "A4 ورقة, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:218
+#: ../src/common/paper.cpp:215
 #, fuzzy
 msgid "A1 sheet, 594 x 841 mm"
 msgstr "A3 ورقة, 297 x 420 mm"
 
-#: ../src/common/paper.cpp:159
+#: ../src/common/paper.cpp:156
 msgid "A2 420 x 594 mm"
 msgstr "A2 420 x 594 mm"
 
-#: ../src/common/paper.cpp:156
+#: ../src/common/paper.cpp:153
 msgid "A3 Extra 322 x 445 mm"
 msgstr "A3 Extra 322 x 445 mm"
 
-#: ../src/common/paper.cpp:161
+#: ../src/common/paper.cpp:158
 msgid "A3 Extra Transverse 322 x 445 mm"
 msgstr "A3 Extra مستعرض 322 x 445 mm"
 
-#: ../src/common/paper.cpp:170
+#: ../src/common/paper.cpp:167
 msgid "A3 Rotated 420 x 297 mm"
 msgstr "A3 مدور 420 x 297 mm"
 
-#: ../src/common/paper.cpp:160
+#: ../src/common/paper.cpp:157
 msgid "A3 Transverse 297 x 420 mm"
 msgstr "A3 مستعرض 297 x 420 mm"
 
-#: ../src/common/paper.cpp:106
+#: ../src/common/paper.cpp:103
 msgid "A3 sheet, 297 x 420 mm"
 msgstr "A3 ورقة, 297 x 420 mm"
 
-#: ../src/common/paper.cpp:146
+#: ../src/common/paper.cpp:143
 msgid "A4 Extra 9.27 x 12.69 in"
 msgstr "A4 Extra 9.27 x 12.69 in"
 
-#: ../src/common/paper.cpp:153
+#: ../src/common/paper.cpp:150
 msgid "A4 Plus 210 x 330 mm"
 msgstr "A4 Plus 210 x 330 mm"
 
-#: ../src/common/paper.cpp:171
+#: ../src/common/paper.cpp:168
 msgid "A4 Rotated 297 x 210 mm"
 msgstr "A4 مدور 297 x 210 mm"
 
-#: ../src/common/paper.cpp:148
+#: ../src/common/paper.cpp:145
 msgid "A4 Transverse 210 x 297 mm"
 msgstr "A4 مستعرض 210 x 297 mm"
 
-#: ../src/common/paper.cpp:97
+#: ../src/common/paper.cpp:94
 msgid "A4 sheet, 210 x 297 mm"
 msgstr "A4 ورقة, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:107
+#: ../src/common/paper.cpp:104
 msgid "A4 small sheet, 210 x 297 mm"
 msgstr "A4 ورقة صغيرة, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:157
+#: ../src/common/paper.cpp:154
 msgid "A5 Extra 174 x 235 mm"
 msgstr "A5 Extra 174 x 235 mm"
 
-#: ../src/common/paper.cpp:172
+#: ../src/common/paper.cpp:169
 msgid "A5 Rotated 210 x 148 mm"
 msgstr "A5 مدور210 x 148 mm"
 
-#: ../src/common/paper.cpp:154
+#: ../src/common/paper.cpp:151
 msgid "A5 Transverse 148 x 210 mm"
 msgstr "A5 مستعرض 148 x 210 mm"
 
-#: ../src/common/paper.cpp:108
+#: ../src/common/paper.cpp:105
 msgid "A5 sheet, 148 x 210 mm"
 msgstr "A5 ورقة, 148 x 210 mm"
 
-#: ../src/common/paper.cpp:164
+#: ../src/common/paper.cpp:161
 msgid "A6 105 x 148 mm"
 msgstr "A6 105 x 148 mm"
 
-#: ../src/common/paper.cpp:177
+#: ../src/common/paper.cpp:174
 msgid "A6 Rotated 148 x 105 mm"
 msgstr "A6 مدور 148 x 105 mm"
 
-#: ../src/generic/fontdlgg.cpp:83 ../src/richtext/richtextformatdlg.cpp:529
-#: ../src/osx/carbon/fontdlg.cpp:153
+#: ../src/osx/carbon/fontdlg.cpp:150 ../src/generic/fontdlgg.cpp:79
+#: ../src/richtext/richtextformatdlg.cpp:521
 msgid "ABCDEFGabcdefg12345"
 msgstr "ABCDEFGabcdefg12345"
 
-#: ../src/richtext/richtextsymboldlg.cpp:458 ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
 msgid "ASCII"
 msgstr "أسكي"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 #, fuzzy
 msgid "About"
 msgstr "&عن..."
 
-#: ../src/generic/aboutdlgg.cpp:140 ../src/osx/menu_osx.cpp:558
-#: ../src/msw/aboutdlg.cpp:64
+#: ../src/osx/menu_osx.cpp:450 ../src/generic/aboutdlgg.cpp:137
+#: ../src/msw/aboutdlg.cpp:61
 #, fuzzy, c-format
 msgid "About %s"
 msgstr "حول"
 
-#: ../src/osx/menu_osx.cpp:560
+#: ../src/osx/menu_osx.cpp:452
 #, fuzzy
 msgid "About..."
 msgstr "&نبذة عن..."
@@ -1240,38 +1236,38 @@ msgid "Absolute"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:873
+#: ../src/propgrid/advprops.cpp:774
 msgid "ActiveBorder"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:874
+#: ../src/propgrid/advprops.cpp:775
 msgid "ActiveCaption"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 #, fuzzy
 msgid "Actual Size"
 msgstr "&المقاس الحقيقي"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:140 ../src/common/accelcmn.cpp:81
+#: ../src/common/stockitem.cpp:137 ../src/common/accelcmn.cpp:78
 msgid "Add"
 msgstr "أضف"
 
-#: ../src/richtext/richtextbuffer.cpp:11455
+#: ../src/richtext/richtextbuffer.cpp:11454
 msgid "Add Column"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11392
+#: ../src/richtext/richtextbuffer.cpp:11391
 msgid "Add Row"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:432
+#: ../src/html/helpwnd.cpp:430
 msgid "Add current page to bookmarks"
 msgstr "أضف الصفحة الحالية لمؤشر الصفحات"
 
-#: ../src/generic/colrdlgg.cpp:366
+#: ../src/generic/colrdlgg.cpp:386
 msgid "Add to custom colours"
 msgstr "أضف للألوان المخصصة"
 
@@ -1283,12 +1279,12 @@ msgstr "AddToPropertyCollection called on a generic accessor"
 msgid "AddToPropertyCollection called w/o valid adder"
 msgstr "AddToPropertyCollection called w/o valid adder"
 
-#: ../src/html/helpctrl.cpp:159
+#: ../src/html/helpctrl.cpp:155
 #, c-format
 msgid "Adding book %s"
 msgstr "إضافة كتاب %s"
 
-#: ../src/common/preferencescmn.cpp:43
+#: ../src/common/preferencescmn.cpp:40
 msgid "Advanced"
 msgstr ""
 
@@ -1296,11 +1292,11 @@ msgstr ""
 msgid "After a paragraph:"
 msgstr "بعد فقرة:"
 
-#: ../src/common/stockitem.cpp:172
+#: ../src/common/stockitem.cpp:169
 msgid "Align Left"
 msgstr "محاذاة لليسار"
 
-#: ../src/common/stockitem.cpp:173
+#: ../src/common/stockitem.cpp:170
 msgid "Align Right"
 msgstr "محاذاة لليمين"
 
@@ -1309,40 +1305,40 @@ msgstr "محاذاة لليمين"
 msgid "Alignment"
 msgstr "&محاذاة"
 
-#: ../src/generic/prntdlgg.cpp:215
+#: ../src/generic/prntdlgg.cpp:208
 msgid "All"
 msgstr "الكل"
 
-#: ../src/generic/filectrlg.cpp:1197 ../src/common/fldlgcmn.cpp:107
+#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1186
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "كل الملفات (%s)|%s"
 
-#: ../include/wx/defs.h:2886
+#: ../include/wx/defs.h:2582
 msgid "All files (*)|*"
 msgstr "كل الملفات (*)|*"
 
-#: ../include/wx/defs.h:2883
+#: ../include/wx/defs.h:2579
 msgid "All files (*.*)|*.*"
 msgstr "كل الملفات (*.*)|*.*"
 
-#: ../src/richtext/richtextstyles.cpp:1061
+#: ../src/richtext/richtextstyles.cpp:1058
 msgid "All styles"
 msgstr "كل الأنماط"
 
-#: ../src/propgrid/manager.cpp:1528
+#: ../src/propgrid/manager.cpp:1544
 msgid "Alphabetic Mode"
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:425
+#: ../src/common/xtistrm.cpp:422
 msgid "Already Registered Object passed to SetObjectClassInfo"
 msgstr "Already Registered Object passed to SetObjectClassInfo"
 
-#: ../src/unix/dialup.cpp:353
+#: ../src/unix/dialup.cpp:352
 msgid "Already dialling ISP."
 msgstr "Already dialling ISP."
 
-#: ../src/common/accelcmn.cpp:331 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/accelcmn.cpp:345 ../src/univ/themes/win32.cpp:3753
 msgid "Alt+"
 msgstr ""
 
@@ -1351,36 +1347,36 @@ msgstr ""
 msgid "An optional corner radius for adding rounded corners."
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:576
+#: ../src/common/debugrpt.cpp:577
 msgid "And includes the following files:\n"
 msgstr "ويشتمل على الملفات التالية:\n"
 
-#: ../src/generic/animateg.cpp:162
+#: ../src/generic/animateg.cpp:145
 #, c-format
 msgid "Animation file is not of type %ld."
 msgstr "ملف الحركة ليس من نوع %ld."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:872
+#: ../src/propgrid/advprops.cpp:773
 msgid "AppWorkspace"
 msgstr ""
 
-#: ../src/generic/logg.cpp:1014
+#: ../src/generic/logg.cpp:1011
 #, c-format
 msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
 msgstr "إرفاق تقرير بالملف '%s' (اختيار [لا] سيتخطاه)?"
 
-#: ../src/osx/menu_osx.cpp:577 ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:469 ../src/osx/menu_osx.cpp:477
 #, fuzzy
 msgid "Application"
 msgstr "تحديد"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 #, fuzzy
 msgid "Apply"
 msgstr "&تطبيق"
 
-#: ../src/propgrid/advprops.cpp:1609
+#: ../src/propgrid/advprops.cpp:1515
 msgid "Aqua"
 msgstr ""
 
@@ -1389,30 +1385,30 @@ msgstr ""
 msgid "Arabic"
 msgstr "عربي"
 
-#: ../src/common/fmapbase.cpp:153
+#: ../src/common/fmapbase.cpp:150
 msgid "Arabic (ISO-8859-6)"
 msgstr "عربي (ISO-8859-6)"
 
-#: ../src/msw/ole/automtn.cpp:672
+#: ../src/msw/ole/automtn.cpp:663
 #, c-format
 msgid "Argument %u not found."
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1753
+#: ../src/propgrid/advprops.cpp:1654
 #, fuzzy
 msgid "Arrow"
 msgstr "غدا"
 
-#: ../src/generic/aboutdlgg.cpp:184
+#: ../src/generic/aboutdlgg.cpp:181
 msgid "Artists"
 msgstr "فنانون"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "Ascending"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:433
+#: ../src/generic/filectrlg.cpp:429
 msgid "Attributes"
 msgstr "خصائص"
 
@@ -1422,91 +1418,91 @@ msgstr "خصائص"
 msgid "Available fonts."
 msgstr "الخطوط المتاحة."
 
-#: ../src/common/paper.cpp:137
+#: ../src/common/paper.cpp:134
 msgid "B4 (ISO) 250 x 353 mm"
 msgstr "B4 (ISO) 250 x 353 mm"
 
-#: ../src/common/paper.cpp:173
+#: ../src/common/paper.cpp:170
 msgid "B4 (JIS) Rotated 364 x 257 mm"
 msgstr "B4 (JIS) مدورة 364 x 257 mm"
 
-#: ../src/common/paper.cpp:127
+#: ../src/common/paper.cpp:124
 msgid "B4 Envelope, 250 x 353 mm"
 msgstr "B4 Envelope, 250 x 353 mm"
 
-#: ../src/common/paper.cpp:109
+#: ../src/common/paper.cpp:106
 msgid "B4 sheet, 250 x 354 mm"
 msgstr "B4 ورقة, 250 x 354 mm"
 
-#: ../src/common/paper.cpp:158
+#: ../src/common/paper.cpp:155
 msgid "B5 (ISO) Extra 201 x 276 mm"
 msgstr "B5 (ISO) Extra 201 x 276 mm"
 
-#: ../src/common/paper.cpp:174
+#: ../src/common/paper.cpp:171
 msgid "B5 (JIS) Rotated 257 x 182 mm"
 msgstr "B5 (JIS) مدورة 257 x 182 mm"
 
-#: ../src/common/paper.cpp:155
+#: ../src/common/paper.cpp:152
 msgid "B5 (JIS) Transverse 182 x 257 mm"
 msgstr "B5 (JIS) مستعرض 182 x 257 mm"
 
-#: ../src/common/paper.cpp:128
+#: ../src/common/paper.cpp:125
 msgid "B5 Envelope, 176 x 250 mm"
 msgstr "B5 Envelope, 176 x 250 mm"
 
-#: ../src/common/paper.cpp:110
+#: ../src/common/paper.cpp:107
 msgid "B5 sheet, 182 x 257 millimeter"
 msgstr "B5 ورقة, 182 x 257 millimeter"
 
-#: ../src/common/paper.cpp:182
+#: ../src/common/paper.cpp:179
 msgid "B6 (JIS) 128 x 182 mm"
 msgstr "B6 (JIS) 128 x 182 mm"
 
-#: ../src/common/paper.cpp:183
+#: ../src/common/paper.cpp:180
 msgid "B6 (JIS) Rotated 182 x 128 mm"
 msgstr "B6 (JIS) مدورة 182 x 128 mm"
 
-#: ../src/common/paper.cpp:129
+#: ../src/common/paper.cpp:126
 msgid "B6 Envelope, 176 x 125 mm"
 msgstr "B6 Envelope, 176 x 125 mm"
 
-#: ../src/common/imagbmp.cpp:531 ../src/common/imagbmp.cpp:561
-#: ../src/common/imagbmp.cpp:576
+#: ../src/common/imagbmp.cpp:528 ../src/common/imagbmp.cpp:558
+#: ../src/common/imagbmp.cpp:573
 msgid "BMP: Couldn't allocate memory."
 msgstr "BMP: لا يمكن تحديد الذاكرة."
 
-#: ../src/common/imagbmp.cpp:100
+#: ../src/common/imagbmp.cpp:97
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: لا يمكن حفظ صورة تالفة."
 
-#: ../src/common/imagbmp.cpp:356
+#: ../src/common/imagbmp.cpp:353
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: لا يمكن كتابة خريطة لون RGB."
 
-#: ../src/common/imagbmp.cpp:490
+#: ../src/common/imagbmp.cpp:487
 msgid "BMP: Couldn't write data."
 msgstr "BMP: لا يمكن كتابة بيانات."
 
-#: ../src/common/imagbmp.cpp:246
+#: ../src/common/imagbmp.cpp:243
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: لا يمكن كتابة الملف (Bitmap) رأس."
 
-#: ../src/common/imagbmp.cpp:269
+#: ../src/common/imagbmp.cpp:266
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: لا يمكن كتابة الملف (BitmapInfo) رأس."
 
-#: ../src/common/imagbmp.cpp:140
+#: ../src/common/imagbmp.cpp:137
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage ليس لديها wxPalette."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:142 ../src/common/accelcmn.cpp:52
+#: ../src/common/stockitem.cpp:139 ../src/common/accelcmn.cpp:49
 #, fuzzy
 msgid "Back"
 msgstr "&رجوع"
 
+#: ../src/richtext/richtextformatdlg.cpp:377
 #: ../src/richtext/richtextbackgroundpage.cpp:148
-#: ../src/richtext/richtextformatdlg.cpp:384
 #, fuzzy
 msgid "Background"
 msgstr "لون الخلفية"
@@ -1516,21 +1512,21 @@ msgstr "لون الخلفية"
 msgid "Background &colour:"
 msgstr "لون الخلفية"
 
-#: ../src/osx/carbon/fontdlg.cpp:220
+#: ../src/osx/carbon/fontdlg.cpp:217
 msgid "Background colour"
 msgstr "لون الخلفية"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:52
+#: ../src/common/accelcmn.cpp:49
 #, fuzzy
 msgid "Backspace"
 msgstr "&رجوع"
 
-#: ../src/common/fmapbase.cpp:160
+#: ../src/common/fmapbase.cpp:157
 msgid "Baltic (ISO-8859-13)"
 msgstr "بلتيق (ISO-8859-13)"
 
-#: ../src/common/fmapbase.cpp:151
+#: ../src/common/fmapbase.cpp:148
 msgid "Baltic (old) (ISO-8859-4)"
 msgstr "بلتيق (old) (ISO-8859-4)"
 
@@ -1543,25 +1539,25 @@ msgstr "قبل الفقرة:"
 msgid "Bitmap"
 msgstr "Bitmap"
 
-#: ../src/propgrid/advprops.cpp:1594
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Black"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1755
+#: ../src/propgrid/advprops.cpp:1656
 msgid "Blank"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1603
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Blue"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:345
+#: ../src/generic/colrdlgg.cpp:365
 msgid "Blue:"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:333 ../src/richtext/richtextfontpage.cpp:355
-#: ../src/osx/carbon/fontdlg.cpp:354 ../src/common/stockitem.cpp:143
+#: ../src/osx/carbon/fontdlg.cpp:351 ../src/common/stockitem.cpp:140
+#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:355
 msgid "Bold"
 msgstr "عريض"
 
@@ -1570,33 +1566,37 @@ msgstr "عريض"
 msgid "Border"
 msgstr ""
 
-#: ../src/richtext/richtextformatdlg.cpp:379
+#: ../src/richtext/richtextformatdlg.cpp:372
 msgid "Borders"
 msgstr ""
 
-#: ../src/richtext/richtextsizepage.cpp:288 ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141 ../src/richtext/richtextsizepage.cpp:288
 msgid "Bottom"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:893
+#: ../src/generic/prntdlgg.cpp:886
 msgid "Bottom margin (mm):"
 msgstr "الهامش الأسفل (mm):"
 
-#: ../src/richtext/richtextbuffer.cpp:9383
+#: ../src/richtext/richtextbuffer.cpp:9380
 #, fuzzy
 msgid "Box Properties"
 msgstr "&الخصائص"
 
-#: ../src/richtext/richtextstyles.cpp:1065
+#: ../src/richtext/richtextstyles.cpp:1062
 #, fuzzy
 msgid "Box styles"
 msgstr "كل الأنماط"
 
-#: ../src/propgrid/advprops.cpp:1602
+#: ../src/osx/cocoa/menu.mm:292
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Brown"
 msgstr ""
 
-#: ../src/common/filepickercmn.cpp:43 ../src/common/filepickercmn.cpp:44
+#: ../src/common/filepickercmn.cpp:40 ../src/common/filepickercmn.cpp:41
 msgid "Browse"
 msgstr ""
 
@@ -1609,73 +1609,73 @@ msgstr "إزا&حة تنقيط:"
 msgid "Bullet style"
 msgstr "إسلوب التنقيط"
 
-#: ../src/richtext/richtextformatdlg.cpp:359
+#: ../src/richtext/richtextformatdlg.cpp:352
 msgid "Bullets"
 msgstr "نقاط"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1756
+#: ../src/propgrid/advprops.cpp:1657
 #, fuzzy
 msgid "Bullseye"
 msgstr "إسلوب التنقيط"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:875
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonFace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:876
+#: ../src/propgrid/advprops.cpp:777
 msgid "ButtonHighlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:877
+#: ../src/propgrid/advprops.cpp:778
 msgid "ButtonShadow"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:878
+#: ../src/propgrid/advprops.cpp:779
 msgid "ButtonText"
 msgstr ""
 
-#: ../src/common/paper.cpp:98
+#: ../src/common/paper.cpp:95
 msgid "C sheet, 17 x 22 in"
 msgstr "C ورقة, 17 x 22 in"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "C&lear"
 msgstr "C&lear"
 
-#: ../src/generic/fontdlgg.cpp:406
+#: ../src/generic/fontdlgg.cpp:403
 msgid "C&olour:"
 msgstr "C&olour:"
 
-#: ../src/common/paper.cpp:123
+#: ../src/common/paper.cpp:120
 msgid "C3 Envelope, 324 x 458 mm"
 msgstr "C3 Envelope, 324 x 458 mm"
 
-#: ../src/common/paper.cpp:124
+#: ../src/common/paper.cpp:121
 msgid "C4 Envelope, 229 x 324 mm"
 msgstr "C4 Envelope, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:122
+#: ../src/common/paper.cpp:119
 msgid "C5 Envelope, 162 x 229 mm"
 msgstr "C5 Envelope, 162 x 229 mm"
 
-#: ../src/common/paper.cpp:125
+#: ../src/common/paper.cpp:122
 msgid "C6 Envelope, 114 x 162 mm"
 msgstr "C6 Envelope, 114 x 162 mm"
 
-#: ../src/common/paper.cpp:126
+#: ../src/common/paper.cpp:123
 msgid "C65 Envelope, 114 x 229 mm"
 msgstr "C65 Envelope, 114 x 229 mm"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "CD-Rom"
 msgstr ""
 
-#: ../src/html/chm.cpp:815 ../src/html/chm.cpp:874
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:865
 msgid "CHM handler currently supports only local files!"
 msgstr "CHM handler لا يدعم في الوقت الراهن سوى الملفات المحلية!"
 
@@ -1683,194 +1683,198 @@ msgstr "CHM handler لا يدعم في الوقت الراهن سوى الملف
 msgid "Ca&pitals"
 msgstr "أحرف &كبيرة"
 
-#: ../src/common/cmdproc.cpp:267
+#: ../src/common/cmdproc.cpp:260
 msgid "Can't &Undo "
 msgstr "لا يمكن ال&تراجع"
 
-#: ../src/common/image.cpp:2824
+#: ../src/common/image.cpp:2924
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 
-#: ../src/msw/registry.cpp:506
+#: ../src/msw/registry.cpp:495
 #, c-format
 msgid "Can't close registry key '%s'"
 msgstr "لا يمكن إغلاق مفتاح السجل '%s'"
 
-#: ../src/msw/registry.cpp:584
+#: ../src/msw/registry.cpp:573
 #, c-format
 msgid "Can't copy values of unsupported type %d."
 msgstr "لا يمكن نسخ قيم النوع الغير مدعوم %d."
 
-#: ../src/msw/registry.cpp:487
+#: ../src/msw/registry.cpp:476
 #, c-format
 msgid "Can't create registry key '%s'"
 msgstr "لا يمكن إنشاء مفتاح السجل '%s'"
 
-#: ../src/msw/thread.cpp:665
+#: ../src/msw/thread.cpp:657
 msgid "Can't create thread"
 msgstr "لا يمكن إنشاء الموضوع"
 
-#: ../src/msw/window.cpp:3691
-#, c-format
-msgid "Can't create window of class %s"
-msgstr "لا يمكن إنشاء نافذة من تصنيف %s"
-
-#: ../src/msw/registry.cpp:777
+#: ../src/msw/registry.cpp:765
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "لا يمكن حذف المفتاح '%s'"
 
-#: ../src/msw/iniconf.cpp:458
+#: ../src/msw/iniconf.cpp:455
 #, c-format
 msgid "Can't delete the INI file '%s'"
 msgstr "لا يمكن حذف الملفini '%s'"
 
-#: ../src/msw/registry.cpp:805
+#: ../src/msw/registry.cpp:793
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "لا يمكن حذف القيمة '%s' من المفتاح '%s'"
 
-#: ../src/msw/registry.cpp:1171
+#: ../src/msw/registry.cpp:1159
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "لا يمكن حصر المفاتيح الفرعية للمفتاح '%s'"
 
-#: ../src/msw/registry.cpp:1132
+#: ../src/msw/registry.cpp:1120
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "لا يمكن حصر قيم المفتاح '%s'"
 
-#: ../src/msw/registry.cpp:1389
+#: ../src/msw/registry.cpp:1377
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "لا يمكن تصدير النوع الغير مدعوم %d."
 
-#: ../src/common/ffile.cpp:254
+#: ../src/common/ffile.cpp:253
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "لا يمكن العثور على الموضع الحالي بملف '%s'"
 
-#: ../src/msw/registry.cpp:418
+#: ../src/msw/registry.cpp:407
 #, c-format
 msgid "Can't get info about registry key '%s'"
 msgstr "لا يمكن الحصول على معلومات حول مفتاح السجل '%s'"
 
-#: ../src/common/zstream.cpp:346
+#: ../src/msw/webview_ie.cpp:1024
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "تعذر تحديد أولوية الموضوع"
+
+#: ../src/common/zstream.cpp:343
 #, fuzzy
 msgid "Can't initialize zlib deflate stream."
 msgstr "Can't initialize zlib deflate stream."
 
-#: ../src/common/zstream.cpp:185
+#: ../src/common/zstream.cpp:182
 #, fuzzy
 msgid "Can't initialize zlib inflate stream."
 msgstr "Can't initialize zlib inflate stream."
 
-#: ../src/msw/fswatcher.cpp:476
+#: ../src/msw/fswatcher.cpp:475
 #, c-format
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr ""
 
-#: ../src/msw/registry.cpp:454
+#: ../src/msw/registry.cpp:443
 #, c-format
 msgid "Can't open registry key '%s'"
 msgstr "لا يمكن فتح مفتاح الجل '%s'"
 
-#: ../src/common/zstream.cpp:252
+#: ../src/common/zstream.cpp:249
 #, fuzzy, c-format
 msgid "Can't read from inflate stream: %s"
 msgstr "Can't read from inflate stream: %s"
 
-#: ../src/common/zstream.cpp:244
+#: ../src/common/zstream.cpp:241
 #, fuzzy
 msgid "Can't read inflate stream: unexpected EOF in underlying stream."
 msgstr "Can't read inflate stream: unexpected EOF in underlying stream."
 
-#: ../src/msw/registry.cpp:1064
+#: ../src/msw/registry.cpp:1052
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "لا يمكن قراءة قيمة '%s'"
 
-#: ../src/msw/registry.cpp:878 ../src/msw/registry.cpp:910
-#: ../src/msw/registry.cpp:975
+#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
+#: ../src/msw/registry.cpp:963
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "لا يمكن قراءة قيمة المفتاح '%s'"
 
-#: ../src/common/image.cpp:2620
+#: ../src/msw/webview_ie.cpp:1017
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/common/image.cpp:2715
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "لا يمكن حفظ الصورة بالملف '%s': الامتداد غير معروف."
 
-#: ../src/generic/logg.cpp:573 ../src/generic/logg.cpp:976
+#: ../src/generic/logg.cpp:570 ../src/generic/logg.cpp:973
 msgid "Can't save log contents to file."
 msgstr "تعذر حفظ محتوى التقرير بملف."
 
-#: ../src/msw/thread.cpp:629
+#: ../src/msw/thread.cpp:621
 msgid "Can't set thread priority"
 msgstr "تعذر تحديد أولوية الموضوع"
 
-#: ../src/msw/registry.cpp:896 ../src/msw/registry.cpp:938
-#: ../src/msw/registry.cpp:1081
+#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
+#: ../src/msw/registry.cpp:1069
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "تعذر تحديد قيمة '%s'"
 
-#: ../src/unix/utilsunx.cpp:351
+#: ../src/unix/utilsunx.cpp:353
 #, fuzzy
 msgid "Can't write to child process's stdin"
 msgstr "Can't write to deflate stream: %s"
 
-#: ../src/common/zstream.cpp:427
+#: ../src/common/zstream.cpp:424
 #, c-format
 msgid "Can't write to deflate stream: %s"
 msgstr "Can't write to deflate stream: %s"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:279 ../src/richtext/richtextstyledlg.cpp:300
-#: ../src/common/stockitem.cpp:145 ../src/common/accelcmn.cpp:71
-#: ../src/msw/msgdlg.cpp:454 ../src/msw/progdlg.cpp:673
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:142
+#: ../src/common/accelcmn.cpp:68 ../src/motif/msgdlg.cpp:196
+#: ../src/gtk1/fontdlg.cpp:144 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/progdlg.cpp:940 ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "إلغاء"
 
-#: ../src/common/filefn.cpp:1261
+#: ../src/common/filefn.cpp:1149
 #, fuzzy, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "لا يمكن حصر ملفات '%s'"
 
-#: ../src/msw/dir.cpp:263
+#: ../src/msw/dir.cpp:260
 #, fuzzy, c-format
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "لا يمكن حصر ملفات المجلد '%s'"
 
-#: ../src/msw/dialup.cpp:523
+#: ../src/msw/dialup.cpp:517
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "تعذر الحصول على محاورة اتصال نشطة: %s"
 
-#: ../src/msw/dialup.cpp:827
+#: ../src/msw/dialup.cpp:821
 msgid "Cannot find the location of address book file"
 msgstr "تعذر وجود موقع ملف دفتر العناوين"
 
-#: ../src/msw/ole/automtn.cpp:562
+#: ../src/msw/ole/automtn.cpp:553
 #, fuzzy, c-format
 msgid "Cannot get an active instance of \"%s\""
 msgstr "تعذر الحصول على محاورة اتصال نشطة: %s"
 
-#: ../src/unix/threadpsx.cpp:1035
+#: ../src/unix/threadpsx.cpp:1053
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "تعذر الحصول على أولوية ترتيب أولوية سياسة الجدول %d"
 
-#: ../src/unix/utilsunx.cpp:987
+#: ../src/unix/utilsunx.cpp:989
 msgid "Cannot get the hostname"
 msgstr "تعذر الحصول على اسم المضيف"
 
-#: ../src/unix/utilsunx.cpp:1023
+#: ../src/unix/utilsunx.cpp:1025
 msgid "Cannot get the official hostname"
 msgstr "تعذر الحصول على اسم المضيف الرسمي"
 
-#: ../src/msw/dialup.cpp:928
+#: ../src/msw/dialup.cpp:922
 msgid "Cannot hang up - no active dialup connection."
 msgstr "لا يمكن تعليق المكالمة - لا يوجد اتصال هاتفي نشط"
 
@@ -1878,131 +1882,131 @@ msgstr "لا يمكن تعليق المكالمة - لا يوجد اتصال ه�
 msgid "Cannot initialize OLE"
 msgstr "Cannot initialize OLE"
 
-#: ../src/common/socket.cpp:853
+#: ../src/common/socket.cpp:850
 #, fuzzy
 msgid "Cannot initialize sockets"
 msgstr "Cannot initialize OLE"
 
-#: ../src/msw/volume.cpp:619
+#: ../src/msw/volume.cpp:627
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "تعذر تحميل الأيقونة من '%s'."
 
-#: ../src/xrc/xmlres.cpp:360
+#: ../src/xrc/xmlres.cpp:358
 #, fuzzy, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "تعذر تحميل المصادر من '%s'."
 
-#: ../src/xrc/xmlres.cpp:742
+#: ../src/xrc/xmlres.cpp:740
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "تعذر تحميل المصادر من '%s'."
 
-#: ../src/html/htmlfilt.cpp:137
+#: ../src/html/htmlfilt.cpp:134
 #, c-format
 msgid "Cannot open HTML document: %s"
 msgstr "تعذر فتح مستند html: %s"
 
-#: ../src/html/helpdata.cpp:667
+#: ../src/html/helpdata.cpp:660
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "تعذر فتح كتاب المساعدة بصيغة html: %s"
 
-#: ../src/html/helpdata.cpp:299
+#: ../src/html/helpdata.cpp:296
 #, c-format
 msgid "Cannot open contents file: %s"
 msgstr "تعذر فتح ملف: المحتويات %s"
 
-#: ../src/generic/dcpsg.cpp:1667
+#: ../src/generic/dcpsg.cpp:1665
 msgid "Cannot open file for PostScript printing!"
 msgstr "تعذر فتح ملف لطباعة postscript"
 
-#: ../src/html/helpdata.cpp:313
+#: ../src/html/helpdata.cpp:310
 #, c-format
 msgid "Cannot open index file: %s"
 msgstr "تعذر فتح ملف التكشيف: %s"
 
-#: ../src/xrc/xmlres.cpp:724
+#: ../src/xrc/xmlres.cpp:722
 #, fuzzy, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "تعذر تحميل المصادر من '%s'."
 
-#: ../src/html/helpwnd.cpp:1534
+#: ../src/html/helpwnd.cpp:1532
 msgid "Cannot print empty page."
 msgstr "تعذر طبع صفحة فارغة"
 
-#: ../src/msw/volume.cpp:507
+#: ../src/msw/volume.cpp:515
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "تعذر قراءة اسم النوع من '%s'!"
 
-#: ../src/msw/thread.cpp:888
+#: ../src/msw/thread.cpp:894
 #, fuzzy, c-format
 msgid "Cannot resume thread %lx"
 msgstr "لا يمكن استئناف الموضوع %x"
 
-#: ../src/unix/threadpsx.cpp:1016
+#: ../src/unix/threadpsx.cpp:1028
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "تعذر استرجاع سياسة جدول الموضوع"
 
-#: ../src/common/intl.cpp:558
+#: ../src/common/intl.cpp:365
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:831 ../src/msw/thread.cpp:546
+#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
 #, fuzzy
 msgid "Cannot start thread: error writing TLS."
 msgstr "لا يمكن بدأ الموضوع: خطأ بكتابة tls."
 
-#: ../src/msw/thread.cpp:872
+#: ../src/msw/thread.cpp:864
 #, fuzzy, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "لا يمكن توقف الموضوع %x"
 
-#: ../src/msw/thread.cpp:794
+#: ../src/msw/thread.cpp:786
 #, fuzzy
 msgid "Cannot wait for thread termination"
 msgstr "تعذر الانتظار حتى إنهاء الموضوع"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:75
+#: ../src/common/accelcmn.cpp:72
 #, fuzzy
 msgid "Capital"
 msgstr "أحرف &كبيرة"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:879
+#: ../src/propgrid/advprops.cpp:780
 msgid "CaptionText"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:531
 msgid "Case sensitive"
 msgstr "حساس لحالة الأحرف"
 
-#: ../src/propgrid/manager.cpp:1509
+#: ../src/propgrid/manager.cpp:1527
 msgid "Categorized Mode"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9968
+#: ../src/richtext/richtextbuffer.cpp:9965
 #, fuzzy
 msgid "Cell Properties"
 msgstr "&الخصائص"
 
-#: ../src/common/fmapbase.cpp:161
+#: ../src/common/fmapbase.cpp:158
 msgid "Celtic (ISO-8859-14)"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:160
 #: ../src/richtext/richtextliststylepage.cpp:349
+#: ../src/richtext/richtextindentspage.cpp:160
 msgid "Cen&tred"
 msgstr "وسط ال&سطر"
 
-#: ../src/common/stockitem.cpp:170
+#: ../src/common/stockitem.cpp:167
 msgid "Centered"
 msgstr "وسط السطر"
 
-#: ../src/common/fmapbase.cpp:149
+#: ../src/common/fmapbase.cpp:146
 msgid "Central European (ISO-8859-2)"
 msgstr ""
 
@@ -2011,10 +2015,10 @@ msgstr ""
 msgid "Centre"
 msgstr "وسط"
 
-#: ../src/richtext/richtextindentspage.cpp:162
-#: ../src/richtext/richtextindentspage.cpp:164
 #: ../src/richtext/richtextliststylepage.cpp:351
 #: ../src/richtext/richtextliststylepage.cpp:353
+#: ../src/richtext/richtextindentspage.cpp:162
+#: ../src/richtext/richtextindentspage.cpp:164
 msgid "Centre text."
 msgstr "محاذاة النص للوسط."
 
@@ -2028,26 +2032,26 @@ msgstr "وسط"
 msgid "Ch&oose..."
 msgstr "اخ&تر"
 
-#: ../src/richtext/richtextbuffer.cpp:4354
+#: ../src/richtext/richtextbuffer.cpp:4351
 msgid "Change List Style"
 msgstr "تغيير إسلوب القائمة"
 
-#: ../src/richtext/richtextbuffer.cpp:3709
+#: ../src/richtext/richtextbuffer.cpp:3706
 #, fuzzy
 msgid "Change Object Style"
 msgstr "تغيير نمط"
 
-#: ../src/richtext/richtextbuffer.cpp:3982
-#: ../src/richtext/richtextbuffer.cpp:8129
+#: ../src/richtext/richtextbuffer.cpp:3979
+#: ../src/richtext/richtextbuffer.cpp:8125
 #, fuzzy
 msgid "Change Properties"
 msgstr "&الخصائص"
 
-#: ../src/richtext/richtextbuffer.cpp:3526
+#: ../src/richtext/richtextbuffer.cpp:3523
 msgid "Change Style"
 msgstr "تغيير نمط"
 
-#: ../src/common/fileconf.cpp:341
+#: ../src/common/fileconf.cpp:335
 #, c-format
 msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
 msgstr ""
@@ -2058,12 +2062,12 @@ msgid "Changing current directory to \"%s\" failed"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1757
+#: ../src/propgrid/advprops.cpp:1658
 #, fuzzy
 msgid "Character"
 msgstr "&ترميز الحرف"
 
-#: ../src/richtext/richtextstyles.cpp:1063
+#: ../src/richtext/richtextstyles.cpp:1060
 msgid "Character styles"
 msgstr "أنماط الحرف"
 
@@ -2101,20 +2105,20 @@ msgstr "حدد كي تغلق الأقواس والتنقيط"
 msgid "Check to indicate right-to-left text layout."
 msgstr "انقر لتغيير لون النص"
 
-#: ../src/osx/carbon/fontdlg.cpp:356 ../src/osx/carbon/fontdlg.cpp:358
+#: ../src/osx/carbon/fontdlg.cpp:353 ../src/osx/carbon/fontdlg.cpp:355
 msgid "Check to make the font bold."
 msgstr "حدد كي تجعل الخط عريض"
 
-#: ../src/osx/carbon/fontdlg.cpp:363 ../src/osx/carbon/fontdlg.cpp:365
+#: ../src/osx/carbon/fontdlg.cpp:360 ../src/osx/carbon/fontdlg.cpp:362
 msgid "Check to make the font italic."
 msgstr "حدد كي تجعل الخط مائلا"
 
-#: ../src/osx/carbon/fontdlg.cpp:372 ../src/osx/carbon/fontdlg.cpp:374
+#: ../src/osx/carbon/fontdlg.cpp:369 ../src/osx/carbon/fontdlg.cpp:371
 msgid "Check to make the font underlined."
 msgstr "حدد كي تجضع تحته خط"
 
-#: ../src/richtext/richtextstyledlg.cpp:289
-#: ../src/richtext/richtextstyledlg.cpp:291
+#: ../src/richtext/richtextstyledlg.cpp:285
+#: ../src/richtext/richtextstyledlg.cpp:287
 msgid "Check to restart numbering."
 msgstr "حدد كي تعيد بدأ الترقيم"
 
@@ -2149,55 +2153,55 @@ msgstr "حدد كي تظهر النص لأعلى"
 msgid "Check to suppress hyphenation."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:763
+#: ../src/msw/dialup.cpp:757
 msgid "Choose ISP to dial"
 msgstr "اختر isp للاتصال"
 
-#: ../src/propgrid/props.cpp:1922
+#: ../src/propgrid/props.cpp:1904
 #, fuzzy
 msgid "Choose a directory:"
 msgstr "إنشاء مجلد"
 
-#: ../src/propgrid/props.cpp:1975
+#: ../src/propgrid/props.cpp:2199
 #, fuzzy
 msgid "Choose a file"
 msgstr "اختر الخط"
 
-#: ../src/generic/colrdlgg.cpp:158 ../src/gtk/colordlg.cpp:54
+#: ../src/generic/colrdlgg.cpp:156 ../src/gtk/colordlg.cpp:49
 msgid "Choose colour"
 msgstr "اختر اللون"
 
-#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/gtk1/fontdlg.cpp:125 ../src/generic/fontpickerg.cpp:47
+#: ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "اختر الخط"
 
-#: ../src/common/module.cpp:74
+#: ../src/common/module.cpp:71
 #, c-format
 msgid "Circular dependency involving module \"%s\" detected."
 msgstr ""
 
-#: ../src/aui/tabmdi.cpp:108 ../src/generic/mdig.cpp:97
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
 msgid "Cl&ose"
 msgstr "إ&غلاق"
 
-#: ../src/msw/ole/automtn.cpp:684
+#: ../src/msw/ole/automtn.cpp:675
 #, fuzzy
 msgid "Class not registered."
 msgstr "لا يمكن استئناف الموضوع %x"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:147 ../src/common/accelcmn.cpp:72
+#: ../src/common/stockitem.cpp:144 ../src/common/accelcmn.cpp:69
 #, fuzzy
 msgid "Clear"
 msgstr "&واضح"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "Clear the log contents"
 msgstr "حذف محتوى التقرير"
 
-#: ../src/richtext/richtextstyledlg.cpp:252
-#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:248
+#: ../src/richtext/richtextstyledlg.cpp:250
 msgid "Click to apply the selected style."
 msgstr "انقر لتطبيق الإسلوب المختار"
 
@@ -2208,15 +2212,15 @@ msgstr "انقر لتطبيق الإسلوب المختار"
 msgid "Click to browse for a symbol."
 msgstr "انقر للبحث عن رمز"
 
-#: ../src/osx/carbon/fontdlg.cpp:403 ../src/osx/carbon/fontdlg.cpp:405
+#: ../src/osx/carbon/fontdlg.cpp:400 ../src/osx/carbon/fontdlg.cpp:402
 msgid "Click to cancel changes to the font."
 msgstr "انقر لإلغاء تغييرات الخط"
 
-#: ../src/generic/fontdlgg.cpp:472 ../src/generic/fontdlgg.cpp:491
+#: ../src/generic/fontdlgg.cpp:468 ../src/generic/fontdlgg.cpp:487
 msgid "Click to cancel the font selection."
 msgstr "انقر لإلغاء تحديد الخط"
 
-#: ../src/osx/carbon/fontdlg.cpp:384 ../src/osx/carbon/fontdlg.cpp:386
+#: ../src/osx/carbon/fontdlg.cpp:381 ../src/osx/carbon/fontdlg.cpp:383
 msgid "Click to change the font colour."
 msgstr "انقر لتغيير لون الخط"
 
@@ -2236,38 +2240,38 @@ msgstr "انقر لتغيير لون النص"
 msgid "Click to choose the font for this level."
 msgstr "انقر لاختيار الخط المناسب لهذا المستوى"
 
-#: ../src/richtext/richtextstyledlg.cpp:279
-#: ../src/richtext/richtextstyledlg.cpp:281
+#: ../src/richtext/richtextstyledlg.cpp:275
+#: ../src/richtext/richtextstyledlg.cpp:277
 msgid "Click to close this window."
 msgstr "انقر لإغلاق هذه النافذة"
 
-#: ../src/osx/carbon/fontdlg.cpp:410 ../src/osx/carbon/fontdlg.cpp:412
+#: ../src/osx/carbon/fontdlg.cpp:407 ../src/osx/carbon/fontdlg.cpp:409
 msgid "Click to confirm changes to the font."
 msgstr "انقر لتأكيد تغييرات الخط"
 
-#: ../src/generic/fontdlgg.cpp:477 ../src/generic/fontdlgg.cpp:479
-#: ../src/generic/fontdlgg.cpp:484 ../src/generic/fontdlgg.cpp:486
+#: ../src/generic/fontdlgg.cpp:473 ../src/generic/fontdlgg.cpp:475
+#: ../src/generic/fontdlgg.cpp:480 ../src/generic/fontdlgg.cpp:482
 msgid "Click to confirm the font selection."
 msgstr "انقر لتأكيد اختيار الخط"
 
-#: ../src/richtext/richtextstyledlg.cpp:244
-#: ../src/richtext/richtextstyledlg.cpp:246
+#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:242
 #, fuzzy
 msgid "Click to create a new box style."
 msgstr "انقر لإنشاء إسلوب قائمة جديد"
 
-#: ../src/richtext/richtextstyledlg.cpp:226
-#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:224
 msgid "Click to create a new character style."
 msgstr "انقر لإنشاء إسلوب حرف جديد"
 
-#: ../src/richtext/richtextstyledlg.cpp:238
-#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:236
 msgid "Click to create a new list style."
 msgstr "انقر لإنشاء إسلوب قائمة جديد"
 
-#: ../src/richtext/richtextstyledlg.cpp:232
-#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:230
 msgid "Click to create a new paragraph style."
 msgstr "انقر لإنشاء إسلوب فقرة جديد"
 
@@ -2281,8 +2285,8 @@ msgstr "انقر لإنشاء وضع انتقال tab جديد"
 msgid "Click to delete all tab positions."
 msgstr "انقر لحذف كل أوضاع tab"
 
-#: ../src/richtext/richtextstyledlg.cpp:270
-#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:268
 msgid "Click to delete the selected style."
 msgstr "انقر لحذف الإسلوب المحدد"
 
@@ -2291,25 +2295,25 @@ msgstr "انقر لحذف الإسلوب المحدد"
 msgid "Click to delete the selected tab position."
 msgstr "انقر لحذف وضع tab المختار"
 
-#: ../src/richtext/richtextstyledlg.cpp:264
-#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:262
 msgid "Click to edit the selected style."
 msgstr "انقر لتحرير الإسلوب المختار"
 
-#: ../src/richtext/richtextstyledlg.cpp:258
-#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:256
 msgid "Click to rename the selected style."
 msgstr "انقر لإعادة تسمية الإسلوب المختار"
 
-#: ../src/generic/dbgrptg.cpp:97 ../src/generic/progdlgg.cpp:759
-#: ../src/richtext/richtextstyledlg.cpp:277
-#: ../src/richtext/richtextsymboldlg.cpp:476 ../src/common/stockitem.cpp:148
-#: ../src/msw/progdlg.cpp:170 ../src/msw/progdlg.cpp:679
-#: ../src/html/helpdlg.cpp:90
+#: ../src/common/stockitem.cpp:145 ../src/generic/dbgrptg.cpp:94
+#: ../src/generic/progdlgg.cpp:781 ../src/msw/progdlg.cpp:211
+#: ../src/msw/progdlg.cpp:946 ../src/html/helpdlg.cpp:87
+#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextstyledlg.cpp:273
 msgid "Close"
 msgstr "إغلاق"
 
-#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:98
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
 msgid "Close All"
 msgstr "إغلاق الكل"
 
@@ -2317,66 +2321,66 @@ msgstr "إغلاق الكل"
 msgid "Close current document"
 msgstr "إغلاق الوثيقة الحالية"
 
-#: ../src/generic/logg.cpp:516
+#: ../src/generic/logg.cpp:513
 msgid "Close this window"
 msgstr "إغلاق هذه النافذة"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6006
+#: ../src/generic/datavgen.cpp:6811
 msgid "Collapse"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 #, fuzzy
 msgid "Color"
 msgstr "لون"
 
-#: ../src/richtext/richtextformatdlg.cpp:776
+#: ../src/richtext/richtextformatdlg.cpp:768
 msgid "Colour"
 msgstr "لون"
 
-#: ../src/msw/colordlg.cpp:158
+#: ../src/msw/colordlg.cpp:227
 #, c-format
 msgid "Colour selection dialog failed with error %0lx."
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:380
+#: ../src/osx/carbon/fontdlg.cpp:377
 msgid "Colour:"
 msgstr "لون:"
 
-#: ../src/generic/datavgen.cpp:6077
+#: ../src/generic/datavgen.cpp:6882
 #, c-format
 msgid "Column %u"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:114
+#: ../src/common/accelcmn.cpp:112
 msgid "Command"
 msgstr ""
 
-#: ../src/common/init.cpp:196
+#: ../src/common/init.cpp:193
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
 "ignored."
 msgstr ""
 
-#: ../src/msw/fontdlg.cpp:120
+#: ../src/msw/fontdlg.cpp:170
 #, c-format
 msgid "Common dialog failed with error code %0lx."
 msgstr ""
 
-#: ../src/gtk/window.cpp:4649
+#: ../src/gtk/window.cpp:5653
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:1549
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "ملف مساعدة html مضغوط (*.chm)|*.chm|"
 
-#: ../src/generic/dirctrlg.cpp:444
+#: ../src/generic/dirctrlg.cpp:410
 msgid "Computer"
 msgstr "حاسوب"
 
@@ -2385,54 +2389,58 @@ msgstr "حاسوب"
 msgid "Config entry name cannot start with '%c'."
 msgstr ""
 
-#: ../src/generic/filedlgg.cpp:349 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
 msgid "Confirm"
 msgstr "تأكيد"
 
-#: ../src/html/htmlwin.cpp:566
+#: ../src/html/htmlwin.cpp:569
 msgid "Connecting..."
 msgstr "جاري الاتصال..."
 
-#: ../src/html/helpwnd.cpp:475
+#: ../src/html/helpwnd.cpp:473
 msgid "Contents"
 msgstr "محتويات"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:880
+#: ../src/propgrid/advprops.cpp:781
 msgid "ControlDark"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:881
+#: ../src/propgrid/advprops.cpp:782
 msgid "ControlLight"
 msgstr ""
 
-#: ../src/common/strconv.cpp:2262
+#: ../src/common/strconv.cpp:2208
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 #, fuzzy
 msgid "Convert"
 msgstr "محتويات"
 
-#: ../src/html/htmlwin.cpp:1079
+#: ../src/html/htmlwin.cpp:1020
 #, c-format
 msgid "Copied to clipboard:\"%s\""
 msgstr "نسخ إلى الحافظة:\"%s\""
 
-#: ../src/generic/prntdlgg.cpp:247
+#: ../src/generic/prntdlgg.cpp:240
 msgid "Copies:"
 msgstr "نُسخ:"
 
-#: ../src/common/stockitem.cpp:150 ../src/stc/stc_i18n.cpp:18
+#: ../src/common/stockitem.cpp:147 ../src/stc/stc_i18n.cpp:18
 msgid "Copy"
 msgstr "نسخ"
 
-#: ../src/common/stockitem.cpp:258
+#: ../src/common/stockitem.cpp:255
 msgid "Copy selection"
 msgstr "نسخ إختيار"
+
+#: ../src/generic/grid.cpp:5945
+msgid "Copying more than one selected block to clipboard is not supported."
+msgstr ""
 
 #: ../src/richtext/richtextborderspage.cpp:566
 #: ../src/richtext/richtextborderspage.cpp:601
@@ -2443,201 +2451,197 @@ msgstr ""
 msgid "Corner &radius:"
 msgstr ""
 
-#: ../src/html/chm.cpp:718
+#: ../src/html/chm.cpp:711
 #, c-format
 msgid "Could not create temporary file '%s'"
 msgstr "تعذر إنشاء الملف المؤقت '%s'"
 
-#: ../src/html/chm.cpp:273
+#: ../src/html/chm.cpp:270
 #, c-format
 msgid "Could not extract %s into %s: %s"
 msgstr "تعذر فك %s into %s: %s"
 
-#: ../src/generic/tabg.cpp:1048
+#: ../src/generic/tabg.cpp:1045
 msgid "Could not find tab for id"
 msgstr ""
 
-#: ../src/gtk/notifmsg.cpp:108
-#, fuzzy
-msgid "Could not initalize libnotify."
-msgstr "تعذر بدأ الطباعة."
-
-#: ../src/html/chm.cpp:444
+#: ../src/html/chm.cpp:437
 #, c-format
 msgid "Could not locate file '%s'."
 msgstr "تعذر تحديد مكان الملف '%s'"
 
-#: ../src/common/filefn.cpp:1403
+#: ../src/msw/graphicsd2d.cpp:604
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/common/filefn.cpp:1291
 #, fuzzy
 msgid "Could not set current working directory"
 msgstr "تعذر بدأ معاينة المستند."
 
-#: ../src/common/prntbase.cpp:2015
+#: ../src/common/prntbase.cpp:2037
 msgid "Could not start document preview."
 msgstr "تعذر بدأ معاينة المستند."
 
-#: ../src/generic/printps.cpp:178 ../src/msw/printwin.cpp:210
-#: ../src/gtk/print.cpp:1132
+#: ../src/generic/printps.cpp:159 ../src/msw/printwin.cpp:184
+#: ../src/gtk/print.cpp:1129
 msgid "Could not start printing."
 msgstr "تعذر بدأ الطباعة."
 
-#: ../src/common/wincmn.cpp:2125
+#: ../src/common/wincmn.cpp:2126
 msgid "Could not transfer data to window"
 msgstr "تعذر نقل البيانات إلى النافذة"
 
-#: ../src/msw/imaglist.cpp:187 ../src/msw/imaglist.cpp:224
-#: ../src/msw/imaglist.cpp:249 ../src/msw/dragimag.cpp:185
-#: ../src/msw/dragimag.cpp:220
+#: ../src/msw/imaglist.cpp:223 ../src/msw/imaglist.cpp:245
+#: ../src/msw/imaglist.cpp:270 ../src/msw/dragimag.cpp:182
+#: ../src/msw/dragimag.cpp:217
 msgid "Couldn't add an image to the image list."
 msgstr "تعذر إضافة صورة لقائمة الصور."
 
-#: ../src/osx/glcanvas_osx.cpp:414 ../src/unix/glx11.cpp:558
-#: ../src/msw/glcanvas.cpp:616
+#: ../src/osx/glcanvas_osx.cpp:411 ../src/msw/glcanvas.cpp:631
+#: ../src/unix/glegl.cpp:315 ../src/unix/glx11.cpp:559
 #, fuzzy
 msgid "Couldn't create OpenGL context"
 msgstr "لم يسطتع إنشاء محول الترميز"
 
-#: ../src/msw/timer.cpp:134
+#: ../src/msw/timer.cpp:131
 msgid "Couldn't create a timer"
 msgstr ""
 
-#: ../src/osx/carbon/overlay.cpp:122
-msgid "Couldn't create the overlay window"
-msgstr ""
-
-#: ../src/common/translation.cpp:2024
+#: ../src/common/translation.cpp:2074
 #, fuzzy
 msgid "Couldn't enumerate translations"
 msgstr "تعذر إنهاء الموضوع"
 
-#: ../src/common/dynlib.cpp:120
+#: ../src/common/dynlib.cpp:110
 #, c-format
 msgid "Couldn't find symbol '%s' in a dynamic library"
 msgstr "تعذر العثور على الرمز '%s' بمكتبة متحركة"
 
-#: ../src/msw/thread.cpp:915
+#: ../src/msw/thread.cpp:921
 msgid "Couldn't get the current thread pointer"
 msgstr ""
 
-#: ../src/osx/carbon/overlay.cpp:129
-msgid "Couldn't init the context on the overlay window"
-msgstr ""
-
-#: ../src/common/imaggif.cpp:244
+#: ../src/common/imaggif.cpp:241
 #, fuzzy
 msgid "Couldn't initialize GIF hash table."
 msgstr "Can't initialize zlib deflate stream."
 
-#: ../src/common/imagpng.cpp:409
+#: ../src/common/imagpng.cpp:437
 msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
 msgstr "تعذر تحميل صورة png-الملف فاسد أو لا توجد ذاكرة تكفي."
 
-#: ../src/unix/sound.cpp:470
+#: ../src/unix/sound.cpp:459
 #, c-format
 msgid "Couldn't load sound data from '%s'."
 msgstr "تعذر تحميل البيانات الصوتية من '%s'"
 
-#: ../src/msw/dirdlg.cpp:435
+#: ../src/msw/dirdlg.cpp:287
 msgid "Couldn't obtain folder name"
 msgstr ""
 
-#: ../src/unix/sound_sdl.cpp:229
+#: ../src/unix/sound_sdl.cpp:226
 #, c-format
 msgid "Couldn't open audio: %s"
 msgstr "تعذر فتح الملف الصوتي: %s"
 
-#: ../src/msw/ole/dataobj.cpp:377
+#: ../src/msw/ole/dataobj.cpp:385
 #, c-format
 msgid "Couldn't register clipboard format '%s'."
 msgstr "تعذر تسجيل تنسق الحافظة '%s'"
 
-#: ../src/msw/listctrl.cpp:869
+#: ../src/msw/listctrl.cpp:933
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr ""
 
-#: ../src/common/imagpng.cpp:498 ../src/common/imagpng.cpp:509
-#: ../src/common/imagpng.cpp:519
+#: ../src/common/imagpng.cpp:511 ../src/common/imagpng.cpp:522
+#: ../src/common/imagpng.cpp:532
 msgid "Couldn't save PNG image."
 msgstr "تعذر حفظ صورة png."
 
-#: ../src/msw/thread.cpp:684
+#: ../src/msw/thread.cpp:676
 msgid "Couldn't terminate thread"
 msgstr "تعذر إنهاء الموضوع"
 
-#: ../src/common/xtistrm.cpp:166
+#: ../src/common/xtistrm.cpp:163
 #, c-format
 msgid "Create Parameter %s not found in declared RTTI Parameters"
 msgstr ""
 
-#: ../src/generic/dirdlgg.cpp:288
+#: ../src/generic/dirdlgg.cpp:285
 msgid "Create directory"
 msgstr "إنشاء مجلد"
 
-#: ../src/generic/filedlgg.cpp:212 ../src/generic/dirdlgg.cpp:111
+#: ../src/generic/filedlgg.cpp:209 ../src/generic/dirdlgg.cpp:108
 msgid "Create new directory"
 msgstr "إنشاء مجلد جديد"
 
-#: ../src/xrc/xmlres.cpp:2460
+#: ../src/common/stockitem.cpp:264
+#, fuzzy
+msgid "Create new document"
+msgstr "إنشاء مجلد جديد"
+
+#: ../src/xrc/xmlres.cpp:2515
 #, fuzzy, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "فشل فك '%s' ب '%s'."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1758
+#: ../src/propgrid/advprops.cpp:1659
 msgid "Cross"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:333
+#: ../src/common/accelcmn.cpp:347
 #, fuzzy
 msgid "Ctrl+"
 msgstr "Ctrl-"
 
-#: ../src/richtext/richtextctrl.cpp:332 ../src/osx/textctrl_osx.cpp:576
-#: ../src/common/stockitem.cpp:151 ../src/msw/textctrl.cpp:2507
+#: ../src/osx/textctrl_osx.cpp:594 ../src/common/stockitem.cpp:148
+#: ../src/msw/textctrl.cpp:2772 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "ق&ص"
 
-#: ../src/generic/filectrlg.cpp:940
+#: ../src/generic/filectrlg.cpp:936
 msgid "Current directory:"
 msgstr "المجلد الحالي:"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:896 ../src/propgrid/advprops.cpp:1574
-#: ../src/propgrid/advprops.cpp:1612
+#: ../src/propgrid/advprops.cpp:797 ../src/propgrid/advprops.cpp:1475
+#: ../src/propgrid/advprops.cpp:1518
 msgid "Custom"
 msgstr ""
 
-#: ../src/gtk/print.cpp:217
+#: ../src/gtk/print.cpp:211
 msgid "Custom size"
 msgstr ""
 
-#: ../src/common/headerctrlcmn.cpp:60
+#: ../src/common/headerctrlcmn.cpp:58
 msgid "Customize Columns"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:151 ../src/stc/stc_i18n.cpp:17
+#: ../src/common/stockitem.cpp:148 ../src/stc/stc_i18n.cpp:17
 #, fuzzy
 msgid "Cut"
 msgstr "ق&ص"
 
-#: ../src/common/stockitem.cpp:259
+#: ../src/common/stockitem.cpp:256
 msgid "Cut selection"
 msgstr "قص التحديد"
 
-#: ../src/common/fmapbase.cpp:152
+#: ../src/common/fmapbase.cpp:149
 msgid "Cyrillic (ISO-8859-5)"
 msgstr ""
 
-#: ../src/common/paper.cpp:99
+#: ../src/common/paper.cpp:96
 msgid "D sheet, 22 x 34 in"
 msgstr ""
 
-#: ../src/msw/dde.cpp:703
+#: ../src/msw/dde.cpp:698
 msgid "DDE poke request failed"
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1169
+#: ../src/common/imagbmp.cpp:1181
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr ""
 
@@ -2657,7 +2661,7 @@ msgstr ""
 msgid "DIB Header: Unknown encoding in file."
 msgstr ""
 
-#: ../src/common/paper.cpp:121
+#: ../src/common/paper.cpp:118
 msgid "DL Envelope, 110 x 220 mm"
 msgstr ""
 
@@ -2665,56 +2669,56 @@ msgstr ""
 msgid "Dashed"
 msgstr ""
 
-#: ../src/generic/dbgrptg.cpp:300
+#: ../src/generic/dbgrptg.cpp:301
 #, c-format
 msgid "Debug report \"%s\""
 msgstr "تقرير خطأ برمجي \"%s\""
 
-#: ../src/common/debugrpt.cpp:210
+#: ../src/common/debugrpt.cpp:211
 msgid "Debug report couldn't be created."
 msgstr "تعذر إنشاء الخطأ البرمجي."
 
-#: ../src/common/debugrpt.cpp:553
+#: ../src/common/debugrpt.cpp:554
 msgid "Debug report generation has failed."
 msgstr "فشل توليد الخطأ البرمجي."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:84
+#: ../src/common/accelcmn.cpp:81
 msgid "Decimal"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:323
+#: ../src/generic/fontdlgg.cpp:319
 msgid "Decorative"
 msgstr "مزخرف"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1752
+#: ../src/propgrid/advprops.cpp:1653
 #, fuzzy
 msgid "Default"
 msgstr "إفتراضي"
 
-#: ../src/common/fmapbase.cpp:796
+#: ../src/common/fmapbase.cpp:792
 msgid "Default encoding"
 msgstr "تشفير افتراضي"
 
-#: ../src/dfb/fontmgr.cpp:180
+#: ../src/dfb/fontmgr.cpp:177
 #, fuzzy
 msgid "Default font"
 msgstr "الطابعة الافتراضية"
 
-#: ../src/generic/prntdlgg.cpp:510
+#: ../src/generic/prntdlgg.cpp:503
 msgid "Default printer"
 msgstr "الطابعة الافتراضية"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:51
+#: ../src/common/accelcmn.cpp:48
 #, fuzzy
 msgid "Del"
 msgstr "حذف"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextbuffer.cpp:8221 ../src/common/stockitem.cpp:152
-#: ../src/common/accelcmn.cpp:50 ../src/stc/stc_i18n.cpp:20
+#: ../src/common/stockitem.cpp:149 ../src/common/accelcmn.cpp:47
+#: ../src/richtext/richtextbuffer.cpp:8217 ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "حذف"
 
@@ -2722,81 +2726,81 @@ msgstr "حذف"
 msgid "Delete A&ll"
 msgstr "حذف ال&كل"
 
-#: ../src/richtext/richtextbuffer.cpp:11341
+#: ../src/richtext/richtextbuffer.cpp:11340
 #, fuzzy
 msgid "Delete Column"
 msgstr "حذف إختيار"
 
-#: ../src/richtext/richtextbuffer.cpp:11291
+#: ../src/richtext/richtextbuffer.cpp:11290
 #, fuzzy
 msgid "Delete Row"
 msgstr "حذف"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 msgid "Delete Style"
 msgstr "حذف الإسلوب"
 
-#: ../src/richtext/richtextctrl.cpp:1345 ../src/richtext/richtextctrl.cpp:1584
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
 msgid "Delete Text"
 msgstr "حذف النص"
 
-#: ../src/generic/editlbox.cpp:170
+#: ../src/generic/editlbox.cpp:147
 msgid "Delete item"
 msgstr "حذف عنصر"
 
-#: ../src/common/stockitem.cpp:260
+#: ../src/common/stockitem.cpp:257
 msgid "Delete selection"
 msgstr "حذف إختيار"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 #, c-format
 msgid "Delete style %s?"
 msgstr "حذف الإسلوب %s?"
 
-#: ../src/unix/snglinst.cpp:301
+#: ../src/unix/snglinst.cpp:298
 #, c-format
 msgid "Deleted stale lock file '%s'."
 msgstr ""
 
-#: ../src/common/secretstore.cpp:220
+#: ../src/common/secretstore.cpp:234
 #, fuzzy, c-format
-msgid "Deleting password for \"%s/%s\" failed: %s."
+msgid "Deleting password for \"%s\" failed: %s."
 msgstr "فشل فك '%s' ب '%s'."
 
-#: ../src/common/module.cpp:124
+#: ../src/common/module.cpp:121
 #, c-format
 msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 #, fuzzy
 msgid "Descending"
 msgstr "تشفير افتراضي"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:526 ../src/propgrid/advprops.cpp:882
+#: ../src/generic/dirctrlg.cpp:492 ../src/propgrid/advprops.cpp:783
 msgid "Desktop"
 msgstr "سطح المكتب"
 
-#: ../src/generic/aboutdlgg.cpp:70
+#: ../src/generic/aboutdlgg.cpp:67
 msgid "Developed by "
 msgstr "تم تطويره بواسطة"
 
-#: ../src/generic/aboutdlgg.cpp:176
+#: ../src/generic/aboutdlgg.cpp:173
 msgid "Developers"
 msgstr "مطورون"
 
-#: ../src/msw/dialup.cpp:374
+#: ../src/msw/dialup.cpp:368
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
 msgstr ""
 
-#: ../src/generic/tipdlg.cpp:211
+#: ../src/generic/tipdlg.cpp:208
 msgid "Did you know..."
 msgstr "هل علمت..."
 
-#: ../src/dfb/wrapdfb.cpp:63
+#: ../src/dfb/wrapdfb.cpp:60
 #, c-format
 msgid "DirectFB error %d occurred."
 msgstr ""
@@ -2805,74 +2809,74 @@ msgstr ""
 msgid "Directories"
 msgstr "مجلدات"
 
-#: ../src/common/filefn.cpp:1183
+#: ../src/common/filefn.cpp:1071
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "تعذر إعادة إنشاء المجلد '%s' لنفسه"
 
-#: ../src/common/filefn.cpp:1197
+#: ../src/common/filefn.cpp:1085
 #, fuzzy, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "تعذر إعادة إنشاء المجلد '%s' لنفسه"
 
-#: ../src/generic/dirdlgg.cpp:204
+#: ../src/generic/dirdlgg.cpp:201
 msgid "Directory does not exist"
 msgstr "المجلد غير موجود"
 
-#: ../src/generic/filectrlg.cpp:1399
+#: ../src/generic/filectrlg.cpp:1388
 msgid "Directory doesn't exist."
 msgstr "المجلد غير موجود"
 
-#: ../src/common/docview.cpp:457
+#: ../src/common/docview.cpp:450
 msgid "Discard changes and reload the last saved version?"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:502
+#: ../src/html/helpwnd.cpp:500
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:679
+#: ../src/html/helpwnd.cpp:677
 msgid "Display options dialog"
 msgstr "عرض محاورة الخيارات"
 
-#: ../src/html/helpwnd.cpp:322
+#: ../src/html/helpwnd.cpp:320
 msgid "Displays help as you browse the books on the left."
 msgstr "يعرض المساعدة أثناء تصفح الكتب على اليسار"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:85
+#: ../src/common/accelcmn.cpp:83
 msgid "Divide"
 msgstr ""
 
-#: ../src/common/docview.cpp:533
+#: ../src/common/docview.cpp:526
 #, fuzzy, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "هل تريد حفظ التغييرات بالملف %s?"
 
-#: ../src/common/prntbase.cpp:542
+#: ../src/common/prntbase.cpp:537
 #, fuzzy
 msgid "Document:"
 msgstr "ملفات المساعدة بواسطة"
 
-#: ../src/generic/aboutdlgg.cpp:73
+#: ../src/generic/aboutdlgg.cpp:70
 msgid "Documentation by "
 msgstr "ملفات المساعدة بواسطة"
 
-#: ../src/generic/aboutdlgg.cpp:180
+#: ../src/generic/aboutdlgg.cpp:177
 msgid "Documentation writers"
 msgstr "كتاب ملفات المساعدة"
 
-#: ../src/common/sizer.cpp:2799
+#: ../src/common/sizer.cpp:2916
 msgid "Don't Save"
 msgstr "لا تحفظ"
 
-#: ../src/html/htmlwin.cpp:633
+#: ../src/html/htmlwin.cpp:643
 msgid "Done"
 msgstr "تم"
 
-#: ../src/generic/progdlgg.cpp:448 ../src/msw/progdlg.cpp:407
+#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
 msgid "Done."
 msgstr "تم."
 
@@ -2884,43 +2888,43 @@ msgstr ""
 msgid "Double"
 msgstr ""
 
-#: ../src/common/paper.cpp:176
+#: ../src/common/paper.cpp:173
 msgid "Double Japanese Postcard Rotated 148 x 200 mm"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:273
+#: ../src/common/xtixml.cpp:269
 #, c-format
 msgid "Doubly used id : %d"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:153
-#: ../src/common/accelcmn.cpp:64
+#: ../src/common/stockitem.cpp:150 ../src/common/accelcmn.cpp:61
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Down"
 msgstr "Down"
 
-#: ../src/richtext/richtextctrl.cpp:865
+#: ../src/richtext/richtextctrl.cpp:864
 msgid "Drag"
 msgstr ""
 
-#: ../src/common/paper.cpp:100
+#: ../src/common/paper.cpp:97
 msgid "E sheet, 34 x 44 in"
 msgstr ""
 
-#: ../src/unix/fswatcher_inotify.cpp:561
+#: ../src/unix/fswatcher_inotify.cpp:558
 msgid "EOF while reading from inotify descriptor"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 #, fuzzy
 msgid "Edit"
 msgstr "&تحرير"
 
-#: ../src/generic/editlbox.cpp:168
+#: ../src/generic/editlbox.cpp:131
 msgid "Edit item"
 msgstr "حرر العنصر"
 
-#: ../include/wx/generic/progdlgg.h:84
+#: ../include/wx/generic/progdlgg.h:85
 #, fuzzy
 msgid "Elapsed time:"
 msgstr "الوقت المنتهي:"
@@ -2992,63 +2996,63 @@ msgid "Enables the shadow spread."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:66
+#: ../src/common/accelcmn.cpp:63
 msgid "End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:55
+#: ../src/common/accelcmn.cpp:52
 #, fuzzy
 msgid "Enter"
 msgstr "طابعة"
 
-#: ../src/richtext/richtextstyledlg.cpp:934
+#: ../src/richtext/richtextstyledlg.cpp:930
 #, fuzzy
 msgid "Enter a box style name"
 msgstr "ادخل اسم إسلوب جديد"
 
-#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:602
 msgid "Enter a character style name"
 msgstr "ادخل اسم إسلوب حرف جديد"
 
-#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:816
 msgid "Enter a list style name"
 msgstr "ادخل اسم إسلوب قائمة جديد"
 
-#: ../src/richtext/richtextstyledlg.cpp:893
+#: ../src/richtext/richtextstyledlg.cpp:889
 msgid "Enter a new style name"
 msgstr "ادخل اسم إسلوب جديد"
 
-#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:650
 msgid "Enter a paragraph style name"
 msgstr "ادخل اسم إسلوب فقرة"
 
-#: ../src/generic/dbgrptg.cpp:174
+#: ../src/generic/dbgrptg.cpp:171
 #, c-format
 msgid "Enter command to open file \"%s\":"
 msgstr ""
 
-#: ../src/generic/helpext.cpp:459
+#: ../src/generic/helpext.cpp:457
 msgid "Entries found"
 msgstr "تم العثور على المدخلات"
 
-#: ../src/common/paper.cpp:142
+#: ../src/common/paper.cpp:139
 msgid "Envelope Invite 220 x 220 mm"
 msgstr ""
 
-#: ../src/common/config.cpp:469
+#: ../src/common/config.cpp:465
 #, c-format
 msgid ""
 "Environment variables expansion failed: missing '%c' at position %u in '%s'."
 msgstr ""
 
-#: ../src/generic/filedlgg.cpp:357 ../src/generic/dirctrlg.cpp:570
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/dirctrlg.cpp:599
-#: ../src/generic/dirdlgg.cpp:323 ../src/generic/filectrlg.cpp:642
-#: ../src/generic/filectrlg.cpp:756 ../src/generic/filectrlg.cpp:770
-#: ../src/generic/filectrlg.cpp:786 ../src/generic/filectrlg.cpp:1368
-#: ../src/generic/filectrlg.cpp:1399 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/gtk1/fontdlg.cpp:74 ../src/generic/dirctrlg.cpp:536
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/dirctrlg.cpp:565
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1357 ../src/generic/filectrlg.cpp:1388
+#: ../src/generic/filedlgg.cpp:354 ../src/generic/dirdlgg.cpp:320
+#: ../src/gtk/filedlg.cpp:74
 msgid "Error"
 msgstr "خطأ"
 
@@ -3057,237 +3061,256 @@ msgstr "خطأ"
 msgid "Error closing epoll descriptor"
 msgstr "خطأ بإنشاء المجلد"
 
-#: ../src/unix/fswatcher_kqueue.cpp:114
+#: ../src/unix/fswatcher_kqueue.cpp:131
 msgid "Error closing kqueue instance"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1049
+#: ../src/common/filefn.cpp:938
 #, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr ""
 
-#: ../src/generic/dirdlgg.cpp:222
+#: ../src/generic/dirdlgg.cpp:219
 msgid "Error creating directory"
 msgstr "خطأ بإنشاء المجلد"
 
-#: ../src/common/imagbmp.cpp:1181
+#: ../src/common/imagbmp.cpp:1193
 msgid "Error in reading image DIB."
 msgstr ""
 
-#: ../src/propgrid/propgrid.cpp:6696
+#: ../src/propgrid/propgrid.cpp:6665
 #, c-format
 msgid "Error in resource: %s"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:422
+#: ../src/common/fileconf.cpp:421
 msgid "Error reading config options."
 msgstr "خطأ بقراءة خيارات الإعدادات."
+
+#: ../src/msw/webview_ie.cpp:1057 ../src/msw/webview_edge.cpp:850
+#: ../src/gtk/webview_webkit2.cpp:1262 ../src/osx/webview_webkit.mm:383
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
 
 #: ../src/common/fileconf.cpp:1029
 msgid "Error saving user configuration data."
 msgstr "خطأ بحفظ بيانات إعدادات المستخدم."
 
-#: ../src/gtk/print.cpp:722
+#: ../src/gtk/print.cpp:720
 msgid "Error while printing: "
 msgstr ""
 
-#: ../src/common/log.cpp:219
+#: ../src/common/log.cpp:237
 msgid "Error: "
 msgstr "خطأ:"
 
+#: ../src/common/webrequest.cpp:98
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "خطأ:"
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:69
+#: ../src/common/accelcmn.cpp:66
 msgid "Esc"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:70
+#: ../src/common/accelcmn.cpp:67
 #, fuzzy
 msgid "Escape"
 msgstr "طولي"
 
-#: ../src/common/fmapbase.cpp:150
+#: ../src/common/fmapbase.cpp:147
 msgid "Esperanto (ISO-8859-3)"
 msgstr ""
 
-#: ../include/wx/generic/progdlgg.h:85
+#: ../include/wx/generic/progdlgg.h:86
 #, fuzzy
 msgid "Estimated time:"
 msgstr "الوقت التقديري:"
 
-#: ../src/generic/dbgrptg.cpp:234
+#: ../src/generic/dbgrptg.cpp:231
 #, fuzzy
 msgid "Executable files (*.exe)|*.exe|"
 msgstr "كل الملفات (*.*)|*.*"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:155 ../src/common/accelcmn.cpp:78
+#: ../src/common/stockitem.cpp:152 ../src/common/accelcmn.cpp:75
 msgid "Execute"
 msgstr ""
 
-#: ../src/msw/utilsexc.cpp:876
+#: ../src/msw/utilsexc.cpp:873
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr ""
 
-#: ../src/common/paper.cpp:105
+#: ../src/common/paper.cpp:102
 msgid "Executive, 7 1/4 x 10 1/2 in"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6009
+#: ../src/generic/datavgen.cpp:6814
 msgid "Expand"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1240
+#: ../src/msw/registry.cpp:1228
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:195
+#: ../src/common/fmapbase.cpp:192
 msgid "Extended Unix Codepage for Japanese (EUC-JP)"
 msgstr ""
 
-#: ../src/html/chm.cpp:725
+#: ../src/html/chm.cpp:718
 #, c-format
 msgid "Extraction of '%s' into '%s' failed."
 msgstr "فشل فك '%s' ب '%s'."
 
-#: ../src/common/accelcmn.cpp:249 ../src/common/accelcmn.cpp:344
+#: ../src/common/accelcmn.cpp:259 ../src/common/accelcmn.cpp:358
 msgid "F"
 msgstr ""
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:672
+#: ../src/propgrid/advprops.cpp:582
 #, fuzzy
 msgid "Face Name"
 msgstr "اسم جديد"
 
-#: ../src/unix/snglinst.cpp:269
+#: ../src/unix/snglinst.cpp:266
 msgid "Failed to access lock file."
 msgstr ""
+
+#: ../src/gtk/font.cpp:572
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "تعذر تحميل المصادر من '%s'."
 
 #: ../src/unix/epolldispatcher.cpp:116
 #, c-format
 msgid "Failed to add descriptor %d to epoll descriptor %d"
 msgstr ""
 
-#: ../src/msw/dib.cpp:489
+#: ../src/msw/dib.cpp:535
 #, c-format
 msgid "Failed to allocate %luKb of memory for bitmap data."
 msgstr ""
 
-#: ../src/common/glcmn.cpp:115
+#: ../src/common/glcmn.cpp:112
 msgid "Failed to allocate colour for OpenGL"
 msgstr ""
 
-#: ../src/unix/displayx11.cpp:236
+#: ../src/common/lzmastream.cpp:231
+msgid "Failed to allocate memory for LZMA compression."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:121
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr ""
+
+#: ../include/wx/unix/private/displayx11.h:89
 msgid "Failed to change video mode"
 msgstr ""
 
-#: ../src/common/image.cpp:3277
+#: ../src/common/image.cpp:3396
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:239
+#: ../src/common/debugrpt.cpp:240
 #, c-format
 msgid "Failed to clean up debug report directory \"%s\""
 msgstr ""
 
-#: ../src/common/filename.cpp:192
+#: ../src/common/filename.cpp:189
 msgid "Failed to close file handle"
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:340
+#: ../src/unix/snglinst.cpp:337
 #, c-format
 msgid "Failed to close lock file '%s'"
 msgstr ""
 
-#: ../src/msw/clipbrd.cpp:112
+#: ../src/msw/clipbrd.cpp:110
 msgid "Failed to close the clipboard."
 msgstr "فشل عند إغلاق الحافظة"
 
-#: ../src/x11/utils.cpp:208
+#: ../src/x11/utils.cpp:170
 #, c-format
 msgid "Failed to close the display \"%s\""
 msgstr ""
 
-#: ../src/msw/dialup.cpp:797
+#: ../src/msw/dialup.cpp:791
 msgid "Failed to connect: missing username/password."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:743
+#: ../src/msw/dialup.cpp:737
 msgid "Failed to connect: no ISP to dial."
 msgstr ""
 
-#: ../src/common/textfile.cpp:203
-#, c-format
-msgid "Failed to convert file \"%s\" to Unicode."
-msgstr ""
-
-#: ../src/generic/logg.cpp:956
+#: ../src/generic/logg.cpp:953
 #, fuzzy
 msgid "Failed to copy dialog contents to the clipboard."
 msgstr "فشل عند إغلاق الحافظة"
 
-#: ../src/msw/registry.cpp:692
+#: ../src/msw/registry.cpp:681
 #, c-format
 msgid "Failed to copy registry value '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:701
+#: ../src/msw/registry.cpp:690
 #, c-format
 msgid "Failed to copy the contents of registry key '%s' to '%s'."
 msgstr ""
 
-#: ../src/common/filefn.cpp:1015
+#: ../src/common/filefn.cpp:904
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:679
+#: ../src/msw/registry.cpp:668
 #, c-format
 msgid "Failed to copy the registry subkey '%s' to '%s'."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1070
+#: ../src/msw/dde.cpp:1134
 msgid "Failed to create DDE string"
 msgstr ""
 
-#: ../src/msw/mdi.cpp:616
+#: ../src/msw/mdi.cpp:621
 msgid "Failed to create MDI parent frame."
 msgstr ""
 
-#: ../src/common/filename.cpp:1027
+#: ../src/common/filename.cpp:1024
 msgid "Failed to create a temporary file name"
 msgstr ""
 
-#: ../src/msw/utilsexc.cpp:228
+#: ../src/msw/utilsexc.cpp:225
 msgid "Failed to create an anonymous pipe"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:522
+#: ../src/msw/ole/automtn.cpp:513
 #, c-format
 msgid "Failed to create an instance of \"%s\""
 msgstr ""
 
-#: ../src/msw/dde.cpp:437
+#: ../src/msw/dde.cpp:432
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr ""
 
-#: ../src/msw/cursor.cpp:204
+#: ../src/msw/cursor.cpp:195
 msgid "Failed to create cursor."
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:209
+#: ../src/common/debugrpt.cpp:210
 #, c-format
 msgid "Failed to create directory \"%s\""
 msgstr ""
 
-#: ../src/generic/dirdlgg.cpp:220
+#: ../src/generic/dirdlgg.cpp:217
 #, c-format
 msgid ""
 "Failed to create directory '%s'\n"
@@ -3299,184 +3322,203 @@ msgstr ""
 msgid "Failed to create epoll descriptor"
 msgstr "فشل عند إغلاق الحافظة"
 
-#: ../src/msw/mimetype.cpp:238
+#: ../src/gtk/font.cpp:562
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "فشل عند إغلاق الحافظة"
+
+#: ../src/msw/mimetype.cpp:235
 #, c-format
 msgid "Failed to create registry entry for '%s' files."
 msgstr ""
 
-#: ../src/msw/fdrepdlg.cpp:409
+#: ../src/msw/fdrepdlg.cpp:408
 #, c-format
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr ""
 
-#: ../src/unix/wakeuppipe.cpp:52
+#: ../src/unix/wakeuppipe.cpp:49
 msgid "Failed to create wake up pipe used by event loop."
 msgstr ""
 
-#: ../src/html/winpars.cpp:730
+#: ../src/html/winpars.cpp:727
 #, c-format
 msgid "Failed to display HTML document in %s encoding"
 msgstr ""
 
-#: ../src/msw/clipbrd.cpp:124
+#: ../src/msw/clipbrd.cpp:122
 msgid "Failed to empty the clipboard."
 msgstr ""
 
-#: ../src/unix/displayx11.cpp:212
+#: ../include/wx/unix/private/displayx11.h:65
 msgid "Failed to enumerate video modes"
 msgstr ""
 
-#: ../src/msw/dde.cpp:722
+#: ../src/msw/dde.cpp:717
 msgid "Failed to establish an advise loop with DDE server"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:629 ../src/msw/dialup.cpp:863
+#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:611
+#: ../src/unix/utilsunx.cpp:613
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:720
+#: ../src/common/debugrpt.cpp:730
 msgid "Failed to execute curl, please install it in PATH."
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:505
+#: ../src/msw/ole/automtn.cpp:496
 #, c-format
 msgid "Failed to find CLSID of \"%s\""
 msgstr ""
 
-#: ../src/common/regex.cpp:431 ../src/common/regex.cpp:479
+#: ../src/common/regex.cpp:428 ../src/common/regex.cpp:476
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:695
+#: ../src/msw/webview_ie.cpp:978
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:689
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:574
+#: ../src/msw/ole/automtn.cpp:565
 #, c-format
 msgid "Failed to get OLE automation interface for \"%s\""
 msgstr ""
 
-#: ../src/msw/clipbrd.cpp:711
+#: ../src/msw/clipbrd.cpp:731
 msgid "Failed to get data from the clipboard"
 msgstr ""
 
-#: ../src/common/time.cpp:223
+#: ../src/common/time.cpp:216
 msgid "Failed to get the local system time"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1345
+#: ../src/common/filefn.cpp:1233
 msgid "Failed to get the working directory"
 msgstr ""
 
-#: ../src/univ/theme.cpp:114
+#: ../src/univ/theme.cpp:111
 msgid "Failed to initialize GUI: no built-in themes found."
 msgstr ""
 
-#: ../src/msw/helpchm.cpp:63
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:60
 msgid "Failed to initialize MS HTML Help."
 msgstr ""
 
-#: ../src/msw/glcanvas.cpp:1381
+#: ../src/msw/glcanvas.cpp:1391
 msgid "Failed to initialize OpenGL"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:858
+#: ../src/msw/dialup.cpp:852
 #, fuzzy, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "تعذر الحصول على محاورة اتصال نشطة: %s"
 
-#: ../src/gtk/textctrl.cpp:1128
+#: ../src/gtk/textctrl.cpp:1209
 msgid "Failed to insert text in the control."
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:241
+#: ../src/unix/snglinst.cpp:238
 #, c-format
 msgid "Failed to inspect the lock file '%s'"
 msgstr ""
 
-#: ../src/unix/appunix.cpp:182
+#: ../src/unix/appunix.cpp:179
 msgid "Failed to install signal handler"
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1167
+#: ../src/unix/threadpsx.cpp:1216
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
 msgstr ""
 
-#: ../src/msw/utils.cpp:629
+#: ../src/msw/utils.cpp:619
 #, c-format
 msgid "Failed to kill process %d"
 msgstr ""
 
-#: ../src/common/image.cpp:2500
+#: ../src/common/image.cpp:2595
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr ""
 
-#: ../src/common/image.cpp:2509
+#: ../src/common/image.cpp:2604
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr ""
 
-#: ../src/common/iconbndl.cpp:225
+#: ../src/common/iconbndl.cpp:224
 #, fuzzy, c-format
 msgid "Failed to load icons from resource '%s'."
 msgstr "تعذر تحميل المصادر من '%s'."
 
-#: ../src/common/iconbndl.cpp:200
+#: ../src/common/iconbndl.cpp:198
 #, fuzzy, c-format
 msgid "Failed to load image %%d from file '%s'."
 msgstr "تعذر تحميل المصادر من '%s'."
 
-#: ../src/common/iconbndl.cpp:208
+#: ../src/common/iconbndl.cpp:206
 #, c-format
 msgid "Failed to load image %d from stream."
 msgstr ""
 
-#: ../src/common/image.cpp:2587 ../src/common/image.cpp:2606
+#: ../src/common/image.cpp:2682 ../src/common/image.cpp:2701
 #, fuzzy, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "تعذر تحميل المصادر من '%s'."
 
-#: ../src/msw/enhmeta.cpp:97
+#: ../src/msw/enhmeta.cpp:94
 #, c-format
 msgid "Failed to load metafile from file \"%s\"."
 msgstr ""
 
-#: ../src/msw/volume.cpp:327
+#: ../src/msw/volume.cpp:335
 msgid "Failed to load mpr.dll."
 msgstr ""
 
-#: ../src/msw/utils.cpp:953
+#: ../src/msw/utils.cpp:943
 #, fuzzy, c-format
 msgid "Failed to load resource \"%s\"."
 msgstr "تعذر تحميل المصادر من '%s'."
 
-#: ../src/common/dynlib.cpp:92
+#: ../src/common/dynlib.cpp:86
 #, c-format
 msgid "Failed to load shared library '%s'"
 msgstr ""
 
-#: ../src/osx/core/sound.cpp:145
+#: ../src/osx/core/sound.cpp:143
 #, fuzzy, c-format
 msgid "Failed to load sound from \"%s\" (error %d)."
 msgstr "تعذر تحميل المصادر من '%s'."
 
-#: ../src/msw/utils.cpp:960
+#: ../src/msw/utils.cpp:950
 #, c-format
 msgid "Failed to lock resource \"%s\"."
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:198
+#: ../src/unix/snglinst.cpp:195
 #, c-format
 msgid "Failed to lock the lock file '%s'"
 msgstr ""
@@ -3486,33 +3528,38 @@ msgstr ""
 msgid "Failed to modify descriptor %d in epoll descriptor %d"
 msgstr ""
 
-#: ../src/common/filename.cpp:2575
+#: ../src/common/filename.cpp:2658
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr ""
 
-#: ../src/common/selectdispatcher.cpp:258
+#: ../src/common/selectdispatcher.cpp:255
 msgid "Failed to monitor I/O channels"
 msgstr ""
 
-#: ../src/common/filename.cpp:175
+#: ../src/common/filename.cpp:172
 #, c-format
 msgid "Failed to open '%s' for reading"
 msgstr ""
 
-#: ../src/common/filename.cpp:180
+#: ../src/common/filename.cpp:177
 #, c-format
 msgid "Failed to open '%s' for writing"
 msgstr ""
 
-#: ../src/html/chm.cpp:141
+#: ../src/html/chm.cpp:138
 #, c-format
 msgid "Failed to open CHM archive '%s'."
 msgstr ""
 
-#: ../src/common/utilscmn.cpp:1126
+#: ../src/common/utilscmn.cpp:1140
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
+msgstr ""
+
+#: ../src/common/hyperlnkcmn.cpp:133
+#, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
 msgstr ""
 
 #: ../include/wx/msw/private/fswatcher.h:92
@@ -3520,209 +3567,227 @@ msgstr ""
 msgid "Failed to open directory \"%s\" for monitoring."
 msgstr ""
 
-#: ../src/x11/utils.cpp:227
+#: ../src/x11/utils.cpp:189
 #, c-format
 msgid "Failed to open display \"%s\"."
 msgstr ""
 
-#: ../src/common/filename.cpp:1062
+#: ../src/common/filename.cpp:1059
 msgid "Failed to open temporary file."
 msgstr ""
 
-#: ../src/msw/clipbrd.cpp:91
+#: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr ""
 
-#: ../src/common/translation.cpp:1184
+#: ../src/common/translation.cpp:1226
 #, fuzzy, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "تعذر تحليل -أشكال- الجمع: '%s'"
 
-#: ../src/unix/mediactrl.cpp:1214
+#: ../src/unix/mediactrl.cpp:1239
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr ""
 
-#: ../src/msw/clipbrd.cpp:600
+#: ../src/msw/clipbrd.cpp:610
 msgid "Failed to put data on the clipboard"
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:278
+#: ../src/unix/snglinst.cpp:275
 msgid "Failed to read PID from lock file."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:433
+#: ../src/common/fileconf.cpp:432
 msgid "Failed to read config options."
 msgstr ""
 
-#: ../src/common/docview.cpp:681
+#: ../src/common/docview.cpp:676
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr ""
 
-#: ../src/dfb/evtloop.cpp:98
+#: ../src/dfb/evtloop.cpp:99
 msgid "Failed to read event from DirectFB pipe"
 msgstr ""
 
-#: ../src/unix/wakeuppipe.cpp:120
+#: ../src/unix/wakeuppipe.cpp:117
 msgid "Failed to read from wake-up pipe"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:679
+#: ../src/common/textfile.cpp:96
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "تعذر تحميل المصادر من '%s'."
+
+#: ../src/unix/utilsunx.cpp:681
 msgid "Failed to redirect child process input/output"
 msgstr ""
 
-#: ../src/msw/utilsexc.cpp:701
+#: ../src/msw/utilsexc.cpp:698
 msgid "Failed to redirect the child process IO"
 msgstr ""
 
-#: ../src/msw/dde.cpp:288
+#: ../src/msw/dde.cpp:283
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr ""
 
-#: ../src/common/fontmap.cpp:245
+#: ../src/gtk/font.cpp:580
+msgid "Failed to register font configuration using private fonts."
+msgstr ""
+
+#: ../src/common/fontmap.cpp:242
 #, c-format
 msgid "Failed to remember the encoding for the charset '%s'."
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:227
+#: ../src/common/debugrpt.cpp:228
 #, c-format
 msgid "Failed to remove debug report file \"%s\""
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:328
+#: ../src/unix/snglinst.cpp:325
 #, c-format
 msgid "Failed to remove lock file '%s'"
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:288
+#: ../src/unix/snglinst.cpp:285
 #, c-format
 msgid "Failed to remove stale lock file '%s'."
 msgstr ""
 
-#: ../src/msw/registry.cpp:529
+#: ../src/msw/registry.cpp:518
 #, c-format
 msgid "Failed to rename registry value '%s' to '%s'."
 msgstr ""
 
-#: ../src/common/filefn.cpp:1122
+#: ../src/common/filefn.cpp:1011
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
 "exists."
 msgstr ""
 
-#: ../src/msw/registry.cpp:634
+#: ../src/msw/registry.cpp:623
 #, c-format
 msgid "Failed to rename the registry key '%s' to '%s'."
 msgstr ""
 
-#: ../src/common/filename.cpp:2671
+#: ../src/msw/webview_ie.cpp:995
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/common/filename.cpp:2754
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:468
+#: ../src/msw/dialup.cpp:462
 msgid "Failed to retrieve text of RAS error message"
 msgstr ""
 
-#: ../src/msw/clipbrd.cpp:748
+#: ../src/msw/clipbrd.cpp:768
 msgid "Failed to retrieve the supported clipboard formats"
 msgstr ""
 
-#: ../src/common/docview.cpp:652
+#: ../src/common/docview.cpp:647
 #, fuzzy, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "تعذر حفظ محتوى التقرير بملف."
 
-#: ../src/msw/dib.cpp:269
+#: ../src/msw/dib.cpp:312
 #, c-format
 msgid "Failed to save the bitmap image to file \"%s\"."
 msgstr ""
 
-#: ../src/msw/dde.cpp:763
+#: ../src/msw/dde.cpp:811
 msgid "Failed to send DDE advise notification"
 msgstr ""
 
-#: ../src/common/ftp.cpp:402
+#: ../src/common/ftp.cpp:399
 #, c-format
 msgid "Failed to set FTP transfer mode to %s."
 msgstr ""
 
-#: ../src/msw/clipbrd.cpp:427
+#: ../src/msw/clipbrd.cpp:443
 msgid "Failed to set clipboard data."
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:181
+#: ../src/unix/snglinst.cpp:178
 #, c-format
 msgid "Failed to set permissions on lock file '%s'"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:668
+#: ../src/unix/utilsunx.cpp:670
 #, fuzzy
 msgid "Failed to set process priority"
 msgstr "فشل عند إغلاق الحافظة"
 
-#: ../src/common/file.cpp:559
+#: ../src/common/ffile.cpp:355 ../src/common/file.cpp:586
 msgid "Failed to set temporary file permissions"
 msgstr ""
 
-#: ../src/gtk/textctrl.cpp:1072
-msgid "Failed to set text in the text control."
-msgstr ""
-
-#: ../src/unix/threadpsx.cpp:1298
+#: ../src/unix/threadpsx.cpp:1347
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1424
+#: ../src/unix/threadpsx.cpp:1473
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:783
+#: ../src/unix/utilsunx.cpp:785
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 
-#: ../src/common/fs_mem.cpp:261
+#: ../src/msw/webview_ie.cpp:987
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:256
 #, c-format
 msgid "Failed to store image '%s' to memory VFS!"
 msgstr ""
 
-#: ../src/dfb/evtloop.cpp:170
+#: ../src/dfb/evtloop.cpp:171
 msgid "Failed to switch DirectFB pipe to non-blocking mode"
 msgstr ""
 
-#: ../src/unix/wakeuppipe.cpp:59
+#: ../src/unix/wakeuppipe.cpp:56
 msgid "Failed to switch wake up pipe to non-blocking mode"
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1605
+#: ../src/unix/threadpsx.cpp:1654
 msgid "Failed to terminate a thread."
 msgstr ""
 
-#: ../src/msw/dde.cpp:741
+#: ../src/msw/dde.cpp:736
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:938
+#: ../src/msw/dialup.cpp:932
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr ""
 
-#: ../src/common/filename.cpp:2590
+#: ../src/common/filename.cpp:2673
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:334
+#: ../src/unix/dlunix.cpp:90
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "فشل عند إغلاق الحافظة"
+
+#: ../src/unix/snglinst.cpp:331
 #, c-format
 msgid "Failed to unlock lock file '%s'"
 msgstr ""
 
-#: ../src/msw/dde.cpp:309
+#: ../src/msw/dde.cpp:304
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr ""
@@ -3736,79 +3801,89 @@ msgstr ""
 msgid "Failed to update user configuration file."
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:733
+#: ../src/common/debugrpt.cpp:743
 #, c-format
 msgid "Failed to upload the debug report (error code %d)."
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:168
+#: ../src/unix/snglinst.cpp:165
 #, c-format
 msgid "Failed to write to lock file '%s'"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:209
+#: ../src/propgrid/propgrid.cpp:190
 #, fuzzy
 msgid "False"
 msgstr "&ملف"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:694
+#: ../src/propgrid/advprops.cpp:604
 #, fuzzy
 msgid "Family"
 msgstr "&عائلة خط:"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/gtk/glcanvas.cpp:176 ../src/gtk/glcanvas.cpp:187
+#, fuzzy
+msgid "Fatal Error"
+msgstr "خطأ فادح"
+
+#: ../src/common/stockitem.cpp:154
 msgid "File"
 msgstr "ملف"
 
-#: ../src/common/docview.cpp:669
+#: ../src/common/docview.cpp:664
 #, fuzzy, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "تعذر تحميل الملف"
 
-#: ../src/common/docview.cpp:646
+#: ../src/common/docview.cpp:641
 #, fuzzy, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "لا يمكن ل wxWidgets فتح الشاشة ل '%s': خروج"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "الملف '%s' موجود بالفعل, هل تريد تخطيه؟"
 
-#: ../src/common/filefn.cpp:1156
+#: ../src/common/filefn.cpp:1044
 #, fuzzy, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "تعذر إعادة إنشاء المجلد '%s' لنفسه"
 
-#: ../src/common/filefn.cpp:1139
+#: ../src/common/filefn.cpp:1028
 #, fuzzy, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "تعذر إعادة إنشاء المجلد '%s' لنفسه"
 
-#: ../src/richtext/richtextctrl.cpp:3081 ../src/common/textcmn.cpp:953
+#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
 msgid "File couldn't be loaded."
 msgstr "تعذر تحميل الملف"
 
-#: ../src/msw/filedlg.cpp:393
+#: ../src/msw/filedlg.cpp:414
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr ""
 
-#: ../src/common/docview.cpp:1789
+#: ../src/common/docview.cpp:1783
 msgid "File error"
 msgstr "خطأ بالملف"
 
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/filectrlg.cpp:770
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/filectrlg.cpp:766
 msgid "File name exists already."
 msgstr "اسم الملف موجود بالفعل."
+
+#: ../src/osx/cocoa/filedlg.mm:264
+#, fuzzy
+msgid "File type:"
+msgstr "خطأ بالملف"
 
 #: ../src/motif/filedlg.cpp:220
 msgid "Files"
 msgstr "ملفات"
 
-#: ../src/common/filefn.cpp:1591
+#: ../src/common/filefn.cpp:1479
 #, c-format
 msgid "Files (%s)"
 msgstr "ملفات (%s)"
@@ -3817,16 +3892,29 @@ msgstr "ملفات (%s)"
 msgid "Filter"
 msgstr "تصفية"
 
-#: ../src/common/stockitem.cpp:158 ../src/html/helpwnd.cpp:490
+#: ../src/html/helpwnd.cpp:488
 msgid "Find"
 msgstr "بحث"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:259
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:258
+msgid "Find in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "Find..."
+msgstr "بحث"
+
+#: ../src/common/stockitem.cpp:156
 #, fuzzy
 msgid "First"
 msgstr "&إنهاء"
 
-#: ../src/common/prntbase.cpp:1548
+#: ../src/common/prntbase.cpp:1573
 #, fuzzy
 msgid "First page"
 msgstr "الصفحة التالية"
@@ -3836,11 +3924,11 @@ msgstr "الصفحة التالية"
 msgid "Fixed"
 msgstr "معالجة الخط:"
 
-#: ../src/html/helpwnd.cpp:1206
+#: ../src/html/helpwnd.cpp:1204
 msgid "Fixed font:"
 msgstr "معالجة الخط:"
 
-#: ../src/html/helpwnd.cpp:1269
+#: ../src/html/helpwnd.cpp:1267
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr ""
 
@@ -3848,17 +3936,17 @@ msgstr ""
 msgid "Floating"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 #, fuzzy
 msgid "Floppy"
 msgstr "نسخ"
 
-#: ../src/common/paper.cpp:111
+#: ../src/common/paper.cpp:108
 msgid "Folio, 8 1/2 x 13 in"
 msgstr ""
 
-#: ../src/richtext/richtextformatdlg.cpp:344 ../src/osx/carbon/fontdlg.cpp:287
-#: ../src/common/stockitem.cpp:194
+#: ../src/osx/carbon/fontdlg.cpp:284 ../src/common/stockitem.cpp:191
+#: ../src/richtext/richtextformatdlg.cpp:337
 msgid "Font"
 msgstr "خط"
 
@@ -3866,7 +3954,24 @@ msgstr "خط"
 msgid "Font &weight:"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1207
+#: ../src/osx/fontutil.cpp:89
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
+"\"."
+msgstr ""
+
+#: ../src/msw/font.cpp:1126
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "تعذر تحميل الملف"
+
+#: ../src/osx/fontutil.cpp:81
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "الملف %s غير موجود."
+
+#: ../src/html/helpwnd.cpp:1205
 msgid "Font size:"
 msgstr "مقاس الخط:"
 
@@ -3874,76 +3979,76 @@ msgstr "مقاس الخط:"
 msgid "Font st&yle:"
 msgstr "نم&ط الخط:"
 
-#: ../src/osx/carbon/fontdlg.cpp:329
+#: ../src/osx/carbon/fontdlg.cpp:326
 msgid "Font:"
 msgstr "خط:"
 
-#: ../src/dfb/fontmgr.cpp:198
+#: ../src/dfb/fontmgr.cpp:195
 #, c-format
 msgid "Fonts index file %s disappeared while loading fonts."
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:645
+#: ../src/unix/utilsunx.cpp:647
 msgid "Fork failed"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 #, fuzzy
 msgid "Forward"
 msgstr "&تقديم"
 
-#: ../src/common/xtixml.cpp:235
+#: ../src/common/xtixml.cpp:231
 msgid "Forward hrefs are not supported"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:875
+#: ../src/html/helpwnd.cpp:873
 #, c-format
 msgid "Found %i matches"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:238
+#: ../src/generic/prntdlgg.cpp:231
 msgid "From:"
 msgstr "من:"
 
-#: ../src/propgrid/advprops.cpp:1604
+#: ../src/propgrid/advprops.cpp:1510
 msgid "Fuchsia"
 msgstr ""
 
-#: ../src/common/imaggif.cpp:138
+#: ../src/common/imaggif.cpp:135
 msgid "GIF: data stream seems to be truncated."
 msgstr ""
 
-#: ../src/common/imaggif.cpp:128
+#: ../src/common/imaggif.cpp:125
 msgid "GIF: error in GIF image format."
 msgstr ""
 
-#: ../src/common/imaggif.cpp:133
+#: ../src/common/imaggif.cpp:130
 msgid "GIF: not enough memory."
 msgstr ""
 
-#: ../src/gtk/window.cpp:4631
+#: ../src/gtk/window.cpp:5635
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
 msgstr ""
 
-#: ../src/univ/themes/gtk.cpp:525
+#: ../src/univ/themes/gtk.cpp:522
 msgid "GTK+ theme"
 msgstr ""
 
-#: ../src/common/preferencescmn.cpp:40
+#: ../src/common/preferencescmn.cpp:37
 msgid "General"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:258
+#: ../src/common/prntbase.cpp:253
 msgid "Generic PostScript"
 msgstr ""
 
-#: ../src/common/paper.cpp:135
+#: ../src/common/paper.cpp:132
 msgid "German Legal Fanfold, 8 1/2 x 13 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:134
+#: ../src/common/paper.cpp:131
 msgid "German Std Fanfold, 8 1/2 x 12 in"
 msgstr ""
 
@@ -3959,48 +4064,48 @@ msgstr ""
 msgid "GetPropertyCollection called w/o valid collection getter"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:658
 msgid "Go back"
 msgstr "رجوع"
 
-#: ../src/html/helpwnd.cpp:661
+#: ../src/html/helpwnd.cpp:659
 msgid "Go forward"
 msgstr "تقدم"
 
-#: ../src/html/helpwnd.cpp:663
+#: ../src/html/helpwnd.cpp:661
 msgid "Go one level up in document hierarchy"
 msgstr "الصعود لمستوى أعلى في ترتيب الوثيقة"
 
-#: ../src/generic/filedlgg.cpp:208 ../src/generic/dirdlgg.cpp:116
+#: ../src/generic/filedlgg.cpp:205 ../src/generic/dirdlgg.cpp:113
 msgid "Go to home directory"
 msgstr "الذهاب للمجلد الرئيسي"
 
-#: ../src/generic/filedlgg.cpp:205
+#: ../src/generic/filedlgg.cpp:202
 msgid "Go to parent directory"
 msgstr "الذهاب للمجلد الحاضن"
 
-#: ../src/generic/aboutdlgg.cpp:76
+#: ../src/generic/aboutdlgg.cpp:73
 msgid "Graphics art by "
 msgstr "فن الرسوم بواسطة"
 
-#: ../src/propgrid/advprops.cpp:1599
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Gray"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:883
+#: ../src/propgrid/advprops.cpp:784
 msgid "GrayText"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:154
+#: ../src/common/fmapbase.cpp:151
 msgid "Greek (ISO-8859-7)"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1600
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Green"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:342
+#: ../src/generic/colrdlgg.cpp:362
 msgid "Green:"
 msgstr ""
 
@@ -4008,108 +4113,108 @@ msgstr ""
 msgid "Groove"
 msgstr ""
 
-#: ../src/common/zstream.cpp:158 ../src/common/zstream.cpp:318
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
 msgid "Gzip not supported by this version of zlib"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1549
+#: ../src/html/helpwnd.cpp:1547
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr ""
 
-#: ../src/html/htmlwin.cpp:681
+#: ../src/html/htmlwin.cpp:691
 #, c-format
 msgid "HTML anchor %s does not exist."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1547
+#: ../src/html/helpwnd.cpp:1545
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1759
+#: ../src/propgrid/advprops.cpp:1660
 msgid "Hand"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "Harddisk"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:155
+#: ../src/common/fmapbase.cpp:152
 msgid "Hebrew (ISO-8859-8)"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:280 ../src/osx/button_osx.cpp:39
-#: ../src/common/stockitem.cpp:163 ../src/common/accelcmn.cpp:80
-#: ../src/html/helpdlg.cpp:66 ../src/html/helpfrm.cpp:111
+#: ../include/wx/msgdlg.h:282 ../src/osx/button_osx.cpp:39
+#: ../src/common/stockitem.cpp:160 ../src/common/accelcmn.cpp:77
+#: ../src/html/helpfrm.cpp:108 ../src/html/helpdlg.cpp:63
 msgid "Help"
 msgstr "مساعدة"
 
-#: ../src/html/helpwnd.cpp:1200
+#: ../src/html/helpwnd.cpp:1198
 msgid "Help Browser Options"
 msgstr "مساعد خيارات المتصفح"
 
-#: ../src/generic/helpext.cpp:454 ../src/generic/helpext.cpp:455
+#: ../src/generic/helpext.cpp:452 ../src/generic/helpext.cpp:453
 msgid "Help Index"
 msgstr "كشاف المساعدة"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1529
 msgid "Help Printing"
 msgstr "مساعدة الطباعة"
 
-#: ../src/html/helpwnd.cpp:801
+#: ../src/html/helpwnd.cpp:799
 msgid "Help Topics"
 msgstr "مواضيع المساعدة"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1546
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr ""
 
-#: ../src/generic/helpext.cpp:267
+#: ../src/generic/helpext.cpp:265
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:275
+#: ../src/generic/helpext.cpp:273
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr ""
 
-#: ../src/html/helpctrl.cpp:63
+#: ../src/html/helpctrl.cpp:59
 #, c-format
 msgid "Help: %s"
 msgstr "مساعدة: %s"
 
-#: ../src/osx/menu_osx.cpp:577
+#: ../src/osx/menu_osx.cpp:469
 #, fuzzy, c-format
 msgid "Hide %s"
 msgstr "&تفاصيل"
 
-#: ../src/osx/menu_osx.cpp:579
+#: ../src/osx/menu_osx.cpp:471
 msgid "Hide Others"
 msgstr ""
 
-#: ../src/generic/infobar.cpp:84
+#: ../src/generic/infobar.cpp:81
 msgid "Hide this notification message."
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:884
+#: ../src/propgrid/advprops.cpp:785
 #, fuzzy
 msgid "Highlight"
 msgstr "فاتح"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:885
+#: ../src/propgrid/advprops.cpp:786
 msgid "HighlightText"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:164 ../src/common/accelcmn.cpp:65
+#: ../src/common/stockitem.cpp:161 ../src/common/accelcmn.cpp:62
 msgid "Home"
 msgstr "رئيسي"
 
-#: ../src/generic/dirctrlg.cpp:524
+#: ../src/generic/dirctrlg.cpp:490
 msgid "Home directory"
 msgstr "مجلد رئيسي"
 
@@ -4119,61 +4224,61 @@ msgid "How the object will float relative to the text."
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1760
+#: ../src/propgrid/advprops.cpp:1661
 msgid "I-Beam"
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1196
+#: ../src/common/imagbmp.cpp:1208
 msgid "ICO: Error in reading mask DIB."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1290 ../src/common/imagbmp.cpp:1390
-#: ../src/common/imagbmp.cpp:1405 ../src/common/imagbmp.cpp:1416
-#: ../src/common/imagbmp.cpp:1430 ../src/common/imagbmp.cpp:1478
-#: ../src/common/imagbmp.cpp:1493 ../src/common/imagbmp.cpp:1507
-#: ../src/common/imagbmp.cpp:1518
+#: ../src/common/imagbmp.cpp:1302 ../src/common/imagbmp.cpp:1402
+#: ../src/common/imagbmp.cpp:1417 ../src/common/imagbmp.cpp:1428
+#: ../src/common/imagbmp.cpp:1442 ../src/common/imagbmp.cpp:1490
+#: ../src/common/imagbmp.cpp:1505 ../src/common/imagbmp.cpp:1519
+#: ../src/common/imagbmp.cpp:1530
 msgid "ICO: Error writing the image file!"
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1255
+#: ../src/common/imagbmp.cpp:1267
 msgid "ICO: Image too tall for an icon."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1263
+#: ../src/common/imagbmp.cpp:1275
 msgid "ICO: Image too wide for an icon."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1603
+#: ../src/common/imagbmp.cpp:1615
 msgid "ICO: Invalid icon index."
 msgstr ""
 
-#: ../src/common/imagiff.cpp:758
+#: ../src/common/imagiff.cpp:755
 msgid "IFF: data stream seems to be truncated."
 msgstr ""
 
-#: ../src/common/imagiff.cpp:742
+#: ../src/common/imagiff.cpp:739
 msgid "IFF: error in IFF image format."
 msgstr ""
 
-#: ../src/common/imagiff.cpp:745
+#: ../src/common/imagiff.cpp:742
 msgid "IFF: not enough memory."
 msgstr ""
 
-#: ../src/common/imagiff.cpp:748
+#: ../src/common/imagiff.cpp:745
 msgid "IFF: unknown error!!!"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:197
+#: ../src/common/fmapbase.cpp:194
 msgid "ISO-2022-JP"
 msgstr ""
 
-#: ../src/html/htmprint.cpp:282
+#: ../src/html/htmprint.cpp:294
 msgid ""
 "If possible, try changing the layout parameters to make the printout more "
 "narrow."
 msgstr ""
 
-#: ../src/generic/dbgrptg.cpp:358
+#: ../src/generic/dbgrptg.cpp:362
 msgid ""
 "If you have any additional information pertaining to this bug\n"
 "report, please enter it here and it will be joined to it:"
@@ -4187,148 +4292,152 @@ msgid ""
 "at all possible please do continue with the report generation.\n"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1405
+#: ../src/common/zipstrm.cpp:1043
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1393
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:295
+#: ../src/common/xtistrm.cpp:292
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr ""
 
-#: ../src/common/xti.cpp:513
+#: ../src/common/xti.cpp:510
 msgid "Illegal Parameter Count for ConstructObject Method"
 msgstr ""
 
-#: ../src/common/xti.cpp:501
+#: ../src/common/xti.cpp:498
 msgid "Illegal Parameter Count for Create Method"
 msgstr ""
 
-#: ../src/generic/dirctrlg.cpp:570 ../src/generic/filectrlg.cpp:756
+#: ../src/generic/dirctrlg.cpp:536 ../src/generic/filectrlg.cpp:752
 msgid "Illegal directory name."
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:1367
+#: ../src/generic/filectrlg.cpp:1356
 msgid "Illegal file specification."
 msgstr ""
 
-#: ../src/common/image.cpp:2269
+#: ../src/common/image.cpp:2363
 msgid "Image and mask have different sizes."
 msgstr ""
 
-#: ../src/common/image.cpp:2746
+#: ../src/common/image.cpp:2841
 #, fuzzy, c-format
 msgid "Image file is not of type %d."
 msgstr "ملف الحركة ليس من نوع %ld."
 
-#: ../src/common/image.cpp:2877
+#: ../src/common/image.cpp:2995
 #, fuzzy, c-format
 msgid "Image is not of type %s."
 msgstr "ملف الحركة ليس من نوع %ld."
 
-#: ../src/msw/textctrl.cpp:488
+#: ../src/msw/textctrl.cpp:534
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:301
+#: ../src/unix/utilsunx.cpp:303
 msgid "Impossible to get child process input"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1028
+#: ../src/common/filefn.cpp:917
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1042
+#: ../src/common/filefn.cpp:931
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1097
+#: ../src/common/filefn.cpp:986
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:886
+#: ../src/propgrid/advprops.cpp:787
 msgid "InactiveBorder"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:887
+#: ../src/propgrid/advprops.cpp:788
 msgid "InactiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:888
+#: ../src/propgrid/advprops.cpp:789
 msgid "InactiveCaptionText"
 msgstr ""
 
-#: ../src/common/gifdecod.cpp:792
+#: ../src/common/gifdecod.cpp:826
 #, c-format
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:635
+#: ../src/msw/ole/automtn.cpp:626
 msgid "Incorrect number of arguments."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:165
+#: ../src/common/stockitem.cpp:162
 msgid "Indent"
 msgstr ""
 
-#: ../src/richtext/richtextformatdlg.cpp:349
+#: ../src/richtext/richtextformatdlg.cpp:342
 msgid "Indents && Spacing"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:166 ../src/html/helpwnd.cpp:515
+#: ../src/common/stockitem.cpp:163 ../src/html/helpwnd.cpp:513
 msgid "Index"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:159
+#: ../src/common/fmapbase.cpp:156
 msgid "Indian (ISO-8859-12)"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "Info"
 msgstr ""
 
-#: ../src/common/init.cpp:287
+#: ../src/common/init.cpp:284
 msgid "Initialization failed in post init, aborting."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:54
+#: ../src/common/accelcmn.cpp:51
 #, fuzzy
 msgid "Ins"
 msgstr "إدراج"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextsymboldlg.cpp:472 ../src/common/accelcmn.cpp:53
+#: ../src/common/accelcmn.cpp:50 ../src/richtext/richtextsymboldlg.cpp:469
 msgid "Insert"
 msgstr "إدراج"
 
-#: ../src/richtext/richtextbuffer.cpp:8067
+#: ../src/richtext/richtextbuffer.cpp:8063
 #, fuzzy
 msgid "Insert Field"
 msgstr "إدراج نص"
 
-#: ../src/richtext/richtextbuffer.cpp:7978
-#: ../src/richtext/richtextbuffer.cpp:8936
+#: ../src/richtext/richtextbuffer.cpp:7974
+#: ../src/richtext/richtextbuffer.cpp:8934
 msgid "Insert Image"
 msgstr "إدراج صورة"
 
-#: ../src/richtext/richtextbuffer.cpp:8025
+#: ../src/richtext/richtextbuffer.cpp:8021
 #, fuzzy
 msgid "Insert Object"
 msgstr "إدراج نص"
 
-#: ../src/richtext/richtextctrl.cpp:1286 ../src/richtext/richtextctrl.cpp:1494
-#: ../src/richtext/richtextbuffer.cpp:7822
-#: ../src/richtext/richtextbuffer.cpp:7852
-#: ../src/richtext/richtextbuffer.cpp:7894
+#: ../src/richtext/richtextbuffer.cpp:7818
+#: ../src/richtext/richtextbuffer.cpp:7848
+#: ../src/richtext/richtextbuffer.cpp:7890
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
 msgid "Insert Text"
 msgstr "إدراج نص"
 
@@ -4342,16 +4451,11 @@ msgstr ""
 msgid "Inset"
 msgstr "إدراج"
 
-#: ../src/gtk/app.cpp:425
-#, c-format
-msgid "Invalid GTK+ command line option, use \"%s --help\""
-msgstr ""
-
-#: ../src/common/imagtiff.cpp:311
+#: ../src/common/imagtiff.cpp:308
 msgid "Invalid TIFF image index."
 msgstr ""
 
-#: ../src/common/appcmn.cpp:273
+#: ../src/common/appcmn.cpp:294
 #, c-format
 msgid "Invalid display mode specification '%s'."
 msgstr ""
@@ -4361,255 +4465,259 @@ msgstr ""
 msgid "Invalid geometry specification '%s'"
 msgstr ""
 
-#: ../src/unix/fswatcher_inotify.cpp:323
+#: ../src/unix/fswatcher_inotify.cpp:320
 #, c-format
 msgid "Invalid inotify event for \"%s\""
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:312
+#: ../src/unix/snglinst.cpp:309
 #, c-format
 msgid "Invalid lock file '%s'."
 msgstr ""
 
-#: ../src/common/translation.cpp:1125
+#: ../src/common/translation.cpp:1167
 #, fuzzy
 msgid "Invalid message catalog."
 msgstr "'%s' ليست رسالة صحيحة بالفهرس."
 
-#: ../src/common/xtistrm.cpp:405 ../src/common/xtistrm.cpp:420
+#: ../src/common/xtistrm.cpp:402 ../src/common/xtistrm.cpp:417
 msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:435
+#: ../src/common/xtistrm.cpp:432
 msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
 msgstr ""
 
-#: ../src/common/regex.cpp:310
+#: ../src/common/regex.cpp:307
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr ""
 
-#: ../src/common/config.cpp:226
+#: ../src/common/config.cpp:222
 #, c-format
 msgid "Invalid value %ld for a boolean key \"%s\" in config file."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:351
-#: ../src/osx/carbon/fontdlg.cpp:361 ../src/common/stockitem.cpp:168
+#: ../src/osx/carbon/fontdlg.cpp:358 ../src/common/stockitem.cpp:165
+#: ../src/generic/fontdlgg.cpp:325 ../src/richtext/richtextfontpage.cpp:351
 msgid "Italic"
 msgstr "مائل"
 
-#: ../src/common/paper.cpp:130
+#: ../src/common/paper.cpp:127
 msgid "Italy Envelope, 110 x 230 mm"
 msgstr ""
 
-#: ../src/common/imagjpeg.cpp:270
+#: ../src/common/imagjpeg.cpp:257
 msgid "JPEG: Couldn't load - file is probably corrupted."
 msgstr ""
 
-#: ../src/common/imagjpeg.cpp:449
+#: ../src/common/imagjpeg.cpp:436
 msgid "JPEG: Couldn't save image."
 msgstr ""
 
-#: ../src/common/paper.cpp:163
+#: ../src/common/paper.cpp:160
 msgid "Japanese Double Postcard 200 x 148 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:167
+#: ../src/common/paper.cpp:164
 msgid "Japanese Envelope Chou #3"
 msgstr ""
 
-#: ../src/common/paper.cpp:180
+#: ../src/common/paper.cpp:177
 msgid "Japanese Envelope Chou #3 Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:168
+#: ../src/common/paper.cpp:165
 msgid "Japanese Envelope Chou #4"
 msgstr ""
 
-#: ../src/common/paper.cpp:181
+#: ../src/common/paper.cpp:178
 msgid "Japanese Envelope Chou #4 Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:165
+#: ../src/common/paper.cpp:162
 msgid "Japanese Envelope Kaku #2"
 msgstr ""
 
-#: ../src/common/paper.cpp:178
+#: ../src/common/paper.cpp:175
 msgid "Japanese Envelope Kaku #2 Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:166
+#: ../src/common/paper.cpp:163
 msgid "Japanese Envelope Kaku #3"
 msgstr ""
 
-#: ../src/common/paper.cpp:179
+#: ../src/common/paper.cpp:176
 msgid "Japanese Envelope Kaku #3 Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:185
+#: ../src/common/paper.cpp:182
 msgid "Japanese Envelope You #4"
 msgstr ""
 
-#: ../src/common/paper.cpp:186
+#: ../src/common/paper.cpp:183
 msgid "Japanese Envelope You #4 Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:138
+#: ../src/common/paper.cpp:135
 msgid "Japanese Postcard 100 x 148 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:175
+#: ../src/common/paper.cpp:172
 msgid "Japanese Postcard Rotated 148 x 100 mm"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "Jump to"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:171
+#: ../src/common/stockitem.cpp:168
 msgid "Justified"
 msgstr "متوسط"
 
-#: ../src/richtext/richtextindentspage.cpp:155
-#: ../src/richtext/richtextindentspage.cpp:157
 #: ../src/richtext/richtextliststylepage.cpp:344
 #: ../src/richtext/richtextliststylepage.cpp:346
+#: ../src/richtext/richtextindentspage.cpp:155
+#: ../src/richtext/richtextindentspage.cpp:157
 msgid "Justify text left and right."
 msgstr "توسط النص يمين ويسار"
 
-#: ../src/common/fmapbase.cpp:163
+#: ../src/common/fmapbase.cpp:160
 msgid "KOI8-R"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:164
+#: ../src/common/fmapbase.cpp:161
 msgid "KOI8-U"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:265 ../src/common/accelcmn.cpp:347
+#: ../src/common/accelcmn.cpp:279 ../src/common/accelcmn.cpp:364
 msgid "KP_"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "KP_Add"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "KP_Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "KP_Decimal"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 #, fuzzy
 msgid "KP_Delete"
 msgstr "حذف"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "KP_Divide"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 #, fuzzy
 msgid "KP_Down"
 msgstr "Down"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "KP_End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 #, fuzzy
 msgid "KP_Enter"
 msgstr "طابعة"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "KP_Equal"
 msgstr ""
 
+#: ../src/common/accelcmn.cpp:276 ../src/common/accelcmn.cpp:361
+msgid "KP_F"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 #, fuzzy
 msgid "KP_Home"
 msgstr "رئيسي"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 #, fuzzy
 msgid "KP_Insert"
 msgstr "إدراج"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 #, fuzzy
 msgid "KP_Left"
 msgstr "يسار"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "KP_Multiply"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:99
+#: ../src/common/accelcmn.cpp:97
 #, fuzzy
 msgid "KP_Next"
 msgstr "التالي"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "KP_PageDown"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "KP_PageUp"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:98
+#: ../src/common/accelcmn.cpp:96
 msgid "KP_Prior"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 #, fuzzy
 msgid "KP_Right"
 msgstr "يمين"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "KP_Separator"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "KP_Space"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "KP_Subtract"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "KP_Tab"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "KP_Up"
 msgstr ""
 
@@ -4617,21 +4725,36 @@ msgstr ""
 msgid "L&ine spacing:"
 msgstr "مسافة السط&ر"
 
-#: ../src/generic/prntdlgg.cpp:613 ../src/generic/prntdlgg.cpp:868
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:280
+#, c-format
+msgid "LZMA compression error: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:196
+#, c-format
+msgid "LZMA decompression error: %s"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:861
 msgid "Landscape"
 msgstr "طولي"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 #, fuzzy
 msgid "Last"
 msgstr "&لصق"
 
-#: ../src/common/prntbase.cpp:1572
+#: ../src/common/prntbase.cpp:1597
 #, fuzzy
 msgid "Last page"
 msgstr "الصفحة التالية"
 
-#: ../src/common/log.cpp:305
+#: ../src/common/log.cpp:324
 #, c-format
 msgid "Last repeated message (\"%s\", %u time) wasn't output"
 msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
@@ -4639,93 +4762,93 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: ../src/common/paper.cpp:103
+#: ../src/common/paper.cpp:100
 msgid "Ledger, 17 x 11 in"
 msgstr ""
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6146
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:58 ../src/generic/datavgen.cpp:6951
+#: ../src/richtext/richtextsizepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:252
 #: ../src/richtext/richtextliststylepage.cpp:253
 #: ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
-#: ../src/richtext/richtextsizepage.cpp:249 ../src/common/accelcmn.cpp:61
 msgid "Left"
 msgstr "يسار"
 
-#: ../src/richtext/richtextindentspage.cpp:204
 #: ../src/richtext/richtextliststylepage.cpp:390
+#: ../src/richtext/richtextindentspage.cpp:204
 msgid "Left (&first line):"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1761
+#: ../src/propgrid/advprops.cpp:1662
 msgid "Left Button"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:880
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Left margin (mm):"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:141
-#: ../src/richtext/richtextindentspage.cpp:143
 #: ../src/richtext/richtextliststylepage.cpp:330
 #: ../src/richtext/richtextliststylepage.cpp:332
+#: ../src/richtext/richtextindentspage.cpp:141
+#: ../src/richtext/richtextindentspage.cpp:143
 msgid "Left-align text."
 msgstr ""
 
-#: ../src/common/paper.cpp:144
+#: ../src/common/paper.cpp:141
 msgid "Legal Extra 9 1/2 x 15 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:96
+#: ../src/common/paper.cpp:93
 msgid "Legal, 8 1/2 x 14 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:143
+#: ../src/common/paper.cpp:140
 msgid "Letter Extra 9 1/2 x 12 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:149
+#: ../src/common/paper.cpp:146
 msgid "Letter Extra Transverse 9.275 x 12 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:152
+#: ../src/common/paper.cpp:149
 msgid "Letter Plus 8 1/2 x 12.69 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:169
+#: ../src/common/paper.cpp:166
 msgid "Letter Rotated 11 x 8 1/2 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:101
+#: ../src/common/paper.cpp:98
 msgid "Letter Small, 8 1/2 x 11 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:147
+#: ../src/common/paper.cpp:144
 msgid "Letter Transverse 8 1/2 x 11 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:95
+#: ../src/common/paper.cpp:92
 msgid "Letter, 8 1/2 x 11 in"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "License"
 msgstr "ترخيص"
 
-#: ../src/generic/fontdlgg.cpp:332
+#: ../src/generic/fontdlgg.cpp:328
 msgid "Light"
 msgstr "فاتح"
 
-#: ../src/propgrid/advprops.cpp:1608
+#: ../src/propgrid/advprops.cpp:1514
 msgid "Lime"
 msgstr ""
 
-#: ../src/generic/helpext.cpp:294
+#: ../src/generic/helpext.cpp:292
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr ""
@@ -4734,15 +4857,15 @@ msgstr ""
 msgid "Line spacing:"
 msgstr "مسافة السطر:"
 
-#: ../src/html/chm.cpp:838
+#: ../src/html/chm.cpp:829
 msgid "Link contained '//', converted to absolute link."
 msgstr ""
 
-#: ../src/richtext/richtextformatdlg.cpp:364
+#: ../src/richtext/richtextformatdlg.cpp:357
 msgid "List Style"
 msgstr "إسلوب القائمة"
 
-#: ../src/richtext/richtextstyles.cpp:1064
+#: ../src/richtext/richtextstyles.cpp:1061
 msgid "List styles"
 msgstr "أساليب القائمة"
 
@@ -4756,26 +4879,26 @@ msgstr "قوائم أحجام الخط بالدرجات"
 msgid "Lists the available fonts."
 msgstr "قوائم الخطوط المتاحة"
 
-#: ../src/common/fldlgcmn.cpp:340
+#: ../src/common/fldlgcmn.cpp:337
 #, c-format
 msgid "Load %s file"
 msgstr ""
 
-#: ../src/html/htmlwin.cpp:597
+#: ../src/html/htmlwin.cpp:600
 msgid "Loading : "
 msgstr "تحميل:"
 
-#: ../src/unix/snglinst.cpp:246
+#: ../src/unix/snglinst.cpp:243
 #, c-format
 msgid "Lock file '%s' has incorrect owner."
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:251
+#: ../src/unix/snglinst.cpp:248
 #, c-format
 msgid "Lock file '%s' has incorrect permissions."
 msgstr ""
 
-#: ../src/generic/logg.cpp:576
+#: ../src/generic/logg.cpp:573
 #, c-format
 msgid "Log saved to the file '%s'."
 msgstr ""
@@ -4790,203 +4913,203 @@ msgstr "أحرف صغيرة"
 msgid "Lower case roman numerals"
 msgstr ""
 
-#: ../src/gtk/mdi.cpp:422 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk1/mdi.cpp:431 ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr ""
 
-#: ../src/msw/helpchm.cpp:56
+#: ../src/msw/helpchm.cpp:53
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
 msgstr ""
 
-#: ../src/univ/themes/win32.cpp:3754
+#: ../src/univ/themes/win32.cpp:3751
 msgid "Ma&ximize"
 msgstr "ت&كبير"
 
-#: ../src/common/fmapbase.cpp:203
+#: ../src/common/fmapbase.cpp:200
 #, fuzzy
 msgid "MacArabic"
 msgstr "عربي"
 
-#: ../src/common/fmapbase.cpp:222
+#: ../src/common/fmapbase.cpp:219
 msgid "MacArmenian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:211
+#: ../src/common/fmapbase.cpp:208
 msgid "MacBengali"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:217
+#: ../src/common/fmapbase.cpp:214
 msgid "MacBurmese"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:236
+#: ../src/common/fmapbase.cpp:233
 msgid "MacCeltic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:227
+#: ../src/common/fmapbase.cpp:224
 msgid "MacCentralEurRoman"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:223
+#: ../src/common/fmapbase.cpp:220
 msgid "MacChineseSimp"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:201
+#: ../src/common/fmapbase.cpp:198
 msgid "MacChineseTrad"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:233
+#: ../src/common/fmapbase.cpp:230
 msgid "MacCroatian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:206
+#: ../src/common/fmapbase.cpp:203
 msgid "MacCyrillic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:207
+#: ../src/common/fmapbase.cpp:204
 msgid "MacDevanagari"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:231
+#: ../src/common/fmapbase.cpp:228
 msgid "MacDingbats"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:226
+#: ../src/common/fmapbase.cpp:223
 msgid "MacEthiopic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:229
+#: ../src/common/fmapbase.cpp:226
 #, fuzzy
 msgid "MacExtArabic"
 msgstr "عربي"
 
-#: ../src/common/fmapbase.cpp:237
+#: ../src/common/fmapbase.cpp:234
 msgid "MacGaelic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:221
+#: ../src/common/fmapbase.cpp:218
 msgid "MacGeorgian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:205
+#: ../src/common/fmapbase.cpp:202
 msgid "MacGreek"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:209
+#: ../src/common/fmapbase.cpp:206
 msgid "MacGujarati"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:208
+#: ../src/common/fmapbase.cpp:205
 msgid "MacGurmukhi"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:204
+#: ../src/common/fmapbase.cpp:201
 msgid "MacHebrew"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:234
+#: ../src/common/fmapbase.cpp:231
 msgid "MacIcelandic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:200
+#: ../src/common/fmapbase.cpp:197
 msgid "MacJapanese"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:214
+#: ../src/common/fmapbase.cpp:211
 msgid "MacKannada"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:238
+#: ../src/common/fmapbase.cpp:235
 msgid "MacKeyboardGlyphs"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:218
+#: ../src/common/fmapbase.cpp:215
 msgid "MacKhmer"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:202
+#: ../src/common/fmapbase.cpp:199
 msgid "MacKorean"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:220
+#: ../src/common/fmapbase.cpp:217
 msgid "MacLaotian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:215
+#: ../src/common/fmapbase.cpp:212
 msgid "MacMalayalam"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:225
+#: ../src/common/fmapbase.cpp:222
 msgid "MacMongolian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:210
+#: ../src/common/fmapbase.cpp:207
 msgid "MacOriya"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:199
+#: ../src/common/fmapbase.cpp:196
 msgid "MacRoman"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:235
+#: ../src/common/fmapbase.cpp:232
 msgid "MacRomanian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:216
+#: ../src/common/fmapbase.cpp:213
 msgid "MacSinhalese"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:230
+#: ../src/common/fmapbase.cpp:227
 #, fuzzy
 msgid "MacSymbol"
 msgstr "&رمز:"
 
-#: ../src/common/fmapbase.cpp:212
+#: ../src/common/fmapbase.cpp:209
 msgid "MacTamil"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:213
+#: ../src/common/fmapbase.cpp:210
 msgid "MacTelugu"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:219
+#: ../src/common/fmapbase.cpp:216
 msgid "MacThai"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:224
+#: ../src/common/fmapbase.cpp:221
 msgid "MacTibetan"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:232
+#: ../src/common/fmapbase.cpp:229
 msgid "MacTurkish"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:228
+#: ../src/common/fmapbase.cpp:225
 msgid "MacVietnamese"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1762
+#: ../src/propgrid/advprops.cpp:1663
 msgid "Magnifier"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:2143
+#: ../src/propgrid/advprops.cpp:2050
 #, fuzzy
 msgid "Make a selection:"
 msgstr "حذف إختيار"
 
-#: ../src/richtext/richtextformatdlg.cpp:374
+#: ../src/richtext/richtextformatdlg.cpp:367
 #: ../src/richtext/richtextmarginspage.cpp:171
 msgid "Margins"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1595
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Maroon"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:147
+#: ../src/generic/fdrepdlg.cpp:144
 msgid "Match case"
 msgstr "توافق الحالة"
 
@@ -4999,41 +5122,41 @@ msgstr "&وزن:"
 msgid "Max width:"
 msgstr ""
 
-#: ../src/unix/mediactrl.cpp:947
+#: ../src/unix/mediactrl.cpp:972
 #, c-format
 msgid "Media playback error: %s"
 msgstr ""
 
-#: ../src/common/fs_mem.cpp:175
+#: ../src/common/fs_mem.cpp:170
 #, c-format
 msgid "Memory VFS already contains file '%s'!"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
 #. TRANSLATORS: Keyword of system colour
-#: ../src/common/accelcmn.cpp:73 ../src/propgrid/advprops.cpp:889
+#: ../src/common/accelcmn.cpp:70 ../src/propgrid/advprops.cpp:790
 msgid "Menu"
 msgstr "قائمة"
 
-#: ../src/common/msgout.cpp:124
+#: ../src/common/msgout.cpp:121
 #, fuzzy
 msgid "Message"
 msgstr "%s رسالة"
 
-#: ../src/univ/themes/metal.cpp:168
+#: ../src/univ/themes/metal.cpp:165
 msgid "Metal theme"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:652
+#: ../src/msw/ole/automtn.cpp:643
 msgid "Method or property not found."
 msgstr ""
 
-#: ../src/univ/themes/win32.cpp:3752
+#: ../src/univ/themes/win32.cpp:3749
 msgid "Mi&nimize"
 msgstr "ت&صغير"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1763
+#: ../src/propgrid/advprops.cpp:1664
 msgid "Middle Button"
 msgstr ""
 
@@ -5046,36 +5169,41 @@ msgstr "محاذاة لليمين"
 msgid "Min width:"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:668
+#: ../src/osx/cocoa/menu.mm:281
+#, fuzzy
+msgid "Minimize"
+msgstr "ت&صغير"
+
+#: ../src/msw/ole/automtn.cpp:659
 msgid "Missing a required parameter."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:324
+#: ../src/generic/fontdlgg.cpp:320
 msgid "Modern"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:427
+#: ../src/generic/filectrlg.cpp:423
 msgid "Modified"
 msgstr "معدل"
 
-#: ../src/common/module.cpp:133
+#: ../src/common/module.cpp:130
 #, c-format
 msgid "Module \"%s\" initialization failed"
 msgstr ""
 
-#: ../src/common/paper.cpp:131
+#: ../src/common/paper.cpp:128
 msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
 msgstr ""
 
-#: ../src/msw/fswatcher.cpp:143
+#: ../src/msw/fswatcher.cpp:140
 msgid "Monitoring individual files for changes is not supported currently."
 msgstr ""
 
-#: ../src/generic/editlbox.cpp:172
+#: ../src/generic/editlbox.cpp:160
 msgid "Move down"
 msgstr "الحركة لأسفل"
 
-#: ../src/generic/editlbox.cpp:171
+#: ../src/generic/editlbox.cpp:155
 msgid "Move up"
 msgstr "الحركة لأعلى"
 
@@ -5089,101 +5217,106 @@ msgstr ""
 msgid "Moves the object to the previous paragraph."
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9966
+#: ../src/richtext/richtextbuffer.cpp:9963
 #, fuzzy
 msgid "Multiple Cell Properties"
 msgstr "خيارات الطباعة"
 
-#: ../src/generic/filectrlg.cpp:424
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:82
+msgid "Multiply"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:420
 msgid "Name"
 msgstr "اسم"
 
-#: ../src/propgrid/advprops.cpp:1596
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Navy"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 #, fuzzy
 msgid "Network"
 msgstr "&جديد"
 
-#: ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173
 #, fuzzy
 msgid "New"
 msgstr "&جديد"
 
-#: ../src/richtext/richtextstyledlg.cpp:243
+#: ../src/richtext/richtextstyledlg.cpp:239
 #, fuzzy
 msgid "New &Box Style..."
 msgstr "نمط جديد"
 
-#: ../src/richtext/richtextstyledlg.cpp:225
+#: ../src/richtext/richtextstyledlg.cpp:221
 msgid "New &Character Style..."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:237
+#: ../src/richtext/richtextstyledlg.cpp:233
 msgid "New &List Style..."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:231
+#: ../src/richtext/richtextstyledlg.cpp:227
 msgid "New &Paragraph Style..."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:606
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:654
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:820
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:893
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:934
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:602
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:650
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:816
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:889
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:930
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "New Style"
 msgstr "نمط جديد"
 
-#: ../src/generic/editlbox.cpp:169
+#: ../src/generic/editlbox.cpp:139
 msgid "New item"
 msgstr "عنصر جديد"
 
-#: ../src/generic/dirdlgg.cpp:297 ../src/generic/dirdlgg.cpp:307
-#: ../src/generic/filectrlg.cpp:618 ../src/generic/filectrlg.cpp:627
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+#: ../src/generic/dirdlgg.cpp:294 ../src/generic/dirdlgg.cpp:304
 msgid "NewName"
 msgstr "اسم جديد"
 
-#: ../src/common/prntbase.cpp:1567 ../src/html/helpwnd.cpp:665
+#: ../src/common/prntbase.cpp:1592 ../src/html/helpwnd.cpp:663
 msgid "Next page"
 msgstr "الصفحة التالية"
 
-#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:177
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:174
 #: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "لا"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1764
+#: ../src/propgrid/advprops.cpp:1665
 msgid "No Entry"
 msgstr ""
 
-#: ../src/generic/animateg.cpp:150
+#: ../src/generic/animateg.cpp:133
 #, c-format
 msgid "No animation handler for type %ld defined."
 msgstr ""
 
-#: ../src/dfb/bitmap.cpp:642 ../src/dfb/bitmap.cpp:676
+#: ../src/dfb/bitmap.cpp:639 ../src/dfb/bitmap.cpp:673
 #, c-format
 msgid "No bitmap handler for type %d defined."
 msgstr ""
 
-#: ../src/common/utilscmn.cpp:1077
+#: ../src/common/utilscmn.cpp:1095
 msgid "No default application configured for HTML files."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:445
+#: ../src/generic/helpext.cpp:443
 msgid "No entries found."
 msgstr ""
 
-#: ../src/common/fontmap.cpp:421
+#: ../src/common/fontmap.cpp:418
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found,\n"
@@ -5192,7 +5325,7 @@ msgid ""
 "one)?"
 msgstr ""
 
-#: ../src/common/fontmap.cpp:426
+#: ../src/common/fontmap.cpp:423
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found.\n"
@@ -5200,207 +5333,207 @@ msgid ""
 "(otherwise the text in this encoding will not be shown correctly)?"
 msgstr ""
 
-#: ../src/generic/animateg.cpp:142
+#: ../src/generic/animateg.cpp:125
 msgid "No handler found for animation type."
 msgstr ""
 
-#: ../src/common/image.cpp:2728
+#: ../src/common/image.cpp:2823
 msgid "No handler found for image type."
 msgstr ""
 
-#: ../src/common/image.cpp:2736 ../src/common/image.cpp:2848
-#: ../src/common/image.cpp:2901
+#: ../src/common/image.cpp:2831 ../src/common/image.cpp:2954
+#: ../src/common/image.cpp:3020
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr ""
 
-#: ../src/common/image.cpp:2871 ../src/common/image.cpp:2915
+#: ../src/common/image.cpp:2986 ../src/common/image.cpp:3034
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:858
+#: ../src/html/helpwnd.cpp:856
 msgid "No matching page found yet"
 msgstr ""
 
-#: ../src/unix/sound.cpp:81
+#: ../src/unix/sound.cpp:78
 msgid "No sound"
 msgstr "بلا صوت"
 
-#: ../src/common/image.cpp:2277 ../src/common/image.cpp:2318
+#: ../src/common/image.cpp:2371 ../src/common/image.cpp:2412
 msgid "No unused colour in image being masked."
 msgstr ""
 
-#: ../src/common/image.cpp:3374
-msgid "No unused colour in image."
-msgstr ""
-
-#: ../src/generic/helpext.cpp:302
+#: ../src/generic/helpext.cpp:300
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr ""
 
-#: ../src/richtext/richtextborderspage.cpp:610
 #: ../src/richtext/richtextsizepage.cpp:248
 #: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:610
 #, fuzzy
 msgid "None"
 msgstr "(لاشئ)"
 
-#: ../src/common/fmapbase.cpp:157
+#: ../src/common/fmapbase.cpp:154
 msgid "Nordic (ISO-8859-10)"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:328 ../src/generic/fontdlgg.cpp:331
+#: ../src/generic/fontdlgg.cpp:324 ../src/generic/fontdlgg.cpp:327
 msgid "Normal"
 msgstr "عادي"
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1261
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1205
+#: ../src/html/helpwnd.cpp:1203
 msgid "Normal font:"
 msgstr ""
 
-#: ../src/propgrid/props.cpp:1128
+#: ../src/propgrid/props.cpp:1115
 #, fuzzy, c-format
 msgid "Not %s"
 msgstr "&ملحوظات:"
 
-#: ../include/wx/filename.h:573 ../include/wx/filename.h:578
-msgid "Not available"
+#: ../src/common/secretstore.cpp:168
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/webrequest.cpp:605
+msgid "Not enough free disk space for download."
 msgstr ""
 
 #: ../src/richtext/richtextfontpage.cpp:358
 msgid "Not underlined"
 msgstr ""
 
-#: ../src/common/paper.cpp:115
+#: ../src/common/paper.cpp:112
 msgid "Note, 8 1/2 x 11 in"
 msgstr ""
 
-#: ../src/generic/notifmsgg.cpp:132
+#: ../src/generic/notifmsgg.cpp:129
 msgid "Notice"
 msgstr "ملحوظة"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "Num *"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "Num +"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "Num ,"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "Num -"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "Num ."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "Num /"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "Num ="
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "Num Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 #, fuzzy
 msgid "Num Delete"
 msgstr "حذف"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 #, fuzzy
 msgid "Num Down"
 msgstr "Down"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "Num End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "Num Enter"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 #, fuzzy
 msgid "Num Home"
 msgstr "رئيسي"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 #, fuzzy
 msgid "Num Insert"
 msgstr "إدراج"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num Lock"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "Num Page Down"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "Num Page Up"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 #, fuzzy
 msgid "Num Right"
 msgstr "يمين"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "Num Space"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "Num Tab"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "Num Up"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "Num left"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num_lock"
 msgstr ""
 
@@ -5409,13 +5542,13 @@ msgstr ""
 msgid "Numbered outline"
 msgstr ""
 
-#: ../include/wx/msgdlg.h:278 ../src/richtext/richtextstyledlg.cpp:297
-#: ../src/common/stockitem.cpp:178 ../src/msw/msgdlg.cpp:454
-#: ../src/msw/msgdlg.cpp:747 ../src/gtk1/fontdlg.cpp:138
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:175
+#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/msgdlg.cpp:741 ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "موافق"
 
-#: ../src/msw/ole/automtn.cpp:692
+#: ../src/msw/ole/automtn.cpp:683
 #, c-format
 msgid "OLE Automation error in %s: %s"
 msgstr ""
@@ -5425,15 +5558,15 @@ msgstr ""
 msgid "Object Properties"
 msgstr "خيارات الطباعة"
 
-#: ../src/msw/ole/automtn.cpp:660
+#: ../src/msw/ole/automtn.cpp:651
 msgid "Object implementation does not support named arguments."
 msgstr ""
 
-#: ../src/common/xtixml.cpp:264
+#: ../src/common/xtixml.cpp:260
 msgid "Objects must have an id attribute"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1601
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Olive"
 msgstr ""
 
@@ -5441,65 +5574,69 @@ msgstr ""
 msgid "Opaci&ty:"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:354
+#: ../src/generic/colrdlgg.cpp:374
 msgid "Opacity:"
 msgstr ""
 
-#: ../src/common/docview.cpp:1773 ../src/common/docview.cpp:1815
+#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
 msgid "Open File"
 msgstr "فتح ملف"
 
-#: ../src/html/helpwnd.cpp:671 ../src/html/helpwnd.cpp:1554
+#: ../src/html/helpwnd.cpp:669 ../src/html/helpwnd.cpp:1552
 msgid "Open HTML document"
 msgstr ""
 
-#: ../src/generic/dbgrptg.cpp:163
+#: ../src/common/stockitem.cpp:265
+msgid "Open an existing document"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:160
 #, c-format
 msgid "Open file \"%s\""
 msgstr ""
 
-#: ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176
 #, fuzzy
 msgid "Open..."
 msgstr "&فتح..."
 
-#: ../src/unix/glx11.cpp:506 ../src/msw/glcanvas.cpp:592
+#: ../src/msw/glcanvas.cpp:607 ../src/unix/glx11.cpp:513
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr ""
 
-#: ../src/generic/dirctrlg.cpp:599 ../src/generic/dirdlgg.cpp:323
-#: ../src/generic/filectrlg.cpp:642 ../src/generic/filectrlg.cpp:786
+#: ../src/generic/dirctrlg.cpp:565 ../src/generic/filectrlg.cpp:638
+#: ../src/generic/filectrlg.cpp:782 ../src/generic/dirdlgg.cpp:320
 msgid "Operation not permitted."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:900
+#: ../src/common/cmdline.cpp:896
 #, fuzzy, c-format
 msgid "Option '%s' can't be negated"
 msgstr "تعذر إعادة إنشاء المجلد '%s' لنفسه"
 
-#: ../src/common/cmdline.cpp:1064
+#: ../src/common/cmdline.cpp:1060
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1147
+#: ../src/common/cmdline.cpp:1143
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:618
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "خيارات"
 
-#: ../src/propgrid/advprops.cpp:1606
+#: ../src/propgrid/advprops.cpp:1512
 msgid "Orange"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:615 ../src/generic/prntdlgg.cpp:869
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:862
 msgid "Orientation"
 msgstr ""
 
-#: ../src/common/windowid.cpp:242
+#: ../src/common/windowid.cpp:237
 msgid "Out of window IDs.  Recommend shutting down application."
 msgstr ""
 
@@ -5513,148 +5650,148 @@ msgstr "&مستوى التخطيط:"
 msgid "Outset"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:656
+#: ../src/msw/ole/automtn.cpp:647
 msgid "Overflow while coercing argument values."
 msgstr ""
 
-#: ../src/common/imagpcx.cpp:457 ../src/common/imagpcx.cpp:480
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:479
 msgid "PCX: couldn't allocate memory"
 msgstr ""
 
-#: ../src/common/imagpcx.cpp:456
+#: ../src/common/imagpcx.cpp:455
 msgid "PCX: image format unsupported"
 msgstr ""
 
-#: ../src/common/imagpcx.cpp:479
+#: ../src/common/imagpcx.cpp:478
 msgid "PCX: invalid image"
 msgstr ""
 
-#: ../src/common/imagpcx.cpp:442
+#: ../src/common/imagpcx.cpp:441
 msgid "PCX: this is not a PCX file."
 msgstr ""
 
-#: ../src/common/imagpcx.cpp:459 ../src/common/imagpcx.cpp:481
+#: ../src/common/imagpcx.cpp:458 ../src/common/imagpcx.cpp:480
 msgid "PCX: unknown error !!!"
 msgstr ""
 
-#: ../src/common/imagpcx.cpp:458
+#: ../src/common/imagpcx.cpp:457
 msgid "PCX: version number too low"
 msgstr ""
 
-#: ../src/common/imagpnm.cpp:91
+#: ../src/common/imagpnm.cpp:89
 msgid "PNM: Couldn't allocate memory."
 msgstr ""
 
-#: ../src/common/imagpnm.cpp:73
+#: ../src/common/imagpnm.cpp:71
 msgid "PNM: File format is not recognized."
 msgstr ""
 
-#: ../src/common/imagpnm.cpp:112 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
 #: ../src/common/imagpnm.cpp:156
 msgid "PNM: File seems truncated."
 msgstr ""
 
-#: ../src/common/paper.cpp:187
+#: ../src/common/paper.cpp:184
 msgid "PRC 16K 146 x 215 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:200
+#: ../src/common/paper.cpp:197
 msgid "PRC 16K Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:188
+#: ../src/common/paper.cpp:185
 msgid "PRC 32K 97 x 151 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:201
+#: ../src/common/paper.cpp:198
 msgid "PRC 32K Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:189
+#: ../src/common/paper.cpp:186
 msgid "PRC 32K(Big) 97 x 151 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:202
+#: ../src/common/paper.cpp:199
 msgid "PRC 32K(Big) Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:190
+#: ../src/common/paper.cpp:187
 msgid "PRC Envelope #1 102 x 165 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:203
+#: ../src/common/paper.cpp:200
 msgid "PRC Envelope #1 Rotated 165 x 102 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:199
+#: ../src/common/paper.cpp:196
 msgid "PRC Envelope #10 324 x 458 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:212
+#: ../src/common/paper.cpp:209
 msgid "PRC Envelope #10 Rotated 458 x 324 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:191
+#: ../src/common/paper.cpp:188
 msgid "PRC Envelope #2 102 x 176 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:204
+#: ../src/common/paper.cpp:201
 msgid "PRC Envelope #2 Rotated 176 x 102 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:192
+#: ../src/common/paper.cpp:189
 msgid "PRC Envelope #3 125 x 176 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:205
+#: ../src/common/paper.cpp:202
 msgid "PRC Envelope #3 Rotated 176 x 125 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:193
+#: ../src/common/paper.cpp:190
 msgid "PRC Envelope #4 110 x 208 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:206
+#: ../src/common/paper.cpp:203
 msgid "PRC Envelope #4 Rotated 208 x 110 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:194
+#: ../src/common/paper.cpp:191
 msgid "PRC Envelope #5 110 x 220 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:207
+#: ../src/common/paper.cpp:204
 msgid "PRC Envelope #5 Rotated 220 x 110 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:195
+#: ../src/common/paper.cpp:192
 msgid "PRC Envelope #6 120 x 230 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:208
+#: ../src/common/paper.cpp:205
 msgid "PRC Envelope #6 Rotated 230 x 120 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:196
+#: ../src/common/paper.cpp:193
 msgid "PRC Envelope #7 160 x 230 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:209
+#: ../src/common/paper.cpp:206
 msgid "PRC Envelope #7 Rotated 230 x 160 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:197
+#: ../src/common/paper.cpp:194
 msgid "PRC Envelope #8 120 x 309 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:210
+#: ../src/common/paper.cpp:207
 msgid "PRC Envelope #8 Rotated 309 x 120 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:198
+#: ../src/common/paper.cpp:195
 msgid "PRC Envelope #9 229 x 324 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:211
+#: ../src/common/paper.cpp:208
 msgid "PRC Envelope #9 Rotated 324 x 229 mm"
 msgstr ""
 
@@ -5662,91 +5799,95 @@ msgstr ""
 msgid "Padding"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:2074
+#: ../src/common/prntbase.cpp:2096
 #, c-format
 msgid "Page %d"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:2072
+#: ../src/common/prntbase.cpp:2094
 #, c-format
 msgid "Page %d of %d"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 #, fuzzy
 msgid "Page Down"
 msgstr "Down"
 
-#: ../src/gtk/print.cpp:826
+#: ../src/gtk/print.cpp:829
 msgid "Page Setup"
 msgstr "إعدادات الصفحة"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 #, fuzzy
 msgid "Page Up"
 msgstr "إعدادات الصفحة"
 
-#: ../src/generic/prntdlgg.cpp:828 ../src/common/prntbase.cpp:484
+#: ../src/common/prntbase.cpp:479 ../src/generic/prntdlgg.cpp:821
 msgid "Page setup"
 msgstr "إعدادات الصفحة"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 #, fuzzy
 msgid "PageDown"
 msgstr "Down"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 #, fuzzy
 msgid "PageUp"
 msgstr "صفحات"
 
-#: ../src/generic/prntdlgg.cpp:216
+#: ../src/generic/prntdlgg.cpp:209
 msgid "Pages"
 msgstr "صفحات"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1765
+#: ../src/propgrid/advprops.cpp:1666
 msgid "Paint Brush"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:602 ../src/generic/prntdlgg.cpp:801
-#: ../src/generic/prntdlgg.cpp:842 ../src/generic/prntdlgg.cpp:855
-#: ../src/generic/prntdlgg.cpp:1052 ../src/generic/prntdlgg.cpp:1057
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:794
+#: ../src/generic/prntdlgg.cpp:835 ../src/generic/prntdlgg.cpp:848
+#: ../src/generic/prntdlgg.cpp:1045 ../src/generic/prntdlgg.cpp:1050
 msgid "Paper size"
 msgstr "حجم الورقة"
 
-#: ../src/richtext/richtextstyles.cpp:1062
+#: ../src/richtext/richtextstyles.cpp:1059
 msgid "Paragraph styles"
 msgstr "أساليب الفقرة"
 
-#: ../src/common/xtistrm.cpp:465
+#: ../src/common/xtistrm.cpp:462
 msgid "Passing a already registered object to SetObject"
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:476
+#: ../src/common/xtistrm.cpp:473
 msgid "Passing an unknown object to GetObject"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:3513 ../src/common/stockitem.cpp:180
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:177 ../src/richtext/richtextctrl.cpp:3514
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "لصق"
 
-#: ../src/common/stockitem.cpp:262
+#: ../src/common/stockitem.cpp:260
 msgid "Paste selection"
 msgstr "لصق التحديد"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:74
+#: ../src/common/accelcmn.cpp:71
 msgid "Pause"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1766
+#: ../src/propgrid/advprops.cpp:1667
 msgid "Pencil"
 msgstr ""
 
@@ -5755,21 +5896,21 @@ msgstr ""
 msgid "Peri&od"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:430
+#: ../src/generic/filectrlg.cpp:426
 msgid "Permissions"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:60
+#: ../src/common/accelcmn.cpp:57
 msgid "PgDn"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:59
+#: ../src/common/accelcmn.cpp:56
 msgid "PgUp"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:12868
+#: ../src/richtext/richtextbuffer.cpp:12863
 #, fuzzy
 msgid "Picture Properties"
 msgstr "خيارات الطباعة"
@@ -5782,45 +5923,45 @@ msgstr ""
 msgid "Please choose a valid font."
 msgstr ""
 
-#: ../src/generic/filedlgg.cpp:357 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
 msgid "Please choose an existing file."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:800
+#: ../src/html/helpwnd.cpp:798
 msgid "Please choose the page to display:"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:764
+#: ../src/msw/dialup.cpp:758
 msgid "Please choose which ISP do you want to connect to"
 msgstr ""
 
-#: ../src/common/headerctrlcmn.cpp:59
+#: ../src/common/headerctrlcmn.cpp:57
 msgid "Please select the columns to show and define their order:"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:538
+#: ../src/common/prntbase.cpp:533
 msgid "Please wait while printing..."
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1767
+#: ../src/propgrid/advprops.cpp:1668
 #, fuzzy
 msgid "Point Left"
 msgstr "مقاس الخط:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1768
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgid "Point Right"
 msgstr "محاذاة لليمين"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:662
+#: ../src/propgrid/advprops.cpp:572
 #, fuzzy
 msgid "Point Size"
 msgstr "مقاس الخط:"
 
-#: ../src/generic/prntdlgg.cpp:612 ../src/generic/prntdlgg.cpp:867
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:860
 msgid "Portrait"
 msgstr "عرضي"
 
@@ -5829,267 +5970,275 @@ msgstr "عرضي"
 msgid "Position"
 msgstr "سؤال"
 
-#: ../src/generic/prntdlgg.cpp:298
+#: ../src/generic/prntdlgg.cpp:291
 msgid "PostScript file"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178 ../src/osx/cocoa/preferences.mm:303
 #, fuzzy
 msgid "Preferences"
 msgstr "&التفضيلات"
 
-#: ../src/osx/menu_osx.cpp:568
+#: ../src/osx/menu_osx.cpp:460
 #, fuzzy
 msgid "Preferences..."
 msgstr "&التفضيلات"
 
-#: ../src/common/prntbase.cpp:546
+#: ../src/common/prntbase.cpp:541
 msgid "Preparing"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:455 ../src/osx/carbon/fontdlg.cpp:390
-#: ../src/html/helpwnd.cpp:1222
+#: ../src/osx/carbon/fontdlg.cpp:387 ../src/generic/fontdlgg.cpp:452
+#: ../src/html/helpwnd.cpp:1220
 msgid "Preview:"
 msgstr "معاينة:"
 
-#: ../src/common/prntbase.cpp:1553 ../src/html/helpwnd.cpp:664
+#: ../src/common/prntbase.cpp:1578 ../src/html/helpwnd.cpp:662
 msgid "Previous page"
 msgstr "الصفحة السابقة"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/prntdlgg.cpp:143 ../src/generic/prntdlgg.cpp:157
-#: ../src/common/prntbase.cpp:426 ../src/common/prntbase.cpp:1541
-#: ../src/common/accelcmn.cpp:77 ../src/gtk/print.cpp:620
-#: ../src/gtk/print.cpp:638
+#: ../src/common/prntbase.cpp:421 ../src/common/prntbase.cpp:1566
+#: ../src/common/accelcmn.cpp:74 ../src/generic/prntdlgg.cpp:136
+#: ../src/generic/prntdlgg.cpp:150 ../src/gtk/print.cpp:616
+#: ../src/gtk/print.cpp:634
 msgid "Print"
 msgstr "طبع"
 
-#: ../include/wx/prntbase.h:399 ../src/common/docview.cpp:1268
+#: ../src/common/docview.cpp:1262
 msgid "Print Preview"
 msgstr "معاينة الطباعة"
 
-#: ../src/common/prntbase.cpp:2015 ../src/common/prntbase.cpp:2057
-#: ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2037 ../src/common/prntbase.cpp:2079
+#: ../src/common/prntbase.cpp:2087
 msgid "Print Preview Failure"
 msgstr "فشل معاينة الطباعة"
 
-#: ../src/generic/prntdlgg.cpp:224
+#: ../src/generic/prntdlgg.cpp:217
 msgid "Print Range"
 msgstr "ترتيب الطباعة"
 
-#: ../src/generic/prntdlgg.cpp:449
+#: ../src/generic/prntdlgg.cpp:442
 msgid "Print Setup"
 msgstr "إعدادات الطباعة"
 
-#: ../src/generic/prntdlgg.cpp:621
+#: ../src/generic/prntdlgg.cpp:614
 msgid "Print in colour"
 msgstr "طبع اللون"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/osx/webview_webkit.mm:260
+msgid "Print operation could not be initialized"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:179
 #, fuzzy
 msgid "Print previe&w..."
 msgstr "معاينة الطبا&عة"
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1256
 #, fuzzy
 msgid "Print preview creation failed."
 msgstr "فشل معاينة الطباعة"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/common/stockitem.cpp:179
 #, fuzzy
 msgid "Print preview..."
 msgstr "معاينة الطباعة"
 
-#: ../src/generic/prntdlgg.cpp:630
+#: ../src/generic/prntdlgg.cpp:623
 msgid "Print spooling"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:675
+#: ../src/html/helpwnd.cpp:673
 msgid "Print this page"
 msgstr "إطبع هذه الصفحة"
 
-#: ../src/generic/prntdlgg.cpp:185
+#: ../src/generic/prntdlgg.cpp:178
 msgid "Print to File"
 msgstr "إطبع لملف"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 #, fuzzy
 msgid "Print..."
 msgstr "&طباعة..."
 
-#: ../src/generic/prntdlgg.cpp:493
+#: ../src/generic/prntdlgg.cpp:486
 msgid "Printer"
 msgstr "طابعة"
 
-#: ../src/generic/prntdlgg.cpp:633
+#: ../src/generic/prntdlgg.cpp:626
 msgid "Printer command:"
 msgstr "أمر الطباعة:"
 
-#: ../src/generic/prntdlgg.cpp:180
+#: ../src/generic/prntdlgg.cpp:173
 msgid "Printer options"
 msgstr "خيارات الطباعة"
 
-#: ../src/generic/prntdlgg.cpp:645
+#: ../src/generic/prntdlgg.cpp:638
 msgid "Printer options:"
 msgstr "خيارات الطباعة:"
 
-#: ../src/generic/prntdlgg.cpp:916
+#: ../src/generic/prntdlgg.cpp:909
 msgid "Printer..."
 msgstr "طابعة..."
 
-#: ../src/generic/prntdlgg.cpp:196
+#: ../src/generic/prntdlgg.cpp:189
 msgid "Printer:"
 msgstr "طابعة:"
 
-#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:535
-#: ../src/html/htmprint.cpp:277
+#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:530
+#: ../src/html/htmprint.cpp:289
 #, fuzzy
 msgid "Printing"
 msgstr "طبع"
 
-#: ../src/common/prntbase.cpp:612
+#: ../src/common/prntbase.cpp:607
 msgid "Printing "
 msgstr "طبع"
 
-#: ../src/common/prntbase.cpp:347
+#: ../src/common/prntbase.cpp:342
 msgid "Printing Error"
 msgstr "خطأ في الطباعة"
 
-#: ../src/common/prntbase.cpp:565
+#: ../src/osx/webview_webkit.mm:251
+msgid "Printing is not supported by the system web control"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:560
 #, fuzzy, c-format
 msgid "Printing page %d"
 msgstr "طبع"
 
-#: ../src/common/prntbase.cpp:570
+#: ../src/common/prntbase.cpp:565
 #, c-format
 msgid "Printing page %d of %d"
 msgstr ""
 
-#: ../src/generic/printps.cpp:201
+#: ../src/generic/printps.cpp:182
 #, c-format
 msgid "Printing page %d..."
 msgstr ""
 
-#: ../src/generic/printps.cpp:161
+#: ../src/generic/printps.cpp:142
 msgid "Printing..."
 msgstr "طبع..."
 
-#: ../include/wx/richtext/richtextprint.h:109 ../include/wx/prntbase.h:267
-#: ../src/common/docview.cpp:2132
+#: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
+#: ../src/common/docview.cpp:2137
 #, fuzzy
 msgid "Printout"
 msgstr "طابعة"
 
-#: ../src/common/debugrpt.cpp:560
+#: ../src/common/debugrpt.cpp:561
 #, c-format
 msgid ""
 "Processing debug report has failed, leaving the files in \"%s\" directory."
 msgstr ""
 
-#: ../src/common/prntbase.cpp:545
+#: ../src/common/prntbase.cpp:540
 msgid "Progress:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181
 #, fuzzy
 msgid "Properties"
 msgstr "&الخصائص"
 
-#: ../src/propgrid/manager.cpp:237
+#: ../src/propgrid/manager.cpp:223
 #, fuzzy
 msgid "Property"
 msgstr "&الخصائص"
 
 #. TRANSLATORS: Caption of message box displaying any property error
-#: ../src/propgrid/propgrid.cpp:3185 ../src/propgrid/propgrid.cpp:3318
+#: ../src/propgrid/propgrid.cpp:3162 ../src/propgrid/propgrid.cpp:3299
 #, fuzzy
 msgid "Property Error"
 msgstr "خطأ في الطباعة"
 
-#: ../src/propgrid/advprops.cpp:1597
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Purple"
 msgstr ""
 
-#: ../src/common/paper.cpp:112
+#: ../src/common/paper.cpp:109
 msgid "Quarto, 215 x 275 mm"
 msgstr ""
 
-#: ../src/generic/logg.cpp:1016
+#: ../src/generic/logg.cpp:1013
 msgid "Question"
 msgstr "سؤال"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1769
+#: ../src/propgrid/advprops.cpp:1670
 #, fuzzy
 msgid "Question Arrow"
 msgstr "سؤال"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 #, fuzzy
 msgid "Quit"
 msgstr "&إنهاء"
 
-#: ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:477
 #, fuzzy, c-format
 msgid "Quit %s"
 msgstr "&إنهاء"
 
-#: ../src/common/stockitem.cpp:263
+#: ../src/common/stockitem.cpp:261
 msgid "Quit this program"
 msgstr "إنهاء البرنامج"
 
-#: ../src/common/accelcmn.cpp:338
+#: ../src/common/accelcmn.cpp:352
 #, fuzzy
 msgid "RawCtrl+"
 msgstr "Ctrl-"
 
-#: ../src/common/ffile.cpp:109 ../src/common/ffile.cpp:133
+#: ../src/common/ffile.cpp:107 ../src/common/ffile.cpp:132
 #, c-format
 msgid "Read error on file '%s'"
 msgstr ""
 
-#: ../src/common/secretstore.cpp:199
+#: ../src/common/secretstore.cpp:211
 #, fuzzy, c-format
-msgid "Reading password for \"%s/%s\" failed: %s."
+msgid "Reading password for \"%s\" failed: %s."
 msgstr "فشل فك '%s' ب '%s'."
 
-#: ../src/common/prntbase.cpp:272
+#: ../src/common/prntbase.cpp:267
 msgid "Ready"
 msgstr "جاهز"
 
-#: ../src/propgrid/advprops.cpp:1605
+#: ../src/propgrid/advprops.cpp:1511
 #, fuzzy
 msgid "Red"
 msgstr "&تكرار الفعل"
 
-#: ../src/generic/colrdlgg.cpp:339
+#: ../src/generic/colrdlgg.cpp:359
 msgid "Red:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:185 ../src/stc/stc_i18n.cpp:16
+#: ../src/common/stockitem.cpp:182 ../src/stc/stc_i18n.cpp:16
 #, fuzzy
 msgid "Redo"
 msgstr "&تكرار الفعل"
 
-#: ../src/common/stockitem.cpp:264
+#: ../src/common/stockitem.cpp:262
 msgid "Redo last action"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:186
+#: ../src/common/stockitem.cpp:183
 msgid "Refresh"
 msgstr "تنشيط"
 
-#: ../src/msw/registry.cpp:626
+#: ../src/msw/registry.cpp:615
 #, c-format
 msgid "Registry key '%s' already exists."
 msgstr ""
 
-#: ../src/msw/registry.cpp:595
+#: ../src/msw/registry.cpp:584
 #, c-format
 msgid "Registry key '%s' does not exist, cannot rename it."
 msgstr ""
 
-#: ../src/msw/registry.cpp:727
+#: ../src/msw/registry.cpp:716
 #, c-format
 msgid ""
 "Registry key '%s' is needed for normal system operation,\n"
@@ -6097,22 +6246,22 @@ msgid ""
 "operation aborted."
 msgstr ""
 
-#: ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:942
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:917
+#: ../src/msw/registry.cpp:905
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1003
+#: ../src/msw/registry.cpp:991
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:521
+#: ../src/msw/registry.cpp:510
 #, c-format
 msgid "Registry value '%s' already exists."
 msgstr ""
@@ -6127,72 +6276,78 @@ msgstr "منتظم"
 msgid "Relative"
 msgstr "مزخرف"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:456
 msgid "Relevant entries:"
 msgstr "مدخلات متقاربة:"
 
-#: ../include/wx/generic/progdlgg.h:86
+#: ../include/wx/generic/progdlgg.h:87
 #, fuzzy
 msgid "Remaining time:"
 msgstr "الوقت المتبقي:"
 
-#: ../src/common/stockitem.cpp:187
+#: ../src/common/stockitem.cpp:184
 msgid "Remove"
 msgstr "إزالة"
 
-#: ../src/richtext/richtextctrl.cpp:1562
+#: ../src/richtext/richtextctrl.cpp:1563
 #, fuzzy
 msgid "Remove Bullet"
 msgstr "إزالة"
 
-#: ../src/html/helpwnd.cpp:433
+#: ../src/html/helpwnd.cpp:431
 msgid "Remove current page from bookmarks"
 msgstr "إزالة الصفحة الحالية من الإشارات المرجعية"
 
-#: ../src/common/rendcmn.cpp:194
+#: ../src/common/rendcmn.cpp:191
 #, c-format
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:4527
+#: ../src/richtext/richtextbuffer.cpp:4524
 msgid "Renumber List"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:188
-msgid "Rep&lace"
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Rep&lace..."
 msgstr "است&بدال"
 
-#: ../src/richtext/richtextctrl.cpp:3673 ../src/common/stockitem.cpp:188
+#: ../src/richtext/richtextctrl.cpp:3674
 msgid "Replace"
 msgstr "استبدال"
 
-#: ../src/generic/fdrepdlg.cpp:182
+#: ../src/generic/fdrepdlg.cpp:179
 msgid "Replace &all"
 msgstr "استبدال ال&كل"
 
-#: ../src/common/stockitem.cpp:261
-msgid "Replace selection"
-msgstr "استبدال التحديد"
-
-#: ../src/generic/fdrepdlg.cpp:124
+#: ../src/generic/fdrepdlg.cpp:121
 msgid "Replace with:"
 msgstr "استبدال ب:"
 
-#: ../src/common/valtext.cpp:163
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Replace..."
+msgstr "استبدال"
+
+#: ../src/common/valtext.cpp:184
 msgid "Required information entry is empty."
 msgstr ""
 
-#: ../src/common/translation.cpp:1975
+#: ../src/common/translation.cpp:2025
 #, fuzzy, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "'%s' ليست رسالة صحيحة بالفهرس."
 
+#: ../src/gtk/webview_webkit.cpp:985
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:56
+#: ../src/common/accelcmn.cpp:53
 msgid "Return"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:189
+#: ../src/common/stockitem.cpp:186
 msgid "Revert to Saved"
 msgstr ""
 
@@ -6205,42 +6360,42 @@ msgstr "يمين"
 msgid "Rig&ht-to-left"
 msgstr ""
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6149
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:59 ../src/generic/datavgen.cpp:6954
+#: ../src/richtext/richtextsizepage.cpp:250
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextbulletspage.cpp:188
-#: ../src/richtext/richtextsizepage.cpp:250 ../src/common/accelcmn.cpp:62
 msgid "Right"
 msgstr "يمين"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1754
+#: ../src/propgrid/advprops.cpp:1655
 #, fuzzy
 msgid "Right Arrow"
 msgstr "يمين"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1770
+#: ../src/propgrid/advprops.cpp:1671
 msgid "Right Button"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:892
+#: ../src/generic/prntdlgg.cpp:885
 msgid "Right margin (mm):"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:148
-#: ../src/richtext/richtextindentspage.cpp:150
 #: ../src/richtext/richtextliststylepage.cpp:337
 #: ../src/richtext/richtextliststylepage.cpp:339
+#: ../src/richtext/richtextindentspage.cpp:148
+#: ../src/richtext/richtextindentspage.cpp:150
 msgid "Right-align text."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:322
+#: ../src/generic/fontdlgg.cpp:318
 msgid "Roman"
 msgstr ""
 
-#: ../src/generic/datavgen.cpp:5916
+#: ../src/generic/datavgen.cpp:6721
 #, c-format
 msgid "Row %i"
 msgstr ""
@@ -6250,31 +6405,32 @@ msgstr ""
 msgid "S&tandard bullet name:"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:268 ../src/common/accelcmn.cpp:350
+#: ../src/common/accelcmn.cpp:282 ../src/common/accelcmn.cpp:367
 msgid "SPECIAL"
 msgstr "خاص"
 
-#: ../src/common/stockitem.cpp:190 ../src/common/sizer.cpp:2797
+#: ../src/common/stockitem.cpp:187 ../src/common/sizer.cpp:2914
 msgid "Save"
 msgstr "حفظ"
 
-#: ../src/common/fldlgcmn.cpp:342
+#: ../src/common/fldlgcmn.cpp:339
 #, c-format
 msgid "Save %s file"
 msgstr "حفظ %s ملف"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/common/stockitem.cpp:188 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "حفظ با&سم..."
 
-#: ../src/common/docview.cpp:366
+#: ../src/common/docview.cpp:359
 #, fuzzy
 msgid "Save As"
 msgstr "حفظ باسم"
 
-#: ../src/common/stockitem.cpp:191
-msgid "Save as"
-msgstr "حفظ باسم"
+#: ../src/common/stockitem.cpp:188
+#, fuzzy
+msgid "Save As..."
+msgstr "حفظ با&سم..."
 
 #: ../src/common/stockitem.cpp:267
 msgid "Save current document"
@@ -6284,96 +6440,96 @@ msgstr "حفظ الوثيقة الحالية"
 msgid "Save current document with a different filename"
 msgstr "حفظ الوثيقة الحالية باسم مختلف"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/generic/logg.cpp:509
 msgid "Save log contents to file"
 msgstr ""
 
-#: ../src/common/secretstore.cpp:179
+#: ../src/common/secretstore.cpp:189
 #, fuzzy, c-format
-msgid "Saving password for \"%s/%s\" failed: %s."
+msgid "Saving password for \"%s\" failed: %s."
 msgstr "فشل فك '%s' ب '%s'."
 
-#: ../src/generic/fontdlgg.cpp:325
+#: ../src/generic/fontdlgg.cpp:321
 msgid "Script"
 msgstr "ملحق برمجي"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll Lock"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll_lock"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:890
+#: ../src/propgrid/advprops.cpp:791
 msgid "Scrollbar"
 msgstr ""
 
-#: ../src/generic/srchctlg.cpp:56 ../src/html/helpwnd.cpp:535
-#: ../src/html/helpwnd.cpp:550
+#: ../src/generic/srchctlg.cpp:55 ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:548 ../src/gtk/srchctrl.cpp:182
 msgid "Search"
 msgstr "بحث"
 
-#: ../src/html/helpwnd.cpp:537
+#: ../src/html/helpwnd.cpp:535
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:160
+#: ../src/generic/fdrepdlg.cpp:157
 msgid "Search direction"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:112
+#: ../src/generic/fdrepdlg.cpp:109
 msgid "Search for:"
 msgstr "بحث عن:"
 
-#: ../src/html/helpwnd.cpp:1052
+#: ../src/html/helpwnd.cpp:1050
 msgid "Search in all books"
 msgstr "بحث في كل الكتب"
 
-#: ../src/html/helpwnd.cpp:857
+#: ../src/html/helpwnd.cpp:855
 msgid "Searching..."
 msgstr "جاري البحث..."
 
-#: ../src/generic/dirctrlg.cpp:446
+#: ../src/generic/dirctrlg.cpp:412
 msgid "Sections"
 msgstr "أقسام"
 
-#: ../src/common/ffile.cpp:238
+#: ../src/common/ffile.cpp:237
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr ""
 
-#: ../src/common/ffile.cpp:228
+#: ../src/common/ffile.cpp:227
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:76
+#: ../src/common/accelcmn.cpp:73
 #, fuzzy
 msgid "Select"
 msgstr "تحديد"
 
-#: ../src/richtext/richtextctrl.cpp:337 ../src/osx/textctrl_osx.cpp:581
-#: ../src/common/stockitem.cpp:192 ../src/msw/textctrl.cpp:2512
+#: ../src/osx/textctrl_osx.cpp:599 ../src/common/stockitem.cpp:189
+#: ../src/msw/textctrl.cpp:2777 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "تحديد ال&كل"
 
-#: ../src/common/stockitem.cpp:192 ../src/stc/stc_i18n.cpp:21
+#: ../src/common/stockitem.cpp:189 ../src/stc/stc_i18n.cpp:21
 #, fuzzy
 msgid "Select All"
 msgstr "تحديد ال&كل"
 
-#: ../src/common/docview.cpp:1895
+#: ../src/common/docview.cpp:1900
 msgid "Select a document template"
 msgstr ""
 
-#: ../src/common/docview.cpp:1969
+#: ../src/common/docview.cpp:1974
 msgid "Select a document view"
 msgstr ""
 
@@ -6402,20 +6558,20 @@ msgid "Selects the list level to edit."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:82
+#: ../src/common/accelcmn.cpp:79
 msgid "Separator"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1083
+#: ../src/common/cmdline.cpp:1079
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:572
+#: ../src/osx/menu_osx.cpp:464
 msgid "Services"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11217
+#: ../src/richtext/richtextbuffer.cpp:11216
 #, fuzzy
 msgid "Set Cell Style"
 msgstr "تغيير نمط"
@@ -6424,11 +6580,11 @@ msgstr "تغيير نمط"
 msgid "SetProperty called w/o valid setter"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:188
+#: ../src/generic/prntdlgg.cpp:181
 msgid "Setup..."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:544
+#: ../src/msw/dialup.cpp:538
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr ""
 
@@ -6445,42 +6601,42 @@ msgstr ""
 msgid "Shadow c&olour:"
 msgstr "اختر اللون"
 
-#: ../src/common/accelcmn.cpp:335
+#: ../src/common/accelcmn.cpp:349
 #, fuzzy
 msgid "Shift+"
 msgstr "Shift-"
 
-#: ../src/generic/dirdlgg.cpp:147
+#: ../src/generic/dirdlgg.cpp:144
 msgid "Show &hidden directories"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:983
+#: ../src/generic/filectrlg.cpp:979
 msgid "Show &hidden files"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:580
+#: ../src/osx/menu_osx.cpp:472
 #, fuzzy
 msgid "Show All"
 msgstr "عرض الكل"
 
-#: ../src/common/stockitem.cpp:257
+#: ../src/common/stockitem.cpp:254
 msgid "Show about dialog"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:492
+#: ../src/html/helpwnd.cpp:490
 msgid "Show all"
 msgstr "عرض الكل"
 
-#: ../src/html/helpwnd.cpp:503
+#: ../src/html/helpwnd.cpp:501
 msgid "Show all items in index"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:656
 msgid "Show/hide navigation panel"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:421
-#: ../src/richtext/richtextsymboldlg.cpp:423
+#: ../src/richtext/richtextsymboldlg.cpp:418
+#: ../src/richtext/richtextsymboldlg.cpp:420
 msgid "Shows a Unicode subset."
 msgstr ""
 
@@ -6496,7 +6652,7 @@ msgstr ""
 msgid "Shows a preview of the font settings."
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:394 ../src/osx/carbon/fontdlg.cpp:396
+#: ../src/osx/carbon/fontdlg.cpp:391 ../src/osx/carbon/fontdlg.cpp:393
 msgid "Shows a preview of the font."
 msgstr ""
 
@@ -6505,62 +6661,62 @@ msgstr ""
 msgid "Shows a preview of the paragraph settings."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:460 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:456 ../src/generic/fontdlgg.cpp:458
 msgid "Shows the font preview."
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1607
+#: ../src/propgrid/advprops.cpp:1513
 msgid "Silver"
 msgstr ""
 
-#: ../src/univ/themes/mono.cpp:516
+#: ../src/univ/themes/mono.cpp:513
 msgid "Simple monochrome theme"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:275
 #: ../src/richtext/richtextliststylepage.cpp:449
+#: ../src/richtext/richtextindentspage.cpp:275
 msgid "Single"
 msgstr "مفرد"
 
-#: ../src/generic/filectrlg.cpp:425 ../src/richtext/richtextformatdlg.cpp:369
-#: ../src/richtext/richtextsizepage.cpp:299
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextsizepage.cpp:299
+#: ../src/richtext/richtextformatdlg.cpp:362
 msgid "Size"
 msgstr "حجم"
 
-#: ../src/osx/carbon/fontdlg.cpp:339
+#: ../src/osx/carbon/fontdlg.cpp:336
 msgid "Size:"
 msgstr "حجم:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1775
+#: ../src/propgrid/advprops.cpp:1676
 msgid "Sizing"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1772
+#: ../src/propgrid/advprops.cpp:1673
 msgid "Sizing N-S"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1771
+#: ../src/propgrid/advprops.cpp:1672
 msgid "Sizing NE-SW"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1773
+#: ../src/propgrid/advprops.cpp:1674
 msgid "Sizing NW-SE"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1774
+#: ../src/propgrid/advprops.cpp:1675
 msgid "Sizing W-E"
 msgstr ""
 
-#: ../src/msw/progdlg.cpp:801
+#: ../src/msw/progdlg.cpp:1088
 msgid "Skip"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:330
+#: ../src/generic/fontdlgg.cpp:326
 msgid "Slant"
 msgstr ""
 
@@ -6570,7 +6726,7 @@ msgid "Small C&apitals"
 msgstr "أحرف &كبيرة"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:79
+#: ../src/common/accelcmn.cpp:76
 msgid "Snapshot"
 msgstr ""
 
@@ -6579,37 +6735,37 @@ msgstr ""
 msgid "Solid"
 msgstr "عريض"
 
-#: ../src/common/docview.cpp:1791
+#: ../src/common/docview.cpp:1785
 msgid "Sorry, could not open this file."
 msgstr ""
 
-#: ../src/common/prntbase.cpp:2057 ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2079 ../src/common/prntbase.cpp:2087
 msgid "Sorry, not enough memory to create a preview."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "Sorry, that name is taken. Please choose another."
 msgstr ""
 
-#: ../src/common/docview.cpp:1814
+#: ../src/common/docview.cpp:1819
 msgid "Sorry, the format for this file is unknown."
 msgstr ""
 
-#: ../src/unix/sound.cpp:492
+#: ../src/unix/sound.cpp:481
 msgid "Sound data are in unsupported format."
 msgstr ""
 
-#: ../src/unix/sound.cpp:477
+#: ../src/unix/sound.cpp:466
 #, c-format
 msgid "Sound file '%s' is in unsupported format."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:67
+#: ../src/common/accelcmn.cpp:64
 msgid "Space"
 msgstr ""
 
@@ -6617,12 +6773,12 @@ msgstr ""
 msgid "Spacing"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "Spell Check"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1776
+#: ../src/propgrid/advprops.cpp:1677
 msgid "Spraycan"
 msgstr ""
 
@@ -6631,7 +6787,7 @@ msgstr ""
 msgid "Standard"
 msgstr ""
 
-#: ../src/common/paper.cpp:104
+#: ../src/common/paper.cpp:101
 msgid "Statement, 5 1/2 x 8 1/2 in"
 msgstr ""
 
@@ -6640,35 +6796,31 @@ msgstr ""
 msgid "Static"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:204
+#: ../src/generic/prntdlgg.cpp:197
 msgid "Status:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 #, fuzzy
 msgid "Stop"
 msgstr "&إيقاف"
 
-#: ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196
 #, fuzzy
 msgid "Strikethrough"
 msgstr "&يتوسطه خط"
 
-#: ../src/common/colourcmn.cpp:45
+#: ../src/common/colourcmn.cpp:42
 #, c-format
 msgid "String To Colour : Incorrect colour specification : %s"
 msgstr ""
 
 #. TRANSLATORS: Label of font style
-#: ../src/richtext/richtextformatdlg.cpp:339 ../src/propgrid/advprops.cpp:680
+#: ../src/propgrid/advprops.cpp:590 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "نمط"
 
-#: ../include/wx/richtext/richtextstyledlg.h:46
-msgid "Style Organiser"
-msgstr ""
-
-#: ../src/osx/carbon/fontdlg.cpp:348
+#: ../src/osx/carbon/fontdlg.cpp:345
 msgid "Style:"
 msgstr ""
 
@@ -6677,7 +6829,7 @@ msgid "Subscrip&t"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:83
+#: ../src/common/accelcmn.cpp:80
 msgid "Subtract"
 msgstr ""
 
@@ -6685,11 +6837,11 @@ msgstr ""
 msgid "Supe&rscript"
 msgstr ""
 
-#: ../src/common/paper.cpp:150
+#: ../src/common/paper.cpp:147
 msgid "SuperA/SuperA/A4 227 x 356 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:151
+#: ../src/common/paper.cpp:148
 msgid "SuperB/SuperB/A3 305 x 487 mm"
 msgstr ""
 
@@ -6697,7 +6849,7 @@ msgstr ""
 msgid "Suppress hyphe&nation"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:326
+#: ../src/generic/fontdlgg.cpp:322
 msgid "Swiss"
 msgstr ""
 
@@ -6715,74 +6867,74 @@ msgstr ""
 msgid "Symbols"
 msgstr "رموز"
 
-#: ../src/common/imagtiff.cpp:369 ../src/common/imagtiff.cpp:382
-#: ../src/common/imagtiff.cpp:741
+#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
+#: ../src/common/imagtiff.cpp:738
 msgid "TIFF: Couldn't allocate memory."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:301
+#: ../src/common/imagtiff.cpp:298
 msgid "TIFF: Error loading image."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:468
+#: ../src/common/imagtiff.cpp:465
 msgid "TIFF: Error reading image."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:608
+#: ../src/common/imagtiff.cpp:605
 msgid "TIFF: Error saving image."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:846
+#: ../src/common/imagtiff.cpp:843
 msgid "TIFF: Error writing image."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:355
+#: ../src/common/imagtiff.cpp:352
 msgid "TIFF: Image size is abnormally big."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:68
+#: ../src/common/accelcmn.cpp:65
 msgid "Tab"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11498
+#: ../src/richtext/richtextbuffer.cpp:11497
 #, fuzzy
 msgid "Table Properties"
 msgstr "&الخصائص"
 
-#: ../src/common/paper.cpp:145
+#: ../src/common/paper.cpp:142
 msgid "Tabloid Extra 11.69 x 18 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:102
+#: ../src/common/paper.cpp:99
 msgid "Tabloid, 11 x 17 in"
 msgstr ""
 
-#: ../src/richtext/richtextformatdlg.cpp:354
+#: ../src/richtext/richtextformatdlg.cpp:347
 msgid "Tabs"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1598
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Teal"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:327
+#: ../src/generic/fontdlgg.cpp:323
 msgid "Teletype"
 msgstr ""
 
-#: ../src/common/docview.cpp:1896
+#: ../src/common/docview.cpp:1901
 msgid "Templates"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:158
+#: ../src/common/fmapbase.cpp:155
 msgid "Thai (ISO-8859-11)"
 msgstr ""
 
-#: ../src/common/ftp.cpp:619
+#: ../src/common/ftp.cpp:622
 msgid "The FTP server doesn't support passive mode."
 msgstr ""
 
-#: ../src/common/ftp.cpp:605
+#: ../src/common/ftp.cpp:608
 msgid "The FTP server doesn't support the PORT command."
 msgstr ""
 
@@ -6793,8 +6945,8 @@ msgstr ""
 msgid "The available bullet styles."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:202
-#: ../src/richtext/richtextstyledlg.cpp:204
+#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:200
 msgid "The available styles."
 msgstr ""
 
@@ -6852,12 +7004,12 @@ msgstr ""
 msgid "The bullet character."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:443
-#: ../src/richtext/richtextsymboldlg.cpp:445
+#: ../src/richtext/richtextsymboldlg.cpp:440
+#: ../src/richtext/richtextsymboldlg.cpp:442
 msgid "The character code."
 msgstr ""
 
-#: ../src/common/fontmap.cpp:203
+#: ../src/common/fontmap.cpp:200
 #, c-format
 msgid ""
 "The charset '%s' is unknown. You may select\n"
@@ -6865,7 +7017,7 @@ msgid ""
 "[Cancel] if it cannot be replaced"
 msgstr ""
 
-#: ../src/msw/ole/dataobj.cpp:394
+#: ../src/msw/ole/dataobj.cpp:402
 #, c-format
 msgid "The clipboard format '%d' doesn't exist."
 msgstr ""
@@ -6875,14 +7027,14 @@ msgstr ""
 msgid "The default style for the next paragraph."
 msgstr ""
 
-#: ../src/generic/dirdlgg.cpp:202
+#: ../src/generic/dirdlgg.cpp:199
 #, c-format
 msgid ""
 "The directory '%s' does not exist\n"
 "Create it now?"
 msgstr ""
 
-#: ../src/html/htmprint.cpp:271
+#: ../src/html/htmprint.cpp:283
 #, c-format
 msgid ""
 "The document \"%s\" doesn't fit on the page horizontally and will be "
@@ -6891,43 +7043,43 @@ msgid ""
 "Would you like to proceed with printing it nevertheless?"
 msgstr ""
 
-#: ../src/common/docview.cpp:1202
+#: ../src/common/docview.cpp:1196
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
 "It has been removed from the most recently used files list."
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:208
-#: ../src/richtext/richtextindentspage.cpp:210
 #: ../src/richtext/richtextliststylepage.cpp:394
 #: ../src/richtext/richtextliststylepage.cpp:396
+#: ../src/richtext/richtextindentspage.cpp:208
+#: ../src/richtext/richtextindentspage.cpp:210
 msgid "The first line indent."
 msgstr ""
 
-#: ../src/gtk/utilsgtk.cpp:481
-msgid "The following standard GTK+ options are also supported:\n"
+#: ../src/generic/dbgrptg.cpp:318
+msgid "The following debug report will be generated\n"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:414 ../src/generic/fontdlgg.cpp:416
+#: ../src/generic/fontdlgg.cpp:411 ../src/generic/fontdlgg.cpp:413
 msgid "The font colour."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:375 ../src/generic/fontdlgg.cpp:377
+#: ../src/generic/fontdlgg.cpp:371 ../src/generic/fontdlgg.cpp:373
 msgid "The font family."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:405
-#: ../src/richtext/richtextsymboldlg.cpp:407
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "The font from which to take the symbol."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:427 ../src/generic/fontdlgg.cpp:429
-#: ../src/generic/fontdlgg.cpp:434 ../src/generic/fontdlgg.cpp:436
+#: ../src/generic/fontdlgg.cpp:424 ../src/generic/fontdlgg.cpp:426
+#: ../src/generic/fontdlgg.cpp:430 ../src/generic/fontdlgg.cpp:432
 msgid "The font point size."
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:343 ../src/osx/carbon/fontdlg.cpp:345
+#: ../src/osx/carbon/fontdlg.cpp:340 ../src/osx/carbon/fontdlg.cpp:342
 msgid "The font size in points."
 msgstr ""
 
@@ -6937,15 +7089,15 @@ msgstr ""
 msgid "The font size units, points or pixels."
 msgstr "قوائم أحجام الخط بالدرجات"
 
-#: ../src/generic/fontdlgg.cpp:386 ../src/generic/fontdlgg.cpp:388
+#: ../src/generic/fontdlgg.cpp:382 ../src/generic/fontdlgg.cpp:384
 msgid "The font style."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:397 ../src/generic/fontdlgg.cpp:399
+#: ../src/generic/fontdlgg.cpp:393 ../src/generic/fontdlgg.cpp:395
 msgid "The font weight."
 msgstr ""
 
-#: ../src/common/docview.cpp:1483
+#: ../src/common/docview.cpp:1477
 #, fuzzy, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "تعذر إعادة إنشاء المجلد '%s' لنفسه"
@@ -6955,10 +7107,10 @@ msgstr "تعذر إعادة إنشاء المجلد '%s' لنفسه"
 msgid "The horizontal offset."
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:199
-#: ../src/richtext/richtextindentspage.cpp:201
 #: ../src/richtext/richtextliststylepage.cpp:385
 #: ../src/richtext/richtextliststylepage.cpp:387
+#: ../src/richtext/richtextindentspage.cpp:199
+#: ../src/richtext/richtextindentspage.cpp:201
 msgid "The left indent."
 msgstr ""
 
@@ -6979,10 +7131,10 @@ msgstr ""
 msgid "The left position."
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:288
-#: ../src/richtext/richtextindentspage.cpp:290
 #: ../src/richtext/richtextliststylepage.cpp:462
 #: ../src/richtext/richtextliststylepage.cpp:464
+#: ../src/richtext/richtextindentspage.cpp:288
+#: ../src/richtext/richtextindentspage.cpp:290
 msgid "The line spacing."
 msgstr ""
 
@@ -6991,7 +7143,7 @@ msgstr ""
 msgid "The list item number."
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:664
+#: ../src/msw/ole/automtn.cpp:655
 msgid "The locale ID is unknown."
 msgstr ""
 
@@ -7030,7 +7182,7 @@ msgstr ""
 msgid "The outline level."
 msgstr ""
 
-#: ../src/common/log.cpp:277
+#: ../src/common/log.cpp:296
 #, c-format
 msgid "The previous message repeated %u time."
 msgid_plural "The previous message repeated %u times."
@@ -7038,12 +7190,12 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: ../src/common/log.cpp:270
+#: ../src/common/log.cpp:289
 msgid "The previous message repeated once."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:462
-#: ../src/richtext/richtextsymboldlg.cpp:464
+#: ../src/richtext/richtextsymboldlg.cpp:459
+#: ../src/richtext/richtextsymboldlg.cpp:461
 msgid "The range to show."
 msgstr ""
 
@@ -7054,15 +7206,15 @@ msgid ""
 "please uncheck them and they will be removed from the report.\n"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1254
+#: ../src/common/cmdline.cpp:1250
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:217
-#: ../src/richtext/richtextindentspage.cpp:219
 #: ../src/richtext/richtextliststylepage.cpp:403
 #: ../src/richtext/richtextliststylepage.cpp:405
+#: ../src/richtext/richtextindentspage.cpp:217
+#: ../src/richtext/richtextindentspage.cpp:219
 msgid "The right indent."
 msgstr ""
 
@@ -7104,16 +7256,16 @@ msgstr ""
 msgid "The shadow spread."
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:267
 #: ../src/richtext/richtextliststylepage.cpp:439
 #: ../src/richtext/richtextliststylepage.cpp:441
+#: ../src/richtext/richtextindentspage.cpp:267
 msgid "The spacing after the paragraph."
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:257
-#: ../src/richtext/richtextindentspage.cpp:259
 #: ../src/richtext/richtextliststylepage.cpp:430
 #: ../src/richtext/richtextliststylepage.cpp:432
+#: ../src/richtext/richtextindentspage.cpp:257
+#: ../src/richtext/richtextindentspage.cpp:259
 msgid "The spacing before the paragraph."
 msgstr ""
 
@@ -7127,12 +7279,12 @@ msgstr ""
 msgid "The style on which this style is based."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:214
-#: ../src/richtext/richtextstyledlg.cpp:216
+#: ../src/richtext/richtextstyledlg.cpp:210
+#: ../src/richtext/richtextstyledlg.cpp:212
 msgid "The style preview."
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:680
+#: ../src/msw/ole/automtn.cpp:671
 msgid "The system cannot find the file specified."
 msgstr ""
 
@@ -7145,7 +7297,7 @@ msgstr ""
 msgid "The tab positions."
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:3098
+#: ../src/richtext/richtextctrl.cpp:3099
 msgid "The text couldn't be saved."
 msgstr ""
 
@@ -7166,7 +7318,7 @@ msgstr ""
 msgid "The top position."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1232
+#: ../src/common/cmdline.cpp:1228
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr ""
@@ -7176,7 +7328,7 @@ msgstr ""
 msgid "The value of the corner radius."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:433
+#: ../src/msw/dialup.cpp:427
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -7189,123 +7341,131 @@ msgstr ""
 msgid "The vertical offset."
 msgstr "&محاذاة"
 
-#: ../src/richtext/richtextprint.cpp:619 ../src/html/htmprint.cpp:745
+#: ../src/html/htmprint.cpp:749 ../src/richtext/richtextprint.cpp:615
 msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr ""
 
-#: ../src/html/htmprint.cpp:255
+#: ../src/html/htmprint.cpp:267
 msgid ""
 "This document doesn't fit on the page horizontally and will be truncated "
 "when it is printed."
 msgstr ""
 
-#: ../src/common/image.cpp:2854
+#: ../src/common/image.cpp:2963
 #, c-format
 msgid "This is not a %s."
 msgstr ""
 
-#: ../src/common/wincmn.cpp:1653
+#: ../src/common/wincmn.cpp:1654
 msgid "This platform does not support background transparency."
 msgstr ""
 
-#: ../src/gtk/window.cpp:4660
+#: ../src/gtk/window.cpp:5664
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
 
-#: ../src/msw/thread.cpp:1240
+#: ../src/gtk/glcanvas.cpp:176
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/msw/thread.cpp:1246
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1794
+#: ../src/unix/threadpsx.cpp:1843
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 
-#: ../src/msw/thread.cpp:1228
+#: ../src/msw/thread.cpp:1234
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1043
+#: ../src/unix/threadpsx.cpp:1061
 msgid "Thread priority setting is ignored."
 msgstr ""
 
-#: ../src/msw/mdi.cpp:176
+#: ../src/msw/mdi.cpp:171
 msgid "Tile &Horizontally"
 msgstr ""
 
-#: ../src/msw/mdi.cpp:177
+#: ../src/msw/mdi.cpp:172
 msgid "Tile &Vertically"
 msgstr ""
 
-#: ../src/common/ftp.cpp:200
+#: ../src/common/ftp.cpp:197
 msgid "Timeout while waiting for FTP server to connect, try passive mode."
 msgstr ""
 
-#: ../src/generic/tipdlg.cpp:201
+#: ../src/generic/tipdlg.cpp:198
 msgid "Tip of the Day"
 msgstr ""
 
-#: ../src/generic/tipdlg.cpp:140
+#: ../src/generic/tipdlg.cpp:137
 msgid "Tips not available, sorry!"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:242
+#: ../src/generic/prntdlgg.cpp:235
 msgid "To:"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:8363
+#: ../src/richtext/richtextbuffer.cpp:8361
 msgid "Too many EndStyle calls!"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:891
+#: ../src/propgrid/advprops.cpp:792
 msgid "Tooltip"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:892
+#: ../src/propgrid/advprops.cpp:793
 msgid "TooltipText"
 msgstr ""
 
-#: ../src/richtext/richtextsizepage.cpp:286
-#: ../src/richtext/richtextsizepage.cpp:290 ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197 ../src/richtext/richtextsizepage.cpp:286
+#: ../src/richtext/richtextsizepage.cpp:290
 #, fuzzy
 msgid "Top"
 msgstr "&نسخ"
 
-#: ../src/generic/prntdlgg.cpp:881
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Top margin (mm):"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:79
+#: ../src/generic/aboutdlgg.cpp:76
 msgid "Translations by "
 msgstr "الترجمة بمعرفة"
 
-#: ../src/generic/aboutdlgg.cpp:188
+#: ../src/generic/aboutdlgg.cpp:185
 msgid "Translators"
 msgstr "المترجمين"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:211
+#: ../src/propgrid/propgrid.cpp:192
 msgid "True"
 msgstr ""
 
-#: ../src/common/fs_mem.cpp:227
+#: ../src/common/fs_mem.cpp:222
 #, c-format
 msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:156
+#: ../src/common/fmapbase.cpp:153
 msgid "Turkish (ISO-8859-9)"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:426
+#: ../src/generic/filectrlg.cpp:422
 msgid "Type"
 msgstr "نوع"
 
@@ -7319,36 +7479,36 @@ msgstr ""
 msgid "Type a size in points."
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:676
+#: ../src/msw/ole/automtn.cpp:667
 #, c-format
 msgid "Type mismatch in argument %u."
 msgstr ""
 
-#: ../src/common/xtixml.cpp:356 ../src/common/xtixml.cpp:509
-#: ../src/common/xtistrm.cpp:318
+#: ../src/common/xtixml.cpp:352 ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315
 msgid "Type must have enum - long conversion"
 msgstr ""
 
-#: ../src/propgrid/propgridiface.cpp:401
+#: ../src/propgrid/propgridiface.cpp:385
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
 "\"%s\"."
 msgstr ""
 
-#: ../src/common/paper.cpp:133
+#: ../src/common/paper.cpp:130
 msgid "US Std Fanfold, 14 7/8 x 11 in"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:196
+#: ../src/common/fmapbase.cpp:193
 msgid "US-ASCII"
 msgstr ""
 
-#: ../src/unix/fswatcher_inotify.cpp:109
+#: ../src/unix/fswatcher_inotify.cpp:106
 msgid "Unable to add inotify watch"
 msgstr ""
 
-#: ../src/unix/fswatcher_kqueue.cpp:136
+#: ../src/unix/fswatcher_kqueue.cpp:153
 msgid "Unable to add kqueue watch"
 msgstr ""
 
@@ -7360,7 +7520,7 @@ msgstr ""
 msgid "Unable to close I/O completion port handle"
 msgstr ""
 
-#: ../src/unix/fswatcher_inotify.cpp:97
+#: ../src/unix/fswatcher_inotify.cpp:94
 msgid "Unable to close inotify instance"
 msgstr ""
 
@@ -7378,15 +7538,15 @@ msgstr "فشل عند إغلاق الحافظة"
 msgid "Unable to create I/O completion port"
 msgstr ""
 
-#: ../src/msw/fswatcher.cpp:84
+#: ../src/msw/fswatcher.cpp:81
 msgid "Unable to create IOCP worker thread"
 msgstr ""
 
-#: ../src/unix/fswatcher_inotify.cpp:74
+#: ../src/unix/fswatcher_inotify.cpp:71
 msgid "Unable to create inotify instance"
 msgstr ""
 
-#: ../src/unix/fswatcher_kqueue.cpp:97
+#: ../src/unix/fswatcher_kqueue.cpp:114
 msgid "Unable to create kqueue instance"
 msgstr ""
 
@@ -7394,11 +7554,11 @@ msgstr ""
 msgid "Unable to dequeue completion packet"
 msgstr ""
 
-#: ../src/unix/fswatcher_kqueue.cpp:185
+#: ../src/unix/fswatcher_kqueue.cpp:202
 msgid "Unable to get events from kqueue"
 msgstr ""
 
-#: ../src/gtk/app.cpp:435
+#: ../src/gtk/app.cpp:431
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr ""
 
@@ -7407,12 +7567,12 @@ msgstr ""
 msgid "Unable to open path '%s'"
 msgstr ""
 
-#: ../src/html/htmlwin.cpp:583
+#: ../src/html/htmlwin.cpp:586
 #, c-format
 msgid "Unable to open requested HTML document: %s"
 msgstr ""
 
-#: ../src/unix/sound.cpp:368
+#: ../src/unix/sound.cpp:365
 msgid "Unable to play sound asynchronously."
 msgstr ""
 
@@ -7420,63 +7580,63 @@ msgstr ""
 msgid "Unable to post completion status"
 msgstr ""
 
-#: ../src/unix/fswatcher_inotify.cpp:556
+#: ../src/unix/fswatcher_inotify.cpp:553
 msgid "Unable to read from inotify descriptor"
 msgstr ""
 
-#: ../src/unix/fswatcher_inotify.cpp:141
+#: ../src/unix/fswatcher_inotify.cpp:138
 #, c-format
 msgid "Unable to remove inotify watch %i"
 msgstr ""
 
-#: ../src/unix/fswatcher_kqueue.cpp:153
+#: ../src/unix/fswatcher_kqueue.cpp:170
 msgid "Unable to remove kqueue watch"
 msgstr ""
 
-#: ../src/msw/fswatcher.cpp:168
+#: ../src/msw/fswatcher.cpp:165
 #, c-format
 msgid "Unable to set up watch for '%s'"
 msgstr ""
 
-#: ../src/msw/fswatcher.cpp:91
+#: ../src/msw/fswatcher.cpp:88
 msgid "Unable to start IOCP worker thread"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:201
+#: ../src/common/stockitem.cpp:198
 msgid "Undelete"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199
 #, fuzzy
 msgid "Underline"
 msgstr "&خط سفلي"
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/richtext/richtextfontpage.cpp:359 ../src/osx/carbon/fontdlg.cpp:370
-#: ../src/propgrid/advprops.cpp:690
+#: ../src/osx/carbon/fontdlg.cpp:367 ../src/propgrid/advprops.cpp:600
+#: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:203 ../src/stc/stc_i18n.cpp:15
+#: ../src/common/stockitem.cpp:200 ../src/stc/stc_i18n.cpp:15
 #, fuzzy
 msgid "Undo"
 msgstr "&تراجع"
 
-#: ../src/common/stockitem.cpp:265
+#: ../src/common/stockitem.cpp:263
 msgid "Undo last action"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1029
+#: ../src/common/cmdline.cpp:1025
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr ""
 
-#: ../src/unix/fswatcher_inotify.cpp:274
+#: ../src/unix/fswatcher_inotify.cpp:271
 #, c-format
 msgid "Unexpected event for \"%s\": no matching watch descriptor."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1195
+#: ../src/common/cmdline.cpp:1191
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr ""
@@ -7485,50 +7645,50 @@ msgstr ""
 msgid "Unexpectedly new I/O completion port was created"
 msgstr ""
 
-#: ../src/msw/fswatcher.cpp:70
+#: ../src/msw/fswatcher.cpp:67
 #, fuzzy
 msgid "Ungraceful worker thread termination"
 msgstr "لا يمكن انتظار إنهاء الموضوع"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:460
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:456
+#: ../src/richtext/richtextsymboldlg.cpp:457
+#: ../src/richtext/richtextsymboldlg.cpp:458
 msgid "Unicode"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:185 ../src/common/fmapbase.cpp:191
+#: ../src/common/fmapbase.cpp:182 ../src/common/fmapbase.cpp:188
 msgid "Unicode 16 bit (UTF-16)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:190
+#: ../src/common/fmapbase.cpp:187
 msgid "Unicode 16 bit Big Endian (UTF-16BE)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:186
+#: ../src/common/fmapbase.cpp:183
 msgid "Unicode 16 bit Little Endian (UTF-16LE)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:187 ../src/common/fmapbase.cpp:193
+#: ../src/common/fmapbase.cpp:184 ../src/common/fmapbase.cpp:190
 msgid "Unicode 32 bit (UTF-32)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:192
+#: ../src/common/fmapbase.cpp:189
 msgid "Unicode 32 bit Big Endian (UTF-32BE)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:188
+#: ../src/common/fmapbase.cpp:185
 msgid "Unicode 32 bit Little Endian (UTF-32LE)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:182
+#: ../src/common/fmapbase.cpp:179
 msgid "Unicode 7 bit (UTF-7)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:183
+#: ../src/common/fmapbase.cpp:180
 msgid "Unicode 8 bit (UTF-8)"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 #, fuzzy
 msgid "Unindent"
 msgstr "&عدم إزاحة"
@@ -7685,100 +7845,105 @@ msgstr "تعذر الانتظار حتى إنهاء الموضوع"
 msgid "Units for this value."
 msgstr "تعذر الانتظار حتى إنهاء الموضوع"
 
-#: ../src/generic/progdlgg.cpp:353 ../src/generic/progdlgg.cpp:622
+#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
 msgid "Unknown"
 msgstr ""
 
-#: ../src/msw/dde.cpp:1174
+#: ../src/msw/dde.cpp:1238
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:410
+#: ../src/common/xtistrm.cpp:407
 msgid "Unknown Object passed to GetObjectClassInfo"
 msgstr ""
 
-#: ../src/common/imagpng.cpp:366
+#: ../src/common/imagpng.cpp:383
 #, c-format
 msgid "Unknown PNG resolution unit %d"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:327
+#: ../src/common/xtixml.cpp:323
 #, fuzzy, c-format
 msgid "Unknown Property %s"
 msgstr "خاصية غير معروفة %s"
 
-#: ../src/common/imagtiff.cpp:529
+#: ../src/common/imagtiff.cpp:526
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr ""
 
-#: ../src/unix/dlunix.cpp:160
+#: ../src/propgrid/props.cpp:155
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/unix/dlunix.cpp:118
 msgid "Unknown dynamic library error"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:810
+#: ../src/common/fmapbase.cpp:806
 #, c-format
 msgid "Unknown encoding (%d)"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:688
+#: ../src/msw/ole/automtn.cpp:679
 #, fuzzy, c-format
 msgid "Unknown error %08x"
 msgstr "خطأ غير معروف"
 
-#: ../src/msw/ole/automtn.cpp:647
+#: ../src/msw/ole/automtn.cpp:638
 #, fuzzy
 msgid "Unknown exception"
 msgstr "خطأ غير معروف"
 
-#: ../src/common/image.cpp:2839
+#: ../src/common/image.cpp:2942
 #, fuzzy
 msgid "Unknown image data format."
 msgstr "نهاية سطر غير معروف"
 
-#: ../src/common/cmdline.cpp:914
+#: ../src/common/cmdline.cpp:910
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:631
+#: ../src/msw/ole/automtn.cpp:622
 msgid "Unknown name or named argument."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:929 ../src/common/cmdline.cpp:951
+#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
 #, c-format
 msgid "Unknown option '%s'"
 msgstr ""
 
-#: ../src/common/mimecmn.cpp:225
+#: ../src/common/mimecmn.cpp:221
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr ""
 
-#: ../src/common/cmdproc.cpp:262 ../src/common/cmdproc.cpp:288
-#: ../src/common/cmdproc.cpp:308
+#: ../src/common/cmdproc.cpp:255 ../src/common/cmdproc.cpp:281
+#: ../src/common/cmdproc.cpp:301
 msgid "Unnamed command"
 msgstr ""
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:413
+#: ../src/propgrid/propgrid.cpp:392
 #, fuzzy
 msgid "Unspecified"
 msgstr "متوسط"
 
-#: ../src/msw/clipbrd.cpp:311
+#: ../src/msw/clipbrd.cpp:325
 msgid "Unsupported clipboard format."
 msgstr ""
 
-#: ../src/common/appcmn.cpp:256
+#: ../src/common/appcmn.cpp:277
 #, c-format
 msgid "Unsupported theme '%s'."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:205
-#: ../src/common/accelcmn.cpp:63
+#: ../src/common/stockitem.cpp:202 ../src/common/accelcmn.cpp:60
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Up"
 msgstr ""
 
@@ -7792,7 +7957,7 @@ msgstr ""
 msgid "Upper case roman numerals"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1326
+#: ../src/common/cmdline.cpp:1322
 #, c-format
 msgid "Usage: %s"
 msgstr ""
@@ -7801,38 +7966,47 @@ msgstr ""
 msgid "Use &shadow"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:169
-#: ../src/richtext/richtextindentspage.cpp:171
 #: ../src/richtext/richtextliststylepage.cpp:358
 #: ../src/richtext/richtextliststylepage.cpp:360
+#: ../src/richtext/richtextindentspage.cpp:169
+#: ../src/richtext/richtextindentspage.cpp:171
 msgid "Use the current alignment setting."
 msgstr ""
 
-#: ../src/common/valtext.cpp:179
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/gtk/font.cpp:552
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/common/valtext.cpp:142
 msgid "Validation conflict"
 msgstr ""
 
-#: ../src/propgrid/manager.cpp:238
+#: ../src/propgrid/manager.cpp:224
 msgid "Value"
 msgstr ""
 
-#: ../src/propgrid/props.cpp:386 ../src/propgrid/props.cpp:500
+#: ../src/propgrid/props.cpp:309
 #, c-format
 msgid "Value must be %s or higher."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:417 ../src/propgrid/props.cpp:531
+#: ../src/propgrid/props.cpp:336
 #, c-format
 msgid "Value must be %s or less."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:393 ../src/propgrid/props.cpp:424
-#: ../src/propgrid/props.cpp:507 ../src/propgrid/props.cpp:538
+#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
 #, fuzzy, c-format
 msgid "Value must be between %s and %s."
 msgstr "ادخل رقم صفحة ما بين %d و %d:"
 
-#: ../src/generic/aboutdlgg.cpp:128
+#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
 #, fuzzy
 msgid "Version "
 msgstr "إصدار"
@@ -7843,25 +8017,32 @@ msgstr "إصدار"
 msgid "Vertical alignment."
 msgstr "&محاذاة"
 
-#: ../src/generic/filedlgg.cpp:202
+#: ../src/generic/filedlgg.cpp:199
 msgid "View files as a detailed view"
 msgstr ""
 
-#: ../src/generic/filedlgg.cpp:200
+#: ../src/generic/filedlgg.cpp:197
 msgid "View files as a list view"
 msgstr ""
 
-#: ../src/common/docview.cpp:1970
+#: ../src/common/docview.cpp:1975
 msgid "Views"
 msgstr ""
 
+#: ../src/gtk/app.cpp:348
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1777
+#: ../src/propgrid/advprops.cpp:1678
 msgid "Wait"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1779
+#: ../src/propgrid/advprops.cpp:1680
 msgid "Wait Arrow"
 msgstr ""
 
@@ -7870,244 +8051,240 @@ msgstr ""
 msgid "Waiting for IO on epoll descriptor %d failed"
 msgstr ""
 
-#: ../src/common/log.cpp:223
+#: ../src/common/log.cpp:241
 msgid "Warning: "
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1778
+#: ../src/propgrid/advprops.cpp:1679
 msgid "Watch"
 msgstr ""
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:685
+#: ../src/propgrid/advprops.cpp:595
 #, fuzzy
 msgid "Weight"
 msgstr "يمين"
 
-#: ../src/common/fmapbase.cpp:148
+#: ../src/common/fmapbase.cpp:145
 msgid "Western European (ISO-8859-1)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:162
+#: ../src/common/fmapbase.cpp:159
 msgid "Western European with Euro (ISO-8859-15)"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:446 ../src/generic/fontdlgg.cpp:448
+#: ../src/generic/fontdlgg.cpp:443 ../src/generic/fontdlgg.cpp:445
 msgid "Whether the font is underlined."
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1611
+#: ../src/propgrid/advprops.cpp:1517
 msgid "White"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:144
+#: ../src/generic/fdrepdlg.cpp:141
 msgid "Whole word"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:532
 msgid "Whole words only"
 msgstr ""
 
-#: ../src/univ/themes/win32.cpp:1102
+#: ../src/univ/themes/win32.cpp:1099
 msgid "Win32 theme"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:893
+#: ../src/propgrid/advprops.cpp:794
 #, fuzzy
 msgid "Window"
 msgstr "&نافذة"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:894
+#: ../src/propgrid/advprops.cpp:795
 #, fuzzy
 msgid "WindowFrame"
 msgstr "&نافذة"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:895
+#: ../src/propgrid/advprops.cpp:796
 #, fuzzy
 msgid "WindowText"
 msgstr "&نافذة"
 
-#: ../src/common/fmapbase.cpp:177
+#: ../src/common/fmapbase.cpp:174
 msgid "Windows Arabic (CP 1256)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:178
+#: ../src/common/fmapbase.cpp:175
 msgid "Windows Baltic (CP 1257)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:171
+#: ../src/common/fmapbase.cpp:168
 msgid "Windows Central European (CP 1250)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:168
+#: ../src/common/fmapbase.cpp:165
 msgid "Windows Chinese Simplified (CP 936) or GB-2312"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:170
+#: ../src/common/fmapbase.cpp:167
 msgid "Windows Chinese Traditional (CP 950) or Big-5"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:172
+#: ../src/common/fmapbase.cpp:169
 msgid "Windows Cyrillic (CP 1251)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:174
+#: ../src/common/fmapbase.cpp:171
 msgid "Windows Greek (CP 1253)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:176
+#: ../src/common/fmapbase.cpp:173
 msgid "Windows Hebrew (CP 1255)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:167
+#: ../src/common/fmapbase.cpp:164
 msgid "Windows Japanese (CP 932) or Shift-JIS"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:180
+#: ../src/common/fmapbase.cpp:177
 msgid "Windows Johab (CP 1361)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:169
+#: ../src/common/fmapbase.cpp:166
 msgid "Windows Korean (CP 949)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:166
+#: ../src/common/fmapbase.cpp:163
 msgid "Windows Thai (CP 874)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:175
+#: ../src/common/fmapbase.cpp:172
 msgid "Windows Turkish (CP 1254)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:179
+#: ../src/common/fmapbase.cpp:176
 msgid "Windows Vietnamese (CP 1258)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:173
+#: ../src/common/fmapbase.cpp:170
 msgid "Windows Western European (CP 1252)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:181
+#: ../src/common/fmapbase.cpp:178
 msgid "Windows/DOS OEM (CP 437)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:165
+#: ../src/common/fmapbase.cpp:162
 msgid "Windows/DOS OEM Cyrillic (CP 866)"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:111
+#: ../src/common/accelcmn.cpp:109
 #, fuzzy
 msgid "Windows_Left"
 msgstr "&نافذة"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:113
+#: ../src/common/accelcmn.cpp:111
 #, fuzzy
 msgid "Windows_Menu"
 msgstr "&نافذة"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:112
+#: ../src/common/accelcmn.cpp:110
 #, fuzzy
 msgid "Windows_Right"
 msgstr "&نافذة"
 
-#: ../src/common/ffile.cpp:150
+#: ../src/common/ffile.cpp:149
 #, c-format
 msgid "Write error on file '%s'"
 msgstr ""
 
-#: ../src/xml/xml.cpp:914
+#: ../src/xml/xml.cpp:925
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr ""
 
-#: ../src/common/xpmdecod.cpp:796
+#: ../src/common/xpmdecod.cpp:794
 msgid "XPM: Malformed pixel data!"
 msgstr ""
 
-#: ../src/common/xpmdecod.cpp:705
+#: ../src/common/xpmdecod.cpp:702
 #, c-format
 msgid "XPM: incorrect colour description in line %d"
 msgstr ""
 
-#: ../src/common/xpmdecod.cpp:680
+#: ../src/common/xpmdecod.cpp:677
 msgid "XPM: incorrect header format!"
 msgstr ""
 
-#: ../src/common/xpmdecod.cpp:716 ../src/common/xpmdecod.cpp:725
+#: ../src/common/xpmdecod.cpp:714 ../src/common/xpmdecod.cpp:723
 #, c-format
 msgid "XPM: malformed colour definition '%s' at line %d!"
 msgstr ""
 
-#: ../src/common/xpmdecod.cpp:755
+#: ../src/common/xpmdecod.cpp:753
 msgid "XPM: no colors left to use for mask!"
 msgstr ""
 
-#: ../src/common/xpmdecod.cpp:782
+#: ../src/common/xpmdecod.cpp:780
 #, c-format
 msgid "XPM: truncated image data at line %d!"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1610
+#: ../src/propgrid/advprops.cpp:1516
 msgid "Yellow"
 msgstr ""
 
-#: ../include/wx/msgdlg.h:276 ../src/common/stockitem.cpp:206
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:203
 #: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "نعم"
 
-#: ../src/osx/carbon/overlay.cpp:155
-msgid "You cannot Clear an overlay that is not inited"
-msgstr ""
-
-#: ../src/osx/carbon/overlay.cpp:107 ../src/dfb/overlay.cpp:61
-msgid "You cannot Init an overlay twice"
-msgstr ""
-
-#: ../src/generic/dirdlgg.cpp:287
+#: ../src/generic/dirdlgg.cpp:284
 msgid "You cannot add a new directory to this section."
 msgstr ""
 
-#: ../src/propgrid/propgrid.cpp:3299
+#: ../src/propgrid/propgrid.cpp:3276
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:209
+#: ../src/osx/cocoa/menu.mm:286
+msgid "Zoom"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:206
 msgid "Zoom &In"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:210
+#: ../src/common/stockitem.cpp:207
 msgid "Zoom &Out"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:209 ../src/common/prntbase.cpp:1594
+#: ../src/common/stockitem.cpp:206 ../src/common/prntbase.cpp:1619
 msgid "Zoom In"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:210 ../src/common/prntbase.cpp:1580
+#: ../src/common/stockitem.cpp:207 ../src/common/prntbase.cpp:1605
 msgid "Zoom Out"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to &Fit"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to Fit"
 msgstr ""
 
-#: ../src/msw/dde.cpp:1141
+#: ../src/msw/dde.cpp:1205
 msgid "a DDEML application has created a prolonged race condition."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1129
+#: ../src/msw/dde.cpp:1193
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -8115,54 +8292,54 @@ msgid ""
 "was passed to a DDEML function."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1147
+#: ../src/msw/dde.cpp:1211
 msgid "a client's attempt to establish a conversation has failed."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1144
+#: ../src/msw/dde.cpp:1208
 msgid "a memory allocation failed."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1138
+#: ../src/msw/dde.cpp:1202
 msgid "a parameter failed to be validated by the DDEML."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1120
+#: ../src/msw/dde.cpp:1184
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1126
+#: ../src/msw/dde.cpp:1190
 msgid "a request for a synchronous data transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1135
+#: ../src/msw/dde.cpp:1199
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1153
+#: ../src/msw/dde.cpp:1217
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1168
+#: ../src/msw/dde.cpp:1232
 msgid "a request to end an advise transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1162
+#: ../src/msw/dde.cpp:1226
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
 "terminated before completing a transaction."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1150
+#: ../src/msw/dde.cpp:1214
 msgid "a transaction failed."
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:189
+#: ../src/common/accelcmn.cpp:188
 msgid "alt"
 msgstr "alt"
 
-#: ../src/msw/dde.cpp:1132
+#: ../src/msw/dde.cpp:1196
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -8170,71 +8347,71 @@ msgid ""
 "attempted to perform server transactions."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1156
+#: ../src/msw/dde.cpp:1220
 msgid "an internal call to the PostMessage function has failed. "
 msgstr ""
 
-#: ../src/msw/dde.cpp:1165
+#: ../src/msw/dde.cpp:1229
 msgid "an internal error has occurred in the DDEML."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1171
+#: ../src/msw/dde.cpp:1235
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
 "the transaction identifier for that callback is no longer valid."
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1483
+#: ../src/common/zipstrm.cpp:1522
 msgid "assuming this is a multi-part zip concatenated"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1847
+#: ../src/common/fileconf.cpp:1849
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr ""
 
-#: ../src/html/chm.cpp:329
+#: ../src/html/chm.cpp:326
 msgid "bad arguments to library function"
 msgstr ""
 
-#: ../src/html/chm.cpp:341
+#: ../src/html/chm.cpp:338
 msgid "bad signature"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1918
+#: ../src/common/zipstrm.cpp:1988
 msgid "bad zipfile offset to entry"
 msgstr ""
 
-#: ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400
 msgid "binary"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:996
+#: ../src/common/fontcmn.cpp:1195
 msgid "bold"
 msgstr ""
 
-#: ../src/msw/utils.cpp:1144
+#: ../src/msw/utils.cpp:1135
 #, c-format
 msgid "build %lu"
 msgstr ""
 
-#: ../src/common/ffile.cpp:75
+#: ../src/common/ffile.cpp:73
 #, c-format
 msgid "can't close file '%s'"
 msgstr ""
 
-#: ../src/common/file.cpp:245
+#: ../src/common/file.cpp:242
 #, c-format
 msgid "can't close file descriptor %d"
 msgstr ""
 
-#: ../src/common/file.cpp:586
+#: ../src/common/ffile.cpp:382 ../src/common/file.cpp:613
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr ""
 
-#: ../src/common/file.cpp:178
+#: ../src/common/file.cpp:175
 #, c-format
 msgid "can't create file '%s'"
 msgstr ""
@@ -8244,49 +8421,49 @@ msgstr ""
 msgid "can't delete user configuration file '%s'"
 msgstr ""
 
-#: ../src/common/file.cpp:495
+#: ../src/common/file.cpp:522
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1692
+#: ../src/common/zipstrm.cpp:1747
 msgid "can't find central directory in zip"
 msgstr ""
 
-#: ../src/common/file.cpp:465
+#: ../src/common/file.cpp:492
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr ""
 
-#: ../src/msw/utils.cpp:341
+#: ../src/msw/utils.cpp:336
 msgid "can't find user's HOME, using current directory."
 msgstr ""
 
-#: ../src/common/file.cpp:366
+#: ../src/common/file.cpp:407
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr ""
 
-#: ../src/common/file.cpp:422
+#: ../src/common/file.cpp:463
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr ""
 
-#: ../src/common/fontmap.cpp:325
+#: ../src/common/fontmap.cpp:322
 msgid "can't load any font, aborting"
 msgstr ""
 
-#: ../src/common/file.cpp:231 ../src/common/ffile.cpp:59
+#: ../src/common/ffile.cpp:57 ../src/common/file.cpp:228
 #, c-format
 msgid "can't open file '%s'"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:320
+#: ../src/common/fileconf.cpp:314
 #, c-format
 msgid "can't open global configuration file '%s'."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:336
+#: ../src/common/fileconf.cpp:330
 #, c-format
 msgid "can't open user configuration file '%s'."
 msgstr ""
@@ -8295,40 +8472,40 @@ msgstr ""
 msgid "can't open user configuration file."
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:579
+#: ../src/common/zipstrm.cpp:572
 msgid "can't re-initialize zlib deflate stream"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:604
+#: ../src/common/zipstrm.cpp:597
 msgid "can't re-initialize zlib inflate stream"
 msgstr ""
 
-#: ../src/common/file.cpp:304
+#: ../src/common/file.cpp:345
 #, c-format
 msgid "can't read from file descriptor %d"
 msgstr ""
 
-#: ../src/common/file.cpp:581
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:608
 #, c-format
 msgid "can't remove file '%s'"
 msgstr ""
 
-#: ../src/common/file.cpp:598
+#: ../src/common/ffile.cpp:394 ../src/common/file.cpp:625
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr ""
 
-#: ../src/common/file.cpp:408
+#: ../src/common/file.cpp:449
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr ""
 
-#: ../src/common/textfile.cpp:273
+#: ../src/common/textfile.cpp:161
 #, c-format
 msgid "can't write buffer '%s' to disk."
 msgstr ""
 
-#: ../src/common/file.cpp:323
+#: ../src/common/file.cpp:364
 #, c-format
 msgid "can't write to file descriptor %d"
 msgstr ""
@@ -8338,22 +8515,28 @@ msgid "can't write user configuration file."
 msgstr ""
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:482 ../src/generic/datavgen.cpp:1261
+#: ../src/common/datavcmn.cpp:2064 ../src/generic/datavgen.cpp:1384
 msgid "checked"
 msgstr ""
 
-#: ../src/html/chm.cpp:345
+#: ../src/html/chm.cpp:342
 msgid "checksum error"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:820
+#: ../src/common/tarstrm.cpp:814
 msgid "checksum failure reading tar header block"
 msgstr ""
 
-#: ../src/richtext/richtextbackgroundpage.cpp:226
-#: ../src/richtext/richtextbackgroundpage.cpp:249
-#: ../src/richtext/richtextbackgroundpage.cpp:289
-#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
 #: ../src/richtext/richtextborderspage.cpp:254
 #: ../src/richtext/richtextborderspage.cpp:288
 #: ../src/richtext/richtextborderspage.cpp:322
@@ -8371,105 +8554,125 @@ msgstr ""
 #: ../src/richtext/richtextmarginspage.cpp:340
 #: ../src/richtext/richtextmarginspage.cpp:363
 #: ../src/richtext/richtextmarginspage.cpp:388
-#: ../src/richtext/richtextsizepage.cpp:339
-#: ../src/richtext/richtextsizepage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:400
-#: ../src/richtext/richtextsizepage.cpp:427
-#: ../src/richtext/richtextsizepage.cpp:454
-#: ../src/richtext/richtextsizepage.cpp:481
-#: ../src/richtext/richtextsizepage.cpp:555
-#: ../src/richtext/richtextsizepage.cpp:590
-#: ../src/richtext/richtextsizepage.cpp:625
-#: ../src/richtext/richtextsizepage.cpp:660
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
 msgid "cm"
 msgstr ""
 
-#: ../src/html/chm.cpp:347
+#: ../src/html/chm.cpp:344
 msgid "compression error"
 msgstr ""
 
-#: ../src/common/regex.cpp:236
+#: ../src/common/regex.cpp:233
 msgid "conversion to 8-bit encoding failed"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:187
+#: ../src/common/accelcmn.cpp:186
 msgid "ctrl"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1500
+#: ../src/common/cmdline.cpp:1496
 msgid "date"
 msgstr "تاريخ"
 
-#: ../src/html/chm.cpp:349
+#: ../src/html/chm.cpp:346
 msgid "decompression error"
 msgstr ""
 
-#: ../src/richtext/richtextstyles.cpp:780 ../src/common/fmapbase.cpp:820
+#: ../src/common/fmapbase.cpp:816 ../src/richtext/richtextstyles.cpp:777
 msgid "default"
 msgstr "إفتراضي"
 
-#: ../src/common/cmdline.cpp:1496
+#: ../src/common/cmdline.cpp:1492
 msgid "double"
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:538
+#: ../src/common/debugrpt.cpp:539
 msgid "dump of the process state (binary)"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1969
+#: ../src/common/datetimefmt.cpp:1992
 msgid "eighteenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1959
+#: ../src/common/datetimefmt.cpp:1982
 msgid "eighth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1962
+#: ../src/common/datetimefmt.cpp:1985
 msgid "eleventh"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1833
+#: ../src/common/fileconf.cpp:1835
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr ""
 
-#: ../src/html/chm.cpp:343
+#: ../src/html/chm.cpp:340
 msgid "error in data format"
 msgstr ""
 
-#: ../src/html/chm.cpp:331
+#: ../src/html/chm.cpp:328
 msgid "error opening file"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1778
+#: ../src/common/zipstrm.cpp:1836
 msgid "error reading zip central directory"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1870
+#: ../src/common/zipstrm.cpp:1940
 msgid "error reading zip local header"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2531
+#: ../src/common/zipstrm.cpp:2615
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr ""
 
-#: ../src/common/ffile.cpp:188
+#: ../src/common/zipstrm.cpp:2608
+#, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1205
+msgid "extrabold"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1223
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1167
+#, fuzzy
+msgid "extralight"
+msgstr "فاتح"
+
+#: ../src/msw/webview_ie.cpp:1036
+msgid "failed to evaluate"
+msgstr ""
+
+#: ../src/common/ffile.cpp:187
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr ""
 
+#: ../src/msw/webview_ie.cpp:1045
+msgid "failed to retrieve execution result"
+msgstr ""
+
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1030
+#: ../src/generic/datavgen.cpp:1150
 #, fuzzy
 msgid "false"
 msgstr "&ملف"
 
-#: ../src/common/datetimefmt.cpp:1966
+#: ../src/common/datetimefmt.cpp:1989
 msgid "fifteenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1956
+#: ../src/common/datetimefmt.cpp:1979
 msgid "fifth"
 msgstr ""
 
@@ -8498,132 +8701,151 @@ msgstr ""
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:8738
+#: ../src/richtext/richtextbuffer.cpp:8736
 msgid "files"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1952
+#: ../src/common/datetimefmt.cpp:1975
 msgid "first"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1252
+#: ../src/html/helpwnd.cpp:1250
 msgid "font size"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1965
+#: ../src/common/datetimefmt.cpp:1988
 msgid "fourteenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1955
+#: ../src/common/datetimefmt.cpp:1978
 msgid "fourth"
 msgstr ""
 
-#: ../src/common/appbase.cpp:783
+#: ../src/common/appbase.cpp:784
 msgid "generate verbose log messages"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:13138
-#: ../src/richtext/richtextbuffer.cpp:13248
+#: ../src/common/fontcmn.cpp:1215
+msgid "heavy"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:13133
+#: ../src/richtext/richtextbuffer.cpp:13243
 msgid "image"
 msgstr "صورة"
 
-#: ../src/common/tarstrm.cpp:796
+#: ../src/common/tarstrm.cpp:790
 msgid "incomplete header block in tar"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:489
+#: ../src/common/xtixml.cpp:485
 msgid "incorrect event handler string, missing dot"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:1381
+#: ../src/common/tarstrm.cpp:1375
 msgid "incorrect size given for tar entry"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:993
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:987
 msgid "invalid data in extended tar header"
 msgstr ""
 
-#: ../src/generic/logg.cpp:1030
+#: ../src/generic/logg.cpp:1027
 msgid "invalid message box return value"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1647
+#: ../src/common/zipstrm.cpp:1688
 msgid "invalid zip file"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:1228
 msgid "italic"
 msgstr "مائل"
 
-#: ../src/common/fontcmn.cpp:991
+#: ../src/common/webrequest_curl.cpp:374
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "تعذر تحميل الملف"
+
+#: ../src/common/fontcmn.cpp:1172
 msgid "light"
 msgstr "فاتح"
 
-#: ../src/common/intl.cpp:303
-#, c-format
-msgid "locale '%s' cannot be set."
+#: ../src/common/fontcmn.cpp:1185
+msgid "medium"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2125
+#: ../src/common/datetimefmt.cpp:2148
 msgid "midnight"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1970
+#: ../src/common/datetimefmt.cpp:1993
 msgid "nineteenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1960
+#: ../src/common/datetimefmt.cpp:1983
 msgid "ninth"
 msgstr ""
 
-#: ../src/msw/dde.cpp:1116
+#: ../src/msw/dde.cpp:1180
 msgid "no DDE error."
 msgstr ""
 
-#: ../src/html/chm.cpp:327
+#: ../src/html/chm.cpp:324
 msgid "no error"
 msgstr "لا يوجد خطأ"
 
-#: ../src/dfb/fontmgr.cpp:174
+#: ../src/dfb/fontmgr.cpp:171
 #, c-format
 msgid "no fonts found in %s, using builtin font"
 msgstr ""
 
-#: ../src/html/helpdata.cpp:657
+#: ../src/html/helpdata.cpp:650
 msgid "noname"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2124
+#: ../src/common/datetimefmt.cpp:2147
 msgid "noon"
 msgstr ""
 
-#: ../src/richtext/richtextstyles.cpp:779
+#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
 #, fuzzy
 msgid "normal"
 msgstr "عادي"
 
-#: ../src/common/cmdline.cpp:1492
+#: ../src/common/cmdline.cpp:1488
 msgid "num"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:259
+#: ../src/common/accelcmn.cpp:194
+msgid "num "
+msgstr ""
+
+#: ../src/common/xtixml.cpp:255
 msgid "objects cannot have XML Text Nodes"
 msgstr ""
 
-#: ../src/html/chm.cpp:339
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
 msgid "out of memory"
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:514
+#: ../src/common/debugrpt.cpp:515
 msgid "process context description"
 msgstr ""
 
-#: ../src/richtext/richtextbackgroundpage.cpp:227
-#: ../src/richtext/richtextbackgroundpage.cpp:250
-#: ../src/richtext/richtextbackgroundpage.cpp:290
-#: ../src/richtext/richtextbackgroundpage.cpp:317
-#: ../src/richtext/richtextfontpage.cpp:177
-#: ../src/richtext/richtextfontpage.cpp:180
 #: ../src/richtext/richtextborderspage.cpp:255
 #: ../src/richtext/richtextborderspage.cpp:289
 #: ../src/richtext/richtextborderspage.cpp:323
@@ -8633,22 +8855,45 @@ msgstr ""
 #: ../src/richtext/richtextborderspage.cpp:491
 #: ../src/richtext/richtextborderspage.cpp:525
 #: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextfontpage.cpp:180
 msgid "pt"
 msgstr ""
 
-#: ../src/richtext/richtextbackgroundpage.cpp:225
-#: ../src/richtext/richtextbackgroundpage.cpp:228
-#: ../src/richtext/richtextbackgroundpage.cpp:229
-#: ../src/richtext/richtextbackgroundpage.cpp:248
-#: ../src/richtext/richtextbackgroundpage.cpp:251
-#: ../src/richtext/richtextbackgroundpage.cpp:252
-#: ../src/richtext/richtextbackgroundpage.cpp:288
-#: ../src/richtext/richtextbackgroundpage.cpp:291
-#: ../src/richtext/richtextbackgroundpage.cpp:292
-#: ../src/richtext/richtextbackgroundpage.cpp:315
-#: ../src/richtext/richtextbackgroundpage.cpp:318
-#: ../src/richtext/richtextbackgroundpage.cpp:319
-#: ../src/richtext/richtextfontpage.cpp:178
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:659
+#: ../src/richtext/richtextsizepage.cpp:662
+#: ../src/richtext/richtextsizepage.cpp:663
 #: ../src/richtext/richtextborderspage.cpp:253
 #: ../src/richtext/richtextborderspage.cpp:256
 #: ../src/richtext/richtextborderspage.cpp:257
@@ -8700,261 +8945,271 @@ msgstr ""
 #: ../src/richtext/richtextmarginspage.cpp:387
 #: ../src/richtext/richtextmarginspage.cpp:389
 #: ../src/richtext/richtextmarginspage.cpp:390
-#: ../src/richtext/richtextsizepage.cpp:338
-#: ../src/richtext/richtextsizepage.cpp:341
-#: ../src/richtext/richtextsizepage.cpp:342
-#: ../src/richtext/richtextsizepage.cpp:372
-#: ../src/richtext/richtextsizepage.cpp:375
-#: ../src/richtext/richtextsizepage.cpp:376
-#: ../src/richtext/richtextsizepage.cpp:399
-#: ../src/richtext/richtextsizepage.cpp:402
-#: ../src/richtext/richtextsizepage.cpp:403
-#: ../src/richtext/richtextsizepage.cpp:426
-#: ../src/richtext/richtextsizepage.cpp:429
-#: ../src/richtext/richtextsizepage.cpp:430
-#: ../src/richtext/richtextsizepage.cpp:453
-#: ../src/richtext/richtextsizepage.cpp:456
-#: ../src/richtext/richtextsizepage.cpp:457
-#: ../src/richtext/richtextsizepage.cpp:480
-#: ../src/richtext/richtextsizepage.cpp:483
-#: ../src/richtext/richtextsizepage.cpp:484
-#: ../src/richtext/richtextsizepage.cpp:554
-#: ../src/richtext/richtextsizepage.cpp:557
-#: ../src/richtext/richtextsizepage.cpp:558
-#: ../src/richtext/richtextsizepage.cpp:589
-#: ../src/richtext/richtextsizepage.cpp:592
-#: ../src/richtext/richtextsizepage.cpp:593
-#: ../src/richtext/richtextsizepage.cpp:624
-#: ../src/richtext/richtextsizepage.cpp:627
-#: ../src/richtext/richtextsizepage.cpp:628
-#: ../src/richtext/richtextsizepage.cpp:659
-#: ../src/richtext/richtextsizepage.cpp:662
-#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextfontpage.cpp:178
 msgid "px"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:193
+#: ../src/common/accelcmn.cpp:192
 msgid "rawctrl"
 msgstr ""
 
-#: ../src/html/chm.cpp:333
+#: ../src/html/chm.cpp:330
 msgid "read error"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2085
+#: ../src/common/zipstrm.cpp:2155
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2080
+#: ../src/common/zipstrm.cpp:2150
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr ""
 
-#: ../src/msw/dde.cpp:1159
+#: ../src/msw/dde.cpp:1223
 msgid "reentrancy problem."
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1953
+#: ../src/common/datetimefmt.cpp:1976
 msgid "second"
 msgstr ""
 
-#: ../src/html/chm.cpp:337
+#: ../src/html/chm.cpp:334
 msgid "seek error"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1968
+#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#, fuzzy
+msgid "semibold"
+msgstr "عريض"
+
+#: ../src/common/datetimefmt.cpp:1991
 msgid "seventeenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1958
+#: ../src/common/datetimefmt.cpp:1981
 msgid "seventh"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:191
+#: ../src/common/accelcmn.cpp:190
 msgid "shift"
 msgstr ""
 
-#: ../src/common/appbase.cpp:773
+#: ../src/common/appbase.cpp:774
 msgid "show this help message"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1967
+#: ../src/common/datetimefmt.cpp:1990
 msgid "sixteenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1957
+#: ../src/common/datetimefmt.cpp:1980
 msgid "sixth"
 msgstr ""
 
-#: ../src/common/appcmn.cpp:234
+#: ../src/common/appcmn.cpp:255
 msgid "specify display mode to use (e.g. 640x480-16)"
 msgstr ""
 
-#: ../src/common/appcmn.cpp:220
+#: ../src/common/appcmn.cpp:241
 msgid "specify the theme to use"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9340
+#: ../src/richtext/richtextbuffer.cpp:9337
 msgid "standard/circle"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9341
+#: ../src/richtext/richtextbuffer.cpp:9338
 msgid "standard/circle-outline"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9343
+#: ../src/richtext/richtextbuffer.cpp:9340
 msgid "standard/diamond"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9342
+#: ../src/richtext/richtextbuffer.cpp:9339
 msgid "standard/square"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9344
+#: ../src/richtext/richtextbuffer.cpp:9341
 msgid "standard/triangle"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1985
+#: ../src/common/zipstrm.cpp:2055
 msgid "stored file length not in Zip header"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1488
+#: ../src/common/cmdline.cpp:1484
 msgid "str"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:982
+#: ../src/common/fontcmn.cpp:1145
 #, fuzzy
 msgid "strikethrough"
 msgstr "&يتوسطه خط"
 
-#: ../src/common/tarstrm.cpp:1003 ../src/common/tarstrm.cpp:1025
-#: ../src/common/tarstrm.cpp:1507 ../src/common/tarstrm.cpp:1529
+#: ../src/common/tarstrm.cpp:997 ../src/common/tarstrm.cpp:1019
+#: ../src/common/tarstrm.cpp:1501 ../src/common/tarstrm.cpp:1523
 msgid "tar entry not open"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1961
+#: ../src/common/datetimefmt.cpp:1984
 msgid "tenth"
 msgstr ""
 
-#: ../src/msw/dde.cpp:1123
+#: ../src/msw/dde.cpp:1187
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1954
+#: ../src/common/fontcmn.cpp:1154
+msgid "thin"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:1977
 msgid "third"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1964
+#: ../src/common/datetimefmt.cpp:1987
 msgid "thirteenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1758
+#: ../src/common/datetimefmt.cpp:1781
 msgid "today"
 msgstr "اليوم"
 
-#: ../src/common/datetimefmt.cpp:1760
+#: ../src/common/datetimefmt.cpp:1783
 msgid "tomorrow"
 msgstr "غدا"
 
-#: ../src/common/fileconf.cpp:1944
+#: ../src/common/fileconf.cpp:1946
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr ""
 
-#: ../src/gtk/aboutdlg.cpp:218
+#: ../src/gtk/aboutdlg.cpp:216
 msgid "translator-credits"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1028
+#: ../src/generic/datavgen.cpp:1148
 msgid "true"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1963
+#: ../src/common/datetimefmt.cpp:1986
 msgid "twelfth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1971
+#: ../src/common/datetimefmt.cpp:1994
 msgid "twentieth"
 msgstr ""
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:486 ../src/generic/datavgen.cpp:1263
+#: ../src/common/datavcmn.cpp:2068 ../src/generic/datavgen.cpp:1386
 msgid "unchecked"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:802 ../src/common/fontcmn.cpp:978
+#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
 msgid "underlined"
 msgstr ""
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:490
+#: ../src/common/datavcmn.cpp:2072
 #, fuzzy
 msgid "undetermined"
 msgstr "&غير محدد"
 
-#: ../src/common/fileconf.cpp:1979
+#: ../src/common/fileconf.cpp:1981
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:1045
+#: ../src/common/tarstrm.cpp:1039
 msgid "unexpected end of file"
 msgstr ""
 
-#: ../src/generic/progdlgg.cpp:370 ../src/common/tarstrm.cpp:371
-#: ../src/common/tarstrm.cpp:394 ../src/common/tarstrm.cpp:425
+#: ../src/common/tarstrm.cpp:366 ../src/common/tarstrm.cpp:389
+#: ../src/common/tarstrm.cpp:420 ../src/generic/progdlgg.cpp:376
 msgid "unknown"
 msgstr "غير معروف"
 
-#: ../src/msw/registry.cpp:150
+#: ../src/msw/registry.cpp:139
 #, fuzzy, c-format
 msgid "unknown (%lu)"
 msgstr "غير معروف"
 
-#: ../src/common/xtixml.cpp:253
+#: ../src/common/xtixml.cpp:249
 #, c-format
 msgid "unknown class %s"
 msgstr ""
 
-#: ../src/common/regex.cpp:258 ../src/html/chm.cpp:351
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "خطأ غير معروف"
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "خطأ غير معروف"
+
+#: ../src/common/regex.cpp:255 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "خطأ غير معروف"
 
-#: ../src/msw/dialup.cpp:471
+#: ../src/msw/dialup.cpp:465
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:834
+#: ../src/common/fmapbase.cpp:830
 #, c-format
 msgid "unknown-%d"
 msgstr ""
 
-#: ../src/common/docview.cpp:509
+#: ../src/common/docview.cpp:502
 msgid "unnamed"
 msgstr "غير مسمى"
 
-#: ../src/common/docview.cpp:1624
+#: ../src/common/docview.cpp:1618
 #, c-format
 msgid "unnamed%d"
 msgstr "غير مسمى %d"
 
-#: ../src/common/zipstrm.cpp:1999 ../src/common/zipstrm.cpp:2319
+#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
 msgid "unsupported Zip compression method"
 msgstr "طريقة تحويل zip غير معروفة."
 
-#: ../src/common/translation.cpp:1892
+#: ../src/common/translation.cpp:1942
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr ""
 
-#: ../src/html/chm.cpp:335
+#: ../src/html/chm.cpp:332
 msgid "write error"
 msgstr "كتابة خطأ"
 
-#: ../src/common/time.cpp:292
+#: ../src/gtk/glcanvas.cpp:187
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/common/time.cpp:285
 msgid "wxGetTimeOfDay failed."
 msgstr ""
 
@@ -8967,15 +9222,15 @@ msgstr "لا يمكن ل wxWidgets فتح الشاشة ل '%s': خروج"
 msgid "wxWidgets could not open display. Exiting."
 msgstr "لا يمكن ل wxWidgets فتح الشاشة. خروج."
 
-#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:431
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/common/datetimefmt.cpp:1759
+#: ../src/common/datetimefmt.cpp:1782
 msgid "yesterday"
 msgstr "أمس"
 
-#: ../src/common/zstream.cpp:251 ../src/common/zstream.cpp:426
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
 #, c-format
 msgid "zlib error %d"
 msgstr ""
@@ -8986,8 +9241,41 @@ msgid "~"
 msgstr "~"
 
 #, fuzzy
-#~ msgid "Column could not be added."
-#~ msgstr "تعذر تحميل الملف"
+#~ msgid "&Save as"
+#~ msgstr "حفظ بإسم"
+
+#, fuzzy
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' ينبغي أن يحتوي على أحرف أبجدية."
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' ينبغي أن يكون رقمي."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' ينبغي أن يحتوي على أحرف لها مكافئ رقمي."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' ينبغي أن يحتوي على أحرف أبجدية."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' ينبغي أن يحتوي على أحرف أبجدية أو رقمية."
+
+#, fuzzy
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' ينبغي أن يحتوي على أحرف لها مكافئ رقمي."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "لا يمكن إنشاء نافذة من تصنيف %s"
+
+#, fuzzy
+#~ msgid "Could not initalize libnotify."
+#~ msgstr "تعذر بدأ الطباعة."
+
+#~ msgid "Replace selection"
+#~ msgstr "استبدال التحديد"
+
+#~ msgid "Save as"
+#~ msgstr "حفظ باسم"
 
 #~ msgid "Confirm registry update"
 #~ msgstr "تأكيد تحديثات السجل"
@@ -9369,14 +9657,8 @@ msgstr "~"
 #~ msgid "Directory '%s' doesn't exist!"
 #~ msgstr "المجلد '%s' غير موجود؟"
 
-#~ msgid "Fatal error"
-#~ msgstr "خطأ فادح"
-
 #~ msgid "Fatal error: "
 #~ msgstr "خطأ فادح:"
-
-#~ msgid "File %s does not exist."
-#~ msgstr "الملف %s غير موجود."
 
 #~ msgid "Found "
 #~ msgstr "تم العثور عليه"

--- a/locale/ca.po
+++ b/locale/ca.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-21 14:25+0200\n"
+"POT-Creation-Date: 2020-10-18 23:11+0300\n"
 "PO-Revision-Date: 2020-02-17 00:54+0100\n"
 "Last-Translator: Eduard Ereza Martínez <eduard@ereza.cat>\n"
 "Language-Team: <wx-translators@wxwidgets.org>\n"
@@ -13,7 +13,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.10.1\n"
 
-#: ../src/common/debugrpt.cpp:586
+#: ../src/common/debugrpt.cpp:587
 msgid ""
 "\n"
 "Please send this report to the program maintainer, thank you!\n"
@@ -21,8 +21,8 @@ msgstr ""
 "\n"
 "Envieu aquest informe al mantenidor del programa. Gràcies!\n"
 
-#: ../src/richtext/richtextstyledlg.cpp:210
-#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:206
+#: ../src/richtext/richtextstyledlg.cpp:218
 msgid " "
 msgstr " "
 
@@ -30,70 +30,96 @@ msgstr " "
 msgid "              Thank you and we're sorry for the inconvenience!\n"
 msgstr "              Gràcies i disculpeu les molèsties!\n"
 
-#: ../src/common/prntbase.cpp:573
+#: ../src/common/prntbase.cpp:568
 #, c-format
 msgid " (copy %d of %d)"
 msgstr " (còpia %d de %d)"
 
-#: ../src/common/log.cpp:421
+#: ../src/common/log.cpp:440
 #, c-format
 msgid " (error %ld: %s)"
 msgstr " (error %ld: %s)"
 
-#: ../src/common/imagtiff.cpp:72
+#: ../src/common/imagtiff.cpp:69
 #, c-format
 msgid " (in module \"%s\")"
 msgstr " (al mòdul \"%s\")"
 
-#: ../src/osx/core/secretstore.cpp:138
-msgid " (while overwriting an existing item)"
-msgstr " (en sobreescriure un element existent)"
-
-#: ../src/common/docview.cpp:1642
+#: ../src/common/docview.cpp:1636
 msgid " - "
 msgstr " - "
 
-#: ../src/richtext/richtextprint.cpp:593 ../src/html/htmprint.cpp:714
+#: ../src/html/htmprint.cpp:712 ../src/richtext/richtextprint.cpp:589
 msgid " Preview"
 msgstr " Previsualitza"
 
-#: ../src/common/fontcmn.cpp:824
+#: ../src/common/fontcmn.cpp:973
 msgid " bold"
 msgstr " negreta"
 
-#: ../src/common/fontcmn.cpp:840
+#: ../src/common/fontcmn.cpp:977
+#, fuzzy
+msgid " extra bold"
+msgstr " negreta"
+
+#: ../src/common/fontcmn.cpp:985
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:957
+#, fuzzy
+msgid " extra light"
+msgstr " prima"
+
+#: ../src/common/fontcmn.cpp:981
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1001
 msgid " italic"
 msgstr " cursiva"
 
-#: ../src/common/fontcmn.cpp:820
+#: ../src/common/fontcmn.cpp:961
 msgid " light"
 msgstr " prima"
 
-#: ../src/common/fontcmn.cpp:807
+#: ../src/common/fontcmn.cpp:965
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:969
+#, fuzzy
+msgid " semi bold"
+msgstr " negreta"
+
+#: ../src/common/fontcmn.cpp:940
 msgid " strikethrough"
 msgstr " ratllat"
 
-#: ../src/common/paper.cpp:117
+#: ../src/common/fontcmn.cpp:953
+msgid " thin"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
 msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
 msgstr "Sobre núm. 10, 4 1/8 x 9 1/2 polz."
 
-#: ../src/common/paper.cpp:118
+#: ../src/common/paper.cpp:115
 msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
 msgstr "Sobre núm. 11, 4 1/2 x 10 3/8 polz."
 
-#: ../src/common/paper.cpp:119
+#: ../src/common/paper.cpp:116
 msgid "#12 Envelope, 4 3/4 x 11 in"
 msgstr "Sobre núm. 12, 4 3/4 x 11 polz."
 
-#: ../src/common/paper.cpp:120
+#: ../src/common/paper.cpp:117
 msgid "#14 Envelope, 5 x 11 1/2 in"
 msgstr "Sobre núm. 14, 5 x 11 1/2 polz."
 
-#: ../src/common/paper.cpp:116
+#: ../src/common/paper.cpp:113
 msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
 msgstr "Sobre núm. 9, 3 7/8 x 8 7/2 polz."
 
-#: ../src/richtext/richtextbackgroundpage.cpp:341
 #: ../src/richtext/richtextsizepage.cpp:340
 #: ../src/richtext/richtextsizepage.cpp:374
 #: ../src/richtext/richtextsizepage.cpp:401
@@ -104,81 +130,82 @@ msgstr "Sobre núm. 9, 3 7/8 x 8 7/2 polz."
 #: ../src/richtext/richtextsizepage.cpp:591
 #: ../src/richtext/richtextsizepage.cpp:626
 #: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextbackgroundpage.cpp:341
 msgid "%"
 msgstr "%"
 
-#: ../src/html/helpwnd.cpp:1031
+#: ../src/html/helpwnd.cpp:1029
 #, c-format
 msgid "%d of %lu"
 msgstr "%d de %lu"
 
-#: ../src/html/helpwnd.cpp:1678
+#: ../src/html/helpwnd.cpp:1676
 #, c-format
 msgid "%i of %u"
 msgstr "%i de %u"
 
-#: ../src/generic/filectrlg.cpp:279
+#: ../src/generic/filectrlg.cpp:275
 #, c-format
 msgid "%ld byte"
 msgid_plural "%ld bytes"
 msgstr[0] "%ld byte"
 msgstr[1] "%ld bytes"
 
-#: ../src/html/helpwnd.cpp:1033
+#: ../src/html/helpwnd.cpp:1031
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu de %lu"
 
-#: ../src/generic/datavgen.cpp:6028
+#: ../src/generic/datavgen.cpp:6833
 #, c-format
 msgid "%s (%d items)"
 msgstr "%s (%d elements)"
 
-#: ../src/common/cmdline.cpp:1221
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (o %s)"
 
-#: ../src/generic/logg.cpp:224
+#: ../src/generic/logg.cpp:221
 #, c-format
 msgid "%s Error"
 msgstr "Error: %s"
 
-#: ../src/generic/logg.cpp:236
+#: ../src/generic/logg.cpp:233
 #, c-format
 msgid "%s Information"
 msgstr "Informació: %s"
 
-#: ../src/generic/preferencesg.cpp:113
+#: ../src/generic/preferencesg.cpp:110
 #, c-format
 msgid "%s Preferences"
 msgstr "Preferències de %s"
 
-#: ../src/generic/logg.cpp:228
+#: ../src/generic/logg.cpp:225
 #, c-format
 msgid "%s Warning"
 msgstr "Advertència: %s"
 
-#: ../src/common/tarstrm.cpp:1319
+#: ../src/common/tarstrm.cpp:1313
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s no s'ajustava a la capçalera tar per a l'entrada '%s'"
 
-#: ../src/common/fldlgcmn.cpp:124
+#: ../src/common/fldlgcmn.cpp:121
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "Fitxers %s (%s)|%s"
 
-#: ../src/html/helpwnd.cpp:1716
+#: ../src/html/helpwnd.cpp:1714
 #, c-format
 msgid "%u of %u"
 msgstr "%u de %u"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "&About"
 msgstr "Qu&ant a"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "&Actual Size"
 msgstr "Mid&a real"
 
@@ -186,28 +213,28 @@ msgstr "Mid&a real"
 msgid "&After a paragraph:"
 msgstr "Després d'un p&aràgraf:"
 
-#: ../src/richtext/richtextindentspage.cpp:128
 #: ../src/richtext/richtextliststylepage.cpp:319
+#: ../src/richtext/richtextindentspage.cpp:128
 msgid "&Alignment"
 msgstr "&Alineació"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "&Apply"
 msgstr "&Aplica"
 
-#: ../src/richtext/richtextstyledlg.cpp:251
+#: ../src/richtext/richtextstyledlg.cpp:247
 msgid "&Apply Style"
 msgstr "&Aplica l'estil"
 
-#: ../src/msw/mdi.cpp:179
+#: ../src/msw/mdi.cpp:174
 msgid "&Arrange Icons"
 msgstr "&Organitza les icones"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "&Ascending"
 msgstr "&Ascendent"
 
-#: ../src/common/stockitem.cpp:142
+#: ../src/common/stockitem.cpp:139
 msgid "&Back"
 msgstr "&Endarrere"
 
@@ -227,24 +254,24 @@ msgstr "Color de &fons:"
 msgid "&Blur distance:"
 msgstr "Distància del &difuminat:"
 
-#: ../src/common/stockitem.cpp:143
+#: ../src/common/stockitem.cpp:140
 msgid "&Bold"
 msgstr "&Negreta"
 
-#: ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141
 msgid "&Bottom"
 msgstr "&Inferior"
 
+#: ../src/richtext/richtextsizepage.cpp:637
+#: ../src/richtext/richtextsizepage.cpp:644
 #: ../src/richtext/richtextborderspage.cpp:345
 #: ../src/richtext/richtextborderspage.cpp:513
 #: ../src/richtext/richtextmarginspage.cpp:259
 #: ../src/richtext/richtextmarginspage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:637
-#: ../src/richtext/richtextsizepage.cpp:644
 msgid "&Bottom:"
 msgstr "&Inferior:"
 
-#: ../include/wx/richtext/richtextbuffer.h:3866
+#: ../include/wx/richtext/richtextbuffer.h:3861
 msgid "&Box"
 msgstr "&Caixa"
 
@@ -253,38 +280,38 @@ msgstr "&Caixa"
 msgid "&Bullet style:"
 msgstr "Estil de &pic:"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "&CD-Rom"
 msgstr "&CD-ROM"
 
-#: ../src/generic/wizard.cpp:434 ../src/generic/fontdlgg.cpp:470
-#: ../src/generic/fontdlgg.cpp:489 ../src/osx/carbon/fontdlg.cpp:402
-#: ../src/common/dlgcmn.cpp:279 ../src/common/stockitem.cpp:145
+#: ../src/osx/carbon/fontdlg.cpp:399 ../src/common/stockitem.cpp:142
+#: ../src/generic/wizard.cpp:433 ../src/generic/fontdlgg.cpp:466
+#: ../src/generic/fontdlgg.cpp:485 ../src/osx/cocoa/button.mm:200
 msgid "&Cancel"
 msgstr "&Cancel·la"
 
-#: ../src/msw/mdi.cpp:175
+#: ../src/msw/mdi.cpp:170
 msgid "&Cascade"
 msgstr "En &cascada"
 
-#: ../include/wx/richtext/richtextbuffer.h:5960
+#: ../include/wx/richtext/richtextbuffer.h:5955
 msgid "&Cell"
 msgstr "&Cel·la"
 
-#: ../src/richtext/richtextsymboldlg.cpp:439
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "&Character code:"
 msgstr "&Codi de caràcter:"
 
-#: ../src/common/stockitem.cpp:147
+#: ../src/common/stockitem.cpp:144
 msgid "&Clear"
 msgstr "&Neteja"
 
-#: ../src/generic/logg.cpp:516 ../src/common/stockitem.cpp:148
-#: ../src/common/prntbase.cpp:1600 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/stockitem.cpp:145 ../src/common/prntbase.cpp:1625
+#: ../src/univ/themes/win32.cpp:3753 ../src/generic/logg.cpp:513
 msgid "&Close"
 msgstr "Tan&ca"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "&Color"
 msgstr "&Color"
 
@@ -292,20 +319,20 @@ msgstr "&Color"
 msgid "&Colour:"
 msgstr "&Color:"
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "&Convert"
 msgstr "&Converteix"
 
-#: ../src/richtext/richtextctrl.cpp:333 ../src/osx/textctrl_osx.cpp:577
-#: ../src/common/stockitem.cpp:150 ../src/msw/textctrl.cpp:2508
+#: ../src/osx/textctrl_osx.cpp:595 ../src/common/stockitem.cpp:147
+#: ../src/msw/textctrl.cpp:2773 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Copia"
 
-#: ../src/generic/hyperlinkg.cpp:156
+#: ../src/generic/hyperlinkg.cpp:153
 msgid "&Copy URL"
 msgstr "&Copia l'URL"
 
-#: ../src/common/headerctrlcmn.cpp:306
+#: ../src/common/headerctrlcmn.cpp:304
 msgid "&Customize..."
 msgstr "&Personalitza..."
 
@@ -313,53 +340,54 @@ msgstr "&Personalitza..."
 msgid "&Debug report preview:"
 msgstr "Previsualització &de l'informe de depuració:"
 
-#: ../src/richtext/richtexttabspage.cpp:138
-#: ../src/richtext/richtextctrl.cpp:335 ../src/osx/textctrl_osx.cpp:579
-#: ../src/common/stockitem.cpp:152 ../src/msw/textctrl.cpp:2510
+#: ../src/osx/textctrl_osx.cpp:597 ../src/common/stockitem.cpp:149
+#: ../src/msw/textctrl.cpp:2775 ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtextctrl.cpp:334
 msgid "&Delete"
 msgstr "&Suprimeix"
 
-#: ../src/richtext/richtextstyledlg.cpp:269
+#: ../src/richtext/richtextstyledlg.cpp:265
 msgid "&Delete Style..."
 msgstr "&Suprimeix l'estil..."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "&Descending"
 msgstr "&Descendent"
 
-#: ../src/generic/logg.cpp:682
+#: ../src/generic/logg.cpp:679
 msgid "&Details"
 msgstr "&Detalls"
 
-#: ../src/common/stockitem.cpp:153
+#: ../src/common/stockitem.cpp:150
 msgid "&Down"
 msgstr "A&vall"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "&Edit"
 msgstr "&Edita"
 
-#: ../src/richtext/richtextstyledlg.cpp:263
+#: ../src/richtext/richtextstyledlg.cpp:259
 msgid "&Edit Style..."
 msgstr "&Edita l'estil..."
 
-#: ../src/common/stockitem.cpp:155
+#: ../src/common/stockitem.cpp:152
 msgid "&Execute"
 msgstr "&Executa"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/common/stockitem.cpp:154
 msgid "&File"
 msgstr "&Fitxer"
 
-#: ../src/common/stockitem.cpp:158
-msgid "&Find"
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "&Find..."
 msgstr "&Cerca"
 
-#: ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:430
 msgid "&Finish"
 msgstr "&Finalitza"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:156
 msgid "&First"
 msgstr "&Primer"
 
@@ -367,15 +395,15 @@ msgstr "&Primer"
 msgid "&Floating mode:"
 msgstr "Mode &flotant:"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "&Floppy"
 msgstr "&Disquet"
 
-#: ../src/common/stockitem.cpp:194
+#: ../src/common/stockitem.cpp:191
 msgid "&Font"
 msgstr "&Tipus de lletra"
 
-#: ../src/generic/fontdlgg.cpp:371
+#: ../src/generic/fontdlgg.cpp:367
 msgid "&Font family:"
 msgstr "&Família del tipus de lletra:"
 
@@ -383,20 +411,20 @@ msgstr "&Família del tipus de lletra:"
 msgid "&Font for Level..."
 msgstr "Tip&us de lletra per al nivell..."
 
+#: ../src/richtext/richtextsymboldlg.cpp:397
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:400
 msgid "&Font:"
 msgstr "&Tipus de lletra:"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "&Forward"
 msgstr "Enda&vant"
 
-#: ../src/richtext/richtextsymboldlg.cpp:451
+#: ../src/richtext/richtextsymboldlg.cpp:448
 msgid "&From:"
 msgstr "&De:"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "&Harddisk"
 msgstr "&Disc dur"
 
@@ -405,9 +433,9 @@ msgstr "&Disc dur"
 msgid "&Height:"
 msgstr "&Alçada:"
 
-#: ../src/generic/wizard.cpp:441 ../src/richtext/richtextstyledlg.cpp:303
-#: ../src/richtext/richtextsymboldlg.cpp:479 ../src/osx/menu_osx.cpp:734
-#: ../src/common/stockitem.cpp:163
+#: ../src/common/stockitem.cpp:160 ../src/generic/wizard.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextstyledlg.cpp:299 ../src/osx/cocoa/menu.mm:226
 msgid "&Help"
 msgstr "&Ajuda"
 
@@ -415,7 +443,7 @@ msgstr "&Ajuda"
 msgid "&Hide details"
 msgstr "&Amaga els detalls"
 
-#: ../src/common/stockitem.cpp:164
+#: ../src/common/stockitem.cpp:161
 msgid "&Home"
 msgstr "&Inici"
 
@@ -423,54 +451,54 @@ msgstr "&Inici"
 msgid "&Horizontal offset:"
 msgstr "Desplaçament &horitzontal:"
 
-#: ../src/richtext/richtextindentspage.cpp:184
 #: ../src/richtext/richtextliststylepage.cpp:372
+#: ../src/richtext/richtextindentspage.cpp:184
 msgid "&Indentation (tenths of a mm)"
 msgstr "Sagnat (dèc&imes de mm)"
 
-#: ../src/richtext/richtextindentspage.cpp:167
 #: ../src/richtext/richtextliststylepage.cpp:356
+#: ../src/richtext/richtextindentspage.cpp:167
 msgid "&Indeterminate"
 msgstr "&Indeterminat"
 
-#: ../src/common/stockitem.cpp:166
+#: ../src/common/stockitem.cpp:163
 msgid "&Index"
 msgstr "Í&ndex"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "&Info"
 msgstr "&Informació"
 
-#: ../src/common/stockitem.cpp:168
+#: ../src/common/stockitem.cpp:165
 msgid "&Italic"
 msgstr "Curs&iva"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "&Jump to"
 msgstr "&Vés a"
 
-#: ../src/richtext/richtextindentspage.cpp:153
 #: ../src/richtext/richtextliststylepage.cpp:342
+#: ../src/richtext/richtextindentspage.cpp:153
 msgid "&Justified"
 msgstr "&Justificat"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "&Last"
 msgstr "Ú&ltim"
 
-#: ../src/richtext/richtextindentspage.cpp:139
 #: ../src/richtext/richtextliststylepage.cpp:328
+#: ../src/richtext/richtextindentspage.cpp:139
 msgid "&Left"
 msgstr "&Esquerra"
 
-#: ../src/richtext/richtextindentspage.cpp:195
+#: ../src/richtext/richtextsizepage.cpp:532
+#: ../src/richtext/richtextsizepage.cpp:539
 #: ../src/richtext/richtextborderspage.cpp:243
 #: ../src/richtext/richtextborderspage.cpp:411
 #: ../src/richtext/richtextliststylepage.cpp:381
+#: ../src/richtext/richtextindentspage.cpp:195
 #: ../src/richtext/richtextmarginspage.cpp:186
 #: ../src/richtext/richtextmarginspage.cpp:300
-#: ../src/richtext/richtextsizepage.cpp:532
-#: ../src/richtext/richtextsizepage.cpp:539
 msgid "&Left:"
 msgstr "&Esquerra:"
 
@@ -478,11 +506,11 @@ msgstr "&Esquerra:"
 msgid "&List level:"
 msgstr "Nivell de la &llista:"
 
-#: ../src/generic/logg.cpp:517
+#: ../src/generic/logg.cpp:514
 msgid "&Log"
 msgstr "&Registre"
 
-#: ../src/univ/themes/win32.cpp:3748
+#: ../src/univ/themes/win32.cpp:3745
 msgid "&Move"
 msgstr "&Mou"
 
@@ -490,20 +518,19 @@ msgstr "&Mou"
 msgid "&Move the object to:"
 msgstr "&Mou l'objecte a:"
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "&Network"
 msgstr "&Xarxa"
 
-#: ../src/richtext/richtexttabspage.cpp:132 ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173 ../src/richtext/richtexttabspage.cpp:132
 msgid "&New"
 msgstr "&Nou"
 
-#: ../src/aui/tabmdi.cpp:111 ../src/generic/mdig.cpp:100
-#: ../src/msw/mdi.cpp:180
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
 msgid "&Next"
 msgstr "&Següent"
 
-#: ../src/generic/wizard.cpp:432 ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:429
 msgid "&Next >"
 msgstr "E&ndavant >"
 
@@ -511,7 +538,7 @@ msgstr "E&ndavant >"
 msgid "&Next Paragraph"
 msgstr "Paràgraf següe&nt"
 
-#: ../src/generic/tipdlg.cpp:240
+#: ../src/generic/tipdlg.cpp:237
 msgid "&Next Tip"
 msgstr "Següe&nt consell"
 
@@ -519,11 +546,11 @@ msgstr "Següe&nt consell"
 msgid "&Next style:"
 msgstr "Següe&nt estil:"
 
-#: ../src/common/stockitem.cpp:177 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:174 ../src/msw/msgdlg.cpp:435
 msgid "&No"
 msgstr "&No"
 
-#: ../src/generic/dbgrptg.cpp:356
+#: ../src/generic/dbgrptg.cpp:360
 msgid "&Notes:"
 msgstr "&Notes:"
 
@@ -531,12 +558,12 @@ msgstr "&Notes:"
 msgid "&Number:"
 msgstr "&Número:"
 
-#: ../src/generic/fontdlgg.cpp:475 ../src/generic/fontdlgg.cpp:482
-#: ../src/osx/carbon/fontdlg.cpp:408 ../src/common/stockitem.cpp:178
+#: ../src/osx/carbon/fontdlg.cpp:405 ../src/common/stockitem.cpp:175
+#: ../src/generic/fontdlgg.cpp:471 ../src/generic/fontdlgg.cpp:478
 msgid "&OK"
 msgstr "D'ac&ord"
 
-#: ../src/generic/dbgrptg.cpp:342 ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176 ../src/generic/dbgrptg.cpp:342
 msgid "&Open..."
 msgstr "&Obre..."
 
@@ -548,16 +575,16 @@ msgstr "Nivell del c&ontorn:"
 msgid "&Page Break"
 msgstr "Salt de &pàgina"
 
-#: ../src/richtext/richtextctrl.cpp:334 ../src/osx/textctrl_osx.cpp:578
-#: ../src/common/stockitem.cpp:180 ../src/msw/textctrl.cpp:2509
+#: ../src/osx/textctrl_osx.cpp:596 ../src/common/stockitem.cpp:177
+#: ../src/msw/textctrl.cpp:2774 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&Enganxa"
 
-#: ../include/wx/richtext/richtextbuffer.h:5010
+#: ../include/wx/richtext/richtextbuffer.h:5005
 msgid "&Picture"
 msgstr "&Imatge"
 
-#: ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:419
 msgid "&Point size:"
 msgstr "Mida en &punts:"
 
@@ -569,12 +596,11 @@ msgstr "&Posició (dècimes de mm):"
 msgid "&Position mode:"
 msgstr "&Mode de posicionament:"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178
 msgid "&Preferences"
 msgstr "&Preferències"
 
-#: ../src/aui/tabmdi.cpp:112 ../src/generic/mdig.cpp:101
-#: ../src/msw/mdi.cpp:181
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
 msgid "&Previous"
 msgstr "&Anterior"
 
@@ -582,78 +608,74 @@ msgstr "&Anterior"
 msgid "&Previous Paragraph"
 msgstr "&Paràgraf anterior"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "&Print..."
 msgstr "Im&primeix..."
 
-#: ../src/richtext/richtextctrl.cpp:339 ../src/richtext/richtextctrl.cpp:5514
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtextctrl.cpp:338
+#: ../src/richtext/richtextctrl.cpp:5512
 msgid "&Properties"
 msgstr "&Propietats"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "&Quit"
 msgstr "&Surt"
 
-#: ../src/richtext/richtextctrl.cpp:330 ../src/osx/textctrl_osx.cpp:574
-#: ../src/common/stockitem.cpp:185 ../src/common/cmdproc.cpp:293
-#: ../src/common/cmdproc.cpp:300 ../src/msw/textctrl.cpp:2505
+#: ../src/osx/textctrl_osx.cpp:592 ../src/common/stockitem.cpp:182
+#: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
+#: ../src/msw/textctrl.cpp:2770 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Refés"
 
-#: ../src/common/cmdproc.cpp:289 ../src/common/cmdproc.cpp:309
+#: ../src/common/cmdproc.cpp:282 ../src/common/cmdproc.cpp:302
 msgid "&Redo "
 msgstr "&Refés "
 
-#: ../src/richtext/richtextstyledlg.cpp:257
+#: ../src/richtext/richtextstyledlg.cpp:253
 msgid "&Rename Style..."
 msgstr "&Canvia el nom de l'estil..."
 
-#: ../src/generic/fdrepdlg.cpp:179
+#: ../src/generic/fdrepdlg.cpp:176
 msgid "&Replace"
 msgstr "&Substitueix"
 
-#: ../src/richtext/richtextstyledlg.cpp:287
+#: ../src/richtext/richtextstyledlg.cpp:283
 msgid "&Restart numbering"
 msgstr "&Reinicia la numeració"
 
-#: ../src/univ/themes/win32.cpp:3747
+#: ../src/univ/themes/win32.cpp:3744
 msgid "&Restore"
 msgstr "&Restaura"
 
-#: ../src/richtext/richtextindentspage.cpp:146
 #: ../src/richtext/richtextliststylepage.cpp:335
+#: ../src/richtext/richtextindentspage.cpp:146
 msgid "&Right"
 msgstr "D&reta"
 
-#: ../src/richtext/richtextindentspage.cpp:213
+#: ../src/richtext/richtextsizepage.cpp:602
+#: ../src/richtext/richtextsizepage.cpp:609
 #: ../src/richtext/richtextborderspage.cpp:277
 #: ../src/richtext/richtextborderspage.cpp:445
 #: ../src/richtext/richtextliststylepage.cpp:399
+#: ../src/richtext/richtextindentspage.cpp:213
 #: ../src/richtext/richtextmarginspage.cpp:211
 #: ../src/richtext/richtextmarginspage.cpp:325
-#: ../src/richtext/richtextsizepage.cpp:602
-#: ../src/richtext/richtextsizepage.cpp:609
 msgid "&Right:"
 msgstr "D&reta:"
 
-#: ../src/common/stockitem.cpp:190
+#: ../src/common/stockitem.cpp:187
 msgid "&Save"
 msgstr "De&sa"
-
-#: ../src/common/stockitem.cpp:191
-msgid "&Save as"
-msgstr "Anomena i de&sa"
 
 #: ../include/wx/richmsgdlg.h:29
 msgid "&See details"
 msgstr "Mo&stra els detalls"
 
-#: ../src/generic/tipdlg.cpp:236
+#: ../src/generic/tipdlg.cpp:233
 msgid "&Show tips at startup"
 msgstr "Mo&stra els consells en iniciar"
 
-#: ../src/univ/themes/win32.cpp:3750
+#: ../src/univ/themes/win32.cpp:3747
 msgid "&Size"
 msgstr "&Mida"
 
@@ -661,36 +683,36 @@ msgstr "&Mida"
 msgid "&Size:"
 msgstr "&Mida:"
 
-#: ../src/generic/progdlgg.cpp:252
+#: ../src/generic/progdlgg.cpp:249
 msgid "&Skip"
 msgstr "&Omet"
 
-#: ../src/richtext/richtextindentspage.cpp:242
 #: ../src/richtext/richtextliststylepage.cpp:417
+#: ../src/richtext/richtextindentspage.cpp:242
 msgid "&Spacing (tenths of a mm)"
 msgstr "E&spaiat (dècimes de mm)"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "&Spell Check"
 msgstr "&Comprova l'ortografia"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "&Stop"
 msgstr "A&tura"
 
-#: ../src/richtext/richtextfontpage.cpp:275 ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196 ../src/richtext/richtextfontpage.cpp:275
 msgid "&Strikethrough"
 msgstr "&Ratllat"
 
-#: ../src/generic/fontdlgg.cpp:382 ../src/richtext/richtextstylepage.cpp:106
+#: ../src/generic/fontdlgg.cpp:378 ../src/richtext/richtextstylepage.cpp:106
 msgid "&Style:"
 msgstr "E&stil:"
 
-#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:194
 msgid "&Styles:"
 msgstr "E&stils:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:413
+#: ../src/richtext/richtextsymboldlg.cpp:410
 msgid "&Subset:"
 msgstr "&Subconjunt:"
 
@@ -704,24 +726,24 @@ msgstr "&Símbol:"
 msgid "&Synchronize values"
 msgstr "&Sincronitza els valors"
 
-#: ../include/wx/richtext/richtextbuffer.h:6069
+#: ../include/wx/richtext/richtextbuffer.h:6064
 msgid "&Table"
 msgstr "&Taula"
 
-#: ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197
 msgid "&Top"
 msgstr "Dal&t de tot"
 
+#: ../src/richtext/richtextsizepage.cpp:567
+#: ../src/richtext/richtextsizepage.cpp:574
 #: ../src/richtext/richtextborderspage.cpp:311
 #: ../src/richtext/richtextborderspage.cpp:479
 #: ../src/richtext/richtextmarginspage.cpp:234
 #: ../src/richtext/richtextmarginspage.cpp:348
-#: ../src/richtext/richtextsizepage.cpp:567
-#: ../src/richtext/richtextsizepage.cpp:574
 msgid "&Top:"
 msgstr "&Superior:"
 
-#: ../src/generic/fontdlgg.cpp:444 ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199 ../src/generic/fontdlgg.cpp:441
 msgid "&Underline"
 msgstr "S&ubratllat"
 
@@ -729,21 +751,21 @@ msgstr "S&ubratllat"
 msgid "&Underlining:"
 msgstr "S&ubratllat:"
 
-#: ../src/richtext/richtextctrl.cpp:329 ../src/osx/textctrl_osx.cpp:573
-#: ../src/common/stockitem.cpp:203 ../src/common/cmdproc.cpp:271
-#: ../src/msw/textctrl.cpp:2504
+#: ../src/osx/textctrl_osx.cpp:591 ../src/common/stockitem.cpp:200
+#: ../src/common/cmdproc.cpp:264 ../src/msw/textctrl.cpp:2769
+#: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Desfés"
 
-#: ../src/common/cmdproc.cpp:265
+#: ../src/common/cmdproc.cpp:258
 msgid "&Undo "
 msgstr "&Desfés "
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "&Unindent"
 msgstr "Desfés el sa&gnat"
 
-#: ../src/common/stockitem.cpp:205
+#: ../src/common/stockitem.cpp:202
 msgid "&Up"
 msgstr "Am&unt"
 
@@ -759,7 +781,7 @@ msgstr "Desplaçament &vertical:"
 msgid "&View..."
 msgstr "&Visualitza..."
 
-#: ../src/generic/fontdlgg.cpp:393
+#: ../src/generic/fontdlgg.cpp:389
 msgid "&Weight:"
 msgstr "&Pes:"
 
@@ -768,88 +790,58 @@ msgstr "&Pes:"
 msgid "&Width:"
 msgstr "A&mplada:"
 
-#: ../src/aui/tabmdi.cpp:311 ../src/aui/tabmdi.cpp:327
-#: ../src/aui/tabmdi.cpp:329 ../src/generic/mdig.cpp:294
-#: ../src/generic/mdig.cpp:310 ../src/generic/mdig.cpp:314
-#: ../src/msw/mdi.cpp:78
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
 msgid "&Window"
 msgstr "&Finestra"
 
-#: ../src/common/stockitem.cpp:206 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:203 ../src/msw/msgdlg.cpp:435
 msgid "&Yes"
 msgstr "&Sí"
 
-#: ../src/common/valtext.cpp:256
-#, c-format
-msgid "'%s' contains illegal characters"
+#: ../src/common/valtext.cpp:197
+#, fuzzy, c-format
+msgid "'%s' contains invalid character(s)"
 msgstr "'%s' conté caràcters no permesos"
 
-#: ../src/common/valtext.cpp:254
-#, c-format
-msgid "'%s' doesn't consist only of valid characters"
-msgstr "'%s' no consisteix només de caràcters vàlids"
-
-#: ../src/common/config.cpp:519 ../src/msw/regconf.cpp:258
+#: ../src/common/config.cpp:515 ../src/msw/regconf.cpp:255
 #, c-format
 msgid "'%s' has extra '..', ignored."
 msgstr "'%s' té '..' extra, s'ha ignorat."
 
-#: ../src/common/cmdline.cpp:1113 ../src/common/cmdline.cpp:1131
+#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' no és valor numèric correcte per a l'opció '%s'."
 
-#: ../src/common/translation.cpp:1100
+#: ../src/common/translation.cpp:1142
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' no és un missatge de catàleg vàlid."
 
-#: ../src/common/valtext.cpp:165
+#: ../src/common/valtext.cpp:188
 #, c-format
 msgid "'%s' is not one of the valid strings"
 msgstr "'%s' no és una de les cadenes vàlides"
 
-#: ../src/common/valtext.cpp:167
+#: ../src/common/valtext.cpp:186
 #, c-format
 msgid "'%s' is one of the invalid strings"
 msgstr "'%s' és una de les cadenes invàlides"
 
-#: ../src/common/textbuf.cpp:237
+#: ../src/common/textbuf.cpp:233
 #, c-format
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' és probablement memòria intermèdia binària."
-
-#: ../src/common/valtext.cpp:252
-#, c-format
-msgid "'%s' should be numeric."
-msgstr "'%s' hauria de ser numèric."
-
-#: ../src/common/valtext.cpp:244
-#, c-format
-msgid "'%s' should only contain ASCII characters."
-msgstr "'%s' només hauria de contenir caràcters ASCII."
-
-#: ../src/common/valtext.cpp:246
-#, c-format
-msgid "'%s' should only contain alphabetic characters."
-msgstr "'%s' només hauria de contenir caràcters alfabètics."
-
-#: ../src/common/valtext.cpp:248
-#, c-format
-msgid "'%s' should only contain alphabetic or numeric characters."
-msgstr "'%s' només hauria de contenir caràcters alfabètics o numèrics."
-
-#: ../src/common/valtext.cpp:250
-#, c-format
-msgid "'%s' should only contain digits."
-msgstr "'%s' només hauria de contenir dígits."
 
 #: ../src/richtext/richtextliststylepage.cpp:229
 #: ../src/richtext/richtextbulletspage.cpp:166
 msgid "(*)"
 msgstr "(*)"
 
-#: ../src/html/helpwnd.cpp:963
+#: ../src/html/helpwnd.cpp:961
 msgid "(Help)"
 msgstr "(Ajuda)"
 
@@ -858,27 +850,32 @@ msgstr "(Ajuda)"
 msgid "(None)"
 msgstr "(Cap)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:504
+#: ../src/richtext/richtextsymboldlg.cpp:503
 msgid "(Normal text)"
 msgstr "(Text normal)"
 
-#: ../src/html/helpwnd.cpp:419 ../src/html/helpwnd.cpp:1106
-#: ../src/html/helpwnd.cpp:1742
+#: ../src/html/helpwnd.cpp:417 ../src/html/helpwnd.cpp:1104
+#: ../src/html/helpwnd.cpp:1740
 msgid "(bookmarks)"
 msgstr "(preferits)"
 
+#: ../src/msw/dlmsw.cpp:167
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (error %ld: %s)"
+
+#: ../src/richtext/richtextformatdlg.cpp:876
+#: ../src/richtext/richtextliststylepage.cpp:448
+#: ../src/richtext/richtextliststylepage.cpp:460
+#: ../src/richtext/richtextliststylepage.cpp:461
 #: ../src/richtext/richtextindentspage.cpp:274
 #: ../src/richtext/richtextindentspage.cpp:286
 #: ../src/richtext/richtextindentspage.cpp:287
 #: ../src/richtext/richtextindentspage.cpp:311
 #: ../src/richtext/richtextindentspage.cpp:326
-#: ../src/richtext/richtextformatdlg.cpp:884
 #: ../src/richtext/richtextfontpage.cpp:349
 #: ../src/richtext/richtextfontpage.cpp:353
 #: ../src/richtext/richtextfontpage.cpp:357
-#: ../src/richtext/richtextliststylepage.cpp:448
-#: ../src/richtext/richtextliststylepage.cpp:460
-#: ../src/richtext/richtextliststylepage.cpp:461
 msgid "(none)"
 msgstr "(cap)"
 
@@ -897,7 +894,7 @@ msgstr "*)"
 msgid "+"
 msgstr "+"
 
-#: ../src/msw/utils.cpp:1152
+#: ../src/msw/utils.cpp:1143
 msgid ", 64-bit edition"
 msgstr ", edició de 64 bits"
 
@@ -906,163 +903,163 @@ msgstr ", edició de 64 bits"
 msgid "-"
 msgstr "-"
 
-#: ../src/generic/filepickerg.cpp:66
+#: ../src/generic/filepickerg.cpp:63
 msgid "..."
 msgstr "..."
 
-#: ../src/richtext/richtextindentspage.cpp:276
 #: ../src/richtext/richtextliststylepage.cpp:450
+#: ../src/richtext/richtextindentspage.cpp:276
 msgid "1.1"
 msgstr "1.1"
 
-#: ../src/richtext/richtextindentspage.cpp:277
 #: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextindentspage.cpp:277
 msgid "1.2"
 msgstr "1.2"
 
-#: ../src/richtext/richtextindentspage.cpp:278
 #: ../src/richtext/richtextliststylepage.cpp:452
+#: ../src/richtext/richtextindentspage.cpp:278
 msgid "1.3"
 msgstr "1.3"
 
-#: ../src/richtext/richtextindentspage.cpp:279
 #: ../src/richtext/richtextliststylepage.cpp:453
+#: ../src/richtext/richtextindentspage.cpp:279
 msgid "1.4"
 msgstr "1.4"
 
-#: ../src/richtext/richtextindentspage.cpp:280
 #: ../src/richtext/richtextliststylepage.cpp:454
+#: ../src/richtext/richtextindentspage.cpp:280
 msgid "1.5"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:281
 #: ../src/richtext/richtextliststylepage.cpp:455
+#: ../src/richtext/richtextindentspage.cpp:281
 msgid "1.6"
 msgstr "1.6"
 
-#: ../src/richtext/richtextindentspage.cpp:282
 #: ../src/richtext/richtextliststylepage.cpp:456
+#: ../src/richtext/richtextindentspage.cpp:282
 msgid "1.7"
 msgstr "1.7"
 
-#: ../src/richtext/richtextindentspage.cpp:283
 #: ../src/richtext/richtextliststylepage.cpp:457
+#: ../src/richtext/richtextindentspage.cpp:283
 msgid "1.8"
 msgstr "1.8"
 
-#: ../src/richtext/richtextindentspage.cpp:284
 #: ../src/richtext/richtextliststylepage.cpp:458
+#: ../src/richtext/richtextindentspage.cpp:284
 msgid "1.9"
 msgstr "1.9"
 
-#: ../src/common/paper.cpp:140
+#: ../src/common/paper.cpp:137
 msgid "10 x 11 in"
 msgstr "10 x 11 polz."
 
-#: ../src/common/paper.cpp:113
+#: ../src/common/paper.cpp:110
 msgid "10 x 14 in"
 msgstr "10 x 14 polz."
 
-#: ../src/common/paper.cpp:114
+#: ../src/common/paper.cpp:111
 msgid "11 x 17 in"
 msgstr "11 x 17 polz."
 
-#: ../src/common/paper.cpp:184
+#: ../src/common/paper.cpp:181
 msgid "12 x 11 in"
 msgstr "12 x 11 polz."
 
-#: ../src/common/paper.cpp:141
+#: ../src/common/paper.cpp:138
 msgid "15 x 11 in"
 msgstr "15 x 11 polz."
 
-#: ../src/richtext/richtextindentspage.cpp:285
 #: ../src/richtext/richtextliststylepage.cpp:459
+#: ../src/richtext/richtextindentspage.cpp:285
 msgid "2"
 msgstr "2"
 
-#: ../src/common/paper.cpp:132
+#: ../src/common/paper.cpp:129
 msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
 msgstr "Sobre 6 3/4, 3 5/8 x 6 1/2 polz."
 
-#: ../src/common/paper.cpp:139
+#: ../src/common/paper.cpp:136
 msgid "9 x 11 in"
 msgstr "9 x 11 polz."
 
-#: ../src/html/htmprint.cpp:431
+#: ../src/html/htmprint.cpp:443
 msgid ": file does not exist!"
 msgstr ": el fitxer no existeix!"
 
-#: ../src/common/fontmap.cpp:199
+#: ../src/common/fontmap.cpp:196
 msgid ": unknown charset"
 msgstr ": joc de caràcters desconegut"
 
-#: ../src/common/fontmap.cpp:413
+#: ../src/common/fontmap.cpp:410
 msgid ": unknown encoding"
 msgstr ": codificació desconeguda"
 
-#: ../src/generic/wizard.cpp:443
+#: ../src/generic/wizard.cpp:438
 msgid "< &Back"
 msgstr "< &Endarrere"
 
-#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:628
-#: ../src/osx/carbon/fontdlg.cpp:648
+#: ../src/osx/carbon/fontdlg.cpp:419 ../src/osx/carbon/fontdlg.cpp:625
+#: ../src/osx/carbon/fontdlg.cpp:645
 msgid "<Any Decorative>"
 msgstr "<Qualsevol decoratiu>"
 
-#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:630
-#: ../src/osx/carbon/fontdlg.cpp:650
+#: ../src/osx/carbon/fontdlg.cpp:420 ../src/osx/carbon/fontdlg.cpp:627
+#: ../src/osx/carbon/fontdlg.cpp:647
 msgid "<Any Modern>"
 msgstr "<Qualsevol modern>"
 
-#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:626
-#: ../src/osx/carbon/fontdlg.cpp:646
+#: ../src/osx/carbon/fontdlg.cpp:418 ../src/osx/carbon/fontdlg.cpp:623
+#: ../src/osx/carbon/fontdlg.cpp:643
 msgid "<Any Roman>"
 msgstr "<Qualsevol Roman>"
 
-#: ../src/osx/carbon/fontdlg.cpp:424 ../src/osx/carbon/fontdlg.cpp:632
-#: ../src/osx/carbon/fontdlg.cpp:652
+#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:629
+#: ../src/osx/carbon/fontdlg.cpp:649
 msgid "<Any Script>"
 msgstr "<Qualsevol Script>"
 
-#: ../src/osx/carbon/fontdlg.cpp:425 ../src/osx/carbon/fontdlg.cpp:637
-#: ../src/osx/carbon/fontdlg.cpp:656
+#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:634
+#: ../src/osx/carbon/fontdlg.cpp:653
 msgid "<Any Swiss>"
 msgstr "<Qualsevol Suís>"
 
-#: ../src/osx/carbon/fontdlg.cpp:426 ../src/osx/carbon/fontdlg.cpp:634
-#: ../src/osx/carbon/fontdlg.cpp:654
+#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:631
+#: ../src/osx/carbon/fontdlg.cpp:651
 msgid "<Any Teletype>"
 msgstr "<Qualsevol Teletip>"
 
-#: ../src/osx/carbon/fontdlg.cpp:420
+#: ../src/osx/carbon/fontdlg.cpp:417
 msgid "<Any>"
 msgstr "<Qualsevol>"
 
-#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
 msgid "<DIR>"
 msgstr "<DIRECTORI>"
 
-#: ../src/generic/filectrlg.cpp:254 ../src/generic/filectrlg.cpp:277
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
 msgid "<DRIVE>"
 msgstr "<UNITAT>"
 
-#: ../src/generic/filectrlg.cpp:252 ../src/generic/filectrlg.cpp:275
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
 msgid "<LINK>"
 msgstr "<ENLLAÇ>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1264
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Negreta i cursiva.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1270
+#: ../src/html/helpwnd.cpp:1268
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>negreta i cursiva <u>subratllada</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1265
+#: ../src/html/helpwnd.cpp:1263
 msgid "<b>Bold face.</b> "
 msgstr "<b>Negreta.</b> "
 
-#: ../src/html/helpwnd.cpp:1264
+#: ../src/html/helpwnd.cpp:1262
 msgid "<i>Italic face.</i> "
 msgstr "<i>Cursiva.</i> "
 
@@ -1071,15 +1068,15 @@ msgstr "<i>Cursiva.</i> "
 msgid ">"
 msgstr ">"
 
-#: ../src/generic/dbgrptg.cpp:318
+#: ../src/generic/dbgrptg.cpp:317
 msgid "A debug report has been generated in the directory\n"
 msgstr "S'ha generat un informe de depuració al driectori\n"
 
-#: ../src/common/debugrpt.cpp:573
+#: ../src/common/debugrpt.cpp:574
 msgid "A debug report has been generated. It can be found in"
 msgstr "S'ha generat un informe de depuració. Podeu trobar-lo a"
 
-#: ../src/common/xtixml.cpp:418
+#: ../src/common/xtixml.cpp:414
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Una col·lecció no buida ha de consistir de nodes 'element'"
 
@@ -1090,106 +1087,106 @@ msgstr "Una col·lecció no buida ha de consistir de nodes 'element'"
 msgid "A standard bullet name."
 msgstr "Un nom de pic estàndard."
 
-#: ../src/common/paper.cpp:217
+#: ../src/common/paper.cpp:214
 msgid "A0 sheet, 841 x 1189 mm"
 msgstr "Full A0, 841 x 1189 mm"
 
-#: ../src/common/paper.cpp:218
+#: ../src/common/paper.cpp:215
 msgid "A1 sheet, 594 x 841 mm"
 msgstr "Full A1, 594 x 841 mm"
 
-#: ../src/common/paper.cpp:159
+#: ../src/common/paper.cpp:156
 msgid "A2 420 x 594 mm"
 msgstr "A2, 420 x 594 mm"
 
-#: ../src/common/paper.cpp:156
+#: ../src/common/paper.cpp:153
 msgid "A3 Extra 322 x 445 mm"
 msgstr "A3 extra, 322 x 445 mm"
 
-#: ../src/common/paper.cpp:161
+#: ../src/common/paper.cpp:158
 msgid "A3 Extra Transverse 322 x 445 mm"
 msgstr "A3 extra transversal, 322 x 445 mm"
 
-#: ../src/common/paper.cpp:170
+#: ../src/common/paper.cpp:167
 msgid "A3 Rotated 420 x 297 mm"
 msgstr "A3 girat, 420 x 297 mm"
 
-#: ../src/common/paper.cpp:160
+#: ../src/common/paper.cpp:157
 msgid "A3 Transverse 297 x 420 mm"
 msgstr "A3 transversal, 297 x 420 mm"
 
-#: ../src/common/paper.cpp:106
+#: ../src/common/paper.cpp:103
 msgid "A3 sheet, 297 x 420 mm"
 msgstr "Full A3, 297 x 420 mm"
 
-#: ../src/common/paper.cpp:146
+#: ../src/common/paper.cpp:143
 msgid "A4 Extra 9.27 x 12.69 in"
 msgstr "A4 extra, 9,27 x 12,69 polz."
 
-#: ../src/common/paper.cpp:153
+#: ../src/common/paper.cpp:150
 msgid "A4 Plus 210 x 330 mm"
 msgstr "A4 plus, 210 x 330 mm"
 
-#: ../src/common/paper.cpp:171
+#: ../src/common/paper.cpp:168
 msgid "A4 Rotated 297 x 210 mm"
 msgstr "A4 girat, 297 x 210 mm"
 
-#: ../src/common/paper.cpp:148
+#: ../src/common/paper.cpp:145
 msgid "A4 Transverse 210 x 297 mm"
 msgstr "A4 transversal, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:97
+#: ../src/common/paper.cpp:94
 msgid "A4 sheet, 210 x 297 mm"
 msgstr "Full A4, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:107
+#: ../src/common/paper.cpp:104
 msgid "A4 small sheet, 210 x 297 mm"
 msgstr "Full petit A4, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:157
+#: ../src/common/paper.cpp:154
 msgid "A5 Extra 174 x 235 mm"
 msgstr "A5 extra, 174 x 235 mm"
 
-#: ../src/common/paper.cpp:172
+#: ../src/common/paper.cpp:169
 msgid "A5 Rotated 210 x 148 mm"
 msgstr "A5 girat, 210 x 148 mm"
 
-#: ../src/common/paper.cpp:154
+#: ../src/common/paper.cpp:151
 msgid "A5 Transverse 148 x 210 mm"
 msgstr "A5 transversal, 148 x 210 mm"
 
-#: ../src/common/paper.cpp:108
+#: ../src/common/paper.cpp:105
 msgid "A5 sheet, 148 x 210 mm"
 msgstr "Full A5, 148 x 210 mm"
 
-#: ../src/common/paper.cpp:164
+#: ../src/common/paper.cpp:161
 msgid "A6 105 x 148 mm"
 msgstr "A6, 105 x 148 mm"
 
-#: ../src/common/paper.cpp:177
+#: ../src/common/paper.cpp:174
 msgid "A6 Rotated 148 x 105 mm"
 msgstr "A6 girat, 148 x 105 mm"
 
-#: ../src/generic/fontdlgg.cpp:83 ../src/richtext/richtextformatdlg.cpp:529
-#: ../src/osx/carbon/fontdlg.cpp:153
+#: ../src/osx/carbon/fontdlg.cpp:150 ../src/generic/fontdlgg.cpp:79
+#: ../src/richtext/richtextformatdlg.cpp:521
 msgid "ABCDEFGabcdefg12345"
 msgstr "ABCDabcd1234ÀÈÉÍÏÒóúüçl·l"
 
-#: ../src/richtext/richtextsymboldlg.cpp:458 ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
 msgid "ASCII"
 msgstr "ASCII"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "About"
 msgstr "Quant a"
 
-#: ../src/generic/aboutdlgg.cpp:140 ../src/osx/menu_osx.cpp:558
-#: ../src/msw/aboutdlg.cpp:64
+#: ../src/osx/menu_osx.cpp:450 ../src/generic/aboutdlgg.cpp:137
+#: ../src/msw/aboutdlg.cpp:61
 #, c-format
 msgid "About %s"
 msgstr "Quant a %s"
 
-#: ../src/osx/menu_osx.cpp:560
+#: ../src/osx/menu_osx.cpp:452
 msgid "About..."
 msgstr "Quant a..."
 
@@ -1198,37 +1195,37 @@ msgid "Absolute"
 msgstr "Absolut"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:873
+#: ../src/propgrid/advprops.cpp:774
 msgid "ActiveBorder"
 msgstr "ActiveBorder"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:874
+#: ../src/propgrid/advprops.cpp:775
 msgid "ActiveCaption"
 msgstr "ActiveCaption"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "Actual Size"
 msgstr "Mida real"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:140 ../src/common/accelcmn.cpp:81
+#: ../src/common/stockitem.cpp:137 ../src/common/accelcmn.cpp:78
 msgid "Add"
 msgstr "Suma"
 
-#: ../src/richtext/richtextbuffer.cpp:11455
+#: ../src/richtext/richtextbuffer.cpp:11454
 msgid "Add Column"
 msgstr "Afegeix una columna"
 
-#: ../src/richtext/richtextbuffer.cpp:11392
+#: ../src/richtext/richtextbuffer.cpp:11391
 msgid "Add Row"
 msgstr "Afegeix una fila"
 
-#: ../src/html/helpwnd.cpp:432
+#: ../src/html/helpwnd.cpp:430
 msgid "Add current page to bookmarks"
 msgstr "Afegeix la pàgina actual als preferits"
 
-#: ../src/generic/colrdlgg.cpp:366
+#: ../src/generic/colrdlgg.cpp:386
 msgid "Add to custom colours"
 msgstr "Afegeix als colors personalitzats"
 
@@ -1240,12 +1237,12 @@ msgstr "S'ha cridat AddToPropertyCollection en un mètode d'accés genèric"
 msgid "AddToPropertyCollection called w/o valid adder"
 msgstr "S'ha cridat AddToPropertyCollection sense un afegidor vàlid"
 
-#: ../src/html/helpctrl.cpp:159
+#: ../src/html/helpctrl.cpp:155
 #, c-format
 msgid "Adding book %s"
 msgstr "S'està afegint el llibre %s"
 
-#: ../src/common/preferencescmn.cpp:43
+#: ../src/common/preferencescmn.cpp:40
 msgid "Advanced"
 msgstr "Avançat"
 
@@ -1253,11 +1250,11 @@ msgstr "Avançat"
 msgid "After a paragraph:"
 msgstr "Després d'un paràgraf:"
 
-#: ../src/common/stockitem.cpp:172
+#: ../src/common/stockitem.cpp:169
 msgid "Align Left"
 msgstr "Alinea a l'esquerra"
 
-#: ../src/common/stockitem.cpp:173
+#: ../src/common/stockitem.cpp:170
 msgid "Align Right"
 msgstr "Alinea a la dreta"
 
@@ -1265,40 +1262,40 @@ msgstr "Alinea a la dreta"
 msgid "Alignment"
 msgstr "Alineació"
 
-#: ../src/generic/prntdlgg.cpp:215
+#: ../src/generic/prntdlgg.cpp:208
 msgid "All"
 msgstr "Tot"
 
-#: ../src/generic/filectrlg.cpp:1197 ../src/common/fldlgcmn.cpp:107
+#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1186
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Tots els fitxers (%s)|%s"
 
-#: ../include/wx/defs.h:2886
+#: ../include/wx/defs.h:2582
 msgid "All files (*)|*"
 msgstr "Tots els fitxers (*)|*"
 
-#: ../include/wx/defs.h:2883
+#: ../include/wx/defs.h:2579
 msgid "All files (*.*)|*.*"
 msgstr "Tots els fitxers (*.*)|*.*"
 
-#: ../src/richtext/richtextstyles.cpp:1061
+#: ../src/richtext/richtextstyles.cpp:1058
 msgid "All styles"
 msgstr "Tots els estils"
 
-#: ../src/propgrid/manager.cpp:1528
+#: ../src/propgrid/manager.cpp:1544
 msgid "Alphabetic Mode"
 msgstr "Mode alfabètic"
 
-#: ../src/common/xtistrm.cpp:425
+#: ../src/common/xtistrm.cpp:422
 msgid "Already Registered Object passed to SetObjectClassInfo"
 msgstr "S'ha passat un objecte ja registrat a SetObjectClassInfo"
 
-#: ../src/unix/dialup.cpp:353
+#: ../src/unix/dialup.cpp:352
 msgid "Already dialling ISP."
 msgstr "Ja s'està trucant al proveïdor d'Internet."
 
-#: ../src/common/accelcmn.cpp:331 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/accelcmn.cpp:345 ../src/univ/themes/win32.cpp:3753
 msgid "Alt+"
 msgstr "Alt+"
 
@@ -1307,35 +1304,35 @@ msgstr "Alt+"
 msgid "An optional corner radius for adding rounded corners."
 msgstr "Un radi de cantonada opcional per a afegir cantonades arrodonides."
 
-#: ../src/common/debugrpt.cpp:576
+#: ../src/common/debugrpt.cpp:577
 msgid "And includes the following files:\n"
 msgstr "I inclou els següents fitxers:\n"
 
-#: ../src/generic/animateg.cpp:162
+#: ../src/generic/animateg.cpp:145
 #, c-format
 msgid "Animation file is not of type %ld."
 msgstr "El fitxer d'animació no és del tipus %ld."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:872
+#: ../src/propgrid/advprops.cpp:773
 msgid "AppWorkspace"
 msgstr "AppWorkspace"
 
-#: ../src/generic/logg.cpp:1014
+#: ../src/generic/logg.cpp:1011
 #, c-format
 msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
 msgstr ""
 "Voleu afegir el registre al fitxer '%s'? (si trieu [No], se sobreescriurà)"
 
-#: ../src/osx/menu_osx.cpp:577 ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:469 ../src/osx/menu_osx.cpp:477
 msgid "Application"
 msgstr "Aplicació"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "Apply"
 msgstr "Aplica"
 
-#: ../src/propgrid/advprops.cpp:1609
+#: ../src/propgrid/advprops.cpp:1515
 msgid "Aqua"
 msgstr "Cian"
 
@@ -1344,29 +1341,29 @@ msgstr "Cian"
 msgid "Arabic"
 msgstr "Àrab"
 
-#: ../src/common/fmapbase.cpp:153
+#: ../src/common/fmapbase.cpp:150
 msgid "Arabic (ISO-8859-6)"
 msgstr "Àrab (ISO-8859-6)"
 
-#: ../src/msw/ole/automtn.cpp:672
+#: ../src/msw/ole/automtn.cpp:663
 #, c-format
 msgid "Argument %u not found."
 msgstr "No s'ha trobat l'argument %u."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1753
+#: ../src/propgrid/advprops.cpp:1654
 msgid "Arrow"
 msgstr "Fletxa"
 
-#: ../src/generic/aboutdlgg.cpp:184
+#: ../src/generic/aboutdlgg.cpp:181
 msgid "Artists"
 msgstr "Artistes"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "Ascending"
 msgstr "Ascendent"
 
-#: ../src/generic/filectrlg.cpp:433
+#: ../src/generic/filectrlg.cpp:429
 msgid "Attributes"
 msgstr "Atributs"
 
@@ -1376,90 +1373,90 @@ msgstr "Atributs"
 msgid "Available fonts."
 msgstr "Tipus de lletra disponibles."
 
-#: ../src/common/paper.cpp:137
+#: ../src/common/paper.cpp:134
 msgid "B4 (ISO) 250 x 353 mm"
 msgstr "B4 (ISO), 250 x 354 mm"
 
-#: ../src/common/paper.cpp:173
+#: ../src/common/paper.cpp:170
 msgid "B4 (JIS) Rotated 364 x 257 mm"
 msgstr "B4 (JIS) girat, 364 x 257 mm"
 
-#: ../src/common/paper.cpp:127
+#: ../src/common/paper.cpp:124
 msgid "B4 Envelope, 250 x 353 mm"
 msgstr "Sobre B4, 250 x 353 mm"
 
-#: ../src/common/paper.cpp:109
+#: ../src/common/paper.cpp:106
 msgid "B4 sheet, 250 x 354 mm"
 msgstr "Full B4, 250 x 354 mm"
 
-#: ../src/common/paper.cpp:158
+#: ../src/common/paper.cpp:155
 msgid "B5 (ISO) Extra 201 x 276 mm"
 msgstr "B5 (ISO) extra, 201 x 276 mm"
 
-#: ../src/common/paper.cpp:174
+#: ../src/common/paper.cpp:171
 msgid "B5 (JIS) Rotated 257 x 182 mm"
 msgstr "B5 (JIS) girat, 257 x 182 mm"
 
-#: ../src/common/paper.cpp:155
+#: ../src/common/paper.cpp:152
 msgid "B5 (JIS) Transverse 182 x 257 mm"
 msgstr "B5 (JIS) transversal, 182 x 257 mm"
 
-#: ../src/common/paper.cpp:128
+#: ../src/common/paper.cpp:125
 msgid "B5 Envelope, 176 x 250 mm"
 msgstr "Sobre B5, 176 x 250 mm"
 
-#: ../src/common/paper.cpp:110
+#: ../src/common/paper.cpp:107
 msgid "B5 sheet, 182 x 257 millimeter"
 msgstr "Full B5, 182 x 257 mil·límetres"
 
-#: ../src/common/paper.cpp:182
+#: ../src/common/paper.cpp:179
 msgid "B6 (JIS) 128 x 182 mm"
 msgstr "B6 (JIS), 128 x 182 mm"
 
-#: ../src/common/paper.cpp:183
+#: ../src/common/paper.cpp:180
 msgid "B6 (JIS) Rotated 182 x 128 mm"
 msgstr "B6 (JIS) girat, 182 x 128 mm"
 
-#: ../src/common/paper.cpp:129
+#: ../src/common/paper.cpp:126
 msgid "B6 Envelope, 176 x 125 mm"
 msgstr "Sobre B6, 176 x 125 mm"
 
-#: ../src/common/imagbmp.cpp:531 ../src/common/imagbmp.cpp:561
-#: ../src/common/imagbmp.cpp:576
+#: ../src/common/imagbmp.cpp:528 ../src/common/imagbmp.cpp:558
+#: ../src/common/imagbmp.cpp:573
 msgid "BMP: Couldn't allocate memory."
 msgstr "BMP: No s'ha pogut assignar la memòria."
 
-#: ../src/common/imagbmp.cpp:100
+#: ../src/common/imagbmp.cpp:97
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: No s'ha pogut desar una imatge invàlida."
 
-#: ../src/common/imagbmp.cpp:356
+#: ../src/common/imagbmp.cpp:353
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: No s'ha pogut escriure el mapa de colors RGB."
 
-#: ../src/common/imagbmp.cpp:490
+#: ../src/common/imagbmp.cpp:487
 msgid "BMP: Couldn't write data."
 msgstr "BMP: No s'han pogut escriure les dades."
 
-#: ../src/common/imagbmp.cpp:246
+#: ../src/common/imagbmp.cpp:243
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: No s'ha pogut escriure la capçalera del fitxer (Bitmap)."
 
-#: ../src/common/imagbmp.cpp:269
+#: ../src/common/imagbmp.cpp:266
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: No s'ha pogut escriure la capçalera del fitxer (BitmapInfo)."
 
-#: ../src/common/imagbmp.cpp:140
+#: ../src/common/imagbmp.cpp:137
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage no té una wxPallette pròpia."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:142 ../src/common/accelcmn.cpp:52
+#: ../src/common/stockitem.cpp:139 ../src/common/accelcmn.cpp:49
 msgid "Back"
 msgstr "Endarrere"
 
+#: ../src/richtext/richtextformatdlg.cpp:377
 #: ../src/richtext/richtextbackgroundpage.cpp:148
-#: ../src/richtext/richtextformatdlg.cpp:384
 msgid "Background"
 msgstr "Fons"
 
@@ -1467,20 +1464,20 @@ msgstr "Fons"
 msgid "Background &colour:"
 msgstr "&Color de fons:"
 
-#: ../src/osx/carbon/fontdlg.cpp:220
+#: ../src/osx/carbon/fontdlg.cpp:217
 msgid "Background colour"
 msgstr "Color de fons"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:52
+#: ../src/common/accelcmn.cpp:49
 msgid "Backspace"
 msgstr "Retrocés"
 
-#: ../src/common/fmapbase.cpp:160
+#: ../src/common/fmapbase.cpp:157
 msgid "Baltic (ISO-8859-13)"
 msgstr "Bàltic (ISO-8859-13)"
 
-#: ../src/common/fmapbase.cpp:151
+#: ../src/common/fmapbase.cpp:148
 msgid "Baltic (old) (ISO-8859-4)"
 msgstr "Bàltic (antic) (ISO-8859-4)"
 
@@ -1493,25 +1490,25 @@ msgstr "Abans d'un paràgraf:"
 msgid "Bitmap"
 msgstr "Mapa de bits"
 
-#: ../src/propgrid/advprops.cpp:1594
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Black"
 msgstr "Negre"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1755
+#: ../src/propgrid/advprops.cpp:1656
 msgid "Blank"
 msgstr "Buit"
 
-#: ../src/propgrid/advprops.cpp:1603
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Blue"
 msgstr "Blau"
 
-#: ../src/generic/colrdlgg.cpp:345
+#: ../src/generic/colrdlgg.cpp:365
 msgid "Blue:"
 msgstr "Blau:"
 
-#: ../src/generic/fontdlgg.cpp:333 ../src/richtext/richtextfontpage.cpp:355
-#: ../src/osx/carbon/fontdlg.cpp:354 ../src/common/stockitem.cpp:143
+#: ../src/osx/carbon/fontdlg.cpp:351 ../src/common/stockitem.cpp:140
+#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:355
 msgid "Bold"
 msgstr "Negreta"
 
@@ -1520,31 +1517,35 @@ msgstr "Negreta"
 msgid "Border"
 msgstr "Vora"
 
-#: ../src/richtext/richtextformatdlg.cpp:379
+#: ../src/richtext/richtextformatdlg.cpp:372
 msgid "Borders"
 msgstr "Vores"
 
-#: ../src/richtext/richtextsizepage.cpp:288 ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141 ../src/richtext/richtextsizepage.cpp:288
 msgid "Bottom"
 msgstr "Inferior"
 
-#: ../src/generic/prntdlgg.cpp:893
+#: ../src/generic/prntdlgg.cpp:886
 msgid "Bottom margin (mm):"
 msgstr "Marge inferior (mm):"
 
-#: ../src/richtext/richtextbuffer.cpp:9383
+#: ../src/richtext/richtextbuffer.cpp:9380
 msgid "Box Properties"
 msgstr "Propietats de la caixa"
 
-#: ../src/richtext/richtextstyles.cpp:1065
+#: ../src/richtext/richtextstyles.cpp:1062
 msgid "Box styles"
 msgstr "Estils de caixa"
 
-#: ../src/propgrid/advprops.cpp:1602
+#: ../src/osx/cocoa/menu.mm:292
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Brown"
 msgstr "Marró"
 
-#: ../src/common/filepickercmn.cpp:43 ../src/common/filepickercmn.cpp:44
+#: ../src/common/filepickercmn.cpp:40 ../src/common/filepickercmn.cpp:41
 msgid "Browse"
 msgstr "Navega"
 
@@ -1557,72 +1558,72 @@ msgstr "&Alineació del pic:"
 msgid "Bullet style"
 msgstr "Estil de pic"
 
-#: ../src/richtext/richtextformatdlg.cpp:359
+#: ../src/richtext/richtextformatdlg.cpp:352
 msgid "Bullets"
 msgstr "Pics"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1756
+#: ../src/propgrid/advprops.cpp:1657
 msgid "Bullseye"
 msgstr "Diana"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:875
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonFace"
 msgstr "ButtonFace"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:876
+#: ../src/propgrid/advprops.cpp:777
 msgid "ButtonHighlight"
 msgstr "ButtonHighlight"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:877
+#: ../src/propgrid/advprops.cpp:778
 msgid "ButtonShadow"
 msgstr "ButtonShadow"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:878
+#: ../src/propgrid/advprops.cpp:779
 msgid "ButtonText"
 msgstr "ButtonText"
 
-#: ../src/common/paper.cpp:98
+#: ../src/common/paper.cpp:95
 msgid "C sheet, 17 x 22 in"
 msgstr "Full C, 17 x 22 polz."
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "C&lear"
 msgstr "&Neteja"
 
-#: ../src/generic/fontdlgg.cpp:406
+#: ../src/generic/fontdlgg.cpp:403
 msgid "C&olour:"
 msgstr "C&olor:"
 
-#: ../src/common/paper.cpp:123
+#: ../src/common/paper.cpp:120
 msgid "C3 Envelope, 324 x 458 mm"
 msgstr "Sobre C3, 324 x 458 mm"
 
-#: ../src/common/paper.cpp:124
+#: ../src/common/paper.cpp:121
 msgid "C4 Envelope, 229 x 324 mm"
 msgstr "Sobre C4, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:122
+#: ../src/common/paper.cpp:119
 msgid "C5 Envelope, 162 x 229 mm"
 msgstr "Sobre C5, 162 x 229 mm"
 
-#: ../src/common/paper.cpp:125
+#: ../src/common/paper.cpp:122
 msgid "C6 Envelope, 114 x 162 mm"
 msgstr "Sobre C6, 114 x 162 mm"
 
-#: ../src/common/paper.cpp:126
+#: ../src/common/paper.cpp:123
 msgid "C65 Envelope, 114 x 229 mm"
 msgstr "Sobre C65, 114 x 229 mm"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "CD-Rom"
 msgstr "CD-ROM"
 
-#: ../src/html/chm.cpp:815 ../src/html/chm.cpp:874
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:865
 msgid "CHM handler currently supports only local files!"
 msgstr "El gestor de CHM actualment només suporta fitxers locals!"
 
@@ -1630,193 +1631,197 @@ msgstr "El gestor de CHM actualment només suporta fitxers locals!"
 msgid "Ca&pitals"
 msgstr "Ma&júscules"
 
-#: ../src/common/cmdproc.cpp:267
+#: ../src/common/cmdproc.cpp:260
 msgid "Can't &Undo "
 msgstr "No es pot &desfer "
 
-#: ../src/common/image.cpp:2824
+#: ../src/common/image.cpp:2924
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 "No es pot determinar automàticament el format d'imatge en una entrada "
 "seqüencial."
 
-#: ../src/msw/registry.cpp:506
+#: ../src/msw/registry.cpp:495
 #, c-format
 msgid "Can't close registry key '%s'"
 msgstr "No es pot tancar la clau de registre '%s'"
 
-#: ../src/msw/registry.cpp:584
+#: ../src/msw/registry.cpp:573
 #, c-format
 msgid "Can't copy values of unsupported type %d."
 msgstr "No es poden copiar els valors del tipus no suportat %d."
 
-#: ../src/msw/registry.cpp:487
+#: ../src/msw/registry.cpp:476
 #, c-format
 msgid "Can't create registry key '%s'"
 msgstr "No es pot crear la clau de registre '%s'"
 
-#: ../src/msw/thread.cpp:665
+#: ../src/msw/thread.cpp:657
 msgid "Can't create thread"
 msgstr "No es pot crear el fil d'execució"
 
-#: ../src/msw/window.cpp:3691
-#, c-format
-msgid "Can't create window of class %s"
-msgstr "No es pot crear una finestra de la classe '%s'"
-
-#: ../src/msw/registry.cpp:777
+#: ../src/msw/registry.cpp:765
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "No es pot suprimir la clau '%s'"
 
-#: ../src/msw/iniconf.cpp:458
+#: ../src/msw/iniconf.cpp:455
 #, c-format
 msgid "Can't delete the INI file '%s'"
 msgstr "No es pot suprimir el fitxer INI '%s'"
 
-#: ../src/msw/registry.cpp:805
+#: ../src/msw/registry.cpp:793
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "No es pot suprimir el valor '%s' de la clau '%s'"
 
-#: ../src/msw/registry.cpp:1171
+#: ../src/msw/registry.cpp:1159
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "No es poden enumerar les subclaus de la clau '%s'"
 
-#: ../src/msw/registry.cpp:1132
+#: ../src/msw/registry.cpp:1120
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "No es poden enumerar els valors de la clau '%s'"
 
-#: ../src/msw/registry.cpp:1389
+#: ../src/msw/registry.cpp:1377
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "No es pot exportar el valor del tipus de no suportat %d."
 
-#: ../src/common/ffile.cpp:254
+#: ../src/common/ffile.cpp:253
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "No es pot trobar la posició actual al fitxer '%s'"
 
-#: ../src/msw/registry.cpp:418
+#: ../src/msw/registry.cpp:407
 #, c-format
 msgid "Can't get info about registry key '%s'"
 msgstr "No es pot obtenir informació de la clau del registre '%s'"
 
-#: ../src/common/zstream.cpp:346
+#: ../src/msw/webview_ie.cpp:1024
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "No es pot definir la prioritat del fil d'execució"
+
+#: ../src/common/zstream.cpp:343
 msgid "Can't initialize zlib deflate stream."
 msgstr "No es pot inicialitzar el flux de deflació de zlib."
 
-#: ../src/common/zstream.cpp:185
+#: ../src/common/zstream.cpp:182
 msgid "Can't initialize zlib inflate stream."
 msgstr "No es pot inicialitzar el flux d'inflació de zlib."
 
-#: ../src/msw/fswatcher.cpp:476
+#: ../src/msw/fswatcher.cpp:475
 #, c-format
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "No es pot supervisar si hi ha canvis al directori inexistent \"%s\"."
 
-#: ../src/msw/registry.cpp:454
+#: ../src/msw/registry.cpp:443
 #, c-format
 msgid "Can't open registry key '%s'"
 msgstr "No es pot obrir la clau del registre '%s'"
 
-#: ../src/common/zstream.cpp:252
+#: ../src/common/zstream.cpp:249
 #, c-format
 msgid "Can't read from inflate stream: %s"
 msgstr "No es pot llegir del flux d'inflació: %s"
 
-#: ../src/common/zstream.cpp:244
+#: ../src/common/zstream.cpp:241
 msgid "Can't read inflate stream: unexpected EOF in underlying stream."
 msgstr "No es pot llegir el flux d'inflació: EOF inesperat al flux subjacent."
 
-#: ../src/msw/registry.cpp:1064
+#: ../src/msw/registry.cpp:1052
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "No es pot llegir el valor de '%s'"
 
-#: ../src/msw/registry.cpp:878 ../src/msw/registry.cpp:910
-#: ../src/msw/registry.cpp:975
+#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
+#: ../src/msw/registry.cpp:963
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "No es pot llegir el valor de la clau '%s'"
 
-#: ../src/common/image.cpp:2620
+#: ../src/msw/webview_ie.cpp:1017
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/common/image.cpp:2715
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "No es pot desar la imatge al fitxer '%s': extensió desconeguda."
 
-#: ../src/generic/logg.cpp:573 ../src/generic/logg.cpp:976
+#: ../src/generic/logg.cpp:570 ../src/generic/logg.cpp:973
 msgid "Can't save log contents to file."
 msgstr "No es pot desar el contingut de registre al fitxer."
 
-#: ../src/msw/thread.cpp:629
+#: ../src/msw/thread.cpp:621
 msgid "Can't set thread priority"
 msgstr "No es pot definir la prioritat del fil d'execució"
 
-#: ../src/msw/registry.cpp:896 ../src/msw/registry.cpp:938
-#: ../src/msw/registry.cpp:1081
+#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
+#: ../src/msw/registry.cpp:1069
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "No es pot definir el valor de '%s'"
 
-#: ../src/unix/utilsunx.cpp:351
+#: ../src/unix/utilsunx.cpp:353
 msgid "Can't write to child process's stdin"
 msgstr "No es pot escriure a l'entrada estàndard del procés fill"
 
-#: ../src/common/zstream.cpp:427
+#: ../src/common/zstream.cpp:424
 #, c-format
 msgid "Can't write to deflate stream: %s"
 msgstr "No es pot escriure al flux de deflació: %s"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:279 ../src/richtext/richtextstyledlg.cpp:300
-#: ../src/common/stockitem.cpp:145 ../src/common/accelcmn.cpp:71
-#: ../src/msw/msgdlg.cpp:454 ../src/msw/progdlg.cpp:673
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:142
+#: ../src/common/accelcmn.cpp:68 ../src/motif/msgdlg.cpp:196
+#: ../src/gtk1/fontdlg.cpp:144 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/progdlg.cpp:940 ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Cancel·la"
 
-#: ../src/common/filefn.cpp:1261
+#: ../src/common/filefn.cpp:1149
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "No es poden enumerar els fitxers '%s'"
 
-#: ../src/msw/dir.cpp:263
+#: ../src/msw/dir.cpp:260
 #, c-format
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "No es poden enumerar els fitxers del directori '%s'"
 
-#: ../src/msw/dialup.cpp:523
+#: ../src/msw/dialup.cpp:517
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "No es pot trobar cap connexió activa de marcatge telefònic: %s"
 
-#: ../src/msw/dialup.cpp:827
+#: ../src/msw/dialup.cpp:821
 msgid "Cannot find the location of address book file"
 msgstr "No es pot trobar la ubicació del fitxer de la llibreta d'adreces"
 
-#: ../src/msw/ole/automtn.cpp:562
+#: ../src/msw/ole/automtn.cpp:553
 #, c-format
 msgid "Cannot get an active instance of \"%s\""
 msgstr "No es pot obtenir una instància activa de \"%s\""
 
-#: ../src/unix/threadpsx.cpp:1035
+#: ../src/unix/threadpsx.cpp:1053
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr ""
 "No es pot obtenir el rang de prioritats per a la política de planificació %d."
 
-#: ../src/unix/utilsunx.cpp:987
+#: ../src/unix/utilsunx.cpp:989
 msgid "Cannot get the hostname"
 msgstr "No es pot obtenir el nom del servidor"
 
-#: ../src/unix/utilsunx.cpp:1023
+#: ../src/unix/utilsunx.cpp:1025
 msgid "Cannot get the official hostname"
 msgstr "No es pot obtenir el nom oficial del servidor"
 
-#: ../src/msw/dialup.cpp:928
+#: ../src/msw/dialup.cpp:922
 msgid "Cannot hang up - no active dialup connection."
 msgstr "No es pot penjar - no hi ha cap connexió de marcatge telefònic activa."
 
@@ -1824,128 +1829,128 @@ msgstr "No es pot penjar - no hi ha cap connexió de marcatge telefònic activa.
 msgid "Cannot initialize OLE"
 msgstr "No es pot inicialitzar OLE"
 
-#: ../src/common/socket.cpp:853
+#: ../src/common/socket.cpp:850
 msgid "Cannot initialize sockets"
 msgstr "No es poden inicialitzar els sòcols"
 
-#: ../src/msw/volume.cpp:619
+#: ../src/msw/volume.cpp:627
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "No es pot carregar la icona de '%s'."
 
-#: ../src/xrc/xmlres.cpp:360
+#: ../src/xrc/xmlres.cpp:358
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "No es poden carregar recursos de '%s'."
 
-#: ../src/xrc/xmlres.cpp:742
+#: ../src/xrc/xmlres.cpp:740
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "No es poden carregar els recursos del fitxer '%s'."
 
-#: ../src/html/htmlfilt.cpp:137
+#: ../src/html/htmlfilt.cpp:134
 #, c-format
 msgid "Cannot open HTML document: %s"
 msgstr "No es pot obrir el document HTML: %s"
 
-#: ../src/html/helpdata.cpp:667
+#: ../src/html/helpdata.cpp:660
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "No es pot obrir el llibre d'ajuda HTML: %s"
 
-#: ../src/html/helpdata.cpp:299
+#: ../src/html/helpdata.cpp:296
 #, c-format
 msgid "Cannot open contents file: %s"
 msgstr "No es pot obrir el fitxer de continguts: %s"
 
-#: ../src/generic/dcpsg.cpp:1667
+#: ../src/generic/dcpsg.cpp:1665
 msgid "Cannot open file for PostScript printing!"
 msgstr "No es pot obrir el fitxer per a la impressió PostScript!"
 
-#: ../src/html/helpdata.cpp:313
+#: ../src/html/helpdata.cpp:310
 #, c-format
 msgid "Cannot open index file: %s"
 msgstr "No es pot obrir el fitxer d'índex: %s"
 
-#: ../src/xrc/xmlres.cpp:724
+#: ../src/xrc/xmlres.cpp:722
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "No es pot obrir el fitxer de recursos '%s'."
 
-#: ../src/html/helpwnd.cpp:1534
+#: ../src/html/helpwnd.cpp:1532
 msgid "Cannot print empty page."
 msgstr "No es pot imprimir una pàgina buida."
 
-#: ../src/msw/volume.cpp:507
+#: ../src/msw/volume.cpp:515
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "No es pot llegir el nom del tipus de '%s'!"
 
-#: ../src/msw/thread.cpp:888
+#: ../src/msw/thread.cpp:894
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "No es pot reprendre el fil d'execució %lx"
 
-#: ../src/unix/threadpsx.cpp:1016
+#: ../src/unix/threadpsx.cpp:1028
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "No es pot obtenir la política de planificació de fils d'execució."
 
-#: ../src/common/intl.cpp:558
+#: ../src/common/intl.cpp:365
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "No es pot definir la configuració local a la llengua \"%s\"."
 
-#: ../src/unix/threadpsx.cpp:831 ../src/msw/thread.cpp:546
+#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
 msgid "Cannot start thread: error writing TLS."
 msgstr ""
 "No es pot iniciar el fil d'execució: s'ha produït un error en escriure el "
 "TLS."
 
-#: ../src/msw/thread.cpp:872
+#: ../src/msw/thread.cpp:864
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "No es pot suspendre el fil d'execució %lx"
 
-#: ../src/msw/thread.cpp:794
+#: ../src/msw/thread.cpp:786
 msgid "Cannot wait for thread termination"
 msgstr "No es pot esperar a la finalització del fil d'execució"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:75
+#: ../src/common/accelcmn.cpp:72
 msgid "Capital"
 msgstr "Majúscules"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:879
+#: ../src/propgrid/advprops.cpp:780
 msgid "CaptionText"
 msgstr "CaptionText"
 
-#: ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:531
 msgid "Case sensitive"
 msgstr "Distingeix entre majúscules i minúscules"
 
-#: ../src/propgrid/manager.cpp:1509
+#: ../src/propgrid/manager.cpp:1527
 msgid "Categorized Mode"
 msgstr "Mode categoritzat"
 
-#: ../src/richtext/richtextbuffer.cpp:9968
+#: ../src/richtext/richtextbuffer.cpp:9965
 msgid "Cell Properties"
 msgstr "Propietats de la cel·la"
 
-#: ../src/common/fmapbase.cpp:161
+#: ../src/common/fmapbase.cpp:158
 msgid "Celtic (ISO-8859-14)"
 msgstr "Cèltic (ISO-8859-14)"
 
-#: ../src/richtext/richtextindentspage.cpp:160
 #: ../src/richtext/richtextliststylepage.cpp:349
+#: ../src/richtext/richtextindentspage.cpp:160
 msgid "Cen&tred"
 msgstr "Cen&trat"
 
-#: ../src/common/stockitem.cpp:170
+#: ../src/common/stockitem.cpp:167
 msgid "Centered"
 msgstr "Centrat"
 
-#: ../src/common/fmapbase.cpp:149
+#: ../src/common/fmapbase.cpp:146
 msgid "Central European (ISO-8859-2)"
 msgstr "Europeu central (ISO-8859-2)"
 
@@ -1954,10 +1959,10 @@ msgstr "Europeu central (ISO-8859-2)"
 msgid "Centre"
 msgstr "Centre"
 
-#: ../src/richtext/richtextindentspage.cpp:162
-#: ../src/richtext/richtextindentspage.cpp:164
 #: ../src/richtext/richtextliststylepage.cpp:351
 #: ../src/richtext/richtextliststylepage.cpp:353
+#: ../src/richtext/richtextindentspage.cpp:162
+#: ../src/richtext/richtextindentspage.cpp:164
 msgid "Centre text."
 msgstr "Centra el text."
 
@@ -1970,24 +1975,24 @@ msgstr "Centrat"
 msgid "Ch&oose..."
 msgstr "T&ria..."
 
-#: ../src/richtext/richtextbuffer.cpp:4354
+#: ../src/richtext/richtextbuffer.cpp:4351
 msgid "Change List Style"
 msgstr "Canvia l'estil de llista"
 
-#: ../src/richtext/richtextbuffer.cpp:3709
+#: ../src/richtext/richtextbuffer.cpp:3706
 msgid "Change Object Style"
 msgstr "Canvia l'estil d'objecte"
 
-#: ../src/richtext/richtextbuffer.cpp:3982
-#: ../src/richtext/richtextbuffer.cpp:8129
+#: ../src/richtext/richtextbuffer.cpp:3979
+#: ../src/richtext/richtextbuffer.cpp:8125
 msgid "Change Properties"
 msgstr "Canvia les propietats"
 
-#: ../src/richtext/richtextbuffer.cpp:3526
+#: ../src/richtext/richtextbuffer.cpp:3523
 msgid "Change Style"
 msgstr "Canvia l'estil"
 
-#: ../src/common/fileconf.cpp:341
+#: ../src/common/fileconf.cpp:335
 #, c-format
 msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
 msgstr ""
@@ -1999,11 +2004,11 @@ msgid "Changing current directory to \"%s\" failed"
 msgstr "No s'ha pogut canviar el directori actual a \"%s\""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1757
+#: ../src/propgrid/advprops.cpp:1658
 msgid "Character"
 msgstr "Caràcter"
 
-#: ../src/richtext/richtextstyles.cpp:1063
+#: ../src/richtext/richtextstyles.cpp:1060
 msgid "Character styles"
 msgstr "Estils de caràcter"
 
@@ -2040,20 +2045,20 @@ msgstr "Marqueu-ho per a envoltar el pic entre parèntesis."
 msgid "Check to indicate right-to-left text layout."
 msgstr "Marqueu-ho per a indicar una disposició de text de dreta a esquerra."
 
-#: ../src/osx/carbon/fontdlg.cpp:356 ../src/osx/carbon/fontdlg.cpp:358
+#: ../src/osx/carbon/fontdlg.cpp:353 ../src/osx/carbon/fontdlg.cpp:355
 msgid "Check to make the font bold."
 msgstr "Marqueu-ho per a fer que la lletra sigui negreta."
 
-#: ../src/osx/carbon/fontdlg.cpp:363 ../src/osx/carbon/fontdlg.cpp:365
+#: ../src/osx/carbon/fontdlg.cpp:360 ../src/osx/carbon/fontdlg.cpp:362
 msgid "Check to make the font italic."
 msgstr "Marqueu-ho per a fer que la lletra sigui cursiva."
 
-#: ../src/osx/carbon/fontdlg.cpp:372 ../src/osx/carbon/fontdlg.cpp:374
+#: ../src/osx/carbon/fontdlg.cpp:369 ../src/osx/carbon/fontdlg.cpp:371
 msgid "Check to make the font underlined."
 msgstr "Marqueu-ho per a fer que la lletra sigui subratllada."
 
-#: ../src/richtext/richtextstyledlg.cpp:289
-#: ../src/richtext/richtextstyledlg.cpp:291
+#: ../src/richtext/richtextstyledlg.cpp:285
+#: ../src/richtext/richtextstyledlg.cpp:287
 msgid "Check to restart numbering."
 msgstr "Marqueu-ho per a reiniciar la numeració."
 
@@ -2087,51 +2092,51 @@ msgstr "Marqueu-ho per a mostrar el text en superíndex."
 msgid "Check to suppress hyphenation."
 msgstr "Marqueu-ho per a suprimir la divisió de paraules."
 
-#: ../src/msw/dialup.cpp:763
+#: ../src/msw/dialup.cpp:757
 msgid "Choose ISP to dial"
 msgstr "Trieu el proveïdor d'Internet a qui voleu trucar"
 
-#: ../src/propgrid/props.cpp:1922
+#: ../src/propgrid/props.cpp:1904
 msgid "Choose a directory:"
 msgstr "Trieu un directori:"
 
-#: ../src/propgrid/props.cpp:1975
+#: ../src/propgrid/props.cpp:2199
 msgid "Choose a file"
 msgstr "Trieu un fitxer"
 
-#: ../src/generic/colrdlgg.cpp:158 ../src/gtk/colordlg.cpp:54
+#: ../src/generic/colrdlgg.cpp:156 ../src/gtk/colordlg.cpp:49
 msgid "Choose colour"
 msgstr "Trieu un color"
 
-#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/gtk1/fontdlg.cpp:125 ../src/generic/fontpickerg.cpp:47
+#: ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Trieu el tipus de lletra"
 
-#: ../src/common/module.cpp:74
+#: ../src/common/module.cpp:71
 #, c-format
 msgid "Circular dependency involving module \"%s\" detected."
 msgstr "S'ha detectat una dependència circular que implica el mòdul \"%s\"."
 
-#: ../src/aui/tabmdi.cpp:108 ../src/generic/mdig.cpp:97
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
 msgid "Cl&ose"
 msgstr "&Tanca"
 
-#: ../src/msw/ole/automtn.cpp:684
+#: ../src/msw/ole/automtn.cpp:675
 msgid "Class not registered."
 msgstr "Classe no registrada."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:147 ../src/common/accelcmn.cpp:72
+#: ../src/common/stockitem.cpp:144 ../src/common/accelcmn.cpp:69
 msgid "Clear"
 msgstr "Neteja"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "Clear the log contents"
 msgstr "Neteja el contingut del registre"
 
-#: ../src/richtext/richtextstyledlg.cpp:252
-#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:248
+#: ../src/richtext/richtextstyledlg.cpp:250
 msgid "Click to apply the selected style."
 msgstr "Feu clic per a aplicar l'estil seleccionat."
 
@@ -2142,15 +2147,15 @@ msgstr "Feu clic per a aplicar l'estil seleccionat."
 msgid "Click to browse for a symbol."
 msgstr "Feu clic per a cercar un símbol."
 
-#: ../src/osx/carbon/fontdlg.cpp:403 ../src/osx/carbon/fontdlg.cpp:405
+#: ../src/osx/carbon/fontdlg.cpp:400 ../src/osx/carbon/fontdlg.cpp:402
 msgid "Click to cancel changes to the font."
 msgstr "Feu clic per a cancel·lar els canvis al tipus de lletra."
 
-#: ../src/generic/fontdlgg.cpp:472 ../src/generic/fontdlgg.cpp:491
+#: ../src/generic/fontdlgg.cpp:468 ../src/generic/fontdlgg.cpp:487
 msgid "Click to cancel the font selection."
 msgstr "Feu clic per a cancel·lar la selecció del tipus de lletra."
 
-#: ../src/osx/carbon/fontdlg.cpp:384 ../src/osx/carbon/fontdlg.cpp:386
+#: ../src/osx/carbon/fontdlg.cpp:381 ../src/osx/carbon/fontdlg.cpp:383
 msgid "Click to change the font colour."
 msgstr "Feu clic per a canviar el color de la lletra."
 
@@ -2169,37 +2174,37 @@ msgstr "Feu clic per a canviar el text del color."
 msgid "Click to choose the font for this level."
 msgstr "Feu clic per a triar el tipus de lletra d'aquest nivell."
 
-#: ../src/richtext/richtextstyledlg.cpp:279
-#: ../src/richtext/richtextstyledlg.cpp:281
+#: ../src/richtext/richtextstyledlg.cpp:275
+#: ../src/richtext/richtextstyledlg.cpp:277
 msgid "Click to close this window."
 msgstr "Feu clic per a tancar aquesta finestra."
 
-#: ../src/osx/carbon/fontdlg.cpp:410 ../src/osx/carbon/fontdlg.cpp:412
+#: ../src/osx/carbon/fontdlg.cpp:407 ../src/osx/carbon/fontdlg.cpp:409
 msgid "Click to confirm changes to the font."
 msgstr "Feu clic per a confirmar els canvis al tipus de lletra."
 
-#: ../src/generic/fontdlgg.cpp:477 ../src/generic/fontdlgg.cpp:479
-#: ../src/generic/fontdlgg.cpp:484 ../src/generic/fontdlgg.cpp:486
+#: ../src/generic/fontdlgg.cpp:473 ../src/generic/fontdlgg.cpp:475
+#: ../src/generic/fontdlgg.cpp:480 ../src/generic/fontdlgg.cpp:482
 msgid "Click to confirm the font selection."
 msgstr "Feu clic per a confirmació la selecció del tipus de lletra."
 
-#: ../src/richtext/richtextstyledlg.cpp:244
-#: ../src/richtext/richtextstyledlg.cpp:246
+#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:242
 msgid "Click to create a new box style."
 msgstr "Feu clic per a crear un estil de caixa nou."
 
-#: ../src/richtext/richtextstyledlg.cpp:226
-#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:224
 msgid "Click to create a new character style."
 msgstr "Feu clic per a crear un estil de caràcter nou."
 
-#: ../src/richtext/richtextstyledlg.cpp:238
-#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:236
 msgid "Click to create a new list style."
 msgstr "Feu clic per a crear un estil de llista nou."
 
-#: ../src/richtext/richtextstyledlg.cpp:232
-#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:230
 msgid "Click to create a new paragraph style."
 msgstr "Feu clic per a crear un estil de paràgraf nou."
 
@@ -2213,8 +2218,8 @@ msgstr "Feu clic per a crear una posició de tabulació nova."
 msgid "Click to delete all tab positions."
 msgstr "Feu clic per a suprimir totes les posicions de tabulació."
 
-#: ../src/richtext/richtextstyledlg.cpp:270
-#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:268
 msgid "Click to delete the selected style."
 msgstr "Feu clic per a suprimir l'estil seleccionat."
 
@@ -2223,25 +2228,25 @@ msgstr "Feu clic per a suprimir l'estil seleccionat."
 msgid "Click to delete the selected tab position."
 msgstr "Feu clic per a suprimir la posició de tabulació seleccionada."
 
-#: ../src/richtext/richtextstyledlg.cpp:264
-#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:262
 msgid "Click to edit the selected style."
 msgstr "Feu clic per a editar l'estil seleccionat."
 
-#: ../src/richtext/richtextstyledlg.cpp:258
-#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:256
 msgid "Click to rename the selected style."
 msgstr "Feu clic per a canviar el nom de l'estil seleccionat."
 
-#: ../src/generic/dbgrptg.cpp:97 ../src/generic/progdlgg.cpp:759
-#: ../src/richtext/richtextstyledlg.cpp:277
-#: ../src/richtext/richtextsymboldlg.cpp:476 ../src/common/stockitem.cpp:148
-#: ../src/msw/progdlg.cpp:170 ../src/msw/progdlg.cpp:679
-#: ../src/html/helpdlg.cpp:90
+#: ../src/common/stockitem.cpp:145 ../src/generic/dbgrptg.cpp:94
+#: ../src/generic/progdlgg.cpp:781 ../src/msw/progdlg.cpp:211
+#: ../src/msw/progdlg.cpp:946 ../src/html/helpdlg.cpp:87
+#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextstyledlg.cpp:273
 msgid "Close"
 msgstr "Tanca"
 
-#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:98
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
 msgid "Close All"
 msgstr "Tanca-ho tot"
 
@@ -2249,43 +2254,43 @@ msgstr "Tanca-ho tot"
 msgid "Close current document"
 msgstr "Tanca el document actual"
 
-#: ../src/generic/logg.cpp:516
+#: ../src/generic/logg.cpp:513
 msgid "Close this window"
 msgstr "Tanca aquesta finestra"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6006
+#: ../src/generic/datavgen.cpp:6811
 msgid "Collapse"
 msgstr "Contrau"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "Color"
 msgstr "Color"
 
-#: ../src/richtext/richtextformatdlg.cpp:776
+#: ../src/richtext/richtextformatdlg.cpp:768
 msgid "Colour"
 msgstr "Color"
 
-#: ../src/msw/colordlg.cpp:158
+#: ../src/msw/colordlg.cpp:227
 #, c-format
 msgid "Colour selection dialog failed with error %0lx."
 msgstr "El diàleg de selecció de color ha fallat amb l'error %0lx."
 
-#: ../src/osx/carbon/fontdlg.cpp:380
+#: ../src/osx/carbon/fontdlg.cpp:377
 msgid "Colour:"
 msgstr "Color:"
 
-#: ../src/generic/datavgen.cpp:6077
+#: ../src/generic/datavgen.cpp:6882
 #, c-format
 msgid "Column %u"
 msgstr "Columna %u"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:114
+#: ../src/common/accelcmn.cpp:112
 msgid "Command"
 msgstr "Ordre"
 
-#: ../src/common/init.cpp:196
+#: ../src/common/init.cpp:193
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
@@ -2294,12 +2299,12 @@ msgstr ""
 "No s'ha pogut convertir a Unicode l'argument %d de la línia d'ordres i "
 "s'ignorarà."
 
-#: ../src/msw/fontdlg.cpp:120
+#: ../src/msw/fontdlg.cpp:170
 #, c-format
 msgid "Common dialog failed with error code %0lx."
 msgstr "El diàleg normal ha fallat amb el codi d'error %0lx."
 
-#: ../src/gtk/window.cpp:4649
+#: ../src/gtk/window.cpp:5653
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
@@ -2307,11 +2312,11 @@ msgstr ""
 "Aquest sistema no suporta la composició, activeu-la al vostre gestor de "
 "finestres."
 
-#: ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:1549
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Fitxer d'ajuda HTML comprimit (*.chm)|*.chm|"
 
-#: ../src/generic/dirctrlg.cpp:444
+#: ../src/generic/dirctrlg.cpp:410
 msgid "Computer"
 msgstr "Ordinador"
 
@@ -2320,53 +2325,57 @@ msgstr "Ordinador"
 msgid "Config entry name cannot start with '%c'."
 msgstr "El nom d'una entrada de configuració no pot començar amb '%c'."
 
-#: ../src/generic/filedlgg.cpp:349 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
 msgid "Confirm"
 msgstr "Confirma"
 
-#: ../src/html/htmlwin.cpp:566
+#: ../src/html/htmlwin.cpp:569
 msgid "Connecting..."
 msgstr "S'està connectant..."
 
-#: ../src/html/helpwnd.cpp:475
+#: ../src/html/helpwnd.cpp:473
 msgid "Contents"
 msgstr "Contingut"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:880
+#: ../src/propgrid/advprops.cpp:781
 msgid "ControlDark"
 msgstr "ControlDark"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:881
+#: ../src/propgrid/advprops.cpp:782
 msgid "ControlLight"
 msgstr "ControlLight"
 
-#: ../src/common/strconv.cpp:2262
+#: ../src/common/strconv.cpp:2208
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "La conversió al joc de caràcters '%s' no funciona."
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "Convert"
 msgstr "Converteix"
 
-#: ../src/html/htmlwin.cpp:1079
+#: ../src/html/htmlwin.cpp:1020
 #, c-format
 msgid "Copied to clipboard:\"%s\""
 msgstr "S'ha copiat al porta-retalls: \"%s\""
 
-#: ../src/generic/prntdlgg.cpp:247
+#: ../src/generic/prntdlgg.cpp:240
 msgid "Copies:"
 msgstr "Còpies:"
 
-#: ../src/common/stockitem.cpp:150 ../src/stc/stc_i18n.cpp:18
+#: ../src/common/stockitem.cpp:147 ../src/stc/stc_i18n.cpp:18
 msgid "Copy"
 msgstr "Copia"
 
-#: ../src/common/stockitem.cpp:258
+#: ../src/common/stockitem.cpp:255
 msgid "Copy selection"
 msgstr "Copia la selecció"
+
+#: ../src/generic/grid.cpp:5945
+msgid "Copying more than one selected block to clipboard is not supported."
+msgstr ""
 
 #: ../src/richtext/richtextborderspage.cpp:566
 #: ../src/richtext/richtextborderspage.cpp:601
@@ -2377,199 +2386,197 @@ msgstr "Cantonada"
 msgid "Corner &radius:"
 msgstr "&Radi de la cantonada:"
 
-#: ../src/html/chm.cpp:718
+#: ../src/html/chm.cpp:711
 #, c-format
 msgid "Could not create temporary file '%s'"
 msgstr "No s'ha pogut crear el fitxer temporal '%s'"
 
-#: ../src/html/chm.cpp:273
+#: ../src/html/chm.cpp:270
 #, c-format
 msgid "Could not extract %s into %s: %s"
 msgstr "No s'ha pogut extreure %s a %s: %s"
 
-#: ../src/generic/tabg.cpp:1048
+#: ../src/generic/tabg.cpp:1045
 msgid "Could not find tab for id"
 msgstr "No s'ha pogut trobar la pestanya per a l'identificador"
 
-#: ../src/gtk/notifmsg.cpp:108
-msgid "Could not initalize libnotify."
-msgstr "No s'ha pogut inicialitzar libnotify."
-
-#: ../src/html/chm.cpp:444
+#: ../src/html/chm.cpp:437
 #, c-format
 msgid "Could not locate file '%s'."
 msgstr "No s'ha pogut trobar el fitxer '%s'."
 
-#: ../src/common/filefn.cpp:1403
+#: ../src/msw/graphicsd2d.cpp:604
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/common/filefn.cpp:1291
 msgid "Could not set current working directory"
 msgstr "No s'ha pogut definir el directori de treball actual"
 
-#: ../src/common/prntbase.cpp:2015
+#: ../src/common/prntbase.cpp:2037
 msgid "Could not start document preview."
 msgstr "No s'ha pogut iniciar la previsualització del document."
 
-#: ../src/generic/printps.cpp:178 ../src/msw/printwin.cpp:210
-#: ../src/gtk/print.cpp:1132
+#: ../src/generic/printps.cpp:159 ../src/msw/printwin.cpp:184
+#: ../src/gtk/print.cpp:1129
 msgid "Could not start printing."
 msgstr "No s'ha pogut iniciar la impressió."
 
-#: ../src/common/wincmn.cpp:2125
+#: ../src/common/wincmn.cpp:2126
 msgid "Could not transfer data to window"
 msgstr "No s'han pogut transferir dades a la finestra"
 
-#: ../src/msw/imaglist.cpp:187 ../src/msw/imaglist.cpp:224
-#: ../src/msw/imaglist.cpp:249 ../src/msw/dragimag.cpp:185
-#: ../src/msw/dragimag.cpp:220
+#: ../src/msw/imaglist.cpp:223 ../src/msw/imaglist.cpp:245
+#: ../src/msw/imaglist.cpp:270 ../src/msw/dragimag.cpp:182
+#: ../src/msw/dragimag.cpp:217
 msgid "Couldn't add an image to the image list."
 msgstr "No s'ha pogut afegir una imatge a la llista d'imatges."
 
-#: ../src/osx/glcanvas_osx.cpp:414 ../src/unix/glx11.cpp:558
-#: ../src/msw/glcanvas.cpp:616
+#: ../src/osx/glcanvas_osx.cpp:411 ../src/msw/glcanvas.cpp:631
+#: ../src/unix/glegl.cpp:315 ../src/unix/glx11.cpp:559
 msgid "Couldn't create OpenGL context"
 msgstr "No s'ha pogut crear el context d'OpenGL"
 
-#: ../src/msw/timer.cpp:134
+#: ../src/msw/timer.cpp:131
 msgid "Couldn't create a timer"
 msgstr "No s'ha pogut crear un temporitzador"
 
-#: ../src/osx/carbon/overlay.cpp:122
-msgid "Couldn't create the overlay window"
-msgstr "No s'ha pogut crear la finestra de superposició"
-
-#: ../src/common/translation.cpp:2024
+#: ../src/common/translation.cpp:2074
 msgid "Couldn't enumerate translations"
 msgstr "No s'han pogut enumerar les traduccions"
 
-#: ../src/common/dynlib.cpp:120
+#: ../src/common/dynlib.cpp:110
 #, c-format
 msgid "Couldn't find symbol '%s' in a dynamic library"
 msgstr "No s'ha pogut trobar el símbol '%s' en una biblioteca dinàmica"
 
-#: ../src/msw/thread.cpp:915
+#: ../src/msw/thread.cpp:921
 msgid "Couldn't get the current thread pointer"
 msgstr "No s'ha pogut obtenir el punter del fil d'execució actual"
 
-#: ../src/osx/carbon/overlay.cpp:129
-msgid "Couldn't init the context on the overlay window"
-msgstr "No s'ha pogut inicialitzar el context a la finestra de superposició"
-
-#: ../src/common/imaggif.cpp:244
+#: ../src/common/imaggif.cpp:241
 msgid "Couldn't initialize GIF hash table."
 msgstr "No s'ha pogut inicialitzar la taula de resums del GIF."
 
-#: ../src/common/imagpng.cpp:409
+#: ../src/common/imagpng.cpp:437
 msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
 msgstr ""
 "No s'ha pogut carregar una imatge PNG - el fitxer és corrupte o no hi ha "
 "prou memòria."
 
-#: ../src/unix/sound.cpp:470
+#: ../src/unix/sound.cpp:459
 #, c-format
 msgid "Couldn't load sound data from '%s'."
 msgstr "No s'han pogut carregar les dades de so de '%s'."
 
-#: ../src/msw/dirdlg.cpp:435
+#: ../src/msw/dirdlg.cpp:287
 msgid "Couldn't obtain folder name"
 msgstr "No s'ha pogut obtenir el nom de la carpeta"
 
-#: ../src/unix/sound_sdl.cpp:229
+#: ../src/unix/sound_sdl.cpp:226
 #, c-format
 msgid "Couldn't open audio: %s"
 msgstr "No s'ha pogut obrir l'àudio: %s"
 
-#: ../src/msw/ole/dataobj.cpp:377
+#: ../src/msw/ole/dataobj.cpp:385
 #, c-format
 msgid "Couldn't register clipboard format '%s'."
 msgstr "No s'ha pogut registrar el format '%s' del porta-retalls."
 
-#: ../src/msw/listctrl.cpp:869
+#: ../src/msw/listctrl.cpp:933
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr ""
 "No es pot obtenir la informació de l'element de control de la llista %d."
 
-#: ../src/common/imagpng.cpp:498 ../src/common/imagpng.cpp:509
-#: ../src/common/imagpng.cpp:519
+#: ../src/common/imagpng.cpp:511 ../src/common/imagpng.cpp:522
+#: ../src/common/imagpng.cpp:532
 msgid "Couldn't save PNG image."
 msgstr "No s'ha pogut desar la imatge PNG."
 
-#: ../src/msw/thread.cpp:684
+#: ../src/msw/thread.cpp:676
 msgid "Couldn't terminate thread"
 msgstr "No s'ha pogut finalitzar el fil d'execució"
 
-#: ../src/common/xtistrm.cpp:166
+#: ../src/common/xtistrm.cpp:163
 #, c-format
 msgid "Create Parameter %s not found in declared RTTI Parameters"
 msgstr "No s'ha trobat el paràmetre Create %s als paràmetres RTTI declarats"
 
-#: ../src/generic/dirdlgg.cpp:288
+#: ../src/generic/dirdlgg.cpp:285
 msgid "Create directory"
 msgstr "Crea un directori"
 
-#: ../src/generic/filedlgg.cpp:212 ../src/generic/dirdlgg.cpp:111
+#: ../src/generic/filedlgg.cpp:209 ../src/generic/dirdlgg.cpp:108
 msgid "Create new directory"
 msgstr "Crea un directori nou"
 
-#: ../src/xrc/xmlres.cpp:2460
+#: ../src/common/stockitem.cpp:264
+#, fuzzy
+msgid "Create new document"
+msgstr "Crea un directori nou"
+
+#: ../src/xrc/xmlres.cpp:2515
 #, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "No s'ha pogut crear %s \"%s\"."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1758
+#: ../src/propgrid/advprops.cpp:1659
 msgid "Cross"
 msgstr "Creu"
 
-#: ../src/common/accelcmn.cpp:333
+#: ../src/common/accelcmn.cpp:347
 msgid "Ctrl+"
 msgstr "Ctrl+"
 
-#: ../src/richtext/richtextctrl.cpp:332 ../src/osx/textctrl_osx.cpp:576
-#: ../src/common/stockitem.cpp:151 ../src/msw/textctrl.cpp:2507
+#: ../src/osx/textctrl_osx.cpp:594 ../src/common/stockitem.cpp:148
+#: ../src/msw/textctrl.cpp:2772 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "Re&talla"
 
-#: ../src/generic/filectrlg.cpp:940
+#: ../src/generic/filectrlg.cpp:936
 msgid "Current directory:"
 msgstr "Directori actual:"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:896 ../src/propgrid/advprops.cpp:1574
-#: ../src/propgrid/advprops.cpp:1612
+#: ../src/propgrid/advprops.cpp:797 ../src/propgrid/advprops.cpp:1475
+#: ../src/propgrid/advprops.cpp:1518
 msgid "Custom"
 msgstr "Personalitzat"
 
-#: ../src/gtk/print.cpp:217
+#: ../src/gtk/print.cpp:211
 msgid "Custom size"
 msgstr "Mida personalitzada"
 
-#: ../src/common/headerctrlcmn.cpp:60
+#: ../src/common/headerctrlcmn.cpp:58
 msgid "Customize Columns"
 msgstr "Personalitza les columnes"
 
-#: ../src/common/stockitem.cpp:151 ../src/stc/stc_i18n.cpp:17
+#: ../src/common/stockitem.cpp:148 ../src/stc/stc_i18n.cpp:17
 msgid "Cut"
 msgstr "Retalla"
 
-#: ../src/common/stockitem.cpp:259
+#: ../src/common/stockitem.cpp:256
 msgid "Cut selection"
 msgstr "Retalla la selecció"
 
-#: ../src/common/fmapbase.cpp:152
+#: ../src/common/fmapbase.cpp:149
 msgid "Cyrillic (ISO-8859-5)"
 msgstr "Ciríl·lic (ISO-8859-5)"
 
-#: ../src/common/paper.cpp:99
+#: ../src/common/paper.cpp:96
 msgid "D sheet, 22 x 34 in"
 msgstr "Full D, 22 x 34 polz."
 
-#: ../src/msw/dde.cpp:703
+#: ../src/msw/dde.cpp:698
 msgid "DDE poke request failed"
 msgstr "Ha fallat la petició d'atiar el DDE"
 
-#: ../src/common/imagbmp.cpp:1169
+#: ../src/common/imagbmp.cpp:1181
 msgid "DIB Header: Encoding doesn't match bitdepth."
-msgstr "Capçalera DIB: La codificació no coincideix amb la profunditat de bits."
+msgstr ""
+"Capçalera DIB: La codificació no coincideix amb la profunditat de bits."
 
 #: ../src/common/imagbmp.cpp:1074
 msgid "DIB Header: Image height > 32767 pixels for file."
@@ -2587,7 +2594,7 @@ msgstr "Capçalera DIB: Profunditat de bits desconeguda al fitxer."
 msgid "DIB Header: Unknown encoding in file."
 msgstr "Capçalera DIB: Codificació desconeguda al fitxer."
 
-#: ../src/common/paper.cpp:121
+#: ../src/common/paper.cpp:118
 msgid "DL Envelope, 110 x 220 mm"
 msgstr "Sobre DL, 110 x 220 mm"
 
@@ -2595,53 +2602,53 @@ msgstr "Sobre DL, 110 x 220 mm"
 msgid "Dashed"
 msgstr "Ratllat"
 
-#: ../src/generic/dbgrptg.cpp:300
+#: ../src/generic/dbgrptg.cpp:301
 #, c-format
 msgid "Debug report \"%s\""
 msgstr "Informe de depuració \"%s\""
 
-#: ../src/common/debugrpt.cpp:210
+#: ../src/common/debugrpt.cpp:211
 msgid "Debug report couldn't be created."
 msgstr "No s'ha pogut crear l'informe de depuració."
 
-#: ../src/common/debugrpt.cpp:553
+#: ../src/common/debugrpt.cpp:554
 msgid "Debug report generation has failed."
 msgstr "No s'ha pogut generar l'informe de depuració."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:84
+#: ../src/common/accelcmn.cpp:81
 msgid "Decimal"
 msgstr "Decimal"
 
-#: ../src/generic/fontdlgg.cpp:323
+#: ../src/generic/fontdlgg.cpp:319
 msgid "Decorative"
 msgstr "Decoratiu"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1752
+#: ../src/propgrid/advprops.cpp:1653
 msgid "Default"
 msgstr "Per defecte"
 
-#: ../src/common/fmapbase.cpp:796
+#: ../src/common/fmapbase.cpp:792
 msgid "Default encoding"
 msgstr "Codificació per defecte"
 
-#: ../src/dfb/fontmgr.cpp:180
+#: ../src/dfb/fontmgr.cpp:177
 msgid "Default font"
 msgstr "Tipus de lletra per defecte"
 
-#: ../src/generic/prntdlgg.cpp:510
+#: ../src/generic/prntdlgg.cpp:503
 msgid "Default printer"
 msgstr "Impressora per defecte"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:51
+#: ../src/common/accelcmn.cpp:48
 msgid "Del"
 msgstr "Supr"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextbuffer.cpp:8221 ../src/common/stockitem.cpp:152
-#: ../src/common/accelcmn.cpp:50 ../src/stc/stc_i18n.cpp:20
+#: ../src/common/stockitem.cpp:149 ../src/common/accelcmn.cpp:47
+#: ../src/richtext/richtextbuffer.cpp:8217 ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Suprimeix"
 
@@ -2649,68 +2656,68 @@ msgstr "Suprimeix"
 msgid "Delete A&ll"
 msgstr "Suprimeix-ho &tot"
 
-#: ../src/richtext/richtextbuffer.cpp:11341
+#: ../src/richtext/richtextbuffer.cpp:11340
 msgid "Delete Column"
 msgstr "Suprimeix la columna"
 
-#: ../src/richtext/richtextbuffer.cpp:11291
+#: ../src/richtext/richtextbuffer.cpp:11290
 msgid "Delete Row"
 msgstr "Suprimeix la fila"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 msgid "Delete Style"
 msgstr "Suprimeix l'estil"
 
-#: ../src/richtext/richtextctrl.cpp:1345 ../src/richtext/richtextctrl.cpp:1584
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
 msgid "Delete Text"
 msgstr "Suprimeix el text"
 
-#: ../src/generic/editlbox.cpp:170
+#: ../src/generic/editlbox.cpp:147
 msgid "Delete item"
 msgstr "Suprimeix l'element"
 
-#: ../src/common/stockitem.cpp:260
+#: ../src/common/stockitem.cpp:257
 msgid "Delete selection"
 msgstr "Suprimeix la selecció"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 #, c-format
 msgid "Delete style %s?"
 msgstr "Voleu suprimir l'estil %s?"
 
-#: ../src/unix/snglinst.cpp:301
+#: ../src/unix/snglinst.cpp:298
 #, c-format
 msgid "Deleted stale lock file '%s'."
 msgstr "S'ha suprimit el fitxer antic de blocatge '%s'."
 
-#: ../src/common/secretstore.cpp:220
-#, c-format
-msgid "Deleting password for \"%s/%s\" failed: %s."
+#: ../src/common/secretstore.cpp:234
+#, fuzzy, c-format
+msgid "Deleting password for \"%s\" failed: %s."
 msgstr "No s'ha pogut suprimir la contrasenya de \"%s/%s\": %s."
 
-#: ../src/common/module.cpp:124
+#: ../src/common/module.cpp:121
 #, c-format
 msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
 msgstr "La dependència \"%s\" del mòdul \"%s\" no existeix."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "Descending"
 msgstr "Descendent"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:526 ../src/propgrid/advprops.cpp:882
+#: ../src/generic/dirctrlg.cpp:492 ../src/propgrid/advprops.cpp:783
 msgid "Desktop"
 msgstr "Desktop"
 
-#: ../src/generic/aboutdlgg.cpp:70
+#: ../src/generic/aboutdlgg.cpp:67
 msgid "Developed by "
 msgstr "Desenvolupat per "
 
-#: ../src/generic/aboutdlgg.cpp:176
+#: ../src/generic/aboutdlgg.cpp:173
 msgid "Developers"
 msgstr "Desenvolupadors"
 
-#: ../src/msw/dialup.cpp:374
+#: ../src/msw/dialup.cpp:368
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -2718,11 +2725,11 @@ msgstr ""
 "Les funcions de marcatge telefònic no estan disponibles perquè el servei "
 "d'accés remot (RAS) no està instal·lat en aquest dispositiu. Instal·leu-lo."
 
-#: ../src/generic/tipdlg.cpp:211
+#: ../src/generic/tipdlg.cpp:208
 msgid "Did you know..."
 msgstr "Sabíeu que..."
 
-#: ../src/dfb/wrapdfb.cpp:63
+#: ../src/dfb/wrapdfb.cpp:60
 #, c-format
 msgid "DirectFB error %d occurred."
 msgstr "S'ha produït un error %d de DirectFB."
@@ -2731,30 +2738,30 @@ msgstr "S'ha produït un error %d de DirectFB."
 msgid "Directories"
 msgstr "Directoris"
 
-#: ../src/common/filefn.cpp:1183
+#: ../src/common/filefn.cpp:1071
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "No s'ha pogut crear el directori '%s'"
 
-#: ../src/common/filefn.cpp:1197
+#: ../src/common/filefn.cpp:1085
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "No s'ha pogut suprimir el directori '%s'"
 
-#: ../src/generic/dirdlgg.cpp:204
+#: ../src/generic/dirdlgg.cpp:201
 msgid "Directory does not exist"
 msgstr "El directori no existeix"
 
-#: ../src/generic/filectrlg.cpp:1399
+#: ../src/generic/filectrlg.cpp:1388
 msgid "Directory doesn't exist."
 msgstr "El directori no existeix."
 
-#: ../src/common/docview.cpp:457
+#: ../src/common/docview.cpp:450
 msgid "Discard changes and reload the last saved version?"
 msgstr ""
 "Voleu descartar els canvis i tornar a carregar la darrera versió desada?"
 
-#: ../src/html/helpwnd.cpp:502
+#: ../src/html/helpwnd.cpp:500
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -2762,45 +2769,45 @@ msgstr ""
 "Mostra tots els elements de l'índex que continguin la subcadena donada. La "
 "cerca no distingeix entre majúscules i minúscules."
 
-#: ../src/html/helpwnd.cpp:679
+#: ../src/html/helpwnd.cpp:677
 msgid "Display options dialog"
 msgstr "Mostra el diàleg d'opcions"
 
-#: ../src/html/helpwnd.cpp:322
+#: ../src/html/helpwnd.cpp:320
 msgid "Displays help as you browse the books on the left."
 msgstr "Mostra l'ajuda mentre navegueu pels llibres de l'esquerra."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:85
+#: ../src/common/accelcmn.cpp:83
 msgid "Divide"
 msgstr "Divisió"
 
-#: ../src/common/docview.cpp:533
+#: ../src/common/docview.cpp:526
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Voleu desar els canvis fets a %s?"
 
-#: ../src/common/prntbase.cpp:542
+#: ../src/common/prntbase.cpp:537
 msgid "Document:"
 msgstr "Document:"
 
-#: ../src/generic/aboutdlgg.cpp:73
+#: ../src/generic/aboutdlgg.cpp:70
 msgid "Documentation by "
 msgstr "Documentació feta per "
 
-#: ../src/generic/aboutdlgg.cpp:180
+#: ../src/generic/aboutdlgg.cpp:177
 msgid "Documentation writers"
 msgstr "Redactors de la documentació"
 
-#: ../src/common/sizer.cpp:2799
+#: ../src/common/sizer.cpp:2916
 msgid "Don't Save"
 msgstr "No desis"
 
-#: ../src/html/htmlwin.cpp:633
+#: ../src/html/htmlwin.cpp:643
 msgid "Done"
 msgstr "Fet"
 
-#: ../src/generic/progdlgg.cpp:448 ../src/msw/progdlg.cpp:407
+#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
 msgid "Done."
 msgstr "Fet."
 
@@ -2812,42 +2819,42 @@ msgstr "Puntejat"
 msgid "Double"
 msgstr "Doble"
 
-#: ../src/common/paper.cpp:176
+#: ../src/common/paper.cpp:173
 msgid "Double Japanese Postcard Rotated 148 x 200 mm"
 msgstr "Targeta postal japonesa doble girada, 148 x 200 mm"
 
-#: ../src/common/xtixml.cpp:273
+#: ../src/common/xtixml.cpp:269
 #, c-format
 msgid "Doubly used id : %d"
 msgstr "Identificador utilitzat dues vegades: %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:153
-#: ../src/common/accelcmn.cpp:64
+#: ../src/common/stockitem.cpp:150 ../src/common/accelcmn.cpp:61
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Down"
 msgstr "Avall"
 
-#: ../src/richtext/richtextctrl.cpp:865
+#: ../src/richtext/richtextctrl.cpp:864
 msgid "Drag"
 msgstr "Arrossega"
 
-#: ../src/common/paper.cpp:100
+#: ../src/common/paper.cpp:97
 msgid "E sheet, 34 x 44 in"
 msgstr "Full E, 34 x 44 polz."
 
-#: ../src/unix/fswatcher_inotify.cpp:561
+#: ../src/unix/fswatcher_inotify.cpp:558
 msgid "EOF while reading from inotify descriptor"
 msgstr "EOF mentre es llegia del descriptor inotify"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "Edit"
 msgstr "Edita"
 
-#: ../src/generic/editlbox.cpp:168
+#: ../src/generic/editlbox.cpp:131
 msgid "Edit item"
 msgstr "Edita l'element"
 
-#: ../include/wx/generic/progdlgg.h:84
+#: ../include/wx/generic/progdlgg.h:85
 msgid "Elapsed time:"
 msgstr "Temps transcorregut:"
 
@@ -2914,49 +2921,49 @@ msgid "Enables the shadow spread."
 msgstr "Activa la difusió de l'ombra."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:66
+#: ../src/common/accelcmn.cpp:63
 msgid "End"
 msgstr "Fi"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:55
+#: ../src/common/accelcmn.cpp:52
 msgid "Enter"
 msgstr "Retorn"
 
-#: ../src/richtext/richtextstyledlg.cpp:934
+#: ../src/richtext/richtextstyledlg.cpp:930
 msgid "Enter a box style name"
 msgstr "Introduïu un nom per a l'estil de caixa"
 
-#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:602
 msgid "Enter a character style name"
 msgstr "Introduïu un nom per a l'estil de caràcter"
 
-#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:816
 msgid "Enter a list style name"
 msgstr "Introduïu un nom per a l'estil de llista"
 
-#: ../src/richtext/richtextstyledlg.cpp:893
+#: ../src/richtext/richtextstyledlg.cpp:889
 msgid "Enter a new style name"
 msgstr "Introduïu un nom per a l'estil nou"
 
-#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:650
 msgid "Enter a paragraph style name"
 msgstr "Introduïu un nom per a l'estil de paràgraf"
 
-#: ../src/generic/dbgrptg.cpp:174
+#: ../src/generic/dbgrptg.cpp:171
 #, c-format
 msgid "Enter command to open file \"%s\":"
 msgstr "Introduïu l'ordre per a obrir el fitxer \"%s\":"
 
-#: ../src/generic/helpext.cpp:459
+#: ../src/generic/helpext.cpp:457
 msgid "Entries found"
 msgstr "Entrades trobades"
 
-#: ../src/common/paper.cpp:142
+#: ../src/common/paper.cpp:139
 msgid "Envelope Invite 220 x 220 mm"
 msgstr "Sobre d'invitació, 220 x 220 mm"
 
-#: ../src/common/config.cpp:469
+#: ../src/common/config.cpp:465
 #, c-format
 msgid ""
 "Environment variables expansion failed: missing '%c' at position %u in '%s'."
@@ -2964,13 +2971,13 @@ msgstr ""
 "No s'han pogut expandir les variables d'entorn: manca '%c' a la posició %u a "
 "'%s'."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/generic/dirctrlg.cpp:570
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/dirctrlg.cpp:599
-#: ../src/generic/dirdlgg.cpp:323 ../src/generic/filectrlg.cpp:642
-#: ../src/generic/filectrlg.cpp:756 ../src/generic/filectrlg.cpp:770
-#: ../src/generic/filectrlg.cpp:786 ../src/generic/filectrlg.cpp:1368
-#: ../src/generic/filectrlg.cpp:1399 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/gtk1/fontdlg.cpp:74 ../src/generic/dirctrlg.cpp:536
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/dirctrlg.cpp:565
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1357 ../src/generic/filectrlg.cpp:1388
+#: ../src/generic/filedlgg.cpp:354 ../src/generic/dirdlgg.cpp:320
+#: ../src/gtk/filedlg.cpp:74
 msgid "Error"
 msgstr "Error"
 
@@ -2978,86 +2985,97 @@ msgstr "Error"
 msgid "Error closing epoll descriptor"
 msgstr "S'ha produït un error en tancar el descriptor epoll"
 
-#: ../src/unix/fswatcher_kqueue.cpp:114
+#: ../src/unix/fswatcher_kqueue.cpp:131
 msgid "Error closing kqueue instance"
 msgstr "S'ha produït un error en tancar la instància kqueue"
 
-#: ../src/common/filefn.cpp:1049
+#: ../src/common/filefn.cpp:938
 #, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "S'ha produït un error en copiar el fitxer '%s' a '%s'."
 
-#: ../src/generic/dirdlgg.cpp:222
+#: ../src/generic/dirdlgg.cpp:219
 msgid "Error creating directory"
 msgstr "S'ha produït un error en crear el directori"
 
-#: ../src/common/imagbmp.cpp:1181
+#: ../src/common/imagbmp.cpp:1193
 msgid "Error in reading image DIB."
 msgstr "S'ha produït un error en llegir la imatge DIB."
 
-#: ../src/propgrid/propgrid.cpp:6696
+#: ../src/propgrid/propgrid.cpp:6665
 #, c-format
 msgid "Error in resource: %s"
 msgstr "S'ha produït un error al recurs: %s"
 
-#: ../src/common/fileconf.cpp:422
+#: ../src/common/fileconf.cpp:421
 msgid "Error reading config options."
 msgstr "S'ha produït un error en llegir les opcions de configuració."
+
+#: ../src/msw/webview_ie.cpp:1057 ../src/msw/webview_edge.cpp:850
+#: ../src/gtk/webview_webkit2.cpp:1262 ../src/osx/webview_webkit.mm:383
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
 
 #: ../src/common/fileconf.cpp:1029
 msgid "Error saving user configuration data."
 msgstr "S'ha produït un error en desar les dades de configuració de l'usuari."
 
-#: ../src/gtk/print.cpp:722
+#: ../src/gtk/print.cpp:720
 msgid "Error while printing: "
 msgstr "S'ha produït un error en imprimir: "
 
-#: ../src/common/log.cpp:219
+#: ../src/common/log.cpp:237
 msgid "Error: "
 msgstr "Error: "
 
+#: ../src/common/webrequest.cpp:98
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Error: "
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:69
+#: ../src/common/accelcmn.cpp:66
 msgid "Esc"
 msgstr "Esc"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:70
+#: ../src/common/accelcmn.cpp:67
 msgid "Escape"
 msgstr "Escapada"
 
-#: ../src/common/fmapbase.cpp:150
+#: ../src/common/fmapbase.cpp:147
 msgid "Esperanto (ISO-8859-3)"
 msgstr "Esperanto (ISO-8859-3)"
 
-#: ../include/wx/generic/progdlgg.h:85
+#: ../include/wx/generic/progdlgg.h:86
 msgid "Estimated time:"
 msgstr "Temps estimat:"
 
-#: ../src/generic/dbgrptg.cpp:234
+#: ../src/generic/dbgrptg.cpp:231
 msgid "Executable files (*.exe)|*.exe|"
 msgstr "Fitxers executables (*.exe)|*.exe|"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:155 ../src/common/accelcmn.cpp:78
+#: ../src/common/stockitem.cpp:152 ../src/common/accelcmn.cpp:75
 msgid "Execute"
 msgstr "Executa"
 
-#: ../src/msw/utilsexc.cpp:876
+#: ../src/msw/utilsexc.cpp:873
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Ha fallat l'execució de l'ordre '%s'"
 
-#: ../src/common/paper.cpp:105
+#: ../src/common/paper.cpp:102
 msgid "Executive, 7 1/4 x 10 1/2 in"
 msgstr "Executiu, 7 1/4 x 10 1/2 polz."
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6009
+#: ../src/generic/datavgen.cpp:6814
 msgid "Expand"
 msgstr "Expandeix"
 
-#: ../src/msw/registry.cpp:1240
+#: ../src/msw/registry.cpp:1228
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
@@ -3065,148 +3083,158 @@ msgstr ""
 "Exportació de la clau del registre: el fitxer \"%s\" ja existeix i no se "
 "sobreescriurà."
 
-#: ../src/common/fmapbase.cpp:195
+#: ../src/common/fmapbase.cpp:192
 msgid "Extended Unix Codepage for Japanese (EUC-JP)"
 msgstr "Codificació de pàgina estesa d'Unix per al japonès (EUC-JP)"
 
-#: ../src/html/chm.cpp:725
+#: ../src/html/chm.cpp:718
 #, c-format
 msgid "Extraction of '%s' into '%s' failed."
 msgstr "No s'ha pogut executar '%s' a '%s'."
 
-#: ../src/common/accelcmn.cpp:249 ../src/common/accelcmn.cpp:344
+#: ../src/common/accelcmn.cpp:259 ../src/common/accelcmn.cpp:358
 msgid "F"
 msgstr "F"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:672
+#: ../src/propgrid/advprops.cpp:582
 msgid "Face Name"
 msgstr "Nom del tipus de lletra"
 
-#: ../src/unix/snglinst.cpp:269
+#: ../src/unix/snglinst.cpp:266
 msgid "Failed to access lock file."
 msgstr "No s'ha pogut accedir el fitxer de blocatge."
+
+#: ../src/gtk/font.cpp:572
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "No s'ha pogut llegir el document del fitxer \"%s\"."
 
 #: ../src/unix/epolldispatcher.cpp:116
 #, c-format
 msgid "Failed to add descriptor %d to epoll descriptor %d"
 msgstr "No s'ha pogut afegir el descriptor %d al descriptor epoll %d"
 
-#: ../src/msw/dib.cpp:489
+#: ../src/msw/dib.cpp:535
 #, c-format
 msgid "Failed to allocate %luKb of memory for bitmap data."
 msgstr "No s'ha pogut assignar %luKb de memòria per a dades de mapa de bits."
 
-#: ../src/common/glcmn.cpp:115
+#: ../src/common/glcmn.cpp:112
 msgid "Failed to allocate colour for OpenGL"
 msgstr "No s'ha pogut assignar el color per a l'OpenGL"
 
-#: ../src/unix/displayx11.cpp:236
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "No s'ha pogut assignar el color per a l'OpenGL"
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "No s'ha pogut assignar el color per a l'OpenGL"
+
+#: ../include/wx/unix/private/displayx11.h:89
 msgid "Failed to change video mode"
 msgstr "No s'ha pogut canviar el mode de vídeo"
 
-#: ../src/common/image.cpp:3277
+#: ../src/common/image.cpp:3396
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "No s'ha pogut comprovar el format del fitxer d'imatge \"%s\"."
 
-#: ../src/common/debugrpt.cpp:239
+#: ../src/common/debugrpt.cpp:240
 #, c-format
 msgid "Failed to clean up debug report directory \"%s\""
 msgstr "No s'ha pogut netejar el directori d'informes de depuració \"%s\""
 
-#: ../src/common/filename.cpp:192
+#: ../src/common/filename.cpp:189
 msgid "Failed to close file handle"
 msgstr "No s'ha pogut tancar el manegador del fitxer"
 
-#: ../src/unix/snglinst.cpp:340
+#: ../src/unix/snglinst.cpp:337
 #, c-format
 msgid "Failed to close lock file '%s'"
 msgstr "No s'ha pogut tancar el fitxer de blocatge '%s'"
 
-#: ../src/msw/clipbrd.cpp:112
+#: ../src/msw/clipbrd.cpp:110
 msgid "Failed to close the clipboard."
 msgstr "No s'ha pogut tancar el porta-retalls."
 
-#: ../src/x11/utils.cpp:208
+#: ../src/x11/utils.cpp:170
 #, c-format
 msgid "Failed to close the display \"%s\""
 msgstr "No s'ha pogut tancar la pantalla \"%s\""
 
-#: ../src/msw/dialup.cpp:797
+#: ../src/msw/dialup.cpp:791
 msgid "Failed to connect: missing username/password."
 msgstr "No s'ha pogut connectar: manca el nom d'usuari o la contrasenya."
 
-#: ../src/msw/dialup.cpp:743
+#: ../src/msw/dialup.cpp:737
 msgid "Failed to connect: no ISP to dial."
 msgstr ""
 "No s'ha pogut connectar: no hi ha cap proveïdor d'Internet al qual trucar."
 
-#: ../src/common/textfile.cpp:203
-#, c-format
-msgid "Failed to convert file \"%s\" to Unicode."
-msgstr "No s'ha pogut convertir el fitxer \"%s\" a Unicode."
-
-#: ../src/generic/logg.cpp:956
+#: ../src/generic/logg.cpp:953
 msgid "Failed to copy dialog contents to the clipboard."
 msgstr "No s'ha pogut copiar el contingut del diàleg al porta-retalls."
 
-#: ../src/msw/registry.cpp:692
+#: ../src/msw/registry.cpp:681
 #, c-format
 msgid "Failed to copy registry value '%s'"
 msgstr "No s'ha pogut copiar el valor del registre '%s'"
 
-#: ../src/msw/registry.cpp:701
+#: ../src/msw/registry.cpp:690
 #, c-format
 msgid "Failed to copy the contents of registry key '%s' to '%s'."
 msgstr "No s'ha pogut copiar el contingut de la clau del registre '%s' a '%s'."
 
-#: ../src/common/filefn.cpp:1015
+#: ../src/common/filefn.cpp:904
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "No s'ha pogut copiar el fitxer '%s' a '%s'"
 
-#: ../src/msw/registry.cpp:679
+#: ../src/msw/registry.cpp:668
 #, c-format
 msgid "Failed to copy the registry subkey '%s' to '%s'."
 msgstr "No s'ha pogut copiar la subclau del registre '%s' a '%s'."
 
-#: ../src/msw/dde.cpp:1070
+#: ../src/msw/dde.cpp:1134
 msgid "Failed to create DDE string"
 msgstr "No s'ha pogut crear la cadena DDE"
 
-#: ../src/msw/mdi.cpp:616
+#: ../src/msw/mdi.cpp:621
 msgid "Failed to create MDI parent frame."
 msgstr "No s'ha pogut crear el marc pare de l'MDI."
 
-#: ../src/common/filename.cpp:1027
+#: ../src/common/filename.cpp:1024
 msgid "Failed to create a temporary file name"
 msgstr "No s'ha pogut crear un nom de fitxer temporal"
 
-#: ../src/msw/utilsexc.cpp:228
+#: ../src/msw/utilsexc.cpp:225
 msgid "Failed to create an anonymous pipe"
 msgstr "No s'ha pogut crear una canonada anònima"
 
-#: ../src/msw/ole/automtn.cpp:522
+#: ../src/msw/ole/automtn.cpp:513
 #, c-format
 msgid "Failed to create an instance of \"%s\""
 msgstr "No s'ha pogut crear una instància de \"%s\""
 
-#: ../src/msw/dde.cpp:437
+#: ../src/msw/dde.cpp:432
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "No s'ha pogut crear una connexió al servidor '%s' en el tema '%s'"
 
-#: ../src/msw/cursor.cpp:204
+#: ../src/msw/cursor.cpp:195
 msgid "Failed to create cursor."
 msgstr "No s'ha pogut crear el cursor."
 
-#: ../src/common/debugrpt.cpp:209
+#: ../src/common/debugrpt.cpp:210
 #, c-format
 msgid "Failed to create directory \"%s\""
 msgstr "No s'ha pogut crear el directori \"%s\""
 
-#: ../src/generic/dirdlgg.cpp:220
+#: ../src/generic/dirdlgg.cpp:217
 #, c-format
 msgid ""
 "Failed to create directory '%s'\n"
@@ -3219,118 +3247,137 @@ msgstr ""
 msgid "Failed to create epoll descriptor"
 msgstr "No s'ha pogut crear el descriptor epoll"
 
-#: ../src/msw/mimetype.cpp:238
+#: ../src/gtk/font.cpp:562
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "No s'ha pogut actualitzar el fitxer de configuració de l'usuari."
+
+#: ../src/msw/mimetype.cpp:235
 #, c-format
 msgid "Failed to create registry entry for '%s' files."
 msgstr "No s'ha pogut crear l'entrada del registre dels fitxers '%s'."
 
-#: ../src/msw/fdrepdlg.cpp:409
+#: ../src/msw/fdrepdlg.cpp:408
 #, c-format
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr ""
 "No s'ha pogut crear el diàleg estàndard de cerca/substitueix (codi d'error "
 "%d)"
 
-#: ../src/unix/wakeuppipe.cpp:52
+#: ../src/unix/wakeuppipe.cpp:49
 msgid "Failed to create wake up pipe used by event loop."
 msgstr ""
 "No s'ha pogut crear la canonada de despertament utilitzada pel bucle "
 "d'esdeveniments."
 
-#: ../src/html/winpars.cpp:730
+#: ../src/html/winpars.cpp:727
 #, c-format
 msgid "Failed to display HTML document in %s encoding"
 msgstr "No s'ha pogut mostrar el document HTML amb la codificació %s"
 
-#: ../src/msw/clipbrd.cpp:124
+#: ../src/msw/clipbrd.cpp:122
 msgid "Failed to empty the clipboard."
 msgstr "No s'ha pogut buidar el porta-retalls."
 
-#: ../src/unix/displayx11.cpp:212
+#: ../include/wx/unix/private/displayx11.h:65
 msgid "Failed to enumerate video modes"
 msgstr "No s'han pogut enumerar els modes de vídeo"
 
-#: ../src/msw/dde.cpp:722
+#: ../src/msw/dde.cpp:717
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "No s'ha pogut establir un bucle d'avís amb el servidor DDE"
 
-#: ../src/msw/dialup.cpp:629 ../src/msw/dialup.cpp:863
+#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "No s'ha pogut establir la connexió de marcatge telefònic: %s"
 
-#: ../src/unix/utilsunx.cpp:611
+#: ../src/unix/utilsunx.cpp:613
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "No s'ha pogut executar '%s'\n"
 
-#: ../src/common/debugrpt.cpp:720
+#: ../src/common/debugrpt.cpp:730
 msgid "Failed to execute curl, please install it in PATH."
 msgstr "No s'ha pogut executar curl, instal·leu-lo al PATH."
 
-#: ../src/msw/ole/automtn.cpp:505
+#: ../src/msw/ole/automtn.cpp:496
 #, c-format
 msgid "Failed to find CLSID of \"%s\""
 msgstr "No s'ha pogut trobar el CLSID de \"%s\""
 
-#: ../src/common/regex.cpp:431 ../src/common/regex.cpp:479
+#: ../src/common/regex.cpp:428 ../src/common/regex.cpp:476
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "No s'ha pogut trobar cap coincidència per a l'expressió regular: %s"
 
-#: ../src/msw/dialup.cpp:695
+#: ../src/msw/webview_ie.cpp:978
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:689
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "No s'han pogut obtenir els noms dels proveïdors d'Internet: %s"
 
-#: ../src/msw/ole/automtn.cpp:574
+#: ../src/msw/ole/automtn.cpp:565
 #, c-format
 msgid "Failed to get OLE automation interface for \"%s\""
 msgstr "No s'ha pogut obtenir la interfície d'automatització OLE per a \"%s\""
 
-#: ../src/msw/clipbrd.cpp:711
+#: ../src/msw/clipbrd.cpp:731
 msgid "Failed to get data from the clipboard"
 msgstr "No s'han pogut obtenir les dades del porta-retalls"
 
-#: ../src/common/time.cpp:223
+#: ../src/common/time.cpp:216
 msgid "Failed to get the local system time"
 msgstr "No s'ha pogut obtenir l'hora del sistema local"
 
-#: ../src/common/filefn.cpp:1345
+#: ../src/common/filefn.cpp:1233
 msgid "Failed to get the working directory"
 msgstr "No s'ha pogut obtenir el directori de treball"
 
-#: ../src/univ/theme.cpp:114
+#: ../src/univ/theme.cpp:111
 msgid "Failed to initialize GUI: no built-in themes found."
 msgstr "No s'ha pogut inicialitzar la GUI: no s'ha trobat cap tema integrat."
 
-#: ../src/msw/helpchm.cpp:63
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:60
 msgid "Failed to initialize MS HTML Help."
 msgstr "No s'ha pogut inicialitzar l'ajuda MS HTML."
 
-#: ../src/msw/glcanvas.cpp:1381
+#: ../src/msw/glcanvas.cpp:1391
 msgid "Failed to initialize OpenGL"
 msgstr "No s'ha pogut inicialitzar l'OpenGL"
 
-#: ../src/msw/dialup.cpp:858
+#: ../src/msw/dialup.cpp:852
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "No s'ha pogut inicialitzar la connexió de marcatge telefònic: %s"
 
-#: ../src/gtk/textctrl.cpp:1128
+#: ../src/gtk/textctrl.cpp:1209
 msgid "Failed to insert text in the control."
 msgstr "No s'ha pogut inserir el text al control."
 
-#: ../src/unix/snglinst.cpp:241
+#: ../src/unix/snglinst.cpp:238
 #, c-format
 msgid "Failed to inspect the lock file '%s'"
 msgstr "No s'ha pogut inspeccionar el fitxer de blocatge '%s'"
 
-#: ../src/unix/appunix.cpp:182
+#: ../src/unix/appunix.cpp:179
 msgid "Failed to install signal handler"
 msgstr "No s'ha pogut instal·lar el gestor de senyals"
 
-#: ../src/unix/threadpsx.cpp:1167
+#: ../src/unix/threadpsx.cpp:1216
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -3338,71 +3385,71 @@ msgstr ""
 "No s'ha pogut sincronitzar amb un fil d'execució, s'ha detectat una possible "
 "fuita de memòria - reinicieu el programa"
 
-#: ../src/msw/utils.cpp:629
+#: ../src/msw/utils.cpp:619
 #, c-format
 msgid "Failed to kill process %d"
 msgstr "No s'ha pogut matar el procés %d"
 
-#: ../src/common/image.cpp:2500
+#: ../src/common/image.cpp:2595
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "No s'ha pogut carregar el mapa de bits \"%s\" dels recursos."
 
-#: ../src/common/image.cpp:2509
+#: ../src/common/image.cpp:2604
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "No s'ha pogut carregar la icona \"%s\" dels recursos."
 
-#: ../src/common/iconbndl.cpp:225
+#: ../src/common/iconbndl.cpp:224
 #, c-format
 msgid "Failed to load icons from resource '%s'."
 msgstr "No s'han pogut carregar les icones del recurs '%s'."
 
-#: ../src/common/iconbndl.cpp:200
+#: ../src/common/iconbndl.cpp:198
 #, c-format
 msgid "Failed to load image %%d from file '%s'."
 msgstr "No s'ha pogut carregar la imatge %%d del fitxer '%s'."
 
-#: ../src/common/iconbndl.cpp:208
+#: ../src/common/iconbndl.cpp:206
 #, c-format
 msgid "Failed to load image %d from stream."
 msgstr "No s'ha pogut carregar la imatge %d del flux."
 
-#: ../src/common/image.cpp:2587 ../src/common/image.cpp:2606
+#: ../src/common/image.cpp:2682 ../src/common/image.cpp:2701
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "No s'ha pogut carregar la imatge del fitxer \"%s\"."
 
-#: ../src/msw/enhmeta.cpp:97
+#: ../src/msw/enhmeta.cpp:94
 #, c-format
 msgid "Failed to load metafile from file \"%s\"."
 msgstr "No s'ha pogut carregar el metafitxer del fitxer \"%s\"."
 
-#: ../src/msw/volume.cpp:327
+#: ../src/msw/volume.cpp:335
 msgid "Failed to load mpr.dll."
 msgstr "No s'ha pogut carregar mpr.dll."
 
-#: ../src/msw/utils.cpp:953
+#: ../src/msw/utils.cpp:943
 #, c-format
 msgid "Failed to load resource \"%s\"."
 msgstr "No s'ha pogut carregar el recurs \"%s\"."
 
-#: ../src/common/dynlib.cpp:92
+#: ../src/common/dynlib.cpp:86
 #, c-format
 msgid "Failed to load shared library '%s'"
 msgstr "No s'ha pogut carregar la biblioteca compartida '%s'"
 
-#: ../src/osx/core/sound.cpp:145
+#: ../src/osx/core/sound.cpp:143
 #, c-format
 msgid "Failed to load sound from \"%s\" (error %d)."
 msgstr "No s'ha pogut carregar el so de \"%s\" (error %d)."
 
-#: ../src/msw/utils.cpp:960
+#: ../src/msw/utils.cpp:950
 #, c-format
 msgid "Failed to lock resource \"%s\"."
 msgstr "No s'ha pogut blocar el recurs \"%s\"."
 
-#: ../src/unix/snglinst.cpp:198
+#: ../src/unix/snglinst.cpp:195
 #, c-format
 msgid "Failed to lock the lock file '%s'"
 msgstr "No s'ha pogut blocar el fitxer de blocatge '%s'"
@@ -3412,33 +3459,38 @@ msgstr "No s'ha pogut blocar el fitxer de blocatge '%s'"
 msgid "Failed to modify descriptor %d in epoll descriptor %d"
 msgstr "No s'ha pogut modificar el descriptor %d al descriptor epoll %d"
 
-#: ../src/common/filename.cpp:2575
+#: ../src/common/filename.cpp:2658
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "No s'han pogut modificar les hores del fitxer '%s'"
 
-#: ../src/common/selectdispatcher.cpp:258
+#: ../src/common/selectdispatcher.cpp:255
 msgid "Failed to monitor I/O channels"
 msgstr "No s'han pogut supervisar els canals d'E/S"
 
-#: ../src/common/filename.cpp:175
+#: ../src/common/filename.cpp:172
 #, c-format
 msgid "Failed to open '%s' for reading"
 msgstr "No s'ha pogut obrir '%s' per a llegir-lo"
 
-#: ../src/common/filename.cpp:180
+#: ../src/common/filename.cpp:177
 #, c-format
 msgid "Failed to open '%s' for writing"
 msgstr "No s'ha pogut obrir '%s' per a escriure-hi"
 
-#: ../src/html/chm.cpp:141
+#: ../src/html/chm.cpp:138
 #, c-format
 msgid "Failed to open CHM archive '%s'."
 msgstr "No s'ha pogut obrir l'arxiu CHM '%s'."
 
-#: ../src/common/utilscmn.cpp:1126
+#: ../src/common/utilscmn.cpp:1140
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
+msgstr "No s'ha pogut obrir l'URL \"%s\" al navegador per defecte."
+
+#: ../src/common/hyperlnkcmn.cpp:133
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "No s'ha pogut obrir l'URL \"%s\" al navegador per defecte."
 
 #: ../include/wx/msw/private/fswatcher.h:92
@@ -3446,93 +3498,103 @@ msgstr "No s'ha pogut obrir l'URL \"%s\" al navegador per defecte."
 msgid "Failed to open directory \"%s\" for monitoring."
 msgstr "No s'ha pogut obrir el directori \"%s\" per a supervisar-lo."
 
-#: ../src/x11/utils.cpp:227
+#: ../src/x11/utils.cpp:189
 #, c-format
 msgid "Failed to open display \"%s\"."
 msgstr "No s'ha pogut obrir la pantalla \"%s\"."
 
-#: ../src/common/filename.cpp:1062
+#: ../src/common/filename.cpp:1059
 msgid "Failed to open temporary file."
 msgstr "No s'ha pogut obrir el fitxer temporal."
 
-#: ../src/msw/clipbrd.cpp:91
+#: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "No s'ha pogut obrir el porta-retalls."
 
-#: ../src/common/translation.cpp:1184
+#: ../src/common/translation.cpp:1226
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "No s'ha pogut analitzar el Plural-Forms: '%s'"
 
-#: ../src/unix/mediactrl.cpp:1214
+#: ../src/unix/mediactrl.cpp:1239
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "No s'ha pogut preparar la reproducció de \"%s\"."
 
-#: ../src/msw/clipbrd.cpp:600
+#: ../src/msw/clipbrd.cpp:610
 msgid "Failed to put data on the clipboard"
 msgstr "No s'han pogut posar les dades al porta-retalls"
 
-#: ../src/unix/snglinst.cpp:278
+#: ../src/unix/snglinst.cpp:275
 msgid "Failed to read PID from lock file."
 msgstr "No s'ha pogut llegir el PID del fitxer de blocatge."
 
-#: ../src/common/fileconf.cpp:433
+#: ../src/common/fileconf.cpp:432
 msgid "Failed to read config options."
 msgstr "No s'han pogut llegir les opcions de la configuració."
 
-#: ../src/common/docview.cpp:681
+#: ../src/common/docview.cpp:676
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "No s'ha pogut llegir el document del fitxer \"%s\"."
 
-#: ../src/dfb/evtloop.cpp:98
+#: ../src/dfb/evtloop.cpp:99
 msgid "Failed to read event from DirectFB pipe"
 msgstr "No s'ha pogut llegir l'esdeveniment de la canonada DirectFB"
 
-#: ../src/unix/wakeuppipe.cpp:120
+#: ../src/unix/wakeuppipe.cpp:117
 msgid "Failed to read from wake-up pipe"
 msgstr "No s'ha pogut llegir la canonada de despertament"
 
-#: ../src/unix/utilsunx.cpp:679
+#: ../src/common/textfile.cpp:96
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "No s'ha pogut llegir el document del fitxer \"%s\"."
+
+#: ../src/unix/utilsunx.cpp:681
 msgid "Failed to redirect child process input/output"
 msgstr "No s'ha pogut redirigir l'entrada/sortida del procés fill"
 
-#: ../src/msw/utilsexc.cpp:701
+#: ../src/msw/utilsexc.cpp:698
 msgid "Failed to redirect the child process IO"
 msgstr "No s'ha pogut redirigir l'E/S del procés fill"
 
-#: ../src/msw/dde.cpp:288
+#: ../src/msw/dde.cpp:283
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "No s'ha pogut registrar el servidor DDE '%s'"
 
-#: ../src/common/fontmap.cpp:245
+#: ../src/gtk/font.cpp:580
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "No s'ha pogut actualitzar el fitxer de configuració de l'usuari."
+
+#: ../src/common/fontmap.cpp:242
 #, c-format
 msgid "Failed to remember the encoding for the charset '%s'."
 msgstr "No s'ha pogut recordar la codificació del joc de caràcters '%s'."
 
-#: ../src/common/debugrpt.cpp:227
+#: ../src/common/debugrpt.cpp:228
 #, c-format
 msgid "Failed to remove debug report file \"%s\""
 msgstr "No s'ha pogut suprimir el fitxer d'informe de depuració \"%s\""
 
-#: ../src/unix/snglinst.cpp:328
+#: ../src/unix/snglinst.cpp:325
 #, c-format
 msgid "Failed to remove lock file '%s'"
 msgstr "No s'ha pogut suprimir el fitxer de blocatge '%s'"
 
-#: ../src/unix/snglinst.cpp:288
+#: ../src/unix/snglinst.cpp:285
 #, c-format
 msgid "Failed to remove stale lock file '%s'."
 msgstr "No s'ha pogut suprimir el fitxer de blocatge antic '%s'."
 
-#: ../src/msw/registry.cpp:529
+#: ../src/msw/registry.cpp:518
 #, c-format
 msgid "Failed to rename registry value '%s' to '%s'."
 msgstr "No s'ha pogut canviar el nom del valor del registre '%s' a '%s'."
 
-#: ../src/common/filefn.cpp:1122
+#: ../src/common/filefn.cpp:1011
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -3541,118 +3603,127 @@ msgstr ""
 "No s'ha pogut canviar el nom del fitxer '%s' a '%s' perquè el fitxer de "
 "destinació ja existeix."
 
-#: ../src/msw/registry.cpp:634
+#: ../src/msw/registry.cpp:623
 #, c-format
 msgid "Failed to rename the registry key '%s' to '%s'."
 msgstr "No s'ha pogut canviar el nom de la clau del registre '%s' a '%s'."
 
-#: ../src/common/filename.cpp:2671
+#: ../src/msw/webview_ie.cpp:995
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/common/filename.cpp:2754
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "No s'han pogut obtenir les hores del fitxer '%s'"
 
-#: ../src/msw/dialup.cpp:468
+#: ../src/msw/dialup.cpp:462
 msgid "Failed to retrieve text of RAS error message"
 msgstr "No s'ha pogut recuperar el text del missatge d'error del RAS"
 
-#: ../src/msw/clipbrd.cpp:748
+#: ../src/msw/clipbrd.cpp:768
 msgid "Failed to retrieve the supported clipboard formats"
 msgstr "No s'han pogut obtenir els formats del porta-retalls suportats"
 
-#: ../src/common/docview.cpp:652
+#: ../src/common/docview.cpp:647
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "No s'ha pogut desar el document al fitxer \"%s\"."
 
-#: ../src/msw/dib.cpp:269
+#: ../src/msw/dib.cpp:312
 #, c-format
 msgid "Failed to save the bitmap image to file \"%s\"."
 msgstr "No s'ha pogut desar la imatge de mapa de bits al fitxer \"%s\"."
 
-#: ../src/msw/dde.cpp:763
+#: ../src/msw/dde.cpp:811
 msgid "Failed to send DDE advise notification"
 msgstr "No s'ha pogut enviar una notificació d'avís DDE"
 
-#: ../src/common/ftp.cpp:402
+#: ../src/common/ftp.cpp:399
 #, c-format
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "No s'ha pogut definir el mode de transferència FTP a %s."
 
-#: ../src/msw/clipbrd.cpp:427
+#: ../src/msw/clipbrd.cpp:443
 msgid "Failed to set clipboard data."
 msgstr "No s'han pogut definir les dades del porta-retalls."
 
-#: ../src/unix/snglinst.cpp:181
+#: ../src/unix/snglinst.cpp:178
 #, c-format
 msgid "Failed to set permissions on lock file '%s'"
 msgstr "No s'han pogut definir els permisos del fitxer de blocatge '%s'"
 
-#: ../src/unix/utilsunx.cpp:668
+#: ../src/unix/utilsunx.cpp:670
 msgid "Failed to set process priority"
 msgstr "No s'ha pogut definir la prioritat del procés"
 
-#: ../src/common/file.cpp:559
+#: ../src/common/ffile.cpp:355 ../src/common/file.cpp:586
 msgid "Failed to set temporary file permissions"
 msgstr "No s'ha pogut definir els permisos del fitxer temporal"
 
-#: ../src/gtk/textctrl.cpp:1072
-msgid "Failed to set text in the text control."
-msgstr "No s'ha pogut definir el text del control de text."
-
-#: ../src/unix/threadpsx.cpp:1298
+#: ../src/unix/threadpsx.cpp:1347
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr ""
 "No s'ha pogut definir el nivell de concurrència del fil d'execució a %lu"
 
-#: ../src/unix/threadpsx.cpp:1424
+#: ../src/unix/threadpsx.cpp:1473
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "No s'ha pogut definir la prioritat del fil d'execució %d."
 
-#: ../src/unix/utilsunx.cpp:783
+#: ../src/unix/utilsunx.cpp:785
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 "No s'ha pogut configurar la canonada no blocant, és possible que el programa "
 "es pengi."
 
-#: ../src/common/fs_mem.cpp:261
+#: ../src/msw/webview_ie.cpp:987
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:256
 #, c-format
 msgid "Failed to store image '%s' to memory VFS!"
 msgstr "No s'ha pogut emmagatzemar la imatge '%s' al VFS de la memòria!"
 
-#: ../src/dfb/evtloop.cpp:170
+#: ../src/dfb/evtloop.cpp:171
 msgid "Failed to switch DirectFB pipe to non-blocking mode"
 msgstr "No s'ha pogut canviar la canonada DirectFB al mode no blocant"
 
-#: ../src/unix/wakeuppipe.cpp:59
+#: ../src/unix/wakeuppipe.cpp:56
 msgid "Failed to switch wake up pipe to non-blocking mode"
 msgstr "No s'ha pogut canviar la canonada de despertament al mode no blocant"
 
-#: ../src/unix/threadpsx.cpp:1605
+#: ../src/unix/threadpsx.cpp:1654
 msgid "Failed to terminate a thread."
 msgstr "No s'ha pogut finalitzar el fil d'execució."
 
-#: ../src/msw/dde.cpp:741
+#: ../src/msw/dde.cpp:736
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "No s'ha pogut finalitzar el bucle d'avís amb el servidor DDE"
 
-#: ../src/msw/dialup.cpp:938
+#: ../src/msw/dialup.cpp:932
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "No s'ha pogut finalitzar la connexió de marcatge telefònic: %s"
 
-#: ../src/common/filename.cpp:2590
+#: ../src/common/filename.cpp:2673
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "No s'ha pogut fer touch al fitxer '%s'"
 
-#: ../src/unix/snglinst.cpp:334
+#: ../src/unix/dlunix.cpp:90
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "No s'ha pogut carregar la biblioteca compartida '%s'"
+
+#: ../src/unix/snglinst.cpp:331
 #, c-format
 msgid "Failed to unlock lock file '%s'"
 msgstr "No s'ha pogut desblocar el fitxer de blocatge '%s'"
 
-#: ../src/msw/dde.cpp:309
+#: ../src/msw/dde.cpp:304
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "No s'ha pogut desregistrar el servidor DDE '%s'"
@@ -3666,77 +3737,87 @@ msgstr "No s'ha pogut desregistrar el descriptor %d del descriptor epoll %d"
 msgid "Failed to update user configuration file."
 msgstr "No s'ha pogut actualitzar el fitxer de configuració de l'usuari."
 
-#: ../src/common/debugrpt.cpp:733
+#: ../src/common/debugrpt.cpp:743
 #, c-format
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "No s'ha pogut pujar l'informe de depuració (codi d'error %d)."
 
-#: ../src/unix/snglinst.cpp:168
+#: ../src/unix/snglinst.cpp:165
 #, c-format
 msgid "Failed to write to lock file '%s'"
 msgstr "No s'ha pogut escriure al fitxer de blocatge '%s'"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:209
+#: ../src/propgrid/propgrid.cpp:190
 msgid "False"
 msgstr "Fals"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:694
+#: ../src/propgrid/advprops.cpp:604
 msgid "Family"
 msgstr "Família"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/gtk/glcanvas.cpp:176 ../src/gtk/glcanvas.cpp:187
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Error fatal"
+
+#: ../src/common/stockitem.cpp:154
 msgid "File"
 msgstr "Fitxer"
 
-#: ../src/common/docview.cpp:669
+#: ../src/common/docview.cpp:664
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "No s'ha pogut obrir el fitxer \"%s\" per a llegir-lo."
 
-#: ../src/common/docview.cpp:646
+#: ../src/common/docview.cpp:641
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "No s'ha pogut obrir el fitxer \"%s\" per a escriure-hi."
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "El fitxer '%s' ja existex, esteu segur que el voleu sobreescriure?"
 
-#: ../src/common/filefn.cpp:1156
+#: ../src/common/filefn.cpp:1044
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "No s'ha pogut suprimir el fitxer '%s'"
 
-#: ../src/common/filefn.cpp:1139
+#: ../src/common/filefn.cpp:1028
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "No s'ha pogut canviar el nom del fitxer '%s' a '%s'"
 
-#: ../src/richtext/richtextctrl.cpp:3081 ../src/common/textcmn.cpp:953
+#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
 msgid "File couldn't be loaded."
 msgstr "No s'ha pogut carregar el fitxer."
 
-#: ../src/msw/filedlg.cpp:393
+#: ../src/msw/filedlg.cpp:414
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "El diàleg de fitxer ha fallat amb el codi d'error %0lx."
 
-#: ../src/common/docview.cpp:1789
+#: ../src/common/docview.cpp:1783
 msgid "File error"
 msgstr "Error de fitxer"
 
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/filectrlg.cpp:770
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/filectrlg.cpp:766
 msgid "File name exists already."
 msgstr "Aquest nom de fitxer ja existeix."
+
+#: ../src/osx/cocoa/filedlg.mm:264
+#, fuzzy
+msgid "File type:"
+msgstr "Teletip"
 
 #: ../src/motif/filedlg.cpp:220
 msgid "Files"
 msgstr "Fitxers"
 
-#: ../src/common/filefn.cpp:1591
+#: ../src/common/filefn.cpp:1479
 #, c-format
 msgid "Files (%s)"
 msgstr "Fitxers (%s)"
@@ -3745,15 +3826,29 @@ msgstr "Fitxers (%s)"
 msgid "Filter"
 msgstr "Filtre"
 
-#: ../src/common/stockitem.cpp:158 ../src/html/helpwnd.cpp:490
+#: ../src/html/helpwnd.cpp:488
 msgid "Find"
 msgstr "Cerca"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:259
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:258
+#, fuzzy
+msgid "Find in document"
+msgstr "Obre un document HTML"
+
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "Find..."
+msgstr "Cerca"
+
+#: ../src/common/stockitem.cpp:156
 msgid "First"
 msgstr "Primer"
 
-#: ../src/common/prntbase.cpp:1548
+#: ../src/common/prntbase.cpp:1573
 msgid "First page"
 msgstr "Primera pàgina"
 
@@ -3761,11 +3856,11 @@ msgstr "Primera pàgina"
 msgid "Fixed"
 msgstr "Fixa"
 
-#: ../src/html/helpwnd.cpp:1206
+#: ../src/html/helpwnd.cpp:1204
 msgid "Fixed font:"
 msgstr "Tipus de lletra de mida fixa:"
 
-#: ../src/html/helpwnd.cpp:1269
+#: ../src/html/helpwnd.cpp:1267
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "De mida fixa.<br> <b>negreta</b> <i>cursiva</i> "
 
@@ -3773,16 +3868,16 @@ msgstr "De mida fixa.<br> <b>negreta</b> <i>cursiva</i> "
 msgid "Floating"
 msgstr "Flotant"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "Floppy"
 msgstr "Disquet"
 
-#: ../src/common/paper.cpp:111
+#: ../src/common/paper.cpp:108
 msgid "Folio, 8 1/2 x 13 in"
 msgstr "Foli, 8 1/2 x 13 polz."
 
-#: ../src/richtext/richtextformatdlg.cpp:344 ../src/osx/carbon/fontdlg.cpp:287
-#: ../src/common/stockitem.cpp:194
+#: ../src/osx/carbon/fontdlg.cpp:284 ../src/common/stockitem.cpp:191
+#: ../src/richtext/richtextformatdlg.cpp:337
 msgid "Font"
 msgstr "Tipus de lletra"
 
@@ -3790,7 +3885,24 @@ msgstr "Tipus de lletra"
 msgid "Font &weight:"
 msgstr "&Pes de la lletra:"
 
-#: ../src/html/helpwnd.cpp:1207
+#: ../src/osx/fontutil.cpp:89
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
+"\"."
+msgstr ""
+
+#: ../src/msw/font.cpp:1126
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "No s'ha pogut carregar el fitxer."
+
+#: ../src/osx/fontutil.cpp:81
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "El fitxer %s no existeix"
+
+#: ../src/html/helpwnd.cpp:1205
 msgid "Font size:"
 msgstr "Mida de la lletra:"
 
@@ -3798,55 +3910,55 @@ msgstr "Mida de la lletra:"
 msgid "Font st&yle:"
 msgstr "&Estil de la lletra:"
 
-#: ../src/osx/carbon/fontdlg.cpp:329
+#: ../src/osx/carbon/fontdlg.cpp:326
 msgid "Font:"
 msgstr "Tipus de lletra:"
 
-#: ../src/dfb/fontmgr.cpp:198
+#: ../src/dfb/fontmgr.cpp:195
 #, c-format
 msgid "Fonts index file %s disappeared while loading fonts."
 msgstr ""
 "El fitxer d'índex de tipus de lletra %s ha desaparegut mentre es carregaven "
 "els tipus de lletra."
 
-#: ../src/unix/utilsunx.cpp:645
+#: ../src/unix/utilsunx.cpp:647
 msgid "Fork failed"
 msgstr "No s'ha pogut bifurcar"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "Forward"
 msgstr "Endavant"
 
-#: ../src/common/xtixml.cpp:235
+#: ../src/common/xtixml.cpp:231
 msgid "Forward hrefs are not supported"
 msgstr "Els href de reenviament no estan suportats"
 
-#: ../src/html/helpwnd.cpp:875
+#: ../src/html/helpwnd.cpp:873
 #, c-format
 msgid "Found %i matches"
 msgstr "S'han trobat %i coincidències"
 
-#: ../src/generic/prntdlgg.cpp:238
+#: ../src/generic/prntdlgg.cpp:231
 msgid "From:"
 msgstr "De:"
 
-#: ../src/propgrid/advprops.cpp:1604
+#: ../src/propgrid/advprops.cpp:1510
 msgid "Fuchsia"
 msgstr "Fúcsia"
 
-#: ../src/common/imaggif.cpp:138
+#: ../src/common/imaggif.cpp:135
 msgid "GIF: data stream seems to be truncated."
 msgstr "GIF: sembla que s'ha truncat el flux de dades."
 
-#: ../src/common/imaggif.cpp:128
+#: ../src/common/imaggif.cpp:125
 msgid "GIF: error in GIF image format."
 msgstr "GIF: error al format d'imatge GIF."
 
-#: ../src/common/imaggif.cpp:133
+#: ../src/common/imaggif.cpp:130
 msgid "GIF: not enough memory."
 msgstr "GIF: no hi ha prou memòria."
 
-#: ../src/gtk/window.cpp:4631
+#: ../src/gtk/window.cpp:5635
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -3854,23 +3966,23 @@ msgstr ""
 "El GTK+ instal·lat en aquest dispositiu és massa antic i no suporta la "
 "composició de pantalla, instal·leu el GTK+ 2.12 o posterior."
 
-#: ../src/univ/themes/gtk.cpp:525
+#: ../src/univ/themes/gtk.cpp:522
 msgid "GTK+ theme"
 msgstr "Tema GTK+"
 
-#: ../src/common/preferencescmn.cpp:40
+#: ../src/common/preferencescmn.cpp:37
 msgid "General"
 msgstr "General"
 
-#: ../src/common/prntbase.cpp:258
+#: ../src/common/prntbase.cpp:253
 msgid "Generic PostScript"
 msgstr "PostScript genèric"
 
-#: ../src/common/paper.cpp:135
+#: ../src/common/paper.cpp:132
 msgid "German Legal Fanfold, 8 1/2 x 13 in"
 msgstr "German Legal Fanfold, 8 1/2 x 13 polz."
 
-#: ../src/common/paper.cpp:134
+#: ../src/common/paper.cpp:131
 msgid "German Std Fanfold, 8 1/2 x 12 in"
 msgstr "German Std Fanfold, 8 1/2 x 12 polz."
 
@@ -3886,48 +3998,48 @@ msgstr "S'ha cridat GetPropertyCollection en un mètode d'accés genèric"
 msgid "GetPropertyCollection called w/o valid collection getter"
 msgstr "S'ha cridat GetPropertyCollection sense un getter de col·lecció vàlid"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:658
 msgid "Go back"
 msgstr "Vés endarrere"
 
-#: ../src/html/helpwnd.cpp:661
+#: ../src/html/helpwnd.cpp:659
 msgid "Go forward"
 msgstr "Vés endavant"
 
-#: ../src/html/helpwnd.cpp:663
+#: ../src/html/helpwnd.cpp:661
 msgid "Go one level up in document hierarchy"
 msgstr "Puja un nivell en la jerarquia del document"
 
-#: ../src/generic/filedlgg.cpp:208 ../src/generic/dirdlgg.cpp:116
+#: ../src/generic/filedlgg.cpp:205 ../src/generic/dirdlgg.cpp:113
 msgid "Go to home directory"
 msgstr "Vés al directori de l'usuari"
 
-#: ../src/generic/filedlgg.cpp:205
+#: ../src/generic/filedlgg.cpp:202
 msgid "Go to parent directory"
 msgstr "Vés al directori pare"
 
-#: ../src/generic/aboutdlgg.cpp:76
+#: ../src/generic/aboutdlgg.cpp:73
 msgid "Graphics art by "
 msgstr "Art gràfic per "
 
-#: ../src/propgrid/advprops.cpp:1599
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Gray"
 msgstr "Gris"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:883
+#: ../src/propgrid/advprops.cpp:784
 msgid "GrayText"
 msgstr "GrayText"
 
-#: ../src/common/fmapbase.cpp:154
+#: ../src/common/fmapbase.cpp:151
 msgid "Greek (ISO-8859-7)"
 msgstr "Grec (ISO-8859-7)"
 
-#: ../src/propgrid/advprops.cpp:1600
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Green"
 msgstr "Verd"
 
-#: ../src/generic/colrdlgg.cpp:342
+#: ../src/generic/colrdlgg.cpp:362
 msgid "Green:"
 msgstr "Verd:"
 
@@ -3935,107 +4047,107 @@ msgstr "Verd:"
 msgid "Groove"
 msgstr "Ranura"
 
-#: ../src/common/zstream.cpp:158 ../src/common/zstream.cpp:318
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
 msgid "Gzip not supported by this version of zlib"
 msgstr "Aquesta versió de zlib no suporta Gzip"
 
-#: ../src/html/helpwnd.cpp:1549
+#: ../src/html/helpwnd.cpp:1547
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "Projecte d'ajuda HTML (*.hhp)|*.hhp|"
 
-#: ../src/html/htmlwin.cpp:681
+#: ../src/html/htmlwin.cpp:691
 #, c-format
 msgid "HTML anchor %s does not exist."
 msgstr "L'àncora l'HTML %s no existeix."
 
-#: ../src/html/helpwnd.cpp:1547
+#: ../src/html/helpwnd.cpp:1545
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "Fitxers HTML (*.html;*.htm)|*.html;*.htm|"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1759
+#: ../src/propgrid/advprops.cpp:1660
 msgid "Hand"
 msgstr "Mà"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "Harddisk"
 msgstr "Disc dur"
 
-#: ../src/common/fmapbase.cpp:155
+#: ../src/common/fmapbase.cpp:152
 msgid "Hebrew (ISO-8859-8)"
 msgstr "Hebreu (ISO-8859-8)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:280 ../src/osx/button_osx.cpp:39
-#: ../src/common/stockitem.cpp:163 ../src/common/accelcmn.cpp:80
-#: ../src/html/helpdlg.cpp:66 ../src/html/helpfrm.cpp:111
+#: ../include/wx/msgdlg.h:282 ../src/osx/button_osx.cpp:39
+#: ../src/common/stockitem.cpp:160 ../src/common/accelcmn.cpp:77
+#: ../src/html/helpfrm.cpp:108 ../src/html/helpdlg.cpp:63
 msgid "Help"
 msgstr "Ajuda"
 
-#: ../src/html/helpwnd.cpp:1200
+#: ../src/html/helpwnd.cpp:1198
 msgid "Help Browser Options"
 msgstr "Opcions del navegador de l'ajuda"
 
-#: ../src/generic/helpext.cpp:454 ../src/generic/helpext.cpp:455
+#: ../src/generic/helpext.cpp:452 ../src/generic/helpext.cpp:453
 msgid "Help Index"
 msgstr "Índex de l'ajuda"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1529
 msgid "Help Printing"
 msgstr "Ajuda de la impressió"
 
-#: ../src/html/helpwnd.cpp:801
+#: ../src/html/helpwnd.cpp:799
 msgid "Help Topics"
 msgstr "Temes de l'ajuda"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1546
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Llibres d'ajuda (*.htb)|*.htb|Llibres d'ajuda (*.zip)|*.zip|"
 
-#: ../src/generic/helpext.cpp:267
+#: ../src/generic/helpext.cpp:265
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "No s'ha trobat el directori d'ajuda \"%s\"."
 
-#: ../src/generic/helpext.cpp:275
+#: ../src/generic/helpext.cpp:273
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "No s'ha trobat el fitxer d'ajuda \"%s\"."
 
-#: ../src/html/helpctrl.cpp:63
+#: ../src/html/helpctrl.cpp:59
 #, c-format
 msgid "Help: %s"
 msgstr "Ajuda: %s"
 
-#: ../src/osx/menu_osx.cpp:577
+#: ../src/osx/menu_osx.cpp:469
 #, c-format
 msgid "Hide %s"
 msgstr "Amaga %s"
 
-#: ../src/osx/menu_osx.cpp:579
+#: ../src/osx/menu_osx.cpp:471
 msgid "Hide Others"
 msgstr "Amaga els altres"
 
-#: ../src/generic/infobar.cpp:84
+#: ../src/generic/infobar.cpp:81
 msgid "Hide this notification message."
 msgstr "Amaga aquest missatge de notificació."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:884
+#: ../src/propgrid/advprops.cpp:785
 msgid "Highlight"
 msgstr "Highlight"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:885
+#: ../src/propgrid/advprops.cpp:786
 msgid "HighlightText"
 msgstr "HighlightText"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:164 ../src/common/accelcmn.cpp:65
+#: ../src/common/stockitem.cpp:161 ../src/common/accelcmn.cpp:62
 msgid "Home"
 msgstr "Inici"
 
-#: ../src/generic/dirctrlg.cpp:524
+#: ../src/generic/dirctrlg.cpp:490
 msgid "Home directory"
 msgstr "Directori de l'usuari"
 
@@ -4045,55 +4157,55 @@ msgid "How the object will float relative to the text."
 msgstr "Com flotarà l'objecte en relació al text."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1760
+#: ../src/propgrid/advprops.cpp:1661
 msgid "I-Beam"
 msgstr "Forma d'I"
 
-#: ../src/common/imagbmp.cpp:1196
+#: ../src/common/imagbmp.cpp:1208
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: S'ha produït un error en llegir la màscara DIB."
 
-#: ../src/common/imagbmp.cpp:1290 ../src/common/imagbmp.cpp:1390
-#: ../src/common/imagbmp.cpp:1405 ../src/common/imagbmp.cpp:1416
-#: ../src/common/imagbmp.cpp:1430 ../src/common/imagbmp.cpp:1478
-#: ../src/common/imagbmp.cpp:1493 ../src/common/imagbmp.cpp:1507
-#: ../src/common/imagbmp.cpp:1518
+#: ../src/common/imagbmp.cpp:1302 ../src/common/imagbmp.cpp:1402
+#: ../src/common/imagbmp.cpp:1417 ../src/common/imagbmp.cpp:1428
+#: ../src/common/imagbmp.cpp:1442 ../src/common/imagbmp.cpp:1490
+#: ../src/common/imagbmp.cpp:1505 ../src/common/imagbmp.cpp:1519
+#: ../src/common/imagbmp.cpp:1530
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: S'ha produït un error en escriure el fitxer d'imatge!"
 
-#: ../src/common/imagbmp.cpp:1255
+#: ../src/common/imagbmp.cpp:1267
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: Imatge massa alta per a una icona."
 
-#: ../src/common/imagbmp.cpp:1263
+#: ../src/common/imagbmp.cpp:1275
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: Imatge massa ampla per a una icona."
 
-#: ../src/common/imagbmp.cpp:1603
+#: ../src/common/imagbmp.cpp:1615
 msgid "ICO: Invalid icon index."
 msgstr "ICO: Índex d'icona invàlid."
 
-#: ../src/common/imagiff.cpp:758
+#: ../src/common/imagiff.cpp:755
 msgid "IFF: data stream seems to be truncated."
 msgstr "IFF: sembla que s'ha truncat el flux de dades."
 
-#: ../src/common/imagiff.cpp:742
+#: ../src/common/imagiff.cpp:739
 msgid "IFF: error in IFF image format."
 msgstr "IFF: error en el format d'imatge IFF."
 
-#: ../src/common/imagiff.cpp:745
+#: ../src/common/imagiff.cpp:742
 msgid "IFF: not enough memory."
 msgstr "IFF: no hi ha prou memòria."
 
-#: ../src/common/imagiff.cpp:748
+#: ../src/common/imagiff.cpp:745
 msgid "IFF: unknown error!!!"
 msgstr "IFF: s'ha produït un error desconegut!!!"
 
-#: ../src/common/fmapbase.cpp:197
+#: ../src/common/fmapbase.cpp:194
 msgid "ISO-2022-JP"
 msgstr "ISO-2022-JP"
 
-#: ../src/html/htmprint.cpp:282
+#: ../src/html/htmprint.cpp:294
 msgid ""
 "If possible, try changing the layout parameters to make the printout more "
 "narrow."
@@ -4101,7 +4213,7 @@ msgstr ""
 "Si és possible, proveu de canviar els paràmetres de disposició per a fer que "
 "la impressió sigui més estreta."
 
-#: ../src/generic/dbgrptg.cpp:358
+#: ../src/generic/dbgrptg.cpp:362
 msgid ""
 "If you have any additional information pertaining to this bug\n"
 "report, please enter it here and it will be joined to it:"
@@ -4116,54 +4228,58 @@ msgid ""
 "but be warned that it may hinder improving the program, so if\n"
 "at all possible please do continue with the report generation.\n"
 msgstr ""
-"Si voleu suprimir completament aquest informe de depuració, trieu el botó \""
-"Cancel·la\",\n"
+"Si voleu suprimir completament aquest informe de depuració, trieu el botó "
+"\"Cancel·la\",\n"
 "però tingueu en compte que això pot impedir que es millori el programa, de "
 "manera\n"
 "que si us és possible, continueu amb la generació de l'informe.\n"
 
-#: ../src/msw/registry.cpp:1405
+#: ../src/common/zipstrm.cpp:1043
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1393
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "S'ignora el valor \"%s\" de la clau \"%s\"."
 
-#: ../src/common/xtistrm.cpp:295
+#: ../src/common/xtistrm.cpp:292
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr ""
 "Classe d'objecte invàlida (no és un wxEvtHandler) com a origen de "
 "l'esdeveniment"
 
-#: ../src/common/xti.cpp:513
+#: ../src/common/xti.cpp:510
 msgid "Illegal Parameter Count for ConstructObject Method"
 msgstr "Nombre de paràmetres incorrecte per al mètode ConstructObject"
 
-#: ../src/common/xti.cpp:501
+#: ../src/common/xti.cpp:498
 msgid "Illegal Parameter Count for Create Method"
 msgstr "Nombre de paràmetres incorrecte per al mètode Create"
 
-#: ../src/generic/dirctrlg.cpp:570 ../src/generic/filectrlg.cpp:756
+#: ../src/generic/dirctrlg.cpp:536 ../src/generic/filectrlg.cpp:752
 msgid "Illegal directory name."
 msgstr "Nom de directori no permès."
 
-#: ../src/generic/filectrlg.cpp:1367
+#: ../src/generic/filectrlg.cpp:1356
 msgid "Illegal file specification."
 msgstr "Especificació de fitxer no permesa."
 
-#: ../src/common/image.cpp:2269
+#: ../src/common/image.cpp:2363
 msgid "Image and mask have different sizes."
 msgstr "La imatge i la màscara tenen mides diferents."
 
-#: ../src/common/image.cpp:2746
+#: ../src/common/image.cpp:2841
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "El fitxer d'imatge no és del tipus %d."
 
-#: ../src/common/image.cpp:2877
+#: ../src/common/image.cpp:2995
 #, c-format
 msgid "Image is not of type %s."
 msgstr "La imatge no és del tipus %s."
 
-#: ../src/msw/textctrl.cpp:488
+#: ../src/msw/textctrl.cpp:534
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -4171,100 +4287,101 @@ msgstr ""
 "No és possible crear un control d'edició rica, s'utilitzarà en el seu lloc "
 "un control de text simple. Reinstal·leu riched32.dll"
 
-#: ../src/unix/utilsunx.cpp:301
+#: ../src/unix/utilsunx.cpp:303
 msgid "Impossible to get child process input"
 msgstr "No és possible obtenir l'entrada del procés fill"
 
-#: ../src/common/filefn.cpp:1028
+#: ../src/common/filefn.cpp:917
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "No és possible obtenir els permisos del fitxer '%s'"
 
-#: ../src/common/filefn.cpp:1042
+#: ../src/common/filefn.cpp:931
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "No és possible sobreescriure el fitxer '%s'"
 
-#: ../src/common/filefn.cpp:1097
+#: ../src/common/filefn.cpp:986
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "No és possible definir els permisos del fitxer '%s'"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:886
+#: ../src/propgrid/advprops.cpp:787
 msgid "InactiveBorder"
 msgstr "InactiveBorder"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:887
+#: ../src/propgrid/advprops.cpp:788
 msgid "InactiveCaption"
 msgstr "InactiveCaption"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:888
+#: ../src/propgrid/advprops.cpp:789
 msgid "InactiveCaptionText"
 msgstr "InactiveCaptionText"
 
-#: ../src/common/gifdecod.cpp:792
+#: ../src/common/gifdecod.cpp:826
 #, c-format
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
-msgstr "Mida de fotograma de GIF incorrecta (%u, %d) per al fotograma número %u"
+msgstr ""
+"Mida de fotograma de GIF incorrecta (%u, %d) per al fotograma número %u"
 
-#: ../src/msw/ole/automtn.cpp:635
+#: ../src/msw/ole/automtn.cpp:626
 msgid "Incorrect number of arguments."
 msgstr "Nombre incorrecte d'arguments."
 
-#: ../src/common/stockitem.cpp:165
+#: ../src/common/stockitem.cpp:162
 msgid "Indent"
 msgstr "Sagnat"
 
-#: ../src/richtext/richtextformatdlg.cpp:349
+#: ../src/richtext/richtextformatdlg.cpp:342
 msgid "Indents && Spacing"
 msgstr "Indentació i espaiat"
 
-#: ../src/common/stockitem.cpp:166 ../src/html/helpwnd.cpp:515
+#: ../src/common/stockitem.cpp:163 ../src/html/helpwnd.cpp:513
 msgid "Index"
 msgstr "Índex"
 
-#: ../src/common/fmapbase.cpp:159
+#: ../src/common/fmapbase.cpp:156
 msgid "Indian (ISO-8859-12)"
 msgstr "Indi (ISO-8859-12)"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "Info"
 msgstr "Informació"
 
-#: ../src/common/init.cpp:287
+#: ../src/common/init.cpp:284
 msgid "Initialization failed in post init, aborting."
 msgstr "Ha fallat la inicialització a post init, s'està avortant."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:54
+#: ../src/common/accelcmn.cpp:51
 msgid "Ins"
 msgstr "Inser"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextsymboldlg.cpp:472 ../src/common/accelcmn.cpp:53
+#: ../src/common/accelcmn.cpp:50 ../src/richtext/richtextsymboldlg.cpp:469
 msgid "Insert"
 msgstr "Insereix"
 
-#: ../src/richtext/richtextbuffer.cpp:8067
+#: ../src/richtext/richtextbuffer.cpp:8063
 msgid "Insert Field"
 msgstr "Insereix un camp"
 
-#: ../src/richtext/richtextbuffer.cpp:7978
-#: ../src/richtext/richtextbuffer.cpp:8936
+#: ../src/richtext/richtextbuffer.cpp:7974
+#: ../src/richtext/richtextbuffer.cpp:8934
 msgid "Insert Image"
 msgstr "Insereix una imatge"
 
-#: ../src/richtext/richtextbuffer.cpp:8025
+#: ../src/richtext/richtextbuffer.cpp:8021
 msgid "Insert Object"
 msgstr "Insereix un objecte"
 
-#: ../src/richtext/richtextctrl.cpp:1286 ../src/richtext/richtextctrl.cpp:1494
-#: ../src/richtext/richtextbuffer.cpp:7822
-#: ../src/richtext/richtextbuffer.cpp:7852
-#: ../src/richtext/richtextbuffer.cpp:7894
+#: ../src/richtext/richtextbuffer.cpp:7818
+#: ../src/richtext/richtextbuffer.cpp:7848
+#: ../src/richtext/richtextbuffer.cpp:7890
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
 msgid "Insert Text"
 msgstr "Insereix text"
 
@@ -4277,16 +4394,11 @@ msgstr "Insereix un salt de pàgina abans del paràgraf."
 msgid "Inset"
 msgstr "Interior"
 
-#: ../src/gtk/app.cpp:425
-#, c-format
-msgid "Invalid GTK+ command line option, use \"%s --help\""
-msgstr "Optó de línia d'ordres de GTK+ invàlida, feu servir \"%s --help\""
-
-#: ../src/common/imagtiff.cpp:311
+#: ../src/common/imagtiff.cpp:308
 msgid "Invalid TIFF image index."
 msgstr "Índex d'imatge TIFF invàlid."
 
-#: ../src/common/appcmn.cpp:273
+#: ../src/common/appcmn.cpp:294
 #, c-format
 msgid "Invalid display mode specification '%s'."
 msgstr "Especificació de mode de pantalla invàlida '%s'."
@@ -4296,247 +4408,251 @@ msgstr "Especificació de mode de pantalla invàlida '%s'."
 msgid "Invalid geometry specification '%s'"
 msgstr "Especificació de geometria invàlida '%s'"
 
-#: ../src/unix/fswatcher_inotify.cpp:323
+#: ../src/unix/fswatcher_inotify.cpp:320
 #, c-format
 msgid "Invalid inotify event for \"%s\""
 msgstr "Esdeveniment inotify invàlid per a \"%s\""
 
-#: ../src/unix/snglinst.cpp:312
+#: ../src/unix/snglinst.cpp:309
 #, c-format
 msgid "Invalid lock file '%s'."
 msgstr "Fitxer de blocatge invàlid '%s'."
 
-#: ../src/common/translation.cpp:1125
+#: ../src/common/translation.cpp:1167
 msgid "Invalid message catalog."
 msgstr "Catàleg de missatges invàlid."
 
-#: ../src/common/xtistrm.cpp:405 ../src/common/xtistrm.cpp:420
+#: ../src/common/xtistrm.cpp:402 ../src/common/xtistrm.cpp:417
 msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
 msgstr "Identificador d'objecte passat a GetObjectClassInfo nul o invàlid"
 
-#: ../src/common/xtistrm.cpp:435
+#: ../src/common/xtistrm.cpp:432
 msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
 msgstr "Identificador d'objecte passat a HasObjectClassInfo nul o invàlid"
 
-#: ../src/common/regex.cpp:310
+#: ../src/common/regex.cpp:307
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Expressió regular invàlida '%s': %s"
 
-#: ../src/common/config.cpp:226
+#: ../src/common/config.cpp:222
 #, c-format
 msgid "Invalid value %ld for a boolean key \"%s\" in config file."
 msgstr ""
 "Valor invàlid %ld per a la clau booleana \"%s\" al fitxer de configuració."
 
-#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:351
-#: ../src/osx/carbon/fontdlg.cpp:361 ../src/common/stockitem.cpp:168
+#: ../src/osx/carbon/fontdlg.cpp:358 ../src/common/stockitem.cpp:165
+#: ../src/generic/fontdlgg.cpp:325 ../src/richtext/richtextfontpage.cpp:351
 msgid "Italic"
 msgstr "Cursiva"
 
-#: ../src/common/paper.cpp:130
+#: ../src/common/paper.cpp:127
 msgid "Italy Envelope, 110 x 230 mm"
 msgstr "Sobre italià, 110 x 230 mm"
 
-#: ../src/common/imagjpeg.cpp:270
+#: ../src/common/imagjpeg.cpp:257
 msgid "JPEG: Couldn't load - file is probably corrupted."
 msgstr "JPEG: No s'ha pogut carregar - probablement el fitxer és corrupte."
 
-#: ../src/common/imagjpeg.cpp:449
+#: ../src/common/imagjpeg.cpp:436
 msgid "JPEG: Couldn't save image."
 msgstr "JPEG: No s'ha pogut desar la imatge."
 
-#: ../src/common/paper.cpp:163
+#: ../src/common/paper.cpp:160
 msgid "Japanese Double Postcard 200 x 148 mm"
 msgstr "Postal japonesa doble, 200 x 148 mm"
 
-#: ../src/common/paper.cpp:167
+#: ../src/common/paper.cpp:164
 msgid "Japanese Envelope Chou #3"
 msgstr "Sobre japonès Chou núm. 3"
 
-#: ../src/common/paper.cpp:180
+#: ../src/common/paper.cpp:177
 msgid "Japanese Envelope Chou #3 Rotated"
 msgstr "Sobre japonès Chou núm. 3 girat"
 
-#: ../src/common/paper.cpp:168
+#: ../src/common/paper.cpp:165
 msgid "Japanese Envelope Chou #4"
 msgstr "Sobre japonès Chou núm. 4"
 
-#: ../src/common/paper.cpp:181
+#: ../src/common/paper.cpp:178
 msgid "Japanese Envelope Chou #4 Rotated"
 msgstr "Sobre japonès Chou núm. 4 girat"
 
-#: ../src/common/paper.cpp:165
+#: ../src/common/paper.cpp:162
 msgid "Japanese Envelope Kaku #2"
 msgstr "Sobre japonès Kaku núm. 2"
 
-#: ../src/common/paper.cpp:178
+#: ../src/common/paper.cpp:175
 msgid "Japanese Envelope Kaku #2 Rotated"
 msgstr "Sobre japonès Kaku núm. 2 girat"
 
-#: ../src/common/paper.cpp:166
+#: ../src/common/paper.cpp:163
 msgid "Japanese Envelope Kaku #3"
 msgstr "Sobre japonès Kaku núm. 3"
 
-#: ../src/common/paper.cpp:179
+#: ../src/common/paper.cpp:176
 msgid "Japanese Envelope Kaku #3 Rotated"
 msgstr "Sobre japonès Kaku núm. 3 girat"
 
-#: ../src/common/paper.cpp:185
+#: ../src/common/paper.cpp:182
 msgid "Japanese Envelope You #4"
 msgstr "Sobre japonès You núm. 4"
 
-#: ../src/common/paper.cpp:186
+#: ../src/common/paper.cpp:183
 msgid "Japanese Envelope You #4 Rotated"
 msgstr "Sobre japonès You núm. 4 girat"
 
-#: ../src/common/paper.cpp:138
+#: ../src/common/paper.cpp:135
 msgid "Japanese Postcard 100 x 148 mm"
 msgstr "Postal japonesa, 100 x 148 mm"
 
-#: ../src/common/paper.cpp:175
+#: ../src/common/paper.cpp:172
 msgid "Japanese Postcard Rotated 148 x 100 mm"
 msgstr "Postal japonesa girada, 148 x 100 mm"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "Jump to"
 msgstr "Vés a"
 
-#: ../src/common/stockitem.cpp:171
+#: ../src/common/stockitem.cpp:168
 msgid "Justified"
 msgstr "Justificat"
 
-#: ../src/richtext/richtextindentspage.cpp:155
-#: ../src/richtext/richtextindentspage.cpp:157
 #: ../src/richtext/richtextliststylepage.cpp:344
 #: ../src/richtext/richtextliststylepage.cpp:346
+#: ../src/richtext/richtextindentspage.cpp:155
+#: ../src/richtext/richtextindentspage.cpp:157
 msgid "Justify text left and right."
 msgstr "Justifica el text a l'esquerra i a la dreta."
 
-#: ../src/common/fmapbase.cpp:163
+#: ../src/common/fmapbase.cpp:160
 msgid "KOI8-R"
 msgstr "KOI8-R"
 
-#: ../src/common/fmapbase.cpp:164
+#: ../src/common/fmapbase.cpp:161
 msgid "KOI8-U"
 msgstr "KOI8-U"
 
-#: ../src/common/accelcmn.cpp:265 ../src/common/accelcmn.cpp:347
+#: ../src/common/accelcmn.cpp:279 ../src/common/accelcmn.cpp:364
 msgid "KP_"
 msgstr "BN_"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "KP_Add"
 msgstr "Suma (teclat numèric)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "KP_Begin"
 msgstr "Inici (teclat numèric)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "KP_Decimal"
 msgstr "Decimal (teclat numèric)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 msgid "KP_Delete"
 msgstr "Suprimeix (teclat numèric)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "KP_Divide"
 msgstr "Divisió (teclat numèric)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 msgid "KP_Down"
 msgstr "Avall (teclat numèric)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "KP_End"
 msgstr "Fi (teclat numèric)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "KP_Enter"
 msgstr "Retorn (teclat numèric)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "KP_Equal"
 msgstr "Igual (teclat numèric)"
 
+#: ../src/common/accelcmn.cpp:276 ../src/common/accelcmn.cpp:361
+msgid "KP_F"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 msgid "KP_Home"
 msgstr "Inici (teclat numèric)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 msgid "KP_Insert"
 msgstr "Insereix (teclat numèric)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "KP_Left"
 msgstr "Esquerra (teclat numèric)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "KP_Multiply"
 msgstr "Multiplicació (teclat numèric)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:99
+#: ../src/common/accelcmn.cpp:97
 msgid "KP_Next"
 msgstr "Següent (teclat numèric)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "KP_PageDown"
 msgstr "Av Pàg (teclat numèric)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "KP_PageUp"
 msgstr "Re Pàg (teclat numèric)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:98
+#: ../src/common/accelcmn.cpp:96
 msgid "KP_Prior"
 msgstr "Anterior (teclat numèric)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 msgid "KP_Right"
 msgstr "Dreta (teclat numèric)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "KP_Separator"
 msgstr "Separador (teclat numèric)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "KP_Space"
 msgstr "Espai (teclat numèric)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "KP_Subtract"
 msgstr "Resta (teclat numèric)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "KP_Tab"
 msgstr "Tab (teclat numèric)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "KP_Up"
 msgstr "Amunt (teclat numèric)"
 
@@ -4544,112 +4660,127 @@ msgstr "Amunt (teclat numèric)"
 msgid "L&ine spacing:"
 msgstr "&Interlineat:"
 
-#: ../src/generic/prntdlgg.cpp:613 ../src/generic/prntdlgg.cpp:868
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "s'ha produït un error de compressió"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "s'ha produït un error de descompressió"
+
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:861
 msgid "Landscape"
 msgstr "Apaïsat"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "Last"
 msgstr "Últim"
 
-#: ../src/common/prntbase.cpp:1572
+#: ../src/common/prntbase.cpp:1597
 msgid "Last page"
 msgstr "Última pàgina"
 
-#: ../src/common/log.cpp:305
+#: ../src/common/log.cpp:324
 #, c-format
 msgid "Last repeated message (\"%s\", %u time) wasn't output"
 msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
 msgstr[0] "No s'ha mostrat el darrer missatge repetit (\"%s\", %u vegada)"
 msgstr[1] "No s'ha mostrat el darrer missatge repetit (\"%s\", %u vegades)"
 
-#: ../src/common/paper.cpp:103
+#: ../src/common/paper.cpp:100
 msgid "Ledger, 17 x 11 in"
 msgstr "Ledger, 17 x 11 polz."
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6146
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:58 ../src/generic/datavgen.cpp:6951
+#: ../src/richtext/richtextsizepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:252
 #: ../src/richtext/richtextliststylepage.cpp:253
 #: ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
-#: ../src/richtext/richtextsizepage.cpp:249 ../src/common/accelcmn.cpp:61
 msgid "Left"
 msgstr "Esquerra"
 
-#: ../src/richtext/richtextindentspage.cpp:204
 #: ../src/richtext/richtextliststylepage.cpp:390
+#: ../src/richtext/richtextindentspage.cpp:204
 msgid "Left (&first line):"
 msgstr "Esquerra (&primera línia):"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1761
+#: ../src/propgrid/advprops.cpp:1662
 msgid "Left Button"
 msgstr "Botó esquerre"
 
-#: ../src/generic/prntdlgg.cpp:880
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Left margin (mm):"
 msgstr "Marge esquerre (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:141
-#: ../src/richtext/richtextindentspage.cpp:143
 #: ../src/richtext/richtextliststylepage.cpp:330
 #: ../src/richtext/richtextliststylepage.cpp:332
+#: ../src/richtext/richtextindentspage.cpp:141
+#: ../src/richtext/richtextindentspage.cpp:143
 msgid "Left-align text."
 msgstr "Alinea el text a l'esquerra."
 
-#: ../src/common/paper.cpp:144
+#: ../src/common/paper.cpp:141
 msgid "Legal Extra 9 1/2 x 15 in"
 msgstr "Legal extra, 9 1/2 x 15 polz."
 
-#: ../src/common/paper.cpp:96
+#: ../src/common/paper.cpp:93
 msgid "Legal, 8 1/2 x 14 in"
 msgstr "Legal, 8 1/2 x 14 polz."
 
-#: ../src/common/paper.cpp:143
+#: ../src/common/paper.cpp:140
 msgid "Letter Extra 9 1/2 x 12 in"
 msgstr "Carta extra, 9 1/2 x 12 polz."
 
-#: ../src/common/paper.cpp:149
+#: ../src/common/paper.cpp:146
 msgid "Letter Extra Transverse 9.275 x 12 in"
 msgstr "Carta extra transversal, 9,275 x 12 polz."
 
-#: ../src/common/paper.cpp:152
+#: ../src/common/paper.cpp:149
 msgid "Letter Plus 8 1/2 x 12.69 in"
 msgstr "Carta plus, 8 1/2 x 12,69 polz."
 
-#: ../src/common/paper.cpp:169
+#: ../src/common/paper.cpp:166
 msgid "Letter Rotated 11 x 8 1/2 in"
 msgstr "Carta girada, 11 x 8 1/2 polz."
 
-#: ../src/common/paper.cpp:101
+#: ../src/common/paper.cpp:98
 msgid "Letter Small, 8 1/2 x 11 in"
 msgstr "Carta petita, 8 1/2 x 11 polz."
 
-#: ../src/common/paper.cpp:147
+#: ../src/common/paper.cpp:144
 msgid "Letter Transverse 8 1/2 x 11 in"
 msgstr "Carta transversal, 8 1/2 x 11 polz."
 
-#: ../src/common/paper.cpp:95
+#: ../src/common/paper.cpp:92
 msgid "Letter, 8 1/2 x 11 in"
 msgstr "Carta, 8 1/2 x 11 polz."
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "License"
 msgstr "Llicència"
 
-#: ../src/generic/fontdlgg.cpp:332
+#: ../src/generic/fontdlgg.cpp:328
 msgid "Light"
 msgstr "Prima"
 
-#: ../src/propgrid/advprops.cpp:1608
+#: ../src/propgrid/advprops.cpp:1514
 msgid "Lime"
 msgstr "Llima"
 
-#: ../src/generic/helpext.cpp:294
+#: ../src/generic/helpext.cpp:292
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr "La línia %lu del fitxer de mapa \"%s\" té sintaxi invàlida, s'ha omès."
@@ -4658,15 +4789,15 @@ msgstr "La línia %lu del fitxer de mapa \"%s\" té sintaxi invàlida, s'ha omè
 msgid "Line spacing:"
 msgstr "Interlineat:"
 
-#: ../src/html/chm.cpp:838
+#: ../src/html/chm.cpp:829
 msgid "Link contained '//', converted to absolute link."
 msgstr "L'enllaç contenia '//', s'ha convertit a un enllaç absolut."
 
-#: ../src/richtext/richtextformatdlg.cpp:364
+#: ../src/richtext/richtextformatdlg.cpp:357
 msgid "List Style"
 msgstr "Estil de llista"
 
-#: ../src/richtext/richtextstyles.cpp:1064
+#: ../src/richtext/richtextstyles.cpp:1061
 msgid "List styles"
 msgstr "Estils de llista"
 
@@ -4680,26 +4811,26 @@ msgstr "Mostra una llista de mides de lletra en punts."
 msgid "Lists the available fonts."
 msgstr "Mostra la llista de tipus de lletra disponibles."
 
-#: ../src/common/fldlgcmn.cpp:340
+#: ../src/common/fldlgcmn.cpp:337
 #, c-format
 msgid "Load %s file"
 msgstr "Carrega el fitxer %s"
 
-#: ../src/html/htmlwin.cpp:597
+#: ../src/html/htmlwin.cpp:600
 msgid "Loading : "
 msgstr "S'està carregant: "
 
-#: ../src/unix/snglinst.cpp:246
+#: ../src/unix/snglinst.cpp:243
 #, c-format
 msgid "Lock file '%s' has incorrect owner."
 msgstr "El fitxer de blocatge '%s' té un propietari incorrecte."
 
-#: ../src/unix/snglinst.cpp:251
+#: ../src/unix/snglinst.cpp:248
 #, c-format
 msgid "Lock file '%s' has incorrect permissions."
 msgstr "El fitxer de blocatge '%s' té els permisos incorrectes."
 
-#: ../src/generic/logg.cpp:576
+#: ../src/generic/logg.cpp:573
 #, c-format
 msgid "Log saved to the file '%s'."
 msgstr "Registre desat al fitxer '%s'."
@@ -4714,11 +4845,11 @@ msgstr "Lletres en minúscules"
 msgid "Lower case roman numerals"
 msgstr "Nombres romans en minúscules"
 
-#: ../src/gtk/mdi.cpp:422 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk1/mdi.cpp:431 ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "Fill de l'MDI"
 
-#: ../src/msw/helpchm.cpp:56
+#: ../src/msw/helpchm.cpp:53
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -4726,189 +4857,189 @@ msgstr ""
 "Les funcions de l'ajuda MS HTML no estan disponibles perquè la biblioteca de "
 "l'ajuda MS HTML no està instal·lada en aquest dispositiu. Instal·leu-la."
 
-#: ../src/univ/themes/win32.cpp:3754
+#: ../src/univ/themes/win32.cpp:3751
 msgid "Ma&ximize"
 msgstr "Ma&ximitza"
 
-#: ../src/common/fmapbase.cpp:203
+#: ../src/common/fmapbase.cpp:200
 msgid "MacArabic"
 msgstr "MacArabic"
 
-#: ../src/common/fmapbase.cpp:222
+#: ../src/common/fmapbase.cpp:219
 msgid "MacArmenian"
 msgstr "MacArmenian"
 
-#: ../src/common/fmapbase.cpp:211
+#: ../src/common/fmapbase.cpp:208
 msgid "MacBengali"
 msgstr "MacBengali"
 
-#: ../src/common/fmapbase.cpp:217
+#: ../src/common/fmapbase.cpp:214
 msgid "MacBurmese"
 msgstr "MacBurmese"
 
-#: ../src/common/fmapbase.cpp:236
+#: ../src/common/fmapbase.cpp:233
 msgid "MacCeltic"
 msgstr "MacCeltic"
 
-#: ../src/common/fmapbase.cpp:227
+#: ../src/common/fmapbase.cpp:224
 msgid "MacCentralEurRoman"
 msgstr "MacCentralEurRoman"
 
-#: ../src/common/fmapbase.cpp:223
+#: ../src/common/fmapbase.cpp:220
 msgid "MacChineseSimp"
 msgstr "MacChineseSimp"
 
-#: ../src/common/fmapbase.cpp:201
+#: ../src/common/fmapbase.cpp:198
 msgid "MacChineseTrad"
 msgstr "MacChineseTrad"
 
-#: ../src/common/fmapbase.cpp:233
+#: ../src/common/fmapbase.cpp:230
 msgid "MacCroatian"
 msgstr "MacCroatian"
 
-#: ../src/common/fmapbase.cpp:206
+#: ../src/common/fmapbase.cpp:203
 msgid "MacCyrillic"
 msgstr "MacCyrillic"
 
-#: ../src/common/fmapbase.cpp:207
+#: ../src/common/fmapbase.cpp:204
 msgid "MacDevanagari"
 msgstr "MacDevanagari"
 
-#: ../src/common/fmapbase.cpp:231
+#: ../src/common/fmapbase.cpp:228
 msgid "MacDingbats"
 msgstr "MacDingbats"
 
-#: ../src/common/fmapbase.cpp:226
+#: ../src/common/fmapbase.cpp:223
 msgid "MacEthiopic"
 msgstr "MacEthiopic"
 
-#: ../src/common/fmapbase.cpp:229
+#: ../src/common/fmapbase.cpp:226
 msgid "MacExtArabic"
 msgstr "MacExtArabic"
 
-#: ../src/common/fmapbase.cpp:237
+#: ../src/common/fmapbase.cpp:234
 msgid "MacGaelic"
 msgstr "MacGaelic"
 
-#: ../src/common/fmapbase.cpp:221
+#: ../src/common/fmapbase.cpp:218
 msgid "MacGeorgian"
 msgstr "MacGeorgian"
 
-#: ../src/common/fmapbase.cpp:205
+#: ../src/common/fmapbase.cpp:202
 msgid "MacGreek"
 msgstr "MacGreek"
 
-#: ../src/common/fmapbase.cpp:209
+#: ../src/common/fmapbase.cpp:206
 msgid "MacGujarati"
 msgstr "MacGujarati"
 
-#: ../src/common/fmapbase.cpp:208
+#: ../src/common/fmapbase.cpp:205
 msgid "MacGurmukhi"
 msgstr "MacGurmukhi"
 
-#: ../src/common/fmapbase.cpp:204
+#: ../src/common/fmapbase.cpp:201
 msgid "MacHebrew"
 msgstr "MacHebrew"
 
-#: ../src/common/fmapbase.cpp:234
+#: ../src/common/fmapbase.cpp:231
 msgid "MacIcelandic"
 msgstr "MacIcelandic"
 
-#: ../src/common/fmapbase.cpp:200
+#: ../src/common/fmapbase.cpp:197
 msgid "MacJapanese"
 msgstr "MacJapanese"
 
-#: ../src/common/fmapbase.cpp:214
+#: ../src/common/fmapbase.cpp:211
 msgid "MacKannada"
 msgstr "MacKannada"
 
-#: ../src/common/fmapbase.cpp:238
+#: ../src/common/fmapbase.cpp:235
 msgid "MacKeyboardGlyphs"
 msgstr "MacKeyboardGlyphs"
 
-#: ../src/common/fmapbase.cpp:218
+#: ../src/common/fmapbase.cpp:215
 msgid "MacKhmer"
 msgstr "MacKhmer"
 
-#: ../src/common/fmapbase.cpp:202
+#: ../src/common/fmapbase.cpp:199
 msgid "MacKorean"
 msgstr "MacKorean"
 
-#: ../src/common/fmapbase.cpp:220
+#: ../src/common/fmapbase.cpp:217
 msgid "MacLaotian"
 msgstr "MacLaotian"
 
-#: ../src/common/fmapbase.cpp:215
+#: ../src/common/fmapbase.cpp:212
 msgid "MacMalayalam"
 msgstr "MacMalayalam"
 
-#: ../src/common/fmapbase.cpp:225
+#: ../src/common/fmapbase.cpp:222
 msgid "MacMongolian"
 msgstr "MacMongolian"
 
-#: ../src/common/fmapbase.cpp:210
+#: ../src/common/fmapbase.cpp:207
 msgid "MacOriya"
 msgstr "MacOriya"
 
-#: ../src/common/fmapbase.cpp:199
+#: ../src/common/fmapbase.cpp:196
 msgid "MacRoman"
 msgstr "MacRoman"
 
-#: ../src/common/fmapbase.cpp:235
+#: ../src/common/fmapbase.cpp:232
 msgid "MacRomanian"
 msgstr "MacRomanian"
 
-#: ../src/common/fmapbase.cpp:216
+#: ../src/common/fmapbase.cpp:213
 msgid "MacSinhalese"
 msgstr "MacSinhalese"
 
-#: ../src/common/fmapbase.cpp:230
+#: ../src/common/fmapbase.cpp:227
 msgid "MacSymbol"
 msgstr "MacSymbol"
 
-#: ../src/common/fmapbase.cpp:212
+#: ../src/common/fmapbase.cpp:209
 msgid "MacTamil"
 msgstr "MacTamil"
 
-#: ../src/common/fmapbase.cpp:213
+#: ../src/common/fmapbase.cpp:210
 msgid "MacTelugu"
 msgstr "MacTelugu"
 
-#: ../src/common/fmapbase.cpp:219
+#: ../src/common/fmapbase.cpp:216
 msgid "MacThai"
 msgstr "MacThai"
 
-#: ../src/common/fmapbase.cpp:224
+#: ../src/common/fmapbase.cpp:221
 msgid "MacTibetan"
 msgstr "MacTibetan"
 
-#: ../src/common/fmapbase.cpp:232
+#: ../src/common/fmapbase.cpp:229
 msgid "MacTurkish"
 msgstr "MacTurkish"
 
-#: ../src/common/fmapbase.cpp:228
+#: ../src/common/fmapbase.cpp:225
 msgid "MacVietnamese"
 msgstr "MacVietnamese"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1762
+#: ../src/propgrid/advprops.cpp:1663
 msgid "Magnifier"
 msgstr "Lupa"
 
-#: ../src/propgrid/advprops.cpp:2143
+#: ../src/propgrid/advprops.cpp:2050
 msgid "Make a selection:"
 msgstr "Crea una selecció:"
 
-#: ../src/richtext/richtextformatdlg.cpp:374
+#: ../src/richtext/richtextformatdlg.cpp:367
 #: ../src/richtext/richtextmarginspage.cpp:171
 msgid "Margins"
 msgstr "Marges"
 
-#: ../src/propgrid/advprops.cpp:1595
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Maroon"
 msgstr "Marró"
 
-#: ../src/generic/fdrepdlg.cpp:147
+#: ../src/generic/fdrepdlg.cpp:144
 msgid "Match case"
 msgstr "Distingeix entre majúscules i minúscules"
 
@@ -4920,40 +5051,40 @@ msgstr "Alçada màxima:"
 msgid "Max width:"
 msgstr "Amplada màxima:"
 
-#: ../src/unix/mediactrl.cpp:947
+#: ../src/unix/mediactrl.cpp:972
 #, c-format
 msgid "Media playback error: %s"
 msgstr "S'ha produït un error en la reproducció del mitjà: %s"
 
-#: ../src/common/fs_mem.cpp:175
+#: ../src/common/fs_mem.cpp:170
 #, c-format
 msgid "Memory VFS already contains file '%s'!"
 msgstr "El VFS en memòria ja conté el fitxer '%s'!"
 
 #. TRANSLATORS: Name of keyboard key
 #. TRANSLATORS: Keyword of system colour
-#: ../src/common/accelcmn.cpp:73 ../src/propgrid/advprops.cpp:889
+#: ../src/common/accelcmn.cpp:70 ../src/propgrid/advprops.cpp:790
 msgid "Menu"
 msgstr "Menú"
 
-#: ../src/common/msgout.cpp:124
+#: ../src/common/msgout.cpp:121
 msgid "Message"
 msgstr "Missatge"
 
-#: ../src/univ/themes/metal.cpp:168
+#: ../src/univ/themes/metal.cpp:165
 msgid "Metal theme"
 msgstr "Tema metàl·lic"
 
-#: ../src/msw/ole/automtn.cpp:652
+#: ../src/msw/ole/automtn.cpp:643
 msgid "Method or property not found."
 msgstr "No s'ha trobat el mètode o la propietat."
 
-#: ../src/univ/themes/win32.cpp:3752
+#: ../src/univ/themes/win32.cpp:3749
 msgid "Mi&nimize"
 msgstr "Mi&nimitza"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1763
+#: ../src/propgrid/advprops.cpp:1664
 msgid "Middle Button"
 msgstr "Botó del mig"
 
@@ -4965,37 +5096,42 @@ msgstr "Alçada mínima:"
 msgid "Min width:"
 msgstr "Amplada mínima:"
 
-#: ../src/msw/ole/automtn.cpp:668
+#: ../src/osx/cocoa/menu.mm:281
+#, fuzzy
+msgid "Minimize"
+msgstr "Mi&nimitza"
+
+#: ../src/msw/ole/automtn.cpp:659
 msgid "Missing a required parameter."
 msgstr "Manca un paràmetre necessari."
 
-#: ../src/generic/fontdlgg.cpp:324
+#: ../src/generic/fontdlgg.cpp:320
 msgid "Modern"
 msgstr "Modern"
 
-#: ../src/generic/filectrlg.cpp:427
+#: ../src/generic/filectrlg.cpp:423
 msgid "Modified"
 msgstr "Modificat"
 
-#: ../src/common/module.cpp:133
+#: ../src/common/module.cpp:130
 #, c-format
 msgid "Module \"%s\" initialization failed"
 msgstr "No s'ha pogut inicialitzar el mòdul \"%s\""
 
-#: ../src/common/paper.cpp:131
+#: ../src/common/paper.cpp:128
 msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
 msgstr "Sobre Monarch, 3 7/8 x 1/2 polz."
 
-#: ../src/msw/fswatcher.cpp:143
+#: ../src/msw/fswatcher.cpp:140
 msgid "Monitoring individual files for changes is not supported currently."
 msgstr ""
 "Actualment no està suportat supervisar els canvis de fitxers individuals."
 
-#: ../src/generic/editlbox.cpp:172
+#: ../src/generic/editlbox.cpp:160
 msgid "Move down"
 msgstr "Mou cap avall"
 
-#: ../src/generic/editlbox.cpp:171
+#: ../src/generic/editlbox.cpp:155
 msgid "Move up"
 msgstr "Mou cap amunt"
 
@@ -5009,97 +5145,103 @@ msgstr "Mou l'objecte al paràgraf següent."
 msgid "Moves the object to the previous paragraph."
 msgstr "Mou l'objecte al paràgraf anterior."
 
-#: ../src/richtext/richtextbuffer.cpp:9966
+#: ../src/richtext/richtextbuffer.cpp:9963
 msgid "Multiple Cell Properties"
 msgstr "Propietats de múltiples cel·les"
 
-#: ../src/generic/filectrlg.cpp:424
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:82
+#, fuzzy
+msgid "Multiply"
+msgstr "Multiplicació (teclat numèric)"
+
+#: ../src/generic/filectrlg.cpp:420
 msgid "Name"
 msgstr "Nom"
 
-#: ../src/propgrid/advprops.cpp:1596
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Navy"
 msgstr "Blau marí"
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "Network"
 msgstr "Xarxa"
 
-#: ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173
 msgid "New"
 msgstr "Nou"
 
-#: ../src/richtext/richtextstyledlg.cpp:243
+#: ../src/richtext/richtextstyledlg.cpp:239
 msgid "New &Box Style..."
 msgstr "&Estil de caixa nou..."
 
-#: ../src/richtext/richtextstyledlg.cpp:225
+#: ../src/richtext/richtextstyledlg.cpp:221
 msgid "New &Character Style..."
 msgstr "Estil de &caràcter nou..."
 
-#: ../src/richtext/richtextstyledlg.cpp:237
+#: ../src/richtext/richtextstyledlg.cpp:233
 msgid "New &List Style..."
 msgstr "Estil de &llista nou..."
 
-#: ../src/richtext/richtextstyledlg.cpp:231
+#: ../src/richtext/richtextstyledlg.cpp:227
 msgid "New &Paragraph Style..."
 msgstr "Estil de &paràgraf nou..."
 
-#: ../src/richtext/richtextstyledlg.cpp:606
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:654
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:820
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:893
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:934
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:602
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:650
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:816
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:889
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:930
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "New Style"
 msgstr "Estil nou"
 
-#: ../src/generic/editlbox.cpp:169
+#: ../src/generic/editlbox.cpp:139
 msgid "New item"
 msgstr "Element nou"
 
-#: ../src/generic/dirdlgg.cpp:297 ../src/generic/dirdlgg.cpp:307
-#: ../src/generic/filectrlg.cpp:618 ../src/generic/filectrlg.cpp:627
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+#: ../src/generic/dirdlgg.cpp:294 ../src/generic/dirdlgg.cpp:304
 msgid "NewName"
 msgstr "Nom nou"
 
-#: ../src/common/prntbase.cpp:1567 ../src/html/helpwnd.cpp:665
+#: ../src/common/prntbase.cpp:1592 ../src/html/helpwnd.cpp:663
 msgid "Next page"
 msgstr "Pàgina següent"
 
-#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:177
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:174
 #: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "No"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1764
+#: ../src/propgrid/advprops.cpp:1665
 msgid "No Entry"
 msgstr "Sense entrada"
 
-#: ../src/generic/animateg.cpp:150
+#: ../src/generic/animateg.cpp:133
 #, c-format
 msgid "No animation handler for type %ld defined."
 msgstr "No hi ha definit cap gestor d'animació per al tipus %ld."
 
-#: ../src/dfb/bitmap.cpp:642 ../src/dfb/bitmap.cpp:676
+#: ../src/dfb/bitmap.cpp:639 ../src/dfb/bitmap.cpp:673
 #, c-format
 msgid "No bitmap handler for type %d defined."
 msgstr "No hi ha definit cap gestor de mapa de bits per al tipus %d."
 
-#: ../src/common/utilscmn.cpp:1077
+#: ../src/common/utilscmn.cpp:1095
 msgid "No default application configured for HTML files."
 msgstr "No hi ha configurada cap aplicació per defecte per als fitxers HTML."
 
-#: ../src/generic/helpext.cpp:445
+#: ../src/generic/helpext.cpp:443
 msgid "No entries found."
 msgstr "No s'ha trobat cap entrada."
 
-#: ../src/common/fontmap.cpp:421
+#: ../src/common/fontmap.cpp:418
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found,\n"
@@ -5112,7 +5254,7 @@ msgstr ""
 "però hi ha una codificació alternativa, '%s'.\n"
 "Voleu fer servir aquesta codificació (si no, n'haureu de triar una altra)?"
 
-#: ../src/common/fontmap.cpp:426
+#: ../src/common/fontmap.cpp:423
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found.\n"
@@ -5125,201 +5267,201 @@ msgstr ""
 "codificació\n"
 "(si no, el text amb aquesta codificació no es mostrarà correctament)?"
 
-#: ../src/generic/animateg.cpp:142
+#: ../src/generic/animateg.cpp:125
 msgid "No handler found for animation type."
 msgstr "No s'ha trobat cap gestor per al tipus d'animació."
 
-#: ../src/common/image.cpp:2728
+#: ../src/common/image.cpp:2823
 msgid "No handler found for image type."
 msgstr "No s'ha trobat cap gestor per al tipus d'imatge."
 
-#: ../src/common/image.cpp:2736 ../src/common/image.cpp:2848
-#: ../src/common/image.cpp:2901
+#: ../src/common/image.cpp:2831 ../src/common/image.cpp:2954
+#: ../src/common/image.cpp:3020
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "No hi ha definit cap gestor d'imatge per al tipus %d."
 
-#: ../src/common/image.cpp:2871 ../src/common/image.cpp:2915
+#: ../src/common/image.cpp:2986 ../src/common/image.cpp:3034
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "No hi ha definit cap gestor d'imatge per al tipus %s."
 
-#: ../src/html/helpwnd.cpp:858
+#: ../src/html/helpwnd.cpp:856
 msgid "No matching page found yet"
 msgstr "Encara no s'ha trobat cap pàgina que hi coincideixi"
 
-#: ../src/unix/sound.cpp:81
+#: ../src/unix/sound.cpp:78
 msgid "No sound"
 msgstr "No hi ha so"
 
-#: ../src/common/image.cpp:2277 ../src/common/image.cpp:2318
+#: ../src/common/image.cpp:2371 ../src/common/image.cpp:2412
 msgid "No unused colour in image being masked."
 msgstr "No hi ha cap color sense utilitzar a la imatge que voleu emmascarar."
 
-#: ../src/common/image.cpp:3374
-msgid "No unused colour in image."
-msgstr "No hi ha cap color sense utilitzar a la imatge."
-
-#: ../src/generic/helpext.cpp:302
+#: ../src/generic/helpext.cpp:300
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "No s'ha trobat cap assignació vàlida al fitxer \"%s\"."
 
-#: ../src/richtext/richtextborderspage.cpp:610
 #: ../src/richtext/richtextsizepage.cpp:248
 #: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:610
 msgid "None"
 msgstr "Cap"
 
-#: ../src/common/fmapbase.cpp:157
+#: ../src/common/fmapbase.cpp:154
 msgid "Nordic (ISO-8859-10)"
 msgstr "Nòrdic (ISO-8859-10)"
 
-#: ../src/generic/fontdlgg.cpp:328 ../src/generic/fontdlgg.cpp:331
+#: ../src/generic/fontdlgg.cpp:324 ../src/generic/fontdlgg.cpp:327
 msgid "Normal"
 msgstr "Normal"
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1261
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Text normal<br>i <u>subratllat</u>. "
 
-#: ../src/html/helpwnd.cpp:1205
+#: ../src/html/helpwnd.cpp:1203
 msgid "Normal font:"
 msgstr "Tipus de lletra normal:"
 
-#: ../src/propgrid/props.cpp:1128
+#: ../src/propgrid/props.cpp:1115
 #, c-format
 msgid "Not %s"
 msgstr "No %s"
 
-#: ../include/wx/filename.h:573 ../include/wx/filename.h:578
-msgid "Not available"
-msgstr "No disponible"
+#: ../src/common/secretstore.cpp:168
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/webrequest.cpp:605
+msgid "Not enough free disk space for download."
+msgstr ""
 
 #: ../src/richtext/richtextfontpage.cpp:358
 msgid "Not underlined"
 msgstr "No subratllat"
 
-#: ../src/common/paper.cpp:115
+#: ../src/common/paper.cpp:112
 msgid "Note, 8 1/2 x 11 in"
 msgstr "Nota, 8 1/2 x 11 polz."
 
-#: ../src/generic/notifmsgg.cpp:132
+#: ../src/generic/notifmsgg.cpp:129
 msgid "Notice"
 msgstr "Avís"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "Num *"
 msgstr "* (teclat numèric)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "Num +"
 msgstr "+ (teclat numèric)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "Num ,"
 msgstr ", (teclat numèric)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "Num -"
 msgstr "- (teclat numèric)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "Num ."
 msgstr ". (teclat numèric)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "Num /"
 msgstr "/ (teclat numèric)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "Num ="
 msgstr "= (teclat numèric)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "Num Begin"
 msgstr "Inici (teclat numèric)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 msgid "Num Delete"
 msgstr "Suprimeix (teclat numèric)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 msgid "Num Down"
 msgstr "Avall (teclat numèric)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "Num End"
 msgstr "Fi (teclat numèric)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "Num Enter"
 msgstr "Retorn (teclat numèric)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 msgid "Num Home"
 msgstr "Inici (teclat numèric)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 msgid "Num Insert"
 msgstr "Insereix (teclat numèric)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num Lock"
 msgstr "Bloq Núm"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "Num Page Down"
 msgstr "Av Pàg (teclat numèric)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "Num Page Up"
 msgstr "Re Pàg (teclat numèric)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 msgid "Num Right"
 msgstr "Dreta (teclat numèric)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "Num Space"
 msgstr "Espai (teclat numèric)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "Num Tab"
 msgstr "Tab (teclat numèric)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "Num Up"
 msgstr "Amunt (teclat numèric)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "Num left"
 msgstr "Esquerra (teclat numèric)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num_lock"
 msgstr "Bloq Núm"
 
@@ -5328,13 +5470,13 @@ msgstr "Bloq Núm"
 msgid "Numbered outline"
 msgstr "Esquema numerat"
 
-#: ../include/wx/msgdlg.h:278 ../src/richtext/richtextstyledlg.cpp:297
-#: ../src/common/stockitem.cpp:178 ../src/msw/msgdlg.cpp:454
-#: ../src/msw/msgdlg.cpp:747 ../src/gtk1/fontdlg.cpp:138
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:175
+#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/msgdlg.cpp:741 ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "D'acord"
 
-#: ../src/msw/ole/automtn.cpp:692
+#: ../src/msw/ole/automtn.cpp:683
 #, c-format
 msgid "OLE Automation error in %s: %s"
 msgstr "S'ha produït un error d'automatització OLE a %s: %s"
@@ -5343,15 +5485,15 @@ msgstr "S'ha produït un error d'automatització OLE a %s: %s"
 msgid "Object Properties"
 msgstr "Propietats de l'objecte"
 
-#: ../src/msw/ole/automtn.cpp:660
+#: ../src/msw/ole/automtn.cpp:651
 msgid "Object implementation does not support named arguments."
 msgstr "La implementació de l'objecte no suporta arguments amb nom."
 
-#: ../src/common/xtixml.cpp:264
+#: ../src/common/xtixml.cpp:260
 msgid "Objects must have an id attribute"
 msgstr "Els objectes han de tenir un atribut d'identificació"
 
-#: ../src/propgrid/advprops.cpp:1601
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Olive"
 msgstr "Oliva"
 
@@ -5359,64 +5501,69 @@ msgstr "Oliva"
 msgid "Opaci&ty:"
 msgstr "Opaci&tat:"
 
-#: ../src/generic/colrdlgg.cpp:354
+#: ../src/generic/colrdlgg.cpp:374
 msgid "Opacity:"
 msgstr "Opacitat:"
 
-#: ../src/common/docview.cpp:1773 ../src/common/docview.cpp:1815
+#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
 msgid "Open File"
 msgstr "Obre un fitxer"
 
-#: ../src/html/helpwnd.cpp:671 ../src/html/helpwnd.cpp:1554
+#: ../src/html/helpwnd.cpp:669 ../src/html/helpwnd.cpp:1552
 msgid "Open HTML document"
 msgstr "Obre un document HTML"
 
-#: ../src/generic/dbgrptg.cpp:163
+#: ../src/common/stockitem.cpp:265
+#, fuzzy
+msgid "Open an existing document"
+msgstr "Obre un document HTML"
+
+#: ../src/generic/dbgrptg.cpp:160
 #, c-format
 msgid "Open file \"%s\""
 msgstr "Obre el fitxer \"%s\""
 
-#: ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176
 msgid "Open..."
 msgstr "Obre..."
 
-#: ../src/unix/glx11.cpp:506 ../src/msw/glcanvas.cpp:592
+#: ../src/msw/glcanvas.cpp:607 ../src/unix/glx11.cpp:513
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr "El controlador d'OpenGL no suporta OpenGL 3.0 o superior."
 
-#: ../src/generic/dirctrlg.cpp:599 ../src/generic/dirdlgg.cpp:323
-#: ../src/generic/filectrlg.cpp:642 ../src/generic/filectrlg.cpp:786
+#: ../src/generic/dirctrlg.cpp:565 ../src/generic/filectrlg.cpp:638
+#: ../src/generic/filectrlg.cpp:782 ../src/generic/dirdlgg.cpp:320
 msgid "Operation not permitted."
 msgstr "L'operació no és permesa."
 
-#: ../src/common/cmdline.cpp:900
+#: ../src/common/cmdline.cpp:896
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "L'opció '%s' no es pot negar"
 
-#: ../src/common/cmdline.cpp:1064
+#: ../src/common/cmdline.cpp:1060
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "L'opció '%s' requereix un valor."
 
-#: ../src/common/cmdline.cpp:1147
+#: ../src/common/cmdline.cpp:1143
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Opció '%s': '%s' no es pot convertir a data."
 
-#: ../src/generic/prntdlgg.cpp:618
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Opcions"
 
-#: ../src/propgrid/advprops.cpp:1606
+#: ../src/propgrid/advprops.cpp:1512
 msgid "Orange"
 msgstr "Carabassa"
 
-#: ../src/generic/prntdlgg.cpp:615 ../src/generic/prntdlgg.cpp:869
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:862
 msgid "Orientation"
 msgstr "Orientació"
 
-#: ../src/common/windowid.cpp:242
+#: ../src/common/windowid.cpp:237
 msgid "Out of window IDs.  Recommend shutting down application."
 msgstr ""
 "S'han esgotat els identificadors de finestra. És recomanable tancar "
@@ -5431,148 +5578,148 @@ msgstr "Contorn"
 msgid "Outset"
 msgstr "Exterior"
 
-#: ../src/msw/ole/automtn.cpp:656
+#: ../src/msw/ole/automtn.cpp:647
 msgid "Overflow while coercing argument values."
 msgstr "S'ha produït un desbordament en forçar els valors dels arguments."
 
-#: ../src/common/imagpcx.cpp:457 ../src/common/imagpcx.cpp:480
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:479
 msgid "PCX: couldn't allocate memory"
 msgstr "PCX: no s'ha pogut assignar la memòria"
 
-#: ../src/common/imagpcx.cpp:456
+#: ../src/common/imagpcx.cpp:455
 msgid "PCX: image format unsupported"
 msgstr "PCX: format d'imatge no suportat"
 
-#: ../src/common/imagpcx.cpp:479
+#: ../src/common/imagpcx.cpp:478
 msgid "PCX: invalid image"
 msgstr "PCX: imatge invàlida"
 
-#: ../src/common/imagpcx.cpp:442
+#: ../src/common/imagpcx.cpp:441
 msgid "PCX: this is not a PCX file."
 msgstr "PCX: això no és un fitxer PCX."
 
-#: ../src/common/imagpcx.cpp:459 ../src/common/imagpcx.cpp:481
+#: ../src/common/imagpcx.cpp:458 ../src/common/imagpcx.cpp:480
 msgid "PCX: unknown error !!!"
 msgstr "PCX: s'ha produït un error desconegut!!!"
 
-#: ../src/common/imagpcx.cpp:458
+#: ../src/common/imagpcx.cpp:457
 msgid "PCX: version number too low"
 msgstr "PCX: número de versió massa baix"
 
-#: ../src/common/imagpnm.cpp:91
+#: ../src/common/imagpnm.cpp:89
 msgid "PNM: Couldn't allocate memory."
 msgstr "PNM: No s'ha pogut assignar la memòria."
 
-#: ../src/common/imagpnm.cpp:73
+#: ../src/common/imagpnm.cpp:71
 msgid "PNM: File format is not recognized."
 msgstr "PNM: Format de fitxer no reconegut."
 
-#: ../src/common/imagpnm.cpp:112 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
 #: ../src/common/imagpnm.cpp:156
 msgid "PNM: File seems truncated."
 msgstr "PNM: El fitxer sembla truncat."
 
-#: ../src/common/paper.cpp:187
+#: ../src/common/paper.cpp:184
 msgid "PRC 16K 146 x 215 mm"
 msgstr "PRC 16K, 146 x 215 mm"
 
-#: ../src/common/paper.cpp:200
+#: ../src/common/paper.cpp:197
 msgid "PRC 16K Rotated"
 msgstr "PRC 16K girat"
 
-#: ../src/common/paper.cpp:188
+#: ../src/common/paper.cpp:185
 msgid "PRC 32K 97 x 151 mm"
 msgstr "PRC 32K, 97 x 151 mm"
 
-#: ../src/common/paper.cpp:201
+#: ../src/common/paper.cpp:198
 msgid "PRC 32K Rotated"
 msgstr "PRC 32K girat"
 
-#: ../src/common/paper.cpp:189
+#: ../src/common/paper.cpp:186
 msgid "PRC 32K(Big) 97 x 151 mm"
 msgstr "PRC 32K (Gros), 97 x 151 mm"
 
-#: ../src/common/paper.cpp:202
+#: ../src/common/paper.cpp:199
 msgid "PRC 32K(Big) Rotated"
 msgstr "PRC 32K (Gros) girat"
 
-#: ../src/common/paper.cpp:190
+#: ../src/common/paper.cpp:187
 msgid "PRC Envelope #1 102 x 165 mm"
 msgstr "Sobre PRC núm. 1, 114 x 162 mm"
 
-#: ../src/common/paper.cpp:203
+#: ../src/common/paper.cpp:200
 msgid "PRC Envelope #1 Rotated 165 x 102 mm"
 msgstr "Sobre PRC núm. 1 girat, 165 x 102 mm"
 
-#: ../src/common/paper.cpp:199
+#: ../src/common/paper.cpp:196
 msgid "PRC Envelope #10 324 x 458 mm"
 msgstr "Sobre PRC núm. 10, 324 x 458 mm"
 
-#: ../src/common/paper.cpp:212
+#: ../src/common/paper.cpp:209
 msgid "PRC Envelope #10 Rotated 458 x 324 mm"
 msgstr "Sobre PRC núm. 10 girat, 458 x 324 mm"
 
-#: ../src/common/paper.cpp:191
+#: ../src/common/paper.cpp:188
 msgid "PRC Envelope #2 102 x 176 mm"
 msgstr "Sobre PRC núm. 2, 102 x 176 mm"
 
-#: ../src/common/paper.cpp:204
+#: ../src/common/paper.cpp:201
 msgid "PRC Envelope #2 Rotated 176 x 102 mm"
 msgstr "Sobre PRC núm. 2 girat, 176 x 102 mm"
 
-#: ../src/common/paper.cpp:192
+#: ../src/common/paper.cpp:189
 msgid "PRC Envelope #3 125 x 176 mm"
 msgstr "Sobre PRC núm. 3, 125 x 176 mm"
 
-#: ../src/common/paper.cpp:205
+#: ../src/common/paper.cpp:202
 msgid "PRC Envelope #3 Rotated 176 x 125 mm"
 msgstr "Sobre PRC núm. 3 girat, 176 x 125 mm"
 
-#: ../src/common/paper.cpp:193
+#: ../src/common/paper.cpp:190
 msgid "PRC Envelope #4 110 x 208 mm"
 msgstr "Sobre PRC núm. 4, 110 x 208 mm"
 
-#: ../src/common/paper.cpp:206
+#: ../src/common/paper.cpp:203
 msgid "PRC Envelope #4 Rotated 208 x 110 mm"
 msgstr "Sobre PRC núm. 4 girat, 208 x 110 mm"
 
-#: ../src/common/paper.cpp:194
+#: ../src/common/paper.cpp:191
 msgid "PRC Envelope #5 110 x 220 mm"
 msgstr "Sobre PRC núm. 5, 110 x 220 mm"
 
-#: ../src/common/paper.cpp:207
+#: ../src/common/paper.cpp:204
 msgid "PRC Envelope #5 Rotated 220 x 110 mm"
 msgstr "Sobre PRC núm. 5 girat, 220 x 110 mm"
 
-#: ../src/common/paper.cpp:195
+#: ../src/common/paper.cpp:192
 msgid "PRC Envelope #6 120 x 230 mm"
 msgstr "Sobre PRC núm. 6, 120 x 230 mm"
 
-#: ../src/common/paper.cpp:208
+#: ../src/common/paper.cpp:205
 msgid "PRC Envelope #6 Rotated 230 x 120 mm"
 msgstr "Sobre PRC núm. 6 girat, 230 x 120 mm"
 
-#: ../src/common/paper.cpp:196
+#: ../src/common/paper.cpp:193
 msgid "PRC Envelope #7 160 x 230 mm"
 msgstr "Sobre PRC núm. 7, 160 x 230 mm"
 
-#: ../src/common/paper.cpp:209
+#: ../src/common/paper.cpp:206
 msgid "PRC Envelope #7 Rotated 230 x 160 mm"
 msgstr "Sobre PRC núm. 7 girat, 230 x 160 mm"
 
-#: ../src/common/paper.cpp:197
+#: ../src/common/paper.cpp:194
 msgid "PRC Envelope #8 120 x 309 mm"
 msgstr "Sobre PRC núm. 8, 120 x 309 mm"
 
-#: ../src/common/paper.cpp:210
+#: ../src/common/paper.cpp:207
 msgid "PRC Envelope #8 Rotated 309 x 120 mm"
 msgstr "Sobre PRC núm. 8 girat, 309 x 120 mm"
 
-#: ../src/common/paper.cpp:198
+#: ../src/common/paper.cpp:195
 msgid "PRC Envelope #9 229 x 324 mm"
 msgstr "Sobre PRC núm. 9, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:211
+#: ../src/common/paper.cpp:208
 msgid "PRC Envelope #9 Rotated 324 x 229 mm"
 msgstr "Sobre PRC núm. 9 girat, 324 x 229 mm"
 
@@ -5580,87 +5727,91 @@ msgstr "Sobre PRC núm. 9 girat, 324 x 229 mm"
 msgid "Padding"
 msgstr "Separació"
 
-#: ../src/common/prntbase.cpp:2074
+#: ../src/common/prntbase.cpp:2096
 #, c-format
 msgid "Page %d"
 msgstr "Pàgina %d"
 
-#: ../src/common/prntbase.cpp:2072
+#: ../src/common/prntbase.cpp:2094
 #, c-format
 msgid "Page %d of %d"
 msgstr "Pàgina %d de %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 msgid "Page Down"
 msgstr "Av Pàg"
 
-#: ../src/gtk/print.cpp:826
+#: ../src/gtk/print.cpp:829
 msgid "Page Setup"
 msgstr "Configuració de la pàgina"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 msgid "Page Up"
 msgstr "Re Pàg"
 
-#: ../src/generic/prntdlgg.cpp:828 ../src/common/prntbase.cpp:484
+#: ../src/common/prntbase.cpp:479 ../src/generic/prntdlgg.cpp:821
 msgid "Page setup"
 msgstr "Configuració de la pàgina"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 msgid "PageDown"
 msgstr "Av Pàg"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 msgid "PageUp"
 msgstr "Re Pàg"
 
-#: ../src/generic/prntdlgg.cpp:216
+#: ../src/generic/prntdlgg.cpp:209
 msgid "Pages"
 msgstr "Pàgines"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1765
+#: ../src/propgrid/advprops.cpp:1666
 msgid "Paint Brush"
 msgstr "Pinzell"
 
-#: ../src/generic/prntdlgg.cpp:602 ../src/generic/prntdlgg.cpp:801
-#: ../src/generic/prntdlgg.cpp:842 ../src/generic/prntdlgg.cpp:855
-#: ../src/generic/prntdlgg.cpp:1052 ../src/generic/prntdlgg.cpp:1057
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:794
+#: ../src/generic/prntdlgg.cpp:835 ../src/generic/prntdlgg.cpp:848
+#: ../src/generic/prntdlgg.cpp:1045 ../src/generic/prntdlgg.cpp:1050
 msgid "Paper size"
 msgstr "Mida del paper"
 
-#: ../src/richtext/richtextstyles.cpp:1062
+#: ../src/richtext/richtextstyles.cpp:1059
 msgid "Paragraph styles"
 msgstr "Estils de paràgraf"
 
-#: ../src/common/xtistrm.cpp:465
+#: ../src/common/xtistrm.cpp:462
 msgid "Passing a already registered object to SetObject"
 msgstr "S'ha passat un objecte ja registrat a SetObject"
 
-#: ../src/common/xtistrm.cpp:476
+#: ../src/common/xtistrm.cpp:473
 msgid "Passing an unknown object to GetObject"
 msgstr "S'ha passat un objecte desconegut a GetObject"
 
-#: ../src/richtext/richtextctrl.cpp:3513 ../src/common/stockitem.cpp:180
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:177 ../src/richtext/richtextctrl.cpp:3514
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Enganxa"
 
-#: ../src/common/stockitem.cpp:262
+#: ../src/common/stockitem.cpp:260
 msgid "Paste selection"
 msgstr "Enganxa la selecció"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:74
+#: ../src/common/accelcmn.cpp:71
 msgid "Pause"
 msgstr "Pausa"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1766
+#: ../src/propgrid/advprops.cpp:1667
 msgid "Pencil"
 msgstr "Llapis"
 
@@ -5669,21 +5820,21 @@ msgstr "Llapis"
 msgid "Peri&od"
 msgstr "Perí&ode"
 
-#: ../src/generic/filectrlg.cpp:430
+#: ../src/generic/filectrlg.cpp:426
 msgid "Permissions"
 msgstr "Permisos"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:60
+#: ../src/common/accelcmn.cpp:57
 msgid "PgDn"
 msgstr "AvPàg"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:59
+#: ../src/common/accelcmn.cpp:56
 msgid "PgUp"
 msgstr "RePàg"
 
-#: ../src/richtext/richtextbuffer.cpp:12868
+#: ../src/richtext/richtextbuffer.cpp:12863
 msgid "Picture Properties"
 msgstr "Propietats de la imatge"
 
@@ -5695,42 +5846,42 @@ msgstr "No s'ha pogut crear la canonada"
 msgid "Please choose a valid font."
 msgstr "Trieu un tipus de lletra vàlid."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
 msgid "Please choose an existing file."
 msgstr "Trieu un fitxer existent."
 
-#: ../src/html/helpwnd.cpp:800
+#: ../src/html/helpwnd.cpp:798
 msgid "Please choose the page to display:"
 msgstr "Trieu la pàgina que vulgueu mostrar:"
 
-#: ../src/msw/dialup.cpp:764
+#: ../src/msw/dialup.cpp:758
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Trieu a quin proveïdor d'Internet us voleu connectar"
 
-#: ../src/common/headerctrlcmn.cpp:59
+#: ../src/common/headerctrlcmn.cpp:57
 msgid "Please select the columns to show and define their order:"
 msgstr "Seleccioneu les columnes que es mostraran i definiu-ne l'ordre:"
 
-#: ../src/common/prntbase.cpp:538
+#: ../src/common/prntbase.cpp:533
 msgid "Please wait while printing..."
 msgstr "Espereu mentre s'imprimeix..."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1767
+#: ../src/propgrid/advprops.cpp:1668
 msgid "Point Left"
 msgstr "Apunta a l'esquerra"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1768
+#: ../src/propgrid/advprops.cpp:1669
 msgid "Point Right"
 msgstr "Apunta a la dreta"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:662
+#: ../src/propgrid/advprops.cpp:572
 msgid "Point Size"
 msgstr "Mida en punts"
 
-#: ../src/generic/prntdlgg.cpp:612 ../src/generic/prntdlgg.cpp:867
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:860
 msgid "Portrait"
 msgstr "Vertical"
 
@@ -5738,150 +5889,160 @@ msgstr "Vertical"
 msgid "Position"
 msgstr "Posició"
 
-#: ../src/generic/prntdlgg.cpp:298
+#: ../src/generic/prntdlgg.cpp:291
 msgid "PostScript file"
 msgstr "Fitxer PostScript"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178 ../src/osx/cocoa/preferences.mm:303
 msgid "Preferences"
 msgstr "Preferències"
 
-#: ../src/osx/menu_osx.cpp:568
+#: ../src/osx/menu_osx.cpp:460
 msgid "Preferences..."
 msgstr "Preferències..."
 
-#: ../src/common/prntbase.cpp:546
+#: ../src/common/prntbase.cpp:541
 msgid "Preparing"
 msgstr "S'està preparant"
 
-#: ../src/generic/fontdlgg.cpp:455 ../src/osx/carbon/fontdlg.cpp:390
-#: ../src/html/helpwnd.cpp:1222
+#: ../src/osx/carbon/fontdlg.cpp:387 ../src/generic/fontdlgg.cpp:452
+#: ../src/html/helpwnd.cpp:1220
 msgid "Preview:"
 msgstr "Previsualització:"
 
-#: ../src/common/prntbase.cpp:1553 ../src/html/helpwnd.cpp:664
+#: ../src/common/prntbase.cpp:1578 ../src/html/helpwnd.cpp:662
 msgid "Previous page"
 msgstr "Pàgina anterior"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/prntdlgg.cpp:143 ../src/generic/prntdlgg.cpp:157
-#: ../src/common/prntbase.cpp:426 ../src/common/prntbase.cpp:1541
-#: ../src/common/accelcmn.cpp:77 ../src/gtk/print.cpp:620
-#: ../src/gtk/print.cpp:638
+#: ../src/common/prntbase.cpp:421 ../src/common/prntbase.cpp:1566
+#: ../src/common/accelcmn.cpp:74 ../src/generic/prntdlgg.cpp:136
+#: ../src/generic/prntdlgg.cpp:150 ../src/gtk/print.cpp:616
+#: ../src/gtk/print.cpp:634
 msgid "Print"
 msgstr "Imprimeix"
 
-#: ../include/wx/prntbase.h:399 ../src/common/docview.cpp:1268
+#: ../src/common/docview.cpp:1262
 msgid "Print Preview"
 msgstr "Previsualització de la impressió"
 
-#: ../src/common/prntbase.cpp:2015 ../src/common/prntbase.cpp:2057
-#: ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2037 ../src/common/prntbase.cpp:2079
+#: ../src/common/prntbase.cpp:2087
 msgid "Print Preview Failure"
 msgstr "S'ha produït un error en la previsualització de la impressió"
 
-#: ../src/generic/prntdlgg.cpp:224
+#: ../src/generic/prntdlgg.cpp:217
 msgid "Print Range"
 msgstr "Rang d'impressió"
 
-#: ../src/generic/prntdlgg.cpp:449
+#: ../src/generic/prntdlgg.cpp:442
 msgid "Print Setup"
 msgstr "Configuració de la impressió"
 
-#: ../src/generic/prntdlgg.cpp:621
+#: ../src/generic/prntdlgg.cpp:614
 msgid "Print in colour"
 msgstr "Imprimeix en color"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/osx/webview_webkit.mm:260
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "No es pot començar a mostrar."
+
+#: ../src/common/stockitem.cpp:179
 msgid "Print previe&w..."
 msgstr "Pre&visualitza la impressió..."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1256
 msgid "Print preview creation failed."
 msgstr "No s'ha pogut crear la previsualització de la impressió."
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/common/stockitem.cpp:179
 msgid "Print preview..."
 msgstr "Previsualització de la impressió..."
 
-#: ../src/generic/prntdlgg.cpp:630
+#: ../src/generic/prntdlgg.cpp:623
 msgid "Print spooling"
 msgstr "Cua d'impressió"
 
-#: ../src/html/helpwnd.cpp:675
+#: ../src/html/helpwnd.cpp:673
 msgid "Print this page"
 msgstr "Imprimeix aquesta pàgina"
 
-#: ../src/generic/prntdlgg.cpp:185
+#: ../src/generic/prntdlgg.cpp:178
 msgid "Print to File"
 msgstr "Imprimeix a un fitxer"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "Print..."
 msgstr "Imprimeix..."
 
-#: ../src/generic/prntdlgg.cpp:493
+#: ../src/generic/prntdlgg.cpp:486
 msgid "Printer"
 msgstr "Impressora"
 
-#: ../src/generic/prntdlgg.cpp:633
+#: ../src/generic/prntdlgg.cpp:626
 msgid "Printer command:"
 msgstr "Ordre de la impressora:"
 
-#: ../src/generic/prntdlgg.cpp:180
+#: ../src/generic/prntdlgg.cpp:173
 msgid "Printer options"
 msgstr "Opcions de la impressora"
 
-#: ../src/generic/prntdlgg.cpp:645
+#: ../src/generic/prntdlgg.cpp:638
 msgid "Printer options:"
 msgstr "Opcions de la impressora:"
 
-#: ../src/generic/prntdlgg.cpp:916
+#: ../src/generic/prntdlgg.cpp:909
 msgid "Printer..."
 msgstr "Impressora..."
 
-#: ../src/generic/prntdlgg.cpp:196
+#: ../src/generic/prntdlgg.cpp:189
 msgid "Printer:"
 msgstr "Impressora:"
 
-#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:535
-#: ../src/html/htmprint.cpp:277
+#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:530
+#: ../src/html/htmprint.cpp:289
 msgid "Printing"
 msgstr "S'està imprimint"
 
-#: ../src/common/prntbase.cpp:612
+#: ../src/common/prntbase.cpp:607
 msgid "Printing "
 msgstr "S'està imprimint "
 
-#: ../src/common/prntbase.cpp:347
+#: ../src/common/prntbase.cpp:342
 msgid "Printing Error"
 msgstr "S'ha produït un error d'impressió"
 
-#: ../src/common/prntbase.cpp:565
+#: ../src/osx/webview_webkit.mm:251
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "Aquesta versió de zlib no suporta Gzip"
+
+#: ../src/common/prntbase.cpp:560
 #, c-format
 msgid "Printing page %d"
 msgstr "S'està imprimint la pàgina %d"
 
-#: ../src/common/prntbase.cpp:570
+#: ../src/common/prntbase.cpp:565
 #, c-format
 msgid "Printing page %d of %d"
 msgstr "S'està imprimint la pàgina %d de %d"
 
-#: ../src/generic/printps.cpp:201
+#: ../src/generic/printps.cpp:182
 #, c-format
 msgid "Printing page %d..."
 msgstr "S'està imprimint la pàgina %d..."
 
-#: ../src/generic/printps.cpp:161
+#: ../src/generic/printps.cpp:142
 msgid "Printing..."
 msgstr "S'està imprimint..."
 
-#: ../include/wx/richtext/richtextprint.h:109 ../include/wx/prntbase.h:267
-#: ../src/common/docview.cpp:2132
+#: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
+#: ../src/common/docview.cpp:2137
 msgid "Printout"
 msgstr "Impressió"
 
-#: ../src/common/debugrpt.cpp:560
+#: ../src/common/debugrpt.cpp:561
 #, c-format
 msgid ""
 "Processing debug report has failed, leaving the files in \"%s\" directory."
@@ -5889,102 +6050,102 @@ msgstr ""
 "No s'ha pogut processar l'informe de depuració, es deixaran els fitxers al "
 "directori \"%s\"."
 
-#: ../src/common/prntbase.cpp:545
+#: ../src/common/prntbase.cpp:540
 msgid "Progress:"
 msgstr "Progrés:"
 
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181
 msgid "Properties"
 msgstr "Propietats"
 
-#: ../src/propgrid/manager.cpp:237
+#: ../src/propgrid/manager.cpp:223
 msgid "Property"
 msgstr "Propietat"
 
 #. TRANSLATORS: Caption of message box displaying any property error
-#: ../src/propgrid/propgrid.cpp:3185 ../src/propgrid/propgrid.cpp:3318
+#: ../src/propgrid/propgrid.cpp:3162 ../src/propgrid/propgrid.cpp:3299
 msgid "Property Error"
 msgstr "Error de propietat"
 
-#: ../src/propgrid/advprops.cpp:1597
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Purple"
 msgstr "Porpra"
 
-#: ../src/common/paper.cpp:112
+#: ../src/common/paper.cpp:109
 msgid "Quarto, 215 x 275 mm"
 msgstr "Quarto, 215 x 275 mm"
 
-#: ../src/generic/logg.cpp:1016
+#: ../src/generic/logg.cpp:1013
 msgid "Question"
 msgstr "Qüestió"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1769
+#: ../src/propgrid/advprops.cpp:1670
 msgid "Question Arrow"
 msgstr "Fletxa amb interrogació"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "Quit"
 msgstr "Surt"
 
-#: ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:477
 #, c-format
 msgid "Quit %s"
 msgstr "Surt de %s"
 
-#: ../src/common/stockitem.cpp:263
+#: ../src/common/stockitem.cpp:261
 msgid "Quit this program"
 msgstr "Surt d'aquest programa"
 
-#: ../src/common/accelcmn.cpp:338
+#: ../src/common/accelcmn.cpp:352
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/ffile.cpp:109 ../src/common/ffile.cpp:133
+#: ../src/common/ffile.cpp:107 ../src/common/ffile.cpp:132
 #, c-format
 msgid "Read error on file '%s'"
 msgstr "S'ha produït un error de lectura al fitxer '%s'"
 
-#: ../src/common/secretstore.cpp:199
-#, c-format
-msgid "Reading password for \"%s/%s\" failed: %s."
+#: ../src/common/secretstore.cpp:211
+#, fuzzy, c-format
+msgid "Reading password for \"%s\" failed: %s."
 msgstr "No s'ha pogut llegir la contrasenya de \"%s/%s\": %s."
 
-#: ../src/common/prntbase.cpp:272
+#: ../src/common/prntbase.cpp:267
 msgid "Ready"
 msgstr "Llest"
 
-#: ../src/propgrid/advprops.cpp:1605
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Red"
 msgstr "Vermell"
 
-#: ../src/generic/colrdlgg.cpp:339
+#: ../src/generic/colrdlgg.cpp:359
 msgid "Red:"
 msgstr "Vermell:"
 
-#: ../src/common/stockitem.cpp:185 ../src/stc/stc_i18n.cpp:16
+#: ../src/common/stockitem.cpp:182 ../src/stc/stc_i18n.cpp:16
 msgid "Redo"
 msgstr "Refés"
 
-#: ../src/common/stockitem.cpp:264
+#: ../src/common/stockitem.cpp:262
 msgid "Redo last action"
 msgstr "Refés la darrera acció"
 
-#: ../src/common/stockitem.cpp:186
+#: ../src/common/stockitem.cpp:183
 msgid "Refresh"
 msgstr "Refresca"
 
-#: ../src/msw/registry.cpp:626
+#: ../src/msw/registry.cpp:615
 #, c-format
 msgid "Registry key '%s' already exists."
 msgstr "La clau del registre '%s' ja existeix."
 
-#: ../src/msw/registry.cpp:595
+#: ../src/msw/registry.cpp:584
 #, c-format
 msgid "Registry key '%s' does not exist, cannot rename it."
 msgstr "La clau del registre '%s' no existeix, no en podeu canviar el nom."
 
-#: ../src/msw/registry.cpp:727
+#: ../src/msw/registry.cpp:716
 #, c-format
 msgid ""
 "Registry key '%s' is needed for normal system operation,\n"
@@ -5996,22 +6157,22 @@ msgstr ""
 "si la suprimiu, deixareu el sistema en un estat inservible:\n"
 "s'ha avortat l'operació."
 
-#: ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:942
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr "El valor del registre \"%s\" no és binari (sinó del tipus %s)"
 
-#: ../src/msw/registry.cpp:917
+#: ../src/msw/registry.cpp:905
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr "El valor del registre \"%s\" no és numèric (sinó del tipus %s)"
 
-#: ../src/msw/registry.cpp:1003
+#: ../src/msw/registry.cpp:991
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr "El valor del registre \"%s\" no és de text (sinó del tipus %s)"
 
-#: ../src/msw/registry.cpp:521
+#: ../src/msw/registry.cpp:510
 #, c-format
 msgid "Registry value '%s' already exists."
 msgstr "El valor del registre '%s' ja existeix."
@@ -6025,72 +6186,78 @@ msgstr "Normal"
 msgid "Relative"
 msgstr "Relatiu"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:456
 msgid "Relevant entries:"
 msgstr "Entrades rellevants:"
 
-#: ../include/wx/generic/progdlgg.h:86
+#: ../include/wx/generic/progdlgg.h:87
 msgid "Remaining time:"
 msgstr "Temps restant:"
 
-#: ../src/common/stockitem.cpp:187
+#: ../src/common/stockitem.cpp:184
 msgid "Remove"
 msgstr "Suprimeix"
 
-#: ../src/richtext/richtextctrl.cpp:1562
+#: ../src/richtext/richtextctrl.cpp:1563
 msgid "Remove Bullet"
 msgstr "Suprimeix el pic"
 
-#: ../src/html/helpwnd.cpp:433
+#: ../src/html/helpwnd.cpp:431
 msgid "Remove current page from bookmarks"
 msgstr "Elimina la pàgina actual dels preferits"
 
-#: ../src/common/rendcmn.cpp:194
+#: ../src/common/rendcmn.cpp:191
 #, c-format
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 "El renderitzador \"%s\" té la versió incompatible %d.%d i no s'ha pogut "
 "carregar."
 
-#: ../src/richtext/richtextbuffer.cpp:4527
+#: ../src/richtext/richtextbuffer.cpp:4524
 msgid "Renumber List"
 msgstr "Torna a numerar la llista"
 
-#: ../src/common/stockitem.cpp:188
-msgid "Rep&lace"
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Rep&lace..."
 msgstr "&Substitueix"
 
-#: ../src/richtext/richtextctrl.cpp:3673 ../src/common/stockitem.cpp:188
+#: ../src/richtext/richtextctrl.cpp:3674
 msgid "Replace"
 msgstr "Substitueix"
 
-#: ../src/generic/fdrepdlg.cpp:182
+#: ../src/generic/fdrepdlg.cpp:179
 msgid "Replace &all"
 msgstr "Substitueix-ho &tot"
 
-#: ../src/common/stockitem.cpp:261
-msgid "Replace selection"
-msgstr "Substitueix la selecció"
-
-#: ../src/generic/fdrepdlg.cpp:124
+#: ../src/generic/fdrepdlg.cpp:121
 msgid "Replace with:"
 msgstr "Substitueix per:"
 
-#: ../src/common/valtext.cpp:163
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Replace..."
+msgstr "Substitueix"
+
+#: ../src/common/valtext.cpp:184
 msgid "Required information entry is empty."
 msgstr "L'entrada d'informació necessària és buida."
 
-#: ../src/common/translation.cpp:1975
+#: ../src/common/translation.cpp:2025
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "El recurs '%s' no és un catàleg de missatges vàlid."
 
+#: ../src/gtk/webview_webkit.cpp:985
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:56
+#: ../src/common/accelcmn.cpp:53
 msgid "Return"
 msgstr "Retorn"
 
-#: ../src/common/stockitem.cpp:189
+#: ../src/common/stockitem.cpp:186
 msgid "Revert to Saved"
 msgstr "Reverteix a la versió desada"
 
@@ -6102,41 +6269,41 @@ msgstr "Arruga"
 msgid "Rig&ht-to-left"
 msgstr "&De dreta a esquerra"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6149
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:59 ../src/generic/datavgen.cpp:6954
+#: ../src/richtext/richtextsizepage.cpp:250
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextbulletspage.cpp:188
-#: ../src/richtext/richtextsizepage.cpp:250 ../src/common/accelcmn.cpp:62
 msgid "Right"
 msgstr "Dreta"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1754
+#: ../src/propgrid/advprops.cpp:1655
 msgid "Right Arrow"
 msgstr "Fletxa a la dreta"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1770
+#: ../src/propgrid/advprops.cpp:1671
 msgid "Right Button"
 msgstr "Botó dret"
 
-#: ../src/generic/prntdlgg.cpp:892
+#: ../src/generic/prntdlgg.cpp:885
 msgid "Right margin (mm):"
 msgstr "Marge dret (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:148
-#: ../src/richtext/richtextindentspage.cpp:150
 #: ../src/richtext/richtextliststylepage.cpp:337
 #: ../src/richtext/richtextliststylepage.cpp:339
+#: ../src/richtext/richtextindentspage.cpp:148
+#: ../src/richtext/richtextindentspage.cpp:150
 msgid "Right-align text."
 msgstr "Alinea el text a la dreta."
 
-#: ../src/generic/fontdlgg.cpp:322
+#: ../src/generic/fontdlgg.cpp:318
 msgid "Roman"
 msgstr "Roman"
 
-#: ../src/generic/datavgen.cpp:5916
+#: ../src/generic/datavgen.cpp:6721
 #, c-format
 msgid "Row %i"
 msgstr "Fila %i"
@@ -6146,30 +6313,31 @@ msgstr "Fila %i"
 msgid "S&tandard bullet name:"
 msgstr "Nom del pic es&tàndard:"
 
-#: ../src/common/accelcmn.cpp:268 ../src/common/accelcmn.cpp:350
+#: ../src/common/accelcmn.cpp:282 ../src/common/accelcmn.cpp:367
 msgid "SPECIAL"
 msgstr "ESPECIAL"
 
-#: ../src/common/stockitem.cpp:190 ../src/common/sizer.cpp:2797
+#: ../src/common/stockitem.cpp:187 ../src/common/sizer.cpp:2914
 msgid "Save"
 msgstr "Desa"
 
-#: ../src/common/fldlgcmn.cpp:342
+#: ../src/common/fldlgcmn.cpp:339
 #, c-format
 msgid "Save %s file"
 msgstr "Desa el fitxer %s"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/common/stockitem.cpp:188 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "&Anomena i desa..."
 
-#: ../src/common/docview.cpp:366
+#: ../src/common/docview.cpp:359
 msgid "Save As"
 msgstr "Anomena i desa"
 
-#: ../src/common/stockitem.cpp:191
-msgid "Save as"
-msgstr "Anomena i desa"
+#: ../src/common/stockitem.cpp:188
+#, fuzzy
+msgid "Save As..."
+msgstr "&Anomena i desa..."
 
 #: ../src/common/stockitem.cpp:267
 msgid "Save current document"
@@ -6179,40 +6347,40 @@ msgstr "Desa el document actual"
 msgid "Save current document with a different filename"
 msgstr "Desa el document actual amb un nom de fitxer diferent"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/generic/logg.cpp:509
 msgid "Save log contents to file"
 msgstr "Desa el contingut del registre al fitxer"
 
-#: ../src/common/secretstore.cpp:179
-#, c-format
-msgid "Saving password for \"%s/%s\" failed: %s."
+#: ../src/common/secretstore.cpp:189
+#, fuzzy, c-format
+msgid "Saving password for \"%s\" failed: %s."
 msgstr "No s'ha pogut desar la contrasenya de \"%s/%s\": %s."
 
-#: ../src/generic/fontdlgg.cpp:325
+#: ../src/generic/fontdlgg.cpp:321
 msgid "Script"
 msgstr "Script"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll Lock"
 msgstr "Bloq Despl"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll_lock"
 msgstr "Bloq Despl"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:890
+#: ../src/propgrid/advprops.cpp:791
 msgid "Scrollbar"
 msgstr "Scrollbar"
 
-#: ../src/generic/srchctlg.cpp:56 ../src/html/helpwnd.cpp:535
-#: ../src/html/helpwnd.cpp:550
+#: ../src/generic/srchctlg.cpp:55 ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:548 ../src/gtk/srchctrl.cpp:182
 msgid "Search"
 msgstr "Cerca"
 
-#: ../src/html/helpwnd.cpp:537
+#: ../src/html/helpwnd.cpp:535
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
@@ -6220,32 +6388,32 @@ msgstr ""
 "Cerca totes les coincidències del text que heu escrit a dalt al contingut "
 "dels llibres d'ajuda"
 
-#: ../src/generic/fdrepdlg.cpp:160
+#: ../src/generic/fdrepdlg.cpp:157
 msgid "Search direction"
 msgstr "Direcció de la cerca"
 
-#: ../src/generic/fdrepdlg.cpp:112
+#: ../src/generic/fdrepdlg.cpp:109
 msgid "Search for:"
 msgstr "Cerca:"
 
-#: ../src/html/helpwnd.cpp:1052
+#: ../src/html/helpwnd.cpp:1050
 msgid "Search in all books"
 msgstr "Cerca a tots els llibres"
 
-#: ../src/html/helpwnd.cpp:857
+#: ../src/html/helpwnd.cpp:855
 msgid "Searching..."
 msgstr "S'està cercant..."
 
-#: ../src/generic/dirctrlg.cpp:446
+#: ../src/generic/dirctrlg.cpp:412
 msgid "Sections"
 msgstr "Seccions"
 
-#: ../src/common/ffile.cpp:238
+#: ../src/common/ffile.cpp:237
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "S'ha produït un error de cerca al fitxer '%s'"
 
-#: ../src/common/ffile.cpp:228
+#: ../src/common/ffile.cpp:227
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
@@ -6253,24 +6421,24 @@ msgstr ""
 "suportats per stdio)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:76
+#: ../src/common/accelcmn.cpp:73
 msgid "Select"
 msgstr "Selecciona"
 
-#: ../src/richtext/richtextctrl.cpp:337 ../src/osx/textctrl_osx.cpp:581
-#: ../src/common/stockitem.cpp:192 ../src/msw/textctrl.cpp:2512
+#: ../src/osx/textctrl_osx.cpp:599 ../src/common/stockitem.cpp:189
+#: ../src/msw/textctrl.cpp:2777 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Seleccion&a-ho tot"
 
-#: ../src/common/stockitem.cpp:192 ../src/stc/stc_i18n.cpp:21
+#: ../src/common/stockitem.cpp:189 ../src/stc/stc_i18n.cpp:21
 msgid "Select All"
 msgstr "Selecciona-ho tot"
 
-#: ../src/common/docview.cpp:1895
+#: ../src/common/docview.cpp:1900
 msgid "Select a document template"
 msgstr "Seleccioneu una plantilla de document"
 
-#: ../src/common/docview.cpp:1969
+#: ../src/common/docview.cpp:1974
 msgid "Select a document view"
 msgstr "Seleccioneu una visualització del document"
 
@@ -6299,20 +6467,20 @@ msgid "Selects the list level to edit."
 msgstr "Selecciona el nivell de la llista a editar."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:82
+#: ../src/common/accelcmn.cpp:79
 msgid "Separator"
 msgstr "Separador"
 
-#: ../src/common/cmdline.cpp:1083
+#: ../src/common/cmdline.cpp:1079
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "S'esperava un separador després de l'opció '%s'."
 
-#: ../src/osx/menu_osx.cpp:572
+#: ../src/osx/menu_osx.cpp:464
 msgid "Services"
 msgstr "Serveis"
 
-#: ../src/richtext/richtextbuffer.cpp:11217
+#: ../src/richtext/richtextbuffer.cpp:11216
 msgid "Set Cell Style"
 msgstr "Defineix l'estil de la cel·la"
 
@@ -6320,11 +6488,11 @@ msgstr "Defineix l'estil de la cel·la"
 msgid "SetProperty called w/o valid setter"
 msgstr "S'ha cridat SetProperty sense un setter vàlid"
 
-#: ../src/generic/prntdlgg.cpp:188
+#: ../src/generic/prntdlgg.cpp:181
 msgid "Setup..."
 msgstr "Configura..."
 
-#: ../src/msw/dialup.cpp:544
+#: ../src/msw/dialup.cpp:538
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr ""
 "S'han trobat diverses connexions actives de marcatge telefònic, se'n triarà "
@@ -6342,40 +6510,40 @@ msgstr "Ombra"
 msgid "Shadow c&olour:"
 msgstr "C&olor de l'ombra:"
 
-#: ../src/common/accelcmn.cpp:335
+#: ../src/common/accelcmn.cpp:349
 msgid "Shift+"
 msgstr "Maj+"
 
-#: ../src/generic/dirdlgg.cpp:147
+#: ../src/generic/dirdlgg.cpp:144
 msgid "Show &hidden directories"
 msgstr "&Mostra els directoris ocults"
 
-#: ../src/generic/filectrlg.cpp:983
+#: ../src/generic/filectrlg.cpp:979
 msgid "Show &hidden files"
 msgstr "&Mostra els fitxers ocults"
 
-#: ../src/osx/menu_osx.cpp:580
+#: ../src/osx/menu_osx.cpp:472
 msgid "Show All"
 msgstr "Mostra-ho tot"
 
-#: ../src/common/stockitem.cpp:257
+#: ../src/common/stockitem.cpp:254
 msgid "Show about dialog"
 msgstr "Mostra el diàleg Quant a"
 
-#: ../src/html/helpwnd.cpp:492
+#: ../src/html/helpwnd.cpp:490
 msgid "Show all"
 msgstr "Mostra-ho tot"
 
-#: ../src/html/helpwnd.cpp:503
+#: ../src/html/helpwnd.cpp:501
 msgid "Show all items in index"
 msgstr "Mostra tots els elements a l'índex"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:656
 msgid "Show/hide navigation panel"
 msgstr "Mostra/amaga el plafó de navegació"
 
-#: ../src/richtext/richtextsymboldlg.cpp:421
-#: ../src/richtext/richtextsymboldlg.cpp:423
+#: ../src/richtext/richtextsymboldlg.cpp:418
+#: ../src/richtext/richtextsymboldlg.cpp:420
 msgid "Shows a Unicode subset."
 msgstr "Mostra un subconjunt d'Unicode."
 
@@ -6391,7 +6559,7 @@ msgstr "Mostra una previsualització de la configuració dels pics."
 msgid "Shows a preview of the font settings."
 msgstr "Mostra una previsualització de la configuració del tipus de lletra."
 
-#: ../src/osx/carbon/fontdlg.cpp:394 ../src/osx/carbon/fontdlg.cpp:396
+#: ../src/osx/carbon/fontdlg.cpp:391 ../src/osx/carbon/fontdlg.cpp:393
 msgid "Shows a preview of the font."
 msgstr "Mostra una previsualització del tipus de lletra."
 
@@ -6400,62 +6568,62 @@ msgstr "Mostra una previsualització del tipus de lletra."
 msgid "Shows a preview of the paragraph settings."
 msgstr "Mostra una previsualització de la configuració del paràgraf."
 
-#: ../src/generic/fontdlgg.cpp:460 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:456 ../src/generic/fontdlgg.cpp:458
 msgid "Shows the font preview."
 msgstr "Mostra la previsualització del tipus de lletra."
 
-#: ../src/propgrid/advprops.cpp:1607
+#: ../src/propgrid/advprops.cpp:1513
 msgid "Silver"
 msgstr "Argent"
 
-#: ../src/univ/themes/mono.cpp:516
+#: ../src/univ/themes/mono.cpp:513
 msgid "Simple monochrome theme"
 msgstr "Tema monocrom simple"
 
-#: ../src/richtext/richtextindentspage.cpp:275
 #: ../src/richtext/richtextliststylepage.cpp:449
+#: ../src/richtext/richtextindentspage.cpp:275
 msgid "Single"
 msgstr "Simple"
 
-#: ../src/generic/filectrlg.cpp:425 ../src/richtext/richtextformatdlg.cpp:369
-#: ../src/richtext/richtextsizepage.cpp:299
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextsizepage.cpp:299
+#: ../src/richtext/richtextformatdlg.cpp:362
 msgid "Size"
 msgstr "Mida"
 
-#: ../src/osx/carbon/fontdlg.cpp:339
+#: ../src/osx/carbon/fontdlg.cpp:336
 msgid "Size:"
 msgstr "Mida:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1775
+#: ../src/propgrid/advprops.cpp:1676
 msgid "Sizing"
 msgstr "Redimensionament"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1772
+#: ../src/propgrid/advprops.cpp:1673
 msgid "Sizing N-S"
 msgstr "Redimensionament N-S"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1771
+#: ../src/propgrid/advprops.cpp:1672
 msgid "Sizing NE-SW"
 msgstr "Redimensionament NE-SO"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1773
+#: ../src/propgrid/advprops.cpp:1674
 msgid "Sizing NW-SE"
 msgstr "Redimensionament NO-SE"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1774
+#: ../src/propgrid/advprops.cpp:1675
 msgid "Sizing W-E"
 msgstr "Redimensionament O-E"
 
-#: ../src/msw/progdlg.cpp:801
+#: ../src/msw/progdlg.cpp:1088
 msgid "Skip"
 msgstr "Omet"
 
-#: ../src/generic/fontdlgg.cpp:330
+#: ../src/generic/fontdlgg.cpp:326
 msgid "Slant"
 msgstr "Inclinat"
 
@@ -6464,7 +6632,7 @@ msgid "Small C&apitals"
 msgstr "Vers&aleta"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:79
+#: ../src/common/accelcmn.cpp:76
 msgid "Snapshot"
 msgstr "Impr Pant"
 
@@ -6472,37 +6640,37 @@ msgstr "Impr Pant"
 msgid "Solid"
 msgstr "Sòlid"
 
-#: ../src/common/docview.cpp:1791
+#: ../src/common/docview.cpp:1785
 msgid "Sorry, could not open this file."
 msgstr "No s'ha pogut obrir aquest fitxer."
 
-#: ../src/common/prntbase.cpp:2057 ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2079 ../src/common/prntbase.cpp:2087
 msgid "Sorry, not enough memory to create a preview."
 msgstr "No hi ha prou memòria per a crear una previsualització."
 
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "Sorry, that name is taken. Please choose another."
 msgstr "Aquest nom ja s'utilitza. Trieu-ne un altre."
 
-#: ../src/common/docview.cpp:1814
+#: ../src/common/docview.cpp:1819
 msgid "Sorry, the format for this file is unknown."
 msgstr "El format d'aquest fitxer és desconegut."
 
-#: ../src/unix/sound.cpp:492
+#: ../src/unix/sound.cpp:481
 msgid "Sound data are in unsupported format."
 msgstr "Les dades del so tenen un format no suportat."
 
-#: ../src/unix/sound.cpp:477
+#: ../src/unix/sound.cpp:466
 #, c-format
 msgid "Sound file '%s' is in unsupported format."
 msgstr "El fitxer de so '%s' té un format no suportat."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:67
+#: ../src/common/accelcmn.cpp:64
 msgid "Space"
 msgstr "Espai"
 
@@ -6510,12 +6678,12 @@ msgstr "Espai"
 msgid "Spacing"
 msgstr "Espaiat"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "Spell Check"
 msgstr "Comprovació ortogràfica"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1776
+#: ../src/propgrid/advprops.cpp:1677
 msgid "Spraycan"
 msgstr "Aerosol"
 
@@ -6524,7 +6692,7 @@ msgstr "Aerosol"
 msgid "Standard"
 msgstr "Estàndard"
 
-#: ../src/common/paper.cpp:104
+#: ../src/common/paper.cpp:101
 msgid "Statement, 5 1/2 x 8 1/2 in"
 msgstr "Statement, 5 1/2 x 8 1/2 polz."
 
@@ -6533,33 +6701,29 @@ msgstr "Statement, 5 1/2 x 8 1/2 polz."
 msgid "Static"
 msgstr "Estàtic"
 
-#: ../src/generic/prntdlgg.cpp:204
+#: ../src/generic/prntdlgg.cpp:197
 msgid "Status:"
 msgstr "Estat:"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "Stop"
 msgstr "Atura"
 
-#: ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196
 msgid "Strikethrough"
 msgstr "Ratllat"
 
-#: ../src/common/colourcmn.cpp:45
+#: ../src/common/colourcmn.cpp:42
 #, c-format
 msgid "String To Colour : Incorrect colour specification : %s"
 msgstr "Cadena a color: Especificació del color incorrecta: %s"
 
 #. TRANSLATORS: Label of font style
-#: ../src/richtext/richtextformatdlg.cpp:339 ../src/propgrid/advprops.cpp:680
+#: ../src/propgrid/advprops.cpp:590 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Estil"
 
-#: ../include/wx/richtext/richtextstyledlg.h:46
-msgid "Style Organiser"
-msgstr "Organitzador d'estils"
-
-#: ../src/osx/carbon/fontdlg.cpp:348
+#: ../src/osx/carbon/fontdlg.cpp:345
 msgid "Style:"
 msgstr "Estil:"
 
@@ -6568,7 +6732,7 @@ msgid "Subscrip&t"
 msgstr "Subín&dex"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:83
+#: ../src/common/accelcmn.cpp:80
 msgid "Subtract"
 msgstr "Resta"
 
@@ -6576,11 +6740,11 @@ msgstr "Resta"
 msgid "Supe&rscript"
 msgstr "Supe&ríndex"
 
-#: ../src/common/paper.cpp:150
+#: ../src/common/paper.cpp:147
 msgid "SuperA/SuperA/A4 227 x 356 mm"
 msgstr "SuperA/SuperA/A4, 227 x 356 mm"
 
-#: ../src/common/paper.cpp:151
+#: ../src/common/paper.cpp:148
 msgid "SuperB/SuperB/A3 305 x 487 mm"
 msgstr "SuperB/SuperB/A3, 305 x 487 mm"
 
@@ -6588,7 +6752,7 @@ msgstr "SuperB/SuperB/A3, 305 x 487 mm"
 msgid "Suppress hyphe&nation"
 msgstr "&Suprimeix la divisió de paraules"
 
-#: ../src/generic/fontdlgg.cpp:326
+#: ../src/generic/fontdlgg.cpp:322
 msgid "Swiss"
 msgstr "Suís"
 
@@ -6606,73 +6770,73 @@ msgstr "&Tipus de lletra per a símbols:"
 msgid "Symbols"
 msgstr "Símbols"
 
-#: ../src/common/imagtiff.cpp:369 ../src/common/imagtiff.cpp:382
-#: ../src/common/imagtiff.cpp:741
+#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
+#: ../src/common/imagtiff.cpp:738
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: No s'ha pogut assignar la memòria."
 
-#: ../src/common/imagtiff.cpp:301
+#: ../src/common/imagtiff.cpp:298
 msgid "TIFF: Error loading image."
 msgstr "TIFF: S'ha produït un error en carregar la imatge."
 
-#: ../src/common/imagtiff.cpp:468
+#: ../src/common/imagtiff.cpp:465
 msgid "TIFF: Error reading image."
 msgstr "TIFF: S'ha produït un error en llegir la imatge."
 
-#: ../src/common/imagtiff.cpp:608
+#: ../src/common/imagtiff.cpp:605
 msgid "TIFF: Error saving image."
 msgstr "TIFF: S'ha produït un error en desar la imatge."
 
-#: ../src/common/imagtiff.cpp:846
+#: ../src/common/imagtiff.cpp:843
 msgid "TIFF: Error writing image."
 msgstr "TIFF: S'ha produït un error en escriure la imatge."
 
-#: ../src/common/imagtiff.cpp:355
+#: ../src/common/imagtiff.cpp:352
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: La mida de la imatge és anormalment gran."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:68
+#: ../src/common/accelcmn.cpp:65
 msgid "Tab"
 msgstr "Tab"
 
-#: ../src/richtext/richtextbuffer.cpp:11498
+#: ../src/richtext/richtextbuffer.cpp:11497
 msgid "Table Properties"
 msgstr "Propietats de la taula"
 
-#: ../src/common/paper.cpp:145
+#: ../src/common/paper.cpp:142
 msgid "Tabloid Extra 11.69 x 18 in"
 msgstr "Tabloide extra, 11,69 x 18 polz."
 
-#: ../src/common/paper.cpp:102
+#: ../src/common/paper.cpp:99
 msgid "Tabloid, 11 x 17 in"
 msgstr "Tabloide, 11 x 17 polz."
 
-#: ../src/richtext/richtextformatdlg.cpp:354
+#: ../src/richtext/richtextformatdlg.cpp:347
 msgid "Tabs"
 msgstr "Tabulacions"
 
-#: ../src/propgrid/advprops.cpp:1598
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Teal"
 msgstr "Xarxet"
 
-#: ../src/generic/fontdlgg.cpp:327
+#: ../src/generic/fontdlgg.cpp:323
 msgid "Teletype"
 msgstr "Teletip"
 
-#: ../src/common/docview.cpp:1896
+#: ../src/common/docview.cpp:1901
 msgid "Templates"
 msgstr "Plantilles"
 
-#: ../src/common/fmapbase.cpp:158
+#: ../src/common/fmapbase.cpp:155
 msgid "Thai (ISO-8859-11)"
 msgstr "Tailandès (ISO-8859-11)"
 
-#: ../src/common/ftp.cpp:619
+#: ../src/common/ftp.cpp:622
 msgid "The FTP server doesn't support passive mode."
 msgstr "El servidor FTP no suporta l'ús del mode passiu."
 
-#: ../src/common/ftp.cpp:605
+#: ../src/common/ftp.cpp:608
 msgid "The FTP server doesn't support the PORT command."
 msgstr "El servidor FTP no suporta l'ordre PORT."
 
@@ -6683,8 +6847,8 @@ msgstr "El servidor FTP no suporta l'ordre PORT."
 msgid "The available bullet styles."
 msgstr "Els estils de pic disponibles."
 
-#: ../src/richtext/richtextstyledlg.cpp:202
-#: ../src/richtext/richtextstyledlg.cpp:204
+#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:200
 msgid "The available styles."
 msgstr "Els estils disponibles."
 
@@ -6740,12 +6904,12 @@ msgstr "La posició inferior."
 msgid "The bullet character."
 msgstr "El caràcter del pic."
 
-#: ../src/richtext/richtextsymboldlg.cpp:443
-#: ../src/richtext/richtextsymboldlg.cpp:445
+#: ../src/richtext/richtextsymboldlg.cpp:440
+#: ../src/richtext/richtextsymboldlg.cpp:442
 msgid "The character code."
 msgstr "El codi del caràcter."
 
-#: ../src/common/fontmap.cpp:203
+#: ../src/common/fontmap.cpp:200
 #, c-format
 msgid ""
 "The charset '%s' is unknown. You may select\n"
@@ -6756,7 +6920,7 @@ msgstr ""
 "un altre joc de caràcters per a substituir-lo o triar\n"
 "[Cancel·la] si no pot ser substituït"
 
-#: ../src/msw/ole/dataobj.cpp:394
+#: ../src/msw/ole/dataobj.cpp:402
 #, c-format
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "El format del porta-retalls '%d' no existeix."
@@ -6766,7 +6930,7 @@ msgstr "El format del porta-retalls '%d' no existeix."
 msgid "The default style for the next paragraph."
 msgstr "L'estil per defecte per al paràgraf següent."
 
-#: ../src/generic/dirdlgg.cpp:202
+#: ../src/generic/dirdlgg.cpp:199
 #, c-format
 msgid ""
 "The directory '%s' does not exist\n"
@@ -6775,7 +6939,7 @@ msgstr ""
 "El directori '%s' no existeix.\n"
 "El voleu crear ara?"
 
-#: ../src/html/htmprint.cpp:271
+#: ../src/html/htmprint.cpp:283
 #, c-format
 msgid ""
 "The document \"%s\" doesn't fit on the page horizontally and will be "
@@ -6788,7 +6952,7 @@ msgstr ""
 "\n"
 "Voleu continuar i imprimir-lo igualment?"
 
-#: ../src/common/docview.cpp:1202
+#: ../src/common/docview.cpp:1196
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -6797,36 +6961,36 @@ msgstr ""
 "El fitxer '%s' no existeix i no s'ha pogut obrir.\n"
 "S'ha suprimit de la llista de fitxers utilitzats més recentment."
 
-#: ../src/richtext/richtextindentspage.cpp:208
-#: ../src/richtext/richtextindentspage.cpp:210
 #: ../src/richtext/richtextliststylepage.cpp:394
 #: ../src/richtext/richtextliststylepage.cpp:396
+#: ../src/richtext/richtextindentspage.cpp:208
+#: ../src/richtext/richtextindentspage.cpp:210
 msgid "The first line indent."
 msgstr "El sagnat de la primera línia."
 
-#: ../src/gtk/utilsgtk.cpp:481
-msgid "The following standard GTK+ options are also supported:\n"
-msgstr "També estan suportades les següents opcions estàndard de GTK+:\n"
+#: ../src/generic/dbgrptg.cpp:318
+msgid "The following debug report will be generated\n"
+msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:414 ../src/generic/fontdlgg.cpp:416
+#: ../src/generic/fontdlgg.cpp:411 ../src/generic/fontdlgg.cpp:413
 msgid "The font colour."
 msgstr "El color de la lletra."
 
-#: ../src/generic/fontdlgg.cpp:375 ../src/generic/fontdlgg.cpp:377
+#: ../src/generic/fontdlgg.cpp:371 ../src/generic/fontdlgg.cpp:373
 msgid "The font family."
 msgstr "La família del tipus de lletra."
 
-#: ../src/richtext/richtextsymboldlg.cpp:405
-#: ../src/richtext/richtextsymboldlg.cpp:407
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "The font from which to take the symbol."
 msgstr "El tipus de lletra del qual prendre el símbol."
 
-#: ../src/generic/fontdlgg.cpp:427 ../src/generic/fontdlgg.cpp:429
-#: ../src/generic/fontdlgg.cpp:434 ../src/generic/fontdlgg.cpp:436
+#: ../src/generic/fontdlgg.cpp:424 ../src/generic/fontdlgg.cpp:426
+#: ../src/generic/fontdlgg.cpp:430 ../src/generic/fontdlgg.cpp:432
 msgid "The font point size."
 msgstr "La mida en punts del tipus de lletra."
 
-#: ../src/osx/carbon/fontdlg.cpp:343 ../src/osx/carbon/fontdlg.cpp:345
+#: ../src/osx/carbon/fontdlg.cpp:340 ../src/osx/carbon/fontdlg.cpp:342
 msgid "The font size in points."
 msgstr "La mida del tipus de lletra en punts."
 
@@ -6835,15 +6999,15 @@ msgstr "La mida del tipus de lletra en punts."
 msgid "The font size units, points or pixels."
 msgstr "Les unitats, punts o píxels de la mida del tipus de lletra."
 
-#: ../src/generic/fontdlgg.cpp:386 ../src/generic/fontdlgg.cpp:388
+#: ../src/generic/fontdlgg.cpp:382 ../src/generic/fontdlgg.cpp:384
 msgid "The font style."
 msgstr "L'estil del tipus de lletra."
 
-#: ../src/generic/fontdlgg.cpp:397 ../src/generic/fontdlgg.cpp:399
+#: ../src/generic/fontdlgg.cpp:393 ../src/generic/fontdlgg.cpp:395
 msgid "The font weight."
 msgstr "El pes de la lletra."
 
-#: ../src/common/docview.cpp:1483
+#: ../src/common/docview.cpp:1477
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "No s'ha pogut determinar el format del fitxer '%s'."
@@ -6853,10 +7017,10 @@ msgstr "No s'ha pogut determinar el format del fitxer '%s'."
 msgid "The horizontal offset."
 msgstr "El desplaçament horitzontal."
 
-#: ../src/richtext/richtextindentspage.cpp:199
-#: ../src/richtext/richtextindentspage.cpp:201
 #: ../src/richtext/richtextliststylepage.cpp:385
 #: ../src/richtext/richtextliststylepage.cpp:387
+#: ../src/richtext/richtextindentspage.cpp:199
+#: ../src/richtext/richtextindentspage.cpp:201
 msgid "The left indent."
 msgstr "El sagnat esquerre."
 
@@ -6877,10 +7041,10 @@ msgstr "La mida de l'espaiat esquerre."
 msgid "The left position."
 msgstr "La posició esquerra."
 
-#: ../src/richtext/richtextindentspage.cpp:288
-#: ../src/richtext/richtextindentspage.cpp:290
 #: ../src/richtext/richtextliststylepage.cpp:462
 #: ../src/richtext/richtextliststylepage.cpp:464
+#: ../src/richtext/richtextindentspage.cpp:288
+#: ../src/richtext/richtextindentspage.cpp:290
 msgid "The line spacing."
 msgstr "L'interlineat."
 
@@ -6889,7 +7053,7 @@ msgstr "L'interlineat."
 msgid "The list item number."
 msgstr "El número de l'element de la llista."
 
-#: ../src/msw/ole/automtn.cpp:664
+#: ../src/msw/ole/automtn.cpp:655
 msgid "The locale ID is unknown."
 msgstr "L'identificador de la configuració local és desconegut."
 
@@ -6928,19 +7092,19 @@ msgstr "L'amplada de l'objecte."
 msgid "The outline level."
 msgstr "El nivell del contorn."
 
-#: ../src/common/log.cpp:277
+#: ../src/common/log.cpp:296
 #, c-format
 msgid "The previous message repeated %u time."
 msgid_plural "The previous message repeated %u times."
 msgstr[0] "El missatge anterior s'ha repetit %u vegada."
 msgstr[1] "El missatge anterior s'ha repetit %u vegades."
 
-#: ../src/common/log.cpp:270
+#: ../src/common/log.cpp:289
 msgid "The previous message repeated once."
 msgstr "El missatge anterior s'ha repetit una vegada."
 
-#: ../src/richtext/richtextsymboldlg.cpp:462
-#: ../src/richtext/richtextsymboldlg.cpp:464
+#: ../src/richtext/richtextsymboldlg.cpp:459
+#: ../src/richtext/richtextsymboldlg.cpp:461
 msgid "The range to show."
 msgstr "L'interval a mostrar."
 
@@ -6954,15 +7118,15 @@ msgstr ""
 "fitxers conté informació privada,\n"
 "desmarqueu-los i se suprimiran de l'informe.\n"
 
-#: ../src/common/cmdline.cpp:1254
+#: ../src/common/cmdline.cpp:1250
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "No s'ha especificat el paràmetre necessari '%s'."
 
-#: ../src/richtext/richtextindentspage.cpp:217
-#: ../src/richtext/richtextindentspage.cpp:219
 #: ../src/richtext/richtextliststylepage.cpp:403
 #: ../src/richtext/richtextliststylepage.cpp:405
+#: ../src/richtext/richtextindentspage.cpp:217
+#: ../src/richtext/richtextindentspage.cpp:219
 msgid "The right indent."
 msgstr "El sagnat dret."
 
@@ -7003,16 +7167,16 @@ msgstr "L'opacitat de l'ombra."
 msgid "The shadow spread."
 msgstr "La difusió de l'ombra."
 
-#: ../src/richtext/richtextindentspage.cpp:267
 #: ../src/richtext/richtextliststylepage.cpp:439
 #: ../src/richtext/richtextliststylepage.cpp:441
+#: ../src/richtext/richtextindentspage.cpp:267
 msgid "The spacing after the paragraph."
 msgstr "L'espaiat després del paràgraf."
 
-#: ../src/richtext/richtextindentspage.cpp:257
-#: ../src/richtext/richtextindentspage.cpp:259
 #: ../src/richtext/richtextliststylepage.cpp:430
 #: ../src/richtext/richtextliststylepage.cpp:432
+#: ../src/richtext/richtextindentspage.cpp:257
+#: ../src/richtext/richtextindentspage.cpp:259
 msgid "The spacing before the paragraph."
 msgstr "L'espaiat abans del paràgraf."
 
@@ -7026,12 +7190,12 @@ msgstr "El nom de l'estil."
 msgid "The style on which this style is based."
 msgstr "L'estil en què es basa aquest estil."
 
-#: ../src/richtext/richtextstyledlg.cpp:214
-#: ../src/richtext/richtextstyledlg.cpp:216
+#: ../src/richtext/richtextstyledlg.cpp:210
+#: ../src/richtext/richtextstyledlg.cpp:212
 msgid "The style preview."
 msgstr "La previsualització de l'estil."
 
-#: ../src/msw/ole/automtn.cpp:680
+#: ../src/msw/ole/automtn.cpp:671
 msgid "The system cannot find the file specified."
 msgstr "El sistema no pot trobar el fitxer especificat."
 
@@ -7044,7 +7208,7 @@ msgstr "La posició de la tabulació."
 msgid "The tab positions."
 msgstr "Les posicions de la tabulació."
 
-#: ../src/richtext/richtextctrl.cpp:3098
+#: ../src/richtext/richtextctrl.cpp:3099
 msgid "The text couldn't be saved."
 msgstr "No s'ha pogut desar el text."
 
@@ -7065,7 +7229,7 @@ msgstr "La mida de l'espaiat superior."
 msgid "The top position."
 msgstr "La posició superior."
 
-#: ../src/common/cmdline.cpp:1232
+#: ../src/common/cmdline.cpp:1228
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "Cal especificar el valor de l'opció '%s'."
@@ -7075,7 +7239,7 @@ msgstr "Cal especificar el valor de l'opció '%s'."
 msgid "The value of the corner radius."
 msgstr "El valor del radi de les cantonades."
 
-#: ../src/msw/dialup.cpp:433
+#: ../src/msw/dialup.cpp:427
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -7089,14 +7253,14 @@ msgstr ""
 msgid "The vertical offset."
 msgstr "El desplaçament vertical."
 
-#: ../src/richtext/richtextprint.cpp:619 ../src/html/htmprint.cpp:745
+#: ../src/html/htmprint.cpp:749 ../src/richtext/richtextprint.cpp:615
 msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr ""
 "Hi ha hagut un problema durant la configuració de la pàgina: pot ser que us "
 "calgui establir una impressora per defecte."
 
-#: ../src/html/htmprint.cpp:255
+#: ../src/html/htmprint.cpp:267
 msgid ""
 "This document doesn't fit on the page horizontally and will be truncated "
 "when it is printed."
@@ -7104,16 +7268,16 @@ msgstr ""
 "Aquest document no cap horitzontalment a la pàgina i es truncarà en imprimir-"
 "lo."
 
-#: ../src/common/image.cpp:2854
+#: ../src/common/image.cpp:2963
 #, c-format
 msgid "This is not a %s."
 msgstr "Això no és un %s."
 
-#: ../src/common/wincmn.cpp:1653
+#: ../src/common/wincmn.cpp:1654
 msgid "This platform does not support background transparency."
 msgstr "Aquesta plataforma no suporta la transparència al fons."
 
-#: ../src/gtk/window.cpp:4660
+#: ../src/gtk/window.cpp:5664
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
@@ -7121,7 +7285,15 @@ msgstr ""
 "Aquest programa s'ha compilat amb una versió massa antiga del GTK+, "
 "recompileu-lo amb el GTK+ 2.12 o posterior."
 
-#: ../src/msw/thread.cpp:1240
+#: ../src/gtk/glcanvas.cpp:176
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/msw/thread.cpp:1246
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -7129,13 +7301,13 @@ msgstr ""
 "No s'ha pogut inicialitzar el mòdul de fils d'execució: no es pot "
 "emmagatzemar el valor a l'emmagatzematge local del fil d'execució"
 
-#: ../src/unix/threadpsx.cpp:1794
+#: ../src/unix/threadpsx.cpp:1843
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 "No s'ha pogut inicialitzar el mòdul de fils d'execució: no s'ha pogut crear "
 "la clau del fil d'execució"
 
-#: ../src/msw/thread.cpp:1228
+#: ../src/msw/thread.cpp:1234
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -7143,84 +7315,84 @@ msgstr ""
 "No s'ha pogut inicialitzar el mòdul de fils d'execució: no és possible "
 "assignar l'índex a l'emmagatzematge local del fil d'execució"
 
-#: ../src/unix/threadpsx.cpp:1043
+#: ../src/unix/threadpsx.cpp:1061
 msgid "Thread priority setting is ignored."
 msgstr "La configuració de prioritat del fil d'execució és ignorada."
 
-#: ../src/msw/mdi.cpp:176
+#: ../src/msw/mdi.cpp:171
 msgid "Tile &Horizontally"
 msgstr "Mosaic &horitzontal"
 
-#: ../src/msw/mdi.cpp:177
+#: ../src/msw/mdi.cpp:172
 msgid "Tile &Vertically"
 msgstr "Mosaic &vertical"
 
-#: ../src/common/ftp.cpp:200
+#: ../src/common/ftp.cpp:197
 msgid "Timeout while waiting for FTP server to connect, try passive mode."
 msgstr ""
 "S'ha excedit el temps límit d'espera en connectar al servidor FTP, proveu el "
 "mode passiu."
 
-#: ../src/generic/tipdlg.cpp:201
+#: ../src/generic/tipdlg.cpp:198
 msgid "Tip of the Day"
 msgstr "Consell del dia"
 
-#: ../src/generic/tipdlg.cpp:140
+#: ../src/generic/tipdlg.cpp:137
 msgid "Tips not available, sorry!"
 msgstr "Els consells no estan disponibles!"
 
-#: ../src/generic/prntdlgg.cpp:242
+#: ../src/generic/prntdlgg.cpp:235
 msgid "To:"
 msgstr "A:"
 
-#: ../src/richtext/richtextbuffer.cpp:8363
+#: ../src/richtext/richtextbuffer.cpp:8361
 msgid "Too many EndStyle calls!"
 msgstr "Massa crides a EndStyle!"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:891
+#: ../src/propgrid/advprops.cpp:792
 msgid "Tooltip"
 msgstr "Tooltip"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:892
+#: ../src/propgrid/advprops.cpp:793
 msgid "TooltipText"
 msgstr "TooltipText"
 
-#: ../src/richtext/richtextsizepage.cpp:286
-#: ../src/richtext/richtextsizepage.cpp:290 ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197 ../src/richtext/richtextsizepage.cpp:286
+#: ../src/richtext/richtextsizepage.cpp:290
 msgid "Top"
 msgstr "Superior"
 
-#: ../src/generic/prntdlgg.cpp:881
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Top margin (mm):"
 msgstr "Marge superior (mm):"
 
-#: ../src/generic/aboutdlgg.cpp:79
+#: ../src/generic/aboutdlgg.cpp:76
 msgid "Translations by "
 msgstr "Traduccions de "
 
-#: ../src/generic/aboutdlgg.cpp:188
+#: ../src/generic/aboutdlgg.cpp:185
 msgid "Translators"
 msgstr "Traductors"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:211
+#: ../src/propgrid/propgrid.cpp:192
 msgid "True"
 msgstr "Cert"
 
-#: ../src/common/fs_mem.cpp:227
+#: ../src/common/fs_mem.cpp:222
 #, c-format
 msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
 msgstr ""
 "S'està provant de suprimir el fitxer '%s' del VFS en memòria, però no està "
 "carregat!"
 
-#: ../src/common/fmapbase.cpp:156
+#: ../src/common/fmapbase.cpp:153
 msgid "Turkish (ISO-8859-9)"
 msgstr "Turc (ISO-8859-9)"
 
-#: ../src/generic/filectrlg.cpp:426
+#: ../src/generic/filectrlg.cpp:422
 msgid "Type"
 msgstr "Tipus"
 
@@ -7234,17 +7406,17 @@ msgstr "Escriviu un nom de tipus de lletra."
 msgid "Type a size in points."
 msgstr "Escriviu una mida en punts."
 
-#: ../src/msw/ole/automtn.cpp:676
+#: ../src/msw/ole/automtn.cpp:667
 #, c-format
 msgid "Type mismatch in argument %u."
 msgstr "El tipus de l'argument %u no coincideix."
 
-#: ../src/common/xtixml.cpp:356 ../src/common/xtixml.cpp:509
-#: ../src/common/xtistrm.cpp:318
+#: ../src/common/xtixml.cpp:352 ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315
 msgid "Type must have enum - long conversion"
 msgstr "El tipus ha de ser convertir d'enum a long"
 
-#: ../src/propgrid/propgridiface.cpp:401
+#: ../src/propgrid/propgridiface.cpp:385
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
@@ -7253,19 +7425,19 @@ msgstr ""
 "L'operació de tipus \"%s\" ha fallat: La propietat etiquetada \"%s\" és del "
 "tipus \"%s\", NO \"%s\"."
 
-#: ../src/common/paper.cpp:133
+#: ../src/common/paper.cpp:130
 msgid "US Std Fanfold, 14 7/8 x 11 in"
 msgstr "US Std Fanfold, 14 7/8 x 11 polz."
 
-#: ../src/common/fmapbase.cpp:196
+#: ../src/common/fmapbase.cpp:193
 msgid "US-ASCII"
 msgstr "US-ASCII"
 
-#: ../src/unix/fswatcher_inotify.cpp:109
+#: ../src/unix/fswatcher_inotify.cpp:106
 msgid "Unable to add inotify watch"
 msgstr "No s'ha pogut afegir la supervisió inotify"
 
-#: ../src/unix/fswatcher_kqueue.cpp:136
+#: ../src/unix/fswatcher_kqueue.cpp:153
 msgid "Unable to add kqueue watch"
 msgstr "No s'ha pogut afegir la supervisió kqueue"
 
@@ -7277,7 +7449,7 @@ msgstr "No s'ha pogut associar el manegador amb el port de compleció d'E/S"
 msgid "Unable to close I/O completion port handle"
 msgstr "No s'ha pogut tancar el manegador del port de compleció d'E/S"
 
-#: ../src/unix/fswatcher_inotify.cpp:97
+#: ../src/unix/fswatcher_inotify.cpp:94
 msgid "Unable to close inotify instance"
 msgstr "No s'ha pogut tancar la instància d'inotify"
 
@@ -7295,15 +7467,15 @@ msgstr "No s'ha pogut tancar el manegador de '%s'"
 msgid "Unable to create I/O completion port"
 msgstr "No s'ha pogut crear el port de compleció d'E/S"
 
-#: ../src/msw/fswatcher.cpp:84
+#: ../src/msw/fswatcher.cpp:81
 msgid "Unable to create IOCP worker thread"
 msgstr "No s'ha pogut crear el fil d'execució de treballs IOCP"
 
-#: ../src/unix/fswatcher_inotify.cpp:74
+#: ../src/unix/fswatcher_inotify.cpp:71
 msgid "Unable to create inotify instance"
 msgstr "No s'ha pogut crear la instància d'inotify"
 
-#: ../src/unix/fswatcher_kqueue.cpp:97
+#: ../src/unix/fswatcher_kqueue.cpp:114
 msgid "Unable to create kqueue instance"
 msgstr "No s'ha pogut crear la instància de kqueue"
 
@@ -7311,25 +7483,26 @@ msgstr "No s'ha pogut crear la instància de kqueue"
 msgid "Unable to dequeue completion packet"
 msgstr "No s'ha pogut treure de la cua el paquet de compleció"
 
-#: ../src/unix/fswatcher_kqueue.cpp:185
+#: ../src/unix/fswatcher_kqueue.cpp:202
 msgid "Unable to get events from kqueue"
 msgstr "No s'han pogut obtenir els esdeveniments de kqueue"
 
-#: ../src/gtk/app.cpp:435
+#: ../src/gtk/app.cpp:431
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
-msgstr "No s'ha pogut inicialitzar el GTK+, teniu definit correctament DISPLAY?"
+msgstr ""
+"No s'ha pogut inicialitzar el GTK+, teniu definit correctament DISPLAY?"
 
 #: ../include/wx/unix/private/fswatcher_kqueue.h:57
 #, c-format
 msgid "Unable to open path '%s'"
 msgstr "No s'ha pogut obrir el camí '%s'"
 
-#: ../src/html/htmlwin.cpp:583
+#: ../src/html/htmlwin.cpp:586
 #, c-format
 msgid "Unable to open requested HTML document: %s"
 msgstr "No s'ha pogut obrir el document HTML sol·licitat: %s"
 
-#: ../src/unix/sound.cpp:368
+#: ../src/unix/sound.cpp:365
 msgid "Unable to play sound asynchronously."
 msgstr "No s'ha pogut reproduir el so asíncronament."
 
@@ -7337,63 +7510,63 @@ msgstr "No s'ha pogut reproduir el so asíncronament."
 msgid "Unable to post completion status"
 msgstr "No s'ha pogut publicar l'estat de compleció"
 
-#: ../src/unix/fswatcher_inotify.cpp:556
+#: ../src/unix/fswatcher_inotify.cpp:553
 msgid "Unable to read from inotify descriptor"
 msgstr "No s'ha pogut llegir el descriptor inotify"
 
-#: ../src/unix/fswatcher_inotify.cpp:141
+#: ../src/unix/fswatcher_inotify.cpp:138
 #, c-format
 msgid "Unable to remove inotify watch %i"
 msgstr "No s'ha pogut suprimir la supervisió inotify %i"
 
-#: ../src/unix/fswatcher_kqueue.cpp:153
+#: ../src/unix/fswatcher_kqueue.cpp:170
 msgid "Unable to remove kqueue watch"
 msgstr "No s'ha pogut suprimir la supervisió kqueue"
 
-#: ../src/msw/fswatcher.cpp:168
+#: ../src/msw/fswatcher.cpp:165
 #, c-format
 msgid "Unable to set up watch for '%s'"
 msgstr "No s'ha pogut configurar la supervisió de '%s'"
 
-#: ../src/msw/fswatcher.cpp:91
+#: ../src/msw/fswatcher.cpp:88
 msgid "Unable to start IOCP worker thread"
 msgstr "No s'ha pogut iniciar el fil d'execució de treballs IOCP"
 
-#: ../src/common/stockitem.cpp:201
+#: ../src/common/stockitem.cpp:198
 msgid "Undelete"
 msgstr "Desfés la supressió"
 
-#: ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199
 msgid "Underline"
 msgstr "Subratlla"
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/richtext/richtextfontpage.cpp:359 ../src/osx/carbon/fontdlg.cpp:370
-#: ../src/propgrid/advprops.cpp:690
+#: ../src/osx/carbon/fontdlg.cpp:367 ../src/propgrid/advprops.cpp:600
+#: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Subratllat"
 
-#: ../src/common/stockitem.cpp:203 ../src/stc/stc_i18n.cpp:15
+#: ../src/common/stockitem.cpp:200 ../src/stc/stc_i18n.cpp:15
 msgid "Undo"
 msgstr "Desfés"
 
-#: ../src/common/stockitem.cpp:265
+#: ../src/common/stockitem.cpp:263
 msgid "Undo last action"
 msgstr "Desfés la darrera acció"
 
-#: ../src/common/cmdline.cpp:1029
+#: ../src/common/cmdline.cpp:1025
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Hi ha caràcters inesperats després de l'opció '%s'."
 
-#: ../src/unix/fswatcher_inotify.cpp:274
+#: ../src/unix/fswatcher_inotify.cpp:271
 #, c-format
 msgid "Unexpected event for \"%s\": no matching watch descriptor."
 msgstr ""
 "Esdeveniment inesperat per a \"%s\": no hi ha cap descriptor de supervisió "
 "coincident."
 
-#: ../src/common/cmdline.cpp:1195
+#: ../src/common/cmdline.cpp:1191
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Paràmetre inesperat '%s'"
@@ -7402,49 +7575,49 @@ msgstr "Paràmetre inesperat '%s'"
 msgid "Unexpectedly new I/O completion port was created"
 msgstr "S'ha creat un port de compleció d'E/S inesperadament nou"
 
-#: ../src/msw/fswatcher.cpp:70
+#: ../src/msw/fswatcher.cpp:67
 msgid "Ungraceful worker thread termination"
 msgstr "El fil d'execució de treballs ha finalitzat de manera inadequada"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:460
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:456
+#: ../src/richtext/richtextsymboldlg.cpp:457
+#: ../src/richtext/richtextsymboldlg.cpp:458
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../src/common/fmapbase.cpp:185 ../src/common/fmapbase.cpp:191
+#: ../src/common/fmapbase.cpp:182 ../src/common/fmapbase.cpp:188
 msgid "Unicode 16 bit (UTF-16)"
 msgstr "Unicode de 16 bits (UTF-16)"
 
-#: ../src/common/fmapbase.cpp:190
+#: ../src/common/fmapbase.cpp:187
 msgid "Unicode 16 bit Big Endian (UTF-16BE)"
 msgstr "Unicode de 16 bits Big Endian (UTF-16BE)"
 
-#: ../src/common/fmapbase.cpp:186
+#: ../src/common/fmapbase.cpp:183
 msgid "Unicode 16 bit Little Endian (UTF-16LE)"
 msgstr "Unicode de 16 bits Little Endian (UTF-16LE)"
 
-#: ../src/common/fmapbase.cpp:187 ../src/common/fmapbase.cpp:193
+#: ../src/common/fmapbase.cpp:184 ../src/common/fmapbase.cpp:190
 msgid "Unicode 32 bit (UTF-32)"
 msgstr "Unicode de 32 bits (UTF-32)"
 
-#: ../src/common/fmapbase.cpp:192
+#: ../src/common/fmapbase.cpp:189
 msgid "Unicode 32 bit Big Endian (UTF-32BE)"
 msgstr "Unicode de 32 bits Big Endian (UTF-32BE)"
 
-#: ../src/common/fmapbase.cpp:188
+#: ../src/common/fmapbase.cpp:185
 msgid "Unicode 32 bit Little Endian (UTF-32LE)"
 msgstr "Unicode de 32 bits Little Endian (UTF-32LE)"
 
-#: ../src/common/fmapbase.cpp:182
+#: ../src/common/fmapbase.cpp:179
 msgid "Unicode 7 bit (UTF-7)"
 msgstr "Unicode de 7 bits (UTF-7)"
 
-#: ../src/common/fmapbase.cpp:183
+#: ../src/common/fmapbase.cpp:180
 msgid "Unicode 8 bit (UTF-8)"
 msgstr "Unicode de 8 bits (UTF-8)"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "Unindent"
 msgstr "Desfés el sagnat"
 
@@ -7594,97 +7767,102 @@ msgstr "Unitats per a la posició superior."
 msgid "Units for this value."
 msgstr "Unitats per a aquest valor."
 
-#: ../src/generic/progdlgg.cpp:353 ../src/generic/progdlgg.cpp:622
+#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
 msgid "Unknown"
 msgstr "Desconegut"
 
-#: ../src/msw/dde.cpp:1174
+#: ../src/msw/dde.cpp:1238
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Error DDE desconegut %08x"
 
-#: ../src/common/xtistrm.cpp:410
+#: ../src/common/xtistrm.cpp:407
 msgid "Unknown Object passed to GetObjectClassInfo"
 msgstr "S'ha passat un objecte desconegut a GetObjectClassInfo"
 
-#: ../src/common/imagpng.cpp:366
+#: ../src/common/imagpng.cpp:383
 #, c-format
 msgid "Unknown PNG resolution unit %d"
 msgstr "Unitat de resolució PNG desconeguda %d"
 
-#: ../src/common/xtixml.cpp:327
+#: ../src/common/xtixml.cpp:323
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Propietat desconeguda %s"
 
-#: ../src/common/imagtiff.cpp:529
+#: ../src/common/imagtiff.cpp:526
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "S'ha ignorat la unitat de resolució TIFF desconeguda %d"
 
-#: ../src/unix/dlunix.cpp:160
+#: ../src/propgrid/props.cpp:155
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/unix/dlunix.cpp:118
 msgid "Unknown dynamic library error"
 msgstr "S'ha produït un error desconegut de biblioteca dinàmica"
 
-#: ../src/common/fmapbase.cpp:810
+#: ../src/common/fmapbase.cpp:806
 #, c-format
 msgid "Unknown encoding (%d)"
 msgstr "Codificació desconeguda (%d)"
 
-#: ../src/msw/ole/automtn.cpp:688
+#: ../src/msw/ole/automtn.cpp:679
 #, c-format
 msgid "Unknown error %08x"
 msgstr "S'ha produït un error desconegut %08x"
 
-#: ../src/msw/ole/automtn.cpp:647
+#: ../src/msw/ole/automtn.cpp:638
 msgid "Unknown exception"
 msgstr "Excepció desconeguda"
 
-#: ../src/common/image.cpp:2839
+#: ../src/common/image.cpp:2942
 msgid "Unknown image data format."
 msgstr "Format de dades d'imatge desconegut."
 
-#: ../src/common/cmdline.cpp:914
+#: ../src/common/cmdline.cpp:910
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Opció llarga desconeguda '%s'"
 
-#: ../src/msw/ole/automtn.cpp:631
+#: ../src/msw/ole/automtn.cpp:622
 msgid "Unknown name or named argument."
 msgstr "Argument o argument amb nom desconegut."
 
-#: ../src/common/cmdline.cpp:929 ../src/common/cmdline.cpp:951
+#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Opció desconeguda '%s'"
 
-#: ../src/common/mimecmn.cpp:225
+#: ../src/common/mimecmn.cpp:221
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "'{' no tancat en una entrada per a tipus mime %s."
 
-#: ../src/common/cmdproc.cpp:262 ../src/common/cmdproc.cpp:288
-#: ../src/common/cmdproc.cpp:308
+#: ../src/common/cmdproc.cpp:255 ../src/common/cmdproc.cpp:281
+#: ../src/common/cmdproc.cpp:301
 msgid "Unnamed command"
 msgstr "Ordre sense nom"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:413
+#: ../src/propgrid/propgrid.cpp:392
 msgid "Unspecified"
 msgstr "No especificat"
 
-#: ../src/msw/clipbrd.cpp:311
+#: ../src/msw/clipbrd.cpp:325
 msgid "Unsupported clipboard format."
 msgstr "Format de porta-retalls no suportat."
 
-#: ../src/common/appcmn.cpp:256
+#: ../src/common/appcmn.cpp:277
 #, c-format
 msgid "Unsupported theme '%s'."
 msgstr "Tema no suportat '%s'."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:205
-#: ../src/common/accelcmn.cpp:63
+#: ../src/common/stockitem.cpp:202 ../src/common/accelcmn.cpp:60
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Up"
 msgstr "Amunt"
 
@@ -7698,7 +7876,7 @@ msgstr "Lletres majúscules"
 msgid "Upper case roman numerals"
 msgstr "Nombres romans en majúscules"
 
-#: ../src/common/cmdline.cpp:1326
+#: ../src/common/cmdline.cpp:1322
 #, c-format
 msgid "Usage: %s"
 msgstr "Ús: %s"
@@ -7707,38 +7885,47 @@ msgstr "Ús: %s"
 msgid "Use &shadow"
 msgstr "&Utilitza ombra"
 
-#: ../src/richtext/richtextindentspage.cpp:169
-#: ../src/richtext/richtextindentspage.cpp:171
 #: ../src/richtext/richtextliststylepage.cpp:358
 #: ../src/richtext/richtextliststylepage.cpp:360
+#: ../src/richtext/richtextindentspage.cpp:169
+#: ../src/richtext/richtextindentspage.cpp:171
 msgid "Use the current alignment setting."
 msgstr "Utilitza la configuració d'alineació actual."
 
-#: ../src/common/valtext.cpp:179
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/gtk/font.cpp:552
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/common/valtext.cpp:142
 msgid "Validation conflict"
 msgstr "Conflicte de validació"
 
-#: ../src/propgrid/manager.cpp:238
+#: ../src/propgrid/manager.cpp:224
 msgid "Value"
 msgstr "Valor"
 
-#: ../src/propgrid/props.cpp:386 ../src/propgrid/props.cpp:500
+#: ../src/propgrid/props.cpp:309
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "El valor ha de ser més gran o igual que %s."
 
-#: ../src/propgrid/props.cpp:417 ../src/propgrid/props.cpp:531
+#: ../src/propgrid/props.cpp:336
 #, c-format
 msgid "Value must be %s or less."
 msgstr "El valor ha de ser més petit o igual que %s."
 
-#: ../src/propgrid/props.cpp:393 ../src/propgrid/props.cpp:424
-#: ../src/propgrid/props.cpp:507 ../src/propgrid/props.cpp:538
+#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "El valor ha de ser entre %s i %s."
 
-#: ../src/generic/aboutdlgg.cpp:128
+#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Versió "
 
@@ -7747,25 +7934,32 @@ msgstr "Versió "
 msgid "Vertical alignment."
 msgstr "Alineació vertical."
 
-#: ../src/generic/filedlgg.cpp:202
+#: ../src/generic/filedlgg.cpp:199
 msgid "View files as a detailed view"
 msgstr "Mostra els fitxers en visualització detallada"
 
-#: ../src/generic/filedlgg.cpp:200
+#: ../src/generic/filedlgg.cpp:197
 msgid "View files as a list view"
 msgstr "Mostra els fitxers en visualització de llista"
 
-#: ../src/common/docview.cpp:1970
+#: ../src/common/docview.cpp:1975
 msgid "Views"
 msgstr "Visualitzacions"
 
+#: ../src/gtk/app.cpp:348
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1777
+#: ../src/propgrid/advprops.cpp:1678
 msgid "Wait"
 msgstr "Espera"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1779
+#: ../src/propgrid/advprops.cpp:1680
 msgid "Wait Arrow"
 msgstr "Fletxa d'espera"
 
@@ -7774,237 +7968,234 @@ msgstr "Fletxa d'espera"
 msgid "Waiting for IO on epoll descriptor %d failed"
 msgstr "S'ha produït un error mentre s'esperava l'E/S del descriptor epoll %d"
 
-#: ../src/common/log.cpp:223
+#: ../src/common/log.cpp:241
 msgid "Warning: "
 msgstr "Advertència: "
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1778
+#: ../src/propgrid/advprops.cpp:1679
 msgid "Watch"
 msgstr "Rellotge"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:685
+#: ../src/propgrid/advprops.cpp:595
 msgid "Weight"
 msgstr "Pes"
 
-#: ../src/common/fmapbase.cpp:148
+#: ../src/common/fmapbase.cpp:145
 msgid "Western European (ISO-8859-1)"
 msgstr "Europa occidental (ISO-8859-1)"
 
-#: ../src/common/fmapbase.cpp:162
+#: ../src/common/fmapbase.cpp:159
 msgid "Western European with Euro (ISO-8859-15)"
 msgstr "Europa occidental amb euro (ISO-8859-15)"
 
-#: ../src/generic/fontdlgg.cpp:446 ../src/generic/fontdlgg.cpp:448
+#: ../src/generic/fontdlgg.cpp:443 ../src/generic/fontdlgg.cpp:445
 msgid "Whether the font is underlined."
 msgstr "Si el tipus de lletra està subratllada."
 
-#: ../src/propgrid/advprops.cpp:1611
+#: ../src/propgrid/advprops.cpp:1517
 msgid "White"
 msgstr "Blanc"
 
-#: ../src/generic/fdrepdlg.cpp:144
+#: ../src/generic/fdrepdlg.cpp:141
 msgid "Whole word"
 msgstr "Paraula sencera"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:532
 msgid "Whole words only"
 msgstr "Només paraules senceres"
 
-#: ../src/univ/themes/win32.cpp:1102
+#: ../src/univ/themes/win32.cpp:1099
 msgid "Win32 theme"
 msgstr "Tema Win32"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:893
+#: ../src/propgrid/advprops.cpp:794
 msgid "Window"
 msgstr "Window"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:894
+#: ../src/propgrid/advprops.cpp:795
 msgid "WindowFrame"
 msgstr "WindowFrame"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:895
+#: ../src/propgrid/advprops.cpp:796
 msgid "WindowText"
 msgstr "WindowText"
 
-#: ../src/common/fmapbase.cpp:177
+#: ../src/common/fmapbase.cpp:174
 msgid "Windows Arabic (CP 1256)"
 msgstr "Àrab del Windows (CP 1256)"
 
-#: ../src/common/fmapbase.cpp:178
+#: ../src/common/fmapbase.cpp:175
 msgid "Windows Baltic (CP 1257)"
 msgstr "Bàltic del Windows (CP 1257)"
 
-#: ../src/common/fmapbase.cpp:171
+#: ../src/common/fmapbase.cpp:168
 msgid "Windows Central European (CP 1250)"
 msgstr "Europa central del Windows (CP 1250)"
 
-#: ../src/common/fmapbase.cpp:168
+#: ../src/common/fmapbase.cpp:165
 msgid "Windows Chinese Simplified (CP 936) or GB-2312"
 msgstr "Xinès simplificat del Windows (CP 936) o GB-2312"
 
-#: ../src/common/fmapbase.cpp:170
+#: ../src/common/fmapbase.cpp:167
 msgid "Windows Chinese Traditional (CP 950) or Big-5"
 msgstr "Xinès tradicional del Windows (CP 950) o Big-5"
 
-#: ../src/common/fmapbase.cpp:172
+#: ../src/common/fmapbase.cpp:169
 msgid "Windows Cyrillic (CP 1251)"
 msgstr "Ciríl·lic del Windows (CP 1251)"
 
-#: ../src/common/fmapbase.cpp:174
+#: ../src/common/fmapbase.cpp:171
 msgid "Windows Greek (CP 1253)"
 msgstr "Grec del Windows (CP 1253)"
 
-#: ../src/common/fmapbase.cpp:176
+#: ../src/common/fmapbase.cpp:173
 msgid "Windows Hebrew (CP 1255)"
 msgstr "Hebreu del Windows (CP 1255)"
 
-#: ../src/common/fmapbase.cpp:167
+#: ../src/common/fmapbase.cpp:164
 msgid "Windows Japanese (CP 932) or Shift-JIS"
 msgstr "Japonès del Windows (CP 932) o Shift-JIS"
 
-#: ../src/common/fmapbase.cpp:180
+#: ../src/common/fmapbase.cpp:177
 msgid "Windows Johab (CP 1361)"
 msgstr "Johab del Windows (CP 1361)"
 
-#: ../src/common/fmapbase.cpp:169
+#: ../src/common/fmapbase.cpp:166
 msgid "Windows Korean (CP 949)"
 msgstr "Coreà del Windows (CP 949)"
 
-#: ../src/common/fmapbase.cpp:166
+#: ../src/common/fmapbase.cpp:163
 msgid "Windows Thai (CP 874)"
 msgstr "Tailandès del Windows (CP 874)"
 
-#: ../src/common/fmapbase.cpp:175
+#: ../src/common/fmapbase.cpp:172
 msgid "Windows Turkish (CP 1254)"
 msgstr "Turc del Windows (CP 1254)"
 
-#: ../src/common/fmapbase.cpp:179
+#: ../src/common/fmapbase.cpp:176
 msgid "Windows Vietnamese (CP 1258)"
 msgstr "Vietnamita del Windows (CP 1258)"
 
-#: ../src/common/fmapbase.cpp:173
+#: ../src/common/fmapbase.cpp:170
 msgid "Windows Western European (CP 1252)"
 msgstr "Europa occidental del Windows (CP 1252)"
 
-#: ../src/common/fmapbase.cpp:181
+#: ../src/common/fmapbase.cpp:178
 msgid "Windows/DOS OEM (CP 437)"
 msgstr "OEM del Windows/DOS (CP 437)"
 
-#: ../src/common/fmapbase.cpp:165
+#: ../src/common/fmapbase.cpp:162
 msgid "Windows/DOS OEM Cyrillic (CP 866)"
 msgstr "Ciríl·lic OEM del Windows/DOS (CP 866)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:111
+#: ../src/common/accelcmn.cpp:109
 msgid "Windows_Left"
 msgstr "Windows (esquerra)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:113
+#: ../src/common/accelcmn.cpp:111
 msgid "Windows_Menu"
 msgstr "Windows (menú)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:112
+#: ../src/common/accelcmn.cpp:110
 msgid "Windows_Right"
 msgstr "Windows (dreta)"
 
-#: ../src/common/ffile.cpp:150
+#: ../src/common/ffile.cpp:149
 #, c-format
 msgid "Write error on file '%s'"
 msgstr "S'ha produït un error en escriure al fitxer '%s'"
 
-#: ../src/xml/xml.cpp:914
+#: ../src/xml/xml.cpp:925
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "S'ha produït un error d'anàlisi XML: '%s' a la línia %d"
 
-#: ../src/common/xpmdecod.cpp:796
+#: ../src/common/xpmdecod.cpp:794
 msgid "XPM: Malformed pixel data!"
 msgstr "XPM: Dades de píxel incorrectes!"
 
-#: ../src/common/xpmdecod.cpp:705
+#: ../src/common/xpmdecod.cpp:702
 #, c-format
 msgid "XPM: incorrect colour description in line %d"
 msgstr "XPM: descripció del color incorrecta a la línia %d"
 
-#: ../src/common/xpmdecod.cpp:680
+#: ../src/common/xpmdecod.cpp:677
 msgid "XPM: incorrect header format!"
 msgstr "XPM: format de la capçalera incorrecte!"
 
-#: ../src/common/xpmdecod.cpp:716 ../src/common/xpmdecod.cpp:725
+#: ../src/common/xpmdecod.cpp:714 ../src/common/xpmdecod.cpp:723
 #, c-format
 msgid "XPM: malformed colour definition '%s' at line %d!"
 msgstr "XPM: definició del color incorrecta '%s' a la línia %d!"
 
-#: ../src/common/xpmdecod.cpp:755
+#: ../src/common/xpmdecod.cpp:753
 msgid "XPM: no colors left to use for mask!"
 msgstr "XPM: no resten colors per a utilitzar per a la màscara!"
 
-#: ../src/common/xpmdecod.cpp:782
+#: ../src/common/xpmdecod.cpp:780
 #, c-format
 msgid "XPM: truncated image data at line %d!"
 msgstr "XPM: dades de la imatge truncades a la línia %d!"
 
-#: ../src/propgrid/advprops.cpp:1610
+#: ../src/propgrid/advprops.cpp:1516
 msgid "Yellow"
 msgstr "Groc"
 
-#: ../include/wx/msgdlg.h:276 ../src/common/stockitem.cpp:206
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:203
 #: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Sí"
 
-#: ../src/osx/carbon/overlay.cpp:155
-msgid "You cannot Clear an overlay that is not inited"
-msgstr "No podeu netejar una superposició que no s'ha inicialitzat"
-
-#: ../src/osx/carbon/overlay.cpp:107 ../src/dfb/overlay.cpp:61
-msgid "You cannot Init an overlay twice"
-msgstr "No podeu inicialitzar una superposició dues vegades"
-
-#: ../src/generic/dirdlgg.cpp:287
+#: ../src/generic/dirdlgg.cpp:284
 msgid "You cannot add a new directory to this section."
 msgstr "No podeu afegir un directori nou a aquesta secció."
 
-#: ../src/propgrid/propgrid.cpp:3299
+#: ../src/propgrid/propgrid.cpp:3276
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr "Heu introduït un valor invàlid. Premeu Esc per a cancel·lar l'edició."
 
-#: ../src/common/stockitem.cpp:209
+#: ../src/osx/cocoa/menu.mm:286
+#, fuzzy
+msgid "Zoom"
+msgstr "Amplia"
+
+#: ../src/common/stockitem.cpp:206
 msgid "Zoom &In"
 msgstr "Ampl&ia"
 
-#: ../src/common/stockitem.cpp:210
+#: ../src/common/stockitem.cpp:207
 msgid "Zoom &Out"
 msgstr "All&unya"
 
-#: ../src/common/stockitem.cpp:209 ../src/common/prntbase.cpp:1594
+#: ../src/common/stockitem.cpp:206 ../src/common/prntbase.cpp:1619
 msgid "Zoom In"
 msgstr "Amplia"
 
-#: ../src/common/stockitem.cpp:210 ../src/common/prntbase.cpp:1580
+#: ../src/common/stockitem.cpp:207 ../src/common/prntbase.cpp:1605
 msgid "Zoom Out"
 msgstr "Allunya"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to &Fit"
 msgstr "Amplia &fins a ajustar"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to Fit"
 msgstr "Amplia fins a ajustar"
 
-#: ../src/msw/dde.cpp:1141
+#: ../src/msw/dde.cpp:1205
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "una aplicació DDEML ha creat una situació de competició prolongada."
 
-#: ../src/msw/dde.cpp:1129
+#: ../src/msw/dde.cpp:1193
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -8015,49 +8206,49 @@ msgstr ""
 "o s'ha passat un identificador d'instància invàlid\n"
 "a una funció DDEML."
 
-#: ../src/msw/dde.cpp:1147
+#: ../src/msw/dde.cpp:1211
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "un client no ha pogut establir una conversa."
 
-#: ../src/msw/dde.cpp:1144
+#: ../src/msw/dde.cpp:1208
 msgid "a memory allocation failed."
 msgstr "no s'ha pogut fer una assignació de memòria."
 
-#: ../src/msw/dde.cpp:1138
+#: ../src/msw/dde.cpp:1202
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "el DDEML no ha pogut validar un paràmetre."
 
-#: ../src/msw/dde.cpp:1120
+#: ../src/msw/dde.cpp:1184
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr ""
 "s'ha excedit el temps límit d'una sol·licitud per a una transacció d'avís "
 "síncrona."
 
-#: ../src/msw/dde.cpp:1126
+#: ../src/msw/dde.cpp:1190
 msgid "a request for a synchronous data transaction has timed out."
 msgstr ""
 "s'ha excedit el temps límit d'una sol·licitud per a una transacció de dades "
 "síncrona."
 
-#: ../src/msw/dde.cpp:1135
+#: ../src/msw/dde.cpp:1199
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr ""
 "s'ha excedit el temps límit d'una sol·licitud per a una transacció "
 "d'execució síncrona."
 
-#: ../src/msw/dde.cpp:1153
+#: ../src/msw/dde.cpp:1217
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr ""
 "s'ha excedit el temps límit d'una sol·licitud per a una transacció poke "
 "síncrona."
 
-#: ../src/msw/dde.cpp:1168
+#: ../src/msw/dde.cpp:1232
 msgid "a request to end an advise transaction has timed out."
 msgstr ""
 "s'ha excedit el temps límit d'una sol·licitud per a finalitzar una "
 "transacció d'avís."
 
-#: ../src/msw/dde.cpp:1162
+#: ../src/msw/dde.cpp:1226
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -8067,15 +8258,15 @@ msgstr ""
 "que ha estat finalitzada pel client, o el servidor\n"
 "ha finalitzat abans de completar una transacció."
 
-#: ../src/msw/dde.cpp:1150
+#: ../src/msw/dde.cpp:1214
 msgid "a transaction failed."
 msgstr "no s'ha pogut executar una transacció."
 
-#: ../src/common/accelcmn.cpp:189
+#: ../src/common/accelcmn.cpp:188
 msgid "alt"
 msgstr "alt"
 
-#: ../src/msw/dde.cpp:1132
+#: ../src/msw/dde.cpp:1196
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -8087,15 +8278,15 @@ msgstr ""
 "o bé una aplicació inicialitzada com a APPCMD_CLIENTONLY ha \n"
 "provat d'executar transaccions de servidor."
 
-#: ../src/msw/dde.cpp:1156
+#: ../src/msw/dde.cpp:1220
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "ha fallat una crida interna a la funció PostMessage. "
 
-#: ../src/msw/dde.cpp:1165
+#: ../src/msw/dde.cpp:1229
 msgid "an internal error has occurred in the DDEML."
 msgstr "s'ha produït un error intern al DDEML."
 
-#: ../src/msw/dde.cpp:1171
+#: ../src/msw/dde.cpp:1235
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -8105,56 +8296,56 @@ msgstr ""
 "Un cop que l'aplicació ha retornat d'una crida XTYP_XACT_COMPLETE, \n"
 "l'identificador de transacció d'aquesta crida ja no és vàlid."
 
-#: ../src/common/zipstrm.cpp:1483
+#: ../src/common/zipstrm.cpp:1522
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "s'assumeix que això és un zip multipart concatenat"
 
-#: ../src/common/fileconf.cpp:1847
+#: ../src/common/fileconf.cpp:1849
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "s'ha ignorat l'intent de canviar la clau immutable '%s'."
 
-#: ../src/html/chm.cpp:329
+#: ../src/html/chm.cpp:326
 msgid "bad arguments to library function"
 msgstr "arguments erronis per a una funció de la biblioteca"
 
-#: ../src/html/chm.cpp:341
+#: ../src/html/chm.cpp:338
 msgid "bad signature"
 msgstr "signatura errònia"
 
-#: ../src/common/zipstrm.cpp:1918
+#: ../src/common/zipstrm.cpp:1988
 msgid "bad zipfile offset to entry"
 msgstr "desplaçament a l'entrada del fitxer zip erroni"
 
-#: ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400
 msgid "binary"
 msgstr "binari"
 
-#: ../src/common/fontcmn.cpp:996
+#: ../src/common/fontcmn.cpp:1195
 msgid "bold"
 msgstr "negreta"
 
-#: ../src/msw/utils.cpp:1144
+#: ../src/msw/utils.cpp:1135
 #, c-format
 msgid "build %lu"
 msgstr "compilació %lu"
 
-#: ../src/common/ffile.cpp:75
+#: ../src/common/ffile.cpp:73
 #, c-format
 msgid "can't close file '%s'"
 msgstr "no es pot tancar el fitxer '%s'"
 
-#: ../src/common/file.cpp:245
+#: ../src/common/file.cpp:242
 #, c-format
 msgid "can't close file descriptor %d"
 msgstr "no es pot tancar el descriptor de fitxer %d"
 
-#: ../src/common/file.cpp:586
+#: ../src/common/ffile.cpp:382 ../src/common/file.cpp:613
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "no es poden publicar els canvis al fitxer '%s'"
 
-#: ../src/common/file.cpp:178
+#: ../src/common/file.cpp:175
 #, c-format
 msgid "can't create file '%s'"
 msgstr "no es pot crear el fitxer '%s'"
@@ -8164,51 +8355,51 @@ msgstr "no es pot crear el fitxer '%s'"
 msgid "can't delete user configuration file '%s'"
 msgstr "no es pot suprimir el fitxer de configuració de l'usuari '%s'"
 
-#: ../src/common/file.cpp:495
+#: ../src/common/file.cpp:522
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr ""
 "no es pot determinar si s'ha arribat al final del fitxer al descriptor %d"
 
-#: ../src/common/zipstrm.cpp:1692
+#: ../src/common/zipstrm.cpp:1747
 msgid "can't find central directory in zip"
 msgstr "no es pot trobar el directori central al zip"
 
-#: ../src/common/file.cpp:465
+#: ../src/common/file.cpp:492
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "no es pot trobar la llargada del fitxer al descriptor del fitxer %d"
 
-#: ../src/msw/utils.cpp:341
+#: ../src/msw/utils.cpp:336
 msgid "can't find user's HOME, using current directory."
 msgstr ""
 "no es pot trobar el directori de l'usuari, s'utilitzarà el directori actual."
 
-#: ../src/common/file.cpp:366
+#: ../src/common/file.cpp:407
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "no es pot buidar el descriptor del fitxer %d"
 
-#: ../src/common/file.cpp:422
+#: ../src/common/file.cpp:463
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "no es pot cercar la posició al descriptor de fitxer %d"
 
-#: ../src/common/fontmap.cpp:325
+#: ../src/common/fontmap.cpp:322
 msgid "can't load any font, aborting"
 msgstr "no es pot carregar cap tipus de lletra, s'avorta"
 
-#: ../src/common/file.cpp:231 ../src/common/ffile.cpp:59
+#: ../src/common/ffile.cpp:57 ../src/common/file.cpp:228
 #, c-format
 msgid "can't open file '%s'"
 msgstr "no es pot obrir el fitxer '%s'"
 
-#: ../src/common/fileconf.cpp:320
+#: ../src/common/fileconf.cpp:314
 #, c-format
 msgid "can't open global configuration file '%s'."
 msgstr "no es pot obrir el fitxer de configuració global '%s'."
 
-#: ../src/common/fileconf.cpp:336
+#: ../src/common/fileconf.cpp:330
 #, c-format
 msgid "can't open user configuration file '%s'."
 msgstr "no es pot obrir el fitxer de configuració de l'usuari '%s'."
@@ -8217,40 +8408,40 @@ msgstr "no es pot obrir el fitxer de configuració de l'usuari '%s'."
 msgid "can't open user configuration file."
 msgstr "no es pot obrir el fitxer de configuració de l'usuari."
 
-#: ../src/common/zipstrm.cpp:579
+#: ../src/common/zipstrm.cpp:572
 msgid "can't re-initialize zlib deflate stream"
 msgstr "no es pot reinicialitzar el flux de deflació de zlib"
 
-#: ../src/common/zipstrm.cpp:604
+#: ../src/common/zipstrm.cpp:597
 msgid "can't re-initialize zlib inflate stream"
 msgstr "no es pot reinicialitzar el flux d'inflació de zlib"
 
-#: ../src/common/file.cpp:304
+#: ../src/common/file.cpp:345
 #, c-format
 msgid "can't read from file descriptor %d"
 msgstr "no es pot llegir del descriptor de fitxer %d"
 
-#: ../src/common/file.cpp:581
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:608
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "no es pot suprimir el fitxer '%s'"
 
-#: ../src/common/file.cpp:598
+#: ../src/common/ffile.cpp:394 ../src/common/file.cpp:625
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "no es pot suprimir el fitxer temporal '%s'"
 
-#: ../src/common/file.cpp:408
+#: ../src/common/file.cpp:449
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "no es pot cercar el descriptor de fitxer %d"
 
-#: ../src/common/textfile.cpp:273
+#: ../src/common/textfile.cpp:161
 #, c-format
 msgid "can't write buffer '%s' to disk."
 msgstr "no es pot escriure la memòria intermèdia '%s' al disc."
 
-#: ../src/common/file.cpp:323
+#: ../src/common/file.cpp:364
 #, c-format
 msgid "can't write to file descriptor %d"
 msgstr "no es pot escriure al descriptor de fitxer %d"
@@ -8260,23 +8451,29 @@ msgid "can't write user configuration file."
 msgstr "no es pot escriure al fitxer de configuració de l'usuari."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:482 ../src/generic/datavgen.cpp:1261
+#: ../src/common/datavcmn.cpp:2064 ../src/generic/datavgen.cpp:1384
 msgid "checked"
 msgstr "marcat"
 
-#: ../src/html/chm.cpp:345
+#: ../src/html/chm.cpp:342
 msgid "checksum error"
 msgstr "s'ha produït un error de suma de verificació"
 
-#: ../src/common/tarstrm.cpp:820
+#: ../src/common/tarstrm.cpp:814
 msgid "checksum failure reading tar header block"
 msgstr ""
 "ha fallat la suma de verificació en llegir el bloc de la capçalera de tar"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:226
-#: ../src/richtext/richtextbackgroundpage.cpp:249
-#: ../src/richtext/richtextbackgroundpage.cpp:289
-#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
 #: ../src/richtext/richtextborderspage.cpp:254
 #: ../src/richtext/richtextborderspage.cpp:288
 #: ../src/richtext/richtextborderspage.cpp:322
@@ -8294,105 +8491,129 @@ msgstr ""
 #: ../src/richtext/richtextmarginspage.cpp:340
 #: ../src/richtext/richtextmarginspage.cpp:363
 #: ../src/richtext/richtextmarginspage.cpp:388
-#: ../src/richtext/richtextsizepage.cpp:339
-#: ../src/richtext/richtextsizepage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:400
-#: ../src/richtext/richtextsizepage.cpp:427
-#: ../src/richtext/richtextsizepage.cpp:454
-#: ../src/richtext/richtextsizepage.cpp:481
-#: ../src/richtext/richtextsizepage.cpp:555
-#: ../src/richtext/richtextsizepage.cpp:590
-#: ../src/richtext/richtextsizepage.cpp:625
-#: ../src/richtext/richtextsizepage.cpp:660
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
 msgid "cm"
 msgstr "cm"
 
-#: ../src/html/chm.cpp:347
+#: ../src/html/chm.cpp:344
 msgid "compression error"
 msgstr "s'ha produït un error de compressió"
 
-#: ../src/common/regex.cpp:236
+#: ../src/common/regex.cpp:233
 msgid "conversion to 8-bit encoding failed"
 msgstr "no s'ha pogut fer la conversió a una codificació de 8 bits"
 
-#: ../src/common/accelcmn.cpp:187
+#: ../src/common/accelcmn.cpp:186
 msgid "ctrl"
 msgstr "ctrl"
 
-#: ../src/common/cmdline.cpp:1500
+#: ../src/common/cmdline.cpp:1496
 msgid "date"
 msgstr "data"
 
-#: ../src/html/chm.cpp:349
+#: ../src/html/chm.cpp:346
 msgid "decompression error"
 msgstr "s'ha produït un error de descompressió"
 
-#: ../src/richtext/richtextstyles.cpp:780 ../src/common/fmapbase.cpp:820
+#: ../src/common/fmapbase.cpp:816 ../src/richtext/richtextstyles.cpp:777
 msgid "default"
 msgstr "per defecte"
 
-#: ../src/common/cmdline.cpp:1496
+#: ../src/common/cmdline.cpp:1492
 msgid "double"
 msgstr "doble"
 
-#: ../src/common/debugrpt.cpp:538
+#: ../src/common/debugrpt.cpp:539
 msgid "dump of the process state (binary)"
 msgstr "bolcat de l'estat del procés (binari)"
 
-#: ../src/common/datetimefmt.cpp:1969
+#: ../src/common/datetimefmt.cpp:1992
 msgid "eighteenth"
 msgstr "divuitè"
 
-#: ../src/common/datetimefmt.cpp:1959
+#: ../src/common/datetimefmt.cpp:1982
 msgid "eighth"
 msgstr "vuitè"
 
-#: ../src/common/datetimefmt.cpp:1962
+#: ../src/common/datetimefmt.cpp:1985
 msgid "eleventh"
 msgstr "onzè"
 
-#: ../src/common/fileconf.cpp:1833
+#: ../src/common/fileconf.cpp:1835
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "l'entrada '%s' apareix més d'un cop al grup '%s'"
 
-#: ../src/html/chm.cpp:343
+#: ../src/html/chm.cpp:340
 msgid "error in data format"
 msgstr "error al format de dades"
 
-#: ../src/html/chm.cpp:331
+#: ../src/html/chm.cpp:328
 msgid "error opening file"
 msgstr "s'ha produït un error en obrir el fitxer"
 
-#: ../src/common/zipstrm.cpp:1778
+#: ../src/common/zipstrm.cpp:1836
 msgid "error reading zip central directory"
 msgstr "s'ha produït un error en llegir el directori central del zip"
 
-#: ../src/common/zipstrm.cpp:1870
+#: ../src/common/zipstrm.cpp:1940
 msgid "error reading zip local header"
 msgstr "s'ha produït un error en llegir la capçalera local del zip"
 
-#: ../src/common/zipstrm.cpp:2531
+#: ../src/common/zipstrm.cpp:2615
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr ""
 "s'ha produït un error en escriure l'entrada zip '%s': crc o longitud invàlids"
 
-#: ../src/common/ffile.cpp:188
+#: ../src/common/zipstrm.cpp:2608
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr ""
+"s'ha produït un error en escriure l'entrada zip '%s': crc o longitud invàlids"
+
+#: ../src/common/fontcmn.cpp:1205
+#, fuzzy
+msgid "extrabold"
+msgstr "negreta"
+
+#: ../src/common/fontcmn.cpp:1223
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1167
+#, fuzzy
+msgid "extralight"
+msgstr "prima"
+
+#: ../src/msw/webview_ie.cpp:1036
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "No s'ha pogut executar '%s'\n"
+
+#: ../src/common/ffile.cpp:187
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "no s'ha pogut buidar el fitxer '%s'"
 
+#: ../src/msw/webview_ie.cpp:1045
+#, fuzzy
+msgid "failed to retrieve execution result"
+msgstr "No s'ha pogut recuperar el text del missatge d'error del RAS"
+
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1030
+#: ../src/generic/datavgen.cpp:1150
 msgid "false"
 msgstr "fals"
 
-#: ../src/common/datetimefmt.cpp:1966
+#: ../src/common/datetimefmt.cpp:1989
 msgid "fifteenth"
 msgstr "quinzè"
 
-#: ../src/common/datetimefmt.cpp:1956
+#: ../src/common/datetimefmt.cpp:1979
 msgid "fifth"
 msgstr "cinquè"
 
@@ -8425,133 +8646,152 @@ msgstr ""
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "fiitxer '%s': caràcter inesperat %c a la línia %zu."
 
-#: ../src/richtext/richtextbuffer.cpp:8738
+#: ../src/richtext/richtextbuffer.cpp:8736
 msgid "files"
 msgstr "fitxers"
 
-#: ../src/common/datetimefmt.cpp:1952
+#: ../src/common/datetimefmt.cpp:1975
 msgid "first"
 msgstr "primer"
 
-#: ../src/html/helpwnd.cpp:1252
+#: ../src/html/helpwnd.cpp:1250
 msgid "font size"
 msgstr "mida del tipus de lletra"
 
-#: ../src/common/datetimefmt.cpp:1965
+#: ../src/common/datetimefmt.cpp:1988
 msgid "fourteenth"
 msgstr "catorzè"
 
-#: ../src/common/datetimefmt.cpp:1955
+#: ../src/common/datetimefmt.cpp:1978
 msgid "fourth"
 msgstr "quart"
 
-#: ../src/common/appbase.cpp:783
+#: ../src/common/appbase.cpp:784
 msgid "generate verbose log messages"
 msgstr "genera missatges de registre detallats"
 
-#: ../src/richtext/richtextbuffer.cpp:13138
-#: ../src/richtext/richtextbuffer.cpp:13248
+#: ../src/common/fontcmn.cpp:1215
+msgid "heavy"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:13133
+#: ../src/richtext/richtextbuffer.cpp:13243
 msgid "image"
 msgstr "imatge"
 
-#: ../src/common/tarstrm.cpp:796
+#: ../src/common/tarstrm.cpp:790
 msgid "incomplete header block in tar"
 msgstr "bloc de capçalera incomplet al tar"
 
-#: ../src/common/xtixml.cpp:489
+#: ../src/common/xtixml.cpp:485
 msgid "incorrect event handler string, missing dot"
 msgstr "cadena de manegador d'esdeveniment incorrecte, hi manca un punt"
 
-#: ../src/common/tarstrm.cpp:1381
+#: ../src/common/tarstrm.cpp:1375
 msgid "incorrect size given for tar entry"
 msgstr "s'ha proporcionat una mida incorrecta per a una entrada del tar"
 
-#: ../src/common/tarstrm.cpp:993
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:987
 msgid "invalid data in extended tar header"
 msgstr "dades invàlides a la capçalera estesa del tar"
 
-#: ../src/generic/logg.cpp:1030
+#: ../src/generic/logg.cpp:1027
 msgid "invalid message box return value"
 msgstr "valor de retorn de la capsa de missatges invàlid"
 
-#: ../src/common/zipstrm.cpp:1647
+#: ../src/common/zipstrm.cpp:1688
 msgid "invalid zip file"
 msgstr "fitxer zip invàlid"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:1228
 msgid "italic"
 msgstr "cursiva"
 
-#: ../src/common/fontcmn.cpp:991
+#: ../src/common/webrequest_curl.cpp:374
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "No s'ha pogut carregar el fitxer."
+
+#: ../src/common/fontcmn.cpp:1172
 msgid "light"
 msgstr "prima"
 
-#: ../src/common/intl.cpp:303
-#, c-format
-msgid "locale '%s' cannot be set."
-msgstr "no es pot definir la configuració local '%s'."
+#: ../src/common/fontcmn.cpp:1185
+msgid "medium"
+msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2125
+#: ../src/common/datetimefmt.cpp:2148
 msgid "midnight"
 msgstr "mitjanit"
 
-#: ../src/common/datetimefmt.cpp:1970
+#: ../src/common/datetimefmt.cpp:1993
 msgid "nineteenth"
 msgstr "dinovè"
 
-#: ../src/common/datetimefmt.cpp:1960
+#: ../src/common/datetimefmt.cpp:1983
 msgid "ninth"
 msgstr "novè"
 
-#: ../src/msw/dde.cpp:1116
+#: ../src/msw/dde.cpp:1180
 msgid "no DDE error."
 msgstr "no hi ha cap error DDE."
 
-#: ../src/html/chm.cpp:327
+#: ../src/html/chm.cpp:324
 msgid "no error"
 msgstr "no hi ha cap error"
 
-#: ../src/dfb/fontmgr.cpp:174
+#: ../src/dfb/fontmgr.cpp:171
 #, c-format
 msgid "no fonts found in %s, using builtin font"
 msgstr ""
 "no s'ha trobat cap tipus de lletra a %s, es farà servir el tipus de lletra "
 "integrat"
 
-#: ../src/html/helpdata.cpp:657
+#: ../src/html/helpdata.cpp:650
 msgid "noname"
 msgstr "sense nom"
 
-#: ../src/common/datetimefmt.cpp:2124
+#: ../src/common/datetimefmt.cpp:2147
 msgid "noon"
 msgstr "migdia"
 
-#: ../src/richtext/richtextstyles.cpp:779
+#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "normal"
 
-#: ../src/common/cmdline.cpp:1492
+#: ../src/common/cmdline.cpp:1488
 msgid "num"
 msgstr "núm."
 
-#: ../src/common/xtixml.cpp:259
+#: ../src/common/accelcmn.cpp:194
+msgid "num "
+msgstr ""
+
+#: ../src/common/xtixml.cpp:255
 msgid "objects cannot have XML Text Nodes"
 msgstr "els objectes no poden tenir nodes XML de text"
 
-#: ../src/html/chm.cpp:339
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
 msgid "out of memory"
 msgstr "s'ha esgotat la memòria"
 
-#: ../src/common/debugrpt.cpp:514
+#: ../src/common/debugrpt.cpp:515
 msgid "process context description"
 msgstr "descripció del context del procés"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:227
-#: ../src/richtext/richtextbackgroundpage.cpp:250
-#: ../src/richtext/richtextbackgroundpage.cpp:290
-#: ../src/richtext/richtextbackgroundpage.cpp:317
-#: ../src/richtext/richtextfontpage.cpp:177
-#: ../src/richtext/richtextfontpage.cpp:180
 #: ../src/richtext/richtextborderspage.cpp:255
 #: ../src/richtext/richtextborderspage.cpp:289
 #: ../src/richtext/richtextborderspage.cpp:323
@@ -8561,22 +8801,45 @@ msgstr "descripció del context del procés"
 #: ../src/richtext/richtextborderspage.cpp:491
 #: ../src/richtext/richtextborderspage.cpp:525
 #: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextfontpage.cpp:180
 msgid "pt"
 msgstr "pt"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:225
-#: ../src/richtext/richtextbackgroundpage.cpp:228
-#: ../src/richtext/richtextbackgroundpage.cpp:229
-#: ../src/richtext/richtextbackgroundpage.cpp:248
-#: ../src/richtext/richtextbackgroundpage.cpp:251
-#: ../src/richtext/richtextbackgroundpage.cpp:252
-#: ../src/richtext/richtextbackgroundpage.cpp:288
-#: ../src/richtext/richtextbackgroundpage.cpp:291
-#: ../src/richtext/richtextbackgroundpage.cpp:292
-#: ../src/richtext/richtextbackgroundpage.cpp:315
-#: ../src/richtext/richtextbackgroundpage.cpp:318
-#: ../src/richtext/richtextbackgroundpage.cpp:319
-#: ../src/richtext/richtextfontpage.cpp:178
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:659
+#: ../src/richtext/richtextsizepage.cpp:662
+#: ../src/richtext/richtextsizepage.cpp:663
 #: ../src/richtext/richtextborderspage.cpp:253
 #: ../src/richtext/richtextborderspage.cpp:256
 #: ../src/richtext/richtextborderspage.cpp:257
@@ -8628,260 +8891,270 @@ msgstr "pt"
 #: ../src/richtext/richtextmarginspage.cpp:387
 #: ../src/richtext/richtextmarginspage.cpp:389
 #: ../src/richtext/richtextmarginspage.cpp:390
-#: ../src/richtext/richtextsizepage.cpp:338
-#: ../src/richtext/richtextsizepage.cpp:341
-#: ../src/richtext/richtextsizepage.cpp:342
-#: ../src/richtext/richtextsizepage.cpp:372
-#: ../src/richtext/richtextsizepage.cpp:375
-#: ../src/richtext/richtextsizepage.cpp:376
-#: ../src/richtext/richtextsizepage.cpp:399
-#: ../src/richtext/richtextsizepage.cpp:402
-#: ../src/richtext/richtextsizepage.cpp:403
-#: ../src/richtext/richtextsizepage.cpp:426
-#: ../src/richtext/richtextsizepage.cpp:429
-#: ../src/richtext/richtextsizepage.cpp:430
-#: ../src/richtext/richtextsizepage.cpp:453
-#: ../src/richtext/richtextsizepage.cpp:456
-#: ../src/richtext/richtextsizepage.cpp:457
-#: ../src/richtext/richtextsizepage.cpp:480
-#: ../src/richtext/richtextsizepage.cpp:483
-#: ../src/richtext/richtextsizepage.cpp:484
-#: ../src/richtext/richtextsizepage.cpp:554
-#: ../src/richtext/richtextsizepage.cpp:557
-#: ../src/richtext/richtextsizepage.cpp:558
-#: ../src/richtext/richtextsizepage.cpp:589
-#: ../src/richtext/richtextsizepage.cpp:592
-#: ../src/richtext/richtextsizepage.cpp:593
-#: ../src/richtext/richtextsizepage.cpp:624
-#: ../src/richtext/richtextsizepage.cpp:627
-#: ../src/richtext/richtextsizepage.cpp:628
-#: ../src/richtext/richtextsizepage.cpp:659
-#: ../src/richtext/richtextsizepage.cpp:662
-#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextfontpage.cpp:178
 msgid "px"
 msgstr "px"
 
-#: ../src/common/accelcmn.cpp:193
+#: ../src/common/accelcmn.cpp:192
 msgid "rawctrl"
 msgstr "rawctrl"
 
-#: ../src/html/chm.cpp:333
+#: ../src/html/chm.cpp:330
 msgid "read error"
 msgstr "s'ha produït un error de lectura"
 
-#: ../src/common/zipstrm.cpp:2085
+#: ../src/common/zipstrm.cpp:2155
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "en llegir el flux zip (entrada %s): crc erroni"
 
-#: ../src/common/zipstrm.cpp:2080
+#: ../src/common/zipstrm.cpp:2150
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "en llegir el flux zip (entrada %s): longitud errònia"
 
-#: ../src/msw/dde.cpp:1159
+#: ../src/msw/dde.cpp:1223
 msgid "reentrancy problem."
 msgstr "problema de reentrada."
 
-#: ../src/common/datetimefmt.cpp:1953
+#: ../src/common/datetimefmt.cpp:1976
 msgid "second"
 msgstr "segon"
 
-#: ../src/html/chm.cpp:337
+#: ../src/html/chm.cpp:334
 msgid "seek error"
 msgstr "s'ha produït un error de cerca"
 
-#: ../src/common/datetimefmt.cpp:1968
+#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#, fuzzy
+msgid "semibold"
+msgstr "negreta"
+
+#: ../src/common/datetimefmt.cpp:1991
 msgid "seventeenth"
 msgstr "dissetè"
 
-#: ../src/common/datetimefmt.cpp:1958
+#: ../src/common/datetimefmt.cpp:1981
 msgid "seventh"
 msgstr "setè"
 
-#: ../src/common/accelcmn.cpp:191
+#: ../src/common/accelcmn.cpp:190
 msgid "shift"
 msgstr "maj"
 
-#: ../src/common/appbase.cpp:773
+#: ../src/common/appbase.cpp:774
 msgid "show this help message"
 msgstr "mostra aquest missatge d'ajuda"
 
-#: ../src/common/datetimefmt.cpp:1967
+#: ../src/common/datetimefmt.cpp:1990
 msgid "sixteenth"
 msgstr "setzè"
 
-#: ../src/common/datetimefmt.cpp:1957
+#: ../src/common/datetimefmt.cpp:1980
 msgid "sixth"
 msgstr "sisè"
 
-#: ../src/common/appcmn.cpp:234
+#: ../src/common/appcmn.cpp:255
 msgid "specify display mode to use (e.g. 640x480-16)"
 msgstr "especifiqueu el mode de pantalla a utilitzar (p. ex. 640x480-16)"
 
-#: ../src/common/appcmn.cpp:220
+#: ../src/common/appcmn.cpp:241
 msgid "specify the theme to use"
 msgstr "especifiqueu el tema a utilitzar"
 
-#: ../src/richtext/richtextbuffer.cpp:9340
+#: ../src/richtext/richtextbuffer.cpp:9337
 msgid "standard/circle"
 msgstr "estàndard/cercle"
 
-#: ../src/richtext/richtextbuffer.cpp:9341
+#: ../src/richtext/richtextbuffer.cpp:9338
 msgid "standard/circle-outline"
 msgstr "estàndard/circumferència"
 
-#: ../src/richtext/richtextbuffer.cpp:9343
+#: ../src/richtext/richtextbuffer.cpp:9340
 msgid "standard/diamond"
 msgstr "estàndard/diamant"
 
-#: ../src/richtext/richtextbuffer.cpp:9342
+#: ../src/richtext/richtextbuffer.cpp:9339
 msgid "standard/square"
 msgstr "estàndard/quadrat"
 
-#: ../src/richtext/richtextbuffer.cpp:9344
+#: ../src/richtext/richtextbuffer.cpp:9341
 msgid "standard/triangle"
 msgstr "estàndard/triangle"
 
-#: ../src/common/zipstrm.cpp:1985
+#: ../src/common/zipstrm.cpp:2055
 msgid "stored file length not in Zip header"
 msgstr "la mida del fitxer emmagatzemat no és a la capçalera del Zip"
 
-#: ../src/common/cmdline.cpp:1488
+#: ../src/common/cmdline.cpp:1484
 msgid "str"
 msgstr "str"
 
-#: ../src/common/fontcmn.cpp:982
+#: ../src/common/fontcmn.cpp:1145
 msgid "strikethrough"
 msgstr "ratllat"
 
-#: ../src/common/tarstrm.cpp:1003 ../src/common/tarstrm.cpp:1025
-#: ../src/common/tarstrm.cpp:1507 ../src/common/tarstrm.cpp:1529
+#: ../src/common/tarstrm.cpp:997 ../src/common/tarstrm.cpp:1019
+#: ../src/common/tarstrm.cpp:1501 ../src/common/tarstrm.cpp:1523
 msgid "tar entry not open"
 msgstr "entrada tar no oberta"
 
-#: ../src/common/datetimefmt.cpp:1961
+#: ../src/common/datetimefmt.cpp:1984
 msgid "tenth"
 msgstr "desè"
 
-#: ../src/msw/dde.cpp:1123
+#: ../src/msw/dde.cpp:1187
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr ""
 "la resposta a la transacció ha provocat que es defineixi el bit DDE_FBUSY."
 
-#: ../src/common/datetimefmt.cpp:1954
+#: ../src/common/fontcmn.cpp:1154
+msgid "thin"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:1977
 msgid "third"
 msgstr "tercer"
 
-#: ../src/common/datetimefmt.cpp:1964
+#: ../src/common/datetimefmt.cpp:1987
 msgid "thirteenth"
 msgstr "tretzè"
 
-#: ../src/common/datetimefmt.cpp:1758
+#: ../src/common/datetimefmt.cpp:1781
 msgid "today"
 msgstr "avui"
 
-#: ../src/common/datetimefmt.cpp:1760
+#: ../src/common/datetimefmt.cpp:1783
 msgid "tomorrow"
 msgstr "demà"
 
-#: ../src/common/fileconf.cpp:1944
+#: ../src/common/fileconf.cpp:1946
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "s'ha ignorat la barra inversa al final a '%s'"
 
-#: ../src/gtk/aboutdlg.cpp:218
+#: ../src/gtk/aboutdlg.cpp:216
 msgid "translator-credits"
 msgstr "Eduard Ereza Martínez <eduard@ereza.cat>"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1028
+#: ../src/generic/datavgen.cpp:1148
 msgid "true"
 msgstr "cert"
 
-#: ../src/common/datetimefmt.cpp:1963
+#: ../src/common/datetimefmt.cpp:1986
 msgid "twelfth"
 msgstr "dotzè"
 
-#: ../src/common/datetimefmt.cpp:1971
+#: ../src/common/datetimefmt.cpp:1994
 msgid "twentieth"
 msgstr "vintè"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:486 ../src/generic/datavgen.cpp:1263
+#: ../src/common/datavcmn.cpp:2068 ../src/generic/datavgen.cpp:1386
 msgid "unchecked"
 msgstr "no marcat"
 
-#: ../src/common/fontcmn.cpp:802 ../src/common/fontcmn.cpp:978
+#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
 msgid "underlined"
 msgstr "subratllat"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:490
+#: ../src/common/datavcmn.cpp:2072
 msgid "undetermined"
 msgstr "indeterminat"
 
-#: ../src/common/fileconf.cpp:1979
+#: ../src/common/fileconf.cpp:1981
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "\" inesperat a la posició %d de '%s'."
 
-#: ../src/common/tarstrm.cpp:1045
+#: ../src/common/tarstrm.cpp:1039
 msgid "unexpected end of file"
 msgstr "final del fitxer inesperat"
 
-#: ../src/generic/progdlgg.cpp:370 ../src/common/tarstrm.cpp:371
-#: ../src/common/tarstrm.cpp:394 ../src/common/tarstrm.cpp:425
+#: ../src/common/tarstrm.cpp:366 ../src/common/tarstrm.cpp:389
+#: ../src/common/tarstrm.cpp:420 ../src/generic/progdlgg.cpp:376
 msgid "unknown"
 msgstr "desconegut"
 
-#: ../src/msw/registry.cpp:150
+#: ../src/msw/registry.cpp:139
 #, c-format
 msgid "unknown (%lu)"
 msgstr "desconegut (%lu)"
 
-#: ../src/common/xtixml.cpp:253
+#: ../src/common/xtixml.cpp:249
 #, c-format
 msgid "unknown class %s"
 msgstr "classe %s desconeguda"
 
-#: ../src/common/regex.cpp:258 ../src/html/chm.cpp:351
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "s'ha produït un error de compressió"
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "s'ha produït un error de descompressió"
+
+#: ../src/common/regex.cpp:255 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "s'ha produït un error desconegut"
 
-#: ../src/msw/dialup.cpp:471
+#: ../src/msw/dialup.cpp:465
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "s'ha produït un error desconegut (codi d'error %08x)."
 
-#: ../src/common/fmapbase.cpp:834
+#: ../src/common/fmapbase.cpp:830
 #, c-format
 msgid "unknown-%d"
 msgstr "desconegut-%d"
 
-#: ../src/common/docview.cpp:509
+#: ../src/common/docview.cpp:502
 msgid "unnamed"
 msgstr "sense nom"
 
-#: ../src/common/docview.cpp:1624
+#: ../src/common/docview.cpp:1618
 #, c-format
 msgid "unnamed%d"
 msgstr "sense nom %d"
 
-#: ../src/common/zipstrm.cpp:1999 ../src/common/zipstrm.cpp:2319
+#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
 msgid "unsupported Zip compression method"
 msgstr "mètode de compressió Zip no suportat"
 
-#: ../src/common/translation.cpp:1892
+#: ../src/common/translation.cpp:1942
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "s'utilitzarà el catàleg '%s' de '%s'."
 
-#: ../src/html/chm.cpp:335
+#: ../src/html/chm.cpp:332
 msgid "write error"
 msgstr "s'ha produït un error d'escriptura"
 
-#: ../src/common/time.cpp:292
+#: ../src/gtk/glcanvas.cpp:187
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/common/time.cpp:285
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay ha fallat."
 
@@ -8894,15 +9167,15 @@ msgstr "wxWidgets no ha pogut obrir la pantalla de '%s': se sortirà."
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets no ha pogut obrir la pantalla. Se sortirà."
 
-#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:431
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/common/datetimefmt.cpp:1759
+#: ../src/common/datetimefmt.cpp:1782
 msgid "yesterday"
 msgstr "ahir"
 
-#: ../src/common/zstream.cpp:251 ../src/common/zstream.cpp:426
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
 #, c-format
 msgid "zlib error %d"
 msgstr "s'ha produït un error de zlib %d"
@@ -8912,9 +9185,77 @@ msgstr "s'ha produït un error de zlib %d"
 msgid "~"
 msgstr "~"
 
-#, fuzzy
-#~ msgid "Column could not be added."
-#~ msgstr "No s'ha pogut carregar el fitxer."
+#~ msgid " (while overwriting an existing item)"
+#~ msgstr " (en sobreescriure un element existent)"
+
+#~ msgid "&Save as"
+#~ msgstr "Anomena i de&sa"
+
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' no consisteix només de caràcters vàlids"
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' hauria de ser numèric."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' només hauria de contenir caràcters ASCII."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' només hauria de contenir caràcters alfabètics."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' només hauria de contenir caràcters alfabètics o numèrics."
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' només hauria de contenir dígits."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "No es pot crear una finestra de la classe '%s'"
+
+#~ msgid "Could not initalize libnotify."
+#~ msgstr "No s'ha pogut inicialitzar libnotify."
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "No s'ha pogut crear la finestra de superposició"
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "No s'ha pogut inicialitzar el context a la finestra de superposició"
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "No s'ha pogut convertir el fitxer \"%s\" a Unicode."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "No s'ha pogut definir el text del control de text."
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr "Optó de línia d'ordres de GTK+ invàlida, feu servir \"%s --help\""
+
+#~ msgid "No unused colour in image."
+#~ msgstr "No hi ha cap color sense utilitzar a la imatge."
+
+#~ msgid "Not available"
+#~ msgstr "No disponible"
+
+#~ msgid "Replace selection"
+#~ msgstr "Substitueix la selecció"
+
+#~ msgid "Save as"
+#~ msgstr "Anomena i desa"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Organitzador d'estils"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "També estan suportades les següents opcions estàndard de GTK+:\n"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "No podeu netejar una superposició que no s'ha inicialitzat"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "No podeu inicialitzar una superposició dues vegades"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "no es pot definir la configuració local '%s'."
 
 #, fuzzy
 #~ msgid "Column index not found."
@@ -9141,10 +9482,6 @@ msgstr "~"
 #~ msgstr "origen de recerca desconegut"
 
 #, fuzzy
-#~ msgid "wxWidget's control not initialized."
-#~ msgstr "No es pot començar a mostrar."
-
-#, fuzzy
 #~ msgid "Cannot create mutex."
 #~ msgstr "No es pot crear un fil"
 
@@ -9220,9 +9557,6 @@ msgstr "~"
 #~ msgid "Directory '%s' doesn't exist!"
 #~ msgstr "El directori '%s' no existeix!"
 
-#~ msgid "File %s does not exist."
-#~ msgstr "El fitxer %s no existeix"
-
 #~ msgid "Mode %ix%i-%i not available."
 #~ msgstr "Mode %ix%i-%i no disponible."
 
@@ -9282,9 +9616,6 @@ msgstr "~"
 #, fuzzy
 #~ msgid "Failed to register OpenGL window class."
 #~ msgstr "No s'ha pogut inicialitzar l'OpenGL"
-
-#~ msgid "Fatal error"
-#~ msgstr "Error fatal"
 
 #~ msgid "Fatal error: "
 #~ msgstr "Error fatal:"

--- a/locale/ca@valencia.po
+++ b/locale/ca@valencia.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-21 14:25+0200\n"
+"POT-Creation-Date: 2020-10-18 23:11+0300\n"
 "PO-Revision-Date: 2003-07-22 11:31+0100\n"
 "Last-Translator: Robert Millan <rmh@aybabtu.com>\n"
 "Language-Team: <wx-translators@wxwidgets.org>\n"
@@ -11,14 +11,14 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../src/common/debugrpt.cpp:586
+#: ../src/common/debugrpt.cpp:587
 msgid ""
 "\n"
 "Please send this report to the program maintainer, thank you!\n"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:210
-#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:206
+#: ../src/richtext/richtextstyledlg.cpp:218
 msgid " "
 msgstr ""
 
@@ -26,73 +26,99 @@ msgstr ""
 msgid "              Thank you and we're sorry for the inconvenience!\n"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:573
+#: ../src/common/prntbase.cpp:568
 #, fuzzy, c-format
 msgid " (copy %d of %d)"
 msgstr "Pàgina %d de %d"
 
-#: ../src/common/log.cpp:421
+#: ../src/common/log.cpp:440
 #, c-format
 msgid " (error %ld: %s)"
 msgstr " (error %ld: %s)"
 
-#: ../src/common/imagtiff.cpp:72
+#: ../src/common/imagtiff.cpp:69
 #, c-format
 msgid " (in module \"%s\")"
 msgstr ""
 
-#: ../src/osx/core/secretstore.cpp:138
-msgid " (while overwriting an existing item)"
-msgstr ""
-
-#: ../src/common/docview.cpp:1642
+#: ../src/common/docview.cpp:1636
 msgid " - "
 msgstr " - "
 
-#: ../src/richtext/richtextprint.cpp:593 ../src/html/htmprint.cpp:714
+#: ../src/html/htmprint.cpp:712 ../src/richtext/richtextprint.cpp:589
 msgid " Preview"
 msgstr " Previsualitza"
 
-#: ../src/common/fontcmn.cpp:824
+#: ../src/common/fontcmn.cpp:973
 #, fuzzy
 msgid " bold"
 msgstr "negreta"
 
-#: ../src/common/fontcmn.cpp:840
+#: ../src/common/fontcmn.cpp:977
+#, fuzzy
+msgid " extra bold"
+msgstr "negreta"
+
+#: ../src/common/fontcmn.cpp:985
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:957
+#, fuzzy
+msgid " extra light"
+msgstr "clar"
+
+#: ../src/common/fontcmn.cpp:981
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1001
 #, fuzzy
 msgid " italic"
 msgstr "cursiva"
 
-#: ../src/common/fontcmn.cpp:820
+#: ../src/common/fontcmn.cpp:961
 #, fuzzy
 msgid " light"
 msgstr "clar"
 
-#: ../src/common/fontcmn.cpp:807
+#: ../src/common/fontcmn.cpp:965
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:969
+#, fuzzy
+msgid " semi bold"
+msgstr "negreta"
+
+#: ../src/common/fontcmn.cpp:940
 msgid " strikethrough"
 msgstr ""
 
-#: ../src/common/paper.cpp:117
+#: ../src/common/fontcmn.cpp:953
+msgid " thin"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
 msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
 msgstr "#10 Sobre, 4 1/8 x 9 1/2 polz. "
 
-#: ../src/common/paper.cpp:118
+#: ../src/common/paper.cpp:115
 msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
 msgstr "#11 Sobre, 4 1/2 x 10 3/8 polz. "
 
-#: ../src/common/paper.cpp:119
+#: ../src/common/paper.cpp:116
 msgid "#12 Envelope, 4 3/4 x 11 in"
 msgstr "#12 Sobre, 4 3/4 x 11 polz."
 
-#: ../src/common/paper.cpp:120
+#: ../src/common/paper.cpp:117
 msgid "#14 Envelope, 5 x 11 1/2 in"
 msgstr "#14 Sobre, 5 x 11 1/2 polz. "
 
-#: ../src/common/paper.cpp:116
+#: ../src/common/paper.cpp:113
 msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
 msgstr "#9 Sobre, 3 7/8 x 8 7/2 polz. "
 
-#: ../src/richtext/richtextbackgroundpage.cpp:341
 #: ../src/richtext/richtextsizepage.cpp:340
 #: ../src/richtext/richtextsizepage.cpp:374
 #: ../src/richtext/richtextsizepage.cpp:401
@@ -103,82 +129,83 @@ msgstr "#9 Sobre, 3 7/8 x 8 7/2 polz. "
 #: ../src/richtext/richtextsizepage.cpp:591
 #: ../src/richtext/richtextsizepage.cpp:626
 #: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextbackgroundpage.cpp:341
 #, fuzzy
 msgid "%"
 msgstr "%d"
 
-#: ../src/html/helpwnd.cpp:1031
+#: ../src/html/helpwnd.cpp:1029
 #, fuzzy, c-format
 msgid "%d of %lu"
 msgstr "%i de %i"
 
-#: ../src/html/helpwnd.cpp:1678
+#: ../src/html/helpwnd.cpp:1676
 #, fuzzy, c-format
 msgid "%i of %u"
 msgstr "%i de %i"
 
-#: ../src/generic/filectrlg.cpp:279
+#: ../src/generic/filectrlg.cpp:275
 #, c-format
 msgid "%ld byte"
 msgid_plural "%ld bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/html/helpwnd.cpp:1033
+#: ../src/html/helpwnd.cpp:1031
 #, fuzzy, c-format
 msgid "%lu of %lu"
 msgstr "%i de %i"
 
-#: ../src/generic/datavgen.cpp:6028
+#: ../src/generic/datavgen.cpp:6833
 #, fuzzy, c-format
 msgid "%s (%d items)"
 msgstr "%s (o %s)"
 
-#: ../src/common/cmdline.cpp:1221
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (o %s)"
 
-#: ../src/generic/logg.cpp:224
+#: ../src/generic/logg.cpp:221
 #, c-format
 msgid "%s Error"
 msgstr "Error %s"
 
-#: ../src/generic/logg.cpp:236
+#: ../src/generic/logg.cpp:233
 #, c-format
 msgid "%s Information"
 msgstr "Informació %s"
 
-#: ../src/generic/preferencesg.cpp:113
+#: ../src/generic/preferencesg.cpp:110
 #, c-format
 msgid "%s Preferences"
 msgstr ""
 
-#: ../src/generic/logg.cpp:228
+#: ../src/generic/logg.cpp:225
 #, c-format
 msgid "%s Warning"
 msgstr "Atenció %s"
 
-#: ../src/common/tarstrm.cpp:1319
+#: ../src/common/tarstrm.cpp:1313
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr ""
 
-#: ../src/common/fldlgcmn.cpp:124
+#: ../src/common/fldlgcmn.cpp:121
 #, fuzzy, c-format
 msgid "%s files (%s)|%s"
 msgstr "Fitxers (%s)|%s"
 
-#: ../src/html/helpwnd.cpp:1716
+#: ../src/html/helpwnd.cpp:1714
 #, fuzzy, c-format
 msgid "%u of %u"
 msgstr "%i de %i"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "&About"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "&Actual Size"
 msgstr ""
 
@@ -186,29 +213,29 @@ msgstr ""
 msgid "&After a paragraph:"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:128
 #: ../src/richtext/richtextliststylepage.cpp:319
+#: ../src/richtext/richtextindentspage.cpp:128
 #, fuzzy
 msgid "&Alignment"
 msgstr "dinovè"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "&Apply"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:251
+#: ../src/richtext/richtextstyledlg.cpp:247
 msgid "&Apply Style"
 msgstr ""
 
-#: ../src/msw/mdi.cpp:179
+#: ../src/msw/mdi.cpp:174
 msgid "&Arrange Icons"
 msgstr "&Organitza les icones"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "&Ascending"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:142
+#: ../src/common/stockitem.cpp:139
 #, fuzzy
 msgid "&Back"
 msgstr "< &Enrere"
@@ -229,25 +256,25 @@ msgstr ""
 msgid "&Blur distance:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:143
+#: ../src/common/stockitem.cpp:140
 #, fuzzy
 msgid "&Bold"
 msgstr "Negreta"
 
-#: ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141
 msgid "&Bottom"
 msgstr ""
 
+#: ../src/richtext/richtextsizepage.cpp:637
+#: ../src/richtext/richtextsizepage.cpp:644
 #: ../src/richtext/richtextborderspage.cpp:345
 #: ../src/richtext/richtextborderspage.cpp:513
 #: ../src/richtext/richtextmarginspage.cpp:259
 #: ../src/richtext/richtextmarginspage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:637
-#: ../src/richtext/richtextsizepage.cpp:644
 msgid "&Bottom:"
 msgstr ""
 
-#: ../include/wx/richtext/richtextbuffer.h:3866
+#: ../include/wx/richtext/richtextbuffer.h:3861
 #, fuzzy
 msgid "&Box"
 msgstr "Negreta"
@@ -257,40 +284,40 @@ msgstr "Negreta"
 msgid "&Bullet style:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "&CD-Rom"
 msgstr ""
 
-#: ../src/generic/wizard.cpp:434 ../src/generic/fontdlgg.cpp:470
-#: ../src/generic/fontdlgg.cpp:489 ../src/osx/carbon/fontdlg.cpp:402
-#: ../src/common/dlgcmn.cpp:279 ../src/common/stockitem.cpp:145
+#: ../src/osx/carbon/fontdlg.cpp:399 ../src/common/stockitem.cpp:142
+#: ../src/generic/wizard.cpp:433 ../src/generic/fontdlgg.cpp:466
+#: ../src/generic/fontdlgg.cpp:485 ../src/osx/cocoa/button.mm:200
 msgid "&Cancel"
 msgstr "&Anul·la"
 
-#: ../src/msw/mdi.cpp:175
+#: ../src/msw/mdi.cpp:170
 msgid "&Cascade"
 msgstr "&Cascada"
 
-#: ../include/wx/richtext/richtextbuffer.h:5960
+#: ../include/wx/richtext/richtextbuffer.h:5955
 #, fuzzy
 msgid "&Cell"
 msgstr "&Anul·la"
 
-#: ../src/richtext/richtextsymboldlg.cpp:439
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "&Character code:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:147
+#: ../src/common/stockitem.cpp:144
 #, fuzzy
 msgid "&Clear"
 msgstr "&Neteja"
 
-#: ../src/generic/logg.cpp:516 ../src/common/stockitem.cpp:148
-#: ../src/common/prntbase.cpp:1600 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/stockitem.cpp:145 ../src/common/prntbase.cpp:1625
+#: ../src/univ/themes/win32.cpp:3753 ../src/generic/logg.cpp:513
 msgid "&Close"
 msgstr "&Tanca"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 #, fuzzy
 msgid "&Color"
 msgstr "Trieu la font"
@@ -299,22 +326,22 @@ msgstr "Trieu la font"
 msgid "&Colour:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 #, fuzzy
 msgid "&Convert"
 msgstr "Contingut"
 
-#: ../src/richtext/richtextctrl.cpp:333 ../src/osx/textctrl_osx.cpp:577
-#: ../src/common/stockitem.cpp:150 ../src/msw/textctrl.cpp:2508
+#: ../src/osx/textctrl_osx.cpp:595 ../src/common/stockitem.cpp:147
+#: ../src/msw/textctrl.cpp:2773 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Copia"
 
-#: ../src/generic/hyperlinkg.cpp:156
+#: ../src/generic/hyperlinkg.cpp:153
 #, fuzzy
 msgid "&Copy URL"
 msgstr "&Copia"
 
-#: ../src/common/headerctrlcmn.cpp:306
+#: ../src/common/headerctrlcmn.cpp:304
 #, fuzzy
 msgid "&Customize..."
 msgstr "Grandària de la font:"
@@ -323,56 +350,57 @@ msgstr "Grandària de la font:"
 msgid "&Debug report preview:"
 msgstr ""
 
-#: ../src/richtext/richtexttabspage.cpp:138
-#: ../src/richtext/richtextctrl.cpp:335 ../src/osx/textctrl_osx.cpp:579
-#: ../src/common/stockitem.cpp:152 ../src/msw/textctrl.cpp:2510
+#: ../src/osx/textctrl_osx.cpp:597 ../src/common/stockitem.cpp:149
+#: ../src/msw/textctrl.cpp:2775 ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtextctrl.cpp:334
 msgid "&Delete"
 msgstr "&Elimina"
 
-#: ../src/richtext/richtextstyledlg.cpp:269
+#: ../src/richtext/richtextstyledlg.cpp:265
 #, fuzzy
 msgid "&Delete Style..."
 msgstr "&Elimina"
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "&Descending"
 msgstr ""
 
-#: ../src/generic/logg.cpp:682
+#: ../src/generic/logg.cpp:679
 msgid "&Details"
 msgstr "&Detalls"
 
-#: ../src/common/stockitem.cpp:153
+#: ../src/common/stockitem.cpp:150
 #, fuzzy
 msgid "&Down"
 msgstr "Avall"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "&Edit"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:263
+#: ../src/richtext/richtextstyledlg.cpp:259
 msgid "&Edit Style..."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:155
+#: ../src/common/stockitem.cpp:152
 msgid "&Execute"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/common/stockitem.cpp:154
 #, fuzzy
 msgid "&File"
 msgstr "&Mida"
 
-#: ../src/common/stockitem.cpp:158
-msgid "&Find"
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "&Find..."
 msgstr "&Cerca"
 
-#: ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:430
 msgid "&Finish"
 msgstr "&Fi"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:156
 #, fuzzy
 msgid "&First"
 msgstr "primer"
@@ -381,17 +409,17 @@ msgstr "primer"
 msgid "&Floating mode:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 #, fuzzy
 msgid "&Floppy"
 msgstr "&Copia"
 
-#: ../src/common/stockitem.cpp:194
+#: ../src/common/stockitem.cpp:191
 #, fuzzy
 msgid "&Font"
 msgstr "Grandària de la font:"
 
-#: ../src/generic/fontdlgg.cpp:371
+#: ../src/generic/fontdlgg.cpp:367
 #, fuzzy
 msgid "&Font family:"
 msgstr "Grandària de la font:"
@@ -400,23 +428,23 @@ msgstr "Grandària de la font:"
 msgid "&Font for Level..."
 msgstr ""
 
+#: ../src/richtext/richtextsymboldlg.cpp:397
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:400
 #, fuzzy
 msgid "&Font:"
 msgstr "Grandària de la font:"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 #, fuzzy
 msgid "&Forward"
 msgstr "Avant"
 
-#: ../src/richtext/richtextsymboldlg.cpp:451
+#: ../src/richtext/richtextsymboldlg.cpp:448
 #, fuzzy
 msgid "&From:"
 msgstr "De:"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "&Harddisk"
 msgstr ""
 
@@ -426,9 +454,9 @@ msgstr ""
 msgid "&Height:"
 msgstr "vuitè"
 
-#: ../src/generic/wizard.cpp:441 ../src/richtext/richtextstyledlg.cpp:303
-#: ../src/richtext/richtextsymboldlg.cpp:479 ../src/osx/menu_osx.cpp:734
-#: ../src/common/stockitem.cpp:163
+#: ../src/common/stockitem.cpp:160 ../src/generic/wizard.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextstyledlg.cpp:299 ../src/osx/cocoa/menu.mm:226
 msgid "&Help"
 msgstr "&Ajuda"
 
@@ -437,7 +465,7 @@ msgstr "&Ajuda"
 msgid "&Hide details"
 msgstr "&Detalls"
 
-#: ../src/common/stockitem.cpp:164
+#: ../src/common/stockitem.cpp:161
 #, fuzzy
 msgid "&Home"
 msgstr "&Mou"
@@ -446,59 +474,59 @@ msgstr "&Mou"
 msgid "&Horizontal offset:"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:184
 #: ../src/richtext/richtextliststylepage.cpp:372
+#: ../src/richtext/richtextindentspage.cpp:184
 msgid "&Indentation (tenths of a mm)"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:167
 #: ../src/richtext/richtextliststylepage.cpp:356
+#: ../src/richtext/richtextindentspage.cpp:167
 #, fuzzy
 msgid "&Indeterminate"
 msgstr "Subratllat"
 
-#: ../src/common/stockitem.cpp:166
+#: ../src/common/stockitem.cpp:163
 #, fuzzy
 msgid "&Index"
 msgstr "Índex"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 #, fuzzy
 msgid "&Info"
 msgstr "&Desfés"
 
-#: ../src/common/stockitem.cpp:168
+#: ../src/common/stockitem.cpp:165
 #, fuzzy
 msgid "&Italic"
 msgstr "Cursiva"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "&Jump to"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:153
 #: ../src/richtext/richtextliststylepage.cpp:342
+#: ../src/richtext/richtextindentspage.cpp:153
 msgid "&Justified"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 #, fuzzy
 msgid "&Last"
 msgstr "&Enganxa"
 
-#: ../src/richtext/richtextindentspage.cpp:139
 #: ../src/richtext/richtextliststylepage.cpp:328
+#: ../src/richtext/richtextindentspage.cpp:139
 msgid "&Left"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:195
+#: ../src/richtext/richtextsizepage.cpp:532
+#: ../src/richtext/richtextsizepage.cpp:539
 #: ../src/richtext/richtextborderspage.cpp:243
 #: ../src/richtext/richtextborderspage.cpp:411
 #: ../src/richtext/richtextliststylepage.cpp:381
+#: ../src/richtext/richtextindentspage.cpp:195
 #: ../src/richtext/richtextmarginspage.cpp:186
 #: ../src/richtext/richtextmarginspage.cpp:300
-#: ../src/richtext/richtextsizepage.cpp:532
-#: ../src/richtext/richtextsizepage.cpp:539
 msgid "&Left:"
 msgstr ""
 
@@ -506,11 +534,11 @@ msgstr ""
 msgid "&List level:"
 msgstr ""
 
-#: ../src/generic/logg.cpp:517
+#: ../src/generic/logg.cpp:514
 msgid "&Log"
 msgstr "&Registre"
 
-#: ../src/univ/themes/win32.cpp:3748
+#: ../src/univ/themes/win32.cpp:3745
 msgid "&Move"
 msgstr "&Mou"
 
@@ -518,22 +546,21 @@ msgstr "&Mou"
 msgid "&Move the object to:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 #, fuzzy
 msgid "&Network"
 msgstr "&Següent"
 
-#: ../src/richtext/richtexttabspage.cpp:132 ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173 ../src/richtext/richtexttabspage.cpp:132
 #, fuzzy
 msgid "&New"
 msgstr "&Següent"
 
-#: ../src/aui/tabmdi.cpp:111 ../src/generic/mdig.cpp:100
-#: ../src/msw/mdi.cpp:180
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
 msgid "&Next"
 msgstr "&Següent"
 
-#: ../src/generic/wizard.cpp:432 ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:429
 msgid "&Next >"
 msgstr "&Següent >"
 
@@ -541,7 +568,7 @@ msgstr "&Següent >"
 msgid "&Next Paragraph"
 msgstr ""
 
-#: ../src/generic/tipdlg.cpp:240
+#: ../src/generic/tipdlg.cpp:237
 msgid "&Next Tip"
 msgstr "Consell &següent"
 
@@ -550,12 +577,12 @@ msgstr "Consell &següent"
 msgid "&Next style:"
 msgstr "&Següent >"
 
-#: ../src/common/stockitem.cpp:177 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:174 ../src/msw/msgdlg.cpp:435
 #, fuzzy
 msgid "&No"
 msgstr "No"
 
-#: ../src/generic/dbgrptg.cpp:356
+#: ../src/generic/dbgrptg.cpp:360
 #, fuzzy
 msgid "&Notes:"
 msgstr "No"
@@ -564,13 +591,13 @@ msgstr "No"
 msgid "&Number:"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:475 ../src/generic/fontdlgg.cpp:482
-#: ../src/osx/carbon/fontdlg.cpp:408 ../src/common/stockitem.cpp:178
+#: ../src/osx/carbon/fontdlg.cpp:405 ../src/common/stockitem.cpp:175
+#: ../src/generic/fontdlgg.cpp:471 ../src/generic/fontdlgg.cpp:478
 #, fuzzy
 msgid "&OK"
 msgstr "D'acord"
 
-#: ../src/generic/dbgrptg.cpp:342 ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176 ../src/generic/dbgrptg.cpp:342
 #, fuzzy
 msgid "&Open..."
 msgstr "&Desa..."
@@ -583,16 +610,16 @@ msgstr ""
 msgid "&Page Break"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:334 ../src/osx/textctrl_osx.cpp:578
-#: ../src/common/stockitem.cpp:180 ../src/msw/textctrl.cpp:2509
+#: ../src/osx/textctrl_osx.cpp:596 ../src/common/stockitem.cpp:177
+#: ../src/msw/textctrl.cpp:2774 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&Enganxa"
 
-#: ../include/wx/richtext/richtextbuffer.h:5010
+#: ../include/wx/richtext/richtextbuffer.h:5005
 msgid "&Picture"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:419
 #, fuzzy
 msgid "&Point size:"
 msgstr "Grandària de la font:"
@@ -606,12 +633,11 @@ msgstr ""
 msgid "&Position mode:"
 msgstr "Pregunta"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178
 msgid "&Preferences"
 msgstr ""
 
-#: ../src/aui/tabmdi.cpp:112 ../src/generic/mdig.cpp:101
-#: ../src/msw/mdi.cpp:181
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
 msgid "&Previous"
 msgstr "&Previ"
 
@@ -620,85 +646,80 @@ msgstr "&Previ"
 msgid "&Previous Paragraph"
 msgstr "Pàgina anterior"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 #, fuzzy
 msgid "&Print..."
 msgstr "Imprimix..."
 
-#: ../src/richtext/richtextctrl.cpp:339 ../src/richtext/richtextctrl.cpp:5514
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtextctrl.cpp:338
+#: ../src/richtext/richtextctrl.cpp:5512
 #, fuzzy
 msgid "&Properties"
 msgstr "&Previ"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "&Quit"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:330 ../src/osx/textctrl_osx.cpp:574
-#: ../src/common/stockitem.cpp:185 ../src/common/cmdproc.cpp:293
-#: ../src/common/cmdproc.cpp:300 ../src/msw/textctrl.cpp:2505
+#: ../src/osx/textctrl_osx.cpp:592 ../src/common/stockitem.cpp:182
+#: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
+#: ../src/msw/textctrl.cpp:2770 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Refés"
 
-#: ../src/common/cmdproc.cpp:289 ../src/common/cmdproc.cpp:309
+#: ../src/common/cmdproc.cpp:282 ../src/common/cmdproc.cpp:302
 msgid "&Redo "
 msgstr "&Refés"
 
-#: ../src/richtext/richtextstyledlg.cpp:257
+#: ../src/richtext/richtextstyledlg.cpp:253
 msgid "&Rename Style..."
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:179
+#: ../src/generic/fdrepdlg.cpp:176
 msgid "&Replace"
 msgstr "&Substituix"
 
-#: ../src/richtext/richtextstyledlg.cpp:287
+#: ../src/richtext/richtextstyledlg.cpp:283
 msgid "&Restart numbering"
 msgstr ""
 
-#: ../src/univ/themes/win32.cpp:3747
+#: ../src/univ/themes/win32.cpp:3744
 msgid "&Restore"
 msgstr "&Restaura"
 
-#: ../src/richtext/richtextindentspage.cpp:146
 #: ../src/richtext/richtextliststylepage.cpp:335
+#: ../src/richtext/richtextindentspage.cpp:146
 #, fuzzy
 msgid "&Right"
 msgstr "Clar"
 
-#: ../src/richtext/richtextindentspage.cpp:213
+#: ../src/richtext/richtextsizepage.cpp:602
+#: ../src/richtext/richtextsizepage.cpp:609
 #: ../src/richtext/richtextborderspage.cpp:277
 #: ../src/richtext/richtextborderspage.cpp:445
 #: ../src/richtext/richtextliststylepage.cpp:399
+#: ../src/richtext/richtextindentspage.cpp:213
 #: ../src/richtext/richtextmarginspage.cpp:211
 #: ../src/richtext/richtextmarginspage.cpp:325
-#: ../src/richtext/richtextsizepage.cpp:602
-#: ../src/richtext/richtextsizepage.cpp:609
 #, fuzzy
 msgid "&Right:"
 msgstr "vuitè"
 
-#: ../src/common/stockitem.cpp:190
+#: ../src/common/stockitem.cpp:187
 #, fuzzy
 msgid "&Save"
 msgstr "&Desa..."
-
-#: ../src/common/stockitem.cpp:191
-#, fuzzy
-msgid "&Save as"
-msgstr "Anomena i Alça"
 
 #: ../include/wx/richmsgdlg.h:29
 #, fuzzy
 msgid "&See details"
 msgstr "&Detalls"
 
-#: ../src/generic/tipdlg.cpp:236
+#: ../src/generic/tipdlg.cpp:233
 msgid "&Show tips at startup"
 msgstr "&Mostra els consells al començar"
 
-#: ../src/univ/themes/win32.cpp:3750
+#: ../src/univ/themes/win32.cpp:3747
 msgid "&Size"
 msgstr "&Mida"
 
@@ -707,39 +728,39 @@ msgstr "&Mida"
 msgid "&Size:"
 msgstr "&Mida"
 
-#: ../src/generic/progdlgg.cpp:252
+#: ../src/generic/progdlgg.cpp:249
 #, fuzzy
 msgid "&Skip"
 msgstr "Script"
 
-#: ../src/richtext/richtextindentspage.cpp:242
 #: ../src/richtext/richtextliststylepage.cpp:417
+#: ../src/richtext/richtextindentspage.cpp:242
 msgid "&Spacing (tenths of a mm)"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "&Spell Check"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 #, fuzzy
 msgid "&Stop"
 msgstr "Configuració"
 
-#: ../src/richtext/richtextfontpage.cpp:275 ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196 ../src/richtext/richtextfontpage.cpp:275
 msgid "&Strikethrough"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:382 ../src/richtext/richtextstylepage.cpp:106
+#: ../src/generic/fontdlgg.cpp:378 ../src/richtext/richtextstylepage.cpp:106
 msgid "&Style:"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:194
 #, fuzzy
 msgid "&Styles:"
 msgstr "No"
 
-#: ../src/richtext/richtextsymboldlg.cpp:413
+#: ../src/richtext/richtextsymboldlg.cpp:410
 msgid "&Subset:"
 msgstr ""
 
@@ -753,26 +774,26 @@ msgstr ""
 msgid "&Synchronize values"
 msgstr ""
 
-#: ../include/wx/richtext/richtextbuffer.h:6069
+#: ../include/wx/richtext/richtextbuffer.h:6064
 msgid "&Table"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197
 #, fuzzy
 msgid "&Top"
 msgstr "&Copia"
 
+#: ../src/richtext/richtextsizepage.cpp:567
+#: ../src/richtext/richtextsizepage.cpp:574
 #: ../src/richtext/richtextborderspage.cpp:311
 #: ../src/richtext/richtextborderspage.cpp:479
 #: ../src/richtext/richtextmarginspage.cpp:234
 #: ../src/richtext/richtextmarginspage.cpp:348
-#: ../src/richtext/richtextsizepage.cpp:567
-#: ../src/richtext/richtextsizepage.cpp:574
 #, fuzzy
 msgid "&Top:"
 msgstr "Per a:"
 
-#: ../src/generic/fontdlgg.cpp:444 ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199 ../src/generic/fontdlgg.cpp:441
 #, fuzzy
 msgid "&Underline"
 msgstr "Subratllat"
@@ -782,22 +803,22 @@ msgstr "Subratllat"
 msgid "&Underlining:"
 msgstr "Subratllat"
 
-#: ../src/richtext/richtextctrl.cpp:329 ../src/osx/textctrl_osx.cpp:573
-#: ../src/common/stockitem.cpp:203 ../src/common/cmdproc.cpp:271
-#: ../src/msw/textctrl.cpp:2504
+#: ../src/osx/textctrl_osx.cpp:591 ../src/common/stockitem.cpp:200
+#: ../src/common/cmdproc.cpp:264 ../src/msw/textctrl.cpp:2769
+#: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Desfés"
 
-#: ../src/common/cmdproc.cpp:265
+#: ../src/common/cmdproc.cpp:258
 msgid "&Undo "
 msgstr "&Desfés"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 #, fuzzy
 msgid "&Unindent"
 msgstr "dinovè"
 
-#: ../src/common/stockitem.cpp:205
+#: ../src/common/stockitem.cpp:202
 #, fuzzy
 msgid "&Up"
 msgstr "Amunt"
@@ -817,7 +838,7 @@ msgstr "dinovè"
 msgid "&View..."
 msgstr "&Desa..."
 
-#: ../src/generic/fontdlgg.cpp:393
+#: ../src/generic/fontdlgg.cpp:389
 #, fuzzy
 msgid "&Weight:"
 msgstr "vuitè"
@@ -828,89 +849,59 @@ msgstr "vuitè"
 msgid "&Width:"
 msgstr "vuitè"
 
-#: ../src/aui/tabmdi.cpp:311 ../src/aui/tabmdi.cpp:327
-#: ../src/aui/tabmdi.cpp:329 ../src/generic/mdig.cpp:294
-#: ../src/generic/mdig.cpp:310 ../src/generic/mdig.cpp:314
-#: ../src/msw/mdi.cpp:78
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
 msgid "&Window"
 msgstr "&Finestra"
 
-#: ../src/common/stockitem.cpp:206 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:203 ../src/msw/msgdlg.cpp:435
 #, fuzzy
 msgid "&Yes"
 msgstr "Sí"
 
-#: ../src/common/valtext.cpp:256
+#: ../src/common/valtext.cpp:197
 #, fuzzy, c-format
-msgid "'%s' contains illegal characters"
+msgid "'%s' contains invalid character(s)"
 msgstr "'%s' només hauria de contenir caràcters alfabètics"
 
-#: ../src/common/valtext.cpp:254
-#, fuzzy, c-format
-msgid "'%s' doesn't consist only of valid characters"
-msgstr "'%s' només hauria de contenir caràcters alfabètics"
-
-#: ../src/common/config.cpp:519 ../src/msw/regconf.cpp:258
+#: ../src/common/config.cpp:515 ../src/msw/regconf.cpp:255
 #, c-format
 msgid "'%s' has extra '..', ignored."
 msgstr "'%s' té '..' extres que han estat ignorats."
 
-#: ../src/common/cmdline.cpp:1113 ../src/common/cmdline.cpp:1131
+#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' no és valor numèric correcte per l'opció '%s'."
 
-#: ../src/common/translation.cpp:1100
+#: ../src/common/translation.cpp:1142
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' no és un missatge vàlid de catàleg"
 
-#: ../src/common/valtext.cpp:165
+#: ../src/common/valtext.cpp:188
 #, fuzzy, c-format
 msgid "'%s' is not one of the valid strings"
 msgstr "'%s' no és un missatge vàlid de catàleg"
 
-#: ../src/common/valtext.cpp:167
+#: ../src/common/valtext.cpp:186
 #, fuzzy, c-format
 msgid "'%s' is one of the invalid strings"
 msgstr "'%s' és invàlid"
 
-#: ../src/common/textbuf.cpp:237
+#: ../src/common/textbuf.cpp:233
 #, c-format
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' és probablement un búffer binari."
-
-#: ../src/common/valtext.cpp:252
-#, c-format
-msgid "'%s' should be numeric."
-msgstr "'%s' hauria de ser numèric."
-
-#: ../src/common/valtext.cpp:244
-#, c-format
-msgid "'%s' should only contain ASCII characters."
-msgstr "'%s' només hauria de contenir caràcters ASCII"
-
-#: ../src/common/valtext.cpp:246
-#, c-format
-msgid "'%s' should only contain alphabetic characters."
-msgstr "'%s' només hauria de contenir caràcters alfabètics"
-
-#: ../src/common/valtext.cpp:248
-#, c-format
-msgid "'%s' should only contain alphabetic or numeric characters."
-msgstr "'%s' només hauria de contenir caràcters alfabètics o numèrics."
-
-#: ../src/common/valtext.cpp:250
-#, fuzzy, c-format
-msgid "'%s' should only contain digits."
-msgstr "'%s' només hauria de contenir caràcters ASCII"
 
 #: ../src/richtext/richtextliststylepage.cpp:229
 #: ../src/richtext/richtextbulletspage.cpp:166
 msgid "(*)"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:963
+#: ../src/html/helpwnd.cpp:961
 msgid "(Help)"
 msgstr "(Ajuda)"
 
@@ -919,28 +910,33 @@ msgstr "(Ajuda)"
 msgid "(None)"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:504
+#: ../src/richtext/richtextsymboldlg.cpp:503
 #, fuzzy
 msgid "(Normal text)"
 msgstr "Font normal"
 
-#: ../src/html/helpwnd.cpp:419 ../src/html/helpwnd.cpp:1106
-#: ../src/html/helpwnd.cpp:1742
+#: ../src/html/helpwnd.cpp:417 ../src/html/helpwnd.cpp:1104
+#: ../src/html/helpwnd.cpp:1740
 msgid "(bookmarks)"
 msgstr "(preferits)"
 
+#: ../src/msw/dlmsw.cpp:167
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (error %ld: %s)"
+
+#: ../src/richtext/richtextformatdlg.cpp:876
+#: ../src/richtext/richtextliststylepage.cpp:448
+#: ../src/richtext/richtextliststylepage.cpp:460
+#: ../src/richtext/richtextliststylepage.cpp:461
 #: ../src/richtext/richtextindentspage.cpp:274
 #: ../src/richtext/richtextindentspage.cpp:286
 #: ../src/richtext/richtextindentspage.cpp:287
 #: ../src/richtext/richtextindentspage.cpp:311
 #: ../src/richtext/richtextindentspage.cpp:326
-#: ../src/richtext/richtextformatdlg.cpp:884
 #: ../src/richtext/richtextfontpage.cpp:349
 #: ../src/richtext/richtextfontpage.cpp:353
 #: ../src/richtext/richtextfontpage.cpp:357
-#: ../src/richtext/richtextliststylepage.cpp:448
-#: ../src/richtext/richtextliststylepage.cpp:460
-#: ../src/richtext/richtextliststylepage.cpp:461
 #, fuzzy
 msgid "(none)"
 msgstr "sense nom"
@@ -960,7 +956,7 @@ msgstr ""
 msgid "+"
 msgstr ""
 
-#: ../src/msw/utils.cpp:1152
+#: ../src/msw/utils.cpp:1143
 msgid ", 64-bit edition"
 msgstr ""
 
@@ -969,175 +965,175 @@ msgstr ""
 msgid "-"
 msgstr ""
 
-#: ../src/generic/filepickerg.cpp:66
+#: ../src/generic/filepickerg.cpp:63
 #, fuzzy
 msgid "..."
 msgstr ".."
 
-#: ../src/richtext/richtextindentspage.cpp:276
 #: ../src/richtext/richtextliststylepage.cpp:450
+#: ../src/richtext/richtextindentspage.cpp:276
 msgid "1.1"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:277
 #: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextindentspage.cpp:277
 msgid "1.2"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:278
 #: ../src/richtext/richtextliststylepage.cpp:452
+#: ../src/richtext/richtextindentspage.cpp:278
 msgid "1.3"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:279
 #: ../src/richtext/richtextliststylepage.cpp:453
+#: ../src/richtext/richtextindentspage.cpp:279
 msgid "1.4"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:280
 #: ../src/richtext/richtextliststylepage.cpp:454
+#: ../src/richtext/richtextindentspage.cpp:280
 msgid "1.5"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:281
 #: ../src/richtext/richtextliststylepage.cpp:455
+#: ../src/richtext/richtextindentspage.cpp:281
 msgid "1.6"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:282
 #: ../src/richtext/richtextliststylepage.cpp:456
+#: ../src/richtext/richtextindentspage.cpp:282
 msgid "1.7"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:283
 #: ../src/richtext/richtextliststylepage.cpp:457
+#: ../src/richtext/richtextindentspage.cpp:283
 msgid "1.8"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:284
 #: ../src/richtext/richtextliststylepage.cpp:458
+#: ../src/richtext/richtextindentspage.cpp:284
 msgid "1.9"
 msgstr ""
 
-#: ../src/common/paper.cpp:140
+#: ../src/common/paper.cpp:137
 #, fuzzy
 msgid "10 x 11 in"
 msgstr "10 x 14 polz."
 
-#: ../src/common/paper.cpp:113
+#: ../src/common/paper.cpp:110
 msgid "10 x 14 in"
 msgstr "10 x 14 polz."
 
-#: ../src/common/paper.cpp:114
+#: ../src/common/paper.cpp:111
 msgid "11 x 17 in"
 msgstr "11 x 17 polz."
 
-#: ../src/common/paper.cpp:184
+#: ../src/common/paper.cpp:181
 #, fuzzy
 msgid "12 x 11 in"
 msgstr "10 x 14 polz."
 
-#: ../src/common/paper.cpp:141
+#: ../src/common/paper.cpp:138
 #, fuzzy
 msgid "15 x 11 in"
 msgstr "10 x 14 polz."
 
-#: ../src/richtext/richtextindentspage.cpp:285
 #: ../src/richtext/richtextliststylepage.cpp:459
+#: ../src/richtext/richtextindentspage.cpp:285
 msgid "2"
 msgstr ""
 
-#: ../src/common/paper.cpp:132
+#: ../src/common/paper.cpp:129
 msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
 msgstr "6 3/4 Sobre, 3 5/8 x 6 1/2 polz."
 
-#: ../src/common/paper.cpp:139
+#: ../src/common/paper.cpp:136
 #, fuzzy
 msgid "9 x 11 in"
 msgstr "11 x 17 polz."
 
-#: ../src/html/htmprint.cpp:431
+#: ../src/html/htmprint.cpp:443
 msgid ": file does not exist!"
 msgstr ": fitxer no existix!"
 
-#: ../src/common/fontmap.cpp:199
+#: ../src/common/fontmap.cpp:196
 msgid ": unknown charset"
 msgstr ": joc de caràcters desconegut"
 
-#: ../src/common/fontmap.cpp:413
+#: ../src/common/fontmap.cpp:410
 msgid ": unknown encoding"
 msgstr ": codificació desconeguda"
 
-#: ../src/generic/wizard.cpp:443
+#: ../src/generic/wizard.cpp:438
 msgid "< &Back"
 msgstr "< &Enrere"
 
-#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:628
-#: ../src/osx/carbon/fontdlg.cpp:648
+#: ../src/osx/carbon/fontdlg.cpp:419 ../src/osx/carbon/fontdlg.cpp:625
+#: ../src/osx/carbon/fontdlg.cpp:645
 #, fuzzy
 msgid "<Any Decorative>"
 msgstr "Decoratiu"
 
-#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:630
-#: ../src/osx/carbon/fontdlg.cpp:650
+#: ../src/osx/carbon/fontdlg.cpp:420 ../src/osx/carbon/fontdlg.cpp:627
+#: ../src/osx/carbon/fontdlg.cpp:647
 #, fuzzy
 msgid "<Any Modern>"
 msgstr "Modern"
 
-#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:626
-#: ../src/osx/carbon/fontdlg.cpp:646
+#: ../src/osx/carbon/fontdlg.cpp:418 ../src/osx/carbon/fontdlg.cpp:623
+#: ../src/osx/carbon/fontdlg.cpp:643
 #, fuzzy
 msgid "<Any Roman>"
 msgstr "Roman"
 
-#: ../src/osx/carbon/fontdlg.cpp:424 ../src/osx/carbon/fontdlg.cpp:632
-#: ../src/osx/carbon/fontdlg.cpp:652
+#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:629
+#: ../src/osx/carbon/fontdlg.cpp:649
 #, fuzzy
 msgid "<Any Script>"
 msgstr "Script"
 
-#: ../src/osx/carbon/fontdlg.cpp:425 ../src/osx/carbon/fontdlg.cpp:637
-#: ../src/osx/carbon/fontdlg.cpp:656
+#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:634
+#: ../src/osx/carbon/fontdlg.cpp:653
 #, fuzzy
 msgid "<Any Swiss>"
 msgstr "Suís"
 
-#: ../src/osx/carbon/fontdlg.cpp:426 ../src/osx/carbon/fontdlg.cpp:634
-#: ../src/osx/carbon/fontdlg.cpp:654
+#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:631
+#: ../src/osx/carbon/fontdlg.cpp:651
 #, fuzzy
 msgid "<Any Teletype>"
 msgstr "Teletip"
 
-#: ../src/osx/carbon/fontdlg.cpp:420
+#: ../src/osx/carbon/fontdlg.cpp:417
 msgid "<Any>"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
 msgid "<DIR>"
 msgstr "<DIR>"
 
-#: ../src/generic/filectrlg.cpp:254 ../src/generic/filectrlg.cpp:277
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
 #, fuzzy
 msgid "<DRIVE>"
 msgstr "<DIR>"
 
-#: ../src/generic/filectrlg.cpp:252 ../src/generic/filectrlg.cpp:275
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
 msgid "<LINK>"
 msgstr "<ENLLAÇ>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1264
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1270
+#: ../src/html/helpwnd.cpp:1268
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1265
+#: ../src/html/helpwnd.cpp:1263
 msgid "<b>Bold face.</b> "
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1264
+#: ../src/html/helpwnd.cpp:1262
 msgid "<i>Italic face.</i> "
 msgstr ""
 
@@ -1146,15 +1142,15 @@ msgstr ""
 msgid ">"
 msgstr ""
 
-#: ../src/generic/dbgrptg.cpp:318
+#: ../src/generic/dbgrptg.cpp:317
 msgid "A debug report has been generated in the directory\n"
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:573
+#: ../src/common/debugrpt.cpp:574
 msgid "A debug report has been generated. It can be found in"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:418
+#: ../src/common/xtixml.cpp:414
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr ""
 
@@ -1165,119 +1161,119 @@ msgstr ""
 msgid "A standard bullet name."
 msgstr ""
 
-#: ../src/common/paper.cpp:217
+#: ../src/common/paper.cpp:214
 #, fuzzy
 msgid "A0 sheet, 841 x 1189 mm"
 msgstr "Full A4, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:218
+#: ../src/common/paper.cpp:215
 #, fuzzy
 msgid "A1 sheet, 594 x 841 mm"
 msgstr "Full A3, 297 x 420 mm"
 
-#: ../src/common/paper.cpp:159
-msgid "A2 420 x 594 mm"
-msgstr ""
-
 #: ../src/common/paper.cpp:156
-#, fuzzy
-msgid "A3 Extra 322 x 445 mm"
-msgstr "C3 Sobre, 324 x 458 mm"
-
-#: ../src/common/paper.cpp:161
-#, fuzzy
-msgid "A3 Extra Transverse 322 x 445 mm"
-msgstr "C3 Sobre, 324 x 458 mm"
-
-#: ../src/common/paper.cpp:170
-#, fuzzy
-msgid "A3 Rotated 420 x 297 mm"
-msgstr "Full A4, 210 x 297 mm"
-
-#: ../src/common/paper.cpp:160
-#, fuzzy
-msgid "A3 Transverse 297 x 420 mm"
-msgstr "Full A3, 297 x 420 mm"
-
-#: ../src/common/paper.cpp:106
-msgid "A3 sheet, 297 x 420 mm"
-msgstr "Full A3, 297 x 420 mm"
-
-#: ../src/common/paper.cpp:146
-msgid "A4 Extra 9.27 x 12.69 in"
+msgid "A2 420 x 594 mm"
 msgstr ""
 
 #: ../src/common/paper.cpp:153
 #, fuzzy
+msgid "A3 Extra 322 x 445 mm"
+msgstr "C3 Sobre, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:158
+#, fuzzy
+msgid "A3 Extra Transverse 322 x 445 mm"
+msgstr "C3 Sobre, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:167
+#, fuzzy
+msgid "A3 Rotated 420 x 297 mm"
+msgstr "Full A4, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:157
+#, fuzzy
+msgid "A3 Transverse 297 x 420 mm"
+msgstr "Full A3, 297 x 420 mm"
+
+#: ../src/common/paper.cpp:103
+msgid "A3 sheet, 297 x 420 mm"
+msgstr "Full A3, 297 x 420 mm"
+
+#: ../src/common/paper.cpp:143
+msgid "A4 Extra 9.27 x 12.69 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:150
+#, fuzzy
 msgid "A4 Plus 210 x 330 mm"
 msgstr "Full A4, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:171
+#: ../src/common/paper.cpp:168
 #, fuzzy
 msgid "A4 Rotated 297 x 210 mm"
 msgstr "Full A3, 297 x 420 mm"
 
-#: ../src/common/paper.cpp:148
+#: ../src/common/paper.cpp:145
 #, fuzzy
 msgid "A4 Transverse 210 x 297 mm"
 msgstr "Full A4, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:97
+#: ../src/common/paper.cpp:94
 msgid "A4 sheet, 210 x 297 mm"
 msgstr "Full A4, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:107
+#: ../src/common/paper.cpp:104
 msgid "A4 small sheet, 210 x 297 mm"
 msgstr "Full petit A4, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:157
+#: ../src/common/paper.cpp:154
 #, fuzzy
 msgid "A5 Extra 174 x 235 mm"
 msgstr "Full A5, 148 x 210 mm"
 
-#: ../src/common/paper.cpp:172
+#: ../src/common/paper.cpp:169
 msgid "A5 Rotated 210 x 148 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:154
+#: ../src/common/paper.cpp:151
 #, fuzzy
 msgid "A5 Transverse 148 x 210 mm"
 msgstr "Full A5, 148 x 210 mm"
 
-#: ../src/common/paper.cpp:108
+#: ../src/common/paper.cpp:105
 msgid "A5 sheet, 148 x 210 mm"
 msgstr "Full A5, 148 x 210 mm"
 
-#: ../src/common/paper.cpp:164
+#: ../src/common/paper.cpp:161
 #, fuzzy
 msgid "A6 105 x 148 mm"
 msgstr "10 x 14 polz."
 
-#: ../src/common/paper.cpp:177
+#: ../src/common/paper.cpp:174
 #, fuzzy
 msgid "A6 Rotated 148 x 105 mm"
 msgstr "Full A5, 148 x 210 mm"
 
-#: ../src/generic/fontdlgg.cpp:83 ../src/richtext/richtextformatdlg.cpp:529
-#: ../src/osx/carbon/fontdlg.cpp:153
+#: ../src/osx/carbon/fontdlg.cpp:150 ../src/generic/fontdlgg.cpp:79
+#: ../src/richtext/richtextformatdlg.cpp:521
 msgid "ABCDEFGabcdefg12345"
 msgstr "ABCDEFGabcdefg12345"
 
-#: ../src/richtext/richtextsymboldlg.cpp:458 ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
 msgid "ASCII"
 msgstr "ASCII"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "About"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:140 ../src/osx/menu_osx.cpp:558
-#: ../src/msw/aboutdlg.cpp:64
+#: ../src/osx/menu_osx.cpp:450 ../src/generic/aboutdlgg.cpp:137
+#: ../src/msw/aboutdlg.cpp:61
 #, c-format
 msgid "About %s"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:560
+#: ../src/osx/menu_osx.cpp:452
 msgid "About..."
 msgstr ""
 
@@ -1286,38 +1282,38 @@ msgid "Absolute"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:873
+#: ../src/propgrid/advprops.cpp:774
 #, fuzzy
 msgid "ActiveBorder"
 msgstr "Modern"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:874
+#: ../src/propgrid/advprops.cpp:775
 msgid "ActiveCaption"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "Actual Size"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:140 ../src/common/accelcmn.cpp:81
+#: ../src/common/stockitem.cpp:137 ../src/common/accelcmn.cpp:78
 msgid "Add"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11455
+#: ../src/richtext/richtextbuffer.cpp:11454
 msgid "Add Column"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11392
+#: ../src/richtext/richtextbuffer.cpp:11391
 msgid "Add Row"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:432
+#: ../src/html/helpwnd.cpp:430
 msgid "Add current page to bookmarks"
 msgstr "Afig la pàgina actual a preferits"
 
-#: ../src/generic/colrdlgg.cpp:366
+#: ../src/generic/colrdlgg.cpp:386
 msgid "Add to custom colours"
 msgstr "Afig a colors personalitzats"
 
@@ -1329,12 +1325,12 @@ msgstr ""
 msgid "AddToPropertyCollection called w/o valid adder"
 msgstr ""
 
-#: ../src/html/helpctrl.cpp:159
+#: ../src/html/helpctrl.cpp:155
 #, c-format
 msgid "Adding book %s"
 msgstr "S'està afegint el llibre %s"
 
-#: ../src/common/preferencescmn.cpp:43
+#: ../src/common/preferencescmn.cpp:40
 msgid "Advanced"
 msgstr ""
 
@@ -1342,11 +1338,11 @@ msgstr ""
 msgid "After a paragraph:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:172
+#: ../src/common/stockitem.cpp:169
 msgid "Align Left"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:173
+#: ../src/common/stockitem.cpp:170
 #, fuzzy
 msgid "Align Right"
 msgstr "mitja nit"
@@ -1356,40 +1352,40 @@ msgstr "mitja nit"
 msgid "Alignment"
 msgstr "dinovè"
 
-#: ../src/generic/prntdlgg.cpp:215
+#: ../src/generic/prntdlgg.cpp:208
 msgid "All"
 msgstr "Tot"
 
-#: ../src/generic/filectrlg.cpp:1197 ../src/common/fldlgcmn.cpp:107
+#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1186
 #, fuzzy, c-format
 msgid "All files (%s)|%s"
 msgstr "Tots els fitxers (*)|*"
 
-#: ../include/wx/defs.h:2886
+#: ../include/wx/defs.h:2582
 msgid "All files (*)|*"
 msgstr "Tots els fitxers (*)|*"
 
-#: ../include/wx/defs.h:2883
+#: ../include/wx/defs.h:2579
 msgid "All files (*.*)|*.*"
 msgstr "Tots els fitxers (*.*) *.*  "
 
-#: ../src/richtext/richtextstyles.cpp:1061
+#: ../src/richtext/richtextstyles.cpp:1058
 msgid "All styles"
 msgstr ""
 
-#: ../src/propgrid/manager.cpp:1528
+#: ../src/propgrid/manager.cpp:1544
 msgid "Alphabetic Mode"
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:425
+#: ../src/common/xtistrm.cpp:422
 msgid "Already Registered Object passed to SetObjectClassInfo"
 msgstr ""
 
-#: ../src/unix/dialup.cpp:353
+#: ../src/unix/dialup.cpp:352
 msgid "Already dialling ISP."
 msgstr "Ja s'està trucant a l'ISP."
 
-#: ../src/common/accelcmn.cpp:331 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/accelcmn.cpp:345 ../src/univ/themes/win32.cpp:3753
 msgid "Alt+"
 msgstr ""
 
@@ -1398,36 +1394,36 @@ msgstr ""
 msgid "An optional corner radius for adding rounded corners."
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:576
+#: ../src/common/debugrpt.cpp:577
 msgid "And includes the following files:\n"
 msgstr ""
 
-#: ../src/generic/animateg.cpp:162
+#: ../src/generic/animateg.cpp:145
 #, fuzzy, c-format
 msgid "Animation file is not of type %ld."
 msgstr "El fitxer d'imatge no és del tipus %d."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:872
+#: ../src/propgrid/advprops.cpp:773
 msgid "AppWorkspace"
 msgstr ""
 
-#: ../src/generic/logg.cpp:1014
+#: ../src/generic/logg.cpp:1011
 #, c-format
 msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
 msgstr ""
 "Afig el registre al fitxer '%s' (escollir [No] sobrescriurà el fitxer)?"
 
-#: ../src/osx/menu_osx.cpp:577 ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:469 ../src/osx/menu_osx.cpp:477
 #, fuzzy
 msgid "Application"
 msgstr "Seccions"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "Apply"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1609
+#: ../src/propgrid/advprops.cpp:1515
 msgid "Aqua"
 msgstr ""
 
@@ -1436,31 +1432,31 @@ msgstr ""
 msgid "Arabic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:153
+#: ../src/common/fmapbase.cpp:150
 msgid "Arabic (ISO-8859-6)"
 msgstr "Àrab (ISO-8859-6)"
 
-#: ../src/msw/ole/automtn.cpp:672
+#: ../src/msw/ole/automtn.cpp:663
 #, fuzzy, c-format
 msgid "Argument %u not found."
 msgstr "no s'ha trobat el fitxer de catàleg per al domini '%s'"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1753
+#: ../src/propgrid/advprops.cpp:1654
 #, fuzzy
 msgid "Arrow"
 msgstr "demà"
 
-#: ../src/generic/aboutdlgg.cpp:184
+#: ../src/generic/aboutdlgg.cpp:181
 msgid "Artists"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 #, fuzzy
 msgid "Ascending"
 msgstr "s'està llegint"
 
-#: ../src/generic/filectrlg.cpp:433
+#: ../src/generic/filectrlg.cpp:429
 msgid "Attributes"
 msgstr ""
 
@@ -1470,93 +1466,93 @@ msgstr ""
 msgid "Available fonts."
 msgstr ""
 
-#: ../src/common/paper.cpp:137
+#: ../src/common/paper.cpp:134
 #, fuzzy
 msgid "B4 (ISO) 250 x 353 mm"
 msgstr "Full B4, 250 x 354 mm"
 
-#: ../src/common/paper.cpp:173
+#: ../src/common/paper.cpp:170
 msgid "B4 (JIS) Rotated 364 x 257 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:127
+#: ../src/common/paper.cpp:124
 msgid "B4 Envelope, 250 x 353 mm"
 msgstr "B4 Sobre, 250 x 353 mm"
 
-#: ../src/common/paper.cpp:109
+#: ../src/common/paper.cpp:106
 msgid "B4 sheet, 250 x 354 mm"
 msgstr "Full B4, 250 x 354 mm"
 
-#: ../src/common/paper.cpp:158
+#: ../src/common/paper.cpp:155
 msgid "B5 (ISO) Extra 201 x 276 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:174
+#: ../src/common/paper.cpp:171
 msgid "B5 (JIS) Rotated 257 x 182 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:155
+#: ../src/common/paper.cpp:152
 #, fuzzy
 msgid "B5 (JIS) Transverse 182 x 257 mm"
 msgstr "Full B5, 182 x 257 mil·límetres"
 
-#: ../src/common/paper.cpp:128
+#: ../src/common/paper.cpp:125
 msgid "B5 Envelope, 176 x 250 mm"
 msgstr "B5 Sobre, 176 x 250 mm"
 
-#: ../src/common/paper.cpp:110
+#: ../src/common/paper.cpp:107
 msgid "B5 sheet, 182 x 257 millimeter"
 msgstr "Full B5, 182 x 257 mil·límetres"
 
-#: ../src/common/paper.cpp:182
+#: ../src/common/paper.cpp:179
 msgid "B6 (JIS) 128 x 182 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:183
+#: ../src/common/paper.cpp:180
 msgid "B6 (JIS) Rotated 182 x 128 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:129
+#: ../src/common/paper.cpp:126
 msgid "B6 Envelope, 176 x 125 mm"
 msgstr "B6 Sobre, 176 x 125 mm"
 
-#: ../src/common/imagbmp.cpp:531 ../src/common/imagbmp.cpp:561
-#: ../src/common/imagbmp.cpp:576
+#: ../src/common/imagbmp.cpp:528 ../src/common/imagbmp.cpp:558
+#: ../src/common/imagbmp.cpp:573
 msgid "BMP: Couldn't allocate memory."
 msgstr "BMP: No s'ha pogut localitzar la memòria."
 
-#: ../src/common/imagbmp.cpp:100
+#: ../src/common/imagbmp.cpp:97
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP:No s'ha pogut alçar la imatge invàlida."
 
-#: ../src/common/imagbmp.cpp:356
+#: ../src/common/imagbmp.cpp:353
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: No s'ha pogut escriure el mapa de colors RGB."
 
-#: ../src/common/imagbmp.cpp:490
+#: ../src/common/imagbmp.cpp:487
 msgid "BMP: Couldn't write data."
 msgstr "BMP: No s'ha pogut escriure la dada."
 
-#: ../src/common/imagbmp.cpp:246
+#: ../src/common/imagbmp.cpp:243
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: No s'ha pogut escriure la capçalera del fitxer (Mapa de bits)."
 
-#: ../src/common/imagbmp.cpp:269
+#: ../src/common/imagbmp.cpp:266
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: No s'ha pogut escriure la capçalera del fitxer (BitmapInfo)."
 
-#: ../src/common/imagbmp.cpp:140
+#: ../src/common/imagbmp.cpp:137
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP:wxImage no té una wxPallette pròpia."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:142 ../src/common/accelcmn.cpp:52
+#: ../src/common/stockitem.cpp:139 ../src/common/accelcmn.cpp:49
 #, fuzzy
 msgid "Back"
 msgstr "< &Enrere"
 
+#: ../src/richtext/richtextformatdlg.cpp:377
 #: ../src/richtext/richtextbackgroundpage.cpp:148
-#: ../src/richtext/richtextformatdlg.cpp:384
 #, fuzzy
 msgid "Background"
 msgstr "Enrere"
@@ -1565,21 +1561,21 @@ msgstr "Enrere"
 msgid "Background &colour:"
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:220
+#: ../src/osx/carbon/fontdlg.cpp:217
 msgid "Background colour"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:52
+#: ../src/common/accelcmn.cpp:49
 #, fuzzy
 msgid "Backspace"
 msgstr "< &Enrere"
 
-#: ../src/common/fmapbase.cpp:160
+#: ../src/common/fmapbase.cpp:157
 msgid "Baltic (ISO-8859-13)"
 msgstr "Bàltic (ISO-8859-13)"
 
-#: ../src/common/fmapbase.cpp:151
+#: ../src/common/fmapbase.cpp:148
 msgid "Baltic (old) (ISO-8859-4)"
 msgstr "Bàltic (antic) (ISO-8859-4)"
 
@@ -1592,25 +1588,25 @@ msgstr ""
 msgid "Bitmap"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1594
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Black"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1755
+#: ../src/propgrid/advprops.cpp:1656
 msgid "Blank"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1603
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Blue"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:345
+#: ../src/generic/colrdlgg.cpp:365
 msgid "Blue:"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:333 ../src/richtext/richtextfontpage.cpp:355
-#: ../src/osx/carbon/fontdlg.cpp:354 ../src/common/stockitem.cpp:143
+#: ../src/osx/carbon/fontdlg.cpp:351 ../src/common/stockitem.cpp:140
+#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:355
 msgid "Bold"
 msgstr "Negreta"
 
@@ -1620,34 +1616,38 @@ msgstr "Negreta"
 msgid "Border"
 msgstr "Modern"
 
-#: ../src/richtext/richtextformatdlg.cpp:379
+#: ../src/richtext/richtextformatdlg.cpp:372
 #, fuzzy
 msgid "Borders"
 msgstr "Modern"
 
-#: ../src/richtext/richtextsizepage.cpp:288 ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141 ../src/richtext/richtextsizepage.cpp:288
 msgid "Bottom"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:893
+#: ../src/generic/prntdlgg.cpp:886
 msgid "Bottom margin (mm):"
 msgstr "Marge inferior (mm):"
 
-#: ../src/richtext/richtextbuffer.cpp:9383
+#: ../src/richtext/richtextbuffer.cpp:9380
 #, fuzzy
 msgid "Box Properties"
 msgstr "&Previ"
 
-#: ../src/richtext/richtextstyles.cpp:1065
+#: ../src/richtext/richtextstyles.cpp:1062
 #, fuzzy
 msgid "Box styles"
 msgstr "&Següent >"
 
-#: ../src/propgrid/advprops.cpp:1602
+#: ../src/osx/cocoa/menu.mm:292
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Brown"
 msgstr ""
 
-#: ../src/common/filepickercmn.cpp:43 ../src/common/filepickercmn.cpp:44
+#: ../src/common/filepickercmn.cpp:40 ../src/common/filepickercmn.cpp:41
 msgid "Browse"
 msgstr ""
 
@@ -1660,72 +1660,72 @@ msgstr ""
 msgid "Bullet style"
 msgstr ""
 
-#: ../src/richtext/richtextformatdlg.cpp:359
+#: ../src/richtext/richtextformatdlg.cpp:352
 msgid "Bullets"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1756
+#: ../src/propgrid/advprops.cpp:1657
 msgid "Bullseye"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:875
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonFace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:876
+#: ../src/propgrid/advprops.cpp:777
 msgid "ButtonHighlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:877
+#: ../src/propgrid/advprops.cpp:778
 msgid "ButtonShadow"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:878
+#: ../src/propgrid/advprops.cpp:779
 msgid "ButtonText"
 msgstr ""
 
-#: ../src/common/paper.cpp:98
+#: ../src/common/paper.cpp:95
 msgid "C sheet, 17 x 22 in"
 msgstr "Full C, 17 x 22 polz."
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "C&lear"
 msgstr "&Neteja"
 
-#: ../src/generic/fontdlgg.cpp:406
+#: ../src/generic/fontdlgg.cpp:403
 msgid "C&olour:"
 msgstr ""
 
-#: ../src/common/paper.cpp:123
+#: ../src/common/paper.cpp:120
 msgid "C3 Envelope, 324 x 458 mm"
 msgstr "C3 Sobre, 324 x 458 mm"
 
-#: ../src/common/paper.cpp:124
+#: ../src/common/paper.cpp:121
 msgid "C4 Envelope, 229 x 324 mm"
 msgstr "C4 Sobre, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:122
+#: ../src/common/paper.cpp:119
 msgid "C5 Envelope, 162 x 229 mm"
 msgstr "C5 Sobre, 162 x 229 mm"
 
-#: ../src/common/paper.cpp:125
+#: ../src/common/paper.cpp:122
 msgid "C6 Envelope, 114 x 162 mm"
 msgstr "C6 Sobre, 114 x 162 mm"
 
-#: ../src/common/paper.cpp:126
+#: ../src/common/paper.cpp:123
 msgid "C65 Envelope, 114 x 229 mm"
 msgstr "C65 Sobre, 114 x 229 mm"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "CD-Rom"
 msgstr ""
 
-#: ../src/html/chm.cpp:815 ../src/html/chm.cpp:874
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:865
 #, fuzzy
 msgid "CHM handler currently supports only local files!"
 msgstr "El manegador ZIP generalment només permet l'ús de fitxers locals!"
@@ -1734,194 +1734,198 @@ msgstr "El manegador ZIP generalment només permet l'ús de fitxers locals!"
 msgid "Ca&pitals"
 msgstr ""
 
-#: ../src/common/cmdproc.cpp:267
+#: ../src/common/cmdproc.cpp:260
 msgid "Can't &Undo "
 msgstr "No s'ha pogut &desfer"
 
-#: ../src/common/image.cpp:2824
+#: ../src/common/image.cpp:2924
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 
-#: ../src/msw/registry.cpp:506
+#: ../src/msw/registry.cpp:495
 #, c-format
 msgid "Can't close registry key '%s'"
 msgstr "No es pot tancar la clau de registre '%s'"
 
-#: ../src/msw/registry.cpp:584
+#: ../src/msw/registry.cpp:573
 #, c-format
 msgid "Can't copy values of unsupported type %d."
 msgstr "No es pot copiar els valors del tipus %d no suportat."
 
-#: ../src/msw/registry.cpp:487
+#: ../src/msw/registry.cpp:476
 #, c-format
 msgid "Can't create registry key '%s'"
 msgstr "No es pot crear la clau de registre '%s'"
 
-#: ../src/msw/thread.cpp:665
+#: ../src/msw/thread.cpp:657
 msgid "Can't create thread"
 msgstr "No es pot crear un fil"
 
-#: ../src/msw/window.cpp:3691
-#, c-format
-msgid "Can't create window of class %s"
-msgstr "No es pot crear una finestra de la classe '%s'"
-
-#: ../src/msw/registry.cpp:777
+#: ../src/msw/registry.cpp:765
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "No es pot eliminar la tecla '%s'"
 
-#: ../src/msw/iniconf.cpp:458
+#: ../src/msw/iniconf.cpp:455
 #, c-format
 msgid "Can't delete the INI file '%s'"
 msgstr "No es pot eliminar el fitxer INI '%s'"
 
-#: ../src/msw/registry.cpp:805
+#: ../src/msw/registry.cpp:793
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "No es pot eliminar el valor '%s' de la clau '%s'"
 
-#: ../src/msw/registry.cpp:1171
+#: ../src/msw/registry.cpp:1159
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "No es poden enumerar subclaus de la clau '%s'"
 
-#: ../src/msw/registry.cpp:1132
+#: ../src/msw/registry.cpp:1120
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "No es pot enumerar els valors de la clau '%s'"
 
-#: ../src/msw/registry.cpp:1389
+#: ../src/msw/registry.cpp:1377
 #, fuzzy, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "No es pot copiar els valors del tipus %d no suportat."
 
-#: ../src/common/ffile.cpp:254
+#: ../src/common/ffile.cpp:253
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "No es pot trobar la posició actual en el fitxer '%s'"
 
-#: ../src/msw/registry.cpp:418
+#: ../src/msw/registry.cpp:407
 #, c-format
 msgid "Can't get info about registry key '%s'"
 msgstr "No es pot obtenir informació sobre la clau de registre '%s'"
 
-#: ../src/common/zstream.cpp:346
+#: ../src/msw/webview_ie.cpp:1024
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "No es pot fixar la prioritat fils"
+
+#: ../src/common/zstream.cpp:343
 #, fuzzy
 msgid "Can't initialize zlib deflate stream."
 msgstr "No es pot començar a mostrar."
 
-#: ../src/common/zstream.cpp:185
+#: ../src/common/zstream.cpp:182
 #, fuzzy
 msgid "Can't initialize zlib inflate stream."
 msgstr "No es pot començar a mostrar."
 
-#: ../src/msw/fswatcher.cpp:476
+#: ../src/msw/fswatcher.cpp:475
 #, c-format
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr ""
 
-#: ../src/msw/registry.cpp:454
+#: ../src/msw/registry.cpp:443
 #, c-format
 msgid "Can't open registry key '%s'"
 msgstr "No es pot obrir la clau de registre '%s'"
 
-#: ../src/common/zstream.cpp:252
+#: ../src/common/zstream.cpp:249
 #, fuzzy, c-format
 msgid "Can't read from inflate stream: %s"
 msgstr "no es pot llegir des del fitxer descriptor %s"
 
-#: ../src/common/zstream.cpp:244
+#: ../src/common/zstream.cpp:241
 msgid "Can't read inflate stream: unexpected EOF in underlying stream."
 msgstr ""
 
-#: ../src/msw/registry.cpp:1064
+#: ../src/msw/registry.cpp:1052
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "No es pot llegir el valor de '%s'"
 
-#: ../src/msw/registry.cpp:878 ../src/msw/registry.cpp:910
-#: ../src/msw/registry.cpp:975
+#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
+#: ../src/msw/registry.cpp:963
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "No es pot llegir el valor de la clau '%s'"
 
-#: ../src/common/image.cpp:2620
+#: ../src/msw/webview_ie.cpp:1017
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/common/image.cpp:2715
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "No es pot alçar la imatge en el format '%s': extensió desconeguda."
 
-#: ../src/generic/logg.cpp:573 ../src/generic/logg.cpp:976
+#: ../src/generic/logg.cpp:570 ../src/generic/logg.cpp:973
 msgid "Can't save log contents to file."
 msgstr "No es pot alçar els continguts de registre al fitxer."
 
-#: ../src/msw/thread.cpp:629
+#: ../src/msw/thread.cpp:621
 msgid "Can't set thread priority"
 msgstr "No es pot fixar la prioritat fils"
 
-#: ../src/msw/registry.cpp:896 ../src/msw/registry.cpp:938
-#: ../src/msw/registry.cpp:1081
+#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
+#: ../src/msw/registry.cpp:1069
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "No es pot fixar un valor de '%s'"
 
-#: ../src/unix/utilsunx.cpp:351
+#: ../src/unix/utilsunx.cpp:353
 #, fuzzy
 msgid "Can't write to child process's stdin"
 msgstr "No s'ha pogut acabar el procés %d"
 
-#: ../src/common/zstream.cpp:427
+#: ../src/common/zstream.cpp:424
 #, fuzzy, c-format
 msgid "Can't write to deflate stream: %s"
 msgstr "no es pot escriure en el fitxer descriptiu %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:279 ../src/richtext/richtextstyledlg.cpp:300
-#: ../src/common/stockitem.cpp:145 ../src/common/accelcmn.cpp:71
-#: ../src/msw/msgdlg.cpp:454 ../src/msw/progdlg.cpp:673
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:142
+#: ../src/common/accelcmn.cpp:68 ../src/motif/msgdlg.cpp:196
+#: ../src/gtk1/fontdlg.cpp:144 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/progdlg.cpp:940 ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Anul·la"
 
-#: ../src/common/filefn.cpp:1261
+#: ../src/common/filefn.cpp:1149
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "No es pot enumerar els fitxers '%s'"
 
-#: ../src/msw/dir.cpp:263
+#: ../src/msw/dir.cpp:260
 #, c-format
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "No es pot enumerar els fitxers en el directori '%s'"
 
-#: ../src/msw/dialup.cpp:523
+#: ../src/msw/dialup.cpp:517
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "No es pot trobar connexió activa de marcatge directe: %s"
 
-#: ../src/msw/dialup.cpp:827
+#: ../src/msw/dialup.cpp:821
 msgid "Cannot find the location of address book file"
 msgstr "No es pot localitzar el fitxer del llibre d'adreces"
 
-#: ../src/msw/ole/automtn.cpp:562
+#: ../src/msw/ole/automtn.cpp:553
 #, fuzzy, c-format
 msgid "Cannot get an active instance of \"%s\""
 msgstr "No es pot trobar connexió activa de marcatge directe: %s"
 
-#: ../src/unix/threadpsx.cpp:1035
+#: ../src/unix/threadpsx.cpp:1053
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr ""
 "No es pot obtenir un rang de prioritats per la política de planificació %d."
 
-#: ../src/unix/utilsunx.cpp:987
+#: ../src/unix/utilsunx.cpp:989
 msgid "Cannot get the hostname"
 msgstr "No es pot obtenir el nom d'hostatger"
 
-#: ../src/unix/utilsunx.cpp:1023
+#: ../src/unix/utilsunx.cpp:1025
 msgid "Cannot get the official hostname"
 msgstr "No es pot obtenir el nom oficial de l'hostatger"
 
-#: ../src/msw/dialup.cpp:928
+#: ../src/msw/dialup.cpp:922
 msgid "Cannot hang up - no active dialup connection."
 msgstr "No es pot penjar - no hi ha activa cap connexió de marcatge directe."
 
@@ -1929,129 +1933,129 @@ msgstr "No es pot penjar - no hi ha activa cap connexió de marcatge directe."
 msgid "Cannot initialize OLE"
 msgstr "No es pot inicialitzar OLE"
 
-#: ../src/common/socket.cpp:853
+#: ../src/common/socket.cpp:850
 #, fuzzy
 msgid "Cannot initialize sockets"
 msgstr "No es pot inicialitzar OLE"
 
-#: ../src/msw/volume.cpp:619
+#: ../src/msw/volume.cpp:627
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "No es pot carregar la icona des de '%s'"
 
-#: ../src/xrc/xmlres.cpp:360
+#: ../src/xrc/xmlres.cpp:358
 #, fuzzy, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "No es pot carregar recursos des del fitxer '%s'."
 
-#: ../src/xrc/xmlres.cpp:742
+#: ../src/xrc/xmlres.cpp:740
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "No es pot carregar recursos des del fitxer '%s'."
 
-#: ../src/html/htmlfilt.cpp:137
+#: ../src/html/htmlfilt.cpp:134
 #, c-format
 msgid "Cannot open HTML document: %s"
 msgstr "No es pot obrir el document HTML %s"
 
-#: ../src/html/helpdata.cpp:667
+#: ../src/html/helpdata.cpp:660
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "No es pot obrir el llibre d'ajuda HTML: %s"
 
-#: ../src/html/helpdata.cpp:299
+#: ../src/html/helpdata.cpp:296
 #, c-format
 msgid "Cannot open contents file: %s"
 msgstr "No es pot obrir fitxers de contingut: %s"
 
-#: ../src/generic/dcpsg.cpp:1667
+#: ../src/generic/dcpsg.cpp:1665
 msgid "Cannot open file for PostScript printing!"
 msgstr "No es pot obrir el fitxer per a la impressió PostScript!"
 
-#: ../src/html/helpdata.cpp:313
+#: ../src/html/helpdata.cpp:310
 #, c-format
 msgid "Cannot open index file: %s"
 msgstr "No es pot obrir el fitxer d'índex: %s"
 
-#: ../src/xrc/xmlres.cpp:724
+#: ../src/xrc/xmlres.cpp:722
 #, fuzzy, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "No es pot carregar recursos des del fitxer '%s'."
 
-#: ../src/html/helpwnd.cpp:1534
+#: ../src/html/helpwnd.cpp:1532
 msgid "Cannot print empty page."
 msgstr "No es pot imprimir una pàgina buida."
 
-#: ../src/msw/volume.cpp:507
+#: ../src/msw/volume.cpp:515
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "No es pot llegir el tipus de nom des de '%s'!"
 
-#: ../src/msw/thread.cpp:888
+#: ../src/msw/thread.cpp:894
 #, fuzzy, c-format
 msgid "Cannot resume thread %lx"
 msgstr "No es pot enumerar els fitxers en el directori '%s'"
 
-#: ../src/unix/threadpsx.cpp:1016
+#: ../src/unix/threadpsx.cpp:1028
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "No es pot recuperar la cadena de política de planificació."
 
-#: ../src/common/intl.cpp:558
+#: ../src/common/intl.cpp:365
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:831 ../src/msw/thread.cpp:546
+#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
 msgid "Cannot start thread: error writing TLS."
 msgstr "No es pot iniciar la cadena: error en escriure TLS."
 
-#: ../src/msw/thread.cpp:872
+#: ../src/msw/thread.cpp:864
 #, fuzzy, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "No es pot suspendre en fil %x"
 
-#: ../src/msw/thread.cpp:794
+#: ../src/msw/thread.cpp:786
 msgid "Cannot wait for thread termination"
 msgstr "No es pot esperar per a l'acabament de cadena"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:75
+#: ../src/common/accelcmn.cpp:72
 #, fuzzy
 msgid "Capital"
 msgstr "cursiva"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:879
+#: ../src/propgrid/advprops.cpp:780
 msgid "CaptionText"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:531
 msgid "Case sensitive"
 msgstr "Distingix entre majúscules i minúscules"
 
-#: ../src/propgrid/manager.cpp:1509
+#: ../src/propgrid/manager.cpp:1527
 msgid "Categorized Mode"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9968
+#: ../src/richtext/richtextbuffer.cpp:9965
 #, fuzzy
 msgid "Cell Properties"
 msgstr "&Previ"
 
-#: ../src/common/fmapbase.cpp:161
+#: ../src/common/fmapbase.cpp:158
 msgid "Celtic (ISO-8859-14)"
 msgstr "Cèltic (ISO-8859-14)"
 
-#: ../src/richtext/richtextindentspage.cpp:160
 #: ../src/richtext/richtextliststylepage.cpp:349
+#: ../src/richtext/richtextindentspage.cpp:160
 msgid "Cen&tred"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:170
+#: ../src/common/stockitem.cpp:167
 msgid "Centered"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:149
+#: ../src/common/fmapbase.cpp:146
 msgid "Central European (ISO-8859-2)"
 msgstr "Europeu central (ISO-8859-2)"
 
@@ -2060,10 +2064,10 @@ msgstr "Europeu central (ISO-8859-2)"
 msgid "Centre"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:162
-#: ../src/richtext/richtextindentspage.cpp:164
 #: ../src/richtext/richtextliststylepage.cpp:351
 #: ../src/richtext/richtextliststylepage.cpp:353
+#: ../src/richtext/richtextindentspage.cpp:162
+#: ../src/richtext/richtextindentspage.cpp:164
 #, fuzzy
 msgid "Centre text."
 msgstr "No es pot crear un fil"
@@ -2079,25 +2083,25 @@ msgstr "No es pot crear un fil"
 msgid "Ch&oose..."
 msgstr "&Tanca"
 
-#: ../src/richtext/richtextbuffer.cpp:4354
+#: ../src/richtext/richtextbuffer.cpp:4351
 msgid "Change List Style"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:3709
+#: ../src/richtext/richtextbuffer.cpp:3706
 msgid "Change Object Style"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:3982
-#: ../src/richtext/richtextbuffer.cpp:8129
+#: ../src/richtext/richtextbuffer.cpp:3979
+#: ../src/richtext/richtextbuffer.cpp:8125
 #, fuzzy
 msgid "Change Properties"
 msgstr "&Previ"
 
-#: ../src/richtext/richtextbuffer.cpp:3526
+#: ../src/richtext/richtextbuffer.cpp:3523
 msgid "Change Style"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:341
+#: ../src/common/fileconf.cpp:335
 #, c-format
 msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
 msgstr ""
@@ -2108,11 +2112,11 @@ msgid "Changing current directory to \"%s\" failed"
 msgstr "No s'ha pogut crear un directori %s/.gnome."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1757
+#: ../src/propgrid/advprops.cpp:1658
 msgid "Character"
 msgstr ""
 
-#: ../src/richtext/richtextstyles.cpp:1063
+#: ../src/richtext/richtextstyles.cpp:1060
 msgid "Character styles"
 msgstr ""
 
@@ -2149,20 +2153,20 @@ msgstr ""
 msgid "Check to indicate right-to-left text layout."
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:356 ../src/osx/carbon/fontdlg.cpp:358
+#: ../src/osx/carbon/fontdlg.cpp:353 ../src/osx/carbon/fontdlg.cpp:355
 msgid "Check to make the font bold."
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:363 ../src/osx/carbon/fontdlg.cpp:365
+#: ../src/osx/carbon/fontdlg.cpp:360 ../src/osx/carbon/fontdlg.cpp:362
 msgid "Check to make the font italic."
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:372 ../src/osx/carbon/fontdlg.cpp:374
+#: ../src/osx/carbon/fontdlg.cpp:369 ../src/osx/carbon/fontdlg.cpp:371
 msgid "Check to make the font underlined."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:289
-#: ../src/richtext/richtextstyledlg.cpp:291
+#: ../src/richtext/richtextstyledlg.cpp:285
+#: ../src/richtext/richtextstyledlg.cpp:287
 msgid "Check to restart numbering."
 msgstr ""
 
@@ -2196,56 +2200,56 @@ msgstr ""
 msgid "Check to suppress hyphenation."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:763
+#: ../src/msw/dialup.cpp:757
 msgid "Choose ISP to dial"
 msgstr "Trieu l'ISP a trucar"
 
-#: ../src/propgrid/props.cpp:1922
+#: ../src/propgrid/props.cpp:1904
 #, fuzzy
 msgid "Choose a directory:"
 msgstr "Crea directori"
 
-#: ../src/propgrid/props.cpp:1975
+#: ../src/propgrid/props.cpp:2199
 #, fuzzy
 msgid "Choose a file"
 msgstr "Trieu la font"
 
-#: ../src/generic/colrdlgg.cpp:158 ../src/gtk/colordlg.cpp:54
+#: ../src/generic/colrdlgg.cpp:156 ../src/gtk/colordlg.cpp:49
 #, fuzzy
 msgid "Choose colour"
 msgstr "Trieu la font"
 
-#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/gtk1/fontdlg.cpp:125 ../src/generic/fontpickerg.cpp:47
+#: ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Trieu la font"
 
-#: ../src/common/module.cpp:74
+#: ../src/common/module.cpp:71
 #, c-format
 msgid "Circular dependency involving module \"%s\" detected."
 msgstr ""
 
-#: ../src/aui/tabmdi.cpp:108 ../src/generic/mdig.cpp:97
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
 msgid "Cl&ose"
 msgstr "&Tanca"
 
-#: ../src/msw/ole/automtn.cpp:684
+#: ../src/msw/ole/automtn.cpp:675
 #, fuzzy
 msgid "Class not registered."
 msgstr "No es pot crear un fil"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:147 ../src/common/accelcmn.cpp:72
+#: ../src/common/stockitem.cpp:144 ../src/common/accelcmn.cpp:69
 #, fuzzy
 msgid "Clear"
 msgstr "&Neteja"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "Clear the log contents"
 msgstr "Neteja els continguts del registre."
 
-#: ../src/richtext/richtextstyledlg.cpp:252
-#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:248
+#: ../src/richtext/richtextstyledlg.cpp:250
 msgid "Click to apply the selected style."
 msgstr ""
 
@@ -2256,15 +2260,15 @@ msgstr ""
 msgid "Click to browse for a symbol."
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:403 ../src/osx/carbon/fontdlg.cpp:405
+#: ../src/osx/carbon/fontdlg.cpp:400 ../src/osx/carbon/fontdlg.cpp:402
 msgid "Click to cancel changes to the font."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:472 ../src/generic/fontdlgg.cpp:491
+#: ../src/generic/fontdlgg.cpp:468 ../src/generic/fontdlgg.cpp:487
 msgid "Click to cancel the font selection."
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:384 ../src/osx/carbon/fontdlg.cpp:386
+#: ../src/osx/carbon/fontdlg.cpp:381 ../src/osx/carbon/fontdlg.cpp:383
 msgid "Click to change the font colour."
 msgstr ""
 
@@ -2283,38 +2287,38 @@ msgstr ""
 msgid "Click to choose the font for this level."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:279
-#: ../src/richtext/richtextstyledlg.cpp:281
+#: ../src/richtext/richtextstyledlg.cpp:275
+#: ../src/richtext/richtextstyledlg.cpp:277
 #, fuzzy
 msgid "Click to close this window."
 msgstr "Tanca esta finestra"
 
-#: ../src/osx/carbon/fontdlg.cpp:410 ../src/osx/carbon/fontdlg.cpp:412
+#: ../src/osx/carbon/fontdlg.cpp:407 ../src/osx/carbon/fontdlg.cpp:409
 msgid "Click to confirm changes to the font."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:477 ../src/generic/fontdlgg.cpp:479
-#: ../src/generic/fontdlgg.cpp:484 ../src/generic/fontdlgg.cpp:486
+#: ../src/generic/fontdlgg.cpp:473 ../src/generic/fontdlgg.cpp:475
+#: ../src/generic/fontdlgg.cpp:480 ../src/generic/fontdlgg.cpp:482
 msgid "Click to confirm the font selection."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:244
-#: ../src/richtext/richtextstyledlg.cpp:246
+#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:242
 msgid "Click to create a new box style."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:226
-#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:224
 msgid "Click to create a new character style."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:238
-#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:236
 msgid "Click to create a new list style."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:232
-#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:230
 msgid "Click to create a new paragraph style."
 msgstr ""
 
@@ -2328,8 +2332,8 @@ msgstr ""
 msgid "Click to delete all tab positions."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:270
-#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:268
 msgid "Click to delete the selected style."
 msgstr ""
 
@@ -2338,25 +2342,25 @@ msgstr ""
 msgid "Click to delete the selected tab position."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:264
-#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:262
 msgid "Click to edit the selected style."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:258
-#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:256
 msgid "Click to rename the selected style."
 msgstr ""
 
-#: ../src/generic/dbgrptg.cpp:97 ../src/generic/progdlgg.cpp:759
-#: ../src/richtext/richtextstyledlg.cpp:277
-#: ../src/richtext/richtextsymboldlg.cpp:476 ../src/common/stockitem.cpp:148
-#: ../src/msw/progdlg.cpp:170 ../src/msw/progdlg.cpp:679
-#: ../src/html/helpdlg.cpp:90
+#: ../src/common/stockitem.cpp:145 ../src/generic/dbgrptg.cpp:94
+#: ../src/generic/progdlgg.cpp:781 ../src/msw/progdlg.cpp:211
+#: ../src/msw/progdlg.cpp:946 ../src/html/helpdlg.cpp:87
+#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextstyledlg.cpp:273
 msgid "Close"
 msgstr "Tanca"
 
-#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:98
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
 msgid "Close All"
 msgstr "Tanca-ho tot"
 
@@ -2364,67 +2368,67 @@ msgstr "Tanca-ho tot"
 msgid "Close current document"
 msgstr ""
 
-#: ../src/generic/logg.cpp:516
+#: ../src/generic/logg.cpp:513
 msgid "Close this window"
 msgstr "Tanca esta finestra"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6006
+#: ../src/generic/datavgen.cpp:6811
 msgid "Collapse"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 #, fuzzy
 msgid "Color"
 msgstr "Trieu la font"
 
-#: ../src/richtext/richtextformatdlg.cpp:776
+#: ../src/richtext/richtextformatdlg.cpp:768
 #, fuzzy
 msgid "Colour"
 msgstr "Trieu la font"
 
-#: ../src/msw/colordlg.cpp:158
+#: ../src/msw/colordlg.cpp:227
 #, fuzzy, c-format
 msgid "Colour selection dialog failed with error %0lx."
 msgstr "L'execució de l'orde '%s' ha fallit."
 
-#: ../src/osx/carbon/fontdlg.cpp:380
+#: ../src/osx/carbon/fontdlg.cpp:377
 msgid "Colour:"
 msgstr ""
 
-#: ../src/generic/datavgen.cpp:6077
+#: ../src/generic/datavgen.cpp:6882
 #, c-format
 msgid "Column %u"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:114
+#: ../src/common/accelcmn.cpp:112
 msgid "Command"
 msgstr ""
 
-#: ../src/common/init.cpp:196
+#: ../src/common/init.cpp:193
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
 "ignored."
 msgstr ""
 
-#: ../src/msw/fontdlg.cpp:120
+#: ../src/msw/fontdlg.cpp:170
 #, fuzzy, c-format
 msgid "Common dialog failed with error code %0lx."
 msgstr "L'execució de l'orde '%s' ha fallit."
 
-#: ../src/gtk/window.cpp:4649
+#: ../src/gtk/window.cpp:5653
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:1549
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr ""
 
-#: ../src/generic/dirctrlg.cpp:444
+#: ../src/generic/dirctrlg.cpp:410
 msgid "Computer"
 msgstr "Ordinador"
 
@@ -2433,56 +2437,60 @@ msgstr "Ordinador"
 msgid "Config entry name cannot start with '%c'."
 msgstr "No es pot iniciar un nom d'entrada de configuració per '%c'."
 
-#: ../src/generic/filedlgg.cpp:349 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
 msgid "Confirm"
 msgstr "Confirma"
 
-#: ../src/html/htmlwin.cpp:566
+#: ../src/html/htmlwin.cpp:569
 msgid "Connecting..."
 msgstr "S'està connectant"
 
-#: ../src/html/helpwnd.cpp:475
+#: ../src/html/helpwnd.cpp:473
 msgid "Contents"
 msgstr "Contingut"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:880
+#: ../src/propgrid/advprops.cpp:781
 msgid "ControlDark"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:881
+#: ../src/propgrid/advprops.cpp:782
 msgid "ControlLight"
 msgstr ""
 
-#: ../src/common/strconv.cpp:2262
+#: ../src/common/strconv.cpp:2208
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "La conversió al joc de caràcters '%s' no funciona."
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 #, fuzzy
 msgid "Convert"
 msgstr "Contingut"
 
-#: ../src/html/htmlwin.cpp:1079
+#: ../src/html/htmlwin.cpp:1020
 #, fuzzy, c-format
 msgid "Copied to clipboard:\"%s\""
 msgstr "No s'ha pogut fixar les dades del porta-retalls"
 
-#: ../src/generic/prntdlgg.cpp:247
+#: ../src/generic/prntdlgg.cpp:240
 msgid "Copies:"
 msgstr "Còpies:"
 
-#: ../src/common/stockitem.cpp:150 ../src/stc/stc_i18n.cpp:18
+#: ../src/common/stockitem.cpp:147 ../src/stc/stc_i18n.cpp:18
 #, fuzzy
 msgid "Copy"
 msgstr "&Copia"
 
-#: ../src/common/stockitem.cpp:258
+#: ../src/common/stockitem.cpp:255
 #, fuzzy
 msgid "Copy selection"
 msgstr "Seccions"
+
+#: ../src/generic/grid.cpp:5945
+msgid "Copying more than one selected block to clipboard is not supported."
+msgstr ""
 
 #: ../src/richtext/richtextborderspage.cpp:566
 #: ../src/richtext/richtextborderspage.cpp:601
@@ -2493,211 +2501,205 @@ msgstr ""
 msgid "Corner &radius:"
 msgstr ""
 
-#: ../src/html/chm.cpp:718
+#: ../src/html/chm.cpp:711
 #, fuzzy, c-format
 msgid "Could not create temporary file '%s'"
 msgstr "no es pot extreure el fitxer temporal '%s'"
 
-#: ../src/html/chm.cpp:273
+#: ../src/html/chm.cpp:270
 #, c-format
 msgid "Could not extract %s into %s: %s"
 msgstr ""
 
-#: ../src/generic/tabg.cpp:1048
+#: ../src/generic/tabg.cpp:1045
 msgid "Could not find tab for id"
 msgstr "No es pot trobar la pestanya per a id"
 
-#: ../src/gtk/notifmsg.cpp:108
-#, fuzzy
-msgid "Could not initalize libnotify."
-msgstr "No s'ha pogut iniciar la impressió"
-
-#: ../src/html/chm.cpp:444
+#: ../src/html/chm.cpp:437
 #, fuzzy, c-format
 msgid "Could not locate file '%s'."
 msgstr "No es pot obrir el fitxer '%s'."
 
-#: ../src/common/filefn.cpp:1403
+#: ../src/msw/graphicsd2d.cpp:604
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/common/filefn.cpp:1291
 #, fuzzy
 msgid "Could not set current working directory"
 msgstr "No s'ha pogut obtenir el directori en funcionament"
 
-#: ../src/common/prntbase.cpp:2015
+#: ../src/common/prntbase.cpp:2037
 msgid "Could not start document preview."
 msgstr "No s'ha pogut iniciar la previsualització del document."
 
-#: ../src/generic/printps.cpp:178 ../src/msw/printwin.cpp:210
-#: ../src/gtk/print.cpp:1132
+#: ../src/generic/printps.cpp:159 ../src/msw/printwin.cpp:184
+#: ../src/gtk/print.cpp:1129
 msgid "Could not start printing."
 msgstr "No s'ha pogut iniciar la impressió"
 
-#: ../src/common/wincmn.cpp:2125
+#: ../src/common/wincmn.cpp:2126
 msgid "Could not transfer data to window"
 msgstr "No s'ha pogut transferir dades a la finestra"
 
-#: ../src/msw/imaglist.cpp:187 ../src/msw/imaglist.cpp:224
-#: ../src/msw/imaglist.cpp:249 ../src/msw/dragimag.cpp:185
-#: ../src/msw/dragimag.cpp:220
+#: ../src/msw/imaglist.cpp:223 ../src/msw/imaglist.cpp:245
+#: ../src/msw/imaglist.cpp:270 ../src/msw/dragimag.cpp:182
+#: ../src/msw/dragimag.cpp:217
 msgid "Couldn't add an image to the image list."
 msgstr "No s'ha pogut afegir una imatge al llistat d'imatges."
 
-#: ../src/osx/glcanvas_osx.cpp:414 ../src/unix/glx11.cpp:558
-#: ../src/msw/glcanvas.cpp:616
+#: ../src/osx/glcanvas_osx.cpp:411 ../src/msw/glcanvas.cpp:631
+#: ../src/unix/glegl.cpp:315 ../src/unix/glx11.cpp:559
 #, fuzzy
 msgid "Couldn't create OpenGL context"
 msgstr "No s'ha pogut crear un temporitzador"
 
-#: ../src/msw/timer.cpp:134
+#: ../src/msw/timer.cpp:131
 msgid "Couldn't create a timer"
 msgstr "No s'ha pogut crear un temporitzador"
 
-#: ../src/osx/carbon/overlay.cpp:122
-#, fuzzy
-msgid "Couldn't create the overlay window"
-msgstr "No s'ha pogut crear un temporitzador"
-
-#: ../src/common/translation.cpp:2024
+#: ../src/common/translation.cpp:2074
 #, fuzzy
 msgid "Couldn't enumerate translations"
 msgstr "No s'ha acabat la cadena"
 
-#: ../src/common/dynlib.cpp:120
+#: ../src/common/dynlib.cpp:110
 #, c-format
 msgid "Couldn't find symbol '%s' in a dynamic library"
 msgstr "No s'ha pogut trobar el símbol '%s' en una llibreria dinàmica"
 
-#: ../src/msw/thread.cpp:915
+#: ../src/msw/thread.cpp:921
 msgid "Couldn't get the current thread pointer"
 msgstr "No es pot obtenir l'actual cadena de punter"
 
-#: ../src/osx/carbon/overlay.cpp:129
-#, fuzzy
-msgid "Couldn't init the context on the overlay window"
-msgstr "No es pot obtenir l'actual cadena de punter"
-
-#: ../src/common/imaggif.cpp:244
+#: ../src/common/imaggif.cpp:241
 #, fuzzy
 msgid "Couldn't initialize GIF hash table."
 msgstr "No es pot començar a mostrar."
 
-#: ../src/common/imagpng.cpp:409
+#: ../src/common/imagpng.cpp:437
 msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
 msgstr ""
 "No s'ha pogut carregar una imatge PNG - el fitxer és corromput o no hi ha "
 "prou memòria."
 
-#: ../src/unix/sound.cpp:470
+#: ../src/unix/sound.cpp:459
 #, fuzzy, c-format
 msgid "Couldn't load sound data from '%s'."
 msgstr "No es pot carregar la icona des de '%s'"
 
-#: ../src/msw/dirdlg.cpp:435
+#: ../src/msw/dirdlg.cpp:287
 #, fuzzy
 msgid "Couldn't obtain folder name"
 msgstr "No s'ha pogut crear un temporitzador"
 
-#: ../src/unix/sound_sdl.cpp:229
+#: ../src/unix/sound_sdl.cpp:226
 #, fuzzy, c-format
 msgid "Couldn't open audio: %s"
 msgstr "No es pot obrir el fitxer '%s'"
 
-#: ../src/msw/ole/dataobj.cpp:377
+#: ../src/msw/ole/dataobj.cpp:385
 #, c-format
 msgid "Couldn't register clipboard format '%s'."
 msgstr "No s'ha pogut registrar el format '%s' del porta-retalls."
 
-#: ../src/msw/listctrl.cpp:869
+#: ../src/msw/listctrl.cpp:933
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr ""
 "No es pot recuperar informació sobre els llistat %d de controls d'elements."
 
-#: ../src/common/imagpng.cpp:498 ../src/common/imagpng.cpp:509
-#: ../src/common/imagpng.cpp:519
+#: ../src/common/imagpng.cpp:511 ../src/common/imagpng.cpp:522
+#: ../src/common/imagpng.cpp:532
 msgid "Couldn't save PNG image."
 msgstr "No s'ha pogut alçar la imatge PNG."
 
-#: ../src/msw/thread.cpp:684
+#: ../src/msw/thread.cpp:676
 msgid "Couldn't terminate thread"
 msgstr "No s'ha acabat la cadena"
 
-#: ../src/common/xtistrm.cpp:166
+#: ../src/common/xtistrm.cpp:163
 #, c-format
 msgid "Create Parameter %s not found in declared RTTI Parameters"
 msgstr ""
 
-#: ../src/generic/dirdlgg.cpp:288
+#: ../src/generic/dirdlgg.cpp:285
 msgid "Create directory"
 msgstr "Crea directori"
 
-#: ../src/generic/filedlgg.cpp:212 ../src/generic/dirdlgg.cpp:111
+#: ../src/generic/filedlgg.cpp:209 ../src/generic/dirdlgg.cpp:108
 msgid "Create new directory"
 msgstr "Crea un directori nou"
 
-#: ../src/xrc/xmlres.cpp:2460
+#: ../src/common/stockitem.cpp:264
+#, fuzzy
+msgid "Create new document"
+msgstr "Crea un directori nou"
+
+#: ../src/xrc/xmlres.cpp:2515
 #, fuzzy, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "L'execució de l'orde '%s' ha fallit."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1758
+#: ../src/propgrid/advprops.cpp:1659
 msgid "Cross"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:333
+#: ../src/common/accelcmn.cpp:347
 #, fuzzy
 msgid "Ctrl+"
 msgstr "control"
 
-#: ../src/richtext/richtextctrl.cpp:332 ../src/osx/textctrl_osx.cpp:576
-#: ../src/common/stockitem.cpp:151 ../src/msw/textctrl.cpp:2507
+#: ../src/osx/textctrl_osx.cpp:594 ../src/common/stockitem.cpp:148
+#: ../src/msw/textctrl.cpp:2772 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "Re&talla"
 
-#: ../src/generic/filectrlg.cpp:940
+#: ../src/generic/filectrlg.cpp:936
 msgid "Current directory:"
 msgstr "Directori actual:"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:896 ../src/propgrid/advprops.cpp:1574
-#: ../src/propgrid/advprops.cpp:1612
+#: ../src/propgrid/advprops.cpp:797 ../src/propgrid/advprops.cpp:1475
+#: ../src/propgrid/advprops.cpp:1518
 #, fuzzy
 msgid "Custom"
 msgstr "Grandària de la font:"
 
-#: ../src/gtk/print.cpp:217
+#: ../src/gtk/print.cpp:211
 #, fuzzy
 msgid "Custom size"
 msgstr "Grandària de la font:"
 
-#: ../src/common/headerctrlcmn.cpp:60
+#: ../src/common/headerctrlcmn.cpp:58
 #, fuzzy
 msgid "Customize Columns"
 msgstr "Grandària de la font:"
 
-#: ../src/common/stockitem.cpp:151 ../src/stc/stc_i18n.cpp:17
+#: ../src/common/stockitem.cpp:148 ../src/stc/stc_i18n.cpp:17
 #, fuzzy
 msgid "Cut"
 msgstr "Re&talla"
 
-#: ../src/common/stockitem.cpp:259
+#: ../src/common/stockitem.cpp:256
 #, fuzzy
 msgid "Cut selection"
 msgstr "Seccions"
 
-#: ../src/common/fmapbase.cpp:152
+#: ../src/common/fmapbase.cpp:149
 msgid "Cyrillic (ISO-8859-5)"
 msgstr "Ciríl·lic (ISO-8859-5)"
 
-#: ../src/common/paper.cpp:99
+#: ../src/common/paper.cpp:96
 msgid "D sheet, 22 x 34 in"
 msgstr "Full D 22 x 34 polzades"
 
-#: ../src/msw/dde.cpp:703
+#: ../src/msw/dde.cpp:698
 msgid "DDE poke request failed"
 msgstr "Sol·licitud de DDE poke fallida"
 
-#: ../src/common/imagbmp.cpp:1169
+#: ../src/common/imagbmp.cpp:1181
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr "Capçalera DIB: la codificació no coincidix amb la profunditat de bits."
 
@@ -2717,7 +2719,7 @@ msgstr "Capçalera DIB: profunditat de bits desconeguda en el fitxer."
 msgid "DIB Header: Unknown encoding in file."
 msgstr "Capçalera DIB: codificació desconeguda en el fitxer."
 
-#: ../src/common/paper.cpp:121
+#: ../src/common/paper.cpp:118
 msgid "DL Envelope, 110 x 220 mm"
 msgstr "Sobre DL, 110 x 220 mm"
 
@@ -2726,58 +2728,58 @@ msgstr "Sobre DL, 110 x 220 mm"
 msgid "Dashed"
 msgstr "Data"
 
-#: ../src/generic/dbgrptg.cpp:300
+#: ../src/generic/dbgrptg.cpp:301
 #, c-format
 msgid "Debug report \"%s\""
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:210
+#: ../src/common/debugrpt.cpp:211
 #, fuzzy
 msgid "Debug report couldn't be created."
 msgstr "No s'ha pogut crear el directori '%s'"
 
-#: ../src/common/debugrpt.cpp:553
+#: ../src/common/debugrpt.cpp:554
 msgid "Debug report generation has failed."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:84
+#: ../src/common/accelcmn.cpp:81
 msgid "Decimal"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:323
+#: ../src/generic/fontdlgg.cpp:319
 msgid "Decorative"
 msgstr "Decoratiu"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1752
+#: ../src/propgrid/advprops.cpp:1653
 #, fuzzy
 msgid "Default"
 msgstr "predeterminat"
 
-#: ../src/common/fmapbase.cpp:796
+#: ../src/common/fmapbase.cpp:792
 msgid "Default encoding"
 msgstr "Codificació predeterminada"
 
-#: ../src/dfb/fontmgr.cpp:180
+#: ../src/dfb/fontmgr.cpp:177
 #, fuzzy
 msgid "Default font"
 msgstr "Codificació predeterminada"
 
-#: ../src/generic/prntdlgg.cpp:510
+#: ../src/generic/prntdlgg.cpp:503
 #, fuzzy
 msgid "Default printer"
 msgstr "Codificació predeterminada"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:51
+#: ../src/common/accelcmn.cpp:48
 #, fuzzy
 msgid "Del"
 msgstr "&Elimina"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextbuffer.cpp:8221 ../src/common/stockitem.cpp:152
-#: ../src/common/accelcmn.cpp:50 ../src/stc/stc_i18n.cpp:20
+#: ../src/common/stockitem.cpp:149 ../src/common/accelcmn.cpp:47
+#: ../src/richtext/richtextbuffer.cpp:8217 ../src/stc/stc_i18n.cpp:20
 #, fuzzy
 msgid "Delete"
 msgstr "&Elimina"
@@ -2787,75 +2789,75 @@ msgstr "&Elimina"
 msgid "Delete A&ll"
 msgstr "Selecciona-ho &tot"
 
-#: ../src/richtext/richtextbuffer.cpp:11341
+#: ../src/richtext/richtextbuffer.cpp:11340
 #, fuzzy
 msgid "Delete Column"
 msgstr "Seccions"
 
-#: ../src/richtext/richtextbuffer.cpp:11291
+#: ../src/richtext/richtextbuffer.cpp:11290
 #, fuzzy
 msgid "Delete Row"
 msgstr "&Elimina"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 #, fuzzy
 msgid "Delete Style"
 msgstr "&Elimina"
 
-#: ../src/richtext/richtextctrl.cpp:1345 ../src/richtext/richtextctrl.cpp:1584
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
 #, fuzzy
 msgid "Delete Text"
 msgstr "&Elimina"
 
-#: ../src/generic/editlbox.cpp:170
+#: ../src/generic/editlbox.cpp:147
 #, fuzzy
 msgid "Delete item"
 msgstr "&Elimina"
 
-#: ../src/common/stockitem.cpp:260
+#: ../src/common/stockitem.cpp:257
 #, fuzzy
 msgid "Delete selection"
 msgstr "Seccions"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 #, fuzzy, c-format
 msgid "Delete style %s?"
 msgstr "&Elimina"
 
-#: ../src/unix/snglinst.cpp:301
+#: ../src/unix/snglinst.cpp:298
 #, c-format
 msgid "Deleted stale lock file '%s'."
 msgstr "S'ha eliminat el fitxer antic de bloqueig '%s'."
 
-#: ../src/common/secretstore.cpp:220
+#: ../src/common/secretstore.cpp:234
 #, fuzzy, c-format
-msgid "Deleting password for \"%s/%s\" failed: %s."
+msgid "Deleting password for \"%s\" failed: %s."
 msgstr "L'execució de l'orde '%s' ha fallit."
 
-#: ../src/common/module.cpp:124
+#: ../src/common/module.cpp:121
 #, c-format
 msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 #, fuzzy
 msgid "Descending"
 msgstr "Codificació predeterminada"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:526 ../src/propgrid/advprops.cpp:882
+#: ../src/generic/dirctrlg.cpp:492 ../src/propgrid/advprops.cpp:783
 msgid "Desktop"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:70
+#: ../src/generic/aboutdlgg.cpp:67
 msgid "Developed by "
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:176
+#: ../src/generic/aboutdlgg.cpp:173
 msgid "Developers"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:374
+#: ../src/msw/dialup.cpp:368
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -2864,11 +2866,11 @@ msgstr ""
 "d'accés remot (RAS) no es troba instal·lat en este maquinari. Reinstal·leu-"
 "ho."
 
-#: ../src/generic/tipdlg.cpp:211
+#: ../src/generic/tipdlg.cpp:208
 msgid "Did you know..."
 msgstr "Sabíeu que..."
 
-#: ../src/dfb/wrapdfb.cpp:63
+#: ../src/dfb/wrapdfb.cpp:60
 #, c-format
 msgid "DirectFB error %d occurred."
 msgstr ""
@@ -2878,30 +2880,30 @@ msgstr ""
 msgid "Directories"
 msgstr "Decoratiu"
 
-#: ../src/common/filefn.cpp:1183
+#: ../src/common/filefn.cpp:1071
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "No s'ha pogut crear el directori '%s'"
 
-#: ../src/common/filefn.cpp:1197
+#: ../src/common/filefn.cpp:1085
 #, fuzzy, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "No s'ha pogut crear el directori '%s'"
 
-#: ../src/generic/dirdlgg.cpp:204
+#: ../src/generic/dirdlgg.cpp:201
 msgid "Directory does not exist"
 msgstr "Directori no existix"
 
-#: ../src/generic/filectrlg.cpp:1399
+#: ../src/generic/filectrlg.cpp:1388
 #, fuzzy
 msgid "Directory doesn't exist."
 msgstr "Directori no existix"
 
-#: ../src/common/docview.cpp:457
+#: ../src/common/docview.cpp:450
 msgid "Discard changes and reload the last saved version?"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:502
+#: ../src/html/helpwnd.cpp:500
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -2909,45 +2911,45 @@ msgstr ""
 "Mostra tots els elements de l'índex que continguin la subcadena donada. La "
 "recerca no distingix majúscules de minúscules."
 
-#: ../src/html/helpwnd.cpp:679
+#: ../src/html/helpwnd.cpp:677
 msgid "Display options dialog"
 msgstr "Mostra les opcions del diàleg"
 
-#: ../src/html/helpwnd.cpp:322
+#: ../src/html/helpwnd.cpp:320
 msgid "Displays help as you browse the books on the left."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:85
+#: ../src/common/accelcmn.cpp:83
 msgid "Divide"
 msgstr ""
 
-#: ../src/common/docview.cpp:533
+#: ../src/common/docview.cpp:526
 #, fuzzy, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Voleu alçar els canvis del document"
 
-#: ../src/common/prntbase.cpp:542
+#: ../src/common/prntbase.cpp:537
 msgid "Document:"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:73
+#: ../src/generic/aboutdlgg.cpp:70
 msgid "Documentation by "
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:180
+#: ../src/generic/aboutdlgg.cpp:177
 msgid "Documentation writers"
 msgstr ""
 
-#: ../src/common/sizer.cpp:2799
+#: ../src/common/sizer.cpp:2916
 msgid "Don't Save"
 msgstr ""
 
-#: ../src/html/htmlwin.cpp:633
+#: ../src/html/htmlwin.cpp:643
 msgid "Done"
 msgstr "Fet"
 
-#: ../src/generic/progdlgg.cpp:448 ../src/msw/progdlg.cpp:407
+#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
 msgid "Done."
 msgstr "Fet."
 
@@ -2961,43 +2963,43 @@ msgstr "Fet"
 msgid "Double"
 msgstr "Fet"
 
-#: ../src/common/paper.cpp:176
+#: ../src/common/paper.cpp:173
 msgid "Double Japanese Postcard Rotated 148 x 200 mm"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:273
+#: ../src/common/xtixml.cpp:269
 #, c-format
 msgid "Doubly used id : %d"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:153
-#: ../src/common/accelcmn.cpp:64
+#: ../src/common/stockitem.cpp:150 ../src/common/accelcmn.cpp:61
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Down"
 msgstr "Avall"
 
-#: ../src/richtext/richtextctrl.cpp:865
+#: ../src/richtext/richtextctrl.cpp:864
 msgid "Drag"
 msgstr ""
 
-#: ../src/common/paper.cpp:100
+#: ../src/common/paper.cpp:97
 msgid "E sheet, 34 x 44 in"
 msgstr "Full E, 34 x 44 polz."
 
-#: ../src/unix/fswatcher_inotify.cpp:561
+#: ../src/unix/fswatcher_inotify.cpp:558
 #, fuzzy
 msgid "EOF while reading from inotify descriptor"
 msgstr "no es pot llegir des del fitxer descriptor %s"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "Edit"
 msgstr ""
 
-#: ../src/generic/editlbox.cpp:168
+#: ../src/generic/editlbox.cpp:131
 msgid "Edit item"
 msgstr ""
 
-#: ../include/wx/generic/progdlgg.h:84
+#: ../include/wx/generic/progdlgg.h:85
 #, fuzzy
 msgid "Elapsed time:"
 msgstr "Temps transcorregut:"
@@ -3069,51 +3071,51 @@ msgid "Enables the shadow spread."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:66
+#: ../src/common/accelcmn.cpp:63
 msgid "End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:55
+#: ../src/common/accelcmn.cpp:52
 #, fuzzy
 msgid "Enter"
 msgstr "Imprimix"
 
-#: ../src/richtext/richtextstyledlg.cpp:934
+#: ../src/richtext/richtextstyledlg.cpp:930
 msgid "Enter a box style name"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:602
 msgid "Enter a character style name"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:816
 msgid "Enter a list style name"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:893
+#: ../src/richtext/richtextstyledlg.cpp:889
 msgid "Enter a new style name"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:650
 msgid "Enter a paragraph style name"
 msgstr ""
 
-#: ../src/generic/dbgrptg.cpp:174
+#: ../src/generic/dbgrptg.cpp:171
 #, fuzzy, c-format
 msgid "Enter command to open file \"%s\":"
 msgstr "no s'ha pogut obrir el fitxer '%s'"
 
-#: ../src/generic/helpext.cpp:459
+#: ../src/generic/helpext.cpp:457
 msgid "Entries found"
 msgstr "Entrades trobades:"
 
-#: ../src/common/paper.cpp:142
+#: ../src/common/paper.cpp:139
 #, fuzzy
 msgid "Envelope Invite 220 x 220 mm"
 msgstr "Sobre DL, 110 x 220 mm"
 
-#: ../src/common/config.cpp:469
+#: ../src/common/config.cpp:465
 #, fuzzy, c-format
 msgid ""
 "Environment variables expansion failed: missing '%c' at position %u in '%s'."
@@ -3121,13 +3123,13 @@ msgstr ""
 "Ha fallat l'expansió de las variables d'entorn: falta '%c' en la posició %d "
 "a '%s'."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/generic/dirctrlg.cpp:570
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/dirctrlg.cpp:599
-#: ../src/generic/dirdlgg.cpp:323 ../src/generic/filectrlg.cpp:642
-#: ../src/generic/filectrlg.cpp:756 ../src/generic/filectrlg.cpp:770
-#: ../src/generic/filectrlg.cpp:786 ../src/generic/filectrlg.cpp:1368
-#: ../src/generic/filectrlg.cpp:1399 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/gtk1/fontdlg.cpp:74 ../src/generic/dirctrlg.cpp:536
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/dirctrlg.cpp:565
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1357 ../src/generic/filectrlg.cpp:1388
+#: ../src/generic/filedlgg.cpp:354 ../src/generic/dirdlgg.cpp:320
+#: ../src/gtk/filedlg.cpp:74
 msgid "Error"
 msgstr "Error"
 
@@ -3136,246 +3138,267 @@ msgstr "Error"
 msgid "Error closing epoll descriptor"
 msgstr "Error en crear directori"
 
-#: ../src/unix/fswatcher_kqueue.cpp:114
+#: ../src/unix/fswatcher_kqueue.cpp:131
 #, fuzzy
 msgid "Error closing kqueue instance"
 msgstr "Error en crear directori"
 
-#: ../src/common/filefn.cpp:1049
+#: ../src/common/filefn.cpp:938
 #, fuzzy, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Impossible de copiar el fitxer '%s' a '%s'"
 
-#: ../src/generic/dirdlgg.cpp:222
+#: ../src/generic/dirdlgg.cpp:219
 msgid "Error creating directory"
 msgstr "Error en crear directori"
 
-#: ../src/common/imagbmp.cpp:1181
+#: ../src/common/imagbmp.cpp:1193
 #, fuzzy
 msgid "Error in reading image DIB."
 msgstr "Error en llegir imatge DIB"
 
-#: ../src/propgrid/propgrid.cpp:6696
+#: ../src/propgrid/propgrid.cpp:6665
 #, c-format
 msgid "Error in resource: %s"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:422
+#: ../src/common/fileconf.cpp:421
 #, fuzzy
 msgid "Error reading config options."
 msgstr "Error en llegir imatge DIB"
+
+#: ../src/msw/webview_ie.cpp:1057 ../src/msw/webview_edge.cpp:850
+#: ../src/gtk/webview_webkit2.cpp:1262 ../src/osx/webview_webkit.mm:383
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
 
 #: ../src/common/fileconf.cpp:1029
 #, fuzzy
 msgid "Error saving user configuration data."
 msgstr "Error en llegir imatge DIB"
 
-#: ../src/gtk/print.cpp:722
+#: ../src/gtk/print.cpp:720
 #, fuzzy
 msgid "Error while printing: "
 msgstr "Espereu mentre simprimix\n"
 
-#: ../src/common/log.cpp:219
+#: ../src/common/log.cpp:237
 msgid "Error: "
 msgstr "Error: "
 
+#: ../src/common/webrequest.cpp:98
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Error: "
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:69
+#: ../src/common/accelcmn.cpp:66
 msgid "Esc"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:70
+#: ../src/common/accelcmn.cpp:67
 #, fuzzy
 msgid "Escape"
 msgstr "Apaïsat"
 
-#: ../src/common/fmapbase.cpp:150
+#: ../src/common/fmapbase.cpp:147
 msgid "Esperanto (ISO-8859-3)"
 msgstr "Esperanto (ISO-8859-3)"
 
-#: ../include/wx/generic/progdlgg.h:85
+#: ../include/wx/generic/progdlgg.h:86
 #, fuzzy
 msgid "Estimated time:"
 msgstr "Temps estimat:"
 
-#: ../src/generic/dbgrptg.cpp:234
+#: ../src/generic/dbgrptg.cpp:231
 #, fuzzy
 msgid "Executable files (*.exe)|*.exe|"
 msgstr "Tots els fitxers (*.*) *.*  "
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:155 ../src/common/accelcmn.cpp:78
+#: ../src/common/stockitem.cpp:152 ../src/common/accelcmn.cpp:75
 msgid "Execute"
 msgstr ""
 
-#: ../src/msw/utilsexc.cpp:876
+#: ../src/msw/utilsexc.cpp:873
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "L'execució de l'orde '%s' ha fallit."
 
-#: ../src/common/paper.cpp:105
+#: ../src/common/paper.cpp:102
 msgid "Executive, 7 1/4 x 10 1/2 in"
 msgstr "Executiu (7 1/4 x 10 1/2 polz. )"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6009
+#: ../src/generic/datavgen.cpp:6814
 msgid "Expand"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1240
+#: ../src/msw/registry.cpp:1228
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:195
+#: ../src/common/fmapbase.cpp:192
 msgid "Extended Unix Codepage for Japanese (EUC-JP)"
 msgstr "Codificació de pàgina estesa per al japonès (EUC-JP)"
 
-#: ../src/html/chm.cpp:725
+#: ../src/html/chm.cpp:718
 #, fuzzy, c-format
 msgid "Extraction of '%s' into '%s' failed."
 msgstr "L'execució de l'orde '%s' ha fallit."
 
-#: ../src/common/accelcmn.cpp:249 ../src/common/accelcmn.cpp:344
+#: ../src/common/accelcmn.cpp:259 ../src/common/accelcmn.cpp:358
 msgid "F"
 msgstr ""
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:672
+#: ../src/propgrid/advprops.cpp:582
 #, fuzzy
 msgid "Face Name"
 msgstr "Nou nom"
 
-#: ../src/unix/snglinst.cpp:269
+#: ../src/unix/snglinst.cpp:266
 msgid "Failed to access lock file."
 msgstr "No s'ha pogut accedir el fitxer de blocatge."
+
+#: ../src/gtk/font.cpp:572
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "No s'ha pogut carregar la imatge %d des del fitxer '%s'."
 
 #: ../src/unix/epolldispatcher.cpp:116
 #, fuzzy, c-format
 msgid "Failed to add descriptor %d to epoll descriptor %d"
 msgstr "no es pot escriure en el fitxer descriptiu %d"
 
-#: ../src/msw/dib.cpp:489
+#: ../src/msw/dib.cpp:535
 #, fuzzy, c-format
 msgid "Failed to allocate %luKb of memory for bitmap data."
 msgstr "No s'ha pogut crear una barra d'estat."
 
-#: ../src/common/glcmn.cpp:115
+#: ../src/common/glcmn.cpp:112
 #, fuzzy
 msgid "Failed to allocate colour for OpenGL"
 msgstr "No s'ha pogut crear una barra d'estat."
 
-#: ../src/unix/displayx11.cpp:236
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "No s'ha pogut crear una barra d'estat."
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "No s'ha pogut crear una barra d'estat."
+
+#: ../include/wx/unix/private/displayx11.h:89
 #, fuzzy
 msgid "Failed to change video mode"
 msgstr "No s'ha pogut tancar el manegador de fitxers"
 
-#: ../src/common/image.cpp:3277
+#: ../src/common/image.cpp:3396
 #, fuzzy, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "No s'ha pogut carregar la imatge %d des del fitxer '%s'."
 
-#: ../src/common/debugrpt.cpp:239
+#: ../src/common/debugrpt.cpp:240
 #, fuzzy, c-format
 msgid "Failed to clean up debug report directory \"%s\""
 msgstr "No s'ha pogut crear un directori %s/.gnome."
 
-#: ../src/common/filename.cpp:192
+#: ../src/common/filename.cpp:189
 msgid "Failed to close file handle"
 msgstr "No s'ha pogut tancar el manegador de fitxers"
 
-#: ../src/unix/snglinst.cpp:340
+#: ../src/unix/snglinst.cpp:337
 #, c-format
 msgid "Failed to close lock file '%s'"
 msgstr "No s'ha pogut tancar el fitxer de bloqueig '%s'"
 
-#: ../src/msw/clipbrd.cpp:112
+#: ../src/msw/clipbrd.cpp:110
 msgid "Failed to close the clipboard."
 msgstr "No s'ha pogut tancar el porta-retalls"
 
-#: ../src/x11/utils.cpp:208
+#: ../src/x11/utils.cpp:170
 #, fuzzy, c-format
 msgid "Failed to close the display \"%s\""
 msgstr "No s'ha pogut tancar el porta-retalls"
 
-#: ../src/msw/dialup.cpp:797
+#: ../src/msw/dialup.cpp:791
 msgid "Failed to connect: missing username/password."
 msgstr "Connexió fallida:  hi manca el nom d'usuari o la contrasenya."
 
-#: ../src/msw/dialup.cpp:743
+#: ../src/msw/dialup.cpp:737
 msgid "Failed to connect: no ISP to dial."
 msgstr "No s'ha pogut connectar: no hi ha cap ISP a trucar."
 
-#: ../src/common/textfile.cpp:203
-#, fuzzy, c-format
-msgid "Failed to convert file \"%s\" to Unicode."
-msgstr "No s'ha pogut tancar el manegador de fitxers"
-
-#: ../src/generic/logg.cpp:956
+#: ../src/generic/logg.cpp:953
 #, fuzzy
 msgid "Failed to copy dialog contents to the clipboard."
 msgstr "No s'ha pogut obrir el porta-retalls"
 
-#: ../src/msw/registry.cpp:692
+#: ../src/msw/registry.cpp:681
 #, c-format
 msgid "Failed to copy registry value '%s'"
 msgstr "No s'ha pogut copiar el valor '%s' de registre"
 
-#: ../src/msw/registry.cpp:701
+#: ../src/msw/registry.cpp:690
 #, c-format
 msgid "Failed to copy the contents of registry key '%s' to '%s'."
 msgstr ""
 "No s'ha pogut copiar els continguts de la clau de registre '%s' a '%s'."
 
-#: ../src/common/filefn.cpp:1015
+#: ../src/common/filefn.cpp:904
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Impossible de copiar el fitxer '%s' a '%s'"
 
-#: ../src/msw/registry.cpp:679
+#: ../src/msw/registry.cpp:668
 #, fuzzy, c-format
 msgid "Failed to copy the registry subkey '%s' to '%s'."
 msgstr "No s'ha pogut reanomenar la clau de registre '%s' a '%s'."
 
-#: ../src/msw/dde.cpp:1070
+#: ../src/msw/dde.cpp:1134
 msgid "Failed to create DDE string"
 msgstr "No s'ha pogut crear una cadena DDE"
 
-#: ../src/msw/mdi.cpp:616
+#: ../src/msw/mdi.cpp:621
 msgid "Failed to create MDI parent frame."
 msgstr "No s'ha pogut crear un marc MDI principal."
 
-#: ../src/common/filename.cpp:1027
+#: ../src/common/filename.cpp:1024
 msgid "Failed to create a temporary file name"
 msgstr "No s'ha pogut crear un nom d'arxiu temporal"
 
-#: ../src/msw/utilsexc.cpp:228
+#: ../src/msw/utilsexc.cpp:225
 msgid "Failed to create an anonymous pipe"
 msgstr "Creació fallida d'un conducte anònim."
 
-#: ../src/msw/ole/automtn.cpp:522
+#: ../src/msw/ole/automtn.cpp:513
 #, fuzzy, c-format
 msgid "Failed to create an instance of \"%s\""
 msgstr "No s'ha pogut crear un directori %s/.gnome."
 
-#: ../src/msw/dde.cpp:437
+#: ../src/msw/dde.cpp:432
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "No s'ha pogut crear una connexió en el servidor '%s' en el tema '%s'"
 
-#: ../src/msw/cursor.cpp:204
+#: ../src/msw/cursor.cpp:195
 #, fuzzy
 msgid "Failed to create cursor."
 msgstr "No s'ha pogut crear una barra d'estat."
 
-#: ../src/common/debugrpt.cpp:209
+#: ../src/common/debugrpt.cpp:210
 #, fuzzy, c-format
 msgid "Failed to create directory \"%s\""
 msgstr "No s'ha pogut crear un directori %s/.gnome."
 
-#: ../src/generic/dirdlgg.cpp:220
+#: ../src/generic/dirdlgg.cpp:217
 #, c-format
 msgid ""
 "Failed to create directory '%s'\n"
@@ -3389,120 +3412,139 @@ msgstr ""
 msgid "Failed to create epoll descriptor"
 msgstr "No s'ha pogut crear una barra d'estat."
 
-#: ../src/msw/mimetype.cpp:238
+#: ../src/gtk/font.cpp:562
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "no es pot obrir el fitxer de configuració de l'usuari."
+
+#: ../src/msw/mimetype.cpp:235
 #, c-format
 msgid "Failed to create registry entry for '%s' files."
 msgstr "No s'ha pogut crear una entrada de registre per '%s' fitxers."
 
-#: ../src/msw/fdrepdlg.cpp:409
+#: ../src/msw/fdrepdlg.cpp:408
 #, c-format
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr ""
 "No s'ha pogut crear el diàleg estàndard de cerca/substituix (codi d'error %d)"
 
-#: ../src/unix/wakeuppipe.cpp:52
+#: ../src/unix/wakeuppipe.cpp:49
 #, fuzzy
 msgid "Failed to create wake up pipe used by event loop."
 msgstr "No s'ha pogut crear una barra d'estat."
 
-#: ../src/html/winpars.cpp:730
+#: ../src/html/winpars.cpp:727
 #, c-format
 msgid "Failed to display HTML document in %s encoding"
 msgstr "No s'ha pogut mostrar el document HTML en codificació %s"
 
-#: ../src/msw/clipbrd.cpp:124
+#: ../src/msw/clipbrd.cpp:122
 msgid "Failed to empty the clipboard."
 msgstr "No s'ha pogut buidar el porta-retalls"
 
-#: ../src/unix/displayx11.cpp:212
+#: ../include/wx/unix/private/displayx11.h:65
 #, fuzzy
 msgid "Failed to enumerate video modes"
 msgstr "No s'ha pogut crear un directori %s/.gnome."
 
-#: ../src/msw/dde.cpp:722
+#: ../src/msw/dde.cpp:717
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "No s'ha pogut establir un bucle d'avís amb el servidor DDE"
 
-#: ../src/msw/dialup.cpp:629 ../src/msw/dialup.cpp:863
+#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "No s'ha pogut establir la connexió: %s"
 
-#: ../src/unix/utilsunx.cpp:611
+#: ../src/unix/utilsunx.cpp:613
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "No s'ha pogut executar '%s'\n"
 
-#: ../src/common/debugrpt.cpp:720
+#: ../src/common/debugrpt.cpp:730
 msgid "Failed to execute curl, please install it in PATH."
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:505
+#: ../src/msw/ole/automtn.cpp:496
 #, fuzzy, c-format
 msgid "Failed to find CLSID of \"%s\""
 msgstr "No s'ha pogut obrir '%s' per %s"
 
-#: ../src/common/regex.cpp:431 ../src/common/regex.cpp:479
+#: ../src/common/regex.cpp:428 ../src/common/regex.cpp:476
 #, fuzzy, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "No s'ha pogut coincidir '%s' en l'expressió regular: %s"
 
-#: ../src/msw/dialup.cpp:695
+#: ../src/msw/webview_ie.cpp:978
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:689
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "No s'han pogut obtenir els noms ISP: %s"
 
-#: ../src/msw/ole/automtn.cpp:574
+#: ../src/msw/ole/automtn.cpp:565
 #, fuzzy, c-format
 msgid "Failed to get OLE automation interface for \"%s\""
 msgstr "No s'ha pogut crear un directori %s/.gnome."
 
-#: ../src/msw/clipbrd.cpp:711
+#: ../src/msw/clipbrd.cpp:731
 msgid "Failed to get data from the clipboard"
 msgstr "No s'ha pogut obtenir les dades del porta-retalls"
 
-#: ../src/common/time.cpp:223
+#: ../src/common/time.cpp:216
 msgid "Failed to get the local system time"
 msgstr "No s'ha pogut obtenir l'horari local del sistema"
 
-#: ../src/common/filefn.cpp:1345
+#: ../src/common/filefn.cpp:1233
 msgid "Failed to get the working directory"
 msgstr "No s'ha pogut obtenir el directori en funcionament"
 
-#: ../src/univ/theme.cpp:114
+#: ../src/univ/theme.cpp:111
 msgid "Failed to initialize GUI: no built-in themes found."
 msgstr ""
 "No s'ha pogut inicialitzar GUI: no s'ha trobat que estigués muntat en temes."
 
-#: ../src/msw/helpchm.cpp:63
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:60
 msgid "Failed to initialize MS HTML Help."
 msgstr "No s'ha pogut inicialitzar l'ajuda MS HTML"
 
-#: ../src/msw/glcanvas.cpp:1381
+#: ../src/msw/glcanvas.cpp:1391
 msgid "Failed to initialize OpenGL"
 msgstr "No s'ha pogut inicialitzar l'OpenGL"
 
-#: ../src/msw/dialup.cpp:858
+#: ../src/msw/dialup.cpp:852
 #, fuzzy, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "No s'ha pogut acabar la connexió de marcatge directe: %s"
 
-#: ../src/gtk/textctrl.cpp:1128
+#: ../src/gtk/textctrl.cpp:1209
 #, fuzzy
 msgid "Failed to insert text in the control."
 msgstr "No s'ha pogut obtenir el directori en funcionament"
 
-#: ../src/unix/snglinst.cpp:241
+#: ../src/unix/snglinst.cpp:238
 #, fuzzy, c-format
 msgid "Failed to inspect the lock file '%s'"
 msgstr "No s'ha pogut bloquejar el fitxer de bloqueig '%s'"
 
-#: ../src/unix/appunix.cpp:182
+#: ../src/unix/appunix.cpp:179
 #, fuzzy
 msgid "Failed to install signal handler"
 msgstr "No s'ha pogut tancar el manegador de fitxers"
 
-#: ../src/unix/threadpsx.cpp:1167
+#: ../src/unix/threadpsx.cpp:1216
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -3510,71 +3552,71 @@ msgstr ""
 "No s'ha pogut sincronitzar amb un fil, s'ha detectat un potencial de pèrdua "
 "de memòria - reinicieu el programa"
 
-#: ../src/msw/utils.cpp:629
+#: ../src/msw/utils.cpp:619
 #, c-format
 msgid "Failed to kill process %d"
 msgstr "No s'ha pogut acabar el procés %d"
 
-#: ../src/common/image.cpp:2500
+#: ../src/common/image.cpp:2595
 #, fuzzy, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "No s'ha pogut carregar la imatge %d des del fitxer '%s'."
 
-#: ../src/common/image.cpp:2509
+#: ../src/common/image.cpp:2604
 #, fuzzy, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "No s'ha pogut carregar la imatge %d des del fitxer '%s'."
 
-#: ../src/common/iconbndl.cpp:225
+#: ../src/common/iconbndl.cpp:224
 #, fuzzy, c-format
 msgid "Failed to load icons from resource '%s'."
 msgstr "No s'ha pogut carregar la imatge %d des del fitxer '%s'."
 
-#: ../src/common/iconbndl.cpp:200
+#: ../src/common/iconbndl.cpp:198
 #, fuzzy, c-format
 msgid "Failed to load image %%d from file '%s'."
 msgstr "No s'ha pogut carregar la imatge %d des del fitxer '%s'."
 
-#: ../src/common/iconbndl.cpp:208
+#: ../src/common/iconbndl.cpp:206
 #, fuzzy, c-format
 msgid "Failed to load image %d from stream."
 msgstr "No s'ha pogut carregar la imatge %d des del fitxer '%s'."
 
-#: ../src/common/image.cpp:2587 ../src/common/image.cpp:2606
+#: ../src/common/image.cpp:2682 ../src/common/image.cpp:2701
 #, fuzzy, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "No s'ha pogut carregar la imatge %d des del fitxer '%s'."
 
-#: ../src/msw/enhmeta.cpp:97
+#: ../src/msw/enhmeta.cpp:94
 #, fuzzy, c-format
 msgid "Failed to load metafile from file \"%s\"."
 msgstr "No s'ha pogut carregar la imatge %d des del fitxer '%s'."
 
-#: ../src/msw/volume.cpp:327
+#: ../src/msw/volume.cpp:335
 msgid "Failed to load mpr.dll."
 msgstr "No s'ha pogut carregar el mpr.dll"
 
-#: ../src/msw/utils.cpp:953
+#: ../src/msw/utils.cpp:943
 #, fuzzy, c-format
 msgid "Failed to load resource \"%s\"."
 msgstr "No s'ha pogut carregar la imatge %d des del fitxer '%s'."
 
-#: ../src/common/dynlib.cpp:92
+#: ../src/common/dynlib.cpp:86
 #, c-format
 msgid "Failed to load shared library '%s'"
 msgstr "No s'ha pogut carregar la llibreria compartida '%s'"
 
-#: ../src/osx/core/sound.cpp:145
+#: ../src/osx/core/sound.cpp:143
 #, fuzzy, c-format
 msgid "Failed to load sound from \"%s\" (error %d)."
 msgstr "No s'ha pogut carregar la imatge %d des del fitxer '%s'."
 
-#: ../src/msw/utils.cpp:960
+#: ../src/msw/utils.cpp:950
 #, fuzzy, c-format
 msgid "Failed to lock resource \"%s\"."
 msgstr "No s'ha pogut bloquejar el fitxer de bloqueig '%s'"
 
-#: ../src/unix/snglinst.cpp:198
+#: ../src/unix/snglinst.cpp:195
 #, c-format
 msgid "Failed to lock the lock file '%s'"
 msgstr "No s'ha pogut bloquejar el fitxer de bloqueig '%s'"
@@ -3584,33 +3626,38 @@ msgstr "No s'ha pogut bloquejar el fitxer de bloqueig '%s'"
 msgid "Failed to modify descriptor %d in epoll descriptor %d"
 msgstr ""
 
-#: ../src/common/filename.cpp:2575
+#: ../src/common/filename.cpp:2658
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "No s'ha pogut modificar les hores de fitxer de '%s'"
 
-#: ../src/common/selectdispatcher.cpp:258
+#: ../src/common/selectdispatcher.cpp:255
 msgid "Failed to monitor I/O channels"
 msgstr ""
 
-#: ../src/common/filename.cpp:175
+#: ../src/common/filename.cpp:172
 #, fuzzy, c-format
 msgid "Failed to open '%s' for reading"
 msgstr "No s'ha pogut obrir '%s' per %s"
 
-#: ../src/common/filename.cpp:180
+#: ../src/common/filename.cpp:177
 #, fuzzy, c-format
 msgid "Failed to open '%s' for writing"
 msgstr "No s'ha pogut obrir '%s' per %s"
 
-#: ../src/html/chm.cpp:141
+#: ../src/html/chm.cpp:138
 #, fuzzy, c-format
 msgid "Failed to open CHM archive '%s'."
 msgstr "No s'ha pogut obrir '%s' per %s"
 
-#: ../src/common/utilscmn.cpp:1126
+#: ../src/common/utilscmn.cpp:1140
 #, fuzzy, c-format
 msgid "Failed to open URL \"%s\" in default browser."
+msgstr "No s'ha pogut obrir '%s' per %s"
+
+#: ../src/common/hyperlnkcmn.cpp:133
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "No s'ha pogut obrir '%s' per %s"
 
 #: ../include/wx/msw/private/fswatcher.h:92
@@ -3618,213 +3665,231 @@ msgstr "No s'ha pogut obrir '%s' per %s"
 msgid "Failed to open directory \"%s\" for monitoring."
 msgstr "No s'ha pogut obrir '%s' per %s"
 
-#: ../src/x11/utils.cpp:227
+#: ../src/x11/utils.cpp:189
 #, fuzzy, c-format
 msgid "Failed to open display \"%s\"."
 msgstr "No s'ha pogut obrir '%s' per %s"
 
-#: ../src/common/filename.cpp:1062
+#: ../src/common/filename.cpp:1059
 msgid "Failed to open temporary file."
 msgstr "No s'ha pogut obrir un fitxer temporal"
 
-#: ../src/msw/clipbrd.cpp:91
+#: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "No s'ha pogut obrir el porta-retalls"
 
-#: ../src/common/translation.cpp:1184
+#: ../src/common/translation.cpp:1226
 #, fuzzy, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "No es pot analitzar les coordenades des de '%s'."
 
-#: ../src/unix/mediactrl.cpp:1214
+#: ../src/unix/mediactrl.cpp:1239
 #, fuzzy, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "No s'ha pogut obrir '%s' per %s"
 
-#: ../src/msw/clipbrd.cpp:600
+#: ../src/msw/clipbrd.cpp:610
 msgid "Failed to put data on the clipboard"
 msgstr "No s'ha pogut posar dades al porta-retalls"
 
-#: ../src/unix/snglinst.cpp:278
+#: ../src/unix/snglinst.cpp:275
 msgid "Failed to read PID from lock file."
 msgstr "No s'ha pogut llegir el PID des del fitxer de registre."
 
-#: ../src/common/fileconf.cpp:433
+#: ../src/common/fileconf.cpp:432
 #, fuzzy
 msgid "Failed to read config options."
 msgstr "Error en llegir imatge DIB"
 
-#: ../src/common/docview.cpp:681
+#: ../src/common/docview.cpp:676
 #, fuzzy, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "No s'ha pogut carregar la imatge %d des del fitxer '%s'."
 
-#: ../src/dfb/evtloop.cpp:98
+#: ../src/dfb/evtloop.cpp:99
 #, fuzzy
 msgid "Failed to read event from DirectFB pipe"
 msgstr "No s'ha pogut llegir el PID des del fitxer de registre."
 
-#: ../src/unix/wakeuppipe.cpp:120
+#: ../src/unix/wakeuppipe.cpp:117
 #, fuzzy
 msgid "Failed to read from wake-up pipe"
 msgstr "No s'ha pogut llegir el PID des del fitxer de registre."
 
-#: ../src/unix/utilsunx.cpp:679
+#: ../src/common/textfile.cpp:96
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "No s'ha pogut carregar la imatge %d des del fitxer '%s'."
+
+#: ../src/unix/utilsunx.cpp:681
 msgid "Failed to redirect child process input/output"
 msgstr "No s'ha pogut redireccionar el procés fill d'entrada/eixida"
 
-#: ../src/msw/utilsexc.cpp:701
+#: ../src/msw/utilsexc.cpp:698
 msgid "Failed to redirect the child process IO"
 msgstr "No s'ha pogut redireccionar el procés fill d'IO"
 
-#: ../src/msw/dde.cpp:288
+#: ../src/msw/dde.cpp:283
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "No es pot registrar el servidor DDE '%s'"
 
-#: ../src/common/fontmap.cpp:245
+#: ../src/gtk/font.cpp:580
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "no es pot obrir el fitxer de configuració de l'usuari."
+
+#: ../src/common/fontmap.cpp:242
 #, c-format
 msgid "Failed to remember the encoding for the charset '%s'."
 msgstr "No es pot recordar la codificació del joc de caràcters '%s'."
 
-#: ../src/common/debugrpt.cpp:227
+#: ../src/common/debugrpt.cpp:228
 #, fuzzy, c-format
 msgid "Failed to remove debug report file \"%s\""
 msgstr "És impossible d'eliminar el fitxer de blocatge '%s'"
 
-#: ../src/unix/snglinst.cpp:328
+#: ../src/unix/snglinst.cpp:325
 #, c-format
 msgid "Failed to remove lock file '%s'"
 msgstr "És impossible d'eliminar el fitxer de blocatge '%s'"
 
-#: ../src/unix/snglinst.cpp:288
+#: ../src/unix/snglinst.cpp:285
 #, c-format
 msgid "Failed to remove stale lock file '%s'."
 msgstr "No s'ha pogut extreure  el fitxer antic de bloqueig '%s'"
 
-#: ../src/msw/registry.cpp:529
+#: ../src/msw/registry.cpp:518
 #, c-format
 msgid "Failed to rename registry value '%s' to '%s'."
 msgstr "No s'ha pogut reanomenar el valor de registre '%s' a '%s'."
 
-#: ../src/common/filefn.cpp:1122
+#: ../src/common/filefn.cpp:1011
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
 "exists."
 msgstr ""
 
-#: ../src/msw/registry.cpp:634
+#: ../src/msw/registry.cpp:623
 #, c-format
 msgid "Failed to rename the registry key '%s' to '%s'."
 msgstr "No s'ha pogut reanomenar la clau de registre '%s' a '%s'."
 
-#: ../src/common/filename.cpp:2671
+#: ../src/msw/webview_ie.cpp:995
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/common/filename.cpp:2754
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "No s'ha pogut recuperar les hores de fitxer de '%s'"
 
-#: ../src/msw/dialup.cpp:468
+#: ../src/msw/dialup.cpp:462
 msgid "Failed to retrieve text of RAS error message"
 msgstr "No s'ha pogut recuperar el text del missatge d'error RAS"
 
-#: ../src/msw/clipbrd.cpp:748
+#: ../src/msw/clipbrd.cpp:768
 msgid "Failed to retrieve the supported clipboard formats"
 msgstr "No s'ha pogut recuperar els formats suportats del porta-retalls."
 
-#: ../src/common/docview.cpp:652
+#: ../src/common/docview.cpp:647
 #, fuzzy, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "No s'ha pogut carregar la imatge %d des del fitxer '%s'."
 
-#: ../src/msw/dib.cpp:269
+#: ../src/msw/dib.cpp:312
 #, fuzzy, c-format
 msgid "Failed to save the bitmap image to file \"%s\"."
 msgstr "No s'ha pogut carregar la imatge %d des del fitxer '%s'."
 
-#: ../src/msw/dde.cpp:763
+#: ../src/msw/dde.cpp:811
 msgid "Failed to send DDE advise notification"
 msgstr "No s'ha pogut enviar una notificació d'avís DDE"
 
-#: ../src/common/ftp.cpp:402
+#: ../src/common/ftp.cpp:399
 #, c-format
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "No s'ha pogut fixar el mode de transferència FTP a %s."
 
-#: ../src/msw/clipbrd.cpp:427
+#: ../src/msw/clipbrd.cpp:443
 msgid "Failed to set clipboard data."
 msgstr "No s'ha pogut fixar les dades del porta-retalls"
 
-#: ../src/unix/snglinst.cpp:181
+#: ../src/unix/snglinst.cpp:178
 #, fuzzy, c-format
 msgid "Failed to set permissions on lock file '%s'"
 msgstr "És impossible fixar els permisos per al fitxer '%s'"
 
-#: ../src/unix/utilsunx.cpp:668
+#: ../src/unix/utilsunx.cpp:670
 #, fuzzy
 msgid "Failed to set process priority"
 msgstr "No s'ha pogut establir la prioritat de la cadena %d"
 
-#: ../src/common/file.cpp:559
+#: ../src/common/ffile.cpp:355 ../src/common/file.cpp:586
 msgid "Failed to set temporary file permissions"
 msgstr "No s'ha pogut fixar els permisos de fitxer temporals."
 
-#: ../src/gtk/textctrl.cpp:1072
-#, fuzzy
-msgid "Failed to set text in the text control."
-msgstr "No s'ha pogut obtenir el temps UTC del sistema."
-
-#: ../src/unix/threadpsx.cpp:1298
+#: ../src/unix/threadpsx.cpp:1347
 #, fuzzy, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "No s'ha pogut establir la prioritat de la cadena %d"
 
-#: ../src/unix/threadpsx.cpp:1424
+#: ../src/unix/threadpsx.cpp:1473
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "No s'ha pogut establir la prioritat de la cadena %d"
 
-#: ../src/unix/utilsunx.cpp:783
+#: ../src/unix/utilsunx.cpp:785
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 
-#: ../src/common/fs_mem.cpp:261
+#: ../src/msw/webview_ie.cpp:987
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:256
 #, c-format
 msgid "Failed to store image '%s' to memory VFS!"
 msgstr "No s'ha pogut emmagatzemar la imatge '%s' a la VFS de memòria!"
 
-#: ../src/dfb/evtloop.cpp:170
+#: ../src/dfb/evtloop.cpp:171
 msgid "Failed to switch DirectFB pipe to non-blocking mode"
 msgstr ""
 
-#: ../src/unix/wakeuppipe.cpp:59
+#: ../src/unix/wakeuppipe.cpp:56
 msgid "Failed to switch wake up pipe to non-blocking mode"
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1605
+#: ../src/unix/threadpsx.cpp:1654
 msgid "Failed to terminate a thread."
 msgstr "No s'ha pogut acabar una cadena."
 
-#: ../src/msw/dde.cpp:741
+#: ../src/msw/dde.cpp:736
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "No s'ha pogut acabar el bucle d'avís amb el servidor DDE."
 
-#: ../src/msw/dialup.cpp:938
+#: ../src/msw/dialup.cpp:932
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "No s'ha pogut acabar la connexió de marcatge directe: %s"
 
-#: ../src/common/filename.cpp:2590
+#: ../src/common/filename.cpp:2673
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "No s'ha pogut posar en contacte amb el fitxer '%s'"
 
-#: ../src/unix/snglinst.cpp:334
+#: ../src/unix/dlunix.cpp:90
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "No s'ha pogut carregar la llibreria compartida '%s'"
+
+#: ../src/unix/snglinst.cpp:331
 #, c-format
 msgid "Failed to unlock lock file '%s'"
 msgstr "No s'ha pogut desbloquejar el fitxer de bloqueig '%s'"
 
-#: ../src/msw/dde.cpp:309
+#: ../src/msw/dde.cpp:304
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "No s'ha pogut desenregistrar el servidor DDE '%s'"
@@ -3839,82 +3904,92 @@ msgstr "No s'ha pogut recuperar les dades del porta-retalls."
 msgid "Failed to update user configuration file."
 msgstr "no es pot obrir el fitxer de configuració de l'usuari."
 
-#: ../src/common/debugrpt.cpp:733
+#: ../src/common/debugrpt.cpp:743
 #, fuzzy, c-format
 msgid "Failed to upload the debug report (error code %d)."
 msgstr ""
 "No s'ha pogut crear el diàleg estàndard de cerca/substituix (codi d'error %d)"
 
-#: ../src/unix/snglinst.cpp:168
+#: ../src/unix/snglinst.cpp:165
 #, c-format
 msgid "Failed to write to lock file '%s'"
 msgstr "No s'ha pogut escriure a l'arxiu de bloqueig '%s'"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:209
+#: ../src/propgrid/propgrid.cpp:190
 #, fuzzy
 msgid "False"
 msgstr "&Mida"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:694
+#: ../src/propgrid/advprops.cpp:604
 #, fuzzy
 msgid "Family"
 msgstr "Grandària de la font:"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/gtk/glcanvas.cpp:176 ../src/gtk/glcanvas.cpp:187
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Error fatal"
+
+#: ../src/common/stockitem.cpp:154
 #, fuzzy
 msgid "File"
 msgstr "&Mida"
 
-#: ../src/common/docview.cpp:669
+#: ../src/common/docview.cpp:664
 #, fuzzy, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "No s'ha pogut obrir '%s' per %s"
 
-#: ../src/common/docview.cpp:646
+#: ../src/common/docview.cpp:641
 #, fuzzy, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "No s'ha pogut obrir '%s' per %s"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
 #, fuzzy, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "El fitxer '%' ja existex, n'esteu segur de voleu rescriure-hi?"
 
-#: ../src/common/filefn.cpp:1156
+#: ../src/common/filefn.cpp:1044
 #, fuzzy, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "No s'ha pogut crear el directori '%s'"
 
-#: ../src/common/filefn.cpp:1139
+#: ../src/common/filefn.cpp:1028
 #, fuzzy, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "No s'ha pogut crear el directori '%s'"
 
-#: ../src/richtext/richtextctrl.cpp:3081 ../src/common/textcmn.cpp:953
+#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
 msgid "File couldn't be loaded."
 msgstr "No s'ha pogut carregar el fitxer."
 
-#: ../src/msw/filedlg.cpp:393
+#: ../src/msw/filedlg.cpp:414
 #, fuzzy, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "L'execució de l'orde '%s' ha fallit."
 
-#: ../src/common/docview.cpp:1789
+#: ../src/common/docview.cpp:1783
 msgid "File error"
 msgstr "Error de fitxer"
 
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/filectrlg.cpp:770
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/filectrlg.cpp:766
 msgid "File name exists already."
 msgstr "Este nom de fitxer ja existix."
+
+#: ../src/osx/cocoa/filedlg.mm:264
+#, fuzzy
+msgid "File type:"
+msgstr "Teletip"
 
 #: ../src/motif/filedlg.cpp:220
 #, fuzzy
 msgid "Files"
 msgstr "&Mida"
 
-#: ../src/common/filefn.cpp:1591
+#: ../src/common/filefn.cpp:1479
 #, fuzzy, c-format
 msgid "Files (%s)"
 msgstr "Fitxers (%s)|%s"
@@ -3924,16 +3999,30 @@ msgstr "Fitxers (%s)|%s"
 msgid "Filter"
 msgstr "&Mida"
 
-#: ../src/common/stockitem.cpp:158 ../src/html/helpwnd.cpp:490
+#: ../src/html/helpwnd.cpp:488
 msgid "Find"
 msgstr "Cerca"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:259
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:258
+#, fuzzy
+msgid "Find in document"
+msgstr "Obri document HTML"
+
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "Find..."
+msgstr "Cerca"
+
+#: ../src/common/stockitem.cpp:156
 #, fuzzy
 msgid "First"
 msgstr "primer"
 
-#: ../src/common/prntbase.cpp:1548
+#: ../src/common/prntbase.cpp:1573
 #, fuzzy
 msgid "First page"
 msgstr "Pàgina següent"
@@ -3943,11 +4032,11 @@ msgstr "Pàgina següent"
 msgid "Fixed"
 msgstr "Font fixada:"
 
-#: ../src/html/helpwnd.cpp:1206
+#: ../src/html/helpwnd.cpp:1204
 msgid "Fixed font:"
 msgstr "Font fixada:"
 
-#: ../src/html/helpwnd.cpp:1269
+#: ../src/html/helpwnd.cpp:1267
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr ""
 
@@ -3955,17 +4044,17 @@ msgstr ""
 msgid "Floating"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 #, fuzzy
 msgid "Floppy"
 msgstr "&Copia"
 
-#: ../src/common/paper.cpp:111
+#: ../src/common/paper.cpp:108
 msgid "Folio, 8 1/2 x 13 in"
 msgstr "Foli, 8 1/2 x 13 polzades"
 
-#: ../src/richtext/richtextformatdlg.cpp:344 ../src/osx/carbon/fontdlg.cpp:287
-#: ../src/common/stockitem.cpp:194
+#: ../src/osx/carbon/fontdlg.cpp:284 ../src/common/stockitem.cpp:191
+#: ../src/richtext/richtextformatdlg.cpp:337
 msgid "Font"
 msgstr ""
 
@@ -3974,7 +4063,24 @@ msgstr ""
 msgid "Font &weight:"
 msgstr "vuitè"
 
-#: ../src/html/helpwnd.cpp:1207
+#: ../src/osx/fontutil.cpp:89
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
+"\"."
+msgstr ""
+
+#: ../src/msw/font.cpp:1126
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "No s'ha pogut carregar el fitxer."
+
+#: ../src/osx/fontutil.cpp:81
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "El fitxer %s no existix"
+
+#: ../src/html/helpwnd.cpp:1205
 msgid "Font size:"
 msgstr "Grandària de la font:"
 
@@ -3983,78 +4089,78 @@ msgstr "Grandària de la font:"
 msgid "Font st&yle:"
 msgstr "Grandària de la font:"
 
-#: ../src/osx/carbon/fontdlg.cpp:329
+#: ../src/osx/carbon/fontdlg.cpp:326
 #, fuzzy
 msgid "Font:"
 msgstr "Grandària de la font:"
 
-#: ../src/dfb/fontmgr.cpp:198
+#: ../src/dfb/fontmgr.cpp:195
 #, c-format
 msgid "Fonts index file %s disappeared while loading fonts."
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:645
+#: ../src/unix/utilsunx.cpp:647
 msgid "Fork failed"
 msgstr "El fork ha fallat!"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 #, fuzzy
 msgid "Forward"
 msgstr "Avant"
 
-#: ../src/common/xtixml.cpp:235
+#: ../src/common/xtixml.cpp:231
 msgid "Forward hrefs are not supported"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:875
+#: ../src/html/helpwnd.cpp:873
 #, c-format
 msgid "Found %i matches"
 msgstr "S'han trobat %i coincidències"
 
-#: ../src/generic/prntdlgg.cpp:238
+#: ../src/generic/prntdlgg.cpp:231
 msgid "From:"
 msgstr "De:"
 
-#: ../src/propgrid/advprops.cpp:1604
+#: ../src/propgrid/advprops.cpp:1510
 msgid "Fuchsia"
 msgstr ""
 
-#: ../src/common/imaggif.cpp:138
+#: ../src/common/imaggif.cpp:135
 msgid "GIF: data stream seems to be truncated."
 msgstr "GIF: el flux de dades sembla haver-se trencat."
 
-#: ../src/common/imaggif.cpp:128
+#: ../src/common/imaggif.cpp:125
 msgid "GIF: error in GIF image format."
 msgstr "GIF: error en el format GIF d'imatge."
 
-#: ../src/common/imaggif.cpp:133
+#: ../src/common/imaggif.cpp:130
 msgid "GIF: not enough memory."
 msgstr "GIF: No hi ha prou memòria"
 
-#: ../src/gtk/window.cpp:4631
+#: ../src/gtk/window.cpp:5635
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
 msgstr ""
 
-#: ../src/univ/themes/gtk.cpp:525
+#: ../src/univ/themes/gtk.cpp:522
 msgid "GTK+ theme"
 msgstr "GTK + tema"
 
-#: ../src/common/preferencescmn.cpp:40
+#: ../src/common/preferencescmn.cpp:37
 msgid "General"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:258
+#: ../src/common/prntbase.cpp:253
 #, fuzzy
 msgid "Generic PostScript"
 msgstr "Fitxer PostScript"
 
-#: ../src/common/paper.cpp:135
+#: ../src/common/paper.cpp:132
 msgid "German Legal Fanfold, 8 1/2 x 13 in"
 msgstr "Fanfold legal alemany, 8 1/2 x 13 polz."
 
-#: ../src/common/paper.cpp:134
+#: ../src/common/paper.cpp:131
 msgid "German Std Fanfold, 8 1/2 x 12 in"
 msgstr "Fanfold alemany estàndard, 8 1/2 x 12 in"
 
@@ -4070,48 +4176,48 @@ msgstr ""
 msgid "GetPropertyCollection called w/o valid collection getter"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:658
 msgid "Go back"
 msgstr "Vés arrere"
 
-#: ../src/html/helpwnd.cpp:661
+#: ../src/html/helpwnd.cpp:659
 msgid "Go forward"
 msgstr "Vés avant"
 
-#: ../src/html/helpwnd.cpp:663
+#: ../src/html/helpwnd.cpp:661
 msgid "Go one level up in document hierarchy"
 msgstr "Puja un nivell de la jerarquia del document."
 
-#: ../src/generic/filedlgg.cpp:208 ../src/generic/dirdlgg.cpp:116
+#: ../src/generic/filedlgg.cpp:205 ../src/generic/dirdlgg.cpp:113
 msgid "Go to home directory"
 msgstr "Vés al directori principal"
 
-#: ../src/generic/filedlgg.cpp:205
+#: ../src/generic/filedlgg.cpp:202
 msgid "Go to parent directory"
 msgstr "Puja un directori "
 
-#: ../src/generic/aboutdlgg.cpp:76
+#: ../src/generic/aboutdlgg.cpp:73
 msgid "Graphics art by "
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1599
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Gray"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:883
+#: ../src/propgrid/advprops.cpp:784
 msgid "GrayText"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:154
+#: ../src/common/fmapbase.cpp:151
 msgid "Greek (ISO-8859-7)"
 msgstr "Grec (ISO-8859-7)"
 
-#: ../src/propgrid/advprops.cpp:1600
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Green"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:342
+#: ../src/generic/colrdlgg.cpp:362
 msgid "Green:"
 msgstr ""
 
@@ -4119,110 +4225,110 @@ msgstr ""
 msgid "Groove"
 msgstr ""
 
-#: ../src/common/zstream.cpp:158 ../src/common/zstream.cpp:318
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
 msgid "Gzip not supported by this version of zlib"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1549
+#: ../src/html/helpwnd.cpp:1547
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr ""
 
-#: ../src/html/htmlwin.cpp:681
+#: ../src/html/htmlwin.cpp:691
 #, fuzzy, c-format
 msgid "HTML anchor %s does not exist."
 msgstr "L'ancoratge de l'HTML no existix."
 
-#: ../src/html/helpwnd.cpp:1547
+#: ../src/html/helpwnd.cpp:1545
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1759
+#: ../src/propgrid/advprops.cpp:1660
 msgid "Hand"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "Harddisk"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:155
+#: ../src/common/fmapbase.cpp:152
 msgid "Hebrew (ISO-8859-8)"
 msgstr "Hebreu (ISO-8859-8)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:280 ../src/osx/button_osx.cpp:39
-#: ../src/common/stockitem.cpp:163 ../src/common/accelcmn.cpp:80
-#: ../src/html/helpdlg.cpp:66 ../src/html/helpfrm.cpp:111
+#: ../include/wx/msgdlg.h:282 ../src/osx/button_osx.cpp:39
+#: ../src/common/stockitem.cpp:160 ../src/common/accelcmn.cpp:77
+#: ../src/html/helpfrm.cpp:108 ../src/html/helpdlg.cpp:63
 msgid "Help"
 msgstr "Ajuda"
 
-#: ../src/html/helpwnd.cpp:1200
+#: ../src/html/helpwnd.cpp:1198
 msgid "Help Browser Options"
 msgstr "Opcions d'ajuda del navegador"
 
-#: ../src/generic/helpext.cpp:454 ../src/generic/helpext.cpp:455
+#: ../src/generic/helpext.cpp:452 ../src/generic/helpext.cpp:453
 msgid "Help Index"
 msgstr "Índex de l'ajuda"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1529
 msgid "Help Printing"
 msgstr "Ajuda de la impressió"
 
-#: ../src/html/helpwnd.cpp:801
+#: ../src/html/helpwnd.cpp:799
 #, fuzzy
 msgid "Help Topics"
 msgstr "Ajuda: %s"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1546
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr ""
 
-#: ../src/generic/helpext.cpp:267
+#: ../src/generic/helpext.cpp:265
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:275
+#: ../src/generic/helpext.cpp:273
 #, fuzzy, c-format
 msgid "Help file \"%s\" not found."
 msgstr "no s'ha trobat el fitxer de catàleg per al domini '%s'"
 
-#: ../src/html/helpctrl.cpp:63
+#: ../src/html/helpctrl.cpp:59
 #, c-format
 msgid "Help: %s"
 msgstr "Ajuda: %s"
 
-#: ../src/osx/menu_osx.cpp:577
+#: ../src/osx/menu_osx.cpp:469
 #, fuzzy, c-format
 msgid "Hide %s"
 msgstr "Ajuda: %s"
 
-#: ../src/osx/menu_osx.cpp:579
+#: ../src/osx/menu_osx.cpp:471
 msgid "Hide Others"
 msgstr ""
 
-#: ../src/generic/infobar.cpp:84
+#: ../src/generic/infobar.cpp:81
 msgid "Hide this notification message."
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:884
+#: ../src/propgrid/advprops.cpp:785
 #, fuzzy
 msgid "Highlight"
 msgstr "clar"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:885
+#: ../src/propgrid/advprops.cpp:786
 msgid "HighlightText"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:164 ../src/common/accelcmn.cpp:65
+#: ../src/common/stockitem.cpp:161 ../src/common/accelcmn.cpp:62
 #, fuzzy
 msgid "Home"
 msgstr "sense nom"
 
-#: ../src/generic/dirctrlg.cpp:524
+#: ../src/generic/dirctrlg.cpp:490
 #, fuzzy
 msgid "Home directory"
 msgstr "Crea directori"
@@ -4233,61 +4339,61 @@ msgid "How the object will float relative to the text."
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1760
+#: ../src/propgrid/advprops.cpp:1661
 msgid "I-Beam"
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1196
+#: ../src/common/imagbmp.cpp:1208
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: Error en llegir la màscara DIB."
 
-#: ../src/common/imagbmp.cpp:1290 ../src/common/imagbmp.cpp:1390
-#: ../src/common/imagbmp.cpp:1405 ../src/common/imagbmp.cpp:1416
-#: ../src/common/imagbmp.cpp:1430 ../src/common/imagbmp.cpp:1478
-#: ../src/common/imagbmp.cpp:1493 ../src/common/imagbmp.cpp:1507
-#: ../src/common/imagbmp.cpp:1518
+#: ../src/common/imagbmp.cpp:1302 ../src/common/imagbmp.cpp:1402
+#: ../src/common/imagbmp.cpp:1417 ../src/common/imagbmp.cpp:1428
+#: ../src/common/imagbmp.cpp:1442 ../src/common/imagbmp.cpp:1490
+#: ../src/common/imagbmp.cpp:1505 ../src/common/imagbmp.cpp:1519
+#: ../src/common/imagbmp.cpp:1530
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: Error en llegir el fitxer d'imatge!"
 
-#: ../src/common/imagbmp.cpp:1255
+#: ../src/common/imagbmp.cpp:1267
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: Imatge massa llarga per a una icona."
 
-#: ../src/common/imagbmp.cpp:1263
+#: ../src/common/imagbmp.cpp:1275
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO:Imatge massa ampla per poder ser una icona."
 
-#: ../src/common/imagbmp.cpp:1603
+#: ../src/common/imagbmp.cpp:1615
 msgid "ICO: Invalid icon index."
 msgstr "ICO: Índex d'icones invàlid"
 
-#: ../src/common/imagiff.cpp:758
+#: ../src/common/imagiff.cpp:755
 msgid "IFF: data stream seems to be truncated."
 msgstr "IFF: el fil de dades sembla estar trencades."
 
-#: ../src/common/imagiff.cpp:742
+#: ../src/common/imagiff.cpp:739
 msgid "IFF: error in IFF image format."
 msgstr "IFF: error en format d'imatge IFF."
 
-#: ../src/common/imagiff.cpp:745
+#: ../src/common/imagiff.cpp:742
 msgid "IFF: not enough memory."
 msgstr "IFF: no hi ha prou memòria."
 
-#: ../src/common/imagiff.cpp:748
+#: ../src/common/imagiff.cpp:745
 msgid "IFF: unknown error!!!"
 msgstr "IFF: error desconegut!!!"
 
-#: ../src/common/fmapbase.cpp:197
+#: ../src/common/fmapbase.cpp:194
 msgid "ISO-2022-JP"
 msgstr ""
 
-#: ../src/html/htmprint.cpp:282
+#: ../src/html/htmprint.cpp:294
 msgid ""
 "If possible, try changing the layout parameters to make the printout more "
 "narrow."
 msgstr ""
 
-#: ../src/generic/dbgrptg.cpp:358
+#: ../src/generic/dbgrptg.cpp:362
 msgid ""
 "If you have any additional information pertaining to this bug\n"
 "report, please enter it here and it will be joined to it:"
@@ -4301,47 +4407,51 @@ msgid ""
 "at all possible please do continue with the report generation.\n"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1405
+#: ../src/common/zipstrm.cpp:1043
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1393
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:295
+#: ../src/common/xtistrm.cpp:292
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr ""
 
-#: ../src/common/xti.cpp:513
+#: ../src/common/xti.cpp:510
 msgid "Illegal Parameter Count for ConstructObject Method"
 msgstr ""
 
-#: ../src/common/xti.cpp:501
+#: ../src/common/xti.cpp:498
 msgid "Illegal Parameter Count for Create Method"
 msgstr ""
 
-#: ../src/generic/dirctrlg.cpp:570 ../src/generic/filectrlg.cpp:756
+#: ../src/generic/dirctrlg.cpp:536 ../src/generic/filectrlg.cpp:752
 msgid "Illegal directory name."
 msgstr "Nom il·legal de directori"
 
-#: ../src/generic/filectrlg.cpp:1367
+#: ../src/generic/filectrlg.cpp:1356
 msgid "Illegal file specification."
 msgstr "Especificació de fitxer il·legal."
 
-#: ../src/common/image.cpp:2269
+#: ../src/common/image.cpp:2363
 #, fuzzy
 msgid "Image and mask have different sizes."
 msgstr "La imatge i la màscara tenen diferents grandàries"
 
-#: ../src/common/image.cpp:2746
+#: ../src/common/image.cpp:2841
 #, fuzzy, c-format
 msgid "Image file is not of type %d."
 msgstr "El fitxer d'imatge no és del tipus %d."
 
-#: ../src/common/image.cpp:2877
+#: ../src/common/image.cpp:2995
 #, fuzzy, c-format
 msgid "Image is not of type %s."
 msgstr "El fitxer d'imatge no és del tipus %d."
 
-#: ../src/msw/textctrl.cpp:488
+#: ../src/msw/textctrl.cpp:534
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -4349,106 +4459,106 @@ msgstr ""
 "No és possible crear un control d'edició rica, utilitzant en el seu lloc un "
 "control de text simple. Reinstal·leu riched32.dll"
 
-#: ../src/unix/utilsunx.cpp:301
+#: ../src/unix/utilsunx.cpp:303
 msgid "Impossible to get child process input"
 msgstr "És impossible obtenir l'entrada de procés fill."
 
-#: ../src/common/filefn.cpp:1028
+#: ../src/common/filefn.cpp:917
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "No és possible obtenir permisos per al fitxer '%s'"
 
-#: ../src/common/filefn.cpp:1042
+#: ../src/common/filefn.cpp:931
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "És impossible sobrescriure el fitxer '%s'"
 
-#: ../src/common/filefn.cpp:1097
+#: ../src/common/filefn.cpp:986
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "És impossible fixar els permisos per al fitxer '%s'"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:886
+#: ../src/propgrid/advprops.cpp:787
 #, fuzzy
 msgid "InactiveBorder"
 msgstr "Modern"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:887
+#: ../src/propgrid/advprops.cpp:788
 msgid "InactiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:888
+#: ../src/propgrid/advprops.cpp:789
 msgid "InactiveCaptionText"
 msgstr ""
 
-#: ../src/common/gifdecod.cpp:792
+#: ../src/common/gifdecod.cpp:826
 #, c-format
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:635
+#: ../src/msw/ole/automtn.cpp:626
 msgid "Incorrect number of arguments."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:165
+#: ../src/common/stockitem.cpp:162
 #, fuzzy
 msgid "Indent"
 msgstr "Índex"
 
-#: ../src/richtext/richtextformatdlg.cpp:349
+#: ../src/richtext/richtextformatdlg.cpp:342
 msgid "Indents && Spacing"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:166 ../src/html/helpwnd.cpp:515
+#: ../src/common/stockitem.cpp:163 ../src/html/helpwnd.cpp:513
 msgid "Index"
 msgstr "Índex"
 
-#: ../src/common/fmapbase.cpp:159
+#: ../src/common/fmapbase.cpp:156
 msgid "Indian (ISO-8859-12)"
 msgstr "Indi (ISO-8859-12)"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "Info"
 msgstr ""
 
-#: ../src/common/init.cpp:287
+#: ../src/common/init.cpp:284
 msgid "Initialization failed in post init, aborting."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:54
+#: ../src/common/accelcmn.cpp:51
 #, fuzzy
 msgid "Ins"
 msgstr "Índex"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextsymboldlg.cpp:472 ../src/common/accelcmn.cpp:53
+#: ../src/common/accelcmn.cpp:50 ../src/richtext/richtextsymboldlg.cpp:469
 #, fuzzy
 msgid "Insert"
 msgstr "Índex"
 
-#: ../src/richtext/richtextbuffer.cpp:8067
+#: ../src/richtext/richtextbuffer.cpp:8063
 #, fuzzy
 msgid "Insert Field"
 msgstr "Índex"
 
-#: ../src/richtext/richtextbuffer.cpp:7978
-#: ../src/richtext/richtextbuffer.cpp:8936
+#: ../src/richtext/richtextbuffer.cpp:7974
+#: ../src/richtext/richtextbuffer.cpp:8934
 msgid "Insert Image"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:8025
+#: ../src/richtext/richtextbuffer.cpp:8021
 #, fuzzy
 msgid "Insert Object"
 msgstr "Índex"
 
-#: ../src/richtext/richtextctrl.cpp:1286 ../src/richtext/richtextctrl.cpp:1494
-#: ../src/richtext/richtextbuffer.cpp:7822
-#: ../src/richtext/richtextbuffer.cpp:7852
-#: ../src/richtext/richtextbuffer.cpp:7894
+#: ../src/richtext/richtextbuffer.cpp:7818
+#: ../src/richtext/richtextbuffer.cpp:7848
+#: ../src/richtext/richtextbuffer.cpp:7890
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
 msgid "Insert Text"
 msgstr ""
 
@@ -4462,16 +4572,11 @@ msgstr ""
 msgid "Inset"
 msgstr "Índex"
 
-#: ../src/gtk/app.cpp:425
-#, c-format
-msgid "Invalid GTK+ command line option, use \"%s --help\""
-msgstr ""
-
-#: ../src/common/imagtiff.cpp:311
+#: ../src/common/imagtiff.cpp:308
 msgid "Invalid TIFF image index."
 msgstr "Index d'imatge TIFF invàlid"
 
-#: ../src/common/appcmn.cpp:273
+#: ../src/common/appcmn.cpp:294
 #, c-format
 msgid "Invalid display mode specification '%s'."
 msgstr "Mode d'especificació de mostreig '%s' invàlid."
@@ -4481,255 +4586,259 @@ msgstr "Mode d'especificació de mostreig '%s' invàlid."
 msgid "Invalid geometry specification '%s'"
 msgstr "Especificació geomètrica invàlida '%s'"
 
-#: ../src/unix/fswatcher_inotify.cpp:323
+#: ../src/unix/fswatcher_inotify.cpp:320
 #, c-format
 msgid "Invalid inotify event for \"%s\""
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:312
+#: ../src/unix/snglinst.cpp:309
 #, c-format
 msgid "Invalid lock file '%s'."
 msgstr "Fitxer de bloqueig '%s' invàlid."
 
-#: ../src/common/translation.cpp:1125
+#: ../src/common/translation.cpp:1167
 #, fuzzy
 msgid "Invalid message catalog."
 msgstr "'%s' no és un missatge vàlid de catàleg"
 
-#: ../src/common/xtistrm.cpp:405 ../src/common/xtistrm.cpp:420
+#: ../src/common/xtistrm.cpp:402 ../src/common/xtistrm.cpp:417
 msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:435
+#: ../src/common/xtistrm.cpp:432
 msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
 msgstr ""
 
-#: ../src/common/regex.cpp:310
+#: ../src/common/regex.cpp:307
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Expressió regular invàlida '%s': %s"
 
-#: ../src/common/config.cpp:226
+#: ../src/common/config.cpp:222
 #, c-format
 msgid "Invalid value %ld for a boolean key \"%s\" in config file."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:351
-#: ../src/osx/carbon/fontdlg.cpp:361 ../src/common/stockitem.cpp:168
+#: ../src/osx/carbon/fontdlg.cpp:358 ../src/common/stockitem.cpp:165
+#: ../src/generic/fontdlgg.cpp:325 ../src/richtext/richtextfontpage.cpp:351
 msgid "Italic"
 msgstr "Cursiva"
 
-#: ../src/common/paper.cpp:130
+#: ../src/common/paper.cpp:127
 msgid "Italy Envelope, 110 x 230 mm"
 msgstr "Sobre italià, 110 x 230 mm"
 
-#: ../src/common/imagjpeg.cpp:270
+#: ../src/common/imagjpeg.cpp:257
 msgid "JPEG: Couldn't load - file is probably corrupted."
 msgstr "JPEG: No s'ha pogut carregar - el fitxer deu estar corromput."
 
-#: ../src/common/imagjpeg.cpp:449
+#: ../src/common/imagjpeg.cpp:436
 msgid "JPEG: Couldn't save image."
 msgstr "JPEG: No s'ha pogut alçar la imatge."
 
-#: ../src/common/paper.cpp:163
+#: ../src/common/paper.cpp:160
 msgid "Japanese Double Postcard 200 x 148 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:167
+#: ../src/common/paper.cpp:164
 msgid "Japanese Envelope Chou #3"
 msgstr ""
 
-#: ../src/common/paper.cpp:180
+#: ../src/common/paper.cpp:177
 msgid "Japanese Envelope Chou #3 Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:168
+#: ../src/common/paper.cpp:165
 msgid "Japanese Envelope Chou #4"
 msgstr ""
 
-#: ../src/common/paper.cpp:181
+#: ../src/common/paper.cpp:178
 msgid "Japanese Envelope Chou #4 Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:165
+#: ../src/common/paper.cpp:162
 msgid "Japanese Envelope Kaku #2"
 msgstr ""
 
-#: ../src/common/paper.cpp:178
+#: ../src/common/paper.cpp:175
 msgid "Japanese Envelope Kaku #2 Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:166
+#: ../src/common/paper.cpp:163
 msgid "Japanese Envelope Kaku #3"
 msgstr ""
 
-#: ../src/common/paper.cpp:179
+#: ../src/common/paper.cpp:176
 msgid "Japanese Envelope Kaku #3 Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:185
+#: ../src/common/paper.cpp:182
 msgid "Japanese Envelope You #4"
 msgstr ""
 
-#: ../src/common/paper.cpp:186
+#: ../src/common/paper.cpp:183
 msgid "Japanese Envelope You #4 Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:138
+#: ../src/common/paper.cpp:135
 msgid "Japanese Postcard 100 x 148 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:175
+#: ../src/common/paper.cpp:172
 msgid "Japanese Postcard Rotated 148 x 100 mm"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "Jump to"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:171
+#: ../src/common/stockitem.cpp:168
 msgid "Justified"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:155
-#: ../src/richtext/richtextindentspage.cpp:157
 #: ../src/richtext/richtextliststylepage.cpp:344
 #: ../src/richtext/richtextliststylepage.cpp:346
+#: ../src/richtext/richtextindentspage.cpp:155
+#: ../src/richtext/richtextindentspage.cpp:157
 msgid "Justify text left and right."
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:163
+#: ../src/common/fmapbase.cpp:160
 msgid "KOI8-R"
 msgstr "KOI8-R"
 
-#: ../src/common/fmapbase.cpp:164
+#: ../src/common/fmapbase.cpp:161
 #, fuzzy
 msgid "KOI8-U"
 msgstr "KOI8-R"
 
-#: ../src/common/accelcmn.cpp:265 ../src/common/accelcmn.cpp:347
+#: ../src/common/accelcmn.cpp:279 ../src/common/accelcmn.cpp:364
 msgid "KP_"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "KP_Add"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "KP_Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "KP_Decimal"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 #, fuzzy
 msgid "KP_Delete"
 msgstr "&Elimina"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "KP_Divide"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 #, fuzzy
 msgid "KP_Down"
 msgstr "Avall"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "KP_End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 #, fuzzy
 msgid "KP_Enter"
 msgstr "Imprimix"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "KP_Equal"
 msgstr ""
 
+#: ../src/common/accelcmn.cpp:276 ../src/common/accelcmn.cpp:361
+msgid "KP_F"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 #, fuzzy
 msgid "KP_Home"
 msgstr "sense nom"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 #, fuzzy
 msgid "KP_Insert"
 msgstr "Índex"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "KP_Left"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "KP_Multiply"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:99
+#: ../src/common/accelcmn.cpp:97
 #, fuzzy
 msgid "KP_Next"
 msgstr "&Següent"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "KP_PageDown"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "KP_PageUp"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:98
+#: ../src/common/accelcmn.cpp:96
 msgid "KP_Prior"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 #, fuzzy
 msgid "KP_Right"
 msgstr "Clar"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "KP_Separator"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "KP_Space"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "KP_Subtract"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "KP_Tab"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "KP_Up"
 msgstr ""
 
@@ -4737,119 +4846,134 @@ msgstr ""
 msgid "L&ine spacing:"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:613 ../src/generic/prntdlgg.cpp:868
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:280
+#, c-format
+msgid "LZMA compression error: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:196
+#, c-format
+msgid "LZMA decompression error: %s"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:861
 msgid "Landscape"
 msgstr "Apaïsat"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 #, fuzzy
 msgid "Last"
 msgstr "&Enganxa"
 
-#: ../src/common/prntbase.cpp:1572
+#: ../src/common/prntbase.cpp:1597
 #, fuzzy
 msgid "Last page"
 msgstr "Pàgina següent"
 
-#: ../src/common/log.cpp:305
+#: ../src/common/log.cpp:324
 #, c-format
 msgid "Last repeated message (\"%s\", %u time) wasn't output"
 msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/common/paper.cpp:103
+#: ../src/common/paper.cpp:100
 msgid "Ledger, 17 x 11 in"
 msgstr "Ledger, 17 x 11 polz."
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6146
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:58 ../src/generic/datavgen.cpp:6951
+#: ../src/richtext/richtextsizepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:252
 #: ../src/richtext/richtextliststylepage.cpp:253
 #: ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
-#: ../src/richtext/richtextsizepage.cpp:249 ../src/common/accelcmn.cpp:61
 msgid "Left"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:204
 #: ../src/richtext/richtextliststylepage.cpp:390
+#: ../src/richtext/richtextindentspage.cpp:204
 msgid "Left (&first line):"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1761
+#: ../src/propgrid/advprops.cpp:1662
 msgid "Left Button"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:880
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Left margin (mm):"
 msgstr "Marge esquerra (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:141
-#: ../src/richtext/richtextindentspage.cpp:143
 #: ../src/richtext/richtextliststylepage.cpp:330
 #: ../src/richtext/richtextliststylepage.cpp:332
+#: ../src/richtext/richtextindentspage.cpp:141
+#: ../src/richtext/richtextindentspage.cpp:143
 msgid "Left-align text."
 msgstr ""
 
-#: ../src/common/paper.cpp:144
+#: ../src/common/paper.cpp:141
 #, fuzzy
 msgid "Legal Extra 9 1/2 x 15 in"
 msgstr "Legal (8 1/2 x 14 polzades)"
 
-#: ../src/common/paper.cpp:96
+#: ../src/common/paper.cpp:93
 msgid "Legal, 8 1/2 x 14 in"
 msgstr "Legal (8 1/2 x 14 polzades)"
 
-#: ../src/common/paper.cpp:143
+#: ../src/common/paper.cpp:140
 #, fuzzy
 msgid "Letter Extra 9 1/2 x 12 in"
 msgstr "Carta (8 1/2 x 11 polzades)"
 
-#: ../src/common/paper.cpp:149
+#: ../src/common/paper.cpp:146
 msgid "Letter Extra Transverse 9.275 x 12 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:152
+#: ../src/common/paper.cpp:149
 #, fuzzy
 msgid "Letter Plus 8 1/2 x 12.69 in"
 msgstr "Carta (8 1/2 x 11 polzades)"
 
-#: ../src/common/paper.cpp:169
+#: ../src/common/paper.cpp:166
 #, fuzzy
 msgid "Letter Rotated 11 x 8 1/2 in"
 msgstr "Carta (8 1/2 x 11 polzades)"
 
-#: ../src/common/paper.cpp:101
+#: ../src/common/paper.cpp:98
 msgid "Letter Small, 8 1/2 x 11 in"
 msgstr "Carta petita, 8 1/2 x 11 polz"
 
-#: ../src/common/paper.cpp:147
+#: ../src/common/paper.cpp:144
 #, fuzzy
 msgid "Letter Transverse 8 1/2 x 11 in"
 msgstr "Carta (8 1/2 x 11 polzades)"
 
-#: ../src/common/paper.cpp:95
+#: ../src/common/paper.cpp:92
 msgid "Letter, 8 1/2 x 11 in"
 msgstr "Carta (8 1/2 x 11 polzades)"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "License"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:332
+#: ../src/generic/fontdlgg.cpp:328
 msgid "Light"
 msgstr "Clar"
 
-#: ../src/propgrid/advprops.cpp:1608
+#: ../src/propgrid/advprops.cpp:1514
 msgid "Lime"
 msgstr ""
 
-#: ../src/generic/helpext.cpp:294
+#: ../src/generic/helpext.cpp:292
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr ""
@@ -4858,15 +4982,15 @@ msgstr ""
 msgid "Line spacing:"
 msgstr ""
 
-#: ../src/html/chm.cpp:838
+#: ../src/html/chm.cpp:829
 msgid "Link contained '//', converted to absolute link."
 msgstr ""
 
-#: ../src/richtext/richtextformatdlg.cpp:364
+#: ../src/richtext/richtextformatdlg.cpp:357
 msgid "List Style"
 msgstr ""
 
-#: ../src/richtext/richtextstyles.cpp:1064
+#: ../src/richtext/richtextstyles.cpp:1061
 msgid "List styles"
 msgstr ""
 
@@ -4881,26 +5005,26 @@ msgstr ""
 msgid "Lists the available fonts."
 msgstr "Els consells no es troben disponibles!"
 
-#: ../src/common/fldlgcmn.cpp:340
+#: ../src/common/fldlgcmn.cpp:337
 #, c-format
 msgid "Load %s file"
 msgstr "Carrega fitxer %s"
 
-#: ../src/html/htmlwin.cpp:597
+#: ../src/html/htmlwin.cpp:600
 msgid "Loading : "
 msgstr "S'està carregant:"
 
-#: ../src/unix/snglinst.cpp:246
+#: ../src/unix/snglinst.cpp:243
 #, c-format
 msgid "Lock file '%s' has incorrect owner."
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:251
+#: ../src/unix/snglinst.cpp:248
 #, c-format
 msgid "Lock file '%s' has incorrect permissions."
 msgstr ""
 
-#: ../src/generic/logg.cpp:576
+#: ../src/generic/logg.cpp:573
 #, c-format
 msgid "Log saved to the file '%s'."
 msgstr "Registre alçat en el fitxer '%s'."
@@ -4915,11 +5039,11 @@ msgstr ""
 msgid "Lower case roman numerals"
 msgstr ""
 
-#: ../src/gtk/mdi.cpp:422 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk1/mdi.cpp:431 ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "MDI fill"
 
-#: ../src/msw/helpchm.cpp:56
+#: ../src/msw/helpchm.cpp:53
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -4927,193 +5051,193 @@ msgstr ""
 "Les funcions d'ajuda MS HTML no están disponibles perque la llibreria "
 "d'Ajuda MS HTML no està instal·lada en este maquinari. L'heu d'instal·lar.."
 
-#: ../src/univ/themes/win32.cpp:3754
+#: ../src/univ/themes/win32.cpp:3751
 msgid "Ma&ximize"
 msgstr "Ma&ximitza"
 
-#: ../src/common/fmapbase.cpp:203
+#: ../src/common/fmapbase.cpp:200
 msgid "MacArabic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:222
+#: ../src/common/fmapbase.cpp:219
 msgid "MacArmenian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:211
+#: ../src/common/fmapbase.cpp:208
 msgid "MacBengali"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:217
+#: ../src/common/fmapbase.cpp:214
 msgid "MacBurmese"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:236
+#: ../src/common/fmapbase.cpp:233
 msgid "MacCeltic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:227
+#: ../src/common/fmapbase.cpp:224
 msgid "MacCentralEurRoman"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:223
+#: ../src/common/fmapbase.cpp:220
 msgid "MacChineseSimp"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:201
+#: ../src/common/fmapbase.cpp:198
 msgid "MacChineseTrad"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:233
+#: ../src/common/fmapbase.cpp:230
 msgid "MacCroatian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:206
+#: ../src/common/fmapbase.cpp:203
 msgid "MacCyrillic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:207
+#: ../src/common/fmapbase.cpp:204
 msgid "MacDevanagari"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:231
+#: ../src/common/fmapbase.cpp:228
 msgid "MacDingbats"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:226
+#: ../src/common/fmapbase.cpp:223
 msgid "MacEthiopic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:229
+#: ../src/common/fmapbase.cpp:226
 msgid "MacExtArabic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:237
+#: ../src/common/fmapbase.cpp:234
 msgid "MacGaelic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:221
+#: ../src/common/fmapbase.cpp:218
 msgid "MacGeorgian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:205
+#: ../src/common/fmapbase.cpp:202
 msgid "MacGreek"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:209
+#: ../src/common/fmapbase.cpp:206
 msgid "MacGujarati"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:208
+#: ../src/common/fmapbase.cpp:205
 msgid "MacGurmukhi"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:204
+#: ../src/common/fmapbase.cpp:201
 msgid "MacHebrew"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:234
+#: ../src/common/fmapbase.cpp:231
 msgid "MacIcelandic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:200
+#: ../src/common/fmapbase.cpp:197
 msgid "MacJapanese"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:214
+#: ../src/common/fmapbase.cpp:211
 msgid "MacKannada"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:238
+#: ../src/common/fmapbase.cpp:235
 msgid "MacKeyboardGlyphs"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:218
+#: ../src/common/fmapbase.cpp:215
 msgid "MacKhmer"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:202
+#: ../src/common/fmapbase.cpp:199
 msgid "MacKorean"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:220
+#: ../src/common/fmapbase.cpp:217
 msgid "MacLaotian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:215
+#: ../src/common/fmapbase.cpp:212
 msgid "MacMalayalam"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:225
+#: ../src/common/fmapbase.cpp:222
 msgid "MacMongolian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:210
+#: ../src/common/fmapbase.cpp:207
 msgid "MacOriya"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:199
+#: ../src/common/fmapbase.cpp:196
 #, fuzzy
 msgid "MacRoman"
 msgstr "Roman"
 
-#: ../src/common/fmapbase.cpp:235
+#: ../src/common/fmapbase.cpp:232
 #, fuzzy
 msgid "MacRomanian"
 msgstr "Roman"
 
-#: ../src/common/fmapbase.cpp:216
+#: ../src/common/fmapbase.cpp:213
 #, fuzzy
 msgid "MacSinhalese"
 msgstr "Coincidència exacta"
 
-#: ../src/common/fmapbase.cpp:230
+#: ../src/common/fmapbase.cpp:227
 msgid "MacSymbol"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:212
+#: ../src/common/fmapbase.cpp:209
 msgid "MacTamil"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:213
+#: ../src/common/fmapbase.cpp:210
 msgid "MacTelugu"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:219
+#: ../src/common/fmapbase.cpp:216
 msgid "MacThai"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:224
+#: ../src/common/fmapbase.cpp:221
 msgid "MacTibetan"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:232
+#: ../src/common/fmapbase.cpp:229
 msgid "MacTurkish"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:228
+#: ../src/common/fmapbase.cpp:225
 msgid "MacVietnamese"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1762
+#: ../src/propgrid/advprops.cpp:1663
 msgid "Magnifier"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:2143
+#: ../src/propgrid/advprops.cpp:2050
 #, fuzzy
 msgid "Make a selection:"
 msgstr "Seccions"
 
-#: ../src/richtext/richtextformatdlg.cpp:374
+#: ../src/richtext/richtextformatdlg.cpp:367
 #: ../src/richtext/richtextmarginspage.cpp:171
 msgid "Margins"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1595
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Maroon"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:147
+#: ../src/generic/fdrepdlg.cpp:144
 msgid "Match case"
 msgstr "Coincidència exacta"
 
@@ -5127,42 +5251,42 @@ msgstr "vuitè"
 msgid "Max width:"
 msgstr "Substituix amb:"
 
-#: ../src/unix/mediactrl.cpp:947
+#: ../src/unix/mediactrl.cpp:972
 #, c-format
 msgid "Media playback error: %s"
 msgstr ""
 
-#: ../src/common/fs_mem.cpp:175
+#: ../src/common/fs_mem.cpp:170
 #, c-format
 msgid "Memory VFS already contains file '%s'!"
 msgstr "La memòria VFs encara conté el fitxer '%s'!"
 
 #. TRANSLATORS: Name of keyboard key
 #. TRANSLATORS: Keyword of system colour
-#: ../src/common/accelcmn.cpp:73 ../src/propgrid/advprops.cpp:889
+#: ../src/common/accelcmn.cpp:70 ../src/propgrid/advprops.cpp:790
 #, fuzzy
 msgid "Menu"
 msgstr "Modern"
 
-#: ../src/common/msgout.cpp:124
+#: ../src/common/msgout.cpp:121
 #, fuzzy
 msgid "Message"
 msgstr "missatge %s"
 
-#: ../src/univ/themes/metal.cpp:168
+#: ../src/univ/themes/metal.cpp:165
 msgid "Metal theme"
 msgstr "Tema metal·litzat"
 
-#: ../src/msw/ole/automtn.cpp:652
+#: ../src/msw/ole/automtn.cpp:643
 msgid "Method or property not found."
 msgstr ""
 
-#: ../src/univ/themes/win32.cpp:3752
+#: ../src/univ/themes/win32.cpp:3749
 msgid "Mi&nimize"
 msgstr "Mi&nimitza"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1763
+#: ../src/propgrid/advprops.cpp:1664
 msgid "Middle Button"
 msgstr ""
 
@@ -5175,36 +5299,41 @@ msgstr "vuitè"
 msgid "Min width:"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:668
+#: ../src/osx/cocoa/menu.mm:281
+#, fuzzy
+msgid "Minimize"
+msgstr "Mi&nimitza"
+
+#: ../src/msw/ole/automtn.cpp:659
 msgid "Missing a required parameter."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:324
+#: ../src/generic/fontdlgg.cpp:320
 msgid "Modern"
 msgstr "Modern"
 
-#: ../src/generic/filectrlg.cpp:427
+#: ../src/generic/filectrlg.cpp:423
 msgid "Modified"
 msgstr ""
 
-#: ../src/common/module.cpp:133
+#: ../src/common/module.cpp:130
 #, c-format
 msgid "Module \"%s\" initialization failed"
 msgstr ""
 
-#: ../src/common/paper.cpp:131
+#: ../src/common/paper.cpp:128
 msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
 msgstr "Sobre reial, 3 7/8 x 1/2 polz"
 
-#: ../src/msw/fswatcher.cpp:143
+#: ../src/msw/fswatcher.cpp:140
 msgid "Monitoring individual files for changes is not supported currently."
 msgstr ""
 
-#: ../src/generic/editlbox.cpp:172
+#: ../src/generic/editlbox.cpp:160
 msgid "Move down"
 msgstr ""
 
-#: ../src/generic/editlbox.cpp:171
+#: ../src/generic/editlbox.cpp:155
 #, fuzzy
 msgid "Move up"
 msgstr "&Mou"
@@ -5219,99 +5348,104 @@ msgstr ""
 msgid "Moves the object to the previous paragraph."
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9966
+#: ../src/richtext/richtextbuffer.cpp:9963
 msgid "Multiple Cell Properties"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:424
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:82
+msgid "Multiply"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:420
 msgid "Name"
 msgstr "Nom"
 
-#: ../src/propgrid/advprops.cpp:1596
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Navy"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "Network"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173
 #, fuzzy
 msgid "New"
 msgstr "&Següent"
 
-#: ../src/richtext/richtextstyledlg.cpp:243
+#: ../src/richtext/richtextstyledlg.cpp:239
 #, fuzzy
 msgid "New &Box Style..."
 msgstr "&Elimina"
 
-#: ../src/richtext/richtextstyledlg.cpp:225
+#: ../src/richtext/richtextstyledlg.cpp:221
 msgid "New &Character Style..."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:237
+#: ../src/richtext/richtextstyledlg.cpp:233
 msgid "New &List Style..."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:231
+#: ../src/richtext/richtextstyledlg.cpp:227
 msgid "New &Paragraph Style..."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:606
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:654
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:820
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:893
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:934
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:602
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:650
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:816
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:889
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:930
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "New Style"
 msgstr ""
 
-#: ../src/generic/editlbox.cpp:169
+#: ../src/generic/editlbox.cpp:139
 msgid "New item"
 msgstr ""
 
-#: ../src/generic/dirdlgg.cpp:297 ../src/generic/dirdlgg.cpp:307
-#: ../src/generic/filectrlg.cpp:618 ../src/generic/filectrlg.cpp:627
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+#: ../src/generic/dirdlgg.cpp:294 ../src/generic/dirdlgg.cpp:304
 msgid "NewName"
 msgstr "Nou nom"
 
-#: ../src/common/prntbase.cpp:1567 ../src/html/helpwnd.cpp:665
+#: ../src/common/prntbase.cpp:1592 ../src/html/helpwnd.cpp:663
 msgid "Next page"
 msgstr "Pàgina següent"
 
-#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:177
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:174
 #: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "No"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1764
+#: ../src/propgrid/advprops.cpp:1665
 msgid "No Entry"
 msgstr ""
 
-#: ../src/generic/animateg.cpp:150
+#: ../src/generic/animateg.cpp:133
 #, fuzzy, c-format
 msgid "No animation handler for type %ld defined."
 msgstr "No hi ha definit cap manegador per al tipus d'imatge %d."
 
-#: ../src/dfb/bitmap.cpp:642 ../src/dfb/bitmap.cpp:676
+#: ../src/dfb/bitmap.cpp:639 ../src/dfb/bitmap.cpp:673
 #, fuzzy, c-format
 msgid "No bitmap handler for type %d defined."
 msgstr "No hi ha definit cap manegador per al tipus d'imatge %d."
 
-#: ../src/common/utilscmn.cpp:1077
+#: ../src/common/utilscmn.cpp:1095
 msgid "No default application configured for HTML files."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:445
+#: ../src/generic/helpext.cpp:443
 msgid "No entries found."
 msgstr "No s'ha trobat entrades."
 
-#: ../src/common/fontmap.cpp:421
+#: ../src/common/fontmap.cpp:418
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found,\n"
@@ -5324,7 +5458,7 @@ msgstr ""
 "però hi ha la codificació '%s' alternativa.\n"
 "Voleu fer servir esta codificació (sino haureu de triar-ne una altra)?"
 
-#: ../src/common/fontmap.cpp:426
+#: ../src/common/fontmap.cpp:423
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found.\n"
@@ -5336,214 +5470,212 @@ msgstr ""
 "Voleu triar un tipus de lletra per esta codificació\n"
 "(sino el text en esta codificació no es mostrarà correctament)?"
 
-#: ../src/generic/animateg.cpp:142
+#: ../src/generic/animateg.cpp:125
 #, fuzzy
 msgid "No handler found for animation type."
 msgstr "No s'ha trobat cap manegador per al tipus d'imatge"
 
-#: ../src/common/image.cpp:2728
+#: ../src/common/image.cpp:2823
 msgid "No handler found for image type."
 msgstr "No s'ha trobat cap manegador per al tipus d'imatge"
 
-#: ../src/common/image.cpp:2736 ../src/common/image.cpp:2848
-#: ../src/common/image.cpp:2901
+#: ../src/common/image.cpp:2831 ../src/common/image.cpp:2954
+#: ../src/common/image.cpp:3020
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "No hi ha definit cap manegador per al tipus d'imatge %d."
 
-#: ../src/common/image.cpp:2871 ../src/common/image.cpp:2915
+#: ../src/common/image.cpp:2986 ../src/common/image.cpp:3034
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "No hi ha definit cap manegador per al tipus d'imatge %s."
 
-#: ../src/html/helpwnd.cpp:858
+#: ../src/html/helpwnd.cpp:856
 msgid "No matching page found yet"
 msgstr "Encara no s'ha trobat cap pàgina que coincidisca"
 
-#: ../src/unix/sound.cpp:81
+#: ../src/unix/sound.cpp:78
 #, fuzzy
 msgid "No sound"
 msgstr "No s'ha trobat entrades."
 
-#: ../src/common/image.cpp:2277 ../src/common/image.cpp:2318
+#: ../src/common/image.cpp:2371 ../src/common/image.cpp:2412
 #, fuzzy
 msgid "No unused colour in image being masked."
 msgstr "Cap color no utilitzat en la imatge està sent emmascarat"
 
-#: ../src/common/image.cpp:3374
-#, fuzzy
-msgid "No unused colour in image."
-msgstr "Cap color no utilitzat en la imatge està sent emmascarat"
-
-#: ../src/generic/helpext.cpp:302
+#: ../src/generic/helpext.cpp:300
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr ""
 
-#: ../src/richtext/richtextborderspage.cpp:610
 #: ../src/richtext/richtextsizepage.cpp:248
 #: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:610
 #, fuzzy
 msgid "None"
 msgstr "Fet"
 
-#: ../src/common/fmapbase.cpp:157
+#: ../src/common/fmapbase.cpp:154
 msgid "Nordic (ISO-8859-10)"
 msgstr "Nòrdic (ISO-8859-10)"
 
-#: ../src/generic/fontdlgg.cpp:328 ../src/generic/fontdlgg.cpp:331
+#: ../src/generic/fontdlgg.cpp:324 ../src/generic/fontdlgg.cpp:327
 msgid "Normal"
 msgstr "Normal"
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1261
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1205
+#: ../src/html/helpwnd.cpp:1203
 msgid "Normal font:"
 msgstr "Font normal"
 
-#: ../src/propgrid/props.cpp:1128
+#: ../src/propgrid/props.cpp:1115
 #, fuzzy, c-format
 msgid "Not %s"
 msgstr "No"
 
-#: ../include/wx/filename.h:573 ../include/wx/filename.h:578
-#, fuzzy
-msgid "Not available"
-msgstr "Servei XBM no disponible!"
+#: ../src/common/secretstore.cpp:168
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/webrequest.cpp:605
+msgid "Not enough free disk space for download."
+msgstr ""
 
 #: ../src/richtext/richtextfontpage.cpp:358
 #, fuzzy
 msgid "Not underlined"
 msgstr "subratllat"
 
-#: ../src/common/paper.cpp:115
+#: ../src/common/paper.cpp:112
 msgid "Note, 8 1/2 x 11 in"
 msgstr "Nota, 8 1/2 x 11 polzades"
 
-#: ../src/generic/notifmsgg.cpp:132
+#: ../src/generic/notifmsgg.cpp:129
 #, fuzzy
 msgid "Notice"
 msgstr "No"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "Num *"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "Num +"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "Num ,"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "Num -"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "Num ."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "Num /"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "Num ="
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "Num Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 #, fuzzy
 msgid "Num Delete"
 msgstr "&Elimina"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 #, fuzzy
 msgid "Num Down"
 msgstr "Avall"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "Num End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "Num Enter"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 #, fuzzy
 msgid "Num Home"
 msgstr "sense nom"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 #, fuzzy
 msgid "Num Insert"
 msgstr "Índex"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num Lock"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "Num Page Down"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "Num Page Up"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 #, fuzzy
 msgid "Num Right"
 msgstr "Clar"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "Num Space"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "Num Tab"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "Num Up"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "Num left"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num_lock"
 msgstr ""
 
@@ -5552,13 +5684,13 @@ msgstr ""
 msgid "Numbered outline"
 msgstr ""
 
-#: ../include/wx/msgdlg.h:278 ../src/richtext/richtextstyledlg.cpp:297
-#: ../src/common/stockitem.cpp:178 ../src/msw/msgdlg.cpp:454
-#: ../src/msw/msgdlg.cpp:747 ../src/gtk1/fontdlg.cpp:138
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:175
+#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/msgdlg.cpp:741 ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "D'acord"
 
-#: ../src/msw/ole/automtn.cpp:692
+#: ../src/msw/ole/automtn.cpp:683
 #, c-format
 msgid "OLE Automation error in %s: %s"
 msgstr ""
@@ -5568,15 +5700,15 @@ msgstr ""
 msgid "Object Properties"
 msgstr "&Previ"
 
-#: ../src/msw/ole/automtn.cpp:660
+#: ../src/msw/ole/automtn.cpp:651
 msgid "Object implementation does not support named arguments."
 msgstr ""
 
-#: ../src/common/xtixml.cpp:264
+#: ../src/common/xtixml.cpp:260
 msgid "Objects must have an id attribute"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1601
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Olive"
 msgstr ""
 
@@ -5584,65 +5716,70 @@ msgstr ""
 msgid "Opaci&ty:"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:354
+#: ../src/generic/colrdlgg.cpp:374
 msgid "Opacity:"
 msgstr ""
 
-#: ../src/common/docview.cpp:1773 ../src/common/docview.cpp:1815
+#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
 msgid "Open File"
 msgstr "Selecciona un Fitxer"
 
-#: ../src/html/helpwnd.cpp:671 ../src/html/helpwnd.cpp:1554
+#: ../src/html/helpwnd.cpp:669 ../src/html/helpwnd.cpp:1552
 msgid "Open HTML document"
 msgstr "Obri document HTML"
 
-#: ../src/generic/dbgrptg.cpp:163
+#: ../src/common/stockitem.cpp:265
+#, fuzzy
+msgid "Open an existing document"
+msgstr "Obri document HTML"
+
+#: ../src/generic/dbgrptg.cpp:160
 #, fuzzy, c-format
 msgid "Open file \"%s\""
 msgstr "no s'ha pogut obrir el fitxer '%s'"
 
-#: ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176
 #, fuzzy
 msgid "Open..."
 msgstr "&Desa..."
 
-#: ../src/unix/glx11.cpp:506 ../src/msw/glcanvas.cpp:592
+#: ../src/msw/glcanvas.cpp:607 ../src/unix/glx11.cpp:513
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr ""
 
-#: ../src/generic/dirctrlg.cpp:599 ../src/generic/dirdlgg.cpp:323
-#: ../src/generic/filectrlg.cpp:642 ../src/generic/filectrlg.cpp:786
+#: ../src/generic/dirctrlg.cpp:565 ../src/generic/filectrlg.cpp:638
+#: ../src/generic/filectrlg.cpp:782 ../src/generic/dirdlgg.cpp:320
 msgid "Operation not permitted."
 msgstr "Operació no permesa."
 
-#: ../src/common/cmdline.cpp:900
+#: ../src/common/cmdline.cpp:896
 #, fuzzy, c-format
 msgid "Option '%s' can't be negated"
 msgstr "No s'ha pogut crear el directori '%s'"
 
-#: ../src/common/cmdline.cpp:1064
+#: ../src/common/cmdline.cpp:1060
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "L'opció '%s' requerix un valor."
 
-#: ../src/common/cmdline.cpp:1147
+#: ../src/common/cmdline.cpp:1143
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Opció '%s': '%s' no es pot convertir a data."
 
-#: ../src/generic/prntdlgg.cpp:618
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Opcions"
 
-#: ../src/propgrid/advprops.cpp:1606
+#: ../src/propgrid/advprops.cpp:1512
 msgid "Orange"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:615 ../src/generic/prntdlgg.cpp:869
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:862
 msgid "Orientation"
 msgstr "Orientació"
 
-#: ../src/common/windowid.cpp:242
+#: ../src/common/windowid.cpp:237
 msgid "Out of window IDs.  Recommend shutting down application."
 msgstr ""
 
@@ -5655,167 +5792,167 @@ msgstr ""
 msgid "Outset"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:656
+#: ../src/msw/ole/automtn.cpp:647
 msgid "Overflow while coercing argument values."
 msgstr ""
 
-#: ../src/common/imagpcx.cpp:457 ../src/common/imagpcx.cpp:480
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:479
 msgid "PCX: couldn't allocate memory"
 msgstr "PCX: no es pot localitzar la memòria"
 
-#: ../src/common/imagpcx.cpp:456
+#: ../src/common/imagpcx.cpp:455
 msgid "PCX: image format unsupported"
 msgstr "PCX: format d'imatge no suportat"
 
-#: ../src/common/imagpcx.cpp:479
+#: ../src/common/imagpcx.cpp:478
 msgid "PCX: invalid image"
 msgstr "PCX: imatge invàlida"
 
-#: ../src/common/imagpcx.cpp:442
+#: ../src/common/imagpcx.cpp:441
 msgid "PCX: this is not a PCX file."
 msgstr "PCX: este no és un fitxer PCX ."
 
-#: ../src/common/imagpcx.cpp:459 ../src/common/imagpcx.cpp:481
+#: ../src/common/imagpcx.cpp:458 ../src/common/imagpcx.cpp:480
 msgid "PCX: unknown error !!!"
 msgstr "PCX: error desconegut!!!"
 
-#: ../src/common/imagpcx.cpp:458
+#: ../src/common/imagpcx.cpp:457
 msgid "PCX: version number too low"
 msgstr "PCX: número de versió massa baix"
 
-#: ../src/common/imagpnm.cpp:91
+#: ../src/common/imagpnm.cpp:89
 msgid "PNM: Couldn't allocate memory."
 msgstr "PNM: No es pot localitzar la memòria."
 
-#: ../src/common/imagpnm.cpp:73
+#: ../src/common/imagpnm.cpp:71
 msgid "PNM: File format is not recognized."
 msgstr "PNM: Format de fitxer no reconegut."
 
-#: ../src/common/imagpnm.cpp:112 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
 #: ../src/common/imagpnm.cpp:156
 msgid "PNM: File seems truncated."
 msgstr "PNM: el fitxer sembla estroncat"
 
-#: ../src/common/paper.cpp:187
+#: ../src/common/paper.cpp:184
 msgid "PRC 16K 146 x 215 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:200
+#: ../src/common/paper.cpp:197
 msgid "PRC 16K Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:188
+#: ../src/common/paper.cpp:185
 msgid "PRC 32K 97 x 151 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:201
+#: ../src/common/paper.cpp:198
 msgid "PRC 32K Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:189
+#: ../src/common/paper.cpp:186
 msgid "PRC 32K(Big) 97 x 151 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:202
+#: ../src/common/paper.cpp:199
 msgid "PRC 32K(Big) Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:190
+#: ../src/common/paper.cpp:187
 #, fuzzy
 msgid "PRC Envelope #1 102 x 165 mm"
 msgstr "C6 Sobre, 114 x 162 mm"
 
-#: ../src/common/paper.cpp:203
+#: ../src/common/paper.cpp:200
 #, fuzzy
 msgid "PRC Envelope #1 Rotated 165 x 102 mm"
 msgstr "C6 Sobre, 114 x 162 mm"
 
-#: ../src/common/paper.cpp:199
+#: ../src/common/paper.cpp:196
 #, fuzzy
 msgid "PRC Envelope #10 324 x 458 mm"
 msgstr "C3 Sobre, 324 x 458 mm"
 
-#: ../src/common/paper.cpp:212
+#: ../src/common/paper.cpp:209
 #, fuzzy
 msgid "PRC Envelope #10 Rotated 458 x 324 mm"
 msgstr "C4 Sobre, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:191
+#: ../src/common/paper.cpp:188
 #, fuzzy
 msgid "PRC Envelope #2 102 x 176 mm"
 msgstr "C6 Sobre, 114 x 162 mm"
 
-#: ../src/common/paper.cpp:204
+#: ../src/common/paper.cpp:201
 #, fuzzy
 msgid "PRC Envelope #2 Rotated 176 x 102 mm"
 msgstr "B6 Sobre, 176 x 125 mm"
 
-#: ../src/common/paper.cpp:192
+#: ../src/common/paper.cpp:189
 #, fuzzy
 msgid "PRC Envelope #3 125 x 176 mm"
 msgstr "C6 Sobre, 114 x 162 mm"
 
-#: ../src/common/paper.cpp:205
+#: ../src/common/paper.cpp:202
 #, fuzzy
 msgid "PRC Envelope #3 Rotated 176 x 125 mm"
 msgstr "B6 Sobre, 176 x 125 mm"
 
-#: ../src/common/paper.cpp:193
+#: ../src/common/paper.cpp:190
 #, fuzzy
 msgid "PRC Envelope #4 110 x 208 mm"
 msgstr "Sobre DL, 110 x 220 mm"
 
-#: ../src/common/paper.cpp:206
+#: ../src/common/paper.cpp:203
 #, fuzzy
 msgid "PRC Envelope #4 Rotated 208 x 110 mm"
 msgstr "C6 Sobre, 114 x 162 mm"
 
-#: ../src/common/paper.cpp:194
+#: ../src/common/paper.cpp:191
 #, fuzzy
 msgid "PRC Envelope #5 110 x 220 mm"
 msgstr "Sobre DL, 110 x 220 mm"
 
-#: ../src/common/paper.cpp:207
+#: ../src/common/paper.cpp:204
 #, fuzzy
 msgid "PRC Envelope #5 Rotated 220 x 110 mm"
 msgstr "C4 Sobre, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:195
+#: ../src/common/paper.cpp:192
 #, fuzzy
 msgid "PRC Envelope #6 120 x 230 mm"
 msgstr "C5 Sobre, 162 x 229 mm"
 
-#: ../src/common/paper.cpp:208
+#: ../src/common/paper.cpp:205
 #, fuzzy
 msgid "PRC Envelope #6 Rotated 230 x 120 mm"
 msgstr "C5 Sobre, 162 x 229 mm"
 
-#: ../src/common/paper.cpp:196
+#: ../src/common/paper.cpp:193
 #, fuzzy
 msgid "PRC Envelope #7 160 x 230 mm"
 msgstr "B5 Sobre, 176 x 250 mm"
 
-#: ../src/common/paper.cpp:209
+#: ../src/common/paper.cpp:206
 #, fuzzy
 msgid "PRC Envelope #7 Rotated 230 x 160 mm"
 msgstr "C6 Sobre, 114 x 162 mm"
 
-#: ../src/common/paper.cpp:197
+#: ../src/common/paper.cpp:194
 #, fuzzy
 msgid "PRC Envelope #8 120 x 309 mm"
 msgstr "C5 Sobre, 162 x 229 mm"
 
-#: ../src/common/paper.cpp:210
+#: ../src/common/paper.cpp:207
 #, fuzzy
 msgid "PRC Envelope #8 Rotated 309 x 120 mm"
 msgstr "C4 Sobre, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:198
+#: ../src/common/paper.cpp:195
 #, fuzzy
 msgid "PRC Envelope #9 229 x 324 mm"
 msgstr "C4 Sobre, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:211
+#: ../src/common/paper.cpp:208
 #, fuzzy
 msgid "PRC Envelope #9 Rotated 324 x 229 mm"
 msgstr "C5 Sobre, 162 x 229 mm"
@@ -5825,94 +5962,98 @@ msgstr "C5 Sobre, 162 x 229 mm"
 msgid "Padding"
 msgstr "s'està llegint"
 
-#: ../src/common/prntbase.cpp:2074
+#: ../src/common/prntbase.cpp:2096
 #, c-format
 msgid "Page %d"
 msgstr "Pàgina %d"
 
-#: ../src/common/prntbase.cpp:2072
+#: ../src/common/prntbase.cpp:2094
 #, c-format
 msgid "Page %d of %d"
 msgstr "Pàgina %d de %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 #, fuzzy
 msgid "Page Down"
 msgstr "Pàgina %d"
 
-#: ../src/gtk/print.cpp:826
+#: ../src/gtk/print.cpp:829
 msgid "Page Setup"
 msgstr "Configuració de la pàgina"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 #, fuzzy
 msgid "Page Up"
 msgstr "Pàgina %d"
 
-#: ../src/generic/prntdlgg.cpp:828 ../src/common/prntbase.cpp:484
+#: ../src/common/prntbase.cpp:479 ../src/generic/prntdlgg.cpp:821
 #, fuzzy
 msgid "Page setup"
 msgstr "Configuració de la pàgina"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 #, fuzzy
 msgid "PageDown"
 msgstr "Avall"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 #, fuzzy
 msgid "PageUp"
 msgstr "Pàgines"
 
-#: ../src/generic/prntdlgg.cpp:216
+#: ../src/generic/prntdlgg.cpp:209
 msgid "Pages"
 msgstr "Pàgines"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1765
+#: ../src/propgrid/advprops.cpp:1666
 msgid "Paint Brush"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:602 ../src/generic/prntdlgg.cpp:801
-#: ../src/generic/prntdlgg.cpp:842 ../src/generic/prntdlgg.cpp:855
-#: ../src/generic/prntdlgg.cpp:1052 ../src/generic/prntdlgg.cpp:1057
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:794
+#: ../src/generic/prntdlgg.cpp:835 ../src/generic/prntdlgg.cpp:848
+#: ../src/generic/prntdlgg.cpp:1045 ../src/generic/prntdlgg.cpp:1050
 msgid "Paper size"
 msgstr "Grandària del paper"
 
-#: ../src/richtext/richtextstyles.cpp:1062
+#: ../src/richtext/richtextstyles.cpp:1059
 msgid "Paragraph styles"
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:465
+#: ../src/common/xtistrm.cpp:462
 msgid "Passing a already registered object to SetObject"
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:476
+#: ../src/common/xtistrm.cpp:473
 msgid "Passing an unknown object to GetObject"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:3513 ../src/common/stockitem.cpp:180
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:177 ../src/richtext/richtextctrl.cpp:3514
 #: ../src/stc/stc_i18n.cpp:19
 #, fuzzy
 msgid "Paste"
 msgstr "&Enganxa"
 
-#: ../src/common/stockitem.cpp:262
+#: ../src/common/stockitem.cpp:260
 #, fuzzy
 msgid "Paste selection"
 msgstr "Seccions"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:74
+#: ../src/common/accelcmn.cpp:71
 msgid "Pause"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1766
+#: ../src/propgrid/advprops.cpp:1667
 msgid "Pencil"
 msgstr ""
 
@@ -5921,21 +6062,21 @@ msgstr ""
 msgid "Peri&od"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:430
+#: ../src/generic/filectrlg.cpp:426
 msgid "Permissions"
 msgstr "Permisos"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:60
+#: ../src/common/accelcmn.cpp:57
 msgid "PgDn"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:59
+#: ../src/common/accelcmn.cpp:56
 msgid "PgUp"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:12868
+#: ../src/richtext/richtextbuffer.cpp:12863
 #, fuzzy
 msgid "Picture Properties"
 msgstr "&Previ"
@@ -5948,47 +6089,47 @@ msgstr "No s'ha pogut crear la canonada."
 msgid "Please choose a valid font."
 msgstr "Trieu una font vàlida"
 
-#: ../src/generic/filedlgg.cpp:357 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
 msgid "Please choose an existing file."
 msgstr "Trieu un fitxer existent."
 
-#: ../src/html/helpwnd.cpp:800
+#: ../src/html/helpwnd.cpp:798
 #, fuzzy
 msgid "Please choose the page to display:"
 msgstr "Trieu un fitxer existent."
 
-#: ../src/msw/dialup.cpp:764
+#: ../src/msw/dialup.cpp:758
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Trieu quin ISP us voleu connectar"
 
-#: ../src/common/headerctrlcmn.cpp:59
+#: ../src/common/headerctrlcmn.cpp:57
 msgid "Please select the columns to show and define their order:"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:538
+#: ../src/common/prntbase.cpp:533
 #, fuzzy
 msgid "Please wait while printing..."
 msgstr "Espereu mentre simprimix\n"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1767
+#: ../src/propgrid/advprops.cpp:1668
 #, fuzzy
 msgid "Point Left"
 msgstr "Grandària de la font:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1768
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgid "Point Right"
 msgstr "mitja nit"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:662
+#: ../src/propgrid/advprops.cpp:572
 #, fuzzy
 msgid "Point Size"
 msgstr "Grandària de la font:"
 
-#: ../src/generic/prntdlgg.cpp:612 ../src/generic/prntdlgg.cpp:867
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:860
 msgid "Portrait"
 msgstr "Vertical"
 
@@ -5997,268 +6138,277 @@ msgstr "Vertical"
 msgid "Position"
 msgstr "Pregunta"
 
-#: ../src/generic/prntdlgg.cpp:298
+#: ../src/generic/prntdlgg.cpp:291
 msgid "PostScript file"
 msgstr "Fitxer PostScript"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178 ../src/osx/cocoa/preferences.mm:303
 msgid "Preferences"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:568
+#: ../src/osx/menu_osx.cpp:460
 msgid "Preferences..."
 msgstr ""
 
-#: ../src/common/prntbase.cpp:546
+#: ../src/common/prntbase.cpp:541
 msgid "Preparing"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:455 ../src/osx/carbon/fontdlg.cpp:390
-#: ../src/html/helpwnd.cpp:1222
+#: ../src/osx/carbon/fontdlg.cpp:387 ../src/generic/fontdlgg.cpp:452
+#: ../src/html/helpwnd.cpp:1220
 msgid "Preview:"
 msgstr "Previsualització:"
 
-#: ../src/common/prntbase.cpp:1553 ../src/html/helpwnd.cpp:664
+#: ../src/common/prntbase.cpp:1578 ../src/html/helpwnd.cpp:662
 msgid "Previous page"
 msgstr "Pàgina anterior"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/prntdlgg.cpp:143 ../src/generic/prntdlgg.cpp:157
-#: ../src/common/prntbase.cpp:426 ../src/common/prntbase.cpp:1541
-#: ../src/common/accelcmn.cpp:77 ../src/gtk/print.cpp:620
-#: ../src/gtk/print.cpp:638
+#: ../src/common/prntbase.cpp:421 ../src/common/prntbase.cpp:1566
+#: ../src/common/accelcmn.cpp:74 ../src/generic/prntdlgg.cpp:136
+#: ../src/generic/prntdlgg.cpp:150 ../src/gtk/print.cpp:616
+#: ../src/gtk/print.cpp:634
 msgid "Print"
 msgstr "Imprimix"
 
-#: ../include/wx/prntbase.h:399 ../src/common/docview.cpp:1268
+#: ../src/common/docview.cpp:1262
 msgid "Print Preview"
 msgstr "Imprimix previsualització"
 
-#: ../src/common/prntbase.cpp:2015 ../src/common/prntbase.cpp:2057
-#: ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2037 ../src/common/prntbase.cpp:2079
+#: ../src/common/prntbase.cpp:2087
 msgid "Print Preview Failure"
 msgstr "Error en la previsualització d'impressió"
 
-#: ../src/generic/prntdlgg.cpp:224
+#: ../src/generic/prntdlgg.cpp:217
 msgid "Print Range"
 msgstr "Rang d'impressió"
 
-#: ../src/generic/prntdlgg.cpp:449
+#: ../src/generic/prntdlgg.cpp:442
 msgid "Print Setup"
 msgstr "Paràmetres d'impressió"
 
-#: ../src/generic/prntdlgg.cpp:621
+#: ../src/generic/prntdlgg.cpp:614
 msgid "Print in colour"
 msgstr "Imprimix en color"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/osx/webview_webkit.mm:260
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "No es pot començar a mostrar."
+
+#: ../src/common/stockitem.cpp:179
 #, fuzzy
 msgid "Print previe&w..."
 msgstr "Imprimix previsualització"
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1256
 #, fuzzy
 msgid "Print preview creation failed."
 msgstr "No s'ha pogut crear la canonada."
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/common/stockitem.cpp:179
 #, fuzzy
 msgid "Print preview..."
 msgstr "Imprimix previsualització"
 
-#: ../src/generic/prntdlgg.cpp:630
+#: ../src/generic/prntdlgg.cpp:623
 msgid "Print spooling"
 msgstr "Cua d'impressió"
 
-#: ../src/html/helpwnd.cpp:675
+#: ../src/html/helpwnd.cpp:673
 msgid "Print this page"
 msgstr "Imprimix esta pàgina"
 
-#: ../src/generic/prntdlgg.cpp:185
+#: ../src/generic/prntdlgg.cpp:178
 msgid "Print to File"
 msgstr "Imprimix al fitxer"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 #, fuzzy
 msgid "Print..."
 msgstr "Imprimix..."
 
-#: ../src/generic/prntdlgg.cpp:493
+#: ../src/generic/prntdlgg.cpp:486
 #, fuzzy
 msgid "Printer"
 msgstr "Imprimix"
 
-#: ../src/generic/prntdlgg.cpp:633
+#: ../src/generic/prntdlgg.cpp:626
 msgid "Printer command:"
 msgstr "Orde d'impressió"
 
-#: ../src/generic/prntdlgg.cpp:180
+#: ../src/generic/prntdlgg.cpp:173
 msgid "Printer options"
 msgstr "Opcions d'impressió"
 
-#: ../src/generic/prntdlgg.cpp:645
+#: ../src/generic/prntdlgg.cpp:638
 msgid "Printer options:"
 msgstr "Opcions d'impressió:"
 
-#: ../src/generic/prntdlgg.cpp:916
+#: ../src/generic/prntdlgg.cpp:909
 msgid "Printer..."
 msgstr "Impressió..."
 
-#: ../src/generic/prntdlgg.cpp:196
+#: ../src/generic/prntdlgg.cpp:189
 #, fuzzy
 msgid "Printer:"
 msgstr "Impressió..."
 
-#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:535
-#: ../src/html/htmprint.cpp:277
+#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:530
+#: ../src/html/htmprint.cpp:289
 #, fuzzy
 msgid "Printing"
 msgstr "S'està imprimint"
 
-#: ../src/common/prntbase.cpp:612
+#: ../src/common/prntbase.cpp:607
 msgid "Printing "
 msgstr "S'està imprimint"
 
-#: ../src/common/prntbase.cpp:347
+#: ../src/common/prntbase.cpp:342
 msgid "Printing Error"
 msgstr "Error d'impressió"
 
-#: ../src/common/prntbase.cpp:565
+#: ../src/osx/webview_webkit.mm:251
+msgid "Printing is not supported by the system web control"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:560
 #, fuzzy, c-format
 msgid "Printing page %d"
 msgstr "S'està imprimint la pàgina %d..."
 
-#: ../src/common/prntbase.cpp:570
+#: ../src/common/prntbase.cpp:565
 #, fuzzy, c-format
 msgid "Printing page %d of %d"
 msgstr "S'està imprimint la pàgina %d..."
 
-#: ../src/generic/printps.cpp:201
+#: ../src/generic/printps.cpp:182
 #, c-format
 msgid "Printing page %d..."
 msgstr "S'està imprimint la pàgina %d..."
 
-#: ../src/generic/printps.cpp:161
+#: ../src/generic/printps.cpp:142
 msgid "Printing..."
 msgstr "S'està imprimint..."
 
-#: ../include/wx/richtext/richtextprint.h:109 ../include/wx/prntbase.h:267
-#: ../src/common/docview.cpp:2132
+#: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
+#: ../src/common/docview.cpp:2137
 #, fuzzy
 msgid "Printout"
 msgstr "Imprimix"
 
-#: ../src/common/debugrpt.cpp:560
+#: ../src/common/debugrpt.cpp:561
 #, c-format
 msgid ""
 "Processing debug report has failed, leaving the files in \"%s\" directory."
 msgstr ""
 
-#: ../src/common/prntbase.cpp:545
+#: ../src/common/prntbase.cpp:540
 msgid "Progress:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181
 #, fuzzy
 msgid "Properties"
 msgstr "&Previ"
 
-#: ../src/propgrid/manager.cpp:237
+#: ../src/propgrid/manager.cpp:223
 #, fuzzy
 msgid "Property"
 msgstr "&Previ"
 
 #. TRANSLATORS: Caption of message box displaying any property error
-#: ../src/propgrid/propgrid.cpp:3185 ../src/propgrid/propgrid.cpp:3318
+#: ../src/propgrid/propgrid.cpp:3162 ../src/propgrid/propgrid.cpp:3299
 #, fuzzy
 msgid "Property Error"
 msgstr "Error d'impressió"
 
-#: ../src/propgrid/advprops.cpp:1597
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Purple"
 msgstr ""
 
-#: ../src/common/paper.cpp:112
+#: ../src/common/paper.cpp:109
 msgid "Quarto, 215 x 275 mm"
 msgstr "Quarto, 215 x 275 mm"
 
-#: ../src/generic/logg.cpp:1016
+#: ../src/generic/logg.cpp:1013
 msgid "Question"
 msgstr "Pregunta"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1769
+#: ../src/propgrid/advprops.cpp:1670
 #, fuzzy
 msgid "Question Arrow"
 msgstr "Pregunta"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "Quit"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:477
 #, fuzzy, c-format
 msgid "Quit %s"
 msgstr "No"
 
-#: ../src/common/stockitem.cpp:263
+#: ../src/common/stockitem.cpp:261
 #, fuzzy
 msgid "Quit this program"
 msgstr "Imprimix esta pàgina"
 
-#: ../src/common/accelcmn.cpp:338
+#: ../src/common/accelcmn.cpp:352
 #, fuzzy
 msgid "RawCtrl+"
 msgstr "control"
 
-#: ../src/common/ffile.cpp:109 ../src/common/ffile.cpp:133
+#: ../src/common/ffile.cpp:107 ../src/common/ffile.cpp:132
 #, c-format
 msgid "Read error on file '%s'"
 msgstr "Llig error en el fitxer '%s'"
 
-#: ../src/common/secretstore.cpp:199
+#: ../src/common/secretstore.cpp:211
 #, fuzzy, c-format
-msgid "Reading password for \"%s/%s\" failed: %s."
+msgid "Reading password for \"%s\" failed: %s."
 msgstr "L'execució de l'orde '%s' ha fallit."
 
-#: ../src/common/prntbase.cpp:272
+#: ../src/common/prntbase.cpp:267
 #, fuzzy
 msgid "Ready"
 msgstr "&Refés"
 
-#: ../src/propgrid/advprops.cpp:1605
+#: ../src/propgrid/advprops.cpp:1511
 #, fuzzy
 msgid "Red"
 msgstr "&Refés"
 
-#: ../src/generic/colrdlgg.cpp:339
+#: ../src/generic/colrdlgg.cpp:359
 msgid "Red:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:185 ../src/stc/stc_i18n.cpp:16
+#: ../src/common/stockitem.cpp:182 ../src/stc/stc_i18n.cpp:16
 #, fuzzy
 msgid "Redo"
 msgstr "&Refés"
 
-#: ../src/common/stockitem.cpp:264
+#: ../src/common/stockitem.cpp:262
 msgid "Redo last action"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:186
+#: ../src/common/stockitem.cpp:183
 msgid "Refresh"
 msgstr ""
 
-#: ../src/msw/registry.cpp:626
+#: ../src/msw/registry.cpp:615
 #, c-format
 msgid "Registry key '%s' already exists."
 msgstr "La clau de registre '%s' ja existix."
 
-#: ../src/msw/registry.cpp:595
+#: ../src/msw/registry.cpp:584
 #, c-format
 msgid "Registry key '%s' does not exist, cannot rename it."
 msgstr "La clau de registre '%s' no existix, no la podeu reanomenar."
 
-#: ../src/msw/registry.cpp:727
+#: ../src/msw/registry.cpp:716
 #, c-format
 msgid ""
 "Registry key '%s' is needed for normal system operation,\n"
@@ -6269,22 +6419,22 @@ msgstr ""
 "eliminant-los deixarà el vostre sistema en un estat inservible:\n"
 "operació avortada."
 
-#: ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:942
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:917
+#: ../src/msw/registry.cpp:905
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1003
+#: ../src/msw/registry.cpp:991
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:521
+#: ../src/msw/registry.cpp:510
 #, c-format
 msgid "Registry value '%s' already exists."
 msgstr "El valor '%s' de registre encara existix."
@@ -6299,74 +6449,78 @@ msgstr ""
 msgid "Relative"
 msgstr "Decoratiu"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:456
 msgid "Relevant entries:"
 msgstr "Entrades rellevants:"
 
-#: ../include/wx/generic/progdlgg.h:86
+#: ../include/wx/generic/progdlgg.h:87
 #, fuzzy
 msgid "Remaining time:"
 msgstr "Temps restant :"
 
-#: ../src/common/stockitem.cpp:187
+#: ../src/common/stockitem.cpp:184
 msgid "Remove"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:1562
+#: ../src/richtext/richtextctrl.cpp:1563
 msgid "Remove Bullet"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:433
+#: ../src/html/helpwnd.cpp:431
 msgid "Remove current page from bookmarks"
 msgstr "Extreu la pàgina actual dels preferits"
 
-#: ../src/common/rendcmn.cpp:194
+#: ../src/common/rendcmn.cpp:191
 #, c-format
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:4527
+#: ../src/richtext/richtextbuffer.cpp:4524
 msgid "Renumber List"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:188
+#: ../src/common/stockitem.cpp:185
 #, fuzzy
-msgid "Rep&lace"
+msgid "Rep&lace..."
 msgstr "&Substituix"
 
-#: ../src/richtext/richtextctrl.cpp:3673 ../src/common/stockitem.cpp:188
+#: ../src/richtext/richtextctrl.cpp:3674
 #, fuzzy
 msgid "Replace"
 msgstr "&Substituix"
 
-#: ../src/generic/fdrepdlg.cpp:182
+#: ../src/generic/fdrepdlg.cpp:179
 msgid "Replace &all"
 msgstr "Substituix-ho &tot"
 
-#: ../src/common/stockitem.cpp:261
-#, fuzzy
-msgid "Replace selection"
-msgstr "Substituix-ho &tot"
-
-#: ../src/generic/fdrepdlg.cpp:124
+#: ../src/generic/fdrepdlg.cpp:121
 msgid "Replace with:"
 msgstr "Substituix amb:"
 
-#: ../src/common/valtext.cpp:163
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Replace..."
+msgstr "&Substituix"
+
+#: ../src/common/valtext.cpp:184
 msgid "Required information entry is empty."
 msgstr ""
 
-#: ../src/common/translation.cpp:1975
+#: ../src/common/translation.cpp:2025
 #, fuzzy, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "'%s' no és un missatge vàlid de catàleg"
 
+#: ../src/gtk/webview_webkit.cpp:985
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:56
+#: ../src/common/accelcmn.cpp:53
 msgid "Return"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:189
+#: ../src/common/stockitem.cpp:186
 msgid "Revert to Saved"
 msgstr ""
 
@@ -6379,43 +6533,43 @@ msgstr "Clar"
 msgid "Rig&ht-to-left"
 msgstr ""
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6149
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:59 ../src/generic/datavgen.cpp:6954
+#: ../src/richtext/richtextsizepage.cpp:250
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextbulletspage.cpp:188
-#: ../src/richtext/richtextsizepage.cpp:250 ../src/common/accelcmn.cpp:62
 #, fuzzy
 msgid "Right"
 msgstr "Clar"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1754
+#: ../src/propgrid/advprops.cpp:1655
 #, fuzzy
 msgid "Right Arrow"
 msgstr "Clar"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1770
+#: ../src/propgrid/advprops.cpp:1671
 msgid "Right Button"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:892
+#: ../src/generic/prntdlgg.cpp:885
 msgid "Right margin (mm):"
 msgstr "Marge dret (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:148
-#: ../src/richtext/richtextindentspage.cpp:150
 #: ../src/richtext/richtextliststylepage.cpp:337
 #: ../src/richtext/richtextliststylepage.cpp:339
+#: ../src/richtext/richtextindentspage.cpp:148
+#: ../src/richtext/richtextindentspage.cpp:150
 msgid "Right-align text."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:322
+#: ../src/generic/fontdlgg.cpp:318
 msgid "Roman"
 msgstr "Roman"
 
-#: ../src/generic/datavgen.cpp:5916
+#: ../src/generic/datavgen.cpp:6721
 #, c-format
 msgid "Row %i"
 msgstr ""
@@ -6425,33 +6579,33 @@ msgstr ""
 msgid "S&tandard bullet name:"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:268 ../src/common/accelcmn.cpp:350
+#: ../src/common/accelcmn.cpp:282 ../src/common/accelcmn.cpp:367
 msgid "SPECIAL"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:190 ../src/common/sizer.cpp:2797
+#: ../src/common/stockitem.cpp:187 ../src/common/sizer.cpp:2914
 #, fuzzy
 msgid "Save"
 msgstr "&Desa..."
 
-#: ../src/common/fldlgcmn.cpp:342
+#: ../src/common/fldlgcmn.cpp:339
 #, c-format
 msgid "Save %s file"
 msgstr "Alça fitxer %s"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/common/stockitem.cpp:188 ../src/generic/logg.cpp:509
 #, fuzzy
 msgid "Save &As..."
 msgstr "&Desa..."
 
-#: ../src/common/docview.cpp:366
+#: ../src/common/docview.cpp:359
 msgid "Save As"
 msgstr "Anomena i Alça"
 
-#: ../src/common/stockitem.cpp:191
+#: ../src/common/stockitem.cpp:188
 #, fuzzy
-msgid "Save as"
-msgstr "Anomena i Alça"
+msgid "Save As..."
+msgstr "&Desa..."
 
 #: ../src/common/stockitem.cpp:267
 #, fuzzy
@@ -6462,40 +6616,40 @@ msgstr "Seleccioneu una vista del document"
 msgid "Save current document with a different filename"
 msgstr ""
 
-#: ../src/generic/logg.cpp:512
+#: ../src/generic/logg.cpp:509
 msgid "Save log contents to file"
 msgstr "Alça els continguts del registre al fitxer"
 
-#: ../src/common/secretstore.cpp:179
+#: ../src/common/secretstore.cpp:189
 #, fuzzy, c-format
-msgid "Saving password for \"%s/%s\" failed: %s."
+msgid "Saving password for \"%s\" failed: %s."
 msgstr "L'execució de l'orde '%s' ha fallit."
 
-#: ../src/generic/fontdlgg.cpp:325
+#: ../src/generic/fontdlgg.cpp:321
 msgid "Script"
 msgstr "Script"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll Lock"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll_lock"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:890
+#: ../src/propgrid/advprops.cpp:791
 msgid "Scrollbar"
 msgstr ""
 
-#: ../src/generic/srchctlg.cpp:56 ../src/html/helpwnd.cpp:535
-#: ../src/html/helpwnd.cpp:550
+#: ../src/generic/srchctlg.cpp:55 ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:548 ../src/gtk/srchctrl.cpp:182
 msgid "Search"
 msgstr "Cerca"
 
-#: ../src/html/helpwnd.cpp:537
+#: ../src/html/helpwnd.cpp:535
 #, fuzzy
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
@@ -6504,57 +6658,57 @@ msgstr ""
 "Cerqueu continguts en llibre(s) d'ajuda per totes les ocurrències del text "
 "escrit"
 
-#: ../src/generic/fdrepdlg.cpp:160
+#: ../src/generic/fdrepdlg.cpp:157
 msgid "Search direction"
 msgstr "Direcció de cerca"
 
-#: ../src/generic/fdrepdlg.cpp:112
+#: ../src/generic/fdrepdlg.cpp:109
 msgid "Search for:"
 msgstr "Cerca:"
 
-#: ../src/html/helpwnd.cpp:1052
+#: ../src/html/helpwnd.cpp:1050
 msgid "Search in all books"
 msgstr "Cerca a tots els llibres"
 
-#: ../src/html/helpwnd.cpp:857
+#: ../src/html/helpwnd.cpp:855
 msgid "Searching..."
 msgstr "S'està cercant..."
 
-#: ../src/generic/dirctrlg.cpp:446
+#: ../src/generic/dirctrlg.cpp:412
 msgid "Sections"
 msgstr "Seccions"
 
-#: ../src/common/ffile.cpp:238
+#: ../src/common/ffile.cpp:237
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Error de recerca en fitxer '%s'"
 
-#: ../src/common/ffile.cpp:228
+#: ../src/common/ffile.cpp:227
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:76
+#: ../src/common/accelcmn.cpp:73
 #, fuzzy
 msgid "Select"
 msgstr "Seccions"
 
-#: ../src/richtext/richtextctrl.cpp:337 ../src/osx/textctrl_osx.cpp:581
-#: ../src/common/stockitem.cpp:192 ../src/msw/textctrl.cpp:2512
+#: ../src/osx/textctrl_osx.cpp:599 ../src/common/stockitem.cpp:189
+#: ../src/msw/textctrl.cpp:2777 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Selecciona-ho &tot"
 
-#: ../src/common/stockitem.cpp:192 ../src/stc/stc_i18n.cpp:21
+#: ../src/common/stockitem.cpp:189 ../src/stc/stc_i18n.cpp:21
 #, fuzzy
 msgid "Select All"
 msgstr "Selecciona-ho &tot"
 
-#: ../src/common/docview.cpp:1895
+#: ../src/common/docview.cpp:1900
 msgid "Select a document template"
 msgstr "Seleccioneu una plantilla de document"
 
-#: ../src/common/docview.cpp:1969
+#: ../src/common/docview.cpp:1974
 msgid "Select a document view"
 msgstr "Seleccioneu una vista del document"
 
@@ -6584,20 +6738,20 @@ msgid "Selects the list level to edit."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:82
+#: ../src/common/accelcmn.cpp:79
 msgid "Separator"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1083
+#: ../src/common/cmdline.cpp:1079
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "S'espera un separador després de l'opció '%s'."
 
-#: ../src/osx/menu_osx.cpp:572
+#: ../src/osx/menu_osx.cpp:464
 msgid "Services"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11217
+#: ../src/richtext/richtextbuffer.cpp:11216
 #, fuzzy
 msgid "Set Cell Style"
 msgstr "&Elimina"
@@ -6606,11 +6760,11 @@ msgstr "&Elimina"
 msgid "SetProperty called w/o valid setter"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:188
+#: ../src/generic/prntdlgg.cpp:181
 msgid "Setup..."
 msgstr "Configura..."
 
-#: ../src/msw/dialup.cpp:544
+#: ../src/msw/dialup.cpp:538
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr ""
 "S'han triat diverses connexions de marcatge directe, triant-ne una "
@@ -6629,44 +6783,44 @@ msgstr ""
 msgid "Shadow c&olour:"
 msgstr "Trieu la font"
 
-#: ../src/common/accelcmn.cpp:335
+#: ../src/common/accelcmn.cpp:349
 #, fuzzy
 msgid "Shift+"
 msgstr "Shift"
 
-#: ../src/generic/dirdlgg.cpp:147
+#: ../src/generic/dirdlgg.cpp:144
 #, fuzzy
 msgid "Show &hidden directories"
 msgstr "Mostra directoris ocults."
 
-#: ../src/generic/filectrlg.cpp:983
+#: ../src/generic/filectrlg.cpp:979
 #, fuzzy
 msgid "Show &hidden files"
 msgstr "Mostra fitgers ocults."
 
-#: ../src/osx/menu_osx.cpp:580
+#: ../src/osx/menu_osx.cpp:472
 #, fuzzy
 msgid "Show All"
 msgstr "Mostra-ho tot"
 
-#: ../src/common/stockitem.cpp:257
+#: ../src/common/stockitem.cpp:254
 msgid "Show about dialog"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:492
+#: ../src/html/helpwnd.cpp:490
 msgid "Show all"
 msgstr "Mostra-ho tot"
 
-#: ../src/html/helpwnd.cpp:503
+#: ../src/html/helpwnd.cpp:501
 msgid "Show all items in index"
 msgstr "Mostra tots els elements en el índex"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:656
 msgid "Show/hide navigation panel"
 msgstr "Mostra/amaga el plafó de navegació"
 
-#: ../src/richtext/richtextsymboldlg.cpp:421
-#: ../src/richtext/richtextsymboldlg.cpp:423
+#: ../src/richtext/richtextsymboldlg.cpp:418
+#: ../src/richtext/richtextsymboldlg.cpp:420
 msgid "Shows a Unicode subset."
 msgstr ""
 
@@ -6682,7 +6836,7 @@ msgstr ""
 msgid "Shows a preview of the font settings."
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:394 ../src/osx/carbon/fontdlg.cpp:396
+#: ../src/osx/carbon/fontdlg.cpp:391 ../src/osx/carbon/fontdlg.cpp:393
 msgid "Shows a preview of the font."
 msgstr ""
 
@@ -6691,64 +6845,64 @@ msgstr ""
 msgid "Shows a preview of the paragraph settings."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:460 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:456 ../src/generic/fontdlgg.cpp:458
 msgid "Shows the font preview."
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1607
+#: ../src/propgrid/advprops.cpp:1513
 msgid "Silver"
 msgstr ""
 
-#: ../src/univ/themes/mono.cpp:516
+#: ../src/univ/themes/mono.cpp:513
 msgid "Simple monochrome theme"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:275
 #: ../src/richtext/richtextliststylepage.cpp:449
+#: ../src/richtext/richtextindentspage.cpp:275
 msgid "Single"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:425 ../src/richtext/richtextformatdlg.cpp:369
-#: ../src/richtext/richtextsizepage.cpp:299
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextsizepage.cpp:299
+#: ../src/richtext/richtextformatdlg.cpp:362
 msgid "Size"
 msgstr "Grandària"
 
-#: ../src/osx/carbon/fontdlg.cpp:339
+#: ../src/osx/carbon/fontdlg.cpp:336
 #, fuzzy
 msgid "Size:"
 msgstr "Grandària"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1775
+#: ../src/propgrid/advprops.cpp:1676
 msgid "Sizing"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1772
+#: ../src/propgrid/advprops.cpp:1673
 msgid "Sizing N-S"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1771
+#: ../src/propgrid/advprops.cpp:1672
 msgid "Sizing NE-SW"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1773
+#: ../src/propgrid/advprops.cpp:1674
 msgid "Sizing NW-SE"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1774
+#: ../src/propgrid/advprops.cpp:1675
 msgid "Sizing W-E"
 msgstr ""
 
-#: ../src/msw/progdlg.cpp:801
+#: ../src/msw/progdlg.cpp:1088
 #, fuzzy
 msgid "Skip"
 msgstr "Script"
 
-#: ../src/generic/fontdlgg.cpp:330
+#: ../src/generic/fontdlgg.cpp:326
 msgid "Slant"
 msgstr "Inclina"
 
@@ -6757,7 +6911,7 @@ msgid "Small C&apitals"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:79
+#: ../src/common/accelcmn.cpp:76
 msgid "Snapshot"
 msgstr ""
 
@@ -6766,38 +6920,38 @@ msgstr ""
 msgid "Solid"
 msgstr "Negreta"
 
-#: ../src/common/docview.cpp:1791
+#: ../src/common/docview.cpp:1785
 msgid "Sorry, could not open this file."
 msgstr "No s'ha pogut obrir este fitxer."
 
-#: ../src/common/prntbase.cpp:2057 ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2079 ../src/common/prntbase.cpp:2087
 msgid "Sorry, not enough memory to create a preview."
 msgstr "No hi ha prou memòria com per crear una previsualització"
 
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "Sorry, that name is taken. Please choose another."
 msgstr ""
 
-#: ../src/common/docview.cpp:1814
+#: ../src/common/docview.cpp:1819
 #, fuzzy
 msgid "Sorry, the format for this file is unknown."
 msgstr "No s'ha pogut obrir este fitxer."
 
-#: ../src/unix/sound.cpp:492
+#: ../src/unix/sound.cpp:481
 msgid "Sound data are in unsupported format."
 msgstr ""
 
-#: ../src/unix/sound.cpp:477
+#: ../src/unix/sound.cpp:466
 #, c-format
 msgid "Sound file '%s' is in unsupported format."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:67
+#: ../src/common/accelcmn.cpp:64
 #, fuzzy
 msgid "Space"
 msgstr "S'està cercant..."
@@ -6807,12 +6961,12 @@ msgstr "S'està cercant..."
 msgid "Spacing"
 msgstr "S'està cercant..."
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "Spell Check"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1776
+#: ../src/propgrid/advprops.cpp:1677
 msgid "Spraycan"
 msgstr ""
 
@@ -6821,7 +6975,7 @@ msgstr ""
 msgid "Standard"
 msgstr ""
 
-#: ../src/common/paper.cpp:104
+#: ../src/common/paper.cpp:101
 msgid "Statement, 5 1/2 x 8 1/2 in"
 msgstr "Statement, 5 1/2 x 8 1/2 polz."
 
@@ -6831,36 +6985,32 @@ msgstr "Statement, 5 1/2 x 8 1/2 polz."
 msgid "Static"
 msgstr "Estat:"
 
-#: ../src/generic/prntdlgg.cpp:204
+#: ../src/generic/prntdlgg.cpp:197
 #, fuzzy
 msgid "Status:"
 msgstr "Estat:"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 #, fuzzy
 msgid "Stop"
 msgstr "Configuració"
 
-#: ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196
 msgid "Strikethrough"
 msgstr ""
 
-#: ../src/common/colourcmn.cpp:45
+#: ../src/common/colourcmn.cpp:42
 #, fuzzy, c-format
 msgid "String To Colour : Incorrect colour specification : %s"
 msgstr ""
 "recurs XRC: Color d'especificació incorrecte '%s'  per a la propietat '%s'."
 
 #. TRANSLATORS: Label of font style
-#: ../src/richtext/richtextformatdlg.cpp:339 ../src/propgrid/advprops.cpp:680
+#: ../src/propgrid/advprops.cpp:590 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr ""
 
-#: ../include/wx/richtext/richtextstyledlg.h:46
-msgid "Style Organiser"
-msgstr ""
-
-#: ../src/osx/carbon/fontdlg.cpp:348
+#: ../src/osx/carbon/fontdlg.cpp:345
 msgid "Style:"
 msgstr ""
 
@@ -6870,7 +7020,7 @@ msgid "Subscrip&t"
 msgstr "Script"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:83
+#: ../src/common/accelcmn.cpp:80
 msgid "Subtract"
 msgstr ""
 
@@ -6879,11 +7029,11 @@ msgstr ""
 msgid "Supe&rscript"
 msgstr "Script"
 
-#: ../src/common/paper.cpp:150
+#: ../src/common/paper.cpp:147
 msgid "SuperA/SuperA/A4 227 x 356 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:151
+#: ../src/common/paper.cpp:148
 msgid "SuperB/SuperB/A3 305 x 487 mm"
 msgstr ""
 
@@ -6891,7 +7041,7 @@ msgstr ""
 msgid "Suppress hyphe&nation"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:326
+#: ../src/generic/fontdlgg.cpp:322
 msgid "Swiss"
 msgstr "Suís"
 
@@ -6911,75 +7061,75 @@ msgstr "Font normal"
 msgid "Symbols"
 msgstr "Font normal"
 
-#: ../src/common/imagtiff.cpp:369 ../src/common/imagtiff.cpp:382
-#: ../src/common/imagtiff.cpp:741
+#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
+#: ../src/common/imagtiff.cpp:738
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: No es pot localitzar la memòria"
 
-#: ../src/common/imagtiff.cpp:301
+#: ../src/common/imagtiff.cpp:298
 msgid "TIFF: Error loading image."
 msgstr "TIFF: Error en carregar la imatge."
 
-#: ../src/common/imagtiff.cpp:468
+#: ../src/common/imagtiff.cpp:465
 msgid "TIFF: Error reading image."
 msgstr "TIFF: Error en llegir la imatge."
 
-#: ../src/common/imagtiff.cpp:608
+#: ../src/common/imagtiff.cpp:605
 msgid "TIFF: Error saving image."
 msgstr "TIFF: Error en alçar la imatge."
 
-#: ../src/common/imagtiff.cpp:846
+#: ../src/common/imagtiff.cpp:843
 msgid "TIFF: Error writing image."
 msgstr "TIFF: Error en escriure la imatge."
 
-#: ../src/common/imagtiff.cpp:355
+#: ../src/common/imagtiff.cpp:352
 msgid "TIFF: Image size is abnormally big."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:68
+#: ../src/common/accelcmn.cpp:65
 msgid "Tab"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11498
+#: ../src/richtext/richtextbuffer.cpp:11497
 #, fuzzy
 msgid "Table Properties"
 msgstr "&Previ"
 
-#: ../src/common/paper.cpp:145
+#: ../src/common/paper.cpp:142
 #, fuzzy
 msgid "Tabloid Extra 11.69 x 18 in"
 msgstr "Tabloid, 11 x 17 polz"
 
-#: ../src/common/paper.cpp:102
+#: ../src/common/paper.cpp:99
 msgid "Tabloid, 11 x 17 in"
 msgstr "Tabloid, 11 x 17 polz"
 
-#: ../src/richtext/richtextformatdlg.cpp:354
+#: ../src/richtext/richtextformatdlg.cpp:347
 msgid "Tabs"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1598
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Teal"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:327
+#: ../src/generic/fontdlgg.cpp:323
 msgid "Teletype"
 msgstr "Teletip"
 
-#: ../src/common/docview.cpp:1896
+#: ../src/common/docview.cpp:1901
 msgid "Templates"
 msgstr "Plantilles"
 
-#: ../src/common/fmapbase.cpp:158
+#: ../src/common/fmapbase.cpp:155
 msgid "Thai (ISO-8859-11)"
 msgstr "Tailandès (ISO-8859-11)"
 
-#: ../src/common/ftp.cpp:619
+#: ../src/common/ftp.cpp:622
 msgid "The FTP server doesn't support passive mode."
 msgstr "El servidor FTP no permet l'ús de mode passiu."
 
-#: ../src/common/ftp.cpp:605
+#: ../src/common/ftp.cpp:608
 #, fuzzy
 msgid "The FTP server doesn't support the PORT command."
 msgstr "El servidor FTP no permet l'ús de mode passiu."
@@ -6991,8 +7141,8 @@ msgstr "El servidor FTP no permet l'ús de mode passiu."
 msgid "The available bullet styles."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:202
-#: ../src/richtext/richtextstyledlg.cpp:204
+#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:200
 msgid "The available styles."
 msgstr ""
 
@@ -7052,12 +7202,12 @@ msgstr "Grandària de la font:"
 msgid "The bullet character."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:443
-#: ../src/richtext/richtextsymboldlg.cpp:445
+#: ../src/richtext/richtextsymboldlg.cpp:440
+#: ../src/richtext/richtextsymboldlg.cpp:442
 msgid "The character code."
 msgstr ""
 
-#: ../src/common/fontmap.cpp:203
+#: ../src/common/fontmap.cpp:200
 #, c-format
 msgid ""
 "The charset '%s' is unknown. You may select\n"
@@ -7068,7 +7218,7 @@ msgstr ""
 "seleccionar un altre conjunt per substituir-lo o escolliu\n"
 "[Anul·la] si no pot ser substituït."
 
-#: ../src/msw/ole/dataobj.cpp:394
+#: ../src/msw/ole/dataobj.cpp:402
 #, fuzzy, c-format
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "El format '%s' del porta-retalls no existix."
@@ -7078,7 +7228,7 @@ msgstr "El format '%s' del porta-retalls no existix."
 msgid "The default style for the next paragraph."
 msgstr ""
 
-#: ../src/generic/dirdlgg.cpp:202
+#: ../src/generic/dirdlgg.cpp:199
 #, c-format
 msgid ""
 "The directory '%s' does not exist\n"
@@ -7087,7 +7237,7 @@ msgstr ""
 "El directori '%s'  not existix\n"
 "Desitgeu crear-lo ara?"
 
-#: ../src/html/htmprint.cpp:271
+#: ../src/html/htmprint.cpp:283
 #, c-format
 msgid ""
 "The document \"%s\" doesn't fit on the page horizontally and will be "
@@ -7096,7 +7246,7 @@ msgid ""
 "Would you like to proceed with printing it nevertheless?"
 msgstr ""
 
-#: ../src/common/docview.cpp:1202
+#: ../src/common/docview.cpp:1196
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -7105,38 +7255,38 @@ msgstr ""
 "El fitxer '%s' no existix i per tant no pot ser obert.\n"
 "Ha estat extret des de llistat de fitxers utilitzats més recentment."
 
-#: ../src/richtext/richtextindentspage.cpp:208
-#: ../src/richtext/richtextindentspage.cpp:210
 #: ../src/richtext/richtextliststylepage.cpp:394
 #: ../src/richtext/richtextliststylepage.cpp:396
+#: ../src/richtext/richtextindentspage.cpp:208
+#: ../src/richtext/richtextindentspage.cpp:210
 #, fuzzy
 msgid "The first line indent."
 msgstr "Grandària de la font:"
 
-#: ../src/gtk/utilsgtk.cpp:481
-msgid "The following standard GTK+ options are also supported:\n"
+#: ../src/generic/dbgrptg.cpp:318
+msgid "The following debug report will be generated\n"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:414 ../src/generic/fontdlgg.cpp:416
+#: ../src/generic/fontdlgg.cpp:411 ../src/generic/fontdlgg.cpp:413
 msgid "The font colour."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:375 ../src/generic/fontdlgg.cpp:377
+#: ../src/generic/fontdlgg.cpp:371 ../src/generic/fontdlgg.cpp:373
 msgid "The font family."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:405
-#: ../src/richtext/richtextsymboldlg.cpp:407
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "The font from which to take the symbol."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:427 ../src/generic/fontdlgg.cpp:429
-#: ../src/generic/fontdlgg.cpp:434 ../src/generic/fontdlgg.cpp:436
+#: ../src/generic/fontdlgg.cpp:424 ../src/generic/fontdlgg.cpp:426
+#: ../src/generic/fontdlgg.cpp:430 ../src/generic/fontdlgg.cpp:432
 #, fuzzy
 msgid "The font point size."
 msgstr "Grandària de la font:"
 
-#: ../src/osx/carbon/fontdlg.cpp:343 ../src/osx/carbon/fontdlg.cpp:345
+#: ../src/osx/carbon/fontdlg.cpp:340 ../src/osx/carbon/fontdlg.cpp:342
 #, fuzzy
 msgid "The font size in points."
 msgstr "Grandària de la font:"
@@ -7147,15 +7297,15 @@ msgstr "Grandària de la font:"
 msgid "The font size units, points or pixels."
 msgstr "Grandària de la font:"
 
-#: ../src/generic/fontdlgg.cpp:386 ../src/generic/fontdlgg.cpp:388
+#: ../src/generic/fontdlgg.cpp:382 ../src/generic/fontdlgg.cpp:384
 msgid "The font style."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:397 ../src/generic/fontdlgg.cpp:399
+#: ../src/generic/fontdlgg.cpp:393 ../src/generic/fontdlgg.cpp:395
 msgid "The font weight."
 msgstr ""
 
-#: ../src/common/docview.cpp:1483
+#: ../src/common/docview.cpp:1477
 #, fuzzy, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "No s'ha pogut crear el directori '%s'"
@@ -7166,10 +7316,10 @@ msgstr "No s'ha pogut crear el directori '%s'"
 msgid "The horizontal offset."
 msgstr "Col·loca &horitzontalment"
 
-#: ../src/richtext/richtextindentspage.cpp:199
-#: ../src/richtext/richtextindentspage.cpp:201
 #: ../src/richtext/richtextliststylepage.cpp:385
 #: ../src/richtext/richtextliststylepage.cpp:387
+#: ../src/richtext/richtextindentspage.cpp:199
+#: ../src/richtext/richtextindentspage.cpp:201
 #, fuzzy
 msgid "The left indent."
 msgstr "Grandària de la font:"
@@ -7194,10 +7344,10 @@ msgstr "Grandària de la font:"
 msgid "The left position."
 msgstr "Grandària de la font:"
 
-#: ../src/richtext/richtextindentspage.cpp:288
-#: ../src/richtext/richtextindentspage.cpp:290
 #: ../src/richtext/richtextliststylepage.cpp:462
 #: ../src/richtext/richtextliststylepage.cpp:464
+#: ../src/richtext/richtextindentspage.cpp:288
+#: ../src/richtext/richtextindentspage.cpp:290
 msgid "The line spacing."
 msgstr ""
 
@@ -7206,7 +7356,7 @@ msgstr ""
 msgid "The list item number."
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:664
+#: ../src/msw/ole/automtn.cpp:655
 msgid "The locale ID is unknown."
 msgstr ""
 
@@ -7251,19 +7401,19 @@ msgstr "Grandària de la font:"
 msgid "The outline level."
 msgstr "Grandària de la font:"
 
-#: ../src/common/log.cpp:277
+#: ../src/common/log.cpp:296
 #, c-format
 msgid "The previous message repeated %u time."
 msgid_plural "The previous message repeated %u times."
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/common/log.cpp:270
+#: ../src/common/log.cpp:289
 msgid "The previous message repeated once."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:462
-#: ../src/richtext/richtextsymboldlg.cpp:464
+#: ../src/richtext/richtextsymboldlg.cpp:459
+#: ../src/richtext/richtextsymboldlg.cpp:461
 msgid "The range to show."
 msgstr ""
 
@@ -7274,15 +7424,15 @@ msgid ""
 "please uncheck them and they will be removed from the report.\n"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1254
+#: ../src/common/cmdline.cpp:1250
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "El paràmetre requerit '%s' no ha estat especificat."
 
-#: ../src/richtext/richtextindentspage.cpp:217
-#: ../src/richtext/richtextindentspage.cpp:219
 #: ../src/richtext/richtextliststylepage.cpp:403
 #: ../src/richtext/richtextliststylepage.cpp:405
+#: ../src/richtext/richtextindentspage.cpp:217
+#: ../src/richtext/richtextindentspage.cpp:219
 msgid "The right indent."
 msgstr ""
 
@@ -7326,16 +7476,16 @@ msgstr ""
 msgid "The shadow spread."
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:267
 #: ../src/richtext/richtextliststylepage.cpp:439
 #: ../src/richtext/richtextliststylepage.cpp:441
+#: ../src/richtext/richtextindentspage.cpp:267
 msgid "The spacing after the paragraph."
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:257
-#: ../src/richtext/richtextindentspage.cpp:259
 #: ../src/richtext/richtextliststylepage.cpp:430
 #: ../src/richtext/richtextliststylepage.cpp:432
+#: ../src/richtext/richtextindentspage.cpp:257
+#: ../src/richtext/richtextindentspage.cpp:259
 msgid "The spacing before the paragraph."
 msgstr ""
 
@@ -7349,12 +7499,12 @@ msgstr ""
 msgid "The style on which this style is based."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:214
-#: ../src/richtext/richtextstyledlg.cpp:216
+#: ../src/richtext/richtextstyledlg.cpp:210
+#: ../src/richtext/richtextstyledlg.cpp:212
 msgid "The style preview."
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:680
+#: ../src/msw/ole/automtn.cpp:671
 msgid "The system cannot find the file specified."
 msgstr ""
 
@@ -7369,7 +7519,7 @@ msgstr "Grandària de la font:"
 msgid "The tab positions."
 msgstr "Grandària de la font:"
 
-#: ../src/richtext/richtextctrl.cpp:3098
+#: ../src/richtext/richtextctrl.cpp:3099
 msgid "The text couldn't be saved."
 msgstr "No s'ha pogut alçar el text."
 
@@ -7393,7 +7543,7 @@ msgstr "Grandària de la font:"
 msgid "The top position."
 msgstr "Grandària de la font:"
 
-#: ../src/common/cmdline.cpp:1232
+#: ../src/common/cmdline.cpp:1228
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "El valor per l'opció '%s' ha d'estar especificat."
@@ -7403,7 +7553,7 @@ msgstr "El valor per l'opció '%s' ha d'estar especificat."
 msgid "The value of the corner radius."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:433
+#: ../src/msw/dialup.cpp:427
 #, fuzzy, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -7419,35 +7569,43 @@ msgstr ""
 msgid "The vertical offset."
 msgstr "No s'ha pogut iniciar la impressió"
 
-#: ../src/richtext/richtextprint.cpp:619 ../src/html/htmprint.cpp:745
+#: ../src/html/htmprint.cpp:749 ../src/richtext/richtextprint.cpp:615
 msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr ""
 "Hi ha hagut un problema durant l'actualització de la pàgina: potser caldrà "
 "establir la impressora predeterminada."
 
-#: ../src/html/htmprint.cpp:255
+#: ../src/html/htmprint.cpp:267
 msgid ""
 "This document doesn't fit on the page horizontally and will be truncated "
 "when it is printed."
 msgstr ""
 
-#: ../src/common/image.cpp:2854
+#: ../src/common/image.cpp:2963
 #, fuzzy, c-format
 msgid "This is not a %s."
 msgstr "PCX: este no és un fitxer PCX ."
 
-#: ../src/common/wincmn.cpp:1653
+#: ../src/common/wincmn.cpp:1654
 msgid "This platform does not support background transparency."
 msgstr ""
 
-#: ../src/gtk/window.cpp:4660
+#: ../src/gtk/window.cpp:5664
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
 
-#: ../src/msw/thread.cpp:1240
+#: ../src/gtk/glcanvas.cpp:176
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/msw/thread.cpp:1246
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -7455,13 +7613,13 @@ msgstr ""
 "La inicialització de mòduls de la cadena ha fallat: no es pot emmagatzemar "
 "valor en cadena emmagatzemada localment"
 
-#: ../src/unix/threadpsx.cpp:1794
+#: ../src/unix/threadpsx.cpp:1843
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 "La inicialització de mòduls de la cadena ha fallat: no s'ha pogut crear una "
 "clau de la cadena."
 
-#: ../src/msw/thread.cpp:1228
+#: ../src/msw/thread.cpp:1234
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -7469,84 +7627,84 @@ msgstr ""
 "La inicialització de mòduls de la cadena ha fallat: no és possible "
 "localitzar l'índex en la cadena emmagatzemada localment"
 
-#: ../src/unix/threadpsx.cpp:1043
+#: ../src/unix/threadpsx.cpp:1061
 msgid "Thread priority setting is ignored."
 msgstr "La prioritat de paràmetres és ignorada."
 
-#: ../src/msw/mdi.cpp:176
+#: ../src/msw/mdi.cpp:171
 msgid "Tile &Horizontally"
 msgstr "Col·loca &horitzontalment"
 
-#: ../src/msw/mdi.cpp:177
+#: ../src/msw/mdi.cpp:172
 msgid "Tile &Vertically"
 msgstr "Col·loca &verticalment"
 
-#: ../src/common/ftp.cpp:200
+#: ../src/common/ftp.cpp:197
 #, fuzzy
 msgid "Timeout while waiting for FTP server to connect, try passive mode."
 msgstr "El servidor FTP no permet l'ús de mode passiu."
 
-#: ../src/generic/tipdlg.cpp:201
+#: ../src/generic/tipdlg.cpp:198
 msgid "Tip of the Day"
 msgstr "Consell del dia"
 
-#: ../src/generic/tipdlg.cpp:140
+#: ../src/generic/tipdlg.cpp:137
 msgid "Tips not available, sorry!"
 msgstr "Els consells no es troben disponibles!"
 
-#: ../src/generic/prntdlgg.cpp:242
+#: ../src/generic/prntdlgg.cpp:235
 msgid "To:"
 msgstr "Per a:"
 
-#: ../src/richtext/richtextbuffer.cpp:8363
+#: ../src/richtext/richtextbuffer.cpp:8361
 msgid "Too many EndStyle calls!"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:891
+#: ../src/propgrid/advprops.cpp:792
 msgid "Tooltip"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:892
+#: ../src/propgrid/advprops.cpp:793
 msgid "TooltipText"
 msgstr ""
 
-#: ../src/richtext/richtextsizepage.cpp:286
-#: ../src/richtext/richtextsizepage.cpp:290 ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197 ../src/richtext/richtextsizepage.cpp:286
+#: ../src/richtext/richtextsizepage.cpp:290
 #, fuzzy
 msgid "Top"
 msgstr "Per a:"
 
-#: ../src/generic/prntdlgg.cpp:881
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Top margin (mm):"
 msgstr "Marge superior (mm):"
 
-#: ../src/generic/aboutdlgg.cpp:79
+#: ../src/generic/aboutdlgg.cpp:76
 msgid "Translations by "
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:188
+#: ../src/generic/aboutdlgg.cpp:185
 msgid "Translators"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:211
+#: ../src/propgrid/propgrid.cpp:192
 msgid "True"
 msgstr ""
 
-#: ../src/common/fs_mem.cpp:227
+#: ../src/common/fs_mem.cpp:222
 #, c-format
 msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
 msgstr ""
 "S'està intentant esborrar el fitxer '%s' de VFS de memòria, però no està "
 "carregat!"
 
-#: ../src/common/fmapbase.cpp:156
+#: ../src/common/fmapbase.cpp:153
 msgid "Turkish (ISO-8859-9)"
 msgstr "Turc (ISO-8859-9)"
 
-#: ../src/generic/filectrlg.cpp:426
+#: ../src/generic/filectrlg.cpp:422
 #, fuzzy
 msgid "Type"
 msgstr "Teletip"
@@ -7561,37 +7719,37 @@ msgstr ""
 msgid "Type a size in points."
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:676
+#: ../src/msw/ole/automtn.cpp:667
 #, c-format
 msgid "Type mismatch in argument %u."
 msgstr ""
 
-#: ../src/common/xtixml.cpp:356 ../src/common/xtixml.cpp:509
-#: ../src/common/xtistrm.cpp:318
+#: ../src/common/xtixml.cpp:352 ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315
 msgid "Type must have enum - long conversion"
 msgstr ""
 
-#: ../src/propgrid/propgridiface.cpp:401
+#: ../src/propgrid/propgridiface.cpp:385
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
 "\"%s\"."
 msgstr ""
 
-#: ../src/common/paper.cpp:133
+#: ../src/common/paper.cpp:130
 msgid "US Std Fanfold, 14 7/8 x 11 in"
 msgstr "US Std Fanfold, 14 7/8 x 11 polz"
 
-#: ../src/common/fmapbase.cpp:196
+#: ../src/common/fmapbase.cpp:193
 #, fuzzy
 msgid "US-ASCII"
 msgstr "ASCII"
 
-#: ../src/unix/fswatcher_inotify.cpp:109
+#: ../src/unix/fswatcher_inotify.cpp:106
 msgid "Unable to add inotify watch"
 msgstr ""
 
-#: ../src/unix/fswatcher_kqueue.cpp:136
+#: ../src/unix/fswatcher_kqueue.cpp:153
 msgid "Unable to add kqueue watch"
 msgstr ""
 
@@ -7604,7 +7762,7 @@ msgstr ""
 msgid "Unable to close I/O completion port handle"
 msgstr "No s'ha pogut tancar el manegador de fitxers"
 
-#: ../src/unix/fswatcher_inotify.cpp:97
+#: ../src/unix/fswatcher_inotify.cpp:94
 #, fuzzy
 msgid "Unable to close inotify instance"
 msgstr "No s'ha pogut tancar el manegador de fitxers"
@@ -7624,17 +7782,17 @@ msgstr "No s'ha pogut tancar el manegador de fitxers"
 msgid "Unable to create I/O completion port"
 msgstr "No s'ha pogut crear una barra d'estat."
 
-#: ../src/msw/fswatcher.cpp:84
+#: ../src/msw/fswatcher.cpp:81
 #, fuzzy
 msgid "Unable to create IOCP worker thread"
 msgstr "No s'ha pogut crear un marc MDI principal."
 
-#: ../src/unix/fswatcher_inotify.cpp:74
+#: ../src/unix/fswatcher_inotify.cpp:71
 #, fuzzy
 msgid "Unable to create inotify instance"
 msgstr "No s'ha pogut crear una cadena DDE"
 
-#: ../src/unix/fswatcher_kqueue.cpp:97
+#: ../src/unix/fswatcher_kqueue.cpp:114
 #, fuzzy
 msgid "Unable to create kqueue instance"
 msgstr "No s'ha pogut crear una cadena DDE"
@@ -7643,11 +7801,11 @@ msgstr "No s'ha pogut crear una cadena DDE"
 msgid "Unable to dequeue completion packet"
 msgstr ""
 
-#: ../src/unix/fswatcher_kqueue.cpp:185
+#: ../src/unix/fswatcher_kqueue.cpp:202
 msgid "Unable to get events from kqueue"
 msgstr ""
 
-#: ../src/gtk/app.cpp:435
+#: ../src/gtk/app.cpp:431
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr ""
 
@@ -7656,12 +7814,12 @@ msgstr ""
 msgid "Unable to open path '%s'"
 msgstr "No s'ha pogut obrir '%s' per %s"
 
-#: ../src/html/htmlwin.cpp:583
+#: ../src/html/htmlwin.cpp:586
 #, c-format
 msgid "Unable to open requested HTML document: %s"
 msgstr "No és possible obrir el document HTML sol·licitat: %s"
 
-#: ../src/unix/sound.cpp:368
+#: ../src/unix/sound.cpp:365
 msgid "Unable to play sound asynchronously."
 msgstr ""
 
@@ -7669,66 +7827,66 @@ msgstr ""
 msgid "Unable to post completion status"
 msgstr ""
 
-#: ../src/unix/fswatcher_inotify.cpp:556
+#: ../src/unix/fswatcher_inotify.cpp:553
 #, fuzzy
 msgid "Unable to read from inotify descriptor"
 msgstr "no es pot llegir des del fitxer descriptor %s"
 
-#: ../src/unix/fswatcher_inotify.cpp:141
+#: ../src/unix/fswatcher_inotify.cpp:138
 #, fuzzy, c-format
 msgid "Unable to remove inotify watch %i"
 msgstr "No s'ha pogut crear una cadena DDE"
 
-#: ../src/unix/fswatcher_kqueue.cpp:153
+#: ../src/unix/fswatcher_kqueue.cpp:170
 msgid "Unable to remove kqueue watch"
 msgstr ""
 
-#: ../src/msw/fswatcher.cpp:168
+#: ../src/msw/fswatcher.cpp:165
 #, fuzzy, c-format
 msgid "Unable to set up watch for '%s'"
 msgstr "No s'ha pogut posar en contacte amb el fitxer '%s'"
 
-#: ../src/msw/fswatcher.cpp:91
+#: ../src/msw/fswatcher.cpp:88
 msgid "Unable to start IOCP worker thread"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:201
+#: ../src/common/stockitem.cpp:198
 #, fuzzy
 msgid "Undelete"
 msgstr "Subratllat"
 
-#: ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199
 #, fuzzy
 msgid "Underline"
 msgstr "Subratllat"
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/richtext/richtextfontpage.cpp:359 ../src/osx/carbon/fontdlg.cpp:370
-#: ../src/propgrid/advprops.cpp:690
+#: ../src/osx/carbon/fontdlg.cpp:367 ../src/propgrid/advprops.cpp:600
+#: ../src/richtext/richtextfontpage.cpp:359
 #, fuzzy
 msgid "Underlined"
 msgstr "Subratllat"
 
-#: ../src/common/stockitem.cpp:203 ../src/stc/stc_i18n.cpp:15
+#: ../src/common/stockitem.cpp:200 ../src/stc/stc_i18n.cpp:15
 #, fuzzy
 msgid "Undo"
 msgstr "&Desfés"
 
-#: ../src/common/stockitem.cpp:265
+#: ../src/common/stockitem.cpp:263
 msgid "Undo last action"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1029
+#: ../src/common/cmdline.cpp:1025
 #, fuzzy, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Paràmetre '%s' no esperat"
 
-#: ../src/unix/fswatcher_inotify.cpp:274
+#: ../src/unix/fswatcher_inotify.cpp:271
 #, c-format
 msgid "Unexpected event for \"%s\": no matching watch descriptor."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1195
+#: ../src/common/cmdline.cpp:1191
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Paràmetre '%s' no esperat"
@@ -7737,57 +7895,57 @@ msgstr "Paràmetre '%s' no esperat"
 msgid "Unexpectedly new I/O completion port was created"
 msgstr ""
 
-#: ../src/msw/fswatcher.cpp:70
+#: ../src/msw/fswatcher.cpp:67
 #, fuzzy
 msgid "Ungraceful worker thread termination"
 msgstr "No es pot esperar per a l'acabament de cadena"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:460
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:456
+#: ../src/richtext/richtextsymboldlg.cpp:457
+#: ../src/richtext/richtextsymboldlg.cpp:458
 #, fuzzy
 msgid "Unicode"
 msgstr "dinovè"
 
-#: ../src/common/fmapbase.cpp:185 ../src/common/fmapbase.cpp:191
+#: ../src/common/fmapbase.cpp:182 ../src/common/fmapbase.cpp:188
 #, fuzzy
 msgid "Unicode 16 bit (UTF-16)"
 msgstr "Unicode 7 bit (UTF-7)"
 
-#: ../src/common/fmapbase.cpp:190
+#: ../src/common/fmapbase.cpp:187
 #, fuzzy
 msgid "Unicode 16 bit Big Endian (UTF-16BE)"
 msgstr "Unicode 8 bit (UTF-8)"
 
-#: ../src/common/fmapbase.cpp:186
+#: ../src/common/fmapbase.cpp:183
 #, fuzzy
 msgid "Unicode 16 bit Little Endian (UTF-16LE)"
 msgstr "Unicode 8 bit (UTF-8)"
 
-#: ../src/common/fmapbase.cpp:187 ../src/common/fmapbase.cpp:193
+#: ../src/common/fmapbase.cpp:184 ../src/common/fmapbase.cpp:190
 #, fuzzy
 msgid "Unicode 32 bit (UTF-32)"
 msgstr "Unicode 7 bit (UTF-7)"
 
-#: ../src/common/fmapbase.cpp:192
+#: ../src/common/fmapbase.cpp:189
 #, fuzzy
 msgid "Unicode 32 bit Big Endian (UTF-32BE)"
 msgstr "Unicode 8 bit (UTF-8)"
 
-#: ../src/common/fmapbase.cpp:188
+#: ../src/common/fmapbase.cpp:185
 #, fuzzy
 msgid "Unicode 32 bit Little Endian (UTF-32LE)"
 msgstr "Unicode 8 bit (UTF-8)"
 
-#: ../src/common/fmapbase.cpp:182
+#: ../src/common/fmapbase.cpp:179
 msgid "Unicode 7 bit (UTF-7)"
 msgstr "Unicode 7 bit (UTF-7)"
 
-#: ../src/common/fmapbase.cpp:183
+#: ../src/common/fmapbase.cpp:180
 msgid "Unicode 8 bit (UTF-8)"
 msgstr "Unicode 8 bit (UTF-8)"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 #, fuzzy
 msgid "Unindent"
 msgstr "dinovè"
@@ -7947,100 +8105,105 @@ msgstr "No es pot esperar per a l'acabament de cadena"
 msgid "Units for this value."
 msgstr "No es pot esperar per a l'acabament de cadena"
 
-#: ../src/generic/progdlgg.cpp:353 ../src/generic/progdlgg.cpp:622
+#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
 #, fuzzy
 msgid "Unknown"
 msgstr "desconegut"
 
-#: ../src/msw/dde.cpp:1174
+#: ../src/msw/dde.cpp:1238
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Error DDE desconegut %08x"
 
-#: ../src/common/xtistrm.cpp:410
+#: ../src/common/xtistrm.cpp:407
 msgid "Unknown Object passed to GetObjectClassInfo"
 msgstr ""
 
-#: ../src/common/imagpng.cpp:366
+#: ../src/common/imagpng.cpp:383
 #, fuzzy, c-format
 msgid "Unknown PNG resolution unit %d"
 msgstr "Opció '%s' desconeguda"
 
-#: ../src/common/xtixml.cpp:327
+#: ../src/common/xtixml.cpp:323
 #, fuzzy, c-format
 msgid "Unknown Property %s"
 msgstr "Opció '%s' desconeguda"
 
-#: ../src/common/imagtiff.cpp:529
+#: ../src/common/imagtiff.cpp:526
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr ""
 
-#: ../src/unix/dlunix.cpp:160
+#: ../src/propgrid/props.cpp:155
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/unix/dlunix.cpp:118
 msgid "Unknown dynamic library error"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:810
+#: ../src/common/fmapbase.cpp:806
 #, c-format
 msgid "Unknown encoding (%d)"
 msgstr "Codificació (%d) desconeguda"
 
-#: ../src/msw/ole/automtn.cpp:688
+#: ../src/msw/ole/automtn.cpp:679
 #, fuzzy, c-format
 msgid "Unknown error %08x"
 msgstr "Error DDE desconegut %08x"
 
-#: ../src/msw/ole/automtn.cpp:647
+#: ../src/msw/ole/automtn.cpp:638
 #, fuzzy
 msgid "Unknown exception"
 msgstr "Opció '%s' desconeguda"
 
-#: ../src/common/image.cpp:2839
+#: ../src/common/image.cpp:2942
 #, fuzzy
 msgid "Unknown image data format."
 msgstr "IFF: error en format d'imatge IFF."
 
-#: ../src/common/cmdline.cpp:914
+#: ../src/common/cmdline.cpp:910
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Opció llarga desconeguda '%s'"
 
-#: ../src/msw/ole/automtn.cpp:631
+#: ../src/msw/ole/automtn.cpp:622
 msgid "Unknown name or named argument."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:929 ../src/common/cmdline.cpp:951
+#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Opció '%s' desconeguda"
 
-#: ../src/common/mimecmn.cpp:225
+#: ../src/common/mimecmn.cpp:221
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "'{' no tancat per a tipus mime %s."
 
-#: ../src/common/cmdproc.cpp:262 ../src/common/cmdproc.cpp:288
-#: ../src/common/cmdproc.cpp:308
+#: ../src/common/cmdproc.cpp:255 ../src/common/cmdproc.cpp:281
+#: ../src/common/cmdproc.cpp:301
 msgid "Unnamed command"
 msgstr "Orde sense nom"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:413
+#: ../src/propgrid/propgrid.cpp:392
 msgid "Unspecified"
 msgstr ""
 
-#: ../src/msw/clipbrd.cpp:311
+#: ../src/msw/clipbrd.cpp:325
 msgid "Unsupported clipboard format."
 msgstr "Format no suportat de porta-retalls"
 
-#: ../src/common/appcmn.cpp:256
+#: ../src/common/appcmn.cpp:277
 #, c-format
 msgid "Unsupported theme '%s'."
 msgstr "Tema '%s' no suportat"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:205
-#: ../src/common/accelcmn.cpp:63
+#: ../src/common/stockitem.cpp:202 ../src/common/accelcmn.cpp:60
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Up"
 msgstr "Amunt"
 
@@ -8054,7 +8217,7 @@ msgstr ""
 msgid "Upper case roman numerals"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1326
+#: ../src/common/cmdline.cpp:1322
 #, c-format
 msgid "Usage: %s"
 msgstr "Sintaxi: %s"
@@ -8063,38 +8226,47 @@ msgstr "Sintaxi: %s"
 msgid "Use &shadow"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:169
-#: ../src/richtext/richtextindentspage.cpp:171
 #: ../src/richtext/richtextliststylepage.cpp:358
 #: ../src/richtext/richtextliststylepage.cpp:360
+#: ../src/richtext/richtextindentspage.cpp:169
+#: ../src/richtext/richtextindentspage.cpp:171
 msgid "Use the current alignment setting."
 msgstr ""
 
-#: ../src/common/valtext.cpp:179
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/gtk/font.cpp:552
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/common/valtext.cpp:142
 msgid "Validation conflict"
 msgstr "Conflicte de validació"
 
-#: ../src/propgrid/manager.cpp:238
+#: ../src/propgrid/manager.cpp:224
 msgid "Value"
 msgstr ""
 
-#: ../src/propgrid/props.cpp:386 ../src/propgrid/props.cpp:500
+#: ../src/propgrid/props.cpp:309
 #, c-format
 msgid "Value must be %s or higher."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:417 ../src/propgrid/props.cpp:531
+#: ../src/propgrid/props.cpp:336
 #, c-format
 msgid "Value must be %s or less."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:393 ../src/propgrid/props.cpp:424
-#: ../src/propgrid/props.cpp:507 ../src/propgrid/props.cpp:538
+#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:128
+#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
 #, fuzzy
 msgid "Version "
 msgstr "Permisos"
@@ -8105,25 +8277,32 @@ msgstr "Permisos"
 msgid "Vertical alignment."
 msgstr "No s'ha pogut iniciar la impressió"
 
-#: ../src/generic/filedlgg.cpp:202
+#: ../src/generic/filedlgg.cpp:199
 msgid "View files as a detailed view"
 msgstr "Mostra els fitxers en vista detallada"
 
-#: ../src/generic/filedlgg.cpp:200
+#: ../src/generic/filedlgg.cpp:197
 msgid "View files as a list view"
 msgstr "Mostra fitxers com a un llistat de vista"
 
-#: ../src/common/docview.cpp:1970
+#: ../src/common/docview.cpp:1975
 msgid "Views"
 msgstr "Vistes"
 
+#: ../src/gtk/app.cpp:348
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1777
+#: ../src/propgrid/advprops.cpp:1678
 msgid "Wait"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1779
+#: ../src/propgrid/advprops.cpp:1680
 msgid "Wait Arrow"
 msgstr ""
 
@@ -8132,252 +8311,247 @@ msgstr ""
 msgid "Waiting for IO on epoll descriptor %d failed"
 msgstr "Error en l'espera de la fi d'un subprocès"
 
-#: ../src/common/log.cpp:223
+#: ../src/common/log.cpp:241
 msgid "Warning: "
 msgstr "Advertència:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1778
+#: ../src/propgrid/advprops.cpp:1679
 msgid "Watch"
 msgstr ""
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:685
+#: ../src/propgrid/advprops.cpp:595
 #, fuzzy
 msgid "Weight"
 msgstr "vuitè"
 
-#: ../src/common/fmapbase.cpp:148
+#: ../src/common/fmapbase.cpp:145
 msgid "Western European (ISO-8859-1)"
 msgstr "Europa de l'est, (ISO-8859-1)"
 
-#: ../src/common/fmapbase.cpp:162
+#: ../src/common/fmapbase.cpp:159
 msgid "Western European with Euro (ISO-8859-15)"
 msgstr "Europeu occidental amb Euro (ISO-8859-15)"
 
-#: ../src/generic/fontdlgg.cpp:446 ../src/generic/fontdlgg.cpp:448
+#: ../src/generic/fontdlgg.cpp:443 ../src/generic/fontdlgg.cpp:445
 msgid "Whether the font is underlined."
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1611
+#: ../src/propgrid/advprops.cpp:1517
 msgid "White"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:144
+#: ../src/generic/fdrepdlg.cpp:141
 msgid "Whole word"
 msgstr "Tota la paraula"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:532
 msgid "Whole words only"
 msgstr "Només paraules senceres"
 
-#: ../src/univ/themes/win32.cpp:1102
+#: ../src/univ/themes/win32.cpp:1099
 msgid "Win32 theme"
 msgstr "Tema Win32"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:893
+#: ../src/propgrid/advprops.cpp:794
 #, fuzzy
 msgid "Window"
 msgstr "&Finestra"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:894
+#: ../src/propgrid/advprops.cpp:795
 #, fuzzy
 msgid "WindowFrame"
 msgstr "&Finestra"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:895
+#: ../src/propgrid/advprops.cpp:796
 #, fuzzy
 msgid "WindowText"
 msgstr "&Finestra"
 
-#: ../src/common/fmapbase.cpp:177
+#: ../src/common/fmapbase.cpp:174
 msgid "Windows Arabic (CP 1256)"
 msgstr "Windows Àrab (CP 1256)"
 
-#: ../src/common/fmapbase.cpp:178
+#: ../src/common/fmapbase.cpp:175
 msgid "Windows Baltic (CP 1257)"
 msgstr "Windows Bàltic (CP 1257)"
 
-#: ../src/common/fmapbase.cpp:171
+#: ../src/common/fmapbase.cpp:168
 msgid "Windows Central European (CP 1250)"
 msgstr "Windows Central Europeu (CP 1250)"
 
-#: ../src/common/fmapbase.cpp:168
+#: ../src/common/fmapbase.cpp:165
 #, fuzzy
 msgid "Windows Chinese Simplified (CP 936) or GB-2312"
 msgstr "Windows Xinés Simplificat (CP 936)"
 
-#: ../src/common/fmapbase.cpp:170
+#: ../src/common/fmapbase.cpp:167
 #, fuzzy
 msgid "Windows Chinese Traditional (CP 950) or Big-5"
 msgstr "Windows Xinés Tradicional (CP 950)"
 
-#: ../src/common/fmapbase.cpp:172
+#: ../src/common/fmapbase.cpp:169
 msgid "Windows Cyrillic (CP 1251)"
 msgstr "Windows Cirílic (CP 1251)"
 
-#: ../src/common/fmapbase.cpp:174
+#: ../src/common/fmapbase.cpp:171
 msgid "Windows Greek (CP 1253)"
 msgstr "Windows Grec (CP 1253)"
 
-#: ../src/common/fmapbase.cpp:176
+#: ../src/common/fmapbase.cpp:173
 msgid "Windows Hebrew (CP 1255)"
 msgstr "Windows Hebreu (CP 1255)"
 
-#: ../src/common/fmapbase.cpp:167
+#: ../src/common/fmapbase.cpp:164
 #, fuzzy
 msgid "Windows Japanese (CP 932) or Shift-JIS"
 msgstr "Windows Japonès (CP 932)"
 
-#: ../src/common/fmapbase.cpp:180
+#: ../src/common/fmapbase.cpp:177
 #, fuzzy
 msgid "Windows Johab (CP 1361)"
 msgstr "Windows Àrab (CP 1256)"
 
-#: ../src/common/fmapbase.cpp:169
+#: ../src/common/fmapbase.cpp:166
 msgid "Windows Korean (CP 949)"
 msgstr "Windows Coreà (CP 949)"
 
-#: ../src/common/fmapbase.cpp:166
+#: ../src/common/fmapbase.cpp:163
 #, fuzzy
 msgid "Windows Thai (CP 874)"
 msgstr "Windows Bàltic (CP 1257)"
 
-#: ../src/common/fmapbase.cpp:175
+#: ../src/common/fmapbase.cpp:172
 msgid "Windows Turkish (CP 1254)"
 msgstr "Windows Turc (CP 1254)"
 
-#: ../src/common/fmapbase.cpp:179
+#: ../src/common/fmapbase.cpp:176
 #, fuzzy
 msgid "Windows Vietnamese (CP 1258)"
 msgstr "Windows Grec (CP 1253)"
 
-#: ../src/common/fmapbase.cpp:173
+#: ../src/common/fmapbase.cpp:170
 msgid "Windows Western European (CP 1252)"
 msgstr "Windows Europeu de l'est (CP 1252)"
 
-#: ../src/common/fmapbase.cpp:181
+#: ../src/common/fmapbase.cpp:178
 msgid "Windows/DOS OEM (CP 437)"
 msgstr "Windows/DOS OEM (CP 437)"
 
-#: ../src/common/fmapbase.cpp:165
+#: ../src/common/fmapbase.cpp:162
 #, fuzzy
 msgid "Windows/DOS OEM Cyrillic (CP 866)"
 msgstr "Windows Cirílic (CP 1251)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:111
+#: ../src/common/accelcmn.cpp:109
 #, fuzzy
 msgid "Windows_Left"
 msgstr "Windows 9%c"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:113
+#: ../src/common/accelcmn.cpp:111
 #, fuzzy
 msgid "Windows_Menu"
 msgstr "Windows 3.1"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:112
+#: ../src/common/accelcmn.cpp:110
 #, fuzzy
 msgid "Windows_Right"
 msgstr "Windows 9%c"
 
-#: ../src/common/ffile.cpp:150
+#: ../src/common/ffile.cpp:149
 #, c-format
 msgid "Write error on file '%s'"
 msgstr "Error en el fitxer '%s'"
 
-#: ../src/xml/xml.cpp:914
+#: ../src/xml/xml.cpp:925
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "error d'anàlisi XML: '%s' a la línia %d"
 
-#: ../src/common/xpmdecod.cpp:796
+#: ../src/common/xpmdecod.cpp:794
 msgid "XPM: Malformed pixel data!"
 msgstr "XPM: dades píxels mal formulades!"
 
-#: ../src/common/xpmdecod.cpp:705
+#: ../src/common/xpmdecod.cpp:702
 #, fuzzy, c-format
 msgid "XPM: incorrect colour description in line %d"
 msgstr "XPM: definició '%s' de color mal formulada!"
 
-#: ../src/common/xpmdecod.cpp:680
+#: ../src/common/xpmdecod.cpp:677
 msgid "XPM: incorrect header format!"
 msgstr ""
 
-#: ../src/common/xpmdecod.cpp:716 ../src/common/xpmdecod.cpp:725
+#: ../src/common/xpmdecod.cpp:714 ../src/common/xpmdecod.cpp:723
 #, fuzzy, c-format
 msgid "XPM: malformed colour definition '%s' at line %d!"
 msgstr "XPM: definició '%s' de color mal formulada!"
 
-#: ../src/common/xpmdecod.cpp:755
+#: ../src/common/xpmdecod.cpp:753
 msgid "XPM: no colors left to use for mask!"
 msgstr ""
 
-#: ../src/common/xpmdecod.cpp:782
+#: ../src/common/xpmdecod.cpp:780
 #, c-format
 msgid "XPM: truncated image data at line %d!"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1610
+#: ../src/propgrid/advprops.cpp:1516
 msgid "Yellow"
 msgstr ""
 
-#: ../include/wx/msgdlg.h:276 ../src/common/stockitem.cpp:206
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:203
 #: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Sí"
 
-#: ../src/osx/carbon/overlay.cpp:155
-#, fuzzy
-msgid "You cannot Clear an overlay that is not inited"
-msgstr "No podeu afegir un directori nou a esta secció"
-
-#: ../src/osx/carbon/overlay.cpp:107 ../src/dfb/overlay.cpp:61
-msgid "You cannot Init an overlay twice"
-msgstr ""
-
-#: ../src/generic/dirdlgg.cpp:287
+#: ../src/generic/dirdlgg.cpp:284
 msgid "You cannot add a new directory to this section."
 msgstr "No podeu afegir un directori nou a esta secció"
 
-#: ../src/propgrid/propgrid.cpp:3299
+#: ../src/propgrid/propgrid.cpp:3276
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:209
+#: ../src/osx/cocoa/menu.mm:286
+msgid "Zoom"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:206
 msgid "Zoom &In"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:210
+#: ../src/common/stockitem.cpp:207
 msgid "Zoom &Out"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:209 ../src/common/prntbase.cpp:1594
+#: ../src/common/stockitem.cpp:206 ../src/common/prntbase.cpp:1619
 msgid "Zoom In"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:210 ../src/common/prntbase.cpp:1580
+#: ../src/common/stockitem.cpp:207 ../src/common/prntbase.cpp:1605
 msgid "Zoom Out"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to &Fit"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to Fit"
 msgstr ""
 
-#: ../src/msw/dde.cpp:1141
+#: ../src/msw/dde.cpp:1205
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "una aplicació DDEML ha creat una condició estreta prolongada."
 
-#: ../src/msw/dde.cpp:1129
+#: ../src/msw/dde.cpp:1193
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -8388,45 +8562,45 @@ msgstr ""
 "o un identificador invàlid d'instància\n"
 "ha passat a funció DDEML."
 
-#: ../src/msw/dde.cpp:1147
+#: ../src/msw/dde.cpp:1211
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "Un client que intentava establir una connexió ha fallit."
 
-#: ../src/msw/dde.cpp:1144
+#: ../src/msw/dde.cpp:1208
 msgid "a memory allocation failed."
 msgstr "ha fallat una assignació de memòria"
 
-#: ../src/msw/dde.cpp:1138
+#: ../src/msw/dde.cpp:1202
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "un paràmetre ha fallat per ser validat pel DDEML"
 
-#: ../src/msw/dde.cpp:1120
+#: ../src/msw/dde.cpp:1184
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr ""
 "una sol·licitud per a una transacció d'avís síncrona ha excedit el temps"
 
-#: ../src/msw/dde.cpp:1126
+#: ../src/msw/dde.cpp:1190
 msgid "a request for a synchronous data transaction has timed out."
 msgstr ""
 "una sol·licitud per a una transacció de dades síncrona ha excedit el temps"
 
-#: ../src/msw/dde.cpp:1135
+#: ../src/msw/dde.cpp:1199
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr ""
 "una sol·licitud per a una transacció síncrona per a executar ha excedit el "
 "temps"
 
-#: ../src/msw/dde.cpp:1153
+#: ../src/msw/dde.cpp:1217
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "una sol·licitud per a una transacció poke ha excedit el temps"
 
-#: ../src/msw/dde.cpp:1168
+#: ../src/msw/dde.cpp:1232
 msgid "a request to end an advise transaction has timed out."
 msgstr ""
 "una sol·licitud per finalitzar un avís de transacció s'ha excedit en el "
 "temps."
 
-#: ../src/msw/dde.cpp:1162
+#: ../src/msw/dde.cpp:1226
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -8436,15 +8610,15 @@ msgstr ""
 "que ha acabat amb el client, o el servidor\n"
 "abans de completar una transacció."
 
-#: ../src/msw/dde.cpp:1150
+#: ../src/msw/dde.cpp:1214
 msgid "a transaction failed."
 msgstr "ha fallat una transacció"
 
-#: ../src/common/accelcmn.cpp:189
+#: ../src/common/accelcmn.cpp:188
 msgid "alt"
 msgstr "alt"
 
-#: ../src/msw/dde.cpp:1132
+#: ../src/msw/dde.cpp:1196
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -8456,15 +8630,15 @@ msgstr ""
 "o bé una aplicació començada com a APPCMD_CLIENTONLY ha \n"
 "intentat fer transaccions de servidor."
 
-#: ../src/msw/dde.cpp:1156
+#: ../src/msw/dde.cpp:1220
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "ha fallat una trucada interna cap a la funció PostMessage"
 
-#: ../src/msw/dde.cpp:1165
+#: ../src/msw/dde.cpp:1229
 msgid "an internal error has occurred in the DDEML."
 msgstr "Hi ha hagut un error intern en el DDEML."
 
-#: ../src/msw/dde.cpp:1171
+#: ../src/msw/dde.cpp:1235
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -8474,56 +8648,56 @@ msgstr ""
 "un cop que l'aplicació ha tornat d'una trucada XTYP_XACT_COMPLETE, \n"
 "l'identificador de transacció d'esta trucada ja no és vàlid."
 
-#: ../src/common/zipstrm.cpp:1483
+#: ../src/common/zipstrm.cpp:1522
 msgid "assuming this is a multi-part zip concatenated"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1847
+#: ../src/common/fileconf.cpp:1849
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "intent de canviar la clau immutable '%s' ignorat."
 
-#: ../src/html/chm.cpp:329
+#: ../src/html/chm.cpp:326
 msgid "bad arguments to library function"
 msgstr ""
 
-#: ../src/html/chm.cpp:341
+#: ../src/html/chm.cpp:338
 msgid "bad signature"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1918
+#: ../src/common/zipstrm.cpp:1988
 msgid "bad zipfile offset to entry"
 msgstr ""
 
-#: ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400
 msgid "binary"
 msgstr "binari"
 
-#: ../src/common/fontcmn.cpp:996
+#: ../src/common/fontcmn.cpp:1195
 msgid "bold"
 msgstr "negreta"
 
-#: ../src/msw/utils.cpp:1144
+#: ../src/msw/utils.cpp:1135
 #, c-format
 msgid "build %lu"
 msgstr ""
 
-#: ../src/common/ffile.cpp:75
+#: ../src/common/ffile.cpp:73
 #, c-format
 msgid "can't close file '%s'"
 msgstr "no s'ha pogut tancar el fitxer '%s'"
 
-#: ../src/common/file.cpp:245
+#: ../src/common/file.cpp:242
 #, c-format
 msgid "can't close file descriptor %d"
 msgstr "no s'ha pogut tancar el descriptor de fitxer %d"
 
-#: ../src/common/file.cpp:586
+#: ../src/common/ffile.cpp:382 ../src/common/file.cpp:613
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "no es pot confiar canvis al fitxer '%s'"
 
-#: ../src/common/file.cpp:178
+#: ../src/common/file.cpp:175
 #, c-format
 msgid "can't create file '%s'"
 msgstr "no s'ha pot crear el fitxer '%s'"
@@ -8533,52 +8707,52 @@ msgstr "no s'ha pot crear el fitxer '%s'"
 msgid "can't delete user configuration file '%s'"
 msgstr "no s'ha pogut eliminar el fitxer de configuració '%s' d'usuari"
 
-#: ../src/common/file.cpp:495
+#: ../src/common/file.cpp:522
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr ""
 "no es pot determinar si s'ha arribat al final del fitxer amb el descriptor %d"
 
-#: ../src/common/zipstrm.cpp:1692
+#: ../src/common/zipstrm.cpp:1747
 #, fuzzy
 msgid "can't find central directory in zip"
 msgstr "No es pot trobar la posició actual en el fitxer '%s'"
 
-#: ../src/common/file.cpp:465
+#: ../src/common/file.cpp:492
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr ""
 "no es pot trobar la llargària del fitxer en el descriptor del fitxer %d"
 
-#: ../src/msw/utils.cpp:341
+#: ../src/msw/utils.cpp:336
 msgid "can't find user's HOME, using current directory."
 msgstr "no es pot trobar la CASA de l'usuari utilitzant el directori actual."
 
-#: ../src/common/file.cpp:366
+#: ../src/common/file.cpp:407
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "no es pot buidar el descriptor del fitxer %d"
 
-#: ../src/common/file.cpp:422
+#: ../src/common/file.cpp:463
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "no es pot cercar en el descriptor del fitxer %d"
 
-#: ../src/common/fontmap.cpp:325
+#: ../src/common/fontmap.cpp:322
 msgid "can't load any font, aborting"
 msgstr "no s'ha pogut carregar cap font, s'està avortant"
 
-#: ../src/common/file.cpp:231 ../src/common/ffile.cpp:59
+#: ../src/common/ffile.cpp:57 ../src/common/file.cpp:228
 #, c-format
 msgid "can't open file '%s'"
 msgstr "no s'ha pogut obrir el fitxer '%s'"
 
-#: ../src/common/fileconf.cpp:320
+#: ../src/common/fileconf.cpp:314
 #, c-format
 msgid "can't open global configuration file '%s'."
 msgstr "no es pot obrir el fitxer de configuració global '%s'."
 
-#: ../src/common/fileconf.cpp:336
+#: ../src/common/fileconf.cpp:330
 #, c-format
 msgid "can't open user configuration file '%s'."
 msgstr "no es pot obrir el fitxer de configuració d'usuari '%s'."
@@ -8587,42 +8761,42 @@ msgstr "no es pot obrir el fitxer de configuració d'usuari '%s'."
 msgid "can't open user configuration file."
 msgstr "no es pot obrir el fitxer de configuració de l'usuari."
 
-#: ../src/common/zipstrm.cpp:579
+#: ../src/common/zipstrm.cpp:572
 #, fuzzy
 msgid "can't re-initialize zlib deflate stream"
 msgstr "No es pot començar a mostrar."
 
-#: ../src/common/zipstrm.cpp:604
+#: ../src/common/zipstrm.cpp:597
 #, fuzzy
 msgid "can't re-initialize zlib inflate stream"
 msgstr "No es pot començar a mostrar."
 
-#: ../src/common/file.cpp:304
+#: ../src/common/file.cpp:345
 #, fuzzy, c-format
 msgid "can't read from file descriptor %d"
 msgstr "no es pot llegir des del fitxer descriptor %s"
 
-#: ../src/common/file.cpp:581
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:608
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "no s'ha pogut extreure el fitxer '%s'"
 
-#: ../src/common/file.cpp:598
+#: ../src/common/ffile.cpp:394 ../src/common/file.cpp:625
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "no es pot extreure el fitxer temporal '%s'"
 
-#: ../src/common/file.cpp:408
+#: ../src/common/file.cpp:449
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "no és pot cercar el fitxer descriptor de %d"
 
-#: ../src/common/textfile.cpp:273
+#: ../src/common/textfile.cpp:161
 #, c-format
 msgid "can't write buffer '%s' to disk."
 msgstr "no es pot escriure el búfer '%s' al disc."
 
-#: ../src/common/file.cpp:323
+#: ../src/common/file.cpp:364
 #, c-format
 msgid "can't write to file descriptor %d"
 msgstr "no es pot escriure en el fitxer descriptiu %d"
@@ -8632,22 +8806,28 @@ msgid "can't write user configuration file."
 msgstr "no es pot escriure el fitxer de configuració de l'usuari"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:482 ../src/generic/datavgen.cpp:1261
+#: ../src/common/datavcmn.cpp:2064 ../src/generic/datavgen.cpp:1384
 msgid "checked"
 msgstr ""
 
-#: ../src/html/chm.cpp:345
+#: ../src/html/chm.cpp:342
 msgid "checksum error"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:820
+#: ../src/common/tarstrm.cpp:814
 msgid "checksum failure reading tar header block"
 msgstr ""
 
-#: ../src/richtext/richtextbackgroundpage.cpp:226
-#: ../src/richtext/richtextbackgroundpage.cpp:249
-#: ../src/richtext/richtextbackgroundpage.cpp:289
-#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
 #: ../src/richtext/richtextborderspage.cpp:254
 #: ../src/richtext/richtextborderspage.cpp:288
 #: ../src/richtext/richtextborderspage.cpp:322
@@ -8665,108 +8845,131 @@ msgstr ""
 #: ../src/richtext/richtextmarginspage.cpp:340
 #: ../src/richtext/richtextmarginspage.cpp:363
 #: ../src/richtext/richtextmarginspage.cpp:388
-#: ../src/richtext/richtextsizepage.cpp:339
-#: ../src/richtext/richtextsizepage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:400
-#: ../src/richtext/richtextsizepage.cpp:427
-#: ../src/richtext/richtextsizepage.cpp:454
-#: ../src/richtext/richtextsizepage.cpp:481
-#: ../src/richtext/richtextsizepage.cpp:555
-#: ../src/richtext/richtextsizepage.cpp:590
-#: ../src/richtext/richtextsizepage.cpp:625
-#: ../src/richtext/richtextsizepage.cpp:660
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
 msgid "cm"
 msgstr ""
 
-#: ../src/html/chm.cpp:347
+#: ../src/html/chm.cpp:344
 msgid "compression error"
 msgstr ""
 
-#: ../src/common/regex.cpp:236
+#: ../src/common/regex.cpp:233
 msgid "conversion to 8-bit encoding failed"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:187
+#: ../src/common/accelcmn.cpp:186
 msgid "ctrl"
 msgstr "control"
 
-#: ../src/common/cmdline.cpp:1500
+#: ../src/common/cmdline.cpp:1496
 msgid "date"
 msgstr "data"
 
-#: ../src/html/chm.cpp:349
+#: ../src/html/chm.cpp:346
 msgid "decompression error"
 msgstr ""
 
-#: ../src/richtext/richtextstyles.cpp:780 ../src/common/fmapbase.cpp:820
+#: ../src/common/fmapbase.cpp:816 ../src/richtext/richtextstyles.cpp:777
 msgid "default"
 msgstr "predeterminat"
 
-#: ../src/common/cmdline.cpp:1496
+#: ../src/common/cmdline.cpp:1492
 msgid "double"
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:538
+#: ../src/common/debugrpt.cpp:539
 msgid "dump of the process state (binary)"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1969
+#: ../src/common/datetimefmt.cpp:1992
 msgid "eighteenth"
 msgstr "divuitè"
 
-#: ../src/common/datetimefmt.cpp:1959
+#: ../src/common/datetimefmt.cpp:1982
 msgid "eighth"
 msgstr "vuitè"
 
-#: ../src/common/datetimefmt.cpp:1962
+#: ../src/common/datetimefmt.cpp:1985
 msgid "eleventh"
 msgstr "onzè"
 
-#: ../src/common/fileconf.cpp:1833
+#: ../src/common/fileconf.cpp:1835
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "l'entrada '%s' apareix més d'un cop en el grup '%s'"
 
-#: ../src/html/chm.cpp:343
+#: ../src/html/chm.cpp:340
 #, fuzzy
 msgid "error in data format"
 msgstr "IFF: error en format d'imatge IFF."
 
-#: ../src/html/chm.cpp:331
+#: ../src/html/chm.cpp:328
 #, fuzzy
 msgid "error opening file"
 msgstr "Error en llegir el fitxer '%s'"
 
-#: ../src/common/zipstrm.cpp:1778
+#: ../src/common/zipstrm.cpp:1836
 #, fuzzy
 msgid "error reading zip central directory"
 msgstr "Error en crear directori"
 
-#: ../src/common/zipstrm.cpp:1870
+#: ../src/common/zipstrm.cpp:1940
 msgid "error reading zip local header"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2531
+#: ../src/common/zipstrm.cpp:2615
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr ""
 
-#: ../src/common/ffile.cpp:188
+#: ../src/common/zipstrm.cpp:2608
+#, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1205
+#, fuzzy
+msgid "extrabold"
+msgstr "negreta"
+
+#: ../src/common/fontcmn.cpp:1223
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1167
+#, fuzzy
+msgid "extralight"
+msgstr "clar"
+
+#: ../src/msw/webview_ie.cpp:1036
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "No s'ha pogut executar '%s'\n"
+
+#: ../src/common/ffile.cpp:187
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "no s'ha pogut buidar la memòria del fitxer '%s'"
 
+#: ../src/msw/webview_ie.cpp:1045
+#, fuzzy
+msgid "failed to retrieve execution result"
+msgstr "No s'ha pogut recuperar el text del missatge d'error RAS"
+
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1030
+#: ../src/generic/datavgen.cpp:1150
 #, fuzzy
 msgid "false"
 msgstr "&Mida"
 
-#: ../src/common/datetimefmt.cpp:1966
+#: ../src/common/datetimefmt.cpp:1989
 msgid "fifteenth"
 msgstr "quinzè"
 
-#: ../src/common/datetimefmt.cpp:1956
+#: ../src/common/datetimefmt.cpp:1979
 msgid "fifth"
 msgstr "cinquè"
 
@@ -8797,138 +9000,157 @@ msgstr "fitxer '%s', línia %d: valor per a clau immutable '%s' ignorat."
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "fiitxer '%s': caràcter inesperat %c a la línia %d."
 
-#: ../src/richtext/richtextbuffer.cpp:8738
+#: ../src/richtext/richtextbuffer.cpp:8736
 #, fuzzy
 msgid "files"
 msgstr "&Mida"
 
-#: ../src/common/datetimefmt.cpp:1952
+#: ../src/common/datetimefmt.cpp:1975
 msgid "first"
 msgstr "primer"
 
-#: ../src/html/helpwnd.cpp:1252
+#: ../src/html/helpwnd.cpp:1250
 #, fuzzy
 msgid "font size"
 msgstr "Grandària de la font:"
 
-#: ../src/common/datetimefmt.cpp:1965
+#: ../src/common/datetimefmt.cpp:1988
 msgid "fourteenth"
 msgstr "catorzé"
 
-#: ../src/common/datetimefmt.cpp:1955
+#: ../src/common/datetimefmt.cpp:1978
 msgid "fourth"
 msgstr "quart"
 
-#: ../src/common/appbase.cpp:783
+#: ../src/common/appbase.cpp:784
 msgid "generate verbose log messages"
 msgstr "genera missatges de registre detallats"
 
-#: ../src/richtext/richtextbuffer.cpp:13138
-#: ../src/richtext/richtextbuffer.cpp:13248
+#: ../src/common/fontcmn.cpp:1215
+msgid "heavy"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:13133
+#: ../src/richtext/richtextbuffer.cpp:13243
 #, fuzzy
 msgid "image"
 msgstr "Temps"
 
-#: ../src/common/tarstrm.cpp:796
+#: ../src/common/tarstrm.cpp:790
 msgid "incomplete header block in tar"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:489
+#: ../src/common/xtixml.cpp:485
 msgid "incorrect event handler string, missing dot"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:1381
+#: ../src/common/tarstrm.cpp:1375
 msgid "incorrect size given for tar entry"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:993
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:987
 msgid "invalid data in extended tar header"
 msgstr ""
 
-#: ../src/generic/logg.cpp:1030
+#: ../src/generic/logg.cpp:1027
 msgid "invalid message box return value"
 msgstr "valor de retorn de la caixa de missatges invàlid"
 
-#: ../src/common/zipstrm.cpp:1647
+#: ../src/common/zipstrm.cpp:1688
 #, fuzzy
 msgid "invalid zip file"
 msgstr "Fitxer de bloqueig '%s' invàlid."
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:1228
 msgid "italic"
 msgstr "cursiva"
 
-#: ../src/common/fontcmn.cpp:991
+#: ../src/common/webrequest_curl.cpp:374
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "No s'ha pogut carregar el fitxer."
+
+#: ../src/common/fontcmn.cpp:1172
 msgid "light"
 msgstr "clar"
 
-#: ../src/common/intl.cpp:303
-#, c-format
-msgid "locale '%s' cannot be set."
-msgstr "la localització '%s' no es pot fixar"
+#: ../src/common/fontcmn.cpp:1185
+msgid "medium"
+msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2125
+#: ../src/common/datetimefmt.cpp:2148
 msgid "midnight"
 msgstr "mitja nit"
 
-#: ../src/common/datetimefmt.cpp:1970
+#: ../src/common/datetimefmt.cpp:1993
 msgid "nineteenth"
 msgstr "dinovè"
 
-#: ../src/common/datetimefmt.cpp:1960
+#: ../src/common/datetimefmt.cpp:1983
 msgid "ninth"
 msgstr "novè"
 
-#: ../src/msw/dde.cpp:1116
+#: ../src/msw/dde.cpp:1180
 msgid "no DDE error."
 msgstr "no hi ha error DDE."
 
-#: ../src/html/chm.cpp:327
+#: ../src/html/chm.cpp:324
 #, fuzzy
 msgid "no error"
 msgstr "error desconegut"
 
-#: ../src/dfb/fontmgr.cpp:174
+#: ../src/dfb/fontmgr.cpp:171
 #, c-format
 msgid "no fonts found in %s, using builtin font"
 msgstr ""
 
-#: ../src/html/helpdata.cpp:657
+#: ../src/html/helpdata.cpp:650
 msgid "noname"
 msgstr "sense nom"
 
-#: ../src/common/datetimefmt.cpp:2124
+#: ../src/common/datetimefmt.cpp:2147
 msgid "noon"
 msgstr "migdia"
 
-#: ../src/richtext/richtextstyles.cpp:779
+#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
 #, fuzzy
 msgid "normal"
 msgstr "Normal"
 
-#: ../src/common/cmdline.cpp:1492
+#: ../src/common/cmdline.cpp:1488
 msgid "num"
 msgstr "núm."
 
-#: ../src/common/xtixml.cpp:259
+#: ../src/common/accelcmn.cpp:194
+msgid "num "
+msgstr ""
+
+#: ../src/common/xtixml.cpp:255
 msgid "objects cannot have XML Text Nodes"
 msgstr ""
 
-#: ../src/html/chm.cpp:339
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
 #, fuzzy
 msgid "out of memory"
 msgstr "GIF: No hi ha prou memòria"
 
-#: ../src/common/debugrpt.cpp:514
+#: ../src/common/debugrpt.cpp:515
 msgid "process context description"
 msgstr ""
 
-#: ../src/richtext/richtextbackgroundpage.cpp:227
-#: ../src/richtext/richtextbackgroundpage.cpp:250
-#: ../src/richtext/richtextbackgroundpage.cpp:290
-#: ../src/richtext/richtextbackgroundpage.cpp:317
-#: ../src/richtext/richtextfontpage.cpp:177
-#: ../src/richtext/richtextfontpage.cpp:180
 #: ../src/richtext/richtextborderspage.cpp:255
 #: ../src/richtext/richtextborderspage.cpp:289
 #: ../src/richtext/richtextborderspage.cpp:323
@@ -8938,22 +9160,45 @@ msgstr ""
 #: ../src/richtext/richtextborderspage.cpp:491
 #: ../src/richtext/richtextborderspage.cpp:525
 #: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextfontpage.cpp:180
 msgid "pt"
 msgstr ""
 
-#: ../src/richtext/richtextbackgroundpage.cpp:225
-#: ../src/richtext/richtextbackgroundpage.cpp:228
-#: ../src/richtext/richtextbackgroundpage.cpp:229
-#: ../src/richtext/richtextbackgroundpage.cpp:248
-#: ../src/richtext/richtextbackgroundpage.cpp:251
-#: ../src/richtext/richtextbackgroundpage.cpp:252
-#: ../src/richtext/richtextbackgroundpage.cpp:288
-#: ../src/richtext/richtextbackgroundpage.cpp:291
-#: ../src/richtext/richtextbackgroundpage.cpp:292
-#: ../src/richtext/richtextbackgroundpage.cpp:315
-#: ../src/richtext/richtextbackgroundpage.cpp:318
-#: ../src/richtext/richtextbackgroundpage.cpp:319
-#: ../src/richtext/richtextfontpage.cpp:178
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:659
+#: ../src/richtext/richtextsizepage.cpp:662
+#: ../src/richtext/richtextsizepage.cpp:663
 #: ../src/richtext/richtextborderspage.cpp:253
 #: ../src/richtext/richtextborderspage.cpp:256
 #: ../src/richtext/richtextborderspage.cpp:257
@@ -9005,267 +9250,277 @@ msgstr ""
 #: ../src/richtext/richtextmarginspage.cpp:387
 #: ../src/richtext/richtextmarginspage.cpp:389
 #: ../src/richtext/richtextmarginspage.cpp:390
-#: ../src/richtext/richtextsizepage.cpp:338
-#: ../src/richtext/richtextsizepage.cpp:341
-#: ../src/richtext/richtextsizepage.cpp:342
-#: ../src/richtext/richtextsizepage.cpp:372
-#: ../src/richtext/richtextsizepage.cpp:375
-#: ../src/richtext/richtextsizepage.cpp:376
-#: ../src/richtext/richtextsizepage.cpp:399
-#: ../src/richtext/richtextsizepage.cpp:402
-#: ../src/richtext/richtextsizepage.cpp:403
-#: ../src/richtext/richtextsizepage.cpp:426
-#: ../src/richtext/richtextsizepage.cpp:429
-#: ../src/richtext/richtextsizepage.cpp:430
-#: ../src/richtext/richtextsizepage.cpp:453
-#: ../src/richtext/richtextsizepage.cpp:456
-#: ../src/richtext/richtextsizepage.cpp:457
-#: ../src/richtext/richtextsizepage.cpp:480
-#: ../src/richtext/richtextsizepage.cpp:483
-#: ../src/richtext/richtextsizepage.cpp:484
-#: ../src/richtext/richtextsizepage.cpp:554
-#: ../src/richtext/richtextsizepage.cpp:557
-#: ../src/richtext/richtextsizepage.cpp:558
-#: ../src/richtext/richtextsizepage.cpp:589
-#: ../src/richtext/richtextsizepage.cpp:592
-#: ../src/richtext/richtextsizepage.cpp:593
-#: ../src/richtext/richtextsizepage.cpp:624
-#: ../src/richtext/richtextsizepage.cpp:627
-#: ../src/richtext/richtextsizepage.cpp:628
-#: ../src/richtext/richtextsizepage.cpp:659
-#: ../src/richtext/richtextsizepage.cpp:662
-#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextfontpage.cpp:178
 msgid "px"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:193
+#: ../src/common/accelcmn.cpp:192
 #, fuzzy
 msgid "rawctrl"
 msgstr "control"
 
-#: ../src/html/chm.cpp:333
+#: ../src/html/chm.cpp:330
 #, fuzzy
 msgid "read error"
 msgstr "Error de fitxer"
 
-#: ../src/common/zipstrm.cpp:2085
+#: ../src/common/zipstrm.cpp:2155
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2080
+#: ../src/common/zipstrm.cpp:2150
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr ""
 
-#: ../src/msw/dde.cpp:1159
+#: ../src/msw/dde.cpp:1223
 msgid "reentrancy problem."
 msgstr "problema de reentrada."
 
-#: ../src/common/datetimefmt.cpp:1953
+#: ../src/common/datetimefmt.cpp:1976
 msgid "second"
 msgstr "segon"
 
-#: ../src/html/chm.cpp:337
+#: ../src/html/chm.cpp:334
 #, fuzzy
 msgid "seek error"
 msgstr "Error de fitxer"
 
-#: ../src/common/datetimefmt.cpp:1968
+#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#, fuzzy
+msgid "semibold"
+msgstr "negreta"
+
+#: ../src/common/datetimefmt.cpp:1991
 msgid "seventeenth"
 msgstr "dissetè"
 
-#: ../src/common/datetimefmt.cpp:1958
+#: ../src/common/datetimefmt.cpp:1981
 msgid "seventh"
 msgstr "setè"
 
-#: ../src/common/accelcmn.cpp:191
+#: ../src/common/accelcmn.cpp:190
 msgid "shift"
 msgstr "Shift"
 
-#: ../src/common/appbase.cpp:773
+#: ../src/common/appbase.cpp:774
 msgid "show this help message"
 msgstr "mostra este missatge d'ajuda"
 
-#: ../src/common/datetimefmt.cpp:1967
+#: ../src/common/datetimefmt.cpp:1990
 msgid "sixteenth"
 msgstr "setzè"
 
-#: ../src/common/datetimefmt.cpp:1957
+#: ../src/common/datetimefmt.cpp:1980
 msgid "sixth"
 msgstr "sisè"
 
-#: ../src/common/appcmn.cpp:234
+#: ../src/common/appcmn.cpp:255
 msgid "specify display mode to use (e.g. 640x480-16)"
 msgstr "especifiqueu el mode de pantalla a utilitzar (p. ex. 640x480-16)"
 
-#: ../src/common/appcmn.cpp:220
+#: ../src/common/appcmn.cpp:241
 msgid "specify the theme to use"
 msgstr "especifica el tema a utilitzar"
 
-#: ../src/richtext/richtextbuffer.cpp:9340
+#: ../src/richtext/richtextbuffer.cpp:9337
 msgid "standard/circle"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9341
+#: ../src/richtext/richtextbuffer.cpp:9338
 msgid "standard/circle-outline"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9343
+#: ../src/richtext/richtextbuffer.cpp:9340
 msgid "standard/diamond"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9342
+#: ../src/richtext/richtextbuffer.cpp:9339
 msgid "standard/square"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9344
+#: ../src/richtext/richtextbuffer.cpp:9341
 msgid "standard/triangle"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1985
+#: ../src/common/zipstrm.cpp:2055
 #, fuzzy
 msgid "stored file length not in Zip header"
 msgstr "Format no suportat de porta-retalls"
 
-#: ../src/common/cmdline.cpp:1488
+#: ../src/common/cmdline.cpp:1484
 msgid "str"
 msgstr "str"
 
-#: ../src/common/fontcmn.cpp:982
+#: ../src/common/fontcmn.cpp:1145
 msgid "strikethrough"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:1003 ../src/common/tarstrm.cpp:1025
-#: ../src/common/tarstrm.cpp:1507 ../src/common/tarstrm.cpp:1529
+#: ../src/common/tarstrm.cpp:997 ../src/common/tarstrm.cpp:1019
+#: ../src/common/tarstrm.cpp:1501 ../src/common/tarstrm.cpp:1523
 msgid "tar entry not open"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1961
+#: ../src/common/datetimefmt.cpp:1984
 msgid "tenth"
 msgstr "desè"
 
-#: ../src/msw/dde.cpp:1123
+#: ../src/msw/dde.cpp:1187
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr ""
 "la resposta a la transacció causada per la DDE_FBUSY s'ha de fixar una mica."
 
-#: ../src/common/datetimefmt.cpp:1954
+#: ../src/common/fontcmn.cpp:1154
+msgid "thin"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:1977
 msgid "third"
 msgstr "tercer"
 
-#: ../src/common/datetimefmt.cpp:1964
+#: ../src/common/datetimefmt.cpp:1987
 msgid "thirteenth"
 msgstr "tretzè"
 
-#: ../src/common/datetimefmt.cpp:1758
+#: ../src/common/datetimefmt.cpp:1781
 msgid "today"
 msgstr "avui"
 
-#: ../src/common/datetimefmt.cpp:1760
+#: ../src/common/datetimefmt.cpp:1783
 msgid "tomorrow"
 msgstr "demà"
 
-#: ../src/common/fileconf.cpp:1944
+#: ../src/common/fileconf.cpp:1946
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr ""
 
-#: ../src/gtk/aboutdlg.cpp:218
+#: ../src/gtk/aboutdlg.cpp:216
 msgid "translator-credits"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1028
+#: ../src/generic/datavgen.cpp:1148
 msgid "true"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1963
+#: ../src/common/datetimefmt.cpp:1986
 msgid "twelfth"
 msgstr "dotzè"
 
-#: ../src/common/datetimefmt.cpp:1971
+#: ../src/common/datetimefmt.cpp:1994
 msgid "twentieth"
 msgstr "vintè"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:486 ../src/generic/datavgen.cpp:1263
+#: ../src/common/datavcmn.cpp:2068 ../src/generic/datavgen.cpp:1386
 msgid "unchecked"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:802 ../src/common/fontcmn.cpp:978
+#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
 msgid "underlined"
 msgstr "subratllat"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:490
+#: ../src/common/datavcmn.cpp:2072
 #, fuzzy
 msgid "undetermined"
 msgstr "subratllat"
 
-#: ../src/common/fileconf.cpp:1979
+#: ../src/common/fileconf.cpp:1981
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "no esperat \" a la posició %d de '%s'."
 
-#: ../src/common/tarstrm.cpp:1045
+#: ../src/common/tarstrm.cpp:1039
 #, fuzzy
 msgid "unexpected end of file"
 msgstr "Fi de fitxer inesperat en analitzar el recurs."
 
-#: ../src/generic/progdlgg.cpp:370 ../src/common/tarstrm.cpp:371
-#: ../src/common/tarstrm.cpp:394 ../src/common/tarstrm.cpp:425
+#: ../src/common/tarstrm.cpp:366 ../src/common/tarstrm.cpp:389
+#: ../src/common/tarstrm.cpp:420 ../src/generic/progdlgg.cpp:376
 msgid "unknown"
 msgstr "desconegut"
 
-#: ../src/msw/registry.cpp:150
+#: ../src/msw/registry.cpp:139
 #, fuzzy, c-format
 msgid "unknown (%lu)"
 msgstr "desconegut"
 
-#: ../src/common/xtixml.cpp:253
+#: ../src/common/xtixml.cpp:249
 #, fuzzy, c-format
 msgid "unknown class %s"
 msgstr ": joc de caràcters desconegut"
 
-#: ../src/common/regex.cpp:258 ../src/html/chm.cpp:351
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "error desconegut"
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "error desconegut"
+
+#: ../src/common/regex.cpp:255 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "error desconegut"
 
-#: ../src/msw/dialup.cpp:471
+#: ../src/msw/dialup.cpp:465
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "error desconegut (error de codi %08x)."
 
-#: ../src/common/fmapbase.cpp:834
+#: ../src/common/fmapbase.cpp:830
 #, c-format
 msgid "unknown-%d"
 msgstr "desconegut-%d"
 
-#: ../src/common/docview.cpp:509
+#: ../src/common/docview.cpp:502
 msgid "unnamed"
 msgstr "sense nom"
 
-#: ../src/common/docview.cpp:1624
+#: ../src/common/docview.cpp:1618
 #, c-format
 msgid "unnamed%d"
 msgstr "%d sense nom"
 
-#: ../src/common/zipstrm.cpp:1999 ../src/common/zipstrm.cpp:2319
+#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
 msgid "unsupported Zip compression method"
 msgstr ""
 
-#: ../src/common/translation.cpp:1892
+#: ../src/common/translation.cpp:1942
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "s'està utilitzant el catàleg '%s' des de '%s'."
 
-#: ../src/html/chm.cpp:335
+#: ../src/html/chm.cpp:332
 #, fuzzy
 msgid "write error"
 msgstr "Error de fitxer"
 
-#: ../src/common/time.cpp:292
+#: ../src/gtk/glcanvas.cpp:187
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/common/time.cpp:285
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay ha fallat."
 
@@ -9278,15 +9533,15 @@ msgstr "wxWidgets no podia obrir l'aplicació per '%s'; s'està eixint."
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets no podien obrien l'exhibició. S'està eixint."
 
-#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:431
 msgid "xxxx"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1759
+#: ../src/common/datetimefmt.cpp:1782
 msgid "yesterday"
 msgstr "ahir"
 
-#: ../src/common/zstream.cpp:251 ../src/common/zstream.cpp:426
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
 #, fuzzy, c-format
 msgid "zlib error %d"
 msgstr " (error %ld: %s)"
@@ -9297,8 +9552,74 @@ msgid "~"
 msgstr ""
 
 #, fuzzy
-#~ msgid "Column could not be added."
-#~ msgstr "No s'ha pogut carregar el fitxer."
+#~ msgid "&Save as"
+#~ msgstr "Anomena i Alça"
+
+#, fuzzy
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' només hauria de contenir caràcters alfabètics"
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' hauria de ser numèric."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' només hauria de contenir caràcters ASCII"
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' només hauria de contenir caràcters alfabètics"
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' només hauria de contenir caràcters alfabètics o numèrics."
+
+#, fuzzy
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' només hauria de contenir caràcters ASCII"
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "No es pot crear una finestra de la classe '%s'"
+
+#, fuzzy
+#~ msgid "Could not initalize libnotify."
+#~ msgstr "No s'ha pogut iniciar la impressió"
+
+#, fuzzy
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "No s'ha pogut crear un temporitzador"
+
+#, fuzzy
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "No es pot obtenir l'actual cadena de punter"
+
+#, fuzzy
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "No s'ha pogut tancar el manegador de fitxers"
+
+#, fuzzy
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "No s'ha pogut obtenir el temps UTC del sistema."
+
+#, fuzzy
+#~ msgid "No unused colour in image."
+#~ msgstr "Cap color no utilitzat en la imatge està sent emmascarat"
+
+#, fuzzy
+#~ msgid "Not available"
+#~ msgstr "Servei XBM no disponible!"
+
+#, fuzzy
+#~ msgid "Replace selection"
+#~ msgstr "Substituix-ho &tot"
+
+#, fuzzy
+#~ msgid "Save as"
+#~ msgstr "Anomena i Alça"
+
+#, fuzzy
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "No podeu afegir un directori nou a esta secció"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "la localització '%s' no es pot fixar"
 
 #, fuzzy
 #~ msgid "Column index not found."
@@ -9526,10 +9847,6 @@ msgstr ""
 #~ msgstr "origen de recerca desconegut"
 
 #, fuzzy
-#~ msgid "wxWidget's control not initialized."
-#~ msgstr "No es pot començar a mostrar."
-
-#, fuzzy
 #~ msgid "Cannot create mutex."
 #~ msgstr "No es pot crear un fil"
 
@@ -9605,9 +9922,6 @@ msgstr ""
 #~ msgid "Directory '%s' doesn't exist!"
 #~ msgstr "El directori '%s' no existix!"
 
-#~ msgid "File %s does not exist."
-#~ msgstr "El fitxer %s no existix"
-
 #~ msgid "Mode %ix%i-%i not available."
 #~ msgstr "Mode %ix%i-%i no disponible."
 
@@ -9667,9 +9981,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Failed to register OpenGL window class."
 #~ msgstr "No s'ha pogut inicialitzar l'OpenGL"
-
-#~ msgid "Fatal error"
-#~ msgstr "Error fatal"
 
 #~ msgid "Fatal error: "
 #~ msgstr "Error fatal:"

--- a/locale/cs.po
+++ b/locale/cs.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-21 14:25+0200\n"
+"POT-Creation-Date: 2020-10-18 23:11+0300\n"
 "PO-Revision-Date: 2017-05-21 20:42+0200\n"
 "Last-Translator: PB <pbfordev@gmail.com>\n"
 "Language-Team: wxWidgets translators <wx-translators@wxwidgets.org>\n"
@@ -15,7 +15,7 @@ msgstr ""
 "X-Poedit-Bookmarks: 1524,-1,-1,-1,-1,-1,-1,-1,-1,-1\n"
 "X-Generator: Poedit 2.0.1\n"
 
-#: ../src/common/debugrpt.cpp:586
+#: ../src/common/debugrpt.cpp:587
 msgid ""
 "\n"
 "Please send this report to the program maintainer, thank you!\n"
@@ -23,8 +23,8 @@ msgstr ""
 "\n"
 "Pošlete, prosím, tento protokol udržovateli programu. Děkujeme!\n"
 
-#: ../src/richtext/richtextstyledlg.cpp:210
-#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:206
+#: ../src/richtext/richtextstyledlg.cpp:218
 msgid " "
 msgstr " "
 
@@ -32,70 +32,96 @@ msgstr " "
 msgid "              Thank you and we're sorry for the inconvenience!\n"
 msgstr "              Děkujeme Vám a omlouváme se za nepříjemnosti!\n"
 
-#: ../src/common/prntbase.cpp:573
+#: ../src/common/prntbase.cpp:568
 #, c-format
 msgid " (copy %d of %d)"
 msgstr " (kopie %d z %d)"
 
-#: ../src/common/log.cpp:421
+#: ../src/common/log.cpp:440
 #, c-format
 msgid " (error %ld: %s)"
 msgstr " (chyba %ld: %s)"
 
-#: ../src/common/imagtiff.cpp:72
+#: ../src/common/imagtiff.cpp:69
 #, c-format
 msgid " (in module \"%s\")"
 msgstr " (v modulu \"%s\")"
 
-#: ../src/osx/core/secretstore.cpp:138
-msgid " (while overwriting an existing item)"
-msgstr " (při přepisování existující položky)"
-
-#: ../src/common/docview.cpp:1642
+#: ../src/common/docview.cpp:1636
 msgid " - "
 msgstr " - "
 
-#: ../src/richtext/richtextprint.cpp:593 ../src/html/htmprint.cpp:714
+#: ../src/html/htmprint.cpp:712 ../src/richtext/richtextprint.cpp:589
 msgid " Preview"
 msgstr " Náhled"
 
-#: ../src/common/fontcmn.cpp:824
+#: ../src/common/fontcmn.cpp:973
 msgid " bold"
 msgstr " tučné"
 
-#: ../src/common/fontcmn.cpp:840
+#: ../src/common/fontcmn.cpp:977
+#, fuzzy
+msgid " extra bold"
+msgstr " tučné"
+
+#: ../src/common/fontcmn.cpp:985
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:957
+#, fuzzy
+msgid " extra light"
+msgstr " tenké"
+
+#: ../src/common/fontcmn.cpp:981
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1001
 msgid " italic"
 msgstr " kurzíva"
 
-#: ../src/common/fontcmn.cpp:820
+#: ../src/common/fontcmn.cpp:961
 msgid " light"
 msgstr " tenké"
 
-#: ../src/common/fontcmn.cpp:807
+#: ../src/common/fontcmn.cpp:965
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:969
+#, fuzzy
+msgid " semi bold"
+msgstr " tučné"
+
+#: ../src/common/fontcmn.cpp:940
 msgid " strikethrough"
 msgstr " přeškrtnuté"
 
-#: ../src/common/paper.cpp:117
+#: ../src/common/fontcmn.cpp:953
+msgid " thin"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
 msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
 msgstr "Obálka č. 10, 4 1/8 x 9 1/2 palce"
 
-#: ../src/common/paper.cpp:118
+#: ../src/common/paper.cpp:115
 msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
 msgstr "Obálka č. 11, 4 1/2 x 10 3/8 palce"
 
-#: ../src/common/paper.cpp:119
+#: ../src/common/paper.cpp:116
 msgid "#12 Envelope, 4 3/4 x 11 in"
 msgstr "Obálka č. 12, 4 3/4 x 11 palců"
 
-#: ../src/common/paper.cpp:120
+#: ../src/common/paper.cpp:117
 msgid "#14 Envelope, 5 x 11 1/2 in"
 msgstr "Obálka č. 14, 5 x 11 1/2 palce"
 
-#: ../src/common/paper.cpp:116
+#: ../src/common/paper.cpp:113
 msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
 msgstr "Obálka č. 9, 3 7/8 x 8 7/8 palce"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:341
 #: ../src/richtext/richtextsizepage.cpp:340
 #: ../src/richtext/richtextsizepage.cpp:374
 #: ../src/richtext/richtextsizepage.cpp:401
@@ -106,20 +132,21 @@ msgstr "Obálka č. 9, 3 7/8 x 8 7/8 palce"
 #: ../src/richtext/richtextsizepage.cpp:591
 #: ../src/richtext/richtextsizepage.cpp:626
 #: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextbackgroundpage.cpp:341
 msgid "%"
 msgstr "%"
 
-#: ../src/html/helpwnd.cpp:1031
+#: ../src/html/helpwnd.cpp:1029
 #, c-format
 msgid "%d of %lu"
 msgstr "%d z %lu"
 
-#: ../src/html/helpwnd.cpp:1678
+#: ../src/html/helpwnd.cpp:1676
 #, c-format
 msgid "%i of %u"
 msgstr "%i z %u"
 
-#: ../src/generic/filectrlg.cpp:279
+#: ../src/generic/filectrlg.cpp:275
 #, c-format
 msgid "%ld byte"
 msgid_plural "%ld bytes"
@@ -127,61 +154,61 @@ msgstr[0] "%ld bajt"
 msgstr[1] "%ld bajty"
 msgstr[2] "%ld bajtů"
 
-#: ../src/html/helpwnd.cpp:1033
+#: ../src/html/helpwnd.cpp:1031
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu z %lu"
 
-#: ../src/generic/datavgen.cpp:6028
+#: ../src/generic/datavgen.cpp:6833
 #, c-format
 msgid "%s (%d items)"
 msgstr "%s (%d pložek)"
 
-#: ../src/common/cmdline.cpp:1221
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (nebo %s)"
 
-#: ../src/generic/logg.cpp:224
+#: ../src/generic/logg.cpp:221
 #, c-format
 msgid "%s Error"
 msgstr "%s - chyba"
 
-#: ../src/generic/logg.cpp:236
+#: ../src/generic/logg.cpp:233
 #, c-format
 msgid "%s Information"
 msgstr "%s - informace"
 
-#: ../src/generic/preferencesg.cpp:113
+#: ../src/generic/preferencesg.cpp:110
 #, c-format
 msgid "%s Preferences"
 msgstr "Předvolby %s"
 
-#: ../src/generic/logg.cpp:228
+#: ../src/generic/logg.cpp:225
 #, c-format
 msgid "%s Warning"
 msgstr "%s - varování"
 
-#: ../src/common/tarstrm.cpp:1319
+#: ../src/common/tarstrm.cpp:1313
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s se nevešlo do tar hlavičky záznamu '%s'"
 
-#: ../src/common/fldlgcmn.cpp:124
+#: ../src/common/fldlgcmn.cpp:121
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "Soubory %s (%s)|%s"
 
-#: ../src/html/helpwnd.cpp:1716
+#: ../src/html/helpwnd.cpp:1714
 #, c-format
 msgid "%u of %u"
 msgstr "%u z %u"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "&About"
 msgstr "O &aplikaci"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "&Actual Size"
 msgstr "&Skutečná velikost"
 
@@ -189,28 +216,28 @@ msgstr "&Skutečná velikost"
 msgid "&After a paragraph:"
 msgstr "Za odst&avcem:"
 
-#: ../src/richtext/richtextindentspage.cpp:128
 #: ../src/richtext/richtextliststylepage.cpp:319
+#: ../src/richtext/richtextindentspage.cpp:128
 msgid "&Alignment"
 msgstr "Z&arovnání"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "&Apply"
 msgstr "&Použít"
 
-#: ../src/richtext/richtextstyledlg.cpp:251
+#: ../src/richtext/richtextstyledlg.cpp:247
 msgid "&Apply Style"
 msgstr "&Použít styl"
 
-#: ../src/msw/mdi.cpp:179
+#: ../src/msw/mdi.cpp:174
 msgid "&Arrange Icons"
 msgstr "Uspořád&at ikony"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "&Ascending"
 msgstr "&Vzestupně"
 
-#: ../src/common/stockitem.cpp:142
+#: ../src/common/stockitem.cpp:139
 msgid "&Back"
 msgstr "&Zpět"
 
@@ -230,24 +257,24 @@ msgstr "&Barva pozadí:"
 msgid "&Blur distance:"
 msgstr "&Délka rozostření:"
 
-#: ../src/common/stockitem.cpp:143
+#: ../src/common/stockitem.cpp:140
 msgid "&Bold"
 msgstr "&Tučné"
 
-#: ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141
 msgid "&Bottom"
 msgstr "&Dolů"
 
+#: ../src/richtext/richtextsizepage.cpp:637
+#: ../src/richtext/richtextsizepage.cpp:644
 #: ../src/richtext/richtextborderspage.cpp:345
 #: ../src/richtext/richtextborderspage.cpp:513
 #: ../src/richtext/richtextmarginspage.cpp:259
 #: ../src/richtext/richtextmarginspage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:637
-#: ../src/richtext/richtextsizepage.cpp:644
 msgid "&Bottom:"
 msgstr "&Dolů:"
 
-#: ../include/wx/richtext/richtextbuffer.h:3866
+#: ../include/wx/richtext/richtextbuffer.h:3861
 msgid "&Box"
 msgstr "&Rámeček"
 
@@ -256,38 +283,38 @@ msgstr "&Rámeček"
 msgid "&Bullet style:"
 msgstr "&Styl odrážek:"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "&CD-Rom"
 msgstr "&CD-Rom"
 
-#: ../src/generic/wizard.cpp:434 ../src/generic/fontdlgg.cpp:470
-#: ../src/generic/fontdlgg.cpp:489 ../src/osx/carbon/fontdlg.cpp:402
-#: ../src/common/dlgcmn.cpp:279 ../src/common/stockitem.cpp:145
+#: ../src/osx/carbon/fontdlg.cpp:399 ../src/common/stockitem.cpp:142
+#: ../src/generic/wizard.cpp:433 ../src/generic/fontdlgg.cpp:466
+#: ../src/generic/fontdlgg.cpp:485 ../src/osx/cocoa/button.mm:200
 msgid "&Cancel"
 msgstr "&Storno"
 
-#: ../src/msw/mdi.cpp:175
+#: ../src/msw/mdi.cpp:170
 msgid "&Cascade"
 msgstr "&Kaskádově"
 
-#: ../include/wx/richtext/richtextbuffer.h:5960
+#: ../include/wx/richtext/richtextbuffer.h:5955
 msgid "&Cell"
 msgstr "&Buňka"
 
-#: ../src/richtext/richtextsymboldlg.cpp:439
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "&Character code:"
 msgstr "Kód &znaku:"
 
-#: ../src/common/stockitem.cpp:147
+#: ../src/common/stockitem.cpp:144
 msgid "&Clear"
 msgstr "&Vymazat"
 
-#: ../src/generic/logg.cpp:516 ../src/common/stockitem.cpp:148
-#: ../src/common/prntbase.cpp:1600 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/stockitem.cpp:145 ../src/common/prntbase.cpp:1625
+#: ../src/univ/themes/win32.cpp:3753 ../src/generic/logg.cpp:513
 msgid "&Close"
 msgstr "&Zavřít"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "&Color"
 msgstr "&Barva"
 
@@ -295,20 +322,20 @@ msgstr "&Barva"
 msgid "&Colour:"
 msgstr "&Barva:"
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "&Convert"
 msgstr "&Převést"
 
-#: ../src/richtext/richtextctrl.cpp:333 ../src/osx/textctrl_osx.cpp:577
-#: ../src/common/stockitem.cpp:150 ../src/msw/textctrl.cpp:2508
+#: ../src/osx/textctrl_osx.cpp:595 ../src/common/stockitem.cpp:147
+#: ../src/msw/textctrl.cpp:2773 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Kopírovat"
 
-#: ../src/generic/hyperlinkg.cpp:156
+#: ../src/generic/hyperlinkg.cpp:153
 msgid "&Copy URL"
 msgstr "&Kopírovat URL"
 
-#: ../src/common/headerctrlcmn.cpp:306
+#: ../src/common/headerctrlcmn.cpp:304
 msgid "&Customize..."
 msgstr "&Upravit..."
 
@@ -316,53 +343,54 @@ msgstr "&Upravit..."
 msgid "&Debug report preview:"
 msgstr "Náhle&d protokolu ladění:"
 
-#: ../src/richtext/richtexttabspage.cpp:138
-#: ../src/richtext/richtextctrl.cpp:335 ../src/osx/textctrl_osx.cpp:579
-#: ../src/common/stockitem.cpp:152 ../src/msw/textctrl.cpp:2510
+#: ../src/osx/textctrl_osx.cpp:597 ../src/common/stockitem.cpp:149
+#: ../src/msw/textctrl.cpp:2775 ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtextctrl.cpp:334
 msgid "&Delete"
 msgstr "&Odstranit"
 
-#: ../src/richtext/richtextstyledlg.cpp:269
+#: ../src/richtext/richtextstyledlg.cpp:265
 msgid "&Delete Style..."
 msgstr "O&dstranit styl..."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "&Descending"
 msgstr "&Sestupně"
 
-#: ../src/generic/logg.cpp:682
+#: ../src/generic/logg.cpp:679
 msgid "&Details"
 msgstr "&Detaily"
 
-#: ../src/common/stockitem.cpp:153
+#: ../src/common/stockitem.cpp:150
 msgid "&Down"
 msgstr "&Dolů"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "&Edit"
 msgstr "&Upravit"
 
-#: ../src/richtext/richtextstyledlg.cpp:263
+#: ../src/richtext/richtextstyledlg.cpp:259
 msgid "&Edit Style..."
 msgstr "&Upravit styl..."
 
-#: ../src/common/stockitem.cpp:155
+#: ../src/common/stockitem.cpp:152
 msgid "&Execute"
 msgstr "&Spustit"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/common/stockitem.cpp:154
 msgid "&File"
 msgstr "&Soubor"
 
-#: ../src/common/stockitem.cpp:158
-msgid "&Find"
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "&Find..."
 msgstr "&Najít"
 
-#: ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:430
 msgid "&Finish"
 msgstr "&Dokončit"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:156
 msgid "&First"
 msgstr "&První"
 
@@ -370,15 +398,15 @@ msgstr "&První"
 msgid "&Floating mode:"
 msgstr "&Režim obtékání:"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "&Floppy"
 msgstr "&Disketa"
 
-#: ../src/common/stockitem.cpp:194
+#: ../src/common/stockitem.cpp:191
 msgid "&Font"
 msgstr "&Písmo"
 
-#: ../src/generic/fontdlgg.cpp:371
+#: ../src/generic/fontdlgg.cpp:367
 msgid "&Font family:"
 msgstr "&Rodina písma:"
 
@@ -386,20 +414,20 @@ msgstr "&Rodina písma:"
 msgid "&Font for Level..."
 msgstr "&Písmo pro úroveň..."
 
+#: ../src/richtext/richtextsymboldlg.cpp:397
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:400
 msgid "&Font:"
 msgstr "&Písmo:"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "&Forward"
 msgstr "&Dopředu"
 
-#: ../src/richtext/richtextsymboldlg.cpp:451
+#: ../src/richtext/richtextsymboldlg.cpp:448
 msgid "&From:"
 msgstr "&Od:"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "&Harddisk"
 msgstr "&Pevný disk"
 
@@ -408,9 +436,9 @@ msgstr "&Pevný disk"
 msgid "&Height:"
 msgstr "&Výška:"
 
-#: ../src/generic/wizard.cpp:441 ../src/richtext/richtextstyledlg.cpp:303
-#: ../src/richtext/richtextsymboldlg.cpp:479 ../src/osx/menu_osx.cpp:734
-#: ../src/common/stockitem.cpp:163
+#: ../src/common/stockitem.cpp:160 ../src/generic/wizard.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextstyledlg.cpp:299 ../src/osx/cocoa/menu.mm:226
 msgid "&Help"
 msgstr "&Nápověda"
 
@@ -418,7 +446,7 @@ msgstr "&Nápověda"
 msgid "&Hide details"
 msgstr "&Skrýt podrobnosti"
 
-#: ../src/common/stockitem.cpp:164
+#: ../src/common/stockitem.cpp:161
 msgid "&Home"
 msgstr "&Domů"
 
@@ -426,54 +454,54 @@ msgstr "&Domů"
 msgid "&Horizontal offset:"
 msgstr "&Vodorovné posunutí:"
 
-#: ../src/richtext/richtextindentspage.cpp:184
 #: ../src/richtext/richtextliststylepage.cpp:372
+#: ../src/richtext/richtextindentspage.cpp:184
 msgid "&Indentation (tenths of a mm)"
 msgstr "Odsazení (desetiny m&ilimetrů)"
 
-#: ../src/richtext/richtextindentspage.cpp:167
 #: ../src/richtext/richtextliststylepage.cpp:356
+#: ../src/richtext/richtextindentspage.cpp:167
 msgid "&Indeterminate"
 msgstr "Neurč&ité"
 
-#: ../src/common/stockitem.cpp:166
+#: ../src/common/stockitem.cpp:163
 msgid "&Index"
 msgstr "&Rejstřík"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "&Info"
 msgstr "&Info"
 
-#: ../src/common/stockitem.cpp:168
+#: ../src/common/stockitem.cpp:165
 msgid "&Italic"
 msgstr "&Kurzíva"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "&Jump to"
 msgstr "&Přejít na"
 
-#: ../src/richtext/richtextindentspage.cpp:153
 #: ../src/richtext/richtextliststylepage.cpp:342
+#: ../src/richtext/richtextindentspage.cpp:153
 msgid "&Justified"
 msgstr "&Do bloku"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "&Last"
 msgstr "Pos&lední"
 
-#: ../src/richtext/richtextindentspage.cpp:139
 #: ../src/richtext/richtextliststylepage.cpp:328
+#: ../src/richtext/richtextindentspage.cpp:139
 msgid "&Left"
 msgstr "Do&leva"
 
-#: ../src/richtext/richtextindentspage.cpp:195
+#: ../src/richtext/richtextsizepage.cpp:532
+#: ../src/richtext/richtextsizepage.cpp:539
 #: ../src/richtext/richtextborderspage.cpp:243
 #: ../src/richtext/richtextborderspage.cpp:411
 #: ../src/richtext/richtextliststylepage.cpp:381
+#: ../src/richtext/richtextindentspage.cpp:195
 #: ../src/richtext/richtextmarginspage.cpp:186
 #: ../src/richtext/richtextmarginspage.cpp:300
-#: ../src/richtext/richtextsizepage.cpp:532
-#: ../src/richtext/richtextsizepage.cpp:539
 msgid "&Left:"
 msgstr "Do&leva:"
 
@@ -481,11 +509,11 @@ msgstr "Do&leva:"
 msgid "&List level:"
 msgstr "Úroveň &seznamu:"
 
-#: ../src/generic/logg.cpp:517
+#: ../src/generic/logg.cpp:514
 msgid "&Log"
 msgstr "&Log"
 
-#: ../src/univ/themes/win32.cpp:3748
+#: ../src/univ/themes/win32.cpp:3745
 msgid "&Move"
 msgstr "&Přesunout"
 
@@ -493,19 +521,19 @@ msgstr "&Přesunout"
 msgid "&Move the object to:"
 msgstr "&Přesunout objekt do:"
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "&Network"
 msgstr "&Síť"
 
-#: ../src/richtext/richtexttabspage.cpp:132 ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173 ../src/richtext/richtexttabspage.cpp:132
 msgid "&New"
 msgstr "&Nový"
 
-#: ../src/aui/tabmdi.cpp:111 ../src/generic/mdig.cpp:100 ../src/msw/mdi.cpp:180
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
 msgid "&Next"
 msgstr "&Další"
 
-#: ../src/generic/wizard.cpp:432 ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:429
 msgid "&Next >"
 msgstr "&Další >"
 
@@ -513,7 +541,7 @@ msgstr "&Další >"
 msgid "&Next Paragraph"
 msgstr "&Další odstavec"
 
-#: ../src/generic/tipdlg.cpp:240
+#: ../src/generic/tipdlg.cpp:237
 msgid "&Next Tip"
 msgstr "&Další tip"
 
@@ -521,11 +549,11 @@ msgstr "&Další tip"
 msgid "&Next style:"
 msgstr "&Další styl:"
 
-#: ../src/common/stockitem.cpp:177 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:174 ../src/msw/msgdlg.cpp:435
 msgid "&No"
 msgstr "&Ne"
 
-#: ../src/generic/dbgrptg.cpp:356
+#: ../src/generic/dbgrptg.cpp:360
 msgid "&Notes:"
 msgstr "Poz&námky:"
 
@@ -533,12 +561,12 @@ msgstr "Poz&námky:"
 msgid "&Number:"
 msgstr "&Číslo:"
 
-#: ../src/generic/fontdlgg.cpp:475 ../src/generic/fontdlgg.cpp:482
-#: ../src/osx/carbon/fontdlg.cpp:408 ../src/common/stockitem.cpp:178
+#: ../src/osx/carbon/fontdlg.cpp:405 ../src/common/stockitem.cpp:175
+#: ../src/generic/fontdlgg.cpp:471 ../src/generic/fontdlgg.cpp:478
 msgid "&OK"
 msgstr "&OK"
 
-#: ../src/generic/dbgrptg.cpp:342 ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176 ../src/generic/dbgrptg.cpp:342
 msgid "&Open..."
 msgstr "&Otevřít..."
 
@@ -550,16 +578,16 @@ msgstr "Úr&oveň odstavce:"
 msgid "&Page Break"
 msgstr "&Konec stránky"
 
-#: ../src/richtext/richtextctrl.cpp:334 ../src/osx/textctrl_osx.cpp:578
-#: ../src/common/stockitem.cpp:180 ../src/msw/textctrl.cpp:2509
+#: ../src/osx/textctrl_osx.cpp:596 ../src/common/stockitem.cpp:177
+#: ../src/msw/textctrl.cpp:2774 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&Vložit"
 
-#: ../include/wx/richtext/richtextbuffer.h:5010
+#: ../include/wx/richtext/richtextbuffer.h:5005
 msgid "&Picture"
 msgstr "&Obrázek"
 
-#: ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:419
 msgid "&Point size:"
 msgstr "&Velikost bodu:"
 
@@ -571,11 +599,11 @@ msgstr "&Pozice (desetiny mm):"
 msgid "&Position mode:"
 msgstr "&Režim pozice:"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178
 msgid "&Preferences"
 msgstr "&Předvolby"
 
-#: ../src/aui/tabmdi.cpp:112 ../src/generic/mdig.cpp:101 ../src/msw/mdi.cpp:181
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
 msgid "&Previous"
 msgstr "&Předchozí"
 
@@ -583,78 +611,74 @@ msgstr "&Předchozí"
 msgid "&Previous Paragraph"
 msgstr "&Předchozí odstavec"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "&Print..."
 msgstr "&Tisk..."
 
-#: ../src/richtext/richtextctrl.cpp:339 ../src/richtext/richtextctrl.cpp:5514
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtextctrl.cpp:338
+#: ../src/richtext/richtextctrl.cpp:5512
 msgid "&Properties"
 msgstr "&Vlastnosti"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "&Quit"
 msgstr "&Ukončit"
 
-#: ../src/richtext/richtextctrl.cpp:330 ../src/osx/textctrl_osx.cpp:574
-#: ../src/common/stockitem.cpp:185 ../src/common/cmdproc.cpp:293
-#: ../src/common/cmdproc.cpp:300 ../src/msw/textctrl.cpp:2505
+#: ../src/osx/textctrl_osx.cpp:592 ../src/common/stockitem.cpp:182
+#: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
+#: ../src/msw/textctrl.cpp:2770 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "P&rovést znovu"
 
-#: ../src/common/cmdproc.cpp:289 ../src/common/cmdproc.cpp:309
+#: ../src/common/cmdproc.cpp:282 ../src/common/cmdproc.cpp:302
 msgid "&Redo "
 msgstr "P&rovést znovu "
 
-#: ../src/richtext/richtextstyledlg.cpp:257
+#: ../src/richtext/richtextstyledlg.cpp:253
 msgid "&Rename Style..."
 msgstr "&Přejmenovat styl..."
 
-#: ../src/generic/fdrepdlg.cpp:179
+#: ../src/generic/fdrepdlg.cpp:176
 msgid "&Replace"
 msgstr "Nah&radit"
 
-#: ../src/richtext/richtextstyledlg.cpp:287
+#: ../src/richtext/richtextstyledlg.cpp:283
 msgid "&Restart numbering"
 msgstr "&Restartovat číslování"
 
-#: ../src/univ/themes/win32.cpp:3747
+#: ../src/univ/themes/win32.cpp:3744
 msgid "&Restore"
 msgstr "&Obnovit"
 
-#: ../src/richtext/richtextindentspage.cpp:146
 #: ../src/richtext/richtextliststylepage.cpp:335
+#: ../src/richtext/richtextindentspage.cpp:146
 msgid "&Right"
 msgstr "Dop&rava"
 
-#: ../src/richtext/richtextindentspage.cpp:213
+#: ../src/richtext/richtextsizepage.cpp:602
+#: ../src/richtext/richtextsizepage.cpp:609
 #: ../src/richtext/richtextborderspage.cpp:277
 #: ../src/richtext/richtextborderspage.cpp:445
 #: ../src/richtext/richtextliststylepage.cpp:399
+#: ../src/richtext/richtextindentspage.cpp:213
 #: ../src/richtext/richtextmarginspage.cpp:211
 #: ../src/richtext/richtextmarginspage.cpp:325
-#: ../src/richtext/richtextsizepage.cpp:602
-#: ../src/richtext/richtextsizepage.cpp:609
 msgid "&Right:"
 msgstr "Dop&rava:"
 
-#: ../src/common/stockitem.cpp:190
+#: ../src/common/stockitem.cpp:187
 msgid "&Save"
 msgstr "&Uložit"
-
-#: ../src/common/stockitem.cpp:191
-msgid "&Save as"
-msgstr "&Uložit jako"
 
 #: ../include/wx/richmsgdlg.h:29
 msgid "&See details"
 msgstr "&Zobrazit podrobnosti"
 
-#: ../src/generic/tipdlg.cpp:236
+#: ../src/generic/tipdlg.cpp:233
 msgid "&Show tips at startup"
 msgstr "&Zobrazovat tipy při spuštění"
 
-#: ../src/univ/themes/win32.cpp:3750
+#: ../src/univ/themes/win32.cpp:3747
 msgid "&Size"
 msgstr "Veliko&st"
 
@@ -662,36 +686,36 @@ msgstr "Veliko&st"
 msgid "&Size:"
 msgstr "Veliko&st:"
 
-#: ../src/generic/progdlgg.cpp:252
+#: ../src/generic/progdlgg.cpp:249
 msgid "&Skip"
 msgstr "Pře&skočit"
 
-#: ../src/richtext/richtextindentspage.cpp:242
 #: ../src/richtext/richtextliststylepage.cpp:417
+#: ../src/richtext/richtextindentspage.cpp:242
 msgid "&Spacing (tenths of a mm)"
 msgstr "Mezery (de&setiny mm)"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "&Spell Check"
 msgstr "Kontrola pravopi&su"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "&Stop"
 msgstr "Za&stavit"
 
-#: ../src/richtext/richtextfontpage.cpp:275 ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196 ../src/richtext/richtextfontpage.cpp:275
 msgid "&Strikethrough"
 msgstr "&Přeškrtnuté"
 
-#: ../src/generic/fontdlgg.cpp:382 ../src/richtext/richtextstylepage.cpp:106
+#: ../src/generic/fontdlgg.cpp:378 ../src/richtext/richtextstylepage.cpp:106
 msgid "&Style:"
 msgstr "&Styl:"
 
-#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:194
 msgid "&Styles:"
 msgstr "&Styly:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:413
+#: ../src/richtext/richtextsymboldlg.cpp:410
 msgid "&Subset:"
 msgstr "Pod&skupina:"
 
@@ -705,24 +729,24 @@ msgstr "&Symbol:"
 msgid "&Synchronize values"
 msgstr "&Synchronizovat hodnoty"
 
-#: ../include/wx/richtext/richtextbuffer.h:6069
+#: ../include/wx/richtext/richtextbuffer.h:6064
 msgid "&Table"
 msgstr "&Tabulka"
 
-#: ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197
 msgid "&Top"
 msgstr "&Nahoru"
 
+#: ../src/richtext/richtextsizepage.cpp:567
+#: ../src/richtext/richtextsizepage.cpp:574
 #: ../src/richtext/richtextborderspage.cpp:311
 #: ../src/richtext/richtextborderspage.cpp:479
 #: ../src/richtext/richtextmarginspage.cpp:234
 #: ../src/richtext/richtextmarginspage.cpp:348
-#: ../src/richtext/richtextsizepage.cpp:567
-#: ../src/richtext/richtextsizepage.cpp:574
 msgid "&Top:"
 msgstr "&Nahoru:"
 
-#: ../src/generic/fontdlgg.cpp:444 ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199 ../src/generic/fontdlgg.cpp:441
 msgid "&Underline"
 msgstr "Podtrže&ní"
 
@@ -730,21 +754,21 @@ msgstr "Podtrže&ní"
 msgid "&Underlining:"
 msgstr "&Podtržení:"
 
-#: ../src/richtext/richtextctrl.cpp:329 ../src/osx/textctrl_osx.cpp:573
-#: ../src/common/stockitem.cpp:203 ../src/common/cmdproc.cpp:271
-#: ../src/msw/textctrl.cpp:2504
+#: ../src/osx/textctrl_osx.cpp:591 ../src/common/stockitem.cpp:200
+#: ../src/common/cmdproc.cpp:264 ../src/msw/textctrl.cpp:2769
+#: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Zpět"
 
-#: ../src/common/cmdproc.cpp:265
+#: ../src/common/cmdproc.cpp:258
 msgid "&Undo "
 msgstr "&Zpět "
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "&Unindent"
 msgstr "Zr&ušit odsazení"
 
-#: ../src/common/stockitem.cpp:205
+#: ../src/common/stockitem.cpp:202
 msgid "&Up"
 msgstr "Nahor&u"
 
@@ -760,7 +784,7 @@ msgstr "&Svislé posunutí:"
 msgid "&View..."
 msgstr "&Zobrazit..."
 
-#: ../src/generic/fontdlgg.cpp:393
+#: ../src/generic/fontdlgg.cpp:389
 msgid "&Weight:"
 msgstr "&Tučnost:"
 
@@ -769,88 +793,58 @@ msgstr "&Tučnost:"
 msgid "&Width:"
 msgstr "Šíř&ka:"
 
-#: ../src/aui/tabmdi.cpp:311 ../src/aui/tabmdi.cpp:327
-#: ../src/aui/tabmdi.cpp:329 ../src/generic/mdig.cpp:294
-#: ../src/generic/mdig.cpp:310 ../src/generic/mdig.cpp:314
-#: ../src/msw/mdi.cpp:78
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
 msgid "&Window"
 msgstr "&Okno"
 
-#: ../src/common/stockitem.cpp:206 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:203 ../src/msw/msgdlg.cpp:435
 msgid "&Yes"
 msgstr "&Ano"
 
-#: ../src/common/valtext.cpp:256
-#, c-format
-msgid "'%s' contains illegal characters"
+#: ../src/common/valtext.cpp:197
+#, fuzzy, c-format
+msgid "'%s' contains invalid character(s)"
 msgstr "'%s' obsahuje neplatné znaky"
 
-#: ../src/common/valtext.cpp:254
-#, c-format
-msgid "'%s' doesn't consist only of valid characters"
-msgstr "'%s' neobsahuje pouze platné znaky"
-
-#: ../src/common/config.cpp:519 ../src/msw/regconf.cpp:258
+#: ../src/common/config.cpp:515 ../src/msw/regconf.cpp:255
 #, c-format
 msgid "'%s' has extra '..', ignored."
 msgstr "'%s' obsahuje přebytečné '..', ignorováno."
 
-#: ../src/common/cmdline.cpp:1113 ../src/common/cmdline.cpp:1131
+#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' není správnou číselnou hodnotou pro volbu '%s'."
 
-#: ../src/common/translation.cpp:1100
+#: ../src/common/translation.cpp:1142
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' není katalogem zpráv."
 
-#: ../src/common/valtext.cpp:165
+#: ../src/common/valtext.cpp:188
 #, c-format
 msgid "'%s' is not one of the valid strings"
 msgstr "'%s' není jeden z platných řetězců"
 
-#: ../src/common/valtext.cpp:167
+#: ../src/common/valtext.cpp:186
 #, c-format
 msgid "'%s' is one of the invalid strings"
 msgstr "'%s' je jeden z neplatných řetězců"
 
-#: ../src/common/textbuf.cpp:237
+#: ../src/common/textbuf.cpp:233
 #, c-format
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' je zřejmě binární buffer."
-
-#: ../src/common/valtext.cpp:252
-#, c-format
-msgid "'%s' should be numeric."
-msgstr "'%s' musí být číslo."
-
-#: ../src/common/valtext.cpp:244
-#, c-format
-msgid "'%s' should only contain ASCII characters."
-msgstr "'%s' musí obsahovat pouze ASCII znaky."
-
-#: ../src/common/valtext.cpp:246
-#, c-format
-msgid "'%s' should only contain alphabetic characters."
-msgstr "'%s' musí obsahovat pouze písmena."
-
-#: ../src/common/valtext.cpp:248
-#, c-format
-msgid "'%s' should only contain alphabetic or numeric characters."
-msgstr "'%s' musí obsahovat pouze písmena nebo číslice."
-
-#: ../src/common/valtext.cpp:250
-#, c-format
-msgid "'%s' should only contain digits."
-msgstr "'%s' musí obsahovat pouze čísla."
 
 #: ../src/richtext/richtextliststylepage.cpp:229
 #: ../src/richtext/richtextbulletspage.cpp:166
 msgid "(*)"
 msgstr "(*)"
 
-#: ../src/html/helpwnd.cpp:963
+#: ../src/html/helpwnd.cpp:961
 msgid "(Help)"
 msgstr "(Nápověda)"
 
@@ -859,27 +853,32 @@ msgstr "(Nápověda)"
 msgid "(None)"
 msgstr "(Žádný)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:504
+#: ../src/richtext/richtextsymboldlg.cpp:503
 msgid "(Normal text)"
 msgstr "(Normální text)"
 
-#: ../src/html/helpwnd.cpp:419 ../src/html/helpwnd.cpp:1106
-#: ../src/html/helpwnd.cpp:1742
+#: ../src/html/helpwnd.cpp:417 ../src/html/helpwnd.cpp:1104
+#: ../src/html/helpwnd.cpp:1740
 msgid "(bookmarks)"
 msgstr "(záložky)"
 
+#: ../src/msw/dlmsw.cpp:167
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (chyba %ld: %s)"
+
+#: ../src/richtext/richtextformatdlg.cpp:876
+#: ../src/richtext/richtextliststylepage.cpp:448
+#: ../src/richtext/richtextliststylepage.cpp:460
+#: ../src/richtext/richtextliststylepage.cpp:461
 #: ../src/richtext/richtextindentspage.cpp:274
 #: ../src/richtext/richtextindentspage.cpp:286
 #: ../src/richtext/richtextindentspage.cpp:287
 #: ../src/richtext/richtextindentspage.cpp:311
 #: ../src/richtext/richtextindentspage.cpp:326
-#: ../src/richtext/richtextformatdlg.cpp:884
 #: ../src/richtext/richtextfontpage.cpp:349
 #: ../src/richtext/richtextfontpage.cpp:353
 #: ../src/richtext/richtextfontpage.cpp:357
-#: ../src/richtext/richtextliststylepage.cpp:448
-#: ../src/richtext/richtextliststylepage.cpp:460
-#: ../src/richtext/richtextliststylepage.cpp:461
 msgid "(none)"
 msgstr "(žádný)"
 
@@ -898,7 +897,7 @@ msgstr "*)"
 msgid "+"
 msgstr "+"
 
-#: ../src/msw/utils.cpp:1152
+#: ../src/msw/utils.cpp:1143
 msgid ", 64-bit edition"
 msgstr ", 64bitová edice"
 
@@ -907,163 +906,163 @@ msgstr ", 64bitová edice"
 msgid "-"
 msgstr "-"
 
-#: ../src/generic/filepickerg.cpp:66
+#: ../src/generic/filepickerg.cpp:63
 msgid "..."
 msgstr "..."
 
-#: ../src/richtext/richtextindentspage.cpp:276
 #: ../src/richtext/richtextliststylepage.cpp:450
+#: ../src/richtext/richtextindentspage.cpp:276
 msgid "1.1"
 msgstr "1.1"
 
-#: ../src/richtext/richtextindentspage.cpp:277
 #: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextindentspage.cpp:277
 msgid "1.2"
 msgstr "1.2"
 
-#: ../src/richtext/richtextindentspage.cpp:278
 #: ../src/richtext/richtextliststylepage.cpp:452
+#: ../src/richtext/richtextindentspage.cpp:278
 msgid "1.3"
 msgstr "1.3"
 
-#: ../src/richtext/richtextindentspage.cpp:279
 #: ../src/richtext/richtextliststylepage.cpp:453
+#: ../src/richtext/richtextindentspage.cpp:279
 msgid "1.4"
 msgstr "1.4"
 
-#: ../src/richtext/richtextindentspage.cpp:280
 #: ../src/richtext/richtextliststylepage.cpp:454
+#: ../src/richtext/richtextindentspage.cpp:280
 msgid "1.5"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:281
 #: ../src/richtext/richtextliststylepage.cpp:455
+#: ../src/richtext/richtextindentspage.cpp:281
 msgid "1.6"
 msgstr "1.6"
 
-#: ../src/richtext/richtextindentspage.cpp:282
 #: ../src/richtext/richtextliststylepage.cpp:456
+#: ../src/richtext/richtextindentspage.cpp:282
 msgid "1.7"
 msgstr "1.7"
 
-#: ../src/richtext/richtextindentspage.cpp:283
 #: ../src/richtext/richtextliststylepage.cpp:457
+#: ../src/richtext/richtextindentspage.cpp:283
 msgid "1.8"
 msgstr "1.8"
 
-#: ../src/richtext/richtextindentspage.cpp:284
 #: ../src/richtext/richtextliststylepage.cpp:458
+#: ../src/richtext/richtextindentspage.cpp:284
 msgid "1.9"
 msgstr "1.9"
 
-#: ../src/common/paper.cpp:140
+#: ../src/common/paper.cpp:137
 msgid "10 x 11 in"
 msgstr "10 x 11 palců"
 
-#: ../src/common/paper.cpp:113
+#: ../src/common/paper.cpp:110
 msgid "10 x 14 in"
 msgstr "10 x 14 palců"
 
-#: ../src/common/paper.cpp:114
+#: ../src/common/paper.cpp:111
 msgid "11 x 17 in"
 msgstr "11 x 17 palců"
 
-#: ../src/common/paper.cpp:184
+#: ../src/common/paper.cpp:181
 msgid "12 x 11 in"
 msgstr "12 x 11 palců"
 
-#: ../src/common/paper.cpp:141
+#: ../src/common/paper.cpp:138
 msgid "15 x 11 in"
 msgstr "15 x 11 palců"
 
-#: ../src/richtext/richtextindentspage.cpp:285
 #: ../src/richtext/richtextliststylepage.cpp:459
+#: ../src/richtext/richtextindentspage.cpp:285
 msgid "2"
 msgstr "2"
 
-#: ../src/common/paper.cpp:132
+#: ../src/common/paper.cpp:129
 msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
 msgstr "Obálka č. 6 3/4, 3 5/8 x 6 1/2 palce"
 
-#: ../src/common/paper.cpp:139
+#: ../src/common/paper.cpp:136
 msgid "9 x 11 in"
 msgstr "9 x 11 palců"
 
-#: ../src/html/htmprint.cpp:431
+#: ../src/html/htmprint.cpp:443
 msgid ": file does not exist!"
 msgstr ": soubor neexistuje!"
 
-#: ../src/common/fontmap.cpp:199
+#: ../src/common/fontmap.cpp:196
 msgid ": unknown charset"
 msgstr ": neznámá znaková sada"
 
-#: ../src/common/fontmap.cpp:413
+#: ../src/common/fontmap.cpp:410
 msgid ": unknown encoding"
 msgstr ": neznámé kódování"
 
-#: ../src/generic/wizard.cpp:443
+#: ../src/generic/wizard.cpp:438
 msgid "< &Back"
 msgstr "< &Zpět"
 
-#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:628
-#: ../src/osx/carbon/fontdlg.cpp:648
+#: ../src/osx/carbon/fontdlg.cpp:419 ../src/osx/carbon/fontdlg.cpp:625
+#: ../src/osx/carbon/fontdlg.cpp:645
 msgid "<Any Decorative>"
 msgstr "<Libovolné ozdobné>"
 
-#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:630
-#: ../src/osx/carbon/fontdlg.cpp:650
+#: ../src/osx/carbon/fontdlg.cpp:420 ../src/osx/carbon/fontdlg.cpp:627
+#: ../src/osx/carbon/fontdlg.cpp:647
 msgid "<Any Modern>"
 msgstr "<Libovolné moderní>"
 
-#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:626
-#: ../src/osx/carbon/fontdlg.cpp:646
+#: ../src/osx/carbon/fontdlg.cpp:418 ../src/osx/carbon/fontdlg.cpp:623
+#: ../src/osx/carbon/fontdlg.cpp:643
 msgid "<Any Roman>"
 msgstr "<Libovolné patkové>"
 
-#: ../src/osx/carbon/fontdlg.cpp:424 ../src/osx/carbon/fontdlg.cpp:632
-#: ../src/osx/carbon/fontdlg.cpp:652
+#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:629
+#: ../src/osx/carbon/fontdlg.cpp:649
 msgid "<Any Script>"
 msgstr "<Libovolné psací>"
 
-#: ../src/osx/carbon/fontdlg.cpp:425 ../src/osx/carbon/fontdlg.cpp:637
-#: ../src/osx/carbon/fontdlg.cpp:656
+#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:634
+#: ../src/osx/carbon/fontdlg.cpp:653
 msgid "<Any Swiss>"
 msgstr "<Libovolné bezpatkové>"
 
-#: ../src/osx/carbon/fontdlg.cpp:426 ../src/osx/carbon/fontdlg.cpp:634
-#: ../src/osx/carbon/fontdlg.cpp:654
+#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:631
+#: ../src/osx/carbon/fontdlg.cpp:651
 msgid "<Any Teletype>"
 msgstr "<Libovolné neproporcionální>"
 
-#: ../src/osx/carbon/fontdlg.cpp:420
+#: ../src/osx/carbon/fontdlg.cpp:417
 msgid "<Any>"
 msgstr "<Libovolné>"
 
-#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
 msgid "<DIR>"
 msgstr "<ADR>"
 
-#: ../src/generic/filectrlg.cpp:254 ../src/generic/filectrlg.cpp:277
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
 msgid "<DRIVE>"
 msgstr "<JEDNOTKA>"
 
-#: ../src/generic/filectrlg.cpp:252 ../src/generic/filectrlg.cpp:275
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
 msgid "<LINK>"
 msgstr "<ODKAZ>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1264
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Tučná kurzíva.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1270
+#: ../src/html/helpwnd.cpp:1268
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>tučná kurzíva <u>podtržené</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1265
+#: ../src/html/helpwnd.cpp:1263
 msgid "<b>Bold face.</b> "
 msgstr "<b>Tučně.</b> "
 
-#: ../src/html/helpwnd.cpp:1264
+#: ../src/html/helpwnd.cpp:1262
 msgid "<i>Italic face.</i> "
 msgstr "<i>Kurzíva.</i> "
 
@@ -1072,15 +1071,15 @@ msgstr "<i>Kurzíva.</i> "
 msgid ">"
 msgstr ">"
 
-#: ../src/generic/dbgrptg.cpp:318
+#: ../src/generic/dbgrptg.cpp:317
 msgid "A debug report has been generated in the directory\n"
 msgstr "Protokol ladění byl vytvořen v adresáři\n"
 
-#: ../src/common/debugrpt.cpp:573
+#: ../src/common/debugrpt.cpp:574
 msgid "A debug report has been generated. It can be found in"
 msgstr "Protokol ladění byl vytvořen. Lze jej nalézt v"
 
-#: ../src/common/xtixml.cpp:418
+#: ../src/common/xtixml.cpp:414
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Sbírka, která není prázdná, musí obsahovat uzly 'element'"
 
@@ -1091,106 +1090,106 @@ msgstr "Sbírka, která není prázdná, musí obsahovat uzly 'element'"
 msgid "A standard bullet name."
 msgstr "Standardní jméno odrážky."
 
-#: ../src/common/paper.cpp:217
+#: ../src/common/paper.cpp:214
 msgid "A0 sheet, 841 x 1189 mm"
 msgstr "A0, 841 x 1189 mm"
 
-#: ../src/common/paper.cpp:218
+#: ../src/common/paper.cpp:215
 msgid "A1 sheet, 594 x 841 mm"
 msgstr "A1, 594 x 841 mm"
 
-#: ../src/common/paper.cpp:159
+#: ../src/common/paper.cpp:156
 msgid "A2 420 x 594 mm"
 msgstr "A2, 420 x 594 mm"
 
-#: ../src/common/paper.cpp:156
+#: ../src/common/paper.cpp:153
 msgid "A3 Extra 322 x 445 mm"
 msgstr "A3, Extra 322 x 445 mm"
 
-#: ../src/common/paper.cpp:161
+#: ../src/common/paper.cpp:158
 msgid "A3 Extra Transverse 322 x 445 mm"
 msgstr "A3 napříč Extra, 324 x 458 mm"
 
-#: ../src/common/paper.cpp:170
+#: ../src/common/paper.cpp:167
 msgid "A3 Rotated 420 x 297 mm"
 msgstr "A3 na šířku, 420 x 297 mm"
 
-#: ../src/common/paper.cpp:160
+#: ../src/common/paper.cpp:157
 msgid "A3 Transverse 297 x 420 mm"
 msgstr "A3 napříč, 297 x 420 mm"
 
-#: ../src/common/paper.cpp:106
+#: ../src/common/paper.cpp:103
 msgid "A3 sheet, 297 x 420 mm"
 msgstr "A3, 297 x 420 mm"
 
-#: ../src/common/paper.cpp:146
+#: ../src/common/paper.cpp:143
 msgid "A4 Extra 9.27 x 12.69 in"
 msgstr "A4 Extra, 9,27 x 12,69 palce"
 
-#: ../src/common/paper.cpp:153
+#: ../src/common/paper.cpp:150
 msgid "A4 Plus 210 x 330 mm"
 msgstr "A4 Plus, 210 x 330 mm"
 
-#: ../src/common/paper.cpp:171
+#: ../src/common/paper.cpp:168
 msgid "A4 Rotated 297 x 210 mm"
 msgstr "A4 na šířku, 297 x 210 mm"
 
-#: ../src/common/paper.cpp:148
+#: ../src/common/paper.cpp:145
 msgid "A4 Transverse 210 x 297 mm"
 msgstr "A4 napříč, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:97
+#: ../src/common/paper.cpp:94
 msgid "A4 sheet, 210 x 297 mm"
 msgstr "A4, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:107
+#: ../src/common/paper.cpp:104
 msgid "A4 small sheet, 210 x 297 mm"
 msgstr "A4 malá, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:157
+#: ../src/common/paper.cpp:154
 msgid "A5 Extra 174 x 235 mm"
 msgstr "A5 Extra, 174 x 235 mm"
 
-#: ../src/common/paper.cpp:172
+#: ../src/common/paper.cpp:169
 msgid "A5 Rotated 210 x 148 mm"
 msgstr "A5 na šířku, 210 x 148 mm"
 
-#: ../src/common/paper.cpp:154
+#: ../src/common/paper.cpp:151
 msgid "A5 Transverse 148 x 210 mm"
 msgstr "A5 napříč, 148 x 210 mm"
 
-#: ../src/common/paper.cpp:108
+#: ../src/common/paper.cpp:105
 msgid "A5 sheet, 148 x 210 mm"
 msgstr "A5, 148 x 210 mm"
 
-#: ../src/common/paper.cpp:164
+#: ../src/common/paper.cpp:161
 msgid "A6 105 x 148 mm"
 msgstr "A6, 105 x 148 mm"
 
-#: ../src/common/paper.cpp:177
+#: ../src/common/paper.cpp:174
 msgid "A6 Rotated 148 x 105 mm"
 msgstr "A6 na šířku, 148 x 105 mm"
 
-#: ../src/generic/fontdlgg.cpp:83 ../src/richtext/richtextformatdlg.cpp:529
-#: ../src/osx/carbon/fontdlg.cpp:153
+#: ../src/osx/carbon/fontdlg.cpp:150 ../src/generic/fontdlgg.cpp:79
+#: ../src/richtext/richtextformatdlg.cpp:521
 msgid "ABCDEFGabcdefg12345"
 msgstr "ABCDEFGabcdefg12345"
 
-#: ../src/richtext/richtextsymboldlg.cpp:458 ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
 msgid "ASCII"
 msgstr "ASCII"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "About"
 msgstr "O"
 
-#: ../src/generic/aboutdlgg.cpp:140 ../src/osx/menu_osx.cpp:558
-#: ../src/msw/aboutdlg.cpp:64
+#: ../src/osx/menu_osx.cpp:450 ../src/generic/aboutdlgg.cpp:137
+#: ../src/msw/aboutdlg.cpp:61
 #, c-format
 msgid "About %s"
 msgstr "O aplikaci %s"
 
-#: ../src/osx/menu_osx.cpp:560
+#: ../src/osx/menu_osx.cpp:452
 msgid "About..."
 msgstr "O aplikaci..."
 
@@ -1199,37 +1198,37 @@ msgid "Absolute"
 msgstr "Absolutní"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:873
+#: ../src/propgrid/advprops.cpp:774
 msgid "ActiveBorder"
 msgstr "Aktivní okraj"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:874
+#: ../src/propgrid/advprops.cpp:775
 msgid "ActiveCaption"
 msgstr "Aktivní nadpis"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "Actual Size"
 msgstr "Skutečná velikost"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:140 ../src/common/accelcmn.cpp:81
+#: ../src/common/stockitem.cpp:137 ../src/common/accelcmn.cpp:78
 msgid "Add"
 msgstr "Přidat"
 
-#: ../src/richtext/richtextbuffer.cpp:11455
+#: ../src/richtext/richtextbuffer.cpp:11454
 msgid "Add Column"
 msgstr "Přidat sloupec"
 
-#: ../src/richtext/richtextbuffer.cpp:11392
+#: ../src/richtext/richtextbuffer.cpp:11391
 msgid "Add Row"
 msgstr "Přidat řádek"
 
-#: ../src/html/helpwnd.cpp:432
+#: ../src/html/helpwnd.cpp:430
 msgid "Add current page to bookmarks"
 msgstr "Přidá tuto stránku do záložek"
 
-#: ../src/generic/colrdlgg.cpp:366
+#: ../src/generic/colrdlgg.cpp:386
 msgid "Add to custom colours"
 msgstr "Přidat do vlastních barev"
 
@@ -1241,12 +1240,12 @@ msgstr "AddToPropertyCollection zavolána na obecném přistupujícím"
 msgid "AddToPropertyCollection called w/o valid adder"
 msgstr "AddToPropertyCollection zavolána bez platného zapisovače"
 
-#: ../src/html/helpctrl.cpp:159
+#: ../src/html/helpctrl.cpp:155
 #, c-format
 msgid "Adding book %s"
 msgstr "Přidávám knihu %s"
 
-#: ../src/common/preferencescmn.cpp:43
+#: ../src/common/preferencescmn.cpp:40
 msgid "Advanced"
 msgstr "Pokročilé"
 
@@ -1254,11 +1253,11 @@ msgstr "Pokročilé"
 msgid "After a paragraph:"
 msgstr "Za odstavcem:"
 
-#: ../src/common/stockitem.cpp:172
+#: ../src/common/stockitem.cpp:169
 msgid "Align Left"
 msgstr "Zarovnat vlevo"
 
-#: ../src/common/stockitem.cpp:173
+#: ../src/common/stockitem.cpp:170
 msgid "Align Right"
 msgstr "Zarovnat vpravo"
 
@@ -1266,40 +1265,40 @@ msgstr "Zarovnat vpravo"
 msgid "Alignment"
 msgstr "Zarovnání"
 
-#: ../src/generic/prntdlgg.cpp:215
+#: ../src/generic/prntdlgg.cpp:208
 msgid "All"
 msgstr "Vše"
 
-#: ../src/generic/filectrlg.cpp:1197 ../src/common/fldlgcmn.cpp:107
+#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1186
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Všechny soubory (%s)|%s"
 
-#: ../include/wx/defs.h:2886
+#: ../include/wx/defs.h:2582
 msgid "All files (*)|*"
 msgstr "Všechny soubory (*)|*"
 
-#: ../include/wx/defs.h:2883
+#: ../include/wx/defs.h:2579
 msgid "All files (*.*)|*.*"
 msgstr "Všechny soubory (*.*)|*"
 
-#: ../src/richtext/richtextstyles.cpp:1061
+#: ../src/richtext/richtextstyles.cpp:1058
 msgid "All styles"
 msgstr "Všechny styly"
 
-#: ../src/propgrid/manager.cpp:1528
+#: ../src/propgrid/manager.cpp:1544
 msgid "Alphabetic Mode"
 msgstr "Podle abecedy"
 
-#: ../src/common/xtistrm.cpp:425
+#: ../src/common/xtistrm.cpp:422
 msgid "Already Registered Object passed to SetObjectClassInfo"
 msgstr "Již zaregistrovaný objekt předán SetObjectClassInfo"
 
-#: ../src/unix/dialup.cpp:353
+#: ../src/unix/dialup.cpp:352
 msgid "Already dialling ISP."
 msgstr "ISP je už vytáčen."
 
-#: ../src/common/accelcmn.cpp:331 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/accelcmn.cpp:345 ../src/univ/themes/win32.cpp:3753
 msgid "Alt+"
 msgstr "Alt+"
 
@@ -1308,34 +1307,34 @@ msgstr "Alt+"
 msgid "An optional corner radius for adding rounded corners."
 msgstr "Nepovinný poloměr zaoblení pro přidání zaoblených rohů."
 
-#: ../src/common/debugrpt.cpp:576
+#: ../src/common/debugrpt.cpp:577
 msgid "And includes the following files:\n"
 msgstr "A zahrnuje následující soubory:\n"
 
-#: ../src/generic/animateg.cpp:162
+#: ../src/generic/animateg.cpp:145
 #, c-format
 msgid "Animation file is not of type %ld."
 msgstr "Soubor animace není typu %ld."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:872
+#: ../src/propgrid/advprops.cpp:773
 msgid "AppWorkspace"
 msgstr "Prostor aplikace"
 
-#: ../src/generic/logg.cpp:1014
+#: ../src/generic/logg.cpp:1011
 #, c-format
 msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
 msgstr "Připojit log k souboru '%s' (pokud zvolíte [Ne] soubor bude přepsán)?"
 
-#: ../src/osx/menu_osx.cpp:577 ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:469 ../src/osx/menu_osx.cpp:477
 msgid "Application"
 msgstr "Aplikace"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "Apply"
 msgstr "Použít"
 
-#: ../src/propgrid/advprops.cpp:1609
+#: ../src/propgrid/advprops.cpp:1515
 msgid "Aqua"
 msgstr "Akvamarinová"
 
@@ -1344,29 +1343,29 @@ msgstr "Akvamarinová"
 msgid "Arabic"
 msgstr "Arabský"
 
-#: ../src/common/fmapbase.cpp:153
+#: ../src/common/fmapbase.cpp:150
 msgid "Arabic (ISO-8859-6)"
 msgstr "Arabský (ISO-8859-6)"
 
-#: ../src/msw/ole/automtn.cpp:672
+#: ../src/msw/ole/automtn.cpp:663
 #, c-format
 msgid "Argument %u not found."
 msgstr "Argument %u nenalezen."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1753
+#: ../src/propgrid/advprops.cpp:1654
 msgid "Arrow"
 msgstr "Šipka"
 
-#: ../src/generic/aboutdlgg.cpp:184
+#: ../src/generic/aboutdlgg.cpp:181
 msgid "Artists"
 msgstr "Umělci"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "Ascending"
 msgstr "Vzestupně"
 
-#: ../src/generic/filectrlg.cpp:433
+#: ../src/generic/filectrlg.cpp:429
 msgid "Attributes"
 msgstr "Atributy"
 
@@ -1376,90 +1375,90 @@ msgstr "Atributy"
 msgid "Available fonts."
 msgstr "Dostupná písma."
 
-#: ../src/common/paper.cpp:137
+#: ../src/common/paper.cpp:134
 msgid "B4 (ISO) 250 x 353 mm"
 msgstr "B4 (ISO), 250 x 353 mm"
 
-#: ../src/common/paper.cpp:173
+#: ../src/common/paper.cpp:170
 msgid "B4 (JIS) Rotated 364 x 257 mm"
 msgstr "B4 (JIS) na šířku, 364 x 257 mm"
 
-#: ../src/common/paper.cpp:127
+#: ../src/common/paper.cpp:124
 msgid "B4 Envelope, 250 x 353 mm"
 msgstr "Obálka B4, 250 x 353 mm"
 
-#: ../src/common/paper.cpp:109
+#: ../src/common/paper.cpp:106
 msgid "B4 sheet, 250 x 354 mm"
 msgstr "B4, 250 x 354 mm"
 
-#: ../src/common/paper.cpp:158
+#: ../src/common/paper.cpp:155
 msgid "B5 (ISO) Extra 201 x 276 mm"
 msgstr "B5 (ISO) Extra, 201 x 276 mm"
 
-#: ../src/common/paper.cpp:174
+#: ../src/common/paper.cpp:171
 msgid "B5 (JIS) Rotated 257 x 182 mm"
 msgstr "B5 (JIS) na šířku, 257 x 182 mm"
 
-#: ../src/common/paper.cpp:155
+#: ../src/common/paper.cpp:152
 msgid "B5 (JIS) Transverse 182 x 257 mm"
 msgstr "B5 (JIS) napříč, 182 x 257 mm"
 
-#: ../src/common/paper.cpp:128
+#: ../src/common/paper.cpp:125
 msgid "B5 Envelope, 176 x 250 mm"
 msgstr "Obálka B5, 176 x 250 mm"
 
-#: ../src/common/paper.cpp:110
+#: ../src/common/paper.cpp:107
 msgid "B5 sheet, 182 x 257 millimeter"
 msgstr "B5, 182 x 257 mm"
 
-#: ../src/common/paper.cpp:182
+#: ../src/common/paper.cpp:179
 msgid "B6 (JIS) 128 x 182 mm"
 msgstr "B6 (JIS), 128 x 182 mm"
 
-#: ../src/common/paper.cpp:183
+#: ../src/common/paper.cpp:180
 msgid "B6 (JIS) Rotated 182 x 128 mm"
 msgstr "B6 (JIS) na šířku, 182 x 128 mm"
 
-#: ../src/common/paper.cpp:129
+#: ../src/common/paper.cpp:126
 msgid "B6 Envelope, 176 x 125 mm"
 msgstr "Obálka B6, 176 x 125 mm"
 
-#: ../src/common/imagbmp.cpp:531 ../src/common/imagbmp.cpp:561
-#: ../src/common/imagbmp.cpp:576
+#: ../src/common/imagbmp.cpp:528 ../src/common/imagbmp.cpp:558
+#: ../src/common/imagbmp.cpp:573
 msgid "BMP: Couldn't allocate memory."
 msgstr "BMP: Nelze přidělit paměť."
 
-#: ../src/common/imagbmp.cpp:100
+#: ../src/common/imagbmp.cpp:97
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: Nelze uložit poškozený obrázek."
 
-#: ../src/common/imagbmp.cpp:356
+#: ../src/common/imagbmp.cpp:353
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: Nelze zapsat RGB paletu."
 
-#: ../src/common/imagbmp.cpp:490
+#: ../src/common/imagbmp.cpp:487
 msgid "BMP: Couldn't write data."
 msgstr "BMP: Nelze zapsat data."
 
-#: ../src/common/imagbmp.cpp:246
+#: ../src/common/imagbmp.cpp:243
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: Nelze zapsat hlavičku souboru (Bitmap)."
 
-#: ../src/common/imagbmp.cpp:269
+#: ../src/common/imagbmp.cpp:266
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: Nelze zapsat hlavičku souboru (BitmapInfo)."
 
-#: ../src/common/imagbmp.cpp:140
+#: ../src/common/imagbmp.cpp:137
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage nemá vlastní wxPalette."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:142 ../src/common/accelcmn.cpp:52
+#: ../src/common/stockitem.cpp:139 ../src/common/accelcmn.cpp:49
 msgid "Back"
 msgstr "Zpět"
 
+#: ../src/richtext/richtextformatdlg.cpp:377
 #: ../src/richtext/richtextbackgroundpage.cpp:148
-#: ../src/richtext/richtextformatdlg.cpp:384
 msgid "Background"
 msgstr "Pozadí"
 
@@ -1467,20 +1466,20 @@ msgstr "Pozadí"
 msgid "Background &colour:"
 msgstr "&Barva pozadí:"
 
-#: ../src/osx/carbon/fontdlg.cpp:220
+#: ../src/osx/carbon/fontdlg.cpp:217
 msgid "Background colour"
 msgstr "Barva pozadí"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:52
+#: ../src/common/accelcmn.cpp:49
 msgid "Backspace"
 msgstr "Backspace"
 
-#: ../src/common/fmapbase.cpp:160
+#: ../src/common/fmapbase.cpp:157
 msgid "Baltic (ISO-8859-13)"
 msgstr "Baltský (ISO-8859-13)"
 
-#: ../src/common/fmapbase.cpp:151
+#: ../src/common/fmapbase.cpp:148
 msgid "Baltic (old) (ISO-8859-4)"
 msgstr "Baltský (staré) (ISO-8859-4)"
 
@@ -1493,25 +1492,25 @@ msgstr "Před odstavcem:"
 msgid "Bitmap"
 msgstr "Bitmapa"
 
-#: ../src/propgrid/advprops.cpp:1594
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Black"
 msgstr "Černá"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1755
+#: ../src/propgrid/advprops.cpp:1656
 msgid "Blank"
 msgstr "Prázdné"
 
-#: ../src/propgrid/advprops.cpp:1603
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Blue"
 msgstr "Modrá"
 
-#: ../src/generic/colrdlgg.cpp:345
+#: ../src/generic/colrdlgg.cpp:365
 msgid "Blue:"
 msgstr "Modrá:"
 
-#: ../src/generic/fontdlgg.cpp:333 ../src/richtext/richtextfontpage.cpp:355
-#: ../src/osx/carbon/fontdlg.cpp:354 ../src/common/stockitem.cpp:143
+#: ../src/osx/carbon/fontdlg.cpp:351 ../src/common/stockitem.cpp:140
+#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:355
 msgid "Bold"
 msgstr "Tučné"
 
@@ -1520,31 +1519,35 @@ msgstr "Tučné"
 msgid "Border"
 msgstr "Okraj"
 
-#: ../src/richtext/richtextformatdlg.cpp:379
+#: ../src/richtext/richtextformatdlg.cpp:372
 msgid "Borders"
 msgstr "Okraje"
 
-#: ../src/richtext/richtextsizepage.cpp:288 ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141 ../src/richtext/richtextsizepage.cpp:288
 msgid "Bottom"
 msgstr "Dolů"
 
-#: ../src/generic/prntdlgg.cpp:893
+#: ../src/generic/prntdlgg.cpp:886
 msgid "Bottom margin (mm):"
 msgstr "Dolní okraj (mm):"
 
-#: ../src/richtext/richtextbuffer.cpp:9383
+#: ../src/richtext/richtextbuffer.cpp:9380
 msgid "Box Properties"
 msgstr "Vlastnosti rámečku"
 
-#: ../src/richtext/richtextstyles.cpp:1065
+#: ../src/richtext/richtextstyles.cpp:1062
 msgid "Box styles"
 msgstr "Styly rámečku"
 
-#: ../src/propgrid/advprops.cpp:1602
+#: ../src/osx/cocoa/menu.mm:292
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Brown"
 msgstr "Hnědá"
 
-#: ../src/common/filepickercmn.cpp:43 ../src/common/filepickercmn.cpp:44
+#: ../src/common/filepickercmn.cpp:40 ../src/common/filepickercmn.cpp:41
 msgid "Browse"
 msgstr "Procházet"
 
@@ -1557,72 +1560,72 @@ msgstr "Z&arovnání odrážek:"
 msgid "Bullet style"
 msgstr "Styl odrážek"
 
-#: ../src/richtext/richtextformatdlg.cpp:359
+#: ../src/richtext/richtextformatdlg.cpp:352
 msgid "Bullets"
 msgstr "Odrážky"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1756
+#: ../src/propgrid/advprops.cpp:1657
 msgid "Bullseye"
 msgstr "Střed terče"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:875
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonFace"
 msgstr "Plocha tlačítka"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:876
+#: ../src/propgrid/advprops.cpp:777
 msgid "ButtonHighlight"
 msgstr "Zvýraznění tlačítka"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:877
+#: ../src/propgrid/advprops.cpp:778
 msgid "ButtonShadow"
 msgstr "Stín tlačítka"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:878
+#: ../src/propgrid/advprops.cpp:779
 msgid "ButtonText"
 msgstr "Text tlačítka"
 
-#: ../src/common/paper.cpp:98
+#: ../src/common/paper.cpp:95
 msgid "C sheet, 17 x 22 in"
 msgstr "C, 17 x 22 palců"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "C&lear"
 msgstr "&Vymazat"
 
-#: ../src/generic/fontdlgg.cpp:406
+#: ../src/generic/fontdlgg.cpp:403
 msgid "C&olour:"
 msgstr "B&arva:"
 
-#: ../src/common/paper.cpp:123
+#: ../src/common/paper.cpp:120
 msgid "C3 Envelope, 324 x 458 mm"
 msgstr "Obálka C3, 324 x 458 mm"
 
-#: ../src/common/paper.cpp:124
+#: ../src/common/paper.cpp:121
 msgid "C4 Envelope, 229 x 324 mm"
 msgstr "Obálka C4, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:122
+#: ../src/common/paper.cpp:119
 msgid "C5 Envelope, 162 x 229 mm"
 msgstr "Obálka C5, 162 x 229 mm"
 
-#: ../src/common/paper.cpp:125
+#: ../src/common/paper.cpp:122
 msgid "C6 Envelope, 114 x 162 mm"
 msgstr "Obálka C6, 114 x 162 mm"
 
-#: ../src/common/paper.cpp:126
+#: ../src/common/paper.cpp:123
 msgid "C65 Envelope, 114 x 229 mm"
 msgstr "Obálka C65, 114 x 229 mm"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "CD-Rom"
 msgstr "CD-Rom"
 
-#: ../src/html/chm.cpp:815 ../src/html/chm.cpp:874
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:865
 msgid "CHM handler currently supports only local files!"
 msgstr "Obslužná rutina CHM v současnosti podporuje pouze místní soubory!"
 
@@ -1630,191 +1633,195 @@ msgstr "Obslužná rutina CHM v současnosti podporuje pouze místní soubory!"
 msgid "Ca&pitals"
 msgstr "Ka&pitálky"
 
-#: ../src/common/cmdproc.cpp:267
+#: ../src/common/cmdproc.cpp:260
 msgid "Can't &Undo "
 msgstr "&Nelze vzít zpět "
 
-#: ../src/common/image.cpp:2824
+#: ../src/common/image.cpp:2924
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr "Nelze automaticky zjistit formát obrázku pro nepřevíjitelný vstup."
 
-#: ../src/msw/registry.cpp:506
+#: ../src/msw/registry.cpp:495
 #, c-format
 msgid "Can't close registry key '%s'"
 msgstr "Nelze zavřít klíč registru '%s'"
 
-#: ../src/msw/registry.cpp:584
+#: ../src/msw/registry.cpp:573
 #, c-format
 msgid "Can't copy values of unsupported type %d."
 msgstr "Nelze kopírovat hodnoty nepodporovaného typu %d."
 
-#: ../src/msw/registry.cpp:487
+#: ../src/msw/registry.cpp:476
 #, c-format
 msgid "Can't create registry key '%s'"
 msgstr "Nelze vytvořit klíč registru '%s'"
 
-#: ../src/msw/thread.cpp:665
+#: ../src/msw/thread.cpp:657
 msgid "Can't create thread"
 msgstr "Nelze vytvořit vlákno"
 
-#: ../src/msw/window.cpp:3691
-#, c-format
-msgid "Can't create window of class %s"
-msgstr "Nelze vytvořit okno třídy %s"
-
-#: ../src/msw/registry.cpp:777
+#: ../src/msw/registry.cpp:765
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Nelze smazat klíč '%s'"
 
-#: ../src/msw/iniconf.cpp:458
+#: ../src/msw/iniconf.cpp:455
 #, c-format
 msgid "Can't delete the INI file '%s'"
 msgstr "Nelze smazat INI soubor '%s'"
 
-#: ../src/msw/registry.cpp:805
+#: ../src/msw/registry.cpp:793
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Nelze smazat hodnotu '%s' z klíče '%s'"
 
-#: ../src/msw/registry.cpp:1171
+#: ../src/msw/registry.cpp:1159
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Nelze vyjmenovat podklíče klíče '%s'"
 
-#: ../src/msw/registry.cpp:1132
+#: ../src/msw/registry.cpp:1120
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Nelze vyjmenovat hodnoty klíče '%s'"
 
-#: ../src/msw/registry.cpp:1389
+#: ../src/msw/registry.cpp:1377
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Nelze exportovat hodnotu nepodporovaného typu %d."
 
-#: ../src/common/ffile.cpp:254
+#: ../src/common/ffile.cpp:253
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Nelze zjistit současnou pozici v souboru '%s'"
 
-#: ../src/msw/registry.cpp:418
+#: ../src/msw/registry.cpp:407
 #, c-format
 msgid "Can't get info about registry key '%s'"
 msgstr "Nelze získat informace o klíči registru '%s'"
 
-#: ../src/common/zstream.cpp:346
+#: ../src/msw/webview_ie.cpp:1024
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "Nelze nastavit prioritu vlákna"
+
+#: ../src/common/zstream.cpp:343
 msgid "Can't initialize zlib deflate stream."
 msgstr "Nelze zavést zlib deflate proud."
 
-#: ../src/common/zstream.cpp:185
+#: ../src/common/zstream.cpp:182
 msgid "Can't initialize zlib inflate stream."
 msgstr "Nelze zavést zlib inflate proud."
 
-#: ../src/msw/fswatcher.cpp:476
+#: ../src/msw/fswatcher.cpp:475
 #, c-format
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "Nelze sledovat změny neexistujícího adresáře \"%s\"."
 
-#: ../src/msw/registry.cpp:454
+#: ../src/msw/registry.cpp:443
 #, c-format
 msgid "Can't open registry key '%s'"
 msgstr "Nelze otevřít klíč registru '%s'"
 
-#: ../src/common/zstream.cpp:252
+#: ../src/common/zstream.cpp:249
 #, c-format
 msgid "Can't read from inflate stream: %s"
 msgstr "Nelze číst z inflate proudu: %s"
 
-#: ../src/common/zstream.cpp:244
+#: ../src/common/zstream.cpp:241
 msgid "Can't read inflate stream: unexpected EOF in underlying stream."
 msgstr ""
 "Nelze číst proud inflate: neočekávaný konec souboru v základovém proudu."
 
-#: ../src/msw/registry.cpp:1064
+#: ../src/msw/registry.cpp:1052
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Nelze přečíst hodnotu '%s'"
 
-#: ../src/msw/registry.cpp:878 ../src/msw/registry.cpp:910
-#: ../src/msw/registry.cpp:975
+#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
+#: ../src/msw/registry.cpp:963
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Nelze načíst hodnotu klíče '%s'"
 
-#: ../src/common/image.cpp:2620
+#: ../src/msw/webview_ie.cpp:1017
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/common/image.cpp:2715
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "Obrázek nelze uložit do souboru '%s': neznámá přípona."
 
-#: ../src/generic/logg.cpp:573 ../src/generic/logg.cpp:976
+#: ../src/generic/logg.cpp:570 ../src/generic/logg.cpp:973
 msgid "Can't save log contents to file."
 msgstr "Nelze uložit obsah logu do souboru."
 
-#: ../src/msw/thread.cpp:629
+#: ../src/msw/thread.cpp:621
 msgid "Can't set thread priority"
 msgstr "Nelze nastavit prioritu vlákna"
 
-#: ../src/msw/registry.cpp:896 ../src/msw/registry.cpp:938
-#: ../src/msw/registry.cpp:1081
+#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
+#: ../src/msw/registry.cpp:1069
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Nelze nastavit hodnotu '%s'"
 
-#: ../src/unix/utilsunx.cpp:351
+#: ../src/unix/utilsunx.cpp:353
 msgid "Can't write to child process's stdin"
 msgstr "Nelze zapisovat na std. výstup podřazeného procesu"
 
-#: ../src/common/zstream.cpp:427
+#: ../src/common/zstream.cpp:424
 #, c-format
 msgid "Can't write to deflate stream: %s"
 msgstr "Nelze zapisovat do deflate proudu: %s"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:279 ../src/richtext/richtextstyledlg.cpp:300
-#: ../src/common/stockitem.cpp:145 ../src/common/accelcmn.cpp:71
-#: ../src/msw/msgdlg.cpp:454 ../src/msw/progdlg.cpp:673
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:142
+#: ../src/common/accelcmn.cpp:68 ../src/motif/msgdlg.cpp:196
+#: ../src/gtk1/fontdlg.cpp:144 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/progdlg.cpp:940 ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Storno"
 
-#: ../src/common/filefn.cpp:1261
+#: ../src/common/filefn.cpp:1149
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Nelze vyjmenovat soubory odpovídající masce '%s'"
 
-#: ../src/msw/dir.cpp:263
+#: ../src/msw/dir.cpp:260
 #, c-format
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Nelze vyjmenovat soubory v adresáři '%s'"
 
-#: ../src/msw/dialup.cpp:523
+#: ../src/msw/dialup.cpp:517
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Nelze nalézt aktivní vytáčené připojení: %s"
 
-#: ../src/msw/dialup.cpp:827
+#: ../src/msw/dialup.cpp:821
 msgid "Cannot find the location of address book file"
 msgstr "Nelze nalézt umístění souboru s adresářem"
 
-#: ../src/msw/ole/automtn.cpp:562
+#: ../src/msw/ole/automtn.cpp:553
 #, c-format
 msgid "Cannot get an active instance of \"%s\""
 msgstr "Nelze nalézt aktivní instanci: \"%s\""
 
-#: ../src/unix/threadpsx.cpp:1035
+#: ../src/unix/threadpsx.cpp:1053
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "Nelze zjistit rozsah priorit pro plánovací politiku %d."
 
-#: ../src/unix/utilsunx.cpp:987
+#: ../src/unix/utilsunx.cpp:989
 msgid "Cannot get the hostname"
 msgstr "Nelze zjistit jméno počítače"
 
-#: ../src/unix/utilsunx.cpp:1023
+#: ../src/unix/utilsunx.cpp:1025
 msgid "Cannot get the official hostname"
 msgstr "Nelze zjistit oficiální jméno počítače"
 
-#: ../src/msw/dialup.cpp:928
+#: ../src/msw/dialup.cpp:922
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Nelze zavěsit - žádná aktivní vytáčená připojení."
 
@@ -1822,126 +1829,126 @@ msgstr "Nelze zavěsit - žádná aktivní vytáčená připojení."
 msgid "Cannot initialize OLE"
 msgstr "Nelze zavést OLE"
 
-#: ../src/common/socket.cpp:853
+#: ../src/common/socket.cpp:850
 msgid "Cannot initialize sockets"
 msgstr "Nelze zavést sockety"
 
-#: ../src/msw/volume.cpp:619
+#: ../src/msw/volume.cpp:627
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Nelze načíst ikonu z '%s'."
 
-#: ../src/xrc/xmlres.cpp:360
+#: ../src/xrc/xmlres.cpp:358
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Nelze načíst zdroje z '%s'."
 
-#: ../src/xrc/xmlres.cpp:742
+#: ../src/xrc/xmlres.cpp:740
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Nelze načíst zdroje ze souboru '%s'."
 
-#: ../src/html/htmlfilt.cpp:137
+#: ../src/html/htmlfilt.cpp:134
 #, c-format
 msgid "Cannot open HTML document: %s"
 msgstr "Nelze otevřít HTML dokument: %s"
 
-#: ../src/html/helpdata.cpp:667
+#: ../src/html/helpdata.cpp:660
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Nelze otevřít knihu HTML nápovědy: %s"
 
-#: ../src/html/helpdata.cpp:299
+#: ../src/html/helpdata.cpp:296
 #, c-format
 msgid "Cannot open contents file: %s"
 msgstr "Nelze otevřít soubor s obsahem: %s"
 
-#: ../src/generic/dcpsg.cpp:1667
+#: ../src/generic/dcpsg.cpp:1665
 msgid "Cannot open file for PostScript printing!"
 msgstr "Nelze otevřít soubor pro PostScriptový tisk!"
 
-#: ../src/html/helpdata.cpp:313
+#: ../src/html/helpdata.cpp:310
 #, c-format
 msgid "Cannot open index file: %s"
 msgstr "Nelze otevřít soubor s rejstříkem: %s"
 
-#: ../src/xrc/xmlres.cpp:724
+#: ../src/xrc/xmlres.cpp:722
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Nelze otevřít soubor zdrojů '%s'."
 
-#: ../src/html/helpwnd.cpp:1534
+#: ../src/html/helpwnd.cpp:1532
 msgid "Cannot print empty page."
 msgstr "Nelze tisknout prázdnou stránku."
 
-#: ../src/msw/volume.cpp:507
+#: ../src/msw/volume.cpp:515
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Nelze přečíst typ z '%s'!"
 
-#: ../src/msw/thread.cpp:888
+#: ../src/msw/thread.cpp:894
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Nelze obnovit vlákno %lx"
 
-#: ../src/unix/threadpsx.cpp:1016
+#: ../src/unix/threadpsx.cpp:1028
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Nelze získat plánovací politiku vlákna."
 
-#: ../src/common/intl.cpp:558
+#: ../src/common/intl.cpp:365
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "Nepodařilo se nastavit místní a jazykové nastavení na \"%s\"."
 
-#: ../src/unix/threadpsx.cpp:831 ../src/msw/thread.cpp:546
+#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
 msgid "Cannot start thread: error writing TLS."
 msgstr "Nelze spustit vlákno: chyba při zápisu do TLS."
 
-#: ../src/msw/thread.cpp:872
+#: ../src/msw/thread.cpp:864
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Nelze pozastavit vlákno %lx"
 
-#: ../src/msw/thread.cpp:794
+#: ../src/msw/thread.cpp:786
 msgid "Cannot wait for thread termination"
 msgstr "Nelze počkat na ukončení vlákna"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:75
+#: ../src/common/accelcmn.cpp:72
 msgid "Capital"
 msgstr "Kapitálky"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:879
+#: ../src/propgrid/advprops.cpp:780
 msgid "CaptionText"
 msgstr "Text nadpisu"
 
-#: ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:531
 msgid "Case sensitive"
 msgstr "Rozlišovat velká/malá"
 
-#: ../src/propgrid/manager.cpp:1509
+#: ../src/propgrid/manager.cpp:1527
 msgid "Categorized Mode"
 msgstr "Podle kategorií"
 
-#: ../src/richtext/richtextbuffer.cpp:9968
+#: ../src/richtext/richtextbuffer.cpp:9965
 msgid "Cell Properties"
 msgstr "&Vlastnosti buňky"
 
-#: ../src/common/fmapbase.cpp:161
+#: ../src/common/fmapbase.cpp:158
 msgid "Celtic (ISO-8859-14)"
 msgstr "Keltské (ISO-8859-14)"
 
-#: ../src/richtext/richtextindentspage.cpp:160
 #: ../src/richtext/richtextliststylepage.cpp:349
+#: ../src/richtext/richtextindentspage.cpp:160
 msgid "Cen&tred"
 msgstr "Na s&třed"
 
-#: ../src/common/stockitem.cpp:170
+#: ../src/common/stockitem.cpp:167
 msgid "Centered"
 msgstr "Na střed"
 
-#: ../src/common/fmapbase.cpp:149
+#: ../src/common/fmapbase.cpp:146
 msgid "Central European (ISO-8859-2)"
 msgstr "Středoevropské (ISO-8859-2)"
 
@@ -1950,10 +1957,10 @@ msgstr "Středoevropské (ISO-8859-2)"
 msgid "Centre"
 msgstr "Na střed"
 
-#: ../src/richtext/richtextindentspage.cpp:162
-#: ../src/richtext/richtextindentspage.cpp:164
 #: ../src/richtext/richtextliststylepage.cpp:351
 #: ../src/richtext/richtextliststylepage.cpp:353
+#: ../src/richtext/richtextindentspage.cpp:162
+#: ../src/richtext/richtextindentspage.cpp:164
 msgid "Centre text."
 msgstr "Vystředit text."
 
@@ -1966,24 +1973,24 @@ msgstr "Na střed"
 msgid "Ch&oose..."
 msgstr "Zv&olte..."
 
-#: ../src/richtext/richtextbuffer.cpp:4354
+#: ../src/richtext/richtextbuffer.cpp:4351
 msgid "Change List Style"
 msgstr "Změnit styl seznamu"
 
-#: ../src/richtext/richtextbuffer.cpp:3709
+#: ../src/richtext/richtextbuffer.cpp:3706
 msgid "Change Object Style"
 msgstr "Změnit styl objektu"
 
-#: ../src/richtext/richtextbuffer.cpp:3982
-#: ../src/richtext/richtextbuffer.cpp:8129
+#: ../src/richtext/richtextbuffer.cpp:3979
+#: ../src/richtext/richtextbuffer.cpp:8125
 msgid "Change Properties"
 msgstr "Změnit vlastnosti"
 
-#: ../src/richtext/richtextbuffer.cpp:3526
+#: ../src/richtext/richtextbuffer.cpp:3523
 msgid "Change Style"
 msgstr "Změnit styl"
 
-#: ../src/common/fileconf.cpp:341
+#: ../src/common/fileconf.cpp:335
 #, c-format
 msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
 msgstr "Změny nebudou uloženy, aby se zabránilo přepsání souboru \"%s\""
@@ -1994,11 +2001,11 @@ msgid "Changing current directory to \"%s\" failed"
 msgstr "Změna současného adresáře na \"%s\" selhala"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1757
+#: ../src/propgrid/advprops.cpp:1658
 msgid "Character"
 msgstr "Karet"
 
-#: ../src/richtext/richtextstyles.cpp:1063
+#: ../src/richtext/richtextstyles.cpp:1060
 msgid "Character styles"
 msgstr "Styly znaků"
 
@@ -2035,20 +2042,20 @@ msgstr "Zaškrtněte pro uzavření odrážek do závorek."
 msgid "Check to indicate right-to-left text layout."
 msgstr "Zaškrtněte pro označení rozvržení textu jako zprava doleva."
 
-#: ../src/osx/carbon/fontdlg.cpp:356 ../src/osx/carbon/fontdlg.cpp:358
+#: ../src/osx/carbon/fontdlg.cpp:353 ../src/osx/carbon/fontdlg.cpp:355
 msgid "Check to make the font bold."
 msgstr "Zaškrtněte pro tučné písmo."
 
-#: ../src/osx/carbon/fontdlg.cpp:363 ../src/osx/carbon/fontdlg.cpp:365
+#: ../src/osx/carbon/fontdlg.cpp:360 ../src/osx/carbon/fontdlg.cpp:362
 msgid "Check to make the font italic."
 msgstr "Zaškrtněte pro kurzívu."
 
-#: ../src/osx/carbon/fontdlg.cpp:372 ../src/osx/carbon/fontdlg.cpp:374
+#: ../src/osx/carbon/fontdlg.cpp:369 ../src/osx/carbon/fontdlg.cpp:371
 msgid "Check to make the font underlined."
 msgstr "Zaškrtněte pro podtržené písmo."
 
-#: ../src/richtext/richtextstyledlg.cpp:289
-#: ../src/richtext/richtextstyledlg.cpp:291
+#: ../src/richtext/richtextstyledlg.cpp:285
+#: ../src/richtext/richtextstyledlg.cpp:287
 msgid "Check to restart numbering."
 msgstr "Zaškrtněte pro číslování od začátku."
 
@@ -2082,51 +2089,51 @@ msgstr "Zaškrtněte pro zobrazení textu v horním indexu."
 msgid "Check to suppress hyphenation."
 msgstr "Zaškrtněte pro potlačení dělení slov."
 
-#: ../src/msw/dialup.cpp:763
+#: ../src/msw/dialup.cpp:757
 msgid "Choose ISP to dial"
 msgstr "Vyberte ISP, ke kterému se má připojit"
 
-#: ../src/propgrid/props.cpp:1922
+#: ../src/propgrid/props.cpp:1904
 msgid "Choose a directory:"
 msgstr "Zvolte adresář:"
 
-#: ../src/propgrid/props.cpp:1975
+#: ../src/propgrid/props.cpp:2199
 msgid "Choose a file"
 msgstr "Zvolte soubor"
 
-#: ../src/generic/colrdlgg.cpp:158 ../src/gtk/colordlg.cpp:54
+#: ../src/generic/colrdlgg.cpp:156 ../src/gtk/colordlg.cpp:49
 msgid "Choose colour"
 msgstr "Vyberte barvu"
 
-#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/gtk1/fontdlg.cpp:125 ../src/generic/fontpickerg.cpp:47
+#: ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Vyberte písmo"
 
-#: ../src/common/module.cpp:74
+#: ../src/common/module.cpp:71
 #, c-format
 msgid "Circular dependency involving module \"%s\" detected."
 msgstr "Zjištěna kruhová závislost zahrnující modul \"%s\"."
 
-#: ../src/aui/tabmdi.cpp:108 ../src/generic/mdig.cpp:97
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
 msgid "Cl&ose"
 msgstr "&Zavřít"
 
-#: ../src/msw/ole/automtn.cpp:684
+#: ../src/msw/ole/automtn.cpp:675
 msgid "Class not registered."
 msgstr "Třída není zaregistrována."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:147 ../src/common/accelcmn.cpp:72
+#: ../src/common/stockitem.cpp:144 ../src/common/accelcmn.cpp:69
 msgid "Clear"
 msgstr "Vymazat"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "Clear the log contents"
 msgstr "Smazat obsah logu"
 
-#: ../src/richtext/richtextstyledlg.cpp:252
-#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:248
+#: ../src/richtext/richtextstyledlg.cpp:250
 msgid "Click to apply the selected style."
 msgstr "Klikněte pro použití vybraného stylu."
 
@@ -2137,15 +2144,15 @@ msgstr "Klikněte pro použití vybraného stylu."
 msgid "Click to browse for a symbol."
 msgstr "Klikněte k procházení pro symbol."
 
-#: ../src/osx/carbon/fontdlg.cpp:403 ../src/osx/carbon/fontdlg.cpp:405
+#: ../src/osx/carbon/fontdlg.cpp:400 ../src/osx/carbon/fontdlg.cpp:402
 msgid "Click to cancel changes to the font."
 msgstr "Klikněte pro zrušení změn v písmu."
 
-#: ../src/generic/fontdlgg.cpp:472 ../src/generic/fontdlgg.cpp:491
+#: ../src/generic/fontdlgg.cpp:468 ../src/generic/fontdlgg.cpp:487
 msgid "Click to cancel the font selection."
 msgstr "Klikněte pro zrušení výběru písma."
 
-#: ../src/osx/carbon/fontdlg.cpp:384 ../src/osx/carbon/fontdlg.cpp:386
+#: ../src/osx/carbon/fontdlg.cpp:381 ../src/osx/carbon/fontdlg.cpp:383
 msgid "Click to change the font colour."
 msgstr "Klikněte pro změnu barvy písma."
 
@@ -2164,37 +2171,37 @@ msgstr "Klikněte pro změnu barvy písma."
 msgid "Click to choose the font for this level."
 msgstr "Klikněte pro zvolení písma pro tuto úroveň."
 
-#: ../src/richtext/richtextstyledlg.cpp:279
-#: ../src/richtext/richtextstyledlg.cpp:281
+#: ../src/richtext/richtextstyledlg.cpp:275
+#: ../src/richtext/richtextstyledlg.cpp:277
 msgid "Click to close this window."
 msgstr "Klikněte pro zavření tohoto okna."
 
-#: ../src/osx/carbon/fontdlg.cpp:410 ../src/osx/carbon/fontdlg.cpp:412
+#: ../src/osx/carbon/fontdlg.cpp:407 ../src/osx/carbon/fontdlg.cpp:409
 msgid "Click to confirm changes to the font."
 msgstr "Klikněte pro potvrzení změn textu."
 
-#: ../src/generic/fontdlgg.cpp:477 ../src/generic/fontdlgg.cpp:479
-#: ../src/generic/fontdlgg.cpp:484 ../src/generic/fontdlgg.cpp:486
+#: ../src/generic/fontdlgg.cpp:473 ../src/generic/fontdlgg.cpp:475
+#: ../src/generic/fontdlgg.cpp:480 ../src/generic/fontdlgg.cpp:482
 msgid "Click to confirm the font selection."
 msgstr "Klikněte pro potvrzení výběru písma."
 
-#: ../src/richtext/richtextstyledlg.cpp:244
-#: ../src/richtext/richtextstyledlg.cpp:246
+#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:242
 msgid "Click to create a new box style."
 msgstr "Klikněte pro vytvoření nového stylu rámečku."
 
-#: ../src/richtext/richtextstyledlg.cpp:226
-#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:224
 msgid "Click to create a new character style."
 msgstr "Klikněte pro vytvoření nového stylu znaků."
 
-#: ../src/richtext/richtextstyledlg.cpp:238
-#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:236
 msgid "Click to create a new list style."
 msgstr "Klikněte pro vytvoření nového stylu seznamu."
 
-#: ../src/richtext/richtextstyledlg.cpp:232
-#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:230
 msgid "Click to create a new paragraph style."
 msgstr "Klikněte pro vytvoření nového stylu odstavce."
 
@@ -2208,8 +2215,8 @@ msgstr "Klikněte pro vytvoření nové pozice tabulátoru."
 msgid "Click to delete all tab positions."
 msgstr "Klikněte pro smazání všech pozicí tabulátorů."
 
-#: ../src/richtext/richtextstyledlg.cpp:270
-#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:268
 msgid "Click to delete the selected style."
 msgstr "Klikněte pro vymazání vybraného stylu."
 
@@ -2218,25 +2225,25 @@ msgstr "Klikněte pro vymazání vybraného stylu."
 msgid "Click to delete the selected tab position."
 msgstr "Klikněte pro smazání pozic vybraných tabulátorů."
 
-#: ../src/richtext/richtextstyledlg.cpp:264
-#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:262
 msgid "Click to edit the selected style."
 msgstr "Klikněte pro úpravu vybraného stylu."
 
-#: ../src/richtext/richtextstyledlg.cpp:258
-#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:256
 msgid "Click to rename the selected style."
 msgstr "Klikněte pro přejmenování vybraného stylu."
 
-#: ../src/generic/dbgrptg.cpp:97 ../src/generic/progdlgg.cpp:759
-#: ../src/richtext/richtextstyledlg.cpp:277
-#: ../src/richtext/richtextsymboldlg.cpp:476 ../src/common/stockitem.cpp:148
-#: ../src/msw/progdlg.cpp:170 ../src/msw/progdlg.cpp:679
-#: ../src/html/helpdlg.cpp:90
+#: ../src/common/stockitem.cpp:145 ../src/generic/dbgrptg.cpp:94
+#: ../src/generic/progdlgg.cpp:781 ../src/msw/progdlg.cpp:211
+#: ../src/msw/progdlg.cpp:946 ../src/html/helpdlg.cpp:87
+#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextstyledlg.cpp:273
 msgid "Close"
 msgstr "Zavřít"
 
-#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:98
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
 msgid "Close All"
 msgstr "Zavřít vše"
 
@@ -2244,66 +2251,66 @@ msgstr "Zavřít vše"
 msgid "Close current document"
 msgstr "Zavřít současný dokument"
 
-#: ../src/generic/logg.cpp:516
+#: ../src/generic/logg.cpp:513
 msgid "Close this window"
 msgstr "Zavřít okno"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6006
+#: ../src/generic/datavgen.cpp:6811
 msgid "Collapse"
 msgstr "Sbalit"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "Color"
 msgstr "Barva"
 
-#: ../src/richtext/richtextformatdlg.cpp:776
+#: ../src/richtext/richtextformatdlg.cpp:768
 msgid "Colour"
 msgstr "Barva"
 
-#: ../src/msw/colordlg.cpp:158
+#: ../src/msw/colordlg.cpp:227
 #, c-format
 msgid "Colour selection dialog failed with error %0lx."
 msgstr "Dialogové okno výběru barvy selhalo s chybou %0lx."
 
-#: ../src/osx/carbon/fontdlg.cpp:380
+#: ../src/osx/carbon/fontdlg.cpp:377
 msgid "Colour:"
 msgstr "Barva:"
 
-#: ../src/generic/datavgen.cpp:6077
+#: ../src/generic/datavgen.cpp:6882
 #, c-format
 msgid "Column %u"
 msgstr "Sloupec %u"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:114
+#: ../src/common/accelcmn.cpp:112
 msgid "Command"
 msgstr "Command"
 
-#: ../src/common/init.cpp:196
+#: ../src/common/init.cpp:193
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
 "ignored."
 msgstr "Argument příkazové řádky %d nelze převést na Unicode a bude ignorován."
 
-#: ../src/msw/fontdlg.cpp:120
+#: ../src/msw/fontdlg.cpp:170
 #, c-format
 msgid "Common dialog failed with error code %0lx."
 msgstr "Dialogové okno selhalo s kódem chyby %0lx."
 
-#: ../src/gtk/window.cpp:4649
+#: ../src/gtk/window.cpp:5653
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
 msgstr ""
 "Skládání není podporováno v tomto systému, povolte ho prosím ve správci oken."
 
-#: ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:1549
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Komprimovaný soubor Nápovědy HTML (*.chm)|*.chm|"
 
-#: ../src/generic/dirctrlg.cpp:444
+#: ../src/generic/dirctrlg.cpp:410
 msgid "Computer"
 msgstr "Počítač"
 
@@ -2312,53 +2319,57 @@ msgstr "Počítač"
 msgid "Config entry name cannot start with '%c'."
 msgstr "Položka konfigurace nesmí začínat na '%c'."
 
-#: ../src/generic/filedlgg.cpp:349 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
 msgid "Confirm"
 msgstr "Potvrdit"
 
-#: ../src/html/htmlwin.cpp:566
+#: ../src/html/htmlwin.cpp:569
 msgid "Connecting..."
 msgstr "Připojuji se..."
 
-#: ../src/html/helpwnd.cpp:475
+#: ../src/html/helpwnd.cpp:473
 msgid "Contents"
 msgstr "Obsah"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:880
+#: ../src/propgrid/advprops.cpp:781
 msgid "ControlDark"
 msgstr "Barva stínu"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:881
+#: ../src/propgrid/advprops.cpp:782
 msgid "ControlLight"
 msgstr "Barva světla"
 
-#: ../src/common/strconv.cpp:2262
+#: ../src/common/strconv.cpp:2208
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Převod do znakové sady '%s' nefunguje."
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "Convert"
 msgstr "Převést"
 
-#: ../src/html/htmlwin.cpp:1079
+#: ../src/html/htmlwin.cpp:1020
 #, c-format
 msgid "Copied to clipboard:\"%s\""
 msgstr "Zkopírováno do schránky: \"%s\""
 
-#: ../src/generic/prntdlgg.cpp:247
+#: ../src/generic/prntdlgg.cpp:240
 msgid "Copies:"
 msgstr "Kopie:"
 
-#: ../src/common/stockitem.cpp:150 ../src/stc/stc_i18n.cpp:18
+#: ../src/common/stockitem.cpp:147 ../src/stc/stc_i18n.cpp:18
 msgid "Copy"
 msgstr "Kopírovat"
 
-#: ../src/common/stockitem.cpp:258
+#: ../src/common/stockitem.cpp:255
 msgid "Copy selection"
 msgstr "Kopírovat výběr"
+
+#: ../src/generic/grid.cpp:5945
+msgid "Copying more than one selected block to clipboard is not supported."
+msgstr ""
 
 #: ../src/richtext/richtextborderspage.cpp:566
 #: ../src/richtext/richtextborderspage.cpp:601
@@ -2369,195 +2380,192 @@ msgstr "Roh"
 msgid "Corner &radius:"
 msgstr "&Zaoblení rohu:"
 
-#: ../src/html/chm.cpp:718
+#: ../src/html/chm.cpp:711
 #, c-format
 msgid "Could not create temporary file '%s'"
 msgstr "Nelze vytvořit dočasný soubor '%s'"
 
-#: ../src/html/chm.cpp:273
+#: ../src/html/chm.cpp:270
 #, c-format
 msgid "Could not extract %s into %s: %s"
 msgstr "Nelze extrahovat %s do %s: %s"
 
-#: ../src/generic/tabg.cpp:1048
+#: ../src/generic/tabg.cpp:1045
 msgid "Could not find tab for id"
 msgstr "Nelze najít záložku pro id"
 
-#: ../src/gtk/notifmsg.cpp:108
-msgid "Could not initalize libnotify."
-msgstr "Nelze zavést libnotify."
-
-#: ../src/html/chm.cpp:444
+#: ../src/html/chm.cpp:437
 #, c-format
 msgid "Could not locate file '%s'."
 msgstr "Nelze nalézt soubor '%s'."
 
-#: ../src/common/filefn.cpp:1403
+#: ../src/msw/graphicsd2d.cpp:604
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/common/filefn.cpp:1291
 msgid "Could not set current working directory"
 msgstr "Nelze nastavit současný pracovní adresář"
 
-#: ../src/common/prntbase.cpp:2015
+#: ../src/common/prntbase.cpp:2037
 msgid "Could not start document preview."
 msgstr "Nelze zobrazit náhled dokumentu."
 
-#: ../src/generic/printps.cpp:178 ../src/msw/printwin.cpp:210
-#: ../src/gtk/print.cpp:1132
+#: ../src/generic/printps.cpp:159 ../src/msw/printwin.cpp:184
+#: ../src/gtk/print.cpp:1129
 msgid "Could not start printing."
 msgstr "Nelze zahájit tisk."
 
-#: ../src/common/wincmn.cpp:2125
+#: ../src/common/wincmn.cpp:2126
 msgid "Could not transfer data to window"
 msgstr "Nelze přenést data do okna"
 
-#: ../src/msw/imaglist.cpp:187 ../src/msw/imaglist.cpp:224
-#: ../src/msw/imaglist.cpp:249 ../src/msw/dragimag.cpp:185
-#: ../src/msw/dragimag.cpp:220
+#: ../src/msw/imaglist.cpp:223 ../src/msw/imaglist.cpp:245
+#: ../src/msw/imaglist.cpp:270 ../src/msw/dragimag.cpp:182
+#: ../src/msw/dragimag.cpp:217
 msgid "Couldn't add an image to the image list."
 msgstr "Nelze přidat obrázek do seznamu obrázků."
 
-#: ../src/osx/glcanvas_osx.cpp:414 ../src/unix/glx11.cpp:558
-#: ../src/msw/glcanvas.cpp:616
+#: ../src/osx/glcanvas_osx.cpp:411 ../src/msw/glcanvas.cpp:631
+#: ../src/unix/glegl.cpp:315 ../src/unix/glx11.cpp:559
 msgid "Couldn't create OpenGL context"
 msgstr "Nelze vytvořit OpenGL kontext"
 
-#: ../src/msw/timer.cpp:134
+#: ../src/msw/timer.cpp:131
 msgid "Couldn't create a timer"
 msgstr "Nelze vytvořit časovač"
 
-#: ../src/osx/carbon/overlay.cpp:122
-msgid "Couldn't create the overlay window"
-msgstr "Nelze vytvořit okno překrytí"
-
-#: ../src/common/translation.cpp:2024
+#: ../src/common/translation.cpp:2074
 msgid "Couldn't enumerate translations"
 msgstr "Nelze vyjmenovat překlady"
 
-#: ../src/common/dynlib.cpp:120
+#: ../src/common/dynlib.cpp:110
 #, c-format
 msgid "Couldn't find symbol '%s' in a dynamic library"
 msgstr "V dynamické knihovně nelze nalézt symbol '%s'"
 
-#: ../src/msw/thread.cpp:915
+#: ../src/msw/thread.cpp:921
 msgid "Couldn't get the current thread pointer"
 msgstr "Nelze získat ukazatel na aktuální vlákno"
 
-#: ../src/osx/carbon/overlay.cpp:129
-msgid "Couldn't init the context on the overlay window"
-msgstr "Nelze inicializovat kontext v okně překrytí"
-
-#: ../src/common/imaggif.cpp:244
+#: ../src/common/imaggif.cpp:241
 msgid "Couldn't initialize GIF hash table."
 msgstr "Nelze zavést hash tabulku GIF."
 
-#: ../src/common/imagpng.cpp:409
+#: ../src/common/imagpng.cpp:437
 msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
 msgstr ""
 "Nelze načíst PNG obrázek - buď je soubor poškozený nebo není dostatek paměti."
 
-#: ../src/unix/sound.cpp:470
+#: ../src/unix/sound.cpp:459
 #, c-format
 msgid "Couldn't load sound data from '%s'."
 msgstr "Nelze načíst zvuková data z '%s'."
 
-#: ../src/msw/dirdlg.cpp:435
+#: ../src/msw/dirdlg.cpp:287
 msgid "Couldn't obtain folder name"
 msgstr "Nelze získat název složky"
 
-#: ../src/unix/sound_sdl.cpp:229
+#: ../src/unix/sound_sdl.cpp:226
 #, c-format
 msgid "Couldn't open audio: %s"
 msgstr "Nelze otevřít zvuk: %s"
 
-#: ../src/msw/ole/dataobj.cpp:377
+#: ../src/msw/ole/dataobj.cpp:385
 #, c-format
 msgid "Couldn't register clipboard format '%s'."
 msgstr "Nelze zaregistrovat formát schránky '%s'."
 
-#: ../src/msw/listctrl.cpp:869
+#: ../src/msw/listctrl.cpp:933
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "Nelze získat informace o položce seznamu %d."
 
-#: ../src/common/imagpng.cpp:498 ../src/common/imagpng.cpp:509
-#: ../src/common/imagpng.cpp:519
+#: ../src/common/imagpng.cpp:511 ../src/common/imagpng.cpp:522
+#: ../src/common/imagpng.cpp:532
 msgid "Couldn't save PNG image."
 msgstr "Nelze uložit PNG obrázek."
 
-#: ../src/msw/thread.cpp:684
+#: ../src/msw/thread.cpp:676
 msgid "Couldn't terminate thread"
 msgstr "Nelze ukončit vlákno"
 
-#: ../src/common/xtistrm.cpp:166
+#: ../src/common/xtistrm.cpp:163
 #, c-format
 msgid "Create Parameter %s not found in declared RTTI Parameters"
 msgstr "Create Parameter %s nebyl nalezen v deklarovaných parametrech RTTI"
 
-#: ../src/generic/dirdlgg.cpp:288
+#: ../src/generic/dirdlgg.cpp:285
 msgid "Create directory"
 msgstr "Vytvořit adresář"
 
-#: ../src/generic/filedlgg.cpp:212 ../src/generic/dirdlgg.cpp:111
+#: ../src/generic/filedlgg.cpp:209 ../src/generic/dirdlgg.cpp:108
 msgid "Create new directory"
 msgstr "Vytvořit nový adresář"
 
-#: ../src/xrc/xmlres.cpp:2460
+#: ../src/common/stockitem.cpp:264
+#, fuzzy
+msgid "Create new document"
+msgstr "Vytvořit nový adresář"
+
+#: ../src/xrc/xmlres.cpp:2515
 #, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Vytvoření %s \"%s\" selhalo."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1758
+#: ../src/propgrid/advprops.cpp:1659
 msgid "Cross"
 msgstr "Křížek"
 
-#: ../src/common/accelcmn.cpp:333
+#: ../src/common/accelcmn.cpp:347
 msgid "Ctrl+"
 msgstr "Ctrl+"
 
-#: ../src/richtext/richtextctrl.cpp:332 ../src/osx/textctrl_osx.cpp:576
-#: ../src/common/stockitem.cpp:151 ../src/msw/textctrl.cpp:2507
+#: ../src/osx/textctrl_osx.cpp:594 ../src/common/stockitem.cpp:148
+#: ../src/msw/textctrl.cpp:2772 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "&Vyjmout"
 
-#: ../src/generic/filectrlg.cpp:940
+#: ../src/generic/filectrlg.cpp:936
 msgid "Current directory:"
 msgstr "Aktuální adresář:"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:896 ../src/propgrid/advprops.cpp:1574
-#: ../src/propgrid/advprops.cpp:1612
+#: ../src/propgrid/advprops.cpp:797 ../src/propgrid/advprops.cpp:1475
+#: ../src/propgrid/advprops.cpp:1518
 msgid "Custom"
 msgstr "Vlastní"
 
-#: ../src/gtk/print.cpp:217
+#: ../src/gtk/print.cpp:211
 msgid "Custom size"
 msgstr "Vlastní velikost"
 
-#: ../src/common/headerctrlcmn.cpp:60
+#: ../src/common/headerctrlcmn.cpp:58
 msgid "Customize Columns"
 msgstr "Přizpůsobit sloupce"
 
-#: ../src/common/stockitem.cpp:151 ../src/stc/stc_i18n.cpp:17
+#: ../src/common/stockitem.cpp:148 ../src/stc/stc_i18n.cpp:17
 msgid "Cut"
 msgstr "Vyjmout"
 
-#: ../src/common/stockitem.cpp:259
+#: ../src/common/stockitem.cpp:256
 msgid "Cut selection"
 msgstr "Vyjmout výběr"
 
-#: ../src/common/fmapbase.cpp:152
+#: ../src/common/fmapbase.cpp:149
 msgid "Cyrillic (ISO-8859-5)"
 msgstr "Cyrilice (ISO-8859-5)"
 
-#: ../src/common/paper.cpp:99
+#: ../src/common/paper.cpp:96
 msgid "D sheet, 22 x 34 in"
 msgstr "D, 22 x 34 palců"
 
-#: ../src/msw/dde.cpp:703
+#: ../src/msw/dde.cpp:698
 msgid "DDE poke request failed"
 msgstr "Požadavek na šťouchnutí DDE selhal"
 
-#: ../src/common/imagbmp.cpp:1169
+#: ../src/common/imagbmp.cpp:1181
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr "DIB hlavička: Kódování neodpovídá bitové hloubce."
 
@@ -2577,7 +2585,7 @@ msgstr "DIB hlavička: Neznámá bitová hloubka."
 msgid "DIB Header: Unknown encoding in file."
 msgstr "DIB hlavička: Neznámé kódování."
 
-#: ../src/common/paper.cpp:121
+#: ../src/common/paper.cpp:118
 msgid "DL Envelope, 110 x 220 mm"
 msgstr "Obálka DL, 110 x 220 mm"
 
@@ -2585,53 +2593,53 @@ msgstr "Obálka DL, 110 x 220 mm"
 msgid "Dashed"
 msgstr "Čárkovaný"
 
-#: ../src/generic/dbgrptg.cpp:300
+#: ../src/generic/dbgrptg.cpp:301
 #, c-format
 msgid "Debug report \"%s\""
 msgstr "Protokol ladění \"%s\""
 
-#: ../src/common/debugrpt.cpp:210
+#: ../src/common/debugrpt.cpp:211
 msgid "Debug report couldn't be created."
 msgstr "Protokol ladění nemohl být vytvořen."
 
-#: ../src/common/debugrpt.cpp:553
+#: ../src/common/debugrpt.cpp:554
 msgid "Debug report generation has failed."
 msgstr "Vytváření protokolu ladění selhalo."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:84
+#: ../src/common/accelcmn.cpp:81
 msgid "Decimal"
 msgstr "Desetinná čárka"
 
-#: ../src/generic/fontdlgg.cpp:323
+#: ../src/generic/fontdlgg.cpp:319
 msgid "Decorative"
 msgstr "Ozdobné"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1752
+#: ../src/propgrid/advprops.cpp:1653
 msgid "Default"
 msgstr "Výchozí"
 
-#: ../src/common/fmapbase.cpp:796
+#: ../src/common/fmapbase.cpp:792
 msgid "Default encoding"
 msgstr "Výchozí znaková sada"
 
-#: ../src/dfb/fontmgr.cpp:180
+#: ../src/dfb/fontmgr.cpp:177
 msgid "Default font"
 msgstr "Výchozí typ písma"
 
-#: ../src/generic/prntdlgg.cpp:510
+#: ../src/generic/prntdlgg.cpp:503
 msgid "Default printer"
 msgstr "Výchozí tiskárna"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:51
+#: ../src/common/accelcmn.cpp:48
 msgid "Del"
 msgstr "Del"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextbuffer.cpp:8221 ../src/common/stockitem.cpp:152
-#: ../src/common/accelcmn.cpp:50 ../src/stc/stc_i18n.cpp:20
+#: ../src/common/stockitem.cpp:149 ../src/common/accelcmn.cpp:47
+#: ../src/richtext/richtextbuffer.cpp:8217 ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Delete"
 
@@ -2639,68 +2647,68 @@ msgstr "Delete"
 msgid "Delete A&ll"
 msgstr "Smazat &vše"
 
-#: ../src/richtext/richtextbuffer.cpp:11341
+#: ../src/richtext/richtextbuffer.cpp:11340
 msgid "Delete Column"
 msgstr "Smazat sloupec"
 
-#: ../src/richtext/richtextbuffer.cpp:11291
+#: ../src/richtext/richtextbuffer.cpp:11290
 msgid "Delete Row"
 msgstr "Smazat řádek"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 msgid "Delete Style"
 msgstr "Smazat styl"
 
-#: ../src/richtext/richtextctrl.cpp:1345 ../src/richtext/richtextctrl.cpp:1584
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
 msgid "Delete Text"
 msgstr "Smazat text"
 
-#: ../src/generic/editlbox.cpp:170
+#: ../src/generic/editlbox.cpp:147
 msgid "Delete item"
 msgstr "Odstranit položku."
 
-#: ../src/common/stockitem.cpp:260
+#: ../src/common/stockitem.cpp:257
 msgid "Delete selection"
 msgstr "Smazat výběr"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 #, c-format
 msgid "Delete style %s?"
 msgstr "Odstranit styl %s?"
 
-#: ../src/unix/snglinst.cpp:301
+#: ../src/unix/snglinst.cpp:298
 #, c-format
 msgid "Deleted stale lock file '%s'."
 msgstr "Smazán starý zámkový soubor '%s'."
 
-#: ../src/common/secretstore.cpp:220
-#, c-format
-msgid "Deleting password for \"%s/%s\" failed: %s."
+#: ../src/common/secretstore.cpp:234
+#, fuzzy, c-format
+msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Nelze smazat heslo pro \"%s/%s\": %s."
 
-#: ../src/common/module.cpp:124
+#: ../src/common/module.cpp:121
 #, c-format
 msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
 msgstr "Závislost \"%s\" modulu \"%s\" neexistuje."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "Descending"
 msgstr "Sestupně"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:526 ../src/propgrid/advprops.cpp:882
+#: ../src/generic/dirctrlg.cpp:492 ../src/propgrid/advprops.cpp:783
 msgid "Desktop"
 msgstr "Plocha"
 
-#: ../src/generic/aboutdlgg.cpp:70
+#: ../src/generic/aboutdlgg.cpp:67
 msgid "Developed by "
 msgstr "Vyvinuto "
 
-#: ../src/generic/aboutdlgg.cpp:176
+#: ../src/generic/aboutdlgg.cpp:173
 msgid "Developers"
 msgstr "Vývojáři"
 
-#: ../src/msw/dialup.cpp:374
+#: ../src/msw/dialup.cpp:368
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -2708,11 +2716,11 @@ msgstr ""
 "Funkce vytáčeného připojení nejsou dostupné, protože Služba vzdáleného "
 "přístupu (RAS) není nainstalována. Prosím, nainstalujte ji."
 
-#: ../src/generic/tipdlg.cpp:211
+#: ../src/generic/tipdlg.cpp:208
 msgid "Did you know..."
 msgstr "Víte, že..."
 
-#: ../src/dfb/wrapdfb.cpp:63
+#: ../src/dfb/wrapdfb.cpp:60
 #, c-format
 msgid "DirectFB error %d occurred."
 msgstr "Vyskytla se chyba DirectFB %d."
@@ -2721,29 +2729,29 @@ msgstr "Vyskytla se chyba DirectFB %d."
 msgid "Directories"
 msgstr "Adresáře"
 
-#: ../src/common/filefn.cpp:1183
+#: ../src/common/filefn.cpp:1071
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Nelze vytvořit adresář '%s'"
 
-#: ../src/common/filefn.cpp:1197
+#: ../src/common/filefn.cpp:1085
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "Nelze smazat adresář '%s'"
 
-#: ../src/generic/dirdlgg.cpp:204
+#: ../src/generic/dirdlgg.cpp:201
 msgid "Directory does not exist"
 msgstr "Adresář neexistuje"
 
-#: ../src/generic/filectrlg.cpp:1399
+#: ../src/generic/filectrlg.cpp:1388
 msgid "Directory doesn't exist."
 msgstr "Adresář neexistuje."
 
-#: ../src/common/docview.cpp:457
+#: ../src/common/docview.cpp:450
 msgid "Discard changes and reload the last saved version?"
 msgstr "Zahodit změny a znovu nahrát poslední uloženou verzi?"
 
-#: ../src/html/helpwnd.cpp:502
+#: ../src/html/helpwnd.cpp:500
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -2751,45 +2759,45 @@ msgstr ""
 "Zobrazí všechny položky rejstříku, které obsahují daný podřetězec. "
 "Nerozlišuje velká a malá písmena."
 
-#: ../src/html/helpwnd.cpp:679
+#: ../src/html/helpwnd.cpp:677
 msgid "Display options dialog"
 msgstr "Zobrazí dialogové okno s nastaveními"
 
-#: ../src/html/helpwnd.cpp:322
+#: ../src/html/helpwnd.cpp:320
 msgid "Displays help as you browse the books on the left."
 msgstr "Při procházení knih zobrazí vlevo nápovědu."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:85
+#: ../src/common/accelcmn.cpp:83
 msgid "Divide"
 msgstr "Lomítko"
 
-#: ../src/common/docview.cpp:533
+#: ../src/common/docview.cpp:526
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Chcete uložit změny v %s?"
 
-#: ../src/common/prntbase.cpp:542
+#: ../src/common/prntbase.cpp:537
 msgid "Document:"
 msgstr "Dokument:"
 
-#: ../src/generic/aboutdlgg.cpp:73
+#: ../src/generic/aboutdlgg.cpp:70
 msgid "Documentation by "
 msgstr "Dokumentace "
 
-#: ../src/generic/aboutdlgg.cpp:180
+#: ../src/generic/aboutdlgg.cpp:177
 msgid "Documentation writers"
 msgstr "Autoři dokumentace"
 
-#: ../src/common/sizer.cpp:2799
+#: ../src/common/sizer.cpp:2916
 msgid "Don't Save"
 msgstr "Neukládat"
 
-#: ../src/html/htmlwin.cpp:633
+#: ../src/html/htmlwin.cpp:643
 msgid "Done"
 msgstr "Hotovo"
 
-#: ../src/generic/progdlgg.cpp:448 ../src/msw/progdlg.cpp:407
+#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
 msgid "Done."
 msgstr "Hotovo."
 
@@ -2801,42 +2809,42 @@ msgstr "Tečkovaný"
 msgid "Double"
 msgstr "Dvojitý"
 
-#: ../src/common/paper.cpp:176
+#: ../src/common/paper.cpp:173
 msgid "Double Japanese Postcard Rotated 148 x 200 mm"
 msgstr "Japonská dvojitá pohlednice na šířku 148 x 200 mm"
 
-#: ../src/common/xtixml.cpp:273
+#: ../src/common/xtixml.cpp:269
 #, c-format
 msgid "Doubly used id : %d"
 msgstr "Dvojitě použité id : %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:153
-#: ../src/common/accelcmn.cpp:64
+#: ../src/common/stockitem.cpp:150 ../src/common/accelcmn.cpp:61
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Down"
 msgstr "Dolů"
 
-#: ../src/richtext/richtextctrl.cpp:865
+#: ../src/richtext/richtextctrl.cpp:864
 msgid "Drag"
 msgstr "Táhnout"
 
-#: ../src/common/paper.cpp:100
+#: ../src/common/paper.cpp:97
 msgid "E sheet, 34 x 44 in"
 msgstr "E, 34 x 44 palců"
 
-#: ../src/unix/fswatcher_inotify.cpp:561
+#: ../src/unix/fswatcher_inotify.cpp:558
 msgid "EOF while reading from inotify descriptor"
 msgstr "Konec souboru při čtení z popisovače inotify"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "Edit"
 msgstr "Upravit"
 
-#: ../src/generic/editlbox.cpp:168
+#: ../src/generic/editlbox.cpp:131
 msgid "Edit item"
 msgstr "Upravit položku"
 
-#: ../include/wx/generic/progdlgg.h:84
+#: ../include/wx/generic/progdlgg.h:85
 msgid "Elapsed time:"
 msgstr "Uplynulý čas:"
 
@@ -2903,62 +2911,62 @@ msgid "Enables the shadow spread."
 msgstr "Povolí rozprostření stínu."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:66
+#: ../src/common/accelcmn.cpp:63
 msgid "End"
 msgstr "Konec"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:55
+#: ../src/common/accelcmn.cpp:52
 msgid "Enter"
 msgstr "Enter"
 
-#: ../src/richtext/richtextstyledlg.cpp:934
+#: ../src/richtext/richtextstyledlg.cpp:930
 msgid "Enter a box style name"
 msgstr "Zadejte název stylu rámečku"
 
-#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:602
 msgid "Enter a character style name"
 msgstr "Zadejte název stylu znaku"
 
-#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:816
 msgid "Enter a list style name"
 msgstr "Zadejte název stylu odrážek"
 
-#: ../src/richtext/richtextstyledlg.cpp:893
+#: ../src/richtext/richtextstyledlg.cpp:889
 msgid "Enter a new style name"
 msgstr "Zadejte nový název stylu"
 
-#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:650
 msgid "Enter a paragraph style name"
 msgstr "Zadejte název stylu odstavce"
 
-#: ../src/generic/dbgrptg.cpp:174
+#: ../src/generic/dbgrptg.cpp:171
 #, c-format
 msgid "Enter command to open file \"%s\":"
 msgstr "Zadejte příkaz pro otevření souboru \"%s\":"
 
-#: ../src/generic/helpext.cpp:459
+#: ../src/generic/helpext.cpp:457
 msgid "Entries found"
 msgstr "Nalezené položky"
 
-#: ../src/common/paper.cpp:142
+#: ../src/common/paper.cpp:139
 msgid "Envelope Invite 220 x 220 mm"
 msgstr "Obálka pozvánka 220 x 220 mm"
 
-#: ../src/common/config.cpp:469
+#: ../src/common/config.cpp:465
 #, c-format
 msgid ""
 "Environment variables expansion failed: missing '%c' at position %u in '%s'."
 msgstr ""
 "Chyba během expanze proměnných prostředí: chybí '%c' na pozici %u v '%s'."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/generic/dirctrlg.cpp:570
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/dirctrlg.cpp:599
-#: ../src/generic/dirdlgg.cpp:323 ../src/generic/filectrlg.cpp:642
-#: ../src/generic/filectrlg.cpp:756 ../src/generic/filectrlg.cpp:770
-#: ../src/generic/filectrlg.cpp:786 ../src/generic/filectrlg.cpp:1368
-#: ../src/generic/filectrlg.cpp:1399 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/gtk1/fontdlg.cpp:74 ../src/generic/dirctrlg.cpp:536
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/dirctrlg.cpp:565
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1357 ../src/generic/filectrlg.cpp:1388
+#: ../src/generic/filedlgg.cpp:354 ../src/generic/dirdlgg.cpp:320
+#: ../src/gtk/filedlg.cpp:74
 msgid "Error"
 msgstr "Chyba"
 
@@ -2966,232 +2974,253 @@ msgstr "Chyba"
 msgid "Error closing epoll descriptor"
 msgstr "Chyba při zavírání epoll popisovače"
 
-#: ../src/unix/fswatcher_kqueue.cpp:114
+#: ../src/unix/fswatcher_kqueue.cpp:131
 msgid "Error closing kqueue instance"
 msgstr "Chyba při zavírání instance kqueue"
 
-#: ../src/common/filefn.cpp:1049
+#: ../src/common/filefn.cpp:938
 #, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Selhalo kopírování souboru '%s' do '%s'."
 
-#: ../src/generic/dirdlgg.cpp:222
+#: ../src/generic/dirdlgg.cpp:219
 msgid "Error creating directory"
 msgstr "Chyba při vytváření adresáře"
 
-#: ../src/common/imagbmp.cpp:1181
+#: ../src/common/imagbmp.cpp:1193
 msgid "Error in reading image DIB."
 msgstr "Chyba při čtení obrázku DIB."
 
-#: ../src/propgrid/propgrid.cpp:6696
+#: ../src/propgrid/propgrid.cpp:6665
 #, c-format
 msgid "Error in resource: %s"
 msgstr "Chyba ve zdroji: %s"
 
-#: ../src/common/fileconf.cpp:422
+#: ../src/common/fileconf.cpp:421
 msgid "Error reading config options."
 msgstr "Chyba při čtení voleb nastavení."
+
+#: ../src/msw/webview_ie.cpp:1057 ../src/msw/webview_edge.cpp:850
+#: ../src/gtk/webview_webkit2.cpp:1262 ../src/osx/webview_webkit.mm:383
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
 
 #: ../src/common/fileconf.cpp:1029
 msgid "Error saving user configuration data."
 msgstr "Chyba při ukládání dat uživatelského nastavení."
 
-#: ../src/gtk/print.cpp:722
+#: ../src/gtk/print.cpp:720
 msgid "Error while printing: "
 msgstr "Chyba při tisku: "
 
-#: ../src/common/log.cpp:219
+#: ../src/common/log.cpp:237
 msgid "Error: "
 msgstr "Chyba: "
 
+#: ../src/common/webrequest.cpp:98
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Chyba: "
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:69
+#: ../src/common/accelcmn.cpp:66
 msgid "Esc"
 msgstr "Esc"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:70
+#: ../src/common/accelcmn.cpp:67
 msgid "Escape"
 msgstr "Escape"
 
-#: ../src/common/fmapbase.cpp:150
+#: ../src/common/fmapbase.cpp:147
 msgid "Esperanto (ISO-8859-3)"
 msgstr "Esperanto (ISO-8859-3)"
 
-#: ../include/wx/generic/progdlgg.h:85
+#: ../include/wx/generic/progdlgg.h:86
 msgid "Estimated time:"
 msgstr "Odhadovaný čas:"
 
-#: ../src/generic/dbgrptg.cpp:234
+#: ../src/generic/dbgrptg.cpp:231
 msgid "Executable files (*.exe)|*.exe|"
 msgstr "Spustitelné soubory (*.exe)|*.exe|"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:155 ../src/common/accelcmn.cpp:78
+#: ../src/common/stockitem.cpp:152 ../src/common/accelcmn.cpp:75
 msgid "Execute"
 msgstr "Spustit"
 
-#: ../src/msw/utilsexc.cpp:876
+#: ../src/msw/utilsexc.cpp:873
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Chyba při volání příkazu '%s'"
 
-#: ../src/common/paper.cpp:105
+#: ../src/common/paper.cpp:102
 msgid "Executive, 7 1/4 x 10 1/2 in"
 msgstr "Executive, 7 1/4 x 10 1/2 palce"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6009
+#: ../src/generic/datavgen.cpp:6814
 msgid "Expand"
 msgstr "Rozbalit"
 
-#: ../src/msw/registry.cpp:1240
+#: ../src/msw/registry.cpp:1228
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
 msgstr "Exportuji klíč registru: soubor \"%s\" již existuje a nebude přepsán."
 
-#: ../src/common/fmapbase.cpp:195
+#: ../src/common/fmapbase.cpp:192
 msgid "Extended Unix Codepage for Japanese (EUC-JP)"
 msgstr "Rozšířená unixová kódová stránka pro Japonštinu (EUC-JP)"
 
-#: ../src/html/chm.cpp:725
+#: ../src/html/chm.cpp:718
 #, c-format
 msgid "Extraction of '%s' into '%s' failed."
 msgstr "Extrakce '%s' do '%s' selhala."
 
-#: ../src/common/accelcmn.cpp:249 ../src/common/accelcmn.cpp:344
+#: ../src/common/accelcmn.cpp:259 ../src/common/accelcmn.cpp:358
 msgid "F"
 msgstr "F"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:672
+#: ../src/propgrid/advprops.cpp:582
 msgid "Face Name"
 msgstr "Jméno písma"
 
-#: ../src/unix/snglinst.cpp:269
+#: ../src/unix/snglinst.cpp:266
 msgid "Failed to access lock file."
 msgstr "Nelze přistoupit k zámkovému souboru."
+
+#: ../src/gtk/font.cpp:572
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Nelze načíst dokument ze souboru \"%s\"."
 
 #: ../src/unix/epolldispatcher.cpp:116
 #, c-format
 msgid "Failed to add descriptor %d to epoll descriptor %d"
 msgstr "Nelze přidat popisovač %d do epoll popisovače %d"
 
-#: ../src/msw/dib.cpp:489
+#: ../src/msw/dib.cpp:535
 #, c-format
 msgid "Failed to allocate %luKb of memory for bitmap data."
 msgstr "Nelze přidělit %luKb paměti pro bitmapová data."
 
-#: ../src/common/glcmn.cpp:115
+#: ../src/common/glcmn.cpp:112
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Nelze přidělit barvu pro OpenGL"
 
-#: ../src/unix/displayx11.cpp:236
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Nelze přidělit barvu pro OpenGL"
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Nelze přidělit barvu pro OpenGL"
+
+#: ../include/wx/unix/private/displayx11.h:89
 msgid "Failed to change video mode"
 msgstr "Nelze změnit režim obrazu"
 
-#: ../src/common/image.cpp:3277
+#: ../src/common/image.cpp:3396
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Nelze zkontrolovat formát souboru s obrázkem \"%s\"."
 
-#: ../src/common/debugrpt.cpp:239
+#: ../src/common/debugrpt.cpp:240
 #, c-format
 msgid "Failed to clean up debug report directory \"%s\""
 msgstr "Nelze vyčistit adresář s protokoly ladění \"%s\""
 
-#: ../src/common/filename.cpp:192
+#: ../src/common/filename.cpp:189
 msgid "Failed to close file handle"
 msgstr "Nelze uzavřít soubor"
 
-#: ../src/unix/snglinst.cpp:340
+#: ../src/unix/snglinst.cpp:337
 #, c-format
 msgid "Failed to close lock file '%s'"
 msgstr "Nelze uzavřít zámkový soubor '%s'"
 
-#: ../src/msw/clipbrd.cpp:112
+#: ../src/msw/clipbrd.cpp:110
 msgid "Failed to close the clipboard."
 msgstr "Nelze uzavřít schránku."
 
-#: ../src/x11/utils.cpp:208
+#: ../src/x11/utils.cpp:170
 #, c-format
 msgid "Failed to close the display \"%s\""
 msgstr "Nelze uzavřít zobrazení \"%s\""
 
-#: ../src/msw/dialup.cpp:797
+#: ../src/msw/dialup.cpp:791
 msgid "Failed to connect: missing username/password."
 msgstr "Nepodařilo se připojit: chybí uživatelské jméno nebo heslo."
 
-#: ../src/msw/dialup.cpp:743
+#: ../src/msw/dialup.cpp:737
 msgid "Failed to connect: no ISP to dial."
 msgstr "Nelze se připojit: žádný ISP."
 
-#: ../src/common/textfile.cpp:203
-#, c-format
-msgid "Failed to convert file \"%s\" to Unicode."
-msgstr "Nelze převést soubor \"%s\" na Unicode."
-
-#: ../src/generic/logg.cpp:956
+#: ../src/generic/logg.cpp:953
 msgid "Failed to copy dialog contents to the clipboard."
 msgstr "Nelze zkopírovat obsah dialogového okna do schránky."
 
-#: ../src/msw/registry.cpp:692
+#: ../src/msw/registry.cpp:681
 #, c-format
 msgid "Failed to copy registry value '%s'"
 msgstr "Nelze zkopírovat hodnotu registru '%s'"
 
-#: ../src/msw/registry.cpp:701
+#: ../src/msw/registry.cpp:690
 #, c-format
 msgid "Failed to copy the contents of registry key '%s' to '%s'."
 msgstr "Nelze zkopírovat obsah klíče registru '%s' do '%s'."
 
-#: ../src/common/filefn.cpp:1015
+#: ../src/common/filefn.cpp:904
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Selhalo kopírování souboru '%s' do '%s'"
 
-#: ../src/msw/registry.cpp:679
+#: ../src/msw/registry.cpp:668
 #, c-format
 msgid "Failed to copy the registry subkey '%s' to '%s'."
 msgstr "Nelze zkopírovat podklíč registru '%s' do '%s'."
 
-#: ../src/msw/dde.cpp:1070
+#: ../src/msw/dde.cpp:1134
 msgid "Failed to create DDE string"
 msgstr "Nelze vytvořit DDE řetězec"
 
-#: ../src/msw/mdi.cpp:616
+#: ../src/msw/mdi.cpp:621
 msgid "Failed to create MDI parent frame."
 msgstr "Nelze vytvořit nadřazené MDI okno."
 
-#: ../src/common/filename.cpp:1027
+#: ../src/common/filename.cpp:1024
 msgid "Failed to create a temporary file name"
 msgstr "Nelze vytvořit jméno dočasného souboru"
 
-#: ../src/msw/utilsexc.cpp:228
+#: ../src/msw/utilsexc.cpp:225
 msgid "Failed to create an anonymous pipe"
 msgstr "Nelze vytvořit anonymní rouru"
 
-#: ../src/msw/ole/automtn.cpp:522
+#: ../src/msw/ole/automtn.cpp:513
 #, c-format
 msgid "Failed to create an instance of \"%s\""
 msgstr "Nelze vytvořit instanci \"%s\""
 
-#: ../src/msw/dde.cpp:437
+#: ../src/msw/dde.cpp:432
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "Nelze navázat spojení se serverem '%s' na téma '%s'"
 
-#: ../src/msw/cursor.cpp:204
+#: ../src/msw/cursor.cpp:195
 msgid "Failed to create cursor."
 msgstr "Nelze vytvořit kurzor."
 
-#: ../src/common/debugrpt.cpp:209
+#: ../src/common/debugrpt.cpp:210
 #, c-format
 msgid "Failed to create directory \"%s\""
 msgstr "Nelze vytvořit adresář \"%s\""
 
-#: ../src/generic/dirdlgg.cpp:220
+#: ../src/generic/dirdlgg.cpp:217
 #, c-format
 msgid ""
 "Failed to create directory '%s'\n"
@@ -3204,114 +3233,133 @@ msgstr ""
 msgid "Failed to create epoll descriptor"
 msgstr "Nelze vytvořit epoll popisovače"
 
-#: ../src/msw/mimetype.cpp:238
+#: ../src/gtk/font.cpp:562
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "Nelze aktualizovat soubor uživatelského nastavení."
+
+#: ../src/msw/mimetype.cpp:235
 #, c-format
 msgid "Failed to create registry entry for '%s' files."
 msgstr "Nelze vytvořit klíč registru pro soubory '%s'."
 
-#: ../src/msw/fdrepdlg.cpp:409
+#: ../src/msw/fdrepdlg.cpp:408
 #, c-format
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr "Nelze vytvořit standardní dialogové okno najít/nahradit (kód chyby %d)"
 
-#: ../src/unix/wakeuppipe.cpp:52
+#: ../src/unix/wakeuppipe.cpp:49
 msgid "Failed to create wake up pipe used by event loop."
 msgstr "Nelze vytvořit probouzecí rouru používanou smyčkou událostí."
 
-#: ../src/html/winpars.cpp:730
+#: ../src/html/winpars.cpp:727
 #, c-format
 msgid "Failed to display HTML document in %s encoding"
 msgstr "Nelze zobrazit HTML dokument v kódování %s"
 
-#: ../src/msw/clipbrd.cpp:124
+#: ../src/msw/clipbrd.cpp:122
 msgid "Failed to empty the clipboard."
 msgstr "Nelze vyprázdnit schránku."
 
-#: ../src/unix/displayx11.cpp:212
+#: ../include/wx/unix/private/displayx11.h:65
 msgid "Failed to enumerate video modes"
 msgstr "Nelze vyjmenovat zobrazovací režimy"
 
-#: ../src/msw/dde.cpp:722
+#: ../src/msw/dde.cpp:717
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "Nelze navázat 'advise loop' s DDE serverem"
 
-#: ../src/msw/dialup.cpp:629 ../src/msw/dialup.cpp:863
+#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Nelze navázat vytáčené spojení: %s"
 
-#: ../src/unix/utilsunx.cpp:611
+#: ../src/unix/utilsunx.cpp:613
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Nelze spustit '%s'\n"
 
-#: ../src/common/debugrpt.cpp:720
+#: ../src/common/debugrpt.cpp:730
 msgid "Failed to execute curl, please install it in PATH."
 msgstr "Nelze spustit curl, instalujte ho, prosím, do PATH."
 
-#: ../src/msw/ole/automtn.cpp:505
+#: ../src/msw/ole/automtn.cpp:496
 #, c-format
 msgid "Failed to find CLSID of \"%s\""
 msgstr "Nelze najít CLSID \"%s\""
 
-#: ../src/common/regex.cpp:431 ../src/common/regex.cpp:479
+#: ../src/common/regex.cpp:428 ../src/common/regex.cpp:476
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "Nelze nalézt shodu pro regulární výraz: %s"
 
-#: ../src/msw/dialup.cpp:695
+#: ../src/msw/webview_ie.cpp:978
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:689
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Nepodařilo se získat jména ISP: %s"
 
-#: ../src/msw/ole/automtn.cpp:574
+#: ../src/msw/ole/automtn.cpp:565
 #, c-format
 msgid "Failed to get OLE automation interface for \"%s\""
 msgstr "Nelze získat rozhraní automatizace OLE pro \"%s\""
 
-#: ../src/msw/clipbrd.cpp:711
+#: ../src/msw/clipbrd.cpp:731
 msgid "Failed to get data from the clipboard"
 msgstr "Nelze získat data ze schránky"
 
-#: ../src/common/time.cpp:223
+#: ../src/common/time.cpp:216
 msgid "Failed to get the local system time"
 msgstr "Nelze zjistit místní systémový čas"
 
-#: ../src/common/filefn.cpp:1345
+#: ../src/common/filefn.cpp:1233
 msgid "Failed to get the working directory"
 msgstr "Nelze zjistit aktuální pracovní adresář"
 
-#: ../src/univ/theme.cpp:114
+#: ../src/univ/theme.cpp:111
 msgid "Failed to initialize GUI: no built-in themes found."
 msgstr "Nelze zavést GUI: nebyly nalezeny žádné zabudované vzhledy."
 
-#: ../src/msw/helpchm.cpp:63
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:60
 msgid "Failed to initialize MS HTML Help."
 msgstr "Nelze zavést MS HTML Help ."
 
-#: ../src/msw/glcanvas.cpp:1381
+#: ../src/msw/glcanvas.cpp:1391
 msgid "Failed to initialize OpenGL"
 msgstr "Nelze zavést OpenGL"
 
-#: ../src/msw/dialup.cpp:858
+#: ../src/msw/dialup.cpp:852
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Nelze zahájit vytáčené spojení: %s"
 
-#: ../src/gtk/textctrl.cpp:1128
+#: ../src/gtk/textctrl.cpp:1209
 msgid "Failed to insert text in the control."
 msgstr "Do textového pole nelze vložit text."
 
-#: ../src/unix/snglinst.cpp:241
+#: ../src/unix/snglinst.cpp:238
 #, c-format
 msgid "Failed to inspect the lock file '%s'"
 msgstr "Nelze prověřit zámkový soubor '%s'"
 
-#: ../src/unix/appunix.cpp:182
+#: ../src/unix/appunix.cpp:179
 msgid "Failed to install signal handler"
 msgstr "Nelze instalovat obslužnou rutinu signálu"
 
-#: ../src/unix/threadpsx.cpp:1167
+#: ../src/unix/threadpsx.cpp:1216
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -3319,71 +3367,71 @@ msgstr ""
 "Nelze připojit vlákno, zjištěna možná chybná alokace paměti - restartujte "
 "prosím program"
 
-#: ../src/msw/utils.cpp:629
+#: ../src/msw/utils.cpp:619
 #, c-format
 msgid "Failed to kill process %d"
 msgstr "Nepodařilo se vynuceně ukončit proces %d"
 
-#: ../src/common/image.cpp:2500
+#: ../src/common/image.cpp:2595
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Nelze načíst bitmapu \"%s\" ze zdrojů."
 
-#: ../src/common/image.cpp:2509
+#: ../src/common/image.cpp:2604
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Nelze načíst ikonu \"%s\" ze zdrojů."
 
-#: ../src/common/iconbndl.cpp:225
+#: ../src/common/iconbndl.cpp:224
 #, c-format
 msgid "Failed to load icons from resource '%s'."
 msgstr "Nelze načíst ikonu ze zdroje '%s' ."
 
-#: ../src/common/iconbndl.cpp:200
+#: ../src/common/iconbndl.cpp:198
 #, c-format
 msgid "Failed to load image %%d from file '%s'."
 msgstr "Selhalo načítání obrázku %%d ze souboru '%s'."
 
-#: ../src/common/iconbndl.cpp:208
+#: ../src/common/iconbndl.cpp:206
 #, c-format
 msgid "Failed to load image %d from stream."
 msgstr "Nelze načíst obrázek %d z proudu."
 
-#: ../src/common/image.cpp:2587 ../src/common/image.cpp:2606
+#: ../src/common/image.cpp:2682 ../src/common/image.cpp:2701
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Nelze načíst obrázek ze souboru \"%s\"."
 
-#: ../src/msw/enhmeta.cpp:97
+#: ../src/msw/enhmeta.cpp:94
 #, c-format
 msgid "Failed to load metafile from file \"%s\"."
 msgstr "Nelze načíst metasoubor ze souboru \"%s\"."
 
-#: ../src/msw/volume.cpp:327
+#: ../src/msw/volume.cpp:335
 msgid "Failed to load mpr.dll."
 msgstr "Nelze načíst knihovnu mpr.dll."
 
-#: ../src/msw/utils.cpp:953
+#: ../src/msw/utils.cpp:943
 #, c-format
 msgid "Failed to load resource \"%s\"."
 msgstr "Nelze načíst zdroj \"%s\"."
 
-#: ../src/common/dynlib.cpp:92
+#: ../src/common/dynlib.cpp:86
 #, c-format
 msgid "Failed to load shared library '%s'"
 msgstr "Nelze načíst sdílenou knihovnu '%s'"
 
-#: ../src/osx/core/sound.cpp:145
+#: ../src/osx/core/sound.cpp:143
 #, c-format
 msgid "Failed to load sound from \"%s\" (error %d)."
 msgstr "Nelze načíst zvuk z \"%s\" (chyba %d)."
 
-#: ../src/msw/utils.cpp:960
+#: ../src/msw/utils.cpp:950
 #, c-format
 msgid "Failed to lock resource \"%s\"."
 msgstr "Nelze uzamknout zdroj \"%s\"."
 
-#: ../src/unix/snglinst.cpp:198
+#: ../src/unix/snglinst.cpp:195
 #, c-format
 msgid "Failed to lock the lock file '%s'"
 msgstr "Nelze uzamknout zámkový soubor '%s'"
@@ -3393,33 +3441,38 @@ msgstr "Nelze uzamknout zámkový soubor '%s'"
 msgid "Failed to modify descriptor %d in epoll descriptor %d"
 msgstr "Nelze změnit popisovač %d v epoll popisovači %d"
 
-#: ../src/common/filename.cpp:2575
+#: ../src/common/filename.cpp:2658
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Nelze změnit hodnoty časů souboru '%s'"
 
-#: ../src/common/selectdispatcher.cpp:258
+#: ../src/common/selectdispatcher.cpp:255
 msgid "Failed to monitor I/O channels"
 msgstr "Nelze monitorovat I/O kanály"
 
-#: ../src/common/filename.cpp:175
+#: ../src/common/filename.cpp:172
 #, c-format
 msgid "Failed to open '%s' for reading"
 msgstr "Nelze otevřít '%s' pro čtení"
 
-#: ../src/common/filename.cpp:180
+#: ../src/common/filename.cpp:177
 #, c-format
 msgid "Failed to open '%s' for writing"
 msgstr "Nelze otevřít '%s' pro zápis"
 
-#: ../src/html/chm.cpp:141
+#: ../src/html/chm.cpp:138
 #, c-format
 msgid "Failed to open CHM archive '%s'."
 msgstr "Nelze otevřít CHM archiv '%s'."
 
-#: ../src/common/utilscmn.cpp:1126
+#: ../src/common/utilscmn.cpp:1140
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Nelze otevřít URL \"%s\"' ve výchozím prohlížeči."
+
+#: ../src/common/hyperlnkcmn.cpp:133
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Nelze otevřít URL \"%s\"' ve výchozím prohlížeči."
 
 #: ../include/wx/msw/private/fswatcher.h:92
@@ -3427,93 +3480,103 @@ msgstr "Nelze otevřít URL \"%s\"' ve výchozím prohlížeči."
 msgid "Failed to open directory \"%s\" for monitoring."
 msgstr "Nelze otevřít adresář \"%s\" pro sledování."
 
-#: ../src/x11/utils.cpp:227
+#: ../src/x11/utils.cpp:189
 #, c-format
 msgid "Failed to open display \"%s\"."
 msgstr "Nelze otevřít zobrazení \"%s\"."
 
-#: ../src/common/filename.cpp:1062
+#: ../src/common/filename.cpp:1059
 msgid "Failed to open temporary file."
 msgstr "Nelze otevřít dočasný soubor."
 
-#: ../src/msw/clipbrd.cpp:91
+#: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Nelze otevřít schránku."
 
-#: ../src/common/translation.cpp:1184
+#: ../src/common/translation.cpp:1226
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Nelze analyzovat formy množného čísla: '%s'"
 
-#: ../src/unix/mediactrl.cpp:1214
+#: ../src/unix/mediactrl.cpp:1239
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "\"%s\" nelze připravit k přehrávání."
 
-#: ../src/msw/clipbrd.cpp:600
+#: ../src/msw/clipbrd.cpp:610
 msgid "Failed to put data on the clipboard"
 msgstr "Nelze vložit data do schránky"
 
-#: ../src/unix/snglinst.cpp:278
+#: ../src/unix/snglinst.cpp:275
 msgid "Failed to read PID from lock file."
 msgstr "Nepodařilo se přečíst PID ze zámkového souboru."
 
-#: ../src/common/fileconf.cpp:433
+#: ../src/common/fileconf.cpp:432
 msgid "Failed to read config options."
 msgstr "Nelze načíst volby nastavení."
 
-#: ../src/common/docview.cpp:681
+#: ../src/common/docview.cpp:676
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Nelze načíst dokument ze souboru \"%s\"."
 
-#: ../src/dfb/evtloop.cpp:98
+#: ../src/dfb/evtloop.cpp:99
 msgid "Failed to read event from DirectFB pipe"
 msgstr "Nelze číst událost z roury DirectFB"
 
-#: ../src/unix/wakeuppipe.cpp:120
+#: ../src/unix/wakeuppipe.cpp:117
 msgid "Failed to read from wake-up pipe"
 msgstr "Nelze číst z probouzecí roury"
 
-#: ../src/unix/utilsunx.cpp:679
+#: ../src/common/textfile.cpp:96
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Nelze načíst dokument ze souboru \"%s\"."
+
+#: ../src/unix/utilsunx.cpp:681
 msgid "Failed to redirect child process input/output"
 msgstr "Nepodařilo se přesměrovat vstup/výstup synovského procesu"
 
-#: ../src/msw/utilsexc.cpp:701
+#: ../src/msw/utilsexc.cpp:698
 msgid "Failed to redirect the child process IO"
 msgstr "Chyba při přesměrovávání vstupu a výstupu synovského procesu"
 
-#: ../src/msw/dde.cpp:288
+#: ../src/msw/dde.cpp:283
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Nelze zaregistrovat DDE server '%s'"
 
-#: ../src/common/fontmap.cpp:245
+#: ../src/gtk/font.cpp:580
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "Nelze aktualizovat soubor uživatelského nastavení."
+
+#: ../src/common/fontmap.cpp:242
 #, c-format
 msgid "Failed to remember the encoding for the charset '%s'."
 msgstr "Nelze uložit kódování znakové sady '%s'."
 
-#: ../src/common/debugrpt.cpp:227
+#: ../src/common/debugrpt.cpp:228
 #, c-format
 msgid "Failed to remove debug report file \"%s\""
 msgstr "Nelze odstranit soubor protokolu ladění \"%s\""
 
-#: ../src/unix/snglinst.cpp:328
+#: ../src/unix/snglinst.cpp:325
 #, c-format
 msgid "Failed to remove lock file '%s'"
 msgstr "Nelze odstranit zámkový soubor '%s'"
 
-#: ../src/unix/snglinst.cpp:288
+#: ../src/unix/snglinst.cpp:285
 #, c-format
 msgid "Failed to remove stale lock file '%s'."
 msgstr "Nelze odstranit starý zámkový soubor '%s'."
 
-#: ../src/msw/registry.cpp:529
+#: ../src/msw/registry.cpp:518
 #, c-format
 msgid "Failed to rename registry value '%s' to '%s'."
 msgstr "Nelze přejmenovat klíč registru '%s' na '%s'."
 
-#: ../src/common/filefn.cpp:1122
+#: ../src/common/filefn.cpp:1011
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -3521,115 +3584,124 @@ msgid ""
 msgstr ""
 "Nelze přejmenovat soubor '%s' na '%s' protože cílový soubor již existuje."
 
-#: ../src/msw/registry.cpp:634
+#: ../src/msw/registry.cpp:623
 #, c-format
 msgid "Failed to rename the registry key '%s' to '%s'."
 msgstr "Nelze přejmenovat klíč registru '%s' na '%s'."
 
-#: ../src/common/filename.cpp:2671
+#: ../src/msw/webview_ie.cpp:995
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/common/filename.cpp:2754
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Nelze zjistit hodnoty časů souboru '%s'"
 
-#: ../src/msw/dialup.cpp:468
+#: ../src/msw/dialup.cpp:462
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Nepodařilo se získat text chybového hlášení RAS"
 
-#: ../src/msw/clipbrd.cpp:748
+#: ../src/msw/clipbrd.cpp:768
 msgid "Failed to retrieve the supported clipboard formats"
 msgstr "Nelze zjistit formáty podporované schránkou"
 
-#: ../src/common/docview.cpp:652
+#: ../src/common/docview.cpp:647
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Nelze uložit dokument do souboru \"%s\"."
 
-#: ../src/msw/dib.cpp:269
+#: ../src/msw/dib.cpp:312
 #, c-format
 msgid "Failed to save the bitmap image to file \"%s\"."
 msgstr "Nelze uložit obrázek do souboru \"%s\"."
 
-#: ../src/msw/dde.cpp:763
+#: ../src/msw/dde.cpp:811
 msgid "Failed to send DDE advise notification"
 msgstr "Nepodařilo se poslat DDE advise notifikaci"
 
-#: ../src/common/ftp.cpp:402
+#: ../src/common/ftp.cpp:399
 #, c-format
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Nelze nastavit přenosový mód FTP na %s."
 
-#: ../src/msw/clipbrd.cpp:427
+#: ../src/msw/clipbrd.cpp:443
 msgid "Failed to set clipboard data."
 msgstr "Nelze uložit data do schránky."
 
-#: ../src/unix/snglinst.cpp:181
+#: ../src/unix/snglinst.cpp:178
 #, c-format
 msgid "Failed to set permissions on lock file '%s'"
 msgstr "Nelze nastavit přístupová práva pro zámkový soubor '%s'"
 
-#: ../src/unix/utilsunx.cpp:668
+#: ../src/unix/utilsunx.cpp:670
 msgid "Failed to set process priority"
 msgstr "Nelze nastavit prioritu procesu"
 
-#: ../src/common/file.cpp:559
+#: ../src/common/ffile.cpp:355 ../src/common/file.cpp:586
 msgid "Failed to set temporary file permissions"
 msgstr "Nelze nastavit přístupová práva k dočasnému souboru"
 
-#: ../src/gtk/textctrl.cpp:1072
-msgid "Failed to set text in the text control."
-msgstr "Nelze nastavit text v textovém poli."
-
-#: ../src/unix/threadpsx.cpp:1298
+#: ../src/unix/threadpsx.cpp:1347
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Nelze nastavit úroveň souběžnosti vlákna na %lu"
 
-#: ../src/unix/threadpsx.cpp:1424
+#: ../src/unix/threadpsx.cpp:1473
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Nelze nastavit prioritu vlákna %d."
 
-#: ../src/unix/utilsunx.cpp:783
+#: ../src/unix/utilsunx.cpp:785
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr "Nelze nastavit neblokující rouru, program se může zaseknout."
 
-#: ../src/common/fs_mem.cpp:261
+#: ../src/msw/webview_ie.cpp:987
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:256
 #, c-format
 msgid "Failed to store image '%s' to memory VFS!"
 msgstr "Nepodařilo se uložit obrázek '%s' do paměťového VFS!"
 
-#: ../src/dfb/evtloop.cpp:170
+#: ../src/dfb/evtloop.cpp:171
 msgid "Failed to switch DirectFB pipe to non-blocking mode"
 msgstr "Nelze přepnout rouru DirectFB do neblokujícího režimu"
 
-#: ../src/unix/wakeuppipe.cpp:59
+#: ../src/unix/wakeuppipe.cpp:56
 msgid "Failed to switch wake up pipe to non-blocking mode"
 msgstr "Nelze přepnout rouru buzení do neblokovacího režimu"
 
-#: ../src/unix/threadpsx.cpp:1605
+#: ../src/unix/threadpsx.cpp:1654
 msgid "Failed to terminate a thread."
 msgstr "Nelze ukončit vlákno."
 
-#: ../src/msw/dde.cpp:741
+#: ../src/msw/dde.cpp:736
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "Nelze ukončit 'advise loop' s DDE serverem"
 
-#: ../src/msw/dialup.cpp:938
+#: ../src/msw/dialup.cpp:932
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Nelze ukončit vytáčené spojení: %s"
 
-#: ../src/common/filename.cpp:2590
+#: ../src/common/filename.cpp:2673
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Nelze nastavit čas na aktuální pro soubor '%s'"
 
-#: ../src/unix/snglinst.cpp:334
+#: ../src/unix/dlunix.cpp:90
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "Nelze načíst sdílenou knihovnu '%s'"
+
+#: ../src/unix/snglinst.cpp:331
 #, c-format
 msgid "Failed to unlock lock file '%s'"
 msgstr "Nelze odemknout zámkový soubor '%s'"
 
-#: ../src/msw/dde.cpp:309
+#: ../src/msw/dde.cpp:304
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Nelze odregistrovat DDE server '%s'"
@@ -3643,77 +3715,87 @@ msgstr "Nelze odregistrovat popisovač %d z epoll popisovače %d"
 msgid "Failed to update user configuration file."
 msgstr "Nelze aktualizovat soubor uživatelského nastavení."
 
-#: ../src/common/debugrpt.cpp:733
+#: ../src/common/debugrpt.cpp:743
 #, c-format
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Nelze nahrát protokol ladění (kód chyby %d)."
 
-#: ../src/unix/snglinst.cpp:168
+#: ../src/unix/snglinst.cpp:165
 #, c-format
 msgid "Failed to write to lock file '%s'"
 msgstr "Nelze zapisovat do zámkového souboru '%s'"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:209
+#: ../src/propgrid/propgrid.cpp:190
 msgid "False"
 msgstr "Nepravda"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:694
+#: ../src/propgrid/advprops.cpp:604
 msgid "Family"
 msgstr "Písmo"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/gtk/glcanvas.cpp:176 ../src/gtk/glcanvas.cpp:187
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Kritická chyba"
+
+#: ../src/common/stockitem.cpp:154
 msgid "File"
 msgstr "Soubor"
 
-#: ../src/common/docview.cpp:669
+#: ../src/common/docview.cpp:664
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Soubor \"%s\" nelze otevřít pro čtení."
 
-#: ../src/common/docview.cpp:646
+#: ../src/common/docview.cpp:641
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Soubor \"%s\" nelze otevřít pro zápis."
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "Soubor '%s' existuje, opravdu ho chcete přepsat?"
 
-#: ../src/common/filefn.cpp:1156
+#: ../src/common/filefn.cpp:1044
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Soubor '%s' nelze odstranit"
 
-#: ../src/common/filefn.cpp:1139
+#: ../src/common/filefn.cpp:1028
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Soubor '%s' nelze přejmenovat na '%s'"
 
-#: ../src/richtext/richtextctrl.cpp:3081 ../src/common/textcmn.cpp:953
+#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
 msgid "File couldn't be loaded."
 msgstr "Soubor nelze načíst."
 
-#: ../src/msw/filedlg.cpp:393
+#: ../src/msw/filedlg.cpp:414
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Dialogové okno souboru selhalo s kódem chyby %0lx."
 
-#: ../src/common/docview.cpp:1789
+#: ../src/common/docview.cpp:1783
 msgid "File error"
 msgstr "Chyba souboru"
 
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/filectrlg.cpp:770
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/filectrlg.cpp:766
 msgid "File name exists already."
 msgstr "Soubor tohoto jména již existuje."
+
+#: ../src/osx/cocoa/filedlg.mm:264
+#, fuzzy
+msgid "File type:"
+msgstr "Neproporcionální"
 
 #: ../src/motif/filedlg.cpp:220
 msgid "Files"
 msgstr "Soubory"
 
-#: ../src/common/filefn.cpp:1591
+#: ../src/common/filefn.cpp:1479
 #, c-format
 msgid "Files (%s)"
 msgstr "Soubory (%s)"
@@ -3722,15 +3804,29 @@ msgstr "Soubory (%s)"
 msgid "Filter"
 msgstr "Filtr"
 
-#: ../src/common/stockitem.cpp:158 ../src/html/helpwnd.cpp:490
+#: ../src/html/helpwnd.cpp:488
 msgid "Find"
 msgstr "Najít"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:259
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:258
+#, fuzzy
+msgid "Find in document"
+msgstr "Otevřít dokument HTML"
+
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "Find..."
+msgstr "Najít"
+
+#: ../src/common/stockitem.cpp:156
 msgid "First"
 msgstr "První"
 
-#: ../src/common/prntbase.cpp:1548
+#: ../src/common/prntbase.cpp:1573
 msgid "First page"
 msgstr "První  stránka"
 
@@ -3738,11 +3834,11 @@ msgstr "První  stránka"
 msgid "Fixed"
 msgstr "Pevná"
 
-#: ../src/html/helpwnd.cpp:1206
+#: ../src/html/helpwnd.cpp:1204
 msgid "Fixed font:"
 msgstr "Neproporcionální písmo:"
 
-#: ../src/html/helpwnd.cpp:1269
+#: ../src/html/helpwnd.cpp:1267
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Písmo s pevnou velikostí.<br> <b>tučné</b> <i>kurzíva</i> "
 
@@ -3750,16 +3846,16 @@ msgstr "Písmo s pevnou velikostí.<br> <b>tučné</b> <i>kurzíva</i> "
 msgid "Floating"
 msgstr "Obtékání"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "Floppy"
 msgstr "Disketa"
 
-#: ../src/common/paper.cpp:111
+#: ../src/common/paper.cpp:108
 msgid "Folio, 8 1/2 x 13 in"
 msgstr "Folio, 8 1/2 x 13 palců"
 
-#: ../src/richtext/richtextformatdlg.cpp:344 ../src/osx/carbon/fontdlg.cpp:287
-#: ../src/common/stockitem.cpp:194
+#: ../src/osx/carbon/fontdlg.cpp:284 ../src/common/stockitem.cpp:191
+#: ../src/richtext/richtextformatdlg.cpp:337
 msgid "Font"
 msgstr "Písmo"
 
@@ -3767,7 +3863,24 @@ msgstr "Písmo"
 msgid "Font &weight:"
 msgstr "&Tučnost písma:"
 
-#: ../src/html/helpwnd.cpp:1207
+#: ../src/osx/fontutil.cpp:89
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
+"\"."
+msgstr ""
+
+#: ../src/msw/font.cpp:1126
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Soubor nelze načíst."
+
+#: ../src/osx/fontutil.cpp:81
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "Soubor %s neexistuje."
+
+#: ../src/html/helpwnd.cpp:1205
 msgid "Font size:"
 msgstr "Velikost písma:"
 
@@ -3775,53 +3888,53 @@ msgstr "Velikost písma:"
 msgid "Font st&yle:"
 msgstr "St&yl písma:"
 
-#: ../src/osx/carbon/fontdlg.cpp:329
+#: ../src/osx/carbon/fontdlg.cpp:326
 msgid "Font:"
 msgstr "Písmo:"
 
-#: ../src/dfb/fontmgr.cpp:198
+#: ../src/dfb/fontmgr.cpp:195
 #, c-format
 msgid "Fonts index file %s disappeared while loading fonts."
 msgstr "Soubor rejstříku písem %s při načítaní písem zmizel ."
 
-#: ../src/unix/utilsunx.cpp:645
+#: ../src/unix/utilsunx.cpp:647
 msgid "Fork failed"
 msgstr "Selhalo forkování"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "Forward"
 msgstr "Dopředu"
 
-#: ../src/common/xtixml.cpp:235
+#: ../src/common/xtixml.cpp:231
 msgid "Forward hrefs are not supported"
 msgstr "Dopředné odkazy nejsou podporovány"
 
-#: ../src/html/helpwnd.cpp:875
+#: ../src/html/helpwnd.cpp:873
 #, c-format
 msgid "Found %i matches"
 msgstr "Nalezeno výskytů: %i"
 
-#: ../src/generic/prntdlgg.cpp:238
+#: ../src/generic/prntdlgg.cpp:231
 msgid "From:"
 msgstr "Od:"
 
-#: ../src/propgrid/advprops.cpp:1604
+#: ../src/propgrid/advprops.cpp:1510
 msgid "Fuchsia"
 msgstr "Fuchsiová"
 
-#: ../src/common/imaggif.cpp:138
+#: ../src/common/imaggif.cpp:135
 msgid "GIF: data stream seems to be truncated."
 msgstr "GIF: datový proud je useknutý před koncem."
 
-#: ../src/common/imaggif.cpp:128
+#: ../src/common/imaggif.cpp:125
 msgid "GIF: error in GIF image format."
 msgstr "GIF: chyba ve formátu GIF obrázku."
 
-#: ../src/common/imaggif.cpp:133
+#: ../src/common/imaggif.cpp:130
 msgid "GIF: not enough memory."
 msgstr "GIF: nedostatek paměti."
 
-#: ../src/gtk/window.cpp:4631
+#: ../src/gtk/window.cpp:5635
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -3829,23 +3942,23 @@ msgstr ""
 "GTK+ instalovaný na tomto stroji je příliš starý pro podporu skládání "
 "obrazovky, nainstalujte prosím GTK+ 2.12 nebo novější."
 
-#: ../src/univ/themes/gtk.cpp:525
+#: ../src/univ/themes/gtk.cpp:522
 msgid "GTK+ theme"
 msgstr "GTK+ téma"
 
-#: ../src/common/preferencescmn.cpp:40
+#: ../src/common/preferencescmn.cpp:37
 msgid "General"
 msgstr "Obecné"
 
-#: ../src/common/prntbase.cpp:258
+#: ../src/common/prntbase.cpp:253
 msgid "Generic PostScript"
 msgstr "Obecný PostScript"
 
-#: ../src/common/paper.cpp:135
+#: ../src/common/paper.cpp:132
 msgid "German Legal Fanfold, 8 1/2 x 13 in"
 msgstr "Německý Legal skládaný, 8 1/2 x 13 palců"
 
-#: ../src/common/paper.cpp:134
+#: ../src/common/paper.cpp:131
 msgid "German Std Fanfold, 8 1/2 x 12 in"
 msgstr "Německý Std skládaný, 8 1/2 x 12 palců"
 
@@ -3861,48 +3974,48 @@ msgstr "GetPropertyCollection zavolána na obecném přistupujícím"
 msgid "GetPropertyCollection called w/o valid collection getter"
 msgstr "GetPropertyCollection zavoláno bez platné čtečky kolekce"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:658
 msgid "Go back"
 msgstr "Jdi zpět"
 
-#: ../src/html/helpwnd.cpp:661
+#: ../src/html/helpwnd.cpp:659
 msgid "Go forward"
 msgstr "Jdi dopředu"
 
-#: ../src/html/helpwnd.cpp:663
+#: ../src/html/helpwnd.cpp:661
 msgid "Go one level up in document hierarchy"
 msgstr "Jdi o úroveň výš"
 
-#: ../src/generic/filedlgg.cpp:208 ../src/generic/dirdlgg.cpp:116
+#: ../src/generic/filedlgg.cpp:205 ../src/generic/dirdlgg.cpp:113
 msgid "Go to home directory"
 msgstr "Jít do domovského adresáře"
 
-#: ../src/generic/filedlgg.cpp:205
+#: ../src/generic/filedlgg.cpp:202
 msgid "Go to parent directory"
 msgstr "Jít do nadřazeného adresáře"
 
-#: ../src/generic/aboutdlgg.cpp:76
+#: ../src/generic/aboutdlgg.cpp:73
 msgid "Graphics art by "
 msgstr "Grafika "
 
-#: ../src/propgrid/advprops.cpp:1599
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Gray"
 msgstr "Šedá"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:883
+#: ../src/propgrid/advprops.cpp:784
 msgid "GrayText"
 msgstr "Neaktivní text"
 
-#: ../src/common/fmapbase.cpp:154
+#: ../src/common/fmapbase.cpp:151
 msgid "Greek (ISO-8859-7)"
 msgstr "Řecky (ISO-8859-7)"
 
-#: ../src/propgrid/advprops.cpp:1600
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Green"
 msgstr "Zelená"
 
-#: ../src/generic/colrdlgg.cpp:342
+#: ../src/generic/colrdlgg.cpp:362
 msgid "Green:"
 msgstr "Zelená:"
 
@@ -3910,107 +4023,107 @@ msgstr "Zelená:"
 msgid "Groove"
 msgstr "Příkop"
 
-#: ../src/common/zstream.cpp:158 ../src/common/zstream.cpp:318
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
 msgid "Gzip not supported by this version of zlib"
 msgstr "Gzip není v této verzi zlib podporován"
 
-#: ../src/html/helpwnd.cpp:1549
+#: ../src/html/helpwnd.cpp:1547
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "Projekt Nápovědy HTML (*.hhp)|*.hhp|"
 
-#: ../src/html/htmlwin.cpp:681
+#: ../src/html/htmlwin.cpp:691
 #, c-format
 msgid "HTML anchor %s does not exist."
 msgstr "Kotva HTML %s neexistuje."
 
-#: ../src/html/helpwnd.cpp:1547
+#: ../src/html/helpwnd.cpp:1545
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "Soubory HTML (*.html;*.htm)|*.html;*.htm|"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1759
+#: ../src/propgrid/advprops.cpp:1660
 msgid "Hand"
 msgstr "Ruka"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "Harddisk"
 msgstr "Pevný disk"
 
-#: ../src/common/fmapbase.cpp:155
+#: ../src/common/fmapbase.cpp:152
 msgid "Hebrew (ISO-8859-8)"
 msgstr "Hebrejský (ISO-8859-8)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:280 ../src/osx/button_osx.cpp:39
-#: ../src/common/stockitem.cpp:163 ../src/common/accelcmn.cpp:80
-#: ../src/html/helpdlg.cpp:66 ../src/html/helpfrm.cpp:111
+#: ../include/wx/msgdlg.h:282 ../src/osx/button_osx.cpp:39
+#: ../src/common/stockitem.cpp:160 ../src/common/accelcmn.cpp:77
+#: ../src/html/helpfrm.cpp:108 ../src/html/helpdlg.cpp:63
 msgid "Help"
 msgstr "Nápověda"
 
-#: ../src/html/helpwnd.cpp:1200
+#: ../src/html/helpwnd.cpp:1198
 msgid "Help Browser Options"
 msgstr "Nastavení prohlížeče nápovědy"
 
-#: ../src/generic/helpext.cpp:454 ../src/generic/helpext.cpp:455
+#: ../src/generic/helpext.cpp:452 ../src/generic/helpext.cpp:453
 msgid "Help Index"
 msgstr "Index nápovědy"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1529
 msgid "Help Printing"
 msgstr "Tisk nápovědy"
 
-#: ../src/html/helpwnd.cpp:801
+#: ../src/html/helpwnd.cpp:799
 msgid "Help Topics"
 msgstr "Témata nápovědy"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1546
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Knihy s nápovědou (*.htb)|*.htb|Knihy s nápovědou (*.zip)|*.zip|"
 
-#: ../src/generic/helpext.cpp:267
+#: ../src/generic/helpext.cpp:265
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "Adresář Nápovědy \"%s\" nenalezen."
 
-#: ../src/generic/helpext.cpp:275
+#: ../src/generic/helpext.cpp:273
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "Soubor s nápovědou \"%s\" nebyl nalezen."
 
-#: ../src/html/helpctrl.cpp:63
+#: ../src/html/helpctrl.cpp:59
 #, c-format
 msgid "Help: %s"
 msgstr "Nápověda: %s"
 
-#: ../src/osx/menu_osx.cpp:577
+#: ../src/osx/menu_osx.cpp:469
 #, c-format
 msgid "Hide %s"
 msgstr "Skrýt %s"
 
-#: ../src/osx/menu_osx.cpp:579
+#: ../src/osx/menu_osx.cpp:471
 msgid "Hide Others"
 msgstr "Skrýt ostatní"
 
-#: ../src/generic/infobar.cpp:84
+#: ../src/generic/infobar.cpp:81
 msgid "Hide this notification message."
 msgstr "Skrýt tuto oznamovací zprávu."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:884
+#: ../src/propgrid/advprops.cpp:785
 msgid "Highlight"
 msgstr "Zvýraznění"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:885
+#: ../src/propgrid/advprops.cpp:786
 msgid "HighlightText"
 msgstr "Zvýraznění textu"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:164 ../src/common/accelcmn.cpp:65
+#: ../src/common/stockitem.cpp:161 ../src/common/accelcmn.cpp:62
 msgid "Home"
 msgstr "Home"
 
-#: ../src/generic/dirctrlg.cpp:524
+#: ../src/generic/dirctrlg.cpp:490
 msgid "Home directory"
 msgstr "Domovský adresář"
 
@@ -4020,62 +4133,62 @@ msgid "How the object will float relative to the text."
 msgstr "Jak bude text obtékat vzhledem k objektu."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1760
+#: ../src/propgrid/advprops.cpp:1661
 msgid "I-Beam"
 msgstr "Výběr textu"
 
-#: ../src/common/imagbmp.cpp:1196
+#: ../src/common/imagbmp.cpp:1208
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: Chyba při načítání DIB masky."
 
-#: ../src/common/imagbmp.cpp:1290 ../src/common/imagbmp.cpp:1390
-#: ../src/common/imagbmp.cpp:1405 ../src/common/imagbmp.cpp:1416
-#: ../src/common/imagbmp.cpp:1430 ../src/common/imagbmp.cpp:1478
-#: ../src/common/imagbmp.cpp:1493 ../src/common/imagbmp.cpp:1507
-#: ../src/common/imagbmp.cpp:1518
+#: ../src/common/imagbmp.cpp:1302 ../src/common/imagbmp.cpp:1402
+#: ../src/common/imagbmp.cpp:1417 ../src/common/imagbmp.cpp:1428
+#: ../src/common/imagbmp.cpp:1442 ../src/common/imagbmp.cpp:1490
+#: ../src/common/imagbmp.cpp:1505 ../src/common/imagbmp.cpp:1519
+#: ../src/common/imagbmp.cpp:1530
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: Chyba při zapisování obrázku!"
 
-#: ../src/common/imagbmp.cpp:1255
+#: ../src/common/imagbmp.cpp:1267
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: Obrázek je na ikonu příliš vysoký."
 
-#: ../src/common/imagbmp.cpp:1263
+#: ../src/common/imagbmp.cpp:1275
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: Obrázek je na ikonu příliš široký."
 
-#: ../src/common/imagbmp.cpp:1603
+#: ../src/common/imagbmp.cpp:1615
 msgid "ICO: Invalid icon index."
 msgstr "ICO: Neplatný index ikony."
 
-#: ../src/common/imagiff.cpp:758
+#: ../src/common/imagiff.cpp:755
 msgid "IFF: data stream seems to be truncated."
 msgstr "IFF: datový proud je useknutý před koncem."
 
-#: ../src/common/imagiff.cpp:742
+#: ../src/common/imagiff.cpp:739
 msgid "IFF: error in IFF image format."
 msgstr "IFF: chyba v IFF formátu obrázku."
 
-#: ../src/common/imagiff.cpp:745
+#: ../src/common/imagiff.cpp:742
 msgid "IFF: not enough memory."
 msgstr "IFF: nedostatek paměti."
 
-#: ../src/common/imagiff.cpp:748
+#: ../src/common/imagiff.cpp:745
 msgid "IFF: unknown error!!!"
 msgstr "IFF: neznámá chyba!!!"
 
-#: ../src/common/fmapbase.cpp:197
+#: ../src/common/fmapbase.cpp:194
 msgid "ISO-2022-JP"
 msgstr "ISO-2022-JP"
 
-#: ../src/html/htmprint.cpp:282
+#: ../src/html/htmprint.cpp:294
 msgid ""
 "If possible, try changing the layout parameters to make the printout more "
 "narrow."
 msgstr ""
 "Pokud je to možné, zkuste změnit parametry rozvržení, aby byl výtisk užší."
 
-#: ../src/generic/dbgrptg.cpp:358
+#: ../src/generic/dbgrptg.cpp:362
 msgid ""
 "If you have any additional information pertaining to this bug\n"
 "report, please enter it here and it will be joined to it:"
@@ -4095,46 +4208,50 @@ msgstr ""
 "ale uvědomte si, že tímto můžete brzdit vylepšování programu, takže pokud\n"
 "je to možné, pokračujte, prosím, ve vytváření protokolu.\n"
 
-#: ../src/msw/registry.cpp:1405
+#: ../src/common/zipstrm.cpp:1043
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1393
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Ignoruji hodnotu \"%s\" klíče \"%s\"."
 
-#: ../src/common/xtistrm.cpp:295
+#: ../src/common/xtistrm.cpp:292
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Neplatná třída objektu (Není wxEvtHandler) jako zdroj události"
 
-#: ../src/common/xti.cpp:513
+#: ../src/common/xti.cpp:510
 msgid "Illegal Parameter Count for ConstructObject Method"
 msgstr "Neplatný počet parametrů pro metodu ConstructObject"
 
-#: ../src/common/xti.cpp:501
+#: ../src/common/xti.cpp:498
 msgid "Illegal Parameter Count for Create Method"
 msgstr "Neplatný počet parametrů pro metodu vytvoření"
 
-#: ../src/generic/dirctrlg.cpp:570 ../src/generic/filectrlg.cpp:756
+#: ../src/generic/dirctrlg.cpp:536 ../src/generic/filectrlg.cpp:752
 msgid "Illegal directory name."
 msgstr "Neplatné jméno adresáře."
 
-#: ../src/generic/filectrlg.cpp:1367
+#: ../src/generic/filectrlg.cpp:1356
 msgid "Illegal file specification."
 msgstr "Neplatná specifikace souboru."
 
-#: ../src/common/image.cpp:2269
+#: ../src/common/image.cpp:2363
 msgid "Image and mask have different sizes."
 msgstr "Obrázek a maska mají různé rozměry."
 
-#: ../src/common/image.cpp:2746
+#: ../src/common/image.cpp:2841
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "Soubor s obrázkem není typu %d."
 
-#: ../src/common/image.cpp:2877
+#: ../src/common/image.cpp:2995
 #, c-format
 msgid "Image is not of type %s."
 msgstr "Obrázek není typu %s."
 
-#: ../src/msw/textctrl.cpp:488
+#: ../src/msw/textctrl.cpp:534
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -4142,100 +4259,100 @@ msgstr ""
 "Není možné vytvořit prvek rich edit, místo něj použit obyčejný. "
 "Přeinstalujte prosím riched32.dll."
 
-#: ../src/unix/utilsunx.cpp:301
+#: ../src/unix/utilsunx.cpp:303
 msgid "Impossible to get child process input"
 msgstr "Není možné získat vstup synovského procesu"
 
-#: ../src/common/filefn.cpp:1028
+#: ../src/common/filefn.cpp:917
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Nelze zjistit přístupová práva souboru '%s'"
 
-#: ../src/common/filefn.cpp:1042
+#: ../src/common/filefn.cpp:931
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Nelze přepsat soubor '%s'"
 
-#: ../src/common/filefn.cpp:1097
+#: ../src/common/filefn.cpp:986
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Nelze nastavit přístupová práva souboru '%s'"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:886
+#: ../src/propgrid/advprops.cpp:787
 msgid "InactiveBorder"
 msgstr "Neaktivní okraj"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:887
+#: ../src/propgrid/advprops.cpp:788
 msgid "InactiveCaption"
 msgstr "Neaktivní nadpis"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:888
+#: ../src/propgrid/advprops.cpp:789
 msgid "InactiveCaptionText"
 msgstr "Text neaktivního nadpisu"
 
-#: ../src/common/gifdecod.cpp:792
+#: ../src/common/gifdecod.cpp:826
 #, c-format
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "Nesprávné rozměry snímku GIF (%u, %d) pro snímek č. %u"
 
-#: ../src/msw/ole/automtn.cpp:635
+#: ../src/msw/ole/automtn.cpp:626
 msgid "Incorrect number of arguments."
 msgstr "Nesprávný počet argumentů."
 
-#: ../src/common/stockitem.cpp:165
+#: ../src/common/stockitem.cpp:162
 msgid "Indent"
 msgstr "Odsazení"
 
-#: ../src/richtext/richtextformatdlg.cpp:349
+#: ../src/richtext/richtextformatdlg.cpp:342
 msgid "Indents && Spacing"
 msgstr "Odsazení && mezery"
 
-#: ../src/common/stockitem.cpp:166 ../src/html/helpwnd.cpp:515
+#: ../src/common/stockitem.cpp:163 ../src/html/helpwnd.cpp:513
 msgid "Index"
 msgstr "Rejstřík"
 
-#: ../src/common/fmapbase.cpp:159
+#: ../src/common/fmapbase.cpp:156
 msgid "Indian (ISO-8859-12)"
 msgstr "Indický (ISO-8859-12)"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "Info"
 msgstr "Info"
 
-#: ../src/common/init.cpp:287
+#: ../src/common/init.cpp:284
 msgid "Initialization failed in post init, aborting."
 msgstr "Zavedení selhala v post init, ukončuji."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:54
+#: ../src/common/accelcmn.cpp:51
 msgid "Ins"
 msgstr "Ins"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextsymboldlg.cpp:472 ../src/common/accelcmn.cpp:53
+#: ../src/common/accelcmn.cpp:50 ../src/richtext/richtextsymboldlg.cpp:469
 msgid "Insert"
 msgstr "Insert"
 
-#: ../src/richtext/richtextbuffer.cpp:8067
+#: ../src/richtext/richtextbuffer.cpp:8063
 msgid "Insert Field"
 msgstr "Vložit pole"
 
-#: ../src/richtext/richtextbuffer.cpp:7978
-#: ../src/richtext/richtextbuffer.cpp:8936
+#: ../src/richtext/richtextbuffer.cpp:7974
+#: ../src/richtext/richtextbuffer.cpp:8934
 msgid "Insert Image"
 msgstr "Vložit obrázek"
 
-#: ../src/richtext/richtextbuffer.cpp:8025
+#: ../src/richtext/richtextbuffer.cpp:8021
 msgid "Insert Object"
 msgstr "Vložit objekt"
 
-#: ../src/richtext/richtextctrl.cpp:1286 ../src/richtext/richtextctrl.cpp:1494
-#: ../src/richtext/richtextbuffer.cpp:7822
-#: ../src/richtext/richtextbuffer.cpp:7852
-#: ../src/richtext/richtextbuffer.cpp:7894
+#: ../src/richtext/richtextbuffer.cpp:7818
+#: ../src/richtext/richtextbuffer.cpp:7848
+#: ../src/richtext/richtextbuffer.cpp:7890
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
 msgid "Insert Text"
 msgstr "Vložit text"
 
@@ -4248,16 +4365,11 @@ msgstr "Vloží konec stránky před odstavcem."
 msgid "Inset"
 msgstr "Ďolík"
 
-#: ../src/gtk/app.cpp:425
-#, c-format
-msgid "Invalid GTK+ command line option, use \"%s --help\""
-msgstr "Neplatná volba příkazové řádky GTK+, použijte \"%s --help\""
-
-#: ../src/common/imagtiff.cpp:311
+#: ../src/common/imagtiff.cpp:308
 msgid "Invalid TIFF image index."
 msgstr "Poškozený index v TIFF obrázku."
 
-#: ../src/common/appcmn.cpp:273
+#: ../src/common/appcmn.cpp:294
 #, c-format
 msgid "Invalid display mode specification '%s'."
 msgstr "Špatné určení grafického režimu '%s'."
@@ -4267,246 +4379,250 @@ msgstr "Špatné určení grafického režimu '%s'."
 msgid "Invalid geometry specification '%s'"
 msgstr "Špatné určení geometrie '%s'."
 
-#: ../src/unix/fswatcher_inotify.cpp:323
+#: ../src/unix/fswatcher_inotify.cpp:320
 #, c-format
 msgid "Invalid inotify event for \"%s\""
 msgstr "Neplatná událost inotify pro \"%s\""
 
-#: ../src/unix/snglinst.cpp:312
+#: ../src/unix/snglinst.cpp:309
 #, c-format
 msgid "Invalid lock file '%s'."
 msgstr "Chybný zamykací soubor '%s'."
 
-#: ../src/common/translation.cpp:1125
+#: ../src/common/translation.cpp:1167
 msgid "Invalid message catalog."
 msgstr "Neplatný katalog zpráv."
 
-#: ../src/common/xtistrm.cpp:405 ../src/common/xtistrm.cpp:420
+#: ../src/common/xtistrm.cpp:402 ../src/common/xtistrm.cpp:417
 msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
 msgstr "Neplatné nebo nulové ID objektu předáno GetObjectClassInfo"
 
-#: ../src/common/xtistrm.cpp:435
+#: ../src/common/xtistrm.cpp:432
 msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
 msgstr "Neplatné nebo nulové ID objektu předáno HasObjectClassInfo"
 
-#: ../src/common/regex.cpp:310
+#: ../src/common/regex.cpp:307
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Špatný regulární výraz '%s': %s"
 
-#: ../src/common/config.cpp:226
+#: ../src/common/config.cpp:222
 #, c-format
 msgid "Invalid value %ld for a boolean key \"%s\" in config file."
 msgstr "Neplatná hodnota %ld booleovského klíče \"%s\"."
 
-#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:351
-#: ../src/osx/carbon/fontdlg.cpp:361 ../src/common/stockitem.cpp:168
+#: ../src/osx/carbon/fontdlg.cpp:358 ../src/common/stockitem.cpp:165
+#: ../src/generic/fontdlgg.cpp:325 ../src/richtext/richtextfontpage.cpp:351
 msgid "Italic"
 msgstr "Kurzíva"
 
-#: ../src/common/paper.cpp:130
+#: ../src/common/paper.cpp:127
 msgid "Italy Envelope, 110 x 230 mm"
 msgstr "Italská obálka, 110 x 230 mm"
 
-#: ../src/common/imagjpeg.cpp:270
+#: ../src/common/imagjpeg.cpp:257
 msgid "JPEG: Couldn't load - file is probably corrupted."
 msgstr "JPEG: Nelze načíst obrázek - soubor je nejspíš poškozen."
 
-#: ../src/common/imagjpeg.cpp:449
+#: ../src/common/imagjpeg.cpp:436
 msgid "JPEG: Couldn't save image."
 msgstr "JPEG: Nelze uložit obrázek."
 
-#: ../src/common/paper.cpp:163
+#: ../src/common/paper.cpp:160
 msgid "Japanese Double Postcard 200 x 148 mm"
 msgstr "Japonská dvojitá pohlednice 200 x 148 mm"
 
-#: ../src/common/paper.cpp:167
+#: ../src/common/paper.cpp:164
 msgid "Japanese Envelope Chou #3"
 msgstr "Japonská obálka Čó č. 3"
 
-#: ../src/common/paper.cpp:180
+#: ../src/common/paper.cpp:177
 msgid "Japanese Envelope Chou #3 Rotated"
 msgstr "Japonská obálka Čó č. 3 na šířku"
 
-#: ../src/common/paper.cpp:168
+#: ../src/common/paper.cpp:165
 msgid "Japanese Envelope Chou #4"
 msgstr "Japonská obálka Čó č. 4"
 
-#: ../src/common/paper.cpp:181
+#: ../src/common/paper.cpp:178
 msgid "Japanese Envelope Chou #4 Rotated"
 msgstr "Japonská obálka Čó č. 4 na šířku"
 
-#: ../src/common/paper.cpp:165
+#: ../src/common/paper.cpp:162
 msgid "Japanese Envelope Kaku #2"
 msgstr "Japonská obálka Kaku č. 2"
 
-#: ../src/common/paper.cpp:178
+#: ../src/common/paper.cpp:175
 msgid "Japanese Envelope Kaku #2 Rotated"
 msgstr "Japonská obálka Kaku č. 2 na šířku"
 
-#: ../src/common/paper.cpp:166
+#: ../src/common/paper.cpp:163
 msgid "Japanese Envelope Kaku #3"
 msgstr "Japonská obálka Kaku č. 3"
 
-#: ../src/common/paper.cpp:179
+#: ../src/common/paper.cpp:176
 msgid "Japanese Envelope Kaku #3 Rotated"
 msgstr "Japonská obálka Kaku č. 3 na šířku"
 
-#: ../src/common/paper.cpp:185
+#: ../src/common/paper.cpp:182
 msgid "Japanese Envelope You #4"
 msgstr "Japonská Obálka Jó č. 4"
 
-#: ../src/common/paper.cpp:186
+#: ../src/common/paper.cpp:183
 msgid "Japanese Envelope You #4 Rotated"
 msgstr "Japonská Obálka Jó č. 4 na šířku"
 
-#: ../src/common/paper.cpp:138
+#: ../src/common/paper.cpp:135
 msgid "Japanese Postcard 100 x 148 mm"
 msgstr "Japonská pohlednice 100 x 148 mm"
 
-#: ../src/common/paper.cpp:175
+#: ../src/common/paper.cpp:172
 msgid "Japanese Postcard Rotated 148 x 100 mm"
 msgstr "Japonská pohlednice na šířku, 148 x 100 mm"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "Jump to"
 msgstr "Přejít na"
 
-#: ../src/common/stockitem.cpp:171
+#: ../src/common/stockitem.cpp:168
 msgid "Justified"
 msgstr "Do bloku"
 
-#: ../src/richtext/richtextindentspage.cpp:155
-#: ../src/richtext/richtextindentspage.cpp:157
 #: ../src/richtext/richtextliststylepage.cpp:344
 #: ../src/richtext/richtextliststylepage.cpp:346
+#: ../src/richtext/richtextindentspage.cpp:155
+#: ../src/richtext/richtextindentspage.cpp:157
 msgid "Justify text left and right."
 msgstr "Zarovnat text do bloku."
 
-#: ../src/common/fmapbase.cpp:163
+#: ../src/common/fmapbase.cpp:160
 msgid "KOI8-R"
 msgstr "KOI8-R"
 
-#: ../src/common/fmapbase.cpp:164
+#: ../src/common/fmapbase.cpp:161
 msgid "KOI8-U"
 msgstr "KOI8-U"
 
-#: ../src/common/accelcmn.cpp:265 ../src/common/accelcmn.cpp:347
+#: ../src/common/accelcmn.cpp:279 ../src/common/accelcmn.cpp:364
 msgid "KP_"
 msgstr "NK_"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "KP_Add"
 msgstr "NK_Plus"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "KP_Begin"
 msgstr "NK_Begin"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "KP_Decimal"
 msgstr "NK_Desetinná čárka"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 msgid "KP_Delete"
 msgstr "NK_Delete"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "KP_Divide"
 msgstr "NK_Lomítko"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 msgid "KP_Down"
 msgstr "NK_Dolů"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "KP_End"
 msgstr "NK_End"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "KP_Enter"
 msgstr "NK_Enter"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "KP_Equal"
 msgstr "NK_Rovná se"
 
+#: ../src/common/accelcmn.cpp:276 ../src/common/accelcmn.cpp:361
+msgid "KP_F"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 msgid "KP_Home"
 msgstr "NK_Home"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 msgid "KP_Insert"
 msgstr "NK_Insert"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "KP_Left"
 msgstr "NK_Doleva"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "KP_Multiply"
 msgstr "NK_Krát"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:99
+#: ../src/common/accelcmn.cpp:97
 msgid "KP_Next"
 msgstr "NK_Další"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "KP_PageDown"
 msgstr "NK_PageDown"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "KP_PageUp"
 msgstr "NK_PageUp"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:98
+#: ../src/common/accelcmn.cpp:96
 msgid "KP_Prior"
 msgstr "NK_Předchozí"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 msgid "KP_Right"
 msgstr "NK_Doprava"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "KP_Separator"
 msgstr "NK_Oddělovač"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "KP_Space"
 msgstr "NK_Mezerník"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "KP_Subtract"
 msgstr "NK_Mínus"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "KP_Tab"
 msgstr "NK_Tabulátor"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "KP_Up"
 msgstr "NK_Nahoru"
 
@@ -4514,19 +4630,34 @@ msgstr "NK_Nahoru"
 msgid "L&ine spacing:"
 msgstr "Řá&dkování:"
 
-#: ../src/generic/prntdlgg.cpp:613 ../src/generic/prntdlgg.cpp:868
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "chyba komprese"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "chyba dekomprese"
+
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:861
 msgid "Landscape"
 msgstr "Na šířku"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "Last"
 msgstr "Poslední"
 
-#: ../src/common/prntbase.cpp:1572
+#: ../src/common/prntbase.cpp:1597
 msgid "Last page"
 msgstr "Poslední stránka"
 
-#: ../src/common/log.cpp:305
+#: ../src/common/log.cpp:324
 #, c-format
 msgid "Last repeated message (\"%s\", %u time) wasn't output"
 msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
@@ -4534,93 +4665,93 @@ msgstr[0] "Poslední opakovaná zpráva (\"%s\", %ukrát) nebyla vypsána"
 msgstr[1] "Poslední opakovaná zpráva (\"%s\", %ukrát) nebyla vypsána"
 msgstr[2] "Poslední opakovaná zpráva (\"%s\", %ukrát) nebyla vypsána"
 
-#: ../src/common/paper.cpp:103
+#: ../src/common/paper.cpp:100
 msgid "Ledger, 17 x 11 in"
 msgstr "Ledger, 17 x 11 palců"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6146
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:58 ../src/generic/datavgen.cpp:6951
+#: ../src/richtext/richtextsizepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:252
 #: ../src/richtext/richtextliststylepage.cpp:253
 #: ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
-#: ../src/richtext/richtextsizepage.cpp:249 ../src/common/accelcmn.cpp:61
 msgid "Left"
 msgstr "Doleva"
 
-#: ../src/richtext/richtextindentspage.cpp:204
 #: ../src/richtext/richtextliststylepage.cpp:390
+#: ../src/richtext/richtextindentspage.cpp:204
 msgid "Left (&first line):"
 msgstr "Zleva (&první řádek):"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1761
+#: ../src/propgrid/advprops.cpp:1662
 msgid "Left Button"
 msgstr "Levé tlačítko"
 
-#: ../src/generic/prntdlgg.cpp:880
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Left margin (mm):"
 msgstr "Levý okraj (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:141
-#: ../src/richtext/richtextindentspage.cpp:143
 #: ../src/richtext/richtextliststylepage.cpp:330
 #: ../src/richtext/richtextliststylepage.cpp:332
+#: ../src/richtext/richtextindentspage.cpp:141
+#: ../src/richtext/richtextindentspage.cpp:143
 msgid "Left-align text."
 msgstr "Zarovnat text doleva."
 
-#: ../src/common/paper.cpp:144
+#: ../src/common/paper.cpp:141
 msgid "Legal Extra 9 1/2 x 15 in"
 msgstr "Legal Extra, 9 1/2 x 15 palců"
 
-#: ../src/common/paper.cpp:96
+#: ../src/common/paper.cpp:93
 msgid "Legal, 8 1/2 x 14 in"
 msgstr "Legal, 8 1/2 x 14 palců"
 
-#: ../src/common/paper.cpp:143
+#: ../src/common/paper.cpp:140
 msgid "Letter Extra 9 1/2 x 12 in"
 msgstr "Letter Extra, 9 1/2 x 12 palců"
 
-#: ../src/common/paper.cpp:149
+#: ../src/common/paper.cpp:146
 msgid "Letter Extra Transverse 9.275 x 12 in"
 msgstr "Letter napříč Extra, 9,275 x 12 palců"
 
-#: ../src/common/paper.cpp:152
+#: ../src/common/paper.cpp:149
 msgid "Letter Plus 8 1/2 x 12.69 in"
 msgstr "Letter Plus, 8 1/2 x 12,69 palce"
 
-#: ../src/common/paper.cpp:169
+#: ../src/common/paper.cpp:166
 msgid "Letter Rotated 11 x 8 1/2 in"
 msgstr "Letter na šířku, 11 x 8 1/2 palce"
 
-#: ../src/common/paper.cpp:101
+#: ../src/common/paper.cpp:98
 msgid "Letter Small, 8 1/2 x 11 in"
 msgstr "Letter malý, 8 1/2 x 11 in"
 
-#: ../src/common/paper.cpp:147
+#: ../src/common/paper.cpp:144
 msgid "Letter Transverse 8 1/2 x 11 in"
 msgstr "Letter napříč 8 1/2 x 11 palců"
 
-#: ../src/common/paper.cpp:95
+#: ../src/common/paper.cpp:92
 msgid "Letter, 8 1/2 x 11 in"
 msgstr "Letter, 8 1/2 x 11 palců"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "License"
 msgstr "Licence"
 
-#: ../src/generic/fontdlgg.cpp:332
+#: ../src/generic/fontdlgg.cpp:328
 msgid "Light"
 msgstr "Tenké"
 
-#: ../src/propgrid/advprops.cpp:1608
+#: ../src/propgrid/advprops.cpp:1514
 msgid "Lime"
 msgstr "Limetková"
 
-#: ../src/generic/helpext.cpp:294
+#: ../src/generic/helpext.cpp:292
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr "Řádek %luz mapovacího souboru \"%s\" nemá platný formát, přeskočen."
@@ -4629,15 +4760,15 @@ msgstr "Řádek %luz mapovacího souboru \"%s\" nemá platný formát, přeskoč
 msgid "Line spacing:"
 msgstr "Řádkování:"
 
-#: ../src/html/chm.cpp:838
+#: ../src/html/chm.cpp:829
 msgid "Link contained '//', converted to absolute link."
 msgstr "Odkaz obsahoval '//', převeden na absolutní."
 
-#: ../src/richtext/richtextformatdlg.cpp:364
+#: ../src/richtext/richtextformatdlg.cpp:357
 msgid "List Style"
 msgstr "Styl seznamu"
 
-#: ../src/richtext/richtextstyles.cpp:1064
+#: ../src/richtext/richtextstyles.cpp:1061
 msgid "List styles"
 msgstr "Styly seznamů"
 
@@ -4651,26 +4782,26 @@ msgstr "Zobrazí velikost písem v bodech."
 msgid "Lists the available fonts."
 msgstr "Zobrazí dostupná písma."
 
-#: ../src/common/fldlgcmn.cpp:340
+#: ../src/common/fldlgcmn.cpp:337
 #, c-format
 msgid "Load %s file"
 msgstr "Otevřít soubor %s"
 
-#: ../src/html/htmlwin.cpp:597
+#: ../src/html/htmlwin.cpp:600
 msgid "Loading : "
 msgstr "Načítám : "
 
-#: ../src/unix/snglinst.cpp:246
+#: ../src/unix/snglinst.cpp:243
 #, c-format
 msgid "Lock file '%s' has incorrect owner."
 msgstr "Zámkový soubor '%s' má nesprávného vlastníka."
 
-#: ../src/unix/snglinst.cpp:251
+#: ../src/unix/snglinst.cpp:248
 #, c-format
 msgid "Lock file '%s' has incorrect permissions."
 msgstr "Zámkový soubor '%s' má nesprávná oprávnění."
 
-#: ../src/generic/logg.cpp:576
+#: ../src/generic/logg.cpp:573
 #, c-format
 msgid "Log saved to the file '%s'."
 msgstr "Log uložen do souboru '%s'."
@@ -4685,11 +4816,11 @@ msgstr "Malá písmena"
 msgid "Lower case roman numerals"
 msgstr "Malé římské číslice"
 
-#: ../src/gtk/mdi.cpp:422 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk1/mdi.cpp:431 ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "MDI syn"
 
-#: ../src/msw/helpchm.cpp:56
+#: ../src/msw/helpchm.cpp:53
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -4697,189 +4828,189 @@ msgstr ""
 "Funkce MS HTML nápovědy nejsou dostupné, protože chybí příslušná komponenta. "
 "Prosím nainstalujte ji."
 
-#: ../src/univ/themes/win32.cpp:3754
+#: ../src/univ/themes/win32.cpp:3751
 msgid "Ma&ximize"
 msgstr "Ma&ximalizovat"
 
-#: ../src/common/fmapbase.cpp:203
+#: ../src/common/fmapbase.cpp:200
 msgid "MacArabic"
 msgstr "MacArabština"
 
-#: ../src/common/fmapbase.cpp:222
+#: ../src/common/fmapbase.cpp:219
 msgid "MacArmenian"
 msgstr "MacArménština"
 
-#: ../src/common/fmapbase.cpp:211
+#: ../src/common/fmapbase.cpp:208
 msgid "MacBengali"
 msgstr "MacBengálština"
 
-#: ../src/common/fmapbase.cpp:217
+#: ../src/common/fmapbase.cpp:214
 msgid "MacBurmese"
 msgstr "MacBarmština"
 
-#: ../src/common/fmapbase.cpp:236
+#: ../src/common/fmapbase.cpp:233
 msgid "MacCeltic"
 msgstr "MacKelština"
 
-#: ../src/common/fmapbase.cpp:227
+#: ../src/common/fmapbase.cpp:224
 msgid "MacCentralEurRoman"
 msgstr "MacStředoevr.Římské"
 
-#: ../src/common/fmapbase.cpp:223
+#: ../src/common/fmapbase.cpp:220
 msgid "MacChineseSimp"
 msgstr "MacČínštinaZjed"
 
-#: ../src/common/fmapbase.cpp:201
+#: ../src/common/fmapbase.cpp:198
 msgid "MacChineseTrad"
 msgstr "MacČínštinaTrad"
 
-#: ../src/common/fmapbase.cpp:233
+#: ../src/common/fmapbase.cpp:230
 msgid "MacCroatian"
 msgstr "MacChorvatština"
 
-#: ../src/common/fmapbase.cpp:206
+#: ../src/common/fmapbase.cpp:203
 msgid "MacCyrillic"
 msgstr "MacCyrilský"
 
-#: ../src/common/fmapbase.cpp:207
+#: ../src/common/fmapbase.cpp:204
 msgid "MacDevanagari"
 msgstr "MacDévanágarí"
 
-#: ../src/common/fmapbase.cpp:231
+#: ../src/common/fmapbase.cpp:228
 msgid "MacDingbats"
 msgstr "MacDingbats"
 
-#: ../src/common/fmapbase.cpp:226
+#: ../src/common/fmapbase.cpp:223
 msgid "MacEthiopic"
 msgstr "MacEtiopské"
 
-#: ../src/common/fmapbase.cpp:229
+#: ../src/common/fmapbase.cpp:226
 msgid "MacExtArabic"
 msgstr "MacArabštinaRozš"
 
-#: ../src/common/fmapbase.cpp:237
+#: ../src/common/fmapbase.cpp:234
 msgid "MacGaelic"
 msgstr "MacGaelština"
 
-#: ../src/common/fmapbase.cpp:221
+#: ../src/common/fmapbase.cpp:218
 msgid "MacGeorgian"
 msgstr "MacGruzinský"
 
-#: ../src/common/fmapbase.cpp:205
+#: ../src/common/fmapbase.cpp:202
 msgid "MacGreek"
 msgstr "MacŘečtina"
 
-#: ../src/common/fmapbase.cpp:209
+#: ../src/common/fmapbase.cpp:206
 msgid "MacGujarati"
 msgstr "MacGudžarátština"
 
-#: ../src/common/fmapbase.cpp:208
+#: ../src/common/fmapbase.cpp:205
 msgid "MacGurmukhi"
 msgstr "MacGurmukhí"
 
-#: ../src/common/fmapbase.cpp:204
+#: ../src/common/fmapbase.cpp:201
 msgid "MacHebrew"
 msgstr "MacHebrejština"
 
-#: ../src/common/fmapbase.cpp:234
+#: ../src/common/fmapbase.cpp:231
 msgid "MacIcelandic"
 msgstr "MacIslandština"
 
-#: ../src/common/fmapbase.cpp:200
+#: ../src/common/fmapbase.cpp:197
 msgid "MacJapanese"
 msgstr "MacJaponština"
 
-#: ../src/common/fmapbase.cpp:214
+#: ../src/common/fmapbase.cpp:211
 msgid "MacKannada"
 msgstr "MacKannadština"
 
-#: ../src/common/fmapbase.cpp:238
+#: ../src/common/fmapbase.cpp:235
 msgid "MacKeyboardGlyphs"
 msgstr "MacKlávesovéGlyfy"
 
-#: ../src/common/fmapbase.cpp:218
+#: ../src/common/fmapbase.cpp:215
 msgid "MacKhmer"
 msgstr "MacKhmerština"
 
-#: ../src/common/fmapbase.cpp:202
+#: ../src/common/fmapbase.cpp:199
 msgid "MacKorean"
 msgstr "MacKorejština"
 
-#: ../src/common/fmapbase.cpp:220
+#: ../src/common/fmapbase.cpp:217
 msgid "MacLaotian"
 msgstr "Maclaoština"
 
-#: ../src/common/fmapbase.cpp:215
+#: ../src/common/fmapbase.cpp:212
 msgid "MacMalayalam"
 msgstr "MacMalajština"
 
-#: ../src/common/fmapbase.cpp:225
+#: ../src/common/fmapbase.cpp:222
 msgid "MacMongolian"
 msgstr "MacMongolština"
 
-#: ../src/common/fmapbase.cpp:210
+#: ../src/common/fmapbase.cpp:207
 msgid "MacOriya"
 msgstr "MacOrijština"
 
-#: ../src/common/fmapbase.cpp:199
+#: ../src/common/fmapbase.cpp:196
 msgid "MacRoman"
 msgstr "MacPatkové"
 
-#: ../src/common/fmapbase.cpp:235
+#: ../src/common/fmapbase.cpp:232
 msgid "MacRomanian"
 msgstr "MacPatkové"
 
-#: ../src/common/fmapbase.cpp:216
+#: ../src/common/fmapbase.cpp:213
 msgid "MacSinhalese"
 msgstr "MacSinhalština"
 
-#: ../src/common/fmapbase.cpp:230
+#: ../src/common/fmapbase.cpp:227
 msgid "MacSymbol"
 msgstr "MacSymbol"
 
-#: ../src/common/fmapbase.cpp:212
+#: ../src/common/fmapbase.cpp:209
 msgid "MacTamil"
 msgstr "MacTamilština"
 
-#: ../src/common/fmapbase.cpp:213
+#: ../src/common/fmapbase.cpp:210
 msgid "MacTelugu"
 msgstr "MacTelugština"
 
-#: ../src/common/fmapbase.cpp:219
+#: ../src/common/fmapbase.cpp:216
 msgid "MacThai"
 msgstr "MacThajština"
 
-#: ../src/common/fmapbase.cpp:224
+#: ../src/common/fmapbase.cpp:221
 msgid "MacTibetan"
 msgstr "MacTibetština"
 
-#: ../src/common/fmapbase.cpp:232
+#: ../src/common/fmapbase.cpp:229
 msgid "MacTurkish"
 msgstr "MacTurečtina"
 
-#: ../src/common/fmapbase.cpp:228
+#: ../src/common/fmapbase.cpp:225
 msgid "MacVietnamese"
 msgstr "MacVietnamština"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1762
+#: ../src/propgrid/advprops.cpp:1663
 msgid "Magnifier"
 msgstr "Lupa"
 
-#: ../src/propgrid/advprops.cpp:2143
+#: ../src/propgrid/advprops.cpp:2050
 msgid "Make a selection:"
 msgstr "Provést výběr:"
 
-#: ../src/richtext/richtextformatdlg.cpp:374
+#: ../src/richtext/richtextformatdlg.cpp:367
 #: ../src/richtext/richtextmarginspage.cpp:171
 msgid "Margins"
 msgstr "Okraje"
 
-#: ../src/propgrid/advprops.cpp:1595
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Maroon"
 msgstr "Kaštanová"
 
-#: ../src/generic/fdrepdlg.cpp:147
+#: ../src/generic/fdrepdlg.cpp:144
 msgid "Match case"
 msgstr "Rozlišuj malá a velká písmena"
 
@@ -4891,40 +5022,40 @@ msgstr "Max šířka:"
 msgid "Max width:"
 msgstr "Max šířka:"
 
-#: ../src/unix/mediactrl.cpp:947
+#: ../src/unix/mediactrl.cpp:972
 #, c-format
 msgid "Media playback error: %s"
 msgstr "Chyba při přehrávání: %s"
 
-#: ../src/common/fs_mem.cpp:175
+#: ../src/common/fs_mem.cpp:170
 #, c-format
 msgid "Memory VFS already contains file '%s'!"
 msgstr "Paměťový VFS už obsahuje soubor '%s'!"
 
 #. TRANSLATORS: Name of keyboard key
 #. TRANSLATORS: Keyword of system colour
-#: ../src/common/accelcmn.cpp:73 ../src/propgrid/advprops.cpp:889
+#: ../src/common/accelcmn.cpp:70 ../src/propgrid/advprops.cpp:790
 msgid "Menu"
 msgstr "Menu"
 
-#: ../src/common/msgout.cpp:124
+#: ../src/common/msgout.cpp:121
 msgid "Message"
 msgstr "Zpráva"
 
-#: ../src/univ/themes/metal.cpp:168
+#: ../src/univ/themes/metal.cpp:165
 msgid "Metal theme"
 msgstr "Téma Metal"
 
-#: ../src/msw/ole/automtn.cpp:652
+#: ../src/msw/ole/automtn.cpp:643
 msgid "Method or property not found."
 msgstr "Metoda nebo vlastnost nenalezena."
 
-#: ../src/univ/themes/win32.cpp:3752
+#: ../src/univ/themes/win32.cpp:3749
 msgid "Mi&nimize"
 msgstr "Mi&nimalizovat"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1763
+#: ../src/propgrid/advprops.cpp:1664
 msgid "Middle Button"
 msgstr "Prostřední tlačítko"
 
@@ -4936,36 +5067,41 @@ msgstr "Min výška:"
 msgid "Min width:"
 msgstr "Min šířka:"
 
-#: ../src/msw/ole/automtn.cpp:668
+#: ../src/osx/cocoa/menu.mm:281
+#, fuzzy
+msgid "Minimize"
+msgstr "Mi&nimalizovat"
+
+#: ../src/msw/ole/automtn.cpp:659
 msgid "Missing a required parameter."
 msgstr "Chybí požadovaný parametr."
 
-#: ../src/generic/fontdlgg.cpp:324
+#: ../src/generic/fontdlgg.cpp:320
 msgid "Modern"
 msgstr "Moderní"
 
-#: ../src/generic/filectrlg.cpp:427
+#: ../src/generic/filectrlg.cpp:423
 msgid "Modified"
 msgstr "Změněno"
 
-#: ../src/common/module.cpp:133
+#: ../src/common/module.cpp:130
 #, c-format
 msgid "Module \"%s\" initialization failed"
 msgstr "Zavédení modulu \"%s\" selhalo"
 
-#: ../src/common/paper.cpp:131
+#: ../src/common/paper.cpp:128
 msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
 msgstr "Obálka Monarch, 3 7/8 x 7 1/2 palce"
 
-#: ../src/msw/fswatcher.cpp:143
+#: ../src/msw/fswatcher.cpp:140
 msgid "Monitoring individual files for changes is not supported currently."
 msgstr "Sledování změn jednotlivých souborů není v současnosti podporováno."
 
-#: ../src/generic/editlbox.cpp:172
+#: ../src/generic/editlbox.cpp:160
 msgid "Move down"
 msgstr "Přesunout dolů"
 
-#: ../src/generic/editlbox.cpp:171
+#: ../src/generic/editlbox.cpp:155
 msgid "Move up"
 msgstr "Přesunout nahoru"
 
@@ -4979,97 +5115,103 @@ msgstr "Přesune objekt do dalšího odstavce."
 msgid "Moves the object to the previous paragraph."
 msgstr "Přesune objekt do předchozího odstavce."
 
-#: ../src/richtext/richtextbuffer.cpp:9966
+#: ../src/richtext/richtextbuffer.cpp:9963
 msgid "Multiple Cell Properties"
 msgstr "Vlastnosti více buněk"
 
-#: ../src/generic/filectrlg.cpp:424
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:82
+#, fuzzy
+msgid "Multiply"
+msgstr "NK_Krát"
+
+#: ../src/generic/filectrlg.cpp:420
 msgid "Name"
 msgstr "Jméno"
 
-#: ../src/propgrid/advprops.cpp:1596
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Navy"
 msgstr "Tmavě modrá"
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "Network"
 msgstr "Síť"
 
-#: ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173
 msgid "New"
 msgstr "Nový"
 
-#: ../src/richtext/richtextstyledlg.cpp:243
+#: ../src/richtext/richtextstyledlg.cpp:239
 msgid "New &Box Style..."
 msgstr "Nový &styl rámečku..."
 
-#: ../src/richtext/richtextstyledlg.cpp:225
+#: ../src/richtext/richtextstyledlg.cpp:221
 msgid "New &Character Style..."
 msgstr "&Nový styl znaku..."
 
-#: ../src/richtext/richtextstyledlg.cpp:237
+#: ../src/richtext/richtextstyledlg.cpp:233
 msgid "New &List Style..."
 msgstr "Nový Sty&l seznamu..."
 
-#: ../src/richtext/richtextstyledlg.cpp:231
+#: ../src/richtext/richtextstyledlg.cpp:227
 msgid "New &Paragraph Style..."
 msgstr "&Nový styl odstavce..."
 
-#: ../src/richtext/richtextstyledlg.cpp:606
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:654
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:820
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:893
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:934
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:602
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:650
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:816
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:889
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:930
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "New Style"
 msgstr "Nový styl"
 
-#: ../src/generic/editlbox.cpp:169
+#: ../src/generic/editlbox.cpp:139
 msgid "New item"
 msgstr "Nova položka"
 
-#: ../src/generic/dirdlgg.cpp:297 ../src/generic/dirdlgg.cpp:307
-#: ../src/generic/filectrlg.cpp:618 ../src/generic/filectrlg.cpp:627
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+#: ../src/generic/dirdlgg.cpp:294 ../src/generic/dirdlgg.cpp:304
 msgid "NewName"
 msgstr "NoveJmeno"
 
-#: ../src/common/prntbase.cpp:1567 ../src/html/helpwnd.cpp:665
+#: ../src/common/prntbase.cpp:1592 ../src/html/helpwnd.cpp:663
 msgid "Next page"
 msgstr "Následující stránka"
 
-#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:177
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:174
 #: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Ne"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1764
+#: ../src/propgrid/advprops.cpp:1665
 msgid "No Entry"
 msgstr "Není k dispozici"
 
-#: ../src/generic/animateg.cpp:150
+#: ../src/generic/animateg.cpp:133
 #, c-format
 msgid "No animation handler for type %ld defined."
 msgstr "Žádná obslužná rutina animací pro typ %ld není stanovena."
 
-#: ../src/dfb/bitmap.cpp:642 ../src/dfb/bitmap.cpp:676
+#: ../src/dfb/bitmap.cpp:639 ../src/dfb/bitmap.cpp:673
 #, c-format
 msgid "No bitmap handler for type %d defined."
 msgstr "Žádná obslužná rutina bitmapy pro typ %d není stanovena."
 
-#: ../src/common/utilscmn.cpp:1077
+#: ../src/common/utilscmn.cpp:1095
 msgid "No default application configured for HTML files."
 msgstr "Není nastavena žádná výchozí aplikace pro HTML soubory."
 
-#: ../src/generic/helpext.cpp:445
+#: ../src/generic/helpext.cpp:443
 msgid "No entries found."
 msgstr "Nenalezeny žádné položky."
 
-#: ../src/common/fontmap.cpp:421
+#: ../src/common/fontmap.cpp:418
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found,\n"
@@ -5081,7 +5223,7 @@ msgstr ""
 "ale je k dispozici alternativní kódování '%s'.\n"
 "Přejete si použít toto kódování (jinak si budete muset vybrat jiné)?"
 
-#: ../src/common/fontmap.cpp:426
+#: ../src/common/fontmap.cpp:423
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found.\n"
@@ -5092,201 +5234,201 @@ msgstr ""
 "Přejete si vybrat font, který se má s tímto kódováním použít\n"
 "(jinak se text v tomto kódování nezobrazí správně)?"
 
-#: ../src/generic/animateg.cpp:142
+#: ../src/generic/animateg.cpp:125
 msgid "No handler found for animation type."
 msgstr "Nenalezená žádná obslužná rutina pro typ animace."
 
-#: ../src/common/image.cpp:2728
+#: ../src/common/image.cpp:2823
 msgid "No handler found for image type."
 msgstr "Nenalezen žádný ovladač pro tento typ obrázků."
 
-#: ../src/common/image.cpp:2736 ../src/common/image.cpp:2848
-#: ../src/common/image.cpp:2901
+#: ../src/common/image.cpp:2831 ../src/common/image.cpp:2954
+#: ../src/common/image.cpp:3020
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "Nebyla stanovena žádná obslužná rutina obrázku pro typ %d."
 
-#: ../src/common/image.cpp:2871 ../src/common/image.cpp:2915
+#: ../src/common/image.cpp:2986 ../src/common/image.cpp:3034
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "Nebyla stanovena žádná obslužná rutina obrázku pro typ %s."
 
-#: ../src/html/helpwnd.cpp:858
+#: ../src/html/helpwnd.cpp:856
 msgid "No matching page found yet"
 msgstr "Ještě nebylo nic nalezeno"
 
-#: ../src/unix/sound.cpp:81
+#: ../src/unix/sound.cpp:78
 msgid "No sound"
 msgstr "Beze zvuku"
 
-#: ../src/common/image.cpp:2277 ../src/common/image.cpp:2318
+#: ../src/common/image.cpp:2371 ../src/common/image.cpp:2412
 msgid "No unused colour in image being masked."
 msgstr "V obrázku není maskována žádná nepoužitá barva."
 
-#: ../src/common/image.cpp:3374
-msgid "No unused colour in image."
-msgstr "V obrázku není žádná nepoužitá barva."
-
-#: ../src/generic/helpext.cpp:302
+#: ../src/generic/helpext.cpp:300
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "Nenalezeno žádné platné mapování v souboru \"%s\"."
 
-#: ../src/richtext/richtextborderspage.cpp:610
 #: ../src/richtext/richtextsizepage.cpp:248
 #: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:610
 msgid "None"
 msgstr "Žádný"
 
-#: ../src/common/fmapbase.cpp:157
+#: ../src/common/fmapbase.cpp:154
 msgid "Nordic (ISO-8859-10)"
 msgstr "Severské (ISO-8859-10)"
 
-#: ../src/generic/fontdlgg.cpp:328 ../src/generic/fontdlgg.cpp:331
+#: ../src/generic/fontdlgg.cpp:324 ../src/generic/fontdlgg.cpp:327
 msgid "Normal"
 msgstr "Normální"
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1261
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Normální písmo<br>a <u>podtržené</u>. "
 
-#: ../src/html/helpwnd.cpp:1205
+#: ../src/html/helpwnd.cpp:1203
 msgid "Normal font:"
 msgstr "Normální písmo:"
 
-#: ../src/propgrid/props.cpp:1128
+#: ../src/propgrid/props.cpp:1115
 #, c-format
 msgid "Not %s"
 msgstr "Není %s"
 
-#: ../include/wx/filename.h:573 ../include/wx/filename.h:578
-msgid "Not available"
-msgstr "Není dostupný"
+#: ../src/common/secretstore.cpp:168
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/webrequest.cpp:605
+msgid "Not enough free disk space for download."
+msgstr ""
 
 #: ../src/richtext/richtextfontpage.cpp:358
 msgid "Not underlined"
 msgstr "Není podtržený"
 
-#: ../src/common/paper.cpp:115
+#: ../src/common/paper.cpp:112
 msgid "Note, 8 1/2 x 11 in"
 msgstr "Note, 8 1/2 x 11 palců"
 
-#: ../src/generic/notifmsgg.cpp:132
+#: ../src/generic/notifmsgg.cpp:129
 msgid "Notice"
 msgstr "Oznámení"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "Num *"
 msgstr "* na numerické klávesnici"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "Num +"
 msgstr "+ na numerické klávesnici"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "Num ,"
 msgstr ", na numerické klávesnici"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "Num -"
 msgstr "- na numerické klávesnici"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "Num ."
 msgstr ". na numerické klávesnici"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "Num /"
 msgstr "/ na numerické klávesnici"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "Num ="
 msgstr "= na numerické klávesnici"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "Num Begin"
 msgstr "Begin na numerické klávesnici"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 msgid "Num Delete"
 msgstr "Delete na numerické klávesnici"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 msgid "Num Down"
 msgstr "Dolů na numerické klávesnici"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "Num End"
 msgstr "End na numerické klávesnici"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "Num Enter"
 msgstr "Enter na numerické klávesnici"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 msgid "Num Home"
 msgstr "Home na numerické klávesnici"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 msgid "Num Insert"
 msgstr "Insert na numerické klávesnici"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num Lock"
 msgstr "Num Lock"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "Num Page Down"
 msgstr "Page Down na numerické klávesnici"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "Num Page Up"
 msgstr "Page Up na numerické klávesnici"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 msgid "Num Right"
 msgstr "Doprava na numerické klávesnici"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "Num Space"
 msgstr "Mezerník na numerické klávesnici"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "Num Tab"
 msgstr "Tabulátor na numerické klávesnici"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "Num Up"
 msgstr "Nahoru na numerické klávesnici"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "Num left"
 msgstr "Doleva na numerické klávesnici"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num_lock"
 msgstr "Num_lock"
 
@@ -5295,13 +5437,13 @@ msgstr "Num_lock"
 msgid "Numbered outline"
 msgstr "Očíslovaný odstavec"
 
-#: ../include/wx/msgdlg.h:278 ../src/richtext/richtextstyledlg.cpp:297
-#: ../src/common/stockitem.cpp:178 ../src/msw/msgdlg.cpp:454
-#: ../src/msw/msgdlg.cpp:747 ../src/gtk1/fontdlg.cpp:138
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:175
+#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/msgdlg.cpp:741 ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "OK"
 
-#: ../src/msw/ole/automtn.cpp:692
+#: ../src/msw/ole/automtn.cpp:683
 #, c-format
 msgid "OLE Automation error in %s: %s"
 msgstr "Chyba automatizace OLE v %s: %s"
@@ -5310,15 +5452,15 @@ msgstr "Chyba automatizace OLE v %s: %s"
 msgid "Object Properties"
 msgstr "Vlastnosti objektu"
 
-#: ../src/msw/ole/automtn.cpp:660
+#: ../src/msw/ole/automtn.cpp:651
 msgid "Object implementation does not support named arguments."
 msgstr "Zavedení objektu nepodporuje pojmenované argumenty."
 
-#: ../src/common/xtixml.cpp:264
+#: ../src/common/xtixml.cpp:260
 msgid "Objects must have an id attribute"
 msgstr "Objekt musí mít atribut id"
 
-#: ../src/propgrid/advprops.cpp:1601
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Olive"
 msgstr "Olivová"
 
@@ -5326,64 +5468,69 @@ msgstr "Olivová"
 msgid "Opaci&ty:"
 msgstr "&Neprůhlednost:"
 
-#: ../src/generic/colrdlgg.cpp:354
+#: ../src/generic/colrdlgg.cpp:374
 msgid "Opacity:"
 msgstr "Neprůhlednost:"
 
-#: ../src/common/docview.cpp:1773 ../src/common/docview.cpp:1815
+#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
 msgid "Open File"
 msgstr "Otevřít soubor"
 
-#: ../src/html/helpwnd.cpp:671 ../src/html/helpwnd.cpp:1554
+#: ../src/html/helpwnd.cpp:669 ../src/html/helpwnd.cpp:1552
 msgid "Open HTML document"
 msgstr "Otevřít dokument HTML"
 
-#: ../src/generic/dbgrptg.cpp:163
+#: ../src/common/stockitem.cpp:265
+#, fuzzy
+msgid "Open an existing document"
+msgstr "Otevřít dokument HTML"
+
+#: ../src/generic/dbgrptg.cpp:160
 #, c-format
 msgid "Open file \"%s\""
 msgstr "Otevřít soubor \"%s\""
 
-#: ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176
 msgid "Open..."
 msgstr "Otevřít..."
 
-#: ../src/unix/glx11.cpp:506 ../src/msw/glcanvas.cpp:592
+#: ../src/msw/glcanvas.cpp:607 ../src/unix/glx11.cpp:513
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr "OpenGL 3.0 nebo novější není podporován ovladačem."
 
-#: ../src/generic/dirctrlg.cpp:599 ../src/generic/dirdlgg.cpp:323
-#: ../src/generic/filectrlg.cpp:642 ../src/generic/filectrlg.cpp:786
+#: ../src/generic/dirctrlg.cpp:565 ../src/generic/filectrlg.cpp:638
+#: ../src/generic/filectrlg.cpp:782 ../src/generic/dirdlgg.cpp:320
 msgid "Operation not permitted."
 msgstr "Zakázaná operace."
 
-#: ../src/common/cmdline.cpp:900
+#: ../src/common/cmdline.cpp:896
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "Možnost '%s' nemůže být znegována"
 
-#: ../src/common/cmdline.cpp:1064
+#: ../src/common/cmdline.cpp:1060
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "Volba '%s' vyžaduje hodnotu."
 
-#: ../src/common/cmdline.cpp:1147
+#: ../src/common/cmdline.cpp:1143
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Volba '%s': '%s' nemůže být převedena na datum."
 
-#: ../src/generic/prntdlgg.cpp:618
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Nastavení"
 
-#: ../src/propgrid/advprops.cpp:1606
+#: ../src/propgrid/advprops.cpp:1512
 msgid "Orange"
 msgstr "Oranžová"
 
-#: ../src/generic/prntdlgg.cpp:615 ../src/generic/prntdlgg.cpp:869
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:862
 msgid "Orientation"
 msgstr "Orientace"
 
-#: ../src/common/windowid.cpp:242
+#: ../src/common/windowid.cpp:237
 msgid "Out of window IDs.  Recommend shutting down application."
 msgstr "Došla ID oken. Doporučujeme zavřít aplikaci."
 
@@ -5396,148 +5543,148 @@ msgstr "Obrys"
 msgid "Outset"
 msgstr "Návrší"
 
-#: ../src/msw/ole/automtn.cpp:656
+#: ../src/msw/ole/automtn.cpp:647
 msgid "Overflow while coercing argument values."
 msgstr "Přetečení při nucení hodnot argumentů."
 
-#: ../src/common/imagpcx.cpp:457 ../src/common/imagpcx.cpp:480
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:479
 msgid "PCX: couldn't allocate memory"
 msgstr "PCX: nelze přidělit paměť."
 
-#: ../src/common/imagpcx.cpp:456
+#: ../src/common/imagpcx.cpp:455
 msgid "PCX: image format unsupported"
 msgstr "PCX: nepodporovaný formát obrázku"
 
-#: ../src/common/imagpcx.cpp:479
+#: ../src/common/imagpcx.cpp:478
 msgid "PCX: invalid image"
 msgstr "PCX: poškozený obrázek"
 
-#: ../src/common/imagpcx.cpp:442
+#: ../src/common/imagpcx.cpp:441
 msgid "PCX: this is not a PCX file."
 msgstr "PCX: tento soubor není PCX."
 
-#: ../src/common/imagpcx.cpp:459 ../src/common/imagpcx.cpp:481
+#: ../src/common/imagpcx.cpp:458 ../src/common/imagpcx.cpp:480
 msgid "PCX: unknown error !!!"
 msgstr "PCX: neznámá chyba !!!"
 
-#: ../src/common/imagpcx.cpp:458
+#: ../src/common/imagpcx.cpp:457
 msgid "PCX: version number too low"
 msgstr "PCX: číslo verze je příliš nízké"
 
-#: ../src/common/imagpnm.cpp:91
+#: ../src/common/imagpnm.cpp:89
 msgid "PNM: Couldn't allocate memory."
 msgstr "PNM: Nelze přidělit paměť."
 
-#: ../src/common/imagpnm.cpp:73
+#: ../src/common/imagpnm.cpp:71
 msgid "PNM: File format is not recognized."
 msgstr "PNM: formát souboru nerozeznán."
 
-#: ../src/common/imagpnm.cpp:112 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
 #: ../src/common/imagpnm.cpp:156
 msgid "PNM: File seems truncated."
 msgstr "PNM: Soubor je nejspíš uříznutý před koncem."
 
-#: ../src/common/paper.cpp:187
+#: ../src/common/paper.cpp:184
 msgid "PRC 16K 146 x 215 mm"
 msgstr "PRC 16K 146 x 215 mm"
 
-#: ../src/common/paper.cpp:200
+#: ../src/common/paper.cpp:197
 msgid "PRC 16K Rotated"
 msgstr "PRC 16K na šířku"
 
-#: ../src/common/paper.cpp:188
+#: ../src/common/paper.cpp:185
 msgid "PRC 32K 97 x 151 mm"
 msgstr "PRC 32K 97 x 151 mm"
 
-#: ../src/common/paper.cpp:201
+#: ../src/common/paper.cpp:198
 msgid "PRC 32K Rotated"
 msgstr "PRC 32K na šířku"
 
-#: ../src/common/paper.cpp:189
+#: ../src/common/paper.cpp:186
 msgid "PRC 32K(Big) 97 x 151 mm"
 msgstr "PRC 32K (velký) 97 x 151 mm"
 
-#: ../src/common/paper.cpp:202
+#: ../src/common/paper.cpp:199
 msgid "PRC 32K(Big) Rotated"
 msgstr "PRC 32K (velký) na šířku"
 
-#: ../src/common/paper.cpp:190
+#: ../src/common/paper.cpp:187
 msgid "PRC Envelope #1 102 x 165 mm"
 msgstr "Obálka PRC č. 1, 102 x 165 mm"
 
-#: ../src/common/paper.cpp:203
+#: ../src/common/paper.cpp:200
 msgid "PRC Envelope #1 Rotated 165 x 102 mm"
 msgstr "Obálka PRC č. 1 na šířku, 165 x 102 mm"
 
-#: ../src/common/paper.cpp:199
+#: ../src/common/paper.cpp:196
 msgid "PRC Envelope #10 324 x 458 mm"
 msgstr "Obálka PRC č. 10, 324 x 458 mm"
 
-#: ../src/common/paper.cpp:212
+#: ../src/common/paper.cpp:209
 msgid "PRC Envelope #10 Rotated 458 x 324 mm"
 msgstr "Obálka PRC č. 10 na šířku, 458 x 324 mm"
 
-#: ../src/common/paper.cpp:191
+#: ../src/common/paper.cpp:188
 msgid "PRC Envelope #2 102 x 176 mm"
 msgstr "Obálka PRC č. 2, 102 x 176 mm"
 
-#: ../src/common/paper.cpp:204
+#: ../src/common/paper.cpp:201
 msgid "PRC Envelope #2 Rotated 176 x 102 mm"
 msgstr "Obálka PRC č. 2, na šířku 176 x 102 mm"
 
-#: ../src/common/paper.cpp:192
+#: ../src/common/paper.cpp:189
 msgid "PRC Envelope #3 125 x 176 mm"
 msgstr "Obálka PRC č. 3, 125 x 176 mm"
 
-#: ../src/common/paper.cpp:205
+#: ../src/common/paper.cpp:202
 msgid "PRC Envelope #3 Rotated 176 x 125 mm"
 msgstr "Obálka PRC č. 3, na šířku 176 x 125 mm"
 
-#: ../src/common/paper.cpp:193
+#: ../src/common/paper.cpp:190
 msgid "PRC Envelope #4 110 x 208 mm"
 msgstr "Obálka PRC č. 4, 110 x 208 mm"
 
-#: ../src/common/paper.cpp:206
+#: ../src/common/paper.cpp:203
 msgid "PRC Envelope #4 Rotated 208 x 110 mm"
 msgstr "Obálka PRC č. 4, na šířku 208 x 110 mm"
 
-#: ../src/common/paper.cpp:194
+#: ../src/common/paper.cpp:191
 msgid "PRC Envelope #5 110 x 220 mm"
 msgstr "Obálka PRC č. 5, 110 x 220 mm"
 
-#: ../src/common/paper.cpp:207
+#: ../src/common/paper.cpp:204
 msgid "PRC Envelope #5 Rotated 220 x 110 mm"
 msgstr "Obálka PRC č. 5 na šířku, 220 x 110 mm"
 
-#: ../src/common/paper.cpp:195
+#: ../src/common/paper.cpp:192
 msgid "PRC Envelope #6 120 x 230 mm"
 msgstr "Obálka PRC č. 6, 120 x 230 mm"
 
-#: ../src/common/paper.cpp:208
+#: ../src/common/paper.cpp:205
 msgid "PRC Envelope #6 Rotated 230 x 120 mm"
 msgstr "Obálka PRC č. 6, na šířku 230 x 120 mm"
 
-#: ../src/common/paper.cpp:196
+#: ../src/common/paper.cpp:193
 msgid "PRC Envelope #7 160 x 230 mm"
 msgstr "Obálka PRC č. 7, 160 x 230 mm"
 
-#: ../src/common/paper.cpp:209
+#: ../src/common/paper.cpp:206
 msgid "PRC Envelope #7 Rotated 230 x 160 mm"
 msgstr "Obálka PRC č. 7 na šířku, 230 x 160 mm"
 
-#: ../src/common/paper.cpp:197
+#: ../src/common/paper.cpp:194
 msgid "PRC Envelope #8 120 x 309 mm"
 msgstr "Obálka PRC č. 8, 120 x 309 mm"
 
-#: ../src/common/paper.cpp:210
+#: ../src/common/paper.cpp:207
 msgid "PRC Envelope #8 Rotated 309 x 120 mm"
 msgstr "Obálka PRC č. 8 na šířku, 309 x 120 mm"
 
-#: ../src/common/paper.cpp:198
+#: ../src/common/paper.cpp:195
 msgid "PRC Envelope #9 229 x 324 mm"
 msgstr "Obálka PRC č. 9, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:211
+#: ../src/common/paper.cpp:208
 msgid "PRC Envelope #9 Rotated 324 x 229 mm"
 msgstr "Obálka PRC č. 9 na šířku, 324 x 229 mm"
 
@@ -5545,87 +5692,91 @@ msgstr "Obálka PRC č. 9 na šířku, 324 x 229 mm"
 msgid "Padding"
 msgstr "Vnitřní okraj"
 
-#: ../src/common/prntbase.cpp:2074
+#: ../src/common/prntbase.cpp:2096
 #, c-format
 msgid "Page %d"
 msgstr "Strana %d"
 
-#: ../src/common/prntbase.cpp:2072
+#: ../src/common/prntbase.cpp:2094
 #, c-format
 msgid "Page %d of %d"
 msgstr "Strana %d z %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 msgid "Page Down"
 msgstr "Page Down"
 
-#: ../src/gtk/print.cpp:826
+#: ../src/gtk/print.cpp:829
 msgid "Page Setup"
 msgstr "Nastavení stránky"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 msgid "Page Up"
 msgstr "Page Up"
 
-#: ../src/generic/prntdlgg.cpp:828 ../src/common/prntbase.cpp:484
+#: ../src/common/prntbase.cpp:479 ../src/generic/prntdlgg.cpp:821
 msgid "Page setup"
 msgstr "Nastavení stránky"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 msgid "PageDown"
 msgstr "PageDown"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 msgid "PageUp"
 msgstr "PageUp"
 
-#: ../src/generic/prntdlgg.cpp:216
+#: ../src/generic/prntdlgg.cpp:209
 msgid "Pages"
 msgstr "Strany"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1765
+#: ../src/propgrid/advprops.cpp:1666
 msgid "Paint Brush"
 msgstr "Štětec"
 
-#: ../src/generic/prntdlgg.cpp:602 ../src/generic/prntdlgg.cpp:801
-#: ../src/generic/prntdlgg.cpp:842 ../src/generic/prntdlgg.cpp:855
-#: ../src/generic/prntdlgg.cpp:1052 ../src/generic/prntdlgg.cpp:1057
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:794
+#: ../src/generic/prntdlgg.cpp:835 ../src/generic/prntdlgg.cpp:848
+#: ../src/generic/prntdlgg.cpp:1045 ../src/generic/prntdlgg.cpp:1050
 msgid "Paper size"
 msgstr "Velikost papíru"
 
-#: ../src/richtext/richtextstyles.cpp:1062
+#: ../src/richtext/richtextstyles.cpp:1059
 msgid "Paragraph styles"
 msgstr "Styly odstavce"
 
-#: ../src/common/xtistrm.cpp:465
+#: ../src/common/xtistrm.cpp:462
 msgid "Passing a already registered object to SetObject"
 msgstr "Předávání už zaregistrovaného objektu do SetObject"
 
-#: ../src/common/xtistrm.cpp:476
+#: ../src/common/xtistrm.cpp:473
 msgid "Passing an unknown object to GetObject"
 msgstr "Předávání neznámého objektu do GetObject"
 
-#: ../src/richtext/richtextctrl.cpp:3513 ../src/common/stockitem.cpp:180
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:177 ../src/richtext/richtextctrl.cpp:3514
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Vložit"
 
-#: ../src/common/stockitem.cpp:262
+#: ../src/common/stockitem.cpp:260
 msgid "Paste selection"
 msgstr "Vložit výběr"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:74
+#: ../src/common/accelcmn.cpp:71
 msgid "Pause"
 msgstr "Pauza"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1766
+#: ../src/propgrid/advprops.cpp:1667
 msgid "Pencil"
 msgstr "Tužka"
 
@@ -5634,21 +5785,21 @@ msgstr "Tužka"
 msgid "Peri&od"
 msgstr "Tečk&a"
 
-#: ../src/generic/filectrlg.cpp:430
+#: ../src/generic/filectrlg.cpp:426
 msgid "Permissions"
 msgstr "Práva"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:60
+#: ../src/common/accelcmn.cpp:57
 msgid "PgDn"
 msgstr "PgDn"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:59
+#: ../src/common/accelcmn.cpp:56
 msgid "PgUp"
 msgstr "PgUp"
 
-#: ../src/richtext/richtextbuffer.cpp:12868
+#: ../src/richtext/richtextbuffer.cpp:12863
 msgid "Picture Properties"
 msgstr "Vlastnosti obrázku"
 
@@ -5660,42 +5811,42 @@ msgstr "Nelze vytvořit rouru"
 msgid "Please choose a valid font."
 msgstr "Prosím vyberte platný font."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
 msgid "Please choose an existing file."
 msgstr "Prosím vyberte existující soubor."
 
-#: ../src/html/helpwnd.cpp:800
+#: ../src/html/helpwnd.cpp:798
 msgid "Please choose the page to display:"
 msgstr "Prosím vyberte stránku k zobrazení:"
 
-#: ../src/msw/dialup.cpp:764
+#: ../src/msw/dialup.cpp:758
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Prosím vyberte si poskytovatele (ISP), ke kterému se chcete připojit"
 
-#: ../src/common/headerctrlcmn.cpp:59
+#: ../src/common/headerctrlcmn.cpp:57
 msgid "Please select the columns to show and define their order:"
 msgstr "Prosím vyberte sloupce k zobrazení a určete jejich pořadí:"
 
-#: ../src/common/prntbase.cpp:538
+#: ../src/common/prntbase.cpp:533
 msgid "Please wait while printing..."
 msgstr "Prosím vyčkejte až skončí tisk..."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1767
+#: ../src/propgrid/advprops.cpp:1668
 msgid "Point Left"
 msgstr "Ukazatel doleva"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1768
+#: ../src/propgrid/advprops.cpp:1669
 msgid "Point Right"
 msgstr "Ukazatel doprava"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:662
+#: ../src/propgrid/advprops.cpp:572
 msgid "Point Size"
 msgstr "Velikost bodu"
 
-#: ../src/generic/prntdlgg.cpp:612 ../src/generic/prntdlgg.cpp:867
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:860
 msgid "Portrait"
 msgstr "Na výšku"
 
@@ -5703,252 +5854,262 @@ msgstr "Na výšku"
 msgid "Position"
 msgstr "Pozice"
 
-#: ../src/generic/prntdlgg.cpp:298
+#: ../src/generic/prntdlgg.cpp:291
 msgid "PostScript file"
 msgstr "soubor PostScriptu"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178 ../src/osx/cocoa/preferences.mm:303
 msgid "Preferences"
 msgstr "Předvolby"
 
-#: ../src/osx/menu_osx.cpp:568
+#: ../src/osx/menu_osx.cpp:460
 msgid "Preferences..."
 msgstr "Předvolby..."
 
-#: ../src/common/prntbase.cpp:546
+#: ../src/common/prntbase.cpp:541
 msgid "Preparing"
 msgstr "Připravování"
 
-#: ../src/generic/fontdlgg.cpp:455 ../src/osx/carbon/fontdlg.cpp:390
-#: ../src/html/helpwnd.cpp:1222
+#: ../src/osx/carbon/fontdlg.cpp:387 ../src/generic/fontdlgg.cpp:452
+#: ../src/html/helpwnd.cpp:1220
 msgid "Preview:"
 msgstr "Náhled:"
 
-#: ../src/common/prntbase.cpp:1553 ../src/html/helpwnd.cpp:664
+#: ../src/common/prntbase.cpp:1578 ../src/html/helpwnd.cpp:662
 msgid "Previous page"
 msgstr "Předchozí stránka"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/prntdlgg.cpp:143 ../src/generic/prntdlgg.cpp:157
-#: ../src/common/prntbase.cpp:426 ../src/common/prntbase.cpp:1541
-#: ../src/common/accelcmn.cpp:77 ../src/gtk/print.cpp:620
-#: ../src/gtk/print.cpp:638
+#: ../src/common/prntbase.cpp:421 ../src/common/prntbase.cpp:1566
+#: ../src/common/accelcmn.cpp:74 ../src/generic/prntdlgg.cpp:136
+#: ../src/generic/prntdlgg.cpp:150 ../src/gtk/print.cpp:616
+#: ../src/gtk/print.cpp:634
 msgid "Print"
 msgstr "Tisk"
 
-#: ../include/wx/prntbase.h:399 ../src/common/docview.cpp:1268
+#: ../src/common/docview.cpp:1262
 msgid "Print Preview"
 msgstr "Náhled tisku"
 
-#: ../src/common/prntbase.cpp:2015 ../src/common/prntbase.cpp:2057
-#: ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2037 ../src/common/prntbase.cpp:2079
+#: ../src/common/prntbase.cpp:2087
 msgid "Print Preview Failure"
 msgstr "Chyba během vytváření náhledu."
 
-#: ../src/generic/prntdlgg.cpp:224
+#: ../src/generic/prntdlgg.cpp:217
 msgid "Print Range"
 msgstr "Rozsah tisku"
 
-#: ../src/generic/prntdlgg.cpp:449
+#: ../src/generic/prntdlgg.cpp:442
 msgid "Print Setup"
 msgstr "Nastavení tisku"
 
-#: ../src/generic/prntdlgg.cpp:621
+#: ../src/generic/prntdlgg.cpp:614
 msgid "Print in colour"
 msgstr "Tisknout barevně"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/osx/webview_webkit.mm:260
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "Popis sloupce nemohl být zaveden."
+
+#: ../src/common/stockitem.cpp:179
 msgid "Print previe&w..."
 msgstr "Náhle&d tisku..."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1256
 msgid "Print preview creation failed."
 msgstr "Nelze vytvořit náhled tisku."
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/common/stockitem.cpp:179
 msgid "Print preview..."
 msgstr "Náhled tisku..."
 
-#: ../src/generic/prntdlgg.cpp:630
+#: ../src/generic/prntdlgg.cpp:623
 msgid "Print spooling"
 msgstr "Tisková fronta"
 
-#: ../src/html/helpwnd.cpp:675
+#: ../src/html/helpwnd.cpp:673
 msgid "Print this page"
 msgstr "Vytiskne tuto stránku"
 
-#: ../src/generic/prntdlgg.cpp:185
+#: ../src/generic/prntdlgg.cpp:178
 msgid "Print to File"
 msgstr "Tisk do souboru"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "Print..."
 msgstr "Tisk..."
 
-#: ../src/generic/prntdlgg.cpp:493
+#: ../src/generic/prntdlgg.cpp:486
 msgid "Printer"
 msgstr "Tiskárna"
 
-#: ../src/generic/prntdlgg.cpp:633
+#: ../src/generic/prntdlgg.cpp:626
 msgid "Printer command:"
 msgstr "Příkaz tisku:"
 
-#: ../src/generic/prntdlgg.cpp:180
+#: ../src/generic/prntdlgg.cpp:173
 msgid "Printer options"
 msgstr "Nastavení tiskárny"
 
-#: ../src/generic/prntdlgg.cpp:645
+#: ../src/generic/prntdlgg.cpp:638
 msgid "Printer options:"
 msgstr "Nastavení tiskárny:"
 
-#: ../src/generic/prntdlgg.cpp:916
+#: ../src/generic/prntdlgg.cpp:909
 msgid "Printer..."
 msgstr "Tiskárna..."
 
-#: ../src/generic/prntdlgg.cpp:196
+#: ../src/generic/prntdlgg.cpp:189
 msgid "Printer:"
 msgstr "Tiskárna:"
 
-#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:535
-#: ../src/html/htmprint.cpp:277
+#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:530
+#: ../src/html/htmprint.cpp:289
 msgid "Printing"
 msgstr "Tisk"
 
-#: ../src/common/prntbase.cpp:612
+#: ../src/common/prntbase.cpp:607
 msgid "Printing "
 msgstr "Tisk "
 
-#: ../src/common/prntbase.cpp:347
+#: ../src/common/prntbase.cpp:342
 msgid "Printing Error"
 msgstr "Chyba tisku"
 
-#: ../src/common/prntbase.cpp:565
+#: ../src/osx/webview_webkit.mm:251
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "Gzip není v této verzi zlib podporován"
+
+#: ../src/common/prntbase.cpp:560
 #, c-format
 msgid "Printing page %d"
 msgstr "Tisk strany %d"
 
-#: ../src/common/prntbase.cpp:570
+#: ../src/common/prntbase.cpp:565
 #, c-format
 msgid "Printing page %d of %d"
 msgstr "Tisk strany %d z %d"
 
-#: ../src/generic/printps.cpp:201
+#: ../src/generic/printps.cpp:182
 #, c-format
 msgid "Printing page %d..."
 msgstr "Tisk strany %d..."
 
-#: ../src/generic/printps.cpp:161
+#: ../src/generic/printps.cpp:142
 msgid "Printing..."
 msgstr "Tisk..."
 
-#: ../include/wx/richtext/richtextprint.h:109 ../include/wx/prntbase.h:267
-#: ../src/common/docview.cpp:2132
+#: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
+#: ../src/common/docview.cpp:2137
 msgid "Printout"
 msgstr "Výtisk"
 
-#: ../src/common/debugrpt.cpp:560
+#: ../src/common/debugrpt.cpp:561
 #, c-format
 msgid ""
 "Processing debug report has failed, leaving the files in \"%s\" directory."
 msgstr ""
 "Zpracování protokolu ladění selhalo, ponechávám soubory v adresáři \"%s\"."
 
-#: ../src/common/prntbase.cpp:545
+#: ../src/common/prntbase.cpp:540
 msgid "Progress:"
 msgstr "Postup:"
 
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181
 msgid "Properties"
 msgstr "Vlastnosti"
 
-#: ../src/propgrid/manager.cpp:237
+#: ../src/propgrid/manager.cpp:223
 msgid "Property"
 msgstr "Vlastnost"
 
 #. TRANSLATORS: Caption of message box displaying any property error
-#: ../src/propgrid/propgrid.cpp:3185 ../src/propgrid/propgrid.cpp:3318
+#: ../src/propgrid/propgrid.cpp:3162 ../src/propgrid/propgrid.cpp:3299
 msgid "Property Error"
 msgstr "Chyba vlastnosti"
 
-#: ../src/propgrid/advprops.cpp:1597
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Purple"
 msgstr "Nachová"
 
-#: ../src/common/paper.cpp:112
+#: ../src/common/paper.cpp:109
 msgid "Quarto, 215 x 275 mm"
 msgstr "Quarto, 215 x 275 mm"
 
-#: ../src/generic/logg.cpp:1016
+#: ../src/generic/logg.cpp:1013
 msgid "Question"
 msgstr "Otázka"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1769
+#: ../src/propgrid/advprops.cpp:1670
 msgid "Question Arrow"
 msgstr "Výběr nápovědy"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "Quit"
 msgstr "Ukončit"
 
-#: ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:477
 #, c-format
 msgid "Quit %s"
 msgstr "Ukončit %s"
 
-#: ../src/common/stockitem.cpp:263
+#: ../src/common/stockitem.cpp:261
 msgid "Quit this program"
 msgstr "Ukončit tento program"
 
-#: ../src/common/accelcmn.cpp:338
+#: ../src/common/accelcmn.cpp:352
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/ffile.cpp:109 ../src/common/ffile.cpp:133
+#: ../src/common/ffile.cpp:107 ../src/common/ffile.cpp:132
 #, c-format
 msgid "Read error on file '%s'"
 msgstr "Chyba při čtení ze souboru '%s'"
 
-#: ../src/common/secretstore.cpp:199
-#, c-format
-msgid "Reading password for \"%s/%s\" failed: %s."
+#: ../src/common/secretstore.cpp:211
+#, fuzzy, c-format
+msgid "Reading password for \"%s\" failed: %s."
 msgstr "Nelze načíst heslo pro \"%s/%s\": %s."
 
-#: ../src/common/prntbase.cpp:272
+#: ../src/common/prntbase.cpp:267
 msgid "Ready"
 msgstr "&Hotovo"
 
-#: ../src/propgrid/advprops.cpp:1605
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Red"
 msgstr "Červená"
 
-#: ../src/generic/colrdlgg.cpp:339
+#: ../src/generic/colrdlgg.cpp:359
 msgid "Red:"
 msgstr "Červená:"
 
-#: ../src/common/stockitem.cpp:185 ../src/stc/stc_i18n.cpp:16
+#: ../src/common/stockitem.cpp:182 ../src/stc/stc_i18n.cpp:16
 msgid "Redo"
 msgstr "&Zopakovat"
 
-#: ../src/common/stockitem.cpp:264
+#: ../src/common/stockitem.cpp:262
 msgid "Redo last action"
 msgstr "Zopakovat poslední činnost"
 
-#: ../src/common/stockitem.cpp:186
+#: ../src/common/stockitem.cpp:183
 msgid "Refresh"
 msgstr "Obnovit"
 
-#: ../src/msw/registry.cpp:626
+#: ../src/msw/registry.cpp:615
 #, c-format
 msgid "Registry key '%s' already exists."
 msgstr "Klíč registru '%s' už existuje."
 
-#: ../src/msw/registry.cpp:595
+#: ../src/msw/registry.cpp:584
 #, c-format
 msgid "Registry key '%s' does not exist, cannot rename it."
 msgstr "Klíč registru '%s' neexistuje, Nelze ho přejmenovat."
 
-#: ../src/msw/registry.cpp:727
+#: ../src/msw/registry.cpp:716
 #, c-format
 msgid ""
 "Registry key '%s' is needed for normal system operation,\n"
@@ -5959,22 +6120,22 @@ msgstr ""
 "pokud ho smažete, systém bude nestabilní:\n"
 "operace přerušena."
 
-#: ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:942
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr "Hodnota registru \"%s\" není binární (má typ %s)"
 
-#: ../src/msw/registry.cpp:917
+#: ../src/msw/registry.cpp:905
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr "Hodnota registru \"%s\" není číselná (má typ %s)"
 
-#: ../src/msw/registry.cpp:1003
+#: ../src/msw/registry.cpp:991
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr "Hodnota registru \"%s\" není textová (má typ %s)"
 
-#: ../src/msw/registry.cpp:521
+#: ../src/msw/registry.cpp:510
 #, c-format
 msgid "Registry value '%s' already exists."
 msgstr "Hodnota klíče registru '%s' už existuje."
@@ -5988,70 +6149,76 @@ msgstr "Normální"
 msgid "Relative"
 msgstr "Relativní"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:456
 msgid "Relevant entries:"
 msgstr "Související položky:"
 
-#: ../include/wx/generic/progdlgg.h:86
+#: ../include/wx/generic/progdlgg.h:87
 msgid "Remaining time:"
 msgstr "Zbývající čas:"
 
-#: ../src/common/stockitem.cpp:187
+#: ../src/common/stockitem.cpp:184
 msgid "Remove"
 msgstr "Odstranit"
 
-#: ../src/richtext/richtextctrl.cpp:1562
+#: ../src/richtext/richtextctrl.cpp:1563
 msgid "Remove Bullet"
 msgstr "Odstranit odrážku"
 
-#: ../src/html/helpwnd.cpp:433
+#: ../src/html/helpwnd.cpp:431
 msgid "Remove current page from bookmarks"
 msgstr "Odstraní tuto stránku ze záložek"
 
-#: ../src/common/rendcmn.cpp:194
+#: ../src/common/rendcmn.cpp:191
 #, c-format
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr "Vykreslovač \"%s\" má nekompatibilní verzi %d.%d a nemohl být načten."
 
-#: ../src/richtext/richtextbuffer.cpp:4527
+#: ../src/richtext/richtextbuffer.cpp:4524
 msgid "Renumber List"
 msgstr "Znovu očíslovat seznam"
 
-#: ../src/common/stockitem.cpp:188
-msgid "Rep&lace"
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Rep&lace..."
 msgstr "&Nahradit"
 
-#: ../src/richtext/richtextctrl.cpp:3673 ../src/common/stockitem.cpp:188
+#: ../src/richtext/richtextctrl.cpp:3674
 msgid "Replace"
 msgstr "Nahradit"
 
-#: ../src/generic/fdrepdlg.cpp:182
+#: ../src/generic/fdrepdlg.cpp:179
 msgid "Replace &all"
 msgstr "N&ahradit vše"
 
-#: ../src/common/stockitem.cpp:261
-msgid "Replace selection"
-msgstr "Nahradit výběr"
-
-#: ../src/generic/fdrepdlg.cpp:124
+#: ../src/generic/fdrepdlg.cpp:121
 msgid "Replace with:"
 msgstr "Nahradit textem:"
 
-#: ../src/common/valtext.cpp:163
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Replace..."
+msgstr "Nahradit"
+
+#: ../src/common/valtext.cpp:184
 msgid "Required information entry is empty."
 msgstr "Požadovaný informační údaj je prázdný."
 
-#: ../src/common/translation.cpp:1975
+#: ../src/common/translation.cpp:2025
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "Zdroj '%s' není platný katalog zpráv."
 
+#: ../src/gtk/webview_webkit.cpp:985
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:56
+#: ../src/common/accelcmn.cpp:53
 msgid "Return"
 msgstr "Return"
 
-#: ../src/common/stockitem.cpp:189
+#: ../src/common/stockitem.cpp:186
 msgid "Revert to Saved"
 msgstr "Vrátit k uloženému"
 
@@ -6063,41 +6230,41 @@ msgstr "Val"
 msgid "Rig&ht-to-left"
 msgstr "&Zprava doleva"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6149
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:59 ../src/generic/datavgen.cpp:6954
+#: ../src/richtext/richtextsizepage.cpp:250
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextbulletspage.cpp:188
-#: ../src/richtext/richtextsizepage.cpp:250 ../src/common/accelcmn.cpp:62
 msgid "Right"
 msgstr "Doprava"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1754
+#: ../src/propgrid/advprops.cpp:1655
 msgid "Right Arrow"
 msgstr "Šipka doprava"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1770
+#: ../src/propgrid/advprops.cpp:1671
 msgid "Right Button"
 msgstr "Pravé tlačítko"
 
-#: ../src/generic/prntdlgg.cpp:892
+#: ../src/generic/prntdlgg.cpp:885
 msgid "Right margin (mm):"
 msgstr "Pravý okraj (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:148
-#: ../src/richtext/richtextindentspage.cpp:150
 #: ../src/richtext/richtextliststylepage.cpp:337
 #: ../src/richtext/richtextliststylepage.cpp:339
+#: ../src/richtext/richtextindentspage.cpp:148
+#: ../src/richtext/richtextindentspage.cpp:150
 msgid "Right-align text."
 msgstr "Zarovnat text doprava."
 
-#: ../src/generic/fontdlgg.cpp:322
+#: ../src/generic/fontdlgg.cpp:318
 msgid "Roman"
 msgstr "Patkové"
 
-#: ../src/generic/datavgen.cpp:5916
+#: ../src/generic/datavgen.cpp:6721
 #, c-format
 msgid "Row %i"
 msgstr "Řádka %i"
@@ -6107,30 +6274,31 @@ msgstr "Řádka %i"
 msgid "S&tandard bullet name:"
 msgstr "S&tandardní jméno odrážky:"
 
-#: ../src/common/accelcmn.cpp:268 ../src/common/accelcmn.cpp:350
+#: ../src/common/accelcmn.cpp:282 ../src/common/accelcmn.cpp:367
 msgid "SPECIAL"
 msgstr "SPECIÁLNÍ"
 
-#: ../src/common/stockitem.cpp:190 ../src/common/sizer.cpp:2797
+#: ../src/common/stockitem.cpp:187 ../src/common/sizer.cpp:2914
 msgid "Save"
 msgstr "Uložit"
 
-#: ../src/common/fldlgcmn.cpp:342
+#: ../src/common/fldlgcmn.cpp:339
 #, c-format
 msgid "Save %s file"
 msgstr "Uložit soubor %s"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/common/stockitem.cpp:188 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Uložit &jako..."
 
-#: ../src/common/docview.cpp:366
+#: ../src/common/docview.cpp:359
 msgid "Save As"
 msgstr "Uložit jako"
 
-#: ../src/common/stockitem.cpp:191
-msgid "Save as"
-msgstr "Uložit jako"
+#: ../src/common/stockitem.cpp:188
+#, fuzzy
+msgid "Save As..."
+msgstr "Uložit &jako..."
 
 #: ../src/common/stockitem.cpp:267
 msgid "Save current document"
@@ -6140,40 +6308,40 @@ msgstr "Uložit aktuální dokument"
 msgid "Save current document with a different filename"
 msgstr "Uložit aktuální dokument s jiným jménem"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/generic/logg.cpp:509
 msgid "Save log contents to file"
 msgstr "Uložit obsah logu do souboru"
 
-#: ../src/common/secretstore.cpp:179
-#, c-format
-msgid "Saving password for \"%s/%s\" failed: %s."
+#: ../src/common/secretstore.cpp:189
+#, fuzzy, c-format
+msgid "Saving password for \"%s\" failed: %s."
 msgstr "Nelze uložit heslo pro \"%s/%s\": %s."
 
-#: ../src/generic/fontdlgg.cpp:325
+#: ../src/generic/fontdlgg.cpp:321
 msgid "Script"
 msgstr "Psací"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll Lock"
 msgstr "Scroll Lock"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll_lock"
 msgstr "Scroll_lock"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:890
+#: ../src/propgrid/advprops.cpp:791
 msgid "Scrollbar"
 msgstr "Posuvník"
 
-#: ../src/generic/srchctlg.cpp:56 ../src/html/helpwnd.cpp:535
-#: ../src/html/helpwnd.cpp:550
+#: ../src/generic/srchctlg.cpp:55 ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:548 ../src/gtk/srchctrl.cpp:182
 msgid "Search"
 msgstr "Hledat"
 
-#: ../src/html/helpwnd.cpp:537
+#: ../src/html/helpwnd.cpp:535
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
@@ -6181,55 +6349,55 @@ msgstr ""
 "Prohledá obsah knih(y) s nápovědou a vypíše všechny výskyty textu, který "
 "jste zadali"
 
-#: ../src/generic/fdrepdlg.cpp:160
+#: ../src/generic/fdrepdlg.cpp:157
 msgid "Search direction"
 msgstr "Směr hledání"
 
-#: ../src/generic/fdrepdlg.cpp:112
+#: ../src/generic/fdrepdlg.cpp:109
 msgid "Search for:"
 msgstr "Vyhledat řetězec:"
 
-#: ../src/html/helpwnd.cpp:1052
+#: ../src/html/helpwnd.cpp:1050
 msgid "Search in all books"
 msgstr "Hledej ve všech knihách"
 
-#: ../src/html/helpwnd.cpp:857
+#: ../src/html/helpwnd.cpp:855
 msgid "Searching..."
 msgstr "Hledám..."
 
-#: ../src/generic/dirctrlg.cpp:446
+#: ../src/generic/dirctrlg.cpp:412
 msgid "Sections"
 msgstr "Sekce"
 
-#: ../src/common/ffile.cpp:238
+#: ../src/common/ffile.cpp:237
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Chyba při nastavování pozice v souboru '%s'"
 
-#: ../src/common/ffile.cpp:228
+#: ../src/common/ffile.cpp:227
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr "Chyba hledání v souboru '%s' (stdio nepodporuje velké soubory)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:76
+#: ../src/common/accelcmn.cpp:73
 msgid "Select"
 msgstr "Vybrat"
 
-#: ../src/richtext/richtextctrl.cpp:337 ../src/osx/textctrl_osx.cpp:581
-#: ../src/common/stockitem.cpp:192 ../src/msw/textctrl.cpp:2512
+#: ../src/osx/textctrl_osx.cpp:599 ../src/common/stockitem.cpp:189
+#: ../src/msw/textctrl.cpp:2777 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Vybrat &vše"
 
-#: ../src/common/stockitem.cpp:192 ../src/stc/stc_i18n.cpp:21
+#: ../src/common/stockitem.cpp:189 ../src/stc/stc_i18n.cpp:21
 msgid "Select All"
 msgstr "Vybrat vše"
 
-#: ../src/common/docview.cpp:1895
+#: ../src/common/docview.cpp:1900
 msgid "Select a document template"
 msgstr "Vyberte šablonu dokumentu"
 
-#: ../src/common/docview.cpp:1969
+#: ../src/common/docview.cpp:1974
 msgid "Select a document view"
 msgstr "Vyberte zobrazení dokumentu"
 
@@ -6258,20 +6426,20 @@ msgid "Selects the list level to edit."
 msgstr "Vyberte úroveň seznamu k úpravě."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:82
+#: ../src/common/accelcmn.cpp:79
 msgid "Separator"
 msgstr "Oddělovač"
 
-#: ../src/common/cmdline.cpp:1083
+#: ../src/common/cmdline.cpp:1079
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Za volbou '%s' se očekává oddělovač."
 
-#: ../src/osx/menu_osx.cpp:572
+#: ../src/osx/menu_osx.cpp:464
 msgid "Services"
 msgstr "Služby"
 
-#: ../src/richtext/richtextbuffer.cpp:11217
+#: ../src/richtext/richtextbuffer.cpp:11216
 msgid "Set Cell Style"
 msgstr "Nastavit styl buňky"
 
@@ -6279,11 +6447,11 @@ msgstr "Nastavit styl buňky"
 msgid "SetProperty called w/o valid setter"
 msgstr "SetProperty zavoláno bez platné čtečky"
 
-#: ../src/generic/prntdlgg.cpp:188
+#: ../src/generic/prntdlgg.cpp:181
 msgid "Setup..."
 msgstr "Nastavení..."
 
-#: ../src/msw/dialup.cpp:544
+#: ../src/msw/dialup.cpp:538
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr ""
 "Nalezeno několik aktivních vytáčených připojení, vybírám jedno náhodně."
@@ -6300,40 +6468,40 @@ msgstr "Stín"
 msgid "Shadow c&olour:"
 msgstr "&Barva stínu:"
 
-#: ../src/common/accelcmn.cpp:335
+#: ../src/common/accelcmn.cpp:349
 msgid "Shift+"
 msgstr "Shift+"
 
-#: ../src/generic/dirdlgg.cpp:147
+#: ../src/generic/dirdlgg.cpp:144
 msgid "Show &hidden directories"
 msgstr "Zobrazit &skryté adresáře"
 
-#: ../src/generic/filectrlg.cpp:983
+#: ../src/generic/filectrlg.cpp:979
 msgid "Show &hidden files"
 msgstr "Zobrazit &skryté soubory"
 
-#: ../src/osx/menu_osx.cpp:580
+#: ../src/osx/menu_osx.cpp:472
 msgid "Show All"
 msgstr "Zobrazit vše"
 
-#: ../src/common/stockitem.cpp:257
+#: ../src/common/stockitem.cpp:254
 msgid "Show about dialog"
 msgstr "Zobrazit dialogové okno O aplikaci"
 
-#: ../src/html/helpwnd.cpp:492
+#: ../src/html/helpwnd.cpp:490
 msgid "Show all"
 msgstr "Zobraz vše"
 
-#: ../src/html/helpwnd.cpp:503
+#: ../src/html/helpwnd.cpp:501
 msgid "Show all items in index"
 msgstr "Zobrazí všechny položky v rejstříku"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:656
 msgid "Show/hide navigation panel"
 msgstr "Zobraz/skryj navigační panel"
 
-#: ../src/richtext/richtextsymboldlg.cpp:421
-#: ../src/richtext/richtextsymboldlg.cpp:423
+#: ../src/richtext/richtextsymboldlg.cpp:418
+#: ../src/richtext/richtextsymboldlg.cpp:420
 msgid "Shows a Unicode subset."
 msgstr "Zobrazí podskupinu Unicode."
 
@@ -6349,7 +6517,7 @@ msgstr "Zobrazí náhled nastavení odrážek."
 msgid "Shows a preview of the font settings."
 msgstr "Zobrazí náhled nastavení písma."
 
-#: ../src/osx/carbon/fontdlg.cpp:394 ../src/osx/carbon/fontdlg.cpp:396
+#: ../src/osx/carbon/fontdlg.cpp:391 ../src/osx/carbon/fontdlg.cpp:393
 msgid "Shows a preview of the font."
 msgstr "Zobrazí náhled písma."
 
@@ -6358,62 +6526,62 @@ msgstr "Zobrazí náhled písma."
 msgid "Shows a preview of the paragraph settings."
 msgstr "Zobrazí náhled nastavení odstavce."
 
-#: ../src/generic/fontdlgg.cpp:460 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:456 ../src/generic/fontdlgg.cpp:458
 msgid "Shows the font preview."
 msgstr "Zobrazí náhled písma."
 
-#: ../src/propgrid/advprops.cpp:1607
+#: ../src/propgrid/advprops.cpp:1513
 msgid "Silver"
 msgstr "Stříbrná"
 
-#: ../src/univ/themes/mono.cpp:516
+#: ../src/univ/themes/mono.cpp:513
 msgid "Simple monochrome theme"
 msgstr "Jednoduchý jednobarevný vzhled"
 
-#: ../src/richtext/richtextindentspage.cpp:275
 #: ../src/richtext/richtextliststylepage.cpp:449
+#: ../src/richtext/richtextindentspage.cpp:275
 msgid "Single"
 msgstr "Jednoduché"
 
-#: ../src/generic/filectrlg.cpp:425 ../src/richtext/richtextformatdlg.cpp:369
-#: ../src/richtext/richtextsizepage.cpp:299
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextsizepage.cpp:299
+#: ../src/richtext/richtextformatdlg.cpp:362
 msgid "Size"
 msgstr "Velikost"
 
-#: ../src/osx/carbon/fontdlg.cpp:339
+#: ../src/osx/carbon/fontdlg.cpp:336
 msgid "Size:"
 msgstr "Velikost:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1775
+#: ../src/propgrid/advprops.cpp:1676
 msgid "Sizing"
 msgstr "Změna velikosti"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1772
+#: ../src/propgrid/advprops.cpp:1673
 msgid "Sizing N-S"
 msgstr "Změna výšky"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1771
+#: ../src/propgrid/advprops.cpp:1672
 msgid "Sizing NE-SW"
 msgstr "Diagonální změna velikosti 2"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1773
+#: ../src/propgrid/advprops.cpp:1674
 msgid "Sizing NW-SE"
 msgstr "Diagonální změna velikosti 1"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1774
+#: ../src/propgrid/advprops.cpp:1675
 msgid "Sizing W-E"
 msgstr "Změna šířky"
 
-#: ../src/msw/progdlg.cpp:801
+#: ../src/msw/progdlg.cpp:1088
 msgid "Skip"
 msgstr "Přeskočit"
 
-#: ../src/generic/fontdlgg.cpp:330
+#: ../src/generic/fontdlgg.cpp:326
 msgid "Slant"
 msgstr "Skloněné"
 
@@ -6422,7 +6590,7 @@ msgid "Small C&apitals"
 msgstr "Malé k&apitálky"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:79
+#: ../src/common/accelcmn.cpp:76
 msgid "Snapshot"
 msgstr "Snapshot"
 
@@ -6430,37 +6598,37 @@ msgstr "Snapshot"
 msgid "Solid"
 msgstr "Plný"
 
-#: ../src/common/docview.cpp:1791
+#: ../src/common/docview.cpp:1785
 msgid "Sorry, could not open this file."
 msgstr "Je nám líto, tento soubor nelze otevřít."
 
-#: ../src/common/prntbase.cpp:2057 ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2079 ../src/common/prntbase.cpp:2087
 msgid "Sorry, not enough memory to create a preview."
 msgstr "Je nám líto, pro vytvoření náhledu je nedostatek paměti."
 
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "Sorry, that name is taken. Please choose another."
 msgstr "Je nám líto, toto jméno je zabrané. Vyberte si, prosím, jiné."
 
-#: ../src/common/docview.cpp:1814
+#: ../src/common/docview.cpp:1819
 msgid "Sorry, the format for this file is unknown."
 msgstr "Je nám líto, tento formát souboru je neznámý."
 
-#: ../src/unix/sound.cpp:492
+#: ../src/unix/sound.cpp:481
 msgid "Sound data are in unsupported format."
 msgstr "Zvuková data jsou v nepodporovaném formátu."
 
-#: ../src/unix/sound.cpp:477
+#: ../src/unix/sound.cpp:466
 #, c-format
 msgid "Sound file '%s' is in unsupported format."
 msgstr "Zvukový soubor '%s' je v nepodporovaném formátu."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:67
+#: ../src/common/accelcmn.cpp:64
 msgid "Space"
 msgstr "Mezerník"
 
@@ -6468,12 +6636,12 @@ msgstr "Mezerník"
 msgid "Spacing"
 msgstr "Řádkování"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "Spell Check"
 msgstr "Kontrola pravopisu"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1776
+#: ../src/propgrid/advprops.cpp:1677
 msgid "Spraycan"
 msgstr "Sprej"
 
@@ -6482,7 +6650,7 @@ msgstr "Sprej"
 msgid "Standard"
 msgstr "Standardní"
 
-#: ../src/common/paper.cpp:104
+#: ../src/common/paper.cpp:101
 msgid "Statement, 5 1/2 x 8 1/2 in"
 msgstr "Statement, 5 1/2 x 8 1/2 palce"
 
@@ -6491,33 +6659,29 @@ msgstr "Statement, 5 1/2 x 8 1/2 palce"
 msgid "Static"
 msgstr "Statické"
 
-#: ../src/generic/prntdlgg.cpp:204
+#: ../src/generic/prntdlgg.cpp:197
 msgid "Status:"
 msgstr "Stav:"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "Stop"
 msgstr "Zastavit"
 
-#: ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196
 msgid "Strikethrough"
 msgstr "Přeškrtnuté"
 
-#: ../src/common/colourcmn.cpp:45
+#: ../src/common/colourcmn.cpp:42
 #, c-format
 msgid "String To Colour : Incorrect colour specification : %s"
 msgstr "Text na barvu: chybná specifikace popisu barvy : %s"
 
 #. TRANSLATORS: Label of font style
-#: ../src/richtext/richtextformatdlg.cpp:339 ../src/propgrid/advprops.cpp:680
+#: ../src/propgrid/advprops.cpp:590 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Styl"
 
-#: ../include/wx/richtext/richtextstyledlg.h:46
-msgid "Style Organiser"
-msgstr "Organizátor stylů"
-
-#: ../src/osx/carbon/fontdlg.cpp:348
+#: ../src/osx/carbon/fontdlg.cpp:345
 msgid "Style:"
 msgstr "Styl:"
 
@@ -6526,7 +6690,7 @@ msgid "Subscrip&t"
 msgstr "Dolní inde&x"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:83
+#: ../src/common/accelcmn.cpp:80
 msgid "Subtract"
 msgstr "Mínus"
 
@@ -6534,11 +6698,11 @@ msgstr "Mínus"
 msgid "Supe&rscript"
 msgstr "Ho&rní index"
 
-#: ../src/common/paper.cpp:150
+#: ../src/common/paper.cpp:147
 msgid "SuperA/SuperA/A4 227 x 356 mm"
 msgstr "SuperA/SuperA/A4 227 x 356 mm"
 
-#: ../src/common/paper.cpp:151
+#: ../src/common/paper.cpp:148
 msgid "SuperB/SuperB/A3 305 x 487 mm"
 msgstr "SuperB/SuperB/A3, 305 x 487 mm"
 
@@ -6546,7 +6710,7 @@ msgstr "SuperB/SuperB/A3, 305 x 487 mm"
 msgid "Suppress hyphe&nation"
 msgstr "Potlačit &dělení slov"
 
-#: ../src/generic/fontdlgg.cpp:326
+#: ../src/generic/fontdlgg.cpp:322
 msgid "Swiss"
 msgstr "Bezpatkové"
 
@@ -6564,73 +6728,73 @@ msgstr "Symbolové &písmo:"
 msgid "Symbols"
 msgstr "Symboly"
 
-#: ../src/common/imagtiff.cpp:369 ../src/common/imagtiff.cpp:382
-#: ../src/common/imagtiff.cpp:741
+#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
+#: ../src/common/imagtiff.cpp:738
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: Nelze přidělit paměť."
 
-#: ../src/common/imagtiff.cpp:301
+#: ../src/common/imagtiff.cpp:298
 msgid "TIFF: Error loading image."
 msgstr "TIFF: Chyba při načítání obrázku."
 
-#: ../src/common/imagtiff.cpp:468
+#: ../src/common/imagtiff.cpp:465
 msgid "TIFF: Error reading image."
 msgstr "TIFF: Chyba při čtení obrázku."
 
-#: ../src/common/imagtiff.cpp:608
+#: ../src/common/imagtiff.cpp:605
 msgid "TIFF: Error saving image."
 msgstr "TIFF: Chyba při ukládání obrázku."
 
-#: ../src/common/imagtiff.cpp:846
+#: ../src/common/imagtiff.cpp:843
 msgid "TIFF: Error writing image."
 msgstr "TIFF: Chyba při zapisování obrázku."
 
-#: ../src/common/imagtiff.cpp:355
+#: ../src/common/imagtiff.cpp:352
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: Rozměr obrázku je abnormálně velký."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:68
+#: ../src/common/accelcmn.cpp:65
 msgid "Tab"
 msgstr "Tabulátor"
 
-#: ../src/richtext/richtextbuffer.cpp:11498
+#: ../src/richtext/richtextbuffer.cpp:11497
 msgid "Table Properties"
 msgstr "Vlastnosti tabulky"
 
-#: ../src/common/paper.cpp:145
+#: ../src/common/paper.cpp:142
 msgid "Tabloid Extra 11.69 x 18 in"
 msgstr "Tabloid Extra 11.69 x 18 palců"
 
-#: ../src/common/paper.cpp:102
+#: ../src/common/paper.cpp:99
 msgid "Tabloid, 11 x 17 in"
 msgstr "Tabloid, 11 x 17 palců"
 
-#: ../src/richtext/richtextformatdlg.cpp:354
+#: ../src/richtext/richtextformatdlg.cpp:347
 msgid "Tabs"
 msgstr "Panely"
 
-#: ../src/propgrid/advprops.cpp:1598
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Teal"
 msgstr "Modrozelená"
 
-#: ../src/generic/fontdlgg.cpp:327
+#: ../src/generic/fontdlgg.cpp:323
 msgid "Teletype"
 msgstr "Neproporcionální"
 
-#: ../src/common/docview.cpp:1896
+#: ../src/common/docview.cpp:1901
 msgid "Templates"
 msgstr "Šablony"
 
-#: ../src/common/fmapbase.cpp:158
+#: ../src/common/fmapbase.cpp:155
 msgid "Thai (ISO-8859-11)"
 msgstr "Thajské (ISO-8859-11)"
 
-#: ../src/common/ftp.cpp:619
+#: ../src/common/ftp.cpp:622
 msgid "The FTP server doesn't support passive mode."
 msgstr "FTP server nepodporuje pasivní mód."
 
-#: ../src/common/ftp.cpp:605
+#: ../src/common/ftp.cpp:608
 msgid "The FTP server doesn't support the PORT command."
 msgstr "FTP server nepodporuje příkaz PORT."
 
@@ -6641,8 +6805,8 @@ msgstr "FTP server nepodporuje příkaz PORT."
 msgid "The available bullet styles."
 msgstr "Dostupné styly odrážek."
 
-#: ../src/richtext/richtextstyledlg.cpp:202
-#: ../src/richtext/richtextstyledlg.cpp:204
+#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:200
 msgid "The available styles."
 msgstr "Dostupné styly."
 
@@ -6698,12 +6862,12 @@ msgstr "Dolní pozice."
 msgid "The bullet character."
 msgstr "Znak odrážky."
 
-#: ../src/richtext/richtextsymboldlg.cpp:443
-#: ../src/richtext/richtextsymboldlg.cpp:445
+#: ../src/richtext/richtextsymboldlg.cpp:440
+#: ../src/richtext/richtextsymboldlg.cpp:442
 msgid "The character code."
 msgstr "Kód znaku."
 
-#: ../src/common/fontmap.cpp:203
+#: ../src/common/fontmap.cpp:200
 #, c-format
 msgid ""
 "The charset '%s' is unknown. You may select\n"
@@ -6714,7 +6878,7 @@ msgstr ""
 "jinou sadu jako náhradu nebo stiskněte\n"
 "[Storno], pokud ji nelze nahradit"
 
-#: ../src/msw/ole/dataobj.cpp:394
+#: ../src/msw/ole/dataobj.cpp:402
 #, c-format
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "Formát schránky '%d' neexistuje."
@@ -6724,7 +6888,7 @@ msgstr "Formát schránky '%d' neexistuje."
 msgid "The default style for the next paragraph."
 msgstr "Výchozí styl pro další odstavec."
 
-#: ../src/generic/dirdlgg.cpp:202
+#: ../src/generic/dirdlgg.cpp:199
 #, c-format
 msgid ""
 "The directory '%s' does not exist\n"
@@ -6733,7 +6897,7 @@ msgstr ""
 "Adresář '%s' neexistuje\n"
 "Chcete ho vytvořit?"
 
-#: ../src/html/htmprint.cpp:271
+#: ../src/html/htmprint.cpp:283
 #, c-format
 msgid ""
 "The document \"%s\" doesn't fit on the page horizontally and will be "
@@ -6746,7 +6910,7 @@ msgstr ""
 "\n"
 "Chcete přesto pokračovat v tisku?"
 
-#: ../src/common/docview.cpp:1202
+#: ../src/common/docview.cpp:1196
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -6755,36 +6919,36 @@ msgstr ""
 "Soubor '%s' neexistuje a nemohl být otevřen.\n"
 "Byl odstraněn ze seznamu naposledy použitých souborů."
 
-#: ../src/richtext/richtextindentspage.cpp:208
-#: ../src/richtext/richtextindentspage.cpp:210
 #: ../src/richtext/richtextliststylepage.cpp:394
 #: ../src/richtext/richtextliststylepage.cpp:396
+#: ../src/richtext/richtextindentspage.cpp:208
+#: ../src/richtext/richtextindentspage.cpp:210
 msgid "The first line indent."
 msgstr "Odsazení prvního řádku."
 
-#: ../src/gtk/utilsgtk.cpp:481
-msgid "The following standard GTK+ options are also supported:\n"
-msgstr "Následující standardní volby GTK+ jsou také podporovány:\n"
+#: ../src/generic/dbgrptg.cpp:318
+msgid "The following debug report will be generated\n"
+msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:414 ../src/generic/fontdlgg.cpp:416
+#: ../src/generic/fontdlgg.cpp:411 ../src/generic/fontdlgg.cpp:413
 msgid "The font colour."
 msgstr "Barva písma."
 
-#: ../src/generic/fontdlgg.cpp:375 ../src/generic/fontdlgg.cpp:377
+#: ../src/generic/fontdlgg.cpp:371 ../src/generic/fontdlgg.cpp:373
 msgid "The font family."
 msgstr "Rodina písma."
 
-#: ../src/richtext/richtextsymboldlg.cpp:405
-#: ../src/richtext/richtextsymboldlg.cpp:407
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "The font from which to take the symbol."
 msgstr "Písmo, z kterého použít symbol."
 
-#: ../src/generic/fontdlgg.cpp:427 ../src/generic/fontdlgg.cpp:429
-#: ../src/generic/fontdlgg.cpp:434 ../src/generic/fontdlgg.cpp:436
+#: ../src/generic/fontdlgg.cpp:424 ../src/generic/fontdlgg.cpp:426
+#: ../src/generic/fontdlgg.cpp:430 ../src/generic/fontdlgg.cpp:432
 msgid "The font point size."
 msgstr "Velikost písma v bodech."
 
-#: ../src/osx/carbon/fontdlg.cpp:343 ../src/osx/carbon/fontdlg.cpp:345
+#: ../src/osx/carbon/fontdlg.cpp:340 ../src/osx/carbon/fontdlg.cpp:342
 msgid "The font size in points."
 msgstr "Velikost písma v bodech."
 
@@ -6793,15 +6957,15 @@ msgstr "Velikost písma v bodech."
 msgid "The font size units, points or pixels."
 msgstr "Jednotky velikosti písma, body nebo pixely."
 
-#: ../src/generic/fontdlgg.cpp:386 ../src/generic/fontdlgg.cpp:388
+#: ../src/generic/fontdlgg.cpp:382 ../src/generic/fontdlgg.cpp:384
 msgid "The font style."
 msgstr "Styl písma."
 
-#: ../src/generic/fontdlgg.cpp:397 ../src/generic/fontdlgg.cpp:399
+#: ../src/generic/fontdlgg.cpp:393 ../src/generic/fontdlgg.cpp:395
 msgid "The font weight."
 msgstr "Tučnost písma."
 
-#: ../src/common/docview.cpp:1483
+#: ../src/common/docview.cpp:1477
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Formát souboru '%s' nelze určit."
@@ -6811,10 +6975,10 @@ msgstr "Formát souboru '%s' nelze určit."
 msgid "The horizontal offset."
 msgstr "Vodorovné posunutí."
 
-#: ../src/richtext/richtextindentspage.cpp:199
-#: ../src/richtext/richtextindentspage.cpp:201
 #: ../src/richtext/richtextliststylepage.cpp:385
 #: ../src/richtext/richtextliststylepage.cpp:387
+#: ../src/richtext/richtextindentspage.cpp:199
+#: ../src/richtext/richtextindentspage.cpp:201
 msgid "The left indent."
 msgstr "Odsazení zleva."
 
@@ -6835,10 +6999,10 @@ msgstr "Velikost vnitřního okraje vlevo."
 msgid "The left position."
 msgstr "Pozice vlevo."
 
-#: ../src/richtext/richtextindentspage.cpp:288
-#: ../src/richtext/richtextindentspage.cpp:290
 #: ../src/richtext/richtextliststylepage.cpp:462
 #: ../src/richtext/richtextliststylepage.cpp:464
+#: ../src/richtext/richtextindentspage.cpp:288
+#: ../src/richtext/richtextindentspage.cpp:290
 msgid "The line spacing."
 msgstr "Řádkování."
 
@@ -6847,7 +7011,7 @@ msgstr "Řádkování."
 msgid "The list item number."
 msgstr "Číslo položky seznamu."
 
-#: ../src/msw/ole/automtn.cpp:664
+#: ../src/msw/ole/automtn.cpp:655
 msgid "The locale ID is unknown."
 msgstr "ID jazyka je neznámé."
 
@@ -6886,7 +7050,7 @@ msgstr "Šířka objektu."
 msgid "The outline level."
 msgstr "Úroveň odsazení"
 
-#: ../src/common/log.cpp:277
+#: ../src/common/log.cpp:296
 #, c-format
 msgid "The previous message repeated %u time."
 msgid_plural "The previous message repeated %u times."
@@ -6894,12 +7058,12 @@ msgstr[0] "Předchozí zpráva opakovaná %ukrát."
 msgstr[1] "Předchozí zpráva opakovaná %ukrát."
 msgstr[2] "Předchozí zpráva opakovaná %ukrát."
 
-#: ../src/common/log.cpp:270
+#: ../src/common/log.cpp:289
 msgid "The previous message repeated once."
 msgstr "Předchozí zpráva opakovaná jednou."
 
-#: ../src/richtext/richtextsymboldlg.cpp:462
-#: ../src/richtext/richtextsymboldlg.cpp:464
+#: ../src/richtext/richtextsymboldlg.cpp:459
+#: ../src/richtext/richtextsymboldlg.cpp:461
 msgid "The range to show."
 msgstr "Rozsah k zobrazení."
 
@@ -6913,15 +7077,15 @@ msgstr ""
 "obsahuje citlivé informace,\n"
 "prosím odškrtněte je a tyto budou z protokolu odstraněny.\n"
 
-#: ../src/common/cmdline.cpp:1254
+#: ../src/common/cmdline.cpp:1250
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "Požadovaný parametr '%s' nebyl zadán."
 
-#: ../src/richtext/richtextindentspage.cpp:217
-#: ../src/richtext/richtextindentspage.cpp:219
 #: ../src/richtext/richtextliststylepage.cpp:403
 #: ../src/richtext/richtextliststylepage.cpp:405
+#: ../src/richtext/richtextindentspage.cpp:217
+#: ../src/richtext/richtextindentspage.cpp:219
 msgid "The right indent."
 msgstr "Odsazení zprava."
 
@@ -6962,16 +7126,16 @@ msgstr "Neprůhlednost stínu."
 msgid "The shadow spread."
 msgstr "Rozprostření stínu."
 
-#: ../src/richtext/richtextindentspage.cpp:267
 #: ../src/richtext/richtextliststylepage.cpp:439
 #: ../src/richtext/richtextliststylepage.cpp:441
+#: ../src/richtext/richtextindentspage.cpp:267
 msgid "The spacing after the paragraph."
 msgstr "Mezera za odstavcem."
 
-#: ../src/richtext/richtextindentspage.cpp:257
-#: ../src/richtext/richtextindentspage.cpp:259
 #: ../src/richtext/richtextliststylepage.cpp:430
 #: ../src/richtext/richtextliststylepage.cpp:432
+#: ../src/richtext/richtextindentspage.cpp:257
+#: ../src/richtext/richtextindentspage.cpp:259
 msgid "The spacing before the paragraph."
 msgstr "Mezera před odstavcem."
 
@@ -6985,12 +7149,12 @@ msgstr "Jméno stylu."
 msgid "The style on which this style is based."
 msgstr "Styl, na kterém je tento styl založen."
 
-#: ../src/richtext/richtextstyledlg.cpp:214
-#: ../src/richtext/richtextstyledlg.cpp:216
+#: ../src/richtext/richtextstyledlg.cpp:210
+#: ../src/richtext/richtextstyledlg.cpp:212
 msgid "The style preview."
 msgstr "Náhled stylu."
 
-#: ../src/msw/ole/automtn.cpp:680
+#: ../src/msw/ole/automtn.cpp:671
 msgid "The system cannot find the file specified."
 msgstr "Systém nemůže nalézt uvedený soubor."
 
@@ -7003,7 +7167,7 @@ msgstr "Pozice tabulátoru."
 msgid "The tab positions."
 msgstr "Pozice tabulátorů."
 
-#: ../src/richtext/richtextctrl.cpp:3098
+#: ../src/richtext/richtextctrl.cpp:3099
 msgid "The text couldn't be saved."
 msgstr "Text nelze uložit."
 
@@ -7024,7 +7188,7 @@ msgstr "Velikost vnitřního okraje nahoře."
 msgid "The top position."
 msgstr "Horní pozice."
 
-#: ../src/common/cmdline.cpp:1232
+#: ../src/common/cmdline.cpp:1228
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "Musíte zadat hodnotu volby '%s'."
@@ -7034,7 +7198,7 @@ msgstr "Musíte zadat hodnotu volby '%s'."
 msgid "The value of the corner radius."
 msgstr "Hodnota zaoblení rohu."
 
-#: ../src/msw/dialup.cpp:433
+#: ../src/msw/dialup.cpp:427
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -7048,28 +7212,28 @@ msgstr ""
 msgid "The vertical offset."
 msgstr "Svislé posunutí."
 
-#: ../src/richtext/richtextprint.cpp:619 ../src/html/htmprint.cpp:745
+#: ../src/html/htmprint.cpp:749 ../src/richtext/richtextprint.cpp:615
 msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr "Při nastavování stránky nastala chyba: nastavte výchozí tiskárnu."
 
-#: ../src/html/htmprint.cpp:255
+#: ../src/html/htmprint.cpp:267
 msgid ""
 "This document doesn't fit on the page horizontally and will be truncated "
 "when it is printed."
 msgstr ""
 "Tento dokument se vodorovně na stránku nevejde a bude při tisku zkrácen."
 
-#: ../src/common/image.cpp:2854
+#: ../src/common/image.cpp:2963
 #, c-format
 msgid "This is not a %s."
 msgstr "Toto není %s."
 
-#: ../src/common/wincmn.cpp:1653
+#: ../src/common/wincmn.cpp:1654
 msgid "This platform does not support background transparency."
 msgstr "Tato platforma nepodporuje průhlednost pozadí."
 
-#: ../src/gtk/window.cpp:4660
+#: ../src/gtk/window.cpp:5664
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
@@ -7077,7 +7241,15 @@ msgstr ""
 "Tento program byl sestaven s příliš starou verzí GTK+, znovu ho, prosím, "
 "sestavte s GTK+ 2.12 nebo novější."
 
-#: ../src/msw/thread.cpp:1240
+#: ../src/gtk/glcanvas.cpp:176
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/msw/thread.cpp:1246
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -7085,11 +7257,11 @@ msgstr ""
 "Vlákno pro modul se nepodařilo zavést: nelze ukládat hodnoty do místního "
 "úložiště vláken"
 
-#: ../src/unix/threadpsx.cpp:1794
+#: ../src/unix/threadpsx.cpp:1843
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr "Selhalo zavedení modulu s vlákny: nelze vytvořit klíč vlákna"
 
-#: ../src/msw/thread.cpp:1228
+#: ../src/msw/thread.cpp:1234
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -7097,80 +7269,80 @@ msgstr ""
 "Vlákno pro modul se nepodařilo zavést: Nelze přidělit index do místního "
 "úložiště vláken"
 
-#: ../src/unix/threadpsx.cpp:1043
+#: ../src/unix/threadpsx.cpp:1061
 msgid "Thread priority setting is ignored."
 msgstr "Nastavení priority vlákna je ignorováno."
 
-#: ../src/msw/mdi.cpp:176
+#: ../src/msw/mdi.cpp:171
 msgid "Tile &Horizontally"
 msgstr "Vyrovnat &vodorovně"
 
-#: ../src/msw/mdi.cpp:177
+#: ../src/msw/mdi.cpp:172
 msgid "Tile &Vertically"
 msgstr "Vyrovnat &svisle"
 
-#: ../src/common/ftp.cpp:200
+#: ../src/common/ftp.cpp:197
 msgid "Timeout while waiting for FTP server to connect, try passive mode."
 msgstr "Při čekání na spojení s FTP serverem vypršel čas, zkuste pasivní mód."
 
-#: ../src/generic/tipdlg.cpp:201
+#: ../src/generic/tipdlg.cpp:198
 msgid "Tip of the Day"
 msgstr "Tip dne"
 
-#: ../src/generic/tipdlg.cpp:140
+#: ../src/generic/tipdlg.cpp:137
 msgid "Tips not available, sorry!"
 msgstr "Tipy nejsou k dispozici, omlouváme se!"
 
-#: ../src/generic/prntdlgg.cpp:242
+#: ../src/generic/prntdlgg.cpp:235
 msgid "To:"
 msgstr "Do:"
 
-#: ../src/richtext/richtextbuffer.cpp:8363
+#: ../src/richtext/richtextbuffer.cpp:8361
 msgid "Too many EndStyle calls!"
 msgstr "Příliš mnoho volání EndStyle!"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:891
+#: ../src/propgrid/advprops.cpp:792
 msgid "Tooltip"
 msgstr "Popisek"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:892
+#: ../src/propgrid/advprops.cpp:793
 msgid "TooltipText"
 msgstr "Text popisku"
 
-#: ../src/richtext/richtextsizepage.cpp:286
-#: ../src/richtext/richtextsizepage.cpp:290 ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197 ../src/richtext/richtextsizepage.cpp:286
+#: ../src/richtext/richtextsizepage.cpp:290
 msgid "Top"
 msgstr "Nahoru"
 
-#: ../src/generic/prntdlgg.cpp:881
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Top margin (mm):"
 msgstr "Horní okraj (mm):"
 
-#: ../src/generic/aboutdlgg.cpp:79
+#: ../src/generic/aboutdlgg.cpp:76
 msgid "Translations by "
 msgstr "Překlad "
 
-#: ../src/generic/aboutdlgg.cpp:188
+#: ../src/generic/aboutdlgg.cpp:185
 msgid "Translators"
 msgstr "Překladatelé"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:211
+#: ../src/propgrid/propgrid.cpp:192
 msgid "True"
 msgstr "Pravda"
 
-#: ../src/common/fs_mem.cpp:227
+#: ../src/common/fs_mem.cpp:222
 #, c-format
 msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
 msgstr "Soubor '%s' nelze odebrat z paměťového VFS, protože nebyl načten!"
 
-#: ../src/common/fmapbase.cpp:156
+#: ../src/common/fmapbase.cpp:153
 msgid "Turkish (ISO-8859-9)"
 msgstr "Turecké (ISO-8859-9)"
 
-#: ../src/generic/filectrlg.cpp:426
+#: ../src/generic/filectrlg.cpp:422
 msgid "Type"
 msgstr "Typ"
 
@@ -7184,17 +7356,17 @@ msgstr "Zadejte název písma."
 msgid "Type a size in points."
 msgstr "Zadejte velikost v bodech."
 
-#: ../src/msw/ole/automtn.cpp:676
+#: ../src/msw/ole/automtn.cpp:667
 #, c-format
 msgid "Type mismatch in argument %u."
 msgstr "Neshoda typu v argumentu %u."
 
-#: ../src/common/xtixml.cpp:356 ../src/common/xtixml.cpp:509
-#: ../src/common/xtistrm.cpp:318
+#: ../src/common/xtixml.cpp:352 ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315
 msgid "Type must have enum - long conversion"
 msgstr "Typ musí podporovat převod typu enum na long"
 
-#: ../src/propgrid/propgridiface.cpp:401
+#: ../src/propgrid/propgridiface.cpp:385
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
@@ -7203,19 +7375,19 @@ msgstr ""
 "Operace typu \"%s\" selhala: Vlastnost označená \"%s\" je typu \"%s\", NE "
 "\"%s\"."
 
-#: ../src/common/paper.cpp:133
+#: ../src/common/paper.cpp:130
 msgid "US Std Fanfold, 14 7/8 x 11 in"
 msgstr "US Std Fanfold, 17 7/8 x 11 palců"
 
-#: ../src/common/fmapbase.cpp:196
+#: ../src/common/fmapbase.cpp:193
 msgid "US-ASCII"
 msgstr "US-ASCII"
 
-#: ../src/unix/fswatcher_inotify.cpp:109
+#: ../src/unix/fswatcher_inotify.cpp:106
 msgid "Unable to add inotify watch"
 msgstr "Nelze přidat sledování inotify"
 
-#: ../src/unix/fswatcher_kqueue.cpp:136
+#: ../src/unix/fswatcher_kqueue.cpp:153
 msgid "Unable to add kqueue watch"
 msgstr "Nelze přidat sledování kqueue"
 
@@ -7227,7 +7399,7 @@ msgstr "Nelze přidružit obslužnou rutinu k I/O portu dokončení"
 msgid "Unable to close I/O completion port handle"
 msgstr "Nelze uzavřít popisovač I/O portu dokončení."
 
-#: ../src/unix/fswatcher_inotify.cpp:97
+#: ../src/unix/fswatcher_inotify.cpp:94
 msgid "Unable to close inotify instance"
 msgstr "Nelze uzavřít instanci inotify."
 
@@ -7245,15 +7417,15 @@ msgstr "Nelze uzavřít popisovač pro '%s'"
 msgid "Unable to create I/O completion port"
 msgstr "Nelze vytvořit I/O port dokončení."
 
-#: ../src/msw/fswatcher.cpp:84
+#: ../src/msw/fswatcher.cpp:81
 msgid "Unable to create IOCP worker thread"
 msgstr "Nelze vytvořit pracovní vlákno I/O portu dokončení."
 
-#: ../src/unix/fswatcher_inotify.cpp:74
+#: ../src/unix/fswatcher_inotify.cpp:71
 msgid "Unable to create inotify instance"
 msgstr "Nelze vytvořit instanci inotify"
 
-#: ../src/unix/fswatcher_kqueue.cpp:97
+#: ../src/unix/fswatcher_kqueue.cpp:114
 msgid "Unable to create kqueue instance"
 msgstr "Nelze vytvořit instanci kqueue"
 
@@ -7261,11 +7433,11 @@ msgstr "Nelze vytvořit instanci kqueue"
 msgid "Unable to dequeue completion packet"
 msgstr "Paket dokončení nelze vyřadit z fronty"
 
-#: ../src/unix/fswatcher_kqueue.cpp:185
+#: ../src/unix/fswatcher_kqueue.cpp:202
 msgid "Unable to get events from kqueue"
 msgstr "Nelze získat události z kqueue"
 
-#: ../src/gtk/app.cpp:435
+#: ../src/gtk/app.cpp:431
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "Nelze spustit GTK+, je ZOBRAZENÍ nastaveno správně?"
 
@@ -7274,12 +7446,12 @@ msgstr "Nelze spustit GTK+, je ZOBRAZENÍ nastaveno správně?"
 msgid "Unable to open path '%s'"
 msgstr "Nelze otevřít cestu '%s'"
 
-#: ../src/html/htmlwin.cpp:583
+#: ../src/html/htmlwin.cpp:586
 #, c-format
 msgid "Unable to open requested HTML document: %s"
 msgstr "Nelze otevřít požadovaný HTML dokument: %s"
 
-#: ../src/unix/sound.cpp:368
+#: ../src/unix/sound.cpp:365
 msgid "Unable to play sound asynchronously."
 msgstr "Nelze přehrát zvuk asynchronně."
 
@@ -7287,62 +7459,62 @@ msgstr "Nelze přehrát zvuk asynchronně."
 msgid "Unable to post completion status"
 msgstr "Nelze poslat stav dokončení"
 
-#: ../src/unix/fswatcher_inotify.cpp:556
+#: ../src/unix/fswatcher_inotify.cpp:553
 msgid "Unable to read from inotify descriptor"
 msgstr "Nelze číst z popisovače inotify"
 
-#: ../src/unix/fswatcher_inotify.cpp:141
+#: ../src/unix/fswatcher_inotify.cpp:138
 #, c-format
 msgid "Unable to remove inotify watch %i"
 msgstr "Nelze odstranit sledování inotify %i"
 
-#: ../src/unix/fswatcher_kqueue.cpp:153
+#: ../src/unix/fswatcher_kqueue.cpp:170
 msgid "Unable to remove kqueue watch"
 msgstr "Nelze odstranit sledování kqueue"
 
-#: ../src/msw/fswatcher.cpp:168
+#: ../src/msw/fswatcher.cpp:165
 #, c-format
 msgid "Unable to set up watch for '%s'"
 msgstr "Nelze nastavit sledování pro '%s'"
 
-#: ../src/msw/fswatcher.cpp:91
+#: ../src/msw/fswatcher.cpp:88
 msgid "Unable to start IOCP worker thread"
 msgstr "Nelze spustit pracovní vlákno I/O portu dokončení."
 
-#: ../src/common/stockitem.cpp:201
+#: ../src/common/stockitem.cpp:198
 msgid "Undelete"
 msgstr "Obnovit smazané"
 
-#: ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199
 msgid "Underline"
 msgstr "Podtržení"
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/richtext/richtextfontpage.cpp:359 ../src/osx/carbon/fontdlg.cpp:370
-#: ../src/propgrid/advprops.cpp:690
+#: ../src/osx/carbon/fontdlg.cpp:367 ../src/propgrid/advprops.cpp:600
+#: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Podtržené"
 
-#: ../src/common/stockitem.cpp:203 ../src/stc/stc_i18n.cpp:15
+#: ../src/common/stockitem.cpp:200 ../src/stc/stc_i18n.cpp:15
 msgid "Undo"
 msgstr "&Zpět"
 
-#: ../src/common/stockitem.cpp:265
+#: ../src/common/stockitem.cpp:263
 msgid "Undo last action"
 msgstr "Vrátit zpět poslední činnost"
 
-#: ../src/common/cmdline.cpp:1029
+#: ../src/common/cmdline.cpp:1025
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Volbu '%s' následovaly neočekávané znaky."
 
-#: ../src/unix/fswatcher_inotify.cpp:274
+#: ../src/unix/fswatcher_inotify.cpp:271
 #, c-format
 msgid "Unexpected event for \"%s\": no matching watch descriptor."
 msgstr ""
 "Neočekávaná událost pro \"%s\": žádný odpovídající popisovač sledování."
 
-#: ../src/common/cmdline.cpp:1195
+#: ../src/common/cmdline.cpp:1191
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Neočekávaný parametr '%s'"
@@ -7351,49 +7523,49 @@ msgstr "Neočekávaný parametr '%s'"
 msgid "Unexpectedly new I/O completion port was created"
 msgstr "Byl neočekávaně vytvořen nový I/O port dokončení"
 
-#: ../src/msw/fswatcher.cpp:70
+#: ../src/msw/fswatcher.cpp:67
 msgid "Ungraceful worker thread termination"
 msgstr "Vynucené ukončení pracovního vlákna"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:460
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:456
+#: ../src/richtext/richtextsymboldlg.cpp:457
+#: ../src/richtext/richtextsymboldlg.cpp:458
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../src/common/fmapbase.cpp:185 ../src/common/fmapbase.cpp:191
+#: ../src/common/fmapbase.cpp:182 ../src/common/fmapbase.cpp:188
 msgid "Unicode 16 bit (UTF-16)"
 msgstr "Unicode 16 bit (UTF-16)"
 
-#: ../src/common/fmapbase.cpp:190
+#: ../src/common/fmapbase.cpp:187
 msgid "Unicode 16 bit Big Endian (UTF-16BE)"
 msgstr "Unicode 16 bit Big Endian (UTF-16BE)"
 
-#: ../src/common/fmapbase.cpp:186
+#: ../src/common/fmapbase.cpp:183
 msgid "Unicode 16 bit Little Endian (UTF-16LE)"
 msgstr "Unicode 16 bit Little Endian (UTF-16LE)"
 
-#: ../src/common/fmapbase.cpp:187 ../src/common/fmapbase.cpp:193
+#: ../src/common/fmapbase.cpp:184 ../src/common/fmapbase.cpp:190
 msgid "Unicode 32 bit (UTF-32)"
 msgstr "Unicode 32 bit (UTF-32)"
 
-#: ../src/common/fmapbase.cpp:192
+#: ../src/common/fmapbase.cpp:189
 msgid "Unicode 32 bit Big Endian (UTF-32BE)"
 msgstr "Unicode 32 bit Big Endian (UTF-32BE)"
 
-#: ../src/common/fmapbase.cpp:188
+#: ../src/common/fmapbase.cpp:185
 msgid "Unicode 32 bit Little Endian (UTF-32LE)"
 msgstr "Unicode 32 bit Little Endian (UTF-32LE)"
 
-#: ../src/common/fmapbase.cpp:182
+#: ../src/common/fmapbase.cpp:179
 msgid "Unicode 7 bit (UTF-7)"
 msgstr "Unicode 7 bit (UTF-7)"
 
-#: ../src/common/fmapbase.cpp:183
+#: ../src/common/fmapbase.cpp:180
 msgid "Unicode 8 bit (UTF-8)"
 msgstr "Unicode 8 bit (UTF-8)"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "Unindent"
 msgstr "Zrušit odsazení"
 
@@ -7543,97 +7715,102 @@ msgstr "Jednotky pro horní pozici."
 msgid "Units for this value."
 msgstr "Jednotky pro tuto hodnotu."
 
-#: ../src/generic/progdlgg.cpp:353 ../src/generic/progdlgg.cpp:622
+#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
 msgid "Unknown"
 msgstr "Neznámo"
 
-#: ../src/msw/dde.cpp:1174
+#: ../src/msw/dde.cpp:1238
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Neznámá chyba DDE: %08x"
 
-#: ../src/common/xtistrm.cpp:410
+#: ../src/common/xtistrm.cpp:407
 msgid "Unknown Object passed to GetObjectClassInfo"
 msgstr "Neznámý objekt předán GetObjectClassInfo"
 
-#: ../src/common/imagpng.cpp:366
+#: ../src/common/imagpng.cpp:383
 #, c-format
 msgid "Unknown PNG resolution unit %d"
 msgstr "Neznámá jednotka rozlišení PNG %d"
 
-#: ../src/common/xtixml.cpp:327
+#: ../src/common/xtixml.cpp:323
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Neznámá vlastnost %s"
 
-#: ../src/common/imagtiff.cpp:529
+#: ../src/common/imagtiff.cpp:526
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "Ignorována neznámá jednotka rozlišení TIFF %d"
 
-#: ../src/unix/dlunix.cpp:160
+#: ../src/propgrid/props.cpp:155
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/unix/dlunix.cpp:118
 msgid "Unknown dynamic library error"
 msgstr "Neznámá chyba dynamické knihovny"
 
-#: ../src/common/fmapbase.cpp:810
+#: ../src/common/fmapbase.cpp:806
 #, c-format
 msgid "Unknown encoding (%d)"
 msgstr "Neznámé kódování (%d)"
 
-#: ../src/msw/ole/automtn.cpp:688
+#: ../src/msw/ole/automtn.cpp:679
 #, c-format
 msgid "Unknown error %08x"
 msgstr "Neznámá chyba %08x"
 
-#: ../src/msw/ole/automtn.cpp:647
+#: ../src/msw/ole/automtn.cpp:638
 msgid "Unknown exception"
 msgstr "Neznámá výjimka"
 
-#: ../src/common/image.cpp:2839
+#: ../src/common/image.cpp:2942
 msgid "Unknown image data format."
 msgstr "Neznámy formát dat obrázku."
 
-#: ../src/common/cmdline.cpp:914
+#: ../src/common/cmdline.cpp:910
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Neznámá dlouhá volba '%s'"
 
-#: ../src/msw/ole/automtn.cpp:631
+#: ../src/msw/ole/automtn.cpp:622
 msgid "Unknown name or named argument."
 msgstr "Neznámý název nebo pojmenovaný argument."
 
-#: ../src/common/cmdline.cpp:929 ../src/common/cmdline.cpp:951
+#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Neznámá volba '%s'"
 
-#: ../src/common/mimecmn.cpp:225
+#: ../src/common/mimecmn.cpp:221
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "Přebytečná '{' v záznamu mime typu %s."
 
-#: ../src/common/cmdproc.cpp:262 ../src/common/cmdproc.cpp:288
-#: ../src/common/cmdproc.cpp:308
+#: ../src/common/cmdproc.cpp:255 ../src/common/cmdproc.cpp:281
+#: ../src/common/cmdproc.cpp:301
 msgid "Unnamed command"
 msgstr "Nepojmenovaný příkaz"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:413
+#: ../src/propgrid/propgrid.cpp:392
 msgid "Unspecified"
 msgstr "Neurčeno"
 
-#: ../src/msw/clipbrd.cpp:311
+#: ../src/msw/clipbrd.cpp:325
 msgid "Unsupported clipboard format."
 msgstr "Nepodporovaný formát obsahu schránky."
 
-#: ../src/common/appcmn.cpp:256
+#: ../src/common/appcmn.cpp:277
 #, c-format
 msgid "Unsupported theme '%s'."
 msgstr "Nepodporované téma '%s'."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:205
-#: ../src/common/accelcmn.cpp:63
+#: ../src/common/stockitem.cpp:202 ../src/common/accelcmn.cpp:60
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Up"
 msgstr "Nahoru"
 
@@ -7647,7 +7824,7 @@ msgstr "Velká písmena"
 msgid "Upper case roman numerals"
 msgstr "Velké římské číslice"
 
-#: ../src/common/cmdline.cpp:1326
+#: ../src/common/cmdline.cpp:1322
 #, c-format
 msgid "Usage: %s"
 msgstr "Použití: %s"
@@ -7656,38 +7833,47 @@ msgstr "Použití: %s"
 msgid "Use &shadow"
 msgstr "Použít &stín"
 
-#: ../src/richtext/richtextindentspage.cpp:169
-#: ../src/richtext/richtextindentspage.cpp:171
 #: ../src/richtext/richtextliststylepage.cpp:358
 #: ../src/richtext/richtextliststylepage.cpp:360
+#: ../src/richtext/richtextindentspage.cpp:169
+#: ../src/richtext/richtextindentspage.cpp:171
 msgid "Use the current alignment setting."
 msgstr "Použít současné nastavení zarovnání."
 
-#: ../src/common/valtext.cpp:179
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/gtk/font.cpp:552
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/common/valtext.cpp:142
 msgid "Validation conflict"
 msgstr "Konflikt validace"
 
-#: ../src/propgrid/manager.cpp:238
+#: ../src/propgrid/manager.cpp:224
 msgid "Value"
 msgstr "Hodnota"
 
-#: ../src/propgrid/props.cpp:386 ../src/propgrid/props.cpp:500
+#: ../src/propgrid/props.cpp:309
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "Hodnota musí být %s nebo větší."
 
-#: ../src/propgrid/props.cpp:417 ../src/propgrid/props.cpp:531
+#: ../src/propgrid/props.cpp:336
 #, c-format
 msgid "Value must be %s or less."
 msgstr "Hodnota musí být %s nebo menší."
 
-#: ../src/propgrid/props.cpp:393 ../src/propgrid/props.cpp:424
-#: ../src/propgrid/props.cpp:507 ../src/propgrid/props.cpp:538
+#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "Hodnota musí být mezi %s a %s."
 
-#: ../src/generic/aboutdlgg.cpp:128
+#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Verze "
 
@@ -7696,25 +7882,32 @@ msgstr "Verze "
 msgid "Vertical alignment."
 msgstr "Svislé zarovnání."
 
-#: ../src/generic/filedlgg.cpp:202
+#: ../src/generic/filedlgg.cpp:199
 msgid "View files as a detailed view"
 msgstr "Zobrazit soubory v detailním pohledu"
 
-#: ../src/generic/filedlgg.cpp:200
+#: ../src/generic/filedlgg.cpp:197
 msgid "View files as a list view"
 msgstr "Zobrazit soubory v seznamu"
 
-#: ../src/common/docview.cpp:1970
+#: ../src/common/docview.cpp:1975
 msgid "Views"
 msgstr "Pohledy"
 
+#: ../src/gtk/app.cpp:348
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1777
+#: ../src/propgrid/advprops.cpp:1678
 msgid "Wait"
 msgstr "Zaneprázdněn"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1779
+#: ../src/propgrid/advprops.cpp:1680
 msgid "Wait Arrow"
 msgstr "Práce na pozadí"
 
@@ -7723,237 +7916,234 @@ msgstr "Práce na pozadí"
 msgid "Waiting for IO on epoll descriptor %d failed"
 msgstr "Čekání na IO v epoll popisovači %d selhalo"
 
-#: ../src/common/log.cpp:223
+#: ../src/common/log.cpp:241
 msgid "Warning: "
 msgstr "Varování: "
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1778
+#: ../src/propgrid/advprops.cpp:1679
 msgid "Watch"
 msgstr "Hodinky"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:685
+#: ../src/propgrid/advprops.cpp:595
 msgid "Weight"
 msgstr "Tučnost"
 
-#: ../src/common/fmapbase.cpp:148
+#: ../src/common/fmapbase.cpp:145
 msgid "Western European (ISO-8859-1)"
 msgstr "Západoevropské (ISO-8859-1)"
 
-#: ../src/common/fmapbase.cpp:162
+#: ../src/common/fmapbase.cpp:159
 msgid "Western European with Euro (ISO-8859-15)"
 msgstr "Západoevropské s eurem (ISO-8859-15)"
 
-#: ../src/generic/fontdlgg.cpp:446 ../src/generic/fontdlgg.cpp:448
+#: ../src/generic/fontdlgg.cpp:443 ../src/generic/fontdlgg.cpp:445
 msgid "Whether the font is underlined."
 msgstr "Zdali má být písmo podtržené."
 
-#: ../src/propgrid/advprops.cpp:1611
+#: ../src/propgrid/advprops.cpp:1517
 msgid "White"
 msgstr "Bílá"
 
-#: ../src/generic/fdrepdlg.cpp:144
+#: ../src/generic/fdrepdlg.cpp:141
 msgid "Whole word"
 msgstr "Pouze celá slova"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:532
 msgid "Whole words only"
 msgstr "Pouze celá slova"
 
-#: ../src/univ/themes/win32.cpp:1102
+#: ../src/univ/themes/win32.cpp:1099
 msgid "Win32 theme"
 msgstr "Téma Win32"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:893
+#: ../src/propgrid/advprops.cpp:794
 msgid "Window"
 msgstr "Okno"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:894
+#: ../src/propgrid/advprops.cpp:795
 msgid "WindowFrame"
 msgstr "Rám okna"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:895
+#: ../src/propgrid/advprops.cpp:796
 msgid "WindowText"
 msgstr "Text okna"
 
-#: ../src/common/fmapbase.cpp:177
+#: ../src/common/fmapbase.cpp:174
 msgid "Windows Arabic (CP 1256)"
 msgstr "Arabské pro Windows (CP 1256)"
 
-#: ../src/common/fmapbase.cpp:178
+#: ../src/common/fmapbase.cpp:175
 msgid "Windows Baltic (CP 1257)"
 msgstr "Baltské pro Windows (CP 1257)"
 
-#: ../src/common/fmapbase.cpp:171
+#: ../src/common/fmapbase.cpp:168
 msgid "Windows Central European (CP 1250)"
 msgstr "Středoevropské pro Windows (CP 1250)"
 
-#: ../src/common/fmapbase.cpp:168
+#: ../src/common/fmapbase.cpp:165
 msgid "Windows Chinese Simplified (CP 936) or GB-2312"
 msgstr "Zjednodušená čínština pro Windows (CP 936) nebo GB-2312"
 
-#: ../src/common/fmapbase.cpp:170
+#: ../src/common/fmapbase.cpp:167
 msgid "Windows Chinese Traditional (CP 950) or Big-5"
 msgstr "Tradiční čínština pro Windows (CP 950) nebo Big-5"
 
-#: ../src/common/fmapbase.cpp:172
+#: ../src/common/fmapbase.cpp:169
 msgid "Windows Cyrillic (CP 1251)"
 msgstr "Cyrilice pro Windows (CP 1251)"
 
-#: ../src/common/fmapbase.cpp:174
+#: ../src/common/fmapbase.cpp:171
 msgid "Windows Greek (CP 1253)"
 msgstr "Řecké pro Windows (CP 1253)"
 
-#: ../src/common/fmapbase.cpp:176
+#: ../src/common/fmapbase.cpp:173
 msgid "Windows Hebrew (CP 1255)"
 msgstr "Hebrejské pro Windows (CP 1255)"
 
-#: ../src/common/fmapbase.cpp:167
+#: ../src/common/fmapbase.cpp:164
 msgid "Windows Japanese (CP 932) or Shift-JIS"
 msgstr "Japonské pro Windows (CP 932) nebo Shift-JIS"
 
-#: ../src/common/fmapbase.cpp:180
+#: ../src/common/fmapbase.cpp:177
 msgid "Windows Johab (CP 1361)"
 msgstr "Johab pro Windows (CP 1361)"
 
-#: ../src/common/fmapbase.cpp:169
+#: ../src/common/fmapbase.cpp:166
 msgid "Windows Korean (CP 949)"
 msgstr "Korejské pro Windows (CP 949)"
 
-#: ../src/common/fmapbase.cpp:166
+#: ../src/common/fmapbase.cpp:163
 msgid "Windows Thai (CP 874)"
 msgstr "Thajské pro Windows (CP 874)"
 
-#: ../src/common/fmapbase.cpp:175
+#: ../src/common/fmapbase.cpp:172
 msgid "Windows Turkish (CP 1254)"
 msgstr "Turecké pro Windows (CP 1254)"
 
-#: ../src/common/fmapbase.cpp:179
+#: ../src/common/fmapbase.cpp:176
 msgid "Windows Vietnamese (CP 1258)"
 msgstr "Vietnamština pro Windows (CP 1258)"
 
-#: ../src/common/fmapbase.cpp:173
+#: ../src/common/fmapbase.cpp:170
 msgid "Windows Western European (CP 1252)"
 msgstr "Západoevropské pro Windows (CP 1252)"
 
-#: ../src/common/fmapbase.cpp:181
+#: ../src/common/fmapbase.cpp:178
 msgid "Windows/DOS OEM (CP 437)"
 msgstr "Windows/DOS OEM (CP 437)"
 
-#: ../src/common/fmapbase.cpp:165
+#: ../src/common/fmapbase.cpp:162
 msgid "Windows/DOS OEM Cyrillic (CP 866)"
 msgstr "Windows/DOS OEM Cyrilické (CP 866)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:111
+#: ../src/common/accelcmn.cpp:109
 msgid "Windows_Left"
 msgstr "Klávesa Windows vlevo"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:113
+#: ../src/common/accelcmn.cpp:111
 msgid "Windows_Menu"
 msgstr "Klávesa Menu"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:112
+#: ../src/common/accelcmn.cpp:110
 msgid "Windows_Right"
 msgstr "Klávesa Windows vpravo"
 
-#: ../src/common/ffile.cpp:150
+#: ../src/common/ffile.cpp:149
 #, c-format
 msgid "Write error on file '%s'"
 msgstr "Chyba při zápisu do souboru '%s'"
 
-#: ../src/xml/xml.cpp:914
+#: ../src/xml/xml.cpp:925
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "Chyba při načítání XML: '%s' na řádce %d"
 
-#: ../src/common/xpmdecod.cpp:796
+#: ../src/common/xpmdecod.cpp:794
 msgid "XPM: Malformed pixel data!"
 msgstr "XPM: Špatná pixelová data!"
 
-#: ../src/common/xpmdecod.cpp:705
+#: ../src/common/xpmdecod.cpp:702
 #, c-format
 msgid "XPM: incorrect colour description in line %d"
 msgstr "XPM: špatný popis barvy na řádku %d"
 
-#: ../src/common/xpmdecod.cpp:680
+#: ../src/common/xpmdecod.cpp:677
 msgid "XPM: incorrect header format!"
 msgstr "XPM: nesprávný formát hlavičky!"
 
-#: ../src/common/xpmdecod.cpp:716 ../src/common/xpmdecod.cpp:725
+#: ../src/common/xpmdecod.cpp:714 ../src/common/xpmdecod.cpp:723
 #, c-format
 msgid "XPM: malformed colour definition '%s' at line %d!"
 msgstr "XPM: špatný formát definice barvy '%s' na řádku %d!"
 
-#: ../src/common/xpmdecod.cpp:755
+#: ../src/common/xpmdecod.cpp:753
 msgid "XPM: no colors left to use for mask!"
 msgstr "XPM: nezbyly žádné barvy na masku!"
 
-#: ../src/common/xpmdecod.cpp:782
+#: ../src/common/xpmdecod.cpp:780
 #, c-format
 msgid "XPM: truncated image data at line %d!"
 msgstr "XPM: ořezaná data obrázku na řádku %d!"
 
-#: ../src/propgrid/advprops.cpp:1610
+#: ../src/propgrid/advprops.cpp:1516
 msgid "Yellow"
 msgstr "Žlutá"
 
-#: ../include/wx/msgdlg.h:276 ../src/common/stockitem.cpp:206
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:203
 #: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Ano"
 
-#: ../src/osx/carbon/overlay.cpp:155
-msgid "You cannot Clear an overlay that is not inited"
-msgstr "Nemůžete použít Clear pro překrytí, které není inicializované"
-
-#: ../src/osx/carbon/overlay.cpp:107 ../src/dfb/overlay.cpp:61
-msgid "You cannot Init an overlay twice"
-msgstr "Překrytí nemůžete inicializovat dvakrát"
-
-#: ../src/generic/dirdlgg.cpp:287
+#: ../src/generic/dirdlgg.cpp:284
 msgid "You cannot add a new directory to this section."
 msgstr "Do této sekce nemůžete přidat nový adresář."
 
-#: ../src/propgrid/propgrid.cpp:3299
+#: ../src/propgrid/propgrid.cpp:3276
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr "Zadali jste nesprávnou hodnotu. Stiskněte ESC pro zrušení úprav."
 
-#: ../src/common/stockitem.cpp:209
+#: ../src/osx/cocoa/menu.mm:286
+#, fuzzy
+msgid "Zoom"
+msgstr "Přiblížit"
+
+#: ../src/common/stockitem.cpp:206
 msgid "Zoom &In"
 msgstr "Př&iblížit"
 
-#: ../src/common/stockitem.cpp:210
+#: ../src/common/stockitem.cpp:207
 msgid "Zoom &Out"
 msgstr "&Oddálit"
 
-#: ../src/common/stockitem.cpp:209 ../src/common/prntbase.cpp:1594
+#: ../src/common/stockitem.cpp:206 ../src/common/prntbase.cpp:1619
 msgid "Zoom In"
 msgstr "Přiblížit"
 
-#: ../src/common/stockitem.cpp:210 ../src/common/prntbase.cpp:1580
+#: ../src/common/stockitem.cpp:207 ../src/common/prntbase.cpp:1605
 msgid "Zoom Out"
 msgstr "Oddálit"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to &Fit"
 msgstr "Při&způsobit"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to Fit"
 msgstr "Přizpůsobit"
 
-#: ../src/msw/dde.cpp:1141
+#: ../src/msw/dde.cpp:1205
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "DDEML aplikace způsobila prodloužený souběh."
 
-#: ../src/msw/dde.cpp:1129
+#: ../src/msw/dde.cpp:1193
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -7964,39 +8154,39 @@ msgstr ""
 "nebo dostala neplatný identifikátor\n"
 "instance."
 
-#: ../src/msw/dde.cpp:1147
+#: ../src/msw/dde.cpp:1211
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "klientův pokus navázat konverzaci selhal."
 
-#: ../src/msw/dde.cpp:1144
+#: ../src/msw/dde.cpp:1208
 msgid "a memory allocation failed."
 msgstr "selhalo přidělení paměti."
 
-#: ../src/msw/dde.cpp:1138
+#: ../src/msw/dde.cpp:1202
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "nepodařilo se ověřit parametr pomocí DDEML."
 
-#: ../src/msw/dde.cpp:1120
+#: ../src/msw/dde.cpp:1184
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "požadavek na synchronní advise transakci vypršel."
 
-#: ../src/msw/dde.cpp:1126
+#: ../src/msw/dde.cpp:1190
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "požadavek na synchronní datovou transakci vypršel."
 
-#: ../src/msw/dde.cpp:1135
+#: ../src/msw/dde.cpp:1199
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "požadavek na synchronní execute transakci vypršel."
 
-#: ../src/msw/dde.cpp:1153
+#: ../src/msw/dde.cpp:1217
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "požadavek na synchronní poke transakci vypršel."
 
-#: ../src/msw/dde.cpp:1168
+#: ../src/msw/dde.cpp:1232
 msgid "a request to end an advise transaction has timed out."
 msgstr "požadavek na ukončení advise transakce vypršel."
 
-#: ../src/msw/dde.cpp:1162
+#: ../src/msw/dde.cpp:1226
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -8006,15 +8196,15 @@ msgstr ""
 "transakci, nebo se server před\n"
 "dokončením transakce ukončil ."
 
-#: ../src/msw/dde.cpp:1150
+#: ../src/msw/dde.cpp:1214
 msgid "a transaction failed."
 msgstr "transakce se nepodařila."
 
-#: ../src/common/accelcmn.cpp:189
+#: ../src/common/accelcmn.cpp:188
 msgid "alt"
 msgstr "alt"
 
-#: ../src/msw/dde.cpp:1132
+#: ../src/msw/dde.cpp:1196
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -8026,15 +8216,15 @@ msgstr ""
 "nebo se aplikace zavedená jako APPCMD_CLIENTONLY pokusila\n"
 "o přenos přes server."
 
-#: ../src/msw/dde.cpp:1156
+#: ../src/msw/dde.cpp:1220
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "interní volání PostMessage selhalo."
 
-#: ../src/msw/dde.cpp:1165
+#: ../src/msw/dde.cpp:1229
 msgid "an internal error has occurred in the DDEML."
 msgstr "nastala interní chyba v DDEML."
 
-#: ../src/msw/dde.cpp:1171
+#: ../src/msw/dde.cpp:1235
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -8044,56 +8234,56 @@ msgstr ""
 "Jakmile se aplikace vrátí z XTYP_XACT_COMPLETE callbacku, \n"
 "identifikátor transakce se stává neplatným."
 
-#: ../src/common/zipstrm.cpp:1483
+#: ../src/common/zipstrm.cpp:1522
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "předpokládám, že toto je vícenásobný zřetězený zip"
 
-#: ../src/common/fileconf.cpp:1847
+#: ../src/common/fileconf.cpp:1849
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "pokus o změnu neměnného klíče '%s' ignorován."
 
-#: ../src/html/chm.cpp:329
+#: ../src/html/chm.cpp:326
 msgid "bad arguments to library function"
 msgstr "špatné argumenty pro funkci knihovny"
 
-#: ../src/html/chm.cpp:341
+#: ../src/html/chm.cpp:338
 msgid "bad signature"
 msgstr "špatný podpis"
 
-#: ../src/common/zipstrm.cpp:1918
+#: ../src/common/zipstrm.cpp:1988
 msgid "bad zipfile offset to entry"
 msgstr "špatná adresa záznamu v souboru zip"
 
-#: ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400
 msgid "binary"
 msgstr "binární"
 
-#: ../src/common/fontcmn.cpp:996
+#: ../src/common/fontcmn.cpp:1195
 msgid "bold"
 msgstr "tučné"
 
-#: ../src/msw/utils.cpp:1144
+#: ../src/msw/utils.cpp:1135
 #, c-format
 msgid "build %lu"
 msgstr "sestavení %lu"
 
-#: ../src/common/ffile.cpp:75
+#: ../src/common/ffile.cpp:73
 #, c-format
 msgid "can't close file '%s'"
 msgstr "nelze zavřít soubor '%s'"
 
-#: ../src/common/file.cpp:245
+#: ../src/common/file.cpp:242
 #, c-format
 msgid "can't close file descriptor %d"
 msgstr "nelze zavřít popisovač souboru %d"
 
-#: ../src/common/file.cpp:586
+#: ../src/common/ffile.cpp:382 ../src/common/file.cpp:613
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "nelze uložit změny v souboru '%s'"
 
-#: ../src/common/file.cpp:178
+#: ../src/common/file.cpp:175
 #, c-format
 msgid "can't create file '%s'"
 msgstr "nelze vytvořit soubor '%s'"
@@ -8103,49 +8293,49 @@ msgstr "nelze vytvořit soubor '%s'"
 msgid "can't delete user configuration file '%s'"
 msgstr "nelze smazat uživatelský konfigurační soubor '%s'"
 
-#: ../src/common/file.cpp:495
+#: ../src/common/file.cpp:522
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr "nelze zjistit, jestli byl dosažen konec souboru pro popisovač %d"
 
-#: ../src/common/zipstrm.cpp:1692
+#: ../src/common/zipstrm.cpp:1747
 msgid "can't find central directory in zip"
 msgstr "v zipu nelze najít centrální adresář"
 
-#: ../src/common/file.cpp:465
+#: ../src/common/file.cpp:492
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "nelze zjistit délku souboru pro popisovač souboru %d"
 
-#: ../src/msw/utils.cpp:341
+#: ../src/msw/utils.cpp:336
 msgid "can't find user's HOME, using current directory."
 msgstr "nelze najít uživatelův domovský adresář, použit aktuální adresář."
 
-#: ../src/common/file.cpp:366
+#: ../src/common/file.cpp:407
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "nelze vyprázdnit popisovač souboru %d"
 
-#: ../src/common/file.cpp:422
+#: ../src/common/file.cpp:463
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "nelze zjistit pozici pro popisovač souboru %d"
 
-#: ../src/common/fontmap.cpp:325
+#: ../src/common/fontmap.cpp:322
 msgid "can't load any font, aborting"
 msgstr "žádné písmo nelze načíst, ukončeno"
 
-#: ../src/common/file.cpp:231 ../src/common/ffile.cpp:59
+#: ../src/common/ffile.cpp:57 ../src/common/file.cpp:228
 #, c-format
 msgid "can't open file '%s'"
 msgstr "nelze otevřít soubor '%s'"
 
-#: ../src/common/fileconf.cpp:320
+#: ../src/common/fileconf.cpp:314
 #, c-format
 msgid "can't open global configuration file '%s'."
 msgstr "nelze otevřít globální konfigurační soubor '%s'."
 
-#: ../src/common/fileconf.cpp:336
+#: ../src/common/fileconf.cpp:330
 #, c-format
 msgid "can't open user configuration file '%s'."
 msgstr "nelze otevřít uživatelský konfigurační soubor '%s'."
@@ -8154,40 +8344,40 @@ msgstr "nelze otevřít uživatelský konfigurační soubor '%s'."
 msgid "can't open user configuration file."
 msgstr "nelze otevřít uživatelský konfigurační soubor."
 
-#: ../src/common/zipstrm.cpp:579
+#: ../src/common/zipstrm.cpp:572
 msgid "can't re-initialize zlib deflate stream"
 msgstr "nelze znovu zavést proud zlib deflate"
 
-#: ../src/common/zipstrm.cpp:604
+#: ../src/common/zipstrm.cpp:597
 msgid "can't re-initialize zlib inflate stream"
 msgstr "nelze znovu zavést proud zlib inflate"
 
-#: ../src/common/file.cpp:304
+#: ../src/common/file.cpp:345
 #, c-format
 msgid "can't read from file descriptor %d"
 msgstr "nelze číst z popisovače souboru %d"
 
-#: ../src/common/file.cpp:581
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:608
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "nelze odstranit soubor '%s'"
 
-#: ../src/common/file.cpp:598
+#: ../src/common/ffile.cpp:394 ../src/common/file.cpp:625
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "nelze odstranit dočasný soubor '%s'"
 
-#: ../src/common/file.cpp:408
+#: ../src/common/file.cpp:449
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "nelze změnit pozici pro popisovač souboru %d"
 
-#: ../src/common/textfile.cpp:273
+#: ../src/common/textfile.cpp:161
 #, c-format
 msgid "can't write buffer '%s' to disk."
 msgstr "nelze zapsat vyrovnávací paměť '%s' na disk."
 
-#: ../src/common/file.cpp:323
+#: ../src/common/file.cpp:364
 #, c-format
 msgid "can't write to file descriptor %d"
 msgstr "nelze zapisovat do popisovače souboru %d"
@@ -8197,22 +8387,28 @@ msgid "can't write user configuration file."
 msgstr "nelze zapisovat do uživatelského konfigurační souboru."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:482 ../src/generic/datavgen.cpp:1261
+#: ../src/common/datavcmn.cpp:2064 ../src/generic/datavgen.cpp:1384
 msgid "checked"
 msgstr "zaškrtnuto"
 
-#: ../src/html/chm.cpp:345
+#: ../src/html/chm.cpp:342
 msgid "checksum error"
 msgstr "chyba kontrolního součtu"
 
-#: ../src/common/tarstrm.cpp:820
+#: ../src/common/tarstrm.cpp:814
 msgid "checksum failure reading tar header block"
 msgstr "selhání kontrolního součtu při čtení bloku tar hlavičky"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:226
-#: ../src/richtext/richtextbackgroundpage.cpp:249
-#: ../src/richtext/richtextbackgroundpage.cpp:289
-#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
 #: ../src/richtext/richtextborderspage.cpp:254
 #: ../src/richtext/richtextborderspage.cpp:288
 #: ../src/richtext/richtextborderspage.cpp:322
@@ -8230,104 +8426,127 @@ msgstr "selhání kontrolního součtu při čtení bloku tar hlavičky"
 #: ../src/richtext/richtextmarginspage.cpp:340
 #: ../src/richtext/richtextmarginspage.cpp:363
 #: ../src/richtext/richtextmarginspage.cpp:388
-#: ../src/richtext/richtextsizepage.cpp:339
-#: ../src/richtext/richtextsizepage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:400
-#: ../src/richtext/richtextsizepage.cpp:427
-#: ../src/richtext/richtextsizepage.cpp:454
-#: ../src/richtext/richtextsizepage.cpp:481
-#: ../src/richtext/richtextsizepage.cpp:555
-#: ../src/richtext/richtextsizepage.cpp:590
-#: ../src/richtext/richtextsizepage.cpp:625
-#: ../src/richtext/richtextsizepage.cpp:660
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
 msgid "cm"
 msgstr "cm"
 
-#: ../src/html/chm.cpp:347
+#: ../src/html/chm.cpp:344
 msgid "compression error"
 msgstr "chyba komprese"
 
-#: ../src/common/regex.cpp:236
+#: ../src/common/regex.cpp:233
 msgid "conversion to 8-bit encoding failed"
 msgstr "převod do 8bitového kódování selhal"
 
-#: ../src/common/accelcmn.cpp:187
+#: ../src/common/accelcmn.cpp:186
 msgid "ctrl"
 msgstr "ctrl"
 
-#: ../src/common/cmdline.cpp:1500
+#: ../src/common/cmdline.cpp:1496
 msgid "date"
 msgstr "datum"
 
-#: ../src/html/chm.cpp:349
+#: ../src/html/chm.cpp:346
 msgid "decompression error"
 msgstr "chyba dekomprese"
 
-#: ../src/richtext/richtextstyles.cpp:780 ../src/common/fmapbase.cpp:820
+#: ../src/common/fmapbase.cpp:816 ../src/richtext/richtextstyles.cpp:777
 msgid "default"
 msgstr "výchozí"
 
-#: ../src/common/cmdline.cpp:1496
+#: ../src/common/cmdline.cpp:1492
 msgid "double"
 msgstr "číslo s plovoucí čárkou"
 
-#: ../src/common/debugrpt.cpp:538
+#: ../src/common/debugrpt.cpp:539
 msgid "dump of the process state (binary)"
 msgstr "výpis stavu procesu (binární)"
 
-#: ../src/common/datetimefmt.cpp:1969
+#: ../src/common/datetimefmt.cpp:1992
 msgid "eighteenth"
 msgstr "osmnáctého"
 
-#: ../src/common/datetimefmt.cpp:1959
+#: ../src/common/datetimefmt.cpp:1982
 msgid "eighth"
 msgstr "osmého"
 
-#: ../src/common/datetimefmt.cpp:1962
+#: ../src/common/datetimefmt.cpp:1985
 msgid "eleventh"
 msgstr "jedenáctého"
 
-#: ../src/common/fileconf.cpp:1833
+#: ../src/common/fileconf.cpp:1835
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "položka '%s' se ve skupině '%s' vyskytuje víc než jednou"
 
-#: ../src/html/chm.cpp:343
+#: ../src/html/chm.cpp:340
 msgid "error in data format"
 msgstr "chyba ve formátu dat."
 
-#: ../src/html/chm.cpp:331
+#: ../src/html/chm.cpp:328
 msgid "error opening file"
 msgstr "chyba při otevírání souboru"
 
-#: ../src/common/zipstrm.cpp:1778
+#: ../src/common/zipstrm.cpp:1836
 msgid "error reading zip central directory"
 msgstr "chyba při čtení centrálního adresáře zip"
 
-#: ../src/common/zipstrm.cpp:1870
+#: ../src/common/zipstrm.cpp:1940
 msgid "error reading zip local header"
 msgstr "chyba při čtení místní zip hlavičky"
 
-#: ../src/common/zipstrm.cpp:2531
+#: ../src/common/zipstrm.cpp:2615
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "chyba při zápisu záznamu zip '%s': špatná CRC nebo délka"
 
-#: ../src/common/ffile.cpp:188
+#: ../src/common/zipstrm.cpp:2608
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "chyba při zápisu záznamu zip '%s': špatná CRC nebo délka"
+
+#: ../src/common/fontcmn.cpp:1205
+#, fuzzy
+msgid "extrabold"
+msgstr "tučné"
+
+#: ../src/common/fontcmn.cpp:1223
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1167
+#, fuzzy
+msgid "extralight"
+msgstr "tenké"
+
+#: ../src/msw/webview_ie.cpp:1036
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "Nelze spustit '%s'\n"
+
+#: ../src/common/ffile.cpp:187
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "nelze vyprázdnit buffer souboru '%s'"
 
+#: ../src/msw/webview_ie.cpp:1045
+#, fuzzy
+msgid "failed to retrieve execution result"
+msgstr "Nepodařilo se získat text chybového hlášení RAS"
+
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1030
+#: ../src/generic/datavgen.cpp:1150
 msgid "false"
 msgstr "nepravda"
 
-#: ../src/common/datetimefmt.cpp:1966
+#: ../src/common/datetimefmt.cpp:1989
 msgid "fifteenth"
 msgstr "patnáctého"
 
-#: ../src/common/datetimefmt.cpp:1956
+#: ../src/common/datetimefmt.cpp:1979
 msgid "fifth"
 msgstr "pátého"
 
@@ -8356,131 +8575,150 @@ msgstr "soubor '%s', řádka %zu: hodnota pro neměnný klíč '%s' ignorována.
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "soubor '%s': neočekávaný znak %c na řádku %zu."
 
-#: ../src/richtext/richtextbuffer.cpp:8738
+#: ../src/richtext/richtextbuffer.cpp:8736
 msgid "files"
 msgstr "soubory"
 
-#: ../src/common/datetimefmt.cpp:1952
+#: ../src/common/datetimefmt.cpp:1975
 msgid "first"
 msgstr "prvního"
 
-#: ../src/html/helpwnd.cpp:1252
+#: ../src/html/helpwnd.cpp:1250
 msgid "font size"
 msgstr "velikost písma"
 
-#: ../src/common/datetimefmt.cpp:1965
+#: ../src/common/datetimefmt.cpp:1988
 msgid "fourteenth"
 msgstr "čtrnáctého"
 
-#: ../src/common/datetimefmt.cpp:1955
+#: ../src/common/datetimefmt.cpp:1978
 msgid "fourth"
 msgstr "čtvrtého"
 
-#: ../src/common/appbase.cpp:783
+#: ../src/common/appbase.cpp:784
 msgid "generate verbose log messages"
 msgstr "v logu vypisovat podrobné zprávy"
 
-#: ../src/richtext/richtextbuffer.cpp:13138
-#: ../src/richtext/richtextbuffer.cpp:13248
+#: ../src/common/fontcmn.cpp:1215
+msgid "heavy"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:13133
+#: ../src/richtext/richtextbuffer.cpp:13243
 msgid "image"
 msgstr "obrázek"
 
-#: ../src/common/tarstrm.cpp:796
+#: ../src/common/tarstrm.cpp:790
 msgid "incomplete header block in tar"
 msgstr "neúplný blok hlavičky v tar"
 
-#: ../src/common/xtixml.cpp:489
+#: ../src/common/xtixml.cpp:485
 msgid "incorrect event handler string, missing dot"
 msgstr "nesprávný řetězec obslužné rutiny události, chybí tečka"
 
-#: ../src/common/tarstrm.cpp:1381
+#: ../src/common/tarstrm.cpp:1375
 msgid "incorrect size given for tar entry"
 msgstr "předána neplatná velikost pro tar záznam"
 
-#: ../src/common/tarstrm.cpp:993
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:987
 msgid "invalid data in extended tar header"
 msgstr "neplatná data v rozšířené tar hlavičce"
 
-#: ../src/generic/logg.cpp:1030
+#: ../src/generic/logg.cpp:1027
 msgid "invalid message box return value"
 msgstr "špatná návratová hodnota message boxu"
 
-#: ../src/common/zipstrm.cpp:1647
+#: ../src/common/zipstrm.cpp:1688
 msgid "invalid zip file"
 msgstr "neplatný zip soubor"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:1228
 msgid "italic"
 msgstr "kurzíva"
 
-#: ../src/common/fontcmn.cpp:991
+#: ../src/common/webrequest_curl.cpp:374
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "Popis sloupce nemohl být zaveden."
+
+#: ../src/common/fontcmn.cpp:1172
 msgid "light"
 msgstr "tenké"
 
-#: ../src/common/intl.cpp:303
-#, c-format
-msgid "locale '%s' cannot be set."
-msgstr "Místní a jazykové nastavení '%s' nemůže být nastaveno."
+#: ../src/common/fontcmn.cpp:1185
+msgid "medium"
+msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2125
+#: ../src/common/datetimefmt.cpp:2148
 msgid "midnight"
 msgstr "půlnoc"
 
-#: ../src/common/datetimefmt.cpp:1970
+#: ../src/common/datetimefmt.cpp:1993
 msgid "nineteenth"
 msgstr "devatenáctého"
 
-#: ../src/common/datetimefmt.cpp:1960
+#: ../src/common/datetimefmt.cpp:1983
 msgid "ninth"
 msgstr "devátého"
 
-#: ../src/msw/dde.cpp:1116
+#: ../src/msw/dde.cpp:1180
 msgid "no DDE error."
 msgstr "žádná chyba DDE."
 
-#: ../src/html/chm.cpp:327
+#: ../src/html/chm.cpp:324
 msgid "no error"
 msgstr "bez chyb"
 
-#: ../src/dfb/fontmgr.cpp:174
+#: ../src/dfb/fontmgr.cpp:171
 #, c-format
 msgid "no fonts found in %s, using builtin font"
 msgstr "v %s nebylo nalezeno žádné písmo, použito zabudované písmo"
 
-#: ../src/html/helpdata.cpp:657
+#: ../src/html/helpdata.cpp:650
 msgid "noname"
 msgstr "bezejmenná"
 
-#: ../src/common/datetimefmt.cpp:2124
+#: ../src/common/datetimefmt.cpp:2147
 msgid "noon"
 msgstr "poledne"
 
-#: ../src/richtext/richtextstyles.cpp:779
+#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "normální"
 
-#: ../src/common/cmdline.cpp:1492
+#: ../src/common/cmdline.cpp:1488
 msgid "num"
 msgstr "číslo"
 
-#: ../src/common/xtixml.cpp:259
+#: ../src/common/accelcmn.cpp:194
+msgid "num "
+msgstr ""
+
+#: ../src/common/xtixml.cpp:255
 msgid "objects cannot have XML Text Nodes"
 msgstr "objekty nemohou mít textové uzly XML"
 
-#: ../src/html/chm.cpp:339
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
 msgid "out of memory"
 msgstr "nedostatek paměti"
 
-#: ../src/common/debugrpt.cpp:514
+#: ../src/common/debugrpt.cpp:515
 msgid "process context description"
 msgstr "popis kontextu procesu"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:227
-#: ../src/richtext/richtextbackgroundpage.cpp:250
-#: ../src/richtext/richtextbackgroundpage.cpp:290
-#: ../src/richtext/richtextbackgroundpage.cpp:317
-#: ../src/richtext/richtextfontpage.cpp:177
-#: ../src/richtext/richtextfontpage.cpp:180
 #: ../src/richtext/richtextborderspage.cpp:255
 #: ../src/richtext/richtextborderspage.cpp:289
 #: ../src/richtext/richtextborderspage.cpp:323
@@ -8490,22 +8728,45 @@ msgstr "popis kontextu procesu"
 #: ../src/richtext/richtextborderspage.cpp:491
 #: ../src/richtext/richtextborderspage.cpp:525
 #: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextfontpage.cpp:180
 msgid "pt"
 msgstr "pt"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:225
-#: ../src/richtext/richtextbackgroundpage.cpp:228
-#: ../src/richtext/richtextbackgroundpage.cpp:229
-#: ../src/richtext/richtextbackgroundpage.cpp:248
-#: ../src/richtext/richtextbackgroundpage.cpp:251
-#: ../src/richtext/richtextbackgroundpage.cpp:252
-#: ../src/richtext/richtextbackgroundpage.cpp:288
-#: ../src/richtext/richtextbackgroundpage.cpp:291
-#: ../src/richtext/richtextbackgroundpage.cpp:292
-#: ../src/richtext/richtextbackgroundpage.cpp:315
-#: ../src/richtext/richtextbackgroundpage.cpp:318
-#: ../src/richtext/richtextbackgroundpage.cpp:319
-#: ../src/richtext/richtextfontpage.cpp:178
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:659
+#: ../src/richtext/richtextsizepage.cpp:662
+#: ../src/richtext/richtextsizepage.cpp:663
 #: ../src/richtext/richtextborderspage.cpp:253
 #: ../src/richtext/richtextborderspage.cpp:256
 #: ../src/richtext/richtextborderspage.cpp:257
@@ -8557,259 +8818,269 @@ msgstr "pt"
 #: ../src/richtext/richtextmarginspage.cpp:387
 #: ../src/richtext/richtextmarginspage.cpp:389
 #: ../src/richtext/richtextmarginspage.cpp:390
-#: ../src/richtext/richtextsizepage.cpp:338
-#: ../src/richtext/richtextsizepage.cpp:341
-#: ../src/richtext/richtextsizepage.cpp:342
-#: ../src/richtext/richtextsizepage.cpp:372
-#: ../src/richtext/richtextsizepage.cpp:375
-#: ../src/richtext/richtextsizepage.cpp:376
-#: ../src/richtext/richtextsizepage.cpp:399
-#: ../src/richtext/richtextsizepage.cpp:402
-#: ../src/richtext/richtextsizepage.cpp:403
-#: ../src/richtext/richtextsizepage.cpp:426
-#: ../src/richtext/richtextsizepage.cpp:429
-#: ../src/richtext/richtextsizepage.cpp:430
-#: ../src/richtext/richtextsizepage.cpp:453
-#: ../src/richtext/richtextsizepage.cpp:456
-#: ../src/richtext/richtextsizepage.cpp:457
-#: ../src/richtext/richtextsizepage.cpp:480
-#: ../src/richtext/richtextsizepage.cpp:483
-#: ../src/richtext/richtextsizepage.cpp:484
-#: ../src/richtext/richtextsizepage.cpp:554
-#: ../src/richtext/richtextsizepage.cpp:557
-#: ../src/richtext/richtextsizepage.cpp:558
-#: ../src/richtext/richtextsizepage.cpp:589
-#: ../src/richtext/richtextsizepage.cpp:592
-#: ../src/richtext/richtextsizepage.cpp:593
-#: ../src/richtext/richtextsizepage.cpp:624
-#: ../src/richtext/richtextsizepage.cpp:627
-#: ../src/richtext/richtextsizepage.cpp:628
-#: ../src/richtext/richtextsizepage.cpp:659
-#: ../src/richtext/richtextsizepage.cpp:662
-#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextfontpage.cpp:178
 msgid "px"
 msgstr "px"
 
-#: ../src/common/accelcmn.cpp:193
+#: ../src/common/accelcmn.cpp:192
 msgid "rawctrl"
 msgstr "rawctrl"
 
-#: ../src/html/chm.cpp:333
+#: ../src/html/chm.cpp:330
 msgid "read error"
 msgstr "chyba při čteni"
 
-#: ../src/common/zipstrm.cpp:2085
+#: ../src/common/zipstrm.cpp:2155
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "čtení proudu zip (záznam %s): špatná CRC"
 
-#: ../src/common/zipstrm.cpp:2080
+#: ../src/common/zipstrm.cpp:2150
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "čtení proudu zip (záznam %s): špatná délka"
 
-#: ../src/msw/dde.cpp:1159
+#: ../src/msw/dde.cpp:1223
 msgid "reentrancy problem."
 msgstr "problém reentrance."
 
-#: ../src/common/datetimefmt.cpp:1953
+#: ../src/common/datetimefmt.cpp:1976
 msgid "second"
 msgstr "druhého"
 
-#: ../src/html/chm.cpp:337
+#: ../src/html/chm.cpp:334
 msgid "seek error"
 msgstr "chyba při hledání"
 
-#: ../src/common/datetimefmt.cpp:1968
+#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#, fuzzy
+msgid "semibold"
+msgstr "tučné"
+
+#: ../src/common/datetimefmt.cpp:1991
 msgid "seventeenth"
 msgstr "sedmnáctého"
 
-#: ../src/common/datetimefmt.cpp:1958
+#: ../src/common/datetimefmt.cpp:1981
 msgid "seventh"
 msgstr "sedmého"
 
-#: ../src/common/accelcmn.cpp:191
+#: ../src/common/accelcmn.cpp:190
 msgid "shift"
 msgstr "shift"
 
-#: ../src/common/appbase.cpp:773
+#: ../src/common/appbase.cpp:774
 msgid "show this help message"
 msgstr "zobrazí tuto nápovědu"
 
-#: ../src/common/datetimefmt.cpp:1967
+#: ../src/common/datetimefmt.cpp:1990
 msgid "sixteenth"
 msgstr "šestnáctého"
 
-#: ../src/common/datetimefmt.cpp:1957
+#: ../src/common/datetimefmt.cpp:1980
 msgid "sixth"
 msgstr "šestého"
 
-#: ../src/common/appcmn.cpp:234
+#: ../src/common/appcmn.cpp:255
 msgid "specify display mode to use (e.g. 640x480-16)"
 msgstr "určete režim obrazovky, který se má použít (např. 640x480-16)"
 
-#: ../src/common/appcmn.cpp:220
+#: ../src/common/appcmn.cpp:241
 msgid "specify the theme to use"
 msgstr "určí, jaké téma použít"
 
-#: ../src/richtext/richtextbuffer.cpp:9340
+#: ../src/richtext/richtextbuffer.cpp:9337
 msgid "standard/circle"
 msgstr "standardní/kruh"
 
-#: ../src/richtext/richtextbuffer.cpp:9341
+#: ../src/richtext/richtextbuffer.cpp:9338
 msgid "standard/circle-outline"
 msgstr "standardní/obrys kruhu"
 
-#: ../src/richtext/richtextbuffer.cpp:9343
+#: ../src/richtext/richtextbuffer.cpp:9340
 msgid "standard/diamond"
 msgstr "standardní/kosočtverec"
 
-#: ../src/richtext/richtextbuffer.cpp:9342
+#: ../src/richtext/richtextbuffer.cpp:9339
 msgid "standard/square"
 msgstr "standardní/čtverec"
 
-#: ../src/richtext/richtextbuffer.cpp:9344
+#: ../src/richtext/richtextbuffer.cpp:9341
 msgid "standard/triangle"
 msgstr "standardní/trojúhelník"
 
-#: ../src/common/zipstrm.cpp:1985
+#: ../src/common/zipstrm.cpp:2055
 msgid "stored file length not in Zip header"
 msgstr "v hlavičce zip není uložená délka souboru"
 
-#: ../src/common/cmdline.cpp:1488
+#: ../src/common/cmdline.cpp:1484
 msgid "str"
 msgstr "řetězec"
 
-#: ../src/common/fontcmn.cpp:982
+#: ../src/common/fontcmn.cpp:1145
 msgid "strikethrough"
 msgstr "přeškrtnuté"
 
-#: ../src/common/tarstrm.cpp:1003 ../src/common/tarstrm.cpp:1025
-#: ../src/common/tarstrm.cpp:1507 ../src/common/tarstrm.cpp:1529
+#: ../src/common/tarstrm.cpp:997 ../src/common/tarstrm.cpp:1019
+#: ../src/common/tarstrm.cpp:1501 ../src/common/tarstrm.cpp:1523
 msgid "tar entry not open"
 msgstr "záznam tar není otevřen"
 
-#: ../src/common/datetimefmt.cpp:1961
+#: ../src/common/datetimefmt.cpp:1984
 msgid "tenth"
 msgstr "desátého"
 
-#: ../src/msw/dde.cpp:1123
+#: ../src/msw/dde.cpp:1187
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "odpověď na transakci způsobila nastavení bitu DDE_FBUSY."
 
-#: ../src/common/datetimefmt.cpp:1954
+#: ../src/common/fontcmn.cpp:1154
+msgid "thin"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:1977
 msgid "third"
 msgstr "třetího"
 
-#: ../src/common/datetimefmt.cpp:1964
+#: ../src/common/datetimefmt.cpp:1987
 msgid "thirteenth"
 msgstr "třináctého"
 
-#: ../src/common/datetimefmt.cpp:1758
+#: ../src/common/datetimefmt.cpp:1781
 msgid "today"
 msgstr "dnes"
 
-#: ../src/common/datetimefmt.cpp:1760
+#: ../src/common/datetimefmt.cpp:1783
 msgid "tomorrow"
 msgstr "zítra"
 
-#: ../src/common/fileconf.cpp:1944
+#: ../src/common/fileconf.cpp:1946
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "zpětné lomítko na konci ignorováno v '%s'"
 
-#: ../src/gtk/aboutdlg.cpp:218
+#: ../src/gtk/aboutdlg.cpp:216
 msgid "translator-credits"
 msgstr "překladatel-poděkování"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1028
+#: ../src/generic/datavgen.cpp:1148
 msgid "true"
 msgstr "pravda"
 
-#: ../src/common/datetimefmt.cpp:1963
+#: ../src/common/datetimefmt.cpp:1986
 msgid "twelfth"
 msgstr "dvanáctého"
 
-#: ../src/common/datetimefmt.cpp:1971
+#: ../src/common/datetimefmt.cpp:1994
 msgid "twentieth"
 msgstr "dvacátého"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:486 ../src/generic/datavgen.cpp:1263
+#: ../src/common/datavcmn.cpp:2068 ../src/generic/datavgen.cpp:1386
 msgid "unchecked"
 msgstr "zaškrtnuto"
 
-#: ../src/common/fontcmn.cpp:802 ../src/common/fontcmn.cpp:978
+#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
 msgid "underlined"
 msgstr "podtržené"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:490
+#: ../src/common/datavcmn.cpp:2072
 msgid "undetermined"
 msgstr "neurčité"
 
-#: ../src/common/fileconf.cpp:1979
+#: ../src/common/fileconf.cpp:1981
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "neočekávané \" na pozici %d v '%s'."
 
-#: ../src/common/tarstrm.cpp:1045
+#: ../src/common/tarstrm.cpp:1039
 msgid "unexpected end of file"
 msgstr "neočekávaný konec souboru"
 
-#: ../src/generic/progdlgg.cpp:370 ../src/common/tarstrm.cpp:371
-#: ../src/common/tarstrm.cpp:394 ../src/common/tarstrm.cpp:425
+#: ../src/common/tarstrm.cpp:366 ../src/common/tarstrm.cpp:389
+#: ../src/common/tarstrm.cpp:420 ../src/generic/progdlgg.cpp:376
 msgid "unknown"
 msgstr "neznámý"
 
-#: ../src/msw/registry.cpp:150
+#: ../src/msw/registry.cpp:139
 #, c-format
 msgid "unknown (%lu)"
 msgstr "neznámé (%lu)"
 
-#: ../src/common/xtixml.cpp:253
+#: ../src/common/xtixml.cpp:249
 #, c-format
 msgid "unknown class %s"
 msgstr "neznámá třida %s"
 
-#: ../src/common/regex.cpp:258 ../src/html/chm.cpp:351
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "chyba komprese"
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "chyba dekomprese"
+
+#: ../src/common/regex.cpp:255 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "neznámá chyba"
 
-#: ../src/msw/dialup.cpp:471
+#: ../src/msw/dialup.cpp:465
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "neznámá chyba (kód %08x)."
 
-#: ../src/common/fmapbase.cpp:834
+#: ../src/common/fmapbase.cpp:830
 #, c-format
 msgid "unknown-%d"
 msgstr "neznámé-%d"
 
-#: ../src/common/docview.cpp:509
+#: ../src/common/docview.cpp:502
 msgid "unnamed"
 msgstr "nepojmenovaný"
 
-#: ../src/common/docview.cpp:1624
+#: ../src/common/docview.cpp:1618
 #, c-format
 msgid "unnamed%d"
 msgstr "nepojmenovaný%d"
 
-#: ../src/common/zipstrm.cpp:1999 ../src/common/zipstrm.cpp:2319
+#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
 msgid "unsupported Zip compression method"
 msgstr "nepodporovaná metoda komprese zip"
 
-#: ../src/common/translation.cpp:1892
+#: ../src/common/translation.cpp:1942
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "používám katalog '%s' z '%s'."
 
-#: ../src/html/chm.cpp:335
+#: ../src/html/chm.cpp:332
 msgid "write error"
 msgstr "chyba při zápisu"
 
-#: ../src/common/time.cpp:292
+#: ../src/gtk/glcanvas.cpp:187
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/common/time.cpp:285
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay selhalo."
 
@@ -8822,15 +9093,15 @@ msgstr "wxWidgets nemůže otevřít zobrazení pro '%s': ukončeno."
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets nemůže otevřít zobrazení. Ukončeno."
 
-#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:431
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/common/datetimefmt.cpp:1759
+#: ../src/common/datetimefmt.cpp:1782
 msgid "yesterday"
 msgstr "včera"
 
-#: ../src/common/zstream.cpp:251 ../src/common/zstream.cpp:426
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
 #, c-format
 msgid "zlib error %d"
 msgstr "chyba zlib %d"
@@ -8839,6 +9110,78 @@ msgstr "chyba zlib %d"
 #: ../src/richtext/richtextbulletspage.cpp:288
 msgid "~"
 msgstr "~"
+
+#~ msgid " (while overwriting an existing item)"
+#~ msgstr " (při přepisování existující položky)"
+
+#~ msgid "&Save as"
+#~ msgstr "&Uložit jako"
+
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' neobsahuje pouze platné znaky"
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' musí být číslo."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' musí obsahovat pouze ASCII znaky."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' musí obsahovat pouze písmena."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' musí obsahovat pouze písmena nebo číslice."
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' musí obsahovat pouze čísla."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "Nelze vytvořit okno třídy %s"
+
+#~ msgid "Could not initalize libnotify."
+#~ msgstr "Nelze zavést libnotify."
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "Nelze vytvořit okno překrytí"
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "Nelze inicializovat kontext v okně překrytí"
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "Nelze převést soubor \"%s\" na Unicode."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "Nelze nastavit text v textovém poli."
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr "Neplatná volba příkazové řádky GTK+, použijte \"%s --help\""
+
+#~ msgid "No unused colour in image."
+#~ msgstr "V obrázku není žádná nepoužitá barva."
+
+#~ msgid "Not available"
+#~ msgstr "Není dostupný"
+
+#~ msgid "Replace selection"
+#~ msgstr "Nahradit výběr"
+
+#~ msgid "Save as"
+#~ msgstr "Uložit jako"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Organizátor stylů"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "Následující standardní volby GTK+ jsou také podporovány:\n"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "Nemůžete použít Clear pro překrytí, které není inicializované"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "Překrytí nemůžete inicializovat dvakrát"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "Místní a jazykové nastavení '%s' nemůže být nastaveno."
 
 #~ msgid "Adding flavor TEXT failed"
 #~ msgstr "Přidání flavor TEXT selhalo"
@@ -8857,9 +9200,6 @@ msgstr "~"
 
 #~ msgid "Column could not be added."
 #~ msgstr "Sloupec nelze přidat."
-
-#~ msgid "Column description could not be initialized."
-#~ msgstr "Popis sloupce nemohl být zaveden."
 
 #~ msgid "Column index not found."
 #~ msgstr "Index sloupce nenalezen."
@@ -9442,9 +9782,6 @@ msgstr "~"
 #~ msgid "Directory '%s' doesn't exist!"
 #~ msgstr "Adresář '%s' neexistuje!"
 
-#~ msgid "File %s does not exist."
-#~ msgstr "Soubor %s neexistuje."
-
 #~ msgid "Mode %ix%i-%i not available."
 #~ msgstr "Režim %ix%i-%i není k dispozici."
 
@@ -9653,9 +9990,6 @@ msgstr "~"
 #, fuzzy
 #~ msgid "Failed to register OpenGL window class."
 #~ msgstr "Nelze inicializovat OpenGL"
-
-#~ msgid "Fatal error"
-#~ msgstr "Kritická chyba"
 
 #~ msgid "Fatal error: "
 #~ msgstr "Kritická chyba: "

--- a/locale/da.po
+++ b/locale/da.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-21 14:25+0200\n"
+"POT-Creation-Date: 2020-10-18 23:11+0300\n"
 "PO-Revision-Date: 2017-07-26 00:00+0000\n"
 "Last-Translator: scootergrisen\n"
 "Language-Team: Danish\n"
@@ -19,7 +19,7 @@ msgstr ""
 "X-Language: da_DK\n"
 "X-Source-Language: C\n"
 
-#: ../src/common/debugrpt.cpp:586
+#: ../src/common/debugrpt.cpp:587
 msgid ""
 "\n"
 "Please send this report to the program maintainer, thank you!\n"
@@ -28,8 +28,8 @@ msgstr ""
 "Send venligst denne rapport til vedligeholderen af programmet. På forhånd "
 "tak.\n"
 
-#: ../src/richtext/richtextstyledlg.cpp:210
-#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:206
+#: ../src/richtext/richtextstyledlg.cpp:218
 msgid " "
 msgstr " "
 
@@ -37,70 +37,96 @@ msgstr " "
 msgid "              Thank you and we're sorry for the inconvenience!\n"
 msgstr "              Mange tak. Vi beklager ulejligheden.\n"
 
-#: ../src/common/prntbase.cpp:573
+#: ../src/common/prntbase.cpp:568
 #, c-format
 msgid " (copy %d of %d)"
 msgstr " (kopi %d af %d)"
 
-#: ../src/common/log.cpp:421
+#: ../src/common/log.cpp:440
 #, c-format
 msgid " (error %ld: %s)"
 msgstr " (fejl %ld: %s)"
 
-#: ../src/common/imagtiff.cpp:72
+#: ../src/common/imagtiff.cpp:69
 #, c-format
 msgid " (in module \"%s\")"
 msgstr " (i modul \"%s\")"
 
-#: ../src/osx/core/secretstore.cpp:138
-msgid " (while overwriting an existing item)"
-msgstr " (under overskrivning af et eksisterende punkt)"
-
-#: ../src/common/docview.cpp:1642
+#: ../src/common/docview.cpp:1636
 msgid " - "
 msgstr " - "
 
-#: ../src/richtext/richtextprint.cpp:593 ../src/html/htmprint.cpp:714
+#: ../src/html/htmprint.cpp:712 ../src/richtext/richtextprint.cpp:589
 msgid " Preview"
 msgstr " Vis udskrift"
 
-#: ../src/common/fontcmn.cpp:824
+#: ../src/common/fontcmn.cpp:973
 msgid " bold"
 msgstr " fed"
 
-#: ../src/common/fontcmn.cpp:840
+#: ../src/common/fontcmn.cpp:977
+#, fuzzy
+msgid " extra bold"
+msgstr " fed"
+
+#: ../src/common/fontcmn.cpp:985
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:957
+#, fuzzy
+msgid " extra light"
+msgstr " let"
+
+#: ../src/common/fontcmn.cpp:981
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1001
 msgid " italic"
 msgstr " kursiv"
 
-#: ../src/common/fontcmn.cpp:820
+#: ../src/common/fontcmn.cpp:961
 msgid " light"
 msgstr " let"
 
-#: ../src/common/fontcmn.cpp:807
+#: ../src/common/fontcmn.cpp:965
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:969
+#, fuzzy
+msgid " semi bold"
+msgstr " fed"
+
+#: ../src/common/fontcmn.cpp:940
 msgid " strikethrough"
 msgstr " gennemstreget"
 
-#: ../src/common/paper.cpp:117
+#: ../src/common/fontcmn.cpp:953
+msgid " thin"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
 msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
 msgstr "#10-konvolut, 4 1/8 x 9 1/2 tommer"
 
-#: ../src/common/paper.cpp:118
+#: ../src/common/paper.cpp:115
 msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
 msgstr "#11-konvolut, 4 1/2 x 10 3/8 tommer"
 
-#: ../src/common/paper.cpp:119
+#: ../src/common/paper.cpp:116
 msgid "#12 Envelope, 4 3/4 x 11 in"
 msgstr "#12-konvolut, 4 3/4 x 11 tommer"
 
-#: ../src/common/paper.cpp:120
+#: ../src/common/paper.cpp:117
 msgid "#14 Envelope, 5 x 11 1/2 in"
 msgstr "#14-konvolut, 5 x 11 1/2 tommer"
 
-#: ../src/common/paper.cpp:116
+#: ../src/common/paper.cpp:113
 msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
 msgstr "#9-konvolut, 3 7/8 x 8 7/8 tommer"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:341
 #: ../src/richtext/richtextsizepage.cpp:340
 #: ../src/richtext/richtextsizepage.cpp:374
 #: ../src/richtext/richtextsizepage.cpp:401
@@ -111,81 +137,82 @@ msgstr "#9-konvolut, 3 7/8 x 8 7/8 tommer"
 #: ../src/richtext/richtextsizepage.cpp:591
 #: ../src/richtext/richtextsizepage.cpp:626
 #: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextbackgroundpage.cpp:341
 msgid "%"
 msgstr "%"
 
-#: ../src/html/helpwnd.cpp:1031
+#: ../src/html/helpwnd.cpp:1029
 #, c-format
 msgid "%d of %lu"
 msgstr "%d af %lu"
 
-#: ../src/html/helpwnd.cpp:1678
+#: ../src/html/helpwnd.cpp:1676
 #, c-format
 msgid "%i of %u"
 msgstr "%i af %u"
 
-#: ../src/generic/filectrlg.cpp:279
+#: ../src/generic/filectrlg.cpp:275
 #, c-format
 msgid "%ld byte"
 msgid_plural "%ld bytes"
 msgstr[0] "%ld byte"
 msgstr[1] "%ld byte"
 
-#: ../src/html/helpwnd.cpp:1033
+#: ../src/html/helpwnd.cpp:1031
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu af %lu"
 
-#: ../src/generic/datavgen.cpp:6028
+#: ../src/generic/datavgen.cpp:6833
 #, c-format
 msgid "%s (%d items)"
 msgstr "%s (%d punkter)"
 
-#: ../src/common/cmdline.cpp:1221
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (eller %s)"
 
-#: ../src/generic/logg.cpp:224
+#: ../src/generic/logg.cpp:221
 #, c-format
 msgid "%s Error"
 msgstr "%s fejl"
 
-#: ../src/generic/logg.cpp:236
+#: ../src/generic/logg.cpp:233
 #, c-format
 msgid "%s Information"
 msgstr "%s information"
 
-#: ../src/generic/preferencesg.cpp:113
+#: ../src/generic/preferencesg.cpp:110
 #, c-format
 msgid "%s Preferences"
 msgstr "%s indstillinger"
 
-#: ../src/generic/logg.cpp:228
+#: ../src/generic/logg.cpp:225
 #, c-format
 msgid "%s Warning"
 msgstr "%s advarsel"
 
-#: ../src/common/tarstrm.cpp:1319
+#: ../src/common/tarstrm.cpp:1313
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s passede ikke til tar-headeren for \"%s\""
 
-#: ../src/common/fldlgcmn.cpp:124
+#: ../src/common/fldlgcmn.cpp:121
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s filer (%s)|%s"
 
-#: ../src/html/helpwnd.cpp:1716
+#: ../src/html/helpwnd.cpp:1714
 #, c-format
 msgid "%u of %u"
 msgstr "%u af %u"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "&About"
 msgstr "&Om"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "&Actual Size"
 msgstr "&Faktisk størrelse"
 
@@ -193,28 +220,28 @@ msgstr "&Faktisk størrelse"
 msgid "&After a paragraph:"
 msgstr "&Efter et afsnit:"
 
-#: ../src/richtext/richtextindentspage.cpp:128
 #: ../src/richtext/richtextliststylepage.cpp:319
+#: ../src/richtext/richtextindentspage.cpp:128
 msgid "&Alignment"
 msgstr "&Justering"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "&Apply"
 msgstr "&Anvend"
 
-#: ../src/richtext/richtextstyledlg.cpp:251
+#: ../src/richtext/richtextstyledlg.cpp:247
 msgid "&Apply Style"
 msgstr "&Anvend typografi"
 
-#: ../src/msw/mdi.cpp:179
+#: ../src/msw/mdi.cpp:174
 msgid "&Arrange Icons"
 msgstr "&Arrangér ikoner"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "&Ascending"
 msgstr "&Stigende"
 
-#: ../src/common/stockitem.cpp:142
+#: ../src/common/stockitem.cpp:139
 msgid "&Back"
 msgstr "&Tilbage"
 
@@ -234,24 +261,24 @@ msgstr "&Bg.-farve:"
 msgid "&Blur distance:"
 msgstr "&Sløringsområde:"
 
-#: ../src/common/stockitem.cpp:143
+#: ../src/common/stockitem.cpp:140
 msgid "&Bold"
 msgstr "&Fed"
 
-#: ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141
 msgid "&Bottom"
 msgstr "&Bund"
 
+#: ../src/richtext/richtextsizepage.cpp:637
+#: ../src/richtext/richtextsizepage.cpp:644
 #: ../src/richtext/richtextborderspage.cpp:345
 #: ../src/richtext/richtextborderspage.cpp:513
 #: ../src/richtext/richtextmarginspage.cpp:259
 #: ../src/richtext/richtextmarginspage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:637
-#: ../src/richtext/richtextsizepage.cpp:644
 msgid "&Bottom:"
 msgstr "&Bund:"
 
-#: ../include/wx/richtext/richtextbuffer.h:3866
+#: ../include/wx/richtext/richtextbuffer.h:3861
 msgid "&Box"
 msgstr "&Boks"
 
@@ -260,38 +287,38 @@ msgstr "&Boks"
 msgid "&Bullet style:"
 msgstr "&Punkttegnstypografi:"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "&CD-Rom"
 msgstr "&CD-Rom"
 
-#: ../src/generic/wizard.cpp:434 ../src/generic/fontdlgg.cpp:470
-#: ../src/generic/fontdlgg.cpp:489 ../src/osx/carbon/fontdlg.cpp:402
-#: ../src/common/dlgcmn.cpp:279 ../src/common/stockitem.cpp:145
+#: ../src/osx/carbon/fontdlg.cpp:399 ../src/common/stockitem.cpp:142
+#: ../src/generic/wizard.cpp:433 ../src/generic/fontdlgg.cpp:466
+#: ../src/generic/fontdlgg.cpp:485 ../src/osx/cocoa/button.mm:200
 msgid "&Cancel"
 msgstr "&Annuller"
 
-#: ../src/msw/mdi.cpp:175
+#: ../src/msw/mdi.cpp:170
 msgid "&Cascade"
 msgstr "&Taglagt"
 
-#: ../include/wx/richtext/richtextbuffer.h:5960
+#: ../include/wx/richtext/richtextbuffer.h:5955
 msgid "&Cell"
 msgstr "&Celle"
 
-#: ../src/richtext/richtextsymboldlg.cpp:439
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "&Character code:"
 msgstr "&Tegnkode:"
 
-#: ../src/common/stockitem.cpp:147
+#: ../src/common/stockitem.cpp:144
 msgid "&Clear"
 msgstr "&Rens"
 
-#: ../src/generic/logg.cpp:516 ../src/common/stockitem.cpp:148
-#: ../src/common/prntbase.cpp:1600 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/stockitem.cpp:145 ../src/common/prntbase.cpp:1625
+#: ../src/univ/themes/win32.cpp:3753 ../src/generic/logg.cpp:513
 msgid "&Close"
 msgstr "&Luk"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "&Color"
 msgstr "F&arve"
 
@@ -299,20 +326,20 @@ msgstr "F&arve"
 msgid "&Colour:"
 msgstr "F&arve:"
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "&Convert"
 msgstr "&Konverter"
 
-#: ../src/richtext/richtextctrl.cpp:333 ../src/osx/textctrl_osx.cpp:577
-#: ../src/common/stockitem.cpp:150 ../src/msw/textctrl.cpp:2508
+#: ../src/osx/textctrl_osx.cpp:595 ../src/common/stockitem.cpp:147
+#: ../src/msw/textctrl.cpp:2773 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Kopiér"
 
-#: ../src/generic/hyperlinkg.cpp:156
+#: ../src/generic/hyperlinkg.cpp:153
 msgid "&Copy URL"
 msgstr "&Kopiér URL"
 
-#: ../src/common/headerctrlcmn.cpp:306
+#: ../src/common/headerctrlcmn.cpp:304
 msgid "&Customize..."
 msgstr "&Tilpas..."
 
@@ -320,53 +347,54 @@ msgstr "&Tilpas..."
 msgid "&Debug report preview:"
 msgstr "&Forhåndsvis fejlfindingsrapport:"
 
-#: ../src/richtext/richtexttabspage.cpp:138
-#: ../src/richtext/richtextctrl.cpp:335 ../src/osx/textctrl_osx.cpp:579
-#: ../src/common/stockitem.cpp:152 ../src/msw/textctrl.cpp:2510
+#: ../src/osx/textctrl_osx.cpp:597 ../src/common/stockitem.cpp:149
+#: ../src/msw/textctrl.cpp:2775 ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtextctrl.cpp:334
 msgid "&Delete"
 msgstr "&Slet"
 
-#: ../src/richtext/richtextstyledlg.cpp:269
+#: ../src/richtext/richtextstyledlg.cpp:265
 msgid "&Delete Style..."
 msgstr "&Slet typografi..."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "&Descending"
 msgstr "&Faldende"
 
-#: ../src/generic/logg.cpp:682
+#: ../src/generic/logg.cpp:679
 msgid "&Details"
 msgstr "&Detaljer"
 
-#: ../src/common/stockitem.cpp:153
+#: ../src/common/stockitem.cpp:150
 msgid "&Down"
 msgstr "&Ned"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "&Edit"
 msgstr "&Rediger"
 
-#: ../src/richtext/richtextstyledlg.cpp:263
+#: ../src/richtext/richtextstyledlg.cpp:259
 msgid "&Edit Style..."
 msgstr "&Rediger typografi..."
 
-#: ../src/common/stockitem.cpp:155
+#: ../src/common/stockitem.cpp:152
 msgid "&Execute"
 msgstr "&Udfør"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/common/stockitem.cpp:154
 msgid "&File"
 msgstr "&Fil"
 
-#: ../src/common/stockitem.cpp:158
-msgid "&Find"
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "&Find..."
 msgstr "&Find"
 
-#: ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:430
 msgid "&Finish"
 msgstr "&Slut"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:156
 msgid "&First"
 msgstr "&Første"
 
@@ -374,15 +402,15 @@ msgstr "&Første"
 msgid "&Floating mode:"
 msgstr "&Flydende tilstand:"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "&Floppy"
 msgstr "&Floppy"
 
-#: ../src/common/stockitem.cpp:194
+#: ../src/common/stockitem.cpp:191
 msgid "&Font"
 msgstr "&Skrift"
 
-#: ../src/generic/fontdlgg.cpp:371
+#: ../src/generic/fontdlgg.cpp:367
 msgid "&Font family:"
 msgstr "&Skrifttype:"
 
@@ -390,20 +418,20 @@ msgstr "&Skrifttype:"
 msgid "&Font for Level..."
 msgstr "&Skrifttype for niveau..."
 
+#: ../src/richtext/richtextsymboldlg.cpp:397
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:400
 msgid "&Font:"
 msgstr "&Skrift:"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "&Forward"
 msgstr "&Fremad"
 
-#: ../src/richtext/richtextsymboldlg.cpp:451
+#: ../src/richtext/richtextsymboldlg.cpp:448
 msgid "&From:"
 msgstr "&Fra:"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "&Harddisk"
 msgstr "&Harddisk"
 
@@ -412,9 +440,9 @@ msgstr "&Harddisk"
 msgid "&Height:"
 msgstr "&Højde:"
 
-#: ../src/generic/wizard.cpp:441 ../src/richtext/richtextstyledlg.cpp:303
-#: ../src/richtext/richtextsymboldlg.cpp:479 ../src/osx/menu_osx.cpp:734
-#: ../src/common/stockitem.cpp:163
+#: ../src/common/stockitem.cpp:160 ../src/generic/wizard.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextstyledlg.cpp:299 ../src/osx/cocoa/menu.mm:226
 msgid "&Help"
 msgstr "&Hjælp"
 
@@ -422,7 +450,7 @@ msgstr "&Hjælp"
 msgid "&Hide details"
 msgstr "&Højdedetaljer"
 
-#: ../src/common/stockitem.cpp:164
+#: ../src/common/stockitem.cpp:161
 msgid "&Home"
 msgstr "&Hjem"
 
@@ -430,54 +458,54 @@ msgstr "&Hjem"
 msgid "&Horizontal offset:"
 msgstr "&Lodret forskydning:"
 
-#: ../src/richtext/richtextindentspage.cpp:184
 #: ../src/richtext/richtextliststylepage.cpp:372
+#: ../src/richtext/richtextindentspage.cpp:184
 msgid "&Indentation (tenths of a mm)"
 msgstr "&Indryk (tiendedele mm)"
 
-#: ../src/richtext/richtextindentspage.cpp:167
 #: ../src/richtext/richtextliststylepage.cpp:356
+#: ../src/richtext/richtextindentspage.cpp:167
 msgid "&Indeterminate"
 msgstr "&Ubestemt"
 
-#: ../src/common/stockitem.cpp:166
+#: ../src/common/stockitem.cpp:163
 msgid "&Index"
 msgstr "&Indeks"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "&Info"
 msgstr "&Info"
 
-#: ../src/common/stockitem.cpp:168
+#: ../src/common/stockitem.cpp:165
 msgid "&Italic"
 msgstr "&Kursiv"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "&Jump to"
 msgstr "&Hop til"
 
-#: ../src/richtext/richtextindentspage.cpp:153
 #: ../src/richtext/richtextliststylepage.cpp:342
+#: ../src/richtext/richtextindentspage.cpp:153
 msgid "&Justified"
 msgstr "&Justeret"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "&Last"
 msgstr "&Sidste"
 
-#: ../src/richtext/richtextindentspage.cpp:139
 #: ../src/richtext/richtextliststylepage.cpp:328
+#: ../src/richtext/richtextindentspage.cpp:139
 msgid "&Left"
 msgstr "&Venstre"
 
-#: ../src/richtext/richtextindentspage.cpp:195
+#: ../src/richtext/richtextsizepage.cpp:532
+#: ../src/richtext/richtextsizepage.cpp:539
 #: ../src/richtext/richtextborderspage.cpp:243
 #: ../src/richtext/richtextborderspage.cpp:411
 #: ../src/richtext/richtextliststylepage.cpp:381
+#: ../src/richtext/richtextindentspage.cpp:195
 #: ../src/richtext/richtextmarginspage.cpp:186
 #: ../src/richtext/richtextmarginspage.cpp:300
-#: ../src/richtext/richtextsizepage.cpp:532
-#: ../src/richtext/richtextsizepage.cpp:539
 msgid "&Left:"
 msgstr "&Venstre:"
 
@@ -485,11 +513,11 @@ msgstr "&Venstre:"
 msgid "&List level:"
 msgstr "&Listeniveau:"
 
-#: ../src/generic/logg.cpp:517
+#: ../src/generic/logg.cpp:514
 msgid "&Log"
 msgstr "&Log"
 
-#: ../src/univ/themes/win32.cpp:3748
+#: ../src/univ/themes/win32.cpp:3745
 msgid "&Move"
 msgstr "&Flyt"
 
@@ -497,19 +525,19 @@ msgstr "&Flyt"
 msgid "&Move the object to:"
 msgstr "&Flyt objektet til:"
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "&Network"
 msgstr "&Netværk"
 
-#: ../src/richtext/richtexttabspage.cpp:132 ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173 ../src/richtext/richtexttabspage.cpp:132
 msgid "&New"
 msgstr "&Ny"
 
-#: ../src/aui/tabmdi.cpp:111 ../src/generic/mdig.cpp:100 ../src/msw/mdi.cpp:180
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
 msgid "&Next"
 msgstr "&Næste"
 
-#: ../src/generic/wizard.cpp:432 ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:429
 msgid "&Next >"
 msgstr "&Næste >"
 
@@ -517,7 +545,7 @@ msgstr "&Næste >"
 msgid "&Next Paragraph"
 msgstr "&Næste afsnit"
 
-#: ../src/generic/tipdlg.cpp:240
+#: ../src/generic/tipdlg.cpp:237
 msgid "&Next Tip"
 msgstr "&Næste tip"
 
@@ -525,11 +553,11 @@ msgstr "&Næste tip"
 msgid "&Next style:"
 msgstr "&Næste typografi:"
 
-#: ../src/common/stockitem.cpp:177 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:174 ../src/msw/msgdlg.cpp:435
 msgid "&No"
 msgstr "&Nej"
 
-#: ../src/generic/dbgrptg.cpp:356
+#: ../src/generic/dbgrptg.cpp:360
 msgid "&Notes:"
 msgstr "&Noter:"
 
@@ -537,12 +565,12 @@ msgstr "&Noter:"
 msgid "&Number:"
 msgstr "&Nummer:"
 
-#: ../src/generic/fontdlgg.cpp:475 ../src/generic/fontdlgg.cpp:482
-#: ../src/osx/carbon/fontdlg.cpp:408 ../src/common/stockitem.cpp:178
+#: ../src/osx/carbon/fontdlg.cpp:405 ../src/common/stockitem.cpp:175
+#: ../src/generic/fontdlgg.cpp:471 ../src/generic/fontdlgg.cpp:478
 msgid "&OK"
 msgstr "&OK"
 
-#: ../src/generic/dbgrptg.cpp:342 ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176 ../src/generic/dbgrptg.cpp:342
 msgid "&Open..."
 msgstr "&Åben..."
 
@@ -554,16 +582,16 @@ msgstr "&Dispositionsniveau:"
 msgid "&Page Break"
 msgstr "&Sideskift"
 
-#: ../src/richtext/richtextctrl.cpp:334 ../src/osx/textctrl_osx.cpp:578
-#: ../src/common/stockitem.cpp:180 ../src/msw/textctrl.cpp:2509
+#: ../src/osx/textctrl_osx.cpp:596 ../src/common/stockitem.cpp:177
+#: ../src/msw/textctrl.cpp:2774 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&Sæt ind"
 
-#: ../include/wx/richtext/richtextbuffer.h:5010
+#: ../include/wx/richtext/richtextbuffer.h:5005
 msgid "&Picture"
 msgstr "&Billede"
 
-#: ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:419
 msgid "&Point size:"
 msgstr "&Punktstørrelse:"
 
@@ -575,11 +603,11 @@ msgstr "&Position (tiendedele mm):"
 msgid "&Position mode:"
 msgstr "&Position mode:"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178
 msgid "&Preferences"
 msgstr "&Indstillinger"
 
-#: ../src/aui/tabmdi.cpp:112 ../src/generic/mdig.cpp:101 ../src/msw/mdi.cpp:181
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
 msgid "&Previous"
 msgstr "&Tilbage"
 
@@ -587,78 +615,74 @@ msgstr "&Tilbage"
 msgid "&Previous Paragraph"
 msgstr "&Forrige afsnit"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "&Print..."
 msgstr "&Udskriv..."
 
-#: ../src/richtext/richtextctrl.cpp:339 ../src/richtext/richtextctrl.cpp:5514
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtextctrl.cpp:338
+#: ../src/richtext/richtextctrl.cpp:5512
 msgid "&Properties"
 msgstr "&Egenskaber"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "&Quit"
 msgstr "&Afslut"
 
-#: ../src/richtext/richtextctrl.cpp:330 ../src/osx/textctrl_osx.cpp:574
-#: ../src/common/stockitem.cpp:185 ../src/common/cmdproc.cpp:293
-#: ../src/common/cmdproc.cpp:300 ../src/msw/textctrl.cpp:2505
+#: ../src/osx/textctrl_osx.cpp:592 ../src/common/stockitem.cpp:182
+#: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
+#: ../src/msw/textctrl.cpp:2770 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Omgør"
 
-#: ../src/common/cmdproc.cpp:289 ../src/common/cmdproc.cpp:309
+#: ../src/common/cmdproc.cpp:282 ../src/common/cmdproc.cpp:302
 msgid "&Redo "
 msgstr "&Omgør "
 
-#: ../src/richtext/richtextstyledlg.cpp:257
+#: ../src/richtext/richtextstyledlg.cpp:253
 msgid "&Rename Style..."
 msgstr "&Omdøb typografi..."
 
-#: ../src/generic/fdrepdlg.cpp:179
+#: ../src/generic/fdrepdlg.cpp:176
 msgid "&Replace"
 msgstr "&Erstat"
 
-#: ../src/richtext/richtextstyledlg.cpp:287
+#: ../src/richtext/richtextstyledlg.cpp:283
 msgid "&Restart numbering"
 msgstr "&Genstart nummerering"
 
-#: ../src/univ/themes/win32.cpp:3747
+#: ../src/univ/themes/win32.cpp:3744
 msgid "&Restore"
 msgstr "&Genindlæs"
 
-#: ../src/richtext/richtextindentspage.cpp:146
 #: ../src/richtext/richtextliststylepage.cpp:335
+#: ../src/richtext/richtextindentspage.cpp:146
 msgid "&Right"
 msgstr "&Højre"
 
-#: ../src/richtext/richtextindentspage.cpp:213
+#: ../src/richtext/richtextsizepage.cpp:602
+#: ../src/richtext/richtextsizepage.cpp:609
 #: ../src/richtext/richtextborderspage.cpp:277
 #: ../src/richtext/richtextborderspage.cpp:445
 #: ../src/richtext/richtextliststylepage.cpp:399
+#: ../src/richtext/richtextindentspage.cpp:213
 #: ../src/richtext/richtextmarginspage.cpp:211
 #: ../src/richtext/richtextmarginspage.cpp:325
-#: ../src/richtext/richtextsizepage.cpp:602
-#: ../src/richtext/richtextsizepage.cpp:609
 msgid "&Right:"
 msgstr "&Højre:"
 
-#: ../src/common/stockitem.cpp:190
+#: ../src/common/stockitem.cpp:187
 msgid "&Save"
 msgstr "&Gem"
-
-#: ../src/common/stockitem.cpp:191
-msgid "&Save as"
-msgstr "Gem &som"
 
 #: ../include/wx/richmsgdlg.h:29
 msgid "&See details"
 msgstr "&Se detaljer"
 
-#: ../src/generic/tipdlg.cpp:236
+#: ../src/generic/tipdlg.cpp:233
 msgid "&Show tips at startup"
 msgstr "&Vis tips ved opstart"
 
-#: ../src/univ/themes/win32.cpp:3750
+#: ../src/univ/themes/win32.cpp:3747
 msgid "&Size"
 msgstr "&Størrelse"
 
@@ -666,36 +690,36 @@ msgstr "&Størrelse"
 msgid "&Size:"
 msgstr "&Størrelse:"
 
-#: ../src/generic/progdlgg.cpp:252
+#: ../src/generic/progdlgg.cpp:249
 msgid "&Skip"
 msgstr "&Spring over"
 
-#: ../src/richtext/richtextindentspage.cpp:242
 #: ../src/richtext/richtextliststylepage.cpp:417
+#: ../src/richtext/richtextindentspage.cpp:242
 msgid "&Spacing (tenths of a mm)"
 msgstr "&Afstand (tiendedele mm)"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "&Spell Check"
 msgstr "&Stavekontrol"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "&Stop"
 msgstr "&Stop"
 
-#: ../src/richtext/richtextfontpage.cpp:275 ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196 ../src/richtext/richtextfontpage.cpp:275
 msgid "&Strikethrough"
 msgstr "&Gennemstreget"
 
-#: ../src/generic/fontdlgg.cpp:382 ../src/richtext/richtextstylepage.cpp:106
+#: ../src/generic/fontdlgg.cpp:378 ../src/richtext/richtextstylepage.cpp:106
 msgid "&Style:"
 msgstr "&Typografi:"
 
-#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:194
 msgid "&Styles:"
 msgstr "&Typografier:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:413
+#: ../src/richtext/richtextsymboldlg.cpp:410
 msgid "&Subset:"
 msgstr "&Del af tegnsæt:"
 
@@ -709,24 +733,24 @@ msgstr "&Symbol:"
 msgid "&Synchronize values"
 msgstr "&Synkroniser værdier"
 
-#: ../include/wx/richtext/richtextbuffer.h:6069
+#: ../include/wx/richtext/richtextbuffer.h:6064
 msgid "&Table"
 msgstr "&Tabel"
 
-#: ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197
 msgid "&Top"
 msgstr "&Top"
 
+#: ../src/richtext/richtextsizepage.cpp:567
+#: ../src/richtext/richtextsizepage.cpp:574
 #: ../src/richtext/richtextborderspage.cpp:311
 #: ../src/richtext/richtextborderspage.cpp:479
 #: ../src/richtext/richtextmarginspage.cpp:234
 #: ../src/richtext/richtextmarginspage.cpp:348
-#: ../src/richtext/richtextsizepage.cpp:567
-#: ../src/richtext/richtextsizepage.cpp:574
 msgid "&Top:"
 msgstr "&Top:"
 
-#: ../src/generic/fontdlgg.cpp:444 ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199 ../src/generic/fontdlgg.cpp:441
 msgid "&Underline"
 msgstr "&Understreget"
 
@@ -734,21 +758,21 @@ msgstr "&Understreget"
 msgid "&Underlining:"
 msgstr "&Understregning:"
 
-#: ../src/richtext/richtextctrl.cpp:329 ../src/osx/textctrl_osx.cpp:573
-#: ../src/common/stockitem.cpp:203 ../src/common/cmdproc.cpp:271
-#: ../src/msw/textctrl.cpp:2504
+#: ../src/osx/textctrl_osx.cpp:591 ../src/common/stockitem.cpp:200
+#: ../src/common/cmdproc.cpp:264 ../src/msw/textctrl.cpp:2769
+#: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Fortryd"
 
-#: ../src/common/cmdproc.cpp:265
+#: ../src/common/cmdproc.cpp:258
 msgid "&Undo "
 msgstr "&Fortryd "
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "&Unindent"
 msgstr "&Afindryk"
 
-#: ../src/common/stockitem.cpp:205
+#: ../src/common/stockitem.cpp:202
 msgid "&Up"
 msgstr "&Op"
 
@@ -764,7 +788,7 @@ msgstr "&Lodret forskydning:"
 msgid "&View..."
 msgstr "&Vis..."
 
-#: ../src/generic/fontdlgg.cpp:393
+#: ../src/generic/fontdlgg.cpp:389
 msgid "&Weight:"
 msgstr "&Vægt:"
 
@@ -773,88 +797,58 @@ msgstr "&Vægt:"
 msgid "&Width:"
 msgstr "&Bredde:"
 
-#: ../src/aui/tabmdi.cpp:311 ../src/aui/tabmdi.cpp:327
-#: ../src/aui/tabmdi.cpp:329 ../src/generic/mdig.cpp:294
-#: ../src/generic/mdig.cpp:310 ../src/generic/mdig.cpp:314
-#: ../src/msw/mdi.cpp:78
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
 msgid "&Window"
 msgstr "&Vindue"
 
-#: ../src/common/stockitem.cpp:206 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:203 ../src/msw/msgdlg.cpp:435
 msgid "&Yes"
 msgstr "&Ja"
 
-#: ../src/common/valtext.cpp:256
-#, c-format
-msgid "'%s' contains illegal characters"
+#: ../src/common/valtext.cpp:197
+#, fuzzy, c-format
+msgid "'%s' contains invalid character(s)"
 msgstr "\"%s\" indeholder ulovlige tegn"
 
-#: ../src/common/valtext.cpp:254
-#, c-format
-msgid "'%s' doesn't consist only of valid characters"
-msgstr "\"%s\" består ikke kun af lovlige tegn"
-
-#: ../src/common/config.cpp:519 ../src/msw/regconf.cpp:258
+#: ../src/common/config.cpp:515 ../src/msw/regconf.cpp:255
 #, c-format
 msgid "'%s' has extra '..', ignored."
 msgstr "\"%s\" har ekstra \"..\", ignoreret."
 
-#: ../src/common/cmdline.cpp:1113 ../src/common/cmdline.cpp:1131
+#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "\"%s\" er ikke en korrekt numerisk værdi til tilvalget \"%s\"."
 
-#: ../src/common/translation.cpp:1100
+#: ../src/common/translation.cpp:1142
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "\"%s\" er ikke et gyldigt meddelelseskatalog."
 
-#: ../src/common/valtext.cpp:165
+#: ../src/common/valtext.cpp:188
 #, c-format
 msgid "'%s' is not one of the valid strings"
 msgstr "\"%s\" er ikke en af de gyldige strenge"
 
-#: ../src/common/valtext.cpp:167
+#: ../src/common/valtext.cpp:186
 #, c-format
 msgid "'%s' is one of the invalid strings"
 msgstr "\"%s\" er en af de ugyldige strenge"
 
-#: ../src/common/textbuf.cpp:237
+#: ../src/common/textbuf.cpp:233
 #, c-format
 msgid "'%s' is probably a binary buffer."
 msgstr "\"%s\" er sandsynligvis en binær buffer."
-
-#: ../src/common/valtext.cpp:252
-#, c-format
-msgid "'%s' should be numeric."
-msgstr "\"%s\" skal være numerisk."
-
-#: ../src/common/valtext.cpp:244
-#, c-format
-msgid "'%s' should only contain ASCII characters."
-msgstr "\"%s\" må kun indeholde ASCII-tegn."
-
-#: ../src/common/valtext.cpp:246
-#, c-format
-msgid "'%s' should only contain alphabetic characters."
-msgstr "\"%s\" må kun indeholde bogstaver."
-
-#: ../src/common/valtext.cpp:248
-#, c-format
-msgid "'%s' should only contain alphabetic or numeric characters."
-msgstr "\"%s\" må kun indeholde bogstaver eller tal."
-
-#: ../src/common/valtext.cpp:250
-#, c-format
-msgid "'%s' should only contain digits."
-msgstr "\"%s\" må kun indeholde tal."
 
 #: ../src/richtext/richtextliststylepage.cpp:229
 #: ../src/richtext/richtextbulletspage.cpp:166
 msgid "(*)"
 msgstr "(*)"
 
-#: ../src/html/helpwnd.cpp:963
+#: ../src/html/helpwnd.cpp:961
 msgid "(Help)"
 msgstr "(hjælp)"
 
@@ -863,27 +857,32 @@ msgstr "(hjælp)"
 msgid "(None)"
 msgstr "(ingen)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:504
+#: ../src/richtext/richtextsymboldlg.cpp:503
 msgid "(Normal text)"
 msgstr "(normal tekst)"
 
-#: ../src/html/helpwnd.cpp:419 ../src/html/helpwnd.cpp:1106
-#: ../src/html/helpwnd.cpp:1742
+#: ../src/html/helpwnd.cpp:417 ../src/html/helpwnd.cpp:1104
+#: ../src/html/helpwnd.cpp:1740
 msgid "(bookmarks)"
 msgstr "(bogmærker)"
 
+#: ../src/msw/dlmsw.cpp:167
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (fejl %ld: %s)"
+
+#: ../src/richtext/richtextformatdlg.cpp:876
+#: ../src/richtext/richtextliststylepage.cpp:448
+#: ../src/richtext/richtextliststylepage.cpp:460
+#: ../src/richtext/richtextliststylepage.cpp:461
 #: ../src/richtext/richtextindentspage.cpp:274
 #: ../src/richtext/richtextindentspage.cpp:286
 #: ../src/richtext/richtextindentspage.cpp:287
 #: ../src/richtext/richtextindentspage.cpp:311
 #: ../src/richtext/richtextindentspage.cpp:326
-#: ../src/richtext/richtextformatdlg.cpp:884
 #: ../src/richtext/richtextfontpage.cpp:349
 #: ../src/richtext/richtextfontpage.cpp:353
 #: ../src/richtext/richtextfontpage.cpp:357
-#: ../src/richtext/richtextliststylepage.cpp:448
-#: ../src/richtext/richtextliststylepage.cpp:460
-#: ../src/richtext/richtextliststylepage.cpp:461
 msgid "(none)"
 msgstr "(ingen)"
 
@@ -902,7 +901,7 @@ msgstr "*)"
 msgid "+"
 msgstr "+"
 
-#: ../src/msw/utils.cpp:1152
+#: ../src/msw/utils.cpp:1143
 msgid ", 64-bit edition"
 msgstr ", 64-bit-udgave"
 
@@ -911,163 +910,163 @@ msgstr ", 64-bit-udgave"
 msgid "-"
 msgstr "-"
 
-#: ../src/generic/filepickerg.cpp:66
+#: ../src/generic/filepickerg.cpp:63
 msgid "..."
 msgstr "..."
 
-#: ../src/richtext/richtextindentspage.cpp:276
 #: ../src/richtext/richtextliststylepage.cpp:450
+#: ../src/richtext/richtextindentspage.cpp:276
 msgid "1.1"
 msgstr "1.1"
 
-#: ../src/richtext/richtextindentspage.cpp:277
 #: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextindentspage.cpp:277
 msgid "1.2"
 msgstr "1.2"
 
-#: ../src/richtext/richtextindentspage.cpp:278
 #: ../src/richtext/richtextliststylepage.cpp:452
+#: ../src/richtext/richtextindentspage.cpp:278
 msgid "1.3"
 msgstr "1.3"
 
-#: ../src/richtext/richtextindentspage.cpp:279
 #: ../src/richtext/richtextliststylepage.cpp:453
+#: ../src/richtext/richtextindentspage.cpp:279
 msgid "1.4"
 msgstr "1.4"
 
-#: ../src/richtext/richtextindentspage.cpp:280
 #: ../src/richtext/richtextliststylepage.cpp:454
+#: ../src/richtext/richtextindentspage.cpp:280
 msgid "1.5"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:281
 #: ../src/richtext/richtextliststylepage.cpp:455
+#: ../src/richtext/richtextindentspage.cpp:281
 msgid "1.6"
 msgstr "1.6"
 
-#: ../src/richtext/richtextindentspage.cpp:282
 #: ../src/richtext/richtextliststylepage.cpp:456
+#: ../src/richtext/richtextindentspage.cpp:282
 msgid "1.7"
 msgstr "1.7"
 
-#: ../src/richtext/richtextindentspage.cpp:283
 #: ../src/richtext/richtextliststylepage.cpp:457
+#: ../src/richtext/richtextindentspage.cpp:283
 msgid "1.8"
 msgstr "1.8"
 
-#: ../src/richtext/richtextindentspage.cpp:284
 #: ../src/richtext/richtextliststylepage.cpp:458
+#: ../src/richtext/richtextindentspage.cpp:284
 msgid "1.9"
 msgstr "1.9"
 
-#: ../src/common/paper.cpp:140
+#: ../src/common/paper.cpp:137
 msgid "10 x 11 in"
 msgstr "10 x 11 tommer"
 
-#: ../src/common/paper.cpp:113
+#: ../src/common/paper.cpp:110
 msgid "10 x 14 in"
 msgstr "10 x 14 tommer"
 
-#: ../src/common/paper.cpp:114
+#: ../src/common/paper.cpp:111
 msgid "11 x 17 in"
 msgstr "11 x 17 tommer"
 
-#: ../src/common/paper.cpp:184
+#: ../src/common/paper.cpp:181
 msgid "12 x 11 in"
 msgstr "12 x 11 tommer"
 
-#: ../src/common/paper.cpp:141
+#: ../src/common/paper.cpp:138
 msgid "15 x 11 in"
 msgstr "15 x 11 tommer"
 
-#: ../src/richtext/richtextindentspage.cpp:285
 #: ../src/richtext/richtextliststylepage.cpp:459
+#: ../src/richtext/richtextindentspage.cpp:285
 msgid "2"
 msgstr "2"
 
-#: ../src/common/paper.cpp:132
+#: ../src/common/paper.cpp:129
 msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
 msgstr "6 3/4 konvolut, 3 5/8 x 6 1/2 tommer"
 
-#: ../src/common/paper.cpp:139
+#: ../src/common/paper.cpp:136
 msgid "9 x 11 in"
 msgstr "9 x 11 tommer"
 
-#: ../src/html/htmprint.cpp:431
+#: ../src/html/htmprint.cpp:443
 msgid ": file does not exist!"
 msgstr ": filen findes ikke!"
 
-#: ../src/common/fontmap.cpp:199
+#: ../src/common/fontmap.cpp:196
 msgid ": unknown charset"
 msgstr ": ukendt tegnsæt"
 
-#: ../src/common/fontmap.cpp:413
+#: ../src/common/fontmap.cpp:410
 msgid ": unknown encoding"
 msgstr ": ukendt kodning"
 
-#: ../src/generic/wizard.cpp:443
+#: ../src/generic/wizard.cpp:438
 msgid "< &Back"
 msgstr "< &Tilbage"
 
-#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:628
-#: ../src/osx/carbon/fontdlg.cpp:648
+#: ../src/osx/carbon/fontdlg.cpp:419 ../src/osx/carbon/fontdlg.cpp:625
+#: ../src/osx/carbon/fontdlg.cpp:645
 msgid "<Any Decorative>"
 msgstr "<Dekorativ>"
 
-#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:630
-#: ../src/osx/carbon/fontdlg.cpp:650
+#: ../src/osx/carbon/fontdlg.cpp:420 ../src/osx/carbon/fontdlg.cpp:627
+#: ../src/osx/carbon/fontdlg.cpp:647
 msgid "<Any Modern>"
 msgstr "<Moderne>"
 
-#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:626
-#: ../src/osx/carbon/fontdlg.cpp:646
+#: ../src/osx/carbon/fontdlg.cpp:418 ../src/osx/carbon/fontdlg.cpp:623
+#: ../src/osx/carbon/fontdlg.cpp:643
 msgid "<Any Roman>"
 msgstr "<Roman>"
 
-#: ../src/osx/carbon/fontdlg.cpp:424 ../src/osx/carbon/fontdlg.cpp:632
-#: ../src/osx/carbon/fontdlg.cpp:652
+#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:629
+#: ../src/osx/carbon/fontdlg.cpp:649
 msgid "<Any Script>"
 msgstr "<Script>"
 
-#: ../src/osx/carbon/fontdlg.cpp:425 ../src/osx/carbon/fontdlg.cpp:637
-#: ../src/osx/carbon/fontdlg.cpp:656
+#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:634
+#: ../src/osx/carbon/fontdlg.cpp:653
 msgid "<Any Swiss>"
 msgstr "<Swiss>"
 
-#: ../src/osx/carbon/fontdlg.cpp:426 ../src/osx/carbon/fontdlg.cpp:634
-#: ../src/osx/carbon/fontdlg.cpp:654
+#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:631
+#: ../src/osx/carbon/fontdlg.cpp:651
 msgid "<Any Teletype>"
 msgstr "<Teletype>"
 
-#: ../src/osx/carbon/fontdlg.cpp:420
+#: ../src/osx/carbon/fontdlg.cpp:417
 msgid "<Any>"
 msgstr "<Hvilken som helst>"
 
-#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
 msgid "<DIR>"
 msgstr "<DIR>"
 
-#: ../src/generic/filectrlg.cpp:254 ../src/generic/filectrlg.cpp:277
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
 msgid "<DRIVE>"
 msgstr "<DREV>"
 
-#: ../src/generic/filectrlg.cpp:252 ../src/generic/filectrlg.cpp:275
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
 msgid "<LINK>"
 msgstr "<LINK>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1264
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Fed kursiv skrift.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1270
+#: ../src/html/helpwnd.cpp:1268
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>fed kursiv <u>understreget</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1265
+#: ../src/html/helpwnd.cpp:1263
 msgid "<b>Bold face.</b> "
 msgstr "<b>Fed skrift.</b> "
 
-#: ../src/html/helpwnd.cpp:1264
+#: ../src/html/helpwnd.cpp:1262
 msgid "<i>Italic face.</i> "
 msgstr "<i>Kursiv skrift.</i> "
 
@@ -1076,15 +1075,15 @@ msgstr "<i>Kursiv skrift.</i> "
 msgid ">"
 msgstr ">"
 
-#: ../src/generic/dbgrptg.cpp:318
+#: ../src/generic/dbgrptg.cpp:317
 msgid "A debug report has been generated in the directory\n"
 msgstr "En fejlfindingsrapport er blevet genereret i mappen\n"
 
-#: ../src/common/debugrpt.cpp:573
+#: ../src/common/debugrpt.cpp:574
 msgid "A debug report has been generated. It can be found in"
 msgstr "En fejlfindingsrapport er blevet oprettet. Den kan findes i"
 
-#: ../src/common/xtixml.cpp:418
+#: ../src/common/xtixml.cpp:414
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "En samling som ikke er tom skal bestå af \"element\"-knuder"
 
@@ -1095,106 +1094,106 @@ msgstr "En samling som ikke er tom skal bestå af \"element\"-knuder"
 msgid "A standard bullet name."
 msgstr "Et standard punktnavn."
 
-#: ../src/common/paper.cpp:217
+#: ../src/common/paper.cpp:214
 msgid "A0 sheet, 841 x 1189 mm"
 msgstr "A0-ark, 841 x 1189 mm"
 
-#: ../src/common/paper.cpp:218
+#: ../src/common/paper.cpp:215
 msgid "A1 sheet, 594 x 841 mm"
 msgstr "A1-ark, 594 x 841 mm"
 
-#: ../src/common/paper.cpp:159
+#: ../src/common/paper.cpp:156
 msgid "A2 420 x 594 mm"
 msgstr "A2 420 x 594 mm"
 
-#: ../src/common/paper.cpp:156
+#: ../src/common/paper.cpp:153
 msgid "A3 Extra 322 x 445 mm"
 msgstr "A3 ekstra 322 x 445 mm"
 
-#: ../src/common/paper.cpp:161
+#: ../src/common/paper.cpp:158
 msgid "A3 Extra Transverse 322 x 445 mm"
 msgstr "A3 ekstra transverse 322 x 445 mm"
 
-#: ../src/common/paper.cpp:170
+#: ../src/common/paper.cpp:167
 msgid "A3 Rotated 420 x 297 mm"
 msgstr "A3 roteret 420 x 297 mm"
 
-#: ../src/common/paper.cpp:160
+#: ../src/common/paper.cpp:157
 msgid "A3 Transverse 297 x 420 mm"
 msgstr "A3 transverse 297 x 420 mm"
 
-#: ../src/common/paper.cpp:106
+#: ../src/common/paper.cpp:103
 msgid "A3 sheet, 297 x 420 mm"
 msgstr "A3-ark 297 x 420 mm"
 
-#: ../src/common/paper.cpp:146
+#: ../src/common/paper.cpp:143
 msgid "A4 Extra 9.27 x 12.69 in"
 msgstr "A4 ekstra 9.27 x 12.69 tommer"
 
-#: ../src/common/paper.cpp:153
+#: ../src/common/paper.cpp:150
 msgid "A4 Plus 210 x 330 mm"
 msgstr "A4 plus 210 x 330 mm"
 
-#: ../src/common/paper.cpp:171
+#: ../src/common/paper.cpp:168
 msgid "A4 Rotated 297 x 210 mm"
 msgstr "A4 roteret 297 x 210 mm"
 
-#: ../src/common/paper.cpp:148
+#: ../src/common/paper.cpp:145
 msgid "A4 Transverse 210 x 297 mm"
 msgstr "A4 transverse 210 x 297 mm"
 
-#: ../src/common/paper.cpp:97
+#: ../src/common/paper.cpp:94
 msgid "A4 sheet, 210 x 297 mm"
 msgstr "A4-ark, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:107
+#: ../src/common/paper.cpp:104
 msgid "A4 small sheet, 210 x 297 mm"
 msgstr "A4-ark (lille), 210 x 297 mm"
 
-#: ../src/common/paper.cpp:157
+#: ../src/common/paper.cpp:154
 msgid "A5 Extra 174 x 235 mm"
 msgstr "A5 ekstra 174 x 235 mm"
 
-#: ../src/common/paper.cpp:172
+#: ../src/common/paper.cpp:169
 msgid "A5 Rotated 210 x 148 mm"
 msgstr "A5 roteret 210 x 148 mm"
 
-#: ../src/common/paper.cpp:154
+#: ../src/common/paper.cpp:151
 msgid "A5 Transverse 148 x 210 mm"
 msgstr "A5 transverse 148 x 210 mm"
 
-#: ../src/common/paper.cpp:108
+#: ../src/common/paper.cpp:105
 msgid "A5 sheet, 148 x 210 mm"
 msgstr "A5-ark, 148 x 210 mm"
 
-#: ../src/common/paper.cpp:164
+#: ../src/common/paper.cpp:161
 msgid "A6 105 x 148 mm"
 msgstr "A6 105 x 148 mm"
 
-#: ../src/common/paper.cpp:177
+#: ../src/common/paper.cpp:174
 msgid "A6 Rotated 148 x 105 mm"
 msgstr "A6 roteret 148 x 105 mm"
 
-#: ../src/generic/fontdlgg.cpp:83 ../src/richtext/richtextformatdlg.cpp:529
-#: ../src/osx/carbon/fontdlg.cpp:153
+#: ../src/osx/carbon/fontdlg.cpp:150 ../src/generic/fontdlgg.cpp:79
+#: ../src/richtext/richtextformatdlg.cpp:521
 msgid "ABCDEFGabcdefg12345"
 msgstr "ABCDEFGabcdefg12345"
 
-#: ../src/richtext/richtextsymboldlg.cpp:458 ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
 msgid "ASCII"
 msgstr "ASCII"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "About"
 msgstr "Om"
 
-#: ../src/generic/aboutdlgg.cpp:140 ../src/osx/menu_osx.cpp:558
-#: ../src/msw/aboutdlg.cpp:64
+#: ../src/osx/menu_osx.cpp:450 ../src/generic/aboutdlgg.cpp:137
+#: ../src/msw/aboutdlg.cpp:61
 #, c-format
 msgid "About %s"
 msgstr "Om %s"
 
-#: ../src/osx/menu_osx.cpp:560
+#: ../src/osx/menu_osx.cpp:452
 msgid "About..."
 msgstr "Om..."
 
@@ -1203,37 +1202,37 @@ msgid "Absolute"
 msgstr "Absolut"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:873
+#: ../src/propgrid/advprops.cpp:774
 msgid "ActiveBorder"
 msgstr "Aktiv kant"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:874
+#: ../src/propgrid/advprops.cpp:775
 msgid "ActiveCaption"
 msgstr "Aktiv overskrift"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "Actual Size"
 msgstr "Faktisk størrelse"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:140 ../src/common/accelcmn.cpp:81
+#: ../src/common/stockitem.cpp:137 ../src/common/accelcmn.cpp:78
 msgid "Add"
 msgstr "Tilføj"
 
-#: ../src/richtext/richtextbuffer.cpp:11455
+#: ../src/richtext/richtextbuffer.cpp:11454
 msgid "Add Column"
 msgstr "Tilføj kolonne"
 
-#: ../src/richtext/richtextbuffer.cpp:11392
+#: ../src/richtext/richtextbuffer.cpp:11391
 msgid "Add Row"
 msgstr "Tilføj række"
 
-#: ../src/html/helpwnd.cpp:432
+#: ../src/html/helpwnd.cpp:430
 msgid "Add current page to bookmarks"
 msgstr "Tilføj denne side til bogmærker"
 
-#: ../src/generic/colrdlgg.cpp:366
+#: ../src/generic/colrdlgg.cpp:386
 msgid "Add to custom colours"
 msgstr "Tilføj til brugerfarver"
 
@@ -1245,12 +1244,12 @@ msgstr "AddToPropertyCollection kaldt på en generisk accessor"
 msgid "AddToPropertyCollection called w/o valid adder"
 msgstr "AddToPropertyCollection kaldt uden gyldig adder"
 
-#: ../src/html/helpctrl.cpp:159
+#: ../src/html/helpctrl.cpp:155
 #, c-format
 msgid "Adding book %s"
 msgstr "Tilføjer bog %s"
 
-#: ../src/common/preferencescmn.cpp:43
+#: ../src/common/preferencescmn.cpp:40
 msgid "Advanced"
 msgstr "Avanceret"
 
@@ -1258,11 +1257,11 @@ msgstr "Avanceret"
 msgid "After a paragraph:"
 msgstr "Efter et afsnit:"
 
-#: ../src/common/stockitem.cpp:172
+#: ../src/common/stockitem.cpp:169
 msgid "Align Left"
 msgstr "Venstrejuster"
 
-#: ../src/common/stockitem.cpp:173
+#: ../src/common/stockitem.cpp:170
 msgid "Align Right"
 msgstr "Højrejuster"
 
@@ -1270,40 +1269,40 @@ msgstr "Højrejuster"
 msgid "Alignment"
 msgstr "Justering"
 
-#: ../src/generic/prntdlgg.cpp:215
+#: ../src/generic/prntdlgg.cpp:208
 msgid "All"
 msgstr "Alle"
 
-#: ../src/generic/filectrlg.cpp:1197 ../src/common/fldlgcmn.cpp:107
+#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1186
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Alle filer (%s)|%s"
 
-#: ../include/wx/defs.h:2886
+#: ../include/wx/defs.h:2582
 msgid "All files (*)|*"
 msgstr "Alle filer (*)|*"
 
-#: ../include/wx/defs.h:2883
+#: ../include/wx/defs.h:2579
 msgid "All files (*.*)|*.*"
 msgstr "Alle filer (*.*)|*.*"
 
-#: ../src/richtext/richtextstyles.cpp:1061
+#: ../src/richtext/richtextstyles.cpp:1058
 msgid "All styles"
 msgstr "Alle typografier"
 
-#: ../src/propgrid/manager.cpp:1528
+#: ../src/propgrid/manager.cpp:1544
 msgid "Alphabetic Mode"
 msgstr "Alfabetisk mode"
 
-#: ../src/common/xtistrm.cpp:425
+#: ../src/common/xtistrm.cpp:422
 msgid "Already Registered Object passed to SetObjectClassInfo"
 msgstr "Allerede registreret objekt sendt til SetObjectClassInfo"
 
-#: ../src/unix/dialup.cpp:353
+#: ../src/unix/dialup.cpp:352
 msgid "Already dialling ISP."
 msgstr "Ringer allerede til ISP."
 
-#: ../src/common/accelcmn.cpp:331 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/accelcmn.cpp:345 ../src/univ/themes/win32.cpp:3753
 msgid "Alt+"
 msgstr "Alt+"
 
@@ -1312,34 +1311,34 @@ msgstr "Alt+"
 msgid "An optional corner radius for adding rounded corners."
 msgstr "Eventuel hjørneradius til tilføjelse af afrundede hjørner."
 
-#: ../src/common/debugrpt.cpp:576
+#: ../src/common/debugrpt.cpp:577
 msgid "And includes the following files:\n"
 msgstr "Og inkluderer de følgende filer:\n"
 
-#: ../src/generic/animateg.cpp:162
+#: ../src/generic/animateg.cpp:145
 #, c-format
 msgid "Animation file is not of type %ld."
 msgstr "Animationsfilen er ikke af typen %ld."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:872
+#: ../src/propgrid/advprops.cpp:773
 msgid "AppWorkspace"
 msgstr "Program arbejdsområde"
 
-#: ../src/generic/logg.cpp:1014
+#: ../src/generic/logg.cpp:1011
 #, c-format
 msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
 msgstr "Tilføj log til filen \"%s\" (valg af [Nej] vil overskrive den)?"
 
-#: ../src/osx/menu_osx.cpp:577 ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:469 ../src/osx/menu_osx.cpp:477
 msgid "Application"
 msgstr "Program"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "Apply"
 msgstr "Anvend"
 
-#: ../src/propgrid/advprops.cpp:1609
+#: ../src/propgrid/advprops.cpp:1515
 msgid "Aqua"
 msgstr "Akvamarin"
 
@@ -1348,29 +1347,29 @@ msgstr "Akvamarin"
 msgid "Arabic"
 msgstr "Arabisk"
 
-#: ../src/common/fmapbase.cpp:153
+#: ../src/common/fmapbase.cpp:150
 msgid "Arabic (ISO-8859-6)"
 msgstr "Arabisk (ISO-8859-6)"
 
-#: ../src/msw/ole/automtn.cpp:672
+#: ../src/msw/ole/automtn.cpp:663
 #, c-format
 msgid "Argument %u not found."
 msgstr "Argument %u ikke fundet."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1753
+#: ../src/propgrid/advprops.cpp:1654
 msgid "Arrow"
 msgstr "Pil"
 
-#: ../src/generic/aboutdlgg.cpp:184
+#: ../src/generic/aboutdlgg.cpp:181
 msgid "Artists"
 msgstr "Kunstnere"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "Ascending"
 msgstr "Stigende"
 
-#: ../src/generic/filectrlg.cpp:433
+#: ../src/generic/filectrlg.cpp:429
 msgid "Attributes"
 msgstr "Attributter"
 
@@ -1380,90 +1379,90 @@ msgstr "Attributter"
 msgid "Available fonts."
 msgstr "Tilgængelige skrifttyper."
 
-#: ../src/common/paper.cpp:137
+#: ../src/common/paper.cpp:134
 msgid "B4 (ISO) 250 x 353 mm"
 msgstr "B4 (ISO) 250 x 353 mm"
 
-#: ../src/common/paper.cpp:173
+#: ../src/common/paper.cpp:170
 msgid "B4 (JIS) Rotated 364 x 257 mm"
 msgstr "B4 (JIS) roteret 364 x 257 mm"
 
-#: ../src/common/paper.cpp:127
+#: ../src/common/paper.cpp:124
 msgid "B4 Envelope, 250 x 353 mm"
 msgstr "B4-konvolut, 250 x 353 mm"
 
-#: ../src/common/paper.cpp:109
+#: ../src/common/paper.cpp:106
 msgid "B4 sheet, 250 x 354 mm"
 msgstr "B4-ark, 250 x 354 mm"
 
-#: ../src/common/paper.cpp:158
+#: ../src/common/paper.cpp:155
 msgid "B5 (ISO) Extra 201 x 276 mm"
 msgstr "B5 (ISO) ekstra 201 x 276 mm"
 
-#: ../src/common/paper.cpp:174
+#: ../src/common/paper.cpp:171
 msgid "B5 (JIS) Rotated 257 x 182 mm"
 msgstr "B5 (JIS) roteret 257 x 182 mm"
 
-#: ../src/common/paper.cpp:155
+#: ../src/common/paper.cpp:152
 msgid "B5 (JIS) Transverse 182 x 257 mm"
 msgstr "B5 (JIS) transverse 182 x 257 mm"
 
-#: ../src/common/paper.cpp:128
+#: ../src/common/paper.cpp:125
 msgid "B5 Envelope, 176 x 250 mm"
 msgstr "B5-konvolut 176 x 250 mm"
 
-#: ../src/common/paper.cpp:110
+#: ../src/common/paper.cpp:107
 msgid "B5 sheet, 182 x 257 millimeter"
 msgstr "B5-ark, 182 x 257 millimeter"
 
-#: ../src/common/paper.cpp:182
+#: ../src/common/paper.cpp:179
 msgid "B6 (JIS) 128 x 182 mm"
 msgstr "B6 (JIS) 128 x 182 mm"
 
-#: ../src/common/paper.cpp:183
+#: ../src/common/paper.cpp:180
 msgid "B6 (JIS) Rotated 182 x 128 mm"
 msgstr "B6 (JIS) roteret 182 x 128 mm"
 
-#: ../src/common/paper.cpp:129
+#: ../src/common/paper.cpp:126
 msgid "B6 Envelope, 176 x 125 mm"
 msgstr "B6-konvolut, 176 x 125 mm"
 
-#: ../src/common/imagbmp.cpp:531 ../src/common/imagbmp.cpp:561
-#: ../src/common/imagbmp.cpp:576
+#: ../src/common/imagbmp.cpp:528 ../src/common/imagbmp.cpp:558
+#: ../src/common/imagbmp.cpp:573
 msgid "BMP: Couldn't allocate memory."
 msgstr "BMP: kunne ikke tildele hukommelse."
 
-#: ../src/common/imagbmp.cpp:100
+#: ../src/common/imagbmp.cpp:97
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: kunne ikke gemme ugyldigt billede."
 
-#: ../src/common/imagbmp.cpp:356
+#: ../src/common/imagbmp.cpp:353
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: kunne ikke skrive RGB-farvekort."
 
-#: ../src/common/imagbmp.cpp:490
+#: ../src/common/imagbmp.cpp:487
 msgid "BMP: Couldn't write data."
 msgstr "BMP: kunne ikke skrive data."
 
-#: ../src/common/imagbmp.cpp:246
+#: ../src/common/imagbmp.cpp:243
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: kunne ikke skrive filheaderen (Bitmap)."
 
-#: ../src/common/imagbmp.cpp:269
+#: ../src/common/imagbmp.cpp:266
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: kunne ikke skrive filheaderen (BitmapInfo)."
 
-#: ../src/common/imagbmp.cpp:140
+#: ../src/common/imagbmp.cpp:137
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage har ikke sin egen wxPalette."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:142 ../src/common/accelcmn.cpp:52
+#: ../src/common/stockitem.cpp:139 ../src/common/accelcmn.cpp:49
 msgid "Back"
 msgstr "Tilbage"
 
+#: ../src/richtext/richtextformatdlg.cpp:377
 #: ../src/richtext/richtextbackgroundpage.cpp:148
-#: ../src/richtext/richtextformatdlg.cpp:384
 msgid "Background"
 msgstr "Baggrund"
 
@@ -1471,20 +1470,20 @@ msgstr "Baggrund"
 msgid "Background &colour:"
 msgstr "Baggrunds&farve:"
 
-#: ../src/osx/carbon/fontdlg.cpp:220
+#: ../src/osx/carbon/fontdlg.cpp:217
 msgid "Background colour"
 msgstr "Baggrundsfarve"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:52
+#: ../src/common/accelcmn.cpp:49
 msgid "Backspace"
 msgstr "Backspace"
 
-#: ../src/common/fmapbase.cpp:160
+#: ../src/common/fmapbase.cpp:157
 msgid "Baltic (ISO-8859-13)"
 msgstr "Baltisk (ISO-8859-13)"
 
-#: ../src/common/fmapbase.cpp:151
+#: ../src/common/fmapbase.cpp:148
 msgid "Baltic (old) (ISO-8859-4)"
 msgstr "Baltisk (gammel) (ISO-8859-4)"
 
@@ -1497,25 +1496,25 @@ msgstr "Før et afsnit:"
 msgid "Bitmap"
 msgstr "Bitmap"
 
-#: ../src/propgrid/advprops.cpp:1594
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Black"
 msgstr "Sort"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1755
+#: ../src/propgrid/advprops.cpp:1656
 msgid "Blank"
 msgstr "Tom"
 
-#: ../src/propgrid/advprops.cpp:1603
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Blue"
 msgstr "Blå"
 
-#: ../src/generic/colrdlgg.cpp:345
+#: ../src/generic/colrdlgg.cpp:365
 msgid "Blue:"
 msgstr "Blå:"
 
-#: ../src/generic/fontdlgg.cpp:333 ../src/richtext/richtextfontpage.cpp:355
-#: ../src/osx/carbon/fontdlg.cpp:354 ../src/common/stockitem.cpp:143
+#: ../src/osx/carbon/fontdlg.cpp:351 ../src/common/stockitem.cpp:140
+#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:355
 msgid "Bold"
 msgstr "Fed"
 
@@ -1524,31 +1523,35 @@ msgstr "Fed"
 msgid "Border"
 msgstr "Kant"
 
-#: ../src/richtext/richtextformatdlg.cpp:379
+#: ../src/richtext/richtextformatdlg.cpp:372
 msgid "Borders"
 msgstr "Kanter"
 
-#: ../src/richtext/richtextsizepage.cpp:288 ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141 ../src/richtext/richtextsizepage.cpp:288
 msgid "Bottom"
 msgstr "Bund"
 
-#: ../src/generic/prntdlgg.cpp:893
+#: ../src/generic/prntdlgg.cpp:886
 msgid "Bottom margin (mm):"
 msgstr "Bundmargen (mm):"
 
-#: ../src/richtext/richtextbuffer.cpp:9383
+#: ../src/richtext/richtextbuffer.cpp:9380
 msgid "Box Properties"
 msgstr "Boks-egenskaber"
 
-#: ../src/richtext/richtextstyles.cpp:1065
+#: ../src/richtext/richtextstyles.cpp:1062
 msgid "Box styles"
 msgstr "Bokstypografier"
 
-#: ../src/propgrid/advprops.cpp:1602
+#: ../src/osx/cocoa/menu.mm:292
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Brown"
 msgstr "Brun"
 
-#: ../src/common/filepickercmn.cpp:43 ../src/common/filepickercmn.cpp:44
+#: ../src/common/filepickercmn.cpp:40 ../src/common/filepickercmn.cpp:41
 msgid "Browse"
 msgstr "Gennemse"
 
@@ -1561,72 +1564,72 @@ msgstr "&Justering af punkttegn:"
 msgid "Bullet style"
 msgstr "Punkttegnstypografi"
 
-#: ../src/richtext/richtextformatdlg.cpp:359
+#: ../src/richtext/richtextformatdlg.cpp:352
 msgid "Bullets"
 msgstr "Punkttegn"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1756
+#: ../src/propgrid/advprops.cpp:1657
 msgid "Bullseye"
 msgstr "Bullseye"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:875
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonFace"
 msgstr "Knap ansigt"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:876
+#: ../src/propgrid/advprops.cpp:777
 msgid "ButtonHighlight"
 msgstr "Knap fremhævning"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:877
+#: ../src/propgrid/advprops.cpp:778
 msgid "ButtonShadow"
 msgstr "Knap skygge"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:878
+#: ../src/propgrid/advprops.cpp:779
 msgid "ButtonText"
 msgstr "Knap tekst"
 
-#: ../src/common/paper.cpp:98
+#: ../src/common/paper.cpp:95
 msgid "C sheet, 17 x 22 in"
 msgstr "C-ark, 17 x 22 tommer"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "C&lear"
 msgstr "&Rens"
 
-#: ../src/generic/fontdlgg.cpp:406
+#: ../src/generic/fontdlgg.cpp:403
 msgid "C&olour:"
 msgstr "F&arve:"
 
-#: ../src/common/paper.cpp:123
+#: ../src/common/paper.cpp:120
 msgid "C3 Envelope, 324 x 458 mm"
 msgstr "C3-konvolut, 324 x 458 mm"
 
-#: ../src/common/paper.cpp:124
+#: ../src/common/paper.cpp:121
 msgid "C4 Envelope, 229 x 324 mm"
 msgstr "C4-konvolut, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:122
+#: ../src/common/paper.cpp:119
 msgid "C5 Envelope, 162 x 229 mm"
 msgstr "C5-konvolut, 162 x 229 mm"
 
-#: ../src/common/paper.cpp:125
+#: ../src/common/paper.cpp:122
 msgid "C6 Envelope, 114 x 162 mm"
 msgstr "C6-konvolut, 114 x 162 mm"
 
-#: ../src/common/paper.cpp:126
+#: ../src/common/paper.cpp:123
 msgid "C65 Envelope, 114 x 229 mm"
 msgstr "C65-konvolut, 114 x 229 mm"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "CD-Rom"
 msgstr "CD-Rom"
 
-#: ../src/html/chm.cpp:815 ../src/html/chm.cpp:874
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:865
 msgid "CHM handler currently supports only local files!"
 msgstr "CHM-handler understøtter i øjeblikket kun lokale filer!"
 
@@ -1634,190 +1637,194 @@ msgstr "CHM-handler understøtter i øjeblikket kun lokale filer!"
 msgid "Ca&pitals"
 msgstr "St&ore bogstaver"
 
-#: ../src/common/cmdproc.cpp:267
+#: ../src/common/cmdproc.cpp:260
 msgid "Can't &Undo "
 msgstr "Kan ikke &fortryde "
 
-#: ../src/common/image.cpp:2824
+#: ../src/common/image.cpp:2924
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr "Kan ikke automatisk bestemme billedformat for ikke-søgbart input."
 
-#: ../src/msw/registry.cpp:506
+#: ../src/msw/registry.cpp:495
 #, c-format
 msgid "Can't close registry key '%s'"
 msgstr "Kan ikke lukke registreringsnøglen \"%s\""
 
-#: ../src/msw/registry.cpp:584
+#: ../src/msw/registry.cpp:573
 #, c-format
 msgid "Can't copy values of unsupported type %d."
 msgstr "Kan ikke kopiere værdier af ikke-understøttet type %d."
 
-#: ../src/msw/registry.cpp:487
+#: ../src/msw/registry.cpp:476
 #, c-format
 msgid "Can't create registry key '%s'"
 msgstr "Kan ikke oprette registreringsnøglen \"%s\""
 
-#: ../src/msw/thread.cpp:665
+#: ../src/msw/thread.cpp:657
 msgid "Can't create thread"
 msgstr "Kan ikke oprette tråd"
 
-#: ../src/msw/window.cpp:3691
-#, c-format
-msgid "Can't create window of class %s"
-msgstr "Kan ikke oprette vindue af klassen %s"
-
-#: ../src/msw/registry.cpp:777
+#: ../src/msw/registry.cpp:765
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Kan ikke slette nøglen \"%s\""
 
-#: ../src/msw/iniconf.cpp:458
+#: ../src/msw/iniconf.cpp:455
 #, c-format
 msgid "Can't delete the INI file '%s'"
 msgstr "Kan ikke slette INI-filen \"%s\""
 
-#: ../src/msw/registry.cpp:805
+#: ../src/msw/registry.cpp:793
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Kan ikke slette værdi \"%s\" fra nøglen \"%s\""
 
-#: ../src/msw/registry.cpp:1171
+#: ../src/msw/registry.cpp:1159
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Kan ikke få liste af undernøgler til nøglen \"%s\""
 
-#: ../src/msw/registry.cpp:1132
+#: ../src/msw/registry.cpp:1120
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Kan ikke få en liste af værdierne fra nøglen \"%s\""
 
-#: ../src/msw/registry.cpp:1389
+#: ../src/msw/registry.cpp:1377
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Kan ikke eksportere værdi af ikke-understøttet type %d."
 
-#: ../src/common/ffile.cpp:254
+#: ../src/common/ffile.cpp:253
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Kan ikke finde aktuel position i filen \"%s\""
 
-#: ../src/msw/registry.cpp:418
+#: ../src/msw/registry.cpp:407
 #, c-format
 msgid "Can't get info about registry key '%s'"
 msgstr "Kan ikke få information om registreringsnøglen \"%s\""
 
-#: ../src/common/zstream.cpp:346
+#: ../src/msw/webview_ie.cpp:1024
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "Kan ikke sætte trådprioritet"
+
+#: ../src/common/zstream.cpp:343
 msgid "Can't initialize zlib deflate stream."
 msgstr "Kan ikke initialisere zlib deflate strøm."
 
-#: ../src/common/zstream.cpp:185
+#: ../src/common/zstream.cpp:182
 msgid "Can't initialize zlib inflate stream."
 msgstr "Kan ikke initialisere zlib inflate strøm."
 
-#: ../src/msw/fswatcher.cpp:476
+#: ../src/msw/fswatcher.cpp:475
 #, c-format
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "Kan ikke overvåge den ikke-eksisterende mappe \"%s\" for ændringer."
 
-#: ../src/msw/registry.cpp:454
+#: ../src/msw/registry.cpp:443
 #, c-format
 msgid "Can't open registry key '%s'"
 msgstr "Kan ikke åbne registreringsnøglen \"%s\""
 
-#: ../src/common/zstream.cpp:252
+#: ../src/common/zstream.cpp:249
 #, c-format
 msgid "Can't read from inflate stream: %s"
 msgstr "Kan ikke læse fra inflate strøm: %s"
 
-#: ../src/common/zstream.cpp:244
+#: ../src/common/zstream.cpp:241
 msgid "Can't read inflate stream: unexpected EOF in underlying stream."
 msgstr "Kan ikke læse inflate strøm: uventet EOF i den underliggende strøm."
 
-#: ../src/msw/registry.cpp:1064
+#: ../src/msw/registry.cpp:1052
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Kan ikke læse værdien af \"%s\""
 
-#: ../src/msw/registry.cpp:878 ../src/msw/registry.cpp:910
-#: ../src/msw/registry.cpp:975
+#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
+#: ../src/msw/registry.cpp:963
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Kan ikke læse værdien af nøglen \"%s\""
 
-#: ../src/common/image.cpp:2620
+#: ../src/msw/webview_ie.cpp:1017
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/common/image.cpp:2715
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "Kan ikke gemme til filen \"%s\": ukendt filtype."
 
-#: ../src/generic/logg.cpp:573 ../src/generic/logg.cpp:976
+#: ../src/generic/logg.cpp:570 ../src/generic/logg.cpp:973
 msgid "Can't save log contents to file."
 msgstr "Kan ikke gemme logdata til fil."
 
-#: ../src/msw/thread.cpp:629
+#: ../src/msw/thread.cpp:621
 msgid "Can't set thread priority"
 msgstr "Kan ikke sætte trådprioritet"
 
-#: ../src/msw/registry.cpp:896 ../src/msw/registry.cpp:938
-#: ../src/msw/registry.cpp:1081
+#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
+#: ../src/msw/registry.cpp:1069
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Kan ikke sætte værdien af \"%s\""
 
-#: ../src/unix/utilsunx.cpp:351
+#: ../src/unix/utilsunx.cpp:353
 msgid "Can't write to child process's stdin"
 msgstr "Kan ikke skrive til barneprocesens stdin"
 
-#: ../src/common/zstream.cpp:427
+#: ../src/common/zstream.cpp:424
 #, c-format
 msgid "Can't write to deflate stream: %s"
 msgstr "Kan ikke skrive til deflate strøm: %s"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:279 ../src/richtext/richtextstyledlg.cpp:300
-#: ../src/common/stockitem.cpp:145 ../src/common/accelcmn.cpp:71
-#: ../src/msw/msgdlg.cpp:454 ../src/msw/progdlg.cpp:673
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:142
+#: ../src/common/accelcmn.cpp:68 ../src/motif/msgdlg.cpp:196
+#: ../src/gtk1/fontdlg.cpp:144 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/progdlg.cpp:940 ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Annuller"
 
-#: ../src/common/filefn.cpp:1261
+#: ../src/common/filefn.cpp:1149
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Kan ikke læse fillisten i mappen \"%s\""
 
-#: ../src/msw/dir.cpp:263
+#: ../src/msw/dir.cpp:260
 #, c-format
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Kan ikke få liste af filer i mappen \"%s\""
 
-#: ../src/msw/dialup.cpp:523
+#: ../src/msw/dialup.cpp:517
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Kan ikke finde aktiv netværk via modem forbindelse: %s"
 
-#: ../src/msw/dialup.cpp:827
+#: ../src/msw/dialup.cpp:821
 msgid "Cannot find the location of address book file"
 msgstr "Kan ikke finde placering af adressebog filen"
 
-#: ../src/msw/ole/automtn.cpp:562
+#: ../src/msw/ole/automtn.cpp:553
 #, c-format
 msgid "Cannot get an active instance of \"%s\""
 msgstr "Kan ikke få fat i en aktiv instans af \"%s\""
 
-#: ../src/unix/threadpsx.cpp:1035
+#: ../src/unix/threadpsx.cpp:1053
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "Kan ikke få prioritetsområde for afviklingsalgoritme %d."
 
-#: ../src/unix/utilsunx.cpp:987
+#: ../src/unix/utilsunx.cpp:989
 msgid "Cannot get the hostname"
 msgstr "Kan ikke finde værtsnavn"
 
-#: ../src/unix/utilsunx.cpp:1023
+#: ../src/unix/utilsunx.cpp:1025
 msgid "Cannot get the official hostname"
 msgstr "Kan ikke finde det officielle værtsnavn"
 
-#: ../src/msw/dialup.cpp:928
+#: ../src/msw/dialup.cpp:922
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Kan ikke afbryde - ingen aktiv netværk via modem forbindelse."
 
@@ -1825,126 +1832,126 @@ msgstr "Kan ikke afbryde - ingen aktiv netværk via modem forbindelse."
 msgid "Cannot initialize OLE"
 msgstr "Kan ikke initialisere OLE"
 
-#: ../src/common/socket.cpp:853
+#: ../src/common/socket.cpp:850
 msgid "Cannot initialize sockets"
 msgstr "Kan ikke initialisere sockets"
 
-#: ../src/msw/volume.cpp:619
+#: ../src/msw/volume.cpp:627
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Kan ikke hente ikon fra \"%s\"."
 
-#: ../src/xrc/xmlres.cpp:360
+#: ../src/xrc/xmlres.cpp:358
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Kan ikke indlæse ressourcer fra \"%s\"."
 
-#: ../src/xrc/xmlres.cpp:742
+#: ../src/xrc/xmlres.cpp:740
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Kan ikke indlæse ressourcer fra filen \"%s\"."
 
-#: ../src/html/htmlfilt.cpp:137
+#: ../src/html/htmlfilt.cpp:134
 #, c-format
 msgid "Cannot open HTML document: %s"
 msgstr "Kan ikke åbne HTML-dokument %s"
 
-#: ../src/html/helpdata.cpp:667
+#: ../src/html/helpdata.cpp:660
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Kan ikke åbne HTML Hjælp-bog: %s"
 
-#: ../src/html/helpdata.cpp:299
+#: ../src/html/helpdata.cpp:296
 #, c-format
 msgid "Cannot open contents file: %s"
 msgstr "Kan ikke åbne indholdsfilen: %s"
 
-#: ../src/generic/dcpsg.cpp:1667
+#: ../src/generic/dcpsg.cpp:1665
 msgid "Cannot open file for PostScript printing!"
 msgstr "Kan ikke åbne fil til PostScript udskrivning!"
 
-#: ../src/html/helpdata.cpp:313
+#: ../src/html/helpdata.cpp:310
 #, c-format
 msgid "Cannot open index file: %s"
 msgstr "Kan ikke åbne indeksfilen %s"
 
-#: ../src/xrc/xmlres.cpp:724
+#: ../src/xrc/xmlres.cpp:722
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Kan ikke åbne ressourcefilen \"%s\"."
 
-#: ../src/html/helpwnd.cpp:1534
+#: ../src/html/helpwnd.cpp:1532
 msgid "Cannot print empty page."
 msgstr "Kan ikke udskrive tom side."
 
-#: ../src/msw/volume.cpp:507
+#: ../src/msw/volume.cpp:515
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Kan ikke læse typenavn fra \"%s\"!"
 
-#: ../src/msw/thread.cpp:888
+#: ../src/msw/thread.cpp:894
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Kan ikke genoptage tråd %lx"
 
-#: ../src/unix/threadpsx.cpp:1016
+#: ../src/unix/threadpsx.cpp:1028
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Kan ikke hente trådafviklingsalgoritme."
 
-#: ../src/common/intl.cpp:558
+#: ../src/common/intl.cpp:365
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "Kan ikke sætte lokale til sproget \"%s\"."
 
-#: ../src/unix/threadpsx.cpp:831 ../src/msw/thread.cpp:546
+#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
 msgid "Cannot start thread: error writing TLS."
 msgstr "Kan ikke starte tråd: fejl ved skrivning af TLS."
 
-#: ../src/msw/thread.cpp:872
+#: ../src/msw/thread.cpp:864
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Kan ikke suspendere tråd %lx"
 
-#: ../src/msw/thread.cpp:794
+#: ../src/msw/thread.cpp:786
 msgid "Cannot wait for thread termination"
 msgstr "Kan ikke vente på afslutning af tråd"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:75
+#: ../src/common/accelcmn.cpp:72
 msgid "Capital"
 msgstr "Stort"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:879
+#: ../src/propgrid/advprops.cpp:780
 msgid "CaptionText"
 msgstr "Overskrifttekst"
 
-#: ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:531
 msgid "Case sensitive"
 msgstr "Forskel på store og små bogstaver"
 
-#: ../src/propgrid/manager.cpp:1509
+#: ../src/propgrid/manager.cpp:1527
 msgid "Categorized Mode"
 msgstr "Kategoritilstand"
 
-#: ../src/richtext/richtextbuffer.cpp:9968
+#: ../src/richtext/richtextbuffer.cpp:9965
 msgid "Cell Properties"
 msgstr "Celleegenskaber"
 
-#: ../src/common/fmapbase.cpp:161
+#: ../src/common/fmapbase.cpp:158
 msgid "Celtic (ISO-8859-14)"
 msgstr "Keltisk (ISO-8859-14)"
 
-#: ../src/richtext/richtextindentspage.cpp:160
 #: ../src/richtext/richtextliststylepage.cpp:349
+#: ../src/richtext/richtextindentspage.cpp:160
 msgid "Cen&tred"
 msgstr "Cen&treret"
 
-#: ../src/common/stockitem.cpp:170
+#: ../src/common/stockitem.cpp:167
 msgid "Centered"
 msgstr "Centreret"
 
-#: ../src/common/fmapbase.cpp:149
+#: ../src/common/fmapbase.cpp:146
 msgid "Central European (ISO-8859-2)"
 msgstr "Centraleuropæisk (ISO-8859-2)"
 
@@ -1953,10 +1960,10 @@ msgstr "Centraleuropæisk (ISO-8859-2)"
 msgid "Centre"
 msgstr "Centrér"
 
-#: ../src/richtext/richtextindentspage.cpp:162
-#: ../src/richtext/richtextindentspage.cpp:164
 #: ../src/richtext/richtextliststylepage.cpp:351
 #: ../src/richtext/richtextliststylepage.cpp:353
+#: ../src/richtext/richtextindentspage.cpp:162
+#: ../src/richtext/richtextindentspage.cpp:164
 msgid "Centre text."
 msgstr "Centrér tekst."
 
@@ -1969,24 +1976,24 @@ msgstr "Centreret"
 msgid "Ch&oose..."
 msgstr "V&ælg..."
 
-#: ../src/richtext/richtextbuffer.cpp:4354
+#: ../src/richtext/richtextbuffer.cpp:4351
 msgid "Change List Style"
 msgstr "Skift listetypografi"
 
-#: ../src/richtext/richtextbuffer.cpp:3709
+#: ../src/richtext/richtextbuffer.cpp:3706
 msgid "Change Object Style"
 msgstr "Skift objekttypografi"
 
-#: ../src/richtext/richtextbuffer.cpp:3982
-#: ../src/richtext/richtextbuffer.cpp:8129
+#: ../src/richtext/richtextbuffer.cpp:3979
+#: ../src/richtext/richtextbuffer.cpp:8125
 msgid "Change Properties"
 msgstr "Rediger egenskaber"
 
-#: ../src/richtext/richtextbuffer.cpp:3526
+#: ../src/richtext/richtextbuffer.cpp:3523
 msgid "Change Style"
 msgstr "Skift typografi"
 
-#: ../src/common/fileconf.cpp:341
+#: ../src/common/fileconf.cpp:335
 #, c-format
 msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
 msgstr ""
@@ -1999,11 +2006,11 @@ msgid "Changing current directory to \"%s\" failed"
 msgstr "Kunne ikke ændre den aktuelle mappe til \"%s\""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1757
+#: ../src/propgrid/advprops.cpp:1658
 msgid "Character"
 msgstr "Tegn"
 
-#: ../src/richtext/richtextstyles.cpp:1063
+#: ../src/richtext/richtextstyles.cpp:1060
 msgid "Character styles"
 msgstr "Tegntypografier"
 
@@ -2040,20 +2047,20 @@ msgstr "Slå til for at sætte parentes om punkttegnet."
 msgid "Check to indicate right-to-left text layout."
 msgstr "Slå til for at indikere højre-til-venstre-tekstlayout."
 
-#: ../src/osx/carbon/fontdlg.cpp:356 ../src/osx/carbon/fontdlg.cpp:358
+#: ../src/osx/carbon/fontdlg.cpp:353 ../src/osx/carbon/fontdlg.cpp:355
 msgid "Check to make the font bold."
 msgstr "Slå til for at gøre teksten fed."
 
-#: ../src/osx/carbon/fontdlg.cpp:363 ../src/osx/carbon/fontdlg.cpp:365
+#: ../src/osx/carbon/fontdlg.cpp:360 ../src/osx/carbon/fontdlg.cpp:362
 msgid "Check to make the font italic."
 msgstr "Slå til for at gøre teksten kursiv."
 
-#: ../src/osx/carbon/fontdlg.cpp:372 ../src/osx/carbon/fontdlg.cpp:374
+#: ../src/osx/carbon/fontdlg.cpp:369 ../src/osx/carbon/fontdlg.cpp:371
 msgid "Check to make the font underlined."
 msgstr "Slå til for at gøre teksten understreget."
 
-#: ../src/richtext/richtextstyledlg.cpp:289
-#: ../src/richtext/richtextstyledlg.cpp:291
+#: ../src/richtext/richtextstyledlg.cpp:285
+#: ../src/richtext/richtextstyledlg.cpp:287
 msgid "Check to restart numbering."
 msgstr "Slå til for at genstarte nummerering."
 
@@ -2087,51 +2094,51 @@ msgstr "Slå til for at vise teksten som hævet skrift."
 msgid "Check to suppress hyphenation."
 msgstr "Slå til for at undertrykke orddeling."
 
-#: ../src/msw/dialup.cpp:763
+#: ../src/msw/dialup.cpp:757
 msgid "Choose ISP to dial"
 msgstr "Vælg ISP til opkald"
 
-#: ../src/propgrid/props.cpp:1922
+#: ../src/propgrid/props.cpp:1904
 msgid "Choose a directory:"
 msgstr "Vælg mappe:"
 
-#: ../src/propgrid/props.cpp:1975
+#: ../src/propgrid/props.cpp:2199
 msgid "Choose a file"
 msgstr "Vælg en fil"
 
-#: ../src/generic/colrdlgg.cpp:158 ../src/gtk/colordlg.cpp:54
+#: ../src/generic/colrdlgg.cpp:156 ../src/gtk/colordlg.cpp:49
 msgid "Choose colour"
 msgstr "Vælg farve"
 
-#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/gtk1/fontdlg.cpp:125 ../src/generic/fontpickerg.cpp:47
+#: ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Vælg skrifttype"
 
-#: ../src/common/module.cpp:74
+#: ../src/common/module.cpp:71
 #, c-format
 msgid "Circular dependency involving module \"%s\" detected."
 msgstr "Registrerede cirkulær afhængighed, som involverer modulet \"%s\"."
 
-#: ../src/aui/tabmdi.cpp:108 ../src/generic/mdig.cpp:97
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
 msgid "Cl&ose"
 msgstr "L&uk"
 
-#: ../src/msw/ole/automtn.cpp:684
+#: ../src/msw/ole/automtn.cpp:675
 msgid "Class not registered."
 msgstr "Klasse er ikke registreret."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:147 ../src/common/accelcmn.cpp:72
+#: ../src/common/stockitem.cpp:144 ../src/common/accelcmn.cpp:69
 msgid "Clear"
 msgstr "Rens"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "Clear the log contents"
 msgstr "Rens log indholdet"
 
-#: ../src/richtext/richtextstyledlg.cpp:252
-#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:248
+#: ../src/richtext/richtextstyledlg.cpp:250
 msgid "Click to apply the selected style."
 msgstr "Klik for at anvende den valgte typografi."
 
@@ -2142,15 +2149,15 @@ msgstr "Klik for at anvende den valgte typografi."
 msgid "Click to browse for a symbol."
 msgstr "Klik for at kigge efter et symbol."
 
-#: ../src/osx/carbon/fontdlg.cpp:403 ../src/osx/carbon/fontdlg.cpp:405
+#: ../src/osx/carbon/fontdlg.cpp:400 ../src/osx/carbon/fontdlg.cpp:402
 msgid "Click to cancel changes to the font."
 msgstr "Klik for at annullere ændringer af skrifttypen."
 
-#: ../src/generic/fontdlgg.cpp:472 ../src/generic/fontdlgg.cpp:491
+#: ../src/generic/fontdlgg.cpp:468 ../src/generic/fontdlgg.cpp:487
 msgid "Click to cancel the font selection."
 msgstr "Klik for at annullere valg af skrifttype."
 
-#: ../src/osx/carbon/fontdlg.cpp:384 ../src/osx/carbon/fontdlg.cpp:386
+#: ../src/osx/carbon/fontdlg.cpp:381 ../src/osx/carbon/fontdlg.cpp:383
 msgid "Click to change the font colour."
 msgstr "Klik for at ændre skriftfarven."
 
@@ -2169,37 +2176,37 @@ msgstr "Klik for at ændre tekstfarven."
 msgid "Click to choose the font for this level."
 msgstr "Klik for at vælge skrifttype for dette niveau."
 
-#: ../src/richtext/richtextstyledlg.cpp:279
-#: ../src/richtext/richtextstyledlg.cpp:281
+#: ../src/richtext/richtextstyledlg.cpp:275
+#: ../src/richtext/richtextstyledlg.cpp:277
 msgid "Click to close this window."
 msgstr "Klik for at lukke dette vindue."
 
-#: ../src/osx/carbon/fontdlg.cpp:410 ../src/osx/carbon/fontdlg.cpp:412
+#: ../src/osx/carbon/fontdlg.cpp:407 ../src/osx/carbon/fontdlg.cpp:409
 msgid "Click to confirm changes to the font."
 msgstr "Klik for at bekræfte ændringer af skrifttypen."
 
-#: ../src/generic/fontdlgg.cpp:477 ../src/generic/fontdlgg.cpp:479
-#: ../src/generic/fontdlgg.cpp:484 ../src/generic/fontdlgg.cpp:486
+#: ../src/generic/fontdlgg.cpp:473 ../src/generic/fontdlgg.cpp:475
+#: ../src/generic/fontdlgg.cpp:480 ../src/generic/fontdlgg.cpp:482
 msgid "Click to confirm the font selection."
 msgstr "Klik for at bekræfte valg af skrifttype."
 
-#: ../src/richtext/richtextstyledlg.cpp:244
-#: ../src/richtext/richtextstyledlg.cpp:246
+#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:242
 msgid "Click to create a new box style."
 msgstr "Klik for at oprette en ny bokstypografi."
 
-#: ../src/richtext/richtextstyledlg.cpp:226
-#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:224
 msgid "Click to create a new character style."
 msgstr "Klik for at oprette en ny tegntypografi."
 
-#: ../src/richtext/richtextstyledlg.cpp:238
-#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:236
 msgid "Click to create a new list style."
 msgstr "Klik for at oprette en ny listetypografi."
 
-#: ../src/richtext/richtextstyledlg.cpp:232
-#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:230
 msgid "Click to create a new paragraph style."
 msgstr "Klik for at oprette en ny afsnitstypografi."
 
@@ -2213,8 +2220,8 @@ msgstr "Klik for at oprette et ny tabulatorposition."
 msgid "Click to delete all tab positions."
 msgstr "Klik for at slette alle tabulatorpositioner."
 
-#: ../src/richtext/richtextstyledlg.cpp:270
-#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:268
 msgid "Click to delete the selected style."
 msgstr "Klik for at slette den valgte typografi."
 
@@ -2223,25 +2230,25 @@ msgstr "Klik for at slette den valgte typografi."
 msgid "Click to delete the selected tab position."
 msgstr "Klik for at slette det valgte tabulatorstop."
 
-#: ../src/richtext/richtextstyledlg.cpp:264
-#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:262
 msgid "Click to edit the selected style."
 msgstr "Klik for at redigere den valgte typografi."
 
-#: ../src/richtext/richtextstyledlg.cpp:258
-#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:256
 msgid "Click to rename the selected style."
 msgstr "Klik for at omdøbe den valgte typografi."
 
-#: ../src/generic/dbgrptg.cpp:97 ../src/generic/progdlgg.cpp:759
-#: ../src/richtext/richtextstyledlg.cpp:277
-#: ../src/richtext/richtextsymboldlg.cpp:476 ../src/common/stockitem.cpp:148
-#: ../src/msw/progdlg.cpp:170 ../src/msw/progdlg.cpp:679
-#: ../src/html/helpdlg.cpp:90
+#: ../src/common/stockitem.cpp:145 ../src/generic/dbgrptg.cpp:94
+#: ../src/generic/progdlgg.cpp:781 ../src/msw/progdlg.cpp:211
+#: ../src/msw/progdlg.cpp:946 ../src/html/helpdlg.cpp:87
+#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextstyledlg.cpp:273
 msgid "Close"
 msgstr "Luk"
 
-#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:98
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
 msgid "Close All"
 msgstr "Luk alle"
 
@@ -2249,43 +2256,43 @@ msgstr "Luk alle"
 msgid "Close current document"
 msgstr "Luk det aktuelle dokument"
 
-#: ../src/generic/logg.cpp:516
+#: ../src/generic/logg.cpp:513
 msgid "Close this window"
 msgstr "Luk dette vindue"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6006
+#: ../src/generic/datavgen.cpp:6811
 msgid "Collapse"
 msgstr "Fold sammen"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "Color"
 msgstr "Farve"
 
-#: ../src/richtext/richtextformatdlg.cpp:776
+#: ../src/richtext/richtextformatdlg.cpp:768
 msgid "Colour"
 msgstr "Farve"
 
-#: ../src/msw/colordlg.cpp:158
+#: ../src/msw/colordlg.cpp:227
 #, c-format
 msgid "Colour selection dialog failed with error %0lx."
 msgstr "Dialogen Valg af farver fejlede med fejlkode %0lx."
 
-#: ../src/osx/carbon/fontdlg.cpp:380
+#: ../src/osx/carbon/fontdlg.cpp:377
 msgid "Colour:"
 msgstr "Farve:"
 
-#: ../src/generic/datavgen.cpp:6077
+#: ../src/generic/datavgen.cpp:6882
 #, c-format
 msgid "Column %u"
 msgstr "Kolonne %u"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:114
+#: ../src/common/accelcmn.cpp:112
 msgid "Command"
 msgstr "Kommando"
 
-#: ../src/common/init.cpp:196
+#: ../src/common/init.cpp:193
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
@@ -2293,12 +2300,12 @@ msgid ""
 msgstr ""
 "Kommandolinjeparameter %d kunne ikke konverteres til Unicode og ignoreres."
 
-#: ../src/msw/fontdlg.cpp:120
+#: ../src/msw/fontdlg.cpp:170
 #, c-format
 msgid "Common dialog failed with error code %0lx."
 msgstr "Almindelig dialog fejlede med fejlkode %0lx."
 
-#: ../src/gtk/window.cpp:4649
+#: ../src/gtk/window.cpp:5653
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
@@ -2306,11 +2313,11 @@ msgstr ""
 "Komposition understøttes ikke af dette system. Slå det venligst til i din "
 "vindueshåndtering."
 
-#: ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:1549
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Komprimeret HTML Hjælp-fil (*.chm)|*.chm|"
 
-#: ../src/generic/dirctrlg.cpp:444
+#: ../src/generic/dirctrlg.cpp:410
 msgid "Computer"
 msgstr "Computer"
 
@@ -2319,53 +2326,57 @@ msgstr "Computer"
 msgid "Config entry name cannot start with '%c'."
 msgstr "Konfigurationspunkt må ikke begynde med \"%c\"."
 
-#: ../src/generic/filedlgg.cpp:349 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
 msgid "Confirm"
 msgstr "Bekræft"
 
-#: ../src/html/htmlwin.cpp:566
+#: ../src/html/htmlwin.cpp:569
 msgid "Connecting..."
 msgstr "Opretter forbindelse..."
 
-#: ../src/html/helpwnd.cpp:475
+#: ../src/html/helpwnd.cpp:473
 msgid "Contents"
 msgstr "Indhold"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:880
+#: ../src/propgrid/advprops.cpp:781
 msgid "ControlDark"
 msgstr "Kontrol mørk"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:881
+#: ../src/propgrid/advprops.cpp:782
 msgid "ControlLight"
 msgstr "Kontrol lys"
 
-#: ../src/common/strconv.cpp:2262
+#: ../src/common/strconv.cpp:2208
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Konvertering til tegnsæt \"%s\" virker ikke."
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "Convert"
 msgstr "Konverter"
 
-#: ../src/html/htmlwin.cpp:1079
+#: ../src/html/htmlwin.cpp:1020
 #, c-format
 msgid "Copied to clipboard:\"%s\""
 msgstr "Kopieret til udklipsholder:\"%s\""
 
-#: ../src/generic/prntdlgg.cpp:247
+#: ../src/generic/prntdlgg.cpp:240
 msgid "Copies:"
 msgstr "Kopier:"
 
-#: ../src/common/stockitem.cpp:150 ../src/stc/stc_i18n.cpp:18
+#: ../src/common/stockitem.cpp:147 ../src/stc/stc_i18n.cpp:18
 msgid "Copy"
 msgstr "Kopiér"
 
-#: ../src/common/stockitem.cpp:258
+#: ../src/common/stockitem.cpp:255
 msgid "Copy selection"
 msgstr "Kopier markering"
+
+#: ../src/generic/grid.cpp:5945
+msgid "Copying more than one selected block to clipboard is not supported."
+msgstr ""
 
 #: ../src/richtext/richtextborderspage.cpp:566
 #: ../src/richtext/richtextborderspage.cpp:601
@@ -2376,196 +2387,193 @@ msgstr "Hjørne"
 msgid "Corner &radius:"
 msgstr "Hjørne&radius:"
 
-#: ../src/html/chm.cpp:718
+#: ../src/html/chm.cpp:711
 #, c-format
 msgid "Could not create temporary file '%s'"
 msgstr "Kunne ikke oprette midlertidig fil \"%s\""
 
-#: ../src/html/chm.cpp:273
+#: ../src/html/chm.cpp:270
 #, c-format
 msgid "Could not extract %s into %s: %s"
 msgstr "Kunne ikke udpakke %s til %s: %s"
 
-#: ../src/generic/tabg.cpp:1048
+#: ../src/generic/tabg.cpp:1045
 msgid "Could not find tab for id"
 msgstr "Kunne ikke finde tab til id"
 
-#: ../src/gtk/notifmsg.cpp:108
-msgid "Could not initalize libnotify."
-msgstr "Kunne ikke initialisere libnotify."
-
-#: ../src/html/chm.cpp:444
+#: ../src/html/chm.cpp:437
 #, c-format
 msgid "Could not locate file '%s'."
 msgstr "Kunne ikke finde filen \"%s\"."
 
-#: ../src/common/filefn.cpp:1403
+#: ../src/msw/graphicsd2d.cpp:604
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/common/filefn.cpp:1291
 msgid "Could not set current working directory"
 msgstr "Kunne ikke sætte den aktuelle arbejdsmappe"
 
-#: ../src/common/prntbase.cpp:2015
+#: ../src/common/prntbase.cpp:2037
 msgid "Could not start document preview."
 msgstr "Kunne ikke starte udskriftsvisning."
 
-#: ../src/generic/printps.cpp:178 ../src/msw/printwin.cpp:210
-#: ../src/gtk/print.cpp:1132
+#: ../src/generic/printps.cpp:159 ../src/msw/printwin.cpp:184
+#: ../src/gtk/print.cpp:1129
 msgid "Could not start printing."
 msgstr "Kunne ikke starte udskrivning."
 
-#: ../src/common/wincmn.cpp:2125
+#: ../src/common/wincmn.cpp:2126
 msgid "Could not transfer data to window"
 msgstr "Kunne ikke overføre data til vindue"
 
-#: ../src/msw/imaglist.cpp:187 ../src/msw/imaglist.cpp:224
-#: ../src/msw/imaglist.cpp:249 ../src/msw/dragimag.cpp:185
-#: ../src/msw/dragimag.cpp:220
+#: ../src/msw/imaglist.cpp:223 ../src/msw/imaglist.cpp:245
+#: ../src/msw/imaglist.cpp:270 ../src/msw/dragimag.cpp:182
+#: ../src/msw/dragimag.cpp:217
 msgid "Couldn't add an image to the image list."
 msgstr "Kunne ikke tilføje et billede til billedlisten."
 
-#: ../src/osx/glcanvas_osx.cpp:414 ../src/unix/glx11.cpp:558
-#: ../src/msw/glcanvas.cpp:616
+#: ../src/osx/glcanvas_osx.cpp:411 ../src/msw/glcanvas.cpp:631
+#: ../src/unix/glegl.cpp:315 ../src/unix/glx11.cpp:559
 msgid "Couldn't create OpenGL context"
 msgstr "Kunne ikke oprette OpenGL-kontekst"
 
-#: ../src/msw/timer.cpp:134
+#: ../src/msw/timer.cpp:131
 msgid "Couldn't create a timer"
 msgstr "Kunne ikke oprette en timer"
 
-#: ../src/osx/carbon/overlay.cpp:122
-msgid "Couldn't create the overlay window"
-msgstr "Kunne ikke oprette overlay-vinduet"
-
-#: ../src/common/translation.cpp:2024
+#: ../src/common/translation.cpp:2074
 msgid "Couldn't enumerate translations"
 msgstr "Kunne ikke optælle oversættelser"
 
-#: ../src/common/dynlib.cpp:120
+#: ../src/common/dynlib.cpp:110
 #, c-format
 msgid "Couldn't find symbol '%s' in a dynamic library"
 msgstr "Kunne ikke finde symbolet \"%s\" i et dynamisk bibliotek"
 
-#: ../src/msw/thread.cpp:915
+#: ../src/msw/thread.cpp:921
 msgid "Couldn't get the current thread pointer"
 msgstr "Kunne ikke få aktuelle trådpointer"
 
-#: ../src/osx/carbon/overlay.cpp:129
-msgid "Couldn't init the context on the overlay window"
-msgstr "Kunne ikke initialisere konteksten på overlay-vinduet"
-
-#: ../src/common/imaggif.cpp:244
+#: ../src/common/imaggif.cpp:241
 msgid "Couldn't initialize GIF hash table."
 msgstr "Kunne ikke initialisere GIF hash tabel."
 
-#: ../src/common/imagpng.cpp:409
+#: ../src/common/imagpng.cpp:437
 msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
 msgstr ""
 "Kunne ikke indlæse et PNG-billede - filen er korrupt eller ikke nok ledig "
 "hukommelse."
 
-#: ../src/unix/sound.cpp:470
+#: ../src/unix/sound.cpp:459
 #, c-format
 msgid "Couldn't load sound data from '%s'."
 msgstr "Kunne ikke indlæse lyddata fra \"%s\"."
 
-#: ../src/msw/dirdlg.cpp:435
+#: ../src/msw/dirdlg.cpp:287
 msgid "Couldn't obtain folder name"
 msgstr "Kunne ikke få fat i mappenavn"
 
-#: ../src/unix/sound_sdl.cpp:229
+#: ../src/unix/sound_sdl.cpp:226
 #, c-format
 msgid "Couldn't open audio: %s"
 msgstr "Kunne ikke åbne lyd: %s"
 
-#: ../src/msw/ole/dataobj.cpp:377
+#: ../src/msw/ole/dataobj.cpp:385
 #, c-format
 msgid "Couldn't register clipboard format '%s'."
 msgstr "Kunne ikke registrere udklipsholderformatet \"%s\"."
 
-#: ../src/msw/listctrl.cpp:869
+#: ../src/msw/listctrl.cpp:933
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "Kunne ikke hente information om listekontrolemne %d."
 
-#: ../src/common/imagpng.cpp:498 ../src/common/imagpng.cpp:509
-#: ../src/common/imagpng.cpp:519
+#: ../src/common/imagpng.cpp:511 ../src/common/imagpng.cpp:522
+#: ../src/common/imagpng.cpp:532
 msgid "Couldn't save PNG image."
 msgstr "Kunne ikke gemme PNG billede."
 
-#: ../src/msw/thread.cpp:684
+#: ../src/msw/thread.cpp:676
 msgid "Couldn't terminate thread"
 msgstr "Kunne ikke afslutte tråd"
 
-#: ../src/common/xtistrm.cpp:166
+#: ../src/common/xtistrm.cpp:163
 #, c-format
 msgid "Create Parameter %s not found in declared RTTI Parameters"
 msgstr "Create-parameter %s ikke fundet i deklarerede RTTI-parametre"
 
-#: ../src/generic/dirdlgg.cpp:288
+#: ../src/generic/dirdlgg.cpp:285
 msgid "Create directory"
 msgstr "Opret mappe"
 
-#: ../src/generic/filedlgg.cpp:212 ../src/generic/dirdlgg.cpp:111
+#: ../src/generic/filedlgg.cpp:209 ../src/generic/dirdlgg.cpp:108
 msgid "Create new directory"
 msgstr "Opret ny mappe"
 
-#: ../src/xrc/xmlres.cpp:2460
+#: ../src/common/stockitem.cpp:264
+#, fuzzy
+msgid "Create new document"
+msgstr "Opret ny mappe"
+
+#: ../src/xrc/xmlres.cpp:2515
 #, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Oprettelse af %s \"%s\" fejlede."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1758
+#: ../src/propgrid/advprops.cpp:1659
 msgid "Cross"
 msgstr "Kryds"
 
-#: ../src/common/accelcmn.cpp:333
+#: ../src/common/accelcmn.cpp:347
 msgid "Ctrl+"
 msgstr "Ctrl+"
 
-#: ../src/richtext/richtextctrl.cpp:332 ../src/osx/textctrl_osx.cpp:576
-#: ../src/common/stockitem.cpp:151 ../src/msw/textctrl.cpp:2507
+#: ../src/osx/textctrl_osx.cpp:594 ../src/common/stockitem.cpp:148
+#: ../src/msw/textctrl.cpp:2772 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "&Klip"
 
-#: ../src/generic/filectrlg.cpp:940
+#: ../src/generic/filectrlg.cpp:936
 msgid "Current directory:"
 msgstr "Aktuel mappe:"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:896 ../src/propgrid/advprops.cpp:1574
-#: ../src/propgrid/advprops.cpp:1612
+#: ../src/propgrid/advprops.cpp:797 ../src/propgrid/advprops.cpp:1475
+#: ../src/propgrid/advprops.cpp:1518
 msgid "Custom"
 msgstr "Speciel"
 
-#: ../src/gtk/print.cpp:217
+#: ../src/gtk/print.cpp:211
 msgid "Custom size"
 msgstr "Speciel størrelse"
 
-#: ../src/common/headerctrlcmn.cpp:60
+#: ../src/common/headerctrlcmn.cpp:58
 msgid "Customize Columns"
 msgstr "Tilpas kolonner"
 
-#: ../src/common/stockitem.cpp:151 ../src/stc/stc_i18n.cpp:17
+#: ../src/common/stockitem.cpp:148 ../src/stc/stc_i18n.cpp:17
 msgid "Cut"
 msgstr "Klip"
 
-#: ../src/common/stockitem.cpp:259
+#: ../src/common/stockitem.cpp:256
 msgid "Cut selection"
 msgstr "Klip markering"
 
-#: ../src/common/fmapbase.cpp:152
+#: ../src/common/fmapbase.cpp:149
 msgid "Cyrillic (ISO-8859-5)"
 msgstr "Kyrillisk (ISO-8859-5)"
 
-#: ../src/common/paper.cpp:99
+#: ../src/common/paper.cpp:96
 msgid "D sheet, 22 x 34 in"
 msgstr "D-ark, 22 x 34 tommer"
 
-#: ../src/msw/dde.cpp:703
+#: ../src/msw/dde.cpp:698
 msgid "DDE poke request failed"
 msgstr "DDE-poke anmodning fejlede"
 
-#: ../src/common/imagbmp.cpp:1169
+#: ../src/common/imagbmp.cpp:1181
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr "DIB-header: kodning svarer ikke til bitdybden."
 
@@ -2585,7 +2593,7 @@ msgstr "DIB-header: ukendt bitdybde i filen."
 msgid "DIB Header: Unknown encoding in file."
 msgstr "DIB-header: ukendt kodning i filen."
 
-#: ../src/common/paper.cpp:121
+#: ../src/common/paper.cpp:118
 msgid "DL Envelope, 110 x 220 mm"
 msgstr "DL-konvolut, 110 x 220 mm"
 
@@ -2593,53 +2601,53 @@ msgstr "DL-konvolut, 110 x 220 mm"
 msgid "Dashed"
 msgstr "Streget"
 
-#: ../src/generic/dbgrptg.cpp:300
+#: ../src/generic/dbgrptg.cpp:301
 #, c-format
 msgid "Debug report \"%s\""
 msgstr "Fejlfindingsrapport \"%s\""
 
-#: ../src/common/debugrpt.cpp:210
+#: ../src/common/debugrpt.cpp:211
 msgid "Debug report couldn't be created."
 msgstr "Kunne ikke oprette fejlfindingsrapport."
 
-#: ../src/common/debugrpt.cpp:553
+#: ../src/common/debugrpt.cpp:554
 msgid "Debug report generation has failed."
 msgstr "Generering af fejlfindingsrapport fejlede."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:84
+#: ../src/common/accelcmn.cpp:81
 msgid "Decimal"
 msgstr "Decimal"
 
-#: ../src/generic/fontdlgg.cpp:323
+#: ../src/generic/fontdlgg.cpp:319
 msgid "Decorative"
 msgstr "Dekorativ"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1752
+#: ../src/propgrid/advprops.cpp:1653
 msgid "Default"
 msgstr "Standard"
 
-#: ../src/common/fmapbase.cpp:796
+#: ../src/common/fmapbase.cpp:792
 msgid "Default encoding"
 msgstr "Standardkodning"
 
-#: ../src/dfb/fontmgr.cpp:180
+#: ../src/dfb/fontmgr.cpp:177
 msgid "Default font"
 msgstr "Standardskrifttype"
 
-#: ../src/generic/prntdlgg.cpp:510
+#: ../src/generic/prntdlgg.cpp:503
 msgid "Default printer"
 msgstr "Standardprinter"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:51
+#: ../src/common/accelcmn.cpp:48
 msgid "Del"
 msgstr "Slet"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextbuffer.cpp:8221 ../src/common/stockitem.cpp:152
-#: ../src/common/accelcmn.cpp:50 ../src/stc/stc_i18n.cpp:20
+#: ../src/common/stockitem.cpp:149 ../src/common/accelcmn.cpp:47
+#: ../src/richtext/richtextbuffer.cpp:8217 ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Slet"
 
@@ -2647,68 +2655,68 @@ msgstr "Slet"
 msgid "Delete A&ll"
 msgstr "Slet &alt"
 
-#: ../src/richtext/richtextbuffer.cpp:11341
+#: ../src/richtext/richtextbuffer.cpp:11340
 msgid "Delete Column"
 msgstr "Slet kolonne"
 
-#: ../src/richtext/richtextbuffer.cpp:11291
+#: ../src/richtext/richtextbuffer.cpp:11290
 msgid "Delete Row"
 msgstr "Slet række"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 msgid "Delete Style"
 msgstr "Slet typografi"
 
-#: ../src/richtext/richtextctrl.cpp:1345 ../src/richtext/richtextctrl.cpp:1584
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
 msgid "Delete Text"
 msgstr "Slet tekst"
 
-#: ../src/generic/editlbox.cpp:170
+#: ../src/generic/editlbox.cpp:147
 msgid "Delete item"
 msgstr "Slet objekt"
 
-#: ../src/common/stockitem.cpp:260
+#: ../src/common/stockitem.cpp:257
 msgid "Delete selection"
 msgstr "Slet markering"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 #, c-format
 msgid "Delete style %s?"
 msgstr "Slet typografien %s?"
 
-#: ../src/unix/snglinst.cpp:301
+#: ../src/unix/snglinst.cpp:298
 #, c-format
 msgid "Deleted stale lock file '%s'."
 msgstr "Slettede gammel låsfilen \"%s\"."
 
-#: ../src/common/secretstore.cpp:220
-#, c-format
-msgid "Deleting password for \"%s/%s\" failed: %s."
+#: ../src/common/secretstore.cpp:234
+#, fuzzy, c-format
+msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Kunne ikke slette adganskode for \"%s/%s\": %s."
 
-#: ../src/common/module.cpp:124
+#: ../src/common/module.cpp:121
 #, c-format
 msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
 msgstr "Afhængighed \"%s\" af modulet \"%s\" findes ikke."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "Descending"
 msgstr "Faldende"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:526 ../src/propgrid/advprops.cpp:882
+#: ../src/generic/dirctrlg.cpp:492 ../src/propgrid/advprops.cpp:783
 msgid "Desktop"
 msgstr "Skrivebord"
 
-#: ../src/generic/aboutdlgg.cpp:70
+#: ../src/generic/aboutdlgg.cpp:67
 msgid "Developed by "
 msgstr "Udviklet af "
 
-#: ../src/generic/aboutdlgg.cpp:176
+#: ../src/generic/aboutdlgg.cpp:173
 msgid "Developers"
 msgstr "Udviklere"
 
-#: ../src/msw/dialup.cpp:374
+#: ../src/msw/dialup.cpp:368
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -2716,11 +2724,11 @@ msgstr ""
 "Opkaldsfunktion er ikke tilgængelig, fordi Remote Access Service (RAS) ikke "
 "er installeret på computeren. Installer det venligst."
 
-#: ../src/generic/tipdlg.cpp:211
+#: ../src/generic/tipdlg.cpp:208
 msgid "Did you know..."
 msgstr "Vidste du..."
 
-#: ../src/dfb/wrapdfb.cpp:63
+#: ../src/dfb/wrapdfb.cpp:60
 #, c-format
 msgid "DirectFB error %d occurred."
 msgstr "DirectFB fejl %d opstod."
@@ -2729,29 +2737,29 @@ msgstr "DirectFB fejl %d opstod."
 msgid "Directories"
 msgstr "Mapper"
 
-#: ../src/common/filefn.cpp:1183
+#: ../src/common/filefn.cpp:1071
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Mappen \"%s\" kunne ikke oprettes"
 
-#: ../src/common/filefn.cpp:1197
+#: ../src/common/filefn.cpp:1085
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "Mappen \"%s\" kunne ikke slettes"
 
-#: ../src/generic/dirdlgg.cpp:204
+#: ../src/generic/dirdlgg.cpp:201
 msgid "Directory does not exist"
 msgstr "Mappen findes ikke"
 
-#: ../src/generic/filectrlg.cpp:1399
+#: ../src/generic/filectrlg.cpp:1388
 msgid "Directory doesn't exist."
 msgstr "Mappen findes ikke."
 
-#: ../src/common/docview.cpp:457
+#: ../src/common/docview.cpp:450
 msgid "Discard changes and reload the last saved version?"
 msgstr "Forkast ændringer og genindlæs den sidst gemte version?"
 
-#: ../src/html/helpwnd.cpp:502
+#: ../src/html/helpwnd.cpp:500
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -2759,45 +2767,45 @@ msgstr ""
 "Vis alle indeksemner, der indeholder understrengen. Ingen forskel på store "
 "og små bogstaver."
 
-#: ../src/html/helpwnd.cpp:679
+#: ../src/html/helpwnd.cpp:677
 msgid "Display options dialog"
 msgstr "Vis dialogen Indstillinger"
 
-#: ../src/html/helpwnd.cpp:322
+#: ../src/html/helpwnd.cpp:320
 msgid "Displays help as you browse the books on the left."
 msgstr "Viser hjælp mens du gennemser bøgerne til venstre."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:85
+#: ../src/common/accelcmn.cpp:83
 msgid "Divide"
 msgstr "Divider"
 
-#: ../src/common/docview.cpp:533
+#: ../src/common/docview.cpp:526
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Ønsker du at gemme ændringer til %s?"
 
-#: ../src/common/prntbase.cpp:542
+#: ../src/common/prntbase.cpp:537
 msgid "Document:"
 msgstr "Dokument:"
 
-#: ../src/generic/aboutdlgg.cpp:73
+#: ../src/generic/aboutdlgg.cpp:70
 msgid "Documentation by "
 msgstr "Dokumentation af "
 
-#: ../src/generic/aboutdlgg.cpp:180
+#: ../src/generic/aboutdlgg.cpp:177
 msgid "Documentation writers"
 msgstr "Dokumentforfattere"
 
-#: ../src/common/sizer.cpp:2799
+#: ../src/common/sizer.cpp:2916
 msgid "Don't Save"
 msgstr "Gem ikke"
 
-#: ../src/html/htmlwin.cpp:633
+#: ../src/html/htmlwin.cpp:643
 msgid "Done"
 msgstr "Færdig"
 
-#: ../src/generic/progdlgg.cpp:448 ../src/msw/progdlg.cpp:407
+#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
 msgid "Done."
 msgstr "Færdig."
 
@@ -2809,42 +2817,42 @@ msgstr "Prikket"
 msgid "Double"
 msgstr "Dobbelt"
 
-#: ../src/common/paper.cpp:176
+#: ../src/common/paper.cpp:173
 msgid "Double Japanese Postcard Rotated 148 x 200 mm"
 msgstr "Dobbelt japansk postkort roteret 148 x 200 mm"
 
-#: ../src/common/xtixml.cpp:273
+#: ../src/common/xtixml.cpp:269
 #, c-format
 msgid "Doubly used id : %d"
 msgstr "Id brugt to gange : %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:153
-#: ../src/common/accelcmn.cpp:64
+#: ../src/common/stockitem.cpp:150 ../src/common/accelcmn.cpp:61
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Down"
 msgstr "Ned"
 
-#: ../src/richtext/richtextctrl.cpp:865
+#: ../src/richtext/richtextctrl.cpp:864
 msgid "Drag"
 msgstr "Træk"
 
-#: ../src/common/paper.cpp:100
+#: ../src/common/paper.cpp:97
 msgid "E sheet, 34 x 44 in"
 msgstr "E-ark, 34 x 44 tommer"
 
-#: ../src/unix/fswatcher_inotify.cpp:561
+#: ../src/unix/fswatcher_inotify.cpp:558
 msgid "EOF while reading from inotify descriptor"
 msgstr "EOF under læsning fra inotify-deskriptor"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "Edit"
 msgstr "Rediger"
 
-#: ../src/generic/editlbox.cpp:168
+#: ../src/generic/editlbox.cpp:131
 msgid "Edit item"
 msgstr "Ret objekt"
 
-#: ../include/wx/generic/progdlgg.h:84
+#: ../include/wx/generic/progdlgg.h:85
 msgid "Elapsed time:"
 msgstr "Forløbet tid:"
 
@@ -2911,62 +2919,62 @@ msgid "Enables the shadow spread."
 msgstr "Aktiverer skyggeudbredelsen."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:66
+#: ../src/common/accelcmn.cpp:63
 msgid "End"
 msgstr "End"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:55
+#: ../src/common/accelcmn.cpp:52
 msgid "Enter"
 msgstr "Enter"
 
-#: ../src/richtext/richtextstyledlg.cpp:934
+#: ../src/richtext/richtextstyledlg.cpp:930
 msgid "Enter a box style name"
 msgstr "Indtast navnet på en bokstypografi"
 
-#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:602
 msgid "Enter a character style name"
 msgstr "Indtast navnet på en tegntypografi"
 
-#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:816
 msgid "Enter a list style name"
 msgstr "Indtast navnet på en listetypografi"
 
-#: ../src/richtext/richtextstyledlg.cpp:893
+#: ../src/richtext/richtextstyledlg.cpp:889
 msgid "Enter a new style name"
 msgstr "Indtast et nyt typografinavn"
 
-#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:650
 msgid "Enter a paragraph style name"
 msgstr "Indtast navnet på en afsnitstypografi"
 
-#: ../src/generic/dbgrptg.cpp:174
+#: ../src/generic/dbgrptg.cpp:171
 #, c-format
 msgid "Enter command to open file \"%s\":"
 msgstr "Skriv kommando for at åbne filen \"%s\":"
 
-#: ../src/generic/helpext.cpp:459
+#: ../src/generic/helpext.cpp:457
 msgid "Entries found"
 msgstr "Indgange fundet"
 
-#: ../src/common/paper.cpp:142
+#: ../src/common/paper.cpp:139
 msgid "Envelope Invite 220 x 220 mm"
 msgstr "Konvolut invitation 220 x 220 mm"
 
-#: ../src/common/config.cpp:469
+#: ../src/common/config.cpp:465
 #, c-format
 msgid ""
 "Environment variables expansion failed: missing '%c' at position %u in '%s'."
 msgstr ""
 "Udvidelse af miljøvariabel fejlede: mangler \"%c\" på position %u i \"%s\"."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/generic/dirctrlg.cpp:570
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/dirctrlg.cpp:599
-#: ../src/generic/dirdlgg.cpp:323 ../src/generic/filectrlg.cpp:642
-#: ../src/generic/filectrlg.cpp:756 ../src/generic/filectrlg.cpp:770
-#: ../src/generic/filectrlg.cpp:786 ../src/generic/filectrlg.cpp:1368
-#: ../src/generic/filectrlg.cpp:1399 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/gtk1/fontdlg.cpp:74 ../src/generic/dirctrlg.cpp:536
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/dirctrlg.cpp:565
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1357 ../src/generic/filectrlg.cpp:1388
+#: ../src/generic/filedlgg.cpp:354 ../src/generic/dirdlgg.cpp:320
+#: ../src/gtk/filedlg.cpp:74
 msgid "Error"
 msgstr "Fejl"
 
@@ -2974,86 +2982,97 @@ msgstr "Fejl"
 msgid "Error closing epoll descriptor"
 msgstr "Fejl under lukning af epoll-deskriptor"
 
-#: ../src/unix/fswatcher_kqueue.cpp:114
+#: ../src/unix/fswatcher_kqueue.cpp:131
 msgid "Error closing kqueue instance"
 msgstr "Fejl under lukning af kqueue-instans"
 
-#: ../src/common/filefn.cpp:1049
+#: ../src/common/filefn.cpp:938
 #, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Kunne ikke kopiere filen \"%s\" til \"%s\"."
 
-#: ../src/generic/dirdlgg.cpp:222
+#: ../src/generic/dirdlgg.cpp:219
 msgid "Error creating directory"
 msgstr "Fejl ved oprettelse af mappe"
 
-#: ../src/common/imagbmp.cpp:1181
+#: ../src/common/imagbmp.cpp:1193
 msgid "Error in reading image DIB."
 msgstr "Fejl ved læsning af billede DIB."
 
-#: ../src/propgrid/propgrid.cpp:6696
+#: ../src/propgrid/propgrid.cpp:6665
 #, c-format
 msgid "Error in resource: %s"
 msgstr "Fejl i ressource: %s"
 
-#: ../src/common/fileconf.cpp:422
+#: ../src/common/fileconf.cpp:421
 msgid "Error reading config options."
 msgstr "Fejl ved læsning af konfigurationsvalg."
+
+#: ../src/msw/webview_ie.cpp:1057 ../src/msw/webview_edge.cpp:850
+#: ../src/gtk/webview_webkit2.cpp:1262 ../src/osx/webview_webkit.mm:383
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
 
 #: ../src/common/fileconf.cpp:1029
 msgid "Error saving user configuration data."
 msgstr "Fejl under gem bruger konfiguration data."
 
-#: ../src/gtk/print.cpp:722
+#: ../src/gtk/print.cpp:720
 msgid "Error while printing: "
 msgstr "Fejl under udskrift: "
 
-#: ../src/common/log.cpp:219
+#: ../src/common/log.cpp:237
 msgid "Error: "
 msgstr "Fejl: "
 
+#: ../src/common/webrequest.cpp:98
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Fejl: "
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:69
+#: ../src/common/accelcmn.cpp:66
 msgid "Esc"
 msgstr "Esc"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:70
+#: ../src/common/accelcmn.cpp:67
 msgid "Escape"
 msgstr "Escape"
 
-#: ../src/common/fmapbase.cpp:150
+#: ../src/common/fmapbase.cpp:147
 msgid "Esperanto (ISO-8859-3)"
 msgstr "Esperanto (ISO-8859-3)"
 
-#: ../include/wx/generic/progdlgg.h:85
+#: ../include/wx/generic/progdlgg.h:86
 msgid "Estimated time:"
 msgstr "Anslået tid:"
 
-#: ../src/generic/dbgrptg.cpp:234
+#: ../src/generic/dbgrptg.cpp:231
 msgid "Executable files (*.exe)|*.exe|"
 msgstr "Programfiler (*.exe)|*.exe|"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:155 ../src/common/accelcmn.cpp:78
+#: ../src/common/stockitem.cpp:152 ../src/common/accelcmn.cpp:75
 msgid "Execute"
 msgstr "Udfør"
 
-#: ../src/msw/utilsexc.cpp:876
+#: ../src/msw/utilsexc.cpp:873
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Afvikling af kommandoen \"%s\" fejlede"
 
-#: ../src/common/paper.cpp:105
+#: ../src/common/paper.cpp:102
 msgid "Executive, 7 1/4 x 10 1/2 in"
 msgstr "Executive, 7 1/4 x 10 1/2 tommer"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6009
+#: ../src/generic/datavgen.cpp:6814
 msgid "Expand"
 msgstr "Fold ud"
 
-#: ../src/msw/registry.cpp:1240
+#: ../src/msw/registry.cpp:1228
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
@@ -3061,147 +3080,157 @@ msgstr ""
 "Eksporterer registernøgle: filen \"%s\" findes allerede og vil ikke blive "
 "overskrevet."
 
-#: ../src/common/fmapbase.cpp:195
+#: ../src/common/fmapbase.cpp:192
 msgid "Extended Unix Codepage for Japanese (EUC-JP)"
 msgstr "Extended Unix Codepage for Japansk (EUC-JP)"
 
-#: ../src/html/chm.cpp:725
+#: ../src/html/chm.cpp:718
 #, c-format
 msgid "Extraction of '%s' into '%s' failed."
 msgstr "Udpakning af \"%s\" til \"%s\" fejlede."
 
-#: ../src/common/accelcmn.cpp:249 ../src/common/accelcmn.cpp:344
+#: ../src/common/accelcmn.cpp:259 ../src/common/accelcmn.cpp:358
 msgid "F"
 msgstr "F"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:672
+#: ../src/propgrid/advprops.cpp:582
 msgid "Face Name"
 msgstr "Skriftnavn"
 
-#: ../src/unix/snglinst.cpp:269
+#: ../src/unix/snglinst.cpp:266
 msgid "Failed to access lock file."
 msgstr "Kunne ikke tilgå låsfilen."
+
+#: ../src/gtk/font.cpp:572
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Kunne ikke læse dokument fra filen \"%s\"."
 
 #: ../src/unix/epolldispatcher.cpp:116
 #, c-format
 msgid "Failed to add descriptor %d to epoll descriptor %d"
 msgstr "Kunne ikke tilføje deskriptor %d til epoll-deskriptor %d"
 
-#: ../src/msw/dib.cpp:489
+#: ../src/msw/dib.cpp:535
 #, c-format
 msgid "Failed to allocate %luKb of memory for bitmap data."
 msgstr "Kunne ikke allokere %luKb hukommelse til bitmap data."
 
-#: ../src/common/glcmn.cpp:115
+#: ../src/common/glcmn.cpp:112
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Kunne ikke tildele farve til OpenGL"
 
-#: ../src/unix/displayx11.cpp:236
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Kunne ikke tildele farve til OpenGL"
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Kunne ikke tildele farve til OpenGL"
+
+#: ../include/wx/unix/private/displayx11.h:89
 msgid "Failed to change video mode"
 msgstr "Kunne ikke ændre video mode"
 
-#: ../src/common/image.cpp:3277
+#: ../src/common/image.cpp:3396
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Kunne ikke tjekke format af billedfilen \"%s\"."
 
-#: ../src/common/debugrpt.cpp:239
+#: ../src/common/debugrpt.cpp:240
 #, c-format
 msgid "Failed to clean up debug report directory \"%s\""
 msgstr "Kunne ikke rydde op i fejlfindingsrapportmappen \"%s\""
 
-#: ../src/common/filename.cpp:192
+#: ../src/common/filename.cpp:189
 msgid "Failed to close file handle"
 msgstr "Kunne ikke lukke filhåndtag"
 
-#: ../src/unix/snglinst.cpp:340
+#: ../src/unix/snglinst.cpp:337
 #, c-format
 msgid "Failed to close lock file '%s'"
 msgstr "Kunne ikke lukke låsfilen \"%s\""
 
-#: ../src/msw/clipbrd.cpp:112
+#: ../src/msw/clipbrd.cpp:110
 msgid "Failed to close the clipboard."
 msgstr "Kunne ikke lukke udklipsholder."
 
-#: ../src/x11/utils.cpp:208
+#: ../src/x11/utils.cpp:170
 #, c-format
 msgid "Failed to close the display \"%s\""
 msgstr "Kunne ikke lukke skærmen \"%s\""
 
-#: ../src/msw/dialup.cpp:797
+#: ../src/msw/dialup.cpp:791
 msgid "Failed to connect: missing username/password."
 msgstr "Kunne ikke oprette forbindelse: mangler brugernavn/adgangskode."
 
-#: ../src/msw/dialup.cpp:743
+#: ../src/msw/dialup.cpp:737
 msgid "Failed to connect: no ISP to dial."
 msgstr "Kunne ikke oprette forbindelse: ingen ISP at foretage opkald til."
 
-#: ../src/common/textfile.cpp:203
-#, c-format
-msgid "Failed to convert file \"%s\" to Unicode."
-msgstr "Kunne ikke konvertere filen \"%s\" til Unicode."
-
-#: ../src/generic/logg.cpp:956
+#: ../src/generic/logg.cpp:953
 msgid "Failed to copy dialog contents to the clipboard."
 msgstr "Kunne ikke kopiere dialogens indhold til udklipsholder."
 
-#: ../src/msw/registry.cpp:692
+#: ../src/msw/registry.cpp:681
 #, c-format
 msgid "Failed to copy registry value '%s'"
 msgstr "Kunne ikke kopiere registreringsværdi \"%s\""
 
-#: ../src/msw/registry.cpp:701
+#: ../src/msw/registry.cpp:690
 #, c-format
 msgid "Failed to copy the contents of registry key '%s' to '%s'."
 msgstr "Kunne ikke kopiere indholdet af registreringsnøglen \"%s\" til \"%s\"."
 
-#: ../src/common/filefn.cpp:1015
+#: ../src/common/filefn.cpp:904
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Kunne ikke kopiere filen \"%s\" til \"%s\""
 
-#: ../src/msw/registry.cpp:679
+#: ../src/msw/registry.cpp:668
 #, c-format
 msgid "Failed to copy the registry subkey '%s' to '%s'."
 msgstr "Kunne ikke kopiere registreringsundernøglen \"%s\" til \"%s\"."
 
-#: ../src/msw/dde.cpp:1070
+#: ../src/msw/dde.cpp:1134
 msgid "Failed to create DDE string"
 msgstr "Kunne ikke oprette DDE-streng"
 
-#: ../src/msw/mdi.cpp:616
+#: ../src/msw/mdi.cpp:621
 msgid "Failed to create MDI parent frame."
 msgstr "Kunne ikke oprette MDI-forældreramme."
 
-#: ../src/common/filename.cpp:1027
+#: ../src/common/filename.cpp:1024
 msgid "Failed to create a temporary file name"
 msgstr "Kunne ikke oprette et midlertidigt filnavn"
 
-#: ../src/msw/utilsexc.cpp:228
+#: ../src/msw/utilsexc.cpp:225
 msgid "Failed to create an anonymous pipe"
 msgstr "Kunne ikke oprette anonym pipe"
 
-#: ../src/msw/ole/automtn.cpp:522
+#: ../src/msw/ole/automtn.cpp:513
 #, c-format
 msgid "Failed to create an instance of \"%s\""
 msgstr "Kunne ikke oprette en instans af \"%s\""
 
-#: ../src/msw/dde.cpp:437
+#: ../src/msw/dde.cpp:432
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "Kunne ikke oprette forbindelse til serveren \"%s\" ang. emne \"%s\""
 
-#: ../src/msw/cursor.cpp:204
+#: ../src/msw/cursor.cpp:195
 msgid "Failed to create cursor."
 msgstr "Kunne ikke oprette markør."
 
-#: ../src/common/debugrpt.cpp:209
+#: ../src/common/debugrpt.cpp:210
 #, c-format
 msgid "Failed to create directory \"%s\""
 msgstr "Kunne ikke oprette mappen \"%s\""
 
-#: ../src/generic/dirdlgg.cpp:220
+#: ../src/generic/dirdlgg.cpp:217
 #, c-format
 msgid ""
 "Failed to create directory '%s'\n"
@@ -3214,115 +3243,134 @@ msgstr ""
 msgid "Failed to create epoll descriptor"
 msgstr "Kunne ikke oprette epoll-deskriptor"
 
-#: ../src/msw/mimetype.cpp:238
+#: ../src/gtk/font.cpp:562
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "Kunne ikke opdatere brugerkonfigurationsfil."
+
+#: ../src/msw/mimetype.cpp:235
 #, c-format
 msgid "Failed to create registry entry for '%s' files."
 msgstr "Kunne ikke oprette registreringsindgang for \"%s\" filer."
 
-#: ../src/msw/fdrepdlg.cpp:409
+#: ../src/msw/fdrepdlg.cpp:408
 #, c-format
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr "Kunne ikke oprette den almindelige søg/erstat dialog (fejlkode %d)"
 
-#: ../src/unix/wakeuppipe.cpp:52
+#: ../src/unix/wakeuppipe.cpp:49
 msgid "Failed to create wake up pipe used by event loop."
 msgstr "Kunne ikke oprette wake up pipe til brug for event loop."
 
-#: ../src/html/winpars.cpp:730
+#: ../src/html/winpars.cpp:727
 #, c-format
 msgid "Failed to display HTML document in %s encoding"
 msgstr "Kunne ikke vise HTML-dokument i %s-kodning"
 
-#: ../src/msw/clipbrd.cpp:124
+#: ../src/msw/clipbrd.cpp:122
 msgid "Failed to empty the clipboard."
 msgstr "Kunne ikke tømme udklipsholder."
 
-#: ../src/unix/displayx11.cpp:212
+#: ../include/wx/unix/private/displayx11.h:65
 msgid "Failed to enumerate video modes"
 msgstr "Kunne ikke optælle video modes"
 
-#: ../src/msw/dde.cpp:722
+#: ../src/msw/dde.cpp:717
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "Kunne ikke oprette advice loop med DDE-server"
 
-#: ../src/msw/dialup.cpp:629 ../src/msw/dialup.cpp:863
+#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Kunne ikke etablere netværk via modem forbindelse: %s"
 
-#: ../src/unix/utilsunx.cpp:611
+#: ../src/unix/utilsunx.cpp:613
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Kunne ikke eksekvere \"%s\"\n"
 
-#: ../src/common/debugrpt.cpp:720
+#: ../src/common/debugrpt.cpp:730
 msgid "Failed to execute curl, please install it in PATH."
 msgstr "Kunne ikke eksekvere curl. Installer den venligst i PATH."
 
-#: ../src/msw/ole/automtn.cpp:505
+#: ../src/msw/ole/automtn.cpp:496
 #, c-format
 msgid "Failed to find CLSID of \"%s\""
 msgstr "Kunne ikke finde CLSID for \"%s\""
 
-#: ../src/common/regex.cpp:431 ../src/common/regex.cpp:479
+#: ../src/common/regex.cpp:428 ../src/common/regex.cpp:476
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "Kunne ikke finde match for det regulære udtryk: %s"
 
-#: ../src/msw/dialup.cpp:695
+#: ../src/msw/webview_ie.cpp:978
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:689
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Kunne ikke få ISP-navne: %s"
 
-#: ../src/msw/ole/automtn.cpp:574
+#: ../src/msw/ole/automtn.cpp:565
 #, c-format
 msgid "Failed to get OLE automation interface for \"%s\""
 msgstr "Kunne ikke få fat i OLE automation interface for \"%s\""
 
-#: ../src/msw/clipbrd.cpp:711
+#: ../src/msw/clipbrd.cpp:731
 msgid "Failed to get data from the clipboard"
 msgstr "Kunne ikke hente data fra udklipsholder"
 
-#: ../src/common/time.cpp:223
+#: ../src/common/time.cpp:216
 msgid "Failed to get the local system time"
 msgstr "Kunne ikke få lokal systemtid"
 
-#: ../src/common/filefn.cpp:1345
+#: ../src/common/filefn.cpp:1233
 msgid "Failed to get the working directory"
 msgstr "Kunne ikke få den aktuelle arbejdsmappe"
 
-#: ../src/univ/theme.cpp:114
+#: ../src/univ/theme.cpp:111
 msgid "Failed to initialize GUI: no built-in themes found."
 msgstr ""
 "Kunne ikke initialisere grafisk brugerflade: fandt ingen indbyggede temaer."
 
-#: ../src/msw/helpchm.cpp:63
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:60
 msgid "Failed to initialize MS HTML Help."
 msgstr "Kunne ikke initialisere MS HTML Hjælp."
 
-#: ../src/msw/glcanvas.cpp:1381
+#: ../src/msw/glcanvas.cpp:1391
 msgid "Failed to initialize OpenGL"
 msgstr "Kunne ikke initialisere OpenGL"
 
-#: ../src/msw/dialup.cpp:858
+#: ../src/msw/dialup.cpp:852
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Kunne ikke initialisere netværk via modem forbindelse: %s"
 
-#: ../src/gtk/textctrl.cpp:1128
+#: ../src/gtk/textctrl.cpp:1209
 msgid "Failed to insert text in the control."
 msgstr "Kunne ikke indsætte tekst i kontrollen."
 
-#: ../src/unix/snglinst.cpp:241
+#: ../src/unix/snglinst.cpp:238
 #, c-format
 msgid "Failed to inspect the lock file '%s'"
 msgstr "Kunne ikke inspicere låsfilen \"%s\""
 
-#: ../src/unix/appunix.cpp:182
+#: ../src/unix/appunix.cpp:179
 msgid "Failed to install signal handler"
 msgstr "Kunne ikke installere signalbehandler"
 
-#: ../src/unix/threadpsx.cpp:1167
+#: ../src/unix/threadpsx.cpp:1216
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -3330,71 +3378,71 @@ msgstr ""
 "Kunne ikke slutte til en tråd, muligt hukommelsestab registreret - genstart "
 "venligst programmet"
 
-#: ../src/msw/utils.cpp:629
+#: ../src/msw/utils.cpp:619
 #, c-format
 msgid "Failed to kill process %d"
 msgstr "Kunne ikke dræbe proces %d"
 
-#: ../src/common/image.cpp:2500
+#: ../src/common/image.cpp:2595
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Kunne ikke indlæse bitmap \"%s\" fra ressourcer."
 
-#: ../src/common/image.cpp:2509
+#: ../src/common/image.cpp:2604
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Kunne ikke indlæse ikon \"%s\" fra ressourcer."
 
-#: ../src/common/iconbndl.cpp:225
+#: ../src/common/iconbndl.cpp:224
 #, c-format
 msgid "Failed to load icons from resource '%s'."
 msgstr "Kunne ikke indlæse ikoner fra ressource \"%s\"."
 
-#: ../src/common/iconbndl.cpp:200
+#: ../src/common/iconbndl.cpp:198
 #, c-format
 msgid "Failed to load image %%d from file '%s'."
 msgstr "Kunne ikke læse billede %%d fra file \"%s\"."
 
-#: ../src/common/iconbndl.cpp:208
+#: ../src/common/iconbndl.cpp:206
 #, c-format
 msgid "Failed to load image %d from stream."
 msgstr "Kunne ikke læse billede %d fra strøm."
 
-#: ../src/common/image.cpp:2587 ../src/common/image.cpp:2606
+#: ../src/common/image.cpp:2682 ../src/common/image.cpp:2701
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Kunne ikke indlæse billede fra file \"%s\"."
 
-#: ../src/msw/enhmeta.cpp:97
+#: ../src/msw/enhmeta.cpp:94
 #, c-format
 msgid "Failed to load metafile from file \"%s\"."
 msgstr "Kunne ikke indlæse metafil fra filen \"%s\"."
 
-#: ../src/msw/volume.cpp:327
+#: ../src/msw/volume.cpp:335
 msgid "Failed to load mpr.dll."
 msgstr "Kunne ikke åbne mpr.dll."
 
-#: ../src/msw/utils.cpp:953
+#: ../src/msw/utils.cpp:943
 #, c-format
 msgid "Failed to load resource \"%s\"."
 msgstr "Kunne ikke indlæse ressource \"%s\"."
 
-#: ../src/common/dynlib.cpp:92
+#: ../src/common/dynlib.cpp:86
 #, c-format
 msgid "Failed to load shared library '%s'"
 msgstr "Kunne ikke åbne delt bibliotek \"%s\""
 
-#: ../src/osx/core/sound.cpp:145
+#: ../src/osx/core/sound.cpp:143
 #, c-format
 msgid "Failed to load sound from \"%s\" (error %d)."
 msgstr "Kunne ikke indlæse lyd fra \"%s\" (fejl %d)."
 
-#: ../src/msw/utils.cpp:960
+#: ../src/msw/utils.cpp:950
 #, c-format
 msgid "Failed to lock resource \"%s\"."
 msgstr "Kunne ikke låse ressource \"%s\"."
 
-#: ../src/unix/snglinst.cpp:198
+#: ../src/unix/snglinst.cpp:195
 #, c-format
 msgid "Failed to lock the lock file '%s'"
 msgstr "Kunne ikke låse låsfilen \"%s\""
@@ -3404,33 +3452,38 @@ msgstr "Kunne ikke låse låsfilen \"%s\""
 msgid "Failed to modify descriptor %d in epoll descriptor %d"
 msgstr "Kunne ikke ændre deskriptor %d i epoll-deskriptor %d"
 
-#: ../src/common/filename.cpp:2575
+#: ../src/common/filename.cpp:2658
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Kunne ikke ændre filtid for \"%s\""
 
-#: ../src/common/selectdispatcher.cpp:258
+#: ../src/common/selectdispatcher.cpp:255
 msgid "Failed to monitor I/O channels"
 msgstr "Kunne ikke overvåge I/O-kanaler"
 
-#: ../src/common/filename.cpp:175
+#: ../src/common/filename.cpp:172
 #, c-format
 msgid "Failed to open '%s' for reading"
 msgstr "Kunne ikke åbne \"%s\" for læsning"
 
-#: ../src/common/filename.cpp:180
+#: ../src/common/filename.cpp:177
 #, c-format
 msgid "Failed to open '%s' for writing"
 msgstr "Kunne ikke åbne \"%s\" for skrivning"
 
-#: ../src/html/chm.cpp:141
+#: ../src/html/chm.cpp:138
 #, c-format
 msgid "Failed to open CHM archive '%s'."
 msgstr "Kunne ikke åbne CHM-arkivet \"%s\"."
 
-#: ../src/common/utilscmn.cpp:1126
+#: ../src/common/utilscmn.cpp:1140
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Kunne ikke åbne URL \"%s\" standard-browseren."
+
+#: ../src/common/hyperlnkcmn.cpp:133
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Kunne ikke åbne URL \"%s\" standard-browseren."
 
 #: ../include/wx/msw/private/fswatcher.h:92
@@ -3438,93 +3491,103 @@ msgstr "Kunne ikke åbne URL \"%s\" standard-browseren."
 msgid "Failed to open directory \"%s\" for monitoring."
 msgstr "Kunne ikke åbne mappen \"%s\" for overvågning."
 
-#: ../src/x11/utils.cpp:227
+#: ../src/x11/utils.cpp:189
 #, c-format
 msgid "Failed to open display \"%s\"."
 msgstr "Kunne ikke åbne skærmen \"%s\"."
 
-#: ../src/common/filename.cpp:1062
+#: ../src/common/filename.cpp:1059
 msgid "Failed to open temporary file."
 msgstr "Kunne ikke åbne midlertidig fil."
 
-#: ../src/msw/clipbrd.cpp:91
+#: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Kunne ikke åbne udklipsholder."
 
-#: ../src/common/translation.cpp:1184
+#: ../src/common/translation.cpp:1226
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Kunne ikke fortolke flertalsformer: \"%s\""
 
-#: ../src/unix/mediactrl.cpp:1214
+#: ../src/unix/mediactrl.cpp:1239
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Kunne ikke forberede afspilning af \"%s\"."
 
-#: ../src/msw/clipbrd.cpp:600
+#: ../src/msw/clipbrd.cpp:610
 msgid "Failed to put data on the clipboard"
 msgstr "Kunne ikke sende data til udklipsholder"
 
-#: ../src/unix/snglinst.cpp:278
+#: ../src/unix/snglinst.cpp:275
 msgid "Failed to read PID from lock file."
 msgstr "Kunne ikke læse PID fra låsfilen."
 
-#: ../src/common/fileconf.cpp:433
+#: ../src/common/fileconf.cpp:432
 msgid "Failed to read config options."
 msgstr "Kunne ikke læse konfigurationsvalg."
 
-#: ../src/common/docview.cpp:681
+#: ../src/common/docview.cpp:676
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Kunne ikke læse dokument fra filen \"%s\"."
 
-#: ../src/dfb/evtloop.cpp:98
+#: ../src/dfb/evtloop.cpp:99
 msgid "Failed to read event from DirectFB pipe"
 msgstr "Kunne ikke læse event fra DirectFB pipe"
 
-#: ../src/unix/wakeuppipe.cpp:120
+#: ../src/unix/wakeuppipe.cpp:117
 msgid "Failed to read from wake-up pipe"
 msgstr "Kunne ikke læse fra wake-up pipe"
 
-#: ../src/unix/utilsunx.cpp:679
+#: ../src/common/textfile.cpp:96
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Kunne ikke læse dokument fra filen \"%s\"."
+
+#: ../src/unix/utilsunx.cpp:681
 msgid "Failed to redirect child process input/output"
 msgstr "Kunne ikke omdirigere input/output fra underproces"
 
-#: ../src/msw/utilsexc.cpp:701
+#: ../src/msw/utilsexc.cpp:698
 msgid "Failed to redirect the child process IO"
 msgstr "Kunne ikke omdirigere input/output fra underproces"
 
-#: ../src/msw/dde.cpp:288
+#: ../src/msw/dde.cpp:283
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Kunne ikke registrere DDE-serveren \"%s\""
 
-#: ../src/common/fontmap.cpp:245
+#: ../src/gtk/font.cpp:580
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "Kunne ikke opdatere brugerkonfigurationsfil."
+
+#: ../src/common/fontmap.cpp:242
 #, c-format
 msgid "Failed to remember the encoding for the charset '%s'."
 msgstr "Kunne ikke huske kodning for tegnsættet \"%s\"."
 
-#: ../src/common/debugrpt.cpp:227
+#: ../src/common/debugrpt.cpp:228
 #, c-format
 msgid "Failed to remove debug report file \"%s\""
 msgstr "Kunne ikke fjerne fejlfindingsrapportfilen \"%s\""
 
-#: ../src/unix/snglinst.cpp:328
+#: ../src/unix/snglinst.cpp:325
 #, c-format
 msgid "Failed to remove lock file '%s'"
 msgstr "Kunne ikke fjerne låsfilen \"%s\""
 
-#: ../src/unix/snglinst.cpp:288
+#: ../src/unix/snglinst.cpp:285
 #, c-format
 msgid "Failed to remove stale lock file '%s'."
 msgstr "Kunne ikke fjerne gammel låsfil \"%s\"."
 
-#: ../src/msw/registry.cpp:529
+#: ../src/msw/registry.cpp:518
 #, c-format
 msgid "Failed to rename registry value '%s' to '%s'."
 msgstr "Kunne ikke omdøbe registreringsværdi \"%s\" til \"%s\"."
 
-#: ../src/common/filefn.cpp:1122
+#: ../src/common/filefn.cpp:1011
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -3532,115 +3595,124 @@ msgid ""
 msgstr ""
 "Kunne ikke omdøbe filen \"%s\" til \"%s\". Destinationsfilen findes allerede."
 
-#: ../src/msw/registry.cpp:634
+#: ../src/msw/registry.cpp:623
 #, c-format
 msgid "Failed to rename the registry key '%s' to '%s'."
 msgstr "Kunne ikke omdøbe registreringsnøglen \"%s\" til \"%s\"."
 
-#: ../src/common/filename.cpp:2671
+#: ../src/msw/webview_ie.cpp:995
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/common/filename.cpp:2754
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Kunne ikke hente filtider for \"%s\""
 
-#: ../src/msw/dialup.cpp:468
+#: ../src/msw/dialup.cpp:462
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Kunne ikke hente tekst fra RAS fejlmeddelelse"
 
-#: ../src/msw/clipbrd.cpp:748
+#: ../src/msw/clipbrd.cpp:768
 msgid "Failed to retrieve the supported clipboard formats"
 msgstr "Kunne ikke hente liste over understøttede udklipsholderformater"
 
-#: ../src/common/docview.cpp:652
+#: ../src/common/docview.cpp:647
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Kunne ikke gemme dokumentet i filen \"%s\"."
 
-#: ../src/msw/dib.cpp:269
+#: ../src/msw/dib.cpp:312
 #, c-format
 msgid "Failed to save the bitmap image to file \"%s\"."
 msgstr "Kunne ikke gemme bitmap-billede i filen \"%s\"."
 
-#: ../src/msw/dde.cpp:763
+#: ../src/msw/dde.cpp:811
 msgid "Failed to send DDE advise notification"
 msgstr "Kunne ikke sende DDE-advice påmindelse"
 
-#: ../src/common/ftp.cpp:402
+#: ../src/common/ftp.cpp:399
 #, c-format
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Kunne ikke sætte FTP transfer mode til %s."
 
-#: ../src/msw/clipbrd.cpp:427
+#: ../src/msw/clipbrd.cpp:443
 msgid "Failed to set clipboard data."
 msgstr "Kunne ikke sende data til udklipsholder."
 
-#: ../src/unix/snglinst.cpp:181
+#: ../src/unix/snglinst.cpp:178
 #, c-format
 msgid "Failed to set permissions on lock file '%s'"
 msgstr "Kunne ikke sætte rettigheder for Lock-filen \"%s\""
 
-#: ../src/unix/utilsunx.cpp:668
+#: ../src/unix/utilsunx.cpp:670
 msgid "Failed to set process priority"
 msgstr "Kunne ikke sætte procesprioritet"
 
-#: ../src/common/file.cpp:559
+#: ../src/common/ffile.cpp:355 ../src/common/file.cpp:586
 msgid "Failed to set temporary file permissions"
 msgstr "Kunne ikke sætte midlertidige filrettigheder"
 
-#: ../src/gtk/textctrl.cpp:1072
-msgid "Failed to set text in the text control."
-msgstr "Kunne ikke sætte tekst i tekstkontrollen."
-
-#: ../src/unix/threadpsx.cpp:1298
+#: ../src/unix/threadpsx.cpp:1347
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Kunne ikke sætte tråd-samtidighed-niveau til %lu"
 
-#: ../src/unix/threadpsx.cpp:1424
+#: ../src/unix/threadpsx.cpp:1473
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Kunne ikke sætte trådprioritet %d."
 
-#: ../src/unix/utilsunx.cpp:783
+#: ../src/unix/utilsunx.cpp:785
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr "Kunne ikke opsætte ikke-blokerende pipe. Programmet hænger muligvis."
 
-#: ../src/common/fs_mem.cpp:261
+#: ../src/msw/webview_ie.cpp:987
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:256
 #, c-format
 msgid "Failed to store image '%s' to memory VFS!"
 msgstr "Kunne ikke gemme billede \"%s\" i hukommelsen VFS!"
 
-#: ../src/dfb/evtloop.cpp:170
+#: ../src/dfb/evtloop.cpp:171
 msgid "Failed to switch DirectFB pipe to non-blocking mode"
 msgstr "Kunne ikke skifte DirectFB pipe til ikke-blokerende-tilstand"
 
-#: ../src/unix/wakeuppipe.cpp:59
+#: ../src/unix/wakeuppipe.cpp:56
 msgid "Failed to switch wake up pipe to non-blocking mode"
 msgstr "Kunne ikke skifte wake up pipe til ikke-blokerende-tilstand"
 
-#: ../src/unix/threadpsx.cpp:1605
+#: ../src/unix/threadpsx.cpp:1654
 msgid "Failed to terminate a thread."
 msgstr "Kunne ikke afslutte en tråd."
 
-#: ../src/msw/dde.cpp:741
+#: ../src/msw/dde.cpp:736
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "Kunne ikke afslutte advice loop med DDE-server"
 
-#: ../src/msw/dialup.cpp:938
+#: ../src/msw/dialup.cpp:932
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Kunne ikke afslutte netværk via modem forbindelse: %s"
 
-#: ../src/common/filename.cpp:2590
+#: ../src/common/filename.cpp:2673
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Kunne ikke røre (touch) filen \"%s\""
 
-#: ../src/unix/snglinst.cpp:334
+#: ../src/unix/dlunix.cpp:90
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "Kunne ikke åbne delt bibliotek \"%s\""
+
+#: ../src/unix/snglinst.cpp:331
 #, c-format
 msgid "Failed to unlock lock file '%s'"
 msgstr "Kunne ikke låse låsfilen \"%s\" op"
 
-#: ../src/msw/dde.cpp:309
+#: ../src/msw/dde.cpp:304
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Kunne ikke afregistrere DDE-serveren \"%s\""
@@ -3654,77 +3726,87 @@ msgstr "Kunne ikke afregistrere deskriptor %d fra epoll-deskriptor %d"
 msgid "Failed to update user configuration file."
 msgstr "Kunne ikke opdatere brugerkonfigurationsfil."
 
-#: ../src/common/debugrpt.cpp:733
+#: ../src/common/debugrpt.cpp:743
 #, c-format
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Kunne ikke uploade fejlfindingsrapport (fejlkode %d)."
 
-#: ../src/unix/snglinst.cpp:168
+#: ../src/unix/snglinst.cpp:165
 #, c-format
 msgid "Failed to write to lock file '%s'"
 msgstr "Kunne ikke skrive til låsfilen \"%s\""
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:209
+#: ../src/propgrid/propgrid.cpp:190
 msgid "False"
 msgstr "Falsk"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:694
+#: ../src/propgrid/advprops.cpp:604
 msgid "Family"
 msgstr "Familie"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/gtk/glcanvas.cpp:176 ../src/gtk/glcanvas.cpp:187
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Filfejl"
+
+#: ../src/common/stockitem.cpp:154
 msgid "File"
 msgstr "Fil"
 
-#: ../src/common/docview.cpp:669
+#: ../src/common/docview.cpp:664
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Filen \"%s\" kunne ikke åbnes for læsning."
 
-#: ../src/common/docview.cpp:646
+#: ../src/common/docview.cpp:641
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Filen \"%s\" kunne ikke åbnes for skrivning."
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "Filen \"%s\" findes allerede, vil du virkelig overskrive den?"
 
-#: ../src/common/filefn.cpp:1156
+#: ../src/common/filefn.cpp:1044
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Filen \"%s\" kunne ikke fjernes"
 
-#: ../src/common/filefn.cpp:1139
+#: ../src/common/filefn.cpp:1028
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Filen \"%s\" kunne ikke omdøbes til \"%s\""
 
-#: ../src/richtext/richtextctrl.cpp:3081 ../src/common/textcmn.cpp:953
+#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
 msgid "File couldn't be loaded."
 msgstr "Fil kunne ikke indlæses."
 
-#: ../src/msw/filedlg.cpp:393
+#: ../src/msw/filedlg.cpp:414
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Fildialog fejlede med fejlkode %0lx."
 
-#: ../src/common/docview.cpp:1789
+#: ../src/common/docview.cpp:1783
 msgid "File error"
 msgstr "Filfejl"
 
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/filectrlg.cpp:770
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/filectrlg.cpp:766
 msgid "File name exists already."
 msgstr "Filnavnet findes allerede."
+
+#: ../src/osx/cocoa/filedlg.mm:264
+#, fuzzy
+msgid "File type:"
+msgstr "Teletype"
 
 #: ../src/motif/filedlg.cpp:220
 msgid "Files"
 msgstr "Filer"
 
-#: ../src/common/filefn.cpp:1591
+#: ../src/common/filefn.cpp:1479
 #, c-format
 msgid "Files (%s)"
 msgstr "Filer (%s)"
@@ -3733,15 +3815,29 @@ msgstr "Filer (%s)"
 msgid "Filter"
 msgstr "Filter"
 
-#: ../src/common/stockitem.cpp:158 ../src/html/helpwnd.cpp:490
+#: ../src/html/helpwnd.cpp:488
 msgid "Find"
 msgstr "Find"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:259
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:258
+#, fuzzy
+msgid "Find in document"
+msgstr "Åbn HTML-dokument"
+
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "Find..."
+msgstr "Find"
+
+#: ../src/common/stockitem.cpp:156
 msgid "First"
 msgstr "Første"
 
-#: ../src/common/prntbase.cpp:1548
+#: ../src/common/prntbase.cpp:1573
 msgid "First page"
 msgstr "Første side"
 
@@ -3749,11 +3845,11 @@ msgstr "Første side"
 msgid "Fixed"
 msgstr "Fast"
 
-#: ../src/html/helpwnd.cpp:1206
+#: ../src/html/helpwnd.cpp:1204
 msgid "Fixed font:"
 msgstr "Fast type:"
 
-#: ../src/html/helpwnd.cpp:1269
+#: ../src/html/helpwnd.cpp:1267
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Fast skriftstørrelse.<br> <b>fed</b> <i>kursiv</i> "
 
@@ -3761,16 +3857,16 @@ msgstr "Fast skriftstørrelse.<br> <b>fed</b> <i>kursiv</i> "
 msgid "Floating"
 msgstr "Flydende"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "Floppy"
 msgstr "Floppy"
 
-#: ../src/common/paper.cpp:111
+#: ../src/common/paper.cpp:108
 msgid "Folio, 8 1/2 x 13 in"
 msgstr "Folio, 8 1/2 x 13 tommer"
 
-#: ../src/richtext/richtextformatdlg.cpp:344 ../src/osx/carbon/fontdlg.cpp:287
-#: ../src/common/stockitem.cpp:194
+#: ../src/osx/carbon/fontdlg.cpp:284 ../src/common/stockitem.cpp:191
+#: ../src/richtext/richtextformatdlg.cpp:337
 msgid "Font"
 msgstr "Skrifttype"
 
@@ -3778,7 +3874,24 @@ msgstr "Skrifttype"
 msgid "Font &weight:"
 msgstr "&Skrifttypevægt:"
 
-#: ../src/html/helpwnd.cpp:1207
+#: ../src/osx/fontutil.cpp:89
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
+"\"."
+msgstr ""
+
+#: ../src/msw/font.cpp:1126
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Fil kunne ikke indlæses."
+
+#: ../src/osx/fontutil.cpp:81
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr ": filen findes ikke!"
+
+#: ../src/html/helpwnd.cpp:1205
 msgid "Font size:"
 msgstr "Skriftstørrelse:"
 
@@ -3786,53 +3899,53 @@ msgstr "Skriftstørrelse:"
 msgid "Font st&yle:"
 msgstr "Skriftst&ypografi:"
 
-#: ../src/osx/carbon/fontdlg.cpp:329
+#: ../src/osx/carbon/fontdlg.cpp:326
 msgid "Font:"
 msgstr "Skrifttype:"
 
-#: ../src/dfb/fontmgr.cpp:198
+#: ../src/dfb/fontmgr.cpp:195
 #, c-format
 msgid "Fonts index file %s disappeared while loading fonts."
 msgstr "Skrifttypeindeksfil %s forsvandt, mens skrifttyper blev indlæst."
 
-#: ../src/unix/utilsunx.cpp:645
+#: ../src/unix/utilsunx.cpp:647
 msgid "Fork failed"
 msgstr "Fork fejlede"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "Forward"
 msgstr "Fremad"
 
-#: ../src/common/xtixml.cpp:235
+#: ../src/common/xtixml.cpp:231
 msgid "Forward hrefs are not supported"
 msgstr "Fremad hrefs understøttes ikke"
 
-#: ../src/html/helpwnd.cpp:875
+#: ../src/html/helpwnd.cpp:873
 #, c-format
 msgid "Found %i matches"
 msgstr "Fandt %i matchende"
 
-#: ../src/generic/prntdlgg.cpp:238
+#: ../src/generic/prntdlgg.cpp:231
 msgid "From:"
 msgstr "Fra:"
 
-#: ../src/propgrid/advprops.cpp:1604
+#: ../src/propgrid/advprops.cpp:1510
 msgid "Fuchsia"
 msgstr "Fuchsiafarvet"
 
-#: ../src/common/imaggif.cpp:138
+#: ../src/common/imaggif.cpp:135
 msgid "GIF: data stream seems to be truncated."
 msgstr "GIF: datastrøm tilsyneladende for kort."
 
-#: ../src/common/imaggif.cpp:128
+#: ../src/common/imaggif.cpp:125
 msgid "GIF: error in GIF image format."
 msgstr "GIF: fejl i GIF billedformat."
 
-#: ../src/common/imaggif.cpp:133
+#: ../src/common/imaggif.cpp:130
 msgid "GIF: not enough memory."
 msgstr "GIF: ikke nok ledig hukommelse."
 
-#: ../src/gtk/window.cpp:4631
+#: ../src/gtk/window.cpp:5635
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -3840,23 +3953,23 @@ msgstr ""
 "Den GTK+, som er installeret maskine, er for gammel til at understøtte "
 "skærmkomposition. Installer venligst GTK+ 2.12 eller senere."
 
-#: ../src/univ/themes/gtk.cpp:525
+#: ../src/univ/themes/gtk.cpp:522
 msgid "GTK+ theme"
 msgstr "GTK+ tema"
 
-#: ../src/common/preferencescmn.cpp:40
+#: ../src/common/preferencescmn.cpp:37
 msgid "General"
 msgstr "Generel"
 
-#: ../src/common/prntbase.cpp:258
+#: ../src/common/prntbase.cpp:253
 msgid "Generic PostScript"
 msgstr "Generisk PostScript"
 
-#: ../src/common/paper.cpp:135
+#: ../src/common/paper.cpp:132
 msgid "German Legal Fanfold, 8 1/2 x 13 in"
 msgstr "Tysk Legal Fanfold, 8 1/2 x 13 tommer"
 
-#: ../src/common/paper.cpp:134
+#: ../src/common/paper.cpp:131
 msgid "German Std Fanfold, 8 1/2 x 12 in"
 msgstr "Tysk Std Fanfold, 8 1/2 x 12 tommer"
 
@@ -3872,48 +3985,48 @@ msgstr "GetPropertyCollection kaldt på en generisk accessor"
 msgid "GetPropertyCollection called w/o valid collection getter"
 msgstr "GetPropertyCollection kaldt uden gyldig collection getter"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:658
 msgid "Go back"
 msgstr "Tilbage"
 
-#: ../src/html/helpwnd.cpp:661
+#: ../src/html/helpwnd.cpp:659
 msgid "Go forward"
 msgstr "Frem"
 
-#: ../src/html/helpwnd.cpp:663
+#: ../src/html/helpwnd.cpp:661
 msgid "Go one level up in document hierarchy"
 msgstr "Et niveau op i dokument hierarkiet"
 
-#: ../src/generic/filedlgg.cpp:208 ../src/generic/dirdlgg.cpp:116
+#: ../src/generic/filedlgg.cpp:205 ../src/generic/dirdlgg.cpp:113
 msgid "Go to home directory"
 msgstr "Gå til hjemmemappe"
 
-#: ../src/generic/filedlgg.cpp:205
+#: ../src/generic/filedlgg.cpp:202
 msgid "Go to parent directory"
 msgstr "Gå til overordnet mappe"
 
-#: ../src/generic/aboutdlgg.cpp:76
+#: ../src/generic/aboutdlgg.cpp:73
 msgid "Graphics art by "
 msgstr "Illustrationer af "
 
-#: ../src/propgrid/advprops.cpp:1599
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Gray"
 msgstr "Grå"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:883
+#: ../src/propgrid/advprops.cpp:784
 msgid "GrayText"
 msgstr "Grå tekst"
 
-#: ../src/common/fmapbase.cpp:154
+#: ../src/common/fmapbase.cpp:151
 msgid "Greek (ISO-8859-7)"
 msgstr "Græsk (ISO-8859-7)"
 
-#: ../src/propgrid/advprops.cpp:1600
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Green"
 msgstr "Grøn"
 
-#: ../src/generic/colrdlgg.cpp:342
+#: ../src/generic/colrdlgg.cpp:362
 msgid "Green:"
 msgstr "Grøn:"
 
@@ -3921,107 +4034,107 @@ msgstr "Grøn:"
 msgid "Groove"
 msgstr "Groove"
 
-#: ../src/common/zstream.cpp:158 ../src/common/zstream.cpp:318
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
 msgid "Gzip not supported by this version of zlib"
 msgstr "Gzip understøttes ikke af denne version af zlib"
 
-#: ../src/html/helpwnd.cpp:1549
+#: ../src/html/helpwnd.cpp:1547
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "HTML Hjælp-projekt (*.hhp)|*.hhp|"
 
-#: ../src/html/htmlwin.cpp:681
+#: ../src/html/htmlwin.cpp:691
 #, c-format
 msgid "HTML anchor %s does not exist."
 msgstr "HTML-anker %s findes ikke."
 
-#: ../src/html/helpwnd.cpp:1547
+#: ../src/html/helpwnd.cpp:1545
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "HTML-filer (*.html;*.htm)|*.html;*.htm|"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1759
+#: ../src/propgrid/advprops.cpp:1660
 msgid "Hand"
 msgstr "Hånd"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "Harddisk"
 msgstr "Harddisk"
 
-#: ../src/common/fmapbase.cpp:155
+#: ../src/common/fmapbase.cpp:152
 msgid "Hebrew (ISO-8859-8)"
 msgstr "Hebraisk (ISO-8859-8)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:280 ../src/osx/button_osx.cpp:39
-#: ../src/common/stockitem.cpp:163 ../src/common/accelcmn.cpp:80
-#: ../src/html/helpdlg.cpp:66 ../src/html/helpfrm.cpp:111
+#: ../include/wx/msgdlg.h:282 ../src/osx/button_osx.cpp:39
+#: ../src/common/stockitem.cpp:160 ../src/common/accelcmn.cpp:77
+#: ../src/html/helpfrm.cpp:108 ../src/html/helpdlg.cpp:63
 msgid "Help"
 msgstr "Hjælp"
 
-#: ../src/html/helpwnd.cpp:1200
+#: ../src/html/helpwnd.cpp:1198
 msgid "Help Browser Options"
 msgstr "Hjælp til browserindstillinger"
 
-#: ../src/generic/helpext.cpp:454 ../src/generic/helpext.cpp:455
+#: ../src/generic/helpext.cpp:452 ../src/generic/helpext.cpp:453
 msgid "Help Index"
 msgstr "Hjælp-indeks"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1529
 msgid "Help Printing"
 msgstr "Hjælp til udskrift"
 
-#: ../src/html/helpwnd.cpp:801
+#: ../src/html/helpwnd.cpp:799
 msgid "Help Topics"
 msgstr "Hjælp-emner"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1546
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Hjælp-bøger (*.htb)|*.htb|Hjælp-bøger (*.zip)|*.zip|"
 
-#: ../src/generic/helpext.cpp:267
+#: ../src/generic/helpext.cpp:265
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "Hjælp-mappen \"%s\" ikke fundet."
 
-#: ../src/generic/helpext.cpp:275
+#: ../src/generic/helpext.cpp:273
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "Hjælp-filen \"%s\" ikke fundet."
 
-#: ../src/html/helpctrl.cpp:63
+#: ../src/html/helpctrl.cpp:59
 #, c-format
 msgid "Help: %s"
 msgstr "Hjælp: %s"
 
-#: ../src/osx/menu_osx.cpp:577
+#: ../src/osx/menu_osx.cpp:469
 #, c-format
 msgid "Hide %s"
 msgstr "Skjul %s"
 
-#: ../src/osx/menu_osx.cpp:579
+#: ../src/osx/menu_osx.cpp:471
 msgid "Hide Others"
 msgstr "Skjul andre"
 
-#: ../src/generic/infobar.cpp:84
+#: ../src/generic/infobar.cpp:81
 msgid "Hide this notification message."
 msgstr "Skjul denne påmindelsesmeddelelse."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:884
+#: ../src/propgrid/advprops.cpp:785
 msgid "Highlight"
 msgstr "Fremhæv"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:885
+#: ../src/propgrid/advprops.cpp:786
 msgid "HighlightText"
 msgstr "Fremhævet tekst"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:164 ../src/common/accelcmn.cpp:65
+#: ../src/common/stockitem.cpp:161 ../src/common/accelcmn.cpp:62
 msgid "Home"
 msgstr "Hjem"
 
-#: ../src/generic/dirctrlg.cpp:524
+#: ../src/generic/dirctrlg.cpp:490
 msgid "Home directory"
 msgstr "Hjemmemappe"
 
@@ -4031,55 +4144,55 @@ msgid "How the object will float relative to the text."
 msgstr "Hvordan objektet placerer sig i forhold til teksten."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1760
+#: ../src/propgrid/advprops.cpp:1661
 msgid "I-Beam"
 msgstr "Lodret streg"
 
-#: ../src/common/imagbmp.cpp:1196
+#: ../src/common/imagbmp.cpp:1208
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: fejl ved læsning af maske DIB."
 
-#: ../src/common/imagbmp.cpp:1290 ../src/common/imagbmp.cpp:1390
-#: ../src/common/imagbmp.cpp:1405 ../src/common/imagbmp.cpp:1416
-#: ../src/common/imagbmp.cpp:1430 ../src/common/imagbmp.cpp:1478
-#: ../src/common/imagbmp.cpp:1493 ../src/common/imagbmp.cpp:1507
-#: ../src/common/imagbmp.cpp:1518
+#: ../src/common/imagbmp.cpp:1302 ../src/common/imagbmp.cpp:1402
+#: ../src/common/imagbmp.cpp:1417 ../src/common/imagbmp.cpp:1428
+#: ../src/common/imagbmp.cpp:1442 ../src/common/imagbmp.cpp:1490
+#: ../src/common/imagbmp.cpp:1505 ../src/common/imagbmp.cpp:1519
+#: ../src/common/imagbmp.cpp:1530
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: fejl ved skrivning af billedfilen!"
 
-#: ../src/common/imagbmp.cpp:1255
+#: ../src/common/imagbmp.cpp:1267
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: billede for højt til ikon."
 
-#: ../src/common/imagbmp.cpp:1263
+#: ../src/common/imagbmp.cpp:1275
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: billede for bredt til ikon."
 
-#: ../src/common/imagbmp.cpp:1603
+#: ../src/common/imagbmp.cpp:1615
 msgid "ICO: Invalid icon index."
 msgstr "ICO: ugyldigt ikonindeks."
 
-#: ../src/common/imagiff.cpp:758
+#: ../src/common/imagiff.cpp:755
 msgid "IFF: data stream seems to be truncated."
 msgstr "IFF: datastrøm tilsyneladende for kort."
 
-#: ../src/common/imagiff.cpp:742
+#: ../src/common/imagiff.cpp:739
 msgid "IFF: error in IFF image format."
 msgstr "IFF: fejl i IFF billedformat."
 
-#: ../src/common/imagiff.cpp:745
+#: ../src/common/imagiff.cpp:742
 msgid "IFF: not enough memory."
 msgstr "IFF: ikke nok ledig hukommelse."
 
-#: ../src/common/imagiff.cpp:748
+#: ../src/common/imagiff.cpp:745
 msgid "IFF: unknown error!!!"
 msgstr "IFF: ukendt fejl!!!"
 
-#: ../src/common/fmapbase.cpp:197
+#: ../src/common/fmapbase.cpp:194
 msgid "ISO-2022-JP"
 msgstr "ISO-2022-JP"
 
-#: ../src/html/htmprint.cpp:282
+#: ../src/html/htmprint.cpp:294
 msgid ""
 "If possible, try changing the layout parameters to make the printout more "
 "narrow."
@@ -4087,7 +4200,7 @@ msgstr ""
 "Hvis det er muligt, så prøv at ændre layout-parametrene, så udskriften "
 "bliver smallere."
 
-#: ../src/generic/dbgrptg.cpp:358
+#: ../src/generic/dbgrptg.cpp:362
 msgid ""
 "If you have any additional information pertaining to this bug\n"
 "report, please enter it here and it will be joined to it:"
@@ -4102,51 +4215,55 @@ msgid ""
 "but be warned that it may hinder improving the program, so if\n"
 "at all possible please do continue with the report generation.\n"
 msgstr ""
-"Hvis du helt vil undertrykke denne fejlfindingsrapport, så vælg "
-"\"Annullér\"-knappen.\n"
+"Hvis du helt vil undertrykke denne fejlfindingsrapport, så vælg \"Annullér\"-"
+"knappen.\n"
 "Det kan imidlertid hindre forbedringer i programmet, så hvis\n"
 "det overhovedet er muligt, så fortsæt med at genere rapporten.\n"
 
-#: ../src/msw/registry.cpp:1405
+#: ../src/common/zipstrm.cpp:1043
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1393
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Ignorerer værdien \"%s\" i nøglen \"%s\"."
 
-#: ../src/common/xtistrm.cpp:295
+#: ../src/common/xtistrm.cpp:292
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Ulovlig Objektklasse (ikke-wxEvtHandler) som Event Source"
 
-#: ../src/common/xti.cpp:513
+#: ../src/common/xti.cpp:510
 msgid "Illegal Parameter Count for ConstructObject Method"
 msgstr "Forkert antal parametre til ConstructObject metode"
 
-#: ../src/common/xti.cpp:501
+#: ../src/common/xti.cpp:498
 msgid "Illegal Parameter Count for Create Method"
 msgstr "Forkert antal parametre til Create metode"
 
-#: ../src/generic/dirctrlg.cpp:570 ../src/generic/filectrlg.cpp:756
+#: ../src/generic/dirctrlg.cpp:536 ../src/generic/filectrlg.cpp:752
 msgid "Illegal directory name."
 msgstr "Ulovligt mappenavn."
 
-#: ../src/generic/filectrlg.cpp:1367
+#: ../src/generic/filectrlg.cpp:1356
 msgid "Illegal file specification."
 msgstr "Ulovlig filspecifikation."
 
-#: ../src/common/image.cpp:2269
+#: ../src/common/image.cpp:2363
 msgid "Image and mask have different sizes."
 msgstr "Billede og maske har forskellige størrelser."
 
-#: ../src/common/image.cpp:2746
+#: ../src/common/image.cpp:2841
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "Billedfilen er ikke af type %d."
 
-#: ../src/common/image.cpp:2877
+#: ../src/common/image.cpp:2995
 #, c-format
 msgid "Image is not of type %s."
 msgstr "Billedet er ikke af typen %s."
 
-#: ../src/msw/textctrl.cpp:488
+#: ../src/msw/textctrl.cpp:534
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -4154,100 +4271,100 @@ msgstr ""
 "Kunne ikke oprette rich edit-kontrol, bruger i stedet en simpel "
 "tekstkontrol. Geninstallér venligst riched32.dll"
 
-#: ../src/unix/utilsunx.cpp:301
+#: ../src/unix/utilsunx.cpp:303
 msgid "Impossible to get child process input"
 msgstr "Kunne ikke få input til underproces"
 
-#: ../src/common/filefn.cpp:1028
+#: ../src/common/filefn.cpp:917
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Kunne ikke få rettigheder til filen \"%s\""
 
-#: ../src/common/filefn.cpp:1042
+#: ../src/common/filefn.cpp:931
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Kunne ikke overskrive filen \"%s\""
 
-#: ../src/common/filefn.cpp:1097
+#: ../src/common/filefn.cpp:986
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Kunne ikke sætte rettigheder for filen \"%s\""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:886
+#: ../src/propgrid/advprops.cpp:787
 msgid "InactiveBorder"
 msgstr "Inaktiv kant"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:887
+#: ../src/propgrid/advprops.cpp:788
 msgid "InactiveCaption"
 msgstr "Inaktiv overskrift"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:888
+#: ../src/propgrid/advprops.cpp:789
 msgid "InactiveCaptionText"
 msgstr "Inaktiv overskrifttekst"
 
-#: ../src/common/gifdecod.cpp:792
+#: ../src/common/gifdecod.cpp:826
 #, c-format
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "Forkert GIF billedstørrelse (%u, %d) for ramme #%u"
 
-#: ../src/msw/ole/automtn.cpp:635
+#: ../src/msw/ole/automtn.cpp:626
 msgid "Incorrect number of arguments."
 msgstr "Forkert antal argumenter."
 
-#: ../src/common/stockitem.cpp:165
+#: ../src/common/stockitem.cpp:162
 msgid "Indent"
 msgstr "Indryk"
 
-#: ../src/richtext/richtextformatdlg.cpp:349
+#: ../src/richtext/richtextformatdlg.cpp:342
 msgid "Indents && Spacing"
 msgstr "Indrykning og afstand"
 
-#: ../src/common/stockitem.cpp:166 ../src/html/helpwnd.cpp:515
+#: ../src/common/stockitem.cpp:163 ../src/html/helpwnd.cpp:513
 msgid "Index"
 msgstr "Indeks"
 
-#: ../src/common/fmapbase.cpp:159
+#: ../src/common/fmapbase.cpp:156
 msgid "Indian (ISO-8859-12)"
 msgstr "Indisk (ISO-8859-12)"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "Info"
 msgstr "Info"
 
-#: ../src/common/init.cpp:287
+#: ../src/common/init.cpp:284
 msgid "Initialization failed in post init, aborting."
 msgstr "Initialisering fejlede i efterinitialisering, afbryder."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:54
+#: ../src/common/accelcmn.cpp:51
 msgid "Ins"
 msgstr "Ins"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextsymboldlg.cpp:472 ../src/common/accelcmn.cpp:53
+#: ../src/common/accelcmn.cpp:50 ../src/richtext/richtextsymboldlg.cpp:469
 msgid "Insert"
 msgstr "Indsæt"
 
-#: ../src/richtext/richtextbuffer.cpp:8067
+#: ../src/richtext/richtextbuffer.cpp:8063
 msgid "Insert Field"
 msgstr "Indsæt felt"
 
-#: ../src/richtext/richtextbuffer.cpp:7978
-#: ../src/richtext/richtextbuffer.cpp:8936
+#: ../src/richtext/richtextbuffer.cpp:7974
+#: ../src/richtext/richtextbuffer.cpp:8934
 msgid "Insert Image"
 msgstr "Indsæt billede"
 
-#: ../src/richtext/richtextbuffer.cpp:8025
+#: ../src/richtext/richtextbuffer.cpp:8021
 msgid "Insert Object"
 msgstr "Indsæt objekt"
 
-#: ../src/richtext/richtextctrl.cpp:1286 ../src/richtext/richtextctrl.cpp:1494
-#: ../src/richtext/richtextbuffer.cpp:7822
-#: ../src/richtext/richtextbuffer.cpp:7852
-#: ../src/richtext/richtextbuffer.cpp:7894
+#: ../src/richtext/richtextbuffer.cpp:7818
+#: ../src/richtext/richtextbuffer.cpp:7848
+#: ../src/richtext/richtextbuffer.cpp:7890
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
 msgid "Insert Text"
 msgstr "Indsæt tekst"
 
@@ -4260,16 +4377,11 @@ msgstr "Indsætter et sideskift før afsnittet."
 msgid "Inset"
 msgstr "Sænket"
 
-#: ../src/gtk/app.cpp:425
-#, c-format
-msgid "Invalid GTK+ command line option, use \"%s --help\""
-msgstr "Ugyldig GTK+ kommandolinjetilvalg, brug \"%s --help\""
-
-#: ../src/common/imagtiff.cpp:311
+#: ../src/common/imagtiff.cpp:308
 msgid "Invalid TIFF image index."
 msgstr "Ugyldigt TIFF billedindeks."
 
-#: ../src/common/appcmn.cpp:273
+#: ../src/common/appcmn.cpp:294
 #, c-format
 msgid "Invalid display mode specification '%s'."
 msgstr "Ugyldig skærmtilstandsspecifikation \"%s\"."
@@ -4279,246 +4391,250 @@ msgstr "Ugyldig skærmtilstandsspecifikation \"%s\"."
 msgid "Invalid geometry specification '%s'"
 msgstr "Ugyldig geometrispecifikation \"%s\""
 
-#: ../src/unix/fswatcher_inotify.cpp:323
+#: ../src/unix/fswatcher_inotify.cpp:320
 #, c-format
 msgid "Invalid inotify event for \"%s\""
 msgstr "Ugyldig inotify-event for \"%s\""
 
-#: ../src/unix/snglinst.cpp:312
+#: ../src/unix/snglinst.cpp:309
 #, c-format
 msgid "Invalid lock file '%s'."
 msgstr "Ugyldig låsfil \"%s\"."
 
-#: ../src/common/translation.cpp:1125
+#: ../src/common/translation.cpp:1167
 msgid "Invalid message catalog."
 msgstr "Ugyldigt meddelelseskatalog."
 
-#: ../src/common/xtistrm.cpp:405 ../src/common/xtistrm.cpp:420
+#: ../src/common/xtistrm.cpp:402 ../src/common/xtistrm.cpp:417
 msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
 msgstr "Ugyldig eller null-objekt ID sendt til GetObjectClassInfo"
 
-#: ../src/common/xtistrm.cpp:435
+#: ../src/common/xtistrm.cpp:432
 msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
 msgstr "Ugyldig eller null-objekt ID sendt til HasObjectClassInfo"
 
-#: ../src/common/regex.cpp:310
+#: ../src/common/regex.cpp:307
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Ugyldigt regulært udtryk: \"%s\": %s"
 
-#: ../src/common/config.cpp:226
+#: ../src/common/config.cpp:222
 #, c-format
 msgid "Invalid value %ld for a boolean key \"%s\" in config file."
 msgstr "Ugyldig værdi %ld for en boolesk nøglen \"%s\" i konfigurationsfilen."
 
-#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:351
-#: ../src/osx/carbon/fontdlg.cpp:361 ../src/common/stockitem.cpp:168
+#: ../src/osx/carbon/fontdlg.cpp:358 ../src/common/stockitem.cpp:165
+#: ../src/generic/fontdlgg.cpp:325 ../src/richtext/richtextfontpage.cpp:351
 msgid "Italic"
 msgstr "Kursiv"
 
-#: ../src/common/paper.cpp:130
+#: ../src/common/paper.cpp:127
 msgid "Italy Envelope, 110 x 230 mm"
 msgstr "Italiensk konvolut, 110 x 230 mm"
 
-#: ../src/common/imagjpeg.cpp:270
+#: ../src/common/imagjpeg.cpp:257
 msgid "JPEG: Couldn't load - file is probably corrupted."
 msgstr "JPEG: kunne ikke læse - filen er sikkert defekt."
 
-#: ../src/common/imagjpeg.cpp:449
+#: ../src/common/imagjpeg.cpp:436
 msgid "JPEG: Couldn't save image."
 msgstr "JPEG: kunne ikke gemme billede."
 
-#: ../src/common/paper.cpp:163
+#: ../src/common/paper.cpp:160
 msgid "Japanese Double Postcard 200 x 148 mm"
 msgstr "Japansk dobbelt postkort 200 x 148 mm"
 
-#: ../src/common/paper.cpp:167
+#: ../src/common/paper.cpp:164
 msgid "Japanese Envelope Chou #3"
 msgstr "Japansk konvolut Chou #3"
 
-#: ../src/common/paper.cpp:180
+#: ../src/common/paper.cpp:177
 msgid "Japanese Envelope Chou #3 Rotated"
 msgstr "Japansk konvolut Chou #3 roteret"
 
-#: ../src/common/paper.cpp:168
+#: ../src/common/paper.cpp:165
 msgid "Japanese Envelope Chou #4"
 msgstr "Japansk konvolut Chou #4"
 
-#: ../src/common/paper.cpp:181
+#: ../src/common/paper.cpp:178
 msgid "Japanese Envelope Chou #4 Rotated"
 msgstr "Japansk konvolut Chou #4 roteret"
 
-#: ../src/common/paper.cpp:165
+#: ../src/common/paper.cpp:162
 msgid "Japanese Envelope Kaku #2"
 msgstr "Japansk konvolut Kaku #2"
 
-#: ../src/common/paper.cpp:178
+#: ../src/common/paper.cpp:175
 msgid "Japanese Envelope Kaku #2 Rotated"
 msgstr "Japansk konvolut Kaku #2 roteret"
 
-#: ../src/common/paper.cpp:166
+#: ../src/common/paper.cpp:163
 msgid "Japanese Envelope Kaku #3"
 msgstr "Japansk konvolut Kaku #3"
 
-#: ../src/common/paper.cpp:179
+#: ../src/common/paper.cpp:176
 msgid "Japanese Envelope Kaku #3 Rotated"
 msgstr "Japansk konvolut Kaku #3 roteret"
 
-#: ../src/common/paper.cpp:185
+#: ../src/common/paper.cpp:182
 msgid "Japanese Envelope You #4"
 msgstr "Japansk konvolut You #4"
 
-#: ../src/common/paper.cpp:186
+#: ../src/common/paper.cpp:183
 msgid "Japanese Envelope You #4 Rotated"
 msgstr "Japansk konvolut You #4 roteret"
 
-#: ../src/common/paper.cpp:138
+#: ../src/common/paper.cpp:135
 msgid "Japanese Postcard 100 x 148 mm"
 msgstr "Japansk postkort 100 x 148 mm"
 
-#: ../src/common/paper.cpp:175
+#: ../src/common/paper.cpp:172
 msgid "Japanese Postcard Rotated 148 x 100 mm"
 msgstr "Japansk postkort roteret 148 x 100 mm"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "Jump to"
 msgstr "Hop til"
 
-#: ../src/common/stockitem.cpp:171
+#: ../src/common/stockitem.cpp:168
 msgid "Justified"
 msgstr "Justeret"
 
-#: ../src/richtext/richtextindentspage.cpp:155
-#: ../src/richtext/richtextindentspage.cpp:157
 #: ../src/richtext/richtextliststylepage.cpp:344
 #: ../src/richtext/richtextliststylepage.cpp:346
+#: ../src/richtext/richtextindentspage.cpp:155
+#: ../src/richtext/richtextindentspage.cpp:157
 msgid "Justify text left and right."
 msgstr "Juster tekst venstre og højre."
 
-#: ../src/common/fmapbase.cpp:163
+#: ../src/common/fmapbase.cpp:160
 msgid "KOI8-R"
 msgstr "KOI8-R"
 
-#: ../src/common/fmapbase.cpp:164
+#: ../src/common/fmapbase.cpp:161
 msgid "KOI8-U"
 msgstr "KOI8-U"
 
-#: ../src/common/accelcmn.cpp:265 ../src/common/accelcmn.cpp:347
+#: ../src/common/accelcmn.cpp:279 ../src/common/accelcmn.cpp:364
 msgid "KP_"
 msgstr "KP_"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "KP_Add"
 msgstr "KP_Add"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "KP_Begin"
 msgstr "KP_Begin"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "KP_Decimal"
 msgstr "KP_Decimal"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 msgid "KP_Delete"
 msgstr "KP_Delete"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "KP_Divide"
 msgstr "KP_Divide"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 msgid "KP_Down"
 msgstr "KP_Ned"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "KP_End"
 msgstr "KP_End"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "KP_Enter"
 msgstr "KP_Enter"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "KP_Equal"
 msgstr "KP_Equal"
 
+#: ../src/common/accelcmn.cpp:276 ../src/common/accelcmn.cpp:361
+msgid "KP_F"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 msgid "KP_Home"
 msgstr "KP_Home"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 msgid "KP_Insert"
 msgstr "KP_Insert"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "KP_Left"
 msgstr "KP_Venstre"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "KP_Multiply"
 msgstr "KP_Multiply"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:99
+#: ../src/common/accelcmn.cpp:97
 msgid "KP_Next"
 msgstr "KP_Next"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "KP_PageDown"
 msgstr "KP_PageDown"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "KP_PageUp"
 msgstr "KP_PageUp"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:98
+#: ../src/common/accelcmn.cpp:96
 msgid "KP_Prior"
 msgstr "KP_Prior"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 msgid "KP_Right"
 msgstr "KP_Højre"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "KP_Separator"
 msgstr "KP_Separator"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "KP_Space"
 msgstr "KP_Mellemrum"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "KP_Subtract"
 msgstr "KP_Minus"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "KP_Tab"
 msgstr "KP_Tab"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "KP_Up"
 msgstr "KP_Op"
 
@@ -4526,112 +4642,127 @@ msgstr "KP_Op"
 msgid "L&ine spacing:"
 msgstr "L&injeafstand:"
 
-#: ../src/generic/prntdlgg.cpp:613 ../src/generic/prntdlgg.cpp:868
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "fejl ved komprimering"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "fejl ved udpakning"
+
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:861
 msgid "Landscape"
 msgstr "Liggende"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "Last"
 msgstr "Sidste"
 
-#: ../src/common/prntbase.cpp:1572
+#: ../src/common/prntbase.cpp:1597
 msgid "Last page"
 msgstr "Sidste side"
 
-#: ../src/common/log.cpp:305
+#: ../src/common/log.cpp:324
 #, c-format
 msgid "Last repeated message (\"%s\", %u time) wasn't output"
 msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
 msgstr[0] "Sidste gentagne meddelelse (\"%s\", %u gang) blev ikke vist"
 msgstr[1] "Sidste gentagne meddelelse (\"%s\", %u gange) blev ikke vist"
 
-#: ../src/common/paper.cpp:103
+#: ../src/common/paper.cpp:100
 msgid "Ledger, 17 x 11 in"
 msgstr "Ledger, 17 x 11 tommer"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6146
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:58 ../src/generic/datavgen.cpp:6951
+#: ../src/richtext/richtextsizepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:252
 #: ../src/richtext/richtextliststylepage.cpp:253
 #: ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
-#: ../src/richtext/richtextsizepage.cpp:249 ../src/common/accelcmn.cpp:61
 msgid "Left"
 msgstr "Venstre"
 
-#: ../src/richtext/richtextindentspage.cpp:204
 #: ../src/richtext/richtextliststylepage.cpp:390
+#: ../src/richtext/richtextindentspage.cpp:204
 msgid "Left (&first line):"
 msgstr "Venstre (&første linje):"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1761
+#: ../src/propgrid/advprops.cpp:1662
 msgid "Left Button"
 msgstr "Venstre knap"
 
-#: ../src/generic/prntdlgg.cpp:880
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Left margin (mm):"
 msgstr "Venstre margen (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:141
-#: ../src/richtext/richtextindentspage.cpp:143
 #: ../src/richtext/richtextliststylepage.cpp:330
 #: ../src/richtext/richtextliststylepage.cpp:332
+#: ../src/richtext/richtextindentspage.cpp:141
+#: ../src/richtext/richtextindentspage.cpp:143
 msgid "Left-align text."
 msgstr "Venstrejuster tekst."
 
-#: ../src/common/paper.cpp:144
+#: ../src/common/paper.cpp:141
 msgid "Legal Extra 9 1/2 x 15 in"
 msgstr "Legal ekstra 9 1/2 x 15 tommer"
 
-#: ../src/common/paper.cpp:96
+#: ../src/common/paper.cpp:93
 msgid "Legal, 8 1/2 x 14 in"
 msgstr "Legal, 8 1/2 x 14 tommer"
 
-#: ../src/common/paper.cpp:143
+#: ../src/common/paper.cpp:140
 msgid "Letter Extra 9 1/2 x 12 in"
 msgstr "Brev ekstra 9 1/2 x 12 tommer"
 
-#: ../src/common/paper.cpp:149
+#: ../src/common/paper.cpp:146
 msgid "Letter Extra Transverse 9.275 x 12 in"
 msgstr "Brev ekstra transverse 9.275 x 12 tommer"
 
-#: ../src/common/paper.cpp:152
+#: ../src/common/paper.cpp:149
 msgid "Letter Plus 8 1/2 x 12.69 in"
 msgstr "Brev plus 8 1/2 x 12.69 tommer"
 
-#: ../src/common/paper.cpp:169
+#: ../src/common/paper.cpp:166
 msgid "Letter Rotated 11 x 8 1/2 in"
 msgstr "Brev roteret 11 x 8 1/2 tommer"
 
-#: ../src/common/paper.cpp:101
+#: ../src/common/paper.cpp:98
 msgid "Letter Small, 8 1/2 x 11 in"
 msgstr "Brev lille, 8 1/2 x 11 tommer"
 
-#: ../src/common/paper.cpp:147
+#: ../src/common/paper.cpp:144
 msgid "Letter Transverse 8 1/2 x 11 in"
 msgstr "Brev transverse 8 1/2 x 11 tommer"
 
-#: ../src/common/paper.cpp:95
+#: ../src/common/paper.cpp:92
 msgid "Letter, 8 1/2 x 11 in"
 msgstr "Brev, 8 1/2 x 11 tommer"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "License"
 msgstr "Licens"
 
-#: ../src/generic/fontdlgg.cpp:332
+#: ../src/generic/fontdlgg.cpp:328
 msgid "Light"
 msgstr "Let"
 
-#: ../src/propgrid/advprops.cpp:1608
+#: ../src/propgrid/advprops.cpp:1514
 msgid "Lime"
 msgstr "Limegrøn"
 
-#: ../src/generic/helpext.cpp:294
+#: ../src/generic/helpext.cpp:292
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr "Linje %lu i map-filen \"%s\" har ugyldig syntaks, sprunget over."
@@ -4640,15 +4771,15 @@ msgstr "Linje %lu i map-filen \"%s\" har ugyldig syntaks, sprunget over."
 msgid "Line spacing:"
 msgstr "Linjeafstand:"
 
-#: ../src/html/chm.cpp:838
+#: ../src/html/chm.cpp:829
 msgid "Link contained '//', converted to absolute link."
 msgstr "Link indeholdt \"//\", konverteret til absolut link."
 
-#: ../src/richtext/richtextformatdlg.cpp:364
+#: ../src/richtext/richtextformatdlg.cpp:357
 msgid "List Style"
 msgstr "Listetypografi"
 
-#: ../src/richtext/richtextstyles.cpp:1064
+#: ../src/richtext/richtextstyles.cpp:1061
 msgid "List styles"
 msgstr "Listetypografier"
 
@@ -4662,26 +4793,26 @@ msgstr "Lister skriftstørrelser i punkter."
 msgid "Lists the available fonts."
 msgstr "Viser tilgængelige skrifttyper."
 
-#: ../src/common/fldlgcmn.cpp:340
+#: ../src/common/fldlgcmn.cpp:337
 #, c-format
 msgid "Load %s file"
 msgstr "Læs %s fil"
 
-#: ../src/html/htmlwin.cpp:597
+#: ../src/html/htmlwin.cpp:600
 msgid "Loading : "
 msgstr "Indlæser : "
 
-#: ../src/unix/snglinst.cpp:246
+#: ../src/unix/snglinst.cpp:243
 #, c-format
 msgid "Lock file '%s' has incorrect owner."
 msgstr "Låsfilen \"%s\" har en forkert ejer."
 
-#: ../src/unix/snglinst.cpp:251
+#: ../src/unix/snglinst.cpp:248
 #, c-format
 msgid "Lock file '%s' has incorrect permissions."
 msgstr "Låsfilen \"%s\" har forkerte rettigheder."
 
-#: ../src/generic/logg.cpp:576
+#: ../src/generic/logg.cpp:573
 #, c-format
 msgid "Log saved to the file '%s'."
 msgstr "Log gemt i filen \"%s\"."
@@ -4696,11 +4827,11 @@ msgstr "Små bogstaver"
 msgid "Lower case roman numerals"
 msgstr "Små romertal"
 
-#: ../src/gtk/mdi.cpp:422 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk1/mdi.cpp:431 ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "MDI-barn"
 
-#: ../src/msw/helpchm.cpp:56
+#: ../src/msw/helpchm.cpp:53
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -4708,189 +4839,189 @@ msgstr ""
 "MS HTML Hjælp-funktioner er ikke tilgængelig fordi MS HTML Hjælp-biblioteket "
 "ikke er installeret på denne computer. Vi foreslår at installere det."
 
-#: ../src/univ/themes/win32.cpp:3754
+#: ../src/univ/themes/win32.cpp:3751
 msgid "Ma&ximize"
 msgstr "Ma&ksimér"
 
-#: ../src/common/fmapbase.cpp:203
+#: ../src/common/fmapbase.cpp:200
 msgid "MacArabic"
 msgstr "MacArabic"
 
-#: ../src/common/fmapbase.cpp:222
+#: ../src/common/fmapbase.cpp:219
 msgid "MacArmenian"
 msgstr "MacArmenian"
 
-#: ../src/common/fmapbase.cpp:211
+#: ../src/common/fmapbase.cpp:208
 msgid "MacBengali"
 msgstr "MacBengali"
 
-#: ../src/common/fmapbase.cpp:217
+#: ../src/common/fmapbase.cpp:214
 msgid "MacBurmese"
 msgstr "MacBurmese"
 
-#: ../src/common/fmapbase.cpp:236
+#: ../src/common/fmapbase.cpp:233
 msgid "MacCeltic"
 msgstr "MacCeltic"
 
-#: ../src/common/fmapbase.cpp:227
+#: ../src/common/fmapbase.cpp:224
 msgid "MacCentralEurRoman"
 msgstr "MacCentralEurRoman"
 
-#: ../src/common/fmapbase.cpp:223
+#: ../src/common/fmapbase.cpp:220
 msgid "MacChineseSimp"
 msgstr "MacChineseSimp"
 
-#: ../src/common/fmapbase.cpp:201
+#: ../src/common/fmapbase.cpp:198
 msgid "MacChineseTrad"
 msgstr "MacChineseTrad"
 
-#: ../src/common/fmapbase.cpp:233
+#: ../src/common/fmapbase.cpp:230
 msgid "MacCroatian"
 msgstr "MacCroatian"
 
-#: ../src/common/fmapbase.cpp:206
+#: ../src/common/fmapbase.cpp:203
 msgid "MacCyrillic"
 msgstr "MacCyrillic"
 
-#: ../src/common/fmapbase.cpp:207
+#: ../src/common/fmapbase.cpp:204
 msgid "MacDevanagari"
 msgstr "MacDevanagari"
 
-#: ../src/common/fmapbase.cpp:231
+#: ../src/common/fmapbase.cpp:228
 msgid "MacDingbats"
 msgstr "MacDingbats"
 
-#: ../src/common/fmapbase.cpp:226
+#: ../src/common/fmapbase.cpp:223
 msgid "MacEthiopic"
 msgstr "MacEthiopic"
 
-#: ../src/common/fmapbase.cpp:229
+#: ../src/common/fmapbase.cpp:226
 msgid "MacExtArabic"
 msgstr "MacExtArabic"
 
-#: ../src/common/fmapbase.cpp:237
+#: ../src/common/fmapbase.cpp:234
 msgid "MacGaelic"
 msgstr "MacGaelic"
 
-#: ../src/common/fmapbase.cpp:221
+#: ../src/common/fmapbase.cpp:218
 msgid "MacGeorgian"
 msgstr "MacGeorgian"
 
-#: ../src/common/fmapbase.cpp:205
+#: ../src/common/fmapbase.cpp:202
 msgid "MacGreek"
 msgstr "MacGreek"
 
-#: ../src/common/fmapbase.cpp:209
+#: ../src/common/fmapbase.cpp:206
 msgid "MacGujarati"
 msgstr "MacGujarati"
 
-#: ../src/common/fmapbase.cpp:208
+#: ../src/common/fmapbase.cpp:205
 msgid "MacGurmukhi"
 msgstr "MacGurmukhi"
 
-#: ../src/common/fmapbase.cpp:204
+#: ../src/common/fmapbase.cpp:201
 msgid "MacHebrew"
 msgstr "MacHebrew"
 
-#: ../src/common/fmapbase.cpp:234
+#: ../src/common/fmapbase.cpp:231
 msgid "MacIcelandic"
 msgstr "MacIcelandic"
 
-#: ../src/common/fmapbase.cpp:200
+#: ../src/common/fmapbase.cpp:197
 msgid "MacJapanese"
 msgstr "MacJapanese"
 
-#: ../src/common/fmapbase.cpp:214
+#: ../src/common/fmapbase.cpp:211
 msgid "MacKannada"
 msgstr "MacKannada"
 
-#: ../src/common/fmapbase.cpp:238
+#: ../src/common/fmapbase.cpp:235
 msgid "MacKeyboardGlyphs"
 msgstr "MacKeyboardGlyphs"
 
-#: ../src/common/fmapbase.cpp:218
+#: ../src/common/fmapbase.cpp:215
 msgid "MacKhmer"
 msgstr "MacKhmer"
 
-#: ../src/common/fmapbase.cpp:202
+#: ../src/common/fmapbase.cpp:199
 msgid "MacKorean"
 msgstr "MacKorean"
 
-#: ../src/common/fmapbase.cpp:220
+#: ../src/common/fmapbase.cpp:217
 msgid "MacLaotian"
 msgstr "MacLaotian"
 
-#: ../src/common/fmapbase.cpp:215
+#: ../src/common/fmapbase.cpp:212
 msgid "MacMalayalam"
 msgstr "MacMalayalam"
 
-#: ../src/common/fmapbase.cpp:225
+#: ../src/common/fmapbase.cpp:222
 msgid "MacMongolian"
 msgstr "MacMongolian"
 
-#: ../src/common/fmapbase.cpp:210
+#: ../src/common/fmapbase.cpp:207
 msgid "MacOriya"
 msgstr "MacOriya"
 
-#: ../src/common/fmapbase.cpp:199
+#: ../src/common/fmapbase.cpp:196
 msgid "MacRoman"
 msgstr "MacRoman"
 
-#: ../src/common/fmapbase.cpp:235
+#: ../src/common/fmapbase.cpp:232
 msgid "MacRomanian"
 msgstr "MacRomanian"
 
-#: ../src/common/fmapbase.cpp:216
+#: ../src/common/fmapbase.cpp:213
 msgid "MacSinhalese"
 msgstr "MacSinhalese"
 
-#: ../src/common/fmapbase.cpp:230
+#: ../src/common/fmapbase.cpp:227
 msgid "MacSymbol"
 msgstr "MacSymbol"
 
-#: ../src/common/fmapbase.cpp:212
+#: ../src/common/fmapbase.cpp:209
 msgid "MacTamil"
 msgstr "MacTamil"
 
-#: ../src/common/fmapbase.cpp:213
+#: ../src/common/fmapbase.cpp:210
 msgid "MacTelugu"
 msgstr "MacTelugu"
 
-#: ../src/common/fmapbase.cpp:219
+#: ../src/common/fmapbase.cpp:216
 msgid "MacThai"
 msgstr "MacThai"
 
-#: ../src/common/fmapbase.cpp:224
+#: ../src/common/fmapbase.cpp:221
 msgid "MacTibetan"
 msgstr "MacTibetan"
 
-#: ../src/common/fmapbase.cpp:232
+#: ../src/common/fmapbase.cpp:229
 msgid "MacTurkish"
 msgstr "MacTurkish"
 
-#: ../src/common/fmapbase.cpp:228
+#: ../src/common/fmapbase.cpp:225
 msgid "MacVietnamese"
 msgstr "MacVietnamese"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1762
+#: ../src/propgrid/advprops.cpp:1663
 msgid "Magnifier"
 msgstr "Forstørrelsesglas"
 
-#: ../src/propgrid/advprops.cpp:2143
+#: ../src/propgrid/advprops.cpp:2050
 msgid "Make a selection:"
 msgstr "Foretag et valg:"
 
-#: ../src/richtext/richtextformatdlg.cpp:374
+#: ../src/richtext/richtextformatdlg.cpp:367
 #: ../src/richtext/richtextmarginspage.cpp:171
 msgid "Margins"
 msgstr "Margener"
 
-#: ../src/propgrid/advprops.cpp:1595
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Maroon"
 msgstr "Rødbrun"
 
-#: ../src/generic/fdrepdlg.cpp:147
+#: ../src/generic/fdrepdlg.cpp:144
 msgid "Match case"
 msgstr "Forskel på store og små bogstaver"
 
@@ -4902,40 +5033,40 @@ msgstr "Maks. højde:"
 msgid "Max width:"
 msgstr "Maks. bredde:"
 
-#: ../src/unix/mediactrl.cpp:947
+#: ../src/unix/mediactrl.cpp:972
 #, c-format
 msgid "Media playback error: %s"
 msgstr "Medieafspilningsfejl: %s"
 
-#: ../src/common/fs_mem.cpp:175
+#: ../src/common/fs_mem.cpp:170
 #, c-format
 msgid "Memory VFS already contains file '%s'!"
 msgstr "Hukommelse VFS indeholder allerede filen \"%s\"!"
 
 #. TRANSLATORS: Name of keyboard key
 #. TRANSLATORS: Keyword of system colour
-#: ../src/common/accelcmn.cpp:73 ../src/propgrid/advprops.cpp:889
+#: ../src/common/accelcmn.cpp:70 ../src/propgrid/advprops.cpp:790
 msgid "Menu"
 msgstr "Menu"
 
-#: ../src/common/msgout.cpp:124
+#: ../src/common/msgout.cpp:121
 msgid "Message"
 msgstr "Meddelelse"
 
-#: ../src/univ/themes/metal.cpp:168
+#: ../src/univ/themes/metal.cpp:165
 msgid "Metal theme"
 msgstr "Metal tema"
 
-#: ../src/msw/ole/automtn.cpp:652
+#: ../src/msw/ole/automtn.cpp:643
 msgid "Method or property not found."
 msgstr "Metode eller egenskab ikke fundet."
 
-#: ../src/univ/themes/win32.cpp:3752
+#: ../src/univ/themes/win32.cpp:3749
 msgid "Mi&nimize"
 msgstr "Mi&nimér"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1763
+#: ../src/propgrid/advprops.cpp:1664
 msgid "Middle Button"
 msgstr "Midterknap"
 
@@ -4947,37 +5078,42 @@ msgstr "Min. højde:"
 msgid "Min width:"
 msgstr "Min. bredde:"
 
-#: ../src/msw/ole/automtn.cpp:668
+#: ../src/osx/cocoa/menu.mm:281
+#, fuzzy
+msgid "Minimize"
+msgstr "Mi&nimér"
+
+#: ../src/msw/ole/automtn.cpp:659
 msgid "Missing a required parameter."
 msgstr "Mangler krævet parameter."
 
-#: ../src/generic/fontdlgg.cpp:324
+#: ../src/generic/fontdlgg.cpp:320
 msgid "Modern"
 msgstr "Moderne"
 
-#: ../src/generic/filectrlg.cpp:427
+#: ../src/generic/filectrlg.cpp:423
 msgid "Modified"
 msgstr "Ændret"
 
-#: ../src/common/module.cpp:133
+#: ../src/common/module.cpp:130
 #, c-format
 msgid "Module \"%s\" initialization failed"
 msgstr "Modul \"%s\" initialisering fejlede"
 
-#: ../src/common/paper.cpp:131
+#: ../src/common/paper.cpp:128
 msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
 msgstr "Monarch konvolut, 3 7/8 x 7 1/2 tommer"
 
-#: ../src/msw/fswatcher.cpp:143
+#: ../src/msw/fswatcher.cpp:140
 msgid "Monitoring individual files for changes is not supported currently."
 msgstr ""
 "Overvågning af ændringer på enkelte filer understøttes ikke i øjeblikket."
 
-#: ../src/generic/editlbox.cpp:172
+#: ../src/generic/editlbox.cpp:160
 msgid "Move down"
 msgstr "Flyt ned"
 
-#: ../src/generic/editlbox.cpp:171
+#: ../src/generic/editlbox.cpp:155
 msgid "Move up"
 msgstr "Flyt op"
 
@@ -4991,97 +5127,103 @@ msgstr "Flytter objektet til det næste afsnit."
 msgid "Moves the object to the previous paragraph."
 msgstr "Flytter objektet til det forrige afsnit."
 
-#: ../src/richtext/richtextbuffer.cpp:9966
+#: ../src/richtext/richtextbuffer.cpp:9963
 msgid "Multiple Cell Properties"
 msgstr "Egenskaber for flere celler"
 
-#: ../src/generic/filectrlg.cpp:424
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:82
+#, fuzzy
+msgid "Multiply"
+msgstr "KP_Multiply"
+
+#: ../src/generic/filectrlg.cpp:420
 msgid "Name"
 msgstr "Navn"
 
-#: ../src/propgrid/advprops.cpp:1596
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Navy"
 msgstr "Marineblå"
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "Network"
 msgstr "Netværk"
 
-#: ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173
 msgid "New"
 msgstr "Ny"
 
-#: ../src/richtext/richtextstyledlg.cpp:243
+#: ../src/richtext/richtextstyledlg.cpp:239
 msgid "New &Box Style..."
 msgstr "Ny &bokstypografi..."
 
-#: ../src/richtext/richtextstyledlg.cpp:225
+#: ../src/richtext/richtextstyledlg.cpp:221
 msgid "New &Character Style..."
 msgstr "Ny &tegntypografi..."
 
-#: ../src/richtext/richtextstyledlg.cpp:237
+#: ../src/richtext/richtextstyledlg.cpp:233
 msgid "New &List Style..."
 msgstr "Ny &listetypografi..."
 
-#: ../src/richtext/richtextstyledlg.cpp:231
+#: ../src/richtext/richtextstyledlg.cpp:227
 msgid "New &Paragraph Style..."
 msgstr "Ny &afsnitstypografi..."
 
-#: ../src/richtext/richtextstyledlg.cpp:606
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:654
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:820
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:893
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:934
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:602
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:650
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:816
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:889
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:930
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "New Style"
 msgstr "Ny typografi"
 
-#: ../src/generic/editlbox.cpp:169
+#: ../src/generic/editlbox.cpp:139
 msgid "New item"
 msgstr "Nyt objekt"
 
-#: ../src/generic/dirdlgg.cpp:297 ../src/generic/dirdlgg.cpp:307
-#: ../src/generic/filectrlg.cpp:618 ../src/generic/filectrlg.cpp:627
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+#: ../src/generic/dirdlgg.cpp:294 ../src/generic/dirdlgg.cpp:304
 msgid "NewName"
 msgstr "NytNavn"
 
-#: ../src/common/prntbase.cpp:1567 ../src/html/helpwnd.cpp:665
+#: ../src/common/prntbase.cpp:1592 ../src/html/helpwnd.cpp:663
 msgid "Next page"
 msgstr "Næste side"
 
-#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:177
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:174
 #: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Nej"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1764
+#: ../src/propgrid/advprops.cpp:1665
 msgid "No Entry"
 msgstr "Ingen adgang"
 
-#: ../src/generic/animateg.cpp:150
+#: ../src/generic/animateg.cpp:133
 #, c-format
 msgid "No animation handler for type %ld defined."
 msgstr "Ingen animationsbehandler defineret for type %ld."
 
-#: ../src/dfb/bitmap.cpp:642 ../src/dfb/bitmap.cpp:676
+#: ../src/dfb/bitmap.cpp:639 ../src/dfb/bitmap.cpp:673
 #, c-format
 msgid "No bitmap handler for type %d defined."
 msgstr "Ingen bitmap-behandler defineret for type %d."
 
-#: ../src/common/utilscmn.cpp:1077
+#: ../src/common/utilscmn.cpp:1095
 msgid "No default application configured for HTML files."
 msgstr "Intet standardprogram konfigureret for HTML-filer."
 
-#: ../src/generic/helpext.cpp:445
+#: ../src/generic/helpext.cpp:443
 msgid "No entries found."
 msgstr "Ingen indgange fundet."
 
-#: ../src/common/fontmap.cpp:421
+#: ../src/common/fontmap.cpp:418
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found,\n"
@@ -5093,7 +5235,7 @@ msgstr ""
 "men en alternativ kodning \"%s\" er tilgængelig.\n"
 "Vil du bruge denne kodning (eller skal du vælge en anden)?"
 
-#: ../src/common/fontmap.cpp:426
+#: ../src/common/fontmap.cpp:423
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found.\n"
@@ -5104,201 +5246,201 @@ msgstr ""
 "Vil du vælge en skrifttype til brug for denne kodning\n"
 "(ellers bliver tekst i denne kodning ikke vist korrekt)?"
 
-#: ../src/generic/animateg.cpp:142
+#: ../src/generic/animateg.cpp:125
 msgid "No handler found for animation type."
 msgstr "Ingen rutine fundet til denne animationstype."
 
-#: ../src/common/image.cpp:2728
+#: ../src/common/image.cpp:2823
 msgid "No handler found for image type."
 msgstr "Ingen rutine fundet til denne billedtype."
 
-#: ../src/common/image.cpp:2736 ../src/common/image.cpp:2848
-#: ../src/common/image.cpp:2901
+#: ../src/common/image.cpp:2831 ../src/common/image.cpp:2954
+#: ../src/common/image.cpp:3020
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "Ingen billedrutine defineret for type %d."
 
-#: ../src/common/image.cpp:2871 ../src/common/image.cpp:2915
+#: ../src/common/image.cpp:2986 ../src/common/image.cpp:3034
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "Ingen billedrutine defineret for type %s."
 
-#: ../src/html/helpwnd.cpp:858
+#: ../src/html/helpwnd.cpp:856
 msgid "No matching page found yet"
 msgstr "Fandt ingen passende side endnu"
 
-#: ../src/unix/sound.cpp:81
+#: ../src/unix/sound.cpp:78
 msgid "No sound"
 msgstr "Ingen lyd"
 
-#: ../src/common/image.cpp:2277 ../src/common/image.cpp:2318
+#: ../src/common/image.cpp:2371 ../src/common/image.cpp:2412
 msgid "No unused colour in image being masked."
 msgstr "Ingen ubrugte farver i det billede, der skal maskes."
 
-#: ../src/common/image.cpp:3374
-msgid "No unused colour in image."
-msgstr "Ingen ubrugte farver i det billede."
-
-#: ../src/generic/helpext.cpp:302
+#: ../src/generic/helpext.cpp:300
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "Ingen gyldige kortlægninger fundet i filen \"%s\"."
 
-#: ../src/richtext/richtextborderspage.cpp:610
 #: ../src/richtext/richtextsizepage.cpp:248
 #: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:610
 msgid "None"
 msgstr "Ingen"
 
-#: ../src/common/fmapbase.cpp:157
+#: ../src/common/fmapbase.cpp:154
 msgid "Nordic (ISO-8859-10)"
 msgstr "Nordisk (ISO-8859-10)"
 
-#: ../src/generic/fontdlgg.cpp:328 ../src/generic/fontdlgg.cpp:331
+#: ../src/generic/fontdlgg.cpp:324 ../src/generic/fontdlgg.cpp:327
 msgid "Normal"
 msgstr "Normal"
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1261
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Normal skrift<br>og <u>understreget</u>. "
 
-#: ../src/html/helpwnd.cpp:1205
+#: ../src/html/helpwnd.cpp:1203
 msgid "Normal font:"
 msgstr "Normal skrift:"
 
-#: ../src/propgrid/props.cpp:1128
+#: ../src/propgrid/props.cpp:1115
 #, c-format
 msgid "Not %s"
 msgstr "Ikke %s"
 
-#: ../include/wx/filename.h:573 ../include/wx/filename.h:578
-msgid "Not available"
-msgstr "Ikke tilgængelig"
+#: ../src/common/secretstore.cpp:168
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/webrequest.cpp:605
+msgid "Not enough free disk space for download."
+msgstr ""
 
 #: ../src/richtext/richtextfontpage.cpp:358
 msgid "Not underlined"
 msgstr "Ikke understreget"
 
-#: ../src/common/paper.cpp:115
+#: ../src/common/paper.cpp:112
 msgid "Note, 8 1/2 x 11 in"
 msgstr "Note, 8 1/2 x 11 tommer"
 
-#: ../src/generic/notifmsgg.cpp:132
+#: ../src/generic/notifmsgg.cpp:129
 msgid "Notice"
 msgstr "Note"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "Num *"
 msgstr "Num *"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "Num +"
 msgstr "Num +"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "Num ,"
 msgstr "Num ,"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "Num -"
 msgstr "Num -"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "Num ."
 msgstr "Num ."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "Num /"
 msgstr "Num /"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "Num ="
 msgstr "Num ="
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "Num Begin"
 msgstr "Num Begin"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 msgid "Num Delete"
 msgstr "Num Delete"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 msgid "Num Down"
 msgstr "Num Down"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "Num End"
 msgstr "Num End"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "Num Enter"
 msgstr "Num Enter"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 msgid "Num Home"
 msgstr "Num Home"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 msgid "Num Insert"
 msgstr "Num Insert"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num Lock"
 msgstr "Num Lock"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "Num Page Down"
 msgstr "Num Page Down"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "Num Page Up"
 msgstr "Num Page Up"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 msgid "Num Right"
 msgstr "Num Right"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "Num Space"
 msgstr "Num Space"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "Num Tab"
 msgstr "Num Tab"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "Num Up"
 msgstr "Num Up"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "Num left"
 msgstr "Num left"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num_lock"
 msgstr "Num_lock"
 
@@ -5307,13 +5449,13 @@ msgstr "Num_lock"
 msgid "Numbered outline"
 msgstr "Nummereret disposition"
 
-#: ../include/wx/msgdlg.h:278 ../src/richtext/richtextstyledlg.cpp:297
-#: ../src/common/stockitem.cpp:178 ../src/msw/msgdlg.cpp:454
-#: ../src/msw/msgdlg.cpp:747 ../src/gtk1/fontdlg.cpp:138
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:175
+#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/msgdlg.cpp:741 ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "OK"
 
-#: ../src/msw/ole/automtn.cpp:692
+#: ../src/msw/ole/automtn.cpp:683
 #, c-format
 msgid "OLE Automation error in %s: %s"
 msgstr "OLE automatiseringsfejl i %s: %s"
@@ -5322,15 +5464,15 @@ msgstr "OLE automatiseringsfejl i %s: %s"
 msgid "Object Properties"
 msgstr "Objektegenskaber"
 
-#: ../src/msw/ole/automtn.cpp:660
+#: ../src/msw/ole/automtn.cpp:651
 msgid "Object implementation does not support named arguments."
 msgstr "Objektimplementering understøtter ikke navngivne argumenter."
 
-#: ../src/common/xtixml.cpp:264
+#: ../src/common/xtixml.cpp:260
 msgid "Objects must have an id attribute"
 msgstr "Objekter skal have en id-attribut"
 
-#: ../src/propgrid/advprops.cpp:1601
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Olive"
 msgstr "Oliven"
 
@@ -5338,64 +5480,69 @@ msgstr "Oliven"
 msgid "Opaci&ty:"
 msgstr "Opaci&tet:"
 
-#: ../src/generic/colrdlgg.cpp:354
+#: ../src/generic/colrdlgg.cpp:374
 msgid "Opacity:"
 msgstr "Opacitet:"
 
-#: ../src/common/docview.cpp:1773 ../src/common/docview.cpp:1815
+#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
 msgid "Open File"
 msgstr "Åbn fil"
 
-#: ../src/html/helpwnd.cpp:671 ../src/html/helpwnd.cpp:1554
+#: ../src/html/helpwnd.cpp:669 ../src/html/helpwnd.cpp:1552
 msgid "Open HTML document"
 msgstr "Åbn HTML-dokument"
 
-#: ../src/generic/dbgrptg.cpp:163
+#: ../src/common/stockitem.cpp:265
+#, fuzzy
+msgid "Open an existing document"
+msgstr "Åbn HTML-dokument"
+
+#: ../src/generic/dbgrptg.cpp:160
 #, c-format
 msgid "Open file \"%s\""
 msgstr "Åbn filen \"%s\""
 
-#: ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176
 msgid "Open..."
 msgstr "Åbn..."
 
-#: ../src/unix/glx11.cpp:506 ../src/msw/glcanvas.cpp:592
+#: ../src/msw/glcanvas.cpp:607 ../src/unix/glx11.cpp:513
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr "OpenGL 3.0 eller senere understøttes ikke af OpenGL-driveren."
 
-#: ../src/generic/dirctrlg.cpp:599 ../src/generic/dirdlgg.cpp:323
-#: ../src/generic/filectrlg.cpp:642 ../src/generic/filectrlg.cpp:786
+#: ../src/generic/dirctrlg.cpp:565 ../src/generic/filectrlg.cpp:638
+#: ../src/generic/filectrlg.cpp:782 ../src/generic/dirdlgg.cpp:320
 msgid "Operation not permitted."
 msgstr "Handling ikke tilladt."
 
-#: ../src/common/cmdline.cpp:900
+#: ../src/common/cmdline.cpp:896
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "Tilvalget \"%s\" kan ikke annulleres"
 
-#: ../src/common/cmdline.cpp:1064
+#: ../src/common/cmdline.cpp:1060
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "Tilvalget \"%s\" kræver en værdi."
 
-#: ../src/common/cmdline.cpp:1147
+#: ../src/common/cmdline.cpp:1143
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Tilvalget \"%s\": \"%s\" kan ikke konverteres til en dato."
 
-#: ../src/generic/prntdlgg.cpp:618
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Indstillinger"
 
-#: ../src/propgrid/advprops.cpp:1606
+#: ../src/propgrid/advprops.cpp:1512
 msgid "Orange"
 msgstr "Orange"
 
-#: ../src/generic/prntdlgg.cpp:615 ../src/generic/prntdlgg.cpp:869
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:862
 msgid "Orientation"
 msgstr "Orientering"
 
-#: ../src/common/windowid.cpp:242
+#: ../src/common/windowid.cpp:237
 msgid "Out of window IDs.  Recommend shutting down application."
 msgstr "Ikke flere vindue ID'er. Anbefaler at lukke programmet."
 
@@ -5408,148 +5555,148 @@ msgstr "Disposition"
 msgid "Outset"
 msgstr "Start"
 
-#: ../src/msw/ole/automtn.cpp:656
+#: ../src/msw/ole/automtn.cpp:647
 msgid "Overflow while coercing argument values."
 msgstr "Overflow under tilpasning af argumentværdier."
 
-#: ../src/common/imagpcx.cpp:457 ../src/common/imagpcx.cpp:480
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:479
 msgid "PCX: couldn't allocate memory"
 msgstr "PCX: kunne ikke tildele hukommelse"
 
-#: ../src/common/imagpcx.cpp:456
+#: ../src/common/imagpcx.cpp:455
 msgid "PCX: image format unsupported"
 msgstr "PCX: billedformat ikke understøttet"
 
-#: ../src/common/imagpcx.cpp:479
+#: ../src/common/imagpcx.cpp:478
 msgid "PCX: invalid image"
 msgstr "PCX: ugyldigt billede"
 
-#: ../src/common/imagpcx.cpp:442
+#: ../src/common/imagpcx.cpp:441
 msgid "PCX: this is not a PCX file."
 msgstr "PCX: dette er ikke en PCX-fil."
 
-#: ../src/common/imagpcx.cpp:459 ../src/common/imagpcx.cpp:481
+#: ../src/common/imagpcx.cpp:458 ../src/common/imagpcx.cpp:480
 msgid "PCX: unknown error !!!"
 msgstr "PCX: ukendt fejl!!!"
 
-#: ../src/common/imagpcx.cpp:458
+#: ../src/common/imagpcx.cpp:457
 msgid "PCX: version number too low"
 msgstr "PCX: for lavt versionsnummer"
 
-#: ../src/common/imagpnm.cpp:91
+#: ../src/common/imagpnm.cpp:89
 msgid "PNM: Couldn't allocate memory."
 msgstr "PNM: kunne ikke tildele hukommelse."
 
-#: ../src/common/imagpnm.cpp:73
+#: ../src/common/imagpnm.cpp:71
 msgid "PNM: File format is not recognized."
 msgstr "PNM: filformatet ikke genkendt."
 
-#: ../src/common/imagpnm.cpp:112 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
 #: ../src/common/imagpnm.cpp:156
 msgid "PNM: File seems truncated."
 msgstr "PNM: filen synes at være afskåret."
 
-#: ../src/common/paper.cpp:187
+#: ../src/common/paper.cpp:184
 msgid "PRC 16K 146 x 215 mm"
 msgstr "PRC 16K 146 x 215 mm"
 
-#: ../src/common/paper.cpp:200
+#: ../src/common/paper.cpp:197
 msgid "PRC 16K Rotated"
 msgstr "PRC 16K roteret"
 
-#: ../src/common/paper.cpp:188
+#: ../src/common/paper.cpp:185
 msgid "PRC 32K 97 x 151 mm"
 msgstr "PRC 32K 97 x 151 mm"
 
-#: ../src/common/paper.cpp:201
+#: ../src/common/paper.cpp:198
 msgid "PRC 32K Rotated"
 msgstr "PRC 32K roteret"
 
-#: ../src/common/paper.cpp:189
+#: ../src/common/paper.cpp:186
 msgid "PRC 32K(Big) 97 x 151 mm"
 msgstr "PRC 32K(Big) 97 x 151 mm"
 
-#: ../src/common/paper.cpp:202
+#: ../src/common/paper.cpp:199
 msgid "PRC 32K(Big) Rotated"
 msgstr "PRC 32K(Big) roteret"
 
-#: ../src/common/paper.cpp:190
+#: ../src/common/paper.cpp:187
 msgid "PRC Envelope #1 102 x 165 mm"
 msgstr "PRC konvolut #1 102 x 165 mm"
 
-#: ../src/common/paper.cpp:203
+#: ../src/common/paper.cpp:200
 msgid "PRC Envelope #1 Rotated 165 x 102 mm"
 msgstr "PRC konvolut #1 roteret 165 x 102 mm"
 
-#: ../src/common/paper.cpp:199
+#: ../src/common/paper.cpp:196
 msgid "PRC Envelope #10 324 x 458 mm"
 msgstr "PRC konvolut #10 324 x 458 mm"
 
-#: ../src/common/paper.cpp:212
+#: ../src/common/paper.cpp:209
 msgid "PRC Envelope #10 Rotated 458 x 324 mm"
 msgstr "PRC konvolut #10 roteret 458 x 324 mm"
 
-#: ../src/common/paper.cpp:191
+#: ../src/common/paper.cpp:188
 msgid "PRC Envelope #2 102 x 176 mm"
 msgstr "PRC konvolut #2 102 x 176 mm"
 
-#: ../src/common/paper.cpp:204
+#: ../src/common/paper.cpp:201
 msgid "PRC Envelope #2 Rotated 176 x 102 mm"
 msgstr "PRC konvolut #2 roteret 176 x 102 mm"
 
-#: ../src/common/paper.cpp:192
+#: ../src/common/paper.cpp:189
 msgid "PRC Envelope #3 125 x 176 mm"
 msgstr "PRC konvolut #3 125 x 176 mm"
 
-#: ../src/common/paper.cpp:205
+#: ../src/common/paper.cpp:202
 msgid "PRC Envelope #3 Rotated 176 x 125 mm"
 msgstr "PRC konvolut #3 roteret 176 x 125 mm"
 
-#: ../src/common/paper.cpp:193
+#: ../src/common/paper.cpp:190
 msgid "PRC Envelope #4 110 x 208 mm"
 msgstr "PRC konvolut #4 110 x 208 mm"
 
-#: ../src/common/paper.cpp:206
+#: ../src/common/paper.cpp:203
 msgid "PRC Envelope #4 Rotated 208 x 110 mm"
 msgstr "PRC konvolut #4 roteret 208 x 110 mm"
 
-#: ../src/common/paper.cpp:194
+#: ../src/common/paper.cpp:191
 msgid "PRC Envelope #5 110 x 220 mm"
 msgstr "PRC konvolut #5 110 x 220 mm"
 
-#: ../src/common/paper.cpp:207
+#: ../src/common/paper.cpp:204
 msgid "PRC Envelope #5 Rotated 220 x 110 mm"
 msgstr "PRC konvolut #5 roteret 220 x 110 mm"
 
-#: ../src/common/paper.cpp:195
+#: ../src/common/paper.cpp:192
 msgid "PRC Envelope #6 120 x 230 mm"
 msgstr "PRC konvolut #6 120 x 230 mm"
 
-#: ../src/common/paper.cpp:208
+#: ../src/common/paper.cpp:205
 msgid "PRC Envelope #6 Rotated 230 x 120 mm"
 msgstr "PRC konvolut #6 roteret 230 x 120 mm"
 
-#: ../src/common/paper.cpp:196
+#: ../src/common/paper.cpp:193
 msgid "PRC Envelope #7 160 x 230 mm"
 msgstr "PRC konvolut #7 160 x 230 mm"
 
-#: ../src/common/paper.cpp:209
+#: ../src/common/paper.cpp:206
 msgid "PRC Envelope #7 Rotated 230 x 160 mm"
 msgstr "PRC konvolut #7 roteret 230 x 160 mm"
 
-#: ../src/common/paper.cpp:197
+#: ../src/common/paper.cpp:194
 msgid "PRC Envelope #8 120 x 309 mm"
 msgstr "PRC konvolut #8 120 x 309 mm"
 
-#: ../src/common/paper.cpp:210
+#: ../src/common/paper.cpp:207
 msgid "PRC Envelope #8 Rotated 309 x 120 mm"
 msgstr "PRC konvolut #8 roteret 309 x 120 mm"
 
-#: ../src/common/paper.cpp:198
+#: ../src/common/paper.cpp:195
 msgid "PRC Envelope #9 229 x 324 mm"
 msgstr "PRC konvolut #9 229 x 324 mm"
 
-#: ../src/common/paper.cpp:211
+#: ../src/common/paper.cpp:208
 msgid "PRC Envelope #9 Rotated 324 x 229 mm"
 msgstr "PRC konvolut #9 roteret 324 x 229 mm"
 
@@ -5557,87 +5704,91 @@ msgstr "PRC konvolut #9 roteret 324 x 229 mm"
 msgid "Padding"
 msgstr "Indre margen"
 
-#: ../src/common/prntbase.cpp:2074
+#: ../src/common/prntbase.cpp:2096
 #, c-format
 msgid "Page %d"
 msgstr "Side %d"
 
-#: ../src/common/prntbase.cpp:2072
+#: ../src/common/prntbase.cpp:2094
 #, c-format
 msgid "Page %d of %d"
 msgstr "Side %d af %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 msgid "Page Down"
 msgstr "Side ned"
 
-#: ../src/gtk/print.cpp:826
+#: ../src/gtk/print.cpp:829
 msgid "Page Setup"
 msgstr "Sideopsætning"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 msgid "Page Up"
 msgstr "Side op"
 
-#: ../src/generic/prntdlgg.cpp:828 ../src/common/prntbase.cpp:484
+#: ../src/common/prntbase.cpp:479 ../src/generic/prntdlgg.cpp:821
 msgid "Page setup"
 msgstr "Sideopsætning"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 msgid "PageDown"
 msgstr "PageDown"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 msgid "PageUp"
 msgstr "PageUp"
 
-#: ../src/generic/prntdlgg.cpp:216
+#: ../src/generic/prntdlgg.cpp:209
 msgid "Pages"
 msgstr "Sider"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1765
+#: ../src/propgrid/advprops.cpp:1666
 msgid "Paint Brush"
 msgstr "Malerpensel"
 
-#: ../src/generic/prntdlgg.cpp:602 ../src/generic/prntdlgg.cpp:801
-#: ../src/generic/prntdlgg.cpp:842 ../src/generic/prntdlgg.cpp:855
-#: ../src/generic/prntdlgg.cpp:1052 ../src/generic/prntdlgg.cpp:1057
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:794
+#: ../src/generic/prntdlgg.cpp:835 ../src/generic/prntdlgg.cpp:848
+#: ../src/generic/prntdlgg.cpp:1045 ../src/generic/prntdlgg.cpp:1050
 msgid "Paper size"
 msgstr "Papirstørrelse"
 
-#: ../src/richtext/richtextstyles.cpp:1062
+#: ../src/richtext/richtextstyles.cpp:1059
 msgid "Paragraph styles"
 msgstr "Afsnitstypografier"
 
-#: ../src/common/xtistrm.cpp:465
+#: ../src/common/xtistrm.cpp:462
 msgid "Passing a already registered object to SetObject"
 msgstr "Sender et allerede registreret objekt til SetObject"
 
-#: ../src/common/xtistrm.cpp:476
+#: ../src/common/xtistrm.cpp:473
 msgid "Passing an unknown object to GetObject"
 msgstr "Sender et ukendt objekt til GetObject"
 
-#: ../src/richtext/richtextctrl.cpp:3513 ../src/common/stockitem.cpp:180
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:177 ../src/richtext/richtextctrl.cpp:3514
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Sæt ind"
 
-#: ../src/common/stockitem.cpp:262
+#: ../src/common/stockitem.cpp:260
 msgid "Paste selection"
 msgstr "Indsæt markering"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:74
+#: ../src/common/accelcmn.cpp:71
 msgid "Pause"
 msgstr "Pause"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1766
+#: ../src/propgrid/advprops.cpp:1667
 msgid "Pencil"
 msgstr "Pen"
 
@@ -5646,21 +5797,21 @@ msgstr "Pen"
 msgid "Peri&od"
 msgstr "Punkt&um"
 
-#: ../src/generic/filectrlg.cpp:430
+#: ../src/generic/filectrlg.cpp:426
 msgid "Permissions"
 msgstr "Tilladelser"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:60
+#: ../src/common/accelcmn.cpp:57
 msgid "PgDn"
 msgstr "PgDn"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:59
+#: ../src/common/accelcmn.cpp:56
 msgid "PgUp"
 msgstr "PgUp"
 
-#: ../src/richtext/richtextbuffer.cpp:12868
+#: ../src/richtext/richtextbuffer.cpp:12863
 msgid "Picture Properties"
 msgstr "Billedegenskaber"
 
@@ -5672,42 +5823,42 @@ msgstr "Pipe oprettelse fejlede"
 msgid "Please choose a valid font."
 msgstr "Vælg venligst en gyldig skrifttype."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
 msgid "Please choose an existing file."
 msgstr "Vælg venligst en eksisterende fil."
 
-#: ../src/html/helpwnd.cpp:800
+#: ../src/html/helpwnd.cpp:798
 msgid "Please choose the page to display:"
 msgstr "Vælg siden der skal vises:"
 
-#: ../src/msw/dialup.cpp:764
+#: ../src/msw/dialup.cpp:758
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Vælg venligst den ISP, du vil oprette forbindelse til"
 
-#: ../src/common/headerctrlcmn.cpp:59
+#: ../src/common/headerctrlcmn.cpp:57
 msgid "Please select the columns to show and define their order:"
 msgstr "Vælg de kolonner, der skal vises, og definer rækkefølge:"
 
-#: ../src/common/prntbase.cpp:538
+#: ../src/common/prntbase.cpp:533
 msgid "Please wait while printing..."
 msgstr "Vent, mens der udskrives..."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1767
+#: ../src/propgrid/advprops.cpp:1668
 msgid "Point Left"
 msgstr "Peg-venstre"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1768
+#: ../src/propgrid/advprops.cpp:1669
 msgid "Point Right"
 msgstr "Peg-højre"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:662
+#: ../src/propgrid/advprops.cpp:572
 msgid "Point Size"
 msgstr "Punktstørrelse"
 
-#: ../src/generic/prntdlgg.cpp:612 ../src/generic/prntdlgg.cpp:867
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:860
 msgid "Portrait"
 msgstr "Opretstående"
 
@@ -5715,253 +5866,262 @@ msgstr "Opretstående"
 msgid "Position"
 msgstr "Position"
 
-#: ../src/generic/prntdlgg.cpp:298
+#: ../src/generic/prntdlgg.cpp:291
 msgid "PostScript file"
 msgstr "PostScript-fil"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178 ../src/osx/cocoa/preferences.mm:303
 msgid "Preferences"
 msgstr "Indstillinger"
 
-#: ../src/osx/menu_osx.cpp:568
+#: ../src/osx/menu_osx.cpp:460
 msgid "Preferences..."
 msgstr "Indstillinger..."
 
-#: ../src/common/prntbase.cpp:546
+#: ../src/common/prntbase.cpp:541
 msgid "Preparing"
 msgstr "Forbereder"
 
-#: ../src/generic/fontdlgg.cpp:455 ../src/osx/carbon/fontdlg.cpp:390
-#: ../src/html/helpwnd.cpp:1222
+#: ../src/osx/carbon/fontdlg.cpp:387 ../src/generic/fontdlgg.cpp:452
+#: ../src/html/helpwnd.cpp:1220
 msgid "Preview:"
 msgstr "Udskriftsvisning:"
 
-#: ../src/common/prntbase.cpp:1553 ../src/html/helpwnd.cpp:664
+#: ../src/common/prntbase.cpp:1578 ../src/html/helpwnd.cpp:662
 msgid "Previous page"
 msgstr "Foregående side"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/prntdlgg.cpp:143 ../src/generic/prntdlgg.cpp:157
-#: ../src/common/prntbase.cpp:426 ../src/common/prntbase.cpp:1541
-#: ../src/common/accelcmn.cpp:77 ../src/gtk/print.cpp:620
-#: ../src/gtk/print.cpp:638
+#: ../src/common/prntbase.cpp:421 ../src/common/prntbase.cpp:1566
+#: ../src/common/accelcmn.cpp:74 ../src/generic/prntdlgg.cpp:136
+#: ../src/generic/prntdlgg.cpp:150 ../src/gtk/print.cpp:616
+#: ../src/gtk/print.cpp:634
 msgid "Print"
 msgstr "Udskriv"
 
-#: ../include/wx/prntbase.h:399 ../src/common/docview.cpp:1268
+#: ../src/common/docview.cpp:1262
 msgid "Print Preview"
 msgstr "Udskriftsvisning"
 
-#: ../src/common/prntbase.cpp:2015 ../src/common/prntbase.cpp:2057
-#: ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2037 ../src/common/prntbase.cpp:2079
+#: ../src/common/prntbase.cpp:2087
 msgid "Print Preview Failure"
 msgstr "Udskriftsvisning fejlede"
 
-#: ../src/generic/prntdlgg.cpp:224
+#: ../src/generic/prntdlgg.cpp:217
 msgid "Print Range"
 msgstr "Udskriv sider"
 
-#: ../src/generic/prntdlgg.cpp:449
+#: ../src/generic/prntdlgg.cpp:442
 msgid "Print Setup"
 msgstr "Udskriftsopsætning"
 
-#: ../src/generic/prntdlgg.cpp:621
+#: ../src/generic/prntdlgg.cpp:614
 msgid "Print in colour"
 msgstr "Udskriv i farver"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/osx/webview_webkit.mm:260
+msgid "Print operation could not be initialized"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:179
 msgid "Print previe&w..."
 msgstr "Udskrifts&visning..."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1256
 msgid "Print preview creation failed."
 msgstr "Oprettelse af udskriftsvisning fejlede."
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/common/stockitem.cpp:179
 msgid "Print preview..."
 msgstr "Udskriftsvisning..."
 
-#: ../src/generic/prntdlgg.cpp:630
+#: ../src/generic/prntdlgg.cpp:623
 msgid "Print spooling"
 msgstr "Udskriftsspooling"
 
-#: ../src/html/helpwnd.cpp:675
+#: ../src/html/helpwnd.cpp:673
 msgid "Print this page"
 msgstr "Udskriv denne side"
 
-#: ../src/generic/prntdlgg.cpp:185
+#: ../src/generic/prntdlgg.cpp:178
 msgid "Print to File"
 msgstr "Udskriv til fil"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "Print..."
 msgstr "Udskriv..."
 
-#: ../src/generic/prntdlgg.cpp:493
+#: ../src/generic/prntdlgg.cpp:486
 msgid "Printer"
 msgstr "Printer"
 
-#: ../src/generic/prntdlgg.cpp:633
+#: ../src/generic/prntdlgg.cpp:626
 msgid "Printer command:"
 msgstr "Printerkommando:"
 
-#: ../src/generic/prntdlgg.cpp:180
+#: ../src/generic/prntdlgg.cpp:173
 msgid "Printer options"
 msgstr "Printervalg"
 
-#: ../src/generic/prntdlgg.cpp:645
+#: ../src/generic/prntdlgg.cpp:638
 msgid "Printer options:"
 msgstr "Printervalg:"
 
-#: ../src/generic/prntdlgg.cpp:916
+#: ../src/generic/prntdlgg.cpp:909
 msgid "Printer..."
 msgstr "Printer..."
 
-#: ../src/generic/prntdlgg.cpp:196
+#: ../src/generic/prntdlgg.cpp:189
 msgid "Printer:"
 msgstr "Printer:"
 
-#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:535
-#: ../src/html/htmprint.cpp:277
+#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:530
+#: ../src/html/htmprint.cpp:289
 msgid "Printing"
 msgstr "Udskriver"
 
-#: ../src/common/prntbase.cpp:612
+#: ../src/common/prntbase.cpp:607
 msgid "Printing "
 msgstr "Udskriver "
 
-#: ../src/common/prntbase.cpp:347
+#: ../src/common/prntbase.cpp:342
 msgid "Printing Error"
 msgstr "Udskriftsfejl"
 
-#: ../src/common/prntbase.cpp:565
+#: ../src/osx/webview_webkit.mm:251
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "Gzip understøttes ikke af denne version af zlib"
+
+#: ../src/common/prntbase.cpp:560
 #, c-format
 msgid "Printing page %d"
 msgstr "Udskriver side %d"
 
-#: ../src/common/prntbase.cpp:570
+#: ../src/common/prntbase.cpp:565
 #, c-format
 msgid "Printing page %d of %d"
 msgstr "Udskriver side %d af %d"
 
-#: ../src/generic/printps.cpp:201
+#: ../src/generic/printps.cpp:182
 #, c-format
 msgid "Printing page %d..."
 msgstr "Udskriver side %d..."
 
-#: ../src/generic/printps.cpp:161
+#: ../src/generic/printps.cpp:142
 msgid "Printing..."
 msgstr "Udskriver..."
 
-#: ../include/wx/richtext/richtextprint.h:109 ../include/wx/prntbase.h:267
-#: ../src/common/docview.cpp:2132
+#: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
+#: ../src/common/docview.cpp:2137
 msgid "Printout"
 msgstr "Udskrift"
 
-#: ../src/common/debugrpt.cpp:560
+#: ../src/common/debugrpt.cpp:561
 #, c-format
 msgid ""
 "Processing debug report has failed, leaving the files in \"%s\" directory."
 msgstr ""
-"Behandling af fejlfindingsrapport fejlede. Efterlader filerne i mappen "
-"\"%s\"."
+"Behandling af fejlfindingsrapport fejlede. Efterlader filerne i mappen \"%s"
+"\"."
 
-#: ../src/common/prntbase.cpp:545
+#: ../src/common/prntbase.cpp:540
 msgid "Progress:"
 msgstr "Behandling:"
 
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181
 msgid "Properties"
 msgstr "Egenskaber"
 
-#: ../src/propgrid/manager.cpp:237
+#: ../src/propgrid/manager.cpp:223
 msgid "Property"
 msgstr "Egenskab"
 
 #. TRANSLATORS: Caption of message box displaying any property error
-#: ../src/propgrid/propgrid.cpp:3185 ../src/propgrid/propgrid.cpp:3318
+#: ../src/propgrid/propgrid.cpp:3162 ../src/propgrid/propgrid.cpp:3299
 msgid "Property Error"
 msgstr "Fejl i egenskab"
 
-#: ../src/propgrid/advprops.cpp:1597
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Purple"
 msgstr "Lilla"
 
-#: ../src/common/paper.cpp:112
+#: ../src/common/paper.cpp:109
 msgid "Quarto, 215 x 275 mm"
 msgstr "Quarto, 215 x 275 mm"
 
-#: ../src/generic/logg.cpp:1016
+#: ../src/generic/logg.cpp:1013
 msgid "Question"
 msgstr "Spørgsmål"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1769
+#: ../src/propgrid/advprops.cpp:1670
 msgid "Question Arrow"
 msgstr "Spørgsmålspil"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "Quit"
 msgstr "Afslut"
 
-#: ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:477
 #, c-format
 msgid "Quit %s"
 msgstr "Afslut %s"
 
-#: ../src/common/stockitem.cpp:263
+#: ../src/common/stockitem.cpp:261
 msgid "Quit this program"
 msgstr "Afslut dette program"
 
-#: ../src/common/accelcmn.cpp:338
+#: ../src/common/accelcmn.cpp:352
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/ffile.cpp:109 ../src/common/ffile.cpp:133
+#: ../src/common/ffile.cpp:107 ../src/common/ffile.cpp:132
 #, c-format
 msgid "Read error on file '%s'"
 msgstr "Læsefejl på filen \"%s\""
 
-#: ../src/common/secretstore.cpp:199
-#, c-format
-msgid "Reading password for \"%s/%s\" failed: %s."
+#: ../src/common/secretstore.cpp:211
+#, fuzzy, c-format
+msgid "Reading password for \"%s\" failed: %s."
 msgstr "Kunne ikke læse adganskode for \"%s/%s\": %s."
 
-#: ../src/common/prntbase.cpp:272
+#: ../src/common/prntbase.cpp:267
 msgid "Ready"
 msgstr "Klar"
 
-#: ../src/propgrid/advprops.cpp:1605
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Red"
 msgstr "Rød"
 
-#: ../src/generic/colrdlgg.cpp:339
+#: ../src/generic/colrdlgg.cpp:359
 msgid "Red:"
 msgstr "Rød:"
 
-#: ../src/common/stockitem.cpp:185 ../src/stc/stc_i18n.cpp:16
+#: ../src/common/stockitem.cpp:182 ../src/stc/stc_i18n.cpp:16
 msgid "Redo"
 msgstr "Omgør"
 
-#: ../src/common/stockitem.cpp:264
+#: ../src/common/stockitem.cpp:262
 msgid "Redo last action"
 msgstr "Omgør seneste handling"
 
-#: ../src/common/stockitem.cpp:186
+#: ../src/common/stockitem.cpp:183
 msgid "Refresh"
 msgstr "Opdatér"
 
-#: ../src/msw/registry.cpp:626
+#: ../src/msw/registry.cpp:615
 #, c-format
 msgid "Registry key '%s' already exists."
 msgstr "Registreringsnøglen \"%s\" findes allerede."
 
-#: ../src/msw/registry.cpp:595
+#: ../src/msw/registry.cpp:584
 #, c-format
 msgid "Registry key '%s' does not exist, cannot rename it."
 msgstr "Registreringsnøglen \"%s\" findes ikke og kan ikke omdøbes."
 
-#: ../src/msw/registry.cpp:727
+#: ../src/msw/registry.cpp:716
 #, c-format
 msgid ""
 "Registry key '%s' is needed for normal system operation,\n"
@@ -5972,22 +6132,22 @@ msgstr ""
 "hvis du sletter den vil efterlade dit system i ubrugelig tilstand:\n"
 "operationen blev afbrudt."
 
-#: ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:942
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr "Registreringsværdien \"%s\" er ikke binær (men af typen %s)"
 
-#: ../src/msw/registry.cpp:917
+#: ../src/msw/registry.cpp:905
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr "Registreringsværdien \"%s\" er ikke numerisk (men af typen %s)"
 
-#: ../src/msw/registry.cpp:1003
+#: ../src/msw/registry.cpp:991
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr "Registreringsværdien \"%s\" er ikke tekst (men af typen %s)"
 
-#: ../src/msw/registry.cpp:521
+#: ../src/msw/registry.cpp:510
 #, c-format
 msgid "Registry value '%s' already exists."
 msgstr "Registreringsværdien \"%s\" findes allerede."
@@ -6001,71 +6161,77 @@ msgstr "Normal"
 msgid "Relative"
 msgstr "Relativ"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:456
 msgid "Relevant entries:"
 msgstr "Relevante indgange:"
 
-#: ../include/wx/generic/progdlgg.h:86
+#: ../include/wx/generic/progdlgg.h:87
 msgid "Remaining time:"
 msgstr "Resterende tid:"
 
-#: ../src/common/stockitem.cpp:187
+#: ../src/common/stockitem.cpp:184
 msgid "Remove"
 msgstr "Fjern"
 
-#: ../src/richtext/richtextctrl.cpp:1562
+#: ../src/richtext/richtextctrl.cpp:1563
 msgid "Remove Bullet"
 msgstr "Fjern punkttegn"
 
-#: ../src/html/helpwnd.cpp:433
+#: ../src/html/helpwnd.cpp:431
 msgid "Remove current page from bookmarks"
 msgstr "Fjern den aktuelle side fra bogmærkerne"
 
-#: ../src/common/rendcmn.cpp:194
+#: ../src/common/rendcmn.cpp:191
 #, c-format
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 "Gengiver \"%s\" er en inkompatibel version %d.%d og kunne ikke indlæses."
 
-#: ../src/richtext/richtextbuffer.cpp:4527
+#: ../src/richtext/richtextbuffer.cpp:4524
 msgid "Renumber List"
 msgstr "Renummerer liste"
 
-#: ../src/common/stockitem.cpp:188
-msgid "Rep&lace"
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Rep&lace..."
 msgstr "&Erstat"
 
-#: ../src/richtext/richtextctrl.cpp:3673 ../src/common/stockitem.cpp:188
+#: ../src/richtext/richtextctrl.cpp:3674
 msgid "Replace"
 msgstr "Erstat"
 
-#: ../src/generic/fdrepdlg.cpp:182
+#: ../src/generic/fdrepdlg.cpp:179
 msgid "Replace &all"
 msgstr "Erstat &alle"
 
-#: ../src/common/stockitem.cpp:261
-msgid "Replace selection"
-msgstr "Erstat markering"
-
-#: ../src/generic/fdrepdlg.cpp:124
+#: ../src/generic/fdrepdlg.cpp:121
 msgid "Replace with:"
 msgstr "Erstat med:"
 
-#: ../src/common/valtext.cpp:163
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Replace..."
+msgstr "Erstat"
+
+#: ../src/common/valtext.cpp:184
 msgid "Required information entry is empty."
 msgstr "Krævet oplysning er tom."
 
-#: ../src/common/translation.cpp:1975
+#: ../src/common/translation.cpp:2025
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "Ressource \"%s\" er ikke et gyldigt meddelelseskatalog."
 
+#: ../src/gtk/webview_webkit.cpp:985
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:56
+#: ../src/common/accelcmn.cpp:53
 msgid "Return"
 msgstr "Retur"
 
-#: ../src/common/stockitem.cpp:189
+#: ../src/common/stockitem.cpp:186
 msgid "Revert to Saved"
 msgstr "Tilbagefør til gemt"
 
@@ -6077,41 +6243,41 @@ msgstr "Ryg"
 msgid "Rig&ht-to-left"
 msgstr "&Højre-mod-venstre"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6149
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:59 ../src/generic/datavgen.cpp:6954
+#: ../src/richtext/richtextsizepage.cpp:250
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextbulletspage.cpp:188
-#: ../src/richtext/richtextsizepage.cpp:250 ../src/common/accelcmn.cpp:62
 msgid "Right"
 msgstr "Højre"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1754
+#: ../src/propgrid/advprops.cpp:1655
 msgid "Right Arrow"
 msgstr "Højre-pil"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1770
+#: ../src/propgrid/advprops.cpp:1671
 msgid "Right Button"
 msgstr "Højre knap"
 
-#: ../src/generic/prntdlgg.cpp:892
+#: ../src/generic/prntdlgg.cpp:885
 msgid "Right margin (mm):"
 msgstr "Højre margen (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:148
-#: ../src/richtext/richtextindentspage.cpp:150
 #: ../src/richtext/richtextliststylepage.cpp:337
 #: ../src/richtext/richtextliststylepage.cpp:339
+#: ../src/richtext/richtextindentspage.cpp:148
+#: ../src/richtext/richtextindentspage.cpp:150
 msgid "Right-align text."
 msgstr "Højrejuster tekst."
 
-#: ../src/generic/fontdlgg.cpp:322
+#: ../src/generic/fontdlgg.cpp:318
 msgid "Roman"
 msgstr "Roman"
 
-#: ../src/generic/datavgen.cpp:5916
+#: ../src/generic/datavgen.cpp:6721
 #, c-format
 msgid "Row %i"
 msgstr "Række %i"
@@ -6121,30 +6287,31 @@ msgstr "Række %i"
 msgid "S&tandard bullet name:"
 msgstr "Navn på s&tandard-punkttegn:"
 
-#: ../src/common/accelcmn.cpp:268 ../src/common/accelcmn.cpp:350
+#: ../src/common/accelcmn.cpp:282 ../src/common/accelcmn.cpp:367
 msgid "SPECIAL"
 msgstr "SPECIEL"
 
-#: ../src/common/stockitem.cpp:190 ../src/common/sizer.cpp:2797
+#: ../src/common/stockitem.cpp:187 ../src/common/sizer.cpp:2914
 msgid "Save"
 msgstr "Gem"
 
-#: ../src/common/fldlgcmn.cpp:342
+#: ../src/common/fldlgcmn.cpp:339
 #, c-format
 msgid "Save %s file"
 msgstr "Gem %s fil"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/common/stockitem.cpp:188 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Gem &som..."
 
-#: ../src/common/docview.cpp:366
+#: ../src/common/docview.cpp:359
 msgid "Save As"
 msgstr "Gem som"
 
-#: ../src/common/stockitem.cpp:191
-msgid "Save as"
-msgstr "Gem som"
+#: ../src/common/stockitem.cpp:188
+#, fuzzy
+msgid "Save As..."
+msgstr "Gem &som..."
 
 #: ../src/common/stockitem.cpp:267
 msgid "Save current document"
@@ -6154,94 +6321,94 @@ msgstr "Gem aktuelle dokument"
 msgid "Save current document with a different filename"
 msgstr "Gem det aktuelle dokument under et andet filnavn"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/generic/logg.cpp:509
 msgid "Save log contents to file"
 msgstr "Gen log indhold til fil"
 
-#: ../src/common/secretstore.cpp:179
-#, c-format
-msgid "Saving password for \"%s/%s\" failed: %s."
+#: ../src/common/secretstore.cpp:189
+#, fuzzy, c-format
+msgid "Saving password for \"%s\" failed: %s."
 msgstr "Kunne ikke gemme adganskode for \"%s/%s\": %s."
 
-#: ../src/generic/fontdlgg.cpp:325
+#: ../src/generic/fontdlgg.cpp:321
 msgid "Script"
 msgstr "Script"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll Lock"
 msgstr "Scroll Lock"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll_lock"
 msgstr "Scroll_lock"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:890
+#: ../src/propgrid/advprops.cpp:791
 msgid "Scrollbar"
 msgstr "Rullebjælke"
 
-#: ../src/generic/srchctlg.cpp:56 ../src/html/helpwnd.cpp:535
-#: ../src/html/helpwnd.cpp:550
+#: ../src/generic/srchctlg.cpp:55 ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:548 ../src/gtk/srchctrl.cpp:182
 msgid "Search"
 msgstr "Søg"
 
-#: ../src/html/helpwnd.cpp:537
+#: ../src/html/helpwnd.cpp:535
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
 msgstr "Søg i hjælp-bøger efter alle forekomster af den indtastede tekst"
 
-#: ../src/generic/fdrepdlg.cpp:160
+#: ../src/generic/fdrepdlg.cpp:157
 msgid "Search direction"
 msgstr "Søgeretning"
 
-#: ../src/generic/fdrepdlg.cpp:112
+#: ../src/generic/fdrepdlg.cpp:109
 msgid "Search for:"
 msgstr "Søg efter:"
 
-#: ../src/html/helpwnd.cpp:1052
+#: ../src/html/helpwnd.cpp:1050
 msgid "Search in all books"
 msgstr "Søg i alle bøger"
 
-#: ../src/html/helpwnd.cpp:857
+#: ../src/html/helpwnd.cpp:855
 msgid "Searching..."
 msgstr "Søger..."
 
-#: ../src/generic/dirctrlg.cpp:446
+#: ../src/generic/dirctrlg.cpp:412
 msgid "Sections"
 msgstr "Afsnit"
 
-#: ../src/common/ffile.cpp:238
+#: ../src/common/ffile.cpp:237
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Søgefejl på filen \"%s\""
 
-#: ../src/common/ffile.cpp:228
+#: ../src/common/ffile.cpp:227
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr "Søgefejl på filen \"%s\" (store filer understøttes ikke af stdio)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:76
+#: ../src/common/accelcmn.cpp:73
 msgid "Select"
 msgstr "Vælg"
 
-#: ../src/richtext/richtextctrl.cpp:337 ../src/osx/textctrl_osx.cpp:581
-#: ../src/common/stockitem.cpp:192 ../src/msw/textctrl.cpp:2512
+#: ../src/osx/textctrl_osx.cpp:599 ../src/common/stockitem.cpp:189
+#: ../src/msw/textctrl.cpp:2777 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Vælg &alt"
 
-#: ../src/common/stockitem.cpp:192 ../src/stc/stc_i18n.cpp:21
+#: ../src/common/stockitem.cpp:189 ../src/stc/stc_i18n.cpp:21
 msgid "Select All"
 msgstr "Vælg alt"
 
-#: ../src/common/docview.cpp:1895
+#: ../src/common/docview.cpp:1900
 msgid "Select a document template"
 msgstr "Vælg en dokumentskabelon"
 
-#: ../src/common/docview.cpp:1969
+#: ../src/common/docview.cpp:1974
 msgid "Select a document view"
 msgstr "Vælg en dokumentvisning"
 
@@ -6270,20 +6437,20 @@ msgid "Selects the list level to edit."
 msgstr "Vælg hvilket listeniveau, der skal redigeres."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:82
+#: ../src/common/accelcmn.cpp:79
 msgid "Separator"
 msgstr "Separator"
 
-#: ../src/common/cmdline.cpp:1083
+#: ../src/common/cmdline.cpp:1079
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Separator forventet efter tilvalget \"%s\"."
 
-#: ../src/osx/menu_osx.cpp:572
+#: ../src/osx/menu_osx.cpp:464
 msgid "Services"
 msgstr "Tjenester"
 
-#: ../src/richtext/richtextbuffer.cpp:11217
+#: ../src/richtext/richtextbuffer.cpp:11216
 msgid "Set Cell Style"
 msgstr "Indstil celletypografi"
 
@@ -6291,11 +6458,11 @@ msgstr "Indstil celletypografi"
 msgid "SetProperty called w/o valid setter"
 msgstr "SetProperty kaldt uden gyldig setter"
 
-#: ../src/generic/prntdlgg.cpp:188
+#: ../src/generic/prntdlgg.cpp:181
 msgid "Setup..."
 msgstr "Opsætning..."
 
-#: ../src/msw/dialup.cpp:544
+#: ../src/msw/dialup.cpp:538
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr "Har fundet flere netværk via modem forbindelser, vælger en tilfældig."
 
@@ -6311,40 +6478,40 @@ msgstr "Skygge"
 msgid "Shadow c&olour:"
 msgstr "&Skyggefarve:"
 
-#: ../src/common/accelcmn.cpp:335
+#: ../src/common/accelcmn.cpp:349
 msgid "Shift+"
 msgstr "Skift+"
 
-#: ../src/generic/dirdlgg.cpp:147
+#: ../src/generic/dirdlgg.cpp:144
 msgid "Show &hidden directories"
 msgstr "Vis sk&julte mapper"
 
-#: ../src/generic/filectrlg.cpp:983
+#: ../src/generic/filectrlg.cpp:979
 msgid "Show &hidden files"
 msgstr "Vis sk&julte filer"
 
-#: ../src/osx/menu_osx.cpp:580
+#: ../src/osx/menu_osx.cpp:472
 msgid "Show All"
 msgstr "Vis alle"
 
-#: ../src/common/stockitem.cpp:257
+#: ../src/common/stockitem.cpp:254
 msgid "Show about dialog"
 msgstr "Vis dialogen Om"
 
-#: ../src/html/helpwnd.cpp:492
+#: ../src/html/helpwnd.cpp:490
 msgid "Show all"
 msgstr "Vis alle"
 
-#: ../src/html/helpwnd.cpp:503
+#: ../src/html/helpwnd.cpp:501
 msgid "Show all items in index"
 msgstr "Vis alle punkter i indeks"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:656
 msgid "Show/hide navigation panel"
 msgstr "Vis/skjul navigationspanel"
 
-#: ../src/richtext/richtextsymboldlg.cpp:421
-#: ../src/richtext/richtextsymboldlg.cpp:423
+#: ../src/richtext/richtextsymboldlg.cpp:418
+#: ../src/richtext/richtextsymboldlg.cpp:420
 msgid "Shows a Unicode subset."
 msgstr "Viser en del af Unicode-tegnsættet."
 
@@ -6360,7 +6527,7 @@ msgstr "Viser en prøve på indstillinger for punkttegn."
 msgid "Shows a preview of the font settings."
 msgstr "Viser en prøve på skrifttypeindstillingerne."
 
-#: ../src/osx/carbon/fontdlg.cpp:394 ../src/osx/carbon/fontdlg.cpp:396
+#: ../src/osx/carbon/fontdlg.cpp:391 ../src/osx/carbon/fontdlg.cpp:393
 msgid "Shows a preview of the font."
 msgstr "Viser en prøve på skrifttypen."
 
@@ -6369,62 +6536,62 @@ msgstr "Viser en prøve på skrifttypen."
 msgid "Shows a preview of the paragraph settings."
 msgstr "Viser en prøve på indstillinger for afsnit."
 
-#: ../src/generic/fontdlgg.cpp:460 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:456 ../src/generic/fontdlgg.cpp:458
 msgid "Shows the font preview."
 msgstr "Viser skrifteksempel."
 
-#: ../src/propgrid/advprops.cpp:1607
+#: ../src/propgrid/advprops.cpp:1513
 msgid "Silver"
 msgstr "Sølv"
 
-#: ../src/univ/themes/mono.cpp:516
+#: ../src/univ/themes/mono.cpp:513
 msgid "Simple monochrome theme"
 msgstr "Simpelt monokromatisk tema"
 
-#: ../src/richtext/richtextindentspage.cpp:275
 #: ../src/richtext/richtextliststylepage.cpp:449
+#: ../src/richtext/richtextindentspage.cpp:275
 msgid "Single"
 msgstr "Single"
 
-#: ../src/generic/filectrlg.cpp:425 ../src/richtext/richtextformatdlg.cpp:369
-#: ../src/richtext/richtextsizepage.cpp:299
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextsizepage.cpp:299
+#: ../src/richtext/richtextformatdlg.cpp:362
 msgid "Size"
 msgstr "Størrelse"
 
-#: ../src/osx/carbon/fontdlg.cpp:339
+#: ../src/osx/carbon/fontdlg.cpp:336
 msgid "Size:"
 msgstr "Størrelse:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1775
+#: ../src/propgrid/advprops.cpp:1676
 msgid "Sizing"
 msgstr "Størrelse"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1772
+#: ../src/propgrid/advprops.cpp:1673
 msgid "Sizing N-S"
 msgstr "Størrelse N-S"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1771
+#: ../src/propgrid/advprops.cpp:1672
 msgid "Sizing NE-SW"
 msgstr "Størrelse NØ-SV"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1773
+#: ../src/propgrid/advprops.cpp:1674
 msgid "Sizing NW-SE"
 msgstr "Størrelse NV-SØ"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1774
+#: ../src/propgrid/advprops.cpp:1675
 msgid "Sizing W-E"
 msgstr "Størrelse V-Ø"
 
-#: ../src/msw/progdlg.cpp:801
+#: ../src/msw/progdlg.cpp:1088
 msgid "Skip"
 msgstr "Spring over"
 
-#: ../src/generic/fontdlgg.cpp:330
+#: ../src/generic/fontdlgg.cpp:326
 msgid "Slant"
 msgstr "Hældning"
 
@@ -6433,7 +6600,7 @@ msgid "Small C&apitals"
 msgstr "Små vers&aler"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:79
+#: ../src/common/accelcmn.cpp:76
 msgid "Snapshot"
 msgstr "Snapshot"
 
@@ -6441,37 +6608,37 @@ msgstr "Snapshot"
 msgid "Solid"
 msgstr "Fast"
 
-#: ../src/common/docview.cpp:1791
+#: ../src/common/docview.cpp:1785
 msgid "Sorry, could not open this file."
 msgstr "Beklager, kunne ikke åbne denne fil."
 
-#: ../src/common/prntbase.cpp:2057 ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2079 ../src/common/prntbase.cpp:2087
 msgid "Sorry, not enough memory to create a preview."
 msgstr "Beklager, der er ikke nok ledig hukommelse til Udskriftsvisning."
 
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "Sorry, that name is taken. Please choose another."
 msgstr "Beklager, navnet er taget. Vælg venligst et andet."
 
-#: ../src/common/docview.cpp:1814
+#: ../src/common/docview.cpp:1819
 msgid "Sorry, the format for this file is unknown."
 msgstr "Beklager, formatet for denne fil er ukendt."
 
-#: ../src/unix/sound.cpp:492
+#: ../src/unix/sound.cpp:481
 msgid "Sound data are in unsupported format."
 msgstr "Lyddata er i et ikke understøttet format."
 
-#: ../src/unix/sound.cpp:477
+#: ../src/unix/sound.cpp:466
 #, c-format
 msgid "Sound file '%s' is in unsupported format."
 msgstr "Lydfilen \"%s\" er i et ikke-understøttet format."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:67
+#: ../src/common/accelcmn.cpp:64
 msgid "Space"
 msgstr "Mellemrum"
 
@@ -6479,12 +6646,12 @@ msgstr "Mellemrum"
 msgid "Spacing"
 msgstr "Afstand"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "Spell Check"
 msgstr "Stavekontrol"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1776
+#: ../src/propgrid/advprops.cpp:1677
 msgid "Spraycan"
 msgstr "Spraydåse"
 
@@ -6493,7 +6660,7 @@ msgstr "Spraydåse"
 msgid "Standard"
 msgstr "Standard"
 
-#: ../src/common/paper.cpp:104
+#: ../src/common/paper.cpp:101
 msgid "Statement, 5 1/2 x 8 1/2 in"
 msgstr "Statement, 5 1/2 x 8 1/2 tommer"
 
@@ -6502,33 +6669,29 @@ msgstr "Statement, 5 1/2 x 8 1/2 tommer"
 msgid "Static"
 msgstr "Statisk"
 
-#: ../src/generic/prntdlgg.cpp:204
+#: ../src/generic/prntdlgg.cpp:197
 msgid "Status:"
 msgstr "Status:"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "Stop"
 msgstr "Stop"
 
-#: ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196
 msgid "Strikethrough"
 msgstr "Gennemstreget"
 
-#: ../src/common/colourcmn.cpp:45
+#: ../src/common/colourcmn.cpp:42
 #, c-format
 msgid "String To Colour : Incorrect colour specification : %s"
 msgstr "Streng til farve : forkert farvespecifikation : %s"
 
 #. TRANSLATORS: Label of font style
-#: ../src/richtext/richtextformatdlg.cpp:339 ../src/propgrid/advprops.cpp:680
+#: ../src/propgrid/advprops.cpp:590 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Typografi"
 
-#: ../include/wx/richtext/richtextstyledlg.h:46
-msgid "Style Organiser"
-msgstr "Typografistyring"
-
-#: ../src/osx/carbon/fontdlg.cpp:348
+#: ../src/osx/carbon/fontdlg.cpp:345
 msgid "Style:"
 msgstr "Typografi:"
 
@@ -6537,7 +6700,7 @@ msgid "Subscrip&t"
 msgstr "Sænket skrif&t"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:83
+#: ../src/common/accelcmn.cpp:80
 msgid "Subtract"
 msgstr "Træk fra"
 
@@ -6545,11 +6708,11 @@ msgstr "Træk fra"
 msgid "Supe&rscript"
 msgstr "Hævet sk&rift"
 
-#: ../src/common/paper.cpp:150
+#: ../src/common/paper.cpp:147
 msgid "SuperA/SuperA/A4 227 x 356 mm"
 msgstr "SuperA/SuperA/A4 227 x 356 mm"
 
-#: ../src/common/paper.cpp:151
+#: ../src/common/paper.cpp:148
 msgid "SuperB/SuperB/A3 305 x 487 mm"
 msgstr "SuperB/SuperB/A3 305 x 487 mm"
 
@@ -6557,7 +6720,7 @@ msgstr "SuperB/SuperB/A3 305 x 487 mm"
 msgid "Suppress hyphe&nation"
 msgstr "Undertryk ord&deling"
 
-#: ../src/generic/fontdlgg.cpp:326
+#: ../src/generic/fontdlgg.cpp:322
 msgid "Swiss"
 msgstr "Swiss"
 
@@ -6575,73 +6738,73 @@ msgstr "Symbol&font:"
 msgid "Symbols"
 msgstr "Symboler"
 
-#: ../src/common/imagtiff.cpp:369 ../src/common/imagtiff.cpp:382
-#: ../src/common/imagtiff.cpp:741
+#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
+#: ../src/common/imagtiff.cpp:738
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: kunne ikke få hukommelse."
 
-#: ../src/common/imagtiff.cpp:301
+#: ../src/common/imagtiff.cpp:298
 msgid "TIFF: Error loading image."
 msgstr "TIFF: fejl ved læsning af billede."
 
-#: ../src/common/imagtiff.cpp:468
+#: ../src/common/imagtiff.cpp:465
 msgid "TIFF: Error reading image."
 msgstr "TIFF: fejl ved læsning af billede."
 
-#: ../src/common/imagtiff.cpp:608
+#: ../src/common/imagtiff.cpp:605
 msgid "TIFF: Error saving image."
 msgstr "TIFF: fejl ved gemning af billede."
 
-#: ../src/common/imagtiff.cpp:846
+#: ../src/common/imagtiff.cpp:843
 msgid "TIFF: Error writing image."
 msgstr "TIFF: fejl ved skrivning af billede."
 
-#: ../src/common/imagtiff.cpp:355
+#: ../src/common/imagtiff.cpp:352
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: billedstørrelse er unormalt stor."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:68
+#: ../src/common/accelcmn.cpp:65
 msgid "Tab"
 msgstr "Tab"
 
-#: ../src/richtext/richtextbuffer.cpp:11498
+#: ../src/richtext/richtextbuffer.cpp:11497
 msgid "Table Properties"
 msgstr "Tabel-egenskaber"
 
-#: ../src/common/paper.cpp:145
+#: ../src/common/paper.cpp:142
 msgid "Tabloid Extra 11.69 x 18 in"
 msgstr "Tabloid ekstra 11.69 x 18 tommer"
 
-#: ../src/common/paper.cpp:102
+#: ../src/common/paper.cpp:99
 msgid "Tabloid, 11 x 17 in"
 msgstr "Tabloid, 11 x 17 tommer"
 
-#: ../src/richtext/richtextformatdlg.cpp:354
+#: ../src/richtext/richtextformatdlg.cpp:347
 msgid "Tabs"
 msgstr "Faneblade"
 
-#: ../src/propgrid/advprops.cpp:1598
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Teal"
 msgstr "Grønblå"
 
-#: ../src/generic/fontdlgg.cpp:327
+#: ../src/generic/fontdlgg.cpp:323
 msgid "Teletype"
 msgstr "Teletype"
 
-#: ../src/common/docview.cpp:1896
+#: ../src/common/docview.cpp:1901
 msgid "Templates"
 msgstr "Skabeloner"
 
-#: ../src/common/fmapbase.cpp:158
+#: ../src/common/fmapbase.cpp:155
 msgid "Thai (ISO-8859-11)"
 msgstr "Thailandsk (ISO-8859-11)"
 
-#: ../src/common/ftp.cpp:619
+#: ../src/common/ftp.cpp:622
 msgid "The FTP server doesn't support passive mode."
 msgstr "FTP-serveren understøtter ikke passiv-tilstand."
 
-#: ../src/common/ftp.cpp:605
+#: ../src/common/ftp.cpp:608
 msgid "The FTP server doesn't support the PORT command."
 msgstr "FTP-serveren understøtter ikke PORT-kommandoen."
 
@@ -6652,8 +6815,8 @@ msgstr "FTP-serveren understøtter ikke PORT-kommandoen."
 msgid "The available bullet styles."
 msgstr "Tilgængelige punkttegnstypografier."
 
-#: ../src/richtext/richtextstyledlg.cpp:202
-#: ../src/richtext/richtextstyledlg.cpp:204
+#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:200
 msgid "The available styles."
 msgstr "Tilgængelige typografier."
 
@@ -6709,12 +6872,12 @@ msgstr "Bundposition."
 msgid "The bullet character."
 msgstr "Punkttegn."
 
-#: ../src/richtext/richtextsymboldlg.cpp:443
-#: ../src/richtext/richtextsymboldlg.cpp:445
+#: ../src/richtext/richtextsymboldlg.cpp:440
+#: ../src/richtext/richtextsymboldlg.cpp:442
 msgid "The character code."
 msgstr "Tegnkode."
 
-#: ../src/common/fontmap.cpp:203
+#: ../src/common/fontmap.cpp:200
 #, c-format
 msgid ""
 "The charset '%s' is unknown. You may select\n"
@@ -6725,7 +6888,7 @@ msgstr ""
 "et andet til at erstatte det, eller vælg\n"
 "[Annullér] hvis det ikke kan erstattes"
 
-#: ../src/msw/ole/dataobj.cpp:394
+#: ../src/msw/ole/dataobj.cpp:402
 #, c-format
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "Udklipsholderformat \"%d\" findes ikke."
@@ -6735,7 +6898,7 @@ msgstr "Udklipsholderformat \"%d\" findes ikke."
 msgid "The default style for the next paragraph."
 msgstr "Standardtypografi for næste afsnit."
 
-#: ../src/generic/dirdlgg.cpp:202
+#: ../src/generic/dirdlgg.cpp:199
 #, c-format
 msgid ""
 "The directory '%s' does not exist\n"
@@ -6744,7 +6907,7 @@ msgstr ""
 "Mappen \"%s\" findes ikke\n"
 "Opret den nu?"
 
-#: ../src/html/htmprint.cpp:271
+#: ../src/html/htmprint.cpp:283
 #, c-format
 msgid ""
 "The document \"%s\" doesn't fit on the page horizontally and will be "
@@ -6757,7 +6920,7 @@ msgstr ""
 "\n"
 "Vil du alligevel fortsætte med udskrivningen?"
 
-#: ../src/common/docview.cpp:1202
+#: ../src/common/docview.cpp:1196
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -6766,36 +6929,36 @@ msgstr ""
 "Filen \"%s\" findes ikke og kunne ikke åbnes.\n"
 "Den er fjernet fra listen over senest brugte filer."
 
-#: ../src/richtext/richtextindentspage.cpp:208
-#: ../src/richtext/richtextindentspage.cpp:210
 #: ../src/richtext/richtextliststylepage.cpp:394
 #: ../src/richtext/richtextliststylepage.cpp:396
+#: ../src/richtext/richtextindentspage.cpp:208
+#: ../src/richtext/richtextindentspage.cpp:210
 msgid "The first line indent."
 msgstr "Indrykning af første linje."
 
-#: ../src/gtk/utilsgtk.cpp:481
-msgid "The following standard GTK+ options are also supported:\n"
-msgstr "Følgende standard GTK+ indstillinger understøttes også:\n"
+#: ../src/generic/dbgrptg.cpp:318
+msgid "The following debug report will be generated\n"
+msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:414 ../src/generic/fontdlgg.cpp:416
+#: ../src/generic/fontdlgg.cpp:411 ../src/generic/fontdlgg.cpp:413
 msgid "The font colour."
 msgstr "Skriftfarven."
 
-#: ../src/generic/fontdlgg.cpp:375 ../src/generic/fontdlgg.cpp:377
+#: ../src/generic/fontdlgg.cpp:371 ../src/generic/fontdlgg.cpp:373
 msgid "The font family."
 msgstr "Skrifttypefamilien."
 
-#: ../src/richtext/richtextsymboldlg.cpp:405
-#: ../src/richtext/richtextsymboldlg.cpp:407
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "The font from which to take the symbol."
 msgstr "Skrifttypen hvorfra symbolet skal tages."
 
-#: ../src/generic/fontdlgg.cpp:427 ../src/generic/fontdlgg.cpp:429
-#: ../src/generic/fontdlgg.cpp:434 ../src/generic/fontdlgg.cpp:436
+#: ../src/generic/fontdlgg.cpp:424 ../src/generic/fontdlgg.cpp:426
+#: ../src/generic/fontdlgg.cpp:430 ../src/generic/fontdlgg.cpp:432
 msgid "The font point size."
 msgstr "Skriftens punktstørrelse."
 
-#: ../src/osx/carbon/fontdlg.cpp:343 ../src/osx/carbon/fontdlg.cpp:345
+#: ../src/osx/carbon/fontdlg.cpp:340 ../src/osx/carbon/fontdlg.cpp:342
 msgid "The font size in points."
 msgstr "Skriftstørrelsen i punkt."
 
@@ -6804,15 +6967,15 @@ msgstr "Skriftstørrelsen i punkt."
 msgid "The font size units, points or pixels."
 msgstr "Enhed for skriftstørrelse, punkt eller pixels."
 
-#: ../src/generic/fontdlgg.cpp:386 ../src/generic/fontdlgg.cpp:388
+#: ../src/generic/fontdlgg.cpp:382 ../src/generic/fontdlgg.cpp:384
 msgid "The font style."
 msgstr "Skrifttypetypografi."
 
-#: ../src/generic/fontdlgg.cpp:397 ../src/generic/fontdlgg.cpp:399
+#: ../src/generic/fontdlgg.cpp:393 ../src/generic/fontdlgg.cpp:395
 msgid "The font weight."
 msgstr "Skrifttypens vægt."
 
-#: ../src/common/docview.cpp:1483
+#: ../src/common/docview.cpp:1477
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Formatet på filen \"%s\" kunne ikke bestemmes."
@@ -6822,10 +6985,10 @@ msgstr "Formatet på filen \"%s\" kunne ikke bestemmes."
 msgid "The horizontal offset."
 msgstr "Den lodrette forskydning."
 
-#: ../src/richtext/richtextindentspage.cpp:199
-#: ../src/richtext/richtextindentspage.cpp:201
 #: ../src/richtext/richtextliststylepage.cpp:385
 #: ../src/richtext/richtextliststylepage.cpp:387
+#: ../src/richtext/richtextindentspage.cpp:199
+#: ../src/richtext/richtextindentspage.cpp:201
 msgid "The left indent."
 msgstr "Den venstre indrykning."
 
@@ -6846,10 +7009,10 @@ msgstr "Størrelsen af venstre indre margen."
 msgid "The left position."
 msgstr "Venstre position."
 
-#: ../src/richtext/richtextindentspage.cpp:288
-#: ../src/richtext/richtextindentspage.cpp:290
 #: ../src/richtext/richtextliststylepage.cpp:462
 #: ../src/richtext/richtextliststylepage.cpp:464
+#: ../src/richtext/richtextindentspage.cpp:288
+#: ../src/richtext/richtextindentspage.cpp:290
 msgid "The line spacing."
 msgstr "Linjeafstand."
 
@@ -6858,7 +7021,7 @@ msgstr "Linjeafstand."
 msgid "The list item number."
 msgstr "Nummeret på punktet i listen."
 
-#: ../src/msw/ole/automtn.cpp:664
+#: ../src/msw/ole/automtn.cpp:655
 msgid "The locale ID is unknown."
 msgstr "Den lokale ID er ukendt."
 
@@ -6897,19 +7060,19 @@ msgstr "Bredden på objektet."
 msgid "The outline level."
 msgstr "Dispositionsniveauet."
 
-#: ../src/common/log.cpp:277
+#: ../src/common/log.cpp:296
 #, c-format
 msgid "The previous message repeated %u time."
 msgid_plural "The previous message repeated %u times."
 msgstr[0] "Den forrige meddelelse gentaget %u gang."
 msgstr[1] "Den forrige meddelelse gentaget %u gange."
 
-#: ../src/common/log.cpp:270
+#: ../src/common/log.cpp:289
 msgid "The previous message repeated once."
 msgstr "Den forrige meddelelse gentaget én gang."
 
-#: ../src/richtext/richtextsymboldlg.cpp:462
-#: ../src/richtext/richtextsymboldlg.cpp:464
+#: ../src/richtext/richtextsymboldlg.cpp:459
+#: ../src/richtext/richtextsymboldlg.cpp:461
 msgid "The range to show."
 msgstr "Område, der skal vises."
 
@@ -6923,15 +7086,15 @@ msgstr ""
 "indeholder private oplysninger, \n"
 "så fravælg dem, og de vil blive fjernet fra rapporten.\n"
 
-#: ../src/common/cmdline.cpp:1254
+#: ../src/common/cmdline.cpp:1250
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "Den nødvendige parameter \"%s\" blev ikke angivet."
 
-#: ../src/richtext/richtextindentspage.cpp:217
-#: ../src/richtext/richtextindentspage.cpp:219
 #: ../src/richtext/richtextliststylepage.cpp:403
 #: ../src/richtext/richtextliststylepage.cpp:405
+#: ../src/richtext/richtextindentspage.cpp:217
+#: ../src/richtext/richtextindentspage.cpp:219
 msgid "The right indent."
 msgstr "Den højre indrykning."
 
@@ -6972,16 +7135,16 @@ msgstr "Skyggens opacitet."
 msgid "The shadow spread."
 msgstr "Skyggens udbredelse."
 
-#: ../src/richtext/richtextindentspage.cpp:267
 #: ../src/richtext/richtextliststylepage.cpp:439
 #: ../src/richtext/richtextliststylepage.cpp:441
+#: ../src/richtext/richtextindentspage.cpp:267
 msgid "The spacing after the paragraph."
 msgstr "Afstand efter afsnittet."
 
-#: ../src/richtext/richtextindentspage.cpp:257
-#: ../src/richtext/richtextindentspage.cpp:259
 #: ../src/richtext/richtextliststylepage.cpp:430
 #: ../src/richtext/richtextliststylepage.cpp:432
+#: ../src/richtext/richtextindentspage.cpp:257
+#: ../src/richtext/richtextindentspage.cpp:259
 msgid "The spacing before the paragraph."
 msgstr "Afstand før afsnittet."
 
@@ -6995,12 +7158,12 @@ msgstr "Navn på typografien."
 msgid "The style on which this style is based."
 msgstr "Typografien, som denne typografi er baseret på."
 
-#: ../src/richtext/richtextstyledlg.cpp:214
-#: ../src/richtext/richtextstyledlg.cpp:216
+#: ../src/richtext/richtextstyledlg.cpp:210
+#: ../src/richtext/richtextstyledlg.cpp:212
 msgid "The style preview."
 msgstr "Visning af typografi."
 
-#: ../src/msw/ole/automtn.cpp:680
+#: ../src/msw/ole/automtn.cpp:671
 msgid "The system cannot find the file specified."
 msgstr "Systemet kan ikke finde den angivne fil."
 
@@ -7013,7 +7176,7 @@ msgstr "Tab-positionen."
 msgid "The tab positions."
 msgstr "Tab-positionerne."
 
-#: ../src/richtext/richtextctrl.cpp:3098
+#: ../src/richtext/richtextctrl.cpp:3099
 msgid "The text couldn't be saved."
 msgstr "Teksten kunne ikke gemmes."
 
@@ -7034,7 +7197,7 @@ msgstr "Størrelsen af indre topmargen."
 msgid "The top position."
 msgstr "Topposition."
 
-#: ../src/common/cmdline.cpp:1232
+#: ../src/common/cmdline.cpp:1228
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "Værdien til tilvalget \"%s\" skal angives."
@@ -7044,7 +7207,7 @@ msgstr "Værdien til tilvalget \"%s\" skal angives."
 msgid "The value of the corner radius."
 msgstr "Værdien af hjørneradius."
 
-#: ../src/msw/dialup.cpp:433
+#: ../src/msw/dialup.cpp:427
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -7059,12 +7222,12 @@ msgstr ""
 msgid "The vertical offset."
 msgstr "Den lodrette forskydning."
 
-#: ../src/richtext/richtextprint.cpp:619 ../src/html/htmprint.cpp:745
+#: ../src/html/htmprint.cpp:749 ../src/richtext/richtextprint.cpp:615
 msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr "Problem ved sideopsætning: du skal muligvis vælge en standardprinter."
 
-#: ../src/html/htmprint.cpp:255
+#: ../src/html/htmprint.cpp:267
 msgid ""
 "This document doesn't fit on the page horizontally and will be truncated "
 "when it is printed."
@@ -7072,16 +7235,16 @@ msgstr ""
 "Dette dokument kan ikke være vandret på siden og vil blive afskåret under "
 "udskrift."
 
-#: ../src/common/image.cpp:2854
+#: ../src/common/image.cpp:2963
 #, c-format
 msgid "This is not a %s."
 msgstr "Dette er ikke nogen %s."
 
-#: ../src/common/wincmn.cpp:1653
+#: ../src/common/wincmn.cpp:1654
 msgid "This platform does not support background transparency."
 msgstr "Denne platform understøtter ikke gennemsigtig baggrund."
 
-#: ../src/gtk/window.cpp:4660
+#: ../src/gtk/window.cpp:5664
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
@@ -7089,7 +7252,15 @@ msgstr ""
 "Dette program blev kompileret med en for gammel version af GTK+. Genbyg "
 "venligst med GTK+ 2.12 eller nyere."
 
-#: ../src/msw/thread.cpp:1240
+#: ../src/gtk/glcanvas.cpp:176
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/msw/thread.cpp:1246
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -7097,11 +7268,11 @@ msgstr ""
 "Trådmodul initialisering fejlede: kan ikke gemme værdi i trådens private "
 "lager"
 
-#: ../src/unix/threadpsx.cpp:1794
+#: ../src/unix/threadpsx.cpp:1843
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr "Trådmodul initialisering fejlede: kunne ikke oprette trådnøgle"
 
-#: ../src/msw/thread.cpp:1228
+#: ../src/msw/thread.cpp:1234
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -7109,83 +7280,83 @@ msgstr ""
 "Trådmodul initialisering fejlede: umuligt at allokere indeks i trådens "
 "private lager"
 
-#: ../src/unix/threadpsx.cpp:1043
+#: ../src/unix/threadpsx.cpp:1061
 msgid "Thread priority setting is ignored."
 msgstr "Prioritetsindstilling for tråd ignoreret."
 
-#: ../src/msw/mdi.cpp:176
+#: ../src/msw/mdi.cpp:171
 msgid "Tile &Horizontally"
 msgstr "Fordel &vandret"
 
-#: ../src/msw/mdi.cpp:177
+#: ../src/msw/mdi.cpp:172
 msgid "Tile &Vertically"
 msgstr "Fordel &lodret"
 
-#: ../src/common/ftp.cpp:200
+#: ../src/common/ftp.cpp:197
 msgid "Timeout while waiting for FTP server to connect, try passive mode."
 msgstr ""
 "Timeout under ventning på, at FTP-server skulle oprette forbindelse. Prøv "
 "passiv-tilstand."
 
-#: ../src/generic/tipdlg.cpp:201
+#: ../src/generic/tipdlg.cpp:198
 msgid "Tip of the Day"
 msgstr "Dagens tip"
 
-#: ../src/generic/tipdlg.cpp:140
+#: ../src/generic/tipdlg.cpp:137
 msgid "Tips not available, sorry!"
 msgstr "Tips ikke tilgængelige, beklager!"
 
-#: ../src/generic/prntdlgg.cpp:242
+#: ../src/generic/prntdlgg.cpp:235
 msgid "To:"
 msgstr "Til:"
 
-#: ../src/richtext/richtextbuffer.cpp:8363
+#: ../src/richtext/richtextbuffer.cpp:8361
 msgid "Too many EndStyle calls!"
 msgstr "For mange EndStyle-kald!"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:891
+#: ../src/propgrid/advprops.cpp:792
 msgid "Tooltip"
 msgstr "Værktøjstip"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:892
+#: ../src/propgrid/advprops.cpp:793
 msgid "TooltipText"
 msgstr "Tekst til værktøjstip"
 
-#: ../src/richtext/richtextsizepage.cpp:286
-#: ../src/richtext/richtextsizepage.cpp:290 ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197 ../src/richtext/richtextsizepage.cpp:286
+#: ../src/richtext/richtextsizepage.cpp:290
 msgid "Top"
 msgstr "Top"
 
-#: ../src/generic/prntdlgg.cpp:881
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Top margin (mm):"
 msgstr "Topmargen (mm):"
 
-#: ../src/generic/aboutdlgg.cpp:79
+#: ../src/generic/aboutdlgg.cpp:76
 msgid "Translations by "
 msgstr "Oversat af "
 
-#: ../src/generic/aboutdlgg.cpp:188
+#: ../src/generic/aboutdlgg.cpp:185
 msgid "Translators"
 msgstr "Oversættere"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:211
+#: ../src/propgrid/propgrid.cpp:192
 msgid "True"
 msgstr "Sand"
 
-#: ../src/common/fs_mem.cpp:227
+#: ../src/common/fs_mem.cpp:222
 #, c-format
 msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
 msgstr ""
 "Prøver at fjerne filen \"%s\" fra hukommelsen VFS, men den er ikke indlæst!"
 
-#: ../src/common/fmapbase.cpp:156
+#: ../src/common/fmapbase.cpp:153
 msgid "Turkish (ISO-8859-9)"
 msgstr "Tyrkisk (ISO-8859-9)"
 
-#: ../src/generic/filectrlg.cpp:426
+#: ../src/generic/filectrlg.cpp:422
 msgid "Type"
 msgstr "Type"
 
@@ -7199,38 +7370,38 @@ msgstr "Indtast et skrifttypenavn."
 msgid "Type a size in points."
 msgstr "Indtast en størrelse i punkter."
 
-#: ../src/msw/ole/automtn.cpp:676
+#: ../src/msw/ole/automtn.cpp:667
 #, c-format
 msgid "Type mismatch in argument %u."
 msgstr "Type uoverensstemmelse i argument %u."
 
-#: ../src/common/xtixml.cpp:356 ../src/common/xtixml.cpp:509
-#: ../src/common/xtistrm.cpp:318
+#: ../src/common/xtixml.cpp:352 ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315
 msgid "Type must have enum - long conversion"
 msgstr "Type skal have enum - long-konvertering"
 
-#: ../src/propgrid/propgridiface.cpp:401
+#: ../src/propgrid/propgridiface.cpp:385
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
 "\"%s\"."
 msgstr ""
-"Type-operation \"%s\" fejlede: egenskab med navnet \"%s\" er af typen "
-"\"%s\", ikke \"%s\"."
+"Type-operation \"%s\" fejlede: egenskab med navnet \"%s\" er af typen \"%s"
+"\", ikke \"%s\"."
 
-#: ../src/common/paper.cpp:133
+#: ../src/common/paper.cpp:130
 msgid "US Std Fanfold, 14 7/8 x 11 in"
 msgstr "US Std Fanfold, 14 7/8 x 11 tommer"
 
-#: ../src/common/fmapbase.cpp:196
+#: ../src/common/fmapbase.cpp:193
 msgid "US-ASCII"
 msgstr "US-ASCII"
 
-#: ../src/unix/fswatcher_inotify.cpp:109
+#: ../src/unix/fswatcher_inotify.cpp:106
 msgid "Unable to add inotify watch"
 msgstr "Kunne ikke tilføje inotify-overvågning"
 
-#: ../src/unix/fswatcher_kqueue.cpp:136
+#: ../src/unix/fswatcher_kqueue.cpp:153
 msgid "Unable to add kqueue watch"
 msgstr "Kunne ikke tilføje overvågning af kø"
 
@@ -7242,7 +7413,7 @@ msgstr "Kunne ikke tilknytte håndtag med I/O completion port"
 msgid "Unable to close I/O completion port handle"
 msgstr "Kunne ikke lukke I/O completion port handle"
 
-#: ../src/unix/fswatcher_inotify.cpp:97
+#: ../src/unix/fswatcher_inotify.cpp:94
 msgid "Unable to close inotify instance"
 msgstr "Kunne ikke lukke inotify-instans"
 
@@ -7260,15 +7431,15 @@ msgstr "Kunne ikke lukke håndtaget til \"%s\""
 msgid "Unable to create I/O completion port"
 msgstr "Kunne ikke oprette I/O completion port"
 
-#: ../src/msw/fswatcher.cpp:84
+#: ../src/msw/fswatcher.cpp:81
 msgid "Unable to create IOCP worker thread"
 msgstr "Kunne ikke oprette IOCP-arbejdstråd"
 
-#: ../src/unix/fswatcher_inotify.cpp:74
+#: ../src/unix/fswatcher_inotify.cpp:71
 msgid "Unable to create inotify instance"
 msgstr "Kunne ikke oprette inotify-instans"
 
-#: ../src/unix/fswatcher_kqueue.cpp:97
+#: ../src/unix/fswatcher_kqueue.cpp:114
 msgid "Unable to create kqueue instance"
 msgstr "Kunne ikke oprette kqueue-instans"
 
@@ -7276,11 +7447,11 @@ msgstr "Kunne ikke oprette kqueue-instans"
 msgid "Unable to dequeue completion packet"
 msgstr "Kunne ikke dequeue completion pakke"
 
-#: ../src/unix/fswatcher_kqueue.cpp:185
+#: ../src/unix/fswatcher_kqueue.cpp:202
 msgid "Unable to get events from kqueue"
 msgstr "Kunne ikke hente events fra kø"
 
-#: ../src/gtk/app.cpp:435
+#: ../src/gtk/app.cpp:431
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "Kunne ikke initialisere GTK+. Er DISPLAY sat korrekt?"
 
@@ -7289,12 +7460,12 @@ msgstr "Kunne ikke initialisere GTK+. Er DISPLAY sat korrekt?"
 msgid "Unable to open path '%s'"
 msgstr "Kunne ikke åbne stien \"%s\""
 
-#: ../src/html/htmlwin.cpp:583
+#: ../src/html/htmlwin.cpp:586
 #, c-format
 msgid "Unable to open requested HTML document: %s"
 msgstr "Kunne ikke åbne det ønskede HTML-dokument: %s"
 
-#: ../src/unix/sound.cpp:368
+#: ../src/unix/sound.cpp:365
 msgid "Unable to play sound asynchronously."
 msgstr "Kunne ikke afspille lyd asynkront."
 
@@ -7302,61 +7473,61 @@ msgstr "Kunne ikke afspille lyd asynkront."
 msgid "Unable to post completion status"
 msgstr "Kunne ikke poste completion status"
 
-#: ../src/unix/fswatcher_inotify.cpp:556
+#: ../src/unix/fswatcher_inotify.cpp:553
 msgid "Unable to read from inotify descriptor"
 msgstr "Kunne ikke læse fra inotify-deskriptor"
 
-#: ../src/unix/fswatcher_inotify.cpp:141
+#: ../src/unix/fswatcher_inotify.cpp:138
 #, c-format
 msgid "Unable to remove inotify watch %i"
 msgstr "Kunne ikke fjerne inotify-overvågning %i"
 
-#: ../src/unix/fswatcher_kqueue.cpp:153
+#: ../src/unix/fswatcher_kqueue.cpp:170
 msgid "Unable to remove kqueue watch"
 msgstr "Kunne ikke fjerne overvågning af kø"
 
-#: ../src/msw/fswatcher.cpp:168
+#: ../src/msw/fswatcher.cpp:165
 #, c-format
 msgid "Unable to set up watch for '%s'"
 msgstr "Kunne ikke opsætte overvågning af \"%s\""
 
-#: ../src/msw/fswatcher.cpp:91
+#: ../src/msw/fswatcher.cpp:88
 msgid "Unable to start IOCP worker thread"
 msgstr "Kunne ikke starte IOCP-arbejdstråd"
 
-#: ../src/common/stockitem.cpp:201
+#: ../src/common/stockitem.cpp:198
 msgid "Undelete"
 msgstr "Gendan"
 
-#: ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199
 msgid "Underline"
 msgstr "Understregning"
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/richtext/richtextfontpage.cpp:359 ../src/osx/carbon/fontdlg.cpp:370
-#: ../src/propgrid/advprops.cpp:690
+#: ../src/osx/carbon/fontdlg.cpp:367 ../src/propgrid/advprops.cpp:600
+#: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Understreget"
 
-#: ../src/common/stockitem.cpp:203 ../src/stc/stc_i18n.cpp:15
+#: ../src/common/stockitem.cpp:200 ../src/stc/stc_i18n.cpp:15
 msgid "Undo"
 msgstr "Fortryd"
 
-#: ../src/common/stockitem.cpp:265
+#: ../src/common/stockitem.cpp:263
 msgid "Undo last action"
 msgstr "Fortryd seneste handling"
 
-#: ../src/common/cmdline.cpp:1029
+#: ../src/common/cmdline.cpp:1025
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Uventede tegn efter tilvalget \"%s\"."
 
-#: ../src/unix/fswatcher_inotify.cpp:274
+#: ../src/unix/fswatcher_inotify.cpp:271
 #, c-format
 msgid "Unexpected event for \"%s\": no matching watch descriptor."
 msgstr "Uventet event for \"%s\": ingen matchende watch-deskriptor."
 
-#: ../src/common/cmdline.cpp:1195
+#: ../src/common/cmdline.cpp:1191
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Uventet parameter \"%s\""
@@ -7365,49 +7536,49 @@ msgstr "Uventet parameter \"%s\""
 msgid "Unexpectedly new I/O completion port was created"
 msgstr "Uventet ny I/O completion port blev oprettet"
 
-#: ../src/msw/fswatcher.cpp:70
+#: ../src/msw/fswatcher.cpp:67
 msgid "Ungraceful worker thread termination"
 msgstr "Ureglementeret afslutning af arbejdstråd"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:460
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:456
+#: ../src/richtext/richtextsymboldlg.cpp:457
+#: ../src/richtext/richtextsymboldlg.cpp:458
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../src/common/fmapbase.cpp:185 ../src/common/fmapbase.cpp:191
+#: ../src/common/fmapbase.cpp:182 ../src/common/fmapbase.cpp:188
 msgid "Unicode 16 bit (UTF-16)"
 msgstr "Unicode 16 bit (UTF-16)"
 
-#: ../src/common/fmapbase.cpp:190
+#: ../src/common/fmapbase.cpp:187
 msgid "Unicode 16 bit Big Endian (UTF-16BE)"
 msgstr "Unicode 16 bit Big Endian (UTF-16BE)"
 
-#: ../src/common/fmapbase.cpp:186
+#: ../src/common/fmapbase.cpp:183
 msgid "Unicode 16 bit Little Endian (UTF-16LE)"
 msgstr "Unicode 16 bit Little Endian (UTF-16LE)"
 
-#: ../src/common/fmapbase.cpp:187 ../src/common/fmapbase.cpp:193
+#: ../src/common/fmapbase.cpp:184 ../src/common/fmapbase.cpp:190
 msgid "Unicode 32 bit (UTF-32)"
 msgstr "Unicode 32 bit (UTF-32)"
 
-#: ../src/common/fmapbase.cpp:192
+#: ../src/common/fmapbase.cpp:189
 msgid "Unicode 32 bit Big Endian (UTF-32BE)"
 msgstr "Unicode 32 bit Big Endian (UTF-32BE)"
 
-#: ../src/common/fmapbase.cpp:188
+#: ../src/common/fmapbase.cpp:185
 msgid "Unicode 32 bit Little Endian (UTF-32LE)"
 msgstr "Unicode 32 bit Little Endian (UTF-32LE)"
 
-#: ../src/common/fmapbase.cpp:182
+#: ../src/common/fmapbase.cpp:179
 msgid "Unicode 7 bit (UTF-7)"
 msgstr "Unicode 7 bit (UTF-7)"
 
-#: ../src/common/fmapbase.cpp:183
+#: ../src/common/fmapbase.cpp:180
 msgid "Unicode 8 bit (UTF-8)"
 msgstr "Unicode 8 bit (UTF-8)"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "Unindent"
 msgstr "Afindryk"
 
@@ -7557,97 +7728,102 @@ msgstr "Enheder for øverste position."
 msgid "Units for this value."
 msgstr "Enheder for denne værdi."
 
-#: ../src/generic/progdlgg.cpp:353 ../src/generic/progdlgg.cpp:622
+#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
 msgid "Unknown"
 msgstr "Ukendt"
 
-#: ../src/msw/dde.cpp:1174
+#: ../src/msw/dde.cpp:1238
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Ukendt DDE-fejl %08x"
 
-#: ../src/common/xtistrm.cpp:410
+#: ../src/common/xtistrm.cpp:407
 msgid "Unknown Object passed to GetObjectClassInfo"
 msgstr "Ukendt objekt sendt til GetObjectClassInfo"
 
-#: ../src/common/imagpng.cpp:366
+#: ../src/common/imagpng.cpp:383
 #, c-format
 msgid "Unknown PNG resolution unit %d"
 msgstr "Ukendt PNG opløsningsenhed %d"
 
-#: ../src/common/xtixml.cpp:327
+#: ../src/common/xtixml.cpp:323
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Ukendt egenskab %s"
 
-#: ../src/common/imagtiff.cpp:529
+#: ../src/common/imagtiff.cpp:526
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "Ukendt TIFF opløsningsenhed %d ignoreret"
 
-#: ../src/unix/dlunix.cpp:160
+#: ../src/propgrid/props.cpp:155
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/unix/dlunix.cpp:118
 msgid "Unknown dynamic library error"
 msgstr "Ukendt fejl ved dynamisk bibliotek"
 
-#: ../src/common/fmapbase.cpp:810
+#: ../src/common/fmapbase.cpp:806
 #, c-format
 msgid "Unknown encoding (%d)"
 msgstr "Ukendt kodning (%d)"
 
-#: ../src/msw/ole/automtn.cpp:688
+#: ../src/msw/ole/automtn.cpp:679
 #, c-format
 msgid "Unknown error %08x"
 msgstr "Ukendt fejl %08x"
 
-#: ../src/msw/ole/automtn.cpp:647
+#: ../src/msw/ole/automtn.cpp:638
 msgid "Unknown exception"
 msgstr "Ukendt undtagelse"
 
-#: ../src/common/image.cpp:2839
+#: ../src/common/image.cpp:2942
 msgid "Unknown image data format."
 msgstr "Ukendt billeddataformat."
 
-#: ../src/common/cmdline.cpp:914
+#: ../src/common/cmdline.cpp:910
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Ukendt langt tilvalg \"%s\""
 
-#: ../src/msw/ole/automtn.cpp:631
+#: ../src/msw/ole/automtn.cpp:622
 msgid "Unknown name or named argument."
 msgstr "Ukendt navn eller navngivet argument."
 
-#: ../src/common/cmdline.cpp:929 ../src/common/cmdline.cpp:951
+#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Ukendt tilvalg \"%s\""
 
-#: ../src/common/mimecmn.cpp:225
+#: ../src/common/mimecmn.cpp:221
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "Uparret \"{\" i en indgang for mime type %s."
 
-#: ../src/common/cmdproc.cpp:262 ../src/common/cmdproc.cpp:288
-#: ../src/common/cmdproc.cpp:308
+#: ../src/common/cmdproc.cpp:255 ../src/common/cmdproc.cpp:281
+#: ../src/common/cmdproc.cpp:301
 msgid "Unnamed command"
 msgstr "Unavngiven kommando"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:413
+#: ../src/propgrid/propgrid.cpp:392
 msgid "Unspecified"
 msgstr "Uspecificeret"
 
-#: ../src/msw/clipbrd.cpp:311
+#: ../src/msw/clipbrd.cpp:325
 msgid "Unsupported clipboard format."
 msgstr "Ikke-understøttet udklipsholderformat."
 
-#: ../src/common/appcmn.cpp:256
+#: ../src/common/appcmn.cpp:277
 #, c-format
 msgid "Unsupported theme '%s'."
 msgstr "Ikke-understøttet tema \"%s\"."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:205
-#: ../src/common/accelcmn.cpp:63
+#: ../src/common/stockitem.cpp:202 ../src/common/accelcmn.cpp:60
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Up"
 msgstr "Op"
 
@@ -7661,7 +7837,7 @@ msgstr "Store bogstaver"
 msgid "Upper case roman numerals"
 msgstr "Store romertal"
 
-#: ../src/common/cmdline.cpp:1326
+#: ../src/common/cmdline.cpp:1322
 #, c-format
 msgid "Usage: %s"
 msgstr "Brug: %s"
@@ -7670,38 +7846,47 @@ msgstr "Brug: %s"
 msgid "Use &shadow"
 msgstr "Brug &skygge"
 
-#: ../src/richtext/richtextindentspage.cpp:169
-#: ../src/richtext/richtextindentspage.cpp:171
 #: ../src/richtext/richtextliststylepage.cpp:358
 #: ../src/richtext/richtextliststylepage.cpp:360
+#: ../src/richtext/richtextindentspage.cpp:169
+#: ../src/richtext/richtextindentspage.cpp:171
 msgid "Use the current alignment setting."
 msgstr "Brug aktuelle justering."
 
-#: ../src/common/valtext.cpp:179
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/gtk/font.cpp:552
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/common/valtext.cpp:142
 msgid "Validation conflict"
 msgstr "Valideringskonflikt"
 
-#: ../src/propgrid/manager.cpp:238
+#: ../src/propgrid/manager.cpp:224
 msgid "Value"
 msgstr "Værdi"
 
-#: ../src/propgrid/props.cpp:386 ../src/propgrid/props.cpp:500
+#: ../src/propgrid/props.cpp:309
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "Værdien skal være %s eller højere."
 
-#: ../src/propgrid/props.cpp:417 ../src/propgrid/props.cpp:531
+#: ../src/propgrid/props.cpp:336
 #, c-format
 msgid "Value must be %s or less."
 msgstr "Værdien skal være %s eller lavere."
 
-#: ../src/propgrid/props.cpp:393 ../src/propgrid/props.cpp:424
-#: ../src/propgrid/props.cpp:507 ../src/propgrid/props.cpp:538
+#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "Værdien skal være mellem %s og %s."
 
-#: ../src/generic/aboutdlgg.cpp:128
+#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Version "
 
@@ -7710,25 +7895,32 @@ msgstr "Version "
 msgid "Vertical alignment."
 msgstr "Lodret justering."
 
-#: ../src/generic/filedlgg.cpp:202
+#: ../src/generic/filedlgg.cpp:199
 msgid "View files as a detailed view"
 msgstr "Vis filer med detaljeretvisning"
 
-#: ../src/generic/filedlgg.cpp:200
+#: ../src/generic/filedlgg.cpp:197
 msgid "View files as a list view"
 msgstr "Vis filer med listevisning"
 
-#: ../src/common/docview.cpp:1970
+#: ../src/common/docview.cpp:1975
 msgid "Views"
 msgstr "Visninger"
 
+#: ../src/gtk/app.cpp:348
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1777
+#: ../src/propgrid/advprops.cpp:1678
 msgid "Wait"
 msgstr "Vent"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1779
+#: ../src/propgrid/advprops.cpp:1680
 msgid "Wait Arrow"
 msgstr "Ventepil"
 
@@ -7737,238 +7929,235 @@ msgstr "Ventepil"
 msgid "Waiting for IO on epoll descriptor %d failed"
 msgstr "Venter på IO på epoll-deskriptor %d fejlede"
 
-#: ../src/common/log.cpp:223
+#: ../src/common/log.cpp:241
 msgid "Warning: "
 msgstr "Advarsel: "
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1778
+#: ../src/propgrid/advprops.cpp:1679
 msgid "Watch"
 msgstr "Overvåg"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:685
+#: ../src/propgrid/advprops.cpp:595
 msgid "Weight"
 msgstr "Vægt"
 
-#: ../src/common/fmapbase.cpp:148
+#: ../src/common/fmapbase.cpp:145
 msgid "Western European (ISO-8859-1)"
 msgstr "Vesteuropæisk (ISO-8859-1)"
 
-#: ../src/common/fmapbase.cpp:162
+#: ../src/common/fmapbase.cpp:159
 msgid "Western European with Euro (ISO-8859-15)"
 msgstr "Vesteuropæisk med euro (ISO-8859-15)"
 
-#: ../src/generic/fontdlgg.cpp:446 ../src/generic/fontdlgg.cpp:448
+#: ../src/generic/fontdlgg.cpp:443 ../src/generic/fontdlgg.cpp:445
 msgid "Whether the font is underlined."
 msgstr "Om skriften er understreget."
 
-#: ../src/propgrid/advprops.cpp:1611
+#: ../src/propgrid/advprops.cpp:1517
 msgid "White"
 msgstr "Hvid"
 
-#: ../src/generic/fdrepdlg.cpp:144
+#: ../src/generic/fdrepdlg.cpp:141
 msgid "Whole word"
 msgstr "Hele ord"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:532
 msgid "Whole words only"
 msgstr "Kun hele ord"
 
-#: ../src/univ/themes/win32.cpp:1102
+#: ../src/univ/themes/win32.cpp:1099
 msgid "Win32 theme"
 msgstr "Win32 tema"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:893
+#: ../src/propgrid/advprops.cpp:794
 msgid "Window"
 msgstr "Vindue"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:894
+#: ../src/propgrid/advprops.cpp:795
 msgid "WindowFrame"
 msgstr "Vinduesramme"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:895
+#: ../src/propgrid/advprops.cpp:796
 msgid "WindowText"
 msgstr "Vinduestekst"
 
-#: ../src/common/fmapbase.cpp:177
+#: ../src/common/fmapbase.cpp:174
 msgid "Windows Arabic (CP 1256)"
 msgstr "Windows arabisk (CP 1256)"
 
-#: ../src/common/fmapbase.cpp:178
+#: ../src/common/fmapbase.cpp:175
 msgid "Windows Baltic (CP 1257)"
 msgstr "Windows baltisk (CP 1257)"
 
-#: ../src/common/fmapbase.cpp:171
+#: ../src/common/fmapbase.cpp:168
 msgid "Windows Central European (CP 1250)"
 msgstr "Windows centraleuropæisk (CP 1250)"
 
-#: ../src/common/fmapbase.cpp:168
+#: ../src/common/fmapbase.cpp:165
 msgid "Windows Chinese Simplified (CP 936) or GB-2312"
 msgstr "Windows kinesisk forenklet (CP 936) eller GB-2312"
 
-#: ../src/common/fmapbase.cpp:170
+#: ../src/common/fmapbase.cpp:167
 msgid "Windows Chinese Traditional (CP 950) or Big-5"
 msgstr "Windows kinesisk traditionel (CP 950) eller Big-5"
 
-#: ../src/common/fmapbase.cpp:172
+#: ../src/common/fmapbase.cpp:169
 msgid "Windows Cyrillic (CP 1251)"
 msgstr "Windows kyrillisk (CP 1251)"
 
-#: ../src/common/fmapbase.cpp:174
+#: ../src/common/fmapbase.cpp:171
 msgid "Windows Greek (CP 1253)"
 msgstr "Windows græsk (CP 1253)"
 
-#: ../src/common/fmapbase.cpp:176
+#: ../src/common/fmapbase.cpp:173
 msgid "Windows Hebrew (CP 1255)"
 msgstr "Windows hebraisk (CP 1255)"
 
-#: ../src/common/fmapbase.cpp:167
+#: ../src/common/fmapbase.cpp:164
 msgid "Windows Japanese (CP 932) or Shift-JIS"
 msgstr "Windows japansk (CP 932) eller Shift-JIS"
 
-#: ../src/common/fmapbase.cpp:180
+#: ../src/common/fmapbase.cpp:177
 msgid "Windows Johab (CP 1361)"
 msgstr "Windows johab (CP 1361)"
 
-#: ../src/common/fmapbase.cpp:169
+#: ../src/common/fmapbase.cpp:166
 msgid "Windows Korean (CP 949)"
 msgstr "Windows koreansk (CP 949)"
 
-#: ../src/common/fmapbase.cpp:166
+#: ../src/common/fmapbase.cpp:163
 msgid "Windows Thai (CP 874)"
 msgstr "Windows thailandsk (CP 874)"
 
-#: ../src/common/fmapbase.cpp:175
+#: ../src/common/fmapbase.cpp:172
 msgid "Windows Turkish (CP 1254)"
 msgstr "Windows tyrkisk (CP 1254)"
 
-#: ../src/common/fmapbase.cpp:179
+#: ../src/common/fmapbase.cpp:176
 msgid "Windows Vietnamese (CP 1258)"
 msgstr "Windows vietnamesisk (CP 1258)"
 
-#: ../src/common/fmapbase.cpp:173
+#: ../src/common/fmapbase.cpp:170
 msgid "Windows Western European (CP 1252)"
 msgstr "Windows vesteuropæisk (CP 1252)"
 
-#: ../src/common/fmapbase.cpp:181
+#: ../src/common/fmapbase.cpp:178
 msgid "Windows/DOS OEM (CP 437)"
 msgstr "Windows/DOS OEM (CP 437)"
 
-#: ../src/common/fmapbase.cpp:165
+#: ../src/common/fmapbase.cpp:162
 msgid "Windows/DOS OEM Cyrillic (CP 866)"
 msgstr "Windows/DOS OEM kyrillisk (CP 866)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:111
+#: ../src/common/accelcmn.cpp:109
 msgid "Windows_Left"
 msgstr "Windows_Venstre"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:113
+#: ../src/common/accelcmn.cpp:111
 msgid "Windows_Menu"
 msgstr "Windows_Menu"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:112
+#: ../src/common/accelcmn.cpp:110
 msgid "Windows_Right"
 msgstr "Windows_Højre"
 
-#: ../src/common/ffile.cpp:150
+#: ../src/common/ffile.cpp:149
 #, c-format
 msgid "Write error on file '%s'"
 msgstr "Skrivefejl på filen \"%s\""
 
-#: ../src/xml/xml.cpp:914
+#: ../src/xml/xml.cpp:925
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "XML tolkningsfejl: \"%s\" på linje %d"
 
-#: ../src/common/xpmdecod.cpp:796
+#: ../src/common/xpmdecod.cpp:794
 msgid "XPM: Malformed pixel data!"
 msgstr "XPM: dårligt udformet pixeldata!"
 
-#: ../src/common/xpmdecod.cpp:705
+#: ../src/common/xpmdecod.cpp:702
 #, c-format
 msgid "XPM: incorrect colour description in line %d"
 msgstr "XPM: forkert farvebeskrivelse i linje %d"
 
-#: ../src/common/xpmdecod.cpp:680
+#: ../src/common/xpmdecod.cpp:677
 msgid "XPM: incorrect header format!"
 msgstr "XPM: forkert header-format!"
 
-#: ../src/common/xpmdecod.cpp:716 ../src/common/xpmdecod.cpp:725
+#: ../src/common/xpmdecod.cpp:714 ../src/common/xpmdecod.cpp:723
 #, c-format
 msgid "XPM: malformed colour definition '%s' at line %d!"
 msgstr "XPM: dårligt udformet farvedefinition \"%s\" i linje %d!"
 
-#: ../src/common/xpmdecod.cpp:755
+#: ../src/common/xpmdecod.cpp:753
 msgid "XPM: no colors left to use for mask!"
 msgstr "XPM: ingen farver tilbage at bruge til maske!"
 
-#: ../src/common/xpmdecod.cpp:782
+#: ../src/common/xpmdecod.cpp:780
 #, c-format
 msgid "XPM: truncated image data at line %d!"
 msgstr "XPM: afskåret billeddata på linje %d!"
 
-#: ../src/propgrid/advprops.cpp:1610
+#: ../src/propgrid/advprops.cpp:1516
 msgid "Yellow"
 msgstr "Gul"
 
-#: ../include/wx/msgdlg.h:276 ../src/common/stockitem.cpp:206
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:203
 #: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Ja"
 
-#: ../src/osx/carbon/overlay.cpp:155
-msgid "You cannot Clear an overlay that is not inited"
-msgstr "Du kan ikke cleare et overlay, som ikke er blevet initialiseret"
-
-#: ../src/osx/carbon/overlay.cpp:107 ../src/dfb/overlay.cpp:61
-msgid "You cannot Init an overlay twice"
-msgstr "Du kan ikke initialisere et overlay to gange"
-
-#: ../src/generic/dirdlgg.cpp:287
+#: ../src/generic/dirdlgg.cpp:284
 msgid "You cannot add a new directory to this section."
 msgstr "Du kan ikke tilføje en mappe til denne sektion."
 
-#: ../src/propgrid/propgrid.cpp:3299
+#: ../src/propgrid/propgrid.cpp:3276
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 "Du har indtastet en ugyldig værdi. Tryk på ESC for at annullere redigeringen."
 
-#: ../src/common/stockitem.cpp:209
+#: ../src/osx/cocoa/menu.mm:286
+#, fuzzy
+msgid "Zoom"
+msgstr "Zoom ind"
+
+#: ../src/common/stockitem.cpp:206
 msgid "Zoom &In"
 msgstr "Zoom &Ind"
 
-#: ../src/common/stockitem.cpp:210
+#: ../src/common/stockitem.cpp:207
 msgid "Zoom &Out"
 msgstr "Zoom &Ud"
 
-#: ../src/common/stockitem.cpp:209 ../src/common/prntbase.cpp:1594
+#: ../src/common/stockitem.cpp:206 ../src/common/prntbase.cpp:1619
 msgid "Zoom In"
 msgstr "Zoom ind"
 
-#: ../src/common/stockitem.cpp:210 ../src/common/prntbase.cpp:1580
+#: ../src/common/stockitem.cpp:207 ../src/common/prntbase.cpp:1605
 msgid "Zoom Out"
 msgstr "Zoom ud"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to &Fit"
 msgstr "Zoom &tilpasset"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to Fit"
 msgstr "Zoom tilpasset"
 
-#: ../src/msw/dde.cpp:1141
+#: ../src/msw/dde.cpp:1205
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "en DDEML-applikation har lavet en forlænget race condition."
 
-#: ../src/msw/dde.cpp:1129
+#: ../src/msw/dde.cpp:1193
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -7979,39 +8168,39 @@ msgstr ""
 "eller der er sendt en ugyldig instans\n"
 "indentifikator til en DDEML-funktion."
 
-#: ../src/msw/dde.cpp:1147
+#: ../src/msw/dde.cpp:1211
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "en klients forsøg på at starte en samtale slog fejl."
 
-#: ../src/msw/dde.cpp:1144
+#: ../src/msw/dde.cpp:1208
 msgid "a memory allocation failed."
 msgstr "en hukommelsestildeling fejlede."
 
-#: ../src/msw/dde.cpp:1138
+#: ../src/msw/dde.cpp:1202
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "en parameter kunne ikke valideres af DDEML."
 
-#: ../src/msw/dde.cpp:1120
+#: ../src/msw/dde.cpp:1184
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "en anmodning om synkron advise-transaktion fik timeout."
 
-#: ../src/msw/dde.cpp:1126
+#: ../src/msw/dde.cpp:1190
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "en anmodning om en synkron data-transaktion fik timeout."
 
-#: ../src/msw/dde.cpp:1135
+#: ../src/msw/dde.cpp:1199
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "en anmodning om en synkron execute-transaktion fik timeout."
 
-#: ../src/msw/dde.cpp:1153
+#: ../src/msw/dde.cpp:1217
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "en anmodning om en synkron poke-transaktion fik timeout."
 
-#: ../src/msw/dde.cpp:1168
+#: ../src/msw/dde.cpp:1232
 msgid "a request to end an advise transaction has timed out."
 msgstr "en anmodning om at afslutte en advise-transaktion fik timeout."
 
-#: ../src/msw/dde.cpp:1162
+#: ../src/msw/dde.cpp:1226
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -8021,15 +8210,15 @@ msgstr ""
 "der blev afsluttet af klienten, eller serveren afsluttede\n"
 "inden fuldførslen af en transaktion."
 
-#: ../src/msw/dde.cpp:1150
+#: ../src/msw/dde.cpp:1214
 msgid "a transaction failed."
 msgstr "en transaktion fejlede."
 
-#: ../src/common/accelcmn.cpp:189
+#: ../src/common/accelcmn.cpp:188
 msgid "alt"
 msgstr "alt"
 
-#: ../src/msw/dde.cpp:1132
+#: ../src/msw/dde.cpp:1196
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -8041,15 +8230,15 @@ msgstr ""
 "eller et program initialiseret som APPCMD_CLIENTONLY\n"
 "har forsøgt at udføre server-transaktioner."
 
-#: ../src/msw/dde.cpp:1156
+#: ../src/msw/dde.cpp:1220
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "et internt kald til PostMessage-funktionen fejlede. "
 
-#: ../src/msw/dde.cpp:1165
+#: ../src/msw/dde.cpp:1229
 msgid "an internal error has occurred in the DDEML."
 msgstr "intern fejl opstået i DDEML."
 
-#: ../src/msw/dde.cpp:1171
+#: ../src/msw/dde.cpp:1235
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -8059,56 +8248,56 @@ msgstr ""
 "Når programmet er returneret fra et XTYP_XACT_COMPLETE-tilbagekald,\n"
 "er transaktion identifikationen for dette tilbagekald ikke længere gyldig."
 
-#: ../src/common/zipstrm.cpp:1483
+#: ../src/common/zipstrm.cpp:1522
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "antager at dette er en sammensat multi-part zip"
 
-#: ../src/common/fileconf.cpp:1847
+#: ../src/common/fileconf.cpp:1849
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "forsøg på at ændre uforanderlig nøgle \"%s\" ignoreret."
 
-#: ../src/html/chm.cpp:329
+#: ../src/html/chm.cpp:326
 msgid "bad arguments to library function"
 msgstr "ugyldige argumenter til biblioteksfunktion"
 
-#: ../src/html/chm.cpp:341
+#: ../src/html/chm.cpp:338
 msgid "bad signature"
 msgstr "forkert signatur"
 
-#: ../src/common/zipstrm.cpp:1918
+#: ../src/common/zipstrm.cpp:1988
 msgid "bad zipfile offset to entry"
 msgstr "forkert zip-fil offset til entry"
 
-#: ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400
 msgid "binary"
 msgstr "binær"
 
-#: ../src/common/fontcmn.cpp:996
+#: ../src/common/fontcmn.cpp:1195
 msgid "bold"
 msgstr "fed"
 
-#: ../src/msw/utils.cpp:1144
+#: ../src/msw/utils.cpp:1135
 #, c-format
 msgid "build %lu"
 msgstr "byg %lu"
 
-#: ../src/common/ffile.cpp:75
+#: ../src/common/ffile.cpp:73
 #, c-format
 msgid "can't close file '%s'"
 msgstr "kan ikke lukke filen \"%s\""
 
-#: ../src/common/file.cpp:245
+#: ../src/common/file.cpp:242
 #, c-format
 msgid "can't close file descriptor %d"
 msgstr "kan ikke lukke fildeskriptoren %d"
 
-#: ../src/common/file.cpp:586
+#: ../src/common/ffile.cpp:382 ../src/common/file.cpp:613
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "kan ikke udføre ændringer på filen \"%s\""
 
-#: ../src/common/file.cpp:178
+#: ../src/common/file.cpp:175
 #, c-format
 msgid "can't create file '%s'"
 msgstr "kan ikke oprette filen \"%s\""
@@ -8118,49 +8307,49 @@ msgstr "kan ikke oprette filen \"%s\""
 msgid "can't delete user configuration file '%s'"
 msgstr "kan ikke slette brugerkonfigurationsfilen \"%s\""
 
-#: ../src/common/file.cpp:495
+#: ../src/common/file.cpp:522
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr "kan ikke afgøre om slutningen på filen er nået på deskriptoren %d"
 
-#: ../src/common/zipstrm.cpp:1692
+#: ../src/common/zipstrm.cpp:1747
 msgid "can't find central directory in zip"
 msgstr "kan ikke finde den centrale mappe i zip"
 
-#: ../src/common/file.cpp:465
+#: ../src/common/file.cpp:492
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "kan ikke finde længden af filen på fildeskriptor %d"
 
-#: ../src/msw/utils.cpp:341
+#: ../src/msw/utils.cpp:336
 msgid "can't find user's HOME, using current directory."
 msgstr "kan ikke finde brugerens hjemmemappe, bruger aktuelle mappe."
 
-#: ../src/common/file.cpp:366
+#: ../src/common/file.cpp:407
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "kan ikke flushe fildeskriptoren %d"
 
-#: ../src/common/file.cpp:422
+#: ../src/common/file.cpp:463
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "kan ikke få søgeposition på fildeskriptoren %d"
 
-#: ../src/common/fontmap.cpp:325
+#: ../src/common/fontmap.cpp:322
 msgid "can't load any font, aborting"
 msgstr "kan ikke indlæse nogen skrifttype, afbryder"
 
-#: ../src/common/file.cpp:231 ../src/common/ffile.cpp:59
+#: ../src/common/ffile.cpp:57 ../src/common/file.cpp:228
 #, c-format
 msgid "can't open file '%s'"
 msgstr "kan ikke åbne filen \"%s\""
 
-#: ../src/common/fileconf.cpp:320
+#: ../src/common/fileconf.cpp:314
 #, c-format
 msgid "can't open global configuration file '%s'."
 msgstr "kan ikke åbne global konfigurationsfilen \"%s\"."
 
-#: ../src/common/fileconf.cpp:336
+#: ../src/common/fileconf.cpp:330
 #, c-format
 msgid "can't open user configuration file '%s'."
 msgstr "kan ikke åbne brugerkonfigurationsfilen \"%s\"."
@@ -8169,40 +8358,40 @@ msgstr "kan ikke åbne brugerkonfigurationsfilen \"%s\"."
 msgid "can't open user configuration file."
 msgstr "kan ikke åbne brugerkonfigurationsfilen."
 
-#: ../src/common/zipstrm.cpp:579
+#: ../src/common/zipstrm.cpp:572
 msgid "can't re-initialize zlib deflate stream"
 msgstr "kan ikke re-initialisere zlib deflate strøm"
 
-#: ../src/common/zipstrm.cpp:604
+#: ../src/common/zipstrm.cpp:597
 msgid "can't re-initialize zlib inflate stream"
 msgstr "kan ikke re-initialisere zlib inflate strøm"
 
-#: ../src/common/file.cpp:304
+#: ../src/common/file.cpp:345
 #, c-format
 msgid "can't read from file descriptor %d"
 msgstr "kan ikke læse fra fildeskriptoren %d"
 
-#: ../src/common/file.cpp:581
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:608
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "kan ikke fjerne filen \"%s\""
 
-#: ../src/common/file.cpp:598
+#: ../src/common/ffile.cpp:394 ../src/common/file.cpp:625
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "kan ikke fjerne midlertidig fil \"%s\""
 
-#: ../src/common/file.cpp:408
+#: ../src/common/file.cpp:449
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "kan ikke søge på fildeskriptoren %d"
 
-#: ../src/common/textfile.cpp:273
+#: ../src/common/textfile.cpp:161
 #, c-format
 msgid "can't write buffer '%s' to disk."
 msgstr "kan ikke skrive buffer \"%s\" til disk."
 
-#: ../src/common/file.cpp:323
+#: ../src/common/file.cpp:364
 #, c-format
 msgid "can't write to file descriptor %d"
 msgstr "kan ikke skrive til fildeskriptoren %d"
@@ -8212,22 +8401,28 @@ msgid "can't write user configuration file."
 msgstr "kan ikke skrive brugerkonfigurationsfilen."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:482 ../src/generic/datavgen.cpp:1261
+#: ../src/common/datavcmn.cpp:2064 ../src/generic/datavgen.cpp:1384
 msgid "checked"
 msgstr "tilvalgt"
 
-#: ../src/html/chm.cpp:345
+#: ../src/html/chm.cpp:342
 msgid "checksum error"
 msgstr "checksum fejl"
 
-#: ../src/common/tarstrm.cpp:820
+#: ../src/common/tarstrm.cpp:814
 msgid "checksum failure reading tar header block"
 msgstr "checksum fejlede ved læsning af tar-header-blok"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:226
-#: ../src/richtext/richtextbackgroundpage.cpp:249
-#: ../src/richtext/richtextbackgroundpage.cpp:289
-#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
 #: ../src/richtext/richtextborderspage.cpp:254
 #: ../src/richtext/richtextborderspage.cpp:288
 #: ../src/richtext/richtextborderspage.cpp:322
@@ -8245,104 +8440,127 @@ msgstr "checksum fejlede ved læsning af tar-header-blok"
 #: ../src/richtext/richtextmarginspage.cpp:340
 #: ../src/richtext/richtextmarginspage.cpp:363
 #: ../src/richtext/richtextmarginspage.cpp:388
-#: ../src/richtext/richtextsizepage.cpp:339
-#: ../src/richtext/richtextsizepage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:400
-#: ../src/richtext/richtextsizepage.cpp:427
-#: ../src/richtext/richtextsizepage.cpp:454
-#: ../src/richtext/richtextsizepage.cpp:481
-#: ../src/richtext/richtextsizepage.cpp:555
-#: ../src/richtext/richtextsizepage.cpp:590
-#: ../src/richtext/richtextsizepage.cpp:625
-#: ../src/richtext/richtextsizepage.cpp:660
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
 msgid "cm"
 msgstr "cm"
 
-#: ../src/html/chm.cpp:347
+#: ../src/html/chm.cpp:344
 msgid "compression error"
 msgstr "fejl ved komprimering"
 
-#: ../src/common/regex.cpp:236
+#: ../src/common/regex.cpp:233
 msgid "conversion to 8-bit encoding failed"
 msgstr "konvertering til 8-bit kodning fejlede"
 
-#: ../src/common/accelcmn.cpp:187
+#: ../src/common/accelcmn.cpp:186
 msgid "ctrl"
 msgstr "ctrl"
 
-#: ../src/common/cmdline.cpp:1500
+#: ../src/common/cmdline.cpp:1496
 msgid "date"
 msgstr "dato"
 
-#: ../src/html/chm.cpp:349
+#: ../src/html/chm.cpp:346
 msgid "decompression error"
 msgstr "fejl ved udpakning"
 
-#: ../src/richtext/richtextstyles.cpp:780 ../src/common/fmapbase.cpp:820
+#: ../src/common/fmapbase.cpp:816 ../src/richtext/richtextstyles.cpp:777
 msgid "default"
 msgstr "standard"
 
-#: ../src/common/cmdline.cpp:1496
+#: ../src/common/cmdline.cpp:1492
 msgid "double"
 msgstr "double"
 
-#: ../src/common/debugrpt.cpp:538
+#: ../src/common/debugrpt.cpp:539
 msgid "dump of the process state (binary)"
 msgstr "dump af proces-status (binær)"
 
-#: ../src/common/datetimefmt.cpp:1969
+#: ../src/common/datetimefmt.cpp:1992
 msgid "eighteenth"
 msgstr "attende"
 
-#: ../src/common/datetimefmt.cpp:1959
+#: ../src/common/datetimefmt.cpp:1982
 msgid "eighth"
 msgstr "ottende"
 
-#: ../src/common/datetimefmt.cpp:1962
+#: ../src/common/datetimefmt.cpp:1985
 msgid "eleventh"
 msgstr "elvte"
 
-#: ../src/common/fileconf.cpp:1833
+#: ../src/common/fileconf.cpp:1835
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "indgang \"%s\" optræder mere end en gang i gruppe \"%s\""
 
-#: ../src/html/chm.cpp:343
+#: ../src/html/chm.cpp:340
 msgid "error in data format"
 msgstr "fejl i dataformat"
 
-#: ../src/html/chm.cpp:331
+#: ../src/html/chm.cpp:328
 msgid "error opening file"
 msgstr "fejl ved åbning af fil"
 
-#: ../src/common/zipstrm.cpp:1778
+#: ../src/common/zipstrm.cpp:1836
 msgid "error reading zip central directory"
 msgstr "fejl ved læsning af centrale zip-mappe"
 
-#: ../src/common/zipstrm.cpp:1870
+#: ../src/common/zipstrm.cpp:1940
 msgid "error reading zip local header"
 msgstr "fejl ved læsning af zip local header"
 
-#: ../src/common/zipstrm.cpp:2531
+#: ../src/common/zipstrm.cpp:2615
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "fejl ved skrivning af zip-entry \"%s\": forkert crc eller længde"
 
-#: ../src/common/ffile.cpp:188
+#: ../src/common/zipstrm.cpp:2608
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "fejl ved skrivning af zip-entry \"%s\": forkert crc eller længde"
+
+#: ../src/common/fontcmn.cpp:1205
+#, fuzzy
+msgid "extrabold"
+msgstr "fed"
+
+#: ../src/common/fontcmn.cpp:1223
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1167
+#, fuzzy
+msgid "extralight"
+msgstr "let"
+
+#: ../src/msw/webview_ie.cpp:1036
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "Kunne ikke eksekvere \"%s\"\n"
+
+#: ../src/common/ffile.cpp:187
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "kunne ikke flushe filen \"%s\""
 
+#: ../src/msw/webview_ie.cpp:1045
+#, fuzzy
+msgid "failed to retrieve execution result"
+msgstr "Kunne ikke hente tekst fra RAS fejlmeddelelse"
+
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1030
+#: ../src/generic/datavgen.cpp:1150
 msgid "false"
 msgstr "falsk"
 
-#: ../src/common/datetimefmt.cpp:1966
+#: ../src/common/datetimefmt.cpp:1989
 msgid "fifteenth"
 msgstr "femtende"
 
-#: ../src/common/datetimefmt.cpp:1956
+#: ../src/common/datetimefmt.cpp:1979
 msgid "fifth"
 msgstr "femte"
 
@@ -8372,131 +8590,150 @@ msgstr ""
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "fil \"%s\": uventet tegn %c på linje %zu."
 
-#: ../src/richtext/richtextbuffer.cpp:8738
+#: ../src/richtext/richtextbuffer.cpp:8736
 msgid "files"
 msgstr "filer"
 
-#: ../src/common/datetimefmt.cpp:1952
+#: ../src/common/datetimefmt.cpp:1975
 msgid "first"
 msgstr "første"
 
-#: ../src/html/helpwnd.cpp:1252
+#: ../src/html/helpwnd.cpp:1250
 msgid "font size"
 msgstr "skriftstørrelse"
 
-#: ../src/common/datetimefmt.cpp:1965
+#: ../src/common/datetimefmt.cpp:1988
 msgid "fourteenth"
 msgstr "fjortende"
 
-#: ../src/common/datetimefmt.cpp:1955
+#: ../src/common/datetimefmt.cpp:1978
 msgid "fourth"
 msgstr "fjerde"
 
-#: ../src/common/appbase.cpp:783
+#: ../src/common/appbase.cpp:784
 msgid "generate verbose log messages"
 msgstr "generer udførlige logmeddelelser"
 
-#: ../src/richtext/richtextbuffer.cpp:13138
-#: ../src/richtext/richtextbuffer.cpp:13248
+#: ../src/common/fontcmn.cpp:1215
+msgid "heavy"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:13133
+#: ../src/richtext/richtextbuffer.cpp:13243
 msgid "image"
 msgstr "billede"
 
-#: ../src/common/tarstrm.cpp:796
+#: ../src/common/tarstrm.cpp:790
 msgid "incomplete header block in tar"
 msgstr "ukomplet header-blok i tar"
 
-#: ../src/common/xtixml.cpp:489
+#: ../src/common/xtixml.cpp:485
 msgid "incorrect event handler string, missing dot"
 msgstr "forkert event-handler-streng. Mangler punktum"
 
-#: ../src/common/tarstrm.cpp:1381
+#: ../src/common/tarstrm.cpp:1375
 msgid "incorrect size given for tar entry"
 msgstr "forkert størrelse givet for tar-entry"
 
-#: ../src/common/tarstrm.cpp:993
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:987
 msgid "invalid data in extended tar header"
 msgstr "ugyldige data i udvidet tar-header"
 
-#: ../src/generic/logg.cpp:1030
+#: ../src/generic/logg.cpp:1027
 msgid "invalid message box return value"
 msgstr "ugyldig returværdi i meddelelsesboks"
 
-#: ../src/common/zipstrm.cpp:1647
+#: ../src/common/zipstrm.cpp:1688
 msgid "invalid zip file"
 msgstr "ugyldig zip-fil"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:1228
 msgid "italic"
 msgstr "kursiv"
 
-#: ../src/common/fontcmn.cpp:991
+#: ../src/common/webrequest_curl.cpp:374
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "Fil kunne ikke indlæses."
+
+#: ../src/common/fontcmn.cpp:1172
 msgid "light"
 msgstr "let"
 
-#: ../src/common/intl.cpp:303
-#, c-format
-msgid "locale '%s' cannot be set."
-msgstr "lokale \"%s\" kan ikke sættes."
+#: ../src/common/fontcmn.cpp:1185
+msgid "medium"
+msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2125
+#: ../src/common/datetimefmt.cpp:2148
 msgid "midnight"
 msgstr "midnat"
 
-#: ../src/common/datetimefmt.cpp:1970
+#: ../src/common/datetimefmt.cpp:1993
 msgid "nineteenth"
 msgstr "nittende"
 
-#: ../src/common/datetimefmt.cpp:1960
+#: ../src/common/datetimefmt.cpp:1983
 msgid "ninth"
 msgstr "niende"
 
-#: ../src/msw/dde.cpp:1116
+#: ../src/msw/dde.cpp:1180
 msgid "no DDE error."
 msgstr "ingen DDE-fejl."
 
-#: ../src/html/chm.cpp:327
+#: ../src/html/chm.cpp:324
 msgid "no error"
 msgstr "ingen fejl"
 
-#: ../src/dfb/fontmgr.cpp:174
+#: ../src/dfb/fontmgr.cpp:171
 #, c-format
 msgid "no fonts found in %s, using builtin font"
 msgstr "ingen skrifttyper fundet i %s. Bruger indbygget skrifttype"
 
-#: ../src/html/helpdata.cpp:657
+#: ../src/html/helpdata.cpp:650
 msgid "noname"
 msgstr "unavngivet"
 
-#: ../src/common/datetimefmt.cpp:2124
+#: ../src/common/datetimefmt.cpp:2147
 msgid "noon"
 msgstr "middag"
 
-#: ../src/richtext/richtextstyles.cpp:779
+#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "normal"
 
-#: ../src/common/cmdline.cpp:1492
+#: ../src/common/cmdline.cpp:1488
 msgid "num"
 msgstr "nummer"
 
-#: ../src/common/xtixml.cpp:259
+#: ../src/common/accelcmn.cpp:194
+msgid "num "
+msgstr ""
+
+#: ../src/common/xtixml.cpp:255
 msgid "objects cannot have XML Text Nodes"
 msgstr "objekter kan ikke have XML-tekstknuder"
 
-#: ../src/html/chm.cpp:339
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
 msgid "out of memory"
 msgstr "ikke mere ledig hukommelse"
 
-#: ../src/common/debugrpt.cpp:514
+#: ../src/common/debugrpt.cpp:515
 msgid "process context description"
 msgstr "proces kontekst beskrivelse"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:227
-#: ../src/richtext/richtextbackgroundpage.cpp:250
-#: ../src/richtext/richtextbackgroundpage.cpp:290
-#: ../src/richtext/richtextbackgroundpage.cpp:317
-#: ../src/richtext/richtextfontpage.cpp:177
-#: ../src/richtext/richtextfontpage.cpp:180
 #: ../src/richtext/richtextborderspage.cpp:255
 #: ../src/richtext/richtextborderspage.cpp:289
 #: ../src/richtext/richtextborderspage.cpp:323
@@ -8506,22 +8743,45 @@ msgstr "proces kontekst beskrivelse"
 #: ../src/richtext/richtextborderspage.cpp:491
 #: ../src/richtext/richtextborderspage.cpp:525
 #: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextfontpage.cpp:180
 msgid "pt"
 msgstr "pt"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:225
-#: ../src/richtext/richtextbackgroundpage.cpp:228
-#: ../src/richtext/richtextbackgroundpage.cpp:229
-#: ../src/richtext/richtextbackgroundpage.cpp:248
-#: ../src/richtext/richtextbackgroundpage.cpp:251
-#: ../src/richtext/richtextbackgroundpage.cpp:252
-#: ../src/richtext/richtextbackgroundpage.cpp:288
-#: ../src/richtext/richtextbackgroundpage.cpp:291
-#: ../src/richtext/richtextbackgroundpage.cpp:292
-#: ../src/richtext/richtextbackgroundpage.cpp:315
-#: ../src/richtext/richtextbackgroundpage.cpp:318
-#: ../src/richtext/richtextbackgroundpage.cpp:319
-#: ../src/richtext/richtextfontpage.cpp:178
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:659
+#: ../src/richtext/richtextsizepage.cpp:662
+#: ../src/richtext/richtextsizepage.cpp:663
 #: ../src/richtext/richtextborderspage.cpp:253
 #: ../src/richtext/richtextborderspage.cpp:256
 #: ../src/richtext/richtextborderspage.cpp:257
@@ -8573,259 +8833,269 @@ msgstr "pt"
 #: ../src/richtext/richtextmarginspage.cpp:387
 #: ../src/richtext/richtextmarginspage.cpp:389
 #: ../src/richtext/richtextmarginspage.cpp:390
-#: ../src/richtext/richtextsizepage.cpp:338
-#: ../src/richtext/richtextsizepage.cpp:341
-#: ../src/richtext/richtextsizepage.cpp:342
-#: ../src/richtext/richtextsizepage.cpp:372
-#: ../src/richtext/richtextsizepage.cpp:375
-#: ../src/richtext/richtextsizepage.cpp:376
-#: ../src/richtext/richtextsizepage.cpp:399
-#: ../src/richtext/richtextsizepage.cpp:402
-#: ../src/richtext/richtextsizepage.cpp:403
-#: ../src/richtext/richtextsizepage.cpp:426
-#: ../src/richtext/richtextsizepage.cpp:429
-#: ../src/richtext/richtextsizepage.cpp:430
-#: ../src/richtext/richtextsizepage.cpp:453
-#: ../src/richtext/richtextsizepage.cpp:456
-#: ../src/richtext/richtextsizepage.cpp:457
-#: ../src/richtext/richtextsizepage.cpp:480
-#: ../src/richtext/richtextsizepage.cpp:483
-#: ../src/richtext/richtextsizepage.cpp:484
-#: ../src/richtext/richtextsizepage.cpp:554
-#: ../src/richtext/richtextsizepage.cpp:557
-#: ../src/richtext/richtextsizepage.cpp:558
-#: ../src/richtext/richtextsizepage.cpp:589
-#: ../src/richtext/richtextsizepage.cpp:592
-#: ../src/richtext/richtextsizepage.cpp:593
-#: ../src/richtext/richtextsizepage.cpp:624
-#: ../src/richtext/richtextsizepage.cpp:627
-#: ../src/richtext/richtextsizepage.cpp:628
-#: ../src/richtext/richtextsizepage.cpp:659
-#: ../src/richtext/richtextsizepage.cpp:662
-#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextfontpage.cpp:178
 msgid "px"
 msgstr "px"
 
-#: ../src/common/accelcmn.cpp:193
+#: ../src/common/accelcmn.cpp:192
 msgid "rawctrl"
 msgstr "rawctrl"
 
-#: ../src/html/chm.cpp:333
+#: ../src/html/chm.cpp:330
 msgid "read error"
 msgstr "læsefejl"
 
-#: ../src/common/zipstrm.cpp:2085
+#: ../src/common/zipstrm.cpp:2155
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "læser zip-strøm (entry %s): forkert crc"
 
-#: ../src/common/zipstrm.cpp:2080
+#: ../src/common/zipstrm.cpp:2150
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "læser zip-strøm (entry %s): forkert længde"
 
-#: ../src/msw/dde.cpp:1159
+#: ../src/msw/dde.cpp:1223
 msgid "reentrancy problem."
 msgstr "reentrancy problem."
 
-#: ../src/common/datetimefmt.cpp:1953
+#: ../src/common/datetimefmt.cpp:1976
 msgid "second"
 msgstr "anden"
 
-#: ../src/html/chm.cpp:337
+#: ../src/html/chm.cpp:334
 msgid "seek error"
 msgstr "søgefejl"
 
-#: ../src/common/datetimefmt.cpp:1968
+#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#, fuzzy
+msgid "semibold"
+msgstr "fed"
+
+#: ../src/common/datetimefmt.cpp:1991
 msgid "seventeenth"
 msgstr "syttende"
 
-#: ../src/common/datetimefmt.cpp:1958
+#: ../src/common/datetimefmt.cpp:1981
 msgid "seventh"
 msgstr "syvende"
 
-#: ../src/common/accelcmn.cpp:191
+#: ../src/common/accelcmn.cpp:190
 msgid "shift"
 msgstr "skift"
 
-#: ../src/common/appbase.cpp:773
+#: ../src/common/appbase.cpp:774
 msgid "show this help message"
 msgstr "vis denne hjælp-meddelelse"
 
-#: ../src/common/datetimefmt.cpp:1967
+#: ../src/common/datetimefmt.cpp:1990
 msgid "sixteenth"
 msgstr "sekstende"
 
-#: ../src/common/datetimefmt.cpp:1957
+#: ../src/common/datetimefmt.cpp:1980
 msgid "sixth"
 msgstr "sjette"
 
-#: ../src/common/appcmn.cpp:234
+#: ../src/common/appcmn.cpp:255
 msgid "specify display mode to use (e.g. 640x480-16)"
 msgstr "angiv ønskede skærmtilstand (f.eks. 640x480-16)"
 
-#: ../src/common/appcmn.cpp:220
+#: ../src/common/appcmn.cpp:241
 msgid "specify the theme to use"
 msgstr "angiv det tema, som skal bruges"
 
-#: ../src/richtext/richtextbuffer.cpp:9340
+#: ../src/richtext/richtextbuffer.cpp:9337
 msgid "standard/circle"
 msgstr "standard/cirkel"
 
-#: ../src/richtext/richtextbuffer.cpp:9341
+#: ../src/richtext/richtextbuffer.cpp:9338
 msgid "standard/circle-outline"
 msgstr "standard/cirkel-omrids"
 
-#: ../src/richtext/richtextbuffer.cpp:9343
+#: ../src/richtext/richtextbuffer.cpp:9340
 msgid "standard/diamond"
 msgstr "standard/diamant"
 
-#: ../src/richtext/richtextbuffer.cpp:9342
+#: ../src/richtext/richtextbuffer.cpp:9339
 msgid "standard/square"
 msgstr "standard/firkant"
 
-#: ../src/richtext/richtextbuffer.cpp:9344
+#: ../src/richtext/richtextbuffer.cpp:9341
 msgid "standard/triangle"
 msgstr "standard/trekant"
 
-#: ../src/common/zipstrm.cpp:1985
+#: ../src/common/zipstrm.cpp:2055
 msgid "stored file length not in Zip header"
 msgstr "gemt fillængde ikke i Zip-header"
 
-#: ../src/common/cmdline.cpp:1488
+#: ../src/common/cmdline.cpp:1484
 msgid "str"
 msgstr "str"
 
-#: ../src/common/fontcmn.cpp:982
+#: ../src/common/fontcmn.cpp:1145
 msgid "strikethrough"
 msgstr "gennemstreget"
 
-#: ../src/common/tarstrm.cpp:1003 ../src/common/tarstrm.cpp:1025
-#: ../src/common/tarstrm.cpp:1507 ../src/common/tarstrm.cpp:1529
+#: ../src/common/tarstrm.cpp:997 ../src/common/tarstrm.cpp:1019
+#: ../src/common/tarstrm.cpp:1501 ../src/common/tarstrm.cpp:1523
 msgid "tar entry not open"
 msgstr "tar-entry ikke åben"
 
-#: ../src/common/datetimefmt.cpp:1961
+#: ../src/common/datetimefmt.cpp:1984
 msgid "tenth"
 msgstr "tiende"
 
-#: ../src/msw/dde.cpp:1123
+#: ../src/msw/dde.cpp:1187
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "svaret på transaktionen bevirkede, at bitten DDE_FBUSY blev sat."
 
-#: ../src/common/datetimefmt.cpp:1954
+#: ../src/common/fontcmn.cpp:1154
+msgid "thin"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:1977
 msgid "third"
 msgstr "tredje"
 
-#: ../src/common/datetimefmt.cpp:1964
+#: ../src/common/datetimefmt.cpp:1987
 msgid "thirteenth"
 msgstr "trettende"
 
-#: ../src/common/datetimefmt.cpp:1758
+#: ../src/common/datetimefmt.cpp:1781
 msgid "today"
 msgstr "i dag"
 
-#: ../src/common/datetimefmt.cpp:1760
+#: ../src/common/datetimefmt.cpp:1783
 msgid "tomorrow"
 msgstr "i morgen"
 
-#: ../src/common/fileconf.cpp:1944
+#: ../src/common/fileconf.cpp:1946
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "efterstillet omvendt skråstreg ignoreret i \"%s\""
 
-#: ../src/gtk/aboutdlg.cpp:218
+#: ../src/gtk/aboutdlg.cpp:216
 msgid "translator-credits"
 msgstr "scootergrisen"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1028
+#: ../src/generic/datavgen.cpp:1148
 msgid "true"
 msgstr "sand"
 
-#: ../src/common/datetimefmt.cpp:1963
+#: ../src/common/datetimefmt.cpp:1986
 msgid "twelfth"
 msgstr "tolvte"
 
-#: ../src/common/datetimefmt.cpp:1971
+#: ../src/common/datetimefmt.cpp:1994
 msgid "twentieth"
 msgstr "tyvende"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:486 ../src/generic/datavgen.cpp:1263
+#: ../src/common/datavcmn.cpp:2068 ../src/generic/datavgen.cpp:1386
 msgid "unchecked"
 msgstr "fravalgt"
 
-#: ../src/common/fontcmn.cpp:802 ../src/common/fontcmn.cpp:978
+#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
 msgid "underlined"
 msgstr "understreget"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:490
+#: ../src/common/datavcmn.cpp:2072
 msgid "undetermined"
 msgstr "ubestemt"
 
-#: ../src/common/fileconf.cpp:1979
+#: ../src/common/fileconf.cpp:1981
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "uventet \" på position %d i \"%s\"."
 
-#: ../src/common/tarstrm.cpp:1045
+#: ../src/common/tarstrm.cpp:1039
 msgid "unexpected end of file"
 msgstr "uventet afslutning på fil"
 
-#: ../src/generic/progdlgg.cpp:370 ../src/common/tarstrm.cpp:371
-#: ../src/common/tarstrm.cpp:394 ../src/common/tarstrm.cpp:425
+#: ../src/common/tarstrm.cpp:366 ../src/common/tarstrm.cpp:389
+#: ../src/common/tarstrm.cpp:420 ../src/generic/progdlgg.cpp:376
 msgid "unknown"
 msgstr "ukendt"
 
-#: ../src/msw/registry.cpp:150
+#: ../src/msw/registry.cpp:139
 #, c-format
 msgid "unknown (%lu)"
 msgstr "ukendt (%lu)"
 
-#: ../src/common/xtixml.cpp:253
+#: ../src/common/xtixml.cpp:249
 #, c-format
 msgid "unknown class %s"
 msgstr "ukendt klasse %s"
 
-#: ../src/common/regex.cpp:258 ../src/html/chm.cpp:351
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "fejl ved komprimering"
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "fejl ved udpakning"
+
+#: ../src/common/regex.cpp:255 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "ukendt fejl"
 
-#: ../src/msw/dialup.cpp:471
+#: ../src/msw/dialup.cpp:465
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "ukendt fejl (fejlkode %08x)."
 
-#: ../src/common/fmapbase.cpp:834
+#: ../src/common/fmapbase.cpp:830
 #, c-format
 msgid "unknown-%d"
 msgstr "ukendt-%d"
 
-#: ../src/common/docview.cpp:509
+#: ../src/common/docview.cpp:502
 msgid "unnamed"
 msgstr "unavngivet"
 
-#: ../src/common/docview.cpp:1624
+#: ../src/common/docview.cpp:1618
 #, c-format
 msgid "unnamed%d"
 msgstr "unavngivet%d"
 
-#: ../src/common/zipstrm.cpp:1999 ../src/common/zipstrm.cpp:2319
+#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
 msgid "unsupported Zip compression method"
 msgstr "ikke-understøttet zip-komprimeringsmetode"
 
-#: ../src/common/translation.cpp:1892
+#: ../src/common/translation.cpp:1942
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "bruger katalog \"%s\" fra \"%s\"."
 
-#: ../src/html/chm.cpp:335
+#: ../src/html/chm.cpp:332
 msgid "write error"
 msgstr "skrivefejl"
 
-#: ../src/common/time.cpp:292
+#: ../src/gtk/glcanvas.cpp:187
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/common/time.cpp:285
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay fejlede."
 
@@ -8838,15 +9108,15 @@ msgstr "wxWidgets kunne ikke åbne skærmen for \"%s\": afslutter."
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets kunne ikke åbne skærmen. Afslutter."
 
-#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:431
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/common/datetimefmt.cpp:1759
+#: ../src/common/datetimefmt.cpp:1782
 msgid "yesterday"
 msgstr "i går"
 
-#: ../src/common/zstream.cpp:251 ../src/common/zstream.cpp:426
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
 #, c-format
 msgid "zlib error %d"
 msgstr "zlib fejl %d"
@@ -8855,3 +9125,75 @@ msgstr "zlib fejl %d"
 #: ../src/richtext/richtextbulletspage.cpp:288
 msgid "~"
 msgstr "~"
+
+#~ msgid " (while overwriting an existing item)"
+#~ msgstr " (under overskrivning af et eksisterende punkt)"
+
+#~ msgid "&Save as"
+#~ msgstr "Gem &som"
+
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "\"%s\" består ikke kun af lovlige tegn"
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "\"%s\" skal være numerisk."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "\"%s\" må kun indeholde ASCII-tegn."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "\"%s\" må kun indeholde bogstaver."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "\"%s\" må kun indeholde bogstaver eller tal."
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "\"%s\" må kun indeholde tal."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "Kan ikke oprette vindue af klassen %s"
+
+#~ msgid "Could not initalize libnotify."
+#~ msgstr "Kunne ikke initialisere libnotify."
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "Kunne ikke oprette overlay-vinduet"
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "Kunne ikke initialisere konteksten på overlay-vinduet"
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "Kunne ikke konvertere filen \"%s\" til Unicode."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "Kunne ikke sætte tekst i tekstkontrollen."
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr "Ugyldig GTK+ kommandolinjetilvalg, brug \"%s --help\""
+
+#~ msgid "No unused colour in image."
+#~ msgstr "Ingen ubrugte farver i det billede."
+
+#~ msgid "Not available"
+#~ msgstr "Ikke tilgængelig"
+
+#~ msgid "Replace selection"
+#~ msgstr "Erstat markering"
+
+#~ msgid "Save as"
+#~ msgstr "Gem som"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Typografistyring"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "Følgende standard GTK+ indstillinger understøttes også:\n"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "Du kan ikke cleare et overlay, som ikke er blevet initialiseret"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "Du kan ikke initialisere et overlay to gange"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "lokale \"%s\" kan ikke sættes."

--- a/locale/de.po
+++ b/locale/de.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-21 14:25+0200\n"
+"POT-Creation-Date: 2020-10-18 23:11+0300\n"
 "PO-Revision-Date: 2019-03-16 21:37+0100\n"
 "Last-Translator: Milo Ivir <mail@milotype.de>\n"
 "Language-Team: wxWidgets Team <wx-dev@wxwidgets.org>\n"
@@ -21,7 +21,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n!=1);\n"
 "X-Generator: Poedit 2.2.1\n"
 
-#: ../src/common/debugrpt.cpp:586
+#: ../src/common/debugrpt.cpp:587
 msgid ""
 "\n"
 "Please send this report to the program maintainer, thank you!\n"
@@ -29,8 +29,8 @@ msgstr ""
 "\n"
 "Bitte senden Sie diesen Bericht an den Programmautor. Vielen Dank!\n"
 
-#: ../src/richtext/richtextstyledlg.cpp:210
-#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:206
+#: ../src/richtext/richtextstyledlg.cpp:218
 msgid " "
 msgstr " "
 
@@ -40,70 +40,96 @@ msgstr ""
 "              Vielen Dank, und wir entschuldigen uns für die "
 "Unannehmlichkeiten.\n"
 
-#: ../src/common/prntbase.cpp:573
+#: ../src/common/prntbase.cpp:568
 #, c-format
 msgid " (copy %d of %d)"
 msgstr " (Kopie %d von %d)"
 
-#: ../src/common/log.cpp:421
+#: ../src/common/log.cpp:440
 #, c-format
 msgid " (error %ld: %s)"
 msgstr " (Fehler %ld: %s)"
 
-#: ../src/common/imagtiff.cpp:72
+#: ../src/common/imagtiff.cpp:69
 #, c-format
 msgid " (in module \"%s\")"
 msgstr " (im Modul „%s“)"
 
-#: ../src/osx/core/secretstore.cpp:138
-msgid " (while overwriting an existing item)"
-msgstr " (während ein Element überschrieben wird)"
-
-#: ../src/common/docview.cpp:1642
+#: ../src/common/docview.cpp:1636
 msgid " - "
 msgstr " - "
 
-#: ../src/richtext/richtextprint.cpp:593 ../src/html/htmprint.cpp:714
+#: ../src/html/htmprint.cpp:712 ../src/richtext/richtextprint.cpp:589
 msgid " Preview"
 msgstr " Vorschau"
 
-#: ../src/common/fontcmn.cpp:824
+#: ../src/common/fontcmn.cpp:973
 msgid " bold"
 msgstr " fett"
 
-#: ../src/common/fontcmn.cpp:840
+#: ../src/common/fontcmn.cpp:977
+#, fuzzy
+msgid " extra bold"
+msgstr " fett"
+
+#: ../src/common/fontcmn.cpp:985
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:957
+#, fuzzy
+msgid " extra light"
+msgstr " dünn"
+
+#: ../src/common/fontcmn.cpp:981
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1001
 msgid " italic"
 msgstr " kursiv"
 
-#: ../src/common/fontcmn.cpp:820
+#: ../src/common/fontcmn.cpp:961
 msgid " light"
 msgstr " dünn"
 
-#: ../src/common/fontcmn.cpp:807
+#: ../src/common/fontcmn.cpp:965
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:969
+#, fuzzy
+msgid " semi bold"
+msgstr " fett"
+
+#: ../src/common/fontcmn.cpp:940
 msgid " strikethrough"
 msgstr " durchgestrichen"
 
-#: ../src/common/paper.cpp:117
+#: ../src/common/fontcmn.cpp:953
+msgid " thin"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
 msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
 msgstr "#10 Umschlag, 4 1/8 × 9 1/2 Zoll"
 
-#: ../src/common/paper.cpp:118
+#: ../src/common/paper.cpp:115
 msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
 msgstr "#11 Umschlag, 4 1/2 × 10 3/8 Zoll"
 
-#: ../src/common/paper.cpp:119
+#: ../src/common/paper.cpp:116
 msgid "#12 Envelope, 4 3/4 x 11 in"
 msgstr "#12 Umschlag, 4 3/4 × 11 Zoll"
 
-#: ../src/common/paper.cpp:120
+#: ../src/common/paper.cpp:117
 msgid "#14 Envelope, 5 x 11 1/2 in"
 msgstr "#14 Umschlag, 5 × 11 1/2 Zoll"
 
-#: ../src/common/paper.cpp:116
+#: ../src/common/paper.cpp:113
 msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
 msgstr "#9 Umschlag, 3 7/8 × 8 7/8 Zoll"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:341
 #: ../src/richtext/richtextsizepage.cpp:340
 #: ../src/richtext/richtextsizepage.cpp:374
 #: ../src/richtext/richtextsizepage.cpp:401
@@ -114,81 +140,82 @@ msgstr "#9 Umschlag, 3 7/8 × 8 7/8 Zoll"
 #: ../src/richtext/richtextsizepage.cpp:591
 #: ../src/richtext/richtextsizepage.cpp:626
 #: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextbackgroundpage.cpp:341
 msgid "%"
 msgstr "%"
 
-#: ../src/html/helpwnd.cpp:1031
+#: ../src/html/helpwnd.cpp:1029
 #, c-format
 msgid "%d of %lu"
 msgstr "%d von %lu"
 
-#: ../src/html/helpwnd.cpp:1678
+#: ../src/html/helpwnd.cpp:1676
 #, c-format
 msgid "%i of %u"
 msgstr "%i von %u"
 
-#: ../src/generic/filectrlg.cpp:279
+#: ../src/generic/filectrlg.cpp:275
 #, c-format
 msgid "%ld byte"
 msgid_plural "%ld bytes"
 msgstr[0] "%ld Byte"
 msgstr[1] "%ld Bytes"
 
-#: ../src/html/helpwnd.cpp:1033
+#: ../src/html/helpwnd.cpp:1031
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu von %lu"
 
-#: ../src/generic/datavgen.cpp:6028
+#: ../src/generic/datavgen.cpp:6833
 #, c-format
 msgid "%s (%d items)"
 msgstr "%s (%d Elemente)"
 
-#: ../src/common/cmdline.cpp:1221
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (oder %s)"
 
-#: ../src/generic/logg.cpp:224
+#: ../src/generic/logg.cpp:221
 #, c-format
 msgid "%s Error"
 msgstr "%s Fehler"
 
-#: ../src/generic/logg.cpp:236
+#: ../src/generic/logg.cpp:233
 #, c-format
 msgid "%s Information"
 msgstr "%s Information"
 
-#: ../src/generic/preferencesg.cpp:113
+#: ../src/generic/preferencesg.cpp:110
 #, c-format
 msgid "%s Preferences"
 msgstr "%s-Einstellungen"
 
-#: ../src/generic/logg.cpp:228
+#: ../src/generic/logg.cpp:225
 #, c-format
 msgid "%s Warning"
 msgstr "%s Warnung"
 
-#: ../src/common/tarstrm.cpp:1319
+#: ../src/common/tarstrm.cpp:1313
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s passte nicht zum tar Kopfeintrag für den Eintrag „%s“"
 
-#: ../src/common/fldlgcmn.cpp:124
+#: ../src/common/fldlgcmn.cpp:121
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s-Dateien (%s)|%s"
 
-#: ../src/html/helpwnd.cpp:1716
+#: ../src/html/helpwnd.cpp:1714
 #, c-format
 msgid "%u of %u"
 msgstr "%u von %u"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "&About"
 msgstr "Übe&r"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "&Actual Size"
 msgstr "T&atsächliche Größe"
 
@@ -196,28 +223,28 @@ msgstr "T&atsächliche Größe"
 msgid "&After a paragraph:"
 msgstr "&Nach einem Absatz:"
 
-#: ../src/richtext/richtextindentspage.cpp:128
 #: ../src/richtext/richtextliststylepage.cpp:319
+#: ../src/richtext/richtextindentspage.cpp:128
 msgid "&Alignment"
 msgstr "&Ausrichtung"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "&Apply"
 msgstr "Ü&bernehmen"
 
-#: ../src/richtext/richtextstyledlg.cpp:251
+#: ../src/richtext/richtextstyledlg.cpp:247
 msgid "&Apply Style"
 msgstr "&Stil anwenden"
 
-#: ../src/msw/mdi.cpp:179
+#: ../src/msw/mdi.cpp:174
 msgid "&Arrange Icons"
 msgstr "&Icons anordnen"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "&Ascending"
 msgstr "&Aufsteigend"
 
-#: ../src/common/stockitem.cpp:142
+#: ../src/common/stockitem.cpp:139
 msgid "&Back"
 msgstr "&Zurück"
 
@@ -237,24 +264,24 @@ msgstr "&Hg Farbe:"
 msgid "&Blur distance:"
 msgstr "Entfernung der &Weichzeichnung:"
 
-#: ../src/common/stockitem.cpp:143
+#: ../src/common/stockitem.cpp:140
 msgid "&Bold"
 msgstr "&Fett"
 
-#: ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141
 msgid "&Bottom"
 msgstr "&Unten"
 
+#: ../src/richtext/richtextsizepage.cpp:637
+#: ../src/richtext/richtextsizepage.cpp:644
 #: ../src/richtext/richtextborderspage.cpp:345
 #: ../src/richtext/richtextborderspage.cpp:513
 #: ../src/richtext/richtextmarginspage.cpp:259
 #: ../src/richtext/richtextmarginspage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:637
-#: ../src/richtext/richtextsizepage.cpp:644
 msgid "&Bottom:"
 msgstr "&Unten:"
 
-#: ../include/wx/richtext/richtextbuffer.h:3866
+#: ../include/wx/richtext/richtextbuffer.h:3861
 msgid "&Box"
 msgstr "&Rahmen"
 
@@ -263,38 +290,38 @@ msgstr "&Rahmen"
 msgid "&Bullet style:"
 msgstr "Stil des &Gliederungspunktes:"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "&CD-Rom"
 msgstr "&CD-ROM"
 
-#: ../src/generic/wizard.cpp:434 ../src/generic/fontdlgg.cpp:470
-#: ../src/generic/fontdlgg.cpp:489 ../src/osx/carbon/fontdlg.cpp:402
-#: ../src/common/dlgcmn.cpp:279 ../src/common/stockitem.cpp:145
+#: ../src/osx/carbon/fontdlg.cpp:399 ../src/common/stockitem.cpp:142
+#: ../src/generic/wizard.cpp:433 ../src/generic/fontdlgg.cpp:466
+#: ../src/generic/fontdlgg.cpp:485 ../src/osx/cocoa/button.mm:200
 msgid "&Cancel"
 msgstr "Ab&brechen"
 
-#: ../src/msw/mdi.cpp:175
+#: ../src/msw/mdi.cpp:170
 msgid "&Cascade"
 msgstr "&Kaskadieren"
 
-#: ../include/wx/richtext/richtextbuffer.h:5960
+#: ../include/wx/richtext/richtextbuffer.h:5955
 msgid "&Cell"
 msgstr "&Zelle"
 
-#: ../src/richtext/richtextsymboldlg.cpp:439
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "&Character code:"
 msgstr "&Zeichencode:"
 
-#: ../src/common/stockitem.cpp:147
+#: ../src/common/stockitem.cpp:144
 msgid "&Clear"
 msgstr "&Löschen"
 
-#: ../src/generic/logg.cpp:516 ../src/common/stockitem.cpp:148
-#: ../src/common/prntbase.cpp:1600 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/stockitem.cpp:145 ../src/common/prntbase.cpp:1625
+#: ../src/univ/themes/win32.cpp:3753 ../src/generic/logg.cpp:513
 msgid "&Close"
 msgstr "&Schließen"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "&Color"
 msgstr "&Farbe"
 
@@ -302,20 +329,20 @@ msgstr "&Farbe"
 msgid "&Colour:"
 msgstr "&Farbe:"
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "&Convert"
 msgstr "&Konvertieren"
 
-#: ../src/richtext/richtextctrl.cpp:333 ../src/osx/textctrl_osx.cpp:577
-#: ../src/common/stockitem.cpp:150 ../src/msw/textctrl.cpp:2508
+#: ../src/osx/textctrl_osx.cpp:595 ../src/common/stockitem.cpp:147
+#: ../src/msw/textctrl.cpp:2773 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Kopieren"
 
-#: ../src/generic/hyperlinkg.cpp:156
+#: ../src/generic/hyperlinkg.cpp:153
 msgid "&Copy URL"
 msgstr "URL &kopieren"
 
-#: ../src/common/headerctrlcmn.cpp:306
+#: ../src/common/headerctrlcmn.cpp:304
 msgid "&Customize..."
 msgstr "&Anpassen …"
 
@@ -323,53 +350,54 @@ msgstr "&Anpassen …"
 msgid "&Debug report preview:"
 msgstr "&Vorschau des Fehlerberichts:"
 
-#: ../src/richtext/richtexttabspage.cpp:138
-#: ../src/richtext/richtextctrl.cpp:335 ../src/osx/textctrl_osx.cpp:579
-#: ../src/common/stockitem.cpp:152 ../src/msw/textctrl.cpp:2510
+#: ../src/osx/textctrl_osx.cpp:597 ../src/common/stockitem.cpp:149
+#: ../src/msw/textctrl.cpp:2775 ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtextctrl.cpp:334
 msgid "&Delete"
 msgstr "&Löschen"
 
-#: ../src/richtext/richtextstyledlg.cpp:269
+#: ../src/richtext/richtextstyledlg.cpp:265
 msgid "&Delete Style..."
 msgstr "Stil &löschen …"
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "&Descending"
 msgstr "&Absteigend"
 
-#: ../src/generic/logg.cpp:682
+#: ../src/generic/logg.cpp:679
 msgid "&Details"
 msgstr "&Einzelheiten"
 
-#: ../src/common/stockitem.cpp:153
+#: ../src/common/stockitem.cpp:150
 msgid "&Down"
 msgstr "&Runter"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "&Edit"
 msgstr "&Bearbeiten"
 
-#: ../src/richtext/richtextstyledlg.cpp:263
+#: ../src/richtext/richtextstyledlg.cpp:259
 msgid "&Edit Style..."
 msgstr "Stil &bearbeiten …"
 
-#: ../src/common/stockitem.cpp:155
+#: ../src/common/stockitem.cpp:152
 msgid "&Execute"
 msgstr "&Ausführen"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/common/stockitem.cpp:154
 msgid "&File"
 msgstr "&Datei"
 
-#: ../src/common/stockitem.cpp:158
-msgid "&Find"
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "&Find..."
 msgstr "&Suchen"
 
-#: ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:430
 msgid "&Finish"
 msgstr "&Fertigstellen"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:156
 msgid "&First"
 msgstr "&Erste"
 
@@ -377,15 +405,15 @@ msgstr "&Erste"
 msgid "&Floating mode:"
 msgstr "&Schwebemodus:"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "&Floppy"
 msgstr "&Diskette"
 
-#: ../src/common/stockitem.cpp:194
+#: ../src/common/stockitem.cpp:191
 msgid "&Font"
 msgstr "&Schriftart"
 
-#: ../src/generic/fontdlgg.cpp:371
+#: ../src/generic/fontdlgg.cpp:367
 msgid "&Font family:"
 msgstr "&Schriftart:"
 
@@ -393,20 +421,20 @@ msgstr "&Schriftart:"
 msgid "&Font for Level..."
 msgstr "&Schriftart für Ebene …"
 
+#: ../src/richtext/richtextsymboldlg.cpp:397
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:400
 msgid "&Font:"
 msgstr "&Schriftart:"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "&Forward"
 msgstr "&Vorwärts"
 
-#: ../src/richtext/richtextsymboldlg.cpp:451
+#: ../src/richtext/richtextsymboldlg.cpp:448
 msgid "&From:"
 msgstr "&Von:"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "&Harddisk"
 msgstr "&Festplatte"
 
@@ -415,9 +443,9 @@ msgstr "&Festplatte"
 msgid "&Height:"
 msgstr "&Höhe:"
 
-#: ../src/generic/wizard.cpp:441 ../src/richtext/richtextstyledlg.cpp:303
-#: ../src/richtext/richtextsymboldlg.cpp:479 ../src/osx/menu_osx.cpp:734
-#: ../src/common/stockitem.cpp:163
+#: ../src/common/stockitem.cpp:160 ../src/generic/wizard.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextstyledlg.cpp:299 ../src/osx/cocoa/menu.mm:226
 msgid "&Help"
 msgstr "&Hilfe"
 
@@ -425,7 +453,7 @@ msgstr "&Hilfe"
 msgid "&Hide details"
 msgstr "&Einzelheiten ausblenden"
 
-#: ../src/common/stockitem.cpp:164
+#: ../src/common/stockitem.cpp:161
 msgid "&Home"
 msgstr "&Start"
 
@@ -433,54 +461,54 @@ msgstr "&Start"
 msgid "&Horizontal offset:"
 msgstr "&Horizontaler Versatz:"
 
-#: ../src/richtext/richtextindentspage.cpp:184
 #: ../src/richtext/richtextliststylepage.cpp:372
+#: ../src/richtext/richtextindentspage.cpp:184
 msgid "&Indentation (tenths of a mm)"
 msgstr "&Einrückung (Zehntel-mm)"
 
-#: ../src/richtext/richtextindentspage.cpp:167
 #: ../src/richtext/richtextliststylepage.cpp:356
+#: ../src/richtext/richtextindentspage.cpp:167
 msgid "&Indeterminate"
 msgstr "&Unbestimmt"
 
-#: ../src/common/stockitem.cpp:166
+#: ../src/common/stockitem.cpp:163
 msgid "&Index"
 msgstr "&Index"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "&Info"
 msgstr "&Information"
 
-#: ../src/common/stockitem.cpp:168
+#: ../src/common/stockitem.cpp:165
 msgid "&Italic"
 msgstr "&Kursiv"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "&Jump to"
 msgstr "&Springen zu"
 
-#: ../src/richtext/richtextindentspage.cpp:153
 #: ../src/richtext/richtextliststylepage.cpp:342
+#: ../src/richtext/richtextindentspage.cpp:153
 msgid "&Justified"
 msgstr "&Blocksatz"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "&Last"
 msgstr "&Letztes"
 
-#: ../src/richtext/richtextindentspage.cpp:139
 #: ../src/richtext/richtextliststylepage.cpp:328
+#: ../src/richtext/richtextindentspage.cpp:139
 msgid "&Left"
 msgstr "&Links"
 
-#: ../src/richtext/richtextindentspage.cpp:195
+#: ../src/richtext/richtextsizepage.cpp:532
+#: ../src/richtext/richtextsizepage.cpp:539
 #: ../src/richtext/richtextborderspage.cpp:243
 #: ../src/richtext/richtextborderspage.cpp:411
 #: ../src/richtext/richtextliststylepage.cpp:381
+#: ../src/richtext/richtextindentspage.cpp:195
 #: ../src/richtext/richtextmarginspage.cpp:186
 #: ../src/richtext/richtextmarginspage.cpp:300
-#: ../src/richtext/richtextsizepage.cpp:532
-#: ../src/richtext/richtextsizepage.cpp:539
 msgid "&Left:"
 msgstr "&Links:"
 
@@ -488,11 +516,11 @@ msgstr "&Links:"
 msgid "&List level:"
 msgstr "&Listenebene:"
 
-#: ../src/generic/logg.cpp:517
+#: ../src/generic/logg.cpp:514
 msgid "&Log"
 msgstr "&Log"
 
-#: ../src/univ/themes/win32.cpp:3748
+#: ../src/univ/themes/win32.cpp:3745
 msgid "&Move"
 msgstr "&Bewegen"
 
@@ -500,19 +528,19 @@ msgstr "&Bewegen"
 msgid "&Move the object to:"
 msgstr "&Bewege das Objekt zu:"
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "&Network"
 msgstr "&Netzwerk"
 
-#: ../src/richtext/richtexttabspage.cpp:132 ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173 ../src/richtext/richtexttabspage.cpp:132
 msgid "&New"
 msgstr "&Neu"
 
-#: ../src/aui/tabmdi.cpp:111 ../src/generic/mdig.cpp:100 ../src/msw/mdi.cpp:180
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
 msgid "&Next"
 msgstr "&Weiter"
 
-#: ../src/generic/wizard.cpp:432 ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:429
 msgid "&Next >"
 msgstr "&Weiter >"
 
@@ -520,7 +548,7 @@ msgstr "&Weiter >"
 msgid "&Next Paragraph"
 msgstr "&Nächster Absatz"
 
-#: ../src/generic/tipdlg.cpp:240
+#: ../src/generic/tipdlg.cpp:237
 msgid "&Next Tip"
 msgstr "&Nächster Tipp"
 
@@ -528,11 +556,11 @@ msgstr "&Nächster Tipp"
 msgid "&Next style:"
 msgstr "&Nächster Stil:"
 
-#: ../src/common/stockitem.cpp:177 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:174 ../src/msw/msgdlg.cpp:435
 msgid "&No"
 msgstr "&Nein"
 
-#: ../src/generic/dbgrptg.cpp:356
+#: ../src/generic/dbgrptg.cpp:360
 msgid "&Notes:"
 msgstr "B&emerkungen:"
 
@@ -540,12 +568,12 @@ msgstr "B&emerkungen:"
 msgid "&Number:"
 msgstr "&Nummer:"
 
-#: ../src/generic/fontdlgg.cpp:475 ../src/generic/fontdlgg.cpp:482
-#: ../src/osx/carbon/fontdlg.cpp:408 ../src/common/stockitem.cpp:178
+#: ../src/osx/carbon/fontdlg.cpp:405 ../src/common/stockitem.cpp:175
+#: ../src/generic/fontdlgg.cpp:471 ../src/generic/fontdlgg.cpp:478
 msgid "&OK"
 msgstr "&OK"
 
-#: ../src/generic/dbgrptg.cpp:342 ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176 ../src/generic/dbgrptg.cpp:342
 msgid "&Open..."
 msgstr "Ö&ffnen …"
 
@@ -557,16 +585,16 @@ msgstr "&Umrandungsebene:"
 msgid "&Page Break"
 msgstr "&Seitenumbruch"
 
-#: ../src/richtext/richtextctrl.cpp:334 ../src/osx/textctrl_osx.cpp:578
-#: ../src/common/stockitem.cpp:180 ../src/msw/textctrl.cpp:2509
+#: ../src/osx/textctrl_osx.cpp:596 ../src/common/stockitem.cpp:177
+#: ../src/msw/textctrl.cpp:2774 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "Ein&fügen"
 
-#: ../include/wx/richtext/richtextbuffer.h:5010
+#: ../include/wx/richtext/richtextbuffer.h:5005
 msgid "&Picture"
 msgstr "&Bild"
 
-#: ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:419
 msgid "&Point size:"
 msgstr "Schriftgröße in &Punkt:"
 
@@ -578,11 +606,11 @@ msgstr "&Position (Zehntel-mm):"
 msgid "&Position mode:"
 msgstr "&Positionierungs-Modus:"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178
 msgid "&Preferences"
 msgstr "&Einstellungen"
 
-#: ../src/aui/tabmdi.cpp:112 ../src/generic/mdig.cpp:101 ../src/msw/mdi.cpp:181
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
 msgid "&Previous"
 msgstr "&Zurück"
 
@@ -590,78 +618,74 @@ msgstr "&Zurück"
 msgid "&Previous Paragraph"
 msgstr "&Vorheriger Absatz"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "&Print..."
 msgstr "&Drucken …"
 
-#: ../src/richtext/richtextctrl.cpp:339 ../src/richtext/richtextctrl.cpp:5514
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtextctrl.cpp:338
+#: ../src/richtext/richtextctrl.cpp:5512
 msgid "&Properties"
 msgstr "&Eigenschaften"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "&Quit"
 msgstr "&Beenden"
 
-#: ../src/richtext/richtextctrl.cpp:330 ../src/osx/textctrl_osx.cpp:574
-#: ../src/common/stockitem.cpp:185 ../src/common/cmdproc.cpp:293
-#: ../src/common/cmdproc.cpp:300 ../src/msw/textctrl.cpp:2505
+#: ../src/osx/textctrl_osx.cpp:592 ../src/common/stockitem.cpp:182
+#: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
+#: ../src/msw/textctrl.cpp:2770 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Wiederholen"
 
-#: ../src/common/cmdproc.cpp:289 ../src/common/cmdproc.cpp:309
+#: ../src/common/cmdproc.cpp:282 ../src/common/cmdproc.cpp:302
 msgid "&Redo "
 msgstr "&Wiederholen "
 
-#: ../src/richtext/richtextstyledlg.cpp:257
+#: ../src/richtext/richtextstyledlg.cpp:253
 msgid "&Rename Style..."
 msgstr "Stil &umbenennen …"
 
-#: ../src/generic/fdrepdlg.cpp:179
+#: ../src/generic/fdrepdlg.cpp:176
 msgid "&Replace"
 msgstr "&Ersetzen"
 
-#: ../src/richtext/richtextstyledlg.cpp:287
+#: ../src/richtext/richtextstyledlg.cpp:283
 msgid "&Restart numbering"
 msgstr "&Starte Nummerierung erneut"
 
-#: ../src/univ/themes/win32.cpp:3747
+#: ../src/univ/themes/win32.cpp:3744
 msgid "&Restore"
 msgstr "&Wiederherstellen"
 
-#: ../src/richtext/richtextindentspage.cpp:146
 #: ../src/richtext/richtextliststylepage.cpp:335
+#: ../src/richtext/richtextindentspage.cpp:146
 msgid "&Right"
 msgstr "&Rechts"
 
-#: ../src/richtext/richtextindentspage.cpp:213
+#: ../src/richtext/richtextsizepage.cpp:602
+#: ../src/richtext/richtextsizepage.cpp:609
 #: ../src/richtext/richtextborderspage.cpp:277
 #: ../src/richtext/richtextborderspage.cpp:445
 #: ../src/richtext/richtextliststylepage.cpp:399
+#: ../src/richtext/richtextindentspage.cpp:213
 #: ../src/richtext/richtextmarginspage.cpp:211
 #: ../src/richtext/richtextmarginspage.cpp:325
-#: ../src/richtext/richtextsizepage.cpp:602
-#: ../src/richtext/richtextsizepage.cpp:609
 msgid "&Right:"
 msgstr "&Rechts:"
 
-#: ../src/common/stockitem.cpp:190
+#: ../src/common/stockitem.cpp:187
 msgid "&Save"
 msgstr "&Speichern"
-
-#: ../src/common/stockitem.cpp:191
-msgid "&Save as"
-msgstr "Speichern &unter"
 
 #: ../include/wx/richmsgdlg.h:29
 msgid "&See details"
 msgstr "&Einzelheiten anzeigen"
 
-#: ../src/generic/tipdlg.cpp:236
+#: ../src/generic/tipdlg.cpp:233
 msgid "&Show tips at startup"
 msgstr "&Tipps beim Programmstart zeigen"
 
-#: ../src/univ/themes/win32.cpp:3750
+#: ../src/univ/themes/win32.cpp:3747
 msgid "&Size"
 msgstr "&Größe"
 
@@ -669,36 +693,36 @@ msgstr "&Größe"
 msgid "&Size:"
 msgstr "&Größe:"
 
-#: ../src/generic/progdlgg.cpp:252
+#: ../src/generic/progdlgg.cpp:249
 msgid "&Skip"
 msgstr "Ü&berspringen"
 
-#: ../src/richtext/richtextindentspage.cpp:242
 #: ../src/richtext/richtextliststylepage.cpp:417
+#: ../src/richtext/richtextindentspage.cpp:242
 msgid "&Spacing (tenths of a mm)"
 msgstr "&Zeichenabstand (Zehntel-mm)"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "&Spell Check"
 msgstr "&Rechtschreibprüfung"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "&Stop"
 msgstr "&Stopp"
 
-#: ../src/richtext/richtextfontpage.cpp:275 ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196 ../src/richtext/richtextfontpage.cpp:275
 msgid "&Strikethrough"
 msgstr "&Durchstreichen"
 
-#: ../src/generic/fontdlgg.cpp:382 ../src/richtext/richtextstylepage.cpp:106
+#: ../src/generic/fontdlgg.cpp:378 ../src/richtext/richtextstylepage.cpp:106
 msgid "&Style:"
 msgstr "&Stil:"
 
-#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:194
 msgid "&Styles:"
 msgstr "&Stile:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:413
+#: ../src/richtext/richtextsymboldlg.cpp:410
 msgid "&Subset:"
 msgstr "&Teilsatz:"
 
@@ -712,24 +736,24 @@ msgstr "&Symbol:"
 msgid "&Synchronize values"
 msgstr "&Werte synchronisieren"
 
-#: ../include/wx/richtext/richtextbuffer.h:6069
+#: ../include/wx/richtext/richtextbuffer.h:6064
 msgid "&Table"
 msgstr "&Tabelle"
 
-#: ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197
 msgid "&Top"
 msgstr "&Oben"
 
+#: ../src/richtext/richtextsizepage.cpp:567
+#: ../src/richtext/richtextsizepage.cpp:574
 #: ../src/richtext/richtextborderspage.cpp:311
 #: ../src/richtext/richtextborderspage.cpp:479
 #: ../src/richtext/richtextmarginspage.cpp:234
 #: ../src/richtext/richtextmarginspage.cpp:348
-#: ../src/richtext/richtextsizepage.cpp:567
-#: ../src/richtext/richtextsizepage.cpp:574
 msgid "&Top:"
 msgstr "&Oben:"
 
-#: ../src/generic/fontdlgg.cpp:444 ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199 ../src/generic/fontdlgg.cpp:441
 msgid "&Underline"
 msgstr "&Unterstreichen"
 
@@ -737,21 +761,21 @@ msgstr "&Unterstreichen"
 msgid "&Underlining:"
 msgstr "&Unterstreichen:"
 
-#: ../src/richtext/richtextctrl.cpp:329 ../src/osx/textctrl_osx.cpp:573
-#: ../src/common/stockitem.cpp:203 ../src/common/cmdproc.cpp:271
-#: ../src/msw/textctrl.cpp:2504
+#: ../src/osx/textctrl_osx.cpp:591 ../src/common/stockitem.cpp:200
+#: ../src/common/cmdproc.cpp:264 ../src/msw/textctrl.cpp:2769
+#: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Rückgängig"
 
-#: ../src/common/cmdproc.cpp:265
+#: ../src/common/cmdproc.cpp:258
 msgid "&Undo "
 msgstr "&Rückgängig "
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "&Unindent"
 msgstr "&Einrückung entfernrn"
 
-#: ../src/common/stockitem.cpp:205
+#: ../src/common/stockitem.cpp:202
 msgid "&Up"
 msgstr "&Hoch"
 
@@ -767,7 +791,7 @@ msgstr "&Vertikaler Versatz:"
 msgid "&View..."
 msgstr "&Ansicht …"
 
-#: ../src/generic/fontdlgg.cpp:393
+#: ../src/generic/fontdlgg.cpp:389
 msgid "&Weight:"
 msgstr "&Dicke:"
 
@@ -776,88 +800,58 @@ msgstr "&Dicke:"
 msgid "&Width:"
 msgstr "&Breite:"
 
-#: ../src/aui/tabmdi.cpp:311 ../src/aui/tabmdi.cpp:327
-#: ../src/aui/tabmdi.cpp:329 ../src/generic/mdig.cpp:294
-#: ../src/generic/mdig.cpp:310 ../src/generic/mdig.cpp:314
-#: ../src/msw/mdi.cpp:78
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
 msgid "&Window"
 msgstr "&Fenster"
 
-#: ../src/common/stockitem.cpp:206 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:203 ../src/msw/msgdlg.cpp:435
 msgid "&Yes"
 msgstr "&Ja"
 
-#: ../src/common/valtext.cpp:256
-#, c-format
-msgid "'%s' contains illegal characters"
+#: ../src/common/valtext.cpp:197
+#, fuzzy, c-format
+msgid "'%s' contains invalid character(s)"
 msgstr "„%s“ enthält ungültige Zeichen"
 
-#: ../src/common/valtext.cpp:254
-#, c-format
-msgid "'%s' doesn't consist only of valid characters"
-msgstr "„%s“ enthält nicht nur gültige Zeichen"
-
-#: ../src/common/config.cpp:519 ../src/msw/regconf.cpp:258
+#: ../src/common/config.cpp:515 ../src/msw/regconf.cpp:255
 #, c-format
 msgid "'%s' has extra '..', ignored."
 msgstr "„%s“ hat extra „..“, ignoriert."
 
-#: ../src/common/cmdline.cpp:1113 ../src/common/cmdline.cpp:1131
+#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "„%s“ ist kein gültiger numerischer Wert für Option „%s“."
 
-#: ../src/common/translation.cpp:1100
+#: ../src/common/translation.cpp:1142
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "„%s“ ist kein gültiger Nachrichtenkatalog."
 
-#: ../src/common/valtext.cpp:165
+#: ../src/common/valtext.cpp:188
 #, c-format
 msgid "'%s' is not one of the valid strings"
 msgstr "„%s“ ist keine gültige Zeichenkette"
 
-#: ../src/common/valtext.cpp:167
+#: ../src/common/valtext.cpp:186
 #, c-format
 msgid "'%s' is one of the invalid strings"
 msgstr "„%s“ ist eine ungültige Zeichenkette"
 
-#: ../src/common/textbuf.cpp:237
+#: ../src/common/textbuf.cpp:233
 #, c-format
 msgid "'%s' is probably a binary buffer."
 msgstr "„%s“ ist vermutlich ein Binärpuffer."
-
-#: ../src/common/valtext.cpp:252
-#, c-format
-msgid "'%s' should be numeric."
-msgstr "„%s“ sollte numerisch sein."
-
-#: ../src/common/valtext.cpp:244
-#, c-format
-msgid "'%s' should only contain ASCII characters."
-msgstr "„%s“ sollte ausschließlich ASCII-Zeichen enthalten."
-
-#: ../src/common/valtext.cpp:246
-#, c-format
-msgid "'%s' should only contain alphabetic characters."
-msgstr "„%s“ sollte nur alphabetische Zeichen enthalten."
-
-#: ../src/common/valtext.cpp:248
-#, c-format
-msgid "'%s' should only contain alphabetic or numeric characters."
-msgstr "„%s“ sollte nur alphanumerische Zeichen enthalten."
-
-#: ../src/common/valtext.cpp:250
-#, c-format
-msgid "'%s' should only contain digits."
-msgstr "„%s“ sollte ausschließlich Ziffern enthalten."
 
 #: ../src/richtext/richtextliststylepage.cpp:229
 #: ../src/richtext/richtextbulletspage.cpp:166
 msgid "(*)"
 msgstr "(*)"
 
-#: ../src/html/helpwnd.cpp:963
+#: ../src/html/helpwnd.cpp:961
 msgid "(Help)"
 msgstr "(Hilfe)"
 
@@ -866,27 +860,32 @@ msgstr "(Hilfe)"
 msgid "(None)"
 msgstr "(Kein)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:504
+#: ../src/richtext/richtextsymboldlg.cpp:503
 msgid "(Normal text)"
 msgstr "(Normaler Text)"
 
-#: ../src/html/helpwnd.cpp:419 ../src/html/helpwnd.cpp:1106
-#: ../src/html/helpwnd.cpp:1742
+#: ../src/html/helpwnd.cpp:417 ../src/html/helpwnd.cpp:1104
+#: ../src/html/helpwnd.cpp:1740
 msgid "(bookmarks)"
 msgstr "(Lesezeichen)"
 
+#: ../src/msw/dlmsw.cpp:167
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (Fehler %ld: %s)"
+
+#: ../src/richtext/richtextformatdlg.cpp:876
+#: ../src/richtext/richtextliststylepage.cpp:448
+#: ../src/richtext/richtextliststylepage.cpp:460
+#: ../src/richtext/richtextliststylepage.cpp:461
 #: ../src/richtext/richtextindentspage.cpp:274
 #: ../src/richtext/richtextindentspage.cpp:286
 #: ../src/richtext/richtextindentspage.cpp:287
 #: ../src/richtext/richtextindentspage.cpp:311
 #: ../src/richtext/richtextindentspage.cpp:326
-#: ../src/richtext/richtextformatdlg.cpp:884
 #: ../src/richtext/richtextfontpage.cpp:349
 #: ../src/richtext/richtextfontpage.cpp:353
 #: ../src/richtext/richtextfontpage.cpp:357
-#: ../src/richtext/richtextliststylepage.cpp:448
-#: ../src/richtext/richtextliststylepage.cpp:460
-#: ../src/richtext/richtextliststylepage.cpp:461
 msgid "(none)"
 msgstr "(Kein)"
 
@@ -905,7 +904,7 @@ msgstr "*)"
 msgid "+"
 msgstr "+"
 
-#: ../src/msw/utils.cpp:1152
+#: ../src/msw/utils.cpp:1143
 msgid ", 64-bit edition"
 msgstr ", 64-bit Edition"
 
@@ -914,163 +913,163 @@ msgstr ", 64-bit Edition"
 msgid "-"
 msgstr "-"
 
-#: ../src/generic/filepickerg.cpp:66
+#: ../src/generic/filepickerg.cpp:63
 msgid "..."
 msgstr "…"
 
-#: ../src/richtext/richtextindentspage.cpp:276
 #: ../src/richtext/richtextliststylepage.cpp:450
+#: ../src/richtext/richtextindentspage.cpp:276
 msgid "1.1"
 msgstr "1.1"
 
-#: ../src/richtext/richtextindentspage.cpp:277
 #: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextindentspage.cpp:277
 msgid "1.2"
 msgstr "1.2"
 
-#: ../src/richtext/richtextindentspage.cpp:278
 #: ../src/richtext/richtextliststylepage.cpp:452
+#: ../src/richtext/richtextindentspage.cpp:278
 msgid "1.3"
 msgstr "1.3"
 
-#: ../src/richtext/richtextindentspage.cpp:279
 #: ../src/richtext/richtextliststylepage.cpp:453
+#: ../src/richtext/richtextindentspage.cpp:279
 msgid "1.4"
 msgstr "1.4"
 
-#: ../src/richtext/richtextindentspage.cpp:280
 #: ../src/richtext/richtextliststylepage.cpp:454
+#: ../src/richtext/richtextindentspage.cpp:280
 msgid "1.5"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:281
 #: ../src/richtext/richtextliststylepage.cpp:455
+#: ../src/richtext/richtextindentspage.cpp:281
 msgid "1.6"
 msgstr "1.6"
 
-#: ../src/richtext/richtextindentspage.cpp:282
 #: ../src/richtext/richtextliststylepage.cpp:456
+#: ../src/richtext/richtextindentspage.cpp:282
 msgid "1.7"
 msgstr "1.7"
 
-#: ../src/richtext/richtextindentspage.cpp:283
 #: ../src/richtext/richtextliststylepage.cpp:457
+#: ../src/richtext/richtextindentspage.cpp:283
 msgid "1.8"
 msgstr "1.8"
 
-#: ../src/richtext/richtextindentspage.cpp:284
 #: ../src/richtext/richtextliststylepage.cpp:458
+#: ../src/richtext/richtextindentspage.cpp:284
 msgid "1.9"
 msgstr "1.9"
 
-#: ../src/common/paper.cpp:140
+#: ../src/common/paper.cpp:137
 msgid "10 x 11 in"
 msgstr "10 × 11 Zoll"
 
-#: ../src/common/paper.cpp:113
+#: ../src/common/paper.cpp:110
 msgid "10 x 14 in"
 msgstr "10 × 14 Zoll"
 
-#: ../src/common/paper.cpp:114
+#: ../src/common/paper.cpp:111
 msgid "11 x 17 in"
 msgstr "11 × 17 Zoll"
 
-#: ../src/common/paper.cpp:184
+#: ../src/common/paper.cpp:181
 msgid "12 x 11 in"
 msgstr "12 × 11 Zoll"
 
-#: ../src/common/paper.cpp:141
+#: ../src/common/paper.cpp:138
 msgid "15 x 11 in"
 msgstr "15 × 11 Zoll"
 
-#: ../src/richtext/richtextindentspage.cpp:285
 #: ../src/richtext/richtextliststylepage.cpp:459
+#: ../src/richtext/richtextindentspage.cpp:285
 msgid "2"
 msgstr "2"
 
-#: ../src/common/paper.cpp:132
+#: ../src/common/paper.cpp:129
 msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
 msgstr "6 3/4 Umschlag, 3 5/8 × 6 1/2 Zoll"
 
-#: ../src/common/paper.cpp:139
+#: ../src/common/paper.cpp:136
 msgid "9 x 11 in"
 msgstr "9 × 11 Zoll"
 
-#: ../src/html/htmprint.cpp:431
+#: ../src/html/htmprint.cpp:443
 msgid ": file does not exist!"
 msgstr ": Datei existiert nicht!"
 
-#: ../src/common/fontmap.cpp:199
+#: ../src/common/fontmap.cpp:196
 msgid ": unknown charset"
 msgstr ": unbekannter Zeichensatz"
 
-#: ../src/common/fontmap.cpp:413
+#: ../src/common/fontmap.cpp:410
 msgid ": unknown encoding"
 msgstr ": unbekannte Kodierung"
 
-#: ../src/generic/wizard.cpp:443
+#: ../src/generic/wizard.cpp:438
 msgid "< &Back"
 msgstr "< &Zurück"
 
-#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:628
-#: ../src/osx/carbon/fontdlg.cpp:648
+#: ../src/osx/carbon/fontdlg.cpp:419 ../src/osx/carbon/fontdlg.cpp:625
+#: ../src/osx/carbon/fontdlg.cpp:645
 msgid "<Any Decorative>"
 msgstr "<Beliebige Dekorative>"
 
-#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:630
-#: ../src/osx/carbon/fontdlg.cpp:650
+#: ../src/osx/carbon/fontdlg.cpp:420 ../src/osx/carbon/fontdlg.cpp:627
+#: ../src/osx/carbon/fontdlg.cpp:647
 msgid "<Any Modern>"
 msgstr "<Beliebige Moderne>"
 
-#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:626
-#: ../src/osx/carbon/fontdlg.cpp:646
+#: ../src/osx/carbon/fontdlg.cpp:418 ../src/osx/carbon/fontdlg.cpp:623
+#: ../src/osx/carbon/fontdlg.cpp:643
 msgid "<Any Roman>"
 msgstr "<Beliebige Serifenschrift>"
 
-#: ../src/osx/carbon/fontdlg.cpp:424 ../src/osx/carbon/fontdlg.cpp:632
-#: ../src/osx/carbon/fontdlg.cpp:652
+#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:629
+#: ../src/osx/carbon/fontdlg.cpp:649
 msgid "<Any Script>"
 msgstr "<Beliebige Schreibschrift>"
 
-#: ../src/osx/carbon/fontdlg.cpp:425 ../src/osx/carbon/fontdlg.cpp:637
-#: ../src/osx/carbon/fontdlg.cpp:656
+#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:634
+#: ../src/osx/carbon/fontdlg.cpp:653
 msgid "<Any Swiss>"
 msgstr "<Beliebige Serifenlose>"
 
-#: ../src/osx/carbon/fontdlg.cpp:426 ../src/osx/carbon/fontdlg.cpp:634
-#: ../src/osx/carbon/fontdlg.cpp:654
+#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:631
+#: ../src/osx/carbon/fontdlg.cpp:651
 msgid "<Any Teletype>"
 msgstr "<Beliebige Schreibmaschinen-Schrift>"
 
-#: ../src/osx/carbon/fontdlg.cpp:420
+#: ../src/osx/carbon/fontdlg.cpp:417
 msgid "<Any>"
 msgstr "<Beliebig>"
 
-#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
 msgid "<DIR>"
 msgstr "<VERZEICHNIS>"
 
-#: ../src/generic/filectrlg.cpp:254 ../src/generic/filectrlg.cpp:277
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
 msgid "<DRIVE>"
 msgstr "<LAUFWERK>"
 
-#: ../src/generic/filectrlg.cpp:252 ../src/generic/filectrlg.cpp:275
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
 msgid "<LINK>"
 msgstr "<LINK>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1264
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Fette kursive Schrift</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1270
+#: ../src/html/helpwnd.cpp:1268
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>fett kursiv <u>unterstrichen</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1265
+#: ../src/html/helpwnd.cpp:1263
 msgid "<b>Bold face.</b> "
 msgstr "<b>Fette Schrift.</b> "
 
-#: ../src/html/helpwnd.cpp:1264
+#: ../src/html/helpwnd.cpp:1262
 msgid "<i>Italic face.</i> "
 msgstr "<i>Kursive Schrift.</i> "
 
@@ -1079,15 +1078,15 @@ msgstr "<i>Kursive Schrift.</i> "
 msgid ">"
 msgstr ">"
 
-#: ../src/generic/dbgrptg.cpp:318
+#: ../src/generic/dbgrptg.cpp:317
 msgid "A debug report has been generated in the directory\n"
 msgstr "Ein Fehlerbericht wurde erstellt im Verzeichnis\n"
 
-#: ../src/common/debugrpt.cpp:573
+#: ../src/common/debugrpt.cpp:574
 msgid "A debug report has been generated. It can be found in"
 msgstr "Ein Fehlerbericht wurde erstellt. Er liegt im Verzeichnis"
 
-#: ../src/common/xtixml.cpp:418
+#: ../src/common/xtixml.cpp:414
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Eine nicht leere Sammlung muss aus „element“-Knoten bestehen"
 
@@ -1098,106 +1097,106 @@ msgstr "Eine nicht leere Sammlung muss aus „element“-Knoten bestehen"
 msgid "A standard bullet name."
 msgstr "Ein vordefinierter Gliederungspunkt."
 
-#: ../src/common/paper.cpp:217
+#: ../src/common/paper.cpp:214
 msgid "A0 sheet, 841 x 1189 mm"
 msgstr "A0 Blatt, 841 × 1189 mm"
 
-#: ../src/common/paper.cpp:218
+#: ../src/common/paper.cpp:215
 msgid "A1 sheet, 594 x 841 mm"
 msgstr "A1 Blatt, 594 × 841 mm"
 
-#: ../src/common/paper.cpp:159
+#: ../src/common/paper.cpp:156
 msgid "A2 420 x 594 mm"
 msgstr "A2 420 × 594 mm"
 
-#: ../src/common/paper.cpp:156
+#: ../src/common/paper.cpp:153
 msgid "A3 Extra 322 x 445 mm"
 msgstr "A3 Extra 322 × 445 mm"
 
-#: ../src/common/paper.cpp:161
+#: ../src/common/paper.cpp:158
 msgid "A3 Extra Transverse 322 x 445 mm"
 msgstr "A3 Extra Quer 322 × 445 mm"
 
-#: ../src/common/paper.cpp:170
+#: ../src/common/paper.cpp:167
 msgid "A3 Rotated 420 x 297 mm"
 msgstr "A3 Rotiert 420 × 297 mm"
 
-#: ../src/common/paper.cpp:160
+#: ../src/common/paper.cpp:157
 msgid "A3 Transverse 297 x 420 mm"
 msgstr "A3 Quer 297 × 420 mm"
 
-#: ../src/common/paper.cpp:106
+#: ../src/common/paper.cpp:103
 msgid "A3 sheet, 297 x 420 mm"
 msgstr "A3 Blatt, 297 × 420 mm"
 
-#: ../src/common/paper.cpp:146
+#: ../src/common/paper.cpp:143
 msgid "A4 Extra 9.27 x 12.69 in"
 msgstr "A4 Extra 9.27 × 12.69 Zoll"
 
-#: ../src/common/paper.cpp:153
+#: ../src/common/paper.cpp:150
 msgid "A4 Plus 210 x 330 mm"
 msgstr "A4 Plus 210 × 330 mm"
 
-#: ../src/common/paper.cpp:171
+#: ../src/common/paper.cpp:168
 msgid "A4 Rotated 297 x 210 mm"
 msgstr "A4 Rotiert 297 × 210 mm"
 
-#: ../src/common/paper.cpp:148
+#: ../src/common/paper.cpp:145
 msgid "A4 Transverse 210 x 297 mm"
 msgstr "A4 Quer 210 × 297 mm"
 
-#: ../src/common/paper.cpp:97
+#: ../src/common/paper.cpp:94
 msgid "A4 sheet, 210 x 297 mm"
 msgstr "A4 Blatt, 210 × 297 mm"
 
-#: ../src/common/paper.cpp:107
+#: ../src/common/paper.cpp:104
 msgid "A4 small sheet, 210 x 297 mm"
 msgstr "A4 klein Blatt, 210 × 297 mm"
 
-#: ../src/common/paper.cpp:157
+#: ../src/common/paper.cpp:154
 msgid "A5 Extra 174 x 235 mm"
 msgstr "A5 Extra 174 × 235 mm"
 
-#: ../src/common/paper.cpp:172
+#: ../src/common/paper.cpp:169
 msgid "A5 Rotated 210 x 148 mm"
 msgstr "A5 Rotiert 210 × 148 mm"
 
-#: ../src/common/paper.cpp:154
+#: ../src/common/paper.cpp:151
 msgid "A5 Transverse 148 x 210 mm"
 msgstr "A5 Quer 148 × 210 mm"
 
-#: ../src/common/paper.cpp:108
+#: ../src/common/paper.cpp:105
 msgid "A5 sheet, 148 x 210 mm"
 msgstr "A4 Blatt, 148 × 210 mm"
 
-#: ../src/common/paper.cpp:164
+#: ../src/common/paper.cpp:161
 msgid "A6 105 x 148 mm"
 msgstr "A6 105 × 148 mm"
 
-#: ../src/common/paper.cpp:177
+#: ../src/common/paper.cpp:174
 msgid "A6 Rotated 148 x 105 mm"
 msgstr "A6 Rotiert 148 × 105 mm"
 
-#: ../src/generic/fontdlgg.cpp:83 ../src/richtext/richtextformatdlg.cpp:529
-#: ../src/osx/carbon/fontdlg.cpp:153
+#: ../src/osx/carbon/fontdlg.cpp:150 ../src/generic/fontdlgg.cpp:79
+#: ../src/richtext/richtextformatdlg.cpp:521
 msgid "ABCDEFGabcdefg12345"
 msgstr "ABCDEFGabcdefg12345ÄÖÜßäöü"
 
-#: ../src/richtext/richtextsymboldlg.cpp:458 ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
 msgid "ASCII"
 msgstr "ASCII"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "About"
 msgstr "Über"
 
-#: ../src/generic/aboutdlgg.cpp:140 ../src/osx/menu_osx.cpp:558
-#: ../src/msw/aboutdlg.cpp:64
+#: ../src/osx/menu_osx.cpp:450 ../src/generic/aboutdlgg.cpp:137
+#: ../src/msw/aboutdlg.cpp:61
 #, c-format
 msgid "About %s"
 msgstr "Über %s"
 
-#: ../src/osx/menu_osx.cpp:560
+#: ../src/osx/menu_osx.cpp:452
 msgid "About..."
 msgstr "Über …"
 
@@ -1207,38 +1206,38 @@ msgstr "Absolut"
 
 # Original wird verwendet
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:873
+#: ../src/propgrid/advprops.cpp:774
 msgid "ActiveBorder"
 msgstr "ActiveBorder"
 
 # Original wird verwendet
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:874
+#: ../src/propgrid/advprops.cpp:775
 msgid "ActiveCaption"
 msgstr "ActiveCaption"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "Actual Size"
 msgstr "Tatsächliche Größe"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:140 ../src/common/accelcmn.cpp:81
+#: ../src/common/stockitem.cpp:137 ../src/common/accelcmn.cpp:78
 msgid "Add"
 msgstr "Hinzufügen"
 
-#: ../src/richtext/richtextbuffer.cpp:11455
+#: ../src/richtext/richtextbuffer.cpp:11454
 msgid "Add Column"
 msgstr "Spalte hinzufügen"
 
-#: ../src/richtext/richtextbuffer.cpp:11392
+#: ../src/richtext/richtextbuffer.cpp:11391
 msgid "Add Row"
 msgstr "Zeile hinzufügen"
 
-#: ../src/html/helpwnd.cpp:432
+#: ../src/html/helpwnd.cpp:430
 msgid "Add current page to bookmarks"
 msgstr "Aktuelle Seite zu Lesezeichen hinzufügen"
 
-#: ../src/generic/colrdlgg.cpp:366
+#: ../src/generic/colrdlgg.cpp:386
 msgid "Add to custom colours"
 msgstr "Zu Benutzerfarben hinzufügen"
 
@@ -1250,12 +1249,12 @@ msgstr "AddToPropertyCollection aufgerufen für einen allgemeinen accessor"
 msgid "AddToPropertyCollection called w/o valid adder"
 msgstr "AddToPropertyCollection aufgerufen ohne gültigen adder"
 
-#: ../src/html/helpctrl.cpp:159
+#: ../src/html/helpctrl.cpp:155
 #, c-format
 msgid "Adding book %s"
 msgstr "Buch %s wird hinzugefügt"
 
-#: ../src/common/preferencescmn.cpp:43
+#: ../src/common/preferencescmn.cpp:40
 msgid "Advanced"
 msgstr "Erweitert"
 
@@ -1263,11 +1262,11 @@ msgstr "Erweitert"
 msgid "After a paragraph:"
 msgstr "Nach einem Absatz:"
 
-#: ../src/common/stockitem.cpp:172
+#: ../src/common/stockitem.cpp:169
 msgid "Align Left"
 msgstr "Linksbündig"
 
-#: ../src/common/stockitem.cpp:173
+#: ../src/common/stockitem.cpp:170
 msgid "Align Right"
 msgstr "Rechtsbündig"
 
@@ -1275,40 +1274,40 @@ msgstr "Rechtsbündig"
 msgid "Alignment"
 msgstr "Ausrichtung"
 
-#: ../src/generic/prntdlgg.cpp:215
+#: ../src/generic/prntdlgg.cpp:208
 msgid "All"
 msgstr "Alle"
 
-#: ../src/generic/filectrlg.cpp:1197 ../src/common/fldlgcmn.cpp:107
+#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1186
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Alle Dateien (%s)|%s"
 
-#: ../include/wx/defs.h:2886
+#: ../include/wx/defs.h:2582
 msgid "All files (*)|*"
 msgstr "Alle Dateien (*)|*"
 
-#: ../include/wx/defs.h:2883
+#: ../include/wx/defs.h:2579
 msgid "All files (*.*)|*.*"
 msgstr "Alle Dateien (*.*)|*.*"
 
-#: ../src/richtext/richtextstyles.cpp:1061
+#: ../src/richtext/richtextstyles.cpp:1058
 msgid "All styles"
 msgstr "Alle Stile"
 
-#: ../src/propgrid/manager.cpp:1528
+#: ../src/propgrid/manager.cpp:1544
 msgid "Alphabetic Mode"
 msgstr "Alphabetischer Modus"
 
-#: ../src/common/xtistrm.cpp:425
+#: ../src/common/xtistrm.cpp:422
 msgid "Already Registered Object passed to SetObjectClassInfo"
 msgstr "Ein bereits registriertes Objekt wurde an SetObjectClassInfo übergeben"
 
-#: ../src/unix/dialup.cpp:353
+#: ../src/unix/dialup.cpp:352
 msgid "Already dialling ISP."
 msgstr "ISP wird bereits angewählt."
 
-#: ../src/common/accelcmn.cpp:331 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/accelcmn.cpp:345 ../src/univ/themes/win32.cpp:3753
 msgid "Alt+"
 msgstr "Alt+"
 
@@ -1317,35 +1316,35 @@ msgstr "Alt+"
 msgid "An optional corner radius for adding rounded corners."
 msgstr "Optionaler Eckradius, um abgerundete Ecken hinzuzufügen."
 
-#: ../src/common/debugrpt.cpp:576
+#: ../src/common/debugrpt.cpp:577
 msgid "And includes the following files:\n"
 msgstr "Und enthält die folgenden Dateien:\n"
 
-#: ../src/generic/animateg.cpp:162
+#: ../src/generic/animateg.cpp:145
 #, c-format
 msgid "Animation file is not of type %ld."
 msgstr "Animationsdatei hat nicht den Typ %ld."
 
 # Original wird verwendet
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:872
+#: ../src/propgrid/advprops.cpp:773
 msgid "AppWorkspace"
 msgstr "AppWorkspace"
 
-#: ../src/generic/logg.cpp:1014
+#: ../src/generic/logg.cpp:1011
 #, c-format
 msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
 msgstr "An Logdatei „%s“ anhängen ([Nein] wird sie ersetzen)?"
 
-#: ../src/osx/menu_osx.cpp:577 ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:469 ../src/osx/menu_osx.cpp:477
 msgid "Application"
 msgstr "Anwendung"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "Apply"
 msgstr "Übernehmen"
 
-#: ../src/propgrid/advprops.cpp:1609
+#: ../src/propgrid/advprops.cpp:1515
 msgid "Aqua"
 msgstr "Cyan"
 
@@ -1354,29 +1353,29 @@ msgstr "Cyan"
 msgid "Arabic"
 msgstr "Arabisch"
 
-#: ../src/common/fmapbase.cpp:153
+#: ../src/common/fmapbase.cpp:150
 msgid "Arabic (ISO-8859-6)"
 msgstr "Arabisch (ISO-8859-6)"
 
-#: ../src/msw/ole/automtn.cpp:672
+#: ../src/msw/ole/automtn.cpp:663
 #, c-format
 msgid "Argument %u not found."
 msgstr "Hilfeverzeichnis %u nicht gefunden."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1753
+#: ../src/propgrid/advprops.cpp:1654
 msgid "Arrow"
 msgstr "Pfeil"
 
-#: ../src/generic/aboutdlgg.cpp:184
+#: ../src/generic/aboutdlgg.cpp:181
 msgid "Artists"
 msgstr "Künstler"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "Ascending"
 msgstr "Absteigend"
 
-#: ../src/generic/filectrlg.cpp:433
+#: ../src/generic/filectrlg.cpp:429
 msgid "Attributes"
 msgstr "Eigenschaften"
 
@@ -1386,90 +1385,90 @@ msgstr "Eigenschaften"
 msgid "Available fonts."
 msgstr "Verfügbare Schriftarten."
 
-#: ../src/common/paper.cpp:137
+#: ../src/common/paper.cpp:134
 msgid "B4 (ISO) 250 x 353 mm"
 msgstr "B4 (ISO) 250 × 353 mm"
 
-#: ../src/common/paper.cpp:173
+#: ../src/common/paper.cpp:170
 msgid "B4 (JIS) Rotated 364 x 257 mm"
 msgstr "B4 (JIS) Rotiert 364 × 257 mm"
 
-#: ../src/common/paper.cpp:127
+#: ../src/common/paper.cpp:124
 msgid "B4 Envelope, 250 x 353 mm"
 msgstr "B4 Umschlag, 250 × 353 mm"
 
-#: ../src/common/paper.cpp:109
+#: ../src/common/paper.cpp:106
 msgid "B4 sheet, 250 x 354 mm"
 msgstr "B4 Blatt, 250 × 354 mm"
 
-#: ../src/common/paper.cpp:158
+#: ../src/common/paper.cpp:155
 msgid "B5 (ISO) Extra 201 x 276 mm"
 msgstr "B5 (ISO) Extra 201 × 276 mm"
 
-#: ../src/common/paper.cpp:174
+#: ../src/common/paper.cpp:171
 msgid "B5 (JIS) Rotated 257 x 182 mm"
 msgstr "B5 (JIS) Rotiert 257 × 182 mm"
 
-#: ../src/common/paper.cpp:155
+#: ../src/common/paper.cpp:152
 msgid "B5 (JIS) Transverse 182 x 257 mm"
 msgstr "B5 (JIS) Quer 182 × 257 mm"
 
-#: ../src/common/paper.cpp:128
+#: ../src/common/paper.cpp:125
 msgid "B5 Envelope, 176 x 250 mm"
 msgstr "B5 Umschlag, 176 × 250 mm"
 
-#: ../src/common/paper.cpp:110
+#: ../src/common/paper.cpp:107
 msgid "B5 sheet, 182 x 257 millimeter"
 msgstr "B5 Blatt, 182 × 257 mm"
 
-#: ../src/common/paper.cpp:182
+#: ../src/common/paper.cpp:179
 msgid "B6 (JIS) 128 x 182 mm"
 msgstr "B6 (JIS) 128 × 182 mm"
 
-#: ../src/common/paper.cpp:183
+#: ../src/common/paper.cpp:180
 msgid "B6 (JIS) Rotated 182 x 128 mm"
 msgstr "B6 (JIS) Rotiert 182 × 128 mm"
 
-#: ../src/common/paper.cpp:129
+#: ../src/common/paper.cpp:126
 msgid "B6 Envelope, 176 x 125 mm"
 msgstr "B6 Umschlag, 176 × 125 mm"
 
-#: ../src/common/imagbmp.cpp:531 ../src/common/imagbmp.cpp:561
-#: ../src/common/imagbmp.cpp:576
+#: ../src/common/imagbmp.cpp:528 ../src/common/imagbmp.cpp:558
+#: ../src/common/imagbmp.cpp:573
 msgid "BMP: Couldn't allocate memory."
 msgstr "BMP: Speicheranforderung fehlgeschlagen."
 
-#: ../src/common/imagbmp.cpp:100
+#: ../src/common/imagbmp.cpp:97
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: Konnte ungültiges Bild nicht speichern."
 
-#: ../src/common/imagbmp.cpp:356
+#: ../src/common/imagbmp.cpp:353
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: Konnte RGB Farbtabelle nicht speichern."
 
-#: ../src/common/imagbmp.cpp:490
+#: ../src/common/imagbmp.cpp:487
 msgid "BMP: Couldn't write data."
 msgstr "BMP: Konnte Daten nicht speichern."
 
-#: ../src/common/imagbmp.cpp:246
+#: ../src/common/imagbmp.cpp:243
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: Dateikopf (Bitmap) konnte nicht geschrieben werden."
 
-#: ../src/common/imagbmp.cpp:269
+#: ../src/common/imagbmp.cpp:266
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: Dateikopf (BitmapInfo) konnte nicht geschrieben werden."
 
-#: ../src/common/imagbmp.cpp:140
+#: ../src/common/imagbmp.cpp:137
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage hat keine eigene wxPalette."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:142 ../src/common/accelcmn.cpp:52
+#: ../src/common/stockitem.cpp:139 ../src/common/accelcmn.cpp:49
 msgid "Back"
 msgstr "Zurück"
 
+#: ../src/richtext/richtextformatdlg.cpp:377
 #: ../src/richtext/richtextbackgroundpage.cpp:148
-#: ../src/richtext/richtextformatdlg.cpp:384
 msgid "Background"
 msgstr "Hintergrund"
 
@@ -1477,20 +1476,20 @@ msgstr "Hintergrund"
 msgid "Background &colour:"
 msgstr "Hintergrund&farbe:"
 
-#: ../src/osx/carbon/fontdlg.cpp:220
+#: ../src/osx/carbon/fontdlg.cpp:217
 msgid "Background colour"
 msgstr "Hintergrundfarbe"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:52
+#: ../src/common/accelcmn.cpp:49
 msgid "Backspace"
 msgstr "Rücktaste"
 
-#: ../src/common/fmapbase.cpp:160
+#: ../src/common/fmapbase.cpp:157
 msgid "Baltic (ISO-8859-13)"
 msgstr "Baltisch (ISO-8859-13)"
 
-#: ../src/common/fmapbase.cpp:151
+#: ../src/common/fmapbase.cpp:148
 msgid "Baltic (old) (ISO-8859-4)"
 msgstr "Baltisch (alt) (ISO-8859-4)"
 
@@ -1503,25 +1502,25 @@ msgstr "Vor einem Absatz:"
 msgid "Bitmap"
 msgstr "Bitmap"
 
-#: ../src/propgrid/advprops.cpp:1594
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Black"
 msgstr "Schwarz"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1755
+#: ../src/propgrid/advprops.cpp:1656
 msgid "Blank"
 msgstr "Leer"
 
-#: ../src/propgrid/advprops.cpp:1603
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Blue"
 msgstr "Blau"
 
-#: ../src/generic/colrdlgg.cpp:345
+#: ../src/generic/colrdlgg.cpp:365
 msgid "Blue:"
 msgstr "Blau:"
 
-#: ../src/generic/fontdlgg.cpp:333 ../src/richtext/richtextfontpage.cpp:355
-#: ../src/osx/carbon/fontdlg.cpp:354 ../src/common/stockitem.cpp:143
+#: ../src/osx/carbon/fontdlg.cpp:351 ../src/common/stockitem.cpp:140
+#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:355
 msgid "Bold"
 msgstr "Fett"
 
@@ -1530,31 +1529,35 @@ msgstr "Fett"
 msgid "Border"
 msgstr "Rahmen"
 
-#: ../src/richtext/richtextformatdlg.cpp:379
+#: ../src/richtext/richtextformatdlg.cpp:372
 msgid "Borders"
 msgstr "Rahmen"
 
-#: ../src/richtext/richtextsizepage.cpp:288 ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141 ../src/richtext/richtextsizepage.cpp:288
 msgid "Bottom"
 msgstr "Unten"
 
-#: ../src/generic/prntdlgg.cpp:893
+#: ../src/generic/prntdlgg.cpp:886
 msgid "Bottom margin (mm):"
 msgstr "Unterer Rand (mm)"
 
-#: ../src/richtext/richtextbuffer.cpp:9383
+#: ../src/richtext/richtextbuffer.cpp:9380
 msgid "Box Properties"
 msgstr "Rahmen-Eigenschaften"
 
-#: ../src/richtext/richtextstyles.cpp:1065
+#: ../src/richtext/richtextstyles.cpp:1062
 msgid "Box styles"
 msgstr "Rahmen-Stile"
 
-#: ../src/propgrid/advprops.cpp:1602
+#: ../src/osx/cocoa/menu.mm:292
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Brown"
 msgstr "Braun"
 
-#: ../src/common/filepickercmn.cpp:43 ../src/common/filepickercmn.cpp:44
+#: ../src/common/filepickercmn.cpp:40 ../src/common/filepickercmn.cpp:41
 msgid "Browse"
 msgstr "Durchsuchen"
 
@@ -1567,77 +1570,77 @@ msgstr "&Ausrichtung der Gliederungspunkte:"
 msgid "Bullet style"
 msgstr "Stil der Gliederungspunkte"
 
-#: ../src/richtext/richtextformatdlg.cpp:359
+#: ../src/richtext/richtextformatdlg.cpp:352
 msgid "Bullets"
 msgstr "Gliederungspunkte"
 
 # Sieht aus wie das innere Feld bei Darts
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1756
+#: ../src/propgrid/advprops.cpp:1657
 msgid "Bullseye"
 msgstr "Bullseye"
 
 # Original wird verwendet
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:875
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonFace"
 msgstr "ButtonFace"
 
 # Original wird verwendet
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:876
+#: ../src/propgrid/advprops.cpp:777
 msgid "ButtonHighlight"
 msgstr "ButtonHighlight"
 
 # Original wird verwendet
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:877
+#: ../src/propgrid/advprops.cpp:778
 msgid "ButtonShadow"
 msgstr "ButtonShadow"
 
 # Original wird verwendet
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:878
+#: ../src/propgrid/advprops.cpp:779
 msgid "ButtonText"
 msgstr "ButtonText"
 
-#: ../src/common/paper.cpp:98
+#: ../src/common/paper.cpp:95
 msgid "C sheet, 17 x 22 in"
 msgstr "C Blatt, 17 × 22 Zoll"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "C&lear"
 msgstr "&Löschen"
 
-#: ../src/generic/fontdlgg.cpp:406
+#: ../src/generic/fontdlgg.cpp:403
 msgid "C&olour:"
 msgstr "&Farbe:"
 
-#: ../src/common/paper.cpp:123
+#: ../src/common/paper.cpp:120
 msgid "C3 Envelope, 324 x 458 mm"
 msgstr "C3 Umschlag, 324 × 458 mm"
 
-#: ../src/common/paper.cpp:124
+#: ../src/common/paper.cpp:121
 msgid "C4 Envelope, 229 x 324 mm"
 msgstr "C4 Umschlag, 229 × 324 mm"
 
-#: ../src/common/paper.cpp:122
+#: ../src/common/paper.cpp:119
 msgid "C5 Envelope, 162 x 229 mm"
 msgstr "C5 Umschlag, 162 × 229 mm"
 
-#: ../src/common/paper.cpp:125
+#: ../src/common/paper.cpp:122
 msgid "C6 Envelope, 114 x 162 mm"
 msgstr "C6 Umschlag, 114 × 162 mm"
 
-#: ../src/common/paper.cpp:126
+#: ../src/common/paper.cpp:123
 msgid "C65 Envelope, 114 x 229 mm"
 msgstr "C65 Umschlag, 114 × 229 mm"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "CD-Rom"
 msgstr "CD-ROM"
 
-#: ../src/html/chm.cpp:815 ../src/html/chm.cpp:874
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:865
 msgid "CHM handler currently supports only local files!"
 msgstr "CHM-Handler unterstützt derzeit nur lokale Dateien!"
 
@@ -1645,196 +1648,200 @@ msgstr "CHM-Handler unterstützt derzeit nur lokale Dateien!"
 msgid "Ca&pitals"
 msgstr "Ka&pitalien"
 
-#: ../src/common/cmdproc.cpp:267
+#: ../src/common/cmdproc.cpp:260
 msgid "Can't &Undo "
 msgstr "K&ann nicht rückgängig machen "
 
-#: ../src/common/image.cpp:2824
+#: ../src/common/image.cpp:2924
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 "Das Bildformat für nicht durchsuchbare Eingabe kann nicht automatisch "
 "bestimmt werden."
 
-#: ../src/msw/registry.cpp:506
+#: ../src/msw/registry.cpp:495
 #, c-format
 msgid "Can't close registry key '%s'"
 msgstr "Kann Registrierungsschlüssel „%s“ nicht schließen."
 
-#: ../src/msw/registry.cpp:584
+#: ../src/msw/registry.cpp:573
 #, c-format
 msgid "Can't copy values of unsupported type %d."
 msgstr "Kann Inhalte des nicht unterstützten Typs %d nicht kopieren."
 
-#: ../src/msw/registry.cpp:487
+#: ../src/msw/registry.cpp:476
 #, c-format
 msgid "Can't create registry key '%s'"
 msgstr "Kann Registrierungsschlüssel „%s“ nicht erzeugen."
 
-#: ../src/msw/thread.cpp:665
+#: ../src/msw/thread.cpp:657
 msgid "Can't create thread"
 msgstr "Kann Thread nicht erzeugen"
 
-#: ../src/msw/window.cpp:3691
-#, c-format
-msgid "Can't create window of class %s"
-msgstr "Kann kein Fenster der Klasse „%s“ anlegen"
-
-#: ../src/msw/registry.cpp:777
+#: ../src/msw/registry.cpp:765
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Kann Schlüssel „%s“ nicht löschen"
 
-#: ../src/msw/iniconf.cpp:458
+#: ../src/msw/iniconf.cpp:455
 #, c-format
 msgid "Can't delete the INI file '%s'"
 msgstr "Kann INI-Datei „%s“ nicht löschen"
 
-#: ../src/msw/registry.cpp:805
+#: ../src/msw/registry.cpp:793
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Kann Wert „%s“ von Schlüssel „%s“ nicht löschen."
 
-#: ../src/msw/registry.cpp:1171
+#: ../src/msw/registry.cpp:1159
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Kann Unterschlüssel von „%s“ nicht auflisten"
 
-#: ../src/msw/registry.cpp:1132
+#: ../src/msw/registry.cpp:1120
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Kann Werte von Schlüssel „%s“ nicht auflisten"
 
-#: ../src/msw/registry.cpp:1389
+#: ../src/msw/registry.cpp:1377
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Kann Wert des nicht unterstützten Typs %d nicht kopieren."
 
-#: ../src/common/ffile.cpp:254
+#: ../src/common/ffile.cpp:253
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Kann aktuelle Position in Datei „%s“ nicht finden."
 
-#: ../src/msw/registry.cpp:418
+#: ../src/msw/registry.cpp:407
 #, c-format
 msgid "Can't get info about registry key '%s'"
 msgstr "Kann keine Information über den Registrierungsschlüssel „%s“ finden"
 
-#: ../src/common/zstream.cpp:346
+#: ../src/msw/webview_ie.cpp:1024
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "Kann Thread-Priorität nicht setzen"
+
+#: ../src/common/zstream.cpp:343
 msgid "Can't initialize zlib deflate stream."
 msgstr "Kann das Entpacken der zlib-Daten nicht initialisieren."
 
-#: ../src/common/zstream.cpp:185
+#: ../src/common/zstream.cpp:182
 msgid "Can't initialize zlib inflate stream."
 msgstr "Kann das Komprimieren der zlib-Daten nicht initialisieren."
 
-#: ../src/msw/fswatcher.cpp:476
+#: ../src/msw/fswatcher.cpp:475
 #, c-format
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr ""
 "Das nicht vorhandene Verzeichnis „%s“ kann nicht auf Änderungen überwacht "
 "werden."
 
-#: ../src/msw/registry.cpp:454
+#: ../src/msw/registry.cpp:443
 #, c-format
 msgid "Can't open registry key '%s'"
 msgstr "Kann Registrierungsschlüssel „%s“ nicht öffnen"
 
-#: ../src/common/zstream.cpp:252
+#: ../src/common/zstream.cpp:249
 #, c-format
 msgid "Can't read from inflate stream: %s"
 msgstr "Kann nicht vom entpackten Datenstrom lesen:%s"
 
-#: ../src/common/zstream.cpp:244
+#: ../src/common/zstream.cpp:241
 msgid "Can't read inflate stream: unexpected EOF in underlying stream."
 msgstr ""
 "Kann den Entkomprimier-Strom nicht lesen: Unerwartetes EOF im "
 "zugrundeliegenden Strom."
 
-#: ../src/msw/registry.cpp:1064
+#: ../src/msw/registry.cpp:1052
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Kann Wert von „%s“ nicht lesen"
 
-#: ../src/msw/registry.cpp:878 ../src/msw/registry.cpp:910
-#: ../src/msw/registry.cpp:975
+#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
+#: ../src/msw/registry.cpp:963
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Kann Wert von Eintrag „%s“ nicht lesen"
 
-#: ../src/common/image.cpp:2620
+#: ../src/msw/webview_ie.cpp:1017
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/common/image.cpp:2715
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "Kann Bild nicht aus Datei „%s“ laden: Unbekannte Dateiendung."
 
-#: ../src/generic/logg.cpp:573 ../src/generic/logg.cpp:976
+#: ../src/generic/logg.cpp:570 ../src/generic/logg.cpp:973
 msgid "Can't save log contents to file."
 msgstr "Kann Logtexte nicht in Datei speichern."
 
-#: ../src/msw/thread.cpp:629
+#: ../src/msw/thread.cpp:621
 msgid "Can't set thread priority"
 msgstr "Kann Thread-Priorität nicht setzen"
 
-#: ../src/msw/registry.cpp:896 ../src/msw/registry.cpp:938
-#: ../src/msw/registry.cpp:1081
+#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
+#: ../src/msw/registry.cpp:1069
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Kann Wert von „%s“ nicht setzen"
 
-#: ../src/unix/utilsunx.cpp:351
+#: ../src/unix/utilsunx.cpp:353
 msgid "Can't write to child process's stdin"
 msgstr "Kann nicht in den Standard-Eingabekanal des Kindprozesses schreiben"
 
-#: ../src/common/zstream.cpp:427
+#: ../src/common/zstream.cpp:424
 #, c-format
 msgid "Can't write to deflate stream: %s"
 msgstr "Kann nicht in den gepackten Datenstrom schreiben: %s"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:279 ../src/richtext/richtextstyledlg.cpp:300
-#: ../src/common/stockitem.cpp:145 ../src/common/accelcmn.cpp:71
-#: ../src/msw/msgdlg.cpp:454 ../src/msw/progdlg.cpp:673
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:142
+#: ../src/common/accelcmn.cpp:68 ../src/motif/msgdlg.cpp:196
+#: ../src/gtk1/fontdlg.cpp:144 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/progdlg.cpp:940 ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: ../src/common/filefn.cpp:1261
+#: ../src/common/filefn.cpp:1149
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Kann Dateien „%s“ nicht auflisten"
 
-#: ../src/msw/dir.cpp:263
+#: ../src/msw/dir.cpp:260
 #, c-format
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Kann Dateien in Verzeichnis „%s“ nicht auflisten"
 
-#: ../src/msw/dialup.cpp:523
+#: ../src/msw/dialup.cpp:517
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Kann keine aktive DFÜ-Verbindung finden: %s"
 
-#: ../src/msw/dialup.cpp:827
+#: ../src/msw/dialup.cpp:821
 msgid "Cannot find the location of address book file"
 msgstr "Kann Adressbuchdatei nicht finden"
 
-#: ../src/msw/ole/automtn.cpp:562
+#: ../src/msw/ole/automtn.cpp:553
 #, c-format
 msgid "Cannot get an active instance of \"%s\""
 msgstr "Kann kein aktives Exemplar von „%s“ bekommen"
 
-#: ../src/unix/threadpsx.cpp:1035
+#: ../src/unix/threadpsx.cpp:1053
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "Kein Prioritätsbereich für Scheduling-Verfahren %d ermittelbar."
 
-#: ../src/unix/utilsunx.cpp:987
+#: ../src/unix/utilsunx.cpp:989
 msgid "Cannot get the hostname"
 msgstr "Hostnamen nicht ermittelbar"
 
-#: ../src/unix/utilsunx.cpp:1023
+#: ../src/unix/utilsunx.cpp:1025
 msgid "Cannot get the official hostname"
 msgstr "Offizieller Hostname nicht ermittelbar"
 
-#: ../src/msw/dialup.cpp:928
+#: ../src/msw/dialup.cpp:922
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Kann nicht auflegen - keine aktive DFÜ-Verbindung vorhanden."
 
@@ -1842,127 +1849,127 @@ msgstr "Kann nicht auflegen - keine aktive DFÜ-Verbindung vorhanden."
 msgid "Cannot initialize OLE"
 msgstr "Kann OLE nicht initialisieren"
 
-#: ../src/common/socket.cpp:853
+#: ../src/common/socket.cpp:850
 msgid "Cannot initialize sockets"
 msgstr "Kann Sockets nicht initialisieren"
 
-#: ../src/msw/volume.cpp:619
+#: ../src/msw/volume.cpp:627
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Kann das Icon nicht von „%s“ laden."
 
-#: ../src/xrc/xmlres.cpp:360
+#: ../src/xrc/xmlres.cpp:358
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Kann die Ressourcen nicht aus „%s“ laden."
 
-#: ../src/xrc/xmlres.cpp:742
+#: ../src/xrc/xmlres.cpp:740
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Kann die Ressourcen nicht aus der Datei „%s“ laden."
 
-#: ../src/html/htmlfilt.cpp:137
+#: ../src/html/htmlfilt.cpp:134
 #, c-format
 msgid "Cannot open HTML document: %s"
 msgstr "HTML-Dokument %s kann nicht geöffnet werden"
 
-#: ../src/html/helpdata.cpp:667
+#: ../src/html/helpdata.cpp:660
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "HTML-Hilfebuch %s kann nicht geöffnet werden"
 
-#: ../src/html/helpdata.cpp:299
+#: ../src/html/helpdata.cpp:296
 #, c-format
 msgid "Cannot open contents file: %s"
 msgstr "Kann den Inhalt der Datei %s nicht öffnen"
 
-#: ../src/generic/dcpsg.cpp:1667
+#: ../src/generic/dcpsg.cpp:1665
 msgid "Cannot open file for PostScript printing!"
 msgstr "Kann Datei für den Postscriptdruck nicht öffnen!"
 
-#: ../src/html/helpdata.cpp:313
+#: ../src/html/helpdata.cpp:310
 #, c-format
 msgid "Cannot open index file: %s"
 msgstr "Kann Indexdatei %s nicht öffnen"
 
-#: ../src/xrc/xmlres.cpp:724
+#: ../src/xrc/xmlres.cpp:722
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Kann die Ressourcendatei „%s“ nicht öffnen."
 
-#: ../src/html/helpwnd.cpp:1534
+#: ../src/html/helpwnd.cpp:1532
 msgid "Cannot print empty page."
 msgstr "Leere Seite kann nicht gedruckt werden."
 
-#: ../src/msw/volume.cpp:507
+#: ../src/msw/volume.cpp:515
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Kann die Typnamen nicht aus „%s“ lesen!"
 
-#: ../src/msw/thread.cpp:888
+#: ../src/msw/thread.cpp:894
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Kann Thread %lx nicht fortsetzen"
 
-#: ../src/unix/threadpsx.cpp:1016
+#: ../src/unix/threadpsx.cpp:1028
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Kann Scheduling-Verfahren der Threads nicht ermitteln."
 
-#: ../src/common/intl.cpp:558
+#: ../src/common/intl.cpp:365
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "Lokalisierung kann nicht auf die Sprache „%s“ gesetzt werden."
 
-#: ../src/unix/threadpsx.cpp:831 ../src/msw/thread.cpp:546
+#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
 msgid "Cannot start thread: error writing TLS."
 msgstr "Kann Thread nicht starten: Fehler beim Beschreiben des TLS."
 
-#: ../src/msw/thread.cpp:872
+#: ../src/msw/thread.cpp:864
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Kann Thread %lx nicht anhalten"
 
-#: ../src/msw/thread.cpp:794
+#: ../src/msw/thread.cpp:786
 msgid "Cannot wait for thread termination"
 msgstr "Kann nicht auf Threadende warten"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:75
+#: ../src/common/accelcmn.cpp:72
 msgid "Capital"
 msgstr "Großbuchstaben"
 
 # Original wird verwendet
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:879
+#: ../src/propgrid/advprops.cpp:780
 msgid "CaptionText"
 msgstr "CaptionText"
 
-#: ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:531
 msgid "Case sensitive"
 msgstr "Groß-/Kleinschreibung"
 
-#: ../src/propgrid/manager.cpp:1509
+#: ../src/propgrid/manager.cpp:1527
 msgid "Categorized Mode"
 msgstr "Kategorie-Modus"
 
-#: ../src/richtext/richtextbuffer.cpp:9968
+#: ../src/richtext/richtextbuffer.cpp:9965
 msgid "Cell Properties"
 msgstr "Zelleneigenschaften"
 
-#: ../src/common/fmapbase.cpp:161
+#: ../src/common/fmapbase.cpp:158
 msgid "Celtic (ISO-8859-14)"
 msgstr "Keltisch (ISO-8859-14)"
 
-#: ../src/richtext/richtextindentspage.cpp:160
 #: ../src/richtext/richtextliststylepage.cpp:349
+#: ../src/richtext/richtextindentspage.cpp:160
 msgid "Cen&tred"
 msgstr "Zen&triert"
 
-#: ../src/common/stockitem.cpp:170
+#: ../src/common/stockitem.cpp:167
 msgid "Centered"
 msgstr "Zentriert"
 
-#: ../src/common/fmapbase.cpp:149
+#: ../src/common/fmapbase.cpp:146
 msgid "Central European (ISO-8859-2)"
 msgstr "Zentraleuropäisch (ISO-8859-2)"
 
@@ -1971,10 +1978,10 @@ msgstr "Zentraleuropäisch (ISO-8859-2)"
 msgid "Centre"
 msgstr "Zentriere"
 
-#: ../src/richtext/richtextindentspage.cpp:162
-#: ../src/richtext/richtextindentspage.cpp:164
 #: ../src/richtext/richtextliststylepage.cpp:351
 #: ../src/richtext/richtextliststylepage.cpp:353
+#: ../src/richtext/richtextindentspage.cpp:162
+#: ../src/richtext/richtextindentspage.cpp:164
 msgid "Centre text."
 msgstr "Zentriere den Text."
 
@@ -1987,24 +1994,24 @@ msgstr "Zentriert"
 msgid "Ch&oose..."
 msgstr "Wä&hle …"
 
-#: ../src/richtext/richtextbuffer.cpp:4354
+#: ../src/richtext/richtextbuffer.cpp:4351
 msgid "Change List Style"
 msgstr "Stil der Liste ändern"
 
-#: ../src/richtext/richtextbuffer.cpp:3709
+#: ../src/richtext/richtextbuffer.cpp:3706
 msgid "Change Object Style"
 msgstr "Stil des Objektes ändern"
 
-#: ../src/richtext/richtextbuffer.cpp:3982
-#: ../src/richtext/richtextbuffer.cpp:8129
+#: ../src/richtext/richtextbuffer.cpp:3979
+#: ../src/richtext/richtextbuffer.cpp:8125
 msgid "Change Properties"
 msgstr "Eigenschaften ändern"
 
-#: ../src/richtext/richtextbuffer.cpp:3526
+#: ../src/richtext/richtextbuffer.cpp:3523
 msgid "Change Style"
 msgstr "Stil ändern"
 
-#: ../src/common/fileconf.cpp:341
+#: ../src/common/fileconf.cpp:335
 #, c-format
 msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
 msgstr ""
@@ -2017,11 +2024,11 @@ msgid "Changing current directory to \"%s\" failed"
 msgstr "Wechseln des aktuellen Ordners auf „%s“ fehlgeschlagen"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1757
+#: ../src/propgrid/advprops.cpp:1658
 msgid "Character"
 msgstr "Zeichen"
 
-#: ../src/richtext/richtextstyles.cpp:1063
+#: ../src/richtext/richtextstyles.cpp:1060
 msgid "Character styles"
 msgstr "Zeichenstil"
 
@@ -2058,20 +2065,20 @@ msgstr "Klicken um den Gliederungspunkt in Klammern zu setzen."
 msgid "Check to indicate right-to-left text layout."
 msgstr "Markieren um rechts-nach-links-Textausrichtung zu aktivieren."
 
-#: ../src/osx/carbon/fontdlg.cpp:356 ../src/osx/carbon/fontdlg.cpp:358
+#: ../src/osx/carbon/fontdlg.cpp:353 ../src/osx/carbon/fontdlg.cpp:355
 msgid "Check to make the font bold."
 msgstr "Klicken um die Schriftart auf fett zu stellen."
 
-#: ../src/osx/carbon/fontdlg.cpp:363 ../src/osx/carbon/fontdlg.cpp:365
+#: ../src/osx/carbon/fontdlg.cpp:360 ../src/osx/carbon/fontdlg.cpp:362
 msgid "Check to make the font italic."
 msgstr "Klicken um die Schriftart auf kursiv zu stellen."
 
-#: ../src/osx/carbon/fontdlg.cpp:372 ../src/osx/carbon/fontdlg.cpp:374
+#: ../src/osx/carbon/fontdlg.cpp:369 ../src/osx/carbon/fontdlg.cpp:371
 msgid "Check to make the font underlined."
 msgstr "Klicken um die Schriftart auf unterstrichen zu stellen."
 
-#: ../src/richtext/richtextstyledlg.cpp:289
-#: ../src/richtext/richtextstyledlg.cpp:291
+#: ../src/richtext/richtextstyledlg.cpp:285
+#: ../src/richtext/richtextstyledlg.cpp:287
 msgid "Check to restart numbering."
 msgstr "Klicken um die Nummerierung neu zu starten."
 
@@ -2105,51 +2112,51 @@ msgstr "Klicken um den Text hochgestellt anzuzeigen."
 msgid "Check to suppress hyphenation."
 msgstr "Markieren um Silbentrennung zu unterdrücken."
 
-#: ../src/msw/dialup.cpp:763
+#: ../src/msw/dialup.cpp:757
 msgid "Choose ISP to dial"
 msgstr "Anzuwählenden ISP auswählen"
 
-#: ../src/propgrid/props.cpp:1922
+#: ../src/propgrid/props.cpp:1904
 msgid "Choose a directory:"
 msgstr "Verzeichnis wählen:"
 
-#: ../src/propgrid/props.cpp:1975
+#: ../src/propgrid/props.cpp:2199
 msgid "Choose a file"
 msgstr "Datei wählen"
 
-#: ../src/generic/colrdlgg.cpp:158 ../src/gtk/colordlg.cpp:54
+#: ../src/generic/colrdlgg.cpp:156 ../src/gtk/colordlg.cpp:49
 msgid "Choose colour"
 msgstr "Farbe wählen"
 
-#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/gtk1/fontdlg.cpp:125 ../src/generic/fontpickerg.cpp:47
+#: ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Schriftart wählen"
 
-#: ../src/common/module.cpp:74
+#: ../src/common/module.cpp:71
 #, c-format
 msgid "Circular dependency involving module \"%s\" detected."
 msgstr "Zirkuläre Abhängigkeit betreffend das Modul „%s“ erkannt."
 
-#: ../src/aui/tabmdi.cpp:108 ../src/generic/mdig.cpp:97
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
 msgid "Cl&ose"
 msgstr "S&chließen"
 
-#: ../src/msw/ole/automtn.cpp:684
+#: ../src/msw/ole/automtn.cpp:675
 msgid "Class not registered."
 msgstr "Klasse nicht registriert."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:147 ../src/common/accelcmn.cpp:72
+#: ../src/common/stockitem.cpp:144 ../src/common/accelcmn.cpp:69
 msgid "Clear"
 msgstr "Löschen"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "Clear the log contents"
 msgstr "Logtexte löschen"
 
-#: ../src/richtext/richtextstyledlg.cpp:252
-#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:248
+#: ../src/richtext/richtextstyledlg.cpp:250
 msgid "Click to apply the selected style."
 msgstr "Klicken um den ausgewählten Stil anzuwenden."
 
@@ -2160,15 +2167,15 @@ msgstr "Klicken um den ausgewählten Stil anzuwenden."
 msgid "Click to browse for a symbol."
 msgstr "Klicken um nach einem Symbol zu navigieren."
 
-#: ../src/osx/carbon/fontdlg.cpp:403 ../src/osx/carbon/fontdlg.cpp:405
+#: ../src/osx/carbon/fontdlg.cpp:400 ../src/osx/carbon/fontdlg.cpp:402
 msgid "Click to cancel changes to the font."
 msgstr "Klicken um die Änderungen der Schriftart zu verwerfen."
 
-#: ../src/generic/fontdlgg.cpp:472 ../src/generic/fontdlgg.cpp:491
+#: ../src/generic/fontdlgg.cpp:468 ../src/generic/fontdlgg.cpp:487
 msgid "Click to cancel the font selection."
 msgstr "Klicken um Wahl der Schriftart abzubrechen."
 
-#: ../src/osx/carbon/fontdlg.cpp:384 ../src/osx/carbon/fontdlg.cpp:386
+#: ../src/osx/carbon/fontdlg.cpp:381 ../src/osx/carbon/fontdlg.cpp:383
 msgid "Click to change the font colour."
 msgstr "Klicken um die Farbe der Schriftart zu ändern."
 
@@ -2187,37 +2194,37 @@ msgstr "Klicken um die Textfarbe zu ändern."
 msgid "Click to choose the font for this level."
 msgstr "Klicken um die Schriftart für diese Ebene zu wählen."
 
-#: ../src/richtext/richtextstyledlg.cpp:279
-#: ../src/richtext/richtextstyledlg.cpp:281
+#: ../src/richtext/richtextstyledlg.cpp:275
+#: ../src/richtext/richtextstyledlg.cpp:277
 msgid "Click to close this window."
 msgstr "Klicken um dieses Fenster zu schließen."
 
-#: ../src/osx/carbon/fontdlg.cpp:410 ../src/osx/carbon/fontdlg.cpp:412
+#: ../src/osx/carbon/fontdlg.cpp:407 ../src/osx/carbon/fontdlg.cpp:409
 msgid "Click to confirm changes to the font."
 msgstr "Klicken um die Änderungen der Schriftart zu bestätigen."
 
-#: ../src/generic/fontdlgg.cpp:477 ../src/generic/fontdlgg.cpp:479
-#: ../src/generic/fontdlgg.cpp:484 ../src/generic/fontdlgg.cpp:486
+#: ../src/generic/fontdlgg.cpp:473 ../src/generic/fontdlgg.cpp:475
+#: ../src/generic/fontdlgg.cpp:480 ../src/generic/fontdlgg.cpp:482
 msgid "Click to confirm the font selection."
 msgstr "Klicken um Wahl der Schriftart zu bestätigen."
 
-#: ../src/richtext/richtextstyledlg.cpp:244
-#: ../src/richtext/richtextstyledlg.cpp:246
+#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:242
 msgid "Click to create a new box style."
 msgstr "Klicken um einen neuen Rahmen-Stil zu erzeugen."
 
-#: ../src/richtext/richtextstyledlg.cpp:226
-#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:224
 msgid "Click to create a new character style."
 msgstr "Klicken um einen neuen Zeichenstil zu erzeugen."
 
-#: ../src/richtext/richtextstyledlg.cpp:238
-#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:236
 msgid "Click to create a new list style."
 msgstr "Klicken um einen neuen Listenstil zu erzeugen."
 
-#: ../src/richtext/richtextstyledlg.cpp:232
-#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:230
 msgid "Click to create a new paragraph style."
 msgstr "Klicken um einen neuen Absatzstil zu erzeugen."
 
@@ -2231,8 +2238,8 @@ msgstr "Klicken um eine neue Tabulatorposition zu erzeugen."
 msgid "Click to delete all tab positions."
 msgstr "Klicken um alle Tabulatorpositionen zu löschen."
 
-#: ../src/richtext/richtextstyledlg.cpp:270
-#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:268
 msgid "Click to delete the selected style."
 msgstr "Klicken um den ausgewählten Stil zu löschen."
 
@@ -2241,25 +2248,25 @@ msgstr "Klicken um den ausgewählten Stil zu löschen."
 msgid "Click to delete the selected tab position."
 msgstr "Klicken um die ausgewählte Tabulatorposition zu löschen."
 
-#: ../src/richtext/richtextstyledlg.cpp:264
-#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:262
 msgid "Click to edit the selected style."
 msgstr "Klicken um den ausgewählten Stil zu bearbeiten."
 
-#: ../src/richtext/richtextstyledlg.cpp:258
-#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:256
 msgid "Click to rename the selected style."
 msgstr "Klicken um den ausgewählten Stil umzubenennen."
 
-#: ../src/generic/dbgrptg.cpp:97 ../src/generic/progdlgg.cpp:759
-#: ../src/richtext/richtextstyledlg.cpp:277
-#: ../src/richtext/richtextsymboldlg.cpp:476 ../src/common/stockitem.cpp:148
-#: ../src/msw/progdlg.cpp:170 ../src/msw/progdlg.cpp:679
-#: ../src/html/helpdlg.cpp:90
+#: ../src/common/stockitem.cpp:145 ../src/generic/dbgrptg.cpp:94
+#: ../src/generic/progdlgg.cpp:781 ../src/msw/progdlg.cpp:211
+#: ../src/msw/progdlg.cpp:946 ../src/html/helpdlg.cpp:87
+#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextstyledlg.cpp:273
 msgid "Close"
 msgstr "Schließen"
 
-#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:98
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
 msgid "Close All"
 msgstr "Alles Schließen"
 
@@ -2267,43 +2274,43 @@ msgstr "Alles Schließen"
 msgid "Close current document"
 msgstr "Aktuelles Dokument schließen"
 
-#: ../src/generic/logg.cpp:516
+#: ../src/generic/logg.cpp:513
 msgid "Close this window"
 msgstr "Fenster schließen"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6006
+#: ../src/generic/datavgen.cpp:6811
 msgid "Collapse"
 msgstr "Zusammenklappen"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "Color"
 msgstr "Farbe"
 
-#: ../src/richtext/richtextformatdlg.cpp:776
+#: ../src/richtext/richtextformatdlg.cpp:768
 msgid "Colour"
 msgstr "Farbe"
 
-#: ../src/msw/colordlg.cpp:158
+#: ../src/msw/colordlg.cpp:227
 #, c-format
 msgid "Colour selection dialog failed with error %0lx."
 msgstr "Farbauswahldialog schlug mit Fehler %0lx fehl."
 
-#: ../src/osx/carbon/fontdlg.cpp:380
+#: ../src/osx/carbon/fontdlg.cpp:377
 msgid "Colour:"
 msgstr "Farbe:"
 
-#: ../src/generic/datavgen.cpp:6077
+#: ../src/generic/datavgen.cpp:6882
 #, c-format
 msgid "Column %u"
 msgstr "Spalte %u"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:114
+#: ../src/common/accelcmn.cpp:112
 msgid "Command"
 msgstr "Befehlstaste"
 
-#: ../src/common/init.cpp:196
+#: ../src/common/init.cpp:193
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
@@ -2312,12 +2319,12 @@ msgstr ""
 "Kommandozeilenargument %d konnte nicht nach Unicode konvertiert werden und "
 "wird ignoriert."
 
-#: ../src/msw/fontdlg.cpp:120
+#: ../src/msw/fontdlg.cpp:170
 #, c-format
 msgid "Common dialog failed with error code %0lx."
 msgstr "Allgemeiner Dialog schlug fehl mit dem Fehlercode %0lx."
 
-#: ../src/gtk/window.cpp:4649
+#: ../src/gtk/window.cpp:5653
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
@@ -2325,11 +2332,11 @@ msgstr ""
 "Zusammenfügen wird nicht durch dieses System unterstützt, bitte über den "
 "Fenster Manager einstellen."
 
-#: ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:1549
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Komprimierte HTML-Hilfedatei (*.chm)|*.chm|"
 
-#: ../src/generic/dirctrlg.cpp:444
+#: ../src/generic/dirctrlg.cpp:410
 msgid "Computer"
 msgstr "Computer"
 
@@ -2339,55 +2346,59 @@ msgid "Config entry name cannot start with '%c'."
 msgstr ""
 "Die Bezeichnung des Konfigurations-Eintrags kann nicht mit „%c“ beginnen."
 
-#: ../src/generic/filedlgg.cpp:349 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
 msgid "Confirm"
 msgstr "Bestätigen"
 
-#: ../src/html/htmlwin.cpp:566
+#: ../src/html/htmlwin.cpp:569
 msgid "Connecting..."
 msgstr "Verbinde …"
 
-#: ../src/html/helpwnd.cpp:475
+#: ../src/html/helpwnd.cpp:473
 msgid "Contents"
 msgstr "Inhalte"
 
 # Original wird verwendet
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:880
+#: ../src/propgrid/advprops.cpp:781
 msgid "ControlDark"
 msgstr "ControlDark"
 
 # Original wird verwendet
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:881
+#: ../src/propgrid/advprops.cpp:782
 msgid "ControlLight"
 msgstr "ControlLight"
 
-#: ../src/common/strconv.cpp:2262
+#: ../src/common/strconv.cpp:2208
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Konvertierung zum Zeichensatz „%s“ funktioniert nicht."
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "Convert"
 msgstr "Konvertieren"
 
-#: ../src/html/htmlwin.cpp:1079
+#: ../src/html/htmlwin.cpp:1020
 #, c-format
 msgid "Copied to clipboard:\"%s\""
 msgstr "In Zwischenablage kopiert:„%s“"
 
-#: ../src/generic/prntdlgg.cpp:247
+#: ../src/generic/prntdlgg.cpp:240
 msgid "Copies:"
 msgstr "Kopien:"
 
-#: ../src/common/stockitem.cpp:150 ../src/stc/stc_i18n.cpp:18
+#: ../src/common/stockitem.cpp:147 ../src/stc/stc_i18n.cpp:18
 msgid "Copy"
 msgstr "Kopieren"
 
-#: ../src/common/stockitem.cpp:258
+#: ../src/common/stockitem.cpp:255
 msgid "Copy selection"
 msgstr "Auswahl kopieren"
+
+#: ../src/generic/grid.cpp:5945
+msgid "Copying more than one selected block to clipboard is not supported."
+msgstr ""
 
 #: ../src/richtext/richtextborderspage.cpp:566
 #: ../src/richtext/richtextborderspage.cpp:601
@@ -2398,197 +2409,194 @@ msgstr "Ecke"
 msgid "Corner &radius:"
 msgstr "Eck&radius:"
 
-#: ../src/html/chm.cpp:718
+#: ../src/html/chm.cpp:711
 #, c-format
 msgid "Could not create temporary file '%s'"
 msgstr "Konnte temporäre Datei „%s“ nicht erzeugen"
 
-#: ../src/html/chm.cpp:273
+#: ../src/html/chm.cpp:270
 #, c-format
 msgid "Could not extract %s into %s: %s"
 msgstr "Konnte nicht %s in %s extrahieren: %s"
 
-#: ../src/generic/tabg.cpp:1048
+#: ../src/generic/tabg.cpp:1045
 msgid "Could not find tab for id"
 msgstr "Konnte Seite für ID nicht finden"
 
-#: ../src/gtk/notifmsg.cpp:108
-msgid "Could not initalize libnotify."
-msgstr "Konnte libnotify nicht initialisieren."
-
-#: ../src/html/chm.cpp:444
+#: ../src/html/chm.cpp:437
 #, c-format
 msgid "Could not locate file '%s'."
 msgstr "Konnte Datei „%s“ nicht finden."
 
-#: ../src/common/filefn.cpp:1403
+#: ../src/msw/graphicsd2d.cpp:604
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/common/filefn.cpp:1291
 msgid "Could not set current working directory"
 msgstr "Konnte das Arbeitsverzeichnis nicht setzen"
 
-#: ../src/common/prntbase.cpp:2015
+#: ../src/common/prntbase.cpp:2037
 msgid "Could not start document preview."
 msgstr "Kann Druckvorschau nicht starten."
 
-#: ../src/generic/printps.cpp:178 ../src/msw/printwin.cpp:210
-#: ../src/gtk/print.cpp:1132
+#: ../src/generic/printps.cpp:159 ../src/msw/printwin.cpp:184
+#: ../src/gtk/print.cpp:1129
 msgid "Could not start printing."
 msgstr "Kann Ausdruck nicht beginnen."
 
-#: ../src/common/wincmn.cpp:2125
+#: ../src/common/wincmn.cpp:2126
 msgid "Could not transfer data to window"
 msgstr "Kann Daten nicht ins Fenster übertragen"
 
-#: ../src/msw/imaglist.cpp:187 ../src/msw/imaglist.cpp:224
-#: ../src/msw/imaglist.cpp:249 ../src/msw/dragimag.cpp:185
-#: ../src/msw/dragimag.cpp:220
+#: ../src/msw/imaglist.cpp:223 ../src/msw/imaglist.cpp:245
+#: ../src/msw/imaglist.cpp:270 ../src/msw/dragimag.cpp:182
+#: ../src/msw/dragimag.cpp:217
 msgid "Couldn't add an image to the image list."
 msgstr "Kann Bild nicht zur Liste hinzufügen."
 
-#: ../src/osx/glcanvas_osx.cpp:414 ../src/unix/glx11.cpp:558
-#: ../src/msw/glcanvas.cpp:616
+#: ../src/osx/glcanvas_osx.cpp:411 ../src/msw/glcanvas.cpp:631
+#: ../src/unix/glegl.cpp:315 ../src/unix/glx11.cpp:559
 msgid "Couldn't create OpenGL context"
 msgstr "Kann keinen OpenGL Inhalt erzeugen"
 
-#: ../src/msw/timer.cpp:134
+#: ../src/msw/timer.cpp:131
 msgid "Couldn't create a timer"
 msgstr "Kann keinen Timer erzeugen"
 
-#: ../src/osx/carbon/overlay.cpp:122
-msgid "Couldn't create the overlay window"
-msgstr "Konnte das überlagerte Fenster nicht erzeugen"
-
-#: ../src/common/translation.cpp:2024
+#: ../src/common/translation.cpp:2074
 msgid "Couldn't enumerate translations"
 msgstr "Konnte Übersetzungen nicht aufzählen"
 
-#: ../src/common/dynlib.cpp:120
+#: ../src/common/dynlib.cpp:110
 #, c-format
 msgid "Couldn't find symbol '%s' in a dynamic library"
 msgstr "Kann Symbol „%s“ in der dynamischen Bibliothek nicht finden"
 
-#: ../src/msw/thread.cpp:915
+#: ../src/msw/thread.cpp:921
 msgid "Couldn't get the current thread pointer"
 msgstr "Kann den aktuellen Threadzeiger nicht bekommen"
 
-#: ../src/osx/carbon/overlay.cpp:129
-msgid "Couldn't init the context on the overlay window"
-msgstr "Konnte den Kontext auf dem überlagerten Fenster nicht initialisieren"
-
-#: ../src/common/imaggif.cpp:244
+#: ../src/common/imaggif.cpp:241
 msgid "Couldn't initialize GIF hash table."
 msgstr "GIF Hash-Tabelle konnte nicht initialisiert werden."
 
-#: ../src/common/imagpng.cpp:409
+#: ../src/common/imagpng.cpp:437
 msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
 msgstr ""
 "Konnte PNG-Bild nicht laden - Datei ist beschädigt oder der Speicher reicht "
 "nicht aus."
 
-#: ../src/unix/sound.cpp:470
+#: ../src/unix/sound.cpp:459
 #, c-format
 msgid "Couldn't load sound data from '%s'."
 msgstr "Klangdaten konnten nicht von „%s“ geladen werden."
 
-#: ../src/msw/dirdlg.cpp:435
+#: ../src/msw/dirdlg.cpp:287
 msgid "Couldn't obtain folder name"
 msgstr "Verzeichnisname konnte nicht ermittelt werden"
 
-#: ../src/unix/sound_sdl.cpp:229
+#: ../src/unix/sound_sdl.cpp:226
 #, c-format
 msgid "Couldn't open audio: %s"
 msgstr "Fehler beim Öffnen der Audiodatei: %s"
 
-#: ../src/msw/ole/dataobj.cpp:377
+#: ../src/msw/ole/dataobj.cpp:385
 #, c-format
 msgid "Couldn't register clipboard format '%s'."
 msgstr "Konnte Zwischenablage-Format „%s“ nicht registrieren."
 
-#: ../src/msw/listctrl.cpp:869
+#: ../src/msw/listctrl.cpp:933
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "Kann keine Informationen über das Listenelement %d bekommen."
 
-#: ../src/common/imagpng.cpp:498 ../src/common/imagpng.cpp:509
-#: ../src/common/imagpng.cpp:519
+#: ../src/common/imagpng.cpp:511 ../src/common/imagpng.cpp:522
+#: ../src/common/imagpng.cpp:532
 msgid "Couldn't save PNG image."
 msgstr "Konnte PNG-Bild nicht speichern."
 
-#: ../src/msw/thread.cpp:684
+#: ../src/msw/thread.cpp:676
 msgid "Couldn't terminate thread"
 msgstr "Kann Thread nicht beenden"
 
-#: ../src/common/xtistrm.cpp:166
+#: ../src/common/xtistrm.cpp:163
 #, c-format
 msgid "Create Parameter %s not found in declared RTTI Parameters"
 msgstr ""
 "Erzeugungsparameter %s nicht in den deklarierten RTTI-Parametern gefunden"
 
-#: ../src/generic/dirdlgg.cpp:288
+#: ../src/generic/dirdlgg.cpp:285
 msgid "Create directory"
 msgstr "Verzeichnis anlegen"
 
-#: ../src/generic/filedlgg.cpp:212 ../src/generic/dirdlgg.cpp:111
+#: ../src/generic/filedlgg.cpp:209 ../src/generic/dirdlgg.cpp:108
 msgid "Create new directory"
 msgstr "Neues Verzeichnis anlegen"
 
-#: ../src/xrc/xmlres.cpp:2460
+#: ../src/common/stockitem.cpp:264
+#, fuzzy
+msgid "Create new document"
+msgstr "Neues Verzeichnis anlegen"
+
+#: ../src/xrc/xmlres.cpp:2515
 #, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Erstellung von %s „%s“ fehlgeschlagen."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1758
+#: ../src/propgrid/advprops.cpp:1659
 msgid "Cross"
 msgstr "Kreuz"
 
-#: ../src/common/accelcmn.cpp:333
+#: ../src/common/accelcmn.cpp:347
 msgid "Ctrl+"
 msgstr "Strg+"
 
-#: ../src/richtext/richtextctrl.cpp:332 ../src/osx/textctrl_osx.cpp:576
-#: ../src/common/stockitem.cpp:151 ../src/msw/textctrl.cpp:2507
+#: ../src/osx/textctrl_osx.cpp:594 ../src/common/stockitem.cpp:148
+#: ../src/msw/textctrl.cpp:2772 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "&Ausschneiden"
 
-#: ../src/generic/filectrlg.cpp:940
+#: ../src/generic/filectrlg.cpp:936
 msgid "Current directory:"
 msgstr "Aktuelles Verzeichnis:"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:896 ../src/propgrid/advprops.cpp:1574
-#: ../src/propgrid/advprops.cpp:1612
+#: ../src/propgrid/advprops.cpp:797 ../src/propgrid/advprops.cpp:1475
+#: ../src/propgrid/advprops.cpp:1518
 msgid "Custom"
 msgstr "Benutzerdefiniert"
 
-#: ../src/gtk/print.cpp:217
+#: ../src/gtk/print.cpp:211
 msgid "Custom size"
 msgstr "Angepasste Größe"
 
-#: ../src/common/headerctrlcmn.cpp:60
+#: ../src/common/headerctrlcmn.cpp:58
 msgid "Customize Columns"
 msgstr "Spalten anpassen"
 
-#: ../src/common/stockitem.cpp:151 ../src/stc/stc_i18n.cpp:17
+#: ../src/common/stockitem.cpp:148 ../src/stc/stc_i18n.cpp:17
 msgid "Cut"
 msgstr "Ausschneiden"
 
-#: ../src/common/stockitem.cpp:259
+#: ../src/common/stockitem.cpp:256
 msgid "Cut selection"
 msgstr "Auswahl ausschneiden"
 
-#: ../src/common/fmapbase.cpp:152
+#: ../src/common/fmapbase.cpp:149
 msgid "Cyrillic (ISO-8859-5)"
 msgstr "Kyrillisch (ISO-8859-5)"
 
-#: ../src/common/paper.cpp:99
+#: ../src/common/paper.cpp:96
 msgid "D sheet, 22 x 34 in"
 msgstr "D Blatt, 22 × 34 Zoll"
 
-#: ../src/msw/dde.cpp:703
+#: ../src/msw/dde.cpp:698
 msgid "DDE poke request failed"
 msgstr "DDE „poke“ Anfrage fehlgeschlagen"
 
-#: ../src/common/imagbmp.cpp:1169
+#: ../src/common/imagbmp.cpp:1181
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr "DIB-Header: Kodierung entspricht nicht der Bittiefe."
 
@@ -2608,7 +2616,7 @@ msgstr "DIB-Header: Unbekannte Bittiefe."
 msgid "DIB Header: Unknown encoding in file."
 msgstr "DIB-Header: Unbekannte Kodierung."
 
-#: ../src/common/paper.cpp:121
+#: ../src/common/paper.cpp:118
 msgid "DL Envelope, 110 x 220 mm"
 msgstr "DL Umschlag, 110 × 220 mm"
 
@@ -2616,53 +2624,53 @@ msgstr "DL Umschlag, 110 × 220 mm"
 msgid "Dashed"
 msgstr "Gestrichelt"
 
-#: ../src/generic/dbgrptg.cpp:300
+#: ../src/generic/dbgrptg.cpp:301
 #, c-format
 msgid "Debug report \"%s\""
 msgstr "Fehlerbericht „%s“"
 
-#: ../src/common/debugrpt.cpp:210
+#: ../src/common/debugrpt.cpp:211
 msgid "Debug report couldn't be created."
 msgstr "Fehlerbericht konnte nicht erstellt werden."
 
-#: ../src/common/debugrpt.cpp:553
+#: ../src/common/debugrpt.cpp:554
 msgid "Debug report generation has failed."
 msgstr "Das Erstellen des Fehlerberichts ist fehlgeschlagen."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:84
+#: ../src/common/accelcmn.cpp:81
 msgid "Decimal"
 msgstr "Dezimaltrennzeichen"
 
-#: ../src/generic/fontdlgg.cpp:323
+#: ../src/generic/fontdlgg.cpp:319
 msgid "Decorative"
 msgstr "Dekorativ"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1752
+#: ../src/propgrid/advprops.cpp:1653
 msgid "Default"
 msgstr "Standard"
 
-#: ../src/common/fmapbase.cpp:796
+#: ../src/common/fmapbase.cpp:792
 msgid "Default encoding"
 msgstr "Standardkodierung"
 
-#: ../src/dfb/fontmgr.cpp:180
+#: ../src/dfb/fontmgr.cpp:177
 msgid "Default font"
 msgstr "Standardschriftart"
 
-#: ../src/generic/prntdlgg.cpp:510
+#: ../src/generic/prntdlgg.cpp:503
 msgid "Default printer"
 msgstr "Standarddrucker"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:51
+#: ../src/common/accelcmn.cpp:48
 msgid "Del"
 msgstr "Entf"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextbuffer.cpp:8221 ../src/common/stockitem.cpp:152
-#: ../src/common/accelcmn.cpp:50 ../src/stc/stc_i18n.cpp:20
+#: ../src/common/stockitem.cpp:149 ../src/common/accelcmn.cpp:47
+#: ../src/richtext/richtextbuffer.cpp:8217 ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Löschen"
 
@@ -2670,68 +2678,68 @@ msgstr "Löschen"
 msgid "Delete A&ll"
 msgstr "A&lles löschen"
 
-#: ../src/richtext/richtextbuffer.cpp:11341
+#: ../src/richtext/richtextbuffer.cpp:11340
 msgid "Delete Column"
 msgstr "Spalte löschen"
 
-#: ../src/richtext/richtextbuffer.cpp:11291
+#: ../src/richtext/richtextbuffer.cpp:11290
 msgid "Delete Row"
 msgstr "Zeile löschen"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 msgid "Delete Style"
 msgstr "Stil löschen"
 
-#: ../src/richtext/richtextctrl.cpp:1345 ../src/richtext/richtextctrl.cpp:1584
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
 msgid "Delete Text"
 msgstr "Text löschen"
 
-#: ../src/generic/editlbox.cpp:170
+#: ../src/generic/editlbox.cpp:147
 msgid "Delete item"
 msgstr "Element löschen"
 
-#: ../src/common/stockitem.cpp:260
+#: ../src/common/stockitem.cpp:257
 msgid "Delete selection"
 msgstr "Auswahl löschen"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 #, c-format
 msgid "Delete style %s?"
 msgstr "Stil %s löschen?"
 
-#: ../src/unix/snglinst.cpp:301
+#: ../src/unix/snglinst.cpp:298
 #, c-format
 msgid "Deleted stale lock file '%s'."
 msgstr "Ungenutzte Sperr-Datei „%s“ wurde gelöscht."
 
-#: ../src/common/secretstore.cpp:220
-#, c-format
-msgid "Deleting password for \"%s/%s\" failed: %s."
+#: ../src/common/secretstore.cpp:234
+#, fuzzy, c-format
+msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Löschen des Passwortes für „%s/%s“ fehlgeschlagen: %s."
 
-#: ../src/common/module.cpp:124
+#: ../src/common/module.cpp:121
 #, c-format
 msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
 msgstr "Abhängigkeit „%s“ des Moduls „%s“ existiert nicht."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "Descending"
 msgstr "Absteigend"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:526 ../src/propgrid/advprops.cpp:882
+#: ../src/generic/dirctrlg.cpp:492 ../src/propgrid/advprops.cpp:783
 msgid "Desktop"
 msgstr "Arbeitsoberfläche"
 
-#: ../src/generic/aboutdlgg.cpp:70
+#: ../src/generic/aboutdlgg.cpp:67
 msgid "Developed by "
 msgstr "Entwickelt von "
 
-#: ../src/generic/aboutdlgg.cpp:176
+#: ../src/generic/aboutdlgg.cpp:173
 msgid "Developers"
 msgstr "Entwickler"
 
-#: ../src/msw/dialup.cpp:374
+#: ../src/msw/dialup.cpp:368
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -2740,11 +2748,11 @@ msgstr ""
 "(Remote Access Service) auf dieser Maschine nicht installiert ist. Bitte "
 "installieren."
 
-#: ../src/generic/tipdlg.cpp:211
+#: ../src/generic/tipdlg.cpp:208
 msgid "Did you know..."
 msgstr "Wussten Sie schon …"
 
-#: ../src/dfb/wrapdfb.cpp:63
+#: ../src/dfb/wrapdfb.cpp:60
 #, c-format
 msgid "DirectFB error %d occurred."
 msgstr "DirectFB-Fehler %d aufgetreten."
@@ -2753,29 +2761,29 @@ msgstr "DirectFB-Fehler %d aufgetreten."
 msgid "Directories"
 msgstr "Verzeichnisse"
 
-#: ../src/common/filefn.cpp:1183
+#: ../src/common/filefn.cpp:1071
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Verzeichnis „%s“ konnte nicht angelegt werden"
 
-#: ../src/common/filefn.cpp:1197
+#: ../src/common/filefn.cpp:1085
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "Verzeichnis „%s“ konnte nicht gelöscht werden"
 
-#: ../src/generic/dirdlgg.cpp:204
+#: ../src/generic/dirdlgg.cpp:201
 msgid "Directory does not exist"
 msgstr "Verzeichnis existiert nicht"
 
-#: ../src/generic/filectrlg.cpp:1399
+#: ../src/generic/filectrlg.cpp:1388
 msgid "Directory doesn't exist."
 msgstr "Verzeichnis existiert nicht."
 
-#: ../src/common/docview.cpp:457
+#: ../src/common/docview.cpp:450
 msgid "Discard changes and reload the last saved version?"
 msgstr "Änderungen verwerfen und letzte gesicherte Version laden?"
 
-#: ../src/html/helpwnd.cpp:502
+#: ../src/html/helpwnd.cpp:500
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -2783,47 +2791,47 @@ msgstr ""
 "Alle Indexelemente anzeigen, die den gegebenen Suchbegriff enthalten. Groß-/"
 "Kleinschreibung wird nicht beachtet."
 
-#: ../src/html/helpwnd.cpp:679
+#: ../src/html/helpwnd.cpp:677
 msgid "Display options dialog"
 msgstr "Einstellungen-Dialog anzeigen"
 
-#: ../src/html/helpwnd.cpp:322
+#: ../src/html/helpwnd.cpp:320
 msgid "Displays help as you browse the books on the left."
 msgstr ""
 "Anzeigen bieten Unterstützung beim Navigieren der Bücher auf der linken "
 "Seite."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:85
+#: ../src/common/accelcmn.cpp:83
 msgid "Divide"
 msgstr "Division"
 
-#: ../src/common/docview.cpp:533
+#: ../src/common/docview.cpp:526
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Möchten Sie die Änderungen nach %s speichern?"
 
-#: ../src/common/prntbase.cpp:542
+#: ../src/common/prntbase.cpp:537
 msgid "Document:"
 msgstr "Dokument:"
 
-#: ../src/generic/aboutdlgg.cpp:73
+#: ../src/generic/aboutdlgg.cpp:70
 msgid "Documentation by "
 msgstr "Dokumentation von "
 
-#: ../src/generic/aboutdlgg.cpp:180
+#: ../src/generic/aboutdlgg.cpp:177
 msgid "Documentation writers"
 msgstr "Autoren der Dokumentation"
 
-#: ../src/common/sizer.cpp:2799
+#: ../src/common/sizer.cpp:2916
 msgid "Don't Save"
 msgstr "Nicht speichern"
 
-#: ../src/html/htmlwin.cpp:633
+#: ../src/html/htmlwin.cpp:643
 msgid "Done"
 msgstr "Fertig"
 
-#: ../src/generic/progdlgg.cpp:448 ../src/msw/progdlg.cpp:407
+#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
 msgid "Done."
 msgstr "Fertig."
 
@@ -2835,42 +2843,42 @@ msgstr "Gepunktet"
 msgid "Double"
 msgstr "Verdoppeln"
 
-#: ../src/common/paper.cpp:176
+#: ../src/common/paper.cpp:173
 msgid "Double Japanese Postcard Rotated 148 x 200 mm"
 msgstr "Doppelte Japanische Postkarte Rotiert 148 × 200 mm"
 
-#: ../src/common/xtixml.cpp:273
+#: ../src/common/xtixml.cpp:269
 #, c-format
 msgid "Doubly used id : %d"
 msgstr "ID doppelt verwendet: %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:153
-#: ../src/common/accelcmn.cpp:64
+#: ../src/common/stockitem.cpp:150 ../src/common/accelcmn.cpp:61
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Down"
 msgstr "Herunter"
 
-#: ../src/richtext/richtextctrl.cpp:865
+#: ../src/richtext/richtextctrl.cpp:864
 msgid "Drag"
 msgstr "Freigeben"
 
-#: ../src/common/paper.cpp:100
+#: ../src/common/paper.cpp:97
 msgid "E sheet, 34 x 44 in"
 msgstr "E Blatt, 34 × 44 Zoll"
 
-#: ../src/unix/fswatcher_inotify.cpp:561
+#: ../src/unix/fswatcher_inotify.cpp:558
 msgid "EOF while reading from inotify descriptor"
 msgstr "EOF beim Lesen vom inotify Bezeichner"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "Edit"
 msgstr "Bearbeiten"
 
-#: ../src/generic/editlbox.cpp:168
+#: ../src/generic/editlbox.cpp:131
 msgid "Edit item"
 msgstr "Element bearbeiten"
 
-#: ../include/wx/generic/progdlgg.h:84
+#: ../include/wx/generic/progdlgg.h:85
 msgid "Elapsed time:"
 msgstr "Benötigte Zeit:"
 
@@ -2937,49 +2945,49 @@ msgid "Enables the shadow spread."
 msgstr "Aktiviert die Ausbreitung des Schattens."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:66
+#: ../src/common/accelcmn.cpp:63
 msgid "End"
 msgstr "Ende"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:55
+#: ../src/common/accelcmn.cpp:52
 msgid "Enter"
 msgstr "Eingabe"
 
-#: ../src/richtext/richtextstyledlg.cpp:934
+#: ../src/richtext/richtextstyledlg.cpp:930
 msgid "Enter a box style name"
 msgstr "Namen für den Rahmen-Stil eintragen"
 
-#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:602
 msgid "Enter a character style name"
 msgstr "Name des Zeichenstils eintragen"
 
-#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:816
 msgid "Enter a list style name"
 msgstr "Name des Listenstils eintragen"
 
-#: ../src/richtext/richtextstyledlg.cpp:893
+#: ../src/richtext/richtextstyledlg.cpp:889
 msgid "Enter a new style name"
 msgstr "Neuen Stilnamen eintragen"
 
-#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:650
 msgid "Enter a paragraph style name"
 msgstr "Name des Absatzstils eintragen"
 
-#: ../src/generic/dbgrptg.cpp:174
+#: ../src/generic/dbgrptg.cpp:171
 #, c-format
 msgid "Enter command to open file \"%s\":"
 msgstr "Befehl zum Öffnen von Datei „%s“ eingeben:"
 
-#: ../src/generic/helpext.cpp:459
+#: ../src/generic/helpext.cpp:457
 msgid "Entries found"
 msgstr "Einträge gefunden"
 
-#: ../src/common/paper.cpp:142
+#: ../src/common/paper.cpp:139
 msgid "Envelope Invite 220 x 220 mm"
 msgstr "Umschlag Einladung 220 × 220 mm"
 
-#: ../src/common/config.cpp:469
+#: ../src/common/config.cpp:465
 #, c-format
 msgid ""
 "Environment variables expansion failed: missing '%c' at position %u in '%s'."
@@ -2987,13 +2995,13 @@ msgstr ""
 "Auswerten der Umgebungsvariablen schlug fehl. Es fehlt „%c“ an Position %u "
 "in „%s“."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/generic/dirctrlg.cpp:570
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/dirctrlg.cpp:599
-#: ../src/generic/dirdlgg.cpp:323 ../src/generic/filectrlg.cpp:642
-#: ../src/generic/filectrlg.cpp:756 ../src/generic/filectrlg.cpp:770
-#: ../src/generic/filectrlg.cpp:786 ../src/generic/filectrlg.cpp:1368
-#: ../src/generic/filectrlg.cpp:1399 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/gtk1/fontdlg.cpp:74 ../src/generic/dirctrlg.cpp:536
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/dirctrlg.cpp:565
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1357 ../src/generic/filectrlg.cpp:1388
+#: ../src/generic/filedlgg.cpp:354 ../src/generic/dirdlgg.cpp:320
+#: ../src/gtk/filedlg.cpp:74
 msgid "Error"
 msgstr "Fehler"
 
@@ -3001,86 +3009,97 @@ msgstr "Fehler"
 msgid "Error closing epoll descriptor"
 msgstr "Fehler beim Schließen des epol Bezeichners"
 
-#: ../src/unix/fswatcher_kqueue.cpp:114
+#: ../src/unix/fswatcher_kqueue.cpp:131
 msgid "Error closing kqueue instance"
 msgstr "Fehler schließt kqueue Vorgang"
 
-#: ../src/common/filefn.cpp:1049
+#: ../src/common/filefn.cpp:938
 #, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Fehler beim Speichern der Datei „%s“ nach „%s“."
 
-#: ../src/generic/dirdlgg.cpp:222
+#: ../src/generic/dirdlgg.cpp:219
 msgid "Error creating directory"
 msgstr "Fehler beim Anlegen des Verzeichnisses"
 
-#: ../src/common/imagbmp.cpp:1181
+#: ../src/common/imagbmp.cpp:1193
 msgid "Error in reading image DIB."
 msgstr "Fehler beim Lesen des DIB-Bildes."
 
-#: ../src/propgrid/propgrid.cpp:6696
+#: ../src/propgrid/propgrid.cpp:6665
 #, c-format
 msgid "Error in resource: %s"
 msgstr "Fehler in der Ressource: %s"
 
-#: ../src/common/fileconf.cpp:422
+#: ../src/common/fileconf.cpp:421
 msgid "Error reading config options."
 msgstr "Fehler beim Parsen der Optionen."
+
+#: ../src/msw/webview_ie.cpp:1057 ../src/msw/webview_edge.cpp:850
+#: ../src/gtk/webview_webkit2.cpp:1262 ../src/osx/webview_webkit.mm:383
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
 
 #: ../src/common/fileconf.cpp:1029
 msgid "Error saving user configuration data."
 msgstr "Fehler beim Speichern der Benutzer-Optionen."
 
-#: ../src/gtk/print.cpp:722
+#: ../src/gtk/print.cpp:720
 msgid "Error while printing: "
 msgstr "Fehler während des Druckens: "
 
-#: ../src/common/log.cpp:219
+#: ../src/common/log.cpp:237
 msgid "Error: "
 msgstr "Fehler: "
 
+#: ../src/common/webrequest.cpp:98
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Fehler: "
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:69
+#: ../src/common/accelcmn.cpp:66
 msgid "Esc"
 msgstr "Esc"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:70
+#: ../src/common/accelcmn.cpp:67
 msgid "Escape"
 msgstr "Esc"
 
-#: ../src/common/fmapbase.cpp:150
+#: ../src/common/fmapbase.cpp:147
 msgid "Esperanto (ISO-8859-3)"
 msgstr "Esperanto (ISO-8859-3)"
 
-#: ../include/wx/generic/progdlgg.h:85
+#: ../include/wx/generic/progdlgg.h:86
 msgid "Estimated time:"
 msgstr "Geschätzte Zeit:"
 
-#: ../src/generic/dbgrptg.cpp:234
+#: ../src/generic/dbgrptg.cpp:231
 msgid "Executable files (*.exe)|*.exe|"
 msgstr "Ausführbare Dateien (*.exe)|*.exe|"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:155 ../src/common/accelcmn.cpp:78
+#: ../src/common/stockitem.cpp:152 ../src/common/accelcmn.cpp:75
 msgid "Execute"
 msgstr "Ausführen"
 
-#: ../src/msw/utilsexc.cpp:876
+#: ../src/msw/utilsexc.cpp:873
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Befehlsausführung „%s“ schlug fehl"
 
-#: ../src/common/paper.cpp:105
+#: ../src/common/paper.cpp:102
 msgid "Executive, 7 1/4 x 10 1/2 in"
 msgstr "Executive, 7 1/4 × 10 1/2 Zoll"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6009
+#: ../src/generic/datavgen.cpp:6814
 msgid "Expand"
 msgstr "Aufklappen"
 
-#: ../src/msw/registry.cpp:1240
+#: ../src/msw/registry.cpp:1228
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
@@ -3088,150 +3107,160 @@ msgstr ""
 "Exportiere Registrierungsschlüssel: Datei „%s“ besteht bereits und wird "
 "nicht überschrieben."
 
-#: ../src/common/fmapbase.cpp:195
+#: ../src/common/fmapbase.cpp:192
 msgid "Extended Unix Codepage for Japanese (EUC-JP)"
 msgstr "Erweiterter Unix-Zeichensatz für Japanisch (EUC-JP)"
 
-#: ../src/html/chm.cpp:725
+#: ../src/html/chm.cpp:718
 #, c-format
 msgid "Extraction of '%s' into '%s' failed."
 msgstr "Extrahieren von „%s“ in „%s“ schlug fehl."
 
-#: ../src/common/accelcmn.cpp:249 ../src/common/accelcmn.cpp:344
+#: ../src/common/accelcmn.cpp:259 ../src/common/accelcmn.cpp:358
 msgid "F"
 msgstr "F"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:672
+#: ../src/propgrid/advprops.cpp:582
 msgid "Face Name"
 msgstr "Schriftname"
 
-#: ../src/unix/snglinst.cpp:269
+#: ../src/unix/snglinst.cpp:266
 msgid "Failed to access lock file."
 msgstr "Fehler beim Zugriff auf Sperr-Datei."
+
+#: ../src/gtk/font.cpp:572
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Konnte Dokument aus der Datei „%s“ nicht lesen."
 
 #: ../src/unix/epolldispatcher.cpp:116
 #, c-format
 msgid "Failed to add descriptor %d to epoll descriptor %d"
 msgstr "Das Hinzufügen des Bezeichners %d zum epoll Bezeichner %d schlug fehl"
 
-#: ../src/msw/dib.cpp:489
+#: ../src/msw/dib.cpp:535
 #, c-format
 msgid "Failed to allocate %luKb of memory for bitmap data."
 msgstr "Anforderung von %lu Kb Speicher für Bitmap fehlgeschlagen."
 
-#: ../src/common/glcmn.cpp:115
+#: ../src/common/glcmn.cpp:112
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Anforderung von Farbe für OpenGL fehlgeschlagen"
 
-#: ../src/unix/displayx11.cpp:236
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Anforderung von Farbe für OpenGL fehlgeschlagen"
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Anforderung von Farbe für OpenGL fehlgeschlagen"
+
+#: ../include/wx/unix/private/displayx11.h:89
 msgid "Failed to change video mode"
 msgstr "Änderung des Video-Modus fehlgeschlagen"
 
-#: ../src/common/image.cpp:3277
+#: ../src/common/image.cpp:3396
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Überprüfung des Formats der Bilddatei „%s“ fehlgeschlagen."
 
-#: ../src/common/debugrpt.cpp:239
+#: ../src/common/debugrpt.cpp:240
 #, c-format
 msgid "Failed to clean up debug report directory \"%s\""
 msgstr "Konnte Fehlerberichtsverzeichnis „%s“ nicht aufräumen."
 
-#: ../src/common/filename.cpp:192
+#: ../src/common/filename.cpp:189
 msgid "Failed to close file handle"
 msgstr "Konnte Datei-Handle nicht schließen"
 
-#: ../src/unix/snglinst.cpp:340
+#: ../src/unix/snglinst.cpp:337
 #, c-format
 msgid "Failed to close lock file '%s'"
 msgstr "Konnte Sperr-Datei „%s“ nicht schließen"
 
-#: ../src/msw/clipbrd.cpp:112
+#: ../src/msw/clipbrd.cpp:110
 msgid "Failed to close the clipboard."
 msgstr "Konnte Zwischenablage nicht schließen."
 
-#: ../src/x11/utils.cpp:208
+#: ../src/x11/utils.cpp:170
 #, c-format
 msgid "Failed to close the display \"%s\""
 msgstr "Konnte das Display „%s“ nicht schließen"
 
-#: ../src/msw/dialup.cpp:797
+#: ../src/msw/dialup.cpp:791
 msgid "Failed to connect: missing username/password."
 msgstr ""
 "Verbindung fehlgeschlagen: Es fehlt der Benutzername bzw. das Passwort."
 
-#: ../src/msw/dialup.cpp:743
+#: ../src/msw/dialup.cpp:737
 msgid "Failed to connect: no ISP to dial."
 msgstr "Verbindungsversuch fehlgeschlagen: kein anwählbares ISP."
 
-#: ../src/common/textfile.cpp:203
-#, c-format
-msgid "Failed to convert file \"%s\" to Unicode."
-msgstr "Konnte die Datei „%s“ nicht nach Unicode konvertieren."
-
-#: ../src/generic/logg.cpp:956
+#: ../src/generic/logg.cpp:953
 msgid "Failed to copy dialog contents to the clipboard."
 msgstr "Kopieren des Dialoginhalts in die Zwischenablage fehlgeschlagen."
 
-#: ../src/msw/registry.cpp:692
+#: ../src/msw/registry.cpp:681
 #, c-format
 msgid "Failed to copy registry value '%s'"
 msgstr "Kopieren des Registry-Werts „%s“ fehlgeschlagen"
 
-#: ../src/msw/registry.cpp:701
+#: ../src/msw/registry.cpp:690
 #, c-format
 msgid "Failed to copy the contents of registry key '%s' to '%s'."
 msgstr ""
 "Kopieren des Inhalts des Registrierungsschlüssels „%s“ nach „%s“ "
 "fehlgeschlagen."
 
-#: ../src/common/filefn.cpp:1015
+#: ../src/common/filefn.cpp:904
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Konnte die Datei „%s“ nicht nach „%s“ kopieren"
 
-#: ../src/msw/registry.cpp:679
+#: ../src/msw/registry.cpp:668
 #, c-format
 msgid "Failed to copy the registry subkey '%s' to '%s'."
 msgstr "Kopieren des Registrierungsschlüssels von „%s“ in „%s“ fehlgeschlagen."
 
-#: ../src/msw/dde.cpp:1070
+#: ../src/msw/dde.cpp:1134
 msgid "Failed to create DDE string"
 msgstr "Erstellung der DDE-Zeichenkette fehlgeschlagen"
 
-#: ../src/msw/mdi.cpp:616
+#: ../src/msw/mdi.cpp:621
 msgid "Failed to create MDI parent frame."
 msgstr "Erstellung des MDI-Hauptrahmens fehlgeschlagen."
 
-#: ../src/common/filename.cpp:1027
+#: ../src/common/filename.cpp:1024
 msgid "Failed to create a temporary file name"
 msgstr "Konnte keinen temporären Dateinamen erstellen"
 
-#: ../src/msw/utilsexc.cpp:228
+#: ../src/msw/utilsexc.cpp:225
 msgid "Failed to create an anonymous pipe"
 msgstr "Konnte keine anonyme Unix-Pipe erstellen"
 
-#: ../src/msw/ole/automtn.cpp:522
+#: ../src/msw/ole/automtn.cpp:513
 #, c-format
 msgid "Failed to create an instance of \"%s\""
 msgstr "Erzeugen eines Exemplars von „%s“ fehlgeschlagen."
 
-#: ../src/msw/dde.cpp:437
+#: ../src/msw/dde.cpp:432
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "Aufbau der Verbindung zum Server „%s“ „on topic“ „%s“ fehlgeschlagen"
 
-#: ../src/msw/cursor.cpp:204
+#: ../src/msw/cursor.cpp:195
 msgid "Failed to create cursor."
 msgstr "Cursor konnte nicht erzeugt werden."
 
-#: ../src/common/debugrpt.cpp:209
+#: ../src/common/debugrpt.cpp:210
 #, c-format
 msgid "Failed to create directory \"%s\""
 msgstr "Konnte das Verzeichnis „%s“ nicht erstellen."
 
-#: ../src/generic/dirdlgg.cpp:220
+#: ../src/generic/dirdlgg.cpp:217
 #, c-format
 msgid ""
 "Failed to create directory '%s'\n"
@@ -3244,114 +3273,133 @@ msgstr ""
 msgid "Failed to create epoll descriptor"
 msgstr "Epoll Beschreibungselement konnte nicht erstellt werden"
 
-#: ../src/msw/mimetype.cpp:238
+#: ../src/gtk/font.cpp:562
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "Kann Benutzer-Konfigurationsdatei nicht aktualisieren."
+
+#: ../src/msw/mimetype.cpp:235
 #, c-format
 msgid "Failed to create registry entry for '%s' files."
 msgstr "Konnte keinen Registrierungseintrag für „%s“-Dateien erstellen."
 
-#: ../src/msw/fdrepdlg.cpp:409
+#: ../src/msw/fdrepdlg.cpp:408
 #, c-format
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr "Konnte keinen Standard-Finden/Ersetzen-Dialog erstellen (Fehler %d)"
 
-#: ../src/unix/wakeuppipe.cpp:52
+#: ../src/unix/wakeuppipe.cpp:49
 msgid "Failed to create wake up pipe used by event loop."
 msgstr "Erzeugung der Weckleitung für die Ereignisschleife fehlgeschlagen."
 
-#: ../src/html/winpars.cpp:730
+#: ../src/html/winpars.cpp:727
 #, c-format
 msgid "Failed to display HTML document in %s encoding"
 msgstr "Konnte HTML-Dokument nicht in der Kodierung %s anzeigen"
 
-#: ../src/msw/clipbrd.cpp:124
+#: ../src/msw/clipbrd.cpp:122
 msgid "Failed to empty the clipboard."
 msgstr "Konnte Zwischenablage nicht leeren."
 
-#: ../src/unix/displayx11.cpp:212
+#: ../include/wx/unix/private/displayx11.h:65
 msgid "Failed to enumerate video modes"
 msgstr "Auflisten der Video-Modi fehlgeschlagen"
 
-#: ../src/msw/dde.cpp:722
+#: ../src/msw/dde.cpp:717
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "Aufbau einer „advise Schleife“ mit dem DDE-Server fehlgeschlagen"
 
-#: ../src/msw/dialup.cpp:629 ../src/msw/dialup.cpp:863
+#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Aufbau der DFÜ-Verbindung fehlgeschlagen: %s"
 
-#: ../src/unix/utilsunx.cpp:611
+#: ../src/unix/utilsunx.cpp:613
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Kann „%s“ nicht ausführen\n"
 
-#: ../src/common/debugrpt.cpp:720
+#: ../src/common/debugrpt.cpp:730
 msgid "Failed to execute curl, please install it in PATH."
 msgstr "Konnte curl nicht starten, bitte im PATH installieren."
 
-#: ../src/msw/ole/automtn.cpp:505
+#: ../src/msw/ole/automtn.cpp:496
 #, c-format
 msgid "Failed to find CLSID of \"%s\""
 msgstr "Konnte CLSID von „%s“ nicht finden"
 
-#: ../src/common/regex.cpp:431 ../src/common/regex.cpp:479
+#: ../src/common/regex.cpp:428 ../src/common/regex.cpp:476
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "Konnte keine Übereinstimmung mit regulärem Ausdruck %s finden"
 
-#: ../src/msw/dialup.cpp:695
+#: ../src/msw/webview_ie.cpp:978
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:689
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Konnte ISP-Namen „%s“ nicht ermitteln"
 
-#: ../src/msw/ole/automtn.cpp:574
+#: ../src/msw/ole/automtn.cpp:565
 #, c-format
 msgid "Failed to get OLE automation interface for \"%s\""
 msgstr "Konnte die OLE Automatisierungsschnittstelle für „%s“ nicht bekommen"
 
-#: ../src/msw/clipbrd.cpp:711
+#: ../src/msw/clipbrd.cpp:731
 msgid "Failed to get data from the clipboard"
 msgstr "Konnte Daten nicht aus der Zwischenablage kopieren"
 
-#: ../src/common/time.cpp:223
+#: ../src/common/time.cpp:216
 msgid "Failed to get the local system time"
 msgstr "Versuch örtliche Systemzeit zu bekommen, fehlgeschlagen"
 
-#: ../src/common/filefn.cpp:1345
+#: ../src/common/filefn.cpp:1233
 msgid "Failed to get the working directory"
 msgstr "Konnte Arbeitsverzeichnis nicht ermitteln"
 
-#: ../src/univ/theme.cpp:114
+#: ../src/univ/theme.cpp:111
 msgid "Failed to initialize GUI: no built-in themes found."
 msgstr "Konnte GUI nicht initialisieren: kein Thema gefunden."
 
-#: ../src/msw/helpchm.cpp:63
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:60
 msgid "Failed to initialize MS HTML Help."
 msgstr "Konnte MS-HTML-Hilfe nicht initialisieren."
 
-#: ../src/msw/glcanvas.cpp:1381
+#: ../src/msw/glcanvas.cpp:1391
 msgid "Failed to initialize OpenGL"
 msgstr "Konnte OpenGL nicht initialisieren"
 
-#: ../src/msw/dialup.cpp:858
+#: ../src/msw/dialup.cpp:852
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Versuch fehlgeschlagen, die Einwählverbindung einzuleiten: %s"
 
-#: ../src/gtk/textctrl.cpp:1128
+#: ../src/gtk/textctrl.cpp:1209
 msgid "Failed to insert text in the control."
 msgstr "Einfügen von Text in das Steuerelement fehlgeschlagen."
 
-#: ../src/unix/snglinst.cpp:241
+#: ../src/unix/snglinst.cpp:238
 #, c-format
 msgid "Failed to inspect the lock file '%s'"
 msgstr "Konnte die Sperr-Datei „%s“ nicht lesen"
 
-#: ../src/unix/appunix.cpp:182
+#: ../src/unix/appunix.cpp:179
 msgid "Failed to install signal handler"
 msgstr "Konnte Signalbearbeitung nicht installieren"
 
-#: ../src/unix/threadpsx.cpp:1167
+#: ../src/unix/threadpsx.cpp:1216
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -3359,71 +3407,71 @@ msgstr ""
 "Thread-Verbindung fehlgeschlagen. Dies ist ein mögliches Speicherleck - "
 "Bitte Programm neu starten"
 
-#: ../src/msw/utils.cpp:629
+#: ../src/msw/utils.cpp:619
 #, c-format
 msgid "Failed to kill process %d"
 msgstr "Konnte Prozess %d nicht abbrechen"
 
-#: ../src/common/image.cpp:2500
+#: ../src/common/image.cpp:2595
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Konnte das Bitmap „%s“ aus der Ressource nicht laden."
 
-#: ../src/common/image.cpp:2509
+#: ../src/common/image.cpp:2604
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Konnte das Symbol „%s“ aus der Ressource nicht laden."
 
-#: ../src/common/iconbndl.cpp:225
+#: ../src/common/iconbndl.cpp:224
 #, c-format
 msgid "Failed to load icons from resource '%s'."
 msgstr "Konnte die Symbole aus der Ressource „%s“ nicht laden."
 
-#: ../src/common/iconbndl.cpp:200
+#: ../src/common/iconbndl.cpp:198
 #, c-format
 msgid "Failed to load image %%d from file '%s'."
 msgstr "Konnte das Bild %%d aus der Datei „%s“ nicht laden."
 
-#: ../src/common/iconbndl.cpp:208
+#: ../src/common/iconbndl.cpp:206
 #, c-format
 msgid "Failed to load image %d from stream."
 msgstr "Konnte das Bild %d aus dem Strom nicht laden."
 
-#: ../src/common/image.cpp:2587 ../src/common/image.cpp:2606
+#: ../src/common/image.cpp:2682 ../src/common/image.cpp:2701
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Konnte das Bild aus der Datei „%s“ nicht laden."
 
-#: ../src/msw/enhmeta.cpp:97
+#: ../src/msw/enhmeta.cpp:94
 #, c-format
 msgid "Failed to load metafile from file \"%s\"."
 msgstr "Konnte Metadatei aus Datei „%s“ nicht laden."
 
-#: ../src/msw/volume.cpp:327
+#: ../src/msw/volume.cpp:335
 msgid "Failed to load mpr.dll."
 msgstr "Konnte mpr.dll nicht laden."
 
-#: ../src/msw/utils.cpp:953
+#: ../src/msw/utils.cpp:943
 #, c-format
 msgid "Failed to load resource \"%s\"."
 msgstr "Konnte die Ressource „%s“ nicht laden."
 
-#: ../src/common/dynlib.cpp:92
+#: ../src/common/dynlib.cpp:86
 #, c-format
 msgid "Failed to load shared library '%s'"
 msgstr "Laden der dynamischen Bibliothek „%s“ fehlgeschlagen"
 
-#: ../src/osx/core/sound.cpp:145
+#: ../src/osx/core/sound.cpp:143
 #, c-format
 msgid "Failed to load sound from \"%s\" (error %d)."
 msgstr "Fehler beim Laden des Klangs von „%s“ (Fehler %d)."
 
-#: ../src/msw/utils.cpp:960
+#: ../src/msw/utils.cpp:950
 #, c-format
 msgid "Failed to lock resource \"%s\"."
 msgstr "Konnte die Ressource „%s“ nicht sperren."
 
-#: ../src/unix/snglinst.cpp:198
+#: ../src/unix/snglinst.cpp:195
 #, c-format
 msgid "Failed to lock the lock file '%s'"
 msgstr "Konnte die Sperr-Datei „%s“ nicht sperren"
@@ -3433,33 +3481,38 @@ msgstr "Konnte die Sperr-Datei „%s“ nicht sperren"
 msgid "Failed to modify descriptor %d in epoll descriptor %d"
 msgstr "Wechsel von Beschreibung %d in Epoll Beschreibung %d fehlgeschlagen"
 
-#: ../src/common/filename.cpp:2575
+#: ../src/common/filename.cpp:2658
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Konnte Zugriffszeit von Datei „%s“ nicht ändern"
 
-#: ../src/common/selectdispatcher.cpp:258
+#: ../src/common/selectdispatcher.cpp:255
 msgid "Failed to monitor I/O channels"
 msgstr "Die Überwachung der I/O Kanäle ist fehlgeschlagen"
 
-#: ../src/common/filename.cpp:175
+#: ../src/common/filename.cpp:172
 #, c-format
 msgid "Failed to open '%s' for reading"
 msgstr "Konnte „%s“ nicht zum Lesen öffnen"
 
-#: ../src/common/filename.cpp:180
+#: ../src/common/filename.cpp:177
 #, c-format
 msgid "Failed to open '%s' for writing"
 msgstr "Konnte „%s“ nicht zum Schreiben öffnen"
 
-#: ../src/html/chm.cpp:141
+#: ../src/html/chm.cpp:138
 #, c-format
 msgid "Failed to open CHM archive '%s'."
 msgstr "CHM-Archiv „%s“ lässt sich nicht öffnen."
 
-#: ../src/common/utilscmn.cpp:1126
+#: ../src/common/utilscmn.cpp:1140
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Konnte die URL „%s“ nicht im voreingestellten Browser öffnen."
+
+#: ../src/common/hyperlnkcmn.cpp:133
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Konnte die URL „%s“ nicht im voreingestellten Browser öffnen."
 
 #: ../include/wx/msw/private/fswatcher.h:92
@@ -3467,95 +3520,105 @@ msgstr "Konnte die URL „%s“ nicht im voreingestellten Browser öffnen."
 msgid "Failed to open directory \"%s\" for monitoring."
 msgstr "Konnte das Verzeichnis „%s“ nicht zur Überwachung öffnen."
 
-#: ../src/x11/utils.cpp:227
+#: ../src/x11/utils.cpp:189
 #, c-format
 msgid "Failed to open display \"%s\"."
 msgstr "Öffnen des Displays „%s“ fehlgeschlagen."
 
-#: ../src/common/filename.cpp:1062
+#: ../src/common/filename.cpp:1059
 msgid "Failed to open temporary file."
 msgstr "Konnte temporäre Datei nicht öffnen."
 
-#: ../src/msw/clipbrd.cpp:91
+#: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Konnte Zwischenablage nicht öffnen."
 
-#: ../src/common/translation.cpp:1184
+#: ../src/common/translation.cpp:1226
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Analyse der Pluralformen fehlgeschlagen: „%s“"
 
-#: ../src/unix/mediactrl.cpp:1214
+#: ../src/unix/mediactrl.cpp:1239
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Fehler bei der Vorbereitung zum Abspielen von „%s“."
 
-#: ../src/msw/clipbrd.cpp:600
+#: ../src/msw/clipbrd.cpp:610
 msgid "Failed to put data on the clipboard"
 msgstr "Versuch Daten in der Zwischenablage abzulegen, fehlgeschlagen"
 
-#: ../src/unix/snglinst.cpp:278
+#: ../src/unix/snglinst.cpp:275
 msgid "Failed to read PID from lock file."
 msgstr "Konnte keine PID von Sperr-Datei lesen."
 
-#: ../src/common/fileconf.cpp:433
+#: ../src/common/fileconf.cpp:432
 msgid "Failed to read config options."
 msgstr "Lesen der Konfigurationsoptionen fehlgeschlagen."
 
-#: ../src/common/docview.cpp:681
+#: ../src/common/docview.cpp:676
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Konnte Dokument aus der Datei „%s“ nicht lesen."
 
-#: ../src/dfb/evtloop.cpp:98
+#: ../src/dfb/evtloop.cpp:99
 msgid "Failed to read event from DirectFB pipe"
 msgstr "Konnte Ereignis von DirectFB Kanal nicht lesen"
 
-#: ../src/unix/wakeuppipe.cpp:120
+#: ../src/unix/wakeuppipe.cpp:117
 msgid "Failed to read from wake-up pipe"
 msgstr "Konnte nicht aus dem Weckkanal lesen"
 
-#: ../src/unix/utilsunx.cpp:679
+#: ../src/common/textfile.cpp:96
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Konnte Dokument aus der Datei „%s“ nicht lesen."
+
+#: ../src/unix/utilsunx.cpp:681
 msgid "Failed to redirect child process input/output"
 msgstr "Umleitung der Ein-/Ausgabe des Unterprozesses fehlgeschlagen"
 
-#: ../src/msw/utilsexc.cpp:701
+#: ../src/msw/utilsexc.cpp:698
 msgid "Failed to redirect the child process IO"
 msgstr "Umleitung der Ein-/Ausgabe des Unterprozesses fehlgeschlagen"
 
-#: ../src/msw/dde.cpp:288
+#: ../src/msw/dde.cpp:283
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Versuch DDE-Server „%s“ zu registrieren, fehlgeschlagen"
 
-#: ../src/common/fontmap.cpp:245
+#: ../src/gtk/font.cpp:580
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "Kann Benutzer-Konfigurationsdatei nicht aktualisieren."
+
+#: ../src/common/fontmap.cpp:242
 #, c-format
 msgid "Failed to remember the encoding for the charset '%s'."
 msgstr ""
 "Versuch fehlgeschlagen, an die Kodierung für den Zeichensatz „%s“ zu "
 "erinnern."
 
-#: ../src/common/debugrpt.cpp:227
+#: ../src/common/debugrpt.cpp:228
 #, c-format
 msgid "Failed to remove debug report file \"%s\""
 msgstr "Konnte Fehlerberichtsdatei „%s“ nicht entfernen."
 
-#: ../src/unix/snglinst.cpp:328
+#: ../src/unix/snglinst.cpp:325
 #, c-format
 msgid "Failed to remove lock file '%s'"
 msgstr "Konnte Sperr-Datei „%s“ nicht löschen."
 
-#: ../src/unix/snglinst.cpp:288
+#: ../src/unix/snglinst.cpp:285
 #, c-format
 msgid "Failed to remove stale lock file '%s'."
 msgstr "Konnte unbenutzte Sperr-Datei „%s“ nicht entfernen."
 
-#: ../src/msw/registry.cpp:529
+#: ../src/msw/registry.cpp:518
 #, c-format
 msgid "Failed to rename registry value '%s' to '%s'."
 msgstr "Umbenennen des Registrierungswertes „%s“ in „%s“ fehlgeschlagen."
 
-#: ../src/common/filefn.cpp:1122
+#: ../src/common/filefn.cpp:1011
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -3564,122 +3627,131 @@ msgstr ""
 "Umbenennen der Datei „%s“ nach „%s“ fehlgeschlagen, da die Zieldatei bereits "
 "existiert."
 
-#: ../src/msw/registry.cpp:634
+#: ../src/msw/registry.cpp:623
 #, c-format
 msgid "Failed to rename the registry key '%s' to '%s'."
 msgstr ""
 "Umbenennen des Registrierungsschlüssels von „%s“ in „%s“ fehlgeschlagen."
 
-#: ../src/common/filename.cpp:2671
+#: ../src/msw/webview_ie.cpp:995
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/common/filename.cpp:2754
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Konnte Zugriffszeit von Datei „%s“ nicht ermitteln"
 
-#: ../src/msw/dialup.cpp:468
+#: ../src/msw/dialup.cpp:462
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Versuch den Inhalt der RAS-Fehlernachricht zu holen, fehlgeschlagen"
 
-#: ../src/msw/clipbrd.cpp:748
+#: ../src/msw/clipbrd.cpp:768
 msgid "Failed to retrieve the supported clipboard formats"
 msgstr ""
 "Konnte die von der Zwischenablage unterstützten Formate nicht ermitteln"
 
-#: ../src/common/docview.cpp:652
+#: ../src/common/docview.cpp:647
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Das Dokument konnte nicht in die Datei „%s“ gesichert werden."
 
-#: ../src/msw/dib.cpp:269
+#: ../src/msw/dib.cpp:312
 #, c-format
 msgid "Failed to save the bitmap image to file \"%s\"."
 msgstr "Das Bitmap-Bild konnte nicht in der Datei „%s“ geschrieben werden."
 
-#: ../src/msw/dde.cpp:763
+#: ../src/msw/dde.cpp:811
 msgid "Failed to send DDE advise notification"
 msgstr "Versuch fehlgeschlagen, eine DDE-Benachrichtigung zu schicken"
 
-#: ../src/common/ftp.cpp:402
+#: ../src/common/ftp.cpp:399
 #, c-format
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Konnte den FTP-Transfermodus nicht auf „%s“ setzen."
 
-#: ../src/msw/clipbrd.cpp:427
+#: ../src/msw/clipbrd.cpp:443
 msgid "Failed to set clipboard data."
 msgstr "Konnte Dateien nicht in die Zwischenablage kopieren."
 
-#: ../src/unix/snglinst.cpp:181
+#: ../src/unix/snglinst.cpp:178
 #, c-format
 msgid "Failed to set permissions on lock file '%s'"
 msgstr "Konnte die Zugriffsrechte für Datei „%s“ nicht setzen"
 
-#: ../src/unix/utilsunx.cpp:668
+#: ../src/unix/utilsunx.cpp:670
 msgid "Failed to set process priority"
 msgstr "Versuch fehlgeschlagen, die Prozess-Priorität zu setzen"
 
-#: ../src/common/file.cpp:559
+#: ../src/common/ffile.cpp:355 ../src/common/file.cpp:586
 msgid "Failed to set temporary file permissions"
 msgstr "Konnte die Zugriffsrechte der temporären Datei nicht setzen"
 
-#: ../src/gtk/textctrl.cpp:1072
-msgid "Failed to set text in the text control."
-msgstr "Setzen von Text in das Text-Steuerelement fehlgeschlagen."
-
-#: ../src/unix/threadpsx.cpp:1298
+#: ../src/unix/threadpsx.cpp:1347
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr ""
 "Versuch fehlgeschlagen, die Thread-Nebenläufigkeit auf Stufe %lu zu setzen"
 
-#: ../src/unix/threadpsx.cpp:1424
+#: ../src/unix/threadpsx.cpp:1473
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Versuch fehlgeschlagen, die Thread-Priorität %d zu setzen."
 
-#: ../src/unix/utilsunx.cpp:783
+#: ../src/unix/utilsunx.cpp:785
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 "Das Erzeugen einer nicht blockierenden Pipe ist fehlgeschlagen, das Programm "
 "könnte stehen bleiben."
 
-#: ../src/common/fs_mem.cpp:261
+#: ../src/msw/webview_ie.cpp:987
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:256
 #, c-format
 msgid "Failed to store image '%s' to memory VFS!"
 msgstr "Versuch das Bild „%s“ im VFS-Speicher zu laden, fehlgeschlagen!"
 
-#: ../src/dfb/evtloop.cpp:170
+#: ../src/dfb/evtloop.cpp:171
 msgid "Failed to switch DirectFB pipe to non-blocking mode"
 msgstr "Wechsel von DirectFB Pipe in den Nicht blockierenden Modus schlug fehl"
 
-#: ../src/unix/wakeuppipe.cpp:59
+#: ../src/unix/wakeuppipe.cpp:56
 msgid "Failed to switch wake up pipe to non-blocking mode"
 msgstr ""
 "Aufweck-Pipe in den nicht blockierenden Modus umzuschalten ist fehlgeschlagen"
 
-#: ../src/unix/threadpsx.cpp:1605
+#: ../src/unix/threadpsx.cpp:1654
 msgid "Failed to terminate a thread."
 msgstr "Versuch den Thread zu beenden, fehlgeschlagen."
 
-#: ../src/msw/dde.cpp:741
+#: ../src/msw/dde.cpp:736
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr ""
 "Versuch fehlgeschlagen, die „advise Schleife“ mit DDE-Server zu beenden"
 
-#: ../src/msw/dialup.cpp:938
+#: ../src/msw/dialup.cpp:932
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Versuch fehlgeschlagen, die DFÜ-Verbindung zu beenden: %s"
 
-#: ../src/common/filename.cpp:2590
+#: ../src/common/filename.cpp:2673
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Konnte die Datei „%s“ nicht „berühren“"
 
-#: ../src/unix/snglinst.cpp:334
+#: ../src/unix/dlunix.cpp:90
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "Laden der dynamischen Bibliothek „%s“ fehlgeschlagen"
+
+#: ../src/unix/snglinst.cpp:331
 #, c-format
 msgid "Failed to unlock lock file '%s'"
 msgstr "Konnte die Sperrung von Datei „%s“ nicht aufheben"
 
-#: ../src/msw/dde.cpp:309
+#: ../src/msw/dde.cpp:304
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Die Registrierung des DDE-Servers „%s“ konnte nicht aufgehoben werden"
@@ -3693,78 +3765,88 @@ msgstr "Konnte Descriptor %d vom Epoll Descriptor nicht %d austragen"
 msgid "Failed to update user configuration file."
 msgstr "Kann Benutzer-Konfigurationsdatei nicht aktualisieren."
 
-#: ../src/common/debugrpt.cpp:733
+#: ../src/common/debugrpt.cpp:743
 #, c-format
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Konnte den Fehlerbericht nicht hochladen (Fehlercode %d)."
 
-#: ../src/unix/snglinst.cpp:168
+#: ../src/unix/snglinst.cpp:165
 #, c-format
 msgid "Failed to write to lock file '%s'"
 msgstr "Konnte Sperr-Datei „%s“ nicht schreiben"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:209
+#: ../src/propgrid/propgrid.cpp:190
 msgid "False"
 msgstr "Falsch"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:694
+#: ../src/propgrid/advprops.cpp:604
 msgid "Family"
 msgstr "Familie"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/gtk/glcanvas.cpp:176 ../src/gtk/glcanvas.cpp:187
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Nicht-behebbarer Fehler"
+
+#: ../src/common/stockitem.cpp:154
 msgid "File"
 msgstr "Datei"
 
-#: ../src/common/docview.cpp:669
+#: ../src/common/docview.cpp:664
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Die Datei „%s“ konnte nicht zum Lesen geöffnet werden."
 
-#: ../src/common/docview.cpp:646
+#: ../src/common/docview.cpp:641
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Die Datei „%s“ konnte nicht zum Schreiben geöffnet werden."
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr ""
 "Datei „%s“ existiert bereits, möchten Sie diese wirklich überschreiben?"
 
-#: ../src/common/filefn.cpp:1156
+#: ../src/common/filefn.cpp:1044
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Die Datei „%s“ konnte nicht gelöscht werden"
 
-#: ../src/common/filefn.cpp:1139
+#: ../src/common/filefn.cpp:1028
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Die Datei „%s“ konnte nicht nach „%s“ umbenannt werden."
 
-#: ../src/richtext/richtextctrl.cpp:3081 ../src/common/textcmn.cpp:953
+#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
 msgid "File couldn't be loaded."
 msgstr "Datei konnte nicht geladen werden."
 
-#: ../src/msw/filedlg.cpp:393
+#: ../src/msw/filedlg.cpp:414
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Datei Dialog schlug fehl mit dem Fehlercode %0lx."
 
-#: ../src/common/docview.cpp:1789
+#: ../src/common/docview.cpp:1783
 msgid "File error"
 msgstr "Dateifehler"
 
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/filectrlg.cpp:770
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/filectrlg.cpp:766
 msgid "File name exists already."
 msgstr "Dateiname bereits vorhanden."
+
+#: ../src/osx/cocoa/filedlg.mm:264
+#, fuzzy
+msgid "File type:"
+msgstr "Schreibmaschine"
 
 #: ../src/motif/filedlg.cpp:220
 msgid "Files"
 msgstr "Dateien"
 
-#: ../src/common/filefn.cpp:1591
+#: ../src/common/filefn.cpp:1479
 #, c-format
 msgid "Files (%s)"
 msgstr "Dateien (%s)"
@@ -3773,15 +3855,29 @@ msgstr "Dateien (%s)"
 msgid "Filter"
 msgstr "Filter"
 
-#: ../src/common/stockitem.cpp:158 ../src/html/helpwnd.cpp:490
+#: ../src/html/helpwnd.cpp:488
 msgid "Find"
 msgstr "Suchen"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:259
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:258
+#, fuzzy
+msgid "Find in document"
+msgstr "Öffne HTML-Dokument"
+
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "Find..."
+msgstr "Suchen"
+
+#: ../src/common/stockitem.cpp:156
 msgid "First"
 msgstr "Erste(r)"
 
-#: ../src/common/prntbase.cpp:1548
+#: ../src/common/prntbase.cpp:1573
 msgid "First page"
 msgstr "Erste Seite"
 
@@ -3789,11 +3885,11 @@ msgstr "Erste Seite"
 msgid "Fixed"
 msgstr "Festgesetzt"
 
-#: ../src/html/helpwnd.cpp:1206
+#: ../src/html/helpwnd.cpp:1204
 msgid "Fixed font:"
 msgstr "Schrift fester Breite:"
 
-#: ../src/html/helpwnd.cpp:1269
+#: ../src/html/helpwnd.cpp:1267
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Schrift fester Breite.<br> <b>fett</b> <i>kursiv</i> "
 
@@ -3801,16 +3897,16 @@ msgstr "Schrift fester Breite.<br> <b>fett</b> <i>kursiv</i> "
 msgid "Floating"
 msgstr "Schwebend"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "Floppy"
 msgstr "Diskette"
 
-#: ../src/common/paper.cpp:111
+#: ../src/common/paper.cpp:108
 msgid "Folio, 8 1/2 x 13 in"
 msgstr "Folio, 8 1/2 × 13 Zoll"
 
-#: ../src/richtext/richtextformatdlg.cpp:344 ../src/osx/carbon/fontdlg.cpp:287
-#: ../src/common/stockitem.cpp:194
+#: ../src/osx/carbon/fontdlg.cpp:284 ../src/common/stockitem.cpp:191
+#: ../src/richtext/richtextformatdlg.cpp:337
 msgid "Font"
 msgstr "Schriftart"
 
@@ -3818,7 +3914,24 @@ msgstr "Schriftart"
 msgid "Font &weight:"
 msgstr "Schrift&dicke:"
 
-#: ../src/html/helpwnd.cpp:1207
+#: ../src/osx/fontutil.cpp:89
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
+"\"."
+msgstr ""
+
+#: ../src/msw/font.cpp:1126
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Datei konnte nicht geladen werden."
+
+#: ../src/osx/fontutil.cpp:81
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "Datei »%s« existiert nicht."
+
+#: ../src/html/helpwnd.cpp:1205
 msgid "Font size:"
 msgstr "Schriftgröße:"
 
@@ -3826,54 +3939,54 @@ msgstr "Schriftgröße:"
 msgid "Font st&yle:"
 msgstr "Schrifst&il:"
 
-#: ../src/osx/carbon/fontdlg.cpp:329
+#: ../src/osx/carbon/fontdlg.cpp:326
 msgid "Font:"
 msgstr "Schrift:"
 
-#: ../src/dfb/fontmgr.cpp:198
+#: ../src/dfb/fontmgr.cpp:195
 #, c-format
 msgid "Fonts index file %s disappeared while loading fonts."
 msgstr ""
 "Indexdatei der Schriftarten %s während des Ladens der Schriften verschwunden."
 
-#: ../src/unix/utilsunx.cpp:645
+#: ../src/unix/utilsunx.cpp:647
 msgid "Fork failed"
 msgstr "„Fork“ fehlgeschlagen"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "Forward"
 msgstr "Vorwärts"
 
-#: ../src/common/xtixml.cpp:235
+#: ../src/common/xtixml.cpp:231
 msgid "Forward hrefs are not supported"
 msgstr "Forward hrefs werden nicht unterstützt"
 
-#: ../src/html/helpwnd.cpp:875
+#: ../src/html/helpwnd.cpp:873
 #, c-format
 msgid "Found %i matches"
 msgstr "Suchbegriff %i mal gefunden"
 
-#: ../src/generic/prntdlgg.cpp:238
+#: ../src/generic/prntdlgg.cpp:231
 msgid "From:"
 msgstr "Von:"
 
-#: ../src/propgrid/advprops.cpp:1604
+#: ../src/propgrid/advprops.cpp:1510
 msgid "Fuchsia"
 msgstr "Magenta"
 
-#: ../src/common/imaggif.cpp:138
+#: ../src/common/imaggif.cpp:135
 msgid "GIF: data stream seems to be truncated."
 msgstr "GIF: Datenstrom scheint unvollständig zu sein."
 
-#: ../src/common/imaggif.cpp:128
+#: ../src/common/imaggif.cpp:125
 msgid "GIF: error in GIF image format."
 msgstr "GIF: Fehler im GIF-Bildformat."
 
-#: ../src/common/imaggif.cpp:133
+#: ../src/common/imaggif.cpp:130
 msgid "GIF: not enough memory."
 msgstr "GIF: nicht genug Speicher."
 
-#: ../src/gtk/window.cpp:4631
+#: ../src/gtk/window.cpp:5635
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -3881,23 +3994,23 @@ msgstr ""
 "Das GTK+, das auf dieser Maschine installiert ist, ist zu alt um "
 "Bildschirmanordnung zu unterstützen, bitte GTK+ 2.12 oder neuer installieren."
 
-#: ../src/univ/themes/gtk.cpp:525
+#: ../src/univ/themes/gtk.cpp:522
 msgid "GTK+ theme"
 msgstr "GTK+ Thema"
 
-#: ../src/common/preferencescmn.cpp:40
+#: ../src/common/preferencescmn.cpp:37
 msgid "General"
 msgstr "Allgemein"
 
-#: ../src/common/prntbase.cpp:258
+#: ../src/common/prntbase.cpp:253
 msgid "Generic PostScript"
 msgstr "Generisches PostScript"
 
-#: ../src/common/paper.cpp:135
+#: ../src/common/paper.cpp:132
 msgid "German Legal Fanfold, 8 1/2 x 13 in"
 msgstr "German Legal Endlospapier, 21,59 × 33,02 cm"
 
-#: ../src/common/paper.cpp:134
+#: ../src/common/paper.cpp:131
 msgid "German Std Fanfold, 8 1/2 x 12 in"
 msgstr "German Std Endlospapier, 8 1/2 × 12 Zoll"
 
@@ -3913,49 +4026,49 @@ msgstr "GetPropertyCollection aufgerufen für einen allgemeinen accessor"
 msgid "GetPropertyCollection called w/o valid collection getter"
 msgstr "GetPropertyCollection aufgerufen ohne gültigen Collection getter"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:658
 msgid "Go back"
 msgstr "Zurück"
 
-#: ../src/html/helpwnd.cpp:661
+#: ../src/html/helpwnd.cpp:659
 msgid "Go forward"
 msgstr "Vorwärts"
 
-#: ../src/html/helpwnd.cpp:663
+#: ../src/html/helpwnd.cpp:661
 msgid "Go one level up in document hierarchy"
 msgstr "In die nächste Dokumentebene gehen"
 
-#: ../src/generic/filedlgg.cpp:208 ../src/generic/dirdlgg.cpp:116
+#: ../src/generic/filedlgg.cpp:205 ../src/generic/dirdlgg.cpp:113
 msgid "Go to home directory"
 msgstr "Gehe zum Benutzerverzeichnis"
 
-#: ../src/generic/filedlgg.cpp:205
+#: ../src/generic/filedlgg.cpp:202
 msgid "Go to parent directory"
 msgstr "Gehe zum „Parent“-Verzeichnis"
 
-#: ../src/generic/aboutdlgg.cpp:76
+#: ../src/generic/aboutdlgg.cpp:73
 msgid "Graphics art by "
 msgstr "Grafikgestaltung von "
 
-#: ../src/propgrid/advprops.cpp:1599
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Gray"
 msgstr "Grau"
 
 # Original wird verwendet
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:883
+#: ../src/propgrid/advprops.cpp:784
 msgid "GrayText"
 msgstr "GrayText"
 
-#: ../src/common/fmapbase.cpp:154
+#: ../src/common/fmapbase.cpp:151
 msgid "Greek (ISO-8859-7)"
 msgstr "Griechisch (ISO-8859-7)"
 
-#: ../src/propgrid/advprops.cpp:1600
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Green"
 msgstr "Grün"
 
-#: ../src/generic/colrdlgg.cpp:342
+#: ../src/generic/colrdlgg.cpp:362
 msgid "Green:"
 msgstr "Grün:"
 
@@ -3963,108 +4076,108 @@ msgstr "Grün:"
 msgid "Groove"
 msgstr "Groove"
 
-#: ../src/common/zstream.cpp:158 ../src/common/zstream.cpp:318
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
 msgid "Gzip not supported by this version of zlib"
 msgstr "Gzip wird nicht von dieser zlib-Version unterstützt"
 
-#: ../src/html/helpwnd.cpp:1549
+#: ../src/html/helpwnd.cpp:1547
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "HTML-Hilfe-Projekt (*.hhp)|*.hhp|"
 
-#: ../src/html/htmlwin.cpp:681
+#: ../src/html/htmlwin.cpp:691
 #, c-format
 msgid "HTML anchor %s does not exist."
 msgstr "HTML-Anker %s existiert nicht."
 
-#: ../src/html/helpwnd.cpp:1547
+#: ../src/html/helpwnd.cpp:1545
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "HTML-Dateien (*.html;*.htm)|*.html;*.htm|"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1759
+#: ../src/propgrid/advprops.cpp:1660
 msgid "Hand"
 msgstr "Hand"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "Harddisk"
 msgstr "Festplatte"
 
-#: ../src/common/fmapbase.cpp:155
+#: ../src/common/fmapbase.cpp:152
 msgid "Hebrew (ISO-8859-8)"
 msgstr "Hebräisch (ISO-8859-8)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:280 ../src/osx/button_osx.cpp:39
-#: ../src/common/stockitem.cpp:163 ../src/common/accelcmn.cpp:80
-#: ../src/html/helpdlg.cpp:66 ../src/html/helpfrm.cpp:111
+#: ../include/wx/msgdlg.h:282 ../src/osx/button_osx.cpp:39
+#: ../src/common/stockitem.cpp:160 ../src/common/accelcmn.cpp:77
+#: ../src/html/helpfrm.cpp:108 ../src/html/helpdlg.cpp:63
 msgid "Help"
 msgstr "Hilfe"
 
-#: ../src/html/helpwnd.cpp:1200
+#: ../src/html/helpwnd.cpp:1198
 msgid "Help Browser Options"
 msgstr "Hilfe zu den Browser-Einstellungen"
 
-#: ../src/generic/helpext.cpp:454 ../src/generic/helpext.cpp:455
+#: ../src/generic/helpext.cpp:452 ../src/generic/helpext.cpp:453
 msgid "Help Index"
 msgstr "Hilfeindex"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1529
 msgid "Help Printing"
 msgstr "Hilfe drucken"
 
-#: ../src/html/helpwnd.cpp:801
+#: ../src/html/helpwnd.cpp:799
 msgid "Help Topics"
 msgstr "Hilfethemen"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1546
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Hilfe-Bücher (*.htb)|*.htb|Hilfe-Bücher (*.zip)|*.zip|"
 
-#: ../src/generic/helpext.cpp:267
+#: ../src/generic/helpext.cpp:265
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "Hilfeverzeichnis „%s“ nicht gefunden."
 
-#: ../src/generic/helpext.cpp:275
+#: ../src/generic/helpext.cpp:273
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "Hilfedatei „%s“ nicht gefunden."
 
-#: ../src/html/helpctrl.cpp:63
+#: ../src/html/helpctrl.cpp:59
 #, c-format
 msgid "Help: %s"
 msgstr "Hilfe: %s"
 
-#: ../src/osx/menu_osx.cpp:577
+#: ../src/osx/menu_osx.cpp:469
 #, c-format
 msgid "Hide %s"
 msgstr "%s ausblenden"
 
-#: ../src/osx/menu_osx.cpp:579
+#: ../src/osx/menu_osx.cpp:471
 msgid "Hide Others"
 msgstr "Andere ausblenden"
 
-#: ../src/generic/infobar.cpp:84
+#: ../src/generic/infobar.cpp:81
 msgid "Hide this notification message."
 msgstr "Diese Meldung ausblenden."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:884
+#: ../src/propgrid/advprops.cpp:785
 msgid "Highlight"
 msgstr "Hervorheben"
 
 # Original wird verwendet
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:885
+#: ../src/propgrid/advprops.cpp:786
 msgid "HighlightText"
 msgstr "HighlightText"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:164 ../src/common/accelcmn.cpp:65
+#: ../src/common/stockitem.cpp:161 ../src/common/accelcmn.cpp:62
 msgid "Home"
 msgstr "Start"
 
-#: ../src/generic/dirctrlg.cpp:524
+#: ../src/generic/dirctrlg.cpp:490
 msgid "Home directory"
 msgstr "Benutzerverzeichnis"
 
@@ -4074,62 +4187,62 @@ msgid "How the object will float relative to the text."
 msgstr "Wie das Objekt relativ zum Text angeordnet wird."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1760
+#: ../src/propgrid/advprops.cpp:1661
 msgid "I-Beam"
 msgstr "Profilstahl"
 
-#: ../src/common/imagbmp.cpp:1196
+#: ../src/common/imagbmp.cpp:1208
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: Fehler beim Lesen der DIB-Maske."
 
-#: ../src/common/imagbmp.cpp:1290 ../src/common/imagbmp.cpp:1390
-#: ../src/common/imagbmp.cpp:1405 ../src/common/imagbmp.cpp:1416
-#: ../src/common/imagbmp.cpp:1430 ../src/common/imagbmp.cpp:1478
-#: ../src/common/imagbmp.cpp:1493 ../src/common/imagbmp.cpp:1507
-#: ../src/common/imagbmp.cpp:1518
+#: ../src/common/imagbmp.cpp:1302 ../src/common/imagbmp.cpp:1402
+#: ../src/common/imagbmp.cpp:1417 ../src/common/imagbmp.cpp:1428
+#: ../src/common/imagbmp.cpp:1442 ../src/common/imagbmp.cpp:1490
+#: ../src/common/imagbmp.cpp:1505 ../src/common/imagbmp.cpp:1519
+#: ../src/common/imagbmp.cpp:1530
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: Schreibfehler beim Speichern!"
 
-#: ../src/common/imagbmp.cpp:1255
+#: ../src/common/imagbmp.cpp:1267
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: Bild zu groß für ein Icon."
 
-#: ../src/common/imagbmp.cpp:1263
+#: ../src/common/imagbmp.cpp:1275
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: Bild zu breit für ein Icon."
 
-#: ../src/common/imagbmp.cpp:1603
+#: ../src/common/imagbmp.cpp:1615
 msgid "ICO: Invalid icon index."
 msgstr "ICO: Ungültiger Icon-Index."
 
-#: ../src/common/imagiff.cpp:758
+#: ../src/common/imagiff.cpp:755
 msgid "IFF: data stream seems to be truncated."
 msgstr "IFF: Datenstrom scheint unvollständig zu sein."
 
-#: ../src/common/imagiff.cpp:742
+#: ../src/common/imagiff.cpp:739
 msgid "IFF: error in IFF image format."
 msgstr "IFF: Fehler im IFF-Bildformat."
 
-#: ../src/common/imagiff.cpp:745
+#: ../src/common/imagiff.cpp:742
 msgid "IFF: not enough memory."
 msgstr "IFF: nicht genug Speicher."
 
-#: ../src/common/imagiff.cpp:748
+#: ../src/common/imagiff.cpp:745
 msgid "IFF: unknown error!!!"
 msgstr "IFF: unbekannter Fehler!"
 
-#: ../src/common/fmapbase.cpp:197
+#: ../src/common/fmapbase.cpp:194
 msgid "ISO-2022-JP"
 msgstr "ISO-2022-JP"
 
-#: ../src/html/htmprint.cpp:282
+#: ../src/html/htmprint.cpp:294
 msgid ""
 "If possible, try changing the layout parameters to make the printout more "
 "narrow."
 msgstr ""
 "Wenn möglich die Layout-Parameter ändern um den Ausdruck schmaler zu machen."
 
-#: ../src/generic/dbgrptg.cpp:358
+#: ../src/generic/dbgrptg.cpp:362
 msgid ""
 "If you have any additional information pertaining to this bug\n"
 "report, please enter it here and it will be joined to it:"
@@ -4150,46 +4263,50 @@ msgstr ""
 "behindern kann,\n"
 "nach Möglichkeit sollten Sie also den Fehlerbericht erstellen.\n"
 
-#: ../src/msw/registry.cpp:1405
+#: ../src/common/zipstrm.cpp:1043
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1393
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Ignoriere Wert „%s“ des Schlüssels „%s“."
 
-#: ../src/common/xtistrm.cpp:295
+#: ../src/common/xtistrm.cpp:292
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Ungültige Objektklasse (nicht wxEvtHandler) als Ereignisquelle"
 
-#: ../src/common/xti.cpp:513
+#: ../src/common/xti.cpp:510
 msgid "Illegal Parameter Count for ConstructObject Method"
 msgstr "Ungültige Anzahl Parameter für ConstructObject-Methode"
 
-#: ../src/common/xti.cpp:501
+#: ../src/common/xti.cpp:498
 msgid "Illegal Parameter Count for Create Method"
 msgstr "Ungültige Anzahl Parameter für Create-Methode"
 
-#: ../src/generic/dirctrlg.cpp:570 ../src/generic/filectrlg.cpp:756
+#: ../src/generic/dirctrlg.cpp:536 ../src/generic/filectrlg.cpp:752
 msgid "Illegal directory name."
 msgstr "Ungültiger Verzeichnisname."
 
-#: ../src/generic/filectrlg.cpp:1367
+#: ../src/generic/filectrlg.cpp:1356
 msgid "Illegal file specification."
 msgstr "Ungültige Dateiangabe."
 
-#: ../src/common/image.cpp:2269
+#: ../src/common/image.cpp:2363
 msgid "Image and mask have different sizes."
 msgstr "Bild und Bildmaske haben verschiedene Größen."
 
-#: ../src/common/image.cpp:2746
+#: ../src/common/image.cpp:2841
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "Bilddatei hat nicht den Typ %d."
 
-#: ../src/common/image.cpp:2877
+#: ../src/common/image.cpp:2995
 #, c-format
 msgid "Image is not of type %s."
 msgstr "Bilddatei hat nicht den Typ %s."
 
-#: ../src/msw/textctrl.cpp:488
+#: ../src/msw/textctrl.cpp:534
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -4197,103 +4314,103 @@ msgstr ""
 "Versuch eine „rich edit control“ zu erstellen fehlgeschlagen, verwende "
 "stattdessen ein einfaches Text-Control. Bitte „riched32.dll“ neu installieren"
 
-#: ../src/unix/utilsunx.cpp:301
+#: ../src/unix/utilsunx.cpp:303
 msgid "Impossible to get child process input"
 msgstr "Es war nicht möglich, die Eingabe des Unterprozesses zu verarbeiten"
 
-#: ../src/common/filefn.cpp:1028
+#: ../src/common/filefn.cpp:917
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Konnte die Zugriffsrechte der Datei „%s“ nicht ermitteln"
 
-#: ../src/common/filefn.cpp:1042
+#: ../src/common/filefn.cpp:931
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Versuch die Datei „%s“ zu überschreiben, fehlgeschlagen"
 
-#: ../src/common/filefn.cpp:1097
+#: ../src/common/filefn.cpp:986
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Konnte die Zugriffsrechte für Datei „%s“ nicht setzen"
 
 # Original wird verwendet
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:886
+#: ../src/propgrid/advprops.cpp:787
 msgid "InactiveBorder"
 msgstr "InactiveBorder"
 
 # Original wird verwendet
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:887
+#: ../src/propgrid/advprops.cpp:788
 msgid "InactiveCaption"
 msgstr "InactiveCaption"
 
 # Original wird verwendet
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:888
+#: ../src/propgrid/advprops.cpp:789
 msgid "InactiveCaptionText"
 msgstr "InactiveCaptionText"
 
-#: ../src/common/gifdecod.cpp:792
+#: ../src/common/gifdecod.cpp:826
 #, c-format
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "Ungültige GIF Bildgröße (%u, %d) für das Bild #%u"
 
-#: ../src/msw/ole/automtn.cpp:635
+#: ../src/msw/ole/automtn.cpp:626
 msgid "Incorrect number of arguments."
 msgstr "Fehlerhafte Anzahl von Argumenten."
 
-#: ../src/common/stockitem.cpp:165
+#: ../src/common/stockitem.cpp:162
 msgid "Indent"
 msgstr "Einrücken"
 
-#: ../src/richtext/richtextformatdlg.cpp:349
+#: ../src/richtext/richtextformatdlg.cpp:342
 msgid "Indents && Spacing"
 msgstr "Einrückungen && Zeichenabstand"
 
-#: ../src/common/stockitem.cpp:166 ../src/html/helpwnd.cpp:515
+#: ../src/common/stockitem.cpp:163 ../src/html/helpwnd.cpp:513
 msgid "Index"
 msgstr "Index"
 
-#: ../src/common/fmapbase.cpp:159
+#: ../src/common/fmapbase.cpp:156
 msgid "Indian (ISO-8859-12)"
 msgstr "Indisch (ISO-8859-12)"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "Info"
 msgstr "Info"
 
-#: ../src/common/init.cpp:287
+#: ../src/common/init.cpp:284
 msgid "Initialization failed in post init, aborting."
 msgstr "Initialisierung in „post init“ fehlgeschlagen, breche ab."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:54
+#: ../src/common/accelcmn.cpp:51
 msgid "Ins"
 msgstr "Einfg"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextsymboldlg.cpp:472 ../src/common/accelcmn.cpp:53
+#: ../src/common/accelcmn.cpp:50 ../src/richtext/richtextsymboldlg.cpp:469
 msgid "Insert"
 msgstr "Einfügen"
 
-#: ../src/richtext/richtextbuffer.cpp:8067
+#: ../src/richtext/richtextbuffer.cpp:8063
 msgid "Insert Field"
 msgstr "Feld einfügen"
 
-#: ../src/richtext/richtextbuffer.cpp:7978
-#: ../src/richtext/richtextbuffer.cpp:8936
+#: ../src/richtext/richtextbuffer.cpp:7974
+#: ../src/richtext/richtextbuffer.cpp:8934
 msgid "Insert Image"
 msgstr "Bild einfügen"
 
-#: ../src/richtext/richtextbuffer.cpp:8025
+#: ../src/richtext/richtextbuffer.cpp:8021
 msgid "Insert Object"
 msgstr "Objekt einfügen"
 
-#: ../src/richtext/richtextctrl.cpp:1286 ../src/richtext/richtextctrl.cpp:1494
-#: ../src/richtext/richtextbuffer.cpp:7822
-#: ../src/richtext/richtextbuffer.cpp:7852
-#: ../src/richtext/richtextbuffer.cpp:7894
+#: ../src/richtext/richtextbuffer.cpp:7818
+#: ../src/richtext/richtextbuffer.cpp:7848
+#: ../src/richtext/richtextbuffer.cpp:7890
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
 msgid "Insert Text"
 msgstr "Text einfügen"
 
@@ -4306,16 +4423,11 @@ msgstr "Fügt einen Seitenumbruch vor dem Absatz ein."
 msgid "Inset"
 msgstr "Einfügen"
 
-#: ../src/gtk/app.cpp:425
-#, c-format
-msgid "Invalid GTK+ command line option, use \"%s --help\""
-msgstr "Ungültige GTK+ Kommentarzeile, benutzen Sie „%s --help“"
-
-#: ../src/common/imagtiff.cpp:311
+#: ../src/common/imagtiff.cpp:308
 msgid "Invalid TIFF image index."
 msgstr "Ungültiger Index des TIFF-Bilds."
 
-#: ../src/common/appcmn.cpp:273
+#: ../src/common/appcmn.cpp:294
 #, c-format
 msgid "Invalid display mode specification '%s'."
 msgstr "Ungültige Angabe „%s“ des Displays."
@@ -4325,248 +4437,252 @@ msgstr "Ungültige Angabe „%s“ des Displays."
 msgid "Invalid geometry specification '%s'"
 msgstr "Ungültige Angabe „%s“ der Fenstergröße"
 
-#: ../src/unix/fswatcher_inotify.cpp:323
+#: ../src/unix/fswatcher_inotify.cpp:320
 #, c-format
 msgid "Invalid inotify event for \"%s\""
 msgstr "Ungültiges inotify-Ereignis für „%s“"
 
-#: ../src/unix/snglinst.cpp:312
+#: ../src/unix/snglinst.cpp:309
 #, c-format
 msgid "Invalid lock file '%s'."
 msgstr "Ungültige Sperr-Datei „%s“."
 
-#: ../src/common/translation.cpp:1125
+#: ../src/common/translation.cpp:1167
 msgid "Invalid message catalog."
 msgstr "Ungültiger Nachrichtenkatalog."
 
-#: ../src/common/xtistrm.cpp:405 ../src/common/xtistrm.cpp:420
+#: ../src/common/xtistrm.cpp:402 ../src/common/xtistrm.cpp:417
 msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
 msgstr "Ungültige oder Null-Objekt-ID an GetObjectClassInfo übergeben"
 
-#: ../src/common/xtistrm.cpp:435
+#: ../src/common/xtistrm.cpp:432
 msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
 msgstr "Ungültige oder Null-Objekt-ID an HasObjectClassInfo übergeben"
 
-#: ../src/common/regex.cpp:310
+#: ../src/common/regex.cpp:307
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Ungültiger regulärer Ausdruck „%s“: %s"
 
-#: ../src/common/config.cpp:226
+#: ../src/common/config.cpp:222
 #, c-format
 msgid "Invalid value %ld for a boolean key \"%s\" in config file."
 msgstr ""
 "Ungültiger Wert %ld für einen booleschen Schlüssel „%s“ in der "
 "Konfigurationsdatei."
 
-#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:351
-#: ../src/osx/carbon/fontdlg.cpp:361 ../src/common/stockitem.cpp:168
+#: ../src/osx/carbon/fontdlg.cpp:358 ../src/common/stockitem.cpp:165
+#: ../src/generic/fontdlgg.cpp:325 ../src/richtext/richtextfontpage.cpp:351
 msgid "Italic"
 msgstr "Kursiv"
 
-#: ../src/common/paper.cpp:130
+#: ../src/common/paper.cpp:127
 msgid "Italy Envelope, 110 x 230 mm"
 msgstr "Italy Umschlag, 110 × 230 mm"
 
-#: ../src/common/imagjpeg.cpp:270
+#: ../src/common/imagjpeg.cpp:257
 msgid "JPEG: Couldn't load - file is probably corrupted."
 msgstr "JPEG: Lesefehler - Datei ist vermutlich beschädigt."
 
-#: ../src/common/imagjpeg.cpp:449
+#: ../src/common/imagjpeg.cpp:436
 msgid "JPEG: Couldn't save image."
 msgstr "JPEG: Konnte Bild nicht speichern."
 
-#: ../src/common/paper.cpp:163
+#: ../src/common/paper.cpp:160
 msgid "Japanese Double Postcard 200 x 148 mm"
 msgstr "Japanische Doppelte Postkarte 200 × 148 mm"
 
-#: ../src/common/paper.cpp:167
+#: ../src/common/paper.cpp:164
 msgid "Japanese Envelope Chou #3"
 msgstr "Japanischer Briefumschlag Chou #3"
 
-#: ../src/common/paper.cpp:180
+#: ../src/common/paper.cpp:177
 msgid "Japanese Envelope Chou #3 Rotated"
 msgstr "Japanischer Briefumschlag Chou #3 Rotiert"
 
-#: ../src/common/paper.cpp:168
+#: ../src/common/paper.cpp:165
 msgid "Japanese Envelope Chou #4"
 msgstr "Japanischer Briefumschlag Chou #4"
 
-#: ../src/common/paper.cpp:181
+#: ../src/common/paper.cpp:178
 msgid "Japanese Envelope Chou #4 Rotated"
 msgstr "Japanischer Briefumschlag Chou #4 Rotiert"
 
-#: ../src/common/paper.cpp:165
+#: ../src/common/paper.cpp:162
 msgid "Japanese Envelope Kaku #2"
 msgstr "Japanischer Briefumschlag Kaku #2"
 
-#: ../src/common/paper.cpp:178
+#: ../src/common/paper.cpp:175
 msgid "Japanese Envelope Kaku #2 Rotated"
 msgstr "Japanischer Briefumschlag Kaku #2 Rotiert"
 
-#: ../src/common/paper.cpp:166
+#: ../src/common/paper.cpp:163
 msgid "Japanese Envelope Kaku #3"
 msgstr "Japanischer Briefumschlag Kaku #3"
 
-#: ../src/common/paper.cpp:179
+#: ../src/common/paper.cpp:176
 msgid "Japanese Envelope Kaku #3 Rotated"
 msgstr "Japanischer Briefumschlag Kaku #3 Rotiert"
 
-#: ../src/common/paper.cpp:185
+#: ../src/common/paper.cpp:182
 msgid "Japanese Envelope You #4"
 msgstr "Japanischer Briefumschlag You #4"
 
-#: ../src/common/paper.cpp:186
+#: ../src/common/paper.cpp:183
 msgid "Japanese Envelope You #4 Rotated"
 msgstr "Japanischer Briefumschlag You #4 Rotiert"
 
-#: ../src/common/paper.cpp:138
+#: ../src/common/paper.cpp:135
 msgid "Japanese Postcard 100 x 148 mm"
 msgstr "Japanische Postkarte 100 × 148 mm"
 
-#: ../src/common/paper.cpp:175
+#: ../src/common/paper.cpp:172
 msgid "Japanese Postcard Rotated 148 x 100 mm"
 msgstr "Japanische Postkarte Rotiert 100 × 148 mm"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "Jump to"
 msgstr "Springen zu"
 
-#: ../src/common/stockitem.cpp:171
+#: ../src/common/stockitem.cpp:168
 msgid "Justified"
 msgstr "Blocksatz"
 
-#: ../src/richtext/richtextindentspage.cpp:155
-#: ../src/richtext/richtextindentspage.cpp:157
 #: ../src/richtext/richtextliststylepage.cpp:344
 #: ../src/richtext/richtextliststylepage.cpp:346
+#: ../src/richtext/richtextindentspage.cpp:155
+#: ../src/richtext/richtextindentspage.cpp:157
 msgid "Justify text left and right."
 msgstr "Text rechts und links ausrichten."
 
-#: ../src/common/fmapbase.cpp:163
+#: ../src/common/fmapbase.cpp:160
 msgid "KOI8-R"
 msgstr "KOI8-R"
 
-#: ../src/common/fmapbase.cpp:164
+#: ../src/common/fmapbase.cpp:161
 msgid "KOI8-U"
 msgstr "KOI8-U"
 
-#: ../src/common/accelcmn.cpp:265 ../src/common/accelcmn.cpp:347
+#: ../src/common/accelcmn.cpp:279 ../src/common/accelcmn.cpp:364
 msgid "KP_"
 msgstr "Num_"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "KP_Add"
 msgstr "Num_Plus"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "KP_Begin"
 msgstr "Num_Anfang"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "KP_Decimal"
 msgstr "Num_Dezimal"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 msgid "KP_Delete"
 msgstr "Num_Entf"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "KP_Divide"
 msgstr "Num_Division"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 msgid "KP_Down"
 msgstr "Num_Runter"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "KP_End"
 msgstr "Num_Ende"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "KP_Enter"
 msgstr "Num_Eingabe"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "KP_Equal"
 msgstr "Num_Gleich"
 
+#: ../src/common/accelcmn.cpp:276 ../src/common/accelcmn.cpp:361
+msgid "KP_F"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 msgid "KP_Home"
 msgstr "Num_Pos1"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 msgid "KP_Insert"
 msgstr "Num_Einfg"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "KP_Left"
 msgstr "Num_Links"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "KP_Multiply"
 msgstr "Num_Mal"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:99
+#: ../src/common/accelcmn.cpp:97
 msgid "KP_Next"
 msgstr "Num_Nächster"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "KP_PageDown"
 msgstr "Num_Bild↓"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "KP_PageUp"
 msgstr "Num_Bild↑"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:98
+#: ../src/common/accelcmn.cpp:96
 msgid "KP_Prior"
 msgstr "Num_Voriger"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 msgid "KP_Right"
 msgstr "Num_Rechts"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "KP_Separator"
 msgstr "Num_Trennzeichen"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "KP_Space"
 msgstr "Num_Leertaste"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "KP_Subtract"
 msgstr "Num_Minus"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "KP_Tab"
 msgstr "Num_Tab"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "KP_Up"
 msgstr "Num_Hoch"
 
@@ -4574,19 +4690,34 @@ msgstr "Num_Hoch"
 msgid "L&ine spacing:"
 msgstr "Ze&ilenabstand:"
 
-#: ../src/generic/prntdlgg.cpp:613 ../src/generic/prntdlgg.cpp:868
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "Fehler beim Komprimieren"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "Fehler beim Entpacken"
+
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:861
 msgid "Landscape"
 msgstr "Querformat"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "Last"
 msgstr "Letzte(r)"
 
-#: ../src/common/prntbase.cpp:1572
+#: ../src/common/prntbase.cpp:1597
 msgid "Last page"
 msgstr "Letzte Seite"
 
-#: ../src/common/log.cpp:305
+#: ../src/common/log.cpp:324
 #, c-format
 msgid "Last repeated message (\"%s\", %u time) wasn't output"
 msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
@@ -4595,93 +4726,93 @@ msgstr[0] ""
 msgstr[1] ""
 "Die letzte wiederholte Nachricht („%s“, %u Mal) wurde nicht ausgegeben"
 
-#: ../src/common/paper.cpp:103
+#: ../src/common/paper.cpp:100
 msgid "Ledger, 17 x 11 in"
 msgstr "Ledger, 17 × 11 Zoll"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6146
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:58 ../src/generic/datavgen.cpp:6951
+#: ../src/richtext/richtextsizepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:252
 #: ../src/richtext/richtextliststylepage.cpp:253
 #: ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
-#: ../src/richtext/richtextsizepage.cpp:249 ../src/common/accelcmn.cpp:61
 msgid "Left"
 msgstr "Links"
 
-#: ../src/richtext/richtextindentspage.cpp:204
 #: ../src/richtext/richtextliststylepage.cpp:390
+#: ../src/richtext/richtextindentspage.cpp:204
 msgid "Left (&first line):"
 msgstr "Links (&erste Zeile):"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1761
+#: ../src/propgrid/advprops.cpp:1662
 msgid "Left Button"
 msgstr "Links-Taste"
 
-#: ../src/generic/prntdlgg.cpp:880
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Left margin (mm):"
 msgstr "Linker Rand (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:141
-#: ../src/richtext/richtextindentspage.cpp:143
 #: ../src/richtext/richtextliststylepage.cpp:330
 #: ../src/richtext/richtextliststylepage.cpp:332
+#: ../src/richtext/richtextindentspage.cpp:141
+#: ../src/richtext/richtextindentspage.cpp:143
 msgid "Left-align text."
 msgstr "Linksbündiger Text."
 
-#: ../src/common/paper.cpp:144
+#: ../src/common/paper.cpp:141
 msgid "Legal Extra 9 1/2 x 15 in"
 msgstr "Legal Extra 9 1/2 × 15 Zoll"
 
-#: ../src/common/paper.cpp:96
+#: ../src/common/paper.cpp:93
 msgid "Legal, 8 1/2 x 14 in"
 msgstr "Legal, 8 1/2 × 14 Zoll"
 
-#: ../src/common/paper.cpp:143
+#: ../src/common/paper.cpp:140
 msgid "Letter Extra 9 1/2 x 12 in"
 msgstr "Letter Extra 9 1/2 × 12 Zoll"
 
-#: ../src/common/paper.cpp:149
+#: ../src/common/paper.cpp:146
 msgid "Letter Extra Transverse 9.275 x 12 in"
 msgstr "Brief Extra Quer 9.275 × 12 Zoll"
 
-#: ../src/common/paper.cpp:152
+#: ../src/common/paper.cpp:149
 msgid "Letter Plus 8 1/2 x 12.69 in"
 msgstr "Brief Plus 8 1/2 × 12.69 Zoll"
 
-#: ../src/common/paper.cpp:169
+#: ../src/common/paper.cpp:166
 msgid "Letter Rotated 11 x 8 1/2 in"
 msgstr "Brief Rotiert 11 × 8 1/2 Zoll"
 
-#: ../src/common/paper.cpp:101
+#: ../src/common/paper.cpp:98
 msgid "Letter Small, 8 1/2 x 11 in"
 msgstr "Letter Small, 8 1/2 × 11 Zoll"
 
-#: ../src/common/paper.cpp:147
+#: ../src/common/paper.cpp:144
 msgid "Letter Transverse 8 1/2 x 11 in"
 msgstr "Brief Quer 8 1/2 × 11 Zoll"
 
-#: ../src/common/paper.cpp:95
+#: ../src/common/paper.cpp:92
 msgid "Letter, 8 1/2 x 11 in"
 msgstr "Letter, 8 1/2 × 11 Zoll"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "License"
 msgstr "Lizenz"
 
-#: ../src/generic/fontdlgg.cpp:332
+#: ../src/generic/fontdlgg.cpp:328
 msgid "Light"
 msgstr "Dünn"
 
-#: ../src/propgrid/advprops.cpp:1608
+#: ../src/propgrid/advprops.cpp:1514
 msgid "Lime"
 msgstr "Zitronengrün"
 
-#: ../src/generic/helpext.cpp:294
+#: ../src/generic/helpext.cpp:292
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr "Zeile %lu der Abbildungsdatei „%s“ hat ungültige Syntax, übersprungen."
@@ -4690,15 +4821,15 @@ msgstr "Zeile %lu der Abbildungsdatei „%s“ hat ungültige Syntax, übersprun
 msgid "Line spacing:"
 msgstr "Zeilenabstand:"
 
-#: ../src/html/chm.cpp:838
+#: ../src/html/chm.cpp:829
 msgid "Link contained '//', converted to absolute link."
 msgstr "Verweis enthielt „//“, in absoluten Link umgewandelt."
 
-#: ../src/richtext/richtextformatdlg.cpp:364
+#: ../src/richtext/richtextformatdlg.cpp:357
 msgid "List Style"
 msgstr "Listenstil"
 
-#: ../src/richtext/richtextstyles.cpp:1064
+#: ../src/richtext/richtextstyles.cpp:1061
 msgid "List styles"
 msgstr "Listenstile"
 
@@ -4712,26 +4843,26 @@ msgstr "Schriftgröße der Listen in Punkt."
 msgid "Lists the available fonts."
 msgstr "Listet die verfügbaren Schriftarten auf."
 
-#: ../src/common/fldlgcmn.cpp:340
+#: ../src/common/fldlgcmn.cpp:337
 #, c-format
 msgid "Load %s file"
 msgstr "%s-Datei laden"
 
-#: ../src/html/htmlwin.cpp:597
+#: ../src/html/htmlwin.cpp:600
 msgid "Loading : "
 msgstr "Laden: "
 
-#: ../src/unix/snglinst.cpp:246
+#: ../src/unix/snglinst.cpp:243
 #, c-format
 msgid "Lock file '%s' has incorrect owner."
 msgstr "Sperr-Datei „%s“ hat falschen Besitzer."
 
-#: ../src/unix/snglinst.cpp:251
+#: ../src/unix/snglinst.cpp:248
 #, c-format
 msgid "Lock file '%s' has incorrect permissions."
 msgstr "Sperr-Datei „%s“ hat falsche Zugriffsrechte."
 
-#: ../src/generic/logg.cpp:576
+#: ../src/generic/logg.cpp:573
 #, c-format
 msgid "Log saved to the file '%s'."
 msgstr "Logtext in Datei „%s“ gespeichert."
@@ -4746,11 +4877,11 @@ msgstr "Kleinbuchstaben"
 msgid "Lower case roman numerals"
 msgstr "Römische Ziffern in Kleinbuchstaben"
 
-#: ../src/gtk/mdi.cpp:422 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk1/mdi.cpp:431 ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "MDI child"
 
-#: ../src/msw/helpchm.cpp:56
+#: ../src/msw/helpchm.cpp:53
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -4758,190 +4889,190 @@ msgstr ""
 "Die MS-HTML-Hilfe funktioniert nicht, da die MS-HTML-Hilfe-Bibliothek nicht "
 "installiert ist. Bitte installieren Sie diese."
 
-#: ../src/univ/themes/win32.cpp:3754
+#: ../src/univ/themes/win32.cpp:3751
 msgid "Ma&ximize"
 msgstr "Ma&ximieren"
 
-#: ../src/common/fmapbase.cpp:203
+#: ../src/common/fmapbase.cpp:200
 msgid "MacArabic"
 msgstr "MacArabic"
 
-#: ../src/common/fmapbase.cpp:222
+#: ../src/common/fmapbase.cpp:219
 msgid "MacArmenian"
 msgstr "MacArmenian"
 
-#: ../src/common/fmapbase.cpp:211
+#: ../src/common/fmapbase.cpp:208
 msgid "MacBengali"
 msgstr "MacBengali"
 
-#: ../src/common/fmapbase.cpp:217
+#: ../src/common/fmapbase.cpp:214
 msgid "MacBurmese"
 msgstr "MacBurmese"
 
-#: ../src/common/fmapbase.cpp:236
+#: ../src/common/fmapbase.cpp:233
 msgid "MacCeltic"
 msgstr "MacCeltic"
 
-#: ../src/common/fmapbase.cpp:227
+#: ../src/common/fmapbase.cpp:224
 msgid "MacCentralEurRoman"
 msgstr "MacCentralEurRoman"
 
-#: ../src/common/fmapbase.cpp:223
+#: ../src/common/fmapbase.cpp:220
 msgid "MacChineseSimp"
 msgstr "MacChineseSimp"
 
-#: ../src/common/fmapbase.cpp:201
+#: ../src/common/fmapbase.cpp:198
 msgid "MacChineseTrad"
 msgstr "MacChineseTrad"
 
-#: ../src/common/fmapbase.cpp:233
+#: ../src/common/fmapbase.cpp:230
 msgid "MacCroatian"
 msgstr "MacCroatian"
 
-#: ../src/common/fmapbase.cpp:206
+#: ../src/common/fmapbase.cpp:203
 msgid "MacCyrillic"
 msgstr "MacCyrillic"
 
-#: ../src/common/fmapbase.cpp:207
+#: ../src/common/fmapbase.cpp:204
 msgid "MacDevanagari"
 msgstr "MacDevanagari"
 
-#: ../src/common/fmapbase.cpp:231
+#: ../src/common/fmapbase.cpp:228
 msgid "MacDingbats"
 msgstr "MacDingbats"
 
-#: ../src/common/fmapbase.cpp:226
+#: ../src/common/fmapbase.cpp:223
 msgid "MacEthiopic"
 msgstr "MacEthiopic"
 
-#: ../src/common/fmapbase.cpp:229
+#: ../src/common/fmapbase.cpp:226
 msgid "MacExtArabic"
 msgstr "MacExtArabic"
 
-#: ../src/common/fmapbase.cpp:237
+#: ../src/common/fmapbase.cpp:234
 msgid "MacGaelic"
 msgstr "MacGaelic"
 
-#: ../src/common/fmapbase.cpp:221
+#: ../src/common/fmapbase.cpp:218
 msgid "MacGeorgian"
 msgstr "MacGeorgian"
 
-#: ../src/common/fmapbase.cpp:205
+#: ../src/common/fmapbase.cpp:202
 msgid "MacGreek"
 msgstr "MacGreek"
 
-#: ../src/common/fmapbase.cpp:209
+#: ../src/common/fmapbase.cpp:206
 msgid "MacGujarati"
 msgstr "MacGujarati"
 
-#: ../src/common/fmapbase.cpp:208
+#: ../src/common/fmapbase.cpp:205
 msgid "MacGurmukhi"
 msgstr "MacGurmukhi"
 
-#: ../src/common/fmapbase.cpp:204
+#: ../src/common/fmapbase.cpp:201
 msgid "MacHebrew"
 msgstr "MacHebrew"
 
-#: ../src/common/fmapbase.cpp:234
+#: ../src/common/fmapbase.cpp:231
 msgid "MacIcelandic"
 msgstr "MacIcelandic"
 
-#: ../src/common/fmapbase.cpp:200
+#: ../src/common/fmapbase.cpp:197
 msgid "MacJapanese"
 msgstr "MacJapanese"
 
-#: ../src/common/fmapbase.cpp:214
+#: ../src/common/fmapbase.cpp:211
 msgid "MacKannada"
 msgstr "MacKannada"
 
-#: ../src/common/fmapbase.cpp:238
+#: ../src/common/fmapbase.cpp:235
 msgid "MacKeyboardGlyphs"
 msgstr "MacKeyboardGlyphs"
 
-#: ../src/common/fmapbase.cpp:218
+#: ../src/common/fmapbase.cpp:215
 msgid "MacKhmer"
 msgstr "MacKhmer"
 
-#: ../src/common/fmapbase.cpp:202
+#: ../src/common/fmapbase.cpp:199
 msgid "MacKorean"
 msgstr "MacKorean"
 
-#: ../src/common/fmapbase.cpp:220
+#: ../src/common/fmapbase.cpp:217
 msgid "MacLaotian"
 msgstr "MacLaotian"
 
-#: ../src/common/fmapbase.cpp:215
+#: ../src/common/fmapbase.cpp:212
 msgid "MacMalayalam"
 msgstr "MacMalayalam"
 
-#: ../src/common/fmapbase.cpp:225
+#: ../src/common/fmapbase.cpp:222
 msgid "MacMongolian"
 msgstr "MacMongolian"
 
-#: ../src/common/fmapbase.cpp:210
+#: ../src/common/fmapbase.cpp:207
 msgid "MacOriya"
 msgstr "MacOriya"
 
-#: ../src/common/fmapbase.cpp:199
+#: ../src/common/fmapbase.cpp:196
 msgid "MacRoman"
 msgstr "MacRoman"
 
-#: ../src/common/fmapbase.cpp:235
+#: ../src/common/fmapbase.cpp:232
 msgid "MacRomanian"
 msgstr "MacRomanian"
 
-#: ../src/common/fmapbase.cpp:216
+#: ../src/common/fmapbase.cpp:213
 msgid "MacSinhalese"
 msgstr "MacSinhalese"
 
-#: ../src/common/fmapbase.cpp:230
+#: ../src/common/fmapbase.cpp:227
 msgid "MacSymbol"
 msgstr "MacSymbol"
 
-#: ../src/common/fmapbase.cpp:212
+#: ../src/common/fmapbase.cpp:209
 msgid "MacTamil"
 msgstr "MacTamil"
 
-#: ../src/common/fmapbase.cpp:213
+#: ../src/common/fmapbase.cpp:210
 msgid "MacTelugu"
 msgstr "MacTelugu"
 
-#: ../src/common/fmapbase.cpp:219
+#: ../src/common/fmapbase.cpp:216
 msgid "MacThai"
 msgstr "MacThai"
 
-#: ../src/common/fmapbase.cpp:224
+#: ../src/common/fmapbase.cpp:221
 msgid "MacTibetan"
 msgstr "MacTibetan"
 
-#: ../src/common/fmapbase.cpp:232
+#: ../src/common/fmapbase.cpp:229
 msgid "MacTurkish"
 msgstr "MacTurkish"
 
-#: ../src/common/fmapbase.cpp:228
+#: ../src/common/fmapbase.cpp:225
 msgid "MacVietnamese"
 msgstr "MacVietnamese"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1762
+#: ../src/propgrid/advprops.cpp:1663
 msgid "Magnifier"
 msgstr "Lupe"
 
-#: ../src/propgrid/advprops.cpp:2143
+#: ../src/propgrid/advprops.cpp:2050
 msgid "Make a selection:"
 msgstr "Bitte auswählen:"
 
-#: ../src/richtext/richtextformatdlg.cpp:374
+#: ../src/richtext/richtextformatdlg.cpp:367
 #: ../src/richtext/richtextmarginspage.cpp:171
 msgid "Margins"
 msgstr "Ränder"
 
 # http://bfw.ac.at/020/farbtabelle.html
-#: ../src/propgrid/advprops.cpp:1595
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Maroon"
 msgstr "Kastanienbraun"
 
-#: ../src/generic/fdrepdlg.cpp:147
+#: ../src/generic/fdrepdlg.cpp:144
 msgid "Match case"
 msgstr "Groß- und Kleinschreibung beachten"
 
@@ -4953,40 +5084,40 @@ msgstr "Maximale Höhe:"
 msgid "Max width:"
 msgstr "Maximale Breite:"
 
-#: ../src/unix/mediactrl.cpp:947
+#: ../src/unix/mediactrl.cpp:972
 #, c-format
 msgid "Media playback error: %s"
 msgstr "Medienwiedergabe-Fehler: %s"
 
-#: ../src/common/fs_mem.cpp:175
+#: ../src/common/fs_mem.cpp:170
 #, c-format
 msgid "Memory VFS already contains file '%s'!"
 msgstr "VFS-Speicher beinhaltet bereits die Datei „%s“!"
 
 #. TRANSLATORS: Name of keyboard key
 #. TRANSLATORS: Keyword of system colour
-#: ../src/common/accelcmn.cpp:73 ../src/propgrid/advprops.cpp:889
+#: ../src/common/accelcmn.cpp:70 ../src/propgrid/advprops.cpp:790
 msgid "Menu"
 msgstr "Menü"
 
-#: ../src/common/msgout.cpp:124
+#: ../src/common/msgout.cpp:121
 msgid "Message"
 msgstr "Nachricht"
 
-#: ../src/univ/themes/metal.cpp:168
+#: ../src/univ/themes/metal.cpp:165
 msgid "Metal theme"
 msgstr "Metal-Thema"
 
-#: ../src/msw/ole/automtn.cpp:652
+#: ../src/msw/ole/automtn.cpp:643
 msgid "Method or property not found."
 msgstr "Methode oder Eigenschaft nicht gefunden."
 
-#: ../src/univ/themes/win32.cpp:3752
+#: ../src/univ/themes/win32.cpp:3749
 msgid "Mi&nimize"
 msgstr "Mi&nimieren"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1763
+#: ../src/propgrid/advprops.cpp:1664
 msgid "Middle Button"
 msgstr "Mittlere Taste"
 
@@ -4998,37 +5129,42 @@ msgstr "Minimale Höhe:"
 msgid "Min width:"
 msgstr "Minimale Breite:"
 
-#: ../src/msw/ole/automtn.cpp:668
+#: ../src/osx/cocoa/menu.mm:281
+#, fuzzy
+msgid "Minimize"
+msgstr "Mi&nimieren"
+
+#: ../src/msw/ole/automtn.cpp:659
 msgid "Missing a required parameter."
 msgstr "Ein notwendiger Parameter fehlt."
 
-#: ../src/generic/fontdlgg.cpp:324
+#: ../src/generic/fontdlgg.cpp:320
 msgid "Modern"
 msgstr "Modern"
 
-#: ../src/generic/filectrlg.cpp:427
+#: ../src/generic/filectrlg.cpp:423
 msgid "Modified"
 msgstr "Geändert"
 
-#: ../src/common/module.cpp:133
+#: ../src/common/module.cpp:130
 #, c-format
 msgid "Module \"%s\" initialization failed"
 msgstr "Initialisierung von Modul „%s“ fehlgeschlagen"
 
-#: ../src/common/paper.cpp:131
+#: ../src/common/paper.cpp:128
 msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
 msgstr "Monarch Envelope, 3 7/8 × 7 1/2 Zoll"
 
-#: ../src/msw/fswatcher.cpp:143
+#: ../src/msw/fswatcher.cpp:140
 msgid "Monitoring individual files for changes is not supported currently."
 msgstr ""
 "Überwachen einzelner Dateien auf Änderungen wird zurzeit nicht unterstützt."
 
-#: ../src/generic/editlbox.cpp:172
+#: ../src/generic/editlbox.cpp:160
 msgid "Move down"
 msgstr "Abwärts verschieben"
 
-#: ../src/generic/editlbox.cpp:171
+#: ../src/generic/editlbox.cpp:155
 msgid "Move up"
 msgstr "Nach oben"
 
@@ -5042,97 +5178,103 @@ msgstr "Verschiebt das Objekt zum nächsten Absatz."
 msgid "Moves the object to the previous paragraph."
 msgstr "Verschiebt das Objekt in den vorherigen Absatz."
 
-#: ../src/richtext/richtextbuffer.cpp:9966
+#: ../src/richtext/richtextbuffer.cpp:9963
 msgid "Multiple Cell Properties"
 msgstr "Mehrfache Zelleneigenschaften"
 
-#: ../src/generic/filectrlg.cpp:424
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:82
+#, fuzzy
+msgid "Multiply"
+msgstr "Num_Mal"
+
+#: ../src/generic/filectrlg.cpp:420
 msgid "Name"
 msgstr "Name"
 
-#: ../src/propgrid/advprops.cpp:1596
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Navy"
 msgstr "Marineblau"
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "Network"
 msgstr "Netzwerk"
 
-#: ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173
 msgid "New"
 msgstr "Neu"
 
-#: ../src/richtext/richtextstyledlg.cpp:243
+#: ../src/richtext/richtextstyledlg.cpp:239
 msgid "New &Box Style..."
 msgstr "Neuer &Rahmenstil …"
 
-#: ../src/richtext/richtextstyledlg.cpp:225
+#: ../src/richtext/richtextstyledlg.cpp:221
 msgid "New &Character Style..."
 msgstr "Neuer &Zeichenstil …"
 
-#: ../src/richtext/richtextstyledlg.cpp:237
+#: ../src/richtext/richtextstyledlg.cpp:233
 msgid "New &List Style..."
 msgstr "Neuer &Listenstil …"
 
-#: ../src/richtext/richtextstyledlg.cpp:231
+#: ../src/richtext/richtextstyledlg.cpp:227
 msgid "New &Paragraph Style..."
 msgstr "Neuer &Absatzstil …"
 
-#: ../src/richtext/richtextstyledlg.cpp:606
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:654
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:820
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:893
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:934
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:602
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:650
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:816
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:889
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:930
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "New Style"
 msgstr "Neuer Stil"
 
-#: ../src/generic/editlbox.cpp:169
+#: ../src/generic/editlbox.cpp:139
 msgid "New item"
 msgstr "Neues Element"
 
-#: ../src/generic/dirdlgg.cpp:297 ../src/generic/dirdlgg.cpp:307
-#: ../src/generic/filectrlg.cpp:618 ../src/generic/filectrlg.cpp:627
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+#: ../src/generic/dirdlgg.cpp:294 ../src/generic/dirdlgg.cpp:304
 msgid "NewName"
 msgstr "NeuerName"
 
-#: ../src/common/prntbase.cpp:1567 ../src/html/helpwnd.cpp:665
+#: ../src/common/prntbase.cpp:1592 ../src/html/helpwnd.cpp:663
 msgid "Next page"
 msgstr "Nächste Seite"
 
-#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:177
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:174
 #: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Nein"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1764
+#: ../src/propgrid/advprops.cpp:1665
 msgid "No Entry"
 msgstr "Kein Eintrag"
 
-#: ../src/generic/animateg.cpp:150
+#: ../src/generic/animateg.cpp:133
 #, c-format
 msgid "No animation handler for type %ld defined."
 msgstr "Kein Animationshandler für Typ %ld definiert."
 
-#: ../src/dfb/bitmap.cpp:642 ../src/dfb/bitmap.cpp:676
+#: ../src/dfb/bitmap.cpp:639 ../src/dfb/bitmap.cpp:673
 #, c-format
 msgid "No bitmap handler for type %d defined."
 msgstr "Keine Bildbehandlungsroutine für den Typ %d definiert."
 
-#: ../src/common/utilscmn.cpp:1077
+#: ../src/common/utilscmn.cpp:1095
 msgid "No default application configured for HTML files."
 msgstr "Keine voreingestellte Anwendung für HTML-Dateien."
 
-#: ../src/generic/helpext.cpp:445
+#: ../src/generic/helpext.cpp:443
 msgid "No entries found."
 msgstr "Keine Einträge gefunden."
 
-#: ../src/common/fontmap.cpp:421
+#: ../src/common/fontmap.cpp:418
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found,\n"
@@ -5145,7 +5287,7 @@ msgstr ""
 "Möchten Sie diese Kodierung wählen\n"
 "(sonst müssen Sie eine andere auswählen)?"
 
-#: ../src/common/fontmap.cpp:426
+#: ../src/common/fontmap.cpp:423
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found.\n"
@@ -5156,203 +5298,203 @@ msgstr ""
 "Möchten Sie eine Schriftart für die Kodierung wählen\n"
 "(sonst wird der Text mit dieser Kodierung nicht richtig dargestellt)?"
 
-#: ../src/generic/animateg.cpp:142
+#: ../src/generic/animateg.cpp:125
 msgid "No handler found for animation type."
 msgstr "Kein Handler für den Animationstyp gefunden."
 
-#: ../src/common/image.cpp:2728
+#: ../src/common/image.cpp:2823
 msgid "No handler found for image type."
 msgstr "Dieses Bildformat wird nicht unterstützt."
 
-#: ../src/common/image.cpp:2736 ../src/common/image.cpp:2848
-#: ../src/common/image.cpp:2901
+#: ../src/common/image.cpp:2831 ../src/common/image.cpp:2954
+#: ../src/common/image.cpp:3020
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "Bildformat %d wurde nicht definiert."
 
-#: ../src/common/image.cpp:2871 ../src/common/image.cpp:2915
+#: ../src/common/image.cpp:2986 ../src/common/image.cpp:3034
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "Bildformat %s wurde nicht definiert."
 
-#: ../src/html/helpwnd.cpp:858
+#: ../src/html/helpwnd.cpp:856
 msgid "No matching page found yet"
 msgstr "Passende Seite noch nicht gefunden"
 
-#: ../src/unix/sound.cpp:81
+#: ../src/unix/sound.cpp:78
 msgid "No sound"
 msgstr "Kein Ton"
 
-#: ../src/common/image.cpp:2277 ../src/common/image.cpp:2318
+#: ../src/common/image.cpp:2371 ../src/common/image.cpp:2412
 msgid "No unused colour in image being masked."
 msgstr "Keine unbenutzte Farbe wurde im Bild unterdrückt."
 
-#: ../src/common/image.cpp:3374
-msgid "No unused colour in image."
-msgstr "Keine unbenutzte Farbe im Bild."
-
-#: ../src/generic/helpext.cpp:302
+#: ../src/generic/helpext.cpp:300
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "Keine gültige Abbildung in der Datei „%s“ gefunden."
 
-#: ../src/richtext/richtextborderspage.cpp:610
 #: ../src/richtext/richtextsizepage.cpp:248
 #: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:610
 msgid "None"
 msgstr "Kein"
 
-#: ../src/common/fmapbase.cpp:157
+#: ../src/common/fmapbase.cpp:154
 msgid "Nordic (ISO-8859-10)"
 msgstr "Nordisch (ISO-8859-10)"
 
-#: ../src/generic/fontdlgg.cpp:328 ../src/generic/fontdlgg.cpp:331
+#: ../src/generic/fontdlgg.cpp:324 ../src/generic/fontdlgg.cpp:327
 msgid "Normal"
 msgstr "Normal"
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1261
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Normale Schrift<br>und <u>unterstrichen</u>. "
 
-#: ../src/html/helpwnd.cpp:1205
+#: ../src/html/helpwnd.cpp:1203
 msgid "Normal font:"
 msgstr "Normal Font:"
 
-#: ../src/propgrid/props.cpp:1128
+#: ../src/propgrid/props.cpp:1115
 #, c-format
 msgid "Not %s"
 msgstr "Nicht %s"
 
-#: ../include/wx/filename.h:573 ../include/wx/filename.h:578
-msgid "Not available"
-msgstr "Nicht verfügbar"
+#: ../src/common/secretstore.cpp:168
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/webrequest.cpp:605
+msgid "Not enough free disk space for download."
+msgstr ""
 
 #: ../src/richtext/richtextfontpage.cpp:358
 msgid "Not underlined"
 msgstr "Nicht unterstrichen"
 
-#: ../src/common/paper.cpp:115
+#: ../src/common/paper.cpp:112
 msgid "Note, 8 1/2 x 11 in"
 msgstr "Note, 8 1/2 × 11 Zoll"
 
-#: ../src/generic/notifmsgg.cpp:132
+#: ../src/generic/notifmsgg.cpp:129
 msgid "Notice"
 msgstr "Bemerkung"
 
 # Ggf. auch Num ×, je nach Tastatur
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "Num *"
 msgstr "Num *"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "Num +"
 msgstr "Num +"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "Num ,"
 msgstr "Num ,"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "Num -"
 msgstr "Num -"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "Num ."
 msgstr "Num ."
 
 # Ggf. auch Num %, je nach Tastatur
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "Num /"
 msgstr "Num /"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "Num ="
 msgstr "Num ="
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "Num Begin"
 msgstr "Num Anfang"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 msgid "Num Delete"
 msgstr "Num Löschen"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 msgid "Num Down"
 msgstr "Num Runter"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "Num End"
 msgstr "Num Ende"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "Num Enter"
 msgstr "Num Eingabe"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 msgid "Num Home"
 msgstr "Num Pos1"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 msgid "Num Insert"
 msgstr "Num Einfg"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num Lock"
 msgstr "Num-Taste"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "Num Page Down"
 msgstr "Num Bild↓"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "Num Page Up"
 msgstr "Num Bild↑"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 msgid "Num Right"
 msgstr "Num Rechts"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "Num Space"
 msgstr "Num Leer"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "Num Tab"
 msgstr "Num Tab"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "Num Up"
 msgstr "Num Hoch"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "Num left"
 msgstr "Num Links"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num_lock"
 msgstr "Num-Taste"
 
@@ -5361,13 +5503,13 @@ msgstr "Num-Taste"
 msgid "Numbered outline"
 msgstr "Nummerierung umrandet"
 
-#: ../include/wx/msgdlg.h:278 ../src/richtext/richtextstyledlg.cpp:297
-#: ../src/common/stockitem.cpp:178 ../src/msw/msgdlg.cpp:454
-#: ../src/msw/msgdlg.cpp:747 ../src/gtk1/fontdlg.cpp:138
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:175
+#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/msgdlg.cpp:741 ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "OK"
 
-#: ../src/msw/ole/automtn.cpp:692
+#: ../src/msw/ole/automtn.cpp:683
 #, c-format
 msgid "OLE Automation error in %s: %s"
 msgstr "OLE-Automatisierungsfehler in %s: %s"
@@ -5376,15 +5518,15 @@ msgstr "OLE-Automatisierungsfehler in %s: %s"
 msgid "Object Properties"
 msgstr "Objekteigenschaften"
 
-#: ../src/msw/ole/automtn.cpp:660
+#: ../src/msw/ole/automtn.cpp:651
 msgid "Object implementation does not support named arguments."
 msgstr "Objekt-Umsetzung unterstützt keine benannten Argumente."
 
-#: ../src/common/xtixml.cpp:264
+#: ../src/common/xtixml.cpp:260
 msgid "Objects must have an id attribute"
 msgstr "Objekte müssen ein ID-Attribut besitzen"
 
-#: ../src/propgrid/advprops.cpp:1601
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Olive"
 msgstr "Olivgrün"
 
@@ -5392,64 +5534,69 @@ msgstr "Olivgrün"
 msgid "Opaci&ty:"
 msgstr "Deckkraf&t:"
 
-#: ../src/generic/colrdlgg.cpp:354
+#: ../src/generic/colrdlgg.cpp:374
 msgid "Opacity:"
 msgstr "Deckkraft:"
 
-#: ../src/common/docview.cpp:1773 ../src/common/docview.cpp:1815
+#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
 msgid "Open File"
 msgstr "Datei öffnen"
 
-#: ../src/html/helpwnd.cpp:671 ../src/html/helpwnd.cpp:1554
+#: ../src/html/helpwnd.cpp:669 ../src/html/helpwnd.cpp:1552
 msgid "Open HTML document"
 msgstr "Öffne HTML-Dokument"
 
-#: ../src/generic/dbgrptg.cpp:163
+#: ../src/common/stockitem.cpp:265
+#, fuzzy
+msgid "Open an existing document"
+msgstr "Öffne HTML-Dokument"
+
+#: ../src/generic/dbgrptg.cpp:160
 #, c-format
 msgid "Open file \"%s\""
 msgstr "Öffne Datei „%s“"
 
-#: ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176
 msgid "Open..."
 msgstr "Öffnen …"
 
-#: ../src/unix/glx11.cpp:506 ../src/msw/glcanvas.cpp:592
+#: ../src/msw/glcanvas.cpp:607 ../src/unix/glx11.cpp:513
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr "OpenGL 3.0 und neuer, wird vom OpenGL-Treiber nicht unterstützt."
 
-#: ../src/generic/dirctrlg.cpp:599 ../src/generic/dirdlgg.cpp:323
-#: ../src/generic/filectrlg.cpp:642 ../src/generic/filectrlg.cpp:786
+#: ../src/generic/dirctrlg.cpp:565 ../src/generic/filectrlg.cpp:638
+#: ../src/generic/filectrlg.cpp:782 ../src/generic/dirdlgg.cpp:320
 msgid "Operation not permitted."
 msgstr "Ausführung nicht erlaubt."
 
-#: ../src/common/cmdline.cpp:900
+#: ../src/common/cmdline.cpp:896
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "Option „%s“ konnte nicht negiert werden"
 
-#: ../src/common/cmdline.cpp:1064
+#: ../src/common/cmdline.cpp:1060
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "Option „%s“ erwartet einen Wert."
 
-#: ../src/common/cmdline.cpp:1147
+#: ../src/common/cmdline.cpp:1143
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Option „%s“: „%s“ kann nicht in ein Datum umgewandelt werden."
 
-#: ../src/generic/prntdlgg.cpp:618
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Einstellungen"
 
-#: ../src/propgrid/advprops.cpp:1606
+#: ../src/propgrid/advprops.cpp:1512
 msgid "Orange"
 msgstr "Orange"
 
-#: ../src/generic/prntdlgg.cpp:615 ../src/generic/prntdlgg.cpp:869
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:862
 msgid "Orientation"
 msgstr "Ausrichtung"
 
-#: ../src/common/windowid.cpp:242
+#: ../src/common/windowid.cpp:237
 msgid "Out of window IDs.  Recommend shutting down application."
 msgstr "Keine Fenster-IDs mehr verfügbar. Bitte Applikation beenden."
 
@@ -5462,148 +5609,148 @@ msgstr "Umrandung"
 msgid "Outset"
 msgstr "Beginn"
 
-#: ../src/msw/ole/automtn.cpp:656
+#: ../src/msw/ole/automtn.cpp:647
 msgid "Overflow while coercing argument values."
 msgstr "Überlauf beim Umwandeln der Argumentwerte."
 
-#: ../src/common/imagpcx.cpp:457 ../src/common/imagpcx.cpp:480
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:479
 msgid "PCX: couldn't allocate memory"
 msgstr "PCX: Speicheranforderung fehlgeschlagen"
 
-#: ../src/common/imagpcx.cpp:456
+#: ../src/common/imagpcx.cpp:455
 msgid "PCX: image format unsupported"
 msgstr "PCX: Bildformat wird nicht unterstützt"
 
-#: ../src/common/imagpcx.cpp:479
+#: ../src/common/imagpcx.cpp:478
 msgid "PCX: invalid image"
 msgstr "PCX: ungültiges Bild"
 
-#: ../src/common/imagpcx.cpp:442
+#: ../src/common/imagpcx.cpp:441
 msgid "PCX: this is not a PCX file."
 msgstr "PCX: dies ist keine PCX-Datei."
 
-#: ../src/common/imagpcx.cpp:459 ../src/common/imagpcx.cpp:481
+#: ../src/common/imagpcx.cpp:458 ../src/common/imagpcx.cpp:480
 msgid "PCX: unknown error !!!"
 msgstr "PCX: unbekannter Fehler!"
 
-#: ../src/common/imagpcx.cpp:458
+#: ../src/common/imagpcx.cpp:457
 msgid "PCX: version number too low"
 msgstr "PCX: Versionsnummer zu niedrig"
 
-#: ../src/common/imagpnm.cpp:91
+#: ../src/common/imagpnm.cpp:89
 msgid "PNM: Couldn't allocate memory."
 msgstr "PNM: Speicheranforderung fehlgeschlagen."
 
-#: ../src/common/imagpnm.cpp:73
+#: ../src/common/imagpnm.cpp:71
 msgid "PNM: File format is not recognized."
 msgstr "PNM: Datei-Format wurde nicht erkannt."
 
-#: ../src/common/imagpnm.cpp:112 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
 #: ../src/common/imagpnm.cpp:156
 msgid "PNM: File seems truncated."
 msgstr "PNM: Datei wurde abgeschnitten."
 
-#: ../src/common/paper.cpp:187
+#: ../src/common/paper.cpp:184
 msgid "PRC 16K 146 x 215 mm"
 msgstr "PRC 16K 146 × 215 mm"
 
-#: ../src/common/paper.cpp:200
+#: ../src/common/paper.cpp:197
 msgid "PRC 16K Rotated"
 msgstr "PRC 16K Rotiert"
 
-#: ../src/common/paper.cpp:188
+#: ../src/common/paper.cpp:185
 msgid "PRC 32K 97 x 151 mm"
 msgstr "PRC 32K 97 × 151 mm"
 
-#: ../src/common/paper.cpp:201
+#: ../src/common/paper.cpp:198
 msgid "PRC 32K Rotated"
 msgstr "PRC 32K Rotiert"
 
-#: ../src/common/paper.cpp:189
+#: ../src/common/paper.cpp:186
 msgid "PRC 32K(Big) 97 x 151 mm"
 msgstr "PRC 32K(Groß) 97 × 151 mm"
 
-#: ../src/common/paper.cpp:202
+#: ../src/common/paper.cpp:199
 msgid "PRC 32K(Big) Rotated"
 msgstr "PRC 32K(Groß) Rotiert"
 
-#: ../src/common/paper.cpp:190
+#: ../src/common/paper.cpp:187
 msgid "PRC Envelope #1 102 x 165 mm"
 msgstr "PRC Umschlag #1 102 × 165 mm"
 
-#: ../src/common/paper.cpp:203
+#: ../src/common/paper.cpp:200
 msgid "PRC Envelope #1 Rotated 165 x 102 mm"
 msgstr "PRC Umschlag #1 Rotated 165 × 102 mm"
 
-#: ../src/common/paper.cpp:199
+#: ../src/common/paper.cpp:196
 msgid "PRC Envelope #10 324 x 458 mm"
 msgstr "PRC Umschlag #10 324 × 458 mm"
 
-#: ../src/common/paper.cpp:212
+#: ../src/common/paper.cpp:209
 msgid "PRC Envelope #10 Rotated 458 x 324 mm"
 msgstr "PRC Umschlag #10 Rotiert 458 × 324 mm"
 
-#: ../src/common/paper.cpp:191
+#: ../src/common/paper.cpp:188
 msgid "PRC Envelope #2 102 x 176 mm"
 msgstr "PRC Umschlag #2 102 × 176 mm"
 
-#: ../src/common/paper.cpp:204
+#: ../src/common/paper.cpp:201
 msgid "PRC Envelope #2 Rotated 176 x 102 mm"
 msgstr "PRC Umschlag #2 Rotiert 176 × 102 mm"
 
-#: ../src/common/paper.cpp:192
+#: ../src/common/paper.cpp:189
 msgid "PRC Envelope #3 125 x 176 mm"
 msgstr "PRC Umschlag #3 125 × 176 mm"
 
-#: ../src/common/paper.cpp:205
+#: ../src/common/paper.cpp:202
 msgid "PRC Envelope #3 Rotated 176 x 125 mm"
 msgstr "PRC Umschlag #3 Rotiert 176 × 125 mm"
 
-#: ../src/common/paper.cpp:193
+#: ../src/common/paper.cpp:190
 msgid "PRC Envelope #4 110 x 208 mm"
 msgstr "PRC Umschlag #4 110 × 208 mm"
 
-#: ../src/common/paper.cpp:206
+#: ../src/common/paper.cpp:203
 msgid "PRC Envelope #4 Rotated 208 x 110 mm"
 msgstr "PRC Umschlag #4 Rotiert 208 × 110 mm"
 
-#: ../src/common/paper.cpp:194
+#: ../src/common/paper.cpp:191
 msgid "PRC Envelope #5 110 x 220 mm"
 msgstr "PRC Umschlag #5 110 × 220 mm"
 
-#: ../src/common/paper.cpp:207
+#: ../src/common/paper.cpp:204
 msgid "PRC Envelope #5 Rotated 220 x 110 mm"
 msgstr "PRC Umschlag #5 Rotiert 220 × 110 mm"
 
-#: ../src/common/paper.cpp:195
+#: ../src/common/paper.cpp:192
 msgid "PRC Envelope #6 120 x 230 mm"
 msgstr "PRC Umschlag #6 120 × 230 mm"
 
-#: ../src/common/paper.cpp:208
+#: ../src/common/paper.cpp:205
 msgid "PRC Envelope #6 Rotated 230 x 120 mm"
 msgstr "PRC Umschlag #6 Rotiert 230 × 120 mm"
 
-#: ../src/common/paper.cpp:196
+#: ../src/common/paper.cpp:193
 msgid "PRC Envelope #7 160 x 230 mm"
 msgstr "PRC Umschlag #7 160 × 230 mm"
 
-#: ../src/common/paper.cpp:209
+#: ../src/common/paper.cpp:206
 msgid "PRC Envelope #7 Rotated 230 x 160 mm"
 msgstr "PRC Umschlag #7 Rotiert 230 × 160 mm"
 
-#: ../src/common/paper.cpp:197
+#: ../src/common/paper.cpp:194
 msgid "PRC Envelope #8 120 x 309 mm"
 msgstr "PRC Umschlag #8 120 × 309 mm"
 
-#: ../src/common/paper.cpp:210
+#: ../src/common/paper.cpp:207
 msgid "PRC Envelope #8 Rotated 309 x 120 mm"
 msgstr "PRC Umschlag #8 Rotiert 309 × 120 mm"
 
-#: ../src/common/paper.cpp:198
+#: ../src/common/paper.cpp:195
 msgid "PRC Envelope #9 229 x 324 mm"
 msgstr "PRC Umschlag #9 229 × 324 mm"
 
-#: ../src/common/paper.cpp:211
+#: ../src/common/paper.cpp:208
 msgid "PRC Envelope #9 Rotated 324 x 229 mm"
 msgstr "PRC Umschlag #9 Rotiert 324 × 229 mm"
 
@@ -5611,87 +5758,91 @@ msgstr "PRC Umschlag #9 Rotiert 324 × 229 mm"
 msgid "Padding"
 msgstr "Auffüllung"
 
-#: ../src/common/prntbase.cpp:2074
+#: ../src/common/prntbase.cpp:2096
 #, c-format
 msgid "Page %d"
 msgstr "Seite %d"
 
-#: ../src/common/prntbase.cpp:2072
+#: ../src/common/prntbase.cpp:2094
 #, c-format
 msgid "Page %d of %d"
 msgstr "Seite %d von %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 msgid "Page Down"
 msgstr "Bild↓"
 
-#: ../src/gtk/print.cpp:826
+#: ../src/gtk/print.cpp:829
 msgid "Page Setup"
 msgstr "Seiten-Einstellungen"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 msgid "Page Up"
 msgstr "Bild↑"
 
-#: ../src/generic/prntdlgg.cpp:828 ../src/common/prntbase.cpp:484
+#: ../src/common/prntbase.cpp:479 ../src/generic/prntdlgg.cpp:821
 msgid "Page setup"
 msgstr "Seiten-Einstellungen"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 msgid "PageDown"
 msgstr "Bild↓"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 msgid "PageUp"
 msgstr "Bild↑"
 
-#: ../src/generic/prntdlgg.cpp:216
+#: ../src/generic/prntdlgg.cpp:209
 msgid "Pages"
 msgstr "Seiten"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1765
+#: ../src/propgrid/advprops.cpp:1666
 msgid "Paint Brush"
 msgstr "Pinsel"
 
-#: ../src/generic/prntdlgg.cpp:602 ../src/generic/prntdlgg.cpp:801
-#: ../src/generic/prntdlgg.cpp:842 ../src/generic/prntdlgg.cpp:855
-#: ../src/generic/prntdlgg.cpp:1052 ../src/generic/prntdlgg.cpp:1057
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:794
+#: ../src/generic/prntdlgg.cpp:835 ../src/generic/prntdlgg.cpp:848
+#: ../src/generic/prntdlgg.cpp:1045 ../src/generic/prntdlgg.cpp:1050
 msgid "Paper size"
 msgstr "Papierformat"
 
-#: ../src/richtext/richtextstyles.cpp:1062
+#: ../src/richtext/richtextstyles.cpp:1059
 msgid "Paragraph styles"
 msgstr "Absatzstile"
 
-#: ../src/common/xtistrm.cpp:465
+#: ../src/common/xtistrm.cpp:462
 msgid "Passing a already registered object to SetObject"
 msgstr "Ein bereits registriertes Objekt wurde an SetObject übergeben"
 
-#: ../src/common/xtistrm.cpp:476
+#: ../src/common/xtistrm.cpp:473
 msgid "Passing an unknown object to GetObject"
 msgstr "Ein unbekanntes Objekt wurde an GetObject übergeben"
 
-#: ../src/richtext/richtextctrl.cpp:3513 ../src/common/stockitem.cpp:180
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:177 ../src/richtext/richtextctrl.cpp:3514
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Einfügen"
 
-#: ../src/common/stockitem.cpp:262
+#: ../src/common/stockitem.cpp:260
 msgid "Paste selection"
 msgstr "Auswahl einfügen"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:74
+#: ../src/common/accelcmn.cpp:71
 msgid "Pause"
 msgstr "Pause"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1766
+#: ../src/propgrid/advprops.cpp:1667
 msgid "Pencil"
 msgstr "Stift"
 
@@ -5700,21 +5851,21 @@ msgstr "Stift"
 msgid "Peri&od"
 msgstr "P&unkt"
 
-#: ../src/generic/filectrlg.cpp:430
+#: ../src/generic/filectrlg.cpp:426
 msgid "Permissions"
 msgstr "Zugriffsrechte"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:60
+#: ../src/common/accelcmn.cpp:57
 msgid "PgDn"
 msgstr "Bild↓"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:59
+#: ../src/common/accelcmn.cpp:56
 msgid "PgUp"
 msgstr "Bild↑"
 
-#: ../src/richtext/richtextbuffer.cpp:12868
+#: ../src/richtext/richtextbuffer.cpp:12863
 msgid "Picture Properties"
 msgstr "Bildeigenschaften"
 
@@ -5726,43 +5877,43 @@ msgstr "Konnte keine Pipe anlegen"
 msgid "Please choose a valid font."
 msgstr "Bitte wählen Sie eine gültige Schriftart."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
 msgid "Please choose an existing file."
 msgstr "Bitte wählen Sie eine bestehende Datei."
 
-#: ../src/html/helpwnd.cpp:800
+#: ../src/html/helpwnd.cpp:798
 msgid "Please choose the page to display:"
 msgstr "Bitte wählen Sie die darzustellende Seite:"
 
-#: ../src/msw/dialup.cpp:764
+#: ../src/msw/dialup.cpp:758
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Bitte gewünschte ISP-Verbindung auswählen"
 
-#: ../src/common/headerctrlcmn.cpp:59
+#: ../src/common/headerctrlcmn.cpp:57
 msgid "Please select the columns to show and define their order:"
 msgstr ""
 "Bitte darzustellende Spalten auswählen und deren Reihenfolge festlegen:"
 
-#: ../src/common/prntbase.cpp:538
+#: ../src/common/prntbase.cpp:533
 msgid "Please wait while printing..."
 msgstr "Bitte warten Sie während gedruckt wird …"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1767
+#: ../src/propgrid/advprops.cpp:1668
 msgid "Point Left"
 msgstr "Punkt links"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1768
+#: ../src/propgrid/advprops.cpp:1669
 msgid "Point Right"
 msgstr "Punkt rechts"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:662
+#: ../src/propgrid/advprops.cpp:572
 msgid "Point Size"
 msgstr "Größe in Punkt"
 
-#: ../src/generic/prntdlgg.cpp:612 ../src/generic/prntdlgg.cpp:867
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:860
 msgid "Portrait"
 msgstr "Hochformat"
 
@@ -5770,150 +5921,160 @@ msgstr "Hochformat"
 msgid "Position"
 msgstr "Position"
 
-#: ../src/generic/prntdlgg.cpp:298
+#: ../src/generic/prntdlgg.cpp:291
 msgid "PostScript file"
 msgstr "PostScript-Datei"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178 ../src/osx/cocoa/preferences.mm:303
 msgid "Preferences"
 msgstr "Einstellungen"
 
-#: ../src/osx/menu_osx.cpp:568
+#: ../src/osx/menu_osx.cpp:460
 msgid "Preferences..."
 msgstr "Einstellungen …"
 
-#: ../src/common/prntbase.cpp:546
+#: ../src/common/prntbase.cpp:541
 msgid "Preparing"
 msgstr "Vorbereitung"
 
-#: ../src/generic/fontdlgg.cpp:455 ../src/osx/carbon/fontdlg.cpp:390
-#: ../src/html/helpwnd.cpp:1222
+#: ../src/osx/carbon/fontdlg.cpp:387 ../src/generic/fontdlgg.cpp:452
+#: ../src/html/helpwnd.cpp:1220
 msgid "Preview:"
 msgstr "Vorschau:"
 
-#: ../src/common/prntbase.cpp:1553 ../src/html/helpwnd.cpp:664
+#: ../src/common/prntbase.cpp:1578 ../src/html/helpwnd.cpp:662
 msgid "Previous page"
 msgstr "Vorherige Seite"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/prntdlgg.cpp:143 ../src/generic/prntdlgg.cpp:157
-#: ../src/common/prntbase.cpp:426 ../src/common/prntbase.cpp:1541
-#: ../src/common/accelcmn.cpp:77 ../src/gtk/print.cpp:620
-#: ../src/gtk/print.cpp:638
+#: ../src/common/prntbase.cpp:421 ../src/common/prntbase.cpp:1566
+#: ../src/common/accelcmn.cpp:74 ../src/generic/prntdlgg.cpp:136
+#: ../src/generic/prntdlgg.cpp:150 ../src/gtk/print.cpp:616
+#: ../src/gtk/print.cpp:634
 msgid "Print"
 msgstr "Drucken"
 
-#: ../include/wx/prntbase.h:399 ../src/common/docview.cpp:1268
+#: ../src/common/docview.cpp:1262
 msgid "Print Preview"
 msgstr "Druckvorschau"
 
-#: ../src/common/prntbase.cpp:2015 ../src/common/prntbase.cpp:2057
-#: ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2037 ../src/common/prntbase.cpp:2079
+#: ../src/common/prntbase.cpp:2087
 msgid "Print Preview Failure"
 msgstr "Fehler bei der Druckvorschau"
 
-#: ../src/generic/prntdlgg.cpp:224
+#: ../src/generic/prntdlgg.cpp:217
 msgid "Print Range"
 msgstr "Seitenbereich"
 
-#: ../src/generic/prntdlgg.cpp:449
+#: ../src/generic/prntdlgg.cpp:442
 msgid "Print Setup"
 msgstr "Druckereinstellungen"
 
-#: ../src/generic/prntdlgg.cpp:621
+#: ../src/generic/prntdlgg.cpp:614
 msgid "Print in colour"
 msgstr "Farbig drucken"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/osx/webview_webkit.mm:260
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "Spaltenbeschreibung konnte nicht installiert werden."
+
+#: ../src/common/stockitem.cpp:179
 msgid "Print previe&w..."
 msgstr "Druck&vorschau …"
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1256
 msgid "Print preview creation failed."
 msgstr "Erzeugung der Druckvorschau fehlgeschlagen."
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/common/stockitem.cpp:179
 msgid "Print preview..."
 msgstr "Druckvorschau …"
 
-#: ../src/generic/prntdlgg.cpp:630
+#: ../src/generic/prntdlgg.cpp:623
 msgid "Print spooling"
 msgstr "Druckersteuerung"
 
-#: ../src/html/helpwnd.cpp:675
+#: ../src/html/helpwnd.cpp:673
 msgid "Print this page"
 msgstr "Diese Seite drucken"
 
-#: ../src/generic/prntdlgg.cpp:185
+#: ../src/generic/prntdlgg.cpp:178
 msgid "Print to File"
 msgstr "In Datei drucken"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "Print..."
 msgstr "Drucken …"
 
-#: ../src/generic/prntdlgg.cpp:493
+#: ../src/generic/prntdlgg.cpp:486
 msgid "Printer"
 msgstr "Drucker"
 
-#: ../src/generic/prntdlgg.cpp:633
+#: ../src/generic/prntdlgg.cpp:626
 msgid "Printer command:"
 msgstr "Druckbefehl:"
 
-#: ../src/generic/prntdlgg.cpp:180
+#: ../src/generic/prntdlgg.cpp:173
 msgid "Printer options"
 msgstr "Drucker-Einstellungen"
 
-#: ../src/generic/prntdlgg.cpp:645
+#: ../src/generic/prntdlgg.cpp:638
 msgid "Printer options:"
 msgstr "Drucker-Einstellungen:"
 
-#: ../src/generic/prntdlgg.cpp:916
+#: ../src/generic/prntdlgg.cpp:909
 msgid "Printer..."
 msgstr "Drucker …"
 
-#: ../src/generic/prntdlgg.cpp:196
+#: ../src/generic/prntdlgg.cpp:189
 msgid "Printer:"
 msgstr "Drucker:"
 
-#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:535
-#: ../src/html/htmprint.cpp:277
+#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:530
+#: ../src/html/htmprint.cpp:289
 msgid "Printing"
 msgstr "Drucken"
 
-#: ../src/common/prntbase.cpp:612
+#: ../src/common/prntbase.cpp:607
 msgid "Printing "
 msgstr "Drucken von "
 
-#: ../src/common/prntbase.cpp:347
+#: ../src/common/prntbase.cpp:342
 msgid "Printing Error"
 msgstr "Fehler beim Drucken"
 
-#: ../src/common/prntbase.cpp:565
+#: ../src/osx/webview_webkit.mm:251
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "Gzip wird nicht von dieser zlib-Version unterstützt"
+
+#: ../src/common/prntbase.cpp:560
 #, c-format
 msgid "Printing page %d"
 msgstr "Seite %d wird gedruckt"
 
-#: ../src/common/prntbase.cpp:570
+#: ../src/common/prntbase.cpp:565
 #, c-format
 msgid "Printing page %d of %d"
 msgstr "Drucke Seite %d von %d"
 
-#: ../src/generic/printps.cpp:201
+#: ../src/generic/printps.cpp:182
 #, c-format
 msgid "Printing page %d..."
 msgstr "Drucke Seite %d …"
 
-#: ../src/generic/printps.cpp:161
+#: ../src/generic/printps.cpp:142
 msgid "Printing..."
 msgstr "Drucke …"
 
-#: ../include/wx/richtext/richtextprint.h:109 ../include/wx/prntbase.h:267
-#: ../src/common/docview.cpp:2132
+#: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
+#: ../src/common/docview.cpp:2137
 msgid "Printout"
 msgstr "Ausdruck"
 
-#: ../src/common/debugrpt.cpp:560
+#: ../src/common/debugrpt.cpp:561
 #, c-format
 msgid ""
 "Processing debug report has failed, leaving the files in \"%s\" directory."
@@ -5921,104 +6082,104 @@ msgstr ""
 "Bearbeitung des Fehlerberichts fehlgeschlagen, belasse die Dateien im Ordner "
 "„%s“."
 
-#: ../src/common/prntbase.cpp:545
+#: ../src/common/prntbase.cpp:540
 msgid "Progress:"
 msgstr "Fortschritt:"
 
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181
 msgid "Properties"
 msgstr "Eigenschaften"
 
-#: ../src/propgrid/manager.cpp:237
+#: ../src/propgrid/manager.cpp:223
 msgid "Property"
 msgstr "Eigenschaft"
 
 #. TRANSLATORS: Caption of message box displaying any property error
-#: ../src/propgrid/propgrid.cpp:3185 ../src/propgrid/propgrid.cpp:3318
+#: ../src/propgrid/propgrid.cpp:3162 ../src/propgrid/propgrid.cpp:3299
 msgid "Property Error"
 msgstr "Eigenschaftsfehler"
 
-#: ../src/propgrid/advprops.cpp:1597
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Purple"
 msgstr "Violett"
 
-#: ../src/common/paper.cpp:112
+#: ../src/common/paper.cpp:109
 msgid "Quarto, 215 x 275 mm"
 msgstr "Quarto, 215 × 275 mm"
 
-#: ../src/generic/logg.cpp:1016
+#: ../src/generic/logg.cpp:1013
 msgid "Question"
 msgstr "Frage"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1769
+#: ../src/propgrid/advprops.cpp:1670
 msgid "Question Arrow"
 msgstr "Fragepfeil"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "Quit"
 msgstr "Beenden"
 
-#: ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:477
 #, c-format
 msgid "Quit %s"
 msgstr "%s beenden"
 
-#: ../src/common/stockitem.cpp:263
+#: ../src/common/stockitem.cpp:261
 msgid "Quit this program"
 msgstr "Dieses Programm beenden"
 
-#: ../src/common/accelcmn.cpp:338
+#: ../src/common/accelcmn.cpp:352
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/ffile.cpp:109 ../src/common/ffile.cpp:133
+#: ../src/common/ffile.cpp:107 ../src/common/ffile.cpp:132
 #, c-format
 msgid "Read error on file '%s'"
 msgstr "Lesefehler in Datei „%s“"
 
-#: ../src/common/secretstore.cpp:199
-#, c-format
-msgid "Reading password for \"%s/%s\" failed: %s."
+#: ../src/common/secretstore.cpp:211
+#, fuzzy, c-format
+msgid "Reading password for \"%s\" failed: %s."
 msgstr "Lesen des Passwortes für „%s/%s“ fehlgeschlagen: %s."
 
-#: ../src/common/prntbase.cpp:272
+#: ../src/common/prntbase.cpp:267
 msgid "Ready"
 msgstr "Bereit"
 
-#: ../src/propgrid/advprops.cpp:1605
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Red"
 msgstr "Rot"
 
-#: ../src/generic/colrdlgg.cpp:339
+#: ../src/generic/colrdlgg.cpp:359
 msgid "Red:"
 msgstr "Rot:"
 
-#: ../src/common/stockitem.cpp:185 ../src/stc/stc_i18n.cpp:16
+#: ../src/common/stockitem.cpp:182 ../src/stc/stc_i18n.cpp:16
 msgid "Redo"
 msgstr "Wiederholen"
 
-#: ../src/common/stockitem.cpp:264
+#: ../src/common/stockitem.cpp:262
 msgid "Redo last action"
 msgstr "Letzte Aktion wiederholen"
 
-#: ../src/common/stockitem.cpp:186
+#: ../src/common/stockitem.cpp:183
 msgid "Refresh"
 msgstr "Aktualisiere"
 
-#: ../src/msw/registry.cpp:626
+#: ../src/msw/registry.cpp:615
 #, c-format
 msgid "Registry key '%s' already exists."
 msgstr "Registrierungsschlüssel „%s“ bereits vorhanden."
 
-#: ../src/msw/registry.cpp:595
+#: ../src/msw/registry.cpp:584
 #, c-format
 msgid "Registry key '%s' does not exist, cannot rename it."
 msgstr ""
 "Registrierungsschlüssel „%s“ existiert nicht, Umbenennung daher nicht "
 "möglich."
 
-#: ../src/msw/registry.cpp:727
+#: ../src/msw/registry.cpp:716
 #, c-format
 msgid ""
 "Registry key '%s' is needed for normal system operation,\n"
@@ -6029,22 +6190,22 @@ msgstr ""
 "durch seine Entfernung wird das System unbrauchbar:\n"
 "Abbruch."
 
-#: ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:942
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr "Registrierungswert „%s“ ist nicht binär (ist aber von der Art %s)"
 
-#: ../src/msw/registry.cpp:917
+#: ../src/msw/registry.cpp:905
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr "Registrierungswert „%s“ ist nicht numerisch (ist aber von der Art %s)"
 
-#: ../src/msw/registry.cpp:1003
+#: ../src/msw/registry.cpp:991
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr "Registrierungswert „%s“ ist kein Text (ist aber von der Art %s)"
 
-#: ../src/msw/registry.cpp:521
+#: ../src/msw/registry.cpp:510
 #, c-format
 msgid "Registry value '%s' already exists."
 msgstr "Registrierungswert „%s“ bereits vorhanden."
@@ -6058,71 +6219,77 @@ msgstr "Regulär"
 msgid "Relative"
 msgstr "Relativ"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:456
 msgid "Relevant entries:"
 msgstr "Relevante Einträge:"
 
-#: ../include/wx/generic/progdlgg.h:86
+#: ../include/wx/generic/progdlgg.h:87
 msgid "Remaining time:"
 msgstr "Verbleibende Zeit:"
 
-#: ../src/common/stockitem.cpp:187
+#: ../src/common/stockitem.cpp:184
 msgid "Remove"
 msgstr "Entfernen"
 
-#: ../src/richtext/richtextctrl.cpp:1562
+#: ../src/richtext/richtextctrl.cpp:1563
 msgid "Remove Bullet"
 msgstr "Gliederungspunkt entfernen"
 
-#: ../src/html/helpwnd.cpp:433
+#: ../src/html/helpwnd.cpp:431
 msgid "Remove current page from bookmarks"
 msgstr "Aktuelle Seite aus Lesezeichen entfernen"
 
-#: ../src/common/rendcmn.cpp:194
+#: ../src/common/rendcmn.cpp:191
 #, c-format
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 "Renderer „%s“ hat eine ungültige Version %d.%d und kann nicht geladen werden."
 
-#: ../src/richtext/richtextbuffer.cpp:4527
+#: ../src/richtext/richtextbuffer.cpp:4524
 msgid "Renumber List"
 msgstr "Liste neu nummerieren"
 
-#: ../src/common/stockitem.cpp:188
-msgid "Rep&lace"
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Rep&lace..."
 msgstr "&Ersetzen"
 
-#: ../src/richtext/richtextctrl.cpp:3673 ../src/common/stockitem.cpp:188
+#: ../src/richtext/richtextctrl.cpp:3674
 msgid "Replace"
 msgstr "Ersetzen"
 
-#: ../src/generic/fdrepdlg.cpp:182
+#: ../src/generic/fdrepdlg.cpp:179
 msgid "Replace &all"
 msgstr "Alle &ersetzen"
 
-#: ../src/common/stockitem.cpp:261
-msgid "Replace selection"
-msgstr "Auswahl ersetzen"
-
-#: ../src/generic/fdrepdlg.cpp:124
+#: ../src/generic/fdrepdlg.cpp:121
 msgid "Replace with:"
 msgstr "Ersetzen durch:"
 
-#: ../src/common/valtext.cpp:163
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Replace..."
+msgstr "Ersetzen"
+
+#: ../src/common/valtext.cpp:184
 msgid "Required information entry is empty."
 msgstr "Erforderlicher Informationseintrag ist leer."
 
-#: ../src/common/translation.cpp:1975
+#: ../src/common/translation.cpp:2025
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "Ressource „%s“ ist kein gültiger Nachrichtenkatalog."
 
+#: ../src/gtk/webview_webkit.cpp:985
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:56
+#: ../src/common/accelcmn.cpp:53
 msgid "Return"
 msgstr "Eingabe"
 
-#: ../src/common/stockitem.cpp:189
+#: ../src/common/stockitem.cpp:186
 msgid "Revert to Saved"
 msgstr "Gespeicherte Version wiederherstellen"
 
@@ -6134,41 +6301,41 @@ msgstr "Grat"
 msgid "Rig&ht-to-left"
 msgstr "Rec&hts nach links"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6149
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:59 ../src/generic/datavgen.cpp:6954
+#: ../src/richtext/richtextsizepage.cpp:250
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextbulletspage.cpp:188
-#: ../src/richtext/richtextsizepage.cpp:250 ../src/common/accelcmn.cpp:62
 msgid "Right"
 msgstr "Rechts"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1754
+#: ../src/propgrid/advprops.cpp:1655
 msgid "Right Arrow"
 msgstr "Rechts-Pfeil"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1770
+#: ../src/propgrid/advprops.cpp:1671
 msgid "Right Button"
 msgstr "Rechts-Taste"
 
-#: ../src/generic/prntdlgg.cpp:892
+#: ../src/generic/prntdlgg.cpp:885
 msgid "Right margin (mm):"
 msgstr "Rechter Rand (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:148
-#: ../src/richtext/richtextindentspage.cpp:150
 #: ../src/richtext/richtextliststylepage.cpp:337
 #: ../src/richtext/richtextliststylepage.cpp:339
+#: ../src/richtext/richtextindentspage.cpp:148
+#: ../src/richtext/richtextindentspage.cpp:150
 msgid "Right-align text."
 msgstr "Rechtsbündiger Text."
 
-#: ../src/generic/fontdlgg.cpp:322
+#: ../src/generic/fontdlgg.cpp:318
 msgid "Roman"
 msgstr "Roman"
 
-#: ../src/generic/datavgen.cpp:5916
+#: ../src/generic/datavgen.cpp:6721
 #, c-format
 msgid "Row %i"
 msgstr "Zeile %i"
@@ -6178,30 +6345,31 @@ msgstr "Zeile %i"
 msgid "S&tandard bullet name:"
 msgstr "&Vordefinierter Gliederungspunkt:"
 
-#: ../src/common/accelcmn.cpp:268 ../src/common/accelcmn.cpp:350
+#: ../src/common/accelcmn.cpp:282 ../src/common/accelcmn.cpp:367
 msgid "SPECIAL"
 msgstr "SPEZIAL"
 
-#: ../src/common/stockitem.cpp:190 ../src/common/sizer.cpp:2797
+#: ../src/common/stockitem.cpp:187 ../src/common/sizer.cpp:2914
 msgid "Save"
 msgstr "Speichern"
 
-#: ../src/common/fldlgcmn.cpp:342
+#: ../src/common/fldlgcmn.cpp:339
 #, c-format
 msgid "Save %s file"
 msgstr "Datei %s speichern"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/common/stockitem.cpp:188 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Speichern &unter …"
 
-#: ../src/common/docview.cpp:366
+#: ../src/common/docview.cpp:359
 msgid "Save As"
 msgstr "Speichern unter"
 
-#: ../src/common/stockitem.cpp:191
-msgid "Save as"
-msgstr "Speichern unter"
+#: ../src/common/stockitem.cpp:188
+#, fuzzy
+msgid "Save As..."
+msgstr "Speichern &unter …"
 
 #: ../src/common/stockitem.cpp:267
 msgid "Save current document"
@@ -6211,40 +6379,40 @@ msgstr "Aktuelles Dokument speichern"
 msgid "Save current document with a different filename"
 msgstr "Aktuelles Dokument mit einen anderen Dateinamen speichern"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/generic/logg.cpp:509
 msgid "Save log contents to file"
 msgstr "Logtexte in Datei speichern"
 
-#: ../src/common/secretstore.cpp:179
-#, c-format
-msgid "Saving password for \"%s/%s\" failed: %s."
+#: ../src/common/secretstore.cpp:189
+#, fuzzy, c-format
+msgid "Saving password for \"%s\" failed: %s."
 msgstr "Speichern des Passwortes für „%s/%s“ fehlgeschlagen: %s."
 
-#: ../src/generic/fontdlgg.cpp:325
+#: ../src/generic/fontdlgg.cpp:321
 msgid "Script"
 msgstr "Skript"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll Lock"
 msgstr "Rollen-Taste"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll_lock"
 msgstr "Rollen-Taste"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:890
+#: ../src/propgrid/advprops.cpp:791
 msgid "Scrollbar"
 msgstr "Bildlaufleiste"
 
-#: ../src/generic/srchctlg.cpp:56 ../src/html/helpwnd.cpp:535
-#: ../src/html/helpwnd.cpp:550
+#: ../src/generic/srchctlg.cpp:55 ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:548 ../src/gtk/srchctrl.cpp:182
 msgid "Search"
 msgstr "Suchen"
 
-#: ../src/html/helpwnd.cpp:537
+#: ../src/html/helpwnd.cpp:535
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
@@ -6252,32 +6420,32 @@ msgstr ""
 "Den Inhalt der Hilfebücher nach allen Vorkommen des oben eingegebenen "
 "Begriffs durchsuchen"
 
-#: ../src/generic/fdrepdlg.cpp:160
+#: ../src/generic/fdrepdlg.cpp:157
 msgid "Search direction"
 msgstr "Suchrichtung"
 
-#: ../src/generic/fdrepdlg.cpp:112
+#: ../src/generic/fdrepdlg.cpp:109
 msgid "Search for:"
 msgstr "Suchen nach:"
 
-#: ../src/html/helpwnd.cpp:1052
+#: ../src/html/helpwnd.cpp:1050
 msgid "Search in all books"
 msgstr "Alle Bücher durchsuchen"
 
-#: ../src/html/helpwnd.cpp:857
+#: ../src/html/helpwnd.cpp:855
 msgid "Searching..."
 msgstr "Suchen …"
 
-#: ../src/generic/dirctrlg.cpp:446
+#: ../src/generic/dirctrlg.cpp:412
 msgid "Sections"
 msgstr "Abschnitte"
 
-#: ../src/common/ffile.cpp:238
+#: ../src/common/ffile.cpp:237
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Suchfehler in Datei „%s“"
 
-#: ../src/common/ffile.cpp:228
+#: ../src/common/ffile.cpp:227
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
@@ -6285,24 +6453,24 @@ msgstr ""
 "unterstützt)."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:76
+#: ../src/common/accelcmn.cpp:73
 msgid "Select"
 msgstr "Auswahl"
 
-#: ../src/richtext/richtextctrl.cpp:337 ../src/osx/textctrl_osx.cpp:581
-#: ../src/common/stockitem.cpp:192 ../src/msw/textctrl.cpp:2512
+#: ../src/osx/textctrl_osx.cpp:599 ../src/common/stockitem.cpp:189
+#: ../src/msw/textctrl.cpp:2777 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "&Alles auswählen"
 
-#: ../src/common/stockitem.cpp:192 ../src/stc/stc_i18n.cpp:21
+#: ../src/common/stockitem.cpp:189 ../src/stc/stc_i18n.cpp:21
 msgid "Select All"
 msgstr "Alles auswählen"
 
-#: ../src/common/docview.cpp:1895
+#: ../src/common/docview.cpp:1900
 msgid "Select a document template"
 msgstr "Dokument-Vorlage wählen"
 
-#: ../src/common/docview.cpp:1969
+#: ../src/common/docview.cpp:1974
 msgid "Select a document view"
 msgstr "Dokument-Anzeige („View“) wählen"
 
@@ -6331,20 +6499,20 @@ msgid "Selects the list level to edit."
 msgstr "Wählt die Listenebene zur Bearbeitung."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:82
+#: ../src/common/accelcmn.cpp:79
 msgid "Separator"
 msgstr "Trennzeichen"
 
-#: ../src/common/cmdline.cpp:1083
+#: ../src/common/cmdline.cpp:1079
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Trennungszeichen nach der Option „%s“ erwartet."
 
-#: ../src/osx/menu_osx.cpp:572
+#: ../src/osx/menu_osx.cpp:464
 msgid "Services"
 msgstr "Dienste"
 
-#: ../src/richtext/richtextbuffer.cpp:11217
+#: ../src/richtext/richtextbuffer.cpp:11216
 msgid "Set Cell Style"
 msgstr "Stil der Zelle einstellen"
 
@@ -6352,11 +6520,11 @@ msgstr "Stil der Zelle einstellen"
 msgid "SetProperty called w/o valid setter"
 msgstr "SetProperty aufgerufen ohne gültigen Setter"
 
-#: ../src/generic/prntdlgg.cpp:188
+#: ../src/generic/prntdlgg.cpp:181
 msgid "Setup..."
 msgstr "Einstellungen …"
 
-#: ../src/msw/dialup.cpp:544
+#: ../src/msw/dialup.cpp:538
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr ""
 "Mehrere aktive DFÜ-Verbindungen gefunden, eine davon wird zufällig "
@@ -6374,40 +6542,40 @@ msgstr "Schatten"
 msgid "Shadow c&olour:"
 msgstr "Schattenf&arbe:"
 
-#: ../src/common/accelcmn.cpp:335
+#: ../src/common/accelcmn.cpp:349
 msgid "Shift+"
 msgstr "Umschalt+"
 
-#: ../src/generic/dirdlgg.cpp:147
+#: ../src/generic/dirdlgg.cpp:144
 msgid "Show &hidden directories"
 msgstr "Versteckte Verzeic&hnisse anzeigen"
 
-#: ../src/generic/filectrlg.cpp:983
+#: ../src/generic/filectrlg.cpp:979
 msgid "Show &hidden files"
 msgstr "V&ersteckte Dateien anzeigen"
 
-#: ../src/osx/menu_osx.cpp:580
+#: ../src/osx/menu_osx.cpp:472
 msgid "Show All"
 msgstr "Alles zeigen"
 
-#: ../src/common/stockitem.cpp:257
+#: ../src/common/stockitem.cpp:254
 msgid "Show about dialog"
 msgstr "Zeige den „Über“-Dialog"
 
-#: ../src/html/helpwnd.cpp:492
+#: ../src/html/helpwnd.cpp:490
 msgid "Show all"
 msgstr "Alles zeigen"
 
-#: ../src/html/helpwnd.cpp:503
+#: ../src/html/helpwnd.cpp:501
 msgid "Show all items in index"
 msgstr "Alle Themen im Index anzeigen"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:656
 msgid "Show/hide navigation panel"
 msgstr "Suchbaum ein-/ausblenden"
 
-#: ../src/richtext/richtextsymboldlg.cpp:421
-#: ../src/richtext/richtextsymboldlg.cpp:423
+#: ../src/richtext/richtextsymboldlg.cpp:418
+#: ../src/richtext/richtextsymboldlg.cpp:420
 msgid "Shows a Unicode subset."
 msgstr "Zeigt einen Unicode-Teilzeichensatz."
 
@@ -6423,7 +6591,7 @@ msgstr "Zeigt eine Vorschau der Gliederungspunkteinstellungen."
 msgid "Shows a preview of the font settings."
 msgstr "Zeigt eine Vorschau der Schriftarteinstellungen."
 
-#: ../src/osx/carbon/fontdlg.cpp:394 ../src/osx/carbon/fontdlg.cpp:396
+#: ../src/osx/carbon/fontdlg.cpp:391 ../src/osx/carbon/fontdlg.cpp:393
 msgid "Shows a preview of the font."
 msgstr "Zeigt eine Vorschau der Schriftart."
 
@@ -6432,66 +6600,66 @@ msgstr "Zeigt eine Vorschau der Schriftart."
 msgid "Shows a preview of the paragraph settings."
 msgstr "Zeigt eine Vorschau der Absatzeinstellungen."
 
-#: ../src/generic/fontdlgg.cpp:460 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:456 ../src/generic/fontdlgg.cpp:458
 msgid "Shows the font preview."
 msgstr "Zeigt die Schriftvorschau."
 
-#: ../src/propgrid/advprops.cpp:1607
+#: ../src/propgrid/advprops.cpp:1513
 msgid "Silver"
 msgstr "Silber"
 
-#: ../src/univ/themes/mono.cpp:516
+#: ../src/univ/themes/mono.cpp:513
 msgid "Simple monochrome theme"
 msgstr "Einfaches einfarbiges Thema"
 
-#: ../src/richtext/richtextindentspage.cpp:275
 #: ../src/richtext/richtextliststylepage.cpp:449
+#: ../src/richtext/richtextindentspage.cpp:275
 msgid "Single"
 msgstr "Einzel"
 
-#: ../src/generic/filectrlg.cpp:425 ../src/richtext/richtextformatdlg.cpp:369
-#: ../src/richtext/richtextsizepage.cpp:299
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextsizepage.cpp:299
+#: ../src/richtext/richtextformatdlg.cpp:362
 msgid "Size"
 msgstr "Größe"
 
-#: ../src/osx/carbon/fontdlg.cpp:339
+#: ../src/osx/carbon/fontdlg.cpp:336
 msgid "Size:"
 msgstr "Größe:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1775
+#: ../src/propgrid/advprops.cpp:1676
 msgid "Sizing"
 msgstr "Größenänderung"
 
 # Ein Cursor für die Größenänderung, dessen Pfeile von Norden nach Süden zeigen
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1772
+#: ../src/propgrid/advprops.cpp:1673
 msgid "Sizing N-S"
 msgstr "Größenänderung N-S"
 
 # Ein Cursor für die Größenänderung, dessen Pfeile von NO nach SW zeigen
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1771
+#: ../src/propgrid/advprops.cpp:1672
 msgid "Sizing NE-SW"
 msgstr "Größenänderung NO-SW"
 
 # Ein Cursor für die Größenänderung, dessen Pfeile von NW nach SO zeigen
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1773
+#: ../src/propgrid/advprops.cpp:1674
 msgid "Sizing NW-SE"
 msgstr "Größenänderung NW-SO"
 
 # Ein Cursor für die Größenänderung, dessen Pfeile von W nach O zeigen
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1774
+#: ../src/propgrid/advprops.cpp:1675
 msgid "Sizing W-E"
 msgstr "Größenänderung W-O"
 
-#: ../src/msw/progdlg.cpp:801
+#: ../src/msw/progdlg.cpp:1088
 msgid "Skip"
 msgstr "Überspringen"
 
-#: ../src/generic/fontdlgg.cpp:330
+#: ../src/generic/fontdlgg.cpp:326
 msgid "Slant"
 msgstr "Geneigt"
 
@@ -6500,7 +6668,7 @@ msgid "Small C&apitals"
 msgstr "Ka&pitälchen"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:79
+#: ../src/common/accelcmn.cpp:76
 msgid "Snapshot"
 msgstr "Drucktaste"
 
@@ -6508,37 +6676,37 @@ msgstr "Drucktaste"
 msgid "Solid"
 msgstr "Fett"
 
-#: ../src/common/docview.cpp:1791
+#: ../src/common/docview.cpp:1785
 msgid "Sorry, could not open this file."
 msgstr "Datei konnte nicht geöffnet werden."
 
-#: ../src/common/prntbase.cpp:2057 ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2079 ../src/common/prntbase.cpp:2087
 msgid "Sorry, not enough memory to create a preview."
 msgstr "Nicht genug Speicher für Vorschau."
 
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "Sorry, that name is taken. Please choose another."
 msgstr "Name bereits vergeben. Bitte anderen auswählen."
 
-#: ../src/common/docview.cpp:1814
+#: ../src/common/docview.cpp:1819
 msgid "Sorry, the format for this file is unknown."
 msgstr "Unbekanntes Dateiformat."
 
-#: ../src/unix/sound.cpp:492
+#: ../src/unix/sound.cpp:481
 msgid "Sound data are in unsupported format."
 msgstr "Klangdaten haben ein nicht unterstütztes Format."
 
-#: ../src/unix/sound.cpp:477
+#: ../src/unix/sound.cpp:466
 #, c-format
 msgid "Sound file '%s' is in unsupported format."
 msgstr "Klangdatei „%s“ besitzt ein nicht unterstütztes Format."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:67
+#: ../src/common/accelcmn.cpp:64
 msgid "Space"
 msgstr "Leer"
 
@@ -6546,12 +6714,12 @@ msgstr "Leer"
 msgid "Spacing"
 msgstr "Zwischenraum"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "Spell Check"
 msgstr "Rechtschreibprüfung"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1776
+#: ../src/propgrid/advprops.cpp:1677
 msgid "Spraycan"
 msgstr "Sprühdose"
 
@@ -6560,7 +6728,7 @@ msgstr "Sprühdose"
 msgid "Standard"
 msgstr "Standard"
 
-#: ../src/common/paper.cpp:104
+#: ../src/common/paper.cpp:101
 msgid "Statement, 5 1/2 x 8 1/2 in"
 msgstr "Statement, 5 1/2 × 8 1/2 Zoll"
 
@@ -6569,33 +6737,29 @@ msgstr "Statement, 5 1/2 × 8 1/2 Zoll"
 msgid "Static"
 msgstr "Statisch"
 
-#: ../src/generic/prntdlgg.cpp:204
+#: ../src/generic/prntdlgg.cpp:197
 msgid "Status:"
 msgstr "Status:"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "Stop"
 msgstr "Stopp"
 
-#: ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196
 msgid "Strikethrough"
 msgstr "Durchstreichen"
 
-#: ../src/common/colourcmn.cpp:45
+#: ../src/common/colourcmn.cpp:42
 #, c-format
 msgid "String To Colour : Incorrect colour specification : %s"
 msgstr "String To Colour: Falsche Farbangabe „%s“"
 
 #. TRANSLATORS: Label of font style
-#: ../src/richtext/richtextformatdlg.cpp:339 ../src/propgrid/advprops.cpp:680
+#: ../src/propgrid/advprops.cpp:590 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Stil"
 
-#: ../include/wx/richtext/richtextstyledlg.h:46
-msgid "Style Organiser"
-msgstr "Stil-Organisator"
-
-#: ../src/osx/carbon/fontdlg.cpp:348
+#: ../src/osx/carbon/fontdlg.cpp:345
 msgid "Style:"
 msgstr "Stil:"
 
@@ -6604,7 +6768,7 @@ msgid "Subscrip&t"
 msgstr "Tiefgestell&t"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:83
+#: ../src/common/accelcmn.cpp:80
 msgid "Subtract"
 msgstr "Minus"
 
@@ -6612,11 +6776,11 @@ msgstr "Minus"
 msgid "Supe&rscript"
 msgstr "Hochge&stellt"
 
-#: ../src/common/paper.cpp:150
+#: ../src/common/paper.cpp:147
 msgid "SuperA/SuperA/A4 227 x 356 mm"
 msgstr "SuperA/SuperA/A4 227 × 356 mm"
 
-#: ../src/common/paper.cpp:151
+#: ../src/common/paper.cpp:148
 msgid "SuperB/SuperB/A3 305 x 487 mm"
 msgstr "SuperB/SuperB/A3 305 × 487 mm"
 
@@ -6624,7 +6788,7 @@ msgstr "SuperB/SuperB/A3 305 × 487 mm"
 msgid "Suppress hyphe&nation"
 msgstr "Silbe&ntrennung unterdrücken"
 
-#: ../src/generic/fontdlgg.cpp:326
+#: ../src/generic/fontdlgg.cpp:322
 msgid "Swiss"
 msgstr "Swiss"
 
@@ -6642,74 +6806,74 @@ msgstr "Symbolschri&ftart:"
 msgid "Symbols"
 msgstr "Symbole"
 
-#: ../src/common/imagtiff.cpp:369 ../src/common/imagtiff.cpp:382
-#: ../src/common/imagtiff.cpp:741
+#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
+#: ../src/common/imagtiff.cpp:738
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: Speicheranforderung fehlgeschlagen."
 
-#: ../src/common/imagtiff.cpp:301
+#: ../src/common/imagtiff.cpp:298
 msgid "TIFF: Error loading image."
 msgstr "TIFF: Fehler beim Laden des Bildes."
 
-#: ../src/common/imagtiff.cpp:468
+#: ../src/common/imagtiff.cpp:465
 msgid "TIFF: Error reading image."
 msgstr "TIFF: Fehler beim Lesen des Bildes."
 
-#: ../src/common/imagtiff.cpp:608
+#: ../src/common/imagtiff.cpp:605
 msgid "TIFF: Error saving image."
 msgstr "TIFF: Schreibfehler beim Speichern."
 
-#: ../src/common/imagtiff.cpp:846
+#: ../src/common/imagtiff.cpp:843
 msgid "TIFF: Error writing image."
 msgstr "TIFF: Schreibfehler beim Speichern."
 
-#: ../src/common/imagtiff.cpp:355
+#: ../src/common/imagtiff.cpp:352
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: Bildgröße ist außergewöhnlich groß."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:68
+#: ../src/common/accelcmn.cpp:65
 msgid "Tab"
 msgstr "Tabulator"
 
-#: ../src/richtext/richtextbuffer.cpp:11498
+#: ../src/richtext/richtextbuffer.cpp:11497
 msgid "Table Properties"
 msgstr "Tabelleneigenschaften"
 
-#: ../src/common/paper.cpp:145
+#: ../src/common/paper.cpp:142
 msgid "Tabloid Extra 11.69 x 18 in"
 msgstr "Tabloid Extra 11.69 × 18 Zoll"
 
-#: ../src/common/paper.cpp:102
+#: ../src/common/paper.cpp:99
 msgid "Tabloid, 11 x 17 in"
 msgstr "Tabloid, 11 × 17 Zoll"
 
-#: ../src/richtext/richtextformatdlg.cpp:354
+#: ../src/richtext/richtextformatdlg.cpp:347
 msgid "Tabs"
 msgstr "Tabulatoren"
 
 # http://bfw.ac.at/020/farbtabelle.html
-#: ../src/propgrid/advprops.cpp:1598
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Teal"
 msgstr "Entenbraun"
 
-#: ../src/generic/fontdlgg.cpp:327
+#: ../src/generic/fontdlgg.cpp:323
 msgid "Teletype"
 msgstr "Schreibmaschine"
 
-#: ../src/common/docview.cpp:1896
+#: ../src/common/docview.cpp:1901
 msgid "Templates"
 msgstr "Vorlagen"
 
-#: ../src/common/fmapbase.cpp:158
+#: ../src/common/fmapbase.cpp:155
 msgid "Thai (ISO-8859-11)"
 msgstr "Thai (ISO-8859-11)"
 
-#: ../src/common/ftp.cpp:619
+#: ../src/common/ftp.cpp:622
 msgid "The FTP server doesn't support passive mode."
 msgstr "Der FTP-Server unterstützt keinen passiven Transfermodus."
 
-#: ../src/common/ftp.cpp:605
+#: ../src/common/ftp.cpp:608
 msgid "The FTP server doesn't support the PORT command."
 msgstr "Der FTP-Server unterstützt nicht das PORT-Kommando."
 
@@ -6720,8 +6884,8 @@ msgstr "Der FTP-Server unterstützt nicht das PORT-Kommando."
 msgid "The available bullet styles."
 msgstr "Die verfügbaren Gliederungspunktstile."
 
-#: ../src/richtext/richtextstyledlg.cpp:202
-#: ../src/richtext/richtextstyledlg.cpp:204
+#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:200
 msgid "The available styles."
 msgstr "Die verfügbaren Schriftarten."
 
@@ -6777,12 +6941,12 @@ msgstr "Abstand nach unten."
 msgid "The bullet character."
 msgstr "Die Gliederungspunktzeichen."
 
-#: ../src/richtext/richtextsymboldlg.cpp:443
-#: ../src/richtext/richtextsymboldlg.cpp:445
+#: ../src/richtext/richtextsymboldlg.cpp:440
+#: ../src/richtext/richtextsymboldlg.cpp:442
 msgid "The character code."
 msgstr "Der Zeichencode."
 
-#: ../src/common/fontmap.cpp:203
+#: ../src/common/fontmap.cpp:200
 #, c-format
 msgid ""
 "The charset '%s' is unknown. You may select\n"
@@ -6793,7 +6957,7 @@ msgstr ""
 "einen Ersatzzeichensatz oder „Abbrechen“, \n"
 "falls er nicht ersetzt werden kann"
 
-#: ../src/msw/ole/dataobj.cpp:394
+#: ../src/msw/ole/dataobj.cpp:402
 #, c-format
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "Das Format „%d“ für die Zwischenablage existiert nicht."
@@ -6803,7 +6967,7 @@ msgstr "Das Format „%d“ für die Zwischenablage existiert nicht."
 msgid "The default style for the next paragraph."
 msgstr "Der voreingestellte Stil für den nächsten Absatz."
 
-#: ../src/generic/dirdlgg.cpp:202
+#: ../src/generic/dirdlgg.cpp:199
 #, c-format
 msgid ""
 "The directory '%s' does not exist\n"
@@ -6812,7 +6976,7 @@ msgstr ""
 "Verzeichnis „%s“ existiert nicht.\n"
 "Soll es jetzt erstellt werden?"
 
-#: ../src/html/htmprint.cpp:271
+#: ../src/html/htmprint.cpp:283
 #, c-format
 msgid ""
 "The document \"%s\" doesn't fit on the page horizontally and will be "
@@ -6825,7 +6989,7 @@ msgstr ""
 "\n"
 "Wollen Sie dennoch mit dem Drucken fortfahren?"
 
-#: ../src/common/docview.cpp:1202
+#: ../src/common/docview.cpp:1196
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -6834,37 +6998,36 @@ msgstr ""
 "Die Datei „%s“ existiert nicht und konnte nicht geöffnet werden.\n"
 "Sie wurde aus der Liste kürzlich verwendeter Dateien entfernt."
 
-#: ../src/richtext/richtextindentspage.cpp:208
-#: ../src/richtext/richtextindentspage.cpp:210
 #: ../src/richtext/richtextliststylepage.cpp:394
 #: ../src/richtext/richtextliststylepage.cpp:396
+#: ../src/richtext/richtextindentspage.cpp:208
+#: ../src/richtext/richtextindentspage.cpp:210
 msgid "The first line indent."
 msgstr "Der Ersteinzug."
 
-#: ../src/gtk/utilsgtk.cpp:481
-msgid "The following standard GTK+ options are also supported:\n"
+#: ../src/generic/dbgrptg.cpp:318
+msgid "The following debug report will be generated\n"
 msgstr ""
-"Die nachfolgenden Standard GTK+ Optionen werden ebenfalls unterstützt:\n"
 
-#: ../src/generic/fontdlgg.cpp:414 ../src/generic/fontdlgg.cpp:416
+#: ../src/generic/fontdlgg.cpp:411 ../src/generic/fontdlgg.cpp:413
 msgid "The font colour."
 msgstr "Die Schriftfarbe."
 
-#: ../src/generic/fontdlgg.cpp:375 ../src/generic/fontdlgg.cpp:377
+#: ../src/generic/fontdlgg.cpp:371 ../src/generic/fontdlgg.cpp:373
 msgid "The font family."
 msgstr "Die Schriftart."
 
-#: ../src/richtext/richtextsymboldlg.cpp:405
-#: ../src/richtext/richtextsymboldlg.cpp:407
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "The font from which to take the symbol."
 msgstr "Die Schriftart aus der das Symbol entnommen wurde."
 
-#: ../src/generic/fontdlgg.cpp:427 ../src/generic/fontdlgg.cpp:429
-#: ../src/generic/fontdlgg.cpp:434 ../src/generic/fontdlgg.cpp:436
+#: ../src/generic/fontdlgg.cpp:424 ../src/generic/fontdlgg.cpp:426
+#: ../src/generic/fontdlgg.cpp:430 ../src/generic/fontdlgg.cpp:432
 msgid "The font point size."
 msgstr "Die Schriftgröße in Punkt."
 
-#: ../src/osx/carbon/fontdlg.cpp:343 ../src/osx/carbon/fontdlg.cpp:345
+#: ../src/osx/carbon/fontdlg.cpp:340 ../src/osx/carbon/fontdlg.cpp:342
 msgid "The font size in points."
 msgstr "Die Schriftgröße in Punkt."
 
@@ -6873,15 +7036,15 @@ msgstr "Die Schriftgröße in Punkt."
 msgid "The font size units, points or pixels."
 msgstr "Einheit der Schriftgröße in Punkt oder Pixel."
 
-#: ../src/generic/fontdlgg.cpp:386 ../src/generic/fontdlgg.cpp:388
+#: ../src/generic/fontdlgg.cpp:382 ../src/generic/fontdlgg.cpp:384
 msgid "The font style."
 msgstr "Der Schriftschnitt."
 
-#: ../src/generic/fontdlgg.cpp:397 ../src/generic/fontdlgg.cpp:399
+#: ../src/generic/fontdlgg.cpp:393 ../src/generic/fontdlgg.cpp:395
 msgid "The font weight."
 msgstr "Die Schriftdicke."
 
-#: ../src/common/docview.cpp:1483
+#: ../src/common/docview.cpp:1477
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Das Format der Datei „%s“ konnte nicht bestimmt werden."
@@ -6891,10 +7054,10 @@ msgstr "Das Format der Datei „%s“ konnte nicht bestimmt werden."
 msgid "The horizontal offset."
 msgstr "Der horizontale Versatz."
 
-#: ../src/richtext/richtextindentspage.cpp:199
-#: ../src/richtext/richtextindentspage.cpp:201
 #: ../src/richtext/richtextliststylepage.cpp:385
 #: ../src/richtext/richtextliststylepage.cpp:387
+#: ../src/richtext/richtextindentspage.cpp:199
+#: ../src/richtext/richtextindentspage.cpp:201
 msgid "The left indent."
 msgstr "Der Linkseinzug."
 
@@ -6915,10 +7078,10 @@ msgstr "Die linke Auffüllung."
 msgid "The left position."
 msgstr "Abstand nach links."
 
-#: ../src/richtext/richtextindentspage.cpp:288
-#: ../src/richtext/richtextindentspage.cpp:290
 #: ../src/richtext/richtextliststylepage.cpp:462
 #: ../src/richtext/richtextliststylepage.cpp:464
+#: ../src/richtext/richtextindentspage.cpp:288
+#: ../src/richtext/richtextindentspage.cpp:290
 msgid "The line spacing."
 msgstr "Der Zeilenabstand."
 
@@ -6927,7 +7090,7 @@ msgstr "Der Zeilenabstand."
 msgid "The list item number."
 msgstr "Die Nummer des Listenelements."
 
-#: ../src/msw/ole/automtn.cpp:664
+#: ../src/msw/ole/automtn.cpp:655
 msgid "The locale ID is unknown."
 msgstr "Die lokale ID ist unbekannt."
 
@@ -6966,19 +7129,19 @@ msgstr "Die Objektbreite."
 msgid "The outline level."
 msgstr "Die Umrandungsebene."
 
-#: ../src/common/log.cpp:277
+#: ../src/common/log.cpp:296
 #, c-format
 msgid "The previous message repeated %u time."
 msgid_plural "The previous message repeated %u times."
 msgstr[0] "Die vorangegangene Nachricht wurde %u Mal wiederholt."
 msgstr[1] "Die vorangegangene Nachricht wurde %u Mal wiederholt."
 
-#: ../src/common/log.cpp:270
+#: ../src/common/log.cpp:289
 msgid "The previous message repeated once."
 msgstr "Die vorangegangene Nachricht wurde ein Mal wiederholt."
 
-#: ../src/richtext/richtextsymboldlg.cpp:462
-#: ../src/richtext/richtextsymboldlg.cpp:464
+#: ../src/richtext/richtextsymboldlg.cpp:459
+#: ../src/richtext/richtextsymboldlg.cpp:461
 msgid "The range to show."
 msgstr "Der anzuzeigende Bereich."
 
@@ -6993,15 +7156,15 @@ msgstr ""
 "die vertrauliche Informationen enthalten, nicht ausgewählt sind; sie werden "
 "dann aus dem Fehlerbericht entfernt.\n"
 
-#: ../src/common/cmdline.cpp:1254
+#: ../src/common/cmdline.cpp:1250
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "Der benötigte Parameter „%s“ wurde nicht angegeben."
 
-#: ../src/richtext/richtextindentspage.cpp:217
-#: ../src/richtext/richtextindentspage.cpp:219
 #: ../src/richtext/richtextliststylepage.cpp:403
 #: ../src/richtext/richtextliststylepage.cpp:405
+#: ../src/richtext/richtextindentspage.cpp:217
+#: ../src/richtext/richtextindentspage.cpp:219
 msgid "The right indent."
 msgstr "Der Rechtseinzug."
 
@@ -7042,16 +7205,16 @@ msgstr "Die Schattendeckkraft."
 msgid "The shadow spread."
 msgstr "Die Schatten-Ausbreitung."
 
-#: ../src/richtext/richtextindentspage.cpp:267
 #: ../src/richtext/richtextliststylepage.cpp:439
 #: ../src/richtext/richtextliststylepage.cpp:441
+#: ../src/richtext/richtextindentspage.cpp:267
 msgid "The spacing after the paragraph."
 msgstr "Der Abstand nach einem Absatz."
 
-#: ../src/richtext/richtextindentspage.cpp:257
-#: ../src/richtext/richtextindentspage.cpp:259
 #: ../src/richtext/richtextliststylepage.cpp:430
 #: ../src/richtext/richtextliststylepage.cpp:432
+#: ../src/richtext/richtextindentspage.cpp:257
+#: ../src/richtext/richtextindentspage.cpp:259
 msgid "The spacing before the paragraph."
 msgstr "Der Abstand vor einem Absatz."
 
@@ -7065,12 +7228,12 @@ msgstr "Der Stilname."
 msgid "The style on which this style is based."
 msgstr "Der Stil auf dem dieser Stil basiert."
 
-#: ../src/richtext/richtextstyledlg.cpp:214
-#: ../src/richtext/richtextstyledlg.cpp:216
+#: ../src/richtext/richtextstyledlg.cpp:210
+#: ../src/richtext/richtextstyledlg.cpp:212
 msgid "The style preview."
 msgstr "Die Schriftvorschau."
 
-#: ../src/msw/ole/automtn.cpp:680
+#: ../src/msw/ole/automtn.cpp:671
 msgid "The system cannot find the file specified."
 msgstr "Das System kann die angegebene Datei nicht finden."
 
@@ -7083,7 +7246,7 @@ msgstr "Die Tabulatorposition."
 msgid "The tab positions."
 msgstr "Die Tabulatorpositionen."
 
-#: ../src/richtext/richtextctrl.cpp:3098
+#: ../src/richtext/richtextctrl.cpp:3099
 msgid "The text couldn't be saved."
 msgstr "Der Text konnte nicht gespeichert werden."
 
@@ -7104,7 +7267,7 @@ msgstr "Die obere Füllung."
 msgid "The top position."
 msgstr "Abstand nach oben."
 
-#: ../src/common/cmdline.cpp:1232
+#: ../src/common/cmdline.cpp:1228
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "Der Wert für die Option „%s“ muss angegeben werden."
@@ -7114,7 +7277,7 @@ msgstr "Der Wert für die Option „%s“ muss angegeben werden."
 msgid "The value of the corner radius."
 msgstr "Wert des Eckradius."
 
-#: ../src/msw/dialup.cpp:433
+#: ../src/msw/dialup.cpp:427
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -7129,14 +7292,14 @@ msgstr ""
 msgid "The vertical offset."
 msgstr "Der vertikale Versatz."
 
-#: ../src/richtext/richtextprint.cpp:619 ../src/html/htmprint.cpp:745
+#: ../src/html/htmprint.cpp:749 ../src/richtext/richtextprint.cpp:615
 msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr ""
 "Es gab ein Problem bei der Seiteneinrichtung: eventuell müssen Sie einen\n"
 "Standarddrucker einrichten."
 
-#: ../src/html/htmprint.cpp:255
+#: ../src/html/htmprint.cpp:267
 msgid ""
 "This document doesn't fit on the page horizontally and will be truncated "
 "when it is printed."
@@ -7144,16 +7307,16 @@ msgstr ""
 "Dieses Dokument ist zu breit für die Seite und wird beim Drucken "
 "abgeschnitten."
 
-#: ../src/common/image.cpp:2854
+#: ../src/common/image.cpp:2963
 #, c-format
 msgid "This is not a %s."
 msgstr "Dies ist kein %s."
 
-#: ../src/common/wincmn.cpp:1653
+#: ../src/common/wincmn.cpp:1654
 msgid "This platform does not support background transparency."
 msgstr "Diese Plattform unterstützt keine Hintergrundtransparenz."
 
-#: ../src/gtk/window.cpp:4660
+#: ../src/gtk/window.cpp:5664
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
@@ -7161,7 +7324,15 @@ msgstr ""
 "Dieses Programm wurde mit einer zu alten Version von GTK+ übersetzt, bitte "
 "mit GTK+2.12 oder neuer erstellen."
 
-#: ../src/msw/thread.cpp:1240
+#: ../src/gtk/glcanvas.cpp:176
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/msw/thread.cpp:1246
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -7169,13 +7340,13 @@ msgstr ""
 "Thread-Modul-Initialisierung fehlgeschlagen: Wert konnte nicht im lokalen "
 "Speicherbereich des Thread gespeichert werden"
 
-#: ../src/unix/threadpsx.cpp:1794
+#: ../src/unix/threadpsx.cpp:1843
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 "Thread-Modul-Initialisierung fehlgeschlagen: Thread-Schlüssel konnte nicht "
 "erstellt werden"
 
-#: ../src/msw/thread.cpp:1228
+#: ../src/msw/thread.cpp:1234
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -7183,84 +7354,84 @@ msgstr ""
 "Thread-Modul-Initialisierung fehlgeschlagen: Index konnte nicht im lokalen "
 "Speicherbereich des Thread allokiert werden"
 
-#: ../src/unix/threadpsx.cpp:1043
+#: ../src/unix/threadpsx.cpp:1061
 msgid "Thread priority setting is ignored."
 msgstr "Thread-Prioritätseinstellung wird ignoriert."
 
-#: ../src/msw/mdi.cpp:176
+#: ../src/msw/mdi.cpp:171
 msgid "Tile &Horizontally"
 msgstr "&Horizontal anordnen"
 
-#: ../src/msw/mdi.cpp:177
+#: ../src/msw/mdi.cpp:172
 msgid "Tile &Vertically"
 msgstr "&Vertikal anordnen"
 
-#: ../src/common/ftp.cpp:200
+#: ../src/common/ftp.cpp:197
 msgid "Timeout while waiting for FTP server to connect, try passive mode."
 msgstr ""
 "Timeout beim Warten auf eine Verbindung zum FTP-Server, versuchen Sie "
 "passiven Modus."
 
-#: ../src/generic/tipdlg.cpp:201
+#: ../src/generic/tipdlg.cpp:198
 msgid "Tip of the Day"
 msgstr "Tipp des Tages"
 
-#: ../src/generic/tipdlg.cpp:140
+#: ../src/generic/tipdlg.cpp:137
 msgid "Tips not available, sorry!"
 msgstr "Bedauere, Tipps stehen nicht zur Verfügung!"
 
-#: ../src/generic/prntdlgg.cpp:242
+#: ../src/generic/prntdlgg.cpp:235
 msgid "To:"
 msgstr "Bis:"
 
-#: ../src/richtext/richtextbuffer.cpp:8363
+#: ../src/richtext/richtextbuffer.cpp:8361
 msgid "Too many EndStyle calls!"
 msgstr "Zu viele EndStyle-Aufrufe!"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:891
+#: ../src/propgrid/advprops.cpp:792
 msgid "Tooltip"
 msgstr "Minihilfe"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:892
+#: ../src/propgrid/advprops.cpp:793
 msgid "TooltipText"
 msgstr "Minihilfe-Text"
 
-#: ../src/richtext/richtextsizepage.cpp:286
-#: ../src/richtext/richtextsizepage.cpp:290 ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197 ../src/richtext/richtextsizepage.cpp:286
+#: ../src/richtext/richtextsizepage.cpp:290
 msgid "Top"
 msgstr "Oben"
 
-#: ../src/generic/prntdlgg.cpp:881
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Top margin (mm):"
 msgstr "Oberer Rand (mm):"
 
-#: ../src/generic/aboutdlgg.cpp:79
+#: ../src/generic/aboutdlgg.cpp:76
 msgid "Translations by "
 msgstr "Übersetzungen von "
 
-#: ../src/generic/aboutdlgg.cpp:188
+#: ../src/generic/aboutdlgg.cpp:185
 msgid "Translators"
 msgstr "Übersetzer"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:211
+#: ../src/propgrid/propgrid.cpp:192
 msgid "True"
 msgstr "Wahr"
 
-#: ../src/common/fs_mem.cpp:227
+#: ../src/common/fs_mem.cpp:222
 #, c-format
 msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
 msgstr ""
 "Beim Versuch die Datei „%s“ aus dem VFS-Speicher zu entfernen, wurde "
 "festgestellt, dass sie gar nicht geladen war!"
 
-#: ../src/common/fmapbase.cpp:156
+#: ../src/common/fmapbase.cpp:153
 msgid "Turkish (ISO-8859-9)"
 msgstr "Türkisch (ISO-8859-9)"
 
-#: ../src/generic/filectrlg.cpp:426
+#: ../src/generic/filectrlg.cpp:422
 msgid "Type"
 msgstr "Typ"
 
@@ -7274,17 +7445,17 @@ msgstr "Schriftart eingeben."
 msgid "Type a size in points."
 msgstr "Größe in Punkt eingeben."
 
-#: ../src/msw/ole/automtn.cpp:676
+#: ../src/msw/ole/automtn.cpp:667
 #, c-format
 msgid "Type mismatch in argument %u."
 msgstr "Typfehler in Argument %u."
 
-#: ../src/common/xtixml.cpp:356 ../src/common/xtixml.cpp:509
-#: ../src/common/xtistrm.cpp:318
+#: ../src/common/xtixml.cpp:352 ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315
 msgid "Type must have enum - long conversion"
 msgstr "Typ muss eine enum-long-Umwandlung haben"
 
-#: ../src/propgrid/propgridiface.cpp:401
+#: ../src/propgrid/propgridiface.cpp:385
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
@@ -7293,19 +7464,19 @@ msgstr ""
 "Die Typoperation „%s“ ist fehlgeschlagen: Die Eigenschaft bezeichnet mit "
 "„%s“ ist vom Typ „%s“, NICHT „%s“."
 
-#: ../src/common/paper.cpp:133
+#: ../src/common/paper.cpp:130
 msgid "US Std Fanfold, 14 7/8 x 11 in"
 msgstr "US Std Endlospapier, 14 7/8 × 11 Zoll"
 
-#: ../src/common/fmapbase.cpp:196
+#: ../src/common/fmapbase.cpp:193
 msgid "US-ASCII"
 msgstr "US-ASCII"
 
-#: ../src/unix/fswatcher_inotify.cpp:109
+#: ../src/unix/fswatcher_inotify.cpp:106
 msgid "Unable to add inotify watch"
 msgstr "Inotify-Überwachung konnte nicht hinzugefügt werden"
 
-#: ../src/unix/fswatcher_kqueue.cpp:136
+#: ../src/unix/fswatcher_kqueue.cpp:153
 msgid "Unable to add kqueue watch"
 msgstr "Kqueue-Überwachung konnte nicht hinzugefügt werden"
 
@@ -7317,7 +7488,7 @@ msgstr "Das Handle konnte nicht mit dem I/O-Completion-Port verknüpft werden"
 msgid "Unable to close I/O completion port handle"
 msgstr "I/O-Completion-Port-Handle konnte nicht geschlossen werden"
 
-#: ../src/unix/fswatcher_inotify.cpp:97
+#: ../src/unix/fswatcher_inotify.cpp:94
 msgid "Unable to close inotify instance"
 msgstr "Inotify-Instanz konnte nicht geschlossen werden"
 
@@ -7335,15 +7506,15 @@ msgstr "Das Handle für „%s“ konnte nicht geschlossen werden"
 msgid "Unable to create I/O completion port"
 msgstr "Der I/O-Completion-Port konnte nicht erstellt werden"
 
-#: ../src/msw/fswatcher.cpp:84
+#: ../src/msw/fswatcher.cpp:81
 msgid "Unable to create IOCP worker thread"
 msgstr "Erzeugen des IOCP-Arbeitsthreads fehlgeschlagen"
 
-#: ../src/unix/fswatcher_inotify.cpp:74
+#: ../src/unix/fswatcher_inotify.cpp:71
 msgid "Unable to create inotify instance"
 msgstr "Erzeugen der Inotify-Instanz fehlgeschlagen"
 
-#: ../src/unix/fswatcher_kqueue.cpp:97
+#: ../src/unix/fswatcher_kqueue.cpp:114
 msgid "Unable to create kqueue instance"
 msgstr "Erzeugen der Kqueue-Instanz fehlgeschlagen"
 
@@ -7351,11 +7522,11 @@ msgstr "Erzeugen der Kqueue-Instanz fehlgeschlagen"
 msgid "Unable to dequeue completion packet"
 msgstr "Nicht möglich das Komplettierungspaket aufzulösen"
 
-#: ../src/unix/fswatcher_kqueue.cpp:185
+#: ../src/unix/fswatcher_kqueue.cpp:202
 msgid "Unable to get events from kqueue"
 msgstr "Ereignisse von Kqueue zu erhalten fehlgeschlagen"
 
-#: ../src/gtk/app.cpp:435
+#: ../src/gtk/app.cpp:431
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "Nicht möglich GTK+ zu initialisieren, ist DISPLAY korrekt gesetzt?"
 
@@ -7364,12 +7535,12 @@ msgstr "Nicht möglich GTK+ zu initialisieren, ist DISPLAY korrekt gesetzt?"
 msgid "Unable to open path '%s'"
 msgstr "Pfad „%s“ lässt sich nicht öffnen"
 
-#: ../src/html/htmlwin.cpp:583
+#: ../src/html/htmlwin.cpp:586
 #, c-format
 msgid "Unable to open requested HTML document: %s"
 msgstr "Das angeforderte HTML-Dokument konnte nicht geöffnet werden: %s"
 
-#: ../src/unix/sound.cpp:368
+#: ../src/unix/sound.cpp:365
 msgid "Unable to play sound asynchronously."
 msgstr "Der Klang kann nicht asynchron abgespielt werden."
 
@@ -7377,62 +7548,62 @@ msgstr "Der Klang kann nicht asynchron abgespielt werden."
 msgid "Unable to post completion status"
 msgstr "Nicht möglich den Ausführungsstatus zu senden"
 
-#: ../src/unix/fswatcher_inotify.cpp:556
+#: ../src/unix/fswatcher_inotify.cpp:553
 msgid "Unable to read from inotify descriptor"
 msgstr "Konnte nicht vom Inotify-Beschreibungselement lesen"
 
-#: ../src/unix/fswatcher_inotify.cpp:141
+#: ../src/unix/fswatcher_inotify.cpp:138
 #, c-format
 msgid "Unable to remove inotify watch %i"
 msgstr "Zurücksetzen der inotify-Überwachung nicht möglich %i"
 
-#: ../src/unix/fswatcher_kqueue.cpp:153
+#: ../src/unix/fswatcher_kqueue.cpp:170
 msgid "Unable to remove kqueue watch"
 msgstr "Zurücksetzen der kqueue-Überwachung nicht möglich"
 
-#: ../src/msw/fswatcher.cpp:168
+#: ../src/msw/fswatcher.cpp:165
 #, c-format
 msgid "Unable to set up watch for '%s'"
 msgstr "Konnte die Überwachung für „%s“ nicht aufsetzen."
 
-#: ../src/msw/fswatcher.cpp:91
+#: ../src/msw/fswatcher.cpp:88
 msgid "Unable to start IOCP worker thread"
 msgstr "IOCP-Arbeitsthread konnte nicht gestartet werden"
 
-#: ../src/common/stockitem.cpp:201
+#: ../src/common/stockitem.cpp:198
 msgid "Undelete"
 msgstr "Löschen rückgängig machen"
 
-#: ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199
 msgid "Underline"
 msgstr "Unterstreichen"
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/richtext/richtextfontpage.cpp:359 ../src/osx/carbon/fontdlg.cpp:370
-#: ../src/propgrid/advprops.cpp:690
+#: ../src/osx/carbon/fontdlg.cpp:367 ../src/propgrid/advprops.cpp:600
+#: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Unterstrichen"
 
-#: ../src/common/stockitem.cpp:203 ../src/stc/stc_i18n.cpp:15
+#: ../src/common/stockitem.cpp:200 ../src/stc/stc_i18n.cpp:15
 msgid "Undo"
 msgstr "Rückgängig"
 
-#: ../src/common/stockitem.cpp:265
+#: ../src/common/stockitem.cpp:263
 msgid "Undo last action"
 msgstr "Letzte Aktion zurücknehmen"
 
-#: ../src/common/cmdline.cpp:1029
+#: ../src/common/cmdline.cpp:1025
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Unerwartete Zeichen folgen der Option „%s“."
 
-#: ../src/unix/fswatcher_inotify.cpp:274
+#: ../src/unix/fswatcher_inotify.cpp:271
 #, c-format
 msgid "Unexpected event for \"%s\": no matching watch descriptor."
 msgstr ""
 "Unerwartetes Ereignis für „%s“: Kein passender Überwachungs-Deskriptor."
 
-#: ../src/common/cmdline.cpp:1195
+#: ../src/common/cmdline.cpp:1191
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Unerwarteter Parameter „%s“"
@@ -7441,49 +7612,49 @@ msgstr "Unerwarteter Parameter „%s“"
 msgid "Unexpectedly new I/O completion port was created"
 msgstr "Neuer unerwarteter I/O-Completion-Port wurde erstellt"
 
-#: ../src/msw/fswatcher.cpp:70
+#: ../src/msw/fswatcher.cpp:67
 msgid "Ungraceful worker thread termination"
 msgstr "Unfreundliche Beendigung des Arbeitsthreads"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:460
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:456
+#: ../src/richtext/richtextsymboldlg.cpp:457
+#: ../src/richtext/richtextsymboldlg.cpp:458
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../src/common/fmapbase.cpp:185 ../src/common/fmapbase.cpp:191
+#: ../src/common/fmapbase.cpp:182 ../src/common/fmapbase.cpp:188
 msgid "Unicode 16 bit (UTF-16)"
 msgstr "Unicode 16 Bit (UTF-16)"
 
-#: ../src/common/fmapbase.cpp:190
+#: ../src/common/fmapbase.cpp:187
 msgid "Unicode 16 bit Big Endian (UTF-16BE)"
 msgstr "Unicode 16 Bit Big Endian (UTF-16BE)"
 
-#: ../src/common/fmapbase.cpp:186
+#: ../src/common/fmapbase.cpp:183
 msgid "Unicode 16 bit Little Endian (UTF-16LE)"
 msgstr "Unicode 16 Bit Little Endian (UTF-16LE)"
 
-#: ../src/common/fmapbase.cpp:187 ../src/common/fmapbase.cpp:193
+#: ../src/common/fmapbase.cpp:184 ../src/common/fmapbase.cpp:190
 msgid "Unicode 32 bit (UTF-32)"
 msgstr "Unicode 32 Bit (UTF-32)"
 
-#: ../src/common/fmapbase.cpp:192
+#: ../src/common/fmapbase.cpp:189
 msgid "Unicode 32 bit Big Endian (UTF-32BE)"
 msgstr "Unicode 32 Bit Big Endian (UTF-32BE)"
 
-#: ../src/common/fmapbase.cpp:188
+#: ../src/common/fmapbase.cpp:185
 msgid "Unicode 32 bit Little Endian (UTF-32LE)"
 msgstr "Unicode 32 Bit Little Endian (UTF-32LE)"
 
-#: ../src/common/fmapbase.cpp:182
+#: ../src/common/fmapbase.cpp:179
 msgid "Unicode 7 bit (UTF-7)"
 msgstr "Unicode 7 Bit (UTF-7)"
 
-#: ../src/common/fmapbase.cpp:183
+#: ../src/common/fmapbase.cpp:180
 msgid "Unicode 8 bit (UTF-8)"
 msgstr "Unicode 8 Bit (UTF-8)"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "Unindent"
 msgstr "Einrücken aufheben"
 
@@ -7633,97 +7804,102 @@ msgstr "Einheit des Abstands nach oben."
 msgid "Units for this value."
 msgstr "Einheiten für diesen Wert."
 
-#: ../src/generic/progdlgg.cpp:353 ../src/generic/progdlgg.cpp:622
+#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
 msgid "Unknown"
 msgstr "Unbekannt"
 
-#: ../src/msw/dde.cpp:1174
+#: ../src/msw/dde.cpp:1238
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Unbekannter DDE-Fehler %08x"
 
-#: ../src/common/xtistrm.cpp:410
+#: ../src/common/xtistrm.cpp:407
 msgid "Unknown Object passed to GetObjectClassInfo"
 msgstr "Unbekanntes Objekt an GetObjectClassInfo übergeben"
 
-#: ../src/common/imagpng.cpp:366
+#: ../src/common/imagpng.cpp:383
 #, c-format
 msgid "Unknown PNG resolution unit %d"
 msgstr "Unbekannte Einheit für die PNG-Auflösung %d"
 
-#: ../src/common/xtixml.cpp:327
+#: ../src/common/xtixml.cpp:323
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Unbekannte Eigenschaft %s"
 
-#: ../src/common/imagtiff.cpp:529
+#: ../src/common/imagtiff.cpp:526
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "Unbekannte TIFF-Auflösungseinheit %d ignoriert"
 
-#: ../src/unix/dlunix.cpp:160
+#: ../src/propgrid/props.cpp:155
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/unix/dlunix.cpp:118
 msgid "Unknown dynamic library error"
 msgstr "Unbekannter Fehler bei Behandlung dynamischer Bibliothek"
 
-#: ../src/common/fmapbase.cpp:810
+#: ../src/common/fmapbase.cpp:806
 #, c-format
 msgid "Unknown encoding (%d)"
 msgstr "Unbekannte Kodierung (%d)"
 
-#: ../src/msw/ole/automtn.cpp:688
+#: ../src/msw/ole/automtn.cpp:679
 #, c-format
 msgid "Unknown error %08x"
 msgstr "Unbekannter Fehler %08x"
 
-#: ../src/msw/ole/automtn.cpp:647
+#: ../src/msw/ole/automtn.cpp:638
 msgid "Unknown exception"
 msgstr "Unbekannte Ausnahme"
 
-#: ../src/common/image.cpp:2839
+#: ../src/common/image.cpp:2942
 msgid "Unknown image data format."
 msgstr "Unbekanntes Bilddateiformat."
 
-#: ../src/common/cmdline.cpp:914
+#: ../src/common/cmdline.cpp:910
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Unbekannte „long“-Option „%s“"
 
-#: ../src/msw/ole/automtn.cpp:631
+#: ../src/msw/ole/automtn.cpp:622
 msgid "Unknown name or named argument."
 msgstr "Unbekannter Name oder unbekanntes Argument."
 
-#: ../src/common/cmdline.cpp:929 ../src/common/cmdline.cpp:951
+#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Unbekannte Option „%s“"
 
-#: ../src/common/mimecmn.cpp:225
+#: ../src/common/mimecmn.cpp:221
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "Unzutreffendes „{“-Zeichen in einem Eintrag des MIME-Typs %s."
 
-#: ../src/common/cmdproc.cpp:262 ../src/common/cmdproc.cpp:288
-#: ../src/common/cmdproc.cpp:308
+#: ../src/common/cmdproc.cpp:255 ../src/common/cmdproc.cpp:281
+#: ../src/common/cmdproc.cpp:301
 msgid "Unnamed command"
 msgstr "Unbenanntes Kommando"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:413
+#: ../src/propgrid/propgrid.cpp:392
 msgid "Unspecified"
 msgstr "Nicht angegeben"
 
-#: ../src/msw/clipbrd.cpp:311
+#: ../src/msw/clipbrd.cpp:325
 msgid "Unsupported clipboard format."
 msgstr "Nicht unterstütztes Format in der Zwischenablage."
 
-#: ../src/common/appcmn.cpp:256
+#: ../src/common/appcmn.cpp:277
 #, c-format
 msgid "Unsupported theme '%s'."
 msgstr "Unbekanntes Thema „%s“."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:205
-#: ../src/common/accelcmn.cpp:63
+#: ../src/common/stockitem.cpp:202 ../src/common/accelcmn.cpp:60
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Up"
 msgstr "Hoch"
 
@@ -7737,7 +7913,7 @@ msgstr "Großbuchstaben"
 msgid "Upper case roman numerals"
 msgstr "Römische Ziffern in Großbuchstaben"
 
-#: ../src/common/cmdline.cpp:1326
+#: ../src/common/cmdline.cpp:1322
 #, c-format
 msgid "Usage: %s"
 msgstr "Verwendung: %s"
@@ -7746,38 +7922,47 @@ msgstr "Verwendung: %s"
 msgid "Use &shadow"
 msgstr "&Schatten verwenden"
 
-#: ../src/richtext/richtextindentspage.cpp:169
-#: ../src/richtext/richtextindentspage.cpp:171
 #: ../src/richtext/richtextliststylepage.cpp:358
 #: ../src/richtext/richtextliststylepage.cpp:360
+#: ../src/richtext/richtextindentspage.cpp:169
+#: ../src/richtext/richtextindentspage.cpp:171
 msgid "Use the current alignment setting."
 msgstr "Benutze die aktuellen Einstellungen für die Ausrichtung."
 
-#: ../src/common/valtext.cpp:179
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/gtk/font.cpp:552
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/common/valtext.cpp:142
 msgid "Validation conflict"
 msgstr "Verifizierungs-Konflikt"
 
-#: ../src/propgrid/manager.cpp:238
+#: ../src/propgrid/manager.cpp:224
 msgid "Value"
 msgstr "Wert"
 
-#: ../src/propgrid/props.cpp:386 ../src/propgrid/props.cpp:500
+#: ../src/propgrid/props.cpp:309
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "Wert muss %s oder höher sein."
 
-#: ../src/propgrid/props.cpp:417 ../src/propgrid/props.cpp:531
+#: ../src/propgrid/props.cpp:336
 #, c-format
 msgid "Value must be %s or less."
 msgstr "Wert muss %s oder kleiner sein."
 
-#: ../src/propgrid/props.cpp:393 ../src/propgrid/props.cpp:424
-#: ../src/propgrid/props.cpp:507 ../src/propgrid/props.cpp:538
+#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "Wert muss zwischen %s und %s liegen."
 
-#: ../src/generic/aboutdlgg.cpp:128
+#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Version "
 
@@ -7786,25 +7971,32 @@ msgstr "Version "
 msgid "Vertical alignment."
 msgstr "Vertikale Ausrichtung."
 
-#: ../src/generic/filedlgg.cpp:202
+#: ../src/generic/filedlgg.cpp:199
 msgid "View files as a detailed view"
 msgstr "Dateien mit Details anzeigen"
 
-#: ../src/generic/filedlgg.cpp:200
+#: ../src/generic/filedlgg.cpp:197
 msgid "View files as a list view"
 msgstr "Dateien als Liste anzeigen"
 
-#: ../src/common/docview.cpp:1970
+#: ../src/common/docview.cpp:1975
 msgid "Views"
 msgstr "Darstellung"
 
+#: ../src/gtk/app.cpp:348
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1777
+#: ../src/propgrid/advprops.cpp:1678
 msgid "Wait"
 msgstr "﻿Warten"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1779
+#: ../src/propgrid/advprops.cpp:1680
 msgid "Wait Arrow"
 msgstr "Wartepfeil"
 
@@ -7814,241 +8006,238 @@ msgid "Waiting for IO on epoll descriptor %d failed"
 msgstr ""
 "Warten auf Eingabe-/Ausgabe-Epoll-Beschreibungselement %d fehlgeschlagen"
 
-#: ../src/common/log.cpp:223
+#: ../src/common/log.cpp:241
 msgid "Warning: "
 msgstr "Warnung: "
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1778
+#: ../src/propgrid/advprops.cpp:1679
 msgid "Watch"
 msgstr "Uhr"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:685
+#: ../src/propgrid/advprops.cpp:595
 msgid "Weight"
 msgstr "Dicke"
 
-#: ../src/common/fmapbase.cpp:148
+#: ../src/common/fmapbase.cpp:145
 msgid "Western European (ISO-8859-1)"
 msgstr "Westeuropäisch (ISO-8859-1)"
 
-#: ../src/common/fmapbase.cpp:162
+#: ../src/common/fmapbase.cpp:159
 msgid "Western European with Euro (ISO-8859-15)"
 msgstr "Westeuropäisch mit Euro (ISO-8859-15)"
 
-#: ../src/generic/fontdlgg.cpp:446 ../src/generic/fontdlgg.cpp:448
+#: ../src/generic/fontdlgg.cpp:443 ../src/generic/fontdlgg.cpp:445
 msgid "Whether the font is underlined."
 msgstr "Ob der Schrifttyp unterstrichen ist."
 
-#: ../src/propgrid/advprops.cpp:1611
+#: ../src/propgrid/advprops.cpp:1517
 msgid "White"
 msgstr "Weiß"
 
-#: ../src/generic/fdrepdlg.cpp:144
+#: ../src/generic/fdrepdlg.cpp:141
 msgid "Whole word"
 msgstr "Ganzes Wort"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:532
 msgid "Whole words only"
 msgstr "Nur ganze Worte"
 
-#: ../src/univ/themes/win32.cpp:1102
+#: ../src/univ/themes/win32.cpp:1099
 msgid "Win32 theme"
 msgstr "Win32-Thema"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:893
+#: ../src/propgrid/advprops.cpp:794
 msgid "Window"
 msgstr "Fenster"
 
 # Original wird verwendet
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:894
+#: ../src/propgrid/advprops.cpp:795
 msgid "WindowFrame"
 msgstr "WindowFrame"
 
 # Original wird verwendet
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:895
+#: ../src/propgrid/advprops.cpp:796
 msgid "WindowText"
 msgstr "WindowText"
 
-#: ../src/common/fmapbase.cpp:177
+#: ../src/common/fmapbase.cpp:174
 msgid "Windows Arabic (CP 1256)"
 msgstr "Windows Arabisch (CP 1256)"
 
-#: ../src/common/fmapbase.cpp:178
+#: ../src/common/fmapbase.cpp:175
 msgid "Windows Baltic (CP 1257)"
 msgstr "Windows Baltisch (CP 1257)"
 
-#: ../src/common/fmapbase.cpp:171
+#: ../src/common/fmapbase.cpp:168
 msgid "Windows Central European (CP 1250)"
 msgstr "Windows Zentraleuropäisch (CP 1250)"
 
-#: ../src/common/fmapbase.cpp:168
+#: ../src/common/fmapbase.cpp:165
 msgid "Windows Chinese Simplified (CP 936) or GB-2312"
 msgstr "Windows Vereinfachtes Chinesisch (CP 936) oder GB-2312"
 
-#: ../src/common/fmapbase.cpp:170
+#: ../src/common/fmapbase.cpp:167
 msgid "Windows Chinese Traditional (CP 950) or Big-5"
 msgstr "Windows Traditionelles Chinesisch (CP 950) oder Big-5"
 
-#: ../src/common/fmapbase.cpp:172
+#: ../src/common/fmapbase.cpp:169
 msgid "Windows Cyrillic (CP 1251)"
 msgstr "Windows Kyrillisch (CP 1251)"
 
-#: ../src/common/fmapbase.cpp:174
+#: ../src/common/fmapbase.cpp:171
 msgid "Windows Greek (CP 1253)"
 msgstr "Windows Griechisch (CP 1253)"
 
-#: ../src/common/fmapbase.cpp:176
+#: ../src/common/fmapbase.cpp:173
 msgid "Windows Hebrew (CP 1255)"
 msgstr "Windows Hebräisch (CP 1255)"
 
-#: ../src/common/fmapbase.cpp:167
+#: ../src/common/fmapbase.cpp:164
 msgid "Windows Japanese (CP 932) or Shift-JIS"
 msgstr "Windows Japanisch (CP 932) oder Shift-JIS"
 
-#: ../src/common/fmapbase.cpp:180
+#: ../src/common/fmapbase.cpp:177
 msgid "Windows Johab (CP 1361)"
 msgstr "Windows Johab (CP 1361)"
 
-#: ../src/common/fmapbase.cpp:169
+#: ../src/common/fmapbase.cpp:166
 msgid "Windows Korean (CP 949)"
 msgstr "Windows Koreanisch (CP 949)"
 
-#: ../src/common/fmapbase.cpp:166
+#: ../src/common/fmapbase.cpp:163
 msgid "Windows Thai (CP 874)"
 msgstr "Windows Thailändisch (CP 874)"
 
-#: ../src/common/fmapbase.cpp:175
+#: ../src/common/fmapbase.cpp:172
 msgid "Windows Turkish (CP 1254)"
 msgstr "Windows Türkisch (CP 1254)"
 
-#: ../src/common/fmapbase.cpp:179
+#: ../src/common/fmapbase.cpp:176
 msgid "Windows Vietnamese (CP 1258)"
 msgstr "Windows Vietnamesisch (CP 1258)"
 
-#: ../src/common/fmapbase.cpp:173
+#: ../src/common/fmapbase.cpp:170
 msgid "Windows Western European (CP 1252)"
 msgstr "Windows Westeuropäisch (CP 1252)"
 
-#: ../src/common/fmapbase.cpp:181
+#: ../src/common/fmapbase.cpp:178
 msgid "Windows/DOS OEM (CP 437)"
 msgstr "Windows/DOS OEM (CP 437)"
 
-#: ../src/common/fmapbase.cpp:165
+#: ../src/common/fmapbase.cpp:162
 msgid "Windows/DOS OEM Cyrillic (CP 866)"
 msgstr "Windows/DOS OEM Kyrillisch (CP 866)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:111
+#: ../src/common/accelcmn.cpp:109
 msgid "Windows_Left"
 msgstr "Windows_Links"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:113
+#: ../src/common/accelcmn.cpp:111
 msgid "Windows_Menu"
 msgstr "Windows_Menü"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:112
+#: ../src/common/accelcmn.cpp:110
 msgid "Windows_Right"
 msgstr "Windows_Rechts"
 
-#: ../src/common/ffile.cpp:150
+#: ../src/common/ffile.cpp:149
 #, c-format
 msgid "Write error on file '%s'"
 msgstr "Schreibfehler bei Datei „%s“"
 
-#: ../src/xml/xml.cpp:914
+#: ../src/xml/xml.cpp:925
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "Fehler beim Lesen des XML: „%s“ in Zeile %d"
 
-#: ../src/common/xpmdecod.cpp:796
+#: ../src/common/xpmdecod.cpp:794
 msgid "XPM: Malformed pixel data!"
 msgstr "XPM: Ungültige Pixeldaten!"
 
-#: ../src/common/xpmdecod.cpp:705
+#: ../src/common/xpmdecod.cpp:702
 #, c-format
 msgid "XPM: incorrect colour description in line %d"
 msgstr "XPM: nicht korrekte Farbbeschreibung in Zeile %d"
 
-#: ../src/common/xpmdecod.cpp:680
+#: ../src/common/xpmdecod.cpp:677
 msgid "XPM: incorrect header format!"
 msgstr "XPM: nicht korrektes Kopfformat!"
 
-#: ../src/common/xpmdecod.cpp:716 ../src/common/xpmdecod.cpp:725
+#: ../src/common/xpmdecod.cpp:714 ../src/common/xpmdecod.cpp:723
 #, c-format
 msgid "XPM: malformed colour definition '%s' at line %d!"
 msgstr "XPM: ungültige Farbdefinition „%s“ in Zeile %d!"
 
-#: ../src/common/xpmdecod.cpp:755
+#: ../src/common/xpmdecod.cpp:753
 msgid "XPM: no colors left to use for mask!"
 msgstr "XPM: keine Farben für die Maske übrig!"
 
-#: ../src/common/xpmdecod.cpp:782
+#: ../src/common/xpmdecod.cpp:780
 #, c-format
 msgid "XPM: truncated image data at line %d!"
 msgstr "XPM: abgeschnittene Bilddaten in Zeile %d!"
 
-#: ../src/propgrid/advprops.cpp:1610
+#: ../src/propgrid/advprops.cpp:1516
 msgid "Yellow"
 msgstr "Gelb"
 
-#: ../include/wx/msgdlg.h:276 ../src/common/stockitem.cpp:206
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:203
 #: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Ja"
 
-#: ../src/osx/carbon/overlay.cpp:155
-msgid "You cannot Clear an overlay that is not inited"
-msgstr "Sie können keine Überlagerung löschen, die nicht initialisiert wurde"
-
-#: ../src/osx/carbon/overlay.cpp:107 ../src/dfb/overlay.cpp:61
-msgid "You cannot Init an overlay twice"
-msgstr "Eine Überlagerung kann nicht zweimal initialisiert werden"
-
-#: ../src/generic/dirdlgg.cpp:287
+#: ../src/generic/dirdlgg.cpp:284
 msgid "You cannot add a new directory to this section."
 msgstr "Sie können hier kein neues Verzeichnis anlegen."
 
-#: ../src/propgrid/propgrid.cpp:3299
+#: ../src/propgrid/propgrid.cpp:3276
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 "Sie haben einen ungültigen Wert eingegeben. Drücken Sie ESC um die "
 "Bearbeitung zu beenden."
 
-#: ../src/common/stockitem.cpp:209
+#: ../src/osx/cocoa/menu.mm:286
+#, fuzzy
+msgid "Zoom"
+msgstr "Vergrößern"
+
+#: ../src/common/stockitem.cpp:206
 msgid "Zoom &In"
 msgstr "Ver&größern"
 
-#: ../src/common/stockitem.cpp:210
+#: ../src/common/stockitem.cpp:207
 msgid "Zoom &Out"
 msgstr "Ver&kleinern"
 
-#: ../src/common/stockitem.cpp:209 ../src/common/prntbase.cpp:1594
+#: ../src/common/stockitem.cpp:206 ../src/common/prntbase.cpp:1619
 msgid "Zoom In"
 msgstr "Vergrößern"
 
-#: ../src/common/stockitem.cpp:210 ../src/common/prntbase.cpp:1580
+#: ../src/common/stockitem.cpp:207 ../src/common/prntbase.cpp:1605
 msgid "Zoom Out"
 msgstr "Verkleinern"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to &Fit"
 msgstr "&Passende Größe"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to Fit"
 msgstr "Einpassen"
 
-#: ../src/msw/dde.cpp:1141
+#: ../src/msw/dde.cpp:1205
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "Eine DDEML-Anwendung hat eine „prolonged race condition“ ausgelöst."
 
-#: ../src/msw/dde.cpp:1129
+#: ../src/msw/dde.cpp:1193
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -8060,50 +8249,50 @@ msgstr ""
 "oder ein ungültiger „instance identifier“\n"
 "wurde an eine DDEML-Funktion übergeben."
 
-#: ../src/msw/dde.cpp:1147
+#: ../src/msw/dde.cpp:1211
 msgid "a client's attempt to establish a conversation has failed."
 msgstr ""
 "Der Versuch eines Clients, eine Verbindung herzustellen, ist fehlgeschlagen."
 
-#: ../src/msw/dde.cpp:1144
+#: ../src/msw/dde.cpp:1208
 msgid "a memory allocation failed."
 msgstr "Eine Speicheranforderung ist fehlgeschlagen."
 
-#: ../src/msw/dde.cpp:1138
+#: ../src/msw/dde.cpp:1202
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "Ein Parameter wurde von DDEML nicht verifiziert."
 
-#: ../src/msw/dde.cpp:1120
+#: ../src/msw/dde.cpp:1184
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr ""
 "Eine Anfrage für eine „synchronous advise transaction“ ist fehlgeschlagen "
 "(time-out)"
 
-#: ../src/msw/dde.cpp:1126
+#: ../src/msw/dde.cpp:1190
 msgid "a request for a synchronous data transaction has timed out."
 msgstr ""
 "Eine Anfrage für eine „synchronous data transaction“ ist fehlgeschlagen "
 "(time-out)"
 
-#: ../src/msw/dde.cpp:1135
+#: ../src/msw/dde.cpp:1199
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr ""
 "Eine Anfrage für eine „synchronous execute transaction“ ist fehlgeschlagen "
 "(time-out)"
 
-#: ../src/msw/dde.cpp:1153
+#: ../src/msw/dde.cpp:1217
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr ""
 "Eine Anfrage für eine „synchronous poke transaction“ ist fehlgeschlagen "
 "(time-out)"
 
-#: ../src/msw/dde.cpp:1168
+#: ../src/msw/dde.cpp:1232
 msgid "a request to end an advise transaction has timed out."
 msgstr ""
 "Eine Anfrage, eine „advise transaction“ zu beenden ist, fehlgeschlagen (time-"
 "out)"
 
-#: ../src/msw/dde.cpp:1162
+#: ../src/msw/dde.cpp:1226
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -8113,15 +8302,15 @@ msgstr ""
 "wurde vom Client unterbrochen, oder der Server\n"
 "beendete bevor die Transaktion vollständig beendet wurde."
 
-#: ../src/msw/dde.cpp:1150
+#: ../src/msw/dde.cpp:1214
 msgid "a transaction failed."
 msgstr "Eine Transaktion ist fehlgeschlagen."
 
-#: ../src/common/accelcmn.cpp:189
+#: ../src/common/accelcmn.cpp:188
 msgid "alt"
 msgstr "alt"
 
-#: ../src/msw/dde.cpp:1132
+#: ../src/msw/dde.cpp:1196
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -8133,15 +8322,15 @@ msgstr ""
 "oder eine Anwendung, die als ein „APPCMD_CLIENTONLY“ gestartet wurde, \n"
 "versuchte eine Server-Transaktion auszuführen."
 
-#: ../src/msw/dde.cpp:1156
+#: ../src/msw/dde.cpp:1220
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "Ein interner Aufruf zur „PostMessage“-Funktion ist fehlgeschlagen. "
 
-#: ../src/msw/dde.cpp:1165
+#: ../src/msw/dde.cpp:1229
 msgid "an internal error has occurred in the DDEML."
 msgstr "Ein interner Fehler ist im DDEML aufgetreten."
 
-#: ../src/msw/dde.cpp:1171
+#: ../src/msw/dde.cpp:1235
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -8152,57 +8341,57 @@ msgstr ""
 "Sobald die Anwendung aus einem „XTYP_XACT_COMPLETE“-Callback zurückkehrt,\n"
 "ist die Transaktions-Identifizierung für diesen Callback nicht mehr gültig."
 
-#: ../src/common/zipstrm.cpp:1483
+#: ../src/common/zipstrm.cpp:1522
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "Nehme an, dies ist ein mehrteiliges, zusammenhängendes Zip-Archiv"
 
-#: ../src/common/fileconf.cpp:1847
+#: ../src/common/fileconf.cpp:1849
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr ""
 "Versuch den unveränderlichen Schlüssel „%s“ anzupassen wurde ignoriert."
 
-#: ../src/html/chm.cpp:329
+#: ../src/html/chm.cpp:326
 msgid "bad arguments to library function"
 msgstr "Ungültige Argumente für die Bibliotheksfunktion"
 
-#: ../src/html/chm.cpp:341
+#: ../src/html/chm.cpp:338
 msgid "bad signature"
 msgstr "Ungültige Unterschrift"
 
-#: ../src/common/zipstrm.cpp:1918
+#: ../src/common/zipstrm.cpp:1988
 msgid "bad zipfile offset to entry"
 msgstr "ungültiges Offset zum Einsprung in der Zipdatei"
 
-#: ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400
 msgid "binary"
 msgstr "binär"
 
-#: ../src/common/fontcmn.cpp:996
+#: ../src/common/fontcmn.cpp:1195
 msgid "bold"
 msgstr "fett"
 
-#: ../src/msw/utils.cpp:1144
+#: ../src/msw/utils.cpp:1135
 #, c-format
 msgid "build %lu"
 msgstr "Erzeugungsversion %lu"
 
-#: ../src/common/ffile.cpp:75
+#: ../src/common/ffile.cpp:73
 #, c-format
 msgid "can't close file '%s'"
 msgstr "Kann Datei „%s“ nicht schließen"
 
-#: ../src/common/file.cpp:245
+#: ../src/common/file.cpp:242
 #, c-format
 msgid "can't close file descriptor %d"
 msgstr "Kann Dateibeschreibung „%d“ nicht schließen"
 
-#: ../src/common/file.cpp:586
+#: ../src/common/ffile.cpp:382 ../src/common/file.cpp:613
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "Kann Änderungen in Datei „%s“ nicht sichern"
 
-#: ../src/common/file.cpp:178
+#: ../src/common/file.cpp:175
 #, c-format
 msgid "can't create file '%s'"
 msgstr "Kann Datei „%s“ nicht anlegen"
@@ -8212,51 +8401,51 @@ msgstr "Kann Datei „%s“ nicht anlegen"
 msgid "can't delete user configuration file '%s'"
 msgstr "Kann Konfigurationsdatei „%s“ nicht löschen"
 
-#: ../src/common/file.cpp:495
+#: ../src/common/file.cpp:522
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr ""
 "Auf Dateibeschreibung „%d“ kann nicht festgestellt werden, ob das Dateiende "
 "erreicht ist"
 
-#: ../src/common/zipstrm.cpp:1692
+#: ../src/common/zipstrm.cpp:1747
 msgid "can't find central directory in zip"
 msgstr "kann Zentralverzeichnis im Zip nicht finden"
 
-#: ../src/common/file.cpp:465
+#: ../src/common/file.cpp:492
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "Kann auf Dateibeschreibung „%d“ die Dateilänge nicht finden"
 
-#: ../src/msw/utils.cpp:341
+#: ../src/msw/utils.cpp:336
 msgid "can't find user's HOME, using current directory."
 msgstr "Kann Benutzerverzeichnis nicht finden, verwende aktuelles Verzeichnis."
 
-#: ../src/common/file.cpp:366
+#: ../src/common/file.cpp:407
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "Kann auf die Dateibeschreibung „%d“ nicht entladen"
 
-#: ../src/common/file.cpp:422
+#: ../src/common/file.cpp:463
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "Kann auf die Dateibeschreibung %d nicht positionieren"
 
-#: ../src/common/fontmap.cpp:325
+#: ../src/common/fontmap.cpp:322
 msgid "can't load any font, aborting"
 msgstr "Kann keine Schriftarten mehr laden, Abbruch"
 
-#: ../src/common/file.cpp:231 ../src/common/ffile.cpp:59
+#: ../src/common/ffile.cpp:57 ../src/common/file.cpp:228
 #, c-format
 msgid "can't open file '%s'"
 msgstr "Kann Datei „%s“ nicht öffnen"
 
-#: ../src/common/fileconf.cpp:320
+#: ../src/common/fileconf.cpp:314
 #, c-format
 msgid "can't open global configuration file '%s'."
 msgstr "Kann globale Konfigurationsdatei „%s“ nicht öffnen."
 
-#: ../src/common/fileconf.cpp:336
+#: ../src/common/fileconf.cpp:330
 #, c-format
 msgid "can't open user configuration file '%s'."
 msgstr "Kann Konfigurationsdatei „%s“ nicht öffnen."
@@ -8265,40 +8454,40 @@ msgstr "Kann Konfigurationsdatei „%s“ nicht öffnen."
 msgid "can't open user configuration file."
 msgstr "Kann Benutzer-Konfigurationsdatei nicht öffnen."
 
-#: ../src/common/zipstrm.cpp:579
+#: ../src/common/zipstrm.cpp:572
 msgid "can't re-initialize zlib deflate stream"
 msgstr "Kann den zlib deflate-stream nicht reinitialisieren"
 
-#: ../src/common/zipstrm.cpp:604
+#: ../src/common/zipstrm.cpp:597
 msgid "can't re-initialize zlib inflate stream"
 msgstr "Kann den zlib inflate-stream nicht reinitialisieren"
 
-#: ../src/common/file.cpp:304
+#: ../src/common/file.cpp:345
 #, c-format
 msgid "can't read from file descriptor %d"
 msgstr "Kann Dateibeschreibung „%d“ nicht lesen"
 
-#: ../src/common/file.cpp:581
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:608
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "Kann Datei „%s“ nicht löschen"
 
-#: ../src/common/file.cpp:598
+#: ../src/common/ffile.cpp:394 ../src/common/file.cpp:625
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "Kann temporäre Datei „%s“ nicht löschen"
 
-#: ../src/common/file.cpp:408
+#: ../src/common/file.cpp:449
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "Kann auf der Dateibeschreibung „%d“ nicht suchen"
 
-#: ../src/common/textfile.cpp:273
+#: ../src/common/textfile.cpp:161
 #, c-format
 msgid "can't write buffer '%s' to disk."
 msgstr "Kann den Puffer „%s“ nicht schreiben."
 
-#: ../src/common/file.cpp:323
+#: ../src/common/file.cpp:364
 #, c-format
 msgid "can't write to file descriptor %d"
 msgstr "Kann auf Dateibeschreibung „%d“ nicht schreiben"
@@ -8308,22 +8497,28 @@ msgid "can't write user configuration file."
 msgstr "Kann Benutzer-Konfigurationsdatei nicht schreiben."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:482 ../src/generic/datavgen.cpp:1261
+#: ../src/common/datavcmn.cpp:2064 ../src/generic/datavgen.cpp:1384
 msgid "checked"
 msgstr "ausgewählt"
 
-#: ../src/html/chm.cpp:345
+#: ../src/html/chm.cpp:342
 msgid "checksum error"
 msgstr "Prüfsummen-Fehler"
 
-#: ../src/common/tarstrm.cpp:820
+#: ../src/common/tarstrm.cpp:814
 msgid "checksum failure reading tar header block"
 msgstr "Prüfsummenfehler beim Lesen der tar-Kopfeintrages"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:226
-#: ../src/richtext/richtextbackgroundpage.cpp:249
-#: ../src/richtext/richtextbackgroundpage.cpp:289
-#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
 #: ../src/richtext/richtextborderspage.cpp:254
 #: ../src/richtext/richtextborderspage.cpp:288
 #: ../src/richtext/richtextborderspage.cpp:322
@@ -8341,105 +8536,129 @@ msgstr "Prüfsummenfehler beim Lesen der tar-Kopfeintrages"
 #: ../src/richtext/richtextmarginspage.cpp:340
 #: ../src/richtext/richtextmarginspage.cpp:363
 #: ../src/richtext/richtextmarginspage.cpp:388
-#: ../src/richtext/richtextsizepage.cpp:339
-#: ../src/richtext/richtextsizepage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:400
-#: ../src/richtext/richtextsizepage.cpp:427
-#: ../src/richtext/richtextsizepage.cpp:454
-#: ../src/richtext/richtextsizepage.cpp:481
-#: ../src/richtext/richtextsizepage.cpp:555
-#: ../src/richtext/richtextsizepage.cpp:590
-#: ../src/richtext/richtextsizepage.cpp:625
-#: ../src/richtext/richtextsizepage.cpp:660
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
 msgid "cm"
 msgstr "cm"
 
-#: ../src/html/chm.cpp:347
+#: ../src/html/chm.cpp:344
 msgid "compression error"
 msgstr "Fehler beim Komprimieren"
 
-#: ../src/common/regex.cpp:236
+#: ../src/common/regex.cpp:233
 msgid "conversion to 8-bit encoding failed"
 msgstr "Umwandlung in 8-Bit-Kodierung fehlgeschlagen"
 
-#: ../src/common/accelcmn.cpp:187
+#: ../src/common/accelcmn.cpp:186
 msgid "ctrl"
 msgstr "strg"
 
-#: ../src/common/cmdline.cpp:1500
+#: ../src/common/cmdline.cpp:1496
 msgid "date"
 msgstr "Datum"
 
-#: ../src/html/chm.cpp:349
+#: ../src/html/chm.cpp:346
 msgid "decompression error"
 msgstr "Fehler beim Entpacken"
 
-#: ../src/richtext/richtextstyles.cpp:780 ../src/common/fmapbase.cpp:820
+#: ../src/common/fmapbase.cpp:816 ../src/richtext/richtextstyles.cpp:777
 msgid "default"
 msgstr "Standard"
 
-#: ../src/common/cmdline.cpp:1496
+#: ../src/common/cmdline.cpp:1492
 msgid "double"
 msgstr "Doppelte Genauigkeit"
 
-#: ../src/common/debugrpt.cpp:538
+#: ../src/common/debugrpt.cpp:539
 msgid "dump of the process state (binary)"
 msgstr "Dump des bearbeiteten Zustands (binär)"
 
-#: ../src/common/datetimefmt.cpp:1969
+#: ../src/common/datetimefmt.cpp:1992
 msgid "eighteenth"
 msgstr "achtzehnte"
 
-#: ../src/common/datetimefmt.cpp:1959
+#: ../src/common/datetimefmt.cpp:1982
 msgid "eighth"
 msgstr "achte"
 
-#: ../src/common/datetimefmt.cpp:1962
+#: ../src/common/datetimefmt.cpp:1985
 msgid "eleventh"
 msgstr "elfte"
 
-#: ../src/common/fileconf.cpp:1833
+#: ../src/common/fileconf.cpp:1835
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "Eintrag „%s“ erscheint in Gruppe „%s“ mehrfach"
 
-#: ../src/html/chm.cpp:343
+#: ../src/html/chm.cpp:340
 msgid "error in data format"
 msgstr "Fehler im Datenformat"
 
-#: ../src/html/chm.cpp:331
+#: ../src/html/chm.cpp:328
 msgid "error opening file"
 msgstr "Fehler beim Öffnen der Datei"
 
-#: ../src/common/zipstrm.cpp:1778
+#: ../src/common/zipstrm.cpp:1836
 msgid "error reading zip central directory"
 msgstr "Fehler beim Lesen des Zentralverzeichnisses im Zip"
 
-#: ../src/common/zipstrm.cpp:1870
+#: ../src/common/zipstrm.cpp:1940
 msgid "error reading zip local header"
 msgstr "Fehler beim Lesen des lokalen Headers in Zipdatei"
 
-#: ../src/common/zipstrm.cpp:2531
+#: ../src/common/zipstrm.cpp:2615
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr ""
 "Fehler beim Schreiben von Zip-Eintrag „%s“: Falsche Prüfsumme oder Länge"
 
-#: ../src/common/ffile.cpp:188
+#: ../src/common/zipstrm.cpp:2608
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr ""
+"Fehler beim Schreiben von Zip-Eintrag „%s“: Falsche Prüfsumme oder Länge"
+
+#: ../src/common/fontcmn.cpp:1205
+#, fuzzy
+msgid "extrabold"
+msgstr "fett"
+
+#: ../src/common/fontcmn.cpp:1223
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1167
+#, fuzzy
+msgid "extralight"
+msgstr "dünn"
+
+#: ../src/msw/webview_ie.cpp:1036
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "Kann „%s“ nicht ausführen\n"
+
+#: ../src/common/ffile.cpp:187
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "Versuch, die Datei „%s“ zu entladen, fehlgeschlagen"
 
+#: ../src/msw/webview_ie.cpp:1045
+#, fuzzy
+msgid "failed to retrieve execution result"
+msgstr "Versuch den Inhalt der RAS-Fehlernachricht zu holen, fehlgeschlagen"
+
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1030
+#: ../src/generic/datavgen.cpp:1150
 msgid "false"
 msgstr "falsch"
 
-#: ../src/common/datetimefmt.cpp:1966
+#: ../src/common/datetimefmt.cpp:1989
 msgid "fifteenth"
 msgstr "fünfzehnte"
 
-#: ../src/common/datetimefmt.cpp:1956
+#: ../src/common/datetimefmt.cpp:1979
 msgid "fifth"
 msgstr "fünfte"
 
@@ -8469,131 +8688,150 @@ msgstr ""
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "Datei „%s“: unerwartetes Zeichen %c in Zeile %zu."
 
-#: ../src/richtext/richtextbuffer.cpp:8738
+#: ../src/richtext/richtextbuffer.cpp:8736
 msgid "files"
 msgstr "Dateien"
 
-#: ../src/common/datetimefmt.cpp:1952
+#: ../src/common/datetimefmt.cpp:1975
 msgid "first"
 msgstr "erste"
 
-#: ../src/html/helpwnd.cpp:1252
+#: ../src/html/helpwnd.cpp:1250
 msgid "font size"
 msgstr "Schriftgröße"
 
-#: ../src/common/datetimefmt.cpp:1965
+#: ../src/common/datetimefmt.cpp:1988
 msgid "fourteenth"
 msgstr "vierzehnte"
 
-#: ../src/common/datetimefmt.cpp:1955
+#: ../src/common/datetimefmt.cpp:1978
 msgid "fourth"
 msgstr "vierte"
 
-#: ../src/common/appbase.cpp:783
+#: ../src/common/appbase.cpp:784
 msgid "generate verbose log messages"
 msgstr "ausführliche Log-Nachrichten erstellen"
 
-#: ../src/richtext/richtextbuffer.cpp:13138
-#: ../src/richtext/richtextbuffer.cpp:13248
+#: ../src/common/fontcmn.cpp:1215
+msgid "heavy"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:13133
+#: ../src/richtext/richtextbuffer.cpp:13243
 msgid "image"
 msgstr "Bild"
 
-#: ../src/common/tarstrm.cpp:796
+#: ../src/common/tarstrm.cpp:790
 msgid "incomplete header block in tar"
 msgstr "unvollständiger Kopfeintrag in tar"
 
-#: ../src/common/xtixml.cpp:489
+#: ../src/common/xtixml.cpp:485
 msgid "incorrect event handler string, missing dot"
 msgstr "Event-Handler-Zeichenkette falsch, Punkt fehlt"
 
-#: ../src/common/tarstrm.cpp:1381
+#: ../src/common/tarstrm.cpp:1375
 msgid "incorrect size given for tar entry"
 msgstr "Falsche Größe für tar-Eintrag"
 
-#: ../src/common/tarstrm.cpp:993
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:987
 msgid "invalid data in extended tar header"
 msgstr "ungültige Daten in erweitertem tar-Kopfeintrag"
 
-#: ../src/generic/logg.cpp:1030
+#: ../src/generic/logg.cpp:1027
 msgid "invalid message box return value"
 msgstr "ungültiger Rückgabewert des Hinweisfensters"
 
-#: ../src/common/zipstrm.cpp:1647
+#: ../src/common/zipstrm.cpp:1688
 msgid "invalid zip file"
 msgstr "Ungültige Zip-Datei"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:1228
 msgid "italic"
 msgstr "kursiv"
 
-#: ../src/common/fontcmn.cpp:991
+#: ../src/common/webrequest_curl.cpp:374
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "Spaltenbeschreibung konnte nicht installiert werden."
+
+#: ../src/common/fontcmn.cpp:1172
 msgid "light"
 msgstr "dünn"
 
-#: ../src/common/intl.cpp:303
-#, c-format
-msgid "locale '%s' cannot be set."
-msgstr "Lokale Umgebung „%s“ kann nicht gesetzt werden."
+#: ../src/common/fontcmn.cpp:1185
+msgid "medium"
+msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2125
+#: ../src/common/datetimefmt.cpp:2148
 msgid "midnight"
 msgstr "Mitternacht"
 
-#: ../src/common/datetimefmt.cpp:1970
+#: ../src/common/datetimefmt.cpp:1993
 msgid "nineteenth"
 msgstr "neunzehnte"
 
-#: ../src/common/datetimefmt.cpp:1960
+#: ../src/common/datetimefmt.cpp:1983
 msgid "ninth"
 msgstr "neunte"
 
-#: ../src/msw/dde.cpp:1116
+#: ../src/msw/dde.cpp:1180
 msgid "no DDE error."
 msgstr "kein DDE-Fehler."
 
-#: ../src/html/chm.cpp:327
+#: ../src/html/chm.cpp:324
 msgid "no error"
 msgstr "kein Fehler"
 
-#: ../src/dfb/fontmgr.cpp:174
+#: ../src/dfb/fontmgr.cpp:171
 #, c-format
 msgid "no fonts found in %s, using builtin font"
 msgstr "Keine Schriftarten in %s, gefunden"
 
-#: ../src/html/helpdata.cpp:657
+#: ../src/html/helpdata.cpp:650
 msgid "noname"
 msgstr "namenlos"
 
-#: ../src/common/datetimefmt.cpp:2124
+#: ../src/common/datetimefmt.cpp:2147
 msgid "noon"
 msgstr "mittags"
 
-#: ../src/richtext/richtextstyles.cpp:779
+#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "Normal"
 
-#: ../src/common/cmdline.cpp:1492
+#: ../src/common/cmdline.cpp:1488
 msgid "num"
 msgstr "num"
 
-#: ../src/common/xtixml.cpp:259
+#: ../src/common/accelcmn.cpp:194
+msgid "num "
+msgstr ""
+
+#: ../src/common/xtixml.cpp:255
 msgid "objects cannot have XML Text Nodes"
 msgstr "Objekte können keine XML-Textknoten haben"
 
-#: ../src/html/chm.cpp:339
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
 msgid "out of memory"
 msgstr "nicht genug Speicher"
 
-#: ../src/common/debugrpt.cpp:514
+#: ../src/common/debugrpt.cpp:515
 msgid "process context description"
 msgstr "Bearbeite Kontextbeschreibung"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:227
-#: ../src/richtext/richtextbackgroundpage.cpp:250
-#: ../src/richtext/richtextbackgroundpage.cpp:290
-#: ../src/richtext/richtextbackgroundpage.cpp:317
-#: ../src/richtext/richtextfontpage.cpp:177
-#: ../src/richtext/richtextfontpage.cpp:180
 #: ../src/richtext/richtextborderspage.cpp:255
 #: ../src/richtext/richtextborderspage.cpp:289
 #: ../src/richtext/richtextborderspage.cpp:323
@@ -8603,22 +8841,45 @@ msgstr "Bearbeite Kontextbeschreibung"
 #: ../src/richtext/richtextborderspage.cpp:491
 #: ../src/richtext/richtextborderspage.cpp:525
 #: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextfontpage.cpp:180
 msgid "pt"
 msgstr "pt"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:225
-#: ../src/richtext/richtextbackgroundpage.cpp:228
-#: ../src/richtext/richtextbackgroundpage.cpp:229
-#: ../src/richtext/richtextbackgroundpage.cpp:248
-#: ../src/richtext/richtextbackgroundpage.cpp:251
-#: ../src/richtext/richtextbackgroundpage.cpp:252
-#: ../src/richtext/richtextbackgroundpage.cpp:288
-#: ../src/richtext/richtextbackgroundpage.cpp:291
-#: ../src/richtext/richtextbackgroundpage.cpp:292
-#: ../src/richtext/richtextbackgroundpage.cpp:315
-#: ../src/richtext/richtextbackgroundpage.cpp:318
-#: ../src/richtext/richtextbackgroundpage.cpp:319
-#: ../src/richtext/richtextfontpage.cpp:178
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:659
+#: ../src/richtext/richtextsizepage.cpp:662
+#: ../src/richtext/richtextsizepage.cpp:663
 #: ../src/richtext/richtextborderspage.cpp:253
 #: ../src/richtext/richtextborderspage.cpp:256
 #: ../src/richtext/richtextborderspage.cpp:257
@@ -8670,260 +8931,270 @@ msgstr "pt"
 #: ../src/richtext/richtextmarginspage.cpp:387
 #: ../src/richtext/richtextmarginspage.cpp:389
 #: ../src/richtext/richtextmarginspage.cpp:390
-#: ../src/richtext/richtextsizepage.cpp:338
-#: ../src/richtext/richtextsizepage.cpp:341
-#: ../src/richtext/richtextsizepage.cpp:342
-#: ../src/richtext/richtextsizepage.cpp:372
-#: ../src/richtext/richtextsizepage.cpp:375
-#: ../src/richtext/richtextsizepage.cpp:376
-#: ../src/richtext/richtextsizepage.cpp:399
-#: ../src/richtext/richtextsizepage.cpp:402
-#: ../src/richtext/richtextsizepage.cpp:403
-#: ../src/richtext/richtextsizepage.cpp:426
-#: ../src/richtext/richtextsizepage.cpp:429
-#: ../src/richtext/richtextsizepage.cpp:430
-#: ../src/richtext/richtextsizepage.cpp:453
-#: ../src/richtext/richtextsizepage.cpp:456
-#: ../src/richtext/richtextsizepage.cpp:457
-#: ../src/richtext/richtextsizepage.cpp:480
-#: ../src/richtext/richtextsizepage.cpp:483
-#: ../src/richtext/richtextsizepage.cpp:484
-#: ../src/richtext/richtextsizepage.cpp:554
-#: ../src/richtext/richtextsizepage.cpp:557
-#: ../src/richtext/richtextsizepage.cpp:558
-#: ../src/richtext/richtextsizepage.cpp:589
-#: ../src/richtext/richtextsizepage.cpp:592
-#: ../src/richtext/richtextsizepage.cpp:593
-#: ../src/richtext/richtextsizepage.cpp:624
-#: ../src/richtext/richtextsizepage.cpp:627
-#: ../src/richtext/richtextsizepage.cpp:628
-#: ../src/richtext/richtextsizepage.cpp:659
-#: ../src/richtext/richtextsizepage.cpp:662
-#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextfontpage.cpp:178
 msgid "px"
 msgstr "px"
 
-#: ../src/common/accelcmn.cpp:193
+#: ../src/common/accelcmn.cpp:192
 msgid "rawctrl"
 msgstr "strg"
 
-#: ../src/html/chm.cpp:333
+#: ../src/html/chm.cpp:330
 msgid "read error"
 msgstr "Lesefehler"
 
-#: ../src/common/zipstrm.cpp:2085
+#: ../src/common/zipstrm.cpp:2155
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "Beim Lesen von Zipstream (Eintrag %s): Falsche Prüfsumme"
 
-#: ../src/common/zipstrm.cpp:2080
+#: ../src/common/zipstrm.cpp:2150
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "Beim Lesen von Zipstream (Eintrag %s): Falsche Länge"
 
-#: ../src/msw/dde.cpp:1159
+#: ../src/msw/dde.cpp:1223
 msgid "reentrancy problem."
 msgstr "Probleme beim Wiedereintreten."
 
-#: ../src/common/datetimefmt.cpp:1953
+#: ../src/common/datetimefmt.cpp:1976
 msgid "second"
 msgstr "zweite"
 
-#: ../src/html/chm.cpp:337
+#: ../src/html/chm.cpp:334
 msgid "seek error"
 msgstr "Seek-Fehler"
 
-#: ../src/common/datetimefmt.cpp:1968
+#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#, fuzzy
+msgid "semibold"
+msgstr "fett"
+
+#: ../src/common/datetimefmt.cpp:1991
 msgid "seventeenth"
 msgstr "siebzehnte"
 
-#: ../src/common/datetimefmt.cpp:1958
+#: ../src/common/datetimefmt.cpp:1981
 msgid "seventh"
 msgstr "siebte"
 
-#: ../src/common/accelcmn.cpp:191
+#: ../src/common/accelcmn.cpp:190
 msgid "shift"
 msgstr "Umschalt"
 
-#: ../src/common/appbase.cpp:773
+#: ../src/common/appbase.cpp:774
 msgid "show this help message"
 msgstr "Zeige diesen Hilfstext"
 
-#: ../src/common/datetimefmt.cpp:1967
+#: ../src/common/datetimefmt.cpp:1990
 msgid "sixteenth"
 msgstr "sechzehnte"
 
-#: ../src/common/datetimefmt.cpp:1957
+#: ../src/common/datetimefmt.cpp:1980
 msgid "sixth"
 msgstr "sechste"
 
-#: ../src/common/appcmn.cpp:234
+#: ../src/common/appcmn.cpp:255
 msgid "specify display mode to use (e.g. 640x480-16)"
 msgstr ""
 "Geben Sie eine zu verwendende Bildschirmauflösung ein (z. B. 640x48-16)"
 
-#: ../src/common/appcmn.cpp:220
+#: ../src/common/appcmn.cpp:241
 msgid "specify the theme to use"
 msgstr "geben Sie das zu benutzende Thema an"
 
-#: ../src/richtext/richtextbuffer.cpp:9340
+#: ../src/richtext/richtextbuffer.cpp:9337
 msgid "standard/circle"
 msgstr "Standard/Kreis"
 
-#: ../src/richtext/richtextbuffer.cpp:9341
+#: ../src/richtext/richtextbuffer.cpp:9338
 msgid "standard/circle-outline"
 msgstr "Standard/Kreisumriss"
 
-#: ../src/richtext/richtextbuffer.cpp:9343
+#: ../src/richtext/richtextbuffer.cpp:9340
 msgid "standard/diamond"
 msgstr "Standard/Raute"
 
-#: ../src/richtext/richtextbuffer.cpp:9342
+#: ../src/richtext/richtextbuffer.cpp:9339
 msgid "standard/square"
 msgstr "Standard/Quadrat"
 
-#: ../src/richtext/richtextbuffer.cpp:9344
+#: ../src/richtext/richtextbuffer.cpp:9341
 msgid "standard/triangle"
 msgstr "Standard/Dreieck"
 
-#: ../src/common/zipstrm.cpp:1985
+#: ../src/common/zipstrm.cpp:2055
 msgid "stored file length not in Zip header"
 msgstr "Gespeicherte Dateilänge nicht in Zip-Header"
 
-#: ../src/common/cmdline.cpp:1488
+#: ../src/common/cmdline.cpp:1484
 msgid "str"
 msgstr "str"
 
-#: ../src/common/fontcmn.cpp:982
+#: ../src/common/fontcmn.cpp:1145
 msgid "strikethrough"
 msgstr "Durchstreichen"
 
-#: ../src/common/tarstrm.cpp:1003 ../src/common/tarstrm.cpp:1025
-#: ../src/common/tarstrm.cpp:1507 ../src/common/tarstrm.cpp:1529
+#: ../src/common/tarstrm.cpp:997 ../src/common/tarstrm.cpp:1019
+#: ../src/common/tarstrm.cpp:1501 ../src/common/tarstrm.cpp:1523
 msgid "tar entry not open"
 msgstr "tar-Eintrag nicht geöffnet"
 
-#: ../src/common/datetimefmt.cpp:1961
+#: ../src/common/datetimefmt.cpp:1984
 msgid "tenth"
 msgstr "zehnte"
 
-#: ../src/msw/dde.cpp:1123
+#: ../src/msw/dde.cpp:1187
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "das Ergebnis zur Transaktion hat das „DDE_FBUSY“-Bit gesetzt."
 
-#: ../src/common/datetimefmt.cpp:1954
+#: ../src/common/fontcmn.cpp:1154
+msgid "thin"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:1977
 msgid "third"
 msgstr "dritte"
 
-#: ../src/common/datetimefmt.cpp:1964
+#: ../src/common/datetimefmt.cpp:1987
 msgid "thirteenth"
 msgstr "dreizehnte"
 
-#: ../src/common/datetimefmt.cpp:1758
+#: ../src/common/datetimefmt.cpp:1781
 msgid "today"
 msgstr "heute"
 
-#: ../src/common/datetimefmt.cpp:1760
+#: ../src/common/datetimefmt.cpp:1783
 msgid "tomorrow"
 msgstr "morgen"
 
-#: ../src/common/fileconf.cpp:1944
+#: ../src/common/fileconf.cpp:1946
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "Abschließenden Gegenschrägstrich in „%s“ ignoriert"
 
-#: ../src/gtk/aboutdlg.cpp:218
+#: ../src/gtk/aboutdlg.cpp:216
 msgid "translator-credits"
 msgstr "Übersetzer"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1028
+#: ../src/generic/datavgen.cpp:1148
 msgid "true"
 msgstr "wahr"
 
-#: ../src/common/datetimefmt.cpp:1963
+#: ../src/common/datetimefmt.cpp:1986
 msgid "twelfth"
 msgstr "zwölfte"
 
-#: ../src/common/datetimefmt.cpp:1971
+#: ../src/common/datetimefmt.cpp:1994
 msgid "twentieth"
 msgstr "zwanzigste"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:486 ../src/generic/datavgen.cpp:1263
+#: ../src/common/datavcmn.cpp:2068 ../src/generic/datavgen.cpp:1386
 msgid "unchecked"
 msgstr "nicht ausgewählt"
 
-#: ../src/common/fontcmn.cpp:802 ../src/common/fontcmn.cpp:978
+#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
 msgid "underlined"
 msgstr "unterstrichen"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:490
+#: ../src/common/datavcmn.cpp:2072
 msgid "undetermined"
 msgstr "untentschieden"
 
-#: ../src/common/fileconf.cpp:1979
+#: ../src/common/fileconf.cpp:1981
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "unerwartetes \" an Position %d in „%s“."
 
-#: ../src/common/tarstrm.cpp:1045
+#: ../src/common/tarstrm.cpp:1039
 msgid "unexpected end of file"
 msgstr "Unerwartetes Ende der Datei"
 
-#: ../src/generic/progdlgg.cpp:370 ../src/common/tarstrm.cpp:371
-#: ../src/common/tarstrm.cpp:394 ../src/common/tarstrm.cpp:425
+#: ../src/common/tarstrm.cpp:366 ../src/common/tarstrm.cpp:389
+#: ../src/common/tarstrm.cpp:420 ../src/generic/progdlgg.cpp:376
 msgid "unknown"
 msgstr "unbekannt"
 
-#: ../src/msw/registry.cpp:150
+#: ../src/msw/registry.cpp:139
 #, c-format
 msgid "unknown (%lu)"
 msgstr "unbekannt (%lu)"
 
-#: ../src/common/xtixml.cpp:253
+#: ../src/common/xtixml.cpp:249
 #, c-format
 msgid "unknown class %s"
 msgstr "Unbekannte Klasse %s"
 
-#: ../src/common/regex.cpp:258 ../src/html/chm.cpp:351
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "Fehler beim Komprimieren"
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "Fehler beim Entpacken"
+
+#: ../src/common/regex.cpp:255 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "unbekannter Fehler"
 
-#: ../src/msw/dialup.cpp:471
+#: ../src/msw/dialup.cpp:465
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "unbekannter Fehler (Fehlercode %08x)."
 
-#: ../src/common/fmapbase.cpp:834
+#: ../src/common/fmapbase.cpp:830
 #, c-format
 msgid "unknown-%d"
 msgstr "unbekannt-%d"
 
-#: ../src/common/docview.cpp:509
+#: ../src/common/docview.cpp:502
 msgid "unnamed"
 msgstr "Unbenannt"
 
-#: ../src/common/docview.cpp:1624
+#: ../src/common/docview.cpp:1618
 #, c-format
 msgid "unnamed%d"
 msgstr "Unbenannt%d"
 
-#: ../src/common/zipstrm.cpp:1999 ../src/common/zipstrm.cpp:2319
+#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
 msgid "unsupported Zip compression method"
 msgstr "nicht unterstütztes Zip-Kompressionsformat"
 
-#: ../src/common/translation.cpp:1892
+#: ../src/common/translation.cpp:1942
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "Verwende Nachrichtenkatalog „%s“ von „%s“."
 
-#: ../src/html/chm.cpp:335
+#: ../src/html/chm.cpp:332
 msgid "write error"
 msgstr "Schreibfehler"
 
-#: ../src/common/time.cpp:292
+#: ../src/gtk/glcanvas.cpp:187
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/common/time.cpp:285
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay fehlgeschlagen."
 
@@ -8936,15 +9207,15 @@ msgstr "wxWidgets konnte „open display“ nicht ausführen für „%s“: Abbr
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets konnte Display nicht öffnen. Abbruch."
 
-#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:431
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/common/datetimefmt.cpp:1759
+#: ../src/common/datetimefmt.cpp:1782
 msgid "yesterday"
 msgstr "Gestern"
 
-#: ../src/common/zstream.cpp:251 ../src/common/zstream.cpp:426
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
 #, c-format
 msgid "zlib error %d"
 msgstr "zlib-Fehler %d"
@@ -8953,6 +9224,81 @@ msgstr "zlib-Fehler %d"
 #: ../src/richtext/richtextbulletspage.cpp:288
 msgid "~"
 msgstr "~"
+
+#~ msgid " (while overwriting an existing item)"
+#~ msgstr " (während ein Element überschrieben wird)"
+
+#~ msgid "&Save as"
+#~ msgstr "Speichern &unter"
+
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "„%s“ enthält nicht nur gültige Zeichen"
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "„%s“ sollte numerisch sein."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "„%s“ sollte ausschließlich ASCII-Zeichen enthalten."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "„%s“ sollte nur alphabetische Zeichen enthalten."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "„%s“ sollte nur alphanumerische Zeichen enthalten."
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "„%s“ sollte ausschließlich Ziffern enthalten."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "Kann kein Fenster der Klasse „%s“ anlegen"
+
+#~ msgid "Could not initalize libnotify."
+#~ msgstr "Konnte libnotify nicht initialisieren."
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "Konnte das überlagerte Fenster nicht erzeugen"
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr ""
+#~ "Konnte den Kontext auf dem überlagerten Fenster nicht initialisieren"
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "Konnte die Datei „%s“ nicht nach Unicode konvertieren."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "Setzen von Text in das Text-Steuerelement fehlgeschlagen."
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr "Ungültige GTK+ Kommentarzeile, benutzen Sie „%s --help“"
+
+#~ msgid "No unused colour in image."
+#~ msgstr "Keine unbenutzte Farbe im Bild."
+
+#~ msgid "Not available"
+#~ msgstr "Nicht verfügbar"
+
+#~ msgid "Replace selection"
+#~ msgstr "Auswahl ersetzen"
+
+#~ msgid "Save as"
+#~ msgstr "Speichern unter"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Stil-Organisator"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr ""
+#~ "Die nachfolgenden Standard GTK+ Optionen werden ebenfalls unterstützt:\n"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr ""
+#~ "Sie können keine Überlagerung löschen, die nicht initialisiert wurde"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "Eine Überlagerung kann nicht zweimal initialisiert werden"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "Lokale Umgebung „%s“ kann nicht gesetzt werden."
 
 #~ msgid "Adding flavor TEXT failed"
 #~ msgstr "Das Hinzufügen der Variante TEXT schlug fehl"
@@ -8971,9 +9317,6 @@ msgstr "~"
 
 #~ msgid "Column could not be added."
 #~ msgstr "Spalte konnte nicht hinzugefügt werden."
-
-#~ msgid "Column description could not be initialized."
-#~ msgstr "Spaltenbeschreibung konnte nicht installiert werden."
 
 #~ msgid "Column index not found."
 #~ msgstr "Spaltenindex nicht gefunden."
@@ -9568,9 +9911,6 @@ msgstr "~"
 #~ msgid "Directory '%s' doesn't exist!"
 #~ msgstr "Verzeichnis »%s« existiert nicht."
 
-#~ msgid "File %s does not exist."
-#~ msgstr "Datei »%s« existiert nicht."
-
 #~ msgid "Mode %ix%i-%i not available."
 #~ msgstr "Darstellung %is%i-%i ist nicht vorhanden"
 
@@ -9748,9 +10088,6 @@ msgstr "~"
 
 #~ msgid "Failed to register OpenGL window class."
 #~ msgstr "Konnte OpenGL Fensterklasse nicht registrieren."
-
-#~ msgid "Fatal error"
-#~ msgstr "Nicht-behebbarer Fehler"
 
 #~ msgid "Fatal error: "
 #~ msgstr "Nicht-behebbarer Fehler: "

--- a/locale/el.po
+++ b/locale/el.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-21 14:25+0200\n"
+"POT-Creation-Date: 2020-10-18 23:11+0300\n"
 "PO-Revision-Date: 2005-02-16 09:03+0200\n"
 "Last-Translator: InterZone <info@interzone.gr>\n"
 "Language-Team: Tsolakos Stavros <tsolako1@otenet.gr>, Nassos Yiannopoulos "
@@ -12,14 +12,14 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../src/common/debugrpt.cpp:586
+#: ../src/common/debugrpt.cpp:587
 msgid ""
 "\n"
 "Please send this report to the program maintainer, thank you!\n"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:210
-#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:206
+#: ../src/richtext/richtextstyledlg.cpp:218
 msgid " "
 msgstr " "
 
@@ -27,73 +27,99 @@ msgstr " "
 msgid "              Thank you and we're sorry for the inconvenience!\n"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:573
+#: ../src/common/prntbase.cpp:568
 #, fuzzy, c-format
 msgid " (copy %d of %d)"
 msgstr "Σελίδα %d από %d"
 
-#: ../src/common/log.cpp:421
+#: ../src/common/log.cpp:440
 #, c-format
 msgid " (error %ld: %s)"
 msgstr " (σφάλμα %ld: %s)"
 
-#: ../src/common/imagtiff.cpp:72
+#: ../src/common/imagtiff.cpp:69
 #, fuzzy, c-format
 msgid " (in module \"%s\")"
 msgstr "tiff module: %s"
 
-#: ../src/osx/core/secretstore.cpp:138
-msgid " (while overwriting an existing item)"
-msgstr ""
-
-#: ../src/common/docview.cpp:1642
+#: ../src/common/docview.cpp:1636
 msgid " - "
 msgstr " - "
 
-#: ../src/richtext/richtextprint.cpp:593 ../src/html/htmprint.cpp:714
+#: ../src/html/htmprint.cpp:712 ../src/richtext/richtextprint.cpp:589
 msgid " Preview"
 msgstr " Προεπισκόπηση"
 
-#: ../src/common/fontcmn.cpp:824
+#: ../src/common/fontcmn.cpp:973
 #, fuzzy
 msgid " bold"
 msgstr "έντονο"
 
-#: ../src/common/fontcmn.cpp:840
+#: ../src/common/fontcmn.cpp:977
+#, fuzzy
+msgid " extra bold"
+msgstr "έντονο"
+
+#: ../src/common/fontcmn.cpp:985
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:957
+#, fuzzy
+msgid " extra light"
+msgstr "απαλό(light)"
+
+#: ../src/common/fontcmn.cpp:981
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1001
 #, fuzzy
 msgid " italic"
 msgstr "πλάγιο"
 
-#: ../src/common/fontcmn.cpp:820
+#: ../src/common/fontcmn.cpp:961
 #, fuzzy
 msgid " light"
 msgstr "απαλό(light)"
 
-#: ../src/common/fontcmn.cpp:807
+#: ../src/common/fontcmn.cpp:965
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:969
+#, fuzzy
+msgid " semi bold"
+msgstr "έντονο"
+
+#: ../src/common/fontcmn.cpp:940
 msgid " strikethrough"
 msgstr ""
 
-#: ../src/common/paper.cpp:117
+#: ../src/common/fontcmn.cpp:953
+msgid " thin"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
 msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
 msgstr "#10 Φάκελος, 4 1/8 x 9 1/2 ίντσες"
 
-#: ../src/common/paper.cpp:118
+#: ../src/common/paper.cpp:115
 msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
 msgstr "#11 Φάκελος, 4 1/2 x 10 3/8 ίντσες"
 
-#: ../src/common/paper.cpp:119
+#: ../src/common/paper.cpp:116
 msgid "#12 Envelope, 4 3/4 x 11 in"
 msgstr "#12 Φάκελος, 4 3/4 x 11 ίντσες"
 
-#: ../src/common/paper.cpp:120
+#: ../src/common/paper.cpp:117
 msgid "#14 Envelope, 5 x 11 1/2 in"
 msgstr "#14 Φάκελος, 5 x 11 1/2 ίντσες"
 
-#: ../src/common/paper.cpp:116
+#: ../src/common/paper.cpp:113
 msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
 msgstr "#9 Φάκελος, 3 7/8 x 8 7/8 ίντσες"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:341
 #: ../src/richtext/richtextsizepage.cpp:340
 #: ../src/richtext/richtextsizepage.cpp:374
 #: ../src/richtext/richtextsizepage.cpp:401
@@ -104,82 +130,83 @@ msgstr "#9 Φάκελος, 3 7/8 x 8 7/8 ίντσες"
 #: ../src/richtext/richtextsizepage.cpp:591
 #: ../src/richtext/richtextsizepage.cpp:626
 #: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextbackgroundpage.cpp:341
 #, fuzzy
 msgid "%"
 msgstr "%d"
 
-#: ../src/html/helpwnd.cpp:1031
+#: ../src/html/helpwnd.cpp:1029
 #, fuzzy, c-format
 msgid "%d of %lu"
 msgstr "%i από %i"
 
-#: ../src/html/helpwnd.cpp:1678
+#: ../src/html/helpwnd.cpp:1676
 #, fuzzy, c-format
 msgid "%i of %u"
 msgstr "%i από %i"
 
-#: ../src/generic/filectrlg.cpp:279
+#: ../src/generic/filectrlg.cpp:275
 #, fuzzy, c-format
 msgid "%ld byte"
 msgid_plural "%ld bytes"
 msgstr[0] "%ld bytes"
 msgstr[1] "%ld bytes"
 
-#: ../src/html/helpwnd.cpp:1033
+#: ../src/html/helpwnd.cpp:1031
 #, fuzzy, c-format
 msgid "%lu of %lu"
 msgstr "%i από %i"
 
-#: ../src/generic/datavgen.cpp:6028
+#: ../src/generic/datavgen.cpp:6833
 #, fuzzy, c-format
 msgid "%s (%d items)"
 msgstr "%s (ή %s)"
 
-#: ../src/common/cmdline.cpp:1221
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (ή %s)"
 
-#: ../src/generic/logg.cpp:224
+#: ../src/generic/logg.cpp:221
 #, c-format
 msgid "%s Error"
 msgstr "%s Σφάλμα"
 
-#: ../src/generic/logg.cpp:236
+#: ../src/generic/logg.cpp:233
 #, c-format
 msgid "%s Information"
 msgstr "%s Πληροφορίες"
 
-#: ../src/generic/preferencesg.cpp:113
+#: ../src/generic/preferencesg.cpp:110
 #, fuzzy, c-format
 msgid "%s Preferences"
 msgstr "&Προτιμήσεις"
 
-#: ../src/generic/logg.cpp:228
+#: ../src/generic/logg.cpp:225
 #, c-format
 msgid "%s Warning"
 msgstr "%s Προειδοποίηση"
 
-#: ../src/common/tarstrm.cpp:1319
+#: ../src/common/tarstrm.cpp:1313
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr ""
 
-#: ../src/common/fldlgcmn.cpp:124
+#: ../src/common/fldlgcmn.cpp:121
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s αρχεία (%s)|%s"
 
-#: ../src/html/helpwnd.cpp:1716
+#: ../src/html/helpwnd.cpp:1714
 #, fuzzy, c-format
 msgid "%u of %u"
 msgstr "%i από %i"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "&About"
 msgstr "&Περί"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "&Actual Size"
 msgstr "&Πραγματικό μέγεθος"
 
@@ -187,30 +214,30 @@ msgstr "&Πραγματικό μέγεθος"
 msgid "&After a paragraph:"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:128
 #: ../src/richtext/richtextliststylepage.cpp:319
+#: ../src/richtext/richtextindentspage.cpp:128
 #, fuzzy
 msgid "&Alignment"
 msgstr "Στοίχιση Αριστερά"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "&Apply"
 msgstr "&Εφαρμογή"
 
-#: ../src/richtext/richtextstyledlg.cpp:251
+#: ../src/richtext/richtextstyledlg.cpp:247
 #, fuzzy
 msgid "&Apply Style"
 msgstr "&Εφαρμογή"
 
-#: ../src/msw/mdi.cpp:179
+#: ../src/msw/mdi.cpp:174
 msgid "&Arrange Icons"
 msgstr "&Τακτοποίηση εικονιδίων"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "&Ascending"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:142
+#: ../src/common/stockitem.cpp:139
 msgid "&Back"
 msgstr "&Πίσω"
 
@@ -231,24 +258,24 @@ msgstr "&Χρώμα:"
 msgid "&Blur distance:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:143
+#: ../src/common/stockitem.cpp:140
 msgid "&Bold"
 msgstr "&Έντονο"
 
-#: ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141
 msgid "&Bottom"
 msgstr ""
 
+#: ../src/richtext/richtextsizepage.cpp:637
+#: ../src/richtext/richtextsizepage.cpp:644
 #: ../src/richtext/richtextborderspage.cpp:345
 #: ../src/richtext/richtextborderspage.cpp:513
 #: ../src/richtext/richtextmarginspage.cpp:259
 #: ../src/richtext/richtextmarginspage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:637
-#: ../src/richtext/richtextsizepage.cpp:644
 msgid "&Bottom:"
 msgstr ""
 
-#: ../include/wx/richtext/richtextbuffer.h:3866
+#: ../include/wx/richtext/richtextbuffer.h:3861
 #, fuzzy
 msgid "&Box"
 msgstr "&Έντονο"
@@ -258,39 +285,39 @@ msgstr "&Έντονο"
 msgid "&Bullet style:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "&CD-Rom"
 msgstr ""
 
-#: ../src/generic/wizard.cpp:434 ../src/generic/fontdlgg.cpp:470
-#: ../src/generic/fontdlgg.cpp:489 ../src/osx/carbon/fontdlg.cpp:402
-#: ../src/common/dlgcmn.cpp:279 ../src/common/stockitem.cpp:145
+#: ../src/osx/carbon/fontdlg.cpp:399 ../src/common/stockitem.cpp:142
+#: ../src/generic/wizard.cpp:433 ../src/generic/fontdlgg.cpp:466
+#: ../src/generic/fontdlgg.cpp:485 ../src/osx/cocoa/button.mm:200
 msgid "&Cancel"
 msgstr "&Ακυρο"
 
-#: ../src/msw/mdi.cpp:175
+#: ../src/msw/mdi.cpp:170
 msgid "&Cascade"
 msgstr "&Επικάλυψη"
 
-#: ../include/wx/richtext/richtextbuffer.h:5960
+#: ../include/wx/richtext/richtextbuffer.h:5955
 #, fuzzy
 msgid "&Cell"
 msgstr "&Ακυρο"
 
-#: ../src/richtext/richtextsymboldlg.cpp:439
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "&Character code:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:147
+#: ../src/common/stockitem.cpp:144
 msgid "&Clear"
 msgstr "&Καθαρισμός"
 
-#: ../src/generic/logg.cpp:516 ../src/common/stockitem.cpp:148
-#: ../src/common/prntbase.cpp:1600 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/stockitem.cpp:145 ../src/common/prntbase.cpp:1625
+#: ../src/univ/themes/win32.cpp:3753 ../src/generic/logg.cpp:513
 msgid "&Close"
 msgstr "&Κλείσιμο"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 #, fuzzy
 msgid "&Color"
 msgstr "&Χρώμα:"
@@ -300,22 +327,22 @@ msgstr "&Χρώμα:"
 msgid "&Colour:"
 msgstr "&Χρώμα:"
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 #, fuzzy
 msgid "&Convert"
 msgstr "Περιεχόμενα"
 
-#: ../src/richtext/richtextctrl.cpp:333 ../src/osx/textctrl_osx.cpp:577
-#: ../src/common/stockitem.cpp:150 ../src/msw/textctrl.cpp:2508
+#: ../src/osx/textctrl_osx.cpp:595 ../src/common/stockitem.cpp:147
+#: ../src/msw/textctrl.cpp:2773 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Αντιγραφή"
 
-#: ../src/generic/hyperlinkg.cpp:156
+#: ../src/generic/hyperlinkg.cpp:153
 #, fuzzy
 msgid "&Copy URL"
 msgstr "&Αντιγραφή"
 
-#: ../src/common/headerctrlcmn.cpp:306
+#: ../src/common/headerctrlcmn.cpp:304
 #, fuzzy
 msgid "&Customize..."
 msgstr "μέγεθος γραμματοσειράς"
@@ -324,55 +351,56 @@ msgstr "μέγεθος γραμματοσειράς"
 msgid "&Debug report preview:"
 msgstr ""
 
-#: ../src/richtext/richtexttabspage.cpp:138
-#: ../src/richtext/richtextctrl.cpp:335 ../src/osx/textctrl_osx.cpp:579
-#: ../src/common/stockitem.cpp:152 ../src/msw/textctrl.cpp:2510
+#: ../src/osx/textctrl_osx.cpp:597 ../src/common/stockitem.cpp:149
+#: ../src/msw/textctrl.cpp:2775 ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtextctrl.cpp:334
 msgid "&Delete"
 msgstr "&Διαγραφή"
 
-#: ../src/richtext/richtextstyledlg.cpp:269
+#: ../src/richtext/richtextstyledlg.cpp:265
 #, fuzzy
 msgid "&Delete Style..."
 msgstr "Διαγραφή στοιχείου"
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "&Descending"
 msgstr ""
 
-#: ../src/generic/logg.cpp:682
+#: ../src/generic/logg.cpp:679
 msgid "&Details"
 msgstr "&Λεπτομέρειες"
 
-#: ../src/common/stockitem.cpp:153
+#: ../src/common/stockitem.cpp:150
 msgid "&Down"
 msgstr "&Κάτω"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "&Edit"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:263
+#: ../src/richtext/richtextstyledlg.cpp:259
 #, fuzzy
 msgid "&Edit Style..."
 msgstr "Επεξεργασία στοιχείου"
 
-#: ../src/common/stockitem.cpp:155
+#: ../src/common/stockitem.cpp:152
 msgid "&Execute"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/common/stockitem.cpp:154
 msgid "&File"
 msgstr "&Αρχείο"
 
-#: ../src/common/stockitem.cpp:158
-msgid "&Find"
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "&Find..."
 msgstr "&Εύρεση"
 
-#: ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:430
 msgid "&Finish"
 msgstr "&Τέλος"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:156
 #, fuzzy
 msgid "&First"
 msgstr "πρώτο"
@@ -381,17 +409,17 @@ msgstr "πρώτο"
 msgid "&Floating mode:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 #, fuzzy
 msgid "&Floppy"
 msgstr "&Αντιγραφή"
 
-#: ../src/common/stockitem.cpp:194
+#: ../src/common/stockitem.cpp:191
 #, fuzzy
 msgid "&Font"
 msgstr "Οικογένεια γραμματοσειράς:"
 
-#: ../src/generic/fontdlgg.cpp:371
+#: ../src/generic/fontdlgg.cpp:367
 msgid "&Font family:"
 msgstr "Οικογένεια γραμματοσειράς:"
 
@@ -399,22 +427,22 @@ msgstr "Οικογένεια γραμματοσειράς:"
 msgid "&Font for Level..."
 msgstr ""
 
+#: ../src/richtext/richtextsymboldlg.cpp:397
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:400
 #, fuzzy
 msgid "&Font:"
 msgstr "Οικογένεια γραμματοσειράς:"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "&Forward"
 msgstr "&Εμπρός"
 
-#: ../src/richtext/richtextsymboldlg.cpp:451
+#: ../src/richtext/richtextsymboldlg.cpp:448
 #, fuzzy
 msgid "&From:"
 msgstr "Από:"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "&Harddisk"
 msgstr ""
 
@@ -424,9 +452,9 @@ msgstr ""
 msgid "&Height:"
 msgstr "&Βάρος:"
 
-#: ../src/generic/wizard.cpp:441 ../src/richtext/richtextstyledlg.cpp:303
-#: ../src/richtext/richtextsymboldlg.cpp:479 ../src/osx/menu_osx.cpp:734
-#: ../src/common/stockitem.cpp:163
+#: ../src/common/stockitem.cpp:160 ../src/generic/wizard.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextstyledlg.cpp:299 ../src/osx/cocoa/menu.mm:226
 msgid "&Help"
 msgstr "&Βοήθεια"
 
@@ -435,7 +463,7 @@ msgstr "&Βοήθεια"
 msgid "&Hide details"
 msgstr "&Λεπτομέρειες"
 
-#: ../src/common/stockitem.cpp:164
+#: ../src/common/stockitem.cpp:161
 msgid "&Home"
 msgstr "&Αρχική"
 
@@ -443,58 +471,58 @@ msgstr "&Αρχική"
 msgid "&Horizontal offset:"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:184
 #: ../src/richtext/richtextliststylepage.cpp:372
+#: ../src/richtext/richtextindentspage.cpp:184
 msgid "&Indentation (tenths of a mm)"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:167
 #: ../src/richtext/richtextliststylepage.cpp:356
+#: ../src/richtext/richtextindentspage.cpp:167
 #, fuzzy
 msgid "&Indeterminate"
 msgstr "&Υπογράμμιση"
 
-#: ../src/common/stockitem.cpp:166
+#: ../src/common/stockitem.cpp:163
 msgid "&Index"
 msgstr "&Ευρετήριο"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 #, fuzzy
 msgid "&Info"
 msgstr "&Αναίρεση"
 
-#: ../src/common/stockitem.cpp:168
+#: ../src/common/stockitem.cpp:165
 msgid "&Italic"
 msgstr "&Πλάγια"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "&Jump to"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:153
 #: ../src/richtext/richtextliststylepage.cpp:342
+#: ../src/richtext/richtextindentspage.cpp:153
 #, fuzzy
 msgid "&Justified"
 msgstr "Ευθυγραμμισμένα"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 #, fuzzy
 msgid "&Last"
 msgstr "&Επικόληση"
 
-#: ../src/richtext/richtextindentspage.cpp:139
 #: ../src/richtext/richtextliststylepage.cpp:328
+#: ../src/richtext/richtextindentspage.cpp:139
 msgid "&Left"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:195
+#: ../src/richtext/richtextsizepage.cpp:532
+#: ../src/richtext/richtextsizepage.cpp:539
 #: ../src/richtext/richtextborderspage.cpp:243
 #: ../src/richtext/richtextborderspage.cpp:411
 #: ../src/richtext/richtextliststylepage.cpp:381
+#: ../src/richtext/richtextindentspage.cpp:195
 #: ../src/richtext/richtextmarginspage.cpp:186
 #: ../src/richtext/richtextmarginspage.cpp:300
-#: ../src/richtext/richtextsizepage.cpp:532
-#: ../src/richtext/richtextsizepage.cpp:539
 msgid "&Left:"
 msgstr ""
 
@@ -502,11 +530,11 @@ msgstr ""
 msgid "&List level:"
 msgstr ""
 
-#: ../src/generic/logg.cpp:517
+#: ../src/generic/logg.cpp:514
 msgid "&Log"
 msgstr "&Καταγραφή"
 
-#: ../src/univ/themes/win32.cpp:3748
+#: ../src/univ/themes/win32.cpp:3745
 msgid "&Move"
 msgstr "&Μετακίνηση"
 
@@ -514,21 +542,20 @@ msgstr "&Μετακίνηση"
 msgid "&Move the object to:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 #, fuzzy
 msgid "&Network"
 msgstr "&Νέο"
 
-#: ../src/richtext/richtexttabspage.cpp:132 ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173 ../src/richtext/richtexttabspage.cpp:132
 msgid "&New"
 msgstr "&Νέο"
 
-#: ../src/aui/tabmdi.cpp:111 ../src/generic/mdig.cpp:100
-#: ../src/msw/mdi.cpp:180
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
 msgid "&Next"
 msgstr "&Επόμενο"
 
-#: ../src/generic/wizard.cpp:432 ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:429
 msgid "&Next >"
 msgstr "&Επόμενο >"
 
@@ -536,7 +563,7 @@ msgstr "&Επόμενο >"
 msgid "&Next Paragraph"
 msgstr ""
 
-#: ../src/generic/tipdlg.cpp:240
+#: ../src/generic/tipdlg.cpp:237
 msgid "&Next Tip"
 msgstr "&Επόμενο Tip"
 
@@ -545,11 +572,11 @@ msgstr "&Επόμενο Tip"
 msgid "&Next style:"
 msgstr "&Επόμενο >"
 
-#: ../src/common/stockitem.cpp:177 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:174 ../src/msw/msgdlg.cpp:435
 msgid "&No"
 msgstr "&Όχι"
 
-#: ../src/generic/dbgrptg.cpp:356
+#: ../src/generic/dbgrptg.cpp:360
 #, fuzzy
 msgid "&Notes:"
 msgstr "&Όχι"
@@ -558,12 +585,12 @@ msgstr "&Όχι"
 msgid "&Number:"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:475 ../src/generic/fontdlgg.cpp:482
-#: ../src/osx/carbon/fontdlg.cpp:408 ../src/common/stockitem.cpp:178
+#: ../src/osx/carbon/fontdlg.cpp:405 ../src/common/stockitem.cpp:175
+#: ../src/generic/fontdlgg.cpp:471 ../src/generic/fontdlgg.cpp:478
 msgid "&OK"
 msgstr "&OK"
 
-#: ../src/generic/dbgrptg.cpp:342 ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176 ../src/generic/dbgrptg.cpp:342
 msgid "&Open..."
 msgstr "&Ανοιγμα..."
 
@@ -575,16 +602,16 @@ msgstr ""
 msgid "&Page Break"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:334 ../src/osx/textctrl_osx.cpp:578
-#: ../src/common/stockitem.cpp:180 ../src/msw/textctrl.cpp:2509
+#: ../src/osx/textctrl_osx.cpp:596 ../src/common/stockitem.cpp:177
+#: ../src/msw/textctrl.cpp:2774 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&Επικόληση"
 
-#: ../include/wx/richtext/richtextbuffer.h:5010
+#: ../include/wx/richtext/richtextbuffer.h:5005
 msgid "&Picture"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:419
 msgid "&Point size:"
 msgstr "Μέγεθος κουκίδας:"
 
@@ -597,12 +624,11 @@ msgstr ""
 msgid "&Position mode:"
 msgstr "Ερώτημα"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178
 msgid "&Preferences"
 msgstr "&Προτιμήσεις"
 
-#: ../src/aui/tabmdi.cpp:112 ../src/generic/mdig.cpp:101
-#: ../src/msw/mdi.cpp:181
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
 msgid "&Previous"
 msgstr "&Προηγούμενο"
 
@@ -611,82 +637,77 @@ msgstr "&Προηγούμενο"
 msgid "&Previous Paragraph"
 msgstr "Προηγούμενη σελίδα"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "&Print..."
 msgstr "&Εκτύπωση..."
 
-#: ../src/richtext/richtextctrl.cpp:339 ../src/richtext/richtextctrl.cpp:5514
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtextctrl.cpp:338
+#: ../src/richtext/richtextctrl.cpp:5512
 msgid "&Properties"
 msgstr "&Ιδιότητες"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "&Quit"
 msgstr "Έ&ξοδος"
 
-#: ../src/richtext/richtextctrl.cpp:330 ../src/osx/textctrl_osx.cpp:574
-#: ../src/common/stockitem.cpp:185 ../src/common/cmdproc.cpp:293
-#: ../src/common/cmdproc.cpp:300 ../src/msw/textctrl.cpp:2505
+#: ../src/osx/textctrl_osx.cpp:592 ../src/common/stockitem.cpp:182
+#: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
+#: ../src/msw/textctrl.cpp:2770 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Επανάληψη"
 
-#: ../src/common/cmdproc.cpp:289 ../src/common/cmdproc.cpp:309
+#: ../src/common/cmdproc.cpp:282 ../src/common/cmdproc.cpp:302
 msgid "&Redo "
 msgstr "&Επανάληψη "
 
-#: ../src/richtext/richtextstyledlg.cpp:257
+#: ../src/richtext/richtextstyledlg.cpp:253
 msgid "&Rename Style..."
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:179
+#: ../src/generic/fdrepdlg.cpp:176
 msgid "&Replace"
 msgstr "&Αντικατάσταση"
 
-#: ../src/richtext/richtextstyledlg.cpp:287
+#: ../src/richtext/richtextstyledlg.cpp:283
 msgid "&Restart numbering"
 msgstr ""
 
-#: ../src/univ/themes/win32.cpp:3747
+#: ../src/univ/themes/win32.cpp:3744
 msgid "&Restore"
 msgstr "&Επαναφορά"
 
-#: ../src/richtext/richtextindentspage.cpp:146
 #: ../src/richtext/richtextliststylepage.cpp:335
+#: ../src/richtext/richtextindentspage.cpp:146
 #, fuzzy
 msgid "&Right"
 msgstr "Απαλό(light)"
 
-#: ../src/richtext/richtextindentspage.cpp:213
+#: ../src/richtext/richtextsizepage.cpp:602
+#: ../src/richtext/richtextsizepage.cpp:609
 #: ../src/richtext/richtextborderspage.cpp:277
 #: ../src/richtext/richtextborderspage.cpp:445
 #: ../src/richtext/richtextliststylepage.cpp:399
+#: ../src/richtext/richtextindentspage.cpp:213
 #: ../src/richtext/richtextmarginspage.cpp:211
 #: ../src/richtext/richtextmarginspage.cpp:325
-#: ../src/richtext/richtextsizepage.cpp:602
-#: ../src/richtext/richtextsizepage.cpp:609
 #, fuzzy
 msgid "&Right:"
 msgstr "&Βάρος:"
 
-#: ../src/common/stockitem.cpp:190
+#: ../src/common/stockitem.cpp:187
 msgid "&Save"
 msgstr "&Αποθήκευση"
-
-#: ../src/common/stockitem.cpp:191
-#, fuzzy
-msgid "&Save as"
-msgstr "Αποθήκευση ως"
 
 #: ../include/wx/richmsgdlg.h:29
 #, fuzzy
 msgid "&See details"
 msgstr "&Λεπτομέρειες"
 
-#: ../src/generic/tipdlg.cpp:236
+#: ../src/generic/tipdlg.cpp:233
 msgid "&Show tips at startup"
 msgstr "&Εμφάνιση tips κατά την εκκίνηση"
 
-#: ../src/univ/themes/win32.cpp:3750
+#: ../src/univ/themes/win32.cpp:3747
 msgid "&Size"
 msgstr "&Μέγεθος"
 
@@ -695,38 +716,38 @@ msgstr "&Μέγεθος"
 msgid "&Size:"
 msgstr "&Μέγεθος"
 
-#: ../src/generic/progdlgg.cpp:252
+#: ../src/generic/progdlgg.cpp:249
 #, fuzzy
 msgid "&Skip"
 msgstr "Παράλειψη"
 
-#: ../src/richtext/richtextindentspage.cpp:242
 #: ../src/richtext/richtextliststylepage.cpp:417
+#: ../src/richtext/richtextindentspage.cpp:242
 msgid "&Spacing (tenths of a mm)"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "&Spell Check"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "&Stop"
 msgstr "&Διακοπή"
 
-#: ../src/richtext/richtextfontpage.cpp:275 ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196 ../src/richtext/richtextfontpage.cpp:275
 msgid "&Strikethrough"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:382 ../src/richtext/richtextstylepage.cpp:106
+#: ../src/generic/fontdlgg.cpp:378 ../src/richtext/richtextstylepage.cpp:106
 msgid "&Style:"
 msgstr "&Στυλ:"
 
-#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:194
 #, fuzzy
 msgid "&Styles:"
 msgstr "&Στυλ:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:413
+#: ../src/richtext/richtextsymboldlg.cpp:410
 msgid "&Subset:"
 msgstr ""
 
@@ -741,26 +762,26 @@ msgstr "&Στυλ:"
 msgid "&Synchronize values"
 msgstr ""
 
-#: ../include/wx/richtext/richtextbuffer.h:6069
+#: ../include/wx/richtext/richtextbuffer.h:6064
 msgid "&Table"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197
 #, fuzzy
 msgid "&Top"
 msgstr "&Αντιγραφή"
 
+#: ../src/richtext/richtextsizepage.cpp:567
+#: ../src/richtext/richtextsizepage.cpp:574
 #: ../src/richtext/richtextborderspage.cpp:311
 #: ../src/richtext/richtextborderspage.cpp:479
 #: ../src/richtext/richtextmarginspage.cpp:234
 #: ../src/richtext/richtextmarginspage.cpp:348
-#: ../src/richtext/richtextsizepage.cpp:567
-#: ../src/richtext/richtextsizepage.cpp:574
 #, fuzzy
 msgid "&Top:"
 msgstr "Πρός:"
 
-#: ../src/generic/fontdlgg.cpp:444 ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199 ../src/generic/fontdlgg.cpp:441
 msgid "&Underline"
 msgstr "&Υπογράμμιση"
 
@@ -769,21 +790,21 @@ msgstr "&Υπογράμμιση"
 msgid "&Underlining:"
 msgstr "&Υπογράμμιση"
 
-#: ../src/richtext/richtextctrl.cpp:329 ../src/osx/textctrl_osx.cpp:573
-#: ../src/common/stockitem.cpp:203 ../src/common/cmdproc.cpp:271
-#: ../src/msw/textctrl.cpp:2504
+#: ../src/osx/textctrl_osx.cpp:591 ../src/common/stockitem.cpp:200
+#: ../src/common/cmdproc.cpp:264 ../src/msw/textctrl.cpp:2769
+#: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Αναίρεση"
 
-#: ../src/common/cmdproc.cpp:265
+#: ../src/common/cmdproc.cpp:258
 msgid "&Undo "
 msgstr "&Αναίρεση "
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "&Unindent"
 msgstr "Α&ποστοίχιση"
 
-#: ../src/common/stockitem.cpp:205
+#: ../src/common/stockitem.cpp:202
 msgid "&Up"
 msgstr "&Επάνω"
 
@@ -802,7 +823,7 @@ msgstr "Στοίχιση Αριστερά"
 msgid "&View..."
 msgstr "&Ανοιγμα..."
 
-#: ../src/generic/fontdlgg.cpp:393
+#: ../src/generic/fontdlgg.cpp:389
 msgid "&Weight:"
 msgstr "&Βάρος:"
 
@@ -812,88 +833,58 @@ msgstr "&Βάρος:"
 msgid "&Width:"
 msgstr "&Βάρος:"
 
-#: ../src/aui/tabmdi.cpp:311 ../src/aui/tabmdi.cpp:327
-#: ../src/aui/tabmdi.cpp:329 ../src/generic/mdig.cpp:294
-#: ../src/generic/mdig.cpp:310 ../src/generic/mdig.cpp:314
-#: ../src/msw/mdi.cpp:78
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
 msgid "&Window"
 msgstr "&Παράθυρο"
 
-#: ../src/common/stockitem.cpp:206 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:203 ../src/msw/msgdlg.cpp:435
 msgid "&Yes"
 msgstr "&Ναι"
 
-#: ../src/common/valtext.cpp:256
+#: ../src/common/valtext.cpp:197
 #, fuzzy, c-format
-msgid "'%s' contains illegal characters"
+msgid "'%s' contains invalid character(s)"
 msgstr "'%s' πρέπει να περιέχει μόνο αλφαβητικούς χαρακτήρες."
 
-#: ../src/common/valtext.cpp:254
-#, fuzzy, c-format
-msgid "'%s' doesn't consist only of valid characters"
-msgstr "'%s' πρέπει να περιέχει μόνο αλφαβητικούς χαρακτήρες."
-
-#: ../src/common/config.cpp:519 ../src/msw/regconf.cpp:258
+#: ../src/common/config.cpp:515 ../src/msw/regconf.cpp:255
 #, c-format
 msgid "'%s' has extra '..', ignored."
 msgstr "'%s' περιέχει επιπλέον '..', αγνοήθηκαν."
 
-#: ../src/common/cmdline.cpp:1113 ../src/common/cmdline.cpp:1131
+#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' δεν είναι μία σωστή αριθμητική τιμή για την επιλογή '%s'."
 
-#: ../src/common/translation.cpp:1100
+#: ../src/common/translation.cpp:1142
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' δεν είναι ένας σωστός κατάλογος μηνυμάτων."
 
-#: ../src/common/valtext.cpp:165
+#: ../src/common/valtext.cpp:188
 #, fuzzy, c-format
 msgid "'%s' is not one of the valid strings"
 msgstr "'%s' δεν είναι ένας σωστός κατάλογος μηνυμάτων."
 
-#: ../src/common/valtext.cpp:167
+#: ../src/common/valtext.cpp:186
 #, fuzzy, c-format
 msgid "'%s' is one of the invalid strings"
 msgstr "'%s' δεν ισχύει"
 
-#: ../src/common/textbuf.cpp:237
+#: ../src/common/textbuf.cpp:233
 #, c-format
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' είναι πιθανόν ένας δυαδικός ( binary ) buffer"
-
-#: ../src/common/valtext.cpp:252
-#, c-format
-msgid "'%s' should be numeric."
-msgstr "'%s' πρέπει να είναι αριθμητικό."
-
-#: ../src/common/valtext.cpp:244
-#, c-format
-msgid "'%s' should only contain ASCII characters."
-msgstr "'%s' πρέπει να περιέχει ASCII χαρακτήρες."
-
-#: ../src/common/valtext.cpp:246
-#, c-format
-msgid "'%s' should only contain alphabetic characters."
-msgstr "'%s' πρέπει να περιέχει μόνο αλφαβητικούς χαρακτήρες."
-
-#: ../src/common/valtext.cpp:248
-#, c-format
-msgid "'%s' should only contain alphabetic or numeric characters."
-msgstr "'%s' πρέπει να περιέχει μόνο αλφαβητικούς ή αριθμητικούς χαρακτήρες."
-
-#: ../src/common/valtext.cpp:250
-#, fuzzy, c-format
-msgid "'%s' should only contain digits."
-msgstr "'%s' πρέπει να περιέχει ASCII χαρακτήρες."
 
 #: ../src/richtext/richtextliststylepage.cpp:229
 #: ../src/richtext/richtextbulletspage.cpp:166
 msgid "(*)"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:963
+#: ../src/html/helpwnd.cpp:961
 msgid "(Help)"
 msgstr "(Βοήθεια)"
 
@@ -902,28 +893,33 @@ msgstr "(Βοήθεια)"
 msgid "(None)"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:504
+#: ../src/richtext/richtextsymboldlg.cpp:503
 #, fuzzy
 msgid "(Normal text)"
 msgstr "Κανονική γραμματοσειρά:"
 
-#: ../src/html/helpwnd.cpp:419 ../src/html/helpwnd.cpp:1106
-#: ../src/html/helpwnd.cpp:1742
+#: ../src/html/helpwnd.cpp:417 ../src/html/helpwnd.cpp:1104
+#: ../src/html/helpwnd.cpp:1740
 msgid "(bookmarks)"
 msgstr "(σελιδοδείκτες)"
 
+#: ../src/msw/dlmsw.cpp:167
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (σφάλμα %ld: %s)"
+
+#: ../src/richtext/richtextformatdlg.cpp:876
+#: ../src/richtext/richtextliststylepage.cpp:448
+#: ../src/richtext/richtextliststylepage.cpp:460
+#: ../src/richtext/richtextliststylepage.cpp:461
 #: ../src/richtext/richtextindentspage.cpp:274
 #: ../src/richtext/richtextindentspage.cpp:286
 #: ../src/richtext/richtextindentspage.cpp:287
 #: ../src/richtext/richtextindentspage.cpp:311
 #: ../src/richtext/richtextindentspage.cpp:326
-#: ../src/richtext/richtextformatdlg.cpp:884
 #: ../src/richtext/richtextfontpage.cpp:349
 #: ../src/richtext/richtextfontpage.cpp:353
 #: ../src/richtext/richtextfontpage.cpp:357
-#: ../src/richtext/richtextliststylepage.cpp:448
-#: ../src/richtext/richtextliststylepage.cpp:460
-#: ../src/richtext/richtextliststylepage.cpp:461
 #, fuzzy
 msgid "(none)"
 msgstr "ανώνυμο"
@@ -943,7 +939,7 @@ msgstr ""
 msgid "+"
 msgstr ""
 
-#: ../src/msw/utils.cpp:1152
+#: ../src/msw/utils.cpp:1143
 msgid ", 64-bit edition"
 msgstr ""
 
@@ -952,174 +948,174 @@ msgstr ""
 msgid "-"
 msgstr ""
 
-#: ../src/generic/filepickerg.cpp:66
+#: ../src/generic/filepickerg.cpp:63
 #, fuzzy
 msgid "..."
 msgstr ".."
 
-#: ../src/richtext/richtextindentspage.cpp:276
 #: ../src/richtext/richtextliststylepage.cpp:450
+#: ../src/richtext/richtextindentspage.cpp:276
 msgid "1.1"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:277
 #: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextindentspage.cpp:277
 msgid "1.2"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:278
 #: ../src/richtext/richtextliststylepage.cpp:452
+#: ../src/richtext/richtextindentspage.cpp:278
 msgid "1.3"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:279
 #: ../src/richtext/richtextliststylepage.cpp:453
+#: ../src/richtext/richtextindentspage.cpp:279
 msgid "1.4"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:280
 #: ../src/richtext/richtextliststylepage.cpp:454
+#: ../src/richtext/richtextindentspage.cpp:280
 msgid "1.5"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:281
 #: ../src/richtext/richtextliststylepage.cpp:455
+#: ../src/richtext/richtextindentspage.cpp:281
 msgid "1.6"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:282
 #: ../src/richtext/richtextliststylepage.cpp:456
+#: ../src/richtext/richtextindentspage.cpp:282
 msgid "1.7"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:283
 #: ../src/richtext/richtextliststylepage.cpp:457
+#: ../src/richtext/richtextindentspage.cpp:283
 msgid "1.8"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:284
 #: ../src/richtext/richtextliststylepage.cpp:458
+#: ../src/richtext/richtextindentspage.cpp:284
 msgid "1.9"
 msgstr ""
 
-#: ../src/common/paper.cpp:140
+#: ../src/common/paper.cpp:137
 #, fuzzy
 msgid "10 x 11 in"
 msgstr "10 x 14 ίντσες"
 
-#: ../src/common/paper.cpp:113
+#: ../src/common/paper.cpp:110
 msgid "10 x 14 in"
 msgstr "10 x 14 ίντσες"
 
-#: ../src/common/paper.cpp:114
+#: ../src/common/paper.cpp:111
 msgid "11 x 17 in"
 msgstr "11 x 17 ίντσες"
 
-#: ../src/common/paper.cpp:184
+#: ../src/common/paper.cpp:181
 #, fuzzy
 msgid "12 x 11 in"
 msgstr "10 x 14 ίντσες"
 
-#: ../src/common/paper.cpp:141
+#: ../src/common/paper.cpp:138
 #, fuzzy
 msgid "15 x 11 in"
 msgstr "10 x 14 ίντσες"
 
-#: ../src/richtext/richtextindentspage.cpp:285
 #: ../src/richtext/richtextliststylepage.cpp:459
+#: ../src/richtext/richtextindentspage.cpp:285
 msgid "2"
 msgstr ""
 
-#: ../src/common/paper.cpp:132
+#: ../src/common/paper.cpp:129
 msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
 msgstr "6 3/4 Φάκελος, 3 5/8 x 6 1/2 ίντσες"
 
-#: ../src/common/paper.cpp:139
+#: ../src/common/paper.cpp:136
 #, fuzzy
 msgid "9 x 11 in"
 msgstr "11 x 17 ίντσες"
 
-#: ../src/html/htmprint.cpp:431
+#: ../src/html/htmprint.cpp:443
 msgid ": file does not exist!"
 msgstr ": το αρχείο δεν υπάρχει!"
 
-#: ../src/common/fontmap.cpp:199
+#: ../src/common/fontmap.cpp:196
 msgid ": unknown charset"
 msgstr ": άγνωστο σετ χαρακτήρων"
 
-#: ../src/common/fontmap.cpp:413
+#: ../src/common/fontmap.cpp:410
 msgid ": unknown encoding"
 msgstr ": άγνωστη κωδικοποίηση"
 
-#: ../src/generic/wizard.cpp:443
+#: ../src/generic/wizard.cpp:438
 msgid "< &Back"
 msgstr "< &Πίσω"
 
-#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:628
-#: ../src/osx/carbon/fontdlg.cpp:648
+#: ../src/osx/carbon/fontdlg.cpp:419 ../src/osx/carbon/fontdlg.cpp:625
+#: ../src/osx/carbon/fontdlg.cpp:645
 #, fuzzy
 msgid "<Any Decorative>"
 msgstr "Διακοσμητικός"
 
-#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:630
-#: ../src/osx/carbon/fontdlg.cpp:650
+#: ../src/osx/carbon/fontdlg.cpp:420 ../src/osx/carbon/fontdlg.cpp:627
+#: ../src/osx/carbon/fontdlg.cpp:647
 #, fuzzy
 msgid "<Any Modern>"
 msgstr "Μοντέρνο"
 
-#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:626
-#: ../src/osx/carbon/fontdlg.cpp:646
+#: ../src/osx/carbon/fontdlg.cpp:418 ../src/osx/carbon/fontdlg.cpp:623
+#: ../src/osx/carbon/fontdlg.cpp:643
 #, fuzzy
 msgid "<Any Roman>"
 msgstr "Ρωμαϊκό"
 
-#: ../src/osx/carbon/fontdlg.cpp:424 ../src/osx/carbon/fontdlg.cpp:632
-#: ../src/osx/carbon/fontdlg.cpp:652
+#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:629
+#: ../src/osx/carbon/fontdlg.cpp:649
 #, fuzzy
 msgid "<Any Script>"
 msgstr "Χειρόγραφο(Script)"
 
-#: ../src/osx/carbon/fontdlg.cpp:425 ../src/osx/carbon/fontdlg.cpp:637
-#: ../src/osx/carbon/fontdlg.cpp:656
+#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:634
+#: ../src/osx/carbon/fontdlg.cpp:653
 #, fuzzy
 msgid "<Any Swiss>"
 msgstr "Ελβετικό(Swiss)"
 
-#: ../src/osx/carbon/fontdlg.cpp:426 ../src/osx/carbon/fontdlg.cpp:634
-#: ../src/osx/carbon/fontdlg.cpp:654
+#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:631
+#: ../src/osx/carbon/fontdlg.cpp:651
 #, fuzzy
 msgid "<Any Teletype>"
 msgstr "Τηλέτυπο"
 
-#: ../src/osx/carbon/fontdlg.cpp:420
+#: ../src/osx/carbon/fontdlg.cpp:417
 msgid "<Any>"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
 msgid "<DIR>"
 msgstr "<ΚΑΤΑΛΟΓΟΣ>"
 
-#: ../src/generic/filectrlg.cpp:254 ../src/generic/filectrlg.cpp:277
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
 msgid "<DRIVE>"
 msgstr "<ΟΔΗΓΟΣ>"
 
-#: ../src/generic/filectrlg.cpp:252 ../src/generic/filectrlg.cpp:275
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
 msgid "<LINK>"
 msgstr "<ΣΥΝΔΕΣΗ>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1264
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Εντονη πλάγια όψη.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1270
+#: ../src/html/helpwnd.cpp:1268
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>έντονα πλάγια <u>υπογραμμισμένα</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1265
+#: ../src/html/helpwnd.cpp:1263
 msgid "<b>Bold face.</b> "
 msgstr "<b>Έντονη όψη</b>"
 
-#: ../src/html/helpwnd.cpp:1264
+#: ../src/html/helpwnd.cpp:1262
 msgid "<i>Italic face.</i> "
 msgstr "<i>Πλάγια όψη."
 
@@ -1129,15 +1125,15 @@ msgstr "<i>Πλάγια όψη."
 msgid ">"
 msgstr ">>"
 
-#: ../src/generic/dbgrptg.cpp:318
+#: ../src/generic/dbgrptg.cpp:317
 msgid "A debug report has been generated in the directory\n"
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:573
+#: ../src/common/debugrpt.cpp:574
 msgid "A debug report has been generated. It can be found in"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:418
+#: ../src/common/xtixml.cpp:414
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Μία μη άδεια συλλογή πρέπει να αποτελείται από κόμβους 'element'"
 
@@ -1148,120 +1144,120 @@ msgstr "Μία μη άδεια συλλογή πρέπει να αποτελεί
 msgid "A standard bullet name."
 msgstr ""
 
-#: ../src/common/paper.cpp:217
+#: ../src/common/paper.cpp:214
 #, fuzzy
 msgid "A0 sheet, 841 x 1189 mm"
 msgstr "Φύλλο A4, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:218
+#: ../src/common/paper.cpp:215
 #, fuzzy
 msgid "A1 sheet, 594 x 841 mm"
 msgstr "Φύλλο A3, 297 x 420 mm"
 
-#: ../src/common/paper.cpp:159
-msgid "A2 420 x 594 mm"
-msgstr ""
-
 #: ../src/common/paper.cpp:156
-#, fuzzy
-msgid "A3 Extra 322 x 445 mm"
-msgstr "C3 Φάκελος, 324 x 458 mm"
-
-#: ../src/common/paper.cpp:161
-#, fuzzy
-msgid "A3 Extra Transverse 322 x 445 mm"
-msgstr "C3 Φάκελος, 324 x 458 mm"
-
-#: ../src/common/paper.cpp:170
-#, fuzzy
-msgid "A3 Rotated 420 x 297 mm"
-msgstr "Φύλλο A4, 210 x 297 mm"
-
-#: ../src/common/paper.cpp:160
-#, fuzzy
-msgid "A3 Transverse 297 x 420 mm"
-msgstr "Φύλλο A3, 297 x 420 mm"
-
-#: ../src/common/paper.cpp:106
-msgid "A3 sheet, 297 x 420 mm"
-msgstr "Φύλλο A3, 297 x 420 mm"
-
-#: ../src/common/paper.cpp:146
-msgid "A4 Extra 9.27 x 12.69 in"
+msgid "A2 420 x 594 mm"
 msgstr ""
 
 #: ../src/common/paper.cpp:153
 #, fuzzy
+msgid "A3 Extra 322 x 445 mm"
+msgstr "C3 Φάκελος, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:158
+#, fuzzy
+msgid "A3 Extra Transverse 322 x 445 mm"
+msgstr "C3 Φάκελος, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:167
+#, fuzzy
+msgid "A3 Rotated 420 x 297 mm"
+msgstr "Φύλλο A4, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:157
+#, fuzzy
+msgid "A3 Transverse 297 x 420 mm"
+msgstr "Φύλλο A3, 297 x 420 mm"
+
+#: ../src/common/paper.cpp:103
+msgid "A3 sheet, 297 x 420 mm"
+msgstr "Φύλλο A3, 297 x 420 mm"
+
+#: ../src/common/paper.cpp:143
+msgid "A4 Extra 9.27 x 12.69 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:150
+#, fuzzy
 msgid "A4 Plus 210 x 330 mm"
 msgstr "Φύλλο A4, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:171
+#: ../src/common/paper.cpp:168
 #, fuzzy
 msgid "A4 Rotated 297 x 210 mm"
 msgstr "Φύλλο A3, 297 x 420 mm"
 
-#: ../src/common/paper.cpp:148
+#: ../src/common/paper.cpp:145
 #, fuzzy
 msgid "A4 Transverse 210 x 297 mm"
 msgstr "Φύλλο A4, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:97
+#: ../src/common/paper.cpp:94
 msgid "A4 sheet, 210 x 297 mm"
 msgstr "Φύλλο A4, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:107
+#: ../src/common/paper.cpp:104
 msgid "A4 small sheet, 210 x 297 mm"
 msgstr "Μικρό φύλλο A4, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:157
+#: ../src/common/paper.cpp:154
 #, fuzzy
 msgid "A5 Extra 174 x 235 mm"
 msgstr "Φύλλο A5, 148 x 210 mm"
 
-#: ../src/common/paper.cpp:172
+#: ../src/common/paper.cpp:169
 msgid "A5 Rotated 210 x 148 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:154
+#: ../src/common/paper.cpp:151
 #, fuzzy
 msgid "A5 Transverse 148 x 210 mm"
 msgstr "Φύλλο A5, 148 x 210 mm"
 
-#: ../src/common/paper.cpp:108
+#: ../src/common/paper.cpp:105
 msgid "A5 sheet, 148 x 210 mm"
 msgstr "Φύλλο A5, 148 x 210 mm"
 
-#: ../src/common/paper.cpp:164
+#: ../src/common/paper.cpp:161
 #, fuzzy
 msgid "A6 105 x 148 mm"
 msgstr "10 x 14 ίντσες"
 
-#: ../src/common/paper.cpp:177
+#: ../src/common/paper.cpp:174
 #, fuzzy
 msgid "A6 Rotated 148 x 105 mm"
 msgstr "Φύλλο A5, 148 x 210 mm"
 
-#: ../src/generic/fontdlgg.cpp:83 ../src/richtext/richtextformatdlg.cpp:529
-#: ../src/osx/carbon/fontdlg.cpp:153
+#: ../src/osx/carbon/fontdlg.cpp:150 ../src/generic/fontdlgg.cpp:79
+#: ../src/richtext/richtextformatdlg.cpp:521
 msgid "ABCDEFGabcdefg12345"
 msgstr "ΑΒΓΔΕΖαβγδεζ12345"
 
-#: ../src/richtext/richtextsymboldlg.cpp:458 ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
 msgid "ASCII"
 msgstr "ASCII"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 #, fuzzy
 msgid "About"
 msgstr "&Περί"
 
-#: ../src/generic/aboutdlgg.cpp:140 ../src/osx/menu_osx.cpp:558
-#: ../src/msw/aboutdlg.cpp:64
+#: ../src/osx/menu_osx.cpp:450 ../src/generic/aboutdlgg.cpp:137
+#: ../src/msw/aboutdlg.cpp:61
 #, fuzzy, c-format
 msgid "About %s"
 msgstr "&Περί..."
 
-#: ../src/osx/menu_osx.cpp:560
+#: ../src/osx/menu_osx.cpp:452
 #, fuzzy
 msgid "About..."
 msgstr "&Περί"
@@ -1271,39 +1267,39 @@ msgid "Absolute"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:873
+#: ../src/propgrid/advprops.cpp:774
 #, fuzzy
 msgid "ActiveBorder"
 msgstr "Μοντέρνο"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:874
+#: ../src/propgrid/advprops.cpp:775
 msgid "ActiveCaption"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 #, fuzzy
 msgid "Actual Size"
 msgstr "&Πραγματικό μέγεθος"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:140 ../src/common/accelcmn.cpp:81
+#: ../src/common/stockitem.cpp:137 ../src/common/accelcmn.cpp:78
 msgid "Add"
 msgstr "Προσθήκη"
 
-#: ../src/richtext/richtextbuffer.cpp:11455
+#: ../src/richtext/richtextbuffer.cpp:11454
 msgid "Add Column"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11392
+#: ../src/richtext/richtextbuffer.cpp:11391
 msgid "Add Row"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:432
+#: ../src/html/helpwnd.cpp:430
 msgid "Add current page to bookmarks"
 msgstr "Προσθήκη της τρέχουσας σελίδας στους σελιδοδείκτες"
 
-#: ../src/generic/colrdlgg.cpp:366
+#: ../src/generic/colrdlgg.cpp:386
 msgid "Add to custom colours"
 msgstr "Προσθήκη στα χρώματα χρήστη"
 
@@ -1315,12 +1311,12 @@ msgstr "AddToPropertyCollection κλήθηκε σε έναν γενικό access
 msgid "AddToPropertyCollection called w/o valid adder"
 msgstr "AddToPropertyCollection κλήθηκε χωρίς έγκυρο προσθέτη"
 
-#: ../src/html/helpctrl.cpp:159
+#: ../src/html/helpctrl.cpp:155
 #, c-format
 msgid "Adding book %s"
 msgstr "Προσθήκη βιβλίου %s"
 
-#: ../src/common/preferencescmn.cpp:43
+#: ../src/common/preferencescmn.cpp:40
 msgid "Advanced"
 msgstr ""
 
@@ -1328,11 +1324,11 @@ msgstr ""
 msgid "After a paragraph:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:172
+#: ../src/common/stockitem.cpp:169
 msgid "Align Left"
 msgstr "Στοίχιση Αριστερά"
 
-#: ../src/common/stockitem.cpp:173
+#: ../src/common/stockitem.cpp:170
 msgid "Align Right"
 msgstr "Στοίχιση Δεξιά"
 
@@ -1341,40 +1337,40 @@ msgstr "Στοίχιση Δεξιά"
 msgid "Alignment"
 msgstr "Στοίχιση Αριστερά"
 
-#: ../src/generic/prntdlgg.cpp:215
+#: ../src/generic/prntdlgg.cpp:208
 msgid "All"
 msgstr "Όλα"
 
-#: ../src/generic/filectrlg.cpp:1197 ../src/common/fldlgcmn.cpp:107
+#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1186
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Όλα τα αρχεία (%s)|%s"
 
-#: ../include/wx/defs.h:2886
+#: ../include/wx/defs.h:2582
 msgid "All files (*)|*"
 msgstr "Όλα τα αρχεία (*)|*"
 
-#: ../include/wx/defs.h:2883
+#: ../include/wx/defs.h:2579
 msgid "All files (*.*)|*.*"
 msgstr "Όλα τα αρχεία (*.*)|*.*"
 
-#: ../src/richtext/richtextstyles.cpp:1061
+#: ../src/richtext/richtextstyles.cpp:1058
 msgid "All styles"
 msgstr ""
 
-#: ../src/propgrid/manager.cpp:1528
+#: ../src/propgrid/manager.cpp:1544
 msgid "Alphabetic Mode"
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:425
+#: ../src/common/xtistrm.cpp:422
 msgid "Already Registered Object passed to SetObjectClassInfo"
 msgstr "Ένα ήδη Registered αντικείμενο δόθηκε στην SetObjectClassInfo"
 
-#: ../src/unix/dialup.cpp:353
+#: ../src/unix/dialup.cpp:352
 msgid "Already dialling ISP."
 msgstr "Γίνεται ήδη κλήση προς τον παροχέα Internet(ISP)."
 
-#: ../src/common/accelcmn.cpp:331 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/accelcmn.cpp:345 ../src/univ/themes/win32.cpp:3753
 msgid "Alt+"
 msgstr ""
 
@@ -1383,38 +1379,38 @@ msgstr ""
 msgid "An optional corner radius for adding rounded corners."
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:576
+#: ../src/common/debugrpt.cpp:577
 msgid "And includes the following files:\n"
 msgstr ""
 
-#: ../src/generic/animateg.cpp:162
+#: ../src/generic/animateg.cpp:145
 #, fuzzy, c-format
 msgid "Animation file is not of type %ld."
 msgstr "Αρχείο εικόνας δεν είναι τύπυ %d."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:872
+#: ../src/propgrid/advprops.cpp:773
 msgid "AppWorkspace"
 msgstr ""
 
-#: ../src/generic/logg.cpp:1014
+#: ../src/generic/logg.cpp:1011
 #, c-format
 msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
 msgstr ""
 "Να γίνει προσάρτηση(append) της καταγραφής(log) στο αρχείο '%s' (Επιλέγοντας "
 "[Όχι] θα το επικαλύψει(overwrite));"
 
-#: ../src/osx/menu_osx.cpp:577 ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:469 ../src/osx/menu_osx.cpp:477
 #, fuzzy
 msgid "Application"
 msgstr "Τμήματα"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 #, fuzzy
 msgid "Apply"
 msgstr "&Εφαρμογή"
 
-#: ../src/propgrid/advprops.cpp:1609
+#: ../src/propgrid/advprops.cpp:1515
 msgid "Aqua"
 msgstr ""
 
@@ -1423,31 +1419,31 @@ msgstr ""
 msgid "Arabic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:153
+#: ../src/common/fmapbase.cpp:150
 msgid "Arabic (ISO-8859-6)"
 msgstr "Αραβικό (ISO-8859-6)"
 
-#: ../src/msw/ole/automtn.cpp:672
+#: ../src/msw/ole/automtn.cpp:663
 #, fuzzy, c-format
 msgid "Argument %u not found."
 msgstr "αρχείο καταλόγου για την περιοχή (domain) '%s' δεν βρέθηκε."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1753
+#: ../src/propgrid/advprops.cpp:1654
 #, fuzzy
 msgid "Arrow"
 msgstr "αύριο"
 
-#: ../src/generic/aboutdlgg.cpp:184
+#: ../src/generic/aboutdlgg.cpp:181
 msgid "Artists"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 #, fuzzy
 msgid "Ascending"
 msgstr "γίνεται ανάγνωση"
 
-#: ../src/generic/filectrlg.cpp:433
+#: ../src/generic/filectrlg.cpp:429
 msgid "Attributes"
 msgstr "Χαρακτηριστικά"
 
@@ -1457,93 +1453,93 @@ msgstr "Χαρακτηριστικά"
 msgid "Available fonts."
 msgstr ""
 
-#: ../src/common/paper.cpp:137
+#: ../src/common/paper.cpp:134
 #, fuzzy
 msgid "B4 (ISO) 250 x 353 mm"
 msgstr "Φύλλο B4, 250 x 354 mm"
 
-#: ../src/common/paper.cpp:173
+#: ../src/common/paper.cpp:170
 msgid "B4 (JIS) Rotated 364 x 257 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:127
+#: ../src/common/paper.cpp:124
 msgid "B4 Envelope, 250 x 353 mm"
 msgstr "B4 Φάκελος, 250 x 353 mm"
 
-#: ../src/common/paper.cpp:109
+#: ../src/common/paper.cpp:106
 msgid "B4 sheet, 250 x 354 mm"
 msgstr "Φύλλο B4, 250 x 354 mm"
 
-#: ../src/common/paper.cpp:158
+#: ../src/common/paper.cpp:155
 msgid "B5 (ISO) Extra 201 x 276 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:174
+#: ../src/common/paper.cpp:171
 msgid "B5 (JIS) Rotated 257 x 182 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:155
+#: ../src/common/paper.cpp:152
 #, fuzzy
 msgid "B5 (JIS) Transverse 182 x 257 mm"
 msgstr "Φύλλο B5, 182 x 257 mm"
 
-#: ../src/common/paper.cpp:128
+#: ../src/common/paper.cpp:125
 msgid "B5 Envelope, 176 x 250 mm"
 msgstr "B5 Φάκελος, 176 x 250 mm"
 
-#: ../src/common/paper.cpp:110
+#: ../src/common/paper.cpp:107
 msgid "B5 sheet, 182 x 257 millimeter"
 msgstr "Φύλλο B5, 182 x 257 mm"
 
-#: ../src/common/paper.cpp:182
+#: ../src/common/paper.cpp:179
 msgid "B6 (JIS) 128 x 182 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:183
+#: ../src/common/paper.cpp:180
 msgid "B6 (JIS) Rotated 182 x 128 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:129
+#: ../src/common/paper.cpp:126
 msgid "B6 Envelope, 176 x 125 mm"
 msgstr "B6 Φάκελος, 176 x 125 mm"
 
-#: ../src/common/imagbmp.cpp:531 ../src/common/imagbmp.cpp:561
-#: ../src/common/imagbmp.cpp:576
+#: ../src/common/imagbmp.cpp:528 ../src/common/imagbmp.cpp:558
+#: ../src/common/imagbmp.cpp:573
 msgid "BMP: Couldn't allocate memory."
 msgstr "BMP: Δεν ήταν δυνατή η δέσμευση(allocation) μνήμης."
 
-#: ../src/common/imagbmp.cpp:100
+#: ../src/common/imagbmp.cpp:97
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: Δεν είναι δυνατή η αποθήκευση μη έγκυρης εικόνας."
 
-#: ../src/common/imagbmp.cpp:356
+#: ../src/common/imagbmp.cpp:353
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: Δεν ήταν δυνατή η εγγραφή του χάρτη RGB."
 
-#: ../src/common/imagbmp.cpp:490
+#: ../src/common/imagbmp.cpp:487
 msgid "BMP: Couldn't write data."
 msgstr "BMP: Δεν ήταν δυνατή η εγγραφή δεδομένων."
 
-#: ../src/common/imagbmp.cpp:246
+#: ../src/common/imagbmp.cpp:243
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: Δεν ήταν δυνατή η εγγραφή της κεφαλής του αρχείου Bitmap."
 
-#: ../src/common/imagbmp.cpp:269
+#: ../src/common/imagbmp.cpp:266
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: Δεν ήταν δυνατή η εγγραφή της κεφαλής του αρχείου BitmapInfo."
 
-#: ../src/common/imagbmp.cpp:140
+#: ../src/common/imagbmp.cpp:137
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: Το wxImage δεν κατέχει κάποιο wxPalette."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:142 ../src/common/accelcmn.cpp:52
+#: ../src/common/stockitem.cpp:139 ../src/common/accelcmn.cpp:49
 #, fuzzy
 msgid "Back"
 msgstr "&Πίσω"
 
+#: ../src/richtext/richtextformatdlg.cpp:377
 #: ../src/richtext/richtextbackgroundpage.cpp:148
-#: ../src/richtext/richtextformatdlg.cpp:384
 #, fuzzy
 msgid "Background"
 msgstr "Πίσω"
@@ -1552,21 +1548,21 @@ msgstr "Πίσω"
 msgid "Background &colour:"
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:220
+#: ../src/osx/carbon/fontdlg.cpp:217
 msgid "Background colour"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:52
+#: ../src/common/accelcmn.cpp:49
 #, fuzzy
 msgid "Backspace"
 msgstr "&Πίσω"
 
-#: ../src/common/fmapbase.cpp:160
+#: ../src/common/fmapbase.cpp:157
 msgid "Baltic (ISO-8859-13)"
 msgstr "Βαλτικό (ISO-8859-13)"
 
-#: ../src/common/fmapbase.cpp:151
+#: ../src/common/fmapbase.cpp:148
 msgid "Baltic (old) (ISO-8859-4)"
 msgstr "Βαλτικό (παλαιό) (ISO-8859-4)"
 
@@ -1579,25 +1575,25 @@ msgstr ""
 msgid "Bitmap"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1594
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Black"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1755
+#: ../src/propgrid/advprops.cpp:1656
 msgid "Blank"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1603
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Blue"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:345
+#: ../src/generic/colrdlgg.cpp:365
 msgid "Blue:"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:333 ../src/richtext/richtextfontpage.cpp:355
-#: ../src/osx/carbon/fontdlg.cpp:354 ../src/common/stockitem.cpp:143
+#: ../src/osx/carbon/fontdlg.cpp:351 ../src/common/stockitem.cpp:140
+#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:355
 msgid "Bold"
 msgstr "Έντονο"
 
@@ -1607,34 +1603,38 @@ msgstr "Έντονο"
 msgid "Border"
 msgstr "Μοντέρνο"
 
-#: ../src/richtext/richtextformatdlg.cpp:379
+#: ../src/richtext/richtextformatdlg.cpp:372
 #, fuzzy
 msgid "Borders"
 msgstr "Μοντέρνο"
 
-#: ../src/richtext/richtextsizepage.cpp:288 ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141 ../src/richtext/richtextsizepage.cpp:288
 msgid "Bottom"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:893
+#: ../src/generic/prntdlgg.cpp:886
 msgid "Bottom margin (mm):"
 msgstr "Κάτω περιθώριο (mm)"
 
-#: ../src/richtext/richtextbuffer.cpp:9383
+#: ../src/richtext/richtextbuffer.cpp:9380
 #, fuzzy
 msgid "Box Properties"
 msgstr "&Ιδιότητες"
 
-#: ../src/richtext/richtextstyles.cpp:1065
+#: ../src/richtext/richtextstyles.cpp:1062
 #, fuzzy
 msgid "Box styles"
 msgstr "&Επόμενο >"
 
-#: ../src/propgrid/advprops.cpp:1602
+#: ../src/osx/cocoa/menu.mm:292
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Brown"
 msgstr ""
 
-#: ../src/common/filepickercmn.cpp:43 ../src/common/filepickercmn.cpp:44
+#: ../src/common/filepickercmn.cpp:40 ../src/common/filepickercmn.cpp:41
 msgid "Browse"
 msgstr ""
 
@@ -1647,72 +1647,72 @@ msgstr ""
 msgid "Bullet style"
 msgstr ""
 
-#: ../src/richtext/richtextformatdlg.cpp:359
+#: ../src/richtext/richtextformatdlg.cpp:352
 msgid "Bullets"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1756
+#: ../src/propgrid/advprops.cpp:1657
 msgid "Bullseye"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:875
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonFace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:876
+#: ../src/propgrid/advprops.cpp:777
 msgid "ButtonHighlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:877
+#: ../src/propgrid/advprops.cpp:778
 msgid "ButtonShadow"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:878
+#: ../src/propgrid/advprops.cpp:779
 msgid "ButtonText"
 msgstr ""
 
-#: ../src/common/paper.cpp:98
+#: ../src/common/paper.cpp:95
 msgid "C sheet, 17 x 22 in"
 msgstr "Φύλλο C, 17 x 22 ίντσες"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "C&lear"
 msgstr "&Καθάρισμα"
 
-#: ../src/generic/fontdlgg.cpp:406
+#: ../src/generic/fontdlgg.cpp:403
 msgid "C&olour:"
 msgstr "&Χρώμα:"
 
-#: ../src/common/paper.cpp:123
+#: ../src/common/paper.cpp:120
 msgid "C3 Envelope, 324 x 458 mm"
 msgstr "C3 Φάκελος, 324 x 458 mm"
 
-#: ../src/common/paper.cpp:124
+#: ../src/common/paper.cpp:121
 msgid "C4 Envelope, 229 x 324 mm"
 msgstr "C4 Φάκελος, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:122
+#: ../src/common/paper.cpp:119
 msgid "C5 Envelope, 162 x 229 mm"
 msgstr "C5 Φάκελος, 162 x 229 mm"
 
-#: ../src/common/paper.cpp:125
+#: ../src/common/paper.cpp:122
 msgid "C6 Envelope, 114 x 162 mm"
 msgstr "C6 Φάκελος, 114 x 162 mm"
 
-#: ../src/common/paper.cpp:126
+#: ../src/common/paper.cpp:123
 msgid "C65 Envelope, 114 x 229 mm"
 msgstr "C65 Φάκελος, 114 x 229 mm"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "CD-Rom"
 msgstr ""
 
-#: ../src/html/chm.cpp:815 ../src/html/chm.cpp:874
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:865
 msgid "CHM handler currently supports only local files!"
 msgstr "ο χειριστής CHM προς το παρόν υποστηρίζει μόνο τοπικά αρχεία!"
 
@@ -1720,198 +1720,202 @@ msgstr "ο χειριστής CHM προς το παρόν υποστηρίζε�
 msgid "Ca&pitals"
 msgstr ""
 
-#: ../src/common/cmdproc.cpp:267
+#: ../src/common/cmdproc.cpp:260
 msgid "Can't &Undo "
 msgstr "Δεν είναι δυνατή η αναίρεση"
 
-#: ../src/common/image.cpp:2824
+#: ../src/common/image.cpp:2924
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 
-#: ../src/msw/registry.cpp:506
+#: ../src/msw/registry.cpp:495
 #, c-format
 msgid "Can't close registry key '%s'"
 msgstr "Δεν είναι δυνατό το κλείσιμο του κλειδιού μητρώου(registry key) '%s'"
 
-#: ../src/msw/registry.cpp:584
+#: ../src/msw/registry.cpp:573
 #, c-format
 msgid "Can't copy values of unsupported type %d."
 msgstr "Δεν είναι δυνατή η αντιγραφή τιμών μη υποστηριζομένου τύπου %d."
 
-#: ../src/msw/registry.cpp:487
+#: ../src/msw/registry.cpp:476
 #, c-format
 msgid "Can't create registry key '%s'"
 msgstr "Δεν είναι δυνατή η δημιουργία του κλειδιού μητρώου(registry key) '%s'"
 
-#: ../src/msw/thread.cpp:665
+#: ../src/msw/thread.cpp:657
 msgid "Can't create thread"
 msgstr "Δεν είναι δυνατή η δημιουργία του νήματος εκτέλεσης (thread)"
 
-#: ../src/msw/window.cpp:3691
-#, c-format
-msgid "Can't create window of class %s"
-msgstr "Δεν είναι δυνατή η δημιουργία παραθύρου τάξεως %s"
-
-#: ../src/msw/registry.cpp:777
+#: ../src/msw/registry.cpp:765
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Δεν είναι δυνατή η διαγραφή του κλειδιού '%s'"
 
-#: ../src/msw/iniconf.cpp:458
+#: ../src/msw/iniconf.cpp:455
 #, c-format
 msgid "Can't delete the INI file '%s'"
 msgstr "Δεν είναι δυνατή η διαγραφή του αρχείου INI '%s'"
 
-#: ../src/msw/registry.cpp:805
+#: ../src/msw/registry.cpp:793
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Δεν είναι δυνατή η διαγραφή της τιμής '%s' από το κλειδί '%s'"
 
-#: ../src/msw/registry.cpp:1171
+#: ../src/msw/registry.cpp:1159
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Δεν είναι δυνατή η απαρίθμηση των υποκλειδιών του '%s'"
 
-#: ../src/msw/registry.cpp:1132
+#: ../src/msw/registry.cpp:1120
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Δεν είναι δυνατή η απαρίθμηση των τιμών του κλειδιού '%s'"
 
-#: ../src/msw/registry.cpp:1389
+#: ../src/msw/registry.cpp:1377
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Δεν είναι δυνατή η εξαγωγή τιμών μη υποστηριζομένου τύπου %d."
 
-#: ../src/common/ffile.cpp:254
+#: ../src/common/ffile.cpp:253
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Δεν είναι δυνατή η εύρεση της τρέχουσας θέσης στο αρχείου '%s'"
 
-#: ../src/msw/registry.cpp:418
+#: ../src/msw/registry.cpp:407
 #, c-format
 msgid "Can't get info about registry key '%s'"
 msgstr ""
 "Δεν είναι δυνατή η συλλογή πληροφοριών για το κλειδί μητρώου(registry) '%s'"
 
-#: ../src/common/zstream.cpp:346
+#: ../src/msw/webview_ie.cpp:1024
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "Δεν είναι δυνατή η θέση προτεραιότητας του νήματος εκτέλεσης (thread)"
+
+#: ../src/common/zstream.cpp:343
 msgid "Can't initialize zlib deflate stream."
 msgstr "Δεν είναι δυνατή η αρχικοποίηση της ροής zlib deflate."
 
-#: ../src/common/zstream.cpp:185
+#: ../src/common/zstream.cpp:182
 msgid "Can't initialize zlib inflate stream."
 msgstr "Δεν είναι δυνατή η αρχικοποίηση της ροής zlib inflate."
 
-#: ../src/msw/fswatcher.cpp:476
+#: ../src/msw/fswatcher.cpp:475
 #, c-format
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr ""
 
-#: ../src/msw/registry.cpp:454
+#: ../src/msw/registry.cpp:443
 #, c-format
 msgid "Can't open registry key '%s'"
 msgstr "Δεν είναι δυνατό το άνοιγμα του κλειδιού μητρώου(registry) '%s'"
 
-#: ../src/common/zstream.cpp:252
+#: ../src/common/zstream.cpp:249
 #, c-format
 msgid "Can't read from inflate stream: %s"
 msgstr "Αδύνατη η ανάγνωση από την ροή inflate: %s"
 
-#: ../src/common/zstream.cpp:244
+#: ../src/common/zstream.cpp:241
 msgid "Can't read inflate stream: unexpected EOF in underlying stream."
 msgstr ""
 "Αδύνατη η ανάγνωση της ροής inflate: απρόσμενο EOF στην υποκείμενη ροή."
 
-#: ../src/msw/registry.cpp:1064
+#: ../src/msw/registry.cpp:1052
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Δεν είναι δυνατή η ανάγνωση της τιμής του '%s'"
 
-#: ../src/msw/registry.cpp:878 ../src/msw/registry.cpp:910
-#: ../src/msw/registry.cpp:975
+#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
+#: ../src/msw/registry.cpp:963
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Δεν είναι δυνατή η ανάγνωση της τιμής του κλειδιού '%s'"
 
-#: ../src/common/image.cpp:2620
+#: ../src/msw/webview_ie.cpp:1017
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/common/image.cpp:2715
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr ""
 "Δεν είναι δυνατή η αποθήκευση της εικόνας στο αρχείο '%s': άγνωστη επέκταση"
 
-#: ../src/generic/logg.cpp:573 ../src/generic/logg.cpp:976
+#: ../src/generic/logg.cpp:570 ../src/generic/logg.cpp:973
 msgid "Can't save log contents to file."
 msgstr ""
 "Δεν είναι δυνατή η αποθήκευση των περιεχομένων της καταγραφής(log) στο "
 "αρχείο."
 
-#: ../src/msw/thread.cpp:629
+#: ../src/msw/thread.cpp:621
 msgid "Can't set thread priority"
 msgstr "Δεν είναι δυνατή η θέση προτεραιότητας του νήματος εκτέλεσης (thread)"
 
-#: ../src/msw/registry.cpp:896 ../src/msw/registry.cpp:938
-#: ../src/msw/registry.cpp:1081
+#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
+#: ../src/msw/registry.cpp:1069
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Δεν είναι δυνατή η ανάθεση τιμής του '%s'"
 
-#: ../src/unix/utilsunx.cpp:351
+#: ../src/unix/utilsunx.cpp:353
 #, fuzzy
 msgid "Can't write to child process's stdin"
 msgstr "Αποτυχία θανάτωσης της διαδικασίας(process) %d"
 
-#: ../src/common/zstream.cpp:427
+#: ../src/common/zstream.cpp:424
 #, c-format
 msgid "Can't write to deflate stream: %s"
 msgstr "Δεν είναι δυνατή η εγγραφή στην ροή deflate: %s"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:279 ../src/richtext/richtextstyledlg.cpp:300
-#: ../src/common/stockitem.cpp:145 ../src/common/accelcmn.cpp:71
-#: ../src/msw/msgdlg.cpp:454 ../src/msw/progdlg.cpp:673
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:142
+#: ../src/common/accelcmn.cpp:68 ../src/motif/msgdlg.cpp:196
+#: ../src/gtk1/fontdlg.cpp:144 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/progdlg.cpp:940 ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Ακυρο"
 
-#: ../src/common/filefn.cpp:1261
+#: ../src/common/filefn.cpp:1149
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Δεν είναι δυνατή η απαρίθμηση των αρχείων '%s'"
 
-#: ../src/msw/dir.cpp:263
+#: ../src/msw/dir.cpp:260
 #, c-format
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Δεν είναι δυνατή η απαρίθμηση των αρχείων στον κατάλογο '%s'"
 
-#: ../src/msw/dialup.cpp:523
+#: ../src/msw/dialup.cpp:517
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Δεν είναι δυνατή η εύρεση της ενεργού τηλεφωνικής συνδέσεως: %s"
 
-#: ../src/msw/dialup.cpp:827
+#: ../src/msw/dialup.cpp:821
 msgid "Cannot find the location of address book file"
 msgstr "Δεν είναι δυνατή η εύρεση της θέσης του αρχείου βιβλίου διευθύνσεων"
 
-#: ../src/msw/ole/automtn.cpp:562
+#: ../src/msw/ole/automtn.cpp:553
 #, fuzzy, c-format
 msgid "Cannot get an active instance of \"%s\""
 msgstr "Δεν είναι δυνατή η εύρεση της ενεργού τηλεφωνικής συνδέσεως: %s"
 
-#: ../src/unix/threadpsx.cpp:1035
+#: ../src/unix/threadpsx.cpp:1053
 #, fuzzy, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "Δεν είναι δυνατή η ανάγνωση του εύρους προτεραιοτήτων"
 
-#: ../src/unix/utilsunx.cpp:987
+#: ../src/unix/utilsunx.cpp:989
 msgid "Cannot get the hostname"
 msgstr "Δεν είναι δυνατή η ανάγνωση του ονόματος διακομιστή(hostname)"
 
-#: ../src/unix/utilsunx.cpp:1023
+#: ../src/unix/utilsunx.cpp:1025
 msgid "Cannot get the official hostname"
 msgstr ""
 "Δεν είναι δυνατή η ανάγνωση του επισήμου ονόματος διακομιστή(official "
 "hostname)"
 
-#: ../src/msw/dialup.cpp:928
+#: ../src/msw/dialup.cpp:922
 msgid "Cannot hang up - no active dialup connection."
 msgstr ""
 "Δεν είναι δυνατό το κλείσιμο της γραμμής - δεν υπάρχει ενεργός τηλεφωνική "
@@ -1921,134 +1925,134 @@ msgstr ""
 msgid "Cannot initialize OLE"
 msgstr "Δεν είναι δυνατή η αρχικοποίηση του OLE"
 
-#: ../src/common/socket.cpp:853
+#: ../src/common/socket.cpp:850
 #, fuzzy
 msgid "Cannot initialize sockets"
 msgstr "Δεν είναι δυνατή η αρχικοποίηση του OLE"
 
-#: ../src/msw/volume.cpp:619
+#: ../src/msw/volume.cpp:627
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Δεν είναι δυνατή η φόρτωση εικονιδίου από το '%s'"
 
-#: ../src/xrc/xmlres.cpp:360
+#: ../src/xrc/xmlres.cpp:358
 #, fuzzy, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Δεν είναι δυνατή η φόρτωση πόρων(resources) από το αρχείο '%s'"
 
-#: ../src/xrc/xmlres.cpp:742
+#: ../src/xrc/xmlres.cpp:740
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Δεν είναι δυνατή η φόρτωση πόρων(resources) από το αρχείο '%s'"
 
-#: ../src/html/htmlfilt.cpp:137
+#: ../src/html/htmlfilt.cpp:134
 #, c-format
 msgid "Cannot open HTML document: %s"
 msgstr "Δεν είναι δυνατό το άνοιγμα εγγράφου HTML: %s"
 
-#: ../src/html/helpdata.cpp:667
+#: ../src/html/helpdata.cpp:660
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Δεν είναι δυνατό το άνοιγμα βιβλίου βοήθειας HTML: %s"
 
-#: ../src/html/helpdata.cpp:299
+#: ../src/html/helpdata.cpp:296
 #, c-format
 msgid "Cannot open contents file: %s"
 msgstr "Δεν είναι δυνατό το άνοιγμα των περιεχομένων του αρχείου: %s"
 
-#: ../src/generic/dcpsg.cpp:1667
+#: ../src/generic/dcpsg.cpp:1665
 msgid "Cannot open file for PostScript printing!"
 msgstr "Δεν είναι δυνατό το άνοιγμα του αρχείου για εκτύπωση PostScript!"
 
-#: ../src/html/helpdata.cpp:313
+#: ../src/html/helpdata.cpp:310
 #, c-format
 msgid "Cannot open index file: %s"
 msgstr "Δεν είναι δυνατό το άνοιγμα του αρχείου ευρετηρίου(index): %s"
 
-#: ../src/xrc/xmlres.cpp:724
+#: ../src/xrc/xmlres.cpp:722
 #, fuzzy, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Δεν είναι δυνατή η φόρτωση πόρων(resources) από το αρχείο '%s'"
 
-#: ../src/html/helpwnd.cpp:1534
+#: ../src/html/helpwnd.cpp:1532
 msgid "Cannot print empty page."
 msgstr "Δεν είναι δυνατή η εκτύπωση άδειας σελίδας."
 
-#: ../src/msw/volume.cpp:507
+#: ../src/msw/volume.cpp:515
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Δεν είναι δυνατή η ανάγνωση ονομάτων τύπων(typenames) από το '%s'"
 
-#: ../src/msw/thread.cpp:888
+#: ../src/msw/thread.cpp:894
 #, fuzzy, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Δεν είναι δυνατή η συνέχιση(resume) του νήματος(thread) %x"
 
-#: ../src/unix/threadpsx.cpp:1016
+#: ../src/unix/threadpsx.cpp:1028
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Δεν είναι δυνατή η ανάκτηση της thread scheduling policy."
 
-#: ../src/common/intl.cpp:558
+#: ../src/common/intl.cpp:365
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:831 ../src/msw/thread.cpp:546
+#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
 msgid "Cannot start thread: error writing TLS."
 msgstr ""
 "Δεν είναι δυνατή η εκκίνηση του νήματος(thread): Σφάλμα κατά την εγγραφή του "
 "TLS"
 
-#: ../src/msw/thread.cpp:872
+#: ../src/msw/thread.cpp:864
 #, fuzzy, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Δεν είναι δυνατή η αναστολή εκτέλεσης(suspend) του νήματος(thread) %x"
 
-#: ../src/msw/thread.cpp:794
+#: ../src/msw/thread.cpp:786
 msgid "Cannot wait for thread termination"
 msgstr ""
 "Δεν είναι δυνατή η αναμονή(wait) για τον τερματισμό του νήματος "
 "εκτέλεσης(thread)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:75
+#: ../src/common/accelcmn.cpp:72
 #, fuzzy
 msgid "Capital"
 msgstr "πλάγιο"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:879
+#: ../src/propgrid/advprops.cpp:780
 msgid "CaptionText"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:531
 msgid "Case sensitive"
 msgstr "Διάκριση κεφαλαίων-πεζών"
 
-#: ../src/propgrid/manager.cpp:1509
+#: ../src/propgrid/manager.cpp:1527
 msgid "Categorized Mode"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9968
+#: ../src/richtext/richtextbuffer.cpp:9965
 #, fuzzy
 msgid "Cell Properties"
 msgstr "&Ιδιότητες"
 
-#: ../src/common/fmapbase.cpp:161
+#: ../src/common/fmapbase.cpp:158
 msgid "Celtic (ISO-8859-14)"
 msgstr "Κελτικό (ISO-8859-14)"
 
-#: ../src/richtext/richtextindentspage.cpp:160
 #: ../src/richtext/richtextliststylepage.cpp:349
+#: ../src/richtext/richtextindentspage.cpp:160
 #, fuzzy
 msgid "Cen&tred"
 msgstr "Στο κέντρο"
 
-#: ../src/common/stockitem.cpp:170
+#: ../src/common/stockitem.cpp:167
 msgid "Centered"
 msgstr "Στο κέντρο"
 
-#: ../src/common/fmapbase.cpp:149
+#: ../src/common/fmapbase.cpp:146
 msgid "Central European (ISO-8859-2)"
 msgstr "Κεντροευρωπαϊκό (ISO-8859-2)"
 
@@ -2058,10 +2062,10 @@ msgstr "Κεντροευρωπαϊκό (ISO-8859-2)"
 msgid "Centre"
 msgstr "Στο κέντρο"
 
-#: ../src/richtext/richtextindentspage.cpp:162
-#: ../src/richtext/richtextindentspage.cpp:164
 #: ../src/richtext/richtextliststylepage.cpp:351
 #: ../src/richtext/richtextliststylepage.cpp:353
+#: ../src/richtext/richtextindentspage.cpp:162
+#: ../src/richtext/richtextindentspage.cpp:164
 #, fuzzy
 msgid "Centre text."
 msgstr "Δεν είναι δυνατή η δημιουργία του mutex."
@@ -2077,25 +2081,25 @@ msgstr "Στο κέντρο"
 msgid "Ch&oose..."
 msgstr "&Μετάβαση..."
 
-#: ../src/richtext/richtextbuffer.cpp:4354
+#: ../src/richtext/richtextbuffer.cpp:4351
 msgid "Change List Style"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:3709
+#: ../src/richtext/richtextbuffer.cpp:3706
 msgid "Change Object Style"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:3982
-#: ../src/richtext/richtextbuffer.cpp:8129
+#: ../src/richtext/richtextbuffer.cpp:3979
+#: ../src/richtext/richtextbuffer.cpp:8125
 #, fuzzy
 msgid "Change Properties"
 msgstr "&Ιδιότητες"
 
-#: ../src/richtext/richtextbuffer.cpp:3526
+#: ../src/richtext/richtextbuffer.cpp:3523
 msgid "Change Style"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:341
+#: ../src/common/fileconf.cpp:335
 #, c-format
 msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
 msgstr ""
@@ -2106,11 +2110,11 @@ msgid "Changing current directory to \"%s\" failed"
 msgstr "Απέτυχε η δημιουργία καταλόγου '%s'/.gnome."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1757
+#: ../src/propgrid/advprops.cpp:1658
 msgid "Character"
 msgstr ""
 
-#: ../src/richtext/richtextstyles.cpp:1063
+#: ../src/richtext/richtextstyles.cpp:1060
 msgid "Character styles"
 msgstr ""
 
@@ -2148,23 +2152,23 @@ msgstr ""
 msgid "Check to indicate right-to-left text layout."
 msgstr "Κάνετε κλικ για να ακυρώσετε την επιλογή γραμματοσειράς."
 
-#: ../src/osx/carbon/fontdlg.cpp:356 ../src/osx/carbon/fontdlg.cpp:358
+#: ../src/osx/carbon/fontdlg.cpp:353 ../src/osx/carbon/fontdlg.cpp:355
 #, fuzzy
 msgid "Check to make the font bold."
 msgstr "Κάνετε κλικ για να ακυρώσετε την επιλογή γραμματοσειράς."
 
-#: ../src/osx/carbon/fontdlg.cpp:363 ../src/osx/carbon/fontdlg.cpp:365
+#: ../src/osx/carbon/fontdlg.cpp:360 ../src/osx/carbon/fontdlg.cpp:362
 #, fuzzy
 msgid "Check to make the font italic."
 msgstr "Κάνετε κλικ για να ακυρώσετε την επιλογή γραμματοσειράς."
 
-#: ../src/osx/carbon/fontdlg.cpp:372 ../src/osx/carbon/fontdlg.cpp:374
+#: ../src/osx/carbon/fontdlg.cpp:369 ../src/osx/carbon/fontdlg.cpp:371
 #, fuzzy
 msgid "Check to make the font underlined."
 msgstr "Επιλογή εαν η γραμματοσειρά είναι υπογραμμισμένη ή όχι."
 
-#: ../src/richtext/richtextstyledlg.cpp:289
-#: ../src/richtext/richtextstyledlg.cpp:291
+#: ../src/richtext/richtextstyledlg.cpp:285
+#: ../src/richtext/richtextstyledlg.cpp:287
 msgid "Check to restart numbering."
 msgstr ""
 
@@ -2203,55 +2207,55 @@ msgstr "Κάνετε κλικ για να ακυρώσετε την επιλογ
 msgid "Check to suppress hyphenation."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:763
+#: ../src/msw/dialup.cpp:757
 msgid "Choose ISP to dial"
 msgstr "Επιλέξτε παροχέα Internet για κλήση"
 
-#: ../src/propgrid/props.cpp:1922
+#: ../src/propgrid/props.cpp:1904
 #, fuzzy
 msgid "Choose a directory:"
 msgstr "Δημιουργία καταλόγου"
 
-#: ../src/propgrid/props.cpp:1975
+#: ../src/propgrid/props.cpp:2199
 #, fuzzy
 msgid "Choose a file"
 msgstr "Επιλέξτε γραμματοσειρά"
 
-#: ../src/generic/colrdlgg.cpp:158 ../src/gtk/colordlg.cpp:54
+#: ../src/generic/colrdlgg.cpp:156 ../src/gtk/colordlg.cpp:49
 msgid "Choose colour"
 msgstr "Επιλέξτε χρώμα"
 
-#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/gtk1/fontdlg.cpp:125 ../src/generic/fontpickerg.cpp:47
+#: ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Επιλέξτε γραμματοσειρά"
 
-#: ../src/common/module.cpp:74
+#: ../src/common/module.cpp:71
 #, c-format
 msgid "Circular dependency involving module \"%s\" detected."
 msgstr ""
 
-#: ../src/aui/tabmdi.cpp:108 ../src/generic/mdig.cpp:97
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
 msgid "Cl&ose"
 msgstr "&Κλείσιμο"
 
-#: ../src/msw/ole/automtn.cpp:684
+#: ../src/msw/ole/automtn.cpp:675
 #, fuzzy
 msgid "Class not registered."
 msgstr "Δεν είναι δυνατή η δημιουργία του νήματος εκτέλεσης (thread)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:147 ../src/common/accelcmn.cpp:72
+#: ../src/common/stockitem.cpp:144 ../src/common/accelcmn.cpp:69
 #, fuzzy
 msgid "Clear"
 msgstr "&Καθαρισμός"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "Clear the log contents"
 msgstr "Καθαρισμός περιεχομένων καταγραφής(log)"
 
-#: ../src/richtext/richtextstyledlg.cpp:252
-#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:248
+#: ../src/richtext/richtextstyledlg.cpp:250
 #, fuzzy
 msgid "Click to apply the selected style."
 msgstr "Κάνετε κλικ για να ακυρώσετε την επιλογή γραμματοσειράς."
@@ -2263,16 +2267,16 @@ msgstr "Κάνετε κλικ για να ακυρώσετε την επιλογ
 msgid "Click to browse for a symbol."
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:403 ../src/osx/carbon/fontdlg.cpp:405
+#: ../src/osx/carbon/fontdlg.cpp:400 ../src/osx/carbon/fontdlg.cpp:402
 #, fuzzy
 msgid "Click to cancel changes to the font."
 msgstr "Κάνετε κλικ για να ακυρώσετε την επιλογή γραμματοσειράς."
 
-#: ../src/generic/fontdlgg.cpp:472 ../src/generic/fontdlgg.cpp:491
+#: ../src/generic/fontdlgg.cpp:468 ../src/generic/fontdlgg.cpp:487
 msgid "Click to cancel the font selection."
 msgstr "Κάνετε κλικ για να ακυρώσετε την επιλογή γραμματοσειράς."
 
-#: ../src/osx/carbon/fontdlg.cpp:384 ../src/osx/carbon/fontdlg.cpp:386
+#: ../src/osx/carbon/fontdlg.cpp:381 ../src/osx/carbon/fontdlg.cpp:383
 #, fuzzy
 msgid "Click to change the font colour."
 msgstr "Κάνετε κλικ για να ακυρώσετε την επιλογή γραμματοσειράς."
@@ -2295,41 +2299,41 @@ msgstr "Κάνετε κλικ για να ακυρώσετε την επιλογ
 msgid "Click to choose the font for this level."
 msgstr "Κάνετε κλικ για να ακυρώσετε την επιλογή γραμματοσειράς."
 
-#: ../src/richtext/richtextstyledlg.cpp:279
-#: ../src/richtext/richtextstyledlg.cpp:281
+#: ../src/richtext/richtextstyledlg.cpp:275
+#: ../src/richtext/richtextstyledlg.cpp:277
 #, fuzzy
 msgid "Click to close this window."
 msgstr "Κλείσιμο αυτού του παραθύρου."
 
-#: ../src/osx/carbon/fontdlg.cpp:410 ../src/osx/carbon/fontdlg.cpp:412
+#: ../src/osx/carbon/fontdlg.cpp:407 ../src/osx/carbon/fontdlg.cpp:409
 #, fuzzy
 msgid "Click to confirm changes to the font."
 msgstr "Κάνετε κλικ για να επιβεβαιώσετε την επιλογή γραμματοσειράς."
 
-#: ../src/generic/fontdlgg.cpp:477 ../src/generic/fontdlgg.cpp:479
-#: ../src/generic/fontdlgg.cpp:484 ../src/generic/fontdlgg.cpp:486
+#: ../src/generic/fontdlgg.cpp:473 ../src/generic/fontdlgg.cpp:475
+#: ../src/generic/fontdlgg.cpp:480 ../src/generic/fontdlgg.cpp:482
 msgid "Click to confirm the font selection."
 msgstr "Κάνετε κλικ για να επιβεβαιώσετε την επιλογή γραμματοσειράς."
 
-#: ../src/richtext/richtextstyledlg.cpp:244
-#: ../src/richtext/richtextstyledlg.cpp:246
+#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:242
 #, fuzzy
 msgid "Click to create a new box style."
 msgstr "Κάνετε κλικ για να ακυρώσετε την επιλογή γραμματοσειράς."
 
-#: ../src/richtext/richtextstyledlg.cpp:226
-#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:224
 msgid "Click to create a new character style."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:238
-#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:236
 #, fuzzy
 msgid "Click to create a new list style."
 msgstr "Κάνετε κλικ για να ακυρώσετε την επιλογή γραμματοσειράς."
 
-#: ../src/richtext/richtextstyledlg.cpp:232
-#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:230
 msgid "Click to create a new paragraph style."
 msgstr ""
 
@@ -2345,8 +2349,8 @@ msgstr "Κάνετε κλικ για να ακυρώσετε την επιλογ
 msgid "Click to delete all tab positions."
 msgstr "Κάνετε κλικ για να ακυρώσετε την επιλογή γραμματοσειράς."
 
-#: ../src/richtext/richtextstyledlg.cpp:270
-#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:268
 #, fuzzy
 msgid "Click to delete the selected style."
 msgstr "Κάνετε κλικ για να ακυρώσετε την επιλογή γραμματοσειράς."
@@ -2357,27 +2361,27 @@ msgstr "Κάνετε κλικ για να ακυρώσετε την επιλογ
 msgid "Click to delete the selected tab position."
 msgstr "Κάνετε κλικ για να ακυρώσετε την επιλογή γραμματοσειράς."
 
-#: ../src/richtext/richtextstyledlg.cpp:264
-#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:262
 #, fuzzy
 msgid "Click to edit the selected style."
 msgstr "Κάνετε κλικ για να ακυρώσετε την επιλογή γραμματοσειράς."
 
-#: ../src/richtext/richtextstyledlg.cpp:258
-#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:256
 #, fuzzy
 msgid "Click to rename the selected style."
 msgstr "Κάνετε κλικ για να ακυρώσετε την επιλογή γραμματοσειράς."
 
-#: ../src/generic/dbgrptg.cpp:97 ../src/generic/progdlgg.cpp:759
-#: ../src/richtext/richtextstyledlg.cpp:277
-#: ../src/richtext/richtextsymboldlg.cpp:476 ../src/common/stockitem.cpp:148
-#: ../src/msw/progdlg.cpp:170 ../src/msw/progdlg.cpp:679
-#: ../src/html/helpdlg.cpp:90
+#: ../src/common/stockitem.cpp:145 ../src/generic/dbgrptg.cpp:94
+#: ../src/generic/progdlgg.cpp:781 ../src/msw/progdlg.cpp:211
+#: ../src/msw/progdlg.cpp:946 ../src/html/helpdlg.cpp:87
+#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextstyledlg.cpp:273
 msgid "Close"
 msgstr "Κλείσιμο"
 
-#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:98
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
 msgid "Close All"
 msgstr "Κλείσιμο"
 
@@ -2385,68 +2389,68 @@ msgstr "Κλείσιμο"
 msgid "Close current document"
 msgstr ""
 
-#: ../src/generic/logg.cpp:516
+#: ../src/generic/logg.cpp:513
 msgid "Close this window"
 msgstr "Κλείσιμο αυτού του παραθύρου."
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6006
+#: ../src/generic/datavgen.cpp:6811
 msgid "Collapse"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 #, fuzzy
 msgid "Color"
 msgstr "&Χρώμα:"
 
-#: ../src/richtext/richtextformatdlg.cpp:776
+#: ../src/richtext/richtextformatdlg.cpp:768
 #, fuzzy
 msgid "Colour"
 msgstr "&Χρώμα:"
 
-#: ../src/msw/colordlg.cpp:158
+#: ../src/msw/colordlg.cpp:227
 #, fuzzy, c-format
 msgid "Colour selection dialog failed with error %0lx."
 msgstr "Η εκτέλεση της εντολής '%s' απέτυχε με σφάλμα: %ul"
 
-#: ../src/osx/carbon/fontdlg.cpp:380
+#: ../src/osx/carbon/fontdlg.cpp:377
 #, fuzzy
 msgid "Colour:"
 msgstr "&Χρώμα:"
 
-#: ../src/generic/datavgen.cpp:6077
+#: ../src/generic/datavgen.cpp:6882
 #, c-format
 msgid "Column %u"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:114
+#: ../src/common/accelcmn.cpp:112
 msgid "Command"
 msgstr ""
 
-#: ../src/common/init.cpp:196
+#: ../src/common/init.cpp:193
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
 "ignored."
 msgstr ""
 
-#: ../src/msw/fontdlg.cpp:120
+#: ../src/msw/fontdlg.cpp:170
 #, fuzzy, c-format
 msgid "Common dialog failed with error code %0lx."
 msgstr "Η εκτέλεση της εντολής '%s' απέτυχε με σφάλμα: %ul"
 
-#: ../src/gtk/window.cpp:4649
+#: ../src/gtk/window.cpp:5653
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:1549
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Αρχείο βοήθειας συμπιεσμένης HTML (*.chm)|*.chm|"
 
-#: ../src/generic/dirctrlg.cpp:444
+#: ../src/generic/dirctrlg.cpp:410
 msgid "Computer"
 msgstr "Υπολογιστής"
 
@@ -2457,56 +2461,60 @@ msgstr ""
 "Το όνομα εισόδου διαμόρφωσης (Config entry name) δεν μπορεί να αρχίζει με "
 "'%c'"
 
-#: ../src/generic/filedlgg.cpp:349 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
 msgid "Confirm"
 msgstr "Επιβεβαίωση"
 
-#: ../src/html/htmlwin.cpp:566
+#: ../src/html/htmlwin.cpp:569
 msgid "Connecting..."
 msgstr "Γίνεται σύνδεση..."
 
-#: ../src/html/helpwnd.cpp:475
+#: ../src/html/helpwnd.cpp:473
 msgid "Contents"
 msgstr "Περιεχόμενα"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:880
+#: ../src/propgrid/advprops.cpp:781
 msgid "ControlDark"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:881
+#: ../src/propgrid/advprops.cpp:782
 msgid "ControlLight"
 msgstr ""
 
-#: ../src/common/strconv.cpp:2262
+#: ../src/common/strconv.cpp:2208
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Η μετατροπή στο σετ χαρακτήρων '%s' δεν λειτουργεί"
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 #, fuzzy
 msgid "Convert"
 msgstr "Περιεχόμενα"
 
-#: ../src/html/htmlwin.cpp:1079
+#: ../src/html/htmlwin.cpp:1020
 #, c-format
 msgid "Copied to clipboard:\"%s\""
 msgstr "Αντιγράφηκε στο πρόχειρο:\"%s\""
 
-#: ../src/generic/prntdlgg.cpp:247
+#: ../src/generic/prntdlgg.cpp:240
 msgid "Copies:"
 msgstr "Αντίγραφα:"
 
-#: ../src/common/stockitem.cpp:150 ../src/stc/stc_i18n.cpp:18
+#: ../src/common/stockitem.cpp:147 ../src/stc/stc_i18n.cpp:18
 #, fuzzy
 msgid "Copy"
 msgstr "&Αντιγραφή"
 
-#: ../src/common/stockitem.cpp:258
+#: ../src/common/stockitem.cpp:255
 #, fuzzy
 msgid "Copy selection"
 msgstr "Τμήματα"
+
+#: ../src/generic/grid.cpp:5945
+msgid "Copying more than one selected block to clipboard is not supported."
+msgstr ""
 
 #: ../src/richtext/richtextborderspage.cpp:566
 #: ../src/richtext/richtextborderspage.cpp:601
@@ -2517,215 +2525,208 @@ msgstr ""
 msgid "Corner &radius:"
 msgstr ""
 
-#: ../src/html/chm.cpp:718
+#: ../src/html/chm.cpp:711
 #, c-format
 msgid "Could not create temporary file '%s'"
 msgstr "Δεν είναι δυνατή η δημιουργία του προσωρινού αρχείου '%s'"
 
-#: ../src/html/chm.cpp:273
+#: ../src/html/chm.cpp:270
 #, c-format
 msgid "Could not extract %s into %s: %s"
 msgstr "Δεν ήταν δυνατή η εξαγωγή του %s στο %s: %s"
 
-#: ../src/generic/tabg.cpp:1048
+#: ../src/generic/tabg.cpp:1045
 msgid "Could not find tab for id"
 msgstr "Δεν ήταν δυνατή η εύρεση tab για το id"
 
-#: ../src/gtk/notifmsg.cpp:108
-#, fuzzy
-msgid "Could not initalize libnotify."
-msgstr "Δεν ήταν δυνατή η εκκίνηση της εκτύπωσης."
-
-#: ../src/html/chm.cpp:444
+#: ../src/html/chm.cpp:437
 #, c-format
 msgid "Could not locate file '%s'."
 msgstr "Δεν είναι δυνατός ο εντοπισμός του αρχείου '%s'."
 
-#: ../src/common/filefn.cpp:1403
+#: ../src/msw/graphicsd2d.cpp:604
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/common/filefn.cpp:1291
 #, fuzzy
 msgid "Could not set current working directory"
 msgstr "Αποτυχία λήψης καταλόγου εργασίας (working directory)"
 
-#: ../src/common/prntbase.cpp:2015
+#: ../src/common/prntbase.cpp:2037
 msgid "Could not start document preview."
 msgstr "Δεν ήταν δυνατή η εκκίνηση της προεπισκόπησης εγγράφου."
 
-#: ../src/generic/printps.cpp:178 ../src/msw/printwin.cpp:210
-#: ../src/gtk/print.cpp:1132
+#: ../src/generic/printps.cpp:159 ../src/msw/printwin.cpp:184
+#: ../src/gtk/print.cpp:1129
 msgid "Could not start printing."
 msgstr "Δεν ήταν δυνατή η εκκίνηση της εκτύπωσης."
 
-#: ../src/common/wincmn.cpp:2125
+#: ../src/common/wincmn.cpp:2126
 msgid "Could not transfer data to window"
 msgstr "Δεν ήταν δυνατή η μεταφορά δεδομένων στο παράθυρο."
 
-#: ../src/msw/imaglist.cpp:187 ../src/msw/imaglist.cpp:224
-#: ../src/msw/imaglist.cpp:249 ../src/msw/dragimag.cpp:185
-#: ../src/msw/dragimag.cpp:220
+#: ../src/msw/imaglist.cpp:223 ../src/msw/imaglist.cpp:245
+#: ../src/msw/imaglist.cpp:270 ../src/msw/dragimag.cpp:182
+#: ../src/msw/dragimag.cpp:217
 msgid "Couldn't add an image to the image list."
 msgstr "Δεν ήταν δυνατή η προσθήκη μιας εικόνας στην λίστα εικόνων."
 
-#: ../src/osx/glcanvas_osx.cpp:414 ../src/unix/glx11.cpp:558
-#: ../src/msw/glcanvas.cpp:616
+#: ../src/osx/glcanvas_osx.cpp:411 ../src/msw/glcanvas.cpp:631
+#: ../src/unix/glegl.cpp:315 ../src/unix/glx11.cpp:559
 #, fuzzy
 msgid "Couldn't create OpenGL context"
 msgstr "Δεν ήταν δυνατή η δημιουργία χρονοδιακόπτη (timer)"
 
-#: ../src/msw/timer.cpp:134
+#: ../src/msw/timer.cpp:131
 msgid "Couldn't create a timer"
 msgstr "Δεν ήταν δυνατή η δημιουργία χρονοδιακόπτη (timer)"
 
-#: ../src/osx/carbon/overlay.cpp:122
-#, fuzzy
-msgid "Couldn't create the overlay window"
-msgstr "Δεν ήταν δυνατή η δημιουργία χρονοδιακόπτη (timer)"
-
-#: ../src/common/translation.cpp:2024
+#: ../src/common/translation.cpp:2074
 #, fuzzy
 msgid "Couldn't enumerate translations"
 msgstr "Δεν ήταν δυνατός ο τερματισμός του thread"
 
-#: ../src/common/dynlib.cpp:120
+#: ../src/common/dynlib.cpp:110
 #, c-format
 msgid "Couldn't find symbol '%s' in a dynamic library"
 msgstr ""
 "Δεν ήταν δυνατός ο εντοπισμός του συμβόλου '%s' σε μια δυναμική βιβλιοθήκη."
 
-#: ../src/msw/thread.cpp:915
+#: ../src/msw/thread.cpp:921
 msgid "Couldn't get the current thread pointer"
 msgstr ""
 "Δεν ήταν δυνατή η ανάκτηση toy τρέχοντος δείκτη νήματος εκτέλεσης(thread)"
 
-#: ../src/osx/carbon/overlay.cpp:129
-#, fuzzy
-msgid "Couldn't init the context on the overlay window"
-msgstr ""
-"Δεν ήταν δυνατή η ανάκτηση toy τρέχοντος δείκτη νήματος εκτέλεσης(thread)"
-
-#: ../src/common/imaggif.cpp:244
+#: ../src/common/imaggif.cpp:241
 #, fuzzy
 msgid "Couldn't initialize GIF hash table."
 msgstr "Δεν είναι δυνατή η αρχικοποίηση της ροής zlib deflate."
 
-#: ../src/common/imagpng.cpp:409
+#: ../src/common/imagpng.cpp:437
 msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
 msgstr ""
 "Δεν ήταν δυνατή η φόρτωση εικόνας PNG - είτε το αρχείο δεν είναι έγκυρο ή "
 "δεν υπάρχει αρκετή μνήμη."
 
-#: ../src/unix/sound.cpp:470
+#: ../src/unix/sound.cpp:459
 #, c-format
 msgid "Couldn't load sound data from '%s'."
 msgstr "Δεν ήταν δυνατή η φόρτωση δεδομένων ήχου από το '%s'"
 
-#: ../src/msw/dirdlg.cpp:435
+#: ../src/msw/dirdlg.cpp:287
 #, fuzzy
 msgid "Couldn't obtain folder name"
 msgstr "Δεν ήταν δυνατή η δημιουργία χρονοδιακόπτη (timer)"
 
-#: ../src/unix/sound_sdl.cpp:229
+#: ../src/unix/sound_sdl.cpp:226
 #, c-format
 msgid "Couldn't open audio: %s"
 msgstr "Δεν είναι δυνατό το άνοιγμα του ήχου: %s"
 
-#: ../src/msw/ole/dataobj.cpp:377
+#: ../src/msw/ole/dataobj.cpp:385
 #, c-format
 msgid "Couldn't register clipboard format '%s'."
 msgstr ""
 "Δεν ήταν δυνατή η καταχώρηση του τύπου προχείρου(clipboard format) '%s'"
 
-#: ../src/msw/listctrl.cpp:869
+#: ../src/msw/listctrl.cpp:933
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr ""
 "Δεν ήταν δυνατή η ανάκτηση πληροφοριών σχετικά με το στοιχείο λίστας %d."
 
-#: ../src/common/imagpng.cpp:498 ../src/common/imagpng.cpp:509
-#: ../src/common/imagpng.cpp:519
+#: ../src/common/imagpng.cpp:511 ../src/common/imagpng.cpp:522
+#: ../src/common/imagpng.cpp:532
 msgid "Couldn't save PNG image."
 msgstr "Δεν ήταν δυνατή η αποθήκευση εικόνας PNG."
 
-#: ../src/msw/thread.cpp:684
+#: ../src/msw/thread.cpp:676
 msgid "Couldn't terminate thread"
 msgstr "Δεν ήταν δυνατός ο τερματισμός του thread"
 
-#: ../src/common/xtistrm.cpp:166
+#: ../src/common/xtistrm.cpp:163
 #, fuzzy, c-format
 msgid "Create Parameter %s not found in declared RTTI Parameters"
 msgstr "Η παράμετρος Create δεν βρέθηκε στις δηλωμένες παραμέτρους RTTI"
 
-#: ../src/generic/dirdlgg.cpp:288
+#: ../src/generic/dirdlgg.cpp:285
 msgid "Create directory"
 msgstr "Δημιουργία καταλόγου"
 
-#: ../src/generic/filedlgg.cpp:212 ../src/generic/dirdlgg.cpp:111
+#: ../src/generic/filedlgg.cpp:209 ../src/generic/dirdlgg.cpp:108
 msgid "Create new directory"
 msgstr "Δημιουργία νέου καταλόγου"
 
-#: ../src/xrc/xmlres.cpp:2460
+#: ../src/common/stockitem.cpp:264
+#, fuzzy
+msgid "Create new document"
+msgstr "Δημιουργία νέου καταλόγου"
+
+#: ../src/xrc/xmlres.cpp:2515
 #, fuzzy, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Η εξαγωγή του '%s' στο '%s' απέτυχε"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1758
+#: ../src/propgrid/advprops.cpp:1659
 msgid "Cross"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:333
+#: ../src/common/accelcmn.cpp:347
 #, fuzzy
 msgid "Ctrl+"
 msgstr "ctrl"
 
-#: ../src/richtext/richtextctrl.cpp:332 ../src/osx/textctrl_osx.cpp:576
-#: ../src/common/stockitem.cpp:151 ../src/msw/textctrl.cpp:2507
+#: ../src/osx/textctrl_osx.cpp:594 ../src/common/stockitem.cpp:148
+#: ../src/msw/textctrl.cpp:2772 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "Απο&κοπή"
 
-#: ../src/generic/filectrlg.cpp:940
+#: ../src/generic/filectrlg.cpp:936
 msgid "Current directory:"
 msgstr "Τρέχον κατάλογος:"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:896 ../src/propgrid/advprops.cpp:1574
-#: ../src/propgrid/advprops.cpp:1612
+#: ../src/propgrid/advprops.cpp:797 ../src/propgrid/advprops.cpp:1475
+#: ../src/propgrid/advprops.cpp:1518
 #, fuzzy
 msgid "Custom"
 msgstr "μέγεθος γραμματοσειράς"
 
-#: ../src/gtk/print.cpp:217
+#: ../src/gtk/print.cpp:211
 #, fuzzy
 msgid "Custom size"
 msgstr "μέγεθος γραμματοσειράς"
 
-#: ../src/common/headerctrlcmn.cpp:60
+#: ../src/common/headerctrlcmn.cpp:58
 #, fuzzy
 msgid "Customize Columns"
 msgstr "μέγεθος γραμματοσειράς"
 
-#: ../src/common/stockitem.cpp:151 ../src/stc/stc_i18n.cpp:17
+#: ../src/common/stockitem.cpp:148 ../src/stc/stc_i18n.cpp:17
 #, fuzzy
 msgid "Cut"
 msgstr "Απο&κοπή"
 
-#: ../src/common/stockitem.cpp:259
+#: ../src/common/stockitem.cpp:256
 #, fuzzy
 msgid "Cut selection"
 msgstr "Τμήματα"
 
-#: ../src/common/fmapbase.cpp:152
+#: ../src/common/fmapbase.cpp:149
 msgid "Cyrillic (ISO-8859-5)"
 msgstr "Κυριλλικό (ISO-8859-5)"
 
-#: ../src/common/paper.cpp:99
+#: ../src/common/paper.cpp:96
 msgid "D sheet, 22 x 34 in"
 msgstr "D sheet, 22 x 34 ίντσες"
 
-#: ../src/msw/dde.cpp:703
+#: ../src/msw/dde.cpp:698
 msgid "DDE poke request failed"
 msgstr "Η DDE poke αίτηση απέτυχε"
 
-#: ../src/common/imagbmp.cpp:1169
+#: ../src/common/imagbmp.cpp:1181
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr "DIB Header: Η κωδικοποίηση δεν ταιρίζει με το βάθος bit."
 
@@ -2747,7 +2748,7 @@ msgstr "DIB Header: Αγνωστο βάθος bit στο αρχείο."
 msgid "DIB Header: Unknown encoding in file."
 msgstr "DIB Header: Αγνωστη κωδικοποίηση στο αρχείο."
 
-#: ../src/common/paper.cpp:121
+#: ../src/common/paper.cpp:118
 msgid "DL Envelope, 110 x 220 mm"
 msgstr "Φάκελος DL, 110 x 220 mm"
 
@@ -2756,57 +2757,57 @@ msgstr "Φάκελος DL, 110 x 220 mm"
 msgid "Dashed"
 msgstr "Ημερομηνία"
 
-#: ../src/generic/dbgrptg.cpp:300
+#: ../src/generic/dbgrptg.cpp:301
 #, c-format
 msgid "Debug report \"%s\""
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:210
+#: ../src/common/debugrpt.cpp:211
 #, fuzzy
 msgid "Debug report couldn't be created."
 msgstr "Δεν ήταν δυνατή η δημιουργία του καταλόγου '%s'"
 
-#: ../src/common/debugrpt.cpp:553
+#: ../src/common/debugrpt.cpp:554
 msgid "Debug report generation has failed."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:84
+#: ../src/common/accelcmn.cpp:81
 msgid "Decimal"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:323
+#: ../src/generic/fontdlgg.cpp:319
 msgid "Decorative"
 msgstr "Διακοσμητικός"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1752
+#: ../src/propgrid/advprops.cpp:1653
 #, fuzzy
 msgid "Default"
 msgstr "προκαθορισμένο"
 
-#: ../src/common/fmapbase.cpp:796
+#: ../src/common/fmapbase.cpp:792
 msgid "Default encoding"
 msgstr "Προκαθορισμένη κωδικοποίηση"
 
-#: ../src/dfb/fontmgr.cpp:180
+#: ../src/dfb/fontmgr.cpp:177
 #, fuzzy
 msgid "Default font"
 msgstr "Προκαθορισμένος εκτυπωτής"
 
-#: ../src/generic/prntdlgg.cpp:510
+#: ../src/generic/prntdlgg.cpp:503
 msgid "Default printer"
 msgstr "Προκαθορισμένος εκτυπωτής"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:51
+#: ../src/common/accelcmn.cpp:48
 #, fuzzy
 msgid "Del"
 msgstr "&Διαγραφή"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextbuffer.cpp:8221 ../src/common/stockitem.cpp:152
-#: ../src/common/accelcmn.cpp:50 ../src/stc/stc_i18n.cpp:20
+#: ../src/common/stockitem.cpp:149 ../src/common/accelcmn.cpp:47
+#: ../src/richtext/richtextbuffer.cpp:8217 ../src/stc/stc_i18n.cpp:20
 #, fuzzy
 msgid "Delete"
 msgstr "&Διαγραφή"
@@ -2816,74 +2817,74 @@ msgstr "&Διαγραφή"
 msgid "Delete A&ll"
 msgstr "Επιλογή &Ολων"
 
-#: ../src/richtext/richtextbuffer.cpp:11341
+#: ../src/richtext/richtextbuffer.cpp:11340
 #, fuzzy
 msgid "Delete Column"
 msgstr "Τμήματα"
 
-#: ../src/richtext/richtextbuffer.cpp:11291
+#: ../src/richtext/richtextbuffer.cpp:11290
 #, fuzzy
 msgid "Delete Row"
 msgstr "&Διαγραφή"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 #, fuzzy
 msgid "Delete Style"
 msgstr "Διαγραφή στοιχείου"
 
-#: ../src/richtext/richtextctrl.cpp:1345 ../src/richtext/richtextctrl.cpp:1584
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
 #, fuzzy
 msgid "Delete Text"
 msgstr "Διαγραφή στοιχείου"
 
-#: ../src/generic/editlbox.cpp:170
+#: ../src/generic/editlbox.cpp:147
 msgid "Delete item"
 msgstr "Διαγραφή στοιχείου"
 
-#: ../src/common/stockitem.cpp:260
+#: ../src/common/stockitem.cpp:257
 #, fuzzy
 msgid "Delete selection"
 msgstr "Τμήματα"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 #, fuzzy, c-format
 msgid "Delete style %s?"
 msgstr "Διαγραφή στοιχείου"
 
-#: ../src/unix/snglinst.cpp:301
+#: ../src/unix/snglinst.cpp:298
 #, c-format
 msgid "Deleted stale lock file '%s'."
 msgstr "Διεγράφη το απαρχειομένο(stale) αρχείο κλειδαριά (lock file) '%s'"
 
-#: ../src/common/secretstore.cpp:220
+#: ../src/common/secretstore.cpp:234
 #, fuzzy, c-format
-msgid "Deleting password for \"%s/%s\" failed: %s."
+msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Η εξαγωγή του '%s' στο '%s' απέτυχε"
 
-#: ../src/common/module.cpp:124
+#: ../src/common/module.cpp:121
 #, c-format
 msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 #, fuzzy
 msgid "Descending"
 msgstr "Προκαθορισμένη κωδικοποίηση"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:526 ../src/propgrid/advprops.cpp:882
+#: ../src/generic/dirctrlg.cpp:492 ../src/propgrid/advprops.cpp:783
 msgid "Desktop"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:70
+#: ../src/generic/aboutdlgg.cpp:67
 msgid "Developed by "
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:176
+#: ../src/generic/aboutdlgg.cpp:173
 msgid "Developers"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:374
+#: ../src/msw/dialup.cpp:368
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -2892,11 +2893,11 @@ msgstr ""
 "γιατί η υπηρεσία απομακρυσμένης πρόσβασης (remote access service, RAS) δεν "
 "είναι εκατεστημένη σε αυτό το μηχάνημα. Παρακαλώ εγκαταστήστε τη."
 
-#: ../src/generic/tipdlg.cpp:211
+#: ../src/generic/tipdlg.cpp:208
 msgid "Did you know..."
 msgstr "Γνωρίζατε ότι..."
 
-#: ../src/dfb/wrapdfb.cpp:63
+#: ../src/dfb/wrapdfb.cpp:60
 #, c-format
 msgid "DirectFB error %d occurred."
 msgstr ""
@@ -2906,29 +2907,29 @@ msgstr ""
 msgid "Directories"
 msgstr "Διακοσμητικός"
 
-#: ../src/common/filefn.cpp:1183
+#: ../src/common/filefn.cpp:1071
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Δεν ήταν δυνατή η δημιουργία του καταλόγου '%s'"
 
-#: ../src/common/filefn.cpp:1197
+#: ../src/common/filefn.cpp:1085
 #, fuzzy, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "Δεν ήταν δυνατή η δημιουργία του καταλόγου '%s'"
 
-#: ../src/generic/dirdlgg.cpp:204
+#: ../src/generic/dirdlgg.cpp:201
 msgid "Directory does not exist"
 msgstr "Ο κατάλογος δεν υπάρχει"
 
-#: ../src/generic/filectrlg.cpp:1399
+#: ../src/generic/filectrlg.cpp:1388
 msgid "Directory doesn't exist."
 msgstr "Ο κατάλογος δεν υπάρχει."
 
-#: ../src/common/docview.cpp:457
+#: ../src/common/docview.cpp:450
 msgid "Discard changes and reload the last saved version?"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:502
+#: ../src/html/helpwnd.cpp:500
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -2936,45 +2937,45 @@ msgstr ""
 "Εμφάνιση όλων των στοιχείων του ευρετηρίου δεδομένου substring. Η αναζήτηση "
 "διακρίνει μεταξύ κεφαλαίων/πεζών."
 
-#: ../src/html/helpwnd.cpp:679
+#: ../src/html/helpwnd.cpp:677
 msgid "Display options dialog"
 msgstr "Εμφάνιση του διαλόγου επιλογών"
 
-#: ../src/html/helpwnd.cpp:322
+#: ../src/html/helpwnd.cpp:320
 msgid "Displays help as you browse the books on the left."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:85
+#: ../src/common/accelcmn.cpp:83
 msgid "Divide"
 msgstr ""
 
-#: ../src/common/docview.cpp:533
+#: ../src/common/docview.cpp:526
 #, fuzzy, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Θέλετε να αποθηκεύσετε τις αλλαγές στο έγγραφο %s ;"
 
-#: ../src/common/prntbase.cpp:542
+#: ../src/common/prntbase.cpp:537
 msgid "Document:"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:73
+#: ../src/generic/aboutdlgg.cpp:70
 msgid "Documentation by "
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:180
+#: ../src/generic/aboutdlgg.cpp:177
 msgid "Documentation writers"
 msgstr ""
 
-#: ../src/common/sizer.cpp:2799
+#: ../src/common/sizer.cpp:2916
 msgid "Don't Save"
 msgstr ""
 
-#: ../src/html/htmlwin.cpp:633
+#: ../src/html/htmlwin.cpp:643
 msgid "Done"
 msgstr "Έτοιμο"
 
-#: ../src/generic/progdlgg.cpp:448 ../src/msw/progdlg.cpp:407
+#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
 msgid "Done."
 msgstr "Έτοιμο."
 
@@ -2988,44 +2989,44 @@ msgstr "Έτοιμο"
 msgid "Double"
 msgstr "Έτοιμο"
 
-#: ../src/common/paper.cpp:176
+#: ../src/common/paper.cpp:173
 msgid "Double Japanese Postcard Rotated 148 x 200 mm"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:273
+#: ../src/common/xtixml.cpp:269
 #, c-format
 msgid "Doubly used id : %d"
 msgstr "Id χρησιμοποιούμενο δύο φορές : %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:153
-#: ../src/common/accelcmn.cpp:64
+#: ../src/common/stockitem.cpp:150 ../src/common/accelcmn.cpp:61
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Down"
 msgstr "Κάτω"
 
-#: ../src/richtext/richtextctrl.cpp:865
+#: ../src/richtext/richtextctrl.cpp:864
 msgid "Drag"
 msgstr ""
 
-#: ../src/common/paper.cpp:100
+#: ../src/common/paper.cpp:97
 msgid "E sheet, 34 x 44 in"
 msgstr "E sheet, 34 x 44 ίντσες"
 
-#: ../src/unix/fswatcher_inotify.cpp:561
+#: ../src/unix/fswatcher_inotify.cpp:558
 #, fuzzy
 msgid "EOF while reading from inotify descriptor"
 msgstr "αδύνατη η ανάγνωση από περiγραφέα (descriptor) αρχείου %d"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 #, fuzzy
 msgid "Edit"
 msgstr "Επεξεργασία στοιχείου"
 
-#: ../src/generic/editlbox.cpp:168
+#: ../src/generic/editlbox.cpp:131
 msgid "Edit item"
 msgstr "Επεξεργασία στοιχείου"
 
-#: ../include/wx/generic/progdlgg.h:84
+#: ../include/wx/generic/progdlgg.h:85
 #, fuzzy
 msgid "Elapsed time:"
 msgstr "Υπολογισθείς χρόνος : "
@@ -3097,53 +3098,53 @@ msgid "Enables the shadow spread."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:66
+#: ../src/common/accelcmn.cpp:63
 msgid "End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:55
+#: ../src/common/accelcmn.cpp:52
 #, fuzzy
 msgid "Enter"
 msgstr "Εκτυπωτής"
 
-#: ../src/richtext/richtextstyledlg.cpp:934
+#: ../src/richtext/richtextstyledlg.cpp:930
 #, fuzzy
 msgid "Enter a box style name"
 msgstr "Το στυλ της γραμματοσειράς."
 
-#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:602
 msgid "Enter a character style name"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:816
 msgid "Enter a list style name"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:893
+#: ../src/richtext/richtextstyledlg.cpp:889
 #, fuzzy
 msgid "Enter a new style name"
 msgstr "Το στυλ της γραμματοσειράς."
 
-#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:650
 msgid "Enter a paragraph style name"
 msgstr ""
 
-#: ../src/generic/dbgrptg.cpp:174
+#: ../src/generic/dbgrptg.cpp:171
 #, fuzzy, c-format
 msgid "Enter command to open file \"%s\":"
 msgstr "δεν είναι δυνατό το άνοιγμα του αρχείου '%s'"
 
-#: ../src/generic/helpext.cpp:459
+#: ../src/generic/helpext.cpp:457
 msgid "Entries found"
 msgstr "Εισαγωγές(entries) βρέθηκαν"
 
-#: ../src/common/paper.cpp:142
+#: ../src/common/paper.cpp:139
 #, fuzzy
 msgid "Envelope Invite 220 x 220 mm"
 msgstr "Φάκελος DL, 110 x 220 mm"
 
-#: ../src/common/config.cpp:469
+#: ../src/common/config.cpp:465
 #, fuzzy, c-format
 msgid ""
 "Environment variables expansion failed: missing '%c' at position %u in '%s'."
@@ -3151,13 +3152,13 @@ msgstr ""
 "Η επέκταση μεταβλητών περιβάλλοντος απέτυχε: λείπει το '%c' στην θέση %d στο "
 "'%s'."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/generic/dirctrlg.cpp:570
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/dirctrlg.cpp:599
-#: ../src/generic/dirdlgg.cpp:323 ../src/generic/filectrlg.cpp:642
-#: ../src/generic/filectrlg.cpp:756 ../src/generic/filectrlg.cpp:770
-#: ../src/generic/filectrlg.cpp:786 ../src/generic/filectrlg.cpp:1368
-#: ../src/generic/filectrlg.cpp:1399 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/gtk1/fontdlg.cpp:74 ../src/generic/dirctrlg.cpp:536
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/dirctrlg.cpp:565
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1357 ../src/generic/filectrlg.cpp:1388
+#: ../src/generic/filedlgg.cpp:354 ../src/generic/dirdlgg.cpp:320
+#: ../src/gtk/filedlg.cpp:74
 msgid "Error"
 msgstr "Σφάλμα"
 
@@ -3166,245 +3167,266 @@ msgstr "Σφάλμα"
 msgid "Error closing epoll descriptor"
 msgstr "Σφάλμα κατα τη δημιουργία καταλόγου"
 
-#: ../src/unix/fswatcher_kqueue.cpp:114
+#: ../src/unix/fswatcher_kqueue.cpp:131
 #, fuzzy
 msgid "Error closing kqueue instance"
 msgstr "Σφάλμα κατα τη δημιουργία καταλόγου"
 
-#: ../src/common/filefn.cpp:1049
+#: ../src/common/filefn.cpp:938
 #, fuzzy, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Αποτυχία αντιγραφής του αρχείου '%s' στο '%s'"
 
-#: ../src/generic/dirdlgg.cpp:222
+#: ../src/generic/dirdlgg.cpp:219
 msgid "Error creating directory"
 msgstr "Σφάλμα κατα τη δημιουργία καταλόγου"
 
-#: ../src/common/imagbmp.cpp:1181
+#: ../src/common/imagbmp.cpp:1193
 #, fuzzy
 msgid "Error in reading image DIB."
 msgstr "Σφάλμα κατά την ανάγνωση εικόνας DIB."
 
-#: ../src/propgrid/propgrid.cpp:6696
+#: ../src/propgrid/propgrid.cpp:6665
 #, c-format
 msgid "Error in resource: %s"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:422
+#: ../src/common/fileconf.cpp:421
 msgid "Error reading config options."
 msgstr "Σφάλμα κατά την ανάγνωση των ρυθμίσεων."
+
+#: ../src/msw/webview_ie.cpp:1057 ../src/msw/webview_edge.cpp:850
+#: ../src/gtk/webview_webkit2.cpp:1262 ../src/osx/webview_webkit.mm:383
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
 
 #: ../src/common/fileconf.cpp:1029
 msgid "Error saving user configuration data."
 msgstr "Σφάλμα κατά την εγγραφή των ρυθμίσεων χρήστη."
 
-#: ../src/gtk/print.cpp:722
+#: ../src/gtk/print.cpp:720
 #, fuzzy
 msgid "Error while printing: "
 msgstr "Σφάλμα κατά την αναμονή στη σημαφόρο"
 
-#: ../src/common/log.cpp:219
+#: ../src/common/log.cpp:237
 msgid "Error: "
 msgstr "Σφάλμα: "
 
+#: ../src/common/webrequest.cpp:98
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Σφάλμα: "
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:69
+#: ../src/common/accelcmn.cpp:66
 msgid "Esc"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:70
+#: ../src/common/accelcmn.cpp:67
 #, fuzzy
 msgid "Escape"
 msgstr "Τοπίο"
 
-#: ../src/common/fmapbase.cpp:150
+#: ../src/common/fmapbase.cpp:147
 msgid "Esperanto (ISO-8859-3)"
 msgstr "Εσπεράντο (ISO-8859-3)"
 
-#: ../include/wx/generic/progdlgg.h:85
+#: ../include/wx/generic/progdlgg.h:86
 #, fuzzy
 msgid "Estimated time:"
 msgstr "Υπολογισθείς χρόνος : "
 
-#: ../src/generic/dbgrptg.cpp:234
+#: ../src/generic/dbgrptg.cpp:231
 #, fuzzy
 msgid "Executable files (*.exe)|*.exe|"
 msgstr "Όλα τα αρχεία (*.*)|*.*"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:155 ../src/common/accelcmn.cpp:78
+#: ../src/common/stockitem.cpp:152 ../src/common/accelcmn.cpp:75
 msgid "Execute"
 msgstr ""
 
-#: ../src/msw/utilsexc.cpp:876
+#: ../src/msw/utilsexc.cpp:873
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Η εκτέλεση της εντολής '%s' απέτυχε"
 
-#: ../src/common/paper.cpp:105
+#: ../src/common/paper.cpp:102
 msgid "Executive, 7 1/4 x 10 1/2 in"
 msgstr "Executive, 7 1/4 x 10 1/2 ίντσες"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6009
+#: ../src/generic/datavgen.cpp:6814
 msgid "Expand"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1240
+#: ../src/msw/registry.cpp:1228
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:195
+#: ../src/common/fmapbase.cpp:192
 msgid "Extended Unix Codepage for Japanese (EUC-JP)"
 msgstr "Εκτεταμένη Κωδικοσελίδα Unix για Ιαπωνικά (EUC-JP)"
 
-#: ../src/html/chm.cpp:725
+#: ../src/html/chm.cpp:718
 #, c-format
 msgid "Extraction of '%s' into '%s' failed."
 msgstr "Η εξαγωγή του '%s' στο '%s' απέτυχε"
 
-#: ../src/common/accelcmn.cpp:249 ../src/common/accelcmn.cpp:344
+#: ../src/common/accelcmn.cpp:259 ../src/common/accelcmn.cpp:358
 msgid "F"
 msgstr ""
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:672
+#: ../src/propgrid/advprops.cpp:582
 #, fuzzy
 msgid "Face Name"
 msgstr "ΝέοΌνομα"
 
-#: ../src/unix/snglinst.cpp:269
+#: ../src/unix/snglinst.cpp:266
 msgid "Failed to access lock file."
 msgstr "Αποτυχία πρόσβασης στο αρχείο 'κλειδωνιά'(lock file)."
+
+#: ../src/gtk/font.cpp:572
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Αποτυχία φόρτωσης της μετα-εικόνας από το αρχείο '%s'."
 
 #: ../src/unix/epolldispatcher.cpp:116
 #, fuzzy, c-format
 msgid "Failed to add descriptor %d to epoll descriptor %d"
 msgstr "δεν είναι δυνατή η εγγραφή του περιγραφέα αρχείου(file descriptor) %d"
 
-#: ../src/msw/dib.cpp:489
+#: ../src/msw/dib.cpp:535
 #, fuzzy, c-format
 msgid "Failed to allocate %luKb of memory for bitmap data."
 msgstr "Αποτυχία δέσμευσης %luKb μνήμης για δεδομένα bitmap."
 
-#: ../src/common/glcmn.cpp:115
+#: ../src/common/glcmn.cpp:112
 #, fuzzy
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Αποτυχία δημιουργίας δείκτη."
 
-#: ../src/unix/displayx11.cpp:236
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Αποτυχία δημιουργίας δείκτη."
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Αποτυχία δημιουργίας δείκτη."
+
+#: ../include/wx/unix/private/displayx11.h:89
 msgid "Failed to change video mode"
 msgstr "Αποτυχία αλλαγής της κατάστασης οθόνης"
 
-#: ../src/common/image.cpp:3277
+#: ../src/common/image.cpp:3396
 #, fuzzy, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Αποτυχία αποθήκευσης της εικόνας στο αρχείο \"%s\"."
 
-#: ../src/common/debugrpt.cpp:239
+#: ../src/common/debugrpt.cpp:240
 #, fuzzy, c-format
 msgid "Failed to clean up debug report directory \"%s\""
 msgstr "Απέτυχε η δημιουργία καταλόγου '%s'/.gnome."
 
-#: ../src/common/filename.cpp:192
+#: ../src/common/filename.cpp:189
 msgid "Failed to close file handle"
 msgstr "Αποτυχία κλεισίματος του χειριστηρίου του αρχείου(file handle)"
 
-#: ../src/unix/snglinst.cpp:340
+#: ../src/unix/snglinst.cpp:337
 #, c-format
 msgid "Failed to close lock file '%s'"
 msgstr "Αποτυχία κλεισίματος του αρχείου 'κλειδωνιά'(lock file) '%s'"
 
-#: ../src/msw/clipbrd.cpp:112
+#: ../src/msw/clipbrd.cpp:110
 msgid "Failed to close the clipboard."
 msgstr "Αποτυχία κλεισίματος του προχείρου(clipboard)"
 
-#: ../src/x11/utils.cpp:208
+#: ../src/x11/utils.cpp:170
 #, fuzzy, c-format
 msgid "Failed to close the display \"%s\""
 msgstr "Αποτυχία κλεισίματος του προχείρου(clipboard)"
 
-#: ../src/msw/dialup.cpp:797
+#: ../src/msw/dialup.cpp:791
 msgid "Failed to connect: missing username/password."
 msgstr "Αποτυχία συνδεσης: λείπει το όνομα χρήστη/συνθηματικό"
 
-#: ../src/msw/dialup.cpp:743
+#: ../src/msw/dialup.cpp:737
 msgid "Failed to connect: no ISP to dial."
 msgstr ""
 "Αποτυχία συνδεσης: κανένας παροχέας υπηρεσιών Internet (ISP) για να καλέσω."
 
-#: ../src/common/textfile.cpp:203
-#, fuzzy, c-format
-msgid "Failed to convert file \"%s\" to Unicode."
-msgstr "Αποτυχία κλεισίματος του χειριστηρίου του αρχείου(file handle)"
-
-#: ../src/generic/logg.cpp:956
+#: ../src/generic/logg.cpp:953
 #, fuzzy
 msgid "Failed to copy dialog contents to the clipboard."
 msgstr "Αποτυχία ανοίγματος του προχείρου (clipboard)."
 
-#: ../src/msw/registry.cpp:692
+#: ../src/msw/registry.cpp:681
 #, c-format
 msgid "Failed to copy registry value '%s'"
 msgstr "Αποτυχία αντιγραφής της τιμής μητρώου '%s'"
 
-#: ../src/msw/registry.cpp:701
+#: ../src/msw/registry.cpp:690
 #, c-format
 msgid "Failed to copy the contents of registry key '%s' to '%s'."
 msgstr ""
 "Αποτυχία αντιγραφής των περιεχομένων του κλειδιού μητρώου '%s' στο '%s'."
 
-#: ../src/common/filefn.cpp:1015
+#: ../src/common/filefn.cpp:904
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Αποτυχία αντιγραφής του αρχείου '%s' στο '%s'"
 
-#: ../src/msw/registry.cpp:679
+#: ../src/msw/registry.cpp:668
 #, c-format
 msgid "Failed to copy the registry subkey '%s' to '%s'."
 msgstr "Αποτυχία της αντιγραφής του υποκλειδιού μητρώου '%s' σε '%s'."
 
-#: ../src/msw/dde.cpp:1070
+#: ../src/msw/dde.cpp:1134
 msgid "Failed to create DDE string"
 msgstr "Απέτυχε η δημιουργεία ενός DDE αλφαρηθμιτικού (string)"
 
-#: ../src/msw/mdi.cpp:616
+#: ../src/msw/mdi.cpp:621
 msgid "Failed to create MDI parent frame."
 msgstr "Αποτυχία δημιουργίας ενός γονεικού περιγράμματος (parent frame) MDI."
 
-#: ../src/common/filename.cpp:1027
+#: ../src/common/filename.cpp:1024
 msgid "Failed to create a temporary file name"
 msgstr "Αποτυχία δημιουργίας ονόματος προσωρινού αρχείου"
 
-#: ../src/msw/utilsexc.cpp:228
+#: ../src/msw/utilsexc.cpp:225
 msgid "Failed to create an anonymous pipe"
 msgstr "Αποτυχία δημιουργίας ενός ανώνυμου pipe"
 
-#: ../src/msw/ole/automtn.cpp:522
+#: ../src/msw/ole/automtn.cpp:513
 #, fuzzy, c-format
 msgid "Failed to create an instance of \"%s\""
 msgstr "Απέτυχε η δημιουργία καταλόγου '%s'/.gnome."
 
-#: ../src/msw/dde.cpp:437
+#: ../src/msw/dde.cpp:432
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr ""
 "Αποτυχία κατά την δημιουργία σύνδεσης με τον εξυπηρετητή (server) '%s' στο "
 "θέμα '%s'"
 
-#: ../src/msw/cursor.cpp:204
+#: ../src/msw/cursor.cpp:195
 msgid "Failed to create cursor."
 msgstr "Αποτυχία δημιουργίας δείκτη."
 
-#: ../src/common/debugrpt.cpp:209
+#: ../src/common/debugrpt.cpp:210
 #, fuzzy, c-format
 msgid "Failed to create directory \"%s\""
 msgstr "Απέτυχε η δημιουργία καταλόγου '%s'/.gnome."
 
-#: ../src/generic/dirdlgg.cpp:220
+#: ../src/generic/dirdlgg.cpp:217
 #, c-format
 msgid ""
 "Failed to create directory '%s'\n"
@@ -3418,122 +3440,141 @@ msgstr ""
 msgid "Failed to create epoll descriptor"
 msgstr "Αποτυχία δημιουργίας δείκτη."
 
-#: ../src/msw/mimetype.cpp:238
+#: ../src/gtk/font.cpp:562
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "Αποτυχία ανανέωσης του αρχείου ρυθμίσεων του χρήστη."
+
+#: ../src/msw/mimetype.cpp:235
 #, c-format
 msgid "Failed to create registry entry for '%s' files."
 msgstr ""
 "Απέτυχε η δημιουργία εγγραφής μητρώου (registry entry) για '%s' αρχεία."
 
-#: ../src/msw/fdrepdlg.cpp:409
+#: ../src/msw/fdrepdlg.cpp:408
 #, c-format
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr ""
 "Απέτυχε η δημιουργία καθιερωμένου παράθυρου διαλόγου εύρεσης/αντικατάστασης "
 "(κωδικός σφάλματος %d)"
 
-#: ../src/unix/wakeuppipe.cpp:52
+#: ../src/unix/wakeuppipe.cpp:49
 #, fuzzy
 msgid "Failed to create wake up pipe used by event loop."
 msgstr "Αποτυχία δημιουργίας μιας μπάρας κατάστασης (status bar)"
 
-#: ../src/html/winpars.cpp:730
+#: ../src/html/winpars.cpp:727
 #, c-format
 msgid "Failed to display HTML document in %s encoding"
 msgstr "Απέτυχε η προβολή του εγγράφου HTML στην κωδικοποίηση %s"
 
-#: ../src/msw/clipbrd.cpp:124
+#: ../src/msw/clipbrd.cpp:122
 msgid "Failed to empty the clipboard."
 msgstr "Αποτυχία αδειάσματος του προχείρου (clipboard)."
 
-#: ../src/unix/displayx11.cpp:212
+#: ../include/wx/unix/private/displayx11.h:65
 msgid "Failed to enumerate video modes"
 msgstr "Απέτυχε η απαρίθμηση των καταστάσεων οθόνης."
 
-#: ../src/msw/dde.cpp:722
+#: ../src/msw/dde.cpp:717
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "Αποτυχία επίτευξης βρόχου advise με τον διακομιστή DDE"
 
-#: ../src/msw/dialup.cpp:629 ../src/msw/dialup.cpp:863
+#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
 #, fuzzy, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Αποτυχία %s της σύνδεσης μέσω τηλεφώνου : %s"
 
-#: ../src/unix/utilsunx.cpp:611
+#: ../src/unix/utilsunx.cpp:613
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Αποτυχία εκτέλεσης του '%s'\n"
 
-#: ../src/common/debugrpt.cpp:720
+#: ../src/common/debugrpt.cpp:730
 msgid "Failed to execute curl, please install it in PATH."
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:505
+#: ../src/msw/ole/automtn.cpp:496
 #, fuzzy, c-format
 msgid "Failed to find CLSID of \"%s\""
 msgstr "Αποτυχία ανοίγματος του '%s' για το '%s'"
 
-#: ../src/common/regex.cpp:431 ../src/common/regex.cpp:479
+#: ../src/common/regex.cpp:428 ../src/common/regex.cpp:476
 #, fuzzy, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr ""
 "Αποτυχία στο συνταίριασμα του '%s' στην κανονική έκφραση (regular "
 "expression): %s"
 
-#: ../src/msw/dialup.cpp:695
+#: ../src/msw/webview_ie.cpp:978
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:689
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Αποτυχία κατά την λήψη των ονομάτων των ISP: %s"
 
-#: ../src/msw/ole/automtn.cpp:574
+#: ../src/msw/ole/automtn.cpp:565
 #, fuzzy, c-format
 msgid "Failed to get OLE automation interface for \"%s\""
 msgstr "Απέτυχε η δημιουργία καταλόγου '%s'/.gnome."
 
-#: ../src/msw/clipbrd.cpp:711
+#: ../src/msw/clipbrd.cpp:731
 msgid "Failed to get data from the clipboard"
 msgstr "Αποτυχία λήψης δεδομένων απο το πρόχειρο"
 
-#: ../src/common/time.cpp:223
+#: ../src/common/time.cpp:216
 msgid "Failed to get the local system time"
 msgstr "Αποτυχία καθορισμού της ώρας του τοπικού συστήματος"
 
-#: ../src/common/filefn.cpp:1345
+#: ../src/common/filefn.cpp:1233
 msgid "Failed to get the working directory"
 msgstr "Αποτυχία λήψης καταλόγου εργασίας (working directory)"
 
-#: ../src/univ/theme.cpp:114
+#: ../src/univ/theme.cpp:111
 msgid "Failed to initialize GUI: no built-in themes found."
 msgstr "Αποτυχία αρχικοποίησης του GUI: δεν βρέθηκαν ενσωματωμένα θέματα."
 
-#: ../src/msw/helpchm.cpp:63
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:60
 msgid "Failed to initialize MS HTML Help."
 msgstr "Αποτυχία στην αρχικοποίηση του MS HTML Help."
 
-#: ../src/msw/glcanvas.cpp:1381
+#: ../src/msw/glcanvas.cpp:1391
 msgid "Failed to initialize OpenGL"
 msgstr "Απέτυχε η αρχικοποίηση του OpenGL"
 
-#: ../src/msw/dialup.cpp:858
+#: ../src/msw/dialup.cpp:852
 #, fuzzy, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Αποτυχία τερματισμού της σύνδεσης μέσω τηλεφώνου : %s"
 
-#: ../src/gtk/textctrl.cpp:1128
+#: ../src/gtk/textctrl.cpp:1209
 #, fuzzy
 msgid "Failed to insert text in the control."
 msgstr "Αποτυχία λήψης καταλόγου εργασίας (working directory)"
 
-#: ../src/unix/snglinst.cpp:241
+#: ../src/unix/snglinst.cpp:238
 #, c-format
 msgid "Failed to inspect the lock file '%s'"
 msgstr "Αποτυχία επιθεώρησης του αρχείου 'κλειδωνιά'(lock file) '%s'"
 
-#: ../src/unix/appunix.cpp:182
+#: ../src/unix/appunix.cpp:179
 #, fuzzy
 msgid "Failed to install signal handler"
 msgstr "Αποτυχία κλεισίματος του χειριστηρίου του αρχείου(file handle)"
 
-#: ../src/unix/threadpsx.cpp:1167
+#: ../src/unix/threadpsx.cpp:1216
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -3541,71 +3582,71 @@ msgstr ""
 "Απέτυχε η συνένωση(join) ενός νήματος εκτέλεσης (thread), πιθανή διαρροή "
 "μνήμης εντοπίστηκε - παρακαλώ επανεκκινήστε το πρόγραμμα"
 
-#: ../src/msw/utils.cpp:629
+#: ../src/msw/utils.cpp:619
 #, c-format
 msgid "Failed to kill process %d"
 msgstr "Αποτυχία θανάτωσης της διαδικασίας(process) %d"
 
-#: ../src/common/image.cpp:2500
+#: ../src/common/image.cpp:2595
 #, fuzzy, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Αποτυχία φόρτωσης της εικόνας %d από το αρχείο '%s'."
 
-#: ../src/common/image.cpp:2509
+#: ../src/common/image.cpp:2604
 #, fuzzy, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Αποτυχία φόρτωσης της εικόνας %d από το αρχείο '%s'."
 
-#: ../src/common/iconbndl.cpp:225
+#: ../src/common/iconbndl.cpp:224
 #, fuzzy, c-format
 msgid "Failed to load icons from resource '%s'."
 msgstr "Αποτυχία φόρτωσης της εικόνας %d από το αρχείο '%s'."
 
-#: ../src/common/iconbndl.cpp:200
+#: ../src/common/iconbndl.cpp:198
 #, fuzzy, c-format
 msgid "Failed to load image %%d from file '%s'."
 msgstr "Αποτυχία φόρτωσης της εικόνας %d από το αρχείο '%s'."
 
-#: ../src/common/iconbndl.cpp:208
+#: ../src/common/iconbndl.cpp:206
 #, fuzzy, c-format
 msgid "Failed to load image %d from stream."
 msgstr "Αποτυχία φόρτωσης της εικόνας %d από το αρχείο '%s'."
 
-#: ../src/common/image.cpp:2587 ../src/common/image.cpp:2606
+#: ../src/common/image.cpp:2682 ../src/common/image.cpp:2701
 #, fuzzy, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Αποτυχία φόρτωσης της εικόνας %d από το αρχείο '%s'."
 
-#: ../src/msw/enhmeta.cpp:97
+#: ../src/msw/enhmeta.cpp:94
 #, c-format
 msgid "Failed to load metafile from file \"%s\"."
 msgstr "Αποτυχία φόρτωσης της μετα-εικόνας από το αρχείο '%s'."
 
-#: ../src/msw/volume.cpp:327
+#: ../src/msw/volume.cpp:335
 msgid "Failed to load mpr.dll."
 msgstr "Αποτυχία φόρτωσης του mpr.dll."
 
-#: ../src/msw/utils.cpp:953
+#: ../src/msw/utils.cpp:943
 #, fuzzy, c-format
 msgid "Failed to load resource \"%s\"."
 msgstr "Αποτυχία φόρτωσης της μετα-εικόνας από το αρχείο '%s'."
 
-#: ../src/common/dynlib.cpp:92
+#: ../src/common/dynlib.cpp:86
 #, c-format
 msgid "Failed to load shared library '%s'"
 msgstr "Αποτυχία φόρτωσης της κοινής βιβλιοθήκης (shared library) '%s'"
 
-#: ../src/osx/core/sound.cpp:145
+#: ../src/osx/core/sound.cpp:143
 #, fuzzy, c-format
 msgid "Failed to load sound from \"%s\" (error %d)."
 msgstr "Αποτυχία φόρτωσης της μετα-εικόνας από το αρχείο '%s'."
 
-#: ../src/msw/utils.cpp:960
+#: ../src/msw/utils.cpp:950
 #, fuzzy, c-format
 msgid "Failed to lock resource \"%s\"."
 msgstr "Αποτυχία κλειδώματος του αρχείου 'κλειδωνιά'(lock file) '%s'"
 
-#: ../src/unix/snglinst.cpp:198
+#: ../src/unix/snglinst.cpp:195
 #, c-format
 msgid "Failed to lock the lock file '%s'"
 msgstr "Αποτυχία κλειδώματος του αρχείου 'κλειδωνιά'(lock file) '%s'"
@@ -3615,33 +3656,38 @@ msgstr "Αποτυχία κλειδώματος του αρχείου 'κλει�
 msgid "Failed to modify descriptor %d in epoll descriptor %d"
 msgstr ""
 
-#: ../src/common/filename.cpp:2575
+#: ../src/common/filename.cpp:2658
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Αποτυχία τροποποίησης ώρας του αρχείου '%s'"
 
-#: ../src/common/selectdispatcher.cpp:258
+#: ../src/common/selectdispatcher.cpp:255
 msgid "Failed to monitor I/O channels"
 msgstr ""
 
-#: ../src/common/filename.cpp:175
+#: ../src/common/filename.cpp:172
 #, fuzzy, c-format
 msgid "Failed to open '%s' for reading"
 msgstr "Αποτυχία ανοίγματος του '%s' για το '%s'"
 
-#: ../src/common/filename.cpp:180
+#: ../src/common/filename.cpp:177
 #, fuzzy, c-format
 msgid "Failed to open '%s' for writing"
 msgstr "Αποτυχία ανοίγματος του '%s' για το '%s'"
 
-#: ../src/html/chm.cpp:141
+#: ../src/html/chm.cpp:138
 #, c-format
 msgid "Failed to open CHM archive '%s'."
 msgstr "Αποτυχία ανοίγματος του arxe;ioy CHM '%s'."
 
-#: ../src/common/utilscmn.cpp:1126
+#: ../src/common/utilscmn.cpp:1140
 #, fuzzy, c-format
 msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Αποτυχία ανοίγματος του '%s' για το '%s'"
+
+#: ../src/common/hyperlnkcmn.cpp:133
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Αποτυχία ανοίγματος του '%s' για το '%s'"
 
 #: ../include/wx/msw/private/fswatcher.h:92
@@ -3649,221 +3695,239 @@ msgstr "Αποτυχία ανοίγματος του '%s' για το '%s'"
 msgid "Failed to open directory \"%s\" for monitoring."
 msgstr "Αποτυχία ανοίγματος του '%s' για το '%s'"
 
-#: ../src/x11/utils.cpp:227
+#: ../src/x11/utils.cpp:189
 #, fuzzy, c-format
 msgid "Failed to open display \"%s\"."
 msgstr "Αποτυχία ανοίγματος του '%s' για το '%s'"
 
-#: ../src/common/filename.cpp:1062
+#: ../src/common/filename.cpp:1059
 msgid "Failed to open temporary file."
 msgstr "Αποτυχία ανοίγματος προσωρινού αρχείου"
 
-#: ../src/msw/clipbrd.cpp:91
+#: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Αποτυχία ανοίγματος του προχείρου (clipboard)."
 
-#: ../src/common/translation.cpp:1184
+#: ../src/common/translation.cpp:1226
 #, fuzzy, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Δεν είναι δυνατή η ανάγνωση Plural-Forms:'%s'."
 
-#: ../src/unix/mediactrl.cpp:1214
+#: ../src/unix/mediactrl.cpp:1239
 #, fuzzy, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Αποτυχία ανοίγματος του '%s' για το '%s'"
 
-#: ../src/msw/clipbrd.cpp:600
+#: ../src/msw/clipbrd.cpp:610
 msgid "Failed to put data on the clipboard"
 msgstr "Αποτυχία τοποθέτησης δεδομένων στο πρόχειρο (clipboard)"
 
-#: ../src/unix/snglinst.cpp:278
+#: ../src/unix/snglinst.cpp:275
 msgid "Failed to read PID from lock file."
 msgstr "Απέτυχε η ανάγνωση PID από αρχείο κλειδωνιά(lock file)."
 
-#: ../src/common/fileconf.cpp:433
+#: ../src/common/fileconf.cpp:432
 #, fuzzy
 msgid "Failed to read config options."
 msgstr "Σφάλμα κατά την ανάγνωση των ρυθμίσεων."
 
-#: ../src/common/docview.cpp:681
+#: ../src/common/docview.cpp:676
 #, fuzzy, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Αποτυχία φόρτωσης της μετα-εικόνας από το αρχείο '%s'."
 
-#: ../src/dfb/evtloop.cpp:98
+#: ../src/dfb/evtloop.cpp:99
 #, fuzzy
 msgid "Failed to read event from DirectFB pipe"
 msgstr "Απέτυχε η ανάγνωση PID από αρχείο κλειδωνιά(lock file)."
 
-#: ../src/unix/wakeuppipe.cpp:120
+#: ../src/unix/wakeuppipe.cpp:117
 #, fuzzy
 msgid "Failed to read from wake-up pipe"
 msgstr "Απέτυχε η ανάγνωση PID από αρχείο κλειδωνιά(lock file)."
 
-#: ../src/unix/utilsunx.cpp:679
+#: ../src/common/textfile.cpp:96
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Αποτυχία φόρτωσης της μετα-εικόνας από το αρχείο '%s'."
+
+#: ../src/unix/utilsunx.cpp:681
 msgid "Failed to redirect child process input/output"
 msgstr ""
 "Αποτυχία στην ανακατεύθυνση της εισόδου/εξόδου διεργασίας απογόνου (child "
 "process input/output)"
 
-#: ../src/msw/utilsexc.cpp:701
+#: ../src/msw/utilsexc.cpp:698
 msgid "Failed to redirect the child process IO"
 msgstr ""
 "Αποτυχία στην ανακατεύθυνση του IO διεργασίας απογόνου (child process IO)"
 
-#: ../src/msw/dde.cpp:288
+#: ../src/msw/dde.cpp:283
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Απέτυχε η καταχώρηση του DDE εξυπηρετητή (server) '%s'"
 
-#: ../src/common/fontmap.cpp:245
+#: ../src/gtk/font.cpp:580
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "Αποτυχία ανανέωσης του αρχείου ρυθμίσεων του χρήστη."
+
+#: ../src/common/fontmap.cpp:242
 #, c-format
 msgid "Failed to remember the encoding for the charset '%s'."
 msgstr ""
 "Αποτυχία ανάμνησης της κωδικοποίησης για το συνολο χαρακτήρων (charset) '%s'."
 
-#: ../src/common/debugrpt.cpp:227
+#: ../src/common/debugrpt.cpp:228
 #, fuzzy, c-format
 msgid "Failed to remove debug report file \"%s\""
 msgstr "Αποτυχία απομάκρυνσης του αρχείου 'κλειδωνιά'(lock file) '%s'"
 
-#: ../src/unix/snglinst.cpp:328
+#: ../src/unix/snglinst.cpp:325
 #, c-format
 msgid "Failed to remove lock file '%s'"
 msgstr "Αποτυχία απομάκρυνσης του αρχείου 'κλειδωνιά'(lock file) '%s'"
 
-#: ../src/unix/snglinst.cpp:288
+#: ../src/unix/snglinst.cpp:285
 #, c-format
 msgid "Failed to remove stale lock file '%s'."
 msgstr ""
 "Αποτυχία απομάκρυνσης του απαρχειομένου(stale) αρχείου 'κλειδωνιά'(lock "
 "file) '%s'"
 
-#: ../src/msw/registry.cpp:529
+#: ../src/msw/registry.cpp:518
 #, c-format
 msgid "Failed to rename registry value '%s' to '%s'."
 msgstr "Αποτυχία της μετονομασίας της τιμής μητρώου '%s' σε '%s'."
 
-#: ../src/common/filefn.cpp:1122
+#: ../src/common/filefn.cpp:1011
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
 "exists."
 msgstr ""
 
-#: ../src/msw/registry.cpp:634
+#: ../src/msw/registry.cpp:623
 #, c-format
 msgid "Failed to rename the registry key '%s' to '%s'."
 msgstr "Αποτυχία της μετονομασίας του κλειδιού μητρώου '%s' σε '%s'."
 
-#: ../src/common/filename.cpp:2671
+#: ../src/msw/webview_ie.cpp:995
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/common/filename.cpp:2754
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Αποτυχία λήψης της ώρας του αρχείου '%s'"
 
-#: ../src/msw/dialup.cpp:468
+#: ../src/msw/dialup.cpp:462
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Αποτυχία στη λήψη κειμένου από το μήνυμα σφάλματος RAS"
 
-#: ../src/msw/clipbrd.cpp:748
+#: ../src/msw/clipbrd.cpp:768
 msgid "Failed to retrieve the supported clipboard formats"
 msgstr ""
 "Αποτυχία στην ανάκτηση των υποστηριζομένων μορφών προχείρου (clipboard "
 "formats)"
 
-#: ../src/common/docview.cpp:652
+#: ../src/common/docview.cpp:647
 #, fuzzy, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Αποτυχία αποθήκευσης της εικόνας στο αρχείο \"%s\"."
 
-#: ../src/msw/dib.cpp:269
+#: ../src/msw/dib.cpp:312
 #, c-format
 msgid "Failed to save the bitmap image to file \"%s\"."
 msgstr "Αποτυχία αποθήκευσης της εικόνας στο αρχείο \"%s\"."
 
-#: ../src/msw/dde.cpp:763
+#: ../src/msw/dde.cpp:811
 msgid "Failed to send DDE advise notification"
 msgstr "Αποτυχία κατά την αποστολή DDE advise επισήμανσης"
 
-#: ../src/common/ftp.cpp:402
+#: ../src/common/ftp.cpp:399
 #, c-format
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Αποτυχία θέσης FTP transfer mode σε '%s'"
 
-#: ../src/msw/clipbrd.cpp:427
+#: ../src/msw/clipbrd.cpp:443
 msgid "Failed to set clipboard data."
 msgstr "Αποτυχία θέσης δεδομένων προχείρου (clipboard)."
 
-#: ../src/unix/snglinst.cpp:181
+#: ../src/unix/snglinst.cpp:178
 #, c-format
 msgid "Failed to set permissions on lock file '%s'"
 msgstr "Αδύνατος ο ορισμός των δικαιωμάτων για το αρχείο 'κλειδωνιά' '%s'"
 
-#: ../src/unix/utilsunx.cpp:668
+#: ../src/unix/utilsunx.cpp:670
 #, fuzzy
 msgid "Failed to set process priority"
 msgstr "Δεν είναι δυνατή η θέση προτεραιότητας του thread"
 
-#: ../src/common/file.cpp:559
+#: ../src/common/ffile.cpp:355 ../src/common/file.cpp:586
 msgid "Failed to set temporary file permissions"
 msgstr "Αποτυχία θέσπισης δικαιωμάτων προσωρινού αρχείου"
 
-#: ../src/gtk/textctrl.cpp:1072
-#, fuzzy
-msgid "Failed to set text in the text control."
-msgstr "Αποτυχία καθορισμού της ώρας του UTC συστήματος"
-
-#: ../src/unix/threadpsx.cpp:1298
+#: ../src/unix/threadpsx.cpp:1347
 #, fuzzy, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Δεν είναι δυνατή η θέση προτεραιότητας του thread"
 
-#: ../src/unix/threadpsx.cpp:1424
+#: ../src/unix/threadpsx.cpp:1473
 #, fuzzy, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Δεν είναι δυνατή η θέση προτεραιότητας του thread"
 
-#: ../src/unix/utilsunx.cpp:783
+#: ../src/unix/utilsunx.cpp:785
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 
-#: ../src/common/fs_mem.cpp:261
+#: ../src/msw/webview_ie.cpp:987
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:256
 #, c-format
 msgid "Failed to store image '%s' to memory VFS!"
 msgstr "Αποτυχία αποθήκευσης της εικόνας '%s' στο VFS μνήμης!"
 
-#: ../src/dfb/evtloop.cpp:170
+#: ../src/dfb/evtloop.cpp:171
 msgid "Failed to switch DirectFB pipe to non-blocking mode"
 msgstr ""
 
-#: ../src/unix/wakeuppipe.cpp:59
+#: ../src/unix/wakeuppipe.cpp:56
 msgid "Failed to switch wake up pipe to non-blocking mode"
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1605
+#: ../src/unix/threadpsx.cpp:1654
 msgid "Failed to terminate a thread."
 msgstr "Αποτυχία τερματισμού του thread"
 
-#: ../src/msw/dde.cpp:741
+#: ../src/msw/dde.cpp:736
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "Αποτυχία τερματισμού του advise loop με τον DDE εξυπηρετητή (server)"
 
-#: ../src/msw/dialup.cpp:938
+#: ../src/msw/dialup.cpp:932
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Αποτυχία τερματισμού της σύνδεσης μέσω τηλεφώνου : %s"
 
-#: ../src/common/filename.cpp:2590
+#: ../src/common/filename.cpp:2673
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Αποτυχία αγγίγματος (touch) του αρχείου '%s'"
 
-#: ../src/unix/snglinst.cpp:334
+#: ../src/unix/dlunix.cpp:90
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "Αποτυχία φόρτωσης της κοινής βιβλιοθήκης (shared library) '%s'"
+
+#: ../src/unix/snglinst.cpp:331
 #, c-format
 msgid "Failed to unlock lock file '%s'"
 msgstr "Αποτυχία ξεκλείδωματος του αρχείου 'κλειδωνιά'(lock file) '%s'"
 
-#: ../src/msw/dde.cpp:309
+#: ../src/msw/dde.cpp:304
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr ""
@@ -3878,82 +3942,92 @@ msgstr "Αποτυχία κατά την ανάκτηση δεδομένων α�
 msgid "Failed to update user configuration file."
 msgstr "Αποτυχία ανανέωσης του αρχείου ρυθμίσεων του χρήστη."
 
-#: ../src/common/debugrpt.cpp:733
+#: ../src/common/debugrpt.cpp:743
 #, fuzzy, c-format
 msgid "Failed to upload the debug report (error code %d)."
 msgstr ""
 "Απέτυχε η δημιουργία καθιερωμένου παράθυρου διαλόγου εύρεσης/αντικατάστασης "
 "(κωδικός σφάλματος %d)"
 
-#: ../src/unix/snglinst.cpp:168
+#: ../src/unix/snglinst.cpp:165
 #, c-format
 msgid "Failed to write to lock file '%s'"
 msgstr "Αποτυχία εγγραφής του αρχείου 'κλειδωνιά'(lock file) '%s'"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:209
+#: ../src/propgrid/propgrid.cpp:190
 #, fuzzy
 msgid "False"
 msgstr "Αρχείο"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:694
+#: ../src/propgrid/advprops.cpp:604
 #, fuzzy
 msgid "Family"
 msgstr "Οικογένεια γραμματοσειράς:"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/gtk/glcanvas.cpp:176 ../src/gtk/glcanvas.cpp:187
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Μοιραίο σφάλμα"
+
+#: ../src/common/stockitem.cpp:154
 msgid "File"
 msgstr "Αρχείο"
 
-#: ../src/common/docview.cpp:669
+#: ../src/common/docview.cpp:664
 #, fuzzy, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Αποτυχία ανοίγματος του '%s' για το '%s'"
 
-#: ../src/common/docview.cpp:646
+#: ../src/common/docview.cpp:641
 #, fuzzy, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Αποτυχία ανοίγματος του '%s' για το '%s'"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "Το αρχείο '%s' υπάρχει ήδη, πραγματικά θέλετε να επικαλυφτεί;"
 
-#: ../src/common/filefn.cpp:1156
+#: ../src/common/filefn.cpp:1044
 #, fuzzy, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Δεν ήταν δυνατή η δημιουργία του καταλόγου '%s'"
 
-#: ../src/common/filefn.cpp:1139
+#: ../src/common/filefn.cpp:1028
 #, fuzzy, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Δεν ήταν δυνατή η δημιουργία του καταλόγου '%s'"
 
-#: ../src/richtext/richtextctrl.cpp:3081 ../src/common/textcmn.cpp:953
+#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
 msgid "File couldn't be loaded."
 msgstr "Το αρχείο δεν μπόρεσε να φορτωθεί."
 
-#: ../src/msw/filedlg.cpp:393
+#: ../src/msw/filedlg.cpp:414
 #, fuzzy, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Η εκτέλεση της εντολής '%s' απέτυχε με σφάλμα: %ul"
 
-#: ../src/common/docview.cpp:1789
+#: ../src/common/docview.cpp:1783
 msgid "File error"
 msgstr "Σφάλμα αρχείου"
 
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/filectrlg.cpp:770
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/filectrlg.cpp:766
 msgid "File name exists already."
 msgstr "Το όνομα αρχείου υπάρχει ήδη."
+
+#: ../src/osx/cocoa/filedlg.mm:264
+#, fuzzy
+msgid "File type:"
+msgstr "Τηλέτυπο"
 
 #: ../src/motif/filedlg.cpp:220
 #, fuzzy
 msgid "Files"
 msgstr "Αρχείο"
 
-#: ../src/common/filefn.cpp:1591
+#: ../src/common/filefn.cpp:1479
 #, c-format
 msgid "Files (%s)"
 msgstr "Αρχεία (%s)"
@@ -3963,16 +4037,30 @@ msgstr "Αρχεία (%s)"
 msgid "Filter"
 msgstr "Αρχείο"
 
-#: ../src/common/stockitem.cpp:158 ../src/html/helpwnd.cpp:490
+#: ../src/html/helpwnd.cpp:488
 msgid "Find"
 msgstr "Εύρεση"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:259
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:258
+#, fuzzy
+msgid "Find in document"
+msgstr "’νοιγμα εγγράφου HTML"
+
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "Find..."
+msgstr "Εύρεση"
+
+#: ../src/common/stockitem.cpp:156
 #, fuzzy
 msgid "First"
 msgstr "πρώτο"
 
-#: ../src/common/prntbase.cpp:1548
+#: ../src/common/prntbase.cpp:1573
 #, fuzzy
 msgid "First page"
 msgstr "Επόμενη σελίδα"
@@ -3982,11 +4070,11 @@ msgstr "Επόμενη σελίδα"
 msgid "Fixed"
 msgstr "Γραμματοσειρά σταθερού μεγέθους:"
 
-#: ../src/html/helpwnd.cpp:1206
+#: ../src/html/helpwnd.cpp:1204
 msgid "Fixed font:"
 msgstr "Γραμματοσειρά σταθερού μεγέθους:"
 
-#: ../src/html/helpwnd.cpp:1269
+#: ../src/html/helpwnd.cpp:1267
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Όψη σταθερού μεγέθους.<br> <b>έντονη</b> <i>πλάγια</i> "
 
@@ -3994,17 +4082,17 @@ msgstr "Όψη σταθερού μεγέθους.<br> <b>έντονη</b> <i>π�
 msgid "Floating"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 #, fuzzy
 msgid "Floppy"
 msgstr "&Αντιγραφή"
 
-#: ../src/common/paper.cpp:111
+#: ../src/common/paper.cpp:108
 msgid "Folio, 8 1/2 x 13 in"
 msgstr "Folio, 8 1/2 x 13 ίντσες"
 
-#: ../src/richtext/richtextformatdlg.cpp:344 ../src/osx/carbon/fontdlg.cpp:287
-#: ../src/common/stockitem.cpp:194
+#: ../src/osx/carbon/fontdlg.cpp:284 ../src/common/stockitem.cpp:191
+#: ../src/richtext/richtextformatdlg.cpp:337
 msgid "Font"
 msgstr ""
 
@@ -4013,7 +4101,24 @@ msgstr ""
 msgid "Font &weight:"
 msgstr "Το βάρος της γραμματοσειράς."
 
-#: ../src/html/helpwnd.cpp:1207
+#: ../src/osx/fontutil.cpp:89
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
+"\"."
+msgstr ""
+
+#: ../src/msw/font.cpp:1126
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Το αρχείο δεν μπόρεσε να φορτωθεί."
+
+#: ../src/osx/fontutil.cpp:81
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "Το αρχείο %s δεν υπάρχει."
+
+#: ../src/html/helpwnd.cpp:1205
 msgid "Font size:"
 msgstr "Μέγεθος γραμματοσειράς:"
 
@@ -4022,77 +4127,77 @@ msgstr "Μέγεθος γραμματοσειράς:"
 msgid "Font st&yle:"
 msgstr "Μέγεθος γραμματοσειράς:"
 
-#: ../src/osx/carbon/fontdlg.cpp:329
+#: ../src/osx/carbon/fontdlg.cpp:326
 #, fuzzy
 msgid "Font:"
 msgstr "Μέγεθος γραμματοσειράς:"
 
-#: ../src/dfb/fontmgr.cpp:198
+#: ../src/dfb/fontmgr.cpp:195
 #, c-format
 msgid "Fonts index file %s disappeared while loading fonts."
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:645
+#: ../src/unix/utilsunx.cpp:647
 msgid "Fork failed"
 msgstr "Fork απέτυχε"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 #, fuzzy
 msgid "Forward"
 msgstr "&Εμπρός"
 
-#: ../src/common/xtixml.cpp:235
+#: ../src/common/xtixml.cpp:231
 msgid "Forward hrefs are not supported"
 msgstr "Οι forward hrefs δεν υποστηρίζονται"
 
-#: ../src/html/helpwnd.cpp:875
+#: ../src/html/helpwnd.cpp:873
 #, c-format
 msgid "Found %i matches"
 msgstr "Βρέθηκαν %i αντιστοιχίες"
 
-#: ../src/generic/prntdlgg.cpp:238
+#: ../src/generic/prntdlgg.cpp:231
 msgid "From:"
 msgstr "Από:"
 
-#: ../src/propgrid/advprops.cpp:1604
+#: ../src/propgrid/advprops.cpp:1510
 msgid "Fuchsia"
 msgstr ""
 
-#: ../src/common/imaggif.cpp:138
+#: ../src/common/imaggif.cpp:135
 msgid "GIF: data stream seems to be truncated."
 msgstr "GIF: το stream δεδομένων μοιάζει να είναι αποκομμένο."
 
-#: ../src/common/imaggif.cpp:128
+#: ../src/common/imaggif.cpp:125
 msgid "GIF: error in GIF image format."
 msgstr "GIF: σφάλμα στην μορφή εικόνας GIF."
 
-#: ../src/common/imaggif.cpp:133
+#: ../src/common/imaggif.cpp:130
 msgid "GIF: not enough memory."
 msgstr "GIF: ανεπαρκής μνήμη."
 
-#: ../src/gtk/window.cpp:4631
+#: ../src/gtk/window.cpp:5635
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
 msgstr ""
 
-#: ../src/univ/themes/gtk.cpp:525
+#: ../src/univ/themes/gtk.cpp:522
 msgid "GTK+ theme"
 msgstr "Θέμα GTK+"
 
-#: ../src/common/preferencescmn.cpp:40
+#: ../src/common/preferencescmn.cpp:37
 msgid "General"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:258
+#: ../src/common/prntbase.cpp:253
 msgid "Generic PostScript"
 msgstr "Γενικό PostScript"
 
-#: ../src/common/paper.cpp:135
+#: ../src/common/paper.cpp:132
 msgid "German Legal Fanfold, 8 1/2 x 13 in"
 msgstr "German Legal Fanfold, 8 1/2 x 13 ίντσες"
 
-#: ../src/common/paper.cpp:134
+#: ../src/common/paper.cpp:131
 msgid "German Std Fanfold, 8 1/2 x 12 in"
 msgstr "German Std Fanfold, 8 1/2 x 12 ίντσες"
 
@@ -4108,48 +4213,48 @@ msgstr "Η GetPropertyCollection κλήθηκε σε έναν γενικό acces
 msgid "GetPropertyCollection called w/o valid collection getter"
 msgstr "Η GetPropertyCollection κλήθηκε χωρίς έγκυρο collection getter"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:658
 msgid "Go back"
 msgstr "Πήγαινε πίσω"
 
-#: ../src/html/helpwnd.cpp:661
+#: ../src/html/helpwnd.cpp:659
 msgid "Go forward"
 msgstr "Πήγαινε εμπρός"
 
-#: ../src/html/helpwnd.cpp:663
+#: ../src/html/helpwnd.cpp:661
 msgid "Go one level up in document hierarchy"
 msgstr "Πήγαινε ένα επίπεδο πάνω στην ιεραρχεία του εγγράφου"
 
-#: ../src/generic/filedlgg.cpp:208 ../src/generic/dirdlgg.cpp:116
+#: ../src/generic/filedlgg.cpp:205 ../src/generic/dirdlgg.cpp:113
 msgid "Go to home directory"
 msgstr "Προς κεντρικό κατάλογο"
 
-#: ../src/generic/filedlgg.cpp:205
+#: ../src/generic/filedlgg.cpp:202
 msgid "Go to parent directory"
 msgstr "Προς πατρικό κατάλογο"
 
-#: ../src/generic/aboutdlgg.cpp:76
+#: ../src/generic/aboutdlgg.cpp:73
 msgid "Graphics art by "
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1599
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Gray"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:883
+#: ../src/propgrid/advprops.cpp:784
 msgid "GrayText"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:154
+#: ../src/common/fmapbase.cpp:151
 msgid "Greek (ISO-8859-7)"
 msgstr "Ελληνικό (ISO-8859-7)"
 
-#: ../src/propgrid/advprops.cpp:1600
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Green"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:342
+#: ../src/generic/colrdlgg.cpp:362
 msgid "Green:"
 msgstr ""
 
@@ -4157,108 +4262,108 @@ msgstr ""
 msgid "Groove"
 msgstr ""
 
-#: ../src/common/zstream.cpp:158 ../src/common/zstream.cpp:318
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
 msgid "Gzip not supported by this version of zlib"
 msgstr "Το Gzip δεν υποστηρίζεται από αυτήν την έκδοση της zlib"
 
-#: ../src/html/helpwnd.cpp:1549
+#: ../src/html/helpwnd.cpp:1547
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "Εργασία HTML βοήθειας (*.hhp)|*.hhp|"
 
-#: ../src/html/htmlwin.cpp:681
+#: ../src/html/htmlwin.cpp:691
 #, c-format
 msgid "HTML anchor %s does not exist."
 msgstr "Η HTML άγκυρα %s δεν υπάρχει."
 
-#: ../src/html/helpwnd.cpp:1547
+#: ../src/html/helpwnd.cpp:1545
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "Αρχεία HTML (*.html;*.htm)|*.html;*.htm|"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1759
+#: ../src/propgrid/advprops.cpp:1660
 msgid "Hand"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "Harddisk"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:155
+#: ../src/common/fmapbase.cpp:152
 msgid "Hebrew (ISO-8859-8)"
 msgstr "Εβραϊκό (ISO-8859-8)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:280 ../src/osx/button_osx.cpp:39
-#: ../src/common/stockitem.cpp:163 ../src/common/accelcmn.cpp:80
-#: ../src/html/helpdlg.cpp:66 ../src/html/helpfrm.cpp:111
+#: ../include/wx/msgdlg.h:282 ../src/osx/button_osx.cpp:39
+#: ../src/common/stockitem.cpp:160 ../src/common/accelcmn.cpp:77
+#: ../src/html/helpfrm.cpp:108 ../src/html/helpdlg.cpp:63
 msgid "Help"
 msgstr "Βοήθεια"
 
-#: ../src/html/helpwnd.cpp:1200
+#: ../src/html/helpwnd.cpp:1198
 msgid "Help Browser Options"
 msgstr "Επιλογές Περιηγητή Βοηθείας"
 
-#: ../src/generic/helpext.cpp:454 ../src/generic/helpext.cpp:455
+#: ../src/generic/helpext.cpp:452 ../src/generic/helpext.cpp:453
 msgid "Help Index"
 msgstr "Ευρετήριο Βοηθείας"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1529
 msgid "Help Printing"
 msgstr "Βοήθεια Εκτύπωσης"
 
-#: ../src/html/helpwnd.cpp:801
+#: ../src/html/helpwnd.cpp:799
 msgid "Help Topics"
 msgstr "Θέματα Βοήθειας"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1546
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Βιβλία βοήθειας (*.htb)|*.htb|Αρχεία βοήθειας (*.zip)|*.zip|"
 
-#: ../src/generic/helpext.cpp:267
+#: ../src/generic/helpext.cpp:265
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:275
+#: ../src/generic/helpext.cpp:273
 #, fuzzy, c-format
 msgid "Help file \"%s\" not found."
 msgstr "αρχείο καταλόγου για την περιοχή (domain) '%s' δεν βρέθηκε."
 
-#: ../src/html/helpctrl.cpp:63
+#: ../src/html/helpctrl.cpp:59
 #, c-format
 msgid "Help: %s"
 msgstr "Βοήθεια: %s"
 
-#: ../src/osx/menu_osx.cpp:577
+#: ../src/osx/menu_osx.cpp:469
 #, fuzzy, c-format
 msgid "Hide %s"
 msgstr "Βοήθεια: %s"
 
-#: ../src/osx/menu_osx.cpp:579
+#: ../src/osx/menu_osx.cpp:471
 msgid "Hide Others"
 msgstr ""
 
-#: ../src/generic/infobar.cpp:84
+#: ../src/generic/infobar.cpp:81
 msgid "Hide this notification message."
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:884
+#: ../src/propgrid/advprops.cpp:785
 #, fuzzy
 msgid "Highlight"
 msgstr "απαλό(light)"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:885
+#: ../src/propgrid/advprops.cpp:786
 msgid "HighlightText"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:164 ../src/common/accelcmn.cpp:65
+#: ../src/common/stockitem.cpp:161 ../src/common/accelcmn.cpp:62
 msgid "Home"
 msgstr "Αρχική σελίδα"
 
-#: ../src/generic/dirctrlg.cpp:524
+#: ../src/generic/dirctrlg.cpp:490
 msgid "Home directory"
 msgstr "Αρχικός κατάλογος"
 
@@ -4268,61 +4373,61 @@ msgid "How the object will float relative to the text."
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1760
+#: ../src/propgrid/advprops.cpp:1661
 msgid "I-Beam"
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1196
+#: ../src/common/imagbmp.cpp:1208
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: Σφάλμα στην ανάγνωση μάσκας DIB."
 
-#: ../src/common/imagbmp.cpp:1290 ../src/common/imagbmp.cpp:1390
-#: ../src/common/imagbmp.cpp:1405 ../src/common/imagbmp.cpp:1416
-#: ../src/common/imagbmp.cpp:1430 ../src/common/imagbmp.cpp:1478
-#: ../src/common/imagbmp.cpp:1493 ../src/common/imagbmp.cpp:1507
-#: ../src/common/imagbmp.cpp:1518
+#: ../src/common/imagbmp.cpp:1302 ../src/common/imagbmp.cpp:1402
+#: ../src/common/imagbmp.cpp:1417 ../src/common/imagbmp.cpp:1428
+#: ../src/common/imagbmp.cpp:1442 ../src/common/imagbmp.cpp:1490
+#: ../src/common/imagbmp.cpp:1505 ../src/common/imagbmp.cpp:1519
+#: ../src/common/imagbmp.cpp:1530
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: Σφάλμα κατά την εγγραφή του αρχείου εικόνας!"
 
-#: ../src/common/imagbmp.cpp:1255
+#: ../src/common/imagbmp.cpp:1267
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: Εικόνα πολύ ψηλή για εικονίδιο(icon)."
 
-#: ../src/common/imagbmp.cpp:1263
+#: ../src/common/imagbmp.cpp:1275
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: Εικόνα πολύ πλατιά για εικονίδιο(icon)."
 
-#: ../src/common/imagbmp.cpp:1603
+#: ../src/common/imagbmp.cpp:1615
 msgid "ICO: Invalid icon index."
 msgstr "ICO: Λανθασμένος δείκτης(index) εικονιδίου(icon)."
 
-#: ../src/common/imagiff.cpp:758
+#: ../src/common/imagiff.cpp:755
 msgid "IFF: data stream seems to be truncated."
 msgstr "IFF: το stream δεδομένων μοιάζει να είναι αποκομμένο."
 
-#: ../src/common/imagiff.cpp:742
+#: ../src/common/imagiff.cpp:739
 msgid "IFF: error in IFF image format."
 msgstr "IFF: σφάλμα στη μορφή εικόνας IFF."
 
-#: ../src/common/imagiff.cpp:745
+#: ../src/common/imagiff.cpp:742
 msgid "IFF: not enough memory."
 msgstr "IFF: ανεπαρκής μνήμη."
 
-#: ../src/common/imagiff.cpp:748
+#: ../src/common/imagiff.cpp:745
 msgid "IFF: unknown error!!!"
 msgstr "IFF: άγνωστο λάθος!!!"
 
-#: ../src/common/fmapbase.cpp:197
+#: ../src/common/fmapbase.cpp:194
 msgid "ISO-2022-JP"
 msgstr ""
 
-#: ../src/html/htmprint.cpp:282
+#: ../src/html/htmprint.cpp:294
 msgid ""
 "If possible, try changing the layout parameters to make the printout more "
 "narrow."
 msgstr ""
 
-#: ../src/generic/dbgrptg.cpp:358
+#: ../src/generic/dbgrptg.cpp:362
 msgid ""
 "If you have any additional information pertaining to this bug\n"
 "report, please enter it here and it will be joined to it:"
@@ -4336,46 +4441,50 @@ msgid ""
 "at all possible please do continue with the report generation.\n"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1405
+#: ../src/common/zipstrm.cpp:1043
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1393
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:295
+#: ../src/common/xtistrm.cpp:292
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Εσφαλμένη κλάση αντικειμένου (μη-wxEvtHandler) σαν πηγή Events"
 
-#: ../src/common/xti.cpp:513
+#: ../src/common/xti.cpp:510
 msgid "Illegal Parameter Count for ConstructObject Method"
 msgstr "Εσφαλμένος αριθμός παραμέτρων για μέθοδο ConstructObject"
 
-#: ../src/common/xti.cpp:501
+#: ../src/common/xti.cpp:498
 msgid "Illegal Parameter Count for Create Method"
 msgstr "Εσφαλμένος αριθμός παραμέτρων για μέθοδο Create"
 
-#: ../src/generic/dirctrlg.cpp:570 ../src/generic/filectrlg.cpp:756
+#: ../src/generic/dirctrlg.cpp:536 ../src/generic/filectrlg.cpp:752
 msgid "Illegal directory name."
 msgstr "Μη έγκυρο όνομα καταλόγου."
 
-#: ../src/generic/filectrlg.cpp:1367
+#: ../src/generic/filectrlg.cpp:1356
 msgid "Illegal file specification."
 msgstr "Μη έγκυρος προσδιορισμός αρχείου."
 
-#: ../src/common/image.cpp:2269
+#: ../src/common/image.cpp:2363
 msgid "Image and mask have different sizes."
 msgstr "Εικόνα και μάσκα έχουν διαφορετικά μεγέθη."
 
-#: ../src/common/image.cpp:2746
+#: ../src/common/image.cpp:2841
 #, fuzzy, c-format
 msgid "Image file is not of type %d."
 msgstr "Αρχείο εικόνας δεν είναι τύπυ %d."
 
-#: ../src/common/image.cpp:2877
+#: ../src/common/image.cpp:2995
 #, fuzzy, c-format
 msgid "Image is not of type %s."
 msgstr "Αρχείο εικόνας δεν είναι τύπυ %d."
 
-#: ../src/msw/textctrl.cpp:488
+#: ../src/msw/textctrl.cpp:534
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -4384,105 +4493,105 @@ msgstr ""
 "γίνεται χρήση του simpe text στοιχείου ελέγχου. Παρακαλώ επανεγκαταστήστε το "
 "riched32.dll"
 
-#: ../src/unix/utilsunx.cpp:301
+#: ../src/unix/utilsunx.cpp:303
 msgid "Impossible to get child process input"
 msgstr "Αδύνατη η λήψη της εισόδου της διεργασίας (process) απογόνου(child)"
 
-#: ../src/common/filefn.cpp:1028
+#: ../src/common/filefn.cpp:917
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Αδύνατη η λήψη των δικαιωμάτων για το αρχείο '%s'"
 
-#: ../src/common/filefn.cpp:1042
+#: ../src/common/filefn.cpp:931
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Αδύνατη η επικάλυψη του αρχείου '%s'"
 
-#: ../src/common/filefn.cpp:1097
+#: ../src/common/filefn.cpp:986
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Αδύνατος ο ορισμός των δικαιωμάτων για το αρχείο '%s'"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:886
+#: ../src/propgrid/advprops.cpp:787
 #, fuzzy
 msgid "InactiveBorder"
 msgstr "Μοντέρνο"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:887
+#: ../src/propgrid/advprops.cpp:788
 msgid "InactiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:888
+#: ../src/propgrid/advprops.cpp:789
 msgid "InactiveCaptionText"
 msgstr ""
 
-#: ../src/common/gifdecod.cpp:792
+#: ../src/common/gifdecod.cpp:826
 #, c-format
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:635
+#: ../src/msw/ole/automtn.cpp:626
 msgid "Incorrect number of arguments."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:165
+#: ../src/common/stockitem.cpp:162
 msgid "Indent"
 msgstr "Στοίχιση"
 
-#: ../src/richtext/richtextformatdlg.cpp:349
+#: ../src/richtext/richtextformatdlg.cpp:342
 msgid "Indents && Spacing"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:166 ../src/html/helpwnd.cpp:515
+#: ../src/common/stockitem.cpp:163 ../src/html/helpwnd.cpp:513
 msgid "Index"
 msgstr "Ευρετήριο"
 
-#: ../src/common/fmapbase.cpp:159
+#: ../src/common/fmapbase.cpp:156
 msgid "Indian (ISO-8859-12)"
 msgstr "Ινδικό (ISO-8859-12)"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "Info"
 msgstr ""
 
-#: ../src/common/init.cpp:287
+#: ../src/common/init.cpp:284
 msgid "Initialization failed in post init, aborting."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:54
+#: ../src/common/accelcmn.cpp:51
 #, fuzzy
 msgid "Ins"
 msgstr "Στοίχιση"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextsymboldlg.cpp:472 ../src/common/accelcmn.cpp:53
+#: ../src/common/accelcmn.cpp:50 ../src/richtext/richtextsymboldlg.cpp:469
 #, fuzzy
 msgid "Insert"
 msgstr "Στοίχιση"
 
-#: ../src/richtext/richtextbuffer.cpp:8067
+#: ../src/richtext/richtextbuffer.cpp:8063
 #, fuzzy
 msgid "Insert Field"
 msgstr "Στοίχιση"
 
-#: ../src/richtext/richtextbuffer.cpp:7978
-#: ../src/richtext/richtextbuffer.cpp:8936
+#: ../src/richtext/richtextbuffer.cpp:7974
+#: ../src/richtext/richtextbuffer.cpp:8934
 msgid "Insert Image"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:8025
+#: ../src/richtext/richtextbuffer.cpp:8021
 #, fuzzy
 msgid "Insert Object"
 msgstr "Στοίχιση"
 
-#: ../src/richtext/richtextctrl.cpp:1286 ../src/richtext/richtextctrl.cpp:1494
-#: ../src/richtext/richtextbuffer.cpp:7822
-#: ../src/richtext/richtextbuffer.cpp:7852
-#: ../src/richtext/richtextbuffer.cpp:7894
+#: ../src/richtext/richtextbuffer.cpp:7818
+#: ../src/richtext/richtextbuffer.cpp:7848
+#: ../src/richtext/richtextbuffer.cpp:7890
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
 msgid "Insert Text"
 msgstr ""
 
@@ -4496,16 +4605,11 @@ msgstr ""
 msgid "Inset"
 msgstr "Στοίχιση"
 
-#: ../src/gtk/app.cpp:425
-#, c-format
-msgid "Invalid GTK+ command line option, use \"%s --help\""
-msgstr ""
-
-#: ../src/common/imagtiff.cpp:311
+#: ../src/common/imagtiff.cpp:308
 msgid "Invalid TIFF image index."
 msgstr "Λανθασμένος δείκτης εικόνας TIFF."
 
-#: ../src/common/appcmn.cpp:273
+#: ../src/common/appcmn.cpp:294
 #, c-format
 msgid "Invalid display mode specification '%s'."
 msgstr ""
@@ -4517,254 +4621,258 @@ msgstr ""
 msgid "Invalid geometry specification '%s'"
 msgstr "Λανθασμένος γεωμετρικός καθορισμός(specification) '%s'"
 
-#: ../src/unix/fswatcher_inotify.cpp:323
+#: ../src/unix/fswatcher_inotify.cpp:320
 #, c-format
 msgid "Invalid inotify event for \"%s\""
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:312
+#: ../src/unix/snglinst.cpp:309
 #, c-format
 msgid "Invalid lock file '%s'."
 msgstr "Λανθασμένο αρχείο κλειδαριά (lock file) '%s'."
 
-#: ../src/common/translation.cpp:1125
+#: ../src/common/translation.cpp:1167
 #, fuzzy
 msgid "Invalid message catalog."
 msgstr "'%s' δεν είναι ένας σωστός κατάλογος μηνυμάτων."
 
-#: ../src/common/xtistrm.cpp:405 ../src/common/xtistrm.cpp:420
+#: ../src/common/xtistrm.cpp:402 ../src/common/xtistrm.cpp:417
 msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
 msgstr "Μη έγκυρο ή Null ID αντικειμένου δόθηκε στην GetObjectClassInfo"
 
-#: ../src/common/xtistrm.cpp:435
+#: ../src/common/xtistrm.cpp:432
 msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
 msgstr "Μη έγκυρο ή Null ID αντικειμένου δόθηκε στην HasObjectClassInfo"
 
-#: ../src/common/regex.cpp:310
+#: ../src/common/regex.cpp:307
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Λανθασμένη κανονική έκφραση (regular expression) '%s': %s"
 
-#: ../src/common/config.cpp:226
+#: ../src/common/config.cpp:222
 #, c-format
 msgid "Invalid value %ld for a boolean key \"%s\" in config file."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:351
-#: ../src/osx/carbon/fontdlg.cpp:361 ../src/common/stockitem.cpp:168
+#: ../src/osx/carbon/fontdlg.cpp:358 ../src/common/stockitem.cpp:165
+#: ../src/generic/fontdlgg.cpp:325 ../src/richtext/richtextfontpage.cpp:351
 msgid "Italic"
 msgstr "Πλάγια"
 
-#: ../src/common/paper.cpp:130
+#: ../src/common/paper.cpp:127
 msgid "Italy Envelope, 110 x 230 mm"
 msgstr "Italy Envelope, 110 x 230 mm"
 
-#: ../src/common/imagjpeg.cpp:270
+#: ../src/common/imagjpeg.cpp:257
 msgid "JPEG: Couldn't load - file is probably corrupted."
 msgstr "JPEG: Αδύνατη η φόρτωση - το αρχείο είναι μάλλον φθαρμένο(corrupted)."
 
-#: ../src/common/imagjpeg.cpp:449
+#: ../src/common/imagjpeg.cpp:436
 msgid "JPEG: Couldn't save image."
 msgstr "JPEG: Αδύνατη η αποθήκευση της εικόνας."
 
-#: ../src/common/paper.cpp:163
+#: ../src/common/paper.cpp:160
 msgid "Japanese Double Postcard 200 x 148 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:167
+#: ../src/common/paper.cpp:164
 msgid "Japanese Envelope Chou #3"
 msgstr ""
 
-#: ../src/common/paper.cpp:180
+#: ../src/common/paper.cpp:177
 msgid "Japanese Envelope Chou #3 Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:168
+#: ../src/common/paper.cpp:165
 msgid "Japanese Envelope Chou #4"
 msgstr ""
 
-#: ../src/common/paper.cpp:181
+#: ../src/common/paper.cpp:178
 msgid "Japanese Envelope Chou #4 Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:165
+#: ../src/common/paper.cpp:162
 msgid "Japanese Envelope Kaku #2"
 msgstr ""
 
-#: ../src/common/paper.cpp:178
+#: ../src/common/paper.cpp:175
 msgid "Japanese Envelope Kaku #2 Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:166
+#: ../src/common/paper.cpp:163
 msgid "Japanese Envelope Kaku #3"
 msgstr ""
 
-#: ../src/common/paper.cpp:179
+#: ../src/common/paper.cpp:176
 msgid "Japanese Envelope Kaku #3 Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:185
+#: ../src/common/paper.cpp:182
 msgid "Japanese Envelope You #4"
 msgstr ""
 
-#: ../src/common/paper.cpp:186
+#: ../src/common/paper.cpp:183
 msgid "Japanese Envelope You #4 Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:138
+#: ../src/common/paper.cpp:135
 msgid "Japanese Postcard 100 x 148 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:175
+#: ../src/common/paper.cpp:172
 msgid "Japanese Postcard Rotated 148 x 100 mm"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "Jump to"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:171
+#: ../src/common/stockitem.cpp:168
 msgid "Justified"
 msgstr "Ευθυγραμμισμένα"
 
-#: ../src/richtext/richtextindentspage.cpp:155
-#: ../src/richtext/richtextindentspage.cpp:157
 #: ../src/richtext/richtextliststylepage.cpp:344
 #: ../src/richtext/richtextliststylepage.cpp:346
+#: ../src/richtext/richtextindentspage.cpp:155
+#: ../src/richtext/richtextindentspage.cpp:157
 msgid "Justify text left and right."
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:163
+#: ../src/common/fmapbase.cpp:160
 msgid "KOI8-R"
 msgstr "KOI8-R"
 
-#: ../src/common/fmapbase.cpp:164
+#: ../src/common/fmapbase.cpp:161
 msgid "KOI8-U"
 msgstr "KOI8-U"
 
-#: ../src/common/accelcmn.cpp:265 ../src/common/accelcmn.cpp:347
+#: ../src/common/accelcmn.cpp:279 ../src/common/accelcmn.cpp:364
 msgid "KP_"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "KP_Add"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "KP_Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "KP_Decimal"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 #, fuzzy
 msgid "KP_Delete"
 msgstr "&Διαγραφή"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "KP_Divide"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 #, fuzzy
 msgid "KP_Down"
 msgstr "Κάτω"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "KP_End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 #, fuzzy
 msgid "KP_Enter"
 msgstr "Εκτυπωτής"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "KP_Equal"
 msgstr ""
 
+#: ../src/common/accelcmn.cpp:276 ../src/common/accelcmn.cpp:361
+msgid "KP_F"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 #, fuzzy
 msgid "KP_Home"
 msgstr "Αρχική σελίδα"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 #, fuzzy
 msgid "KP_Insert"
 msgstr "Στοίχιση"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "KP_Left"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "KP_Multiply"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:99
+#: ../src/common/accelcmn.cpp:97
 #, fuzzy
 msgid "KP_Next"
 msgstr "Επόμενο"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "KP_PageDown"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "KP_PageUp"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:98
+#: ../src/common/accelcmn.cpp:96
 msgid "KP_Prior"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 #, fuzzy
 msgid "KP_Right"
 msgstr "Απαλό(light)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "KP_Separator"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "KP_Space"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "KP_Subtract"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "KP_Tab"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "KP_Up"
 msgstr ""
 
@@ -4772,119 +4880,134 @@ msgstr ""
 msgid "L&ine spacing:"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:613 ../src/generic/prntdlgg.cpp:868
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "σφάλμα συμπίεσης"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "σφάλμα αποσυμπίεσης"
+
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:861
 msgid "Landscape"
 msgstr "Τοπίο"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 #, fuzzy
 msgid "Last"
 msgstr "&Επικόληση"
 
-#: ../src/common/prntbase.cpp:1572
+#: ../src/common/prntbase.cpp:1597
 #, fuzzy
 msgid "Last page"
 msgstr "Επόμενη σελίδα"
 
-#: ../src/common/log.cpp:305
+#: ../src/common/log.cpp:324
 #, c-format
 msgid "Last repeated message (\"%s\", %u time) wasn't output"
 msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/common/paper.cpp:103
+#: ../src/common/paper.cpp:100
 msgid "Ledger, 17 x 11 in"
 msgstr "Ledger, 17 x 11 ίντσες"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6146
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:58 ../src/generic/datavgen.cpp:6951
+#: ../src/richtext/richtextsizepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:252
 #: ../src/richtext/richtextliststylepage.cpp:253
 #: ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
-#: ../src/richtext/richtextsizepage.cpp:249 ../src/common/accelcmn.cpp:61
 msgid "Left"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:204
 #: ../src/richtext/richtextliststylepage.cpp:390
+#: ../src/richtext/richtextindentspage.cpp:204
 msgid "Left (&first line):"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1761
+#: ../src/propgrid/advprops.cpp:1662
 msgid "Left Button"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:880
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Left margin (mm):"
 msgstr "Αριστερό περιθώριο (mm)"
 
-#: ../src/richtext/richtextindentspage.cpp:141
-#: ../src/richtext/richtextindentspage.cpp:143
 #: ../src/richtext/richtextliststylepage.cpp:330
 #: ../src/richtext/richtextliststylepage.cpp:332
+#: ../src/richtext/richtextindentspage.cpp:141
+#: ../src/richtext/richtextindentspage.cpp:143
 msgid "Left-align text."
 msgstr ""
 
-#: ../src/common/paper.cpp:144
+#: ../src/common/paper.cpp:141
 #, fuzzy
 msgid "Legal Extra 9 1/2 x 15 in"
 msgstr "Νομικό, 8 1/2 x 14 ίντσες"
 
-#: ../src/common/paper.cpp:96
+#: ../src/common/paper.cpp:93
 msgid "Legal, 8 1/2 x 14 in"
 msgstr "Νομικό, 8 1/2 x 14 ίντσες"
 
-#: ../src/common/paper.cpp:143
+#: ../src/common/paper.cpp:140
 #, fuzzy
 msgid "Letter Extra 9 1/2 x 12 in"
 msgstr "Γράμμα, 8 1/2 x 11 ίντσες"
 
-#: ../src/common/paper.cpp:149
+#: ../src/common/paper.cpp:146
 msgid "Letter Extra Transverse 9.275 x 12 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:152
+#: ../src/common/paper.cpp:149
 #, fuzzy
 msgid "Letter Plus 8 1/2 x 12.69 in"
 msgstr "Γράμμα, 8 1/2 x 11 ίντσες"
 
-#: ../src/common/paper.cpp:169
+#: ../src/common/paper.cpp:166
 #, fuzzy
 msgid "Letter Rotated 11 x 8 1/2 in"
 msgstr "Γράμμα, 8 1/2 x 11 ίντσες"
 
-#: ../src/common/paper.cpp:101
+#: ../src/common/paper.cpp:98
 msgid "Letter Small, 8 1/2 x 11 in"
 msgstr "Γράμμα Μικρό, 8 1/2 x 11 ίντσες"
 
-#: ../src/common/paper.cpp:147
+#: ../src/common/paper.cpp:144
 #, fuzzy
 msgid "Letter Transverse 8 1/2 x 11 in"
 msgstr "Γράμμα, 8 1/2 x 11 ίντσες"
 
-#: ../src/common/paper.cpp:95
+#: ../src/common/paper.cpp:92
 msgid "Letter, 8 1/2 x 11 in"
 msgstr "Γράμμα, 8 1/2 x 11 ίντσες"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "License"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:332
+#: ../src/generic/fontdlgg.cpp:328
 msgid "Light"
 msgstr "Απαλό(light)"
 
-#: ../src/propgrid/advprops.cpp:1608
+#: ../src/propgrid/advprops.cpp:1514
 msgid "Lime"
 msgstr ""
 
-#: ../src/generic/helpext.cpp:294
+#: ../src/generic/helpext.cpp:292
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr ""
@@ -4893,15 +5016,15 @@ msgstr ""
 msgid "Line spacing:"
 msgstr ""
 
-#: ../src/html/chm.cpp:838
+#: ../src/html/chm.cpp:829
 msgid "Link contained '//', converted to absolute link."
 msgstr "Η σύνδεση που περιείχε '//', μετατράπηκε σε απόλυτη σύνδεση."
 
-#: ../src/richtext/richtextformatdlg.cpp:364
+#: ../src/richtext/richtextformatdlg.cpp:357
 msgid "List Style"
 msgstr ""
 
-#: ../src/richtext/richtextstyles.cpp:1064
+#: ../src/richtext/richtextstyles.cpp:1061
 msgid "List styles"
 msgstr ""
 
@@ -4916,26 +5039,26 @@ msgstr ""
 msgid "Lists the available fonts."
 msgstr "Το Tip δεν είναι διαθέσιμο, συγγνώμη!"
 
-#: ../src/common/fldlgcmn.cpp:340
+#: ../src/common/fldlgcmn.cpp:337
 #, c-format
 msgid "Load %s file"
 msgstr "Φόρτωση %s αρχείου"
 
-#: ../src/html/htmlwin.cpp:597
+#: ../src/html/htmlwin.cpp:600
 msgid "Loading : "
 msgstr "Γίνεται φόρτωση : "
 
-#: ../src/unix/snglinst.cpp:246
+#: ../src/unix/snglinst.cpp:243
 #, c-format
 msgid "Lock file '%s' has incorrect owner."
 msgstr "Το αρχείο 'κλειδωνιά' '%s' έχει λανθασμένο ιδιοκτήτη."
 
-#: ../src/unix/snglinst.cpp:251
+#: ../src/unix/snglinst.cpp:248
 #, c-format
 msgid "Lock file '%s' has incorrect permissions."
 msgstr "Το αρχείο 'κλειδωνιά' '%s' έχει λανθασμένα δικαιώματα."
 
-#: ../src/generic/logg.cpp:576
+#: ../src/generic/logg.cpp:573
 #, c-format
 msgid "Log saved to the file '%s'."
 msgstr "Η καταγραφή (log) αποθηκεύτηκε στο αρχείο '%s'"
@@ -4950,11 +5073,11 @@ msgstr ""
 msgid "Lower case roman numerals"
 msgstr ""
 
-#: ../src/gtk/mdi.cpp:422 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk1/mdi.cpp:431 ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "MDI παιδί"
 
-#: ../src/msw/helpchm.cpp:56
+#: ../src/msw/helpchm.cpp:53
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -4962,194 +5085,194 @@ msgstr ""
 "Οι συναρτήσεις (functions) της MS HTML Help δεν είναι διαθέσιμες γιατί η "
 "βιβλιοθήκη MS HTML Help δεν είναι εγκατεστημένη. Παρακαλώ εγκαταστήστε την."
 
-#: ../src/univ/themes/win32.cpp:3754
+#: ../src/univ/themes/win32.cpp:3751
 msgid "Ma&ximize"
 msgstr "Με&γιστοποίηση"
 
-#: ../src/common/fmapbase.cpp:203
+#: ../src/common/fmapbase.cpp:200
 msgid "MacArabic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:222
+#: ../src/common/fmapbase.cpp:219
 msgid "MacArmenian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:211
+#: ../src/common/fmapbase.cpp:208
 msgid "MacBengali"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:217
+#: ../src/common/fmapbase.cpp:214
 msgid "MacBurmese"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:236
+#: ../src/common/fmapbase.cpp:233
 msgid "MacCeltic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:227
+#: ../src/common/fmapbase.cpp:224
 msgid "MacCentralEurRoman"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:223
+#: ../src/common/fmapbase.cpp:220
 msgid "MacChineseSimp"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:201
+#: ../src/common/fmapbase.cpp:198
 msgid "MacChineseTrad"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:233
+#: ../src/common/fmapbase.cpp:230
 msgid "MacCroatian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:206
+#: ../src/common/fmapbase.cpp:203
 msgid "MacCyrillic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:207
+#: ../src/common/fmapbase.cpp:204
 msgid "MacDevanagari"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:231
+#: ../src/common/fmapbase.cpp:228
 msgid "MacDingbats"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:226
+#: ../src/common/fmapbase.cpp:223
 msgid "MacEthiopic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:229
+#: ../src/common/fmapbase.cpp:226
 msgid "MacExtArabic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:237
+#: ../src/common/fmapbase.cpp:234
 msgid "MacGaelic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:221
+#: ../src/common/fmapbase.cpp:218
 msgid "MacGeorgian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:205
+#: ../src/common/fmapbase.cpp:202
 msgid "MacGreek"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:209
+#: ../src/common/fmapbase.cpp:206
 msgid "MacGujarati"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:208
+#: ../src/common/fmapbase.cpp:205
 msgid "MacGurmukhi"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:204
+#: ../src/common/fmapbase.cpp:201
 msgid "MacHebrew"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:234
+#: ../src/common/fmapbase.cpp:231
 msgid "MacIcelandic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:200
+#: ../src/common/fmapbase.cpp:197
 msgid "MacJapanese"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:214
+#: ../src/common/fmapbase.cpp:211
 msgid "MacKannada"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:238
+#: ../src/common/fmapbase.cpp:235
 msgid "MacKeyboardGlyphs"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:218
+#: ../src/common/fmapbase.cpp:215
 msgid "MacKhmer"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:202
+#: ../src/common/fmapbase.cpp:199
 msgid "MacKorean"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:220
+#: ../src/common/fmapbase.cpp:217
 msgid "MacLaotian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:215
+#: ../src/common/fmapbase.cpp:212
 msgid "MacMalayalam"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:225
+#: ../src/common/fmapbase.cpp:222
 msgid "MacMongolian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:210
+#: ../src/common/fmapbase.cpp:207
 msgid "MacOriya"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:199
+#: ../src/common/fmapbase.cpp:196
 #, fuzzy
 msgid "MacRoman"
 msgstr "Ρωμαϊκό"
 
-#: ../src/common/fmapbase.cpp:235
+#: ../src/common/fmapbase.cpp:232
 #, fuzzy
 msgid "MacRomanian"
 msgstr "Ρωμαϊκό"
 
-#: ../src/common/fmapbase.cpp:216
+#: ../src/common/fmapbase.cpp:213
 #, fuzzy
 msgid "MacSinhalese"
 msgstr "Ταίριασμα πεζών/κεφαλαίων"
 
-#: ../src/common/fmapbase.cpp:230
+#: ../src/common/fmapbase.cpp:227
 #, fuzzy
 msgid "MacSymbol"
 msgstr "&Στυλ:"
 
-#: ../src/common/fmapbase.cpp:212
+#: ../src/common/fmapbase.cpp:209
 msgid "MacTamil"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:213
+#: ../src/common/fmapbase.cpp:210
 msgid "MacTelugu"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:219
+#: ../src/common/fmapbase.cpp:216
 msgid "MacThai"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:224
+#: ../src/common/fmapbase.cpp:221
 msgid "MacTibetan"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:232
+#: ../src/common/fmapbase.cpp:229
 msgid "MacTurkish"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:228
+#: ../src/common/fmapbase.cpp:225
 msgid "MacVietnamese"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1762
+#: ../src/propgrid/advprops.cpp:1663
 msgid "Magnifier"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:2143
+#: ../src/propgrid/advprops.cpp:2050
 #, fuzzy
 msgid "Make a selection:"
 msgstr "Τμήματα"
 
-#: ../src/richtext/richtextformatdlg.cpp:374
+#: ../src/richtext/richtextformatdlg.cpp:367
 #: ../src/richtext/richtextmarginspage.cpp:171
 msgid "Margins"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1595
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Maroon"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:147
+#: ../src/generic/fdrepdlg.cpp:144
 msgid "Match case"
 msgstr "Ταίριασμα πεζών/κεφαλαίων"
 
@@ -5163,41 +5286,41 @@ msgstr "&Βάρος:"
 msgid "Max width:"
 msgstr "Αντικατάσταση με:"
 
-#: ../src/unix/mediactrl.cpp:947
+#: ../src/unix/mediactrl.cpp:972
 #, c-format
 msgid "Media playback error: %s"
 msgstr ""
 
-#: ../src/common/fs_mem.cpp:175
+#: ../src/common/fs_mem.cpp:170
 #, c-format
 msgid "Memory VFS already contains file '%s'!"
 msgstr "VFS μνήμης ήδη περιέχει το αρχείο '%s'!"
 
 #. TRANSLATORS: Name of keyboard key
 #. TRANSLATORS: Keyword of system colour
-#: ../src/common/accelcmn.cpp:73 ../src/propgrid/advprops.cpp:889
+#: ../src/common/accelcmn.cpp:70 ../src/propgrid/advprops.cpp:790
 msgid "Menu"
 msgstr "Μενού"
 
-#: ../src/common/msgout.cpp:124
+#: ../src/common/msgout.cpp:121
 #, fuzzy
 msgid "Message"
 msgstr "%s μήνυμα"
 
-#: ../src/univ/themes/metal.cpp:168
+#: ../src/univ/themes/metal.cpp:165
 msgid "Metal theme"
 msgstr "Μεταλλικό θέμα"
 
-#: ../src/msw/ole/automtn.cpp:652
+#: ../src/msw/ole/automtn.cpp:643
 msgid "Method or property not found."
 msgstr ""
 
-#: ../src/univ/themes/win32.cpp:3752
+#: ../src/univ/themes/win32.cpp:3749
 msgid "Mi&nimize"
 msgstr "Ελα&χιστοποίηση"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1763
+#: ../src/propgrid/advprops.cpp:1664
 msgid "Middle Button"
 msgstr ""
 
@@ -5210,36 +5333,41 @@ msgstr "Το βάρος της γραμματοσειράς."
 msgid "Min width:"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:668
+#: ../src/osx/cocoa/menu.mm:281
+#, fuzzy
+msgid "Minimize"
+msgstr "Ελα&χιστοποίηση"
+
+#: ../src/msw/ole/automtn.cpp:659
 msgid "Missing a required parameter."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:324
+#: ../src/generic/fontdlgg.cpp:320
 msgid "Modern"
 msgstr "Μοντέρνο"
 
-#: ../src/generic/filectrlg.cpp:427
+#: ../src/generic/filectrlg.cpp:423
 msgid "Modified"
 msgstr "Τροποποιημένο"
 
-#: ../src/common/module.cpp:133
+#: ../src/common/module.cpp:130
 #, c-format
 msgid "Module \"%s\" initialization failed"
 msgstr ""
 
-#: ../src/common/paper.cpp:131
+#: ../src/common/paper.cpp:128
 msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
 msgstr "Φακελος Monarch, 3 7/8 x 7 1/2 ίντσες"
 
-#: ../src/msw/fswatcher.cpp:143
+#: ../src/msw/fswatcher.cpp:140
 msgid "Monitoring individual files for changes is not supported currently."
 msgstr ""
 
-#: ../src/generic/editlbox.cpp:172
+#: ../src/generic/editlbox.cpp:160
 msgid "Move down"
 msgstr "Μετακίνηση κάτω"
 
-#: ../src/generic/editlbox.cpp:171
+#: ../src/generic/editlbox.cpp:155
 msgid "Move up"
 msgstr "Μετακίνηση επάνω"
 
@@ -5253,100 +5381,105 @@ msgstr ""
 msgid "Moves the object to the previous paragraph."
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9966
+#: ../src/richtext/richtextbuffer.cpp:9963
 msgid "Multiple Cell Properties"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:424
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:82
+msgid "Multiply"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:420
 msgid "Name"
 msgstr "Όνομα"
 
-#: ../src/propgrid/advprops.cpp:1596
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Navy"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "Network"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173
 #, fuzzy
 msgid "New"
 msgstr "&Νέο"
 
-#: ../src/richtext/richtextstyledlg.cpp:243
+#: ../src/richtext/richtextstyledlg.cpp:239
 #, fuzzy
 msgid "New &Box Style..."
 msgstr "Νέο στοιχείο"
 
-#: ../src/richtext/richtextstyledlg.cpp:225
+#: ../src/richtext/richtextstyledlg.cpp:221
 msgid "New &Character Style..."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:237
+#: ../src/richtext/richtextstyledlg.cpp:233
 msgid "New &List Style..."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:231
+#: ../src/richtext/richtextstyledlg.cpp:227
 msgid "New &Paragraph Style..."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:606
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:654
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:820
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:893
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:934
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:602
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:650
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:816
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:889
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:930
+#: ../src/richtext/richtextstyledlg.cpp:935
 #, fuzzy
 msgid "New Style"
 msgstr "Νέο στοιχείο"
 
-#: ../src/generic/editlbox.cpp:169
+#: ../src/generic/editlbox.cpp:139
 msgid "New item"
 msgstr "Νέο στοιχείο"
 
-#: ../src/generic/dirdlgg.cpp:297 ../src/generic/dirdlgg.cpp:307
-#: ../src/generic/filectrlg.cpp:618 ../src/generic/filectrlg.cpp:627
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+#: ../src/generic/dirdlgg.cpp:294 ../src/generic/dirdlgg.cpp:304
 msgid "NewName"
 msgstr "ΝέοΌνομα"
 
-#: ../src/common/prntbase.cpp:1567 ../src/html/helpwnd.cpp:665
+#: ../src/common/prntbase.cpp:1592 ../src/html/helpwnd.cpp:663
 msgid "Next page"
 msgstr "Επόμενη σελίδα"
 
-#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:177
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:174
 #: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Όχι"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1764
+#: ../src/propgrid/advprops.cpp:1665
 msgid "No Entry"
 msgstr ""
 
-#: ../src/generic/animateg.cpp:150
+#: ../src/generic/animateg.cpp:133
 #, fuzzy, c-format
 msgid "No animation handler for type %ld defined."
 msgstr "Δεν έχει οριστεί χειριστής εικόνας για τον τύπο %d."
 
-#: ../src/dfb/bitmap.cpp:642 ../src/dfb/bitmap.cpp:676
+#: ../src/dfb/bitmap.cpp:639 ../src/dfb/bitmap.cpp:673
 #, fuzzy, c-format
 msgid "No bitmap handler for type %d defined."
 msgstr "Δεν έχει οριστεί χειριστής εικόνας για τον τύπο %d."
 
-#: ../src/common/utilscmn.cpp:1077
+#: ../src/common/utilscmn.cpp:1095
 msgid "No default application configured for HTML files."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:445
+#: ../src/generic/helpext.cpp:443
 msgid "No entries found."
 msgstr "Δεν βρέθηκαν εισαγωγές(entries)."
 
-#: ../src/common/fontmap.cpp:421
+#: ../src/common/fontmap.cpp:418
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found,\n"
@@ -5360,7 +5493,7 @@ msgstr ""
 "Θέλετε να χρησιμοποιήσετε αυτή την κωδικοποίηση (διαφορετικά θα πρέπει να "
 "επιλέξετε μία άλλη) ;"
 
-#: ../src/common/fontmap.cpp:426
+#: ../src/common/fontmap.cpp:423
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found.\n"
@@ -5373,212 +5506,211 @@ msgstr ""
 "κωδικοποίηση(διαφορετικά το κείμενο σε αυτή την κωδικοποίηση δεν θα "
 "εμφανιστεί κανονικά) ;"
 
-#: ../src/generic/animateg.cpp:142
+#: ../src/generic/animateg.cpp:125
 #, fuzzy
 msgid "No handler found for animation type."
 msgstr "Δεν βρέθηκε χειριστής για τύπο εικόνας."
 
-#: ../src/common/image.cpp:2728
+#: ../src/common/image.cpp:2823
 msgid "No handler found for image type."
 msgstr "Δεν βρέθηκε χειριστής για τύπο εικόνας."
 
-#: ../src/common/image.cpp:2736 ../src/common/image.cpp:2848
-#: ../src/common/image.cpp:2901
+#: ../src/common/image.cpp:2831 ../src/common/image.cpp:2954
+#: ../src/common/image.cpp:3020
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "Δεν έχει οριστεί χειριστής εικόνας για τον τύπο %d."
 
-#: ../src/common/image.cpp:2871 ../src/common/image.cpp:2915
+#: ../src/common/image.cpp:2986 ../src/common/image.cpp:3034
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "Δεν έχει οριστεί χειριστής εικόνας για τον τύπο %s."
 
-#: ../src/html/helpwnd.cpp:858
+#: ../src/html/helpwnd.cpp:856
 msgid "No matching page found yet"
 msgstr "Δεν βρέθηκε ακόμα σελίδα που να ταιράζει"
 
-#: ../src/unix/sound.cpp:81
+#: ../src/unix/sound.cpp:78
 msgid "No sound"
 msgstr "Χωρίς ήχο"
 
-#: ../src/common/image.cpp:2277 ../src/common/image.cpp:2318
+#: ../src/common/image.cpp:2371 ../src/common/image.cpp:2412
 msgid "No unused colour in image being masked."
 msgstr ""
 "Δεν υπάρχει μη χρησιμοποιούμενο χρώμα στην εικόνα που εφααρμόζεται η μάσκα"
 
-#: ../src/common/image.cpp:3374
-msgid "No unused colour in image."
-msgstr "Δεν υπάρχει μη χρησιμοποιούμενο χρώμα στην εικόνα"
-
-#: ../src/generic/helpext.cpp:302
+#: ../src/generic/helpext.cpp:300
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr ""
 
-#: ../src/richtext/richtextborderspage.cpp:610
 #: ../src/richtext/richtextsizepage.cpp:248
 #: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:610
 #, fuzzy
 msgid "None"
 msgstr "Έτοιμο"
 
-#: ../src/common/fmapbase.cpp:157
+#: ../src/common/fmapbase.cpp:154
 msgid "Nordic (ISO-8859-10)"
 msgstr "Νορδικό (ISO-8859-10)"
 
-#: ../src/generic/fontdlgg.cpp:328 ../src/generic/fontdlgg.cpp:331
+#: ../src/generic/fontdlgg.cpp:324 ../src/generic/fontdlgg.cpp:327
 msgid "Normal"
 msgstr "Κανονικό"
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1261
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Κανονική όψη<br>και <u>υπογραμμισμένη</u>."
 
-#: ../src/html/helpwnd.cpp:1205
+#: ../src/html/helpwnd.cpp:1203
 msgid "Normal font:"
 msgstr "Κανονική γραμματοσειρά:"
 
-#: ../src/propgrid/props.cpp:1128
+#: ../src/propgrid/props.cpp:1115
 #, fuzzy, c-format
 msgid "Not %s"
 msgstr "&Περί..."
 
-#: ../include/wx/filename.h:573 ../include/wx/filename.h:578
-#, fuzzy
-msgid "Not available"
-msgstr "Δεν υπάρχει μονάδα(facility) XBM διαθέσιμη!"
+#: ../src/common/secretstore.cpp:168
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/webrequest.cpp:605
+msgid "Not enough free disk space for download."
+msgstr ""
 
 #: ../src/richtext/richtextfontpage.cpp:358
 #, fuzzy
 msgid "Not underlined"
 msgstr "υπογεγραμμένο"
 
-#: ../src/common/paper.cpp:115
+#: ../src/common/paper.cpp:112
 msgid "Note, 8 1/2 x 11 in"
 msgstr "Σημείωμα, 8 1/2 x 11 ίντσες"
 
-#: ../src/generic/notifmsgg.cpp:132
+#: ../src/generic/notifmsgg.cpp:129
 #, fuzzy
 msgid "Notice"
 msgstr "&Όχι"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "Num *"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "Num +"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "Num ,"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "Num -"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "Num ."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "Num /"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "Num ="
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "Num Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 #, fuzzy
 msgid "Num Delete"
 msgstr "&Διαγραφή"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 #, fuzzy
 msgid "Num Down"
 msgstr "Κάτω"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "Num End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "Num Enter"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 #, fuzzy
 msgid "Num Home"
 msgstr "Αρχική σελίδα"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 #, fuzzy
 msgid "Num Insert"
 msgstr "Στοίχιση"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num Lock"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "Num Page Down"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "Num Page Up"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 #, fuzzy
 msgid "Num Right"
 msgstr "Απαλό(light)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "Num Space"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "Num Tab"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "Num Up"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "Num left"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num_lock"
 msgstr ""
 
@@ -5587,13 +5719,13 @@ msgstr ""
 msgid "Numbered outline"
 msgstr ""
 
-#: ../include/wx/msgdlg.h:278 ../src/richtext/richtextstyledlg.cpp:297
-#: ../src/common/stockitem.cpp:178 ../src/msw/msgdlg.cpp:454
-#: ../src/msw/msgdlg.cpp:747 ../src/gtk1/fontdlg.cpp:138
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:175
+#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/msgdlg.cpp:741 ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "OK"
 
-#: ../src/msw/ole/automtn.cpp:692
+#: ../src/msw/ole/automtn.cpp:683
 #, c-format
 msgid "OLE Automation error in %s: %s"
 msgstr ""
@@ -5603,15 +5735,15 @@ msgstr ""
 msgid "Object Properties"
 msgstr "&Ιδιότητες"
 
-#: ../src/msw/ole/automtn.cpp:660
+#: ../src/msw/ole/automtn.cpp:651
 msgid "Object implementation does not support named arguments."
 msgstr ""
 
-#: ../src/common/xtixml.cpp:264
+#: ../src/common/xtixml.cpp:260
 msgid "Objects must have an id attribute"
 msgstr "Τα αντικείμενα πρέπει να έχουν ένα χαρακτηριστικό id"
 
-#: ../src/propgrid/advprops.cpp:1601
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Olive"
 msgstr ""
 
@@ -5619,65 +5751,70 @@ msgstr ""
 msgid "Opaci&ty:"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:354
+#: ../src/generic/colrdlgg.cpp:374
 msgid "Opacity:"
 msgstr ""
 
-#: ../src/common/docview.cpp:1773 ../src/common/docview.cpp:1815
+#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
 msgid "Open File"
 msgstr "Ανοιγμα Αρχείου"
 
-#: ../src/html/helpwnd.cpp:671 ../src/html/helpwnd.cpp:1554
+#: ../src/html/helpwnd.cpp:669 ../src/html/helpwnd.cpp:1552
 msgid "Open HTML document"
 msgstr "’νοιγμα εγγράφου HTML"
 
-#: ../src/generic/dbgrptg.cpp:163
+#: ../src/common/stockitem.cpp:265
+#, fuzzy
+msgid "Open an existing document"
+msgstr "’νοιγμα εγγράφου HTML"
+
+#: ../src/generic/dbgrptg.cpp:160
 #, fuzzy, c-format
 msgid "Open file \"%s\""
 msgstr "Ανοιγμα Αρχείου"
 
-#: ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176
 #, fuzzy
 msgid "Open..."
 msgstr "&Ανοιγμα..."
 
-#: ../src/unix/glx11.cpp:506 ../src/msw/glcanvas.cpp:592
+#: ../src/msw/glcanvas.cpp:607 ../src/unix/glx11.cpp:513
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr ""
 
-#: ../src/generic/dirctrlg.cpp:599 ../src/generic/dirdlgg.cpp:323
-#: ../src/generic/filectrlg.cpp:642 ../src/generic/filectrlg.cpp:786
+#: ../src/generic/dirctrlg.cpp:565 ../src/generic/filectrlg.cpp:638
+#: ../src/generic/filectrlg.cpp:782 ../src/generic/dirdlgg.cpp:320
 msgid "Operation not permitted."
 msgstr "Λειτουργία δεν ειπιτρέπετε."
 
-#: ../src/common/cmdline.cpp:900
+#: ../src/common/cmdline.cpp:896
 #, fuzzy, c-format
 msgid "Option '%s' can't be negated"
 msgstr "Δεν ήταν δυνατή η δημιουργία του καταλόγου '%s'"
 
-#: ../src/common/cmdline.cpp:1064
+#: ../src/common/cmdline.cpp:1060
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "Η επιλογή '%s' απαιτεί μια τιμή."
 
-#: ../src/common/cmdline.cpp:1147
+#: ../src/common/cmdline.cpp:1143
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Επιλογή '%s': το '%s' δεν μπροει να μετατραπει σε ημερομηνία."
 
-#: ../src/generic/prntdlgg.cpp:618
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Επιλογές"
 
-#: ../src/propgrid/advprops.cpp:1606
+#: ../src/propgrid/advprops.cpp:1512
 msgid "Orange"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:615 ../src/generic/prntdlgg.cpp:869
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:862
 msgid "Orientation"
 msgstr "Προσανατολισμός"
 
-#: ../src/common/windowid.cpp:242
+#: ../src/common/windowid.cpp:237
 msgid "Out of window IDs.  Recommend shutting down application."
 msgstr ""
 
@@ -5690,167 +5827,167 @@ msgstr ""
 msgid "Outset"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:656
+#: ../src/msw/ole/automtn.cpp:647
 msgid "Overflow while coercing argument values."
 msgstr ""
 
-#: ../src/common/imagpcx.cpp:457 ../src/common/imagpcx.cpp:480
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:479
 msgid "PCX: couldn't allocate memory"
 msgstr "PCX: Δεν ήταν δυνατή η δέσμευση μνήμης"
 
-#: ../src/common/imagpcx.cpp:456
+#: ../src/common/imagpcx.cpp:455
 msgid "PCX: image format unsupported"
 msgstr "PCX: μορφή εικόνας δεν υποστηρίζεται"
 
-#: ../src/common/imagpcx.cpp:479
+#: ../src/common/imagpcx.cpp:478
 msgid "PCX: invalid image"
 msgstr "PCX: λανθασμένη εικόνα"
 
-#: ../src/common/imagpcx.cpp:442
+#: ../src/common/imagpcx.cpp:441
 msgid "PCX: this is not a PCX file."
 msgstr "PCX: αυτό δεν είναι αρχείο PCX."
 
-#: ../src/common/imagpcx.cpp:459 ../src/common/imagpcx.cpp:481
+#: ../src/common/imagpcx.cpp:458 ../src/common/imagpcx.cpp:480
 msgid "PCX: unknown error !!!"
 msgstr "PCX: άγνωστο σφάλμα !!!"
 
-#: ../src/common/imagpcx.cpp:458
+#: ../src/common/imagpcx.cpp:457
 msgid "PCX: version number too low"
 msgstr "PCX: αριθμός έκδοσης πολύ χαμηλός"
 
-#: ../src/common/imagpnm.cpp:91
+#: ../src/common/imagpnm.cpp:89
 msgid "PNM: Couldn't allocate memory."
 msgstr "PNM: Δεν ήταν δυνατή η δέσμευση μνήμης."
 
-#: ../src/common/imagpnm.cpp:73
+#: ../src/common/imagpnm.cpp:71
 msgid "PNM: File format is not recognized."
 msgstr "PNM: Η μορφή αρχείου δεν αναγνωρίζεται."
 
-#: ../src/common/imagpnm.cpp:112 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
 #: ../src/common/imagpnm.cpp:156
 msgid "PNM: File seems truncated."
 msgstr "PNM: Το αρχείο μοιάζει να είναι αποκομμένο."
 
-#: ../src/common/paper.cpp:187
+#: ../src/common/paper.cpp:184
 msgid "PRC 16K 146 x 215 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:200
+#: ../src/common/paper.cpp:197
 msgid "PRC 16K Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:188
+#: ../src/common/paper.cpp:185
 msgid "PRC 32K 97 x 151 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:201
+#: ../src/common/paper.cpp:198
 msgid "PRC 32K Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:189
+#: ../src/common/paper.cpp:186
 msgid "PRC 32K(Big) 97 x 151 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:202
+#: ../src/common/paper.cpp:199
 msgid "PRC 32K(Big) Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:190
+#: ../src/common/paper.cpp:187
 #, fuzzy
 msgid "PRC Envelope #1 102 x 165 mm"
 msgstr "C6 Φάκελος, 114 x 162 mm"
 
-#: ../src/common/paper.cpp:203
+#: ../src/common/paper.cpp:200
 #, fuzzy
 msgid "PRC Envelope #1 Rotated 165 x 102 mm"
 msgstr "C6 Φάκελος, 114 x 162 mm"
 
-#: ../src/common/paper.cpp:199
+#: ../src/common/paper.cpp:196
 #, fuzzy
 msgid "PRC Envelope #10 324 x 458 mm"
 msgstr "C3 Φάκελος, 324 x 458 mm"
 
-#: ../src/common/paper.cpp:212
+#: ../src/common/paper.cpp:209
 #, fuzzy
 msgid "PRC Envelope #10 Rotated 458 x 324 mm"
 msgstr "C4 Φάκελος, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:191
+#: ../src/common/paper.cpp:188
 #, fuzzy
 msgid "PRC Envelope #2 102 x 176 mm"
 msgstr "C6 Φάκελος, 114 x 162 mm"
 
-#: ../src/common/paper.cpp:204
+#: ../src/common/paper.cpp:201
 #, fuzzy
 msgid "PRC Envelope #2 Rotated 176 x 102 mm"
 msgstr "B6 Φάκελος, 176 x 125 mm"
 
-#: ../src/common/paper.cpp:192
+#: ../src/common/paper.cpp:189
 #, fuzzy
 msgid "PRC Envelope #3 125 x 176 mm"
 msgstr "C6 Φάκελος, 114 x 162 mm"
 
-#: ../src/common/paper.cpp:205
+#: ../src/common/paper.cpp:202
 #, fuzzy
 msgid "PRC Envelope #3 Rotated 176 x 125 mm"
 msgstr "B6 Φάκελος, 176 x 125 mm"
 
-#: ../src/common/paper.cpp:193
+#: ../src/common/paper.cpp:190
 #, fuzzy
 msgid "PRC Envelope #4 110 x 208 mm"
 msgstr "Φάκελος DL, 110 x 220 mm"
 
-#: ../src/common/paper.cpp:206
+#: ../src/common/paper.cpp:203
 #, fuzzy
 msgid "PRC Envelope #4 Rotated 208 x 110 mm"
 msgstr "C6 Φάκελος, 114 x 162 mm"
 
-#: ../src/common/paper.cpp:194
+#: ../src/common/paper.cpp:191
 #, fuzzy
 msgid "PRC Envelope #5 110 x 220 mm"
 msgstr "Φάκελος DL, 110 x 220 mm"
 
-#: ../src/common/paper.cpp:207
+#: ../src/common/paper.cpp:204
 #, fuzzy
 msgid "PRC Envelope #5 Rotated 220 x 110 mm"
 msgstr "C4 Φάκελος, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:195
+#: ../src/common/paper.cpp:192
 #, fuzzy
 msgid "PRC Envelope #6 120 x 230 mm"
 msgstr "C5 Φάκελος, 162 x 229 mm"
 
-#: ../src/common/paper.cpp:208
+#: ../src/common/paper.cpp:205
 #, fuzzy
 msgid "PRC Envelope #6 Rotated 230 x 120 mm"
 msgstr "C5 Φάκελος, 162 x 229 mm"
 
-#: ../src/common/paper.cpp:196
+#: ../src/common/paper.cpp:193
 #, fuzzy
 msgid "PRC Envelope #7 160 x 230 mm"
 msgstr "B5 Φάκελος, 176 x 250 mm"
 
-#: ../src/common/paper.cpp:209
+#: ../src/common/paper.cpp:206
 #, fuzzy
 msgid "PRC Envelope #7 Rotated 230 x 160 mm"
 msgstr "C6 Φάκελος, 114 x 162 mm"
 
-#: ../src/common/paper.cpp:197
+#: ../src/common/paper.cpp:194
 #, fuzzy
 msgid "PRC Envelope #8 120 x 309 mm"
 msgstr "C5 Φάκελος, 162 x 229 mm"
 
-#: ../src/common/paper.cpp:210
+#: ../src/common/paper.cpp:207
 #, fuzzy
 msgid "PRC Envelope #8 Rotated 309 x 120 mm"
 msgstr "C4 Φάκελος, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:198
+#: ../src/common/paper.cpp:195
 #, fuzzy
 msgid "PRC Envelope #9 229 x 324 mm"
 msgstr "C4 Φάκελος, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:211
+#: ../src/common/paper.cpp:208
 #, fuzzy
 msgid "PRC Envelope #9 Rotated 324 x 229 mm"
 msgstr "C5 Φάκελος, 162 x 229 mm"
@@ -5860,94 +5997,98 @@ msgstr "C5 Φάκελος, 162 x 229 mm"
 msgid "Padding"
 msgstr "γίνεται ανάγνωση"
 
-#: ../src/common/prntbase.cpp:2074
+#: ../src/common/prntbase.cpp:2096
 #, c-format
 msgid "Page %d"
 msgstr "Σελίδα %d"
 
-#: ../src/common/prntbase.cpp:2072
+#: ../src/common/prntbase.cpp:2094
 #, c-format
 msgid "Page %d of %d"
 msgstr "Σελίδα %d από %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 #, fuzzy
 msgid "Page Down"
 msgstr "Σελίδα %d"
 
-#: ../src/gtk/print.cpp:826
+#: ../src/gtk/print.cpp:829
 msgid "Page Setup"
 msgstr "Οργάνωση(setup) Σελίδας"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 #, fuzzy
 msgid "Page Up"
 msgstr "Σελίδα %d"
 
-#: ../src/generic/prntdlgg.cpp:828 ../src/common/prntbase.cpp:484
+#: ../src/common/prntbase.cpp:479 ../src/generic/prntdlgg.cpp:821
 msgid "Page setup"
 msgstr "Ρύθμιση(setup) Σελίδας"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 #, fuzzy
 msgid "PageDown"
 msgstr "Κάτω"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 #, fuzzy
 msgid "PageUp"
 msgstr "Σελίδες"
 
-#: ../src/generic/prntdlgg.cpp:216
+#: ../src/generic/prntdlgg.cpp:209
 msgid "Pages"
 msgstr "Σελίδες"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1765
+#: ../src/propgrid/advprops.cpp:1666
 msgid "Paint Brush"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:602 ../src/generic/prntdlgg.cpp:801
-#: ../src/generic/prntdlgg.cpp:842 ../src/generic/prntdlgg.cpp:855
-#: ../src/generic/prntdlgg.cpp:1052 ../src/generic/prntdlgg.cpp:1057
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:794
+#: ../src/generic/prntdlgg.cpp:835 ../src/generic/prntdlgg.cpp:848
+#: ../src/generic/prntdlgg.cpp:1045 ../src/generic/prntdlgg.cpp:1050
 msgid "Paper size"
 msgstr "Μέγεθος χαρτιού"
 
-#: ../src/richtext/richtextstyles.cpp:1062
+#: ../src/richtext/richtextstyles.cpp:1059
 msgid "Paragraph styles"
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:465
+#: ../src/common/xtistrm.cpp:462
 msgid "Passing a already registered object to SetObject"
 msgstr "Δόθηκε ένα ήδη registered αντικείμενο στην SetObject"
 
-#: ../src/common/xtistrm.cpp:476
+#: ../src/common/xtistrm.cpp:473
 #, fuzzy
 msgid "Passing an unknown object to GetObject"
 msgstr "Δόθηκε ένα άγνωστο αντικείμενο στην GetObject"
 
-#: ../src/richtext/richtextctrl.cpp:3513 ../src/common/stockitem.cpp:180
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:177 ../src/richtext/richtextctrl.cpp:3514
 #: ../src/stc/stc_i18n.cpp:19
 #, fuzzy
 msgid "Paste"
 msgstr "&Επικόληση"
 
-#: ../src/common/stockitem.cpp:262
+#: ../src/common/stockitem.cpp:260
 #, fuzzy
 msgid "Paste selection"
 msgstr "Τμήματα"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:74
+#: ../src/common/accelcmn.cpp:71
 msgid "Pause"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1766
+#: ../src/propgrid/advprops.cpp:1667
 msgid "Pencil"
 msgstr ""
 
@@ -5956,21 +6097,21 @@ msgstr ""
 msgid "Peri&od"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:430
+#: ../src/generic/filectrlg.cpp:426
 msgid "Permissions"
 msgstr "Δικαιώματα"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:60
+#: ../src/common/accelcmn.cpp:57
 msgid "PgDn"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:59
+#: ../src/common/accelcmn.cpp:56
 msgid "PgUp"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:12868
+#: ../src/richtext/richtextbuffer.cpp:12863
 #, fuzzy
 msgid "Picture Properties"
 msgstr "&Ιδιότητες"
@@ -5983,48 +6124,48 @@ msgstr "Δημιουργία pipe απέτυχε"
 msgid "Please choose a valid font."
 msgstr "Παρακαλώ επιλέξτε μία αποδεκτή γραμματοσειρά."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
 msgid "Please choose an existing file."
 msgstr "Παρακλώ επιλέξτε ένα υπάρχον αρχείο."
 
-#: ../src/html/helpwnd.cpp:800
+#: ../src/html/helpwnd.cpp:798
 msgid "Please choose the page to display:"
 msgstr "Παρακλώ επιλέξτε την σελίδα για απεικόνιση:"
 
-#: ../src/msw/dialup.cpp:764
+#: ../src/msw/dialup.cpp:758
 msgid "Please choose which ISP do you want to connect to"
 msgstr ""
 "Παρακαλώ επιλέξτε τον παροχέα υπηρεσιών Internet (ISP) με τον οποίο θέλετε "
 "να συνδεθείτε"
 
-#: ../src/common/headerctrlcmn.cpp:59
+#: ../src/common/headerctrlcmn.cpp:57
 msgid "Please select the columns to show and define their order:"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:538
+#: ../src/common/prntbase.cpp:533
 #, fuzzy
 msgid "Please wait while printing..."
 msgstr "Παρακαλώ περιμένετε όσο διαρκεί η εκτύπωση\n"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1767
+#: ../src/propgrid/advprops.cpp:1668
 #, fuzzy
 msgid "Point Left"
 msgstr "Μέγεθος κουκίδας:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1768
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgid "Point Right"
 msgstr "Στοίχιση Δεξιά"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:662
+#: ../src/propgrid/advprops.cpp:572
 #, fuzzy
 msgid "Point Size"
 msgstr "Μέγεθος κουκίδας:"
 
-#: ../src/generic/prntdlgg.cpp:612 ../src/generic/prntdlgg.cpp:867
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:860
 msgid "Portrait"
 msgstr "Πορτραίτο"
 
@@ -6033,268 +6174,278 @@ msgstr "Πορτραίτο"
 msgid "Position"
 msgstr "Ερώτημα"
 
-#: ../src/generic/prntdlgg.cpp:298
+#: ../src/generic/prntdlgg.cpp:291
 msgid "PostScript file"
 msgstr "Αρχείο PostScript"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178 ../src/osx/cocoa/preferences.mm:303
 #, fuzzy
 msgid "Preferences"
 msgstr "&Προτιμήσεις"
 
-#: ../src/osx/menu_osx.cpp:568
+#: ../src/osx/menu_osx.cpp:460
 #, fuzzy
 msgid "Preferences..."
 msgstr "&Προτιμήσεις"
 
-#: ../src/common/prntbase.cpp:546
+#: ../src/common/prntbase.cpp:541
 msgid "Preparing"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:455 ../src/osx/carbon/fontdlg.cpp:390
-#: ../src/html/helpwnd.cpp:1222
+#: ../src/osx/carbon/fontdlg.cpp:387 ../src/generic/fontdlgg.cpp:452
+#: ../src/html/helpwnd.cpp:1220
 msgid "Preview:"
 msgstr "Προεπισκόπηση:"
 
-#: ../src/common/prntbase.cpp:1553 ../src/html/helpwnd.cpp:664
+#: ../src/common/prntbase.cpp:1578 ../src/html/helpwnd.cpp:662
 msgid "Previous page"
 msgstr "Προηγούμενη σελίδα"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/prntdlgg.cpp:143 ../src/generic/prntdlgg.cpp:157
-#: ../src/common/prntbase.cpp:426 ../src/common/prntbase.cpp:1541
-#: ../src/common/accelcmn.cpp:77 ../src/gtk/print.cpp:620
-#: ../src/gtk/print.cpp:638
+#: ../src/common/prntbase.cpp:421 ../src/common/prntbase.cpp:1566
+#: ../src/common/accelcmn.cpp:74 ../src/generic/prntdlgg.cpp:136
+#: ../src/generic/prntdlgg.cpp:150 ../src/gtk/print.cpp:616
+#: ../src/gtk/print.cpp:634
 msgid "Print"
 msgstr "Εκτύπωση"
 
-#: ../include/wx/prntbase.h:399 ../src/common/docview.cpp:1268
+#: ../src/common/docview.cpp:1262
 msgid "Print Preview"
 msgstr "Προεπισκόπηση Εκτύπωσης"
 
-#: ../src/common/prntbase.cpp:2015 ../src/common/prntbase.cpp:2057
-#: ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2037 ../src/common/prntbase.cpp:2079
+#: ../src/common/prntbase.cpp:2087
 msgid "Print Preview Failure"
 msgstr "Αποτυχία Προεπισκόπησης Εκτύπωσης"
 
-#: ../src/generic/prntdlgg.cpp:224
+#: ../src/generic/prntdlgg.cpp:217
 msgid "Print Range"
 msgstr "Εύρος εκτύπωσης"
 
-#: ../src/generic/prntdlgg.cpp:449
+#: ../src/generic/prntdlgg.cpp:442
 msgid "Print Setup"
 msgstr "Οργάνωση(setup) Εκτύπωσης"
 
-#: ../src/generic/prntdlgg.cpp:621
+#: ../src/generic/prntdlgg.cpp:614
 msgid "Print in colour"
 msgstr "Εγχρωμη εκτύπωση"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/osx/webview_webkit.mm:260
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "Δεν είναι δυνατή η αρχικοποίηση απεικόνησης."
+
+#: ../src/common/stockitem.cpp:179
 #, fuzzy
 msgid "Print previe&w..."
 msgstr "Π&ροεπισκόπηση εκτύπωσης"
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1256
 #, fuzzy
 msgid "Print preview creation failed."
 msgstr "Δημιουργία pipe απέτυχε"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/common/stockitem.cpp:179
 #, fuzzy
 msgid "Print preview..."
 msgstr "Προεπισκόπηση εκτύπωσης"
 
-#: ../src/generic/prntdlgg.cpp:630
+#: ../src/generic/prntdlgg.cpp:623
 msgid "Print spooling"
 msgstr "Spooling εκτύπωσης"
 
-#: ../src/html/helpwnd.cpp:675
+#: ../src/html/helpwnd.cpp:673
 msgid "Print this page"
 msgstr "Εκτύπωση αυτής της σελίδας"
 
-#: ../src/generic/prntdlgg.cpp:185
+#: ../src/generic/prntdlgg.cpp:178
 msgid "Print to File"
 msgstr "Εκτύπωση σε Αρχείο"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 #, fuzzy
 msgid "Print..."
 msgstr "&Εκτύπωση..."
 
-#: ../src/generic/prntdlgg.cpp:493
+#: ../src/generic/prntdlgg.cpp:486
 msgid "Printer"
 msgstr "Εκτυπωτής"
 
-#: ../src/generic/prntdlgg.cpp:633
+#: ../src/generic/prntdlgg.cpp:626
 msgid "Printer command:"
 msgstr "Εντολή εκτυπωτή:"
 
-#: ../src/generic/prntdlgg.cpp:180
+#: ../src/generic/prntdlgg.cpp:173
 msgid "Printer options"
 msgstr "Επιλογές εκτυπωτή"
 
-#: ../src/generic/prntdlgg.cpp:645
+#: ../src/generic/prntdlgg.cpp:638
 msgid "Printer options:"
 msgstr "Επιλογές εκτυπωτή:"
 
-#: ../src/generic/prntdlgg.cpp:916
+#: ../src/generic/prntdlgg.cpp:909
 msgid "Printer..."
 msgstr "Εκτυπωτής..."
 
-#: ../src/generic/prntdlgg.cpp:196
+#: ../src/generic/prntdlgg.cpp:189
 msgid "Printer:"
 msgstr "Εκτυπωτής:"
 
-#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:535
-#: ../src/html/htmprint.cpp:277
+#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:530
+#: ../src/html/htmprint.cpp:289
 #, fuzzy
 msgid "Printing"
 msgstr "Γίνεται εκτύπωση του "
 
-#: ../src/common/prntbase.cpp:612
+#: ../src/common/prntbase.cpp:607
 msgid "Printing "
 msgstr "Γίνεται εκτύπωση του "
 
-#: ../src/common/prntbase.cpp:347
+#: ../src/common/prntbase.cpp:342
 msgid "Printing Error"
 msgstr "Σφάλμα Εκτύπωσης"
 
-#: ../src/common/prntbase.cpp:565
+#: ../src/osx/webview_webkit.mm:251
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "Το Gzip δεν υποστηρίζεται από αυτήν την έκδοση της zlib"
+
+#: ../src/common/prntbase.cpp:560
 #, fuzzy, c-format
 msgid "Printing page %d"
 msgstr "Γίνεται εκτύπωση σελίδας %d..."
 
-#: ../src/common/prntbase.cpp:570
+#: ../src/common/prntbase.cpp:565
 #, fuzzy, c-format
 msgid "Printing page %d of %d"
 msgstr "Γίνεται εκτύπωση σελίδας %d..."
 
-#: ../src/generic/printps.cpp:201
+#: ../src/generic/printps.cpp:182
 #, c-format
 msgid "Printing page %d..."
 msgstr "Γίνεται εκτύπωση σελίδας %d..."
 
-#: ../src/generic/printps.cpp:161
+#: ../src/generic/printps.cpp:142
 msgid "Printing..."
 msgstr "Γίνεται εκτύπωση..."
 
-#: ../include/wx/richtext/richtextprint.h:109 ../include/wx/prntbase.h:267
-#: ../src/common/docview.cpp:2132
+#: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
+#: ../src/common/docview.cpp:2137
 #, fuzzy
 msgid "Printout"
 msgstr "Εκτύπωση"
 
-#: ../src/common/debugrpt.cpp:560
+#: ../src/common/debugrpt.cpp:561
 #, c-format
 msgid ""
 "Processing debug report has failed, leaving the files in \"%s\" directory."
 msgstr ""
 
-#: ../src/common/prntbase.cpp:545
+#: ../src/common/prntbase.cpp:540
 msgid "Progress:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181
 #, fuzzy
 msgid "Properties"
 msgstr "&Ιδιότητες"
 
-#: ../src/propgrid/manager.cpp:237
+#: ../src/propgrid/manager.cpp:223
 #, fuzzy
 msgid "Property"
 msgstr "&Ιδιότητες"
 
 #. TRANSLATORS: Caption of message box displaying any property error
-#: ../src/propgrid/propgrid.cpp:3185 ../src/propgrid/propgrid.cpp:3318
+#: ../src/propgrid/propgrid.cpp:3162 ../src/propgrid/propgrid.cpp:3299
 #, fuzzy
 msgid "Property Error"
 msgstr "Σφάλμα Εκτύπωσης"
 
-#: ../src/propgrid/advprops.cpp:1597
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Purple"
 msgstr ""
 
-#: ../src/common/paper.cpp:112
+#: ../src/common/paper.cpp:109
 msgid "Quarto, 215 x 275 mm"
 msgstr "Quarto, 215 x 275 mm"
 
-#: ../src/generic/logg.cpp:1016
+#: ../src/generic/logg.cpp:1013
 msgid "Question"
 msgstr "Ερώτημα"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1769
+#: ../src/propgrid/advprops.cpp:1670
 #, fuzzy
 msgid "Question Arrow"
 msgstr "Ερώτημα"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 #, fuzzy
 msgid "Quit"
 msgstr "Έ&ξοδος"
 
-#: ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:477
 #, fuzzy, c-format
 msgid "Quit %s"
 msgstr "Έ&ξοδος"
 
-#: ../src/common/stockitem.cpp:263
+#: ../src/common/stockitem.cpp:261
 #, fuzzy
 msgid "Quit this program"
 msgstr "Εκτύπωση αυτής της σελίδας"
 
-#: ../src/common/accelcmn.cpp:338
+#: ../src/common/accelcmn.cpp:352
 #, fuzzy
 msgid "RawCtrl+"
 msgstr "ctrl"
 
-#: ../src/common/ffile.cpp:109 ../src/common/ffile.cpp:133
+#: ../src/common/ffile.cpp:107 ../src/common/ffile.cpp:132
 #, c-format
 msgid "Read error on file '%s'"
 msgstr "Λάθος ανάγνωσης στο αρχείο '%s'"
 
-#: ../src/common/secretstore.cpp:199
+#: ../src/common/secretstore.cpp:211
 #, fuzzy, c-format
-msgid "Reading password for \"%s/%s\" failed: %s."
+msgid "Reading password for \"%s\" failed: %s."
 msgstr "Η εξαγωγή του '%s' στο '%s' απέτυχε"
 
-#: ../src/common/prntbase.cpp:272
+#: ../src/common/prntbase.cpp:267
 msgid "Ready"
 msgstr "Έτοιμο"
 
-#: ../src/propgrid/advprops.cpp:1605
+#: ../src/propgrid/advprops.cpp:1511
 #, fuzzy
 msgid "Red"
 msgstr "&Επανάληψη"
 
-#: ../src/generic/colrdlgg.cpp:339
+#: ../src/generic/colrdlgg.cpp:359
 msgid "Red:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:185 ../src/stc/stc_i18n.cpp:16
+#: ../src/common/stockitem.cpp:182 ../src/stc/stc_i18n.cpp:16
 #, fuzzy
 msgid "Redo"
 msgstr "&Επανάληψη"
 
-#: ../src/common/stockitem.cpp:264
+#: ../src/common/stockitem.cpp:262
 msgid "Redo last action"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:186
+#: ../src/common/stockitem.cpp:183
 msgid "Refresh"
 msgstr "Ανανέωση"
 
-#: ../src/msw/registry.cpp:626
+#: ../src/msw/registry.cpp:615
 #, c-format
 msgid "Registry key '%s' already exists."
 msgstr "Το κλειδί μητρώου '%s' υπάρχει ήδη."
 
-#: ../src/msw/registry.cpp:595
+#: ../src/msw/registry.cpp:584
 #, c-format
 msgid "Registry key '%s' does not exist, cannot rename it."
 msgstr "Το κλειδί μητρώου '%s' δεν υπάρχει, αδύνατη η μετονομασία του."
 
-#: ../src/msw/registry.cpp:727
+#: ../src/msw/registry.cpp:716
 #, c-format
 msgid ""
 "Registry key '%s' is needed for normal system operation,\n"
@@ -6306,22 +6457,22 @@ msgstr ""
 "διαγράφοντάς το θα αφήσει το σύστημά σας σε κατάσταση αχρηστίας:\n"
 "η λειτουργία ματαιώθηκε."
 
-#: ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:942
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:917
+#: ../src/msw/registry.cpp:905
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1003
+#: ../src/msw/registry.cpp:991
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:521
+#: ../src/msw/registry.cpp:510
 #, c-format
 msgid "Registry value '%s' already exists."
 msgstr "Η τιμή μητρώου '%s' υπάρχει ήδη."
@@ -6336,75 +6487,80 @@ msgstr ""
 msgid "Relative"
 msgstr "Διακοσμητικός"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:456
 msgid "Relevant entries:"
 msgstr "Σχετικές εγγραφές:"
 
-#: ../include/wx/generic/progdlgg.h:86
+#: ../include/wx/generic/progdlgg.h:87
 #, fuzzy
 msgid "Remaining time:"
 msgstr "Xρόνος που απομένει : "
 
-#: ../src/common/stockitem.cpp:187
+#: ../src/common/stockitem.cpp:184
 msgid "Remove"
 msgstr "Απομάκρυνση"
 
-#: ../src/richtext/richtextctrl.cpp:1562
+#: ../src/richtext/richtextctrl.cpp:1563
 #, fuzzy
 msgid "Remove Bullet"
 msgstr "Απομάκρυνση"
 
-#: ../src/html/helpwnd.cpp:433
+#: ../src/html/helpwnd.cpp:431
 msgid "Remove current page from bookmarks"
 msgstr "Αφαίρεση τρέχουσας σελίδας από τους σελιδοδείκτες"
 
-#: ../src/common/rendcmn.cpp:194
+#: ../src/common/rendcmn.cpp:191
 #, c-format
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 "Ο Renderer \"%s\" είναι σε ασύμβατη έκδοση %d.%d και δεν μπορεί να φορτωθεί."
 
-#: ../src/richtext/richtextbuffer.cpp:4527
+#: ../src/richtext/richtextbuffer.cpp:4524
 msgid "Renumber List"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:188
-msgid "Rep&lace"
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Rep&lace..."
 msgstr "&Αντικατάσταση"
 
-#: ../src/richtext/richtextctrl.cpp:3673 ../src/common/stockitem.cpp:188
+#: ../src/richtext/richtextctrl.cpp:3674
 #, fuzzy
 msgid "Replace"
 msgstr "&Αντικατάσταση"
 
-#: ../src/generic/fdrepdlg.cpp:182
+#: ../src/generic/fdrepdlg.cpp:179
 msgid "Replace &all"
 msgstr "Αντικατάσταση &Όλων"
 
-#: ../src/common/stockitem.cpp:261
-#, fuzzy
-msgid "Replace selection"
-msgstr "Αντικατάσταση &Όλων"
-
-#: ../src/generic/fdrepdlg.cpp:124
+#: ../src/generic/fdrepdlg.cpp:121
 msgid "Replace with:"
 msgstr "Αντικατάσταση με:"
 
-#: ../src/common/valtext.cpp:163
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Replace..."
+msgstr "&Αντικατάσταση"
+
+#: ../src/common/valtext.cpp:184
 msgid "Required information entry is empty."
 msgstr ""
 
-#: ../src/common/translation.cpp:1975
+#: ../src/common/translation.cpp:2025
 #, fuzzy, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "'%s' δεν είναι ένας σωστός κατάλογος μηνυμάτων."
 
+#: ../src/gtk/webview_webkit.cpp:985
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:56
+#: ../src/common/accelcmn.cpp:53
 msgid "Return"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:189
+#: ../src/common/stockitem.cpp:186
 msgid "Revert to Saved"
 msgstr "Επαναφορά από το αποθηκευμένο"
 
@@ -6417,43 +6573,43 @@ msgstr "Απαλό(light)"
 msgid "Rig&ht-to-left"
 msgstr ""
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6149
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:59 ../src/generic/datavgen.cpp:6954
+#: ../src/richtext/richtextsizepage.cpp:250
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextbulletspage.cpp:188
-#: ../src/richtext/richtextsizepage.cpp:250 ../src/common/accelcmn.cpp:62
 #, fuzzy
 msgid "Right"
 msgstr "Απαλό(light)"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1754
+#: ../src/propgrid/advprops.cpp:1655
 #, fuzzy
 msgid "Right Arrow"
 msgstr "Απαλό(light)"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1770
+#: ../src/propgrid/advprops.cpp:1671
 msgid "Right Button"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:892
+#: ../src/generic/prntdlgg.cpp:885
 msgid "Right margin (mm):"
 msgstr "Δεξί περιθώριο (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:148
-#: ../src/richtext/richtextindentspage.cpp:150
 #: ../src/richtext/richtextliststylepage.cpp:337
 #: ../src/richtext/richtextliststylepage.cpp:339
+#: ../src/richtext/richtextindentspage.cpp:148
+#: ../src/richtext/richtextindentspage.cpp:150
 msgid "Right-align text."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:322
+#: ../src/generic/fontdlgg.cpp:318
 msgid "Roman"
 msgstr "Ρωμαϊκό"
 
-#: ../src/generic/datavgen.cpp:5916
+#: ../src/generic/datavgen.cpp:6721
 #, c-format
 msgid "Row %i"
 msgstr ""
@@ -6463,31 +6619,31 @@ msgstr ""
 msgid "S&tandard bullet name:"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:268 ../src/common/accelcmn.cpp:350
+#: ../src/common/accelcmn.cpp:282 ../src/common/accelcmn.cpp:367
 msgid "SPECIAL"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:190 ../src/common/sizer.cpp:2797
+#: ../src/common/stockitem.cpp:187 ../src/common/sizer.cpp:2914
 msgid "Save"
 msgstr "Αποθήκευση"
 
-#: ../src/common/fldlgcmn.cpp:342
+#: ../src/common/fldlgcmn.cpp:339
 #, c-format
 msgid "Save %s file"
 msgstr "Αποθήκευση %s αρχείου"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/common/stockitem.cpp:188 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Αποθήκευση &ως..."
 
-#: ../src/common/docview.cpp:366
+#: ../src/common/docview.cpp:359
 msgid "Save As"
 msgstr "Αποθήκευση ως"
 
-#: ../src/common/stockitem.cpp:191
+#: ../src/common/stockitem.cpp:188
 #, fuzzy
-msgid "Save as"
-msgstr "Αποθήκευση ως"
+msgid "Save As..."
+msgstr "Αποθήκευση &ως..."
 
 #: ../src/common/stockitem.cpp:267
 #, fuzzy
@@ -6498,40 +6654,40 @@ msgstr "Επιλέξτε μια προβολή εγγράφων"
 msgid "Save current document with a different filename"
 msgstr ""
 
-#: ../src/generic/logg.cpp:512
+#: ../src/generic/logg.cpp:509
 msgid "Save log contents to file"
 msgstr "Αποθήκευση περιεχομένων καταγραφής(log) σε αρχείο"
 
-#: ../src/common/secretstore.cpp:179
+#: ../src/common/secretstore.cpp:189
 #, fuzzy, c-format
-msgid "Saving password for \"%s/%s\" failed: %s."
+msgid "Saving password for \"%s\" failed: %s."
 msgstr "Η εξαγωγή του '%s' στο '%s' απέτυχε"
 
-#: ../src/generic/fontdlgg.cpp:325
+#: ../src/generic/fontdlgg.cpp:321
 msgid "Script"
 msgstr "Χειρόγραφο(Script)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll Lock"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll_lock"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:890
+#: ../src/propgrid/advprops.cpp:791
 msgid "Scrollbar"
 msgstr ""
 
-#: ../src/generic/srchctlg.cpp:56 ../src/html/helpwnd.cpp:535
-#: ../src/html/helpwnd.cpp:550
+#: ../src/generic/srchctlg.cpp:55 ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:548 ../src/gtk/srchctrl.cpp:182
 msgid "Search"
 msgstr "Αναζήτηση"
 
-#: ../src/html/helpwnd.cpp:537
+#: ../src/html/helpwnd.cpp:535
 #, fuzzy
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
@@ -6540,57 +6696,57 @@ msgstr ""
 "Αναζήτηση στα περιεχόμενα του/των βιβλίου/βιβλίων βοηθείας για όλες τις "
 "εμφανίσεις του κειμένου που γράψατε επάνω"
 
-#: ../src/generic/fdrepdlg.cpp:160
+#: ../src/generic/fdrepdlg.cpp:157
 msgid "Search direction"
 msgstr "Κατεύθυνση αναζήτησης"
 
-#: ../src/generic/fdrepdlg.cpp:112
+#: ../src/generic/fdrepdlg.cpp:109
 msgid "Search for:"
 msgstr "Αναζήτηση για:"
 
-#: ../src/html/helpwnd.cpp:1052
+#: ../src/html/helpwnd.cpp:1050
 msgid "Search in all books"
 msgstr "Εύρεση σε όλα τα βιβλία"
 
-#: ../src/html/helpwnd.cpp:857
+#: ../src/html/helpwnd.cpp:855
 msgid "Searching..."
 msgstr "Γίνεται αναζήτηση..."
 
-#: ../src/generic/dirctrlg.cpp:446
+#: ../src/generic/dirctrlg.cpp:412
 msgid "Sections"
 msgstr "Τμήματα"
 
-#: ../src/common/ffile.cpp:238
+#: ../src/common/ffile.cpp:237
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Λάθος ανίχνευσης (seek error) στο αρχείο '%s'."
 
-#: ../src/common/ffile.cpp:228
+#: ../src/common/ffile.cpp:227
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:76
+#: ../src/common/accelcmn.cpp:73
 #, fuzzy
 msgid "Select"
 msgstr "Τμήματα"
 
-#: ../src/richtext/richtextctrl.cpp:337 ../src/osx/textctrl_osx.cpp:581
-#: ../src/common/stockitem.cpp:192 ../src/msw/textctrl.cpp:2512
+#: ../src/osx/textctrl_osx.cpp:599 ../src/common/stockitem.cpp:189
+#: ../src/msw/textctrl.cpp:2777 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Επιλογή &Ολων"
 
-#: ../src/common/stockitem.cpp:192 ../src/stc/stc_i18n.cpp:21
+#: ../src/common/stockitem.cpp:189 ../src/stc/stc_i18n.cpp:21
 #, fuzzy
 msgid "Select All"
 msgstr "Επιλογή &Ολων"
 
-#: ../src/common/docview.cpp:1895
+#: ../src/common/docview.cpp:1900
 msgid "Select a document template"
 msgstr "Επιλέξτε ένα πρότυπα εγγράφου"
 
-#: ../src/common/docview.cpp:1969
+#: ../src/common/docview.cpp:1974
 msgid "Select a document view"
 msgstr "Επιλέξτε μια προβολή εγγράφων"
 
@@ -6620,20 +6776,20 @@ msgid "Selects the list level to edit."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:82
+#: ../src/common/accelcmn.cpp:79
 msgid "Separator"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1083
+#: ../src/common/cmdline.cpp:1079
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Αναμενόταν διαχωριστικό μετά την επιλογή '%s'."
 
-#: ../src/osx/menu_osx.cpp:572
+#: ../src/osx/menu_osx.cpp:464
 msgid "Services"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11217
+#: ../src/richtext/richtextbuffer.cpp:11216
 #, fuzzy
 msgid "Set Cell Style"
 msgstr "Διαγραφή στοιχείου"
@@ -6642,11 +6798,11 @@ msgstr "Διαγραφή στοιχείου"
 msgid "SetProperty called w/o valid setter"
 msgstr "Η SetProperty κλήθηκε χωρίς έγκυρο θέτη"
 
-#: ../src/generic/prntdlgg.cpp:188
+#: ../src/generic/prntdlgg.cpp:181
 msgid "Setup..."
 msgstr "Ρυθμίσεις..."
 
-#: ../src/msw/dialup.cpp:544
+#: ../src/msw/dialup.cpp:538
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr ""
 "Βρέθηκαν πολλαπλές ενεργές τηλεφωνικές συνδέσεις, γίνεται τυχαία επιλογή "
@@ -6665,44 +6821,44 @@ msgstr ""
 msgid "Shadow c&olour:"
 msgstr "Επιλέξτε χρώμα"
 
-#: ../src/common/accelcmn.cpp:335
+#: ../src/common/accelcmn.cpp:349
 #, fuzzy
 msgid "Shift+"
 msgstr "shift"
 
-#: ../src/generic/dirdlgg.cpp:147
+#: ../src/generic/dirdlgg.cpp:144
 #, fuzzy
 msgid "Show &hidden directories"
 msgstr "Εμφάνιση κρυφών καταλόγων"
 
-#: ../src/generic/filectrlg.cpp:983
+#: ../src/generic/filectrlg.cpp:979
 #, fuzzy
 msgid "Show &hidden files"
 msgstr "Εμφάνιση κρυφών αρχείων."
 
-#: ../src/osx/menu_osx.cpp:580
+#: ../src/osx/menu_osx.cpp:472
 #, fuzzy
 msgid "Show All"
 msgstr "Εμφάνιση όλων"
 
-#: ../src/common/stockitem.cpp:257
+#: ../src/common/stockitem.cpp:254
 msgid "Show about dialog"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:492
+#: ../src/html/helpwnd.cpp:490
 msgid "Show all"
 msgstr "Εμφάνιση όλων"
 
-#: ../src/html/helpwnd.cpp:503
+#: ../src/html/helpwnd.cpp:501
 msgid "Show all items in index"
 msgstr "Εμφάνιση όλων των στοιχείων στο ευρετήριο"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:656
 msgid "Show/hide navigation panel"
 msgstr "Εμφλανιση/Κρύψιμο πλαίσιο πλοήγησης (navigation panel)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:421
-#: ../src/richtext/richtextsymboldlg.cpp:423
+#: ../src/richtext/richtextsymboldlg.cpp:418
+#: ../src/richtext/richtextsymboldlg.cpp:420
 msgid "Shows a Unicode subset."
 msgstr ""
 
@@ -6718,7 +6874,7 @@ msgstr ""
 msgid "Shows a preview of the font settings."
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:394 ../src/osx/carbon/fontdlg.cpp:396
+#: ../src/osx/carbon/fontdlg.cpp:391 ../src/osx/carbon/fontdlg.cpp:393
 msgid "Shows a preview of the font."
 msgstr ""
 
@@ -6727,63 +6883,63 @@ msgstr ""
 msgid "Shows a preview of the paragraph settings."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:460 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:456 ../src/generic/fontdlgg.cpp:458
 msgid "Shows the font preview."
 msgstr "Εμφανίζει την προεπισκόπηση της γραμματοσειράς"
 
-#: ../src/propgrid/advprops.cpp:1607
+#: ../src/propgrid/advprops.cpp:1513
 msgid "Silver"
 msgstr ""
 
-#: ../src/univ/themes/mono.cpp:516
+#: ../src/univ/themes/mono.cpp:513
 msgid "Simple monochrome theme"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:275
 #: ../src/richtext/richtextliststylepage.cpp:449
+#: ../src/richtext/richtextindentspage.cpp:275
 msgid "Single"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:425 ../src/richtext/richtextformatdlg.cpp:369
-#: ../src/richtext/richtextsizepage.cpp:299
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextsizepage.cpp:299
+#: ../src/richtext/richtextformatdlg.cpp:362
 msgid "Size"
 msgstr "Μέγεθος"
 
-#: ../src/osx/carbon/fontdlg.cpp:339
+#: ../src/osx/carbon/fontdlg.cpp:336
 #, fuzzy
 msgid "Size:"
 msgstr "Μέγεθος"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1775
+#: ../src/propgrid/advprops.cpp:1676
 msgid "Sizing"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1772
+#: ../src/propgrid/advprops.cpp:1673
 msgid "Sizing N-S"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1771
+#: ../src/propgrid/advprops.cpp:1672
 msgid "Sizing NE-SW"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1773
+#: ../src/propgrid/advprops.cpp:1674
 msgid "Sizing NW-SE"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1774
+#: ../src/propgrid/advprops.cpp:1675
 msgid "Sizing W-E"
 msgstr ""
 
-#: ../src/msw/progdlg.cpp:801
+#: ../src/msw/progdlg.cpp:1088
 msgid "Skip"
 msgstr "Παράλειψη"
 
-#: ../src/generic/fontdlgg.cpp:330
+#: ../src/generic/fontdlgg.cpp:326
 msgid "Slant"
 msgstr "Κλήση"
 
@@ -6792,7 +6948,7 @@ msgid "Small C&apitals"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:79
+#: ../src/common/accelcmn.cpp:76
 msgid "Snapshot"
 msgstr ""
 
@@ -6801,37 +6957,37 @@ msgstr ""
 msgid "Solid"
 msgstr "Έντονο"
 
-#: ../src/common/docview.cpp:1791
+#: ../src/common/docview.cpp:1785
 msgid "Sorry, could not open this file."
 msgstr "Συγγνώμη, δεν μπόρεσε να ανοιχθεί αυτό το αρχείο."
 
-#: ../src/common/prntbase.cpp:2057 ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2079 ../src/common/prntbase.cpp:2087
 msgid "Sorry, not enough memory to create a preview."
 msgstr "Συγγνώμη, δεν υπάρχει αρκετή μνήμη για την δημιουργία προεπισκόπησης."
 
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "Sorry, that name is taken. Please choose another."
 msgstr ""
 
-#: ../src/common/docview.cpp:1814
+#: ../src/common/docview.cpp:1819
 msgid "Sorry, the format for this file is unknown."
 msgstr "Συγγνώμη, η μορφή αυτού του αρχείου είναι άγνωστη."
 
-#: ../src/unix/sound.cpp:492
+#: ../src/unix/sound.cpp:481
 msgid "Sound data are in unsupported format."
 msgstr "Τα δεδομένα ήχου είναι σε μη υποστηριζόμενη μορφή."
 
-#: ../src/unix/sound.cpp:477
+#: ../src/unix/sound.cpp:466
 #, c-format
 msgid "Sound file '%s' is in unsupported format."
 msgstr "Το αρχείο '%s' είναι σε μη υποστηριζόμενη μορφή."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:67
+#: ../src/common/accelcmn.cpp:64
 #, fuzzy
 msgid "Space"
 msgstr "Γίνεται αναζήτηση..."
@@ -6841,12 +6997,12 @@ msgstr "Γίνεται αναζήτηση..."
 msgid "Spacing"
 msgstr "Γίνεται αναζήτηση..."
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "Spell Check"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1776
+#: ../src/propgrid/advprops.cpp:1677
 msgid "Spraycan"
 msgstr ""
 
@@ -6855,7 +7011,7 @@ msgstr ""
 msgid "Standard"
 msgstr ""
 
-#: ../src/common/paper.cpp:104
+#: ../src/common/paper.cpp:101
 msgid "Statement, 5 1/2 x 8 1/2 in"
 msgstr "Δήλωση, 5 1/2 x 8 1/2 ίντσες"
 
@@ -6865,35 +7021,31 @@ msgstr "Δήλωση, 5 1/2 x 8 1/2 ίντσες"
 msgid "Static"
 msgstr "Κατάσταση: "
 
-#: ../src/generic/prntdlgg.cpp:204
+#: ../src/generic/prntdlgg.cpp:197
 msgid "Status:"
 msgstr "Κατάσταση: "
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 #, fuzzy
 msgid "Stop"
 msgstr "&Διακοπή"
 
-#: ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196
 msgid "Strikethrough"
 msgstr ""
 
-#: ../src/common/colourcmn.cpp:45
+#: ../src/common/colourcmn.cpp:42
 #, c-format
 msgid "String To Colour : Incorrect colour specification : %s"
 msgstr "String To Colour : Λανθασμένος καθορισμός χρώματος: %s"
 
 #. TRANSLATORS: Label of font style
-#: ../src/richtext/richtextformatdlg.cpp:339 ../src/propgrid/advprops.cpp:680
+#: ../src/propgrid/advprops.cpp:590 ../src/richtext/richtextformatdlg.cpp:332
 #, fuzzy
 msgid "Style"
 msgstr "&Στυλ:"
 
-#: ../include/wx/richtext/richtextstyledlg.h:46
-msgid "Style Organiser"
-msgstr ""
-
-#: ../src/osx/carbon/fontdlg.cpp:348
+#: ../src/osx/carbon/fontdlg.cpp:345
 #, fuzzy
 msgid "Style:"
 msgstr "&Στυλ:"
@@ -6904,7 +7056,7 @@ msgid "Subscrip&t"
 msgstr "Χειρόγραφο(Script)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:83
+#: ../src/common/accelcmn.cpp:80
 msgid "Subtract"
 msgstr ""
 
@@ -6913,11 +7065,11 @@ msgstr ""
 msgid "Supe&rscript"
 msgstr "Χειρόγραφο(Script)"
 
-#: ../src/common/paper.cpp:150
+#: ../src/common/paper.cpp:147
 msgid "SuperA/SuperA/A4 227 x 356 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:151
+#: ../src/common/paper.cpp:148
 msgid "SuperB/SuperB/A3 305 x 487 mm"
 msgstr ""
 
@@ -6925,7 +7077,7 @@ msgstr ""
 msgid "Suppress hyphe&nation"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:326
+#: ../src/generic/fontdlgg.cpp:322
 msgid "Swiss"
 msgstr "Ελβετικό(Swiss)"
 
@@ -6945,76 +7097,76 @@ msgstr "Κανονική γραμματοσειρά:"
 msgid "Symbols"
 msgstr "&Στυλ:"
 
-#: ../src/common/imagtiff.cpp:369 ../src/common/imagtiff.cpp:382
-#: ../src/common/imagtiff.cpp:741
+#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
+#: ../src/common/imagtiff.cpp:738
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: Αδύνατη η δέσμευση μνήμης."
 
-#: ../src/common/imagtiff.cpp:301
+#: ../src/common/imagtiff.cpp:298
 msgid "TIFF: Error loading image."
 msgstr "TIFF: Λάθος κατά την φόρτωση εικόνας."
 
-#: ../src/common/imagtiff.cpp:468
+#: ../src/common/imagtiff.cpp:465
 msgid "TIFF: Error reading image."
 msgstr "TIFF: Λάθος κατά την ανάγνωση εικόνας."
 
-#: ../src/common/imagtiff.cpp:608
+#: ../src/common/imagtiff.cpp:605
 msgid "TIFF: Error saving image."
 msgstr "TIFF: Λάθος κατά την αποθήκευση εικόνας."
 
-#: ../src/common/imagtiff.cpp:846
+#: ../src/common/imagtiff.cpp:843
 msgid "TIFF: Error writing image."
 msgstr "TIFF: Λάθος κατα την εγγραφή εικόνας."
 
-#: ../src/common/imagtiff.cpp:355
+#: ../src/common/imagtiff.cpp:352
 msgid "TIFF: Image size is abnormally big."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:68
+#: ../src/common/accelcmn.cpp:65
 msgid "Tab"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11498
+#: ../src/richtext/richtextbuffer.cpp:11497
 #, fuzzy
 msgid "Table Properties"
 msgstr "&Ιδιότητες"
 
-#: ../src/common/paper.cpp:145
+#: ../src/common/paper.cpp:142
 #, fuzzy
 msgid "Tabloid Extra 11.69 x 18 in"
 msgstr "11 x 17 ίντσες"
 
-#: ../src/common/paper.cpp:102
+#: ../src/common/paper.cpp:99
 msgid "Tabloid, 11 x 17 in"
 msgstr "11 x 17 ίντσες"
 
-#: ../src/richtext/richtextformatdlg.cpp:354
+#: ../src/richtext/richtextformatdlg.cpp:347
 msgid "Tabs"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1598
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Teal"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:327
+#: ../src/generic/fontdlgg.cpp:323
 msgid "Teletype"
 msgstr "Τηλέτυπο"
 
-#: ../src/common/docview.cpp:1896
+#: ../src/common/docview.cpp:1901
 msgid "Templates"
 msgstr "Πρότυπα"
 
-#: ../src/common/fmapbase.cpp:158
+#: ../src/common/fmapbase.cpp:155
 msgid "Thai (ISO-8859-11)"
 msgstr "Ταϋλανδέζικο (ISO-8859-11)"
 
-#: ../src/common/ftp.cpp:619
+#: ../src/common/ftp.cpp:622
 msgid "The FTP server doesn't support passive mode."
 msgstr ""
 "Ο διακομιστής FTP δεν υποστηρίζει κατάσταση λειτουργίας(mode) 'passive'."
 
-#: ../src/common/ftp.cpp:605
+#: ../src/common/ftp.cpp:608
 msgid "The FTP server doesn't support the PORT command."
 msgstr "Ο διακομιστής FTP δεν υποστηρίζει την εντολή PORT."
 
@@ -7025,8 +7177,8 @@ msgstr "Ο διακομιστής FTP δεν υποστηρίζει την εν�
 msgid "The available bullet styles."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:202
-#: ../src/richtext/richtextstyledlg.cpp:204
+#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:200
 #, fuzzy
 msgid "The available styles."
 msgstr "Το στυλ της γραμματοσειράς."
@@ -7088,12 +7240,12 @@ msgstr "Το μέγεθος κουκίδας γραμματοσειράς"
 msgid "The bullet character."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:443
-#: ../src/richtext/richtextsymboldlg.cpp:445
+#: ../src/richtext/richtextsymboldlg.cpp:440
+#: ../src/richtext/richtextsymboldlg.cpp:442
 msgid "The character code."
 msgstr ""
 
-#: ../src/common/fontmap.cpp:203
+#: ../src/common/fontmap.cpp:200
 #, c-format
 msgid ""
 "The charset '%s' is unknown. You may select\n"
@@ -7104,7 +7256,7 @@ msgstr ""
 "ένα άλλο σύνολο χαρακτήρων να το αντικαταστήσει ή διαλέξτε\n"
 "[Ακύρωση] εάν δεν μπορεί να αντικατασταθεί"
 
-#: ../src/msw/ole/dataobj.cpp:394
+#: ../src/msw/ole/dataobj.cpp:402
 #, c-format
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "O τύπος προχείρου(clipboard format) '%d' δεν υπάρχει."
@@ -7114,7 +7266,7 @@ msgstr "O τύπος προχείρου(clipboard format) '%d' δεν υπάρχ
 msgid "The default style for the next paragraph."
 msgstr ""
 
-#: ../src/generic/dirdlgg.cpp:202
+#: ../src/generic/dirdlgg.cpp:199
 #, c-format
 msgid ""
 "The directory '%s' does not exist\n"
@@ -7123,7 +7275,7 @@ msgstr ""
 "Ο κατάλογος '%s' δεν υπάρχει\n"
 "Να δημιουργηθεί τώρα;"
 
-#: ../src/html/htmprint.cpp:271
+#: ../src/html/htmprint.cpp:283
 #, c-format
 msgid ""
 "The document \"%s\" doesn't fit on the page horizontally and will be "
@@ -7132,7 +7284,7 @@ msgid ""
 "Would you like to proceed with printing it nevertheless?"
 msgstr ""
 
-#: ../src/common/docview.cpp:1202
+#: ../src/common/docview.cpp:1196
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -7141,37 +7293,37 @@ msgstr ""
 "Το αρχείο '%s' δεν υπάρχει και δεν μπόρεσε να ανοιχτεί.\n"
 "Αφαιρέθηκε από την λίστα με τα πρόσφατα χρησιμοποιημένα αρχεία."
 
-#: ../src/richtext/richtextindentspage.cpp:208
-#: ../src/richtext/richtextindentspage.cpp:210
 #: ../src/richtext/richtextliststylepage.cpp:394
 #: ../src/richtext/richtextliststylepage.cpp:396
+#: ../src/richtext/richtextindentspage.cpp:208
+#: ../src/richtext/richtextindentspage.cpp:210
 #, fuzzy
 msgid "The first line indent."
 msgstr "Το μέγεθος κουκίδας γραμματοσειράς"
 
-#: ../src/gtk/utilsgtk.cpp:481
-msgid "The following standard GTK+ options are also supported:\n"
+#: ../src/generic/dbgrptg.cpp:318
+msgid "The following debug report will be generated\n"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:414 ../src/generic/fontdlgg.cpp:416
+#: ../src/generic/fontdlgg.cpp:411 ../src/generic/fontdlgg.cpp:413
 msgid "The font colour."
 msgstr "Το χρώμα της γραμματοσειράς."
 
-#: ../src/generic/fontdlgg.cpp:375 ../src/generic/fontdlgg.cpp:377
+#: ../src/generic/fontdlgg.cpp:371 ../src/generic/fontdlgg.cpp:373
 msgid "The font family."
 msgstr "Η οικογένεια της γραμματοσειρας."
 
-#: ../src/richtext/richtextsymboldlg.cpp:405
-#: ../src/richtext/richtextsymboldlg.cpp:407
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "The font from which to take the symbol."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:427 ../src/generic/fontdlgg.cpp:429
-#: ../src/generic/fontdlgg.cpp:434 ../src/generic/fontdlgg.cpp:436
+#: ../src/generic/fontdlgg.cpp:424 ../src/generic/fontdlgg.cpp:426
+#: ../src/generic/fontdlgg.cpp:430 ../src/generic/fontdlgg.cpp:432
 msgid "The font point size."
 msgstr "Το μέγεθος κουκίδας γραμματοσειράς"
 
-#: ../src/osx/carbon/fontdlg.cpp:343 ../src/osx/carbon/fontdlg.cpp:345
+#: ../src/osx/carbon/fontdlg.cpp:340 ../src/osx/carbon/fontdlg.cpp:342
 #, fuzzy
 msgid "The font size in points."
 msgstr "Το μέγεθος κουκίδας γραμματοσειράς"
@@ -7182,15 +7334,15 @@ msgstr "Το μέγεθος κουκίδας γραμματοσειράς"
 msgid "The font size units, points or pixels."
 msgstr "Το μέγεθος κουκίδας γραμματοσειράς"
 
-#: ../src/generic/fontdlgg.cpp:386 ../src/generic/fontdlgg.cpp:388
+#: ../src/generic/fontdlgg.cpp:382 ../src/generic/fontdlgg.cpp:384
 msgid "The font style."
 msgstr "Το στυλ της γραμματοσειράς."
 
-#: ../src/generic/fontdlgg.cpp:397 ../src/generic/fontdlgg.cpp:399
+#: ../src/generic/fontdlgg.cpp:393 ../src/generic/fontdlgg.cpp:395
 msgid "The font weight."
 msgstr "Το βάρος της γραμματοσειράς."
 
-#: ../src/common/docview.cpp:1483
+#: ../src/common/docview.cpp:1477
 #, fuzzy, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Δεν ήταν δυνατή η δημιουργία του καταλόγου '%s'"
@@ -7201,10 +7353,10 @@ msgstr "Δεν ήταν δυνατή η δημιουργία του καταλό
 msgid "The horizontal offset."
 msgstr "Οριζόντια παράθεση"
 
-#: ../src/richtext/richtextindentspage.cpp:199
-#: ../src/richtext/richtextindentspage.cpp:201
 #: ../src/richtext/richtextliststylepage.cpp:385
 #: ../src/richtext/richtextliststylepage.cpp:387
+#: ../src/richtext/richtextindentspage.cpp:199
+#: ../src/richtext/richtextindentspage.cpp:201
 #, fuzzy
 msgid "The left indent."
 msgstr "Το βάρος της γραμματοσειράς."
@@ -7229,10 +7381,10 @@ msgstr "Το μέγεθος κουκίδας γραμματοσειράς"
 msgid "The left position."
 msgstr "Το μέγεθος κουκίδας γραμματοσειράς"
 
-#: ../src/richtext/richtextindentspage.cpp:288
-#: ../src/richtext/richtextindentspage.cpp:290
 #: ../src/richtext/richtextliststylepage.cpp:462
 #: ../src/richtext/richtextliststylepage.cpp:464
+#: ../src/richtext/richtextindentspage.cpp:288
+#: ../src/richtext/richtextindentspage.cpp:290
 msgid "The line spacing."
 msgstr ""
 
@@ -7241,7 +7393,7 @@ msgstr ""
 msgid "The list item number."
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:664
+#: ../src/msw/ole/automtn.cpp:655
 msgid "The locale ID is unknown."
 msgstr ""
 
@@ -7287,19 +7439,19 @@ msgstr "Το βάρος της γραμματοσειράς."
 msgid "The outline level."
 msgstr "Εμφανίζει την προεπισκόπηση της γραμματοσειράς"
 
-#: ../src/common/log.cpp:277
+#: ../src/common/log.cpp:296
 #, c-format
 msgid "The previous message repeated %u time."
 msgid_plural "The previous message repeated %u times."
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/common/log.cpp:270
+#: ../src/common/log.cpp:289
 msgid "The previous message repeated once."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:462
-#: ../src/richtext/richtextsymboldlg.cpp:464
+#: ../src/richtext/richtextsymboldlg.cpp:459
+#: ../src/richtext/richtextsymboldlg.cpp:461
 msgid "The range to show."
 msgstr ""
 
@@ -7310,15 +7462,15 @@ msgid ""
 "please uncheck them and they will be removed from the report.\n"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1254
+#: ../src/common/cmdline.cpp:1250
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "Η απαραίτητη παράμετρος '%s' δεν προσδιορίστηκε."
 
-#: ../src/richtext/richtextindentspage.cpp:217
-#: ../src/richtext/richtextindentspage.cpp:219
 #: ../src/richtext/richtextliststylepage.cpp:403
 #: ../src/richtext/richtextliststylepage.cpp:405
+#: ../src/richtext/richtextindentspage.cpp:217
+#: ../src/richtext/richtextindentspage.cpp:219
 msgid "The right indent."
 msgstr ""
 
@@ -7363,16 +7515,16 @@ msgstr ""
 msgid "The shadow spread."
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:267
 #: ../src/richtext/richtextliststylepage.cpp:439
 #: ../src/richtext/richtextliststylepage.cpp:441
+#: ../src/richtext/richtextindentspage.cpp:267
 msgid "The spacing after the paragraph."
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:257
-#: ../src/richtext/richtextindentspage.cpp:259
 #: ../src/richtext/richtextliststylepage.cpp:430
 #: ../src/richtext/richtextliststylepage.cpp:432
+#: ../src/richtext/richtextindentspage.cpp:257
+#: ../src/richtext/richtextindentspage.cpp:259
 msgid "The spacing before the paragraph."
 msgstr ""
 
@@ -7387,13 +7539,13 @@ msgstr "Το στυλ της γραμματοσειράς."
 msgid "The style on which this style is based."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:214
-#: ../src/richtext/richtextstyledlg.cpp:216
+#: ../src/richtext/richtextstyledlg.cpp:210
+#: ../src/richtext/richtextstyledlg.cpp:212
 #, fuzzy
 msgid "The style preview."
 msgstr "Εμφανίζει την προεπισκόπηση της γραμματοσειράς"
 
-#: ../src/msw/ole/automtn.cpp:680
+#: ../src/msw/ole/automtn.cpp:671
 msgid "The system cannot find the file specified."
 msgstr ""
 
@@ -7408,7 +7560,7 @@ msgstr "Το μέγεθος κουκίδας γραμματοσειράς"
 msgid "The tab positions."
 msgstr "Το μέγεθος κουκίδας γραμματοσειράς"
 
-#: ../src/richtext/richtextctrl.cpp:3098
+#: ../src/richtext/richtextctrl.cpp:3099
 msgid "The text couldn't be saved."
 msgstr "Το κείμενο δεν μπόρεσε να αποθυκευτεί."
 
@@ -7432,7 +7584,7 @@ msgstr "Το μέγεθος κουκίδας γραμματοσειράς"
 msgid "The top position."
 msgstr "Το μέγεθος κουκίδας γραμματοσειράς"
 
-#: ../src/common/cmdline.cpp:1232
+#: ../src/common/cmdline.cpp:1228
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "Η τιμή για την επιλογή '%s' πρέπει να προσδιοριστεί,"
@@ -7442,7 +7594,7 @@ msgstr "Η τιμή για την επιλογή '%s' πρέπει να προσ
 msgid "The value of the corner radius."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:433
+#: ../src/msw/dialup.cpp:427
 #, fuzzy, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -7458,35 +7610,43 @@ msgstr ""
 msgid "The vertical offset."
 msgstr "Δεν ήταν δυνατή η εκκίνηση της εκτύπωσης."
 
-#: ../src/richtext/richtextprint.cpp:619 ../src/html/htmprint.cpp:745
+#: ../src/html/htmprint.cpp:749 ../src/richtext/richtextprint.cpp:615
 msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr ""
 "Υπήρξε πρόβλημα κατά την διάρκεια οργάνωσης δελίδας (page setup): ίσως να "
 "χρειαστεί να θέσετε έναν προεπιλεγμένο (default) εκτυπωτή."
 
-#: ../src/html/htmprint.cpp:255
+#: ../src/html/htmprint.cpp:267
 msgid ""
 "This document doesn't fit on the page horizontally and will be truncated "
 "when it is printed."
 msgstr ""
 
-#: ../src/common/image.cpp:2854
+#: ../src/common/image.cpp:2963
 #, fuzzy, c-format
 msgid "This is not a %s."
 msgstr "PCX: αυτό δεν είναι αρχείο PCX."
 
-#: ../src/common/wincmn.cpp:1653
+#: ../src/common/wincmn.cpp:1654
 msgid "This platform does not support background transparency."
 msgstr ""
 
-#: ../src/gtk/window.cpp:4660
+#: ../src/gtk/window.cpp:5664
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
 
-#: ../src/msw/thread.cpp:1240
+#: ../src/gtk/glcanvas.cpp:176
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/msw/thread.cpp:1246
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -7494,13 +7654,13 @@ msgstr ""
 "Η αρχικοποίηση μονάδας νήματος εκτέλεσης (thread module) απέτυχε: αδύνατη η "
 "αποθήκευση τιμής στην τοπική αποθήκευση νήματος (thread local storage)"
 
-#: ../src/unix/threadpsx.cpp:1794
+#: ../src/unix/threadpsx.cpp:1843
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 "Η αρχικοποίηση μονάδας νήματος εκτέλεσης (thread module) απέτυχε: αποτυχία "
 "δημιουργίας κλειδιού νήματος (thread key)"
 
-#: ../src/msw/thread.cpp:1228
+#: ../src/msw/thread.cpp:1234
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -7509,85 +7669,85 @@ msgstr ""
 "δεσμευτεί (allocate) δείκτης (index) στην στην τοπική αποθήκευση νήματος "
 "(thread local storage)"
 
-#: ../src/unix/threadpsx.cpp:1043
+#: ../src/unix/threadpsx.cpp:1061
 msgid "Thread priority setting is ignored."
 msgstr "Η ρύθμιση προτεραιότητας του νήματος εκτέλεσης (thread) αγνοήθηκε. "
 
-#: ../src/msw/mdi.cpp:176
+#: ../src/msw/mdi.cpp:171
 msgid "Tile &Horizontally"
 msgstr "Οριζόντια παράθεση"
 
-#: ../src/msw/mdi.cpp:177
+#: ../src/msw/mdi.cpp:172
 msgid "Tile &Vertically"
 msgstr "Κατακόρυφη παράθεση"
 
-#: ../src/common/ftp.cpp:200
+#: ../src/common/ftp.cpp:197
 msgid "Timeout while waiting for FTP server to connect, try passive mode."
 msgstr ""
 "Τέλος χρόνου κατά την αναμονή για την σύνδεση στον διακομιστή FTP, δοκιμάστε "
 "σε passive mode."
 
-#: ../src/generic/tipdlg.cpp:201
+#: ../src/generic/tipdlg.cpp:198
 msgid "Tip of the Day"
 msgstr "Tip της Ημέρας"
 
-#: ../src/generic/tipdlg.cpp:140
+#: ../src/generic/tipdlg.cpp:137
 msgid "Tips not available, sorry!"
 msgstr "Το Tip δεν είναι διαθέσιμο, συγγνώμη!"
 
-#: ../src/generic/prntdlgg.cpp:242
+#: ../src/generic/prntdlgg.cpp:235
 msgid "To:"
 msgstr "Πρός:"
 
-#: ../src/richtext/richtextbuffer.cpp:8363
+#: ../src/richtext/richtextbuffer.cpp:8361
 msgid "Too many EndStyle calls!"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:891
+#: ../src/propgrid/advprops.cpp:792
 msgid "Tooltip"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:892
+#: ../src/propgrid/advprops.cpp:793
 msgid "TooltipText"
 msgstr ""
 
-#: ../src/richtext/richtextsizepage.cpp:286
-#: ../src/richtext/richtextsizepage.cpp:290 ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197 ../src/richtext/richtextsizepage.cpp:286
+#: ../src/richtext/richtextsizepage.cpp:290
 #, fuzzy
 msgid "Top"
 msgstr "Πρός:"
 
-#: ../src/generic/prntdlgg.cpp:881
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Top margin (mm):"
 msgstr "Πάνω περιθώριο (mm)"
 
-#: ../src/generic/aboutdlgg.cpp:79
+#: ../src/generic/aboutdlgg.cpp:76
 msgid "Translations by "
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:188
+#: ../src/generic/aboutdlgg.cpp:185
 msgid "Translators"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:211
+#: ../src/propgrid/propgrid.cpp:192
 msgid "True"
 msgstr ""
 
-#: ../src/common/fs_mem.cpp:227
+#: ../src/common/fs_mem.cpp:222
 #, c-format
 msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
 msgstr ""
 "Προσπάθεια απομάκρυνσης αρχείου '%s' από VFS μνήμης, αλλά δεν είναι "
 "φορτωμένο!"
 
-#: ../src/common/fmapbase.cpp:156
+#: ../src/common/fmapbase.cpp:153
 msgid "Turkish (ISO-8859-9)"
 msgstr "Τουρκικό (ISO-8859-9)"
 
-#: ../src/generic/filectrlg.cpp:426
+#: ../src/generic/filectrlg.cpp:422
 msgid "Type"
 msgstr "Τύπος"
 
@@ -7602,37 +7762,37 @@ msgstr "Η οικογένεια της γραμματοσειρας."
 msgid "Type a size in points."
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:676
+#: ../src/msw/ole/automtn.cpp:667
 #, c-format
 msgid "Type mismatch in argument %u."
 msgstr ""
 
-#: ../src/common/xtixml.cpp:356 ../src/common/xtixml.cpp:509
-#: ../src/common/xtistrm.cpp:318
+#: ../src/common/xtixml.cpp:352 ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315
 msgid "Type must have enum - long conversion"
 msgstr "Ο τύπος πρέπει να έχει μετατροπή enum - long"
 
-#: ../src/propgrid/propgridiface.cpp:401
+#: ../src/propgrid/propgridiface.cpp:385
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
 "\"%s\"."
 msgstr ""
 
-#: ../src/common/paper.cpp:133
+#: ../src/common/paper.cpp:130
 msgid "US Std Fanfold, 14 7/8 x 11 in"
 msgstr "US Std Fanfold, 14 7/8 x 11 ίντσες"
 
-#: ../src/common/fmapbase.cpp:196
+#: ../src/common/fmapbase.cpp:193
 #, fuzzy
 msgid "US-ASCII"
 msgstr "ASCII"
 
-#: ../src/unix/fswatcher_inotify.cpp:109
+#: ../src/unix/fswatcher_inotify.cpp:106
 msgid "Unable to add inotify watch"
 msgstr ""
 
-#: ../src/unix/fswatcher_kqueue.cpp:136
+#: ../src/unix/fswatcher_kqueue.cpp:153
 msgid "Unable to add kqueue watch"
 msgstr ""
 
@@ -7645,7 +7805,7 @@ msgstr ""
 msgid "Unable to close I/O completion port handle"
 msgstr "Αποτυχία κλεισίματος του χειριστηρίου του αρχείου(file handle)"
 
-#: ../src/unix/fswatcher_inotify.cpp:97
+#: ../src/unix/fswatcher_inotify.cpp:94
 #, fuzzy
 msgid "Unable to close inotify instance"
 msgstr "Αποτυχία κλεισίματος του χειριστηρίου του αρχείου(file handle)"
@@ -7665,17 +7825,17 @@ msgstr "Αποτυχία κλεισίματος του χειριστηρίου 
 msgid "Unable to create I/O completion port"
 msgstr "Αποτυχία δημιουργίας δείκτη."
 
-#: ../src/msw/fswatcher.cpp:84
+#: ../src/msw/fswatcher.cpp:81
 #, fuzzy
 msgid "Unable to create IOCP worker thread"
 msgstr "Αποτυχία δημιουργίας ενός γονεικού περιγράμματος (parent frame) MDI."
 
-#: ../src/unix/fswatcher_inotify.cpp:74
+#: ../src/unix/fswatcher_inotify.cpp:71
 #, fuzzy
 msgid "Unable to create inotify instance"
 msgstr "Απέτυχε η δημιουργεία ενός DDE αλφαρηθμιτικού (string)"
 
-#: ../src/unix/fswatcher_kqueue.cpp:97
+#: ../src/unix/fswatcher_kqueue.cpp:114
 #, fuzzy
 msgid "Unable to create kqueue instance"
 msgstr "Απέτυχε η δημιουργεία ενός DDE αλφαρηθμιτικού (string)"
@@ -7684,11 +7844,11 @@ msgstr "Απέτυχε η δημιουργεία ενός DDE αλφαρηθμι
 msgid "Unable to dequeue completion packet"
 msgstr ""
 
-#: ../src/unix/fswatcher_kqueue.cpp:185
+#: ../src/unix/fswatcher_kqueue.cpp:202
 msgid "Unable to get events from kqueue"
 msgstr ""
 
-#: ../src/gtk/app.cpp:435
+#: ../src/gtk/app.cpp:431
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr ""
 
@@ -7697,12 +7857,12 @@ msgstr ""
 msgid "Unable to open path '%s'"
 msgstr "Αποτυχία ανοίγματος του arxe;ioy CHM '%s'."
 
-#: ../src/html/htmlwin.cpp:583
+#: ../src/html/htmlwin.cpp:586
 #, c-format
 msgid "Unable to open requested HTML document: %s"
 msgstr "Δεν είναι δυνατό το άνοιγμα εγγράφου HTML: %s"
 
-#: ../src/unix/sound.cpp:368
+#: ../src/unix/sound.cpp:365
 msgid "Unable to play sound asynchronously."
 msgstr "Αδύνατη η ασύγχρονη αναπαραγωγή ήχου."
 
@@ -7710,65 +7870,65 @@ msgstr "Αδύνατη η ασύγχρονη αναπαραγωγή ήχου."
 msgid "Unable to post completion status"
 msgstr ""
 
-#: ../src/unix/fswatcher_inotify.cpp:556
+#: ../src/unix/fswatcher_inotify.cpp:553
 #, fuzzy
 msgid "Unable to read from inotify descriptor"
 msgstr "αδύνατη η ανάγνωση από περiγραφέα (descriptor) αρχείου %d"
 
-#: ../src/unix/fswatcher_inotify.cpp:141
+#: ../src/unix/fswatcher_inotify.cpp:138
 #, fuzzy, c-format
 msgid "Unable to remove inotify watch %i"
 msgstr "Απέτυχε η δημιουργεία ενός DDE αλφαρηθμιτικού (string)"
 
-#: ../src/unix/fswatcher_kqueue.cpp:153
+#: ../src/unix/fswatcher_kqueue.cpp:170
 msgid "Unable to remove kqueue watch"
 msgstr ""
 
-#: ../src/msw/fswatcher.cpp:168
+#: ../src/msw/fswatcher.cpp:165
 #, fuzzy, c-format
 msgid "Unable to set up watch for '%s'"
 msgstr "Αποτυχία αγγίγματος (touch) του αρχείου '%s'"
 
-#: ../src/msw/fswatcher.cpp:91
+#: ../src/msw/fswatcher.cpp:88
 msgid "Unable to start IOCP worker thread"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:201
+#: ../src/common/stockitem.cpp:198
 msgid "Undelete"
 msgstr "Αναίρεση διαγραφής"
 
-#: ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199
 #, fuzzy
 msgid "Underline"
 msgstr "&Υπογράμμιση"
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/richtext/richtextfontpage.cpp:359 ../src/osx/carbon/fontdlg.cpp:370
-#: ../src/propgrid/advprops.cpp:690
+#: ../src/osx/carbon/fontdlg.cpp:367 ../src/propgrid/advprops.cpp:600
+#: ../src/richtext/richtextfontpage.cpp:359
 #, fuzzy
 msgid "Underlined"
 msgstr "&Υπογράμμιση"
 
-#: ../src/common/stockitem.cpp:203 ../src/stc/stc_i18n.cpp:15
+#: ../src/common/stockitem.cpp:200 ../src/stc/stc_i18n.cpp:15
 #, fuzzy
 msgid "Undo"
 msgstr "&Αναίρεση"
 
-#: ../src/common/stockitem.cpp:265
+#: ../src/common/stockitem.cpp:263
 msgid "Undo last action"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1029
+#: ../src/common/cmdline.cpp:1025
 #, fuzzy, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Απροσδόκητη παράμετρος '%s'"
 
-#: ../src/unix/fswatcher_inotify.cpp:274
+#: ../src/unix/fswatcher_inotify.cpp:271
 #, c-format
 msgid "Unexpected event for \"%s\": no matching watch descriptor."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1195
+#: ../src/common/cmdline.cpp:1191
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Απροσδόκητη παράμετρος '%s'"
@@ -7777,53 +7937,53 @@ msgstr "Απροσδόκητη παράμετρος '%s'"
 msgid "Unexpectedly new I/O completion port was created"
 msgstr ""
 
-#: ../src/msw/fswatcher.cpp:70
+#: ../src/msw/fswatcher.cpp:67
 #, fuzzy
 msgid "Ungraceful worker thread termination"
 msgstr ""
 "Δεν είναι δυνατή η αναμονή(wait) για τον τερματισμό του νήματος "
 "εκτέλεσης(thread)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:460
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:456
+#: ../src/richtext/richtextsymboldlg.cpp:457
+#: ../src/richtext/richtextsymboldlg.cpp:458
 #, fuzzy
 msgid "Unicode"
 msgstr "Α&ποστοίχιση"
 
-#: ../src/common/fmapbase.cpp:185 ../src/common/fmapbase.cpp:191
+#: ../src/common/fmapbase.cpp:182 ../src/common/fmapbase.cpp:188
 msgid "Unicode 16 bit (UTF-16)"
 msgstr "Unicode 16 bit (UTF-16)"
 
-#: ../src/common/fmapbase.cpp:190
+#: ../src/common/fmapbase.cpp:187
 msgid "Unicode 16 bit Big Endian (UTF-16BE)"
 msgstr "Unicode 16 bit Big Endian (UTF-16BE)"
 
-#: ../src/common/fmapbase.cpp:186
+#: ../src/common/fmapbase.cpp:183
 msgid "Unicode 16 bit Little Endian (UTF-16LE)"
 msgstr "Unicode 16 bit Little Endian (UTF-16LE)"
 
-#: ../src/common/fmapbase.cpp:187 ../src/common/fmapbase.cpp:193
+#: ../src/common/fmapbase.cpp:184 ../src/common/fmapbase.cpp:190
 msgid "Unicode 32 bit (UTF-32)"
 msgstr "Unicode 32 bit (UTF-32)"
 
-#: ../src/common/fmapbase.cpp:192
+#: ../src/common/fmapbase.cpp:189
 msgid "Unicode 32 bit Big Endian (UTF-32BE)"
 msgstr "Unicode 32 bit Big Endian (UTF-32BE)"
 
-#: ../src/common/fmapbase.cpp:188
+#: ../src/common/fmapbase.cpp:185
 msgid "Unicode 32 bit Little Endian (UTF-32LE)"
 msgstr "Unicode 32 bit Little Endian (UTF-32LE)"
 
-#: ../src/common/fmapbase.cpp:182
+#: ../src/common/fmapbase.cpp:179
 msgid "Unicode 7 bit (UTF-7)"
 msgstr "Unicode 7 bit (UTF-7)"
 
-#: ../src/common/fmapbase.cpp:183
+#: ../src/common/fmapbase.cpp:180
 msgid "Unicode 8 bit (UTF-8)"
 msgstr "Unicode 8 bit (UTF-8)"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 #, fuzzy
 msgid "Unindent"
 msgstr "Α&ποστοίχιση"
@@ -7999,101 +8159,106 @@ msgstr ""
 "Δεν είναι δυνατή η αναμονή(wait) για τον τερματισμό του νήματος "
 "εκτέλεσης(thread)"
 
-#: ../src/generic/progdlgg.cpp:353 ../src/generic/progdlgg.cpp:622
+#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
 #, fuzzy
 msgid "Unknown"
 msgstr "άγνωστο"
 
-#: ../src/msw/dde.cpp:1174
+#: ../src/msw/dde.cpp:1238
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "’γνωστο σφάλμα DDE %08x"
 
-#: ../src/common/xtistrm.cpp:410
+#: ../src/common/xtistrm.cpp:407
 msgid "Unknown Object passed to GetObjectClassInfo"
 msgstr "’γνωστο αντικείμενο δόθηκε στην GetObjectClassInfo"
 
-#: ../src/common/imagpng.cpp:366
+#: ../src/common/imagpng.cpp:383
 #, fuzzy, c-format
 msgid "Unknown PNG resolution unit %d"
 msgstr "’γνωστη επιλογή '%s'"
 
-#: ../src/common/xtixml.cpp:327
+#: ../src/common/xtixml.cpp:323
 #, fuzzy, c-format
 msgid "Unknown Property %s"
 msgstr "’γνωστη Ιδιότητα %s"
 
-#: ../src/common/imagtiff.cpp:529
+#: ../src/common/imagtiff.cpp:526
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr ""
 
-#: ../src/unix/dlunix.cpp:160
+#: ../src/propgrid/props.cpp:155
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/unix/dlunix.cpp:118
 msgid "Unknown dynamic library error"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:810
+#: ../src/common/fmapbase.cpp:806
 #, c-format
 msgid "Unknown encoding (%d)"
 msgstr "’γνωστη κωδικοποίηση (%d)"
 
-#: ../src/msw/ole/automtn.cpp:688
+#: ../src/msw/ole/automtn.cpp:679
 #, fuzzy, c-format
 msgid "Unknown error %08x"
 msgstr "’γνωστο σφάλμα DDE %08x"
 
-#: ../src/msw/ole/automtn.cpp:647
+#: ../src/msw/ole/automtn.cpp:638
 #, fuzzy
 msgid "Unknown exception"
 msgstr "’γνωστη επιλογή '%s'"
 
-#: ../src/common/image.cpp:2839
+#: ../src/common/image.cpp:2942
 #, fuzzy
 msgid "Unknown image data format."
 msgstr "σφάλμα στη μορφή των δεδομένων"
 
-#: ../src/common/cmdline.cpp:914
+#: ../src/common/cmdline.cpp:910
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "’γνωστη επιλογή long '%s'"
 
-#: ../src/msw/ole/automtn.cpp:631
+#: ../src/msw/ole/automtn.cpp:622
 msgid "Unknown name or named argument."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:929 ../src/common/cmdline.cpp:951
+#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "’γνωστη επιλογή '%s'"
 
-#: ../src/common/mimecmn.cpp:225
+#: ../src/common/mimecmn.cpp:221
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "Αταίριαστο '{' σε μία είσοδο (entry) για τον τύπο mime %s."
 
-#: ../src/common/cmdproc.cpp:262 ../src/common/cmdproc.cpp:288
-#: ../src/common/cmdproc.cpp:308
+#: ../src/common/cmdproc.cpp:255 ../src/common/cmdproc.cpp:281
+#: ../src/common/cmdproc.cpp:301
 msgid "Unnamed command"
 msgstr "Ανώνυμη εντολή"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:413
+#: ../src/propgrid/propgrid.cpp:392
 #, fuzzy
 msgid "Unspecified"
 msgstr "Ευθυγραμμισμένα"
 
-#: ../src/msw/clipbrd.cpp:311
+#: ../src/msw/clipbrd.cpp:325
 msgid "Unsupported clipboard format."
 msgstr "Δεν υποστηρίζεται ο τύπος προχείρου(clipboard format)."
 
-#: ../src/common/appcmn.cpp:256
+#: ../src/common/appcmn.cpp:277
 #, c-format
 msgid "Unsupported theme '%s'."
 msgstr "Το θέμα '%s' δεν υποστηρίζεται."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:205
-#: ../src/common/accelcmn.cpp:63
+#: ../src/common/stockitem.cpp:202 ../src/common/accelcmn.cpp:60
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Up"
 msgstr "Επάνω"
 
@@ -8107,7 +8272,7 @@ msgstr ""
 msgid "Upper case roman numerals"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1326
+#: ../src/common/cmdline.cpp:1322
 #, c-format
 msgid "Usage: %s"
 msgstr "Χρήση: %s"
@@ -8116,38 +8281,47 @@ msgstr "Χρήση: %s"
 msgid "Use &shadow"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:169
-#: ../src/richtext/richtextindentspage.cpp:171
 #: ../src/richtext/richtextliststylepage.cpp:358
 #: ../src/richtext/richtextliststylepage.cpp:360
+#: ../src/richtext/richtextindentspage.cpp:169
+#: ../src/richtext/richtextindentspage.cpp:171
 msgid "Use the current alignment setting."
 msgstr ""
 
-#: ../src/common/valtext.cpp:179
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/gtk/font.cpp:552
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/common/valtext.cpp:142
 msgid "Validation conflict"
 msgstr "Σύγκρουση επικύρωσης (validation conflict)"
 
-#: ../src/propgrid/manager.cpp:238
+#: ../src/propgrid/manager.cpp:224
 msgid "Value"
 msgstr ""
 
-#: ../src/propgrid/props.cpp:386 ../src/propgrid/props.cpp:500
+#: ../src/propgrid/props.cpp:309
 #, c-format
 msgid "Value must be %s or higher."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:417 ../src/propgrid/props.cpp:531
+#: ../src/propgrid/props.cpp:336
 #, c-format
 msgid "Value must be %s or less."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:393 ../src/propgrid/props.cpp:424
-#: ../src/propgrid/props.cpp:507 ../src/propgrid/props.cpp:538
+#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
 #, fuzzy, c-format
 msgid "Value must be between %s and %s."
 msgstr "Δώστε έναν αριθμό σελίδας μεταξύ %d και %d:"
 
-#: ../src/generic/aboutdlgg.cpp:128
+#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
 #, fuzzy
 msgid "Version "
 msgstr "Δικαιώματα"
@@ -8158,25 +8332,32 @@ msgstr "Δικαιώματα"
 msgid "Vertical alignment."
 msgstr "Δεν ήταν δυνατή η εκκίνηση της εκτύπωσης."
 
-#: ../src/generic/filedlgg.cpp:202
+#: ../src/generic/filedlgg.cpp:199
 msgid "View files as a detailed view"
 msgstr "Εμφάνιση αρχείων σε προβολή με λεπτομέρειες"
 
-#: ../src/generic/filedlgg.cpp:200
+#: ../src/generic/filedlgg.cpp:197
 msgid "View files as a list view"
 msgstr "Εμφάνιση αρχείων σε προβολή λίστας"
 
-#: ../src/common/docview.cpp:1970
+#: ../src/common/docview.cpp:1975
 msgid "Views"
 msgstr "Προβολές"
 
+#: ../src/gtk/app.cpp:348
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1777
+#: ../src/propgrid/advprops.cpp:1678
 msgid "Wait"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1779
+#: ../src/propgrid/advprops.cpp:1680
 msgid "Wait Arrow"
 msgstr ""
 
@@ -8185,255 +8366,251 @@ msgstr ""
 msgid "Waiting for IO on epoll descriptor %d failed"
 msgstr "Η αναμονή για τον τερματισμό υπο-διεργασίας (subprocess) απέτυχε"
 
-#: ../src/common/log.cpp:223
+#: ../src/common/log.cpp:241
 msgid "Warning: "
 msgstr "Προειδοποίηση: "
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1778
+#: ../src/propgrid/advprops.cpp:1679
 msgid "Watch"
 msgstr ""
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:685
+#: ../src/propgrid/advprops.cpp:595
 #, fuzzy
 msgid "Weight"
 msgstr "&Βάρος:"
 
-#: ../src/common/fmapbase.cpp:148
+#: ../src/common/fmapbase.cpp:145
 msgid "Western European (ISO-8859-1)"
 msgstr "Δυτικο-Ευρωπαϊκό (ISO-8859-1)"
 
-#: ../src/common/fmapbase.cpp:162
+#: ../src/common/fmapbase.cpp:159
 msgid "Western European with Euro (ISO-8859-15)"
 msgstr "Δυτικο-Ευρωπαϊκό με Euro (ISO-8859-15)"
 
-#: ../src/generic/fontdlgg.cpp:446 ../src/generic/fontdlgg.cpp:448
+#: ../src/generic/fontdlgg.cpp:443 ../src/generic/fontdlgg.cpp:445
 msgid "Whether the font is underlined."
 msgstr "Επιλογή εαν η γραμματοσειρά είναι υπογραμμισμένη ή όχι."
 
-#: ../src/propgrid/advprops.cpp:1611
+#: ../src/propgrid/advprops.cpp:1517
 msgid "White"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:144
+#: ../src/generic/fdrepdlg.cpp:141
 msgid "Whole word"
 msgstr "Ολόκληρη λέξη"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:532
 msgid "Whole words only"
 msgstr "Ολόκληρες λέξεις μόνο"
 
-#: ../src/univ/themes/win32.cpp:1102
+#: ../src/univ/themes/win32.cpp:1099
 msgid "Win32 theme"
 msgstr "Win32 θέμα"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:893
+#: ../src/propgrid/advprops.cpp:794
 #, fuzzy
 msgid "Window"
 msgstr "&Παράθυρο"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:894
+#: ../src/propgrid/advprops.cpp:795
 #, fuzzy
 msgid "WindowFrame"
 msgstr "&Παράθυρο"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:895
+#: ../src/propgrid/advprops.cpp:796
 #, fuzzy
 msgid "WindowText"
 msgstr "&Παράθυρο"
 
-#: ../src/common/fmapbase.cpp:177
+#: ../src/common/fmapbase.cpp:174
 msgid "Windows Arabic (CP 1256)"
 msgstr "Windows Αραβικό (CP 1256)"
 
-#: ../src/common/fmapbase.cpp:178
+#: ../src/common/fmapbase.cpp:175
 msgid "Windows Baltic (CP 1257)"
 msgstr "Windows Βαλτικό (CP 1257)"
 
-#: ../src/common/fmapbase.cpp:171
+#: ../src/common/fmapbase.cpp:168
 msgid "Windows Central European (CP 1250)"
 msgstr "Windows Κεντρο-Ευρωπαϊκό (CP 1250)"
 
-#: ../src/common/fmapbase.cpp:168
+#: ../src/common/fmapbase.cpp:165
 #, fuzzy
 msgid "Windows Chinese Simplified (CP 936) or GB-2312"
 msgstr "Windows Απλοποιημένο Κινέζικο (CP 936)"
 
-#: ../src/common/fmapbase.cpp:170
+#: ../src/common/fmapbase.cpp:167
 #, fuzzy
 msgid "Windows Chinese Traditional (CP 950) or Big-5"
 msgstr "Windows Παραδοσιακό Κινέζικο (CP 950)"
 
-#: ../src/common/fmapbase.cpp:172
+#: ../src/common/fmapbase.cpp:169
 msgid "Windows Cyrillic (CP 1251)"
 msgstr "Windows Κυριλικό (CP 1251)"
 
-#: ../src/common/fmapbase.cpp:174
+#: ../src/common/fmapbase.cpp:171
 msgid "Windows Greek (CP 1253)"
 msgstr "Windows Ελληνικό (CP 1253)"
 
-#: ../src/common/fmapbase.cpp:176
+#: ../src/common/fmapbase.cpp:173
 msgid "Windows Hebrew (CP 1255)"
 msgstr "Windows Εβραϊκό (CP 1255)"
 
-#: ../src/common/fmapbase.cpp:167
+#: ../src/common/fmapbase.cpp:164
 #, fuzzy
 msgid "Windows Japanese (CP 932) or Shift-JIS"
 msgstr "Windows Ιαπωνικό (CP 932)"
 
-#: ../src/common/fmapbase.cpp:180
+#: ../src/common/fmapbase.cpp:177
 #, fuzzy
 msgid "Windows Johab (CP 1361)"
 msgstr "Windows Αραβικό (CP 1256)"
 
-#: ../src/common/fmapbase.cpp:169
+#: ../src/common/fmapbase.cpp:166
 msgid "Windows Korean (CP 949)"
 msgstr "Windows Κορεάτικο (CP 949)"
 
-#: ../src/common/fmapbase.cpp:166
+#: ../src/common/fmapbase.cpp:163
 #, fuzzy
 msgid "Windows Thai (CP 874)"
 msgstr "Windows Βαλτικό (CP 1257)"
 
-#: ../src/common/fmapbase.cpp:175
+#: ../src/common/fmapbase.cpp:172
 msgid "Windows Turkish (CP 1254)"
 msgstr "Windows Τουρκικό (CP 1254)"
 
-#: ../src/common/fmapbase.cpp:179
+#: ../src/common/fmapbase.cpp:176
 #, fuzzy
 msgid "Windows Vietnamese (CP 1258)"
 msgstr "Windows Ελληνικό (CP 1253)"
 
-#: ../src/common/fmapbase.cpp:173
+#: ../src/common/fmapbase.cpp:170
 msgid "Windows Western European (CP 1252)"
 msgstr "Windows Δυτικο-Ευρωπαϊκό (CP 1252)"
 
-#: ../src/common/fmapbase.cpp:181
+#: ../src/common/fmapbase.cpp:178
 msgid "Windows/DOS OEM (CP 437)"
 msgstr "Windows/DOS OEM (CP 437)"
 
-#: ../src/common/fmapbase.cpp:165
+#: ../src/common/fmapbase.cpp:162
 #, fuzzy
 msgid "Windows/DOS OEM Cyrillic (CP 866)"
 msgstr "Windows Κυριλικό (CP 1251)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:111
+#: ../src/common/accelcmn.cpp:109
 #, fuzzy
 msgid "Windows_Left"
 msgstr "Windows 95"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:113
+#: ../src/common/accelcmn.cpp:111
 #, fuzzy
 msgid "Windows_Menu"
 msgstr "Windows ME"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:112
+#: ../src/common/accelcmn.cpp:110
 #, fuzzy
 msgid "Windows_Right"
 msgstr "Windows 95"
 
-#: ../src/common/ffile.cpp:150
+#: ../src/common/ffile.cpp:149
 #, c-format
 msgid "Write error on file '%s'"
 msgstr "Σφάλμα εγγραφής (write error) στο αρχείο '%s'"
 
-#: ../src/xml/xml.cpp:914
+#: ../src/xml/xml.cpp:925
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "XML σφάλμα ανάγνωσης (parsing error): '%s' στη γραμμή %d"
 
-#: ../src/common/xpmdecod.cpp:796
+#: ../src/common/xpmdecod.cpp:794
 msgid "XPM: Malformed pixel data!"
 msgstr "XPM: Κακοσχηματισμένα δεδομένα εικονοστοιχείων (pixel)!"
 
-#: ../src/common/xpmdecod.cpp:705
+#: ../src/common/xpmdecod.cpp:702
 #, fuzzy, c-format
 msgid "XPM: incorrect colour description in line %d"
 msgstr "XPM: κακοσχηματισμένος ορισμός χρώματος '%s'!"
 
-#: ../src/common/xpmdecod.cpp:680
+#: ../src/common/xpmdecod.cpp:677
 msgid "XPM: incorrect header format!"
 msgstr ""
 
-#: ../src/common/xpmdecod.cpp:716 ../src/common/xpmdecod.cpp:725
+#: ../src/common/xpmdecod.cpp:714 ../src/common/xpmdecod.cpp:723
 #, fuzzy, c-format
 msgid "XPM: malformed colour definition '%s' at line %d!"
 msgstr "XPM: κακοσχηματισμένος ορισμός χρώματος '%s'!"
 
-#: ../src/common/xpmdecod.cpp:755
+#: ../src/common/xpmdecod.cpp:753
 msgid "XPM: no colors left to use for mask!"
 msgstr ""
 
-#: ../src/common/xpmdecod.cpp:782
+#: ../src/common/xpmdecod.cpp:780
 #, c-format
 msgid "XPM: truncated image data at line %d!"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1610
+#: ../src/propgrid/advprops.cpp:1516
 msgid "Yellow"
 msgstr ""
 
-#: ../include/wx/msgdlg.h:276 ../src/common/stockitem.cpp:206
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:203
 #: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Ναι"
 
-#: ../src/osx/carbon/overlay.cpp:155
-#, fuzzy
-msgid "You cannot Clear an overlay that is not inited"
-msgstr "Δεν μπορείτε να προσθέσετε καινούργιο κατάλογο σε αυτό το τμήμα."
-
-#: ../src/osx/carbon/overlay.cpp:107 ../src/dfb/overlay.cpp:61
-msgid "You cannot Init an overlay twice"
-msgstr ""
-
-#: ../src/generic/dirdlgg.cpp:287
+#: ../src/generic/dirdlgg.cpp:284
 msgid "You cannot add a new directory to this section."
 msgstr "Δεν μπορείτε να προσθέσετε καινούργιο κατάλογο σε αυτό το τμήμα."
 
-#: ../src/propgrid/propgrid.cpp:3299
+#: ../src/propgrid/propgrid.cpp:3276
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:209
+#: ../src/osx/cocoa/menu.mm:286
+#, fuzzy
+msgid "Zoom"
+msgstr "&Αύξηση ζουμ"
+
+#: ../src/common/stockitem.cpp:206
 msgid "Zoom &In"
 msgstr "&Αύξηση ζουμ"
 
-#: ../src/common/stockitem.cpp:210
+#: ../src/common/stockitem.cpp:207
 msgid "Zoom &Out"
 msgstr "&Ελάττωση ζουμ"
 
-#: ../src/common/stockitem.cpp:209 ../src/common/prntbase.cpp:1594
+#: ../src/common/stockitem.cpp:206 ../src/common/prntbase.cpp:1619
 #, fuzzy
 msgid "Zoom In"
 msgstr "&Αύξηση ζουμ"
 
-#: ../src/common/stockitem.cpp:210 ../src/common/prntbase.cpp:1580
+#: ../src/common/stockitem.cpp:207 ../src/common/prntbase.cpp:1605
 #, fuzzy
 msgid "Zoom Out"
 msgstr "&Ελάττωση ζουμ"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to &Fit"
 msgstr "Βέλτιστο ζουμ"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 #, fuzzy
 msgid "Zoom to Fit"
 msgstr "Βέλτιστο ζουμ"
 
-#: ../src/msw/dde.cpp:1141
+#: ../src/msw/dde.cpp:1205
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "μια DDEML εφαρμογή έχει δημιουργήσει έναν παρατεταμένο race condition."
 
-#: ../src/msw/dde.cpp:1129
+#: ../src/msw/dde.cpp:1193
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -8445,51 +8622,51 @@ msgstr ""
 "ή ένα λανθασμένο αναγνωριστικό(identifier) instance\n"
 "δόθηκε σε μια DDEML συνάρτηση(function)."
 
-#: ../src/msw/dde.cpp:1147
+#: ../src/msw/dde.cpp:1211
 msgid "a client's attempt to establish a conversation has failed."
 msgstr ""
 "η προσπάθεια ενός πελάτη(client) να εδραιώσει(establish) μία "
 "συνδιάλεξη(conversation) απέτυχε."
 
-#: ../src/msw/dde.cpp:1144
+#: ../src/msw/dde.cpp:1208
 msgid "a memory allocation failed."
 msgstr "μία προσπάθεια δέσμευσης (allocation) μνήμης απέτυχε."
 
-#: ../src/msw/dde.cpp:1138
+#: ../src/msw/dde.cpp:1202
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "απέτυχε η επικύρωση μιας παραμέτρου από το DDEML."
 
-#: ../src/msw/dde.cpp:1120
+#: ../src/msw/dde.cpp:1184
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr ""
 "μία αίτηση για σύγχρονη(synchronous) ενημερωτική(advise) "
 "συναλλαγή(transaction) ξεπέρασε το χρονικό περιθώριο (timed out)"
 
-#: ../src/msw/dde.cpp:1126
+#: ../src/msw/dde.cpp:1190
 msgid "a request for a synchronous data transaction has timed out."
 msgstr ""
 "μία αίτηση για σύγχρονη(synchronous) συναλλαγή(transaction) δεδομένων(data) "
 "ξεπέρασε το χρονικό περιθώριο (timed out)"
 
-#: ../src/msw/dde.cpp:1135
+#: ../src/msw/dde.cpp:1199
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr ""
 "μία αίτηση για σύγχρονη(synchronous) συναλλαγή(transaction) "
 "εκτέλεσης(execute) ξεπέρασε το χρονικό περιθώριο (timed out)"
 
-#: ../src/msw/dde.cpp:1153
+#: ../src/msw/dde.cpp:1217
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr ""
 "μία αίτηση για σύγχρονη(synchronous) poke συναλλαγή(transaction) ξεπέρασε το "
 "χρονικό περιθώριο (timed out)"
 
-#: ../src/msw/dde.cpp:1168
+#: ../src/msw/dde.cpp:1232
 msgid "a request to end an advise transaction has timed out."
 msgstr ""
 "μία αίτηση για τερματισμό μιας ενημερωτικής(advise) συναλλαγής(transaction) "
 "ξεπέρασε το χρονικό περιθώριο (timed out)"
 
-#: ../src/msw/dde.cpp:1162
+#: ../src/msw/dde.cpp:1226
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -8500,15 +8677,15 @@ msgstr ""
 "που είχε τερματιστεί από τον πελάτη(client), ή ο εξυπηρετητής (server)\n"
 "τερμάτισε πριν ολοκληρωθεί μια συναλλαγή( transaction)."
 
-#: ../src/msw/dde.cpp:1150
+#: ../src/msw/dde.cpp:1214
 msgid "a transaction failed."
 msgstr "μία συναλλαγή (transaction) απέτυχε."
 
-#: ../src/common/accelcmn.cpp:189
+#: ../src/common/accelcmn.cpp:188
 msgid "alt"
 msgstr "alt"
 
-#: ../src/msw/dde.cpp:1132
+#: ../src/msw/dde.cpp:1196
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -8520,15 +8697,15 @@ msgstr ""
 "ή μία εφαρμογή που αρχικοποιήθηκε ως APPCMD_CLIENTONLY\n"
 "προσπάθησε να κάνει συναλλαγές εξυπηρετητή (server transactions)."
 
-#: ../src/msw/dde.cpp:1156
+#: ../src/msw/dde.cpp:1220
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "μία εσωτερική κλήση στην συνάρτηση (function) PostMessage απέτυχε."
 
-#: ../src/msw/dde.cpp:1165
+#: ../src/msw/dde.cpp:1229
 msgid "an internal error has occurred in the DDEML."
 msgstr "ένα εσωτερικό λάθος συνέβη στο DDEML."
 
-#: ../src/msw/dde.cpp:1171
+#: ../src/msw/dde.cpp:1235
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -8539,56 +8716,56 @@ msgstr ""
 "Όταν η εφαρμογή επιστρέψει από ένα XTYP_XACT_COMPLETE callback,\n"
 "το αναγνωριστικό συναλλαγής για εκείνο το callback δεν θα είναι πλέον έγκυρο."
 
-#: ../src/common/zipstrm.cpp:1483
+#: ../src/common/zipstrm.cpp:1522
 msgid "assuming this is a multi-part zip concatenated"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1847
+#: ../src/common/fileconf.cpp:1849
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "η προσπάθεια αλλαγής αμετάβλητου κλειδιού '%s' αγνοήθηκε."
 
-#: ../src/html/chm.cpp:329
+#: ../src/html/chm.cpp:326
 msgid "bad arguments to library function"
 msgstr "λανθασμένες παράμετροι σε συνάρτηση βιβλιοθήκης"
 
-#: ../src/html/chm.cpp:341
+#: ../src/html/chm.cpp:338
 msgid "bad signature"
 msgstr "κακή σήμανση"
 
-#: ../src/common/zipstrm.cpp:1918
+#: ../src/common/zipstrm.cpp:1988
 msgid "bad zipfile offset to entry"
 msgstr ""
 
-#: ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400
 msgid "binary"
 msgstr "δυαδικό"
 
-#: ../src/common/fontcmn.cpp:996
+#: ../src/common/fontcmn.cpp:1195
 msgid "bold"
 msgstr "έντονο"
 
-#: ../src/msw/utils.cpp:1144
+#: ../src/msw/utils.cpp:1135
 #, c-format
 msgid "build %lu"
 msgstr ""
 
-#: ../src/common/ffile.cpp:75
+#: ../src/common/ffile.cpp:73
 #, c-format
 msgid "can't close file '%s'"
 msgstr "δεν είναι δυνατό το κλείσιμο του αρχείου '%s'"
 
-#: ../src/common/file.cpp:245
+#: ../src/common/file.cpp:242
 #, c-format
 msgid "can't close file descriptor %d"
 msgstr "αδύνατο το κλείσιμο περιγραφέα (descriptor) αρχείου %d"
 
-#: ../src/common/file.cpp:586
+#: ../src/common/ffile.cpp:382 ../src/common/file.cpp:613
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "αδύνατη η δέσμευση των αλλαγών στο αρχείο '%s'"
 
-#: ../src/common/file.cpp:178
+#: ../src/common/file.cpp:175
 #, c-format
 msgid "can't create file '%s'"
 msgstr "δεν είναι δυνατή η δημιουργία του αρχείου '%s'"
@@ -8598,58 +8775,58 @@ msgstr "δεν είναι δυνατή η δημιουργία του αρχεί
 msgid "can't delete user configuration file '%s'"
 msgstr "Δεν είναι δυνατή η διαγραφή του αρχείου ρυθμίσεων '%s' του χρήστη"
 
-#: ../src/common/file.cpp:495
+#: ../src/common/file.cpp:522
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr ""
 "αδύνατο να καθοριστεί εαν το τέλος αρχείου του έχει φτάσει στο περιγραφέα "
 "(descriptor) %d"
 
-#: ../src/common/zipstrm.cpp:1692
+#: ../src/common/zipstrm.cpp:1747
 msgid "can't find central directory in zip"
 msgstr ""
 "Δεν είναι δυνατή η εύρεση του κεντρικού καταλόγου στο συμπιεσμένο αρχείο"
 
-#: ../src/common/file.cpp:465
+#: ../src/common/file.cpp:492
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr ""
 "αδύνατη η εύρεση του μεγέθους αρχείου στον περιγραφέα αρχείου (file "
 "desciptor) %d"
 
-#: ../src/msw/utils.cpp:341
+#: ../src/msw/utils.cpp:336
 msgid "can't find user's HOME, using current directory."
 msgstr ""
 "αδύνατη η εύρεση του HOME του χρήστη, γίνεται χρήση τρέχοντος καταλόγου."
 
-#: ../src/common/file.cpp:366
+#: ../src/common/file.cpp:407
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr ""
 "δεν μπορεί να πραγματοποιηθεί το άδειασμα (flush) του περιγραφέα αρχείου %d"
 
-#: ../src/common/file.cpp:422
+#: ../src/common/file.cpp:463
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr ""
 "αδύνατη η λήψη θέσης αναζήτησης (seek position) στον περιγραφέα(descriptor) "
 "αρχείου %d"
 
-#: ../src/common/fontmap.cpp:325
+#: ../src/common/fontmap.cpp:322
 msgid "can't load any font, aborting"
 msgstr "αδύνατη η φόρτωση οποιασδήποτε γραμματοσειράς, γίνεται ματαίωση"
 
-#: ../src/common/file.cpp:231 ../src/common/ffile.cpp:59
+#: ../src/common/ffile.cpp:57 ../src/common/file.cpp:228
 #, c-format
 msgid "can't open file '%s'"
 msgstr "δεν είναι δυνατό το άνοιγμα του αρχείου '%s'"
 
-#: ../src/common/fileconf.cpp:320
+#: ../src/common/fileconf.cpp:314
 #, c-format
 msgid "can't open global configuration file '%s'."
 msgstr "δεν είναι δυνατό το άνοιγμα του γενικού(global) αρχείου ρυθμίσεων %s"
 
-#: ../src/common/fileconf.cpp:336
+#: ../src/common/fileconf.cpp:330
 #, c-format
 msgid "can't open user configuration file '%s'."
 msgstr "δεν είναι δυνατό το άνοιγμα του αρχείου ρυθμίσεων '%s' του χρήστη"
@@ -8658,40 +8835,40 @@ msgstr "δεν είναι δυνατό το άνοιγμα του αρχείου
 msgid "can't open user configuration file."
 msgstr "αδύνατο το άνοιγμα αρχείου ρυθμίσεων του χρήστη."
 
-#: ../src/common/zipstrm.cpp:579
+#: ../src/common/zipstrm.cpp:572
 msgid "can't re-initialize zlib deflate stream"
 msgstr "Δεν είναι δυνατή η αρχικοποίηση της ροής zlib deflate."
 
-#: ../src/common/zipstrm.cpp:604
+#: ../src/common/zipstrm.cpp:597
 msgid "can't re-initialize zlib inflate stream"
 msgstr "Δεν είναι δυνατή η αρχικοποίηση της ροής zlib inflate."
 
-#: ../src/common/file.cpp:304
+#: ../src/common/file.cpp:345
 #, c-format
 msgid "can't read from file descriptor %d"
 msgstr "αδύνατη η ανάγνωση από περiγραφέα (descriptor) αρχείου %d"
 
-#: ../src/common/file.cpp:581
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:608
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "δεν είναι δυνατό το σβήσιμο του αρχείου '%s'"
 
-#: ../src/common/file.cpp:598
+#: ../src/common/ffile.cpp:394 ../src/common/file.cpp:625
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "δεν είναι δυνατό το σβήσιμο του προσωρινού αρχείου '%s'"
 
-#: ../src/common/file.cpp:408
+#: ../src/common/file.cpp:449
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "αδύνατη η αναζήτηση(seek) στον περγραφέα(descriptor) αρχείου %d"
 
-#: ../src/common/textfile.cpp:273
+#: ../src/common/textfile.cpp:161
 #, c-format
 msgid "can't write buffer '%s' to disk."
 msgstr "αδύνατη η εγγραφή της προσωρινής μνήμης (buffer) '%s' στο δίσκο."
 
-#: ../src/common/file.cpp:323
+#: ../src/common/file.cpp:364
 #, c-format
 msgid "can't write to file descriptor %d"
 msgstr "δεν είναι δυνατή η εγγραφή του περιγραφέα αρχείου(file descriptor) %d"
@@ -8701,22 +8878,28 @@ msgid "can't write user configuration file."
 msgstr "Αδύνατη η εγγραφή αρχείου ρυθμίσεων χρήστη."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:482 ../src/generic/datavgen.cpp:1261
+#: ../src/common/datavcmn.cpp:2064 ../src/generic/datavgen.cpp:1384
 msgid "checked"
 msgstr ""
 
-#: ../src/html/chm.cpp:345
+#: ../src/html/chm.cpp:342
 msgid "checksum error"
 msgstr "σφάλμα checksum"
 
-#: ../src/common/tarstrm.cpp:820
+#: ../src/common/tarstrm.cpp:814
 msgid "checksum failure reading tar header block"
 msgstr ""
 
-#: ../src/richtext/richtextbackgroundpage.cpp:226
-#: ../src/richtext/richtextbackgroundpage.cpp:249
-#: ../src/richtext/richtextbackgroundpage.cpp:289
-#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
 #: ../src/richtext/richtextborderspage.cpp:254
 #: ../src/richtext/richtextborderspage.cpp:288
 #: ../src/richtext/richtextborderspage.cpp:322
@@ -8734,105 +8917,128 @@ msgstr ""
 #: ../src/richtext/richtextmarginspage.cpp:340
 #: ../src/richtext/richtextmarginspage.cpp:363
 #: ../src/richtext/richtextmarginspage.cpp:388
-#: ../src/richtext/richtextsizepage.cpp:339
-#: ../src/richtext/richtextsizepage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:400
-#: ../src/richtext/richtextsizepage.cpp:427
-#: ../src/richtext/richtextsizepage.cpp:454
-#: ../src/richtext/richtextsizepage.cpp:481
-#: ../src/richtext/richtextsizepage.cpp:555
-#: ../src/richtext/richtextsizepage.cpp:590
-#: ../src/richtext/richtextsizepage.cpp:625
-#: ../src/richtext/richtextsizepage.cpp:660
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
 msgid "cm"
 msgstr ""
 
-#: ../src/html/chm.cpp:347
+#: ../src/html/chm.cpp:344
 msgid "compression error"
 msgstr "σφάλμα συμπίεσης"
 
-#: ../src/common/regex.cpp:236
+#: ../src/common/regex.cpp:233
 msgid "conversion to 8-bit encoding failed"
 msgstr "η μετατροπή σε 8-bit κωδικοποίηση απέτυχε"
 
-#: ../src/common/accelcmn.cpp:187
+#: ../src/common/accelcmn.cpp:186
 msgid "ctrl"
 msgstr "ctrl"
 
-#: ../src/common/cmdline.cpp:1500
+#: ../src/common/cmdline.cpp:1496
 msgid "date"
 msgstr "ημερομηνία"
 
-#: ../src/html/chm.cpp:349
+#: ../src/html/chm.cpp:346
 msgid "decompression error"
 msgstr "σφάλμα αποσυμπίεσης"
 
-#: ../src/richtext/richtextstyles.cpp:780 ../src/common/fmapbase.cpp:820
+#: ../src/common/fmapbase.cpp:816 ../src/richtext/richtextstyles.cpp:777
 msgid "default"
 msgstr "προκαθορισμένο"
 
-#: ../src/common/cmdline.cpp:1496
+#: ../src/common/cmdline.cpp:1492
 msgid "double"
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:538
+#: ../src/common/debugrpt.cpp:539
 msgid "dump of the process state (binary)"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1969
+#: ../src/common/datetimefmt.cpp:1992
 msgid "eighteenth"
 msgstr "δέκατο όγδοο"
 
-#: ../src/common/datetimefmt.cpp:1959
+#: ../src/common/datetimefmt.cpp:1982
 msgid "eighth"
 msgstr "όγδοο"
 
-#: ../src/common/datetimefmt.cpp:1962
+#: ../src/common/datetimefmt.cpp:1985
 msgid "eleventh"
 msgstr "έβδομο"
 
-#: ../src/common/fileconf.cpp:1833
+#: ../src/common/fileconf.cpp:1835
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "η εισαγωγή(entry) '%s' εμφανίζεται πάνω από μία φορά στο γκρούπ '%s'"
 
-#: ../src/html/chm.cpp:343
+#: ../src/html/chm.cpp:340
 msgid "error in data format"
 msgstr "σφάλμα στη μορφή των δεδομένων"
 
-#: ../src/html/chm.cpp:331
+#: ../src/html/chm.cpp:328
 msgid "error opening file"
 msgstr "σφάλμα κατά το άνοιγμα του αρχείου"
 
-#: ../src/common/zipstrm.cpp:1778
+#: ../src/common/zipstrm.cpp:1836
 msgid "error reading zip central directory"
 msgstr "σφάλμα κατα την ανάγνωση κεντρικού καταλόγου στο συμπιεσμένο αρχείο"
 
-#: ../src/common/zipstrm.cpp:1870
+#: ../src/common/zipstrm.cpp:1940
 msgid "error reading zip local header"
 msgstr "σφάλμα κατά την ανάγνωση τοπικής κεφαλίδας του συμπιεσμένου αρχείου"
 
-#: ../src/common/zipstrm.cpp:2531
+#: ../src/common/zipstrm.cpp:2615
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "σφάλμα κατά την εγγραφή αρχείου zip '%s': εσφαλμένο crc ή μήκος"
 
-#: ../src/common/ffile.cpp:188
+#: ../src/common/zipstrm.cpp:2608
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "σφάλμα κατά την εγγραφή αρχείου zip '%s': εσφαλμένο crc ή μήκος"
+
+#: ../src/common/fontcmn.cpp:1205
+#, fuzzy
+msgid "extrabold"
+msgstr "έντονο"
+
+#: ../src/common/fontcmn.cpp:1223
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1167
+#, fuzzy
+msgid "extralight"
+msgstr "απαλό(light)"
+
+#: ../src/msw/webview_ie.cpp:1036
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "Αποτυχία εκτέλεσης του '%s'\n"
+
+#: ../src/common/ffile.cpp:187
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "Αποτυχία αδειάσματος buffer (flush) του αρχείου '%s'"
 
+#: ../src/msw/webview_ie.cpp:1045
+#, fuzzy
+msgid "failed to retrieve execution result"
+msgstr "Αποτυχία στη λήψη κειμένου από το μήνυμα σφάλματος RAS"
+
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1030
+#: ../src/generic/datavgen.cpp:1150
 #, fuzzy
 msgid "false"
 msgstr "Αρχείο"
 
-#: ../src/common/datetimefmt.cpp:1966
+#: ../src/common/datetimefmt.cpp:1989
 msgid "fifteenth"
 msgstr "δέκατο-πέμπτο"
 
-#: ../src/common/datetimefmt.cpp:1956
+#: ../src/common/datetimefmt.cpp:1979
 msgid "fifth"
 msgstr "πέμπτο"
 
@@ -8863,134 +9069,153 @@ msgstr "αρχείο '%s', γραμμή %d: τιμή για αμετάβλητο
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "αρχείο '%s': απροσδόκητος χαρακτήρας %c στη γραμμή %d."
 
-#: ../src/richtext/richtextbuffer.cpp:8738
+#: ../src/richtext/richtextbuffer.cpp:8736
 #, fuzzy
 msgid "files"
 msgstr "Αρχείο"
 
-#: ../src/common/datetimefmt.cpp:1952
+#: ../src/common/datetimefmt.cpp:1975
 msgid "first"
 msgstr "πρώτο"
 
-#: ../src/html/helpwnd.cpp:1252
+#: ../src/html/helpwnd.cpp:1250
 msgid "font size"
 msgstr "μέγεθος γραμματοσειράς"
 
-#: ../src/common/datetimefmt.cpp:1965
+#: ../src/common/datetimefmt.cpp:1988
 msgid "fourteenth"
 msgstr "δέκατο τέταρτο"
 
-#: ../src/common/datetimefmt.cpp:1955
+#: ../src/common/datetimefmt.cpp:1978
 msgid "fourth"
 msgstr "τέταρτο"
 
-#: ../src/common/appbase.cpp:783
+#: ../src/common/appbase.cpp:784
 msgid "generate verbose log messages"
 msgstr "δημιουργία αναλυτικών (verbose) μηνυμάτων καταγραφής (log)"
 
-#: ../src/richtext/richtextbuffer.cpp:13138
-#: ../src/richtext/richtextbuffer.cpp:13248
+#: ../src/common/fontcmn.cpp:1215
+msgid "heavy"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:13133
+#: ../src/richtext/richtextbuffer.cpp:13243
 #, fuzzy
 msgid "image"
 msgstr "Ώρα"
 
-#: ../src/common/tarstrm.cpp:796
+#: ../src/common/tarstrm.cpp:790
 msgid "incomplete header block in tar"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:489
+#: ../src/common/xtixml.cpp:485
 msgid "incorrect event handler string, missing dot"
 msgstr "εσφαλμένο string χειριστή event, λείπει τελεία"
 
-#: ../src/common/tarstrm.cpp:1381
+#: ../src/common/tarstrm.cpp:1375
 msgid "incorrect size given for tar entry"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:993
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:987
 msgid "invalid data in extended tar header"
 msgstr ""
 
-#: ../src/generic/logg.cpp:1030
+#: ../src/generic/logg.cpp:1027
 msgid "invalid message box return value"
 msgstr "μη αποδεκτή τιμή επιστροφής παράθυρου μηνύματος"
 
-#: ../src/common/zipstrm.cpp:1647
+#: ../src/common/zipstrm.cpp:1688
 msgid "invalid zip file"
 msgstr "μη έγκυρο συμπιεσμένο αρχείο"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:1228
 msgid "italic"
 msgstr "πλάγιο"
 
-#: ../src/common/fontcmn.cpp:991
+#: ../src/common/webrequest_curl.cpp:374
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "Το αρχείο δεν μπόρεσε να φορτωθεί."
+
+#: ../src/common/fontcmn.cpp:1172
 msgid "light"
 msgstr "απαλό(light)"
 
-#: ../src/common/intl.cpp:303
-#, c-format
-msgid "locale '%s' cannot be set."
-msgstr "η γλώσσα '%s' δεν μπορει να οριστεί"
+#: ../src/common/fontcmn.cpp:1185
+msgid "medium"
+msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2125
+#: ../src/common/datetimefmt.cpp:2148
 msgid "midnight"
 msgstr "μεσάνυκτα"
 
-#: ../src/common/datetimefmt.cpp:1970
+#: ../src/common/datetimefmt.cpp:1993
 msgid "nineteenth"
 msgstr "δέκατο ένατο"
 
-#: ../src/common/datetimefmt.cpp:1960
+#: ../src/common/datetimefmt.cpp:1983
 msgid "ninth"
 msgstr "ένατο"
 
-#: ../src/msw/dde.cpp:1116
+#: ../src/msw/dde.cpp:1180
 msgid "no DDE error."
 msgstr "κανένα λάθος DDE"
 
-#: ../src/html/chm.cpp:327
+#: ../src/html/chm.cpp:324
 msgid "no error"
 msgstr "κανένα λάθος"
 
-#: ../src/dfb/fontmgr.cpp:174
+#: ../src/dfb/fontmgr.cpp:171
 #, c-format
 msgid "no fonts found in %s, using builtin font"
 msgstr ""
 
-#: ../src/html/helpdata.cpp:657
+#: ../src/html/helpdata.cpp:650
 msgid "noname"
 msgstr "ανώνυμο"
 
-#: ../src/common/datetimefmt.cpp:2124
+#: ../src/common/datetimefmt.cpp:2147
 msgid "noon"
 msgstr "μεσημέρι"
 
-#: ../src/richtext/richtextstyles.cpp:779
+#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
 #, fuzzy
 msgid "normal"
 msgstr "Κανονικό"
 
-#: ../src/common/cmdline.cpp:1492
+#: ../src/common/cmdline.cpp:1488
 msgid "num"
 msgstr "num"
 
-#: ../src/common/xtixml.cpp:259
+#: ../src/common/accelcmn.cpp:194
+msgid "num "
+msgstr ""
+
+#: ../src/common/xtixml.cpp:255
 msgid "objects cannot have XML Text Nodes"
 msgstr "τα αντικείμενα δεν μπορούν να έχουν XML κόμβους κειμένου"
 
-#: ../src/html/chm.cpp:339
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
 msgid "out of memory"
 msgstr "ανεπαρκής μνήμη"
 
-#: ../src/common/debugrpt.cpp:514
+#: ../src/common/debugrpt.cpp:515
 msgid "process context description"
 msgstr ""
 
-#: ../src/richtext/richtextbackgroundpage.cpp:227
-#: ../src/richtext/richtextbackgroundpage.cpp:250
-#: ../src/richtext/richtextbackgroundpage.cpp:290
-#: ../src/richtext/richtextbackgroundpage.cpp:317
-#: ../src/richtext/richtextfontpage.cpp:177
-#: ../src/richtext/richtextfontpage.cpp:180
 #: ../src/richtext/richtextborderspage.cpp:255
 #: ../src/richtext/richtextborderspage.cpp:289
 #: ../src/richtext/richtextborderspage.cpp:323
@@ -9000,22 +9225,45 @@ msgstr ""
 #: ../src/richtext/richtextborderspage.cpp:491
 #: ../src/richtext/richtextborderspage.cpp:525
 #: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextfontpage.cpp:180
 msgid "pt"
 msgstr ""
 
-#: ../src/richtext/richtextbackgroundpage.cpp:225
-#: ../src/richtext/richtextbackgroundpage.cpp:228
-#: ../src/richtext/richtextbackgroundpage.cpp:229
-#: ../src/richtext/richtextbackgroundpage.cpp:248
-#: ../src/richtext/richtextbackgroundpage.cpp:251
-#: ../src/richtext/richtextbackgroundpage.cpp:252
-#: ../src/richtext/richtextbackgroundpage.cpp:288
-#: ../src/richtext/richtextbackgroundpage.cpp:291
-#: ../src/richtext/richtextbackgroundpage.cpp:292
-#: ../src/richtext/richtextbackgroundpage.cpp:315
-#: ../src/richtext/richtextbackgroundpage.cpp:318
-#: ../src/richtext/richtextbackgroundpage.cpp:319
-#: ../src/richtext/richtextfontpage.cpp:178
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:659
+#: ../src/richtext/richtextsizepage.cpp:662
+#: ../src/richtext/richtextsizepage.cpp:663
 #: ../src/richtext/richtextborderspage.cpp:253
 #: ../src/richtext/richtextborderspage.cpp:256
 #: ../src/richtext/richtextborderspage.cpp:257
@@ -9067,263 +9315,273 @@ msgstr ""
 #: ../src/richtext/richtextmarginspage.cpp:387
 #: ../src/richtext/richtextmarginspage.cpp:389
 #: ../src/richtext/richtextmarginspage.cpp:390
-#: ../src/richtext/richtextsizepage.cpp:338
-#: ../src/richtext/richtextsizepage.cpp:341
-#: ../src/richtext/richtextsizepage.cpp:342
-#: ../src/richtext/richtextsizepage.cpp:372
-#: ../src/richtext/richtextsizepage.cpp:375
-#: ../src/richtext/richtextsizepage.cpp:376
-#: ../src/richtext/richtextsizepage.cpp:399
-#: ../src/richtext/richtextsizepage.cpp:402
-#: ../src/richtext/richtextsizepage.cpp:403
-#: ../src/richtext/richtextsizepage.cpp:426
-#: ../src/richtext/richtextsizepage.cpp:429
-#: ../src/richtext/richtextsizepage.cpp:430
-#: ../src/richtext/richtextsizepage.cpp:453
-#: ../src/richtext/richtextsizepage.cpp:456
-#: ../src/richtext/richtextsizepage.cpp:457
-#: ../src/richtext/richtextsizepage.cpp:480
-#: ../src/richtext/richtextsizepage.cpp:483
-#: ../src/richtext/richtextsizepage.cpp:484
-#: ../src/richtext/richtextsizepage.cpp:554
-#: ../src/richtext/richtextsizepage.cpp:557
-#: ../src/richtext/richtextsizepage.cpp:558
-#: ../src/richtext/richtextsizepage.cpp:589
-#: ../src/richtext/richtextsizepage.cpp:592
-#: ../src/richtext/richtextsizepage.cpp:593
-#: ../src/richtext/richtextsizepage.cpp:624
-#: ../src/richtext/richtextsizepage.cpp:627
-#: ../src/richtext/richtextsizepage.cpp:628
-#: ../src/richtext/richtextsizepage.cpp:659
-#: ../src/richtext/richtextsizepage.cpp:662
-#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextfontpage.cpp:178
 msgid "px"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:193
+#: ../src/common/accelcmn.cpp:192
 #, fuzzy
 msgid "rawctrl"
 msgstr "ctrl"
 
-#: ../src/html/chm.cpp:333
+#: ../src/html/chm.cpp:330
 msgid "read error"
 msgstr "σφάλμα ανάγνωσης"
 
-#: ../src/common/zipstrm.cpp:2085
+#: ../src/common/zipstrm.cpp:2155
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "ανάγνωση ροής zip (εγγραφή %s): εσφαλμένο crc "
 
-#: ../src/common/zipstrm.cpp:2080
+#: ../src/common/zipstrm.cpp:2150
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "ανάγνωση ροής zip (εγγραφή %s): λανθασμένο μήκος"
 
-#: ../src/msw/dde.cpp:1159
+#: ../src/msw/dde.cpp:1223
 msgid "reentrancy problem."
 msgstr "πρόβλημα επανεισαγωγής (reentrancy problem)."
 
-#: ../src/common/datetimefmt.cpp:1953
+#: ../src/common/datetimefmt.cpp:1976
 msgid "second"
 msgstr "δεύτερο"
 
-#: ../src/html/chm.cpp:337
+#: ../src/html/chm.cpp:334
 msgid "seek error"
 msgstr "σφάλμα εντοπισμού"
 
-#: ../src/common/datetimefmt.cpp:1968
+#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#, fuzzy
+msgid "semibold"
+msgstr "έντονο"
+
+#: ../src/common/datetimefmt.cpp:1991
 msgid "seventeenth"
 msgstr "δέκατο-έβδομο"
 
-#: ../src/common/datetimefmt.cpp:1958
+#: ../src/common/datetimefmt.cpp:1981
 msgid "seventh"
 msgstr "έβδομο"
 
-#: ../src/common/accelcmn.cpp:191
+#: ../src/common/accelcmn.cpp:190
 msgid "shift"
 msgstr "shift"
 
-#: ../src/common/appbase.cpp:773
+#: ../src/common/appbase.cpp:774
 msgid "show this help message"
 msgstr "εμφάνιση αυτού του μηνύματος βοηθείας"
 
-#: ../src/common/datetimefmt.cpp:1967
+#: ../src/common/datetimefmt.cpp:1990
 msgid "sixteenth"
 msgstr "δέκατο έκτο"
 
-#: ../src/common/datetimefmt.cpp:1957
+#: ../src/common/datetimefmt.cpp:1980
 msgid "sixth"
 msgstr "έκτο"
 
-#: ../src/common/appcmn.cpp:234
+#: ../src/common/appcmn.cpp:255
 msgid "specify display mode to use (e.g. 640x480-16)"
 msgstr ""
 "διευκρινήστε τον τρόπο απεικόνισης που θα χρησιμοποιηθεί (π.χ. 640x480-16)"
 
-#: ../src/common/appcmn.cpp:220
+#: ../src/common/appcmn.cpp:241
 msgid "specify the theme to use"
 msgstr "καθορίστε το θέμα που θα χρησιμοποιηθεί"
 
-#: ../src/richtext/richtextbuffer.cpp:9340
+#: ../src/richtext/richtextbuffer.cpp:9337
 msgid "standard/circle"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9341
+#: ../src/richtext/richtextbuffer.cpp:9338
 msgid "standard/circle-outline"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9343
+#: ../src/richtext/richtextbuffer.cpp:9340
 msgid "standard/diamond"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9342
+#: ../src/richtext/richtextbuffer.cpp:9339
 msgid "standard/square"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9344
+#: ../src/richtext/richtextbuffer.cpp:9341
 msgid "standard/triangle"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1985
+#: ../src/common/zipstrm.cpp:2055
 msgid "stored file length not in Zip header"
 msgstr "το μήκος του αποθκευμένου αρχείου δεν υπάρχει στην κεφαλίδα Zip"
 
-#: ../src/common/cmdline.cpp:1488
+#: ../src/common/cmdline.cpp:1484
 msgid "str"
 msgstr "str"
 
-#: ../src/common/fontcmn.cpp:982
+#: ../src/common/fontcmn.cpp:1145
 msgid "strikethrough"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:1003 ../src/common/tarstrm.cpp:1025
-#: ../src/common/tarstrm.cpp:1507 ../src/common/tarstrm.cpp:1529
+#: ../src/common/tarstrm.cpp:997 ../src/common/tarstrm.cpp:1019
+#: ../src/common/tarstrm.cpp:1501 ../src/common/tarstrm.cpp:1523
 msgid "tar entry not open"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1961
+#: ../src/common/datetimefmt.cpp:1984
 msgid "tenth"
 msgstr "δέκατο"
 
-#: ../src/msw/dde.cpp:1123
+#: ../src/msw/dde.cpp:1187
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "η απάντηση στη συναλλαγή ανάγκασε το DDE_FBUSY bit να τεθεί."
 
-#: ../src/common/datetimefmt.cpp:1954
+#: ../src/common/fontcmn.cpp:1154
+msgid "thin"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:1977
 msgid "third"
 msgstr "τρίτο"
 
-#: ../src/common/datetimefmt.cpp:1964
+#: ../src/common/datetimefmt.cpp:1987
 msgid "thirteenth"
 msgstr "δέκατο τρίτο"
 
-#: ../src/common/datetimefmt.cpp:1758
+#: ../src/common/datetimefmt.cpp:1781
 msgid "today"
 msgstr "σήμερα"
 
-#: ../src/common/datetimefmt.cpp:1760
+#: ../src/common/datetimefmt.cpp:1783
 msgid "tomorrow"
 msgstr "αύριο"
 
-#: ../src/common/fileconf.cpp:1944
+#: ../src/common/fileconf.cpp:1946
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr ""
 
-#: ../src/gtk/aboutdlg.cpp:218
+#: ../src/gtk/aboutdlg.cpp:216
 msgid "translator-credits"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1028
+#: ../src/generic/datavgen.cpp:1148
 msgid "true"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1963
+#: ../src/common/datetimefmt.cpp:1986
 msgid "twelfth"
 msgstr "δωδέκατο"
 
-#: ../src/common/datetimefmt.cpp:1971
+#: ../src/common/datetimefmt.cpp:1994
 msgid "twentieth"
 msgstr "εικοστό"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:486 ../src/generic/datavgen.cpp:1263
+#: ../src/common/datavcmn.cpp:2068 ../src/generic/datavgen.cpp:1386
 msgid "unchecked"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:802 ../src/common/fontcmn.cpp:978
+#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
 msgid "underlined"
 msgstr "υπογεγραμμένο"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:490
+#: ../src/common/datavcmn.cpp:2072
 #, fuzzy
 msgid "undetermined"
 msgstr "υπογεγραμμένο"
 
-#: ../src/common/fileconf.cpp:1979
+#: ../src/common/fileconf.cpp:1981
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "απροσδόκητο \" στη θέση %d στο '%s'."
 
-#: ../src/common/tarstrm.cpp:1045
+#: ../src/common/tarstrm.cpp:1039
 #, fuzzy
 msgid "unexpected end of file"
 msgstr "Απροσδόκητο τέλος αρχείου κατά την ανάγνωση πόρου."
 
-#: ../src/generic/progdlgg.cpp:370 ../src/common/tarstrm.cpp:371
-#: ../src/common/tarstrm.cpp:394 ../src/common/tarstrm.cpp:425
+#: ../src/common/tarstrm.cpp:366 ../src/common/tarstrm.cpp:389
+#: ../src/common/tarstrm.cpp:420 ../src/generic/progdlgg.cpp:376
 msgid "unknown"
 msgstr "άγνωστο"
 
-#: ../src/msw/registry.cpp:150
+#: ../src/msw/registry.cpp:139
 #, fuzzy, c-format
 msgid "unknown (%lu)"
 msgstr "άγνωστο"
 
-#: ../src/common/xtixml.cpp:253
+#: ../src/common/xtixml.cpp:249
 #, c-format
 msgid "unknown class %s"
 msgstr "άγνωστη κλάση %s"
 
-#: ../src/common/regex.cpp:258 ../src/html/chm.cpp:351
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "σφάλμα συμπίεσης"
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "σφάλμα αποσυμπίεσης"
+
+#: ../src/common/regex.cpp:255 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "άνωστο λάθος"
 
-#: ../src/msw/dialup.cpp:471
+#: ../src/msw/dialup.cpp:465
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "άνωστο λάθος (κωδικός λάθους %08x)"
 
-#: ../src/common/fmapbase.cpp:834
+#: ../src/common/fmapbase.cpp:830
 #, c-format
 msgid "unknown-%d"
 msgstr "άγνωστο-%d"
 
-#: ../src/common/docview.cpp:509
+#: ../src/common/docview.cpp:502
 msgid "unnamed"
 msgstr "απροσδιόριστο"
 
-#: ../src/common/docview.cpp:1624
+#: ../src/common/docview.cpp:1618
 #, c-format
 msgid "unnamed%d"
 msgstr "απροσδιόριστο%d"
 
-#: ../src/common/zipstrm.cpp:1999 ../src/common/zipstrm.cpp:2319
+#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
 msgid "unsupported Zip compression method"
 msgstr "μη υποστηριζόμενη μέθοδος συμπίεσης Zip"
 
-#: ../src/common/translation.cpp:1892
+#: ../src/common/translation.cpp:1942
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "χρήση καταλόγου '%s' από '%s'"
 
-#: ../src/html/chm.cpp:335
+#: ../src/html/chm.cpp:332
 msgid "write error"
 msgstr "σφάλμα εγγραφής"
 
-#: ../src/common/time.cpp:292
+#: ../src/gtk/glcanvas.cpp:187
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/common/time.cpp:285
 msgid "wxGetTimeOfDay failed."
 msgstr "το wxGetTimeOfDay απέτυχε."
 
@@ -9338,15 +9596,15 @@ msgstr ""
 msgid "wxWidgets could not open display. Exiting."
 msgstr "Η βιλιοθήκη wxWidgets δεν μπορεί να ανοίξει την απεικόνιση. 'Εξοδος..."
 
-#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:431
 msgid "xxxx"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1759
+#: ../src/common/datetimefmt.cpp:1782
 msgid "yesterday"
 msgstr "χθες"
 
-#: ../src/common/zstream.cpp:251 ../src/common/zstream.cpp:426
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
 #, c-format
 msgid "zlib error %d"
 msgstr "σφάλμα zlib %d"
@@ -9357,8 +9615,75 @@ msgid "~"
 msgstr ""
 
 #, fuzzy
-#~ msgid "Column could not be added."
-#~ msgstr "Το αρχείο δεν μπόρεσε να φορτωθεί."
+#~ msgid "&Save as"
+#~ msgstr "Αποθήκευση ως"
+
+#, fuzzy
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' πρέπει να περιέχει μόνο αλφαβητικούς χαρακτήρες."
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' πρέπει να είναι αριθμητικό."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' πρέπει να περιέχει ASCII χαρακτήρες."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' πρέπει να περιέχει μόνο αλφαβητικούς χαρακτήρες."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr ""
+#~ "'%s' πρέπει να περιέχει μόνο αλφαβητικούς ή αριθμητικούς χαρακτήρες."
+
+#, fuzzy
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' πρέπει να περιέχει ASCII χαρακτήρες."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "Δεν είναι δυνατή η δημιουργία παραθύρου τάξεως %s"
+
+#, fuzzy
+#~ msgid "Could not initalize libnotify."
+#~ msgstr "Δεν ήταν δυνατή η εκκίνηση της εκτύπωσης."
+
+#, fuzzy
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "Δεν ήταν δυνατή η δημιουργία χρονοδιακόπτη (timer)"
+
+#, fuzzy
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr ""
+#~ "Δεν ήταν δυνατή η ανάκτηση toy τρέχοντος δείκτη νήματος εκτέλεσης(thread)"
+
+#, fuzzy
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "Αποτυχία κλεισίματος του χειριστηρίου του αρχείου(file handle)"
+
+#, fuzzy
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "Αποτυχία καθορισμού της ώρας του UTC συστήματος"
+
+#~ msgid "No unused colour in image."
+#~ msgstr "Δεν υπάρχει μη χρησιμοποιούμενο χρώμα στην εικόνα"
+
+#, fuzzy
+#~ msgid "Not available"
+#~ msgstr "Δεν υπάρχει μονάδα(facility) XBM διαθέσιμη!"
+
+#, fuzzy
+#~ msgid "Replace selection"
+#~ msgstr "Αντικατάσταση &Όλων"
+
+#, fuzzy
+#~ msgid "Save as"
+#~ msgstr "Αποθήκευση ως"
+
+#, fuzzy
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "Δεν μπορείτε να προσθέσετε καινούργιο κατάλογο σε αυτό το τμήμα."
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "η γλώσσα '%s' δεν μπορει να οριστεί"
 
 #, fuzzy
 #~ msgid "Column index not found."
@@ -9580,10 +9905,6 @@ msgstr ""
 #~ msgid "unknown seek origin"
 #~ msgstr "άγνωστη αφετηρία(origin) αναζήτησης(seek)"
 
-#, fuzzy
-#~ msgid "wxWidget's control not initialized."
-#~ msgstr "Δεν είναι δυνατή η αρχικοποίηση απεικόνησης."
-
 #~ msgid "Cannot create mutex."
 #~ msgstr "Δεν είναι δυνατή η δημιουργία του mutex."
 
@@ -9657,9 +9978,6 @@ msgstr ""
 
 #~ msgid "Directory '%s' doesn't exist!"
 #~ msgstr "Ο κατάλογος '%s' δεν υπάρχει!"
-
-#~ msgid "File %s does not exist."
-#~ msgstr "Το αρχείο %s δεν υπάρχει."
 
 #~ msgid "Mode %ix%i-%i not available."
 #~ msgstr "Η κατάσταση λειτουργίας (mode) %ix%i-%i δεν είναι διαθέσιμη."
@@ -9744,9 +10062,6 @@ msgstr ""
 
 #~ msgid "Failed to register OpenGL window class."
 #~ msgstr "Απέτυχε η θέση της κλάσης του παραθύρου OpenGL"
-
-#~ msgid "Fatal error"
-#~ msgstr "Μοιραίο σφάλμα"
 
 #~ msgid "Fatal error: "
 #~ msgstr "Μοιραίο σφάλμα: "

--- a/locale/es.po
+++ b/locale/es.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-21 14:25+0200\n"
+"POT-Creation-Date: 2020-10-18 23:11+0300\n"
 "PO-Revision-Date: 2017-08-09 15:55-0500\n"
 "Last-Translator: Adolfo Jayme Barrientos <fitojb@ubuntu.com>\n"
 "Language-Team: wxWidgets translators <wx-translators@wxwidgets.org>\n"
@@ -14,7 +14,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.0.3\n"
 
-#: ../src/common/debugrpt.cpp:586
+#: ../src/common/debugrpt.cpp:587
 msgid ""
 "\n"
 "Please send this report to the program maintainer, thank you!\n"
@@ -22,8 +22,8 @@ msgstr ""
 "\n"
 "Envíe este informe al responsable del programa. ¡Gracias!\n"
 
-#: ../src/richtext/richtextstyledlg.cpp:210
-#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:206
+#: ../src/richtext/richtextstyledlg.cpp:218
 msgid " "
 msgstr " "
 
@@ -31,70 +31,96 @@ msgstr " "
 msgid "              Thank you and we're sorry for the inconvenience!\n"
 msgstr "              Gracias. Sentimos las molestias.\n"
 
-#: ../src/common/prntbase.cpp:573
+#: ../src/common/prntbase.cpp:568
 #, c-format
 msgid " (copy %d of %d)"
 msgstr " (copia %d de %d)"
 
-#: ../src/common/log.cpp:421
+#: ../src/common/log.cpp:440
 #, c-format
 msgid " (error %ld: %s)"
 msgstr " (error %ld: %s)"
 
-#: ../src/common/imagtiff.cpp:72
+#: ../src/common/imagtiff.cpp:69
 #, c-format
 msgid " (in module \"%s\")"
 msgstr " (en el módulo «%s»)"
 
-#: ../src/osx/core/secretstore.cpp:138
-msgid " (while overwriting an existing item)"
-msgstr " (al sobrescribir un elemento existente)"
-
-#: ../src/common/docview.cpp:1642
+#: ../src/common/docview.cpp:1636
 msgid " - "
 msgstr " - "
 
-#: ../src/richtext/richtextprint.cpp:593 ../src/html/htmprint.cpp:714
+#: ../src/html/htmprint.cpp:712 ../src/richtext/richtextprint.cpp:589
 msgid " Preview"
 msgstr " Previsualización"
 
-#: ../src/common/fontcmn.cpp:824
+#: ../src/common/fontcmn.cpp:973
 msgid " bold"
 msgstr " negrita"
 
-#: ../src/common/fontcmn.cpp:840
+#: ../src/common/fontcmn.cpp:977
+#, fuzzy
+msgid " extra bold"
+msgstr " negrita"
+
+#: ../src/common/fontcmn.cpp:985
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:957
+#, fuzzy
+msgid " extra light"
+msgstr " ligera"
+
+#: ../src/common/fontcmn.cpp:981
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1001
 msgid " italic"
 msgstr " cursiva"
 
-#: ../src/common/fontcmn.cpp:820
+#: ../src/common/fontcmn.cpp:961
 msgid " light"
 msgstr " ligera"
 
-#: ../src/common/fontcmn.cpp:807
+#: ../src/common/fontcmn.cpp:965
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:969
+#, fuzzy
+msgid " semi bold"
+msgstr " negrita"
+
+#: ../src/common/fontcmn.cpp:940
 msgid " strikethrough"
 msgstr " tachado"
 
-#: ../src/common/paper.cpp:117
+#: ../src/common/fontcmn.cpp:953
+msgid " thin"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
 msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
 msgstr "Sobre n.º 10, 4 1/8 × 9 1/2 in"
 
-#: ../src/common/paper.cpp:118
+#: ../src/common/paper.cpp:115
 msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
 msgstr "Sobre n.º 11, 4 1/2 × 10 3/8 in"
 
-#: ../src/common/paper.cpp:119
+#: ../src/common/paper.cpp:116
 msgid "#12 Envelope, 4 3/4 x 11 in"
 msgstr "Sobre n.º 12, 4 3/4 × 11 in"
 
-#: ../src/common/paper.cpp:120
+#: ../src/common/paper.cpp:117
 msgid "#14 Envelope, 5 x 11 1/2 in"
 msgstr "Sobre n.º 14, 5 × 11 1/2 in"
 
-#: ../src/common/paper.cpp:116
+#: ../src/common/paper.cpp:113
 msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
 msgstr "Sobre n.º 9, 3 7/8 × 8 7/8 in"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:341
 #: ../src/richtext/richtextsizepage.cpp:340
 #: ../src/richtext/richtextsizepage.cpp:374
 #: ../src/richtext/richtextsizepage.cpp:401
@@ -105,81 +131,82 @@ msgstr "Sobre n.º 9, 3 7/8 × 8 7/8 in"
 #: ../src/richtext/richtextsizepage.cpp:591
 #: ../src/richtext/richtextsizepage.cpp:626
 #: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextbackgroundpage.cpp:341
 msgid "%"
 msgstr "%"
 
-#: ../src/html/helpwnd.cpp:1031
+#: ../src/html/helpwnd.cpp:1029
 #, c-format
 msgid "%d of %lu"
 msgstr "%d de %lu"
 
-#: ../src/html/helpwnd.cpp:1678
+#: ../src/html/helpwnd.cpp:1676
 #, c-format
 msgid "%i of %u"
 msgstr "%i de %u"
 
-#: ../src/generic/filectrlg.cpp:279
+#: ../src/generic/filectrlg.cpp:275
 #, c-format
 msgid "%ld byte"
 msgid_plural "%ld bytes"
 msgstr[0] "%ld byte"
 msgstr[1] "%ld bytes"
 
-#: ../src/html/helpwnd.cpp:1033
+#: ../src/html/helpwnd.cpp:1031
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu de %lu"
 
-#: ../src/generic/datavgen.cpp:6028
+#: ../src/generic/datavgen.cpp:6833
 #, c-format
 msgid "%s (%d items)"
 msgstr "%s (%d elementos)"
 
-#: ../src/common/cmdline.cpp:1221
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (o %s)"
 
-#: ../src/generic/logg.cpp:224
+#: ../src/generic/logg.cpp:221
 #, c-format
 msgid "%s Error"
 msgstr "Error de %s"
 
-#: ../src/generic/logg.cpp:236
+#: ../src/generic/logg.cpp:233
 #, c-format
 msgid "%s Information"
 msgstr "Información de %s"
 
-#: ../src/generic/preferencesg.cpp:113
+#: ../src/generic/preferencesg.cpp:110
 #, c-format
 msgid "%s Preferences"
 msgstr "Preferencias de %s"
 
-#: ../src/generic/logg.cpp:228
+#: ../src/generic/logg.cpp:225
 #, c-format
 msgid "%s Warning"
 msgstr "Alerta de %s"
 
-#: ../src/common/tarstrm.cpp:1319
+#: ../src/common/tarstrm.cpp:1313
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s no se ajustó a la cabecera tar para la entrada '%s'"
 
-#: ../src/common/fldlgcmn.cpp:124
+#: ../src/common/fldlgcmn.cpp:121
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "archivos %s (%s)|%s"
 
-#: ../src/html/helpwnd.cpp:1716
+#: ../src/html/helpwnd.cpp:1714
 #, c-format
 msgid "%u of %u"
 msgstr "%u de %u"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "&About"
 msgstr "&Acerca de"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "&Actual Size"
 msgstr "Tamaño re&al"
 
@@ -187,28 +214,28 @@ msgstr "Tamaño re&al"
 msgid "&After a paragraph:"
 msgstr "&Después de un párrafo:"
 
-#: ../src/richtext/richtextindentspage.cpp:128
 #: ../src/richtext/richtextliststylepage.cpp:319
+#: ../src/richtext/richtextindentspage.cpp:128
 msgid "&Alignment"
 msgstr "&Alinear"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "&Apply"
 msgstr "&Aplicar"
 
-#: ../src/richtext/richtextstyledlg.cpp:251
+#: ../src/richtext/richtextstyledlg.cpp:247
 msgid "&Apply Style"
 msgstr "&Aplicar estilo"
 
-#: ../src/msw/mdi.cpp:179
+#: ../src/msw/mdi.cpp:174
 msgid "&Arrange Icons"
 msgstr "&Organizar iconos"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "&Ascending"
 msgstr "&Ascendente"
 
-#: ../src/common/stockitem.cpp:142
+#: ../src/common/stockitem.cpp:139
 msgid "&Back"
 msgstr "&Atrás"
 
@@ -228,24 +255,24 @@ msgstr "Color &fondo:"
 msgid "&Blur distance:"
 msgstr "Distancia de &difuminado:"
 
-#: ../src/common/stockitem.cpp:143
+#: ../src/common/stockitem.cpp:140
 msgid "&Bold"
 msgstr "&Negrita"
 
-#: ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141
 msgid "&Bottom"
 msgstr "&Inferior"
 
+#: ../src/richtext/richtextsizepage.cpp:637
+#: ../src/richtext/richtextsizepage.cpp:644
 #: ../src/richtext/richtextborderspage.cpp:345
 #: ../src/richtext/richtextborderspage.cpp:513
 #: ../src/richtext/richtextmarginspage.cpp:259
 #: ../src/richtext/richtextmarginspage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:637
-#: ../src/richtext/richtextsizepage.cpp:644
 msgid "&Bottom:"
 msgstr "&Inferior:"
 
-#: ../include/wx/richtext/richtextbuffer.h:3866
+#: ../include/wx/richtext/richtextbuffer.h:3861
 msgid "&Box"
 msgstr "&Caja"
 
@@ -254,38 +281,38 @@ msgstr "&Caja"
 msgid "&Bullet style:"
 msgstr "Estilo de &viñeta:"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "&CD-Rom"
 msgstr "&CD-ROM"
 
-#: ../src/generic/wizard.cpp:434 ../src/generic/fontdlgg.cpp:470
-#: ../src/generic/fontdlgg.cpp:489 ../src/osx/carbon/fontdlg.cpp:402
-#: ../src/common/dlgcmn.cpp:279 ../src/common/stockitem.cpp:145
+#: ../src/osx/carbon/fontdlg.cpp:399 ../src/common/stockitem.cpp:142
+#: ../src/generic/wizard.cpp:433 ../src/generic/fontdlgg.cpp:466
+#: ../src/generic/fontdlgg.cpp:485 ../src/osx/cocoa/button.mm:200
 msgid "&Cancel"
 msgstr "&Cancelar"
 
-#: ../src/msw/mdi.cpp:175
+#: ../src/msw/mdi.cpp:170
 msgid "&Cascade"
 msgstr "&Cascada"
 
-#: ../include/wx/richtext/richtextbuffer.h:5960
+#: ../include/wx/richtext/richtextbuffer.h:5955
 msgid "&Cell"
 msgstr "&Celda"
 
-#: ../src/richtext/richtextsymboldlg.cpp:439
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "&Character code:"
 msgstr "&Código de carácter:"
 
-#: ../src/common/stockitem.cpp:147
+#: ../src/common/stockitem.cpp:144
 msgid "&Clear"
 msgstr "&Limpiar"
 
-#: ../src/generic/logg.cpp:516 ../src/common/stockitem.cpp:148
-#: ../src/common/prntbase.cpp:1600 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/stockitem.cpp:145 ../src/common/prntbase.cpp:1625
+#: ../src/univ/themes/win32.cpp:3753 ../src/generic/logg.cpp:513
 msgid "&Close"
 msgstr "&Cerrar"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "&Color"
 msgstr "&Color"
 
@@ -293,20 +320,20 @@ msgstr "&Color"
 msgid "&Colour:"
 msgstr "&Color:"
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "&Convert"
 msgstr "&Convertir"
 
-#: ../src/richtext/richtextctrl.cpp:333 ../src/osx/textctrl_osx.cpp:577
-#: ../src/common/stockitem.cpp:150 ../src/msw/textctrl.cpp:2508
+#: ../src/osx/textctrl_osx.cpp:595 ../src/common/stockitem.cpp:147
+#: ../src/msw/textctrl.cpp:2773 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Copiar"
 
-#: ../src/generic/hyperlinkg.cpp:156
+#: ../src/generic/hyperlinkg.cpp:153
 msgid "&Copy URL"
 msgstr "&Copiar URL"
 
-#: ../src/common/headerctrlcmn.cpp:306
+#: ../src/common/headerctrlcmn.cpp:304
 msgid "&Customize..."
 msgstr "&Personalizar…"
 
@@ -314,53 +341,54 @@ msgstr "&Personalizar…"
 msgid "&Debug report preview:"
 msgstr "&Vista previa del informe de depuración:"
 
-#: ../src/richtext/richtexttabspage.cpp:138
-#: ../src/richtext/richtextctrl.cpp:335 ../src/osx/textctrl_osx.cpp:579
-#: ../src/common/stockitem.cpp:152 ../src/msw/textctrl.cpp:2510
+#: ../src/osx/textctrl_osx.cpp:597 ../src/common/stockitem.cpp:149
+#: ../src/msw/textctrl.cpp:2775 ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtextctrl.cpp:334
 msgid "&Delete"
 msgstr "&Eliminar"
 
-#: ../src/richtext/richtextstyledlg.cpp:269
+#: ../src/richtext/richtextstyledlg.cpp:265
 msgid "&Delete Style..."
 msgstr "&Eliminar estilo…"
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "&Descending"
 msgstr "&Descendente"
 
-#: ../src/generic/logg.cpp:682
+#: ../src/generic/logg.cpp:679
 msgid "&Details"
 msgstr "&Detalles"
 
-#: ../src/common/stockitem.cpp:153
+#: ../src/common/stockitem.cpp:150
 msgid "&Down"
 msgstr "A&bajo"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "&Edit"
 msgstr "&Editar"
 
-#: ../src/richtext/richtextstyledlg.cpp:263
+#: ../src/richtext/richtextstyledlg.cpp:259
 msgid "&Edit Style..."
 msgstr "&Editar estilo…"
 
-#: ../src/common/stockitem.cpp:155
+#: ../src/common/stockitem.cpp:152
 msgid "&Execute"
 msgstr "&Ejecutar"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/common/stockitem.cpp:154
 msgid "&File"
 msgstr "&Archivo"
 
-#: ../src/common/stockitem.cpp:158
-msgid "&Find"
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "&Find..."
 msgstr "&Buscar"
 
-#: ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:430
 msgid "&Finish"
 msgstr "&Finalizar"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:156
 msgid "&First"
 msgstr "&Primero"
 
@@ -368,15 +396,15 @@ msgstr "&Primero"
 msgid "&Floating mode:"
 msgstr "Modo &flotante:"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "&Floppy"
 msgstr "&Disco flexible"
 
-#: ../src/common/stockitem.cpp:194
+#: ../src/common/stockitem.cpp:191
 msgid "&Font"
 msgstr "&Tipo de letra"
 
-#: ../src/generic/fontdlgg.cpp:371
+#: ../src/generic/fontdlgg.cpp:367
 msgid "&Font family:"
 msgstr "&Familia tipográfica:"
 
@@ -384,20 +412,20 @@ msgstr "&Familia tipográfica:"
 msgid "&Font for Level..."
 msgstr "&Tipo de letra del nivel…"
 
+#: ../src/richtext/richtextsymboldlg.cpp:397
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:400
 msgid "&Font:"
 msgstr "&Tipo de letra:"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "&Forward"
 msgstr "Adelante"
 
-#: ../src/richtext/richtextsymboldlg.cpp:451
+#: ../src/richtext/richtextsymboldlg.cpp:448
 msgid "&From:"
 msgstr "&Desde:"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "&Harddisk"
 msgstr "&Disco duro"
 
@@ -406,9 +434,9 @@ msgstr "&Disco duro"
 msgid "&Height:"
 msgstr "&Altura:"
 
-#: ../src/generic/wizard.cpp:441 ../src/richtext/richtextstyledlg.cpp:303
-#: ../src/richtext/richtextsymboldlg.cpp:479 ../src/osx/menu_osx.cpp:734
-#: ../src/common/stockitem.cpp:163
+#: ../src/common/stockitem.cpp:160 ../src/generic/wizard.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextstyledlg.cpp:299 ../src/osx/cocoa/menu.mm:226
 msgid "&Help"
 msgstr "Ay&uda"
 
@@ -416,7 +444,7 @@ msgstr "Ay&uda"
 msgid "&Hide details"
 msgstr "&Ocultar detalles"
 
-#: ../src/common/stockitem.cpp:164
+#: ../src/common/stockitem.cpp:161
 msgid "&Home"
 msgstr "&Inicio"
 
@@ -424,54 +452,54 @@ msgstr "&Inicio"
 msgid "&Horizontal offset:"
 msgstr "Desplazamiento &horizontal:"
 
-#: ../src/richtext/richtextindentspage.cpp:184
 #: ../src/richtext/richtextliststylepage.cpp:372
+#: ../src/richtext/richtextindentspage.cpp:184
 msgid "&Indentation (tenths of a mm)"
 msgstr "&Sangría (décimas de mm)"
 
-#: ../src/richtext/richtextindentspage.cpp:167
 #: ../src/richtext/richtextliststylepage.cpp:356
+#: ../src/richtext/richtextindentspage.cpp:167
 msgid "&Indeterminate"
 msgstr "&Indeterminado"
 
-#: ../src/common/stockitem.cpp:166
+#: ../src/common/stockitem.cpp:163
 msgid "&Index"
 msgstr "Índ&ice"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "&Info"
 msgstr "&Información"
 
-#: ../src/common/stockitem.cpp:168
+#: ../src/common/stockitem.cpp:165
 msgid "&Italic"
 msgstr "Curs&iva"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "&Jump to"
 msgstr "&Ir a"
 
-#: ../src/richtext/richtextindentspage.cpp:153
 #: ../src/richtext/richtextliststylepage.cpp:342
+#: ../src/richtext/richtextindentspage.cpp:153
 msgid "&Justified"
 msgstr "&Justificado"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "&Last"
 msgstr "&Último"
 
-#: ../src/richtext/richtextindentspage.cpp:139
 #: ../src/richtext/richtextliststylepage.cpp:328
+#: ../src/richtext/richtextindentspage.cpp:139
 msgid "&Left"
 msgstr "&Izquierda"
 
-#: ../src/richtext/richtextindentspage.cpp:195
+#: ../src/richtext/richtextsizepage.cpp:532
+#: ../src/richtext/richtextsizepage.cpp:539
 #: ../src/richtext/richtextborderspage.cpp:243
 #: ../src/richtext/richtextborderspage.cpp:411
 #: ../src/richtext/richtextliststylepage.cpp:381
+#: ../src/richtext/richtextindentspage.cpp:195
 #: ../src/richtext/richtextmarginspage.cpp:186
 #: ../src/richtext/richtextmarginspage.cpp:300
-#: ../src/richtext/richtextsizepage.cpp:532
-#: ../src/richtext/richtextsizepage.cpp:539
 msgid "&Left:"
 msgstr "&Izquierda:"
 
@@ -479,11 +507,11 @@ msgstr "&Izquierda:"
 msgid "&List level:"
 msgstr "Nivel de &lista:"
 
-#: ../src/generic/logg.cpp:517
+#: ../src/generic/logg.cpp:514
 msgid "&Log"
 msgstr "&Registro"
 
-#: ../src/univ/themes/win32.cpp:3748
+#: ../src/univ/themes/win32.cpp:3745
 msgid "&Move"
 msgstr "&Mover"
 
@@ -491,19 +519,19 @@ msgstr "&Mover"
 msgid "&Move the object to:"
 msgstr "&Mover el objeto a:"
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "&Network"
 msgstr "&Red"
 
-#: ../src/richtext/richtexttabspage.cpp:132 ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173 ../src/richtext/richtexttabspage.cpp:132
 msgid "&New"
 msgstr "&Nuevo"
 
-#: ../src/aui/tabmdi.cpp:111 ../src/generic/mdig.cpp:100 ../src/msw/mdi.cpp:180
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
 msgid "&Next"
 msgstr "&Siguiente"
 
-#: ../src/generic/wizard.cpp:432 ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:429
 msgid "&Next >"
 msgstr "&Siguiente >"
 
@@ -511,7 +539,7 @@ msgstr "&Siguiente >"
 msgid "&Next Paragraph"
 msgstr "Párrafo &siguiente"
 
-#: ../src/generic/tipdlg.cpp:240
+#: ../src/generic/tipdlg.cpp:237
 msgid "&Next Tip"
 msgstr "&Siguiente Sugerencia"
 
@@ -519,11 +547,11 @@ msgstr "&Siguiente Sugerencia"
 msgid "&Next style:"
 msgstr "Estilo &siguiente:"
 
-#: ../src/common/stockitem.cpp:177 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:174 ../src/msw/msgdlg.cpp:435
 msgid "&No"
 msgstr "&No"
 
-#: ../src/generic/dbgrptg.cpp:356
+#: ../src/generic/dbgrptg.cpp:360
 msgid "&Notes:"
 msgstr "&Notas:"
 
@@ -531,12 +559,12 @@ msgstr "&Notas:"
 msgid "&Number:"
 msgstr "&Número:"
 
-#: ../src/generic/fontdlgg.cpp:475 ../src/generic/fontdlgg.cpp:482
-#: ../src/osx/carbon/fontdlg.cpp:408 ../src/common/stockitem.cpp:178
+#: ../src/osx/carbon/fontdlg.cpp:405 ../src/common/stockitem.cpp:175
+#: ../src/generic/fontdlgg.cpp:471 ../src/generic/fontdlgg.cpp:478
 msgid "&OK"
 msgstr "&Aceptar"
 
-#: ../src/generic/dbgrptg.cpp:342 ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176 ../src/generic/dbgrptg.cpp:342
 msgid "&Open..."
 msgstr "A&brir…"
 
@@ -548,16 +576,16 @@ msgstr "Nivel del c&ontorno:"
 msgid "&Page Break"
 msgstr "Salto de &página"
 
-#: ../src/richtext/richtextctrl.cpp:334 ../src/osx/textctrl_osx.cpp:578
-#: ../src/common/stockitem.cpp:180 ../src/msw/textctrl.cpp:2509
+#: ../src/osx/textctrl_osx.cpp:596 ../src/common/stockitem.cpp:177
+#: ../src/msw/textctrl.cpp:2774 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&Pegar"
 
-#: ../include/wx/richtext/richtextbuffer.h:5010
+#: ../include/wx/richtext/richtextbuffer.h:5005
 msgid "&Picture"
 msgstr "&Imagen"
 
-#: ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:419
 msgid "&Point size:"
 msgstr "Tamaño de &punto:"
 
@@ -569,11 +597,11 @@ msgstr "&Posición (décimas de mm):"
 msgid "&Position mode:"
 msgstr "&Modo de colocar:"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178
 msgid "&Preferences"
 msgstr "&Preferencias"
 
-#: ../src/aui/tabmdi.cpp:112 ../src/generic/mdig.cpp:101 ../src/msw/mdi.cpp:181
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
 msgid "&Previous"
 msgstr "&Anterior"
 
@@ -581,78 +609,74 @@ msgstr "&Anterior"
 msgid "&Previous Paragraph"
 msgstr "Párrafo &anterior"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "&Print..."
 msgstr "&Imprimir…"
 
-#: ../src/richtext/richtextctrl.cpp:339 ../src/richtext/richtextctrl.cpp:5514
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtextctrl.cpp:338
+#: ../src/richtext/richtextctrl.cpp:5512
 msgid "&Properties"
 msgstr "&Propiedades"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "&Quit"
 msgstr "&Salir"
 
-#: ../src/richtext/richtextctrl.cpp:330 ../src/osx/textctrl_osx.cpp:574
-#: ../src/common/stockitem.cpp:185 ../src/common/cmdproc.cpp:293
-#: ../src/common/cmdproc.cpp:300 ../src/msw/textctrl.cpp:2505
+#: ../src/osx/textctrl_osx.cpp:592 ../src/common/stockitem.cpp:182
+#: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
+#: ../src/msw/textctrl.cpp:2770 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Rehacer"
 
-#: ../src/common/cmdproc.cpp:289 ../src/common/cmdproc.cpp:309
+#: ../src/common/cmdproc.cpp:282 ../src/common/cmdproc.cpp:302
 msgid "&Redo "
 msgstr "&Rehacer "
 
-#: ../src/richtext/richtextstyledlg.cpp:257
+#: ../src/richtext/richtextstyledlg.cpp:253
 msgid "&Rename Style..."
 msgstr "&Cambiar nombre de estilo…"
 
-#: ../src/generic/fdrepdlg.cpp:179
+#: ../src/generic/fdrepdlg.cpp:176
 msgid "&Replace"
 msgstr "&Sustituir"
 
-#: ../src/richtext/richtextstyledlg.cpp:287
+#: ../src/richtext/richtextstyledlg.cpp:283
 msgid "&Restart numbering"
 msgstr "&Recomenzar numeración"
 
-#: ../src/univ/themes/win32.cpp:3747
+#: ../src/univ/themes/win32.cpp:3744
 msgid "&Restore"
 msgstr "&Restaurar"
 
-#: ../src/richtext/richtextindentspage.cpp:146
 #: ../src/richtext/richtextliststylepage.cpp:335
+#: ../src/richtext/richtextindentspage.cpp:146
 msgid "&Right"
 msgstr "&Derecha"
 
-#: ../src/richtext/richtextindentspage.cpp:213
+#: ../src/richtext/richtextsizepage.cpp:602
+#: ../src/richtext/richtextsizepage.cpp:609
 #: ../src/richtext/richtextborderspage.cpp:277
 #: ../src/richtext/richtextborderspage.cpp:445
 #: ../src/richtext/richtextliststylepage.cpp:399
+#: ../src/richtext/richtextindentspage.cpp:213
 #: ../src/richtext/richtextmarginspage.cpp:211
 #: ../src/richtext/richtextmarginspage.cpp:325
-#: ../src/richtext/richtextsizepage.cpp:602
-#: ../src/richtext/richtextsizepage.cpp:609
 msgid "&Right:"
 msgstr "&Derecha:"
 
-#: ../src/common/stockitem.cpp:190
+#: ../src/common/stockitem.cpp:187
 msgid "&Save"
 msgstr "&Guardar"
-
-#: ../src/common/stockitem.cpp:191
-msgid "&Save as"
-msgstr "&Guardar como"
 
 #: ../include/wx/richmsgdlg.h:29
 msgid "&See details"
 msgstr "&Ver detalles"
 
-#: ../src/generic/tipdlg.cpp:236
+#: ../src/generic/tipdlg.cpp:233
 msgid "&Show tips at startup"
 msgstr "&Mostrar sugerencias al inicio"
 
-#: ../src/univ/themes/win32.cpp:3750
+#: ../src/univ/themes/win32.cpp:3747
 msgid "&Size"
 msgstr "&Tamaño"
 
@@ -660,36 +684,36 @@ msgstr "&Tamaño"
 msgid "&Size:"
 msgstr "&Tamaño:"
 
-#: ../src/generic/progdlgg.cpp:252
+#: ../src/generic/progdlgg.cpp:249
 msgid "&Skip"
 msgstr "&Saltar"
 
-#: ../src/richtext/richtextindentspage.cpp:242
 #: ../src/richtext/richtextliststylepage.cpp:417
+#: ../src/richtext/richtextindentspage.cpp:242
 msgid "&Spacing (tenths of a mm)"
 msgstr "&Espaciado (décimas de mm)"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "&Spell Check"
 msgstr "&Comprobar ortografía"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "&Stop"
 msgstr "&Detener"
 
-#: ../src/richtext/richtextfontpage.cpp:275 ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196 ../src/richtext/richtextfontpage.cpp:275
 msgid "&Strikethrough"
 msgstr "&Tachado"
 
-#: ../src/generic/fontdlgg.cpp:382 ../src/richtext/richtextstylepage.cpp:106
+#: ../src/generic/fontdlgg.cpp:378 ../src/richtext/richtextstylepage.cpp:106
 msgid "&Style:"
 msgstr "E&stilo:"
 
-#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:194
 msgid "&Styles:"
 msgstr "E&stilos:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:413
+#: ../src/richtext/richtextsymboldlg.cpp:410
 msgid "&Subset:"
 msgstr "&Subconjunto:"
 
@@ -703,24 +727,24 @@ msgstr "&Símbolo:"
 msgid "&Synchronize values"
 msgstr "&Sincronizar valores"
 
-#: ../include/wx/richtext/richtextbuffer.h:6069
+#: ../include/wx/richtext/richtextbuffer.h:6064
 msgid "&Table"
 msgstr "&Tabla"
 
-#: ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197
 msgid "&Top"
 msgstr "&Arriba"
 
+#: ../src/richtext/richtextsizepage.cpp:567
+#: ../src/richtext/richtextsizepage.cpp:574
 #: ../src/richtext/richtextborderspage.cpp:311
 #: ../src/richtext/richtextborderspage.cpp:479
 #: ../src/richtext/richtextmarginspage.cpp:234
 #: ../src/richtext/richtextmarginspage.cpp:348
-#: ../src/richtext/richtextsizepage.cpp:567
-#: ../src/richtext/richtextsizepage.cpp:574
 msgid "&Top:"
 msgstr "&Arriba:"
 
-#: ../src/generic/fontdlgg.cpp:444 ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199 ../src/generic/fontdlgg.cpp:441
 msgid "&Underline"
 msgstr "Subrayar"
 
@@ -728,21 +752,21 @@ msgstr "Subrayar"
 msgid "&Underlining:"
 msgstr "&Subrayado:"
 
-#: ../src/richtext/richtextctrl.cpp:329 ../src/osx/textctrl_osx.cpp:573
-#: ../src/common/stockitem.cpp:203 ../src/common/cmdproc.cpp:271
-#: ../src/msw/textctrl.cpp:2504
+#: ../src/osx/textctrl_osx.cpp:591 ../src/common/stockitem.cpp:200
+#: ../src/common/cmdproc.cpp:264 ../src/msw/textctrl.cpp:2769
+#: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Deshacer"
 
-#: ../src/common/cmdproc.cpp:265
+#: ../src/common/cmdproc.cpp:258
 msgid "&Undo "
 msgstr "&Deshacer "
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "&Unindent"
 msgstr "&Quitar sangría"
 
-#: ../src/common/stockitem.cpp:205
+#: ../src/common/stockitem.cpp:202
 msgid "&Up"
 msgstr "&Arriba"
 
@@ -758,7 +782,7 @@ msgstr "Desplazamiento &vertical:"
 msgid "&View..."
 msgstr "&Ver…"
 
-#: ../src/generic/fontdlgg.cpp:393
+#: ../src/generic/fontdlgg.cpp:389
 msgid "&Weight:"
 msgstr "&Peso:"
 
@@ -767,88 +791,58 @@ msgstr "&Peso:"
 msgid "&Width:"
 msgstr "&Ancho:"
 
-#: ../src/aui/tabmdi.cpp:311 ../src/aui/tabmdi.cpp:327
-#: ../src/aui/tabmdi.cpp:329 ../src/generic/mdig.cpp:294
-#: ../src/generic/mdig.cpp:310 ../src/generic/mdig.cpp:314
-#: ../src/msw/mdi.cpp:78
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
 msgid "&Window"
 msgstr "&Ventana"
 
-#: ../src/common/stockitem.cpp:206 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:203 ../src/msw/msgdlg.cpp:435
 msgid "&Yes"
 msgstr "&Sí"
 
-#: ../src/common/valtext.cpp:256
-#, c-format
-msgid "'%s' contains illegal characters"
+#: ../src/common/valtext.cpp:197
+#, fuzzy, c-format
+msgid "'%s' contains invalid character(s)"
 msgstr "«%s» contiene caracteres no permitidos"
 
-#: ../src/common/valtext.cpp:254
-#, c-format
-msgid "'%s' doesn't consist only of valid characters"
-msgstr "'%s' no tiene exclusivamente caracteres válidos"
-
-#: ../src/common/config.cpp:519 ../src/msw/regconf.cpp:258
+#: ../src/common/config.cpp:515 ../src/msw/regconf.cpp:255
 #, c-format
 msgid "'%s' has extra '..', ignored."
 msgstr "'%s' tiene '..' adicional, se ignora."
 
-#: ../src/common/cmdline.cpp:1113 ../src/common/cmdline.cpp:1131
+#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' no es un valor numérico correcto para el parámetro '%s'."
 
-#: ../src/common/translation.cpp:1100
+#: ../src/common/translation.cpp:1142
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' no es un catálogo de mensajes válido."
 
-#: ../src/common/valtext.cpp:165
+#: ../src/common/valtext.cpp:188
 #, c-format
 msgid "'%s' is not one of the valid strings"
 msgstr "'%s' no es una de las cadenas válidas"
 
-#: ../src/common/valtext.cpp:167
+#: ../src/common/valtext.cpp:186
 #, c-format
 msgid "'%s' is one of the invalid strings"
 msgstr "'%s' es una de las cadenas no válidas"
 
-#: ../src/common/textbuf.cpp:237
+#: ../src/common/textbuf.cpp:233
 #, c-format
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' es probablemente un buffer binario."
-
-#: ../src/common/valtext.cpp:252
-#, c-format
-msgid "'%s' should be numeric."
-msgstr "'%s debería ser numérico."
-
-#: ../src/common/valtext.cpp:244
-#, c-format
-msgid "'%s' should only contain ASCII characters."
-msgstr "'%s' debería contener sólo caracteres ASCII."
-
-#: ../src/common/valtext.cpp:246
-#, c-format
-msgid "'%s' should only contain alphabetic characters."
-msgstr "'%s' debería contener sólo caracteres de texto."
-
-#: ../src/common/valtext.cpp:248
-#, c-format
-msgid "'%s' should only contain alphabetic or numeric characters."
-msgstr "'%s debería contener sólo caracteres alfanuméricos."
-
-#: ../src/common/valtext.cpp:250
-#, c-format
-msgid "'%s' should only contain digits."
-msgstr "'%s' debería contener solo dígitos."
 
 #: ../src/richtext/richtextliststylepage.cpp:229
 #: ../src/richtext/richtextbulletspage.cpp:166
 msgid "(*)"
 msgstr "(*)"
 
-#: ../src/html/helpwnd.cpp:963
+#: ../src/html/helpwnd.cpp:961
 msgid "(Help)"
 msgstr "(Ayuda)"
 
@@ -857,27 +851,32 @@ msgstr "(Ayuda)"
 msgid "(None)"
 msgstr "(Ninguno)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:504
+#: ../src/richtext/richtextsymboldlg.cpp:503
 msgid "(Normal text)"
 msgstr "(Texto normal)"
 
-#: ../src/html/helpwnd.cpp:419 ../src/html/helpwnd.cpp:1106
-#: ../src/html/helpwnd.cpp:1742
+#: ../src/html/helpwnd.cpp:417 ../src/html/helpwnd.cpp:1104
+#: ../src/html/helpwnd.cpp:1740
 msgid "(bookmarks)"
 msgstr "(favoritos)"
 
+#: ../src/msw/dlmsw.cpp:167
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (error %ld: %s)"
+
+#: ../src/richtext/richtextformatdlg.cpp:876
+#: ../src/richtext/richtextliststylepage.cpp:448
+#: ../src/richtext/richtextliststylepage.cpp:460
+#: ../src/richtext/richtextliststylepage.cpp:461
 #: ../src/richtext/richtextindentspage.cpp:274
 #: ../src/richtext/richtextindentspage.cpp:286
 #: ../src/richtext/richtextindentspage.cpp:287
 #: ../src/richtext/richtextindentspage.cpp:311
 #: ../src/richtext/richtextindentspage.cpp:326
-#: ../src/richtext/richtextformatdlg.cpp:884
 #: ../src/richtext/richtextfontpage.cpp:349
 #: ../src/richtext/richtextfontpage.cpp:353
 #: ../src/richtext/richtextfontpage.cpp:357
-#: ../src/richtext/richtextliststylepage.cpp:448
-#: ../src/richtext/richtextliststylepage.cpp:460
-#: ../src/richtext/richtextliststylepage.cpp:461
 msgid "(none)"
 msgstr "(ninguno)"
 
@@ -896,7 +895,7 @@ msgstr "*)"
 msgid "+"
 msgstr "+"
 
-#: ../src/msw/utils.cpp:1152
+#: ../src/msw/utils.cpp:1143
 msgid ", 64-bit edition"
 msgstr ", edición de 64 bits"
 
@@ -905,163 +904,163 @@ msgstr ", edición de 64 bits"
 msgid "-"
 msgstr "-"
 
-#: ../src/generic/filepickerg.cpp:66
+#: ../src/generic/filepickerg.cpp:63
 msgid "..."
 msgstr "…"
 
-#: ../src/richtext/richtextindentspage.cpp:276
 #: ../src/richtext/richtextliststylepage.cpp:450
+#: ../src/richtext/richtextindentspage.cpp:276
 msgid "1.1"
 msgstr "1.1"
 
-#: ../src/richtext/richtextindentspage.cpp:277
 #: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextindentspage.cpp:277
 msgid "1.2"
 msgstr "1.2"
 
-#: ../src/richtext/richtextindentspage.cpp:278
 #: ../src/richtext/richtextliststylepage.cpp:452
+#: ../src/richtext/richtextindentspage.cpp:278
 msgid "1.3"
 msgstr "1.3"
 
-#: ../src/richtext/richtextindentspage.cpp:279
 #: ../src/richtext/richtextliststylepage.cpp:453
+#: ../src/richtext/richtextindentspage.cpp:279
 msgid "1.4"
 msgstr "1.4"
 
-#: ../src/richtext/richtextindentspage.cpp:280
 #: ../src/richtext/richtextliststylepage.cpp:454
+#: ../src/richtext/richtextindentspage.cpp:280
 msgid "1.5"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:281
 #: ../src/richtext/richtextliststylepage.cpp:455
+#: ../src/richtext/richtextindentspage.cpp:281
 msgid "1.6"
 msgstr "1.6"
 
-#: ../src/richtext/richtextindentspage.cpp:282
 #: ../src/richtext/richtextliststylepage.cpp:456
+#: ../src/richtext/richtextindentspage.cpp:282
 msgid "1.7"
 msgstr "1.7"
 
-#: ../src/richtext/richtextindentspage.cpp:283
 #: ../src/richtext/richtextliststylepage.cpp:457
+#: ../src/richtext/richtextindentspage.cpp:283
 msgid "1.8"
 msgstr "1.8"
 
-#: ../src/richtext/richtextindentspage.cpp:284
 #: ../src/richtext/richtextliststylepage.cpp:458
+#: ../src/richtext/richtextindentspage.cpp:284
 msgid "1.9"
 msgstr "1.9"
 
-#: ../src/common/paper.cpp:140
+#: ../src/common/paper.cpp:137
 msgid "10 x 11 in"
 msgstr "10 x 11 pulgadas"
 
-#: ../src/common/paper.cpp:113
+#: ../src/common/paper.cpp:110
 msgid "10 x 14 in"
 msgstr "10 x 14 pulgadas"
 
-#: ../src/common/paper.cpp:114
+#: ../src/common/paper.cpp:111
 msgid "11 x 17 in"
 msgstr "11 x 17 pulgadas"
 
-#: ../src/common/paper.cpp:184
+#: ../src/common/paper.cpp:181
 msgid "12 x 11 in"
 msgstr "12 x 11 pulgadas"
 
-#: ../src/common/paper.cpp:141
+#: ../src/common/paper.cpp:138
 msgid "15 x 11 in"
 msgstr "15 x 11 pulgadas"
 
-#: ../src/richtext/richtextindentspage.cpp:285
 #: ../src/richtext/richtextliststylepage.cpp:459
+#: ../src/richtext/richtextindentspage.cpp:285
 msgid "2"
 msgstr "2"
 
-#: ../src/common/paper.cpp:132
+#: ../src/common/paper.cpp:129
 msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
 msgstr "Sobre 6 3/4, 3 5/8 x 6 1/2 pulgadas"
 
-#: ../src/common/paper.cpp:139
+#: ../src/common/paper.cpp:136
 msgid "9 x 11 in"
 msgstr "9 x 11 pulgadas"
 
-#: ../src/html/htmprint.cpp:431
+#: ../src/html/htmprint.cpp:443
 msgid ": file does not exist!"
 msgstr ": ¡el archivo no existe!"
 
-#: ../src/common/fontmap.cpp:199
+#: ../src/common/fontmap.cpp:196
 msgid ": unknown charset"
 msgstr ": conjunto de caracteres desconocido"
 
-#: ../src/common/fontmap.cpp:413
+#: ../src/common/fontmap.cpp:410
 msgid ": unknown encoding"
 msgstr ": codificación desconocida"
 
-#: ../src/generic/wizard.cpp:443
+#: ../src/generic/wizard.cpp:438
 msgid "< &Back"
 msgstr "< &Atrás"
 
-#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:628
-#: ../src/osx/carbon/fontdlg.cpp:648
+#: ../src/osx/carbon/fontdlg.cpp:419 ../src/osx/carbon/fontdlg.cpp:625
+#: ../src/osx/carbon/fontdlg.cpp:645
 msgid "<Any Decorative>"
 msgstr "<Cualquiera Decorativa>"
 
-#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:630
-#: ../src/osx/carbon/fontdlg.cpp:650
+#: ../src/osx/carbon/fontdlg.cpp:420 ../src/osx/carbon/fontdlg.cpp:627
+#: ../src/osx/carbon/fontdlg.cpp:647
 msgid "<Any Modern>"
 msgstr "<Cualquiera Moderna>"
 
-#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:626
-#: ../src/osx/carbon/fontdlg.cpp:646
+#: ../src/osx/carbon/fontdlg.cpp:418 ../src/osx/carbon/fontdlg.cpp:623
+#: ../src/osx/carbon/fontdlg.cpp:643
 msgid "<Any Roman>"
 msgstr "<Cualquiera Roman>"
 
-#: ../src/osx/carbon/fontdlg.cpp:424 ../src/osx/carbon/fontdlg.cpp:632
-#: ../src/osx/carbon/fontdlg.cpp:652
+#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:629
+#: ../src/osx/carbon/fontdlg.cpp:649
 msgid "<Any Script>"
 msgstr "<Cualquiera Script>"
 
-#: ../src/osx/carbon/fontdlg.cpp:425 ../src/osx/carbon/fontdlg.cpp:637
-#: ../src/osx/carbon/fontdlg.cpp:656
+#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:634
+#: ../src/osx/carbon/fontdlg.cpp:653
 msgid "<Any Swiss>"
 msgstr "<Cualquiera Swiss>"
 
-#: ../src/osx/carbon/fontdlg.cpp:426 ../src/osx/carbon/fontdlg.cpp:634
-#: ../src/osx/carbon/fontdlg.cpp:654
+#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:631
+#: ../src/osx/carbon/fontdlg.cpp:651
 msgid "<Any Teletype>"
 msgstr "<Cualquiera Teletipo>"
 
-#: ../src/osx/carbon/fontdlg.cpp:420
+#: ../src/osx/carbon/fontdlg.cpp:417
 msgid "<Any>"
 msgstr "<Cualquiera>"
 
-#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
 msgid "<DIR>"
 msgstr "<DIR>"
 
-#: ../src/generic/filectrlg.cpp:254 ../src/generic/filectrlg.cpp:277
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
 msgid "<DRIVE>"
 msgstr "<UNIDAD>"
 
-#: ../src/generic/filectrlg.cpp:252 ../src/generic/filectrlg.cpp:275
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
 msgid "<LINK>"
 msgstr "<ENLACE>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1264
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Negrita cursiva.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1270
+#: ../src/html/helpwnd.cpp:1268
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>negrita cursiva <u>subrayada</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1265
+#: ../src/html/helpwnd.cpp:1263
 msgid "<b>Bold face.</b> "
 msgstr "<b>Negrita.</b> "
 
-#: ../src/html/helpwnd.cpp:1264
+#: ../src/html/helpwnd.cpp:1262
 msgid "<i>Italic face.</i> "
 msgstr "<i>Cursiva.</i> "
 
@@ -1070,15 +1069,15 @@ msgstr "<i>Cursiva.</i> "
 msgid ">"
 msgstr ">"
 
-#: ../src/generic/dbgrptg.cpp:318
+#: ../src/generic/dbgrptg.cpp:317
 msgid "A debug report has been generated in the directory\n"
 msgstr "Se ha generado un informe de depuración en el directorio\n"
 
-#: ../src/common/debugrpt.cpp:573
+#: ../src/common/debugrpt.cpp:574
 msgid "A debug report has been generated. It can be found in"
 msgstr "Se ha generado un informe de depuración en"
 
-#: ../src/common/xtixml.cpp:418
+#: ../src/common/xtixml.cpp:414
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Una colección no vacía debe consistir en nodos del tipo «element»"
 
@@ -1089,106 +1088,106 @@ msgstr "Una colección no vacía debe consistir en nodos del tipo «element»"
 msgid "A standard bullet name."
 msgstr "Un nombre de viñeta estándar."
 
-#: ../src/common/paper.cpp:217
+#: ../src/common/paper.cpp:214
 msgid "A0 sheet, 841 x 1189 mm"
 msgstr "Hoja A0, 841 × 1189 mm"
 
-#: ../src/common/paper.cpp:218
+#: ../src/common/paper.cpp:215
 msgid "A1 sheet, 594 x 841 mm"
 msgstr "Hoja A1, 594 × 841 mm"
 
-#: ../src/common/paper.cpp:159
+#: ../src/common/paper.cpp:156
 msgid "A2 420 x 594 mm"
 msgstr "A2 420 × 594 mm"
 
-#: ../src/common/paper.cpp:156
+#: ../src/common/paper.cpp:153
 msgid "A3 Extra 322 x 445 mm"
 msgstr "A3 Extra 322 × 445 mm"
 
-#: ../src/common/paper.cpp:161
+#: ../src/common/paper.cpp:158
 msgid "A3 Extra Transverse 322 x 445 mm"
 msgstr "A3 Extra Transversal 322 × 445 mm"
 
-#: ../src/common/paper.cpp:170
+#: ../src/common/paper.cpp:167
 msgid "A3 Rotated 420 x 297 mm"
 msgstr "A3 Girada 420 × 297 mm"
 
-#: ../src/common/paper.cpp:160
+#: ../src/common/paper.cpp:157
 msgid "A3 Transverse 297 x 420 mm"
 msgstr "A3 Transversal 297 × 420 mm"
 
-#: ../src/common/paper.cpp:106
+#: ../src/common/paper.cpp:103
 msgid "A3 sheet, 297 x 420 mm"
 msgstr "Hoja A3, 297 × 420 mm"
 
-#: ../src/common/paper.cpp:146
+#: ../src/common/paper.cpp:143
 msgid "A4 Extra 9.27 x 12.69 in"
 msgstr "A4 Extra 9.27 × 12.69 in"
 
-#: ../src/common/paper.cpp:153
+#: ../src/common/paper.cpp:150
 msgid "A4 Plus 210 x 330 mm"
 msgstr "A4 Plus 210 × 330 mm"
 
-#: ../src/common/paper.cpp:171
+#: ../src/common/paper.cpp:168
 msgid "A4 Rotated 297 x 210 mm"
 msgstr "A4 Girada 297 × 210 mm"
 
-#: ../src/common/paper.cpp:148
+#: ../src/common/paper.cpp:145
 msgid "A4 Transverse 210 x 297 mm"
 msgstr "A4 Transversal 210 × 297 mm"
 
-#: ../src/common/paper.cpp:97
+#: ../src/common/paper.cpp:94
 msgid "A4 sheet, 210 x 297 mm"
 msgstr "Hoja A4, 210 × 297 mm"
 
-#: ../src/common/paper.cpp:107
+#: ../src/common/paper.cpp:104
 msgid "A4 small sheet, 210 x 297 mm"
 msgstr "Hoja pequeña A4, 210 × 297 mm"
 
-#: ../src/common/paper.cpp:157
+#: ../src/common/paper.cpp:154
 msgid "A5 Extra 174 x 235 mm"
 msgstr "A5 Extra 174 × 235 mm"
 
-#: ../src/common/paper.cpp:172
+#: ../src/common/paper.cpp:169
 msgid "A5 Rotated 210 x 148 mm"
 msgstr "A5 Girado 210 × 148 mm"
 
-#: ../src/common/paper.cpp:154
+#: ../src/common/paper.cpp:151
 msgid "A5 Transverse 148 x 210 mm"
 msgstr "A5 Transversal 148 × 210 mm"
 
-#: ../src/common/paper.cpp:108
+#: ../src/common/paper.cpp:105
 msgid "A5 sheet, 148 x 210 mm"
 msgstr "Hoja A5, 148 × 210 mm"
 
-#: ../src/common/paper.cpp:164
+#: ../src/common/paper.cpp:161
 msgid "A6 105 x 148 mm"
 msgstr "A6 105 × 148 mm"
 
-#: ../src/common/paper.cpp:177
+#: ../src/common/paper.cpp:174
 msgid "A6 Rotated 148 x 105 mm"
 msgstr "A6 Girada 148 × 105 mm"
 
-#: ../src/generic/fontdlgg.cpp:83 ../src/richtext/richtextformatdlg.cpp:529
-#: ../src/osx/carbon/fontdlg.cpp:153
+#: ../src/osx/carbon/fontdlg.cpp:150 ../src/generic/fontdlgg.cpp:79
+#: ../src/richtext/richtextformatdlg.cpp:521
 msgid "ABCDEFGabcdefg12345"
 msgstr "ABCDEFGabcdefg12345"
 
-#: ../src/richtext/richtextsymboldlg.cpp:458 ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
 msgid "ASCII"
 msgstr "ASCII"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "About"
 msgstr "Acerca de"
 
-#: ../src/generic/aboutdlgg.cpp:140 ../src/osx/menu_osx.cpp:558
-#: ../src/msw/aboutdlg.cpp:64
+#: ../src/osx/menu_osx.cpp:450 ../src/generic/aboutdlgg.cpp:137
+#: ../src/msw/aboutdlg.cpp:61
 #, c-format
 msgid "About %s"
 msgstr "Acerca de %s"
 
-#: ../src/osx/menu_osx.cpp:560
+#: ../src/osx/menu_osx.cpp:452
 msgid "About..."
 msgstr "Acerca de…"
 
@@ -1197,37 +1196,37 @@ msgid "Absolute"
 msgstr "Absoluto"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:873
+#: ../src/propgrid/advprops.cpp:774
 msgid "ActiveBorder"
 msgstr "ActiveBorder"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:874
+#: ../src/propgrid/advprops.cpp:775
 msgid "ActiveCaption"
 msgstr "ActiveCaption"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "Actual Size"
 msgstr "Tamaño real"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:140 ../src/common/accelcmn.cpp:81
+#: ../src/common/stockitem.cpp:137 ../src/common/accelcmn.cpp:78
 msgid "Add"
 msgstr "Añadir"
 
-#: ../src/richtext/richtextbuffer.cpp:11455
+#: ../src/richtext/richtextbuffer.cpp:11454
 msgid "Add Column"
 msgstr "Añadir columna"
 
-#: ../src/richtext/richtextbuffer.cpp:11392
+#: ../src/richtext/richtextbuffer.cpp:11391
 msgid "Add Row"
 msgstr "Añadir fila"
 
-#: ../src/html/helpwnd.cpp:432
+#: ../src/html/helpwnd.cpp:430
 msgid "Add current page to bookmarks"
 msgstr "Añadir página actual a Marcadores"
 
-#: ../src/generic/colrdlgg.cpp:366
+#: ../src/generic/colrdlgg.cpp:386
 msgid "Add to custom colours"
 msgstr "Añadir a colores personalizados"
 
@@ -1239,12 +1238,12 @@ msgstr "Se llamó a AddToPropertyCollection sobre un accedente genérico"
 msgid "AddToPropertyCollection called w/o valid adder"
 msgstr "Se llamó a AddToPropertyCollection sin añadidor válido"
 
-#: ../src/html/helpctrl.cpp:159
+#: ../src/html/helpctrl.cpp:155
 #, c-format
 msgid "Adding book %s"
 msgstr "Añadiendo libro %s"
 
-#: ../src/common/preferencescmn.cpp:43
+#: ../src/common/preferencescmn.cpp:40
 msgid "Advanced"
 msgstr "Avanzado"
 
@@ -1252,11 +1251,11 @@ msgstr "Avanzado"
 msgid "After a paragraph:"
 msgstr "Después de un párrafo:"
 
-#: ../src/common/stockitem.cpp:172
+#: ../src/common/stockitem.cpp:169
 msgid "Align Left"
 msgstr "Alinear a la izquierda"
 
-#: ../src/common/stockitem.cpp:173
+#: ../src/common/stockitem.cpp:170
 msgid "Align Right"
 msgstr "Alinear a la derecha"
 
@@ -1264,40 +1263,40 @@ msgstr "Alinear a la derecha"
 msgid "Alignment"
 msgstr "Alineación"
 
-#: ../src/generic/prntdlgg.cpp:215
+#: ../src/generic/prntdlgg.cpp:208
 msgid "All"
 msgstr "Todo"
 
-#: ../src/generic/filectrlg.cpp:1197 ../src/common/fldlgcmn.cpp:107
+#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1186
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Todos los archivos (%s)|%s"
 
-#: ../include/wx/defs.h:2886
+#: ../include/wx/defs.h:2582
 msgid "All files (*)|*"
 msgstr "Todos los archivos (*)|*"
 
-#: ../include/wx/defs.h:2883
+#: ../include/wx/defs.h:2579
 msgid "All files (*.*)|*.*"
 msgstr "Todos los archivos (*.*)|*"
 
-#: ../src/richtext/richtextstyles.cpp:1061
+#: ../src/richtext/richtextstyles.cpp:1058
 msgid "All styles"
 msgstr "Todos los estilos"
 
-#: ../src/propgrid/manager.cpp:1528
+#: ../src/propgrid/manager.cpp:1544
 msgid "Alphabetic Mode"
 msgstr "Modo alfabético"
 
-#: ../src/common/xtistrm.cpp:425
+#: ../src/common/xtistrm.cpp:422
 msgid "Already Registered Object passed to SetObjectClassInfo"
 msgstr "Se pasó un objeto ya registrado a SetObjectClassInfo"
 
-#: ../src/unix/dialup.cpp:353
+#: ../src/unix/dialup.cpp:352
 msgid "Already dialling ISP."
 msgstr "Ya está llamando al ISP."
 
-#: ../src/common/accelcmn.cpp:331 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/accelcmn.cpp:345 ../src/univ/themes/win32.cpp:3753
 msgid "Alt+"
 msgstr "Alt+"
 
@@ -1306,35 +1305,35 @@ msgstr "Alt+"
 msgid "An optional corner radius for adding rounded corners."
 msgstr "Un radio de esquina opcional para añadir esquinas redondeadas."
 
-#: ../src/common/debugrpt.cpp:576
+#: ../src/common/debugrpt.cpp:577
 msgid "And includes the following files:\n"
 msgstr "E incluye los siguientes archivos:\n"
 
-#: ../src/generic/animateg.cpp:162
+#: ../src/generic/animateg.cpp:145
 #, c-format
 msgid "Animation file is not of type %ld."
 msgstr "El archivo de animación no es del tipo %ld."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:872
+#: ../src/propgrid/advprops.cpp:773
 msgid "AppWorkspace"
 msgstr "AppWorkspace"
 
-#: ../src/generic/logg.cpp:1014
+#: ../src/generic/logg.cpp:1011
 #, c-format
 msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
 msgstr ""
 "¿Quiere añadir el registro al archivo «%s»? (elegir [No] lo sobrescribirá)"
 
-#: ../src/osx/menu_osx.cpp:577 ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:469 ../src/osx/menu_osx.cpp:477
 msgid "Application"
 msgstr "Aplicación"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "Apply"
 msgstr "Aplicar"
 
-#: ../src/propgrid/advprops.cpp:1609
+#: ../src/propgrid/advprops.cpp:1515
 msgid "Aqua"
 msgstr "Aguamarina"
 
@@ -1343,29 +1342,29 @@ msgstr "Aguamarina"
 msgid "Arabic"
 msgstr "Arábigo"
 
-#: ../src/common/fmapbase.cpp:153
+#: ../src/common/fmapbase.cpp:150
 msgid "Arabic (ISO-8859-6)"
 msgstr "Arábigo (ISO-8859-6)"
 
-#: ../src/msw/ole/automtn.cpp:672
+#: ../src/msw/ole/automtn.cpp:663
 #, c-format
 msgid "Argument %u not found."
 msgstr "No se encontró el argumento %u."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1753
+#: ../src/propgrid/advprops.cpp:1654
 msgid "Arrow"
 msgstr "Flecha"
 
-#: ../src/generic/aboutdlgg.cpp:184
+#: ../src/generic/aboutdlgg.cpp:181
 msgid "Artists"
 msgstr "Artistas"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "Ascending"
 msgstr "Ascendente"
 
-#: ../src/generic/filectrlg.cpp:433
+#: ../src/generic/filectrlg.cpp:429
 msgid "Attributes"
 msgstr "Atributos"
 
@@ -1375,90 +1374,90 @@ msgstr "Atributos"
 msgid "Available fonts."
 msgstr "Tipos de letra disponibles."
 
-#: ../src/common/paper.cpp:137
+#: ../src/common/paper.cpp:134
 msgid "B4 (ISO) 250 x 353 mm"
 msgstr "B4 (ISO) 250 × 353 mm"
 
-#: ../src/common/paper.cpp:173
+#: ../src/common/paper.cpp:170
 msgid "B4 (JIS) Rotated 364 x 257 mm"
 msgstr "B4 (JIS) Girado 364 × 257 mm"
 
-#: ../src/common/paper.cpp:127
+#: ../src/common/paper.cpp:124
 msgid "B4 Envelope, 250 x 353 mm"
 msgstr "Sobre B4, 250 × 353 mm"
 
-#: ../src/common/paper.cpp:109
+#: ../src/common/paper.cpp:106
 msgid "B4 sheet, 250 x 354 mm"
 msgstr "Hoja B4, 250 × 354 mm"
 
-#: ../src/common/paper.cpp:158
+#: ../src/common/paper.cpp:155
 msgid "B5 (ISO) Extra 201 x 276 mm"
 msgstr "B5 (ISO) Extra 201 × 276 mm"
 
-#: ../src/common/paper.cpp:174
+#: ../src/common/paper.cpp:171
 msgid "B5 (JIS) Rotated 257 x 182 mm"
 msgstr "B5 (JIS) Girado 257 × 182 mm"
 
-#: ../src/common/paper.cpp:155
+#: ../src/common/paper.cpp:152
 msgid "B5 (JIS) Transverse 182 x 257 mm"
 msgstr "B5 (JIS) Transversal 182 × 257 mm"
 
-#: ../src/common/paper.cpp:128
+#: ../src/common/paper.cpp:125
 msgid "B5 Envelope, 176 x 250 mm"
 msgstr "Sobre B5, 176 × 250 mm"
 
-#: ../src/common/paper.cpp:110
+#: ../src/common/paper.cpp:107
 msgid "B5 sheet, 182 x 257 millimeter"
 msgstr "Hoja B5, 182 × 257 mm"
 
-#: ../src/common/paper.cpp:182
+#: ../src/common/paper.cpp:179
 msgid "B6 (JIS) 128 x 182 mm"
 msgstr "B6 (JIS) 128 × 182 mm"
 
-#: ../src/common/paper.cpp:183
+#: ../src/common/paper.cpp:180
 msgid "B6 (JIS) Rotated 182 x 128 mm"
 msgstr "B6 (JIS) Girado 182 × 128 mm"
 
-#: ../src/common/paper.cpp:129
+#: ../src/common/paper.cpp:126
 msgid "B6 Envelope, 176 x 125 mm"
 msgstr "Sobre B6, 176 × 125 mm"
 
-#: ../src/common/imagbmp.cpp:531 ../src/common/imagbmp.cpp:561
-#: ../src/common/imagbmp.cpp:576
+#: ../src/common/imagbmp.cpp:528 ../src/common/imagbmp.cpp:558
+#: ../src/common/imagbmp.cpp:573
 msgid "BMP: Couldn't allocate memory."
 msgstr "BMP: no se pudo reservar memoria."
 
-#: ../src/common/imagbmp.cpp:100
+#: ../src/common/imagbmp.cpp:97
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: no se pudo guardar una imagen no válida."
 
-#: ../src/common/imagbmp.cpp:356
+#: ../src/common/imagbmp.cpp:353
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: no se pudo escribir el mapa de color RGB."
 
-#: ../src/common/imagbmp.cpp:490
+#: ../src/common/imagbmp.cpp:487
 msgid "BMP: Couldn't write data."
 msgstr "BMP: no se pudieron escribir los datos."
 
-#: ../src/common/imagbmp.cpp:246
+#: ../src/common/imagbmp.cpp:243
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: no se pudo escribir la cabecera (Bitmap) del archivo."
 
-#: ../src/common/imagbmp.cpp:269
+#: ../src/common/imagbmp.cpp:266
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: no se pudo escribir la cabecera (BitmapInfo) del archivo."
 
-#: ../src/common/imagbmp.cpp:140
+#: ../src/common/imagbmp.cpp:137
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage no tiene su propia wxPalette."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:142 ../src/common/accelcmn.cpp:52
+#: ../src/common/stockitem.cpp:139 ../src/common/accelcmn.cpp:49
 msgid "Back"
 msgstr "Atrás"
 
+#: ../src/richtext/richtextformatdlg.cpp:377
 #: ../src/richtext/richtextbackgroundpage.cpp:148
-#: ../src/richtext/richtextformatdlg.cpp:384
 msgid "Background"
 msgstr "Fondo"
 
@@ -1466,20 +1465,20 @@ msgstr "Fondo"
 msgid "Background &colour:"
 msgstr "&Color de fondo:"
 
-#: ../src/osx/carbon/fontdlg.cpp:220
+#: ../src/osx/carbon/fontdlg.cpp:217
 msgid "Background colour"
 msgstr "Color de fondo"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:52
+#: ../src/common/accelcmn.cpp:49
 msgid "Backspace"
 msgstr "Retroceso"
 
-#: ../src/common/fmapbase.cpp:160
+#: ../src/common/fmapbase.cpp:157
 msgid "Baltic (ISO-8859-13)"
 msgstr "Báltico (ISO-8859-13)"
 
-#: ../src/common/fmapbase.cpp:151
+#: ../src/common/fmapbase.cpp:148
 msgid "Baltic (old) (ISO-8859-4)"
 msgstr "Báltico (antiguo) (ISO-8859-4)"
 
@@ -1492,25 +1491,25 @@ msgstr "Antes de un párrafo:"
 msgid "Bitmap"
 msgstr "Mapa de bits"
 
-#: ../src/propgrid/advprops.cpp:1594
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Black"
 msgstr "Negro"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1755
+#: ../src/propgrid/advprops.cpp:1656
 msgid "Blank"
 msgstr "Vacío"
 
-#: ../src/propgrid/advprops.cpp:1603
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Blue"
 msgstr "Azul"
 
-#: ../src/generic/colrdlgg.cpp:345
+#: ../src/generic/colrdlgg.cpp:365
 msgid "Blue:"
 msgstr "Azul:"
 
-#: ../src/generic/fontdlgg.cpp:333 ../src/richtext/richtextfontpage.cpp:355
-#: ../src/osx/carbon/fontdlg.cpp:354 ../src/common/stockitem.cpp:143
+#: ../src/osx/carbon/fontdlg.cpp:351 ../src/common/stockitem.cpp:140
+#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:355
 msgid "Bold"
 msgstr "Negrita"
 
@@ -1519,31 +1518,35 @@ msgstr "Negrita"
 msgid "Border"
 msgstr "Borde"
 
-#: ../src/richtext/richtextformatdlg.cpp:379
+#: ../src/richtext/richtextformatdlg.cpp:372
 msgid "Borders"
 msgstr "Bordes"
 
-#: ../src/richtext/richtextsizepage.cpp:288 ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141 ../src/richtext/richtextsizepage.cpp:288
 msgid "Bottom"
 msgstr "Inferior"
 
-#: ../src/generic/prntdlgg.cpp:893
+#: ../src/generic/prntdlgg.cpp:886
 msgid "Bottom margin (mm):"
 msgstr "Margen inferior (mm):"
 
-#: ../src/richtext/richtextbuffer.cpp:9383
+#: ../src/richtext/richtextbuffer.cpp:9380
 msgid "Box Properties"
 msgstr "Propiedades de caja"
 
-#: ../src/richtext/richtextstyles.cpp:1065
+#: ../src/richtext/richtextstyles.cpp:1062
 msgid "Box styles"
 msgstr "Estilos de caja"
 
-#: ../src/propgrid/advprops.cpp:1602
+#: ../src/osx/cocoa/menu.mm:292
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Brown"
 msgstr "Marrón"
 
-#: ../src/common/filepickercmn.cpp:43 ../src/common/filepickercmn.cpp:44
+#: ../src/common/filepickercmn.cpp:40 ../src/common/filepickercmn.cpp:41
 msgid "Browse"
 msgstr "Navegar"
 
@@ -1556,72 +1559,72 @@ msgstr "&Alineación de viñeta:"
 msgid "Bullet style"
 msgstr "Estilo de viñeta"
 
-#: ../src/richtext/richtextformatdlg.cpp:359
+#: ../src/richtext/richtextformatdlg.cpp:352
 msgid "Bullets"
 msgstr "Viñetas"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1756
+#: ../src/propgrid/advprops.cpp:1657
 msgid "Bullseye"
 msgstr "Diana"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:875
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonFace"
 msgstr "ButtonFace"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:876
+#: ../src/propgrid/advprops.cpp:777
 msgid "ButtonHighlight"
 msgstr "ButtonHighlight"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:877
+#: ../src/propgrid/advprops.cpp:778
 msgid "ButtonShadow"
 msgstr "ButtonShadow"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:878
+#: ../src/propgrid/advprops.cpp:779
 msgid "ButtonText"
 msgstr "ButtonText"
 
-#: ../src/common/paper.cpp:98
+#: ../src/common/paper.cpp:95
 msgid "C sheet, 17 x 22 in"
 msgstr "Hoja C, 17 × 22 in"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "C&lear"
 msgstr "&Limpiar"
 
-#: ../src/generic/fontdlgg.cpp:406
+#: ../src/generic/fontdlgg.cpp:403
 msgid "C&olour:"
 msgstr "C&olor:"
 
-#: ../src/common/paper.cpp:123
+#: ../src/common/paper.cpp:120
 msgid "C3 Envelope, 324 x 458 mm"
 msgstr "Sobre C3, 324 × 458 mm"
 
-#: ../src/common/paper.cpp:124
+#: ../src/common/paper.cpp:121
 msgid "C4 Envelope, 229 x 324 mm"
 msgstr "Sobre C4, 229 × 324 mm"
 
-#: ../src/common/paper.cpp:122
+#: ../src/common/paper.cpp:119
 msgid "C5 Envelope, 162 x 229 mm"
 msgstr "Sobre C5, 162 × 229 mm"
 
-#: ../src/common/paper.cpp:125
+#: ../src/common/paper.cpp:122
 msgid "C6 Envelope, 114 x 162 mm"
 msgstr "Sobre C6, 114 × 162 mm"
 
-#: ../src/common/paper.cpp:126
+#: ../src/common/paper.cpp:123
 msgid "C65 Envelope, 114 x 229 mm"
 msgstr "Sobre C65, 114 × 229 mm"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "CD-Rom"
 msgstr "CD-ROM"
 
-#: ../src/html/chm.cpp:815 ../src/html/chm.cpp:874
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:865
 msgid "CHM handler currently supports only local files!"
 msgstr "El manipulador de CHM actualmente admite únicamente archivos locales."
 
@@ -1629,197 +1632,201 @@ msgstr "El manipulador de CHM actualmente admite únicamente archivos locales."
 msgid "Ca&pitals"
 msgstr "Ma&yúsculas"
 
-#: ../src/common/cmdproc.cpp:267
+#: ../src/common/cmdproc.cpp:260
 msgid "Can't &Undo "
 msgstr "No se puede &deshacer "
 
-#: ../src/common/image.cpp:2824
+#: ../src/common/image.cpp:2924
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 "No se puede determinar automáticamente el formato de imagen en entradas "
 "secuenciales."
 
-#: ../src/msw/registry.cpp:506
+#: ../src/msw/registry.cpp:495
 #, c-format
 msgid "Can't close registry key '%s'"
 msgstr "No se puede cerrar la clave del Registro «%s»"
 
-#: ../src/msw/registry.cpp:584
+#: ../src/msw/registry.cpp:573
 #, c-format
 msgid "Can't copy values of unsupported type %d."
 msgstr "No se pueden copiar valores del tipo no admitido %d."
 
-#: ../src/msw/registry.cpp:487
+#: ../src/msw/registry.cpp:476
 #, c-format
 msgid "Can't create registry key '%s'"
 msgstr "No se puede crear la clave del Registro «%s»"
 
-#: ../src/msw/thread.cpp:665
+#: ../src/msw/thread.cpp:657
 msgid "Can't create thread"
 msgstr "No se puede crear el hilo de ejecución"
 
-#: ../src/msw/window.cpp:3691
-#, c-format
-msgid "Can't create window of class %s"
-msgstr "No se puede crear la ventana de clase %s"
-
-#: ../src/msw/registry.cpp:777
+#: ../src/msw/registry.cpp:765
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "No se puede eliminar la clave «%s»"
 
-#: ../src/msw/iniconf.cpp:458
+#: ../src/msw/iniconf.cpp:455
 #, c-format
 msgid "Can't delete the INI file '%s'"
 msgstr "No se puede elimininar el archivo INI «%s»"
 
-#: ../src/msw/registry.cpp:805
+#: ../src/msw/registry.cpp:793
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "No se puede eliminar el valor «%s» de la clave «%s»"
 
-#: ../src/msw/registry.cpp:1171
+#: ../src/msw/registry.cpp:1159
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "No se pueden enumerar las subclaves de la clave «%s»"
 
-#: ../src/msw/registry.cpp:1132
+#: ../src/msw/registry.cpp:1120
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "No se pueden enumerar los valores de la clave «%s»"
 
-#: ../src/msw/registry.cpp:1389
+#: ../src/msw/registry.cpp:1377
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "No se puede exportar el valor del tipo no admitido %d."
 
-#: ../src/common/ffile.cpp:254
+#: ../src/common/ffile.cpp:253
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "No se puede encontrar la posición actual en el archivo «%s»"
 
-#: ../src/msw/registry.cpp:418
+#: ../src/msw/registry.cpp:407
 #, c-format
 msgid "Can't get info about registry key '%s'"
 msgstr "No se puede obtener información de la clave del Registro «%s»"
 
-#: ../src/common/zstream.cpp:346
+#: ../src/msw/webview_ie.cpp:1024
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "No se puede establecer la prioridad del hilo de ejecución"
+
+#: ../src/common/zstream.cpp:343
 msgid "Can't initialize zlib deflate stream."
 msgstr "No se puede inicializar el flujo de compresión de zlib."
 
-#: ../src/common/zstream.cpp:185
+#: ../src/common/zstream.cpp:182
 msgid "Can't initialize zlib inflate stream."
 msgstr "No se puede inicializar el flujo de descompresión de zlib."
 
-#: ../src/msw/fswatcher.cpp:476
+#: ../src/msw/fswatcher.cpp:475
 #, c-format
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "No se pueden monitorizar los cambios del directorio inexistente «%s»."
 
-#: ../src/msw/registry.cpp:454
+#: ../src/msw/registry.cpp:443
 #, c-format
 msgid "Can't open registry key '%s'"
 msgstr "No se puede abrir la clave del registro «%s»"
 
-#: ../src/common/zstream.cpp:252
+#: ../src/common/zstream.cpp:249
 #, c-format
 msgid "Can't read from inflate stream: %s"
 msgstr "No se puede leer desde el flujo de descompresión %s"
 
-#: ../src/common/zstream.cpp:244
+#: ../src/common/zstream.cpp:241
 msgid "Can't read inflate stream: unexpected EOF in underlying stream."
 msgstr ""
 "No se puede leer el flujo de descompresión: EOF inesperado en el flujo "
 "subyacente."
 
-#: ../src/msw/registry.cpp:1064
+#: ../src/msw/registry.cpp:1052
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "No se puede leer el valor de «%s»"
 
-#: ../src/msw/registry.cpp:878 ../src/msw/registry.cpp:910
-#: ../src/msw/registry.cpp:975
+#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
+#: ../src/msw/registry.cpp:963
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "No se puede leer el valor de la clave «%s»"
 
-#: ../src/common/image.cpp:2620
+#: ../src/msw/webview_ie.cpp:1017
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/common/image.cpp:2715
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr ""
 "No se puede guardar la imagen en el archivo «%s»: extensión desconocida."
 
-#: ../src/generic/logg.cpp:573 ../src/generic/logg.cpp:976
+#: ../src/generic/logg.cpp:570 ../src/generic/logg.cpp:973
 msgid "Can't save log contents to file."
 msgstr "No se puede guardar el contenido del registro en un archivo."
 
-#: ../src/msw/thread.cpp:629
+#: ../src/msw/thread.cpp:621
 msgid "Can't set thread priority"
 msgstr "No se puede establecer la prioridad del hilo de ejecución"
 
-#: ../src/msw/registry.cpp:896 ../src/msw/registry.cpp:938
-#: ../src/msw/registry.cpp:1081
+#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
+#: ../src/msw/registry.cpp:1069
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "No se puede establecer el valor de «%s»"
 
-#: ../src/unix/utilsunx.cpp:351
+#: ../src/unix/utilsunx.cpp:353
 msgid "Can't write to child process's stdin"
 msgstr "No se puede escribir en stdin del proceso hijo"
 
-#: ../src/common/zstream.cpp:427
+#: ../src/common/zstream.cpp:424
 #, c-format
 msgid "Can't write to deflate stream: %s"
 msgstr "No se puede escribir en el flujo de compresión: %s"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:279 ../src/richtext/richtextstyledlg.cpp:300
-#: ../src/common/stockitem.cpp:145 ../src/common/accelcmn.cpp:71
-#: ../src/msw/msgdlg.cpp:454 ../src/msw/progdlg.cpp:673
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:142
+#: ../src/common/accelcmn.cpp:68 ../src/motif/msgdlg.cpp:196
+#: ../src/gtk1/fontdlg.cpp:144 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/progdlg.cpp:940 ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: ../src/common/filefn.cpp:1261
+#: ../src/common/filefn.cpp:1149
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "No se pueden enumerar los archivos «%s»"
 
-#: ../src/msw/dir.cpp:263
+#: ../src/msw/dir.cpp:260
 #, c-format
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "No se pueden enumerar los archivos en el directorio «%s»"
 
-#: ../src/msw/dialup.cpp:523
+#: ../src/msw/dialup.cpp:517
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "No se puede encontrar ninguna conexión telefónica activa: %s"
 
-#: ../src/msw/dialup.cpp:827
+#: ../src/msw/dialup.cpp:821
 msgid "Cannot find the location of address book file"
 msgstr "No se puede encontrar el archivo de libreta de direcciones"
 
-#: ../src/msw/ole/automtn.cpp:562
+#: ../src/msw/ole/automtn.cpp:553
 #, c-format
 msgid "Cannot get an active instance of \"%s\""
 msgstr "No se puede obtener una instancia activa de «%s»"
 
-#: ../src/unix/threadpsx.cpp:1035
+#: ../src/unix/threadpsx.cpp:1053
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr ""
 "No se puede obtener un intervalo de prioridades para la normativa de "
 "planificación %d."
 
-#: ../src/unix/utilsunx.cpp:987
+#: ../src/unix/utilsunx.cpp:989
 msgid "Cannot get the hostname"
 msgstr "No se puede obtener el nombre de la máquina"
 
-#: ../src/unix/utilsunx.cpp:1023
+#: ../src/unix/utilsunx.cpp:1025
 msgid "Cannot get the official hostname"
 msgstr "No se puede obtener el nombre oficial de la máquina"
 
-#: ../src/msw/dialup.cpp:928
+#: ../src/msw/dialup.cpp:922
 msgid "Cannot hang up - no active dialup connection."
 msgstr "No se puede colgar: no hay ninguna conexión telefónica activa."
 
@@ -1827,127 +1834,127 @@ msgstr "No se puede colgar: no hay ninguna conexión telefónica activa."
 msgid "Cannot initialize OLE"
 msgstr "No se puede inicializar OLE"
 
-#: ../src/common/socket.cpp:853
+#: ../src/common/socket.cpp:850
 msgid "Cannot initialize sockets"
 msgstr "No se pueden inicializar los sockets"
 
-#: ../src/msw/volume.cpp:619
+#: ../src/msw/volume.cpp:627
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "No se puede cargar el icono desde «%s»."
 
-#: ../src/xrc/xmlres.cpp:360
+#: ../src/xrc/xmlres.cpp:358
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "No se pueden cargar recursos desde «%s»."
 
-#: ../src/xrc/xmlres.cpp:742
+#: ../src/xrc/xmlres.cpp:740
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "No se pueden cargar los recursos a partir del archivo «%s»."
 
-#: ../src/html/htmlfilt.cpp:137
+#: ../src/html/htmlfilt.cpp:134
 #, c-format
 msgid "Cannot open HTML document: %s"
 msgstr "No se puede abrir el documento HTML: %s"
 
-#: ../src/html/helpdata.cpp:667
+#: ../src/html/helpdata.cpp:660
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "No se puede abrir el libro de ayuda HTML: %s"
 
-#: ../src/html/helpdata.cpp:299
+#: ../src/html/helpdata.cpp:296
 #, c-format
 msgid "Cannot open contents file: %s"
 msgstr "No se puede abrir el archivo de contenidos: %s"
 
-#: ../src/generic/dcpsg.cpp:1667
+#: ../src/generic/dcpsg.cpp:1665
 msgid "Cannot open file for PostScript printing!"
 msgstr "No se puede abrir el archivo para impresión PostScript."
 
-#: ../src/html/helpdata.cpp:313
+#: ../src/html/helpdata.cpp:310
 #, c-format
 msgid "Cannot open index file: %s"
 msgstr "No se puede abrir el archivo de índice: %s"
 
-#: ../src/xrc/xmlres.cpp:724
+#: ../src/xrc/xmlres.cpp:722
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "No se puede cargar el archivo de recursos «%s»."
 
-#: ../src/html/helpwnd.cpp:1534
+#: ../src/html/helpwnd.cpp:1532
 msgid "Cannot print empty page."
 msgstr "No se puede imprimir una página vacía."
 
-#: ../src/msw/volume.cpp:507
+#: ../src/msw/volume.cpp:515
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "No se puede leer el nombre del tipo desde «%s»."
 
-#: ../src/msw/thread.cpp:888
+#: ../src/msw/thread.cpp:894
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "No se puede reanudar el hilo de ejecución %lx"
 
-#: ../src/unix/threadpsx.cpp:1016
+#: ../src/unix/threadpsx.cpp:1028
 msgid "Cannot retrieve thread scheduling policy."
 msgstr ""
 "No se puede recuperar la normativa de planificación de hilos de ejecución."
 
-#: ../src/common/intl.cpp:558
+#: ../src/common/intl.cpp:365
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "No se puede cambiar la configuración regional al idioma «%s»."
 
-#: ../src/unix/threadpsx.cpp:831 ../src/msw/thread.cpp:546
+#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
 msgid "Cannot start thread: error writing TLS."
 msgstr "No se puede iniciar el hilo de ejecución: error al escribir TLS."
 
-#: ../src/msw/thread.cpp:872
+#: ../src/msw/thread.cpp:864
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "No se puede suspender el hilo de ejecución %lx"
 
-#: ../src/msw/thread.cpp:794
+#: ../src/msw/thread.cpp:786
 msgid "Cannot wait for thread termination"
 msgstr "No se puede esperar a la finalización del hilo de ejecución"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:75
+#: ../src/common/accelcmn.cpp:72
 msgid "Capital"
 msgstr "Mayúscula"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:879
+#: ../src/propgrid/advprops.cpp:780
 msgid "CaptionText"
 msgstr "CaptionText"
 
-#: ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:531
 msgid "Case sensitive"
 msgstr "Distingue mayúsculas y minúsculas"
 
-#: ../src/propgrid/manager.cpp:1509
+#: ../src/propgrid/manager.cpp:1527
 msgid "Categorized Mode"
 msgstr "Modo categorizado"
 
-#: ../src/richtext/richtextbuffer.cpp:9968
+#: ../src/richtext/richtextbuffer.cpp:9965
 msgid "Cell Properties"
 msgstr "Propiedades de celda"
 
-#: ../src/common/fmapbase.cpp:161
+#: ../src/common/fmapbase.cpp:158
 msgid "Celtic (ISO-8859-14)"
 msgstr "Céltico (ISO-8859-14)"
 
-#: ../src/richtext/richtextindentspage.cpp:160
 #: ../src/richtext/richtextliststylepage.cpp:349
+#: ../src/richtext/richtextindentspage.cpp:160
 msgid "Cen&tred"
 msgstr "Cen&trado"
 
-#: ../src/common/stockitem.cpp:170
+#: ../src/common/stockitem.cpp:167
 msgid "Centered"
 msgstr "Centrado"
 
-#: ../src/common/fmapbase.cpp:149
+#: ../src/common/fmapbase.cpp:146
 msgid "Central European (ISO-8859-2)"
 msgstr "Europa Central (ISO-8859-2)"
 
@@ -1956,10 +1963,10 @@ msgstr "Europa Central (ISO-8859-2)"
 msgid "Centre"
 msgstr "Centrar"
 
-#: ../src/richtext/richtextindentspage.cpp:162
-#: ../src/richtext/richtextindentspage.cpp:164
 #: ../src/richtext/richtextliststylepage.cpp:351
 #: ../src/richtext/richtextliststylepage.cpp:353
+#: ../src/richtext/richtextindentspage.cpp:162
+#: ../src/richtext/richtextindentspage.cpp:164
 msgid "Centre text."
 msgstr "Centrar texto."
 
@@ -1972,24 +1979,24 @@ msgstr "Centrado"
 msgid "Ch&oose..."
 msgstr "&Elegir…"
 
-#: ../src/richtext/richtextbuffer.cpp:4354
+#: ../src/richtext/richtextbuffer.cpp:4351
 msgid "Change List Style"
 msgstr "Cambiar estilo de lista"
 
-#: ../src/richtext/richtextbuffer.cpp:3709
+#: ../src/richtext/richtextbuffer.cpp:3706
 msgid "Change Object Style"
 msgstr "Cambiar estilo de objeto"
 
-#: ../src/richtext/richtextbuffer.cpp:3982
-#: ../src/richtext/richtextbuffer.cpp:8129
+#: ../src/richtext/richtextbuffer.cpp:3979
+#: ../src/richtext/richtextbuffer.cpp:8125
 msgid "Change Properties"
 msgstr "Cambiar propiedades"
 
-#: ../src/richtext/richtextbuffer.cpp:3526
+#: ../src/richtext/richtextbuffer.cpp:3523
 msgid "Change Style"
 msgstr "Cambiar estilo"
 
-#: ../src/common/fileconf.cpp:341
+#: ../src/common/fileconf.cpp:335
 #, c-format
 msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
 msgstr ""
@@ -2002,11 +2009,11 @@ msgid "Changing current directory to \"%s\" failed"
 msgstr "Falló el cambio del directorio actual a «%s»"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1757
+#: ../src/propgrid/advprops.cpp:1658
 msgid "Character"
 msgstr "Carácter"
 
-#: ../src/richtext/richtextstyles.cpp:1063
+#: ../src/richtext/richtextstyles.cpp:1060
 msgid "Character styles"
 msgstr "Estilos de carácter"
 
@@ -2043,20 +2050,20 @@ msgstr "Active para encerrar la viñeta entre paréntesis."
 msgid "Check to indicate right-to-left text layout."
 msgstr "Active para indicar texto dispuesto de derecha a izquierda."
 
-#: ../src/osx/carbon/fontdlg.cpp:356 ../src/osx/carbon/fontdlg.cpp:358
+#: ../src/osx/carbon/fontdlg.cpp:353 ../src/osx/carbon/fontdlg.cpp:355
 msgid "Check to make the font bold."
 msgstr "Active para definir en negrita el tipo de letra."
 
-#: ../src/osx/carbon/fontdlg.cpp:363 ../src/osx/carbon/fontdlg.cpp:365
+#: ../src/osx/carbon/fontdlg.cpp:360 ../src/osx/carbon/fontdlg.cpp:362
 msgid "Check to make the font italic."
 msgstr "Active para definir en cursiva el tipo de letra."
 
-#: ../src/osx/carbon/fontdlg.cpp:372 ../src/osx/carbon/fontdlg.cpp:374
+#: ../src/osx/carbon/fontdlg.cpp:369 ../src/osx/carbon/fontdlg.cpp:371
 msgid "Check to make the font underlined."
 msgstr "Active para definir en subrayado el tipo de letra."
 
-#: ../src/richtext/richtextstyledlg.cpp:289
-#: ../src/richtext/richtextstyledlg.cpp:291
+#: ../src/richtext/richtextstyledlg.cpp:285
+#: ../src/richtext/richtextstyledlg.cpp:287
 msgid "Check to restart numbering."
 msgstr "Active para reiniciar la numeración."
 
@@ -2090,51 +2097,51 @@ msgstr "Active para mostrar el texto en superíndice."
 msgid "Check to suppress hyphenation."
 msgstr "Active para suprimir la división de palabras."
 
-#: ../src/msw/dialup.cpp:763
+#: ../src/msw/dialup.cpp:757
 msgid "Choose ISP to dial"
 msgstr "Elija un ISP al que conectar"
 
-#: ../src/propgrid/props.cpp:1922
+#: ../src/propgrid/props.cpp:1904
 msgid "Choose a directory:"
 msgstr "Elija un directorio:"
 
-#: ../src/propgrid/props.cpp:1975
+#: ../src/propgrid/props.cpp:2199
 msgid "Choose a file"
 msgstr "Elija un archivo"
 
-#: ../src/generic/colrdlgg.cpp:158 ../src/gtk/colordlg.cpp:54
+#: ../src/generic/colrdlgg.cpp:156 ../src/gtk/colordlg.cpp:49
 msgid "Choose colour"
 msgstr "Elija un color"
 
-#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/gtk1/fontdlg.cpp:125 ../src/generic/fontpickerg.cpp:47
+#: ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Elija un tipo de letra"
 
-#: ../src/common/module.cpp:74
+#: ../src/common/module.cpp:71
 #, c-format
 msgid "Circular dependency involving module \"%s\" detected."
 msgstr "Se ha detectado una dependencia circular concerniente al módulo «%s»."
 
-#: ../src/aui/tabmdi.cpp:108 ../src/generic/mdig.cpp:97
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
 msgid "Cl&ose"
 msgstr "&Cerrar"
 
-#: ../src/msw/ole/automtn.cpp:684
+#: ../src/msw/ole/automtn.cpp:675
 msgid "Class not registered."
 msgstr "Clase no registrada."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:147 ../src/common/accelcmn.cpp:72
+#: ../src/common/stockitem.cpp:144 ../src/common/accelcmn.cpp:69
 msgid "Clear"
 msgstr "Limpiar"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "Clear the log contents"
 msgstr "Eliminar el contenido del log"
 
-#: ../src/richtext/richtextstyledlg.cpp:252
-#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:248
+#: ../src/richtext/richtextstyledlg.cpp:250
 msgid "Click to apply the selected style."
 msgstr "Pulse para aplicar el estilo seleccionado."
 
@@ -2145,15 +2152,15 @@ msgstr "Pulse para aplicar el estilo seleccionado."
 msgid "Click to browse for a symbol."
 msgstr "Pulse click para buscar un símbolo."
 
-#: ../src/osx/carbon/fontdlg.cpp:403 ../src/osx/carbon/fontdlg.cpp:405
+#: ../src/osx/carbon/fontdlg.cpp:400 ../src/osx/carbon/fontdlg.cpp:402
 msgid "Click to cancel changes to the font."
 msgstr "Pulse para cancelar los cambios al tipo de letra."
 
-#: ../src/generic/fontdlgg.cpp:472 ../src/generic/fontdlgg.cpp:491
+#: ../src/generic/fontdlgg.cpp:468 ../src/generic/fontdlgg.cpp:487
 msgid "Click to cancel the font selection."
 msgstr "Pulse para cancelar la selección del tipo de letra."
 
-#: ../src/osx/carbon/fontdlg.cpp:384 ../src/osx/carbon/fontdlg.cpp:386
+#: ../src/osx/carbon/fontdlg.cpp:381 ../src/osx/carbon/fontdlg.cpp:383
 msgid "Click to change the font colour."
 msgstr "Pulse para cambiar el color de letra."
 
@@ -2172,37 +2179,37 @@ msgstr "Pulse para cambiar el color del texto."
 msgid "Click to choose the font for this level."
 msgstr "Pulse para elegir el tipo de letra de este nivel."
 
-#: ../src/richtext/richtextstyledlg.cpp:279
-#: ../src/richtext/richtextstyledlg.cpp:281
+#: ../src/richtext/richtextstyledlg.cpp:275
+#: ../src/richtext/richtextstyledlg.cpp:277
 msgid "Click to close this window."
 msgstr "Pulse para cerrar esta ventana."
 
-#: ../src/osx/carbon/fontdlg.cpp:410 ../src/osx/carbon/fontdlg.cpp:412
+#: ../src/osx/carbon/fontdlg.cpp:407 ../src/osx/carbon/fontdlg.cpp:409
 msgid "Click to confirm changes to the font."
 msgstr "Pulse para confirmar los cambios al tipo de letra."
 
-#: ../src/generic/fontdlgg.cpp:477 ../src/generic/fontdlgg.cpp:479
-#: ../src/generic/fontdlgg.cpp:484 ../src/generic/fontdlgg.cpp:486
+#: ../src/generic/fontdlgg.cpp:473 ../src/generic/fontdlgg.cpp:475
+#: ../src/generic/fontdlgg.cpp:480 ../src/generic/fontdlgg.cpp:482
 msgid "Click to confirm the font selection."
 msgstr "Pulse para confirmar la selección del tipo de letra."
 
-#: ../src/richtext/richtextstyledlg.cpp:244
-#: ../src/richtext/richtextstyledlg.cpp:246
+#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:242
 msgid "Click to create a new box style."
 msgstr "Pulse para crear un nuevo estilo de caja."
 
-#: ../src/richtext/richtextstyledlg.cpp:226
-#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:224
 msgid "Click to create a new character style."
 msgstr "Pulse para crear un nuevo estilo de caracter."
 
-#: ../src/richtext/richtextstyledlg.cpp:238
-#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:236
 msgid "Click to create a new list style."
 msgstr "Pulse para carear una nueva lista de estilo."
 
-#: ../src/richtext/richtextstyledlg.cpp:232
-#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:230
 msgid "Click to create a new paragraph style."
 msgstr "Pulse para crear un nuevo estilo de párrafo."
 
@@ -2216,8 +2223,8 @@ msgstr "Pulse para crear una nueva posición de tabulador."
 msgid "Click to delete all tab positions."
 msgstr "Pulse para borrar todas las posiciones de tabulación."
 
-#: ../src/richtext/richtextstyledlg.cpp:270
-#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:268
 msgid "Click to delete the selected style."
 msgstr "Pulse para borrar el estilo seleccionado."
 
@@ -2226,25 +2233,25 @@ msgstr "Pulse para borrar el estilo seleccionado."
 msgid "Click to delete the selected tab position."
 msgstr "Pulse para borrar la posición de tabulador seleccionada."
 
-#: ../src/richtext/richtextstyledlg.cpp:264
-#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:262
 msgid "Click to edit the selected style."
 msgstr "Pulse para editar el estilo seleccionado."
 
-#: ../src/richtext/richtextstyledlg.cpp:258
-#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:256
 msgid "Click to rename the selected style."
 msgstr "Pulse para renombrar el estilo seleccionado."
 
-#: ../src/generic/dbgrptg.cpp:97 ../src/generic/progdlgg.cpp:759
-#: ../src/richtext/richtextstyledlg.cpp:277
-#: ../src/richtext/richtextsymboldlg.cpp:476 ../src/common/stockitem.cpp:148
-#: ../src/msw/progdlg.cpp:170 ../src/msw/progdlg.cpp:679
-#: ../src/html/helpdlg.cpp:90
+#: ../src/common/stockitem.cpp:145 ../src/generic/dbgrptg.cpp:94
+#: ../src/generic/progdlgg.cpp:781 ../src/msw/progdlg.cpp:211
+#: ../src/msw/progdlg.cpp:946 ../src/html/helpdlg.cpp:87
+#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextstyledlg.cpp:273
 msgid "Close"
 msgstr "Cerrar"
 
-#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:98
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
 msgid "Close All"
 msgstr "Cerrar Todo"
 
@@ -2252,43 +2259,43 @@ msgstr "Cerrar Todo"
 msgid "Close current document"
 msgstr "Cerrar el documento actual"
 
-#: ../src/generic/logg.cpp:516
+#: ../src/generic/logg.cpp:513
 msgid "Close this window"
 msgstr "Cerrar esta ventana"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6006
+#: ../src/generic/datavgen.cpp:6811
 msgid "Collapse"
 msgstr "Contraer"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "Color"
 msgstr "Color"
 
-#: ../src/richtext/richtextformatdlg.cpp:776
+#: ../src/richtext/richtextformatdlg.cpp:768
 msgid "Colour"
 msgstr "Color"
 
-#: ../src/msw/colordlg.cpp:158
+#: ../src/msw/colordlg.cpp:227
 #, c-format
 msgid "Colour selection dialog failed with error %0lx."
 msgstr "El diálogo de selección de color falló con error %0lx."
 
-#: ../src/osx/carbon/fontdlg.cpp:380
+#: ../src/osx/carbon/fontdlg.cpp:377
 msgid "Colour:"
 msgstr "Color:"
 
-#: ../src/generic/datavgen.cpp:6077
+#: ../src/generic/datavgen.cpp:6882
 #, c-format
 msgid "Column %u"
 msgstr "Columna %u"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:114
+#: ../src/common/accelcmn.cpp:112
 msgid "Command"
 msgstr "Orden"
 
-#: ../src/common/init.cpp:196
+#: ../src/common/init.cpp:193
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
@@ -2296,23 +2303,23 @@ msgid ""
 msgstr ""
 "No se pudo convertir el argumento de consola %d en Unicode y se ignorará."
 
-#: ../src/msw/fontdlg.cpp:120
+#: ../src/msw/fontdlg.cpp:170
 #, c-format
 msgid "Common dialog failed with error code %0lx."
 msgstr "El diálogo común falló con error %0lx."
 
-#: ../src/gtk/window.cpp:4649
+#: ../src/gtk/window.cpp:5653
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
 msgstr ""
 "El sistema no admite la composición. Actívela en su gestor de ventanas."
 
-#: ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:1549
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Archivo de ayuda HTML comprimido (*.chm)|*.chm|"
 
-#: ../src/generic/dirctrlg.cpp:444
+#: ../src/generic/dirctrlg.cpp:410
 msgid "Computer"
 msgstr "Equipo"
 
@@ -2321,53 +2328,57 @@ msgstr "Equipo"
 msgid "Config entry name cannot start with '%c'."
 msgstr "Un nombre de entrada de configuración no puede empezar por «%c»."
 
-#: ../src/generic/filedlgg.cpp:349 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
 msgid "Confirm"
 msgstr "Confirmar"
 
-#: ../src/html/htmlwin.cpp:566
+#: ../src/html/htmlwin.cpp:569
 msgid "Connecting..."
 msgstr "Conectando…"
 
-#: ../src/html/helpwnd.cpp:475
+#: ../src/html/helpwnd.cpp:473
 msgid "Contents"
 msgstr "Contenidos"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:880
+#: ../src/propgrid/advprops.cpp:781
 msgid "ControlDark"
 msgstr "ControlDark"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:881
+#: ../src/propgrid/advprops.cpp:782
 msgid "ControlLight"
 msgstr "ControlLight"
 
-#: ../src/common/strconv.cpp:2262
+#: ../src/common/strconv.cpp:2208
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Conversión a juego de caracteres '%s' no funciona."
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "Convert"
 msgstr "Convertir"
 
-#: ../src/html/htmlwin.cpp:1079
+#: ../src/html/htmlwin.cpp:1020
 #, c-format
 msgid "Copied to clipboard:\"%s\""
 msgstr "Copiado en el portapapeles:\"%s\""
 
-#: ../src/generic/prntdlgg.cpp:247
+#: ../src/generic/prntdlgg.cpp:240
 msgid "Copies:"
 msgstr "Copias:"
 
-#: ../src/common/stockitem.cpp:150 ../src/stc/stc_i18n.cpp:18
+#: ../src/common/stockitem.cpp:147 ../src/stc/stc_i18n.cpp:18
 msgid "Copy"
 msgstr "Copiar"
 
-#: ../src/common/stockitem.cpp:258
+#: ../src/common/stockitem.cpp:255
 msgid "Copy selection"
 msgstr "Copiar selección"
+
+#: ../src/generic/grid.cpp:5945
+msgid "Copying more than one selected block to clipboard is not supported."
+msgstr ""
 
 #: ../src/richtext/richtextborderspage.cpp:566
 #: ../src/richtext/richtextborderspage.cpp:601
@@ -2378,198 +2389,195 @@ msgstr "Esquina"
 msgid "Corner &radius:"
 msgstr "&Radio de la esquina:"
 
-#: ../src/html/chm.cpp:718
+#: ../src/html/chm.cpp:711
 #, c-format
 msgid "Could not create temporary file '%s'"
 msgstr "No se pudo crear el archivo temporal '%s'"
 
-#: ../src/html/chm.cpp:273
+#: ../src/html/chm.cpp:270
 #, c-format
 msgid "Could not extract %s into %s: %s"
 msgstr "No se pudo extraer %s en %s: %s"
 
-#: ../src/generic/tabg.cpp:1048
+#: ../src/generic/tabg.cpp:1045
 msgid "Could not find tab for id"
 msgstr "No se pudo encontrar pestaña para id"
 
-#: ../src/gtk/notifmsg.cpp:108
-msgid "Could not initalize libnotify."
-msgstr "No se pudo inicializar libnotify."
-
-#: ../src/html/chm.cpp:444
+#: ../src/html/chm.cpp:437
 #, c-format
 msgid "Could not locate file '%s'."
 msgstr "No se pudo encontrar el archivo '%s'."
 
-#: ../src/common/filefn.cpp:1403
+#: ../src/msw/graphicsd2d.cpp:604
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/common/filefn.cpp:1291
 msgid "Could not set current working directory"
 msgstr "No se pudo establecer la carpeta de trabajo actual"
 
-#: ../src/common/prntbase.cpp:2015
+#: ../src/common/prntbase.cpp:2037
 msgid "Could not start document preview."
 msgstr "No se pudo iniciar la previsualización del documento."
 
-#: ../src/generic/printps.cpp:178 ../src/msw/printwin.cpp:210
-#: ../src/gtk/print.cpp:1132
+#: ../src/generic/printps.cpp:159 ../src/msw/printwin.cpp:184
+#: ../src/gtk/print.cpp:1129
 msgid "Could not start printing."
 msgstr "No se pudo iniciar la impresión."
 
-#: ../src/common/wincmn.cpp:2125
+#: ../src/common/wincmn.cpp:2126
 msgid "Could not transfer data to window"
 msgstr "No se pudieron transferir datos a la ventana"
 
-#: ../src/msw/imaglist.cpp:187 ../src/msw/imaglist.cpp:224
-#: ../src/msw/imaglist.cpp:249 ../src/msw/dragimag.cpp:185
-#: ../src/msw/dragimag.cpp:220
+#: ../src/msw/imaglist.cpp:223 ../src/msw/imaglist.cpp:245
+#: ../src/msw/imaglist.cpp:270 ../src/msw/dragimag.cpp:182
+#: ../src/msw/dragimag.cpp:217
 msgid "Couldn't add an image to the image list."
 msgstr "No se pudo añadir una imagen a la lista de imágenes."
 
-#: ../src/osx/glcanvas_osx.cpp:414 ../src/unix/glx11.cpp:558
-#: ../src/msw/glcanvas.cpp:616
+#: ../src/osx/glcanvas_osx.cpp:411 ../src/msw/glcanvas.cpp:631
+#: ../src/unix/glegl.cpp:315 ../src/unix/glx11.cpp:559
 msgid "Couldn't create OpenGL context"
 msgstr "No se pudo crear el contexto OpenGL"
 
-#: ../src/msw/timer.cpp:134
+#: ../src/msw/timer.cpp:131
 msgid "Couldn't create a timer"
 msgstr "No se pudo crear un temporizador"
 
-#: ../src/osx/carbon/overlay.cpp:122
-msgid "Couldn't create the overlay window"
-msgstr "No se pudo crear la ventana de superposición"
-
-#: ../src/common/translation.cpp:2024
+#: ../src/common/translation.cpp:2074
 msgid "Couldn't enumerate translations"
 msgstr "No se pudieron enumerar las traducciones"
 
-#: ../src/common/dynlib.cpp:120
+#: ../src/common/dynlib.cpp:110
 #, c-format
 msgid "Couldn't find symbol '%s' in a dynamic library"
 msgstr "No se pudo encontrar el símbolo «%s» en la biblioteca dinámica"
 
-#: ../src/msw/thread.cpp:915
+#: ../src/msw/thread.cpp:921
 msgid "Couldn't get the current thread pointer"
 msgstr "No se pudo obtener el puntero al hilo de ejecución actual"
 
-#: ../src/osx/carbon/overlay.cpp:129
-msgid "Couldn't init the context on the overlay window"
-msgstr "No se pudo inicializar el contexto en la ventana de superposición"
-
-#: ../src/common/imaggif.cpp:244
+#: ../src/common/imaggif.cpp:241
 msgid "Couldn't initialize GIF hash table."
 msgstr "No se pudo inicializar la tabla hash del GIF."
 
-#: ../src/common/imagpng.cpp:409
+#: ../src/common/imagpng.cpp:437
 msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
 msgstr ""
 "No se pudo abrir la imagen PNG: el archivo está dañado o no hay memoria "
 "suficiente."
 
-#: ../src/unix/sound.cpp:470
+#: ../src/unix/sound.cpp:459
 #, c-format
 msgid "Couldn't load sound data from '%s'."
 msgstr "No se pudieron cargar los datos de sonido desde «%s»."
 
-#: ../src/msw/dirdlg.cpp:435
+#: ../src/msw/dirdlg.cpp:287
 msgid "Couldn't obtain folder name"
 msgstr "No se pudo obtener el nombre la carpeta"
 
-#: ../src/unix/sound_sdl.cpp:229
+#: ../src/unix/sound_sdl.cpp:226
 #, c-format
 msgid "Couldn't open audio: %s"
 msgstr "No se pudo abrir el audio: %s"
 
-#: ../src/msw/ole/dataobj.cpp:377
+#: ../src/msw/ole/dataobj.cpp:385
 #, c-format
 msgid "Couldn't register clipboard format '%s'."
 msgstr "No se pudo registrar el formato del portapapeles «%s»."
 
-#: ../src/msw/listctrl.cpp:869
+#: ../src/msw/listctrl.cpp:933
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr ""
 "No se pudo obtener información sobre el elemento de control de la lista %d."
 
-#: ../src/common/imagpng.cpp:498 ../src/common/imagpng.cpp:509
-#: ../src/common/imagpng.cpp:519
+#: ../src/common/imagpng.cpp:511 ../src/common/imagpng.cpp:522
+#: ../src/common/imagpng.cpp:532
 msgid "Couldn't save PNG image."
 msgstr "No se pudo guardar la imagen PNG."
 
-#: ../src/msw/thread.cpp:684
+#: ../src/msw/thread.cpp:676
 msgid "Couldn't terminate thread"
 msgstr "No se pudo finalizar el hilo de ejecución"
 
-#: ../src/common/xtistrm.cpp:166
+#: ../src/common/xtistrm.cpp:163
 #, c-format
 msgid "Create Parameter %s not found in declared RTTI Parameters"
 msgstr ""
 "No se encontró el parámetro de Create %s en los parámetros RTTI declarados"
 
-#: ../src/generic/dirdlgg.cpp:288
+#: ../src/generic/dirdlgg.cpp:285
 msgid "Create directory"
 msgstr "Crear directorio"
 
-#: ../src/generic/filedlgg.cpp:212 ../src/generic/dirdlgg.cpp:111
+#: ../src/generic/filedlgg.cpp:209 ../src/generic/dirdlgg.cpp:108
 msgid "Create new directory"
 msgstr "Crear directorio nuevo"
 
-#: ../src/xrc/xmlres.cpp:2460
+#: ../src/common/stockitem.cpp:264
+#, fuzzy
+msgid "Create new document"
+msgstr "Crear directorio nuevo"
+
+#: ../src/xrc/xmlres.cpp:2515
 #, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Falló la creación de %s «%s»."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1758
+#: ../src/propgrid/advprops.cpp:1659
 msgid "Cross"
 msgstr "Cruz"
 
-#: ../src/common/accelcmn.cpp:333
+#: ../src/common/accelcmn.cpp:347
 msgid "Ctrl+"
 msgstr "Ctrl+"
 
-#: ../src/richtext/richtextctrl.cpp:332 ../src/osx/textctrl_osx.cpp:576
-#: ../src/common/stockitem.cpp:151 ../src/msw/textctrl.cpp:2507
+#: ../src/osx/textctrl_osx.cpp:594 ../src/common/stockitem.cpp:148
+#: ../src/msw/textctrl.cpp:2772 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "Cor&tar"
 
-#: ../src/generic/filectrlg.cpp:940
+#: ../src/generic/filectrlg.cpp:936
 msgid "Current directory:"
 msgstr "Directorio actual:"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:896 ../src/propgrid/advprops.cpp:1574
-#: ../src/propgrid/advprops.cpp:1612
+#: ../src/propgrid/advprops.cpp:797 ../src/propgrid/advprops.cpp:1475
+#: ../src/propgrid/advprops.cpp:1518
 msgid "Custom"
 msgstr "Personalizado"
 
-#: ../src/gtk/print.cpp:217
+#: ../src/gtk/print.cpp:211
 msgid "Custom size"
 msgstr "Tamaño personalizado"
 
-#: ../src/common/headerctrlcmn.cpp:60
+#: ../src/common/headerctrlcmn.cpp:58
 msgid "Customize Columns"
 msgstr "Personalizar columnas"
 
-#: ../src/common/stockitem.cpp:151 ../src/stc/stc_i18n.cpp:17
+#: ../src/common/stockitem.cpp:148 ../src/stc/stc_i18n.cpp:17
 msgid "Cut"
 msgstr "Cortar"
 
-#: ../src/common/stockitem.cpp:259
+#: ../src/common/stockitem.cpp:256
 msgid "Cut selection"
 msgstr "Cortar selección"
 
-#: ../src/common/fmapbase.cpp:152
+#: ../src/common/fmapbase.cpp:149
 msgid "Cyrillic (ISO-8859-5)"
 msgstr "Cirílico (ISO-8859-14)"
 
-#: ../src/common/paper.cpp:99
+#: ../src/common/paper.cpp:96
 msgid "D sheet, 22 x 34 in"
 msgstr "Hoja D, 22 x 34 in"
 
-#: ../src/msw/dde.cpp:703
+#: ../src/msw/dde.cpp:698
 msgid "DDE poke request failed"
 msgstr "Falló la petición de rastreo DDE"
 
-#: ../src/common/imagbmp.cpp:1169
+#: ../src/common/imagbmp.cpp:1181
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr "Cabecera DIB: La codificación no coincide con la profundidad de bits."
 
@@ -2589,7 +2597,7 @@ msgstr "Cabecera DIB: Profundidad de color desconocida en archivo."
 msgid "DIB Header: Unknown encoding in file."
 msgstr "Cabecera DIB: Codificación desconocida en archivo."
 
-#: ../src/common/paper.cpp:121
+#: ../src/common/paper.cpp:118
 msgid "DL Envelope, 110 x 220 mm"
 msgstr "Sobre DL, 110 x 220 mm"
 
@@ -2597,53 +2605,53 @@ msgstr "Sobre DL, 110 x 220 mm"
 msgid "Dashed"
 msgstr "Barrado"
 
-#: ../src/generic/dbgrptg.cpp:300
+#: ../src/generic/dbgrptg.cpp:301
 #, c-format
 msgid "Debug report \"%s\""
 msgstr "Informe de depuración «%s»"
 
-#: ../src/common/debugrpt.cpp:210
+#: ../src/common/debugrpt.cpp:211
 msgid "Debug report couldn't be created."
 msgstr "No se pudo crear el informe de depuración."
 
-#: ../src/common/debugrpt.cpp:553
+#: ../src/common/debugrpt.cpp:554
 msgid "Debug report generation has failed."
 msgstr "No se pudo generar el informe de depuración."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:84
+#: ../src/common/accelcmn.cpp:81
 msgid "Decimal"
 msgstr "Decimal"
 
-#: ../src/generic/fontdlgg.cpp:323
+#: ../src/generic/fontdlgg.cpp:319
 msgid "Decorative"
 msgstr "Decorativo"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1752
+#: ../src/propgrid/advprops.cpp:1653
 msgid "Default"
 msgstr "Predeterminado"
 
-#: ../src/common/fmapbase.cpp:796
+#: ../src/common/fmapbase.cpp:792
 msgid "Default encoding"
 msgstr "Codificación predeterminada"
 
-#: ../src/dfb/fontmgr.cpp:180
+#: ../src/dfb/fontmgr.cpp:177
 msgid "Default font"
 msgstr "Tipo de letra predeterminado"
 
-#: ../src/generic/prntdlgg.cpp:510
+#: ../src/generic/prntdlgg.cpp:503
 msgid "Default printer"
 msgstr "Impresora predeterminada"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:51
+#: ../src/common/accelcmn.cpp:48
 msgid "Del"
 msgstr "Eliminar"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextbuffer.cpp:8221 ../src/common/stockitem.cpp:152
-#: ../src/common/accelcmn.cpp:50 ../src/stc/stc_i18n.cpp:20
+#: ../src/common/stockitem.cpp:149 ../src/common/accelcmn.cpp:47
+#: ../src/richtext/richtextbuffer.cpp:8217 ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Eliminar"
 
@@ -2651,68 +2659,68 @@ msgstr "Eliminar"
 msgid "Delete A&ll"
 msgstr "Eliminar &todo"
 
-#: ../src/richtext/richtextbuffer.cpp:11341
+#: ../src/richtext/richtextbuffer.cpp:11340
 msgid "Delete Column"
 msgstr "Eliminar columna"
 
-#: ../src/richtext/richtextbuffer.cpp:11291
+#: ../src/richtext/richtextbuffer.cpp:11290
 msgid "Delete Row"
 msgstr "Eliminar fila"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 msgid "Delete Style"
 msgstr "Eliminar estilo"
 
-#: ../src/richtext/richtextctrl.cpp:1345 ../src/richtext/richtextctrl.cpp:1584
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
 msgid "Delete Text"
 msgstr "Eliminar texto"
 
-#: ../src/generic/editlbox.cpp:170
+#: ../src/generic/editlbox.cpp:147
 msgid "Delete item"
 msgstr "Eliminar elemento"
 
-#: ../src/common/stockitem.cpp:260
+#: ../src/common/stockitem.cpp:257
 msgid "Delete selection"
 msgstr "Borrar selección"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 #, c-format
 msgid "Delete style %s?"
 msgstr "¿Eliminar estilo %s?"
 
-#: ../src/unix/snglinst.cpp:301
+#: ../src/unix/snglinst.cpp:298
 #, c-format
 msgid "Deleted stale lock file '%s'."
 msgstr "Archivo antiguo de bloqueo '%s' eliminado."
 
-#: ../src/common/secretstore.cpp:220
-#, c-format
-msgid "Deleting password for \"%s/%s\" failed: %s."
+#: ../src/common/secretstore.cpp:234
+#, fuzzy, c-format
+msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Falló la eliminación de la contraseña de «%s/%s»: %s."
 
-#: ../src/common/module.cpp:124
+#: ../src/common/module.cpp:121
 #, c-format
 msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
 msgstr "No existe la dependencia \"%s\" del módulo \"%s\"."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "Descending"
 msgstr "Descendente"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:526 ../src/propgrid/advprops.cpp:882
+#: ../src/generic/dirctrlg.cpp:492 ../src/propgrid/advprops.cpp:783
 msgid "Desktop"
 msgstr "Escritorio"
 
-#: ../src/generic/aboutdlgg.cpp:70
+#: ../src/generic/aboutdlgg.cpp:67
 msgid "Developed by "
 msgstr "Desarrollado por "
 
-#: ../src/generic/aboutdlgg.cpp:176
+#: ../src/generic/aboutdlgg.cpp:173
 msgid "Developers"
 msgstr "Desarrolladores"
 
-#: ../src/msw/dialup.cpp:374
+#: ../src/msw/dialup.cpp:368
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -2720,11 +2728,11 @@ msgstr ""
 "Las funciones de marcado no están disponibles porque los servicios de acceso "
 "remoto (RAS) no están instalados. Por favor instálelos."
 
-#: ../src/generic/tipdlg.cpp:211
+#: ../src/generic/tipdlg.cpp:208
 msgid "Did you know..."
 msgstr "¿Sabía que…?"
 
-#: ../src/dfb/wrapdfb.cpp:63
+#: ../src/dfb/wrapdfb.cpp:60
 #, c-format
 msgid "DirectFB error %d occurred."
 msgstr "Ha ocurrido un error DirectFB %d."
@@ -2733,29 +2741,29 @@ msgstr "Ha ocurrido un error DirectFB %d."
 msgid "Directories"
 msgstr "Directorios"
 
-#: ../src/common/filefn.cpp:1183
+#: ../src/common/filefn.cpp:1071
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "No se pudo crear el directorio «%s»"
 
-#: ../src/common/filefn.cpp:1197
+#: ../src/common/filefn.cpp:1085
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "No se pudo eliminar el directorio «%s»"
 
-#: ../src/generic/dirdlgg.cpp:204
+#: ../src/generic/dirdlgg.cpp:201
 msgid "Directory does not exist"
 msgstr "El directorio no existe"
 
-#: ../src/generic/filectrlg.cpp:1399
+#: ../src/generic/filectrlg.cpp:1388
 msgid "Directory doesn't exist."
 msgstr "La carpeta no existe."
 
-#: ../src/common/docview.cpp:457
+#: ../src/common/docview.cpp:450
 msgid "Discard changes and reload the last saved version?"
 msgstr "¿Descartar los cambios y recargar la última versión guardada?"
 
-#: ../src/html/helpwnd.cpp:502
+#: ../src/html/helpwnd.cpp:500
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -2763,45 +2771,45 @@ msgstr ""
 "Mostrar todos los elementos del índice que contengan la subcadena dada. La "
 "búsqueda es Insensitiva."
 
-#: ../src/html/helpwnd.cpp:679
+#: ../src/html/helpwnd.cpp:677
 msgid "Display options dialog"
 msgstr "Mostrar el diálogo de opciones"
 
-#: ../src/html/helpwnd.cpp:322
+#: ../src/html/helpwnd.cpp:320
 msgid "Displays help as you browse the books on the left."
 msgstr "Muestra la ayuda mientras revisa los libros a la izquierda."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:85
+#: ../src/common/accelcmn.cpp:83
 msgid "Divide"
 msgstr "Dividir"
 
-#: ../src/common/docview.cpp:533
+#: ../src/common/docview.cpp:526
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "¿Desea guardar los cambios hechos a %s?"
 
-#: ../src/common/prntbase.cpp:542
+#: ../src/common/prntbase.cpp:537
 msgid "Document:"
 msgstr "Documento:"
 
-#: ../src/generic/aboutdlgg.cpp:73
+#: ../src/generic/aboutdlgg.cpp:70
 msgid "Documentation by "
 msgstr "Documentación por "
 
-#: ../src/generic/aboutdlgg.cpp:180
+#: ../src/generic/aboutdlgg.cpp:177
 msgid "Documentation writers"
 msgstr "Redactores de documentación"
 
-#: ../src/common/sizer.cpp:2799
+#: ../src/common/sizer.cpp:2916
 msgid "Don't Save"
 msgstr "No guardar"
 
-#: ../src/html/htmlwin.cpp:633
+#: ../src/html/htmlwin.cpp:643
 msgid "Done"
 msgstr "Hecho"
 
-#: ../src/generic/progdlgg.cpp:448 ../src/msw/progdlg.cpp:407
+#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
 msgid "Done."
 msgstr "Hecho."
 
@@ -2813,42 +2821,42 @@ msgstr "Punteado"
 msgid "Double"
 msgstr "Doble"
 
-#: ../src/common/paper.cpp:176
+#: ../src/common/paper.cpp:173
 msgid "Double Japanese Postcard Rotated 148 x 200 mm"
 msgstr "Tarjeta Japonesa Doble Girada 148 x 200 mm"
 
-#: ../src/common/xtixml.cpp:273
+#: ../src/common/xtixml.cpp:269
 #, c-format
 msgid "Doubly used id : %d"
 msgstr "Identificador usado dos veces: %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:153
-#: ../src/common/accelcmn.cpp:64
+#: ../src/common/stockitem.cpp:150 ../src/common/accelcmn.cpp:61
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Down"
 msgstr "Abajo"
 
-#: ../src/richtext/richtextctrl.cpp:865
+#: ../src/richtext/richtextctrl.cpp:864
 msgid "Drag"
 msgstr "Arrastrar"
 
-#: ../src/common/paper.cpp:100
+#: ../src/common/paper.cpp:97
 msgid "E sheet, 34 x 44 in"
 msgstr "Hoja E, 34 x 44 in"
 
-#: ../src/unix/fswatcher_inotify.cpp:561
+#: ../src/unix/fswatcher_inotify.cpp:558
 msgid "EOF while reading from inotify descriptor"
 msgstr "EOF mientras se leia del descriptor inotify"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "Edit"
 msgstr "Editar"
 
-#: ../src/generic/editlbox.cpp:168
+#: ../src/generic/editlbox.cpp:131
 msgid "Edit item"
 msgstr "Editar elemento"
 
-#: ../include/wx/generic/progdlgg.h:84
+#: ../include/wx/generic/progdlgg.h:85
 msgid "Elapsed time:"
 msgstr "Tiempo transcurrido:"
 
@@ -2915,49 +2923,49 @@ msgid "Enables the shadow spread."
 msgstr "Activa la difusión de la sombra."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:66
+#: ../src/common/accelcmn.cpp:63
 msgid "End"
 msgstr "Fin"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:55
+#: ../src/common/accelcmn.cpp:52
 msgid "Enter"
 msgstr "Intro"
 
-#: ../src/richtext/richtextstyledlg.cpp:934
+#: ../src/richtext/richtextstyledlg.cpp:930
 msgid "Enter a box style name"
 msgstr "Introduzca un nombre de estilo de caja"
 
-#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:602
 msgid "Enter a character style name"
 msgstr "Introduzca un nombre de estilo de caracter"
 
-#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:816
 msgid "Enter a list style name"
 msgstr "Introduzca un nombre de estilo de lista"
 
-#: ../src/richtext/richtextstyledlg.cpp:893
+#: ../src/richtext/richtextstyledlg.cpp:889
 msgid "Enter a new style name"
 msgstr "Introduzca un nuevo nombre de estilo"
 
-#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:650
 msgid "Enter a paragraph style name"
 msgstr "Introduzca un nombre de estilo de párrafo"
 
-#: ../src/generic/dbgrptg.cpp:174
+#: ../src/generic/dbgrptg.cpp:171
 #, c-format
 msgid "Enter command to open file \"%s\":"
 msgstr "Escriba la orden para abrir el archivo «%s»:"
 
-#: ../src/generic/helpext.cpp:459
+#: ../src/generic/helpext.cpp:457
 msgid "Entries found"
 msgstr "Entradas encontradas"
 
-#: ../src/common/paper.cpp:142
+#: ../src/common/paper.cpp:139
 msgid "Envelope Invite 220 x 220 mm"
 msgstr "Envelope Invite 220 x 220 mm"
 
-#: ../src/common/config.cpp:469
+#: ../src/common/config.cpp:465
 #, c-format
 msgid ""
 "Environment variables expansion failed: missing '%c' at position %u in '%s'."
@@ -2965,13 +2973,13 @@ msgstr ""
 "Fallo en expansión de variable de entorno: falta '%c' en la posición %u en "
 "'%s'."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/generic/dirctrlg.cpp:570
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/dirctrlg.cpp:599
-#: ../src/generic/dirdlgg.cpp:323 ../src/generic/filectrlg.cpp:642
-#: ../src/generic/filectrlg.cpp:756 ../src/generic/filectrlg.cpp:770
-#: ../src/generic/filectrlg.cpp:786 ../src/generic/filectrlg.cpp:1368
-#: ../src/generic/filectrlg.cpp:1399 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/gtk1/fontdlg.cpp:74 ../src/generic/dirctrlg.cpp:536
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/dirctrlg.cpp:565
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1357 ../src/generic/filectrlg.cpp:1388
+#: ../src/generic/filedlgg.cpp:354 ../src/generic/dirdlgg.cpp:320
+#: ../src/gtk/filedlg.cpp:74
 msgid "Error"
 msgstr "Error"
 
@@ -2979,86 +2987,97 @@ msgstr "Error"
 msgid "Error closing epoll descriptor"
 msgstr "Error al cerrar el descriptor epoll"
 
-#: ../src/unix/fswatcher_kqueue.cpp:114
+#: ../src/unix/fswatcher_kqueue.cpp:131
 msgid "Error closing kqueue instance"
 msgstr "Error cerrando la instancia kqueue"
 
-#: ../src/common/filefn.cpp:1049
+#: ../src/common/filefn.cpp:938
 #, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Falló la copia del archivo «%s» en «%s»."
 
-#: ../src/generic/dirdlgg.cpp:222
+#: ../src/generic/dirdlgg.cpp:219
 msgid "Error creating directory"
 msgstr "Error al crear el directorio"
 
-#: ../src/common/imagbmp.cpp:1181
+#: ../src/common/imagbmp.cpp:1193
 msgid "Error in reading image DIB."
 msgstr "Error al leer la imagen DIB."
 
-#: ../src/propgrid/propgrid.cpp:6696
+#: ../src/propgrid/propgrid.cpp:6665
 #, c-format
 msgid "Error in resource: %s"
 msgstr "Error en recurso: %s"
 
-#: ../src/common/fileconf.cpp:422
+#: ../src/common/fileconf.cpp:421
 msgid "Error reading config options."
 msgstr "Error al leer las opciones de configuración."
+
+#: ../src/msw/webview_ie.cpp:1057 ../src/msw/webview_edge.cpp:850
+#: ../src/gtk/webview_webkit2.cpp:1262 ../src/osx/webview_webkit.mm:383
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
 
 #: ../src/common/fileconf.cpp:1029
 msgid "Error saving user configuration data."
 msgstr "Error al guardar los datos de configuración del usuario."
 
-#: ../src/gtk/print.cpp:722
+#: ../src/gtk/print.cpp:720
 msgid "Error while printing: "
 msgstr "Error al imprimir: "
 
-#: ../src/common/log.cpp:219
+#: ../src/common/log.cpp:237
 msgid "Error: "
 msgstr "Error: "
 
+#: ../src/common/webrequest.cpp:98
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Error: "
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:69
+#: ../src/common/accelcmn.cpp:66
 msgid "Esc"
 msgstr "Esc"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:70
+#: ../src/common/accelcmn.cpp:67
 msgid "Escape"
 msgstr "Escape"
 
-#: ../src/common/fmapbase.cpp:150
+#: ../src/common/fmapbase.cpp:147
 msgid "Esperanto (ISO-8859-3)"
 msgstr "Esperanto (ISO-8859-3)"
 
-#: ../include/wx/generic/progdlgg.h:85
+#: ../include/wx/generic/progdlgg.h:86
 msgid "Estimated time:"
 msgstr "Tiempo estimado:"
 
-#: ../src/generic/dbgrptg.cpp:234
+#: ../src/generic/dbgrptg.cpp:231
 msgid "Executable files (*.exe)|*.exe|"
 msgstr "Archivos ejecutables (*.exe)|*.exe|"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:155 ../src/common/accelcmn.cpp:78
+#: ../src/common/stockitem.cpp:152 ../src/common/accelcmn.cpp:75
 msgid "Execute"
 msgstr "Ejecutar"
 
-#: ../src/msw/utilsexc.cpp:876
+#: ../src/msw/utilsexc.cpp:873
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Falló la ejecución de la orden «%s»"
 
-#: ../src/common/paper.cpp:105
+#: ../src/common/paper.cpp:102
 msgid "Executive, 7 1/4 x 10 1/2 in"
 msgstr "Ejecutivo, 7 1/4 x 10 1/2 pulgadas"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6009
+#: ../src/generic/datavgen.cpp:6814
 msgid "Expand"
 msgstr "Expandir"
 
-#: ../src/msw/registry.cpp:1240
+#: ../src/msw/registry.cpp:1228
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
@@ -3066,148 +3085,158 @@ msgstr ""
 "Exportando clave de Registro: el archivo «%s» ya existe y no se "
 "sobrescribirá."
 
-#: ../src/common/fmapbase.cpp:195
+#: ../src/common/fmapbase.cpp:192
 msgid "Extended Unix Codepage for Japanese (EUC-JP)"
 msgstr "Página de códigos extendidad Unix para japonés (EUC-JP)"
 
-#: ../src/html/chm.cpp:725
+#: ../src/html/chm.cpp:718
 #, c-format
 msgid "Extraction of '%s' into '%s' failed."
 msgstr "Falló la extracción de «%s» en «%s»."
 
-#: ../src/common/accelcmn.cpp:249 ../src/common/accelcmn.cpp:344
+#: ../src/common/accelcmn.cpp:259 ../src/common/accelcmn.cpp:358
 msgid "F"
 msgstr "F"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:672
+#: ../src/propgrid/advprops.cpp:582
 msgid "Face Name"
 msgstr "Nombre del tipo de letra"
 
-#: ../src/unix/snglinst.cpp:269
+#: ../src/unix/snglinst.cpp:266
 msgid "Failed to access lock file."
 msgstr "Fallo al acceder al archivo de bloqueo."
+
+#: ../src/gtk/font.cpp:572
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Falló la lectura del documento a partir del archivo «%s»."
 
 #: ../src/unix/epolldispatcher.cpp:116
 #, c-format
 msgid "Failed to add descriptor %d to epoll descriptor %d"
 msgstr "Fallo al añadir el descriptor %d al descriptor epoll %d"
 
-#: ../src/msw/dib.cpp:489
+#: ../src/msw/dib.cpp:535
 #, c-format
 msgid "Failed to allocate %luKb of memory for bitmap data."
 msgstr ""
 "No se pudieron reservar %lu kb de memoria para los datos del mapa de bits."
 
-#: ../src/common/glcmn.cpp:115
+#: ../src/common/glcmn.cpp:112
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Fallo al reservar un color para OpenGL"
 
-#: ../src/unix/displayx11.cpp:236
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Fallo al reservar un color para OpenGL"
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Fallo al reservar un color para OpenGL"
+
+#: ../include/wx/unix/private/displayx11.h:89
 msgid "Failed to change video mode"
 msgstr "Error al cambiar el modo de vídeo"
 
-#: ../src/common/image.cpp:3277
+#: ../src/common/image.cpp:3396
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Fallo comprobando el formato del archivo de imagen \"%s\"."
 
-#: ../src/common/debugrpt.cpp:239
+#: ../src/common/debugrpt.cpp:240
 #, c-format
 msgid "Failed to clean up debug report directory \"%s\""
 msgstr "No se pudo vaciar el directorio de informe de depuración \"%s\""
 
-#: ../src/common/filename.cpp:192
+#: ../src/common/filename.cpp:189
 msgid "Failed to close file handle"
 msgstr "Error al cerrar el manejador del archivo"
 
-#: ../src/unix/snglinst.cpp:340
+#: ../src/unix/snglinst.cpp:337
 #, c-format
 msgid "Failed to close lock file '%s'"
 msgstr "No se pudo cerrar el archivo de bloqueo '%s'"
 
-#: ../src/msw/clipbrd.cpp:112
+#: ../src/msw/clipbrd.cpp:110
 msgid "Failed to close the clipboard."
 msgstr "Error al cerrar el portapapeles."
 
-#: ../src/x11/utils.cpp:208
+#: ../src/x11/utils.cpp:170
 #, c-format
 msgid "Failed to close the display \"%s\""
 msgstr "No se pudo cerrar el display \"%s\""
 
-#: ../src/msw/dialup.cpp:797
+#: ../src/msw/dialup.cpp:791
 msgid "Failed to connect: missing username/password."
 msgstr "Fallo al conectar: faltan usuario/contraseña."
 
-#: ../src/msw/dialup.cpp:743
+#: ../src/msw/dialup.cpp:737
 msgid "Failed to connect: no ISP to dial."
 msgstr "Fallo al conectar: no hay ISP al que llamar."
 
-#: ../src/common/textfile.cpp:203
-#, c-format
-msgid "Failed to convert file \"%s\" to Unicode."
-msgstr "Fallo al convertir el archivo \"%s\" a Unicode."
-
-#: ../src/generic/logg.cpp:956
+#: ../src/generic/logg.cpp:953
 msgid "Failed to copy dialog contents to the clipboard."
 msgstr "Error al copiar el contenido del diálogo al portapapeles."
 
-#: ../src/msw/registry.cpp:692
+#: ../src/msw/registry.cpp:681
 #, c-format
 msgid "Failed to copy registry value '%s'"
 msgstr "Falló la copia del valor del Registro «%s»"
 
-#: ../src/msw/registry.cpp:701
+#: ../src/msw/registry.cpp:690
 #, c-format
 msgid "Failed to copy the contents of registry key '%s' to '%s'."
 msgstr "Fallo al copiar los contenidos de la clave del registro '%s' a '%s'."
 
-#: ../src/common/filefn.cpp:1015
+#: ../src/common/filefn.cpp:904
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "No se pudo copiar el archivo '%s' a '%s'"
 
-#: ../src/msw/registry.cpp:679
+#: ../src/msw/registry.cpp:668
 #, c-format
 msgid "Failed to copy the registry subkey '%s' to '%s'."
 msgstr "Error al copiar la subclave del registro '%s' en '%s'."
 
-#: ../src/msw/dde.cpp:1070
+#: ../src/msw/dde.cpp:1134
 msgid "Failed to create DDE string"
 msgstr "Fallo al crear cadena DDE"
 
-#: ../src/msw/mdi.cpp:616
+#: ../src/msw/mdi.cpp:621
 msgid "Failed to create MDI parent frame."
 msgstr "Falló la creación del panel MDI padre."
 
-#: ../src/common/filename.cpp:1027
+#: ../src/common/filename.cpp:1024
 msgid "Failed to create a temporary file name"
 msgstr "No se pudo crear un nombre temporal de archivo"
 
-#: ../src/msw/utilsexc.cpp:228
+#: ../src/msw/utilsexc.cpp:225
 msgid "Failed to create an anonymous pipe"
 msgstr "Fallo al crear tubería anónima"
 
-#: ../src/msw/ole/automtn.cpp:522
+#: ../src/msw/ole/automtn.cpp:513
 #, c-format
 msgid "Failed to create an instance of \"%s\""
 msgstr "Error creando una instancia de \"%s\""
 
-#: ../src/msw/dde.cpp:437
+#: ../src/msw/dde.cpp:432
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "Falló la creación de la conexión con el servidor «%s» en «%s»"
 
-#: ../src/msw/cursor.cpp:204
+#: ../src/msw/cursor.cpp:195
 msgid "Failed to create cursor."
 msgstr "Falló la creación del cursor."
 
-#: ../src/common/debugrpt.cpp:209
+#: ../src/common/debugrpt.cpp:210
 #, c-format
 msgid "Failed to create directory \"%s\""
 msgstr "Falló la creación del directorio «%s»"
 
-#: ../src/generic/dirdlgg.cpp:220
+#: ../src/generic/dirdlgg.cpp:217
 #, c-format
 msgid ""
 "Failed to create directory '%s'\n"
@@ -3220,116 +3249,135 @@ msgstr ""
 msgid "Failed to create epoll descriptor"
 msgstr "Falló la creación del descriptor epoll"
 
-#: ../src/msw/mimetype.cpp:238
+#: ../src/gtk/font.cpp:562
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "No se pudo actualizar el archivo de configuración de usuario."
+
+#: ../src/msw/mimetype.cpp:235
 #, c-format
 msgid "Failed to create registry entry for '%s' files."
 msgstr "Falló la creación de la entrada del Registro para los archivos «%s»."
 
-#: ../src/msw/fdrepdlg.cpp:409
+#: ../src/msw/fdrepdlg.cpp:408
 #, c-format
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr ""
 "Fallo al crear el diálogo estándar de buscar/reemplazar (código de error %d)"
 
-#: ../src/unix/wakeuppipe.cpp:52
+#: ../src/unix/wakeuppipe.cpp:49
 msgid "Failed to create wake up pipe used by event loop."
 msgstr ""
 "Falló la creación de la tubería de aviso usada por el bucle de sucesos."
 
-#: ../src/html/winpars.cpp:730
+#: ../src/html/winpars.cpp:727
 #, c-format
 msgid "Failed to display HTML document in %s encoding"
 msgstr "Error al mostrar el documento HTML con codificación %s"
 
-#: ../src/msw/clipbrd.cpp:124
+#: ../src/msw/clipbrd.cpp:122
 msgid "Failed to empty the clipboard."
 msgstr "Fallo al vaciar el portapapeles."
 
-#: ../src/unix/displayx11.cpp:212
+#: ../include/wx/unix/private/displayx11.h:65
 msgid "Failed to enumerate video modes"
 msgstr "Falló la enumeración de los modos de vídeo"
 
-#: ../src/msw/dde.cpp:722
+#: ../src/msw/dde.cpp:717
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "Fallo al establecer un lazo de aviso con el servidor DDE"
 
-#: ../src/msw/dialup.cpp:629 ../src/msw/dialup.cpp:863
+#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Fallo al establecer la conexión: %s"
 
-#: ../src/unix/utilsunx.cpp:611
+#: ../src/unix/utilsunx.cpp:613
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Error al ejecutar '%s'\n"
 
-#: ../src/common/debugrpt.cpp:720
+#: ../src/common/debugrpt.cpp:730
 msgid "Failed to execute curl, please install it in PATH."
 msgstr "Fallo al ejecutar curl, por favor instálelo en el PATH."
 
-#: ../src/msw/ole/automtn.cpp:505
+#: ../src/msw/ole/automtn.cpp:496
 #, c-format
 msgid "Failed to find CLSID of \"%s\""
 msgstr "No se encontró el CLSID de «%s»"
 
-#: ../src/common/regex.cpp:431 ../src/common/regex.cpp:479
+#: ../src/common/regex.cpp:428 ../src/common/regex.cpp:476
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "Failed to find match for regular expression: %s"
 
-#: ../src/msw/dialup.cpp:695
+#: ../src/msw/webview_ie.cpp:978
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:689
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Error al obtener nombres de ISP: %s"
 
-#: ../src/msw/ole/automtn.cpp:574
+#: ../src/msw/ole/automtn.cpp:565
 #, c-format
 msgid "Failed to get OLE automation interface for \"%s\""
 msgstr "No se pudo obtener la interfaz de automatización OLE para \"%s\""
 
-#: ../src/msw/clipbrd.cpp:711
+#: ../src/msw/clipbrd.cpp:731
 msgid "Failed to get data from the clipboard"
 msgstr "Error al obtener datos del portapapeles"
 
-#: ../src/common/time.cpp:223
+#: ../src/common/time.cpp:216
 msgid "Failed to get the local system time"
 msgstr "Error al obtener el sistema horario local"
 
-#: ../src/common/filefn.cpp:1345
+#: ../src/common/filefn.cpp:1233
 msgid "Failed to get the working directory"
 msgstr "Error al obtener el directorio de trabajo"
 
-#: ../src/univ/theme.cpp:114
+#: ../src/univ/theme.cpp:111
 msgid "Failed to initialize GUI: no built-in themes found."
 msgstr "Fallo al inicializar GUI: no se encontraron temas."
 
-#: ../src/msw/helpchm.cpp:63
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:60
 msgid "Failed to initialize MS HTML Help."
 msgstr "Fallo al inicializar la ayuda MS HTML."
 
-#: ../src/msw/glcanvas.cpp:1381
+#: ../src/msw/glcanvas.cpp:1391
 msgid "Failed to initialize OpenGL"
 msgstr "Falló la inicialización de OpenGL"
 
-#: ../src/msw/dialup.cpp:858
+#: ../src/msw/dialup.cpp:852
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Error al iniciar la conexión de marcado: %s"
 
-#: ../src/gtk/textctrl.cpp:1128
+#: ../src/gtk/textctrl.cpp:1209
 msgid "Failed to insert text in the control."
 msgstr "No se pudo insertar texto en el control."
 
-#: ../src/unix/snglinst.cpp:241
+#: ../src/unix/snglinst.cpp:238
 #, c-format
 msgid "Failed to inspect the lock file '%s'"
 msgstr "Error al inspeccionar el archivo de bloqueo '%s'"
 
-#: ../src/unix/appunix.cpp:182
+#: ../src/unix/appunix.cpp:179
 msgid "Failed to install signal handler"
 msgstr "Error instalando el manejador de señal"
 
-#: ../src/unix/threadpsx.cpp:1167
+#: ../src/unix/threadpsx.cpp:1216
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -3337,71 +3385,71 @@ msgstr ""
 "Error al sincronizar con un hilo de ejecución, pérdida potencial de memoría "
 "detectada - por favor reinicie el programa"
 
-#: ../src/msw/utils.cpp:629
+#: ../src/msw/utils.cpp:619
 #, c-format
 msgid "Failed to kill process %d"
 msgstr "No se pudo matar el proceso %d"
 
-#: ../src/common/image.cpp:2500
+#: ../src/common/image.cpp:2595
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "No se pudo cargar la imagen \"%s\" desde los recursos."
 
-#: ../src/common/image.cpp:2509
+#: ../src/common/image.cpp:2604
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "No se pudo cargar el icono \"%s\"  desde los recursos."
 
-#: ../src/common/iconbndl.cpp:225
+#: ../src/common/iconbndl.cpp:224
 #, c-format
 msgid "Failed to load icons from resource '%s'."
 msgstr "Falló la carga de los iconos a partir del recurso «%s»."
 
-#: ../src/common/iconbndl.cpp:200
+#: ../src/common/iconbndl.cpp:198
 #, c-format
 msgid "Failed to load image %%d from file '%s'."
 msgstr "No se pudo abrir la imagen %%d desde el archivo '%s'."
 
-#: ../src/common/iconbndl.cpp:208
+#: ../src/common/iconbndl.cpp:206
 #, c-format
 msgid "Failed to load image %d from stream."
 msgstr "No se pudo abrir la imagen %d desde el flujo."
 
-#: ../src/common/image.cpp:2587 ../src/common/image.cpp:2606
+#: ../src/common/image.cpp:2682 ../src/common/image.cpp:2701
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "No se pudo abrir la imagen desde el archivo \"'%s\"."
 
-#: ../src/msw/enhmeta.cpp:97
+#: ../src/msw/enhmeta.cpp:94
 #, c-format
 msgid "Failed to load metafile from file \"%s\"."
 msgstr "No se pudo abrir el metaarchivo desde el archivo \"%s\"."
 
-#: ../src/msw/volume.cpp:327
+#: ../src/msw/volume.cpp:335
 msgid "Failed to load mpr.dll."
 msgstr "No se pudo cargar mpr.dll."
 
-#: ../src/msw/utils.cpp:953
+#: ../src/msw/utils.cpp:943
 #, c-format
 msgid "Failed to load resource \"%s\"."
 msgstr "Falló la carga del recurso «%s»."
 
-#: ../src/common/dynlib.cpp:92
+#: ../src/common/dynlib.cpp:86
 #, c-format
 msgid "Failed to load shared library '%s'"
 msgstr "Falló la carga de la biblioteca compartida «%s»"
 
-#: ../src/osx/core/sound.cpp:145
+#: ../src/osx/core/sound.cpp:143
 #, c-format
 msgid "Failed to load sound from \"%s\" (error %d)."
 msgstr "No se pudo cargar el sonido de \"%s\" (error %d)."
 
-#: ../src/msw/utils.cpp:960
+#: ../src/msw/utils.cpp:950
 #, c-format
 msgid "Failed to lock resource \"%s\"."
 msgstr "Falló el bloqueo del recurso «%s»."
 
-#: ../src/unix/snglinst.cpp:198
+#: ../src/unix/snglinst.cpp:195
 #, c-format
 msgid "Failed to lock the lock file '%s'"
 msgstr "No se pudo bloquear el bloqueo del archivo '%s'"
@@ -3411,33 +3459,38 @@ msgstr "No se pudo bloquear el bloqueo del archivo '%s'"
 msgid "Failed to modify descriptor %d in epoll descriptor %d"
 msgstr "No se pudo modificar el descriptor %d en el descriptor epoll %d"
 
-#: ../src/common/filename.cpp:2575
+#: ../src/common/filename.cpp:2658
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "No se pudo modificar la hora del archivo para '%s'"
 
-#: ../src/common/selectdispatcher.cpp:258
+#: ../src/common/selectdispatcher.cpp:255
 msgid "Failed to monitor I/O channels"
 msgstr "Fallo al monitorizar los canales de E/S"
 
-#: ../src/common/filename.cpp:175
+#: ../src/common/filename.cpp:172
 #, c-format
 msgid "Failed to open '%s' for reading"
 msgstr "Falló la apertura del archivo «%s» para su lectura"
 
-#: ../src/common/filename.cpp:180
+#: ../src/common/filename.cpp:177
 #, c-format
 msgid "Failed to open '%s' for writing"
 msgstr "Falló la apertura del archivo «%s» para su escritura"
 
-#: ../src/html/chm.cpp:141
+#: ../src/html/chm.cpp:138
 #, c-format
 msgid "Failed to open CHM archive '%s'."
 msgstr "Falló la apertura del archivador CHM «%s»."
 
-#: ../src/common/utilscmn.cpp:1126
+#: ../src/common/utilscmn.cpp:1140
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Falló la apertura del URL «%s» en el navegador predeterminado."
+
+#: ../src/common/hyperlnkcmn.cpp:133
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Falló la apertura del URL «%s» en el navegador predeterminado."
 
 #: ../include/wx/msw/private/fswatcher.h:92
@@ -3445,93 +3498,103 @@ msgstr "Falló la apertura del URL «%s» en el navegador predeterminado."
 msgid "Failed to open directory \"%s\" for monitoring."
 msgstr "Falló la apertura del directorio «%s» para su monitorización."
 
-#: ../src/x11/utils.cpp:227
+#: ../src/x11/utils.cpp:189
 #, c-format
 msgid "Failed to open display \"%s\"."
 msgstr "Falló la apertura de la pantalla «%s»."
 
-#: ../src/common/filename.cpp:1062
+#: ../src/common/filename.cpp:1059
 msgid "Failed to open temporary file."
 msgstr "Falló la apertura del archivo temporal."
 
-#: ../src/msw/clipbrd.cpp:91
+#: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Falló la apertura del portapapeles."
 
-#: ../src/common/translation.cpp:1184
+#: ../src/common/translation.cpp:1226
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "No se pudieron analizar las formas plurales: «%s»"
 
-#: ../src/unix/mediactrl.cpp:1214
+#: ../src/unix/mediactrl.cpp:1239
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Falló la preparación de la reproducción de «%s»."
 
-#: ../src/msw/clipbrd.cpp:600
+#: ../src/msw/clipbrd.cpp:610
 msgid "Failed to put data on the clipboard"
 msgstr "Falló la transferencia de datos al portapapeles"
 
-#: ../src/unix/snglinst.cpp:278
+#: ../src/unix/snglinst.cpp:275
 msgid "Failed to read PID from lock file."
 msgstr "Falló la lectura del PID a partir del archivo de bloqueo."
 
-#: ../src/common/fileconf.cpp:433
+#: ../src/common/fileconf.cpp:432
 msgid "Failed to read config options."
 msgstr "Falló la lectura de las opciones de configuración."
 
-#: ../src/common/docview.cpp:681
+#: ../src/common/docview.cpp:676
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Falló la lectura del documento a partir del archivo «%s»."
 
-#: ../src/dfb/evtloop.cpp:98
+#: ../src/dfb/evtloop.cpp:99
 msgid "Failed to read event from DirectFB pipe"
 msgstr "Falló la lectura del suceso a partir de la tubería DirectFB"
 
-#: ../src/unix/wakeuppipe.cpp:120
+#: ../src/unix/wakeuppipe.cpp:117
 msgid "Failed to read from wake-up pipe"
 msgstr "Fallo leyendo de la tubería de aviso."
 
-#: ../src/unix/utilsunx.cpp:679
+#: ../src/common/textfile.cpp:96
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Falló la lectura del documento a partir del archivo «%s»."
+
+#: ../src/unix/utilsunx.cpp:681
 msgid "Failed to redirect child process input/output"
 msgstr "Error en la redirección de la entrada/salida del proceso hijo"
 
-#: ../src/msw/utilsexc.cpp:701
+#: ../src/msw/utilsexc.cpp:698
 msgid "Failed to redirect the child process IO"
 msgstr "Error en la redirección de la entrada/salida del proceso hijo"
 
-#: ../src/msw/dde.cpp:288
+#: ../src/msw/dde.cpp:283
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Error al registrar el servidor DDE '%s'"
 
-#: ../src/common/fontmap.cpp:245
+#: ../src/gtk/font.cpp:580
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "No se pudo actualizar el archivo de configuración de usuario."
+
+#: ../src/common/fontmap.cpp:242
 #, c-format
 msgid "Failed to remember the encoding for the charset '%s'."
 msgstr "Error al recordar la codificación para el conjunto de caracteres '%s'."
 
-#: ../src/common/debugrpt.cpp:227
+#: ../src/common/debugrpt.cpp:228
 #, c-format
 msgid "Failed to remove debug report file \"%s\""
 msgstr "No se pudo eliminar el archivo de informe de depuración '%s'"
 
-#: ../src/unix/snglinst.cpp:328
+#: ../src/unix/snglinst.cpp:325
 #, c-format
 msgid "Failed to remove lock file '%s'"
 msgstr "No se pudo quitar el archivo de bloqueo '%s'"
 
-#: ../src/unix/snglinst.cpp:288
+#: ../src/unix/snglinst.cpp:285
 #, c-format
 msgid "Failed to remove stale lock file '%s'."
 msgstr "No se pudo eliminar el antiguo archivo de bloqueo '%s'."
 
-#: ../src/msw/registry.cpp:529
+#: ../src/msw/registry.cpp:518
 #, c-format
 msgid "Failed to rename registry value '%s' to '%s'."
 msgstr "Fallo al renombrar valor del registro '%s' a '%s'."
 
-#: ../src/common/filefn.cpp:1122
+#: ../src/common/filefn.cpp:1011
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -3540,117 +3603,126 @@ msgstr ""
 "No se pudo renombrar el archivo '%s' a '%s' porque el archivo de destino ya "
 "existe."
 
-#: ../src/msw/registry.cpp:634
+#: ../src/msw/registry.cpp:623
 #, c-format
 msgid "Failed to rename the registry key '%s' to '%s'."
 msgstr "Error al renombrar la clave del registro '%s' a '%s'."
 
-#: ../src/common/filename.cpp:2671
+#: ../src/msw/webview_ie.cpp:995
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/common/filename.cpp:2754
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "No se pudo obtener horas del archivo para '%s'"
 
-#: ../src/msw/dialup.cpp:468
+#: ../src/msw/dialup.cpp:462
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Fallo al recuperar el mensaje de error de RAS"
 
-#: ../src/msw/clipbrd.cpp:748
+#: ../src/msw/clipbrd.cpp:768
 msgid "Failed to retrieve the supported clipboard formats"
 msgstr "Falló la recuperación de los formatos admitidos del portapapeles"
 
-#: ../src/common/docview.cpp:652
+#: ../src/common/docview.cpp:647
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Falló el guardado del documento en el archivo «%s»."
 
-#: ../src/msw/dib.cpp:269
+#: ../src/msw/dib.cpp:312
 #, c-format
 msgid "Failed to save the bitmap image to file \"%s\"."
 msgstr "Falló el guardado de la imagen de mapa de bits en el archivo «%s»."
 
-#: ../src/msw/dde.cpp:763
+#: ../src/msw/dde.cpp:811
 msgid "Failed to send DDE advise notification"
 msgstr "Fallo al enviar notificación de aviso DDE"
 
-#: ../src/common/ftp.cpp:402
+#: ../src/common/ftp.cpp:399
 #, c-format
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Falló la definición del modo de transferencia FTP a %s."
 
-#: ../src/msw/clipbrd.cpp:427
+#: ../src/msw/clipbrd.cpp:443
 msgid "Failed to set clipboard data."
 msgstr "Error al colocar datos en el portapapeles."
 
-#: ../src/unix/snglinst.cpp:181
+#: ../src/unix/snglinst.cpp:178
 #, c-format
 msgid "Failed to set permissions on lock file '%s'"
 msgstr "No se pudieron establecer permisos para el archivo de bloqueo '%s'"
 
-#: ../src/unix/utilsunx.cpp:668
+#: ../src/unix/utilsunx.cpp:670
 msgid "Failed to set process priority"
 msgstr "Error al establecer la prioridad del proceso"
 
-#: ../src/common/file.cpp:559
+#: ../src/common/ffile.cpp:355 ../src/common/file.cpp:586
 msgid "Failed to set temporary file permissions"
 msgstr "No se pudieron cambiar permisos del archivo temporal"
 
-#: ../src/gtk/textctrl.cpp:1072
-msgid "Failed to set text in the text control."
-msgstr "No se pudo colocar texto en el control de texto."
-
-#: ../src/unix/threadpsx.cpp:1298
+#: ../src/unix/threadpsx.cpp:1347
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr ""
 "Error al establecer el nivel de concurrencia del hilo de ejecución a %lu"
 
-#: ../src/unix/threadpsx.cpp:1424
+#: ../src/unix/threadpsx.cpp:1473
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Error al establecer la prioridad del hilo de ejecución %d."
 
-#: ../src/unix/utilsunx.cpp:783
+#: ../src/unix/utilsunx.cpp:785
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 "Fallo al establecer una tubería no bloqueante, el progrma puede colgarse."
 
-#: ../src/common/fs_mem.cpp:261
+#: ../src/msw/webview_ie.cpp:987
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:256
 #, c-format
 msgid "Failed to store image '%s' to memory VFS!"
 msgstr "Falló el almacenamiento de la imagen «%s» en el VFS de memoria."
 
-#: ../src/dfb/evtloop.cpp:170
+#: ../src/dfb/evtloop.cpp:171
 msgid "Failed to switch DirectFB pipe to non-blocking mode"
 msgstr "Fallo al cambiar la tubería DirectFB a modo no bloqueante"
 
-#: ../src/unix/wakeuppipe.cpp:59
+#: ../src/unix/wakeuppipe.cpp:56
 msgid "Failed to switch wake up pipe to non-blocking mode"
 msgstr "Fallo al cambiar la tubería de aviso a modo no bloqueante"
 
-#: ../src/unix/threadpsx.cpp:1605
+#: ../src/unix/threadpsx.cpp:1654
 msgid "Failed to terminate a thread."
 msgstr "Error al terminar un hilo de ejecución."
 
-#: ../src/msw/dde.cpp:741
+#: ../src/msw/dde.cpp:736
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "Error al terminar el bucle de aviso con el servidor DDE"
 
-#: ../src/msw/dialup.cpp:938
+#: ../src/msw/dialup.cpp:932
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Error al terminar la conexión: %s"
 
-#: ../src/common/filename.cpp:2590
+#: ../src/common/filename.cpp:2673
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "No se pudo  retocar' el archivo '%s'"
 
-#: ../src/unix/snglinst.cpp:334
+#: ../src/unix/dlunix.cpp:90
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "Falló la carga de la biblioteca compartida «%s»"
+
+#: ../src/unix/snglinst.cpp:331
 #, c-format
 msgid "Failed to unlock lock file '%s'"
 msgstr "No se pudo desbloquear el archivo de bloqueo '%s'"
 
-#: ../src/msw/dde.cpp:309
+#: ../src/msw/dde.cpp:304
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Error al desregistrar el servidor DDE '%s'"
@@ -3666,77 +3738,87 @@ msgstr ""
 msgid "Failed to update user configuration file."
 msgstr "No se pudo actualizar el archivo de configuración de usuario."
 
-#: ../src/common/debugrpt.cpp:733
+#: ../src/common/debugrpt.cpp:743
 #, c-format
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Fallo al enviar el informe de depuración (código error %d)"
 
-#: ../src/unix/snglinst.cpp:168
+#: ../src/unix/snglinst.cpp:165
 #, c-format
 msgid "Failed to write to lock file '%s'"
 msgstr "No se pudo escribir en el archivo de bloqueo «%s»"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:209
+#: ../src/propgrid/propgrid.cpp:190
 msgid "False"
 msgstr "Falso"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:694
+#: ../src/propgrid/advprops.cpp:604
 msgid "Family"
 msgstr "Familia"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/gtk/glcanvas.cpp:176 ../src/gtk/glcanvas.cpp:187
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Error de archivo"
+
+#: ../src/common/stockitem.cpp:154
 msgid "File"
 msgstr "Archivo"
 
-#: ../src/common/docview.cpp:669
+#: ../src/common/docview.cpp:664
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "No se pudo abrir el archivo «%s» para su lectura."
 
-#: ../src/common/docview.cpp:646
+#: ../src/common/docview.cpp:641
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "No se pudo abrir el archivo «%s» para su escritura."
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "El archivo «%s» ya existe; ¿realmente quiere sobrescribirlo?"
 
-#: ../src/common/filefn.cpp:1156
+#: ../src/common/filefn.cpp:1044
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "No se pudo quitar el archivo «%s»"
 
-#: ../src/common/filefn.cpp:1139
+#: ../src/common/filefn.cpp:1028
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "No se pudo cambiar el nombre del archivo «%s» como «%s»"
 
-#: ../src/richtext/richtextctrl.cpp:3081 ../src/common/textcmn.cpp:953
+#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
 msgid "File couldn't be loaded."
 msgstr "No se pudo abrir el archivo."
 
-#: ../src/msw/filedlg.cpp:393
+#: ../src/msw/filedlg.cpp:414
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "El diálogo de archivo falló con código de error %0lx."
 
-#: ../src/common/docview.cpp:1789
+#: ../src/common/docview.cpp:1783
 msgid "File error"
 msgstr "Error de archivo"
 
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/filectrlg.cpp:770
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/filectrlg.cpp:766
 msgid "File name exists already."
 msgstr "Ya existe un archivo con el mismo nombre."
+
+#: ../src/osx/cocoa/filedlg.mm:264
+#, fuzzy
+msgid "File type:"
+msgstr "Teletipo"
 
 #: ../src/motif/filedlg.cpp:220
 msgid "Files"
 msgstr "Archivos"
 
-#: ../src/common/filefn.cpp:1591
+#: ../src/common/filefn.cpp:1479
 #, c-format
 msgid "Files (%s)"
 msgstr "Archivos (%s)"
@@ -3745,15 +3827,29 @@ msgstr "Archivos (%s)"
 msgid "Filter"
 msgstr "Filtro"
 
-#: ../src/common/stockitem.cpp:158 ../src/html/helpwnd.cpp:490
+#: ../src/html/helpwnd.cpp:488
 msgid "Find"
 msgstr "Buscar"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:259
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:258
+#, fuzzy
+msgid "Find in document"
+msgstr "Abrir documento HTML"
+
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "Find..."
+msgstr "Buscar"
+
+#: ../src/common/stockitem.cpp:156
 msgid "First"
 msgstr "Primero"
 
-#: ../src/common/prntbase.cpp:1548
+#: ../src/common/prntbase.cpp:1573
 msgid "First page"
 msgstr "Primera página"
 
@@ -3761,11 +3857,11 @@ msgstr "Primera página"
 msgid "Fixed"
 msgstr "Fija"
 
-#: ../src/html/helpwnd.cpp:1206
+#: ../src/html/helpwnd.cpp:1204
 msgid "Fixed font:"
 msgstr "Tipo monoespaciado:"
 
-#: ../src/html/helpwnd.cpp:1269
+#: ../src/html/helpwnd.cpp:1267
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Tipo de letra de tamaño fijo.<br> <b>negrita</b> <i>cursiva</i> "
 
@@ -3773,16 +3869,16 @@ msgstr "Tipo de letra de tamaño fijo.<br> <b>negrita</b> <i>cursiva</i> "
 msgid "Floating"
 msgstr "Flotante"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "Floppy"
 msgstr "Disco flexible"
 
-#: ../src/common/paper.cpp:111
+#: ../src/common/paper.cpp:108
 msgid "Folio, 8 1/2 x 13 in"
 msgstr "Folio, 8 1/2 × 13 in"
 
-#: ../src/richtext/richtextformatdlg.cpp:344 ../src/osx/carbon/fontdlg.cpp:287
-#: ../src/common/stockitem.cpp:194
+#: ../src/osx/carbon/fontdlg.cpp:284 ../src/common/stockitem.cpp:191
+#: ../src/richtext/richtextformatdlg.cpp:337
 msgid "Font"
 msgstr "Tipo de letra"
 
@@ -3790,7 +3886,24 @@ msgstr "Tipo de letra"
 msgid "Font &weight:"
 msgstr "&Peso tipográfico:"
 
-#: ../src/html/helpwnd.cpp:1207
+#: ../src/osx/fontutil.cpp:89
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
+"\"."
+msgstr ""
+
+#: ../src/msw/font.cpp:1126
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "No se pudo abrir el archivo."
+
+#: ../src/osx/fontutil.cpp:81
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr ": ¡el archivo no existe!"
+
+#: ../src/html/helpwnd.cpp:1205
 msgid "Font size:"
 msgstr "Tamaño de letra:"
 
@@ -3798,55 +3911,55 @@ msgstr "Tamaño de letra:"
 msgid "Font st&yle:"
 msgstr "&Estilo tipográfico:"
 
-#: ../src/osx/carbon/fontdlg.cpp:329
+#: ../src/osx/carbon/fontdlg.cpp:326
 msgid "Font:"
 msgstr "Tipo de letra:"
 
-#: ../src/dfb/fontmgr.cpp:198
+#: ../src/dfb/fontmgr.cpp:195
 #, c-format
 msgid "Fonts index file %s disappeared while loading fonts."
 msgstr ""
 "El archivo de índice tipográfico %s desapareció mientras se cargaban los "
 "tipos de letra."
 
-#: ../src/unix/utilsunx.cpp:645
+#: ../src/unix/utilsunx.cpp:647
 msgid "Fork failed"
 msgstr "Error en bifurcación de proceso (fork)"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "Forward"
 msgstr "Adelante"
 
-#: ../src/common/xtixml.cpp:235
+#: ../src/common/xtixml.cpp:231
 msgid "Forward hrefs are not supported"
 msgstr "No se admiten los HREF de reenvío"
 
-#: ../src/html/helpwnd.cpp:875
+#: ../src/html/helpwnd.cpp:873
 #, c-format
 msgid "Found %i matches"
 msgstr "Se encontraron %i coincidencias"
 
-#: ../src/generic/prntdlgg.cpp:238
+#: ../src/generic/prntdlgg.cpp:231
 msgid "From:"
 msgstr "De:"
 
-#: ../src/propgrid/advprops.cpp:1604
+#: ../src/propgrid/advprops.cpp:1510
 msgid "Fuchsia"
 msgstr "Fucsia"
 
-#: ../src/common/imaggif.cpp:138
+#: ../src/common/imaggif.cpp:135
 msgid "GIF: data stream seems to be truncated."
 msgstr "GIF: el flujo de datos parece haberse truncado."
 
-#: ../src/common/imaggif.cpp:128
+#: ../src/common/imaggif.cpp:125
 msgid "GIF: error in GIF image format."
 msgstr "GIF: error en formato de imagen GIF."
 
-#: ../src/common/imaggif.cpp:133
+#: ../src/common/imaggif.cpp:130
 msgid "GIF: not enough memory."
 msgstr "GIF: memoria insuficiente."
 
-#: ../src/gtk/window.cpp:4631
+#: ../src/gtk/window.cpp:5635
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -3854,23 +3967,23 @@ msgstr ""
 "El GTK+ instalado en esta máquina es demasiado antiguo para admitir la "
 "composición de pantallas; instale GTK+ 2.12 o posterior."
 
-#: ../src/univ/themes/gtk.cpp:525
+#: ../src/univ/themes/gtk.cpp:522
 msgid "GTK+ theme"
 msgstr "Tema de GTK+"
 
-#: ../src/common/preferencescmn.cpp:40
+#: ../src/common/preferencescmn.cpp:37
 msgid "General"
 msgstr "General"
 
-#: ../src/common/prntbase.cpp:258
+#: ../src/common/prntbase.cpp:253
 msgid "Generic PostScript"
 msgstr "PostScript genérico"
 
-#: ../src/common/paper.cpp:135
+#: ../src/common/paper.cpp:132
 msgid "German Legal Fanfold, 8 1/2 x 13 in"
 msgstr "German Legal Fanfold, 8 1/2 × 13 in"
 
-#: ../src/common/paper.cpp:134
+#: ../src/common/paper.cpp:131
 msgid "German Std Fanfold, 8 1/2 x 12 in"
 msgstr "German Std Fanfold, 8 1/2 × 12 in"
 
@@ -3886,48 +3999,48 @@ msgstr "Se llamó a GetPropertyCollection sobre un accedente genérico"
 msgid "GetPropertyCollection called w/o valid collection getter"
 msgstr "Se llamó a GetPropertyCollection sin un captador de colecciones válido"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:658
 msgid "Go back"
 msgstr "Retroceder"
 
-#: ../src/html/helpwnd.cpp:661
+#: ../src/html/helpwnd.cpp:659
 msgid "Go forward"
 msgstr "Avanzar"
 
-#: ../src/html/helpwnd.cpp:663
+#: ../src/html/helpwnd.cpp:661
 msgid "Go one level up in document hierarchy"
 msgstr "Subir un nivel en la jerarquía del documento"
 
-#: ../src/generic/filedlgg.cpp:208 ../src/generic/dirdlgg.cpp:116
+#: ../src/generic/filedlgg.cpp:205 ../src/generic/dirdlgg.cpp:113
 msgid "Go to home directory"
 msgstr "Ir al directorio de usuario"
 
-#: ../src/generic/filedlgg.cpp:205
+#: ../src/generic/filedlgg.cpp:202
 msgid "Go to parent directory"
 msgstr "Ir al directorio contenedor"
 
-#: ../src/generic/aboutdlgg.cpp:76
+#: ../src/generic/aboutdlgg.cpp:73
 msgid "Graphics art by "
 msgstr "Arte gráfico por "
 
-#: ../src/propgrid/advprops.cpp:1599
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Gray"
 msgstr "Gris"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:883
+#: ../src/propgrid/advprops.cpp:784
 msgid "GrayText"
 msgstr "GrayText"
 
-#: ../src/common/fmapbase.cpp:154
+#: ../src/common/fmapbase.cpp:151
 msgid "Greek (ISO-8859-7)"
 msgstr "Griego (ISO-8859-7)"
 
-#: ../src/propgrid/advprops.cpp:1600
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Green"
 msgstr "Verde"
 
-#: ../src/generic/colrdlgg.cpp:342
+#: ../src/generic/colrdlgg.cpp:362
 msgid "Green:"
 msgstr "Verde:"
 
@@ -3935,107 +4048,107 @@ msgstr "Verde:"
 msgid "Groove"
 msgstr "Ranura"
 
-#: ../src/common/zstream.cpp:158 ../src/common/zstream.cpp:318
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
 msgid "Gzip not supported by this version of zlib"
 msgstr "Esta versión de zlib no admite GZIP"
 
-#: ../src/html/helpwnd.cpp:1549
+#: ../src/html/helpwnd.cpp:1547
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "Proyecto de ayuda HTML (*.hhp)|*.hhp|"
 
-#: ../src/html/htmlwin.cpp:681
+#: ../src/html/htmlwin.cpp:691
 #, c-format
 msgid "HTML anchor %s does not exist."
 msgstr "El anclaje HTML %s no existe."
 
-#: ../src/html/helpwnd.cpp:1547
+#: ../src/html/helpwnd.cpp:1545
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "Archivos HTML (*.html;*.htm)|*.html;*.htm|"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1759
+#: ../src/propgrid/advprops.cpp:1660
 msgid "Hand"
 msgstr "Mano"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "Harddisk"
 msgstr "Disco duro"
 
-#: ../src/common/fmapbase.cpp:155
+#: ../src/common/fmapbase.cpp:152
 msgid "Hebrew (ISO-8859-8)"
 msgstr "Hebreo (ISO-8859-8)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:280 ../src/osx/button_osx.cpp:39
-#: ../src/common/stockitem.cpp:163 ../src/common/accelcmn.cpp:80
-#: ../src/html/helpdlg.cpp:66 ../src/html/helpfrm.cpp:111
+#: ../include/wx/msgdlg.h:282 ../src/osx/button_osx.cpp:39
+#: ../src/common/stockitem.cpp:160 ../src/common/accelcmn.cpp:77
+#: ../src/html/helpfrm.cpp:108 ../src/html/helpdlg.cpp:63
 msgid "Help"
 msgstr "Ayuda"
 
-#: ../src/html/helpwnd.cpp:1200
+#: ../src/html/helpwnd.cpp:1198
 msgid "Help Browser Options"
 msgstr "Opciones del Navegador de ayuda"
 
-#: ../src/generic/helpext.cpp:454 ../src/generic/helpext.cpp:455
+#: ../src/generic/helpext.cpp:452 ../src/generic/helpext.cpp:453
 msgid "Help Index"
 msgstr "Contenido de la ayuda"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1529
 msgid "Help Printing"
 msgstr "Ayuda de impresión"
 
-#: ../src/html/helpwnd.cpp:801
+#: ../src/html/helpwnd.cpp:799
 msgid "Help Topics"
 msgstr "Temas de ayuda"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1546
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Libros de ayuda (*.htb)|*.htb|Libros de ayuda (*.zip)|*.zip|"
 
-#: ../src/generic/helpext.cpp:267
+#: ../src/generic/helpext.cpp:265
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "No se encontró el directorio de ayuda «%s»."
 
-#: ../src/generic/helpext.cpp:275
+#: ../src/generic/helpext.cpp:273
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "No se encontró el archivo de ayuda «%s»."
 
-#: ../src/html/helpctrl.cpp:63
+#: ../src/html/helpctrl.cpp:59
 #, c-format
 msgid "Help: %s"
 msgstr "Ayuda: %s"
 
-#: ../src/osx/menu_osx.cpp:577
+#: ../src/osx/menu_osx.cpp:469
 #, c-format
 msgid "Hide %s"
 msgstr "Ocultar %s"
 
-#: ../src/osx/menu_osx.cpp:579
+#: ../src/osx/menu_osx.cpp:471
 msgid "Hide Others"
 msgstr "Ocultar otros"
 
-#: ../src/generic/infobar.cpp:84
+#: ../src/generic/infobar.cpp:81
 msgid "Hide this notification message."
 msgstr "Ocultar esta notificación."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:884
+#: ../src/propgrid/advprops.cpp:785
 msgid "Highlight"
 msgstr "Highlight"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:885
+#: ../src/propgrid/advprops.cpp:786
 msgid "HighlightText"
 msgstr "HighlightText"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:164 ../src/common/accelcmn.cpp:65
+#: ../src/common/stockitem.cpp:161 ../src/common/accelcmn.cpp:62
 msgid "Home"
 msgstr "Inicio"
 
-#: ../src/generic/dirctrlg.cpp:524
+#: ../src/generic/dirctrlg.cpp:490
 msgid "Home directory"
 msgstr "Directorio de usuario"
 
@@ -4045,55 +4158,55 @@ msgid "How the object will float relative to the text."
 msgstr "Cómo flotará el objeto en relación con el texto."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1760
+#: ../src/propgrid/advprops.cpp:1661
 msgid "I-Beam"
 msgstr "I-Beam"
 
-#: ../src/common/imagbmp.cpp:1196
+#: ../src/common/imagbmp.cpp:1208
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: Error al leer máscara DIB."
 
-#: ../src/common/imagbmp.cpp:1290 ../src/common/imagbmp.cpp:1390
-#: ../src/common/imagbmp.cpp:1405 ../src/common/imagbmp.cpp:1416
-#: ../src/common/imagbmp.cpp:1430 ../src/common/imagbmp.cpp:1478
-#: ../src/common/imagbmp.cpp:1493 ../src/common/imagbmp.cpp:1507
-#: ../src/common/imagbmp.cpp:1518
+#: ../src/common/imagbmp.cpp:1302 ../src/common/imagbmp.cpp:1402
+#: ../src/common/imagbmp.cpp:1417 ../src/common/imagbmp.cpp:1428
+#: ../src/common/imagbmp.cpp:1442 ../src/common/imagbmp.cpp:1490
+#: ../src/common/imagbmp.cpp:1505 ../src/common/imagbmp.cpp:1519
+#: ../src/common/imagbmp.cpp:1530
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: ¡Error al escribir el archivo de imagen!"
 
-#: ../src/common/imagbmp.cpp:1255
+#: ../src/common/imagbmp.cpp:1267
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: Imagen demasiado alta para un icono."
 
-#: ../src/common/imagbmp.cpp:1263
+#: ../src/common/imagbmp.cpp:1275
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: Imagen demasiado ancha para un icono."
 
-#: ../src/common/imagbmp.cpp:1603
+#: ../src/common/imagbmp.cpp:1615
 msgid "ICO: Invalid icon index."
 msgstr "ICO: Indice de icono no válido."
 
-#: ../src/common/imagiff.cpp:758
+#: ../src/common/imagiff.cpp:755
 msgid "IFF: data stream seems to be truncated."
 msgstr "IFF: el flujo de datos parece truncado."
 
-#: ../src/common/imagiff.cpp:742
+#: ../src/common/imagiff.cpp:739
 msgid "IFF: error in IFF image format."
 msgstr "IFF: error en formato de imagen IFF."
 
-#: ../src/common/imagiff.cpp:745
+#: ../src/common/imagiff.cpp:742
 msgid "IFF: not enough memory."
 msgstr "IFF: memoria insuficiente."
 
-#: ../src/common/imagiff.cpp:748
+#: ../src/common/imagiff.cpp:745
 msgid "IFF: unknown error!!!"
 msgstr "IFF: ¡¡¡error desconocido!!!"
 
-#: ../src/common/fmapbase.cpp:197
+#: ../src/common/fmapbase.cpp:194
 msgid "ISO-2022-JP"
 msgstr "ISO-2022-JP"
 
-#: ../src/html/htmprint.cpp:282
+#: ../src/html/htmprint.cpp:294
 msgid ""
 "If possible, try changing the layout parameters to make the printout more "
 "narrow."
@@ -4101,7 +4214,7 @@ msgstr ""
 "Si es posible, intente cambiar los parámetros para hacer la impresión más "
 "estrecha"
 
-#: ../src/generic/dbgrptg.cpp:358
+#: ../src/generic/dbgrptg.cpp:362
 msgid ""
 "If you have any additional information pertaining to this bug\n"
 "report, please enter it here and it will be joined to it:"
@@ -4121,46 +4234,50 @@ msgstr ""
 "pero sepa que ésto no ayuda a la mejora del programa, por tanto, si\n"
 "es posible, por favor, continue con la generación del informe.\n"
 
-#: ../src/msw/registry.cpp:1405
+#: ../src/common/zipstrm.cpp:1043
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1393
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Se ignora el valor «%s» de la clave «%s»."
 
-#: ../src/common/xtistrm.cpp:295
+#: ../src/common/xtistrm.cpp:292
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Clase de objeto no permitida (Non-wxEvtHandler) como origen de sucesos"
 
-#: ../src/common/xti.cpp:513
+#: ../src/common/xti.cpp:510
 msgid "Illegal Parameter Count for ConstructObject Method"
 msgstr "Número incorrecto de parámetros para el método ConstructObject"
 
-#: ../src/common/xti.cpp:501
+#: ../src/common/xti.cpp:498
 msgid "Illegal Parameter Count for Create Method"
 msgstr "Número incorrecto de parámetros para el método Create"
 
-#: ../src/generic/dirctrlg.cpp:570 ../src/generic/filectrlg.cpp:756
+#: ../src/generic/dirctrlg.cpp:536 ../src/generic/filectrlg.cpp:752
 msgid "Illegal directory name."
 msgstr "El nombre del directorio no está permitido."
 
-#: ../src/generic/filectrlg.cpp:1367
+#: ../src/generic/filectrlg.cpp:1356
 msgid "Illegal file specification."
 msgstr "Especificación de archivo incorrecta."
 
-#: ../src/common/image.cpp:2269
+#: ../src/common/image.cpp:2363
 msgid "Image and mask have different sizes."
 msgstr "La imagen y la máscara son de tamaños distintos."
 
-#: ../src/common/image.cpp:2746
+#: ../src/common/image.cpp:2841
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "El archivo de imagen no es del tipo %d."
 
-#: ../src/common/image.cpp:2877
+#: ../src/common/image.cpp:2995
 #, c-format
 msgid "Image is not of type %s."
 msgstr "La imagen no es del tipo %s."
 
-#: ../src/msw/textctrl.cpp:488
+#: ../src/msw/textctrl.cpp:534
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -4168,101 +4285,101 @@ msgstr ""
 "Imposible crear control 'rich edit', se usará el control de texto simple. "
 "Por favor instale riched32.dll"
 
-#: ../src/unix/utilsunx.cpp:301
+#: ../src/unix/utilsunx.cpp:303
 msgid "Impossible to get child process input"
 msgstr "Imposible obtener la entrada del proceso hijo"
 
-#: ../src/common/filefn.cpp:1028
+#: ../src/common/filefn.cpp:917
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Imposible obtener permisos para el archivo '%s'"
 
-#: ../src/common/filefn.cpp:1042
+#: ../src/common/filefn.cpp:931
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Imposible sobrescribir el archivo «%s»"
 
-#: ../src/common/filefn.cpp:1097
+#: ../src/common/filefn.cpp:986
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Imposible establecer los permisos del archivo «%s»"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:886
+#: ../src/propgrid/advprops.cpp:787
 msgid "InactiveBorder"
 msgstr "InactiveBorder"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:887
+#: ../src/propgrid/advprops.cpp:788
 msgid "InactiveCaption"
 msgstr "InactiveCaption"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:888
+#: ../src/propgrid/advprops.cpp:789
 msgid "InactiveCaptionText"
 msgstr "InactiveCaptionText"
 
-#: ../src/common/gifdecod.cpp:792
+#: ../src/common/gifdecod.cpp:826
 #, c-format
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr ""
 "Tamaño de fotograma incorrecto en el GIF (%u, %d) para el fotograma #%u"
 
-#: ../src/msw/ole/automtn.cpp:635
+#: ../src/msw/ole/automtn.cpp:626
 msgid "Incorrect number of arguments."
 msgstr "Número de argumentos incorrecto."
 
-#: ../src/common/stockitem.cpp:165
+#: ../src/common/stockitem.cpp:162
 msgid "Indent"
 msgstr "Sangría"
 
-#: ../src/richtext/richtextformatdlg.cpp:349
+#: ../src/richtext/richtextformatdlg.cpp:342
 msgid "Indents && Spacing"
 msgstr "Sangrías y espaciado"
 
-#: ../src/common/stockitem.cpp:166 ../src/html/helpwnd.cpp:515
+#: ../src/common/stockitem.cpp:163 ../src/html/helpwnd.cpp:513
 msgid "Index"
 msgstr "Índice"
 
-#: ../src/common/fmapbase.cpp:159
+#: ../src/common/fmapbase.cpp:156
 msgid "Indian (ISO-8859-12)"
 msgstr "India (ISO-8859-12)"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "Info"
 msgstr "Información"
 
-#: ../src/common/init.cpp:287
+#: ../src/common/init.cpp:284
 msgid "Initialization failed in post init, aborting."
 msgstr "Falló la inicialización en la fase «post init»; se ha interrumpido."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:54
+#: ../src/common/accelcmn.cpp:51
 msgid "Ins"
 msgstr "Insertar"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextsymboldlg.cpp:472 ../src/common/accelcmn.cpp:53
+#: ../src/common/accelcmn.cpp:50 ../src/richtext/richtextsymboldlg.cpp:469
 msgid "Insert"
 msgstr "Insertar"
 
-#: ../src/richtext/richtextbuffer.cpp:8067
+#: ../src/richtext/richtextbuffer.cpp:8063
 msgid "Insert Field"
 msgstr "Insertar campo"
 
-#: ../src/richtext/richtextbuffer.cpp:7978
-#: ../src/richtext/richtextbuffer.cpp:8936
+#: ../src/richtext/richtextbuffer.cpp:7974
+#: ../src/richtext/richtextbuffer.cpp:8934
 msgid "Insert Image"
 msgstr "Insertar imagen"
 
-#: ../src/richtext/richtextbuffer.cpp:8025
+#: ../src/richtext/richtextbuffer.cpp:8021
 msgid "Insert Object"
 msgstr "Insertar objeto"
 
-#: ../src/richtext/richtextctrl.cpp:1286 ../src/richtext/richtextctrl.cpp:1494
-#: ../src/richtext/richtextbuffer.cpp:7822
-#: ../src/richtext/richtextbuffer.cpp:7852
-#: ../src/richtext/richtextbuffer.cpp:7894
+#: ../src/richtext/richtextbuffer.cpp:7818
+#: ../src/richtext/richtextbuffer.cpp:7848
+#: ../src/richtext/richtextbuffer.cpp:7890
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
 msgid "Insert Text"
 msgstr "Insertar texto"
 
@@ -4275,16 +4392,11 @@ msgstr "Inserta un salto de página antes del párrafo."
 msgid "Inset"
 msgstr "Recuadro"
 
-#: ../src/gtk/app.cpp:425
-#, c-format
-msgid "Invalid GTK+ command line option, use \"%s --help\""
-msgstr "La opción de GTK+ de consola no es válida; utilice «%s --help»"
-
-#: ../src/common/imagtiff.cpp:311
+#: ../src/common/imagtiff.cpp:308
 msgid "Invalid TIFF image index."
 msgstr "Índice de imagen TIFF no válido."
 
-#: ../src/common/appcmn.cpp:273
+#: ../src/common/appcmn.cpp:294
 #, c-format
 msgid "Invalid display mode specification '%s'."
 msgstr "Especificación de 'display' no válida: '%s'."
@@ -4294,248 +4406,252 @@ msgstr "Especificación de 'display' no válida: '%s'."
 msgid "Invalid geometry specification '%s'"
 msgstr "Especificación de geometría no válida: '%s'"
 
-#: ../src/unix/fswatcher_inotify.cpp:323
+#: ../src/unix/fswatcher_inotify.cpp:320
 #, c-format
 msgid "Invalid inotify event for \"%s\""
 msgstr "Suceso inotify no válido para «%s»"
 
-#: ../src/unix/snglinst.cpp:312
+#: ../src/unix/snglinst.cpp:309
 #, c-format
 msgid "Invalid lock file '%s'."
 msgstr "Archivo de bloqueo «%s» no válido."
 
-#: ../src/common/translation.cpp:1125
+#: ../src/common/translation.cpp:1167
 msgid "Invalid message catalog."
 msgstr "Catálogo de mensajes no válido."
 
-#: ../src/common/xtistrm.cpp:405 ../src/common/xtistrm.cpp:420
+#: ../src/common/xtistrm.cpp:402 ../src/common/xtistrm.cpp:417
 msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
 msgstr "Identificador de objeto pasado a GetObjectClassInfo nulo o no válido"
 
-#: ../src/common/xtistrm.cpp:435
+#: ../src/common/xtistrm.cpp:432
 msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
 msgstr "Identificador de objeto pasado a HasObjectClassInfo nulo o no válido"
 
-#: ../src/common/regex.cpp:310
+#: ../src/common/regex.cpp:307
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Expresión regular no válida «%s»: %s"
 
-#: ../src/common/config.cpp:226
+#: ../src/common/config.cpp:222
 #, c-format
 msgid "Invalid value %ld for a boolean key \"%s\" in config file."
 msgstr ""
 "Valor %ld no válido para una clave booleana «%s» en el archivo de "
 "configuración."
 
-#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:351
-#: ../src/osx/carbon/fontdlg.cpp:361 ../src/common/stockitem.cpp:168
+#: ../src/osx/carbon/fontdlg.cpp:358 ../src/common/stockitem.cpp:165
+#: ../src/generic/fontdlgg.cpp:325 ../src/richtext/richtextfontpage.cpp:351
 msgid "Italic"
 msgstr "Cursiva"
 
-#: ../src/common/paper.cpp:130
+#: ../src/common/paper.cpp:127
 msgid "Italy Envelope, 110 x 230 mm"
 msgstr "Sobre Italy, 110 × 230 mm"
 
-#: ../src/common/imagjpeg.cpp:270
+#: ../src/common/imagjpeg.cpp:257
 msgid "JPEG: Couldn't load - file is probably corrupted."
 msgstr "JPEG: no se pudo cargar: quizás el archivo está dañado."
 
-#: ../src/common/imagjpeg.cpp:449
+#: ../src/common/imagjpeg.cpp:436
 msgid "JPEG: Couldn't save image."
 msgstr "JPEG: No pudo guardarse imagen."
 
-#: ../src/common/paper.cpp:163
+#: ../src/common/paper.cpp:160
 msgid "Japanese Double Postcard 200 x 148 mm"
 msgstr "Tarjeta Japonesa Doble 200 x 148 mm"
 
-#: ../src/common/paper.cpp:167
+#: ../src/common/paper.cpp:164
 msgid "Japanese Envelope Chou #3"
 msgstr "Sobre japonés Chou n.º 3"
 
-#: ../src/common/paper.cpp:180
+#: ../src/common/paper.cpp:177
 msgid "Japanese Envelope Chou #3 Rotated"
 msgstr "Sobre japonés Chou n.º 3 Girado"
 
-#: ../src/common/paper.cpp:168
+#: ../src/common/paper.cpp:165
 msgid "Japanese Envelope Chou #4"
 msgstr "Sobre japonés Chou n.º 4"
 
-#: ../src/common/paper.cpp:181
+#: ../src/common/paper.cpp:178
 msgid "Japanese Envelope Chou #4 Rotated"
 msgstr "Sobre japonés Chou n.º 4 Girado"
 
-#: ../src/common/paper.cpp:165
+#: ../src/common/paper.cpp:162
 msgid "Japanese Envelope Kaku #2"
 msgstr "Sobre japonés Kaku n.º 2"
 
-#: ../src/common/paper.cpp:178
+#: ../src/common/paper.cpp:175
 msgid "Japanese Envelope Kaku #2 Rotated"
 msgstr "Sobre japonés Kaku n.º 2 Girado"
 
-#: ../src/common/paper.cpp:166
+#: ../src/common/paper.cpp:163
 msgid "Japanese Envelope Kaku #3"
 msgstr "Sobre japonés Kaku n.º 3"
 
-#: ../src/common/paper.cpp:179
+#: ../src/common/paper.cpp:176
 msgid "Japanese Envelope Kaku #3 Rotated"
 msgstr "Sobre japonés Kaku n.º 3 Girado"
 
-#: ../src/common/paper.cpp:185
+#: ../src/common/paper.cpp:182
 msgid "Japanese Envelope You #4"
 msgstr "Sobre japonés You n.º 4"
 
-#: ../src/common/paper.cpp:186
+#: ../src/common/paper.cpp:183
 msgid "Japanese Envelope You #4 Rotated"
 msgstr "Sobre japonés You n.º 4 Girado"
 
-#: ../src/common/paper.cpp:138
+#: ../src/common/paper.cpp:135
 msgid "Japanese Postcard 100 x 148 mm"
 msgstr "Tarjeta japonesa 100 × 148 mm"
 
-#: ../src/common/paper.cpp:175
+#: ../src/common/paper.cpp:172
 msgid "Japanese Postcard Rotated 148 x 100 mm"
 msgstr "Tarjeta japonesa Girada 148 × 100 mm"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "Jump to"
 msgstr "Ir a"
 
-#: ../src/common/stockitem.cpp:171
+#: ../src/common/stockitem.cpp:168
 msgid "Justified"
 msgstr "Justificado"
 
-#: ../src/richtext/richtextindentspage.cpp:155
-#: ../src/richtext/richtextindentspage.cpp:157
 #: ../src/richtext/richtextliststylepage.cpp:344
 #: ../src/richtext/richtextliststylepage.cpp:346
+#: ../src/richtext/richtextindentspage.cpp:155
+#: ../src/richtext/richtextindentspage.cpp:157
 msgid "Justify text left and right."
 msgstr "Justificar texto a izquierda y derecha."
 
-#: ../src/common/fmapbase.cpp:163
+#: ../src/common/fmapbase.cpp:160
 msgid "KOI8-R"
 msgstr "KOI8-R"
 
-#: ../src/common/fmapbase.cpp:164
+#: ../src/common/fmapbase.cpp:161
 msgid "KOI8-U"
 msgstr "KOI8-U"
 
-#: ../src/common/accelcmn.cpp:265 ../src/common/accelcmn.cpp:347
+#: ../src/common/accelcmn.cpp:279 ../src/common/accelcmn.cpp:364
 msgid "KP_"
 msgstr "KP_"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "KP_Add"
 msgstr "KP_Add"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "KP_Begin"
 msgstr "KP_Begin"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "KP_Decimal"
 msgstr "KP_Decimal"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 msgid "KP_Delete"
 msgstr "KP_Delete"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "KP_Divide"
 msgstr "KP_Divide"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 msgid "KP_Down"
 msgstr "KP_Down"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "KP_End"
 msgstr "KP_End"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "KP_Enter"
 msgstr "KP_Enter"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "KP_Equal"
 msgstr "KP_Equal"
 
+#: ../src/common/accelcmn.cpp:276 ../src/common/accelcmn.cpp:361
+msgid "KP_F"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 msgid "KP_Home"
 msgstr "KP_Home"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 msgid "KP_Insert"
 msgstr "KP_Insert"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "KP_Left"
 msgstr "KP_Left"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "KP_Multiply"
 msgstr "KP_Multiply"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:99
+#: ../src/common/accelcmn.cpp:97
 msgid "KP_Next"
 msgstr "KP_Next"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "KP_PageDown"
 msgstr "KP_PageDown"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "KP_PageUp"
 msgstr "KP_PageUp"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:98
+#: ../src/common/accelcmn.cpp:96
 msgid "KP_Prior"
 msgstr "KP_Prior"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 msgid "KP_Right"
 msgstr "KP_Right"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "KP_Separator"
 msgstr "KP_Separator"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "KP_Space"
 msgstr "KP_Space"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "KP_Subtract"
 msgstr "KP_Subtract"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "KP_Tab"
 msgstr "KP_Tab"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "KP_Up"
 msgstr "KP_Up"
 
@@ -4543,112 +4659,127 @@ msgstr "KP_Up"
 msgid "L&ine spacing:"
 msgstr "&Interlineado:"
 
-#: ../src/generic/prntdlgg.cpp:613 ../src/generic/prntdlgg.cpp:868
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "error de compresión"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "error de descompresión"
+
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:861
 msgid "Landscape"
 msgstr "Horizontal"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "Last"
 msgstr "Último"
 
-#: ../src/common/prntbase.cpp:1572
+#: ../src/common/prntbase.cpp:1597
 msgid "Last page"
 msgstr "Última página"
 
-#: ../src/common/log.cpp:305
+#: ../src/common/log.cpp:324
 #, c-format
 msgid "Last repeated message (\"%s\", %u time) wasn't output"
 msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
 msgstr[0] "No se mostró el último mensaje repetido («%s», %u vez)"
 msgstr[1] "No se mostró el último mensaje repetido («%s», %u veces)"
 
-#: ../src/common/paper.cpp:103
+#: ../src/common/paper.cpp:100
 msgid "Ledger, 17 x 11 in"
 msgstr "Libro mayor, 17 × 11 in"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6146
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:58 ../src/generic/datavgen.cpp:6951
+#: ../src/richtext/richtextsizepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:252
 #: ../src/richtext/richtextliststylepage.cpp:253
 #: ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
-#: ../src/richtext/richtextsizepage.cpp:249 ../src/common/accelcmn.cpp:61
 msgid "Left"
 msgstr "Izquierda"
 
-#: ../src/richtext/richtextindentspage.cpp:204
 #: ../src/richtext/richtextliststylepage.cpp:390
+#: ../src/richtext/richtextindentspage.cpp:204
 msgid "Left (&first line):"
 msgstr "Izquierda (&primer renglón):"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1761
+#: ../src/propgrid/advprops.cpp:1662
 msgid "Left Button"
 msgstr "Botón izquierdo"
 
-#: ../src/generic/prntdlgg.cpp:880
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Left margin (mm):"
 msgstr "Margen izquierdo (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:141
-#: ../src/richtext/richtextindentspage.cpp:143
 #: ../src/richtext/richtextliststylepage.cpp:330
 #: ../src/richtext/richtextliststylepage.cpp:332
+#: ../src/richtext/richtextindentspage.cpp:141
+#: ../src/richtext/richtextindentspage.cpp:143
 msgid "Left-align text."
 msgstr "Texto alineado a la izquierda."
 
-#: ../src/common/paper.cpp:144
+#: ../src/common/paper.cpp:141
 msgid "Legal Extra 9 1/2 x 15 in"
 msgstr "Legal Extra 9 1/2 × 15 in"
 
-#: ../src/common/paper.cpp:96
+#: ../src/common/paper.cpp:93
 msgid "Legal, 8 1/2 x 14 in"
 msgstr "Legal, 8 1/2 × 14 in"
 
-#: ../src/common/paper.cpp:143
+#: ../src/common/paper.cpp:140
 msgid "Letter Extra 9 1/2 x 12 in"
 msgstr "Carta Extra 9 1/2 × 12 in"
 
-#: ../src/common/paper.cpp:149
+#: ../src/common/paper.cpp:146
 msgid "Letter Extra Transverse 9.275 x 12 in"
 msgstr "Carta Extra Transversal 9,275 × 12 in"
 
-#: ../src/common/paper.cpp:152
+#: ../src/common/paper.cpp:149
 msgid "Letter Plus 8 1/2 x 12.69 in"
 msgstr "Carta Plus 8 1/2 × 12,69 in"
 
-#: ../src/common/paper.cpp:169
+#: ../src/common/paper.cpp:166
 msgid "Letter Rotated 11 x 8 1/2 in"
 msgstr "Carta Girada 11 × 8 1/2 in"
 
-#: ../src/common/paper.cpp:101
+#: ../src/common/paper.cpp:98
 msgid "Letter Small, 8 1/2 x 11 in"
 msgstr "Carta Pequeña, 8 1/2 × 11 in"
 
-#: ../src/common/paper.cpp:147
+#: ../src/common/paper.cpp:144
 msgid "Letter Transverse 8 1/2 x 11 in"
 msgstr "Carta Transversal 8 1/2 × 11 in"
 
-#: ../src/common/paper.cpp:95
+#: ../src/common/paper.cpp:92
 msgid "Letter, 8 1/2 x 11 in"
 msgstr "Carta, 8 1/2 × 11 in"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "License"
 msgstr "Licencia"
 
-#: ../src/generic/fontdlgg.cpp:332
+#: ../src/generic/fontdlgg.cpp:328
 msgid "Light"
 msgstr "Ligera"
 
-#: ../src/propgrid/advprops.cpp:1608
+#: ../src/propgrid/advprops.cpp:1514
 msgid "Lime"
 msgstr "Lima"
 
-#: ../src/generic/helpext.cpp:294
+#: ../src/generic/helpext.cpp:292
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr ""
@@ -4658,15 +4789,15 @@ msgstr ""
 msgid "Line spacing:"
 msgstr "Interlineado:"
 
-#: ../src/html/chm.cpp:838
+#: ../src/html/chm.cpp:829
 msgid "Link contained '//', converted to absolute link."
 msgstr "El enlace contiene «//»; se ha convertido en enlace absoluto."
 
-#: ../src/richtext/richtextformatdlg.cpp:364
+#: ../src/richtext/richtextformatdlg.cpp:357
 msgid "List Style"
 msgstr "Estilo de lista"
 
-#: ../src/richtext/richtextstyles.cpp:1064
+#: ../src/richtext/richtextstyles.cpp:1061
 msgid "List styles"
 msgstr "Estilos de lista"
 
@@ -4680,26 +4811,26 @@ msgstr "Enumera los tamaños de letra en puntos."
 msgid "Lists the available fonts."
 msgstr "Muestra los tipos de letra disponibles."
 
-#: ../src/common/fldlgcmn.cpp:340
+#: ../src/common/fldlgcmn.cpp:337
 #, c-format
 msgid "Load %s file"
 msgstr "Cargar el archivo %s"
 
-#: ../src/html/htmlwin.cpp:597
+#: ../src/html/htmlwin.cpp:600
 msgid "Loading : "
 msgstr "Cargando: "
 
-#: ../src/unix/snglinst.cpp:246
+#: ../src/unix/snglinst.cpp:243
 #, c-format
 msgid "Lock file '%s' has incorrect owner."
 msgstr "El archivo de bloqueo «%s» tiene un propietario incorrecto."
 
-#: ../src/unix/snglinst.cpp:251
+#: ../src/unix/snglinst.cpp:248
 #, c-format
 msgid "Lock file '%s' has incorrect permissions."
 msgstr "El archivo de bloqueo «%s» tiene permisos incorrectos."
 
-#: ../src/generic/logg.cpp:576
+#: ../src/generic/logg.cpp:573
 #, c-format
 msgid "Log saved to the file '%s'."
 msgstr "Registro guardado en el archivo «%s»."
@@ -4714,11 +4845,11 @@ msgstr "Letras minúsculas"
 msgid "Lower case roman numerals"
 msgstr "Números romanos en minúscula"
 
-#: ../src/gtk/mdi.cpp:422 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk1/mdi.cpp:431 ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "Ventana hija MDI"
 
-#: ../src/msw/helpchm.cpp:56
+#: ../src/msw/helpchm.cpp:53
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -4726,189 +4857,189 @@ msgstr ""
 "La funciones de Ayuda MS HTML no están disponibles porque la biblioteca de "
 "Ayuda MS HTML no está instalada. Instálela."
 
-#: ../src/univ/themes/win32.cpp:3754
+#: ../src/univ/themes/win32.cpp:3751
 msgid "Ma&ximize"
 msgstr "Ma&ximizar"
 
-#: ../src/common/fmapbase.cpp:203
+#: ../src/common/fmapbase.cpp:200
 msgid "MacArabic"
 msgstr "MacArabic"
 
-#: ../src/common/fmapbase.cpp:222
+#: ../src/common/fmapbase.cpp:219
 msgid "MacArmenian"
 msgstr "MacArmenian"
 
-#: ../src/common/fmapbase.cpp:211
+#: ../src/common/fmapbase.cpp:208
 msgid "MacBengali"
 msgstr "MacBengali"
 
-#: ../src/common/fmapbase.cpp:217
+#: ../src/common/fmapbase.cpp:214
 msgid "MacBurmese"
 msgstr "MacBurmese"
 
-#: ../src/common/fmapbase.cpp:236
+#: ../src/common/fmapbase.cpp:233
 msgid "MacCeltic"
 msgstr "MacCeltic"
 
-#: ../src/common/fmapbase.cpp:227
+#: ../src/common/fmapbase.cpp:224
 msgid "MacCentralEurRoman"
 msgstr "MacCentralEurRoman"
 
-#: ../src/common/fmapbase.cpp:223
+#: ../src/common/fmapbase.cpp:220
 msgid "MacChineseSimp"
 msgstr "MacChineseSimp"
 
-#: ../src/common/fmapbase.cpp:201
+#: ../src/common/fmapbase.cpp:198
 msgid "MacChineseTrad"
 msgstr "MacChineseTrad"
 
-#: ../src/common/fmapbase.cpp:233
+#: ../src/common/fmapbase.cpp:230
 msgid "MacCroatian"
 msgstr "MacCroatian"
 
-#: ../src/common/fmapbase.cpp:206
+#: ../src/common/fmapbase.cpp:203
 msgid "MacCyrillic"
 msgstr "MacCyrillic"
 
-#: ../src/common/fmapbase.cpp:207
+#: ../src/common/fmapbase.cpp:204
 msgid "MacDevanagari"
 msgstr "MacDevanagari"
 
-#: ../src/common/fmapbase.cpp:231
+#: ../src/common/fmapbase.cpp:228
 msgid "MacDingbats"
 msgstr "MacDingbats"
 
-#: ../src/common/fmapbase.cpp:226
+#: ../src/common/fmapbase.cpp:223
 msgid "MacEthiopic"
 msgstr "MacEthiopic"
 
-#: ../src/common/fmapbase.cpp:229
+#: ../src/common/fmapbase.cpp:226
 msgid "MacExtArabic"
 msgstr "MacExtArabic"
 
-#: ../src/common/fmapbase.cpp:237
+#: ../src/common/fmapbase.cpp:234
 msgid "MacGaelic"
 msgstr "MacGaelic"
 
-#: ../src/common/fmapbase.cpp:221
+#: ../src/common/fmapbase.cpp:218
 msgid "MacGeorgian"
 msgstr "MacGeorgian"
 
-#: ../src/common/fmapbase.cpp:205
+#: ../src/common/fmapbase.cpp:202
 msgid "MacGreek"
 msgstr "MacGreek"
 
-#: ../src/common/fmapbase.cpp:209
+#: ../src/common/fmapbase.cpp:206
 msgid "MacGujarati"
 msgstr "MacGujarati"
 
-#: ../src/common/fmapbase.cpp:208
+#: ../src/common/fmapbase.cpp:205
 msgid "MacGurmukhi"
 msgstr "MacGurmukhi"
 
-#: ../src/common/fmapbase.cpp:204
+#: ../src/common/fmapbase.cpp:201
 msgid "MacHebrew"
 msgstr "MacHebrew"
 
-#: ../src/common/fmapbase.cpp:234
+#: ../src/common/fmapbase.cpp:231
 msgid "MacIcelandic"
 msgstr "MacIcelandic"
 
-#: ../src/common/fmapbase.cpp:200
+#: ../src/common/fmapbase.cpp:197
 msgid "MacJapanese"
 msgstr "MacJapanese"
 
-#: ../src/common/fmapbase.cpp:214
+#: ../src/common/fmapbase.cpp:211
 msgid "MacKannada"
 msgstr "MacKannada"
 
-#: ../src/common/fmapbase.cpp:238
+#: ../src/common/fmapbase.cpp:235
 msgid "MacKeyboardGlyphs"
 msgstr "MacKeyboardGlyphs"
 
-#: ../src/common/fmapbase.cpp:218
+#: ../src/common/fmapbase.cpp:215
 msgid "MacKhmer"
 msgstr "MacKhmer"
 
-#: ../src/common/fmapbase.cpp:202
+#: ../src/common/fmapbase.cpp:199
 msgid "MacKorean"
 msgstr "MacKorean"
 
-#: ../src/common/fmapbase.cpp:220
+#: ../src/common/fmapbase.cpp:217
 msgid "MacLaotian"
 msgstr "MacLaotian"
 
-#: ../src/common/fmapbase.cpp:215
+#: ../src/common/fmapbase.cpp:212
 msgid "MacMalayalam"
 msgstr "MacMalayalam"
 
-#: ../src/common/fmapbase.cpp:225
+#: ../src/common/fmapbase.cpp:222
 msgid "MacMongolian"
 msgstr "MacMongolian"
 
-#: ../src/common/fmapbase.cpp:210
+#: ../src/common/fmapbase.cpp:207
 msgid "MacOriya"
 msgstr "MacOriya"
 
-#: ../src/common/fmapbase.cpp:199
+#: ../src/common/fmapbase.cpp:196
 msgid "MacRoman"
 msgstr "MacRoman"
 
-#: ../src/common/fmapbase.cpp:235
+#: ../src/common/fmapbase.cpp:232
 msgid "MacRomanian"
 msgstr "MacRomanian"
 
-#: ../src/common/fmapbase.cpp:216
+#: ../src/common/fmapbase.cpp:213
 msgid "MacSinhalese"
 msgstr "MacSinhalese"
 
-#: ../src/common/fmapbase.cpp:230
+#: ../src/common/fmapbase.cpp:227
 msgid "MacSymbol"
 msgstr "MacSymbol"
 
-#: ../src/common/fmapbase.cpp:212
+#: ../src/common/fmapbase.cpp:209
 msgid "MacTamil"
 msgstr "MacTamil"
 
-#: ../src/common/fmapbase.cpp:213
+#: ../src/common/fmapbase.cpp:210
 msgid "MacTelugu"
 msgstr "MacTelugu"
 
-#: ../src/common/fmapbase.cpp:219
+#: ../src/common/fmapbase.cpp:216
 msgid "MacThai"
 msgstr "MacThai"
 
-#: ../src/common/fmapbase.cpp:224
+#: ../src/common/fmapbase.cpp:221
 msgid "MacTibetan"
 msgstr "MacTibetan"
 
-#: ../src/common/fmapbase.cpp:232
+#: ../src/common/fmapbase.cpp:229
 msgid "MacTurkish"
 msgstr "MacTurkish"
 
-#: ../src/common/fmapbase.cpp:228
+#: ../src/common/fmapbase.cpp:225
 msgid "MacVietnamese"
 msgstr "MacVietnamese"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1762
+#: ../src/propgrid/advprops.cpp:1663
 msgid "Magnifier"
 msgstr "Lupa"
 
-#: ../src/propgrid/advprops.cpp:2143
+#: ../src/propgrid/advprops.cpp:2050
 msgid "Make a selection:"
 msgstr "Hacer una selección:"
 
-#: ../src/richtext/richtextformatdlg.cpp:374
+#: ../src/richtext/richtextformatdlg.cpp:367
 #: ../src/richtext/richtextmarginspage.cpp:171
 msgid "Margins"
 msgstr "Márgenes"
 
-#: ../src/propgrid/advprops.cpp:1595
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Maroon"
 msgstr "Marrón"
 
-#: ../src/generic/fdrepdlg.cpp:147
+#: ../src/generic/fdrepdlg.cpp:144
 msgid "Match case"
 msgstr "Distinguir mayúsculas y minúsculas"
 
@@ -4920,40 +5051,40 @@ msgstr "Altura máxima:"
 msgid "Max width:"
 msgstr "Anchura máxima:"
 
-#: ../src/unix/mediactrl.cpp:947
+#: ../src/unix/mediactrl.cpp:972
 #, c-format
 msgid "Media playback error: %s"
 msgstr "Error de reproducción del medio: %s"
 
-#: ../src/common/fs_mem.cpp:175
+#: ../src/common/fs_mem.cpp:170
 #, c-format
 msgid "Memory VFS already contains file '%s'!"
 msgstr "El VFS en memoria ya contiene el archivo «%s»."
 
 #. TRANSLATORS: Name of keyboard key
 #. TRANSLATORS: Keyword of system colour
-#: ../src/common/accelcmn.cpp:73 ../src/propgrid/advprops.cpp:889
+#: ../src/common/accelcmn.cpp:70 ../src/propgrid/advprops.cpp:790
 msgid "Menu"
 msgstr "Menú"
 
-#: ../src/common/msgout.cpp:124
+#: ../src/common/msgout.cpp:121
 msgid "Message"
 msgstr "Mensaje"
 
-#: ../src/univ/themes/metal.cpp:168
+#: ../src/univ/themes/metal.cpp:165
 msgid "Metal theme"
 msgstr "Tema metálico"
 
-#: ../src/msw/ole/automtn.cpp:652
+#: ../src/msw/ole/automtn.cpp:643
 msgid "Method or property not found."
 msgstr "No se encontró el método o la propiedad."
 
-#: ../src/univ/themes/win32.cpp:3752
+#: ../src/univ/themes/win32.cpp:3749
 msgid "Mi&nimize"
 msgstr "Mi&nimizar"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1763
+#: ../src/propgrid/advprops.cpp:1664
 msgid "Middle Button"
 msgstr "Botón central"
 
@@ -4965,38 +5096,43 @@ msgstr "Altura mínima:"
 msgid "Min width:"
 msgstr "Anchura mínima:"
 
-#: ../src/msw/ole/automtn.cpp:668
+#: ../src/osx/cocoa/menu.mm:281
+#, fuzzy
+msgid "Minimize"
+msgstr "Mi&nimizar"
+
+#: ../src/msw/ole/automtn.cpp:659
 msgid "Missing a required parameter."
 msgstr "Falta un parámetro requerido."
 
-#: ../src/generic/fontdlgg.cpp:324
+#: ../src/generic/fontdlgg.cpp:320
 msgid "Modern"
 msgstr "Moderna"
 
-#: ../src/generic/filectrlg.cpp:427
+#: ../src/generic/filectrlg.cpp:423
 msgid "Modified"
 msgstr "Modificado"
 
-#: ../src/common/module.cpp:133
+#: ../src/common/module.cpp:130
 #, c-format
 msgid "Module \"%s\" initialization failed"
 msgstr "Falló la inicialización del módulo «%s»"
 
-#: ../src/common/paper.cpp:131
+#: ../src/common/paper.cpp:128
 msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
 msgstr "Sobre Monarch, 3 7/8 × 7 1/2 in"
 
-#: ../src/msw/fswatcher.cpp:143
+#: ../src/msw/fswatcher.cpp:140
 msgid "Monitoring individual files for changes is not supported currently."
 msgstr ""
 "Actualmente no se admite la monitorización de cambios en archivos "
 "individuales."
 
-#: ../src/generic/editlbox.cpp:172
+#: ../src/generic/editlbox.cpp:160
 msgid "Move down"
 msgstr "Bajar"
 
-#: ../src/generic/editlbox.cpp:171
+#: ../src/generic/editlbox.cpp:155
 msgid "Move up"
 msgstr "Subir"
 
@@ -5010,97 +5146,103 @@ msgstr "Mueve el objeto al párrafo siguiente."
 msgid "Moves the object to the previous paragraph."
 msgstr "Mueve el objeto al párrafo anterior."
 
-#: ../src/richtext/richtextbuffer.cpp:9966
+#: ../src/richtext/richtextbuffer.cpp:9963
 msgid "Multiple Cell Properties"
 msgstr "Múltiples propiedades de celda"
 
-#: ../src/generic/filectrlg.cpp:424
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:82
+#, fuzzy
+msgid "Multiply"
+msgstr "KP_Multiply"
+
+#: ../src/generic/filectrlg.cpp:420
 msgid "Name"
 msgstr "Nombre"
 
-#: ../src/propgrid/advprops.cpp:1596
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Navy"
 msgstr "Azul marino"
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "Network"
 msgstr "Red"
 
-#: ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173
 msgid "New"
 msgstr "Nuevo"
 
-#: ../src/richtext/richtextstyledlg.cpp:243
+#: ../src/richtext/richtextstyledlg.cpp:239
 msgid "New &Box Style..."
 msgstr "Estilo de &caja nuevo…"
 
-#: ../src/richtext/richtextstyledlg.cpp:225
+#: ../src/richtext/richtextstyledlg.cpp:221
 msgid "New &Character Style..."
 msgstr "Estilo de &carácter nuevo…"
 
-#: ../src/richtext/richtextstyledlg.cpp:237
+#: ../src/richtext/richtextstyledlg.cpp:233
 msgid "New &List Style..."
 msgstr "Estilo de &lista nuevo…"
 
-#: ../src/richtext/richtextstyledlg.cpp:231
+#: ../src/richtext/richtextstyledlg.cpp:227
 msgid "New &Paragraph Style..."
 msgstr "Estilo de &párrafo nuevo…"
 
-#: ../src/richtext/richtextstyledlg.cpp:606
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:654
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:820
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:893
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:934
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:602
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:650
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:816
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:889
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:930
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "New Style"
 msgstr "Estilo nuevo"
 
-#: ../src/generic/editlbox.cpp:169
+#: ../src/generic/editlbox.cpp:139
 msgid "New item"
 msgstr "Elemento nuevo"
 
-#: ../src/generic/dirdlgg.cpp:297 ../src/generic/dirdlgg.cpp:307
-#: ../src/generic/filectrlg.cpp:618 ../src/generic/filectrlg.cpp:627
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+#: ../src/generic/dirdlgg.cpp:294 ../src/generic/dirdlgg.cpp:304
 msgid "NewName"
 msgstr "NewName"
 
-#: ../src/common/prntbase.cpp:1567 ../src/html/helpwnd.cpp:665
+#: ../src/common/prntbase.cpp:1592 ../src/html/helpwnd.cpp:663
 msgid "Next page"
 msgstr "Página siguiente"
 
-#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:177
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:174
 #: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "No"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1764
+#: ../src/propgrid/advprops.cpp:1665
 msgid "No Entry"
 msgstr "No hay entrada"
 
-#: ../src/generic/animateg.cpp:150
+#: ../src/generic/animateg.cpp:133
 #, c-format
 msgid "No animation handler for type %ld defined."
 msgstr "No hay definido ningún manipulador de animación para tipo %ld."
 
-#: ../src/dfb/bitmap.cpp:642 ../src/dfb/bitmap.cpp:676
+#: ../src/dfb/bitmap.cpp:639 ../src/dfb/bitmap.cpp:673
 #, c-format
 msgid "No bitmap handler for type %d defined."
 msgstr "No hay manipulador de imagen para el tipo %d."
 
-#: ../src/common/utilscmn.cpp:1077
+#: ../src/common/utilscmn.cpp:1095
 msgid "No default application configured for HTML files."
 msgstr "No se ha configurado la aplicación predeterminada para archivos HTML."
 
-#: ../src/generic/helpext.cpp:445
+#: ../src/generic/helpext.cpp:443
 msgid "No entries found."
 msgstr "No se han encontrado documentos."
 
-#: ../src/common/fontmap.cpp:421
+#: ../src/common/fontmap.cpp:418
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found,\n"
@@ -5112,7 +5254,7 @@ msgstr ""
 "pero existe una codificación alternativa, «%s».\n"
 "¿Le gustaría usar esta codificación (de otra forma deberá elegir otra)?"
 
-#: ../src/common/fontmap.cpp:426
+#: ../src/common/fontmap.cpp:423
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found.\n"
@@ -5123,201 +5265,201 @@ msgstr ""
 "¿Le gustaría seleccionar un tipo de letra para usarse con esta codificación\n"
 "(de otra forma el texto con esta codificación no se mostrará correctamente)?"
 
-#: ../src/generic/animateg.cpp:142
+#: ../src/generic/animateg.cpp:125
 msgid "No handler found for animation type."
 msgstr "No se ha encontrado ningún manipulador para el tipo de animación."
 
-#: ../src/common/image.cpp:2728
+#: ../src/common/image.cpp:2823
 msgid "No handler found for image type."
 msgstr "No se ha encontrado ningún manipulador para el tipo de imagen."
 
-#: ../src/common/image.cpp:2736 ../src/common/image.cpp:2848
-#: ../src/common/image.cpp:2901
+#: ../src/common/image.cpp:2831 ../src/common/image.cpp:2954
+#: ../src/common/image.cpp:3020
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "No hay definido ningún manipulador de imagen para tipo %d."
 
-#: ../src/common/image.cpp:2871 ../src/common/image.cpp:2915
+#: ../src/common/image.cpp:2986 ../src/common/image.cpp:3034
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "No hay definido ningún manipulador de imagen para tipo %s."
 
-#: ../src/html/helpwnd.cpp:858
+#: ../src/html/helpwnd.cpp:856
 msgid "No matching page found yet"
 msgstr "Todavía no se ha encontrado una página con coincidencias"
 
-#: ../src/unix/sound.cpp:81
+#: ../src/unix/sound.cpp:78
 msgid "No sound"
 msgstr "No hay ningún sonido"
 
-#: ../src/common/image.cpp:2277 ../src/common/image.cpp:2318
+#: ../src/common/image.cpp:2371 ../src/common/image.cpp:2412
 msgid "No unused colour in image being masked."
 msgstr "No hay ningún color sin utilizar en la imagen que se está enmascarando"
 
-#: ../src/common/image.cpp:3374
-msgid "No unused colour in image."
-msgstr "No hay ningún color sin usar en la imagen."
-
-#: ../src/generic/helpext.cpp:302
+#: ../src/generic/helpext.cpp:300
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "No se han encontrado asignaciones válidas en el archivo «%s»."
 
-#: ../src/richtext/richtextborderspage.cpp:610
 #: ../src/richtext/richtextsizepage.cpp:248
 #: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:610
 msgid "None"
 msgstr "Ninguno"
 
-#: ../src/common/fmapbase.cpp:157
+#: ../src/common/fmapbase.cpp:154
 msgid "Nordic (ISO-8859-10)"
 msgstr "Nórdico (ISO-8859-10)"
 
-#: ../src/generic/fontdlgg.cpp:328 ../src/generic/fontdlgg.cpp:331
+#: ../src/generic/fontdlgg.cpp:324 ../src/generic/fontdlgg.cpp:327
 msgid "Normal"
 msgstr "Normal"
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1261
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Tipo de letra normal<br>y <u>subrayado</u>. "
 
-#: ../src/html/helpwnd.cpp:1205
+#: ../src/html/helpwnd.cpp:1203
 msgid "Normal font:"
 msgstr "Tipo de letra normal:"
 
-#: ../src/propgrid/props.cpp:1128
+#: ../src/propgrid/props.cpp:1115
 #, c-format
 msgid "Not %s"
 msgstr "No %s"
 
-#: ../include/wx/filename.h:573 ../include/wx/filename.h:578
-msgid "Not available"
-msgstr "No disponible"
+#: ../src/common/secretstore.cpp:168
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/webrequest.cpp:605
+msgid "Not enough free disk space for download."
+msgstr ""
 
 #: ../src/richtext/richtextfontpage.cpp:358
 msgid "Not underlined"
 msgstr "No subrayada"
 
-#: ../src/common/paper.cpp:115
+#: ../src/common/paper.cpp:112
 msgid "Note, 8 1/2 x 11 in"
 msgstr "Nota, 8 1/2 × 11 in"
 
-#: ../src/generic/notifmsgg.cpp:132
+#: ../src/generic/notifmsgg.cpp:129
 msgid "Notice"
 msgstr "Aviso"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "Num *"
 msgstr "Num *"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "Num +"
 msgstr "Num +"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "Num ,"
 msgstr "Num ,"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "Num -"
 msgstr "Num -"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "Num ."
 msgstr "Num ."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "Num /"
 msgstr "Num /"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "Num ="
 msgstr "Num ="
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "Num Begin"
 msgstr "Num Inicio"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 msgid "Num Delete"
 msgstr "Num Eliminar"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 msgid "Num Down"
 msgstr "Num Abajo"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "Num End"
 msgstr "Num Fin"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "Num Enter"
 msgstr "Num Intro"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 msgid "Num Home"
 msgstr "Num Inicio"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 msgid "Num Insert"
 msgstr "Num Ins"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num Lock"
 msgstr "Num Bloq"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "Num Page Down"
 msgstr "Num Av Pág"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "Num Page Up"
 msgstr "Num Re Pág"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 msgid "Num Right"
 msgstr "Num Derecha"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "Num Space"
 msgstr "Num Espacio"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "Num Tab"
 msgstr "Num Tab"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "Num Up"
 msgstr "Num Arriba"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "Num left"
 msgstr "Num Izquierda"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num_lock"
 msgstr "Bloq_Num"
 
@@ -5326,13 +5468,13 @@ msgstr "Bloq_Num"
 msgid "Numbered outline"
 msgstr "Esquema numerado"
 
-#: ../include/wx/msgdlg.h:278 ../src/richtext/richtextstyledlg.cpp:297
-#: ../src/common/stockitem.cpp:178 ../src/msw/msgdlg.cpp:454
-#: ../src/msw/msgdlg.cpp:747 ../src/gtk1/fontdlg.cpp:138
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:175
+#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/msgdlg.cpp:741 ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "Aceptar"
 
-#: ../src/msw/ole/automtn.cpp:692
+#: ../src/msw/ole/automtn.cpp:683
 #, c-format
 msgid "OLE Automation error in %s: %s"
 msgstr "Error de automatización OLE en %s: %s"
@@ -5341,15 +5483,15 @@ msgstr "Error de automatización OLE en %s: %s"
 msgid "Object Properties"
 msgstr "Propiedades del objeto"
 
-#: ../src/msw/ole/automtn.cpp:660
+#: ../src/msw/ole/automtn.cpp:651
 msgid "Object implementation does not support named arguments."
 msgstr "La implementación del objeto no admite argumentos con nombre."
 
-#: ../src/common/xtixml.cpp:264
+#: ../src/common/xtixml.cpp:260
 msgid "Objects must have an id attribute"
 msgstr "Los objetos deben tener un atributo de identificación"
 
-#: ../src/propgrid/advprops.cpp:1601
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Olive"
 msgstr "Aceituna"
 
@@ -5357,64 +5499,69 @@ msgstr "Aceituna"
 msgid "Opaci&ty:"
 msgstr "Opaci&dad:"
 
-#: ../src/generic/colrdlgg.cpp:354
+#: ../src/generic/colrdlgg.cpp:374
 msgid "Opacity:"
 msgstr "Opacidad:"
 
-#: ../src/common/docview.cpp:1773 ../src/common/docview.cpp:1815
+#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
 msgid "Open File"
 msgstr "Abrir archivo"
 
-#: ../src/html/helpwnd.cpp:671 ../src/html/helpwnd.cpp:1554
+#: ../src/html/helpwnd.cpp:669 ../src/html/helpwnd.cpp:1552
 msgid "Open HTML document"
 msgstr "Abrir documento HTML"
 
-#: ../src/generic/dbgrptg.cpp:163
+#: ../src/common/stockitem.cpp:265
+#, fuzzy
+msgid "Open an existing document"
+msgstr "Abrir documento HTML"
+
+#: ../src/generic/dbgrptg.cpp:160
 #, c-format
 msgid "Open file \"%s\""
 msgstr "Abrir archivo «%s»"
 
-#: ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176
 msgid "Open..."
 msgstr "Abrir…"
 
-#: ../src/unix/glx11.cpp:506 ../src/msw/glcanvas.cpp:592
+#: ../src/msw/glcanvas.cpp:607 ../src/unix/glx11.cpp:513
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr "El controlador de OpenGL no admite OpenGL 3.0 o más reciente."
 
-#: ../src/generic/dirctrlg.cpp:599 ../src/generic/dirdlgg.cpp:323
-#: ../src/generic/filectrlg.cpp:642 ../src/generic/filectrlg.cpp:786
+#: ../src/generic/dirctrlg.cpp:565 ../src/generic/filectrlg.cpp:638
+#: ../src/generic/filectrlg.cpp:782 ../src/generic/dirdlgg.cpp:320
 msgid "Operation not permitted."
 msgstr "Operación no permitida"
 
-#: ../src/common/cmdline.cpp:900
+#: ../src/common/cmdline.cpp:896
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "La opción «%s» no puede negarse"
 
-#: ../src/common/cmdline.cpp:1064
+#: ../src/common/cmdline.cpp:1060
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "La opción «%s» exige un valor."
 
-#: ../src/common/cmdline.cpp:1147
+#: ../src/common/cmdline.cpp:1143
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Parámetro «%s»: «%s» no puede convertirse en fecha."
 
-#: ../src/generic/prntdlgg.cpp:618
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Opciones"
 
-#: ../src/propgrid/advprops.cpp:1606
+#: ../src/propgrid/advprops.cpp:1512
 msgid "Orange"
 msgstr "Naranja"
 
-#: ../src/generic/prntdlgg.cpp:615 ../src/generic/prntdlgg.cpp:869
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:862
 msgid "Orientation"
 msgstr "Orientación"
 
-#: ../src/common/windowid.cpp:242
+#: ../src/common/windowid.cpp:237
 msgid "Out of window IDs.  Recommend shutting down application."
 msgstr "Se agotaron los ids. de ventana. Se recomienda cerrar la aplicación."
 
@@ -5427,148 +5574,148 @@ msgstr "Contorno"
 msgid "Outset"
 msgstr "Comienzo"
 
-#: ../src/msw/ole/automtn.cpp:656
+#: ../src/msw/ole/automtn.cpp:647
 msgid "Overflow while coercing argument values."
 msgstr "Desbordamiento durante el forzado de los valores de argumentos."
 
-#: ../src/common/imagpcx.cpp:457 ../src/common/imagpcx.cpp:480
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:479
 msgid "PCX: couldn't allocate memory"
 msgstr "PCX: no pudo reservarse memoria"
 
-#: ../src/common/imagpcx.cpp:456
+#: ../src/common/imagpcx.cpp:455
 msgid "PCX: image format unsupported"
 msgstr "PCX: formato de imagen no admitido"
 
-#: ../src/common/imagpcx.cpp:479
+#: ../src/common/imagpcx.cpp:478
 msgid "PCX: invalid image"
 msgstr "PCX: imagen no válida"
 
-#: ../src/common/imagpcx.cpp:442
+#: ../src/common/imagpcx.cpp:441
 msgid "PCX: this is not a PCX file."
 msgstr "PCX: este no es un archivo PCX."
 
-#: ../src/common/imagpcx.cpp:459 ../src/common/imagpcx.cpp:481
+#: ../src/common/imagpcx.cpp:458 ../src/common/imagpcx.cpp:480
 msgid "PCX: unknown error !!!"
 msgstr "PCX: ¡error desconocido!"
 
-#: ../src/common/imagpcx.cpp:458
+#: ../src/common/imagpcx.cpp:457
 msgid "PCX: version number too low"
 msgstr "PCX: número de versión demasiado antiguo"
 
-#: ../src/common/imagpnm.cpp:91
+#: ../src/common/imagpnm.cpp:89
 msgid "PNM: Couldn't allocate memory."
 msgstr "PNM: no se pudo reservar memoria."
 
-#: ../src/common/imagpnm.cpp:73
+#: ../src/common/imagpnm.cpp:71
 msgid "PNM: File format is not recognized."
 msgstr "PNM: no se reconoce el formato de archivo."
 
-#: ../src/common/imagpnm.cpp:112 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
 #: ../src/common/imagpnm.cpp:156
 msgid "PNM: File seems truncated."
 msgstr "PNM: el archivo parece estar truncado."
 
-#: ../src/common/paper.cpp:187
+#: ../src/common/paper.cpp:184
 msgid "PRC 16K 146 x 215 mm"
 msgstr "PRC 16K 146 × 215 mm"
 
-#: ../src/common/paper.cpp:200
+#: ../src/common/paper.cpp:197
 msgid "PRC 16K Rotated"
 msgstr "PRC 16K Girado"
 
-#: ../src/common/paper.cpp:188
+#: ../src/common/paper.cpp:185
 msgid "PRC 32K 97 x 151 mm"
 msgstr "PRC 32K 97 × 151 mm"
 
-#: ../src/common/paper.cpp:201
+#: ../src/common/paper.cpp:198
 msgid "PRC 32K Rotated"
 msgstr "PRC 32K Girado"
 
-#: ../src/common/paper.cpp:189
+#: ../src/common/paper.cpp:186
 msgid "PRC 32K(Big) 97 x 151 mm"
 msgstr "PRC 32K(Grande) 97 × 151 mm"
 
-#: ../src/common/paper.cpp:202
+#: ../src/common/paper.cpp:199
 msgid "PRC 32K(Big) Rotated"
 msgstr "PRC 32K(Grande) Girado"
 
-#: ../src/common/paper.cpp:190
+#: ../src/common/paper.cpp:187
 msgid "PRC Envelope #1 102 x 165 mm"
 msgstr "Sobre PRC n.º 1 102 × 165 mm"
 
-#: ../src/common/paper.cpp:203
+#: ../src/common/paper.cpp:200
 msgid "PRC Envelope #1 Rotated 165 x 102 mm"
 msgstr "Sobre PRC n.º1 Girado 165 × 102 mm"
 
-#: ../src/common/paper.cpp:199
+#: ../src/common/paper.cpp:196
 msgid "PRC Envelope #10 324 x 458 mm"
 msgstr "Sobre PRC n.º 10 324 × 458 mm"
 
-#: ../src/common/paper.cpp:212
+#: ../src/common/paper.cpp:209
 msgid "PRC Envelope #10 Rotated 458 x 324 mm"
 msgstr "Sobre PRC n.º 10 Girado 458 × 324 mm"
 
-#: ../src/common/paper.cpp:191
+#: ../src/common/paper.cpp:188
 msgid "PRC Envelope #2 102 x 176 mm"
 msgstr "Sobre PRC n.º 2 102 × 176 mm"
 
-#: ../src/common/paper.cpp:204
+#: ../src/common/paper.cpp:201
 msgid "PRC Envelope #2 Rotated 176 x 102 mm"
 msgstr "Sobre PRC n.º 2 Girado 176 × 102 mm"
 
-#: ../src/common/paper.cpp:192
+#: ../src/common/paper.cpp:189
 msgid "PRC Envelope #3 125 x 176 mm"
 msgstr "Sobre PRC n.º 3 125 × 176 mm"
 
-#: ../src/common/paper.cpp:205
+#: ../src/common/paper.cpp:202
 msgid "PRC Envelope #3 Rotated 176 x 125 mm"
 msgstr "Sobre PRC n.º 3 Girado 176 × 125 mm"
 
-#: ../src/common/paper.cpp:193
+#: ../src/common/paper.cpp:190
 msgid "PRC Envelope #4 110 x 208 mm"
 msgstr "Sobre PRC n.º 4 110 × 208 mm"
 
-#: ../src/common/paper.cpp:206
+#: ../src/common/paper.cpp:203
 msgid "PRC Envelope #4 Rotated 208 x 110 mm"
 msgstr "Sobre PRC n.º 4 Girado 208 × 110 mm"
 
-#: ../src/common/paper.cpp:194
+#: ../src/common/paper.cpp:191
 msgid "PRC Envelope #5 110 x 220 mm"
 msgstr "Sobre PRC n.º 5 110 × 220 mm"
 
-#: ../src/common/paper.cpp:207
+#: ../src/common/paper.cpp:204
 msgid "PRC Envelope #5 Rotated 220 x 110 mm"
 msgstr "Sobre PRC n.º 5 Girado 220 × 110 mm"
 
-#: ../src/common/paper.cpp:195
+#: ../src/common/paper.cpp:192
 msgid "PRC Envelope #6 120 x 230 mm"
 msgstr "Sobre PRC n.º 6 120 × 230 mm"
 
-#: ../src/common/paper.cpp:208
+#: ../src/common/paper.cpp:205
 msgid "PRC Envelope #6 Rotated 230 x 120 mm"
 msgstr "Sobre PRC n.º 6 Girado 230 × 120 mm"
 
-#: ../src/common/paper.cpp:196
+#: ../src/common/paper.cpp:193
 msgid "PRC Envelope #7 160 x 230 mm"
 msgstr "Sobre PRC n.º 7 160 × 230 mm"
 
-#: ../src/common/paper.cpp:209
+#: ../src/common/paper.cpp:206
 msgid "PRC Envelope #7 Rotated 230 x 160 mm"
 msgstr "Sobre PRC n.º 7 Girado 230 × 160 mm"
 
-#: ../src/common/paper.cpp:197
+#: ../src/common/paper.cpp:194
 msgid "PRC Envelope #8 120 x 309 mm"
 msgstr "Sobre PRC n.º 8 120 × 309 mm"
 
-#: ../src/common/paper.cpp:210
+#: ../src/common/paper.cpp:207
 msgid "PRC Envelope #8 Rotated 309 x 120 mm"
 msgstr "Sobre PRC n.º 8 Girado 309 × 120 mm"
 
-#: ../src/common/paper.cpp:198
+#: ../src/common/paper.cpp:195
 msgid "PRC Envelope #9 229 x 324 mm"
 msgstr "Sobre PRC n.º 9 229 × 324 mm"
 
-#: ../src/common/paper.cpp:211
+#: ../src/common/paper.cpp:208
 msgid "PRC Envelope #9 Rotated 324 x 229 mm"
 msgstr "Sobre PRC n.º 9 Girado 324 × 229 mm"
 
@@ -5576,87 +5723,91 @@ msgstr "Sobre PRC n.º 9 Girado 324 × 229 mm"
 msgid "Padding"
 msgstr "Relleno"
 
-#: ../src/common/prntbase.cpp:2074
+#: ../src/common/prntbase.cpp:2096
 #, c-format
 msgid "Page %d"
 msgstr "Página %d"
 
-#: ../src/common/prntbase.cpp:2072
+#: ../src/common/prntbase.cpp:2094
 #, c-format
 msgid "Page %d of %d"
 msgstr "Página %d de %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 msgid "Page Down"
 msgstr "Página abajo"
 
-#: ../src/gtk/print.cpp:826
+#: ../src/gtk/print.cpp:829
 msgid "Page Setup"
 msgstr "Configurar página"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 msgid "Page Up"
 msgstr "Página arriba"
 
-#: ../src/generic/prntdlgg.cpp:828 ../src/common/prntbase.cpp:484
+#: ../src/common/prntbase.cpp:479 ../src/generic/prntdlgg.cpp:821
 msgid "Page setup"
 msgstr "Configurar página"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 msgid "PageDown"
 msgstr "AvPág"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 msgid "PageUp"
 msgstr "RePág"
 
-#: ../src/generic/prntdlgg.cpp:216
+#: ../src/generic/prntdlgg.cpp:209
 msgid "Pages"
 msgstr "Páginas"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1765
+#: ../src/propgrid/advprops.cpp:1666
 msgid "Paint Brush"
 msgstr "Brocha"
 
-#: ../src/generic/prntdlgg.cpp:602 ../src/generic/prntdlgg.cpp:801
-#: ../src/generic/prntdlgg.cpp:842 ../src/generic/prntdlgg.cpp:855
-#: ../src/generic/prntdlgg.cpp:1052 ../src/generic/prntdlgg.cpp:1057
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:794
+#: ../src/generic/prntdlgg.cpp:835 ../src/generic/prntdlgg.cpp:848
+#: ../src/generic/prntdlgg.cpp:1045 ../src/generic/prntdlgg.cpp:1050
 msgid "Paper size"
 msgstr "Tamaño del papel"
 
-#: ../src/richtext/richtextstyles.cpp:1062
+#: ../src/richtext/richtextstyles.cpp:1059
 msgid "Paragraph styles"
 msgstr "Estilos de párrafo"
 
-#: ../src/common/xtistrm.cpp:465
+#: ../src/common/xtistrm.cpp:462
 msgid "Passing a already registered object to SetObject"
 msgstr "Paso de un objeto ya registrado a SetObject"
 
-#: ../src/common/xtistrm.cpp:476
+#: ../src/common/xtistrm.cpp:473
 msgid "Passing an unknown object to GetObject"
 msgstr "Paso de un objeto desconocido a GetObject"
 
-#: ../src/richtext/richtextctrl.cpp:3513 ../src/common/stockitem.cpp:180
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:177 ../src/richtext/richtextctrl.cpp:3514
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Pegar"
 
-#: ../src/common/stockitem.cpp:262
+#: ../src/common/stockitem.cpp:260
 msgid "Paste selection"
 msgstr "Pegar selección"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:74
+#: ../src/common/accelcmn.cpp:71
 msgid "Pause"
 msgstr "Pausa"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1766
+#: ../src/propgrid/advprops.cpp:1667
 msgid "Pencil"
 msgstr "Lápiz"
 
@@ -5665,21 +5816,21 @@ msgstr "Lápiz"
 msgid "Peri&od"
 msgstr "Peri&odo"
 
-#: ../src/generic/filectrlg.cpp:430
+#: ../src/generic/filectrlg.cpp:426
 msgid "Permissions"
 msgstr "Permisos"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:60
+#: ../src/common/accelcmn.cpp:57
 msgid "PgDn"
 msgstr "AvPg"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:59
+#: ../src/common/accelcmn.cpp:56
 msgid "PgUp"
 msgstr "RePg"
 
-#: ../src/richtext/richtextbuffer.cpp:12868
+#: ../src/richtext/richtextbuffer.cpp:12863
 msgid "Picture Properties"
 msgstr "Propiedades de la imagen"
 
@@ -5691,42 +5842,42 @@ msgstr "Error en la creación de la tubería"
 msgid "Please choose a valid font."
 msgstr "Elija un tipo de letra válido."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
 msgid "Please choose an existing file."
 msgstr "Elija un archivo existente."
 
-#: ../src/html/helpwnd.cpp:800
+#: ../src/html/helpwnd.cpp:798
 msgid "Please choose the page to display:"
 msgstr "Elija la página que quiera mostrar:"
 
-#: ../src/msw/dialup.cpp:764
+#: ../src/msw/dialup.cpp:758
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Elija el ISP con el que se quiera conectar"
 
-#: ../src/common/headerctrlcmn.cpp:59
+#: ../src/common/headerctrlcmn.cpp:57
 msgid "Please select the columns to show and define their order:"
 msgstr "Seleccione las columnas que se mostrarán y defina su orden:"
 
-#: ../src/common/prntbase.cpp:538
+#: ../src/common/prntbase.cpp:533
 msgid "Please wait while printing..."
 msgstr "Imprimiendo; espere un momento…"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1767
+#: ../src/propgrid/advprops.cpp:1668
 msgid "Point Left"
 msgstr "Apuntar a la izquierda"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1768
+#: ../src/propgrid/advprops.cpp:1669
 msgid "Point Right"
 msgstr "Apuntar a la derecha"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:662
+#: ../src/propgrid/advprops.cpp:572
 msgid "Point Size"
 msgstr "Tamaño de punto"
 
-#: ../src/generic/prntdlgg.cpp:612 ../src/generic/prntdlgg.cpp:867
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:860
 msgid "Portrait"
 msgstr "Vertical"
 
@@ -5734,150 +5885,159 @@ msgstr "Vertical"
 msgid "Position"
 msgstr "Posición"
 
-#: ../src/generic/prntdlgg.cpp:298
+#: ../src/generic/prntdlgg.cpp:291
 msgid "PostScript file"
 msgstr "Archivo PostScript"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178 ../src/osx/cocoa/preferences.mm:303
 msgid "Preferences"
 msgstr "Preferencias"
 
-#: ../src/osx/menu_osx.cpp:568
+#: ../src/osx/menu_osx.cpp:460
 msgid "Preferences..."
 msgstr "Preferencias..."
 
-#: ../src/common/prntbase.cpp:546
+#: ../src/common/prntbase.cpp:541
 msgid "Preparing"
 msgstr "Preparando"
 
-#: ../src/generic/fontdlgg.cpp:455 ../src/osx/carbon/fontdlg.cpp:390
-#: ../src/html/helpwnd.cpp:1222
+#: ../src/osx/carbon/fontdlg.cpp:387 ../src/generic/fontdlgg.cpp:452
+#: ../src/html/helpwnd.cpp:1220
 msgid "Preview:"
 msgstr "Previsualización:"
 
-#: ../src/common/prntbase.cpp:1553 ../src/html/helpwnd.cpp:664
+#: ../src/common/prntbase.cpp:1578 ../src/html/helpwnd.cpp:662
 msgid "Previous page"
 msgstr "Página anterior"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/prntdlgg.cpp:143 ../src/generic/prntdlgg.cpp:157
-#: ../src/common/prntbase.cpp:426 ../src/common/prntbase.cpp:1541
-#: ../src/common/accelcmn.cpp:77 ../src/gtk/print.cpp:620
-#: ../src/gtk/print.cpp:638
+#: ../src/common/prntbase.cpp:421 ../src/common/prntbase.cpp:1566
+#: ../src/common/accelcmn.cpp:74 ../src/generic/prntdlgg.cpp:136
+#: ../src/generic/prntdlgg.cpp:150 ../src/gtk/print.cpp:616
+#: ../src/gtk/print.cpp:634
 msgid "Print"
 msgstr "Imprimir"
 
-#: ../include/wx/prntbase.h:399 ../src/common/docview.cpp:1268
+#: ../src/common/docview.cpp:1262
 msgid "Print Preview"
 msgstr "Previsualización de la impresión"
 
-#: ../src/common/prntbase.cpp:2015 ../src/common/prntbase.cpp:2057
-#: ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2037 ../src/common/prntbase.cpp:2079
+#: ../src/common/prntbase.cpp:2087
 msgid "Print Preview Failure"
 msgstr "Error en previsualización de impresión"
 
-#: ../src/generic/prntdlgg.cpp:224
+#: ../src/generic/prntdlgg.cpp:217
 msgid "Print Range"
 msgstr "Intervalo de impresión"
 
-#: ../src/generic/prntdlgg.cpp:449
+#: ../src/generic/prntdlgg.cpp:442
 msgid "Print Setup"
 msgstr "Configuración de impresión"
 
-#: ../src/generic/prntdlgg.cpp:621
+#: ../src/generic/prntdlgg.cpp:614
 msgid "Print in colour"
 msgstr "Impresión en color"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/osx/webview_webkit.mm:260
+msgid "Print operation could not be initialized"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:179
 msgid "Print previe&w..."
 msgstr "&Vista previa de impresión"
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1256
 msgid "Print preview creation failed."
 msgstr "Error al crear la previsualización de impresión."
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/common/stockitem.cpp:179
 msgid "Print preview..."
 msgstr "Vista previa de impresión..."
 
-#: ../src/generic/prntdlgg.cpp:630
+#: ../src/generic/prntdlgg.cpp:623
 msgid "Print spooling"
 msgstr "Cola de impresión"
 
-#: ../src/html/helpwnd.cpp:675
+#: ../src/html/helpwnd.cpp:673
 msgid "Print this page"
 msgstr "Imprimir esta página"
 
-#: ../src/generic/prntdlgg.cpp:185
+#: ../src/generic/prntdlgg.cpp:178
 msgid "Print to File"
 msgstr "Imprimir a archivo "
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "Print..."
 msgstr "Imprimir..."
 
-#: ../src/generic/prntdlgg.cpp:493
+#: ../src/generic/prntdlgg.cpp:486
 msgid "Printer"
 msgstr "Impresora"
 
-#: ../src/generic/prntdlgg.cpp:633
+#: ../src/generic/prntdlgg.cpp:626
 msgid "Printer command:"
 msgstr "Orden de la impresora:"
 
-#: ../src/generic/prntdlgg.cpp:180
+#: ../src/generic/prntdlgg.cpp:173
 msgid "Printer options"
 msgstr "Opciones de impresión"
 
-#: ../src/generic/prntdlgg.cpp:645
+#: ../src/generic/prntdlgg.cpp:638
 msgid "Printer options:"
 msgstr "Opciones de impresión:"
 
-#: ../src/generic/prntdlgg.cpp:916
+#: ../src/generic/prntdlgg.cpp:909
 msgid "Printer..."
 msgstr "Impresora..."
 
-#: ../src/generic/prntdlgg.cpp:196
+#: ../src/generic/prntdlgg.cpp:189
 msgid "Printer:"
 msgstr "Impresora:"
 
-#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:535
-#: ../src/html/htmprint.cpp:277
+#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:530
+#: ../src/html/htmprint.cpp:289
 msgid "Printing"
 msgstr "Imprimiendo"
 
-#: ../src/common/prntbase.cpp:612
+#: ../src/common/prntbase.cpp:607
 msgid "Printing "
 msgstr "Imprimiendo "
 
-#: ../src/common/prntbase.cpp:347
+#: ../src/common/prntbase.cpp:342
 msgid "Printing Error"
 msgstr "Error de impresión"
 
-#: ../src/common/prntbase.cpp:565
+#: ../src/osx/webview_webkit.mm:251
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "Esta versión de zlib no admite GZIP"
+
+#: ../src/common/prntbase.cpp:560
 #, c-format
 msgid "Printing page %d"
 msgstr "Imprimiendo página %d"
 
-#: ../src/common/prntbase.cpp:570
+#: ../src/common/prntbase.cpp:565
 #, c-format
 msgid "Printing page %d of %d"
 msgstr "Imprimiendo página %d de %d"
 
-#: ../src/generic/printps.cpp:201
+#: ../src/generic/printps.cpp:182
 #, c-format
 msgid "Printing page %d..."
 msgstr "Imprimiendo página %d..."
 
-#: ../src/generic/printps.cpp:161
+#: ../src/generic/printps.cpp:142
 msgid "Printing..."
 msgstr "Imprimiendo..."
 
-#: ../include/wx/richtext/richtextprint.h:109 ../include/wx/prntbase.h:267
-#: ../src/common/docview.cpp:2132
+#: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
+#: ../src/common/docview.cpp:2137
 msgid "Printout"
 msgstr "Impresión"
 
-#: ../src/common/debugrpt.cpp:560
+#: ../src/common/debugrpt.cpp:561
 #, c-format
 msgid ""
 "Processing debug report has failed, leaving the files in \"%s\" directory."
@@ -5885,102 +6045,102 @@ msgstr ""
 "Falló el procesamiento del informe de depuración; se han dejado los archivos "
 "en el directorio «%s»."
 
-#: ../src/common/prntbase.cpp:545
+#: ../src/common/prntbase.cpp:540
 msgid "Progress:"
 msgstr "Progreso:"
 
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181
 msgid "Properties"
 msgstr "Propiedades"
 
-#: ../src/propgrid/manager.cpp:237
+#: ../src/propgrid/manager.cpp:223
 msgid "Property"
 msgstr "Propiedad"
 
 #. TRANSLATORS: Caption of message box displaying any property error
-#: ../src/propgrid/propgrid.cpp:3185 ../src/propgrid/propgrid.cpp:3318
+#: ../src/propgrid/propgrid.cpp:3162 ../src/propgrid/propgrid.cpp:3299
 msgid "Property Error"
 msgstr "Error de propiedad"
 
-#: ../src/propgrid/advprops.cpp:1597
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Purple"
 msgstr "Morado"
 
-#: ../src/common/paper.cpp:112
+#: ../src/common/paper.cpp:109
 msgid "Quarto, 215 x 275 mm"
 msgstr "Quarto, 215 x 275 mm"
 
-#: ../src/generic/logg.cpp:1016
+#: ../src/generic/logg.cpp:1013
 msgid "Question"
 msgstr "Pregunta"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1769
+#: ../src/propgrid/advprops.cpp:1670
 msgid "Question Arrow"
 msgstr "Pregunta Flecha"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "Quit"
 msgstr "Salir"
 
-#: ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:477
 #, c-format
 msgid "Quit %s"
 msgstr "Salir %s"
 
-#: ../src/common/stockitem.cpp:263
+#: ../src/common/stockitem.cpp:261
 msgid "Quit this program"
 msgstr "Salir de este programa"
 
-#: ../src/common/accelcmn.cpp:338
+#: ../src/common/accelcmn.cpp:352
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/ffile.cpp:109 ../src/common/ffile.cpp:133
+#: ../src/common/ffile.cpp:107 ../src/common/ffile.cpp:132
 #, c-format
 msgid "Read error on file '%s'"
 msgstr "Error de lectura en el archivo '%s'"
 
-#: ../src/common/secretstore.cpp:199
-#, c-format
-msgid "Reading password for \"%s/%s\" failed: %s."
+#: ../src/common/secretstore.cpp:211
+#, fuzzy, c-format
+msgid "Reading password for \"%s\" failed: %s."
 msgstr "Falló la lectura de la contraseña de «%s/%s»: %s."
 
-#: ../src/common/prntbase.cpp:272
+#: ../src/common/prntbase.cpp:267
 msgid "Ready"
 msgstr "Listo"
 
-#: ../src/propgrid/advprops.cpp:1605
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Red"
 msgstr "Rojo"
 
-#: ../src/generic/colrdlgg.cpp:339
+#: ../src/generic/colrdlgg.cpp:359
 msgid "Red:"
 msgstr "Rojo:"
 
-#: ../src/common/stockitem.cpp:185 ../src/stc/stc_i18n.cpp:16
+#: ../src/common/stockitem.cpp:182 ../src/stc/stc_i18n.cpp:16
 msgid "Redo"
 msgstr "Rehacer"
 
-#: ../src/common/stockitem.cpp:264
+#: ../src/common/stockitem.cpp:262
 msgid "Redo last action"
 msgstr "Rehacer la última acción"
 
-#: ../src/common/stockitem.cpp:186
+#: ../src/common/stockitem.cpp:183
 msgid "Refresh"
 msgstr "Refrescar"
 
-#: ../src/msw/registry.cpp:626
+#: ../src/msw/registry.cpp:615
 #, c-format
 msgid "Registry key '%s' already exists."
 msgstr "La clave del registro '%s' ya existe."
 
-#: ../src/msw/registry.cpp:595
+#: ../src/msw/registry.cpp:584
 #, c-format
 msgid "Registry key '%s' does not exist, cannot rename it."
 msgstr "La clave del registro '%s' no existe, no se puede renombrar."
 
-#: ../src/msw/registry.cpp:727
+#: ../src/msw/registry.cpp:716
 #, c-format
 msgid ""
 "Registry key '%s' is needed for normal system operation,\n"
@@ -5992,22 +6152,22 @@ msgstr ""
 "si se elimina puede dejar el sistema en un estado inestable:\n"
 "operación abortada."
 
-#: ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:942
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr "El valor del Registro «%s» no es binario (sino del tipo %s)"
 
-#: ../src/msw/registry.cpp:917
+#: ../src/msw/registry.cpp:905
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr "El valor del Registro «%s» no es numérico (sino del tipo %s)"
 
-#: ../src/msw/registry.cpp:1003
+#: ../src/msw/registry.cpp:991
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr "El valor del Registro «%s» no es de texto (sino del tipo %s)"
 
-#: ../src/msw/registry.cpp:521
+#: ../src/msw/registry.cpp:510
 #, c-format
 msgid "Registry value '%s' already exists."
 msgstr "La clave del registro '%s' ya existe."
@@ -6021,72 +6181,78 @@ msgstr "Normal"
 msgid "Relative"
 msgstr "Relativo"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:456
 msgid "Relevant entries:"
 msgstr "Entradas relevantes:"
 
-#: ../include/wx/generic/progdlgg.h:86
+#: ../include/wx/generic/progdlgg.h:87
 msgid "Remaining time:"
 msgstr "Tiempo restante:"
 
-#: ../src/common/stockitem.cpp:187
+#: ../src/common/stockitem.cpp:184
 msgid "Remove"
 msgstr "Eliminar"
 
-#: ../src/richtext/richtextctrl.cpp:1562
+#: ../src/richtext/richtextctrl.cpp:1563
 msgid "Remove Bullet"
 msgstr "Eliminar marca"
 
-#: ../src/html/helpwnd.cpp:433
+#: ../src/html/helpwnd.cpp:431
 msgid "Remove current page from bookmarks"
 msgstr "Eliminar la página actual de favoritos"
 
-#: ../src/common/rendcmn.cpp:194
+#: ../src/common/rendcmn.cpp:191
 #, c-format
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 "El renderizador \"%s\" tiene una versión %d.%d incompatible y no se ha "
 "podido abrir."
 
-#: ../src/richtext/richtextbuffer.cpp:4527
+#: ../src/richtext/richtextbuffer.cpp:4524
 msgid "Renumber List"
 msgstr "Renumerar Lista"
 
-#: ../src/common/stockitem.cpp:188
-msgid "Rep&lace"
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Rep&lace..."
 msgstr "&Sustituir"
 
-#: ../src/richtext/richtextctrl.cpp:3673 ../src/common/stockitem.cpp:188
+#: ../src/richtext/richtextctrl.cpp:3674
 msgid "Replace"
 msgstr "Sustituir"
 
-#: ../src/generic/fdrepdlg.cpp:182
+#: ../src/generic/fdrepdlg.cpp:179
 msgid "Replace &all"
 msgstr "Sustituir &todo"
 
-#: ../src/common/stockitem.cpp:261
-msgid "Replace selection"
-msgstr "Reemplazar selección"
-
-#: ../src/generic/fdrepdlg.cpp:124
+#: ../src/generic/fdrepdlg.cpp:121
 msgid "Replace with:"
 msgstr "Sustituir por:"
 
-#: ../src/common/valtext.cpp:163
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Replace..."
+msgstr "Sustituir"
+
+#: ../src/common/valtext.cpp:184
 msgid "Required information entry is empty."
 msgstr "La entrada de información requerida está vacía"
 
-#: ../src/common/translation.cpp:1975
+#: ../src/common/translation.cpp:2025
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "El recurso '%s' no es un catálogo de mensajes válido."
 
+#: ../src/gtk/webview_webkit.cpp:985
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:56
+#: ../src/common/accelcmn.cpp:53
 msgid "Return"
 msgstr "Regresar"
 
-#: ../src/common/stockitem.cpp:189
+#: ../src/common/stockitem.cpp:186
 msgid "Revert to Saved"
 msgstr "Recuperar versión guardada"
 
@@ -6098,41 +6264,41 @@ msgstr "Arrugar"
 msgid "Rig&ht-to-left"
 msgstr "Derec&ha a izquierda"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6149
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:59 ../src/generic/datavgen.cpp:6954
+#: ../src/richtext/richtextsizepage.cpp:250
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextbulletspage.cpp:188
-#: ../src/richtext/richtextsizepage.cpp:250 ../src/common/accelcmn.cpp:62
 msgid "Right"
 msgstr "Derecha"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1754
+#: ../src/propgrid/advprops.cpp:1655
 msgid "Right Arrow"
 msgstr "Flecha derecha"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1770
+#: ../src/propgrid/advprops.cpp:1671
 msgid "Right Button"
 msgstr "Botón derecho"
 
-#: ../src/generic/prntdlgg.cpp:892
+#: ../src/generic/prntdlgg.cpp:885
 msgid "Right margin (mm):"
 msgstr "Margen derecho (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:148
-#: ../src/richtext/richtextindentspage.cpp:150
 #: ../src/richtext/richtextliststylepage.cpp:337
 #: ../src/richtext/richtextliststylepage.cpp:339
+#: ../src/richtext/richtextindentspage.cpp:148
+#: ../src/richtext/richtextindentspage.cpp:150
 msgid "Right-align text."
 msgstr "Alinear texto a la derecha."
 
-#: ../src/generic/fontdlgg.cpp:322
+#: ../src/generic/fontdlgg.cpp:318
 msgid "Roman"
 msgstr "Roman"
 
-#: ../src/generic/datavgen.cpp:5916
+#: ../src/generic/datavgen.cpp:6721
 #, c-format
 msgid "Row %i"
 msgstr "Fila %i"
@@ -6142,30 +6308,31 @@ msgstr "Fila %i"
 msgid "S&tandard bullet name:"
 msgstr "Nombre de viñeta es&tándar:"
 
-#: ../src/common/accelcmn.cpp:268 ../src/common/accelcmn.cpp:350
+#: ../src/common/accelcmn.cpp:282 ../src/common/accelcmn.cpp:367
 msgid "SPECIAL"
 msgstr "ESPECIAL"
 
-#: ../src/common/stockitem.cpp:190 ../src/common/sizer.cpp:2797
+#: ../src/common/stockitem.cpp:187 ../src/common/sizer.cpp:2914
 msgid "Save"
 msgstr "Guardar"
 
-#: ../src/common/fldlgcmn.cpp:342
+#: ../src/common/fldlgcmn.cpp:339
 #, c-format
 msgid "Save %s file"
 msgstr "Guardar el archivo %s"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/common/stockitem.cpp:188 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "G&uardar como…"
 
-#: ../src/common/docview.cpp:366
+#: ../src/common/docview.cpp:359
 msgid "Save As"
 msgstr "Guardar como"
 
-#: ../src/common/stockitem.cpp:191
-msgid "Save as"
-msgstr "Guardar como"
+#: ../src/common/stockitem.cpp:188
+#, fuzzy
+msgid "Save As..."
+msgstr "G&uardar como…"
 
 #: ../src/common/stockitem.cpp:267
 msgid "Save current document"
@@ -6175,96 +6342,96 @@ msgstr "Guardar documento actual"
 msgid "Save current document with a different filename"
 msgstr "Guardar el documento actual con otro nombre"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/generic/logg.cpp:509
 msgid "Save log contents to file"
 msgstr "Guardar los contenidos del log en un archivo"
 
-#: ../src/common/secretstore.cpp:179
-#, c-format
-msgid "Saving password for \"%s/%s\" failed: %s."
+#: ../src/common/secretstore.cpp:189
+#, fuzzy, c-format
+msgid "Saving password for \"%s\" failed: %s."
 msgstr "Falló el guardado de la contraseña de «%s/%s»: %s."
 
-#: ../src/generic/fontdlgg.cpp:325
+#: ../src/generic/fontdlgg.cpp:321
 msgid "Script"
 msgstr "Script"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll Lock"
 msgstr "Bloq Despl"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll_lock"
 msgstr "Bloq_despl"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:890
+#: ../src/propgrid/advprops.cpp:791
 msgid "Scrollbar"
 msgstr "Barra de desplazamiento"
 
-#: ../src/generic/srchctlg.cpp:56 ../src/html/helpwnd.cpp:535
-#: ../src/html/helpwnd.cpp:550
+#: ../src/generic/srchctlg.cpp:55 ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:548 ../src/gtk/srchctrl.cpp:182
 msgid "Search"
 msgstr "Buscar"
 
-#: ../src/html/helpwnd.cpp:537
+#: ../src/html/helpwnd.cpp:535
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
 msgstr ""
 "Buscar en los libros de ayuda todas las apariciones del texto que ha escrito"
 
-#: ../src/generic/fdrepdlg.cpp:160
+#: ../src/generic/fdrepdlg.cpp:157
 msgid "Search direction"
 msgstr "Dirección de búsqueda"
 
-#: ../src/generic/fdrepdlg.cpp:112
+#: ../src/generic/fdrepdlg.cpp:109
 msgid "Search for:"
 msgstr "Buscar:"
 
-#: ../src/html/helpwnd.cpp:1052
+#: ../src/html/helpwnd.cpp:1050
 msgid "Search in all books"
 msgstr "Buscar en todos los libros"
 
-#: ../src/html/helpwnd.cpp:857
+#: ../src/html/helpwnd.cpp:855
 msgid "Searching..."
 msgstr "Buscando…"
 
-#: ../src/generic/dirctrlg.cpp:446
+#: ../src/generic/dirctrlg.cpp:412
 msgid "Sections"
 msgstr "Secciones"
 
-#: ../src/common/ffile.cpp:238
+#: ../src/common/ffile.cpp:237
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Error de búsqueda en el archivo «%s»"
 
-#: ../src/common/ffile.cpp:228
+#: ../src/common/ffile.cpp:227
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
 "Error de búsqueda en el archivo «%s» (stdio no admite los archivos grandes)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:76
+#: ../src/common/accelcmn.cpp:73
 msgid "Select"
 msgstr "Seleccione"
 
-#: ../src/richtext/richtextctrl.cpp:337 ../src/osx/textctrl_osx.cpp:581
-#: ../src/common/stockitem.cpp:192 ../src/msw/textctrl.cpp:2512
+#: ../src/osx/textctrl_osx.cpp:599 ../src/common/stockitem.cpp:189
+#: ../src/msw/textctrl.cpp:2777 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Seleccionar &todo"
 
-#: ../src/common/stockitem.cpp:192 ../src/stc/stc_i18n.cpp:21
+#: ../src/common/stockitem.cpp:189 ../src/stc/stc_i18n.cpp:21
 msgid "Select All"
 msgstr "Seleccionar todo"
 
-#: ../src/common/docview.cpp:1895
+#: ../src/common/docview.cpp:1900
 msgid "Select a document template"
 msgstr "Seleccionar una plantilla de documento"
 
-#: ../src/common/docview.cpp:1969
+#: ../src/common/docview.cpp:1974
 msgid "Select a document view"
 msgstr "Seleccionar una vista de documento"
 
@@ -6293,20 +6460,20 @@ msgid "Selects the list level to edit."
 msgstr "Selecciona el nivel de lista a editar."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:82
+#: ../src/common/accelcmn.cpp:79
 msgid "Separator"
 msgstr "Separador"
 
-#: ../src/common/cmdline.cpp:1083
+#: ../src/common/cmdline.cpp:1079
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Se esperaba un separador después de la opción «%s»."
 
-#: ../src/osx/menu_osx.cpp:572
+#: ../src/osx/menu_osx.cpp:464
 msgid "Services"
 msgstr "Servicios"
 
-#: ../src/richtext/richtextbuffer.cpp:11217
+#: ../src/richtext/richtextbuffer.cpp:11216
 msgid "Set Cell Style"
 msgstr "Cambiar estilo de celda"
 
@@ -6314,11 +6481,11 @@ msgstr "Cambiar estilo de celda"
 msgid "SetProperty called w/o valid setter"
 msgstr "Se llamó a SetProperty sin un establecedor válido"
 
-#: ../src/generic/prntdlgg.cpp:188
+#: ../src/generic/prntdlgg.cpp:181
 msgid "Setup..."
 msgstr "Configuración…"
 
-#: ../src/msw/dialup.cpp:544
+#: ../src/msw/dialup.cpp:538
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr ""
 "Se han encontrado varias conexiones activas, eligiendo una aleatoriamente."
@@ -6335,40 +6502,40 @@ msgstr "Sombra"
 msgid "Shadow c&olour:"
 msgstr "C&olor de la sombra:"
 
-#: ../src/common/accelcmn.cpp:335
+#: ../src/common/accelcmn.cpp:349
 msgid "Shift+"
 msgstr "Mayúsculas+"
 
-#: ../src/generic/dirdlgg.cpp:147
+#: ../src/generic/dirdlgg.cpp:144
 msgid "Show &hidden directories"
 msgstr "Mostrar directorios &ocultos"
 
-#: ../src/generic/filectrlg.cpp:983
+#: ../src/generic/filectrlg.cpp:979
 msgid "Show &hidden files"
 msgstr "Mostrar archivos &ocultos"
 
-#: ../src/osx/menu_osx.cpp:580
+#: ../src/osx/menu_osx.cpp:472
 msgid "Show All"
 msgstr "Mostrar todo"
 
-#: ../src/common/stockitem.cpp:257
+#: ../src/common/stockitem.cpp:254
 msgid "Show about dialog"
 msgstr "Muestra el diálogo Acerca de"
 
-#: ../src/html/helpwnd.cpp:492
+#: ../src/html/helpwnd.cpp:490
 msgid "Show all"
 msgstr "Mostrar todo"
 
-#: ../src/html/helpwnd.cpp:503
+#: ../src/html/helpwnd.cpp:501
 msgid "Show all items in index"
 msgstr "Mostrar todos los datos en el índice"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:656
 msgid "Show/hide navigation panel"
 msgstr "Mostrar/ocultar panel de navegación"
 
-#: ../src/richtext/richtextsymboldlg.cpp:421
-#: ../src/richtext/richtextsymboldlg.cpp:423
+#: ../src/richtext/richtextsymboldlg.cpp:418
+#: ../src/richtext/richtextsymboldlg.cpp:420
 msgid "Shows a Unicode subset."
 msgstr "Muestra un subconjunto Unicode"
 
@@ -6384,7 +6551,7 @@ msgstr "Muestra una previsualización de las opciones de la viñeta."
 msgid "Shows a preview of the font settings."
 msgstr "Muestra una vista previa de las opciones de la fuente."
 
-#: ../src/osx/carbon/fontdlg.cpp:394 ../src/osx/carbon/fontdlg.cpp:396
+#: ../src/osx/carbon/fontdlg.cpp:391 ../src/osx/carbon/fontdlg.cpp:393
 msgid "Shows a preview of the font."
 msgstr "Muestra una vista previa de la fuente."
 
@@ -6393,62 +6560,62 @@ msgstr "Muestra una vista previa de la fuente."
 msgid "Shows a preview of the paragraph settings."
 msgstr "Muestra una previsualización de las opciones del párrafo."
 
-#: ../src/generic/fontdlgg.cpp:460 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:456 ../src/generic/fontdlgg.cpp:458
 msgid "Shows the font preview."
 msgstr "Muestra la vista previa de la fuente."
 
-#: ../src/propgrid/advprops.cpp:1607
+#: ../src/propgrid/advprops.cpp:1513
 msgid "Silver"
 msgstr "Plata"
 
-#: ../src/univ/themes/mono.cpp:516
+#: ../src/univ/themes/mono.cpp:513
 msgid "Simple monochrome theme"
 msgstr "Tema monocromo sencillo"
 
-#: ../src/richtext/richtextindentspage.cpp:275
 #: ../src/richtext/richtextliststylepage.cpp:449
+#: ../src/richtext/richtextindentspage.cpp:275
 msgid "Single"
 msgstr "Sencillo"
 
-#: ../src/generic/filectrlg.cpp:425 ../src/richtext/richtextformatdlg.cpp:369
-#: ../src/richtext/richtextsizepage.cpp:299
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextsizepage.cpp:299
+#: ../src/richtext/richtextformatdlg.cpp:362
 msgid "Size"
 msgstr "Tamaño"
 
-#: ../src/osx/carbon/fontdlg.cpp:339
+#: ../src/osx/carbon/fontdlg.cpp:336
 msgid "Size:"
 msgstr "Tamaño:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1775
+#: ../src/propgrid/advprops.cpp:1676
 msgid "Sizing"
 msgstr "Dimensionado"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1772
+#: ../src/propgrid/advprops.cpp:1673
 msgid "Sizing N-S"
 msgstr "Dimensionado N-S"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1771
+#: ../src/propgrid/advprops.cpp:1672
 msgid "Sizing NE-SW"
 msgstr "Dimensionado NE-SO"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1773
+#: ../src/propgrid/advprops.cpp:1674
 msgid "Sizing NW-SE"
 msgstr "Dimensionado NO-SE"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1774
+#: ../src/propgrid/advprops.cpp:1675
 msgid "Sizing W-E"
 msgstr "Dimensionado O-E"
 
-#: ../src/msw/progdlg.cpp:801
+#: ../src/msw/progdlg.cpp:1088
 msgid "Skip"
 msgstr "Saltar"
 
-#: ../src/generic/fontdlgg.cpp:330
+#: ../src/generic/fontdlgg.cpp:326
 msgid "Slant"
 msgstr "Cursiva"
 
@@ -6457,7 +6624,7 @@ msgid "Small C&apitals"
 msgstr "M&ayúsculas pequeñas"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:79
+#: ../src/common/accelcmn.cpp:76
 msgid "Snapshot"
 msgstr "Instantánea"
 
@@ -6465,37 +6632,37 @@ msgstr "Instantánea"
 msgid "Solid"
 msgstr "Sólida"
 
-#: ../src/common/docview.cpp:1791
+#: ../src/common/docview.cpp:1785
 msgid "Sorry, could not open this file."
 msgstr "No pudo abrirse este archivo."
 
-#: ../src/common/prntbase.cpp:2057 ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2079 ../src/common/prntbase.cpp:2087
 msgid "Sorry, not enough memory to create a preview."
 msgstr "No se pudo abrir este archivo."
 
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "Sorry, that name is taken. Please choose another."
 msgstr "Ese nombre ya está en uso. Elija otro."
 
-#: ../src/common/docview.cpp:1814
+#: ../src/common/docview.cpp:1819
 msgid "Sorry, the format for this file is unknown."
 msgstr "Se desconoce el formato de este archivo."
 
-#: ../src/unix/sound.cpp:492
+#: ../src/unix/sound.cpp:481
 msgid "Sound data are in unsupported format."
 msgstr "Los datos de sonido están en un formato no admitido."
 
-#: ../src/unix/sound.cpp:477
+#: ../src/unix/sound.cpp:466
 #, c-format
 msgid "Sound file '%s' is in unsupported format."
 msgstr "El archivo de sonido «%s» está en un formato no admitido."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:67
+#: ../src/common/accelcmn.cpp:64
 msgid "Space"
 msgstr "Espacio"
 
@@ -6503,12 +6670,12 @@ msgstr "Espacio"
 msgid "Spacing"
 msgstr "Espaciado"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "Spell Check"
 msgstr "Comprobar ortografía"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1776
+#: ../src/propgrid/advprops.cpp:1677
 msgid "Spraycan"
 msgstr "Aerosol"
 
@@ -6517,7 +6684,7 @@ msgstr "Aerosol"
 msgid "Standard"
 msgstr "Estándar"
 
-#: ../src/common/paper.cpp:104
+#: ../src/common/paper.cpp:101
 msgid "Statement, 5 1/2 x 8 1/2 in"
 msgstr "Declaración, 5 1/2 × 8 1/2 in"
 
@@ -6526,33 +6693,29 @@ msgstr "Declaración, 5 1/2 × 8 1/2 in"
 msgid "Static"
 msgstr "Estático"
 
-#: ../src/generic/prntdlgg.cpp:204
+#: ../src/generic/prntdlgg.cpp:197
 msgid "Status:"
 msgstr "Estado:"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "Stop"
 msgstr "Detener"
 
-#: ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196
 msgid "Strikethrough"
 msgstr "Tachado"
 
-#: ../src/common/colourcmn.cpp:45
+#: ../src/common/colourcmn.cpp:42
 #, c-format
 msgid "String To Colour : Incorrect colour specification : %s"
 msgstr "String To Colour: especificación de color incorrecta: %s"
 
 #. TRANSLATORS: Label of font style
-#: ../src/richtext/richtextformatdlg.cpp:339 ../src/propgrid/advprops.cpp:680
+#: ../src/propgrid/advprops.cpp:590 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Estilo"
 
-#: ../include/wx/richtext/richtextstyledlg.h:46
-msgid "Style Organiser"
-msgstr "Organizador de estilos"
-
-#: ../src/osx/carbon/fontdlg.cpp:348
+#: ../src/osx/carbon/fontdlg.cpp:345
 msgid "Style:"
 msgstr "Estilo:"
 
@@ -6561,7 +6724,7 @@ msgid "Subscrip&t"
 msgstr "Subín&dice"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:83
+#: ../src/common/accelcmn.cpp:80
 msgid "Subtract"
 msgstr "Sustraer"
 
@@ -6569,11 +6732,11 @@ msgstr "Sustraer"
 msgid "Supe&rscript"
 msgstr "Supe&rínidice"
 
-#: ../src/common/paper.cpp:150
+#: ../src/common/paper.cpp:147
 msgid "SuperA/SuperA/A4 227 x 356 mm"
 msgstr "SuperA/SuperA/A4 227 × 356 mm"
 
-#: ../src/common/paper.cpp:151
+#: ../src/common/paper.cpp:148
 msgid "SuperB/SuperB/A3 305 x 487 mm"
 msgstr "SuperB/SuperB/A3 305 × 487 mm"
 
@@ -6581,7 +6744,7 @@ msgstr "SuperB/SuperB/A3 305 × 487 mm"
 msgid "Suppress hyphe&nation"
 msgstr "Suprimir divisió&n de palabras"
 
-#: ../src/generic/fontdlgg.cpp:326
+#: ../src/generic/fontdlgg.cpp:322
 msgid "Swiss"
 msgstr "Swiss"
 
@@ -6599,73 +6762,73 @@ msgstr "&Tipo de letra de símbolos:"
 msgid "Symbols"
 msgstr "Símbolos"
 
-#: ../src/common/imagtiff.cpp:369 ../src/common/imagtiff.cpp:382
-#: ../src/common/imagtiff.cpp:741
+#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
+#: ../src/common/imagtiff.cpp:738
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: no se pudo reservar memoria."
 
-#: ../src/common/imagtiff.cpp:301
+#: ../src/common/imagtiff.cpp:298
 msgid "TIFF: Error loading image."
 msgstr "TIFF: error al cargar la imagen."
 
-#: ../src/common/imagtiff.cpp:468
+#: ../src/common/imagtiff.cpp:465
 msgid "TIFF: Error reading image."
 msgstr "TIFF: error al leer la imagen."
 
-#: ../src/common/imagtiff.cpp:608
+#: ../src/common/imagtiff.cpp:605
 msgid "TIFF: Error saving image."
 msgstr "TIFF: error al guardar la imagen."
 
-#: ../src/common/imagtiff.cpp:846
+#: ../src/common/imagtiff.cpp:843
 msgid "TIFF: Error writing image."
 msgstr "TIFF: error al escribir la imagen."
 
-#: ../src/common/imagtiff.cpp:355
+#: ../src/common/imagtiff.cpp:352
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: el tamaño de la imagen es anormalmente grande."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:68
+#: ../src/common/accelcmn.cpp:65
 msgid "Tab"
 msgstr "Tabulador"
 
-#: ../src/richtext/richtextbuffer.cpp:11498
+#: ../src/richtext/richtextbuffer.cpp:11497
 msgid "Table Properties"
 msgstr "Propiedades de tabla"
 
-#: ../src/common/paper.cpp:145
+#: ../src/common/paper.cpp:142
 msgid "Tabloid Extra 11.69 x 18 in"
 msgstr "Tabloide Extra 11,69 × 18 in"
 
-#: ../src/common/paper.cpp:102
+#: ../src/common/paper.cpp:99
 msgid "Tabloid, 11 x 17 in"
 msgstr "Tabloide, 11 × 17 in"
 
-#: ../src/richtext/richtextformatdlg.cpp:354
+#: ../src/richtext/richtextformatdlg.cpp:347
 msgid "Tabs"
 msgstr "Tabulaciones"
 
-#: ../src/propgrid/advprops.cpp:1598
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Teal"
 msgstr "Turquesa"
 
-#: ../src/generic/fontdlgg.cpp:327
+#: ../src/generic/fontdlgg.cpp:323
 msgid "Teletype"
 msgstr "Teletipo"
 
-#: ../src/common/docview.cpp:1896
+#: ../src/common/docview.cpp:1901
 msgid "Templates"
 msgstr "Plantillas"
 
-#: ../src/common/fmapbase.cpp:158
+#: ../src/common/fmapbase.cpp:155
 msgid "Thai (ISO-8859-11)"
 msgstr "Tailandés (ISO-8859-11)"
 
-#: ../src/common/ftp.cpp:619
+#: ../src/common/ftp.cpp:622
 msgid "The FTP server doesn't support passive mode."
 msgstr "El servidor FTP no admite el modo pasivo."
 
-#: ../src/common/ftp.cpp:605
+#: ../src/common/ftp.cpp:608
 msgid "The FTP server doesn't support the PORT command."
 msgstr "El servidor FTP no admite la orden PORT."
 
@@ -6676,8 +6839,8 @@ msgstr "El servidor FTP no admite la orden PORT."
 msgid "The available bullet styles."
 msgstr "Los estilos de viñeta disponibles."
 
-#: ../src/richtext/richtextstyledlg.cpp:202
-#: ../src/richtext/richtextstyledlg.cpp:204
+#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:200
 msgid "The available styles."
 msgstr "Los estilos disponibles."
 
@@ -6733,12 +6896,12 @@ msgstr "La posición inferior."
 msgid "The bullet character."
 msgstr "El carácter de viñeta."
 
-#: ../src/richtext/richtextsymboldlg.cpp:443
-#: ../src/richtext/richtextsymboldlg.cpp:445
+#: ../src/richtext/richtextsymboldlg.cpp:440
+#: ../src/richtext/richtextsymboldlg.cpp:442
 msgid "The character code."
 msgstr "El código de carácter."
 
-#: ../src/common/fontmap.cpp:203
+#: ../src/common/fontmap.cpp:200
 #, c-format
 msgid ""
 "The charset '%s' is unknown. You may select\n"
@@ -6749,7 +6912,7 @@ msgstr ""
 "seleccionar otro conjunto para reemplazarlo o elegir\n"
 "[Cancelar] si no puede reemplazarse"
 
-#: ../src/msw/ole/dataobj.cpp:394
+#: ../src/msw/ole/dataobj.cpp:402
 #, c-format
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "El formato %d del portapapeles no existe."
@@ -6759,7 +6922,7 @@ msgstr "El formato %d del portapapeles no existe."
 msgid "The default style for the next paragraph."
 msgstr "El estilo predeterminado para el siguiente párrafo."
 
-#: ../src/generic/dirdlgg.cpp:202
+#: ../src/generic/dirdlgg.cpp:199
 #, c-format
 msgid ""
 "The directory '%s' does not exist\n"
@@ -6768,7 +6931,7 @@ msgstr ""
 "El directorio «%s» no existe.\n"
 "¿Quiere crearlo ahora?"
 
-#: ../src/html/htmprint.cpp:271
+#: ../src/html/htmprint.cpp:283
 #, c-format
 msgid ""
 "The document \"%s\" doesn't fit on the page horizontally and will be "
@@ -6781,7 +6944,7 @@ msgstr ""
 "\n"
 "¿Quiere imprimirlo de todas formas?"
 
-#: ../src/common/docview.cpp:1202
+#: ../src/common/docview.cpp:1196
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -6790,36 +6953,36 @@ msgstr ""
 "El archivo '%s' no existe y no puede abrirse.\n"
 "También ha sido eliminado de la lista de archivos recientes."
 
-#: ../src/richtext/richtextindentspage.cpp:208
-#: ../src/richtext/richtextindentspage.cpp:210
 #: ../src/richtext/richtextliststylepage.cpp:394
 #: ../src/richtext/richtextliststylepage.cpp:396
+#: ../src/richtext/richtextindentspage.cpp:208
+#: ../src/richtext/richtextindentspage.cpp:210
 msgid "The first line indent."
 msgstr "La sangría del primer renglón."
 
-#: ../src/gtk/utilsgtk.cpp:481
-msgid "The following standard GTK+ options are also supported:\n"
-msgstr "También se admiten las siguientes opciones estándares de GTK+:\n"
+#: ../src/generic/dbgrptg.cpp:318
+msgid "The following debug report will be generated\n"
+msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:414 ../src/generic/fontdlgg.cpp:416
+#: ../src/generic/fontdlgg.cpp:411 ../src/generic/fontdlgg.cpp:413
 msgid "The font colour."
 msgstr "El color del tipo de letra."
 
-#: ../src/generic/fontdlgg.cpp:375 ../src/generic/fontdlgg.cpp:377
+#: ../src/generic/fontdlgg.cpp:371 ../src/generic/fontdlgg.cpp:373
 msgid "The font family."
 msgstr "La familia tipográfica."
 
-#: ../src/richtext/richtextsymboldlg.cpp:405
-#: ../src/richtext/richtextsymboldlg.cpp:407
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "The font from which to take the symbol."
 msgstr "El tipo de letra del que tomar el símbolo."
 
-#: ../src/generic/fontdlgg.cpp:427 ../src/generic/fontdlgg.cpp:429
-#: ../src/generic/fontdlgg.cpp:434 ../src/generic/fontdlgg.cpp:436
+#: ../src/generic/fontdlgg.cpp:424 ../src/generic/fontdlgg.cpp:426
+#: ../src/generic/fontdlgg.cpp:430 ../src/generic/fontdlgg.cpp:432
 msgid "The font point size."
 msgstr "El tamaño en puntos del tipo de letra."
 
-#: ../src/osx/carbon/fontdlg.cpp:343 ../src/osx/carbon/fontdlg.cpp:345
+#: ../src/osx/carbon/fontdlg.cpp:340 ../src/osx/carbon/fontdlg.cpp:342
 msgid "The font size in points."
 msgstr "El tamaño en puntos del tipo de letra."
 
@@ -6828,15 +6991,15 @@ msgstr "El tamaño en puntos del tipo de letra."
 msgid "The font size units, points or pixels."
 msgstr "Las unidades, puntos o píxeles del tamaño del tipo de letra."
 
-#: ../src/generic/fontdlgg.cpp:386 ../src/generic/fontdlgg.cpp:388
+#: ../src/generic/fontdlgg.cpp:382 ../src/generic/fontdlgg.cpp:384
 msgid "The font style."
 msgstr "El estilo del tipo de letra."
 
-#: ../src/generic/fontdlgg.cpp:397 ../src/generic/fontdlgg.cpp:399
+#: ../src/generic/fontdlgg.cpp:393 ../src/generic/fontdlgg.cpp:395
 msgid "The font weight."
 msgstr "El peso del tipo de letra."
 
-#: ../src/common/docview.cpp:1483
+#: ../src/common/docview.cpp:1477
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "No se pudo determinar el formato del archivo «%s»."
@@ -6846,10 +7009,10 @@ msgstr "No se pudo determinar el formato del archivo «%s»."
 msgid "The horizontal offset."
 msgstr "El desplazamiento horizontal."
 
-#: ../src/richtext/richtextindentspage.cpp:199
-#: ../src/richtext/richtextindentspage.cpp:201
 #: ../src/richtext/richtextliststylepage.cpp:385
 #: ../src/richtext/richtextliststylepage.cpp:387
+#: ../src/richtext/richtextindentspage.cpp:199
+#: ../src/richtext/richtextindentspage.cpp:201
 msgid "The left indent."
 msgstr "La sangría izquierda."
 
@@ -6870,10 +7033,10 @@ msgstr "El tamaño del relleno izquierdo."
 msgid "The left position."
 msgstr "La posición izquierda."
 
-#: ../src/richtext/richtextindentspage.cpp:288
-#: ../src/richtext/richtextindentspage.cpp:290
 #: ../src/richtext/richtextliststylepage.cpp:462
 #: ../src/richtext/richtextliststylepage.cpp:464
+#: ../src/richtext/richtextindentspage.cpp:288
+#: ../src/richtext/richtextindentspage.cpp:290
 msgid "The line spacing."
 msgstr "El espaciado de línea."
 
@@ -6882,7 +7045,7 @@ msgstr "El espaciado de línea."
 msgid "The list item number."
 msgstr "El número de elemento de la lista."
 
-#: ../src/msw/ole/automtn.cpp:664
+#: ../src/msw/ole/automtn.cpp:655
 msgid "The locale ID is unknown."
 msgstr "La ID del local es desconocida."
 
@@ -6921,19 +7084,19 @@ msgstr "El ancho del objeto."
 msgid "The outline level."
 msgstr "El nivel del contorno."
 
-#: ../src/common/log.cpp:277
+#: ../src/common/log.cpp:296
 #, c-format
 msgid "The previous message repeated %u time."
 msgid_plural "The previous message repeated %u times."
 msgstr[0] "El mensaje anterior repetido %u vez."
 msgstr[1] "El mensaje anterior repetido %u veces."
 
-#: ../src/common/log.cpp:270
+#: ../src/common/log.cpp:289
 msgid "The previous message repeated once."
 msgstr "El mensaje anterior repetido una vez."
 
-#: ../src/richtext/richtextsymboldlg.cpp:462
-#: ../src/richtext/richtextsymboldlg.cpp:464
+#: ../src/richtext/richtextsymboldlg.cpp:459
+#: ../src/richtext/richtextsymboldlg.cpp:461
 msgid "The range to show."
 msgstr "El intervalo que mostrar."
 
@@ -6947,15 +7110,15 @@ msgstr ""
 "archivos contiene información privada,\n"
 "por favor desmárquelos y serán eliminados del informe.\n"
 
-#: ../src/common/cmdline.cpp:1254
+#: ../src/common/cmdline.cpp:1250
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "El parámetro requerido '%s' no fue especificado."
 
-#: ../src/richtext/richtextindentspage.cpp:217
-#: ../src/richtext/richtextindentspage.cpp:219
 #: ../src/richtext/richtextliststylepage.cpp:403
 #: ../src/richtext/richtextliststylepage.cpp:405
+#: ../src/richtext/richtextindentspage.cpp:217
+#: ../src/richtext/richtextindentspage.cpp:219
 msgid "The right indent."
 msgstr "La sangría derecha."
 
@@ -6996,16 +7159,16 @@ msgstr "La opacidad de la sombra."
 msgid "The shadow spread."
 msgstr "La difusión de la sombra."
 
-#: ../src/richtext/richtextindentspage.cpp:267
 #: ../src/richtext/richtextliststylepage.cpp:439
 #: ../src/richtext/richtextliststylepage.cpp:441
+#: ../src/richtext/richtextindentspage.cpp:267
 msgid "The spacing after the paragraph."
 msgstr "El espaciado depués del párrafo."
 
-#: ../src/richtext/richtextindentspage.cpp:257
-#: ../src/richtext/richtextindentspage.cpp:259
 #: ../src/richtext/richtextliststylepage.cpp:430
 #: ../src/richtext/richtextliststylepage.cpp:432
+#: ../src/richtext/richtextindentspage.cpp:257
+#: ../src/richtext/richtextindentspage.cpp:259
 msgid "The spacing before the paragraph."
 msgstr "El espaciado antes del párrafo."
 
@@ -7019,12 +7182,12 @@ msgstr "El nombre del estilo."
 msgid "The style on which this style is based."
 msgstr "El estilo en que se basa este estilo."
 
-#: ../src/richtext/richtextstyledlg.cpp:214
-#: ../src/richtext/richtextstyledlg.cpp:216
+#: ../src/richtext/richtextstyledlg.cpp:210
+#: ../src/richtext/richtextstyledlg.cpp:212
 msgid "The style preview."
 msgstr "La vista previa del estilo."
 
-#: ../src/msw/ole/automtn.cpp:680
+#: ../src/msw/ole/automtn.cpp:671
 msgid "The system cannot find the file specified."
 msgstr "El sistema no puede encontrar el archivo indicado."
 
@@ -7037,7 +7200,7 @@ msgstr "La posición de tabulación."
 msgid "The tab positions."
 msgstr "Las posiciones de tabulación."
 
-#: ../src/richtext/richtextctrl.cpp:3098
+#: ../src/richtext/richtextctrl.cpp:3099
 msgid "The text couldn't be saved."
 msgstr "El texto no pudo guardarse."
 
@@ -7058,7 +7221,7 @@ msgstr "El tamaño del relleno superior."
 msgid "The top position."
 msgstr "La posición superior."
 
-#: ../src/common/cmdline.cpp:1232
+#: ../src/common/cmdline.cpp:1228
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "El valor para la opción '%s' debe especificarse."
@@ -7068,7 +7231,7 @@ msgstr "El valor para la opción '%s' debe especificarse."
 msgid "The value of the corner radius."
 msgstr "El valor del radio de la esquina."
 
-#: ../src/msw/dialup.cpp:433
+#: ../src/msw/dialup.cpp:427
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -7083,14 +7246,14 @@ msgstr ""
 msgid "The vertical offset."
 msgstr "El desplazamiento vertical."
 
-#: ../src/richtext/richtextprint.cpp:619 ../src/html/htmprint.cpp:745
+#: ../src/html/htmprint.cpp:749 ../src/richtext/richtextprint.cpp:615
 msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr ""
 "Hubo un problema al configurar la página: se necesita una impresora "
 "predeterminada."
 
-#: ../src/html/htmprint.cpp:255
+#: ../src/html/htmprint.cpp:267
 msgid ""
 "This document doesn't fit on the page horizontally and will be truncated "
 "when it is printed."
@@ -7098,16 +7261,16 @@ msgstr ""
 "Este documento no cabe horizontalmente en la página y será truncado al "
 "imprimirlo."
 
-#: ../src/common/image.cpp:2854
+#: ../src/common/image.cpp:2963
 #, c-format
 msgid "This is not a %s."
 msgstr "Esto no es un %s."
 
-#: ../src/common/wincmn.cpp:1653
+#: ../src/common/wincmn.cpp:1654
 msgid "This platform does not support background transparency."
 msgstr "Esta plataforma no admite transparencias de fondo."
 
-#: ../src/gtk/window.cpp:4660
+#: ../src/gtk/window.cpp:5664
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
@@ -7115,7 +7278,15 @@ msgstr ""
 "Este programa se compiló con una versión muy antigua de GTK+. Recompílelo "
 "con GTK+ 2.12 o posterior."
 
-#: ../src/msw/thread.cpp:1240
+#: ../src/gtk/glcanvas.cpp:176
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/msw/thread.cpp:1246
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -7123,13 +7294,13 @@ msgstr ""
 "Error en la inicialización del módulo de hilos de ejecución: no se pudo "
 "almacenar valor en el almacén local de hilos"
 
-#: ../src/unix/threadpsx.cpp:1794
+#: ../src/unix/threadpsx.cpp:1843
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 "Error en la inicialización del módulo de hilos de ejecución: error al crear "
 "clave de hilo"
 
-#: ../src/msw/thread.cpp:1228
+#: ../src/msw/thread.cpp:1234
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -7137,83 +7308,83 @@ msgstr ""
 "Error en la inicialización del módulo de hilos de ejecución: imposible "
 "reservar índice en el almacen local de hilos"
 
-#: ../src/unix/threadpsx.cpp:1043
+#: ../src/unix/threadpsx.cpp:1061
 msgid "Thread priority setting is ignored."
 msgstr "La configuración de la prioridad del hilo de ejecución es ignorada."
 
-#: ../src/msw/mdi.cpp:176
+#: ../src/msw/mdi.cpp:171
 msgid "Tile &Horizontally"
 msgstr "Mosaico &horizontal"
 
-#: ../src/msw/mdi.cpp:177
+#: ../src/msw/mdi.cpp:172
 msgid "Tile &Vertically"
 msgstr "Mosaico &vertical"
 
-#: ../src/common/ftp.cpp:200
+#: ../src/common/ftp.cpp:197
 msgid "Timeout while waiting for FTP server to connect, try passive mode."
 msgstr ""
 "Tiempo de espera de la conexión del servidor FTP excedido, pruebe a "
 "establecer el modo pasivo."
 
-#: ../src/generic/tipdlg.cpp:201
+#: ../src/generic/tipdlg.cpp:198
 msgid "Tip of the Day"
 msgstr "Sugerencia del día"
 
-#: ../src/generic/tipdlg.cpp:140
+#: ../src/generic/tipdlg.cpp:137
 msgid "Tips not available, sorry!"
 msgstr "Sugerencias no disponibles, ¡lástima!"
 
-#: ../src/generic/prntdlgg.cpp:242
+#: ../src/generic/prntdlgg.cpp:235
 msgid "To:"
 msgstr "Hasta:"
 
-#: ../src/richtext/richtextbuffer.cpp:8363
+#: ../src/richtext/richtextbuffer.cpp:8361
 msgid "Too many EndStyle calls!"
 msgstr "¡Demasiadas llamadas a EndStyle!"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:891
+#: ../src/propgrid/advprops.cpp:792
 msgid "Tooltip"
 msgstr "Pista"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:892
+#: ../src/propgrid/advprops.cpp:793
 msgid "TooltipText"
 msgstr "TooltipText"
 
-#: ../src/richtext/richtextsizepage.cpp:286
-#: ../src/richtext/richtextsizepage.cpp:290 ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197 ../src/richtext/richtextsizepage.cpp:286
+#: ../src/richtext/richtextsizepage.cpp:290
 msgid "Top"
 msgstr "Arriba"
 
-#: ../src/generic/prntdlgg.cpp:881
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Top margin (mm):"
 msgstr "Margen superior (mm):"
 
-#: ../src/generic/aboutdlgg.cpp:79
+#: ../src/generic/aboutdlgg.cpp:76
 msgid "Translations by "
 msgstr "Traducciones por "
 
-#: ../src/generic/aboutdlgg.cpp:188
+#: ../src/generic/aboutdlgg.cpp:185
 msgid "Translators"
 msgstr "Traductores"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:211
+#: ../src/propgrid/propgrid.cpp:192
 msgid "True"
 msgstr "Verdadero"
 
-#: ../src/common/fs_mem.cpp:227
+#: ../src/common/fs_mem.cpp:222
 #, c-format
 msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
 msgstr ""
 "¡Intentando eliminar el archivo '%s' de VFS de memoria, pero no está abierto!"
 
-#: ../src/common/fmapbase.cpp:156
+#: ../src/common/fmapbase.cpp:153
 msgid "Turkish (ISO-8859-9)"
 msgstr "Turco (ISO-8859-9)"
 
-#: ../src/generic/filectrlg.cpp:426
+#: ../src/generic/filectrlg.cpp:422
 msgid "Type"
 msgstr "Tipo"
 
@@ -7227,17 +7398,17 @@ msgstr "Escriba un nombre de fuente."
 msgid "Type a size in points."
 msgstr "Escribir un tamaño en puntos."
 
-#: ../src/msw/ole/automtn.cpp:676
+#: ../src/msw/ole/automtn.cpp:667
 #, c-format
 msgid "Type mismatch in argument %u."
 msgstr "No coincide el tipo del argumento %u."
 
-#: ../src/common/xtixml.cpp:356 ../src/common/xtixml.cpp:509
-#: ../src/common/xtistrm.cpp:318
+#: ../src/common/xtixml.cpp:352 ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315
 msgid "Type must have enum - long conversion"
 msgstr "El tipo debe tener conversión de enum a long"
 
-#: ../src/propgrid/propgridiface.cpp:401
+#: ../src/propgrid/propgridiface.cpp:385
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
@@ -7246,19 +7417,19 @@ msgstr ""
 "La operación de tipos \"%s\" falló: la propiedad etiquetada \"%s\" es del "
 "tipo \"%s\", NO \"%s\"."
 
-#: ../src/common/paper.cpp:133
+#: ../src/common/paper.cpp:130
 msgid "US Std Fanfold, 14 7/8 x 11 in"
 msgstr "US Std Fanfold, 14 7/8 x 11 pulgadas"
 
-#: ../src/common/fmapbase.cpp:196
+#: ../src/common/fmapbase.cpp:193
 msgid "US-ASCII"
 msgstr "US-ASCII"
 
-#: ../src/unix/fswatcher_inotify.cpp:109
+#: ../src/unix/fswatcher_inotify.cpp:106
 msgid "Unable to add inotify watch"
 msgstr "No se pudo añadir la vista inotify"
 
-#: ../src/unix/fswatcher_kqueue.cpp:136
+#: ../src/unix/fswatcher_kqueue.cpp:153
 msgid "Unable to add kqueue watch"
 msgstr "No se pudo añadir la vista kqueue"
 
@@ -7270,7 +7441,7 @@ msgstr "No se pudo asociar manejador con el puerto de finalización de E/S"
 msgid "Unable to close I/O completion port handle"
 msgstr "Error al cerrar el manejador del puerto de finalización de E/S"
 
-#: ../src/unix/fswatcher_inotify.cpp:97
+#: ../src/unix/fswatcher_inotify.cpp:94
 msgid "Unable to close inotify instance"
 msgstr "No se pudo cerrar la instancia inotify"
 
@@ -7288,15 +7459,15 @@ msgstr "No se pudo cerrar el manejador para '%s'"
 msgid "Unable to create I/O completion port"
 msgstr "No se pudo crear el puerto de finalización de E/S"
 
-#: ../src/msw/fswatcher.cpp:84
+#: ../src/msw/fswatcher.cpp:81
 msgid "Unable to create IOCP worker thread"
 msgstr "No se pudo crear el hilo IOCP"
 
-#: ../src/unix/fswatcher_inotify.cpp:74
+#: ../src/unix/fswatcher_inotify.cpp:71
 msgid "Unable to create inotify instance"
 msgstr "No se pudo crear la instancia inotify"
 
-#: ../src/unix/fswatcher_kqueue.cpp:97
+#: ../src/unix/fswatcher_kqueue.cpp:114
 msgid "Unable to create kqueue instance"
 msgstr "No se pudo crear la instancia kqueue"
 
@@ -7304,11 +7475,11 @@ msgstr "No se pudo crear la instancia kqueue"
 msgid "Unable to dequeue completion packet"
 msgstr "No se pudo sacar de la cola el paquete de finalización"
 
-#: ../src/unix/fswatcher_kqueue.cpp:185
+#: ../src/unix/fswatcher_kqueue.cpp:202
 msgid "Unable to get events from kqueue"
 msgstr "No se pudieron obtener sucesos de kqueue"
 
-#: ../src/gtk/app.cpp:435
+#: ../src/gtk/app.cpp:431
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "No se pudo inicializar GTK+, ¿está DISPLAY configurada correctamente?"
 
@@ -7317,12 +7488,12 @@ msgstr "No se pudo inicializar GTK+, ¿está DISPLAY configurada correctamente?"
 msgid "Unable to open path '%s'"
 msgstr "No se pudo abrir el caminor '%s'"
 
-#: ../src/html/htmlwin.cpp:583
+#: ../src/html/htmlwin.cpp:586
 #, c-format
 msgid "Unable to open requested HTML document: %s"
 msgstr "Incapaz de abrir el docuemento HTML pedido: %s"
 
-#: ../src/unix/sound.cpp:368
+#: ../src/unix/sound.cpp:365
 msgid "Unable to play sound asynchronously."
 msgstr "Imposible reproducir el sonido de forma asíncrona."
 
@@ -7330,61 +7501,61 @@ msgstr "Imposible reproducir el sonido de forma asíncrona."
 msgid "Unable to post completion status"
 msgstr "No se pudo enviar el estado de finalización"
 
-#: ../src/unix/fswatcher_inotify.cpp:556
+#: ../src/unix/fswatcher_inotify.cpp:553
 msgid "Unable to read from inotify descriptor"
 msgstr "No se pudo leer del descriptor inotify"
 
-#: ../src/unix/fswatcher_inotify.cpp:141
+#: ../src/unix/fswatcher_inotify.cpp:138
 #, c-format
 msgid "Unable to remove inotify watch %i"
 msgstr "No se pudo quitar la supervisión inotify %i"
 
-#: ../src/unix/fswatcher_kqueue.cpp:153
+#: ../src/unix/fswatcher_kqueue.cpp:170
 msgid "Unable to remove kqueue watch"
 msgstr "No se pudo eliminar la vista kqueue"
 
-#: ../src/msw/fswatcher.cpp:168
+#: ../src/msw/fswatcher.cpp:165
 #, c-format
 msgid "Unable to set up watch for '%s'"
 msgstr "No se pudo activar la vista para '%s'"
 
-#: ../src/msw/fswatcher.cpp:91
+#: ../src/msw/fswatcher.cpp:88
 msgid "Unable to start IOCP worker thread"
 msgstr "No se pudo iniciar el hilo IOCP"
 
-#: ../src/common/stockitem.cpp:201
+#: ../src/common/stockitem.cpp:198
 msgid "Undelete"
 msgstr "Restaurar"
 
-#: ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199
 msgid "Underline"
 msgstr "Subrayar"
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/richtext/richtextfontpage.cpp:359 ../src/osx/carbon/fontdlg.cpp:370
-#: ../src/propgrid/advprops.cpp:690
+#: ../src/osx/carbon/fontdlg.cpp:367 ../src/propgrid/advprops.cpp:600
+#: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Subrayado"
 
-#: ../src/common/stockitem.cpp:203 ../src/stc/stc_i18n.cpp:15
+#: ../src/common/stockitem.cpp:200 ../src/stc/stc_i18n.cpp:15
 msgid "Undo"
 msgstr "Deshacer"
 
-#: ../src/common/stockitem.cpp:265
+#: ../src/common/stockitem.cpp:263
 msgid "Undo last action"
 msgstr "Deshacer la última acción"
 
-#: ../src/common/cmdline.cpp:1029
+#: ../src/common/cmdline.cpp:1025
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Caracteres inesperados tras la opción '%s'."
 
-#: ../src/unix/fswatcher_inotify.cpp:274
+#: ../src/unix/fswatcher_inotify.cpp:271
 #, c-format
 msgid "Unexpected event for \"%s\": no matching watch descriptor."
 msgstr "Suceso inesperado para «%s»: no hay descriptor de vista coincidente."
 
-#: ../src/common/cmdline.cpp:1195
+#: ../src/common/cmdline.cpp:1191
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Parámetro «%s» inesperado"
@@ -7393,49 +7564,49 @@ msgstr "Parámetro «%s» inesperado"
 msgid "Unexpectedly new I/O completion port was created"
 msgstr "Se creó inesperadamente un puerto de finalización de E/S"
 
-#: ../src/msw/fswatcher.cpp:70
+#: ../src/msw/fswatcher.cpp:67
 msgid "Ungraceful worker thread termination"
 msgstr "Terminación del hilo inapropiada"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:460
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:456
+#: ../src/richtext/richtextsymboldlg.cpp:457
+#: ../src/richtext/richtextsymboldlg.cpp:458
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../src/common/fmapbase.cpp:185 ../src/common/fmapbase.cpp:191
+#: ../src/common/fmapbase.cpp:182 ../src/common/fmapbase.cpp:188
 msgid "Unicode 16 bit (UTF-16)"
 msgstr "Unicode 16 bits (UTF-16)"
 
-#: ../src/common/fmapbase.cpp:190
+#: ../src/common/fmapbase.cpp:187
 msgid "Unicode 16 bit Big Endian (UTF-16BE)"
 msgstr "Unicode 16 bits Endian Grande (UTF-16BE)"
 
-#: ../src/common/fmapbase.cpp:186
+#: ../src/common/fmapbase.cpp:183
 msgid "Unicode 16 bit Little Endian (UTF-16LE)"
 msgstr "Unicode 16 bits Endian Pequeña (UTF-16LE)"
 
-#: ../src/common/fmapbase.cpp:187 ../src/common/fmapbase.cpp:193
+#: ../src/common/fmapbase.cpp:184 ../src/common/fmapbase.cpp:190
 msgid "Unicode 32 bit (UTF-32)"
 msgstr "Unicode 32 bits (UTF-32)"
 
-#: ../src/common/fmapbase.cpp:192
+#: ../src/common/fmapbase.cpp:189
 msgid "Unicode 32 bit Big Endian (UTF-32BE)"
 msgstr "Unicode 32 bits Endian Grande (UTF-32BE)"
 
-#: ../src/common/fmapbase.cpp:188
+#: ../src/common/fmapbase.cpp:185
 msgid "Unicode 32 bit Little Endian (UTF-32LE)"
 msgstr "Unicode 32 bits Endian Pequeña (UTF-32LE)"
 
-#: ../src/common/fmapbase.cpp:182
+#: ../src/common/fmapbase.cpp:179
 msgid "Unicode 7 bit (UTF-7)"
 msgstr "Unicode 7 bit (UTF-7)"
 
-#: ../src/common/fmapbase.cpp:183
+#: ../src/common/fmapbase.cpp:180
 msgid "Unicode 8 bit (UTF-8)"
 msgstr "Unicode 8 bit (UTF-8)"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "Unindent"
 msgstr "Quitar sangría"
 
@@ -7585,97 +7756,102 @@ msgstr "Unidades para la posición superior."
 msgid "Units for this value."
 msgstr "Unidades para este valor."
 
-#: ../src/generic/progdlgg.cpp:353 ../src/generic/progdlgg.cpp:622
+#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
 msgid "Unknown"
 msgstr "Desconocido"
 
-#: ../src/msw/dde.cpp:1174
+#: ../src/msw/dde.cpp:1238
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Error DDE desconocido %08x"
 
-#: ../src/common/xtistrm.cpp:410
+#: ../src/common/xtistrm.cpp:407
 msgid "Unknown Object passed to GetObjectClassInfo"
 msgstr "Objeto desconocido pasado a GetObjectClassInfo"
 
-#: ../src/common/imagpng.cpp:366
+#: ../src/common/imagpng.cpp:383
 #, c-format
 msgid "Unknown PNG resolution unit %d"
 msgstr "Resolución de la unidad %d de PNG desconocida"
 
-#: ../src/common/xtixml.cpp:327
+#: ../src/common/xtixml.cpp:323
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Propiedad %s desconocida"
 
-#: ../src/common/imagtiff.cpp:529
+#: ../src/common/imagtiff.cpp:526
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "Ignorada la unidad desconocida de resolución TIFF %d"
 
-#: ../src/unix/dlunix.cpp:160
+#: ../src/propgrid/props.cpp:155
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/unix/dlunix.cpp:118
 msgid "Unknown dynamic library error"
 msgstr "Error desconocido de biblioteca dinámica"
 
-#: ../src/common/fmapbase.cpp:810
+#: ../src/common/fmapbase.cpp:806
 #, c-format
 msgid "Unknown encoding (%d)"
 msgstr "Codificación desconocida (%d)"
 
-#: ../src/msw/ole/automtn.cpp:688
+#: ../src/msw/ole/automtn.cpp:679
 #, c-format
 msgid "Unknown error %08x"
 msgstr "Error desconocido %08x"
 
-#: ../src/msw/ole/automtn.cpp:647
+#: ../src/msw/ole/automtn.cpp:638
 msgid "Unknown exception"
 msgstr "Excepción desconocida"
 
-#: ../src/common/image.cpp:2839
+#: ../src/common/image.cpp:2942
 msgid "Unknown image data format."
 msgstr "Formato de imagen desconocido."
 
-#: ../src/common/cmdline.cpp:914
+#: ../src/common/cmdline.cpp:910
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "El parámetro '%s' de entero largo es desconocido"
 
-#: ../src/msw/ole/automtn.cpp:631
+#: ../src/msw/ole/automtn.cpp:622
 msgid "Unknown name or named argument."
 msgstr "Nombre o argumento con nombre desconocido."
 
-#: ../src/common/cmdline.cpp:929 ../src/common/cmdline.cpp:951
+#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "La opción «%s» es desconocida"
 
-#: ../src/common/mimecmn.cpp:225
+#: ../src/common/mimecmn.cpp:221
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "Llave abierta no emparejada en una entrada para tipo mime %s."
 
-#: ../src/common/cmdproc.cpp:262 ../src/common/cmdproc.cpp:288
-#: ../src/common/cmdproc.cpp:308
+#: ../src/common/cmdproc.cpp:255 ../src/common/cmdproc.cpp:281
+#: ../src/common/cmdproc.cpp:301
 msgid "Unnamed command"
 msgstr "Orden sin nombre"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:413
+#: ../src/propgrid/propgrid.cpp:392
 msgid "Unspecified"
 msgstr "No especificado"
 
-#: ../src/msw/clipbrd.cpp:311
+#: ../src/msw/clipbrd.cpp:325
 msgid "Unsupported clipboard format."
 msgstr "Formato de portapapeles no admitido."
 
-#: ../src/common/appcmn.cpp:256
+#: ../src/common/appcmn.cpp:277
 #, c-format
 msgid "Unsupported theme '%s'."
 msgstr "No se admite el tema «%s»."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:205
-#: ../src/common/accelcmn.cpp:63
+#: ../src/common/stockitem.cpp:202 ../src/common/accelcmn.cpp:60
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Up"
 msgstr "Arriba"
 
@@ -7689,7 +7865,7 @@ msgstr "Letras mayúsculas"
 msgid "Upper case roman numerals"
 msgstr "Números romanos en mayúsculas"
 
-#: ../src/common/cmdline.cpp:1326
+#: ../src/common/cmdline.cpp:1322
 #, c-format
 msgid "Usage: %s"
 msgstr "Uso: %s"
@@ -7698,38 +7874,47 @@ msgstr "Uso: %s"
 msgid "Use &shadow"
 msgstr "Usar &sombra"
 
-#: ../src/richtext/richtextindentspage.cpp:169
-#: ../src/richtext/richtextindentspage.cpp:171
 #: ../src/richtext/richtextliststylepage.cpp:358
 #: ../src/richtext/richtextliststylepage.cpp:360
+#: ../src/richtext/richtextindentspage.cpp:169
+#: ../src/richtext/richtextindentspage.cpp:171
 msgid "Use the current alignment setting."
 msgstr "Utilizar el alineamiento actual."
 
-#: ../src/common/valtext.cpp:179
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/gtk/font.cpp:552
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/common/valtext.cpp:142
 msgid "Validation conflict"
 msgstr "Conflicto de validación"
 
-#: ../src/propgrid/manager.cpp:238
+#: ../src/propgrid/manager.cpp:224
 msgid "Value"
 msgstr "Valor"
 
-#: ../src/propgrid/props.cpp:386 ../src/propgrid/props.cpp:500
+#: ../src/propgrid/props.cpp:309
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "El valor debe ser %s o mayor."
 
-#: ../src/propgrid/props.cpp:417 ../src/propgrid/props.cpp:531
+#: ../src/propgrid/props.cpp:336
 #, c-format
 msgid "Value must be %s or less."
 msgstr "El valor debe ser %s o inferior."
 
-#: ../src/propgrid/props.cpp:393 ../src/propgrid/props.cpp:424
-#: ../src/propgrid/props.cpp:507 ../src/propgrid/props.cpp:538
+#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "El valor debe estar entre %s y %s."
 
-#: ../src/generic/aboutdlgg.cpp:128
+#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Versión "
 
@@ -7738,25 +7923,32 @@ msgstr "Versión "
 msgid "Vertical alignment."
 msgstr "Alineación vertical."
 
-#: ../src/generic/filedlgg.cpp:202
+#: ../src/generic/filedlgg.cpp:199
 msgid "View files as a detailed view"
 msgstr "Ver archivos como vista detallada"
 
-#: ../src/generic/filedlgg.cpp:200
+#: ../src/generic/filedlgg.cpp:197
 msgid "View files as a list view"
 msgstr "Ver archivos como lista"
 
-#: ../src/common/docview.cpp:1970
+#: ../src/common/docview.cpp:1975
 msgid "Views"
 msgstr "Vistas"
 
+#: ../src/gtk/app.cpp:348
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1777
+#: ../src/propgrid/advprops.cpp:1678
 msgid "Wait"
 msgstr "Espere"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1779
+#: ../src/propgrid/advprops.cpp:1680
 msgid "Wait Arrow"
 msgstr "Espera Flecha"
 
@@ -7765,238 +7957,235 @@ msgstr "Espera Flecha"
 msgid "Waiting for IO on epoll descriptor %d failed"
 msgstr "Falló la espera de E/S en el descriptor epoll %d"
 
-#: ../src/common/log.cpp:223
+#: ../src/common/log.cpp:241
 msgid "Warning: "
 msgstr "Alerta: "
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1778
+#: ../src/propgrid/advprops.cpp:1679
 msgid "Watch"
 msgstr "Mirar"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:685
+#: ../src/propgrid/advprops.cpp:595
 msgid "Weight"
 msgstr "Peso"
 
-#: ../src/common/fmapbase.cpp:148
+#: ../src/common/fmapbase.cpp:145
 msgid "Western European (ISO-8859-1)"
 msgstr "Europa Occidental (ISO-8859-1)"
 
-#: ../src/common/fmapbase.cpp:162
+#: ../src/common/fmapbase.cpp:159
 msgid "Western European with Euro (ISO-8859-15)"
 msgstr "Europa Occidental con Euro (ISO-8859-15)"
 
-#: ../src/generic/fontdlgg.cpp:446 ../src/generic/fontdlgg.cpp:448
+#: ../src/generic/fontdlgg.cpp:443 ../src/generic/fontdlgg.cpp:445
 msgid "Whether the font is underlined."
 msgstr "Si la fuente está subrayada."
 
-#: ../src/propgrid/advprops.cpp:1611
+#: ../src/propgrid/advprops.cpp:1517
 msgid "White"
 msgstr "Blanco"
 
-#: ../src/generic/fdrepdlg.cpp:144
+#: ../src/generic/fdrepdlg.cpp:141
 msgid "Whole word"
 msgstr "Palabra completa"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:532
 msgid "Whole words only"
 msgstr "Sólo palabras completas"
 
-#: ../src/univ/themes/win32.cpp:1102
+#: ../src/univ/themes/win32.cpp:1099
 msgid "Win32 theme"
 msgstr "Tema Win32"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:893
+#: ../src/propgrid/advprops.cpp:794
 msgid "Window"
 msgstr "Ventana"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:894
+#: ../src/propgrid/advprops.cpp:795
 msgid "WindowFrame"
 msgstr "WindowFrame"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:895
+#: ../src/propgrid/advprops.cpp:796
 msgid "WindowText"
 msgstr "WindowText"
 
-#: ../src/common/fmapbase.cpp:177
+#: ../src/common/fmapbase.cpp:174
 msgid "Windows Arabic (CP 1256)"
 msgstr "Windows Árabe (CP 1256)"
 
-#: ../src/common/fmapbase.cpp:178
+#: ../src/common/fmapbase.cpp:175
 msgid "Windows Baltic (CP 1257)"
 msgstr "Windows Báltico (CP 1257)"
 
-#: ../src/common/fmapbase.cpp:171
+#: ../src/common/fmapbase.cpp:168
 msgid "Windows Central European (CP 1250)"
 msgstr "Windows Centro Europeo (CP 1250)"
 
-#: ../src/common/fmapbase.cpp:168
+#: ../src/common/fmapbase.cpp:165
 msgid "Windows Chinese Simplified (CP 936) or GB-2312"
 msgstr "Windows Chino simplificado (CP 936) or GB-2312"
 
-#: ../src/common/fmapbase.cpp:170
+#: ../src/common/fmapbase.cpp:167
 msgid "Windows Chinese Traditional (CP 950) or Big-5"
 msgstr "Windows Chino tradicional (CP 950) o Big-5"
 
-#: ../src/common/fmapbase.cpp:172
+#: ../src/common/fmapbase.cpp:169
 msgid "Windows Cyrillic (CP 1251)"
 msgstr "Windows Cirílico (CP 1251)"
 
-#: ../src/common/fmapbase.cpp:174
+#: ../src/common/fmapbase.cpp:171
 msgid "Windows Greek (CP 1253)"
 msgstr "Windows Griego (CP 1253)"
 
-#: ../src/common/fmapbase.cpp:176
+#: ../src/common/fmapbase.cpp:173
 msgid "Windows Hebrew (CP 1255)"
 msgstr "Windows Hebreo (CP 1255)"
 
-#: ../src/common/fmapbase.cpp:167
+#: ../src/common/fmapbase.cpp:164
 msgid "Windows Japanese (CP 932) or Shift-JIS"
 msgstr "Windows Japonés (CP 932) o Shift-JIS"
 
-#: ../src/common/fmapbase.cpp:180
+#: ../src/common/fmapbase.cpp:177
 msgid "Windows Johab (CP 1361)"
 msgstr "Windows Johab (CP 1361)"
 
-#: ../src/common/fmapbase.cpp:169
+#: ../src/common/fmapbase.cpp:166
 msgid "Windows Korean (CP 949)"
 msgstr "Windows Coreano (CP 949)"
 
-#: ../src/common/fmapbase.cpp:166
+#: ../src/common/fmapbase.cpp:163
 msgid "Windows Thai (CP 874)"
 msgstr "Windows Tailandés (CP 874)"
 
-#: ../src/common/fmapbase.cpp:175
+#: ../src/common/fmapbase.cpp:172
 msgid "Windows Turkish (CP 1254)"
 msgstr "Windows Turco (CP 1254)"
 
-#: ../src/common/fmapbase.cpp:179
+#: ../src/common/fmapbase.cpp:176
 msgid "Windows Vietnamese (CP 1258)"
 msgstr "Windows Vietnamita (CP 1258)"
 
-#: ../src/common/fmapbase.cpp:173
+#: ../src/common/fmapbase.cpp:170
 msgid "Windows Western European (CP 1252)"
 msgstr "Windows European Occidental (CP 1252)"
 
-#: ../src/common/fmapbase.cpp:181
+#: ../src/common/fmapbase.cpp:178
 msgid "Windows/DOS OEM (CP 437)"
 msgstr "Windows/DOS OEM (CP 437)"
 
-#: ../src/common/fmapbase.cpp:165
+#: ../src/common/fmapbase.cpp:162
 msgid "Windows/DOS OEM Cyrillic (CP 866)"
 msgstr "Windows/DOS OEM Cirílico (CP 866)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:111
+#: ../src/common/accelcmn.cpp:109
 msgid "Windows_Left"
 msgstr "Windows_Izquierda"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:113
+#: ../src/common/accelcmn.cpp:111
 msgid "Windows_Menu"
 msgstr "Windows_Menú"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:112
+#: ../src/common/accelcmn.cpp:110
 msgid "Windows_Right"
 msgstr "Windows_Derecha"
 
-#: ../src/common/ffile.cpp:150
+#: ../src/common/ffile.cpp:149
 #, c-format
 msgid "Write error on file '%s'"
 msgstr "Error de escritura en el archivo '%s'"
 
-#: ../src/xml/xml.cpp:914
+#: ../src/xml/xml.cpp:925
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "Error de parseo de XML: '%s' en la línea %d"
 
-#: ../src/common/xpmdecod.cpp:796
+#: ../src/common/xpmdecod.cpp:794
 msgid "XPM: Malformed pixel data!"
 msgstr "XPM: ¡Datos de píxel erróneos!"
 
-#: ../src/common/xpmdecod.cpp:705
+#: ../src/common/xpmdecod.cpp:702
 #, c-format
 msgid "XPM: incorrect colour description in line %d"
 msgstr "XPM: definición de color incorrecta en línea %d"
 
-#: ../src/common/xpmdecod.cpp:680
+#: ../src/common/xpmdecod.cpp:677
 msgid "XPM: incorrect header format!"
 msgstr "XPM: ¡formato de cabecera incorrecto!"
 
-#: ../src/common/xpmdecod.cpp:716 ../src/common/xpmdecod.cpp:725
+#: ../src/common/xpmdecod.cpp:714 ../src/common/xpmdecod.cpp:723
 #, c-format
 msgid "XPM: malformed colour definition '%s' at line %d!"
 msgstr "XPM: definición de color '%s' incorrecta en línea %d"
 
-#: ../src/common/xpmdecod.cpp:755
+#: ../src/common/xpmdecod.cpp:753
 msgid "XPM: no colors left to use for mask!"
 msgstr "XPM: ¡no quedan colores para la máscara!"
 
-#: ../src/common/xpmdecod.cpp:782
+#: ../src/common/xpmdecod.cpp:780
 #, c-format
 msgid "XPM: truncated image data at line %d!"
 msgstr "XPM: ¡datos de imagen truncados en la línea %d!"
 
-#: ../src/propgrid/advprops.cpp:1610
+#: ../src/propgrid/advprops.cpp:1516
 msgid "Yellow"
 msgstr "Amarillo"
 
-#: ../include/wx/msgdlg.h:276 ../src/common/stockitem.cpp:206
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:203
 #: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Sí"
 
-#: ../src/osx/carbon/overlay.cpp:155
-msgid "You cannot Clear an overlay that is not inited"
-msgstr "No puede quitar una superposición que no ha sido inicializada"
-
-#: ../src/osx/carbon/overlay.cpp:107 ../src/dfb/overlay.cpp:61
-msgid "You cannot Init an overlay twice"
-msgstr "No puede Inicializar una superposición dos veces"
-
-#: ../src/generic/dirdlgg.cpp:287
+#: ../src/generic/dirdlgg.cpp:284
 msgid "You cannot add a new directory to this section."
 msgstr "No puede añadir un directorio nuevo a esta sección."
 
-#: ../src/propgrid/propgrid.cpp:3299
+#: ../src/propgrid/propgrid.cpp:3276
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 "Ha introducido un valor incorrecto. Pulse ESC para cancelar la edición."
 
-#: ../src/common/stockitem.cpp:209
+#: ../src/osx/cocoa/menu.mm:286
+#, fuzzy
+msgid "Zoom"
+msgstr "Acercar"
+
+#: ../src/common/stockitem.cpp:206
 msgid "Zoom &In"
 msgstr "A&cercar"
 
-#: ../src/common/stockitem.cpp:210
+#: ../src/common/stockitem.cpp:207
 msgid "Zoom &Out"
 msgstr "A&lejar"
 
-#: ../src/common/stockitem.cpp:209 ../src/common/prntbase.cpp:1594
+#: ../src/common/stockitem.cpp:206 ../src/common/prntbase.cpp:1619
 msgid "Zoom In"
 msgstr "Acercar"
 
-#: ../src/common/stockitem.cpp:210 ../src/common/prntbase.cpp:1580
+#: ../src/common/stockitem.cpp:207 ../src/common/prntbase.cpp:1605
 msgid "Zoom Out"
 msgstr "Alejar"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to &Fit"
 msgstr "&Ajustar al tamaño"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to Fit"
 msgstr "Ajustar al tamaño"
 
-#: ../src/msw/dde.cpp:1141
+#: ../src/msw/dde.cpp:1205
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "una aplicación DDEML ha creado una condición acelerada prolongada."
 
-#: ../src/msw/dde.cpp:1129
+#: ../src/msw/dde.cpp:1193
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -8008,39 +8197,39 @@ msgstr ""
 "o se pasó un identificador de instancia no válido\n"
 "a una función DDEML."
 
-#: ../src/msw/dde.cpp:1147
+#: ../src/msw/dde.cpp:1211
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "el intento de un cliente de establece conversación falló."
 
-#: ../src/msw/dde.cpp:1144
+#: ../src/msw/dde.cpp:1208
 msgid "a memory allocation failed."
 msgstr "fallo al reservar memoria."
 
-#: ../src/msw/dde.cpp:1138
+#: ../src/msw/dde.cpp:1202
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "fallo al validar un parémetro por DDEML."
 
-#: ../src/msw/dde.cpp:1120
+#: ../src/msw/dde.cpp:1184
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "una petición para una transación síncrona ha finalizado."
 
-#: ../src/msw/dde.cpp:1126
+#: ../src/msw/dde.cpp:1190
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "una petición para una transacción de datos síncrona ha finalizado."
 
-#: ../src/msw/dde.cpp:1135
+#: ../src/msw/dde.cpp:1199
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "una petición para una transación de ejecución síncrona ha finalizado."
 
-#: ../src/msw/dde.cpp:1153
+#: ../src/msw/dde.cpp:1217
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "una petición para una transacción síncrona de revisión ha finalizado."
 
-#: ../src/msw/dde.cpp:1168
+#: ../src/msw/dde.cpp:1232
 msgid "a request to end an advise transaction has timed out."
 msgstr "una petición para una transacción síncrona de auditoría ha finalizado."
 
-#: ../src/msw/dde.cpp:1162
+#: ../src/msw/dde.cpp:1226
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -8050,15 +8239,15 @@ msgstr ""
 "que fue finalizada por el cliente, o el servidor\n"
 "terminó antes de completar una transacción."
 
-#: ../src/msw/dde.cpp:1150
+#: ../src/msw/dde.cpp:1214
 msgid "a transaction failed."
 msgstr "fallo en la transacción."
 
-#: ../src/common/accelcmn.cpp:189
+#: ../src/common/accelcmn.cpp:188
 msgid "alt"
 msgstr "alt"
 
-#: ../src/msw/dde.cpp:1132
+#: ../src/msw/dde.cpp:1196
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -8070,15 +8259,15 @@ msgstr ""
 "o una aplicación inicializada como APPCMD_CLIENTONLY ha\n"
 "intentado realizar transacciones de servidor."
 
-#: ../src/msw/dde.cpp:1156
+#: ../src/msw/dde.cpp:1220
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "ha fallado una llamada interna a la función PostMessage."
 
-#: ../src/msw/dde.cpp:1165
+#: ../src/msw/dde.cpp:1229
 msgid "an internal error has occurred in the DDEML."
 msgstr "ha ocurrido un error interno en DDEML."
 
-#: ../src/msw/dde.cpp:1171
+#: ../src/msw/dde.cpp:1235
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -8089,56 +8278,56 @@ msgstr ""
 "XTYP_XACT_COMPLETE,\n"
 "el identificador de la transacción para esa llamada deja de ser válido."
 
-#: ../src/common/zipstrm.cpp:1483
+#: ../src/common/zipstrm.cpp:1522
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "suponemos que es un archivo zip multiparte concatenado"
 
-#: ../src/common/fileconf.cpp:1847
+#: ../src/common/fileconf.cpp:1849
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "intento de cambiar clave inmutable '%s', ignorado."
 
-#: ../src/html/chm.cpp:329
+#: ../src/html/chm.cpp:326
 msgid "bad arguments to library function"
 msgstr "argumentos erróneos a la función de biblioteca"
 
-#: ../src/html/chm.cpp:341
+#: ../src/html/chm.cpp:338
 msgid "bad signature"
 msgstr "firma errónea"
 
-#: ../src/common/zipstrm.cpp:1918
+#: ../src/common/zipstrm.cpp:1988
 msgid "bad zipfile offset to entry"
 msgstr "desplazamiento erróneo al elemento del archivo zip"
 
-#: ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400
 msgid "binary"
 msgstr "binario"
 
-#: ../src/common/fontcmn.cpp:996
+#: ../src/common/fontcmn.cpp:1195
 msgid "bold"
 msgstr "negrita"
 
-#: ../src/msw/utils.cpp:1144
+#: ../src/msw/utils.cpp:1135
 #, c-format
 msgid "build %lu"
 msgstr "compilación %lu"
 
-#: ../src/common/ffile.cpp:75
+#: ../src/common/ffile.cpp:73
 #, c-format
 msgid "can't close file '%s'"
 msgstr "no se puede cerrar el archivo '%s'"
 
-#: ../src/common/file.cpp:245
+#: ../src/common/file.cpp:242
 #, c-format
 msgid "can't close file descriptor %d"
 msgstr "no se puede cerrar el descriptor de archivo %d"
 
-#: ../src/common/file.cpp:586
+#: ../src/common/ffile.cpp:382 ../src/common/file.cpp:613
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "no se pueden hacer efectivos los cambios en archivo '%s'"
 
-#: ../src/common/file.cpp:178
+#: ../src/common/file.cpp:175
 #, c-format
 msgid "can't create file '%s'"
 msgstr "no se puede crear el archivo '%s'"
@@ -8148,53 +8337,53 @@ msgstr "no se puede crear el archivo '%s'"
 msgid "can't delete user configuration file '%s'"
 msgstr "no se puede eliminar el archivo de configuración de usuario '%s'"
 
-#: ../src/common/file.cpp:495
+#: ../src/common/file.cpp:522
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr ""
 "no se puede determinar si el final del archivo con descriptor %d se ha "
 "alcanzado"
 
-#: ../src/common/zipstrm.cpp:1692
+#: ../src/common/zipstrm.cpp:1747
 msgid "can't find central directory in zip"
 msgstr "no se puede encontrar el directorio central del ZIP"
 
-#: ../src/common/file.cpp:465
+#: ../src/common/file.cpp:492
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "no se puede obtener el tamaño del archivo con descriptor %d"
 
-#: ../src/msw/utils.cpp:341
+#: ../src/msw/utils.cpp:336
 msgid "can't find user's HOME, using current directory."
 msgstr ""
 "no se encontró el directorio HOME del usuario; se usa el directorio actual."
 
-#: ../src/common/file.cpp:366
+#: ../src/common/file.cpp:407
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "no se puede vaciar el descriptor de archivo %d"
 
-#: ../src/common/file.cpp:422
+#: ../src/common/file.cpp:463
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr ""
 "no se puede alcanzar posición de búsqueda en el descriptor de archivo %d"
 
-#: ../src/common/fontmap.cpp:325
+#: ../src/common/fontmap.cpp:322
 msgid "can't load any font, aborting"
 msgstr "no se puede cargar ninguna fuente, abortando"
 
-#: ../src/common/file.cpp:231 ../src/common/ffile.cpp:59
+#: ../src/common/ffile.cpp:57 ../src/common/file.cpp:228
 #, c-format
 msgid "can't open file '%s'"
 msgstr "no se puede abrir el archivo '%s'"
 
-#: ../src/common/fileconf.cpp:320
+#: ../src/common/fileconf.cpp:314
 #, c-format
 msgid "can't open global configuration file '%s'."
 msgstr "no se puede abrir el archivo de configuración global '%s'."
 
-#: ../src/common/fileconf.cpp:336
+#: ../src/common/fileconf.cpp:330
 #, c-format
 msgid "can't open user configuration file '%s'."
 msgstr "no se puede abrir el archivo de configuración de usuario '%s'."
@@ -8203,40 +8392,40 @@ msgstr "no se puede abrir el archivo de configuración de usuario '%s'."
 msgid "can't open user configuration file."
 msgstr "no puede abrirse el archivo de configuración de usuario"
 
-#: ../src/common/zipstrm.cpp:579
+#: ../src/common/zipstrm.cpp:572
 msgid "can't re-initialize zlib deflate stream"
 msgstr "no se puede reinicializar el flujo de compresión de zlib."
 
-#: ../src/common/zipstrm.cpp:604
+#: ../src/common/zipstrm.cpp:597
 msgid "can't re-initialize zlib inflate stream"
 msgstr "no se puede reinicializar el flujo de descompresión de zlib."
 
-#: ../src/common/file.cpp:304
+#: ../src/common/file.cpp:345
 #, c-format
 msgid "can't read from file descriptor %d"
 msgstr "no se puede leer desde el descriptor de archivo %d"
 
-#: ../src/common/file.cpp:581
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:608
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "no se puede eliminar el archivo '%s'"
 
-#: ../src/common/file.cpp:598
+#: ../src/common/ffile.cpp:394 ../src/common/file.cpp:625
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "no se puede eliminar el archivo temporal '%s'"
 
-#: ../src/common/file.cpp:408
+#: ../src/common/file.cpp:449
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "no se puede buscar en el descriptor de archivo %d"
 
-#: ../src/common/textfile.cpp:273
+#: ../src/common/textfile.cpp:161
 #, c-format
 msgid "can't write buffer '%s' to disk."
 msgstr "no se puede guardar el buffer '%s' al disco."
 
-#: ../src/common/file.cpp:323
+#: ../src/common/file.cpp:364
 #, c-format
 msgid "can't write to file descriptor %d"
 msgstr "no se puede escribir el descriptor de archivo %d"
@@ -8246,22 +8435,28 @@ msgid "can't write user configuration file."
 msgstr "no puede escribirse el archivo de configuración de usuario"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:482 ../src/generic/datavgen.cpp:1261
+#: ../src/common/datavcmn.cpp:2064 ../src/generic/datavgen.cpp:1384
 msgid "checked"
 msgstr "activada"
 
-#: ../src/html/chm.cpp:345
+#: ../src/html/chm.cpp:342
 msgid "checksum error"
 msgstr "error de suma de comprobación"
 
-#: ../src/common/tarstrm.cpp:820
+#: ../src/common/tarstrm.cpp:814
 msgid "checksum failure reading tar header block"
 msgstr "fallo de suma de comprobación leyendo bloque de cabecera de tar"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:226
-#: ../src/richtext/richtextbackgroundpage.cpp:249
-#: ../src/richtext/richtextbackgroundpage.cpp:289
-#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
 #: ../src/richtext/richtextborderspage.cpp:254
 #: ../src/richtext/richtextborderspage.cpp:288
 #: ../src/richtext/richtextborderspage.cpp:322
@@ -8279,104 +8474,127 @@ msgstr "fallo de suma de comprobación leyendo bloque de cabecera de tar"
 #: ../src/richtext/richtextmarginspage.cpp:340
 #: ../src/richtext/richtextmarginspage.cpp:363
 #: ../src/richtext/richtextmarginspage.cpp:388
-#: ../src/richtext/richtextsizepage.cpp:339
-#: ../src/richtext/richtextsizepage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:400
-#: ../src/richtext/richtextsizepage.cpp:427
-#: ../src/richtext/richtextsizepage.cpp:454
-#: ../src/richtext/richtextsizepage.cpp:481
-#: ../src/richtext/richtextsizepage.cpp:555
-#: ../src/richtext/richtextsizepage.cpp:590
-#: ../src/richtext/richtextsizepage.cpp:625
-#: ../src/richtext/richtextsizepage.cpp:660
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
 msgid "cm"
 msgstr "cm"
 
-#: ../src/html/chm.cpp:347
+#: ../src/html/chm.cpp:344
 msgid "compression error"
 msgstr "error de compresión"
 
-#: ../src/common/regex.cpp:236
+#: ../src/common/regex.cpp:233
 msgid "conversion to 8-bit encoding failed"
 msgstr "falló la conversión a codificación de 8 bits"
 
-#: ../src/common/accelcmn.cpp:187
+#: ../src/common/accelcmn.cpp:186
 msgid "ctrl"
 msgstr "ctrl"
 
-#: ../src/common/cmdline.cpp:1500
+#: ../src/common/cmdline.cpp:1496
 msgid "date"
 msgstr "fecha"
 
-#: ../src/html/chm.cpp:349
+#: ../src/html/chm.cpp:346
 msgid "decompression error"
 msgstr "error de descompresión"
 
-#: ../src/richtext/richtextstyles.cpp:780 ../src/common/fmapbase.cpp:820
+#: ../src/common/fmapbase.cpp:816 ../src/richtext/richtextstyles.cpp:777
 msgid "default"
 msgstr "predeterminado"
 
-#: ../src/common/cmdline.cpp:1496
+#: ../src/common/cmdline.cpp:1492
 msgid "double"
 msgstr "doble"
 
-#: ../src/common/debugrpt.cpp:538
+#: ../src/common/debugrpt.cpp:539
 msgid "dump of the process state (binary)"
 msgstr "volcado de estado de proceso (binario)"
 
-#: ../src/common/datetimefmt.cpp:1969
+#: ../src/common/datetimefmt.cpp:1992
 msgid "eighteenth"
 msgstr "decimoctavo"
 
-#: ../src/common/datetimefmt.cpp:1959
+#: ../src/common/datetimefmt.cpp:1982
 msgid "eighth"
 msgstr "octavo"
 
-#: ../src/common/datetimefmt.cpp:1962
+#: ../src/common/datetimefmt.cpp:1985
 msgid "eleventh"
 msgstr "undécimo"
 
-#: ../src/common/fileconf.cpp:1833
+#: ../src/common/fileconf.cpp:1835
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "la entrada '%s' aparece más de una vez en el grupo '%s'"
 
-#: ../src/html/chm.cpp:343
+#: ../src/html/chm.cpp:340
 msgid "error in data format"
 msgstr "error en formato de datos"
 
-#: ../src/html/chm.cpp:331
+#: ../src/html/chm.cpp:328
 msgid "error opening file"
 msgstr "error al abrir el archivo"
 
-#: ../src/common/zipstrm.cpp:1778
+#: ../src/common/zipstrm.cpp:1836
 msgid "error reading zip central directory"
 msgstr "error al leer el directorio central del ZIP"
 
-#: ../src/common/zipstrm.cpp:1870
+#: ../src/common/zipstrm.cpp:1940
 msgid "error reading zip local header"
 msgstr "error al leer la cabecera local del archivo zip"
 
-#: ../src/common/zipstrm.cpp:2531
+#: ../src/common/zipstrm.cpp:2615
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "error al escribir el elemento de zip '%s': crc o longitud erróneos"
 
-#: ../src/common/ffile.cpp:188
+#: ../src/common/zipstrm.cpp:2608
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "error al escribir el elemento de zip '%s': crc o longitud erróneos"
+
+#: ../src/common/fontcmn.cpp:1205
+#, fuzzy
+msgid "extrabold"
+msgstr "negrita"
+
+#: ../src/common/fontcmn.cpp:1223
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1167
+#, fuzzy
+msgid "extralight"
+msgstr "ligera"
+
+#: ../src/msw/webview_ie.cpp:1036
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "Error al ejecutar '%s'\n"
+
+#: ../src/common/ffile.cpp:187
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "no se pudo limpiar el archivo '%s'"
 
+#: ../src/msw/webview_ie.cpp:1045
+#, fuzzy
+msgid "failed to retrieve execution result"
+msgstr "Fallo al recuperar el mensaje de error de RAS"
+
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1030
+#: ../src/generic/datavgen.cpp:1150
 msgid "false"
 msgstr "falso"
 
-#: ../src/common/datetimefmt.cpp:1966
+#: ../src/common/datetimefmt.cpp:1989
 msgid "fifteenth"
 msgstr "decimoquinto"
 
-#: ../src/common/datetimefmt.cpp:1956
+#: ../src/common/datetimefmt.cpp:1979
 msgid "fifth"
 msgstr "quinto"
 
@@ -8408,131 +8626,150 @@ msgstr ""
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "archivo «%s»: carácter %c inesperado en el renglón %zu."
 
-#: ../src/richtext/richtextbuffer.cpp:8738
+#: ../src/richtext/richtextbuffer.cpp:8736
 msgid "files"
 msgstr "archivos"
 
-#: ../src/common/datetimefmt.cpp:1952
+#: ../src/common/datetimefmt.cpp:1975
 msgid "first"
 msgstr "primero"
 
-#: ../src/html/helpwnd.cpp:1252
+#: ../src/html/helpwnd.cpp:1250
 msgid "font size"
 msgstr "tamaño de fuente"
 
-#: ../src/common/datetimefmt.cpp:1965
+#: ../src/common/datetimefmt.cpp:1988
 msgid "fourteenth"
 msgstr "decimocuarto"
 
-#: ../src/common/datetimefmt.cpp:1955
+#: ../src/common/datetimefmt.cpp:1978
 msgid "fourth"
 msgstr "cuarto"
 
-#: ../src/common/appbase.cpp:783
+#: ../src/common/appbase.cpp:784
 msgid "generate verbose log messages"
 msgstr "generar mensajes de log explicativos"
 
-#: ../src/richtext/richtextbuffer.cpp:13138
-#: ../src/richtext/richtextbuffer.cpp:13248
+#: ../src/common/fontcmn.cpp:1215
+msgid "heavy"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:13133
+#: ../src/richtext/richtextbuffer.cpp:13243
 msgid "image"
 msgstr "imagen"
 
-#: ../src/common/tarstrm.cpp:796
+#: ../src/common/tarstrm.cpp:790
 msgid "incomplete header block in tar"
 msgstr "bloque de cabecera incompleto en tar"
 
-#: ../src/common/xtixml.cpp:489
+#: ../src/common/xtixml.cpp:485
 msgid "incorrect event handler string, missing dot"
 msgstr "cadena de identificador de suceso incorrecta; falta el punto"
 
-#: ../src/common/tarstrm.cpp:1381
+#: ../src/common/tarstrm.cpp:1375
 msgid "incorrect size given for tar entry"
 msgstr "tamaño incorrecto para elemento de TAR"
 
-#: ../src/common/tarstrm.cpp:993
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:987
 msgid "invalid data in extended tar header"
 msgstr "datos no válidos en la cabecera de TAR extendida"
 
-#: ../src/generic/logg.cpp:1030
+#: ../src/generic/logg.cpp:1027
 msgid "invalid message box return value"
 msgstr "valor de retorno de bandeja de entrada no válido"
 
-#: ../src/common/zipstrm.cpp:1647
+#: ../src/common/zipstrm.cpp:1688
 msgid "invalid zip file"
 msgstr "archivo ZIP no válido"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:1228
 msgid "italic"
 msgstr "cursiva"
 
-#: ../src/common/fontcmn.cpp:991
+#: ../src/common/webrequest_curl.cpp:374
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "No se pudo abrir el archivo."
+
+#: ../src/common/fontcmn.cpp:1172
 msgid "light"
 msgstr "ligera"
 
-#: ../src/common/intl.cpp:303
-#, c-format
-msgid "locale '%s' cannot be set."
-msgstr "no se puede establecer la configuración regional «%s»."
+#: ../src/common/fontcmn.cpp:1185
+msgid "medium"
+msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2125
+#: ../src/common/datetimefmt.cpp:2148
 msgid "midnight"
 msgstr "medianoche"
 
-#: ../src/common/datetimefmt.cpp:1970
+#: ../src/common/datetimefmt.cpp:1993
 msgid "nineteenth"
 msgstr "decimonoveno"
 
-#: ../src/common/datetimefmt.cpp:1960
+#: ../src/common/datetimefmt.cpp:1983
 msgid "ninth"
 msgstr "noveno"
 
-#: ../src/msw/dde.cpp:1116
+#: ../src/msw/dde.cpp:1180
 msgid "no DDE error."
 msgstr "no hay error DDE."
 
-#: ../src/html/chm.cpp:327
+#: ../src/html/chm.cpp:324
 msgid "no error"
 msgstr "no hay error"
 
-#: ../src/dfb/fontmgr.cpp:174
+#: ../src/dfb/fontmgr.cpp:171
 #, c-format
 msgid "no fonts found in %s, using builtin font"
 msgstr "no se han encontrado tipos de letra en %s; se usa el tipo incorporado"
 
-#: ../src/html/helpdata.cpp:657
+#: ../src/html/helpdata.cpp:650
 msgid "noname"
 msgstr "anónimo"
 
-#: ../src/common/datetimefmt.cpp:2124
+#: ../src/common/datetimefmt.cpp:2147
 msgid "noon"
 msgstr "mediodía"
 
-#: ../src/richtext/richtextstyles.cpp:779
+#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "normal"
 
-#: ../src/common/cmdline.cpp:1492
+#: ../src/common/cmdline.cpp:1488
 msgid "num"
 msgstr "núm"
 
-#: ../src/common/xtixml.cpp:259
+#: ../src/common/accelcmn.cpp:194
+msgid "num "
+msgstr ""
+
+#: ../src/common/xtixml.cpp:255
 msgid "objects cannot have XML Text Nodes"
 msgstr "los objetos no pueden tener nodos XML de texto"
 
-#: ../src/html/chm.cpp:339
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
 msgid "out of memory"
 msgstr "memoria agotada"
 
-#: ../src/common/debugrpt.cpp:514
+#: ../src/common/debugrpt.cpp:515
 msgid "process context description"
 msgstr "descripción del contexto de proceso"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:227
-#: ../src/richtext/richtextbackgroundpage.cpp:250
-#: ../src/richtext/richtextbackgroundpage.cpp:290
-#: ../src/richtext/richtextbackgroundpage.cpp:317
-#: ../src/richtext/richtextfontpage.cpp:177
-#: ../src/richtext/richtextfontpage.cpp:180
 #: ../src/richtext/richtextborderspage.cpp:255
 #: ../src/richtext/richtextborderspage.cpp:289
 #: ../src/richtext/richtextborderspage.cpp:323
@@ -8542,22 +8779,45 @@ msgstr "descripción del contexto de proceso"
 #: ../src/richtext/richtextborderspage.cpp:491
 #: ../src/richtext/richtextborderspage.cpp:525
 #: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextfontpage.cpp:180
 msgid "pt"
 msgstr "pt"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:225
-#: ../src/richtext/richtextbackgroundpage.cpp:228
-#: ../src/richtext/richtextbackgroundpage.cpp:229
-#: ../src/richtext/richtextbackgroundpage.cpp:248
-#: ../src/richtext/richtextbackgroundpage.cpp:251
-#: ../src/richtext/richtextbackgroundpage.cpp:252
-#: ../src/richtext/richtextbackgroundpage.cpp:288
-#: ../src/richtext/richtextbackgroundpage.cpp:291
-#: ../src/richtext/richtextbackgroundpage.cpp:292
-#: ../src/richtext/richtextbackgroundpage.cpp:315
-#: ../src/richtext/richtextbackgroundpage.cpp:318
-#: ../src/richtext/richtextbackgroundpage.cpp:319
-#: ../src/richtext/richtextfontpage.cpp:178
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:659
+#: ../src/richtext/richtextsizepage.cpp:662
+#: ../src/richtext/richtextsizepage.cpp:663
 #: ../src/richtext/richtextborderspage.cpp:253
 #: ../src/richtext/richtextborderspage.cpp:256
 #: ../src/richtext/richtextborderspage.cpp:257
@@ -8609,259 +8869,269 @@ msgstr "pt"
 #: ../src/richtext/richtextmarginspage.cpp:387
 #: ../src/richtext/richtextmarginspage.cpp:389
 #: ../src/richtext/richtextmarginspage.cpp:390
-#: ../src/richtext/richtextsizepage.cpp:338
-#: ../src/richtext/richtextsizepage.cpp:341
-#: ../src/richtext/richtextsizepage.cpp:342
-#: ../src/richtext/richtextsizepage.cpp:372
-#: ../src/richtext/richtextsizepage.cpp:375
-#: ../src/richtext/richtextsizepage.cpp:376
-#: ../src/richtext/richtextsizepage.cpp:399
-#: ../src/richtext/richtextsizepage.cpp:402
-#: ../src/richtext/richtextsizepage.cpp:403
-#: ../src/richtext/richtextsizepage.cpp:426
-#: ../src/richtext/richtextsizepage.cpp:429
-#: ../src/richtext/richtextsizepage.cpp:430
-#: ../src/richtext/richtextsizepage.cpp:453
-#: ../src/richtext/richtextsizepage.cpp:456
-#: ../src/richtext/richtextsizepage.cpp:457
-#: ../src/richtext/richtextsizepage.cpp:480
-#: ../src/richtext/richtextsizepage.cpp:483
-#: ../src/richtext/richtextsizepage.cpp:484
-#: ../src/richtext/richtextsizepage.cpp:554
-#: ../src/richtext/richtextsizepage.cpp:557
-#: ../src/richtext/richtextsizepage.cpp:558
-#: ../src/richtext/richtextsizepage.cpp:589
-#: ../src/richtext/richtextsizepage.cpp:592
-#: ../src/richtext/richtextsizepage.cpp:593
-#: ../src/richtext/richtextsizepage.cpp:624
-#: ../src/richtext/richtextsizepage.cpp:627
-#: ../src/richtext/richtextsizepage.cpp:628
-#: ../src/richtext/richtextsizepage.cpp:659
-#: ../src/richtext/richtextsizepage.cpp:662
-#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextfontpage.cpp:178
 msgid "px"
 msgstr "px"
 
-#: ../src/common/accelcmn.cpp:193
+#: ../src/common/accelcmn.cpp:192
 msgid "rawctrl"
 msgstr "rawctrl"
 
-#: ../src/html/chm.cpp:333
+#: ../src/html/chm.cpp:330
 msgid "read error"
 msgstr "error de lectura"
 
-#: ../src/common/zipstrm.cpp:2085
+#: ../src/common/zipstrm.cpp:2155
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "al leer flujo de zip (elemento %s): crc erróneo"
 
-#: ../src/common/zipstrm.cpp:2080
+#: ../src/common/zipstrm.cpp:2150
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "al leer flujo de zip (elemento %s): longitud errónea"
 
-#: ../src/msw/dde.cpp:1159
+#: ../src/msw/dde.cpp:1223
 msgid "reentrancy problem."
 msgstr "problema de reentrada."
 
-#: ../src/common/datetimefmt.cpp:1953
+#: ../src/common/datetimefmt.cpp:1976
 msgid "second"
 msgstr "segundo"
 
-#: ../src/html/chm.cpp:337
+#: ../src/html/chm.cpp:334
 msgid "seek error"
 msgstr "error de búsqueda"
 
-#: ../src/common/datetimefmt.cpp:1968
+#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#, fuzzy
+msgid "semibold"
+msgstr "negrita"
+
+#: ../src/common/datetimefmt.cpp:1991
 msgid "seventeenth"
 msgstr "decimoséptimo"
 
-#: ../src/common/datetimefmt.cpp:1958
+#: ../src/common/datetimefmt.cpp:1981
 msgid "seventh"
 msgstr "séptimo"
 
-#: ../src/common/accelcmn.cpp:191
+#: ../src/common/accelcmn.cpp:190
 msgid "shift"
 msgstr "mayúsculas"
 
-#: ../src/common/appbase.cpp:773
+#: ../src/common/appbase.cpp:774
 msgid "show this help message"
 msgstr "mostrar este mensaje de ayuda"
 
-#: ../src/common/datetimefmt.cpp:1967
+#: ../src/common/datetimefmt.cpp:1990
 msgid "sixteenth"
 msgstr "decimosexto"
 
-#: ../src/common/datetimefmt.cpp:1957
+#: ../src/common/datetimefmt.cpp:1980
 msgid "sixth"
 msgstr "sexto"
 
-#: ../src/common/appcmn.cpp:234
+#: ../src/common/appcmn.cpp:255
 msgid "specify display mode to use (e.g. 640x480-16)"
 msgstr "especifique el modo de pantalla a usar (ej.: 640x480-16)"
 
-#: ../src/common/appcmn.cpp:220
+#: ../src/common/appcmn.cpp:241
 msgid "specify the theme to use"
 msgstr "especifique el tema a usar"
 
-#: ../src/richtext/richtextbuffer.cpp:9340
+#: ../src/richtext/richtextbuffer.cpp:9337
 msgid "standard/circle"
 msgstr "estándar/círculo"
 
-#: ../src/richtext/richtextbuffer.cpp:9341
+#: ../src/richtext/richtextbuffer.cpp:9338
 msgid "standard/circle-outline"
 msgstr "estándar/circunferencia"
 
-#: ../src/richtext/richtextbuffer.cpp:9343
+#: ../src/richtext/richtextbuffer.cpp:9340
 msgid "standard/diamond"
 msgstr "estándar/diamante"
 
-#: ../src/richtext/richtextbuffer.cpp:9342
+#: ../src/richtext/richtextbuffer.cpp:9339
 msgid "standard/square"
 msgstr "estándar/cuadrado"
 
-#: ../src/richtext/richtextbuffer.cpp:9344
+#: ../src/richtext/richtextbuffer.cpp:9341
 msgid "standard/triangle"
 msgstr "estándar/triángulo"
 
-#: ../src/common/zipstrm.cpp:1985
+#: ../src/common/zipstrm.cpp:2055
 msgid "stored file length not in Zip header"
 msgstr "longitud del archivo almacenada no está en la cabecera del Zip"
 
-#: ../src/common/cmdline.cpp:1488
+#: ../src/common/cmdline.cpp:1484
 msgid "str"
 msgstr "cad"
 
-#: ../src/common/fontcmn.cpp:982
+#: ../src/common/fontcmn.cpp:1145
 msgid "strikethrough"
 msgstr "tachado"
 
-#: ../src/common/tarstrm.cpp:1003 ../src/common/tarstrm.cpp:1025
-#: ../src/common/tarstrm.cpp:1507 ../src/common/tarstrm.cpp:1529
+#: ../src/common/tarstrm.cpp:997 ../src/common/tarstrm.cpp:1019
+#: ../src/common/tarstrm.cpp:1501 ../src/common/tarstrm.cpp:1523
 msgid "tar entry not open"
 msgstr "elemento tar no abierto"
 
-#: ../src/common/datetimefmt.cpp:1961
+#: ../src/common/datetimefmt.cpp:1984
 msgid "tenth"
 msgstr "décimo"
 
-#: ../src/msw/dde.cpp:1123
+#: ../src/msw/dde.cpp:1187
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "la respuesta a la transacción causó que se activase el bit DDE_FBUSY."
 
-#: ../src/common/datetimefmt.cpp:1954
+#: ../src/common/fontcmn.cpp:1154
+msgid "thin"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:1977
 msgid "third"
 msgstr "tercero"
 
-#: ../src/common/datetimefmt.cpp:1964
+#: ../src/common/datetimefmt.cpp:1987
 msgid "thirteenth"
 msgstr "decimotercero"
 
-#: ../src/common/datetimefmt.cpp:1758
+#: ../src/common/datetimefmt.cpp:1781
 msgid "today"
 msgstr "hoy"
 
-#: ../src/common/datetimefmt.cpp:1760
+#: ../src/common/datetimefmt.cpp:1783
 msgid "tomorrow"
 msgstr "mañana"
 
-#: ../src/common/fileconf.cpp:1944
+#: ../src/common/fileconf.cpp:1946
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "ignorada la barra inversa al final de '%s'."
 
-#: ../src/gtk/aboutdlg.cpp:218
+#: ../src/gtk/aboutdlg.cpp:216
 msgid "translator-credits"
 msgstr "traductor-créditos"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1028
+#: ../src/generic/datavgen.cpp:1148
 msgid "true"
 msgstr "verdadero"
 
-#: ../src/common/datetimefmt.cpp:1963
+#: ../src/common/datetimefmt.cpp:1986
 msgid "twelfth"
 msgstr "duodécimo"
 
-#: ../src/common/datetimefmt.cpp:1971
+#: ../src/common/datetimefmt.cpp:1994
 msgid "twentieth"
 msgstr "vigésimo"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:486 ../src/generic/datavgen.cpp:1263
+#: ../src/common/datavcmn.cpp:2068 ../src/generic/datavgen.cpp:1386
 msgid "unchecked"
 msgstr "desactivada"
 
-#: ../src/common/fontcmn.cpp:802 ../src/common/fontcmn.cpp:978
+#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
 msgid "underlined"
 msgstr "subrayado"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:490
+#: ../src/common/datavcmn.cpp:2072
 msgid "undetermined"
 msgstr "sin determinar"
 
-#: ../src/common/fileconf.cpp:1979
+#: ../src/common/fileconf.cpp:1981
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "\" inesperada en la posición %d en '%s'."
 
-#: ../src/common/tarstrm.cpp:1045
+#: ../src/common/tarstrm.cpp:1039
 msgid "unexpected end of file"
 msgstr "fin de archivo inesperado"
 
-#: ../src/generic/progdlgg.cpp:370 ../src/common/tarstrm.cpp:371
-#: ../src/common/tarstrm.cpp:394 ../src/common/tarstrm.cpp:425
+#: ../src/common/tarstrm.cpp:366 ../src/common/tarstrm.cpp:389
+#: ../src/common/tarstrm.cpp:420 ../src/generic/progdlgg.cpp:376
 msgid "unknown"
 msgstr "desconocido"
 
-#: ../src/msw/registry.cpp:150
+#: ../src/msw/registry.cpp:139
 #, c-format
 msgid "unknown (%lu)"
 msgstr "desconocido (%lu)"
 
-#: ../src/common/xtixml.cpp:253
+#: ../src/common/xtixml.cpp:249
 #, c-format
 msgid "unknown class %s"
 msgstr "clase %s desconocida"
 
-#: ../src/common/regex.cpp:258 ../src/html/chm.cpp:351
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "error de compresión"
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "error de descompresión"
+
+#: ../src/common/regex.cpp:255 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "error desconocido"
 
-#: ../src/msw/dialup.cpp:471
+#: ../src/msw/dialup.cpp:465
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "error desconocido (código %08x)."
 
-#: ../src/common/fmapbase.cpp:834
+#: ../src/common/fmapbase.cpp:830
 #, c-format
 msgid "unknown-%d"
 msgstr "desconocido-%d"
 
-#: ../src/common/docview.cpp:509
+#: ../src/common/docview.cpp:502
 msgid "unnamed"
 msgstr "anónimo"
 
-#: ../src/common/docview.cpp:1624
+#: ../src/common/docview.cpp:1618
 #, c-format
 msgid "unnamed%d"
 msgstr "anónimo%d"
 
-#: ../src/common/zipstrm.cpp:1999 ../src/common/zipstrm.cpp:2319
+#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
 msgid "unsupported Zip compression method"
 msgstr "no se admite el método de compresión ZIP"
 
-#: ../src/common/translation.cpp:1892
+#: ../src/common/translation.cpp:1942
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "se usa el catálogo «%s» de «%s»."
 
-#: ../src/html/chm.cpp:335
+#: ../src/html/chm.cpp:332
 msgid "write error"
 msgstr "error de escritura"
 
-#: ../src/common/time.cpp:292
+#: ../src/gtk/glcanvas.cpp:187
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/common/time.cpp:285
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay falló."
 
@@ -8874,15 +9144,15 @@ msgstr "wxWidgets no pudo abrir el 'display' para '%s': saliendo."
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets no pudo abrir el display. Saliendo."
 
-#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:431
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/common/datetimefmt.cpp:1759
+#: ../src/common/datetimefmt.cpp:1782
 msgid "yesterday"
 msgstr "ayer"
 
-#: ../src/common/zstream.cpp:251 ../src/common/zstream.cpp:426
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
 #, c-format
 msgid "zlib error %d"
 msgstr "error de zlib %d"
@@ -8891,3 +9161,75 @@ msgstr "error de zlib %d"
 #: ../src/richtext/richtextbulletspage.cpp:288
 msgid "~"
 msgstr "~"
+
+#~ msgid " (while overwriting an existing item)"
+#~ msgstr " (al sobrescribir un elemento existente)"
+
+#~ msgid "&Save as"
+#~ msgstr "&Guardar como"
+
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' no tiene exclusivamente caracteres válidos"
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s debería ser numérico."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' debería contener sólo caracteres ASCII."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' debería contener sólo caracteres de texto."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s debería contener sólo caracteres alfanuméricos."
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' debería contener solo dígitos."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "No se puede crear la ventana de clase %s"
+
+#~ msgid "Could not initalize libnotify."
+#~ msgstr "No se pudo inicializar libnotify."
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "No se pudo crear la ventana de superposición"
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "No se pudo inicializar el contexto en la ventana de superposición"
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "Fallo al convertir el archivo \"%s\" a Unicode."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "No se pudo colocar texto en el control de texto."
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr "La opción de GTK+ de consola no es válida; utilice «%s --help»"
+
+#~ msgid "No unused colour in image."
+#~ msgstr "No hay ningún color sin usar en la imagen."
+
+#~ msgid "Not available"
+#~ msgstr "No disponible"
+
+#~ msgid "Replace selection"
+#~ msgstr "Reemplazar selección"
+
+#~ msgid "Save as"
+#~ msgstr "Guardar como"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Organizador de estilos"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "También se admiten las siguientes opciones estándares de GTK+:\n"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "No puede quitar una superposición que no ha sido inicializada"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "No puede Inicializar una superposición dos veces"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "no se puede establecer la configuración regional «%s»."

--- a/locale/eu.po
+++ b/locale/eu.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-21 14:25+0200\n"
+"POT-Creation-Date: 2020-10-18 23:11+0300\n"
 "PO-Revision-Date: 2015-07-18 21:39+0200\n"
 "Last-Translator: Xabier Aramendi <azpidatziak@gmail.com>\n"
 "Language-Team: (EUS_Xabier Aramendi) <azpidatziak@gmail.com>\n"
@@ -14,7 +14,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 1.8.2\n"
 
-#: ../src/common/debugrpt.cpp:586
+#: ../src/common/debugrpt.cpp:587
 msgid ""
 "\n"
 "Please send this report to the program maintainer, thank you!\n"
@@ -22,8 +22,8 @@ msgstr ""
 "\n"
 "Mesedez bidali jakinarazpen hau programaren arduradunari, mila esker!\n"
 
-#: ../src/richtext/richtextstyledlg.cpp:210
-#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:206
+#: ../src/richtext/richtextstyledlg.cpp:218
 msgid " "
 msgstr " "
 
@@ -31,70 +31,96 @@ msgstr " "
 msgid "              Thank you and we're sorry for the inconvenience!\n"
 msgstr "             Mila esker eta barkatu eragozpenak!\n"
 
-#: ../src/common/prntbase.cpp:573
+#: ../src/common/prntbase.cpp:568
 #, c-format
 msgid " (copy %d of %d)"
 msgstr " (kopiatu %d --> %d-tik"
 
-#: ../src/common/log.cpp:421
+#: ../src/common/log.cpp:440
 #, c-format
 msgid " (error %ld: %s)"
 msgstr " (%ld akatsa: %s)"
 
-#: ../src/common/imagtiff.cpp:72
+#: ../src/common/imagtiff.cpp:69
 #, c-format
 msgid " (in module \"%s\")"
 msgstr " (\"%s\" moduloan)"
 
-#: ../src/osx/core/secretstore.cpp:138
-msgid " (while overwriting an existing item)"
-msgstr ""
-
-#: ../src/common/docview.cpp:1642
+#: ../src/common/docview.cpp:1636
 msgid " - "
 msgstr " -"
 
-#: ../src/richtext/richtextprint.cpp:593 ../src/html/htmprint.cpp:714
+#: ../src/html/htmprint.cpp:712 ../src/richtext/richtextprint.cpp:589
 msgid " Preview"
 msgstr " Aurreikuspena"
 
-#: ../src/common/fontcmn.cpp:824
+#: ../src/common/fontcmn.cpp:973
 msgid " bold"
 msgstr " lodia"
 
-#: ../src/common/fontcmn.cpp:840
+#: ../src/common/fontcmn.cpp:977
+#, fuzzy
+msgid " extra bold"
+msgstr " lodia"
+
+#: ../src/common/fontcmn.cpp:985
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:957
+#, fuzzy
+msgid " extra light"
+msgstr " arina"
+
+#: ../src/common/fontcmn.cpp:981
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1001
 msgid " italic"
 msgstr " etzana"
 
-#: ../src/common/fontcmn.cpp:820
+#: ../src/common/fontcmn.cpp:961
 msgid " light"
 msgstr " arina"
 
-#: ../src/common/fontcmn.cpp:807
+#: ../src/common/fontcmn.cpp:965
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:969
+#, fuzzy
+msgid " semi bold"
+msgstr " lodia"
+
+#: ../src/common/fontcmn.cpp:940
 msgid " strikethrough"
 msgstr "Marratuta"
 
-#: ../src/common/paper.cpp:117
+#: ../src/common/fontcmn.cpp:953
+msgid " thin"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
 msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
 msgstr "#10 Gutunazala, 4 1/8 x 9 1/2 in"
 
-#: ../src/common/paper.cpp:118
+#: ../src/common/paper.cpp:115
 msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
 msgstr "#11 Gutunazala, 4 1/2 x 10 3/8 in"
 
-#: ../src/common/paper.cpp:119
+#: ../src/common/paper.cpp:116
 msgid "#12 Envelope, 4 3/4 x 11 in"
 msgstr "#12 Gutunazala, 4 3/4 x 11 in"
 
-#: ../src/common/paper.cpp:120
+#: ../src/common/paper.cpp:117
 msgid "#14 Envelope, 5 x 11 1/2 in"
 msgstr "#14 Gutunazala, 5 x 11 1/2 in"
 
-#: ../src/common/paper.cpp:116
+#: ../src/common/paper.cpp:113
 msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
 msgstr "#9 Gutunazala, 3 7/8 x 8 7/8 in"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:341
 #: ../src/richtext/richtextsizepage.cpp:340
 #: ../src/richtext/richtextsizepage.cpp:374
 #: ../src/richtext/richtextsizepage.cpp:401
@@ -105,81 +131,82 @@ msgstr "#9 Gutunazala, 3 7/8 x 8 7/8 in"
 #: ../src/richtext/richtextsizepage.cpp:591
 #: ../src/richtext/richtextsizepage.cpp:626
 #: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextbackgroundpage.cpp:341
 msgid "%"
 msgstr "%"
 
-#: ../src/html/helpwnd.cpp:1031
+#: ../src/html/helpwnd.cpp:1029
 #, c-format
 msgid "%d of %lu"
 msgstr "%d %lu-tik"
 
-#: ../src/html/helpwnd.cpp:1678
+#: ../src/html/helpwnd.cpp:1676
 #, c-format
 msgid "%i of %u"
 msgstr "%i -> %u-tik"
 
-#: ../src/generic/filectrlg.cpp:279
+#: ../src/generic/filectrlg.cpp:275
 #, c-format
 msgid "%ld byte"
 msgid_plural "%ld bytes"
 msgstr[0] "%ld byte"
 msgstr[1] "%ld byte"
 
-#: ../src/html/helpwnd.cpp:1033
+#: ../src/html/helpwnd.cpp:1031
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu -> %lu-tik"
 
-#: ../src/generic/datavgen.cpp:6028
+#: ../src/generic/datavgen.cpp:6833
 #, fuzzy, c-format
 msgid "%s (%d items)"
 msgstr "%s (edo %s)"
 
-#: ../src/common/cmdline.cpp:1221
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (edo %s)"
 
-#: ../src/generic/logg.cpp:224
+#: ../src/generic/logg.cpp:221
 #, c-format
 msgid "%s Error"
 msgstr "%s Akatsa"
 
-#: ../src/generic/logg.cpp:236
+#: ../src/generic/logg.cpp:233
 #, c-format
 msgid "%s Information"
 msgstr "%s Argibideak"
 
-#: ../src/generic/preferencesg.cpp:113
+#: ../src/generic/preferencesg.cpp:110
 #, c-format
 msgid "%s Preferences"
 msgstr "%s Hobespenak"
 
-#: ../src/generic/logg.cpp:228
+#: ../src/generic/logg.cpp:225
 #, c-format
 msgid "%s Warning"
 msgstr "%s Oharra"
 
-#: ../src/common/tarstrm.cpp:1319
+#: ../src/common/tarstrm.cpp:1313
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s-k ez du finkatzen tar idazburua '%s' sarrerarentzat"
 
-#: ../src/common/fldlgcmn.cpp:124
+#: ../src/common/fldlgcmn.cpp:121
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s agiri (%s)|%s"
 
-#: ../src/html/helpwnd.cpp:1716
+#: ../src/html/helpwnd.cpp:1714
 #, c-format
 msgid "%u of %u"
 msgstr "%u -> %u-tik"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "&About"
 msgstr "&Honi buruz"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "&Actual Size"
 msgstr "&Oraingo Neurria"
 
@@ -187,28 +214,28 @@ msgstr "&Oraingo Neurria"
 msgid "&After a paragraph:"
 msgstr "&Esaldi baten ondoren:"
 
-#: ../src/richtext/richtextindentspage.cpp:128
 #: ../src/richtext/richtextliststylepage.cpp:319
+#: ../src/richtext/richtextindentspage.cpp:128
 msgid "&Alignment"
 msgstr "&Lerrokapena"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "&Apply"
 msgstr "&Ezarri"
 
-#: ../src/richtext/richtextstyledlg.cpp:251
+#: ../src/richtext/richtextstyledlg.cpp:247
 msgid "&Apply Style"
 msgstr "&Ezarri Estiloa"
 
-#: ../src/msw/mdi.cpp:179
+#: ../src/msw/mdi.cpp:174
 msgid "&Arrange Icons"
 msgstr "&Alderatu Ikurrak"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "&Ascending"
 msgstr "&Gorantz"
 
-#: ../src/common/stockitem.cpp:142
+#: ../src/common/stockitem.cpp:139
 msgid "&Back"
 msgstr "&Atzera"
 
@@ -228,24 +255,24 @@ msgstr "&Br margoa:"
 msgid "&Blur distance:"
 msgstr "&Lausotze hurruntasuna:"
 
-#: ../src/common/stockitem.cpp:143
+#: ../src/common/stockitem.cpp:140
 msgid "&Bold"
 msgstr "&Lodia"
 
-#: ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141
 msgid "&Bottom"
 msgstr "&Behean"
 
+#: ../src/richtext/richtextsizepage.cpp:637
+#: ../src/richtext/richtextsizepage.cpp:644
 #: ../src/richtext/richtextborderspage.cpp:345
 #: ../src/richtext/richtextborderspage.cpp:513
 #: ../src/richtext/richtextmarginspage.cpp:259
 #: ../src/richtext/richtextmarginspage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:637
-#: ../src/richtext/richtextsizepage.cpp:644
 msgid "&Bottom:"
 msgstr "&Behean:"
 
-#: ../include/wx/richtext/richtextbuffer.h:3866
+#: ../include/wx/richtext/richtextbuffer.h:3861
 msgid "&Box"
 msgstr "&Kutxa"
 
@@ -254,38 +281,38 @@ msgstr "&Kutxa"
 msgid "&Bullet style:"
 msgstr "&Buleta estiloa:"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "&CD-Rom"
 msgstr "&CD-Rom"
 
-#: ../src/generic/wizard.cpp:434 ../src/generic/fontdlgg.cpp:470
-#: ../src/generic/fontdlgg.cpp:489 ../src/osx/carbon/fontdlg.cpp:402
-#: ../src/common/dlgcmn.cpp:279 ../src/common/stockitem.cpp:145
+#: ../src/osx/carbon/fontdlg.cpp:399 ../src/common/stockitem.cpp:142
+#: ../src/generic/wizard.cpp:433 ../src/generic/fontdlgg.cpp:466
+#: ../src/generic/fontdlgg.cpp:485 ../src/osx/cocoa/button.mm:200
 msgid "&Cancel"
 msgstr "E&zeztatu"
 
-#: ../src/msw/mdi.cpp:175
+#: ../src/msw/mdi.cpp:170
 msgid "&Cascade"
 msgstr "&Urjauzia"
 
-#: ../include/wx/richtext/richtextbuffer.h:5960
+#: ../include/wx/richtext/richtextbuffer.h:5955
 msgid "&Cell"
 msgstr "%Gelaxka"
 
-#: ../src/richtext/richtextsymboldlg.cpp:439
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "&Character code:"
 msgstr "&Hizki kodea:"
 
-#: ../src/common/stockitem.cpp:147
+#: ../src/common/stockitem.cpp:144
 msgid "&Clear"
 msgstr "&Garbitu"
 
-#: ../src/generic/logg.cpp:516 ../src/common/stockitem.cpp:148
-#: ../src/common/prntbase.cpp:1600 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/stockitem.cpp:145 ../src/common/prntbase.cpp:1625
+#: ../src/univ/themes/win32.cpp:3753 ../src/generic/logg.cpp:513
 msgid "&Close"
 msgstr "It&xi"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "&Color"
 msgstr "&Margoa"
 
@@ -293,20 +320,20 @@ msgstr "&Margoa"
 msgid "&Colour:"
 msgstr "&Margoa:"
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "&Convert"
 msgstr "&Bihurtu"
 
-#: ../src/richtext/richtextctrl.cpp:333 ../src/osx/textctrl_osx.cpp:577
-#: ../src/common/stockitem.cpp:150 ../src/msw/textctrl.cpp:2508
+#: ../src/osx/textctrl_osx.cpp:595 ../src/common/stockitem.cpp:147
+#: ../src/msw/textctrl.cpp:2773 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Kopiatu"
 
-#: ../src/generic/hyperlinkg.cpp:156
+#: ../src/generic/hyperlinkg.cpp:153
 msgid "&Copy URL"
 msgstr "&Kopiatu URL-a"
 
-#: ../src/common/headerctrlcmn.cpp:306
+#: ../src/common/headerctrlcmn.cpp:304
 msgid "&Customize..."
 msgstr "&Norbereratu..."
 
@@ -314,53 +341,54 @@ msgstr "&Norbereratu..."
 msgid "&Debug report preview:"
 msgstr "&Garbiketa jakinarazpen aurreikuspena:"
 
-#: ../src/richtext/richtexttabspage.cpp:138
-#: ../src/richtext/richtextctrl.cpp:335 ../src/osx/textctrl_osx.cpp:579
-#: ../src/common/stockitem.cpp:152 ../src/msw/textctrl.cpp:2510
+#: ../src/osx/textctrl_osx.cpp:597 ../src/common/stockitem.cpp:149
+#: ../src/msw/textctrl.cpp:2775 ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtextctrl.cpp:334
 msgid "&Delete"
 msgstr "Ezabatu"
 
-#: ../src/richtext/richtextstyledlg.cpp:269
+#: ../src/richtext/richtextstyledlg.cpp:265
 msgid "&Delete Style..."
 msgstr "E&zabatu Estiloa..."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "&Descending"
 msgstr "&Beherantz"
 
-#: ../src/generic/logg.cpp:682
+#: ../src/generic/logg.cpp:679
 msgid "&Details"
 msgstr "&Xehetasunak"
 
-#: ../src/common/stockitem.cpp:153
+#: ../src/common/stockitem.cpp:150
 msgid "&Down"
 msgstr "&Behera"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "&Edit"
 msgstr "&Editatu"
 
-#: ../src/richtext/richtextstyledlg.cpp:263
+#: ../src/richtext/richtextstyledlg.cpp:259
 msgid "&Edit Style..."
 msgstr "&Editatu Estiloa..."
 
-#: ../src/common/stockitem.cpp:155
+#: ../src/common/stockitem.cpp:152
 msgid "&Execute"
 msgstr "&Ekin"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/common/stockitem.cpp:154
 msgid "&File"
 msgstr "&Agiria"
 
-#: ../src/common/stockitem.cpp:158
-msgid "&Find"
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "&Find..."
 msgstr "&Bilatu"
 
-#: ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:430
 msgid "&Finish"
 msgstr "&Amaitu"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:156
 msgid "&First"
 msgstr "&Lehena"
 
@@ -368,15 +396,15 @@ msgstr "&Lehena"
 msgid "&Floating mode:"
 msgstr "&Gain modua:"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "&Floppy"
 msgstr "&Nasai"
 
-#: ../src/common/stockitem.cpp:194
+#: ../src/common/stockitem.cpp:191
 msgid "&Font"
 msgstr "&Hizkia"
 
-#: ../src/generic/fontdlgg.cpp:371
+#: ../src/generic/fontdlgg.cpp:367
 msgid "&Font family:"
 msgstr "&Hizki sendia:"
 
@@ -384,20 +412,20 @@ msgstr "&Hizki sendia:"
 msgid "&Font for Level..."
 msgstr "&Hizkia Mailarako..."
 
+#: ../src/richtext/richtextsymboldlg.cpp:397
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:400
 msgid "&Font:"
 msgstr "&Hizkia:"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "&Forward"
 msgstr "&Aurrera"
 
-#: ../src/richtext/richtextsymboldlg.cpp:451
+#: ../src/richtext/richtextsymboldlg.cpp:448
 msgid "&From:"
 msgstr "&Hemendik:"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "&Harddisk"
 msgstr "&Diska gogorra"
 
@@ -406,9 +434,9 @@ msgstr "&Diska gogorra"
 msgid "&Height:"
 msgstr "&Garaiera:"
 
-#: ../src/generic/wizard.cpp:441 ../src/richtext/richtextstyledlg.cpp:303
-#: ../src/richtext/richtextsymboldlg.cpp:479 ../src/osx/menu_osx.cpp:734
-#: ../src/common/stockitem.cpp:163
+#: ../src/common/stockitem.cpp:160 ../src/generic/wizard.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextstyledlg.cpp:299 ../src/osx/cocoa/menu.mm:226
 msgid "&Help"
 msgstr "&Laguntza"
 
@@ -416,7 +444,7 @@ msgstr "&Laguntza"
 msgid "&Hide details"
 msgstr "E&zkutatu xehetasunak"
 
-#: ../src/common/stockitem.cpp:164
+#: ../src/common/stockitem.cpp:161
 msgid "&Home"
 msgstr "&Hasiera"
 
@@ -424,54 +452,54 @@ msgstr "&Hasiera"
 msgid "&Horizontal offset:"
 msgstr "&Etzeneko oreka:"
 
-#: ../src/richtext/richtextindentspage.cpp:184
 #: ../src/richtext/richtextliststylepage.cpp:372
+#: ../src/richtext/richtextindentspage.cpp:184
 msgid "&Indentation (tenths of a mm)"
 msgstr "&Nortasuna (mm hamarrena)"
 
-#: ../src/richtext/richtextindentspage.cpp:167
 #: ../src/richtext/richtextliststylepage.cpp:356
+#: ../src/richtext/richtextindentspage.cpp:167
 msgid "&Indeterminate"
 msgstr "&Zehaztugabea"
 
-#: ../src/common/stockitem.cpp:166
+#: ../src/common/stockitem.cpp:163
 msgid "&Index"
 msgstr "&Aurkibidea"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "&Info"
 msgstr "&Argibideak"
 
-#: ../src/common/stockitem.cpp:168
+#: ../src/common/stockitem.cpp:165
 msgid "&Italic"
 msgstr "&Etzana"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "&Jump to"
 msgstr "&Jauzi hona"
 
-#: ../src/richtext/richtextindentspage.cpp:153
 #: ../src/richtext/richtextliststylepage.cpp:342
+#: ../src/richtext/richtextindentspage.cpp:153
 msgid "&Justified"
 msgstr "&Berdinduta"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "&Last"
 msgstr "&Azkena"
 
-#: ../src/richtext/richtextindentspage.cpp:139
 #: ../src/richtext/richtextliststylepage.cpp:328
+#: ../src/richtext/richtextindentspage.cpp:139
 msgid "&Left"
 msgstr "&Ezkerra"
 
-#: ../src/richtext/richtextindentspage.cpp:195
+#: ../src/richtext/richtextsizepage.cpp:532
+#: ../src/richtext/richtextsizepage.cpp:539
 #: ../src/richtext/richtextborderspage.cpp:243
 #: ../src/richtext/richtextborderspage.cpp:411
 #: ../src/richtext/richtextliststylepage.cpp:381
+#: ../src/richtext/richtextindentspage.cpp:195
 #: ../src/richtext/richtextmarginspage.cpp:186
 #: ../src/richtext/richtextmarginspage.cpp:300
-#: ../src/richtext/richtextsizepage.cpp:532
-#: ../src/richtext/richtextsizepage.cpp:539
 msgid "&Left:"
 msgstr "&Ezkerra:"
 
@@ -479,11 +507,11 @@ msgstr "&Ezkerra:"
 msgid "&List level:"
 msgstr "&Zerrenda maila:"
 
-#: ../src/generic/logg.cpp:517
+#: ../src/generic/logg.cpp:514
 msgid "&Log"
 msgstr "&Oharra"
 
-#: ../src/univ/themes/win32.cpp:3748
+#: ../src/univ/themes/win32.cpp:3745
 msgid "&Move"
 msgstr "&Mugitu"
 
@@ -491,20 +519,19 @@ msgstr "&Mugitu"
 msgid "&Move the object to:"
 msgstr "&Mugitu objetua hona:"
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "&Network"
 msgstr "&Sarea"
 
-#: ../src/richtext/richtexttabspage.cpp:132 ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173 ../src/richtext/richtexttabspage.cpp:132
 msgid "&New"
 msgstr "Berria"
 
-#: ../src/aui/tabmdi.cpp:111 ../src/generic/mdig.cpp:100
-#: ../src/msw/mdi.cpp:180
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
 msgid "&Next"
 msgstr "&Hurrengoa"
 
-#: ../src/generic/wizard.cpp:432 ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:429
 msgid "&Next >"
 msgstr "&Hurrengoa >"
 
@@ -512,7 +539,7 @@ msgstr "&Hurrengoa >"
 msgid "&Next Paragraph"
 msgstr "&Hurrengo Esaldia"
 
-#: ../src/generic/tipdlg.cpp:240
+#: ../src/generic/tipdlg.cpp:237
 msgid "&Next Tip"
 msgstr "&Hurrengo Idatzia"
 
@@ -520,11 +547,11 @@ msgstr "&Hurrengo Idatzia"
 msgid "&Next style:"
 msgstr "&Hurrengo estiloa:"
 
-#: ../src/common/stockitem.cpp:177 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:174 ../src/msw/msgdlg.cpp:435
 msgid "&No"
 msgstr "&Ez"
 
-#: ../src/generic/dbgrptg.cpp:356
+#: ../src/generic/dbgrptg.cpp:360
 msgid "&Notes:"
 msgstr "&Oharrak:"
 
@@ -532,12 +559,12 @@ msgstr "&Oharrak:"
 msgid "&Number:"
 msgstr "&Zenbakia:"
 
-#: ../src/generic/fontdlgg.cpp:475 ../src/generic/fontdlgg.cpp:482
-#: ../src/osx/carbon/fontdlg.cpp:408 ../src/common/stockitem.cpp:178
+#: ../src/osx/carbon/fontdlg.cpp:405 ../src/common/stockitem.cpp:175
+#: ../src/generic/fontdlgg.cpp:471 ../src/generic/fontdlgg.cpp:478
 msgid "&OK"
 msgstr "&Ongi"
 
-#: ../src/generic/dbgrptg.cpp:342 ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176 ../src/generic/dbgrptg.cpp:342
 msgid "&Open..."
 msgstr "&Ireki..."
 
@@ -549,16 +576,16 @@ msgstr "&Inguru maila:"
 msgid "&Page Break"
 msgstr "&Orrialde Haustea"
 
-#: ../src/richtext/richtextctrl.cpp:334 ../src/osx/textctrl_osx.cpp:578
-#: ../src/common/stockitem.cpp:180 ../src/msw/textctrl.cpp:2509
+#: ../src/osx/textctrl_osx.cpp:596 ../src/common/stockitem.cpp:177
+#: ../src/msw/textctrl.cpp:2774 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&Itsatsi"
 
-#: ../include/wx/richtext/richtextbuffer.h:5010
+#: ../include/wx/richtext/richtextbuffer.h:5005
 msgid "&Picture"
 msgstr "&Irudia"
 
-#: ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:419
 msgid "&Point size:"
 msgstr "&Puntu neurria:"
 
@@ -570,12 +597,11 @@ msgstr "&Kokapena (mm hamarrenak):"
 msgid "&Position mode:"
 msgstr "&Kokapen modua:"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178
 msgid "&Preferences"
 msgstr "&Hobespenak"
 
-#: ../src/aui/tabmdi.cpp:112 ../src/generic/mdig.cpp:101
-#: ../src/msw/mdi.cpp:181
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
 msgid "&Previous"
 msgstr "&Aurrekoa"
 
@@ -583,78 +609,74 @@ msgstr "&Aurrekoa"
 msgid "&Previous Paragraph"
 msgstr "A&urreko Esaldia"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "&Print..."
 msgstr "&Irarkitu..."
 
-#: ../src/richtext/richtextctrl.cpp:339 ../src/richtext/richtextctrl.cpp:5514
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtextctrl.cpp:338
+#: ../src/richtext/richtextctrl.cpp:5512
 msgid "&Properties"
 msgstr "&Ezaugarriak"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "&Quit"
 msgstr "&Utzi"
 
-#: ../src/richtext/richtextctrl.cpp:330 ../src/osx/textctrl_osx.cpp:574
-#: ../src/common/stockitem.cpp:185 ../src/common/cmdproc.cpp:293
-#: ../src/common/cmdproc.cpp:300 ../src/msw/textctrl.cpp:2505
+#: ../src/osx/textctrl_osx.cpp:592 ../src/common/stockitem.cpp:182
+#: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
+#: ../src/msw/textctrl.cpp:2770 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Berregin"
 
-#: ../src/common/cmdproc.cpp:289 ../src/common/cmdproc.cpp:309
+#: ../src/common/cmdproc.cpp:282 ../src/common/cmdproc.cpp:302
 msgid "&Redo "
 msgstr "&Berregin"
 
-#: ../src/richtext/richtextstyledlg.cpp:257
+#: ../src/richtext/richtextstyledlg.cpp:253
 msgid "&Rename Style..."
 msgstr "&Berrizendatu Estiloa..."
 
-#: ../src/generic/fdrepdlg.cpp:179
+#: ../src/generic/fdrepdlg.cpp:176
 msgid "&Replace"
 msgstr "&Ordeztu"
 
-#: ../src/richtext/richtextstyledlg.cpp:287
+#: ../src/richtext/richtextstyledlg.cpp:283
 msgid "&Restart numbering"
 msgstr "&Berrabiarazi zenbakiketa"
 
-#: ../src/univ/themes/win32.cpp:3747
+#: ../src/univ/themes/win32.cpp:3744
 msgid "&Restore"
 msgstr "&Berrezarri"
 
-#: ../src/richtext/richtextindentspage.cpp:146
 #: ../src/richtext/richtextliststylepage.cpp:335
+#: ../src/richtext/richtextindentspage.cpp:146
 msgid "&Right"
 msgstr "&Eskuina"
 
-#: ../src/richtext/richtextindentspage.cpp:213
+#: ../src/richtext/richtextsizepage.cpp:602
+#: ../src/richtext/richtextsizepage.cpp:609
 #: ../src/richtext/richtextborderspage.cpp:277
 #: ../src/richtext/richtextborderspage.cpp:445
 #: ../src/richtext/richtextliststylepage.cpp:399
+#: ../src/richtext/richtextindentspage.cpp:213
 #: ../src/richtext/richtextmarginspage.cpp:211
 #: ../src/richtext/richtextmarginspage.cpp:325
-#: ../src/richtext/richtextsizepage.cpp:602
-#: ../src/richtext/richtextsizepage.cpp:609
 msgid "&Right:"
 msgstr "&Eskuina:"
 
-#: ../src/common/stockitem.cpp:190
+#: ../src/common/stockitem.cpp:187
 msgid "&Save"
 msgstr "&Gorde"
-
-#: ../src/common/stockitem.cpp:191
-msgid "&Save as"
-msgstr "&Gorde honela"
 
 #: ../include/wx/richmsgdlg.h:29
 msgid "&See details"
 msgstr "&Ikusi xehetasunak"
 
-#: ../src/generic/tipdlg.cpp:236
+#: ../src/generic/tipdlg.cpp:233
 msgid "&Show tips at startup"
 msgstr "&Erakutsi idaztziak hasterakoan"
 
-#: ../src/univ/themes/win32.cpp:3750
+#: ../src/univ/themes/win32.cpp:3747
 msgid "&Size"
 msgstr "&Neurria"
 
@@ -662,36 +684,36 @@ msgstr "&Neurria"
 msgid "&Size:"
 msgstr "&Neurria:"
 
-#: ../src/generic/progdlgg.cpp:252
+#: ../src/generic/progdlgg.cpp:249
 msgid "&Skip"
 msgstr "&Ahaztu"
 
-#: ../src/richtext/richtextindentspage.cpp:242
 #: ../src/richtext/richtextliststylepage.cpp:417
+#: ../src/richtext/richtextindentspage.cpp:242
 msgid "&Spacing (tenths of a mm)"
 msgstr "&Tartekatzen (mm hamarrenak)"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "&Spell Check"
 msgstr "&Idaz Egiaztapena"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "&Stop"
 msgstr "&Gelditu"
 
-#: ../src/richtext/richtextfontpage.cpp:275 ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196 ../src/richtext/richtextfontpage.cpp:275
 msgid "&Strikethrough"
 msgstr "&Tatxatuta"
 
-#: ../src/generic/fontdlgg.cpp:382 ../src/richtext/richtextstylepage.cpp:106
+#: ../src/generic/fontdlgg.cpp:378 ../src/richtext/richtextstylepage.cpp:106
 msgid "&Style:"
 msgstr "&Estiloa:"
 
-#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:194
 msgid "&Styles:"
 msgstr "&Estiloak:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:413
+#: ../src/richtext/richtextsymboldlg.cpp:410
 msgid "&Subset:"
 msgstr "&Azpiezarpena:"
 
@@ -705,24 +727,24 @@ msgstr "&Ikurra:"
 msgid "&Synchronize values"
 msgstr "&Aldiberetu balioak"
 
-#: ../include/wx/richtext/richtextbuffer.h:6069
+#: ../include/wx/richtext/richtextbuffer.h:6064
 msgid "&Table"
 msgstr "&Taula"
 
-#: ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197
 msgid "&Top"
 msgstr "&Goia"
 
+#: ../src/richtext/richtextsizepage.cpp:567
+#: ../src/richtext/richtextsizepage.cpp:574
 #: ../src/richtext/richtextborderspage.cpp:311
 #: ../src/richtext/richtextborderspage.cpp:479
 #: ../src/richtext/richtextmarginspage.cpp:234
 #: ../src/richtext/richtextmarginspage.cpp:348
-#: ../src/richtext/richtextsizepage.cpp:567
-#: ../src/richtext/richtextsizepage.cpp:574
 msgid "&Top:"
 msgstr "G&oian:"
 
-#: ../src/generic/fontdlgg.cpp:444 ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199 ../src/generic/fontdlgg.cpp:441
 msgid "&Underline"
 msgstr "&Azpimarratuta"
 
@@ -730,21 +752,21 @@ msgstr "&Azpimarratuta"
 msgid "&Underlining:"
 msgstr "&Azpimarraketa:"
 
-#: ../src/richtext/richtextctrl.cpp:329 ../src/osx/textctrl_osx.cpp:573
-#: ../src/common/stockitem.cpp:203 ../src/common/cmdproc.cpp:271
-#: ../src/msw/textctrl.cpp:2504
+#: ../src/osx/textctrl_osx.cpp:591 ../src/common/stockitem.cpp:200
+#: ../src/common/cmdproc.cpp:264 ../src/msw/textctrl.cpp:2769
+#: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Desegin"
 
-#: ../src/common/cmdproc.cpp:265
+#: ../src/common/cmdproc.cpp:258
 msgid "&Undo "
 msgstr "&Desegin"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "&Unindent"
 msgstr "&Elkarmarratxo gabe"
 
-#: ../src/common/stockitem.cpp:205
+#: ../src/common/stockitem.cpp:202
 msgid "&Up"
 msgstr "&Igo"
 
@@ -760,7 +782,7 @@ msgstr "Z&utikako oreka:"
 msgid "&View..."
 msgstr "&Ikusi..."
 
-#: ../src/generic/fontdlgg.cpp:393
+#: ../src/generic/fontdlgg.cpp:389
 msgid "&Weight:"
 msgstr "&Zabalera:"
 
@@ -769,88 +791,58 @@ msgstr "&Zabalera:"
 msgid "&Width:"
 msgstr "&Zabalera:"
 
-#: ../src/aui/tabmdi.cpp:311 ../src/aui/tabmdi.cpp:327
-#: ../src/aui/tabmdi.cpp:329 ../src/generic/mdig.cpp:294
-#: ../src/generic/mdig.cpp:310 ../src/generic/mdig.cpp:314
-#: ../src/msw/mdi.cpp:78
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
 msgid "&Window"
 msgstr "&Leihoa"
 
-#: ../src/common/stockitem.cpp:206 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:203 ../src/msw/msgdlg.cpp:435
 msgid "&Yes"
 msgstr "&Bai"
 
-#: ../src/common/valtext.cpp:256
-#, c-format
-msgid "'%s' contains illegal characters"
+#: ../src/common/valtext.cpp:197
+#, fuzzy, c-format
+msgid "'%s' contains invalid character(s)"
 msgstr "'%s' legezkanpoko hizkiak ditu"
 
-#: ../src/common/valtext.cpp:254
-#, c-format
-msgid "'%s' doesn't consist only of valid characters"
-msgstr "'%s' ez dago hizki baliogarriz osatuta bakarrik"
-
-#: ../src/common/config.cpp:519 ../src/msw/regconf.cpp:258
+#: ../src/common/config.cpp:515 ../src/msw/regconf.cpp:255
 #, c-format
 msgid "'%s' has extra '..', ignored."
 msgstr "'%s' estra '..', ezikusita."
 
-#: ../src/common/cmdline.cpp:1113 ../src/common/cmdline.cpp:1131
+#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' ez da zenbaki balio zuzena '%s' aukerarako."
 
-#: ../src/common/translation.cpp:1100
+#: ../src/common/translation.cpp:1142
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' ez da mezu katalogo baliozkoa."
 
-#: ../src/common/valtext.cpp:165
+#: ../src/common/valtext.cpp:188
 #, c-format
 msgid "'%s' is not one of the valid strings"
 msgstr "'%s' ez da kate baliogarrietako bat"
 
-#: ../src/common/valtext.cpp:167
+#: ../src/common/valtext.cpp:186
 #, c-format
 msgid "'%s' is one of the invalid strings"
 msgstr "'%s' kate baliogabeetako bat da"
 
-#: ../src/common/textbuf.cpp:237
+#: ../src/common/textbuf.cpp:233
 #, c-format
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' zihurrenik buffer binario bat da."
-
-#: ../src/common/valtext.cpp:252
-#, c-format
-msgid "'%s' should be numeric."
-msgstr "'%s' zenbakizkoa izan behar du."
-
-#: ../src/common/valtext.cpp:244
-#, c-format
-msgid "'%s' should only contain ASCII characters."
-msgstr "'%s' ASCII hizkiak bakarrik izan behar ditu."
-
-#: ../src/common/valtext.cpp:246
-#, c-format
-msgid "'%s' should only contain alphabetic characters."
-msgstr "'%s' alfabetoko hizkiak bakarrik izan behar ditu."
-
-#: ../src/common/valtext.cpp:248
-#, c-format
-msgid "'%s' should only contain alphabetic or numeric characters."
-msgstr "'%s' alfabetoko edo zenbakizko hizkiak bakarrik izan behar ditu."
-
-#: ../src/common/valtext.cpp:250
-#, c-format
-msgid "'%s' should only contain digits."
-msgstr "'%s' zenbakiak bakarrik izan behar ditu."
 
 #: ../src/richtext/richtextliststylepage.cpp:229
 #: ../src/richtext/richtextbulletspage.cpp:166
 msgid "(*)"
 msgstr "(*)"
 
-#: ../src/html/helpwnd.cpp:963
+#: ../src/html/helpwnd.cpp:961
 msgid "(Help)"
 msgstr "(Laguntza)"
 
@@ -859,27 +851,32 @@ msgstr "(Laguntza)"
 msgid "(None)"
 msgstr "(Bat ere ez)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:504
+#: ../src/richtext/richtextsymboldlg.cpp:503
 msgid "(Normal text)"
 msgstr "(Idazki arrunta)"
 
-#: ../src/html/helpwnd.cpp:419 ../src/html/helpwnd.cpp:1106
-#: ../src/html/helpwnd.cpp:1742
+#: ../src/html/helpwnd.cpp:417 ../src/html/helpwnd.cpp:1104
+#: ../src/html/helpwnd.cpp:1740
 msgid "(bookmarks)"
 msgstr "(lastermarkak)"
 
+#: ../src/msw/dlmsw.cpp:167
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (%ld akatsa: %s)"
+
+#: ../src/richtext/richtextformatdlg.cpp:876
+#: ../src/richtext/richtextliststylepage.cpp:448
+#: ../src/richtext/richtextliststylepage.cpp:460
+#: ../src/richtext/richtextliststylepage.cpp:461
 #: ../src/richtext/richtextindentspage.cpp:274
 #: ../src/richtext/richtextindentspage.cpp:286
 #: ../src/richtext/richtextindentspage.cpp:287
 #: ../src/richtext/richtextindentspage.cpp:311
 #: ../src/richtext/richtextindentspage.cpp:326
-#: ../src/richtext/richtextformatdlg.cpp:884
 #: ../src/richtext/richtextfontpage.cpp:349
 #: ../src/richtext/richtextfontpage.cpp:353
 #: ../src/richtext/richtextfontpage.cpp:357
-#: ../src/richtext/richtextliststylepage.cpp:448
-#: ../src/richtext/richtextliststylepage.cpp:460
-#: ../src/richtext/richtextliststylepage.cpp:461
 msgid "(none)"
 msgstr "(bat ere ez)"
 
@@ -898,7 +895,7 @@ msgstr "*)"
 msgid "+"
 msgstr "+"
 
-#: ../src/msw/utils.cpp:1152
+#: ../src/msw/utils.cpp:1143
 msgid ", 64-bit edition"
 msgstr ", 64-bit edizioa"
 
@@ -907,163 +904,163 @@ msgstr ", 64-bit edizioa"
 msgid "-"
 msgstr "-"
 
-#: ../src/generic/filepickerg.cpp:66
+#: ../src/generic/filepickerg.cpp:63
 msgid "..."
 msgstr "..."
 
-#: ../src/richtext/richtextindentspage.cpp:276
 #: ../src/richtext/richtextliststylepage.cpp:450
+#: ../src/richtext/richtextindentspage.cpp:276
 msgid "1.1"
 msgstr "1.1"
 
-#: ../src/richtext/richtextindentspage.cpp:277
 #: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextindentspage.cpp:277
 msgid "1.2"
 msgstr "1.2"
 
-#: ../src/richtext/richtextindentspage.cpp:278
 #: ../src/richtext/richtextliststylepage.cpp:452
+#: ../src/richtext/richtextindentspage.cpp:278
 msgid "1.3"
 msgstr "1.3"
 
-#: ../src/richtext/richtextindentspage.cpp:279
 #: ../src/richtext/richtextliststylepage.cpp:453
+#: ../src/richtext/richtextindentspage.cpp:279
 msgid "1.4"
 msgstr "1.4"
 
-#: ../src/richtext/richtextindentspage.cpp:280
 #: ../src/richtext/richtextliststylepage.cpp:454
+#: ../src/richtext/richtextindentspage.cpp:280
 msgid "1.5"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:281
 #: ../src/richtext/richtextliststylepage.cpp:455
+#: ../src/richtext/richtextindentspage.cpp:281
 msgid "1.6"
 msgstr "1.6"
 
-#: ../src/richtext/richtextindentspage.cpp:282
 #: ../src/richtext/richtextliststylepage.cpp:456
+#: ../src/richtext/richtextindentspage.cpp:282
 msgid "1.7"
 msgstr "1.7"
 
-#: ../src/richtext/richtextindentspage.cpp:283
 #: ../src/richtext/richtextliststylepage.cpp:457
+#: ../src/richtext/richtextindentspage.cpp:283
 msgid "1.8"
 msgstr "1.8"
 
-#: ../src/richtext/richtextindentspage.cpp:284
 #: ../src/richtext/richtextliststylepage.cpp:458
+#: ../src/richtext/richtextindentspage.cpp:284
 msgid "1.9"
 msgstr "1.9"
 
-#: ../src/common/paper.cpp:140
+#: ../src/common/paper.cpp:137
 msgid "10 x 11 in"
 msgstr "10 x 11 in"
 
-#: ../src/common/paper.cpp:113
+#: ../src/common/paper.cpp:110
 msgid "10 x 14 in"
 msgstr "10 x 14 in"
 
-#: ../src/common/paper.cpp:114
+#: ../src/common/paper.cpp:111
 msgid "11 x 17 in"
 msgstr "11 x 17 in"
 
-#: ../src/common/paper.cpp:184
+#: ../src/common/paper.cpp:181
 msgid "12 x 11 in"
 msgstr "12 x 11 in"
 
-#: ../src/common/paper.cpp:141
+#: ../src/common/paper.cpp:138
 msgid "15 x 11 in"
 msgstr "15 x 11 in"
 
-#: ../src/richtext/richtextindentspage.cpp:285
 #: ../src/richtext/richtextliststylepage.cpp:459
+#: ../src/richtext/richtextindentspage.cpp:285
 msgid "2"
 msgstr "2"
 
-#: ../src/common/paper.cpp:132
+#: ../src/common/paper.cpp:129
 msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
 msgstr "6 3/4 Gutunazala, 3 5/8 x 6 1/2 in"
 
-#: ../src/common/paper.cpp:139
+#: ../src/common/paper.cpp:136
 msgid "9 x 11 in"
 msgstr "9 x 11 in"
 
-#: ../src/html/htmprint.cpp:431
+#: ../src/html/htmprint.cpp:443
 msgid ": file does not exist!"
 msgstr ": agiria ez dago!"
 
-#: ../src/common/fontmap.cpp:199
+#: ../src/common/fontmap.cpp:196
 msgid ": unknown charset"
 msgstr ": hizki-kode ezezaguna"
 
-#: ../src/common/fontmap.cpp:413
+#: ../src/common/fontmap.cpp:410
 msgid ": unknown encoding"
 msgstr ": kodeaketa ezezaguna"
 
-#: ../src/generic/wizard.cpp:443
+#: ../src/generic/wizard.cpp:438
 msgid "< &Back"
 msgstr "< &Atzera"
 
-#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:628
-#: ../src/osx/carbon/fontdlg.cpp:648
+#: ../src/osx/carbon/fontdlg.cpp:419 ../src/osx/carbon/fontdlg.cpp:625
+#: ../src/osx/carbon/fontdlg.cpp:645
 msgid "<Any Decorative>"
 msgstr "<Edozein Apaingarria>"
 
-#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:630
-#: ../src/osx/carbon/fontdlg.cpp:650
+#: ../src/osx/carbon/fontdlg.cpp:420 ../src/osx/carbon/fontdlg.cpp:627
+#: ../src/osx/carbon/fontdlg.cpp:647
 msgid "<Any Modern>"
 msgstr "<Edozein Modernoa>"
 
-#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:626
-#: ../src/osx/carbon/fontdlg.cpp:646
+#: ../src/osx/carbon/fontdlg.cpp:418 ../src/osx/carbon/fontdlg.cpp:623
+#: ../src/osx/carbon/fontdlg.cpp:643
 msgid "<Any Roman>"
 msgstr "<Edozein Erromatar>"
 
-#: ../src/osx/carbon/fontdlg.cpp:424 ../src/osx/carbon/fontdlg.cpp:632
-#: ../src/osx/carbon/fontdlg.cpp:652
+#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:629
+#: ../src/osx/carbon/fontdlg.cpp:649
 msgid "<Any Script>"
 msgstr "<Eskripten bat>"
 
-#: ../src/osx/carbon/fontdlg.cpp:425 ../src/osx/carbon/fontdlg.cpp:637
-#: ../src/osx/carbon/fontdlg.cpp:656
+#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:634
+#: ../src/osx/carbon/fontdlg.cpp:653
 msgid "<Any Swiss>"
 msgstr "<Edozein Suitzar>"
 
-#: ../src/osx/carbon/fontdlg.cpp:426 ../src/osx/carbon/fontdlg.cpp:634
-#: ../src/osx/carbon/fontdlg.cpp:654
+#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:631
+#: ../src/osx/carbon/fontdlg.cpp:651
 msgid "<Any Teletype>"
 msgstr "<Teletiporen bat>"
 
-#: ../src/osx/carbon/fontdlg.cpp:420
+#: ../src/osx/carbon/fontdlg.cpp:417
 msgid "<Any>"
 msgstr "<Edozein>"
 
-#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
 msgid "<DIR>"
 msgstr "<ZUZ>"
 
-#: ../src/generic/filectrlg.cpp:254 ../src/generic/filectrlg.cpp:277
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
 msgid "<DRIVE>"
 msgstr "<GIDAG.>"
 
-#: ../src/generic/filectrlg.cpp:252 ../src/generic/filectrlg.cpp:275
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
 msgid "<LINK>"
 msgstr "<LOTURA>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1264
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Alde etzan lodia.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1270
+#: ../src/html/helpwnd.cpp:1268
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>lodi etzana <u>azpimarratuta</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1265
+#: ../src/html/helpwnd.cpp:1263
 msgid "<b>Bold face.</b> "
 msgstr "<b>Alde lodia..</b> "
 
-#: ../src/html/helpwnd.cpp:1264
+#: ../src/html/helpwnd.cpp:1262
 msgid "<i>Italic face.</i> "
 msgstr "<i>Alde etzana.</i> "
 
@@ -1072,15 +1069,15 @@ msgstr "<i>Alde etzana.</i> "
 msgid ">"
 msgstr ">"
 
-#: ../src/generic/dbgrptg.cpp:318
+#: ../src/generic/dbgrptg.cpp:317
 msgid "A debug report has been generated in the directory\n"
 msgstr "Garbiketa jakinarazpena zuzenbidean sortu da\n"
 
-#: ../src/common/debugrpt.cpp:573
+#: ../src/common/debugrpt.cpp:574
 msgid "A debug report has been generated. It can be found in"
 msgstr "Garbiketa jakinarazpena sortu da. Aurkitu daiteke hemen"
 
-#: ../src/common/xtixml.cpp:418
+#: ../src/common/xtixml.cpp:414
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Bilduma ez hutsa 'elementu' elkarguneak izan behar da"
 
@@ -1091,106 +1088,106 @@ msgstr "Bilduma ez hutsa 'elementu' elkarguneak izan behar da"
 msgid "A standard bullet name."
 msgstr "Buleta izen estandarra."
 
-#: ../src/common/paper.cpp:217
+#: ../src/common/paper.cpp:214
 msgid "A0 sheet, 841 x 1189 mm"
 msgstr "A0 orria, 841 x 1189 mm"
 
-#: ../src/common/paper.cpp:218
+#: ../src/common/paper.cpp:215
 msgid "A1 sheet, 594 x 841 mm"
 msgstr "A1 orria, 594 x 841 mm"
 
-#: ../src/common/paper.cpp:159
+#: ../src/common/paper.cpp:156
 msgid "A2 420 x 594 mm"
 msgstr "A2 420 x 594 mm"
 
-#: ../src/common/paper.cpp:156
+#: ../src/common/paper.cpp:153
 msgid "A3 Extra 322 x 445 mm"
 msgstr "A3 Estra 322 x 445 mm"
 
-#: ../src/common/paper.cpp:161
+#: ../src/common/paper.cpp:158
 msgid "A3 Extra Transverse 322 x 445 mm"
 msgstr "A3 Estra Zeharka 322 x 445 mm"
 
-#: ../src/common/paper.cpp:170
+#: ../src/common/paper.cpp:167
 msgid "A3 Rotated 420 x 297 mm"
 msgstr "A3 Itzulita 420 x 297 mm"
 
-#: ../src/common/paper.cpp:160
+#: ../src/common/paper.cpp:157
 msgid "A3 Transverse 297 x 420 mm"
 msgstr "A3 Zeharka 297 x 420 mm"
 
-#: ../src/common/paper.cpp:106
+#: ../src/common/paper.cpp:103
 msgid "A3 sheet, 297 x 420 mm"
 msgstr "A3 orria, 297 x 420 mm"
 
-#: ../src/common/paper.cpp:146
+#: ../src/common/paper.cpp:143
 msgid "A4 Extra 9.27 x 12.69 in"
 msgstr "A4 Estra 9.27 x 12.69 in"
 
-#: ../src/common/paper.cpp:153
+#: ../src/common/paper.cpp:150
 msgid "A4 Plus 210 x 330 mm"
 msgstr "A4 Plus 210 x 330 mm"
 
-#: ../src/common/paper.cpp:171
+#: ../src/common/paper.cpp:168
 msgid "A4 Rotated 297 x 210 mm"
 msgstr "A4 Itzulita 297 x 210 mm"
 
-#: ../src/common/paper.cpp:148
+#: ../src/common/paper.cpp:145
 msgid "A4 Transverse 210 x 297 mm"
 msgstr "A4 Zeharka 210 x 297 mm"
 
-#: ../src/common/paper.cpp:97
+#: ../src/common/paper.cpp:94
 msgid "A4 sheet, 210 x 297 mm"
 msgstr "A4 orria, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:107
+#: ../src/common/paper.cpp:104
 msgid "A4 small sheet, 210 x 297 mm"
 msgstr "A4 orri txikia, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:157
+#: ../src/common/paper.cpp:154
 msgid "A5 Extra 174 x 235 mm"
 msgstr "A5 Estra 174 x 235 mm"
 
-#: ../src/common/paper.cpp:172
+#: ../src/common/paper.cpp:169
 msgid "A5 Rotated 210 x 148 mm"
 msgstr "A5 Itzulita 210 x 148 mm"
 
-#: ../src/common/paper.cpp:154
+#: ../src/common/paper.cpp:151
 msgid "A5 Transverse 148 x 210 mm"
 msgstr "A5 Zeharka 148 x 210 mm"
 
-#: ../src/common/paper.cpp:108
+#: ../src/common/paper.cpp:105
 msgid "A5 sheet, 148 x 210 mm"
 msgstr "A5 orria, 148 x 210 mm"
 
-#: ../src/common/paper.cpp:164
+#: ../src/common/paper.cpp:161
 msgid "A6 105 x 148 mm"
 msgstr "A6 105 x 148 mm"
 
-#: ../src/common/paper.cpp:177
+#: ../src/common/paper.cpp:174
 msgid "A6 Rotated 148 x 105 mm"
 msgstr "A6 Itzulita 148 x 105 mm"
 
-#: ../src/generic/fontdlgg.cpp:83 ../src/richtext/richtextformatdlg.cpp:529
-#: ../src/osx/carbon/fontdlg.cpp:153
+#: ../src/osx/carbon/fontdlg.cpp:150 ../src/generic/fontdlgg.cpp:79
+#: ../src/richtext/richtextformatdlg.cpp:521
 msgid "ABCDEFGabcdefg12345"
 msgstr "ABCDEFGabcdefg12345"
 
-#: ../src/richtext/richtextsymboldlg.cpp:458 ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
 msgid "ASCII"
 msgstr "ASCII"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "About"
 msgstr "Honi buruz"
 
-#: ../src/generic/aboutdlgg.cpp:140 ../src/osx/menu_osx.cpp:558
-#: ../src/msw/aboutdlg.cpp:64
+#: ../src/osx/menu_osx.cpp:450 ../src/generic/aboutdlgg.cpp:137
+#: ../src/msw/aboutdlg.cpp:61
 #, c-format
 msgid "About %s"
 msgstr "%s-ri buruz"
 
-#: ../src/osx/menu_osx.cpp:560
+#: ../src/osx/menu_osx.cpp:452
 msgid "About..."
 msgstr "Honi buruz..."
 
@@ -1199,37 +1196,37 @@ msgid "Absolute"
 msgstr "Osoa"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:873
+#: ../src/propgrid/advprops.cpp:774
 msgid "ActiveBorder"
 msgstr "Hertza-Gaituta"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:874
+#: ../src/propgrid/advprops.cpp:775
 msgid "ActiveCaption"
 msgstr "Harpena-Gaituta"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "Actual Size"
 msgstr "Oraingo Neurria"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:140 ../src/common/accelcmn.cpp:81
+#: ../src/common/stockitem.cpp:137 ../src/common/accelcmn.cpp:78
 msgid "Add"
 msgstr "Gehitu"
 
-#: ../src/richtext/richtextbuffer.cpp:11455
+#: ../src/richtext/richtextbuffer.cpp:11454
 msgid "Add Column"
 msgstr "Gehitu Zutabea"
 
-#: ../src/richtext/richtextbuffer.cpp:11392
+#: ../src/richtext/richtextbuffer.cpp:11391
 msgid "Add Row"
 msgstr "Gehitu Lerroa"
 
-#: ../src/html/helpwnd.cpp:432
+#: ../src/html/helpwnd.cpp:430
 msgid "Add current page to bookmarks"
 msgstr "Gehitu oraingo orrialdea lastermarketara"
 
-#: ../src/generic/colrdlgg.cpp:366
+#: ../src/generic/colrdlgg.cpp:386
 msgid "Add to custom colours"
 msgstr "Gehitu egile margoetara"
 
@@ -1241,12 +1238,12 @@ msgstr "AddToPropertyCollection deituta sarbideratzaile generiko batean"
 msgid "AddToPropertyCollection called w/o valid adder"
 msgstr "AddToPropertyCollection w/o baliozko gehitzailea deituta"
 
-#: ../src/html/helpctrl.cpp:159
+#: ../src/html/helpctrl.cpp:155
 #, c-format
 msgid "Adding book %s"
 msgstr "%s liburua gehitzen"
 
-#: ../src/common/preferencescmn.cpp:43
+#: ../src/common/preferencescmn.cpp:40
 msgid "Advanced"
 msgstr "Aurreratua"
 
@@ -1254,11 +1251,11 @@ msgstr "Aurreratua"
 msgid "After a paragraph:"
 msgstr "Esaldi baten ondoren:"
 
-#: ../src/common/stockitem.cpp:172
+#: ../src/common/stockitem.cpp:169
 msgid "Align Left"
 msgstr "Lerrokatu Ezkerrera"
 
-#: ../src/common/stockitem.cpp:173
+#: ../src/common/stockitem.cpp:170
 msgid "Align Right"
 msgstr "Lerrokatu Eskuinera"
 
@@ -1266,40 +1263,40 @@ msgstr "Lerrokatu Eskuinera"
 msgid "Alignment"
 msgstr "Lerrokapena"
 
-#: ../src/generic/prntdlgg.cpp:215
+#: ../src/generic/prntdlgg.cpp:208
 msgid "All"
 msgstr "Denak"
 
-#: ../src/generic/filectrlg.cpp:1197 ../src/common/fldlgcmn.cpp:107
+#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1186
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Agiri denak (%s)|%s"
 
-#: ../include/wx/defs.h:2886
+#: ../include/wx/defs.h:2582
 msgid "All files (*)|*"
 msgstr "Agiri denak (*)|*"
 
-#: ../include/wx/defs.h:2883
+#: ../include/wx/defs.h:2579
 msgid "All files (*.*)|*.*"
 msgstr "Agiri denak (*.*)|*.*"
 
-#: ../src/richtext/richtextstyles.cpp:1061
+#: ../src/richtext/richtextstyles.cpp:1058
 msgid "All styles"
 msgstr "Estilo guztiak"
 
-#: ../src/propgrid/manager.cpp:1528
+#: ../src/propgrid/manager.cpp:1544
 msgid "Alphabetic Mode"
 msgstr "Alfabeto Moduan"
 
-#: ../src/common/xtistrm.cpp:425
+#: ../src/common/xtistrm.cpp:422
 msgid "Already Registered Object passed to SetObjectClassInfo"
 msgstr "Jadanik Erregistraturiko Objetua SetObjectClassInfo-ra pasatuta"
 
-#: ../src/unix/dialup.cpp:353
+#: ../src/unix/dialup.cpp:352
 msgid "Already dialling ISP."
 msgstr "Jadanik ISP-a deitzen."
 
-#: ../src/common/accelcmn.cpp:331 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/accelcmn.cpp:345 ../src/univ/themes/win32.cpp:3753
 msgid "Alt+"
 msgstr "Alt+"
 
@@ -1308,34 +1305,34 @@ msgstr "Alt+"
 msgid "An optional corner radius for adding rounded corners."
 msgstr "Aukerazko bazterreko erradio bat inguru bazterrak gehitzeko."
 
-#: ../src/common/debugrpt.cpp:576
+#: ../src/common/debugrpt.cpp:577
 msgid "And includes the following files:\n"
 msgstr "Eta hurrengo agiriak ditu:\n"
 
-#: ../src/generic/animateg.cpp:162
+#: ../src/generic/animateg.cpp:145
 #, c-format
 msgid "Animation file is not of type %ld."
 msgstr "Animazio agiria ez %ld motakoa."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:872
+#: ../src/propgrid/advprops.cpp:773
 msgid "AppWorkspace"
 msgstr "Aplik-Laningurua"
 
-#: ../src/generic/logg.cpp:1014
+#: ../src/generic/logg.cpp:1011
 #, c-format
 msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
 msgstr "Oharra eransten '%s' agiriari (hautatzen [Ez] gainidatziko da)? "
 
-#: ../src/osx/menu_osx.cpp:577 ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:469 ../src/osx/menu_osx.cpp:477
 msgid "Application"
 msgstr "Aplikazioa"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "Apply"
 msgstr "Ezarri"
 
-#: ../src/propgrid/advprops.cpp:1609
+#: ../src/propgrid/advprops.cpp:1515
 msgid "Aqua"
 msgstr "Ura"
 
@@ -1344,29 +1341,29 @@ msgstr "Ura"
 msgid "Arabic"
 msgstr "Arabiera"
 
-#: ../src/common/fmapbase.cpp:153
+#: ../src/common/fmapbase.cpp:150
 msgid "Arabic (ISO-8859-6)"
 msgstr "Arabiera (ISO-8859-6)"
 
-#: ../src/msw/ole/automtn.cpp:672
+#: ../src/msw/ole/automtn.cpp:663
 #, c-format
 msgid "Argument %u not found."
 msgstr "%u argumentoa ez da aurkitu."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1753
+#: ../src/propgrid/advprops.cpp:1654
 msgid "Arrow"
 msgstr "Gezia"
 
-#: ../src/generic/aboutdlgg.cpp:184
+#: ../src/generic/aboutdlgg.cpp:181
 msgid "Artists"
 msgstr "Artistak"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "Ascending"
 msgstr "Gorantz"
 
-#: ../src/generic/filectrlg.cpp:433
+#: ../src/generic/filectrlg.cpp:429
 msgid "Attributes"
 msgstr "Ezaugarriak"
 
@@ -1376,90 +1373,90 @@ msgstr "Ezaugarriak"
 msgid "Available fonts."
 msgstr "Hizki eskuragarriak."
 
-#: ../src/common/paper.cpp:137
+#: ../src/common/paper.cpp:134
 msgid "B4 (ISO) 250 x 353 mm"
 msgstr "B4 (ISO) 250 x 353 mm"
 
-#: ../src/common/paper.cpp:173
+#: ../src/common/paper.cpp:170
 msgid "B4 (JIS) Rotated 364 x 257 mm"
 msgstr "B4 (JIS) Itzulita 364 x 257 mm"
 
-#: ../src/common/paper.cpp:127
+#: ../src/common/paper.cpp:124
 msgid "B4 Envelope, 250 x 353 mm"
 msgstr "B4 Gutunazala, 250 x 353 mm"
 
-#: ../src/common/paper.cpp:109
+#: ../src/common/paper.cpp:106
 msgid "B4 sheet, 250 x 354 mm"
 msgstr "B4 orria, 250 x 354 mm"
 
-#: ../src/common/paper.cpp:158
+#: ../src/common/paper.cpp:155
 msgid "B5 (ISO) Extra 201 x 276 mm"
 msgstr "B5 (ISO) Estra 201 x 276 mm"
 
-#: ../src/common/paper.cpp:174
+#: ../src/common/paper.cpp:171
 msgid "B5 (JIS) Rotated 257 x 182 mm"
 msgstr "B5 (JIS) Itzulita 257 x 182 mm"
 
-#: ../src/common/paper.cpp:155
+#: ../src/common/paper.cpp:152
 msgid "B5 (JIS) Transverse 182 x 257 mm"
 msgstr "B5 (JIS) Zeharka 182 x 257 mm"
 
-#: ../src/common/paper.cpp:128
+#: ../src/common/paper.cpp:125
 msgid "B5 Envelope, 176 x 250 mm"
 msgstr "B5 Gutunazala, 176 x 250 mm"
 
-#: ../src/common/paper.cpp:110
+#: ../src/common/paper.cpp:107
 msgid "B5 sheet, 182 x 257 millimeter"
 msgstr "B5 orria, 182 x 257 metromilaen"
 
-#: ../src/common/paper.cpp:182
+#: ../src/common/paper.cpp:179
 msgid "B6 (JIS) 128 x 182 mm"
 msgstr "B6 (JIS) 128 x 182 mm"
 
-#: ../src/common/paper.cpp:183
+#: ../src/common/paper.cpp:180
 msgid "B6 (JIS) Rotated 182 x 128 mm"
 msgstr "B6 (JIS) Itzulita 182 x 128 mm"
 
-#: ../src/common/paper.cpp:129
+#: ../src/common/paper.cpp:126
 msgid "B6 Envelope, 176 x 125 mm"
 msgstr "B6 Gutunazala, 176 x 125 mm"
 
-#: ../src/common/imagbmp.cpp:531 ../src/common/imagbmp.cpp:561
-#: ../src/common/imagbmp.cpp:576
+#: ../src/common/imagbmp.cpp:528 ../src/common/imagbmp.cpp:558
+#: ../src/common/imagbmp.cpp:573
 msgid "BMP: Couldn't allocate memory."
 msgstr "BMP: Ezinezkoa oroimena esleitzea."
 
-#: ../src/common/imagbmp.cpp:100
+#: ../src/common/imagbmp.cpp:97
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: Ezinezkoa baliogabeko irudia gordetzea."
 
-#: ../src/common/imagbmp.cpp:356
+#: ../src/common/imagbmp.cpp:353
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: Ezinezkoa RGB margo mapa idaztea."
 
-#: ../src/common/imagbmp.cpp:490
+#: ../src/common/imagbmp.cpp:487
 msgid "BMP: Couldn't write data."
 msgstr "BMP: Ezinezkoa datuak idaztea."
 
-#: ../src/common/imagbmp.cpp:246
+#: ../src/common/imagbmp.cpp:243
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: Ezinezkoa agiri idazburua (Bitmapa) idaztea."
 
-#: ../src/common/imagbmp.cpp:269
+#: ../src/common/imagbmp.cpp:266
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: Ezinezkoa agiri idazburua (BitmapaArgib.) idaztea."
 
-#: ../src/common/imagbmp.cpp:140
+#: ../src/common/imagbmp.cpp:137
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImagek ez du ber wxPalette."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:142 ../src/common/accelcmn.cpp:52
+#: ../src/common/stockitem.cpp:139 ../src/common/accelcmn.cpp:49
 msgid "Back"
 msgstr "Atzera"
 
+#: ../src/richtext/richtextformatdlg.cpp:377
 #: ../src/richtext/richtextbackgroundpage.cpp:148
-#: ../src/richtext/richtextformatdlg.cpp:384
 msgid "Background"
 msgstr "Barrena"
 
@@ -1467,20 +1464,20 @@ msgstr "Barrena"
 msgid "Background &colour:"
 msgstr "Barren &margoa:"
 
-#: ../src/osx/carbon/fontdlg.cpp:220
+#: ../src/osx/carbon/fontdlg.cpp:217
 msgid "Background colour"
 msgstr "Barren margoa"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:52
+#: ../src/common/accelcmn.cpp:49
 msgid "Backspace"
 msgstr "Atzera"
 
-#: ../src/common/fmapbase.cpp:160
+#: ../src/common/fmapbase.cpp:157
 msgid "Baltic (ISO-8859-13)"
 msgstr "Baltikoa (ISO-8859-13)"
 
-#: ../src/common/fmapbase.cpp:151
+#: ../src/common/fmapbase.cpp:148
 msgid "Baltic (old) (ISO-8859-4)"
 msgstr "Baltikoa (old) (ISO-8859-4)"
 
@@ -1493,26 +1490,26 @@ msgstr "Esaldi baten aurretik:"
 msgid "Bitmap"
 msgstr "Bitmapa"
 
-#: ../src/propgrid/advprops.cpp:1594
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Black"
 msgstr "Beltza"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1755
+#: ../src/propgrid/advprops.cpp:1656
 msgid "Blank"
 msgstr "Hutsik"
 
-#: ../src/propgrid/advprops.cpp:1603
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Blue"
 msgstr "Urdina"
 
-#: ../src/generic/colrdlgg.cpp:345
+#: ../src/generic/colrdlgg.cpp:365
 #, fuzzy
 msgid "Blue:"
 msgstr "Urdina"
 
-#: ../src/generic/fontdlgg.cpp:333 ../src/richtext/richtextfontpage.cpp:355
-#: ../src/osx/carbon/fontdlg.cpp:354 ../src/common/stockitem.cpp:143
+#: ../src/osx/carbon/fontdlg.cpp:351 ../src/common/stockitem.cpp:140
+#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:355
 msgid "Bold"
 msgstr "Lodia"
 
@@ -1521,31 +1518,35 @@ msgstr "Lodia"
 msgid "Border"
 msgstr "Hertza"
 
-#: ../src/richtext/richtextformatdlg.cpp:379
+#: ../src/richtext/richtextformatdlg.cpp:372
 msgid "Borders"
 msgstr "Hertzak"
 
-#: ../src/richtext/richtextsizepage.cpp:288 ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141 ../src/richtext/richtextsizepage.cpp:288
 msgid "Bottom"
 msgstr "Behean"
 
-#: ../src/generic/prntdlgg.cpp:893
+#: ../src/generic/prntdlgg.cpp:886
 msgid "Bottom margin (mm):"
 msgstr "Beheko bazterra (mm):"
 
-#: ../src/richtext/richtextbuffer.cpp:9383
+#: ../src/richtext/richtextbuffer.cpp:9380
 msgid "Box Properties"
 msgstr "Kutxaren Ezaugarriak"
 
-#: ../src/richtext/richtextstyles.cpp:1065
+#: ../src/richtext/richtextstyles.cpp:1062
 msgid "Box styles"
 msgstr "Kutxaren estiloak"
 
-#: ../src/propgrid/advprops.cpp:1602
+#: ../src/osx/cocoa/menu.mm:292
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Brown"
 msgstr "Marroia"
 
-#: ../src/common/filepickercmn.cpp:43 ../src/common/filepickercmn.cpp:44
+#: ../src/common/filepickercmn.cpp:40 ../src/common/filepickercmn.cpp:41
 msgid "Browse"
 msgstr "Bilatu"
 
@@ -1558,72 +1559,72 @@ msgstr "Buleta &Lerrokapena:"
 msgid "Bullet style"
 msgstr "Buleta estiloa"
 
-#: ../src/richtext/richtextformatdlg.cpp:359
+#: ../src/richtext/richtextformatdlg.cpp:352
 msgid "Bullets"
 msgstr "Buletak"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1756
+#: ../src/propgrid/advprops.cpp:1657
 msgid "Bullseye"
 msgstr "Idibegia"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:875
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonFace"
 msgstr "Botoi-Aldea"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:876
+#: ../src/propgrid/advprops.cpp:777
 msgid "ButtonHighlight"
 msgstr "Botoi-Nabarmentzea"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:877
+#: ../src/propgrid/advprops.cpp:778
 msgid "ButtonShadow"
 msgstr "Botoi-Itzala"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:878
+#: ../src/propgrid/advprops.cpp:779
 msgid "ButtonText"
 msgstr "Botoi-Idazkia"
 
-#: ../src/common/paper.cpp:98
+#: ../src/common/paper.cpp:95
 msgid "C sheet, 17 x 22 in"
 msgstr "C orria, 17 x 22 in"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "C&lear"
 msgstr "&Garbitu"
 
-#: ../src/generic/fontdlgg.cpp:406
+#: ../src/generic/fontdlgg.cpp:403
 msgid "C&olour:"
 msgstr "&Margoa:"
 
-#: ../src/common/paper.cpp:123
+#: ../src/common/paper.cpp:120
 msgid "C3 Envelope, 324 x 458 mm"
 msgstr "C3 Gutunazala, 324 x 458 mm"
 
-#: ../src/common/paper.cpp:124
+#: ../src/common/paper.cpp:121
 msgid "C4 Envelope, 229 x 324 mm"
 msgstr "C4 Gutunazala, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:122
+#: ../src/common/paper.cpp:119
 msgid "C5 Envelope, 162 x 229 mm"
 msgstr "C5 Gutunazala, 162 x 229 mm"
 
-#: ../src/common/paper.cpp:125
+#: ../src/common/paper.cpp:122
 msgid "C6 Envelope, 114 x 162 mm"
 msgstr "C6 Gutunazala, 114 x 162 mm"
 
-#: ../src/common/paper.cpp:126
+#: ../src/common/paper.cpp:123
 msgid "C65 Envelope, 114 x 229 mm"
 msgstr "C65 Gutunazala, 114 x 229 mm"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "CD-Rom"
 msgstr "CD-Rom"
 
-#: ../src/html/chm.cpp:815 ../src/html/chm.cpp:874
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:865
 msgid "CHM handler currently supports only local files!"
 msgstr "CHM kudeatzaileak orain tokiko agiriak bakarrik sostengatzen ditu!"
 
@@ -1631,192 +1632,196 @@ msgstr "CHM kudeatzaileak orain tokiko agiriak bakarrik sostengatzen ditu!"
 msgid "Ca&pitals"
 msgstr "&Larriak"
 
-#: ../src/common/cmdproc.cpp:267
+#: ../src/common/cmdproc.cpp:260
 msgid "Can't &Undo "
 msgstr "Ezin da De&segin"
 
-#: ../src/common/image.cpp:2824
+#: ../src/common/image.cpp:2924
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 "Ezin da berezgaitasunez zehaztu irudi heuskarria sarrera ez-"
 "bilagarriarentzat."
 
-#: ../src/msw/registry.cpp:506
+#: ../src/msw/registry.cpp:495
 #, c-format
 msgid "Can't close registry key '%s'"
 msgstr "Ezin da '%s' erregistro giltza itxi"
 
-#: ../src/msw/registry.cpp:584
+#: ../src/msw/registry.cpp:573
 #, c-format
 msgid "Can't copy values of unsupported type %d."
 msgstr "Ezin dira %d hizkimota sostengatugabearen balioak kopiatu"
 
-#: ../src/msw/registry.cpp:487
+#: ../src/msw/registry.cpp:476
 #, c-format
 msgid "Can't create registry key '%s'"
 msgstr "Ezin da '%s' erregistro giltza sortu"
 
-#: ../src/msw/thread.cpp:665
+#: ../src/msw/thread.cpp:657
 msgid "Can't create thread"
 msgstr "Ezin da haria sortu"
 
-#: ../src/msw/window.cpp:3691
-#, c-format
-msgid "Can't create window of class %s"
-msgstr "Ezin da %s klasearen leihoa sortu"
-
-#: ../src/msw/registry.cpp:777
+#: ../src/msw/registry.cpp:765
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Ezin da '%s' giltza ezabatu"
 
-#: ../src/msw/iniconf.cpp:458
+#: ../src/msw/iniconf.cpp:455
 #, c-format
 msgid "Can't delete the INI file '%s'"
 msgstr "Ezin da '%s' INI agiria ezabatu"
 
-#: ../src/msw/registry.cpp:805
+#: ../src/msw/registry.cpp:793
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Ezin da '%s' balioa '%s' giltzatik ezabatu"
 
-#: ../src/msw/registry.cpp:1171
+#: ../src/msw/registry.cpp:1159
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Ezin '%s' gitzaren azpigiltzak zenbakitu"
 
-#: ../src/msw/registry.cpp:1132
+#: ../src/msw/registry.cpp:1120
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Ezin dira '%s' giltzaren balioak zenbakitu"
 
-#: ../src/msw/registry.cpp:1389
+#: ../src/msw/registry.cpp:1377
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Ezin da %d hizkimota sostengugabetik balioa esportatu."
 
-#: ../src/common/ffile.cpp:254
+#: ../src/common/ffile.cpp:253
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Ezin da aurkitu oraingo kokapena '%s' agirian"
 
-#: ../src/msw/registry.cpp:418
+#: ../src/msw/registry.cpp:407
 #, c-format
 msgid "Can't get info about registry key '%s'"
 msgstr "Ezin da lortu '%s' giltzari buruzko argibiderik"
 
-#: ../src/common/zstream.cpp:346
+#: ../src/msw/webview_ie.cpp:1024
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "Ezin da hari lehentasuna ezarri"
+
+#: ../src/common/zstream.cpp:343
 msgid "Can't initialize zlib deflate stream."
 msgstr "Ezin da zlib hustutako jarioa abiatu."
 
-#: ../src/common/zstream.cpp:185
+#: ../src/common/zstream.cpp:182
 msgid "Can't initialize zlib inflate stream."
 msgstr "Ezin da zlib puztutako jarioa abiatu."
 
-#: ../src/msw/fswatcher.cpp:476
+#: ../src/msw/fswatcher.cpp:475
 #, c-format
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "Ezin da monitorizatu ez-dagoen \"%s\" zuzenbidea aldaketetarako."
 
-#: ../src/msw/registry.cpp:454
+#: ../src/msw/registry.cpp:443
 #, c-format
 msgid "Can't open registry key '%s'"
 msgstr "Ezin da '%s' erregistro giltza ireki"
 
-#: ../src/common/zstream.cpp:252
+#: ../src/common/zstream.cpp:249
 #, c-format
 msgid "Can't read from inflate stream: %s"
 msgstr "Ezin da irakurri puztutako jariotik: %s"
 
-#: ../src/common/zstream.cpp:244
+#: ../src/common/zstream.cpp:241
 msgid "Can't read inflate stream: unexpected EOF in underlying stream."
 msgstr "Ezin da jario puztua irakurri: ustekabeko EOF erdietsitako jarioan."
 
-#: ../src/msw/registry.cpp:1064
+#: ../src/msw/registry.cpp:1052
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Ezin da '%s'-ren balioa irakurri"
 
-#: ../src/msw/registry.cpp:878 ../src/msw/registry.cpp:910
-#: ../src/msw/registry.cpp:975
+#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
+#: ../src/msw/registry.cpp:963
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Ezin da '%s' giltzaren balioa irakurri"
 
-#: ../src/common/image.cpp:2620
+#: ../src/msw/webview_ie.cpp:1017
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/common/image.cpp:2715
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "Ezin da irudia '%s' agirian gorde: luzepen ezezaguna."
 
-#: ../src/generic/logg.cpp:573 ../src/generic/logg.cpp:976
+#: ../src/generic/logg.cpp:570 ../src/generic/logg.cpp:973
 msgid "Can't save log contents to file."
 msgstr "Ezin dira ohar edukiak agirian gorde."
 
-#: ../src/msw/thread.cpp:629
+#: ../src/msw/thread.cpp:621
 msgid "Can't set thread priority"
 msgstr "Ezin da hari lehentasuna ezarri"
 
-#: ../src/msw/registry.cpp:896 ../src/msw/registry.cpp:938
-#: ../src/msw/registry.cpp:1081
+#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
+#: ../src/msw/registry.cpp:1069
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Ezin da '%s'-ren balioa ezarri"
 
-#: ../src/unix/utilsunx.cpp:351
+#: ../src/unix/utilsunx.cpp:353
 msgid "Can't write to child process's stdin"
 msgstr "Ezin da child prozesuaren stdin idatzi"
 
-#: ../src/common/zstream.cpp:427
+#: ../src/common/zstream.cpp:424
 #, c-format
 msgid "Can't write to deflate stream: %s"
 msgstr "Ezin da deflate jariora idatzi : %s"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:279 ../src/richtext/richtextstyledlg.cpp:300
-#: ../src/common/stockitem.cpp:145 ../src/common/accelcmn.cpp:71
-#: ../src/msw/msgdlg.cpp:454 ../src/msw/progdlg.cpp:673
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:142
+#: ../src/common/accelcmn.cpp:68 ../src/motif/msgdlg.cpp:196
+#: ../src/gtk1/fontdlg.cpp:144 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/progdlg.cpp:940 ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "E&zeztatu"
 
-#: ../src/common/filefn.cpp:1261
+#: ../src/common/filefn.cpp:1149
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Ezin dira '%s' agiriak zenbakitu"
 
-#: ../src/msw/dir.cpp:263
+#: ../src/msw/dir.cpp:260
 #, c-format
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Ezin dira '%s' zuzenbidean agirak zenbakitu"
 
-#: ../src/msw/dialup.cpp:523
+#: ../src/msw/dialup.cpp:517
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Ezin da aurkitu urrutizkin elkarketa eragindua: %s"
 
-#: ../src/msw/dialup.cpp:827
+#: ../src/msw/dialup.cpp:821
 msgid "Cannot find the location of address book file"
 msgstr "Ezin da aurkitu helbide liburu agiriaren kokalekua"
 
-#: ../src/msw/ole/automtn.cpp:562
+#: ../src/msw/ole/automtn.cpp:553
 #, c-format
 msgid "Cannot get an active instance of \"%s\""
 msgstr "Ezinezkoa \"%s\"-ren eskabide aktibo bat lortzea"
 
-#: ../src/unix/threadpsx.cpp:1035
+#: ../src/unix/threadpsx.cpp:1053
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "Ezin da lortu lehentasun maila %d egitarautzaile itunerako."
 
-#: ../src/unix/utilsunx.cpp:987
+#: ../src/unix/utilsunx.cpp:989
 msgid "Cannot get the hostname"
 msgstr "Ezin da lortu hostalari-izena"
 
-#: ../src/unix/utilsunx.cpp:1023
+#: ../src/unix/utilsunx.cpp:1025
 msgid "Cannot get the official hostname"
 msgstr "Ezin da lortu hostalari-izen ofiziala"
 
-#: ../src/msw/dialup.cpp:928
+#: ../src/msw/dialup.cpp:922
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Ezinezkoa eskegitzea - ez dago dei elkarketarik lanean."
 
@@ -1824,126 +1829,126 @@ msgstr "Ezinezkoa eskegitzea - ez dago dei elkarketarik lanean."
 msgid "Cannot initialize OLE"
 msgstr "Ezin da abiatu OLE"
 
-#: ../src/common/socket.cpp:853
+#: ../src/common/socket.cpp:850
 msgid "Cannot initialize sockets"
 msgstr "Ezinezkoa ahoak abiaraztea"
 
-#: ../src/msw/volume.cpp:619
+#: ../src/msw/volume.cpp:627
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Ezin da gertatu ikurra '%s'-tik."
 
-#: ../src/xrc/xmlres.cpp:360
+#: ../src/xrc/xmlres.cpp:358
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Ezin dira gertatu baliabideak '%s'-tik."
 
-#: ../src/xrc/xmlres.cpp:742
+#: ../src/xrc/xmlres.cpp:740
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Ezin dira gertatu baliabideak '%s' agiritik."
 
-#: ../src/html/htmlfilt.cpp:137
+#: ../src/html/htmlfilt.cpp:134
 #, c-format
 msgid "Cannot open HTML document: %s"
 msgstr "Ezin da ireki HTML agiria: %s"
 
-#: ../src/html/helpdata.cpp:667
+#: ../src/html/helpdata.cpp:660
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Ezin da ireki HTML laguntza libuura: %s"
 
-#: ../src/html/helpdata.cpp:299
+#: ../src/html/helpdata.cpp:296
 #, c-format
 msgid "Cannot open contents file: %s"
 msgstr "Ezin da ireki eduki agiria: %s"
 
-#: ../src/generic/dcpsg.cpp:1667
+#: ../src/generic/dcpsg.cpp:1665
 msgid "Cannot open file for PostScript printing!"
 msgstr "Ezin da ireki agiria PostScript irarketarako!"
 
-#: ../src/html/helpdata.cpp:313
+#: ../src/html/helpdata.cpp:310
 #, c-format
 msgid "Cannot open index file: %s"
 msgstr "Ezin da ireki aurkibide agiria: %s"
 
-#: ../src/xrc/xmlres.cpp:724
+#: ../src/xrc/xmlres.cpp:722
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Ezinezkoa '%s' baliabide agiria irekitzea."
 
-#: ../src/html/helpwnd.cpp:1534
+#: ../src/html/helpwnd.cpp:1532
 msgid "Cannot print empty page."
 msgstr "Ezin da irarkitu orrialde hutsa."
 
-#: ../src/msw/volume.cpp:507
+#: ../src/msw/volume.cpp:515
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Ezinezkoa mota-izena '%s'-tik irakurtzea"
 
-#: ../src/msw/thread.cpp:888
+#: ../src/msw/thread.cpp:894
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Ezin da %lx haria kendu"
 
-#: ../src/unix/threadpsx.cpp:1016
+#: ../src/unix/threadpsx.cpp:1028
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Ezinezkoa hari egitaraupen araudia berreskuratzea."
 
-#: ../src/common/intl.cpp:558
+#: ../src/common/intl.cpp:365
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "Ezin da ezarri tokikoa \"%s\" hizkuntzari."
 
-#: ../src/unix/threadpsx.cpp:831 ../src/msw/thread.cpp:546
+#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
 msgid "Cannot start thread: error writing TLS."
 msgstr "Ezin da haria hasi: akatsa TLS idazterakoan."
 
-#: ../src/msw/thread.cpp:872
+#: ../src/msw/thread.cpp:864
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Ezin da %lx haria utzi"
 
-#: ../src/msw/thread.cpp:794
+#: ../src/msw/thread.cpp:786
 msgid "Cannot wait for thread termination"
 msgstr "Ezin da hari amaiera itxaron"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:75
+#: ../src/common/accelcmn.cpp:72
 msgid "Capital"
 msgstr "Larria"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:879
+#: ../src/propgrid/advprops.cpp:780
 msgid "CaptionText"
 msgstr "Idazki Larria"
 
-#: ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:531
 msgid "Case sensitive"
 msgstr "Hizki larri-xeheak"
 
-#: ../src/propgrid/manager.cpp:1509
+#: ../src/propgrid/manager.cpp:1527
 msgid "Categorized Mode"
 msgstr "Kategoriatutako Modua"
 
-#: ../src/richtext/richtextbuffer.cpp:9968
+#: ../src/richtext/richtextbuffer.cpp:9965
 msgid "Cell Properties"
 msgstr "Gelaxka Ezaugarriak"
 
-#: ../src/common/fmapbase.cpp:161
+#: ../src/common/fmapbase.cpp:158
 msgid "Celtic (ISO-8859-14)"
 msgstr "Zeltiera (ISO-8859-14)"
 
-#: ../src/richtext/richtextindentspage.cpp:160
 #: ../src/richtext/richtextliststylepage.cpp:349
+#: ../src/richtext/richtextindentspage.cpp:160
 msgid "Cen&tred"
 msgstr "Er&diratuta"
 
-#: ../src/common/stockitem.cpp:170
+#: ../src/common/stockitem.cpp:167
 msgid "Centered"
 msgstr "Erdiratuta"
 
-#: ../src/common/fmapbase.cpp:149
+#: ../src/common/fmapbase.cpp:146
 msgid "Central European (ISO-8859-2)"
 msgstr "Europa Erdialdea (ISO-8859-2)"
 
@@ -1952,10 +1957,10 @@ msgstr "Europa Erdialdea (ISO-8859-2)"
 msgid "Centre"
 msgstr "Erdian"
 
-#: ../src/richtext/richtextindentspage.cpp:162
-#: ../src/richtext/richtextindentspage.cpp:164
 #: ../src/richtext/richtextliststylepage.cpp:351
 #: ../src/richtext/richtextliststylepage.cpp:353
+#: ../src/richtext/richtextindentspage.cpp:162
+#: ../src/richtext/richtextindentspage.cpp:164
 msgid "Centre text."
 msgstr "Erdiratu idazkia."
 
@@ -1968,24 +1973,24 @@ msgstr "Erdiratuta"
 msgid "Ch&oose..."
 msgstr "&Hautatu..."
 
-#: ../src/richtext/richtextbuffer.cpp:4354
+#: ../src/richtext/richtextbuffer.cpp:4351
 msgid "Change List Style"
 msgstr "Aldatu Zerrenda Estiloa"
 
-#: ../src/richtext/richtextbuffer.cpp:3709
+#: ../src/richtext/richtextbuffer.cpp:3706
 msgid "Change Object Style"
 msgstr "Aldatu Objetu Estiloa"
 
-#: ../src/richtext/richtextbuffer.cpp:3982
-#: ../src/richtext/richtextbuffer.cpp:8129
+#: ../src/richtext/richtextbuffer.cpp:3979
+#: ../src/richtext/richtextbuffer.cpp:8125
 msgid "Change Properties"
 msgstr "Aldatu Ezaugarriak"
 
-#: ../src/richtext/richtextbuffer.cpp:3526
+#: ../src/richtext/richtextbuffer.cpp:3523
 msgid "Change Style"
 msgstr "Aldatu Estiloa"
 
-#: ../src/common/fileconf.cpp:341
+#: ../src/common/fileconf.cpp:335
 #, c-format
 msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
 msgstr ""
@@ -1997,11 +2002,11 @@ msgid "Changing current directory to \"%s\" failed"
 msgstr "Hutsegita oraingo zuzenbidea \"%s\"-ra aldatzerakoan"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1757
+#: ../src/propgrid/advprops.cpp:1658
 msgid "Character"
 msgstr "Hizkia"
 
-#: ../src/richtext/richtextstyles.cpp:1063
+#: ../src/richtext/richtextstyles.cpp:1060
 msgid "Character styles"
 msgstr "Hizki-kode estiloak"
 
@@ -2038,20 +2043,20 @@ msgstr "Hautatu buletak hitzartean jartzeko."
 msgid "Check to indicate right-to-left text layout."
 msgstr "Hautatu eskuin-ezker idazketa antolakuntza adierazteko."
 
-#: ../src/osx/carbon/fontdlg.cpp:356 ../src/osx/carbon/fontdlg.cpp:358
+#: ../src/osx/carbon/fontdlg.cpp:353 ../src/osx/carbon/fontdlg.cpp:355
 msgid "Check to make the font bold."
 msgstr "Hautatu hizkia lodi egiteko."
 
-#: ../src/osx/carbon/fontdlg.cpp:363 ../src/osx/carbon/fontdlg.cpp:365
+#: ../src/osx/carbon/fontdlg.cpp:360 ../src/osx/carbon/fontdlg.cpp:362
 msgid "Check to make the font italic."
 msgstr "Hautatu hizkia etzana egiteko."
 
-#: ../src/osx/carbon/fontdlg.cpp:372 ../src/osx/carbon/fontdlg.cpp:374
+#: ../src/osx/carbon/fontdlg.cpp:369 ../src/osx/carbon/fontdlg.cpp:371
 msgid "Check to make the font underlined."
 msgstr "Hautatu hizkia azpimarratua egiteko."
 
-#: ../src/richtext/richtextstyledlg.cpp:289
-#: ../src/richtext/richtextstyledlg.cpp:291
+#: ../src/richtext/richtextstyledlg.cpp:285
+#: ../src/richtext/richtextstyledlg.cpp:287
 msgid "Check to restart numbering."
 msgstr "Hautatu zenbaketa birrabiarazteko."
 
@@ -2085,51 +2090,51 @@ msgstr "Hautatu erakusteko idazkia gaineskriptean."
 msgid "Check to suppress hyphenation."
 msgstr "Hautatu elkarmarratzea kentzeko."
 
-#: ../src/msw/dialup.cpp:763
+#: ../src/msw/dialup.cpp:757
 msgid "Choose ISP to dial"
 msgstr "Hautatu dialerako ISP-a"
 
-#: ../src/propgrid/props.cpp:1922
+#: ../src/propgrid/props.cpp:1904
 msgid "Choose a directory:"
 msgstr "Hautatu zuzenbide bat:"
 
-#: ../src/propgrid/props.cpp:1975
+#: ../src/propgrid/props.cpp:2199
 msgid "Choose a file"
 msgstr "Hautatu agiri bat"
 
-#: ../src/generic/colrdlgg.cpp:158 ../src/gtk/colordlg.cpp:54
+#: ../src/generic/colrdlgg.cpp:156 ../src/gtk/colordlg.cpp:49
 msgid "Choose colour"
 msgstr "Hautatu margoa"
 
-#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/gtk1/fontdlg.cpp:125 ../src/generic/fontpickerg.cpp:47
+#: ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Hautatu hizkia"
 
-#: ../src/common/module.cpp:74
+#: ../src/common/module.cpp:71
 #, c-format
 msgid "Circular dependency involving module \"%s\" detected."
 msgstr "\"%s\" moduloa inguratzen duen elkartoki zirkularra atzeman da."
 
-#: ../src/aui/tabmdi.cpp:108 ../src/generic/mdig.cpp:97
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
 msgid "Cl&ose"
 msgstr "I&txi"
 
-#: ../src/msw/ole/automtn.cpp:684
+#: ../src/msw/ole/automtn.cpp:675
 msgid "Class not registered."
 msgstr "Klase erregistratu gabe."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:147 ../src/common/accelcmn.cpp:72
+#: ../src/common/stockitem.cpp:144 ../src/common/accelcmn.cpp:69
 msgid "Clear"
 msgstr "Garbitu"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "Clear the log contents"
 msgstr "Garbitu ohar edukiak"
 
-#: ../src/richtext/richtextstyledlg.cpp:252
-#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:248
+#: ../src/richtext/richtextstyledlg.cpp:250
 msgid "Click to apply the selected style."
 msgstr "Klikatu hautatutako estiloa ezartzeko."
 
@@ -2140,15 +2145,15 @@ msgstr "Klikatu hautatutako estiloa ezartzeko."
 msgid "Click to browse for a symbol."
 msgstr "Klikatu ikur bat bilatzeko."
 
-#: ../src/osx/carbon/fontdlg.cpp:403 ../src/osx/carbon/fontdlg.cpp:405
+#: ../src/osx/carbon/fontdlg.cpp:400 ../src/osx/carbon/fontdlg.cpp:402
 msgid "Click to cancel changes to the font."
 msgstr "Klikatu hizkian aldaketak ezeztatzeko."
 
-#: ../src/generic/fontdlgg.cpp:472 ../src/generic/fontdlgg.cpp:491
+#: ../src/generic/fontdlgg.cpp:468 ../src/generic/fontdlgg.cpp:487
 msgid "Click to cancel the font selection."
 msgstr "Klikatu hizki hautapena ezeztatzeko."
 
-#: ../src/osx/carbon/fontdlg.cpp:384 ../src/osx/carbon/fontdlg.cpp:386
+#: ../src/osx/carbon/fontdlg.cpp:381 ../src/osx/carbon/fontdlg.cpp:383
 msgid "Click to change the font colour."
 msgstr "Klikatu hizki margoa aldatzeko."
 
@@ -2167,37 +2172,37 @@ msgstr "Klikatu idazki margoa aldatzeko."
 msgid "Click to choose the font for this level."
 msgstr "Klikatu maila honentzako hizkia hautatzeko."
 
-#: ../src/richtext/richtextstyledlg.cpp:279
-#: ../src/richtext/richtextstyledlg.cpp:281
+#: ../src/richtext/richtextstyledlg.cpp:275
+#: ../src/richtext/richtextstyledlg.cpp:277
 msgid "Click to close this window."
 msgstr "Klikatu leiho hau isteko."
 
-#: ../src/osx/carbon/fontdlg.cpp:410 ../src/osx/carbon/fontdlg.cpp:412
+#: ../src/osx/carbon/fontdlg.cpp:407 ../src/osx/carbon/fontdlg.cpp:409
 msgid "Click to confirm changes to the font."
 msgstr "Klikatu hizkian aldaketak baieztatzeko."
 
-#: ../src/generic/fontdlgg.cpp:477 ../src/generic/fontdlgg.cpp:479
-#: ../src/generic/fontdlgg.cpp:484 ../src/generic/fontdlgg.cpp:486
+#: ../src/generic/fontdlgg.cpp:473 ../src/generic/fontdlgg.cpp:475
+#: ../src/generic/fontdlgg.cpp:480 ../src/generic/fontdlgg.cpp:482
 msgid "Click to confirm the font selection."
 msgstr "Klikatu hizki hautapena baieztatzeko."
 
-#: ../src/richtext/richtextstyledlg.cpp:244
-#: ../src/richtext/richtextstyledlg.cpp:246
+#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:242
 msgid "Click to create a new box style."
 msgstr "Klikatu kutxa estilo berria sortzeko."
 
-#: ../src/richtext/richtextstyledlg.cpp:226
-#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:224
 msgid "Click to create a new character style."
 msgstr "Klikatu hizki-kode estilo berria sortzeko."
 
-#: ../src/richtext/richtextstyledlg.cpp:238
-#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:236
 msgid "Click to create a new list style."
 msgstr "Klikatu zerrenda estilo berria sortzeko."
 
-#: ../src/richtext/richtextstyledlg.cpp:232
-#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:230
 msgid "Click to create a new paragraph style."
 msgstr "Klikatu esaldi estilo berria sortzeko."
 
@@ -2211,8 +2216,8 @@ msgstr "Klikatu tab guztien kokapena sortzeko."
 msgid "Click to delete all tab positions."
 msgstr "Klikatu tab guztien kokapena ezabatzeko."
 
-#: ../src/richtext/richtextstyledlg.cpp:270
-#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:268
 msgid "Click to delete the selected style."
 msgstr "Klikatu hautaturiko estiloa ezabatzeko."
 
@@ -2221,25 +2226,25 @@ msgstr "Klikatu hautaturiko estiloa ezabatzeko."
 msgid "Click to delete the selected tab position."
 msgstr "Klikatu hautatutako tab kokopena ezabatzeko."
 
-#: ../src/richtext/richtextstyledlg.cpp:264
-#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:262
 msgid "Click to edit the selected style."
 msgstr "Klikatu hautatutako estiloa editatzeko."
 
-#: ../src/richtext/richtextstyledlg.cpp:258
-#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:256
 msgid "Click to rename the selected style."
 msgstr "Klikatu hautatutako estiloa berrizendatzeko."
 
-#: ../src/generic/dbgrptg.cpp:97 ../src/generic/progdlgg.cpp:759
-#: ../src/richtext/richtextstyledlg.cpp:277
-#: ../src/richtext/richtextsymboldlg.cpp:476 ../src/common/stockitem.cpp:148
-#: ../src/msw/progdlg.cpp:170 ../src/msw/progdlg.cpp:679
-#: ../src/html/helpdlg.cpp:90
+#: ../src/common/stockitem.cpp:145 ../src/generic/dbgrptg.cpp:94
+#: ../src/generic/progdlgg.cpp:781 ../src/msw/progdlg.cpp:211
+#: ../src/msw/progdlg.cpp:946 ../src/html/helpdlg.cpp:87
+#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextstyledlg.cpp:273
 msgid "Close"
 msgstr "It&xi"
 
-#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:98
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
 msgid "Close All"
 msgstr "Itxi Denak"
 
@@ -2247,43 +2252,43 @@ msgstr "Itxi Denak"
 msgid "Close current document"
 msgstr "Itxi oraingo agiria"
 
-#: ../src/generic/logg.cpp:516
+#: ../src/generic/logg.cpp:513
 msgid "Close this window"
 msgstr "Itxi leiho hau"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6006
+#: ../src/generic/datavgen.cpp:6811
 msgid "Collapse"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "Color"
 msgstr "Margoa"
 
-#: ../src/richtext/richtextformatdlg.cpp:776
+#: ../src/richtext/richtextformatdlg.cpp:768
 msgid "Colour"
 msgstr "Margoa"
 
-#: ../src/msw/colordlg.cpp:158
+#: ../src/msw/colordlg.cpp:227
 #, c-format
 msgid "Colour selection dialog failed with error %0lx."
 msgstr "Margo hautapen elkarrizketa hutsegitea %0lx akatsarekin."
 
-#: ../src/osx/carbon/fontdlg.cpp:380
+#: ../src/osx/carbon/fontdlg.cpp:377
 msgid "Colour:"
 msgstr "Margoa:"
 
-#: ../src/generic/datavgen.cpp:6077
+#: ../src/generic/datavgen.cpp:6882
 #, fuzzy, c-format
 msgid "Column %u"
 msgstr "Gehitu Zutabea"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:114
+#: ../src/common/accelcmn.cpp:112
 msgid "Command"
 msgstr "Agindua"
 
-#: ../src/common/init.cpp:196
+#: ../src/common/init.cpp:193
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
@@ -2291,12 +2296,12 @@ msgid ""
 msgstr ""
 "%d agindu lerro argumentua ezin da Unicodera bihurtu eta ezikusi egingo da."
 
-#: ../src/msw/fontdlg.cpp:120
+#: ../src/msw/fontdlg.cpp:170
 #, c-format
 msgid "Common dialog failed with error code %0lx."
 msgstr "Elkarrizketa arrunt hutsegitea %0lx akats kodearekin."
 
-#: ../src/gtk/window.cpp:4649
+#: ../src/gtk/window.cpp:5653
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
@@ -2304,11 +2309,11 @@ msgstr ""
 "Osaketa ez dago sostengaturik sistema honetan, mesedez gaitu ezazu zure "
 "Leiho Kudeatzailean."
 
-#: ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:1549
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Konprimitutako HTML Laguntza agiria (*.chm)|*.chm|"
 
-#: ../src/generic/dirctrlg.cpp:444
+#: ../src/generic/dirctrlg.cpp:410
 msgid "Computer"
 msgstr "Ordenagailua"
 
@@ -2317,53 +2322,57 @@ msgstr "Ordenagailua"
 msgid "Config entry name cannot start with '%c'."
 msgstr "Itxurap sarrera izean ezin da '%c'-rekin hasi."
 
-#: ../src/generic/filedlgg.cpp:349 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
 msgid "Confirm"
 msgstr "Baieztatu"
 
-#: ../src/html/htmlwin.cpp:566
+#: ../src/html/htmlwin.cpp:569
 msgid "Connecting..."
 msgstr "Elkarketatzen..."
 
-#: ../src/html/helpwnd.cpp:475
+#: ../src/html/helpwnd.cpp:473
 msgid "Contents"
 msgstr "Edukiak"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:880
+#: ../src/propgrid/advprops.cpp:781
 msgid "ControlDark"
 msgstr "Aginte-Iluna"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:881
+#: ../src/propgrid/advprops.cpp:782
 msgid "ControlLight"
 msgstr "Aginte-Argia"
 
-#: ../src/common/strconv.cpp:2262
+#: ../src/common/strconv.cpp:2208
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "'%s' hizki-kodera bihurtzeak ez du lanik egiten. "
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "Convert"
 msgstr "Bihurtu"
 
-#: ../src/html/htmlwin.cpp:1079
+#: ../src/html/htmlwin.cpp:1020
 #, c-format
 msgid "Copied to clipboard:\"%s\""
 msgstr "Gakora kopiatuta:\"%s\""
 
-#: ../src/generic/prntdlgg.cpp:247
+#: ../src/generic/prntdlgg.cpp:240
 msgid "Copies:"
 msgstr "Kopiak:"
 
-#: ../src/common/stockitem.cpp:150 ../src/stc/stc_i18n.cpp:18
+#: ../src/common/stockitem.cpp:147 ../src/stc/stc_i18n.cpp:18
 msgid "Copy"
 msgstr "Kopiatu"
 
-#: ../src/common/stockitem.cpp:258
+#: ../src/common/stockitem.cpp:255
 msgid "Copy selection"
 msgstr "Kopiatu hautapena"
+
+#: ../src/generic/grid.cpp:5945
+msgid "Copying more than one selected block to clipboard is not supported."
+msgstr ""
 
 #: ../src/richtext/richtextborderspage.cpp:566
 #: ../src/richtext/richtextborderspage.cpp:601
@@ -2374,198 +2383,194 @@ msgstr "Bazterrra"
 msgid "Corner &radius:"
 msgstr "Bazter er&radioa:"
 
-#: ../src/html/chm.cpp:718
+#: ../src/html/chm.cpp:711
 #, c-format
 msgid "Could not create temporary file '%s'"
 msgstr "Ezin da '%s' aldibaterako agiria sortu"
 
-#: ../src/html/chm.cpp:273
+#: ../src/html/chm.cpp:270
 #, c-format
 msgid "Could not extract %s into %s: %s"
 msgstr "Ezin da %s atera %s-n: %s"
 
-#: ../src/generic/tabg.cpp:1048
+#: ../src/generic/tabg.cpp:1045
 msgid "Could not find tab for id"
 msgstr "Ezin da id-arentzako tab aurkitu"
 
-#: ../src/gtk/notifmsg.cpp:108
-#, fuzzy
-msgid "Could not initalize libnotify."
-msgstr "Ezin da lerrokapena ezarri."
-
-#: ../src/html/chm.cpp:444
+#: ../src/html/chm.cpp:437
 #, c-format
 msgid "Could not locate file '%s'."
 msgstr "Ezin da '%s' agiria kokatu."
 
-#: ../src/common/filefn.cpp:1403
+#: ../src/msw/graphicsd2d.cpp:604
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/common/filefn.cpp:1291
 msgid "Could not set current working directory"
 msgstr "Ezinezkoa oraingo lan zuzenbidea ezartzea"
 
-#: ../src/common/prntbase.cpp:2015
+#: ../src/common/prntbase.cpp:2037
 msgid "Could not start document preview."
 msgstr "Ezin da agiriaren aurreikuspena hasi."
 
-#: ../src/generic/printps.cpp:178 ../src/msw/printwin.cpp:210
-#: ../src/gtk/print.cpp:1132
+#: ../src/generic/printps.cpp:159 ../src/msw/printwin.cpp:184
+#: ../src/gtk/print.cpp:1129
 msgid "Could not start printing."
 msgstr "Ezin da irarketa hasi"
 
-#: ../src/common/wincmn.cpp:2125
+#: ../src/common/wincmn.cpp:2126
 msgid "Could not transfer data to window"
 msgstr "Ezinezkoa datuak leihora eskualdatzea"
 
-#: ../src/msw/imaglist.cpp:187 ../src/msw/imaglist.cpp:224
-#: ../src/msw/imaglist.cpp:249 ../src/msw/dragimag.cpp:185
-#: ../src/msw/dragimag.cpp:220
+#: ../src/msw/imaglist.cpp:223 ../src/msw/imaglist.cpp:245
+#: ../src/msw/imaglist.cpp:270 ../src/msw/dragimag.cpp:182
+#: ../src/msw/dragimag.cpp:217
 msgid "Couldn't add an image to the image list."
 msgstr "Ezinezkoa irudia gehitzea irudi zerrendara."
 
-#: ../src/osx/glcanvas_osx.cpp:414 ../src/unix/glx11.cpp:558
-#: ../src/msw/glcanvas.cpp:616
+#: ../src/osx/glcanvas_osx.cpp:411 ../src/msw/glcanvas.cpp:631
+#: ../src/unix/glegl.cpp:315 ../src/unix/glx11.cpp:559
 #, fuzzy
 msgid "Couldn't create OpenGL context"
 msgstr "Ezinezkoa denboragailu bat sortzea"
 
-#: ../src/msw/timer.cpp:134
+#: ../src/msw/timer.cpp:131
 msgid "Couldn't create a timer"
 msgstr "Ezinezkoa denboragailu bat sortzea"
 
-#: ../src/osx/carbon/overlay.cpp:122
-msgid "Couldn't create the overlay window"
-msgstr "Ezinezkoa leiho gainjarria sortzea"
-
-#: ../src/common/translation.cpp:2024
+#: ../src/common/translation.cpp:2074
 msgid "Couldn't enumerate translations"
 msgstr "Ezinezkoa itzulpenak zenbatzea"
 
-#: ../src/common/dynlib.cpp:120
+#: ../src/common/dynlib.cpp:110
 #, c-format
 msgid "Couldn't find symbol '%s' in a dynamic library"
 msgstr "Ezinezkoa '%s' ikurra aurkitzea liburutegi dinamikoan"
 
-#: ../src/msw/thread.cpp:915
+#: ../src/msw/thread.cpp:921
 msgid "Couldn't get the current thread pointer"
 msgstr "Ezinezkoa oraingo hari puntua lortzea"
 
-#: ../src/osx/carbon/overlay.cpp:129
-msgid "Couldn't init the context on the overlay window"
-msgstr "Ezinezkoa hastea hitzingurua gainjarritako leihoan"
-
-#: ../src/common/imaggif.cpp:244
+#: ../src/common/imaggif.cpp:241
 msgid "Couldn't initialize GIF hash table."
 msgstr "Ezinezkoa GIF hash taula abiaraztea."
 
-#: ../src/common/imagpng.cpp:409
+#: ../src/common/imagpng.cpp:437
 msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
 msgstr ""
 "Ezinezkoa PNG irudia gertatzea - agiria hondatuta dago edo ez dago nahikoa "
 "oroimen."
 
-#: ../src/unix/sound.cpp:470
+#: ../src/unix/sound.cpp:459
 #, c-format
 msgid "Couldn't load sound data from '%s'."
 msgstr "Ezinezkoa '%s'-tik soinu datua gertatzea."
 
-#: ../src/msw/dirdlg.cpp:435
+#: ../src/msw/dirdlg.cpp:287
 msgid "Couldn't obtain folder name"
 msgstr "Ezinezkoa agiritegi izena lortzea"
 
-#: ../src/unix/sound_sdl.cpp:229
+#: ../src/unix/sound_sdl.cpp:226
 #, c-format
 msgid "Couldn't open audio: %s"
 msgstr "Ezinezkoa audioa irekitzea: %s"
 
-#: ../src/msw/ole/dataobj.cpp:377
+#: ../src/msw/ole/dataobj.cpp:385
 #, c-format
 msgid "Couldn't register clipboard format '%s'."
 msgstr "Ezinezkoa '%s' gako heuskarrri erregistratzea."
 
-#: ../src/msw/listctrl.cpp:869
+#: ../src/msw/listctrl.cpp:933
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "Ezinezkoa %d zerrenda aginte gaiari buruzko argibideak berreskuratzea."
 
-#: ../src/common/imagpng.cpp:498 ../src/common/imagpng.cpp:509
-#: ../src/common/imagpng.cpp:519
+#: ../src/common/imagpng.cpp:511 ../src/common/imagpng.cpp:522
+#: ../src/common/imagpng.cpp:532
 msgid "Couldn't save PNG image."
 msgstr "Ezinezkoa PNG irudia gordetzea."
 
-#: ../src/msw/thread.cpp:684
+#: ../src/msw/thread.cpp:676
 msgid "Couldn't terminate thread"
 msgstr "Ezinezkoa haria amaitzea"
 
-#: ../src/common/xtistrm.cpp:166
+#: ../src/common/xtistrm.cpp:163
 #, c-format
 msgid "Create Parameter %s not found in declared RTTI Parameters"
 msgstr "%s Sortu Paremetroa ez da aurkitu aitorturiko RTTI Parametroetan"
 
-#: ../src/generic/dirdlgg.cpp:288
+#: ../src/generic/dirdlgg.cpp:285
 msgid "Create directory"
 msgstr "Sortu zuzenbidea"
 
-#: ../src/generic/filedlgg.cpp:212 ../src/generic/dirdlgg.cpp:111
+#: ../src/generic/filedlgg.cpp:209 ../src/generic/dirdlgg.cpp:108
 msgid "Create new directory"
 msgstr "Sortu zuzenbide berria"
 
-#: ../src/xrc/xmlres.cpp:2460
+#: ../src/common/stockitem.cpp:264
+#, fuzzy
+msgid "Create new document"
+msgstr "Sortu zuzenbide berria"
+
+#: ../src/xrc/xmlres.cpp:2515
 #, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Hutsegitea %s \"%s\" sortzerakoan."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1758
+#: ../src/propgrid/advprops.cpp:1659
 msgid "Cross"
 msgstr "Zeharka"
 
-#: ../src/common/accelcmn.cpp:333
+#: ../src/common/accelcmn.cpp:347
 msgid "Ctrl+"
 msgstr "Ktrl+"
 
-#: ../src/richtext/richtextctrl.cpp:332 ../src/osx/textctrl_osx.cpp:576
-#: ../src/common/stockitem.cpp:151 ../src/msw/textctrl.cpp:2507
+#: ../src/osx/textctrl_osx.cpp:594 ../src/common/stockitem.cpp:148
+#: ../src/msw/textctrl.cpp:2772 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "Eba&ki"
 
-#: ../src/generic/filectrlg.cpp:940
+#: ../src/generic/filectrlg.cpp:936
 msgid "Current directory:"
 msgstr "Oraingo zuzenbidea:"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:896 ../src/propgrid/advprops.cpp:1574
-#: ../src/propgrid/advprops.cpp:1612
+#: ../src/propgrid/advprops.cpp:797 ../src/propgrid/advprops.cpp:1475
+#: ../src/propgrid/advprops.cpp:1518
 msgid "Custom"
 msgstr "Norberea"
 
-#: ../src/gtk/print.cpp:217
+#: ../src/gtk/print.cpp:211
 msgid "Custom size"
 msgstr "Norbere neurria"
 
-#: ../src/common/headerctrlcmn.cpp:60
+#: ../src/common/headerctrlcmn.cpp:58
 msgid "Customize Columns"
 msgstr "Norbereraratu Zutabeak"
 
-#: ../src/common/stockitem.cpp:151 ../src/stc/stc_i18n.cpp:17
+#: ../src/common/stockitem.cpp:148 ../src/stc/stc_i18n.cpp:17
 msgid "Cut"
 msgstr "Ebaki"
 
-#: ../src/common/stockitem.cpp:259
+#: ../src/common/stockitem.cpp:256
 msgid "Cut selection"
 msgstr "Ebaki hautapena"
 
-#: ../src/common/fmapbase.cpp:152
+#: ../src/common/fmapbase.cpp:149
 msgid "Cyrillic (ISO-8859-5)"
 msgstr "Zirilikoa (ISO-8859-5)"
 
-#: ../src/common/paper.cpp:99
+#: ../src/common/paper.cpp:96
 msgid "D sheet, 22 x 34 in"
 msgstr "D orria, 22 x 34 in"
 
-#: ../src/msw/dde.cpp:703
+#: ../src/msw/dde.cpp:698
 msgid "DDE poke request failed"
 msgstr "DDE eskabideak huts egin du"
 
-#: ../src/common/imagbmp.cpp:1169
+#: ../src/common/imagbmp.cpp:1181
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr "DIB Idazburua: Kodeaketak ez du bitsakonera."
 
@@ -2585,7 +2590,7 @@ msgstr "DIB Idazburua: Bit-sakonera ezezaguna agirian."
 msgid "DIB Header: Unknown encoding in file."
 msgstr "DIB Idazburua: Kodeaketa ezezaguna agirian."
 
-#: ../src/common/paper.cpp:121
+#: ../src/common/paper.cpp:118
 msgid "DL Envelope, 110 x 220 mm"
 msgstr "DL Gutunazala, 110 x 220 mm"
 
@@ -2593,53 +2598,53 @@ msgstr "DL Gutunazala, 110 x 220 mm"
 msgid "Dashed"
 msgstr "elkar-marratuta"
 
-#: ../src/generic/dbgrptg.cpp:300
+#: ../src/generic/dbgrptg.cpp:301
 #, c-format
 msgid "Debug report \"%s\""
 msgstr " \"%s\" garbikea jakinarazpena"
 
-#: ../src/common/debugrpt.cpp:210
+#: ../src/common/debugrpt.cpp:211
 msgid "Debug report couldn't be created."
 msgstr "Garbiketa jakinarazpena ezin da sortu."
 
-#: ../src/common/debugrpt.cpp:553
+#: ../src/common/debugrpt.cpp:554
 msgid "Debug report generation has failed."
 msgstr "Garbiketa jakinarazpena sortzeak huts egin du."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:84
+#: ../src/common/accelcmn.cpp:81
 msgid "Decimal"
 msgstr "Hamarrena"
 
-#: ../src/generic/fontdlgg.cpp:323
+#: ../src/generic/fontdlgg.cpp:319
 msgid "Decorative"
 msgstr "Edergarria"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1752
+#: ../src/propgrid/advprops.cpp:1653
 msgid "Default"
 msgstr "Berezkoa"
 
-#: ../src/common/fmapbase.cpp:796
+#: ../src/common/fmapbase.cpp:792
 msgid "Default encoding"
 msgstr "Berezko kodeaketa"
 
-#: ../src/dfb/fontmgr.cpp:180
+#: ../src/dfb/fontmgr.cpp:177
 msgid "Default font"
 msgstr "Berezko hizkia"
 
-#: ../src/generic/prntdlgg.cpp:510
+#: ../src/generic/prntdlgg.cpp:503
 msgid "Default printer"
 msgstr "Berezko irarkailua"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:51
+#: ../src/common/accelcmn.cpp:48
 msgid "Del"
 msgstr "Ezab"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextbuffer.cpp:8221 ../src/common/stockitem.cpp:152
-#: ../src/common/accelcmn.cpp:50 ../src/stc/stc_i18n.cpp:20
+#: ../src/common/stockitem.cpp:149 ../src/common/accelcmn.cpp:47
+#: ../src/richtext/richtextbuffer.cpp:8217 ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Ezabatu"
 
@@ -2647,68 +2652,68 @@ msgstr "Ezabatu"
 msgid "Delete A&ll"
 msgstr "Ezabatu &Denak"
 
-#: ../src/richtext/richtextbuffer.cpp:11341
+#: ../src/richtext/richtextbuffer.cpp:11340
 msgid "Delete Column"
 msgstr "Ezabatu Zutabea"
 
-#: ../src/richtext/richtextbuffer.cpp:11291
+#: ../src/richtext/richtextbuffer.cpp:11290
 msgid "Delete Row"
 msgstr "Ezabatu Lerroa"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 msgid "Delete Style"
 msgstr "Ezabatu Estiloa"
 
-#: ../src/richtext/richtextctrl.cpp:1345 ../src/richtext/richtextctrl.cpp:1584
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
 msgid "Delete Text"
 msgstr "Ezabatu Idazkia"
 
-#: ../src/generic/editlbox.cpp:170
+#: ../src/generic/editlbox.cpp:147
 msgid "Delete item"
 msgstr "Ezabatu gaia"
 
-#: ../src/common/stockitem.cpp:260
+#: ../src/common/stockitem.cpp:257
 msgid "Delete selection"
 msgstr "Ezabatu hautapena"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 #, c-format
 msgid "Delete style %s?"
 msgstr "%s estiloa ezabatu?"
 
-#: ../src/unix/snglinst.cpp:301
+#: ../src/unix/snglinst.cpp:298
 #, c-format
 msgid "Deleted stale lock file '%s'."
 msgstr "Ezabatuta hondatutako blokeo agiria '%s'."
 
-#: ../src/common/secretstore.cpp:220
+#: ../src/common/secretstore.cpp:234
 #, fuzzy, c-format
-msgid "Deleting password for \"%s/%s\" failed: %s."
+msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Hutsegitea %s \"%s\" sortzerakoan."
 
-#: ../src/common/module.cpp:124
+#: ../src/common/module.cpp:121
 #, c-format
 msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
 msgstr "Elkargunea \"%s\" Moduloa \"%s\" ez dago."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "Descending"
 msgstr "Beherantz"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:526 ../src/propgrid/advprops.cpp:882
+#: ../src/generic/dirctrlg.cpp:492 ../src/propgrid/advprops.cpp:783
 msgid "Desktop"
 msgstr "Mahigaina"
 
-#: ../src/generic/aboutdlgg.cpp:70
+#: ../src/generic/aboutdlgg.cpp:67
 msgid "Developed by "
 msgstr "Garatzaileak"
 
-#: ../src/generic/aboutdlgg.cpp:176
+#: ../src/generic/aboutdlgg.cpp:173
 msgid "Developers"
 msgstr "Garatzaileak"
 
-#: ../src/msw/dialup.cpp:374
+#: ../src/msw/dialup.cpp:368
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -2716,11 +2721,11 @@ msgstr ""
 "Dei eginkizunak ez daude eskuragarri hurreneko sarbide zerbitzua (RAS) ez "
 "dagoelako ezarrita makina honetan. Mesedez ezarri ezazu."
 
-#: ../src/generic/tipdlg.cpp:211
+#: ../src/generic/tipdlg.cpp:208
 msgid "Did you know..."
 msgstr "Esanahi duzu..."
 
-#: ../src/dfb/wrapdfb.cpp:63
+#: ../src/dfb/wrapdfb.cpp:60
 #, c-format
 msgid "DirectFB error %d occurred."
 msgstr "DirectFB %d akatsa gertatu da."
@@ -2729,29 +2734,29 @@ msgstr "DirectFB %d akatsa gertatu da."
 msgid "Directories"
 msgstr "Zuzenbideak"
 
-#: ../src/common/filefn.cpp:1183
+#: ../src/common/filefn.cpp:1071
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "'%s' zuzenbidea ezin da sortu"
 
-#: ../src/common/filefn.cpp:1197
+#: ../src/common/filefn.cpp:1085
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "%s' zuzenbidea ezin da ezabatu"
 
-#: ../src/generic/dirdlgg.cpp:204
+#: ../src/generic/dirdlgg.cpp:201
 msgid "Directory does not exist"
 msgstr "Zuzenbidea ez dago"
 
-#: ../src/generic/filectrlg.cpp:1399
+#: ../src/generic/filectrlg.cpp:1388
 msgid "Directory doesn't exist."
 msgstr "Zuzenbidea ez dago."
 
-#: ../src/common/docview.cpp:457
+#: ../src/common/docview.cpp:450
 msgid "Discard changes and reload the last saved version?"
 msgstr "Baztertu aldaketak eta gertatu gordetako azken bertsioa?"
 
-#: ../src/html/helpwnd.cpp:502
+#: ../src/html/helpwnd.cpp:500
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -2759,45 +2764,45 @@ msgstr ""
 "Erakutsi emandako azpikatea duten aurkibideko gai guztiak. Bilaketak hizki "
 "xehe-larriak bereizten ditu."
 
-#: ../src/html/helpwnd.cpp:679
+#: ../src/html/helpwnd.cpp:677
 msgid "Display options dialog"
 msgstr "Erakutsi aukeren elkarrizketa"
 
-#: ../src/html/helpwnd.cpp:322
+#: ../src/html/helpwnd.cpp:320
 msgid "Displays help as you browse the books on the left."
 msgstr "Laguntza erakusten du ezkerreko liburuetan nabigatzean."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:85
+#: ../src/common/accelcmn.cpp:83
 msgid "Divide"
 msgstr "Zatiketa"
 
-#: ../src/common/docview.cpp:533
+#: ../src/common/docview.cpp:526
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Nahi duzu %s-ri aldaketak gordetzea?"
 
-#: ../src/common/prntbase.cpp:542
+#: ../src/common/prntbase.cpp:537
 msgid "Document:"
 msgstr "Agiria:"
 
-#: ../src/generic/aboutdlgg.cpp:73
+#: ../src/generic/aboutdlgg.cpp:70
 msgid "Documentation by "
 msgstr "Agirigilea"
 
-#: ../src/generic/aboutdlgg.cpp:180
+#: ../src/generic/aboutdlgg.cpp:177
 msgid "Documentation writers"
 msgstr "Agiri idazleak"
 
-#: ../src/common/sizer.cpp:2799
+#: ../src/common/sizer.cpp:2916
 msgid "Don't Save"
 msgstr "Ez Gorde"
 
-#: ../src/html/htmlwin.cpp:633
+#: ../src/html/htmlwin.cpp:643
 msgid "Done"
 msgstr "Eginda"
 
-#: ../src/generic/progdlgg.cpp:448 ../src/msw/progdlg.cpp:407
+#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
 msgid "Done."
 msgstr "Eginda."
 
@@ -2809,42 +2814,42 @@ msgstr "Puntukatuta"
 msgid "Double"
 msgstr "Bikoitza"
 
-#: ../src/common/paper.cpp:176
+#: ../src/common/paper.cpp:173
 msgid "Double Japanese Postcard Rotated 148 x 200 mm"
 msgstr "Japoniar Bidaitxartel Bikoitza Itzulita 148 x 200 mm"
 
-#: ../src/common/xtixml.cpp:273
+#: ../src/common/xtixml.cpp:269
 #, c-format
 msgid "Doubly used id : %d"
 msgstr "id bikoiztua : %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:153
-#: ../src/common/accelcmn.cpp:64
+#: ../src/common/stockitem.cpp:150 ../src/common/accelcmn.cpp:61
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Down"
 msgstr "Behera"
 
-#: ../src/richtext/richtextctrl.cpp:865
+#: ../src/richtext/richtextctrl.cpp:864
 msgid "Drag"
 msgstr "Harrastatu"
 
-#: ../src/common/paper.cpp:100
+#: ../src/common/paper.cpp:97
 msgid "E sheet, 34 x 44 in"
 msgstr "E orria, 34 x 44 in"
 
-#: ../src/unix/fswatcher_inotify.cpp:561
+#: ../src/unix/fswatcher_inotify.cpp:558
 msgid "EOF while reading from inotify descriptor"
 msgstr "EOF inotify azaltzailetik irakurtzean"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "Edit"
 msgstr "Editatu"
 
-#: ../src/generic/editlbox.cpp:168
+#: ../src/generic/editlbox.cpp:131
 msgid "Edit item"
 msgstr "Editatu gaia"
 
-#: ../include/wx/generic/progdlgg.h:84
+#: ../include/wx/generic/progdlgg.h:85
 msgid "Elapsed time:"
 msgstr "Igarotako denbora:"
 
@@ -2911,49 +2916,49 @@ msgid "Enables the shadow spread."
 msgstr "Itzal barreiapena gaitzen du."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:66
+#: ../src/common/accelcmn.cpp:63
 msgid "End"
 msgstr "Amaiera"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:55
+#: ../src/common/accelcmn.cpp:52
 msgid "Enter"
 msgstr "Sartu"
 
-#: ../src/richtext/richtextstyledlg.cpp:934
+#: ../src/richtext/richtextstyledlg.cpp:930
 msgid "Enter a box style name"
 msgstr "Sartu kutxa estilo izen bat"
 
-#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:602
 msgid "Enter a character style name"
 msgstr "Sartu hizki estilo izen bat"
 
-#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:816
 msgid "Enter a list style name"
 msgstr "Sartu zerrenda estilo izen bat"
 
-#: ../src/richtext/richtextstyledlg.cpp:893
+#: ../src/richtext/richtextstyledlg.cpp:889
 msgid "Enter a new style name"
 msgstr "Sartu estilo izen berri bat"
 
-#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:650
 msgid "Enter a paragraph style name"
 msgstr "Sartu esaldi estilo izena"
 
-#: ../src/generic/dbgrptg.cpp:174
+#: ../src/generic/dbgrptg.cpp:171
 #, c-format
 msgid "Enter command to open file \"%s\":"
 msgstr "Sartu komandoa \"%s\" agiria irekitzeko:"
 
-#: ../src/generic/helpext.cpp:459
+#: ../src/generic/helpext.cpp:457
 msgid "Entries found"
 msgstr "Aurkitutako sarrerak"
 
-#: ../src/common/paper.cpp:142
+#: ../src/common/paper.cpp:139
 msgid "Envelope Invite 220 x 220 mm"
 msgstr "Gonbidapen Gutunazala 220 x 220 mm"
 
-#: ../src/common/config.cpp:469
+#: ../src/common/config.cpp:465
 #, c-format
 msgid ""
 "Environment variables expansion failed: missing '%c' at position %u in '%s'."
@@ -2961,13 +2966,13 @@ msgstr ""
 "Ingurugiro aldaera hedapen hutsegitea: ez dago '%c'  %u kokapenean, hemen: "
 "'%s'."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/generic/dirctrlg.cpp:570
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/dirctrlg.cpp:599
-#: ../src/generic/dirdlgg.cpp:323 ../src/generic/filectrlg.cpp:642
-#: ../src/generic/filectrlg.cpp:756 ../src/generic/filectrlg.cpp:770
-#: ../src/generic/filectrlg.cpp:786 ../src/generic/filectrlg.cpp:1368
-#: ../src/generic/filectrlg.cpp:1399 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/gtk1/fontdlg.cpp:74 ../src/generic/dirctrlg.cpp:536
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/dirctrlg.cpp:565
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1357 ../src/generic/filectrlg.cpp:1388
+#: ../src/generic/filedlgg.cpp:354 ../src/generic/dirdlgg.cpp:320
+#: ../src/gtk/filedlg.cpp:74
 msgid "Error"
 msgstr "Akatsa"
 
@@ -2975,86 +2980,97 @@ msgstr "Akatsa"
 msgid "Error closing epoll descriptor"
 msgstr "Akatsa epoll azaltzailea istean"
 
-#: ../src/unix/fswatcher_kqueue.cpp:114
+#: ../src/unix/fswatcher_kqueue.cpp:131
 msgid "Error closing kqueue instance"
 msgstr "Akats kqueue eskabidea istean"
 
-#: ../src/common/filefn.cpp:1049
+#: ../src/common/filefn.cpp:938
 #, fuzzy, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Hutsegitea '%s' agiria '%s'-ra kopiatzerakoan"
 
-#: ../src/generic/dirdlgg.cpp:222
+#: ../src/generic/dirdlgg.cpp:219
 msgid "Error creating directory"
 msgstr "Akatsa zuzenbidea irakurtzean"
 
-#: ../src/common/imagbmp.cpp:1181
+#: ../src/common/imagbmp.cpp:1193
 msgid "Error in reading image DIB."
 msgstr "Akatsa DIB irudia irakurtzean."
 
-#: ../src/propgrid/propgrid.cpp:6696
+#: ../src/propgrid/propgrid.cpp:6665
 #, c-format
 msgid "Error in resource: %s"
 msgstr "Akatsa baliabidean: %s"
 
-#: ../src/common/fileconf.cpp:422
+#: ../src/common/fileconf.cpp:421
 msgid "Error reading config options."
 msgstr "Akatsa itxurap aukerak irakurtzean."
+
+#: ../src/msw/webview_ie.cpp:1057 ../src/msw/webview_edge.cpp:850
+#: ../src/gtk/webview_webkit2.cpp:1262 ../src/osx/webview_webkit.mm:383
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
 
 #: ../src/common/fileconf.cpp:1029
 msgid "Error saving user configuration data."
 msgstr "Akatsa erabiltzaile itxurapen datuak gordetzean."
 
-#: ../src/gtk/print.cpp:722
+#: ../src/gtk/print.cpp:720
 msgid "Error while printing: "
 msgstr "Akatsa irarkitzerakoan:"
 
-#: ../src/common/log.cpp:219
+#: ../src/common/log.cpp:237
 msgid "Error: "
 msgstr "Akatsa:"
 
+#: ../src/common/webrequest.cpp:98
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Akatsa:"
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:69
+#: ../src/common/accelcmn.cpp:66
 msgid "Esc"
 msgstr "Irt"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:70
+#: ../src/common/accelcmn.cpp:67
 msgid "Escape"
 msgstr "Irten"
 
-#: ../src/common/fmapbase.cpp:150
+#: ../src/common/fmapbase.cpp:147
 msgid "Esperanto (ISO-8859-3)"
 msgstr "Esperantoera (ISO-8859-3)"
 
-#: ../include/wx/generic/progdlgg.h:85
+#: ../include/wx/generic/progdlgg.h:86
 msgid "Estimated time:"
 msgstr "Ustezko denbora:"
 
-#: ../src/generic/dbgrptg.cpp:234
+#: ../src/generic/dbgrptg.cpp:231
 msgid "Executable files (*.exe)|*.exe|"
 msgstr "Agiri exekutagarriak (*.exe)|*.exe|"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:155 ../src/common/accelcmn.cpp:78
+#: ../src/common/stockitem.cpp:152 ../src/common/accelcmn.cpp:75
 msgid "Execute"
 msgstr "Exekutatu"
 
-#: ../src/msw/utilsexc.cpp:876
+#: ../src/msw/utilsexc.cpp:873
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Hutsegitea '%s' komandoa exekutatzerakoan"
 
-#: ../src/common/paper.cpp:105
+#: ../src/common/paper.cpp:102
 msgid "Executive, 7 1/4 x 10 1/2 in"
 msgstr "Exekutiboa, 7 1/4 x 10 1/2 in"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6009
+#: ../src/generic/datavgen.cpp:6814
 msgid "Expand"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1240
+#: ../src/msw/registry.cpp:1228
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
@@ -3062,147 +3078,157 @@ msgstr ""
 "Esportatzen erregistro giltza: \"%s\" agiria jadanik badago eta ezin da "
 "gainidatzi."
 
-#: ../src/common/fmapbase.cpp:195
+#: ../src/common/fmapbase.cpp:192
 msgid "Extended Unix Codepage for Japanese (EUC-JP)"
 msgstr "Unix Kodeorrialde Hedatua Japonierarako (EUC-JP)"
 
-#: ../src/html/chm.cpp:725
+#: ../src/html/chm.cpp:718
 #, c-format
 msgid "Extraction of '%s' into '%s' failed."
 msgstr "Hutsegitea '%s' '%s'-ra ateratzerakoan."
 
-#: ../src/common/accelcmn.cpp:249 ../src/common/accelcmn.cpp:344
+#: ../src/common/accelcmn.cpp:259 ../src/common/accelcmn.cpp:358
 msgid "F"
 msgstr "F"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:672
+#: ../src/propgrid/advprops.cpp:582
 msgid "Face Name"
 msgstr "Aurpegi Izena"
 
-#: ../src/unix/snglinst.cpp:269
+#: ../src/unix/snglinst.cpp:266
 msgid "Failed to access lock file."
 msgstr "Hutsegitea blokeo agirira sartzerakoan."
+
+#: ../src/gtk/font.cpp:572
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Hutsegitea \"%s\" agiritik agiria irakurtzerakoan."
 
 #: ../src/unix/epolldispatcher.cpp:116
 #, c-format
 msgid "Failed to add descriptor %d to epoll descriptor %d"
 msgstr "Hutsegitea %d azaltzailea %d epoll azaltzailera gehitzerakoan"
 
-#: ../src/msw/dib.cpp:489
+#: ../src/msw/dib.cpp:535
 #, c-format
 msgid "Failed to allocate %luKb of memory for bitmap data."
 msgstr "Hutsegitea bitmaparako oroimenaren %luKb-a esleitzerakoan."
 
-#: ../src/common/glcmn.cpp:115
+#: ../src/common/glcmn.cpp:112
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Hutsegitea OpenGL-rako margoa esleitzerakoan"
 
-#: ../src/unix/displayx11.cpp:236
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Hutsegitea OpenGL-rako margoa esleitzerakoan"
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Hutsegitea OpenGL-rako margoa esleitzerakoan"
+
+#: ../include/wx/unix/private/displayx11.h:89
 msgid "Failed to change video mode"
 msgstr "Hutsegitea bideo modua aldatzerakoan"
 
-#: ../src/common/image.cpp:3277
+#: ../src/common/image.cpp:3396
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Hutsegitea \"%s\" irudi agiriaren heuskarria egiaztatzerakoan"
 
-#: ../src/common/debugrpt.cpp:239
+#: ../src/common/debugrpt.cpp:240
 #, c-format
 msgid "Failed to clean up debug report directory \"%s\""
 msgstr "Hutsegitea \"%s\" garbiketa jakinarazpen zuzenbidea garbitzerakoan"
 
-#: ../src/common/filename.cpp:192
+#: ../src/common/filename.cpp:189
 msgid "Failed to close file handle"
 msgstr "Hutsegitea agiri kudeatzailea isterakoan"
 
-#: ../src/unix/snglinst.cpp:340
+#: ../src/unix/snglinst.cpp:337
 #, c-format
 msgid "Failed to close lock file '%s'"
 msgstr "Hutsegitea '%s' blokeo agiria isterakoan"
 
-#: ../src/msw/clipbrd.cpp:112
+#: ../src/msw/clipbrd.cpp:110
 msgid "Failed to close the clipboard."
 msgstr "Hutsegitea gakoa isterakoan."
 
-#: ../src/x11/utils.cpp:208
+#: ../src/x11/utils.cpp:170
 #, c-format
 msgid "Failed to close the display \"%s\""
 msgstr "Hutsegitea \"%s\" erakuspena isterakoan"
 
-#: ../src/msw/dialup.cpp:797
+#: ../src/msw/dialup.cpp:791
 msgid "Failed to connect: missing username/password."
 msgstr "Hutsegitea elkarketatzerakoan: ez dago erabiltzaile-izen/sar-hitzik."
 
-#: ../src/msw/dialup.cpp:743
+#: ../src/msw/dialup.cpp:737
 msgid "Failed to connect: no ISP to dial."
 msgstr "Hutsegitea elkarketatzerakoan:: ez dago ISP deitzeko."
 
-#: ../src/common/textfile.cpp:203
-#, c-format
-msgid "Failed to convert file \"%s\" to Unicode."
-msgstr "Hutsegitea \"%s\" agiria Unicodera bihurtzerakoan."
-
-#: ../src/generic/logg.cpp:956
+#: ../src/generic/logg.cpp:953
 msgid "Failed to copy dialog contents to the clipboard."
 msgstr "Hutsegitea elkarrizketa edukiak gakora kopiatzerakoan."
 
-#: ../src/msw/registry.cpp:692
+#: ../src/msw/registry.cpp:681
 #, c-format
 msgid "Failed to copy registry value '%s'"
 msgstr "Hutsegitea '%s' erregistro balioa kopiatzerakoan"
 
-#: ../src/msw/registry.cpp:701
+#: ../src/msw/registry.cpp:690
 #, c-format
 msgid "Failed to copy the contents of registry key '%s' to '%s'."
 msgstr "Hutsegitea '%s' erregistro giltzako edukiak '%s'-ra kopiatzerakoan."
 
-#: ../src/common/filefn.cpp:1015
+#: ../src/common/filefn.cpp:904
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Hutsegitea '%s' agiria '%s'-ra kopiatzerakoan"
 
-#: ../src/msw/registry.cpp:679
+#: ../src/msw/registry.cpp:668
 #, c-format
 msgid "Failed to copy the registry subkey '%s' to '%s'."
 msgstr "Hutsegitea '%s' erregistro azpigiltza '%s'-ra  kopiatzerakoan."
 
-#: ../src/msw/dde.cpp:1070
+#: ../src/msw/dde.cpp:1134
 msgid "Failed to create DDE string"
 msgstr "Hutsegitea DDE katea sortzerakoan"
 
-#: ../src/msw/mdi.cpp:616
+#: ../src/msw/mdi.cpp:621
 msgid "Failed to create MDI parent frame."
 msgstr "Hutsegitea MDI gaineko framea sortzerakoan."
 
-#: ../src/common/filename.cpp:1027
+#: ../src/common/filename.cpp:1024
 msgid "Failed to create a temporary file name"
 msgstr "Hutsegitea aldibaterako agiri izena sortzerakoan"
 
-#: ../src/msw/utilsexc.cpp:228
+#: ../src/msw/utilsexc.cpp:225
 msgid "Failed to create an anonymous pipe"
 msgstr "Hutsegitea izengabeko hodia sortzerakoan"
 
-#: ../src/msw/ole/automtn.cpp:522
+#: ../src/msw/ole/automtn.cpp:513
 #, c-format
 msgid "Failed to create an instance of \"%s\""
 msgstr "Hutsegitea \"%s\" eskabidea sortzerakoan"
 
-#: ../src/msw/dde.cpp:437
+#: ../src/msw/dde.cpp:432
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "Hutsegitea '%s' zerbitzariarekin '%s' gaian elkarketa sortzerakoan"
 
-#: ../src/msw/cursor.cpp:204
+#: ../src/msw/cursor.cpp:195
 msgid "Failed to create cursor."
 msgstr "Hutsegitea kurtsorea sortzerakoan."
 
-#: ../src/common/debugrpt.cpp:209
+#: ../src/common/debugrpt.cpp:210
 #, c-format
 msgid "Failed to create directory \"%s\""
 msgstr "Hutsegitea \"%s\" zuzenbidea sortzerakoan"
 
-#: ../src/generic/dirdlgg.cpp:220
+#: ../src/generic/dirdlgg.cpp:217
 #, c-format
 msgid ""
 "Failed to create directory '%s'\n"
@@ -3215,118 +3241,137 @@ msgstr ""
 msgid "Failed to create epoll descriptor"
 msgstr "Hutsegitea epoll azaltzailea sortzerakoan"
 
-#: ../src/msw/mimetype.cpp:238
+#: ../src/gtk/font.cpp:562
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "Hutsegitea erabiltzaile itxurapen agiria eguneratzerakoan."
+
+#: ../src/msw/mimetype.cpp:235
 #, c-format
 msgid "Failed to create registry entry for '%s' files."
 msgstr "Hutsegitea '%s' agirientzak sarrera erregistroa sortzerakoan."
 
-#: ../src/msw/fdrepdlg.cpp:409
+#: ../src/msw/fdrepdlg.cpp:408
 #, c-format
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr ""
 "Hutsegitea bilaketa estandarra/ordeztu elkarrizketa sortzerakoan (akats "
 "kodea %d)"
 
-#: ../src/unix/wakeuppipe.cpp:52
+#: ../src/unix/wakeuppipe.cpp:49
 msgid "Failed to create wake up pipe used by event loop."
 msgstr ""
 "Hutsegitea gertaera bigiztak erabilitako iratzarpen hodia sortzearakoan."
 
-#: ../src/html/winpars.cpp:730
+#: ../src/html/winpars.cpp:727
 #, c-format
 msgid "Failed to display HTML document in %s encoding"
 msgstr "Hutsegitea HTML agiria %s kodeaketan erakusterakoan"
 
-#: ../src/msw/clipbrd.cpp:124
+#: ../src/msw/clipbrd.cpp:122
 msgid "Failed to empty the clipboard."
 msgstr "Hutsegitea gakoa husterakoan."
 
-#: ../src/unix/displayx11.cpp:212
+#: ../include/wx/unix/private/displayx11.h:65
 msgid "Failed to enumerate video modes"
 msgstr "Hutsegita bideo moduak zenbakitzerakoan"
 
-#: ../src/msw/dde.cpp:722
+#: ../src/msw/dde.cpp:717
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "Hutsegitea DDE zerbitzariarekin ohar bigizta ezartzerakoan"
 
-#: ../src/msw/dialup.cpp:629 ../src/msw/dialup.cpp:863
+#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Hutsegitea urrutizkin elkarketa ezartzerakoan: %s"
 
-#: ../src/unix/utilsunx.cpp:611
+#: ../src/unix/utilsunx.cpp:613
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Hutsegitea '%s' exekutatzerakoan\n"
 
-#: ../src/common/debugrpt.cpp:720
+#: ../src/common/debugrpt.cpp:730
 msgid "Failed to execute curl, please install it in PATH."
 msgstr "Hutsegitea curl exekutatzerakoan, mesedez ezarri HELBURUAN."
 
-#: ../src/msw/ole/automtn.cpp:505
+#: ../src/msw/ole/automtn.cpp:496
 #, c-format
 msgid "Failed to find CLSID of \"%s\""
 msgstr "Hutsegitea \"%s\"-ren CLSID bilatzerakoan."
 
-#: ../src/common/regex.cpp:431 ../src/common/regex.cpp:479
+#: ../src/common/regex.cpp:428 ../src/common/regex.cpp:476
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr ""
 "Hutsegitea adierazpen arrunt honentzak bateragarririk aurkitzerakoan: %s"
 
-#: ../src/msw/dialup.cpp:695
+#: ../src/msw/webview_ie.cpp:978
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:689
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Hutsegitea ISP izenak lortzerakoan: %s"
 
-#: ../src/msw/ole/automtn.cpp:574
+#: ../src/msw/ole/automtn.cpp:565
 #, c-format
 msgid "Failed to get OLE automation interface for \"%s\""
 msgstr "Hutsegitea \"%s\"-rentzat OLE berezgaitasun interfazea lortzerakoan"
 
-#: ../src/msw/clipbrd.cpp:711
+#: ../src/msw/clipbrd.cpp:731
 msgid "Failed to get data from the clipboard"
 msgstr "Hutsegitea gakotik datuak lortzerakoan"
 
-#: ../src/common/time.cpp:223
+#: ../src/common/time.cpp:216
 msgid "Failed to get the local system time"
 msgstr "Hutsegitea tokiko sistema ordua lortzerakoan"
 
-#: ../src/common/filefn.cpp:1345
+#: ../src/common/filefn.cpp:1233
 msgid "Failed to get the working directory"
 msgstr "Hutsegitea lan zuzenbidea lortzerakoan"
 
-#: ../src/univ/theme.cpp:114
+#: ../src/univ/theme.cpp:111
 msgid "Failed to initialize GUI: no built-in themes found."
 msgstr "Hutsegitea EIG abiatzerakoan: ez da barneko azalgairik aurkitu."
 
-#: ../src/msw/helpchm.cpp:63
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:60
 msgid "Failed to initialize MS HTML Help."
 msgstr "Hutsegitea MS HTML Laguntza abiatzerakoan."
 
-#: ../src/msw/glcanvas.cpp:1381
+#: ../src/msw/glcanvas.cpp:1391
 msgid "Failed to initialize OpenGL"
 msgstr "Hutsegitea OpenGL abiatzerakoan"
 
-#: ../src/msw/dialup.cpp:858
+#: ../src/msw/dialup.cpp:852
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Hutsegitea urrutizkin elkarketa hasterakoan: %s"
 
-#: ../src/gtk/textctrl.cpp:1128
+#: ../src/gtk/textctrl.cpp:1209
 msgid "Failed to insert text in the control."
 msgstr "Hutsegitea agintean idazkia sartzerakoan."
 
-#: ../src/unix/snglinst.cpp:241
+#: ../src/unix/snglinst.cpp:238
 #, c-format
 msgid "Failed to inspect the lock file '%s'"
 msgstr "Hutsegitea '%s' blokeo agiria ikertzerakoan"
 
-#: ../src/unix/appunix.cpp:182
+#: ../src/unix/appunix.cpp:179
 msgid "Failed to install signal handler"
 msgstr "Hutsegitea seinale kudeatzeilea ezartzerakoan"
 
-#: ../src/unix/threadpsx.cpp:1167
+#: ../src/unix/threadpsx.cpp:1216
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -3334,71 +3379,71 @@ msgstr ""
 "Hutsegitea harira batzerakoan, oroimen galera potentziala atzeman da - "
 "mesedez berrabiarazi programa"
 
-#: ../src/msw/utils.cpp:629
+#: ../src/msw/utils.cpp:619
 #, c-format
 msgid "Failed to kill process %d"
 msgstr "Hutsegitea %d garapena hiltzerakoan"
 
-#: ../src/common/image.cpp:2500
+#: ../src/common/image.cpp:2595
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Hutsegitea \"%s\" bitmapa baliabideetatik gertatzerakoan."
 
-#: ../src/common/image.cpp:2509
+#: ../src/common/image.cpp:2604
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Hutsegitea \"%s\" ikurra baliabideetatik gertatzerakoan."
 
-#: ../src/common/iconbndl.cpp:225
+#: ../src/common/iconbndl.cpp:224
 #, fuzzy, c-format
 msgid "Failed to load icons from resource '%s'."
 msgstr "Hutsegitea \"%s\" ikurra baliabideetatik gertatzerakoan."
 
-#: ../src/common/iconbndl.cpp:200
+#: ../src/common/iconbndl.cpp:198
 #, c-format
 msgid "Failed to load image %%d from file '%s'."
 msgstr "Hutsegitea %%d irudia '%s' agiritik gertatzerakoan."
 
-#: ../src/common/iconbndl.cpp:208
+#: ../src/common/iconbndl.cpp:206
 #, c-format
 msgid "Failed to load image %d from stream."
 msgstr "Hutsegitea %d irudia jariotik gertatzerakoan."
 
-#: ../src/common/image.cpp:2587 ../src/common/image.cpp:2606
+#: ../src/common/image.cpp:2682 ../src/common/image.cpp:2701
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Hutsegita irudia \"%s\" agiritik gertatzerakoan."
 
-#: ../src/msw/enhmeta.cpp:97
+#: ../src/msw/enhmeta.cpp:94
 #, c-format
 msgid "Failed to load metafile from file \"%s\"."
 msgstr "Hutsegita meta-agiria \"%s\" agiritik gertatzerakoan."
 
-#: ../src/msw/volume.cpp:327
+#: ../src/msw/volume.cpp:335
 msgid "Failed to load mpr.dll."
 msgstr "Hutsegitea mpr.dll gertatzerakoan."
 
-#: ../src/msw/utils.cpp:953
+#: ../src/msw/utils.cpp:943
 #, c-format
 msgid "Failed to load resource \"%s\"."
 msgstr "Hutsegitea \"%s\" baliabidea gertatzerakoan."
 
-#: ../src/common/dynlib.cpp:92
+#: ../src/common/dynlib.cpp:86
 #, c-format
 msgid "Failed to load shared library '%s'"
 msgstr "Hutsegitea '%s' partekatze agiria gertatzerakoan"
 
-#: ../src/osx/core/sound.cpp:145
+#: ../src/osx/core/sound.cpp:143
 #, c-format
 msgid "Failed to load sound from \"%s\" (error %d)."
 msgstr "Hutsegitea soinua \"%s\"-tik gertatzerakoan (akatsa %d)."
 
-#: ../src/msw/utils.cpp:960
+#: ../src/msw/utils.cpp:950
 #, c-format
 msgid "Failed to lock resource \"%s\"."
 msgstr "Hutsegitea \"%s\" baliabidea blokeatzerakoan."
 
-#: ../src/unix/snglinst.cpp:198
+#: ../src/unix/snglinst.cpp:195
 #, c-format
 msgid "Failed to lock the lock file '%s'"
 msgstr "Hutsegitea '%s' blokeo agiria blokeatzerakoan"
@@ -3408,33 +3453,38 @@ msgstr "Hutsegitea '%s' blokeo agiria blokeatzerakoan"
 msgid "Failed to modify descriptor %d in epoll descriptor %d"
 msgstr "Hutsegitea %d azaltzailea %d epoll azaltzailean aldatzerakoan"
 
-#: ../src/common/filename.cpp:2575
+#: ../src/common/filename.cpp:2658
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Hutsegitea '%s'-rako agiri denborak aldatzerakoan"
 
-#: ../src/common/selectdispatcher.cpp:258
+#: ../src/common/selectdispatcher.cpp:255
 msgid "Failed to monitor I/O channels"
 msgstr "Hutsegitea Sar/Irt bideak monitorizatzerakoan"
 
-#: ../src/common/filename.cpp:175
+#: ../src/common/filename.cpp:172
 #, c-format
 msgid "Failed to open '%s' for reading"
 msgstr "Hutsegitea '%s' irakurtzeko irekitzerakoan"
 
-#: ../src/common/filename.cpp:180
+#: ../src/common/filename.cpp:177
 #, c-format
 msgid "Failed to open '%s' for writing"
 msgstr "Hutsegitea '%s' idazteko irekitzerakoan"
 
-#: ../src/html/chm.cpp:141
+#: ../src/html/chm.cpp:138
 #, c-format
 msgid "Failed to open CHM archive '%s'."
 msgstr "Hutsegitea '%s' CHM agiria irekitzerakoan."
 
-#: ../src/common/utilscmn.cpp:1126
+#: ../src/common/utilscmn.cpp:1140
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Hutsegitea \"%s\" URL-a berezko bilatzailean irekitzerakoan."
+
+#: ../src/common/hyperlnkcmn.cpp:133
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Hutsegitea \"%s\" URL-a berezko bilatzailean irekitzerakoan."
 
 #: ../include/wx/msw/private/fswatcher.h:92
@@ -3442,93 +3492,103 @@ msgstr "Hutsegitea \"%s\" URL-a berezko bilatzailean irekitzerakoan."
 msgid "Failed to open directory \"%s\" for monitoring."
 msgstr "Hutsegitea \"%s\" zuzenbidea monitorizatzeko irekitzerakoan."
 
-#: ../src/x11/utils.cpp:227
+#: ../src/x11/utils.cpp:189
 #, c-format
 msgid "Failed to open display \"%s\"."
 msgstr "Hutsegitea \"%s\" erakustea irekitzerakoan."
 
-#: ../src/common/filename.cpp:1062
+#: ../src/common/filename.cpp:1059
 msgid "Failed to open temporary file."
 msgstr "Hutsegitea aldibaterako agiria irekitzerakoan."
 
-#: ../src/msw/clipbrd.cpp:91
+#: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Hutsegitea gakoa irekitzeakoan."
 
-#: ../src/common/translation.cpp:1184
+#: ../src/common/translation.cpp:1226
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Hutsegitea Anitz-Erak aztertzerakoan: '%s'"
 
-#: ../src/unix/mediactrl.cpp:1214
+#: ../src/unix/mediactrl.cpp:1239
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Hutsegitea \"%s\" irakurketa gertatzerakoan."
 
-#: ../src/msw/clipbrd.cpp:600
+#: ../src/msw/clipbrd.cpp:610
 msgid "Failed to put data on the clipboard"
 msgstr "Hutsegitea datua gakoan jartzerakoan"
 
-#: ../src/unix/snglinst.cpp:278
+#: ../src/unix/snglinst.cpp:275
 msgid "Failed to read PID from lock file."
 msgstr "Hutsegitea blokeo agiritik PID-a irakurtzerakoan."
 
-#: ../src/common/fileconf.cpp:433
+#: ../src/common/fileconf.cpp:432
 msgid "Failed to read config options."
 msgstr "Hutsegitea itxurap aukerak irakurtzerakoan."
 
-#: ../src/common/docview.cpp:681
+#: ../src/common/docview.cpp:676
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Hutsegitea \"%s\" agiritik agiria irakurtzerakoan."
 
-#: ../src/dfb/evtloop.cpp:98
+#: ../src/dfb/evtloop.cpp:99
 msgid "Failed to read event from DirectFB pipe"
 msgstr "Hutsegitea DirectFB pipe-tik gertaera irakurtzerakoan"
 
-#: ../src/unix/wakeuppipe.cpp:120
+#: ../src/unix/wakeuppipe.cpp:117
 msgid "Failed to read from wake-up pipe"
 msgstr "Hutsegitea iratzar hoditik irakurtzerakoan"
 
-#: ../src/unix/utilsunx.cpp:679
+#: ../src/common/textfile.cpp:96
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Hutsegitea \"%s\" agiritik agiria irakurtzerakoan."
+
+#: ../src/unix/utilsunx.cpp:681
 msgid "Failed to redirect child process input/output"
 msgstr "Hutsegitea child garapen sarrera/irteera berbideratzerakoan"
 
-#: ../src/msw/utilsexc.cpp:701
+#: ../src/msw/utilsexc.cpp:698
 msgid "Failed to redirect the child process IO"
 msgstr "Hutsegitea child garapen SI berbideratzerakoan"
 
-#: ../src/msw/dde.cpp:288
+#: ../src/msw/dde.cpp:283
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Hutsegitea '%s' DDE zerbitzaria erregistratzerakoan"
 
-#: ../src/common/fontmap.cpp:245
+#: ../src/gtk/font.cpp:580
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "Hutsegitea erabiltzaile itxurapen agiria eguneratzerakoan."
+
+#: ../src/common/fontmap.cpp:242
 #, c-format
 msgid "Failed to remember the encoding for the charset '%s'."
 msgstr "Hutsegitea '%s' hizkikodea kodeatzeaz gogoratzerakoan."
 
-#: ../src/common/debugrpt.cpp:227
+#: ../src/common/debugrpt.cpp:228
 #, c-format
 msgid "Failed to remove debug report file \"%s\""
 msgstr "Hutsegitea \"%s\" garbiketa jakinarazpen agiria kentzerakoan"
 
-#: ../src/unix/snglinst.cpp:328
+#: ../src/unix/snglinst.cpp:325
 #, c-format
 msgid "Failed to remove lock file '%s'"
 msgstr "Hutsegitea '%s' blokeo agiria kentzerakoan"
 
-#: ../src/unix/snglinst.cpp:288
+#: ../src/unix/snglinst.cpp:285
 #, c-format
 msgid "Failed to remove stale lock file '%s'."
 msgstr "Hutsegitea '%s' blokeo agiri zaharra kentzerakoan."
 
-#: ../src/msw/registry.cpp:529
+#: ../src/msw/registry.cpp:518
 #, c-format
 msgid "Failed to rename registry value '%s' to '%s'."
 msgstr "Hutsegitea '%s' erregistro balioa '%s'-ra birrizendatzerakoan."
 
-#: ../src/common/filefn.cpp:1122
+#: ../src/common/filefn.cpp:1011
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -3537,116 +3597,125 @@ msgstr ""
 "Hutsegitea '%s' agiria '%s'-ra birrizendatzean zerezn helmuga agiria jadanik "
 "badago."
 
-#: ../src/msw/registry.cpp:634
+#: ../src/msw/registry.cpp:623
 #, c-format
 msgid "Failed to rename the registry key '%s' to '%s'."
 msgstr "Hutsegitea '%s' erregistro giltza '%s'-ra birrizendatzerakoan."
 
-#: ../src/common/filename.cpp:2671
+#: ../src/msw/webview_ie.cpp:995
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/common/filename.cpp:2754
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Hutsegitea '%s'-rako agiri denborak berreskuratzerakoan"
 
-#: ../src/msw/dialup.cpp:468
+#: ../src/msw/dialup.cpp:462
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Hutsegitea RAS akats mezutik idazkia berreskuratzerakoan"
 
-#: ../src/msw/clipbrd.cpp:748
+#: ../src/msw/clipbrd.cpp:768
 msgid "Failed to retrieve the supported clipboard formats"
 msgstr "Hutsegitea gako heuskarri sostengatuak berreskuratzearakoan"
 
-#: ../src/common/docview.cpp:652
+#: ../src/common/docview.cpp:647
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Hutsegitea agiria \"%s\" agirian gordetzerakoan."
 
-#: ../src/msw/dib.cpp:269
+#: ../src/msw/dib.cpp:312
 #, c-format
 msgid "Failed to save the bitmap image to file \"%s\"."
 msgstr "Hutsegitea bitmapa irudia \"%s\" agirian gordetzerakoan."
 
-#: ../src/msw/dde.cpp:763
+#: ../src/msw/dde.cpp:811
 msgid "Failed to send DDE advise notification"
 msgstr "Hutsegitea DDE ohar jakinarazpena bildaltzerakoan"
 
-#: ../src/common/ftp.cpp:402
+#: ../src/common/ftp.cpp:399
 #, c-format
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Hutsegitea FTP eskualdaketa modua %s-ra ezartzerakoan."
 
-#: ../src/msw/clipbrd.cpp:427
+#: ../src/msw/clipbrd.cpp:443
 msgid "Failed to set clipboard data."
 msgstr "Hutsegitea gako datua ezartzerakoan."
 
-#: ../src/unix/snglinst.cpp:181
+#: ../src/unix/snglinst.cpp:178
 #, c-format
 msgid "Failed to set permissions on lock file '%s'"
 msgstr "Hutsegitea '%s' blokeo agirian baimenak ezartzerakoan"
 
-#: ../src/unix/utilsunx.cpp:668
+#: ../src/unix/utilsunx.cpp:670
 msgid "Failed to set process priority"
 msgstr "Hutsegitea prozesu lehentasuna ezartzerakoan"
 
-#: ../src/common/file.cpp:559
+#: ../src/common/ffile.cpp:355 ../src/common/file.cpp:586
 msgid "Failed to set temporary file permissions"
 msgstr "Hutsegitea aldibaterako agiri baimenak ezartzerakoan"
 
-#: ../src/gtk/textctrl.cpp:1072
-msgid "Failed to set text in the text control."
-msgstr "Hutsegitea idazki agintean idazkia ezartzerakoan."
-
-#: ../src/unix/threadpsx.cpp:1298
+#: ../src/unix/threadpsx.cpp:1347
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Hutsegitea hari lehentasuna %lu ezartzerakoan."
 
-#: ../src/unix/threadpsx.cpp:1424
+#: ../src/unix/threadpsx.cpp:1473
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Hutsegitea %d hari lehentasuna ezartzerakoan."
 
-#: ../src/unix/utilsunx.cpp:783
+#: ../src/unix/utilsunx.cpp:785
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 "Hutsegitea ez-blokeo hodia ezartzerakoan, programa blokeatu egin daiteke."
 
-#: ../src/common/fs_mem.cpp:261
+#: ../src/msw/webview_ie.cpp:987
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:256
 #, c-format
 msgid "Failed to store image '%s' to memory VFS!"
 msgstr "Hutsegitea '%s' irudia VFS oroimenean biltegiratzerakoan!"
 
-#: ../src/dfb/evtloop.cpp:170
+#: ../src/dfb/evtloop.cpp:171
 msgid "Failed to switch DirectFB pipe to non-blocking mode"
 msgstr "Hutsegitea DirectFB hodia ez-blokeatzen modura aldatzerakoan"
 
-#: ../src/unix/wakeuppipe.cpp:59
+#: ../src/unix/wakeuppipe.cpp:56
 msgid "Failed to switch wake up pipe to non-blocking mode"
 msgstr "Hutsegitea iratzar hodia ez-blokeatzen modura aldatzerakoan"
 
-#: ../src/unix/threadpsx.cpp:1605
+#: ../src/unix/threadpsx.cpp:1654
 msgid "Failed to terminate a thread."
 msgstr "Hutsegitea hari bat amaitzerakoan."
 
-#: ../src/msw/dde.cpp:741
+#: ../src/msw/dde.cpp:736
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "Hutsegitea DDE zerbitzariarekin ohar bigizta amaitzerakoan"
 
-#: ../src/msw/dialup.cpp:938
+#: ../src/msw/dialup.cpp:932
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Hutsegitea urrutizkin elkarketa amaitzerakoan: %s"
 
-#: ../src/common/filename.cpp:2590
+#: ../src/common/filename.cpp:2673
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Hutsegitea '%s' agiria ikutzerakoan"
 
-#: ../src/unix/snglinst.cpp:334
+#: ../src/unix/dlunix.cpp:90
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "Hutsegitea '%s' partekatze agiria gertatzerakoan"
+
+#: ../src/unix/snglinst.cpp:331
 #, c-format
 msgid "Failed to unlock lock file '%s'"
 msgstr "Hutsegitea '%s' blokeo agiria desblokeatzerakoan"
 
-#: ../src/msw/dde.cpp:309
+#: ../src/msw/dde.cpp:304
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Hutsegitea '%s' DDE zerbitzaria erregistratu gabetzerakoan"
@@ -3661,77 +3730,87 @@ msgstr ""
 msgid "Failed to update user configuration file."
 msgstr "Hutsegitea erabiltzaile itxurapen agiria eguneratzerakoan."
 
-#: ../src/common/debugrpt.cpp:733
+#: ../src/common/debugrpt.cpp:743
 #, c-format
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Hutsegitea garbiketa jakinarazpena igotzerakoan (akats kodea %d)."
 
-#: ../src/unix/snglinst.cpp:168
+#: ../src/unix/snglinst.cpp:165
 #, c-format
 msgid "Failed to write to lock file '%s'"
 msgstr "Hutsegitea '%s' blokeo agiria idazterakoan"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:209
+#: ../src/propgrid/propgrid.cpp:190
 msgid "False"
 msgstr "Faltsua"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:694
+#: ../src/propgrid/advprops.cpp:604
 msgid "Family"
 msgstr "Sendia"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/gtk/glcanvas.cpp:176 ../src/gtk/glcanvas.cpp:187
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Agiri akatsa"
+
+#: ../src/common/stockitem.cpp:154
 msgid "File"
 msgstr "Agiria"
 
-#: ../src/common/docview.cpp:669
+#: ../src/common/docview.cpp:664
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "\"%s\" agiria ezin da irakurtzeko ireki."
 
-#: ../src/common/docview.cpp:646
+#: ../src/common/docview.cpp:641
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "\"%s\" agiria ezin da idazteko ireki."
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "'%s' agiria jadanik badago, egitan nahi duzu gainidaztea?"
 
-#: ../src/common/filefn.cpp:1156
+#: ../src/common/filefn.cpp:1044
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "'%s' agiria ezin da kendu"
 
-#: ../src/common/filefn.cpp:1139
+#: ../src/common/filefn.cpp:1028
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "'%s' agiria ezin da berrizendatu '%s'"
 
-#: ../src/richtext/richtextctrl.cpp:3081 ../src/common/textcmn.cpp:953
+#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
 msgid "File couldn't be loaded."
 msgstr "Agiria ezin da gertatu."
 
-#: ../src/msw/filedlg.cpp:393
+#: ../src/msw/filedlg.cpp:414
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Agiri elkarrizketa hutsegitea %0lx akats kodearekin."
 
-#: ../src/common/docview.cpp:1789
+#: ../src/common/docview.cpp:1783
 msgid "File error"
 msgstr "Agiri akatsa"
 
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/filectrlg.cpp:770
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/filectrlg.cpp:766
 msgid "File name exists already."
 msgstr "Agiri izena badago jadanik."
+
+#: ../src/osx/cocoa/filedlg.mm:264
+#, fuzzy
+msgid "File type:"
+msgstr "Teletipoa"
 
 #: ../src/motif/filedlg.cpp:220
 msgid "Files"
 msgstr "Agiriak"
 
-#: ../src/common/filefn.cpp:1591
+#: ../src/common/filefn.cpp:1479
 #, c-format
 msgid "Files (%s)"
 msgstr "Agiriak (%s)"
@@ -3740,15 +3819,29 @@ msgstr "Agiriak (%s)"
 msgid "Filter"
 msgstr "Iragazkia"
 
-#: ../src/common/stockitem.cpp:158 ../src/html/helpwnd.cpp:490
+#: ../src/html/helpwnd.cpp:488
 msgid "Find"
 msgstr "Bilatu"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:259
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:258
+#, fuzzy
+msgid "Find in document"
+msgstr "Ireki HTML agiria"
+
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "Find..."
+msgstr "Bilatu"
+
+#: ../src/common/stockitem.cpp:156
 msgid "First"
 msgstr "Lehena"
 
-#: ../src/common/prntbase.cpp:1548
+#: ../src/common/prntbase.cpp:1573
 msgid "First page"
 msgstr "Lehen orrialdea"
 
@@ -3756,11 +3849,11 @@ msgstr "Lehen orrialdea"
 msgid "Fixed"
 msgstr "Zuzenduta"
 
-#: ../src/html/helpwnd.cpp:1206
+#: ../src/html/helpwnd.cpp:1204
 msgid "Fixed font:"
 msgstr "Zuzendutako hizkia:"
 
-#: ../src/html/helpwnd.cpp:1269
+#: ../src/html/helpwnd.cpp:1267
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Zuzendutako neurri aldea.<br> <b>lodia</b> <i>etzana</i> "
 
@@ -3768,16 +3861,16 @@ msgstr "Zuzendutako neurri aldea.<br> <b>lodia</b> <i>etzana</i> "
 msgid "Floating"
 msgstr "Gain"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "Floppy"
 msgstr "Malgua"
 
-#: ../src/common/paper.cpp:111
+#: ../src/common/paper.cpp:108
 msgid "Folio, 8 1/2 x 13 in"
 msgstr "Folio, 8 1/2 x 13 in"
 
-#: ../src/richtext/richtextformatdlg.cpp:344 ../src/osx/carbon/fontdlg.cpp:287
-#: ../src/common/stockitem.cpp:194
+#: ../src/osx/carbon/fontdlg.cpp:284 ../src/common/stockitem.cpp:191
+#: ../src/richtext/richtextformatdlg.cpp:337
 msgid "Font"
 msgstr "Hizkia"
 
@@ -3785,7 +3878,24 @@ msgstr "Hizkia"
 msgid "Font &weight:"
 msgstr "Hizki &zabalera:"
 
-#: ../src/html/helpwnd.cpp:1207
+#: ../src/osx/fontutil.cpp:89
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
+"\"."
+msgstr ""
+
+#: ../src/msw/font.cpp:1126
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Agiria ezin da gertatu."
+
+#: ../src/osx/fontutil.cpp:81
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "%s agiria ez dago."
+
+#: ../src/html/helpwnd.cpp:1205
 msgid "Font size:"
 msgstr "Hizki neurria:"
 
@@ -3793,53 +3903,53 @@ msgstr "Hizki neurria:"
 msgid "Font st&yle:"
 msgstr "Hizki es&tiloa:"
 
-#: ../src/osx/carbon/fontdlg.cpp:329
+#: ../src/osx/carbon/fontdlg.cpp:326
 msgid "Font:"
 msgstr "Hizkia:"
 
-#: ../src/dfb/fontmgr.cpp:198
+#: ../src/dfb/fontmgr.cpp:195
 #, c-format
 msgid "Fonts index file %s disappeared while loading fonts."
 msgstr "%s hizki agiria ezagertu egin da hizkiak gertatzerakoan."
 
-#: ../src/unix/utilsunx.cpp:645
+#: ../src/unix/utilsunx.cpp:647
 msgid "Fork failed"
 msgstr "Adar hutsegitea"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "Forward"
 msgstr "Aurrera"
 
-#: ../src/common/xtixml.cpp:235
+#: ../src/common/xtixml.cpp:231
 msgid "Forward hrefs are not supported"
 msgstr "hrefs bidalketa ez dago sostengaturik"
 
-#: ../src/html/helpwnd.cpp:875
+#: ../src/html/helpwnd.cpp:873
 #, c-format
 msgid "Found %i matches"
 msgstr "Aurkituta %i bat egite"
 
-#: ../src/generic/prntdlgg.cpp:238
+#: ../src/generic/prntdlgg.cpp:231
 msgid "From:"
 msgstr "Hemendik:"
 
-#: ../src/propgrid/advprops.cpp:1604
+#: ../src/propgrid/advprops.cpp:1510
 msgid "Fuchsia"
 msgstr "Fuksia"
 
-#: ../src/common/imaggif.cpp:138
+#: ../src/common/imaggif.cpp:135
 msgid "GIF: data stream seems to be truncated."
 msgstr "GiF: datu jarioa etenda dagoela dirudi."
 
-#: ../src/common/imaggif.cpp:128
+#: ../src/common/imaggif.cpp:125
 msgid "GIF: error in GIF image format."
 msgstr "GIF: akats GIF irudi heuskarrian."
 
-#: ../src/common/imaggif.cpp:133
+#: ../src/common/imaggif.cpp:130
 msgid "GIF: not enough memory."
 msgstr "GIF: ez dago nahikoa oroimenik."
 
-#: ../src/gtk/window.cpp:4631
+#: ../src/gtk/window.cpp:5635
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -3847,23 +3957,23 @@ msgstr ""
 "Gailu honetan ezarritako GTK+ zaharregia da ikusleiho osaketa sostengatzeko, "
 "mesedez ezarri GTK+2.12 edo berriagoa."
 
-#: ../src/univ/themes/gtk.cpp:525
+#: ../src/univ/themes/gtk.cpp:522
 msgid "GTK+ theme"
 msgstr "GTK+ azalgaia"
 
-#: ../src/common/preferencescmn.cpp:40
+#: ../src/common/preferencescmn.cpp:37
 msgid "General"
 msgstr "Orokorra"
 
-#: ../src/common/prntbase.cpp:258
+#: ../src/common/prntbase.cpp:253
 msgid "Generic PostScript"
 msgstr "PostScript Generikoa"
 
-#: ../src/common/paper.cpp:135
+#: ../src/common/paper.cpp:132
 msgid "German Legal Fanfold, 8 1/2 x 13 in"
 msgstr "German Legal Fanfold, 8 1/2 x 13 in"
 
-#: ../src/common/paper.cpp:134
+#: ../src/common/paper.cpp:131
 msgid "German Std Fanfold, 8 1/2 x 12 in"
 msgstr "German Std Fanfold, 8 1/2 x 12 in"
 
@@ -3879,48 +3989,48 @@ msgstr "GetPropertyCollection sarbideratzaile generiko batean deituta"
 msgid "GetPropertyCollection called w/o valid collection getter"
 msgstr "GetPropertyCollection w/o baliozko bilduma lortzailea deituta"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:658
 msgid "Go back"
 msgstr "Joan atzera"
 
-#: ../src/html/helpwnd.cpp:661
+#: ../src/html/helpwnd.cpp:659
 msgid "Go forward"
 msgstr "Joan aurrera"
 
-#: ../src/html/helpwnd.cpp:663
+#: ../src/html/helpwnd.cpp:661
 msgid "Go one level up in document hierarchy"
 msgstr "Joan maila bat gora agiri hierarkian"
 
-#: ../src/generic/filedlgg.cpp:208 ../src/generic/dirdlgg.cpp:116
+#: ../src/generic/filedlgg.cpp:205 ../src/generic/dirdlgg.cpp:113
 msgid "Go to home directory"
 msgstr "Joan hasierako zuzenbidera"
 
-#: ../src/generic/filedlgg.cpp:205
+#: ../src/generic/filedlgg.cpp:202
 msgid "Go to parent directory"
 msgstr "Joan gaineko zuzenbidera"
 
-#: ../src/generic/aboutdlgg.cpp:76
+#: ../src/generic/aboutdlgg.cpp:73
 msgid "Graphics art by "
 msgstr "Grafiko egilea"
 
-#: ../src/propgrid/advprops.cpp:1599
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Gray"
 msgstr "Urdinabarra"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:883
+#: ../src/propgrid/advprops.cpp:784
 msgid "GrayText"
 msgstr "Urdainabar-Idazkia"
 
-#: ../src/common/fmapbase.cpp:154
+#: ../src/common/fmapbase.cpp:151
 msgid "Greek (ISO-8859-7)"
 msgstr "Greziera (ISO-8859-7)"
 
-#: ../src/propgrid/advprops.cpp:1600
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Green"
 msgstr "Orlegia"
 
-#: ../src/generic/colrdlgg.cpp:342
+#: ../src/generic/colrdlgg.cpp:362
 #, fuzzy
 msgid "Green:"
 msgstr "Orlegia"
@@ -3929,107 +4039,107 @@ msgstr "Orlegia"
 msgid "Groove"
 msgstr "Groove"
 
-#: ../src/common/zstream.cpp:158 ../src/common/zstream.cpp:318
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
 msgid "Gzip not supported by this version of zlib"
 msgstr "Gzip ez dago sostengaturik zlib bertsio honetarako"
 
-#: ../src/html/helpwnd.cpp:1549
+#: ../src/html/helpwnd.cpp:1547
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "HTML Laguntza Egitasmoa (*.hhp)|*.hhp|"
 
-#: ../src/html/htmlwin.cpp:681
+#: ../src/html/htmlwin.cpp:691
 #, c-format
 msgid "HTML anchor %s does not exist."
 msgstr "HTML %s aingura ez dago."
 
-#: ../src/html/helpwnd.cpp:1547
+#: ../src/html/helpwnd.cpp:1545
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "HTML agiriak (*.html;*.htm)|*.html;*.htm|"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1759
+#: ../src/propgrid/advprops.cpp:1660
 msgid "Hand"
 msgstr "Eskua"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "Harddisk"
 msgstr "Diska-gogorra"
 
-#: ../src/common/fmapbase.cpp:155
+#: ../src/common/fmapbase.cpp:152
 msgid "Hebrew (ISO-8859-8)"
 msgstr "Hebraiera (ISO-8859-8)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:280 ../src/osx/button_osx.cpp:39
-#: ../src/common/stockitem.cpp:163 ../src/common/accelcmn.cpp:80
-#: ../src/html/helpdlg.cpp:66 ../src/html/helpfrm.cpp:111
+#: ../include/wx/msgdlg.h:282 ../src/osx/button_osx.cpp:39
+#: ../src/common/stockitem.cpp:160 ../src/common/accelcmn.cpp:77
+#: ../src/html/helpfrm.cpp:108 ../src/html/helpdlg.cpp:63
 msgid "Help"
 msgstr "Laguntza"
 
-#: ../src/html/helpwnd.cpp:1200
+#: ../src/html/helpwnd.cpp:1198
 msgid "Help Browser Options"
 msgstr "Laguntza Bilatzaile Aukerak"
 
-#: ../src/generic/helpext.cpp:454 ../src/generic/helpext.cpp:455
+#: ../src/generic/helpext.cpp:452 ../src/generic/helpext.cpp:453
 msgid "Help Index"
 msgstr "Laguntza Aurkibidea"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1529
 msgid "Help Printing"
 msgstr "Laguntza Irarketa"
 
-#: ../src/html/helpwnd.cpp:801
+#: ../src/html/helpwnd.cpp:799
 msgid "Help Topics"
 msgstr "Laguntza Gaiak"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1546
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Laguntza liburuak (*.htb)|*.htb|Laguntza liburuak (*.zip)|*.zip|"
 
-#: ../src/generic/helpext.cpp:267
+#: ../src/generic/helpext.cpp:265
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "\"%s\" laguntza zuzenbidea ez da aurkitu."
 
-#: ../src/generic/helpext.cpp:275
+#: ../src/generic/helpext.cpp:273
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "\"%s\" laguntza agiri ez da aurkitu."
 
-#: ../src/html/helpctrl.cpp:63
+#: ../src/html/helpctrl.cpp:59
 #, c-format
 msgid "Help: %s"
 msgstr "Laguntza: %s"
 
-#: ../src/osx/menu_osx.cpp:577
+#: ../src/osx/menu_osx.cpp:469
 #, c-format
 msgid "Hide %s"
 msgstr "Ezkutatu %s"
 
-#: ../src/osx/menu_osx.cpp:579
+#: ../src/osx/menu_osx.cpp:471
 msgid "Hide Others"
 msgstr "Ezkutatu Besteak"
 
-#: ../src/generic/infobar.cpp:84
+#: ../src/generic/infobar.cpp:81
 msgid "Hide this notification message."
 msgstr "Ezkutatu ohar mezu hau."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:884
+#: ../src/propgrid/advprops.cpp:785
 msgid "Highlight"
 msgstr "Nabarmendu"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:885
+#: ../src/propgrid/advprops.cpp:786
 msgid "HighlightText"
 msgstr "Nabarmendu-Idazkia"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:164 ../src/common/accelcmn.cpp:65
+#: ../src/common/stockitem.cpp:161 ../src/common/accelcmn.cpp:62
 msgid "Home"
 msgstr "Hasiera"
 
-#: ../src/generic/dirctrlg.cpp:524
+#: ../src/generic/dirctrlg.cpp:490
 msgid "Home directory"
 msgstr "Hasierako zuzenbidea"
 
@@ -4039,55 +4149,55 @@ msgid "How the object will float relative to the text."
 msgstr "Objetua idazkiarekiko nola gain ezarriko den."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1760
+#: ../src/propgrid/advprops.cpp:1661
 msgid "I-Beam"
 msgstr "I-Beam"
 
-#: ../src/common/imagbmp.cpp:1196
+#: ../src/common/imagbmp.cpp:1208
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: Akatsa DIB mozorroa irakurtzerakoan."
 
-#: ../src/common/imagbmp.cpp:1290 ../src/common/imagbmp.cpp:1390
-#: ../src/common/imagbmp.cpp:1405 ../src/common/imagbmp.cpp:1416
-#: ../src/common/imagbmp.cpp:1430 ../src/common/imagbmp.cpp:1478
-#: ../src/common/imagbmp.cpp:1493 ../src/common/imagbmp.cpp:1507
-#: ../src/common/imagbmp.cpp:1518
+#: ../src/common/imagbmp.cpp:1302 ../src/common/imagbmp.cpp:1402
+#: ../src/common/imagbmp.cpp:1417 ../src/common/imagbmp.cpp:1428
+#: ../src/common/imagbmp.cpp:1442 ../src/common/imagbmp.cpp:1490
+#: ../src/common/imagbmp.cpp:1505 ../src/common/imagbmp.cpp:1519
+#: ../src/common/imagbmp.cpp:1530
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: Akatsa irudi agiria idazterakoan!"
 
-#: ../src/common/imagbmp.cpp:1255
+#: ../src/common/imagbmp.cpp:1267
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: Irudi garaiegia ikur batentzat."
 
-#: ../src/common/imagbmp.cpp:1263
+#: ../src/common/imagbmp.cpp:1275
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: Irudi zabalegia ikur batentzat."
 
-#: ../src/common/imagbmp.cpp:1603
+#: ../src/common/imagbmp.cpp:1615
 msgid "ICO: Invalid icon index."
 msgstr "ICO: ikur aurkibide baliogabea."
 
-#: ../src/common/imagiff.cpp:758
+#: ../src/common/imagiff.cpp:755
 msgid "IFF: data stream seems to be truncated."
 msgstr "IFF: datu jarioa etenda dagoela dirudi."
 
-#: ../src/common/imagiff.cpp:742
+#: ../src/common/imagiff.cpp:739
 msgid "IFF: error in IFF image format."
 msgstr "IFF: akatsa IFF irudi heuskarrian."
 
-#: ../src/common/imagiff.cpp:745
+#: ../src/common/imagiff.cpp:742
 msgid "IFF: not enough memory."
 msgstr "IFF: ez dago nahikoa oroimenik."
 
-#: ../src/common/imagiff.cpp:748
+#: ../src/common/imagiff.cpp:745
 msgid "IFF: unknown error!!!"
 msgstr "IFF: akats ezezaguna!!!"
 
-#: ../src/common/fmapbase.cpp:197
+#: ../src/common/fmapbase.cpp:194
 msgid "ISO-2022-JP"
 msgstr "ISO-2022-JP"
 
-#: ../src/html/htmprint.cpp:282
+#: ../src/html/htmprint.cpp:294
 msgid ""
 "If possible, try changing the layout parameters to make the printout more "
 "narrow."
@@ -4095,7 +4205,7 @@ msgstr ""
 "Ahal bada, saiatu antolakuntza parametroak aldatzen irarketa estuagoa "
 "egiteko."
 
-#: ../src/generic/dbgrptg.cpp:358
+#: ../src/generic/dbgrptg.cpp:362
 msgid ""
 "If you have any additional information pertaining to this bug\n"
 "report, please enter it here and it will be joined to it:"
@@ -4115,46 +4225,50 @@ msgstr ""
 "baina kontuan izan programaren hobekuntza zaildu dezakeela, hortaz\n"
 "ahal bezain mesedez jarraitu jakinarazpenaren sortzearekin.\n"
 
-#: ../src/msw/registry.cpp:1405
+#: ../src/common/zipstrm.cpp:1043
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1393
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "\"%s\" giltzaren \"%s\" balioa ezikusten."
 
-#: ../src/common/xtistrm.cpp:295
+#: ../src/common/xtistrm.cpp:292
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Legezkanpoko Objetu Klasea (Ez-wxEvtHandler) Gertaera Iturubur bezala"
 
-#: ../src/common/xti.cpp:513
+#: ../src/common/xti.cpp:510
 msgid "Illegal Parameter Count for ConstructObject Method"
 msgstr "Legezkanpoko Zenbaketa Parametroa Eraiki-Objetua Metodoarentzat"
 
-#: ../src/common/xti.cpp:501
+#: ../src/common/xti.cpp:498
 msgid "Illegal Parameter Count for Create Method"
 msgstr "Legezkanpoko Zenbaketa Parametroa Sortu Metodoarentzat"
 
-#: ../src/generic/dirctrlg.cpp:570 ../src/generic/filectrlg.cpp:756
+#: ../src/generic/dirctrlg.cpp:536 ../src/generic/filectrlg.cpp:752
 msgid "Illegal directory name."
 msgstr "Legezkanpoko zuzenbide izena."
 
-#: ../src/generic/filectrlg.cpp:1367
+#: ../src/generic/filectrlg.cpp:1356
 msgid "Illegal file specification."
 msgstr "Legezkanpoko agiri zehaztapena"
 
-#: ../src/common/image.cpp:2269
+#: ../src/common/image.cpp:2363
 msgid "Image and mask have different sizes."
 msgstr "Irudia eta mozorroak neurri ezberdinak dituzte."
 
-#: ../src/common/image.cpp:2746
+#: ../src/common/image.cpp:2841
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "Irudi agiria ez da %d motakoa."
 
-#: ../src/common/image.cpp:2877
+#: ../src/common/image.cpp:2995
 #, c-format
 msgid "Image is not of type %s."
 msgstr "Irudia ez da %s motakoa."
 
-#: ../src/msw/textctrl.cpp:488
+#: ../src/msw/textctrl.cpp:534
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -4162,100 +4276,100 @@ msgstr ""
 "Ezinezkoa aberastu edizio aginte bat sortzea, idazki arrunt agintea "
 "erabiltzen ordez. Mesedez berrezarri riched32.dll"
 
-#: ../src/unix/utilsunx.cpp:301
+#: ../src/unix/utilsunx.cpp:303
 msgid "Impossible to get child process input"
 msgstr "Ezinezkoa child garapen sarrera lortu"
 
-#: ../src/common/filefn.cpp:1028
+#: ../src/common/filefn.cpp:917
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Ezinezkoa '%s' agiriarentzat baimenak lortzea"
 
-#: ../src/common/filefn.cpp:1042
+#: ../src/common/filefn.cpp:931
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Ezinezkoa '%s' agiria gainidaztea"
 
-#: ../src/common/filefn.cpp:1097
+#: ../src/common/filefn.cpp:986
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Ezinezkoa '%s' agiriarentzako baimenak ezartzea"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:886
+#: ../src/propgrid/advprops.cpp:787
 msgid "InactiveBorder"
 msgstr "Hertza-Ezgaituta"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:887
+#: ../src/propgrid/advprops.cpp:788
 msgid "InactiveCaption"
 msgstr "Harpena-Ezgaituta"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:888
+#: ../src/propgrid/advprops.cpp:789
 msgid "InactiveCaptionText"
 msgstr "Harpen-Idazkia-Ezgaituta"
 
-#: ../src/common/gifdecod.cpp:792
+#: ../src/common/gifdecod.cpp:826
 #, c-format
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "GIF frame neurri okerra (%u, %d) #%u framean"
 
-#: ../src/msw/ole/automtn.cpp:635
+#: ../src/msw/ole/automtn.cpp:626
 msgid "Incorrect number of arguments."
 msgstr "Argumentu zenbateko okerra."
 
-#: ../src/common/stockitem.cpp:165
+#: ../src/common/stockitem.cpp:162
 msgid "Indent"
 msgstr "Elkarmarratxoa"
 
-#: ../src/richtext/richtextformatdlg.cpp:349
+#: ../src/richtext/richtextformatdlg.cpp:342
 msgid "Indents && Spacing"
 msgstr "Elkarmarratxoak eta Tarteak"
 
-#: ../src/common/stockitem.cpp:166 ../src/html/helpwnd.cpp:515
+#: ../src/common/stockitem.cpp:163 ../src/html/helpwnd.cpp:513
 msgid "Index"
 msgstr "Aurkibidea"
 
-#: ../src/common/fmapbase.cpp:159
+#: ../src/common/fmapbase.cpp:156
 msgid "Indian (ISO-8859-12)"
 msgstr "Indian (ISO-8859-12)"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "Info"
 msgstr "Argibideak"
 
-#: ../src/common/init.cpp:287
+#: ../src/common/init.cpp:284
 msgid "Initialization failed in post init, aborting."
 msgstr "Abiatzeak huts egin du abiostean, uzten."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:54
+#: ../src/common/accelcmn.cpp:51
 msgid "Ins"
 msgstr "Txert"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextsymboldlg.cpp:472 ../src/common/accelcmn.cpp:53
+#: ../src/common/accelcmn.cpp:50 ../src/richtext/richtextsymboldlg.cpp:469
 msgid "Insert"
 msgstr "Sartu"
 
-#: ../src/richtext/richtextbuffer.cpp:8067
+#: ../src/richtext/richtextbuffer.cpp:8063
 msgid "Insert Field"
 msgstr "Txertatu Eremua"
 
-#: ../src/richtext/richtextbuffer.cpp:7978
-#: ../src/richtext/richtextbuffer.cpp:8936
+#: ../src/richtext/richtextbuffer.cpp:7974
+#: ../src/richtext/richtextbuffer.cpp:8934
 msgid "Insert Image"
 msgstr "Sartu Irudia"
 
-#: ../src/richtext/richtextbuffer.cpp:8025
+#: ../src/richtext/richtextbuffer.cpp:8021
 msgid "Insert Object"
 msgstr "Sartu Objetua"
 
-#: ../src/richtext/richtextctrl.cpp:1286 ../src/richtext/richtextctrl.cpp:1494
-#: ../src/richtext/richtextbuffer.cpp:7822
-#: ../src/richtext/richtextbuffer.cpp:7852
-#: ../src/richtext/richtextbuffer.cpp:7894
+#: ../src/richtext/richtextbuffer.cpp:7818
+#: ../src/richtext/richtextbuffer.cpp:7848
+#: ../src/richtext/richtextbuffer.cpp:7890
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
 msgid "Insert Text"
 msgstr "Sartu Idazkia"
 
@@ -4268,16 +4382,11 @@ msgstr "Orrialde hauste bat txertatzen dut esaldiaren aurretik."
 msgid "Inset"
 msgstr "Sartu"
 
-#: ../src/gtk/app.cpp:425
-#, c-format
-msgid "Invalid GTK+ command line option, use \"%s --help\""
-msgstr "GTK+ komando lerro aukera baliogabea, erabili \"%s --help\""
-
-#: ../src/common/imagtiff.cpp:311
+#: ../src/common/imagtiff.cpp:308
 msgid "Invalid TIFF image index."
 msgstr "TIFF irudi aurkibide baliogabea."
 
-#: ../src/common/appcmn.cpp:273
+#: ../src/common/appcmn.cpp:294
 #, c-format
 msgid "Invalid display mode specification '%s'."
 msgstr "Erakus modu zehaztapen baliogabea '%s'."
@@ -4287,246 +4396,250 @@ msgstr "Erakus modu zehaztapen baliogabea '%s'."
 msgid "Invalid geometry specification '%s'"
 msgstr "Geometria zehaztapen baliogabea '%s'"
 
-#: ../src/unix/fswatcher_inotify.cpp:323
+#: ../src/unix/fswatcher_inotify.cpp:320
 #, c-format
 msgid "Invalid inotify event for \"%s\""
 msgstr "Inotify gertaera baliogabea \"%s\""
 
-#: ../src/unix/snglinst.cpp:312
+#: ../src/unix/snglinst.cpp:309
 #, c-format
 msgid "Invalid lock file '%s'."
 msgstr " '%s' blokeo agiri baliogabea "
 
-#: ../src/common/translation.cpp:1125
+#: ../src/common/translation.cpp:1167
 msgid "Invalid message catalog."
 msgstr "Mezu katalogo baliogabea."
 
-#: ../src/common/xtistrm.cpp:405 ../src/common/xtistrm.cpp:420
+#: ../src/common/xtistrm.cpp:402 ../src/common/xtistrm.cpp:417
 msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
 msgstr "Baliogabeko edo Nulloa Objetu ID-a igaro da GetObjectClassInfo-ra"
 
-#: ../src/common/xtistrm.cpp:435
+#: ../src/common/xtistrm.cpp:432
 msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
 msgstr "Baliogabeko edo Nuloa den Objetu ID-a igaro da HasObjectClassInfo-ra"
 
-#: ../src/common/regex.cpp:310
+#: ../src/common/regex.cpp:307
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Adierazpen arrunt baliogabea '%s': %s"
 
-#: ../src/common/config.cpp:226
+#: ../src/common/config.cpp:222
 #, c-format
 msgid "Invalid value %ld for a boolean key \"%s\" in config file."
 msgstr "Balio baliogabea %ld boolean giltzarakon \"%s\" itxurapen agirian."
 
-#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:351
-#: ../src/osx/carbon/fontdlg.cpp:361 ../src/common/stockitem.cpp:168
+#: ../src/osx/carbon/fontdlg.cpp:358 ../src/common/stockitem.cpp:165
+#: ../src/generic/fontdlgg.cpp:325 ../src/richtext/richtextfontpage.cpp:351
 msgid "Italic"
 msgstr "Etzana"
 
-#: ../src/common/paper.cpp:130
+#: ../src/common/paper.cpp:127
 msgid "Italy Envelope, 110 x 230 mm"
 msgstr "Italiar Gutunazala, 110 x 230 mm"
 
-#: ../src/common/imagjpeg.cpp:270
+#: ../src/common/imagjpeg.cpp:257
 msgid "JPEG: Couldn't load - file is probably corrupted."
 msgstr "JPEG: Ezinezkoa gertatzea - agiria zihurrenik hondatuta dago."
 
-#: ../src/common/imagjpeg.cpp:449
+#: ../src/common/imagjpeg.cpp:436
 msgid "JPEG: Couldn't save image."
 msgstr "JPEG: Ezinezkoa irudia gordetzea."
 
-#: ../src/common/paper.cpp:163
+#: ../src/common/paper.cpp:160
 msgid "Japanese Double Postcard 200 x 148 mm"
 msgstr "Japoniar Bidaitxartel Bikoitza 200 x 148 mm"
 
-#: ../src/common/paper.cpp:167
+#: ../src/common/paper.cpp:164
 msgid "Japanese Envelope Chou #3"
 msgstr "Japoniar Gutunazala Chou #3"
 
-#: ../src/common/paper.cpp:180
+#: ../src/common/paper.cpp:177
 msgid "Japanese Envelope Chou #3 Rotated"
 msgstr "Japoniar Gutunazala Chou #3 Itzulita"
 
-#: ../src/common/paper.cpp:168
+#: ../src/common/paper.cpp:165
 msgid "Japanese Envelope Chou #4"
 msgstr "Japoniar Gutunazala Chou #4"
 
-#: ../src/common/paper.cpp:181
+#: ../src/common/paper.cpp:178
 msgid "Japanese Envelope Chou #4 Rotated"
 msgstr "Japoniar Gutunazala Chou #4 Itzulita"
 
-#: ../src/common/paper.cpp:165
+#: ../src/common/paper.cpp:162
 msgid "Japanese Envelope Kaku #2"
 msgstr "Japoniar Gutunazala Kaku #2"
 
-#: ../src/common/paper.cpp:178
+#: ../src/common/paper.cpp:175
 msgid "Japanese Envelope Kaku #2 Rotated"
 msgstr "Japoniar Gutunazala Kaku #2 Itzulita"
 
-#: ../src/common/paper.cpp:166
+#: ../src/common/paper.cpp:163
 msgid "Japanese Envelope Kaku #3"
 msgstr "Japoniar Gutunazala Kaku #3"
 
-#: ../src/common/paper.cpp:179
+#: ../src/common/paper.cpp:176
 msgid "Japanese Envelope Kaku #3 Rotated"
 msgstr "Japoniar Gutunazala Kaku #3 Itzulita"
 
-#: ../src/common/paper.cpp:185
+#: ../src/common/paper.cpp:182
 msgid "Japanese Envelope You #4"
 msgstr "Japoniar Gutunazala You #4"
 
-#: ../src/common/paper.cpp:186
+#: ../src/common/paper.cpp:183
 msgid "Japanese Envelope You #4 Rotated"
 msgstr "Japoniar Gutunazala You #4 Itzulita"
 
-#: ../src/common/paper.cpp:138
+#: ../src/common/paper.cpp:135
 msgid "Japanese Postcard 100 x 148 mm"
 msgstr "Japoniar Bidaitxartela 100 x 148 mm"
 
-#: ../src/common/paper.cpp:175
+#: ../src/common/paper.cpp:172
 msgid "Japanese Postcard Rotated 148 x 100 mm"
 msgstr "Japoniar Bidaitxartela Itzulita 148 x 100 mm"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "Jump to"
 msgstr "Jauzi hona"
 
-#: ../src/common/stockitem.cpp:171
+#: ../src/common/stockitem.cpp:168
 msgid "Justified"
 msgstr "Berdinduta"
 
-#: ../src/richtext/richtextindentspage.cpp:155
-#: ../src/richtext/richtextindentspage.cpp:157
 #: ../src/richtext/richtextliststylepage.cpp:344
 #: ../src/richtext/richtextliststylepage.cpp:346
+#: ../src/richtext/richtextindentspage.cpp:155
+#: ../src/richtext/richtextindentspage.cpp:157
 msgid "Justify text left and right."
 msgstr "Berdindu idazkia ezker eta eskuin."
 
-#: ../src/common/fmapbase.cpp:163
+#: ../src/common/fmapbase.cpp:160
 msgid "KOI8-R"
 msgstr "KOI8-R"
 
-#: ../src/common/fmapbase.cpp:164
+#: ../src/common/fmapbase.cpp:161
 msgid "KOI8-U"
 msgstr "KOI8-U"
 
-#: ../src/common/accelcmn.cpp:265 ../src/common/accelcmn.cpp:347
+#: ../src/common/accelcmn.cpp:279 ../src/common/accelcmn.cpp:364
 msgid "KP_"
 msgstr "ZP_"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "KP_Add"
 msgstr "ZP_Gehiketa"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "KP_Begin"
 msgstr "ZP_Hasi"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "KP_Decimal"
 msgstr "ZP_Hamarrena"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 msgid "KP_Delete"
 msgstr "ZP_Ezabatu"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "KP_Divide"
 msgstr "ZP_Zatiketa"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 msgid "KP_Down"
 msgstr "ZP_Behera"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "KP_End"
 msgstr "ZP_Amaiera"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "KP_Enter"
 msgstr "ZP_Sartu"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "KP_Equal"
 msgstr "ZP_Berdin"
 
+#: ../src/common/accelcmn.cpp:276 ../src/common/accelcmn.cpp:361
+msgid "KP_F"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 msgid "KP_Home"
 msgstr "ZP_Hasiera"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 msgid "KP_Insert"
 msgstr "ZP_Txertatu"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "KP_Left"
 msgstr "ZP_Ezker"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "KP_Multiply"
 msgstr "ZP_Biderketa"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:99
+#: ../src/common/accelcmn.cpp:97
 msgid "KP_Next"
 msgstr "ZP_Hurrengoa"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "KP_PageDown"
 msgstr "ZP_OrrBehera"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "KP_PageUp"
 msgstr "ZP_OrrGora"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:98
+#: ../src/common/accelcmn.cpp:96
 msgid "KP_Prior"
 msgstr "ZP_Prior"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 msgid "KP_Right"
 msgstr "ZP_Eskuin"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "KP_Separator"
 msgstr "ZP_Banantzailea"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "KP_Space"
 msgstr "ZP_Tartea"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "KP_Subtract"
 msgstr "ZP_Kenketa"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "KP_Tab"
 msgstr "ZP_Tab"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "KP_Up"
 msgstr "ZP_Gora"
 
@@ -4534,112 +4647,127 @@ msgstr "ZP_Gora"
 msgid "L&ine spacing:"
 msgstr "L&erro tartea:"
 
-#: ../src/generic/prntdlgg.cpp:613 ../src/generic/prntdlgg.cpp:868
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "konpresio akatsa"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "deskonpresio akatsa"
+
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:861
 msgid "Landscape"
 msgstr "Etzana"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "Last"
 msgstr "Azkena"
 
-#: ../src/common/prntbase.cpp:1572
+#: ../src/common/prntbase.cpp:1597
 msgid "Last page"
 msgstr "Azken orrialdea"
 
-#: ../src/common/log.cpp:305
+#: ../src/common/log.cpp:324
 #, c-format
 msgid "Last repeated message (\"%s\", %u time) wasn't output"
 msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
 msgstr[0] "Berregindako azken mezua (\"%s\", %u aldiz) ez zen irteera"
 msgstr[1] "Berregindako azken mezua (\"%s\", %u aldiz) ez zen irteera"
 
-#: ../src/common/paper.cpp:103
+#: ../src/common/paper.cpp:100
 msgid "Ledger, 17 x 11 in"
 msgstr "Liburu nagusia, 17 x 11 in"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6146
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:58 ../src/generic/datavgen.cpp:6951
+#: ../src/richtext/richtextsizepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:252
 #: ../src/richtext/richtextliststylepage.cpp:253
 #: ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
-#: ../src/richtext/richtextsizepage.cpp:249 ../src/common/accelcmn.cpp:61
 msgid "Left"
 msgstr "Ezker"
 
-#: ../src/richtext/richtextindentspage.cpp:204
 #: ../src/richtext/richtextliststylepage.cpp:390
+#: ../src/richtext/richtextindentspage.cpp:204
 msgid "Left (&first line):"
 msgstr "Ezkerra (&lehen lerroa):"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1761
+#: ../src/propgrid/advprops.cpp:1662
 msgid "Left Button"
 msgstr "Ezker Botoia"
 
-#: ../src/generic/prntdlgg.cpp:880
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Left margin (mm):"
 msgstr "Ezker bazterra (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:141
-#: ../src/richtext/richtextindentspage.cpp:143
 #: ../src/richtext/richtextliststylepage.cpp:330
 #: ../src/richtext/richtextliststylepage.cpp:332
+#: ../src/richtext/richtextindentspage.cpp:141
+#: ../src/richtext/richtextindentspage.cpp:143
 msgid "Left-align text."
 msgstr "Idazkiaren ezkerrera lerrokatu."
 
-#: ../src/common/paper.cpp:144
+#: ../src/common/paper.cpp:141
 msgid "Legal Extra 9 1/2 x 15 in"
 msgstr "Legezkoa Estra 9 1/2 x 15 in"
 
-#: ../src/common/paper.cpp:96
+#: ../src/common/paper.cpp:93
 msgid "Legal, 8 1/2 x 14 in"
 msgstr "Legezkoa, 8 1/2 x 14 in"
 
-#: ../src/common/paper.cpp:143
+#: ../src/common/paper.cpp:140
 msgid "Letter Extra 9 1/2 x 12 in"
 msgstr "Gutuna Estra 9 1/2 x 12 in"
 
-#: ../src/common/paper.cpp:149
+#: ../src/common/paper.cpp:146
 msgid "Letter Extra Transverse 9.275 x 12 in"
 msgstr "Gutuna Estra Zeharka 9.275 x 12 in"
 
-#: ../src/common/paper.cpp:152
+#: ../src/common/paper.cpp:149
 msgid "Letter Plus 8 1/2 x 12.69 in"
 msgstr "Gutuna Plus 8 1/2 x 12.69 in"
 
-#: ../src/common/paper.cpp:169
+#: ../src/common/paper.cpp:166
 msgid "Letter Rotated 11 x 8 1/2 in"
 msgstr "Gutuna Itzulita 11 x 8 1/2 in"
 
-#: ../src/common/paper.cpp:101
+#: ../src/common/paper.cpp:98
 msgid "Letter Small, 8 1/2 x 11 in"
 msgstr "Gutun Txikia, 8 1/2 x 11 in"
 
-#: ../src/common/paper.cpp:147
+#: ../src/common/paper.cpp:144
 msgid "Letter Transverse 8 1/2 x 11 in"
 msgstr "Gutuna Zeharka 8 1/2 x 11 in"
 
-#: ../src/common/paper.cpp:95
+#: ../src/common/paper.cpp:92
 msgid "Letter, 8 1/2 x 11 in"
 msgstr "Gutuna, 8 1/2 x 11 in"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "License"
 msgstr "Baimena"
 
-#: ../src/generic/fontdlgg.cpp:332
+#: ../src/generic/fontdlgg.cpp:328
 msgid "Light"
 msgstr "Arina"
 
-#: ../src/propgrid/advprops.cpp:1608
+#: ../src/propgrid/advprops.cpp:1514
 msgid "Lime"
 msgstr "Lima"
 
-#: ../src/generic/helpext.cpp:294
+#: ../src/generic/helpext.cpp:292
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr "%lu lerroa \"%s\" mapa agirian joskera baliogabea du, ahaztuta."
@@ -4648,15 +4776,15 @@ msgstr "%lu lerroa \"%s\" mapa agirian joskera baliogabea du, ahaztuta."
 msgid "Line spacing:"
 msgstr "Lerro tartea:"
 
-#: ../src/html/chm.cpp:838
+#: ../src/html/chm.cpp:829
 msgid "Link contained '//', converted to absolute link."
 msgstr "Loturak  '//' du, lotura osoan bihurtuta."
 
-#: ../src/richtext/richtextformatdlg.cpp:364
+#: ../src/richtext/richtextformatdlg.cpp:357
 msgid "List Style"
 msgstr "Zerrenda Estiloa"
 
-#: ../src/richtext/richtextstyles.cpp:1064
+#: ../src/richtext/richtextstyles.cpp:1061
 msgid "List styles"
 msgstr "Zerrenda estiloak"
 
@@ -4670,26 +4798,26 @@ msgstr "Hizki neurriak puntutan zerrenda."
 msgid "Lists the available fonts."
 msgstr "Hizki eskuragarrien zerrenda"
 
-#: ../src/common/fldlgcmn.cpp:340
+#: ../src/common/fldlgcmn.cpp:337
 #, c-format
 msgid "Load %s file"
 msgstr "Gertatu %s agiria"
 
-#: ../src/html/htmlwin.cpp:597
+#: ../src/html/htmlwin.cpp:600
 msgid "Loading : "
 msgstr "Gertatzen :"
 
-#: ../src/unix/snglinst.cpp:246
+#: ../src/unix/snglinst.cpp:243
 #, c-format
 msgid "Lock file '%s' has incorrect owner."
 msgstr "'%s' blokeo agiriak jabe okerra du."
 
-#: ../src/unix/snglinst.cpp:251
+#: ../src/unix/snglinst.cpp:248
 #, c-format
 msgid "Lock file '%s' has incorrect permissions."
 msgstr "'%s' blokeo agiriak baimen okerrak ditu."
 
-#: ../src/generic/logg.cpp:576
+#: ../src/generic/logg.cpp:573
 #, c-format
 msgid "Log saved to the file '%s'."
 msgstr "Oharra '%s' agirian gordeta."
@@ -4704,11 +4832,11 @@ msgstr "Hizki xeheak"
 msgid "Lower case roman numerals"
 msgstr "Zenbaki erromatarrak hizki xehetan"
 
-#: ../src/gtk/mdi.cpp:422 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk1/mdi.cpp:431 ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "MDI child"
 
-#: ../src/msw/helpchm.cpp:56
+#: ../src/msw/helpchm.cpp:53
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -4716,189 +4844,189 @@ msgstr ""
 "MS HTML Laguntza eginkizunak ez daude eskuragarri MS HTML Laguntza "
 "liburutegia ez delako ezarri gailu honetan. Mesedez ezarri ezazu."
 
-#: ../src/univ/themes/win32.cpp:3754
+#: ../src/univ/themes/win32.cpp:3751
 msgid "Ma&ximize"
 msgstr "Han&ditu"
 
-#: ../src/common/fmapbase.cpp:203
+#: ../src/common/fmapbase.cpp:200
 msgid "MacArabic"
 msgstr "MacArabiera"
 
-#: ../src/common/fmapbase.cpp:222
+#: ../src/common/fmapbase.cpp:219
 msgid "MacArmenian"
 msgstr "MacArmeniera"
 
-#: ../src/common/fmapbase.cpp:211
+#: ../src/common/fmapbase.cpp:208
 msgid "MacBengali"
 msgstr "MacBengaliera"
 
-#: ../src/common/fmapbase.cpp:217
+#: ../src/common/fmapbase.cpp:214
 msgid "MacBurmese"
 msgstr "MacBurmesera"
 
-#: ../src/common/fmapbase.cpp:236
+#: ../src/common/fmapbase.cpp:233
 msgid "MacCeltic"
 msgstr "MacZeltiera"
 
-#: ../src/common/fmapbase.cpp:227
+#: ../src/common/fmapbase.cpp:224
 msgid "MacCentralEurRoman"
 msgstr "MacEurErdErrom"
 
-#: ../src/common/fmapbase.cpp:223
+#: ../src/common/fmapbase.cpp:220
 msgid "MacChineseSimp"
 msgstr "MacTxineraArrun"
 
-#: ../src/common/fmapbase.cpp:201
+#: ../src/common/fmapbase.cpp:198
 msgid "MacChineseTrad"
 msgstr "MacTxineraTrad"
 
-#: ../src/common/fmapbase.cpp:233
+#: ../src/common/fmapbase.cpp:230
 msgid "MacCroatian"
 msgstr "MacKroaziera"
 
-#: ../src/common/fmapbase.cpp:206
+#: ../src/common/fmapbase.cpp:203
 msgid "MacCyrillic"
 msgstr "MacZirilikoa"
 
-#: ../src/common/fmapbase.cpp:207
+#: ../src/common/fmapbase.cpp:204
 msgid "MacDevanagari"
 msgstr "MacDevanagariera"
 
-#: ../src/common/fmapbase.cpp:231
+#: ../src/common/fmapbase.cpp:228
 msgid "MacDingbats"
 msgstr "MacDingbatsera"
 
-#: ../src/common/fmapbase.cpp:226
+#: ../src/common/fmapbase.cpp:223
 msgid "MacEthiopic"
 msgstr "MacEtiopiera"
 
-#: ../src/common/fmapbase.cpp:229
+#: ../src/common/fmapbase.cpp:226
 msgid "MacExtArabic"
 msgstr "MacExtArabiera"
 
-#: ../src/common/fmapbase.cpp:237
+#: ../src/common/fmapbase.cpp:234
 msgid "MacGaelic"
 msgstr "MacGaeliera"
 
-#: ../src/common/fmapbase.cpp:221
+#: ../src/common/fmapbase.cpp:218
 msgid "MacGeorgian"
 msgstr "MacGeorgiera"
 
-#: ../src/common/fmapbase.cpp:205
+#: ../src/common/fmapbase.cpp:202
 msgid "MacGreek"
 msgstr "MacGreziera"
 
-#: ../src/common/fmapbase.cpp:209
+#: ../src/common/fmapbase.cpp:206
 msgid "MacGujarati"
 msgstr "MacGujaratiera"
 
-#: ../src/common/fmapbase.cpp:208
+#: ../src/common/fmapbase.cpp:205
 msgid "MacGurmukhi"
 msgstr "MacGurmukhiera"
 
-#: ../src/common/fmapbase.cpp:204
+#: ../src/common/fmapbase.cpp:201
 msgid "MacHebrew"
 msgstr "MacHebraiera"
 
-#: ../src/common/fmapbase.cpp:234
+#: ../src/common/fmapbase.cpp:231
 msgid "MacIcelandic"
 msgstr "MacIslandiera"
 
-#: ../src/common/fmapbase.cpp:200
+#: ../src/common/fmapbase.cpp:197
 msgid "MacJapanese"
 msgstr "MacJaponiera"
 
-#: ../src/common/fmapbase.cpp:214
+#: ../src/common/fmapbase.cpp:211
 msgid "MacKannada"
 msgstr "MacKannadera"
 
-#: ../src/common/fmapbase.cpp:238
+#: ../src/common/fmapbase.cpp:235
 msgid "MacKeyboardGlyphs"
 msgstr "MacTeklatuaGlyphs"
 
-#: ../src/common/fmapbase.cpp:218
+#: ../src/common/fmapbase.cpp:215
 msgid "MacKhmer"
 msgstr "MacKhmerrera"
 
-#: ../src/common/fmapbase.cpp:202
+#: ../src/common/fmapbase.cpp:199
 msgid "MacKorean"
 msgstr "MacKoreaera"
 
-#: ../src/common/fmapbase.cpp:220
+#: ../src/common/fmapbase.cpp:217
 msgid "MacLaotian"
 msgstr "MacLaotiera"
 
-#: ../src/common/fmapbase.cpp:215
+#: ../src/common/fmapbase.cpp:212
 msgid "MacMalayalam"
 msgstr "MacMalayalera"
 
-#: ../src/common/fmapbase.cpp:225
+#: ../src/common/fmapbase.cpp:222
 msgid "MacMongolian"
 msgstr "MacMongoliera"
 
-#: ../src/common/fmapbase.cpp:210
+#: ../src/common/fmapbase.cpp:207
 msgid "MacOriya"
 msgstr "MacOriyera"
 
-#: ../src/common/fmapbase.cpp:199
+#: ../src/common/fmapbase.cpp:196
 msgid "MacRoman"
 msgstr "MacErromatarra"
 
-#: ../src/common/fmapbase.cpp:235
+#: ../src/common/fmapbase.cpp:232
 msgid "MacRomanian"
 msgstr "MacErrumaniera"
 
-#: ../src/common/fmapbase.cpp:216
+#: ../src/common/fmapbase.cpp:213
 msgid "MacSinhalese"
 msgstr "MacSinhalera"
 
-#: ../src/common/fmapbase.cpp:230
+#: ../src/common/fmapbase.cpp:227
 msgid "MacSymbol"
 msgstr "MacSymbol"
 
-#: ../src/common/fmapbase.cpp:212
+#: ../src/common/fmapbase.cpp:209
 msgid "MacTamil"
 msgstr "MacTamilera"
 
-#: ../src/common/fmapbase.cpp:213
+#: ../src/common/fmapbase.cpp:210
 msgid "MacTelugu"
 msgstr "MacTeluguera"
 
-#: ../src/common/fmapbase.cpp:219
+#: ../src/common/fmapbase.cpp:216
 msgid "MacThai"
 msgstr "MacThailandiera"
 
-#: ../src/common/fmapbase.cpp:224
+#: ../src/common/fmapbase.cpp:221
 msgid "MacTibetan"
 msgstr "MacTibetera"
 
-#: ../src/common/fmapbase.cpp:232
+#: ../src/common/fmapbase.cpp:229
 msgid "MacTurkish"
 msgstr "MacTurkiera"
 
-#: ../src/common/fmapbase.cpp:228
+#: ../src/common/fmapbase.cpp:225
 msgid "MacVietnamese"
 msgstr "MacVietnamera"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1762
+#: ../src/propgrid/advprops.cpp:1663
 msgid "Magnifier"
 msgstr "Handitzailea"
 
-#: ../src/propgrid/advprops.cpp:2143
+#: ../src/propgrid/advprops.cpp:2050
 msgid "Make a selection:"
 msgstr "Egin hautapen bat:"
 
-#: ../src/richtext/richtextformatdlg.cpp:374
+#: ../src/richtext/richtextformatdlg.cpp:367
 #: ../src/richtext/richtextmarginspage.cpp:171
 msgid "Margins"
 msgstr "Bazterrak"
 
-#: ../src/propgrid/advprops.cpp:1595
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Maroon"
 msgstr "Gorriluna"
 
-#: ../src/generic/fdrepdlg.cpp:147
+#: ../src/generic/fdrepdlg.cpp:144
 msgid "Match case"
 msgstr "Hizki xehe-larriak"
 
@@ -4910,40 +5038,40 @@ msgstr "Geh. garaiera:"
 msgid "Max width:"
 msgstr "Geh. zabalera:"
 
-#: ../src/unix/mediactrl.cpp:947
+#: ../src/unix/mediactrl.cpp:972
 #, c-format
 msgid "Media playback error: %s"
 msgstr "Multimedia irakurketa akatsa: %s"
 
-#: ../src/common/fs_mem.cpp:175
+#: ../src/common/fs_mem.cpp:170
 #, c-format
 msgid "Memory VFS already contains file '%s'!"
 msgstr "VFS oroimenak jadanik badu '%s' agiria!"
 
 #. TRANSLATORS: Name of keyboard key
 #. TRANSLATORS: Keyword of system colour
-#: ../src/common/accelcmn.cpp:73 ../src/propgrid/advprops.cpp:889
+#: ../src/common/accelcmn.cpp:70 ../src/propgrid/advprops.cpp:790
 msgid "Menu"
 msgstr "Menua"
 
-#: ../src/common/msgout.cpp:124
+#: ../src/common/msgout.cpp:121
 msgid "Message"
 msgstr "Mezua"
 
-#: ../src/univ/themes/metal.cpp:168
+#: ../src/univ/themes/metal.cpp:165
 msgid "Metal theme"
 msgstr "Metal azalgaia"
 
-#: ../src/msw/ole/automtn.cpp:652
+#: ../src/msw/ole/automtn.cpp:643
 msgid "Method or property not found."
 msgstr "Metodoa edo ezaugarria ez da aurkitu."
 
-#: ../src/univ/themes/win32.cpp:3752
+#: ../src/univ/themes/win32.cpp:3749
 msgid "Mi&nimize"
 msgstr "I&kurtu"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1763
+#: ../src/propgrid/advprops.cpp:1664
 msgid "Middle Button"
 msgstr "Erdiko Botoia"
 
@@ -4955,36 +5083,41 @@ msgstr "Gutx. garaiera:"
 msgid "Min width:"
 msgstr "Gutx. zabalera:"
 
-#: ../src/msw/ole/automtn.cpp:668
+#: ../src/osx/cocoa/menu.mm:281
+#, fuzzy
+msgid "Minimize"
+msgstr "I&kurtu"
+
+#: ../src/msw/ole/automtn.cpp:659
 msgid "Missing a required parameter."
 msgstr "Beharrezko parametroa ez dago:"
 
-#: ../src/generic/fontdlgg.cpp:324
+#: ../src/generic/fontdlgg.cpp:320
 msgid "Modern"
 msgstr "Modernoa"
 
-#: ../src/generic/filectrlg.cpp:427
+#: ../src/generic/filectrlg.cpp:423
 msgid "Modified"
 msgstr "Aldatuta"
 
-#: ../src/common/module.cpp:133
+#: ../src/common/module.cpp:130
 #, c-format
 msgid "Module \"%s\" initialization failed"
 msgstr "\"%s\" moduloa abiatzeak huts egin du"
 
-#: ../src/common/paper.cpp:131
+#: ../src/common/paper.cpp:128
 msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
 msgstr "Errege Gutunazala, 3 7/8 x 7 1/2 in"
 
-#: ../src/msw/fswatcher.cpp:143
+#: ../src/msw/fswatcher.cpp:140
 msgid "Monitoring individual files for changes is not supported currently."
 msgstr "Banakako agiriak aldatzeko monitorizatzea orain ez dago sostengaturik."
 
-#: ../src/generic/editlbox.cpp:172
+#: ../src/generic/editlbox.cpp:160
 msgid "Move down"
 msgstr "Mugitu behera"
 
-#: ../src/generic/editlbox.cpp:171
+#: ../src/generic/editlbox.cpp:155
 msgid "Move up"
 msgstr "Mugitu gora"
 
@@ -4998,97 +5131,103 @@ msgstr "Objetua hurrengo esaldira mugitzen du."
 msgid "Moves the object to the previous paragraph."
 msgstr "Objetuak aurreko esaldira mugitzen ditu."
 
-#: ../src/richtext/richtextbuffer.cpp:9966
+#: ../src/richtext/richtextbuffer.cpp:9963
 msgid "Multiple Cell Properties"
 msgstr "Gelaxka Anitz Ezaugarriak"
 
-#: ../src/generic/filectrlg.cpp:424
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:82
+#, fuzzy
+msgid "Multiply"
+msgstr "ZP_Biderketa"
+
+#: ../src/generic/filectrlg.cpp:420
 msgid "Name"
 msgstr "Izena"
 
-#: ../src/propgrid/advprops.cpp:1596
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Navy"
 msgstr "Itsas-urdina"
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "Network"
 msgstr "Sarea"
 
-#: ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173
 msgid "New"
 msgstr "Berria"
 
-#: ../src/richtext/richtextstyledlg.cpp:243
+#: ../src/richtext/richtextstyledlg.cpp:239
 msgid "New &Box Style..."
 msgstr "Kutxa E&stilo Berria..."
 
-#: ../src/richtext/richtextstyledlg.cpp:225
+#: ../src/richtext/richtextstyledlg.cpp:221
 msgid "New &Character Style..."
 msgstr "Hizki Estilo &Berria..."
 
-#: ../src/richtext/richtextstyledlg.cpp:237
+#: ../src/richtext/richtextstyledlg.cpp:233
 msgid "New &List Style..."
 msgstr "Zerrenda E&stilo Berria..."
 
-#: ../src/richtext/richtextstyledlg.cpp:231
+#: ../src/richtext/richtextstyledlg.cpp:227
 msgid "New &Paragraph Style..."
 msgstr "Esaldi &Estilo Berria..."
 
-#: ../src/richtext/richtextstyledlg.cpp:606
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:654
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:820
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:893
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:934
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:602
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:650
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:816
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:889
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:930
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "New Style"
 msgstr "Estilo Berria"
 
-#: ../src/generic/editlbox.cpp:169
+#: ../src/generic/editlbox.cpp:139
 msgid "New item"
 msgstr "Gai berria"
 
-#: ../src/generic/dirdlgg.cpp:297 ../src/generic/dirdlgg.cpp:307
-#: ../src/generic/filectrlg.cpp:618 ../src/generic/filectrlg.cpp:627
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+#: ../src/generic/dirdlgg.cpp:294 ../src/generic/dirdlgg.cpp:304
 msgid "NewName"
 msgstr "Izen Berria"
 
-#: ../src/common/prntbase.cpp:1567 ../src/html/helpwnd.cpp:665
+#: ../src/common/prntbase.cpp:1592 ../src/html/helpwnd.cpp:663
 msgid "Next page"
 msgstr "Hurrengo orrialdea"
 
-#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:177
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:174
 #: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "EZ"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1764
+#: ../src/propgrid/advprops.cpp:1665
 msgid "No Entry"
 msgstr "Sarrerarik Ez"
 
-#: ../src/generic/animateg.cpp:150
+#: ../src/generic/animateg.cpp:133
 #, c-format
 msgid "No animation handler for type %ld defined."
 msgstr "Ez da animazio kudeatzailerik adierazi %ld motarako."
 
-#: ../src/dfb/bitmap.cpp:642 ../src/dfb/bitmap.cpp:676
+#: ../src/dfb/bitmap.cpp:639 ../src/dfb/bitmap.cpp:673
 #, c-format
 msgid "No bitmap handler for type %d defined."
 msgstr "Ez da bitmap kudeatzailerik adierazi %d motarako."
 
-#: ../src/common/utilscmn.cpp:1077
+#: ../src/common/utilscmn.cpp:1095
 msgid "No default application configured for HTML files."
 msgstr "Ez dago berezko aplikaziorik itxuratuta HTML agirientzat."
 
-#: ../src/generic/helpext.cpp:445
+#: ../src/generic/helpext.cpp:443
 msgid "No entries found."
 msgstr "Ez da sarrerarik aurkitu."
 
-#: ../src/common/fontmap.cpp:421
+#: ../src/common/fontmap.cpp:418
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found,\n"
@@ -5100,7 +5239,7 @@ msgstr ""
 "baina '%s' kodeaketa aukera eskuragarri dago.\n"
 "Nahi duzu kodeaketa hau erabiltzea (bestela beste bat hautatu beharko duzu)?"
 
-#: ../src/common/fontmap.cpp:426
+#: ../src/common/fontmap.cpp:423
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found.\n"
@@ -5111,201 +5250,201 @@ msgstr ""
 "Nahi duzu hautatzea hizki bat kodeaketa honetarako erabitzeko\n"
 "(bestela idazkia kodeaketa honetan ez da zuzen erakutsiko)?"
 
-#: ../src/generic/animateg.cpp:142
+#: ../src/generic/animateg.cpp:125
 msgid "No handler found for animation type."
 msgstr "Ez da kudeatzailerik aurkitu animazio motarentzat."
 
-#: ../src/common/image.cpp:2728
+#: ../src/common/image.cpp:2823
 msgid "No handler found for image type."
 msgstr "Ez da kudeatzailerik aurkitu irudi motarentzat."
 
-#: ../src/common/image.cpp:2736 ../src/common/image.cpp:2848
-#: ../src/common/image.cpp:2901
+#: ../src/common/image.cpp:2831 ../src/common/image.cpp:2954
+#: ../src/common/image.cpp:3020
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "Ez da irudi kudeatzailerik adierazi %d motarako."
 
-#: ../src/common/image.cpp:2871 ../src/common/image.cpp:2915
+#: ../src/common/image.cpp:2986 ../src/common/image.cpp:3034
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "Ez da irudi kudeatzailerik adierazi %s motarako."
 
-#: ../src/html/helpwnd.cpp:858
+#: ../src/html/helpwnd.cpp:856
 msgid "No matching page found yet"
 msgstr "Ez da bat datorren orrialderik aurkitu oraindik"
 
-#: ../src/unix/sound.cpp:81
+#: ../src/unix/sound.cpp:78
 msgid "No sound"
 msgstr "Soinu gabe"
 
-#: ../src/common/image.cpp:2277 ../src/common/image.cpp:2318
+#: ../src/common/image.cpp:2371 ../src/common/image.cpp:2412
 msgid "No unused colour in image being masked."
 msgstr "Ez dago erabiligabeko margorik mozorrotzen den irudian."
 
-#: ../src/common/image.cpp:3374
-msgid "No unused colour in image."
-msgstr "Ez dago erabiligabeko margorik irudian."
-
-#: ../src/generic/helpext.cpp:302
+#: ../src/generic/helpext.cpp:300
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "Ez da baliozko mapaketarik aurkitu \"%s\" agirian."
 
-#: ../src/richtext/richtextborderspage.cpp:610
 #: ../src/richtext/richtextsizepage.cpp:248
 #: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:610
 msgid "None"
 msgstr "Bat ere ez"
 
-#: ../src/common/fmapbase.cpp:157
+#: ../src/common/fmapbase.cpp:154
 msgid "Nordic (ISO-8859-10)"
 msgstr "Nordikoa (ISO-8859-10)"
 
-#: ../src/generic/fontdlgg.cpp:328 ../src/generic/fontdlgg.cpp:331
+#: ../src/generic/fontdlgg.cpp:324 ../src/generic/fontdlgg.cpp:327
 msgid "Normal"
 msgstr "Normala"
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1261
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Alde arrunta<br>eta <u>azpimarratua</u>. "
 
-#: ../src/html/helpwnd.cpp:1205
+#: ../src/html/helpwnd.cpp:1203
 msgid "Normal font:"
 msgstr "Hizki arrunta:"
 
-#: ../src/propgrid/props.cpp:1128
+#: ../src/propgrid/props.cpp:1115
 #, c-format
 msgid "Not %s"
 msgstr "Ez %s"
 
-#: ../include/wx/filename.h:573 ../include/wx/filename.h:578
-msgid "Not available"
-msgstr "Eskuraezina"
+#: ../src/common/secretstore.cpp:168
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/webrequest.cpp:605
+msgid "Not enough free disk space for download."
+msgstr ""
 
 #: ../src/richtext/richtextfontpage.cpp:358
 msgid "Not underlined"
 msgstr "Ez azpimarratua"
 
-#: ../src/common/paper.cpp:115
+#: ../src/common/paper.cpp:112
 msgid "Note, 8 1/2 x 11 in"
 msgstr "Oharra, 8 1/2 x 11 in"
 
-#: ../src/generic/notifmsgg.cpp:132
+#: ../src/generic/notifmsgg.cpp:129
 msgid "Notice"
 msgstr "Albistea"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "Num *"
 msgstr "Zbk *"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "Num +"
 msgstr "Zbk +"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "Num ,"
 msgstr "Zbk ,"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "Num -"
 msgstr "Zbk -"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "Num ."
 msgstr "Zbk ."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "Num /"
 msgstr "Zbk /"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "Num ="
 msgstr "Zbk ="
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "Num Begin"
 msgstr "Zbk Hasi"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 msgid "Num Delete"
 msgstr "Zbk Ezabatu"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 msgid "Num Down"
 msgstr "Zbk Behera"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "Num End"
 msgstr "Zbk Amaiera"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "Num Enter"
 msgstr "Zbk Sartu"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 msgid "Num Home"
 msgstr "Zbk Hasiera"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 msgid "Num Insert"
 msgstr "Zbk Txertatu"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num Lock"
 msgstr "Zbk Blokeoa"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "Num Page Down"
 msgstr "Zbk Orrian Behera"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "Num Page Up"
 msgstr "Zbk Orrian Gora"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 msgid "Num Right"
 msgstr "Zbk Eskuin"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "Num Space"
 msgstr "Zbk Tartea"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "Num Tab"
 msgstr "Zbk Tab"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "Num Up"
 msgstr "Zbk Gora"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "Num left"
 msgstr "Zbk ezker"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num_lock"
 msgstr "Zbk_blokeoa"
 
@@ -5314,13 +5453,13 @@ msgstr "Zbk_blokeoa"
 msgid "Numbered outline"
 msgstr "Zenbakituriko ingurua"
 
-#: ../include/wx/msgdlg.h:278 ../src/richtext/richtextstyledlg.cpp:297
-#: ../src/common/stockitem.cpp:178 ../src/msw/msgdlg.cpp:454
-#: ../src/msw/msgdlg.cpp:747 ../src/gtk1/fontdlg.cpp:138
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:175
+#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/msgdlg.cpp:741 ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "&Ongi"
 
-#: ../src/msw/ole/automtn.cpp:692
+#: ../src/msw/ole/automtn.cpp:683
 #, c-format
 msgid "OLE Automation error in %s: %s"
 msgstr "OLE Berezgaitasun akatsa %s: %s"
@@ -5329,15 +5468,15 @@ msgstr "OLE Berezgaitasun akatsa %s: %s"
 msgid "Object Properties"
 msgstr "Objetu Ezaugarriak"
 
-#: ../src/msw/ole/automtn.cpp:660
+#: ../src/msw/ole/automtn.cpp:651
 msgid "Object implementation does not support named arguments."
 msgstr "Objetu inplementazioak ez du argumendu izendunik sostengatzen."
 
-#: ../src/common/xtixml.cpp:264
+#: ../src/common/xtixml.cpp:260
 msgid "Objects must have an id attribute"
 msgstr "Objetuek id ezaugarria izan behar dute"
 
-#: ../src/propgrid/advprops.cpp:1601
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Olive"
 msgstr "Oliba"
 
@@ -5345,66 +5484,71 @@ msgstr "Oliba"
 msgid "Opaci&ty:"
 msgstr "A&rgikazitasuna:"
 
-#: ../src/generic/colrdlgg.cpp:354
+#: ../src/generic/colrdlgg.cpp:374
 #, fuzzy
 msgid "Opacity:"
 msgstr "A&rgikazitasuna:"
 
-#: ../src/common/docview.cpp:1773 ../src/common/docview.cpp:1815
+#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
 msgid "Open File"
 msgstr "Ireki Agiria"
 
-#: ../src/html/helpwnd.cpp:671 ../src/html/helpwnd.cpp:1554
+#: ../src/html/helpwnd.cpp:669 ../src/html/helpwnd.cpp:1552
 msgid "Open HTML document"
 msgstr "Ireki HTML agiria"
 
-#: ../src/generic/dbgrptg.cpp:163
+#: ../src/common/stockitem.cpp:265
+#, fuzzy
+msgid "Open an existing document"
+msgstr "Ireki HTML agiria"
+
+#: ../src/generic/dbgrptg.cpp:160
 #, c-format
 msgid "Open file \"%s\""
 msgstr "Ireki \"%s\" agiria"
 
-#: ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176
 msgid "Open..."
 msgstr "Ireki..."
 
-#: ../src/unix/glx11.cpp:506 ../src/msw/glcanvas.cpp:592
+#: ../src/msw/glcanvas.cpp:607 ../src/unix/glx11.cpp:513
 #, fuzzy
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr "Core OpenGL profila ez dago sostengatuta OpenGL gidatzailean."
 
-#: ../src/generic/dirctrlg.cpp:599 ../src/generic/dirdlgg.cpp:323
-#: ../src/generic/filectrlg.cpp:642 ../src/generic/filectrlg.cpp:786
+#: ../src/generic/dirctrlg.cpp:565 ../src/generic/filectrlg.cpp:638
+#: ../src/generic/filectrlg.cpp:782 ../src/generic/dirdlgg.cpp:320
 msgid "Operation not permitted."
 msgstr "Eragiketa baimengabea."
 
-#: ../src/common/cmdline.cpp:900
+#: ../src/common/cmdline.cpp:896
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "'%s' aukera ezin da ukatua izan"
 
-#: ../src/common/cmdline.cpp:1064
+#: ../src/common/cmdline.cpp:1060
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "'%s' aukerak balio bat behar du."
 
-#: ../src/common/cmdline.cpp:1147
+#: ../src/common/cmdline.cpp:1143
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "'%s' aukera: '%s' ezin du bihurtu data batera."
 
-#: ../src/generic/prntdlgg.cpp:618
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Aukerak"
 
-#: ../src/propgrid/advprops.cpp:1606
+#: ../src/propgrid/advprops.cpp:1512
 msgid "Orange"
 msgstr "Laranja"
 
-#: ../src/generic/prntdlgg.cpp:615 ../src/generic/prntdlgg.cpp:869
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:862
 msgid "Orientation"
 msgstr "Norantza"
 
-#: ../src/common/windowid.cpp:242
+#: ../src/common/windowid.cpp:237
 msgid "Out of window IDs.  Recommend shutting down application."
 msgstr "Leiho ID-tik kanpo. Aplikazioa itzaltzea gomendatzen da."
 
@@ -5417,148 +5561,148 @@ msgstr "Ingurua"
 msgid "Outset"
 msgstr "Hasiera"
 
-#: ../src/msw/ole/automtn.cpp:656
+#: ../src/msw/ole/automtn.cpp:647
 msgid "Overflow while coercing argument values."
 msgstr "Gainezkatzea argumentu balioak behartzean."
 
-#: ../src/common/imagpcx.cpp:457 ../src/common/imagpcx.cpp:480
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:479
 msgid "PCX: couldn't allocate memory"
 msgstr "PCX: ezinezkoa oroimena esleitzea"
 
-#: ../src/common/imagpcx.cpp:456
+#: ../src/common/imagpcx.cpp:455
 msgid "PCX: image format unsupported"
 msgstr "PCX: irudi heuskarri sostengatu gabea"
 
-#: ../src/common/imagpcx.cpp:479
+#: ../src/common/imagpcx.cpp:478
 msgid "PCX: invalid image"
 msgstr "PCX: irudi baliogabea"
 
-#: ../src/common/imagpcx.cpp:442
+#: ../src/common/imagpcx.cpp:441
 msgid "PCX: this is not a PCX file."
 msgstr "PCX: hau ez da PCX agiri bat."
 
-#: ../src/common/imagpcx.cpp:459 ../src/common/imagpcx.cpp:481
+#: ../src/common/imagpcx.cpp:458 ../src/common/imagpcx.cpp:480
 msgid "PCX: unknown error !!!"
 msgstr "PCX: akats ezezaguna!!!"
 
-#: ../src/common/imagpcx.cpp:458
+#: ../src/common/imagpcx.cpp:457
 msgid "PCX: version number too low"
 msgstr "PCX: bertsio zenbaki txikiegia"
 
-#: ../src/common/imagpnm.cpp:91
+#: ../src/common/imagpnm.cpp:89
 msgid "PNM: Couldn't allocate memory."
 msgstr "PNM: Ezinezkoa oroimena esleitzea."
 
-#: ../src/common/imagpnm.cpp:73
+#: ../src/common/imagpnm.cpp:71
 msgid "PNM: File format is not recognized."
 msgstr "PNM: Agiri heuskarria ezezaguna da."
 
-#: ../src/common/imagpnm.cpp:112 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
 #: ../src/common/imagpnm.cpp:156
 msgid "PNM: File seems truncated."
 msgstr "PNM: Agiriak trunkatua dirudi."
 
-#: ../src/common/paper.cpp:187
+#: ../src/common/paper.cpp:184
 msgid "PRC 16K 146 x 215 mm"
 msgstr "PRC 16K 146 x 215 mm"
 
-#: ../src/common/paper.cpp:200
+#: ../src/common/paper.cpp:197
 msgid "PRC 16K Rotated"
 msgstr "PRC 16K Itzulita"
 
-#: ../src/common/paper.cpp:188
+#: ../src/common/paper.cpp:185
 msgid "PRC 32K 97 x 151 mm"
 msgstr "PRC 32K 97 x 151 mm"
 
-#: ../src/common/paper.cpp:201
+#: ../src/common/paper.cpp:198
 msgid "PRC 32K Rotated"
 msgstr "PRC 32K Itzulita"
 
-#: ../src/common/paper.cpp:189
+#: ../src/common/paper.cpp:186
 msgid "PRC 32K(Big) 97 x 151 mm"
 msgstr "PRC 32K(Handia) 97 x 151 mm"
 
-#: ../src/common/paper.cpp:202
+#: ../src/common/paper.cpp:199
 msgid "PRC 32K(Big) Rotated"
 msgstr "PRC 32K(Handia) Itzulita"
 
-#: ../src/common/paper.cpp:190
+#: ../src/common/paper.cpp:187
 msgid "PRC Envelope #1 102 x 165 mm"
 msgstr "PRC Gutunazala #1 102 x 165 mm"
 
-#: ../src/common/paper.cpp:203
+#: ../src/common/paper.cpp:200
 msgid "PRC Envelope #1 Rotated 165 x 102 mm"
 msgstr "PRC Gutunazala #1 Itzulita 165 x 102 mm"
 
-#: ../src/common/paper.cpp:199
+#: ../src/common/paper.cpp:196
 msgid "PRC Envelope #10 324 x 458 mm"
 msgstr "PRC Gutunazala #10 324 x 458 mm"
 
-#: ../src/common/paper.cpp:212
+#: ../src/common/paper.cpp:209
 msgid "PRC Envelope #10 Rotated 458 x 324 mm"
 msgstr "PRC Gutunazala #10 Itzulita 458 x 324 mm"
 
-#: ../src/common/paper.cpp:191
+#: ../src/common/paper.cpp:188
 msgid "PRC Envelope #2 102 x 176 mm"
 msgstr "PRC Gutunazala #2 102 x 176 mm"
 
-#: ../src/common/paper.cpp:204
+#: ../src/common/paper.cpp:201
 msgid "PRC Envelope #2 Rotated 176 x 102 mm"
 msgstr "PRC Gutunazala #2 Itzulita 176 x 102 mm"
 
-#: ../src/common/paper.cpp:192
+#: ../src/common/paper.cpp:189
 msgid "PRC Envelope #3 125 x 176 mm"
 msgstr "PRC Gutunazala #3 125 x 176 mm"
 
-#: ../src/common/paper.cpp:205
+#: ../src/common/paper.cpp:202
 msgid "PRC Envelope #3 Rotated 176 x 125 mm"
 msgstr "PRC Gutunazala #3 Itzulita 176 x 125 mm"
 
-#: ../src/common/paper.cpp:193
+#: ../src/common/paper.cpp:190
 msgid "PRC Envelope #4 110 x 208 mm"
 msgstr "PRC Gutunazala #4 110 x 208 mm"
 
-#: ../src/common/paper.cpp:206
+#: ../src/common/paper.cpp:203
 msgid "PRC Envelope #4 Rotated 208 x 110 mm"
 msgstr "PRC Gutunazala #4 Itzulita 208 x 110 mm"
 
-#: ../src/common/paper.cpp:194
+#: ../src/common/paper.cpp:191
 msgid "PRC Envelope #5 110 x 220 mm"
 msgstr "PRC Gutunazala #5 110 x 220 mm"
 
-#: ../src/common/paper.cpp:207
+#: ../src/common/paper.cpp:204
 msgid "PRC Envelope #5 Rotated 220 x 110 mm"
 msgstr "PRC Gutunazala #5 Itzulita 220 x 110 mm"
 
-#: ../src/common/paper.cpp:195
+#: ../src/common/paper.cpp:192
 msgid "PRC Envelope #6 120 x 230 mm"
 msgstr "PRC Gutunazala #6 120 x 230 mm"
 
-#: ../src/common/paper.cpp:208
+#: ../src/common/paper.cpp:205
 msgid "PRC Envelope #6 Rotated 230 x 120 mm"
 msgstr "PRC Gutunazala #6 Itzulita 230 x 120 mm"
 
-#: ../src/common/paper.cpp:196
+#: ../src/common/paper.cpp:193
 msgid "PRC Envelope #7 160 x 230 mm"
 msgstr "PRC Gutunazala #7 160 x 230 mm"
 
-#: ../src/common/paper.cpp:209
+#: ../src/common/paper.cpp:206
 msgid "PRC Envelope #7 Rotated 230 x 160 mm"
 msgstr "PRC Gutunazala #7 Itzulita 230 x 160 mm"
 
-#: ../src/common/paper.cpp:197
+#: ../src/common/paper.cpp:194
 msgid "PRC Envelope #8 120 x 309 mm"
 msgstr "PRC Gutunazala #8 120 x 309 mm"
 
-#: ../src/common/paper.cpp:210
+#: ../src/common/paper.cpp:207
 msgid "PRC Envelope #8 Rotated 309 x 120 mm"
 msgstr "PRC Gutunazala #8 Itzulita 309 x 120 mm"
 
-#: ../src/common/paper.cpp:198
+#: ../src/common/paper.cpp:195
 msgid "PRC Envelope #9 229 x 324 mm"
 msgstr "PRC Gutunazala #9 229 x 324 mm"
 
-#: ../src/common/paper.cpp:211
+#: ../src/common/paper.cpp:208
 msgid "PRC Envelope #9 Rotated 324 x 229 mm"
 msgstr "PRC Gutunazala #9 Itzulita 324 x 229 mm"
 
@@ -5566,87 +5710,91 @@ msgstr "PRC Gutunazala #9 Itzulita 324 x 229 mm"
 msgid "Padding"
 msgstr "Betegarria"
 
-#: ../src/common/prntbase.cpp:2074
+#: ../src/common/prntbase.cpp:2096
 #, c-format
 msgid "Page %d"
 msgstr "%d orrialde"
 
-#: ../src/common/prntbase.cpp:2072
+#: ../src/common/prntbase.cpp:2094
 #, c-format
 msgid "Page %d of %d"
 msgstr "%d orrialde %d-tik"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 msgid "Page Down"
 msgstr "Orrialdean Behera"
 
-#: ../src/gtk/print.cpp:826
+#: ../src/gtk/print.cpp:829
 msgid "Page Setup"
 msgstr "Orrialde Ezarpena"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 msgid "Page Up"
 msgstr "Orrialdean Gora"
 
-#: ../src/generic/prntdlgg.cpp:828 ../src/common/prntbase.cpp:484
+#: ../src/common/prntbase.cpp:479 ../src/generic/prntdlgg.cpp:821
 msgid "Page setup"
 msgstr "Orrialde ezarpena"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 msgid "PageDown"
 msgstr "OrrBeh"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 msgid "PageUp"
 msgstr "OrrGora"
 
-#: ../src/generic/prntdlgg.cpp:216
+#: ../src/generic/prntdlgg.cpp:209
 msgid "Pages"
 msgstr "Orrialdeak"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1765
+#: ../src/propgrid/advprops.cpp:1666
 msgid "Paint Brush"
 msgstr "Margoketa Brotxa"
 
-#: ../src/generic/prntdlgg.cpp:602 ../src/generic/prntdlgg.cpp:801
-#: ../src/generic/prntdlgg.cpp:842 ../src/generic/prntdlgg.cpp:855
-#: ../src/generic/prntdlgg.cpp:1052 ../src/generic/prntdlgg.cpp:1057
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:794
+#: ../src/generic/prntdlgg.cpp:835 ../src/generic/prntdlgg.cpp:848
+#: ../src/generic/prntdlgg.cpp:1045 ../src/generic/prntdlgg.cpp:1050
 msgid "Paper size"
 msgstr "Paper neurria"
 
-#: ../src/richtext/richtextstyles.cpp:1062
+#: ../src/richtext/richtextstyles.cpp:1059
 msgid "Paragraph styles"
 msgstr "Esaldi estiloak"
 
-#: ../src/common/xtistrm.cpp:465
+#: ../src/common/xtistrm.cpp:462
 msgid "Passing a already registered object to SetObject"
 msgstr "Jadanik erregistraturiko objetua SetObject-ra pasatzen"
 
-#: ../src/common/xtistrm.cpp:476
+#: ../src/common/xtistrm.cpp:473
 msgid "Passing an unknown object to GetObject"
 msgstr "Objetu ezezaguna igaro da GetObjectClassInfo-ra"
 
-#: ../src/richtext/richtextctrl.cpp:3513 ../src/common/stockitem.cpp:180
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:177 ../src/richtext/richtextctrl.cpp:3514
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Itsatsi"
 
-#: ../src/common/stockitem.cpp:262
+#: ../src/common/stockitem.cpp:260
 msgid "Paste selection"
 msgstr "Itsati hautapena"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:74
+#: ../src/common/accelcmn.cpp:71
 msgid "Pause"
 msgstr "Pausatu"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1766
+#: ../src/propgrid/advprops.cpp:1667
 msgid "Pencil"
 msgstr "Bolaluma"
 
@@ -5655,21 +5803,21 @@ msgstr "Bolaluma"
 msgid "Peri&od"
 msgstr "Al&dia"
 
-#: ../src/generic/filectrlg.cpp:430
+#: ../src/generic/filectrlg.cpp:426
 msgid "Permissions"
 msgstr "Baimenak"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:60
+#: ../src/common/accelcmn.cpp:57
 msgid "PgDn"
 msgstr "OrrBeh"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:59
+#: ../src/common/accelcmn.cpp:56
 msgid "PgUp"
 msgstr "OrrGor"
 
-#: ../src/richtext/richtextbuffer.cpp:12868
+#: ../src/richtext/richtextbuffer.cpp:12863
 msgid "Picture Properties"
 msgstr "Irudiaren Ezaugarriak"
 
@@ -5681,42 +5829,42 @@ msgstr "Hutsegitea hodia sortzean"
 msgid "Please choose a valid font."
 msgstr "Mesedez hautatu baliozko hizki bat."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
 msgid "Please choose an existing file."
 msgstr "Mesedez hautatu dagoen agiri bat."
 
-#: ../src/html/helpwnd.cpp:800
+#: ../src/html/helpwnd.cpp:798
 msgid "Please choose the page to display:"
 msgstr "Mesedez hautatu erakusteko orrialdea:"
 
-#: ../src/msw/dialup.cpp:764
+#: ../src/msw/dialup.cpp:758
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Mesedez zein IZH-ra nahi duzun elkarketatzea"
 
-#: ../src/common/headerctrlcmn.cpp:59
+#: ../src/common/headerctrlcmn.cpp:57
 msgid "Please select the columns to show and define their order:"
 msgstr "Mesedez hautatu erakusteko zutabeak eta zehaztu beren ordena:"
 
-#: ../src/common/prntbase.cpp:538
+#: ../src/common/prntbase.cpp:533
 msgid "Please wait while printing..."
 msgstr "Mesedez itxaron irarkitzen den bitartean..."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1767
+#: ../src/propgrid/advprops.cpp:1668
 msgid "Point Left"
 msgstr "Ezker Puntua"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1768
+#: ../src/propgrid/advprops.cpp:1669
 msgid "Point Right"
 msgstr "Eskuin Puntua"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:662
+#: ../src/propgrid/advprops.cpp:572
 msgid "Point Size"
 msgstr "Puntu Neurria"
 
-#: ../src/generic/prntdlgg.cpp:612 ../src/generic/prntdlgg.cpp:867
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:860
 msgid "Portrait"
 msgstr "Argazkia"
 
@@ -5724,150 +5872,160 @@ msgstr "Argazkia"
 msgid "Position"
 msgstr "Kokapena"
 
-#: ../src/generic/prntdlgg.cpp:298
+#: ../src/generic/prntdlgg.cpp:291
 msgid "PostScript file"
 msgstr "PostScript agiria"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178 ../src/osx/cocoa/preferences.mm:303
 msgid "Preferences"
 msgstr "Hobespenak"
 
-#: ../src/osx/menu_osx.cpp:568
+#: ../src/osx/menu_osx.cpp:460
 msgid "Preferences..."
 msgstr "Hobespenak..."
 
-#: ../src/common/prntbase.cpp:546
+#: ../src/common/prntbase.cpp:541
 msgid "Preparing"
 msgstr "Gertatzen"
 
-#: ../src/generic/fontdlgg.cpp:455 ../src/osx/carbon/fontdlg.cpp:390
-#: ../src/html/helpwnd.cpp:1222
+#: ../src/osx/carbon/fontdlg.cpp:387 ../src/generic/fontdlgg.cpp:452
+#: ../src/html/helpwnd.cpp:1220
 msgid "Preview:"
 msgstr "Aurreikuspena:"
 
-#: ../src/common/prntbase.cpp:1553 ../src/html/helpwnd.cpp:664
+#: ../src/common/prntbase.cpp:1578 ../src/html/helpwnd.cpp:662
 msgid "Previous page"
 msgstr "Aurreko orrialdea"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/prntdlgg.cpp:143 ../src/generic/prntdlgg.cpp:157
-#: ../src/common/prntbase.cpp:426 ../src/common/prntbase.cpp:1541
-#: ../src/common/accelcmn.cpp:77 ../src/gtk/print.cpp:620
-#: ../src/gtk/print.cpp:638
+#: ../src/common/prntbase.cpp:421 ../src/common/prntbase.cpp:1566
+#: ../src/common/accelcmn.cpp:74 ../src/generic/prntdlgg.cpp:136
+#: ../src/generic/prntdlgg.cpp:150 ../src/gtk/print.cpp:616
+#: ../src/gtk/print.cpp:634
 msgid "Print"
 msgstr "Irarkitu"
 
-#: ../include/wx/prntbase.h:399 ../src/common/docview.cpp:1268
+#: ../src/common/docview.cpp:1262
 msgid "Print Preview"
 msgstr "Irarketa Aurreikuspena"
 
-#: ../src/common/prntbase.cpp:2015 ../src/common/prntbase.cpp:2057
-#: ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2037 ../src/common/prntbase.cpp:2079
+#: ../src/common/prntbase.cpp:2087
 msgid "Print Preview Failure"
 msgstr "Aurreikuspen Irarketa Hutsegitea"
 
-#: ../src/generic/prntdlgg.cpp:224
+#: ../src/generic/prntdlgg.cpp:217
 msgid "Print Range"
 msgstr "Irarketa Maila"
 
-#: ../src/generic/prntdlgg.cpp:449
+#: ../src/generic/prntdlgg.cpp:442
 msgid "Print Setup"
 msgstr "Irarketa Ezarpena"
 
-#: ../src/generic/prntdlgg.cpp:621
+#: ../src/generic/prntdlgg.cpp:614
 msgid "Print in colour"
 msgstr "Irarkitu margoekin"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/osx/webview_webkit.mm:260
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "Zutabe azalpena ezin da abiarazi."
+
+#: ../src/common/stockitem.cpp:179
 msgid "Print previe&w..."
 msgstr "Irarketa aur&reikuspena..."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1256
 msgid "Print preview creation failed."
 msgstr "Irarketa aurreikuspena sortzeak huts egin du."
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/common/stockitem.cpp:179
 msgid "Print preview..."
 msgstr "Irarketa aurreikuspena..."
 
-#: ../src/generic/prntdlgg.cpp:630
+#: ../src/generic/prntdlgg.cpp:623
 msgid "Print spooling"
 msgstr "Irarketa lerrokapena"
 
-#: ../src/html/helpwnd.cpp:675
+#: ../src/html/helpwnd.cpp:673
 msgid "Print this page"
 msgstr "Irarkitu orrialde hau"
 
-#: ../src/generic/prntdlgg.cpp:185
+#: ../src/generic/prntdlgg.cpp:178
 msgid "Print to File"
 msgstr "Irarkitu Agirira"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "Print..."
 msgstr "Irarkitu..."
 
-#: ../src/generic/prntdlgg.cpp:493
+#: ../src/generic/prntdlgg.cpp:486
 msgid "Printer"
 msgstr "Irarkailua"
 
-#: ../src/generic/prntdlgg.cpp:633
+#: ../src/generic/prntdlgg.cpp:626
 msgid "Printer command:"
 msgstr "Irarkailu komandoa:"
 
-#: ../src/generic/prntdlgg.cpp:180
+#: ../src/generic/prntdlgg.cpp:173
 msgid "Printer options"
 msgstr "Irarkailu aukerak"
 
-#: ../src/generic/prntdlgg.cpp:645
+#: ../src/generic/prntdlgg.cpp:638
 msgid "Printer options:"
 msgstr "Irarkailu aukerak:"
 
-#: ../src/generic/prntdlgg.cpp:916
+#: ../src/generic/prntdlgg.cpp:909
 msgid "Printer..."
 msgstr "Irarkailua..."
 
-#: ../src/generic/prntdlgg.cpp:196
+#: ../src/generic/prntdlgg.cpp:189
 msgid "Printer:"
 msgstr "Irarkailua:"
 
-#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:535
-#: ../src/html/htmprint.cpp:277
+#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:530
+#: ../src/html/htmprint.cpp:289
 msgid "Printing"
 msgstr "Irarkitzen"
 
-#: ../src/common/prntbase.cpp:612
+#: ../src/common/prntbase.cpp:607
 msgid "Printing "
 msgstr "Irarkitzen"
 
-#: ../src/common/prntbase.cpp:347
+#: ../src/common/prntbase.cpp:342
 msgid "Printing Error"
 msgstr "Irarketa Akatsa"
 
-#: ../src/common/prntbase.cpp:565
+#: ../src/osx/webview_webkit.mm:251
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "Gzip ez dago sostengaturik zlib bertsio honetarako"
+
+#: ../src/common/prntbase.cpp:560
 #, c-format
 msgid "Printing page %d"
 msgstr "Orrialdea irarkitzen %d"
 
-#: ../src/common/prntbase.cpp:570
+#: ../src/common/prntbase.cpp:565
 #, c-format
 msgid "Printing page %d of %d"
 msgstr "%d orrialdea irarkitzen %d-tik..."
 
-#: ../src/generic/printps.cpp:201
+#: ../src/generic/printps.cpp:182
 #, c-format
 msgid "Printing page %d..."
 msgstr "%d orrialdea irarkitzen..."
 
-#: ../src/generic/printps.cpp:161
+#: ../src/generic/printps.cpp:142
 msgid "Printing..."
 msgstr "Irarkitzen..."
 
-#: ../include/wx/richtext/richtextprint.h:109 ../include/wx/prntbase.h:267
-#: ../src/common/docview.cpp:2132
+#: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
+#: ../src/common/docview.cpp:2137
 msgid "Printout"
 msgstr "Irarketa"
 
-#: ../src/common/debugrpt.cpp:560
+#: ../src/common/debugrpt.cpp:561
 #, c-format
 msgid ""
 "Processing debug report has failed, leaving the files in \"%s\" directory."
@@ -5875,102 +6033,102 @@ msgstr ""
 "Garbiketa jakinarazpen prozesapenak huts egin du, agiria \"%s\" zuzenbidean "
 "uzten."
 
-#: ../src/common/prntbase.cpp:545
+#: ../src/common/prntbase.cpp:540
 msgid "Progress:"
 msgstr "Garapena:"
 
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181
 msgid "Properties"
 msgstr "Ezaugarriak"
 
-#: ../src/propgrid/manager.cpp:237
+#: ../src/propgrid/manager.cpp:223
 msgid "Property"
 msgstr "Ezaugarria"
 
 #. TRANSLATORS: Caption of message box displaying any property error
-#: ../src/propgrid/propgrid.cpp:3185 ../src/propgrid/propgrid.cpp:3318
+#: ../src/propgrid/propgrid.cpp:3162 ../src/propgrid/propgrid.cpp:3299
 msgid "Property Error"
 msgstr "Ezaugarri Akatsa"
 
-#: ../src/propgrid/advprops.cpp:1597
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Purple"
 msgstr "Purpura"
 
-#: ../src/common/paper.cpp:112
+#: ../src/common/paper.cpp:109
 msgid "Quarto, 215 x 275 mm"
 msgstr "Quarto, 215 x 275 mm"
 
-#: ../src/generic/logg.cpp:1016
+#: ../src/generic/logg.cpp:1013
 msgid "Question"
 msgstr "Galdera"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1769
+#: ../src/propgrid/advprops.cpp:1670
 msgid "Question Arrow"
 msgstr "Galdera Gezia"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "Quit"
 msgstr "Utzi"
 
-#: ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:477
 #, c-format
 msgid "Quit %s"
 msgstr "Utzi %s"
 
-#: ../src/common/stockitem.cpp:263
+#: ../src/common/stockitem.cpp:261
 msgid "Quit this program"
 msgstr "Utzi programa hau"
 
-#: ../src/common/accelcmn.cpp:338
+#: ../src/common/accelcmn.cpp:352
 msgid "RawCtrl+"
 msgstr "RawKtrl+"
 
-#: ../src/common/ffile.cpp:109 ../src/common/ffile.cpp:133
+#: ../src/common/ffile.cpp:107 ../src/common/ffile.cpp:132
 #, c-format
 msgid "Read error on file '%s'"
 msgstr "Irakurri akatsa '%s' agirian"
 
-#: ../src/common/secretstore.cpp:199
+#: ../src/common/secretstore.cpp:211
 #, fuzzy, c-format
-msgid "Reading password for \"%s/%s\" failed: %s."
+msgid "Reading password for \"%s\" failed: %s."
 msgstr "Hutsegitea %s \"%s\" sortzerakoan."
 
-#: ../src/common/prntbase.cpp:272
+#: ../src/common/prntbase.cpp:267
 msgid "Ready"
 msgstr "Gertu"
 
-#: ../src/propgrid/advprops.cpp:1605
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Red"
 msgstr "Gorria"
 
-#: ../src/generic/colrdlgg.cpp:339
+#: ../src/generic/colrdlgg.cpp:359
 msgid "Red:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:185 ../src/stc/stc_i18n.cpp:16
+#: ../src/common/stockitem.cpp:182 ../src/stc/stc_i18n.cpp:16
 msgid "Redo"
 msgstr "Berregin"
 
-#: ../src/common/stockitem.cpp:264
+#: ../src/common/stockitem.cpp:262
 msgid "Redo last action"
 msgstr "Berregin azken ekintza"
 
-#: ../src/common/stockitem.cpp:186
+#: ../src/common/stockitem.cpp:183
 msgid "Refresh"
 msgstr "Berritu"
 
-#: ../src/msw/registry.cpp:626
+#: ../src/msw/registry.cpp:615
 #, c-format
 msgid "Registry key '%s' already exists."
 msgstr "'%s' erregistro giltza jadanik badago."
 
-#: ../src/msw/registry.cpp:595
+#: ../src/msw/registry.cpp:584
 #, c-format
 msgid "Registry key '%s' does not exist, cannot rename it."
 msgstr "'%s' erregistro giltza ez dago, ezin da birrizendatu."
 
-#: ../src/msw/registry.cpp:727
+#: ../src/msw/registry.cpp:716
 #, c-format
 msgid ""
 "Registry key '%s' is needed for normal system operation,\n"
@@ -5981,22 +6139,22 @@ msgstr ""
 "ezabatzen bada zure sistema erabiltezin geldituko da:\n"
 "eragiketa utzita."
 
-#: ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:942
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:917
+#: ../src/msw/registry.cpp:905
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1003
+#: ../src/msw/registry.cpp:991
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:521
+#: ../src/msw/registry.cpp:510
 #, c-format
 msgid "Registry value '%s' already exists."
 msgstr "'%s' erregistro balioa badago jadanik."
@@ -6010,71 +6168,77 @@ msgstr "Arrunta"
 msgid "Relative"
 msgstr "Erlatiboa"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:456
 msgid "Relevant entries:"
 msgstr "Sarrera nabarmenak:"
 
-#: ../include/wx/generic/progdlgg.h:86
+#: ../include/wx/generic/progdlgg.h:87
 msgid "Remaining time:"
 msgstr "Gelditzen den denbora:"
 
-#: ../src/common/stockitem.cpp:187
+#: ../src/common/stockitem.cpp:184
 msgid "Remove"
 msgstr "Kendu"
 
-#: ../src/richtext/richtextctrl.cpp:1562
+#: ../src/richtext/richtextctrl.cpp:1563
 msgid "Remove Bullet"
 msgstr "Kendu Buleta"
 
-#: ../src/html/helpwnd.cpp:433
+#: ../src/html/helpwnd.cpp:431
 msgid "Remove current page from bookmarks"
 msgstr "Kendu oraingo orrialdea lastermarketatik"
 
-#: ../src/common/rendcmn.cpp:194
+#: ../src/common/rendcmn.cpp:191
 #, c-format
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 "\"%s\" aurkezlea bateraezina da %d bertsioarekin.%d ezinezkoa gertatzea."
 
-#: ../src/richtext/richtextbuffer.cpp:4527
+#: ../src/richtext/richtextbuffer.cpp:4524
 msgid "Renumber List"
 msgstr "Birzenbakitu Zerrenda"
 
-#: ../src/common/stockitem.cpp:188
-msgid "Rep&lace"
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Rep&lace..."
 msgstr "Or&deztu"
 
-#: ../src/richtext/richtextctrl.cpp:3673 ../src/common/stockitem.cpp:188
+#: ../src/richtext/richtextctrl.cpp:3674
 msgid "Replace"
 msgstr "Ordeztu"
 
-#: ../src/generic/fdrepdlg.cpp:182
+#: ../src/generic/fdrepdlg.cpp:179
 msgid "Replace &all"
 msgstr "Ordeztu &denak"
 
-#: ../src/common/stockitem.cpp:261
-msgid "Replace selection"
-msgstr "Ordeztu hautapena"
-
-#: ../src/generic/fdrepdlg.cpp:124
+#: ../src/generic/fdrepdlg.cpp:121
 msgid "Replace with:"
 msgstr "Ordeztu honekin:"
 
-#: ../src/common/valtext.cpp:163
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Replace..."
+msgstr "Ordeztu"
+
+#: ../src/common/valtext.cpp:184
 msgid "Required information entry is empty."
 msgstr "Beharrezko argibide sarrera hutsik dago."
 
-#: ../src/common/translation.cpp:1975
+#: ../src/common/translation.cpp:2025
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "'%s' baliabidea ez da baliozko mezu katalogoa."
 
+#: ../src/gtk/webview_webkit.cpp:985
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:56
+#: ../src/common/accelcmn.cpp:53
 msgid "Return"
 msgstr "Sartu"
 
-#: ../src/common/stockitem.cpp:189
+#: ../src/common/stockitem.cpp:186
 msgid "Revert to Saved"
 msgstr "Itzuli Gordetakora"
 
@@ -6086,41 +6250,41 @@ msgstr "Haria"
 msgid "Rig&ht-to-left"
 msgstr "E&skuin-ezker"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6149
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:59 ../src/generic/datavgen.cpp:6954
+#: ../src/richtext/richtextsizepage.cpp:250
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextbulletspage.cpp:188
-#: ../src/richtext/richtextsizepage.cpp:250 ../src/common/accelcmn.cpp:62
 msgid "Right"
 msgstr "Eskuin"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1754
+#: ../src/propgrid/advprops.cpp:1655
 msgid "Right Arrow"
 msgstr "Eskuin Gezia"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1770
+#: ../src/propgrid/advprops.cpp:1671
 msgid "Right Button"
 msgstr "Eskuin Botoia"
 
-#: ../src/generic/prntdlgg.cpp:892
+#: ../src/generic/prntdlgg.cpp:885
 msgid "Right margin (mm):"
 msgstr "Eskuin bazterra (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:148
-#: ../src/richtext/richtextindentspage.cpp:150
 #: ../src/richtext/richtextliststylepage.cpp:337
 #: ../src/richtext/richtextliststylepage.cpp:339
+#: ../src/richtext/richtextindentspage.cpp:148
+#: ../src/richtext/richtextindentspage.cpp:150
 msgid "Right-align text."
 msgstr "Eskuin-lerrokatze idazkia."
 
-#: ../src/generic/fontdlgg.cpp:322
+#: ../src/generic/fontdlgg.cpp:318
 msgid "Roman"
 msgstr "Erromatarra"
 
-#: ../src/generic/datavgen.cpp:5916
+#: ../src/generic/datavgen.cpp:6721
 #, c-format
 msgid "Row %i"
 msgstr ""
@@ -6130,30 +6294,31 @@ msgstr ""
 msgid "S&tandard bullet name:"
 msgstr "B&uleta izen estandarra:"
 
-#: ../src/common/accelcmn.cpp:268 ../src/common/accelcmn.cpp:350
+#: ../src/common/accelcmn.cpp:282 ../src/common/accelcmn.cpp:367
 msgid "SPECIAL"
 msgstr "BEREZIA"
 
-#: ../src/common/stockitem.cpp:190 ../src/common/sizer.cpp:2797
+#: ../src/common/stockitem.cpp:187 ../src/common/sizer.cpp:2914
 msgid "Save"
 msgstr "Gorde"
 
-#: ../src/common/fldlgcmn.cpp:342
+#: ../src/common/fldlgcmn.cpp:339
 #, c-format
 msgid "Save %s file"
 msgstr "Gorde %s agiria"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/common/stockitem.cpp:188 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Gorde &Honela..."
 
-#: ../src/common/docview.cpp:366
+#: ../src/common/docview.cpp:359
 msgid "Save As"
 msgstr "Gorde Honela"
 
-#: ../src/common/stockitem.cpp:191
-msgid "Save as"
-msgstr "Gorde honela"
+#: ../src/common/stockitem.cpp:188
+#, fuzzy
+msgid "Save As..."
+msgstr "Gorde &Honela..."
 
 #: ../src/common/stockitem.cpp:267
 msgid "Save current document"
@@ -6163,40 +6328,40 @@ msgstr "Gorde oraingo agiria"
 msgid "Save current document with a different filename"
 msgstr "Gorde oraingo agiria agirizen ezberdinarekin"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/generic/logg.cpp:509
 msgid "Save log contents to file"
 msgstr "Gorde ohar edukiak agirian"
 
-#: ../src/common/secretstore.cpp:179
+#: ../src/common/secretstore.cpp:189
 #, fuzzy, c-format
-msgid "Saving password for \"%s/%s\" failed: %s."
+msgid "Saving password for \"%s\" failed: %s."
 msgstr "Hutsegitea %s \"%s\" sortzerakoan."
 
-#: ../src/generic/fontdlgg.cpp:325
+#: ../src/generic/fontdlgg.cpp:321
 msgid "Script"
 msgstr "Eskripta"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll Lock"
 msgstr "Irristari Blokeoa"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll_lock"
 msgstr "Irristari_blokeoa"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:890
+#: ../src/propgrid/advprops.cpp:791
 msgid "Scrollbar"
 msgstr "Irristabarra"
 
-#: ../src/generic/srchctlg.cpp:56 ../src/html/helpwnd.cpp:535
-#: ../src/html/helpwnd.cpp:550
+#: ../src/generic/srchctlg.cpp:55 ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:548 ../src/gtk/srchctrl.cpp:182
 msgid "Search"
 msgstr "Bilatu"
 
-#: ../src/html/helpwnd.cpp:537
+#: ../src/html/helpwnd.cpp:535
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
@@ -6204,56 +6369,56 @@ msgstr ""
 "Bilatu edukiak laguntza liburuan gainean idatzi duzun idazkiaren gertaera "
 "guztientzat"
 
-#: ../src/generic/fdrepdlg.cpp:160
+#: ../src/generic/fdrepdlg.cpp:157
 msgid "Search direction"
 msgstr "Bilatu helbidea"
 
-#: ../src/generic/fdrepdlg.cpp:112
+#: ../src/generic/fdrepdlg.cpp:109
 msgid "Search for:"
 msgstr "Bilatu hau:"
 
-#: ../src/html/helpwnd.cpp:1052
+#: ../src/html/helpwnd.cpp:1050
 msgid "Search in all books"
 msgstr "Bilatu liburu guztietan"
 
-#: ../src/html/helpwnd.cpp:857
+#: ../src/html/helpwnd.cpp:855
 msgid "Searching..."
 msgstr "Bilatzen...."
 
-#: ../src/generic/dirctrlg.cpp:446
+#: ../src/generic/dirctrlg.cpp:412
 msgid "Sections"
 msgstr "Atalak"
 
-#: ../src/common/ffile.cpp:238
+#: ../src/common/ffile.cpp:237
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Bilatu akatsak '%s' agirian"
 
-#: ../src/common/ffile.cpp:228
+#: ../src/common/ffile.cpp:227
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
 "Bilatu akatsak '%s' agirian (stdiok ez du agiri handiagorik sostengatzen)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:76
+#: ../src/common/accelcmn.cpp:73
 msgid "Select"
 msgstr "Hautatu"
 
-#: ../src/richtext/richtextctrl.cpp:337 ../src/osx/textctrl_osx.cpp:581
-#: ../src/common/stockitem.cpp:192 ../src/msw/textctrl.cpp:2512
+#: ../src/osx/textctrl_osx.cpp:599 ../src/common/stockitem.cpp:189
+#: ../src/msw/textctrl.cpp:2777 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Hautatu &Denak"
 
-#: ../src/common/stockitem.cpp:192 ../src/stc/stc_i18n.cpp:21
+#: ../src/common/stockitem.cpp:189 ../src/stc/stc_i18n.cpp:21
 msgid "Select All"
 msgstr "Hautatu Denak"
 
-#: ../src/common/docview.cpp:1895
+#: ../src/common/docview.cpp:1900
 msgid "Select a document template"
 msgstr "Hautatu agiri eredu bat"
 
-#: ../src/common/docview.cpp:1969
+#: ../src/common/docview.cpp:1974
 msgid "Select a document view"
 msgstr "Hautatu agiri ikuspena"
 
@@ -6282,20 +6447,20 @@ msgid "Selects the list level to edit."
 msgstr "Editatzeko zerrenda maila hautatzen du."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:82
+#: ../src/common/accelcmn.cpp:79
 msgid "Separator"
 msgstr "Banantzailea"
 
-#: ../src/common/cmdline.cpp:1083
+#: ../src/common/cmdline.cpp:1079
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Banantzailea '%s' aukeraren ondoren itxaroten da."
 
-#: ../src/osx/menu_osx.cpp:572
+#: ../src/osx/menu_osx.cpp:464
 msgid "Services"
 msgstr "Zerbitzuak"
 
-#: ../src/richtext/richtextbuffer.cpp:11217
+#: ../src/richtext/richtextbuffer.cpp:11216
 msgid "Set Cell Style"
 msgstr "Ezarri Gelaxka estiloa"
 
@@ -6303,11 +6468,11 @@ msgstr "Ezarri Gelaxka estiloa"
 msgid "SetProperty called w/o valid setter"
 msgstr "SetProperty w/o baliozko ezartzailea deituta"
 
-#: ../src/generic/prntdlgg.cpp:188
+#: ../src/generic/prntdlgg.cpp:181
 msgid "Setup..."
 msgstr "Ezarpena..."
 
-#: ../src/msw/dialup.cpp:544
+#: ../src/msw/dialup.cpp:538
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr "Dei elkarketa ugari aurkitu dira lanean, zorizko bat hautatzen."
 
@@ -6323,40 +6488,40 @@ msgstr "Itzala"
 msgid "Shadow c&olour:"
 msgstr "Itzal &margoa:"
 
-#: ../src/common/accelcmn.cpp:335
+#: ../src/common/accelcmn.cpp:349
 msgid "Shift+"
 msgstr "Shift+"
 
-#: ../src/generic/dirdlgg.cpp:147
+#: ../src/generic/dirdlgg.cpp:144
 msgid "Show &hidden directories"
 msgstr "Erakutsi e&zkutuko zuzenbideak"
 
-#: ../src/generic/filectrlg.cpp:983
+#: ../src/generic/filectrlg.cpp:979
 msgid "Show &hidden files"
 msgstr "Erakutsi &ezkutuko agiriak"
 
-#: ../src/osx/menu_osx.cpp:580
+#: ../src/osx/menu_osx.cpp:472
 msgid "Show All"
 msgstr "Erakutsi Denak"
 
-#: ../src/common/stockitem.cpp:257
+#: ../src/common/stockitem.cpp:254
 msgid "Show about dialog"
 msgstr "Erakutsi elkarrizketari buruz"
 
-#: ../src/html/helpwnd.cpp:492
+#: ../src/html/helpwnd.cpp:490
 msgid "Show all"
 msgstr "Erakutsi denak"
 
-#: ../src/html/helpwnd.cpp:503
+#: ../src/html/helpwnd.cpp:501
 msgid "Show all items in index"
 msgstr "Erakutsi gai guzitak aurkibidean"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:656
 msgid "Show/hide navigation panel"
 msgstr "Erakusi/ezkutatu nabigazio panela"
 
-#: ../src/richtext/richtextsymboldlg.cpp:421
-#: ../src/richtext/richtextsymboldlg.cpp:423
+#: ../src/richtext/richtextsymboldlg.cpp:418
+#: ../src/richtext/richtextsymboldlg.cpp:420
 msgid "Shows a Unicode subset."
 msgstr "Unicode azpiezarpena erakusten du."
 
@@ -6372,7 +6537,7 @@ msgstr "Buleta ezarpenen aurreikuspen bat erakusten du."
 msgid "Shows a preview of the font settings."
 msgstr "Hizki ezarpenen aurreikuspen bat erakusten du."
 
-#: ../src/osx/carbon/fontdlg.cpp:394 ../src/osx/carbon/fontdlg.cpp:396
+#: ../src/osx/carbon/fontdlg.cpp:391 ../src/osx/carbon/fontdlg.cpp:393
 msgid "Shows a preview of the font."
 msgstr "Hizkiaren aurreikuspen bat erakusten du."
 
@@ -6381,62 +6546,62 @@ msgstr "Hizkiaren aurreikuspen bat erakusten du."
 msgid "Shows a preview of the paragraph settings."
 msgstr "Esaldi ezarpenen aurreikuspen bat erakusten du."
 
-#: ../src/generic/fontdlgg.cpp:460 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:456 ../src/generic/fontdlgg.cpp:458
 msgid "Shows the font preview."
 msgstr "Hizki aurreikuspen bat erakusten du."
 
-#: ../src/propgrid/advprops.cpp:1607
+#: ../src/propgrid/advprops.cpp:1513
 msgid "Silver"
 msgstr "Zilarra"
 
-#: ../src/univ/themes/mono.cpp:516
+#: ../src/univ/themes/mono.cpp:513
 msgid "Simple monochrome theme"
 msgstr "Azalgai margobakar arrunta"
 
-#: ../src/richtext/richtextindentspage.cpp:275
 #: ../src/richtext/richtextliststylepage.cpp:449
+#: ../src/richtext/richtextindentspage.cpp:275
 msgid "Single"
 msgstr "Bakarra"
 
-#: ../src/generic/filectrlg.cpp:425 ../src/richtext/richtextformatdlg.cpp:369
-#: ../src/richtext/richtextsizepage.cpp:299
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextsizepage.cpp:299
+#: ../src/richtext/richtextformatdlg.cpp:362
 msgid "Size"
 msgstr "Neurria"
 
-#: ../src/osx/carbon/fontdlg.cpp:339
+#: ../src/osx/carbon/fontdlg.cpp:336
 msgid "Size:"
 msgstr "Neurria:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1775
+#: ../src/propgrid/advprops.cpp:1676
 msgid "Sizing"
 msgstr "Neurritzen"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1772
+#: ../src/propgrid/advprops.cpp:1673
 msgid "Sizing N-S"
 msgstr "Neurritzen I-H"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1771
+#: ../src/propgrid/advprops.cpp:1672
 msgid "Sizing NE-SW"
 msgstr "Neurritzen IE-HM"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1773
+#: ../src/propgrid/advprops.cpp:1674
 msgid "Sizing NW-SE"
 msgstr "Neurritzen IM-HE"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1774
+#: ../src/propgrid/advprops.cpp:1675
 msgid "Sizing W-E"
 msgstr "Neurritzen M-E"
 
-#: ../src/msw/progdlg.cpp:801
+#: ../src/msw/progdlg.cpp:1088
 msgid "Skip"
 msgstr "Jauzi"
 
-#: ../src/generic/fontdlgg.cpp:330
+#: ../src/generic/fontdlgg.cpp:326
 msgid "Slant"
 msgstr "Oker"
 
@@ -6445,7 +6610,7 @@ msgid "Small C&apitals"
 msgstr "&Larri Txikiak"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:79
+#: ../src/common/accelcmn.cpp:76
 msgid "Snapshot"
 msgstr "Berehalakoa"
 
@@ -6453,37 +6618,37 @@ msgstr "Berehalakoa"
 msgid "Solid"
 msgstr "Solidoa"
 
-#: ../src/common/docview.cpp:1791
+#: ../src/common/docview.cpp:1785
 msgid "Sorry, could not open this file."
 msgstr "Barkatu, ezin da agiria hau ireki."
 
-#: ../src/common/prntbase.cpp:2057 ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2079 ../src/common/prntbase.cpp:2087
 msgid "Sorry, not enough memory to create a preview."
 msgstr "Barkatu, ez dago nahikoa oroimenik aurreikuspen bat sortzeko."
 
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "Sorry, that name is taken. Please choose another."
 msgstr "Barkatu, izena hartuta dago. Mesedez hautatu beste bat."
 
-#: ../src/common/docview.cpp:1814
+#: ../src/common/docview.cpp:1819
 msgid "Sorry, the format for this file is unknown."
 msgstr "Barkatu, agiri honentzako heuskarria ezezaguna da."
 
-#: ../src/unix/sound.cpp:492
+#: ../src/unix/sound.cpp:481
 msgid "Sound data are in unsupported format."
 msgstr "Soinu datua heuskarri sostengatu gabean dago."
 
-#: ../src/unix/sound.cpp:477
+#: ../src/unix/sound.cpp:466
 #, c-format
 msgid "Sound file '%s' is in unsupported format."
 msgstr "'%s' soinu agiria heuskarri sostengatu gabean dago"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:67
+#: ../src/common/accelcmn.cpp:64
 msgid "Space"
 msgstr "Tartea"
 
@@ -6491,12 +6656,12 @@ msgstr "Tartea"
 msgid "Spacing"
 msgstr "Tartea"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "Spell Check"
 msgstr "Idaz Egiaztapena"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1776
+#: ../src/propgrid/advprops.cpp:1677
 msgid "Spraycan"
 msgstr "Spraycan"
 
@@ -6505,7 +6670,7 @@ msgstr "Spraycan"
 msgid "Standard"
 msgstr "Estandarra"
 
-#: ../src/common/paper.cpp:104
+#: ../src/common/paper.cpp:101
 msgid "Statement, 5 1/2 x 8 1/2 in"
 msgstr "Adierazpena, 5 1/2 x 8 1/2 in"
 
@@ -6514,33 +6679,29 @@ msgstr "Adierazpena, 5 1/2 x 8 1/2 in"
 msgid "Static"
 msgstr "Estatikoa"
 
-#: ../src/generic/prntdlgg.cpp:204
+#: ../src/generic/prntdlgg.cpp:197
 msgid "Status:"
 msgstr "Egoera:"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "Stop"
 msgstr "Gelditu"
 
-#: ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196
 msgid "Strikethrough"
 msgstr "Marratuta"
 
-#: ../src/common/colourcmn.cpp:45
+#: ../src/common/colourcmn.cpp:42
 #, c-format
 msgid "String To Colour : Incorrect colour specification : %s"
 msgstr "Margoarentzako Katea : margo zehaztapen okerra : %s"
 
 #. TRANSLATORS: Label of font style
-#: ../src/richtext/richtextformatdlg.cpp:339 ../src/propgrid/advprops.cpp:680
+#: ../src/propgrid/advprops.cpp:590 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Estiloa"
 
-#: ../include/wx/richtext/richtextstyledlg.h:46
-msgid "Style Organiser"
-msgstr "Estilo Antolatzailea"
-
-#: ../src/osx/carbon/fontdlg.cpp:348
+#: ../src/osx/carbon/fontdlg.cpp:345
 msgid "Style:"
 msgstr "Estiloa:"
 
@@ -6549,7 +6710,7 @@ msgid "Subscrip&t"
 msgstr "Azpieskrip&ta"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:83
+#: ../src/common/accelcmn.cpp:80
 msgid "Subtract"
 msgstr "Kenketa"
 
@@ -6557,11 +6718,11 @@ msgstr "Kenketa"
 msgid "Supe&rscript"
 msgstr "Gaine&skripta"
 
-#: ../src/common/paper.cpp:150
+#: ../src/common/paper.cpp:147
 msgid "SuperA/SuperA/A4 227 x 356 mm"
 msgstr "SuperA/SuperA/A4 227 x 356 mm"
 
-#: ../src/common/paper.cpp:151
+#: ../src/common/paper.cpp:148
 msgid "SuperB/SuperB/A3 305 x 487 mm"
 msgstr "SuperB/SuperB/A3 305 x 487 mm"
 
@@ -6569,7 +6730,7 @@ msgstr "SuperB/SuperB/A3 305 x 487 mm"
 msgid "Suppress hyphe&nation"
 msgstr "Kendu elkar&marratzea"
 
-#: ../src/generic/fontdlgg.cpp:326
+#: ../src/generic/fontdlgg.cpp:322
 msgid "Swiss"
 msgstr "Suitzarra"
 
@@ -6587,73 +6748,73 @@ msgstr "Ikur &hizkia:"
 msgid "Symbols"
 msgstr "Sinboloak"
 
-#: ../src/common/imagtiff.cpp:369 ../src/common/imagtiff.cpp:382
-#: ../src/common/imagtiff.cpp:741
+#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
+#: ../src/common/imagtiff.cpp:738
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: Ezinezkoa oroimena esleitzea."
 
-#: ../src/common/imagtiff.cpp:301
+#: ../src/common/imagtiff.cpp:298
 msgid "TIFF: Error loading image."
 msgstr "TIFF: Akatsa irudia gertatzen."
 
-#: ../src/common/imagtiff.cpp:468
+#: ../src/common/imagtiff.cpp:465
 msgid "TIFF: Error reading image."
 msgstr "TIFF: Akats irudia irakurtzen."
 
-#: ../src/common/imagtiff.cpp:608
+#: ../src/common/imagtiff.cpp:605
 msgid "TIFF: Error saving image."
 msgstr "TIFF: Akatsa irudia gordetzen."
 
-#: ../src/common/imagtiff.cpp:846
+#: ../src/common/imagtiff.cpp:843
 msgid "TIFF: Error writing image."
 msgstr "TIFF: Akatsa irudia idazterakoan."
 
-#: ../src/common/imagtiff.cpp:355
+#: ../src/common/imagtiff.cpp:352
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: Irudi neurria handiegia da."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:68
+#: ../src/common/accelcmn.cpp:65
 msgid "Tab"
 msgstr "Tab"
 
-#: ../src/richtext/richtextbuffer.cpp:11498
+#: ../src/richtext/richtextbuffer.cpp:11497
 msgid "Table Properties"
 msgstr "Taula Ezaugarriak"
 
-#: ../src/common/paper.cpp:145
+#: ../src/common/paper.cpp:142
 msgid "Tabloid Extra 11.69 x 18 in"
 msgstr "Tabloidea Estra 11.69 x 18 in"
 
-#: ../src/common/paper.cpp:102
+#: ../src/common/paper.cpp:99
 msgid "Tabloid, 11 x 17 in"
 msgstr "Tabloidea, 11 x 17 in"
 
-#: ../src/richtext/richtextformatdlg.cpp:354
+#: ../src/richtext/richtextformatdlg.cpp:347
 msgid "Tabs"
 msgstr "Hegatsak"
 
-#: ../src/propgrid/advprops.cpp:1598
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Teal"
 msgstr "Zertzeta"
 
-#: ../src/generic/fontdlgg.cpp:327
+#: ../src/generic/fontdlgg.cpp:323
 msgid "Teletype"
 msgstr "Teletipoa"
 
-#: ../src/common/docview.cpp:1896
+#: ../src/common/docview.cpp:1901
 msgid "Templates"
 msgstr "Ereduak"
 
-#: ../src/common/fmapbase.cpp:158
+#: ../src/common/fmapbase.cpp:155
 msgid "Thai (ISO-8859-11)"
 msgstr "Thailandiera (ISO-8859-11)"
 
-#: ../src/common/ftp.cpp:619
+#: ../src/common/ftp.cpp:622
 msgid "The FTP server doesn't support passive mode."
 msgstr "FTP zerbitzariak ez du modu pasiboa sostengatzen."
 
-#: ../src/common/ftp.cpp:605
+#: ../src/common/ftp.cpp:608
 msgid "The FTP server doesn't support the PORT command."
 msgstr "FTP zerbitzariak ez du ATAKA komandoa sostengatzen."
 
@@ -6664,8 +6825,8 @@ msgstr "FTP zerbitzariak ez du ATAKA komandoa sostengatzen."
 msgid "The available bullet styles."
 msgstr "Bulet estilo eskuragarriak."
 
-#: ../src/richtext/richtextstyledlg.cpp:202
-#: ../src/richtext/richtextstyledlg.cpp:204
+#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:200
 msgid "The available styles."
 msgstr "Estilo eskuragarriak."
 
@@ -6721,12 +6882,12 @@ msgstr "Beheko kokapena."
 msgid "The bullet character."
 msgstr "Buleta ikurra."
 
-#: ../src/richtext/richtextsymboldlg.cpp:443
-#: ../src/richtext/richtextsymboldlg.cpp:445
+#: ../src/richtext/richtextsymboldlg.cpp:440
+#: ../src/richtext/richtextsymboldlg.cpp:442
 msgid "The character code."
 msgstr "Hizki kodea."
 
-#: ../src/common/fontmap.cpp:203
+#: ../src/common/fontmap.cpp:200
 #, c-format
 msgid ""
 "The charset '%s' is unknown. You may select\n"
@@ -6737,7 +6898,7 @@ msgstr ""
 "beste hizkikode bat ordezteko edo hautatu\n"
 "[Ezeztatu] ezin bada ordeztu"
 
-#: ../src/msw/ole/dataobj.cpp:394
+#: ../src/msw/ole/dataobj.cpp:402
 #, c-format
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "'%d' gako heuskarria ez dago."
@@ -6747,7 +6908,7 @@ msgstr "'%d' gako heuskarria ez dago."
 msgid "The default style for the next paragraph."
 msgstr "Berezko estiloa hurrengo esaldirako."
 
-#: ../src/generic/dirdlgg.cpp:202
+#: ../src/generic/dirdlgg.cpp:199
 #, c-format
 msgid ""
 "The directory '%s' does not exist\n"
@@ -6756,7 +6917,7 @@ msgstr ""
 "'%s' zuzenbidea ez dago\n"
 "Orain sortu?"
 
-#: ../src/html/htmprint.cpp:271
+#: ../src/html/htmprint.cpp:283
 #, c-format
 msgid ""
 "The document \"%s\" doesn't fit on the page horizontally and will be "
@@ -6769,7 +6930,7 @@ msgstr ""
 "\n"
 "Horrela ere irarkitzea nahi duzu?"
 
-#: ../src/common/docview.cpp:1202
+#: ../src/common/docview.cpp:1196
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -6778,36 +6939,36 @@ msgstr ""
 "'%s' agiria ez dago edo ezin da ireki.\n"
 "Kendua izanda berrikien erabilitako agiri zerrendatik."
 
-#: ../src/richtext/richtextindentspage.cpp:208
-#: ../src/richtext/richtextindentspage.cpp:210
 #: ../src/richtext/richtextliststylepage.cpp:394
 #: ../src/richtext/richtextliststylepage.cpp:396
+#: ../src/richtext/richtextindentspage.cpp:208
+#: ../src/richtext/richtextindentspage.cpp:210
 msgid "The first line indent."
 msgstr "Lehen lerro elkarmarratxoa."
 
-#: ../src/gtk/utilsgtk.cpp:481
-msgid "The following standard GTK+ options are also supported:\n"
-msgstr "Hurrengo GTK+ estandar aukerak ere sostengatuak dira:\n"
+#: ../src/generic/dbgrptg.cpp:318
+msgid "The following debug report will be generated\n"
+msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:414 ../src/generic/fontdlgg.cpp:416
+#: ../src/generic/fontdlgg.cpp:411 ../src/generic/fontdlgg.cpp:413
 msgid "The font colour."
 msgstr "Hizki margoa."
 
-#: ../src/generic/fontdlgg.cpp:375 ../src/generic/fontdlgg.cpp:377
+#: ../src/generic/fontdlgg.cpp:371 ../src/generic/fontdlgg.cpp:373
 msgid "The font family."
 msgstr "Hizki sendia."
 
-#: ../src/richtext/richtextsymboldlg.cpp:405
-#: ../src/richtext/richtextsymboldlg.cpp:407
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "The font from which to take the symbol."
 msgstr "Sinboloa hartzeko hizki mota."
 
-#: ../src/generic/fontdlgg.cpp:427 ../src/generic/fontdlgg.cpp:429
-#: ../src/generic/fontdlgg.cpp:434 ../src/generic/fontdlgg.cpp:436
+#: ../src/generic/fontdlgg.cpp:424 ../src/generic/fontdlgg.cpp:426
+#: ../src/generic/fontdlgg.cpp:430 ../src/generic/fontdlgg.cpp:432
 msgid "The font point size."
 msgstr "Hizkiaren puntu neurria."
 
-#: ../src/osx/carbon/fontdlg.cpp:343 ../src/osx/carbon/fontdlg.cpp:345
+#: ../src/osx/carbon/fontdlg.cpp:340 ../src/osx/carbon/fontdlg.cpp:342
 msgid "The font size in points."
 msgstr "Hizki neurria puntutan."
 
@@ -6816,15 +6977,15 @@ msgstr "Hizki neurria puntutan."
 msgid "The font size units, points or pixels."
 msgstr "Hizki neurri batasuna, puntutak edo pixelak."
 
-#: ../src/generic/fontdlgg.cpp:386 ../src/generic/fontdlgg.cpp:388
+#: ../src/generic/fontdlgg.cpp:382 ../src/generic/fontdlgg.cpp:384
 msgid "The font style."
 msgstr "Hizki estiloa."
 
-#: ../src/generic/fontdlgg.cpp:397 ../src/generic/fontdlgg.cpp:399
+#: ../src/generic/fontdlgg.cpp:393 ../src/generic/fontdlgg.cpp:395
 msgid "The font weight."
 msgstr "Hizkiaren zabalera."
 
-#: ../src/common/docview.cpp:1483
+#: ../src/common/docview.cpp:1477
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "'%s' agiriaren heuskarria ezin da zehaztu."
@@ -6834,10 +6995,10 @@ msgstr "'%s' agiriaren heuskarria ezin da zehaztu."
 msgid "The horizontal offset."
 msgstr "Etzaneko oreka."
 
-#: ../src/richtext/richtextindentspage.cpp:199
-#: ../src/richtext/richtextindentspage.cpp:201
 #: ../src/richtext/richtextliststylepage.cpp:385
 #: ../src/richtext/richtextliststylepage.cpp:387
+#: ../src/richtext/richtextindentspage.cpp:199
+#: ../src/richtext/richtextindentspage.cpp:201
 msgid "The left indent."
 msgstr "Ezker elkarmarratxoa."
 
@@ -6858,10 +7019,10 @@ msgstr "Ezkerreko betegarri neurria."
 msgid "The left position."
 msgstr "Ezker kokapena."
 
-#: ../src/richtext/richtextindentspage.cpp:288
-#: ../src/richtext/richtextindentspage.cpp:290
 #: ../src/richtext/richtextliststylepage.cpp:462
 #: ../src/richtext/richtextliststylepage.cpp:464
+#: ../src/richtext/richtextindentspage.cpp:288
+#: ../src/richtext/richtextindentspage.cpp:290
 msgid "The line spacing."
 msgstr "Lerro tartea."
 
@@ -6870,7 +7031,7 @@ msgstr "Lerro tartea."
 msgid "The list item number."
 msgstr "Zerrendaren gai zenbatekoa."
 
-#: ../src/msw/ole/automtn.cpp:664
+#: ../src/msw/ole/automtn.cpp:655
 msgid "The locale ID is unknown."
 msgstr "Tokiko ID-a ezezaguna da."
 
@@ -6909,19 +7070,19 @@ msgstr "Objetuaren zabalera."
 msgid "The outline level."
 msgstr "Inguru maila."
 
-#: ../src/common/log.cpp:277
+#: ../src/common/log.cpp:296
 #, c-format
 msgid "The previous message repeated %u time."
 msgid_plural "The previous message repeated %u times."
 msgstr[0] "Aurreko mezua %u aldiz errepikatuta."
 msgstr[1] "Aurreko mezua %u aldiz errepikatuta."
 
-#: ../src/common/log.cpp:270
+#: ../src/common/log.cpp:289
 msgid "The previous message repeated once."
 msgstr "Aurreko mezua behin errepikatuta."
 
-#: ../src/richtext/richtextsymboldlg.cpp:462
-#: ../src/richtext/richtextsymboldlg.cpp:464
+#: ../src/richtext/richtextsymboldlg.cpp:459
+#: ../src/richtext/richtextsymboldlg.cpp:461
 msgid "The range to show."
 msgstr "Erakusteko maila."
 
@@ -6935,15 +7096,15 @@ msgstr ""
 "argibide pribatuak baditu,\n"
 "mesedez ez hautatu itzazu eta jakinarazpenetik kenduko dira.\n"
 
-#: ../src/common/cmdline.cpp:1254
+#: ../src/common/cmdline.cpp:1250
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "'%s' beharrezko parametroa ez da adierazi."
 
-#: ../src/richtext/richtextindentspage.cpp:217
-#: ../src/richtext/richtextindentspage.cpp:219
 #: ../src/richtext/richtextliststylepage.cpp:403
 #: ../src/richtext/richtextliststylepage.cpp:405
+#: ../src/richtext/richtextindentspage.cpp:217
+#: ../src/richtext/richtextindentspage.cpp:219
 msgid "The right indent."
 msgstr "Eskuin elkarmarratxoa."
 
@@ -6984,16 +7145,16 @@ msgstr "Itzal argikaiztasuna"
 msgid "The shadow spread."
 msgstr "Itzal barreiapena."
 
-#: ../src/richtext/richtextindentspage.cpp:267
 #: ../src/richtext/richtextliststylepage.cpp:439
 #: ../src/richtext/richtextliststylepage.cpp:441
+#: ../src/richtext/richtextindentspage.cpp:267
 msgid "The spacing after the paragraph."
 msgstr "Tartea esaldiaren ondoren."
 
-#: ../src/richtext/richtextindentspage.cpp:257
-#: ../src/richtext/richtextindentspage.cpp:259
 #: ../src/richtext/richtextliststylepage.cpp:430
 #: ../src/richtext/richtextliststylepage.cpp:432
+#: ../src/richtext/richtextindentspage.cpp:257
+#: ../src/richtext/richtextindentspage.cpp:259
 msgid "The spacing before the paragraph."
 msgstr "Tartea esaldiaren aurretik."
 
@@ -7007,12 +7168,12 @@ msgstr "Estilo izena."
 msgid "The style on which this style is based."
 msgstr "Estilo hau ohinarrituta dagoen estiloa."
 
-#: ../src/richtext/richtextstyledlg.cpp:214
-#: ../src/richtext/richtextstyledlg.cpp:216
+#: ../src/richtext/richtextstyledlg.cpp:210
+#: ../src/richtext/richtextstyledlg.cpp:212
 msgid "The style preview."
 msgstr "Estiloaren aurreikuspena."
 
-#: ../src/msw/ole/automtn.cpp:680
+#: ../src/msw/ole/automtn.cpp:671
 msgid "The system cannot find the file specified."
 msgstr "Sistemak ezin du adierazitako agiria aurkitu."
 
@@ -7025,7 +7186,7 @@ msgstr "Hegats kokapena."
 msgid "The tab positions."
 msgstr "Hegats kokapenak."
 
-#: ../src/richtext/richtextctrl.cpp:3098
+#: ../src/richtext/richtextctrl.cpp:3099
 msgid "The text couldn't be saved."
 msgstr "Idazkia ezin da gorde."
 
@@ -7046,7 +7207,7 @@ msgstr "Goiko betegarri neurria."
 msgid "The top position."
 msgstr "Goiko kokapena."
 
-#: ../src/common/cmdline.cpp:1232
+#: ../src/common/cmdline.cpp:1228
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "'%s' aukerarentzako balioa adierazi behar da."
@@ -7056,7 +7217,7 @@ msgstr "'%s' aukerarentzako balioa adierazi behar da."
 msgid "The value of the corner radius."
 msgstr "Bazterreko erradioaren balioa."
 
-#: ../src/msw/dialup.cpp:433
+#: ../src/msw/dialup.cpp:427
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -7070,14 +7231,14 @@ msgstr ""
 msgid "The vertical offset."
 msgstr "Zutikako oreka."
 
-#: ../src/richtext/richtextprint.cpp:619 ../src/html/htmprint.cpp:745
+#: ../src/html/htmprint.cpp:749 ../src/richtext/richtextprint.cpp:615
 msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr ""
 "Arazo bat egon da orrialde ezarpenean: badaiteke berezko irarkailu bat "
 "ezarri behar izatea. "
 
-#: ../src/html/htmprint.cpp:255
+#: ../src/html/htmprint.cpp:267
 msgid ""
 "This document doesn't fit on the page horizontally and will be truncated "
 "when it is printed."
@@ -7085,16 +7246,16 @@ msgstr ""
 "Agiri hau ez da orrialdean etzanka finkatzen eta itzulikatu egingo da "
 "irarkitzerakoan."
 
-#: ../src/common/image.cpp:2854
+#: ../src/common/image.cpp:2963
 #, c-format
 msgid "This is not a %s."
 msgstr "Hau ez da %s bat."
 
-#: ../src/common/wincmn.cpp:1653
+#: ../src/common/wincmn.cpp:1654
 msgid "This platform does not support background transparency."
 msgstr "Plataforma honek ez dut barren gardentasuna sostengatzen."
 
-#: ../src/gtk/window.cpp:4660
+#: ../src/gtk/window.cpp:5664
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
@@ -7102,7 +7263,15 @@ msgstr ""
 "Plataforma hau GTK+ bertsio zahar batekin bildua da, mesedez berreraiki GTK+ "
 "2.12 edo berriago batekin."
 
-#: ../src/msw/thread.cpp:1240
+#: ../src/gtk/glcanvas.cpp:176
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/msw/thread.cpp:1246
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -7110,11 +7279,11 @@ msgstr ""
 "Hari modulo abiarazpen hutsegitea: ezinezkoa biltegiratzea balioa hariaren "
 "tokiko biltegian "
 
-#: ../src/unix/threadpsx.cpp:1794
+#: ../src/unix/threadpsx.cpp:1843
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr "Hari modulo abiarazpen hutsegitea: hutsegitea hari giltza sortzerakoan"
 
-#: ../src/msw/thread.cpp:1228
+#: ../src/msw/thread.cpp:1234
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -7122,82 +7291,82 @@ msgstr ""
 "Hari modulo abiarazpen hutsegitea: ezinezkoa aurkibidea esleitzea hariaren "
 "tokiko biltegian"
 
-#: ../src/unix/threadpsx.cpp:1043
+#: ../src/unix/threadpsx.cpp:1061
 msgid "Thread priority setting is ignored."
 msgstr "Hari lehentasun ezarpena ezikusia da."
 
-#: ../src/msw/mdi.cpp:176
+#: ../src/msw/mdi.cpp:171
 msgid "Tile &Horizontally"
 msgstr "Teila &Etzana"
 
-#: ../src/msw/mdi.cpp:177
+#: ../src/msw/mdi.cpp:172
 msgid "Tile &Vertically"
 msgstr "Teila &Zutia"
 
-#: ../src/common/ftp.cpp:200
+#: ../src/common/ftp.cpp:197
 msgid "Timeout while waiting for FTP server to connect, try passive mode."
 msgstr ""
 "Denboraz kanpo FTP zerbitzariarekin elkarketatzeari itxaroten, saiatu modu "
 "pasiboarekin."
 
-#: ../src/generic/tipdlg.cpp:201
+#: ../src/generic/tipdlg.cpp:198
 msgid "Tip of the Day"
 msgstr "Eguneko Gomendioa"
 
-#: ../src/generic/tipdlg.cpp:140
+#: ../src/generic/tipdlg.cpp:137
 msgid "Tips not available, sorry!"
 msgstr "Gomendioak ez daude eskuragarri, barkatu!"
 
-#: ../src/generic/prntdlgg.cpp:242
+#: ../src/generic/prntdlgg.cpp:235
 msgid "To:"
 msgstr "Hona:"
 
-#: ../src/richtext/richtextbuffer.cpp:8363
+#: ../src/richtext/richtextbuffer.cpp:8361
 msgid "Too many EndStyle calls!"
 msgstr "EndStyle dei gehiegi!"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:891
+#: ../src/propgrid/advprops.cpp:792
 msgid "Tooltip"
 msgstr "Tresnaburu"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:892
+#: ../src/propgrid/advprops.cpp:793
 msgid "TooltipText"
 msgstr "Tresnaburu Idazkia"
 
-#: ../src/richtext/richtextsizepage.cpp:286
-#: ../src/richtext/richtextsizepage.cpp:290 ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197 ../src/richtext/richtextsizepage.cpp:286
+#: ../src/richtext/richtextsizepage.cpp:290
 msgid "Top"
 msgstr "Goia"
 
-#: ../src/generic/prntdlgg.cpp:881
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Top margin (mm):"
 msgstr "Goiko bazterra (mm):"
 
-#: ../src/generic/aboutdlgg.cpp:79
+#: ../src/generic/aboutdlgg.cpp:76
 msgid "Translations by "
 msgstr "Itzultzailea"
 
-#: ../src/generic/aboutdlgg.cpp:188
+#: ../src/generic/aboutdlgg.cpp:185
 msgid "Translators"
 msgstr "Itzultzaileak"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:211
+#: ../src/propgrid/propgrid.cpp:192
 msgid "True"
 msgstr "Egia"
 
-#: ../src/common/fs_mem.cpp:227
+#: ../src/common/fs_mem.cpp:222
 #, c-format
 msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
 msgstr "Saiatzen '%s' agiria VFS oroimenetik kentzen, baina ez dago gertatuta!"
 
-#: ../src/common/fmapbase.cpp:156
+#: ../src/common/fmapbase.cpp:153
 msgid "Turkish (ISO-8859-9)"
 msgstr "Turkiera (ISO-8859-9)"
 
-#: ../src/generic/filectrlg.cpp:426
+#: ../src/generic/filectrlg.cpp:422
 msgid "Type"
 msgstr "Idatzi"
 
@@ -7211,17 +7380,17 @@ msgstr "Idatzi hizki izen bat."
 msgid "Type a size in points."
 msgstr "Idatzi neurri bat puntutan."
 
-#: ../src/msw/ole/automtn.cpp:676
+#: ../src/msw/ole/automtn.cpp:667
 #, c-format
 msgid "Type mismatch in argument %u."
 msgstr "Idaz bat ez etortzea %u argumentoan."
 
-#: ../src/common/xtixml.cpp:356 ../src/common/xtixml.cpp:509
-#: ../src/common/xtistrm.cpp:318
+#: ../src/common/xtixml.cpp:352 ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315
 msgid "Type must have enum - long conversion"
 msgstr "Motak enum- long bihurketa izan behar du"
 
-#: ../src/propgrid/propgridiface.cpp:401
+#: ../src/propgrid/propgridiface.cpp:385
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
@@ -7230,19 +7399,19 @@ msgstr ""
 " \"%s\" eragiketa hutsegitea:  \"%s\" ezaugarri etiketatua \"%s\" motakoa "
 "da, EZ \"%s\"."
 
-#: ../src/common/paper.cpp:133
+#: ../src/common/paper.cpp:130
 msgid "US Std Fanfold, 14 7/8 x 11 in"
 msgstr "US Std Fanfold, 14 7/8 x 11 in"
 
-#: ../src/common/fmapbase.cpp:196
+#: ../src/common/fmapbase.cpp:193
 msgid "US-ASCII"
 msgstr "US-ASCII"
 
-#: ../src/unix/fswatcher_inotify.cpp:109
+#: ../src/unix/fswatcher_inotify.cpp:106
 msgid "Unable to add inotify watch"
 msgstr "Ezinezkoa inotify behatza gehitzea"
 
-#: ../src/unix/fswatcher_kqueue.cpp:136
+#: ../src/unix/fswatcher_kqueue.cpp:153
 msgid "Unable to add kqueue watch"
 msgstr "Ezinezkoa kqueue behatzea gehitzea"
 
@@ -7254,7 +7423,7 @@ msgstr "Ezinezkoa Sar/Irt osaketa atakarekin kudeaketa elkartzea "
 msgid "Unable to close I/O completion port handle"
 msgstr "Ezinezkoa Sar/Irt osaketa ataka kudeaketa istea"
 
-#: ../src/unix/fswatcher_inotify.cpp:97
+#: ../src/unix/fswatcher_inotify.cpp:94
 msgid "Unable to close inotify instance"
 msgstr "Ezinezkoa inotify eskabidea istea"
 
@@ -7272,15 +7441,15 @@ msgstr "Ezinezkoa '%s'-rako kudeaketa istea"
 msgid "Unable to create I/O completion port"
 msgstr "Ezinezkoa Sar/Irt osaketa ataka sortzea"
 
-#: ../src/msw/fswatcher.cpp:84
+#: ../src/msw/fswatcher.cpp:81
 msgid "Unable to create IOCP worker thread"
 msgstr "Ezinezkoa IOCP langile haria sortzea"
 
-#: ../src/unix/fswatcher_inotify.cpp:74
+#: ../src/unix/fswatcher_inotify.cpp:71
 msgid "Unable to create inotify instance"
 msgstr "Ezinezkoa inotify eskabidea sortzea"
 
-#: ../src/unix/fswatcher_kqueue.cpp:97
+#: ../src/unix/fswatcher_kqueue.cpp:114
 msgid "Unable to create kqueue instance"
 msgstr "Ezinezkoa kqueue eskabidea sortzea"
 
@@ -7288,11 +7457,11 @@ msgstr "Ezinezkoa kqueue eskabidea sortzea"
 msgid "Unable to dequeue completion packet"
 msgstr "Ezinezkoa osaketa paketea deslerrotzea"
 
-#: ../src/unix/fswatcher_kqueue.cpp:185
+#: ../src/unix/fswatcher_kqueue.cpp:202
 msgid "Unable to get events from kqueue"
 msgstr "Ezinezkoa kqueue-tik gertaera lortzea"
 
-#: ../src/gtk/app.cpp:435
+#: ../src/gtk/app.cpp:431
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "Ezinezkoa GTK+ hastea, ERAKUTSI ongi ezarrita dago?"
 
@@ -7301,12 +7470,12 @@ msgstr "Ezinezkoa GTK+ hastea, ERAKUTSI ongi ezarrita dago?"
 msgid "Unable to open path '%s'"
 msgstr "Ezinezkoa '%s' helburua irekitzea"
 
-#: ../src/html/htmlwin.cpp:583
+#: ../src/html/htmlwin.cpp:586
 #, c-format
 msgid "Unable to open requested HTML document: %s"
 msgstr "Ezinezkoa eskaturiko HTML agira irekitzea: %s"
 
-#: ../src/unix/sound.cpp:368
+#: ../src/unix/sound.cpp:365
 msgid "Unable to play sound asynchronously."
 msgstr "Ezinezkoa soinua ezaldiberean irakurtzea."
 
@@ -7314,61 +7483,61 @@ msgstr "Ezinezkoa soinua ezaldiberean irakurtzea."
 msgid "Unable to post completion status"
 msgstr "Ezinezkoa osaketa egoera aurkeztea"
 
-#: ../src/unix/fswatcher_inotify.cpp:556
+#: ../src/unix/fswatcher_inotify.cpp:553
 msgid "Unable to read from inotify descriptor"
 msgstr "Ezinezkoa inotify azaltzailetik irakurtzea"
 
-#: ../src/unix/fswatcher_inotify.cpp:141
+#: ../src/unix/fswatcher_inotify.cpp:138
 #, fuzzy, c-format
 msgid "Unable to remove inotify watch %i"
 msgstr "Ezinezkoa inotify behaketa kentzea"
 
-#: ../src/unix/fswatcher_kqueue.cpp:153
+#: ../src/unix/fswatcher_kqueue.cpp:170
 msgid "Unable to remove kqueue watch"
 msgstr "Ezinezkoa kqueue behaketa kentzea"
 
-#: ../src/msw/fswatcher.cpp:168
+#: ../src/msw/fswatcher.cpp:165
 #, c-format
 msgid "Unable to set up watch for '%s'"
 msgstr "Ezinezkoa Unable to set up watch for '%s'"
 
-#: ../src/msw/fswatcher.cpp:91
+#: ../src/msw/fswatcher.cpp:88
 msgid "Unable to start IOCP worker thread"
 msgstr "Ezinezkoa hastea IOCP langile haria"
 
-#: ../src/common/stockitem.cpp:201
+#: ../src/common/stockitem.cpp:198
 msgid "Undelete"
 msgstr "Desezabatu"
 
-#: ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199
 msgid "Underline"
 msgstr "Azpimarratua"
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/richtext/richtextfontpage.cpp:359 ../src/osx/carbon/fontdlg.cpp:370
-#: ../src/propgrid/advprops.cpp:690
+#: ../src/osx/carbon/fontdlg.cpp:367 ../src/propgrid/advprops.cpp:600
+#: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Azpimarratuta"
 
-#: ../src/common/stockitem.cpp:203 ../src/stc/stc_i18n.cpp:15
+#: ../src/common/stockitem.cpp:200 ../src/stc/stc_i18n.cpp:15
 msgid "Undo"
 msgstr "Desegin"
 
-#: ../src/common/stockitem.cpp:265
+#: ../src/common/stockitem.cpp:263
 msgid "Undo last action"
 msgstr "Desegin azken ekintza"
 
-#: ../src/common/cmdline.cpp:1029
+#: ../src/common/cmdline.cpp:1025
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Ustekabeko hizkiak '%s' aukeraren ondoren."
 
-#: ../src/unix/fswatcher_inotify.cpp:274
+#: ../src/unix/fswatcher_inotify.cpp:271
 #, c-format
 msgid "Unexpected event for \"%s\": no matching watch descriptor."
 msgstr "Ustekabeko gertaera \"%s\": ez dator bat behaketa azaltzailea."
 
-#: ../src/common/cmdline.cpp:1195
+#: ../src/common/cmdline.cpp:1191
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Ustekabeko parametroa '%s'"
@@ -7377,49 +7546,49 @@ msgstr "Ustekabeko parametroa '%s'"
 msgid "Unexpectedly new I/O completion port was created"
 msgstr "Ustekabeko S/I osaketa ataka berri bat sortu da"
 
-#: ../src/msw/fswatcher.cpp:70
+#: ../src/msw/fswatcher.cpp:67
 msgid "Ungraceful worker thread termination"
 msgstr "Langile hari amaiera zakartua"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:460
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:456
+#: ../src/richtext/richtextsymboldlg.cpp:457
+#: ../src/richtext/richtextsymboldlg.cpp:458
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../src/common/fmapbase.cpp:185 ../src/common/fmapbase.cpp:191
+#: ../src/common/fmapbase.cpp:182 ../src/common/fmapbase.cpp:188
 msgid "Unicode 16 bit (UTF-16)"
 msgstr "Unicode 16 bit (UTF-16)"
 
-#: ../src/common/fmapbase.cpp:190
+#: ../src/common/fmapbase.cpp:187
 msgid "Unicode 16 bit Big Endian (UTF-16BE)"
 msgstr "Unicode 16 bit Big Endian (UTF-16BE)"
 
-#: ../src/common/fmapbase.cpp:186
+#: ../src/common/fmapbase.cpp:183
 msgid "Unicode 16 bit Little Endian (UTF-16LE)"
 msgstr "Unicode 16 bit Little Endian (UTF-16LE)"
 
-#: ../src/common/fmapbase.cpp:187 ../src/common/fmapbase.cpp:193
+#: ../src/common/fmapbase.cpp:184 ../src/common/fmapbase.cpp:190
 msgid "Unicode 32 bit (UTF-32)"
 msgstr "Unicode 32 bit (UTF-32)"
 
-#: ../src/common/fmapbase.cpp:192
+#: ../src/common/fmapbase.cpp:189
 msgid "Unicode 32 bit Big Endian (UTF-32BE)"
 msgstr "Unicode 32 bit Big Endian (UTF-32BE)"
 
-#: ../src/common/fmapbase.cpp:188
+#: ../src/common/fmapbase.cpp:185
 msgid "Unicode 32 bit Little Endian (UTF-32LE)"
 msgstr "Unicode 32 bit Little Endian (UTF-32LE)"
 
-#: ../src/common/fmapbase.cpp:182
+#: ../src/common/fmapbase.cpp:179
 msgid "Unicode 7 bit (UTF-7)"
 msgstr "Unicode 7 bit (UTF-7)"
 
-#: ../src/common/fmapbase.cpp:183
+#: ../src/common/fmapbase.cpp:180
 msgid "Unicode 8 bit (UTF-8)"
 msgstr "Unicode 8 bit (UTF-8)"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "Unindent"
 msgstr "Hertzgabe"
 
@@ -7569,97 +7738,102 @@ msgstr "Goiko kokapenerako unitateak."
 msgid "Units for this value."
 msgstr "Balio honentzako unitateak."
 
-#: ../src/generic/progdlgg.cpp:353 ../src/generic/progdlgg.cpp:622
+#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
 msgid "Unknown"
 msgstr "Ezezaguna"
 
-#: ../src/msw/dde.cpp:1174
+#: ../src/msw/dde.cpp:1238
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "DDE akats %08x ezezaguna"
 
-#: ../src/common/xtistrm.cpp:410
+#: ../src/common/xtistrm.cpp:407
 msgid "Unknown Object passed to GetObjectClassInfo"
 msgstr "Objetu ezezaguna igaro da GetObjectClassInfo-ra"
 
-#: ../src/common/imagpng.cpp:366
+#: ../src/common/imagpng.cpp:383
 #, c-format
 msgid "Unknown PNG resolution unit %d"
 msgstr "PNG bereizmen unitate ezezaguna %d"
 
-#: ../src/common/xtixml.cpp:327
+#: ../src/common/xtixml.cpp:323
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Ezaugarri %s ezezaguna"
 
-#: ../src/common/imagtiff.cpp:529
+#: ../src/common/imagtiff.cpp:526
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "TIFF bereizmen unitate ezezaguna %d baztertuta"
 
-#: ../src/unix/dlunix.cpp:160
+#: ../src/propgrid/props.cpp:155
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/unix/dlunix.cpp:118
 msgid "Unknown dynamic library error"
 msgstr "Liburutegi dinamiko akats ezezaguna"
 
-#: ../src/common/fmapbase.cpp:810
+#: ../src/common/fmapbase.cpp:806
 #, c-format
 msgid "Unknown encoding (%d)"
 msgstr "Kodeaketa ezezaguna (%d)"
 
-#: ../src/msw/ole/automtn.cpp:688
+#: ../src/msw/ole/automtn.cpp:679
 #, c-format
 msgid "Unknown error %08x"
 msgstr "Akats ezezaguna %08x"
 
-#: ../src/msw/ole/automtn.cpp:647
+#: ../src/msw/ole/automtn.cpp:638
 msgid "Unknown exception"
 msgstr "Salbuespen ezezaguna"
 
-#: ../src/common/image.cpp:2839
+#: ../src/common/image.cpp:2942
 msgid "Unknown image data format."
 msgstr "Irudi datu heuskarri ezezaguna"
 
-#: ../src/common/cmdline.cpp:914
+#: ../src/common/cmdline.cpp:910
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Aukera luze ezezaguna '%s'"
 
-#: ../src/msw/ole/automtn.cpp:631
+#: ../src/msw/ole/automtn.cpp:622
 msgid "Unknown name or named argument."
 msgstr "Izen edo izendapen argumentu ezezaguna"
 
-#: ../src/common/cmdline.cpp:929 ../src/common/cmdline.cpp:951
+#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Aukera ezezaguana '%s'"
 
-#: ../src/common/mimecmn.cpp:225
+#: ../src/common/mimecmn.cpp:221
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "Alderaezina  '{' mime motako %s sarrera batean."
 
-#: ../src/common/cmdproc.cpp:262 ../src/common/cmdproc.cpp:288
-#: ../src/common/cmdproc.cpp:308
+#: ../src/common/cmdproc.cpp:255 ../src/common/cmdproc.cpp:281
+#: ../src/common/cmdproc.cpp:301
 msgid "Unnamed command"
 msgstr "Izengabeko agindua"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:413
+#: ../src/propgrid/propgrid.cpp:392
 msgid "Unspecified"
 msgstr "Zehaztugabea"
 
-#: ../src/msw/clipbrd.cpp:311
+#: ../src/msw/clipbrd.cpp:325
 msgid "Unsupported clipboard format."
 msgstr "Gako heuskarri sostengatu gabea."
 
-#: ../src/common/appcmn.cpp:256
+#: ../src/common/appcmn.cpp:277
 #, c-format
 msgid "Unsupported theme '%s'."
 msgstr "Azalgai sostengatu gabea'%s'"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:205
-#: ../src/common/accelcmn.cpp:63
+#: ../src/common/stockitem.cpp:202 ../src/common/accelcmn.cpp:60
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Up"
 msgstr "Gora"
 
@@ -7673,7 +7847,7 @@ msgstr "Hizki larriak"
 msgid "Upper case roman numerals"
 msgstr "Zenbaki erromatarrak hizki larrietan"
 
-#: ../src/common/cmdline.cpp:1326
+#: ../src/common/cmdline.cpp:1322
 #, c-format
 msgid "Usage: %s"
 msgstr "Erabilia: %s"
@@ -7682,38 +7856,47 @@ msgstr "Erabilia: %s"
 msgid "Use &shadow"
 msgstr "Erabili &Itzala"
 
-#: ../src/richtext/richtextindentspage.cpp:169
-#: ../src/richtext/richtextindentspage.cpp:171
 #: ../src/richtext/richtextliststylepage.cpp:358
 #: ../src/richtext/richtextliststylepage.cpp:360
+#: ../src/richtext/richtextindentspage.cpp:169
+#: ../src/richtext/richtextindentspage.cpp:171
 msgid "Use the current alignment setting."
 msgstr "Erabili oraingo lerrokapen ezarpena."
 
-#: ../src/common/valtext.cpp:179
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/gtk/font.cpp:552
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/common/valtext.cpp:142
 msgid "Validation conflict"
 msgstr "Balioztapen gatazka"
 
-#: ../src/propgrid/manager.cpp:238
+#: ../src/propgrid/manager.cpp:224
 msgid "Value"
 msgstr "Balioa"
 
-#: ../src/propgrid/props.cpp:386 ../src/propgrid/props.cpp:500
+#: ../src/propgrid/props.cpp:309
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "Baliloa izan behar da %s edo handiagoa."
 
-#: ../src/propgrid/props.cpp:417 ../src/propgrid/props.cpp:531
+#: ../src/propgrid/props.cpp:336
 #, c-format
 msgid "Value must be %s or less."
 msgstr "Balioa izan behar da %s edo txikiagoa."
 
-#: ../src/propgrid/props.cpp:393 ../src/propgrid/props.cpp:424
-#: ../src/propgrid/props.cpp:507 ../src/propgrid/props.cpp:538
+#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "Balioa izan behar da %s eta %s artekoa."
 
-#: ../src/generic/aboutdlgg.cpp:128
+#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Bertsioa"
 
@@ -7722,25 +7905,32 @@ msgstr "Bertsioa"
 msgid "Vertical alignment."
 msgstr "Zutikako lerrokapena."
 
-#: ../src/generic/filedlgg.cpp:202
+#: ../src/generic/filedlgg.cpp:199
 msgid "View files as a detailed view"
 msgstr "Ikusi agiriak xehetasunekin"
 
-#: ../src/generic/filedlgg.cpp:200
+#: ../src/generic/filedlgg.cpp:197
 msgid "View files as a list view"
 msgstr "Ikusi agiriak zerrenda bezala"
 
-#: ../src/common/docview.cpp:1970
+#: ../src/common/docview.cpp:1975
 msgid "Views"
 msgstr "Ikus"
 
+#: ../src/gtk/app.cpp:348
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1777
+#: ../src/propgrid/advprops.cpp:1678
 msgid "Wait"
 msgstr "Itxaron"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1779
+#: ../src/propgrid/advprops.cpp:1680
 msgid "Wait Arrow"
 msgstr "Itxaron Gezia"
 
@@ -7749,237 +7939,234 @@ msgstr "Itxaron Gezia"
 msgid "Waiting for IO on epoll descriptor %d failed"
 msgstr "Itxaroten IO epoll azaltzailean %d hutsegitea"
 
-#: ../src/common/log.cpp:223
+#: ../src/common/log.cpp:241
 msgid "Warning: "
 msgstr "Kontuz:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1778
+#: ../src/propgrid/advprops.cpp:1679
 msgid "Watch"
 msgstr "Behatu"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:685
+#: ../src/propgrid/advprops.cpp:595
 msgid "Weight"
 msgstr "Pisua"
 
-#: ../src/common/fmapbase.cpp:148
+#: ../src/common/fmapbase.cpp:145
 msgid "Western European (ISO-8859-1)"
 msgstr "Europa Mendebaldea (ISO-8859-1)"
 
-#: ../src/common/fmapbase.cpp:162
+#: ../src/common/fmapbase.cpp:159
 msgid "Western European with Euro (ISO-8859-15)"
 msgstr "Europa Mendebaldea Euroarekin (ISO-8859-15)"
 
-#: ../src/generic/fontdlgg.cpp:446 ../src/generic/fontdlgg.cpp:448
+#: ../src/generic/fontdlgg.cpp:443 ../src/generic/fontdlgg.cpp:445
 msgid "Whether the font is underlined."
 msgstr "Hizkia azpimarratuta badago."
 
-#: ../src/propgrid/advprops.cpp:1611
+#: ../src/propgrid/advprops.cpp:1517
 msgid "White"
 msgstr "Zuria"
 
-#: ../src/generic/fdrepdlg.cpp:144
+#: ../src/generic/fdrepdlg.cpp:141
 msgid "Whole word"
 msgstr "Hitz osoa"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:532
 msgid "Whole words only"
 msgstr "Hitz osoak bakarrik"
 
-#: ../src/univ/themes/win32.cpp:1102
+#: ../src/univ/themes/win32.cpp:1099
 msgid "Win32 theme"
 msgstr "Win32 azalgaia"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:893
+#: ../src/propgrid/advprops.cpp:794
 msgid "Window"
 msgstr "Leihoa"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:894
+#: ../src/propgrid/advprops.cpp:795
 msgid "WindowFrame"
 msgstr "Leiho-Uztaia"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:895
+#: ../src/propgrid/advprops.cpp:796
 msgid "WindowText"
 msgstr "Leiho-Idazkia"
 
-#: ../src/common/fmapbase.cpp:177
+#: ../src/common/fmapbase.cpp:174
 msgid "Windows Arabic (CP 1256)"
 msgstr "Windows Arabiarra (CP 1256)"
 
-#: ../src/common/fmapbase.cpp:178
+#: ../src/common/fmapbase.cpp:175
 msgid "Windows Baltic (CP 1257)"
 msgstr "Windows Baltikoa (CP 1257)"
 
-#: ../src/common/fmapbase.cpp:171
+#: ../src/common/fmapbase.cpp:168
 msgid "Windows Central European (CP 1250)"
 msgstr "Windows Europa Erdialdea (CP 1250)"
 
-#: ../src/common/fmapbase.cpp:168
+#: ../src/common/fmapbase.cpp:165
 msgid "Windows Chinese Simplified (CP 936) or GB-2312"
 msgstr "Windows Txinera Arrundua (CP 936) edo GB-2312"
 
-#: ../src/common/fmapbase.cpp:170
+#: ../src/common/fmapbase.cpp:167
 msgid "Windows Chinese Traditional (CP 950) or Big-5"
 msgstr "Windows Txinera Tradizionala (CP 950) edo Big-5"
 
-#: ../src/common/fmapbase.cpp:172
+#: ../src/common/fmapbase.cpp:169
 msgid "Windows Cyrillic (CP 1251)"
 msgstr "Windows Zirilikoa (CP 1251)"
 
-#: ../src/common/fmapbase.cpp:174
+#: ../src/common/fmapbase.cpp:171
 msgid "Windows Greek (CP 1253)"
 msgstr "Windows Greziera (CP 1253)"
 
-#: ../src/common/fmapbase.cpp:176
+#: ../src/common/fmapbase.cpp:173
 msgid "Windows Hebrew (CP 1255)"
 msgstr "Windows Hebraiera (CP 1255)"
 
-#: ../src/common/fmapbase.cpp:167
+#: ../src/common/fmapbase.cpp:164
 msgid "Windows Japanese (CP 932) or Shift-JIS"
 msgstr "Windows Japoniera (CP 932) edo Shift-JIS"
 
-#: ../src/common/fmapbase.cpp:180
+#: ../src/common/fmapbase.cpp:177
 msgid "Windows Johab (CP 1361)"
 msgstr "Windows Joahb (CP 1356)"
 
-#: ../src/common/fmapbase.cpp:169
+#: ../src/common/fmapbase.cpp:166
 msgid "Windows Korean (CP 949)"
 msgstr "Windows Koreaera (CP 949)"
 
-#: ../src/common/fmapbase.cpp:166
+#: ../src/common/fmapbase.cpp:163
 msgid "Windows Thai (CP 874)"
 msgstr "Windows Thailandiera (CP 874)"
 
-#: ../src/common/fmapbase.cpp:175
+#: ../src/common/fmapbase.cpp:172
 msgid "Windows Turkish (CP 1254)"
 msgstr "Windows Turkiera (CP 1254)"
 
-#: ../src/common/fmapbase.cpp:179
+#: ../src/common/fmapbase.cpp:176
 msgid "Windows Vietnamese (CP 1258)"
 msgstr "Windows Vietnamiera (CP 1258)"
 
-#: ../src/common/fmapbase.cpp:173
+#: ../src/common/fmapbase.cpp:170
 msgid "Windows Western European (CP 1252)"
 msgstr "Windows Europa Mendebaldea (CP 1252)"
 
-#: ../src/common/fmapbase.cpp:181
+#: ../src/common/fmapbase.cpp:178
 msgid "Windows/DOS OEM (CP 437)"
 msgstr "Windows/DOS OEM (CP 437)"
 
-#: ../src/common/fmapbase.cpp:165
+#: ../src/common/fmapbase.cpp:162
 msgid "Windows/DOS OEM Cyrillic (CP 866)"
 msgstr "Windows/DOS OEM Zirilikoa (CP 866)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:111
+#: ../src/common/accelcmn.cpp:109
 msgid "Windows_Left"
 msgstr "Windows_Ezker"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:113
+#: ../src/common/accelcmn.cpp:111
 msgid "Windows_Menu"
 msgstr "Windows_Menua"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:112
+#: ../src/common/accelcmn.cpp:110
 msgid "Windows_Right"
 msgstr "Windows_Eskuin"
 
-#: ../src/common/ffile.cpp:150
+#: ../src/common/ffile.cpp:149
 #, c-format
 msgid "Write error on file '%s'"
 msgstr "Idaz akatsa '%s' agirian"
 
-#: ../src/xml/xml.cpp:914
+#: ../src/xml/xml.cpp:925
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "XML azterketa akatsa : '%s' %d lerroan"
 
-#: ../src/common/xpmdecod.cpp:796
+#: ../src/common/xpmdecod.cpp:794
 msgid "XPM: Malformed pixel data!"
 msgstr "XPM: Pixel datu okerra!"
 
-#: ../src/common/xpmdecod.cpp:705
+#: ../src/common/xpmdecod.cpp:702
 #, c-format
 msgid "XPM: incorrect colour description in line %d"
 msgstr "XPM: margo azalpen okerra %d lerroan"
 
-#: ../src/common/xpmdecod.cpp:680
+#: ../src/common/xpmdecod.cpp:677
 msgid "XPM: incorrect header format!"
 msgstr "XPM: idazburu heuskarri okerra!"
 
-#: ../src/common/xpmdecod.cpp:716 ../src/common/xpmdecod.cpp:725
+#: ../src/common/xpmdecod.cpp:714 ../src/common/xpmdecod.cpp:723
 #, c-format
 msgid "XPM: malformed colour definition '%s' at line %d!"
 msgstr "XPM: margo bereizmen okerra '%s' %d lerroan!"
 
-#: ../src/common/xpmdecod.cpp:755
+#: ../src/common/xpmdecod.cpp:753
 msgid "XPM: no colors left to use for mask!"
 msgstr "XPM: ez duzu mozorro margoak erabiltzeari utzi!"
 
-#: ../src/common/xpmdecod.cpp:782
+#: ../src/common/xpmdecod.cpp:780
 #, c-format
 msgid "XPM: truncated image data at line %d!"
 msgstr "XPM: irudi datuak trunkatuta %d lerroan!"
 
-#: ../src/propgrid/advprops.cpp:1610
+#: ../src/propgrid/advprops.cpp:1516
 msgid "Yellow"
 msgstr "Oria"
 
-#: ../include/wx/msgdlg.h:276 ../src/common/stockitem.cpp:206
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:203
 #: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Bai"
 
-#: ../src/osx/carbon/overlay.cpp:155
-msgid "You cannot Clear an overlay that is not inited"
-msgstr "Ezin duzu Garbitu hasita ez dagoen gainjarpena "
-
-#: ../src/osx/carbon/overlay.cpp:107 ../src/dfb/overlay.cpp:61
-msgid "You cannot Init an overlay twice"
-msgstr "Ezin duzu Hasi bi aldiko gainjarpenean"
-
-#: ../src/generic/dirdlgg.cpp:287
+#: ../src/generic/dirdlgg.cpp:284
 msgid "You cannot add a new directory to this section."
 msgstr "Ezin duzu zuzenbide berririk gehitu atal honetara."
 
-#: ../src/propgrid/propgrid.cpp:3299
+#: ../src/propgrid/propgrid.cpp:3276
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr "Balio okerra sartu duzu. Sakatu IRTEN edizioa ezeztatzeko."
 
-#: ../src/common/stockitem.cpp:209
+#: ../src/osx/cocoa/menu.mm:286
+#, fuzzy
+msgid "Zoom"
+msgstr "Zooma Handitu"
+
+#: ../src/common/stockitem.cpp:206
 msgid "Zoom &In"
 msgstr "Zooma &Handitu"
 
-#: ../src/common/stockitem.cpp:210
+#: ../src/common/stockitem.cpp:207
 msgid "Zoom &Out"
 msgstr "Zooma &Gutxitu"
 
-#: ../src/common/stockitem.cpp:209 ../src/common/prntbase.cpp:1594
+#: ../src/common/stockitem.cpp:206 ../src/common/prntbase.cpp:1619
 msgid "Zoom In"
 msgstr "Zooma Handitu"
 
-#: ../src/common/stockitem.cpp:210 ../src/common/prntbase.cpp:1580
+#: ../src/common/stockitem.cpp:207 ../src/common/prntbase.cpp:1605
 msgid "Zoom Out"
 msgstr "Zooma Gutxitu"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to &Fit"
 msgstr "Zooma &Zehazteko"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to Fit"
 msgstr "Zooma Zehazteko"
 
-#: ../src/msw/dde.cpp:1141
+#: ../src/msw/dde.cpp:1205
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "DDEML aplikazio batek lasterketa baldintza luzatu bat sortu du."
 
-#: ../src/msw/dde.cpp:1129
+#: ../src/msw/dde.cpp:1193
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -7990,39 +8177,39 @@ msgstr ""
 "edo ekinbide ezagutarazle baliogabe bat\n"
 "pasatu da DDEML eginkizun batera."
 
-#: ../src/msw/dde.cpp:1147
+#: ../src/msw/dde.cpp:1211
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "hutsegitea bezero baten elkarrizketa baten ezartze saiakeran"
 
-#: ../src/msw/dde.cpp:1144
+#: ../src/msw/dde.cpp:1208
 msgid "a memory allocation failed."
 msgstr "oroimen esleipen hutsegitea."
 
-#: ../src/msw/dde.cpp:1138
+#: ../src/msw/dde.cpp:1202
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "paremetro batek huts egin du DDEML-ak balidatzerakoan."
 
-#: ../src/msw/dde.cpp:1120
+#: ../src/msw/dde.cpp:1184
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "ohar eskualdaketa sinkrono baterako eskabidea denboraz-kanpo."
 
-#: ../src/msw/dde.cpp:1126
+#: ../src/msw/dde.cpp:1190
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "datu eskualdaketa sinkrono baterako eskabidea denboraz-kanpo."
 
-#: ../src/msw/dde.cpp:1135
+#: ../src/msw/dde.cpp:1199
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "exekuzio eskualdaketa sinkrono baterako eskabidea denboraz-kanpo."
 
-#: ../src/msw/dde.cpp:1153
+#: ../src/msw/dde.cpp:1217
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "sarrera eskualdaketa sinkrono baterako eskabidea denboraz-kanpo."
 
-#: ../src/msw/dde.cpp:1168
+#: ../src/msw/dde.cpp:1232
 msgid "a request to end an advise transaction has timed out."
 msgstr "ohar eskualdaketa amaiera eskabidea denboraz-kanpo."
 
-#: ../src/msw/dde.cpp:1162
+#: ../src/msw/dde.cpp:1226
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -8032,15 +8219,15 @@ msgstr ""
 "bezeroak amaitu duena, edo zerbitzariak\n"
 "amaitu du eskualdaketa bat osatu aurretik."
 
-#: ../src/msw/dde.cpp:1150
+#: ../src/msw/dde.cpp:1214
 msgid "a transaction failed."
 msgstr "eskualdaketa hutsegitea."
 
-#: ../src/common/accelcmn.cpp:189
+#: ../src/common/accelcmn.cpp:188
 msgid "alt"
 msgstr "alt"
 
-#: ../src/msw/dde.cpp:1132
+#: ../src/msw/dde.cpp:1196
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -8052,15 +8239,15 @@ msgstr ""
 "edo APPCMD_CLIENTONLY bezala abiatutako aplikazio bat \n"
 "zerbitzari transakzioak egiten saiatu da."
 
-#: ../src/msw/dde.cpp:1156
+#: ../src/msw/dde.cpp:1220
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "PostMessage eginkizunerako barne deiak huts egin du."
 
-#: ../src/msw/dde.cpp:1165
+#: ../src/msw/dde.cpp:1229
 msgid "an internal error has occurred in the DDEML."
 msgstr "barne akats bat gertatu da DDEML-an."
 
-#: ../src/msw/dde.cpp:1171
+#: ../src/msw/dde.cpp:1235
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -8070,56 +8257,56 @@ msgstr ""
 "Behin aplikazioak XTYP_XACT_COMPLETE irizkizunetik erantzundakoan,\n"
 "irizkizun horretarako ezgutarazlea ez da baliogarria gehiago."
 
-#: ../src/common/zipstrm.cpp:1483
+#: ../src/common/zipstrm.cpp:1522
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "onartzen zip zati-anitz kateatutakoa dela "
 
-#: ../src/common/fileconf.cpp:1847
+#: ../src/common/fileconf.cpp:1849
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "'%s' tekla aldaezina aldatzeko saiakera baztertuta."
 
-#: ../src/html/chm.cpp:329
+#: ../src/html/chm.cpp:326
 msgid "bad arguments to library function"
 msgstr "argumengu okerra liburutegi eginkizunerako"
 
-#: ../src/html/chm.cpp:341
+#: ../src/html/chm.cpp:338
 msgid "bad signature"
 msgstr "sinadura okerra"
 
-#: ../src/common/zipstrm.cpp:1918
+#: ../src/common/zipstrm.cpp:1988
 msgid "bad zipfile offset to entry"
 msgstr "zipagiri okerra orekatuta sarrerarako"
 
-#: ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400
 msgid "binary"
 msgstr "binarioa"
 
-#: ../src/common/fontcmn.cpp:996
+#: ../src/common/fontcmn.cpp:1195
 msgid "bold"
 msgstr "lodia"
 
-#: ../src/msw/utils.cpp:1144
+#: ../src/msw/utils.cpp:1135
 #, c-format
 msgid "build %lu"
 msgstr "%lu eraiketa"
 
-#: ../src/common/ffile.cpp:75
+#: ../src/common/ffile.cpp:73
 #, c-format
 msgid "can't close file '%s'"
 msgstr "ezin da itxi '%s' agiria"
 
-#: ../src/common/file.cpp:245
+#: ../src/common/file.cpp:242
 #, c-format
 msgid "can't close file descriptor %d"
 msgstr "ezin da itxi %d agiri azaltzailea "
 
-#: ../src/common/file.cpp:586
+#: ../src/common/ffile.cpp:382 ../src/common/file.cpp:613
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "ezin da aldaketarik egin '%s' agirian"
 
-#: ../src/common/file.cpp:178
+#: ../src/common/file.cpp:175
 #, c-format
 msgid "can't create file '%s'"
 msgstr "ezin da '%s' agiria sortu"
@@ -8129,50 +8316,50 @@ msgstr "ezin da '%s' agiria sortu"
 msgid "can't delete user configuration file '%s'"
 msgstr "ezin da ezabatu '%s' erabiltzailearen itxurapen agiria"
 
-#: ../src/common/file.cpp:495
+#: ../src/common/file.cpp:522
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr "ezin da zehaztu agiriaren amaiera lortu den %d azaltzailean"
 
-#: ../src/common/zipstrm.cpp:1692
+#: ../src/common/zipstrm.cpp:1747
 msgid "can't find central directory in zip"
 msgstr "ezin da aurkitu zuzenbide nagusia zip-ean"
 
-#: ../src/common/file.cpp:465
+#: ../src/common/file.cpp:492
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "ezin da aurkitu agiri luzera %d agiri azaltzailean"
 
-#: ../src/msw/utils.cpp:341
+#: ../src/msw/utils.cpp:336
 msgid "can't find user's HOME, using current directory."
 msgstr ""
 "ezin da aurkitu erabiltzailearen HASIERA, oraingo zuzenbidea erabiltzen."
 
-#: ../src/common/file.cpp:366
+#: ../src/common/file.cpp:407
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "ezin da jaso %d agiri azaltzailea"
 
-#: ../src/common/file.cpp:422
+#: ../src/common/file.cpp:463
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "ezin da bilaketa kokapenik bilatu %d agiri azaltzailean"
 
-#: ../src/common/fontmap.cpp:325
+#: ../src/common/fontmap.cpp:322
 msgid "can't load any font, aborting"
 msgstr "ezin da gertatu hizkirik, uzten"
 
-#: ../src/common/file.cpp:231 ../src/common/ffile.cpp:59
+#: ../src/common/ffile.cpp:57 ../src/common/file.cpp:228
 #, c-format
 msgid "can't open file '%s'"
 msgstr "ezin da ireki '%s' agiria"
 
-#: ../src/common/fileconf.cpp:320
+#: ../src/common/fileconf.cpp:314
 #, c-format
 msgid "can't open global configuration file '%s'."
 msgstr "ezin da ireki '%s'  itxurapen globaleko agiria"
 
-#: ../src/common/fileconf.cpp:336
+#: ../src/common/fileconf.cpp:330
 #, c-format
 msgid "can't open user configuration file '%s'."
 msgstr "ezin da ireki '%s' erabiltzailearen itxurapen agiria ."
@@ -8181,40 +8368,40 @@ msgstr "ezin da ireki '%s' erabiltzailearen itxurapen agiria ."
 msgid "can't open user configuration file."
 msgstr "ezin da ireki erabiltzailearen itxurapen agiria."
 
-#: ../src/common/zipstrm.cpp:579
+#: ../src/common/zipstrm.cpp:572
 msgid "can't re-initialize zlib deflate stream"
 msgstr "ezin da birrabiarazi zlib deflate jarioa"
 
-#: ../src/common/zipstrm.cpp:604
+#: ../src/common/zipstrm.cpp:597
 msgid "can't re-initialize zlib inflate stream"
 msgstr "ezin da birrabiarazi zlib inflate jarioa "
 
-#: ../src/common/file.cpp:304
+#: ../src/common/file.cpp:345
 #, c-format
 msgid "can't read from file descriptor %d"
 msgstr "ezin da irakurri %d agiri azaltzailetik"
 
-#: ../src/common/file.cpp:581
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:608
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "ezin da kendu '%s' agiria"
 
-#: ../src/common/file.cpp:598
+#: ../src/common/ffile.cpp:394 ../src/common/file.cpp:625
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "ezin da kendu '%s' aldibaterako agiria"
 
-#: ../src/common/file.cpp:408
+#: ../src/common/file.cpp:449
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "ezin da bilatu %d agiri azaltzailean"
 
-#: ../src/common/textfile.cpp:273
+#: ../src/common/textfile.cpp:161
 #, c-format
 msgid "can't write buffer '%s' to disk."
 msgstr "ezin da idatzi '%s' bufferra diskara"
 
-#: ../src/common/file.cpp:323
+#: ../src/common/file.cpp:364
 #, c-format
 msgid "can't write to file descriptor %d"
 msgstr "ezin da idatzi %d agiri azaltzailera"
@@ -8224,22 +8411,28 @@ msgid "can't write user configuration file."
 msgstr "ezin da idatzi erabiltzailearen itxurapen agiria."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:482 ../src/generic/datavgen.cpp:1261
+#: ../src/common/datavcmn.cpp:2064 ../src/generic/datavgen.cpp:1384
 msgid "checked"
 msgstr ""
 
-#: ../src/html/chm.cpp:345
+#: ../src/html/chm.cpp:342
 msgid "checksum error"
 msgstr "Egiaztapen hutsegitea"
 
-#: ../src/common/tarstrm.cpp:820
+#: ../src/common/tarstrm.cpp:814
 msgid "checksum failure reading tar header block"
 msgstr "Egiaztapen hutsegitea tar idazburu blokea irakurtzean"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:226
-#: ../src/richtext/richtextbackgroundpage.cpp:249
-#: ../src/richtext/richtextbackgroundpage.cpp:289
-#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
 #: ../src/richtext/richtextborderspage.cpp:254
 #: ../src/richtext/richtextborderspage.cpp:288
 #: ../src/richtext/richtextborderspage.cpp:322
@@ -8257,105 +8450,128 @@ msgstr "Egiaztapen hutsegitea tar idazburu blokea irakurtzean"
 #: ../src/richtext/richtextmarginspage.cpp:340
 #: ../src/richtext/richtextmarginspage.cpp:363
 #: ../src/richtext/richtextmarginspage.cpp:388
-#: ../src/richtext/richtextsizepage.cpp:339
-#: ../src/richtext/richtextsizepage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:400
-#: ../src/richtext/richtextsizepage.cpp:427
-#: ../src/richtext/richtextsizepage.cpp:454
-#: ../src/richtext/richtextsizepage.cpp:481
-#: ../src/richtext/richtextsizepage.cpp:555
-#: ../src/richtext/richtextsizepage.cpp:590
-#: ../src/richtext/richtextsizepage.cpp:625
-#: ../src/richtext/richtextsizepage.cpp:660
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
 msgid "cm"
 msgstr "me"
 
-#: ../src/html/chm.cpp:347
+#: ../src/html/chm.cpp:344
 msgid "compression error"
 msgstr "konpresio akatsa"
 
-#: ../src/common/regex.cpp:236
+#: ../src/common/regex.cpp:233
 msgid "conversion to 8-bit encoding failed"
 msgstr "hutsegitea 8-bitera bihurtzerakoan"
 
-#: ../src/common/accelcmn.cpp:187
+#: ../src/common/accelcmn.cpp:186
 msgid "ctrl"
 msgstr "ktrl"
 
-#: ../src/common/cmdline.cpp:1500
+#: ../src/common/cmdline.cpp:1496
 msgid "date"
 msgstr "eguna"
 
-#: ../src/html/chm.cpp:349
+#: ../src/html/chm.cpp:346
 msgid "decompression error"
 msgstr "deskonpresio akatsa"
 
-#: ../src/richtext/richtextstyles.cpp:780 ../src/common/fmapbase.cpp:820
+#: ../src/common/fmapbase.cpp:816 ../src/richtext/richtextstyles.cpp:777
 msgid "default"
 msgstr "berezkoa"
 
-#: ../src/common/cmdline.cpp:1496
+#: ../src/common/cmdline.cpp:1492
 msgid "double"
 msgstr "bikoitza"
 
-#: ../src/common/debugrpt.cpp:538
+#: ../src/common/debugrpt.cpp:539
 msgid "dump of the process state (binary)"
 msgstr "garapen egoeraren erauztea (binarioa)"
 
-#: ../src/common/datetimefmt.cpp:1969
+#: ../src/common/datetimefmt.cpp:1992
 msgid "eighteenth"
 msgstr "hemezortzigarren"
 
-#: ../src/common/datetimefmt.cpp:1959
+#: ../src/common/datetimefmt.cpp:1982
 msgid "eighth"
 msgstr "zortzigarren"
 
-#: ../src/common/datetimefmt.cpp:1962
+#: ../src/common/datetimefmt.cpp:1985
 msgid "eleventh"
 msgstr "hamaikagarren"
 
-#: ../src/common/fileconf.cpp:1833
+#: ../src/common/fileconf.cpp:1835
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "'%s' sarrera behin baino gehiagotan agertzen da '%s' taldean"
 
-#: ../src/html/chm.cpp:343
+#: ../src/html/chm.cpp:340
 msgid "error in data format"
 msgstr "akatsa datu heuskarrian"
 
-#: ../src/html/chm.cpp:331
+#: ../src/html/chm.cpp:328
 msgid "error opening file"
 msgstr "akatsa agira irakitzean"
 
-#: ../src/common/zipstrm.cpp:1778
+#: ../src/common/zipstrm.cpp:1836
 msgid "error reading zip central directory"
 msgstr "akatsa ziparen zuzenbide nagusia irakurtzean"
 
-#: ../src/common/zipstrm.cpp:1870
+#: ../src/common/zipstrm.cpp:1940
 msgid "error reading zip local header"
 msgstr "akatsa ziparen tokiko idazburua irakurtzen"
 
-#: ../src/common/zipstrm.cpp:2531
+#: ../src/common/zipstrm.cpp:2615
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "akatsa '%s' zip sarrera irakurtzean: crc okerra edo luzeegia"
 
-#: ../src/common/ffile.cpp:188
+#: ../src/common/zipstrm.cpp:2608
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "akatsa '%s' zip sarrera irakurtzean: crc okerra edo luzeegia"
+
+#: ../src/common/fontcmn.cpp:1205
+#, fuzzy
+msgid "extrabold"
+msgstr "lodia"
+
+#: ../src/common/fontcmn.cpp:1223
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1167
+#, fuzzy
+msgid "extralight"
+msgstr "arina"
+
+#: ../src/msw/webview_ie.cpp:1036
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "Hutsegitea '%s' exekutatzerakoan\n"
+
+#: ../src/common/ffile.cpp:187
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "hutsegitea '%s' agiria jalgitzean "
 
+#: ../src/msw/webview_ie.cpp:1045
+#, fuzzy
+msgid "failed to retrieve execution result"
+msgstr "Hutsegitea RAS akats mezutik idazkia berreskuratzerakoan"
+
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1030
+#: ../src/generic/datavgen.cpp:1150
 #, fuzzy
 msgid "false"
 msgstr "Faltsua"
 
-#: ../src/common/datetimefmt.cpp:1966
+#: ../src/common/datetimefmt.cpp:1989
 msgid "fifteenth"
 msgstr "hamabostgarren"
 
-#: ../src/common/datetimefmt.cpp:1956
+#: ../src/common/datetimefmt.cpp:1979
 msgid "fifth"
 msgstr "bostgarren"
 
@@ -8384,131 +8600,150 @@ msgstr "'%s' agiria, %d lerroa: '%s' tekla aldaezinarentzako balioa baztertua."
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "'%s' agira: ustekabeko %c hizkia %d lerroan."
 
-#: ../src/richtext/richtextbuffer.cpp:8738
+#: ../src/richtext/richtextbuffer.cpp:8736
 msgid "files"
 msgstr "agiriak"
 
-#: ../src/common/datetimefmt.cpp:1952
+#: ../src/common/datetimefmt.cpp:1975
 msgid "first"
 msgstr "lehen"
 
-#: ../src/html/helpwnd.cpp:1252
+#: ../src/html/helpwnd.cpp:1250
 msgid "font size"
 msgstr "hizki neurria"
 
-#: ../src/common/datetimefmt.cpp:1965
+#: ../src/common/datetimefmt.cpp:1988
 msgid "fourteenth"
 msgstr "hamalaugarren"
 
-#: ../src/common/datetimefmt.cpp:1955
+#: ../src/common/datetimefmt.cpp:1978
 msgid "fourth"
 msgstr "laugarren"
 
-#: ../src/common/appbase.cpp:783
+#: ../src/common/appbase.cpp:784
 msgid "generate verbose log messages"
 msgstr "sortu ohar mezu berritsuak"
 
-#: ../src/richtext/richtextbuffer.cpp:13138
-#: ../src/richtext/richtextbuffer.cpp:13248
+#: ../src/common/fontcmn.cpp:1215
+msgid "heavy"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:13133
+#: ../src/richtext/richtextbuffer.cpp:13243
 msgid "image"
 msgstr "irudia"
 
-#: ../src/common/tarstrm.cpp:796
+#: ../src/common/tarstrm.cpp:790
 msgid "incomplete header block in tar"
 msgstr "idazburu bloke osatugabea tar-en"
 
-#: ../src/common/xtixml.cpp:489
+#: ../src/common/xtixml.cpp:485
 msgid "incorrect event handler string, missing dot"
 msgstr "gertaera kudeatzaile kate okerra, puntu gabe"
 
-#: ../src/common/tarstrm.cpp:1381
+#: ../src/common/tarstrm.cpp:1375
 msgid "incorrect size given for tar entry"
 msgstr "tar sarrereak neurri okerra eman du"
 
-#: ../src/common/tarstrm.cpp:993
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:987
 msgid "invalid data in extended tar header"
 msgstr "datu baliogabea tar hedatu idazburuan"
 
-#: ../src/generic/logg.cpp:1030
+#: ../src/generic/logg.cpp:1027
 msgid "invalid message box return value"
 msgstr "mezu kutxa baliogabea balioa itzultzen"
 
-#: ../src/common/zipstrm.cpp:1647
+#: ../src/common/zipstrm.cpp:1688
 msgid "invalid zip file"
 msgstr "zip agiri baliogabea"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:1228
 msgid "italic"
 msgstr "etzana"
 
-#: ../src/common/fontcmn.cpp:991
+#: ../src/common/webrequest_curl.cpp:374
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "Zutabe azalpena ezin da abiarazi."
+
+#: ../src/common/fontcmn.cpp:1172
 msgid "light"
 msgstr "arina"
 
-#: ../src/common/intl.cpp:303
-#, c-format
-msgid "locale '%s' cannot be set."
-msgstr "tokiko '%s' ezin da ezarri."
+#: ../src/common/fontcmn.cpp:1185
+msgid "medium"
+msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2125
+#: ../src/common/datetimefmt.cpp:2148
 msgid "midnight"
 msgstr "gauerdia"
 
-#: ../src/common/datetimefmt.cpp:1970
+#: ../src/common/datetimefmt.cpp:1993
 msgid "nineteenth"
 msgstr "hemeretzigarren"
 
-#: ../src/common/datetimefmt.cpp:1960
+#: ../src/common/datetimefmt.cpp:1983
 msgid "ninth"
 msgstr "bederatzigarren"
 
-#: ../src/msw/dde.cpp:1116
+#: ../src/msw/dde.cpp:1180
 msgid "no DDE error."
 msgstr "no DDE akatsa."
 
-#: ../src/html/chm.cpp:327
+#: ../src/html/chm.cpp:324
 msgid "no error"
 msgstr "no akatsa"
 
-#: ../src/dfb/fontmgr.cpp:174
+#: ../src/dfb/fontmgr.cpp:171
 #, c-format
 msgid "no fonts found in %s, using builtin font"
 msgstr "ez da hizkirik aurkitu hemen: %s, barne hizikia erabiltzen"
 
-#: ../src/html/helpdata.cpp:657
+#: ../src/html/helpdata.cpp:650
 msgid "noname"
 msgstr "izengabe"
 
-#: ../src/common/datetimefmt.cpp:2124
+#: ../src/common/datetimefmt.cpp:2147
 msgid "noon"
 msgstr "eguerdia"
 
-#: ../src/richtext/richtextstyles.cpp:779
+#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "arrunta"
 
-#: ../src/common/cmdline.cpp:1492
+#: ../src/common/cmdline.cpp:1488
 msgid "num"
 msgstr "zenb"
 
-#: ../src/common/xtixml.cpp:259
+#: ../src/common/accelcmn.cpp:194
+msgid "num "
+msgstr ""
+
+#: ../src/common/xtixml.cpp:255
 msgid "objects cannot have XML Text Nodes"
 msgstr "objetuek ezin dute XML Testu Nodorik izan"
 
-#: ../src/html/chm.cpp:339
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
 msgid "out of memory"
 msgstr "oroimenetik kanpo"
 
-#: ../src/common/debugrpt.cpp:514
+#: ../src/common/debugrpt.cpp:515
 msgid "process context description"
 msgstr "garapen hitzinguru azalpena"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:227
-#: ../src/richtext/richtextbackgroundpage.cpp:250
-#: ../src/richtext/richtextbackgroundpage.cpp:290
-#: ../src/richtext/richtextbackgroundpage.cpp:317
-#: ../src/richtext/richtextfontpage.cpp:177
-#: ../src/richtext/richtextfontpage.cpp:180
 #: ../src/richtext/richtextborderspage.cpp:255
 #: ../src/richtext/richtextborderspage.cpp:289
 #: ../src/richtext/richtextborderspage.cpp:323
@@ -8518,22 +8753,45 @@ msgstr "garapen hitzinguru azalpena"
 #: ../src/richtext/richtextborderspage.cpp:491
 #: ../src/richtext/richtextborderspage.cpp:525
 #: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextfontpage.cpp:180
 msgid "pt"
 msgstr "pt"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:225
-#: ../src/richtext/richtextbackgroundpage.cpp:228
-#: ../src/richtext/richtextbackgroundpage.cpp:229
-#: ../src/richtext/richtextbackgroundpage.cpp:248
-#: ../src/richtext/richtextbackgroundpage.cpp:251
-#: ../src/richtext/richtextbackgroundpage.cpp:252
-#: ../src/richtext/richtextbackgroundpage.cpp:288
-#: ../src/richtext/richtextbackgroundpage.cpp:291
-#: ../src/richtext/richtextbackgroundpage.cpp:292
-#: ../src/richtext/richtextbackgroundpage.cpp:315
-#: ../src/richtext/richtextbackgroundpage.cpp:318
-#: ../src/richtext/richtextbackgroundpage.cpp:319
-#: ../src/richtext/richtextfontpage.cpp:178
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:659
+#: ../src/richtext/richtextsizepage.cpp:662
+#: ../src/richtext/richtextsizepage.cpp:663
 #: ../src/richtext/richtextborderspage.cpp:253
 #: ../src/richtext/richtextborderspage.cpp:256
 #: ../src/richtext/richtextborderspage.cpp:257
@@ -8585,260 +8843,270 @@ msgstr "pt"
 #: ../src/richtext/richtextmarginspage.cpp:387
 #: ../src/richtext/richtextmarginspage.cpp:389
 #: ../src/richtext/richtextmarginspage.cpp:390
-#: ../src/richtext/richtextsizepage.cpp:338
-#: ../src/richtext/richtextsizepage.cpp:341
-#: ../src/richtext/richtextsizepage.cpp:342
-#: ../src/richtext/richtextsizepage.cpp:372
-#: ../src/richtext/richtextsizepage.cpp:375
-#: ../src/richtext/richtextsizepage.cpp:376
-#: ../src/richtext/richtextsizepage.cpp:399
-#: ../src/richtext/richtextsizepage.cpp:402
-#: ../src/richtext/richtextsizepage.cpp:403
-#: ../src/richtext/richtextsizepage.cpp:426
-#: ../src/richtext/richtextsizepage.cpp:429
-#: ../src/richtext/richtextsizepage.cpp:430
-#: ../src/richtext/richtextsizepage.cpp:453
-#: ../src/richtext/richtextsizepage.cpp:456
-#: ../src/richtext/richtextsizepage.cpp:457
-#: ../src/richtext/richtextsizepage.cpp:480
-#: ../src/richtext/richtextsizepage.cpp:483
-#: ../src/richtext/richtextsizepage.cpp:484
-#: ../src/richtext/richtextsizepage.cpp:554
-#: ../src/richtext/richtextsizepage.cpp:557
-#: ../src/richtext/richtextsizepage.cpp:558
-#: ../src/richtext/richtextsizepage.cpp:589
-#: ../src/richtext/richtextsizepage.cpp:592
-#: ../src/richtext/richtextsizepage.cpp:593
-#: ../src/richtext/richtextsizepage.cpp:624
-#: ../src/richtext/richtextsizepage.cpp:627
-#: ../src/richtext/richtextsizepage.cpp:628
-#: ../src/richtext/richtextsizepage.cpp:659
-#: ../src/richtext/richtextsizepage.cpp:662
-#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextfontpage.cpp:178
 msgid "px"
 msgstr "px"
 
-#: ../src/common/accelcmn.cpp:193
+#: ../src/common/accelcmn.cpp:192
 msgid "rawctrl"
 msgstr "rawktrl"
 
-#: ../src/html/chm.cpp:333
+#: ../src/html/chm.cpp:330
 msgid "read error"
 msgstr "irakur akatsa"
 
-#: ../src/common/zipstrm.cpp:2085
+#: ../src/common/zipstrm.cpp:2155
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "zip jario irakurtzen (sarrera %s): crc okerra"
 
-#: ../src/common/zipstrm.cpp:2080
+#: ../src/common/zipstrm.cpp:2150
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "zip jario irakurtzen (sarrera %s): luzera okerra"
 
-#: ../src/msw/dde.cpp:1159
+#: ../src/msw/dde.cpp:1223
 msgid "reentrancy problem."
 msgstr "birsarrera arazoa."
 
-#: ../src/common/datetimefmt.cpp:1953
+#: ../src/common/datetimefmt.cpp:1976
 msgid "second"
 msgstr "bigarren"
 
-#: ../src/html/chm.cpp:337
+#: ../src/html/chm.cpp:334
 msgid "seek error"
 msgstr "bilatu akatsa"
 
-#: ../src/common/datetimefmt.cpp:1968
+#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#, fuzzy
+msgid "semibold"
+msgstr "lodia"
+
+#: ../src/common/datetimefmt.cpp:1991
 msgid "seventeenth"
 msgstr "hemezazpigarren"
 
-#: ../src/common/datetimefmt.cpp:1958
+#: ../src/common/datetimefmt.cpp:1981
 msgid "seventh"
 msgstr "zazpigarren"
 
-#: ../src/common/accelcmn.cpp:191
+#: ../src/common/accelcmn.cpp:190
 msgid "shift"
 msgstr "aldatu"
 
-#: ../src/common/appbase.cpp:773
+#: ../src/common/appbase.cpp:774
 msgid "show this help message"
 msgstr "erakutsi laguntza mezu hau"
 
-#: ../src/common/datetimefmt.cpp:1967
+#: ../src/common/datetimefmt.cpp:1990
 msgid "sixteenth"
 msgstr "hamaseigarren"
 
-#: ../src/common/datetimefmt.cpp:1957
+#: ../src/common/datetimefmt.cpp:1980
 msgid "sixth"
 msgstr "seigarren"
 
-#: ../src/common/appcmn.cpp:234
+#: ../src/common/appcmn.cpp:255
 msgid "specify display mode to use (e.g. 640x480-16)"
 msgstr "adierazi erabiltzeko erakus modua (adib. 640x480-16)"
 
-#: ../src/common/appcmn.cpp:220
+#: ../src/common/appcmn.cpp:241
 msgid "specify the theme to use"
 msgstr "adierazi erabiltzeko azalgaia"
 
-#: ../src/richtext/richtextbuffer.cpp:9340
+#: ../src/richtext/richtextbuffer.cpp:9337
 msgid "standard/circle"
 msgstr "estandarra/borobila"
 
-#: ../src/richtext/richtextbuffer.cpp:9341
+#: ../src/richtext/richtextbuffer.cpp:9338
 msgid "standard/circle-outline"
 msgstr "estandarra/borobil-ingurua"
 
-#: ../src/richtext/richtextbuffer.cpp:9343
+#: ../src/richtext/richtextbuffer.cpp:9340
 msgid "standard/diamond"
 msgstr "estandarra/diamantea"
 
-#: ../src/richtext/richtextbuffer.cpp:9342
+#: ../src/richtext/richtextbuffer.cpp:9339
 msgid "standard/square"
 msgstr "estandarra/laukia"
 
-#: ../src/richtext/richtextbuffer.cpp:9344
+#: ../src/richtext/richtextbuffer.cpp:9341
 msgid "standard/triangle"
 msgstr "estandarra/hirukia"
 
-#: ../src/common/zipstrm.cpp:1985
+#: ../src/common/zipstrm.cpp:2055
 msgid "stored file length not in Zip header"
 msgstr "bildutako agiri zabalera ez dago Zip idazburuan"
 
-#: ../src/common/cmdline.cpp:1488
+#: ../src/common/cmdline.cpp:1484
 msgid "str"
 msgstr "str"
 
-#: ../src/common/fontcmn.cpp:982
+#: ../src/common/fontcmn.cpp:1145
 msgid "strikethrough"
 msgstr "Marratuta"
 
-#: ../src/common/tarstrm.cpp:1003 ../src/common/tarstrm.cpp:1025
-#: ../src/common/tarstrm.cpp:1507 ../src/common/tarstrm.cpp:1529
+#: ../src/common/tarstrm.cpp:997 ../src/common/tarstrm.cpp:1019
+#: ../src/common/tarstrm.cpp:1501 ../src/common/tarstrm.cpp:1523
 msgid "tar entry not open"
 msgstr "tar sarrera ez dago irekita"
 
-#: ../src/common/datetimefmt.cpp:1961
+#: ../src/common/datetimefmt.cpp:1984
 msgid "tenth"
 msgstr "hamargarren"
 
-#: ../src/msw/dde.cpp:1123
+#: ../src/msw/dde.cpp:1187
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "eragiketaren erantzunak DDE_FBUSY bit zehaztea eragindu."
 
-#: ../src/common/datetimefmt.cpp:1954
+#: ../src/common/fontcmn.cpp:1154
+msgid "thin"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:1977
 msgid "third"
 msgstr "hirugarren"
 
-#: ../src/common/datetimefmt.cpp:1964
+#: ../src/common/datetimefmt.cpp:1987
 msgid "thirteenth"
 msgstr "hamahirugarren"
 
-#: ../src/common/datetimefmt.cpp:1758
+#: ../src/common/datetimefmt.cpp:1781
 msgid "today"
 msgstr "gaur"
 
-#: ../src/common/datetimefmt.cpp:1760
+#: ../src/common/datetimefmt.cpp:1783
 msgid "tomorrow"
 msgstr "atzo"
 
-#: ../src/common/fileconf.cpp:1944
+#: ../src/common/fileconf.cpp:1946
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "amaierako ezkerbarra '%s'-n baztertuta"
 
-#: ../src/gtk/aboutdlg.cpp:218
+#: ../src/gtk/aboutdlg.cpp:216
 msgid "translator-credits"
 msgstr "itzultzaileak"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1028
+#: ../src/generic/datavgen.cpp:1148
 msgid "true"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1963
+#: ../src/common/datetimefmt.cpp:1986
 msgid "twelfth"
 msgstr "hamabigarren"
 
-#: ../src/common/datetimefmt.cpp:1971
+#: ../src/common/datetimefmt.cpp:1994
 msgid "twentieth"
 msgstr "hogeigarren"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:486 ../src/generic/datavgen.cpp:1263
+#: ../src/common/datavcmn.cpp:2068 ../src/generic/datavgen.cpp:1386
 msgid "unchecked"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:802 ../src/common/fontcmn.cpp:978
+#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
 msgid "underlined"
 msgstr "azpimarratua"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:490
+#: ../src/common/datavcmn.cpp:2072
 #, fuzzy
 msgid "undetermined"
 msgstr "azpimarratua"
 
-#: ../src/common/fileconf.cpp:1979
+#: ../src/common/fileconf.cpp:1981
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "ustekabeko \" kokapena %d '%s'."
 
-#: ../src/common/tarstrm.cpp:1045
+#: ../src/common/tarstrm.cpp:1039
 msgid "unexpected end of file"
 msgstr "ustekabekoa agiri amaiera"
 
-#: ../src/generic/progdlgg.cpp:370 ../src/common/tarstrm.cpp:371
-#: ../src/common/tarstrm.cpp:394 ../src/common/tarstrm.cpp:425
+#: ../src/common/tarstrm.cpp:366 ../src/common/tarstrm.cpp:389
+#: ../src/common/tarstrm.cpp:420 ../src/generic/progdlgg.cpp:376
 msgid "unknown"
 msgstr "ezezaguna"
 
-#: ../src/msw/registry.cpp:150
+#: ../src/msw/registry.cpp:139
 #, fuzzy, c-format
 msgid "unknown (%lu)"
 msgstr "ezezaguna"
 
-#: ../src/common/xtixml.cpp:253
+#: ../src/common/xtixml.cpp:249
 #, c-format
 msgid "unknown class %s"
 msgstr "klase ezezaguna %s"
 
-#: ../src/common/regex.cpp:258 ../src/html/chm.cpp:351
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "konpresio akatsa"
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "deskonpresio akatsa"
+
+#: ../src/common/regex.cpp:255 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "akats ezezaguna"
 
-#: ../src/msw/dialup.cpp:471
+#: ../src/msw/dialup.cpp:465
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "akats ezezaguana (kode akatsa %08x)."
 
-#: ../src/common/fmapbase.cpp:834
+#: ../src/common/fmapbase.cpp:830
 #, c-format
 msgid "unknown-%d"
 msgstr "ezezaguna-%d"
 
-#: ../src/common/docview.cpp:509
+#: ../src/common/docview.cpp:502
 msgid "unnamed"
 msgstr "izengabea"
 
-#: ../src/common/docview.cpp:1624
+#: ../src/common/docview.cpp:1618
 #, c-format
 msgid "unnamed%d"
 msgstr "izengabea%d"
 
-#: ../src/common/zipstrm.cpp:1999 ../src/common/zipstrm.cpp:2319
+#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
 msgid "unsupported Zip compression method"
 msgstr "Zip konpresio metodo sostengatu gabea"
 
-#: ../src/common/translation.cpp:1892
+#: ../src/common/translation.cpp:1942
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "'%s' katalogoa '%s' hemendik erabiltzen."
 
-#: ../src/html/chm.cpp:335
+#: ../src/html/chm.cpp:332
 msgid "write error"
 msgstr "idaz akatsa"
 
-#: ../src/common/time.cpp:292
+#: ../src/gtk/glcanvas.cpp:187
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/common/time.cpp:285
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay hutsegitea."
 
@@ -8851,15 +9119,15 @@ msgstr "wxWidget-ek ezin du '%s' erakuspena ireki: irtetzen."
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidget-ek ezin du erakuspena ireki. Irtetzen."
 
-#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:431
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/common/datetimefmt.cpp:1759
+#: ../src/common/datetimefmt.cpp:1782
 msgid "yesterday"
 msgstr "atzo"
 
-#: ../src/common/zstream.cpp:251 ../src/common/zstream.cpp:426
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
 #, c-format
 msgid "zlib error %d"
 msgstr "zlib akatsa %d"
@@ -8868,6 +9136,76 @@ msgstr "zlib akatsa %d"
 #: ../src/richtext/richtextbulletspage.cpp:288
 msgid "~"
 msgstr "~"
+
+#~ msgid "&Save as"
+#~ msgstr "&Gorde honela"
+
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' ez dago hizki baliogarriz osatuta bakarrik"
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' zenbakizkoa izan behar du."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' ASCII hizkiak bakarrik izan behar ditu."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' alfabetoko hizkiak bakarrik izan behar ditu."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' alfabetoko edo zenbakizko hizkiak bakarrik izan behar ditu."
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' zenbakiak bakarrik izan behar ditu."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "Ezin da %s klasearen leihoa sortu"
+
+#, fuzzy
+#~ msgid "Could not initalize libnotify."
+#~ msgstr "Ezin da lerrokapena ezarri."
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "Ezinezkoa leiho gainjarria sortzea"
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "Ezinezkoa hastea hitzingurua gainjarritako leihoan"
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "Hutsegitea \"%s\" agiria Unicodera bihurtzerakoan."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "Hutsegitea idazki agintean idazkia ezartzerakoan."
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr "GTK+ komando lerro aukera baliogabea, erabili \"%s --help\""
+
+#~ msgid "No unused colour in image."
+#~ msgstr "Ez dago erabiligabeko margorik irudian."
+
+#~ msgid "Not available"
+#~ msgstr "Eskuraezina"
+
+#~ msgid "Replace selection"
+#~ msgstr "Ordeztu hautapena"
+
+#~ msgid "Save as"
+#~ msgstr "Gorde honela"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Estilo Antolatzailea"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "Hurrengo GTK+ estandar aukerak ere sostengatuak dira:\n"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "Ezin duzu Garbitu hasita ez dagoen gainjarpena "
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "Ezin duzu Hasi bi aldiko gainjarpenean"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "tokiko '%s' ezin da ezarri."
 
 #~ msgid "Adding flavor TEXT failed"
 #~ msgstr "flavor TEXT gehitze hutsegitea"
@@ -8885,9 +9223,6 @@ msgstr "~"
 
 #~ msgid "Column could not be added."
 #~ msgstr "Zutabea ezin da gehitu."
-
-#~ msgid "Column description could not be initialized."
-#~ msgstr "Zutabe azalpena ezin da abiarazi."
 
 #~ msgid "Column index not found."
 #~ msgstr "Zutabe aurkibidea ez da aurkitu."
@@ -9467,9 +9802,6 @@ msgstr "~"
 
 #~ msgid "Directory '%s' doesn't exist!"
 #~ msgstr "'%s' zuzenbidea ez dago!"
-
-#~ msgid "File %s does not exist."
-#~ msgstr "%s agiria ez dago."
 
 #~ msgid "Mode %ix%i-%i not available."
 #~ msgstr "%ix%i-%i modua ez da eskuragarria."

--- a/locale/fa_IR.po
+++ b/locale/fa_IR.po
@@ -4,18 +4,18 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-21 14:25+0200\n"
+"POT-Creation-Date: 2020-10-18 23:11+0300\n"
 "PO-Revision-Date: 2020-07-17 12:42+0430\n"
+"Last-Translator: \n"
 "Language-Team: Ali Asadi <ali.asadi@wxwidgets.ir>\n"
+"Language: fa_IR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n==0 || n==1);\n"
 "X-Generator: Poedit 2.2\n"
-"Last-Translator: \n"
-"Language: fa_IR\n"
 
-#: ../src/common/debugrpt.cpp:586
+#: ../src/common/debugrpt.cpp:587
 msgid ""
 "\n"
 "Please send this report to the program maintainer, thank you!\n"
@@ -23,8 +23,8 @@ msgstr ""
 "\n"
 "لطفا این گزارش را به نگهدار برنامه ارسال کنید ، متشکرم!\n"
 
-#: ../src/richtext/richtextstyledlg.cpp:210
-#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:206
+#: ../src/richtext/richtextstyledlg.cpp:218
 msgid " "
 msgstr ""
 
@@ -32,70 +32,96 @@ msgstr ""
 msgid "              Thank you and we're sorry for the inconvenience!\n"
 msgstr " با تشکر از شما و ما برای ناراحتی پوزش می طلبیم!\n"
 
-#: ../src/common/prntbase.cpp:573
+#: ../src/common/prntbase.cpp:568
 #, c-format
 msgid " (copy %d of %d)"
 msgstr ""
 
-#: ../src/common/log.cpp:421
+#: ../src/common/log.cpp:440
 #, c-format
 msgid " (error %ld: %s)"
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:72
+#: ../src/common/imagtiff.cpp:69
 #, c-format
 msgid " (in module \"%s\")"
 msgstr ""
 
-#: ../src/osx/core/secretstore.cpp:138
-msgid " (while overwriting an existing item)"
-msgstr " (درحال رونویسی  یک مورد موجود)"
-
-#: ../src/common/docview.cpp:1642
+#: ../src/common/docview.cpp:1636
 msgid " - "
 msgstr ""
 
-#: ../src/richtext/richtextprint.cpp:593 ../src/html/htmprint.cpp:714
+#: ../src/html/htmprint.cpp:712 ../src/richtext/richtextprint.cpp:589
 msgid " Preview"
 msgstr " پیش نمایش"
 
-#: ../src/common/fontcmn.cpp:824
+#: ../src/common/fontcmn.cpp:973
 msgid " bold"
 msgstr " پررنگ"
 
-#: ../src/common/fontcmn.cpp:840
+#: ../src/common/fontcmn.cpp:977
+#, fuzzy
+msgid " extra bold"
+msgstr " پررنگ"
+
+#: ../src/common/fontcmn.cpp:985
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:957
+#, fuzzy
+msgid " extra light"
+msgstr " سبک"
+
+#: ../src/common/fontcmn.cpp:981
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1001
 msgid " italic"
 msgstr " مایل"
 
-#: ../src/common/fontcmn.cpp:820
+#: ../src/common/fontcmn.cpp:961
 msgid " light"
 msgstr " سبک"
 
-#: ../src/common/fontcmn.cpp:807
+#: ../src/common/fontcmn.cpp:965
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:969
+#, fuzzy
+msgid " semi bold"
+msgstr " پررنگ"
+
+#: ../src/common/fontcmn.cpp:940
 msgid " strikethrough"
 msgstr ""
 
-#: ../src/common/paper.cpp:117
+#: ../src/common/fontcmn.cpp:953
+msgid " thin"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
 msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
 msgstr "#10 Envelope, 4 1/8 x 9 1/2 in"
 
-#: ../src/common/paper.cpp:118
+#: ../src/common/paper.cpp:115
 msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
 msgstr "#11 Envelope, 4 1/2 x 10 3/8 in"
 
-#: ../src/common/paper.cpp:119
+#: ../src/common/paper.cpp:116
 msgid "#12 Envelope, 4 3/4 x 11 in"
 msgstr "#12 Envelope, 4 3/4 x 11 in"
 
-#: ../src/common/paper.cpp:120
+#: ../src/common/paper.cpp:117
 msgid "#14 Envelope, 5 x 11 1/2 in"
 msgstr "#14 Envelope, 5 x 11 1/2 in"
 
-#: ../src/common/paper.cpp:116
+#: ../src/common/paper.cpp:113
 msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
 msgstr "#9 Envelope, 3 7/8 x 8 7/8 in"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:341
 #: ../src/richtext/richtextsizepage.cpp:340
 #: ../src/richtext/richtextsizepage.cpp:374
 #: ../src/richtext/richtextsizepage.cpp:401
@@ -106,81 +132,82 @@ msgstr "#9 Envelope, 3 7/8 x 8 7/8 in"
 #: ../src/richtext/richtextsizepage.cpp:591
 #: ../src/richtext/richtextsizepage.cpp:626
 #: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextbackgroundpage.cpp:341
 msgid "%"
 msgstr "%"
 
-#: ../src/html/helpwnd.cpp:1031
+#: ../src/html/helpwnd.cpp:1029
 #, c-format
 msgid "%d of %lu"
 msgstr "%d of %lu"
 
-#: ../src/html/helpwnd.cpp:1678
+#: ../src/html/helpwnd.cpp:1676
 #, c-format
 msgid "%i of %u"
 msgstr "%i of %u"
 
-#: ../src/generic/filectrlg.cpp:279
+#: ../src/generic/filectrlg.cpp:275
 #, c-format
 msgid "%ld byte"
 msgid_plural "%ld bytes"
 msgstr[0] "%ld byte"
 msgstr[1] "%ld bytes"
 
-#: ../src/html/helpwnd.cpp:1033
+#: ../src/html/helpwnd.cpp:1031
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu of %lu"
 
-#: ../src/generic/datavgen.cpp:6028
+#: ../src/generic/datavgen.cpp:6833
 #, c-format
 msgid "%s (%d items)"
 msgstr "%s (%d items)"
 
-#: ../src/common/cmdline.cpp:1221
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (or %s)"
 
-#: ../src/generic/logg.cpp:224
+#: ../src/generic/logg.cpp:221
 #, c-format
 msgid "%s Error"
 msgstr "%s Error"
 
-#: ../src/generic/logg.cpp:236
+#: ../src/generic/logg.cpp:233
 #, c-format
 msgid "%s Information"
 msgstr "%s Information"
 
-#: ../src/generic/preferencesg.cpp:113
+#: ../src/generic/preferencesg.cpp:110
 #, c-format
 msgid "%s Preferences"
 msgstr "%s Preferences"
 
-#: ../src/generic/logg.cpp:228
+#: ../src/generic/logg.cpp:225
 #, c-format
 msgid "%s Warning"
 msgstr "%s Warning"
 
-#: ../src/common/tarstrm.cpp:1319
+#: ../src/common/tarstrm.cpp:1313
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s did not fit the tar header for entry '%s'"
 
-#: ../src/common/fldlgcmn.cpp:124
+#: ../src/common/fldlgcmn.cpp:121
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s files (%s)|%s"
 
-#: ../src/html/helpwnd.cpp:1716
+#: ../src/html/helpwnd.cpp:1714
 #, c-format
 msgid "%u of %u"
 msgstr "%u of %u"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "&About"
 msgstr "&در باره"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "&Actual Size"
 msgstr "ا&ندازه واقعی"
 
@@ -188,28 +215,28 @@ msgstr "ا&ندازه واقعی"
 msgid "&After a paragraph:"
 msgstr "&بعد از یک پاراگراف:"
 
-#: ../src/richtext/richtextindentspage.cpp:128
 #: ../src/richtext/richtextliststylepage.cpp:319
+#: ../src/richtext/richtextindentspage.cpp:128
 msgid "&Alignment"
 msgstr "&هم ترازی"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "&Apply"
 msgstr "اع&مال"
 
-#: ../src/richtext/richtextstyledlg.cpp:251
+#: ../src/richtext/richtextstyledlg.cpp:247
 msgid "&Apply Style"
 msgstr "اعمال سبک"
 
-#: ../src/msw/mdi.cpp:179
+#: ../src/msw/mdi.cpp:174
 msgid "&Arrange Icons"
 msgstr "مرتب کردن نشانه ها"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "&Ascending"
 msgstr "صعودی"
 
-#: ../src/common/stockitem.cpp:142
+#: ../src/common/stockitem.cpp:139
 msgid "&Back"
 msgstr "&عقب"
 
@@ -229,24 +256,24 @@ msgstr ""
 msgid "&Blur distance:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:143
+#: ../src/common/stockitem.cpp:140
 msgid "&Bold"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141
 msgid "&Bottom"
 msgstr ""
 
+#: ../src/richtext/richtextsizepage.cpp:637
+#: ../src/richtext/richtextsizepage.cpp:644
 #: ../src/richtext/richtextborderspage.cpp:345
 #: ../src/richtext/richtextborderspage.cpp:513
 #: ../src/richtext/richtextmarginspage.cpp:259
 #: ../src/richtext/richtextmarginspage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:637
-#: ../src/richtext/richtextsizepage.cpp:644
 msgid "&Bottom:"
 msgstr ""
 
-#: ../include/wx/richtext/richtextbuffer.h:3866
+#: ../include/wx/richtext/richtextbuffer.h:3861
 msgid "&Box"
 msgstr ""
 
@@ -255,38 +282,38 @@ msgstr ""
 msgid "&Bullet style:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "&CD-Rom"
 msgstr ""
 
-#: ../src/generic/wizard.cpp:434 ../src/generic/fontdlgg.cpp:470
-#: ../src/generic/fontdlgg.cpp:489 ../src/osx/carbon/fontdlg.cpp:402
-#: ../src/common/dlgcmn.cpp:279 ../src/common/stockitem.cpp:145
+#: ../src/osx/carbon/fontdlg.cpp:399 ../src/common/stockitem.cpp:142
+#: ../src/generic/wizard.cpp:433 ../src/generic/fontdlgg.cpp:466
+#: ../src/generic/fontdlgg.cpp:485 ../src/osx/cocoa/button.mm:200
 msgid "&Cancel"
 msgstr ""
 
-#: ../src/msw/mdi.cpp:175
+#: ../src/msw/mdi.cpp:170
 msgid "&Cascade"
 msgstr ""
 
-#: ../include/wx/richtext/richtextbuffer.h:5960
+#: ../include/wx/richtext/richtextbuffer.h:5955
 msgid "&Cell"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:439
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "&Character code:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:147
+#: ../src/common/stockitem.cpp:144
 msgid "&Clear"
 msgstr ""
 
-#: ../src/generic/logg.cpp:516 ../src/common/stockitem.cpp:148
-#: ../src/common/prntbase.cpp:1600 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/stockitem.cpp:145 ../src/common/prntbase.cpp:1625
+#: ../src/univ/themes/win32.cpp:3753 ../src/generic/logg.cpp:513
 msgid "&Close"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "&Color"
 msgstr ""
 
@@ -294,20 +321,20 @@ msgstr ""
 msgid "&Colour:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "&Convert"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:333 ../src/osx/textctrl_osx.cpp:577
-#: ../src/common/stockitem.cpp:150 ../src/msw/textctrl.cpp:2508
+#: ../src/osx/textctrl_osx.cpp:595 ../src/common/stockitem.cpp:147
+#: ../src/msw/textctrl.cpp:2773 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr ""
 
-#: ../src/generic/hyperlinkg.cpp:156
+#: ../src/generic/hyperlinkg.cpp:153
 msgid "&Copy URL"
 msgstr ""
 
-#: ../src/common/headerctrlcmn.cpp:306
+#: ../src/common/headerctrlcmn.cpp:304
 msgid "&Customize..."
 msgstr ""
 
@@ -315,53 +342,53 @@ msgstr ""
 msgid "&Debug report preview:"
 msgstr ""
 
-#: ../src/richtext/richtexttabspage.cpp:138
-#: ../src/richtext/richtextctrl.cpp:335 ../src/osx/textctrl_osx.cpp:579
-#: ../src/common/stockitem.cpp:152 ../src/msw/textctrl.cpp:2510
+#: ../src/osx/textctrl_osx.cpp:597 ../src/common/stockitem.cpp:149
+#: ../src/msw/textctrl.cpp:2775 ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtextctrl.cpp:334
 msgid "&Delete"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:269
+#: ../src/richtext/richtextstyledlg.cpp:265
 msgid "&Delete Style..."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "&Descending"
 msgstr ""
 
-#: ../src/generic/logg.cpp:682
+#: ../src/generic/logg.cpp:679
 msgid "&Details"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:153
+#: ../src/common/stockitem.cpp:150
 msgid "&Down"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "&Edit"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:263
+#: ../src/richtext/richtextstyledlg.cpp:259
 msgid "&Edit Style..."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:155
+#: ../src/common/stockitem.cpp:152
 msgid "&Execute"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/common/stockitem.cpp:154
 msgid "&File"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:158
-msgid "&Find"
+#: ../src/common/stockitem.cpp:155
+msgid "&Find..."
 msgstr ""
 
-#: ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:430
 msgid "&Finish"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:156
 msgid "&First"
 msgstr ""
 
@@ -369,15 +396,15 @@ msgstr ""
 msgid "&Floating mode:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "&Floppy"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:194
+#: ../src/common/stockitem.cpp:191
 msgid "&Font"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:371
+#: ../src/generic/fontdlgg.cpp:367
 msgid "&Font family:"
 msgstr ""
 
@@ -385,20 +412,20 @@ msgstr ""
 msgid "&Font for Level..."
 msgstr ""
 
+#: ../src/richtext/richtextsymboldlg.cpp:397
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:400
 msgid "&Font:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "&Forward"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:451
+#: ../src/richtext/richtextsymboldlg.cpp:448
 msgid "&From:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "&Harddisk"
 msgstr ""
 
@@ -407,9 +434,9 @@ msgstr ""
 msgid "&Height:"
 msgstr ""
 
-#: ../src/generic/wizard.cpp:441 ../src/richtext/richtextstyledlg.cpp:303
-#: ../src/richtext/richtextsymboldlg.cpp:479 ../src/osx/menu_osx.cpp:734
-#: ../src/common/stockitem.cpp:163
+#: ../src/common/stockitem.cpp:160 ../src/generic/wizard.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextstyledlg.cpp:299 ../src/osx/cocoa/menu.mm:226
 msgid "&Help"
 msgstr ""
 
@@ -417,7 +444,7 @@ msgstr ""
 msgid "&Hide details"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:164
+#: ../src/common/stockitem.cpp:161
 msgid "&Home"
 msgstr ""
 
@@ -425,54 +452,54 @@ msgstr ""
 msgid "&Horizontal offset:"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:184
 #: ../src/richtext/richtextliststylepage.cpp:372
+#: ../src/richtext/richtextindentspage.cpp:184
 msgid "&Indentation (tenths of a mm)"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:167
 #: ../src/richtext/richtextliststylepage.cpp:356
+#: ../src/richtext/richtextindentspage.cpp:167
 msgid "&Indeterminate"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:166
+#: ../src/common/stockitem.cpp:163
 msgid "&Index"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "&Info"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:168
+#: ../src/common/stockitem.cpp:165
 msgid "&Italic"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "&Jump to"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:153
 #: ../src/richtext/richtextliststylepage.cpp:342
+#: ../src/richtext/richtextindentspage.cpp:153
 msgid "&Justified"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "&Last"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:139
 #: ../src/richtext/richtextliststylepage.cpp:328
+#: ../src/richtext/richtextindentspage.cpp:139
 msgid "&Left"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:195
+#: ../src/richtext/richtextsizepage.cpp:532
+#: ../src/richtext/richtextsizepage.cpp:539
 #: ../src/richtext/richtextborderspage.cpp:243
 #: ../src/richtext/richtextborderspage.cpp:411
 #: ../src/richtext/richtextliststylepage.cpp:381
+#: ../src/richtext/richtextindentspage.cpp:195
 #: ../src/richtext/richtextmarginspage.cpp:186
 #: ../src/richtext/richtextmarginspage.cpp:300
-#: ../src/richtext/richtextsizepage.cpp:532
-#: ../src/richtext/richtextsizepage.cpp:539
 msgid "&Left:"
 msgstr ""
 
@@ -480,11 +507,11 @@ msgstr ""
 msgid "&List level:"
 msgstr ""
 
-#: ../src/generic/logg.cpp:517
+#: ../src/generic/logg.cpp:514
 msgid "&Log"
 msgstr ""
 
-#: ../src/univ/themes/win32.cpp:3748
+#: ../src/univ/themes/win32.cpp:3745
 msgid "&Move"
 msgstr ""
 
@@ -492,19 +519,19 @@ msgstr ""
 msgid "&Move the object to:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "&Network"
 msgstr ""
 
-#: ../src/richtext/richtexttabspage.cpp:132 ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173 ../src/richtext/richtexttabspage.cpp:132
 msgid "&New"
 msgstr ""
 
-#: ../src/aui/tabmdi.cpp:111 ../src/generic/mdig.cpp:100 ../src/msw/mdi.cpp:180
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
 msgid "&Next"
 msgstr ""
 
-#: ../src/generic/wizard.cpp:432 ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:429
 msgid "&Next >"
 msgstr ""
 
@@ -512,7 +539,7 @@ msgstr ""
 msgid "&Next Paragraph"
 msgstr ""
 
-#: ../src/generic/tipdlg.cpp:240
+#: ../src/generic/tipdlg.cpp:237
 msgid "&Next Tip"
 msgstr ""
 
@@ -520,11 +547,11 @@ msgstr ""
 msgid "&Next style:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:177 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:174 ../src/msw/msgdlg.cpp:435
 msgid "&No"
 msgstr ""
 
-#: ../src/generic/dbgrptg.cpp:356
+#: ../src/generic/dbgrptg.cpp:360
 msgid "&Notes:"
 msgstr ""
 
@@ -532,12 +559,12 @@ msgstr ""
 msgid "&Number:"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:475 ../src/generic/fontdlgg.cpp:482
-#: ../src/osx/carbon/fontdlg.cpp:408 ../src/common/stockitem.cpp:178
+#: ../src/osx/carbon/fontdlg.cpp:405 ../src/common/stockitem.cpp:175
+#: ../src/generic/fontdlgg.cpp:471 ../src/generic/fontdlgg.cpp:478
 msgid "&OK"
 msgstr ""
 
-#: ../src/generic/dbgrptg.cpp:342 ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176 ../src/generic/dbgrptg.cpp:342
 msgid "&Open..."
 msgstr ""
 
@@ -549,16 +576,16 @@ msgstr ""
 msgid "&Page Break"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:334 ../src/osx/textctrl_osx.cpp:578
-#: ../src/common/stockitem.cpp:180 ../src/msw/textctrl.cpp:2509
+#: ../src/osx/textctrl_osx.cpp:596 ../src/common/stockitem.cpp:177
+#: ../src/msw/textctrl.cpp:2774 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr ""
 
-#: ../include/wx/richtext/richtextbuffer.h:5010
+#: ../include/wx/richtext/richtextbuffer.h:5005
 msgid "&Picture"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:419
 msgid "&Point size:"
 msgstr ""
 
@@ -570,11 +597,11 @@ msgstr ""
 msgid "&Position mode:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178
 msgid "&Preferences"
 msgstr ""
 
-#: ../src/aui/tabmdi.cpp:112 ../src/generic/mdig.cpp:101 ../src/msw/mdi.cpp:181
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
 msgid "&Previous"
 msgstr ""
 
@@ -582,78 +609,74 @@ msgstr ""
 msgid "&Previous Paragraph"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "&Print..."
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:339 ../src/richtext/richtextctrl.cpp:5514
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtextctrl.cpp:338
+#: ../src/richtext/richtextctrl.cpp:5512
 msgid "&Properties"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "&Quit"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:330 ../src/osx/textctrl_osx.cpp:574
-#: ../src/common/stockitem.cpp:185 ../src/common/cmdproc.cpp:293
-#: ../src/common/cmdproc.cpp:300 ../src/msw/textctrl.cpp:2505
+#: ../src/osx/textctrl_osx.cpp:592 ../src/common/stockitem.cpp:182
+#: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
+#: ../src/msw/textctrl.cpp:2770 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr ""
 
-#: ../src/common/cmdproc.cpp:289 ../src/common/cmdproc.cpp:309
+#: ../src/common/cmdproc.cpp:282 ../src/common/cmdproc.cpp:302
 msgid "&Redo "
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:257
+#: ../src/richtext/richtextstyledlg.cpp:253
 msgid "&Rename Style..."
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:179
+#: ../src/generic/fdrepdlg.cpp:176
 msgid "&Replace"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:287
+#: ../src/richtext/richtextstyledlg.cpp:283
 msgid "&Restart numbering"
 msgstr ""
 
-#: ../src/univ/themes/win32.cpp:3747
+#: ../src/univ/themes/win32.cpp:3744
 msgid "&Restore"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:146
 #: ../src/richtext/richtextliststylepage.cpp:335
+#: ../src/richtext/richtextindentspage.cpp:146
 msgid "&Right"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:213
+#: ../src/richtext/richtextsizepage.cpp:602
+#: ../src/richtext/richtextsizepage.cpp:609
 #: ../src/richtext/richtextborderspage.cpp:277
 #: ../src/richtext/richtextborderspage.cpp:445
 #: ../src/richtext/richtextliststylepage.cpp:399
+#: ../src/richtext/richtextindentspage.cpp:213
 #: ../src/richtext/richtextmarginspage.cpp:211
 #: ../src/richtext/richtextmarginspage.cpp:325
-#: ../src/richtext/richtextsizepage.cpp:602
-#: ../src/richtext/richtextsizepage.cpp:609
 msgid "&Right:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:190
+#: ../src/common/stockitem.cpp:187
 msgid "&Save"
-msgstr ""
-
-#: ../src/common/stockitem.cpp:191
-msgid "&Save as"
 msgstr ""
 
 #: ../include/wx/richmsgdlg.h:29
 msgid "&See details"
 msgstr ""
 
-#: ../src/generic/tipdlg.cpp:236
+#: ../src/generic/tipdlg.cpp:233
 msgid "&Show tips at startup"
 msgstr ""
 
-#: ../src/univ/themes/win32.cpp:3750
+#: ../src/univ/themes/win32.cpp:3747
 msgid "&Size"
 msgstr ""
 
@@ -661,36 +684,36 @@ msgstr ""
 msgid "&Size:"
 msgstr ""
 
-#: ../src/generic/progdlgg.cpp:252
+#: ../src/generic/progdlgg.cpp:249
 msgid "&Skip"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:242
 #: ../src/richtext/richtextliststylepage.cpp:417
+#: ../src/richtext/richtextindentspage.cpp:242
 msgid "&Spacing (tenths of a mm)"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "&Spell Check"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "&Stop"
 msgstr ""
 
-#: ../src/richtext/richtextfontpage.cpp:275 ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196 ../src/richtext/richtextfontpage.cpp:275
 msgid "&Strikethrough"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:382 ../src/richtext/richtextstylepage.cpp:106
+#: ../src/generic/fontdlgg.cpp:378 ../src/richtext/richtextstylepage.cpp:106
 msgid "&Style:"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:194
 msgid "&Styles:"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:413
+#: ../src/richtext/richtextsymboldlg.cpp:410
 msgid "&Subset:"
 msgstr ""
 
@@ -704,24 +727,24 @@ msgstr ""
 msgid "&Synchronize values"
 msgstr ""
 
-#: ../include/wx/richtext/richtextbuffer.h:6069
+#: ../include/wx/richtext/richtextbuffer.h:6064
 msgid "&Table"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197
 msgid "&Top"
 msgstr ""
 
+#: ../src/richtext/richtextsizepage.cpp:567
+#: ../src/richtext/richtextsizepage.cpp:574
 #: ../src/richtext/richtextborderspage.cpp:311
 #: ../src/richtext/richtextborderspage.cpp:479
 #: ../src/richtext/richtextmarginspage.cpp:234
 #: ../src/richtext/richtextmarginspage.cpp:348
-#: ../src/richtext/richtextsizepage.cpp:567
-#: ../src/richtext/richtextsizepage.cpp:574
 msgid "&Top:"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:444 ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199 ../src/generic/fontdlgg.cpp:441
 msgid "&Underline"
 msgstr ""
 
@@ -729,21 +752,21 @@ msgstr ""
 msgid "&Underlining:"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:329 ../src/osx/textctrl_osx.cpp:573
-#: ../src/common/stockitem.cpp:203 ../src/common/cmdproc.cpp:271
-#: ../src/msw/textctrl.cpp:2504
+#: ../src/osx/textctrl_osx.cpp:591 ../src/common/stockitem.cpp:200
+#: ../src/common/cmdproc.cpp:264 ../src/msw/textctrl.cpp:2769
+#: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr ""
 
-#: ../src/common/cmdproc.cpp:265
+#: ../src/common/cmdproc.cpp:258
 msgid "&Undo "
 msgstr ""
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "&Unindent"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:205
+#: ../src/common/stockitem.cpp:202
 msgid "&Up"
 msgstr ""
 
@@ -759,7 +782,7 @@ msgstr ""
 msgid "&View..."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:393
+#: ../src/generic/fontdlgg.cpp:389
 msgid "&Weight:"
 msgstr ""
 
@@ -768,80 +791,50 @@ msgstr ""
 msgid "&Width:"
 msgstr ""
 
-#: ../src/aui/tabmdi.cpp:311 ../src/aui/tabmdi.cpp:327
-#: ../src/aui/tabmdi.cpp:329 ../src/generic/mdig.cpp:294
-#: ../src/generic/mdig.cpp:310 ../src/generic/mdig.cpp:314
-#: ../src/msw/mdi.cpp:78
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
 msgid "&Window"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:206 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:203 ../src/msw/msgdlg.cpp:435
 msgid "&Yes"
 msgstr ""
 
-#: ../src/common/valtext.cpp:256
+#: ../src/common/valtext.cpp:197
 #, c-format
-msgid "'%s' contains illegal characters"
+msgid "'%s' contains invalid character(s)"
 msgstr ""
 
-#: ../src/common/valtext.cpp:254
-#, c-format
-msgid "'%s' doesn't consist only of valid characters"
-msgstr ""
-
-#: ../src/common/config.cpp:519 ../src/msw/regconf.cpp:258
+#: ../src/common/config.cpp:515 ../src/msw/regconf.cpp:255
 #, c-format
 msgid "'%s' has extra '..', ignored."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1113 ../src/common/cmdline.cpp:1131
+#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr ""
 
-#: ../src/common/translation.cpp:1100
+#: ../src/common/translation.cpp:1142
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr ""
 
-#: ../src/common/valtext.cpp:165
+#: ../src/common/valtext.cpp:188
 #, c-format
 msgid "'%s' is not one of the valid strings"
 msgstr ""
 
-#: ../src/common/valtext.cpp:167
+#: ../src/common/valtext.cpp:186
 #, c-format
 msgid "'%s' is one of the invalid strings"
 msgstr ""
 
-#: ../src/common/textbuf.cpp:237
+#: ../src/common/textbuf.cpp:233
 #, c-format
 msgid "'%s' is probably a binary buffer."
-msgstr ""
-
-#: ../src/common/valtext.cpp:252
-#, c-format
-msgid "'%s' should be numeric."
-msgstr ""
-
-#: ../src/common/valtext.cpp:244
-#, c-format
-msgid "'%s' should only contain ASCII characters."
-msgstr ""
-
-#: ../src/common/valtext.cpp:246
-#, c-format
-msgid "'%s' should only contain alphabetic characters."
-msgstr ""
-
-#: ../src/common/valtext.cpp:248
-#, c-format
-msgid "'%s' should only contain alphabetic or numeric characters."
-msgstr ""
-
-#: ../src/common/valtext.cpp:250
-#, c-format
-msgid "'%s' should only contain digits."
 msgstr ""
 
 #: ../src/richtext/richtextliststylepage.cpp:229
@@ -849,7 +842,7 @@ msgstr ""
 msgid "(*)"
 msgstr "(*)"
 
-#: ../src/html/helpwnd.cpp:963
+#: ../src/html/helpwnd.cpp:961
 msgid "(Help)"
 msgstr "(راهنما)"
 
@@ -858,27 +851,32 @@ msgstr "(راهنما)"
 msgid "(None)"
 msgstr "(هیچ)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:504
+#: ../src/richtext/richtextsymboldlg.cpp:503
 msgid "(Normal text)"
 msgstr "(متن عادی)"
 
-#: ../src/html/helpwnd.cpp:419 ../src/html/helpwnd.cpp:1106
-#: ../src/html/helpwnd.cpp:1742
+#: ../src/html/helpwnd.cpp:417 ../src/html/helpwnd.cpp:1104
+#: ../src/html/helpwnd.cpp:1740
 msgid "(bookmarks)"
 msgstr "(نشانک)"
 
+#: ../src/msw/dlmsw.cpp:167
+#, c-format
+msgid "(error %d: %s)"
+msgstr ""
+
+#: ../src/richtext/richtextformatdlg.cpp:876
+#: ../src/richtext/richtextliststylepage.cpp:448
+#: ../src/richtext/richtextliststylepage.cpp:460
+#: ../src/richtext/richtextliststylepage.cpp:461
 #: ../src/richtext/richtextindentspage.cpp:274
 #: ../src/richtext/richtextindentspage.cpp:286
 #: ../src/richtext/richtextindentspage.cpp:287
 #: ../src/richtext/richtextindentspage.cpp:311
 #: ../src/richtext/richtextindentspage.cpp:326
-#: ../src/richtext/richtextformatdlg.cpp:884
 #: ../src/richtext/richtextfontpage.cpp:349
 #: ../src/richtext/richtextfontpage.cpp:353
 #: ../src/richtext/richtextfontpage.cpp:357
-#: ../src/richtext/richtextliststylepage.cpp:448
-#: ../src/richtext/richtextliststylepage.cpp:460
-#: ../src/richtext/richtextliststylepage.cpp:461
 msgid "(none)"
 msgstr "(هیچ)"
 
@@ -897,7 +895,7 @@ msgstr ""
 msgid "+"
 msgstr ""
 
-#: ../src/msw/utils.cpp:1152
+#: ../src/msw/utils.cpp:1143
 msgid ", 64-bit edition"
 msgstr ""
 
@@ -906,163 +904,163 @@ msgstr ""
 msgid "-"
 msgstr "-"
 
-#: ../src/generic/filepickerg.cpp:66
+#: ../src/generic/filepickerg.cpp:63
 msgid "..."
 msgstr "..."
 
-#: ../src/richtext/richtextindentspage.cpp:276
 #: ../src/richtext/richtextliststylepage.cpp:450
+#: ../src/richtext/richtextindentspage.cpp:276
 msgid "1.1"
 msgstr "1.1"
 
-#: ../src/richtext/richtextindentspage.cpp:277
 #: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextindentspage.cpp:277
 msgid "1.2"
 msgstr "1.2"
 
-#: ../src/richtext/richtextindentspage.cpp:278
 #: ../src/richtext/richtextliststylepage.cpp:452
+#: ../src/richtext/richtextindentspage.cpp:278
 msgid "1.3"
 msgstr "1.3"
 
-#: ../src/richtext/richtextindentspage.cpp:279
 #: ../src/richtext/richtextliststylepage.cpp:453
+#: ../src/richtext/richtextindentspage.cpp:279
 msgid "1.4"
 msgstr "1.4"
 
-#: ../src/richtext/richtextindentspage.cpp:280
 #: ../src/richtext/richtextliststylepage.cpp:454
+#: ../src/richtext/richtextindentspage.cpp:280
 msgid "1.5"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:281
 #: ../src/richtext/richtextliststylepage.cpp:455
+#: ../src/richtext/richtextindentspage.cpp:281
 msgid "1.6"
 msgstr "1.6"
 
-#: ../src/richtext/richtextindentspage.cpp:282
 #: ../src/richtext/richtextliststylepage.cpp:456
+#: ../src/richtext/richtextindentspage.cpp:282
 msgid "1.7"
 msgstr "1.7"
 
-#: ../src/richtext/richtextindentspage.cpp:283
 #: ../src/richtext/richtextliststylepage.cpp:457
+#: ../src/richtext/richtextindentspage.cpp:283
 msgid "1.8"
 msgstr "1.8"
 
-#: ../src/richtext/richtextindentspage.cpp:284
 #: ../src/richtext/richtextliststylepage.cpp:458
+#: ../src/richtext/richtextindentspage.cpp:284
 msgid "1.9"
 msgstr "1.9"
 
-#: ../src/common/paper.cpp:140
+#: ../src/common/paper.cpp:137
 msgid "10 x 11 in"
 msgstr "10 x 11 in"
 
-#: ../src/common/paper.cpp:113
+#: ../src/common/paper.cpp:110
 msgid "10 x 14 in"
 msgstr "10 x 14 in"
 
-#: ../src/common/paper.cpp:114
+#: ../src/common/paper.cpp:111
 msgid "11 x 17 in"
 msgstr "11 x 17 in"
 
-#: ../src/common/paper.cpp:184
+#: ../src/common/paper.cpp:181
 msgid "12 x 11 in"
 msgstr "12 x 11 in"
 
-#: ../src/common/paper.cpp:141
+#: ../src/common/paper.cpp:138
 msgid "15 x 11 in"
 msgstr "15 x 11 in"
 
-#: ../src/richtext/richtextindentspage.cpp:285
 #: ../src/richtext/richtextliststylepage.cpp:459
+#: ../src/richtext/richtextindentspage.cpp:285
 msgid "2"
 msgstr "2"
 
-#: ../src/common/paper.cpp:132
+#: ../src/common/paper.cpp:129
 msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
 msgstr "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
 
-#: ../src/common/paper.cpp:139
+#: ../src/common/paper.cpp:136
 msgid "9 x 11 in"
 msgstr "9 x 11 in"
 
-#: ../src/html/htmprint.cpp:431
+#: ../src/html/htmprint.cpp:443
 msgid ": file does not exist!"
 msgstr ": فایل موجود نیست!"
 
-#: ../src/common/fontmap.cpp:199
+#: ../src/common/fontmap.cpp:196
 msgid ": unknown charset"
 msgstr ": مجموعه کاراکتر ناشناس"
 
-#: ../src/common/fontmap.cpp:413
+#: ../src/common/fontmap.cpp:410
 msgid ": unknown encoding"
 msgstr ": رمزگذاری ناشناخته"
 
-#: ../src/generic/wizard.cpp:443
+#: ../src/generic/wizard.cpp:438
 msgid "< &Back"
 msgstr "< &Back"
 
-#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:628
-#: ../src/osx/carbon/fontdlg.cpp:648
+#: ../src/osx/carbon/fontdlg.cpp:419 ../src/osx/carbon/fontdlg.cpp:625
+#: ../src/osx/carbon/fontdlg.cpp:645
 msgid "<Any Decorative>"
 msgstr "<هر تزئینی>"
 
-#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:630
-#: ../src/osx/carbon/fontdlg.cpp:650
+#: ../src/osx/carbon/fontdlg.cpp:420 ../src/osx/carbon/fontdlg.cpp:627
+#: ../src/osx/carbon/fontdlg.cpp:647
 msgid "<Any Modern>"
 msgstr "<هر مدرن>"
 
-#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:626
-#: ../src/osx/carbon/fontdlg.cpp:646
+#: ../src/osx/carbon/fontdlg.cpp:418 ../src/osx/carbon/fontdlg.cpp:623
+#: ../src/osx/carbon/fontdlg.cpp:643
 msgid "<Any Roman>"
 msgstr "<هر رومان>"
 
-#: ../src/osx/carbon/fontdlg.cpp:424 ../src/osx/carbon/fontdlg.cpp:632
-#: ../src/osx/carbon/fontdlg.cpp:652
+#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:629
+#: ../src/osx/carbon/fontdlg.cpp:649
 msgid "<Any Script>"
 msgstr "<هر اسکریپتی>"
 
-#: ../src/osx/carbon/fontdlg.cpp:425 ../src/osx/carbon/fontdlg.cpp:637
-#: ../src/osx/carbon/fontdlg.cpp:656
+#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:634
+#: ../src/osx/carbon/fontdlg.cpp:653
 msgid "<Any Swiss>"
 msgstr "<هر سوئیسی>"
 
-#: ../src/osx/carbon/fontdlg.cpp:426 ../src/osx/carbon/fontdlg.cpp:634
-#: ../src/osx/carbon/fontdlg.cpp:654
+#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:631
+#: ../src/osx/carbon/fontdlg.cpp:651
 msgid "<Any Teletype>"
 msgstr "<هرگونه Teletype>"
 
-#: ../src/osx/carbon/fontdlg.cpp:420
+#: ../src/osx/carbon/fontdlg.cpp:417
 msgid "<Any>"
 msgstr "<Any>"
 
-#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
 msgid "<DIR>"
 msgstr "<DIR>"
 
-#: ../src/generic/filectrlg.cpp:254 ../src/generic/filectrlg.cpp:277
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
 msgid "<DRIVE>"
 msgstr "<DRIVE>"
 
-#: ../src/generic/filectrlg.cpp:252 ../src/generic/filectrlg.cpp:275
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
 msgid "<LINK>"
 msgstr "<LINK>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1264
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Bold italic face.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1270
+#: ../src/html/helpwnd.cpp:1268
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>bold italic <u>underlined</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1265
+#: ../src/html/helpwnd.cpp:1263
 msgid "<b>Bold face.</b> "
 msgstr "<b>Bold face.</b> "
 
-#: ../src/html/helpwnd.cpp:1264
+#: ../src/html/helpwnd.cpp:1262
 msgid "<i>Italic face.</i> "
 msgstr "<i>Italic face.</i> "
 
@@ -1071,15 +1069,15 @@ msgstr "<i>Italic face.</i> "
 msgid ">"
 msgstr ">"
 
-#: ../src/generic/dbgrptg.cpp:318
+#: ../src/generic/dbgrptg.cpp:317
 msgid "A debug report has been generated in the directory\n"
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:573
+#: ../src/common/debugrpt.cpp:574
 msgid "A debug report has been generated. It can be found in"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:418
+#: ../src/common/xtixml.cpp:414
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr ""
 
@@ -1090,106 +1088,106 @@ msgstr ""
 msgid "A standard bullet name."
 msgstr ""
 
-#: ../src/common/paper.cpp:217
+#: ../src/common/paper.cpp:214
 msgid "A0 sheet, 841 x 1189 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:218
+#: ../src/common/paper.cpp:215
 msgid "A1 sheet, 594 x 841 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:159
+#: ../src/common/paper.cpp:156
 msgid "A2 420 x 594 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:156
+#: ../src/common/paper.cpp:153
 msgid "A3 Extra 322 x 445 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:161
+#: ../src/common/paper.cpp:158
 msgid "A3 Extra Transverse 322 x 445 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:170
+#: ../src/common/paper.cpp:167
 msgid "A3 Rotated 420 x 297 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:160
+#: ../src/common/paper.cpp:157
 msgid "A3 Transverse 297 x 420 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:106
+#: ../src/common/paper.cpp:103
 msgid "A3 sheet, 297 x 420 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:146
+#: ../src/common/paper.cpp:143
 msgid "A4 Extra 9.27 x 12.69 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:153
+#: ../src/common/paper.cpp:150
 msgid "A4 Plus 210 x 330 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:171
+#: ../src/common/paper.cpp:168
 msgid "A4 Rotated 297 x 210 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:148
+#: ../src/common/paper.cpp:145
 msgid "A4 Transverse 210 x 297 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:97
+#: ../src/common/paper.cpp:94
 msgid "A4 sheet, 210 x 297 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:107
+#: ../src/common/paper.cpp:104
 msgid "A4 small sheet, 210 x 297 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:157
+#: ../src/common/paper.cpp:154
 msgid "A5 Extra 174 x 235 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:172
+#: ../src/common/paper.cpp:169
 msgid "A5 Rotated 210 x 148 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:154
+#: ../src/common/paper.cpp:151
 msgid "A5 Transverse 148 x 210 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:108
+#: ../src/common/paper.cpp:105
 msgid "A5 sheet, 148 x 210 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:164
+#: ../src/common/paper.cpp:161
 msgid "A6 105 x 148 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:177
+#: ../src/common/paper.cpp:174
 msgid "A6 Rotated 148 x 105 mm"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:83 ../src/richtext/richtextformatdlg.cpp:529
-#: ../src/osx/carbon/fontdlg.cpp:153
+#: ../src/osx/carbon/fontdlg.cpp:150 ../src/generic/fontdlgg.cpp:79
+#: ../src/richtext/richtextformatdlg.cpp:521
 msgid "ABCDEFGabcdefg12345"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:458 ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
 msgid "ASCII"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "About"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:140 ../src/osx/menu_osx.cpp:558
-#: ../src/msw/aboutdlg.cpp:64
+#: ../src/osx/menu_osx.cpp:450 ../src/generic/aboutdlgg.cpp:137
+#: ../src/msw/aboutdlg.cpp:61
 #, c-format
 msgid "About %s"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:560
+#: ../src/osx/menu_osx.cpp:452
 msgid "About..."
 msgstr ""
 
@@ -1198,37 +1196,37 @@ msgid "Absolute"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:873
+#: ../src/propgrid/advprops.cpp:774
 msgid "ActiveBorder"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:874
+#: ../src/propgrid/advprops.cpp:775
 msgid "ActiveCaption"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "Actual Size"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:140 ../src/common/accelcmn.cpp:81
+#: ../src/common/stockitem.cpp:137 ../src/common/accelcmn.cpp:78
 msgid "Add"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11455
+#: ../src/richtext/richtextbuffer.cpp:11454
 msgid "Add Column"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11392
+#: ../src/richtext/richtextbuffer.cpp:11391
 msgid "Add Row"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:432
+#: ../src/html/helpwnd.cpp:430
 msgid "Add current page to bookmarks"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:366
+#: ../src/generic/colrdlgg.cpp:386
 msgid "Add to custom colours"
 msgstr ""
 
@@ -1240,12 +1238,12 @@ msgstr ""
 msgid "AddToPropertyCollection called w/o valid adder"
 msgstr ""
 
-#: ../src/html/helpctrl.cpp:159
+#: ../src/html/helpctrl.cpp:155
 #, c-format
 msgid "Adding book %s"
 msgstr ""
 
-#: ../src/common/preferencescmn.cpp:43
+#: ../src/common/preferencescmn.cpp:40
 msgid "Advanced"
 msgstr ""
 
@@ -1253,11 +1251,11 @@ msgstr ""
 msgid "After a paragraph:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:172
+#: ../src/common/stockitem.cpp:169
 msgid "Align Left"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:173
+#: ../src/common/stockitem.cpp:170
 msgid "Align Right"
 msgstr ""
 
@@ -1265,40 +1263,40 @@ msgstr ""
 msgid "Alignment"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:215
+#: ../src/generic/prntdlgg.cpp:208
 msgid "All"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:1197 ../src/common/fldlgcmn.cpp:107
+#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1186
 #, c-format
 msgid "All files (%s)|%s"
 msgstr ""
 
-#: ../include/wx/defs.h:2886
+#: ../include/wx/defs.h:2582
 msgid "All files (*)|*"
 msgstr ""
 
-#: ../include/wx/defs.h:2883
+#: ../include/wx/defs.h:2579
 msgid "All files (*.*)|*.*"
 msgstr ""
 
-#: ../src/richtext/richtextstyles.cpp:1061
+#: ../src/richtext/richtextstyles.cpp:1058
 msgid "All styles"
 msgstr ""
 
-#: ../src/propgrid/manager.cpp:1528
+#: ../src/propgrid/manager.cpp:1544
 msgid "Alphabetic Mode"
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:425
+#: ../src/common/xtistrm.cpp:422
 msgid "Already Registered Object passed to SetObjectClassInfo"
 msgstr ""
 
-#: ../src/unix/dialup.cpp:353
+#: ../src/unix/dialup.cpp:352
 msgid "Already dialling ISP."
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:331 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/accelcmn.cpp:345 ../src/univ/themes/win32.cpp:3753
 msgid "Alt+"
 msgstr ""
 
@@ -1307,34 +1305,34 @@ msgstr ""
 msgid "An optional corner radius for adding rounded corners."
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:576
+#: ../src/common/debugrpt.cpp:577
 msgid "And includes the following files:\n"
 msgstr ""
 
-#: ../src/generic/animateg.cpp:162
+#: ../src/generic/animateg.cpp:145
 #, c-format
 msgid "Animation file is not of type %ld."
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:872
+#: ../src/propgrid/advprops.cpp:773
 msgid "AppWorkspace"
 msgstr ""
 
-#: ../src/generic/logg.cpp:1014
+#: ../src/generic/logg.cpp:1011
 #, c-format
 msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:577 ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:469 ../src/osx/menu_osx.cpp:477
 msgid "Application"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "Apply"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1609
+#: ../src/propgrid/advprops.cpp:1515
 msgid "Aqua"
 msgstr ""
 
@@ -1343,29 +1341,29 @@ msgstr ""
 msgid "Arabic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:153
+#: ../src/common/fmapbase.cpp:150
 msgid "Arabic (ISO-8859-6)"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:672
+#: ../src/msw/ole/automtn.cpp:663
 #, c-format
 msgid "Argument %u not found."
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1753
+#: ../src/propgrid/advprops.cpp:1654
 msgid "Arrow"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:184
+#: ../src/generic/aboutdlgg.cpp:181
 msgid "Artists"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "Ascending"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:433
+#: ../src/generic/filectrlg.cpp:429
 msgid "Attributes"
 msgstr ""
 
@@ -1375,90 +1373,90 @@ msgstr ""
 msgid "Available fonts."
 msgstr ""
 
-#: ../src/common/paper.cpp:137
+#: ../src/common/paper.cpp:134
 msgid "B4 (ISO) 250 x 353 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:173
+#: ../src/common/paper.cpp:170
 msgid "B4 (JIS) Rotated 364 x 257 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:127
+#: ../src/common/paper.cpp:124
 msgid "B4 Envelope, 250 x 353 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:109
+#: ../src/common/paper.cpp:106
 msgid "B4 sheet, 250 x 354 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:158
+#: ../src/common/paper.cpp:155
 msgid "B5 (ISO) Extra 201 x 276 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:174
+#: ../src/common/paper.cpp:171
 msgid "B5 (JIS) Rotated 257 x 182 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:155
+#: ../src/common/paper.cpp:152
 msgid "B5 (JIS) Transverse 182 x 257 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:128
+#: ../src/common/paper.cpp:125
 msgid "B5 Envelope, 176 x 250 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:110
+#: ../src/common/paper.cpp:107
 msgid "B5 sheet, 182 x 257 millimeter"
 msgstr ""
 
-#: ../src/common/paper.cpp:182
+#: ../src/common/paper.cpp:179
 msgid "B6 (JIS) 128 x 182 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:183
+#: ../src/common/paper.cpp:180
 msgid "B6 (JIS) Rotated 182 x 128 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:129
+#: ../src/common/paper.cpp:126
 msgid "B6 Envelope, 176 x 125 mm"
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:531 ../src/common/imagbmp.cpp:561
-#: ../src/common/imagbmp.cpp:576
+#: ../src/common/imagbmp.cpp:528 ../src/common/imagbmp.cpp:558
+#: ../src/common/imagbmp.cpp:573
 msgid "BMP: Couldn't allocate memory."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:100
+#: ../src/common/imagbmp.cpp:97
 msgid "BMP: Couldn't save invalid image."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:356
+#: ../src/common/imagbmp.cpp:353
 msgid "BMP: Couldn't write RGB color map."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:490
+#: ../src/common/imagbmp.cpp:487
 msgid "BMP: Couldn't write data."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:246
+#: ../src/common/imagbmp.cpp:243
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:269
+#: ../src/common/imagbmp.cpp:266
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:140
+#: ../src/common/imagbmp.cpp:137
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:142 ../src/common/accelcmn.cpp:52
+#: ../src/common/stockitem.cpp:139 ../src/common/accelcmn.cpp:49
 msgid "Back"
 msgstr ""
 
+#: ../src/richtext/richtextformatdlg.cpp:377
 #: ../src/richtext/richtextbackgroundpage.cpp:148
-#: ../src/richtext/richtextformatdlg.cpp:384
 msgid "Background"
 msgstr ""
 
@@ -1466,20 +1464,20 @@ msgstr ""
 msgid "Background &colour:"
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:220
+#: ../src/osx/carbon/fontdlg.cpp:217
 msgid "Background colour"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:52
+#: ../src/common/accelcmn.cpp:49
 msgid "Backspace"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:160
+#: ../src/common/fmapbase.cpp:157
 msgid "Baltic (ISO-8859-13)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:151
+#: ../src/common/fmapbase.cpp:148
 msgid "Baltic (old) (ISO-8859-4)"
 msgstr ""
 
@@ -1492,25 +1490,25 @@ msgstr ""
 msgid "Bitmap"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1594
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Black"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1755
+#: ../src/propgrid/advprops.cpp:1656
 msgid "Blank"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1603
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Blue"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:345
+#: ../src/generic/colrdlgg.cpp:365
 msgid "Blue:"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:333 ../src/richtext/richtextfontpage.cpp:355
-#: ../src/osx/carbon/fontdlg.cpp:354 ../src/common/stockitem.cpp:143
+#: ../src/osx/carbon/fontdlg.cpp:351 ../src/common/stockitem.cpp:140
+#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:355
 msgid "Bold"
 msgstr ""
 
@@ -1519,31 +1517,35 @@ msgstr ""
 msgid "Border"
 msgstr ""
 
-#: ../src/richtext/richtextformatdlg.cpp:379
+#: ../src/richtext/richtextformatdlg.cpp:372
 msgid "Borders"
 msgstr ""
 
-#: ../src/richtext/richtextsizepage.cpp:288 ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141 ../src/richtext/richtextsizepage.cpp:288
 msgid "Bottom"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:893
+#: ../src/generic/prntdlgg.cpp:886
 msgid "Bottom margin (mm):"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9383
+#: ../src/richtext/richtextbuffer.cpp:9380
 msgid "Box Properties"
 msgstr ""
 
-#: ../src/richtext/richtextstyles.cpp:1065
+#: ../src/richtext/richtextstyles.cpp:1062
 msgid "Box styles"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1602
+#: ../src/osx/cocoa/menu.mm:292
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Brown"
 msgstr ""
 
-#: ../src/common/filepickercmn.cpp:43 ../src/common/filepickercmn.cpp:44
+#: ../src/common/filepickercmn.cpp:40 ../src/common/filepickercmn.cpp:41
 msgid "Browse"
 msgstr ""
 
@@ -1556,72 +1558,72 @@ msgstr ""
 msgid "Bullet style"
 msgstr ""
 
-#: ../src/richtext/richtextformatdlg.cpp:359
+#: ../src/richtext/richtextformatdlg.cpp:352
 msgid "Bullets"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1756
+#: ../src/propgrid/advprops.cpp:1657
 msgid "Bullseye"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:875
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonFace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:876
+#: ../src/propgrid/advprops.cpp:777
 msgid "ButtonHighlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:877
+#: ../src/propgrid/advprops.cpp:778
 msgid "ButtonShadow"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:878
+#: ../src/propgrid/advprops.cpp:779
 msgid "ButtonText"
 msgstr ""
 
-#: ../src/common/paper.cpp:98
+#: ../src/common/paper.cpp:95
 msgid "C sheet, 17 x 22 in"
 msgstr ""
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "C&lear"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:406
+#: ../src/generic/fontdlgg.cpp:403
 msgid "C&olour:"
 msgstr ""
 
-#: ../src/common/paper.cpp:123
+#: ../src/common/paper.cpp:120
 msgid "C3 Envelope, 324 x 458 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:124
+#: ../src/common/paper.cpp:121
 msgid "C4 Envelope, 229 x 324 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:122
+#: ../src/common/paper.cpp:119
 msgid "C5 Envelope, 162 x 229 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:125
+#: ../src/common/paper.cpp:122
 msgid "C6 Envelope, 114 x 162 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:126
+#: ../src/common/paper.cpp:123
 msgid "C65 Envelope, 114 x 229 mm"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "CD-Rom"
 msgstr ""
 
-#: ../src/html/chm.cpp:815 ../src/html/chm.cpp:874
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:865
 msgid "CHM handler currently supports only local files!"
 msgstr ""
 
@@ -1629,190 +1631,193 @@ msgstr ""
 msgid "Ca&pitals"
 msgstr ""
 
-#: ../src/common/cmdproc.cpp:267
+#: ../src/common/cmdproc.cpp:260
 msgid "Can't &Undo "
 msgstr ""
 
-#: ../src/common/image.cpp:2824
+#: ../src/common/image.cpp:2924
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 
-#: ../src/msw/registry.cpp:506
+#: ../src/msw/registry.cpp:495
 #, c-format
 msgid "Can't close registry key '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:584
+#: ../src/msw/registry.cpp:573
 #, c-format
 msgid "Can't copy values of unsupported type %d."
 msgstr ""
 
-#: ../src/msw/registry.cpp:487
+#: ../src/msw/registry.cpp:476
 #, c-format
 msgid "Can't create registry key '%s'"
 msgstr ""
 
-#: ../src/msw/thread.cpp:665
+#: ../src/msw/thread.cpp:657
 msgid "Can't create thread"
 msgstr ""
 
-#: ../src/msw/window.cpp:3691
-#, c-format
-msgid "Can't create window of class %s"
-msgstr ""
-
-#: ../src/msw/registry.cpp:777
+#: ../src/msw/registry.cpp:765
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr ""
 
-#: ../src/msw/iniconf.cpp:458
+#: ../src/msw/iniconf.cpp:455
 #, c-format
 msgid "Can't delete the INI file '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:805
+#: ../src/msw/registry.cpp:793
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1171
+#: ../src/msw/registry.cpp:1159
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1132
+#: ../src/msw/registry.cpp:1120
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1389
+#: ../src/msw/registry.cpp:1377
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr ""
 
-#: ../src/common/ffile.cpp:254
+#: ../src/common/ffile.cpp:253
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:418
+#: ../src/msw/registry.cpp:407
 #, c-format
 msgid "Can't get info about registry key '%s'"
 msgstr ""
 
-#: ../src/common/zstream.cpp:346
+#: ../src/msw/webview_ie.cpp:1024
+msgid "Can't get the JavaScript object"
+msgstr ""
+
+#: ../src/common/zstream.cpp:343
 msgid "Can't initialize zlib deflate stream."
 msgstr ""
 
-#: ../src/common/zstream.cpp:185
+#: ../src/common/zstream.cpp:182
 msgid "Can't initialize zlib inflate stream."
 msgstr ""
 
-#: ../src/msw/fswatcher.cpp:476
+#: ../src/msw/fswatcher.cpp:475
 #, c-format
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr ""
 
-#: ../src/msw/registry.cpp:454
+#: ../src/msw/registry.cpp:443
 #, c-format
 msgid "Can't open registry key '%s'"
 msgstr ""
 
-#: ../src/common/zstream.cpp:252
+#: ../src/common/zstream.cpp:249
 #, c-format
 msgid "Can't read from inflate stream: %s"
 msgstr ""
 
-#: ../src/common/zstream.cpp:244
+#: ../src/common/zstream.cpp:241
 msgid "Can't read inflate stream: unexpected EOF in underlying stream."
 msgstr ""
 
-#: ../src/msw/registry.cpp:1064
+#: ../src/msw/registry.cpp:1052
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:878 ../src/msw/registry.cpp:910
-#: ../src/msw/registry.cpp:975
+#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
+#: ../src/msw/registry.cpp:963
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr ""
 
-#: ../src/common/image.cpp:2620
+#: ../src/msw/webview_ie.cpp:1017
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/common/image.cpp:2715
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr ""
 
-#: ../src/generic/logg.cpp:573 ../src/generic/logg.cpp:976
+#: ../src/generic/logg.cpp:570 ../src/generic/logg.cpp:973
 msgid "Can't save log contents to file."
 msgstr ""
 
-#: ../src/msw/thread.cpp:629
+#: ../src/msw/thread.cpp:621
 msgid "Can't set thread priority"
 msgstr ""
 
-#: ../src/msw/registry.cpp:896 ../src/msw/registry.cpp:938
-#: ../src/msw/registry.cpp:1081
+#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
+#: ../src/msw/registry.cpp:1069
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:351
+#: ../src/unix/utilsunx.cpp:353
 msgid "Can't write to child process's stdin"
 msgstr ""
 
-#: ../src/common/zstream.cpp:427
+#: ../src/common/zstream.cpp:424
 #, c-format
 msgid "Can't write to deflate stream: %s"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:279 ../src/richtext/richtextstyledlg.cpp:300
-#: ../src/common/stockitem.cpp:145 ../src/common/accelcmn.cpp:71
-#: ../src/msw/msgdlg.cpp:454 ../src/msw/progdlg.cpp:673
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:142
+#: ../src/common/accelcmn.cpp:68 ../src/motif/msgdlg.cpp:196
+#: ../src/gtk1/fontdlg.cpp:144 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/progdlg.cpp:940 ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1261
+#: ../src/common/filefn.cpp:1149
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr ""
 
-#: ../src/msw/dir.cpp:263
+#: ../src/msw/dir.cpp:260
 #, c-format
 msgid "Cannot enumerate files in directory '%s'"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:523
+#: ../src/msw/dialup.cpp:517
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:827
+#: ../src/msw/dialup.cpp:821
 msgid "Cannot find the location of address book file"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:562
+#: ../src/msw/ole/automtn.cpp:553
 #, c-format
 msgid "Cannot get an active instance of \"%s\""
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1035
+#: ../src/unix/threadpsx.cpp:1053
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:987
+#: ../src/unix/utilsunx.cpp:989
 msgid "Cannot get the hostname"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:1023
+#: ../src/unix/utilsunx.cpp:1025
 msgid "Cannot get the official hostname"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:928
+#: ../src/msw/dialup.cpp:922
 msgid "Cannot hang up - no active dialup connection."
 msgstr ""
 
@@ -1820,126 +1825,126 @@ msgstr ""
 msgid "Cannot initialize OLE"
 msgstr ""
 
-#: ../src/common/socket.cpp:853
+#: ../src/common/socket.cpp:850
 msgid "Cannot initialize sockets"
 msgstr ""
 
-#: ../src/msw/volume.cpp:619
+#: ../src/msw/volume.cpp:627
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr ""
 
-#: ../src/xrc/xmlres.cpp:360
+#: ../src/xrc/xmlres.cpp:358
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr ""
 
-#: ../src/xrc/xmlres.cpp:742
+#: ../src/xrc/xmlres.cpp:740
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr ""
 
-#: ../src/html/htmlfilt.cpp:137
+#: ../src/html/htmlfilt.cpp:134
 #, c-format
 msgid "Cannot open HTML document: %s"
 msgstr ""
 
-#: ../src/html/helpdata.cpp:667
+#: ../src/html/helpdata.cpp:660
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr ""
 
-#: ../src/html/helpdata.cpp:299
+#: ../src/html/helpdata.cpp:296
 #, c-format
 msgid "Cannot open contents file: %s"
 msgstr ""
 
-#: ../src/generic/dcpsg.cpp:1667
+#: ../src/generic/dcpsg.cpp:1665
 msgid "Cannot open file for PostScript printing!"
 msgstr ""
 
-#: ../src/html/helpdata.cpp:313
+#: ../src/html/helpdata.cpp:310
 #, c-format
 msgid "Cannot open index file: %s"
 msgstr ""
 
-#: ../src/xrc/xmlres.cpp:724
+#: ../src/xrc/xmlres.cpp:722
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1534
+#: ../src/html/helpwnd.cpp:1532
 msgid "Cannot print empty page."
 msgstr ""
 
-#: ../src/msw/volume.cpp:507
+#: ../src/msw/volume.cpp:515
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr ""
 
-#: ../src/msw/thread.cpp:888
+#: ../src/msw/thread.cpp:894
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1016
+#: ../src/unix/threadpsx.cpp:1028
 msgid "Cannot retrieve thread scheduling policy."
 msgstr ""
 
-#: ../src/common/intl.cpp:558
+#: ../src/common/intl.cpp:365
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:831 ../src/msw/thread.cpp:546
+#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
 msgid "Cannot start thread: error writing TLS."
 msgstr ""
 
-#: ../src/msw/thread.cpp:872
+#: ../src/msw/thread.cpp:864
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr ""
 
-#: ../src/msw/thread.cpp:794
+#: ../src/msw/thread.cpp:786
 msgid "Cannot wait for thread termination"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:75
+#: ../src/common/accelcmn.cpp:72
 msgid "Capital"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:879
+#: ../src/propgrid/advprops.cpp:780
 msgid "CaptionText"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:531
 msgid "Case sensitive"
 msgstr ""
 
-#: ../src/propgrid/manager.cpp:1509
+#: ../src/propgrid/manager.cpp:1527
 msgid "Categorized Mode"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9968
+#: ../src/richtext/richtextbuffer.cpp:9965
 msgid "Cell Properties"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:161
+#: ../src/common/fmapbase.cpp:158
 msgid "Celtic (ISO-8859-14)"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:160
 #: ../src/richtext/richtextliststylepage.cpp:349
+#: ../src/richtext/richtextindentspage.cpp:160
 msgid "Cen&tred"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:170
+#: ../src/common/stockitem.cpp:167
 msgid "Centered"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:149
+#: ../src/common/fmapbase.cpp:146
 msgid "Central European (ISO-8859-2)"
 msgstr ""
 
@@ -1948,10 +1953,10 @@ msgstr ""
 msgid "Centre"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:162
-#: ../src/richtext/richtextindentspage.cpp:164
 #: ../src/richtext/richtextliststylepage.cpp:351
 #: ../src/richtext/richtextliststylepage.cpp:353
+#: ../src/richtext/richtextindentspage.cpp:162
+#: ../src/richtext/richtextindentspage.cpp:164
 msgid "Centre text."
 msgstr ""
 
@@ -1964,24 +1969,24 @@ msgstr ""
 msgid "Ch&oose..."
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:4354
+#: ../src/richtext/richtextbuffer.cpp:4351
 msgid "Change List Style"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:3709
+#: ../src/richtext/richtextbuffer.cpp:3706
 msgid "Change Object Style"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:3982
-#: ../src/richtext/richtextbuffer.cpp:8129
+#: ../src/richtext/richtextbuffer.cpp:3979
+#: ../src/richtext/richtextbuffer.cpp:8125
 msgid "Change Properties"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:3526
+#: ../src/richtext/richtextbuffer.cpp:3523
 msgid "Change Style"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:341
+#: ../src/common/fileconf.cpp:335
 #, c-format
 msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
 msgstr ""
@@ -1992,11 +1997,11 @@ msgid "Changing current directory to \"%s\" failed"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1757
+#: ../src/propgrid/advprops.cpp:1658
 msgid "Character"
 msgstr ""
 
-#: ../src/richtext/richtextstyles.cpp:1063
+#: ../src/richtext/richtextstyles.cpp:1060
 msgid "Character styles"
 msgstr ""
 
@@ -2033,20 +2038,20 @@ msgstr ""
 msgid "Check to indicate right-to-left text layout."
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:356 ../src/osx/carbon/fontdlg.cpp:358
+#: ../src/osx/carbon/fontdlg.cpp:353 ../src/osx/carbon/fontdlg.cpp:355
 msgid "Check to make the font bold."
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:363 ../src/osx/carbon/fontdlg.cpp:365
+#: ../src/osx/carbon/fontdlg.cpp:360 ../src/osx/carbon/fontdlg.cpp:362
 msgid "Check to make the font italic."
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:372 ../src/osx/carbon/fontdlg.cpp:374
+#: ../src/osx/carbon/fontdlg.cpp:369 ../src/osx/carbon/fontdlg.cpp:371
 msgid "Check to make the font underlined."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:289
-#: ../src/richtext/richtextstyledlg.cpp:291
+#: ../src/richtext/richtextstyledlg.cpp:285
+#: ../src/richtext/richtextstyledlg.cpp:287
 msgid "Check to restart numbering."
 msgstr ""
 
@@ -2080,51 +2085,51 @@ msgstr ""
 msgid "Check to suppress hyphenation."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:763
+#: ../src/msw/dialup.cpp:757
 msgid "Choose ISP to dial"
 msgstr ""
 
-#: ../src/propgrid/props.cpp:1922
+#: ../src/propgrid/props.cpp:1904
 msgid "Choose a directory:"
 msgstr ""
 
-#: ../src/propgrid/props.cpp:1975
+#: ../src/propgrid/props.cpp:2199
 msgid "Choose a file"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:158 ../src/gtk/colordlg.cpp:54
+#: ../src/generic/colrdlgg.cpp:156 ../src/gtk/colordlg.cpp:49
 msgid "Choose colour"
 msgstr ""
 
-#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/gtk1/fontdlg.cpp:125 ../src/generic/fontpickerg.cpp:47
+#: ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr ""
 
-#: ../src/common/module.cpp:74
+#: ../src/common/module.cpp:71
 #, c-format
 msgid "Circular dependency involving module \"%s\" detected."
 msgstr ""
 
-#: ../src/aui/tabmdi.cpp:108 ../src/generic/mdig.cpp:97
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
 msgid "Cl&ose"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:684
+#: ../src/msw/ole/automtn.cpp:675
 msgid "Class not registered."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:147 ../src/common/accelcmn.cpp:72
+#: ../src/common/stockitem.cpp:144 ../src/common/accelcmn.cpp:69
 msgid "Clear"
 msgstr ""
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "Clear the log contents"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:252
-#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:248
+#: ../src/richtext/richtextstyledlg.cpp:250
 msgid "Click to apply the selected style."
 msgstr ""
 
@@ -2135,15 +2140,15 @@ msgstr ""
 msgid "Click to browse for a symbol."
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:403 ../src/osx/carbon/fontdlg.cpp:405
+#: ../src/osx/carbon/fontdlg.cpp:400 ../src/osx/carbon/fontdlg.cpp:402
 msgid "Click to cancel changes to the font."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:472 ../src/generic/fontdlgg.cpp:491
+#: ../src/generic/fontdlgg.cpp:468 ../src/generic/fontdlgg.cpp:487
 msgid "Click to cancel the font selection."
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:384 ../src/osx/carbon/fontdlg.cpp:386
+#: ../src/osx/carbon/fontdlg.cpp:381 ../src/osx/carbon/fontdlg.cpp:383
 msgid "Click to change the font colour."
 msgstr ""
 
@@ -2162,37 +2167,37 @@ msgstr ""
 msgid "Click to choose the font for this level."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:279
-#: ../src/richtext/richtextstyledlg.cpp:281
+#: ../src/richtext/richtextstyledlg.cpp:275
+#: ../src/richtext/richtextstyledlg.cpp:277
 msgid "Click to close this window."
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:410 ../src/osx/carbon/fontdlg.cpp:412
+#: ../src/osx/carbon/fontdlg.cpp:407 ../src/osx/carbon/fontdlg.cpp:409
 msgid "Click to confirm changes to the font."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:477 ../src/generic/fontdlgg.cpp:479
-#: ../src/generic/fontdlgg.cpp:484 ../src/generic/fontdlgg.cpp:486
+#: ../src/generic/fontdlgg.cpp:473 ../src/generic/fontdlgg.cpp:475
+#: ../src/generic/fontdlgg.cpp:480 ../src/generic/fontdlgg.cpp:482
 msgid "Click to confirm the font selection."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:244
-#: ../src/richtext/richtextstyledlg.cpp:246
+#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:242
 msgid "Click to create a new box style."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:226
-#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:224
 msgid "Click to create a new character style."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:238
-#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:236
 msgid "Click to create a new list style."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:232
-#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:230
 msgid "Click to create a new paragraph style."
 msgstr ""
 
@@ -2206,8 +2211,8 @@ msgstr ""
 msgid "Click to delete all tab positions."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:270
-#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:268
 msgid "Click to delete the selected style."
 msgstr ""
 
@@ -2216,25 +2221,25 @@ msgstr ""
 msgid "Click to delete the selected tab position."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:264
-#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:262
 msgid "Click to edit the selected style."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:258
-#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:256
 msgid "Click to rename the selected style."
 msgstr ""
 
-#: ../src/generic/dbgrptg.cpp:97 ../src/generic/progdlgg.cpp:759
-#: ../src/richtext/richtextstyledlg.cpp:277
-#: ../src/richtext/richtextsymboldlg.cpp:476 ../src/common/stockitem.cpp:148
-#: ../src/msw/progdlg.cpp:170 ../src/msw/progdlg.cpp:679
-#: ../src/html/helpdlg.cpp:90
+#: ../src/common/stockitem.cpp:145 ../src/generic/dbgrptg.cpp:94
+#: ../src/generic/progdlgg.cpp:781 ../src/msw/progdlg.cpp:211
+#: ../src/msw/progdlg.cpp:946 ../src/html/helpdlg.cpp:87
+#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextstyledlg.cpp:273
 msgid "Close"
 msgstr ""
 
-#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:98
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
 msgid "Close All"
 msgstr ""
 
@@ -2242,65 +2247,65 @@ msgstr ""
 msgid "Close current document"
 msgstr ""
 
-#: ../src/generic/logg.cpp:516
+#: ../src/generic/logg.cpp:513
 msgid "Close this window"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6006
+#: ../src/generic/datavgen.cpp:6811
 msgid "Collapse"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "Color"
 msgstr ""
 
-#: ../src/richtext/richtextformatdlg.cpp:776
+#: ../src/richtext/richtextformatdlg.cpp:768
 msgid "Colour"
 msgstr ""
 
-#: ../src/msw/colordlg.cpp:158
+#: ../src/msw/colordlg.cpp:227
 #, c-format
 msgid "Colour selection dialog failed with error %0lx."
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:380
+#: ../src/osx/carbon/fontdlg.cpp:377
 msgid "Colour:"
 msgstr ""
 
-#: ../src/generic/datavgen.cpp:6077
+#: ../src/generic/datavgen.cpp:6882
 #, c-format
 msgid "Column %u"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:114
+#: ../src/common/accelcmn.cpp:112
 msgid "Command"
 msgstr ""
 
-#: ../src/common/init.cpp:196
+#: ../src/common/init.cpp:193
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
 "ignored."
 msgstr ""
 
-#: ../src/msw/fontdlg.cpp:120
+#: ../src/msw/fontdlg.cpp:170
 #, c-format
 msgid "Common dialog failed with error code %0lx."
 msgstr ""
 
-#: ../src/gtk/window.cpp:4649
+#: ../src/gtk/window.cpp:5653
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:1549
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr ""
 
-#: ../src/generic/dirctrlg.cpp:444
+#: ../src/generic/dirctrlg.cpp:410
 msgid "Computer"
 msgstr ""
 
@@ -2309,52 +2314,56 @@ msgstr ""
 msgid "Config entry name cannot start with '%c'."
 msgstr ""
 
-#: ../src/generic/filedlgg.cpp:349 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
 msgid "Confirm"
 msgstr ""
 
-#: ../src/html/htmlwin.cpp:566
+#: ../src/html/htmlwin.cpp:569
 msgid "Connecting..."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:475
+#: ../src/html/helpwnd.cpp:473
 msgid "Contents"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:880
+#: ../src/propgrid/advprops.cpp:781
 msgid "ControlDark"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:881
+#: ../src/propgrid/advprops.cpp:782
 msgid "ControlLight"
 msgstr ""
 
-#: ../src/common/strconv.cpp:2262
+#: ../src/common/strconv.cpp:2208
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "Convert"
 msgstr ""
 
-#: ../src/html/htmlwin.cpp:1079
+#: ../src/html/htmlwin.cpp:1020
 #, c-format
 msgid "Copied to clipboard:\"%s\""
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:247
+#: ../src/generic/prntdlgg.cpp:240
 msgid "Copies:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:150 ../src/stc/stc_i18n.cpp:18
+#: ../src/common/stockitem.cpp:147 ../src/stc/stc_i18n.cpp:18
 msgid "Copy"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:258
+#: ../src/common/stockitem.cpp:255
 msgid "Copy selection"
+msgstr ""
+
+#: ../src/generic/grid.cpp:5945
+msgid "Copying more than one selected block to clipboard is not supported."
 msgstr ""
 
 #: ../src/richtext/richtextborderspage.cpp:566
@@ -2366,194 +2375,190 @@ msgstr ""
 msgid "Corner &radius:"
 msgstr ""
 
-#: ../src/html/chm.cpp:718
+#: ../src/html/chm.cpp:711
 #, c-format
 msgid "Could not create temporary file '%s'"
 msgstr ""
 
-#: ../src/html/chm.cpp:273
+#: ../src/html/chm.cpp:270
 #, c-format
 msgid "Could not extract %s into %s: %s"
 msgstr ""
 
-#: ../src/generic/tabg.cpp:1048
+#: ../src/generic/tabg.cpp:1045
 msgid "Could not find tab for id"
 msgstr ""
 
-#: ../src/gtk/notifmsg.cpp:108
-msgid "Could not initalize libnotify."
-msgstr ""
-
-#: ../src/html/chm.cpp:444
+#: ../src/html/chm.cpp:437
 #, c-format
 msgid "Could not locate file '%s'."
 msgstr ""
 
-#: ../src/common/filefn.cpp:1403
+#: ../src/msw/graphicsd2d.cpp:604
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/common/filefn.cpp:1291
 msgid "Could not set current working directory"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:2015
+#: ../src/common/prntbase.cpp:2037
 msgid "Could not start document preview."
 msgstr ""
 
-#: ../src/generic/printps.cpp:178 ../src/msw/printwin.cpp:210
-#: ../src/gtk/print.cpp:1132
+#: ../src/generic/printps.cpp:159 ../src/msw/printwin.cpp:184
+#: ../src/gtk/print.cpp:1129
 msgid "Could not start printing."
 msgstr ""
 
-#: ../src/common/wincmn.cpp:2125
+#: ../src/common/wincmn.cpp:2126
 msgid "Could not transfer data to window"
 msgstr ""
 
-#: ../src/msw/imaglist.cpp:187 ../src/msw/imaglist.cpp:224
-#: ../src/msw/imaglist.cpp:249 ../src/msw/dragimag.cpp:185
-#: ../src/msw/dragimag.cpp:220
+#: ../src/msw/imaglist.cpp:223 ../src/msw/imaglist.cpp:245
+#: ../src/msw/imaglist.cpp:270 ../src/msw/dragimag.cpp:182
+#: ../src/msw/dragimag.cpp:217
 msgid "Couldn't add an image to the image list."
 msgstr ""
 
-#: ../src/osx/glcanvas_osx.cpp:414 ../src/unix/glx11.cpp:558
-#: ../src/msw/glcanvas.cpp:616
+#: ../src/osx/glcanvas_osx.cpp:411 ../src/msw/glcanvas.cpp:631
+#: ../src/unix/glegl.cpp:315 ../src/unix/glx11.cpp:559
 msgid "Couldn't create OpenGL context"
 msgstr ""
 
-#: ../src/msw/timer.cpp:134
+#: ../src/msw/timer.cpp:131
 msgid "Couldn't create a timer"
 msgstr ""
 
-#: ../src/osx/carbon/overlay.cpp:122
-msgid "Couldn't create the overlay window"
-msgstr ""
-
-#: ../src/common/translation.cpp:2024
+#: ../src/common/translation.cpp:2074
 msgid "Couldn't enumerate translations"
 msgstr ""
 
-#: ../src/common/dynlib.cpp:120
+#: ../src/common/dynlib.cpp:110
 #, c-format
 msgid "Couldn't find symbol '%s' in a dynamic library"
 msgstr ""
 
-#: ../src/msw/thread.cpp:915
+#: ../src/msw/thread.cpp:921
 msgid "Couldn't get the current thread pointer"
 msgstr ""
 
-#: ../src/osx/carbon/overlay.cpp:129
-msgid "Couldn't init the context on the overlay window"
-msgstr ""
-
-#: ../src/common/imaggif.cpp:244
+#: ../src/common/imaggif.cpp:241
 msgid "Couldn't initialize GIF hash table."
 msgstr ""
 
-#: ../src/common/imagpng.cpp:409
+#: ../src/common/imagpng.cpp:437
 msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
 msgstr ""
 
-#: ../src/unix/sound.cpp:470
+#: ../src/unix/sound.cpp:459
 #, c-format
 msgid "Couldn't load sound data from '%s'."
 msgstr ""
 
-#: ../src/msw/dirdlg.cpp:435
+#: ../src/msw/dirdlg.cpp:287
 msgid "Couldn't obtain folder name"
 msgstr ""
 
-#: ../src/unix/sound_sdl.cpp:229
+#: ../src/unix/sound_sdl.cpp:226
 #, c-format
 msgid "Couldn't open audio: %s"
 msgstr ""
 
-#: ../src/msw/ole/dataobj.cpp:377
+#: ../src/msw/ole/dataobj.cpp:385
 #, c-format
 msgid "Couldn't register clipboard format '%s'."
 msgstr ""
 
-#: ../src/msw/listctrl.cpp:869
+#: ../src/msw/listctrl.cpp:933
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr ""
 
-#: ../src/common/imagpng.cpp:498 ../src/common/imagpng.cpp:509
-#: ../src/common/imagpng.cpp:519
+#: ../src/common/imagpng.cpp:511 ../src/common/imagpng.cpp:522
+#: ../src/common/imagpng.cpp:532
 msgid "Couldn't save PNG image."
 msgstr ""
 
-#: ../src/msw/thread.cpp:684
+#: ../src/msw/thread.cpp:676
 msgid "Couldn't terminate thread"
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:166
+#: ../src/common/xtistrm.cpp:163
 #, c-format
 msgid "Create Parameter %s not found in declared RTTI Parameters"
 msgstr ""
 
-#: ../src/generic/dirdlgg.cpp:288
+#: ../src/generic/dirdlgg.cpp:285
 msgid "Create directory"
 msgstr ""
 
-#: ../src/generic/filedlgg.cpp:212 ../src/generic/dirdlgg.cpp:111
+#: ../src/generic/filedlgg.cpp:209 ../src/generic/dirdlgg.cpp:108
 msgid "Create new directory"
 msgstr ""
 
-#: ../src/xrc/xmlres.cpp:2460
+#: ../src/common/stockitem.cpp:264
+msgid "Create new document"
+msgstr ""
+
+#: ../src/xrc/xmlres.cpp:2515
 #, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1758
+#: ../src/propgrid/advprops.cpp:1659
 msgid "Cross"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:333
+#: ../src/common/accelcmn.cpp:347
 msgid "Ctrl+"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:332 ../src/osx/textctrl_osx.cpp:576
-#: ../src/common/stockitem.cpp:151 ../src/msw/textctrl.cpp:2507
+#: ../src/osx/textctrl_osx.cpp:594 ../src/common/stockitem.cpp:148
+#: ../src/msw/textctrl.cpp:2772 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:940
+#: ../src/generic/filectrlg.cpp:936
 msgid "Current directory:"
 msgstr ""
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:896 ../src/propgrid/advprops.cpp:1574
-#: ../src/propgrid/advprops.cpp:1612
+#: ../src/propgrid/advprops.cpp:797 ../src/propgrid/advprops.cpp:1475
+#: ../src/propgrid/advprops.cpp:1518
 msgid "Custom"
 msgstr ""
 
-#: ../src/gtk/print.cpp:217
+#: ../src/gtk/print.cpp:211
 msgid "Custom size"
 msgstr ""
 
-#: ../src/common/headerctrlcmn.cpp:60
+#: ../src/common/headerctrlcmn.cpp:58
 msgid "Customize Columns"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:151 ../src/stc/stc_i18n.cpp:17
+#: ../src/common/stockitem.cpp:148 ../src/stc/stc_i18n.cpp:17
 msgid "Cut"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:259
+#: ../src/common/stockitem.cpp:256
 msgid "Cut selection"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:152
+#: ../src/common/fmapbase.cpp:149
 msgid "Cyrillic (ISO-8859-5)"
 msgstr ""
 
-#: ../src/common/paper.cpp:99
+#: ../src/common/paper.cpp:96
 msgid "D sheet, 22 x 34 in"
 msgstr ""
 
-#: ../src/msw/dde.cpp:703
+#: ../src/msw/dde.cpp:698
 msgid "DDE poke request failed"
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1169
+#: ../src/common/imagbmp.cpp:1181
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr ""
 
@@ -2573,7 +2578,7 @@ msgstr ""
 msgid "DIB Header: Unknown encoding in file."
 msgstr ""
 
-#: ../src/common/paper.cpp:121
+#: ../src/common/paper.cpp:118
 msgid "DL Envelope, 110 x 220 mm"
 msgstr ""
 
@@ -2581,53 +2586,53 @@ msgstr ""
 msgid "Dashed"
 msgstr ""
 
-#: ../src/generic/dbgrptg.cpp:300
+#: ../src/generic/dbgrptg.cpp:301
 #, c-format
 msgid "Debug report \"%s\""
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:210
+#: ../src/common/debugrpt.cpp:211
 msgid "Debug report couldn't be created."
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:553
+#: ../src/common/debugrpt.cpp:554
 msgid "Debug report generation has failed."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:84
+#: ../src/common/accelcmn.cpp:81
 msgid "Decimal"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:323
+#: ../src/generic/fontdlgg.cpp:319
 msgid "Decorative"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1752
+#: ../src/propgrid/advprops.cpp:1653
 msgid "Default"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:796
+#: ../src/common/fmapbase.cpp:792
 msgid "Default encoding"
 msgstr ""
 
-#: ../src/dfb/fontmgr.cpp:180
+#: ../src/dfb/fontmgr.cpp:177
 msgid "Default font"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:510
+#: ../src/generic/prntdlgg.cpp:503
 msgid "Default printer"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:51
+#: ../src/common/accelcmn.cpp:48
 msgid "Del"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextbuffer.cpp:8221 ../src/common/stockitem.cpp:152
-#: ../src/common/accelcmn.cpp:50 ../src/stc/stc_i18n.cpp:20
+#: ../src/common/stockitem.cpp:149 ../src/common/accelcmn.cpp:47
+#: ../src/richtext/richtextbuffer.cpp:8217 ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr ""
 
@@ -2635,78 +2640,78 @@ msgstr ""
 msgid "Delete A&ll"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11341
+#: ../src/richtext/richtextbuffer.cpp:11340
 msgid "Delete Column"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11291
+#: ../src/richtext/richtextbuffer.cpp:11290
 msgid "Delete Row"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 msgid "Delete Style"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:1345 ../src/richtext/richtextctrl.cpp:1584
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
 msgid "Delete Text"
 msgstr ""
 
-#: ../src/generic/editlbox.cpp:170
+#: ../src/generic/editlbox.cpp:147
 msgid "Delete item"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:260
+#: ../src/common/stockitem.cpp:257
 msgid "Delete selection"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 #, c-format
 msgid "Delete style %s?"
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:301
+#: ../src/unix/snglinst.cpp:298
 #, c-format
 msgid "Deleted stale lock file '%s'."
 msgstr ""
 
-#: ../src/common/secretstore.cpp:220
+#: ../src/common/secretstore.cpp:234
 #, c-format
-msgid "Deleting password for \"%s/%s\" failed: %s."
+msgid "Deleting password for \"%s\" failed: %s."
 msgstr ""
 
-#: ../src/common/module.cpp:124
+#: ../src/common/module.cpp:121
 #, c-format
 msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "Descending"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:526 ../src/propgrid/advprops.cpp:882
+#: ../src/generic/dirctrlg.cpp:492 ../src/propgrid/advprops.cpp:783
 msgid "Desktop"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:70
+#: ../src/generic/aboutdlgg.cpp:67
 msgid "Developed by "
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:176
+#: ../src/generic/aboutdlgg.cpp:173
 msgid "Developers"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:374
+#: ../src/msw/dialup.cpp:368
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
 msgstr ""
 
-#: ../src/generic/tipdlg.cpp:211
+#: ../src/generic/tipdlg.cpp:208
 msgid "Did you know..."
 msgstr ""
 
-#: ../src/dfb/wrapdfb.cpp:63
+#: ../src/dfb/wrapdfb.cpp:60
 #, c-format
 msgid "DirectFB error %d occurred."
 msgstr ""
@@ -2715,73 +2720,73 @@ msgstr ""
 msgid "Directories"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1183
+#: ../src/common/filefn.cpp:1071
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1197
+#: ../src/common/filefn.cpp:1085
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr ""
 
-#: ../src/generic/dirdlgg.cpp:204
+#: ../src/generic/dirdlgg.cpp:201
 msgid "Directory does not exist"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:1399
+#: ../src/generic/filectrlg.cpp:1388
 msgid "Directory doesn't exist."
 msgstr ""
 
-#: ../src/common/docview.cpp:457
+#: ../src/common/docview.cpp:450
 msgid "Discard changes and reload the last saved version?"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:502
+#: ../src/html/helpwnd.cpp:500
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:679
+#: ../src/html/helpwnd.cpp:677
 msgid "Display options dialog"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:322
+#: ../src/html/helpwnd.cpp:320
 msgid "Displays help as you browse the books on the left."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:85
+#: ../src/common/accelcmn.cpp:83
 msgid "Divide"
 msgstr ""
 
-#: ../src/common/docview.cpp:533
+#: ../src/common/docview.cpp:526
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:542
+#: ../src/common/prntbase.cpp:537
 msgid "Document:"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:73
+#: ../src/generic/aboutdlgg.cpp:70
 msgid "Documentation by "
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:180
+#: ../src/generic/aboutdlgg.cpp:177
 msgid "Documentation writers"
 msgstr ""
 
-#: ../src/common/sizer.cpp:2799
+#: ../src/common/sizer.cpp:2916
 msgid "Don't Save"
 msgstr ""
 
-#: ../src/html/htmlwin.cpp:633
+#: ../src/html/htmlwin.cpp:643
 msgid "Done"
 msgstr ""
 
-#: ../src/generic/progdlgg.cpp:448 ../src/msw/progdlg.cpp:407
+#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
 msgid "Done."
 msgstr ""
 
@@ -2793,42 +2798,42 @@ msgstr ""
 msgid "Double"
 msgstr ""
 
-#: ../src/common/paper.cpp:176
+#: ../src/common/paper.cpp:173
 msgid "Double Japanese Postcard Rotated 148 x 200 mm"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:273
+#: ../src/common/xtixml.cpp:269
 #, c-format
 msgid "Doubly used id : %d"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:153
-#: ../src/common/accelcmn.cpp:64
+#: ../src/common/stockitem.cpp:150 ../src/common/accelcmn.cpp:61
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Down"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:865
+#: ../src/richtext/richtextctrl.cpp:864
 msgid "Drag"
 msgstr ""
 
-#: ../src/common/paper.cpp:100
+#: ../src/common/paper.cpp:97
 msgid "E sheet, 34 x 44 in"
 msgstr ""
 
-#: ../src/unix/fswatcher_inotify.cpp:561
+#: ../src/unix/fswatcher_inotify.cpp:558
 msgid "EOF while reading from inotify descriptor"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "Edit"
 msgstr ""
 
-#: ../src/generic/editlbox.cpp:168
+#: ../src/generic/editlbox.cpp:131
 msgid "Edit item"
 msgstr ""
 
-#: ../include/wx/generic/progdlgg.h:84
+#: ../include/wx/generic/progdlgg.h:85
 msgid "Elapsed time:"
 msgstr ""
 
@@ -2895,61 +2900,61 @@ msgid "Enables the shadow spread."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:66
+#: ../src/common/accelcmn.cpp:63
 msgid "End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:55
+#: ../src/common/accelcmn.cpp:52
 msgid "Enter"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:934
+#: ../src/richtext/richtextstyledlg.cpp:930
 msgid "Enter a box style name"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:602
 msgid "Enter a character style name"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:816
 msgid "Enter a list style name"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:893
+#: ../src/richtext/richtextstyledlg.cpp:889
 msgid "Enter a new style name"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:650
 msgid "Enter a paragraph style name"
 msgstr ""
 
-#: ../src/generic/dbgrptg.cpp:174
+#: ../src/generic/dbgrptg.cpp:171
 #, c-format
 msgid "Enter command to open file \"%s\":"
 msgstr ""
 
-#: ../src/generic/helpext.cpp:459
+#: ../src/generic/helpext.cpp:457
 msgid "Entries found"
 msgstr ""
 
-#: ../src/common/paper.cpp:142
+#: ../src/common/paper.cpp:139
 msgid "Envelope Invite 220 x 220 mm"
 msgstr ""
 
-#: ../src/common/config.cpp:469
+#: ../src/common/config.cpp:465
 #, c-format
 msgid ""
 "Environment variables expansion failed: missing '%c' at position %u in '%s'."
 msgstr ""
 
-#: ../src/generic/filedlgg.cpp:357 ../src/generic/dirctrlg.cpp:570
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/dirctrlg.cpp:599
-#: ../src/generic/dirdlgg.cpp:323 ../src/generic/filectrlg.cpp:642
-#: ../src/generic/filectrlg.cpp:756 ../src/generic/filectrlg.cpp:770
-#: ../src/generic/filectrlg.cpp:786 ../src/generic/filectrlg.cpp:1368
-#: ../src/generic/filectrlg.cpp:1399 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/gtk1/fontdlg.cpp:74 ../src/generic/dirctrlg.cpp:536
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/dirctrlg.cpp:565
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1357 ../src/generic/filectrlg.cpp:1388
+#: ../src/generic/filedlgg.cpp:354 ../src/generic/dirdlgg.cpp:320
+#: ../src/gtk/filedlg.cpp:74
 msgid "Error"
 msgstr ""
 
@@ -2957,111 +2962,127 @@ msgstr ""
 msgid "Error closing epoll descriptor"
 msgstr ""
 
-#: ../src/unix/fswatcher_kqueue.cpp:114
+#: ../src/unix/fswatcher_kqueue.cpp:131
 msgid "Error closing kqueue instance"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1049
+#: ../src/common/filefn.cpp:938
 #, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr ""
 
-#: ../src/generic/dirdlgg.cpp:222
+#: ../src/generic/dirdlgg.cpp:219
 msgid "Error creating directory"
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1181
+#: ../src/common/imagbmp.cpp:1193
 msgid "Error in reading image DIB."
 msgstr ""
 
-#: ../src/propgrid/propgrid.cpp:6696
+#: ../src/propgrid/propgrid.cpp:6665
 #, c-format
 msgid "Error in resource: %s"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:422
+#: ../src/common/fileconf.cpp:421
 msgid "Error reading config options."
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1057 ../src/msw/webview_edge.cpp:850
+#: ../src/gtk/webview_webkit2.cpp:1262 ../src/osx/webview_webkit.mm:383
+#, c-format
+msgid "Error running JavaScript: %s"
 msgstr ""
 
 #: ../src/common/fileconf.cpp:1029
 msgid "Error saving user configuration data."
 msgstr ""
 
-#: ../src/gtk/print.cpp:722
+#: ../src/gtk/print.cpp:720
 msgid "Error while printing: "
 msgstr ""
 
-#: ../src/common/log.cpp:219
+#: ../src/common/log.cpp:237
 msgid "Error: "
 msgstr ""
 
+#: ../src/common/webrequest.cpp:98
+#, c-format
+msgid "Error: %s (%d)"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:69
+#: ../src/common/accelcmn.cpp:66
 msgid "Esc"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:70
+#: ../src/common/accelcmn.cpp:67
 msgid "Escape"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:150
+#: ../src/common/fmapbase.cpp:147
 msgid "Esperanto (ISO-8859-3)"
 msgstr ""
 
-#: ../include/wx/generic/progdlgg.h:85
+#: ../include/wx/generic/progdlgg.h:86
 msgid "Estimated time:"
 msgstr ""
 
-#: ../src/generic/dbgrptg.cpp:234
+#: ../src/generic/dbgrptg.cpp:231
 msgid "Executable files (*.exe)|*.exe|"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:155 ../src/common/accelcmn.cpp:78
+#: ../src/common/stockitem.cpp:152 ../src/common/accelcmn.cpp:75
 msgid "Execute"
 msgstr ""
 
-#: ../src/msw/utilsexc.cpp:876
+#: ../src/msw/utilsexc.cpp:873
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr ""
 
-#: ../src/common/paper.cpp:105
+#: ../src/common/paper.cpp:102
 msgid "Executive, 7 1/4 x 10 1/2 in"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6009
+#: ../src/generic/datavgen.cpp:6814
 msgid "Expand"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1240
+#: ../src/msw/registry.cpp:1228
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:195
+#: ../src/common/fmapbase.cpp:192
 msgid "Extended Unix Codepage for Japanese (EUC-JP)"
 msgstr ""
 
-#: ../src/html/chm.cpp:725
+#: ../src/html/chm.cpp:718
 #, c-format
 msgid "Extraction of '%s' into '%s' failed."
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:249 ../src/common/accelcmn.cpp:344
+#: ../src/common/accelcmn.cpp:259 ../src/common/accelcmn.cpp:358
 msgid "F"
 msgstr ""
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:672
+#: ../src/propgrid/advprops.cpp:582
 msgid "Face Name"
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:269
+#: ../src/unix/snglinst.cpp:266
 msgid "Failed to access lock file."
+msgstr ""
+
+#: ../src/gtk/font.cpp:572
+#, c-format
+msgid "Failed to add custom font \"%s\"."
 msgstr ""
 
 #: ../src/unix/epolldispatcher.cpp:116
@@ -3069,120 +3090,123 @@ msgstr ""
 msgid "Failed to add descriptor %d to epoll descriptor %d"
 msgstr ""
 
-#: ../src/msw/dib.cpp:489
+#: ../src/msw/dib.cpp:535
 #, c-format
 msgid "Failed to allocate %luKb of memory for bitmap data."
 msgstr ""
 
-#: ../src/common/glcmn.cpp:115
+#: ../src/common/glcmn.cpp:112
 msgid "Failed to allocate colour for OpenGL"
 msgstr ""
 
-#: ../src/unix/displayx11.cpp:236
+#: ../src/common/lzmastream.cpp:231
+msgid "Failed to allocate memory for LZMA compression."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:121
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr ""
+
+#: ../include/wx/unix/private/displayx11.h:89
 msgid "Failed to change video mode"
 msgstr ""
 
-#: ../src/common/image.cpp:3277
+#: ../src/common/image.cpp:3396
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:239
+#: ../src/common/debugrpt.cpp:240
 #, c-format
 msgid "Failed to clean up debug report directory \"%s\""
 msgstr ""
 
-#: ../src/common/filename.cpp:192
+#: ../src/common/filename.cpp:189
 msgid "Failed to close file handle"
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:340
+#: ../src/unix/snglinst.cpp:337
 #, c-format
 msgid "Failed to close lock file '%s'"
 msgstr ""
 
-#: ../src/msw/clipbrd.cpp:112
+#: ../src/msw/clipbrd.cpp:110
 msgid "Failed to close the clipboard."
 msgstr ""
 
-#: ../src/x11/utils.cpp:208
+#: ../src/x11/utils.cpp:170
 #, c-format
 msgid "Failed to close the display \"%s\""
 msgstr ""
 
-#: ../src/msw/dialup.cpp:797
+#: ../src/msw/dialup.cpp:791
 msgid "Failed to connect: missing username/password."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:743
+#: ../src/msw/dialup.cpp:737
 msgid "Failed to connect: no ISP to dial."
 msgstr ""
 
-#: ../src/common/textfile.cpp:203
-#, c-format
-msgid "Failed to convert file \"%s\" to Unicode."
-msgstr ""
-
-#: ../src/generic/logg.cpp:956
+#: ../src/generic/logg.cpp:953
 msgid "Failed to copy dialog contents to the clipboard."
 msgstr ""
 
-#: ../src/msw/registry.cpp:692
+#: ../src/msw/registry.cpp:681
 #, c-format
 msgid "Failed to copy registry value '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:701
+#: ../src/msw/registry.cpp:690
 #, c-format
 msgid "Failed to copy the contents of registry key '%s' to '%s'."
 msgstr ""
 
-#: ../src/common/filefn.cpp:1015
+#: ../src/common/filefn.cpp:904
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:679
+#: ../src/msw/registry.cpp:668
 #, c-format
 msgid "Failed to copy the registry subkey '%s' to '%s'."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1070
+#: ../src/msw/dde.cpp:1134
 msgid "Failed to create DDE string"
 msgstr ""
 
-#: ../src/msw/mdi.cpp:616
+#: ../src/msw/mdi.cpp:621
 msgid "Failed to create MDI parent frame."
 msgstr ""
 
-#: ../src/common/filename.cpp:1027
+#: ../src/common/filename.cpp:1024
 msgid "Failed to create a temporary file name"
 msgstr ""
 
-#: ../src/msw/utilsexc.cpp:228
+#: ../src/msw/utilsexc.cpp:225
 msgid "Failed to create an anonymous pipe"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:522
+#: ../src/msw/ole/automtn.cpp:513
 #, c-format
 msgid "Failed to create an instance of \"%s\""
 msgstr ""
 
-#: ../src/msw/dde.cpp:437
+#: ../src/msw/dde.cpp:432
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr ""
 
-#: ../src/msw/cursor.cpp:204
+#: ../src/msw/cursor.cpp:195
 msgid "Failed to create cursor."
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:209
+#: ../src/common/debugrpt.cpp:210
 #, c-format
 msgid "Failed to create directory \"%s\""
 msgstr ""
 
-#: ../src/generic/dirdlgg.cpp:220
+#: ../src/generic/dirdlgg.cpp:217
 #, c-format
 msgid ""
 "Failed to create directory '%s'\n"
@@ -3193,184 +3217,202 @@ msgstr ""
 msgid "Failed to create epoll descriptor"
 msgstr ""
 
-#: ../src/msw/mimetype.cpp:238
+#: ../src/gtk/font.cpp:562
+msgid "Failed to create font configuration object."
+msgstr ""
+
+#: ../src/msw/mimetype.cpp:235
 #, c-format
 msgid "Failed to create registry entry for '%s' files."
 msgstr ""
 
-#: ../src/msw/fdrepdlg.cpp:409
+#: ../src/msw/fdrepdlg.cpp:408
 #, c-format
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr ""
 
-#: ../src/unix/wakeuppipe.cpp:52
+#: ../src/unix/wakeuppipe.cpp:49
 msgid "Failed to create wake up pipe used by event loop."
 msgstr ""
 
-#: ../src/html/winpars.cpp:730
+#: ../src/html/winpars.cpp:727
 #, c-format
 msgid "Failed to display HTML document in %s encoding"
 msgstr ""
 
-#: ../src/msw/clipbrd.cpp:124
+#: ../src/msw/clipbrd.cpp:122
 msgid "Failed to empty the clipboard."
 msgstr ""
 
-#: ../src/unix/displayx11.cpp:212
+#: ../include/wx/unix/private/displayx11.h:65
 msgid "Failed to enumerate video modes"
 msgstr ""
 
-#: ../src/msw/dde.cpp:722
+#: ../src/msw/dde.cpp:717
 msgid "Failed to establish an advise loop with DDE server"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:629 ../src/msw/dialup.cpp:863
+#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:611
+#: ../src/unix/utilsunx.cpp:613
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:720
+#: ../src/common/debugrpt.cpp:730
 msgid "Failed to execute curl, please install it in PATH."
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:505
+#: ../src/msw/ole/automtn.cpp:496
 #, c-format
 msgid "Failed to find CLSID of \"%s\""
 msgstr ""
 
-#: ../src/common/regex.cpp:431 ../src/common/regex.cpp:479
+#: ../src/common/regex.cpp:428 ../src/common/regex.cpp:476
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:695
+#: ../src/msw/webview_ie.cpp:978
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:689
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:574
+#: ../src/msw/ole/automtn.cpp:565
 #, c-format
 msgid "Failed to get OLE automation interface for \"%s\""
 msgstr ""
 
-#: ../src/msw/clipbrd.cpp:711
+#: ../src/msw/clipbrd.cpp:731
 msgid "Failed to get data from the clipboard"
 msgstr ""
 
-#: ../src/common/time.cpp:223
+#: ../src/common/time.cpp:216
 msgid "Failed to get the local system time"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1345
+#: ../src/common/filefn.cpp:1233
 msgid "Failed to get the working directory"
 msgstr ""
 
-#: ../src/univ/theme.cpp:114
+#: ../src/univ/theme.cpp:111
 msgid "Failed to initialize GUI: no built-in themes found."
 msgstr ""
 
-#: ../src/msw/helpchm.cpp:63
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:60
 msgid "Failed to initialize MS HTML Help."
 msgstr ""
 
-#: ../src/msw/glcanvas.cpp:1381
+#: ../src/msw/glcanvas.cpp:1391
 msgid "Failed to initialize OpenGL"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:858
+#: ../src/msw/dialup.cpp:852
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr ""
 
-#: ../src/gtk/textctrl.cpp:1128
+#: ../src/gtk/textctrl.cpp:1209
 msgid "Failed to insert text in the control."
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:241
+#: ../src/unix/snglinst.cpp:238
 #, c-format
 msgid "Failed to inspect the lock file '%s'"
 msgstr ""
 
-#: ../src/unix/appunix.cpp:182
+#: ../src/unix/appunix.cpp:179
 msgid "Failed to install signal handler"
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1167
+#: ../src/unix/threadpsx.cpp:1216
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
 msgstr ""
 
-#: ../src/msw/utils.cpp:629
+#: ../src/msw/utils.cpp:619
 #, c-format
 msgid "Failed to kill process %d"
 msgstr ""
 
-#: ../src/common/image.cpp:2500
+#: ../src/common/image.cpp:2595
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr ""
 
-#: ../src/common/image.cpp:2509
+#: ../src/common/image.cpp:2604
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr ""
 
-#: ../src/common/iconbndl.cpp:225
+#: ../src/common/iconbndl.cpp:224
 #, c-format
 msgid "Failed to load icons from resource '%s'."
 msgstr ""
 
-#: ../src/common/iconbndl.cpp:200
+#: ../src/common/iconbndl.cpp:198
 #, c-format
 msgid "Failed to load image %%d from file '%s'."
 msgstr ""
 
-#: ../src/common/iconbndl.cpp:208
+#: ../src/common/iconbndl.cpp:206
 #, c-format
 msgid "Failed to load image %d from stream."
 msgstr ""
 
-#: ../src/common/image.cpp:2587 ../src/common/image.cpp:2606
+#: ../src/common/image.cpp:2682 ../src/common/image.cpp:2701
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr ""
 
-#: ../src/msw/enhmeta.cpp:97
+#: ../src/msw/enhmeta.cpp:94
 #, c-format
 msgid "Failed to load metafile from file \"%s\"."
 msgstr ""
 
-#: ../src/msw/volume.cpp:327
+#: ../src/msw/volume.cpp:335
 msgid "Failed to load mpr.dll."
 msgstr ""
 
-#: ../src/msw/utils.cpp:953
+#: ../src/msw/utils.cpp:943
 #, c-format
 msgid "Failed to load resource \"%s\"."
 msgstr ""
 
-#: ../src/common/dynlib.cpp:92
+#: ../src/common/dynlib.cpp:86
 #, c-format
 msgid "Failed to load shared library '%s'"
 msgstr ""
 
-#: ../src/osx/core/sound.cpp:145
+#: ../src/osx/core/sound.cpp:143
 #, c-format
 msgid "Failed to load sound from \"%s\" (error %d)."
 msgstr ""
 
-#: ../src/msw/utils.cpp:960
+#: ../src/msw/utils.cpp:950
 #, c-format
 msgid "Failed to lock resource \"%s\"."
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:198
+#: ../src/unix/snglinst.cpp:195
 #, c-format
 msgid "Failed to lock the lock file '%s'"
 msgstr ""
@@ -3380,33 +3422,38 @@ msgstr ""
 msgid "Failed to modify descriptor %d in epoll descriptor %d"
 msgstr ""
 
-#: ../src/common/filename.cpp:2575
+#: ../src/common/filename.cpp:2658
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr ""
 
-#: ../src/common/selectdispatcher.cpp:258
+#: ../src/common/selectdispatcher.cpp:255
 msgid "Failed to monitor I/O channels"
 msgstr ""
 
-#: ../src/common/filename.cpp:175
+#: ../src/common/filename.cpp:172
 #, c-format
 msgid "Failed to open '%s' for reading"
 msgstr ""
 
-#: ../src/common/filename.cpp:180
+#: ../src/common/filename.cpp:177
 #, c-format
 msgid "Failed to open '%s' for writing"
 msgstr ""
 
-#: ../src/html/chm.cpp:141
+#: ../src/html/chm.cpp:138
 #, c-format
 msgid "Failed to open CHM archive '%s'."
 msgstr ""
 
-#: ../src/common/utilscmn.cpp:1126
+#: ../src/common/utilscmn.cpp:1140
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
+msgstr ""
+
+#: ../src/common/hyperlnkcmn.cpp:133
+#, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
 msgstr ""
 
 #: ../include/wx/msw/private/fswatcher.h:92
@@ -3414,208 +3461,225 @@ msgstr ""
 msgid "Failed to open directory \"%s\" for monitoring."
 msgstr ""
 
-#: ../src/x11/utils.cpp:227
+#: ../src/x11/utils.cpp:189
 #, c-format
 msgid "Failed to open display \"%s\"."
 msgstr ""
 
-#: ../src/common/filename.cpp:1062
+#: ../src/common/filename.cpp:1059
 msgid "Failed to open temporary file."
 msgstr ""
 
-#: ../src/msw/clipbrd.cpp:91
+#: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr ""
 
-#: ../src/common/translation.cpp:1184
+#: ../src/common/translation.cpp:1226
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr ""
 
-#: ../src/unix/mediactrl.cpp:1214
+#: ../src/unix/mediactrl.cpp:1239
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr ""
 
-#: ../src/msw/clipbrd.cpp:600
+#: ../src/msw/clipbrd.cpp:610
 msgid "Failed to put data on the clipboard"
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:278
+#: ../src/unix/snglinst.cpp:275
 msgid "Failed to read PID from lock file."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:433
+#: ../src/common/fileconf.cpp:432
 msgid "Failed to read config options."
 msgstr ""
 
-#: ../src/common/docview.cpp:681
+#: ../src/common/docview.cpp:676
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr ""
 
-#: ../src/dfb/evtloop.cpp:98
+#: ../src/dfb/evtloop.cpp:99
 msgid "Failed to read event from DirectFB pipe"
 msgstr ""
 
-#: ../src/unix/wakeuppipe.cpp:120
+#: ../src/unix/wakeuppipe.cpp:117
 msgid "Failed to read from wake-up pipe"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:679
+#: ../src/common/textfile.cpp:96
+#, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr ""
+
+#: ../src/unix/utilsunx.cpp:681
 msgid "Failed to redirect child process input/output"
 msgstr ""
 
-#: ../src/msw/utilsexc.cpp:701
+#: ../src/msw/utilsexc.cpp:698
 msgid "Failed to redirect the child process IO"
 msgstr ""
 
-#: ../src/msw/dde.cpp:288
+#: ../src/msw/dde.cpp:283
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr ""
 
-#: ../src/common/fontmap.cpp:245
+#: ../src/gtk/font.cpp:580
+msgid "Failed to register font configuration using private fonts."
+msgstr ""
+
+#: ../src/common/fontmap.cpp:242
 #, c-format
 msgid "Failed to remember the encoding for the charset '%s'."
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:227
+#: ../src/common/debugrpt.cpp:228
 #, c-format
 msgid "Failed to remove debug report file \"%s\""
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:328
+#: ../src/unix/snglinst.cpp:325
 #, c-format
 msgid "Failed to remove lock file '%s'"
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:288
+#: ../src/unix/snglinst.cpp:285
 #, c-format
 msgid "Failed to remove stale lock file '%s'."
 msgstr ""
 
-#: ../src/msw/registry.cpp:529
+#: ../src/msw/registry.cpp:518
 #, c-format
 msgid "Failed to rename registry value '%s' to '%s'."
 msgstr ""
 
-#: ../src/common/filefn.cpp:1122
+#: ../src/common/filefn.cpp:1011
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
 "exists."
 msgstr ""
 
-#: ../src/msw/registry.cpp:634
+#: ../src/msw/registry.cpp:623
 #, c-format
 msgid "Failed to rename the registry key '%s' to '%s'."
 msgstr ""
 
-#: ../src/common/filename.cpp:2671
+#: ../src/msw/webview_ie.cpp:995
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/common/filename.cpp:2754
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:468
+#: ../src/msw/dialup.cpp:462
 msgid "Failed to retrieve text of RAS error message"
 msgstr ""
 
-#: ../src/msw/clipbrd.cpp:748
+#: ../src/msw/clipbrd.cpp:768
 msgid "Failed to retrieve the supported clipboard formats"
 msgstr ""
 
-#: ../src/common/docview.cpp:652
+#: ../src/common/docview.cpp:647
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr ""
 
-#: ../src/msw/dib.cpp:269
+#: ../src/msw/dib.cpp:312
 #, c-format
 msgid "Failed to save the bitmap image to file \"%s\"."
 msgstr ""
 
-#: ../src/msw/dde.cpp:763
+#: ../src/msw/dde.cpp:811
 msgid "Failed to send DDE advise notification"
 msgstr ""
 
-#: ../src/common/ftp.cpp:402
+#: ../src/common/ftp.cpp:399
 #, c-format
 msgid "Failed to set FTP transfer mode to %s."
 msgstr ""
 
-#: ../src/msw/clipbrd.cpp:427
+#: ../src/msw/clipbrd.cpp:443
 msgid "Failed to set clipboard data."
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:181
+#: ../src/unix/snglinst.cpp:178
 #, c-format
 msgid "Failed to set permissions on lock file '%s'"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:668
+#: ../src/unix/utilsunx.cpp:670
 msgid "Failed to set process priority"
 msgstr ""
 
-#: ../src/common/file.cpp:559
+#: ../src/common/ffile.cpp:355 ../src/common/file.cpp:586
 msgid "Failed to set temporary file permissions"
 msgstr ""
 
-#: ../src/gtk/textctrl.cpp:1072
-msgid "Failed to set text in the text control."
-msgstr ""
-
-#: ../src/unix/threadpsx.cpp:1298
+#: ../src/unix/threadpsx.cpp:1347
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1424
+#: ../src/unix/threadpsx.cpp:1473
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:783
+#: ../src/unix/utilsunx.cpp:785
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 
-#: ../src/common/fs_mem.cpp:261
+#: ../src/msw/webview_ie.cpp:987
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:256
 #, c-format
 msgid "Failed to store image '%s' to memory VFS!"
 msgstr ""
 
-#: ../src/dfb/evtloop.cpp:170
+#: ../src/dfb/evtloop.cpp:171
 msgid "Failed to switch DirectFB pipe to non-blocking mode"
 msgstr ""
 
-#: ../src/unix/wakeuppipe.cpp:59
+#: ../src/unix/wakeuppipe.cpp:56
 msgid "Failed to switch wake up pipe to non-blocking mode"
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1605
+#: ../src/unix/threadpsx.cpp:1654
 msgid "Failed to terminate a thread."
 msgstr ""
 
-#: ../src/msw/dde.cpp:741
+#: ../src/msw/dde.cpp:736
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:938
+#: ../src/msw/dialup.cpp:932
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr ""
 
-#: ../src/common/filename.cpp:2590
+#: ../src/common/filename.cpp:2673
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:334
+#: ../src/unix/dlunix.cpp:90
+msgid "Failed to unload shared library"
+msgstr ""
+
+#: ../src/unix/snglinst.cpp:331
 #, c-format
 msgid "Failed to unlock lock file '%s'"
 msgstr ""
 
-#: ../src/msw/dde.cpp:309
+#: ../src/msw/dde.cpp:304
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr ""
@@ -3629,77 +3693,86 @@ msgstr ""
 msgid "Failed to update user configuration file."
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:733
+#: ../src/common/debugrpt.cpp:743
 #, c-format
 msgid "Failed to upload the debug report (error code %d)."
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:168
+#: ../src/unix/snglinst.cpp:165
 #, c-format
 msgid "Failed to write to lock file '%s'"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:209
+#: ../src/propgrid/propgrid.cpp:190
 msgid "False"
 msgstr ""
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:694
+#: ../src/propgrid/advprops.cpp:604
 msgid "Family"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/gtk/glcanvas.cpp:176 ../src/gtk/glcanvas.cpp:187
+#, fuzzy
+msgid "Fatal Error"
+msgstr "%s Error"
+
+#: ../src/common/stockitem.cpp:154
 msgid "File"
 msgstr ""
 
-#: ../src/common/docview.cpp:669
+#: ../src/common/docview.cpp:664
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr ""
 
-#: ../src/common/docview.cpp:646
+#: ../src/common/docview.cpp:641
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr ""
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1156
+#: ../src/common/filefn.cpp:1044
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1139
+#: ../src/common/filefn.cpp:1028
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:3081 ../src/common/textcmn.cpp:953
+#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
 msgid "File couldn't be loaded."
 msgstr ""
 
-#: ../src/msw/filedlg.cpp:393
+#: ../src/msw/filedlg.cpp:414
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr ""
 
-#: ../src/common/docview.cpp:1789
+#: ../src/common/docview.cpp:1783
 msgid "File error"
 msgstr ""
 
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/filectrlg.cpp:770
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/filectrlg.cpp:766
 msgid "File name exists already."
+msgstr ""
+
+#: ../src/osx/cocoa/filedlg.mm:264
+msgid "File type:"
 msgstr ""
 
 #: ../src/motif/filedlg.cpp:220
 msgid "Files"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1591
+#: ../src/common/filefn.cpp:1479
 #, c-format
 msgid "Files (%s)"
 msgstr ""
@@ -3708,15 +3781,27 @@ msgstr ""
 msgid "Filter"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:158 ../src/html/helpwnd.cpp:490
+#: ../src/html/helpwnd.cpp:488
 msgid "Find"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:259
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:258
+msgid "Find in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:155
+msgid "Find..."
+msgstr ""
+
+#: ../src/common/stockitem.cpp:156
 msgid "First"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:1548
+#: ../src/common/prntbase.cpp:1573
 msgid "First page"
 msgstr ""
 
@@ -3724,11 +3809,11 @@ msgstr ""
 msgid "Fixed"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1206
+#: ../src/html/helpwnd.cpp:1204
 msgid "Fixed font:"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1269
+#: ../src/html/helpwnd.cpp:1267
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr ""
 
@@ -3736,16 +3821,16 @@ msgstr ""
 msgid "Floating"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "Floppy"
 msgstr ""
 
-#: ../src/common/paper.cpp:111
+#: ../src/common/paper.cpp:108
 msgid "Folio, 8 1/2 x 13 in"
 msgstr ""
 
-#: ../src/richtext/richtextformatdlg.cpp:344 ../src/osx/carbon/fontdlg.cpp:287
-#: ../src/common/stockitem.cpp:194
+#: ../src/osx/carbon/fontdlg.cpp:284 ../src/common/stockitem.cpp:191
+#: ../src/richtext/richtextformatdlg.cpp:337
 msgid "Font"
 msgstr ""
 
@@ -3753,7 +3838,24 @@ msgstr ""
 msgid "Font &weight:"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1207
+#: ../src/osx/fontutil.cpp:89
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
+"\"."
+msgstr ""
+
+#: ../src/msw/font.cpp:1126
+#, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr ""
+
+#: ../src/osx/fontutil.cpp:81
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr ": فایل موجود نیست!"
+
+#: ../src/html/helpwnd.cpp:1205
 msgid "Font size:"
 msgstr ""
 
@@ -3761,75 +3863,75 @@ msgstr ""
 msgid "Font st&yle:"
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:329
+#: ../src/osx/carbon/fontdlg.cpp:326
 msgid "Font:"
 msgstr ""
 
-#: ../src/dfb/fontmgr.cpp:198
+#: ../src/dfb/fontmgr.cpp:195
 #, c-format
 msgid "Fonts index file %s disappeared while loading fonts."
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:645
+#: ../src/unix/utilsunx.cpp:647
 msgid "Fork failed"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "Forward"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:235
+#: ../src/common/xtixml.cpp:231
 msgid "Forward hrefs are not supported"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:875
+#: ../src/html/helpwnd.cpp:873
 #, c-format
 msgid "Found %i matches"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:238
+#: ../src/generic/prntdlgg.cpp:231
 msgid "From:"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1604
+#: ../src/propgrid/advprops.cpp:1510
 msgid "Fuchsia"
 msgstr ""
 
-#: ../src/common/imaggif.cpp:138
+#: ../src/common/imaggif.cpp:135
 msgid "GIF: data stream seems to be truncated."
 msgstr ""
 
-#: ../src/common/imaggif.cpp:128
+#: ../src/common/imaggif.cpp:125
 msgid "GIF: error in GIF image format."
 msgstr ""
 
-#: ../src/common/imaggif.cpp:133
+#: ../src/common/imaggif.cpp:130
 msgid "GIF: not enough memory."
 msgstr ""
 
-#: ../src/gtk/window.cpp:4631
+#: ../src/gtk/window.cpp:5635
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
 msgstr ""
 
-#: ../src/univ/themes/gtk.cpp:525
+#: ../src/univ/themes/gtk.cpp:522
 msgid "GTK+ theme"
 msgstr ""
 
-#: ../src/common/preferencescmn.cpp:40
+#: ../src/common/preferencescmn.cpp:37
 msgid "General"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:258
+#: ../src/common/prntbase.cpp:253
 msgid "Generic PostScript"
 msgstr ""
 
-#: ../src/common/paper.cpp:135
+#: ../src/common/paper.cpp:132
 msgid "German Legal Fanfold, 8 1/2 x 13 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:134
+#: ../src/common/paper.cpp:131
 msgid "German Std Fanfold, 8 1/2 x 12 in"
 msgstr ""
 
@@ -3845,48 +3947,48 @@ msgstr ""
 msgid "GetPropertyCollection called w/o valid collection getter"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:658
 msgid "Go back"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:661
+#: ../src/html/helpwnd.cpp:659
 msgid "Go forward"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:663
+#: ../src/html/helpwnd.cpp:661
 msgid "Go one level up in document hierarchy"
 msgstr ""
 
-#: ../src/generic/filedlgg.cpp:208 ../src/generic/dirdlgg.cpp:116
+#: ../src/generic/filedlgg.cpp:205 ../src/generic/dirdlgg.cpp:113
 msgid "Go to home directory"
 msgstr ""
 
-#: ../src/generic/filedlgg.cpp:205
+#: ../src/generic/filedlgg.cpp:202
 msgid "Go to parent directory"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:76
+#: ../src/generic/aboutdlgg.cpp:73
 msgid "Graphics art by "
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1599
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Gray"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:883
+#: ../src/propgrid/advprops.cpp:784
 msgid "GrayText"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:154
+#: ../src/common/fmapbase.cpp:151
 msgid "Greek (ISO-8859-7)"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1600
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Green"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:342
+#: ../src/generic/colrdlgg.cpp:362
 msgid "Green:"
 msgstr ""
 
@@ -3894,107 +3996,107 @@ msgstr ""
 msgid "Groove"
 msgstr ""
 
-#: ../src/common/zstream.cpp:158 ../src/common/zstream.cpp:318
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
 msgid "Gzip not supported by this version of zlib"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1549
+#: ../src/html/helpwnd.cpp:1547
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr ""
 
-#: ../src/html/htmlwin.cpp:681
+#: ../src/html/htmlwin.cpp:691
 #, c-format
 msgid "HTML anchor %s does not exist."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1547
+#: ../src/html/helpwnd.cpp:1545
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1759
+#: ../src/propgrid/advprops.cpp:1660
 msgid "Hand"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "Harddisk"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:155
+#: ../src/common/fmapbase.cpp:152
 msgid "Hebrew (ISO-8859-8)"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:280 ../src/osx/button_osx.cpp:39
-#: ../src/common/stockitem.cpp:163 ../src/common/accelcmn.cpp:80
-#: ../src/html/helpdlg.cpp:66 ../src/html/helpfrm.cpp:111
+#: ../include/wx/msgdlg.h:282 ../src/osx/button_osx.cpp:39
+#: ../src/common/stockitem.cpp:160 ../src/common/accelcmn.cpp:77
+#: ../src/html/helpfrm.cpp:108 ../src/html/helpdlg.cpp:63
 msgid "Help"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1200
+#: ../src/html/helpwnd.cpp:1198
 msgid "Help Browser Options"
 msgstr ""
 
-#: ../src/generic/helpext.cpp:454 ../src/generic/helpext.cpp:455
+#: ../src/generic/helpext.cpp:452 ../src/generic/helpext.cpp:453
 msgid "Help Index"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1529
 msgid "Help Printing"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:801
+#: ../src/html/helpwnd.cpp:799
 msgid "Help Topics"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1546
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr ""
 
-#: ../src/generic/helpext.cpp:267
+#: ../src/generic/helpext.cpp:265
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:275
+#: ../src/generic/helpext.cpp:273
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr ""
 
-#: ../src/html/helpctrl.cpp:63
+#: ../src/html/helpctrl.cpp:59
 #, c-format
 msgid "Help: %s"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:577
+#: ../src/osx/menu_osx.cpp:469
 #, c-format
 msgid "Hide %s"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:579
+#: ../src/osx/menu_osx.cpp:471
 msgid "Hide Others"
 msgstr ""
 
-#: ../src/generic/infobar.cpp:84
+#: ../src/generic/infobar.cpp:81
 msgid "Hide this notification message."
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:884
+#: ../src/propgrid/advprops.cpp:785
 msgid "Highlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:885
+#: ../src/propgrid/advprops.cpp:786
 msgid "HighlightText"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:164 ../src/common/accelcmn.cpp:65
+#: ../src/common/stockitem.cpp:161 ../src/common/accelcmn.cpp:62
 msgid "Home"
 msgstr ""
 
-#: ../src/generic/dirctrlg.cpp:524
+#: ../src/generic/dirctrlg.cpp:490
 msgid "Home directory"
 msgstr ""
 
@@ -4004,61 +4106,61 @@ msgid "How the object will float relative to the text."
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1760
+#: ../src/propgrid/advprops.cpp:1661
 msgid "I-Beam"
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1196
+#: ../src/common/imagbmp.cpp:1208
 msgid "ICO: Error in reading mask DIB."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1290 ../src/common/imagbmp.cpp:1390
-#: ../src/common/imagbmp.cpp:1405 ../src/common/imagbmp.cpp:1416
-#: ../src/common/imagbmp.cpp:1430 ../src/common/imagbmp.cpp:1478
-#: ../src/common/imagbmp.cpp:1493 ../src/common/imagbmp.cpp:1507
-#: ../src/common/imagbmp.cpp:1518
+#: ../src/common/imagbmp.cpp:1302 ../src/common/imagbmp.cpp:1402
+#: ../src/common/imagbmp.cpp:1417 ../src/common/imagbmp.cpp:1428
+#: ../src/common/imagbmp.cpp:1442 ../src/common/imagbmp.cpp:1490
+#: ../src/common/imagbmp.cpp:1505 ../src/common/imagbmp.cpp:1519
+#: ../src/common/imagbmp.cpp:1530
 msgid "ICO: Error writing the image file!"
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1255
+#: ../src/common/imagbmp.cpp:1267
 msgid "ICO: Image too tall for an icon."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1263
+#: ../src/common/imagbmp.cpp:1275
 msgid "ICO: Image too wide for an icon."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1603
+#: ../src/common/imagbmp.cpp:1615
 msgid "ICO: Invalid icon index."
 msgstr ""
 
-#: ../src/common/imagiff.cpp:758
+#: ../src/common/imagiff.cpp:755
 msgid "IFF: data stream seems to be truncated."
 msgstr ""
 
-#: ../src/common/imagiff.cpp:742
+#: ../src/common/imagiff.cpp:739
 msgid "IFF: error in IFF image format."
 msgstr ""
 
-#: ../src/common/imagiff.cpp:745
+#: ../src/common/imagiff.cpp:742
 msgid "IFF: not enough memory."
 msgstr ""
 
-#: ../src/common/imagiff.cpp:748
+#: ../src/common/imagiff.cpp:745
 msgid "IFF: unknown error!!!"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:197
+#: ../src/common/fmapbase.cpp:194
 msgid "ISO-2022-JP"
 msgstr ""
 
-#: ../src/html/htmprint.cpp:282
+#: ../src/html/htmprint.cpp:294
 msgid ""
 "If possible, try changing the layout parameters to make the printout more "
 "narrow."
 msgstr ""
 
-#: ../src/generic/dbgrptg.cpp:358
+#: ../src/generic/dbgrptg.cpp:362
 msgid ""
 "If you have any additional information pertaining to this bug\n"
 "report, please enter it here and it will be joined to it:"
@@ -4072,145 +4174,149 @@ msgid ""
 "at all possible please do continue with the report generation.\n"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1405
+#: ../src/common/zipstrm.cpp:1043
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1393
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:295
+#: ../src/common/xtistrm.cpp:292
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr ""
 
-#: ../src/common/xti.cpp:513
+#: ../src/common/xti.cpp:510
 msgid "Illegal Parameter Count for ConstructObject Method"
 msgstr ""
 
-#: ../src/common/xti.cpp:501
+#: ../src/common/xti.cpp:498
 msgid "Illegal Parameter Count for Create Method"
 msgstr ""
 
-#: ../src/generic/dirctrlg.cpp:570 ../src/generic/filectrlg.cpp:756
+#: ../src/generic/dirctrlg.cpp:536 ../src/generic/filectrlg.cpp:752
 msgid "Illegal directory name."
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:1367
+#: ../src/generic/filectrlg.cpp:1356
 msgid "Illegal file specification."
 msgstr ""
 
-#: ../src/common/image.cpp:2269
+#: ../src/common/image.cpp:2363
 msgid "Image and mask have different sizes."
 msgstr ""
 
-#: ../src/common/image.cpp:2746
+#: ../src/common/image.cpp:2841
 #, c-format
 msgid "Image file is not of type %d."
 msgstr ""
 
-#: ../src/common/image.cpp:2877
+#: ../src/common/image.cpp:2995
 #, c-format
 msgid "Image is not of type %s."
 msgstr ""
 
-#: ../src/msw/textctrl.cpp:488
+#: ../src/msw/textctrl.cpp:534
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:301
+#: ../src/unix/utilsunx.cpp:303
 msgid "Impossible to get child process input"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1028
+#: ../src/common/filefn.cpp:917
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1042
+#: ../src/common/filefn.cpp:931
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1097
+#: ../src/common/filefn.cpp:986
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:886
+#: ../src/propgrid/advprops.cpp:787
 msgid "InactiveBorder"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:887
+#: ../src/propgrid/advprops.cpp:788
 msgid "InactiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:888
+#: ../src/propgrid/advprops.cpp:789
 msgid "InactiveCaptionText"
 msgstr ""
 
-#: ../src/common/gifdecod.cpp:792
+#: ../src/common/gifdecod.cpp:826
 #, c-format
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:635
+#: ../src/msw/ole/automtn.cpp:626
 msgid "Incorrect number of arguments."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:165
+#: ../src/common/stockitem.cpp:162
 msgid "Indent"
 msgstr ""
 
-#: ../src/richtext/richtextformatdlg.cpp:349
+#: ../src/richtext/richtextformatdlg.cpp:342
 msgid "Indents && Spacing"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:166 ../src/html/helpwnd.cpp:515
+#: ../src/common/stockitem.cpp:163 ../src/html/helpwnd.cpp:513
 msgid "Index"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:159
+#: ../src/common/fmapbase.cpp:156
 msgid "Indian (ISO-8859-12)"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "Info"
 msgstr ""
 
-#: ../src/common/init.cpp:287
+#: ../src/common/init.cpp:284
 msgid "Initialization failed in post init, aborting."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:54
+#: ../src/common/accelcmn.cpp:51
 msgid "Ins"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextsymboldlg.cpp:472 ../src/common/accelcmn.cpp:53
+#: ../src/common/accelcmn.cpp:50 ../src/richtext/richtextsymboldlg.cpp:469
 msgid "Insert"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:8067
+#: ../src/richtext/richtextbuffer.cpp:8063
 msgid "Insert Field"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:7978
-#: ../src/richtext/richtextbuffer.cpp:8936
+#: ../src/richtext/richtextbuffer.cpp:7974
+#: ../src/richtext/richtextbuffer.cpp:8934
 msgid "Insert Image"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:8025
+#: ../src/richtext/richtextbuffer.cpp:8021
 msgid "Insert Object"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:1286 ../src/richtext/richtextctrl.cpp:1494
-#: ../src/richtext/richtextbuffer.cpp:7822
-#: ../src/richtext/richtextbuffer.cpp:7852
-#: ../src/richtext/richtextbuffer.cpp:7894
+#: ../src/richtext/richtextbuffer.cpp:7818
+#: ../src/richtext/richtextbuffer.cpp:7848
+#: ../src/richtext/richtextbuffer.cpp:7890
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
 msgid "Insert Text"
 msgstr ""
 
@@ -4223,16 +4329,11 @@ msgstr ""
 msgid "Inset"
 msgstr ""
 
-#: ../src/gtk/app.cpp:425
-#, c-format
-msgid "Invalid GTK+ command line option, use \"%s --help\""
-msgstr ""
-
-#: ../src/common/imagtiff.cpp:311
+#: ../src/common/imagtiff.cpp:308
 msgid "Invalid TIFF image index."
 msgstr ""
 
-#: ../src/common/appcmn.cpp:273
+#: ../src/common/appcmn.cpp:294
 #, c-format
 msgid "Invalid display mode specification '%s'."
 msgstr ""
@@ -4242,246 +4343,250 @@ msgstr ""
 msgid "Invalid geometry specification '%s'"
 msgstr ""
 
-#: ../src/unix/fswatcher_inotify.cpp:323
+#: ../src/unix/fswatcher_inotify.cpp:320
 #, c-format
 msgid "Invalid inotify event for \"%s\""
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:312
+#: ../src/unix/snglinst.cpp:309
 #, c-format
 msgid "Invalid lock file '%s'."
 msgstr ""
 
-#: ../src/common/translation.cpp:1125
+#: ../src/common/translation.cpp:1167
 msgid "Invalid message catalog."
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:405 ../src/common/xtistrm.cpp:420
+#: ../src/common/xtistrm.cpp:402 ../src/common/xtistrm.cpp:417
 msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:435
+#: ../src/common/xtistrm.cpp:432
 msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
 msgstr ""
 
-#: ../src/common/regex.cpp:310
+#: ../src/common/regex.cpp:307
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr ""
 
-#: ../src/common/config.cpp:226
+#: ../src/common/config.cpp:222
 #, c-format
 msgid "Invalid value %ld for a boolean key \"%s\" in config file."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:351
-#: ../src/osx/carbon/fontdlg.cpp:361 ../src/common/stockitem.cpp:168
+#: ../src/osx/carbon/fontdlg.cpp:358 ../src/common/stockitem.cpp:165
+#: ../src/generic/fontdlgg.cpp:325 ../src/richtext/richtextfontpage.cpp:351
 msgid "Italic"
 msgstr ""
 
-#: ../src/common/paper.cpp:130
+#: ../src/common/paper.cpp:127
 msgid "Italy Envelope, 110 x 230 mm"
 msgstr ""
 
-#: ../src/common/imagjpeg.cpp:270
+#: ../src/common/imagjpeg.cpp:257
 msgid "JPEG: Couldn't load - file is probably corrupted."
 msgstr ""
 
-#: ../src/common/imagjpeg.cpp:449
+#: ../src/common/imagjpeg.cpp:436
 msgid "JPEG: Couldn't save image."
 msgstr ""
 
-#: ../src/common/paper.cpp:163
+#: ../src/common/paper.cpp:160
 msgid "Japanese Double Postcard 200 x 148 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:167
+#: ../src/common/paper.cpp:164
 msgid "Japanese Envelope Chou #3"
 msgstr ""
 
-#: ../src/common/paper.cpp:180
+#: ../src/common/paper.cpp:177
 msgid "Japanese Envelope Chou #3 Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:168
+#: ../src/common/paper.cpp:165
 msgid "Japanese Envelope Chou #4"
 msgstr ""
 
-#: ../src/common/paper.cpp:181
+#: ../src/common/paper.cpp:178
 msgid "Japanese Envelope Chou #4 Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:165
+#: ../src/common/paper.cpp:162
 msgid "Japanese Envelope Kaku #2"
 msgstr ""
 
-#: ../src/common/paper.cpp:178
+#: ../src/common/paper.cpp:175
 msgid "Japanese Envelope Kaku #2 Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:166
+#: ../src/common/paper.cpp:163
 msgid "Japanese Envelope Kaku #3"
 msgstr ""
 
-#: ../src/common/paper.cpp:179
+#: ../src/common/paper.cpp:176
 msgid "Japanese Envelope Kaku #3 Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:185
+#: ../src/common/paper.cpp:182
 msgid "Japanese Envelope You #4"
 msgstr ""
 
-#: ../src/common/paper.cpp:186
+#: ../src/common/paper.cpp:183
 msgid "Japanese Envelope You #4 Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:138
+#: ../src/common/paper.cpp:135
 msgid "Japanese Postcard 100 x 148 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:175
+#: ../src/common/paper.cpp:172
 msgid "Japanese Postcard Rotated 148 x 100 mm"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "Jump to"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:171
+#: ../src/common/stockitem.cpp:168
 msgid "Justified"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:155
-#: ../src/richtext/richtextindentspage.cpp:157
 #: ../src/richtext/richtextliststylepage.cpp:344
 #: ../src/richtext/richtextliststylepage.cpp:346
+#: ../src/richtext/richtextindentspage.cpp:155
+#: ../src/richtext/richtextindentspage.cpp:157
 msgid "Justify text left and right."
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:163
+#: ../src/common/fmapbase.cpp:160
 msgid "KOI8-R"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:164
+#: ../src/common/fmapbase.cpp:161
 msgid "KOI8-U"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:265 ../src/common/accelcmn.cpp:347
+#: ../src/common/accelcmn.cpp:279 ../src/common/accelcmn.cpp:364
 msgid "KP_"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "KP_Add"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "KP_Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "KP_Decimal"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 msgid "KP_Delete"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "KP_Divide"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 msgid "KP_Down"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "KP_End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "KP_Enter"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "KP_Equal"
 msgstr ""
 
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
-msgid "KP_Home"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
-msgid "KP_Insert"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
-msgid "KP_Left"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
-msgid "KP_Multiply"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:99
-msgid "KP_Next"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
-msgid "KP_PageDown"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
-msgid "KP_PageUp"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:98
-msgid "KP_Prior"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
-msgid "KP_Right"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
-msgid "KP_Separator"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
-msgid "KP_Space"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
-msgid "KP_Subtract"
+#: ../src/common/accelcmn.cpp:276 ../src/common/accelcmn.cpp:361
+msgid "KP_F"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
 #: ../src/common/accelcmn.cpp:89
+msgid "KP_Home"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:100
+msgid "KP_Insert"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:90
+msgid "KP_Left"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:103
+msgid "KP_Multiply"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:97
+msgid "KP_Next"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:95
+msgid "KP_PageDown"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:94
+msgid "KP_PageUp"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:96
+msgid "KP_Prior"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:92
+msgid "KP_Right"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:105
+msgid "KP_Separator"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:86
+msgid "KP_Space"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:106
+msgid "KP_Subtract"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:87
 msgid "KP_Tab"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "KP_Up"
 msgstr ""
 
@@ -4489,112 +4594,127 @@ msgstr ""
 msgid "L&ine spacing:"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:613 ../src/generic/prntdlgg.cpp:868
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:280
+#, c-format
+msgid "LZMA compression error: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:196
+#, c-format
+msgid "LZMA decompression error: %s"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:861
 msgid "Landscape"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "Last"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:1572
+#: ../src/common/prntbase.cpp:1597
 msgid "Last page"
 msgstr ""
 
-#: ../src/common/log.cpp:305
+#: ../src/common/log.cpp:324
 #, c-format
 msgid "Last repeated message (\"%s\", %u time) wasn't output"
 msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/common/paper.cpp:103
+#: ../src/common/paper.cpp:100
 msgid "Ledger, 17 x 11 in"
 msgstr ""
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6146
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:58 ../src/generic/datavgen.cpp:6951
+#: ../src/richtext/richtextsizepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:252
 #: ../src/richtext/richtextliststylepage.cpp:253
 #: ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
-#: ../src/richtext/richtextsizepage.cpp:249 ../src/common/accelcmn.cpp:61
 msgid "Left"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:204
 #: ../src/richtext/richtextliststylepage.cpp:390
+#: ../src/richtext/richtextindentspage.cpp:204
 msgid "Left (&first line):"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1761
+#: ../src/propgrid/advprops.cpp:1662
 msgid "Left Button"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:880
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Left margin (mm):"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:141
-#: ../src/richtext/richtextindentspage.cpp:143
 #: ../src/richtext/richtextliststylepage.cpp:330
 #: ../src/richtext/richtextliststylepage.cpp:332
+#: ../src/richtext/richtextindentspage.cpp:141
+#: ../src/richtext/richtextindentspage.cpp:143
 msgid "Left-align text."
 msgstr ""
 
-#: ../src/common/paper.cpp:144
+#: ../src/common/paper.cpp:141
 msgid "Legal Extra 9 1/2 x 15 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:96
+#: ../src/common/paper.cpp:93
 msgid "Legal, 8 1/2 x 14 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:143
+#: ../src/common/paper.cpp:140
 msgid "Letter Extra 9 1/2 x 12 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:149
+#: ../src/common/paper.cpp:146
 msgid "Letter Extra Transverse 9.275 x 12 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:152
+#: ../src/common/paper.cpp:149
 msgid "Letter Plus 8 1/2 x 12.69 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:169
+#: ../src/common/paper.cpp:166
 msgid "Letter Rotated 11 x 8 1/2 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:101
+#: ../src/common/paper.cpp:98
 msgid "Letter Small, 8 1/2 x 11 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:147
+#: ../src/common/paper.cpp:144
 msgid "Letter Transverse 8 1/2 x 11 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:95
+#: ../src/common/paper.cpp:92
 msgid "Letter, 8 1/2 x 11 in"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "License"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:332
+#: ../src/generic/fontdlgg.cpp:328
 msgid "Light"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1608
+#: ../src/propgrid/advprops.cpp:1514
 msgid "Lime"
 msgstr ""
 
-#: ../src/generic/helpext.cpp:294
+#: ../src/generic/helpext.cpp:292
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr ""
@@ -4603,15 +4723,15 @@ msgstr ""
 msgid "Line spacing:"
 msgstr ""
 
-#: ../src/html/chm.cpp:838
+#: ../src/html/chm.cpp:829
 msgid "Link contained '//', converted to absolute link."
 msgstr ""
 
-#: ../src/richtext/richtextformatdlg.cpp:364
+#: ../src/richtext/richtextformatdlg.cpp:357
 msgid "List Style"
 msgstr ""
 
-#: ../src/richtext/richtextstyles.cpp:1064
+#: ../src/richtext/richtextstyles.cpp:1061
 msgid "List styles"
 msgstr ""
 
@@ -4625,26 +4745,26 @@ msgstr ""
 msgid "Lists the available fonts."
 msgstr ""
 
-#: ../src/common/fldlgcmn.cpp:340
+#: ../src/common/fldlgcmn.cpp:337
 #, c-format
 msgid "Load %s file"
 msgstr ""
 
-#: ../src/html/htmlwin.cpp:597
+#: ../src/html/htmlwin.cpp:600
 msgid "Loading : "
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:246
+#: ../src/unix/snglinst.cpp:243
 #, c-format
 msgid "Lock file '%s' has incorrect owner."
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:251
+#: ../src/unix/snglinst.cpp:248
 #, c-format
 msgid "Lock file '%s' has incorrect permissions."
 msgstr ""
 
-#: ../src/generic/logg.cpp:576
+#: ../src/generic/logg.cpp:573
 #, c-format
 msgid "Log saved to the file '%s'."
 msgstr ""
@@ -4659,199 +4779,199 @@ msgstr ""
 msgid "Lower case roman numerals"
 msgstr ""
 
-#: ../src/gtk/mdi.cpp:422 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk1/mdi.cpp:431 ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr ""
 
-#: ../src/msw/helpchm.cpp:56
+#: ../src/msw/helpchm.cpp:53
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
 msgstr ""
 
-#: ../src/univ/themes/win32.cpp:3754
+#: ../src/univ/themes/win32.cpp:3751
 msgid "Ma&ximize"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:203
+#: ../src/common/fmapbase.cpp:200
 msgid "MacArabic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:222
+#: ../src/common/fmapbase.cpp:219
 msgid "MacArmenian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:211
+#: ../src/common/fmapbase.cpp:208
 msgid "MacBengali"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:217
+#: ../src/common/fmapbase.cpp:214
 msgid "MacBurmese"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:236
+#: ../src/common/fmapbase.cpp:233
 msgid "MacCeltic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:227
+#: ../src/common/fmapbase.cpp:224
 msgid "MacCentralEurRoman"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:223
+#: ../src/common/fmapbase.cpp:220
 msgid "MacChineseSimp"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:201
+#: ../src/common/fmapbase.cpp:198
 msgid "MacChineseTrad"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:233
+#: ../src/common/fmapbase.cpp:230
 msgid "MacCroatian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:206
+#: ../src/common/fmapbase.cpp:203
 msgid "MacCyrillic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:207
+#: ../src/common/fmapbase.cpp:204
 msgid "MacDevanagari"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:231
+#: ../src/common/fmapbase.cpp:228
 msgid "MacDingbats"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:226
+#: ../src/common/fmapbase.cpp:223
 msgid "MacEthiopic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:229
+#: ../src/common/fmapbase.cpp:226
 msgid "MacExtArabic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:237
+#: ../src/common/fmapbase.cpp:234
 msgid "MacGaelic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:221
+#: ../src/common/fmapbase.cpp:218
 msgid "MacGeorgian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:205
+#: ../src/common/fmapbase.cpp:202
 msgid "MacGreek"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:209
+#: ../src/common/fmapbase.cpp:206
 msgid "MacGujarati"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:208
+#: ../src/common/fmapbase.cpp:205
 msgid "MacGurmukhi"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:204
+#: ../src/common/fmapbase.cpp:201
 msgid "MacHebrew"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:234
+#: ../src/common/fmapbase.cpp:231
 msgid "MacIcelandic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:200
+#: ../src/common/fmapbase.cpp:197
 msgid "MacJapanese"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:214
+#: ../src/common/fmapbase.cpp:211
 msgid "MacKannada"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:238
+#: ../src/common/fmapbase.cpp:235
 msgid "MacKeyboardGlyphs"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:218
+#: ../src/common/fmapbase.cpp:215
 msgid "MacKhmer"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:202
+#: ../src/common/fmapbase.cpp:199
 msgid "MacKorean"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:220
+#: ../src/common/fmapbase.cpp:217
 msgid "MacLaotian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:215
+#: ../src/common/fmapbase.cpp:212
 msgid "MacMalayalam"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:225
+#: ../src/common/fmapbase.cpp:222
 msgid "MacMongolian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:210
+#: ../src/common/fmapbase.cpp:207
 msgid "MacOriya"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:199
+#: ../src/common/fmapbase.cpp:196
 msgid "MacRoman"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:235
+#: ../src/common/fmapbase.cpp:232
 msgid "MacRomanian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:216
+#: ../src/common/fmapbase.cpp:213
 msgid "MacSinhalese"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:230
+#: ../src/common/fmapbase.cpp:227
 msgid "MacSymbol"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:212
+#: ../src/common/fmapbase.cpp:209
 msgid "MacTamil"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:213
+#: ../src/common/fmapbase.cpp:210
 msgid "MacTelugu"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:219
+#: ../src/common/fmapbase.cpp:216
 msgid "MacThai"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:224
+#: ../src/common/fmapbase.cpp:221
 msgid "MacTibetan"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:232
+#: ../src/common/fmapbase.cpp:229
 msgid "MacTurkish"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:228
+#: ../src/common/fmapbase.cpp:225
 msgid "MacVietnamese"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1762
+#: ../src/propgrid/advprops.cpp:1663
 msgid "Magnifier"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:2143
+#: ../src/propgrid/advprops.cpp:2050
 msgid "Make a selection:"
 msgstr ""
 
-#: ../src/richtext/richtextformatdlg.cpp:374
+#: ../src/richtext/richtextformatdlg.cpp:367
 #: ../src/richtext/richtextmarginspage.cpp:171
 msgid "Margins"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1595
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Maroon"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:147
+#: ../src/generic/fdrepdlg.cpp:144
 msgid "Match case"
 msgstr ""
 
@@ -4863,40 +4983,40 @@ msgstr ""
 msgid "Max width:"
 msgstr ""
 
-#: ../src/unix/mediactrl.cpp:947
+#: ../src/unix/mediactrl.cpp:972
 #, c-format
 msgid "Media playback error: %s"
 msgstr ""
 
-#: ../src/common/fs_mem.cpp:175
+#: ../src/common/fs_mem.cpp:170
 #, c-format
 msgid "Memory VFS already contains file '%s'!"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
 #. TRANSLATORS: Keyword of system colour
-#: ../src/common/accelcmn.cpp:73 ../src/propgrid/advprops.cpp:889
+#: ../src/common/accelcmn.cpp:70 ../src/propgrid/advprops.cpp:790
 msgid "Menu"
 msgstr ""
 
-#: ../src/common/msgout.cpp:124
+#: ../src/common/msgout.cpp:121
 msgid "Message"
 msgstr ""
 
-#: ../src/univ/themes/metal.cpp:168
+#: ../src/univ/themes/metal.cpp:165
 msgid "Metal theme"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:652
+#: ../src/msw/ole/automtn.cpp:643
 msgid "Method or property not found."
 msgstr ""
 
-#: ../src/univ/themes/win32.cpp:3752
+#: ../src/univ/themes/win32.cpp:3749
 msgid "Mi&nimize"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1763
+#: ../src/propgrid/advprops.cpp:1664
 msgid "Middle Button"
 msgstr ""
 
@@ -4908,36 +5028,40 @@ msgstr ""
 msgid "Min width:"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:668
+#: ../src/osx/cocoa/menu.mm:281
+msgid "Minimize"
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:659
 msgid "Missing a required parameter."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:324
+#: ../src/generic/fontdlgg.cpp:320
 msgid "Modern"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:427
+#: ../src/generic/filectrlg.cpp:423
 msgid "Modified"
 msgstr ""
 
-#: ../src/common/module.cpp:133
+#: ../src/common/module.cpp:130
 #, c-format
 msgid "Module \"%s\" initialization failed"
 msgstr ""
 
-#: ../src/common/paper.cpp:131
+#: ../src/common/paper.cpp:128
 msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
 msgstr ""
 
-#: ../src/msw/fswatcher.cpp:143
+#: ../src/msw/fswatcher.cpp:140
 msgid "Monitoring individual files for changes is not supported currently."
 msgstr ""
 
-#: ../src/generic/editlbox.cpp:172
+#: ../src/generic/editlbox.cpp:160
 msgid "Move down"
 msgstr ""
 
-#: ../src/generic/editlbox.cpp:171
+#: ../src/generic/editlbox.cpp:155
 msgid "Move up"
 msgstr ""
 
@@ -4951,97 +5075,102 @@ msgstr ""
 msgid "Moves the object to the previous paragraph."
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9966
+#: ../src/richtext/richtextbuffer.cpp:9963
 msgid "Multiple Cell Properties"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:424
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:82
+msgid "Multiply"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:420
 msgid "Name"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1596
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Navy"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "Network"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173
 msgid "New"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:243
+#: ../src/richtext/richtextstyledlg.cpp:239
 msgid "New &Box Style..."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:225
+#: ../src/richtext/richtextstyledlg.cpp:221
 msgid "New &Character Style..."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:237
+#: ../src/richtext/richtextstyledlg.cpp:233
 msgid "New &List Style..."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:231
+#: ../src/richtext/richtextstyledlg.cpp:227
 msgid "New &Paragraph Style..."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:606
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:654
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:820
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:893
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:934
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:602
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:650
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:816
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:889
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:930
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "New Style"
 msgstr ""
 
-#: ../src/generic/editlbox.cpp:169
+#: ../src/generic/editlbox.cpp:139
 msgid "New item"
 msgstr ""
 
-#: ../src/generic/dirdlgg.cpp:297 ../src/generic/dirdlgg.cpp:307
-#: ../src/generic/filectrlg.cpp:618 ../src/generic/filectrlg.cpp:627
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+#: ../src/generic/dirdlgg.cpp:294 ../src/generic/dirdlgg.cpp:304
 msgid "NewName"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:1567 ../src/html/helpwnd.cpp:665
+#: ../src/common/prntbase.cpp:1592 ../src/html/helpwnd.cpp:663
 msgid "Next page"
 msgstr ""
 
-#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:177
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:174
 #: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1764
+#: ../src/propgrid/advprops.cpp:1665
 msgid "No Entry"
 msgstr ""
 
-#: ../src/generic/animateg.cpp:150
+#: ../src/generic/animateg.cpp:133
 #, c-format
 msgid "No animation handler for type %ld defined."
 msgstr ""
 
-#: ../src/dfb/bitmap.cpp:642 ../src/dfb/bitmap.cpp:676
+#: ../src/dfb/bitmap.cpp:639 ../src/dfb/bitmap.cpp:673
 #, c-format
 msgid "No bitmap handler for type %d defined."
 msgstr ""
 
-#: ../src/common/utilscmn.cpp:1077
+#: ../src/common/utilscmn.cpp:1095
 msgid "No default application configured for HTML files."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:445
+#: ../src/generic/helpext.cpp:443
 msgid "No entries found."
 msgstr ""
 
-#: ../src/common/fontmap.cpp:421
+#: ../src/common/fontmap.cpp:418
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found,\n"
@@ -5050,7 +5179,7 @@ msgid ""
 "one)?"
 msgstr ""
 
-#: ../src/common/fontmap.cpp:426
+#: ../src/common/fontmap.cpp:423
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found.\n"
@@ -5058,201 +5187,201 @@ msgid ""
 "(otherwise the text in this encoding will not be shown correctly)?"
 msgstr ""
 
-#: ../src/generic/animateg.cpp:142
+#: ../src/generic/animateg.cpp:125
 msgid "No handler found for animation type."
 msgstr ""
 
-#: ../src/common/image.cpp:2728
+#: ../src/common/image.cpp:2823
 msgid "No handler found for image type."
 msgstr ""
 
-#: ../src/common/image.cpp:2736 ../src/common/image.cpp:2848
-#: ../src/common/image.cpp:2901
+#: ../src/common/image.cpp:2831 ../src/common/image.cpp:2954
+#: ../src/common/image.cpp:3020
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr ""
 
-#: ../src/common/image.cpp:2871 ../src/common/image.cpp:2915
+#: ../src/common/image.cpp:2986 ../src/common/image.cpp:3034
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:858
+#: ../src/html/helpwnd.cpp:856
 msgid "No matching page found yet"
 msgstr ""
 
-#: ../src/unix/sound.cpp:81
+#: ../src/unix/sound.cpp:78
 msgid "No sound"
 msgstr ""
 
-#: ../src/common/image.cpp:2277 ../src/common/image.cpp:2318
+#: ../src/common/image.cpp:2371 ../src/common/image.cpp:2412
 msgid "No unused colour in image being masked."
 msgstr ""
 
-#: ../src/common/image.cpp:3374
-msgid "No unused colour in image."
-msgstr ""
-
-#: ../src/generic/helpext.cpp:302
+#: ../src/generic/helpext.cpp:300
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr ""
 
-#: ../src/richtext/richtextborderspage.cpp:610
 #: ../src/richtext/richtextsizepage.cpp:248
 #: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:610
 msgid "None"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:157
+#: ../src/common/fmapbase.cpp:154
 msgid "Nordic (ISO-8859-10)"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:328 ../src/generic/fontdlgg.cpp:331
+#: ../src/generic/fontdlgg.cpp:324 ../src/generic/fontdlgg.cpp:327
 msgid "Normal"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1261
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1205
+#: ../src/html/helpwnd.cpp:1203
 msgid "Normal font:"
 msgstr ""
 
-#: ../src/propgrid/props.cpp:1128
+#: ../src/propgrid/props.cpp:1115
 #, c-format
 msgid "Not %s"
 msgstr ""
 
-#: ../include/wx/filename.h:573 ../include/wx/filename.h:578
-msgid "Not available"
+#: ../src/common/secretstore.cpp:168
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/webrequest.cpp:605
+msgid "Not enough free disk space for download."
 msgstr ""
 
 #: ../src/richtext/richtextfontpage.cpp:358
 msgid "Not underlined"
 msgstr ""
 
-#: ../src/common/paper.cpp:115
+#: ../src/common/paper.cpp:112
 msgid "Note, 8 1/2 x 11 in"
 msgstr ""
 
-#: ../src/generic/notifmsgg.cpp:132
+#: ../src/generic/notifmsgg.cpp:129
 msgid "Notice"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "Num *"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "Num +"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "Num ,"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "Num -"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "Num ."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "Num /"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "Num ="
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "Num Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 msgid "Num Delete"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 msgid "Num Down"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "Num End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "Num Enter"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 msgid "Num Home"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 msgid "Num Insert"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num Lock"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "Num Page Down"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "Num Page Up"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 msgid "Num Right"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "Num Space"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "Num Tab"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "Num Up"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "Num left"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num_lock"
 msgstr ""
 
@@ -5261,13 +5390,13 @@ msgstr ""
 msgid "Numbered outline"
 msgstr ""
 
-#: ../include/wx/msgdlg.h:278 ../src/richtext/richtextstyledlg.cpp:297
-#: ../src/common/stockitem.cpp:178 ../src/msw/msgdlg.cpp:454
-#: ../src/msw/msgdlg.cpp:747 ../src/gtk1/fontdlg.cpp:138
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:175
+#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/msgdlg.cpp:741 ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:692
+#: ../src/msw/ole/automtn.cpp:683
 #, c-format
 msgid "OLE Automation error in %s: %s"
 msgstr ""
@@ -5276,15 +5405,15 @@ msgstr ""
 msgid "Object Properties"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:660
+#: ../src/msw/ole/automtn.cpp:651
 msgid "Object implementation does not support named arguments."
 msgstr ""
 
-#: ../src/common/xtixml.cpp:264
+#: ../src/common/xtixml.cpp:260
 msgid "Objects must have an id attribute"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1601
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Olive"
 msgstr ""
 
@@ -5292,64 +5421,68 @@ msgstr ""
 msgid "Opaci&ty:"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:354
+#: ../src/generic/colrdlgg.cpp:374
 msgid "Opacity:"
 msgstr ""
 
-#: ../src/common/docview.cpp:1773 ../src/common/docview.cpp:1815
+#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
 msgid "Open File"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:671 ../src/html/helpwnd.cpp:1554
+#: ../src/html/helpwnd.cpp:669 ../src/html/helpwnd.cpp:1552
 msgid "Open HTML document"
 msgstr ""
 
-#: ../src/generic/dbgrptg.cpp:163
+#: ../src/common/stockitem.cpp:265
+msgid "Open an existing document"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:160
 #, c-format
 msgid "Open file \"%s\""
 msgstr ""
 
-#: ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176
 msgid "Open..."
 msgstr ""
 
-#: ../src/unix/glx11.cpp:506 ../src/msw/glcanvas.cpp:592
+#: ../src/msw/glcanvas.cpp:607 ../src/unix/glx11.cpp:513
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr ""
 
-#: ../src/generic/dirctrlg.cpp:599 ../src/generic/dirdlgg.cpp:323
-#: ../src/generic/filectrlg.cpp:642 ../src/generic/filectrlg.cpp:786
+#: ../src/generic/dirctrlg.cpp:565 ../src/generic/filectrlg.cpp:638
+#: ../src/generic/filectrlg.cpp:782 ../src/generic/dirdlgg.cpp:320
 msgid "Operation not permitted."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:900
+#: ../src/common/cmdline.cpp:896
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1064
+#: ../src/common/cmdline.cpp:1060
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1147
+#: ../src/common/cmdline.cpp:1143
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:618
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1606
+#: ../src/propgrid/advprops.cpp:1512
 msgid "Orange"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:615 ../src/generic/prntdlgg.cpp:869
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:862
 msgid "Orientation"
 msgstr ""
 
-#: ../src/common/windowid.cpp:242
+#: ../src/common/windowid.cpp:237
 msgid "Out of window IDs.  Recommend shutting down application."
 msgstr ""
 
@@ -5362,148 +5495,148 @@ msgstr ""
 msgid "Outset"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:656
+#: ../src/msw/ole/automtn.cpp:647
 msgid "Overflow while coercing argument values."
 msgstr ""
 
-#: ../src/common/imagpcx.cpp:457 ../src/common/imagpcx.cpp:480
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:479
 msgid "PCX: couldn't allocate memory"
 msgstr ""
 
-#: ../src/common/imagpcx.cpp:456
+#: ../src/common/imagpcx.cpp:455
 msgid "PCX: image format unsupported"
 msgstr ""
 
-#: ../src/common/imagpcx.cpp:479
+#: ../src/common/imagpcx.cpp:478
 msgid "PCX: invalid image"
 msgstr ""
 
-#: ../src/common/imagpcx.cpp:442
+#: ../src/common/imagpcx.cpp:441
 msgid "PCX: this is not a PCX file."
 msgstr ""
 
-#: ../src/common/imagpcx.cpp:459 ../src/common/imagpcx.cpp:481
+#: ../src/common/imagpcx.cpp:458 ../src/common/imagpcx.cpp:480
 msgid "PCX: unknown error !!!"
 msgstr ""
 
-#: ../src/common/imagpcx.cpp:458
+#: ../src/common/imagpcx.cpp:457
 msgid "PCX: version number too low"
 msgstr ""
 
-#: ../src/common/imagpnm.cpp:91
+#: ../src/common/imagpnm.cpp:89
 msgid "PNM: Couldn't allocate memory."
 msgstr ""
 
-#: ../src/common/imagpnm.cpp:73
+#: ../src/common/imagpnm.cpp:71
 msgid "PNM: File format is not recognized."
 msgstr ""
 
-#: ../src/common/imagpnm.cpp:112 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
 #: ../src/common/imagpnm.cpp:156
 msgid "PNM: File seems truncated."
 msgstr ""
 
-#: ../src/common/paper.cpp:187
+#: ../src/common/paper.cpp:184
 msgid "PRC 16K 146 x 215 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:200
+#: ../src/common/paper.cpp:197
 msgid "PRC 16K Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:188
+#: ../src/common/paper.cpp:185
 msgid "PRC 32K 97 x 151 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:201
+#: ../src/common/paper.cpp:198
 msgid "PRC 32K Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:189
+#: ../src/common/paper.cpp:186
 msgid "PRC 32K(Big) 97 x 151 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:202
+#: ../src/common/paper.cpp:199
 msgid "PRC 32K(Big) Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:190
+#: ../src/common/paper.cpp:187
 msgid "PRC Envelope #1 102 x 165 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:203
+#: ../src/common/paper.cpp:200
 msgid "PRC Envelope #1 Rotated 165 x 102 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:199
+#: ../src/common/paper.cpp:196
 msgid "PRC Envelope #10 324 x 458 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:212
+#: ../src/common/paper.cpp:209
 msgid "PRC Envelope #10 Rotated 458 x 324 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:191
+#: ../src/common/paper.cpp:188
 msgid "PRC Envelope #2 102 x 176 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:204
+#: ../src/common/paper.cpp:201
 msgid "PRC Envelope #2 Rotated 176 x 102 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:192
+#: ../src/common/paper.cpp:189
 msgid "PRC Envelope #3 125 x 176 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:205
+#: ../src/common/paper.cpp:202
 msgid "PRC Envelope #3 Rotated 176 x 125 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:193
+#: ../src/common/paper.cpp:190
 msgid "PRC Envelope #4 110 x 208 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:206
+#: ../src/common/paper.cpp:203
 msgid "PRC Envelope #4 Rotated 208 x 110 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:194
+#: ../src/common/paper.cpp:191
 msgid "PRC Envelope #5 110 x 220 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:207
+#: ../src/common/paper.cpp:204
 msgid "PRC Envelope #5 Rotated 220 x 110 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:195
+#: ../src/common/paper.cpp:192
 msgid "PRC Envelope #6 120 x 230 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:208
+#: ../src/common/paper.cpp:205
 msgid "PRC Envelope #6 Rotated 230 x 120 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:196
+#: ../src/common/paper.cpp:193
 msgid "PRC Envelope #7 160 x 230 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:209
+#: ../src/common/paper.cpp:206
 msgid "PRC Envelope #7 Rotated 230 x 160 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:197
+#: ../src/common/paper.cpp:194
 msgid "PRC Envelope #8 120 x 309 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:210
+#: ../src/common/paper.cpp:207
 msgid "PRC Envelope #8 Rotated 309 x 120 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:198
+#: ../src/common/paper.cpp:195
 msgid "PRC Envelope #9 229 x 324 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:211
+#: ../src/common/paper.cpp:208
 msgid "PRC Envelope #9 Rotated 324 x 229 mm"
 msgstr ""
 
@@ -5511,87 +5644,91 @@ msgstr ""
 msgid "Padding"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:2074
+#: ../src/common/prntbase.cpp:2096
 #, c-format
 msgid "Page %d"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:2072
+#: ../src/common/prntbase.cpp:2094
 #, c-format
 msgid "Page %d of %d"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 msgid "Page Down"
 msgstr ""
 
-#: ../src/gtk/print.cpp:826
+#: ../src/gtk/print.cpp:829
 msgid "Page Setup"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 msgid "Page Up"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:828 ../src/common/prntbase.cpp:484
+#: ../src/common/prntbase.cpp:479 ../src/generic/prntdlgg.cpp:821
 msgid "Page setup"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 msgid "PageDown"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 msgid "PageUp"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:216
+#: ../src/generic/prntdlgg.cpp:209
 msgid "Pages"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1765
+#: ../src/propgrid/advprops.cpp:1666
 msgid "Paint Brush"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:602 ../src/generic/prntdlgg.cpp:801
-#: ../src/generic/prntdlgg.cpp:842 ../src/generic/prntdlgg.cpp:855
-#: ../src/generic/prntdlgg.cpp:1052 ../src/generic/prntdlgg.cpp:1057
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:794
+#: ../src/generic/prntdlgg.cpp:835 ../src/generic/prntdlgg.cpp:848
+#: ../src/generic/prntdlgg.cpp:1045 ../src/generic/prntdlgg.cpp:1050
 msgid "Paper size"
 msgstr ""
 
-#: ../src/richtext/richtextstyles.cpp:1062
+#: ../src/richtext/richtextstyles.cpp:1059
 msgid "Paragraph styles"
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:465
+#: ../src/common/xtistrm.cpp:462
 msgid "Passing a already registered object to SetObject"
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:476
+#: ../src/common/xtistrm.cpp:473
 msgid "Passing an unknown object to GetObject"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:3513 ../src/common/stockitem.cpp:180
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:177 ../src/richtext/richtextctrl.cpp:3514
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:262
+#: ../src/common/stockitem.cpp:260
 msgid "Paste selection"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:74
+#: ../src/common/accelcmn.cpp:71
 msgid "Pause"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1766
+#: ../src/propgrid/advprops.cpp:1667
 msgid "Pencil"
 msgstr ""
 
@@ -5600,21 +5737,21 @@ msgstr ""
 msgid "Peri&od"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:430
+#: ../src/generic/filectrlg.cpp:426
 msgid "Permissions"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:60
+#: ../src/common/accelcmn.cpp:57
 msgid "PgDn"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:59
+#: ../src/common/accelcmn.cpp:56
 msgid "PgUp"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:12868
+#: ../src/richtext/richtextbuffer.cpp:12863
 msgid "Picture Properties"
 msgstr ""
 
@@ -5626,42 +5763,42 @@ msgstr ""
 msgid "Please choose a valid font."
 msgstr ""
 
-#: ../src/generic/filedlgg.cpp:357 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
 msgid "Please choose an existing file."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:800
+#: ../src/html/helpwnd.cpp:798
 msgid "Please choose the page to display:"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:764
+#: ../src/msw/dialup.cpp:758
 msgid "Please choose which ISP do you want to connect to"
 msgstr ""
 
-#: ../src/common/headerctrlcmn.cpp:59
+#: ../src/common/headerctrlcmn.cpp:57
 msgid "Please select the columns to show and define their order:"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:538
+#: ../src/common/prntbase.cpp:533
 msgid "Please wait while printing..."
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1767
+#: ../src/propgrid/advprops.cpp:1668
 msgid "Point Left"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1768
+#: ../src/propgrid/advprops.cpp:1669
 msgid "Point Right"
 msgstr ""
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:662
+#: ../src/propgrid/advprops.cpp:572
 msgid "Point Size"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:612 ../src/generic/prntdlgg.cpp:867
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:860
 msgid "Portrait"
 msgstr ""
 
@@ -5669,251 +5806,259 @@ msgstr ""
 msgid "Position"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:298
+#: ../src/generic/prntdlgg.cpp:291
 msgid "PostScript file"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178 ../src/osx/cocoa/preferences.mm:303
 msgid "Preferences"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:568
+#: ../src/osx/menu_osx.cpp:460
 msgid "Preferences..."
 msgstr ""
 
-#: ../src/common/prntbase.cpp:546
+#: ../src/common/prntbase.cpp:541
 msgid "Preparing"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:455 ../src/osx/carbon/fontdlg.cpp:390
-#: ../src/html/helpwnd.cpp:1222
+#: ../src/osx/carbon/fontdlg.cpp:387 ../src/generic/fontdlgg.cpp:452
+#: ../src/html/helpwnd.cpp:1220
 msgid "Preview:"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:1553 ../src/html/helpwnd.cpp:664
+#: ../src/common/prntbase.cpp:1578 ../src/html/helpwnd.cpp:662
 msgid "Previous page"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/prntdlgg.cpp:143 ../src/generic/prntdlgg.cpp:157
-#: ../src/common/prntbase.cpp:426 ../src/common/prntbase.cpp:1541
-#: ../src/common/accelcmn.cpp:77 ../src/gtk/print.cpp:620
-#: ../src/gtk/print.cpp:638
+#: ../src/common/prntbase.cpp:421 ../src/common/prntbase.cpp:1566
+#: ../src/common/accelcmn.cpp:74 ../src/generic/prntdlgg.cpp:136
+#: ../src/generic/prntdlgg.cpp:150 ../src/gtk/print.cpp:616
+#: ../src/gtk/print.cpp:634
 msgid "Print"
 msgstr ""
 
-#: ../include/wx/prntbase.h:399 ../src/common/docview.cpp:1268
+#: ../src/common/docview.cpp:1262
 msgid "Print Preview"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:2015 ../src/common/prntbase.cpp:2057
-#: ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2037 ../src/common/prntbase.cpp:2079
+#: ../src/common/prntbase.cpp:2087
 msgid "Print Preview Failure"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:224
+#: ../src/generic/prntdlgg.cpp:217
 msgid "Print Range"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:449
+#: ../src/generic/prntdlgg.cpp:442
 msgid "Print Setup"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:621
+#: ../src/generic/prntdlgg.cpp:614
 msgid "Print in colour"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/osx/webview_webkit.mm:260
+msgid "Print operation could not be initialized"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:179
 msgid "Print previe&w..."
 msgstr ""
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1256
 msgid "Print preview creation failed."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/common/stockitem.cpp:179
 msgid "Print preview..."
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:630
+#: ../src/generic/prntdlgg.cpp:623
 msgid "Print spooling"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:675
+#: ../src/html/helpwnd.cpp:673
 msgid "Print this page"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:185
+#: ../src/generic/prntdlgg.cpp:178
 msgid "Print to File"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "Print..."
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:493
+#: ../src/generic/prntdlgg.cpp:486
 msgid "Printer"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:633
+#: ../src/generic/prntdlgg.cpp:626
 msgid "Printer command:"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:180
+#: ../src/generic/prntdlgg.cpp:173
 msgid "Printer options"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:645
+#: ../src/generic/prntdlgg.cpp:638
 msgid "Printer options:"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:916
+#: ../src/generic/prntdlgg.cpp:909
 msgid "Printer..."
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:196
+#: ../src/generic/prntdlgg.cpp:189
 msgid "Printer:"
 msgstr ""
 
-#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:535
-#: ../src/html/htmprint.cpp:277
+#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:530
+#: ../src/html/htmprint.cpp:289
 msgid "Printing"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:612
+#: ../src/common/prntbase.cpp:607
 msgid "Printing "
 msgstr ""
 
-#: ../src/common/prntbase.cpp:347
+#: ../src/common/prntbase.cpp:342
 msgid "Printing Error"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:565
+#: ../src/osx/webview_webkit.mm:251
+msgid "Printing is not supported by the system web control"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:560
 #, c-format
 msgid "Printing page %d"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:570
+#: ../src/common/prntbase.cpp:565
 #, c-format
 msgid "Printing page %d of %d"
 msgstr ""
 
-#: ../src/generic/printps.cpp:201
+#: ../src/generic/printps.cpp:182
 #, c-format
 msgid "Printing page %d..."
 msgstr ""
 
-#: ../src/generic/printps.cpp:161
+#: ../src/generic/printps.cpp:142
 msgid "Printing..."
 msgstr ""
 
-#: ../include/wx/richtext/richtextprint.h:109 ../include/wx/prntbase.h:267
-#: ../src/common/docview.cpp:2132
+#: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
+#: ../src/common/docview.cpp:2137
 msgid "Printout"
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:560
+#: ../src/common/debugrpt.cpp:561
 #, c-format
 msgid ""
 "Processing debug report has failed, leaving the files in \"%s\" directory."
 msgstr ""
 
-#: ../src/common/prntbase.cpp:545
+#: ../src/common/prntbase.cpp:540
 msgid "Progress:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181
 msgid "Properties"
 msgstr ""
 
-#: ../src/propgrid/manager.cpp:237
+#: ../src/propgrid/manager.cpp:223
 msgid "Property"
 msgstr ""
 
 #. TRANSLATORS: Caption of message box displaying any property error
-#: ../src/propgrid/propgrid.cpp:3185 ../src/propgrid/propgrid.cpp:3318
+#: ../src/propgrid/propgrid.cpp:3162 ../src/propgrid/propgrid.cpp:3299
 msgid "Property Error"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1597
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Purple"
 msgstr ""
 
-#: ../src/common/paper.cpp:112
+#: ../src/common/paper.cpp:109
 msgid "Quarto, 215 x 275 mm"
 msgstr ""
 
-#: ../src/generic/logg.cpp:1016
+#: ../src/generic/logg.cpp:1013
 msgid "Question"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1769
+#: ../src/propgrid/advprops.cpp:1670
 msgid "Question Arrow"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "Quit"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:477
 #, c-format
 msgid "Quit %s"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:263
+#: ../src/common/stockitem.cpp:261
 msgid "Quit this program"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:338
+#: ../src/common/accelcmn.cpp:352
 msgid "RawCtrl+"
 msgstr ""
 
-#: ../src/common/ffile.cpp:109 ../src/common/ffile.cpp:133
+#: ../src/common/ffile.cpp:107 ../src/common/ffile.cpp:132
 #, c-format
 msgid "Read error on file '%s'"
 msgstr ""
 
-#: ../src/common/secretstore.cpp:199
+#: ../src/common/secretstore.cpp:211
 #, c-format
-msgid "Reading password for \"%s/%s\" failed: %s."
+msgid "Reading password for \"%s\" failed: %s."
 msgstr ""
 
-#: ../src/common/prntbase.cpp:272
+#: ../src/common/prntbase.cpp:267
 msgid "Ready"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1605
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Red"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:339
+#: ../src/generic/colrdlgg.cpp:359
 msgid "Red:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:185 ../src/stc/stc_i18n.cpp:16
+#: ../src/common/stockitem.cpp:182 ../src/stc/stc_i18n.cpp:16
 msgid "Redo"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:264
+#: ../src/common/stockitem.cpp:262
 msgid "Redo last action"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:186
+#: ../src/common/stockitem.cpp:183
 msgid "Refresh"
 msgstr ""
 
-#: ../src/msw/registry.cpp:626
+#: ../src/msw/registry.cpp:615
 #, c-format
 msgid "Registry key '%s' already exists."
 msgstr ""
 
-#: ../src/msw/registry.cpp:595
+#: ../src/msw/registry.cpp:584
 #, c-format
 msgid "Registry key '%s' does not exist, cannot rename it."
 msgstr ""
 
-#: ../src/msw/registry.cpp:727
+#: ../src/msw/registry.cpp:716
 #, c-format
 msgid ""
 "Registry key '%s' is needed for normal system operation,\n"
@@ -5921,22 +6066,22 @@ msgid ""
 "operation aborted."
 msgstr ""
 
-#: ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:942
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:917
+#: ../src/msw/registry.cpp:905
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1003
+#: ../src/msw/registry.cpp:991
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:521
+#: ../src/msw/registry.cpp:510
 #, c-format
 msgid "Registry value '%s' already exists."
 msgstr ""
@@ -5950,70 +6095,74 @@ msgstr ""
 msgid "Relative"
 msgstr ""
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:456
 msgid "Relevant entries:"
 msgstr ""
 
-#: ../include/wx/generic/progdlgg.h:86
+#: ../include/wx/generic/progdlgg.h:87
 msgid "Remaining time:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:187
+#: ../src/common/stockitem.cpp:184
 msgid "Remove"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:1562
+#: ../src/richtext/richtextctrl.cpp:1563
 msgid "Remove Bullet"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:433
+#: ../src/html/helpwnd.cpp:431
 msgid "Remove current page from bookmarks"
 msgstr ""
 
-#: ../src/common/rendcmn.cpp:194
+#: ../src/common/rendcmn.cpp:191
 #, c-format
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:4527
+#: ../src/richtext/richtextbuffer.cpp:4524
 msgid "Renumber List"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:188
-msgid "Rep&lace"
+#: ../src/common/stockitem.cpp:185
+msgid "Rep&lace..."
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:3673 ../src/common/stockitem.cpp:188
+#: ../src/richtext/richtextctrl.cpp:3674
 msgid "Replace"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:182
+#: ../src/generic/fdrepdlg.cpp:179
 msgid "Replace &all"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:261
-msgid "Replace selection"
-msgstr ""
-
-#: ../src/generic/fdrepdlg.cpp:124
+#: ../src/generic/fdrepdlg.cpp:121
 msgid "Replace with:"
 msgstr ""
 
-#: ../src/common/valtext.cpp:163
+#: ../src/common/stockitem.cpp:185
+msgid "Replace..."
+msgstr ""
+
+#: ../src/common/valtext.cpp:184
 msgid "Required information entry is empty."
 msgstr ""
 
-#: ../src/common/translation.cpp:1975
+#: ../src/common/translation.cpp:2025
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr ""
 
+#: ../src/gtk/webview_webkit.cpp:985
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:56
+#: ../src/common/accelcmn.cpp:53
 msgid "Return"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:189
+#: ../src/common/stockitem.cpp:186
 msgid "Revert to Saved"
 msgstr ""
 
@@ -6025,41 +6174,41 @@ msgstr ""
 msgid "Rig&ht-to-left"
 msgstr ""
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6149
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:59 ../src/generic/datavgen.cpp:6954
+#: ../src/richtext/richtextsizepage.cpp:250
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextbulletspage.cpp:188
-#: ../src/richtext/richtextsizepage.cpp:250 ../src/common/accelcmn.cpp:62
 msgid "Right"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1754
+#: ../src/propgrid/advprops.cpp:1655
 msgid "Right Arrow"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1770
+#: ../src/propgrid/advprops.cpp:1671
 msgid "Right Button"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:892
+#: ../src/generic/prntdlgg.cpp:885
 msgid "Right margin (mm):"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:148
-#: ../src/richtext/richtextindentspage.cpp:150
 #: ../src/richtext/richtextliststylepage.cpp:337
 #: ../src/richtext/richtextliststylepage.cpp:339
+#: ../src/richtext/richtextindentspage.cpp:148
+#: ../src/richtext/richtextindentspage.cpp:150
 msgid "Right-align text."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:322
+#: ../src/generic/fontdlgg.cpp:318
 msgid "Roman"
 msgstr ""
 
-#: ../src/generic/datavgen.cpp:5916
+#: ../src/generic/datavgen.cpp:6721
 #, c-format
 msgid "Row %i"
 msgstr ""
@@ -6069,29 +6218,29 @@ msgstr ""
 msgid "S&tandard bullet name:"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:268 ../src/common/accelcmn.cpp:350
+#: ../src/common/accelcmn.cpp:282 ../src/common/accelcmn.cpp:367
 msgid "SPECIAL"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:190 ../src/common/sizer.cpp:2797
+#: ../src/common/stockitem.cpp:187 ../src/common/sizer.cpp:2914
 msgid "Save"
 msgstr ""
 
-#: ../src/common/fldlgcmn.cpp:342
+#: ../src/common/fldlgcmn.cpp:339
 #, c-format
 msgid "Save %s file"
 msgstr ""
 
-#: ../src/generic/logg.cpp:512
+#: ../src/common/stockitem.cpp:188 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr ""
 
-#: ../src/common/docview.cpp:366
+#: ../src/common/docview.cpp:359
 msgid "Save As"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:191
-msgid "Save as"
+#: ../src/common/stockitem.cpp:188
+msgid "Save As..."
 msgstr ""
 
 #: ../src/common/stockitem.cpp:267
@@ -6102,94 +6251,94 @@ msgstr ""
 msgid "Save current document with a different filename"
 msgstr ""
 
-#: ../src/generic/logg.cpp:512
+#: ../src/generic/logg.cpp:509
 msgid "Save log contents to file"
 msgstr ""
 
-#: ../src/common/secretstore.cpp:179
+#: ../src/common/secretstore.cpp:189
 #, c-format
-msgid "Saving password for \"%s/%s\" failed: %s."
+msgid "Saving password for \"%s\" failed: %s."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:325
+#: ../src/generic/fontdlgg.cpp:321
 msgid "Script"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll Lock"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll_lock"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:890
+#: ../src/propgrid/advprops.cpp:791
 msgid "Scrollbar"
 msgstr ""
 
-#: ../src/generic/srchctlg.cpp:56 ../src/html/helpwnd.cpp:535
-#: ../src/html/helpwnd.cpp:550
+#: ../src/generic/srchctlg.cpp:55 ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:548 ../src/gtk/srchctrl.cpp:182
 msgid "Search"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:537
+#: ../src/html/helpwnd.cpp:535
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:160
+#: ../src/generic/fdrepdlg.cpp:157
 msgid "Search direction"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:112
+#: ../src/generic/fdrepdlg.cpp:109
 msgid "Search for:"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1052
+#: ../src/html/helpwnd.cpp:1050
 msgid "Search in all books"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:857
+#: ../src/html/helpwnd.cpp:855
 msgid "Searching..."
 msgstr ""
 
-#: ../src/generic/dirctrlg.cpp:446
+#: ../src/generic/dirctrlg.cpp:412
 msgid "Sections"
 msgstr ""
 
-#: ../src/common/ffile.cpp:238
+#: ../src/common/ffile.cpp:237
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr ""
 
-#: ../src/common/ffile.cpp:228
+#: ../src/common/ffile.cpp:227
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:76
+#: ../src/common/accelcmn.cpp:73
 msgid "Select"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:337 ../src/osx/textctrl_osx.cpp:581
-#: ../src/common/stockitem.cpp:192 ../src/msw/textctrl.cpp:2512
+#: ../src/osx/textctrl_osx.cpp:599 ../src/common/stockitem.cpp:189
+#: ../src/msw/textctrl.cpp:2777 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:192 ../src/stc/stc_i18n.cpp:21
+#: ../src/common/stockitem.cpp:189 ../src/stc/stc_i18n.cpp:21
 msgid "Select All"
 msgstr ""
 
-#: ../src/common/docview.cpp:1895
+#: ../src/common/docview.cpp:1900
 msgid "Select a document template"
 msgstr ""
 
-#: ../src/common/docview.cpp:1969
+#: ../src/common/docview.cpp:1974
 msgid "Select a document view"
 msgstr ""
 
@@ -6218,20 +6367,20 @@ msgid "Selects the list level to edit."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:82
+#: ../src/common/accelcmn.cpp:79
 msgid "Separator"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1083
+#: ../src/common/cmdline.cpp:1079
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:572
+#: ../src/osx/menu_osx.cpp:464
 msgid "Services"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11217
+#: ../src/richtext/richtextbuffer.cpp:11216
 msgid "Set Cell Style"
 msgstr ""
 
@@ -6239,11 +6388,11 @@ msgstr ""
 msgid "SetProperty called w/o valid setter"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:188
+#: ../src/generic/prntdlgg.cpp:181
 msgid "Setup..."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:544
+#: ../src/msw/dialup.cpp:538
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr ""
 
@@ -6259,40 +6408,40 @@ msgstr ""
 msgid "Shadow c&olour:"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:335
+#: ../src/common/accelcmn.cpp:349
 msgid "Shift+"
 msgstr ""
 
-#: ../src/generic/dirdlgg.cpp:147
+#: ../src/generic/dirdlgg.cpp:144
 msgid "Show &hidden directories"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:983
+#: ../src/generic/filectrlg.cpp:979
 msgid "Show &hidden files"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:580
+#: ../src/osx/menu_osx.cpp:472
 msgid "Show All"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:257
+#: ../src/common/stockitem.cpp:254
 msgid "Show about dialog"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:492
+#: ../src/html/helpwnd.cpp:490
 msgid "Show all"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:503
+#: ../src/html/helpwnd.cpp:501
 msgid "Show all items in index"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:656
 msgid "Show/hide navigation panel"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:421
-#: ../src/richtext/richtextsymboldlg.cpp:423
+#: ../src/richtext/richtextsymboldlg.cpp:418
+#: ../src/richtext/richtextsymboldlg.cpp:420
 msgid "Shows a Unicode subset."
 msgstr ""
 
@@ -6308,7 +6457,7 @@ msgstr ""
 msgid "Shows a preview of the font settings."
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:394 ../src/osx/carbon/fontdlg.cpp:396
+#: ../src/osx/carbon/fontdlg.cpp:391 ../src/osx/carbon/fontdlg.cpp:393
 msgid "Shows a preview of the font."
 msgstr ""
 
@@ -6317,62 +6466,62 @@ msgstr ""
 msgid "Shows a preview of the paragraph settings."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:460 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:456 ../src/generic/fontdlgg.cpp:458
 msgid "Shows the font preview."
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1607
+#: ../src/propgrid/advprops.cpp:1513
 msgid "Silver"
 msgstr ""
 
-#: ../src/univ/themes/mono.cpp:516
+#: ../src/univ/themes/mono.cpp:513
 msgid "Simple monochrome theme"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:275
 #: ../src/richtext/richtextliststylepage.cpp:449
+#: ../src/richtext/richtextindentspage.cpp:275
 msgid "Single"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:425 ../src/richtext/richtextformatdlg.cpp:369
-#: ../src/richtext/richtextsizepage.cpp:299
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextsizepage.cpp:299
+#: ../src/richtext/richtextformatdlg.cpp:362
 msgid "Size"
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:339
+#: ../src/osx/carbon/fontdlg.cpp:336
 msgid "Size:"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1775
+#: ../src/propgrid/advprops.cpp:1676
 msgid "Sizing"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1772
+#: ../src/propgrid/advprops.cpp:1673
 msgid "Sizing N-S"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1771
+#: ../src/propgrid/advprops.cpp:1672
 msgid "Sizing NE-SW"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1773
+#: ../src/propgrid/advprops.cpp:1674
 msgid "Sizing NW-SE"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1774
+#: ../src/propgrid/advprops.cpp:1675
 msgid "Sizing W-E"
 msgstr ""
 
-#: ../src/msw/progdlg.cpp:801
+#: ../src/msw/progdlg.cpp:1088
 msgid "Skip"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:330
+#: ../src/generic/fontdlgg.cpp:326
 msgid "Slant"
 msgstr ""
 
@@ -6381,7 +6530,7 @@ msgid "Small C&apitals"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:79
+#: ../src/common/accelcmn.cpp:76
 msgid "Snapshot"
 msgstr ""
 
@@ -6389,37 +6538,37 @@ msgstr ""
 msgid "Solid"
 msgstr ""
 
-#: ../src/common/docview.cpp:1791
+#: ../src/common/docview.cpp:1785
 msgid "Sorry, could not open this file."
 msgstr ""
 
-#: ../src/common/prntbase.cpp:2057 ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2079 ../src/common/prntbase.cpp:2087
 msgid "Sorry, not enough memory to create a preview."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "Sorry, that name is taken. Please choose another."
 msgstr ""
 
-#: ../src/common/docview.cpp:1814
+#: ../src/common/docview.cpp:1819
 msgid "Sorry, the format for this file is unknown."
 msgstr ""
 
-#: ../src/unix/sound.cpp:492
+#: ../src/unix/sound.cpp:481
 msgid "Sound data are in unsupported format."
 msgstr ""
 
-#: ../src/unix/sound.cpp:477
+#: ../src/unix/sound.cpp:466
 #, c-format
 msgid "Sound file '%s' is in unsupported format."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:67
+#: ../src/common/accelcmn.cpp:64
 msgid "Space"
 msgstr ""
 
@@ -6427,12 +6576,12 @@ msgstr ""
 msgid "Spacing"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "Spell Check"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1776
+#: ../src/propgrid/advprops.cpp:1677
 msgid "Spraycan"
 msgstr ""
 
@@ -6441,7 +6590,7 @@ msgstr ""
 msgid "Standard"
 msgstr ""
 
-#: ../src/common/paper.cpp:104
+#: ../src/common/paper.cpp:101
 msgid "Statement, 5 1/2 x 8 1/2 in"
 msgstr ""
 
@@ -6450,33 +6599,29 @@ msgstr ""
 msgid "Static"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:204
+#: ../src/generic/prntdlgg.cpp:197
 msgid "Status:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "Stop"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196
 msgid "Strikethrough"
 msgstr ""
 
-#: ../src/common/colourcmn.cpp:45
+#: ../src/common/colourcmn.cpp:42
 #, c-format
 msgid "String To Colour : Incorrect colour specification : %s"
 msgstr ""
 
 #. TRANSLATORS: Label of font style
-#: ../src/richtext/richtextformatdlg.cpp:339 ../src/propgrid/advprops.cpp:680
+#: ../src/propgrid/advprops.cpp:590 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr ""
 
-#: ../include/wx/richtext/richtextstyledlg.h:46
-msgid "Style Organiser"
-msgstr ""
-
-#: ../src/osx/carbon/fontdlg.cpp:348
+#: ../src/osx/carbon/fontdlg.cpp:345
 msgid "Style:"
 msgstr ""
 
@@ -6485,7 +6630,7 @@ msgid "Subscrip&t"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:83
+#: ../src/common/accelcmn.cpp:80
 msgid "Subtract"
 msgstr ""
 
@@ -6493,11 +6638,11 @@ msgstr ""
 msgid "Supe&rscript"
 msgstr ""
 
-#: ../src/common/paper.cpp:150
+#: ../src/common/paper.cpp:147
 msgid "SuperA/SuperA/A4 227 x 356 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:151
+#: ../src/common/paper.cpp:148
 msgid "SuperB/SuperB/A3 305 x 487 mm"
 msgstr ""
 
@@ -6505,7 +6650,7 @@ msgstr ""
 msgid "Suppress hyphe&nation"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:326
+#: ../src/generic/fontdlgg.cpp:322
 msgid "Swiss"
 msgstr ""
 
@@ -6523,73 +6668,73 @@ msgstr ""
 msgid "Symbols"
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:369 ../src/common/imagtiff.cpp:382
-#: ../src/common/imagtiff.cpp:741
+#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
+#: ../src/common/imagtiff.cpp:738
 msgid "TIFF: Couldn't allocate memory."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:301
+#: ../src/common/imagtiff.cpp:298
 msgid "TIFF: Error loading image."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:468
+#: ../src/common/imagtiff.cpp:465
 msgid "TIFF: Error reading image."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:608
+#: ../src/common/imagtiff.cpp:605
 msgid "TIFF: Error saving image."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:846
+#: ../src/common/imagtiff.cpp:843
 msgid "TIFF: Error writing image."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:355
+#: ../src/common/imagtiff.cpp:352
 msgid "TIFF: Image size is abnormally big."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:68
+#: ../src/common/accelcmn.cpp:65
 msgid "Tab"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11498
+#: ../src/richtext/richtextbuffer.cpp:11497
 msgid "Table Properties"
 msgstr ""
 
-#: ../src/common/paper.cpp:145
+#: ../src/common/paper.cpp:142
 msgid "Tabloid Extra 11.69 x 18 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:102
+#: ../src/common/paper.cpp:99
 msgid "Tabloid, 11 x 17 in"
 msgstr ""
 
-#: ../src/richtext/richtextformatdlg.cpp:354
+#: ../src/richtext/richtextformatdlg.cpp:347
 msgid "Tabs"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1598
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Teal"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:327
+#: ../src/generic/fontdlgg.cpp:323
 msgid "Teletype"
 msgstr ""
 
-#: ../src/common/docview.cpp:1896
+#: ../src/common/docview.cpp:1901
 msgid "Templates"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:158
+#: ../src/common/fmapbase.cpp:155
 msgid "Thai (ISO-8859-11)"
 msgstr ""
 
-#: ../src/common/ftp.cpp:619
+#: ../src/common/ftp.cpp:622
 msgid "The FTP server doesn't support passive mode."
 msgstr ""
 
-#: ../src/common/ftp.cpp:605
+#: ../src/common/ftp.cpp:608
 msgid "The FTP server doesn't support the PORT command."
 msgstr ""
 
@@ -6600,8 +6745,8 @@ msgstr ""
 msgid "The available bullet styles."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:202
-#: ../src/richtext/richtextstyledlg.cpp:204
+#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:200
 msgid "The available styles."
 msgstr ""
 
@@ -6657,12 +6802,12 @@ msgstr ""
 msgid "The bullet character."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:443
-#: ../src/richtext/richtextsymboldlg.cpp:445
+#: ../src/richtext/richtextsymboldlg.cpp:440
+#: ../src/richtext/richtextsymboldlg.cpp:442
 msgid "The character code."
 msgstr ""
 
-#: ../src/common/fontmap.cpp:203
+#: ../src/common/fontmap.cpp:200
 #, c-format
 msgid ""
 "The charset '%s' is unknown. You may select\n"
@@ -6670,7 +6815,7 @@ msgid ""
 "[Cancel] if it cannot be replaced"
 msgstr ""
 
-#: ../src/msw/ole/dataobj.cpp:394
+#: ../src/msw/ole/dataobj.cpp:402
 #, c-format
 msgid "The clipboard format '%d' doesn't exist."
 msgstr ""
@@ -6680,14 +6825,14 @@ msgstr ""
 msgid "The default style for the next paragraph."
 msgstr ""
 
-#: ../src/generic/dirdlgg.cpp:202
+#: ../src/generic/dirdlgg.cpp:199
 #, c-format
 msgid ""
 "The directory '%s' does not exist\n"
 "Create it now?"
 msgstr ""
 
-#: ../src/html/htmprint.cpp:271
+#: ../src/html/htmprint.cpp:283
 #, c-format
 msgid ""
 "The document \"%s\" doesn't fit on the page horizontally and will be "
@@ -6696,43 +6841,43 @@ msgid ""
 "Would you like to proceed with printing it nevertheless?"
 msgstr ""
 
-#: ../src/common/docview.cpp:1202
+#: ../src/common/docview.cpp:1196
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
 "It has been removed from the most recently used files list."
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:208
-#: ../src/richtext/richtextindentspage.cpp:210
 #: ../src/richtext/richtextliststylepage.cpp:394
 #: ../src/richtext/richtextliststylepage.cpp:396
+#: ../src/richtext/richtextindentspage.cpp:208
+#: ../src/richtext/richtextindentspage.cpp:210
 msgid "The first line indent."
 msgstr ""
 
-#: ../src/gtk/utilsgtk.cpp:481
-msgid "The following standard GTK+ options are also supported:\n"
+#: ../src/generic/dbgrptg.cpp:318
+msgid "The following debug report will be generated\n"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:414 ../src/generic/fontdlgg.cpp:416
+#: ../src/generic/fontdlgg.cpp:411 ../src/generic/fontdlgg.cpp:413
 msgid "The font colour."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:375 ../src/generic/fontdlgg.cpp:377
+#: ../src/generic/fontdlgg.cpp:371 ../src/generic/fontdlgg.cpp:373
 msgid "The font family."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:405
-#: ../src/richtext/richtextsymboldlg.cpp:407
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "The font from which to take the symbol."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:427 ../src/generic/fontdlgg.cpp:429
-#: ../src/generic/fontdlgg.cpp:434 ../src/generic/fontdlgg.cpp:436
+#: ../src/generic/fontdlgg.cpp:424 ../src/generic/fontdlgg.cpp:426
+#: ../src/generic/fontdlgg.cpp:430 ../src/generic/fontdlgg.cpp:432
 msgid "The font point size."
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:343 ../src/osx/carbon/fontdlg.cpp:345
+#: ../src/osx/carbon/fontdlg.cpp:340 ../src/osx/carbon/fontdlg.cpp:342
 msgid "The font size in points."
 msgstr ""
 
@@ -6741,15 +6886,15 @@ msgstr ""
 msgid "The font size units, points or pixels."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:386 ../src/generic/fontdlgg.cpp:388
+#: ../src/generic/fontdlgg.cpp:382 ../src/generic/fontdlgg.cpp:384
 msgid "The font style."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:397 ../src/generic/fontdlgg.cpp:399
+#: ../src/generic/fontdlgg.cpp:393 ../src/generic/fontdlgg.cpp:395
 msgid "The font weight."
 msgstr ""
 
-#: ../src/common/docview.cpp:1483
+#: ../src/common/docview.cpp:1477
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr ""
@@ -6759,10 +6904,10 @@ msgstr ""
 msgid "The horizontal offset."
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:199
-#: ../src/richtext/richtextindentspage.cpp:201
 #: ../src/richtext/richtextliststylepage.cpp:385
 #: ../src/richtext/richtextliststylepage.cpp:387
+#: ../src/richtext/richtextindentspage.cpp:199
+#: ../src/richtext/richtextindentspage.cpp:201
 msgid "The left indent."
 msgstr ""
 
@@ -6783,10 +6928,10 @@ msgstr ""
 msgid "The left position."
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:288
-#: ../src/richtext/richtextindentspage.cpp:290
 #: ../src/richtext/richtextliststylepage.cpp:462
 #: ../src/richtext/richtextliststylepage.cpp:464
+#: ../src/richtext/richtextindentspage.cpp:288
+#: ../src/richtext/richtextindentspage.cpp:290
 msgid "The line spacing."
 msgstr ""
 
@@ -6795,7 +6940,7 @@ msgstr ""
 msgid "The list item number."
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:664
+#: ../src/msw/ole/automtn.cpp:655
 msgid "The locale ID is unknown."
 msgstr ""
 
@@ -6834,19 +6979,19 @@ msgstr ""
 msgid "The outline level."
 msgstr ""
 
-#: ../src/common/log.cpp:277
+#: ../src/common/log.cpp:296
 #, c-format
 msgid "The previous message repeated %u time."
 msgid_plural "The previous message repeated %u times."
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/common/log.cpp:270
+#: ../src/common/log.cpp:289
 msgid "The previous message repeated once."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:462
-#: ../src/richtext/richtextsymboldlg.cpp:464
+#: ../src/richtext/richtextsymboldlg.cpp:459
+#: ../src/richtext/richtextsymboldlg.cpp:461
 msgid "The range to show."
 msgstr ""
 
@@ -6857,15 +7002,15 @@ msgid ""
 "please uncheck them and they will be removed from the report.\n"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1254
+#: ../src/common/cmdline.cpp:1250
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:217
-#: ../src/richtext/richtextindentspage.cpp:219
 #: ../src/richtext/richtextliststylepage.cpp:403
 #: ../src/richtext/richtextliststylepage.cpp:405
+#: ../src/richtext/richtextindentspage.cpp:217
+#: ../src/richtext/richtextindentspage.cpp:219
 msgid "The right indent."
 msgstr ""
 
@@ -6906,16 +7051,16 @@ msgstr ""
 msgid "The shadow spread."
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:267
 #: ../src/richtext/richtextliststylepage.cpp:439
 #: ../src/richtext/richtextliststylepage.cpp:441
+#: ../src/richtext/richtextindentspage.cpp:267
 msgid "The spacing after the paragraph."
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:257
-#: ../src/richtext/richtextindentspage.cpp:259
 #: ../src/richtext/richtextliststylepage.cpp:430
 #: ../src/richtext/richtextliststylepage.cpp:432
+#: ../src/richtext/richtextindentspage.cpp:257
+#: ../src/richtext/richtextindentspage.cpp:259
 msgid "The spacing before the paragraph."
 msgstr ""
 
@@ -6929,12 +7074,12 @@ msgstr ""
 msgid "The style on which this style is based."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:214
-#: ../src/richtext/richtextstyledlg.cpp:216
+#: ../src/richtext/richtextstyledlg.cpp:210
+#: ../src/richtext/richtextstyledlg.cpp:212
 msgid "The style preview."
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:680
+#: ../src/msw/ole/automtn.cpp:671
 msgid "The system cannot find the file specified."
 msgstr ""
 
@@ -6947,7 +7092,7 @@ msgstr ""
 msgid "The tab positions."
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:3098
+#: ../src/richtext/richtextctrl.cpp:3099
 msgid "The text couldn't be saved."
 msgstr ""
 
@@ -6968,7 +7113,7 @@ msgstr ""
 msgid "The top position."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1232
+#: ../src/common/cmdline.cpp:1228
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr ""
@@ -6978,7 +7123,7 @@ msgstr ""
 msgid "The value of the corner radius."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:433
+#: ../src/msw/dialup.cpp:427
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -6990,122 +7135,130 @@ msgstr ""
 msgid "The vertical offset."
 msgstr ""
 
-#: ../src/richtext/richtextprint.cpp:619 ../src/html/htmprint.cpp:745
+#: ../src/html/htmprint.cpp:749 ../src/richtext/richtextprint.cpp:615
 msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr ""
 
-#: ../src/html/htmprint.cpp:255
+#: ../src/html/htmprint.cpp:267
 msgid ""
 "This document doesn't fit on the page horizontally and will be truncated "
 "when it is printed."
 msgstr ""
 
-#: ../src/common/image.cpp:2854
+#: ../src/common/image.cpp:2963
 #, c-format
 msgid "This is not a %s."
 msgstr ""
 
-#: ../src/common/wincmn.cpp:1653
+#: ../src/common/wincmn.cpp:1654
 msgid "This platform does not support background transparency."
 msgstr ""
 
-#: ../src/gtk/window.cpp:4660
+#: ../src/gtk/window.cpp:5664
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
 
-#: ../src/msw/thread.cpp:1240
+#: ../src/gtk/glcanvas.cpp:176
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/msw/thread.cpp:1246
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1794
+#: ../src/unix/threadpsx.cpp:1843
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 
-#: ../src/msw/thread.cpp:1228
+#: ../src/msw/thread.cpp:1234
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1043
+#: ../src/unix/threadpsx.cpp:1061
 msgid "Thread priority setting is ignored."
 msgstr ""
 
-#: ../src/msw/mdi.cpp:176
+#: ../src/msw/mdi.cpp:171
 msgid "Tile &Horizontally"
 msgstr ""
 
-#: ../src/msw/mdi.cpp:177
+#: ../src/msw/mdi.cpp:172
 msgid "Tile &Vertically"
 msgstr ""
 
-#: ../src/common/ftp.cpp:200
+#: ../src/common/ftp.cpp:197
 msgid "Timeout while waiting for FTP server to connect, try passive mode."
 msgstr ""
 
-#: ../src/generic/tipdlg.cpp:201
+#: ../src/generic/tipdlg.cpp:198
 msgid "Tip of the Day"
 msgstr ""
 
-#: ../src/generic/tipdlg.cpp:140
+#: ../src/generic/tipdlg.cpp:137
 msgid "Tips not available, sorry!"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:242
+#: ../src/generic/prntdlgg.cpp:235
 msgid "To:"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:8363
+#: ../src/richtext/richtextbuffer.cpp:8361
 msgid "Too many EndStyle calls!"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:891
+#: ../src/propgrid/advprops.cpp:792
 msgid "Tooltip"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:892
+#: ../src/propgrid/advprops.cpp:793
 msgid "TooltipText"
 msgstr ""
 
-#: ../src/richtext/richtextsizepage.cpp:286
-#: ../src/richtext/richtextsizepage.cpp:290 ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197 ../src/richtext/richtextsizepage.cpp:286
+#: ../src/richtext/richtextsizepage.cpp:290
 msgid "Top"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:881
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Top margin (mm):"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:79
+#: ../src/generic/aboutdlgg.cpp:76
 msgid "Translations by "
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:188
+#: ../src/generic/aboutdlgg.cpp:185
 msgid "Translators"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:211
+#: ../src/propgrid/propgrid.cpp:192
 msgid "True"
 msgstr ""
 
-#: ../src/common/fs_mem.cpp:227
+#: ../src/common/fs_mem.cpp:222
 #, c-format
 msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:156
+#: ../src/common/fmapbase.cpp:153
 msgid "Turkish (ISO-8859-9)"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:426
+#: ../src/generic/filectrlg.cpp:422
 msgid "Type"
 msgstr ""
 
@@ -7119,36 +7272,36 @@ msgstr ""
 msgid "Type a size in points."
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:676
+#: ../src/msw/ole/automtn.cpp:667
 #, c-format
 msgid "Type mismatch in argument %u."
 msgstr ""
 
-#: ../src/common/xtixml.cpp:356 ../src/common/xtixml.cpp:509
-#: ../src/common/xtistrm.cpp:318
+#: ../src/common/xtixml.cpp:352 ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315
 msgid "Type must have enum - long conversion"
 msgstr ""
 
-#: ../src/propgrid/propgridiface.cpp:401
+#: ../src/propgrid/propgridiface.cpp:385
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
 "\"%s\"."
 msgstr ""
 
-#: ../src/common/paper.cpp:133
+#: ../src/common/paper.cpp:130
 msgid "US Std Fanfold, 14 7/8 x 11 in"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:196
+#: ../src/common/fmapbase.cpp:193
 msgid "US-ASCII"
 msgstr ""
 
-#: ../src/unix/fswatcher_inotify.cpp:109
+#: ../src/unix/fswatcher_inotify.cpp:106
 msgid "Unable to add inotify watch"
 msgstr ""
 
-#: ../src/unix/fswatcher_kqueue.cpp:136
+#: ../src/unix/fswatcher_kqueue.cpp:153
 msgid "Unable to add kqueue watch"
 msgstr ""
 
@@ -7160,7 +7313,7 @@ msgstr ""
 msgid "Unable to close I/O completion port handle"
 msgstr ""
 
-#: ../src/unix/fswatcher_inotify.cpp:97
+#: ../src/unix/fswatcher_inotify.cpp:94
 msgid "Unable to close inotify instance"
 msgstr ""
 
@@ -7178,15 +7331,15 @@ msgstr ""
 msgid "Unable to create I/O completion port"
 msgstr ""
 
-#: ../src/msw/fswatcher.cpp:84
+#: ../src/msw/fswatcher.cpp:81
 msgid "Unable to create IOCP worker thread"
 msgstr ""
 
-#: ../src/unix/fswatcher_inotify.cpp:74
+#: ../src/unix/fswatcher_inotify.cpp:71
 msgid "Unable to create inotify instance"
 msgstr ""
 
-#: ../src/unix/fswatcher_kqueue.cpp:97
+#: ../src/unix/fswatcher_kqueue.cpp:114
 msgid "Unable to create kqueue instance"
 msgstr ""
 
@@ -7194,11 +7347,11 @@ msgstr ""
 msgid "Unable to dequeue completion packet"
 msgstr ""
 
-#: ../src/unix/fswatcher_kqueue.cpp:185
+#: ../src/unix/fswatcher_kqueue.cpp:202
 msgid "Unable to get events from kqueue"
 msgstr ""
 
-#: ../src/gtk/app.cpp:435
+#: ../src/gtk/app.cpp:431
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr ""
 
@@ -7207,12 +7360,12 @@ msgstr ""
 msgid "Unable to open path '%s'"
 msgstr ""
 
-#: ../src/html/htmlwin.cpp:583
+#: ../src/html/htmlwin.cpp:586
 #, c-format
 msgid "Unable to open requested HTML document: %s"
 msgstr ""
 
-#: ../src/unix/sound.cpp:368
+#: ../src/unix/sound.cpp:365
 msgid "Unable to play sound asynchronously."
 msgstr ""
 
@@ -7220,61 +7373,61 @@ msgstr ""
 msgid "Unable to post completion status"
 msgstr ""
 
-#: ../src/unix/fswatcher_inotify.cpp:556
+#: ../src/unix/fswatcher_inotify.cpp:553
 msgid "Unable to read from inotify descriptor"
 msgstr ""
 
-#: ../src/unix/fswatcher_inotify.cpp:141
+#: ../src/unix/fswatcher_inotify.cpp:138
 #, c-format
 msgid "Unable to remove inotify watch %i"
 msgstr ""
 
-#: ../src/unix/fswatcher_kqueue.cpp:153
+#: ../src/unix/fswatcher_kqueue.cpp:170
 msgid "Unable to remove kqueue watch"
 msgstr ""
 
-#: ../src/msw/fswatcher.cpp:168
+#: ../src/msw/fswatcher.cpp:165
 #, c-format
 msgid "Unable to set up watch for '%s'"
 msgstr ""
 
-#: ../src/msw/fswatcher.cpp:91
+#: ../src/msw/fswatcher.cpp:88
 msgid "Unable to start IOCP worker thread"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:201
+#: ../src/common/stockitem.cpp:198
 msgid "Undelete"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199
 msgid "Underline"
 msgstr ""
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/richtext/richtextfontpage.cpp:359 ../src/osx/carbon/fontdlg.cpp:370
-#: ../src/propgrid/advprops.cpp:690
+#: ../src/osx/carbon/fontdlg.cpp:367 ../src/propgrid/advprops.cpp:600
+#: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:203 ../src/stc/stc_i18n.cpp:15
+#: ../src/common/stockitem.cpp:200 ../src/stc/stc_i18n.cpp:15
 msgid "Undo"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:265
+#: ../src/common/stockitem.cpp:263
 msgid "Undo last action"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1029
+#: ../src/common/cmdline.cpp:1025
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr ""
 
-#: ../src/unix/fswatcher_inotify.cpp:274
+#: ../src/unix/fswatcher_inotify.cpp:271
 #, c-format
 msgid "Unexpected event for \"%s\": no matching watch descriptor."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1195
+#: ../src/common/cmdline.cpp:1191
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr ""
@@ -7283,49 +7436,49 @@ msgstr ""
 msgid "Unexpectedly new I/O completion port was created"
 msgstr ""
 
-#: ../src/msw/fswatcher.cpp:70
+#: ../src/msw/fswatcher.cpp:67
 msgid "Ungraceful worker thread termination"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:460
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:456
+#: ../src/richtext/richtextsymboldlg.cpp:457
+#: ../src/richtext/richtextsymboldlg.cpp:458
 msgid "Unicode"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:185 ../src/common/fmapbase.cpp:191
+#: ../src/common/fmapbase.cpp:182 ../src/common/fmapbase.cpp:188
 msgid "Unicode 16 bit (UTF-16)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:190
+#: ../src/common/fmapbase.cpp:187
 msgid "Unicode 16 bit Big Endian (UTF-16BE)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:186
+#: ../src/common/fmapbase.cpp:183
 msgid "Unicode 16 bit Little Endian (UTF-16LE)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:187 ../src/common/fmapbase.cpp:193
+#: ../src/common/fmapbase.cpp:184 ../src/common/fmapbase.cpp:190
 msgid "Unicode 32 bit (UTF-32)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:192
+#: ../src/common/fmapbase.cpp:189
 msgid "Unicode 32 bit Big Endian (UTF-32BE)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:188
+#: ../src/common/fmapbase.cpp:185
 msgid "Unicode 32 bit Little Endian (UTF-32LE)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:182
+#: ../src/common/fmapbase.cpp:179
 msgid "Unicode 7 bit (UTF-7)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:183
+#: ../src/common/fmapbase.cpp:180
 msgid "Unicode 8 bit (UTF-8)"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "Unindent"
 msgstr ""
 
@@ -7475,97 +7628,102 @@ msgstr ""
 msgid "Units for this value."
 msgstr ""
 
-#: ../src/generic/progdlgg.cpp:353 ../src/generic/progdlgg.cpp:622
+#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
 msgid "Unknown"
 msgstr ""
 
-#: ../src/msw/dde.cpp:1174
+#: ../src/msw/dde.cpp:1238
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:410
+#: ../src/common/xtistrm.cpp:407
 msgid "Unknown Object passed to GetObjectClassInfo"
 msgstr ""
 
-#: ../src/common/imagpng.cpp:366
+#: ../src/common/imagpng.cpp:383
 #, c-format
 msgid "Unknown PNG resolution unit %d"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:327
+#: ../src/common/xtixml.cpp:323
 #, c-format
 msgid "Unknown Property %s"
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:529
+#: ../src/common/imagtiff.cpp:526
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr ""
 
-#: ../src/unix/dlunix.cpp:160
+#: ../src/propgrid/props.cpp:155
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/unix/dlunix.cpp:118
 msgid "Unknown dynamic library error"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:810
+#: ../src/common/fmapbase.cpp:806
 #, c-format
 msgid "Unknown encoding (%d)"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:688
+#: ../src/msw/ole/automtn.cpp:679
 #, c-format
 msgid "Unknown error %08x"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:647
+#: ../src/msw/ole/automtn.cpp:638
 msgid "Unknown exception"
 msgstr ""
 
-#: ../src/common/image.cpp:2839
+#: ../src/common/image.cpp:2942
 msgid "Unknown image data format."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:914
+#: ../src/common/cmdline.cpp:910
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:631
+#: ../src/msw/ole/automtn.cpp:622
 msgid "Unknown name or named argument."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:929 ../src/common/cmdline.cpp:951
+#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
 #, c-format
 msgid "Unknown option '%s'"
 msgstr ""
 
-#: ../src/common/mimecmn.cpp:225
+#: ../src/common/mimecmn.cpp:221
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr ""
 
-#: ../src/common/cmdproc.cpp:262 ../src/common/cmdproc.cpp:288
-#: ../src/common/cmdproc.cpp:308
+#: ../src/common/cmdproc.cpp:255 ../src/common/cmdproc.cpp:281
+#: ../src/common/cmdproc.cpp:301
 msgid "Unnamed command"
 msgstr ""
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:413
+#: ../src/propgrid/propgrid.cpp:392
 msgid "Unspecified"
 msgstr ""
 
-#: ../src/msw/clipbrd.cpp:311
+#: ../src/msw/clipbrd.cpp:325
 msgid "Unsupported clipboard format."
 msgstr ""
 
-#: ../src/common/appcmn.cpp:256
+#: ../src/common/appcmn.cpp:277
 #, c-format
 msgid "Unsupported theme '%s'."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:205
-#: ../src/common/accelcmn.cpp:63
+#: ../src/common/stockitem.cpp:202 ../src/common/accelcmn.cpp:60
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Up"
 msgstr ""
 
@@ -7579,7 +7737,7 @@ msgstr ""
 msgid "Upper case roman numerals"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1326
+#: ../src/common/cmdline.cpp:1322
 #, c-format
 msgid "Usage: %s"
 msgstr ""
@@ -7588,38 +7746,47 @@ msgstr ""
 msgid "Use &shadow"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:169
-#: ../src/richtext/richtextindentspage.cpp:171
 #: ../src/richtext/richtextliststylepage.cpp:358
 #: ../src/richtext/richtextliststylepage.cpp:360
+#: ../src/richtext/richtextindentspage.cpp:169
+#: ../src/richtext/richtextindentspage.cpp:171
 msgid "Use the current alignment setting."
 msgstr ""
 
-#: ../src/common/valtext.cpp:179
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/gtk/font.cpp:552
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/common/valtext.cpp:142
 msgid "Validation conflict"
 msgstr ""
 
-#: ../src/propgrid/manager.cpp:238
+#: ../src/propgrid/manager.cpp:224
 msgid "Value"
 msgstr ""
 
-#: ../src/propgrid/props.cpp:386 ../src/propgrid/props.cpp:500
+#: ../src/propgrid/props.cpp:309
 #, c-format
 msgid "Value must be %s or higher."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:417 ../src/propgrid/props.cpp:531
+#: ../src/propgrid/props.cpp:336
 #, c-format
 msgid "Value must be %s or less."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:393 ../src/propgrid/props.cpp:424
-#: ../src/propgrid/props.cpp:507 ../src/propgrid/props.cpp:538
+#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:128
+#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr ""
 
@@ -7628,25 +7795,32 @@ msgstr ""
 msgid "Vertical alignment."
 msgstr ""
 
-#: ../src/generic/filedlgg.cpp:202
+#: ../src/generic/filedlgg.cpp:199
 msgid "View files as a detailed view"
 msgstr ""
 
-#: ../src/generic/filedlgg.cpp:200
+#: ../src/generic/filedlgg.cpp:197
 msgid "View files as a list view"
 msgstr ""
 
-#: ../src/common/docview.cpp:1970
+#: ../src/common/docview.cpp:1975
 msgid "Views"
 msgstr ""
 
+#: ../src/gtk/app.cpp:348
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1777
+#: ../src/propgrid/advprops.cpp:1678
 msgid "Wait"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1779
+#: ../src/propgrid/advprops.cpp:1680
 msgid "Wait Arrow"
 msgstr ""
 
@@ -7655,237 +7829,233 @@ msgstr ""
 msgid "Waiting for IO on epoll descriptor %d failed"
 msgstr ""
 
-#: ../src/common/log.cpp:223
+#: ../src/common/log.cpp:241
 msgid "Warning: "
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1778
+#: ../src/propgrid/advprops.cpp:1679
 msgid "Watch"
 msgstr ""
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:685
+#: ../src/propgrid/advprops.cpp:595
 msgid "Weight"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:148
+#: ../src/common/fmapbase.cpp:145
 msgid "Western European (ISO-8859-1)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:162
+#: ../src/common/fmapbase.cpp:159
 msgid "Western European with Euro (ISO-8859-15)"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:446 ../src/generic/fontdlgg.cpp:448
+#: ../src/generic/fontdlgg.cpp:443 ../src/generic/fontdlgg.cpp:445
 msgid "Whether the font is underlined."
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1611
+#: ../src/propgrid/advprops.cpp:1517
 msgid "White"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:144
+#: ../src/generic/fdrepdlg.cpp:141
 msgid "Whole word"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:532
 msgid "Whole words only"
 msgstr ""
 
-#: ../src/univ/themes/win32.cpp:1102
+#: ../src/univ/themes/win32.cpp:1099
 msgid "Win32 theme"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:893
+#: ../src/propgrid/advprops.cpp:794
 msgid "Window"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:894
+#: ../src/propgrid/advprops.cpp:795
 msgid "WindowFrame"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:895
+#: ../src/propgrid/advprops.cpp:796
 msgid "WindowText"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:177
+#: ../src/common/fmapbase.cpp:174
 msgid "Windows Arabic (CP 1256)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:178
+#: ../src/common/fmapbase.cpp:175
 msgid "Windows Baltic (CP 1257)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:171
+#: ../src/common/fmapbase.cpp:168
 msgid "Windows Central European (CP 1250)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:168
+#: ../src/common/fmapbase.cpp:165
 msgid "Windows Chinese Simplified (CP 936) or GB-2312"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:170
+#: ../src/common/fmapbase.cpp:167
 msgid "Windows Chinese Traditional (CP 950) or Big-5"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:172
+#: ../src/common/fmapbase.cpp:169
 msgid "Windows Cyrillic (CP 1251)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:174
+#: ../src/common/fmapbase.cpp:171
 msgid "Windows Greek (CP 1253)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:176
+#: ../src/common/fmapbase.cpp:173
 msgid "Windows Hebrew (CP 1255)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:167
+#: ../src/common/fmapbase.cpp:164
 msgid "Windows Japanese (CP 932) or Shift-JIS"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:180
+#: ../src/common/fmapbase.cpp:177
 msgid "Windows Johab (CP 1361)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:169
+#: ../src/common/fmapbase.cpp:166
 msgid "Windows Korean (CP 949)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:166
+#: ../src/common/fmapbase.cpp:163
 msgid "Windows Thai (CP 874)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:175
+#: ../src/common/fmapbase.cpp:172
 msgid "Windows Turkish (CP 1254)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:179
+#: ../src/common/fmapbase.cpp:176
 msgid "Windows Vietnamese (CP 1258)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:173
+#: ../src/common/fmapbase.cpp:170
 msgid "Windows Western European (CP 1252)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:181
+#: ../src/common/fmapbase.cpp:178
 msgid "Windows/DOS OEM (CP 437)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:165
+#: ../src/common/fmapbase.cpp:162
 msgid "Windows/DOS OEM Cyrillic (CP 866)"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:111
+#: ../src/common/accelcmn.cpp:109
 msgid "Windows_Left"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:113
+#: ../src/common/accelcmn.cpp:111
 msgid "Windows_Menu"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:112
+#: ../src/common/accelcmn.cpp:110
 msgid "Windows_Right"
 msgstr ""
 
-#: ../src/common/ffile.cpp:150
+#: ../src/common/ffile.cpp:149
 #, c-format
 msgid "Write error on file '%s'"
 msgstr ""
 
-#: ../src/xml/xml.cpp:914
+#: ../src/xml/xml.cpp:925
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr ""
 
-#: ../src/common/xpmdecod.cpp:796
+#: ../src/common/xpmdecod.cpp:794
 msgid "XPM: Malformed pixel data!"
 msgstr ""
 
-#: ../src/common/xpmdecod.cpp:705
+#: ../src/common/xpmdecod.cpp:702
 #, c-format
 msgid "XPM: incorrect colour description in line %d"
 msgstr ""
 
-#: ../src/common/xpmdecod.cpp:680
+#: ../src/common/xpmdecod.cpp:677
 msgid "XPM: incorrect header format!"
 msgstr ""
 
-#: ../src/common/xpmdecod.cpp:716 ../src/common/xpmdecod.cpp:725
+#: ../src/common/xpmdecod.cpp:714 ../src/common/xpmdecod.cpp:723
 #, c-format
 msgid "XPM: malformed colour definition '%s' at line %d!"
 msgstr ""
 
-#: ../src/common/xpmdecod.cpp:755
+#: ../src/common/xpmdecod.cpp:753
 msgid "XPM: no colors left to use for mask!"
 msgstr ""
 
-#: ../src/common/xpmdecod.cpp:782
+#: ../src/common/xpmdecod.cpp:780
 #, c-format
 msgid "XPM: truncated image data at line %d!"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1610
+#: ../src/propgrid/advprops.cpp:1516
 msgid "Yellow"
 msgstr ""
 
-#: ../include/wx/msgdlg.h:276 ../src/common/stockitem.cpp:206
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:203
 #: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr ""
 
-#: ../src/osx/carbon/overlay.cpp:155
-msgid "You cannot Clear an overlay that is not inited"
-msgstr ""
-
-#: ../src/osx/carbon/overlay.cpp:107 ../src/dfb/overlay.cpp:61
-msgid "You cannot Init an overlay twice"
-msgstr ""
-
-#: ../src/generic/dirdlgg.cpp:287
+#: ../src/generic/dirdlgg.cpp:284
 msgid "You cannot add a new directory to this section."
 msgstr ""
 
-#: ../src/propgrid/propgrid.cpp:3299
+#: ../src/propgrid/propgrid.cpp:3276
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:209
+#: ../src/osx/cocoa/menu.mm:286
+msgid "Zoom"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:206
 msgid "Zoom &In"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:210
+#: ../src/common/stockitem.cpp:207
 msgid "Zoom &Out"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:209 ../src/common/prntbase.cpp:1594
+#: ../src/common/stockitem.cpp:206 ../src/common/prntbase.cpp:1619
 msgid "Zoom In"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:210 ../src/common/prntbase.cpp:1580
+#: ../src/common/stockitem.cpp:207 ../src/common/prntbase.cpp:1605
 msgid "Zoom Out"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to &Fit"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to Fit"
 msgstr ""
 
-#: ../src/msw/dde.cpp:1141
+#: ../src/msw/dde.cpp:1205
 msgid "a DDEML application has created a prolonged race condition."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1129
+#: ../src/msw/dde.cpp:1193
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -7893,54 +8063,54 @@ msgid ""
 "was passed to a DDEML function."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1147
+#: ../src/msw/dde.cpp:1211
 msgid "a client's attempt to establish a conversation has failed."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1144
+#: ../src/msw/dde.cpp:1208
 msgid "a memory allocation failed."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1138
+#: ../src/msw/dde.cpp:1202
 msgid "a parameter failed to be validated by the DDEML."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1120
+#: ../src/msw/dde.cpp:1184
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1126
+#: ../src/msw/dde.cpp:1190
 msgid "a request for a synchronous data transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1135
+#: ../src/msw/dde.cpp:1199
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1153
+#: ../src/msw/dde.cpp:1217
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1168
+#: ../src/msw/dde.cpp:1232
 msgid "a request to end an advise transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1162
+#: ../src/msw/dde.cpp:1226
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
 "terminated before completing a transaction."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1150
+#: ../src/msw/dde.cpp:1214
 msgid "a transaction failed."
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:189
+#: ../src/common/accelcmn.cpp:188
 msgid "alt"
 msgstr ""
 
-#: ../src/msw/dde.cpp:1132
+#: ../src/msw/dde.cpp:1196
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -7948,71 +8118,71 @@ msgid ""
 "attempted to perform server transactions."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1156
+#: ../src/msw/dde.cpp:1220
 msgid "an internal call to the PostMessage function has failed. "
 msgstr ""
 
-#: ../src/msw/dde.cpp:1165
+#: ../src/msw/dde.cpp:1229
 msgid "an internal error has occurred in the DDEML."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1171
+#: ../src/msw/dde.cpp:1235
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
 "the transaction identifier for that callback is no longer valid."
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1483
+#: ../src/common/zipstrm.cpp:1522
 msgid "assuming this is a multi-part zip concatenated"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1847
+#: ../src/common/fileconf.cpp:1849
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr ""
 
-#: ../src/html/chm.cpp:329
+#: ../src/html/chm.cpp:326
 msgid "bad arguments to library function"
 msgstr ""
 
-#: ../src/html/chm.cpp:341
+#: ../src/html/chm.cpp:338
 msgid "bad signature"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1918
+#: ../src/common/zipstrm.cpp:1988
 msgid "bad zipfile offset to entry"
 msgstr ""
 
-#: ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400
 msgid "binary"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:996
+#: ../src/common/fontcmn.cpp:1195
 msgid "bold"
 msgstr ""
 
-#: ../src/msw/utils.cpp:1144
+#: ../src/msw/utils.cpp:1135
 #, c-format
 msgid "build %lu"
 msgstr ""
 
-#: ../src/common/ffile.cpp:75
+#: ../src/common/ffile.cpp:73
 #, c-format
 msgid "can't close file '%s'"
 msgstr ""
 
-#: ../src/common/file.cpp:245
+#: ../src/common/file.cpp:242
 #, c-format
 msgid "can't close file descriptor %d"
 msgstr ""
 
-#: ../src/common/file.cpp:586
+#: ../src/common/ffile.cpp:382 ../src/common/file.cpp:613
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr ""
 
-#: ../src/common/file.cpp:178
+#: ../src/common/file.cpp:175
 #, c-format
 msgid "can't create file '%s'"
 msgstr ""
@@ -8022,49 +8192,49 @@ msgstr ""
 msgid "can't delete user configuration file '%s'"
 msgstr ""
 
-#: ../src/common/file.cpp:495
+#: ../src/common/file.cpp:522
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1692
+#: ../src/common/zipstrm.cpp:1747
 msgid "can't find central directory in zip"
 msgstr ""
 
-#: ../src/common/file.cpp:465
+#: ../src/common/file.cpp:492
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr ""
 
-#: ../src/msw/utils.cpp:341
+#: ../src/msw/utils.cpp:336
 msgid "can't find user's HOME, using current directory."
 msgstr ""
 
-#: ../src/common/file.cpp:366
+#: ../src/common/file.cpp:407
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr ""
 
-#: ../src/common/file.cpp:422
+#: ../src/common/file.cpp:463
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr ""
 
-#: ../src/common/fontmap.cpp:325
+#: ../src/common/fontmap.cpp:322
 msgid "can't load any font, aborting"
 msgstr ""
 
-#: ../src/common/file.cpp:231 ../src/common/ffile.cpp:59
+#: ../src/common/ffile.cpp:57 ../src/common/file.cpp:228
 #, c-format
 msgid "can't open file '%s'"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:320
+#: ../src/common/fileconf.cpp:314
 #, c-format
 msgid "can't open global configuration file '%s'."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:336
+#: ../src/common/fileconf.cpp:330
 #, c-format
 msgid "can't open user configuration file '%s'."
 msgstr ""
@@ -8073,40 +8243,40 @@ msgstr ""
 msgid "can't open user configuration file."
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:579
+#: ../src/common/zipstrm.cpp:572
 msgid "can't re-initialize zlib deflate stream"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:604
+#: ../src/common/zipstrm.cpp:597
 msgid "can't re-initialize zlib inflate stream"
 msgstr ""
 
-#: ../src/common/file.cpp:304
+#: ../src/common/file.cpp:345
 #, c-format
 msgid "can't read from file descriptor %d"
 msgstr ""
 
-#: ../src/common/file.cpp:581
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:608
 #, c-format
 msgid "can't remove file '%s'"
 msgstr ""
 
-#: ../src/common/file.cpp:598
+#: ../src/common/ffile.cpp:394 ../src/common/file.cpp:625
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr ""
 
-#: ../src/common/file.cpp:408
+#: ../src/common/file.cpp:449
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr ""
 
-#: ../src/common/textfile.cpp:273
+#: ../src/common/textfile.cpp:161
 #, c-format
 msgid "can't write buffer '%s' to disk."
 msgstr ""
 
-#: ../src/common/file.cpp:323
+#: ../src/common/file.cpp:364
 #, c-format
 msgid "can't write to file descriptor %d"
 msgstr ""
@@ -8116,22 +8286,28 @@ msgid "can't write user configuration file."
 msgstr ""
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:482 ../src/generic/datavgen.cpp:1261
+#: ../src/common/datavcmn.cpp:2064 ../src/generic/datavgen.cpp:1384
 msgid "checked"
 msgstr ""
 
-#: ../src/html/chm.cpp:345
+#: ../src/html/chm.cpp:342
 msgid "checksum error"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:820
+#: ../src/common/tarstrm.cpp:814
 msgid "checksum failure reading tar header block"
 msgstr ""
 
-#: ../src/richtext/richtextbackgroundpage.cpp:226
-#: ../src/richtext/richtextbackgroundpage.cpp:249
-#: ../src/richtext/richtextbackgroundpage.cpp:289
-#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
 #: ../src/richtext/richtextborderspage.cpp:254
 #: ../src/richtext/richtextborderspage.cpp:288
 #: ../src/richtext/richtextborderspage.cpp:322
@@ -8149,104 +8325,124 @@ msgstr ""
 #: ../src/richtext/richtextmarginspage.cpp:340
 #: ../src/richtext/richtextmarginspage.cpp:363
 #: ../src/richtext/richtextmarginspage.cpp:388
-#: ../src/richtext/richtextsizepage.cpp:339
-#: ../src/richtext/richtextsizepage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:400
-#: ../src/richtext/richtextsizepage.cpp:427
-#: ../src/richtext/richtextsizepage.cpp:454
-#: ../src/richtext/richtextsizepage.cpp:481
-#: ../src/richtext/richtextsizepage.cpp:555
-#: ../src/richtext/richtextsizepage.cpp:590
-#: ../src/richtext/richtextsizepage.cpp:625
-#: ../src/richtext/richtextsizepage.cpp:660
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
 msgid "cm"
 msgstr ""
 
-#: ../src/html/chm.cpp:347
+#: ../src/html/chm.cpp:344
 msgid "compression error"
 msgstr ""
 
-#: ../src/common/regex.cpp:236
+#: ../src/common/regex.cpp:233
 msgid "conversion to 8-bit encoding failed"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:187
+#: ../src/common/accelcmn.cpp:186
 msgid "ctrl"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1500
+#: ../src/common/cmdline.cpp:1496
 msgid "date"
 msgstr ""
 
-#: ../src/html/chm.cpp:349
+#: ../src/html/chm.cpp:346
 msgid "decompression error"
 msgstr ""
 
-#: ../src/richtext/richtextstyles.cpp:780 ../src/common/fmapbase.cpp:820
+#: ../src/common/fmapbase.cpp:816 ../src/richtext/richtextstyles.cpp:777
 msgid "default"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1496
+#: ../src/common/cmdline.cpp:1492
 msgid "double"
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:538
+#: ../src/common/debugrpt.cpp:539
 msgid "dump of the process state (binary)"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1969
+#: ../src/common/datetimefmt.cpp:1992
 msgid "eighteenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1959
+#: ../src/common/datetimefmt.cpp:1982
 msgid "eighth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1962
+#: ../src/common/datetimefmt.cpp:1985
 msgid "eleventh"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1833
+#: ../src/common/fileconf.cpp:1835
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr ""
 
-#: ../src/html/chm.cpp:343
+#: ../src/html/chm.cpp:340
 msgid "error in data format"
 msgstr ""
 
-#: ../src/html/chm.cpp:331
+#: ../src/html/chm.cpp:328
 msgid "error opening file"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1778
+#: ../src/common/zipstrm.cpp:1836
 msgid "error reading zip central directory"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1870
+#: ../src/common/zipstrm.cpp:1940
 msgid "error reading zip local header"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2531
+#: ../src/common/zipstrm.cpp:2615
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr ""
 
-#: ../src/common/ffile.cpp:188
+#: ../src/common/zipstrm.cpp:2608
+#, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1205
+msgid "extrabold"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1223
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1167
+#, fuzzy
+msgid "extralight"
+msgstr " سبک"
+
+#: ../src/msw/webview_ie.cpp:1036
+msgid "failed to evaluate"
+msgstr ""
+
+#: ../src/common/ffile.cpp:187
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr ""
 
+#: ../src/msw/webview_ie.cpp:1045
+msgid "failed to retrieve execution result"
+msgstr ""
+
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1030
+#: ../src/generic/datavgen.cpp:1150
 msgid "false"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1966
+#: ../src/common/datetimefmt.cpp:1989
 msgid "fifteenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1956
+#: ../src/common/datetimefmt.cpp:1979
 msgid "fifth"
 msgstr ""
 
@@ -8275,131 +8471,149 @@ msgstr ""
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:8738
+#: ../src/richtext/richtextbuffer.cpp:8736
 msgid "files"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1952
+#: ../src/common/datetimefmt.cpp:1975
 msgid "first"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1252
+#: ../src/html/helpwnd.cpp:1250
 msgid "font size"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1965
+#: ../src/common/datetimefmt.cpp:1988
 msgid "fourteenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1955
+#: ../src/common/datetimefmt.cpp:1978
 msgid "fourth"
 msgstr ""
 
-#: ../src/common/appbase.cpp:783
+#: ../src/common/appbase.cpp:784
 msgid "generate verbose log messages"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:13138
-#: ../src/richtext/richtextbuffer.cpp:13248
+#: ../src/common/fontcmn.cpp:1215
+msgid "heavy"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:13133
+#: ../src/richtext/richtextbuffer.cpp:13243
 msgid "image"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:796
+#: ../src/common/tarstrm.cpp:790
 msgid "incomplete header block in tar"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:489
+#: ../src/common/xtixml.cpp:485
 msgid "incorrect event handler string, missing dot"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:1381
+#: ../src/common/tarstrm.cpp:1375
 msgid "incorrect size given for tar entry"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:993
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:987
 msgid "invalid data in extended tar header"
 msgstr ""
 
-#: ../src/generic/logg.cpp:1030
+#: ../src/generic/logg.cpp:1027
 msgid "invalid message box return value"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1647
+#: ../src/common/zipstrm.cpp:1688
 msgid "invalid zip file"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:1228
 msgid "italic"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:991
+#: ../src/common/webrequest_curl.cpp:374
+msgid "libcurl could not be initialized"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1172
 msgid "light"
 msgstr ""
 
-#: ../src/common/intl.cpp:303
-#, c-format
-msgid "locale '%s' cannot be set."
+#: ../src/common/fontcmn.cpp:1185
+msgid "medium"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2125
+#: ../src/common/datetimefmt.cpp:2148
 msgid "midnight"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1970
+#: ../src/common/datetimefmt.cpp:1993
 msgid "nineteenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1960
+#: ../src/common/datetimefmt.cpp:1983
 msgid "ninth"
 msgstr ""
 
-#: ../src/msw/dde.cpp:1116
+#: ../src/msw/dde.cpp:1180
 msgid "no DDE error."
 msgstr ""
 
-#: ../src/html/chm.cpp:327
+#: ../src/html/chm.cpp:324
 msgid "no error"
 msgstr ""
 
-#: ../src/dfb/fontmgr.cpp:174
+#: ../src/dfb/fontmgr.cpp:171
 #, c-format
 msgid "no fonts found in %s, using builtin font"
 msgstr ""
 
-#: ../src/html/helpdata.cpp:657
+#: ../src/html/helpdata.cpp:650
 msgid "noname"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2124
+#: ../src/common/datetimefmt.cpp:2147
 msgid "noon"
 msgstr ""
 
-#: ../src/richtext/richtextstyles.cpp:779
+#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1492
+#: ../src/common/cmdline.cpp:1488
 msgid "num"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:259
+#: ../src/common/accelcmn.cpp:194
+msgid "num "
+msgstr ""
+
+#: ../src/common/xtixml.cpp:255
 msgid "objects cannot have XML Text Nodes"
 msgstr ""
 
-#: ../src/html/chm.cpp:339
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
 msgid "out of memory"
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:514
+#: ../src/common/debugrpt.cpp:515
 msgid "process context description"
 msgstr ""
 
-#: ../src/richtext/richtextbackgroundpage.cpp:227
-#: ../src/richtext/richtextbackgroundpage.cpp:250
-#: ../src/richtext/richtextbackgroundpage.cpp:290
-#: ../src/richtext/richtextbackgroundpage.cpp:317
-#: ../src/richtext/richtextfontpage.cpp:177
-#: ../src/richtext/richtextfontpage.cpp:180
 #: ../src/richtext/richtextborderspage.cpp:255
 #: ../src/richtext/richtextborderspage.cpp:289
 #: ../src/richtext/richtextborderspage.cpp:323
@@ -8409,22 +8623,45 @@ msgstr ""
 #: ../src/richtext/richtextborderspage.cpp:491
 #: ../src/richtext/richtextborderspage.cpp:525
 #: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextfontpage.cpp:180
 msgid "pt"
 msgstr ""
 
-#: ../src/richtext/richtextbackgroundpage.cpp:225
-#: ../src/richtext/richtextbackgroundpage.cpp:228
-#: ../src/richtext/richtextbackgroundpage.cpp:229
-#: ../src/richtext/richtextbackgroundpage.cpp:248
-#: ../src/richtext/richtextbackgroundpage.cpp:251
-#: ../src/richtext/richtextbackgroundpage.cpp:252
-#: ../src/richtext/richtextbackgroundpage.cpp:288
-#: ../src/richtext/richtextbackgroundpage.cpp:291
-#: ../src/richtext/richtextbackgroundpage.cpp:292
-#: ../src/richtext/richtextbackgroundpage.cpp:315
-#: ../src/richtext/richtextbackgroundpage.cpp:318
-#: ../src/richtext/richtextbackgroundpage.cpp:319
-#: ../src/richtext/richtextfontpage.cpp:178
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:659
+#: ../src/richtext/richtextsizepage.cpp:662
+#: ../src/richtext/richtextsizepage.cpp:663
 #: ../src/richtext/richtextborderspage.cpp:253
 #: ../src/richtext/richtextborderspage.cpp:256
 #: ../src/richtext/richtextborderspage.cpp:257
@@ -8476,259 +8713,269 @@ msgstr ""
 #: ../src/richtext/richtextmarginspage.cpp:387
 #: ../src/richtext/richtextmarginspage.cpp:389
 #: ../src/richtext/richtextmarginspage.cpp:390
-#: ../src/richtext/richtextsizepage.cpp:338
-#: ../src/richtext/richtextsizepage.cpp:341
-#: ../src/richtext/richtextsizepage.cpp:342
-#: ../src/richtext/richtextsizepage.cpp:372
-#: ../src/richtext/richtextsizepage.cpp:375
-#: ../src/richtext/richtextsizepage.cpp:376
-#: ../src/richtext/richtextsizepage.cpp:399
-#: ../src/richtext/richtextsizepage.cpp:402
-#: ../src/richtext/richtextsizepage.cpp:403
-#: ../src/richtext/richtextsizepage.cpp:426
-#: ../src/richtext/richtextsizepage.cpp:429
-#: ../src/richtext/richtextsizepage.cpp:430
-#: ../src/richtext/richtextsizepage.cpp:453
-#: ../src/richtext/richtextsizepage.cpp:456
-#: ../src/richtext/richtextsizepage.cpp:457
-#: ../src/richtext/richtextsizepage.cpp:480
-#: ../src/richtext/richtextsizepage.cpp:483
-#: ../src/richtext/richtextsizepage.cpp:484
-#: ../src/richtext/richtextsizepage.cpp:554
-#: ../src/richtext/richtextsizepage.cpp:557
-#: ../src/richtext/richtextsizepage.cpp:558
-#: ../src/richtext/richtextsizepage.cpp:589
-#: ../src/richtext/richtextsizepage.cpp:592
-#: ../src/richtext/richtextsizepage.cpp:593
-#: ../src/richtext/richtextsizepage.cpp:624
-#: ../src/richtext/richtextsizepage.cpp:627
-#: ../src/richtext/richtextsizepage.cpp:628
-#: ../src/richtext/richtextsizepage.cpp:659
-#: ../src/richtext/richtextsizepage.cpp:662
-#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextfontpage.cpp:178
 msgid "px"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:193
+#: ../src/common/accelcmn.cpp:192
 msgid "rawctrl"
 msgstr ""
 
-#: ../src/html/chm.cpp:333
+#: ../src/html/chm.cpp:330
 msgid "read error"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2085
+#: ../src/common/zipstrm.cpp:2155
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2080
+#: ../src/common/zipstrm.cpp:2150
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr ""
 
-#: ../src/msw/dde.cpp:1159
+#: ../src/msw/dde.cpp:1223
 msgid "reentrancy problem."
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1953
+#: ../src/common/datetimefmt.cpp:1976
 msgid "second"
 msgstr ""
 
-#: ../src/html/chm.cpp:337
+#: ../src/html/chm.cpp:334
 msgid "seek error"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1968
+#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#, fuzzy
+msgid "semibold"
+msgstr " پررنگ"
+
+#: ../src/common/datetimefmt.cpp:1991
 msgid "seventeenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1958
+#: ../src/common/datetimefmt.cpp:1981
 msgid "seventh"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:191
+#: ../src/common/accelcmn.cpp:190
 msgid "shift"
 msgstr ""
 
-#: ../src/common/appbase.cpp:773
+#: ../src/common/appbase.cpp:774
 msgid "show this help message"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1967
+#: ../src/common/datetimefmt.cpp:1990
 msgid "sixteenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1957
+#: ../src/common/datetimefmt.cpp:1980
 msgid "sixth"
 msgstr ""
 
-#: ../src/common/appcmn.cpp:234
+#: ../src/common/appcmn.cpp:255
 msgid "specify display mode to use (e.g. 640x480-16)"
 msgstr ""
 
-#: ../src/common/appcmn.cpp:220
+#: ../src/common/appcmn.cpp:241
 msgid "specify the theme to use"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9340
+#: ../src/richtext/richtextbuffer.cpp:9337
 msgid "standard/circle"
 msgstr "استاندارد / دایره"
 
-#: ../src/richtext/richtextbuffer.cpp:9341
+#: ../src/richtext/richtextbuffer.cpp:9338
 msgid "standard/circle-outline"
 msgstr "طرح کلی / دایره"
 
-#: ../src/richtext/richtextbuffer.cpp:9343
+#: ../src/richtext/richtextbuffer.cpp:9340
 msgid "standard/diamond"
 msgstr "استاندارد / الماس"
 
-#: ../src/richtext/richtextbuffer.cpp:9342
+#: ../src/richtext/richtextbuffer.cpp:9339
 msgid "standard/square"
 msgstr "استاندارد / مربع"
 
-#: ../src/richtext/richtextbuffer.cpp:9344
+#: ../src/richtext/richtextbuffer.cpp:9341
 msgid "standard/triangle"
 msgstr "استاندارد / مثلث"
 
-#: ../src/common/zipstrm.cpp:1985
+#: ../src/common/zipstrm.cpp:2055
 msgid "stored file length not in Zip header"
 msgstr "طول پرونده ذخیره شده در سربرگ Zip نیست"
 
-#: ../src/common/cmdline.cpp:1488
+#: ../src/common/cmdline.cpp:1484
 msgid "str"
 msgstr "رشته"
 
-#: ../src/common/fontcmn.cpp:982
+#: ../src/common/fontcmn.cpp:1145
 msgid "strikethrough"
 msgstr "متن برجسته"
 
-#: ../src/common/tarstrm.cpp:1003 ../src/common/tarstrm.cpp:1025
-#: ../src/common/tarstrm.cpp:1507 ../src/common/tarstrm.cpp:1529
+#: ../src/common/tarstrm.cpp:997 ../src/common/tarstrm.cpp:1019
+#: ../src/common/tarstrm.cpp:1501 ../src/common/tarstrm.cpp:1523
 msgid "tar entry not open"
 msgstr "ورودی تار باز نیست"
 
-#: ../src/common/datetimefmt.cpp:1961
+#: ../src/common/datetimefmt.cpp:1984
 msgid "tenth"
 msgstr "دهم"
 
-#: ../src/msw/dde.cpp:1123
+#: ../src/msw/dde.cpp:1187
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "پاسخ به ترکنش باعث شد بیت DDE_FBUSY تنظیم شود."
 
-#: ../src/common/datetimefmt.cpp:1954
+#: ../src/common/fontcmn.cpp:1154
+msgid "thin"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:1977
 msgid "third"
 msgstr "سومین"
 
-#: ../src/common/datetimefmt.cpp:1964
+#: ../src/common/datetimefmt.cpp:1987
 msgid "thirteenth"
 msgstr "سیزدهم"
 
-#: ../src/common/datetimefmt.cpp:1758
+#: ../src/common/datetimefmt.cpp:1781
 msgid "today"
 msgstr "امروز"
 
-#: ../src/common/datetimefmt.cpp:1760
+#: ../src/common/datetimefmt.cpp:1783
 msgid "tomorrow"
 msgstr "فردا"
 
-#: ../src/common/fileconf.cpp:1944
+#: ../src/common/fileconf.cpp:1946
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr ""
 
-#: ../src/gtk/aboutdlg.cpp:218
+#: ../src/gtk/aboutdlg.cpp:216
 msgid "translator-credits"
 msgstr "مترجم-اعتبارات"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1028
+#: ../src/generic/datavgen.cpp:1148
 msgid "true"
 msgstr "درست"
 
-#: ../src/common/datetimefmt.cpp:1963
+#: ../src/common/datetimefmt.cpp:1986
 msgid "twelfth"
 msgstr "دوازدهم"
 
-#: ../src/common/datetimefmt.cpp:1971
+#: ../src/common/datetimefmt.cpp:1994
 msgid "twentieth"
 msgstr "بیستم"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:486 ../src/generic/datavgen.cpp:1263
+#: ../src/common/datavcmn.cpp:2068 ../src/generic/datavgen.cpp:1386
 msgid "unchecked"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:802 ../src/common/fontcmn.cpp:978
+#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
 msgid "underlined"
 msgstr "زیر خط دار"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:490
+#: ../src/common/datavcmn.cpp:2072
 msgid "undetermined"
 msgstr "نامشخص"
 
-#: ../src/common/fileconf.cpp:1979
+#: ../src/common/fileconf.cpp:1981
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:1045
+#: ../src/common/tarstrm.cpp:1039
 msgid "unexpected end of file"
 msgstr "پایان غیر منتظره فایل"
 
-#: ../src/generic/progdlgg.cpp:370 ../src/common/tarstrm.cpp:371
-#: ../src/common/tarstrm.cpp:394 ../src/common/tarstrm.cpp:425
+#: ../src/common/tarstrm.cpp:366 ../src/common/tarstrm.cpp:389
+#: ../src/common/tarstrm.cpp:420 ../src/generic/progdlgg.cpp:376
 msgid "unknown"
 msgstr "ناشناخته"
 
-#: ../src/msw/registry.cpp:150
+#: ../src/msw/registry.cpp:139
 #, c-format
 msgid "unknown (%lu)"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:253
+#: ../src/common/xtixml.cpp:249
 #, c-format
 msgid "unknown class %s"
 msgstr ""
 
-#: ../src/common/regex.cpp:258 ../src/html/chm.cpp:351
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "خطای ناشناخته"
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "خطای ناشناخته"
+
+#: ../src/common/regex.cpp:255 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "خطای ناشناخته"
 
-#: ../src/msw/dialup.cpp:471
+#: ../src/msw/dialup.cpp:465
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:834
+#: ../src/common/fmapbase.cpp:830
 #, c-format
 msgid "unknown-%d"
 msgstr ""
 
-#: ../src/common/docview.cpp:509
+#: ../src/common/docview.cpp:502
 msgid "unnamed"
 msgstr "بی نام"
 
-#: ../src/common/docview.cpp:1624
+#: ../src/common/docview.cpp:1618
 #, c-format
 msgid "unnamed%d"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1999 ../src/common/zipstrm.cpp:2319
+#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
 msgid "unsupported Zip compression method"
 msgstr "روش فشرده سازی فایل های فشرده پشتیبانی نمی شود"
 
-#: ../src/common/translation.cpp:1892
+#: ../src/common/translation.cpp:1942
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr ""
 
-#: ../src/html/chm.cpp:335
+#: ../src/html/chm.cpp:332
 msgid "write error"
 msgstr "خطا در نوشتن"
 
-#: ../src/common/time.cpp:292
+#: ../src/gtk/glcanvas.cpp:187
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/common/time.cpp:285
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay انجام نشد."
 
@@ -8741,15 +8988,15 @@ msgstr ""
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets نمی تواند نمایش را باز کند. خارج شدن."
 
-#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:431
 msgid "xxxx"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1759
+#: ../src/common/datetimefmt.cpp:1782
 msgid "yesterday"
 msgstr "دیروز"
 
-#: ../src/common/zstream.cpp:251 ../src/common/zstream.cpp:426
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
 #, c-format
 msgid "zlib error %d"
 msgstr ""
@@ -8758,3 +9005,6 @@ msgstr ""
 #: ../src/richtext/richtextbulletspage.cpp:288
 msgid "~"
 msgstr ""
+
+#~ msgid " (while overwriting an existing item)"
+#~ msgstr " (درحال رونویسی  یک مورد موجود)"

--- a/locale/fi.po
+++ b/locale/fi.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-21 14:25+0200\n"
+"POT-Creation-Date: 2020-10-18 23:11+0300\n"
 "PO-Revision-Date: 2012-08-07 13:31+0200\n"
 "Last-Translator: Jani Kinnunen <jani.kinnunen@wippies.fi>\n"
 "Language-Team: Finnish <translation-team-fi@lists.sourceforge.net>\n"
@@ -22,7 +22,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 
-#: ../src/common/debugrpt.cpp:586
+#: ../src/common/debugrpt.cpp:587
 msgid ""
 "\n"
 "Please send this report to the program maintainer, thank you!\n"
@@ -30,8 +30,8 @@ msgstr ""
 "\n"
 "Lähetä tämä ilmoitus ohjelman ylläpitäjälle, kiitos!\n"
 
-#: ../src/richtext/richtextstyledlg.cpp:210
-#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:206
+#: ../src/richtext/richtextstyledlg.cpp:218
 msgid " "
 msgstr " "
 
@@ -39,70 +39,96 @@ msgstr " "
 msgid "              Thank you and we're sorry for the inconvenience!\n"
 msgstr "              Kiitos, ja olemme pahoillamme kaikista hankaluuksista!\n"
 
-#: ../src/common/prntbase.cpp:573
+#: ../src/common/prntbase.cpp:568
 #, fuzzy, c-format
 msgid " (copy %d of %d)"
 msgstr "Sivu %d / %d"
 
-#: ../src/common/log.cpp:421
+#: ../src/common/log.cpp:440
 #, c-format
 msgid " (error %ld: %s)"
 msgstr " (virhe %ld: %s)"
 
-#: ../src/common/imagtiff.cpp:72
+#: ../src/common/imagtiff.cpp:69
 #, fuzzy, c-format
 msgid " (in module \"%s\")"
 msgstr "tiff-moduuli: %s"
 
-#: ../src/osx/core/secretstore.cpp:138
-msgid " (while overwriting an existing item)"
-msgstr ""
-
-#: ../src/common/docview.cpp:1642
+#: ../src/common/docview.cpp:1636
 msgid " - "
 msgstr " - "
 
-#: ../src/richtext/richtextprint.cpp:593 ../src/html/htmprint.cpp:714
+#: ../src/html/htmprint.cpp:712 ../src/richtext/richtextprint.cpp:589
 msgid " Preview"
 msgstr " Esikatselu"
 
-#: ../src/common/fontcmn.cpp:824
+#: ../src/common/fontcmn.cpp:973
 msgid " bold"
 msgstr " lihavoitu"
 
-#: ../src/common/fontcmn.cpp:840
+#: ../src/common/fontcmn.cpp:977
+#, fuzzy
+msgid " extra bold"
+msgstr " lihavoitu"
+
+#: ../src/common/fontcmn.cpp:985
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:957
+#, fuzzy
+msgid " extra light"
+msgstr " heikko"
+
+#: ../src/common/fontcmn.cpp:981
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1001
 msgid " italic"
 msgstr " kursivoitu"
 
-#: ../src/common/fontcmn.cpp:820
+#: ../src/common/fontcmn.cpp:961
 msgid " light"
 msgstr " heikko"
 
-#: ../src/common/fontcmn.cpp:807
+#: ../src/common/fontcmn.cpp:965
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:969
+#, fuzzy
+msgid " semi bold"
+msgstr " lihavoitu"
+
+#: ../src/common/fontcmn.cpp:940
 msgid " strikethrough"
 msgstr " yliviivaus"
 
-#: ../src/common/paper.cpp:117
+#: ../src/common/fontcmn.cpp:953
+msgid " thin"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
 msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
 msgstr "#10 kirjekuori, 4 1/8″ x 9 1/2″"
 
-#: ../src/common/paper.cpp:118
+#: ../src/common/paper.cpp:115
 msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
 msgstr "#11 kirjekuori, 4 1/2″ x 10 3/8″"
 
-#: ../src/common/paper.cpp:119
+#: ../src/common/paper.cpp:116
 msgid "#12 Envelope, 4 3/4 x 11 in"
 msgstr "#12 kirjekuori, 4 3/4″ x 11″"
 
-#: ../src/common/paper.cpp:120
+#: ../src/common/paper.cpp:117
 msgid "#14 Envelope, 5 x 11 1/2 in"
 msgstr "#14 kirjekuori, 5″ x 11 1/2″"
 
-#: ../src/common/paper.cpp:116
+#: ../src/common/paper.cpp:113
 msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
 msgstr "#9 kirjekuori, 3 7/8″ x 8 7/8″"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:341
 #: ../src/richtext/richtextsizepage.cpp:340
 #: ../src/richtext/richtextsizepage.cpp:374
 #: ../src/richtext/richtextsizepage.cpp:401
@@ -113,82 +139,83 @@ msgstr "#9 kirjekuori, 3 7/8″ x 8 7/8″"
 #: ../src/richtext/richtextsizepage.cpp:591
 #: ../src/richtext/richtextsizepage.cpp:626
 #: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextbackgroundpage.cpp:341
 #, fuzzy
 msgid "%"
 msgstr "%s"
 
-#: ../src/html/helpwnd.cpp:1031
+#: ../src/html/helpwnd.cpp:1029
 #, c-format
 msgid "%d of %lu"
 msgstr "%d / %lu"
 
-#: ../src/html/helpwnd.cpp:1678
+#: ../src/html/helpwnd.cpp:1676
 #, fuzzy, c-format
 msgid "%i of %u"
 msgstr "%i / %i"
 
-#: ../src/generic/filectrlg.cpp:279
+#: ../src/generic/filectrlg.cpp:275
 #, c-format
 msgid "%ld byte"
 msgid_plural "%ld bytes"
 msgstr[0] "%ld tavu"
 msgstr[1] "%ld tavua"
 
-#: ../src/html/helpwnd.cpp:1033
+#: ../src/html/helpwnd.cpp:1031
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu / %lu"
 
-#: ../src/generic/datavgen.cpp:6028
+#: ../src/generic/datavgen.cpp:6833
 #, fuzzy, c-format
 msgid "%s (%d items)"
 msgstr "%s (tai %s)"
 
-#: ../src/common/cmdline.cpp:1221
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (tai %s)"
 
-#: ../src/generic/logg.cpp:224
+#: ../src/generic/logg.cpp:221
 #, c-format
 msgid "%s Error"
 msgstr "%s-virhe"
 
-#: ../src/generic/logg.cpp:236
+#: ../src/generic/logg.cpp:233
 #, c-format
 msgid "%s Information"
 msgstr "%s-tiedotus"
 
-#: ../src/generic/preferencesg.cpp:113
+#: ../src/generic/preferencesg.cpp:110
 #, fuzzy, c-format
 msgid "%s Preferences"
 msgstr "&Asetukset"
 
-#: ../src/generic/logg.cpp:228
+#: ../src/generic/logg.cpp:225
 #, c-format
 msgid "%s Warning"
 msgstr "%s-varoitus"
 
-#: ../src/common/tarstrm.cpp:1319
+#: ../src/common/tarstrm.cpp:1313
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s ei mahtunut kohteen '%s' tar-otsakkeeseen"
 
-#: ../src/common/fldlgcmn.cpp:124
+#: ../src/common/fldlgcmn.cpp:121
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s-tiedostot (%s)|%s"
 
-#: ../src/html/helpwnd.cpp:1716
+#: ../src/html/helpwnd.cpp:1714
 #, fuzzy, c-format
 msgid "%u of %u"
 msgstr "%lu / %lu"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "&About"
 msgstr "&Tietoja"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "&Actual Size"
 msgstr "&Oikea koko"
 
@@ -196,28 +223,28 @@ msgstr "&Oikea koko"
 msgid "&After a paragraph:"
 msgstr "&Kappaleen jälkeen:"
 
-#: ../src/richtext/richtextindentspage.cpp:128
 #: ../src/richtext/richtextliststylepage.cpp:319
+#: ../src/richtext/richtextindentspage.cpp:128
 msgid "&Alignment"
 msgstr "&Tasaus"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "&Apply"
 msgstr "&Käytä"
 
-#: ../src/richtext/richtextstyledlg.cpp:251
+#: ../src/richtext/richtextstyledlg.cpp:247
 msgid "&Apply Style"
 msgstr "&Käytä tyyliä"
 
-#: ../src/msw/mdi.cpp:179
+#: ../src/msw/mdi.cpp:174
 msgid "&Arrange Icons"
 msgstr "&Järjestä kuvakkeet"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "&Ascending"
 msgstr "&Nouseva"
 
-#: ../src/common/stockitem.cpp:142
+#: ../src/common/stockitem.cpp:139
 msgid "&Back"
 msgstr "&Takaisin"
 
@@ -237,24 +264,24 @@ msgstr "&Taustaväri:"
 msgid "&Blur distance:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:143
+#: ../src/common/stockitem.cpp:140
 msgid "&Bold"
 msgstr "&Lihavoitu"
 
-#: ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141
 msgid "&Bottom"
 msgstr "&Alaosa"
 
+#: ../src/richtext/richtextsizepage.cpp:637
+#: ../src/richtext/richtextsizepage.cpp:644
 #: ../src/richtext/richtextborderspage.cpp:345
 #: ../src/richtext/richtextborderspage.cpp:513
 #: ../src/richtext/richtextmarginspage.cpp:259
 #: ../src/richtext/richtextmarginspage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:637
-#: ../src/richtext/richtextsizepage.cpp:644
 msgid "&Bottom:"
 msgstr "&Alaosa:"
 
-#: ../include/wx/richtext/richtextbuffer.h:3866
+#: ../include/wx/richtext/richtextbuffer.h:3861
 #, fuzzy
 msgid "&Box"
 msgstr "&Lihavoitu"
@@ -264,38 +291,38 @@ msgstr "&Lihavoitu"
 msgid "&Bullet style:"
 msgstr "&Luettelomerkkityyli:"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "&CD-Rom"
 msgstr "&CD-ROM"
 
-#: ../src/generic/wizard.cpp:434 ../src/generic/fontdlgg.cpp:470
-#: ../src/generic/fontdlgg.cpp:489 ../src/osx/carbon/fontdlg.cpp:402
-#: ../src/common/dlgcmn.cpp:279 ../src/common/stockitem.cpp:145
+#: ../src/osx/carbon/fontdlg.cpp:399 ../src/common/stockitem.cpp:142
+#: ../src/generic/wizard.cpp:433 ../src/generic/fontdlgg.cpp:466
+#: ../src/generic/fontdlgg.cpp:485 ../src/osx/cocoa/button.mm:200
 msgid "&Cancel"
 msgstr "&Peruuta"
 
-#: ../src/msw/mdi.cpp:175
+#: ../src/msw/mdi.cpp:170
 msgid "&Cascade"
 msgstr "&Limitä"
 
-#: ../include/wx/richtext/richtextbuffer.h:5960
+#: ../include/wx/richtext/richtextbuffer.h:5955
 msgid "&Cell"
 msgstr "&Solu"
 
-#: ../src/richtext/richtextsymboldlg.cpp:439
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "&Character code:"
 msgstr "&Merkkikoodi:"
 
-#: ../src/common/stockitem.cpp:147
+#: ../src/common/stockitem.cpp:144
 msgid "&Clear"
 msgstr "&Tyhjennä"
 
-#: ../src/generic/logg.cpp:516 ../src/common/stockitem.cpp:148
-#: ../src/common/prntbase.cpp:1600 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/stockitem.cpp:145 ../src/common/prntbase.cpp:1625
+#: ../src/univ/themes/win32.cpp:3753 ../src/generic/logg.cpp:513
 msgid "&Close"
 msgstr "&Sulje"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "&Color"
 msgstr "&Väri"
 
@@ -303,20 +330,20 @@ msgstr "&Väri"
 msgid "&Colour:"
 msgstr "&Väri:"
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "&Convert"
 msgstr "&Muunna"
 
-#: ../src/richtext/richtextctrl.cpp:333 ../src/osx/textctrl_osx.cpp:577
-#: ../src/common/stockitem.cpp:150 ../src/msw/textctrl.cpp:2508
+#: ../src/osx/textctrl_osx.cpp:595 ../src/common/stockitem.cpp:147
+#: ../src/msw/textctrl.cpp:2773 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "K&opioi"
 
-#: ../src/generic/hyperlinkg.cpp:156
+#: ../src/generic/hyperlinkg.cpp:153
 msgid "&Copy URL"
 msgstr "&Kopioi URL-osoite"
 
-#: ../src/common/headerctrlcmn.cpp:306
+#: ../src/common/headerctrlcmn.cpp:304
 msgid "&Customize..."
 msgstr "&Mukauta..."
 
@@ -324,53 +351,54 @@ msgstr "&Mukauta..."
 msgid "&Debug report preview:"
 msgstr "&Ohjelmavirheilmoituksen esikatselu:"
 
-#: ../src/richtext/richtexttabspage.cpp:138
-#: ../src/richtext/richtextctrl.cpp:335 ../src/osx/textctrl_osx.cpp:579
-#: ../src/common/stockitem.cpp:152 ../src/msw/textctrl.cpp:2510
+#: ../src/osx/textctrl_osx.cpp:597 ../src/common/stockitem.cpp:149
+#: ../src/msw/textctrl.cpp:2775 ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtextctrl.cpp:334
 msgid "&Delete"
 msgstr "&Poista"
 
-#: ../src/richtext/richtextstyledlg.cpp:269
+#: ../src/richtext/richtextstyledlg.cpp:265
 msgid "&Delete Style..."
 msgstr "&Poista tyyli..."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "&Descending"
 msgstr "&Laskeva"
 
-#: ../src/generic/logg.cpp:682
+#: ../src/generic/logg.cpp:679
 msgid "&Details"
 msgstr "&Yksityiskohdat"
 
-#: ../src/common/stockitem.cpp:153
+#: ../src/common/stockitem.cpp:150
 msgid "&Down"
 msgstr "&Alas"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "&Edit"
 msgstr "&Muokkaa"
 
-#: ../src/richtext/richtextstyledlg.cpp:263
+#: ../src/richtext/richtextstyledlg.cpp:259
 msgid "&Edit Style..."
 msgstr "&Muokkaa tyyliä..."
 
-#: ../src/common/stockitem.cpp:155
+#: ../src/common/stockitem.cpp:152
 msgid "&Execute"
 msgstr "&Suorita"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/common/stockitem.cpp:154
 msgid "&File"
 msgstr "&Tiedosto"
 
-#: ../src/common/stockitem.cpp:158
-msgid "&Find"
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "&Find..."
 msgstr "&Etsi"
 
-#: ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:430
 msgid "&Finish"
 msgstr "&Lopeta"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:156
 msgid "&First"
 msgstr "&Ensimmäinen"
 
@@ -378,16 +406,16 @@ msgstr "&Ensimmäinen"
 msgid "&Floating mode:"
 msgstr "&Liukuva tila:"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 #, fuzzy
 msgid "&Floppy"
 msgstr "K&opioi"
 
-#: ../src/common/stockitem.cpp:194
+#: ../src/common/stockitem.cpp:191
 msgid "&Font"
 msgstr "&Kirjasin"
 
-#: ../src/generic/fontdlgg.cpp:371
+#: ../src/generic/fontdlgg.cpp:367
 msgid "&Font family:"
 msgstr "&Kirjasinperhe:"
 
@@ -395,20 +423,20 @@ msgstr "&Kirjasinperhe:"
 msgid "&Font for Level..."
 msgstr "&Kirjasin tasolle..."
 
+#: ../src/richtext/richtextsymboldlg.cpp:397
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:400
 msgid "&Font:"
 msgstr "&Kirjasin:"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "&Forward"
 msgstr "&Eteenpäin"
 
-#: ../src/richtext/richtextsymboldlg.cpp:451
+#: ../src/richtext/richtextsymboldlg.cpp:448
 msgid "&From:"
 msgstr "&Lähettäjä:"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "&Harddisk"
 msgstr "&Kiintolevy"
 
@@ -417,9 +445,9 @@ msgstr "&Kiintolevy"
 msgid "&Height:"
 msgstr "&Korkeus:"
 
-#: ../src/generic/wizard.cpp:441 ../src/richtext/richtextstyledlg.cpp:303
-#: ../src/richtext/richtextsymboldlg.cpp:479 ../src/osx/menu_osx.cpp:734
-#: ../src/common/stockitem.cpp:163
+#: ../src/common/stockitem.cpp:160 ../src/generic/wizard.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextstyledlg.cpp:299 ../src/osx/cocoa/menu.mm:226
 msgid "&Help"
 msgstr "&Ohje"
 
@@ -427,7 +455,7 @@ msgstr "&Ohje"
 msgid "&Hide details"
 msgstr "&Piilota tiedot"
 
-#: ../src/common/stockitem.cpp:164
+#: ../src/common/stockitem.cpp:161
 msgid "&Home"
 msgstr "&Koti"
 
@@ -435,55 +463,55 @@ msgstr "&Koti"
 msgid "&Horizontal offset:"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:184
 #: ../src/richtext/richtextliststylepage.cpp:372
+#: ../src/richtext/richtextindentspage.cpp:184
 msgid "&Indentation (tenths of a mm)"
 msgstr "&Sisennys (millimetrin kymmenyksiä)"
 
-#: ../src/richtext/richtextindentspage.cpp:167
 #: ../src/richtext/richtextliststylepage.cpp:356
+#: ../src/richtext/richtextindentspage.cpp:167
 #, fuzzy
 msgid "&Indeterminate"
 msgstr "&Alleviivaus"
 
-#: ../src/common/stockitem.cpp:166
+#: ../src/common/stockitem.cpp:163
 msgid "&Index"
 msgstr "&Indeksi"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "&Info"
 msgstr "&Tiedot"
 
-#: ../src/common/stockitem.cpp:168
+#: ../src/common/stockitem.cpp:165
 msgid "&Italic"
 msgstr "&Kursivoitu"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "&Jump to"
 msgstr "&Hyppää kohteeseen"
 
-#: ../src/richtext/richtextindentspage.cpp:153
 #: ../src/richtext/richtextliststylepage.cpp:342
+#: ../src/richtext/richtextindentspage.cpp:153
 msgid "&Justified"
 msgstr "Tasattu"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "&Last"
 msgstr "&Viimeinen"
 
-#: ../src/richtext/richtextindentspage.cpp:139
 #: ../src/richtext/richtextliststylepage.cpp:328
+#: ../src/richtext/richtextindentspage.cpp:139
 msgid "&Left"
 msgstr "&Vasemmalle"
 
-#: ../src/richtext/richtextindentspage.cpp:195
+#: ../src/richtext/richtextsizepage.cpp:532
+#: ../src/richtext/richtextsizepage.cpp:539
 #: ../src/richtext/richtextborderspage.cpp:243
 #: ../src/richtext/richtextborderspage.cpp:411
 #: ../src/richtext/richtextliststylepage.cpp:381
+#: ../src/richtext/richtextindentspage.cpp:195
 #: ../src/richtext/richtextmarginspage.cpp:186
 #: ../src/richtext/richtextmarginspage.cpp:300
-#: ../src/richtext/richtextsizepage.cpp:532
-#: ../src/richtext/richtextsizepage.cpp:539
 msgid "&Left:"
 msgstr "&Vasemmalle:"
 
@@ -491,11 +519,11 @@ msgstr "&Vasemmalle:"
 msgid "&List level:"
 msgstr "&Luettelotaso:"
 
-#: ../src/generic/logg.cpp:517
+#: ../src/generic/logg.cpp:514
 msgid "&Log"
 msgstr "&Loki"
 
-#: ../src/univ/themes/win32.cpp:3748
+#: ../src/univ/themes/win32.cpp:3745
 msgid "&Move"
 msgstr "&Siirrä"
 
@@ -503,20 +531,19 @@ msgstr "&Siirrä"
 msgid "&Move the object to:"
 msgstr "&Siirrä objekti kohteeseen:"
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "&Network"
 msgstr "&Verkko"
 
-#: ../src/richtext/richtexttabspage.cpp:132 ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173 ../src/richtext/richtexttabspage.cpp:132
 msgid "&New"
 msgstr "&Uusi"
 
-#: ../src/aui/tabmdi.cpp:111 ../src/generic/mdig.cpp:100
-#: ../src/msw/mdi.cpp:180
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
 msgid "&Next"
 msgstr "&Seuraava"
 
-#: ../src/generic/wizard.cpp:432 ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:429
 msgid "&Next >"
 msgstr "&Seuraava >"
 
@@ -524,7 +551,7 @@ msgstr "&Seuraava >"
 msgid "&Next Paragraph"
 msgstr "&Seuraava kappale"
 
-#: ../src/generic/tipdlg.cpp:240
+#: ../src/generic/tipdlg.cpp:237
 msgid "&Next Tip"
 msgstr "&Seuraava vihje"
 
@@ -532,11 +559,11 @@ msgstr "&Seuraava vihje"
 msgid "&Next style:"
 msgstr "&Uusi tyyli:"
 
-#: ../src/common/stockitem.cpp:177 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:174 ../src/msw/msgdlg.cpp:435
 msgid "&No"
 msgstr "&Ei"
 
-#: ../src/generic/dbgrptg.cpp:356
+#: ../src/generic/dbgrptg.cpp:360
 msgid "&Notes:"
 msgstr "&Huomiot:"
 
@@ -544,12 +571,12 @@ msgstr "&Huomiot:"
 msgid "&Number:"
 msgstr "&Numero:"
 
-#: ../src/generic/fontdlgg.cpp:475 ../src/generic/fontdlgg.cpp:482
-#: ../src/osx/carbon/fontdlg.cpp:408 ../src/common/stockitem.cpp:178
+#: ../src/osx/carbon/fontdlg.cpp:405 ../src/common/stockitem.cpp:175
+#: ../src/generic/fontdlgg.cpp:471 ../src/generic/fontdlgg.cpp:478
 msgid "&OK"
 msgstr "&OK"
 
-#: ../src/generic/dbgrptg.cpp:342 ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176 ../src/generic/dbgrptg.cpp:342
 msgid "&Open..."
 msgstr "&Avaa..."
 
@@ -561,16 +588,16 @@ msgstr "&Jäsennyksen taso:"
 msgid "&Page Break"
 msgstr "&Sivunvaihto"
 
-#: ../src/richtext/richtextctrl.cpp:334 ../src/osx/textctrl_osx.cpp:578
-#: ../src/common/stockitem.cpp:180 ../src/msw/textctrl.cpp:2509
+#: ../src/osx/textctrl_osx.cpp:596 ../src/common/stockitem.cpp:177
+#: ../src/msw/textctrl.cpp:2774 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "L&iitä"
 
-#: ../include/wx/richtext/richtextbuffer.h:5010
+#: ../include/wx/richtext/richtextbuffer.h:5005
 msgid "&Picture"
 msgstr "&Kuva"
 
-#: ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:419
 msgid "&Point size:"
 msgstr "K&irjasinkoko:"
 
@@ -583,12 +610,11 @@ msgstr "&Sijainti (millimetrin kymmenyksiä):"
 msgid "&Position mode:"
 msgstr "&Liukuva tila:"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178
 msgid "&Preferences"
 msgstr "&Asetukset"
 
-#: ../src/aui/tabmdi.cpp:112 ../src/generic/mdig.cpp:101
-#: ../src/msw/mdi.cpp:181
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
 msgid "&Previous"
 msgstr "&Edellinen"
 
@@ -596,78 +622,74 @@ msgstr "&Edellinen"
 msgid "&Previous Paragraph"
 msgstr "&Edellinen kappale"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "&Print..."
 msgstr "&Tulosta..."
 
-#: ../src/richtext/richtextctrl.cpp:339 ../src/richtext/richtextctrl.cpp:5514
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtextctrl.cpp:338
+#: ../src/richtext/richtextctrl.cpp:5512
 msgid "&Properties"
 msgstr "&Ominaisuudet"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "&Quit"
 msgstr "&Poistu"
 
-#: ../src/richtext/richtextctrl.cpp:330 ../src/osx/textctrl_osx.cpp:574
-#: ../src/common/stockitem.cpp:185 ../src/common/cmdproc.cpp:293
-#: ../src/common/cmdproc.cpp:300 ../src/msw/textctrl.cpp:2505
+#: ../src/osx/textctrl_osx.cpp:592 ../src/common/stockitem.cpp:182
+#: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
+#: ../src/msw/textctrl.cpp:2770 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Toista"
 
-#: ../src/common/cmdproc.cpp:289 ../src/common/cmdproc.cpp:309
+#: ../src/common/cmdproc.cpp:282 ../src/common/cmdproc.cpp:302
 msgid "&Redo "
 msgstr "&Tee uudelleen "
 
-#: ../src/richtext/richtextstyledlg.cpp:257
+#: ../src/richtext/richtextstyledlg.cpp:253
 msgid "&Rename Style..."
 msgstr "&Nimeä tyyli uudelleen"
 
-#: ../src/generic/fdrepdlg.cpp:179
+#: ../src/generic/fdrepdlg.cpp:176
 msgid "&Replace"
 msgstr "&Korvaa"
 
-#: ../src/richtext/richtextstyledlg.cpp:287
+#: ../src/richtext/richtextstyledlg.cpp:283
 msgid "&Restart numbering"
 msgstr "&Aloita numerointi uudelleen"
 
-#: ../src/univ/themes/win32.cpp:3747
+#: ../src/univ/themes/win32.cpp:3744
 msgid "&Restore"
 msgstr "&Palauta"
 
-#: ../src/richtext/richtextindentspage.cpp:146
 #: ../src/richtext/richtextliststylepage.cpp:335
+#: ../src/richtext/richtextindentspage.cpp:146
 msgid "&Right"
 msgstr "&Oikealle"
 
-#: ../src/richtext/richtextindentspage.cpp:213
+#: ../src/richtext/richtextsizepage.cpp:602
+#: ../src/richtext/richtextsizepage.cpp:609
 #: ../src/richtext/richtextborderspage.cpp:277
 #: ../src/richtext/richtextborderspage.cpp:445
 #: ../src/richtext/richtextliststylepage.cpp:399
+#: ../src/richtext/richtextindentspage.cpp:213
 #: ../src/richtext/richtextmarginspage.cpp:211
 #: ../src/richtext/richtextmarginspage.cpp:325
-#: ../src/richtext/richtextsizepage.cpp:602
-#: ../src/richtext/richtextsizepage.cpp:609
 msgid "&Right:"
 msgstr "&Oikealle:"
 
-#: ../src/common/stockitem.cpp:190
+#: ../src/common/stockitem.cpp:187
 msgid "&Save"
 msgstr "&Tallenna"
-
-#: ../src/common/stockitem.cpp:191
-msgid "&Save as"
-msgstr "&Tallenna nimellä"
 
 #: ../include/wx/richmsgdlg.h:29
 msgid "&See details"
 msgstr "&Tiedot"
 
-#: ../src/generic/tipdlg.cpp:236
+#: ../src/generic/tipdlg.cpp:233
 msgid "&Show tips at startup"
 msgstr "&Näytä vihjeet käynnistyksessä"
 
-#: ../src/univ/themes/win32.cpp:3750
+#: ../src/univ/themes/win32.cpp:3747
 msgid "&Size"
 msgstr "&Koko"
 
@@ -675,36 +697,36 @@ msgstr "&Koko"
 msgid "&Size:"
 msgstr "&Koko:"
 
-#: ../src/generic/progdlgg.cpp:252
+#: ../src/generic/progdlgg.cpp:249
 msgid "&Skip"
 msgstr "Ohita"
 
-#: ../src/richtext/richtextindentspage.cpp:242
 #: ../src/richtext/richtextliststylepage.cpp:417
+#: ../src/richtext/richtextindentspage.cpp:242
 msgid "&Spacing (tenths of a mm)"
 msgstr "&Riviväli (millimetrin kymmenyksiä)"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "&Spell Check"
 msgstr "&Oikeinkirjoituksen tarkistus"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "&Stop"
 msgstr "&Pysäytä"
 
-#: ../src/richtext/richtextfontpage.cpp:275 ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196 ../src/richtext/richtextfontpage.cpp:275
 msgid "&Strikethrough"
 msgstr "&Yliviivaus"
 
-#: ../src/generic/fontdlgg.cpp:382 ../src/richtext/richtextstylepage.cpp:106
+#: ../src/generic/fontdlgg.cpp:378 ../src/richtext/richtextstylepage.cpp:106
 msgid "&Style:"
 msgstr "&Tyyli:"
 
-#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:194
 msgid "&Styles:"
 msgstr "&Tyylit:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:413
+#: ../src/richtext/richtextsymboldlg.cpp:410
 msgid "&Subset:"
 msgstr "&Osajoukko:"
 
@@ -718,24 +740,24 @@ msgstr "&Symbolit:"
 msgid "&Synchronize values"
 msgstr ""
 
-#: ../include/wx/richtext/richtextbuffer.h:6069
+#: ../include/wx/richtext/richtextbuffer.h:6064
 msgid "&Table"
 msgstr "&Taulukko"
 
-#: ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197
 msgid "&Top"
 msgstr "&Yläosa"
 
+#: ../src/richtext/richtextsizepage.cpp:567
+#: ../src/richtext/richtextsizepage.cpp:574
 #: ../src/richtext/richtextborderspage.cpp:311
 #: ../src/richtext/richtextborderspage.cpp:479
 #: ../src/richtext/richtextmarginspage.cpp:234
 #: ../src/richtext/richtextmarginspage.cpp:348
-#: ../src/richtext/richtextsizepage.cpp:567
-#: ../src/richtext/richtextsizepage.cpp:574
 msgid "&Top:"
 msgstr "&Yläosa:"
 
-#: ../src/generic/fontdlgg.cpp:444 ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199 ../src/generic/fontdlgg.cpp:441
 msgid "&Underline"
 msgstr "&Alleviivaus"
 
@@ -743,21 +765,21 @@ msgstr "&Alleviivaus"
 msgid "&Underlining:"
 msgstr "&Alleviivaus:"
 
-#: ../src/richtext/richtextctrl.cpp:329 ../src/osx/textctrl_osx.cpp:573
-#: ../src/common/stockitem.cpp:203 ../src/common/cmdproc.cpp:271
-#: ../src/msw/textctrl.cpp:2504
+#: ../src/osx/textctrl_osx.cpp:591 ../src/common/stockitem.cpp:200
+#: ../src/common/cmdproc.cpp:264 ../src/msw/textctrl.cpp:2769
+#: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Kumoa"
 
-#: ../src/common/cmdproc.cpp:265
+#: ../src/common/cmdproc.cpp:258
 msgid "&Undo "
 msgstr "&Kumoa "
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "&Unindent"
 msgstr "&Vähennä sisennystä"
 
-#: ../src/common/stockitem.cpp:205
+#: ../src/common/stockitem.cpp:202
 msgid "&Up"
 msgstr "&Ylös"
 
@@ -774,7 +796,7 @@ msgstr "&Tasaus pystysuunnassa:"
 msgid "&View..."
 msgstr "&Näytä..."
 
-#: ../src/generic/fontdlgg.cpp:393
+#: ../src/generic/fontdlgg.cpp:389
 msgid "&Weight:"
 msgstr "&Paino:"
 
@@ -783,88 +805,58 @@ msgstr "&Paino:"
 msgid "&Width:"
 msgstr "&Leveys:"
 
-#: ../src/aui/tabmdi.cpp:311 ../src/aui/tabmdi.cpp:327
-#: ../src/aui/tabmdi.cpp:329 ../src/generic/mdig.cpp:294
-#: ../src/generic/mdig.cpp:310 ../src/generic/mdig.cpp:314
-#: ../src/msw/mdi.cpp:78
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
 msgid "&Window"
 msgstr "&Ikkuna"
 
-#: ../src/common/stockitem.cpp:206 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:203 ../src/msw/msgdlg.cpp:435
 msgid "&Yes"
 msgstr "&Kyllä"
 
-#: ../src/common/valtext.cpp:256
+#: ../src/common/valtext.cpp:197
 #, fuzzy, c-format
-msgid "'%s' contains illegal characters"
+msgid "'%s' contains invalid character(s)"
 msgstr "”%s” saa sisältää vain kirjaimia."
 
-#: ../src/common/valtext.cpp:254
-#, fuzzy, c-format
-msgid "'%s' doesn't consist only of valid characters"
-msgstr "”%s” saa sisältää vain kirjaimia."
-
-#: ../src/common/config.cpp:519 ../src/msw/regconf.cpp:258
+#: ../src/common/config.cpp:515 ../src/msw/regconf.cpp:255
 #, c-format
 msgid "'%s' has extra '..', ignored."
 msgstr "”%s” sisältää ylimääräisen ”..”, ohitettu."
 
-#: ../src/common/cmdline.cpp:1113 ../src/common/cmdline.cpp:1131
+#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "”%s” ei ole oikea numeerinen arvo valitsimelle ”%s”."
 
-#: ../src/common/translation.cpp:1100
+#: ../src/common/translation.cpp:1142
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "”%s” ei ole kelvollinen viestiluettelo."
 
-#: ../src/common/valtext.cpp:165
+#: ../src/common/valtext.cpp:188
 #, fuzzy, c-format
 msgid "'%s' is not one of the valid strings"
 msgstr "”%s” ei ole kelvollinen viestiluettelo."
 
-#: ../src/common/valtext.cpp:167
+#: ../src/common/valtext.cpp:186
 #, fuzzy, c-format
 msgid "'%s' is one of the invalid strings"
 msgstr "”%s” on virheellinen"
 
-#: ../src/common/textbuf.cpp:237
+#: ../src/common/textbuf.cpp:233
 #, c-format
 msgid "'%s' is probably a binary buffer."
 msgstr "”%s” on todennäköisesti binääripuskuri."
-
-#: ../src/common/valtext.cpp:252
-#, c-format
-msgid "'%s' should be numeric."
-msgstr "”%s” on oltava numeerinen."
-
-#: ../src/common/valtext.cpp:244
-#, c-format
-msgid "'%s' should only contain ASCII characters."
-msgstr "”%s” saa sisältää vain ASCII-merkkejä."
-
-#: ../src/common/valtext.cpp:246
-#, c-format
-msgid "'%s' should only contain alphabetic characters."
-msgstr "”%s” saa sisältää vain kirjaimia."
-
-#: ../src/common/valtext.cpp:248
-#, c-format
-msgid "'%s' should only contain alphabetic or numeric characters."
-msgstr "”%s” saa sisältää vain kirjaimia ja numeroita."
-
-#: ../src/common/valtext.cpp:250
-#, c-format
-msgid "'%s' should only contain digits."
-msgstr "”%s” saa sisältää vain ASCII-merkkejä."
 
 #: ../src/richtext/richtextliststylepage.cpp:229
 #: ../src/richtext/richtextbulletspage.cpp:166
 msgid "(*)"
 msgstr "(*)"
 
-#: ../src/html/helpwnd.cpp:963
+#: ../src/html/helpwnd.cpp:961
 msgid "(Help)"
 msgstr "(Ohje)"
 
@@ -873,27 +865,32 @@ msgstr "(Ohje)"
 msgid "(None)"
 msgstr "(Ei mitään)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:504
+#: ../src/richtext/richtextsymboldlg.cpp:503
 msgid "(Normal text)"
 msgstr "(Tavallinen teksti)"
 
-#: ../src/html/helpwnd.cpp:419 ../src/html/helpwnd.cpp:1106
-#: ../src/html/helpwnd.cpp:1742
+#: ../src/html/helpwnd.cpp:417 ../src/html/helpwnd.cpp:1104
+#: ../src/html/helpwnd.cpp:1740
 msgid "(bookmarks)"
 msgstr "(kirjanmerkit)"
 
+#: ../src/msw/dlmsw.cpp:167
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (virhe %ld: %s)"
+
+#: ../src/richtext/richtextformatdlg.cpp:876
+#: ../src/richtext/richtextliststylepage.cpp:448
+#: ../src/richtext/richtextliststylepage.cpp:460
+#: ../src/richtext/richtextliststylepage.cpp:461
 #: ../src/richtext/richtextindentspage.cpp:274
 #: ../src/richtext/richtextindentspage.cpp:286
 #: ../src/richtext/richtextindentspage.cpp:287
 #: ../src/richtext/richtextindentspage.cpp:311
 #: ../src/richtext/richtextindentspage.cpp:326
-#: ../src/richtext/richtextformatdlg.cpp:884
 #: ../src/richtext/richtextfontpage.cpp:349
 #: ../src/richtext/richtextfontpage.cpp:353
 #: ../src/richtext/richtextfontpage.cpp:357
-#: ../src/richtext/richtextliststylepage.cpp:448
-#: ../src/richtext/richtextliststylepage.cpp:460
-#: ../src/richtext/richtextliststylepage.cpp:461
 msgid "(none)"
 msgstr "(ei mitään)"
 
@@ -912,7 +909,7 @@ msgstr "*)"
 msgid "+"
 msgstr "+"
 
-#: ../src/msw/utils.cpp:1152
+#: ../src/msw/utils.cpp:1143
 msgid ", 64-bit edition"
 msgstr ", 64-bittinen versio"
 
@@ -921,163 +918,163 @@ msgstr ", 64-bittinen versio"
 msgid "-"
 msgstr "-"
 
-#: ../src/generic/filepickerg.cpp:66
+#: ../src/generic/filepickerg.cpp:63
 msgid "..."
 msgstr "..."
 
-#: ../src/richtext/richtextindentspage.cpp:276
 #: ../src/richtext/richtextliststylepage.cpp:450
+#: ../src/richtext/richtextindentspage.cpp:276
 msgid "1.1"
 msgstr "1.1"
 
-#: ../src/richtext/richtextindentspage.cpp:277
 #: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextindentspage.cpp:277
 msgid "1.2"
 msgstr "1.2"
 
-#: ../src/richtext/richtextindentspage.cpp:278
 #: ../src/richtext/richtextliststylepage.cpp:452
+#: ../src/richtext/richtextindentspage.cpp:278
 msgid "1.3"
 msgstr "1.3"
 
-#: ../src/richtext/richtextindentspage.cpp:279
 #: ../src/richtext/richtextliststylepage.cpp:453
+#: ../src/richtext/richtextindentspage.cpp:279
 msgid "1.4"
 msgstr "1.4"
 
-#: ../src/richtext/richtextindentspage.cpp:280
 #: ../src/richtext/richtextliststylepage.cpp:454
+#: ../src/richtext/richtextindentspage.cpp:280
 msgid "1.5"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:281
 #: ../src/richtext/richtextliststylepage.cpp:455
+#: ../src/richtext/richtextindentspage.cpp:281
 msgid "1.6"
 msgstr "1.6"
 
-#: ../src/richtext/richtextindentspage.cpp:282
 #: ../src/richtext/richtextliststylepage.cpp:456
+#: ../src/richtext/richtextindentspage.cpp:282
 msgid "1.7"
 msgstr "1.7"
 
-#: ../src/richtext/richtextindentspage.cpp:283
 #: ../src/richtext/richtextliststylepage.cpp:457
+#: ../src/richtext/richtextindentspage.cpp:283
 msgid "1.8"
 msgstr "1.8"
 
-#: ../src/richtext/richtextindentspage.cpp:284
 #: ../src/richtext/richtextliststylepage.cpp:458
+#: ../src/richtext/richtextindentspage.cpp:284
 msgid "1.9"
 msgstr "1.9"
 
-#: ../src/common/paper.cpp:140
+#: ../src/common/paper.cpp:137
 msgid "10 x 11 in"
 msgstr "10″ x 11″"
 
-#: ../src/common/paper.cpp:113
+#: ../src/common/paper.cpp:110
 msgid "10 x 14 in"
 msgstr "10″ x 14″"
 
-#: ../src/common/paper.cpp:114
+#: ../src/common/paper.cpp:111
 msgid "11 x 17 in"
 msgstr "11″ x 17″"
 
-#: ../src/common/paper.cpp:184
+#: ../src/common/paper.cpp:181
 msgid "12 x 11 in"
 msgstr "12″ x 11″"
 
-#: ../src/common/paper.cpp:141
+#: ../src/common/paper.cpp:138
 msgid "15 x 11 in"
 msgstr "15″ x 11″"
 
-#: ../src/richtext/richtextindentspage.cpp:285
 #: ../src/richtext/richtextliststylepage.cpp:459
+#: ../src/richtext/richtextindentspage.cpp:285
 msgid "2"
 msgstr "2"
 
-#: ../src/common/paper.cpp:132
+#: ../src/common/paper.cpp:129
 msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
 msgstr "6 3/4 kirjekuori, 3 5/8″ x 6 1/2″"
 
-#: ../src/common/paper.cpp:139
+#: ../src/common/paper.cpp:136
 msgid "9 x 11 in"
 msgstr "9″ x 11″"
 
-#: ../src/html/htmprint.cpp:431
+#: ../src/html/htmprint.cpp:443
 msgid ": file does not exist!"
 msgstr ": tiedostoa ei ole!"
 
-#: ../src/common/fontmap.cpp:199
+#: ../src/common/fontmap.cpp:196
 msgid ": unknown charset"
 msgstr ": tuntematon merkistö"
 
-#: ../src/common/fontmap.cpp:413
+#: ../src/common/fontmap.cpp:410
 msgid ": unknown encoding"
 msgstr ": tuntematon koodaus"
 
-#: ../src/generic/wizard.cpp:443
+#: ../src/generic/wizard.cpp:438
 msgid "< &Back"
 msgstr "< &Takaisin"
 
-#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:628
-#: ../src/osx/carbon/fontdlg.cpp:648
+#: ../src/osx/carbon/fontdlg.cpp:419 ../src/osx/carbon/fontdlg.cpp:625
+#: ../src/osx/carbon/fontdlg.cpp:645
 msgid "<Any Decorative>"
 msgstr "<Koristeellinen>"
 
-#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:630
-#: ../src/osx/carbon/fontdlg.cpp:650
+#: ../src/osx/carbon/fontdlg.cpp:420 ../src/osx/carbon/fontdlg.cpp:627
+#: ../src/osx/carbon/fontdlg.cpp:647
 msgid "<Any Modern>"
 msgstr "<Moderni>"
 
-#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:626
-#: ../src/osx/carbon/fontdlg.cpp:646
+#: ../src/osx/carbon/fontdlg.cpp:418 ../src/osx/carbon/fontdlg.cpp:623
+#: ../src/osx/carbon/fontdlg.cpp:643
 msgid "<Any Roman>"
 msgstr "<Roman>"
 
-#: ../src/osx/carbon/fontdlg.cpp:424 ../src/osx/carbon/fontdlg.cpp:632
-#: ../src/osx/carbon/fontdlg.cpp:652
+#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:629
+#: ../src/osx/carbon/fontdlg.cpp:649
 msgid "<Any Script>"
 msgstr "<Script>"
 
-#: ../src/osx/carbon/fontdlg.cpp:425 ../src/osx/carbon/fontdlg.cpp:637
-#: ../src/osx/carbon/fontdlg.cpp:656
+#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:634
+#: ../src/osx/carbon/fontdlg.cpp:653
 msgid "<Any Swiss>"
 msgstr "<Swiss>"
 
-#: ../src/osx/carbon/fontdlg.cpp:426 ../src/osx/carbon/fontdlg.cpp:634
-#: ../src/osx/carbon/fontdlg.cpp:654
+#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:631
+#: ../src/osx/carbon/fontdlg.cpp:651
 msgid "<Any Teletype>"
 msgstr "<Teletype>"
 
-#: ../src/osx/carbon/fontdlg.cpp:420
+#: ../src/osx/carbon/fontdlg.cpp:417
 msgid "<Any>"
 msgstr "<Mikä tahansa>"
 
-#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
 msgid "<DIR>"
 msgstr "<HAK>"
 
-#: ../src/generic/filectrlg.cpp:254 ../src/generic/filectrlg.cpp:277
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
 msgid "<DRIVE>"
 msgstr "<ASEMA>"
 
-#: ../src/generic/filectrlg.cpp:252 ../src/generic/filectrlg.cpp:275
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
 msgid "<LINK>"
 msgstr "<LINKKI>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1264
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Lihavoitu kursivoitu kirjasin.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1270
+#: ../src/html/helpwnd.cpp:1268
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>lihavoitu kursivoitu <u>alleviivattu</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1265
+#: ../src/html/helpwnd.cpp:1263
 msgid "<b>Bold face.</b> "
 msgstr "<b>Lihavoitu kirjasin.</b> "
 
-#: ../src/html/helpwnd.cpp:1264
+#: ../src/html/helpwnd.cpp:1262
 msgid "<i>Italic face.</i> "
 msgstr "<i>Kursivoitu kirjasin.</i> "
 
@@ -1086,15 +1083,15 @@ msgstr "<i>Kursivoitu kirjasin.</i> "
 msgid ">"
 msgstr ">"
 
-#: ../src/generic/dbgrptg.cpp:318
+#: ../src/generic/dbgrptg.cpp:317
 msgid "A debug report has been generated in the directory\n"
 msgstr "Virheraportti on luotu hakemistoon\n"
 
-#: ../src/common/debugrpt.cpp:573
+#: ../src/common/debugrpt.cpp:574
 msgid "A debug report has been generated. It can be found in"
 msgstr "Virheraportti on luotu. Se löytyy kohteesta"
 
-#: ../src/common/xtixml.cpp:418
+#: ../src/common/xtixml.cpp:414
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Muun kuin tyhjän kokoelman tulee muodostua 'element'-solmuista"
 
@@ -1105,106 +1102,106 @@ msgstr "Muun kuin tyhjän kokoelman tulee muodostua 'element'-solmuista"
 msgid "A standard bullet name."
 msgstr "Oletus luettelomerkin nimi."
 
-#: ../src/common/paper.cpp:217
+#: ../src/common/paper.cpp:214
 msgid "A0 sheet, 841 x 1189 mm"
 msgstr "A0-lomake, 841 x 1189 mm"
 
-#: ../src/common/paper.cpp:218
+#: ../src/common/paper.cpp:215
 msgid "A1 sheet, 594 x 841 mm"
 msgstr "A1lomake, 594 x 841 mm"
 
-#: ../src/common/paper.cpp:159
+#: ../src/common/paper.cpp:156
 msgid "A2 420 x 594 mm"
 msgstr "A2 420 x 594 mm"
 
-#: ../src/common/paper.cpp:156
+#: ../src/common/paper.cpp:153
 msgid "A3 Extra 322 x 445 mm"
 msgstr "A3 extra 322 x 445 mm"
 
-#: ../src/common/paper.cpp:161
+#: ../src/common/paper.cpp:158
 msgid "A3 Extra Transverse 322 x 445 mm"
 msgstr "A3 extra poikittain 322 x 445 mm"
 
-#: ../src/common/paper.cpp:170
+#: ../src/common/paper.cpp:167
 msgid "A3 Rotated 420 x 297 mm"
 msgstr "A3 käännetty 420 x 297 mm"
 
-#: ../src/common/paper.cpp:160
+#: ../src/common/paper.cpp:157
 msgid "A3 Transverse 297 x 420 mm"
 msgstr "A3 poikittain 297 x 420 mm"
 
-#: ../src/common/paper.cpp:106
+#: ../src/common/paper.cpp:103
 msgid "A3 sheet, 297 x 420 mm"
 msgstr "A3-paperi 297 ä 420 mm"
 
-#: ../src/common/paper.cpp:146
+#: ../src/common/paper.cpp:143
 msgid "A4 Extra 9.27 x 12.69 in"
 msgstr "A4 Extra 9.27″ x 12.69″"
 
-#: ../src/common/paper.cpp:153
+#: ../src/common/paper.cpp:150
 msgid "A4 Plus 210 x 330 mm"
 msgstr "A4 Plus 210 x 330 mm"
 
-#: ../src/common/paper.cpp:171
+#: ../src/common/paper.cpp:168
 msgid "A4 Rotated 297 x 210 mm"
 msgstr "A4 käännetty 297 x 210 mm"
 
-#: ../src/common/paper.cpp:148
+#: ../src/common/paper.cpp:145
 msgid "A4 Transverse 210 x 297 mm"
 msgstr "A4 poikittain 210 x 297 mm"
 
-#: ../src/common/paper.cpp:97
+#: ../src/common/paper.cpp:94
 msgid "A4 sheet, 210 x 297 mm"
 msgstr "A4-paperi, 210 ä 297 mm"
 
-#: ../src/common/paper.cpp:107
+#: ../src/common/paper.cpp:104
 msgid "A4 small sheet, 210 x 297 mm"
 msgstr "A4 pieni arkki, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:157
+#: ../src/common/paper.cpp:154
 msgid "A5 Extra 174 x 235 mm"
 msgstr "A5 extra 174 x 235 mm"
 
-#: ../src/common/paper.cpp:172
+#: ../src/common/paper.cpp:169
 msgid "A5 Rotated 210 x 148 mm"
 msgstr "A5 käännetty 210 x 148 mm"
 
-#: ../src/common/paper.cpp:154
+#: ../src/common/paper.cpp:151
 msgid "A5 Transverse 148 x 210 mm"
 msgstr "A5 poikittain 148 x 210 mm"
 
-#: ../src/common/paper.cpp:108
+#: ../src/common/paper.cpp:105
 msgid "A5 sheet, 148 x 210 mm"
 msgstr "A5-arkki, 148 x 210 mm"
 
-#: ../src/common/paper.cpp:164
+#: ../src/common/paper.cpp:161
 msgid "A6 105 x 148 mm"
 msgstr "A6 105 x 148 mm"
 
-#: ../src/common/paper.cpp:177
+#: ../src/common/paper.cpp:174
 msgid "A6 Rotated 148 x 105 mm"
 msgstr "A6 käännetty 148 x 105 mm"
 
-#: ../src/generic/fontdlgg.cpp:83 ../src/richtext/richtextformatdlg.cpp:529
-#: ../src/osx/carbon/fontdlg.cpp:153
+#: ../src/osx/carbon/fontdlg.cpp:150 ../src/generic/fontdlgg.cpp:79
+#: ../src/richtext/richtextformatdlg.cpp:521
 msgid "ABCDEFGabcdefg12345"
 msgstr "ABCDEFGabcdefg12345"
 
-#: ../src/richtext/richtextsymboldlg.cpp:458 ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
 msgid "ASCII"
 msgstr "ASCII"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "About"
 msgstr "Tietoja"
 
-#: ../src/generic/aboutdlgg.cpp:140 ../src/osx/menu_osx.cpp:558
-#: ../src/msw/aboutdlg.cpp:64
+#: ../src/osx/menu_osx.cpp:450 ../src/generic/aboutdlgg.cpp:137
+#: ../src/msw/aboutdlg.cpp:61
 #, c-format
 msgid "About %s"
 msgstr "Tietoja ohjelmasta %s"
 
-#: ../src/osx/menu_osx.cpp:560
+#: ../src/osx/menu_osx.cpp:452
 #, fuzzy
 msgid "About..."
 msgstr "Tietoja"
@@ -1214,38 +1211,38 @@ msgid "Absolute"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:873
+#: ../src/propgrid/advprops.cpp:774
 #, fuzzy
 msgid "ActiveBorder"
 msgstr "Moderni"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:874
+#: ../src/propgrid/advprops.cpp:775
 msgid "ActiveCaption"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "Actual Size"
 msgstr "Oikea koko"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:140 ../src/common/accelcmn.cpp:81
+#: ../src/common/stockitem.cpp:137 ../src/common/accelcmn.cpp:78
 msgid "Add"
 msgstr "Lisää"
 
-#: ../src/richtext/richtextbuffer.cpp:11455
+#: ../src/richtext/richtextbuffer.cpp:11454
 msgid "Add Column"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11392
+#: ../src/richtext/richtextbuffer.cpp:11391
 msgid "Add Row"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:432
+#: ../src/html/helpwnd.cpp:430
 msgid "Add current page to bookmarks"
 msgstr "Lisää tämä sivu kirjanmerkkeihin"
 
-#: ../src/generic/colrdlgg.cpp:366
+#: ../src/generic/colrdlgg.cpp:386
 msgid "Add to custom colours"
 msgstr "Lisää muokattuihin väreihin"
 
@@ -1257,12 +1254,12 @@ msgstr "Funktiota AddToPropertyCollection kutsuttu yleisellä haulla"
 msgid "AddToPropertyCollection called w/o valid adder"
 msgstr "AddToPropertyCollection kutsuttu ilman kelvollista lisääjää"
 
-#: ../src/html/helpctrl.cpp:159
+#: ../src/html/helpctrl.cpp:155
 #, c-format
 msgid "Adding book %s"
 msgstr "Lisätään kirja %s"
 
-#: ../src/common/preferencescmn.cpp:43
+#: ../src/common/preferencescmn.cpp:40
 msgid "Advanced"
 msgstr ""
 
@@ -1270,11 +1267,11 @@ msgstr ""
 msgid "After a paragraph:"
 msgstr "Kappaleen jälkeen:"
 
-#: ../src/common/stockitem.cpp:172
+#: ../src/common/stockitem.cpp:169
 msgid "Align Left"
 msgstr "Tasaa vasemmalle"
 
-#: ../src/common/stockitem.cpp:173
+#: ../src/common/stockitem.cpp:170
 msgid "Align Right"
 msgstr "Tasaa oikealle"
 
@@ -1282,40 +1279,40 @@ msgstr "Tasaa oikealle"
 msgid "Alignment"
 msgstr "Tasaus"
 
-#: ../src/generic/prntdlgg.cpp:215
+#: ../src/generic/prntdlgg.cpp:208
 msgid "All"
 msgstr "Kaikki"
 
-#: ../src/generic/filectrlg.cpp:1197 ../src/common/fldlgcmn.cpp:107
+#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1186
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Kaikki tiedostot (%s)|%s"
 
-#: ../include/wx/defs.h:2886
+#: ../include/wx/defs.h:2582
 msgid "All files (*)|*"
 msgstr "Kaikki tiedostot (*)|*"
 
-#: ../include/wx/defs.h:2883
+#: ../include/wx/defs.h:2579
 msgid "All files (*.*)|*.*"
 msgstr "Kaikki tiedostot (*.*)|*.*"
 
-#: ../src/richtext/richtextstyles.cpp:1061
+#: ../src/richtext/richtextstyles.cpp:1058
 msgid "All styles"
 msgstr "Kaikki tyylit"
 
-#: ../src/propgrid/manager.cpp:1528
+#: ../src/propgrid/manager.cpp:1544
 msgid "Alphabetic Mode"
 msgstr "Aakkosnumeerinen tila"
 
-#: ../src/common/xtistrm.cpp:425
+#: ../src/common/xtistrm.cpp:422
 msgid "Already Registered Object passed to SetObjectClassInfo"
 msgstr "Jo rekisteröity objekti välitetty kohteelle SetObjectClassInfo"
 
-#: ../src/unix/dialup.cpp:353
+#: ../src/unix/dialup.cpp:352
 msgid "Already dialling ISP."
 msgstr "Palveluntarjoajalle soitetaan jo."
 
-#: ../src/common/accelcmn.cpp:331 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/accelcmn.cpp:345 ../src/univ/themes/win32.cpp:3753
 msgid "Alt+"
 msgstr "Alt+"
 
@@ -1324,35 +1321,35 @@ msgstr "Alt+"
 msgid "An optional corner radius for adding rounded corners."
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:576
+#: ../src/common/debugrpt.cpp:577
 msgid "And includes the following files:\n"
 msgstr "Ja sisällytä seuraavat tiedostot:\n"
 
-#: ../src/generic/animateg.cpp:162
+#: ../src/generic/animateg.cpp:145
 #, c-format
 msgid "Animation file is not of type %ld."
 msgstr "Animaatiotiedosto ei ole tyyppiä %ld."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:872
+#: ../src/propgrid/advprops.cpp:773
 msgid "AppWorkspace"
 msgstr ""
 
-#: ../src/generic/logg.cpp:1014
+#: ../src/generic/logg.cpp:1011
 #, c-format
 msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
 msgstr "Lisää loki tiedostoon ”%s” (valitse [Ei] korvataksesi tiedoston)?"
 
-#: ../src/osx/menu_osx.cpp:577 ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:469 ../src/osx/menu_osx.cpp:477
 #, fuzzy
 msgid "Application"
 msgstr "Valinta"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "Apply"
 msgstr "Käytä"
 
-#: ../src/propgrid/advprops.cpp:1609
+#: ../src/propgrid/advprops.cpp:1515
 msgid "Aqua"
 msgstr ""
 
@@ -1361,30 +1358,30 @@ msgstr ""
 msgid "Arabic"
 msgstr "Arabialainen"
 
-#: ../src/common/fmapbase.cpp:153
+#: ../src/common/fmapbase.cpp:150
 msgid "Arabic (ISO-8859-6)"
 msgstr "Arabialainen (ISO-8859-6)"
 
-#: ../src/msw/ole/automtn.cpp:672
+#: ../src/msw/ole/automtn.cpp:663
 #, c-format
 msgid "Argument %u not found."
 msgstr "Parametria %u ei löydy."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1753
+#: ../src/propgrid/advprops.cpp:1654
 #, fuzzy
 msgid "Arrow"
 msgstr "huomenna"
 
-#: ../src/generic/aboutdlgg.cpp:184
+#: ../src/generic/aboutdlgg.cpp:181
 msgid "Artists"
 msgstr "Artistit"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "Ascending"
 msgstr "Nouseva"
 
-#: ../src/generic/filectrlg.cpp:433
+#: ../src/generic/filectrlg.cpp:429
 msgid "Attributes"
 msgstr "Ominaisuudet"
 
@@ -1394,90 +1391,90 @@ msgstr "Ominaisuudet"
 msgid "Available fonts."
 msgstr "Käytettävät kirjasimet."
 
-#: ../src/common/paper.cpp:137
+#: ../src/common/paper.cpp:134
 msgid "B4 (ISO) 250 x 353 mm"
 msgstr "B4 (ISO) 250 x 353 mm"
 
-#: ../src/common/paper.cpp:173
+#: ../src/common/paper.cpp:170
 msgid "B4 (JIS) Rotated 364 x 257 mm"
 msgstr "B4 (JIS) käännetty 364 x 257 mm"
 
-#: ../src/common/paper.cpp:127
+#: ../src/common/paper.cpp:124
 msgid "B4 Envelope, 250 x 353 mm"
 msgstr "B4 kirjekuori, 250 x 353 mm"
 
-#: ../src/common/paper.cpp:109
+#: ../src/common/paper.cpp:106
 msgid "B4 sheet, 250 x 354 mm"
 msgstr "B4-paperi, 250 ä 354 mm"
 
-#: ../src/common/paper.cpp:158
+#: ../src/common/paper.cpp:155
 msgid "B5 (ISO) Extra 201 x 276 mm"
 msgstr "B5 (ISO) Extra 201 x 276 mm"
 
-#: ../src/common/paper.cpp:174
+#: ../src/common/paper.cpp:171
 msgid "B5 (JIS) Rotated 257 x 182 mm"
 msgstr "B5 (JIS) käännetty 257 x 182 mm"
 
-#: ../src/common/paper.cpp:155
+#: ../src/common/paper.cpp:152
 msgid "B5 (JIS) Transverse 182 x 257 mm"
 msgstr "B5 (JIS) poikittain 182 x 257 mm"
 
-#: ../src/common/paper.cpp:128
+#: ../src/common/paper.cpp:125
 msgid "B5 Envelope, 176 x 250 mm"
 msgstr "B5 kirjekuori, 176 x 250 mm"
 
-#: ../src/common/paper.cpp:110
+#: ../src/common/paper.cpp:107
 msgid "B5 sheet, 182 x 257 millimeter"
 msgstr "B5-paperi, 182 ä 257 mm"
 
-#: ../src/common/paper.cpp:182
+#: ../src/common/paper.cpp:179
 msgid "B6 (JIS) 128 x 182 mm"
 msgstr "B6 (JIS) 128 x 182 mm"
 
-#: ../src/common/paper.cpp:183
+#: ../src/common/paper.cpp:180
 msgid "B6 (JIS) Rotated 182 x 128 mm"
 msgstr "B6 (JIS) käännetty 182 x 128 mm"
 
-#: ../src/common/paper.cpp:129
+#: ../src/common/paper.cpp:126
 msgid "B6 Envelope, 176 x 125 mm"
 msgstr "B6 kirjekuori, 176 x 125 mm"
 
-#: ../src/common/imagbmp.cpp:531 ../src/common/imagbmp.cpp:561
-#: ../src/common/imagbmp.cpp:576
+#: ../src/common/imagbmp.cpp:528 ../src/common/imagbmp.cpp:558
+#: ../src/common/imagbmp.cpp:573
 msgid "BMP: Couldn't allocate memory."
 msgstr "BMP: Muistin varaaminen epäonnistui."
 
-#: ../src/common/imagbmp.cpp:100
+#: ../src/common/imagbmp.cpp:97
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: Virheellistä kuvaa ei voitu tallentaa."
 
-#: ../src/common/imagbmp.cpp:356
+#: ../src/common/imagbmp.cpp:353
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: RGB-värikarttaa ei voitu kirjoittaa."
 
-#: ../src/common/imagbmp.cpp:490
+#: ../src/common/imagbmp.cpp:487
 msgid "BMP: Couldn't write data."
 msgstr "BMP: Dataa ei voitu kirjoittaa."
 
-#: ../src/common/imagbmp.cpp:246
+#: ../src/common/imagbmp.cpp:243
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: Tiedoston otsaketta (Bitmap) ei voitu kirjoittaa."
 
-#: ../src/common/imagbmp.cpp:269
+#: ../src/common/imagbmp.cpp:266
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: En voinut kirjoittaa tiedoston (BitmapInfo) otsaketta."
 
-#: ../src/common/imagbmp.cpp:140
+#: ../src/common/imagbmp.cpp:137
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage:lla ei ole omaa wxPalette:a."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:142 ../src/common/accelcmn.cpp:52
+#: ../src/common/stockitem.cpp:139 ../src/common/accelcmn.cpp:49
 msgid "Back"
 msgstr "Takaisin"
 
+#: ../src/richtext/richtextformatdlg.cpp:377
 #: ../src/richtext/richtextbackgroundpage.cpp:148
-#: ../src/richtext/richtextformatdlg.cpp:384
 msgid "Background"
 msgstr "Tausta"
 
@@ -1485,22 +1482,22 @@ msgstr "Tausta"
 msgid "Background &colour:"
 msgstr "Tausta&väri:"
 
-#: ../src/osx/carbon/fontdlg.cpp:220
+#: ../src/osx/carbon/fontdlg.cpp:217
 msgid "Background colour"
 msgstr "Taustaväri"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:52
+#: ../src/common/accelcmn.cpp:49
 #, fuzzy
 msgid "Backspace"
 msgstr "Takaisin"
 
-#: ../src/common/fmapbase.cpp:160
+#: ../src/common/fmapbase.cpp:157
 #, fuzzy
 msgid "Baltic (ISO-8859-13)"
 msgstr "Baltti (ISO-8859-13)"
 
-#: ../src/common/fmapbase.cpp:151
+#: ../src/common/fmapbase.cpp:148
 #, fuzzy
 msgid "Baltic (old) (ISO-8859-4)"
 msgstr "Vanha baltti (ISO-8859-4)"
@@ -1514,25 +1511,25 @@ msgstr "Ennen kappaletta:"
 msgid "Bitmap"
 msgstr "Värikartta"
 
-#: ../src/propgrid/advprops.cpp:1594
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Black"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1755
+#: ../src/propgrid/advprops.cpp:1656
 msgid "Blank"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1603
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Blue"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:345
+#: ../src/generic/colrdlgg.cpp:365
 msgid "Blue:"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:333 ../src/richtext/richtextfontpage.cpp:355
-#: ../src/osx/carbon/fontdlg.cpp:354 ../src/common/stockitem.cpp:143
+#: ../src/osx/carbon/fontdlg.cpp:351 ../src/common/stockitem.cpp:140
+#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:355
 msgid "Bold"
 msgstr "Lihavoitu"
 
@@ -1542,35 +1539,39 @@ msgstr "Lihavoitu"
 msgid "Border"
 msgstr "Moderni"
 
-#: ../src/richtext/richtextformatdlg.cpp:379
+#: ../src/richtext/richtextformatdlg.cpp:372
 #, fuzzy
 msgid "Borders"
 msgstr "Moderni"
 
-#: ../src/richtext/richtextsizepage.cpp:288 ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141 ../src/richtext/richtextsizepage.cpp:288
 msgid "Bottom"
 msgstr "Alaosa"
 
-#: ../src/generic/prntdlgg.cpp:893
+#: ../src/generic/prntdlgg.cpp:886
 msgid "Bottom margin (mm):"
 msgstr "Alamarginaali (mm):"
 
-#: ../src/richtext/richtextbuffer.cpp:9383
+#: ../src/richtext/richtextbuffer.cpp:9380
 #, fuzzy
 msgid "Box Properties"
 msgstr "&Ominaisuudet"
 
-#: ../src/richtext/richtextstyles.cpp:1065
+#: ../src/richtext/richtextstyles.cpp:1062
 #, fuzzy
 msgid "Box styles"
 msgstr "Kaikki tyylit"
 
-#: ../src/propgrid/advprops.cpp:1602
+#: ../src/osx/cocoa/menu.mm:292
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1508
 #, fuzzy
 msgid "Brown"
 msgstr "Selaa"
 
-#: ../src/common/filepickercmn.cpp:43 ../src/common/filepickercmn.cpp:44
+#: ../src/common/filepickercmn.cpp:40 ../src/common/filepickercmn.cpp:41
 msgid "Browse"
 msgstr "Selaa"
 
@@ -1583,73 +1584,73 @@ msgstr "Luettelon &tasaus:"
 msgid "Bullet style"
 msgstr "Luettelomerkkityyli"
 
-#: ../src/richtext/richtextformatdlg.cpp:359
+#: ../src/richtext/richtextformatdlg.cpp:352
 msgid "Bullets"
 msgstr "Luettelomerkit"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1756
+#: ../src/propgrid/advprops.cpp:1657
 #, fuzzy
 msgid "Bullseye"
 msgstr "Luettelomerkkityyli"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:875
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonFace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:876
+#: ../src/propgrid/advprops.cpp:777
 msgid "ButtonHighlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:877
+#: ../src/propgrid/advprops.cpp:778
 msgid "ButtonShadow"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:878
+#: ../src/propgrid/advprops.cpp:779
 msgid "ButtonText"
 msgstr ""
 
-#: ../src/common/paper.cpp:98
+#: ../src/common/paper.cpp:95
 msgid "C sheet, 17 x 22 in"
 msgstr "C-arkki, 17″ x 22″"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "C&lear"
 msgstr "&Tyhjennä"
 
-#: ../src/generic/fontdlgg.cpp:406
+#: ../src/generic/fontdlgg.cpp:403
 msgid "C&olour:"
 msgstr "&Väri:"
 
-#: ../src/common/paper.cpp:123
+#: ../src/common/paper.cpp:120
 msgid "C3 Envelope, 324 x 458 mm"
 msgstr "C3 kirjekuori, 324 x 458 mm"
 
-#: ../src/common/paper.cpp:124
+#: ../src/common/paper.cpp:121
 msgid "C4 Envelope, 229 x 324 mm"
 msgstr "C4 kirjekuori, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:122
+#: ../src/common/paper.cpp:119
 msgid "C5 Envelope, 162 x 229 mm"
 msgstr "C5 kirjekuori, 162 x 229 mm"
 
-#: ../src/common/paper.cpp:125
+#: ../src/common/paper.cpp:122
 msgid "C6 Envelope, 114 x 162 mm"
 msgstr "C6 kirjekuori, 114 x 162 mm"
 
-#: ../src/common/paper.cpp:126
+#: ../src/common/paper.cpp:123
 msgid "C65 Envelope, 114 x 229 mm"
 msgstr "C65 kirjekuori, 114 x 229 mm"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "CD-Rom"
 msgstr "CD-ROM"
 
-#: ../src/html/chm.cpp:815 ../src/html/chm.cpp:874
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:865
 msgid "CHM handler currently supports only local files!"
 msgstr "CHM käsittelijä tukee vain paikallisia tiedostoja!"
 
@@ -1657,194 +1658,198 @@ msgstr "CHM käsittelijä tukee vain paikallisia tiedostoja!"
 msgid "Ca&pitals"
 msgstr "&Suuraakkoset"
 
-#: ../src/common/cmdproc.cpp:267
+#: ../src/common/cmdproc.cpp:260
 msgid "Can't &Undo "
 msgstr "Ei voi &Kumota "
 
-#: ../src/common/image.cpp:2824
+#: ../src/common/image.cpp:2924
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 "Kuvamuotoa ei voi määrittää automaattisesti syötteelle, joka ei ole "
 "haettavissa."
 
-#: ../src/msw/registry.cpp:506
+#: ../src/msw/registry.cpp:495
 #, c-format
 msgid "Can't close registry key '%s'"
 msgstr "Rekisteriavainta ”%s” ei voida sulkea"
 
-#: ../src/msw/registry.cpp:584
+#: ../src/msw/registry.cpp:573
 #, c-format
 msgid "Can't copy values of unsupported type %d."
 msgstr "En voi kopioida arvoja, joiden tyyppiä %d ei ole tuettu."
 
-#: ../src/msw/registry.cpp:487
+#: ../src/msw/registry.cpp:476
 #, c-format
 msgid "Can't create registry key '%s'"
 msgstr "Rekisteriavaimen ”%s” luonti ei onnistu"
 
-#: ../src/msw/thread.cpp:665
+#: ../src/msw/thread.cpp:657
 msgid "Can't create thread"
 msgstr "Säiettä ei voi luoda"
 
-#: ../src/msw/window.cpp:3691
-#, c-format
-msgid "Can't create window of class %s"
-msgstr "Luokan ”%s” ikkunan luonti epäonnistui"
-
-#: ../src/msw/registry.cpp:777
+#: ../src/msw/registry.cpp:765
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Avainta ”%s” ei voi poistaa"
 
-#: ../src/msw/iniconf.cpp:458
+#: ../src/msw/iniconf.cpp:455
 #, c-format
 msgid "Can't delete the INI file '%s'"
 msgstr "INI-tiedoston ”%s” poisto epäonnistui"
 
-#: ../src/msw/registry.cpp:805
+#: ../src/msw/registry.cpp:793
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Arvon ”%s” poisto avaimesta ”%s” ei onnistu"
 
-#: ../src/msw/registry.cpp:1171
+#: ../src/msw/registry.cpp:1159
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Avaimen ”%s” aliavaimia ei voi luetella"
 
-#: ../src/msw/registry.cpp:1132
+#: ../src/msw/registry.cpp:1120
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Avaimen ”%s” arvoja ei voi luetella"
 
-#: ../src/msw/registry.cpp:1389
+#: ../src/msw/registry.cpp:1377
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Tukemattoman tyypin %d arvoja ei voida viedä."
 
-#: ../src/common/ffile.cpp:254
+#: ../src/common/ffile.cpp:253
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Tiedoston ”%s” nykyistä kohtaa ei löydy"
 
-#: ../src/msw/registry.cpp:418
+#: ../src/msw/registry.cpp:407
 #, c-format
 msgid "Can't get info about registry key '%s'"
 msgstr "Tiedon saanti rekisteriavaimesta ”%s” ei onnistu"
 
-#: ../src/common/zstream.cpp:346
+#: ../src/msw/webview_ie.cpp:1024
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "Säikeen prioriteetin asetus epäonnistui"
+
+#: ../src/common/zstream.cpp:343
 msgid "Can't initialize zlib deflate stream."
 msgstr "Zlib deflate -virtaa ei pystytä alustamaan."
 
-#: ../src/common/zstream.cpp:185
+#: ../src/common/zstream.cpp:182
 msgid "Can't initialize zlib inflate stream."
 msgstr "Zlib inflate -virtaa ei pystytä alustamaan."
 
-#: ../src/msw/fswatcher.cpp:476
+#: ../src/msw/fswatcher.cpp:475
 #, c-format
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr ""
 "Hakemiston \"%s\" muutoksia ei voida tarkkailla, koska sitä ei ole olemassa."
 
-#: ../src/msw/registry.cpp:454
+#: ../src/msw/registry.cpp:443
 #, c-format
 msgid "Can't open registry key '%s'"
 msgstr "Rekisteriavaimen ”%s” avaaminen ei onnistu"
 
-#: ../src/common/zstream.cpp:252
+#: ../src/common/zstream.cpp:249
 #, c-format
 msgid "Can't read from inflate stream: %s"
 msgstr "Ei voi lukea inflate-irrasta: %s"
 
-#: ../src/common/zstream.cpp:244
+#: ../src/common/zstream.cpp:241
 msgid "Can't read inflate stream: unexpected EOF in underlying stream."
 msgstr "Ei voi lukea inflate-virtaa: odottamaton EOF käytetyssä virrassa."
 
-#: ../src/msw/registry.cpp:1064
+#: ../src/msw/registry.cpp:1052
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "”%s”:n arvoa ei voida lukea"
 
-#: ../src/msw/registry.cpp:878 ../src/msw/registry.cpp:910
-#: ../src/msw/registry.cpp:975
+#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
+#: ../src/msw/registry.cpp:963
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Ei voida lukea arvoa avaimesta ”%s”"
 
-#: ../src/common/image.cpp:2620
+#: ../src/msw/webview_ie.cpp:1017
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/common/image.cpp:2715
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "Tiedostoon ”%s” ei voi tallentaa kuvaa: tuntematon tiedostopääte."
 
-#: ../src/generic/logg.cpp:573 ../src/generic/logg.cpp:976
+#: ../src/generic/logg.cpp:570 ../src/generic/logg.cpp:973
 msgid "Can't save log contents to file."
 msgstr "Lokisisällön tallennus tiedostoon epäonnistui."
 
-#: ../src/msw/thread.cpp:629
+#: ../src/msw/thread.cpp:621
 msgid "Can't set thread priority"
 msgstr "Säikeen prioriteetin asetus epäonnistui"
 
-#: ../src/msw/registry.cpp:896 ../src/msw/registry.cpp:938
-#: ../src/msw/registry.cpp:1081
+#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
+#: ../src/msw/registry.cpp:1069
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Ei voida asettaa arvoa ”%s”"
 
-#: ../src/unix/utilsunx.cpp:351
+#: ../src/unix/utilsunx.cpp:353
 #, fuzzy
 msgid "Can't write to child process's stdin"
 msgstr "Prosessia %d ei voitu lopettaa."
 
-#: ../src/common/zstream.cpp:427
+#: ../src/common/zstream.cpp:424
 #, c-format
 msgid "Can't write to deflate stream: %s"
 msgstr "Ei voi kirjoittaa deflate-virtaan: %s"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:279 ../src/richtext/richtextstyledlg.cpp:300
-#: ../src/common/stockitem.cpp:145 ../src/common/accelcmn.cpp:71
-#: ../src/msw/msgdlg.cpp:454 ../src/msw/progdlg.cpp:673
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:142
+#: ../src/common/accelcmn.cpp:68 ../src/motif/msgdlg.cpp:196
+#: ../src/gtk1/fontdlg.cpp:144 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/progdlg.cpp:940 ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Peruuta"
 
-#: ../src/common/filefn.cpp:1261
+#: ../src/common/filefn.cpp:1149
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Tiedostojen ”%s” luettelointi epäonnistui"
 
-#: ../src/msw/dir.cpp:263
+#: ../src/msw/dir.cpp:260
 #, c-format
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Hakemiston ”%s” tiedostojen luettelointi epäonnistui"
 
-#: ../src/msw/dialup.cpp:523
+#: ../src/msw/dialup.cpp:517
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Aktiivista puhelinyhteyttä ei löydy: %s"
 
-#: ../src/msw/dialup.cpp:827
+#: ../src/msw/dialup.cpp:821
 msgid "Cannot find the location of address book file"
 msgstr "Osoitekirjatiedoston sijaintia ei löydy"
 
-#: ../src/msw/ole/automtn.cpp:562
+#: ../src/msw/ole/automtn.cpp:553
 #, fuzzy, c-format
 msgid "Cannot get an active instance of \"%s\""
 msgstr "Aktiivista puhelinyhteyttä ei löydy: %s"
 
-#: ../src/unix/threadpsx.cpp:1035
+#: ../src/unix/threadpsx.cpp:1053
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "Järjestyspolitiikan %d priorisointialue ei ole tiedossa."
 
-#: ../src/unix/utilsunx.cpp:987
+#: ../src/unix/utilsunx.cpp:989
 msgid "Cannot get the hostname"
 msgstr "Isäntäkoneen nimeä ei onnistuttu saamaan"
 
-#: ../src/unix/utilsunx.cpp:1023
+#: ../src/unix/utilsunx.cpp:1025
 msgid "Cannot get the official hostname"
 msgstr "Isäntäkoneen virallista nimeä ei onnistuttu saamaan"
 
-#: ../src/msw/dialup.cpp:928
+#: ../src/msw/dialup.cpp:922
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Puhelua ei voi lopettaa - ei aktiivista yhteyttä."
 
@@ -1852,129 +1857,129 @@ msgstr "Puhelua ei voi lopettaa - ei aktiivista yhteyttä."
 msgid "Cannot initialize OLE"
 msgstr "OLE:n alustus epäonnistui"
 
-#: ../src/common/socket.cpp:853
+#: ../src/common/socket.cpp:850
 #, fuzzy
 msgid "Cannot initialize sockets"
 msgstr "OLE:n alustus epäonnistui"
 
-#: ../src/msw/volume.cpp:619
+#: ../src/msw/volume.cpp:627
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Ei voitu ladata kuvaketta tiedostosta ”%s”."
 
-#: ../src/xrc/xmlres.cpp:360
+#: ../src/xrc/xmlres.cpp:358
 #, fuzzy, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Ei voi ladata resursseja tiedostosta ”%s”."
 
-#: ../src/xrc/xmlres.cpp:742
+#: ../src/xrc/xmlres.cpp:740
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Ei voi ladata resursseja tiedostosta ”%s”."
 
-#: ../src/html/htmlfilt.cpp:137
+#: ../src/html/htmlfilt.cpp:134
 #, c-format
 msgid "Cannot open HTML document: %s"
 msgstr "HTML-asiakirjaa ei voi avata: %s"
 
-#: ../src/html/helpdata.cpp:667
+#: ../src/html/helpdata.cpp:660
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "HTML-ohjekirjaa ei voi avata: %s"
 
-#: ../src/html/helpdata.cpp:299
+#: ../src/html/helpdata.cpp:296
 #, c-format
 msgid "Cannot open contents file: %s"
 msgstr "Sisällysluettelotiedostoa %s ei voi avata"
 
-#: ../src/generic/dcpsg.cpp:1667
+#: ../src/generic/dcpsg.cpp:1665
 msgid "Cannot open file for PostScript printing!"
 msgstr "Tiedoston avaaminen PostScript-tulostusta varten epäonnistui!"
 
-#: ../src/html/helpdata.cpp:313
+#: ../src/html/helpdata.cpp:310
 #, c-format
 msgid "Cannot open index file: %s"
 msgstr "Indeksitiedostoa %s ei voi avata!"
 
-#: ../src/xrc/xmlres.cpp:724
+#: ../src/xrc/xmlres.cpp:722
 #, fuzzy, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Ei voi ladata resursseja tiedostosta ”%s”."
 
-#: ../src/html/helpwnd.cpp:1534
+#: ../src/html/helpwnd.cpp:1532
 msgid "Cannot print empty page."
 msgstr "Tyhjää sivua ei voi tulostaa."
 
-#: ../src/msw/volume.cpp:507
+#: ../src/msw/volume.cpp:515
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Tyyppinimeä ei voi lukea: ”%s”"
 
-#: ../src/msw/thread.cpp:888
+#: ../src/msw/thread.cpp:894
 #, fuzzy, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Säikeen %x jatko epäonnistui"
 
-#: ../src/unix/threadpsx.cpp:1016
+#: ../src/unix/threadpsx.cpp:1028
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Säikeen järjestyspolitiikka ei löydettävissä."
 
-#: ../src/common/intl.cpp:558
+#: ../src/common/intl.cpp:365
 #, fuzzy, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "Kieliasetusta ei voida asettaa kieleen ”%s”"
 
-#: ../src/unix/threadpsx.cpp:831 ../src/msw/thread.cpp:546
+#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
 msgid "Cannot start thread: error writing TLS."
 msgstr "Säikeen käynnistys epäonnistui: virhe TLS-kirjoituksessa."
 
-#: ../src/msw/thread.cpp:872
+#: ../src/msw/thread.cpp:864
 #, fuzzy, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Säikeen %x keskeytys epäonnistui"
 
-#: ../src/msw/thread.cpp:794
+#: ../src/msw/thread.cpp:786
 msgid "Cannot wait for thread termination"
 msgstr "Ei voi odottaa säikeen keskeytystä"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:75
+#: ../src/common/accelcmn.cpp:72
 #, fuzzy
 msgid "Capital"
 msgstr "&Suuraakkoset"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:879
+#: ../src/propgrid/advprops.cpp:780
 msgid "CaptionText"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:531
 msgid "Case sensitive"
 msgstr "Sama merkkikoko"
 
-#: ../src/propgrid/manager.cpp:1509
+#: ../src/propgrid/manager.cpp:1527
 msgid "Categorized Mode"
 msgstr "Kategorisoitu tila"
 
-#: ../src/richtext/richtextbuffer.cpp:9968
+#: ../src/richtext/richtextbuffer.cpp:9965
 #, fuzzy
 msgid "Cell Properties"
 msgstr "&Ominaisuudet"
 
-#: ../src/common/fmapbase.cpp:161
+#: ../src/common/fmapbase.cpp:158
 msgid "Celtic (ISO-8859-14)"
 msgstr "kelttiläinen (ISO-8859-14)"
 
-#: ../src/richtext/richtextindentspage.cpp:160
 #: ../src/richtext/richtextliststylepage.cpp:349
+#: ../src/richtext/richtextindentspage.cpp:160
 msgid "Cen&tred"
 msgstr "&Keskitetty"
 
-#: ../src/common/stockitem.cpp:170
+#: ../src/common/stockitem.cpp:167
 msgid "Centered"
 msgstr "Keskitetty"
 
-#: ../src/common/fmapbase.cpp:149
+#: ../src/common/fmapbase.cpp:146
 msgid "Central European (ISO-8859-2)"
 msgstr "keskieurooppalainen (ISO-8859-2)"
 
@@ -1983,10 +1988,10 @@ msgstr "keskieurooppalainen (ISO-8859-2)"
 msgid "Centre"
 msgstr "Keskitetty"
 
-#: ../src/richtext/richtextindentspage.cpp:162
-#: ../src/richtext/richtextindentspage.cpp:164
 #: ../src/richtext/richtextliststylepage.cpp:351
 #: ../src/richtext/richtextliststylepage.cpp:353
+#: ../src/richtext/richtextindentspage.cpp:162
+#: ../src/richtext/richtextindentspage.cpp:164
 msgid "Centre text."
 msgstr "Keskitä teksti."
 
@@ -2000,26 +2005,26 @@ msgstr "&Keskitetty"
 msgid "Ch&oose..."
 msgstr "&Valitse..."
 
-#: ../src/richtext/richtextbuffer.cpp:4354
+#: ../src/richtext/richtextbuffer.cpp:4351
 msgid "Change List Style"
 msgstr "Muuta luettelotyyli"
 
-#: ../src/richtext/richtextbuffer.cpp:3709
+#: ../src/richtext/richtextbuffer.cpp:3706
 #, fuzzy
 msgid "Change Object Style"
 msgstr "Muuta luettelotyyli"
 
-#: ../src/richtext/richtextbuffer.cpp:3982
-#: ../src/richtext/richtextbuffer.cpp:8129
+#: ../src/richtext/richtextbuffer.cpp:3979
+#: ../src/richtext/richtextbuffer.cpp:8125
 #, fuzzy
 msgid "Change Properties"
 msgstr "&Ominaisuudet"
 
-#: ../src/richtext/richtextbuffer.cpp:3526
+#: ../src/richtext/richtextbuffer.cpp:3523
 msgid "Change Style"
 msgstr "Muuta tyyli"
 
-#: ../src/common/fileconf.cpp:341
+#: ../src/common/fileconf.cpp:335
 #, c-format
 msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
 msgstr ""
@@ -2032,12 +2037,12 @@ msgid "Changing current directory to \"%s\" failed"
 msgstr "Hakemiston ”%s” luonti epäonnistui."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1757
+#: ../src/propgrid/advprops.cpp:1658
 #, fuzzy
 msgid "Character"
 msgstr "&Merkkikoodi:"
 
-#: ../src/richtext/richtextstyles.cpp:1063
+#: ../src/richtext/richtextstyles.cpp:1060
 msgid "Character styles"
 msgstr "Merkkityylit"
 
@@ -2075,20 +2080,20 @@ msgstr "Valitse sulkeaksesi luettelomerkin heittomerkkien sisään."
 msgid "Check to indicate right-to-left text layout."
 msgstr "Napsauta muuttaaksesi tekstin värin."
 
-#: ../src/osx/carbon/fontdlg.cpp:356 ../src/osx/carbon/fontdlg.cpp:358
+#: ../src/osx/carbon/fontdlg.cpp:353 ../src/osx/carbon/fontdlg.cpp:355
 msgid "Check to make the font bold."
 msgstr "Valitse tehdäksesi kirjasimesta lihavoidun."
 
-#: ../src/osx/carbon/fontdlg.cpp:363 ../src/osx/carbon/fontdlg.cpp:365
+#: ../src/osx/carbon/fontdlg.cpp:360 ../src/osx/carbon/fontdlg.cpp:362
 msgid "Check to make the font italic."
 msgstr "Valitse tehdäksesi kirjasimesta kursivoidun."
 
-#: ../src/osx/carbon/fontdlg.cpp:372 ../src/osx/carbon/fontdlg.cpp:374
+#: ../src/osx/carbon/fontdlg.cpp:369 ../src/osx/carbon/fontdlg.cpp:371
 msgid "Check to make the font underlined."
 msgstr "Valitse alleviivataksesi kirjasimen."
 
-#: ../src/richtext/richtextstyledlg.cpp:289
-#: ../src/richtext/richtextstyledlg.cpp:291
+#: ../src/richtext/richtextstyledlg.cpp:285
+#: ../src/richtext/richtextstyledlg.cpp:287
 msgid "Check to restart numbering."
 msgstr "Napsauta aloittaaksesi numeroinnin uudelleen."
 
@@ -2125,55 +2130,55 @@ msgstr "Napsauta peruuttaaksesi fontin valinnan."
 msgid "Check to suppress hyphenation."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:763
+#: ../src/msw/dialup.cpp:757
 msgid "Choose ISP to dial"
 msgstr "Valitse palveluntarjoaja jolle soitetaan"
 
-#: ../src/propgrid/props.cpp:1922
+#: ../src/propgrid/props.cpp:1904
 #, fuzzy
 msgid "Choose a directory:"
 msgstr "Luo hakemisto"
 
-#: ../src/propgrid/props.cpp:1975
+#: ../src/propgrid/props.cpp:2199
 #, fuzzy
 msgid "Choose a file"
 msgstr "Valitse kirjasinlaji"
 
-#: ../src/generic/colrdlgg.cpp:158 ../src/gtk/colordlg.cpp:54
+#: ../src/generic/colrdlgg.cpp:156 ../src/gtk/colordlg.cpp:49
 msgid "Choose colour"
 msgstr "Valitse väri"
 
-#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/gtk1/fontdlg.cpp:125 ../src/generic/fontpickerg.cpp:47
+#: ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Valitse kirjasinlaji"
 
-#: ../src/common/module.cpp:74
+#: ../src/common/module.cpp:71
 #, c-format
 msgid "Circular dependency involving module \"%s\" detected."
 msgstr "Moduulin \"%s\" sisältävä kiertoriippuvuus havaittu."
 
-#: ../src/aui/tabmdi.cpp:108 ../src/generic/mdig.cpp:97
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
 msgid "Cl&ose"
 msgstr "&Sulje"
 
-#: ../src/msw/ole/automtn.cpp:684
+#: ../src/msw/ole/automtn.cpp:675
 #, fuzzy
 msgid "Class not registered."
 msgstr "Säiettä ei voi luoda"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:147 ../src/common/accelcmn.cpp:72
+#: ../src/common/stockitem.cpp:144 ../src/common/accelcmn.cpp:69
 #, fuzzy
 msgid "Clear"
 msgstr "&Tyhjennä"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "Clear the log contents"
 msgstr "Tyhjennä lokin sisältä"
 
-#: ../src/richtext/richtextstyledlg.cpp:252
-#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:248
+#: ../src/richtext/richtextstyledlg.cpp:250
 msgid "Click to apply the selected style."
 msgstr "Napsauta käyttääksesi valittua tyyliä."
 
@@ -2184,15 +2189,15 @@ msgstr "Napsauta käyttääksesi valittua tyyliä."
 msgid "Click to browse for a symbol."
 msgstr "Napsauta etsiäksesi symbolin."
 
-#: ../src/osx/carbon/fontdlg.cpp:403 ../src/osx/carbon/fontdlg.cpp:405
+#: ../src/osx/carbon/fontdlg.cpp:400 ../src/osx/carbon/fontdlg.cpp:402
 msgid "Click to cancel changes to the font."
 msgstr "Napsauta peruuttaaksesi muutokset kirjasimeen."
 
-#: ../src/generic/fontdlgg.cpp:472 ../src/generic/fontdlgg.cpp:491
+#: ../src/generic/fontdlgg.cpp:468 ../src/generic/fontdlgg.cpp:487
 msgid "Click to cancel the font selection."
 msgstr "Napsauta peruuttaaksesi kirjasimen valinnan."
 
-#: ../src/osx/carbon/fontdlg.cpp:384 ../src/osx/carbon/fontdlg.cpp:386
+#: ../src/osx/carbon/fontdlg.cpp:381 ../src/osx/carbon/fontdlg.cpp:383
 msgid "Click to change the font colour."
 msgstr "Napsauta muuttaaksesi kirjasimen värin."
 
@@ -2212,38 +2217,38 @@ msgstr "Napsauta muuttaaksesi tekstin värin."
 msgid "Click to choose the font for this level."
 msgstr "Napsauta valitaksesi kirjasimen tälle tasolle."
 
-#: ../src/richtext/richtextstyledlg.cpp:279
-#: ../src/richtext/richtextstyledlg.cpp:281
+#: ../src/richtext/richtextstyledlg.cpp:275
+#: ../src/richtext/richtextstyledlg.cpp:277
 msgid "Click to close this window."
 msgstr "Napsauta sulkeaksesi tämä ikkuna."
 
-#: ../src/osx/carbon/fontdlg.cpp:410 ../src/osx/carbon/fontdlg.cpp:412
+#: ../src/osx/carbon/fontdlg.cpp:407 ../src/osx/carbon/fontdlg.cpp:409
 msgid "Click to confirm changes to the font."
 msgstr "Napsauta varmistaaksesi muutokset kirjasimeen."
 
-#: ../src/generic/fontdlgg.cpp:477 ../src/generic/fontdlgg.cpp:479
-#: ../src/generic/fontdlgg.cpp:484 ../src/generic/fontdlgg.cpp:486
+#: ../src/generic/fontdlgg.cpp:473 ../src/generic/fontdlgg.cpp:475
+#: ../src/generic/fontdlgg.cpp:480 ../src/generic/fontdlgg.cpp:482
 msgid "Click to confirm the font selection."
 msgstr "Napsauta varmistaaksesi fontin valinnan."
 
-#: ../src/richtext/richtextstyledlg.cpp:244
-#: ../src/richtext/richtextstyledlg.cpp:246
+#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:242
 #, fuzzy
 msgid "Click to create a new box style."
 msgstr "Napsauta luodaksesi uuden luettelotyylin."
 
-#: ../src/richtext/richtextstyledlg.cpp:226
-#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:224
 msgid "Click to create a new character style."
 msgstr "Napsauta luodaksesi uuden merkkityylin."
 
-#: ../src/richtext/richtextstyledlg.cpp:238
-#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:236
 msgid "Click to create a new list style."
 msgstr "Napsauta luodaksesi uuden luettelotyylin."
 
-#: ../src/richtext/richtextstyledlg.cpp:232
-#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:230
 msgid "Click to create a new paragraph style."
 msgstr "Napsauta luodaksesi uuden kappaletyylin."
 
@@ -2257,8 +2262,8 @@ msgstr "Napsauta luodaksesi uuden välilehden sijainnin."
 msgid "Click to delete all tab positions."
 msgstr "Napsauta poistaaksesi kaikki välilehtien sijainnit."
 
-#: ../src/richtext/richtextstyledlg.cpp:270
-#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:268
 msgid "Click to delete the selected style."
 msgstr "Napsauta poistaaksesi valitun tyylin."
 
@@ -2267,25 +2272,25 @@ msgstr "Napsauta poistaaksesi valitun tyylin."
 msgid "Click to delete the selected tab position."
 msgstr "Napsauta poistaaksesi valitun välilehden sijainnin."
 
-#: ../src/richtext/richtextstyledlg.cpp:264
-#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:262
 msgid "Click to edit the selected style."
 msgstr "Napsauta muokataksesi valittua tyyliä."
 
-#: ../src/richtext/richtextstyledlg.cpp:258
-#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:256
 msgid "Click to rename the selected style."
 msgstr "Napsauta nimetäksesi valitun tyylin uudelleen."
 
-#: ../src/generic/dbgrptg.cpp:97 ../src/generic/progdlgg.cpp:759
-#: ../src/richtext/richtextstyledlg.cpp:277
-#: ../src/richtext/richtextsymboldlg.cpp:476 ../src/common/stockitem.cpp:148
-#: ../src/msw/progdlg.cpp:170 ../src/msw/progdlg.cpp:679
-#: ../src/html/helpdlg.cpp:90
+#: ../src/common/stockitem.cpp:145 ../src/generic/dbgrptg.cpp:94
+#: ../src/generic/progdlgg.cpp:781 ../src/msw/progdlg.cpp:211
+#: ../src/msw/progdlg.cpp:946 ../src/html/helpdlg.cpp:87
+#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextstyledlg.cpp:273
 msgid "Close"
 msgstr "Sulje"
 
-#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:98
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
 msgid "Close All"
 msgstr "Sulje kaikki"
 
@@ -2293,44 +2298,44 @@ msgstr "Sulje kaikki"
 msgid "Close current document"
 msgstr "Sulje nykyinen asiakirja"
 
-#: ../src/generic/logg.cpp:516
+#: ../src/generic/logg.cpp:513
 msgid "Close this window"
 msgstr "Sulje tämä ikkuna"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6006
+#: ../src/generic/datavgen.cpp:6811
 msgid "Collapse"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 #, fuzzy
 msgid "Color"
 msgstr "Väri"
 
-#: ../src/richtext/richtextformatdlg.cpp:776
+#: ../src/richtext/richtextformatdlg.cpp:768
 msgid "Colour"
 msgstr "Väri"
 
-#: ../src/msw/colordlg.cpp:158
+#: ../src/msw/colordlg.cpp:227
 #, c-format
 msgid "Colour selection dialog failed with error %0lx."
 msgstr "Värin valintaikkuna epäonnistui virheellä %0lx."
 
-#: ../src/osx/carbon/fontdlg.cpp:380
+#: ../src/osx/carbon/fontdlg.cpp:377
 msgid "Colour:"
 msgstr "Väri:"
 
-#: ../src/generic/datavgen.cpp:6077
+#: ../src/generic/datavgen.cpp:6882
 #, c-format
 msgid "Column %u"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:114
+#: ../src/common/accelcmn.cpp:112
 msgid "Command"
 msgstr ""
 
-#: ../src/common/init.cpp:196
+#: ../src/common/init.cpp:193
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
@@ -2339,22 +2344,22 @@ msgstr ""
 "Komentoriviparametria %d ei voitu muuntaa Unicode-merkistöön, joten se "
 "ohitetaan ."
 
-#: ../src/msw/fontdlg.cpp:120
+#: ../src/msw/fontdlg.cpp:170
 #, fuzzy, c-format
 msgid "Common dialog failed with error code %0lx."
 msgstr "Värin valintaikkuna epäonnistui virheellä %0lx."
 
-#: ../src/gtk/window.cpp:4649
+#: ../src/gtk/window.cpp:5653
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:1549
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Tiivistetty HTML-ohjetiedosto (*.chm)|*.chm|"
 
-#: ../src/generic/dirctrlg.cpp:444
+#: ../src/generic/dirctrlg.cpp:410
 msgid "Computer"
 msgstr "Tietokone"
 
@@ -2363,54 +2368,58 @@ msgstr "Tietokone"
 msgid "Config entry name cannot start with '%c'."
 msgstr "Asetuskohdan nimi ei voi alkaa merkillä ”%c”."
 
-#: ../src/generic/filedlgg.cpp:349 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
 msgid "Confirm"
 msgstr "Varmista"
 
-#: ../src/html/htmlwin.cpp:566
+#: ../src/html/htmlwin.cpp:569
 msgid "Connecting..."
 msgstr "Yhdistetään..."
 
-#: ../src/html/helpwnd.cpp:475
+#: ../src/html/helpwnd.cpp:473
 msgid "Contents"
 msgstr "Sisältä"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:880
+#: ../src/propgrid/advprops.cpp:781
 msgid "ControlDark"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:881
+#: ../src/propgrid/advprops.cpp:782
 msgid "ControlLight"
 msgstr ""
 
-#: ../src/common/strconv.cpp:2262
+#: ../src/common/strconv.cpp:2208
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Muunnos merkistöön ”%s” ei toimi."
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 #, fuzzy
 msgid "Convert"
 msgstr "Sisältä"
 
-#: ../src/html/htmlwin.cpp:1079
+#: ../src/html/htmlwin.cpp:1020
 #, fuzzy, c-format
 msgid "Copied to clipboard:\"%s\""
 msgstr "Kopioitu leikepöydälle: ”%s”"
 
-#: ../src/generic/prntdlgg.cpp:247
+#: ../src/generic/prntdlgg.cpp:240
 msgid "Copies:"
 msgstr "Kopiot:"
 
-#: ../src/common/stockitem.cpp:150 ../src/stc/stc_i18n.cpp:18
+#: ../src/common/stockitem.cpp:147 ../src/stc/stc_i18n.cpp:18
 msgid "Copy"
 msgstr "Kopioi"
 
-#: ../src/common/stockitem.cpp:258
+#: ../src/common/stockitem.cpp:255
 msgid "Copy selection"
 msgstr "Kopioi valinta"
+
+#: ../src/generic/grid.cpp:5945
+msgid "Copying more than one selected block to clipboard is not supported."
+msgstr ""
 
 #: ../src/richtext/richtextborderspage.cpp:566
 #: ../src/richtext/richtextborderspage.cpp:601
@@ -2421,208 +2430,202 @@ msgstr ""
 msgid "Corner &radius:"
 msgstr ""
 
-#: ../src/html/chm.cpp:718
+#: ../src/html/chm.cpp:711
 #, c-format
 msgid "Could not create temporary file '%s'"
 msgstr "Väliaikaistiedoston ”%s” luonti ei onnistu"
 
-#: ../src/html/chm.cpp:273
+#: ../src/html/chm.cpp:270
 #, c-format
 msgid "Could not extract %s into %s: %s"
 msgstr "Ei voitu purkaa kohdetta %s kansioon %s: %s"
 
-#: ../src/generic/tabg.cpp:1048
+#: ../src/generic/tabg.cpp:1045
 msgid "Could not find tab for id"
 msgstr "Ei löydetty sisennystä tunnukselle"
 
-#: ../src/gtk/notifmsg.cpp:108
-#, fuzzy
-msgid "Could not initalize libnotify."
-msgstr "Tasausta ei voitu asettaa."
-
-#: ../src/html/chm.cpp:444
+#: ../src/html/chm.cpp:437
 #, c-format
 msgid "Could not locate file '%s'."
 msgstr "Tiedostoa ”%s” ei löydy"
 
-#: ../src/common/filefn.cpp:1403
+#: ../src/msw/graphicsd2d.cpp:604
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/common/filefn.cpp:1291
 #, fuzzy
 msgid "Could not set current working directory"
 msgstr "Työhakemistoa ei saatu"
 
-#: ../src/common/prntbase.cpp:2015
+#: ../src/common/prntbase.cpp:2037
 msgid "Could not start document preview."
 msgstr "Dokumentin esikatselu epäonnistui."
 
-#: ../src/generic/printps.cpp:178 ../src/msw/printwin.cpp:210
-#: ../src/gtk/print.cpp:1132
+#: ../src/generic/printps.cpp:159 ../src/msw/printwin.cpp:184
+#: ../src/gtk/print.cpp:1129
 msgid "Could not start printing."
 msgstr "Tulostus epäonnistui."
 
-#: ../src/common/wincmn.cpp:2125
+#: ../src/common/wincmn.cpp:2126
 msgid "Could not transfer data to window"
 msgstr "Tiedonsiirto ikkunaan ei onnistu"
 
-#: ../src/msw/imaglist.cpp:187 ../src/msw/imaglist.cpp:224
-#: ../src/msw/imaglist.cpp:249 ../src/msw/dragimag.cpp:185
-#: ../src/msw/dragimag.cpp:220
+#: ../src/msw/imaglist.cpp:223 ../src/msw/imaglist.cpp:245
+#: ../src/msw/imaglist.cpp:270 ../src/msw/dragimag.cpp:182
+#: ../src/msw/dragimag.cpp:217
 msgid "Couldn't add an image to the image list."
 msgstr "Kuvan lisäys kuvalistaan epäonnistui."
 
-#: ../src/osx/glcanvas_osx.cpp:414 ../src/unix/glx11.cpp:558
-#: ../src/msw/glcanvas.cpp:616
+#: ../src/osx/glcanvas_osx.cpp:411 ../src/msw/glcanvas.cpp:631
+#: ../src/unix/glegl.cpp:315 ../src/unix/glx11.cpp:559
 #, fuzzy
 msgid "Couldn't create OpenGL context"
 msgstr "Ajastimen luonti epäonnistui"
 
-#: ../src/msw/timer.cpp:134
+#: ../src/msw/timer.cpp:131
 msgid "Couldn't create a timer"
 msgstr "Ajastimen luonti epäonnistui"
 
-#: ../src/osx/carbon/overlay.cpp:122
-#, fuzzy
-msgid "Couldn't create the overlay window"
-msgstr "Ajastimen luonti epäonnistui"
-
-#: ../src/common/translation.cpp:2024
+#: ../src/common/translation.cpp:2074
 #, fuzzy
 msgid "Couldn't enumerate translations"
 msgstr "Säiettä ei voi päättää"
 
-#: ../src/common/dynlib.cpp:120
+#: ../src/common/dynlib.cpp:110
 #, c-format
 msgid "Couldn't find symbol '%s' in a dynamic library"
 msgstr "Symbolia ”%s” ei löydy dynaamisesta kirjastosta"
 
-#: ../src/msw/thread.cpp:915
+#: ../src/msw/thread.cpp:921
 msgid "Couldn't get the current thread pointer"
 msgstr "Säikeen osoittimen haku epäonnistui"
 
-#: ../src/osx/carbon/overlay.cpp:129
-#, fuzzy
-msgid "Couldn't init the context on the overlay window"
-msgstr "Säikeen osoittimen haku epäonnistui"
-
-#: ../src/common/imaggif.cpp:244
+#: ../src/common/imaggif.cpp:241
 #, fuzzy
 msgid "Couldn't initialize GIF hash table."
 msgstr "Zlib deflate -virtaa ei pystytä alustamaan."
 
-#: ../src/common/imagpng.cpp:409
+#: ../src/common/imagpng.cpp:437
 msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
 msgstr ""
 "PNG-kuvan lataus ei onnistunut - tiedosto korruptoitunut tai ei tarpeeksi "
 "muistia."
 
-#: ../src/unix/sound.cpp:470
+#: ../src/unix/sound.cpp:459
 #, c-format
 msgid "Couldn't load sound data from '%s'."
 msgstr "Ei voi ladata äänidataa kohteesta ”%s”"
 
-#: ../src/msw/dirdlg.cpp:435
+#: ../src/msw/dirdlg.cpp:287
 #, fuzzy
 msgid "Couldn't obtain folder name"
 msgstr "Ajastimen luonti epäonnistui"
 
-#: ../src/unix/sound_sdl.cpp:229
+#: ../src/unix/sound_sdl.cpp:226
 #, c-format
 msgid "Couldn't open audio: %s"
 msgstr "ääntä ei voi avata: %s"
 
-#: ../src/msw/ole/dataobj.cpp:377
+#: ../src/msw/ole/dataobj.cpp:385
 #, c-format
 msgid "Couldn't register clipboard format '%s'."
 msgstr "Ei voi rekisteröidä leikepöytämuotoa ”%s”."
 
-#: ../src/msw/listctrl.cpp:869
+#: ../src/msw/listctrl.cpp:933
 #, fuzzy, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "Ei voi hakea tietoja list-kontrollin jäsenestä indeksissä %d."
 
-#: ../src/common/imagpng.cpp:498 ../src/common/imagpng.cpp:509
-#: ../src/common/imagpng.cpp:519
+#: ../src/common/imagpng.cpp:511 ../src/common/imagpng.cpp:522
+#: ../src/common/imagpng.cpp:532
 msgid "Couldn't save PNG image."
 msgstr "JPEG: Ei voinut tallentaa kuvaa"
 
-#: ../src/msw/thread.cpp:684
+#: ../src/msw/thread.cpp:676
 msgid "Couldn't terminate thread"
 msgstr "Säiettä ei voi päättää"
 
-#: ../src/common/xtistrm.cpp:166
+#: ../src/common/xtistrm.cpp:163
 #, c-format
 msgid "Create Parameter %s not found in declared RTTI Parameters"
 msgstr "Parametrin %s luontia ei löydy ilmoitetuista RTTI-parametreista"
 
-#: ../src/generic/dirdlgg.cpp:288
+#: ../src/generic/dirdlgg.cpp:285
 msgid "Create directory"
 msgstr "Luo hakemisto"
 
-#: ../src/generic/filedlgg.cpp:212 ../src/generic/dirdlgg.cpp:111
+#: ../src/generic/filedlgg.cpp:209 ../src/generic/dirdlgg.cpp:108
 msgid "Create new directory"
 msgstr "Luo uusi hakemisto"
 
-#: ../src/xrc/xmlres.cpp:2460
+#: ../src/common/stockitem.cpp:264
+#, fuzzy
+msgid "Create new document"
+msgstr "Luo uusi hakemisto"
+
+#: ../src/xrc/xmlres.cpp:2515
 #, fuzzy, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Ei voitu purkaa ”%s”:aa kohteeseen ”%s”."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1758
+#: ../src/propgrid/advprops.cpp:1659
 msgid "Cross"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:333
+#: ../src/common/accelcmn.cpp:347
 #, fuzzy
 msgid "Ctrl+"
 msgstr "Ctrl-"
 
-#: ../src/richtext/richtextctrl.cpp:332 ../src/osx/textctrl_osx.cpp:576
-#: ../src/common/stockitem.cpp:151 ../src/msw/textctrl.cpp:2507
+#: ../src/osx/textctrl_osx.cpp:594 ../src/common/stockitem.cpp:148
+#: ../src/msw/textctrl.cpp:2772 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "&Leikkaa"
 
-#: ../src/generic/filectrlg.cpp:940
+#: ../src/generic/filectrlg.cpp:936
 msgid "Current directory:"
 msgstr "Nykyinen hakemisto:"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:896 ../src/propgrid/advprops.cpp:1574
-#: ../src/propgrid/advprops.cpp:1612
+#: ../src/propgrid/advprops.cpp:797 ../src/propgrid/advprops.cpp:1475
+#: ../src/propgrid/advprops.cpp:1518
 #, fuzzy
 msgid "Custom"
 msgstr "Valinnainen koko"
 
-#: ../src/gtk/print.cpp:217
+#: ../src/gtk/print.cpp:211
 msgid "Custom size"
 msgstr "Valinnainen koko"
 
-#: ../src/common/headerctrlcmn.cpp:60
+#: ../src/common/headerctrlcmn.cpp:58
 #, fuzzy
 msgid "Customize Columns"
 msgstr "Valinnainen koko"
 
-#: ../src/common/stockitem.cpp:151 ../src/stc/stc_i18n.cpp:17
+#: ../src/common/stockitem.cpp:148 ../src/stc/stc_i18n.cpp:17
 msgid "Cut"
 msgstr "Leikkaa"
 
-#: ../src/common/stockitem.cpp:259
+#: ../src/common/stockitem.cpp:256
 msgid "Cut selection"
 msgstr "Leikkaa valinta"
 
-#: ../src/common/fmapbase.cpp:152
+#: ../src/common/fmapbase.cpp:149
 msgid "Cyrillic (ISO-8859-5)"
 msgstr "kyrillinen (ISO-8859-5)"
 
-#: ../src/common/paper.cpp:99
+#: ../src/common/paper.cpp:96
 msgid "D sheet, 22 x 34 in"
 msgstr "D-arkki, 22″ x 34″"
 
-#: ../src/msw/dde.cpp:703
+#: ../src/msw/dde.cpp:698
 #, fuzzy
 msgid "DDE poke request failed"
 msgstr "DDE-kirjoituspyyntö epäonnistui"
 
-#: ../src/common/imagbmp.cpp:1169
+#: ../src/common/imagbmp.cpp:1181
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr "DIB Otsake: Koodaus ei vastaa bittisyvyyttä."
 
@@ -2642,7 +2645,7 @@ msgstr "DIB Otsake: tuntematon bittisyvyys."
 msgid "DIB Header: Unknown encoding in file."
 msgstr "DIB Otsake: Tiedostolla tuntematon koodaus."
 
-#: ../src/common/paper.cpp:121
+#: ../src/common/paper.cpp:118
 msgid "DL Envelope, 110 x 220 mm"
 msgstr "DL kirjekuori, 110 x 220 mm"
 
@@ -2650,55 +2653,55 @@ msgstr "DL kirjekuori, 110 x 220 mm"
 msgid "Dashed"
 msgstr ""
 
-#: ../src/generic/dbgrptg.cpp:300
+#: ../src/generic/dbgrptg.cpp:301
 #, fuzzy, c-format
 msgid "Debug report \"%s\""
 msgstr "Ohjelmavirheilmoitus ”%s”"
 
-#: ../src/common/debugrpt.cpp:210
+#: ../src/common/debugrpt.cpp:211
 msgid "Debug report couldn't be created."
 msgstr "Ohjelmavirheilmoitusta ei voitu luoda."
 
-#: ../src/common/debugrpt.cpp:553
+#: ../src/common/debugrpt.cpp:554
 msgid "Debug report generation has failed."
 msgstr "Ohjelmavirheilmoituksen luonti epäonnistui."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:84
+#: ../src/common/accelcmn.cpp:81
 msgid "Decimal"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:323
+#: ../src/generic/fontdlgg.cpp:319
 msgid "Decorative"
 msgstr "Koristeellinen"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1752
+#: ../src/propgrid/advprops.cpp:1653
 #, fuzzy
 msgid "Default"
 msgstr "oletus"
 
-#: ../src/common/fmapbase.cpp:796
+#: ../src/common/fmapbase.cpp:792
 msgid "Default encoding"
 msgstr "Oletuskoodaus"
 
-#: ../src/dfb/fontmgr.cpp:180
+#: ../src/dfb/fontmgr.cpp:177
 msgid "Default font"
 msgstr "Oletuskirjasin"
 
-#: ../src/generic/prntdlgg.cpp:510
+#: ../src/generic/prntdlgg.cpp:503
 msgid "Default printer"
 msgstr "Oletustulostin"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:51
+#: ../src/common/accelcmn.cpp:48
 #, fuzzy
 msgid "Del"
 msgstr "Poista"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextbuffer.cpp:8221 ../src/common/stockitem.cpp:152
-#: ../src/common/accelcmn.cpp:50 ../src/stc/stc_i18n.cpp:20
+#: ../src/common/stockitem.cpp:149 ../src/common/accelcmn.cpp:47
+#: ../src/richtext/richtextbuffer.cpp:8217 ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Poista"
 
@@ -2706,71 +2709,71 @@ msgstr "Poista"
 msgid "Delete A&ll"
 msgstr "Poista &kaikki"
 
-#: ../src/richtext/richtextbuffer.cpp:11341
+#: ../src/richtext/richtextbuffer.cpp:11340
 #, fuzzy
 msgid "Delete Column"
 msgstr "Poista valinta"
 
-#: ../src/richtext/richtextbuffer.cpp:11291
+#: ../src/richtext/richtextbuffer.cpp:11290
 #, fuzzy
 msgid "Delete Row"
 msgstr "Poista"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 msgid "Delete Style"
 msgstr "Poista tyyli"
 
-#: ../src/richtext/richtextctrl.cpp:1345 ../src/richtext/richtextctrl.cpp:1584
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
 msgid "Delete Text"
 msgstr "Poista teksti"
 
-#: ../src/generic/editlbox.cpp:170
+#: ../src/generic/editlbox.cpp:147
 msgid "Delete item"
 msgstr "Poista kohta"
 
-#: ../src/common/stockitem.cpp:260
+#: ../src/common/stockitem.cpp:257
 msgid "Delete selection"
 msgstr "Poista valinta"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 #, c-format
 msgid "Delete style %s?"
 msgstr "Poistetaanko tyyli %s?"
 
-#: ../src/unix/snglinst.cpp:301
+#: ../src/unix/snglinst.cpp:298
 #, c-format
 msgid "Deleted stale lock file '%s'."
 msgstr "Vanha lukitustiedosto '%s' poistettu."
 
-#: ../src/common/secretstore.cpp:220
+#: ../src/common/secretstore.cpp:234
 #, fuzzy, c-format
-msgid "Deleting password for \"%s/%s\" failed: %s."
+msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Ei voitu purkaa ”%s”:aa kohteeseen ”%s”."
 
-#: ../src/common/module.cpp:124
+#: ../src/common/module.cpp:121
 #, fuzzy, c-format
 msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
 msgstr "Riippuvuutta ”%s” moduulille ”%s” ei ole."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 #, fuzzy
 msgid "Descending"
 msgstr "Oletuskoodaus"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:526 ../src/propgrid/advprops.cpp:882
+#: ../src/generic/dirctrlg.cpp:492 ../src/propgrid/advprops.cpp:783
 msgid "Desktop"
 msgstr "Työpöytä"
 
-#: ../src/generic/aboutdlgg.cpp:70
+#: ../src/generic/aboutdlgg.cpp:67
 msgid "Developed by "
 msgstr "Kehittänyt:"
 
-#: ../src/generic/aboutdlgg.cpp:176
+#: ../src/generic/aboutdlgg.cpp:173
 msgid "Developers"
 msgstr "Kehittäjät"
 
-#: ../src/msw/dialup.cpp:374
+#: ../src/msw/dialup.cpp:368
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -2778,11 +2781,11 @@ msgstr ""
 "Puhelinsoittomahdollisuutta ei ole koska RAS (remote access service)\n"
 "ei ole asennettu tälle koneelle. Ole hyvä asenna se."
 
-#: ../src/generic/tipdlg.cpp:211
+#: ../src/generic/tipdlg.cpp:208
 msgid "Did you know..."
 msgstr "Tiesitkö..."
 
-#: ../src/dfb/wrapdfb.cpp:63
+#: ../src/dfb/wrapdfb.cpp:60
 #, fuzzy, c-format
 msgid "DirectFB error %d occurred."
 msgstr "DirectFB-virhe %d tapahtui."
@@ -2791,30 +2794,30 @@ msgstr "DirectFB-virhe %d tapahtui."
 msgid "Directories"
 msgstr "Hakemistot"
 
-#: ../src/common/filefn.cpp:1183
+#: ../src/common/filefn.cpp:1071
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Hakemistoa ”%s” ei voitu luoda"
 
-#: ../src/common/filefn.cpp:1197
+#: ../src/common/filefn.cpp:1085
 #, fuzzy, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "Hakemistoa ”%s” ei voitu luoda"
 
-#: ../src/generic/dirdlgg.cpp:204
+#: ../src/generic/dirdlgg.cpp:201
 msgid "Directory does not exist"
 msgstr "Hakemistoa ei ole olemassa"
 
-#: ../src/generic/filectrlg.cpp:1399
+#: ../src/generic/filectrlg.cpp:1388
 msgid "Directory doesn't exist."
 msgstr "Hakemistoa ei ole olemassa."
 
-#: ../src/common/docview.cpp:457
+#: ../src/common/docview.cpp:450
 msgid "Discard changes and reload the last saved version?"
 msgstr ""
 "Hylätäänkö muutokset ja ladataanko uudelleen viimeisin tallennettu versio?"
 
-#: ../src/html/helpwnd.cpp:502
+#: ../src/html/helpwnd.cpp:500
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -2822,46 +2825,46 @@ msgstr ""
 "Näytä sisällysluettelosta kaikki kohdat, jotka sisältävät annetun "
 "osatekstin. Haku on merkkikoosta riippumaton."
 
-#: ../src/html/helpwnd.cpp:679
+#: ../src/html/helpwnd.cpp:677
 msgid "Display options dialog"
 msgstr "Näytä asetusikkuna"
 
-#: ../src/html/helpwnd.cpp:322
+#: ../src/html/helpwnd.cpp:320
 msgid "Displays help as you browse the books on the left."
 msgstr "Näyttää ohjeen selatessasi kirjoja vasemmalla."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:85
+#: ../src/common/accelcmn.cpp:83
 msgid "Divide"
 msgstr ""
 
-#: ../src/common/docview.cpp:533
+#: ../src/common/docview.cpp:526
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Haluatko tallentaa muutokset asiakirjaan %s?"
 
-#: ../src/common/prntbase.cpp:542
+#: ../src/common/prntbase.cpp:537
 #, fuzzy
 msgid "Document:"
 msgstr "Dokumentaatio:"
 
-#: ../src/generic/aboutdlgg.cpp:73
+#: ../src/generic/aboutdlgg.cpp:70
 msgid "Documentation by "
 msgstr "Dokumentaatio:"
 
-#: ../src/generic/aboutdlgg.cpp:180
+#: ../src/generic/aboutdlgg.cpp:177
 msgid "Documentation writers"
 msgstr "Dokumentaation kirjoittajat"
 
-#: ../src/common/sizer.cpp:2799
+#: ../src/common/sizer.cpp:2916
 msgid "Don't Save"
 msgstr "älä tallenna"
 
-#: ../src/html/htmlwin.cpp:633
+#: ../src/html/htmlwin.cpp:643
 msgid "Done"
 msgstr "Valmis"
 
-#: ../src/generic/progdlgg.cpp:448 ../src/msw/progdlg.cpp:407
+#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
 msgid "Done."
 msgstr "Valmis."
 
@@ -2875,43 +2878,43 @@ msgstr "Valmis"
 msgid "Double"
 msgstr "Valmis"
 
-#: ../src/common/paper.cpp:176
+#: ../src/common/paper.cpp:173
 msgid "Double Japanese Postcard Rotated 148 x 200 mm"
 msgstr "Kaksinkertainen japanilainen postikortti käännetty 148 x 200 mm"
 
-#: ../src/common/xtixml.cpp:273
+#: ../src/common/xtixml.cpp:269
 #, c-format
 msgid "Doubly used id : %d"
 msgstr "Kahteen kertaan käytetty id : %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:153
-#: ../src/common/accelcmn.cpp:64
+#: ../src/common/stockitem.cpp:150 ../src/common/accelcmn.cpp:61
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Down"
 msgstr "Alas"
 
-#: ../src/richtext/richtextctrl.cpp:865
+#: ../src/richtext/richtextctrl.cpp:864
 msgid "Drag"
 msgstr ""
 
-#: ../src/common/paper.cpp:100
+#: ../src/common/paper.cpp:97
 msgid "E sheet, 34 x 44 in"
 msgstr "E-arkki, 34″ x 44″"
 
-#: ../src/unix/fswatcher_inotify.cpp:561
+#: ../src/unix/fswatcher_inotify.cpp:558
 #, fuzzy
 msgid "EOF while reading from inotify descriptor"
 msgstr "tiedoston kuvauksen %d luku epäonnistui"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "Edit"
 msgstr "Muokkaa"
 
-#: ../src/generic/editlbox.cpp:168
+#: ../src/generic/editlbox.cpp:131
 msgid "Edit item"
 msgstr "Muokkaa"
 
-#: ../include/wx/generic/progdlgg.h:84
+#: ../include/wx/generic/progdlgg.h:85
 msgid "Elapsed time:"
 msgstr "Käytetty aika:"
 
@@ -2988,52 +2991,52 @@ msgid "Enables the shadow spread."
 msgstr "Käytä leveysarvoa."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:66
+#: ../src/common/accelcmn.cpp:63
 msgid "End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:55
+#: ../src/common/accelcmn.cpp:52
 #, fuzzy
 msgid "Enter"
 msgstr "Tulostin"
 
-#: ../src/richtext/richtextstyledlg.cpp:934
+#: ../src/richtext/richtextstyledlg.cpp:930
 #, fuzzy
 msgid "Enter a box style name"
 msgstr "Anna uuden tyylin nimi"
 
-#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:602
 msgid "Enter a character style name"
 msgstr "Anna merkkityylin nimi"
 
-#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:816
 msgid "Enter a list style name"
 msgstr "Anna luettelotyylin nimi"
 
-#: ../src/richtext/richtextstyledlg.cpp:893
+#: ../src/richtext/richtextstyledlg.cpp:889
 msgid "Enter a new style name"
 msgstr "Anna uuden tyylin nimi"
 
-#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:650
 msgid "Enter a paragraph style name"
 msgstr "Anna kappaletyylin nimi"
 
-#: ../src/generic/dbgrptg.cpp:174
+#: ../src/generic/dbgrptg.cpp:171
 #, fuzzy, c-format
 msgid "Enter command to open file \"%s\":"
 msgstr "Anna komento tiedoston ”%s” avaamiseksi:"
 
-#: ../src/generic/helpext.cpp:459
+#: ../src/generic/helpext.cpp:457
 msgid "Entries found"
 msgstr "Löydetyt kohdat"
 
-#: ../src/common/paper.cpp:142
+#: ../src/common/paper.cpp:139
 #, fuzzy
 msgid "Envelope Invite 220 x 220 mm"
 msgstr "DL Kirjekuori, 110 x 220 mm"
 
-#: ../src/common/config.cpp:469
+#: ../src/common/config.cpp:465
 #, fuzzy, c-format
 msgid ""
 "Environment variables expansion failed: missing '%c' at position %u in '%s'."
@@ -3041,13 +3044,13 @@ msgstr ""
 "Ympäristömuuttujien laajennus epäonnistui: puuttuva ”%1$c” muuttujan ”%3$s” "
 "kohdassa %2$d."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/generic/dirctrlg.cpp:570
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/dirctrlg.cpp:599
-#: ../src/generic/dirdlgg.cpp:323 ../src/generic/filectrlg.cpp:642
-#: ../src/generic/filectrlg.cpp:756 ../src/generic/filectrlg.cpp:770
-#: ../src/generic/filectrlg.cpp:786 ../src/generic/filectrlg.cpp:1368
-#: ../src/generic/filectrlg.cpp:1399 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/gtk1/fontdlg.cpp:74 ../src/generic/dirctrlg.cpp:536
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/dirctrlg.cpp:565
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1357 ../src/generic/filectrlg.cpp:1388
+#: ../src/generic/filedlgg.cpp:354 ../src/generic/dirdlgg.cpp:320
+#: ../src/gtk/filedlg.cpp:74
 msgid "Error"
 msgstr "Virhe"
 
@@ -3056,239 +3059,260 @@ msgstr "Virhe"
 msgid "Error closing epoll descriptor"
 msgstr "Virhe hakemistoa luotaessa"
 
-#: ../src/unix/fswatcher_kqueue.cpp:114
+#: ../src/unix/fswatcher_kqueue.cpp:131
 #, fuzzy
 msgid "Error closing kqueue instance"
 msgstr "Virhe hakemistoa luotaessa"
 
-#: ../src/common/filefn.cpp:1049
+#: ../src/common/filefn.cpp:938
 #, fuzzy, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Tiedoston ”%s” kopiointi kohteeseen ”%s” epäonnistui."
 
-#: ../src/generic/dirdlgg.cpp:222
+#: ../src/generic/dirdlgg.cpp:219
 msgid "Error creating directory"
 msgstr "Virhe hakemistoa luotaessa"
 
-#: ../src/common/imagbmp.cpp:1181
+#: ../src/common/imagbmp.cpp:1193
 msgid "Error in reading image DIB."
 msgstr "DIB: virhe kuvan lukemisessa ."
 
-#: ../src/propgrid/propgrid.cpp:6696
+#: ../src/propgrid/propgrid.cpp:6665
 #, c-format
 msgid "Error in resource: %s"
 msgstr "Virhe resurssissa: %s"
 
-#: ../src/common/fileconf.cpp:422
+#: ../src/common/fileconf.cpp:421
 msgid "Error reading config options."
 msgstr "Virhe asetusten lukemisessa."
+
+#: ../src/msw/webview_ie.cpp:1057 ../src/msw/webview_edge.cpp:850
+#: ../src/gtk/webview_webkit2.cpp:1262 ../src/osx/webview_webkit.mm:383
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
 
 #: ../src/common/fileconf.cpp:1029
 msgid "Error saving user configuration data."
 msgstr "Virhe käyttäjän asetusten tallentamisessa."
 
-#: ../src/gtk/print.cpp:722
+#: ../src/gtk/print.cpp:720
 msgid "Error while printing: "
 msgstr "Virhe tulostettaessa: "
 
-#: ../src/common/log.cpp:219
+#: ../src/common/log.cpp:237
 msgid "Error: "
 msgstr "Virhe: "
 
+#: ../src/common/webrequest.cpp:98
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Virhe: "
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:69
+#: ../src/common/accelcmn.cpp:66
 msgid "Esc"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:70
+#: ../src/common/accelcmn.cpp:67
 #, fuzzy
 msgid "Escape"
 msgstr "Vaakasuunta"
 
-#: ../src/common/fmapbase.cpp:150
+#: ../src/common/fmapbase.cpp:147
 msgid "Esperanto (ISO-8859-3)"
 msgstr "esperanto (ISO-8859-3)"
 
-#: ../include/wx/generic/progdlgg.h:85
+#: ../include/wx/generic/progdlgg.h:86
 msgid "Estimated time:"
 msgstr "Arvioitu aika:"
 
-#: ../src/generic/dbgrptg.cpp:234
+#: ../src/generic/dbgrptg.cpp:231
 #, fuzzy
 msgid "Executable files (*.exe)|*.exe|"
 msgstr "Suoritettavat tiedostot (*.exe)|*.exe|Kaikki tiedostot (*.*)|*.*||"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:155 ../src/common/accelcmn.cpp:78
+#: ../src/common/stockitem.cpp:152 ../src/common/accelcmn.cpp:75
 msgid "Execute"
 msgstr "Suorita"
 
-#: ../src/msw/utilsexc.cpp:876
+#: ../src/msw/utilsexc.cpp:873
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Komennon ”%s” käynnistäminen epäonnistui"
 
-#: ../src/common/paper.cpp:105
+#: ../src/common/paper.cpp:102
 #, fuzzy
 msgid "Executive, 7 1/4 x 10 1/2 in"
 msgstr "Executive, 7 1/4 x 10 1/2” "
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6009
+#: ../src/generic/datavgen.cpp:6814
 msgid "Expand"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1240
+#: ../src/msw/registry.cpp:1228
 #, fuzzy, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
 msgstr "Viety rekisteriavain: tiedosto ”%s” on jo olemassa eikä sitä korvata."
 
-#: ../src/common/fmapbase.cpp:195
+#: ../src/common/fmapbase.cpp:192
 msgid "Extended Unix Codepage for Japanese (EUC-JP)"
 msgstr "Laajennettu japanilainen Unix-koodisivu (EUC-JP)"
 
-#: ../src/html/chm.cpp:725
+#: ../src/html/chm.cpp:718
 #, c-format
 msgid "Extraction of '%s' into '%s' failed."
 msgstr "Ei voitu purkaa ”%s”:aa kohteeseen ”%s”."
 
-#: ../src/common/accelcmn.cpp:249 ../src/common/accelcmn.cpp:344
+#: ../src/common/accelcmn.cpp:259 ../src/common/accelcmn.cpp:358
 msgid "F"
 msgstr "F"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:672
+#: ../src/propgrid/advprops.cpp:582
 #, fuzzy
 msgid "Face Name"
 msgstr "UusiNimi"
 
-#: ../src/unix/snglinst.cpp:269
+#: ../src/unix/snglinst.cpp:266
 msgid "Failed to access lock file."
 msgstr "Lukkotiedostoon ei päästy käsiksi."
+
+#: ../src/gtk/font.cpp:572
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Kuvaa %d ei voi ladata tiedostosta ”%s”."
 
 #: ../src/unix/epolldispatcher.cpp:116
 #, fuzzy, c-format
 msgid "Failed to add descriptor %d to epoll descriptor %d"
 msgstr "kirjoittaminen epäonnistui tiedoston kuvaukseen %d"
 
-#: ../src/msw/dib.cpp:489
+#: ../src/msw/dib.cpp:535
 #, fuzzy, c-format
 msgid "Failed to allocate %luKb of memory for bitmap data."
 msgstr "Osoittimen luonti epäonnistui."
 
-#: ../src/common/glcmn.cpp:115
+#: ../src/common/glcmn.cpp:112
 #, fuzzy
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Osoittimen luonti epäonnistui."
 
-#: ../src/unix/displayx11.cpp:236
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Osoittimen luonti epäonnistui."
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Osoittimen luonti epäonnistui."
+
+#: ../include/wx/unix/private/displayx11.h:89
 msgid "Failed to change video mode"
 msgstr "Näyttötilan vaihto epäonnistui"
 
-#: ../src/common/image.cpp:3277
+#: ../src/common/image.cpp:3396
 #, fuzzy, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Kuvaa %d ei voi ladata tiedostosta ”%s”."
 
-#: ../src/common/debugrpt.cpp:239
+#: ../src/common/debugrpt.cpp:240
 #, fuzzy, c-format
 msgid "Failed to clean up debug report directory \"%s\""
 msgstr "Ohjelmavirheiden ilmoituskansion ”%s” tyhjentäminen epäonnistui."
 
-#: ../src/common/filename.cpp:192
+#: ../src/common/filename.cpp:189
 msgid "Failed to close file handle"
 msgstr "Tiedostokahvan sulkeminen epäonnistui"
 
-#: ../src/unix/snglinst.cpp:340
+#: ../src/unix/snglinst.cpp:337
 #, c-format
 msgid "Failed to close lock file '%s'"
 msgstr "Lukkotiedoston ”%s” sulkeminen epäonnistui"
 
-#: ../src/msw/clipbrd.cpp:112
+#: ../src/msw/clipbrd.cpp:110
 msgid "Failed to close the clipboard."
 msgstr "Leikepöydän sulkeminen epäonnistui."
 
-#: ../src/x11/utils.cpp:208
+#: ../src/x11/utils.cpp:170
 #, fuzzy, c-format
 msgid "Failed to close the display \"%s\""
 msgstr "Näytön ”%s” sulkeminen epäonnistui"
 
-#: ../src/msw/dialup.cpp:797
+#: ../src/msw/dialup.cpp:791
 msgid "Failed to connect: missing username/password."
 msgstr "Yhdistäminen epäonnistui: käyttäjätunnus/salasana puutui."
 
-#: ../src/msw/dialup.cpp:743
+#: ../src/msw/dialup.cpp:737
 msgid "Failed to connect: no ISP to dial."
 msgstr "Yhdistäminen epäonnistui: ei soitettavissa olevaa palveluntarjoajaa."
 
-#: ../src/common/textfile.cpp:203
-#, fuzzy, c-format
-msgid "Failed to convert file \"%s\" to Unicode."
-msgstr "Tiedostoa ”%s” ei voitu muuntaa Unicode-muotoon."
-
-#: ../src/generic/logg.cpp:956
+#: ../src/generic/logg.cpp:953
 #, fuzzy
 msgid "Failed to copy dialog contents to the clipboard."
 msgstr "Leikepöydän avaus ei onnistunut."
 
-#: ../src/msw/registry.cpp:692
+#: ../src/msw/registry.cpp:681
 #, c-format
 msgid "Failed to copy registry value '%s'"
 msgstr "Rekisteriarvon ”%s” kopiointi ei onnistu"
 
-#: ../src/msw/registry.cpp:701
+#: ../src/msw/registry.cpp:690
 #, c-format
 msgid "Failed to copy the contents of registry key '%s' to '%s'."
 msgstr "Ei voi kopioida rekisteriavaimen ”%s” sisältää avaimeen ”%s”."
 
-#: ../src/common/filefn.cpp:1015
+#: ../src/common/filefn.cpp:904
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Tiedoston ”%s” kopiointi kohteeseen ”%s” epäonnistui."
 
-#: ../src/msw/registry.cpp:679
+#: ../src/msw/registry.cpp:668
 #, fuzzy, c-format
 msgid "Failed to copy the registry subkey '%s' to '%s'."
 msgstr "Ali-rekisteriavaimen ”%s” kopiointi ”%s”:ksi ei onnistu."
 
-#: ../src/msw/dde.cpp:1070
+#: ../src/msw/dde.cpp:1134
 msgid "Failed to create DDE string"
 msgstr "DDE-merkkijonoa ei voitu luoda"
 
-#: ../src/msw/mdi.cpp:616
+#: ../src/msw/mdi.cpp:621
 msgid "Failed to create MDI parent frame."
 msgstr "MDI-isäntäkehystä ei voitu luoda."
 
-#: ../src/common/filename.cpp:1027
+#: ../src/common/filename.cpp:1024
 msgid "Failed to create a temporary file name"
 msgstr "Tilapäistiedoston nimen luonti epäonnistui."
 
-#: ../src/msw/utilsexc.cpp:228
+#: ../src/msw/utilsexc.cpp:225
 msgid "Failed to create an anonymous pipe"
 msgstr "Anonyymin putken luonti epäonnistui"
 
-#: ../src/msw/ole/automtn.cpp:522
+#: ../src/msw/ole/automtn.cpp:513
 #, fuzzy, c-format
 msgid "Failed to create an instance of \"%s\""
 msgstr "Tilarivin luonti epäonnistui."
 
-#: ../src/msw/dde.cpp:437
+#: ../src/msw/dde.cpp:432
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "Ei voitu yhdistää palvelimeen ”%s” asiassa %s"
 
-#: ../src/msw/cursor.cpp:204
+#: ../src/msw/cursor.cpp:195
 msgid "Failed to create cursor."
 msgstr "Osoittimen luonti epäonnistui."
 
-#: ../src/common/debugrpt.cpp:209
+#: ../src/common/debugrpt.cpp:210
 #, fuzzy, c-format
 msgid "Failed to create directory \"%s\""
 msgstr "Hakemiston ”%s” luonti epäonnistui."
 
-#: ../src/generic/dirdlgg.cpp:220
+#: ../src/generic/dirdlgg.cpp:217
 #, c-format
 msgid ""
 "Failed to create directory '%s'\n"
@@ -3302,120 +3326,139 @@ msgstr ""
 msgid "Failed to create epoll descriptor"
 msgstr "Osoittimen luonti epäonnistui."
 
-#: ../src/msw/mimetype.cpp:238
+#: ../src/gtk/font.cpp:562
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "Käyttäjän asetustiedoston päivitys ei onnistu."
+
+#: ../src/msw/mimetype.cpp:235
 #, c-format
 msgid "Failed to create registry entry for '%s' files."
 msgstr "Rekisteriavaimen luonti ”%s” tyypin tiedostoille ei onnistu."
 
-#: ../src/msw/fdrepdlg.cpp:409
+#: ../src/msw/fdrepdlg.cpp:408
 #, c-format
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr "Standardin etsi/korvaa ikkunan luonti epäonnistui (virhekoodi %d)"
 
-#: ../src/unix/wakeuppipe.cpp:52
+#: ../src/unix/wakeuppipe.cpp:49
 #, fuzzy
 msgid "Failed to create wake up pipe used by event loop."
 msgstr "Tilarivin luonti epäonnistui."
 
-#: ../src/html/winpars.cpp:730
+#: ../src/html/winpars.cpp:727
 #, c-format
 msgid "Failed to display HTML document in %s encoding"
 msgstr "HTML %s-koodattua asiakirjaa ei voi näyttää"
 
-#: ../src/msw/clipbrd.cpp:124
+#: ../src/msw/clipbrd.cpp:122
 msgid "Failed to empty the clipboard."
 msgstr "Leikepöydän tyhjennys epäonnistui."
 
-#: ../src/unix/displayx11.cpp:212
+#: ../include/wx/unix/private/displayx11.h:65
 msgid "Failed to enumerate video modes"
 msgstr "Näyttötilojen luettelointi ei onnistu"
 
-#: ../src/msw/dde.cpp:722
+#: ../src/msw/dde.cpp:717
 #, fuzzy
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "DDE-serverin ohjeistuspiiriä ei aikaansaatu"
 
-#: ../src/msw/dialup.cpp:629 ../src/msw/dialup.cpp:863
+#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Soittoyhteyttä %s ei voitu luoda"
 
-#: ../src/unix/utilsunx.cpp:611
+#: ../src/unix/utilsunx.cpp:613
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Ei voitu ajaa kohdetta ”%s”\n"
 
-#: ../src/common/debugrpt.cpp:720
+#: ../src/common/debugrpt.cpp:730
 msgid "Failed to execute curl, please install it in PATH."
 msgstr ""
 "curl:in suorittaminen epäonnistui. Asenna se johonkin PATH-määrityksessä "
 "olevaan hakemistoon."
 
-#: ../src/msw/ole/automtn.cpp:505
+#: ../src/msw/ole/automtn.cpp:496
 #, c-format
 msgid "Failed to find CLSID of \"%s\""
 msgstr "Kohteen \"%s\" CLSID:n haku epäonnistui"
 
-#: ../src/common/regex.cpp:431 ../src/common/regex.cpp:479
+#: ../src/common/regex.cpp:428 ../src/common/regex.cpp:476
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "Ei voitu löytää osumia säännölliselle lausekkeelle: %s"
 
-#: ../src/msw/dialup.cpp:695
+#: ../src/msw/webview_ie.cpp:978
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:689
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Palveluntarjoajien nimeä ei saatu: %s"
 
-#: ../src/msw/ole/automtn.cpp:574
+#: ../src/msw/ole/automtn.cpp:565
 #, c-format
 msgid "Failed to get OLE automation interface for \"%s\""
 msgstr "Kohteen \"%s\" OLE -automaatiorajapinnan selvittäminen epäonnistui"
 
-#: ../src/msw/clipbrd.cpp:711
+#: ../src/msw/clipbrd.cpp:731
 msgid "Failed to get data from the clipboard"
 msgstr "Dataa ei voida hakea leikepöydältä"
 
-#: ../src/common/time.cpp:223
+#: ../src/common/time.cpp:216
 msgid "Failed to get the local system time"
 msgstr "Paikallista systeemiaikaa ei saatu"
 
-#: ../src/common/filefn.cpp:1345
+#: ../src/common/filefn.cpp:1233
 msgid "Failed to get the working directory"
 msgstr "Työhakemistoa ei saatu"
 
-#: ../src/univ/theme.cpp:114
+#: ../src/univ/theme.cpp:111
 msgid "Failed to initialize GUI: no built-in themes found."
 msgstr "GUI:n alustus epäonnistui: ei teemoja mukana."
 
-#: ../src/msw/helpchm.cpp:63
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:60
 msgid "Failed to initialize MS HTML Help."
 msgstr "MS HTML Ohjeen alustus epäonnistui."
 
-#: ../src/msw/glcanvas.cpp:1381
+#: ../src/msw/glcanvas.cpp:1391
 msgid "Failed to initialize OpenGL"
 msgstr "OpenGL:n alustus epäonnistui"
 
-#: ../src/msw/dialup.cpp:858
+#: ../src/msw/dialup.cpp:852
 #, fuzzy, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Puhelinyhteyden ”%s” keskeytys ei onnistunut."
 
-#: ../src/gtk/textctrl.cpp:1128
+#: ../src/gtk/textctrl.cpp:1209
 #, fuzzy
 msgid "Failed to insert text in the control."
 msgstr "Työhakemistoa ei saatu"
 
-#: ../src/unix/snglinst.cpp:241
+#: ../src/unix/snglinst.cpp:238
 #, c-format
 msgid "Failed to inspect the lock file '%s'"
 msgstr "Lukkotiedostoa ”%s” ei voitu tutkia"
 
-#: ../src/unix/appunix.cpp:182
+#: ../src/unix/appunix.cpp:179
 #, fuzzy
 msgid "Failed to install signal handler"
 msgstr "Tiedostokahvan sulkeminen epäonnistui"
 
-#: ../src/unix/threadpsx.cpp:1167
+#: ../src/unix/threadpsx.cpp:1216
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -3423,71 +3466,71 @@ msgstr ""
 "Säikeen kytkentä epäonnistui, todennäköisesti muistivuoto - ole hyvä ja "
 "käynnistä ohjelma uudestaan"
 
-#: ../src/msw/utils.cpp:629
+#: ../src/msw/utils.cpp:619
 #, c-format
 msgid "Failed to kill process %d"
 msgstr "Prosessia %d ei voitu lopettaa."
 
-#: ../src/common/image.cpp:2500
+#: ../src/common/image.cpp:2595
 #, fuzzy, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Kuvaa %d ei voi ladata tiedostosta ”%s”."
 
-#: ../src/common/image.cpp:2509
+#: ../src/common/image.cpp:2604
 #, fuzzy, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Kuvaa %d ei voi ladata tiedostosta ”%s”."
 
-#: ../src/common/iconbndl.cpp:225
+#: ../src/common/iconbndl.cpp:224
 #, fuzzy, c-format
 msgid "Failed to load icons from resource '%s'."
 msgstr "Kuvaa %d ei voi ladata tiedostosta ”%s”."
 
-#: ../src/common/iconbndl.cpp:200
+#: ../src/common/iconbndl.cpp:198
 #, fuzzy, c-format
 msgid "Failed to load image %%d from file '%s'."
 msgstr "Kuvaa %d ei voi ladata tiedostosta ”%s”."
 
-#: ../src/common/iconbndl.cpp:208
+#: ../src/common/iconbndl.cpp:206
 #, fuzzy, c-format
 msgid "Failed to load image %d from stream."
 msgstr "Kuvaa %d ei voi ladata tiedostosta ”%s”."
 
-#: ../src/common/image.cpp:2587 ../src/common/image.cpp:2606
+#: ../src/common/image.cpp:2682 ../src/common/image.cpp:2701
 #, fuzzy, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Kuvaa %d ei voi ladata tiedostosta ”%s”."
 
-#: ../src/msw/enhmeta.cpp:97
+#: ../src/msw/enhmeta.cpp:94
 #, fuzzy, c-format
 msgid "Failed to load metafile from file \"%s\"."
 msgstr "Metatiedostoa ei voitu ladata tiedostosta ”%s”."
 
-#: ../src/msw/volume.cpp:327
+#: ../src/msw/volume.cpp:335
 msgid "Failed to load mpr.dll."
 msgstr "Tiedoston mpr.dll lataus epäonnistui."
 
-#: ../src/msw/utils.cpp:953
+#: ../src/msw/utils.cpp:943
 #, fuzzy, c-format
 msgid "Failed to load resource \"%s\"."
 msgstr "Prosessia %d ei voitu lopettaa."
 
-#: ../src/common/dynlib.cpp:92
+#: ../src/common/dynlib.cpp:86
 #, c-format
 msgid "Failed to load shared library '%s'"
 msgstr "Jaetun kirjaston ”%s” lataaminen epäonnistui"
 
-#: ../src/osx/core/sound.cpp:145
+#: ../src/osx/core/sound.cpp:143
 #, fuzzy, c-format
 msgid "Failed to load sound from \"%s\" (error %d)."
 msgstr "Prosessia %d ei voitu lopettaa."
 
-#: ../src/msw/utils.cpp:960
+#: ../src/msw/utils.cpp:950
 #, fuzzy, c-format
 msgid "Failed to lock resource \"%s\"."
 msgstr "Lukkotiedostoa ”%s” ei voitu lukita"
 
-#: ../src/unix/snglinst.cpp:198
+#: ../src/unix/snglinst.cpp:195
 #, c-format
 msgid "Failed to lock the lock file '%s'"
 msgstr "Lukkotiedostoa ”%s” ei voitu lukita"
@@ -3497,33 +3540,38 @@ msgstr "Lukkotiedostoa ”%s” ei voitu lukita"
 msgid "Failed to modify descriptor %d in epoll descriptor %d"
 msgstr "Kuvaajan %d muokkaus epäonnistui epoll-kuvaajassa %d"
 
-#: ../src/common/filename.cpp:2575
+#: ../src/common/filename.cpp:2658
 #, fuzzy, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Tiedoston ”%s” aikoja ei voitu muuttaa"
 
-#: ../src/common/selectdispatcher.cpp:258
+#: ../src/common/selectdispatcher.cpp:255
 msgid "Failed to monitor I/O channels"
 msgstr "I/O-kanavien seuraaminen epäonnistui"
 
-#: ../src/common/filename.cpp:175
+#: ../src/common/filename.cpp:172
 #, c-format
 msgid "Failed to open '%s' for reading"
 msgstr "Kohteen ”%s” avaaminen lukemista varten epäonnistui"
 
-#: ../src/common/filename.cpp:180
+#: ../src/common/filename.cpp:177
 #, c-format
 msgid "Failed to open '%s' for writing"
 msgstr "Kohteen ”%s” avaaminen kirjoittamista varten epäonnistui"
 
-#: ../src/html/chm.cpp:141
+#: ../src/html/chm.cpp:138
 #, c-format
 msgid "Failed to open CHM archive '%s'."
 msgstr "CHM arkiston ”%s” avaaminen epäonnistui."
 
-#: ../src/common/utilscmn.cpp:1126
+#: ../src/common/utilscmn.cpp:1140
 #, fuzzy, c-format
 msgid "Failed to open URL \"%s\" in default browser."
+msgstr "URL-osoitetta ”%s” ei voitu avata oletusselaimessa."
+
+#: ../src/common/hyperlnkcmn.cpp:133
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "URL-osoitetta ”%s” ei voitu avata oletusselaimessa."
 
 #: ../include/wx/msw/private/fswatcher.h:92
@@ -3531,95 +3579,105 @@ msgstr "URL-osoitetta ”%s” ei voitu avata oletusselaimessa."
 msgid "Failed to open directory \"%s\" for monitoring."
 msgstr "Kohteen ”%s” avaaminen kirjoittamista varten epäonnistui"
 
-#: ../src/x11/utils.cpp:227
+#: ../src/x11/utils.cpp:189
 #, fuzzy, c-format
 msgid "Failed to open display \"%s\"."
 msgstr "Näyttöä ”%s” ei voitu avata."
 
-#: ../src/common/filename.cpp:1062
+#: ../src/common/filename.cpp:1059
 msgid "Failed to open temporary file."
 msgstr "Tilapäistiedoston avaus epäonnistui."
 
-#: ../src/msw/clipbrd.cpp:91
+#: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Leikepöydän avaus ei onnistunut."
 
-#: ../src/common/translation.cpp:1184
+#: ../src/common/translation.cpp:1226
 #, fuzzy, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Monikkomuotoja ”%s” ei voida käsitellä"
 
-#: ../src/unix/mediactrl.cpp:1214
+#: ../src/unix/mediactrl.cpp:1239
 #, fuzzy, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Näyttöä ”%s” ei voitu avata."
 
-#: ../src/msw/clipbrd.cpp:600
+#: ../src/msw/clipbrd.cpp:610
 msgid "Failed to put data on the clipboard"
 msgstr "Dataa ei voida siirtää leikepöydälle."
 
-#: ../src/unix/snglinst.cpp:278
+#: ../src/unix/snglinst.cpp:275
 msgid "Failed to read PID from lock file."
 msgstr "PID:iä ei voitu lukea lukkotiedostosta."
 
-#: ../src/common/fileconf.cpp:433
+#: ../src/common/fileconf.cpp:432
 msgid "Failed to read config options."
 msgstr "Asetuksia ei voitu lukea."
 
-#: ../src/common/docview.cpp:681
+#: ../src/common/docview.cpp:676
 #, fuzzy, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Kuvaa %d ei voi ladata tiedostosta ”%s”."
 
-#: ../src/dfb/evtloop.cpp:98
+#: ../src/dfb/evtloop.cpp:99
 #, fuzzy
 msgid "Failed to read event from DirectFB pipe"
 msgstr "PID:iä ei voitu lukea lukkotiedostosta."
 
-#: ../src/unix/wakeuppipe.cpp:120
+#: ../src/unix/wakeuppipe.cpp:117
 #, fuzzy
 msgid "Failed to read from wake-up pipe"
 msgstr "PID:iä ei voitu lukea lukkotiedostosta."
 
-#: ../src/unix/utilsunx.cpp:679
+#: ../src/common/textfile.cpp:96
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Kuvaa %d ei voi ladata tiedostosta ”%s”."
+
+#: ../src/unix/utilsunx.cpp:681
 msgid "Failed to redirect child process input/output"
 msgstr "Lapsiprosessin I/O:n uudelleenohjaus epäonnistui"
 
-#: ../src/msw/utilsexc.cpp:701
+#: ../src/msw/utilsexc.cpp:698
 msgid "Failed to redirect the child process IO"
 msgstr "Lapsiprosessin I/O:n uudelleenohjaus epäonnistui"
 
-#: ../src/msw/dde.cpp:288
+#: ../src/msw/dde.cpp:283
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "DDE-palvelimen ”%s” rekisteröinti epäonnistui"
 
-#: ../src/common/fontmap.cpp:245
+#: ../src/gtk/font.cpp:580
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "Käyttäjän asetustiedoston päivitys ei onnistu."
+
+#: ../src/common/fontmap.cpp:242
 #, c-format
 msgid "Failed to remember the encoding for the charset '%s'."
 msgstr "Merkistön ”%s” koodaus on unohtunut."
 
-#: ../src/common/debugrpt.cpp:227
+#: ../src/common/debugrpt.cpp:228
 #, fuzzy, c-format
 msgid "Failed to remove debug report file \"%s\""
 msgstr "Ohjelmavirhetiedostoa ”%s” ei voitu poistaa."
 
-#: ../src/unix/snglinst.cpp:328
+#: ../src/unix/snglinst.cpp:325
 #, c-format
 msgid "Failed to remove lock file '%s'"
 msgstr "Lukkotiedoston ”%s” poisto ei onnistu"
 
-#: ../src/unix/snglinst.cpp:288
+#: ../src/unix/snglinst.cpp:285
 #, c-format
 msgid "Failed to remove stale lock file '%s'."
 msgstr "Vanhan lukitustiedoston '%s' poisto epäonnistui."
 
-#: ../src/msw/registry.cpp:529
+#: ../src/msw/registry.cpp:518
 #, c-format
 msgid "Failed to rename registry value '%s' to '%s'."
 msgstr "Rekisteriavaimen ”%s” nimeäminen ”%s”:ksi ei onnistu."
 
-#: ../src/common/filefn.cpp:1122
+#: ../src/common/filefn.cpp:1011
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -3628,117 +3686,125 @@ msgstr ""
 "Tiedoston '%s' uudelleennimeäminen tiedostoksi '%s' epäonnistui, koska "
 "kohdetiedosto on jo olemassa."
 
-#: ../src/msw/registry.cpp:634
+#: ../src/msw/registry.cpp:623
 #, c-format
 msgid "Failed to rename the registry key '%s' to '%s'."
 msgstr "Rekisteriavaimen ”%s” nimeäminen ”%s”:ksi ei onnistu."
 
-#: ../src/common/filename.cpp:2671
+#: ../src/msw/webview_ie.cpp:995
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/common/filename.cpp:2754
 #, fuzzy, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Tiedoston ”%s” aikoja ei voida hakea"
 
-#: ../src/msw/dialup.cpp:468
+#: ../src/msw/dialup.cpp:462
 msgid "Failed to retrieve text of RAS error message"
 msgstr "RAS-virheilmoitusta ei saatu."
 
-#: ../src/msw/clipbrd.cpp:748
+#: ../src/msw/clipbrd.cpp:768
 msgid "Failed to retrieve the supported clipboard formats"
 msgstr "Ei voi hakea tuettuja leikepöytämuotoja"
 
-#: ../src/common/docview.cpp:652
+#: ../src/common/docview.cpp:647
 #, fuzzy, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Touch epäonnistui tiedostolle ”%s”"
 
-#: ../src/msw/dib.cpp:269
+#: ../src/msw/dib.cpp:312
 #, fuzzy, c-format
 msgid "Failed to save the bitmap image to file \"%s\"."
 msgstr "Kuvatiedostoa ”%s” ei voitu tallentaa."
 
-#: ../src/msw/dde.cpp:763
+#: ../src/msw/dde.cpp:811
 msgid "Failed to send DDE advise notification"
 msgstr "DDE:n ohjeistustiedotuksen lähetys epäonnistui"
 
-#: ../src/common/ftp.cpp:402
+#: ../src/common/ftp.cpp:399
 #, c-format
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "FTP:n siirtotilan %s asetus epäonnistui."
 
-#: ../src/msw/clipbrd.cpp:427
+#: ../src/msw/clipbrd.cpp:443
 msgid "Failed to set clipboard data."
 msgstr "Leikepöydän datan asetus epäonnistui."
 
-#: ../src/unix/snglinst.cpp:181
+#: ../src/unix/snglinst.cpp:178
 #, c-format
 msgid "Failed to set permissions on lock file '%s'"
 msgstr "Oikeuksia ei voitu asettaa lukkotiedostolle ”%s”"
 
-#: ../src/unix/utilsunx.cpp:668
+#: ../src/unix/utilsunx.cpp:670
 #, fuzzy
 msgid "Failed to set process priority"
 msgstr "Säikeen prioriteetin %d asetus epäonnistui."
 
-#: ../src/common/file.cpp:559
+#: ../src/common/ffile.cpp:355 ../src/common/file.cpp:586
 msgid "Failed to set temporary file permissions"
 msgstr "Tilapäistiedoston oikeuksia ei voitu asettaa."
 
-#: ../src/gtk/textctrl.cpp:1072
-#, fuzzy
-msgid "Failed to set text in the text control."
-msgstr "Työhakemistoa ei saatu"
-
-#: ../src/unix/threadpsx.cpp:1298
+#: ../src/unix/threadpsx.cpp:1347
 #, fuzzy, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Säikeen prioriteetin %d asetus epäonnistui."
 
-#: ../src/unix/threadpsx.cpp:1424
+#: ../src/unix/threadpsx.cpp:1473
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Säikeen prioriteetin %d asetus epäonnistui."
 
-#: ../src/unix/utilsunx.cpp:783
+#: ../src/unix/utilsunx.cpp:785
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 
-#: ../src/common/fs_mem.cpp:261
+#: ../src/msw/webview_ie.cpp:987
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:256
 #, c-format
 msgid "Failed to store image '%s' to memory VFS!"
 msgstr "Kuvan ”%s” tallennus Muisti-VFS:ään epäonnistui!"
 
-#: ../src/dfb/evtloop.cpp:170
+#: ../src/dfb/evtloop.cpp:171
 msgid "Failed to switch DirectFB pipe to non-blocking mode"
 msgstr ""
 
-#: ../src/unix/wakeuppipe.cpp:59
+#: ../src/unix/wakeuppipe.cpp:56
 msgid "Failed to switch wake up pipe to non-blocking mode"
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1605
+#: ../src/unix/threadpsx.cpp:1654
 msgid "Failed to terminate a thread."
 msgstr "Säikeen päättäminen epäonnistui."
 
-#: ../src/msw/dde.cpp:741
+#: ../src/msw/dde.cpp:736
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "DDE ohjeistuspiirin (advise loop) keskeytys ei onnistunut"
 
-#: ../src/msw/dialup.cpp:938
+#: ../src/msw/dialup.cpp:932
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Puhelinyhteyden ”%s” keskeytys ei onnistunut."
 
-#: ../src/common/filename.cpp:2590
+#: ../src/common/filename.cpp:2673
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Touch epäonnistui tiedostolle ”%s”"
 
-#: ../src/unix/snglinst.cpp:334
+#: ../src/unix/dlunix.cpp:90
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "Jaetun kirjaston ”%s” lataaminen epäonnistui"
+
+#: ../src/unix/snglinst.cpp:331
 #, c-format
 msgid "Failed to unlock lock file '%s'"
 msgstr "Lukkotiedoston ”%s” lukitusta ei voitu purkaa"
 
-#: ../src/msw/dde.cpp:309
+#: ../src/msw/dde.cpp:304
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "DDE-serverin ”%s” poisto rekisteröinnistä epäonnistui"
@@ -3752,79 +3818,89 @@ msgstr "Dataa ei voida hakea leikepöydältä."
 msgid "Failed to update user configuration file."
 msgstr "Käyttäjän asetustiedoston päivitys ei onnistu."
 
-#: ../src/common/debugrpt.cpp:733
+#: ../src/common/debugrpt.cpp:743
 #, c-format
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Ohjelmavirheilmoitusta ei voitu lähettää (virhekoodi %d)."
 
-#: ../src/unix/snglinst.cpp:168
+#: ../src/unix/snglinst.cpp:165
 #, c-format
 msgid "Failed to write to lock file '%s'"
 msgstr "Lukkotiedoston ”%s” kirjoitus epäonnistui"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:209
+#: ../src/propgrid/propgrid.cpp:190
 #, fuzzy
 msgid "False"
 msgstr "Tiedosto"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:694
+#: ../src/propgrid/advprops.cpp:604
 #, fuzzy
 msgid "Family"
 msgstr "&Kirjasinperhe:"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/gtk/glcanvas.cpp:176 ../src/gtk/glcanvas.cpp:187
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Tuhoisa virhe"
+
+#: ../src/common/stockitem.cpp:154
 msgid "File"
 msgstr "Tiedosto"
 
-#: ../src/common/docview.cpp:669
+#: ../src/common/docview.cpp:664
 #, fuzzy, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Kohteen ”%s” avaaminen lukemista varten epäonnistui"
 
-#: ../src/common/docview.cpp:646
+#: ../src/common/docview.cpp:641
 #, fuzzy, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Kohteen ”%s” avaaminen kirjoittamista varten epäonnistui"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "Tiedosto ”%s” on jo olemassa, korvataanko se varmasti?"
 
-#: ../src/common/filefn.cpp:1156
+#: ../src/common/filefn.cpp:1044
 #, fuzzy, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Hakemistoa ”%s” ei voitu luoda"
 
-#: ../src/common/filefn.cpp:1139
+#: ../src/common/filefn.cpp:1028
 #, fuzzy, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Hakemistoa ”%s” ei voitu luoda"
 
-#: ../src/richtext/richtextctrl.cpp:3081 ../src/common/textcmn.cpp:953
+#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
 msgid "File couldn't be loaded."
 msgstr "Tiedostoa ei voitu ladata."
 
-#: ../src/msw/filedlg.cpp:393
+#: ../src/msw/filedlg.cpp:414
 #, fuzzy, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Värin valintaikkuna epäonnistui virheellä %0lx."
 
-#: ../src/common/docview.cpp:1789
+#: ../src/common/docview.cpp:1783
 msgid "File error"
 msgstr "Tiedostovirhe"
 
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/filectrlg.cpp:770
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/filectrlg.cpp:766
 msgid "File name exists already."
 msgstr "Tiedostonimi on jo olemassa."
+
+#: ../src/osx/cocoa/filedlg.mm:264
+#, fuzzy
+msgid "File type:"
+msgstr "Teletype"
 
 #: ../src/motif/filedlg.cpp:220
 msgid "Files"
 msgstr "Tiedostot"
 
-#: ../src/common/filefn.cpp:1591
+#: ../src/common/filefn.cpp:1479
 #, c-format
 msgid "Files (%s)"
 msgstr "Tiedostot (%s)"
@@ -3833,16 +3909,30 @@ msgstr "Tiedostot (%s)"
 msgid "Filter"
 msgstr "Suodatin"
 
-#: ../src/common/stockitem.cpp:158 ../src/html/helpwnd.cpp:490
+#: ../src/html/helpwnd.cpp:488
 msgid "Find"
 msgstr "Etsi"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:259
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:258
+#, fuzzy
+msgid "Find in document"
+msgstr "Avaa HTML-asiakirja"
+
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "Find..."
+msgstr "Etsi"
+
+#: ../src/common/stockitem.cpp:156
 #, fuzzy
 msgid "First"
 msgstr "ensimmäinen"
 
-#: ../src/common/prntbase.cpp:1548
+#: ../src/common/prntbase.cpp:1573
 #, fuzzy
 msgid "First page"
 msgstr "Seuraava sivu"
@@ -3852,11 +3942,11 @@ msgstr "Seuraava sivu"
 msgid "Fixed"
 msgstr "Kiinteälevyinen fontti:"
 
-#: ../src/html/helpwnd.cpp:1206
+#: ../src/html/helpwnd.cpp:1204
 msgid "Fixed font:"
 msgstr "Kiinteälevyinen fontti:"
 
-#: ../src/html/helpwnd.cpp:1269
+#: ../src/html/helpwnd.cpp:1267
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Kiinteäkokoinen kirjasin.<br> <b>lihavoitu</b> <i>kursivoitu</i> "
 
@@ -3864,17 +3954,17 @@ msgstr "Kiinteäkokoinen kirjasin.<br> <b>lihavoitu</b> <i>kursivoitu</i> "
 msgid "Floating"
 msgstr "Liukuva"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 #, fuzzy
 msgid "Floppy"
 msgstr "Kopioi"
 
-#: ../src/common/paper.cpp:111
+#: ../src/common/paper.cpp:108
 msgid "Folio, 8 1/2 x 13 in"
 msgstr "Folio, 8 1/2″ x 13″"
 
-#: ../src/richtext/richtextformatdlg.cpp:344 ../src/osx/carbon/fontdlg.cpp:287
-#: ../src/common/stockitem.cpp:194
+#: ../src/osx/carbon/fontdlg.cpp:284 ../src/common/stockitem.cpp:191
+#: ../src/richtext/richtextformatdlg.cpp:337
 msgid "Font"
 msgstr "Kirjasin"
 
@@ -3882,7 +3972,24 @@ msgstr "Kirjasin"
 msgid "Font &weight:"
 msgstr "Kirjasimen &paino:"
 
-#: ../src/html/helpwnd.cpp:1207
+#: ../src/osx/fontutil.cpp:89
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
+"\"."
+msgstr ""
+
+#: ../src/msw/font.cpp:1126
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Tiedostoa ei voitu ladata."
+
+#: ../src/osx/fontutil.cpp:81
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "Tiedosto %s ei ole olemassa."
+
+#: ../src/html/helpwnd.cpp:1205
 msgid "Font size:"
 msgstr "Kirjasinkoko:"
 
@@ -3890,77 +3997,77 @@ msgstr "Kirjasinkoko:"
 msgid "Font st&yle:"
 msgstr "Kirjasimen &tyyli:"
 
-#: ../src/osx/carbon/fontdlg.cpp:329
+#: ../src/osx/carbon/fontdlg.cpp:326
 msgid "Font:"
 msgstr "Kirjasin:"
 
-#: ../src/dfb/fontmgr.cpp:198
+#: ../src/dfb/fontmgr.cpp:195
 #, c-format
 msgid "Fonts index file %s disappeared while loading fonts."
 msgstr "Kirjasinten indeksitiedosto %s katosi kirjasimia ladattaessa."
 
-#: ../src/unix/utilsunx.cpp:645
+#: ../src/unix/utilsunx.cpp:647
 msgid "Fork failed"
 msgstr "Haarauttaminen epäonnistui"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 #, fuzzy
 msgid "Forward"
 msgstr "&Eteenpäin"
 
-#: ../src/common/xtixml.cpp:235
+#: ../src/common/xtixml.cpp:231
 msgid "Forward hrefs are not supported"
 msgstr "Eteenpäin osoittavia href-viittauksia ei tueta"
 
-#: ../src/html/helpwnd.cpp:875
+#: ../src/html/helpwnd.cpp:873
 #, c-format
 msgid "Found %i matches"
 msgstr "Löytyi %i täsmäävää"
 
-#: ../src/generic/prntdlgg.cpp:238
+#: ../src/generic/prntdlgg.cpp:231
 msgid "From:"
 msgstr "Lähettäjä:"
 
-#: ../src/propgrid/advprops.cpp:1604
+#: ../src/propgrid/advprops.cpp:1510
 msgid "Fuchsia"
 msgstr ""
 
-#: ../src/common/imaggif.cpp:138
+#: ../src/common/imaggif.cpp:135
 msgid "GIF: data stream seems to be truncated."
 msgstr "GIF: datan virta typistetty."
 
-#: ../src/common/imaggif.cpp:128
+#: ../src/common/imaggif.cpp:125
 msgid "GIF: error in GIF image format."
 msgstr "GIF: virhe GIF-kuvamuodossa."
 
-#: ../src/common/imaggif.cpp:133
+#: ../src/common/imaggif.cpp:130
 msgid "GIF: not enough memory."
 msgstr "GIF: ei riittävästi muistia."
 
-#: ../src/gtk/window.cpp:4631
+#: ../src/gtk/window.cpp:5635
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
 msgstr ""
 
-#: ../src/univ/themes/gtk.cpp:525
+#: ../src/univ/themes/gtk.cpp:522
 msgid "GTK+ theme"
 msgstr "GTK+-teema"
 
-#: ../src/common/preferencescmn.cpp:40
+#: ../src/common/preferencescmn.cpp:37
 msgid "General"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:258
+#: ../src/common/prntbase.cpp:253
 msgid "Generic PostScript"
 msgstr "Generic PostScript"
 
-#: ../src/common/paper.cpp:135
+#: ../src/common/paper.cpp:132
 #, fuzzy
 msgid "German Legal Fanfold, 8 1/2 x 13 in"
 msgstr "Saksalainen traktoriveto, 8 1/2 x 13” "
 
-#: ../src/common/paper.cpp:134
+#: ../src/common/paper.cpp:131
 #, fuzzy
 msgid "German Std Fanfold, 8 1/2 x 12 in"
 msgstr "Eurooppalainen traktoriveto, 8 1/2 x 12” "
@@ -3978,49 +4085,49 @@ msgid "GetPropertyCollection called w/o valid collection getter"
 msgstr ""
 "GetPropertyCollection-funktiota kutsuttu ilman kelvollista kokoelman hakijaa"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:658
 msgid "Go back"
 msgstr "Takaisin"
 
-#: ../src/html/helpwnd.cpp:661
+#: ../src/html/helpwnd.cpp:659
 msgid "Go forward"
 msgstr "Eteenpäin"
 
-#: ../src/html/helpwnd.cpp:663
+#: ../src/html/helpwnd.cpp:661
 msgid "Go one level up in document hierarchy"
 msgstr "Mene ylös asiakirjahierarkiassa"
 
-#: ../src/generic/filedlgg.cpp:208 ../src/generic/dirdlgg.cpp:116
+#: ../src/generic/filedlgg.cpp:205 ../src/generic/dirdlgg.cpp:113
 msgid "Go to home directory"
 msgstr "Siirry kotihakemistoon"
 
-#: ../src/generic/filedlgg.cpp:205
+#: ../src/generic/filedlgg.cpp:202
 msgid "Go to parent directory"
 msgstr "Mene ylähakemistoon"
 
-#: ../src/generic/aboutdlgg.cpp:76
+#: ../src/generic/aboutdlgg.cpp:73
 msgid "Graphics art by "
 msgstr "Graafisen taiteen tekijä:"
 
-#: ../src/propgrid/advprops.cpp:1599
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Gray"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:883
+#: ../src/propgrid/advprops.cpp:784
 msgid "GrayText"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:154
+#: ../src/common/fmapbase.cpp:151
 msgid "Greek (ISO-8859-7)"
 msgstr "kreikkalainen (ISO-8859-7)"
 
-#: ../src/propgrid/advprops.cpp:1600
+#: ../src/propgrid/advprops.cpp:1506
 #, fuzzy
 msgid "Green"
 msgstr "Mac (kreikkalainen)"
 
-#: ../src/generic/colrdlgg.cpp:342
+#: ../src/generic/colrdlgg.cpp:362
 #, fuzzy
 msgid "Green:"
 msgstr "Mac (kreikkalainen)"
@@ -4029,109 +4136,109 @@ msgstr "Mac (kreikkalainen)"
 msgid "Groove"
 msgstr ""
 
-#: ../src/common/zstream.cpp:158 ../src/common/zstream.cpp:318
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
 msgid "Gzip not supported by this version of zlib"
 msgstr "Gzip:iä ei tueta zlib:in tässä versiossa"
 
-#: ../src/html/helpwnd.cpp:1549
+#: ../src/html/helpwnd.cpp:1547
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "HTML Ohjeprojekti (*.hhp)|*.hhp|"
 
-#: ../src/html/htmlwin.cpp:681
+#: ../src/html/htmlwin.cpp:691
 #, c-format
 msgid "HTML anchor %s does not exist."
 msgstr "HTML-ankkuria %s ei ole olemassa."
 
-#: ../src/html/helpwnd.cpp:1547
+#: ../src/html/helpwnd.cpp:1545
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "HTML-tiedostot (*.html;*.htm)|*.html;*.htm|"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1759
+#: ../src/propgrid/advprops.cpp:1660
 msgid "Hand"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "Harddisk"
 msgstr "Kiintolevy"
 
-#: ../src/common/fmapbase.cpp:155
+#: ../src/common/fmapbase.cpp:152
 msgid "Hebrew (ISO-8859-8)"
 msgstr "heprea (ISO-8859-8)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:280 ../src/osx/button_osx.cpp:39
-#: ../src/common/stockitem.cpp:163 ../src/common/accelcmn.cpp:80
-#: ../src/html/helpdlg.cpp:66 ../src/html/helpfrm.cpp:111
+#: ../include/wx/msgdlg.h:282 ../src/osx/button_osx.cpp:39
+#: ../src/common/stockitem.cpp:160 ../src/common/accelcmn.cpp:77
+#: ../src/html/helpfrm.cpp:108 ../src/html/helpdlg.cpp:63
 msgid "Help"
 msgstr "Ohje"
 
-#: ../src/html/helpwnd.cpp:1200
+#: ../src/html/helpwnd.cpp:1198
 msgid "Help Browser Options"
 msgstr "Ohjeselaimen valinnat"
 
-#: ../src/generic/helpext.cpp:454 ../src/generic/helpext.cpp:455
+#: ../src/generic/helpext.cpp:452 ../src/generic/helpext.cpp:453
 msgid "Help Index"
 msgstr "Ohjeen sisältä"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1529
 msgid "Help Printing"
 msgstr "Ohjeen tulostus"
 
-#: ../src/html/helpwnd.cpp:801
+#: ../src/html/helpwnd.cpp:799
 msgid "Help Topics"
 msgstr "Ohjeen aiheet"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1546
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Ohjekirjat (*.htb)|*.htb|Ohjekirjat (*.zip)|*.zip|"
 
-#: ../src/generic/helpext.cpp:267
+#: ../src/generic/helpext.cpp:265
 #, fuzzy, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "Ohjehakemistoa ”%s” ei löytynyt."
 
-#: ../src/generic/helpext.cpp:275
+#: ../src/generic/helpext.cpp:273
 #, fuzzy, c-format
 msgid "Help file \"%s\" not found."
 msgstr "Ohjetiedostoa ”%s” ei löytynyt."
 
-#: ../src/html/helpctrl.cpp:63
+#: ../src/html/helpctrl.cpp:59
 #, c-format
 msgid "Help: %s"
 msgstr "Ohje: %s"
 
-#: ../src/osx/menu_osx.cpp:577
+#: ../src/osx/menu_osx.cpp:469
 #, fuzzy, c-format
 msgid "Hide %s"
 msgstr "Piilota"
 
-#: ../src/osx/menu_osx.cpp:579
+#: ../src/osx/menu_osx.cpp:471
 msgid "Hide Others"
 msgstr "Piilota muut"
 
-#: ../src/generic/infobar.cpp:84
+#: ../src/generic/infobar.cpp:81
 msgid "Hide this notification message."
 msgstr "Piilota tämä huomautus."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:884
+#: ../src/propgrid/advprops.cpp:785
 #, fuzzy
 msgid "Highlight"
 msgstr "heikko"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:885
+#: ../src/propgrid/advprops.cpp:786
 #, fuzzy
 msgid "HighlightText"
 msgstr "Tasaa teksti oikealle."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:164 ../src/common/accelcmn.cpp:65
+#: ../src/common/stockitem.cpp:161 ../src/common/accelcmn.cpp:62
 msgid "Home"
 msgstr "Koti"
 
-#: ../src/generic/dirctrlg.cpp:524
+#: ../src/generic/dirctrlg.cpp:490
 msgid "Home directory"
 msgstr "Kotihakemisto"
 
@@ -4141,61 +4248,61 @@ msgid "How the object will float relative to the text."
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1760
+#: ../src/propgrid/advprops.cpp:1661
 msgid "I-Beam"
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1196
+#: ../src/common/imagbmp.cpp:1208
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: Virhe DIB peitteen lukemisessa."
 
-#: ../src/common/imagbmp.cpp:1290 ../src/common/imagbmp.cpp:1390
-#: ../src/common/imagbmp.cpp:1405 ../src/common/imagbmp.cpp:1416
-#: ../src/common/imagbmp.cpp:1430 ../src/common/imagbmp.cpp:1478
-#: ../src/common/imagbmp.cpp:1493 ../src/common/imagbmp.cpp:1507
-#: ../src/common/imagbmp.cpp:1518
+#: ../src/common/imagbmp.cpp:1302 ../src/common/imagbmp.cpp:1402
+#: ../src/common/imagbmp.cpp:1417 ../src/common/imagbmp.cpp:1428
+#: ../src/common/imagbmp.cpp:1442 ../src/common/imagbmp.cpp:1490
+#: ../src/common/imagbmp.cpp:1505 ../src/common/imagbmp.cpp:1519
+#: ../src/common/imagbmp.cpp:1530
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: Virhe kuvatiedoston kirjoittamisessa."
 
-#: ../src/common/imagbmp.cpp:1255
+#: ../src/common/imagbmp.cpp:1267
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: Kuva liian suuri kuvakkeeksi."
 
-#: ../src/common/imagbmp.cpp:1263
+#: ../src/common/imagbmp.cpp:1275
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: Kuva liian leveä kuvakkeeksi."
 
-#: ../src/common/imagbmp.cpp:1603
+#: ../src/common/imagbmp.cpp:1615
 msgid "ICO: Invalid icon index."
 msgstr "ICO: Väärä kuvake-indeksi."
 
-#: ../src/common/imagiff.cpp:758
+#: ../src/common/imagiff.cpp:755
 msgid "IFF: data stream seems to be truncated."
 msgstr "IFF: datavirta on typistetty."
 
-#: ../src/common/imagiff.cpp:742
+#: ../src/common/imagiff.cpp:739
 msgid "IFF: error in IFF image format."
 msgstr "IFF: virhe IFF-kuvamuodossa."
 
-#: ../src/common/imagiff.cpp:745
+#: ../src/common/imagiff.cpp:742
 msgid "IFF: not enough memory."
 msgstr "IFF: ei riittävästi muistia."
 
-#: ../src/common/imagiff.cpp:748
+#: ../src/common/imagiff.cpp:745
 msgid "IFF: unknown error!!!"
 msgstr "IFF: tuntematon virhe!!!"
 
-#: ../src/common/fmapbase.cpp:197
+#: ../src/common/fmapbase.cpp:194
 msgid "ISO-2022-JP"
 msgstr "ISO-2022-JP"
 
-#: ../src/html/htmprint.cpp:282
+#: ../src/html/htmprint.cpp:294
 msgid ""
 "If possible, try changing the layout parameters to make the printout more "
 "narrow."
 msgstr ""
 
-#: ../src/generic/dbgrptg.cpp:358
+#: ../src/generic/dbgrptg.cpp:362
 msgid ""
 "If you have any additional information pertaining to this bug\n"
 "report, please enter it here and it will be joined to it:"
@@ -4209,46 +4316,50 @@ msgid ""
 "at all possible please do continue with the report generation.\n"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1405
+#: ../src/common/zipstrm.cpp:1043
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1393
 #, fuzzy, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Ohitetaan arvo ”%s” avaimessa ”%s”."
 
-#: ../src/common/xtistrm.cpp:295
+#: ../src/common/xtistrm.cpp:292
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr ""
 
-#: ../src/common/xti.cpp:513
+#: ../src/common/xti.cpp:510
 msgid "Illegal Parameter Count for ConstructObject Method"
 msgstr ""
 
-#: ../src/common/xti.cpp:501
+#: ../src/common/xti.cpp:498
 msgid "Illegal Parameter Count for Create Method"
 msgstr ""
 
-#: ../src/generic/dirctrlg.cpp:570 ../src/generic/filectrlg.cpp:756
+#: ../src/generic/dirctrlg.cpp:536 ../src/generic/filectrlg.cpp:752
 msgid "Illegal directory name."
 msgstr "Virheellinen hakemiston nimi."
 
-#: ../src/generic/filectrlg.cpp:1367
+#: ../src/generic/filectrlg.cpp:1356
 msgid "Illegal file specification."
 msgstr "Virheellinen tiedostomääritelmä."
 
-#: ../src/common/image.cpp:2269
+#: ../src/common/image.cpp:2363
 msgid "Image and mask have different sizes."
 msgstr "Kuvan ja peitteen koot ovat erisuuruiset."
 
-#: ../src/common/image.cpp:2746
+#: ../src/common/image.cpp:2841
 #, fuzzy, c-format
 msgid "Image file is not of type %d."
 msgstr "Kuvatiedoston tyyppi ei ole %ld."
 
-#: ../src/common/image.cpp:2877
+#: ../src/common/image.cpp:2995
 #, fuzzy, c-format
 msgid "Image is not of type %s."
 msgstr "Kuvatiedoston tyyppi ei ole %s."
 
-#: ../src/msw/textctrl.cpp:488
+#: ../src/msw/textctrl.cpp:534
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -4256,104 +4367,104 @@ msgstr ""
 "Rich Edit tekstimuokkaus on mahdotonta, käytetään tavanomaista "
 "tekstimuokkausta.Asenna riched32.dll uudestaan."
 
-#: ../src/unix/utilsunx.cpp:301
+#: ../src/unix/utilsunx.cpp:303
 msgid "Impossible to get child process input"
 msgstr "Lapsiprosessin syötteen saanti on mahdotonta"
 
-#: ../src/common/filefn.cpp:1028
+#: ../src/common/filefn.cpp:917
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Tiedoston ”%s” oikeuksien saanti on mahdotonta"
 
-#: ../src/common/filefn.cpp:1042
+#: ../src/common/filefn.cpp:931
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Tiedostoa ”%s” ei voida korvata"
 
-#: ../src/common/filefn.cpp:1097
+#: ../src/common/filefn.cpp:986
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Lupien asetus tiedostolle ”%s” on mahdotonta"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:886
+#: ../src/propgrid/advprops.cpp:787
 #, fuzzy
 msgid "InactiveBorder"
 msgstr "Moderni"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:887
+#: ../src/propgrid/advprops.cpp:788
 msgid "InactiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:888
+#: ../src/propgrid/advprops.cpp:789
 msgid "InactiveCaptionText"
 msgstr ""
 
-#: ../src/common/gifdecod.cpp:792
+#: ../src/common/gifdecod.cpp:826
 #, c-format
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "Virheellinen GIF-kehyksen koko (%u, %d) kehykselle #%u"
 
-#: ../src/msw/ole/automtn.cpp:635
+#: ../src/msw/ole/automtn.cpp:626
 msgid "Incorrect number of arguments."
 msgstr "Virheellinen argumenttien määrä."
 
-#: ../src/common/stockitem.cpp:165
+#: ../src/common/stockitem.cpp:162
 msgid "Indent"
 msgstr "Sisennys"
 
-#: ../src/richtext/richtextformatdlg.cpp:349
+#: ../src/richtext/richtextformatdlg.cpp:342
 msgid "Indents && Spacing"
 msgstr "Sisennys && välit"
 
-#: ../src/common/stockitem.cpp:166 ../src/html/helpwnd.cpp:515
+#: ../src/common/stockitem.cpp:163 ../src/html/helpwnd.cpp:513
 msgid "Index"
 msgstr "Sisältä"
 
-#: ../src/common/fmapbase.cpp:159
+#: ../src/common/fmapbase.cpp:156
 msgid "Indian (ISO-8859-12)"
 msgstr "intialainen (ISO-8859-12)"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "Info"
 msgstr "Tiedot"
 
-#: ../src/common/init.cpp:287
+#: ../src/common/init.cpp:284
 msgid "Initialization failed in post init, aborting."
 msgstr "Alustus epäonnistui jälkialustuksessa, keskeytetään."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:54
+#: ../src/common/accelcmn.cpp:51
 #, fuzzy
 msgid "Ins"
 msgstr "Lisää"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextsymboldlg.cpp:472 ../src/common/accelcmn.cpp:53
+#: ../src/common/accelcmn.cpp:50 ../src/richtext/richtextsymboldlg.cpp:469
 msgid "Insert"
 msgstr "Lisää"
 
-#: ../src/richtext/richtextbuffer.cpp:8067
+#: ../src/richtext/richtextbuffer.cpp:8063
 #, fuzzy
 msgid "Insert Field"
 msgstr "Lisää teksti"
 
-#: ../src/richtext/richtextbuffer.cpp:7978
-#: ../src/richtext/richtextbuffer.cpp:8936
+#: ../src/richtext/richtextbuffer.cpp:7974
+#: ../src/richtext/richtextbuffer.cpp:8934
 msgid "Insert Image"
 msgstr "Lisää kuva"
 
-#: ../src/richtext/richtextbuffer.cpp:8025
+#: ../src/richtext/richtextbuffer.cpp:8021
 #, fuzzy
 msgid "Insert Object"
 msgstr "Lisää teksti"
 
-#: ../src/richtext/richtextctrl.cpp:1286 ../src/richtext/richtextctrl.cpp:1494
-#: ../src/richtext/richtextbuffer.cpp:7822
-#: ../src/richtext/richtextbuffer.cpp:7852
-#: ../src/richtext/richtextbuffer.cpp:7894
+#: ../src/richtext/richtextbuffer.cpp:7818
+#: ../src/richtext/richtextbuffer.cpp:7848
+#: ../src/richtext/richtextbuffer.cpp:7890
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
 msgid "Insert Text"
 msgstr "Lisää teksti"
 
@@ -4368,16 +4479,11 @@ msgstr "Tyhjä tila ennen kappaletta."
 msgid "Inset"
 msgstr "Lisää"
 
-#: ../src/gtk/app.cpp:425
-#, fuzzy, c-format
-msgid "Invalid GTK+ command line option, use \"%s --help\""
-msgstr "Virheellinen GTK+-komentorivivalinta, kokeile ”%s --help”"
-
-#: ../src/common/imagtiff.cpp:311
+#: ../src/common/imagtiff.cpp:308
 msgid "Invalid TIFF image index."
 msgstr "Virheellinen TIFF-kuvaindeksi."
 
-#: ../src/common/appcmn.cpp:273
+#: ../src/common/appcmn.cpp:294
 #, c-format
 msgid "Invalid display mode specification '%s'."
 msgstr "Virheellinen näyttötilamääritelmä ”%s”."
@@ -4387,260 +4493,264 @@ msgstr "Virheellinen näyttötilamääritelmä ”%s”."
 msgid "Invalid geometry specification '%s'"
 msgstr "Virheellinen geometry-määritelmä ”%s”"
 
-#: ../src/unix/fswatcher_inotify.cpp:323
+#: ../src/unix/fswatcher_inotify.cpp:320
 #, c-format
 msgid "Invalid inotify event for \"%s\""
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:312
+#: ../src/unix/snglinst.cpp:309
 #, c-format
 msgid "Invalid lock file '%s'."
 msgstr "Virheellinen lukkotiedosto ”%s”."
 
-#: ../src/common/translation.cpp:1125
+#: ../src/common/translation.cpp:1167
 #, fuzzy
 msgid "Invalid message catalog."
 msgstr "”%s” ei ole kelvollinen viestiluettelo."
 
-#: ../src/common/xtistrm.cpp:405 ../src/common/xtistrm.cpp:420
+#: ../src/common/xtistrm.cpp:402 ../src/common/xtistrm.cpp:417
 msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
 msgstr ""
 "Virheellinen tai nollaobjektitunnus välitetty kohteelle GetObjectClassInfo"
 
-#: ../src/common/xtistrm.cpp:435
+#: ../src/common/xtistrm.cpp:432
 msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
 msgstr ""
 "Virheellinen tai nollaobjektitunnus välitetty kohteelle HasObjectClassInfo"
 
-#: ../src/common/regex.cpp:310
+#: ../src/common/regex.cpp:307
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Virheellinen säännösetellinen lauseke ”%s”: %s"
 
-#: ../src/common/config.cpp:226
+#: ../src/common/config.cpp:222
 #, c-format
 msgid "Invalid value %ld for a boolean key \"%s\" in config file."
 msgstr "Virheellinen arvo %ld totuusavaimelle \"%s\" asetustiedostossa."
 
-#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:351
-#: ../src/osx/carbon/fontdlg.cpp:361 ../src/common/stockitem.cpp:168
+#: ../src/osx/carbon/fontdlg.cpp:358 ../src/common/stockitem.cpp:165
+#: ../src/generic/fontdlgg.cpp:325 ../src/richtext/richtextfontpage.cpp:351
 msgid "Italic"
 msgstr "Kursivoitu"
 
-#: ../src/common/paper.cpp:130
+#: ../src/common/paper.cpp:127
 msgid "Italy Envelope, 110 x 230 mm"
 msgstr "Italialainen kirjekuori, 110 x 230 mm"
 
-#: ../src/common/imagjpeg.cpp:270
+#: ../src/common/imagjpeg.cpp:257
 msgid "JPEG: Couldn't load - file is probably corrupted."
 msgstr "JPEG-kuvan lataus ei onnistu - tiedosto ehkä korruptoitunut."
 
-#: ../src/common/imagjpeg.cpp:449
+#: ../src/common/imagjpeg.cpp:436
 msgid "JPEG: Couldn't save image."
 msgstr "JPEG: Ei voinut tallentaa kuvaa"
 
-#: ../src/common/paper.cpp:163
+#: ../src/common/paper.cpp:160
 msgid "Japanese Double Postcard 200 x 148 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:167
+#: ../src/common/paper.cpp:164
 msgid "Japanese Envelope Chou #3"
 msgstr ""
 
-#: ../src/common/paper.cpp:180
+#: ../src/common/paper.cpp:177
 msgid "Japanese Envelope Chou #3 Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:168
+#: ../src/common/paper.cpp:165
 msgid "Japanese Envelope Chou #4"
 msgstr ""
 
-#: ../src/common/paper.cpp:181
+#: ../src/common/paper.cpp:178
 msgid "Japanese Envelope Chou #4 Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:165
+#: ../src/common/paper.cpp:162
 msgid "Japanese Envelope Kaku #2"
 msgstr ""
 
-#: ../src/common/paper.cpp:178
+#: ../src/common/paper.cpp:175
 msgid "Japanese Envelope Kaku #2 Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:166
+#: ../src/common/paper.cpp:163
 msgid "Japanese Envelope Kaku #3"
 msgstr ""
 
-#: ../src/common/paper.cpp:179
+#: ../src/common/paper.cpp:176
 msgid "Japanese Envelope Kaku #3 Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:185
+#: ../src/common/paper.cpp:182
 msgid "Japanese Envelope You #4"
 msgstr ""
 
-#: ../src/common/paper.cpp:186
+#: ../src/common/paper.cpp:183
 msgid "Japanese Envelope You #4 Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:138
+#: ../src/common/paper.cpp:135
 msgid "Japanese Postcard 100 x 148 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:175
+#: ../src/common/paper.cpp:172
 msgid "Japanese Postcard Rotated 148 x 100 mm"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "Jump to"
 msgstr "Hyppää kohteeseen"
 
-#: ../src/common/stockitem.cpp:171
+#: ../src/common/stockitem.cpp:168
 msgid "Justified"
 msgstr "Tasattu"
 
-#: ../src/richtext/richtextindentspage.cpp:155
-#: ../src/richtext/richtextindentspage.cpp:157
 #: ../src/richtext/richtextliststylepage.cpp:344
 #: ../src/richtext/richtextliststylepage.cpp:346
+#: ../src/richtext/richtextindentspage.cpp:155
+#: ../src/richtext/richtextindentspage.cpp:157
 msgid "Justify text left and right."
 msgstr "Tasaa teksti vasemmalle ja oikealle."
 
-#: ../src/common/fmapbase.cpp:163
+#: ../src/common/fmapbase.cpp:160
 msgid "KOI8-R"
 msgstr "KOI8-R"
 
-#: ../src/common/fmapbase.cpp:164
+#: ../src/common/fmapbase.cpp:161
 msgid "KOI8-U"
 msgstr "KOI8-U"
 
-#: ../src/common/accelcmn.cpp:265 ../src/common/accelcmn.cpp:347
+#: ../src/common/accelcmn.cpp:279 ../src/common/accelcmn.cpp:364
 msgid "KP_"
 msgstr "KP_"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 #, fuzzy
 msgid "KP_Add"
 msgstr "KP_LISÄÄ"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "KP_Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "KP_Decimal"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 #, fuzzy
 msgid "KP_Delete"
 msgstr "Poista"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "KP_Divide"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 #, fuzzy
 msgid "KP_Down"
 msgstr "Alas"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 #, fuzzy
 msgid "KP_End"
 msgstr "KP_END"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 #, fuzzy
 msgid "KP_Enter"
 msgstr "Tulostin"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "KP_Equal"
 msgstr ""
 
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
-#, fuzzy
-msgid "KP_Home"
-msgstr "Koti"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
-#, fuzzy
-msgid "KP_Insert"
-msgstr "Lisää"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
-#, fuzzy
-msgid "KP_Left"
-msgstr "Vasen"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
-msgid "KP_Multiply"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:99
-#, fuzzy
-msgid "KP_Next"
-msgstr "Seuraava"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
-msgid "KP_PageDown"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
-msgid "KP_PageUp"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:98
-msgid "KP_Prior"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
-#, fuzzy
-msgid "KP_Right"
-msgstr "Oikealle"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
-msgid "KP_Separator"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
-msgid "KP_Space"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
-msgid "KP_Subtract"
+#: ../src/common/accelcmn.cpp:276 ../src/common/accelcmn.cpp:361
+msgid "KP_F"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
 #: ../src/common/accelcmn.cpp:89
 #, fuzzy
+msgid "KP_Home"
+msgstr "Koti"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:100
+#, fuzzy
+msgid "KP_Insert"
+msgstr "Lisää"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:90
+#, fuzzy
+msgid "KP_Left"
+msgstr "Vasen"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:103
+msgid "KP_Multiply"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:97
+#, fuzzy
+msgid "KP_Next"
+msgstr "Seuraava"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:95
+msgid "KP_PageDown"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:94
+msgid "KP_PageUp"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:96
+msgid "KP_Prior"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:92
+#, fuzzy
+msgid "KP_Right"
+msgstr "Oikealle"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:105
+msgid "KP_Separator"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:86
+msgid "KP_Space"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:106
+msgid "KP_Subtract"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:87
+#, fuzzy
 msgid "KP_Tab"
 msgstr "KP_SARKAIN"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 #, fuzzy
 msgid "KP_Up"
 msgstr "KP_YLÖS"
@@ -4649,123 +4759,138 @@ msgstr "KP_YLÖS"
 msgid "L&ine spacing:"
 msgstr "&Riviväli:"
 
-#: ../src/generic/prntdlgg.cpp:613 ../src/generic/prntdlgg.cpp:868
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "pakkausvirhe"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "purkamisvirhe"
+
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:861
 msgid "Landscape"
 msgstr "Vaakasuunta"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 #, fuzzy
 msgid "Last"
 msgstr "Liitä"
 
-#: ../src/common/prntbase.cpp:1572
+#: ../src/common/prntbase.cpp:1597
 #, fuzzy
 msgid "Last page"
 msgstr "Seuraava sivu"
 
-#: ../src/common/log.cpp:305
+#: ../src/common/log.cpp:324
 #, c-format
 msgid "Last repeated message (\"%s\", %u time) wasn't output"
 msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/common/paper.cpp:103
+#: ../src/common/paper.cpp:100
 #, fuzzy
 msgid "Ledger, 17 x 11 in"
 msgstr "Ledger, 17 x 11” "
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6146
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:58 ../src/generic/datavgen.cpp:6951
+#: ../src/richtext/richtextsizepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:252
 #: ../src/richtext/richtextliststylepage.cpp:253
 #: ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
-#: ../src/richtext/richtextsizepage.cpp:249 ../src/common/accelcmn.cpp:61
 msgid "Left"
 msgstr "Vasen"
 
-#: ../src/richtext/richtextindentspage.cpp:204
 #: ../src/richtext/richtextliststylepage.cpp:390
+#: ../src/richtext/richtextindentspage.cpp:204
 msgid "Left (&first line):"
 msgstr "Vasen (&ensimmäinen rivi):"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1761
+#: ../src/propgrid/advprops.cpp:1662
 msgid "Left Button"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:880
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Left margin (mm):"
 msgstr "Vasen marginaali (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:141
-#: ../src/richtext/richtextindentspage.cpp:143
 #: ../src/richtext/richtextliststylepage.cpp:330
 #: ../src/richtext/richtextliststylepage.cpp:332
+#: ../src/richtext/richtextindentspage.cpp:141
+#: ../src/richtext/richtextindentspage.cpp:143
 msgid "Left-align text."
 msgstr "Vasemmalle tasattu teksti:"
 
-#: ../src/common/paper.cpp:144
+#: ../src/common/paper.cpp:141
 #, fuzzy
 msgid "Legal Extra 9 1/2 x 15 in"
 msgstr "Legal 8 1/2 x 14” "
 
-#: ../src/common/paper.cpp:96
+#: ../src/common/paper.cpp:93
 #, fuzzy
 msgid "Legal, 8 1/2 x 14 in"
 msgstr "Legal 8 1/2 x 14” "
 
-#: ../src/common/paper.cpp:143
+#: ../src/common/paper.cpp:140
 #, fuzzy
 msgid "Letter Extra 9 1/2 x 12 in"
 msgstr "Letter 8 1/2 x 11” "
 
-#: ../src/common/paper.cpp:149
+#: ../src/common/paper.cpp:146
 msgid "Letter Extra Transverse 9.275 x 12 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:152
+#: ../src/common/paper.cpp:149
 #, fuzzy
 msgid "Letter Plus 8 1/2 x 12.69 in"
 msgstr "Letter 8 1/2 x 11” "
 
-#: ../src/common/paper.cpp:169
+#: ../src/common/paper.cpp:166
 #, fuzzy
 msgid "Letter Rotated 11 x 8 1/2 in"
 msgstr "Letter 8 1/2 x 11” "
 
-#: ../src/common/paper.cpp:101
+#: ../src/common/paper.cpp:98
 #, fuzzy
 msgid "Letter Small, 8 1/2 x 11 in"
 msgstr "Letter (pieni) 8 1/2 x 11” "
 
-#: ../src/common/paper.cpp:147
+#: ../src/common/paper.cpp:144
 #, fuzzy
 msgid "Letter Transverse 8 1/2 x 11 in"
 msgstr "Letter 8 1/2 x 11” "
 
-#: ../src/common/paper.cpp:95
+#: ../src/common/paper.cpp:92
 #, fuzzy
 msgid "Letter, 8 1/2 x 11 in"
 msgstr "Letter 8 1/2 x 11” "
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "License"
 msgstr "Lisenssi"
 
-#: ../src/generic/fontdlgg.cpp:332
+#: ../src/generic/fontdlgg.cpp:328
 msgid "Light"
 msgstr "Kevyt"
 
-#: ../src/propgrid/advprops.cpp:1608
+#: ../src/propgrid/advprops.cpp:1514
 msgid "Lime"
 msgstr ""
 
-#: ../src/generic/helpext.cpp:294
+#: ../src/generic/helpext.cpp:292
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr ""
@@ -4775,15 +4900,15 @@ msgstr ""
 msgid "Line spacing:"
 msgstr "Riviväli:"
 
-#: ../src/html/chm.cpp:838
+#: ../src/html/chm.cpp:829
 msgid "Link contained '//', converted to absolute link."
 msgstr "'//'-määrityksen sisältävä linkki muunnettu absoluuttiseksi."
 
-#: ../src/richtext/richtextformatdlg.cpp:364
+#: ../src/richtext/richtextformatdlg.cpp:357
 msgid "List Style"
 msgstr "Luettelotyyli"
 
-#: ../src/richtext/richtextstyles.cpp:1064
+#: ../src/richtext/richtextstyles.cpp:1061
 msgid "List styles"
 msgstr "Luettelotyylit"
 
@@ -4797,26 +4922,26 @@ msgstr "Luetteloi kirjasinkoot pisteinä."
 msgid "Lists the available fonts."
 msgstr "Luetteloi käytettävissä olevat kirjasimet."
 
-#: ../src/common/fldlgcmn.cpp:340
+#: ../src/common/fldlgcmn.cpp:337
 #, c-format
 msgid "Load %s file"
 msgstr "Lataa %s tiedosto"
 
-#: ../src/html/htmlwin.cpp:597
+#: ../src/html/htmlwin.cpp:600
 msgid "Loading : "
 msgstr "Ladataan : "
 
-#: ../src/unix/snglinst.cpp:246
+#: ../src/unix/snglinst.cpp:243
 #, c-format
 msgid "Lock file '%s' has incorrect owner."
 msgstr "Lukkotiedostolla ”%s” on virheellinen omista."
 
-#: ../src/unix/snglinst.cpp:251
+#: ../src/unix/snglinst.cpp:248
 #, c-format
 msgid "Lock file '%s' has incorrect permissions."
 msgstr "Lukkotiedostolla ”%s” on virheelliset oikeudet."
 
-#: ../src/generic/logg.cpp:576
+#: ../src/generic/logg.cpp:573
 #, c-format
 msgid "Log saved to the file '%s'."
 msgstr "Loki tallennettu tiedostoon ”%s”."
@@ -4831,11 +4956,11 @@ msgstr "Pienoisaakkoskirjaimet"
 msgid "Lower case roman numerals"
 msgstr "Pienoisaakkos romaaniset numeraalit"
 
-#: ../src/gtk/mdi.cpp:422 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk1/mdi.cpp:431 ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "MDI lapsi"
 
-#: ../src/msw/helpchm.cpp:56
+#: ../src/msw/helpchm.cpp:53
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -4843,196 +4968,196 @@ msgstr ""
 "MS HTML Ohjetoiminnot eivät ole saatavilla koska MS HTML Help kirjastoa ei "
 "ole asennettu tälle koneelle. Ole hyvä ja asenna se."
 
-#: ../src/univ/themes/win32.cpp:3754
+#: ../src/univ/themes/win32.cpp:3751
 msgid "Ma&ximize"
 msgstr "S&uurenna"
 
-#: ../src/common/fmapbase.cpp:203
+#: ../src/common/fmapbase.cpp:200
 #, fuzzy
 msgid "MacArabic"
 msgstr "Arabialainen"
 
-#: ../src/common/fmapbase.cpp:222
+#: ../src/common/fmapbase.cpp:219
 msgid "MacArmenian"
 msgstr "Mac (armenialainen)"
 
-#: ../src/common/fmapbase.cpp:211
+#: ../src/common/fmapbase.cpp:208
 msgid "MacBengali"
 msgstr "Mac (bengalilainen)"
 
-#: ../src/common/fmapbase.cpp:217
+#: ../src/common/fmapbase.cpp:214
 msgid "MacBurmese"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:236
+#: ../src/common/fmapbase.cpp:233
 msgid "MacCeltic"
 msgstr "Mac (kelttiläinen)"
 
-#: ../src/common/fmapbase.cpp:227
+#: ../src/common/fmapbase.cpp:224
 msgid "MacCentralEurRoman"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:223
+#: ../src/common/fmapbase.cpp:220
 msgid "MacChineseSimp"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:201
+#: ../src/common/fmapbase.cpp:198
 msgid "MacChineseTrad"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:233
+#: ../src/common/fmapbase.cpp:230
 msgid "MacCroatian"
 msgstr "Mac (kroatialainen)"
 
-#: ../src/common/fmapbase.cpp:206
+#: ../src/common/fmapbase.cpp:203
 msgid "MacCyrillic"
 msgstr "Mac (kyrillinen)"
 
-#: ../src/common/fmapbase.cpp:207
+#: ../src/common/fmapbase.cpp:204
 msgid "MacDevanagari"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:231
+#: ../src/common/fmapbase.cpp:228
 msgid "MacDingbats"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:226
+#: ../src/common/fmapbase.cpp:223
 msgid "MacEthiopic"
 msgstr "Mac (etiopialainen)"
 
-#: ../src/common/fmapbase.cpp:229
+#: ../src/common/fmapbase.cpp:226
 #, fuzzy
 msgid "MacExtArabic"
 msgstr "Arabialainen"
 
-#: ../src/common/fmapbase.cpp:237
+#: ../src/common/fmapbase.cpp:234
 msgid "MacGaelic"
 msgstr "MacGaelic"
 
-#: ../src/common/fmapbase.cpp:221
+#: ../src/common/fmapbase.cpp:218
 msgid "MacGeorgian"
 msgstr "Mac (georgialainen)"
 
-#: ../src/common/fmapbase.cpp:205
+#: ../src/common/fmapbase.cpp:202
 msgid "MacGreek"
 msgstr "Mac (kreikkalainen)"
 
-#: ../src/common/fmapbase.cpp:209
+#: ../src/common/fmapbase.cpp:206
 msgid "MacGujarati"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:208
+#: ../src/common/fmapbase.cpp:205
 msgid "MacGurmukhi"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:204
+#: ../src/common/fmapbase.cpp:201
 msgid "MacHebrew"
 msgstr "Mac (heprealainen)"
 
-#: ../src/common/fmapbase.cpp:234
+#: ../src/common/fmapbase.cpp:231
 msgid "MacIcelandic"
 msgstr "Mac (islantilainen)"
 
-#: ../src/common/fmapbase.cpp:200
+#: ../src/common/fmapbase.cpp:197
 msgid "MacJapanese"
 msgstr "Mac (japanilainen)"
 
-#: ../src/common/fmapbase.cpp:214
+#: ../src/common/fmapbase.cpp:211
 msgid "MacKannada"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:238
+#: ../src/common/fmapbase.cpp:235
 msgid "MacKeyboardGlyphs"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:218
+#: ../src/common/fmapbase.cpp:215
 msgid "MacKhmer"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:202
+#: ../src/common/fmapbase.cpp:199
 msgid "MacKorean"
 msgstr "Mac (korealainen)"
 
-#: ../src/common/fmapbase.cpp:220
+#: ../src/common/fmapbase.cpp:217
 msgid "MacLaotian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:215
+#: ../src/common/fmapbase.cpp:212
 msgid "MacMalayalam"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:225
+#: ../src/common/fmapbase.cpp:222
 msgid "MacMongolian"
 msgstr "Mac (mongolialainen)"
 
-#: ../src/common/fmapbase.cpp:210
+#: ../src/common/fmapbase.cpp:207
 msgid "MacOriya"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:199
+#: ../src/common/fmapbase.cpp:196
 #, fuzzy
 msgid "MacRoman"
 msgstr "Roman"
 
-#: ../src/common/fmapbase.cpp:235
+#: ../src/common/fmapbase.cpp:232
 #, fuzzy
 msgid "MacRomanian"
 msgstr "Roman"
 
-#: ../src/common/fmapbase.cpp:216
+#: ../src/common/fmapbase.cpp:213
 #, fuzzy
 msgid "MacSinhalese"
 msgstr "Sama kirjainkoko"
 
-#: ../src/common/fmapbase.cpp:230
+#: ../src/common/fmapbase.cpp:227
 #, fuzzy
 msgid "MacSymbol"
 msgstr "Symboli"
 
-#: ../src/common/fmapbase.cpp:212
+#: ../src/common/fmapbase.cpp:209
 msgid "MacTamil"
 msgstr "Mac (tamililainen)"
 
-#: ../src/common/fmapbase.cpp:213
+#: ../src/common/fmapbase.cpp:210
 msgid "MacTelugu"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:219
+#: ../src/common/fmapbase.cpp:216
 msgid "MacThai"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:224
+#: ../src/common/fmapbase.cpp:221
 msgid "MacTibetan"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:232
+#: ../src/common/fmapbase.cpp:229
 msgid "MacTurkish"
 msgstr "Mac (turkkilainen)"
 
-#: ../src/common/fmapbase.cpp:228
+#: ../src/common/fmapbase.cpp:225
 msgid "MacVietnamese"
 msgstr "Mac (vietnamilainen)"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1762
+#: ../src/propgrid/advprops.cpp:1663
 msgid "Magnifier"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:2143
+#: ../src/propgrid/advprops.cpp:2050
 #, fuzzy
 msgid "Make a selection:"
 msgstr "Liitä valinta"
 
-#: ../src/richtext/richtextformatdlg.cpp:374
+#: ../src/richtext/richtextformatdlg.cpp:367
 #: ../src/richtext/richtextmarginspage.cpp:171
 msgid "Margins"
 msgstr "Marginaalit"
 
-#: ../src/propgrid/advprops.cpp:1595
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Maroon"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:147
+#: ../src/generic/fdrepdlg.cpp:144
 msgid "Match case"
 msgstr "Sama kirjainkoko"
 
@@ -5045,41 +5170,41 @@ msgstr "&Korkeus:"
 msgid "Max width:"
 msgstr ""
 
-#: ../src/unix/mediactrl.cpp:947
+#: ../src/unix/mediactrl.cpp:972
 #, c-format
 msgid "Media playback error: %s"
 msgstr ""
 
-#: ../src/common/fs_mem.cpp:175
+#: ../src/common/fs_mem.cpp:170
 #, c-format
 msgid "Memory VFS already contains file '%s'!"
 msgstr "Muisti-VFS sisältää jo tiedoston ”%s”!"
 
 #. TRANSLATORS: Name of keyboard key
 #. TRANSLATORS: Keyword of system colour
-#: ../src/common/accelcmn.cpp:73 ../src/propgrid/advprops.cpp:889
+#: ../src/common/accelcmn.cpp:70 ../src/propgrid/advprops.cpp:790
 msgid "Menu"
 msgstr "Valikko"
 
-#: ../src/common/msgout.cpp:124
+#: ../src/common/msgout.cpp:121
 #, fuzzy
 msgid "Message"
 msgstr "%s-viesti"
 
-#: ../src/univ/themes/metal.cpp:168
+#: ../src/univ/themes/metal.cpp:165
 msgid "Metal theme"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:652
+#: ../src/msw/ole/automtn.cpp:643
 msgid "Method or property not found."
 msgstr ""
 
-#: ../src/univ/themes/win32.cpp:3752
+#: ../src/univ/themes/win32.cpp:3749
 msgid "Mi&nimize"
 msgstr "P&ienennä"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1763
+#: ../src/propgrid/advprops.cpp:1664
 msgid "Middle Button"
 msgstr ""
 
@@ -5092,37 +5217,42 @@ msgstr "Kirjasimen &paino:"
 msgid "Min width:"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:668
+#: ../src/osx/cocoa/menu.mm:281
+#, fuzzy
+msgid "Minimize"
+msgstr "P&ienennä"
+
+#: ../src/msw/ole/automtn.cpp:659
 msgid "Missing a required parameter."
 msgstr "Pakollinen parametri puuttuu."
 
-#: ../src/generic/fontdlgg.cpp:324
+#: ../src/generic/fontdlgg.cpp:320
 msgid "Modern"
 msgstr "Moderni"
 
-#: ../src/generic/filectrlg.cpp:427
+#: ../src/generic/filectrlg.cpp:423
 msgid "Modified"
 msgstr "Muokattu"
 
-#: ../src/common/module.cpp:133
+#: ../src/common/module.cpp:130
 #, fuzzy, c-format
 msgid "Module \"%s\" initialization failed"
 msgstr "Moduulin ”%s” alustus epäonnistui"
 
-#: ../src/common/paper.cpp:131
+#: ../src/common/paper.cpp:128
 #, fuzzy
 msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
 msgstr "Monarch Envelope, 3 7/8 x 7 1/2” "
 
-#: ../src/msw/fswatcher.cpp:143
+#: ../src/msw/fswatcher.cpp:140
 msgid "Monitoring individual files for changes is not supported currently."
 msgstr "Yksittäisten tiedostojen muutosten tarkkailua ei tueta tällä hetkellä."
 
-#: ../src/generic/editlbox.cpp:172
+#: ../src/generic/editlbox.cpp:160
 msgid "Move down"
 msgstr "Siirrä alas"
 
-#: ../src/generic/editlbox.cpp:171
+#: ../src/generic/editlbox.cpp:155
 msgid "Move up"
 msgstr "Siirrä ylös"
 
@@ -5136,100 +5266,105 @@ msgstr "Siirtää objektin seuraavaan kappaleeseen."
 msgid "Moves the object to the previous paragraph."
 msgstr "Siirtää objektin edelliseen kappaleeseen."
 
-#: ../src/richtext/richtextbuffer.cpp:9966
+#: ../src/richtext/richtextbuffer.cpp:9963
 msgid "Multiple Cell Properties"
 msgstr "Usean solun ominaisuudet"
 
-#: ../src/generic/filectrlg.cpp:424
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:82
+msgid "Multiply"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:420
 msgid "Name"
 msgstr "Nimi"
 
-#: ../src/propgrid/advprops.cpp:1596
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Navy"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "Network"
 msgstr "Verkko"
 
-#: ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173
 #, fuzzy
 msgid "New"
 msgstr "&Uusi"
 
-#: ../src/richtext/richtextstyledlg.cpp:243
+#: ../src/richtext/richtextstyledlg.cpp:239
 #, fuzzy
 msgid "New &Box Style..."
 msgstr "Uusi &luettelotyyli"
 
-#: ../src/richtext/richtextstyledlg.cpp:225
+#: ../src/richtext/richtextstyledlg.cpp:221
 msgid "New &Character Style..."
 msgstr "Uusi &merkkityyli..."
 
-#: ../src/richtext/richtextstyledlg.cpp:237
+#: ../src/richtext/richtextstyledlg.cpp:233
 msgid "New &List Style..."
 msgstr "Uusi &luettelotyyli"
 
-#: ../src/richtext/richtextstyledlg.cpp:231
+#: ../src/richtext/richtextstyledlg.cpp:227
 msgid "New &Paragraph Style..."
 msgstr "Uusi &kappaletyyli..."
 
-#: ../src/richtext/richtextstyledlg.cpp:606
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:654
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:820
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:893
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:934
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:602
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:650
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:816
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:889
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:930
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "New Style"
 msgstr "Uusi tyyli"
 
-#: ../src/generic/editlbox.cpp:169
+#: ../src/generic/editlbox.cpp:139
 #, fuzzy
 msgid "New item"
 msgstr "Uusi kohta"
 
-#: ../src/generic/dirdlgg.cpp:297 ../src/generic/dirdlgg.cpp:307
-#: ../src/generic/filectrlg.cpp:618 ../src/generic/filectrlg.cpp:627
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+#: ../src/generic/dirdlgg.cpp:294 ../src/generic/dirdlgg.cpp:304
 msgid "NewName"
 msgstr "UusiNimi"
 
-#: ../src/common/prntbase.cpp:1567 ../src/html/helpwnd.cpp:665
+#: ../src/common/prntbase.cpp:1592 ../src/html/helpwnd.cpp:663
 msgid "Next page"
 msgstr "Seuraava sivu"
 
-#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:177
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:174
 #: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Ei"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1764
+#: ../src/propgrid/advprops.cpp:1665
 msgid "No Entry"
 msgstr ""
 
-#: ../src/generic/animateg.cpp:150
+#: ../src/generic/animateg.cpp:133
 #, fuzzy, c-format
 msgid "No animation handler for type %ld defined."
 msgstr "Kuvatyypin %d käsittelijää ei määritelty."
 
-#: ../src/dfb/bitmap.cpp:642 ../src/dfb/bitmap.cpp:676
+#: ../src/dfb/bitmap.cpp:639 ../src/dfb/bitmap.cpp:673
 #, fuzzy, c-format
 msgid "No bitmap handler for type %d defined."
 msgstr "Kuvatyypin %d käsittelijää ei määritelty."
 
-#: ../src/common/utilscmn.cpp:1077
+#: ../src/common/utilscmn.cpp:1095
 msgid "No default application configured for HTML files."
 msgstr "Oletusohjelmaa HTML-tiedostojen hallintaan ei ole asetettu."
 
-#: ../src/generic/helpext.cpp:445
+#: ../src/generic/helpext.cpp:443
 msgid "No entries found."
 msgstr "Kohtia ei löytynyt."
 
-#: ../src/common/fontmap.cpp:421
+#: ../src/common/fontmap.cpp:418
 #, fuzzy, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found,\n"
@@ -5241,7 +5376,7 @@ msgstr ""
 "koodaus ”%s” on saatavilla.\n"
 "Haluatko käyttää tätä koodausta (muutoin joudut valitsemaan toisen)?"
 
-#: ../src/common/fontmap.cpp:426
+#: ../src/common/fontmap.cpp:423
 #, fuzzy, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found.\n"
@@ -5252,210 +5387,209 @@ msgstr ""
 "Haluatko valita kirjasintyypin, jota käytetään tähän?\n"
 "(Muutoin tällä koodauksella olevaa teksiä ei näytetä oikein)"
 
-#: ../src/generic/animateg.cpp:142
+#: ../src/generic/animateg.cpp:125
 #, fuzzy
 msgid "No handler found for animation type."
 msgstr "Kuvatyypin käsittelijää ei löytynyt."
 
-#: ../src/common/image.cpp:2728
+#: ../src/common/image.cpp:2823
 msgid "No handler found for image type."
 msgstr "Kuvatyypin käsittelijää ei löytynyt."
 
-#: ../src/common/image.cpp:2736 ../src/common/image.cpp:2848
-#: ../src/common/image.cpp:2901
+#: ../src/common/image.cpp:2831 ../src/common/image.cpp:2954
+#: ../src/common/image.cpp:3020
 #, fuzzy, c-format
 msgid "No image handler for type %d defined."
 msgstr "Kuvatyypin %d käsittelijää ei määritelty."
 
-#: ../src/common/image.cpp:2871 ../src/common/image.cpp:2915
+#: ../src/common/image.cpp:2986 ../src/common/image.cpp:3034
 #, fuzzy, c-format
 msgid "No image handler for type %s defined."
 msgstr "Kuvatyypin %s käsittelyohjelmaa ei määritelty."
 
-#: ../src/html/helpwnd.cpp:858
+#: ../src/html/helpwnd.cpp:856
 msgid "No matching page found yet"
 msgstr "Täsmääviä sivuja ei vielä löydetty"
 
-#: ../src/unix/sound.cpp:81
+#: ../src/unix/sound.cpp:78
 msgid "No sound"
 msgstr "Ei ääntä"
 
-#: ../src/common/image.cpp:2277 ../src/common/image.cpp:2318
+#: ../src/common/image.cpp:2371 ../src/common/image.cpp:2412
 msgid "No unused colour in image being masked."
 msgstr ""
 
-#: ../src/common/image.cpp:3374
-msgid "No unused colour in image."
-msgstr "Ei käyttämättömiä värejä kuvassa"
-
-#: ../src/generic/helpext.cpp:302
+#: ../src/generic/helpext.cpp:300
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr ""
 
-#: ../src/richtext/richtextborderspage.cpp:610
 #: ../src/richtext/richtextsizepage.cpp:248
 #: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:610
 #, fuzzy
 msgid "None"
 msgstr "(Ei mitään)"
 
-#: ../src/common/fmapbase.cpp:157
+#: ../src/common/fmapbase.cpp:154
 msgid "Nordic (ISO-8859-10)"
 msgstr "pohjoismainen (ISO-8859-10)"
 
-#: ../src/generic/fontdlgg.cpp:328 ../src/generic/fontdlgg.cpp:331
+#: ../src/generic/fontdlgg.cpp:324 ../src/generic/fontdlgg.cpp:327
 msgid "Normal"
 msgstr "Tavallinen"
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1261
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Normaali kirjasin<br>ja <u>alleviivattu</u>. "
 
-#: ../src/html/helpwnd.cpp:1205
+#: ../src/html/helpwnd.cpp:1203
 msgid "Normal font:"
 msgstr "Tavallinen fontti:"
 
-#: ../src/propgrid/props.cpp:1128
+#: ../src/propgrid/props.cpp:1115
 #, fuzzy, c-format
 msgid "Not %s"
 msgstr "Tietoja %s"
 
-#: ../include/wx/filename.h:573 ../include/wx/filename.h:578
-#, fuzzy
-msgid "Not available"
-msgstr "Valitettavasti vihjeitä ei ole!"
+#: ../src/common/secretstore.cpp:168
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/webrequest.cpp:605
+msgid "Not enough free disk space for download."
+msgstr ""
 
 #: ../src/richtext/richtextfontpage.cpp:358
 msgid "Not underlined"
 msgstr "Ei alleviivattu"
 
-#: ../src/common/paper.cpp:115
+#: ../src/common/paper.cpp:112
 #, fuzzy
 msgid "Note, 8 1/2 x 11 in"
 msgstr "Note, 8 1/2 x 11” "
 
-#: ../src/generic/notifmsgg.cpp:132
+#: ../src/generic/notifmsgg.cpp:129
 msgid "Notice"
 msgstr "Huomio"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "Num *"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "Num +"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "Num ,"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "Num -"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "Num ."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "Num /"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "Num ="
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "Num Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 #, fuzzy
 msgid "Num Delete"
 msgstr "Poista"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 #, fuzzy
 msgid "Num Down"
 msgstr "Alas"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "Num End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "Num Enter"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 #, fuzzy
 msgid "Num Home"
 msgstr "Koti"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 #, fuzzy
 msgid "Num Insert"
 msgstr "Lisää"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num Lock"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "Num Page Down"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "Num Page Up"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 #, fuzzy
 msgid "Num Right"
 msgstr "Oikealle"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "Num Space"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "Num Tab"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "Num Up"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "Num left"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num_lock"
 msgstr ""
 
@@ -5464,13 +5598,13 @@ msgstr ""
 msgid "Numbered outline"
 msgstr "Numeroitu jäsennys"
 
-#: ../include/wx/msgdlg.h:278 ../src/richtext/richtextstyledlg.cpp:297
-#: ../src/common/stockitem.cpp:178 ../src/msw/msgdlg.cpp:454
-#: ../src/msw/msgdlg.cpp:747 ../src/gtk1/fontdlg.cpp:138
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:175
+#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/msgdlg.cpp:741 ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "OK"
 
-#: ../src/msw/ole/automtn.cpp:692
+#: ../src/msw/ole/automtn.cpp:683
 #, c-format
 msgid "OLE Automation error in %s: %s"
 msgstr "OLE-automaatiovirhe kohteessa %s: %s"
@@ -5480,15 +5614,15 @@ msgstr "OLE-automaatiovirhe kohteessa %s: %s"
 msgid "Object Properties"
 msgstr "&Ominaisuudet"
 
-#: ../src/msw/ole/automtn.cpp:660
+#: ../src/msw/ole/automtn.cpp:651
 msgid "Object implementation does not support named arguments."
 msgstr "Objektin toteutus ei tue nimettyjä argumentteja."
 
-#: ../src/common/xtixml.cpp:264
+#: ../src/common/xtixml.cpp:260
 msgid "Objects must have an id attribute"
 msgstr "Objekteilla täytyy olla id-määre"
 
-#: ../src/propgrid/advprops.cpp:1601
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Olive"
 msgstr ""
 
@@ -5496,65 +5630,70 @@ msgstr ""
 msgid "Opaci&ty:"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:354
+#: ../src/generic/colrdlgg.cpp:374
 msgid "Opacity:"
 msgstr ""
 
-#: ../src/common/docview.cpp:1773 ../src/common/docview.cpp:1815
+#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
 msgid "Open File"
 msgstr "Valitse Tiedosto"
 
-#: ../src/html/helpwnd.cpp:671 ../src/html/helpwnd.cpp:1554
+#: ../src/html/helpwnd.cpp:669 ../src/html/helpwnd.cpp:1552
 msgid "Open HTML document"
 msgstr "Avaa HTML-asiakirja"
 
-#: ../src/generic/dbgrptg.cpp:163
+#: ../src/common/stockitem.cpp:265
+#, fuzzy
+msgid "Open an existing document"
+msgstr "Avaa HTML-asiakirja"
+
+#: ../src/generic/dbgrptg.cpp:160
 #, fuzzy, c-format
 msgid "Open file \"%s\""
 msgstr "Avaa tiedosto ”%s”"
 
-#: ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176
 #, fuzzy
 msgid "Open..."
 msgstr "&Avaa..."
 
-#: ../src/unix/glx11.cpp:506 ../src/msw/glcanvas.cpp:592
+#: ../src/msw/glcanvas.cpp:607 ../src/unix/glx11.cpp:513
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr ""
 
-#: ../src/generic/dirctrlg.cpp:599 ../src/generic/dirdlgg.cpp:323
-#: ../src/generic/filectrlg.cpp:642 ../src/generic/filectrlg.cpp:786
+#: ../src/generic/dirctrlg.cpp:565 ../src/generic/filectrlg.cpp:638
+#: ../src/generic/filectrlg.cpp:782 ../src/generic/dirdlgg.cpp:320
 msgid "Operation not permitted."
 msgstr "Ei sallittu toimenpide."
 
-#: ../src/common/cmdline.cpp:900
+#: ../src/common/cmdline.cpp:896
 #, fuzzy, c-format
 msgid "Option '%s' can't be negated"
 msgstr "Hakemistoa ”%s” ei voitu luoda"
 
-#: ../src/common/cmdline.cpp:1064
+#: ../src/common/cmdline.cpp:1060
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "Valinta ”%s” vaatii arvon."
 
-#: ../src/common/cmdline.cpp:1147
+#: ../src/common/cmdline.cpp:1143
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Valinta ”%s”: ”%s” ei voida muuntua päiväykseksi."
 
-#: ../src/generic/prntdlgg.cpp:618
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Valinnat"
 
-#: ../src/propgrid/advprops.cpp:1606
+#: ../src/propgrid/advprops.cpp:1512
 msgid "Orange"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:615 ../src/generic/prntdlgg.cpp:869
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:862
 msgid "Orientation"
 msgstr "Suunta"
 
-#: ../src/common/windowid.cpp:242
+#: ../src/common/windowid.cpp:237
 msgid "Out of window IDs.  Recommend shutting down application."
 msgstr ""
 
@@ -5567,148 +5706,148 @@ msgstr "Jäsennys"
 msgid "Outset"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:656
+#: ../src/msw/ole/automtn.cpp:647
 msgid "Overflow while coercing argument values."
 msgstr ""
 
-#: ../src/common/imagpcx.cpp:457 ../src/common/imagpcx.cpp:480
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:479
 msgid "PCX: couldn't allocate memory"
 msgstr "PCX: muistia ei voitu varata"
 
-#: ../src/common/imagpcx.cpp:456
+#: ../src/common/imagpcx.cpp:455
 msgid "PCX: image format unsupported"
 msgstr "PCX: kuva-muotoa ei tuettu"
 
-#: ../src/common/imagpcx.cpp:479
+#: ../src/common/imagpcx.cpp:478
 msgid "PCX: invalid image"
 msgstr "PCX: virheellinen kuva"
 
-#: ../src/common/imagpcx.cpp:442
+#: ../src/common/imagpcx.cpp:441
 msgid "PCX: this is not a PCX file."
 msgstr "PCX: tämä ei ole PCX tiedosto."
 
-#: ../src/common/imagpcx.cpp:459 ../src/common/imagpcx.cpp:481
+#: ../src/common/imagpcx.cpp:458 ../src/common/imagpcx.cpp:480
 msgid "PCX: unknown error !!!"
 msgstr "PCX: tuntematon virhe !!!"
 
-#: ../src/common/imagpcx.cpp:458
+#: ../src/common/imagpcx.cpp:457
 msgid "PCX: version number too low"
 msgstr "PCX: Liian pieni versionumero"
 
-#: ../src/common/imagpnm.cpp:91
+#: ../src/common/imagpnm.cpp:89
 msgid "PNM: Couldn't allocate memory."
 msgstr "PNM: Muistin varaaminen epäonnistui."
 
-#: ../src/common/imagpnm.cpp:73
+#: ../src/common/imagpnm.cpp:71
 msgid "PNM: File format is not recognized."
 msgstr "PNM: Tuntematon tiedostomuoto."
 
-#: ../src/common/imagpnm.cpp:112 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
 #: ../src/common/imagpnm.cpp:156
 msgid "PNM: File seems truncated."
 msgstr "PNM: Tiedosto on ehkä typistetty."
 
-#: ../src/common/paper.cpp:187
+#: ../src/common/paper.cpp:184
 msgid "PRC 16K 146 x 215 mm"
 msgstr "PRC 16K 146 x 215 mm"
 
-#: ../src/common/paper.cpp:200
+#: ../src/common/paper.cpp:197
 msgid "PRC 16K Rotated"
 msgstr "PRC 16K käännetty"
 
-#: ../src/common/paper.cpp:188
+#: ../src/common/paper.cpp:185
 msgid "PRC 32K 97 x 151 mm"
 msgstr "PRC 32K 97 x 151 mm"
 
-#: ../src/common/paper.cpp:201
+#: ../src/common/paper.cpp:198
 msgid "PRC 32K Rotated"
 msgstr "PRC 32K käännetty"
 
-#: ../src/common/paper.cpp:189
+#: ../src/common/paper.cpp:186
 msgid "PRC 32K(Big) 97 x 151 mm"
 msgstr "PRC 32K(iso) 97 x 151 mm"
 
-#: ../src/common/paper.cpp:202
+#: ../src/common/paper.cpp:199
 msgid "PRC 32K(Big) Rotated"
 msgstr "PRC 32K(iso) käännetty"
 
-#: ../src/common/paper.cpp:190
+#: ../src/common/paper.cpp:187
 msgid "PRC Envelope #1 102 x 165 mm"
 msgstr "PRC-kirjekori #1 102 x 165 mm"
 
-#: ../src/common/paper.cpp:203
+#: ../src/common/paper.cpp:200
 msgid "PRC Envelope #1 Rotated 165 x 102 mm"
 msgstr "PRC-kirjekuori #1 käännetty 165 x 102 mm"
 
-#: ../src/common/paper.cpp:199
+#: ../src/common/paper.cpp:196
 msgid "PRC Envelope #10 324 x 458 mm"
 msgstr "PRC-kirjekuori #10 324 x 458 mm"
 
-#: ../src/common/paper.cpp:212
+#: ../src/common/paper.cpp:209
 msgid "PRC Envelope #10 Rotated 458 x 324 mm"
 msgstr "PRC-kirjekuori #10 käännetty 458 x 324 mm"
 
-#: ../src/common/paper.cpp:191
+#: ../src/common/paper.cpp:188
 msgid "PRC Envelope #2 102 x 176 mm"
 msgstr "PRC-kirjekuori #2 102 x 176 mm"
 
-#: ../src/common/paper.cpp:204
+#: ../src/common/paper.cpp:201
 msgid "PRC Envelope #2 Rotated 176 x 102 mm"
 msgstr "PRC-kirjekuori #2 käännetty 176 x 102 mm"
 
-#: ../src/common/paper.cpp:192
+#: ../src/common/paper.cpp:189
 msgid "PRC Envelope #3 125 x 176 mm"
 msgstr "PRC-kirjekuori #3 125 x 176 mm"
 
-#: ../src/common/paper.cpp:205
+#: ../src/common/paper.cpp:202
 msgid "PRC Envelope #3 Rotated 176 x 125 mm"
 msgstr "PRC-kirjekuori #3 käännetty 176 x 125 mm"
 
-#: ../src/common/paper.cpp:193
+#: ../src/common/paper.cpp:190
 msgid "PRC Envelope #4 110 x 208 mm"
 msgstr "PRC-kirjekuori #4 110 x 208 mm"
 
-#: ../src/common/paper.cpp:206
+#: ../src/common/paper.cpp:203
 msgid "PRC Envelope #4 Rotated 208 x 110 mm"
 msgstr "PRC-kirjekuori #4 käännetty 208 x 110 mm"
 
-#: ../src/common/paper.cpp:194
+#: ../src/common/paper.cpp:191
 msgid "PRC Envelope #5 110 x 220 mm"
 msgstr "PRC-kirjekuori#5 110 x 220 mm"
 
-#: ../src/common/paper.cpp:207
+#: ../src/common/paper.cpp:204
 msgid "PRC Envelope #5 Rotated 220 x 110 mm"
 msgstr "PRC-kirjekuori #5 käännetty 220 x 110 mm"
 
-#: ../src/common/paper.cpp:195
+#: ../src/common/paper.cpp:192
 msgid "PRC Envelope #6 120 x 230 mm"
 msgstr "PRC-kirjekuori #6 120 x 230 mm"
 
-#: ../src/common/paper.cpp:208
+#: ../src/common/paper.cpp:205
 msgid "PRC Envelope #6 Rotated 230 x 120 mm"
 msgstr "PRC-kirjekuori #6 käännetty 230 x 120 mm"
 
-#: ../src/common/paper.cpp:196
+#: ../src/common/paper.cpp:193
 msgid "PRC Envelope #7 160 x 230 mm"
 msgstr "PRC-kirjekuori #7 160 x 230 mm"
 
-#: ../src/common/paper.cpp:209
+#: ../src/common/paper.cpp:206
 msgid "PRC Envelope #7 Rotated 230 x 160 mm"
 msgstr "PRC-kirjekuori #7 käännetty 230 x 160 mm"
 
-#: ../src/common/paper.cpp:197
+#: ../src/common/paper.cpp:194
 msgid "PRC Envelope #8 120 x 309 mm"
 msgstr "PRC-kirjekuori #8 120 x 309 mm"
 
-#: ../src/common/paper.cpp:210
+#: ../src/common/paper.cpp:207
 msgid "PRC Envelope #8 Rotated 309 x 120 mm"
 msgstr "PRC-kirjekuori #8 käännetty 309 x 120 mm"
 
-#: ../src/common/paper.cpp:198
+#: ../src/common/paper.cpp:195
 msgid "PRC Envelope #9 229 x 324 mm"
 msgstr "PRC-kirjekuori #9 229 x 324 mm"
 
-#: ../src/common/paper.cpp:211
+#: ../src/common/paper.cpp:208
 msgid "PRC Envelope #9 Rotated 324 x 229 mm"
 msgstr "PRC-kirjekuori #9 käännetty 324 x 229 mm"
 
@@ -5716,91 +5855,95 @@ msgstr "PRC-kirjekuori #9 käännetty 324 x 229 mm"
 msgid "Padding"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:2074
+#: ../src/common/prntbase.cpp:2096
 #, c-format
 msgid "Page %d"
 msgstr "Sivu %d"
 
-#: ../src/common/prntbase.cpp:2072
+#: ../src/common/prntbase.cpp:2094
 #, c-format
 msgid "Page %d of %d"
 msgstr "Sivu %d / %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 #, fuzzy
 msgid "Page Down"
 msgstr "Sivu %d"
 
-#: ../src/gtk/print.cpp:826
+#: ../src/gtk/print.cpp:829
 msgid "Page Setup"
 msgstr "Sivun asetukset"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 #, fuzzy
 msgid "Page Up"
 msgstr "Sivu %d"
 
-#: ../src/generic/prntdlgg.cpp:828 ../src/common/prntbase.cpp:484
+#: ../src/common/prntbase.cpp:479 ../src/generic/prntdlgg.cpp:821
 msgid "Page setup"
 msgstr "Sivun asetukset"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 #, fuzzy
 msgid "PageDown"
 msgstr "Alas"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 #, fuzzy
 msgid "PageUp"
 msgstr "Sivut"
 
-#: ../src/generic/prntdlgg.cpp:216
+#: ../src/generic/prntdlgg.cpp:209
 msgid "Pages"
 msgstr "Sivut"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1765
+#: ../src/propgrid/advprops.cpp:1666
 msgid "Paint Brush"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:602 ../src/generic/prntdlgg.cpp:801
-#: ../src/generic/prntdlgg.cpp:842 ../src/generic/prntdlgg.cpp:855
-#: ../src/generic/prntdlgg.cpp:1052 ../src/generic/prntdlgg.cpp:1057
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:794
+#: ../src/generic/prntdlgg.cpp:835 ../src/generic/prntdlgg.cpp:848
+#: ../src/generic/prntdlgg.cpp:1045 ../src/generic/prntdlgg.cpp:1050
 msgid "Paper size"
 msgstr "Paperin koko"
 
-#: ../src/richtext/richtextstyles.cpp:1062
+#: ../src/richtext/richtextstyles.cpp:1059
 msgid "Paragraph styles"
 msgstr "Kappaletyylit"
 
-#: ../src/common/xtistrm.cpp:465
+#: ../src/common/xtistrm.cpp:462
 msgid "Passing a already registered object to SetObject"
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:476
+#: ../src/common/xtistrm.cpp:473
 msgid "Passing an unknown object to GetObject"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:3513 ../src/common/stockitem.cpp:180
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:177 ../src/richtext/richtextctrl.cpp:3514
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Liitä"
 
-#: ../src/common/stockitem.cpp:262
+#: ../src/common/stockitem.cpp:260
 msgid "Paste selection"
 msgstr "Liitä valinta"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:74
+#: ../src/common/accelcmn.cpp:71
 msgid "Pause"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1766
+#: ../src/propgrid/advprops.cpp:1667
 msgid "Pencil"
 msgstr ""
 
@@ -5809,21 +5952,21 @@ msgstr ""
 msgid "Peri&od"
 msgstr "P&iste"
 
-#: ../src/generic/filectrlg.cpp:430
+#: ../src/generic/filectrlg.cpp:426
 msgid "Permissions"
 msgstr "Oikeudet"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:60
+#: ../src/common/accelcmn.cpp:57
 msgid "PgDn"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:59
+#: ../src/common/accelcmn.cpp:56
 msgid "PgUp"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:12868
+#: ../src/richtext/richtextbuffer.cpp:12863
 #, fuzzy
 msgid "Picture Properties"
 msgstr "&Ominaisuudet"
@@ -5836,46 +5979,46 @@ msgstr "Putken luonti epäonnistui"
 msgid "Please choose a valid font."
 msgstr "Valitse kelvollinen fontti."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
 msgid "Please choose an existing file."
 msgstr "Valitse olemassa oleva tiedosto."
 
-#: ../src/html/helpwnd.cpp:800
+#: ../src/html/helpwnd.cpp:798
 msgid "Please choose the page to display:"
 msgstr "Valitse näytettävä sivu:"
 
-#: ../src/msw/dialup.cpp:764
+#: ../src/msw/dialup.cpp:758
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Valitse palveluntarjoaja, johon haluat kytkeytyä"
 
-#: ../src/common/headerctrlcmn.cpp:59
+#: ../src/common/headerctrlcmn.cpp:57
 msgid "Please select the columns to show and define their order:"
 msgstr "Valitse näytettävät sarakkeet ja määritä niiden järjestys:"
 
-#: ../src/common/prntbase.cpp:538
+#: ../src/common/prntbase.cpp:533
 #, fuzzy
 msgid "Please wait while printing..."
 msgstr "Odota kunnes tulostus loppuu\n"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1767
+#: ../src/propgrid/advprops.cpp:1668
 #, fuzzy
 msgid "Point Left"
 msgstr "K&irjasinkoko:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1768
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgid "Point Right"
 msgstr "Tasaa oikealle"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:662
+#: ../src/propgrid/advprops.cpp:572
 #, fuzzy
 msgid "Point Size"
 msgstr "K&irjasinkoko:"
 
-#: ../src/generic/prntdlgg.cpp:612 ../src/generic/prntdlgg.cpp:867
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:860
 msgid "Portrait"
 msgstr "Pystysuunta"
 
@@ -5884,159 +6027,169 @@ msgstr "Pystysuunta"
 msgid "Position"
 msgstr "Kysymys"
 
-#: ../src/generic/prntdlgg.cpp:298
+#: ../src/generic/prntdlgg.cpp:291
 msgid "PostScript file"
 msgstr "PostScript-tiedosto"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178 ../src/osx/cocoa/preferences.mm:303
 #, fuzzy
 msgid "Preferences"
 msgstr "&Asetukset"
 
-#: ../src/osx/menu_osx.cpp:568
+#: ../src/osx/menu_osx.cpp:460
 #, fuzzy
 msgid "Preferences..."
 msgstr "&Asetukset"
 
-#: ../src/common/prntbase.cpp:546
+#: ../src/common/prntbase.cpp:541
 msgid "Preparing"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:455 ../src/osx/carbon/fontdlg.cpp:390
-#: ../src/html/helpwnd.cpp:1222
+#: ../src/osx/carbon/fontdlg.cpp:387 ../src/generic/fontdlgg.cpp:452
+#: ../src/html/helpwnd.cpp:1220
 msgid "Preview:"
 msgstr "Esikatselu:"
 
-#: ../src/common/prntbase.cpp:1553 ../src/html/helpwnd.cpp:664
+#: ../src/common/prntbase.cpp:1578 ../src/html/helpwnd.cpp:662
 msgid "Previous page"
 msgstr "Edellinen sivu"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/prntdlgg.cpp:143 ../src/generic/prntdlgg.cpp:157
-#: ../src/common/prntbase.cpp:426 ../src/common/prntbase.cpp:1541
-#: ../src/common/accelcmn.cpp:77 ../src/gtk/print.cpp:620
-#: ../src/gtk/print.cpp:638
+#: ../src/common/prntbase.cpp:421 ../src/common/prntbase.cpp:1566
+#: ../src/common/accelcmn.cpp:74 ../src/generic/prntdlgg.cpp:136
+#: ../src/generic/prntdlgg.cpp:150 ../src/gtk/print.cpp:616
+#: ../src/gtk/print.cpp:634
 msgid "Print"
 msgstr "Tulosta"
 
-#: ../include/wx/prntbase.h:399 ../src/common/docview.cpp:1268
+#: ../src/common/docview.cpp:1262
 msgid "Print Preview"
 msgstr "Tulostuksen esikatselu"
 
-#: ../src/common/prntbase.cpp:2015 ../src/common/prntbase.cpp:2057
-#: ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2037 ../src/common/prntbase.cpp:2079
+#: ../src/common/prntbase.cpp:2087
 msgid "Print Preview Failure"
 msgstr "Tulostuksen esikatselu epäonnistui"
 
-#: ../src/generic/prntdlgg.cpp:224
+#: ../src/generic/prntdlgg.cpp:217
 msgid "Print Range"
 msgstr "Tulostusalue"
 
-#: ../src/generic/prntdlgg.cpp:449
+#: ../src/generic/prntdlgg.cpp:442
 msgid "Print Setup"
 msgstr "Tulostusasetukset"
 
-#: ../src/generic/prntdlgg.cpp:621
+#: ../src/generic/prntdlgg.cpp:614
 msgid "Print in colour"
 msgstr "Väritulostus"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/osx/webview_webkit.mm:260
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "Sarakkeen kuvausta ei voitu alustaa."
+
+#: ../src/common/stockitem.cpp:179
 #, fuzzy
 msgid "Print previe&w..."
 msgstr "Tulostuksen &esikatselu"
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1256
 #, fuzzy
 msgid "Print preview creation failed."
 msgstr "Putken luonti epäonnistui"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/common/stockitem.cpp:179
 #, fuzzy
 msgid "Print preview..."
 msgstr "Tulostuksen esikatselu"
 
-#: ../src/generic/prntdlgg.cpp:630
+#: ../src/generic/prntdlgg.cpp:623
 #, fuzzy
 msgid "Print spooling"
 msgstr "Tulostuksen sivuajo"
 
-#: ../src/html/helpwnd.cpp:675
+#: ../src/html/helpwnd.cpp:673
 msgid "Print this page"
 msgstr "Tulosta tämä sivu"
 
-#: ../src/generic/prntdlgg.cpp:185
+#: ../src/generic/prntdlgg.cpp:178
 msgid "Print to File"
 msgstr "Tulosta tiedostoon"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 #, fuzzy
 msgid "Print..."
 msgstr "&Tulosta..."
 
-#: ../src/generic/prntdlgg.cpp:493
+#: ../src/generic/prntdlgg.cpp:486
 msgid "Printer"
 msgstr "Tulostin"
 
-#: ../src/generic/prntdlgg.cpp:633
+#: ../src/generic/prntdlgg.cpp:626
 msgid "Printer command:"
 msgstr "Tulostinkomento:"
 
-#: ../src/generic/prntdlgg.cpp:180
+#: ../src/generic/prntdlgg.cpp:173
 msgid "Printer options"
 msgstr "Tulostimen valinnat"
 
-#: ../src/generic/prntdlgg.cpp:645
+#: ../src/generic/prntdlgg.cpp:638
 msgid "Printer options:"
 msgstr "Tulostimen valinnat:"
 
-#: ../src/generic/prntdlgg.cpp:916
+#: ../src/generic/prntdlgg.cpp:909
 msgid "Printer..."
 msgstr "Tulostin..."
 
-#: ../src/generic/prntdlgg.cpp:196
+#: ../src/generic/prntdlgg.cpp:189
 msgid "Printer:"
 msgstr "Tulostin:"
 
-#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:535
-#: ../src/html/htmprint.cpp:277
+#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:530
+#: ../src/html/htmprint.cpp:289
 #, fuzzy
 msgid "Printing"
 msgstr "Tulostetaan "
 
-#: ../src/common/prntbase.cpp:612
+#: ../src/common/prntbase.cpp:607
 msgid "Printing "
 msgstr "Tulostetaan "
 
-#: ../src/common/prntbase.cpp:347
+#: ../src/common/prntbase.cpp:342
 msgid "Printing Error"
 msgstr "Tulostusvirhe"
 
-#: ../src/common/prntbase.cpp:565
+#: ../src/osx/webview_webkit.mm:251
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "Gzip:iä ei tueta zlib:in tässä versiossa"
+
+#: ../src/common/prntbase.cpp:560
 #, fuzzy, c-format
 msgid "Printing page %d"
 msgstr "Tulostetaan sivua %d..."
 
-#: ../src/common/prntbase.cpp:570
+#: ../src/common/prntbase.cpp:565
 #, fuzzy, c-format
 msgid "Printing page %d of %d"
 msgstr "Tulostetaan sivua %d..."
 
-#: ../src/generic/printps.cpp:201
+#: ../src/generic/printps.cpp:182
 #, c-format
 msgid "Printing page %d..."
 msgstr "Tulostetaan sivua %d..."
 
-#: ../src/generic/printps.cpp:161
+#: ../src/generic/printps.cpp:142
 msgid "Printing..."
 msgstr "Tulostetaan..."
 
-#: ../include/wx/richtext/richtextprint.h:109 ../include/wx/prntbase.h:267
-#: ../src/common/docview.cpp:2132
+#: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
+#: ../src/common/docview.cpp:2137
 #, fuzzy
 msgid "Printout"
 msgstr "Tulosta"
 
-#: ../src/common/debugrpt.cpp:560
+#: ../src/common/debugrpt.cpp:561
 #, fuzzy, c-format
 msgid ""
 "Processing debug report has failed, leaving the files in \"%s\" directory."
@@ -6044,110 +6197,110 @@ msgstr ""
 "Ohjelmavirheilmoituksen valmistelu epäonnistui, tiedostot jätetään "
 "hakemistoon ”%s”."
 
-#: ../src/common/prntbase.cpp:545
+#: ../src/common/prntbase.cpp:540
 msgid "Progress:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181
 #, fuzzy
 msgid "Properties"
 msgstr "&Ominaisuudet"
 
-#: ../src/propgrid/manager.cpp:237
+#: ../src/propgrid/manager.cpp:223
 #, fuzzy
 msgid "Property"
 msgstr "&Ominaisuudet"
 
 #. TRANSLATORS: Caption of message box displaying any property error
-#: ../src/propgrid/propgrid.cpp:3185 ../src/propgrid/propgrid.cpp:3318
+#: ../src/propgrid/propgrid.cpp:3162 ../src/propgrid/propgrid.cpp:3299
 #, fuzzy
 msgid "Property Error"
 msgstr "Tulostusvirhe"
 
-#: ../src/propgrid/advprops.cpp:1597
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Purple"
 msgstr ""
 
-#: ../src/common/paper.cpp:112
+#: ../src/common/paper.cpp:109
 #, fuzzy
 msgid "Quarto, 215 x 275 mm"
 msgstr "Quarto, 215 x 275 mm"
 
-#: ../src/generic/logg.cpp:1016
+#: ../src/generic/logg.cpp:1013
 msgid "Question"
 msgstr "Kysymys"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1769
+#: ../src/propgrid/advprops.cpp:1670
 #, fuzzy
 msgid "Question Arrow"
 msgstr "Kysymys"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 #, fuzzy
 msgid "Quit"
 msgstr "&Poistu"
 
-#: ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:477
 #, fuzzy, c-format
 msgid "Quit %s"
 msgstr "&Poistu"
 
-#: ../src/common/stockitem.cpp:263
+#: ../src/common/stockitem.cpp:261
 msgid "Quit this program"
 msgstr "Poistu tästä sovelluksesta"
 
-#: ../src/common/accelcmn.cpp:338
+#: ../src/common/accelcmn.cpp:352
 #, fuzzy
 msgid "RawCtrl+"
 msgstr "Ctrl-"
 
-#: ../src/common/ffile.cpp:109 ../src/common/ffile.cpp:133
+#: ../src/common/ffile.cpp:107 ../src/common/ffile.cpp:132
 #, c-format
 msgid "Read error on file '%s'"
 msgstr "Lukuvirhe tiedostossa ”%s”"
 
-#: ../src/common/secretstore.cpp:199
+#: ../src/common/secretstore.cpp:211
 #, fuzzy, c-format
-msgid "Reading password for \"%s/%s\" failed: %s."
+msgid "Reading password for \"%s\" failed: %s."
 msgstr "Ei voitu purkaa ”%s”:aa kohteeseen ”%s”."
 
-#: ../src/common/prntbase.cpp:272
+#: ../src/common/prntbase.cpp:267
 msgid "Ready"
 msgstr "Valmis"
 
-#: ../src/propgrid/advprops.cpp:1605
+#: ../src/propgrid/advprops.cpp:1511
 #, fuzzy
 msgid "Red"
 msgstr "Toista"
 
-#: ../src/generic/colrdlgg.cpp:339
+#: ../src/generic/colrdlgg.cpp:359
 msgid "Red:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:185 ../src/stc/stc_i18n.cpp:16
+#: ../src/common/stockitem.cpp:182 ../src/stc/stc_i18n.cpp:16
 msgid "Redo"
 msgstr "Toista"
 
-#: ../src/common/stockitem.cpp:264
+#: ../src/common/stockitem.cpp:262
 msgid "Redo last action"
 msgstr "Toista viimeisin toimenpide"
 
-#: ../src/common/stockitem.cpp:186
+#: ../src/common/stockitem.cpp:183
 msgid "Refresh"
 msgstr "Päivitä"
 
-#: ../src/msw/registry.cpp:626
+#: ../src/msw/registry.cpp:615
 #, c-format
 msgid "Registry key '%s' already exists."
 msgstr "Rekisteriavain ”%s” on jo olemassa."
 
-#: ../src/msw/registry.cpp:595
+#: ../src/msw/registry.cpp:584
 #, c-format
 msgid "Registry key '%s' does not exist, cannot rename it."
 msgstr "Rekisteriavain ”%s” ei ole olemassa, sitä ei voi uudelleennimetä."
 
-#: ../src/msw/registry.cpp:727
+#: ../src/msw/registry.cpp:716
 #, c-format
 msgid ""
 "Registry key '%s' is needed for normal system operation,\n"
@@ -6158,22 +6311,22 @@ msgstr ""
 "toimintaan. Avaimen poistaminen jättää järjestelmän\n"
 "epävakaaseen tilaan: toiminto keskeytetty."
 
-#: ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:942
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:917
+#: ../src/msw/registry.cpp:905
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1003
+#: ../src/msw/registry.cpp:991
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:521
+#: ../src/msw/registry.cpp:510
 #, c-format
 msgid "Registry value '%s' already exists."
 msgstr "Rekisterin arvo ”%s” on jo olemassa."
@@ -6188,71 +6341,77 @@ msgstr "Tavallinen"
 msgid "Relative"
 msgstr "Koristeellinen"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:456
 msgid "Relevant entries:"
 msgstr "Tähdelliset kohdat:"
 
-#: ../include/wx/generic/progdlgg.h:86
+#: ../include/wx/generic/progdlgg.h:87
 msgid "Remaining time:"
 msgstr "Jäljellä oleva aika:"
 
-#: ../src/common/stockitem.cpp:187
+#: ../src/common/stockitem.cpp:184
 msgid "Remove"
 msgstr "Poista"
 
-#: ../src/richtext/richtextctrl.cpp:1562
+#: ../src/richtext/richtextctrl.cpp:1563
 #, fuzzy
 msgid "Remove Bullet"
 msgstr "Poista"
 
-#: ../src/html/helpwnd.cpp:433
+#: ../src/html/helpwnd.cpp:431
 msgid "Remove current page from bookmarks"
 msgstr "Poista nykyinen sivu kirjanmerkeistä"
 
-#: ../src/common/rendcmn.cpp:194
+#: ../src/common/rendcmn.cpp:191
 #, c-format
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:4527
+#: ../src/richtext/richtextbuffer.cpp:4524
 msgid "Renumber List"
 msgstr "Numeroi luettelo uudelleen"
 
-#: ../src/common/stockitem.cpp:188
-msgid "Rep&lace"
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Rep&lace..."
 msgstr "&Korvaa"
 
-#: ../src/richtext/richtextctrl.cpp:3673 ../src/common/stockitem.cpp:188
+#: ../src/richtext/richtextctrl.cpp:3674
 msgid "Replace"
 msgstr "Korvaa"
 
-#: ../src/generic/fdrepdlg.cpp:182
+#: ../src/generic/fdrepdlg.cpp:179
 msgid "Replace &all"
 msgstr "Korvaa k&aikki"
 
-#: ../src/common/stockitem.cpp:261
-msgid "Replace selection"
-msgstr "Korvaa valinta"
-
-#: ../src/generic/fdrepdlg.cpp:124
+#: ../src/generic/fdrepdlg.cpp:121
 msgid "Replace with:"
 msgstr "Korvaa kohteella:"
 
-#: ../src/common/valtext.cpp:163
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Replace..."
+msgstr "Korvaa"
+
+#: ../src/common/valtext.cpp:184
 msgid "Required information entry is empty."
 msgstr ""
 
-#: ../src/common/translation.cpp:1975
+#: ../src/common/translation.cpp:2025
 #, fuzzy, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "”%s” ei ole kelvollinen viestiluettelo."
 
+#: ../src/gtk/webview_webkit.cpp:985
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:56
+#: ../src/common/accelcmn.cpp:53
 msgid "Return"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:189
+#: ../src/common/stockitem.cpp:186
 msgid "Revert to Saved"
 msgstr "Palauta tallennettuun"
 
@@ -6265,42 +6424,42 @@ msgstr "Oikealle"
 msgid "Rig&ht-to-left"
 msgstr ""
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6149
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:59 ../src/generic/datavgen.cpp:6954
+#: ../src/richtext/richtextsizepage.cpp:250
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextbulletspage.cpp:188
-#: ../src/richtext/richtextsizepage.cpp:250 ../src/common/accelcmn.cpp:62
 msgid "Right"
 msgstr "Oikealle"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1754
+#: ../src/propgrid/advprops.cpp:1655
 #, fuzzy
 msgid "Right Arrow"
 msgstr "Oikealle"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1770
+#: ../src/propgrid/advprops.cpp:1671
 msgid "Right Button"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:892
+#: ../src/generic/prntdlgg.cpp:885
 msgid "Right margin (mm):"
 msgstr "Oikea marginaali (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:148
-#: ../src/richtext/richtextindentspage.cpp:150
 #: ../src/richtext/richtextliststylepage.cpp:337
 #: ../src/richtext/richtextliststylepage.cpp:339
+#: ../src/richtext/richtextindentspage.cpp:148
+#: ../src/richtext/richtextindentspage.cpp:150
 msgid "Right-align text."
 msgstr "Tasaa teksti oikealle."
 
-#: ../src/generic/fontdlgg.cpp:322
+#: ../src/generic/fontdlgg.cpp:318
 msgid "Roman"
 msgstr "Roman"
 
-#: ../src/generic/datavgen.cpp:5916
+#: ../src/generic/datavgen.cpp:6721
 #, c-format
 msgid "Row %i"
 msgstr ""
@@ -6310,31 +6469,31 @@ msgstr ""
 msgid "S&tandard bullet name:"
 msgstr "&Oletus luettelomerkin nimi:"
 
-#: ../src/common/accelcmn.cpp:268 ../src/common/accelcmn.cpp:350
+#: ../src/common/accelcmn.cpp:282 ../src/common/accelcmn.cpp:367
 msgid "SPECIAL"
 msgstr "EIRKOIS"
 
-#: ../src/common/stockitem.cpp:190 ../src/common/sizer.cpp:2797
+#: ../src/common/stockitem.cpp:187 ../src/common/sizer.cpp:2914
 msgid "Save"
 msgstr "Tallenna"
 
-#: ../src/common/fldlgcmn.cpp:342
+#: ../src/common/fldlgcmn.cpp:339
 #, c-format
 msgid "Save %s file"
 msgstr "Tallenna %s tiedosto"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/common/stockitem.cpp:188 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Tallenna &nimellä..."
 
-#: ../src/common/docview.cpp:366
+#: ../src/common/docview.cpp:359
 msgid "Save As"
 msgstr "Tallenna nimellä"
 
-#: ../src/common/stockitem.cpp:191
+#: ../src/common/stockitem.cpp:188
 #, fuzzy
-msgid "Save as"
-msgstr "Tallenna nimellä"
+msgid "Save As..."
+msgstr "Tallenna &nimellä..."
 
 #: ../src/common/stockitem.cpp:267
 msgid "Save current document"
@@ -6344,40 +6503,40 @@ msgstr "Tallenna nykyinen asiakirja"
 msgid "Save current document with a different filename"
 msgstr "Tallenna nykyinen asiakirja eri nimellä"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/generic/logg.cpp:509
 msgid "Save log contents to file"
 msgstr "Tallenna lokin sisältä tiedostoon"
 
-#: ../src/common/secretstore.cpp:179
+#: ../src/common/secretstore.cpp:189
 #, fuzzy, c-format
-msgid "Saving password for \"%s/%s\" failed: %s."
+msgid "Saving password for \"%s\" failed: %s."
 msgstr "Ei voitu purkaa ”%s”:aa kohteeseen ”%s”."
 
-#: ../src/generic/fontdlgg.cpp:325
+#: ../src/generic/fontdlgg.cpp:321
 msgid "Script"
 msgstr "Script"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll Lock"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll_lock"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:890
+#: ../src/propgrid/advprops.cpp:791
 msgid "Scrollbar"
 msgstr ""
 
-#: ../src/generic/srchctlg.cpp:56 ../src/html/helpwnd.cpp:535
-#: ../src/html/helpwnd.cpp:550
+#: ../src/generic/srchctlg.cpp:55 ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:548 ../src/gtk/srchctrl.cpp:182
 msgid "Search"
 msgstr "Etsi"
 
-#: ../src/html/helpwnd.cpp:537
+#: ../src/html/helpwnd.cpp:535
 #, fuzzy
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
@@ -6385,56 +6544,56 @@ msgid ""
 msgstr ""
 "Hae ohjekirjojen sisällöstä kaikki tapaukset, jossa on yllä antamasi teksti"
 
-#: ../src/generic/fdrepdlg.cpp:160
+#: ../src/generic/fdrepdlg.cpp:157
 msgid "Search direction"
 msgstr "Hakusuunta"
 
-#: ../src/generic/fdrepdlg.cpp:112
+#: ../src/generic/fdrepdlg.cpp:109
 msgid "Search for:"
 msgstr "Etsi:"
 
-#: ../src/html/helpwnd.cpp:1052
+#: ../src/html/helpwnd.cpp:1050
 msgid "Search in all books"
 msgstr "Hae kaikista kirjoista"
 
-#: ../src/html/helpwnd.cpp:857
+#: ../src/html/helpwnd.cpp:855
 msgid "Searching..."
 msgstr "Etsitään..."
 
-#: ../src/generic/dirctrlg.cpp:446
+#: ../src/generic/dirctrlg.cpp:412
 msgid "Sections"
 msgstr "Lohkot"
 
-#: ../src/common/ffile.cpp:238
+#: ../src/common/ffile.cpp:237
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Hakuvirhe tiedostossa ”%s”"
 
-#: ../src/common/ffile.cpp:228
+#: ../src/common/ffile.cpp:227
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr "Hakuvirhe tiedostossa ”%s” (stdio ei tue suuria tiedostoja)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:76
+#: ../src/common/accelcmn.cpp:73
 #, fuzzy
 msgid "Select"
 msgstr "Valinta"
 
-#: ../src/richtext/richtextctrl.cpp:337 ../src/osx/textctrl_osx.cpp:581
-#: ../src/common/stockitem.cpp:192 ../src/msw/textctrl.cpp:2512
+#: ../src/osx/textctrl_osx.cpp:599 ../src/common/stockitem.cpp:189
+#: ../src/msw/textctrl.cpp:2777 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Valitse k&aikki"
 
-#: ../src/common/stockitem.cpp:192 ../src/stc/stc_i18n.cpp:21
+#: ../src/common/stockitem.cpp:189 ../src/stc/stc_i18n.cpp:21
 msgid "Select All"
 msgstr "Valitse kaikki"
 
-#: ../src/common/docview.cpp:1895
+#: ../src/common/docview.cpp:1900
 msgid "Select a document template"
 msgstr "Valitse asiakirjamalli"
 
-#: ../src/common/docview.cpp:1969
+#: ../src/common/docview.cpp:1974
 msgid "Select a document view"
 msgstr "Valitse asiakirjanäkymä"
 
@@ -6463,20 +6622,20 @@ msgid "Selects the list level to edit."
 msgstr "Valitse muokattava luettelotaso."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:82
+#: ../src/common/accelcmn.cpp:79
 msgid "Separator"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1083
+#: ../src/common/cmdline.cpp:1079
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Erotinmerkki tarvitaan option ”%s” jälkeen."
 
-#: ../src/osx/menu_osx.cpp:572
+#: ../src/osx/menu_osx.cpp:464
 msgid "Services"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11217
+#: ../src/richtext/richtextbuffer.cpp:11216
 #, fuzzy
 msgid "Set Cell Style"
 msgstr "Poista tyyli"
@@ -6485,11 +6644,11 @@ msgstr "Poista tyyli"
 msgid "SetProperty called w/o valid setter"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:188
+#: ../src/generic/prntdlgg.cpp:181
 msgid "Setup..."
 msgstr "Asetukset..."
 
-#: ../src/msw/dialup.cpp:544
+#: ../src/msw/dialup.cpp:538
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr ""
 "Monta aktiivista puhelinvalintaikkunaa auki, valitsen yhden satunnaisesti."
@@ -6507,42 +6666,42 @@ msgstr ""
 msgid "Shadow c&olour:"
 msgstr "Valitse väri"
 
-#: ../src/common/accelcmn.cpp:335
+#: ../src/common/accelcmn.cpp:349
 #, fuzzy
 msgid "Shift+"
 msgstr "Shift-"
 
-#: ../src/generic/dirdlgg.cpp:147
+#: ../src/generic/dirdlgg.cpp:144
 msgid "Show &hidden directories"
 msgstr "Näytä piilo&hakemistot"
 
-#: ../src/generic/filectrlg.cpp:983
+#: ../src/generic/filectrlg.cpp:979
 msgid "Show &hidden files"
 msgstr "Näytä piilo&tiedostot"
 
-#: ../src/osx/menu_osx.cpp:580
+#: ../src/osx/menu_osx.cpp:472
 #, fuzzy
 msgid "Show All"
 msgstr "Näytä kaikki"
 
-#: ../src/common/stockitem.cpp:257
+#: ../src/common/stockitem.cpp:254
 msgid "Show about dialog"
 msgstr "Näytä tietoja-valintaikkuna"
 
-#: ../src/html/helpwnd.cpp:492
+#: ../src/html/helpwnd.cpp:490
 msgid "Show all"
 msgstr "Näytä kaikki"
 
-#: ../src/html/helpwnd.cpp:503
+#: ../src/html/helpwnd.cpp:501
 msgid "Show all items in index"
 msgstr "Näytä kaikki indeksissä"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:656
 msgid "Show/hide navigation panel"
 msgstr "Näytä/piilota suunnistustaulu"
 
-#: ../src/richtext/richtextsymboldlg.cpp:421
-#: ../src/richtext/richtextsymboldlg.cpp:423
+#: ../src/richtext/richtextsymboldlg.cpp:418
+#: ../src/richtext/richtextsymboldlg.cpp:420
 msgid "Shows a Unicode subset."
 msgstr "Näyttää Unicode-osajoukon"
 
@@ -6558,7 +6717,7 @@ msgstr ""
 msgid "Shows a preview of the font settings."
 msgstr "Näyttää kirjasinasetusten esikatselun."
 
-#: ../src/osx/carbon/fontdlg.cpp:394 ../src/osx/carbon/fontdlg.cpp:396
+#: ../src/osx/carbon/fontdlg.cpp:391 ../src/osx/carbon/fontdlg.cpp:393
 msgid "Shows a preview of the font."
 msgstr "Näyttää kirjasimen esikatselun."
 
@@ -6567,62 +6726,62 @@ msgstr "Näyttää kirjasimen esikatselun."
 msgid "Shows a preview of the paragraph settings."
 msgstr "Näyttää  kappaleen asetuksien esikatselun."
 
-#: ../src/generic/fontdlgg.cpp:460 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:456 ../src/generic/fontdlgg.cpp:458
 msgid "Shows the font preview."
 msgstr "Näytä kirjasimen esikatselu."
 
-#: ../src/propgrid/advprops.cpp:1607
+#: ../src/propgrid/advprops.cpp:1513
 msgid "Silver"
 msgstr ""
 
-#: ../src/univ/themes/mono.cpp:516
+#: ../src/univ/themes/mono.cpp:513
 msgid "Simple monochrome theme"
 msgstr "Yksinkertainen yksivärinen teema"
 
-#: ../src/richtext/richtextindentspage.cpp:275
 #: ../src/richtext/richtextliststylepage.cpp:449
+#: ../src/richtext/richtextindentspage.cpp:275
 msgid "Single"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:425 ../src/richtext/richtextformatdlg.cpp:369
-#: ../src/richtext/richtextsizepage.cpp:299
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextsizepage.cpp:299
+#: ../src/richtext/richtextformatdlg.cpp:362
 msgid "Size"
 msgstr "Koko"
 
-#: ../src/osx/carbon/fontdlg.cpp:339
+#: ../src/osx/carbon/fontdlg.cpp:336
 msgid "Size:"
 msgstr "Koko:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1775
+#: ../src/propgrid/advprops.cpp:1676
 msgid "Sizing"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1772
+#: ../src/propgrid/advprops.cpp:1673
 msgid "Sizing N-S"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1771
+#: ../src/propgrid/advprops.cpp:1672
 msgid "Sizing NE-SW"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1773
+#: ../src/propgrid/advprops.cpp:1674
 msgid "Sizing NW-SE"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1774
+#: ../src/propgrid/advprops.cpp:1675
 msgid "Sizing W-E"
 msgstr ""
 
-#: ../src/msw/progdlg.cpp:801
+#: ../src/msw/progdlg.cpp:1088
 msgid "Skip"
 msgstr "Ohita"
 
-#: ../src/generic/fontdlgg.cpp:330
+#: ../src/generic/fontdlgg.cpp:326
 msgid "Slant"
 msgstr "Kalteva"
 
@@ -6632,7 +6791,7 @@ msgid "Small C&apitals"
 msgstr "&Suuraakkoset"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:79
+#: ../src/common/accelcmn.cpp:76
 msgid "Snapshot"
 msgstr ""
 
@@ -6641,37 +6800,37 @@ msgstr ""
 msgid "Solid"
 msgstr "Lihavoitu"
 
-#: ../src/common/docview.cpp:1791
+#: ../src/common/docview.cpp:1785
 msgid "Sorry, could not open this file."
 msgstr "Tätä tiedostoa ei voi avata."
 
-#: ../src/common/prntbase.cpp:2057 ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2079 ../src/common/prntbase.cpp:2087
 msgid "Sorry, not enough memory to create a preview."
 msgstr "Liian vähän muistia esikatseluun."
 
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "Sorry, that name is taken. Please choose another."
 msgstr "Nimi on jo käytössä. Valitse toinen."
 
-#: ../src/common/docview.cpp:1814
+#: ../src/common/docview.cpp:1819
 msgid "Sorry, the format for this file is unknown."
 msgstr "Tämän tiedoston muoto on tuntematon."
 
-#: ../src/unix/sound.cpp:492
+#: ../src/unix/sound.cpp:481
 msgid "Sound data are in unsupported format."
 msgstr "äänidatan muotoa ei tueta."
 
-#: ../src/unix/sound.cpp:477
+#: ../src/unix/sound.cpp:466
 #, c-format
 msgid "Sound file '%s' is in unsupported format."
 msgstr "äänitiedoston ”%s” muotoa ei tueta."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:67
+#: ../src/common/accelcmn.cpp:64
 #, fuzzy
 msgid "Space"
 msgstr "Etsitään..."
@@ -6681,12 +6840,12 @@ msgstr "Etsitään..."
 msgid "Spacing"
 msgstr "Etsitään..."
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "Spell Check"
 msgstr "Oikeinkirjoituksen tarkistus"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1776
+#: ../src/propgrid/advprops.cpp:1677
 msgid "Spraycan"
 msgstr ""
 
@@ -6695,7 +6854,7 @@ msgstr ""
 msgid "Standard"
 msgstr "Perus"
 
-#: ../src/common/paper.cpp:104
+#: ../src/common/paper.cpp:101
 #, fuzzy
 msgid "Statement, 5 1/2 x 8 1/2 in"
 msgstr "Statement, 5 1/2 x 8 1/2” "
@@ -6706,34 +6865,30 @@ msgstr "Statement, 5 1/2 x 8 1/2” "
 msgid "Static"
 msgstr "Tila:"
 
-#: ../src/generic/prntdlgg.cpp:204
+#: ../src/generic/prntdlgg.cpp:197
 msgid "Status:"
 msgstr "Tila:"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 #, fuzzy
 msgid "Stop"
 msgstr "&Pysäytä"
 
-#: ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196
 msgid "Strikethrough"
 msgstr "Yliviivaus"
 
-#: ../src/common/colourcmn.cpp:45
+#: ../src/common/colourcmn.cpp:42
 #, c-format
 msgid "String To Colour : Incorrect colour specification : %s"
 msgstr ""
 
 #. TRANSLATORS: Label of font style
-#: ../src/richtext/richtextformatdlg.cpp:339 ../src/propgrid/advprops.cpp:680
+#: ../src/propgrid/advprops.cpp:590 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Tyyli"
 
-#: ../include/wx/richtext/richtextstyledlg.h:46
-msgid "Style Organiser"
-msgstr "Tyylien hallitsija"
-
-#: ../src/osx/carbon/fontdlg.cpp:348
+#: ../src/osx/carbon/fontdlg.cpp:345
 msgid "Style:"
 msgstr "Tyyli:"
 
@@ -6743,7 +6898,7 @@ msgid "Subscrip&t"
 msgstr "Script"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:83
+#: ../src/common/accelcmn.cpp:80
 msgid "Subtract"
 msgstr ""
 
@@ -6752,11 +6907,11 @@ msgstr ""
 msgid "Supe&rscript"
 msgstr "Script"
 
-#: ../src/common/paper.cpp:150
+#: ../src/common/paper.cpp:147
 msgid "SuperA/SuperA/A4 227 x 356 mm"
 msgstr "SuperA/SuperA/A4 227 x 356 mm"
 
-#: ../src/common/paper.cpp:151
+#: ../src/common/paper.cpp:148
 msgid "SuperB/SuperB/A3 305 x 487 mm"
 msgstr "SuperB/SuperB/A3 305 x 487 mm"
 
@@ -6764,7 +6919,7 @@ msgstr "SuperB/SuperB/A3 305 x 487 mm"
 msgid "Suppress hyphe&nation"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:326
+#: ../src/generic/fontdlgg.cpp:322
 msgid "Swiss"
 msgstr "Swiss"
 
@@ -6782,77 +6937,77 @@ msgstr "&Symbolikirjasin:"
 msgid "Symbols"
 msgstr "Symbolit"
 
-#: ../src/common/imagtiff.cpp:369 ../src/common/imagtiff.cpp:382
-#: ../src/common/imagtiff.cpp:741
+#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
+#: ../src/common/imagtiff.cpp:738
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: Muistinvaraus epäonnistui."
 
-#: ../src/common/imagtiff.cpp:301
+#: ../src/common/imagtiff.cpp:298
 msgid "TIFF: Error loading image."
 msgstr "TIFF: Virhe kuvan latauksessa."
 
-#: ../src/common/imagtiff.cpp:468
+#: ../src/common/imagtiff.cpp:465
 msgid "TIFF: Error reading image."
 msgstr "TIFF: Virhe kuvan lukemisessa ."
 
-#: ../src/common/imagtiff.cpp:608
+#: ../src/common/imagtiff.cpp:605
 msgid "TIFF: Error saving image."
 msgstr "TIFF: Virhe kuvan tallennuksesa."
 
-#: ../src/common/imagtiff.cpp:846
+#: ../src/common/imagtiff.cpp:843
 msgid "TIFF: Error writing image."
 msgstr "TIFF: Virhe kuvan kirjoituksessa."
 
-#: ../src/common/imagtiff.cpp:355
+#: ../src/common/imagtiff.cpp:352
 msgid "TIFF: Image size is abnormally big."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:68
+#: ../src/common/accelcmn.cpp:65
 #, fuzzy
 msgid "Tab"
 msgstr "Välilehdet"
 
-#: ../src/richtext/richtextbuffer.cpp:11498
+#: ../src/richtext/richtextbuffer.cpp:11497
 #, fuzzy
 msgid "Table Properties"
 msgstr "&Ominaisuudet"
 
-#: ../src/common/paper.cpp:145
+#: ../src/common/paper.cpp:142
 #, fuzzy
 msgid "Tabloid Extra 11.69 x 18 in"
 msgstr "Tabloid, 11 x 17” "
 
-#: ../src/common/paper.cpp:102
+#: ../src/common/paper.cpp:99
 #, fuzzy
 msgid "Tabloid, 11 x 17 in"
 msgstr "Tabloid, 11 x 17” "
 
-#: ../src/richtext/richtextformatdlg.cpp:354
+#: ../src/richtext/richtextformatdlg.cpp:347
 msgid "Tabs"
 msgstr "Välilehdet"
 
-#: ../src/propgrid/advprops.cpp:1598
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Teal"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:327
+#: ../src/generic/fontdlgg.cpp:323
 msgid "Teletype"
 msgstr "Teletype"
 
-#: ../src/common/docview.cpp:1896
+#: ../src/common/docview.cpp:1901
 msgid "Templates"
 msgstr "Asiakirjamallit"
 
-#: ../src/common/fmapbase.cpp:158
+#: ../src/common/fmapbase.cpp:155
 msgid "Thai (ISO-8859-11)"
 msgstr "Thaimaalainen (ISO-8859-11)"
 
-#: ../src/common/ftp.cpp:619
+#: ../src/common/ftp.cpp:622
 msgid "The FTP server doesn't support passive mode."
 msgstr "FTP-palvelin ei tue passiivista tilaa."
 
-#: ../src/common/ftp.cpp:605
+#: ../src/common/ftp.cpp:608
 msgid "The FTP server doesn't support the PORT command."
 msgstr "FTP-palvelin ei tue komentoa PORT."
 
@@ -6863,8 +7018,8 @@ msgstr "FTP-palvelin ei tue komentoa PORT."
 msgid "The available bullet styles."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:202
-#: ../src/richtext/richtextstyledlg.cpp:204
+#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:200
 msgid "The available styles."
 msgstr "Käytettävissä olevat tyylit."
 
@@ -6925,12 +7080,12 @@ msgstr "Välilehden sijainti."
 msgid "The bullet character."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:443
-#: ../src/richtext/richtextsymboldlg.cpp:445
+#: ../src/richtext/richtextsymboldlg.cpp:440
+#: ../src/richtext/richtextsymboldlg.cpp:442
 msgid "The character code."
 msgstr "Merkkikoodi."
 
-#: ../src/common/fontmap.cpp:203
+#: ../src/common/fontmap.cpp:200
 #, c-format
 msgid ""
 "The charset '%s' is unknown. You may select\n"
@@ -6941,7 +7096,7 @@ msgstr ""
 "voi valita toisen merkistön. Ellei korvaavaa\n"
 "merkistöä ole, valitse [Peruuta]."
 
-#: ../src/msw/ole/dataobj.cpp:394
+#: ../src/msw/ole/dataobj.cpp:402
 #, c-format
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "Leikepöydän muotoa ”%d” ei ole olemassa."
@@ -6951,7 +7106,7 @@ msgstr "Leikepöydän muotoa ”%d” ei ole olemassa."
 msgid "The default style for the next paragraph."
 msgstr "Oletustyyli seuraavalle kappaleelle."
 
-#: ../src/generic/dirdlgg.cpp:202
+#: ../src/generic/dirdlgg.cpp:199
 #, c-format
 msgid ""
 "The directory '%s' does not exist\n"
@@ -6960,7 +7115,7 @@ msgstr ""
 "Hakemisto ”%s” ei ole olemassa.\n"
 "Luodaanko se nyt?"
 
-#: ../src/html/htmprint.cpp:271
+#: ../src/html/htmprint.cpp:283
 #, c-format
 msgid ""
 "The document \"%s\" doesn't fit on the page horizontally and will be "
@@ -6969,7 +7124,7 @@ msgid ""
 "Would you like to proceed with printing it nevertheless?"
 msgstr ""
 
-#: ../src/common/docview.cpp:1202
+#: ../src/common/docview.cpp:1196
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -6978,36 +7133,36 @@ msgstr ""
 "Tiedosto ”%s” ei ole olemassa ja eikä sitä voi avata.\n"
 "Se on myös poistettu MRU-tiedostojen luettelosta"
 
-#: ../src/richtext/richtextindentspage.cpp:208
-#: ../src/richtext/richtextindentspage.cpp:210
 #: ../src/richtext/richtextliststylepage.cpp:394
 #: ../src/richtext/richtextliststylepage.cpp:396
+#: ../src/richtext/richtextindentspage.cpp:208
+#: ../src/richtext/richtextindentspage.cpp:210
 msgid "The first line indent."
 msgstr "Ensimmäisen rivin sisennys."
 
-#: ../src/gtk/utilsgtk.cpp:481
-msgid "The following standard GTK+ options are also supported:\n"
-msgstr "Seuraavat standardit GTK+-valinnat ovat myös tuettuina:\n"
+#: ../src/generic/dbgrptg.cpp:318
+msgid "The following debug report will be generated\n"
+msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:414 ../src/generic/fontdlgg.cpp:416
+#: ../src/generic/fontdlgg.cpp:411 ../src/generic/fontdlgg.cpp:413
 msgid "The font colour."
 msgstr "Kirjasimen väri."
 
-#: ../src/generic/fontdlgg.cpp:375 ../src/generic/fontdlgg.cpp:377
+#: ../src/generic/fontdlgg.cpp:371 ../src/generic/fontdlgg.cpp:373
 msgid "The font family."
 msgstr "Kirjasinperhe."
 
-#: ../src/richtext/richtextsymboldlg.cpp:405
-#: ../src/richtext/richtextsymboldlg.cpp:407
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "The font from which to take the symbol."
 msgstr "Kirjasin, josta symboli otetaan."
 
-#: ../src/generic/fontdlgg.cpp:427 ../src/generic/fontdlgg.cpp:429
-#: ../src/generic/fontdlgg.cpp:434 ../src/generic/fontdlgg.cpp:436
+#: ../src/generic/fontdlgg.cpp:424 ../src/generic/fontdlgg.cpp:426
+#: ../src/generic/fontdlgg.cpp:430 ../src/generic/fontdlgg.cpp:432
 msgid "The font point size."
 msgstr "Kirjasinkoko."
 
-#: ../src/osx/carbon/fontdlg.cpp:343 ../src/osx/carbon/fontdlg.cpp:345
+#: ../src/osx/carbon/fontdlg.cpp:340 ../src/osx/carbon/fontdlg.cpp:342
 msgid "The font size in points."
 msgstr "Kirjasinkoko pisteinä."
 
@@ -7017,15 +7172,15 @@ msgstr "Kirjasinkoko pisteinä."
 msgid "The font size units, points or pixels."
 msgstr "Kirjasinkoko pisteinä."
 
-#: ../src/generic/fontdlgg.cpp:386 ../src/generic/fontdlgg.cpp:388
+#: ../src/generic/fontdlgg.cpp:382 ../src/generic/fontdlgg.cpp:384
 msgid "The font style."
 msgstr "Kirjasimen tyyli."
 
-#: ../src/generic/fontdlgg.cpp:397 ../src/generic/fontdlgg.cpp:399
+#: ../src/generic/fontdlgg.cpp:393 ../src/generic/fontdlgg.cpp:395
 msgid "The font weight."
 msgstr "Kirjasimen paino."
 
-#: ../src/common/docview.cpp:1483
+#: ../src/common/docview.cpp:1477
 #, fuzzy, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Sarakkeen leveyttä ei voitu määritellä"
@@ -7036,10 +7191,10 @@ msgstr "Sarakkeen leveyttä ei voitu määritellä"
 msgid "The horizontal offset."
 msgstr "Ota käyttöön pysty-offset."
 
-#: ../src/richtext/richtextindentspage.cpp:199
-#: ../src/richtext/richtextindentspage.cpp:201
 #: ../src/richtext/richtextliststylepage.cpp:385
 #: ../src/richtext/richtextliststylepage.cpp:387
+#: ../src/richtext/richtextindentspage.cpp:199
+#: ../src/richtext/richtextindentspage.cpp:201
 msgid "The left indent."
 msgstr "Vasen sisennys."
 
@@ -7063,10 +7218,10 @@ msgstr "Kirjasinkoko."
 msgid "The left position."
 msgstr "Välilehden sijainti."
 
-#: ../src/richtext/richtextindentspage.cpp:288
-#: ../src/richtext/richtextindentspage.cpp:290
 #: ../src/richtext/richtextliststylepage.cpp:462
 #: ../src/richtext/richtextliststylepage.cpp:464
+#: ../src/richtext/richtextindentspage.cpp:288
+#: ../src/richtext/richtextindentspage.cpp:290
 msgid "The line spacing."
 msgstr "Riviväli"
 
@@ -7075,7 +7230,7 @@ msgstr "Riviväli"
 msgid "The list item number."
 msgstr "Luettelokohdan numero."
 
-#: ../src/msw/ole/automtn.cpp:664
+#: ../src/msw/ole/automtn.cpp:655
 msgid "The locale ID is unknown."
 msgstr ""
 
@@ -7121,19 +7276,19 @@ msgstr "Kirjasimen paino."
 msgid "The outline level."
 msgstr "Näytä kirjasimen esikatselu."
 
-#: ../src/common/log.cpp:277
+#: ../src/common/log.cpp:296
 #, c-format
 msgid "The previous message repeated %u time."
 msgid_plural "The previous message repeated %u times."
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/common/log.cpp:270
+#: ../src/common/log.cpp:289
 msgid "The previous message repeated once."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:462
-#: ../src/richtext/richtextsymboldlg.cpp:464
+#: ../src/richtext/richtextsymboldlg.cpp:459
+#: ../src/richtext/richtextsymboldlg.cpp:461
 msgid "The range to show."
 msgstr "Näytettävä alue."
 
@@ -7144,15 +7299,15 @@ msgid ""
 "please uncheck them and they will be removed from the report.\n"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1254
+#: ../src/common/cmdline.cpp:1250
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "Tarvittavaa parametria ”%s” ei ole määritelty."
 
-#: ../src/richtext/richtextindentspage.cpp:217
-#: ../src/richtext/richtextindentspage.cpp:219
 #: ../src/richtext/richtextliststylepage.cpp:403
 #: ../src/richtext/richtextliststylepage.cpp:405
+#: ../src/richtext/richtextindentspage.cpp:217
+#: ../src/richtext/richtextindentspage.cpp:219
 msgid "The right indent."
 msgstr "Oikea sisennys."
 
@@ -7197,16 +7352,16 @@ msgstr ""
 msgid "The shadow spread."
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:267
 #: ../src/richtext/richtextliststylepage.cpp:439
 #: ../src/richtext/richtextliststylepage.cpp:441
+#: ../src/richtext/richtextindentspage.cpp:267
 msgid "The spacing after the paragraph."
 msgstr "Tyhjä tila kappaleen jälkeen."
 
-#: ../src/richtext/richtextindentspage.cpp:257
-#: ../src/richtext/richtextindentspage.cpp:259
 #: ../src/richtext/richtextliststylepage.cpp:430
 #: ../src/richtext/richtextliststylepage.cpp:432
+#: ../src/richtext/richtextindentspage.cpp:257
+#: ../src/richtext/richtextindentspage.cpp:259
 msgid "The spacing before the paragraph."
 msgstr "Tyhjä tila ennen kappaletta."
 
@@ -7220,12 +7375,12 @@ msgstr "Tyylin nimi."
 msgid "The style on which this style is based."
 msgstr "Tyyli, johon tämä tyyli perustuu."
 
-#: ../src/richtext/richtextstyledlg.cpp:214
-#: ../src/richtext/richtextstyledlg.cpp:216
+#: ../src/richtext/richtextstyledlg.cpp:210
+#: ../src/richtext/richtextstyledlg.cpp:212
 msgid "The style preview."
 msgstr "Tyylin esikatselu."
 
-#: ../src/msw/ole/automtn.cpp:680
+#: ../src/msw/ole/automtn.cpp:671
 msgid "The system cannot find the file specified."
 msgstr "Järjestelmä ei löydä määritettyä tiedostoa."
 
@@ -7238,7 +7393,7 @@ msgstr "Välilehden sijainti."
 msgid "The tab positions."
 msgstr "Välilehtien sijainnit."
 
-#: ../src/richtext/richtextctrl.cpp:3098
+#: ../src/richtext/richtextctrl.cpp:3099
 msgid "The text couldn't be saved."
 msgstr "Tekstiä ei voitu tallentaa."
 
@@ -7262,7 +7417,7 @@ msgstr "Kirjasinkoko."
 msgid "The top position."
 msgstr "Välilehden sijainti."
 
-#: ../src/common/cmdline.cpp:1232
+#: ../src/common/cmdline.cpp:1228
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "Valinnan ”%s” arvo täyty olla määritelty."
@@ -7272,7 +7427,7 @@ msgstr "Valinnan ”%s” arvo täyty olla määritelty."
 msgid "The value of the corner radius."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:433
+#: ../src/msw/dialup.cpp:427
 #, fuzzy, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -7287,45 +7442,53 @@ msgstr ""
 msgid "The vertical offset."
 msgstr "Ota käyttöön pysty-offset."
 
-#: ../src/richtext/richtextprint.cpp:619 ../src/html/htmprint.cpp:745
+#: ../src/html/htmprint.cpp:749 ../src/richtext/richtextprint.cpp:615
 msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr ""
 "Sivun asetusten kanssa oli ongelma: voit joutua asettamaan oletustulostimen."
 
-#: ../src/html/htmprint.cpp:255
+#: ../src/html/htmprint.cpp:267
 msgid ""
 "This document doesn't fit on the page horizontally and will be truncated "
 "when it is printed."
 msgstr ""
 
-#: ../src/common/image.cpp:2854
+#: ../src/common/image.cpp:2963
 #, fuzzy, c-format
 msgid "This is not a %s."
 msgstr "PCX: tämä ei ole PCX tiedosto."
 
-#: ../src/common/wincmn.cpp:1653
+#: ../src/common/wincmn.cpp:1654
 msgid "This platform does not support background transparency."
 msgstr ""
 
-#: ../src/gtk/window.cpp:4660
+#: ../src/gtk/window.cpp:5664
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
 
-#: ../src/msw/thread.cpp:1240
+#: ../src/gtk/glcanvas.cpp:176
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/msw/thread.cpp:1246
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
 msgstr ""
 "Säiemoduulin käynnistys epäonnistui: arvoa ei voi tallentaa säikeen muistiin"
 
-#: ../src/unix/threadpsx.cpp:1794
+#: ../src/unix/threadpsx.cpp:1843
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr "Säiemoduulin käynnistys epäonnistui: säieavainta ei voi luoda"
 
-#: ../src/msw/thread.cpp:1228
+#: ../src/msw/thread.cpp:1234
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -7333,84 +7496,84 @@ msgstr ""
 "Säiemoduulin käynnistys epäonnistui: indeksin varaus säikeen muistiin "
 "mahdotonta"
 
-#: ../src/unix/threadpsx.cpp:1043
+#: ../src/unix/threadpsx.cpp:1061
 msgid "Thread priority setting is ignored."
 msgstr "Säikeen prioriteettiasetus jätetään huomiotta."
 
-#: ../src/msw/mdi.cpp:176
+#: ../src/msw/mdi.cpp:171
 msgid "Tile &Horizontally"
 msgstr "Järjestä &vaakasuoraan"
 
-#: ../src/msw/mdi.cpp:177
+#: ../src/msw/mdi.cpp:172
 msgid "Tile &Vertically"
 msgstr "Järjestä &pystysuoraan"
 
-#: ../src/common/ftp.cpp:200
+#: ../src/common/ftp.cpp:197
 msgid "Timeout while waiting for FTP server to connect, try passive mode."
 msgstr ""
 "Aikakatkaisu tapahtui yhteydenotossa FTP-palvelimeen, kokeile passiivista "
 "tilaa."
 
-#: ../src/generic/tipdlg.cpp:201
+#: ../src/generic/tipdlg.cpp:198
 msgid "Tip of the Day"
 msgstr "Päivän vihje"
 
-#: ../src/generic/tipdlg.cpp:140
+#: ../src/generic/tipdlg.cpp:137
 msgid "Tips not available, sorry!"
 msgstr "Valitettavasti vihjeitä ei ole!"
 
-#: ../src/generic/prntdlgg.cpp:242
+#: ../src/generic/prntdlgg.cpp:235
 msgid "To:"
 msgstr "Vastaanottaja:"
 
-#: ../src/richtext/richtextbuffer.cpp:8363
+#: ../src/richtext/richtextbuffer.cpp:8361
 msgid "Too many EndStyle calls!"
 msgstr "Liian monta EndStyle-kutsua!"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:891
+#: ../src/propgrid/advprops.cpp:792
 msgid "Tooltip"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:892
+#: ../src/propgrid/advprops.cpp:793
 msgid "TooltipText"
 msgstr ""
 
-#: ../src/richtext/richtextsizepage.cpp:286
-#: ../src/richtext/richtextsizepage.cpp:290 ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197 ../src/richtext/richtextsizepage.cpp:286
+#: ../src/richtext/richtextsizepage.cpp:290
 #, fuzzy
 msgid "Top"
 msgstr "Vastaanottaja:"
 
-#: ../src/generic/prntdlgg.cpp:881
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Top margin (mm):"
 msgstr "Ylämarginaali (mm):"
 
-#: ../src/generic/aboutdlgg.cpp:79
+#: ../src/generic/aboutdlgg.cpp:76
 msgid "Translations by "
 msgstr "Suomentajat:"
 
-#: ../src/generic/aboutdlgg.cpp:188
+#: ../src/generic/aboutdlgg.cpp:185
 msgid "Translators"
 msgstr "Suomentajat"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:211
+#: ../src/propgrid/propgrid.cpp:192
 msgid "True"
 msgstr "Tosi"
 
-#: ../src/common/fs_mem.cpp:227
+#: ../src/common/fs_mem.cpp:222
 #, c-format
 msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
 msgstr ""
 "Tiedosto ”%s” yritettiin poistaa Muisti-VFS:stä, mutta se ei ole ladattu!"
 
-#: ../src/common/fmapbase.cpp:156
+#: ../src/common/fmapbase.cpp:153
 msgid "Turkish (ISO-8859-9)"
 msgstr "turkki (ISO-8859-9)"
 
-#: ../src/generic/filectrlg.cpp:426
+#: ../src/generic/filectrlg.cpp:422
 msgid "Type"
 msgstr "Tyyppi"
 
@@ -7424,37 +7587,37 @@ msgstr "Anna kirjasimen nimi."
 msgid "Type a size in points."
 msgstr "Anna koko pisteinä."
 
-#: ../src/msw/ole/automtn.cpp:676
+#: ../src/msw/ole/automtn.cpp:667
 #, c-format
 msgid "Type mismatch in argument %u."
 msgstr ""
 
-#: ../src/common/xtixml.cpp:356 ../src/common/xtixml.cpp:509
-#: ../src/common/xtistrm.cpp:318
+#: ../src/common/xtixml.cpp:352 ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315
 msgid "Type must have enum - long conversion"
 msgstr ""
 
-#: ../src/propgrid/propgridiface.cpp:401
+#: ../src/propgrid/propgridiface.cpp:385
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
 "\"%s\"."
 msgstr ""
 
-#: ../src/common/paper.cpp:133
+#: ../src/common/paper.cpp:130
 #, fuzzy
 msgid "US Std Fanfold, 14 7/8 x 11 in"
 msgstr "Vakio traktoriveto, 14 7/8 x 11” "
 
-#: ../src/common/fmapbase.cpp:196
+#: ../src/common/fmapbase.cpp:193
 msgid "US-ASCII"
 msgstr "US-ASCII"
 
-#: ../src/unix/fswatcher_inotify.cpp:109
+#: ../src/unix/fswatcher_inotify.cpp:106
 msgid "Unable to add inotify watch"
 msgstr ""
 
-#: ../src/unix/fswatcher_kqueue.cpp:136
+#: ../src/unix/fswatcher_kqueue.cpp:153
 msgid "Unable to add kqueue watch"
 msgstr ""
 
@@ -7467,7 +7630,7 @@ msgstr ""
 msgid "Unable to close I/O completion port handle"
 msgstr "Tiedostokahvan sulkeminen epäonnistui"
 
-#: ../src/unix/fswatcher_inotify.cpp:97
+#: ../src/unix/fswatcher_inotify.cpp:94
 #, fuzzy
 msgid "Unable to close inotify instance"
 msgstr "Tiedostokahvan sulkeminen epäonnistui"
@@ -7487,17 +7650,17 @@ msgstr "Tiedostokahvan sulkeminen epäonnistui"
 msgid "Unable to create I/O completion port"
 msgstr "Osoittimen luonti epäonnistui."
 
-#: ../src/msw/fswatcher.cpp:84
+#: ../src/msw/fswatcher.cpp:81
 #, fuzzy
 msgid "Unable to create IOCP worker thread"
 msgstr "MDI-isäntäkehystä ei voitu luoda."
 
-#: ../src/unix/fswatcher_inotify.cpp:74
+#: ../src/unix/fswatcher_inotify.cpp:71
 #, fuzzy
 msgid "Unable to create inotify instance"
 msgstr "DDE-merkkijonoa ei voitu luoda"
 
-#: ../src/unix/fswatcher_kqueue.cpp:97
+#: ../src/unix/fswatcher_kqueue.cpp:114
 #, fuzzy
 msgid "Unable to create kqueue instance"
 msgstr "DDE-merkkijonoa ei voitu luoda"
@@ -7506,11 +7669,11 @@ msgstr "DDE-merkkijonoa ei voitu luoda"
 msgid "Unable to dequeue completion packet"
 msgstr ""
 
-#: ../src/unix/fswatcher_kqueue.cpp:185
+#: ../src/unix/fswatcher_kqueue.cpp:202
 msgid "Unable to get events from kqueue"
 msgstr ""
 
-#: ../src/gtk/app.cpp:435
+#: ../src/gtk/app.cpp:431
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr ""
 
@@ -7519,12 +7682,12 @@ msgstr ""
 msgid "Unable to open path '%s'"
 msgstr "CHM arkiston ”%s” avaaminen epäonnistui."
 
-#: ../src/html/htmlwin.cpp:583
+#: ../src/html/htmlwin.cpp:586
 #, c-format
 msgid "Unable to open requested HTML document: %s"
 msgstr "Vaadittua HTML-asiakirjaa ei voi avata: %s"
 
-#: ../src/unix/sound.cpp:368
+#: ../src/unix/sound.cpp:365
 msgid "Unable to play sound asynchronously."
 msgstr ""
 
@@ -7532,63 +7695,63 @@ msgstr ""
 msgid "Unable to post completion status"
 msgstr ""
 
-#: ../src/unix/fswatcher_inotify.cpp:556
+#: ../src/unix/fswatcher_inotify.cpp:553
 #, fuzzy
 msgid "Unable to read from inotify descriptor"
 msgstr "tiedoston kuvauksen %d luku epäonnistui"
 
-#: ../src/unix/fswatcher_inotify.cpp:141
+#: ../src/unix/fswatcher_inotify.cpp:138
 #, fuzzy, c-format
 msgid "Unable to remove inotify watch %i"
 msgstr "DDE-merkkijonoa ei voitu luoda"
 
-#: ../src/unix/fswatcher_kqueue.cpp:153
+#: ../src/unix/fswatcher_kqueue.cpp:170
 msgid "Unable to remove kqueue watch"
 msgstr ""
 
-#: ../src/msw/fswatcher.cpp:168
+#: ../src/msw/fswatcher.cpp:165
 #, fuzzy, c-format
 msgid "Unable to set up watch for '%s'"
 msgstr "Touch epäonnistui tiedostolle ”%s”"
 
-#: ../src/msw/fswatcher.cpp:91
+#: ../src/msw/fswatcher.cpp:88
 msgid "Unable to start IOCP worker thread"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:201
+#: ../src/common/stockitem.cpp:198
 msgid "Undelete"
 msgstr "Kumoa poisto"
 
-#: ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199
 #, fuzzy
 msgid "Underline"
 msgstr "&Alleviivaus"
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/richtext/richtextfontpage.cpp:359 ../src/osx/carbon/fontdlg.cpp:370
-#: ../src/propgrid/advprops.cpp:690
+#: ../src/osx/carbon/fontdlg.cpp:367 ../src/propgrid/advprops.cpp:600
+#: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Alleviivattu"
 
-#: ../src/common/stockitem.cpp:203 ../src/stc/stc_i18n.cpp:15
+#: ../src/common/stockitem.cpp:200 ../src/stc/stc_i18n.cpp:15
 msgid "Undo"
 msgstr "Kumoa"
 
-#: ../src/common/stockitem.cpp:265
+#: ../src/common/stockitem.cpp:263
 msgid "Undo last action"
 msgstr "Kumoa viimeisin toiminto"
 
-#: ../src/common/cmdline.cpp:1029
+#: ../src/common/cmdline.cpp:1025
 #, fuzzy, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Odottamaton parametri ”%s”"
 
-#: ../src/unix/fswatcher_inotify.cpp:274
+#: ../src/unix/fswatcher_inotify.cpp:271
 #, c-format
 msgid "Unexpected event for \"%s\": no matching watch descriptor."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1195
+#: ../src/common/cmdline.cpp:1191
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Odottamaton parametri ”%s”"
@@ -7597,50 +7760,50 @@ msgstr "Odottamaton parametri ”%s”"
 msgid "Unexpectedly new I/O completion port was created"
 msgstr ""
 
-#: ../src/msw/fswatcher.cpp:70
+#: ../src/msw/fswatcher.cpp:67
 #, fuzzy
 msgid "Ungraceful worker thread termination"
 msgstr "Ei voi odottaa säikeen keskeytystä"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:460
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:456
+#: ../src/richtext/richtextsymboldlg.cpp:457
+#: ../src/richtext/richtextsymboldlg.cpp:458
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../src/common/fmapbase.cpp:185 ../src/common/fmapbase.cpp:191
+#: ../src/common/fmapbase.cpp:182 ../src/common/fmapbase.cpp:188
 msgid "Unicode 16 bit (UTF-16)"
 msgstr "Unicode 16 bit (UTF-16)"
 
-#: ../src/common/fmapbase.cpp:190
+#: ../src/common/fmapbase.cpp:187
 msgid "Unicode 16 bit Big Endian (UTF-16BE)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:186
+#: ../src/common/fmapbase.cpp:183
 msgid "Unicode 16 bit Little Endian (UTF-16LE)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:187 ../src/common/fmapbase.cpp:193
+#: ../src/common/fmapbase.cpp:184 ../src/common/fmapbase.cpp:190
 msgid "Unicode 32 bit (UTF-32)"
 msgstr "Unicode 32 bit (UTF-32)"
 
-#: ../src/common/fmapbase.cpp:192
+#: ../src/common/fmapbase.cpp:189
 msgid "Unicode 32 bit Big Endian (UTF-32BE)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:188
+#: ../src/common/fmapbase.cpp:185
 msgid "Unicode 32 bit Little Endian (UTF-32LE)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:182
+#: ../src/common/fmapbase.cpp:179
 msgid "Unicode 7 bit (UTF-7)"
 msgstr "Unicode 7 bit (UTF-7)"
 
-#: ../src/common/fmapbase.cpp:183
+#: ../src/common/fmapbase.cpp:180
 msgid "Unicode 8 bit (UTF-8)"
 msgstr "Unicode 8 bit (UTF-8)"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 #, fuzzy
 msgid "Unindent"
 msgstr "&Vähennä sisennystä"
@@ -7802,100 +7965,105 @@ msgstr "Ei voi odottaa säikeen keskeytystä"
 msgid "Units for this value."
 msgstr "Ei voi odottaa säikeen keskeytystä"
 
-#: ../src/generic/progdlgg.cpp:353 ../src/generic/progdlgg.cpp:622
+#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
 msgid "Unknown"
 msgstr "Tuntematon"
 
-#: ../src/msw/dde.cpp:1174
+#: ../src/msw/dde.cpp:1238
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Tuntematon DDE-virhe %08x"
 
-#: ../src/common/xtistrm.cpp:410
+#: ../src/common/xtistrm.cpp:407
 msgid "Unknown Object passed to GetObjectClassInfo"
 msgstr ""
 
-#: ../src/common/imagpng.cpp:366
+#: ../src/common/imagpng.cpp:383
 #, fuzzy, c-format
 msgid "Unknown PNG resolution unit %d"
 msgstr "Tuntematon valitsin ”%s”"
 
-#: ../src/common/xtixml.cpp:327
+#: ../src/common/xtixml.cpp:323
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Tuntematon ominaisuus %s"
 
-#: ../src/common/imagtiff.cpp:529
+#: ../src/common/imagtiff.cpp:526
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr ""
 
-#: ../src/unix/dlunix.cpp:160
+#: ../src/propgrid/props.cpp:155
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/unix/dlunix.cpp:118
 msgid "Unknown dynamic library error"
 msgstr "Tuntematon dynamic library virhe"
 
-#: ../src/common/fmapbase.cpp:810
+#: ../src/common/fmapbase.cpp:806
 #, c-format
 msgid "Unknown encoding (%d)"
 msgstr "Tuntematon koodaus (%d)"
 
-#: ../src/msw/ole/automtn.cpp:688
+#: ../src/msw/ole/automtn.cpp:679
 #, fuzzy, c-format
 msgid "Unknown error %08x"
 msgstr "Tuntematon DDE-virhe %08x"
 
-#: ../src/msw/ole/automtn.cpp:647
+#: ../src/msw/ole/automtn.cpp:638
 #, fuzzy
 msgid "Unknown exception"
 msgstr "Tuntematon valitsin ”%s”"
 
-#: ../src/common/image.cpp:2839
+#: ../src/common/image.cpp:2942
 #, fuzzy
 msgid "Unknown image data format."
 msgstr "virhe dataformaatissa"
 
-#: ../src/common/cmdline.cpp:914
+#: ../src/common/cmdline.cpp:910
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Tuntematon pitkä valitsin ”%s”"
 
-#: ../src/msw/ole/automtn.cpp:631
+#: ../src/msw/ole/automtn.cpp:622
 msgid "Unknown name or named argument."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:929 ../src/common/cmdline.cpp:951
+#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Tuntematon valitsin ”%s”"
 
-#: ../src/common/mimecmn.cpp:225
+#: ../src/common/mimecmn.cpp:221
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "Pariton ”{” mime-tyyppi-merkinnässä %s."
 
-#: ../src/common/cmdproc.cpp:262 ../src/common/cmdproc.cpp:288
-#: ../src/common/cmdproc.cpp:308
+#: ../src/common/cmdproc.cpp:255 ../src/common/cmdproc.cpp:281
+#: ../src/common/cmdproc.cpp:301
 msgid "Unnamed command"
 msgstr "Nimeämätän komento"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:413
+#: ../src/propgrid/propgrid.cpp:392
 #, fuzzy
 msgid "Unspecified"
 msgstr "Tasattu"
 
-#: ../src/msw/clipbrd.cpp:311
+#: ../src/msw/clipbrd.cpp:325
 msgid "Unsupported clipboard format."
 msgstr "Leikepöydän muoto ei ole tuettu."
 
-#: ../src/common/appcmn.cpp:256
+#: ../src/common/appcmn.cpp:277
 #, c-format
 msgid "Unsupported theme '%s'."
 msgstr "Teemaa ”%s” ei tueta."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:205
-#: ../src/common/accelcmn.cpp:63
+#: ../src/common/stockitem.cpp:202 ../src/common/accelcmn.cpp:60
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Up"
 msgstr "Ylös"
 
@@ -7909,7 +8077,7 @@ msgstr "Suuraakkoskirjaimet"
 msgid "Upper case roman numerals"
 msgstr "Suurakkos romaaniset numeraalit"
 
-#: ../src/common/cmdline.cpp:1326
+#: ../src/common/cmdline.cpp:1322
 #, c-format
 msgid "Usage: %s"
 msgstr "Käyttö: %s"
@@ -7918,38 +8086,47 @@ msgstr "Käyttö: %s"
 msgid "Use &shadow"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:169
-#: ../src/richtext/richtextindentspage.cpp:171
 #: ../src/richtext/richtextliststylepage.cpp:358
 #: ../src/richtext/richtextliststylepage.cpp:360
+#: ../src/richtext/richtextindentspage.cpp:169
+#: ../src/richtext/richtextindentspage.cpp:171
 msgid "Use the current alignment setting."
 msgstr ""
 
-#: ../src/common/valtext.cpp:179
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/gtk/font.cpp:552
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/common/valtext.cpp:142
 msgid "Validation conflict"
 msgstr "Validointiristiriita"
 
-#: ../src/propgrid/manager.cpp:238
+#: ../src/propgrid/manager.cpp:224
 msgid "Value"
 msgstr ""
 
-#: ../src/propgrid/props.cpp:386 ../src/propgrid/props.cpp:500
+#: ../src/propgrid/props.cpp:309
 #, c-format
 msgid "Value must be %s or higher."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:417 ../src/propgrid/props.cpp:531
+#: ../src/propgrid/props.cpp:336
 #, c-format
 msgid "Value must be %s or less."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:393 ../src/propgrid/props.cpp:424
-#: ../src/propgrid/props.cpp:507 ../src/propgrid/props.cpp:538
+#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
 #, fuzzy, c-format
 msgid "Value must be between %s and %s."
 msgstr "Anna sivunumero väliltä %d ja %d:"
 
-#: ../src/generic/aboutdlgg.cpp:128
+#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
 #, fuzzy
 msgid "Version "
 msgstr "Versio %s"
@@ -7960,25 +8137,32 @@ msgstr "Versio %s"
 msgid "Vertical alignment."
 msgstr "Tasausta ei voitu asettaa."
 
-#: ../src/generic/filedlgg.cpp:202
+#: ../src/generic/filedlgg.cpp:199
 msgid "View files as a detailed view"
 msgstr "Näytä tiedostot lisätiedoilla"
 
-#: ../src/generic/filedlgg.cpp:200
+#: ../src/generic/filedlgg.cpp:197
 msgid "View files as a list view"
 msgstr "Näytä tiedostot luettelona"
 
-#: ../src/common/docview.cpp:1970
+#: ../src/common/docview.cpp:1975
 msgid "Views"
 msgstr "Näkymät"
 
+#: ../src/gtk/app.cpp:348
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1777
+#: ../src/propgrid/advprops.cpp:1678
 msgid "Wait"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1779
+#: ../src/propgrid/advprops.cpp:1680
 msgid "Wait Arrow"
 msgstr ""
 
@@ -7987,250 +8171,246 @@ msgstr ""
 msgid "Waiting for IO on epoll descriptor %d failed"
 msgstr "Aliprosessin keskeytymisen odotus epäonnistui"
 
-#: ../src/common/log.cpp:223
+#: ../src/common/log.cpp:241
 msgid "Warning: "
 msgstr "Varoitus: "
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1778
+#: ../src/propgrid/advprops.cpp:1679
 msgid "Watch"
 msgstr ""
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:685
+#: ../src/propgrid/advprops.cpp:595
 msgid "Weight"
 msgstr "Paino"
 
-#: ../src/common/fmapbase.cpp:148
+#: ../src/common/fmapbase.cpp:145
 msgid "Western European (ISO-8859-1)"
 msgstr "Länsi-Eurooppa (ISO-8859-1/Latin 1)"
 
-#: ../src/common/fmapbase.cpp:162
+#: ../src/common/fmapbase.cpp:159
 msgid "Western European with Euro (ISO-8859-15)"
 msgstr "Länsieurooppalainen euro:lla (ISO-8859-15)"
 
-#: ../src/generic/fontdlgg.cpp:446 ../src/generic/fontdlgg.cpp:448
+#: ../src/generic/fontdlgg.cpp:443 ../src/generic/fontdlgg.cpp:445
 msgid "Whether the font is underlined."
 msgstr "Onko kirjasin alleviivattu."
 
-#: ../src/propgrid/advprops.cpp:1611
+#: ../src/propgrid/advprops.cpp:1517
 msgid "White"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:144
+#: ../src/generic/fdrepdlg.cpp:141
 msgid "Whole word"
 msgstr "Vain kokonaiset sanat"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:532
 msgid "Whole words only"
 msgstr "Vain kokonaiset sanat"
 
-#: ../src/univ/themes/win32.cpp:1102
+#: ../src/univ/themes/win32.cpp:1099
 msgid "Win32 theme"
 msgstr "Win32-teema"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:893
+#: ../src/propgrid/advprops.cpp:794
 #, fuzzy
 msgid "Window"
 msgstr "&Ikkuna"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:894
+#: ../src/propgrid/advprops.cpp:795
 #, fuzzy
 msgid "WindowFrame"
 msgstr "&Ikkuna"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:895
+#: ../src/propgrid/advprops.cpp:796
 #, fuzzy
 msgid "WindowText"
 msgstr "&Ikkuna"
 
-#: ../src/common/fmapbase.cpp:177
+#: ../src/common/fmapbase.cpp:174
 msgid "Windows Arabic (CP 1256)"
 msgstr "Windows, arabia (CP 1256)"
 
-#: ../src/common/fmapbase.cpp:178
+#: ../src/common/fmapbase.cpp:175
 msgid "Windows Baltic (CP 1257)"
 msgstr "Windows baltialainen (CP 1257)"
 
-#: ../src/common/fmapbase.cpp:171
+#: ../src/common/fmapbase.cpp:168
 msgid "Windows Central European (CP 1250)"
 msgstr "Windows, Keski-Eurooppa (CP 1250)"
 
-#: ../src/common/fmapbase.cpp:168
+#: ../src/common/fmapbase.cpp:165
 msgid "Windows Chinese Simplified (CP 936) or GB-2312"
 msgstr "Windows yksinkertaistettu kiina (CP 936) tai GB-2312"
 
-#: ../src/common/fmapbase.cpp:170
+#: ../src/common/fmapbase.cpp:167
 msgid "Windows Chinese Traditional (CP 950) or Big-5"
 msgstr "Windows kiinalainen perinteinen (CP 950) tai Big-5"
 
-#: ../src/common/fmapbase.cpp:172
+#: ../src/common/fmapbase.cpp:169
 msgid "Windows Cyrillic (CP 1251)"
 msgstr "Windows, kyrillinen (CP 1251)"
 
-#: ../src/common/fmapbase.cpp:174
+#: ../src/common/fmapbase.cpp:171
 msgid "Windows Greek (CP 1253)"
 msgstr "Windows, kreikka (CP 1253)"
 
-#: ../src/common/fmapbase.cpp:176
+#: ../src/common/fmapbase.cpp:173
 msgid "Windows Hebrew (CP 1255)"
 msgstr "Windows, heprea (CP 1255)"
 
-#: ../src/common/fmapbase.cpp:167
+#: ../src/common/fmapbase.cpp:164
 msgid "Windows Japanese (CP 932) or Shift-JIS"
 msgstr "Windows japanilainen (CP 932) tai Shift-JIS"
 
-#: ../src/common/fmapbase.cpp:180
+#: ../src/common/fmapbase.cpp:177
 #, fuzzy
 msgid "Windows Johab (CP 1361)"
 msgstr "Windows, arabia (CP 1256)"
 
-#: ../src/common/fmapbase.cpp:169
+#: ../src/common/fmapbase.cpp:166
 msgid "Windows Korean (CP 949)"
 msgstr "Windows, korea (CP 949)"
 
-#: ../src/common/fmapbase.cpp:166
+#: ../src/common/fmapbase.cpp:163
 msgid "Windows Thai (CP 874)"
 msgstr "Windows thai (CP 874)"
 
-#: ../src/common/fmapbase.cpp:175
+#: ../src/common/fmapbase.cpp:172
 msgid "Windows Turkish (CP 1254)"
 msgstr "Windows, turkki (CP 1254)"
 
-#: ../src/common/fmapbase.cpp:179
+#: ../src/common/fmapbase.cpp:176
 #, fuzzy
 msgid "Windows Vietnamese (CP 1258)"
 msgstr "Windows, kreikka (CP 1253)"
 
-#: ../src/common/fmapbase.cpp:173
+#: ../src/common/fmapbase.cpp:170
 msgid "Windows Western European (CP 1252)"
 msgstr "Windows, Länsi-Eurooppa (CP 1252)"
 
-#: ../src/common/fmapbase.cpp:181
+#: ../src/common/fmapbase.cpp:178
 msgid "Windows/DOS OEM (CP 437)"
 msgstr "Windows/DOS OEM (CP 437)"
 
-#: ../src/common/fmapbase.cpp:165
+#: ../src/common/fmapbase.cpp:162
 msgid "Windows/DOS OEM Cyrillic (CP 866)"
 msgstr "Windows/DOS OEM kyrillinen (CP 866)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:111
+#: ../src/common/accelcmn.cpp:109
 #, fuzzy
 msgid "Windows_Left"
 msgstr "Windows 7"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:113
+#: ../src/common/accelcmn.cpp:111
 #, fuzzy
 msgid "Windows_Menu"
 msgstr "Windows ME"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:112
+#: ../src/common/accelcmn.cpp:110
 #, fuzzy
 msgid "Windows_Right"
 msgstr "Windows Vista"
 
-#: ../src/common/ffile.cpp:150
+#: ../src/common/ffile.cpp:149
 #, c-format
 msgid "Write error on file '%s'"
 msgstr "Tiedostoon ”%s” ei voi kirjoittaa"
 
-#: ../src/xml/xml.cpp:914
+#: ../src/xml/xml.cpp:925
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "XML-jäsennysvirhe: ”%s” rivillä %d"
 
-#: ../src/common/xpmdecod.cpp:796
+#: ../src/common/xpmdecod.cpp:794
 msgid "XPM: Malformed pixel data!"
 msgstr "XPM: virheellinen pikselitieto"
 
-#: ../src/common/xpmdecod.cpp:705
+#: ../src/common/xpmdecod.cpp:702
 #, c-format
 msgid "XPM: incorrect colour description in line %d"
 msgstr "XPM: virheellinen värikuvaus rivillä %d"
 
-#: ../src/common/xpmdecod.cpp:680
+#: ../src/common/xpmdecod.cpp:677
 msgid "XPM: incorrect header format!"
 msgstr "XPM: virheellinen otsikkomuoto"
 
-#: ../src/common/xpmdecod.cpp:716 ../src/common/xpmdecod.cpp:725
+#: ../src/common/xpmdecod.cpp:714 ../src/common/xpmdecod.cpp:723
 #, c-format
 msgid "XPM: malformed colour definition '%s' at line %d!"
 msgstr "XPM: virheellinen värimääritys ”%s” rivillä %d!"
 
-#: ../src/common/xpmdecod.cpp:755
+#: ../src/common/xpmdecod.cpp:753
 msgid "XPM: no colors left to use for mask!"
 msgstr "XPM: värejä ei ole jäljellä maskin käytettäväksi"
 
-#: ../src/common/xpmdecod.cpp:782
+#: ../src/common/xpmdecod.cpp:780
 #, c-format
 msgid "XPM: truncated image data at line %d!"
 msgstr "XPM: katkennut kuvatieto rivillä %d"
 
-#: ../src/propgrid/advprops.cpp:1610
+#: ../src/propgrid/advprops.cpp:1516
 msgid "Yellow"
 msgstr ""
 
-#: ../include/wx/msgdlg.h:276 ../src/common/stockitem.cpp:206
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:203
 #: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Kyllä"
 
-#: ../src/osx/carbon/overlay.cpp:155
-#, fuzzy
-msgid "You cannot Clear an overlay that is not inited"
-msgstr "Et voi lisätä uutta hakemistoa tähän kohtaan."
-
-#: ../src/osx/carbon/overlay.cpp:107 ../src/dfb/overlay.cpp:61
-msgid "You cannot Init an overlay twice"
-msgstr ""
-
-#: ../src/generic/dirdlgg.cpp:287
+#: ../src/generic/dirdlgg.cpp:284
 msgid "You cannot add a new directory to this section."
 msgstr "Et voi lisätä uutta hakemistoa tähän kohtaan."
 
-#: ../src/propgrid/propgrid.cpp:3299
+#: ../src/propgrid/propgrid.cpp:3276
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:209
+#: ../src/osx/cocoa/menu.mm:286
+#, fuzzy
+msgid "Zoom"
+msgstr "&Lähennä"
+
+#: ../src/common/stockitem.cpp:206
 msgid "Zoom &In"
 msgstr "&Lähennä"
 
-#: ../src/common/stockitem.cpp:210
+#: ../src/common/stockitem.cpp:207
 msgid "Zoom &Out"
 msgstr "Lo&itonna"
 
-#: ../src/common/stockitem.cpp:209 ../src/common/prntbase.cpp:1594
+#: ../src/common/stockitem.cpp:206 ../src/common/prntbase.cpp:1619
 #, fuzzy
 msgid "Zoom In"
 msgstr "&Lähennä"
 
-#: ../src/common/stockitem.cpp:210 ../src/common/prntbase.cpp:1580
+#: ../src/common/stockitem.cpp:207 ../src/common/prntbase.cpp:1605
 #, fuzzy
 msgid "Zoom Out"
 msgstr "Lo&itonna"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to &Fit"
 msgstr "&Sovita"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 #, fuzzy
 msgid "Zoom to Fit"
 msgstr "&Sovita"
 
-#: ../src/msw/dde.cpp:1141
+#: ../src/msw/dde.cpp:1205
 #, fuzzy
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "DDEML-sovellus on luonut pitkän kilpailutilanteen."
 
-#: ../src/msw/dde.cpp:1129
+#: ../src/msw/dde.cpp:1193
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -8240,41 +8420,41 @@ msgstr ""
 "DDEML funktio kutsuttiin ilman edeltävää DDE-initialisointia, \n"
 "tai epäkelpo instanssin tunniste annetiin DDEML funktiolle."
 
-#: ../src/msw/dde.cpp:1147
+#: ../src/msw/dde.cpp:1211
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "asiakkaan yritys aloittaa keskustelu epäonnistui."
 
-#: ../src/msw/dde.cpp:1144
+#: ../src/msw/dde.cpp:1208
 msgid "a memory allocation failed."
 msgstr "muistin varaus epäonnistui."
 
-#: ../src/msw/dde.cpp:1138
+#: ../src/msw/dde.cpp:1202
 #, fuzzy
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "DDEML ei voinut varmistaa parametria."
 
-#: ../src/msw/dde.cpp:1120
+#: ../src/msw/dde.cpp:1184
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "synkronisen ohjeistustapahtuman pyynnön sallittu aika ylittyi."
 
-#: ../src/msw/dde.cpp:1126
+#: ../src/msw/dde.cpp:1190
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "synkronisen datasiirron pyynnön sallittu aika ylittyi."
 
-#: ../src/msw/dde.cpp:1135
+#: ../src/msw/dde.cpp:1199
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "synkronisen ohjelmapyynnön sallittu aika ylittyi."
 
-#: ../src/msw/dde.cpp:1153
+#: ../src/msw/dde.cpp:1217
 #, fuzzy
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "synkronisen datakirjoitustapahtuman pyynnön sallittu aika ylittyi."
 
-#: ../src/msw/dde.cpp:1168
+#: ../src/msw/dde.cpp:1232
 msgid "a request to end an advise transaction has timed out."
 msgstr "ohjeistustapahtuman lopettamisen pyynnön sallittu aika ylittyi."
 
-#: ../src/msw/dde.cpp:1162
+#: ../src/msw/dde.cpp:1226
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -8284,15 +8464,15 @@ msgstr ""
 "joka pysäytettiin asiakkaan taholla, tai palvelin\n"
 "keskeytti ennen tapahtuman valmistumista."
 
-#: ../src/msw/dde.cpp:1150
+#: ../src/msw/dde.cpp:1214
 msgid "a transaction failed."
 msgstr "tapahtuma epäonnistui."
 
-#: ../src/common/accelcmn.cpp:189
+#: ../src/common/accelcmn.cpp:188
 msgid "alt"
 msgstr "alt"
 
-#: ../src/msw/dde.cpp:1132
+#: ../src/msw/dde.cpp:1196
 #, fuzzy
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
@@ -8304,15 +8484,15 @@ msgstr ""
 "tehdä DDE tapahtuman tai APPCMD_CLIENTONLY on yrittänyt \n"
 "tehdä palvelimen tapahtuman."
 
-#: ../src/msw/dde.cpp:1156
+#: ../src/msw/dde.cpp:1220
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "sisäinen kutsu ”PostMessage”-funktion epäonnistui. "
 
-#: ../src/msw/dde.cpp:1165
+#: ../src/msw/dde.cpp:1229
 msgid "an internal error has occurred in the DDEML."
 msgstr "sisäinen virhe tapahtui DDEML:ssä."
 
-#: ../src/msw/dde.cpp:1171
+#: ../src/msw/dde.cpp:1235
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -8322,56 +8502,56 @@ msgstr ""
 "Kun sovellus on palannut XTYP_XACT_COMPLETE vastakutsusta, \n"
 "tapahtuman tunnus tälle vastakutsulle ei päde enää."
 
-#: ../src/common/zipstrm.cpp:1483
+#: ../src/common/zipstrm.cpp:1522
 msgid "assuming this is a multi-part zip concatenated"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1847
+#: ../src/common/fileconf.cpp:1849
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "muuttumattoman avaimen ”%s” muutosyritys ohitettu."
 
-#: ../src/html/chm.cpp:329
+#: ../src/html/chm.cpp:326
 msgid "bad arguments to library function"
 msgstr "virheelliset argumentit kirjastofunktioon"
 
-#: ../src/html/chm.cpp:341
+#: ../src/html/chm.cpp:338
 msgid "bad signature"
 msgstr "väärä allekirjoitus"
 
-#: ../src/common/zipstrm.cpp:1918
+#: ../src/common/zipstrm.cpp:1988
 msgid "bad zipfile offset to entry"
 msgstr ""
 
-#: ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400
 msgid "binary"
 msgstr "binääri"
 
-#: ../src/common/fontcmn.cpp:996
+#: ../src/common/fontcmn.cpp:1195
 msgid "bold"
 msgstr "lihavoitu"
 
-#: ../src/msw/utils.cpp:1144
+#: ../src/msw/utils.cpp:1135
 #, c-format
 msgid "build %lu"
 msgstr "käännös %lu"
 
-#: ../src/common/ffile.cpp:75
+#: ../src/common/ffile.cpp:73
 #, c-format
 msgid "can't close file '%s'"
 msgstr "tiedostoa ”%s” ei voi sulkea"
 
-#: ../src/common/file.cpp:245
+#: ../src/common/file.cpp:242
 #, c-format
 msgid "can't close file descriptor %d"
 msgstr "tiedoston kuvaajaa %d ei voida sulkea"
 
-#: ../src/common/file.cpp:586
+#: ../src/common/ffile.cpp:382 ../src/common/file.cpp:613
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "ei voi toimittaa muutoksia tiedostoon ”%s”"
 
-#: ../src/common/file.cpp:178
+#: ../src/common/file.cpp:175
 #, c-format
 msgid "can't create file '%s'"
 msgstr "tiedoston ”%s” luonti ei onnistu"
@@ -8381,49 +8561,49 @@ msgstr "tiedoston ”%s” luonti ei onnistu"
 msgid "can't delete user configuration file '%s'"
 msgstr "käyttäjän asetustiedostoa ”%s” ei voi poistaa"
 
-#: ../src/common/file.cpp:495
+#: ../src/common/file.cpp:522
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr "ei voida päätellä tuliko kuvaajan %d loppu vastaan"
 
-#: ../src/common/zipstrm.cpp:1692
+#: ../src/common/zipstrm.cpp:1747
 msgid "can't find central directory in zip"
 msgstr ""
 
-#: ../src/common/file.cpp:465
+#: ../src/common/file.cpp:492
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "tiedoston koko ei löydy tiedoston kuvauksesta %d"
 
-#: ../src/msw/utils.cpp:341
+#: ../src/msw/utils.cpp:336
 msgid "can't find user's HOME, using current directory."
 msgstr "käyttäjän kotihakemistoa ei löydy, käytetään nykyistä hakemistoa."
 
-#: ../src/common/file.cpp:366
+#: ../src/common/file.cpp:407
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "tiedoston kuvausta %d ei voida tyhjentää"
 
-#: ../src/common/file.cpp:422
+#: ../src/common/file.cpp:463
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "paikanmääritys tiedoston kuvauksessa %d ei onnistu"
 
-#: ../src/common/fontmap.cpp:325
+#: ../src/common/fontmap.cpp:322
 msgid "can't load any font, aborting"
 msgstr "ei voi ladata yhtäkään fonttia, lopetetaan"
 
-#: ../src/common/file.cpp:231 ../src/common/ffile.cpp:59
+#: ../src/common/ffile.cpp:57 ../src/common/file.cpp:228
 #, c-format
 msgid "can't open file '%s'"
 msgstr "tiedostoa ”%s” ei voi avata"
 
-#: ../src/common/fileconf.cpp:320
+#: ../src/common/fileconf.cpp:314
 #, c-format
 msgid "can't open global configuration file '%s'."
 msgstr "globaalin asetustiedoston ”%s” avaus ei onnistu."
 
-#: ../src/common/fileconf.cpp:336
+#: ../src/common/fileconf.cpp:330
 #, c-format
 msgid "can't open user configuration file '%s'."
 msgstr "käyttäjän asetustiedoston ”%s” avaus ei onnistu."
@@ -8432,40 +8612,40 @@ msgstr "käyttäjän asetustiedoston ”%s” avaus ei onnistu."
 msgid "can't open user configuration file."
 msgstr "käyttäjän asetustiedoston avaus ei onnistu."
 
-#: ../src/common/zipstrm.cpp:579
+#: ../src/common/zipstrm.cpp:572
 msgid "can't re-initialize zlib deflate stream"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:604
+#: ../src/common/zipstrm.cpp:597
 msgid "can't re-initialize zlib inflate stream"
 msgstr ""
 
-#: ../src/common/file.cpp:304
+#: ../src/common/file.cpp:345
 #, c-format
 msgid "can't read from file descriptor %d"
 msgstr "tiedoston kuvauksen %d luku epäonnistui"
 
-#: ../src/common/file.cpp:581
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:608
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "tiedostoa ”%s” ei voi poistaa"
 
-#: ../src/common/file.cpp:598
+#: ../src/common/ffile.cpp:394 ../src/common/file.cpp:625
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "väliaikaistiedostoa ”%s” ei voi poistaa"
 
-#: ../src/common/file.cpp:408
+#: ../src/common/file.cpp:449
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr ""
 
-#: ../src/common/textfile.cpp:273
+#: ../src/common/textfile.cpp:161
 #, c-format
 msgid "can't write buffer '%s' to disk."
 msgstr "puskuria ”%s” ei voida kirjoittaa levylle."
 
-#: ../src/common/file.cpp:323
+#: ../src/common/file.cpp:364
 #, c-format
 msgid "can't write to file descriptor %d"
 msgstr "kirjoittaminen epäonnistui tiedoston kuvaukseen %d"
@@ -8475,22 +8655,28 @@ msgid "can't write user configuration file."
 msgstr "käyttäjän asetustiedoston kirjoitus epäonnistui."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:482 ../src/generic/datavgen.cpp:1261
+#: ../src/common/datavcmn.cpp:2064 ../src/generic/datavgen.cpp:1384
 msgid "checked"
 msgstr ""
 
-#: ../src/html/chm.cpp:345
+#: ../src/html/chm.cpp:342
 msgid "checksum error"
 msgstr "tarkistussummavirhe"
 
-#: ../src/common/tarstrm.cpp:820
+#: ../src/common/tarstrm.cpp:814
 msgid "checksum failure reading tar header block"
 msgstr ""
 
-#: ../src/richtext/richtextbackgroundpage.cpp:226
-#: ../src/richtext/richtextbackgroundpage.cpp:249
-#: ../src/richtext/richtextbackgroundpage.cpp:289
-#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
 #: ../src/richtext/richtextborderspage.cpp:254
 #: ../src/richtext/richtextborderspage.cpp:288
 #: ../src/richtext/richtextborderspage.cpp:322
@@ -8508,105 +8694,128 @@ msgstr ""
 #: ../src/richtext/richtextmarginspage.cpp:340
 #: ../src/richtext/richtextmarginspage.cpp:363
 #: ../src/richtext/richtextmarginspage.cpp:388
-#: ../src/richtext/richtextsizepage.cpp:339
-#: ../src/richtext/richtextsizepage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:400
-#: ../src/richtext/richtextsizepage.cpp:427
-#: ../src/richtext/richtextsizepage.cpp:454
-#: ../src/richtext/richtextsizepage.cpp:481
-#: ../src/richtext/richtextsizepage.cpp:555
-#: ../src/richtext/richtextsizepage.cpp:590
-#: ../src/richtext/richtextsizepage.cpp:625
-#: ../src/richtext/richtextsizepage.cpp:660
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
 msgid "cm"
 msgstr ""
 
-#: ../src/html/chm.cpp:347
+#: ../src/html/chm.cpp:344
 msgid "compression error"
 msgstr "pakkausvirhe"
 
-#: ../src/common/regex.cpp:236
+#: ../src/common/regex.cpp:233
 msgid "conversion to 8-bit encoding failed"
 msgstr "muunnos 8-bittiseksi koodaukseksi epäonnistui"
 
-#: ../src/common/accelcmn.cpp:187
+#: ../src/common/accelcmn.cpp:186
 msgid "ctrl"
 msgstr "ctrl"
 
-#: ../src/common/cmdline.cpp:1500
+#: ../src/common/cmdline.cpp:1496
 msgid "date"
 msgstr "päiväys"
 
-#: ../src/html/chm.cpp:349
+#: ../src/html/chm.cpp:346
 msgid "decompression error"
 msgstr "purkamisvirhe"
 
-#: ../src/richtext/richtextstyles.cpp:780 ../src/common/fmapbase.cpp:820
+#: ../src/common/fmapbase.cpp:816 ../src/richtext/richtextstyles.cpp:777
 msgid "default"
 msgstr "oletus"
 
-#: ../src/common/cmdline.cpp:1496
+#: ../src/common/cmdline.cpp:1492
 msgid "double"
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:538
+#: ../src/common/debugrpt.cpp:539
 msgid "dump of the process state (binary)"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1969
+#: ../src/common/datetimefmt.cpp:1992
 msgid "eighteenth"
 msgstr "kahdeksastoista"
 
-#: ../src/common/datetimefmt.cpp:1959
+#: ../src/common/datetimefmt.cpp:1982
 msgid "eighth"
 msgstr "kahdeksas"
 
-#: ../src/common/datetimefmt.cpp:1962
+#: ../src/common/datetimefmt.cpp:1985
 msgid "eleventh"
 msgstr "yhdestoista"
 
-#: ../src/common/fileconf.cpp:1833
+#: ../src/common/fileconf.cpp:1835
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "kohta ”%s” ilmenee useammin kuin kerran ryhmässä ”%s”"
 
-#: ../src/html/chm.cpp:343
+#: ../src/html/chm.cpp:340
 msgid "error in data format"
 msgstr "virhe dataformaatissa"
 
-#: ../src/html/chm.cpp:331
+#: ../src/html/chm.cpp:328
 msgid "error opening file"
 msgstr "virhe avattaessa tiedostoa"
 
-#: ../src/common/zipstrm.cpp:1778
+#: ../src/common/zipstrm.cpp:1836
 msgid "error reading zip central directory"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1870
+#: ../src/common/zipstrm.cpp:1940
 msgid "error reading zip local header"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2531
+#: ../src/common/zipstrm.cpp:2615
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr ""
 
-#: ../src/common/ffile.cpp:188
+#: ../src/common/zipstrm.cpp:2608
+#, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1205
+#, fuzzy
+msgid "extrabold"
+msgstr "lihavoitu"
+
+#: ../src/common/fontcmn.cpp:1223
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1167
+#, fuzzy
+msgid "extralight"
+msgstr "heikko"
+
+#: ../src/msw/webview_ie.cpp:1036
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "Ei voitu ajaa kohdetta ”%s”\n"
+
+#: ../src/common/ffile.cpp:187
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "tiedostoa ”%s” ei voitu kirjoittaa"
 
+#: ../src/msw/webview_ie.cpp:1045
+#, fuzzy
+msgid "failed to retrieve execution result"
+msgstr "RAS-virheilmoitusta ei saatu."
+
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1030
+#: ../src/generic/datavgen.cpp:1150
 #, fuzzy
 msgid "false"
 msgstr "Tiedosto"
 
-#: ../src/common/datetimefmt.cpp:1966
+#: ../src/common/datetimefmt.cpp:1989
 msgid "fifteenth"
 msgstr "viidestoista"
 
-#: ../src/common/datetimefmt.cpp:1956
+#: ../src/common/datetimefmt.cpp:1979
 msgid "fifth"
 msgstr "viides"
 
@@ -8635,131 +8844,150 @@ msgstr "tiedosto ”%s”, rivi %d: muuttamattoman avaimen ”%s” arvo ohitett
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "tiedosto ”%s”: odottamaton merkki %c rivillä %d."
 
-#: ../src/richtext/richtextbuffer.cpp:8738
+#: ../src/richtext/richtextbuffer.cpp:8736
 msgid "files"
 msgstr "tiedostot"
 
-#: ../src/common/datetimefmt.cpp:1952
+#: ../src/common/datetimefmt.cpp:1975
 msgid "first"
 msgstr "ensimmäinen"
 
-#: ../src/html/helpwnd.cpp:1252
+#: ../src/html/helpwnd.cpp:1250
 msgid "font size"
 msgstr "kirjasinkoko"
 
-#: ../src/common/datetimefmt.cpp:1965
+#: ../src/common/datetimefmt.cpp:1988
 msgid "fourteenth"
 msgstr "neljästoista"
 
-#: ../src/common/datetimefmt.cpp:1955
+#: ../src/common/datetimefmt.cpp:1978
 msgid "fourth"
 msgstr "neljäs"
 
-#: ../src/common/appbase.cpp:783
+#: ../src/common/appbase.cpp:784
 msgid "generate verbose log messages"
 msgstr "luo yksityiskohtaiset lokiviestit"
 
-#: ../src/richtext/richtextbuffer.cpp:13138
-#: ../src/richtext/richtextbuffer.cpp:13248
+#: ../src/common/fontcmn.cpp:1215
+msgid "heavy"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:13133
+#: ../src/richtext/richtextbuffer.cpp:13243
 msgid "image"
 msgstr "kuva"
 
-#: ../src/common/tarstrm.cpp:796
+#: ../src/common/tarstrm.cpp:790
 msgid "incomplete header block in tar"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:489
+#: ../src/common/xtixml.cpp:485
 msgid "incorrect event handler string, missing dot"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:1381
+#: ../src/common/tarstrm.cpp:1375
 msgid "incorrect size given for tar entry"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:993
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:987
 msgid "invalid data in extended tar header"
 msgstr ""
 
-#: ../src/generic/logg.cpp:1030
+#: ../src/generic/logg.cpp:1027
 msgid "invalid message box return value"
 msgstr "virheellinen viestilaatikon (message box) palautusarvo"
 
-#: ../src/common/zipstrm.cpp:1647
+#: ../src/common/zipstrm.cpp:1688
 msgid "invalid zip file"
 msgstr "virheellinen zip-tiedosto"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:1228
 msgid "italic"
 msgstr "kursivoitu"
 
-#: ../src/common/fontcmn.cpp:991
+#: ../src/common/webrequest_curl.cpp:374
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "Sarakkeen kuvausta ei voitu alustaa."
+
+#: ../src/common/fontcmn.cpp:1172
 msgid "light"
 msgstr "heikko"
 
-#: ../src/common/intl.cpp:303
-#, c-format
-msgid "locale '%s' cannot be set."
-msgstr "maa-arvoa ”%s” ei voida asettaa."
+#: ../src/common/fontcmn.cpp:1185
+msgid "medium"
+msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2125
+#: ../src/common/datetimefmt.cpp:2148
 msgid "midnight"
 msgstr "keskiyö"
 
-#: ../src/common/datetimefmt.cpp:1970
+#: ../src/common/datetimefmt.cpp:1993
 msgid "nineteenth"
 msgstr "yhdeksästoista"
 
-#: ../src/common/datetimefmt.cpp:1960
+#: ../src/common/datetimefmt.cpp:1983
 msgid "ninth"
 msgstr "yhdeksäs"
 
-#: ../src/msw/dde.cpp:1116
+#: ../src/msw/dde.cpp:1180
 msgid "no DDE error."
 msgstr "ei DDE-virhettä."
 
-#: ../src/html/chm.cpp:327
+#: ../src/html/chm.cpp:324
 msgid "no error"
 msgstr "ei virhettä"
 
-#: ../src/dfb/fontmgr.cpp:174
+#: ../src/dfb/fontmgr.cpp:171
 #, c-format
 msgid "no fonts found in %s, using builtin font"
 msgstr "Kirjasimia ei löytynyt kohteesta %s, käytetään sisäänrakennettua"
 
-#: ../src/html/helpdata.cpp:657
+#: ../src/html/helpdata.cpp:650
 msgid "noname"
 msgstr "nimeämätön"
 
-#: ../src/common/datetimefmt.cpp:2124
+#: ../src/common/datetimefmt.cpp:2147
 msgid "noon"
 msgstr "keskipäivä"
 
-#: ../src/richtext/richtextstyles.cpp:779
+#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "tavallinen"
 
-#: ../src/common/cmdline.cpp:1492
+#: ../src/common/cmdline.cpp:1488
 msgid "num"
 msgstr "num."
 
-#: ../src/common/xtixml.cpp:259
+#: ../src/common/accelcmn.cpp:194
+msgid "num "
+msgstr ""
+
+#: ../src/common/xtixml.cpp:255
 msgid "objects cannot have XML Text Nodes"
 msgstr "Objekteilla ei voi olla XML-tekstisolmuja"
 
-#: ../src/html/chm.cpp:339
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
 msgid "out of memory"
 msgstr "muisti loppu"
 
-#: ../src/common/debugrpt.cpp:514
+#: ../src/common/debugrpt.cpp:515
 msgid "process context description"
 msgstr ""
 
-#: ../src/richtext/richtextbackgroundpage.cpp:227
-#: ../src/richtext/richtextbackgroundpage.cpp:250
-#: ../src/richtext/richtextbackgroundpage.cpp:290
-#: ../src/richtext/richtextbackgroundpage.cpp:317
-#: ../src/richtext/richtextfontpage.cpp:177
-#: ../src/richtext/richtextfontpage.cpp:180
 #: ../src/richtext/richtextborderspage.cpp:255
 #: ../src/richtext/richtextborderspage.cpp:289
 #: ../src/richtext/richtextborderspage.cpp:323
@@ -8769,22 +8997,45 @@ msgstr ""
 #: ../src/richtext/richtextborderspage.cpp:491
 #: ../src/richtext/richtextborderspage.cpp:525
 #: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextfontpage.cpp:180
 msgid "pt"
 msgstr ""
 
-#: ../src/richtext/richtextbackgroundpage.cpp:225
-#: ../src/richtext/richtextbackgroundpage.cpp:228
-#: ../src/richtext/richtextbackgroundpage.cpp:229
-#: ../src/richtext/richtextbackgroundpage.cpp:248
-#: ../src/richtext/richtextbackgroundpage.cpp:251
-#: ../src/richtext/richtextbackgroundpage.cpp:252
-#: ../src/richtext/richtextbackgroundpage.cpp:288
-#: ../src/richtext/richtextbackgroundpage.cpp:291
-#: ../src/richtext/richtextbackgroundpage.cpp:292
-#: ../src/richtext/richtextbackgroundpage.cpp:315
-#: ../src/richtext/richtextbackgroundpage.cpp:318
-#: ../src/richtext/richtextbackgroundpage.cpp:319
-#: ../src/richtext/richtextfontpage.cpp:178
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:659
+#: ../src/richtext/richtextsizepage.cpp:662
+#: ../src/richtext/richtextsizepage.cpp:663
 #: ../src/richtext/richtextborderspage.cpp:253
 #: ../src/richtext/richtextborderspage.cpp:256
 #: ../src/richtext/richtextborderspage.cpp:257
@@ -8836,170 +9087,162 @@ msgstr ""
 #: ../src/richtext/richtextmarginspage.cpp:387
 #: ../src/richtext/richtextmarginspage.cpp:389
 #: ../src/richtext/richtextmarginspage.cpp:390
-#: ../src/richtext/richtextsizepage.cpp:338
-#: ../src/richtext/richtextsizepage.cpp:341
-#: ../src/richtext/richtextsizepage.cpp:342
-#: ../src/richtext/richtextsizepage.cpp:372
-#: ../src/richtext/richtextsizepage.cpp:375
-#: ../src/richtext/richtextsizepage.cpp:376
-#: ../src/richtext/richtextsizepage.cpp:399
-#: ../src/richtext/richtextsizepage.cpp:402
-#: ../src/richtext/richtextsizepage.cpp:403
-#: ../src/richtext/richtextsizepage.cpp:426
-#: ../src/richtext/richtextsizepage.cpp:429
-#: ../src/richtext/richtextsizepage.cpp:430
-#: ../src/richtext/richtextsizepage.cpp:453
-#: ../src/richtext/richtextsizepage.cpp:456
-#: ../src/richtext/richtextsizepage.cpp:457
-#: ../src/richtext/richtextsizepage.cpp:480
-#: ../src/richtext/richtextsizepage.cpp:483
-#: ../src/richtext/richtextsizepage.cpp:484
-#: ../src/richtext/richtextsizepage.cpp:554
-#: ../src/richtext/richtextsizepage.cpp:557
-#: ../src/richtext/richtextsizepage.cpp:558
-#: ../src/richtext/richtextsizepage.cpp:589
-#: ../src/richtext/richtextsizepage.cpp:592
-#: ../src/richtext/richtextsizepage.cpp:593
-#: ../src/richtext/richtextsizepage.cpp:624
-#: ../src/richtext/richtextsizepage.cpp:627
-#: ../src/richtext/richtextsizepage.cpp:628
-#: ../src/richtext/richtextsizepage.cpp:659
-#: ../src/richtext/richtextsizepage.cpp:662
-#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextfontpage.cpp:178
 msgid "px"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:193
+#: ../src/common/accelcmn.cpp:192
 #, fuzzy
 msgid "rawctrl"
 msgstr "ctrl"
 
-#: ../src/html/chm.cpp:333
+#: ../src/html/chm.cpp:330
 msgid "read error"
 msgstr "lukuvirhe"
 
-#: ../src/common/zipstrm.cpp:2085
+#: ../src/common/zipstrm.cpp:2155
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "luetaan zip-virtaa (kohta %s): virheellinen crc"
 
-#: ../src/common/zipstrm.cpp:2080
+#: ../src/common/zipstrm.cpp:2150
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "luetaan zip-virtaa (kohta %s): virheellinen pituus"
 
-#: ../src/msw/dde.cpp:1159
+#: ../src/msw/dde.cpp:1223
 msgid "reentrancy problem."
 msgstr "vaikeuksia uudelleen palaamisessa."
 
-#: ../src/common/datetimefmt.cpp:1953
+#: ../src/common/datetimefmt.cpp:1976
 msgid "second"
 msgstr "toinen"
 
-#: ../src/html/chm.cpp:337
+#: ../src/html/chm.cpp:334
 msgid "seek error"
 msgstr "hakuvirhe"
 
-#: ../src/common/datetimefmt.cpp:1968
+#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#, fuzzy
+msgid "semibold"
+msgstr "lihavoitu"
+
+#: ../src/common/datetimefmt.cpp:1991
 msgid "seventeenth"
 msgstr "seitsemästoista"
 
-#: ../src/common/datetimefmt.cpp:1958
+#: ../src/common/datetimefmt.cpp:1981
 msgid "seventh"
 msgstr "seitsemäs"
 
-#: ../src/common/accelcmn.cpp:191
+#: ../src/common/accelcmn.cpp:190
 msgid "shift"
 msgstr "vaihto"
 
-#: ../src/common/appbase.cpp:773
+#: ../src/common/appbase.cpp:774
 msgid "show this help message"
 msgstr "näytä tämä ohjeviesti"
 
-#: ../src/common/datetimefmt.cpp:1967
+#: ../src/common/datetimefmt.cpp:1990
 msgid "sixteenth"
 msgstr "kuudestoista"
 
-#: ../src/common/datetimefmt.cpp:1957
+#: ../src/common/datetimefmt.cpp:1980
 msgid "sixth"
 msgstr "kuudes"
 
-#: ../src/common/appcmn.cpp:234
+#: ../src/common/appcmn.cpp:255
 msgid "specify display mode to use (e.g. 640x480-16)"
 msgstr "määritä käytettävä näyttötila (esim. 640x480-16)"
 
-#: ../src/common/appcmn.cpp:220
+#: ../src/common/appcmn.cpp:241
 msgid "specify the theme to use"
 msgstr "määritä käytettävä teema"
 
-#: ../src/richtext/richtextbuffer.cpp:9340
+#: ../src/richtext/richtextbuffer.cpp:9337
 msgid "standard/circle"
 msgstr "perus/ympyrä"
 
-#: ../src/richtext/richtextbuffer.cpp:9341
+#: ../src/richtext/richtextbuffer.cpp:9338
 msgid "standard/circle-outline"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9343
+#: ../src/richtext/richtextbuffer.cpp:9340
 msgid "standard/diamond"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9342
+#: ../src/richtext/richtextbuffer.cpp:9339
 msgid "standard/square"
 msgstr "perus/neliö"
 
-#: ../src/richtext/richtextbuffer.cpp:9344
+#: ../src/richtext/richtextbuffer.cpp:9341
 msgid "standard/triangle"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1985
+#: ../src/common/zipstrm.cpp:2055
 msgid "stored file length not in Zip header"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1488
+#: ../src/common/cmdline.cpp:1484
 msgid "str"
 msgstr "merkkijono"
 
-#: ../src/common/fontcmn.cpp:982
+#: ../src/common/fontcmn.cpp:1145
 #, fuzzy
 msgid "strikethrough"
 msgstr "Yliviivaus"
 
-#: ../src/common/tarstrm.cpp:1003 ../src/common/tarstrm.cpp:1025
-#: ../src/common/tarstrm.cpp:1507 ../src/common/tarstrm.cpp:1529
+#: ../src/common/tarstrm.cpp:997 ../src/common/tarstrm.cpp:1019
+#: ../src/common/tarstrm.cpp:1501 ../src/common/tarstrm.cpp:1523
 msgid "tar entry not open"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1961
+#: ../src/common/datetimefmt.cpp:1984
 msgid "tenth"
 msgstr "kymmenes"
 
-#: ../src/msw/dde.cpp:1123
+#: ../src/msw/dde.cpp:1187
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "tapahtuman vastaus aiheutti DDE_FBUSY-bitin asettumisen."
 
-#: ../src/common/datetimefmt.cpp:1954
+#: ../src/common/fontcmn.cpp:1154
+msgid "thin"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:1977
 msgid "third"
 msgstr "kolmas"
 
-#: ../src/common/datetimefmt.cpp:1964
+#: ../src/common/datetimefmt.cpp:1987
 msgid "thirteenth"
 msgstr "kolmastoista"
 
-#: ../src/common/datetimefmt.cpp:1758
+#: ../src/common/datetimefmt.cpp:1781
 msgid "today"
 msgstr "tänään"
 
-#: ../src/common/datetimefmt.cpp:1760
+#: ../src/common/datetimefmt.cpp:1783
 msgid "tomorrow"
 msgstr "huomenna"
 
-#: ../src/common/fileconf.cpp:1944
+#: ../src/common/fileconf.cpp:1946
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr ""
 
-#: ../src/gtk/aboutdlg.cpp:218
+#: ../src/gtk/aboutdlg.cpp:216
 msgid "translator-credits"
 msgstr ""
 "Elias Julkunen <elias.julkunen@gmail.com>, 2008.Jaakko Salli "
@@ -9007,94 +9250,112 @@ msgstr ""
 "Backas <kgb@compart.fi>, 2000."
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1028
+#: ../src/generic/datavgen.cpp:1148
 msgid "true"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1963
+#: ../src/common/datetimefmt.cpp:1986
 msgid "twelfth"
 msgstr "kahdestoista"
 
-#: ../src/common/datetimefmt.cpp:1971
+#: ../src/common/datetimefmt.cpp:1994
 msgid "twentieth"
 msgstr "kahdeskymmenes"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:486 ../src/generic/datavgen.cpp:1263
+#: ../src/common/datavcmn.cpp:2068 ../src/generic/datavgen.cpp:1386
 msgid "unchecked"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:802 ../src/common/fontcmn.cpp:978
+#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
 msgid "underlined"
 msgstr "alleviivattu"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:490
+#: ../src/common/datavcmn.cpp:2072
 #, fuzzy
 msgid "undetermined"
 msgstr "alleviivattu"
 
-#: ../src/common/fileconf.cpp:1979
+#: ../src/common/fileconf.cpp:1981
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "Odottamaton \"-merkki kohdassa %d tiedostossa '%s'."
 
-#: ../src/common/tarstrm.cpp:1045
+#: ../src/common/tarstrm.cpp:1039
 msgid "unexpected end of file"
 msgstr "odottamaton tiedoston loppu"
 
-#: ../src/generic/progdlgg.cpp:370 ../src/common/tarstrm.cpp:371
-#: ../src/common/tarstrm.cpp:394 ../src/common/tarstrm.cpp:425
+#: ../src/common/tarstrm.cpp:366 ../src/common/tarstrm.cpp:389
+#: ../src/common/tarstrm.cpp:420 ../src/generic/progdlgg.cpp:376
 msgid "unknown"
 msgstr "tuntematon"
 
-#: ../src/msw/registry.cpp:150
+#: ../src/msw/registry.cpp:139
 #, fuzzy, c-format
 msgid "unknown (%lu)"
 msgstr "tuntematon"
 
-#: ../src/common/xtixml.cpp:253
+#: ../src/common/xtixml.cpp:249
 #, c-format
 msgid "unknown class %s"
 msgstr "tuntematon luokka %s"
 
-#: ../src/common/regex.cpp:258 ../src/html/chm.cpp:351
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "pakkausvirhe"
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "purkamisvirhe"
+
+#: ../src/common/regex.cpp:255 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "tuntematon virhe"
 
-#: ../src/msw/dialup.cpp:471
+#: ../src/msw/dialup.cpp:465
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "tuntematon virhe (virhekoodi %08x)."
 
-#: ../src/common/fmapbase.cpp:834
+#: ../src/common/fmapbase.cpp:830
 #, c-format
 msgid "unknown-%d"
 msgstr "tuntematon-%d"
 
-#: ../src/common/docview.cpp:509
+#: ../src/common/docview.cpp:502
 msgid "unnamed"
 msgstr "nimetön"
 
-#: ../src/common/docview.cpp:1624
+#: ../src/common/docview.cpp:1618
 #, c-format
 msgid "unnamed%d"
 msgstr "nimetön%d"
 
-#: ../src/common/zipstrm.cpp:1999 ../src/common/zipstrm.cpp:2319
+#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
 msgid "unsupported Zip compression method"
 msgstr "ei-tuettu Zip-pakkaustyyppi"
 
-#: ../src/common/translation.cpp:1892
+#: ../src/common/translation.cpp:1942
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "käytössä luettelo ”%s” ”%s”sta."
 
-#: ../src/html/chm.cpp:335
+#: ../src/html/chm.cpp:332
 msgid "write error"
 msgstr "kirjoitusvirhe"
 
-#: ../src/common/time.cpp:292
+#: ../src/gtk/glcanvas.cpp:187
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/common/time.cpp:285
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay epäonnistui."
 
@@ -9107,15 +9368,15 @@ msgstr "wxWidgets ei voi avata näyttöä prosessille ”%s”: poistutaan."
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets ei voi avata näyttöä. Poistutaan."
 
-#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:431
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/common/datetimefmt.cpp:1759
+#: ../src/common/datetimefmt.cpp:1782
 msgid "yesterday"
 msgstr "eilen"
 
-#: ../src/common/zstream.cpp:251 ../src/common/zstream.cpp:426
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
 #, c-format
 msgid "zlib error %d"
 msgstr "zlib-virhe %d"
@@ -9124,6 +9385,82 @@ msgstr "zlib-virhe %d"
 #: ../src/richtext/richtextbulletspage.cpp:288
 msgid "~"
 msgstr "~"
+
+#~ msgid "&Save as"
+#~ msgstr "&Tallenna nimellä"
+
+#, fuzzy
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "”%s” saa sisältää vain kirjaimia."
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "”%s” on oltava numeerinen."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "”%s” saa sisältää vain ASCII-merkkejä."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "”%s” saa sisältää vain kirjaimia."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "”%s” saa sisältää vain kirjaimia ja numeroita."
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "”%s” saa sisältää vain ASCII-merkkejä."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "Luokan ”%s” ikkunan luonti epäonnistui"
+
+#, fuzzy
+#~ msgid "Could not initalize libnotify."
+#~ msgstr "Tasausta ei voitu asettaa."
+
+#, fuzzy
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "Ajastimen luonti epäonnistui"
+
+#, fuzzy
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "Säikeen osoittimen haku epäonnistui"
+
+#, fuzzy
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "Tiedostoa ”%s” ei voitu muuntaa Unicode-muotoon."
+
+#, fuzzy
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "Työhakemistoa ei saatu"
+
+#, fuzzy
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr "Virheellinen GTK+-komentorivivalinta, kokeile ”%s --help”"
+
+#~ msgid "No unused colour in image."
+#~ msgstr "Ei käyttämättömiä värejä kuvassa"
+
+#, fuzzy
+#~ msgid "Not available"
+#~ msgstr "Valitettavasti vihjeitä ei ole!"
+
+#~ msgid "Replace selection"
+#~ msgstr "Korvaa valinta"
+
+#, fuzzy
+#~ msgid "Save as"
+#~ msgstr "Tallenna nimellä"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Tyylien hallitsija"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "Seuraavat standardit GTK+-valinnat ovat myös tuettuina:\n"
+
+#, fuzzy
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "Et voi lisätä uutta hakemistoa tähän kohtaan."
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "maa-arvoa ”%s” ei voida asettaa."
 
 #~ msgid "Adding flavor TEXT failed"
 #~ msgstr "TEXT-kerroksen lisääminen epäonnistui"
@@ -9142,9 +9479,6 @@ msgstr "~"
 
 #~ msgid "Column could not be added."
 #~ msgstr "Saraketta ei voitu lisätä."
-
-#~ msgid "Column description could not be initialized."
-#~ msgstr "Sarakkeen kuvausta ei voitu alustaa."
 
 #~ msgid "Column index not found."
 #~ msgstr "Sarakeindeksiä ei löytynyt."
@@ -9665,9 +9999,6 @@ msgstr "~"
 #~ msgid "Directory '%s' doesn't exist!"
 #~ msgstr "Hakemistoa ”%s” ei ole olemassa!"
 
-#~ msgid "File %s does not exist."
-#~ msgstr "Tiedosto %s ei ole olemassa."
-
 #~ msgid "Mode %ix%i-%i not available."
 #~ msgstr "Tila %ix%i-%i ei käytettävissä."
 
@@ -9759,9 +10090,6 @@ msgstr "~"
 
 #~ msgid "Failed to register OpenGL window class."
 #~ msgstr "OpenGL-ikkunaluokan rekisteröinti epäonnistui."
-
-#~ msgid "Fatal error"
-#~ msgstr "Tuhoisa virhe"
 
 #~ msgid "Fatal error: "
 #~ msgstr "Tuhoisa virhe: "

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-21 14:25+0200\n"
+"POT-Creation-Date: 2020-10-18 23:11+0300\n"
 "PO-Revision-Date: 2020-06-27 11:00+0200\n"
 "Last-Translator: TMTisFree <tmtisfree@free.fr>\n"
 "Language-Team: French <debian-l10n-french@lists.debian.org>\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 2.3.1\n"
 
-#: ../src/common/debugrpt.cpp:586
+#: ../src/common/debugrpt.cpp:587
 msgid ""
 "\n"
 "Please send this report to the program maintainer, thank you!\n"
@@ -24,8 +24,8 @@ msgstr ""
 "\n"
 "Merci d'envoyer ce rapport au responsable du programme !\n"
 
-#: ../src/richtext/richtextstyledlg.cpp:210
-#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:206
+#: ../src/richtext/richtextstyledlg.cpp:218
 msgid " "
 msgstr " "
 
@@ -33,70 +33,96 @@ msgstr " "
 msgid "              Thank you and we're sorry for the inconvenience!\n"
 msgstr "              Merci et désolé pour le dérangement !\n"
 
-#: ../src/common/prntbase.cpp:573
+#: ../src/common/prntbase.cpp:568
 #, c-format
 msgid " (copy %d of %d)"
 msgstr " (copie %d sur %d)"
 
-#: ../src/common/log.cpp:421
+#: ../src/common/log.cpp:440
 #, c-format
 msgid " (error %ld: %s)"
 msgstr " (erreur %ld : %s)"
 
-#: ../src/common/imagtiff.cpp:72
+#: ../src/common/imagtiff.cpp:69
 #, c-format
 msgid " (in module \"%s\")"
 msgstr " (dans le module « %s »)"
 
-#: ../src/osx/core/secretstore.cpp:138
-msgid " (while overwriting an existing item)"
-msgstr " (lors de la réécriture d'un élément existant)"
-
-#: ../src/common/docview.cpp:1642
+#: ../src/common/docview.cpp:1636
 msgid " - "
 msgstr " - "
 
-#: ../src/richtext/richtextprint.cpp:593 ../src/html/htmprint.cpp:714
+#: ../src/html/htmprint.cpp:712 ../src/richtext/richtextprint.cpp:589
 msgid " Preview"
 msgstr " Aperçu"
 
-#: ../src/common/fontcmn.cpp:824
+#: ../src/common/fontcmn.cpp:973
 msgid " bold"
 msgstr " gras"
 
-#: ../src/common/fontcmn.cpp:840
+#: ../src/common/fontcmn.cpp:977
+#, fuzzy
+msgid " extra bold"
+msgstr " gras"
+
+#: ../src/common/fontcmn.cpp:985
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:957
+#, fuzzy
+msgid " extra light"
+msgstr " léger"
+
+#: ../src/common/fontcmn.cpp:981
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1001
 msgid " italic"
 msgstr " italique"
 
-#: ../src/common/fontcmn.cpp:820
+#: ../src/common/fontcmn.cpp:961
 msgid " light"
 msgstr " léger"
 
-#: ../src/common/fontcmn.cpp:807
+#: ../src/common/fontcmn.cpp:965
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:969
+#, fuzzy
+msgid " semi bold"
+msgstr " gras"
+
+#: ../src/common/fontcmn.cpp:940
 msgid " strikethrough"
 msgstr " barré"
 
-#: ../src/common/paper.cpp:117
+#: ../src/common/fontcmn.cpp:953
+msgid " thin"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
 msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
 msgstr "Enveloppe n° 10 (4,125 x 9,5 pouces)"
 
-#: ../src/common/paper.cpp:118
+#: ../src/common/paper.cpp:115
 msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
 msgstr "Enveloppe n° 11 (4,5 x 10,375 pouces)"
 
-#: ../src/common/paper.cpp:119
+#: ../src/common/paper.cpp:116
 msgid "#12 Envelope, 4 3/4 x 11 in"
 msgstr "Enveloppe n° 12 (4,75 x 11 pouces)"
 
-#: ../src/common/paper.cpp:120
+#: ../src/common/paper.cpp:117
 msgid "#14 Envelope, 5 x 11 1/2 in"
 msgstr "Enveloppe n° 14 (5 x 11,5 pouces)"
 
-#: ../src/common/paper.cpp:116
+#: ../src/common/paper.cpp:113
 msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
 msgstr "Enveloppe n° 9 (3,875 x 8,875 pouces)"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:341
 #: ../src/richtext/richtextsizepage.cpp:340
 #: ../src/richtext/richtextsizepage.cpp:374
 #: ../src/richtext/richtextsizepage.cpp:401
@@ -107,81 +133,82 @@ msgstr "Enveloppe n° 9 (3,875 x 8,875 pouces)"
 #: ../src/richtext/richtextsizepage.cpp:591
 #: ../src/richtext/richtextsizepage.cpp:626
 #: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextbackgroundpage.cpp:341
 msgid "%"
 msgstr "%"
 
-#: ../src/html/helpwnd.cpp:1031
+#: ../src/html/helpwnd.cpp:1029
 #, c-format
 msgid "%d of %lu"
 msgstr "%d dur %lu"
 
-#: ../src/html/helpwnd.cpp:1678
+#: ../src/html/helpwnd.cpp:1676
 #, c-format
 msgid "%i of %u"
 msgstr "%i de %u"
 
-#: ../src/generic/filectrlg.cpp:279
+#: ../src/generic/filectrlg.cpp:275
 #, c-format
 msgid "%ld byte"
 msgid_plural "%ld bytes"
 msgstr[0] "%ld octet"
 msgstr[1] "%ld octets"
 
-#: ../src/html/helpwnd.cpp:1033
+#: ../src/html/helpwnd.cpp:1031
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu sur %lu"
 
-#: ../src/generic/datavgen.cpp:6028
+#: ../src/generic/datavgen.cpp:6833
 #, c-format
 msgid "%s (%d items)"
 msgstr "%s (%d éléments)"
 
-#: ../src/common/cmdline.cpp:1221
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (ou %s)"
 
-#: ../src/generic/logg.cpp:224
+#: ../src/generic/logg.cpp:221
 #, c-format
 msgid "%s Error"
 msgstr "%s Erreur"
 
-#: ../src/generic/logg.cpp:236
+#: ../src/generic/logg.cpp:233
 #, c-format
 msgid "%s Information"
 msgstr "%s Informations"
 
-#: ../src/generic/preferencesg.cpp:113
+#: ../src/generic/preferencesg.cpp:110
 #, c-format
 msgid "%s Preferences"
 msgstr "Préférences %s"
 
-#: ../src/generic/logg.cpp:228
+#: ../src/generic/logg.cpp:225
 #, c-format
 msgid "%s Warning"
 msgstr "%s Avertissement"
 
-#: ../src/common/tarstrm.cpp:1319
+#: ../src/common/tarstrm.cpp:1313
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s ne rentre pas dans l'entête tar pour l'entrée « %s »"
 
-#: ../src/common/fldlgcmn.cpp:124
+#: ../src/common/fldlgcmn.cpp:121
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s fichiers (%s)|%s"
 
-#: ../src/html/helpwnd.cpp:1716
+#: ../src/html/helpwnd.cpp:1714
 #, c-format
 msgid "%u of %u"
 msgstr "%u sur %u"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "&About"
 msgstr "À &propos"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "&Actual Size"
 msgstr "&Taille actuelle"
 
@@ -189,28 +216,28 @@ msgstr "&Taille actuelle"
 msgid "&After a paragraph:"
 msgstr "&Après un paragraphe :"
 
-#: ../src/richtext/richtextindentspage.cpp:128
 #: ../src/richtext/richtextliststylepage.cpp:319
+#: ../src/richtext/richtextindentspage.cpp:128
 msgid "&Alignment"
 msgstr "&Alignement"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "&Apply"
 msgstr "&Appliquer"
 
-#: ../src/richtext/richtextstyledlg.cpp:251
+#: ../src/richtext/richtextstyledlg.cpp:247
 msgid "&Apply Style"
 msgstr "&Appliquer le style"
 
-#: ../src/msw/mdi.cpp:179
+#: ../src/msw/mdi.cpp:174
 msgid "&Arrange Icons"
 msgstr "&Arranger les icônes"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "&Ascending"
 msgstr "Croiss&ant"
 
-#: ../src/common/stockitem.cpp:142
+#: ../src/common/stockitem.cpp:139
 msgid "&Back"
 msgstr "&Retour"
 
@@ -230,24 +257,24 @@ msgstr "Couleur de &fond :"
 msgid "&Blur distance:"
 msgstr "Distance de &flou :"
 
-#: ../src/common/stockitem.cpp:143
+#: ../src/common/stockitem.cpp:140
 msgid "&Bold"
 msgstr "&Gras"
 
-#: ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141
 msgid "&Bottom"
 msgstr "&Bas"
 
+#: ../src/richtext/richtextsizepage.cpp:637
+#: ../src/richtext/richtextsizepage.cpp:644
 #: ../src/richtext/richtextborderspage.cpp:345
 #: ../src/richtext/richtextborderspage.cpp:513
 #: ../src/richtext/richtextmarginspage.cpp:259
 #: ../src/richtext/richtextmarginspage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:637
-#: ../src/richtext/richtextsizepage.cpp:644
 msgid "&Bottom:"
 msgstr "&Bas :"
 
-#: ../include/wx/richtext/richtextbuffer.h:3866
+#: ../include/wx/richtext/richtextbuffer.h:3861
 msgid "&Box"
 msgstr "&Boîte"
 
@@ -256,38 +283,38 @@ msgstr "&Boîte"
 msgid "&Bullet style:"
 msgstr "Style de ti&ret :"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "&CD-Rom"
 msgstr "&CD-Rom"
 
-#: ../src/generic/wizard.cpp:434 ../src/generic/fontdlgg.cpp:470
-#: ../src/generic/fontdlgg.cpp:489 ../src/osx/carbon/fontdlg.cpp:402
-#: ../src/common/dlgcmn.cpp:279 ../src/common/stockitem.cpp:145
+#: ../src/osx/carbon/fontdlg.cpp:399 ../src/common/stockitem.cpp:142
+#: ../src/generic/wizard.cpp:433 ../src/generic/fontdlgg.cpp:466
+#: ../src/generic/fontdlgg.cpp:485 ../src/osx/cocoa/button.mm:200
 msgid "&Cancel"
 msgstr "&Annuler"
 
-#: ../src/msw/mdi.cpp:175
+#: ../src/msw/mdi.cpp:170
 msgid "&Cascade"
 msgstr "&Cascade"
 
-#: ../include/wx/richtext/richtextbuffer.h:5960
+#: ../include/wx/richtext/richtextbuffer.h:5955
 msgid "&Cell"
 msgstr "&Cellule"
 
-#: ../src/richtext/richtextsymboldlg.cpp:439
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "&Character code:"
 msgstr "&Code caractère :"
 
-#: ../src/common/stockitem.cpp:147
+#: ../src/common/stockitem.cpp:144
 msgid "&Clear"
 msgstr "&Supprimer"
 
-#: ../src/generic/logg.cpp:516 ../src/common/stockitem.cpp:148
-#: ../src/common/prntbase.cpp:1600 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/stockitem.cpp:145 ../src/common/prntbase.cpp:1625
+#: ../src/univ/themes/win32.cpp:3753 ../src/generic/logg.cpp:513
 msgid "&Close"
 msgstr "&Fermer"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "&Color"
 msgstr "&Couleur"
 
@@ -295,20 +322,20 @@ msgstr "&Couleur"
 msgid "&Colour:"
 msgstr "C&ouleur :"
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "&Convert"
 msgstr "&Convertir"
 
-#: ../src/richtext/richtextctrl.cpp:333 ../src/osx/textctrl_osx.cpp:577
-#: ../src/common/stockitem.cpp:150 ../src/msw/textctrl.cpp:2508
+#: ../src/osx/textctrl_osx.cpp:595 ../src/common/stockitem.cpp:147
+#: ../src/msw/textctrl.cpp:2773 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Copier"
 
-#: ../src/generic/hyperlinkg.cpp:156
+#: ../src/generic/hyperlinkg.cpp:153
 msgid "&Copy URL"
 msgstr "&Copier l'adresse"
 
-#: ../src/common/headerctrlcmn.cpp:306
+#: ../src/common/headerctrlcmn.cpp:304
 msgid "&Customize..."
 msgstr "&Personnaliser..."
 
@@ -316,53 +343,54 @@ msgstr "&Personnaliser..."
 msgid "&Debug report preview:"
 msgstr "Aperçu du rapport de &débogage :"
 
-#: ../src/richtext/richtexttabspage.cpp:138
-#: ../src/richtext/richtextctrl.cpp:335 ../src/osx/textctrl_osx.cpp:579
-#: ../src/common/stockitem.cpp:152 ../src/msw/textctrl.cpp:2510
+#: ../src/osx/textctrl_osx.cpp:597 ../src/common/stockitem.cpp:149
+#: ../src/msw/textctrl.cpp:2775 ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtextctrl.cpp:334
 msgid "&Delete"
 msgstr "&Supprimer"
 
-#: ../src/richtext/richtextstyledlg.cpp:269
+#: ../src/richtext/richtextstyledlg.cpp:265
 msgid "&Delete Style..."
 msgstr "Su&pprimer le style..."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "&Descending"
 msgstr "&Décroissant"
 
-#: ../src/generic/logg.cpp:682
+#: ../src/generic/logg.cpp:679
 msgid "&Details"
 msgstr "&Détails"
 
-#: ../src/common/stockitem.cpp:153
+#: ../src/common/stockitem.cpp:150
 msgid "&Down"
 msgstr "&Bas"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "&Edit"
 msgstr "&Edition"
 
-#: ../src/richtext/richtextstyledlg.cpp:263
+#: ../src/richtext/richtextstyledlg.cpp:259
 msgid "&Edit Style..."
 msgstr "Édit&er le style..."
 
-#: ../src/common/stockitem.cpp:155
+#: ../src/common/stockitem.cpp:152
 msgid "&Execute"
 msgstr "&Exécuter"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/common/stockitem.cpp:154
 msgid "&File"
 msgstr "&Fichier"
 
-#: ../src/common/stockitem.cpp:158
-msgid "&Find"
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "&Find..."
 msgstr "&Trouver"
 
-#: ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:430
 msgid "&Finish"
 msgstr "&Finir"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:156
 msgid "&First"
 msgstr "&Premier"
 
@@ -370,15 +398,15 @@ msgstr "&Premier"
 msgid "&Floating mode:"
 msgstr "Mode &flottant :"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "&Floppy"
 msgstr "&Disquette"
 
-#: ../src/common/stockitem.cpp:194
+#: ../src/common/stockitem.cpp:191
 msgid "&Font"
 msgstr "&Police"
 
-#: ../src/generic/fontdlgg.cpp:371
+#: ../src/generic/fontdlgg.cpp:367
 msgid "&Font family:"
 msgstr "&Famille de polices :"
 
@@ -386,20 +414,20 @@ msgstr "&Famille de polices :"
 msgid "&Font for Level..."
 msgstr "&Police de caractères pour le Niveau..."
 
+#: ../src/richtext/richtextsymboldlg.cpp:397
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:400
 msgid "&Font:"
 msgstr "&Police :"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "&Forward"
 msgstr "&Suivant"
 
-#: ../src/richtext/richtextsymboldlg.cpp:451
+#: ../src/richtext/richtextsymboldlg.cpp:448
 msgid "&From:"
 msgstr "De :"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "&Harddisk"
 msgstr "&Disque dur"
 
@@ -408,9 +436,9 @@ msgstr "&Disque dur"
 msgid "&Height:"
 msgstr "&Hauteur :"
 
-#: ../src/generic/wizard.cpp:441 ../src/richtext/richtextstyledlg.cpp:303
-#: ../src/richtext/richtextsymboldlg.cpp:479 ../src/osx/menu_osx.cpp:734
-#: ../src/common/stockitem.cpp:163
+#: ../src/common/stockitem.cpp:160 ../src/generic/wizard.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextstyledlg.cpp:299 ../src/osx/cocoa/menu.mm:226
 msgid "&Help"
 msgstr "&Aide"
 
@@ -418,7 +446,7 @@ msgstr "&Aide"
 msgid "&Hide details"
 msgstr "Cac&her les détails"
 
-#: ../src/common/stockitem.cpp:164
+#: ../src/common/stockitem.cpp:161
 msgid "&Home"
 msgstr "&Dossier personnel"
 
@@ -426,54 +454,54 @@ msgstr "&Dossier personnel"
 msgid "&Horizontal offset:"
 msgstr "Décalage &horizontal :"
 
-#: ../src/richtext/richtextindentspage.cpp:184
 #: ../src/richtext/richtextliststylepage.cpp:372
+#: ../src/richtext/richtextindentspage.cpp:184
 msgid "&Indentation (tenths of a mm)"
 msgstr "&Indentation (dixièmes de mm)"
 
-#: ../src/richtext/richtextindentspage.cpp:167
 #: ../src/richtext/richtextliststylepage.cpp:356
+#: ../src/richtext/richtextindentspage.cpp:167
 msgid "&Indeterminate"
 msgstr "&Indeterminé"
 
-#: ../src/common/stockitem.cpp:166
+#: ../src/common/stockitem.cpp:163
 msgid "&Index"
 msgstr "&Index"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "&Info"
 msgstr "&Info"
 
-#: ../src/common/stockitem.cpp:168
+#: ../src/common/stockitem.cpp:165
 msgid "&Italic"
 msgstr "&Italique"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "&Jump to"
 msgstr "&Aller à"
 
-#: ../src/richtext/richtextindentspage.cpp:153
 #: ../src/richtext/richtextliststylepage.cpp:342
+#: ../src/richtext/richtextindentspage.cpp:153
 msgid "&Justified"
 msgstr "&Justifié"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "&Last"
 msgstr "&Dernier"
 
-#: ../src/richtext/richtextindentspage.cpp:139
 #: ../src/richtext/richtextliststylepage.cpp:328
+#: ../src/richtext/richtextindentspage.cpp:139
 msgid "&Left"
 msgstr "&Gauche"
 
-#: ../src/richtext/richtextindentspage.cpp:195
+#: ../src/richtext/richtextsizepage.cpp:532
+#: ../src/richtext/richtextsizepage.cpp:539
 #: ../src/richtext/richtextborderspage.cpp:243
 #: ../src/richtext/richtextborderspage.cpp:411
 #: ../src/richtext/richtextliststylepage.cpp:381
+#: ../src/richtext/richtextindentspage.cpp:195
 #: ../src/richtext/richtextmarginspage.cpp:186
 #: ../src/richtext/richtextmarginspage.cpp:300
-#: ../src/richtext/richtextsizepage.cpp:532
-#: ../src/richtext/richtextsizepage.cpp:539
 msgid "&Left:"
 msgstr "&Gauche:"
 
@@ -481,11 +509,11 @@ msgstr "&Gauche:"
 msgid "&List level:"
 msgstr "Niveau de &Liste:"
 
-#: ../src/generic/logg.cpp:517
+#: ../src/generic/logg.cpp:514
 msgid "&Log"
 msgstr "&Journal"
 
-#: ../src/univ/themes/win32.cpp:3748
+#: ../src/univ/themes/win32.cpp:3745
 msgid "&Move"
 msgstr "&Déplacer"
 
@@ -493,19 +521,19 @@ msgstr "&Déplacer"
 msgid "&Move the object to:"
 msgstr "&Déplacer l'objet vers :"
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "&Network"
 msgstr "&Reseau"
 
-#: ../src/richtext/richtexttabspage.cpp:132 ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173 ../src/richtext/richtexttabspage.cpp:132
 msgid "&New"
 msgstr "&Nouveau"
 
-#: ../src/aui/tabmdi.cpp:111 ../src/generic/mdig.cpp:100 ../src/msw/mdi.cpp:180
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
 msgid "&Next"
 msgstr "&Suivant"
 
-#: ../src/generic/wizard.cpp:432 ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:429
 msgid "&Next >"
 msgstr "&Suivant >"
 
@@ -513,7 +541,7 @@ msgstr "&Suivant >"
 msgid "&Next Paragraph"
 msgstr "Paragraphe Suiva&nt"
 
-#: ../src/generic/tipdlg.cpp:240
+#: ../src/generic/tipdlg.cpp:237
 msgid "&Next Tip"
 msgstr "&Astuce Suivante"
 
@@ -521,11 +549,11 @@ msgstr "&Astuce Suivante"
 msgid "&Next style:"
 msgstr "&Style Suivant :"
 
-#: ../src/common/stockitem.cpp:177 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:174 ../src/msw/msgdlg.cpp:435
 msgid "&No"
 msgstr "&Non"
 
-#: ../src/generic/dbgrptg.cpp:356
+#: ../src/generic/dbgrptg.cpp:360
 msgid "&Notes:"
 msgstr "&Notes :"
 
@@ -533,12 +561,12 @@ msgstr "&Notes :"
 msgid "&Number:"
 msgstr "&Numéro :"
 
-#: ../src/generic/fontdlgg.cpp:475 ../src/generic/fontdlgg.cpp:482
-#: ../src/osx/carbon/fontdlg.cpp:408 ../src/common/stockitem.cpp:178
+#: ../src/osx/carbon/fontdlg.cpp:405 ../src/common/stockitem.cpp:175
+#: ../src/generic/fontdlgg.cpp:471 ../src/generic/fontdlgg.cpp:478
 msgid "&OK"
 msgstr "&Accepter"
 
-#: ../src/generic/dbgrptg.cpp:342 ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176 ../src/generic/dbgrptg.cpp:342
 msgid "&Open..."
 msgstr "&Ouvrir..."
 
@@ -550,16 +578,16 @@ msgstr "Niveau de C&ontour :"
 msgid "&Page Break"
 msgstr "Saut de &Page"
 
-#: ../src/richtext/richtextctrl.cpp:334 ../src/osx/textctrl_osx.cpp:578
-#: ../src/common/stockitem.cpp:180 ../src/msw/textctrl.cpp:2509
+#: ../src/osx/textctrl_osx.cpp:596 ../src/common/stockitem.cpp:177
+#: ../src/msw/textctrl.cpp:2774 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&Coller"
 
-#: ../include/wx/richtext/richtextbuffer.h:5010
+#: ../include/wx/richtext/richtextbuffer.h:5005
 msgid "&Picture"
 msgstr "&Image"
 
-#: ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:419
 msgid "&Point size:"
 msgstr "Taille de &point :"
 
@@ -571,11 +599,11 @@ msgstr "&Position (dizièmes de mm):"
 msgid "&Position mode:"
 msgstr "Mode de &position :"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178
 msgid "&Preferences"
 msgstr "&Préférences"
 
-#: ../src/aui/tabmdi.cpp:112 ../src/generic/mdig.cpp:101 ../src/msw/mdi.cpp:181
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
 msgid "&Previous"
 msgstr "&Précédent"
 
@@ -583,78 +611,74 @@ msgstr "&Précédent"
 msgid "&Previous Paragraph"
 msgstr "Paragraphe &Précédent"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "&Print..."
 msgstr "&Imprimer..."
 
-#: ../src/richtext/richtextctrl.cpp:339 ../src/richtext/richtextctrl.cpp:5514
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtextctrl.cpp:338
+#: ../src/richtext/richtextctrl.cpp:5512
 msgid "&Properties"
 msgstr "&Propriétés"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "&Quit"
 msgstr "&Quitter"
 
-#: ../src/richtext/richtextctrl.cpp:330 ../src/osx/textctrl_osx.cpp:574
-#: ../src/common/stockitem.cpp:185 ../src/common/cmdproc.cpp:293
-#: ../src/common/cmdproc.cpp:300 ../src/msw/textctrl.cpp:2505
+#: ../src/osx/textctrl_osx.cpp:592 ../src/common/stockitem.cpp:182
+#: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
+#: ../src/msw/textctrl.cpp:2770 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Refaire"
 
-#: ../src/common/cmdproc.cpp:289 ../src/common/cmdproc.cpp:309
+#: ../src/common/cmdproc.cpp:282 ../src/common/cmdproc.cpp:302
 msgid "&Redo "
 msgstr "&Refaire "
 
-#: ../src/richtext/richtextstyledlg.cpp:257
+#: ../src/richtext/richtextstyledlg.cpp:253
 msgid "&Rename Style..."
 msgstr "&Renommer le style..."
 
-#: ../src/generic/fdrepdlg.cpp:179
+#: ../src/generic/fdrepdlg.cpp:176
 msgid "&Replace"
 msgstr "&Remplacer"
 
-#: ../src/richtext/richtextstyledlg.cpp:287
+#: ../src/richtext/richtextstyledlg.cpp:283
 msgid "&Restart numbering"
 msgstr "&Recommencer la numérotation"
 
-#: ../src/univ/themes/win32.cpp:3747
+#: ../src/univ/themes/win32.cpp:3744
 msgid "&Restore"
 msgstr "&Restaurer"
 
-#: ../src/richtext/richtextindentspage.cpp:146
 #: ../src/richtext/richtextliststylepage.cpp:335
+#: ../src/richtext/richtextindentspage.cpp:146
 msgid "&Right"
 msgstr "&Droite"
 
-#: ../src/richtext/richtextindentspage.cpp:213
+#: ../src/richtext/richtextsizepage.cpp:602
+#: ../src/richtext/richtextsizepage.cpp:609
 #: ../src/richtext/richtextborderspage.cpp:277
 #: ../src/richtext/richtextborderspage.cpp:445
 #: ../src/richtext/richtextliststylepage.cpp:399
+#: ../src/richtext/richtextindentspage.cpp:213
 #: ../src/richtext/richtextmarginspage.cpp:211
 #: ../src/richtext/richtextmarginspage.cpp:325
-#: ../src/richtext/richtextsizepage.cpp:602
-#: ../src/richtext/richtextsizepage.cpp:609
 msgid "&Right:"
 msgstr "&Droite :"
 
-#: ../src/common/stockitem.cpp:190
+#: ../src/common/stockitem.cpp:187
 msgid "&Save"
 msgstr "&Enregistrer"
-
-#: ../src/common/stockitem.cpp:191
-msgid "&Save as"
-msgstr "Enregistrer &Sous"
 
 #: ../include/wx/richmsgdlg.h:29
 msgid "&See details"
 msgstr "Voir les détail&s"
 
-#: ../src/generic/tipdlg.cpp:236
+#: ../src/generic/tipdlg.cpp:233
 msgid "&Show tips at startup"
 msgstr "&Afficher les astuces au démarrage"
 
-#: ../src/univ/themes/win32.cpp:3750
+#: ../src/univ/themes/win32.cpp:3747
 msgid "&Size"
 msgstr "&Taille"
 
@@ -662,36 +686,36 @@ msgstr "&Taille"
 msgid "&Size:"
 msgstr "&Taille :"
 
-#: ../src/generic/progdlgg.cpp:252
+#: ../src/generic/progdlgg.cpp:249
 msgid "&Skip"
 msgstr "Pa&sser"
 
-#: ../src/richtext/richtextindentspage.cpp:242
 #: ../src/richtext/richtextliststylepage.cpp:417
+#: ../src/richtext/richtextindentspage.cpp:242
 msgid "&Spacing (tenths of a mm)"
 msgstr "E&spacement (dixièmes de mm)"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "&Spell Check"
 msgstr "&Vérification Orthographique"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "&Stop"
 msgstr "&Arrêter"
 
-#: ../src/richtext/richtextfontpage.cpp:275 ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196 ../src/richtext/richtextfontpage.cpp:275
 msgid "&Strikethrough"
 msgstr "&Barré"
 
-#: ../src/generic/fontdlgg.cpp:382 ../src/richtext/richtextstylepage.cpp:106
+#: ../src/generic/fontdlgg.cpp:378 ../src/richtext/richtextstylepage.cpp:106
 msgid "&Style:"
 msgstr "&Style :"
 
-#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:194
 msgid "&Styles:"
 msgstr "&Style :"
 
-#: ../src/richtext/richtextsymboldlg.cpp:413
+#: ../src/richtext/richtextsymboldlg.cpp:410
 msgid "&Subset:"
 msgstr "&Sous-ensemble:"
 
@@ -705,24 +729,24 @@ msgstr "&Symbole :"
 msgid "&Synchronize values"
 msgstr "&Synchroniser les valeurs"
 
-#: ../include/wx/richtext/richtextbuffer.h:6069
+#: ../include/wx/richtext/richtextbuffer.h:6064
 msgid "&Table"
 msgstr "&Table"
 
-#: ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197
 msgid "&Top"
 msgstr "Hau&t"
 
+#: ../src/richtext/richtextsizepage.cpp:567
+#: ../src/richtext/richtextsizepage.cpp:574
 #: ../src/richtext/richtextborderspage.cpp:311
 #: ../src/richtext/richtextborderspage.cpp:479
 #: ../src/richtext/richtextmarginspage.cpp:234
 #: ../src/richtext/richtextmarginspage.cpp:348
-#: ../src/richtext/richtextsizepage.cpp:567
-#: ../src/richtext/richtextsizepage.cpp:574
 msgid "&Top:"
 msgstr "Hau&t :"
 
-#: ../src/generic/fontdlgg.cpp:444 ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199 ../src/generic/fontdlgg.cpp:441
 msgid "&Underline"
 msgstr "&Souligner"
 
@@ -730,21 +754,21 @@ msgstr "&Souligner"
 msgid "&Underlining:"
 msgstr "So&uligner:"
 
-#: ../src/richtext/richtextctrl.cpp:329 ../src/osx/textctrl_osx.cpp:573
-#: ../src/common/stockitem.cpp:203 ../src/common/cmdproc.cpp:271
-#: ../src/msw/textctrl.cpp:2504
+#: ../src/osx/textctrl_osx.cpp:591 ../src/common/stockitem.cpp:200
+#: ../src/common/cmdproc.cpp:264 ../src/msw/textctrl.cpp:2769
+#: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Annuler"
 
-#: ../src/common/cmdproc.cpp:265
+#: ../src/common/cmdproc.cpp:258
 msgid "&Undo "
 msgstr "&Annuler "
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "&Unindent"
 msgstr "&Désindenter"
 
-#: ../src/common/stockitem.cpp:205
+#: ../src/common/stockitem.cpp:202
 msgid "&Up"
 msgstr "&Haut"
 
@@ -760,7 +784,7 @@ msgstr "Décalage &vertical :"
 msgid "&View..."
 msgstr "&Affichage..."
 
-#: ../src/generic/fontdlgg.cpp:393
+#: ../src/generic/fontdlgg.cpp:389
 msgid "&Weight:"
 msgstr "&Largeur :"
 
@@ -769,88 +793,58 @@ msgstr "&Largeur :"
 msgid "&Width:"
 msgstr "&Largeur :"
 
-#: ../src/aui/tabmdi.cpp:311 ../src/aui/tabmdi.cpp:327
-#: ../src/aui/tabmdi.cpp:329 ../src/generic/mdig.cpp:294
-#: ../src/generic/mdig.cpp:310 ../src/generic/mdig.cpp:314
-#: ../src/msw/mdi.cpp:78
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
 msgid "&Window"
 msgstr "&Fenêtre"
 
-#: ../src/common/stockitem.cpp:206 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:203 ../src/msw/msgdlg.cpp:435
 msgid "&Yes"
 msgstr "&Oui"
 
-#: ../src/common/valtext.cpp:256
-#, c-format
-msgid "'%s' contains illegal characters"
+#: ../src/common/valtext.cpp:197
+#, fuzzy, c-format
+msgid "'%s' contains invalid character(s)"
 msgstr "'%s' contient des caractères illégaux"
 
-#: ../src/common/valtext.cpp:254
-#, c-format
-msgid "'%s' doesn't consist only of valid characters"
-msgstr "'%s' ne consiste pas uniquement de caractères valables"
-
-#: ../src/common/config.cpp:519 ../src/msw/regconf.cpp:258
+#: ../src/common/config.cpp:515 ../src/msw/regconf.cpp:255
 #, c-format
 msgid "'%s' has extra '..', ignored."
 msgstr "« %s » a trop de « .. » : ils sont ignorés."
 
-#: ../src/common/cmdline.cpp:1113 ../src/common/cmdline.cpp:1131
+#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "« %s » n'est pas une valeur numérique correcte pour l'option « %s »."
 
-#: ../src/common/translation.cpp:1100
+#: ../src/common/translation.cpp:1142
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "« %s » n'est pas un catalogue valable de messages."
 
-#: ../src/common/valtext.cpp:165
+#: ../src/common/valtext.cpp:188
 #, c-format
 msgid "'%s' is not one of the valid strings"
 msgstr "« %s » n'est pas l'une des chaînes non valables"
 
-#: ../src/common/valtext.cpp:167
+#: ../src/common/valtext.cpp:186
 #, c-format
 msgid "'%s' is one of the invalid strings"
 msgstr "« %s » est l'une des chaînes non valables"
 
-#: ../src/common/textbuf.cpp:237
+#: ../src/common/textbuf.cpp:233
 #, c-format
 msgid "'%s' is probably a binary buffer."
 msgstr "« %s » est probablement un tampon binaire."
-
-#: ../src/common/valtext.cpp:252
-#, c-format
-msgid "'%s' should be numeric."
-msgstr "« %s » doit être numérique."
-
-#: ../src/common/valtext.cpp:244
-#, c-format
-msgid "'%s' should only contain ASCII characters."
-msgstr "« %s » ne doit contenir que des caractères ASCII."
-
-#: ../src/common/valtext.cpp:246
-#, c-format
-msgid "'%s' should only contain alphabetic characters."
-msgstr "« %s » ne doit contenir que des caractères alphabétiques."
-
-#: ../src/common/valtext.cpp:248
-#, c-format
-msgid "'%s' should only contain alphabetic or numeric characters."
-msgstr "« %s » ne doit contenir que des caractères alphanumériques."
-
-#: ../src/common/valtext.cpp:250
-#, c-format
-msgid "'%s' should only contain digits."
-msgstr "« %s » ne doit contenir que des chiffres."
 
 #: ../src/richtext/richtextliststylepage.cpp:229
 #: ../src/richtext/richtextbulletspage.cpp:166
 msgid "(*)"
 msgstr "(*)"
 
-#: ../src/html/helpwnd.cpp:963
+#: ../src/html/helpwnd.cpp:961
 msgid "(Help)"
 msgstr "(Aide)"
 
@@ -859,27 +853,32 @@ msgstr "(Aide)"
 msgid "(None)"
 msgstr "(Aucun)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:504
+#: ../src/richtext/richtextsymboldlg.cpp:503
 msgid "(Normal text)"
 msgstr "(Texte normale)"
 
-#: ../src/html/helpwnd.cpp:419 ../src/html/helpwnd.cpp:1106
-#: ../src/html/helpwnd.cpp:1742
+#: ../src/html/helpwnd.cpp:417 ../src/html/helpwnd.cpp:1104
+#: ../src/html/helpwnd.cpp:1740
 msgid "(bookmarks)"
 msgstr "(marque-pages)"
 
+#: ../src/msw/dlmsw.cpp:167
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (erreur %ld : %s)"
+
+#: ../src/richtext/richtextformatdlg.cpp:876
+#: ../src/richtext/richtextliststylepage.cpp:448
+#: ../src/richtext/richtextliststylepage.cpp:460
+#: ../src/richtext/richtextliststylepage.cpp:461
 #: ../src/richtext/richtextindentspage.cpp:274
 #: ../src/richtext/richtextindentspage.cpp:286
 #: ../src/richtext/richtextindentspage.cpp:287
 #: ../src/richtext/richtextindentspage.cpp:311
 #: ../src/richtext/richtextindentspage.cpp:326
-#: ../src/richtext/richtextformatdlg.cpp:884
 #: ../src/richtext/richtextfontpage.cpp:349
 #: ../src/richtext/richtextfontpage.cpp:353
 #: ../src/richtext/richtextfontpage.cpp:357
-#: ../src/richtext/richtextliststylepage.cpp:448
-#: ../src/richtext/richtextliststylepage.cpp:460
-#: ../src/richtext/richtextliststylepage.cpp:461
 msgid "(none)"
 msgstr "(aucun)"
 
@@ -898,7 +897,7 @@ msgstr "*)"
 msgid "+"
 msgstr "+"
 
-#: ../src/msw/utils.cpp:1152
+#: ../src/msw/utils.cpp:1143
 msgid ", 64-bit edition"
 msgstr ", édition 64-bit"
 
@@ -907,163 +906,163 @@ msgstr ", édition 64-bit"
 msgid "-"
 msgstr "-"
 
-#: ../src/generic/filepickerg.cpp:66
+#: ../src/generic/filepickerg.cpp:63
 msgid "..."
 msgstr "..."
 
-#: ../src/richtext/richtextindentspage.cpp:276
 #: ../src/richtext/richtextliststylepage.cpp:450
+#: ../src/richtext/richtextindentspage.cpp:276
 msgid "1.1"
 msgstr "1.1"
 
-#: ../src/richtext/richtextindentspage.cpp:277
 #: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextindentspage.cpp:277
 msgid "1.2"
 msgstr "1.2"
 
-#: ../src/richtext/richtextindentspage.cpp:278
 #: ../src/richtext/richtextliststylepage.cpp:452
+#: ../src/richtext/richtextindentspage.cpp:278
 msgid "1.3"
 msgstr "1.3"
 
-#: ../src/richtext/richtextindentspage.cpp:279
 #: ../src/richtext/richtextliststylepage.cpp:453
+#: ../src/richtext/richtextindentspage.cpp:279
 msgid "1.4"
 msgstr "1.4"
 
-#: ../src/richtext/richtextindentspage.cpp:280
 #: ../src/richtext/richtextliststylepage.cpp:454
+#: ../src/richtext/richtextindentspage.cpp:280
 msgid "1.5"
 msgstr "1,5"
 
-#: ../src/richtext/richtextindentspage.cpp:281
 #: ../src/richtext/richtextliststylepage.cpp:455
+#: ../src/richtext/richtextindentspage.cpp:281
 msgid "1.6"
 msgstr "1.6"
 
-#: ../src/richtext/richtextindentspage.cpp:282
 #: ../src/richtext/richtextliststylepage.cpp:456
+#: ../src/richtext/richtextindentspage.cpp:282
 msgid "1.7"
 msgstr "1.7"
 
-#: ../src/richtext/richtextindentspage.cpp:283
 #: ../src/richtext/richtextliststylepage.cpp:457
+#: ../src/richtext/richtextindentspage.cpp:283
 msgid "1.8"
 msgstr "1.8"
 
-#: ../src/richtext/richtextindentspage.cpp:284
 #: ../src/richtext/richtextliststylepage.cpp:458
+#: ../src/richtext/richtextindentspage.cpp:284
 msgid "1.9"
 msgstr "1.9"
 
-#: ../src/common/paper.cpp:140
+#: ../src/common/paper.cpp:137
 msgid "10 x 11 in"
 msgstr "10 x 11 pouces"
 
-#: ../src/common/paper.cpp:113
+#: ../src/common/paper.cpp:110
 msgid "10 x 14 in"
 msgstr "10 x 14 pouces"
 
-#: ../src/common/paper.cpp:114
+#: ../src/common/paper.cpp:111
 msgid "11 x 17 in"
 msgstr "11 x 17 pouces"
 
-#: ../src/common/paper.cpp:184
+#: ../src/common/paper.cpp:181
 msgid "12 x 11 in"
 msgstr "12 x 11 pouces"
 
-#: ../src/common/paper.cpp:141
+#: ../src/common/paper.cpp:138
 msgid "15 x 11 in"
 msgstr "15 x 11 pouces"
 
-#: ../src/richtext/richtextindentspage.cpp:285
 #: ../src/richtext/richtextliststylepage.cpp:459
+#: ../src/richtext/richtextindentspage.cpp:285
 msgid "2"
 msgstr "2"
 
-#: ../src/common/paper.cpp:132
+#: ../src/common/paper.cpp:129
 msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
 msgstr "Enveloppe 6 3/4 (3,625 x 6,5 pouces)"
 
-#: ../src/common/paper.cpp:139
+#: ../src/common/paper.cpp:136
 msgid "9 x 11 in"
 msgstr "9 x 11 pouces"
 
-#: ../src/html/htmprint.cpp:431
+#: ../src/html/htmprint.cpp:443
 msgid ": file does not exist!"
 msgstr ": le fichier n'existe pas !"
 
-#: ../src/common/fontmap.cpp:199
+#: ../src/common/fontmap.cpp:196
 msgid ": unknown charset"
 msgstr ": jeu de caractères inconnu"
 
-#: ../src/common/fontmap.cpp:413
+#: ../src/common/fontmap.cpp:410
 msgid ": unknown encoding"
 msgstr ": codage inconnu"
 
-#: ../src/generic/wizard.cpp:443
+#: ../src/generic/wizard.cpp:438
 msgid "< &Back"
 msgstr "< &Retour"
 
-#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:628
-#: ../src/osx/carbon/fontdlg.cpp:648
+#: ../src/osx/carbon/fontdlg.cpp:419 ../src/osx/carbon/fontdlg.cpp:625
+#: ../src/osx/carbon/fontdlg.cpp:645
 msgid "<Any Decorative>"
 msgstr "<N'importe quelle Décoration>"
 
-#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:630
-#: ../src/osx/carbon/fontdlg.cpp:650
+#: ../src/osx/carbon/fontdlg.cpp:420 ../src/osx/carbon/fontdlg.cpp:627
+#: ../src/osx/carbon/fontdlg.cpp:647
 msgid "<Any Modern>"
 msgstr "<N'importe quel Moderne>"
 
-#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:626
-#: ../src/osx/carbon/fontdlg.cpp:646
+#: ../src/osx/carbon/fontdlg.cpp:418 ../src/osx/carbon/fontdlg.cpp:623
+#: ../src/osx/carbon/fontdlg.cpp:643
 msgid "<Any Roman>"
 msgstr "<N'importe quel Roman>"
 
-#: ../src/osx/carbon/fontdlg.cpp:424 ../src/osx/carbon/fontdlg.cpp:632
-#: ../src/osx/carbon/fontdlg.cpp:652
+#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:629
+#: ../src/osx/carbon/fontdlg.cpp:649
 msgid "<Any Script>"
 msgstr "<N'importe quel Script>"
 
-#: ../src/osx/carbon/fontdlg.cpp:425 ../src/osx/carbon/fontdlg.cpp:637
-#: ../src/osx/carbon/fontdlg.cpp:656
+#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:634
+#: ../src/osx/carbon/fontdlg.cpp:653
 msgid "<Any Swiss>"
 msgstr "<N'importe quel Suisse>"
 
-#: ../src/osx/carbon/fontdlg.cpp:426 ../src/osx/carbon/fontdlg.cpp:634
-#: ../src/osx/carbon/fontdlg.cpp:654
+#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:631
+#: ../src/osx/carbon/fontdlg.cpp:651
 msgid "<Any Teletype>"
 msgstr "<N'importe quel Télétype>"
 
-#: ../src/osx/carbon/fontdlg.cpp:420
+#: ../src/osx/carbon/fontdlg.cpp:417
 msgid "<Any>"
 msgstr "<Quelconque>"
 
-#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
 msgid "<DIR>"
 msgstr "<DOSSIER>"
 
-#: ../src/generic/filectrlg.cpp:254 ../src/generic/filectrlg.cpp:277
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
 msgid "<DRIVE>"
 msgstr "<DISQUE>"
 
-#: ../src/generic/filectrlg.cpp:252 ../src/generic/filectrlg.cpp:275
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
 msgid "<LINK>"
 msgstr "<LIEN>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1264
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Gras italique.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1270
+#: ../src/html/helpwnd.cpp:1268
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>gras italique <u>souligné</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1265
+#: ../src/html/helpwnd.cpp:1263
 msgid "<b>Bold face.</b> "
 msgstr "<b>Gras.</b> "
 
-#: ../src/html/helpwnd.cpp:1264
+#: ../src/html/helpwnd.cpp:1262
 msgid "<i>Italic face.</i> "
 msgstr "<i>Italique.</i> "
 
@@ -1072,15 +1071,15 @@ msgstr "<i>Italique.</i> "
 msgid ">"
 msgstr ">"
 
-#: ../src/generic/dbgrptg.cpp:318
+#: ../src/generic/dbgrptg.cpp:317
 msgid "A debug report has been generated in the directory\n"
 msgstr "Un rapport de débogage a été créé dans le dossier\n"
 
-#: ../src/common/debugrpt.cpp:573
+#: ../src/common/debugrpt.cpp:574
 msgid "A debug report has been generated. It can be found in"
 msgstr "Un rapport de débogage a été généré. Il peut être trouvé dans"
 
-#: ../src/common/xtixml.cpp:418
+#: ../src/common/xtixml.cpp:414
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Une collection non vide doit comprendre des noeuds « éléments »"
 
@@ -1091,106 +1090,106 @@ msgstr "Une collection non vide doit comprendre des noeuds « éléments »"
 msgid "A standard bullet name."
 msgstr "Un nom de tiret standard."
 
-#: ../src/common/paper.cpp:217
+#: ../src/common/paper.cpp:214
 msgid "A0 sheet, 841 x 1189 mm"
 msgstr "Feuille A0, 841 x 1189 mm"
 
-#: ../src/common/paper.cpp:218
+#: ../src/common/paper.cpp:215
 msgid "A1 sheet, 594 x 841 mm"
 msgstr "Feuille A1, 594 x 841 mm"
 
-#: ../src/common/paper.cpp:159
+#: ../src/common/paper.cpp:156
 msgid "A2 420 x 594 mm"
 msgstr "A2 420 x 594 mm"
 
-#: ../src/common/paper.cpp:156
+#: ../src/common/paper.cpp:153
 msgid "A3 Extra 322 x 445 mm"
 msgstr "A3 Extra 322 x 445 mm"
 
-#: ../src/common/paper.cpp:161
+#: ../src/common/paper.cpp:158
 msgid "A3 Extra Transverse 322 x 445 mm"
 msgstr "A3 Extra, Paysage, 322 x 445 mm"
 
-#: ../src/common/paper.cpp:170
+#: ../src/common/paper.cpp:167
 msgid "A3 Rotated 420 x 297 mm"
 msgstr "A3 Paysage 420 x 297 mm"
 
-#: ../src/common/paper.cpp:160
+#: ../src/common/paper.cpp:157
 msgid "A3 Transverse 297 x 420 mm"
 msgstr "A3 Portrait 297 x 420 mm"
 
-#: ../src/common/paper.cpp:106
+#: ../src/common/paper.cpp:103
 msgid "A3 sheet, 297 x 420 mm"
 msgstr "Feuille A3, 297 x 420 mm"
 
-#: ../src/common/paper.cpp:146
+#: ../src/common/paper.cpp:143
 msgid "A4 Extra 9.27 x 12.69 in"
 msgstr "A4 Extra 9.27 x 12.69 pouces"
 
-#: ../src/common/paper.cpp:153
+#: ../src/common/paper.cpp:150
 msgid "A4 Plus 210 x 330 mm"
 msgstr "A4 Plus 210 x 330 mm"
 
-#: ../src/common/paper.cpp:171
+#: ../src/common/paper.cpp:168
 msgid "A4 Rotated 297 x 210 mm"
 msgstr "A4 Paysage 297 x 210 mm"
 
-#: ../src/common/paper.cpp:148
+#: ../src/common/paper.cpp:145
 msgid "A4 Transverse 210 x 297 mm"
 msgstr "A4 Portrait 210 x 297 mm"
 
-#: ../src/common/paper.cpp:97
+#: ../src/common/paper.cpp:94
 msgid "A4 sheet, 210 x 297 mm"
 msgstr "Feuille A4, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:107
+#: ../src/common/paper.cpp:104
 msgid "A4 small sheet, 210 x 297 mm"
 msgstr "Petite feuille A4, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:157
+#: ../src/common/paper.cpp:154
 msgid "A5 Extra 174 x 235 mm"
 msgstr "A5 Extra 174 x 235 mm"
 
-#: ../src/common/paper.cpp:172
+#: ../src/common/paper.cpp:169
 msgid "A5 Rotated 210 x 148 mm"
 msgstr "A5 Paysage 210 x 148 mm"
 
-#: ../src/common/paper.cpp:154
+#: ../src/common/paper.cpp:151
 msgid "A5 Transverse 148 x 210 mm"
 msgstr "A5 Portrait 148 x 210 mm"
 
-#: ../src/common/paper.cpp:108
+#: ../src/common/paper.cpp:105
 msgid "A5 sheet, 148 x 210 mm"
 msgstr "Feuille A5, 148 x 210 mm"
 
-#: ../src/common/paper.cpp:164
+#: ../src/common/paper.cpp:161
 msgid "A6 105 x 148 mm"
 msgstr "A6 105 x 148 mm"
 
-#: ../src/common/paper.cpp:177
+#: ../src/common/paper.cpp:174
 msgid "A6 Rotated 148 x 105 mm"
 msgstr "A6 Paysage 148 x 105 mm"
 
-#: ../src/generic/fontdlgg.cpp:83 ../src/richtext/richtextformatdlg.cpp:529
-#: ../src/osx/carbon/fontdlg.cpp:153
+#: ../src/osx/carbon/fontdlg.cpp:150 ../src/generic/fontdlgg.cpp:79
+#: ../src/richtext/richtextformatdlg.cpp:521
 msgid "ABCDEFGabcdefg12345"
 msgstr "ABCDEFGabcdefg12345"
 
-#: ../src/richtext/richtextsymboldlg.cpp:458 ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
 msgid "ASCII"
 msgstr "ASCII"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "About"
 msgstr "À propos"
 
-#: ../src/generic/aboutdlgg.cpp:140 ../src/osx/menu_osx.cpp:558
-#: ../src/msw/aboutdlg.cpp:64
+#: ../src/osx/menu_osx.cpp:450 ../src/generic/aboutdlgg.cpp:137
+#: ../src/msw/aboutdlg.cpp:61
 #, c-format
 msgid "About %s"
 msgstr "À propos de %s"
 
-#: ../src/osx/menu_osx.cpp:560
+#: ../src/osx/menu_osx.cpp:452
 msgid "About..."
 msgstr "À propos..."
 
@@ -1199,37 +1198,37 @@ msgid "Absolute"
 msgstr "Absolue"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:873
+#: ../src/propgrid/advprops.cpp:774
 msgid "ActiveBorder"
 msgstr "ActiveBorder"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:874
+#: ../src/propgrid/advprops.cpp:775
 msgid "ActiveCaption"
 msgstr "ActiveCaption"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "Actual Size"
 msgstr "Taille Actuelle"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:140 ../src/common/accelcmn.cpp:81
+#: ../src/common/stockitem.cpp:137 ../src/common/accelcmn.cpp:78
 msgid "Add"
 msgstr "Ajouter"
 
-#: ../src/richtext/richtextbuffer.cpp:11455
+#: ../src/richtext/richtextbuffer.cpp:11454
 msgid "Add Column"
 msgstr "Ajouter une colonne"
 
-#: ../src/richtext/richtextbuffer.cpp:11392
+#: ../src/richtext/richtextbuffer.cpp:11391
 msgid "Add Row"
 msgstr "Ajouter une ligne"
 
-#: ../src/html/helpwnd.cpp:432
+#: ../src/html/helpwnd.cpp:430
 msgid "Add current page to bookmarks"
 msgstr "Ajouter la page courante aux marque-pages"
 
-#: ../src/generic/colrdlgg.cpp:366
+#: ../src/generic/colrdlgg.cpp:386
 msgid "Add to custom colours"
 msgstr "Ajouter aux couleurs personnalisées"
 
@@ -1241,12 +1240,12 @@ msgstr "AddToPropertyCollection appelé sur un assesseur générique"
 msgid "AddToPropertyCollection called w/o valid adder"
 msgstr "AddToPropertyCollection appelé sans additionneur valable"
 
-#: ../src/html/helpctrl.cpp:159
+#: ../src/html/helpctrl.cpp:155
 #, c-format
 msgid "Adding book %s"
 msgstr "Ajouter le manuel %s"
 
-#: ../src/common/preferencescmn.cpp:43
+#: ../src/common/preferencescmn.cpp:40
 msgid "Advanced"
 msgstr "Avancé"
 
@@ -1254,11 +1253,11 @@ msgstr "Avancé"
 msgid "After a paragraph:"
 msgstr "Après un paragraphe:"
 
-#: ../src/common/stockitem.cpp:172
+#: ../src/common/stockitem.cpp:169
 msgid "Align Left"
 msgstr "Aligner à gauche"
 
-#: ../src/common/stockitem.cpp:173
+#: ../src/common/stockitem.cpp:170
 msgid "Align Right"
 msgstr "Aligner à droite"
 
@@ -1266,40 +1265,40 @@ msgstr "Aligner à droite"
 msgid "Alignment"
 msgstr "Alignement"
 
-#: ../src/generic/prntdlgg.cpp:215
+#: ../src/generic/prntdlgg.cpp:208
 msgid "All"
 msgstr "Tout"
 
-#: ../src/generic/filectrlg.cpp:1197 ../src/common/fldlgcmn.cpp:107
+#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1186
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Tous les fichiers (%s)|%s"
 
-#: ../include/wx/defs.h:2886
+#: ../include/wx/defs.h:2582
 msgid "All files (*)|*"
 msgstr "Tous les fichiers (*)|*"
 
-#: ../include/wx/defs.h:2883
+#: ../include/wx/defs.h:2579
 msgid "All files (*.*)|*.*"
 msgstr "Tous les fichiers (*.*)|*.*"
 
-#: ../src/richtext/richtextstyles.cpp:1061
+#: ../src/richtext/richtextstyles.cpp:1058
 msgid "All styles"
 msgstr "Tous les styles"
 
-#: ../src/propgrid/manager.cpp:1528
+#: ../src/propgrid/manager.cpp:1544
 msgid "Alphabetic Mode"
 msgstr "Mode Alphabétique"
 
-#: ../src/common/xtistrm.cpp:425
+#: ../src/common/xtistrm.cpp:422
 msgid "Already Registered Object passed to SetObjectClassInfo"
 msgstr "Objet déjà enregistré envoyé à SetObjectClassInfo"
 
-#: ../src/unix/dialup.cpp:353
+#: ../src/unix/dialup.cpp:352
 msgid "Already dialling ISP."
 msgstr "FAI déjà en cours d'appel."
 
-#: ../src/common/accelcmn.cpp:331 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/accelcmn.cpp:345 ../src/univ/themes/win32.cpp:3753
 msgid "Alt+"
 msgstr "Alt+"
 
@@ -1308,35 +1307,35 @@ msgstr "Alt+"
 msgid "An optional corner radius for adding rounded corners."
 msgstr "Un rayon de courbure optionnel pour ajouter des coins arrondis."
 
-#: ../src/common/debugrpt.cpp:576
+#: ../src/common/debugrpt.cpp:577
 msgid "And includes the following files:\n"
 msgstr "Et inclut les fichiers suivants :\n"
 
-#: ../src/generic/animateg.cpp:162
+#: ../src/generic/animateg.cpp:145
 #, c-format
 msgid "Animation file is not of type %ld."
 msgstr "Le fichier animé n'est pas du type %ld."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:872
+#: ../src/propgrid/advprops.cpp:773
 msgid "AppWorkspace"
 msgstr "AppWorkspace"
 
-#: ../src/generic/logg.cpp:1014
+#: ../src/generic/logg.cpp:1011
 #, c-format
 msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
 msgstr ""
 "Faut-il ajouter le journal au fichier « %s » (choisir [Non] l'écrasera) ?"
 
-#: ../src/osx/menu_osx.cpp:577 ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:469 ../src/osx/menu_osx.cpp:477
 msgid "Application"
 msgstr "Application"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "Apply"
 msgstr "Appliquer"
 
-#: ../src/propgrid/advprops.cpp:1609
+#: ../src/propgrid/advprops.cpp:1515
 msgid "Aqua"
 msgstr "Aqua"
 
@@ -1345,29 +1344,29 @@ msgstr "Aqua"
 msgid "Arabic"
 msgstr "Arabe"
 
-#: ../src/common/fmapbase.cpp:153
+#: ../src/common/fmapbase.cpp:150
 msgid "Arabic (ISO-8859-6)"
 msgstr "Arabe (ISO-8859-6)"
 
-#: ../src/msw/ole/automtn.cpp:672
+#: ../src/msw/ole/automtn.cpp:663
 #, c-format
 msgid "Argument %u not found."
 msgstr "Argument %u non trouvé."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1753
+#: ../src/propgrid/advprops.cpp:1654
 msgid "Arrow"
 msgstr "Flèche"
 
-#: ../src/generic/aboutdlgg.cpp:184
+#: ../src/generic/aboutdlgg.cpp:181
 msgid "Artists"
 msgstr "Artistes"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "Ascending"
 msgstr "Croissant"
 
-#: ../src/generic/filectrlg.cpp:433
+#: ../src/generic/filectrlg.cpp:429
 msgid "Attributes"
 msgstr "Attributs"
 
@@ -1377,90 +1376,90 @@ msgstr "Attributs"
 msgid "Available fonts."
 msgstr "Polices de caractères disponibles."
 
-#: ../src/common/paper.cpp:137
+#: ../src/common/paper.cpp:134
 msgid "B4 (ISO) 250 x 353 mm"
 msgstr "B4 (ISO) 250 x 353 mm"
 
-#: ../src/common/paper.cpp:173
+#: ../src/common/paper.cpp:170
 msgid "B4 (JIS) Rotated 364 x 257 mm"
 msgstr "B4 (JIS) Paysage 364 x 257 mm"
 
-#: ../src/common/paper.cpp:127
+#: ../src/common/paper.cpp:124
 msgid "B4 Envelope, 250 x 353 mm"
 msgstr "Enveloppe B4, 250 x 353 mm"
 
-#: ../src/common/paper.cpp:109
+#: ../src/common/paper.cpp:106
 msgid "B4 sheet, 250 x 354 mm"
 msgstr "Feuille B4, 250 x 354 mm"
 
-#: ../src/common/paper.cpp:158
+#: ../src/common/paper.cpp:155
 msgid "B5 (ISO) Extra 201 x 276 mm"
 msgstr "B5 (ISO) Extra 201 x 276 mm"
 
-#: ../src/common/paper.cpp:174
+#: ../src/common/paper.cpp:171
 msgid "B5 (JIS) Rotated 257 x 182 mm"
 msgstr "B5 (JIS) Paysage 257 x 182 mm"
 
-#: ../src/common/paper.cpp:155
+#: ../src/common/paper.cpp:152
 msgid "B5 (JIS) Transverse 182 x 257 mm"
 msgstr "B5 (JIS), Paysage, 182 x 257 mm"
 
-#: ../src/common/paper.cpp:128
+#: ../src/common/paper.cpp:125
 msgid "B5 Envelope, 176 x 250 mm"
 msgstr "Enveloppe B5, 176 x 250 mm"
 
-#: ../src/common/paper.cpp:110
+#: ../src/common/paper.cpp:107
 msgid "B5 sheet, 182 x 257 millimeter"
 msgstr "Feuille B5, 182 x 257 mm"
 
-#: ../src/common/paper.cpp:182
+#: ../src/common/paper.cpp:179
 msgid "B6 (JIS) 128 x 182 mm"
 msgstr "B6 (JIS) 128 x 182 mm"
 
-#: ../src/common/paper.cpp:183
+#: ../src/common/paper.cpp:180
 msgid "B6 (JIS) Rotated 182 x 128 mm"
 msgstr "B6 (JIS) Paysage 182 x 128 mm"
 
-#: ../src/common/paper.cpp:129
+#: ../src/common/paper.cpp:126
 msgid "B6 Envelope, 176 x 125 mm"
 msgstr "Enveloppe B6, 176 x 125 mm"
 
-#: ../src/common/imagbmp.cpp:531 ../src/common/imagbmp.cpp:561
-#: ../src/common/imagbmp.cpp:576
+#: ../src/common/imagbmp.cpp:528 ../src/common/imagbmp.cpp:558
+#: ../src/common/imagbmp.cpp:573
 msgid "BMP: Couldn't allocate memory."
 msgstr "BMP : impossible d'allouer de la mémoire."
 
-#: ../src/common/imagbmp.cpp:100
+#: ../src/common/imagbmp.cpp:97
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP : impossible de sauvegarder une image non valable."
 
-#: ../src/common/imagbmp.cpp:356
+#: ../src/common/imagbmp.cpp:353
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP : impossible d'écrire la palette de couleurs RGB."
 
-#: ../src/common/imagbmp.cpp:490
+#: ../src/common/imagbmp.cpp:487
 msgid "BMP: Couldn't write data."
 msgstr "BMP : impossible d'écrire les données."
 
-#: ../src/common/imagbmp.cpp:246
+#: ../src/common/imagbmp.cpp:243
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP : impossible d'écrire l'entête du fichier (Bitmap)."
 
-#: ../src/common/imagbmp.cpp:269
+#: ../src/common/imagbmp.cpp:266
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP : impossible d'écrire l'entête du fichier (BitmapInfo)."
 
-#: ../src/common/imagbmp.cpp:140
+#: ../src/common/imagbmp.cpp:137
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP : wxImage n'a pas sa propre wxPalette."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:142 ../src/common/accelcmn.cpp:52
+#: ../src/common/stockitem.cpp:139 ../src/common/accelcmn.cpp:49
 msgid "Back"
 msgstr "Retour"
 
+#: ../src/richtext/richtextformatdlg.cpp:377
 #: ../src/richtext/richtextbackgroundpage.cpp:148
-#: ../src/richtext/richtextformatdlg.cpp:384
 msgid "Background"
 msgstr "Arrière plan"
 
@@ -1468,20 +1467,20 @@ msgstr "Arrière plan"
 msgid "Background &colour:"
 msgstr "&Couleur d'arrière plan :"
 
-#: ../src/osx/carbon/fontdlg.cpp:220
+#: ../src/osx/carbon/fontdlg.cpp:217
 msgid "Background colour"
 msgstr "Couleur d'arrière plan"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:52
+#: ../src/common/accelcmn.cpp:49
 msgid "Backspace"
 msgstr "Retour arrière"
 
-#: ../src/common/fmapbase.cpp:160
+#: ../src/common/fmapbase.cpp:157
 msgid "Baltic (ISO-8859-13)"
 msgstr "Balte (ISO-8859-13)"
 
-#: ../src/common/fmapbase.cpp:151
+#: ../src/common/fmapbase.cpp:148
 msgid "Baltic (old) (ISO-8859-4)"
 msgstr "Balte (ancien) (ISO-8859-4)"
 
@@ -1494,25 +1493,25 @@ msgstr "Avant un paragraphe:"
 msgid "Bitmap"
 msgstr "Image bitmap"
 
-#: ../src/propgrid/advprops.cpp:1594
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Black"
 msgstr "Noir"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1755
+#: ../src/propgrid/advprops.cpp:1656
 msgid "Blank"
 msgstr "Vide"
 
-#: ../src/propgrid/advprops.cpp:1603
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Blue"
 msgstr "Bleu"
 
-#: ../src/generic/colrdlgg.cpp:345
+#: ../src/generic/colrdlgg.cpp:365
 msgid "Blue:"
 msgstr "Bleu :"
 
-#: ../src/generic/fontdlgg.cpp:333 ../src/richtext/richtextfontpage.cpp:355
-#: ../src/osx/carbon/fontdlg.cpp:354 ../src/common/stockitem.cpp:143
+#: ../src/osx/carbon/fontdlg.cpp:351 ../src/common/stockitem.cpp:140
+#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:355
 msgid "Bold"
 msgstr "Gras"
 
@@ -1521,31 +1520,35 @@ msgstr "Gras"
 msgid "Border"
 msgstr "Bord"
 
-#: ../src/richtext/richtextformatdlg.cpp:379
+#: ../src/richtext/richtextformatdlg.cpp:372
 msgid "Borders"
 msgstr "Bords"
 
-#: ../src/richtext/richtextsizepage.cpp:288 ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141 ../src/richtext/richtextsizepage.cpp:288
 msgid "Bottom"
 msgstr "Bas"
 
-#: ../src/generic/prntdlgg.cpp:893
+#: ../src/generic/prntdlgg.cpp:886
 msgid "Bottom margin (mm):"
 msgstr "Marge de bas de page (mm) :"
 
-#: ../src/richtext/richtextbuffer.cpp:9383
+#: ../src/richtext/richtextbuffer.cpp:9380
 msgid "Box Properties"
 msgstr "Propriétés de la boîte"
 
-#: ../src/richtext/richtextstyles.cpp:1065
+#: ../src/richtext/richtextstyles.cpp:1062
 msgid "Box styles"
 msgstr "Styles de boîte"
 
-#: ../src/propgrid/advprops.cpp:1602
+#: ../src/osx/cocoa/menu.mm:292
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Brown"
 msgstr "Brun"
 
-#: ../src/common/filepickercmn.cpp:43 ../src/common/filepickercmn.cpp:44
+#: ../src/common/filepickercmn.cpp:40 ../src/common/filepickercmn.cpp:41
 msgid "Browse"
 msgstr "Parcourir"
 
@@ -1558,72 +1561,72 @@ msgstr "&Alignement des tirets:"
 msgid "Bullet style"
 msgstr "Style des tirets"
 
-#: ../src/richtext/richtextformatdlg.cpp:359
+#: ../src/richtext/richtextformatdlg.cpp:352
 msgid "Bullets"
 msgstr "Tirets"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1756
+#: ../src/propgrid/advprops.cpp:1657
 msgid "Bullseye"
 msgstr "Carton"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:875
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonFace"
 msgstr "ButtonFace"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:876
+#: ../src/propgrid/advprops.cpp:777
 msgid "ButtonHighlight"
 msgstr "ButtonHighlight"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:877
+#: ../src/propgrid/advprops.cpp:778
 msgid "ButtonShadow"
 msgstr "ButtonShadow"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:878
+#: ../src/propgrid/advprops.cpp:779
 msgid "ButtonText"
 msgstr "ButtonText"
 
-#: ../src/common/paper.cpp:98
+#: ../src/common/paper.cpp:95
 msgid "C sheet, 17 x 22 in"
 msgstr "Feuille C, 17 x 22 mm"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "C&lear"
 msgstr "&Effacer"
 
-#: ../src/generic/fontdlgg.cpp:406
+#: ../src/generic/fontdlgg.cpp:403
 msgid "C&olour:"
 msgstr "C&ouleur :"
 
-#: ../src/common/paper.cpp:123
+#: ../src/common/paper.cpp:120
 msgid "C3 Envelope, 324 x 458 mm"
 msgstr "Enveloppe C3, 324 x 458 mm"
 
-#: ../src/common/paper.cpp:124
+#: ../src/common/paper.cpp:121
 msgid "C4 Envelope, 229 x 324 mm"
 msgstr "Enveloppe C4, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:122
+#: ../src/common/paper.cpp:119
 msgid "C5 Envelope, 162 x 229 mm"
 msgstr "Enveloppe C5, 162 x 229 mm"
 
-#: ../src/common/paper.cpp:125
+#: ../src/common/paper.cpp:122
 msgid "C6 Envelope, 114 x 162 mm"
 msgstr "Enveloppe C6, 114 x 162 mm"
 
-#: ../src/common/paper.cpp:126
+#: ../src/common/paper.cpp:123
 msgid "C65 Envelope, 114 x 229 mm"
 msgstr "Enveloppe C65, 114 x 229 mm"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "CD-Rom"
 msgstr "CD-Rom"
 
-#: ../src/html/chm.cpp:815 ../src/html/chm.cpp:874
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:865
 msgid "CHM handler currently supports only local files!"
 msgstr "Le gestionnaire CHM ne gère actuellement que les fichiers locaux !"
 
@@ -1631,196 +1634,200 @@ msgstr "Le gestionnaire CHM ne gère actuellement que les fichiers locaux !"
 msgid "Ca&pitals"
 msgstr "Majuscules"
 
-#: ../src/common/cmdproc.cpp:267
+#: ../src/common/cmdproc.cpp:260
 msgid "Can't &Undo "
 msgstr "Impossible d'&annuler "
 
-#: ../src/common/image.cpp:2824
+#: ../src/common/image.cpp:2924
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 "Impossible de déterminer le format d'image pour une entrée non positionnable."
 
-#: ../src/msw/registry.cpp:506
+#: ../src/msw/registry.cpp:495
 #, c-format
 msgid "Can't close registry key '%s'"
 msgstr "Impossible de fermer la clé de registre « %s »"
 
-#: ../src/msw/registry.cpp:584
+#: ../src/msw/registry.cpp:573
 #, c-format
 msgid "Can't copy values of unsupported type %d."
 msgstr "Impossible de copier les valeurs de type %d non reconnu."
 
-#: ../src/msw/registry.cpp:487
+#: ../src/msw/registry.cpp:476
 #, c-format
 msgid "Can't create registry key '%s'"
 msgstr "Impossible de créer la clé de registre « %s »"
 
-#: ../src/msw/thread.cpp:665
+#: ../src/msw/thread.cpp:657
 msgid "Can't create thread"
 msgstr "Impossible de créer le processus"
 
-#: ../src/msw/window.cpp:3691
-#, c-format
-msgid "Can't create window of class %s"
-msgstr "Impossible de créer la fenêtre de classe %s"
-
-#: ../src/msw/registry.cpp:777
+#: ../src/msw/registry.cpp:765
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Impossible d'effacer la clé « %s »"
 
-#: ../src/msw/iniconf.cpp:458
+#: ../src/msw/iniconf.cpp:455
 #, c-format
 msgid "Can't delete the INI file '%s'"
 msgstr "Impossible d'effacer le fichier INI « %s »"
 
-#: ../src/msw/registry.cpp:805
+#: ../src/msw/registry.cpp:793
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Impossible d'effacer la valeur « %s » de la clé « %s »"
 
-#: ../src/msw/registry.cpp:1171
+#: ../src/msw/registry.cpp:1159
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Impossible d'énumérer les sous-clés de la clé « %s »"
 
-#: ../src/msw/registry.cpp:1132
+#: ../src/msw/registry.cpp:1120
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Impossible d'énumérer les valeurs de la clé « %s »"
 
-#: ../src/msw/registry.cpp:1389
+#: ../src/msw/registry.cpp:1377
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Impossible d'exporter les valeurs de type non reconnu %d."
 
-#: ../src/common/ffile.cpp:254
+#: ../src/common/ffile.cpp:253
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Impossible de trouver la position courante dans le fichier « %s »"
 
-#: ../src/msw/registry.cpp:418
+#: ../src/msw/registry.cpp:407
 #, c-format
 msgid "Can't get info about registry key '%s'"
 msgstr "Impossible d'obtenir des informations sur la clé de registre « %s »"
 
-#: ../src/common/zstream.cpp:346
+#: ../src/msw/webview_ie.cpp:1024
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "Impossible de spécifier la priorité du processus"
+
+#: ../src/common/zstream.cpp:343
 msgid "Can't initialize zlib deflate stream."
 msgstr "Impossible d'initialiser le flux de déchargement de zlib."
 
-#: ../src/common/zstream.cpp:185
+#: ../src/common/zstream.cpp:182
 msgid "Can't initialize zlib inflate stream."
 msgstr "Impossible d'initialiser le flux de chargement de zlib."
 
-#: ../src/msw/fswatcher.cpp:476
+#: ../src/msw/fswatcher.cpp:475
 #, c-format
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "Impossible de surveiller les changements du dossier inexistant « %s »."
 
-#: ../src/msw/registry.cpp:454
+#: ../src/msw/registry.cpp:443
 #, c-format
 msgid "Can't open registry key '%s'"
 msgstr "Impossible d'ouvrir la clé de registre « %s »"
 
-#: ../src/common/zstream.cpp:252
+#: ../src/common/zstream.cpp:249
 #, c-format
 msgid "Can't read from inflate stream: %s"
 msgstr "Impossible de lire le flux de chargement : %s"
 
-#: ../src/common/zstream.cpp:244
+#: ../src/common/zstream.cpp:241
 msgid "Can't read inflate stream: unexpected EOF in underlying stream."
 msgstr ""
 "Impossible de lire le flux de chargement : EOF inattendu dans le flux "
 "inférieur."
 
-#: ../src/msw/registry.cpp:1064
+#: ../src/msw/registry.cpp:1052
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Impossible de lire la valeur de « %s »"
 
-#: ../src/msw/registry.cpp:878 ../src/msw/registry.cpp:910
-#: ../src/msw/registry.cpp:975
+#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
+#: ../src/msw/registry.cpp:963
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Impossible de lire la valeur de la clé « %s »"
 
-#: ../src/common/image.cpp:2620
+#: ../src/msw/webview_ie.cpp:1017
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/common/image.cpp:2715
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr ""
 "Impossible d'enregistrer l'image dans le fichier « %s » : extension inconnue."
 
-#: ../src/generic/logg.cpp:573 ../src/generic/logg.cpp:976
+#: ../src/generic/logg.cpp:570 ../src/generic/logg.cpp:973
 msgid "Can't save log contents to file."
 msgstr "Impossible d'enregistrer le contenu du journal dans le fichier."
 
-#: ../src/msw/thread.cpp:629
+#: ../src/msw/thread.cpp:621
 msgid "Can't set thread priority"
 msgstr "Impossible de spécifier la priorité du processus"
 
-#: ../src/msw/registry.cpp:896 ../src/msw/registry.cpp:938
-#: ../src/msw/registry.cpp:1081
+#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
+#: ../src/msw/registry.cpp:1069
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Impossible de spécifier la valeur de « %s »"
 
-#: ../src/unix/utilsunx.cpp:351
+#: ../src/unix/utilsunx.cpp:353
 msgid "Can't write to child process's stdin"
 msgstr "Impossible d'écrire sur l'entrée du processus enfant"
 
-#: ../src/common/zstream.cpp:427
+#: ../src/common/zstream.cpp:424
 #, c-format
 msgid "Can't write to deflate stream: %s"
 msgstr "Impossible d'écrire pour décharger le flux : %s"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:279 ../src/richtext/richtextstyledlg.cpp:300
-#: ../src/common/stockitem.cpp:145 ../src/common/accelcmn.cpp:71
-#: ../src/msw/msgdlg.cpp:454 ../src/msw/progdlg.cpp:673
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:142
+#: ../src/common/accelcmn.cpp:68 ../src/motif/msgdlg.cpp:196
+#: ../src/gtk1/fontdlg.cpp:144 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/progdlg.cpp:940 ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Annuler"
 
-#: ../src/common/filefn.cpp:1261
+#: ../src/common/filefn.cpp:1149
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Impossible d'énumérer les fichiers « %s »"
 
-#: ../src/msw/dir.cpp:263
+#: ../src/msw/dir.cpp:260
 #, c-format
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Impossible d'énumérer les fichiers dans le répertoire « %s »"
 
-#: ../src/msw/dialup.cpp:523
+#: ../src/msw/dialup.cpp:517
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Impossible de trouver une connexion active : %s"
 
-#: ../src/msw/dialup.cpp:827
+#: ../src/msw/dialup.cpp:821
 msgid "Cannot find the location of address book file"
 msgstr "Impossible de trouver l'emplacement du fichier du manuel des adresses"
 
-#: ../src/msw/ole/automtn.cpp:562
+#: ../src/msw/ole/automtn.cpp:553
 #, c-format
 msgid "Cannot get an active instance of \"%s\""
 msgstr "Impossible d'obtenir une instance active de : « %s »"
 
-#: ../src/unix/threadpsx.cpp:1035
+#: ../src/unix/threadpsx.cpp:1053
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr ""
 "Impossible d'obtenir une gamme de priorités pour la stratégie de "
 "planification %d."
 
-#: ../src/unix/utilsunx.cpp:987
+#: ../src/unix/utilsunx.cpp:989
 msgid "Cannot get the hostname"
 msgstr "Impossible d'obtenir le nom d'hôte"
 
-#: ../src/unix/utilsunx.cpp:1023
+#: ../src/unix/utilsunx.cpp:1025
 msgid "Cannot get the official hostname"
 msgstr "Impossible d'obtenir le nom d'hôte officiel"
 
-#: ../src/msw/dialup.cpp:928
+#: ../src/msw/dialup.cpp:922
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Impossible de raccrocher - pas de connexion active."
 
@@ -1828,126 +1835,126 @@ msgstr "Impossible de raccrocher - pas de connexion active."
 msgid "Cannot initialize OLE"
 msgstr "Impossible d'initialiser l'OLE"
 
-#: ../src/common/socket.cpp:853
+#: ../src/common/socket.cpp:850
 msgid "Cannot initialize sockets"
 msgstr "Impossible d'initialiser les sockets"
 
-#: ../src/msw/volume.cpp:619
+#: ../src/msw/volume.cpp:627
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Impossible de charger l'icône depuis « %s »."
 
-#: ../src/xrc/xmlres.cpp:360
+#: ../src/xrc/xmlres.cpp:358
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Impossible de charger les ressources depuis « %s »."
 
-#: ../src/xrc/xmlres.cpp:742
+#: ../src/xrc/xmlres.cpp:740
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Impossible de charger les ressources du fichier « %s »."
 
-#: ../src/html/htmlfilt.cpp:137
+#: ../src/html/htmlfilt.cpp:134
 #, c-format
 msgid "Cannot open HTML document: %s"
 msgstr "Impossible d'ouvrir le document HTML : %s"
 
-#: ../src/html/helpdata.cpp:667
+#: ../src/html/helpdata.cpp:660
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Impossible d'ouvrir le manuel d'aide HTML : %s"
 
-#: ../src/html/helpdata.cpp:299
+#: ../src/html/helpdata.cpp:296
 #, c-format
 msgid "Cannot open contents file: %s"
 msgstr "Impossible d'ouvrir le fichier de table des matières : %s"
 
-#: ../src/generic/dcpsg.cpp:1667
+#: ../src/generic/dcpsg.cpp:1665
 msgid "Cannot open file for PostScript printing!"
 msgstr "Impossible d'ouvrir le fichier pour une impression PostScript !"
 
-#: ../src/html/helpdata.cpp:313
+#: ../src/html/helpdata.cpp:310
 #, c-format
 msgid "Cannot open index file: %s"
 msgstr "Impossible d'ouvrir le fichier d'index : %s"
 
-#: ../src/xrc/xmlres.cpp:724
+#: ../src/xrc/xmlres.cpp:722
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Impossible d'ouvrir le fichier de ressources « %s »."
 
-#: ../src/html/helpwnd.cpp:1534
+#: ../src/html/helpwnd.cpp:1532
 msgid "Cannot print empty page."
 msgstr "Impossible d'imprimer une page vide."
 
-#: ../src/msw/volume.cpp:507
+#: ../src/msw/volume.cpp:515
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Impossible de lire le nom de type de « %s » !"
 
-#: ../src/msw/thread.cpp:888
+#: ../src/msw/thread.cpp:894
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Impossible de reprendre le thread %lx"
 
-#: ../src/unix/threadpsx.cpp:1016
+#: ../src/unix/threadpsx.cpp:1028
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Impossible de récupérer la charte de planification des processus."
 
-#: ../src/common/intl.cpp:558
+#: ../src/common/intl.cpp:365
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "Impossible d'établir la localisation pour la langue « %s »."
 
-#: ../src/unix/threadpsx.cpp:831 ../src/msw/thread.cpp:546
+#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
 msgid "Cannot start thread: error writing TLS."
 msgstr "Impossible de lancer le processus : erreur lors de l'écriture de TLS."
 
-#: ../src/msw/thread.cpp:872
+#: ../src/msw/thread.cpp:864
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Impossible de suspendre le thread %lx"
 
-#: ../src/msw/thread.cpp:794
+#: ../src/msw/thread.cpp:786
 msgid "Cannot wait for thread termination"
 msgstr "Impossible d'attendre la fin du processus"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:75
+#: ../src/common/accelcmn.cpp:72
 msgid "Capital"
 msgstr "Majuscule"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:879
+#: ../src/propgrid/advprops.cpp:780
 msgid "CaptionText"
 msgstr "CaptionText"
 
-#: ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:531
 msgid "Case sensitive"
 msgstr "Sensible à la casse"
 
-#: ../src/propgrid/manager.cpp:1509
+#: ../src/propgrid/manager.cpp:1527
 msgid "Categorized Mode"
 msgstr "Mode Catégories"
 
-#: ../src/richtext/richtextbuffer.cpp:9968
+#: ../src/richtext/richtextbuffer.cpp:9965
 msgid "Cell Properties"
 msgstr "Propriétés de Cellule"
 
-#: ../src/common/fmapbase.cpp:161
+#: ../src/common/fmapbase.cpp:158
 msgid "Celtic (ISO-8859-14)"
 msgstr "Celtique (ISO-8859-14)"
 
-#: ../src/richtext/richtextindentspage.cpp:160
 #: ../src/richtext/richtextliststylepage.cpp:349
+#: ../src/richtext/richtextindentspage.cpp:160
 msgid "Cen&tred"
 msgstr "Cen&tré"
 
-#: ../src/common/stockitem.cpp:170
+#: ../src/common/stockitem.cpp:167
 msgid "Centered"
 msgstr "Centré"
 
-#: ../src/common/fmapbase.cpp:149
+#: ../src/common/fmapbase.cpp:146
 msgid "Central European (ISO-8859-2)"
 msgstr "Europe centrale (ISO-8859-2)"
 
@@ -1956,10 +1963,10 @@ msgstr "Europe centrale (ISO-8859-2)"
 msgid "Centre"
 msgstr "Centre"
 
-#: ../src/richtext/richtextindentspage.cpp:162
-#: ../src/richtext/richtextindentspage.cpp:164
 #: ../src/richtext/richtextliststylepage.cpp:351
 #: ../src/richtext/richtextliststylepage.cpp:353
+#: ../src/richtext/richtextindentspage.cpp:162
+#: ../src/richtext/richtextindentspage.cpp:164
 msgid "Centre text."
 msgstr "Centrer le texte."
 
@@ -1972,24 +1979,24 @@ msgstr "Centré"
 msgid "Ch&oose..."
 msgstr "&Choisir..."
 
-#: ../src/richtext/richtextbuffer.cpp:4354
+#: ../src/richtext/richtextbuffer.cpp:4351
 msgid "Change List Style"
 msgstr "Modifier la liste de styles"
 
-#: ../src/richtext/richtextbuffer.cpp:3709
+#: ../src/richtext/richtextbuffer.cpp:3706
 msgid "Change Object Style"
 msgstr "Modifier le Style de l'Objet"
 
-#: ../src/richtext/richtextbuffer.cpp:3982
-#: ../src/richtext/richtextbuffer.cpp:8129
+#: ../src/richtext/richtextbuffer.cpp:3979
+#: ../src/richtext/richtextbuffer.cpp:8125
 msgid "Change Properties"
 msgstr "Modifier les Propriétés"
 
-#: ../src/richtext/richtextbuffer.cpp:3526
+#: ../src/richtext/richtextbuffer.cpp:3523
 msgid "Change Style"
 msgstr "Modifier le style"
 
-#: ../src/common/fileconf.cpp:341
+#: ../src/common/fileconf.cpp:335
 #, c-format
 msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
 msgstr ""
@@ -2002,11 +2009,11 @@ msgid "Changing current directory to \"%s\" failed"
 msgstr "Échec de la modification du dossier courant en « %s »"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1757
+#: ../src/propgrid/advprops.cpp:1658
 msgid "Character"
 msgstr "Caractère"
 
-#: ../src/richtext/richtextstyles.cpp:1063
+#: ../src/richtext/richtextstyles.cpp:1060
 msgid "Character styles"
 msgstr "Styles de caractères"
 
@@ -2043,20 +2050,20 @@ msgstr "Cocher pour mettre le tiret entre parenthèses."
 msgid "Check to indicate right-to-left text layout."
 msgstr "Cocher pour indiquer une disposition de texte de droite-à-gauche."
 
-#: ../src/osx/carbon/fontdlg.cpp:356 ../src/osx/carbon/fontdlg.cpp:358
+#: ../src/osx/carbon/fontdlg.cpp:353 ../src/osx/carbon/fontdlg.cpp:355
 msgid "Check to make the font bold."
 msgstr "Cocher pour mettre la police en gras."
 
-#: ../src/osx/carbon/fontdlg.cpp:363 ../src/osx/carbon/fontdlg.cpp:365
+#: ../src/osx/carbon/fontdlg.cpp:360 ../src/osx/carbon/fontdlg.cpp:362
 msgid "Check to make the font italic."
 msgstr "Cocher pour mettre la police en italique."
 
-#: ../src/osx/carbon/fontdlg.cpp:372 ../src/osx/carbon/fontdlg.cpp:374
+#: ../src/osx/carbon/fontdlg.cpp:369 ../src/osx/carbon/fontdlg.cpp:371
 msgid "Check to make the font underlined."
 msgstr "Cocher pour mettre la police en souligné."
 
-#: ../src/richtext/richtextstyledlg.cpp:289
-#: ../src/richtext/richtextstyledlg.cpp:291
+#: ../src/richtext/richtextstyledlg.cpp:285
+#: ../src/richtext/richtextstyledlg.cpp:287
 msgid "Check to restart numbering."
 msgstr "Cocher pour recommencer la numérotation."
 
@@ -2090,51 +2097,51 @@ msgstr "Cocher pour afficher le texte en exposant."
 msgid "Check to suppress hyphenation."
 msgstr "Cocher pour supprimer l'hyphénation."
 
-#: ../src/msw/dialup.cpp:763
+#: ../src/msw/dialup.cpp:757
 msgid "Choose ISP to dial"
 msgstr "Choisir le FAI à appeler"
 
-#: ../src/propgrid/props.cpp:1922
+#: ../src/propgrid/props.cpp:1904
 msgid "Choose a directory:"
 msgstr "Choisir un dossier :"
 
-#: ../src/propgrid/props.cpp:1975
+#: ../src/propgrid/props.cpp:2199
 msgid "Choose a file"
 msgstr "Choisir un fichier"
 
-#: ../src/generic/colrdlgg.cpp:158 ../src/gtk/colordlg.cpp:54
+#: ../src/generic/colrdlgg.cpp:156 ../src/gtk/colordlg.cpp:49
 msgid "Choose colour"
 msgstr "Choisir la couleur"
 
-#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/gtk1/fontdlg.cpp:125 ../src/generic/fontpickerg.cpp:47
+#: ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Choisir la police"
 
-#: ../src/common/module.cpp:74
+#: ../src/common/module.cpp:71
 #, c-format
 msgid "Circular dependency involving module \"%s\" detected."
 msgstr "Dépendance en boucle détectée, impliquant le module \"%s\"."
 
-#: ../src/aui/tabmdi.cpp:108 ../src/generic/mdig.cpp:97
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
 msgid "Cl&ose"
 msgstr "&Fermer"
 
-#: ../src/msw/ole/automtn.cpp:684
+#: ../src/msw/ole/automtn.cpp:675
 msgid "Class not registered."
 msgstr "Classe non enregistrée."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:147 ../src/common/accelcmn.cpp:72
+#: ../src/common/stockitem.cpp:144 ../src/common/accelcmn.cpp:69
 msgid "Clear"
 msgstr "Effacer"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "Clear the log contents"
 msgstr "Effacer le contenu du journal"
 
-#: ../src/richtext/richtextstyledlg.cpp:252
-#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:248
+#: ../src/richtext/richtextstyledlg.cpp:250
 msgid "Click to apply the selected style."
 msgstr "Cliquer pour appliquer le style sélectionné."
 
@@ -2145,15 +2152,15 @@ msgstr "Cliquer pour appliquer le style sélectionné."
 msgid "Click to browse for a symbol."
 msgstr "Cliquer pour rechercher un symbole."
 
-#: ../src/osx/carbon/fontdlg.cpp:403 ../src/osx/carbon/fontdlg.cpp:405
+#: ../src/osx/carbon/fontdlg.cpp:400 ../src/osx/carbon/fontdlg.cpp:402
 msgid "Click to cancel changes to the font."
 msgstr "Cliquer pour annuler les modifications sur la police."
 
-#: ../src/generic/fontdlgg.cpp:472 ../src/generic/fontdlgg.cpp:491
+#: ../src/generic/fontdlgg.cpp:468 ../src/generic/fontdlgg.cpp:487
 msgid "Click to cancel the font selection."
 msgstr "Cliquer pour annuler la sélection de la police."
 
-#: ../src/osx/carbon/fontdlg.cpp:384 ../src/osx/carbon/fontdlg.cpp:386
+#: ../src/osx/carbon/fontdlg.cpp:381 ../src/osx/carbon/fontdlg.cpp:383
 msgid "Click to change the font colour."
 msgstr "Cliquez pour changer la couleur de la police."
 
@@ -2172,37 +2179,37 @@ msgstr "Cliquer pour changer la couleur du texte."
 msgid "Click to choose the font for this level."
 msgstr "Cliquer pour choisir la police de ce niveau."
 
-#: ../src/richtext/richtextstyledlg.cpp:279
-#: ../src/richtext/richtextstyledlg.cpp:281
+#: ../src/richtext/richtextstyledlg.cpp:275
+#: ../src/richtext/richtextstyledlg.cpp:277
 msgid "Click to close this window."
 msgstr "Cliquer pour fermer cette fenêtre."
 
-#: ../src/osx/carbon/fontdlg.cpp:410 ../src/osx/carbon/fontdlg.cpp:412
+#: ../src/osx/carbon/fontdlg.cpp:407 ../src/osx/carbon/fontdlg.cpp:409
 msgid "Click to confirm changes to the font."
 msgstr "Cliquer pour confirmer les modifications de la police."
 
-#: ../src/generic/fontdlgg.cpp:477 ../src/generic/fontdlgg.cpp:479
-#: ../src/generic/fontdlgg.cpp:484 ../src/generic/fontdlgg.cpp:486
+#: ../src/generic/fontdlgg.cpp:473 ../src/generic/fontdlgg.cpp:475
+#: ../src/generic/fontdlgg.cpp:480 ../src/generic/fontdlgg.cpp:482
 msgid "Click to confirm the font selection."
 msgstr "Cliquer pour confirmer la sélection de la police."
 
-#: ../src/richtext/richtextstyledlg.cpp:244
-#: ../src/richtext/richtextstyledlg.cpp:246
+#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:242
 msgid "Click to create a new box style."
 msgstr "Cliquer pour créer un nouveau style de boîte."
 
-#: ../src/richtext/richtextstyledlg.cpp:226
-#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:224
 msgid "Click to create a new character style."
 msgstr "Cliquer pour créer un nouveau style de caractère."
 
-#: ../src/richtext/richtextstyledlg.cpp:238
-#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:236
 msgid "Click to create a new list style."
 msgstr "Cliquer pour créer un nouveau style de liste."
 
-#: ../src/richtext/richtextstyledlg.cpp:232
-#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:230
 msgid "Click to create a new paragraph style."
 msgstr "Cliquer pour créer un nouveau style de paragraphe."
 
@@ -2216,8 +2223,8 @@ msgstr "Cliquer pour créer une nouvelle position de tabulation."
 msgid "Click to delete all tab positions."
 msgstr "Cliquer pour supprimer toutes les positions de tabulation."
 
-#: ../src/richtext/richtextstyledlg.cpp:270
-#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:268
 msgid "Click to delete the selected style."
 msgstr "Cliquer pour suprimer le style sélectionné."
 
@@ -2226,25 +2233,25 @@ msgstr "Cliquer pour suprimer le style sélectionné."
 msgid "Click to delete the selected tab position."
 msgstr "Cliquer pour supprimer la position de tabulation sélectionnée."
 
-#: ../src/richtext/richtextstyledlg.cpp:264
-#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:262
 msgid "Click to edit the selected style."
 msgstr "Cliquer pour éditer le style sélectionné."
 
-#: ../src/richtext/richtextstyledlg.cpp:258
-#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:256
 msgid "Click to rename the selected style."
 msgstr "Cliquer pour renommer le style sélectionné."
 
-#: ../src/generic/dbgrptg.cpp:97 ../src/generic/progdlgg.cpp:759
-#: ../src/richtext/richtextstyledlg.cpp:277
-#: ../src/richtext/richtextsymboldlg.cpp:476 ../src/common/stockitem.cpp:148
-#: ../src/msw/progdlg.cpp:170 ../src/msw/progdlg.cpp:679
-#: ../src/html/helpdlg.cpp:90
+#: ../src/common/stockitem.cpp:145 ../src/generic/dbgrptg.cpp:94
+#: ../src/generic/progdlgg.cpp:781 ../src/msw/progdlg.cpp:211
+#: ../src/msw/progdlg.cpp:946 ../src/html/helpdlg.cpp:87
+#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextstyledlg.cpp:273
 msgid "Close"
 msgstr "Fermer"
 
-#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:98
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
 msgid "Close All"
 msgstr "Fermer tout"
 
@@ -2252,43 +2259,43 @@ msgstr "Fermer tout"
 msgid "Close current document"
 msgstr "Fermer le document courant"
 
-#: ../src/generic/logg.cpp:516
+#: ../src/generic/logg.cpp:513
 msgid "Close this window"
 msgstr "Fermer cette fenêtre"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6006
+#: ../src/generic/datavgen.cpp:6811
 msgid "Collapse"
 msgstr "Compacter"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "Color"
 msgstr "Couleur"
 
-#: ../src/richtext/richtextformatdlg.cpp:776
+#: ../src/richtext/richtextformatdlg.cpp:768
 msgid "Colour"
 msgstr "Couleur"
 
-#: ../src/msw/colordlg.cpp:158
+#: ../src/msw/colordlg.cpp:227
 #, c-format
 msgid "Colour selection dialog failed with error %0lx."
 msgstr "Échec du dialogue de sélection de couleur avec l'erreur %0lx."
 
-#: ../src/osx/carbon/fontdlg.cpp:380
+#: ../src/osx/carbon/fontdlg.cpp:377
 msgid "Colour:"
 msgstr "Couleur :"
 
-#: ../src/generic/datavgen.cpp:6077
+#: ../src/generic/datavgen.cpp:6882
 #, c-format
 msgid "Column %u"
 msgstr "Colonne %u"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:114
+#: ../src/common/accelcmn.cpp:112
 msgid "Command"
 msgstr "Commande"
 
-#: ../src/common/init.cpp:196
+#: ../src/common/init.cpp:193
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
@@ -2297,12 +2304,12 @@ msgstr ""
 "L'argument %d de la ligne de commande n'a pas pu être converti en Unicode et "
 "sera ignoré."
 
-#: ../src/msw/fontdlg.cpp:120
+#: ../src/msw/fontdlg.cpp:170
 #, c-format
 msgid "Common dialog failed with error code %0lx."
 msgstr "Échec du dialogue commun avec le code d'erreur %0lx."
 
-#: ../src/gtk/window.cpp:4649
+#: ../src/gtk/window.cpp:5653
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
@@ -2310,11 +2317,11 @@ msgstr ""
 "La composition d'écran n'est pas reconnue par ce système, il faut l'activer "
 "dans le Gestionnaire de Fenêtre."
 
-#: ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:1549
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Fichier HTML compilé (*.chm)|*.chm|"
 
-#: ../src/generic/dirctrlg.cpp:444
+#: ../src/generic/dirctrlg.cpp:410
 msgid "Computer"
 msgstr "L'ordinateur"
 
@@ -2323,53 +2330,57 @@ msgstr "L'ordinateur"
 msgid "Config entry name cannot start with '%c'."
 msgstr "Le nom d'entrée de configuration ne peut pas commencer par « %c »."
 
-#: ../src/generic/filedlgg.cpp:349 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
 msgid "Confirm"
 msgstr "Confirmer"
 
-#: ../src/html/htmlwin.cpp:566
+#: ../src/html/htmlwin.cpp:569
 msgid "Connecting..."
 msgstr "Connexion en cours..."
 
-#: ../src/html/helpwnd.cpp:475
+#: ../src/html/helpwnd.cpp:473
 msgid "Contents"
 msgstr "Table des matières"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:880
+#: ../src/propgrid/advprops.cpp:781
 msgid "ControlDark"
 msgstr "ControlDark"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:881
+#: ../src/propgrid/advprops.cpp:782
 msgid "ControlLight"
 msgstr "ControlLight"
 
-#: ../src/common/strconv.cpp:2262
+#: ../src/common/strconv.cpp:2208
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "La conversion vers le jeu de caractères « %s » ne fonctionne pas."
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "Convert"
 msgstr "Convertir"
 
-#: ../src/html/htmlwin.cpp:1079
+#: ../src/html/htmlwin.cpp:1020
 #, c-format
 msgid "Copied to clipboard:\"%s\""
 msgstr "Copié dans le presse-papiers « %s »"
 
-#: ../src/generic/prntdlgg.cpp:247
+#: ../src/generic/prntdlgg.cpp:240
 msgid "Copies:"
 msgstr "Copies :"
 
-#: ../src/common/stockitem.cpp:150 ../src/stc/stc_i18n.cpp:18
+#: ../src/common/stockitem.cpp:147 ../src/stc/stc_i18n.cpp:18
 msgid "Copy"
 msgstr "Copier"
 
-#: ../src/common/stockitem.cpp:258
+#: ../src/common/stockitem.cpp:255
 msgid "Copy selection"
 msgstr "Copier la sélection"
+
+#: ../src/generic/grid.cpp:5945
+msgid "Copying more than one selected block to clipboard is not supported."
+msgstr ""
 
 #: ../src/richtext/richtextborderspage.cpp:566
 #: ../src/richtext/richtextborderspage.cpp:601
@@ -2380,198 +2391,195 @@ msgstr "Coin"
 msgid "Corner &radius:"
 msgstr "Rayon de courbure des &coins :"
 
-#: ../src/html/chm.cpp:718
+#: ../src/html/chm.cpp:711
 #, c-format
 msgid "Could not create temporary file '%s'"
 msgstr "Impossible de créer le fichier temporaire « %s »"
 
-#: ../src/html/chm.cpp:273
+#: ../src/html/chm.cpp:270
 #, c-format
 msgid "Could not extract %s into %s: %s"
 msgstr "Impossible d'extraire %s de %s : %s"
 
-#: ../src/generic/tabg.cpp:1048
+#: ../src/generic/tabg.cpp:1045
 msgid "Could not find tab for id"
 msgstr "Impossible de trouver l'onglet pour l'identifiant"
 
-#: ../src/gtk/notifmsg.cpp:108
-msgid "Could not initalize libnotify."
-msgstr "N'a pas pu initialiser libnotify."
-
-#: ../src/html/chm.cpp:444
+#: ../src/html/chm.cpp:437
 #, c-format
 msgid "Could not locate file '%s'."
 msgstr "Impossible de localiser le fichier « %s »."
 
-#: ../src/common/filefn.cpp:1403
+#: ../src/msw/graphicsd2d.cpp:604
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/common/filefn.cpp:1291
 msgid "Could not set current working directory"
 msgstr "Impossible de définir le répertoire de travail courant"
 
-#: ../src/common/prntbase.cpp:2015
+#: ../src/common/prntbase.cpp:2037
 msgid "Could not start document preview."
 msgstr "Impossible de lancer l'aperçu du document."
 
-#: ../src/generic/printps.cpp:178 ../src/msw/printwin.cpp:210
-#: ../src/gtk/print.cpp:1132
+#: ../src/generic/printps.cpp:159 ../src/msw/printwin.cpp:184
+#: ../src/gtk/print.cpp:1129
 msgid "Could not start printing."
 msgstr "Impossible de lancer l'impression."
 
-#: ../src/common/wincmn.cpp:2125
+#: ../src/common/wincmn.cpp:2126
 msgid "Could not transfer data to window"
 msgstr "Impossible de transférer les données à la fenêtre"
 
-#: ../src/msw/imaglist.cpp:187 ../src/msw/imaglist.cpp:224
-#: ../src/msw/imaglist.cpp:249 ../src/msw/dragimag.cpp:185
-#: ../src/msw/dragimag.cpp:220
+#: ../src/msw/imaglist.cpp:223 ../src/msw/imaglist.cpp:245
+#: ../src/msw/imaglist.cpp:270 ../src/msw/dragimag.cpp:182
+#: ../src/msw/dragimag.cpp:217
 msgid "Couldn't add an image to the image list."
 msgstr "Impossible d'ajouter une image à la liste des images."
 
-#: ../src/osx/glcanvas_osx.cpp:414 ../src/unix/glx11.cpp:558
-#: ../src/msw/glcanvas.cpp:616
+#: ../src/osx/glcanvas_osx.cpp:411 ../src/msw/glcanvas.cpp:631
+#: ../src/unix/glegl.cpp:315 ../src/unix/glx11.cpp:559
 msgid "Couldn't create OpenGL context"
 msgstr "N'a pas pu créer le contexte OpenGL"
 
-#: ../src/msw/timer.cpp:134
+#: ../src/msw/timer.cpp:131
 msgid "Couldn't create a timer"
 msgstr "Impossible de créer un minuteur"
 
-#: ../src/osx/carbon/overlay.cpp:122
-msgid "Couldn't create the overlay window"
-msgstr "Impossible de créer une fenêtre de recouvrement"
-
-#: ../src/common/translation.cpp:2024
+#: ../src/common/translation.cpp:2074
 msgid "Couldn't enumerate translations"
 msgstr "Impossible d'énumérer les traductions"
 
-#: ../src/common/dynlib.cpp:120
+#: ../src/common/dynlib.cpp:110
 #, c-format
 msgid "Couldn't find symbol '%s' in a dynamic library"
 msgstr "Impossible de trouver le symbole « %s » dans la bibliothèque dynamique"
 
-#: ../src/msw/thread.cpp:915
+#: ../src/msw/thread.cpp:921
 msgid "Couldn't get the current thread pointer"
 msgstr "Impossible d'obtenir le pointeur du processus actuel"
 
-#: ../src/osx/carbon/overlay.cpp:129
-msgid "Couldn't init the context on the overlay window"
-msgstr "Impossible d'initialiser le contexte de la fenêtre de recouvrement"
-
-#: ../src/common/imaggif.cpp:244
+#: ../src/common/imaggif.cpp:241
 msgid "Couldn't initialize GIF hash table."
 msgstr "Impossible d'initialiser la table de hachage GIF."
 
-#: ../src/common/imagpng.cpp:409
+#: ../src/common/imagpng.cpp:437
 msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
 msgstr ""
 "Impossible de charger une image PNG - fichier corrompu ou mémoire "
 "insuffisante."
 
-#: ../src/unix/sound.cpp:470
+#: ../src/unix/sound.cpp:459
 #, c-format
 msgid "Couldn't load sound data from '%s'."
 msgstr "Impossible de charger les données sonores depuis « %s »."
 
-#: ../src/msw/dirdlg.cpp:435
+#: ../src/msw/dirdlg.cpp:287
 msgid "Couldn't obtain folder name"
 msgstr "Impossible d'obtenir le nom du dossier"
 
-#: ../src/unix/sound_sdl.cpp:229
+#: ../src/unix/sound_sdl.cpp:226
 #, c-format
 msgid "Couldn't open audio: %s"
 msgstr "Impossible d'ouvrir le fichier audio : %s"
 
-#: ../src/msw/ole/dataobj.cpp:377
+#: ../src/msw/ole/dataobj.cpp:385
 #, c-format
 msgid "Couldn't register clipboard format '%s'."
 msgstr "Impossible d'enregistrer le format de presse-papiers « %s »."
 
-#: ../src/msw/listctrl.cpp:869
+#: ../src/msw/listctrl.cpp:933
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr ""
 "Impossible de récupérer des informations sur l'élément « %d » de contrôle "
 "des listes."
 
-#: ../src/common/imagpng.cpp:498 ../src/common/imagpng.cpp:509
-#: ../src/common/imagpng.cpp:519
+#: ../src/common/imagpng.cpp:511 ../src/common/imagpng.cpp:522
+#: ../src/common/imagpng.cpp:532
 msgid "Couldn't save PNG image."
 msgstr "Impossible de sauvegarder l'image PNG."
 
-#: ../src/msw/thread.cpp:684
+#: ../src/msw/thread.cpp:676
 msgid "Couldn't terminate thread"
 msgstr "Impossible d'arrêter le processus"
 
-#: ../src/common/xtistrm.cpp:166
+#: ../src/common/xtistrm.cpp:163
 #, c-format
 msgid "Create Parameter %s not found in declared RTTI Parameters"
 msgstr "Paramètre de création %s non trouvé dans les Paramètres RTTI déclarés"
 
-#: ../src/generic/dirdlgg.cpp:288
+#: ../src/generic/dirdlgg.cpp:285
 msgid "Create directory"
 msgstr "Créer le dossier"
 
-#: ../src/generic/filedlgg.cpp:212 ../src/generic/dirdlgg.cpp:111
+#: ../src/generic/filedlgg.cpp:209 ../src/generic/dirdlgg.cpp:108
 msgid "Create new directory"
 msgstr "Créer un nouveau dossier"
 
-#: ../src/xrc/xmlres.cpp:2460
+#: ../src/common/stockitem.cpp:264
+#, fuzzy
+msgid "Create new document"
+msgstr "Créer un nouveau dossier"
+
+#: ../src/xrc/xmlres.cpp:2515
 #, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Échec de la création de %s « %s »."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1758
+#: ../src/propgrid/advprops.cpp:1659
 msgid "Cross"
 msgstr "Croix"
 
-#: ../src/common/accelcmn.cpp:333
+#: ../src/common/accelcmn.cpp:347
 msgid "Ctrl+"
 msgstr "Ctrl+"
 
-#: ../src/richtext/richtextctrl.cpp:332 ../src/osx/textctrl_osx.cpp:576
-#: ../src/common/stockitem.cpp:151 ../src/msw/textctrl.cpp:2507
+#: ../src/osx/textctrl_osx.cpp:594 ../src/common/stockitem.cpp:148
+#: ../src/msw/textctrl.cpp:2772 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "Cou&per"
 
-#: ../src/generic/filectrlg.cpp:940
+#: ../src/generic/filectrlg.cpp:936
 msgid "Current directory:"
 msgstr "Dossier courant :"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:896 ../src/propgrid/advprops.cpp:1574
-#: ../src/propgrid/advprops.cpp:1612
+#: ../src/propgrid/advprops.cpp:797 ../src/propgrid/advprops.cpp:1475
+#: ../src/propgrid/advprops.cpp:1518
 msgid "Custom"
 msgstr "Personnalisé"
 
-#: ../src/gtk/print.cpp:217
+#: ../src/gtk/print.cpp:211
 msgid "Custom size"
 msgstr "Taille personnalisée"
 
-#: ../src/common/headerctrlcmn.cpp:60
+#: ../src/common/headerctrlcmn.cpp:58
 msgid "Customize Columns"
 msgstr "Personnaliser les Colonnes"
 
-#: ../src/common/stockitem.cpp:151 ../src/stc/stc_i18n.cpp:17
+#: ../src/common/stockitem.cpp:148 ../src/stc/stc_i18n.cpp:17
 msgid "Cut"
 msgstr "Couper"
 
-#: ../src/common/stockitem.cpp:259
+#: ../src/common/stockitem.cpp:256
 msgid "Cut selection"
 msgstr "Couper la sélection"
 
-#: ../src/common/fmapbase.cpp:152
+#: ../src/common/fmapbase.cpp:149
 msgid "Cyrillic (ISO-8859-5)"
 msgstr "Cyrillique (ISO-8859-5)"
 
-#: ../src/common/paper.cpp:99
+#: ../src/common/paper.cpp:96
 msgid "D sheet, 22 x 34 in"
 msgstr "Feuille D, 22 x 34 mm"
 
-#: ../src/msw/dde.cpp:703
+#: ../src/msw/dde.cpp:698
 msgid "DDE poke request failed"
 msgstr "Échec de la demande de transfert DDE"
 
-#: ../src/common/imagbmp.cpp:1169
+#: ../src/common/imagbmp.cpp:1181
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr "En-tête DIB : le codage ne correspond pas au nombre de bits par pixel."
 
@@ -2593,7 +2601,7 @@ msgstr "En-tête DIB : nombre de bits par pixel inconnu dans le fichier."
 msgid "DIB Header: Unknown encoding in file."
 msgstr "En-tête DIB : codage inconnu dans le fichier."
 
-#: ../src/common/paper.cpp:121
+#: ../src/common/paper.cpp:118
 msgid "DL Envelope, 110 x 220 mm"
 msgstr "Enveloppe DL, 110 x 220 mm"
 
@@ -2601,53 +2609,53 @@ msgstr "Enveloppe DL, 110 x 220 mm"
 msgid "Dashed"
 msgstr "Tirets"
 
-#: ../src/generic/dbgrptg.cpp:300
+#: ../src/generic/dbgrptg.cpp:301
 #, c-format
 msgid "Debug report \"%s\""
 msgstr "Rapport de débogage « %s »"
 
-#: ../src/common/debugrpt.cpp:210
+#: ../src/common/debugrpt.cpp:211
 msgid "Debug report couldn't be created."
 msgstr "Échec de la création du rapport de débogage."
 
-#: ../src/common/debugrpt.cpp:553
+#: ../src/common/debugrpt.cpp:554
 msgid "Debug report generation has failed."
 msgstr "Échec de la génération du rapport de débogage."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:84
+#: ../src/common/accelcmn.cpp:81
 msgid "Decimal"
 msgstr "Décimale"
 
-#: ../src/generic/fontdlgg.cpp:323
+#: ../src/generic/fontdlgg.cpp:319
 msgid "Decorative"
 msgstr "Décoratif"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1752
+#: ../src/propgrid/advprops.cpp:1653
 msgid "Default"
 msgstr "Par défaut"
 
-#: ../src/common/fmapbase.cpp:796
+#: ../src/common/fmapbase.cpp:792
 msgid "Default encoding"
 msgstr "Codage par défaut"
 
-#: ../src/dfb/fontmgr.cpp:180
+#: ../src/dfb/fontmgr.cpp:177
 msgid "Default font"
 msgstr "Police par défaut"
 
-#: ../src/generic/prntdlgg.cpp:510
+#: ../src/generic/prntdlgg.cpp:503
 msgid "Default printer"
 msgstr "Imprimante par défaut"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:51
+#: ../src/common/accelcmn.cpp:48
 msgid "Del"
 msgstr "Suppr"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextbuffer.cpp:8221 ../src/common/stockitem.cpp:152
-#: ../src/common/accelcmn.cpp:50 ../src/stc/stc_i18n.cpp:20
+#: ../src/common/stockitem.cpp:149 ../src/common/accelcmn.cpp:47
+#: ../src/richtext/richtextbuffer.cpp:8217 ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Supprimer"
 
@@ -2655,68 +2663,68 @@ msgstr "Supprimer"
 msgid "Delete A&ll"
 msgstr "&Tout supprimer"
 
-#: ../src/richtext/richtextbuffer.cpp:11341
+#: ../src/richtext/richtextbuffer.cpp:11340
 msgid "Delete Column"
 msgstr "Supprimer la colonne"
 
-#: ../src/richtext/richtextbuffer.cpp:11291
+#: ../src/richtext/richtextbuffer.cpp:11290
 msgid "Delete Row"
 msgstr "Supprimer la ligne"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 msgid "Delete Style"
 msgstr "Supprimer le style"
 
-#: ../src/richtext/richtextctrl.cpp:1345 ../src/richtext/richtextctrl.cpp:1584
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
 msgid "Delete Text"
 msgstr "Supprimer le texte"
 
-#: ../src/generic/editlbox.cpp:170
+#: ../src/generic/editlbox.cpp:147
 msgid "Delete item"
 msgstr "Supprimer l'élément"
 
-#: ../src/common/stockitem.cpp:260
+#: ../src/common/stockitem.cpp:257
 msgid "Delete selection"
 msgstr "Effacer la sélection"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 #, c-format
 msgid "Delete style %s?"
 msgstr "Faut-il supprimer le style %s ?"
 
-#: ../src/unix/snglinst.cpp:301
+#: ../src/unix/snglinst.cpp:298
 #, c-format
 msgid "Deleted stale lock file '%s'."
 msgstr "Suppression du fichier verrou périmé « %s »."
 
-#: ../src/common/secretstore.cpp:220
-#, c-format
-msgid "Deleting password for \"%s/%s\" failed: %s."
+#: ../src/common/secretstore.cpp:234
+#, fuzzy, c-format
+msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Suppression de mot de passe pour \"%s/%s\" en erreur : %s."
 
-#: ../src/common/module.cpp:124
+#: ../src/common/module.cpp:121
 #, c-format
 msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
 msgstr "La dépendance « %s » du module « %s » n'existe pas."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "Descending"
 msgstr "Décroissant"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:526 ../src/propgrid/advprops.cpp:882
+#: ../src/generic/dirctrlg.cpp:492 ../src/propgrid/advprops.cpp:783
 msgid "Desktop"
 msgstr "Bureau"
 
-#: ../src/generic/aboutdlgg.cpp:70
+#: ../src/generic/aboutdlgg.cpp:67
 msgid "Developed by "
 msgstr "Développé par "
 
-#: ../src/generic/aboutdlgg.cpp:176
+#: ../src/generic/aboutdlgg.cpp:173
 msgid "Developers"
 msgstr "Développeurs"
 
-#: ../src/msw/dialup.cpp:374
+#: ../src/msw/dialup.cpp:368
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -2724,11 +2732,11 @@ msgstr ""
 "Les fonctions d'appel ne sont pas disponibles car le service d'accès à "
 "distance (RAS) n'est pas installé sur cet ordinateur. L'installer."
 
-#: ../src/generic/tipdlg.cpp:211
+#: ../src/generic/tipdlg.cpp:208
 msgid "Did you know..."
 msgstr "Saviez-vous que..."
 
-#: ../src/dfb/wrapdfb.cpp:63
+#: ../src/dfb/wrapdfb.cpp:60
 #, c-format
 msgid "DirectFB error %d occurred."
 msgstr "L'erreur DirectFB %d est survenue."
@@ -2737,30 +2745,30 @@ msgstr "L'erreur DirectFB %d est survenue."
 msgid "Directories"
 msgstr "Dossiers"
 
-#: ../src/common/filefn.cpp:1183
+#: ../src/common/filefn.cpp:1071
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Le dossier « %s » n'a pas pu être créé"
 
-#: ../src/common/filefn.cpp:1197
+#: ../src/common/filefn.cpp:1085
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "Le dossier « %s » n'a pas pu être supprimé"
 
-#: ../src/generic/dirdlgg.cpp:204
+#: ../src/generic/dirdlgg.cpp:201
 msgid "Directory does not exist"
 msgstr "Dossier inexistant"
 
-#: ../src/generic/filectrlg.cpp:1399
+#: ../src/generic/filectrlg.cpp:1388
 msgid "Directory doesn't exist."
 msgstr "Dossier inexistant."
 
-#: ../src/common/docview.cpp:457
+#: ../src/common/docview.cpp:450
 msgid "Discard changes and reload the last saved version?"
 msgstr ""
 "Ignorer les modifications et recharger la dernière version enregistrée ?"
 
-#: ../src/html/helpwnd.cpp:502
+#: ../src/html/helpwnd.cpp:500
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -2768,45 +2776,45 @@ msgstr ""
 "Afficher tous les éléments de l'index qui contiennent une sous-chaîne "
 "donnée. Recherche non sensible à la casse."
 
-#: ../src/html/helpwnd.cpp:679
+#: ../src/html/helpwnd.cpp:677
 msgid "Display options dialog"
 msgstr "Dialogue d'options de l'affichage"
 
-#: ../src/html/helpwnd.cpp:322
+#: ../src/html/helpwnd.cpp:320
 msgid "Displays help as you browse the books on the left."
 msgstr "Affiche l'aide pendant que le parcours des livres sur la gauche."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:85
+#: ../src/common/accelcmn.cpp:83
 msgid "Divide"
 msgstr "Diviser"
 
-#: ../src/common/docview.cpp:533
+#: ../src/common/docview.cpp:526
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Faut-il enregistrer les modifications vers %s ?"
 
-#: ../src/common/prntbase.cpp:542
+#: ../src/common/prntbase.cpp:537
 msgid "Document:"
 msgstr "Document :"
 
-#: ../src/generic/aboutdlgg.cpp:73
+#: ../src/generic/aboutdlgg.cpp:70
 msgid "Documentation by "
 msgstr "Documentation par "
 
-#: ../src/generic/aboutdlgg.cpp:180
+#: ../src/generic/aboutdlgg.cpp:177
 msgid "Documentation writers"
 msgstr "Rédacteurs de la documentation"
 
-#: ../src/common/sizer.cpp:2799
+#: ../src/common/sizer.cpp:2916
 msgid "Don't Save"
 msgstr "Ne pas enregistrer"
 
-#: ../src/html/htmlwin.cpp:633
+#: ../src/html/htmlwin.cpp:643
 msgid "Done"
 msgstr "Terminé"
 
-#: ../src/generic/progdlgg.cpp:448 ../src/msw/progdlg.cpp:407
+#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
 msgid "Done."
 msgstr "Terminé."
 
@@ -2818,44 +2826,44 @@ msgstr "Pointillé"
 msgid "Double"
 msgstr "Double"
 
-#: ../src/common/paper.cpp:176
+#: ../src/common/paper.cpp:173
 msgid "Double Japanese Postcard Rotated 148 x 200 mm"
 msgstr "Carte postale japonaise double Paysage 148 x 200 mm"
 
-#: ../src/common/xtixml.cpp:273
+#: ../src/common/xtixml.cpp:269
 #, c-format
 msgid "Doubly used id : %d"
 msgstr "Identifiant utilisé deux fois : %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:153
-#: ../src/common/accelcmn.cpp:64
+#: ../src/common/stockitem.cpp:150 ../src/common/accelcmn.cpp:61
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Down"
 msgstr "Bas"
 
-#: ../src/richtext/richtextctrl.cpp:865
+#: ../src/richtext/richtextctrl.cpp:864
 msgid "Drag"
 msgstr "Glisser"
 
-#: ../src/common/paper.cpp:100
+#: ../src/common/paper.cpp:97
 msgid "E sheet, 34 x 44 in"
 msgstr "Feuille E (34 x 44 pouces)"
 
-#: ../src/unix/fswatcher_inotify.cpp:561
+#: ../src/unix/fswatcher_inotify.cpp:558
 msgid "EOF while reading from inotify descriptor"
 msgstr ""
 "Fin de fichier (EOF) atteinte lors de la lecture depuis le descripteur "
 "inotify"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "Edit"
 msgstr "Édition"
 
-#: ../src/generic/editlbox.cpp:168
+#: ../src/generic/editlbox.cpp:131
 msgid "Edit item"
 msgstr "Éditer l'élément"
 
-#: ../include/wx/generic/progdlgg.h:84
+#: ../include/wx/generic/progdlgg.h:85
 msgid "Elapsed time:"
 msgstr "Temps écoulé :"
 
@@ -2922,49 +2930,49 @@ msgid "Enables the shadow spread."
 msgstr "Active la dispersion de l'ombre."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:66
+#: ../src/common/accelcmn.cpp:63
 msgid "End"
 msgstr "Fin"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:55
+#: ../src/common/accelcmn.cpp:52
 msgid "Enter"
 msgstr "Entrée"
 
-#: ../src/richtext/richtextstyledlg.cpp:934
+#: ../src/richtext/richtextstyledlg.cpp:930
 msgid "Enter a box style name"
 msgstr "Entrer le nom d'un style de boîte"
 
-#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:602
 msgid "Enter a character style name"
 msgstr "Entrer le nom d'un style de caractère"
 
-#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:816
 msgid "Enter a list style name"
 msgstr "Entrer le nom d'un style de liste"
 
-#: ../src/richtext/richtextstyledlg.cpp:893
+#: ../src/richtext/richtextstyledlg.cpp:889
 msgid "Enter a new style name"
 msgstr "Entrer le nom d'un nouveau style"
 
-#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:650
 msgid "Enter a paragraph style name"
 msgstr "Entrer le nom d'un style de paragraphe"
 
-#: ../src/generic/dbgrptg.cpp:174
+#: ../src/generic/dbgrptg.cpp:171
 #, c-format
 msgid "Enter command to open file \"%s\":"
 msgstr "Entrer la commande pour ouvrir le fichier « %s » :"
 
-#: ../src/generic/helpext.cpp:459
+#: ../src/generic/helpext.cpp:457
 msgid "Entries found"
 msgstr "Entrées trouvées"
 
-#: ../src/common/paper.cpp:142
+#: ../src/common/paper.cpp:139
 msgid "Envelope Invite 220 x 220 mm"
 msgstr "Enveloppe Invite 220 x 220 mm"
 
-#: ../src/common/config.cpp:469
+#: ../src/common/config.cpp:465
 #, c-format
 msgid ""
 "Environment variables expansion failed: missing '%c' at position %u in '%s'."
@@ -2972,13 +2980,13 @@ msgstr ""
 "Échec de l'expansion des variables d'environnement : « %c » manquant à la "
 "position %u dans « %s »."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/generic/dirctrlg.cpp:570
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/dirctrlg.cpp:599
-#: ../src/generic/dirdlgg.cpp:323 ../src/generic/filectrlg.cpp:642
-#: ../src/generic/filectrlg.cpp:756 ../src/generic/filectrlg.cpp:770
-#: ../src/generic/filectrlg.cpp:786 ../src/generic/filectrlg.cpp:1368
-#: ../src/generic/filectrlg.cpp:1399 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/gtk1/fontdlg.cpp:74 ../src/generic/dirctrlg.cpp:536
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/dirctrlg.cpp:565
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1357 ../src/generic/filectrlg.cpp:1388
+#: ../src/generic/filedlgg.cpp:354 ../src/generic/dirdlgg.cpp:320
+#: ../src/gtk/filedlg.cpp:74
 msgid "Error"
 msgstr "Erreur"
 
@@ -2986,31 +2994,37 @@ msgstr "Erreur"
 msgid "Error closing epoll descriptor"
 msgstr "Erreur lors de la fermeture du descripteur epoll"
 
-#: ../src/unix/fswatcher_kqueue.cpp:114
+#: ../src/unix/fswatcher_kqueue.cpp:131
 msgid "Error closing kqueue instance"
 msgstr "Erreur lors de la fermeture de l'instance kqueue"
 
-#: ../src/common/filefn.cpp:1049
+#: ../src/common/filefn.cpp:938
 #, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Erreur à la copie du fichier '%s' vers '%s'."
 
-#: ../src/generic/dirdlgg.cpp:222
+#: ../src/generic/dirdlgg.cpp:219
 msgid "Error creating directory"
 msgstr "Erreur lors de la création du répertoire"
 
-#: ../src/common/imagbmp.cpp:1181
+#: ../src/common/imagbmp.cpp:1193
 msgid "Error in reading image DIB."
 msgstr "Erreur lors de la lecture d'une image DIB."
 
-#: ../src/propgrid/propgrid.cpp:6696
+#: ../src/propgrid/propgrid.cpp:6665
 #, c-format
 msgid "Error in resource: %s"
 msgstr "Erreur dans la ressource : %s"
 
-#: ../src/common/fileconf.cpp:422
+#: ../src/common/fileconf.cpp:421
 msgid "Error reading config options."
 msgstr "Erreur lors de la lecture des options de configuration."
+
+#: ../src/msw/webview_ie.cpp:1057 ../src/msw/webview_edge.cpp:850
+#: ../src/gtk/webview_webkit2.cpp:1262 ../src/osx/webview_webkit.mm:383
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
 
 #: ../src/common/fileconf.cpp:1029
 msgid "Error saving user configuration data."
@@ -3018,56 +3032,61 @@ msgstr ""
 "Erreur lors de l'enregistrement des données de configuration de "
 "l'utilisateur."
 
-#: ../src/gtk/print.cpp:722
+#: ../src/gtk/print.cpp:720
 msgid "Error while printing: "
 msgstr "Erreur lors de l'impression : "
 
-#: ../src/common/log.cpp:219
+#: ../src/common/log.cpp:237
 msgid "Error: "
 msgstr "Erreur : "
 
+#: ../src/common/webrequest.cpp:98
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Erreur : "
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:69
+#: ../src/common/accelcmn.cpp:66
 msgid "Esc"
 msgstr "Échapp"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:70
+#: ../src/common/accelcmn.cpp:67
 msgid "Escape"
 msgstr "Echapp"
 
-#: ../src/common/fmapbase.cpp:150
+#: ../src/common/fmapbase.cpp:147
 msgid "Esperanto (ISO-8859-3)"
 msgstr "Espéranto (ISO-8859-3)"
 
-#: ../include/wx/generic/progdlgg.h:85
+#: ../include/wx/generic/progdlgg.h:86
 msgid "Estimated time:"
 msgstr "Temps estimé :"
 
-#: ../src/generic/dbgrptg.cpp:234
+#: ../src/generic/dbgrptg.cpp:231
 msgid "Executable files (*.exe)|*.exe|"
 msgstr "Fichiers exécutables (*.exe)|*.exe|"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:155 ../src/common/accelcmn.cpp:78
+#: ../src/common/stockitem.cpp:152 ../src/common/accelcmn.cpp:75
 msgid "Execute"
 msgstr "Exécuter"
 
-#: ../src/msw/utilsexc.cpp:876
+#: ../src/msw/utilsexc.cpp:873
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Échec de l'exécution de la commande « %s »"
 
-#: ../src/common/paper.cpp:105
+#: ../src/common/paper.cpp:102
 msgid "Executive, 7 1/4 x 10 1/2 in"
 msgstr "Executive (7,25 x 10,5 pouces)"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6009
+#: ../src/generic/datavgen.cpp:6814
 msgid "Expand"
 msgstr "Étendre"
 
-#: ../src/msw/registry.cpp:1240
+#: ../src/msw/registry.cpp:1228
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
@@ -3075,148 +3094,158 @@ msgstr ""
 "Exportation de la clé de registre : le fichier « %s » existe déjà et ne sera "
 "pas écrasé."
 
-#: ../src/common/fmapbase.cpp:195
+#: ../src/common/fmapbase.cpp:192
 msgid "Extended Unix Codepage for Japanese (EUC-JP)"
 msgstr "Codepage Unix étendu pour le japonais (EUC-JP)"
 
-#: ../src/html/chm.cpp:725
+#: ../src/html/chm.cpp:718
 #, c-format
 msgid "Extraction of '%s' into '%s' failed."
 msgstr "Échec de l'extraction de « %s » de « %s »."
 
-#: ../src/common/accelcmn.cpp:249 ../src/common/accelcmn.cpp:344
+#: ../src/common/accelcmn.cpp:259 ../src/common/accelcmn.cpp:358
 msgid "F"
 msgstr "F"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:672
+#: ../src/propgrid/advprops.cpp:582
 msgid "Face Name"
 msgstr "Nom"
 
-#: ../src/unix/snglinst.cpp:269
+#: ../src/unix/snglinst.cpp:266
 msgid "Failed to access lock file."
 msgstr "Échec de l'accès au fichier verrou."
+
+#: ../src/gtk/font.cpp:572
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Échec de la lecture du document depuis le fichier « %s »."
 
 #: ../src/unix/epolldispatcher.cpp:116
 #, c-format
 msgid "Failed to add descriptor %d to epoll descriptor %d"
 msgstr "Échec de l'ajout du descripteur %d au descripteur epoll %d"
 
-#: ../src/msw/dib.cpp:489
+#: ../src/msw/dib.cpp:535
 #, c-format
 msgid "Failed to allocate %luKb of memory for bitmap data."
 msgstr "Échec de l'allocation de %lu Ko de mémoire pour les données bitmap."
 
-#: ../src/common/glcmn.cpp:115
+#: ../src/common/glcmn.cpp:112
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Échec de l'allocation de couleur pour OpenGL"
 
-#: ../src/unix/displayx11.cpp:236
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Échec de l'allocation de couleur pour OpenGL"
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Échec de l'allocation de couleur pour OpenGL"
+
+#: ../include/wx/unix/private/displayx11.h:89
 msgid "Failed to change video mode"
 msgstr "Échec du changement de mode vidéo"
 
-#: ../src/common/image.cpp:3277
+#: ../src/common/image.cpp:3396
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Échec de la vérification de format du fichier image « %s »."
 
-#: ../src/common/debugrpt.cpp:239
+#: ../src/common/debugrpt.cpp:240
 #, c-format
 msgid "Failed to clean up debug report directory \"%s\""
 msgstr "Échec du nettoyage du répertoire « %s » des rapports de débogage"
 
-#: ../src/common/filename.cpp:192
+#: ../src/common/filename.cpp:189
 msgid "Failed to close file handle"
 msgstr "Échec de la fermeture du gestionnaire de fichier"
 
-#: ../src/unix/snglinst.cpp:340
+#: ../src/unix/snglinst.cpp:337
 #, c-format
 msgid "Failed to close lock file '%s'"
 msgstr "Échec de la fermeture du fichier verrou « %s »"
 
-#: ../src/msw/clipbrd.cpp:112
+#: ../src/msw/clipbrd.cpp:110
 msgid "Failed to close the clipboard."
 msgstr "Échec de la fermeture du presse-papiers."
 
-#: ../src/x11/utils.cpp:208
+#: ../src/x11/utils.cpp:170
 #, c-format
 msgid "Failed to close the display \"%s\""
 msgstr "Échec de la fermeture de l'écran « %s »."
 
-#: ../src/msw/dialup.cpp:797
+#: ../src/msw/dialup.cpp:791
 msgid "Failed to connect: missing username/password."
 msgstr "Échec de la connexion : nom d'utilisateur ou mot de passe manquant."
 
-#: ../src/msw/dialup.cpp:743
+#: ../src/msw/dialup.cpp:737
 msgid "Failed to connect: no ISP to dial."
 msgstr "Échec de la connexion : pas de FAI à appeler."
 
-#: ../src/common/textfile.cpp:203
-#, c-format
-msgid "Failed to convert file \"%s\" to Unicode."
-msgstr "Échec de la conversion du fichier « %s » en Unicode."
-
-#: ../src/generic/logg.cpp:956
+#: ../src/generic/logg.cpp:953
 msgid "Failed to copy dialog contents to the clipboard."
 msgstr "Échec à la copie du contenu du dialogue vers le presse-papiers."
 
-#: ../src/msw/registry.cpp:692
+#: ../src/msw/registry.cpp:681
 #, c-format
 msgid "Failed to copy registry value '%s'"
 msgstr "Échec de la copie de la valeur de registre « %s »"
 
-#: ../src/msw/registry.cpp:701
+#: ../src/msw/registry.cpp:690
 #, c-format
 msgid "Failed to copy the contents of registry key '%s' to '%s'."
 msgstr "Échec de la copie du contenu de la clé de registre « %s » vers « %s »."
 
-#: ../src/common/filefn.cpp:1015
+#: ../src/common/filefn.cpp:904
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Échec de la copie du fichier « %s » vers « %s »"
 
-#: ../src/msw/registry.cpp:679
+#: ../src/msw/registry.cpp:668
 #, c-format
 msgid "Failed to copy the registry subkey '%s' to '%s'."
 msgstr "Échec de la copie de la sous-clé de registre « %s » vers « %s »."
 
-#: ../src/msw/dde.cpp:1070
+#: ../src/msw/dde.cpp:1134
 msgid "Failed to create DDE string"
 msgstr "Échec de la création de la chaîne DDE"
 
-#: ../src/msw/mdi.cpp:616
+#: ../src/msw/mdi.cpp:621
 msgid "Failed to create MDI parent frame."
 msgstr "Échec de la création du cadre parent MDI."
 
-#: ../src/common/filename.cpp:1027
+#: ../src/common/filename.cpp:1024
 msgid "Failed to create a temporary file name"
 msgstr "Échec de la création d'un nom de fichier temporaire"
 
-#: ../src/msw/utilsexc.cpp:228
+#: ../src/msw/utilsexc.cpp:225
 msgid "Failed to create an anonymous pipe"
 msgstr "Échec de la création d'un tube (pipe) anonyme"
 
-#: ../src/msw/ole/automtn.cpp:522
+#: ../src/msw/ole/automtn.cpp:513
 #, c-format
 msgid "Failed to create an instance of \"%s\""
 msgstr "Échec de la création d'une instance de « %s »"
 
-#: ../src/msw/dde.cpp:437
+#: ../src/msw/dde.cpp:432
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr ""
 "Échec de la création d'une connexion au serveur « %s » sur le sujet « %s »"
 
-#: ../src/msw/cursor.cpp:204
+#: ../src/msw/cursor.cpp:195
 msgid "Failed to create cursor."
 msgstr "Échec de la création d'un curseur."
 
-#: ../src/common/debugrpt.cpp:209
+#: ../src/common/debugrpt.cpp:210
 #, c-format
 msgid "Failed to create directory \"%s\""
 msgstr "Échec de la création du répertoire « %s »"
 
-#: ../src/generic/dirdlgg.cpp:220
+#: ../src/generic/dirdlgg.cpp:217
 #, c-format
 msgid ""
 "Failed to create directory '%s'\n"
@@ -3229,123 +3258,142 @@ msgstr ""
 msgid "Failed to create epoll descriptor"
 msgstr "Échec de la création du descripteur epoll"
 
-#: ../src/msw/mimetype.cpp:238
+#: ../src/gtk/font.cpp:562
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "Échec de la mise à jour du fichier de configuration utilisateur."
+
+#: ../src/msw/mimetype.cpp:235
 #, c-format
 msgid "Failed to create registry entry for '%s' files."
 msgstr ""
 "Échec de la création d'une entrée dans le registre pour les fichiers « %s »."
 
-#: ../src/msw/fdrepdlg.cpp:409
+#: ../src/msw/fdrepdlg.cpp:408
 #, c-format
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr ""
 "Échec de la création de la boîte de dialogue standard rechercher/remplacer "
 "(code d'erreur %d)"
 
-#: ../src/unix/wakeuppipe.cpp:52
+#: ../src/unix/wakeuppipe.cpp:49
 msgid "Failed to create wake up pipe used by event loop."
 msgstr ""
 "Échec de la création d'un tube (pipe) de réveil utilisé par la boucle "
 "d'évènements."
 
-#: ../src/html/winpars.cpp:730
+#: ../src/html/winpars.cpp:727
 #, c-format
 msgid "Failed to display HTML document in %s encoding"
 msgstr "Échec de l'affichage du document HTML avec le codage %s"
 
-#: ../src/msw/clipbrd.cpp:124
+#: ../src/msw/clipbrd.cpp:122
 msgid "Failed to empty the clipboard."
 msgstr "Échec du vidage du presse-papiers."
 
-#: ../src/unix/displayx11.cpp:212
+#: ../include/wx/unix/private/displayx11.h:65
 msgid "Failed to enumerate video modes"
 msgstr "Échec de l'énumération des modes vidéo"
 
-#: ../src/msw/dde.cpp:722
+#: ../src/msw/dde.cpp:717
 msgid "Failed to establish an advise loop with DDE server"
 msgstr ""
 "Échec de l'établissement d'une boucle d'instructions avec le serveur DDE"
 
-#: ../src/msw/dialup.cpp:629 ../src/msw/dialup.cpp:863
+#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Échec de l'établissement d'une connexion : %s"
 
-#: ../src/unix/utilsunx.cpp:611
+#: ../src/unix/utilsunx.cpp:613
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Échec de l'exécution de « %s »\n"
 
-#: ../src/common/debugrpt.cpp:720
+#: ../src/common/debugrpt.cpp:730
 msgid "Failed to execute curl, please install it in PATH."
 msgstr "Échec de l'exécution de curl, veuillez l'installer dans le PATH."
 
-#: ../src/msw/ole/automtn.cpp:505
+#: ../src/msw/ole/automtn.cpp:496
 #, c-format
 msgid "Failed to find CLSID of \"%s\""
 msgstr "Échec de la recherche du CLSID de « %s »"
 
-#: ../src/common/regex.cpp:431 ../src/common/regex.cpp:479
+#: ../src/common/regex.cpp:428 ../src/common/regex.cpp:476
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr ""
 "Aucune correspondance pour l'expression régulière « %s » n'a été trouvée"
 
-#: ../src/msw/dialup.cpp:695
+#: ../src/msw/webview_ie.cpp:978
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:689
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Échec de l'obtention des noms des FAI : %s"
 
-#: ../src/msw/ole/automtn.cpp:574
+#: ../src/msw/ole/automtn.cpp:565
 #, c-format
 msgid "Failed to get OLE automation interface for \"%s\""
 msgstr "Échec de l'obtention de l'interface OLE Automation pour « %s »"
 
-#: ../src/msw/clipbrd.cpp:711
+#: ../src/msw/clipbrd.cpp:731
 msgid "Failed to get data from the clipboard"
 msgstr "Échec de l'obtention des données du presse-papiers"
 
-#: ../src/common/time.cpp:223
+#: ../src/common/time.cpp:216
 msgid "Failed to get the local system time"
 msgstr "Échec de l'obtention de l'heure locale du système"
 
-#: ../src/common/filefn.cpp:1345
+#: ../src/common/filefn.cpp:1233
 msgid "Failed to get the working directory"
 msgstr "Échec de l'obtention du répertoire courant"
 
-#: ../src/univ/theme.cpp:114
+#: ../src/univ/theme.cpp:111
 msgid "Failed to initialize GUI: no built-in themes found."
 msgstr ""
 "Échec de l'initialisation de l'interface graphique : aucun thème préfabriqué "
 "n'a été trouvé."
 
-#: ../src/msw/helpchm.cpp:63
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:60
 msgid "Failed to initialize MS HTML Help."
 msgstr "Échec de l'initialisation de l'aide MS HTML."
 
-#: ../src/msw/glcanvas.cpp:1381
+#: ../src/msw/glcanvas.cpp:1391
 msgid "Failed to initialize OpenGL"
 msgstr "Échec de l'initialisation d'OpenGL"
 
-#: ../src/msw/dialup.cpp:858
+#: ../src/msw/dialup.cpp:852
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Échec de l'initialisation de la connexion modem : %s"
 
-#: ../src/gtk/textctrl.cpp:1128
+#: ../src/gtk/textctrl.cpp:1209
 msgid "Failed to insert text in the control."
 msgstr "Échec de l'insertion de texte dans le contrôle."
 
-#: ../src/unix/snglinst.cpp:241
+#: ../src/unix/snglinst.cpp:238
 #, c-format
 msgid "Failed to inspect the lock file '%s'"
 msgstr "Échec de l'inspection du fichier verrou « %s »"
 
-#: ../src/unix/appunix.cpp:182
+#: ../src/unix/appunix.cpp:179
 msgid "Failed to install signal handler"
 msgstr "Échec de l'installation du gestionnaire de signal"
 
-#: ../src/unix/threadpsx.cpp:1167
+#: ../src/unix/threadpsx.cpp:1216
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -3353,71 +3401,71 @@ msgstr ""
 "Échec de l'adjonction d'un processus : fuite potentielle de mémoire "
 "détectée, redémarrer le programme"
 
-#: ../src/msw/utils.cpp:629
+#: ../src/msw/utils.cpp:619
 #, c-format
 msgid "Failed to kill process %d"
 msgstr "Échec de l'arrêt du processus %d"
 
-#: ../src/common/image.cpp:2500
+#: ../src/common/image.cpp:2595
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Échec du chargement du bitmap « %s » depuis les ressources."
 
-#: ../src/common/image.cpp:2509
+#: ../src/common/image.cpp:2604
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Échec du chargement de l'icône « %s » depuis les ressources."
 
-#: ../src/common/iconbndl.cpp:225
+#: ../src/common/iconbndl.cpp:224
 #, c-format
 msgid "Failed to load icons from resource '%s'."
 msgstr "Échec du chargement des icônes depuis les ressources '%s'."
 
-#: ../src/common/iconbndl.cpp:200
+#: ../src/common/iconbndl.cpp:198
 #, c-format
 msgid "Failed to load image %%d from file '%s'."
 msgstr "Échec du chargement de l'image %%d depuis le fichier « %s »."
 
-#: ../src/common/iconbndl.cpp:208
+#: ../src/common/iconbndl.cpp:206
 #, c-format
 msgid "Failed to load image %d from stream."
 msgstr "Échec du chargement de l'image %d depuis le flux."
 
-#: ../src/common/image.cpp:2587 ../src/common/image.cpp:2606
+#: ../src/common/image.cpp:2682 ../src/common/image.cpp:2701
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Échec du chargement de l'image depuis le fichier « %s »."
 
-#: ../src/msw/enhmeta.cpp:97
+#: ../src/msw/enhmeta.cpp:94
 #, c-format
 msgid "Failed to load metafile from file \"%s\"."
 msgstr "Échec du chargement du métafichier depuis le fichier « %s »."
 
-#: ../src/msw/volume.cpp:327
+#: ../src/msw/volume.cpp:335
 msgid "Failed to load mpr.dll."
 msgstr "Échec du chargement de mpr.dll."
 
-#: ../src/msw/utils.cpp:953
+#: ../src/msw/utils.cpp:943
 #, c-format
 msgid "Failed to load resource \"%s\"."
 msgstr "Échec du chargement de la ressource « %s »."
 
-#: ../src/common/dynlib.cpp:92
+#: ../src/common/dynlib.cpp:86
 #, c-format
 msgid "Failed to load shared library '%s'"
 msgstr "Échec du chargement de la bibliothèque partagée « %s »"
 
-#: ../src/osx/core/sound.cpp:145
+#: ../src/osx/core/sound.cpp:143
 #, c-format
 msgid "Failed to load sound from \"%s\" (error %d)."
 msgstr "Échec du chargement du son depuis « %s » (erreur %d)."
 
-#: ../src/msw/utils.cpp:960
+#: ../src/msw/utils.cpp:950
 #, c-format
 msgid "Failed to lock resource \"%s\"."
 msgstr "Échec du verrouillage de la ressource « %s »."
 
-#: ../src/unix/snglinst.cpp:198
+#: ../src/unix/snglinst.cpp:195
 #, c-format
 msgid "Failed to lock the lock file '%s'"
 msgstr "Échec du verrouillage du fichier verrou « %s »"
@@ -3428,33 +3476,38 @@ msgid "Failed to modify descriptor %d in epoll descriptor %d"
 msgstr ""
 "Échec de la modification du descripteur %d dans le descripteur epoll %d"
 
-#: ../src/common/filename.cpp:2575
+#: ../src/common/filename.cpp:2658
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Échec de la modification de la date du fichier « %s »"
 
-#: ../src/common/selectdispatcher.cpp:258
+#: ../src/common/selectdispatcher.cpp:255
 msgid "Failed to monitor I/O channels"
 msgstr "Impossible de contrôler les canaux d'E/S"
 
-#: ../src/common/filename.cpp:175
+#: ../src/common/filename.cpp:172
 #, c-format
 msgid "Failed to open '%s' for reading"
 msgstr "Échec de l'ouverture de « %s » en lecture"
 
-#: ../src/common/filename.cpp:180
+#: ../src/common/filename.cpp:177
 #, c-format
 msgid "Failed to open '%s' for writing"
 msgstr "Échec de l'ouverture de « %s » en écriture"
 
-#: ../src/html/chm.cpp:141
+#: ../src/html/chm.cpp:138
 #, c-format
 msgid "Failed to open CHM archive '%s'."
 msgstr "Échec de l'ouverture de l'archive CHM « %s »."
 
-#: ../src/common/utilscmn.cpp:1126
+#: ../src/common/utilscmn.cpp:1140
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Échec de l'ouverture de l'URL « %s » avec le navigateur par défaut."
+
+#: ../src/common/hyperlnkcmn.cpp:133
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Échec de l'ouverture de l'URL « %s » avec le navigateur par défaut."
 
 #: ../include/wx/msw/private/fswatcher.h:92
@@ -3462,94 +3515,104 @@ msgstr "Échec de l'ouverture de l'URL « %s » avec le navigateur par défaut
 msgid "Failed to open directory \"%s\" for monitoring."
 msgstr "Échec de l'ouverture du répertoire « %s » pour surveillance."
 
-#: ../src/x11/utils.cpp:227
+#: ../src/x11/utils.cpp:189
 #, c-format
 msgid "Failed to open display \"%s\"."
 msgstr "Échec de l'ouverture de l'écran « %s »."
 
-#: ../src/common/filename.cpp:1062
+#: ../src/common/filename.cpp:1059
 msgid "Failed to open temporary file."
 msgstr "Échec de l'ouverture d'un fichier temporaire."
 
-#: ../src/msw/clipbrd.cpp:91
+#: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Échec de l'ouverture du presse-papiers."
 
-#: ../src/common/translation.cpp:1184
+#: ../src/common/translation.cpp:1226
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Écher de l'analyse des formes plurielles  : « %s »"
 
-#: ../src/unix/mediactrl.cpp:1214
+#: ../src/unix/mediactrl.cpp:1239
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Échec de la préparation à la lecture « %s »."
 
-#: ../src/msw/clipbrd.cpp:600
+#: ../src/msw/clipbrd.cpp:610
 msgid "Failed to put data on the clipboard"
 msgstr "Échec de l'ajout de données dans le presse-papiers"
 
-#: ../src/unix/snglinst.cpp:278
+#: ../src/unix/snglinst.cpp:275
 msgid "Failed to read PID from lock file."
 msgstr ""
 "Échec de la lecture du numéro de processus (PID) depuis le fichier verrou."
 
-#: ../src/common/fileconf.cpp:433
+#: ../src/common/fileconf.cpp:432
 msgid "Failed to read config options."
 msgstr "Échec de la lecture des options de configuration."
 
-#: ../src/common/docview.cpp:681
+#: ../src/common/docview.cpp:676
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Échec de la lecture du document depuis le fichier « %s »."
 
-#: ../src/dfb/evtloop.cpp:98
+#: ../src/dfb/evtloop.cpp:99
 msgid "Failed to read event from DirectFB pipe"
 msgstr "Échec de la lecture d'évènement depuis un tube (pipe) DirectFB"
 
-#: ../src/unix/wakeuppipe.cpp:120
+#: ../src/unix/wakeuppipe.cpp:117
 msgid "Failed to read from wake-up pipe"
 msgstr "Échec de la lecture du tube (pipe) de réveil"
 
-#: ../src/unix/utilsunx.cpp:679
+#: ../src/common/textfile.cpp:96
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Échec de la lecture du document depuis le fichier « %s »."
+
+#: ../src/unix/utilsunx.cpp:681
 msgid "Failed to redirect child process input/output"
 msgstr "Échec de la redirection des entrées et sorties du processus fils"
 
-#: ../src/msw/utilsexc.cpp:701
+#: ../src/msw/utilsexc.cpp:698
 msgid "Failed to redirect the child process IO"
 msgstr "Échec de la redirection des entrées et sorties du processus fils"
 
-#: ../src/msw/dde.cpp:288
+#: ../src/msw/dde.cpp:283
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Échec de l'enregistrement du serveur DDE « %s »"
 
-#: ../src/common/fontmap.cpp:245
+#: ../src/gtk/font.cpp:580
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "Échec de la mise à jour du fichier de configuration utilisateur."
+
+#: ../src/common/fontmap.cpp:242
 #, c-format
 msgid "Failed to remember the encoding for the charset '%s'."
 msgstr "Échec du rappel du codage du jeu de caractères « %s »."
 
-#: ../src/common/debugrpt.cpp:227
+#: ../src/common/debugrpt.cpp:228
 #, c-format
 msgid "Failed to remove debug report file \"%s\""
 msgstr "Échec de la suppression du fichier de rapport de débogage « %s »"
 
-#: ../src/unix/snglinst.cpp:328
+#: ../src/unix/snglinst.cpp:325
 #, c-format
 msgid "Failed to remove lock file '%s'"
 msgstr "Échec de la suppression du fichier verrou « %s »"
 
-#: ../src/unix/snglinst.cpp:288
+#: ../src/unix/snglinst.cpp:285
 #, c-format
 msgid "Failed to remove stale lock file '%s'."
 msgstr "Échec de la suppression du fichier verrou périmé « %s »."
 
-#: ../src/msw/registry.cpp:529
+#: ../src/msw/registry.cpp:518
 #, c-format
 msgid "Failed to rename registry value '%s' to '%s'."
 msgstr "Échec du renommage de la valeur de registre « %s » en « %s »."
 
-#: ../src/common/filefn.cpp:1122
+#: ../src/common/filefn.cpp:1011
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -3558,119 +3621,128 @@ msgstr ""
 "Erreur lors du changement de nom de « %s » en « %s » : il existe déjà un "
 "fichier avec le nom de destination."
 
-#: ../src/msw/registry.cpp:634
+#: ../src/msw/registry.cpp:623
 #, c-format
 msgid "Failed to rename the registry key '%s' to '%s'."
 msgstr "Échec du renommage de la clé de registre « %s » en « %s »."
 
-#: ../src/common/filename.cpp:2671
+#: ../src/msw/webview_ie.cpp:995
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/common/filename.cpp:2754
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Échec de la récupération de la date du fichier « %s »"
 
-#: ../src/msw/dialup.cpp:468
+#: ../src/msw/dialup.cpp:462
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Échec de la récupération du texte du message d'erreur RAS"
 
-#: ../src/msw/clipbrd.cpp:748
+#: ../src/msw/clipbrd.cpp:768
 msgid "Failed to retrieve the supported clipboard formats"
 msgstr "Échec de la récupération des formats de presse-papiers reconnus"
 
-#: ../src/common/docview.cpp:652
+#: ../src/common/docview.cpp:647
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Échec de l'enregistrement du document dans le fichier « %s »."
 
-#: ../src/msw/dib.cpp:269
+#: ../src/msw/dib.cpp:312
 #, c-format
 msgid "Failed to save the bitmap image to file \"%s\"."
 msgstr "Échec de l'enregistrement de l'image bitmap dans le fichier « %s »."
 
-#: ../src/msw/dde.cpp:763
+#: ../src/msw/dde.cpp:811
 msgid "Failed to send DDE advise notification"
 msgstr "Échec de l'envoi d'une notification d'instructions au DDE"
 
-#: ../src/common/ftp.cpp:402
+#: ../src/common/ftp.cpp:399
 #, c-format
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Échec de la configuration du mode de transfert FTP en %s."
 
-#: ../src/msw/clipbrd.cpp:427
+#: ../src/msw/clipbrd.cpp:443
 msgid "Failed to set clipboard data."
 msgstr "Échec de la configuration des données du presse-papiers."
 
-#: ../src/unix/snglinst.cpp:181
+#: ../src/unix/snglinst.cpp:178
 #, c-format
 msgid "Failed to set permissions on lock file '%s'"
 msgstr "Échec de la configuration des permissions du fichier verrou « %s »"
 
-#: ../src/unix/utilsunx.cpp:668
+#: ../src/unix/utilsunx.cpp:670
 msgid "Failed to set process priority"
 msgstr "Échec de la définition de la priorité du processus"
 
-#: ../src/common/file.cpp:559
+#: ../src/common/ffile.cpp:355 ../src/common/file.cpp:586
 msgid "Failed to set temporary file permissions"
 msgstr "Échec de la configuration des permissions du fichier temporaire"
 
-#: ../src/gtk/textctrl.cpp:1072
-msgid "Failed to set text in the text control."
-msgstr "Échec: le texte n'a pas pu être placé dans le contrôle de texte."
-
-#: ../src/unix/threadpsx.cpp:1298
+#: ../src/unix/threadpsx.cpp:1347
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Échec de l'établissement du niveau de concurrence de processus à %lu"
 
-#: ../src/unix/threadpsx.cpp:1424
+#: ../src/unix/threadpsx.cpp:1473
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Échec de la configuration de la priorité %d du processus."
 
-#: ../src/unix/utilsunx.cpp:783
+#: ../src/unix/utilsunx.cpp:785
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 "Échec de l'établissement du tube (pipe) non bloquant, le prgramme pourrait "
 "s'arrêter inopinément."
 
-#: ../src/common/fs_mem.cpp:261
+#: ../src/msw/webview_ie.cpp:987
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:256
 #, c-format
 msgid "Failed to store image '%s' to memory VFS!"
 msgstr "Échec du stockage de l'image « %s » dans la mémoire VFS !"
 
-#: ../src/dfb/evtloop.cpp:170
+#: ../src/dfb/evtloop.cpp:171
 msgid "Failed to switch DirectFB pipe to non-blocking mode"
 msgstr "Échec du basculement du tube (pipe) DirectFB vers le mode non bloquant"
 
-#: ../src/unix/wakeuppipe.cpp:59
+#: ../src/unix/wakeuppipe.cpp:56
 msgid "Failed to switch wake up pipe to non-blocking mode"
 msgstr ""
 "Échec du basculement du tube (pipe) de réveil vers le mode non bloquant"
 
-#: ../src/unix/threadpsx.cpp:1605
+#: ../src/unix/threadpsx.cpp:1654
 msgid "Failed to terminate a thread."
 msgstr "Échec de la terminaison d'un processus."
 
-#: ../src/msw/dde.cpp:741
+#: ../src/msw/dde.cpp:736
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr ""
 "Échec de la terminaison de la boucle d'instructions avec le serveur DDE"
 
-#: ../src/msw/dialup.cpp:938
+#: ../src/msw/dialup.cpp:932
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Échec de la terminaison de la connexion : %s"
 
-#: ../src/common/filename.cpp:2590
+#: ../src/common/filename.cpp:2673
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Échec de la mise à jour de la date du fichier « %s »"
 
-#: ../src/unix/snglinst.cpp:334
+#: ../src/unix/dlunix.cpp:90
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "Échec du chargement de la bibliothèque partagée « %s »"
+
+#: ../src/unix/snglinst.cpp:331
 #, c-format
 msgid "Failed to unlock lock file '%s'"
 msgstr "Échec du déverrouillage du fichier verrou « %s »"
 
-#: ../src/msw/dde.cpp:309
+#: ../src/msw/dde.cpp:304
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Échec du désenregistrement du serveur DDE « %s »"
@@ -3685,77 +3757,87 @@ msgstr ""
 msgid "Failed to update user configuration file."
 msgstr "Échec de la mise à jour du fichier de configuration utilisateur."
 
-#: ../src/common/debugrpt.cpp:733
+#: ../src/common/debugrpt.cpp:743
 #, c-format
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Échec de l'envoi du rapport de bogue (code d'erreur %d)."
 
-#: ../src/unix/snglinst.cpp:168
+#: ../src/unix/snglinst.cpp:165
 #, c-format
 msgid "Failed to write to lock file '%s'"
 msgstr "Échec de l'écriture dans le fichier verrou « %s »"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:209
+#: ../src/propgrid/propgrid.cpp:190
 msgid "False"
 msgstr "Faux"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:694
+#: ../src/propgrid/advprops.cpp:604
 msgid "Family"
 msgstr "Famille"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/gtk/glcanvas.cpp:176 ../src/gtk/glcanvas.cpp:187
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Erreur fatale"
+
+#: ../src/common/stockitem.cpp:154
 msgid "File"
 msgstr "Fichier"
 
-#: ../src/common/docview.cpp:669
+#: ../src/common/docview.cpp:664
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Le fichier « %s » n'a pas pu être ouvert en lecture."
 
-#: ../src/common/docview.cpp:646
+#: ../src/common/docview.cpp:641
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Le fichier « %s » n'a pas pu être ouvert en écriture."
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "Le fichier « %s » existe déjà, faut-il vraiment l'écraser ?"
 
-#: ../src/common/filefn.cpp:1156
+#: ../src/common/filefn.cpp:1044
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Le fichier « %s » n'a pas pu être supprimé"
 
-#: ../src/common/filefn.cpp:1139
+#: ../src/common/filefn.cpp:1028
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Le fichier « %s » n'a pas pu être renommé en « %s »"
 
-#: ../src/richtext/richtextctrl.cpp:3081 ../src/common/textcmn.cpp:953
+#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
 msgid "File couldn't be loaded."
 msgstr "Le fichier n'a pas pu être chargé."
 
-#: ../src/msw/filedlg.cpp:393
+#: ../src/msw/filedlg.cpp:414
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Échec du dialogue de fichier avec le code d'erreur %0lx."
 
-#: ../src/common/docview.cpp:1789
+#: ../src/common/docview.cpp:1783
 msgid "File error"
 msgstr "Erreur fichier"
 
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/filectrlg.cpp:770
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/filectrlg.cpp:766
 msgid "File name exists already."
 msgstr "Nom de fichier existant."
+
+#: ../src/osx/cocoa/filedlg.mm:264
+#, fuzzy
+msgid "File type:"
+msgstr "Télétype"
 
 #: ../src/motif/filedlg.cpp:220
 msgid "Files"
 msgstr "Fichiers"
 
-#: ../src/common/filefn.cpp:1591
+#: ../src/common/filefn.cpp:1479
 #, c-format
 msgid "Files (%s)"
 msgstr "Fichiers (%s)"
@@ -3764,15 +3846,29 @@ msgstr "Fichiers (%s)"
 msgid "Filter"
 msgstr "Filtre"
 
-#: ../src/common/stockitem.cpp:158 ../src/html/helpwnd.cpp:490
+#: ../src/html/helpwnd.cpp:488
 msgid "Find"
 msgstr "Trouver"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:259
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:258
+#, fuzzy
+msgid "Find in document"
+msgstr "Ouvrir un document HTML"
+
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "Find..."
+msgstr "Trouver"
+
+#: ../src/common/stockitem.cpp:156
 msgid "First"
 msgstr "Premier"
 
-#: ../src/common/prntbase.cpp:1548
+#: ../src/common/prntbase.cpp:1573
 msgid "First page"
 msgstr "Première page"
 
@@ -3780,11 +3876,11 @@ msgstr "Première page"
 msgid "Fixed"
 msgstr "Fixe"
 
-#: ../src/html/helpwnd.cpp:1206
+#: ../src/html/helpwnd.cpp:1204
 msgid "Fixed font:"
 msgstr "Police de taille fixe :"
 
-#: ../src/html/helpwnd.cpp:1269
+#: ../src/html/helpwnd.cpp:1267
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Police de taille fixe. <br> <b>gras</b> <i>italique</i> "
 
@@ -3792,16 +3888,16 @@ msgstr "Police de taille fixe. <br> <b>gras</b> <i>italique</i> "
 msgid "Floating"
 msgstr "Flottant"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "Floppy"
 msgstr "Disquette"
 
-#: ../src/common/paper.cpp:111
+#: ../src/common/paper.cpp:108
 msgid "Folio, 8 1/2 x 13 in"
 msgstr "Folio (8,5 x 13 pouces)"
 
-#: ../src/richtext/richtextformatdlg.cpp:344 ../src/osx/carbon/fontdlg.cpp:287
-#: ../src/common/stockitem.cpp:194
+#: ../src/osx/carbon/fontdlg.cpp:284 ../src/common/stockitem.cpp:191
+#: ../src/richtext/richtextformatdlg.cpp:337
 msgid "Font"
 msgstr "Police de caractères"
 
@@ -3809,7 +3905,24 @@ msgstr "Police de caractères"
 msgid "Font &weight:"
 msgstr "Lar&geur de police :"
 
-#: ../src/html/helpwnd.cpp:1207
+#: ../src/osx/fontutil.cpp:89
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
+"\"."
+msgstr ""
+
+#: ../src/msw/font.cpp:1126
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Le fichier n'a pas pu être chargé."
+
+#: ../src/osx/fontutil.cpp:81
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "Fichier « %s » inexistant."
+
+#: ../src/html/helpwnd.cpp:1205
 msgid "Font size:"
 msgstr "Taille de la police :"
 
@@ -3817,54 +3930,54 @@ msgstr "Taille de la police :"
 msgid "Font st&yle:"
 msgstr "St&yle de la police :"
 
-#: ../src/osx/carbon/fontdlg.cpp:329
+#: ../src/osx/carbon/fontdlg.cpp:326
 msgid "Font:"
 msgstr "Police de caractères :"
 
-#: ../src/dfb/fontmgr.cpp:198
+#: ../src/dfb/fontmgr.cpp:195
 #, c-format
 msgid "Fonts index file %s disappeared while loading fonts."
 msgstr ""
 "Le fichier d'index de polices %s a disparu lors du chargement des polices."
 
-#: ../src/unix/utilsunx.cpp:645
+#: ../src/unix/utilsunx.cpp:647
 msgid "Fork failed"
 msgstr "Échec du clonage"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "Forward"
 msgstr "Suivant"
 
-#: ../src/common/xtixml.cpp:235
+#: ../src/common/xtixml.cpp:231
 msgid "Forward hrefs are not supported"
 msgstr "Transferts href non reconnus"
 
-#: ../src/html/helpwnd.cpp:875
+#: ../src/html/helpwnd.cpp:873
 #, c-format
 msgid "Found %i matches"
 msgstr "%i correspondances trouvées"
 
-#: ../src/generic/prntdlgg.cpp:238
+#: ../src/generic/prntdlgg.cpp:231
 msgid "From:"
 msgstr "De :"
 
-#: ../src/propgrid/advprops.cpp:1604
+#: ../src/propgrid/advprops.cpp:1510
 msgid "Fuchsia"
 msgstr "Fuchia"
 
-#: ../src/common/imaggif.cpp:138
+#: ../src/common/imaggif.cpp:135
 msgid "GIF: data stream seems to be truncated."
 msgstr "GIF : le flux des données semble être tronqué."
 
-#: ../src/common/imaggif.cpp:128
+#: ../src/common/imaggif.cpp:125
 msgid "GIF: error in GIF image format."
 msgstr "GIF : erreur dans le format de l'image GIF."
 
-#: ../src/common/imaggif.cpp:133
+#: ../src/common/imaggif.cpp:130
 msgid "GIF: not enough memory."
 msgstr "GIF : mémoire insuffisante."
 
-#: ../src/gtk/window.cpp:4631
+#: ../src/gtk/window.cpp:5635
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -3873,23 +3986,23 @@ msgstr ""
 "reconnaitre la composition d'écran, il faut installer GTK+ 2.12 ou plus "
 "récent."
 
-#: ../src/univ/themes/gtk.cpp:525
+#: ../src/univ/themes/gtk.cpp:522
 msgid "GTK+ theme"
 msgstr "Thème GTK+"
 
-#: ../src/common/preferencescmn.cpp:40
+#: ../src/common/preferencescmn.cpp:37
 msgid "General"
 msgstr "Général"
 
-#: ../src/common/prntbase.cpp:258
+#: ../src/common/prntbase.cpp:253
 msgid "Generic PostScript"
 msgstr "Fichier PostScript"
 
-#: ../src/common/paper.cpp:135
+#: ../src/common/paper.cpp:132
 msgid "German Legal Fanfold, 8 1/2 x 13 in"
 msgstr "Légal allemand en accordéon (8,5 x 13 pouces)"
 
-#: ../src/common/paper.cpp:134
+#: ../src/common/paper.cpp:131
 msgid "German Std Fanfold, 8 1/2 x 12 in"
 msgstr "Standard allemand en accordéon (8,5 x 12 pouces)"
 
@@ -3905,48 +4018,48 @@ msgstr "GetPropertyCollection appelé sur un assesseur générique"
 msgid "GetPropertyCollection called w/o valid collection getter"
 msgstr "GetPropertyCollection appelé sans récupérateur de collection valable"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:658
 msgid "Go back"
 msgstr "Revenir"
 
-#: ../src/html/helpwnd.cpp:661
+#: ../src/html/helpwnd.cpp:659
 msgid "Go forward"
 msgstr "Continuer"
 
-#: ../src/html/helpwnd.cpp:663
+#: ../src/html/helpwnd.cpp:661
 msgid "Go one level up in document hierarchy"
 msgstr "Monter au niveau supérieur dans la hiérarchie du document"
 
-#: ../src/generic/filedlgg.cpp:208 ../src/generic/dirdlgg.cpp:116
+#: ../src/generic/filedlgg.cpp:205 ../src/generic/dirdlgg.cpp:113
 msgid "Go to home directory"
 msgstr "Aller au dossier personnel"
 
-#: ../src/generic/filedlgg.cpp:205
+#: ../src/generic/filedlgg.cpp:202
 msgid "Go to parent directory"
 msgstr "Aller au dossier parent"
 
-#: ../src/generic/aboutdlgg.cpp:76
+#: ../src/generic/aboutdlgg.cpp:73
 msgid "Graphics art by "
 msgstr "Graphismes par "
 
-#: ../src/propgrid/advprops.cpp:1599
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Gray"
 msgstr "Gris"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:883
+#: ../src/propgrid/advprops.cpp:784
 msgid "GrayText"
 msgstr "GrayText"
 
-#: ../src/common/fmapbase.cpp:154
+#: ../src/common/fmapbase.cpp:151
 msgid "Greek (ISO-8859-7)"
 msgstr "Grec (ISO-8859-7)"
 
-#: ../src/propgrid/advprops.cpp:1600
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Green"
 msgstr "Vert"
 
-#: ../src/generic/colrdlgg.cpp:342
+#: ../src/generic/colrdlgg.cpp:362
 msgid "Green:"
 msgstr "Vert :"
 
@@ -3954,107 +4067,107 @@ msgstr "Vert :"
 msgid "Groove"
 msgstr "Groove"
 
-#: ../src/common/zstream.cpp:158 ../src/common/zstream.cpp:318
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
 msgid "Gzip not supported by this version of zlib"
 msgstr "Gzip n'est pas géré par cette version de zlib"
 
-#: ../src/html/helpwnd.cpp:1549
+#: ../src/html/helpwnd.cpp:1547
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "Projet d'aide HTML (*.hhp)|*.hhp|"
 
-#: ../src/html/htmlwin.cpp:681
+#: ../src/html/htmlwin.cpp:691
 #, c-format
 msgid "HTML anchor %s does not exist."
 msgstr "Ancre HTML %s inexistante."
 
-#: ../src/html/helpwnd.cpp:1547
+#: ../src/html/helpwnd.cpp:1545
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "Fichiers HTML (*.html;*.htm)|*.html;*.htm|"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1759
+#: ../src/propgrid/advprops.cpp:1660
 msgid "Hand"
 msgstr "Main"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "Harddisk"
 msgstr "Disque dur"
 
-#: ../src/common/fmapbase.cpp:155
+#: ../src/common/fmapbase.cpp:152
 msgid "Hebrew (ISO-8859-8)"
 msgstr "Hébreu (ISO-8859-8)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:280 ../src/osx/button_osx.cpp:39
-#: ../src/common/stockitem.cpp:163 ../src/common/accelcmn.cpp:80
-#: ../src/html/helpdlg.cpp:66 ../src/html/helpfrm.cpp:111
+#: ../include/wx/msgdlg.h:282 ../src/osx/button_osx.cpp:39
+#: ../src/common/stockitem.cpp:160 ../src/common/accelcmn.cpp:77
+#: ../src/html/helpfrm.cpp:108 ../src/html/helpdlg.cpp:63
 msgid "Help"
 msgstr "Aide"
 
-#: ../src/html/helpwnd.cpp:1200
+#: ../src/html/helpwnd.cpp:1198
 msgid "Help Browser Options"
 msgstr "Aide Options Navigateur"
 
-#: ../src/generic/helpext.cpp:454 ../src/generic/helpext.cpp:455
+#: ../src/generic/helpext.cpp:452 ../src/generic/helpext.cpp:453
 msgid "Help Index"
 msgstr "Aide Index"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1529
 msgid "Help Printing"
 msgstr "Aide Impression"
 
-#: ../src/html/helpwnd.cpp:801
+#: ../src/html/helpwnd.cpp:799
 msgid "Help Topics"
 msgstr "Sujets Aide"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1546
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Livres d'aide (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 
-#: ../src/generic/helpext.cpp:267
+#: ../src/generic/helpext.cpp:265
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "Dossier d'aide « %s » non trouvé."
 
-#: ../src/generic/helpext.cpp:275
+#: ../src/generic/helpext.cpp:273
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "Fichier d'aide « %s » non trouvé."
 
-#: ../src/html/helpctrl.cpp:63
+#: ../src/html/helpctrl.cpp:59
 #, c-format
 msgid "Help: %s"
 msgstr "Aide : %s"
 
-#: ../src/osx/menu_osx.cpp:577
+#: ../src/osx/menu_osx.cpp:469
 #, c-format
 msgid "Hide %s"
 msgstr "Cacher %s"
 
-#: ../src/osx/menu_osx.cpp:579
+#: ../src/osx/menu_osx.cpp:471
 msgid "Hide Others"
 msgstr "Cacher les Autres"
 
-#: ../src/generic/infobar.cpp:84
+#: ../src/generic/infobar.cpp:81
 msgid "Hide this notification message."
 msgstr "Cacher ce message de notification."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:884
+#: ../src/propgrid/advprops.cpp:785
 msgid "Highlight"
 msgstr "Surlignage"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:885
+#: ../src/propgrid/advprops.cpp:786
 msgid "HighlightText"
 msgstr "HighlightText"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:164 ../src/common/accelcmn.cpp:65
+#: ../src/common/stockitem.cpp:161 ../src/common/accelcmn.cpp:62
 msgid "Home"
 msgstr "Dossier personnel"
 
-#: ../src/generic/dirctrlg.cpp:524
+#: ../src/generic/dirctrlg.cpp:490
 msgid "Home directory"
 msgstr "Dossier personnel"
 
@@ -4064,55 +4177,55 @@ msgid "How the object will float relative to the text."
 msgstr "Comment l'objet flottera par rapport au texte."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1760
+#: ../src/propgrid/advprops.cpp:1661
 msgid "I-Beam"
 msgstr "I-Beam"
 
-#: ../src/common/imagbmp.cpp:1196
+#: ../src/common/imagbmp.cpp:1208
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO : erreur à la lecture du masque DIB."
 
-#: ../src/common/imagbmp.cpp:1290 ../src/common/imagbmp.cpp:1390
-#: ../src/common/imagbmp.cpp:1405 ../src/common/imagbmp.cpp:1416
-#: ../src/common/imagbmp.cpp:1430 ../src/common/imagbmp.cpp:1478
-#: ../src/common/imagbmp.cpp:1493 ../src/common/imagbmp.cpp:1507
-#: ../src/common/imagbmp.cpp:1518
+#: ../src/common/imagbmp.cpp:1302 ../src/common/imagbmp.cpp:1402
+#: ../src/common/imagbmp.cpp:1417 ../src/common/imagbmp.cpp:1428
+#: ../src/common/imagbmp.cpp:1442 ../src/common/imagbmp.cpp:1490
+#: ../src/common/imagbmp.cpp:1505 ../src/common/imagbmp.cpp:1519
+#: ../src/common/imagbmp.cpp:1530
 msgid "ICO: Error writing the image file!"
 msgstr "ICO : erreur à l'écriture du fichier image !"
 
-#: ../src/common/imagbmp.cpp:1255
+#: ../src/common/imagbmp.cpp:1267
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO : image trop grande pour une icône."
 
-#: ../src/common/imagbmp.cpp:1263
+#: ../src/common/imagbmp.cpp:1275
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO : image trop large pour une icône."
 
-#: ../src/common/imagbmp.cpp:1603
+#: ../src/common/imagbmp.cpp:1615
 msgid "ICO: Invalid icon index."
 msgstr "ICO : index de l'icône non valable."
 
-#: ../src/common/imagiff.cpp:758
+#: ../src/common/imagiff.cpp:755
 msgid "IFF: data stream seems to be truncated."
 msgstr "IFF : le flux de données semble être tronqué."
 
-#: ../src/common/imagiff.cpp:742
+#: ../src/common/imagiff.cpp:739
 msgid "IFF: error in IFF image format."
 msgstr "IFF : erreur dans le format de l'image IFF."
 
-#: ../src/common/imagiff.cpp:745
+#: ../src/common/imagiff.cpp:742
 msgid "IFF: not enough memory."
 msgstr "IFF : mémoire insuffisante."
 
-#: ../src/common/imagiff.cpp:748
+#: ../src/common/imagiff.cpp:745
 msgid "IFF: unknown error!!!"
 msgstr "IFF : erreur inconnue !!!"
 
-#: ../src/common/fmapbase.cpp:197
+#: ../src/common/fmapbase.cpp:194
 msgid "ISO-2022-JP"
 msgstr "ISO-2022-JP"
 
-#: ../src/html/htmprint.cpp:282
+#: ../src/html/htmprint.cpp:294
 msgid ""
 "If possible, try changing the layout parameters to make the printout more "
 "narrow."
@@ -4120,7 +4233,7 @@ msgstr ""
 "Si possible, essayer de modifier les paramètres de mise en page pour rendre "
 "l'imprimé plus étroit."
 
-#: ../src/generic/dbgrptg.cpp:358
+#: ../src/generic/dbgrptg.cpp:362
 msgid ""
 "If you have any additional information pertaining to this bug\n"
 "report, please enter it here and it will be joined to it:"
@@ -4139,47 +4252,51 @@ msgstr ""
 "le bouton « Annuler », mais cela peut empêcher l'amélioration du\n"
 "programme, donc si possible continuer la création de ce rapport.\n"
 
-#: ../src/msw/registry.cpp:1405
+#: ../src/common/zipstrm.cpp:1043
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1393
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Valeur « %s » de la clé « %s » ignorée."
 
-#: ../src/common/xtistrm.cpp:295
+#: ../src/common/xtistrm.cpp:292
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr ""
 "Classe d'objet non valable en tant que source d'événement (Non-wxEvtHandler)"
 
-#: ../src/common/xti.cpp:513
+#: ../src/common/xti.cpp:510
 msgid "Illegal Parameter Count for ConstructObject Method"
 msgstr "Nombre de paramètres illégal pour la méthode ConstructObject"
 
-#: ../src/common/xti.cpp:501
+#: ../src/common/xti.cpp:498
 msgid "Illegal Parameter Count for Create Method"
 msgstr "Nombre de paramètres illégal pour la méthode Create"
 
-#: ../src/generic/dirctrlg.cpp:570 ../src/generic/filectrlg.cpp:756
+#: ../src/generic/dirctrlg.cpp:536 ../src/generic/filectrlg.cpp:752
 msgid "Illegal directory name."
 msgstr "Nom de répertoire illégal."
 
-#: ../src/generic/filectrlg.cpp:1367
+#: ../src/generic/filectrlg.cpp:1356
 msgid "Illegal file specification."
 msgstr "Spécification de fichier illégale."
 
-#: ../src/common/image.cpp:2269
+#: ../src/common/image.cpp:2363
 msgid "Image and mask have different sizes."
 msgstr "L'image et le masque sont de tailles différentes."
 
-#: ../src/common/image.cpp:2746
+#: ../src/common/image.cpp:2841
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "Le fichier image n'est pas du type %d."
 
-#: ../src/common/image.cpp:2877
+#: ../src/common/image.cpp:2995
 #, c-format
 msgid "Image is not of type %s."
 msgstr "Le fichier image n'est pas du type %s."
 
-#: ../src/msw/textctrl.cpp:488
+#: ../src/msw/textctrl.cpp:534
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -4187,100 +4304,100 @@ msgstr ""
 "Impossible de créer un contrôle d'édition riche, utilisation d'un contrôle "
 "de texte simple à la place. Réinstaller riched32.dll"
 
-#: ../src/unix/utilsunx.cpp:301
+#: ../src/unix/utilsunx.cpp:303
 msgid "Impossible to get child process input"
 msgstr "Impossible d'obtenir l'entrée du processus fils"
 
-#: ../src/common/filefn.cpp:1028
+#: ../src/common/filefn.cpp:917
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Impossible d'obtenir les permissions du fichier « %s »"
 
-#: ../src/common/filefn.cpp:1042
+#: ../src/common/filefn.cpp:931
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Impossible d'écraser le fichier « %s »"
 
-#: ../src/common/filefn.cpp:1097
+#: ../src/common/filefn.cpp:986
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Impossible de configurer les permissions du fichier « %s »"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:886
+#: ../src/propgrid/advprops.cpp:787
 msgid "InactiveBorder"
 msgstr "InactiveBorder"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:887
+#: ../src/propgrid/advprops.cpp:788
 msgid "InactiveCaption"
 msgstr "InactiveCaption"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:888
+#: ../src/propgrid/advprops.cpp:789
 msgid "InactiveCaptionText"
 msgstr "InactiveCaptionText"
 
-#: ../src/common/gifdecod.cpp:792
+#: ../src/common/gifdecod.cpp:826
 #, c-format
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "Taille d'image GIF incorrecte (%u, %d) for l'image #%u"
 
-#: ../src/msw/ole/automtn.cpp:635
+#: ../src/msw/ole/automtn.cpp:626
 msgid "Incorrect number of arguments."
 msgstr "Nombre d'arguments incorrect."
 
-#: ../src/common/stockitem.cpp:165
+#: ../src/common/stockitem.cpp:162
 msgid "Indent"
 msgstr "Indenter"
 
-#: ../src/richtext/richtextformatdlg.cpp:349
+#: ../src/richtext/richtextformatdlg.cpp:342
 msgid "Indents && Spacing"
 msgstr "Indentations && Espacements"
 
-#: ../src/common/stockitem.cpp:166 ../src/html/helpwnd.cpp:515
+#: ../src/common/stockitem.cpp:163 ../src/html/helpwnd.cpp:513
 msgid "Index"
 msgstr "Index"
 
-#: ../src/common/fmapbase.cpp:159
+#: ../src/common/fmapbase.cpp:156
 msgid "Indian (ISO-8859-12)"
 msgstr "Indien (ISO-8859-12)"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "Info"
 msgstr "Infos"
 
-#: ../src/common/init.cpp:287
+#: ../src/common/init.cpp:284
 msgid "Initialization failed in post init, aborting."
 msgstr "L'initialisation a échoué dans post init, abandon."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:54
+#: ../src/common/accelcmn.cpp:51
 msgid "Ins"
 msgstr "Inser"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextsymboldlg.cpp:472 ../src/common/accelcmn.cpp:53
+#: ../src/common/accelcmn.cpp:50 ../src/richtext/richtextsymboldlg.cpp:469
 msgid "Insert"
 msgstr "Insérer"
 
-#: ../src/richtext/richtextbuffer.cpp:8067
+#: ../src/richtext/richtextbuffer.cpp:8063
 msgid "Insert Field"
 msgstr "Insérer un champ"
 
-#: ../src/richtext/richtextbuffer.cpp:7978
-#: ../src/richtext/richtextbuffer.cpp:8936
+#: ../src/richtext/richtextbuffer.cpp:7974
+#: ../src/richtext/richtextbuffer.cpp:8934
 msgid "Insert Image"
 msgstr "Insérer une image"
 
-#: ../src/richtext/richtextbuffer.cpp:8025
+#: ../src/richtext/richtextbuffer.cpp:8021
 msgid "Insert Object"
 msgstr "Insérer un objet"
 
-#: ../src/richtext/richtextctrl.cpp:1286 ../src/richtext/richtextctrl.cpp:1494
-#: ../src/richtext/richtextbuffer.cpp:7822
-#: ../src/richtext/richtextbuffer.cpp:7852
-#: ../src/richtext/richtextbuffer.cpp:7894
+#: ../src/richtext/richtextbuffer.cpp:7818
+#: ../src/richtext/richtextbuffer.cpp:7848
+#: ../src/richtext/richtextbuffer.cpp:7890
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
 msgid "Insert Text"
 msgstr "Insérer du texte"
 
@@ -4293,16 +4410,11 @@ msgstr "Insère un saut de page avant le paragraphe."
 msgid "Inset"
 msgstr "Intérieur"
 
-#: ../src/gtk/app.cpp:425
-#, c-format
-msgid "Invalid GTK+ command line option, use \"%s --help\""
-msgstr "Option de ligne de commandeGTK+ non valable, utiliser « %s --help »"
-
-#: ../src/common/imagtiff.cpp:311
+#: ../src/common/imagtiff.cpp:308
 msgid "Invalid TIFF image index."
 msgstr "Index d'image TIFF non valable."
 
-#: ../src/common/appcmn.cpp:273
+#: ../src/common/appcmn.cpp:294
 #, c-format
 msgid "Invalid display mode specification '%s'."
 msgstr "Spécification du mode d'affichage « %s » non valable."
@@ -4312,248 +4424,252 @@ msgstr "Spécification du mode d'affichage « %s » non valable."
 msgid "Invalid geometry specification '%s'"
 msgstr "Spécification géométrique « %s » non valable"
 
-#: ../src/unix/fswatcher_inotify.cpp:323
+#: ../src/unix/fswatcher_inotify.cpp:320
 #, c-format
 msgid "Invalid inotify event for \"%s\""
 msgstr "Évènement inotify pour « %s » non valable"
 
-#: ../src/unix/snglinst.cpp:312
+#: ../src/unix/snglinst.cpp:309
 #, c-format
 msgid "Invalid lock file '%s'."
 msgstr "Fichier verrou « %s » non valable."
 
-#: ../src/common/translation.cpp:1125
+#: ../src/common/translation.cpp:1167
 msgid "Invalid message catalog."
 msgstr "Catalogue de message non valable."
 
-#: ../src/common/xtistrm.cpp:405 ../src/common/xtistrm.cpp:420
+#: ../src/common/xtistrm.cpp:402 ../src/common/xtistrm.cpp:417
 msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
 msgstr "Identifiant d'objet non valable ou vide indiqué à GetObjectClassInfo"
 
-#: ../src/common/xtistrm.cpp:435
+#: ../src/common/xtistrm.cpp:432
 msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
 msgstr "Identifiant d'objet non valable ou vide indiqué à HasObjectClassInfo"
 
-#: ../src/common/regex.cpp:310
+#: ../src/common/regex.cpp:307
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Expression rationnelle « %s » non valable : %s"
 
-#: ../src/common/config.cpp:226
+#: ../src/common/config.cpp:222
 #, c-format
 msgid "Invalid value %ld for a boolean key \"%s\" in config file."
 msgstr ""
 "Valeur %ld incorrecte pour une clé booléenne « %s » dans le fichier de "
 "configuration."
 
-#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:351
-#: ../src/osx/carbon/fontdlg.cpp:361 ../src/common/stockitem.cpp:168
+#: ../src/osx/carbon/fontdlg.cpp:358 ../src/common/stockitem.cpp:165
+#: ../src/generic/fontdlgg.cpp:325 ../src/richtext/richtextfontpage.cpp:351
 msgid "Italic"
 msgstr "Italique"
 
-#: ../src/common/paper.cpp:130
+#: ../src/common/paper.cpp:127
 msgid "Italy Envelope, 110 x 230 mm"
 msgstr "Enveloppe italienne, 110 x 230 mm"
 
-#: ../src/common/imagjpeg.cpp:270
+#: ../src/common/imagjpeg.cpp:257
 msgid "JPEG: Couldn't load - file is probably corrupted."
 msgstr "JPEG : échec du chargement - le fichier est probablement corrompu."
 
-#: ../src/common/imagjpeg.cpp:449
+#: ../src/common/imagjpeg.cpp:436
 msgid "JPEG: Couldn't save image."
 msgstr "JPEG : échec de la sauvegarde de l'image."
 
-#: ../src/common/paper.cpp:163
+#: ../src/common/paper.cpp:160
 msgid "Japanese Double Postcard 200 x 148 mm"
 msgstr "Carte postale double japonaise 200 x148 mm"
 
-#: ../src/common/paper.cpp:167
+#: ../src/common/paper.cpp:164
 msgid "Japanese Envelope Chou #3"
 msgstr "Enveloppe japonaise Chou n. 3"
 
-#: ../src/common/paper.cpp:180
+#: ../src/common/paper.cpp:177
 msgid "Japanese Envelope Chou #3 Rotated"
 msgstr "Enveloppe japonaise Chou n. 3 Paysage"
 
-#: ../src/common/paper.cpp:168
+#: ../src/common/paper.cpp:165
 msgid "Japanese Envelope Chou #4"
 msgstr "Enveloppe japonaise Chou n. 4"
 
-#: ../src/common/paper.cpp:181
+#: ../src/common/paper.cpp:178
 msgid "Japanese Envelope Chou #4 Rotated"
 msgstr "Enveloppe japonaise Chou n. 4 Paysage"
 
-#: ../src/common/paper.cpp:165
+#: ../src/common/paper.cpp:162
 msgid "Japanese Envelope Kaku #2"
 msgstr "Enveloppe japonaise Kaky  n. 2"
 
-#: ../src/common/paper.cpp:178
+#: ../src/common/paper.cpp:175
 msgid "Japanese Envelope Kaku #2 Rotated"
 msgstr "Enveloppe japonaise Kaky  n. 2 Paysage"
 
-#: ../src/common/paper.cpp:166
+#: ../src/common/paper.cpp:163
 msgid "Japanese Envelope Kaku #3"
 msgstr "Enveloppe japonaise Kaky  n. 3"
 
-#: ../src/common/paper.cpp:179
+#: ../src/common/paper.cpp:176
 msgid "Japanese Envelope Kaku #3 Rotated"
 msgstr "Enveloppe japonaise Kaky  n. 3 Paysage"
 
-#: ../src/common/paper.cpp:185
+#: ../src/common/paper.cpp:182
 msgid "Japanese Envelope You #4"
 msgstr "Enveloppe japonaise Kaky  n. 4"
 
-#: ../src/common/paper.cpp:186
+#: ../src/common/paper.cpp:183
 msgid "Japanese Envelope You #4 Rotated"
 msgstr "Enveloppe japonaise Kaky  n. 4 Paysage"
 
-#: ../src/common/paper.cpp:138
+#: ../src/common/paper.cpp:135
 msgid "Japanese Postcard 100 x 148 mm"
 msgstr "Enveloppe japonaise 100 x 148 mm"
 
-#: ../src/common/paper.cpp:175
+#: ../src/common/paper.cpp:172
 msgid "Japanese Postcard Rotated 148 x 100 mm"
 msgstr "Enveloppe japonaise Paysage 148 x 100 mm"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "Jump to"
 msgstr "Aller à"
 
-#: ../src/common/stockitem.cpp:171
+#: ../src/common/stockitem.cpp:168
 msgid "Justified"
 msgstr "Justifié"
 
-#: ../src/richtext/richtextindentspage.cpp:155
-#: ../src/richtext/richtextindentspage.cpp:157
 #: ../src/richtext/richtextliststylepage.cpp:344
 #: ../src/richtext/richtextliststylepage.cpp:346
+#: ../src/richtext/richtextindentspage.cpp:155
+#: ../src/richtext/richtextindentspage.cpp:157
 msgid "Justify text left and right."
 msgstr "Justifier le texte."
 
-#: ../src/common/fmapbase.cpp:163
+#: ../src/common/fmapbase.cpp:160
 msgid "KOI8-R"
 msgstr "KOI8-R"
 
-#: ../src/common/fmapbase.cpp:164
+#: ../src/common/fmapbase.cpp:161
 msgid "KOI8-U"
 msgstr "KOI8-U"
 
-#: ../src/common/accelcmn.cpp:265 ../src/common/accelcmn.cpp:347
+#: ../src/common/accelcmn.cpp:279 ../src/common/accelcmn.cpp:364
 msgid "KP_"
 msgstr "KP_"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "KP_Add"
 msgstr "KP_Add"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "KP_Begin"
 msgstr "KP_Begin"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "KP_Decimal"
 msgstr "KP_Decimal"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 msgid "KP_Delete"
 msgstr "KP_Delete"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "KP_Divide"
 msgstr "KP_Divide"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 msgid "KP_Down"
 msgstr "KP_Down"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "KP_End"
 msgstr "KP_End"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "KP_Enter"
 msgstr "KP_Enter"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "KP_Equal"
 msgstr "KP_Equal"
 
+#: ../src/common/accelcmn.cpp:276 ../src/common/accelcmn.cpp:361
+msgid "KP_F"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 msgid "KP_Home"
 msgstr "KP_Home"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 msgid "KP_Insert"
 msgstr "KP_Insert"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "KP_Left"
 msgstr "KP_Left"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "KP_Multiply"
 msgstr "KP_Multiply"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:99
+#: ../src/common/accelcmn.cpp:97
 msgid "KP_Next"
 msgstr "KP_Next"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "KP_PageDown"
 msgstr "KP_PageDown"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "KP_PageUp"
 msgstr "KP_PageUp"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:98
+#: ../src/common/accelcmn.cpp:96
 msgid "KP_Prior"
 msgstr "KP_Prior"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 msgid "KP_Right"
 msgstr "KP_Right"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "KP_Separator"
 msgstr "KP_Separator"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "KP_Space"
 msgstr "KP_Space"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "KP_Subtract"
 msgstr "KP_Subtract"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "KP_Tab"
 msgstr "KP_Tab"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "KP_Up"
 msgstr "KP_Up"
 
@@ -4561,112 +4677,127 @@ msgstr "KP_Up"
 msgid "L&ine spacing:"
 msgstr "Interligne :"
 
-#: ../src/generic/prntdlgg.cpp:613 ../src/generic/prntdlgg.cpp:868
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "erreur de compression"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "erreur de décompression"
+
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:861
 msgid "Landscape"
 msgstr "Paysage"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "Last"
 msgstr "Dernier"
 
-#: ../src/common/prntbase.cpp:1572
+#: ../src/common/prntbase.cpp:1597
 msgid "Last page"
 msgstr "Dernière page"
 
-#: ../src/common/log.cpp:305
+#: ../src/common/log.cpp:324
 #, c-format
 msgid "Last repeated message (\"%s\", %u time) wasn't output"
 msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
 msgstr[0] "Le dernier message répété (« %s », %u fois) n'a pas été affiché"
 msgstr[1] "Le dernier message répété (« %s », %u fois) n'a pas été affiché"
 
-#: ../src/common/paper.cpp:103
+#: ../src/common/paper.cpp:100
 msgid "Ledger, 17 x 11 in"
 msgstr "Grand livre (17 x 11 pouces)"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6146
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:58 ../src/generic/datavgen.cpp:6951
+#: ../src/richtext/richtextsizepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:252
 #: ../src/richtext/richtextliststylepage.cpp:253
 #: ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
-#: ../src/richtext/richtextsizepage.cpp:249 ../src/common/accelcmn.cpp:61
 msgid "Left"
 msgstr "Gauche"
 
-#: ../src/richtext/richtextindentspage.cpp:204
 #: ../src/richtext/richtextliststylepage.cpp:390
+#: ../src/richtext/richtextindentspage.cpp:204
 msgid "Left (&first line):"
 msgstr "Gauche (&Première ligne):"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1761
+#: ../src/propgrid/advprops.cpp:1662
 msgid "Left Button"
 msgstr "Bouton gauche"
 
-#: ../src/generic/prntdlgg.cpp:880
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Left margin (mm):"
 msgstr "Marge gauche (mm) :"
 
-#: ../src/richtext/richtextindentspage.cpp:141
-#: ../src/richtext/richtextindentspage.cpp:143
 #: ../src/richtext/richtextliststylepage.cpp:330
 #: ../src/richtext/richtextliststylepage.cpp:332
+#: ../src/richtext/richtextindentspage.cpp:141
+#: ../src/richtext/richtextindentspage.cpp:143
 msgid "Left-align text."
 msgstr "Aligne le texte à gauche."
 
-#: ../src/common/paper.cpp:144
+#: ../src/common/paper.cpp:141
 msgid "Legal Extra 9 1/2 x 15 in"
 msgstr "Légal Extra 9,5 x 15 pouces"
 
-#: ../src/common/paper.cpp:96
+#: ../src/common/paper.cpp:93
 msgid "Legal, 8 1/2 x 14 in"
 msgstr "Légal (8,5 x 14 pouces)"
 
-#: ../src/common/paper.cpp:143
+#: ../src/common/paper.cpp:140
 msgid "Letter Extra 9 1/2 x 12 in"
 msgstr "Lettre Extra 9.5 x 12 pouces"
 
-#: ../src/common/paper.cpp:149
+#: ../src/common/paper.cpp:146
 msgid "Letter Extra Transverse 9.275 x 12 in"
 msgstr "Lettre Extra Portrait 9.275 x 12 pouces"
 
-#: ../src/common/paper.cpp:152
+#: ../src/common/paper.cpp:149
 msgid "Letter Plus 8 1/2 x 12.69 in"
 msgstr "Lettre Plus 8,5 x 11.69 pouces"
 
-#: ../src/common/paper.cpp:169
+#: ../src/common/paper.cpp:166
 msgid "Letter Rotated 11 x 8 1/2 in"
 msgstr "Lettre paysage 11 x 8.5 pouces"
 
-#: ../src/common/paper.cpp:101
+#: ../src/common/paper.cpp:98
 msgid "Letter Small, 8 1/2 x 11 in"
 msgstr "Lettre réduite (8,5 x 11 pouces)"
 
-#: ../src/common/paper.cpp:147
+#: ../src/common/paper.cpp:144
 msgid "Letter Transverse 8 1/2 x 11 in"
 msgstr "Lettre 8,5 x 11 pouces"
 
-#: ../src/common/paper.cpp:95
+#: ../src/common/paper.cpp:92
 msgid "Letter, 8 1/2 x 11 in"
 msgstr "Lettre (8,5 x 11 pouces)"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "License"
 msgstr "Licence"
 
-#: ../src/generic/fontdlgg.cpp:332
+#: ../src/generic/fontdlgg.cpp:328
 msgid "Light"
 msgstr "Léger"
 
-#: ../src/propgrid/advprops.cpp:1608
+#: ../src/propgrid/advprops.cpp:1514
 msgid "Lime"
 msgstr "Citron"
 
-#: ../src/generic/helpext.cpp:294
+#: ../src/generic/helpext.cpp:292
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr ""
@@ -4677,15 +4808,15 @@ msgstr ""
 msgid "Line spacing:"
 msgstr "Espacement interligne:"
 
-#: ../src/html/chm.cpp:838
+#: ../src/html/chm.cpp:829
 msgid "Link contained '//', converted to absolute link."
 msgstr "Le lien contenait « // » et a été converti en lien absolu."
 
-#: ../src/richtext/richtextformatdlg.cpp:364
+#: ../src/richtext/richtextformatdlg.cpp:357
 msgid "List Style"
 msgstr "Style de liste"
 
-#: ../src/richtext/richtextstyles.cpp:1064
+#: ../src/richtext/richtextstyles.cpp:1061
 msgid "List styles"
 msgstr "Styles de liste"
 
@@ -4699,26 +4830,26 @@ msgstr "Liste des tailles de polices en points."
 msgid "Lists the available fonts."
 msgstr "Liste des polices de caractères disponibles."
 
-#: ../src/common/fldlgcmn.cpp:340
+#: ../src/common/fldlgcmn.cpp:337
 #, c-format
 msgid "Load %s file"
 msgstr "Charger le fichier %s"
 
-#: ../src/html/htmlwin.cpp:597
+#: ../src/html/htmlwin.cpp:600
 msgid "Loading : "
 msgstr "Chargement : "
 
-#: ../src/unix/snglinst.cpp:246
+#: ../src/unix/snglinst.cpp:243
 #, c-format
 msgid "Lock file '%s' has incorrect owner."
 msgstr "Le fichier verrou « %s » a un propriétaire incorrect."
 
-#: ../src/unix/snglinst.cpp:251
+#: ../src/unix/snglinst.cpp:248
 #, c-format
 msgid "Lock file '%s' has incorrect permissions."
 msgstr "Le fichier verrou « %s » a des permissions incorrectes."
 
-#: ../src/generic/logg.cpp:576
+#: ../src/generic/logg.cpp:573
 #, c-format
 msgid "Log saved to the file '%s'."
 msgstr "Journal sauvé dans le fichier « %s »."
@@ -4733,11 +4864,11 @@ msgstr "Lettres minuscules"
 msgid "Lower case roman numerals"
 msgstr "Chiffres romains minuscules"
 
-#: ../src/gtk/mdi.cpp:422 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk1/mdi.cpp:431 ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "Fils MDI"
 
-#: ../src/msw/helpchm.cpp:56
+#: ../src/msw/helpchm.cpp:53
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -4745,189 +4876,189 @@ msgstr ""
 "Les fonctions de l'aide MS HTML ne sont pas disponibles car la bibliothèque "
 "MS HTML Help n'est pas présente sur cette machine. Il faut l'installer."
 
-#: ../src/univ/themes/win32.cpp:3754
+#: ../src/univ/themes/win32.cpp:3751
 msgid "Ma&ximize"
 msgstr "Ma&ximiser"
 
-#: ../src/common/fmapbase.cpp:203
+#: ../src/common/fmapbase.cpp:200
 msgid "MacArabic"
 msgstr "MacArabe"
 
-#: ../src/common/fmapbase.cpp:222
+#: ../src/common/fmapbase.cpp:219
 msgid "MacArmenian"
 msgstr "MacArménien"
 
-#: ../src/common/fmapbase.cpp:211
+#: ../src/common/fmapbase.cpp:208
 msgid "MacBengali"
 msgstr "MacBengali"
 
-#: ../src/common/fmapbase.cpp:217
+#: ../src/common/fmapbase.cpp:214
 msgid "MacBurmese"
 msgstr "MacBirman"
 
-#: ../src/common/fmapbase.cpp:236
+#: ../src/common/fmapbase.cpp:233
 msgid "MacCeltic"
 msgstr "MacCelte"
 
-#: ../src/common/fmapbase.cpp:227
+#: ../src/common/fmapbase.cpp:224
 msgid "MacCentralEurRoman"
 msgstr "MacRomanEuropeCentrale"
 
-#: ../src/common/fmapbase.cpp:223
+#: ../src/common/fmapbase.cpp:220
 msgid "MacChineseSimp"
 msgstr "MacChinoisSimp"
 
-#: ../src/common/fmapbase.cpp:201
+#: ../src/common/fmapbase.cpp:198
 msgid "MacChineseTrad"
 msgstr "MacChinoisTrad"
 
-#: ../src/common/fmapbase.cpp:233
+#: ../src/common/fmapbase.cpp:230
 msgid "MacCroatian"
 msgstr "MacCroate"
 
-#: ../src/common/fmapbase.cpp:206
+#: ../src/common/fmapbase.cpp:203
 msgid "MacCyrillic"
 msgstr "MacCyrillique"
 
-#: ../src/common/fmapbase.cpp:207
+#: ../src/common/fmapbase.cpp:204
 msgid "MacDevanagari"
 msgstr "MacDevanagari"
 
-#: ../src/common/fmapbase.cpp:231
+#: ../src/common/fmapbase.cpp:228
 msgid "MacDingbats"
 msgstr "MacDingbats"
 
-#: ../src/common/fmapbase.cpp:226
+#: ../src/common/fmapbase.cpp:223
 msgid "MacEthiopic"
 msgstr "MacÉthiopien"
 
-#: ../src/common/fmapbase.cpp:229
+#: ../src/common/fmapbase.cpp:226
 msgid "MacExtArabic"
 msgstr "MacArabeÉtendu"
 
-#: ../src/common/fmapbase.cpp:237
+#: ../src/common/fmapbase.cpp:234
 msgid "MacGaelic"
 msgstr "MacGaélic"
 
-#: ../src/common/fmapbase.cpp:221
+#: ../src/common/fmapbase.cpp:218
 msgid "MacGeorgian"
 msgstr "MacGéorgien"
 
-#: ../src/common/fmapbase.cpp:205
+#: ../src/common/fmapbase.cpp:202
 msgid "MacGreek"
 msgstr "MacGrec"
 
-#: ../src/common/fmapbase.cpp:209
+#: ../src/common/fmapbase.cpp:206
 msgid "MacGujarati"
 msgstr "MacGujarati"
 
-#: ../src/common/fmapbase.cpp:208
+#: ../src/common/fmapbase.cpp:205
 msgid "MacGurmukhi"
 msgstr "MacGurmukhi"
 
-#: ../src/common/fmapbase.cpp:204
+#: ../src/common/fmapbase.cpp:201
 msgid "MacHebrew"
 msgstr "MacHébreu"
 
-#: ../src/common/fmapbase.cpp:234
+#: ../src/common/fmapbase.cpp:231
 msgid "MacIcelandic"
 msgstr "MacIslandais"
 
-#: ../src/common/fmapbase.cpp:200
+#: ../src/common/fmapbase.cpp:197
 msgid "MacJapanese"
 msgstr "MacJaponais"
 
-#: ../src/common/fmapbase.cpp:214
+#: ../src/common/fmapbase.cpp:211
 msgid "MacKannada"
 msgstr "MacKannada"
 
-#: ../src/common/fmapbase.cpp:238
+#: ../src/common/fmapbase.cpp:235
 msgid "MacKeyboardGlyphs"
 msgstr "MacKeyboardGlyphs"
 
-#: ../src/common/fmapbase.cpp:218
+#: ../src/common/fmapbase.cpp:215
 msgid "MacKhmer"
 msgstr "MacKhmer"
 
-#: ../src/common/fmapbase.cpp:202
+#: ../src/common/fmapbase.cpp:199
 msgid "MacKorean"
 msgstr "MacCoréen"
 
-#: ../src/common/fmapbase.cpp:220
+#: ../src/common/fmapbase.cpp:217
 msgid "MacLaotian"
 msgstr "MacLaotien"
 
-#: ../src/common/fmapbase.cpp:215
+#: ../src/common/fmapbase.cpp:212
 msgid "MacMalayalam"
 msgstr "MacMalayalam"
 
-#: ../src/common/fmapbase.cpp:225
+#: ../src/common/fmapbase.cpp:222
 msgid "MacMongolian"
 msgstr "MacMongol"
 
-#: ../src/common/fmapbase.cpp:210
+#: ../src/common/fmapbase.cpp:207
 msgid "MacOriya"
 msgstr "MacOriya"
 
-#: ../src/common/fmapbase.cpp:199
+#: ../src/common/fmapbase.cpp:196
 msgid "MacRoman"
 msgstr "MacRoman"
 
-#: ../src/common/fmapbase.cpp:235
+#: ../src/common/fmapbase.cpp:232
 msgid "MacRomanian"
 msgstr "MacRoumain"
 
-#: ../src/common/fmapbase.cpp:216
+#: ../src/common/fmapbase.cpp:213
 msgid "MacSinhalese"
 msgstr "MacCingalais"
 
-#: ../src/common/fmapbase.cpp:230
+#: ../src/common/fmapbase.cpp:227
 msgid "MacSymbol"
 msgstr "MacSymbole"
 
-#: ../src/common/fmapbase.cpp:212
+#: ../src/common/fmapbase.cpp:209
 msgid "MacTamil"
 msgstr "MacTamoul"
 
-#: ../src/common/fmapbase.cpp:213
+#: ../src/common/fmapbase.cpp:210
 msgid "MacTelugu"
 msgstr "MacTelugu"
 
-#: ../src/common/fmapbase.cpp:219
+#: ../src/common/fmapbase.cpp:216
 msgid "MacThai"
 msgstr "MacThaï"
 
-#: ../src/common/fmapbase.cpp:224
+#: ../src/common/fmapbase.cpp:221
 msgid "MacTibetan"
 msgstr "MacTibétain"
 
-#: ../src/common/fmapbase.cpp:232
+#: ../src/common/fmapbase.cpp:229
 msgid "MacTurkish"
 msgstr "MacTurque"
 
-#: ../src/common/fmapbase.cpp:228
+#: ../src/common/fmapbase.cpp:225
 msgid "MacVietnamese"
 msgstr "MacVietnamien"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1762
+#: ../src/propgrid/advprops.cpp:1663
 msgid "Magnifier"
 msgstr "Loupe"
 
-#: ../src/propgrid/advprops.cpp:2143
+#: ../src/propgrid/advprops.cpp:2050
 msgid "Make a selection:"
 msgstr "Créer une sélection :"
 
-#: ../src/richtext/richtextformatdlg.cpp:374
+#: ../src/richtext/richtextformatdlg.cpp:367
 #: ../src/richtext/richtextmarginspage.cpp:171
 msgid "Margins"
 msgstr "Marges"
 
-#: ../src/propgrid/advprops.cpp:1595
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Maroon"
 msgstr "Marron"
 
-#: ../src/generic/fdrepdlg.cpp:147
+#: ../src/generic/fdrepdlg.cpp:144
 msgid "Match case"
 msgstr "Respecter la casse"
 
@@ -4939,40 +5070,40 @@ msgstr "Hauteur max. :"
 msgid "Max width:"
 msgstr "Largeur max. :"
 
-#: ../src/unix/mediactrl.cpp:947
+#: ../src/unix/mediactrl.cpp:972
 #, c-format
 msgid "Media playback error: %s"
 msgstr "Erreur du lecteur de média : %s"
 
-#: ../src/common/fs_mem.cpp:175
+#: ../src/common/fs_mem.cpp:170
 #, c-format
 msgid "Memory VFS already contains file '%s'!"
 msgstr "La mémoire VFS contient déjà le fichier « %s » !"
 
 #. TRANSLATORS: Name of keyboard key
 #. TRANSLATORS: Keyword of system colour
-#: ../src/common/accelcmn.cpp:73 ../src/propgrid/advprops.cpp:889
+#: ../src/common/accelcmn.cpp:70 ../src/propgrid/advprops.cpp:790
 msgid "Menu"
 msgstr "Menu"
 
-#: ../src/common/msgout.cpp:124
+#: ../src/common/msgout.cpp:121
 msgid "Message"
 msgstr "Message"
 
-#: ../src/univ/themes/metal.cpp:168
+#: ../src/univ/themes/metal.cpp:165
 msgid "Metal theme"
 msgstr "Thème métallique"
 
-#: ../src/msw/ole/automtn.cpp:652
+#: ../src/msw/ole/automtn.cpp:643
 msgid "Method or property not found."
 msgstr "Méthode ou propriété non trouvée."
 
-#: ../src/univ/themes/win32.cpp:3752
+#: ../src/univ/themes/win32.cpp:3749
 msgid "Mi&nimize"
 msgstr "Mi&nimiser"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1763
+#: ../src/propgrid/advprops.cpp:1664
 msgid "Middle Button"
 msgstr "Bouton du milieu"
 
@@ -4984,38 +5115,43 @@ msgstr "Hauteur min. :"
 msgid "Min width:"
 msgstr "Largeur min. :"
 
-#: ../src/msw/ole/automtn.cpp:668
+#: ../src/osx/cocoa/menu.mm:281
+#, fuzzy
+msgid "Minimize"
+msgstr "Mi&nimiser"
+
+#: ../src/msw/ole/automtn.cpp:659
 msgid "Missing a required parameter."
 msgstr "Un paramètre requis est manquant."
 
-#: ../src/generic/fontdlgg.cpp:324
+#: ../src/generic/fontdlgg.cpp:320
 msgid "Modern"
 msgstr "Moderne"
 
-#: ../src/generic/filectrlg.cpp:427
+#: ../src/generic/filectrlg.cpp:423
 msgid "Modified"
 msgstr "Modifié"
 
-#: ../src/common/module.cpp:133
+#: ../src/common/module.cpp:130
 #, c-format
 msgid "Module \"%s\" initialization failed"
 msgstr "L'initialisation du module « %s » a échoué"
 
-#: ../src/common/paper.cpp:131
+#: ../src/common/paper.cpp:128
 msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
 msgstr "Enveloppe monarchique (3,875 x 7,5 pouces)"
 
-#: ../src/msw/fswatcher.cpp:143
+#: ../src/msw/fswatcher.cpp:140
 msgid "Monitoring individual files for changes is not supported currently."
 msgstr ""
 "La surveillance des modifications de fichiers individuels n'est actuellement "
 "pas supporté."
 
-#: ../src/generic/editlbox.cpp:172
+#: ../src/generic/editlbox.cpp:160
 msgid "Move down"
 msgstr "Descendre"
 
-#: ../src/generic/editlbox.cpp:171
+#: ../src/generic/editlbox.cpp:155
 msgid "Move up"
 msgstr "Monter"
 
@@ -5029,97 +5165,103 @@ msgstr "Déplacer l'objet vers le paragraphe suivant."
 msgid "Moves the object to the previous paragraph."
 msgstr "Déplacer l'objet vers le paragraphe précédent."
 
-#: ../src/richtext/richtextbuffer.cpp:9966
+#: ../src/richtext/richtextbuffer.cpp:9963
 msgid "Multiple Cell Properties"
 msgstr "Propriétés de Plusieurs Cellules"
 
-#: ../src/generic/filectrlg.cpp:424
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:82
+#, fuzzy
+msgid "Multiply"
+msgstr "KP_Multiply"
+
+#: ../src/generic/filectrlg.cpp:420
 msgid "Name"
 msgstr "Nom"
 
-#: ../src/propgrid/advprops.cpp:1596
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Navy"
 msgstr "Bleu marine"
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "Network"
 msgstr "Réseau"
 
-#: ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173
 msgid "New"
 msgstr "Nouveau"
 
-#: ../src/richtext/richtextstyledlg.cpp:243
+#: ../src/richtext/richtextstyledlg.cpp:239
 msgid "New &Box Style..."
 msgstr "Nouveau Style de &Boîte..."
 
-#: ../src/richtext/richtextstyledlg.cpp:225
+#: ../src/richtext/richtextstyledlg.cpp:221
 msgid "New &Character Style..."
 msgstr "Nouveau Style de &Caractères..."
 
-#: ../src/richtext/richtextstyledlg.cpp:237
+#: ../src/richtext/richtextstyledlg.cpp:233
 msgid "New &List Style..."
 msgstr "Nouveau Style de &Liste..."
 
-#: ../src/richtext/richtextstyledlg.cpp:231
+#: ../src/richtext/richtextstyledlg.cpp:227
 msgid "New &Paragraph Style..."
 msgstr "Nouveau Style de &Paragraphe..."
 
-#: ../src/richtext/richtextstyledlg.cpp:606
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:654
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:820
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:893
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:934
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:602
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:650
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:816
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:889
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:930
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "New Style"
 msgstr "Nouveau style"
 
-#: ../src/generic/editlbox.cpp:169
+#: ../src/generic/editlbox.cpp:139
 msgid "New item"
 msgstr "Nouvel élément"
 
-#: ../src/generic/dirdlgg.cpp:297 ../src/generic/dirdlgg.cpp:307
-#: ../src/generic/filectrlg.cpp:618 ../src/generic/filectrlg.cpp:627
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+#: ../src/generic/dirdlgg.cpp:294 ../src/generic/dirdlgg.cpp:304
 msgid "NewName"
 msgstr "NouveauNom"
 
-#: ../src/common/prntbase.cpp:1567 ../src/html/helpwnd.cpp:665
+#: ../src/common/prntbase.cpp:1592 ../src/html/helpwnd.cpp:663
 msgid "Next page"
 msgstr "Page suivante"
 
-#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:177
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:174
 #: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Non"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1764
+#: ../src/propgrid/advprops.cpp:1665
 msgid "No Entry"
 msgstr "Pas d'entrée"
 
-#: ../src/generic/animateg.cpp:150
+#: ../src/generic/animateg.cpp:133
 #, c-format
 msgid "No animation handler for type %ld defined."
 msgstr "Aucun gestionnaire d'animation n'est défini pour le type %ld."
 
-#: ../src/dfb/bitmap.cpp:642 ../src/dfb/bitmap.cpp:676
+#: ../src/dfb/bitmap.cpp:639 ../src/dfb/bitmap.cpp:673
 #, c-format
 msgid "No bitmap handler for type %d defined."
 msgstr "Aucun gestionnaire d'image défini pour le type %d."
 
-#: ../src/common/utilscmn.cpp:1077
+#: ../src/common/utilscmn.cpp:1095
 msgid "No default application configured for HTML files."
 msgstr "Pas d'application configurée pour les fichiers HTML."
 
-#: ../src/generic/helpext.cpp:445
+#: ../src/generic/helpext.cpp:443
 msgid "No entries found."
 msgstr "Aucune entrée trouvée."
 
-#: ../src/common/fontmap.cpp:421
+#: ../src/common/fontmap.cpp:418
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found,\n"
@@ -5131,7 +5273,7 @@ msgstr ""
 "mais le codage similaire « %s » est disponible.\n"
 "Faut-il l'utiliser (sinon, en choisir un autre) ?"
 
-#: ../src/common/fontmap.cpp:426
+#: ../src/common/fontmap.cpp:423
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found.\n"
@@ -5142,203 +5284,203 @@ msgstr ""
 "Faut-il choisir une police à utiliser pour ce codage\n"
 "(sinon le texte avec ce codage n'apparaîtra pas correctement) ?"
 
-#: ../src/generic/animateg.cpp:142
+#: ../src/generic/animateg.cpp:125
 msgid "No handler found for animation type."
 msgstr "Aucun gestionnaire trouvé pour le type d'animation."
 
-#: ../src/common/image.cpp:2728
+#: ../src/common/image.cpp:2823
 msgid "No handler found for image type."
 msgstr "Aucun gestionnaire trouvé pour le type d'image."
 
-#: ../src/common/image.cpp:2736 ../src/common/image.cpp:2848
-#: ../src/common/image.cpp:2901
+#: ../src/common/image.cpp:2831 ../src/common/image.cpp:2954
+#: ../src/common/image.cpp:3020
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "Aucun gestionnaire d'image défini pour le type %d."
 
-#: ../src/common/image.cpp:2871 ../src/common/image.cpp:2915
+#: ../src/common/image.cpp:2986 ../src/common/image.cpp:3034
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "Aucun gestionnaire d'image défini pour le type %s."
 
-#: ../src/html/helpwnd.cpp:858
+#: ../src/html/helpwnd.cpp:856
 msgid "No matching page found yet"
 msgstr "Aucune page correspondante n'a encore été trouvée"
 
-#: ../src/unix/sound.cpp:81
+#: ../src/unix/sound.cpp:78
 msgid "No sound"
 msgstr "Pas de son"
 
-#: ../src/common/image.cpp:2277 ../src/common/image.cpp:2318
+#: ../src/common/image.cpp:2371 ../src/common/image.cpp:2412
 msgid "No unused colour in image being masked."
 msgstr "Aucune couleur n'est disponible dans l'image en cours de masquage."
 
-#: ../src/common/image.cpp:3374
-msgid "No unused colour in image."
-msgstr "Aucune couleur n'est disponible dans l'image."
-
-#: ../src/generic/helpext.cpp:302
+#: ../src/generic/helpext.cpp:300
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr ""
 "Aucune table de correspondance valablee n'a été trouvée dans le fichier « %s "
 "»."
 
-#: ../src/richtext/richtextborderspage.cpp:610
 #: ../src/richtext/richtextsizepage.cpp:248
 #: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:610
 msgid "None"
 msgstr "Aucun"
 
-#: ../src/common/fmapbase.cpp:157
+#: ../src/common/fmapbase.cpp:154
 msgid "Nordic (ISO-8859-10)"
 msgstr "Nordique (ISO-8859-10)"
 
-#: ../src/generic/fontdlgg.cpp:328 ../src/generic/fontdlgg.cpp:331
+#: ../src/generic/fontdlgg.cpp:324 ../src/generic/fontdlgg.cpp:327
 msgid "Normal"
 msgstr "Normal"
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1261
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Normal<br>et <u>souligné</u>. "
 
-#: ../src/html/helpwnd.cpp:1205
+#: ../src/html/helpwnd.cpp:1203
 msgid "Normal font:"
 msgstr "Police normale :"
 
-#: ../src/propgrid/props.cpp:1128
+#: ../src/propgrid/props.cpp:1115
 #, c-format
 msgid "Not %s"
 msgstr "Pas %s"
 
-#: ../include/wx/filename.h:573 ../include/wx/filename.h:578
-msgid "Not available"
-msgstr "Non disponible"
+#: ../src/common/secretstore.cpp:168
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/webrequest.cpp:605
+msgid "Not enough free disk space for download."
+msgstr ""
 
 #: ../src/richtext/richtextfontpage.cpp:358
 msgid "Not underlined"
 msgstr "Non souligné"
 
-#: ../src/common/paper.cpp:115
+#: ../src/common/paper.cpp:112
 msgid "Note, 8 1/2 x 11 in"
 msgstr "Note (8,5 x 11 pouces)"
 
-#: ../src/generic/notifmsgg.cpp:132
+#: ../src/generic/notifmsgg.cpp:129
 msgid "Notice"
 msgstr "Note"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "Num *"
 msgstr "Num *"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "Num +"
 msgstr "Num +"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "Num ,"
 msgstr "Num ,"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "Num -"
 msgstr "Num -"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "Num ."
 msgstr "Num ."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "Num /"
 msgstr "Num /"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "Num ="
 msgstr "Num ="
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "Num Begin"
 msgstr "Num Début"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 msgid "Num Delete"
 msgstr "Num Suppr"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 msgid "Num Down"
 msgstr "Num Bas"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "Num End"
 msgstr "Num Fin"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "Num Enter"
 msgstr "Num Entrée"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 msgid "Num Home"
 msgstr "Num Début"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 msgid "Num Insert"
 msgstr "Num Inser"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num Lock"
 msgstr "Verr Num"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "Num Page Down"
 msgstr "Num Page Suiv"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "Num Page Up"
 msgstr "Num Page Préc"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 msgid "Num Right"
 msgstr "Num Droite"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "Num Space"
 msgstr "Num Espace"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "Num Tab"
 msgstr "Num Tab"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "Num Up"
 msgstr "Num Préc"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "Num left"
 msgstr "Num Gauche"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num_lock"
 msgstr "Verr_num"
 
@@ -5347,13 +5489,13 @@ msgstr "Verr_num"
 msgid "Numbered outline"
 msgstr "Table des matières numérotée"
 
-#: ../include/wx/msgdlg.h:278 ../src/richtext/richtextstyledlg.cpp:297
-#: ../src/common/stockitem.cpp:178 ../src/msw/msgdlg.cpp:454
-#: ../src/msw/msgdlg.cpp:747 ../src/gtk1/fontdlg.cpp:138
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:175
+#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/msgdlg.cpp:741 ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "Ok"
 
-#: ../src/msw/ole/automtn.cpp:692
+#: ../src/msw/ole/automtn.cpp:683
 #, c-format
 msgid "OLE Automation error in %s: %s"
 msgstr "Erreur OLE Automation dans %s : %s"
@@ -5362,15 +5504,15 @@ msgstr "Erreur OLE Automation dans %s : %s"
 msgid "Object Properties"
 msgstr "Propriétés de l'Objet"
 
-#: ../src/msw/ole/automtn.cpp:660
+#: ../src/msw/ole/automtn.cpp:651
 msgid "Object implementation does not support named arguments."
 msgstr "L'implémentation de l'objet ne supporte pas les arguments nommés."
 
-#: ../src/common/xtixml.cpp:264
+#: ../src/common/xtixml.cpp:260
 msgid "Objects must have an id attribute"
 msgstr "Les objets doivent avoir un attribut id"
 
-#: ../src/propgrid/advprops.cpp:1601
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Olive"
 msgstr "Olive"
 
@@ -5378,64 +5520,69 @@ msgstr "Olive"
 msgid "Opaci&ty:"
 msgstr "Opaci&té :"
 
-#: ../src/generic/colrdlgg.cpp:354
+#: ../src/generic/colrdlgg.cpp:374
 msgid "Opacity:"
 msgstr "Opacité :"
 
-#: ../src/common/docview.cpp:1773 ../src/common/docview.cpp:1815
+#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
 msgid "Open File"
 msgstr "Ouvrir un Fichier"
 
-#: ../src/html/helpwnd.cpp:671 ../src/html/helpwnd.cpp:1554
+#: ../src/html/helpwnd.cpp:669 ../src/html/helpwnd.cpp:1552
 msgid "Open HTML document"
 msgstr "Ouvrir un document HTML"
 
-#: ../src/generic/dbgrptg.cpp:163
+#: ../src/common/stockitem.cpp:265
+#, fuzzy
+msgid "Open an existing document"
+msgstr "Ouvrir un document HTML"
+
+#: ../src/generic/dbgrptg.cpp:160
 #, c-format
 msgid "Open file \"%s\""
 msgstr "Ouvrir le fichier « %s »"
 
-#: ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176
 msgid "Open..."
 msgstr "Ouvrir..."
 
-#: ../src/unix/glx11.cpp:506 ../src/msw/glcanvas.cpp:592
+#: ../src/msw/glcanvas.cpp:607 ../src/unix/glx11.cpp:513
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr "OpenGL 3.0 et au-dessus n'est pas reconnu par le pilote OpenGL."
 
-#: ../src/generic/dirctrlg.cpp:599 ../src/generic/dirdlgg.cpp:323
-#: ../src/generic/filectrlg.cpp:642 ../src/generic/filectrlg.cpp:786
+#: ../src/generic/dirctrlg.cpp:565 ../src/generic/filectrlg.cpp:638
+#: ../src/generic/filectrlg.cpp:782 ../src/generic/dirdlgg.cpp:320
 msgid "Operation not permitted."
 msgstr "Opération interdite."
 
-#: ../src/common/cmdline.cpp:900
+#: ../src/common/cmdline.cpp:896
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "L'option « %s » ne peut pas être inversée"
 
-#: ../src/common/cmdline.cpp:1064
+#: ../src/common/cmdline.cpp:1060
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "L'option « %s » nécessite une valeur."
 
-#: ../src/common/cmdline.cpp:1147
+#: ../src/common/cmdline.cpp:1143
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Option « %s » : « %s » ne peut pas être converti en date."
 
-#: ../src/generic/prntdlgg.cpp:618
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Options"
 
-#: ../src/propgrid/advprops.cpp:1606
+#: ../src/propgrid/advprops.cpp:1512
 msgid "Orange"
 msgstr "Orange"
 
-#: ../src/generic/prntdlgg.cpp:615 ../src/generic/prntdlgg.cpp:869
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:862
 msgid "Orientation"
 msgstr "Orientation"
 
-#: ../src/common/windowid.cpp:242
+#: ../src/common/windowid.cpp:237
 msgid "Out of window IDs.  Recommend shutting down application."
 msgstr "Plus d'IDs de fenêtre. Il est recommandé de fermer l'application."
 
@@ -5448,148 +5595,148 @@ msgstr "Contour"
 msgid "Outset"
 msgstr "Extérieur"
 
-#: ../src/msw/ole/automtn.cpp:656
+#: ../src/msw/ole/automtn.cpp:647
 msgid "Overflow while coercing argument values."
 msgstr "Dépassement lors de la contrainte des valeurs d'arguments."
 
-#: ../src/common/imagpcx.cpp:457 ../src/common/imagpcx.cpp:480
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:479
 msgid "PCX: couldn't allocate memory"
 msgstr "PCX : impossible d'allouer de la mémoire"
 
-#: ../src/common/imagpcx.cpp:456
+#: ../src/common/imagpcx.cpp:455
 msgid "PCX: image format unsupported"
 msgstr "PCX : format d'image non reconnu"
 
-#: ../src/common/imagpcx.cpp:479
+#: ../src/common/imagpcx.cpp:478
 msgid "PCX: invalid image"
 msgstr "PCX : image non valable"
 
-#: ../src/common/imagpcx.cpp:442
+#: ../src/common/imagpcx.cpp:441
 msgid "PCX: this is not a PCX file."
 msgstr "PCX : ce n'est pas un fichier PCX."
 
-#: ../src/common/imagpcx.cpp:459 ../src/common/imagpcx.cpp:481
+#: ../src/common/imagpcx.cpp:458 ../src/common/imagpcx.cpp:480
 msgid "PCX: unknown error !!!"
 msgstr "PCX : erreur inconnue !!!"
 
-#: ../src/common/imagpcx.cpp:458
+#: ../src/common/imagpcx.cpp:457
 msgid "PCX: version number too low"
 msgstr "PCX : numéro de version trop petit"
 
-#: ../src/common/imagpnm.cpp:91
+#: ../src/common/imagpnm.cpp:89
 msgid "PNM: Couldn't allocate memory."
 msgstr "PNM : impossible d'allouer de la mémoire."
 
-#: ../src/common/imagpnm.cpp:73
+#: ../src/common/imagpnm.cpp:71
 msgid "PNM: File format is not recognized."
 msgstr "PNM : le format de fichier n'est pas reconnu."
 
-#: ../src/common/imagpnm.cpp:112 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
 #: ../src/common/imagpnm.cpp:156
 msgid "PNM: File seems truncated."
 msgstr "PNM : le fichier semble tronqué."
 
-#: ../src/common/paper.cpp:187
+#: ../src/common/paper.cpp:184
 msgid "PRC 16K 146 x 215 mm"
 msgstr "PRC 16K 146 x 215 mm"
 
-#: ../src/common/paper.cpp:200
+#: ../src/common/paper.cpp:197
 msgid "PRC 16K Rotated"
 msgstr "PRC 16K Paysage"
 
-#: ../src/common/paper.cpp:188
+#: ../src/common/paper.cpp:185
 msgid "PRC 32K 97 x 151 mm"
 msgstr "PRC 32K 97 x 151 mm"
 
-#: ../src/common/paper.cpp:201
+#: ../src/common/paper.cpp:198
 msgid "PRC 32K Rotated"
 msgstr "PRC 32K Paysage"
 
-#: ../src/common/paper.cpp:189
+#: ../src/common/paper.cpp:186
 msgid "PRC 32K(Big) 97 x 151 mm"
 msgstr "Format PRC 32K (Large), 97 x 151 mm"
 
-#: ../src/common/paper.cpp:202
+#: ../src/common/paper.cpp:199
 msgid "PRC 32K(Big) Rotated"
 msgstr "Format PRC 32K (Large), Paysage"
 
-#: ../src/common/paper.cpp:190
+#: ../src/common/paper.cpp:187
 msgid "PRC Envelope #1 102 x 165 mm"
 msgstr "Enveloppe PRC n. 1, 102 x 165 mm"
 
-#: ../src/common/paper.cpp:203
+#: ../src/common/paper.cpp:200
 msgid "PRC Envelope #1 Rotated 165 x 102 mm"
 msgstr "Enveloppe PRC n. 1, Paysage, 165 x 102 mm"
 
-#: ../src/common/paper.cpp:199
+#: ../src/common/paper.cpp:196
 msgid "PRC Envelope #10 324 x 458 mm"
 msgstr "Enveloppe PRC n. 10, 324 x 458 mm"
 
-#: ../src/common/paper.cpp:212
+#: ../src/common/paper.cpp:209
 msgid "PRC Envelope #10 Rotated 458 x 324 mm"
 msgstr "Enveloppe PRC n. 10, Paysage, 458 x 324 mm"
 
-#: ../src/common/paper.cpp:191
+#: ../src/common/paper.cpp:188
 msgid "PRC Envelope #2 102 x 176 mm"
 msgstr "Enveloppe PRC n. 2, 102 x 176 mm"
 
-#: ../src/common/paper.cpp:204
+#: ../src/common/paper.cpp:201
 msgid "PRC Envelope #2 Rotated 176 x 102 mm"
 msgstr "Enveloppe PRC n. 2, Paysage, 176 x 102 mm"
 
-#: ../src/common/paper.cpp:192
+#: ../src/common/paper.cpp:189
 msgid "PRC Envelope #3 125 x 176 mm"
 msgstr "Enveloppe PRC n. 3, 125 x 176 mm"
 
-#: ../src/common/paper.cpp:205
+#: ../src/common/paper.cpp:202
 msgid "PRC Envelope #3 Rotated 176 x 125 mm"
 msgstr "Enveloppe PRC n. 3, Paysage, 176 x 125 mm"
 
-#: ../src/common/paper.cpp:193
+#: ../src/common/paper.cpp:190
 msgid "PRC Envelope #4 110 x 208 mm"
 msgstr "Enveloppe PRC n. 4, 110 x 208 mm"
 
-#: ../src/common/paper.cpp:206
+#: ../src/common/paper.cpp:203
 msgid "PRC Envelope #4 Rotated 208 x 110 mm"
 msgstr "Enveloppe PRC n. 4, Paysage, 208 x 110 mm"
 
-#: ../src/common/paper.cpp:194
+#: ../src/common/paper.cpp:191
 msgid "PRC Envelope #5 110 x 220 mm"
 msgstr "Enveloppe PRC n. 5, 110 x 220 mm"
 
-#: ../src/common/paper.cpp:207
+#: ../src/common/paper.cpp:204
 msgid "PRC Envelope #5 Rotated 220 x 110 mm"
 msgstr "Enveloppe PRC n. 5, Paysage, 220 x 110 mm"
 
-#: ../src/common/paper.cpp:195
+#: ../src/common/paper.cpp:192
 msgid "PRC Envelope #6 120 x 230 mm"
 msgstr "Enveloppe PRC n. 6, 120 x 230 mm"
 
-#: ../src/common/paper.cpp:208
+#: ../src/common/paper.cpp:205
 msgid "PRC Envelope #6 Rotated 230 x 120 mm"
 msgstr "Enveloppe PRC n. 6, Paysage, 230 x 120 mm"
 
-#: ../src/common/paper.cpp:196
+#: ../src/common/paper.cpp:193
 msgid "PRC Envelope #7 160 x 230 mm"
 msgstr "Enveloppe PRC n. 7, 160 x 230 mm"
 
-#: ../src/common/paper.cpp:209
+#: ../src/common/paper.cpp:206
 msgid "PRC Envelope #7 Rotated 230 x 160 mm"
 msgstr "Enveloppe PRC n. 7, Paysage, 230 x 160 mm"
 
-#: ../src/common/paper.cpp:197
+#: ../src/common/paper.cpp:194
 msgid "PRC Envelope #8 120 x 309 mm"
 msgstr "Enveloppe PRC n. 8, 120 x 309 mm"
 
-#: ../src/common/paper.cpp:210
+#: ../src/common/paper.cpp:207
 msgid "PRC Envelope #8 Rotated 309 x 120 mm"
 msgstr "Enveloppe PRC n. 8, Paysage, 309 x 120 mm"
 
-#: ../src/common/paper.cpp:198
+#: ../src/common/paper.cpp:195
 msgid "PRC Envelope #9 229 x 324 mm"
 msgstr "Enveloppe PRC n. 9, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:211
+#: ../src/common/paper.cpp:208
 msgid "PRC Envelope #9 Rotated 324 x 229 mm"
 msgstr "Enveloppe PRC n. 9, Paysage, 324 x 229 mm"
 
@@ -5597,87 +5744,91 @@ msgstr "Enveloppe PRC n. 9, Paysage, 324 x 229 mm"
 msgid "Padding"
 msgstr "Espacement"
 
-#: ../src/common/prntbase.cpp:2074
+#: ../src/common/prntbase.cpp:2096
 #, c-format
 msgid "Page %d"
 msgstr "Page %d"
 
-#: ../src/common/prntbase.cpp:2072
+#: ../src/common/prntbase.cpp:2094
 #, c-format
 msgid "Page %d of %d"
 msgstr "Page %d de %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 msgid "Page Down"
 msgstr "Page Suiv"
 
-#: ../src/gtk/print.cpp:826
+#: ../src/gtk/print.cpp:829
 msgid "Page Setup"
 msgstr "Mise en Page"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 msgid "Page Up"
 msgstr "Page Préc"
 
-#: ../src/generic/prntdlgg.cpp:828 ../src/common/prntbase.cpp:484
+#: ../src/common/prntbase.cpp:479 ../src/generic/prntdlgg.cpp:821
 msgid "Page setup"
 msgstr "Mise en page"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 msgid "PageDown"
 msgstr "PageDown"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 msgid "PageUp"
 msgstr "PageUp"
 
-#: ../src/generic/prntdlgg.cpp:216
+#: ../src/generic/prntdlgg.cpp:209
 msgid "Pages"
 msgstr "Pages"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1765
+#: ../src/propgrid/advprops.cpp:1666
 msgid "Paint Brush"
 msgstr "Brosse à peinture"
 
-#: ../src/generic/prntdlgg.cpp:602 ../src/generic/prntdlgg.cpp:801
-#: ../src/generic/prntdlgg.cpp:842 ../src/generic/prntdlgg.cpp:855
-#: ../src/generic/prntdlgg.cpp:1052 ../src/generic/prntdlgg.cpp:1057
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:794
+#: ../src/generic/prntdlgg.cpp:835 ../src/generic/prntdlgg.cpp:848
+#: ../src/generic/prntdlgg.cpp:1045 ../src/generic/prntdlgg.cpp:1050
 msgid "Paper size"
 msgstr "Taille de la page"
 
-#: ../src/richtext/richtextstyles.cpp:1062
+#: ../src/richtext/richtextstyles.cpp:1059
 msgid "Paragraph styles"
 msgstr "Styles de paragraphe"
 
-#: ../src/common/xtistrm.cpp:465
+#: ../src/common/xtistrm.cpp:462
 msgid "Passing a already registered object to SetObject"
 msgstr "Objet déjà enregistré indiqué à SetObject"
 
-#: ../src/common/xtistrm.cpp:476
+#: ../src/common/xtistrm.cpp:473
 msgid "Passing an unknown object to GetObject"
 msgstr "Objet inconnu passé à GetObject"
 
-#: ../src/richtext/richtextctrl.cpp:3513 ../src/common/stockitem.cpp:180
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:177 ../src/richtext/richtextctrl.cpp:3514
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Coller"
 
-#: ../src/common/stockitem.cpp:262
+#: ../src/common/stockitem.cpp:260
 msgid "Paste selection"
 msgstr "Coller la sélection"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:74
+#: ../src/common/accelcmn.cpp:71
 msgid "Pause"
 msgstr "Pause"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1766
+#: ../src/propgrid/advprops.cpp:1667
 msgid "Pencil"
 msgstr "Crayon"
 
@@ -5686,21 +5837,21 @@ msgstr "Crayon"
 msgid "Peri&od"
 msgstr "&Virgule"
 
-#: ../src/generic/filectrlg.cpp:430
+#: ../src/generic/filectrlg.cpp:426
 msgid "Permissions"
 msgstr "Permissions"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:60
+#: ../src/common/accelcmn.cpp:57
 msgid "PgDn"
 msgstr "PgSv"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:59
+#: ../src/common/accelcmn.cpp:56
 msgid "PgUp"
 msgstr "PgPc"
 
-#: ../src/richtext/richtextbuffer.cpp:12868
+#: ../src/richtext/richtextbuffer.cpp:12863
 msgid "Picture Properties"
 msgstr "Propriétés de l'Image"
 
@@ -5712,42 +5863,42 @@ msgstr "Échec de la création du tube (pipe)"
 msgid "Please choose a valid font."
 msgstr "Choisir une police valable."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
 msgid "Please choose an existing file."
 msgstr "Choisir un fichier existant."
 
-#: ../src/html/helpwnd.cpp:800
+#: ../src/html/helpwnd.cpp:798
 msgid "Please choose the page to display:"
 msgstr "Choisir la page à afficher :"
 
-#: ../src/msw/dialup.cpp:764
+#: ../src/msw/dialup.cpp:758
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Choisir à quel FAI se connecter"
 
-#: ../src/common/headerctrlcmn.cpp:59
+#: ../src/common/headerctrlcmn.cpp:57
 msgid "Please select the columns to show and define their order:"
 msgstr "Sélectionner les colonnes à afficher et définir leur ordre :"
 
-#: ../src/common/prntbase.cpp:538
+#: ../src/common/prntbase.cpp:533
 msgid "Please wait while printing..."
 msgstr "Impression en cours..."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1767
+#: ../src/propgrid/advprops.cpp:1668
 msgid "Point Left"
 msgstr "Point Gauche"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1768
+#: ../src/propgrid/advprops.cpp:1669
 msgid "Point Right"
 msgstr "Point Droite"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:662
+#: ../src/propgrid/advprops.cpp:572
 msgid "Point Size"
 msgstr "Taille de Point"
 
-#: ../src/generic/prntdlgg.cpp:612 ../src/generic/prntdlgg.cpp:867
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:860
 msgid "Portrait"
 msgstr "Portrait"
 
@@ -5755,150 +5906,160 @@ msgstr "Portrait"
 msgid "Position"
 msgstr "Position"
 
-#: ../src/generic/prntdlgg.cpp:298
+#: ../src/generic/prntdlgg.cpp:291
 msgid "PostScript file"
 msgstr "Fichier PostScript"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178 ../src/osx/cocoa/preferences.mm:303
 msgid "Preferences"
 msgstr "Préférences"
 
-#: ../src/osx/menu_osx.cpp:568
+#: ../src/osx/menu_osx.cpp:460
 msgid "Preferences..."
 msgstr "Préférences..."
 
-#: ../src/common/prntbase.cpp:546
+#: ../src/common/prntbase.cpp:541
 msgid "Preparing"
 msgstr "Préparation"
 
-#: ../src/generic/fontdlgg.cpp:455 ../src/osx/carbon/fontdlg.cpp:390
-#: ../src/html/helpwnd.cpp:1222
+#: ../src/osx/carbon/fontdlg.cpp:387 ../src/generic/fontdlgg.cpp:452
+#: ../src/html/helpwnd.cpp:1220
 msgid "Preview:"
 msgstr "Aperçu :"
 
-#: ../src/common/prntbase.cpp:1553 ../src/html/helpwnd.cpp:664
+#: ../src/common/prntbase.cpp:1578 ../src/html/helpwnd.cpp:662
 msgid "Previous page"
 msgstr "Page précédente"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/prntdlgg.cpp:143 ../src/generic/prntdlgg.cpp:157
-#: ../src/common/prntbase.cpp:426 ../src/common/prntbase.cpp:1541
-#: ../src/common/accelcmn.cpp:77 ../src/gtk/print.cpp:620
-#: ../src/gtk/print.cpp:638
+#: ../src/common/prntbase.cpp:421 ../src/common/prntbase.cpp:1566
+#: ../src/common/accelcmn.cpp:74 ../src/generic/prntdlgg.cpp:136
+#: ../src/generic/prntdlgg.cpp:150 ../src/gtk/print.cpp:616
+#: ../src/gtk/print.cpp:634
 msgid "Print"
 msgstr "Imprimer"
 
-#: ../include/wx/prntbase.h:399 ../src/common/docview.cpp:1268
+#: ../src/common/docview.cpp:1262
 msgid "Print Preview"
 msgstr "Aperçu avant impression"
 
-#: ../src/common/prntbase.cpp:2015 ../src/common/prntbase.cpp:2057
-#: ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2037 ../src/common/prntbase.cpp:2079
+#: ../src/common/prntbase.cpp:2087
 msgid "Print Preview Failure"
 msgstr "Erreur de l'aperçu avant impression"
 
-#: ../src/generic/prntdlgg.cpp:224
+#: ../src/generic/prntdlgg.cpp:217
 msgid "Print Range"
 msgstr "Pages à imprimer"
 
-#: ../src/generic/prntdlgg.cpp:449
+#: ../src/generic/prntdlgg.cpp:442
 msgid "Print Setup"
 msgstr "Configuration de l'impression"
 
-#: ../src/generic/prntdlgg.cpp:621
+#: ../src/generic/prntdlgg.cpp:614
 msgid "Print in colour"
 msgstr "Imprimer en couleur"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/osx/webview_webkit.mm:260
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "La description de la colonne n'a pas pu être initialisée."
+
+#: ../src/common/stockitem.cpp:179
 msgid "Print previe&w..."
 msgstr "&Aperçu avant impression..."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1256
 msgid "Print preview creation failed."
 msgstr "Échec de la création de l'aperçu avant impression."
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/common/stockitem.cpp:179
 msgid "Print preview..."
 msgstr "Aperçu avant impression..."
 
-#: ../src/generic/prntdlgg.cpp:630
+#: ../src/generic/prntdlgg.cpp:623
 msgid "Print spooling"
 msgstr "File d'attente d'impression"
 
-#: ../src/html/helpwnd.cpp:675
+#: ../src/html/helpwnd.cpp:673
 msgid "Print this page"
 msgstr "Imprimer cette page"
 
-#: ../src/generic/prntdlgg.cpp:185
+#: ../src/generic/prntdlgg.cpp:178
 msgid "Print to File"
 msgstr "Imprimer dans un fichier"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "Print..."
 msgstr "&Imprimer..."
 
-#: ../src/generic/prntdlgg.cpp:493
+#: ../src/generic/prntdlgg.cpp:486
 msgid "Printer"
 msgstr "Imprimante"
 
-#: ../src/generic/prntdlgg.cpp:633
+#: ../src/generic/prntdlgg.cpp:626
 msgid "Printer command:"
 msgstr "Commande pour l'imprimante :"
 
-#: ../src/generic/prntdlgg.cpp:180
+#: ../src/generic/prntdlgg.cpp:173
 msgid "Printer options"
 msgstr "Options de l'imprimante"
 
-#: ../src/generic/prntdlgg.cpp:645
+#: ../src/generic/prntdlgg.cpp:638
 msgid "Printer options:"
 msgstr "Options de l'imprimante :"
 
-#: ../src/generic/prntdlgg.cpp:916
+#: ../src/generic/prntdlgg.cpp:909
 msgid "Printer..."
 msgstr "Imprimante..."
 
-#: ../src/generic/prntdlgg.cpp:196
+#: ../src/generic/prntdlgg.cpp:189
 msgid "Printer:"
 msgstr "Imprimante :"
 
-#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:535
-#: ../src/html/htmprint.cpp:277
+#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:530
+#: ../src/html/htmprint.cpp:289
 msgid "Printing"
 msgstr "Impression"
 
-#: ../src/common/prntbase.cpp:612
+#: ../src/common/prntbase.cpp:607
 msgid "Printing "
 msgstr "Impression en cours "
 
-#: ../src/common/prntbase.cpp:347
+#: ../src/common/prntbase.cpp:342
 msgid "Printing Error"
 msgstr "Erreur d'impression"
 
-#: ../src/common/prntbase.cpp:565
+#: ../src/osx/webview_webkit.mm:251
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "Gzip n'est pas géré par cette version de zlib"
+
+#: ../src/common/prntbase.cpp:560
 #, c-format
 msgid "Printing page %d"
 msgstr "Impression de la page %d"
 
-#: ../src/common/prntbase.cpp:570
+#: ../src/common/prntbase.cpp:565
 #, c-format
 msgid "Printing page %d of %d"
 msgstr "Impression de la page %d sur %d"
 
-#: ../src/generic/printps.cpp:201
+#: ../src/generic/printps.cpp:182
 #, c-format
 msgid "Printing page %d..."
 msgstr "Impression de la page %d..."
 
-#: ../src/generic/printps.cpp:161
+#: ../src/generic/printps.cpp:142
 msgid "Printing..."
 msgstr "Impression en cours..."
 
-#: ../include/wx/richtext/richtextprint.h:109 ../include/wx/prntbase.h:267
-#: ../src/common/docview.cpp:2132
+#: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
+#: ../src/common/docview.cpp:2137
 msgid "Printout"
 msgstr "Impression"
 
-#: ../src/common/debugrpt.cpp:560
+#: ../src/common/debugrpt.cpp:561
 #, c-format
 msgid ""
 "Processing debug report has failed, leaving the files in \"%s\" directory."
@@ -5906,103 +6067,103 @@ msgstr ""
 "Échec du traitement du rapport de débogage, les fichiers sont maintenus dans "
 "le répertoire « %s »."
 
-#: ../src/common/prntbase.cpp:545
+#: ../src/common/prntbase.cpp:540
 msgid "Progress:"
 msgstr "Progression :"
 
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181
 msgid "Properties"
 msgstr "Propriétés"
 
-#: ../src/propgrid/manager.cpp:237
+#: ../src/propgrid/manager.cpp:223
 msgid "Property"
 msgstr "Propriété"
 
 #. TRANSLATORS: Caption of message box displaying any property error
-#: ../src/propgrid/propgrid.cpp:3185 ../src/propgrid/propgrid.cpp:3318
+#: ../src/propgrid/propgrid.cpp:3162 ../src/propgrid/propgrid.cpp:3299
 msgid "Property Error"
 msgstr "Erreur de Propriété"
 
-#: ../src/propgrid/advprops.cpp:1597
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Purple"
 msgstr "Pourpre"
 
-#: ../src/common/paper.cpp:112
+#: ../src/common/paper.cpp:109
 msgid "Quarto, 215 x 275 mm"
 msgstr "Quarto, 215 x 275 mm"
 
-#: ../src/generic/logg.cpp:1016
+#: ../src/generic/logg.cpp:1013
 msgid "Question"
 msgstr "Question"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1769
+#: ../src/propgrid/advprops.cpp:1670
 msgid "Question Arrow"
 msgstr "Point d'Interrogation"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "Quit"
 msgstr "Quitter"
 
-#: ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:477
 #, c-format
 msgid "Quit %s"
 msgstr "Quitter %s"
 
-#: ../src/common/stockitem.cpp:263
+#: ../src/common/stockitem.cpp:261
 msgid "Quit this program"
 msgstr "Quitter ce programme"
 
-#: ../src/common/accelcmn.cpp:338
+#: ../src/common/accelcmn.cpp:352
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/ffile.cpp:109 ../src/common/ffile.cpp:133
+#: ../src/common/ffile.cpp:107 ../src/common/ffile.cpp:132
 #, c-format
 msgid "Read error on file '%s'"
 msgstr "Erreur de lecture dans le fichier « %s »"
 
-#: ../src/common/secretstore.cpp:199
-#, c-format
-msgid "Reading password for \"%s/%s\" failed: %s."
+#: ../src/common/secretstore.cpp:211
+#, fuzzy, c-format
+msgid "Reading password for \"%s\" failed: %s."
 msgstr "Lecture de mot de passe pour \"%s/%s\" en erreur : %s."
 
-#: ../src/common/prntbase.cpp:272
+#: ../src/common/prntbase.cpp:267
 msgid "Ready"
 msgstr "Prêt"
 
-#: ../src/propgrid/advprops.cpp:1605
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Red"
 msgstr "Rouge"
 
-#: ../src/generic/colrdlgg.cpp:339
+#: ../src/generic/colrdlgg.cpp:359
 msgid "Red:"
 msgstr "Rouge :"
 
-#: ../src/common/stockitem.cpp:185 ../src/stc/stc_i18n.cpp:16
+#: ../src/common/stockitem.cpp:182 ../src/stc/stc_i18n.cpp:16
 msgid "Redo"
 msgstr "Refaire"
 
-#: ../src/common/stockitem.cpp:264
+#: ../src/common/stockitem.cpp:262
 msgid "Redo last action"
 msgstr "Exécuter à nouveau la dernière action"
 
-#: ../src/common/stockitem.cpp:186
+#: ../src/common/stockitem.cpp:183
 msgid "Refresh"
 msgstr "Actualiser"
 
-#: ../src/msw/registry.cpp:626
+#: ../src/msw/registry.cpp:615
 #, c-format
 msgid "Registry key '%s' already exists."
 msgstr "La clé de registre « %s » existe déjà."
 
-#: ../src/msw/registry.cpp:595
+#: ../src/msw/registry.cpp:584
 #, c-format
 msgid "Registry key '%s' does not exist, cannot rename it."
 msgstr ""
 "Impossible de renommer la clé de registre « %s », celle-ci n'existe pas."
 
-#: ../src/msw/registry.cpp:727
+#: ../src/msw/registry.cpp:716
 #, c-format
 msgid ""
 "Registry key '%s' is needed for normal system operation,\n"
@@ -6013,22 +6174,22 @@ msgstr ""
 "du système ; sa suppression laisserait ce système inutilisable :\n"
 "opération abandonnée."
 
-#: ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:942
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr "La valeur de registre \"%s\" n'est pas binaire (mais de type %s)"
 
-#: ../src/msw/registry.cpp:917
+#: ../src/msw/registry.cpp:905
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr "La valeur de registre \"%s\" n'est pas numérique (mais de type %s)"
 
-#: ../src/msw/registry.cpp:1003
+#: ../src/msw/registry.cpp:991
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr "La valeur de registre \"%s\" n'est pas du texte (mais de type %s)"
 
-#: ../src/msw/registry.cpp:521
+#: ../src/msw/registry.cpp:510
 #, c-format
 msgid "Registry value '%s' already exists."
 msgstr "La valeur de registre « %s » existe déjà."
@@ -6042,72 +6203,78 @@ msgstr "Régulier"
 msgid "Relative"
 msgstr "Relatif"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:456
 msgid "Relevant entries:"
 msgstr "Entrées pertinentes :"
 
-#: ../include/wx/generic/progdlgg.h:86
+#: ../include/wx/generic/progdlgg.h:87
 msgid "Remaining time:"
 msgstr "Temps restant :"
 
-#: ../src/common/stockitem.cpp:187
+#: ../src/common/stockitem.cpp:184
 msgid "Remove"
 msgstr "Supprimer"
 
-#: ../src/richtext/richtextctrl.cpp:1562
+#: ../src/richtext/richtextctrl.cpp:1563
 msgid "Remove Bullet"
 msgstr "Retirer le tiret"
 
-#: ../src/html/helpwnd.cpp:433
+#: ../src/html/helpwnd.cpp:431
 msgid "Remove current page from bookmarks"
 msgstr "Retirer la page courante des marque-pages"
 
-#: ../src/common/rendcmn.cpp:194
+#: ../src/common/rendcmn.cpp:191
 #, c-format
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 "Le moteur de rendu « %s » a une version %d.%d incompatible et n'a pas pu "
 "être chargé."
 
-#: ../src/richtext/richtextbuffer.cpp:4527
+#: ../src/richtext/richtextbuffer.cpp:4524
 msgid "Renumber List"
 msgstr "Renuméroter la liste"
 
-#: ../src/common/stockitem.cpp:188
-msgid "Rep&lace"
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Rep&lace..."
 msgstr "Remp&lacer"
 
-#: ../src/richtext/richtextctrl.cpp:3673 ../src/common/stockitem.cpp:188
+#: ../src/richtext/richtextctrl.cpp:3674
 msgid "Replace"
 msgstr "Remplacer"
 
-#: ../src/generic/fdrepdlg.cpp:182
+#: ../src/generic/fdrepdlg.cpp:179
 msgid "Replace &all"
 msgstr "Rempl&acer tout"
 
-#: ../src/common/stockitem.cpp:261
-msgid "Replace selection"
-msgstr "Remplacer la sélection"
-
-#: ../src/generic/fdrepdlg.cpp:124
+#: ../src/generic/fdrepdlg.cpp:121
 msgid "Replace with:"
 msgstr "Remplacer par :"
 
-#: ../src/common/valtext.cpp:163
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Replace..."
+msgstr "Remplacer"
+
+#: ../src/common/valtext.cpp:184
 msgid "Required information entry is empty."
 msgstr "L'entrée d'information requise est vide."
 
-#: ../src/common/translation.cpp:1975
+#: ../src/common/translation.cpp:2025
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "La ressource « %s » n'est pas un catalogue messages valable."
 
+#: ../src/gtk/webview_webkit.cpp:985
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:56
+#: ../src/common/accelcmn.cpp:53
 msgid "Return"
 msgstr "Retour"
 
-#: ../src/common/stockitem.cpp:189
+#: ../src/common/stockitem.cpp:186
 msgid "Revert to Saved"
 msgstr "Changer en enregistré"
 
@@ -6119,41 +6286,41 @@ msgstr "Arête"
 msgid "Rig&ht-to-left"
 msgstr "Droite-à-gauche"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6149
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:59 ../src/generic/datavgen.cpp:6954
+#: ../src/richtext/richtextsizepage.cpp:250
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextbulletspage.cpp:188
-#: ../src/richtext/richtextsizepage.cpp:250 ../src/common/accelcmn.cpp:62
 msgid "Right"
 msgstr "Droite"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1754
+#: ../src/propgrid/advprops.cpp:1655
 msgid "Right Arrow"
 msgstr "Flèche Droite"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1770
+#: ../src/propgrid/advprops.cpp:1671
 msgid "Right Button"
 msgstr "Bouton droit"
 
-#: ../src/generic/prntdlgg.cpp:892
+#: ../src/generic/prntdlgg.cpp:885
 msgid "Right margin (mm):"
 msgstr "Marge droite (mm) :"
 
-#: ../src/richtext/richtextindentspage.cpp:148
-#: ../src/richtext/richtextindentspage.cpp:150
 #: ../src/richtext/richtextliststylepage.cpp:337
 #: ../src/richtext/richtextliststylepage.cpp:339
+#: ../src/richtext/richtextindentspage.cpp:148
+#: ../src/richtext/richtextindentspage.cpp:150
 msgid "Right-align text."
 msgstr "Alignement à droite du texte."
 
-#: ../src/generic/fontdlgg.cpp:322
+#: ../src/generic/fontdlgg.cpp:318
 msgid "Roman"
 msgstr "Roman"
 
-#: ../src/generic/datavgen.cpp:5916
+#: ../src/generic/datavgen.cpp:6721
 #, c-format
 msgid "Row %i"
 msgstr "Ligne %i"
@@ -6163,30 +6330,31 @@ msgstr "Ligne %i"
 msgid "S&tandard bullet name:"
 msgstr "Nom s&tandard de tiret :"
 
-#: ../src/common/accelcmn.cpp:268 ../src/common/accelcmn.cpp:350
+#: ../src/common/accelcmn.cpp:282 ../src/common/accelcmn.cpp:367
 msgid "SPECIAL"
 msgstr "SPECIAL"
 
-#: ../src/common/stockitem.cpp:190 ../src/common/sizer.cpp:2797
+#: ../src/common/stockitem.cpp:187 ../src/common/sizer.cpp:2914
 msgid "Save"
 msgstr "Enregistrer"
 
-#: ../src/common/fldlgcmn.cpp:342
+#: ../src/common/fldlgcmn.cpp:339
 #, c-format
 msgid "Save %s file"
 msgstr "Enregistrer le fichier %s"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/common/stockitem.cpp:188 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Enregistrer &sous..."
 
-#: ../src/common/docview.cpp:366
+#: ../src/common/docview.cpp:359
 msgid "Save As"
 msgstr "Enregistrer Sous"
 
-#: ../src/common/stockitem.cpp:191
-msgid "Save as"
-msgstr "Enregistrer sous"
+#: ../src/common/stockitem.cpp:188
+#, fuzzy
+msgid "Save As..."
+msgstr "Enregistrer &sous..."
 
 #: ../src/common/stockitem.cpp:267
 msgid "Save current document"
@@ -6196,40 +6364,40 @@ msgstr "Enregistrer le document courant"
 msgid "Save current document with a different filename"
 msgstr "Enregistrer le document courant avec un nouveau nom"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/generic/logg.cpp:509
 msgid "Save log contents to file"
 msgstr "Enregistrer le contenu du journal dans un fichier"
 
-#: ../src/common/secretstore.cpp:179
-#, c-format
-msgid "Saving password for \"%s/%s\" failed: %s."
+#: ../src/common/secretstore.cpp:189
+#, fuzzy, c-format
+msgid "Saving password for \"%s\" failed: %s."
 msgstr "Enregistrement de mot de passe pour \"%s/%s\" en erreur : %s."
 
-#: ../src/generic/fontdlgg.cpp:325
+#: ../src/generic/fontdlgg.cpp:321
 msgid "Script"
 msgstr "Script"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll Lock"
 msgstr "Verr Défil"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll_lock"
 msgstr "Verr_défil"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:890
+#: ../src/propgrid/advprops.cpp:791
 msgid "Scrollbar"
 msgstr "Barre de défilement"
 
-#: ../src/generic/srchctlg.cpp:56 ../src/html/helpwnd.cpp:535
-#: ../src/html/helpwnd.cpp:550
+#: ../src/generic/srchctlg.cpp:55 ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:548 ../src/gtk/srchctrl.cpp:182
 msgid "Search"
 msgstr "Chercher"
 
-#: ../src/html/helpwnd.cpp:537
+#: ../src/html/helpwnd.cpp:535
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
@@ -6237,32 +6405,32 @@ msgstr ""
 "Rechercher dans le contenu du/des manuel(s) d'aide toutes les occurrences du "
 "texte tapé ci-dessus"
 
-#: ../src/generic/fdrepdlg.cpp:160
+#: ../src/generic/fdrepdlg.cpp:157
 msgid "Search direction"
 msgstr "Direction de la recherche"
 
-#: ../src/generic/fdrepdlg.cpp:112
+#: ../src/generic/fdrepdlg.cpp:109
 msgid "Search for:"
 msgstr "Chercher :"
 
-#: ../src/html/helpwnd.cpp:1052
+#: ../src/html/helpwnd.cpp:1050
 msgid "Search in all books"
 msgstr "Chercher dans tous les manuels"
 
-#: ../src/html/helpwnd.cpp:857
+#: ../src/html/helpwnd.cpp:855
 msgid "Searching..."
 msgstr "Recherche..."
 
-#: ../src/generic/dirctrlg.cpp:446
+#: ../src/generic/dirctrlg.cpp:412
 msgid "Sections"
 msgstr "Sections"
 
-#: ../src/common/ffile.cpp:238
+#: ../src/common/ffile.cpp:237
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Erreur de recherche dans le fichier « %s »"
 
-#: ../src/common/ffile.cpp:228
+#: ../src/common/ffile.cpp:227
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
@@ -6270,24 +6438,24 @@ msgstr ""
 "pas gérés par stdio)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:76
+#: ../src/common/accelcmn.cpp:73
 msgid "Select"
 msgstr "Sélectioner"
 
-#: ../src/richtext/richtextctrl.cpp:337 ../src/osx/textctrl_osx.cpp:581
-#: ../src/common/stockitem.cpp:192 ../src/msw/textctrl.cpp:2512
+#: ../src/osx/textctrl_osx.cpp:599 ../src/common/stockitem.cpp:189
+#: ../src/msw/textctrl.cpp:2777 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "&Tout sélectionner"
 
-#: ../src/common/stockitem.cpp:192 ../src/stc/stc_i18n.cpp:21
+#: ../src/common/stockitem.cpp:189 ../src/stc/stc_i18n.cpp:21
 msgid "Select All"
 msgstr "Tout sélectionner"
 
-#: ../src/common/docview.cpp:1895
+#: ../src/common/docview.cpp:1900
 msgid "Select a document template"
 msgstr "Sélectionner un modèle de document"
 
-#: ../src/common/docview.cpp:1969
+#: ../src/common/docview.cpp:1974
 msgid "Select a document view"
 msgstr "Sélectionner une vue du document"
 
@@ -6316,20 +6484,20 @@ msgid "Selects the list level to edit."
 msgstr "Choisir le niveau de liste à éditer."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:82
+#: ../src/common/accelcmn.cpp:79
 msgid "Separator"
 msgstr "Séparateur"
 
-#: ../src/common/cmdline.cpp:1083
+#: ../src/common/cmdline.cpp:1079
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Séparateur attendu après l'option « %s »."
 
-#: ../src/osx/menu_osx.cpp:572
+#: ../src/osx/menu_osx.cpp:464
 msgid "Services"
 msgstr "Services"
 
-#: ../src/richtext/richtextbuffer.cpp:11217
+#: ../src/richtext/richtextbuffer.cpp:11216
 msgid "Set Cell Style"
 msgstr "Définir le Style de Cellule"
 
@@ -6337,11 +6505,11 @@ msgstr "Définir le Style de Cellule"
 msgid "SetProperty called w/o valid setter"
 msgstr "SetProperty appelé sans monteur valable"
 
-#: ../src/generic/prntdlgg.cpp:188
+#: ../src/generic/prntdlgg.cpp:181
 msgid "Setup..."
 msgstr "Configurer..."
 
-#: ../src/msw/dialup.cpp:544
+#: ../src/msw/dialup.cpp:538
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr "Plusieurs connexions actives trouvées, sélection unique aléatoire."
 
@@ -6357,40 +6525,40 @@ msgstr "Ombre"
 msgid "Shadow c&olour:"
 msgstr "&Couleur de l'ombre :"
 
-#: ../src/common/accelcmn.cpp:335
+#: ../src/common/accelcmn.cpp:349
 msgid "Shift+"
 msgstr "Majuscule+"
 
-#: ../src/generic/dirdlgg.cpp:147
+#: ../src/generic/dirdlgg.cpp:144
 msgid "Show &hidden directories"
 msgstr "Montrer les répertoires cac&hés"
 
-#: ../src/generic/filectrlg.cpp:983
+#: ../src/generic/filectrlg.cpp:979
 msgid "Show &hidden files"
 msgstr "Montrer les fichiers cac&hés"
 
-#: ../src/osx/menu_osx.cpp:580
+#: ../src/osx/menu_osx.cpp:472
 msgid "Show All"
 msgstr "Tout Montrer"
 
-#: ../src/common/stockitem.cpp:257
+#: ../src/common/stockitem.cpp:254
 msgid "Show about dialog"
 msgstr "Montrer la fenêtre d'à propos"
 
-#: ../src/html/helpwnd.cpp:492
+#: ../src/html/helpwnd.cpp:490
 msgid "Show all"
 msgstr "Tout montrer"
 
-#: ../src/html/helpwnd.cpp:503
+#: ../src/html/helpwnd.cpp:501
 msgid "Show all items in index"
 msgstr "Montrer tous les éléments de l'index"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:656
 msgid "Show/hide navigation panel"
 msgstr "Montrer/cacher le panneau de navigation"
 
-#: ../src/richtext/richtextsymboldlg.cpp:421
-#: ../src/richtext/richtextsymboldlg.cpp:423
+#: ../src/richtext/richtextsymboldlg.cpp:418
+#: ../src/richtext/richtextsymboldlg.cpp:420
 msgid "Shows a Unicode subset."
 msgstr "Affiche un échantillon d'Unicode."
 
@@ -6406,7 +6574,7 @@ msgstr "Affiche un aperçu des réglages pour les tirets."
 msgid "Shows a preview of the font settings."
 msgstr "Affiche un aperçu de réglages de la police."
 
-#: ../src/osx/carbon/fontdlg.cpp:394 ../src/osx/carbon/fontdlg.cpp:396
+#: ../src/osx/carbon/fontdlg.cpp:391 ../src/osx/carbon/fontdlg.cpp:393
 msgid "Shows a preview of the font."
 msgstr "Montre un aperçu de la liste."
 
@@ -6415,62 +6583,62 @@ msgstr "Montre un aperçu de la liste."
 msgid "Shows a preview of the paragraph settings."
 msgstr "Affiche un aperçu des réglages de paragraphe."
 
-#: ../src/generic/fontdlgg.cpp:460 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:456 ../src/generic/fontdlgg.cpp:458
 msgid "Shows the font preview."
 msgstr "Montrer un aperçu des polices."
 
-#: ../src/propgrid/advprops.cpp:1607
+#: ../src/propgrid/advprops.cpp:1513
 msgid "Silver"
 msgstr "Argent"
 
-#: ../src/univ/themes/mono.cpp:516
+#: ../src/univ/themes/mono.cpp:513
 msgid "Simple monochrome theme"
 msgstr "Simple thème monochrome"
 
-#: ../src/richtext/richtextindentspage.cpp:275
 #: ../src/richtext/richtextliststylepage.cpp:449
+#: ../src/richtext/richtextindentspage.cpp:275
 msgid "Single"
 msgstr "Simple"
 
-#: ../src/generic/filectrlg.cpp:425 ../src/richtext/richtextformatdlg.cpp:369
-#: ../src/richtext/richtextsizepage.cpp:299
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextsizepage.cpp:299
+#: ../src/richtext/richtextformatdlg.cpp:362
 msgid "Size"
 msgstr "Taille"
 
-#: ../src/osx/carbon/fontdlg.cpp:339
+#: ../src/osx/carbon/fontdlg.cpp:336
 msgid "Size:"
 msgstr "Taille :"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1775
+#: ../src/propgrid/advprops.cpp:1676
 msgid "Sizing"
 msgstr "Dimensionnement"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1772
+#: ../src/propgrid/advprops.cpp:1673
 msgid "Sizing N-S"
 msgstr "Dimensionnement N-S"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1771
+#: ../src/propgrid/advprops.cpp:1672
 msgid "Sizing NE-SW"
 msgstr "Dimensionnement NE-SO"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1773
+#: ../src/propgrid/advprops.cpp:1674
 msgid "Sizing NW-SE"
 msgstr "Dimensionnement NW-SE"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1774
+#: ../src/propgrid/advprops.cpp:1675
 msgid "Sizing W-E"
 msgstr "Dimensionnement O-E"
 
-#: ../src/msw/progdlg.cpp:801
+#: ../src/msw/progdlg.cpp:1088
 msgid "Skip"
 msgstr "Sauter"
 
-#: ../src/generic/fontdlgg.cpp:330
+#: ../src/generic/fontdlgg.cpp:326
 msgid "Slant"
 msgstr "Incliné"
 
@@ -6479,7 +6647,7 @@ msgid "Small C&apitals"
 msgstr "Petites M&ajuscules"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:79
+#: ../src/common/accelcmn.cpp:76
 msgid "Snapshot"
 msgstr "Instantané"
 
@@ -6487,37 +6655,37 @@ msgstr "Instantané"
 msgid "Solid"
 msgstr "Solide"
 
-#: ../src/common/docview.cpp:1791
+#: ../src/common/docview.cpp:1785
 msgid "Sorry, could not open this file."
 msgstr "Impossible d'ouvrir ce fichier."
 
-#: ../src/common/prntbase.cpp:2057 ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2079 ../src/common/prntbase.cpp:2087
 msgid "Sorry, not enough memory to create a preview."
 msgstr "Mémoire insuffisante pour créer un aperçu."
 
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "Sorry, that name is taken. Please choose another."
 msgstr "Ce nom est déjà pris, en choisir un autre."
 
-#: ../src/common/docview.cpp:1814
+#: ../src/common/docview.cpp:1819
 msgid "Sorry, the format for this file is unknown."
 msgstr "Format de fichier inconnu."
 
-#: ../src/unix/sound.cpp:492
+#: ../src/unix/sound.cpp:481
 msgid "Sound data are in unsupported format."
 msgstr "Format des données sonores non reconnu."
 
-#: ../src/unix/sound.cpp:477
+#: ../src/unix/sound.cpp:466
 #, c-format
 msgid "Sound file '%s' is in unsupported format."
 msgstr "Format du fichier sonore « %s » non reconnu."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:67
+#: ../src/common/accelcmn.cpp:64
 msgid "Space"
 msgstr "Espace"
 
@@ -6525,12 +6693,12 @@ msgstr "Espace"
 msgid "Spacing"
 msgstr "Espacement"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "Spell Check"
 msgstr "Vérification Orthographique"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1776
+#: ../src/propgrid/advprops.cpp:1677
 msgid "Spraycan"
 msgstr "Vaporisateur"
 
@@ -6539,7 +6707,7 @@ msgstr "Vaporisateur"
 msgid "Standard"
 msgstr "Standard"
 
-#: ../src/common/paper.cpp:104
+#: ../src/common/paper.cpp:101
 msgid "Statement, 5 1/2 x 8 1/2 in"
 msgstr "Communiqué (5,5 x 8,5 pouces)"
 
@@ -6548,19 +6716,19 @@ msgstr "Communiqué (5,5 x 8,5 pouces)"
 msgid "Static"
 msgstr "Statique"
 
-#: ../src/generic/prntdlgg.cpp:204
+#: ../src/generic/prntdlgg.cpp:197
 msgid "Status:"
 msgstr "État :"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "Stop"
 msgstr "Arrêter"
 
-#: ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196
 msgid "Strikethrough"
 msgstr "Barré"
 
-#: ../src/common/colourcmn.cpp:45
+#: ../src/common/colourcmn.cpp:42
 #, c-format
 msgid "String To Colour : Incorrect colour specification : %s"
 msgstr ""
@@ -6568,15 +6736,11 @@ msgstr ""
 "%s"
 
 #. TRANSLATORS: Label of font style
-#: ../src/richtext/richtextformatdlg.cpp:339 ../src/propgrid/advprops.cpp:680
+#: ../src/propgrid/advprops.cpp:590 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Style"
 
-#: ../include/wx/richtext/richtextstyledlg.h:46
-msgid "Style Organiser"
-msgstr "Organiseur de styles"
-
-#: ../src/osx/carbon/fontdlg.cpp:348
+#: ../src/osx/carbon/fontdlg.cpp:345
 msgid "Style:"
 msgstr "Style :"
 
@@ -6585,7 +6749,7 @@ msgid "Subscrip&t"
 msgstr "Indice"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:83
+#: ../src/common/accelcmn.cpp:80
 msgid "Subtract"
 msgstr "Soustraire"
 
@@ -6593,11 +6757,11 @@ msgstr "Soustraire"
 msgid "Supe&rscript"
 msgstr "Exposant"
 
-#: ../src/common/paper.cpp:150
+#: ../src/common/paper.cpp:147
 msgid "SuperA/SuperA/A4 227 x 356 mm"
 msgstr "SuperA/SuperA/A4 227 x 356 mm"
 
-#: ../src/common/paper.cpp:151
+#: ../src/common/paper.cpp:148
 msgid "SuperB/SuperB/A3 305 x 487 mm"
 msgstr "SuperB/SuperB/A3 305 x 487 mm"
 
@@ -6605,7 +6769,7 @@ msgstr "SuperB/SuperB/A3 305 x 487 mm"
 msgid "Suppress hyphe&nation"
 msgstr "Supprimer l'hyphé&nation"
 
-#: ../src/generic/fontdlgg.cpp:326
+#: ../src/generic/fontdlgg.cpp:322
 msgid "Swiss"
 msgstr "Suisse"
 
@@ -6623,73 +6787,73 @@ msgstr "Police du symbole:"
 msgid "Symbols"
 msgstr "Symboles"
 
-#: ../src/common/imagtiff.cpp:369 ../src/common/imagtiff.cpp:382
-#: ../src/common/imagtiff.cpp:741
+#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
+#: ../src/common/imagtiff.cpp:738
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF : allocation de mémoire impossible."
 
-#: ../src/common/imagtiff.cpp:301
+#: ../src/common/imagtiff.cpp:298
 msgid "TIFF: Error loading image."
 msgstr "TIFF : erreur au chargement de l'image."
 
-#: ../src/common/imagtiff.cpp:468
+#: ../src/common/imagtiff.cpp:465
 msgid "TIFF: Error reading image."
 msgstr "TIFF : erreur à la lecture de l'image."
 
-#: ../src/common/imagtiff.cpp:608
+#: ../src/common/imagtiff.cpp:605
 msgid "TIFF: Error saving image."
 msgstr "TIFF : erreur à la sauvegarde de l'image."
 
-#: ../src/common/imagtiff.cpp:846
+#: ../src/common/imagtiff.cpp:843
 msgid "TIFF: Error writing image."
 msgstr "TIFF : erreur à l'écriture de l'image."
 
-#: ../src/common/imagtiff.cpp:355
+#: ../src/common/imagtiff.cpp:352
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF : La taille de l'image est anormalement grande."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:68
+#: ../src/common/accelcmn.cpp:65
 msgid "Tab"
 msgstr "Tab"
 
-#: ../src/richtext/richtextbuffer.cpp:11498
+#: ../src/richtext/richtextbuffer.cpp:11497
 msgid "Table Properties"
 msgstr "Propriétés du Tableau"
 
-#: ../src/common/paper.cpp:145
+#: ../src/common/paper.cpp:142
 msgid "Tabloid Extra 11.69 x 18 in"
 msgstr "Tabloïde Extra 11.69 x 18 pouces"
 
-#: ../src/common/paper.cpp:102
+#: ../src/common/paper.cpp:99
 msgid "Tabloid, 11 x 17 in"
 msgstr "Tabloïde (11 x 17 pouces)"
 
-#: ../src/richtext/richtextformatdlg.cpp:354
+#: ../src/richtext/richtextformatdlg.cpp:347
 msgid "Tabs"
 msgstr "Tabulations"
 
-#: ../src/propgrid/advprops.cpp:1598
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Teal"
 msgstr "Bleu sarcelle"
 
-#: ../src/generic/fontdlgg.cpp:327
+#: ../src/generic/fontdlgg.cpp:323
 msgid "Teletype"
 msgstr "Télétype"
 
-#: ../src/common/docview.cpp:1896
+#: ../src/common/docview.cpp:1901
 msgid "Templates"
 msgstr "Modèles"
 
-#: ../src/common/fmapbase.cpp:158
+#: ../src/common/fmapbase.cpp:155
 msgid "Thai (ISO-8859-11)"
 msgstr "Thaï (ISO-8859-11)"
 
-#: ../src/common/ftp.cpp:619
+#: ../src/common/ftp.cpp:622
 msgid "The FTP server doesn't support passive mode."
 msgstr "Mode passif non reconnu par le serveur FTP."
 
-#: ../src/common/ftp.cpp:605
+#: ../src/common/ftp.cpp:608
 msgid "The FTP server doesn't support the PORT command."
 msgstr "Commande PORT non reconnue par le serveur FTP."
 
@@ -6700,8 +6864,8 @@ msgstr "Commande PORT non reconnue par le serveur FTP."
 msgid "The available bullet styles."
 msgstr "Les styles de tirets disponibles."
 
-#: ../src/richtext/richtextstyledlg.cpp:202
-#: ../src/richtext/richtextstyledlg.cpp:204
+#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:200
 msgid "The available styles."
 msgstr "Les styles disponibles."
 
@@ -6757,12 +6921,12 @@ msgstr "La position inférieure."
 msgid "The bullet character."
 msgstr "Le caractère de tiret."
 
-#: ../src/richtext/richtextsymboldlg.cpp:443
-#: ../src/richtext/richtextsymboldlg.cpp:445
+#: ../src/richtext/richtextsymboldlg.cpp:440
+#: ../src/richtext/richtextsymboldlg.cpp:442
 msgid "The character code."
 msgstr "Le code caractère."
 
-#: ../src/common/fontmap.cpp:203
+#: ../src/common/fontmap.cpp:200
 #, c-format
 msgid ""
 "The charset '%s' is unknown. You may select\n"
@@ -6772,7 +6936,7 @@ msgstr ""
 "Jeu de caractères « %s » inconnu. Sélectionner un autre en remplacement\n"
 "ou [Annuler] s'il ne peut pas être remplacé"
 
-#: ../src/msw/ole/dataobj.cpp:394
+#: ../src/msw/ole/dataobj.cpp:402
 #, c-format
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "Format « %d » de presse-papiers inexistant."
@@ -6782,7 +6946,7 @@ msgstr "Format « %d » de presse-papiers inexistant."
 msgid "The default style for the next paragraph."
 msgstr "Le style par défaut pour le paragraphe suivant."
 
-#: ../src/generic/dirdlgg.cpp:202
+#: ../src/generic/dirdlgg.cpp:199
 #, c-format
 msgid ""
 "The directory '%s' does not exist\n"
@@ -6791,7 +6955,7 @@ msgstr ""
 "Le dossier « %s » est inexistant.\n"
 "Faut-il le créer maintenant ?"
 
-#: ../src/html/htmprint.cpp:271
+#: ../src/html/htmprint.cpp:283
 #, c-format
 msgid ""
 "The document \"%s\" doesn't fit on the page horizontally and will be "
@@ -6804,7 +6968,7 @@ msgstr ""
 "\n"
 "Faut-il néanmoins procéder à l'impression ?"
 
-#: ../src/common/docview.cpp:1202
+#: ../src/common/docview.cpp:1196
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -6813,36 +6977,37 @@ msgstr ""
 "Le fichier « %s » n'existe pas et n'a pas pu être ouvert.\n"
 "Il a été retiré de la liste des fichiers récemment utilisés."
 
-#: ../src/richtext/richtextindentspage.cpp:208
-#: ../src/richtext/richtextindentspage.cpp:210
 #: ../src/richtext/richtextliststylepage.cpp:394
 #: ../src/richtext/richtextliststylepage.cpp:396
+#: ../src/richtext/richtextindentspage.cpp:208
+#: ../src/richtext/richtextindentspage.cpp:210
 msgid "The first line indent."
 msgstr "Indentation de la première ligne."
 
-#: ../src/gtk/utilsgtk.cpp:481
-msgid "The following standard GTK+ options are also supported:\n"
-msgstr "Les options standards GTK+ suivantes sont également reconnues :\n"
+#: ../src/generic/dbgrptg.cpp:318
+#, fuzzy
+msgid "The following debug report will be generated\n"
+msgstr "*** Un rapport de débogage a été créé\n"
 
-#: ../src/generic/fontdlgg.cpp:414 ../src/generic/fontdlgg.cpp:416
+#: ../src/generic/fontdlgg.cpp:411 ../src/generic/fontdlgg.cpp:413
 msgid "The font colour."
 msgstr "Couleur de police."
 
-#: ../src/generic/fontdlgg.cpp:375 ../src/generic/fontdlgg.cpp:377
+#: ../src/generic/fontdlgg.cpp:371 ../src/generic/fontdlgg.cpp:373
 msgid "The font family."
 msgstr "Famille de police."
 
-#: ../src/richtext/richtextsymboldlg.cpp:405
-#: ../src/richtext/richtextsymboldlg.cpp:407
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "The font from which to take the symbol."
 msgstr "La police de laquelle prendre le symbole."
 
-#: ../src/generic/fontdlgg.cpp:427 ../src/generic/fontdlgg.cpp:429
-#: ../src/generic/fontdlgg.cpp:434 ../src/generic/fontdlgg.cpp:436
+#: ../src/generic/fontdlgg.cpp:424 ../src/generic/fontdlgg.cpp:426
+#: ../src/generic/fontdlgg.cpp:430 ../src/generic/fontdlgg.cpp:432
 msgid "The font point size."
 msgstr "Taille du point de la police."
 
-#: ../src/osx/carbon/fontdlg.cpp:343 ../src/osx/carbon/fontdlg.cpp:345
+#: ../src/osx/carbon/fontdlg.cpp:340 ../src/osx/carbon/fontdlg.cpp:342
 msgid "The font size in points."
 msgstr "Taille de la police en points."
 
@@ -6851,15 +7016,15 @@ msgstr "Taille de la police en points."
 msgid "The font size units, points or pixels."
 msgstr "Les unités de taille de police, points ou pixels."
 
-#: ../src/generic/fontdlgg.cpp:386 ../src/generic/fontdlgg.cpp:388
+#: ../src/generic/fontdlgg.cpp:382 ../src/generic/fontdlgg.cpp:384
 msgid "The font style."
 msgstr "Style de police."
 
-#: ../src/generic/fontdlgg.cpp:397 ../src/generic/fontdlgg.cpp:399
+#: ../src/generic/fontdlgg.cpp:393 ../src/generic/fontdlgg.cpp:395
 msgid "The font weight."
 msgstr "Largeur de police."
 
-#: ../src/common/docview.cpp:1483
+#: ../src/common/docview.cpp:1477
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Le format du fichier « %s » n'a pas pu être déterminé."
@@ -6869,10 +7034,10 @@ msgstr "Le format du fichier « %s » n'a pas pu être déterminé."
 msgid "The horizontal offset."
 msgstr "Le décalage horizontal."
 
-#: ../src/richtext/richtextindentspage.cpp:199
-#: ../src/richtext/richtextindentspage.cpp:201
 #: ../src/richtext/richtextliststylepage.cpp:385
 #: ../src/richtext/richtextliststylepage.cpp:387
+#: ../src/richtext/richtextindentspage.cpp:199
+#: ../src/richtext/richtextindentspage.cpp:201
 msgid "The left indent."
 msgstr "L'indentation de gauche."
 
@@ -6893,10 +7058,10 @@ msgstr "La taille de l'espacement gauche."
 msgid "The left position."
 msgstr "La position gauche."
 
-#: ../src/richtext/richtextindentspage.cpp:288
-#: ../src/richtext/richtextindentspage.cpp:290
 #: ../src/richtext/richtextliststylepage.cpp:462
 #: ../src/richtext/richtextliststylepage.cpp:464
+#: ../src/richtext/richtextindentspage.cpp:288
+#: ../src/richtext/richtextindentspage.cpp:290
 msgid "The line spacing."
 msgstr "L'espacement d'interligne."
 
@@ -6905,7 +7070,7 @@ msgstr "L'espacement d'interligne."
 msgid "The list item number."
 msgstr "Le numéro de l'élément de la liste."
 
-#: ../src/msw/ole/automtn.cpp:664
+#: ../src/msw/ole/automtn.cpp:655
 msgid "The locale ID is unknown."
 msgstr "L'identifiant de la localisation est inconnu."
 
@@ -6944,19 +7109,19 @@ msgstr "La largeur de l'objet."
 msgid "The outline level."
 msgstr "Le niveau du contour."
 
-#: ../src/common/log.cpp:277
+#: ../src/common/log.cpp:296
 #, c-format
 msgid "The previous message repeated %u time."
 msgid_plural "The previous message repeated %u times."
 msgstr[0] "Le message précédent répété %u fois."
 msgstr[1] "Le message précédent répété %u fois."
 
-#: ../src/common/log.cpp:270
+#: ../src/common/log.cpp:289
 msgid "The previous message repeated once."
 msgstr "Le message précédent répété une fois."
 
-#: ../src/richtext/richtextsymboldlg.cpp:462
-#: ../src/richtext/richtextsymboldlg.cpp:464
+#: ../src/richtext/richtextsymboldlg.cpp:459
+#: ../src/richtext/richtextsymboldlg.cpp:461
 msgid "The range to show."
 msgstr "L'intervalle à afficher."
 
@@ -6970,15 +7135,15 @@ msgstr ""
 "fichiers contient des informations sensibles, le décocher pour le\n"
 "retirer de ce rapport.\n"
 
-#: ../src/common/cmdline.cpp:1254
+#: ../src/common/cmdline.cpp:1250
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "Paramètre nécessaire « %s » non fourni."
 
-#: ../src/richtext/richtextindentspage.cpp:217
-#: ../src/richtext/richtextindentspage.cpp:219
 #: ../src/richtext/richtextliststylepage.cpp:403
 #: ../src/richtext/richtextliststylepage.cpp:405
+#: ../src/richtext/richtextindentspage.cpp:217
+#: ../src/richtext/richtextindentspage.cpp:219
 msgid "The right indent."
 msgstr "L'indentation à droite."
 
@@ -7019,16 +7184,16 @@ msgstr "L'opacité de l'ombre."
 msgid "The shadow spread."
 msgstr "La dispersion de l'ombre."
 
-#: ../src/richtext/richtextindentspage.cpp:267
 #: ../src/richtext/richtextliststylepage.cpp:439
 #: ../src/richtext/richtextliststylepage.cpp:441
+#: ../src/richtext/richtextindentspage.cpp:267
 msgid "The spacing after the paragraph."
 msgstr "L'espacement après le paragraphe."
 
-#: ../src/richtext/richtextindentspage.cpp:257
-#: ../src/richtext/richtextindentspage.cpp:259
 #: ../src/richtext/richtextliststylepage.cpp:430
 #: ../src/richtext/richtextliststylepage.cpp:432
+#: ../src/richtext/richtextindentspage.cpp:257
+#: ../src/richtext/richtextindentspage.cpp:259
 msgid "The spacing before the paragraph."
 msgstr "L'espacement avant le paragraphe."
 
@@ -7042,12 +7207,12 @@ msgstr "Le nom du style."
 msgid "The style on which this style is based."
 msgstr "Le style sur lequel ce style est basé."
 
-#: ../src/richtext/richtextstyledlg.cpp:214
-#: ../src/richtext/richtextstyledlg.cpp:216
+#: ../src/richtext/richtextstyledlg.cpp:210
+#: ../src/richtext/richtextstyledlg.cpp:212
 msgid "The style preview."
 msgstr "Aperçu des styles."
 
-#: ../src/msw/ole/automtn.cpp:680
+#: ../src/msw/ole/automtn.cpp:671
 msgid "The system cannot find the file specified."
 msgstr "Le système ne peut pas trouver le fichier spécifié."
 
@@ -7060,7 +7225,7 @@ msgstr "La position du taquet de tabulation."
 msgid "The tab positions."
 msgstr "La position des taquets de tabulation."
 
-#: ../src/richtext/richtextctrl.cpp:3098
+#: ../src/richtext/richtextctrl.cpp:3099
 msgid "The text couldn't be saved."
 msgstr "Le texte n'a pas pu être enregistré."
 
@@ -7081,7 +7246,7 @@ msgstr "La taille de l'espacement supérieur."
 msgid "The top position."
 msgstr "La position supérieure."
 
-#: ../src/common/cmdline.cpp:1232
+#: ../src/common/cmdline.cpp:1228
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "La valeur de l'option « %s » doit être précisée."
@@ -7091,7 +7256,7 @@ msgstr "La valeur de l'option « %s » doit être précisée."
 msgid "The value of the corner radius."
 msgstr "La valeur du rayon de courbure des coins."
 
-#: ../src/msw/dialup.cpp:433
+#: ../src/msw/dialup.cpp:427
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -7105,14 +7270,14 @@ msgstr ""
 msgid "The vertical offset."
 msgstr "Le décalage vertical."
 
-#: ../src/richtext/richtextprint.cpp:619 ../src/html/htmprint.cpp:745
+#: ../src/html/htmprint.cpp:749 ../src/richtext/richtextprint.cpp:615
 msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr ""
 "Un problème est apparu lors de la mise en page : la configuration d'une "
 "imprimante par défaut peut être nécessaire."
 
-#: ../src/html/htmprint.cpp:255
+#: ../src/html/htmprint.cpp:267
 msgid ""
 "This document doesn't fit on the page horizontally and will be truncated "
 "when it is printed."
@@ -7120,16 +7285,16 @@ msgstr ""
 "Ce document ne tient pas sur la page horizontalement et sera tronqué lors de "
 "l'impression."
 
-#: ../src/common/image.cpp:2854
+#: ../src/common/image.cpp:2963
 #, c-format
 msgid "This is not a %s."
 msgstr "Ceci n'est pas un %s."
 
-#: ../src/common/wincmn.cpp:1653
+#: ../src/common/wincmn.cpp:1654
 msgid "This platform does not support background transparency."
 msgstr "Cette plateforme ne supporte pas la transparence d'arrière plan."
 
-#: ../src/gtk/window.cpp:4660
+#: ../src/gtk/window.cpp:5664
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
@@ -7137,7 +7302,15 @@ msgstr ""
 "Ce programme a été compilé avec une version trop ancienne de GTK+, "
 "recompiler avec GTK+ 2.12 ou plus récent."
 
-#: ../src/msw/thread.cpp:1240
+#: ../src/gtk/glcanvas.cpp:176
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/msw/thread.cpp:1246
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -7145,13 +7318,13 @@ msgstr ""
 "Échec de l'initialisation du module du processus : enregistrement impossible "
 "de la valeur dans le stockage local des processus"
 
-#: ../src/unix/threadpsx.cpp:1794
+#: ../src/unix/threadpsx.cpp:1843
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 "Échec de l'initialisation du module du processus : échec de la création de "
 "la clé du processus"
 
-#: ../src/msw/thread.cpp:1228
+#: ../src/msw/thread.cpp:1234
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -7159,83 +7332,83 @@ msgstr ""
 "Échec de l'initialisation du module du processus : impossible d'allouer un "
 "index dans le stockage local des processus"
 
-#: ../src/unix/threadpsx.cpp:1043
+#: ../src/unix/threadpsx.cpp:1061
 msgid "Thread priority setting is ignored."
 msgstr "La priorité donnée au processus est ignorée."
 
-#: ../src/msw/mdi.cpp:176
+#: ../src/msw/mdi.cpp:171
 msgid "Tile &Horizontally"
 msgstr "Répartir &horizontalement"
 
-#: ../src/msw/mdi.cpp:177
+#: ../src/msw/mdi.cpp:172
 msgid "Tile &Vertically"
 msgstr "Répartir &verticalement"
 
-#: ../src/common/ftp.cpp:200
+#: ../src/common/ftp.cpp:197
 msgid "Timeout while waiting for FTP server to connect, try passive mode."
 msgstr ""
 "Temps dépassé lors de la connexion du serveur FTP, essai du mode passif."
 
-#: ../src/generic/tipdlg.cpp:201
+#: ../src/generic/tipdlg.cpp:198
 msgid "Tip of the Day"
 msgstr "Astuce du Jour"
 
-#: ../src/generic/tipdlg.cpp:140
+#: ../src/generic/tipdlg.cpp:137
 msgid "Tips not available, sorry!"
 msgstr "Astuces non disponibles, désolé !"
 
-#: ../src/generic/prntdlgg.cpp:242
+#: ../src/generic/prntdlgg.cpp:235
 msgid "To:"
 msgstr "À :"
 
-#: ../src/richtext/richtextbuffer.cpp:8363
+#: ../src/richtext/richtextbuffer.cpp:8361
 msgid "Too many EndStyle calls!"
 msgstr "Trop d'appels à EndStyle !"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:891
+#: ../src/propgrid/advprops.cpp:792
 msgid "Tooltip"
 msgstr "Infobulle"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:892
+#: ../src/propgrid/advprops.cpp:793
 msgid "TooltipText"
 msgstr "InfobulleTexte"
 
-#: ../src/richtext/richtextsizepage.cpp:286
-#: ../src/richtext/richtextsizepage.cpp:290 ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197 ../src/richtext/richtextsizepage.cpp:286
+#: ../src/richtext/richtextsizepage.cpp:290
 msgid "Top"
 msgstr "Haut"
 
-#: ../src/generic/prntdlgg.cpp:881
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Top margin (mm):"
 msgstr "Marge de haut de page (mm) :"
 
-#: ../src/generic/aboutdlgg.cpp:79
+#: ../src/generic/aboutdlgg.cpp:76
 msgid "Translations by "
 msgstr "Traductions par "
 
-#: ../src/generic/aboutdlgg.cpp:188
+#: ../src/generic/aboutdlgg.cpp:185
 msgid "Translators"
 msgstr "Traducteurs"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:211
+#: ../src/propgrid/propgrid.cpp:192
 msgid "True"
 msgstr "Vrai"
 
-#: ../src/common/fs_mem.cpp:227
+#: ../src/common/fs_mem.cpp:222
 #, c-format
 msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
 msgstr ""
 "Tentative de suppression du fichier « %s » de la mémoire VFS, mais il n'est "
 "pas chargé !"
 
-#: ../src/common/fmapbase.cpp:156
+#: ../src/common/fmapbase.cpp:153
 msgid "Turkish (ISO-8859-9)"
 msgstr "Turc (ISO-8859-9)"
 
-#: ../src/generic/filectrlg.cpp:426
+#: ../src/generic/filectrlg.cpp:422
 msgid "Type"
 msgstr "Type"
 
@@ -7249,17 +7422,17 @@ msgstr "Taper le nom d'une police de caractères."
 msgid "Type a size in points."
 msgstr "Saisir une taille en points."
 
-#: ../src/msw/ole/automtn.cpp:676
+#: ../src/msw/ole/automtn.cpp:667
 #, c-format
 msgid "Type mismatch in argument %u."
 msgstr "Incompatibilité de type pour l'argument %u."
 
-#: ../src/common/xtixml.cpp:356 ../src/common/xtixml.cpp:509
-#: ../src/common/xtistrm.cpp:318
+#: ../src/common/xtixml.cpp:352 ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315
 msgid "Type must have enum - long conversion"
 msgstr "Le type doit être énumérable - conversion longue"
 
-#: ../src/propgrid/propgridiface.cpp:401
+#: ../src/propgrid/propgridiface.cpp:385
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
@@ -7268,19 +7441,19 @@ msgstr ""
 "Échec du type d'operation « %s » : la propriété désignée par « %s » est du "
 "type « %s », et NON « %s »."
 
-#: ../src/common/paper.cpp:133
+#: ../src/common/paper.cpp:130
 msgid "US Std Fanfold, 14 7/8 x 11 in"
 msgstr "Standard US en accordéon (14,875 x 11 pouces)"
 
-#: ../src/common/fmapbase.cpp:196
+#: ../src/common/fmapbase.cpp:193
 msgid "US-ASCII"
 msgstr "US-ASCII"
 
-#: ../src/unix/fswatcher_inotify.cpp:109
+#: ../src/unix/fswatcher_inotify.cpp:106
 msgid "Unable to add inotify watch"
 msgstr "Impossible d'ajouter un scrutateur inotify"
 
-#: ../src/unix/fswatcher_kqueue.cpp:136
+#: ../src/unix/fswatcher_kqueue.cpp:153
 msgid "Unable to add kqueue watch"
 msgstr "Impossible d'ajouter un scrutateur kqueue"
 
@@ -7293,7 +7466,7 @@ msgstr ""
 msgid "Unable to close I/O completion port handle"
 msgstr "Impossible de fermer le gestionnaire de port de terminaison d'E/S"
 
-#: ../src/unix/fswatcher_inotify.cpp:97
+#: ../src/unix/fswatcher_inotify.cpp:94
 msgid "Unable to close inotify instance"
 msgstr "Impossible de fermer une instance inotify"
 
@@ -7311,15 +7484,15 @@ msgstr "Impossible de fermer le gestionnaire pour « %s »"
 msgid "Unable to create I/O completion port"
 msgstr "Impossible de créer un port de terminaison d'E/S"
 
-#: ../src/msw/fswatcher.cpp:84
+#: ../src/msw/fswatcher.cpp:81
 msgid "Unable to create IOCP worker thread"
 msgstr "Impossible de créer un processus de travailleur (worker) IOCP"
 
-#: ../src/unix/fswatcher_inotify.cpp:74
+#: ../src/unix/fswatcher_inotify.cpp:71
 msgid "Unable to create inotify instance"
 msgstr "Impossible de créer une instance inotify"
 
-#: ../src/unix/fswatcher_kqueue.cpp:97
+#: ../src/unix/fswatcher_kqueue.cpp:114
 msgid "Unable to create kqueue instance"
 msgstr "Impossible de créer une instance kqueue"
 
@@ -7327,11 +7500,11 @@ msgstr "Impossible de créer une instance kqueue"
 msgid "Unable to dequeue completion packet"
 msgstr "Impossible d'extraire de la file d'attente le paquet de terminaison"
 
-#: ../src/unix/fswatcher_kqueue.cpp:185
+#: ../src/unix/fswatcher_kqueue.cpp:202
 msgid "Unable to get events from kqueue"
 msgstr "Impossible d'obtenir les évènements depuis kqueue"
 
-#: ../src/gtk/app.cpp:435
+#: ../src/gtk/app.cpp:431
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "Impossible d'initialiser GTK+, l'AFFICHAGE est-il correctement réglé ?"
 
@@ -7340,12 +7513,12 @@ msgstr "Impossible d'initialiser GTK+, l'AFFICHAGE est-il correctement réglé ?
 msgid "Unable to open path '%s'"
 msgstr "Impossible d'ouvrir le chemin « %s »"
 
-#: ../src/html/htmlwin.cpp:583
+#: ../src/html/htmlwin.cpp:586
 #, c-format
 msgid "Unable to open requested HTML document: %s"
 msgstr "Impossible d'ouvrir le document HTML demandé : %s"
 
-#: ../src/unix/sound.cpp:368
+#: ../src/unix/sound.cpp:365
 msgid "Unable to play sound asynchronously."
 msgstr "Impossible de jouer les sons de manière non synchrone."
 
@@ -7353,63 +7526,63 @@ msgstr "Impossible de jouer les sons de manière non synchrone."
 msgid "Unable to post completion status"
 msgstr "Impossible d'envoyer l'état de terminaison"
 
-#: ../src/unix/fswatcher_inotify.cpp:556
+#: ../src/unix/fswatcher_inotify.cpp:553
 msgid "Unable to read from inotify descriptor"
 msgstr "Impossible de lire depuis le descripteur inotify"
 
-#: ../src/unix/fswatcher_inotify.cpp:141
+#: ../src/unix/fswatcher_inotify.cpp:138
 #, c-format
 msgid "Unable to remove inotify watch %i"
 msgstr "Impossible de retirer un scrutateur inotify %i"
 
-#: ../src/unix/fswatcher_kqueue.cpp:153
+#: ../src/unix/fswatcher_kqueue.cpp:170
 msgid "Unable to remove kqueue watch"
 msgstr "Impossible de retirer un scrutateur kqueue"
 
-#: ../src/msw/fswatcher.cpp:168
+#: ../src/msw/fswatcher.cpp:165
 #, c-format
 msgid "Unable to set up watch for '%s'"
 msgstr "Impossible d'établir un scrutateur pour « %s »"
 
-#: ../src/msw/fswatcher.cpp:91
+#: ../src/msw/fswatcher.cpp:88
 msgid "Unable to start IOCP worker thread"
 msgstr "Impossible de démarrer le processus de travailleur (worker) IOCP"
 
-#: ../src/common/stockitem.cpp:201
+#: ../src/common/stockitem.cpp:198
 msgid "Undelete"
 msgstr "Rétablir"
 
-#: ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199
 msgid "Underline"
 msgstr "Souligner"
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/richtext/richtextfontpage.cpp:359 ../src/osx/carbon/fontdlg.cpp:370
-#: ../src/propgrid/advprops.cpp:690
+#: ../src/osx/carbon/fontdlg.cpp:367 ../src/propgrid/advprops.cpp:600
+#: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Souligné"
 
-#: ../src/common/stockitem.cpp:203 ../src/stc/stc_i18n.cpp:15
+#: ../src/common/stockitem.cpp:200 ../src/stc/stc_i18n.cpp:15
 msgid "Undo"
 msgstr "Annuler"
 
-#: ../src/common/stockitem.cpp:265
+#: ../src/common/stockitem.cpp:263
 msgid "Undo last action"
 msgstr "Annuler la dernière action"
 
-#: ../src/common/cmdline.cpp:1029
+#: ../src/common/cmdline.cpp:1025
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Caractères non attendus suivant l'option « %s »."
 
-#: ../src/unix/fswatcher_inotify.cpp:274
+#: ../src/unix/fswatcher_inotify.cpp:271
 #, c-format
 msgid "Unexpected event for \"%s\": no matching watch descriptor."
 msgstr ""
 "Évènement inattendu pour « %s » : pas de descripteur de surveillance "
 "correspondant."
 
-#: ../src/common/cmdline.cpp:1195
+#: ../src/common/cmdline.cpp:1191
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Paramètre « %s » inattendu"
@@ -7418,49 +7591,49 @@ msgstr "Paramètre « %s » inattendu"
 msgid "Unexpectedly new I/O completion port was created"
 msgstr "Un nouveau port de terminaison d'E/S a été créé de manière inopinée"
 
-#: ../src/msw/fswatcher.cpp:70
+#: ../src/msw/fswatcher.cpp:67
 msgid "Ungraceful worker thread termination"
 msgstr "Fin inopinée du processus de travailleur (worker)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:460
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:456
+#: ../src/richtext/richtextsymboldlg.cpp:457
+#: ../src/richtext/richtextsymboldlg.cpp:458
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../src/common/fmapbase.cpp:185 ../src/common/fmapbase.cpp:191
+#: ../src/common/fmapbase.cpp:182 ../src/common/fmapbase.cpp:188
 msgid "Unicode 16 bit (UTF-16)"
 msgstr "Unicode 16 bit (UTF-16)"
 
-#: ../src/common/fmapbase.cpp:190
+#: ../src/common/fmapbase.cpp:187
 msgid "Unicode 16 bit Big Endian (UTF-16BE)"
 msgstr "Unicode 16 bit gros-boutiste (UTF-16BE)"
 
-#: ../src/common/fmapbase.cpp:186
+#: ../src/common/fmapbase.cpp:183
 msgid "Unicode 16 bit Little Endian (UTF-16LE)"
 msgstr "Unicode 16 bit petit-boutiste (UTF-16LE)"
 
-#: ../src/common/fmapbase.cpp:187 ../src/common/fmapbase.cpp:193
+#: ../src/common/fmapbase.cpp:184 ../src/common/fmapbase.cpp:190
 msgid "Unicode 32 bit (UTF-32)"
 msgstr "Unicode 32 bit (UTF-32)"
 
-#: ../src/common/fmapbase.cpp:192
+#: ../src/common/fmapbase.cpp:189
 msgid "Unicode 32 bit Big Endian (UTF-32BE)"
 msgstr "Unicode 32 bit gros-boutiste (UTF-32BE)"
 
-#: ../src/common/fmapbase.cpp:188
+#: ../src/common/fmapbase.cpp:185
 msgid "Unicode 32 bit Little Endian (UTF-32LE)"
 msgstr "Unicode 32 bit petit-boutiste (UTF-8)"
 
-#: ../src/common/fmapbase.cpp:182
+#: ../src/common/fmapbase.cpp:179
 msgid "Unicode 7 bit (UTF-7)"
 msgstr "Unicode 7 bit (UTF-7)"
 
-#: ../src/common/fmapbase.cpp:183
+#: ../src/common/fmapbase.cpp:180
 msgid "Unicode 8 bit (UTF-8)"
 msgstr "Unicode 8 bit (UTF-8)"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "Unindent"
 msgstr "Désindenter"
 
@@ -7610,97 +7783,102 @@ msgstr "Unités pour la position supérieure."
 msgid "Units for this value."
 msgstr "Unités pour cette valeur."
 
-#: ../src/generic/progdlgg.cpp:353 ../src/generic/progdlgg.cpp:622
+#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
 msgid "Unknown"
 msgstr "Inconnu"
 
-#: ../src/msw/dde.cpp:1174
+#: ../src/msw/dde.cpp:1238
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Erreur DDE inconnue : %08x"
 
-#: ../src/common/xtistrm.cpp:410
+#: ../src/common/xtistrm.cpp:407
 msgid "Unknown Object passed to GetObjectClassInfo"
 msgstr "Objet inconnu indiqué à GetObjectClassInfo"
 
-#: ../src/common/imagpng.cpp:366
+#: ../src/common/imagpng.cpp:383
 #, c-format
 msgid "Unknown PNG resolution unit %d"
 msgstr "Unité %d de résolution PNG inconnue"
 
-#: ../src/common/xtixml.cpp:327
+#: ../src/common/xtixml.cpp:323
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Propriété « %s » inconnue"
 
-#: ../src/common/imagtiff.cpp:529
+#: ../src/common/imagtiff.cpp:526
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "Unité %d de résolution TIFF inconnue et ignorée"
 
-#: ../src/unix/dlunix.cpp:160
+#: ../src/propgrid/props.cpp:155
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/unix/dlunix.cpp:118
 msgid "Unknown dynamic library error"
 msgstr "Erreur de bibliothèque dynamique inconnue"
 
-#: ../src/common/fmapbase.cpp:810
+#: ../src/common/fmapbase.cpp:806
 #, c-format
 msgid "Unknown encoding (%d)"
 msgstr "Codage inconnu (%d)"
 
-#: ../src/msw/ole/automtn.cpp:688
+#: ../src/msw/ole/automtn.cpp:679
 #, c-format
 msgid "Unknown error %08x"
 msgstr "Erreur inconnue %08x"
 
-#: ../src/msw/ole/automtn.cpp:647
+#: ../src/msw/ole/automtn.cpp:638
 msgid "Unknown exception"
 msgstr "Exception inconnue"
 
-#: ../src/common/image.cpp:2839
+#: ../src/common/image.cpp:2942
 msgid "Unknown image data format."
 msgstr "Format de données d'image inconnu."
 
-#: ../src/common/cmdline.cpp:914
+#: ../src/common/cmdline.cpp:910
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Option longue « %s » inconnue"
 
-#: ../src/msw/ole/automtn.cpp:631
+#: ../src/msw/ole/automtn.cpp:622
 msgid "Unknown name or named argument."
 msgstr "Nom ou argument nommé inconnu."
 
-#: ../src/common/cmdline.cpp:929 ../src/common/cmdline.cpp:951
+#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Option « %s » inconnue"
 
-#: ../src/common/mimecmn.cpp:225
+#: ../src/common/mimecmn.cpp:221
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "Symbole « { » non assorti dans une entrée pour le type mime %s."
 
-#: ../src/common/cmdproc.cpp:262 ../src/common/cmdproc.cpp:288
-#: ../src/common/cmdproc.cpp:308
+#: ../src/common/cmdproc.cpp:255 ../src/common/cmdproc.cpp:281
+#: ../src/common/cmdproc.cpp:301
 msgid "Unnamed command"
 msgstr "Commande sans nom"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:413
+#: ../src/propgrid/propgrid.cpp:392
 msgid "Unspecified"
 msgstr "Non spécifié"
 
-#: ../src/msw/clipbrd.cpp:311
+#: ../src/msw/clipbrd.cpp:325
 msgid "Unsupported clipboard format."
 msgstr "Format de presse-papiers non reconnu."
 
-#: ../src/common/appcmn.cpp:256
+#: ../src/common/appcmn.cpp:277
 #, c-format
 msgid "Unsupported theme '%s'."
 msgstr "Thème « %s » non reconnu."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:205
-#: ../src/common/accelcmn.cpp:63
+#: ../src/common/stockitem.cpp:202 ../src/common/accelcmn.cpp:60
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Up"
 msgstr "Haut"
 
@@ -7714,7 +7892,7 @@ msgstr "Lettres majuscules"
 msgid "Upper case roman numerals"
 msgstr "Chiffres romains majuscules"
 
-#: ../src/common/cmdline.cpp:1326
+#: ../src/common/cmdline.cpp:1322
 #, c-format
 msgid "Usage: %s"
 msgstr "Utilisation : %s"
@@ -7723,38 +7901,47 @@ msgstr "Utilisation : %s"
 msgid "Use &shadow"
 msgstr "Utiliser une o&mbre"
 
-#: ../src/richtext/richtextindentspage.cpp:169
-#: ../src/richtext/richtextindentspage.cpp:171
 #: ../src/richtext/richtextliststylepage.cpp:358
 #: ../src/richtext/richtextliststylepage.cpp:360
+#: ../src/richtext/richtextindentspage.cpp:169
+#: ../src/richtext/richtextindentspage.cpp:171
 msgid "Use the current alignment setting."
 msgstr "Utiliser les réglages courants d'alignement."
 
-#: ../src/common/valtext.cpp:179
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/gtk/font.cpp:552
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/common/valtext.cpp:142
 msgid "Validation conflict"
 msgstr "Conflit de validation"
 
-#: ../src/propgrid/manager.cpp:238
+#: ../src/propgrid/manager.cpp:224
 msgid "Value"
 msgstr "Valeur"
 
-#: ../src/propgrid/props.cpp:386 ../src/propgrid/props.cpp:500
+#: ../src/propgrid/props.cpp:309
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "La valeur doit être %s ou plus."
 
-#: ../src/propgrid/props.cpp:417 ../src/propgrid/props.cpp:531
+#: ../src/propgrid/props.cpp:336
 #, c-format
 msgid "Value must be %s or less."
 msgstr "La valeur doit être %s ou moins."
 
-#: ../src/propgrid/props.cpp:393 ../src/propgrid/props.cpp:424
-#: ../src/propgrid/props.cpp:507 ../src/propgrid/props.cpp:538
+#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "La valeur doit être entre %s et %s."
 
-#: ../src/generic/aboutdlgg.cpp:128
+#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Version "
 
@@ -7763,25 +7950,32 @@ msgstr "Version "
 msgid "Vertical alignment."
 msgstr "Alignement vertical."
 
-#: ../src/generic/filedlgg.cpp:202
+#: ../src/generic/filedlgg.cpp:199
 msgid "View files as a detailed view"
 msgstr "Voir les fichiers en vue détaillée"
 
-#: ../src/generic/filedlgg.cpp:200
+#: ../src/generic/filedlgg.cpp:197
 msgid "View files as a list view"
 msgstr "Voir les fichiers en liste"
 
-#: ../src/common/docview.cpp:1970
+#: ../src/common/docview.cpp:1975
 msgid "Views"
 msgstr "Vues"
 
+#: ../src/gtk/app.cpp:348
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1777
+#: ../src/propgrid/advprops.cpp:1678
 msgid "Wait"
 msgstr "Attente"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1779
+#: ../src/propgrid/advprops.cpp:1680
 msgid "Wait Arrow"
 msgstr "Flèche d'attente"
 
@@ -7790,241 +7984,235 @@ msgstr "Flèche d'attente"
 msgid "Waiting for IO on epoll descriptor %d failed"
 msgstr "Échec de l'attente de l'E/S sur le descriptoeur epoll %d"
 
-#: ../src/common/log.cpp:223
+#: ../src/common/log.cpp:241
 msgid "Warning: "
 msgstr "Avertissement : "
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1778
+#: ../src/propgrid/advprops.cpp:1679
 msgid "Watch"
 msgstr "Scrutateur"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:685
+#: ../src/propgrid/advprops.cpp:595
 msgid "Weight"
 msgstr "Poids"
 
-#: ../src/common/fmapbase.cpp:148
+#: ../src/common/fmapbase.cpp:145
 msgid "Western European (ISO-8859-1)"
 msgstr "Europe de l'Ouest (ISO-8859-1)"
 
-#: ../src/common/fmapbase.cpp:162
+#: ../src/common/fmapbase.cpp:159
 msgid "Western European with Euro (ISO-8859-15)"
 msgstr "Europe de l'Ouest avec l'Euro (ISO-8859-15)"
 
-#: ../src/generic/fontdlgg.cpp:446 ../src/generic/fontdlgg.cpp:448
+#: ../src/generic/fontdlgg.cpp:443 ../src/generic/fontdlgg.cpp:445
 msgid "Whether the font is underlined."
 msgstr "Si la police est soulignée."
 
-#: ../src/propgrid/advprops.cpp:1611
+#: ../src/propgrid/advprops.cpp:1517
 msgid "White"
 msgstr "Blanc"
 
-#: ../src/generic/fdrepdlg.cpp:144
+#: ../src/generic/fdrepdlg.cpp:141
 msgid "Whole word"
 msgstr "Mot complet"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:532
 msgid "Whole words only"
 msgstr "Mots complets seulement"
 
-#: ../src/univ/themes/win32.cpp:1102
+#: ../src/univ/themes/win32.cpp:1099
 msgid "Win32 theme"
 msgstr "Thème Win32"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:893
+#: ../src/propgrid/advprops.cpp:794
 msgid "Window"
 msgstr "Fenêtre"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:894
+#: ../src/propgrid/advprops.cpp:795
 msgid "WindowFrame"
 msgstr "WindowFrame"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:895
+#: ../src/propgrid/advprops.cpp:796
 msgid "WindowText"
 msgstr "WindowText"
 
-#: ../src/common/fmapbase.cpp:177
+#: ../src/common/fmapbase.cpp:174
 msgid "Windows Arabic (CP 1256)"
 msgstr "Arabe limité à Windows (CP 1256)"
 
-#: ../src/common/fmapbase.cpp:178
+#: ../src/common/fmapbase.cpp:175
 msgid "Windows Baltic (CP 1257)"
 msgstr "Balte limité à Windows (CP 1257)"
 
-#: ../src/common/fmapbase.cpp:171
+#: ../src/common/fmapbase.cpp:168
 msgid "Windows Central European (CP 1250)"
 msgstr "Européen central limité à Windows (CP 1255)"
 
-#: ../src/common/fmapbase.cpp:168
+#: ../src/common/fmapbase.cpp:165
 msgid "Windows Chinese Simplified (CP 936) or GB-2312"
 msgstr "Chinois Simplifié Windows (CP 936) ou GB-2312"
 
-#: ../src/common/fmapbase.cpp:170
+#: ../src/common/fmapbase.cpp:167
 msgid "Windows Chinese Traditional (CP 950) or Big-5"
 msgstr "Chinois Traditionnel Windows (CP 950) ou Big-5"
 
-#: ../src/common/fmapbase.cpp:172
+#: ../src/common/fmapbase.cpp:169
 msgid "Windows Cyrillic (CP 1251)"
 msgstr "Cyrillique limité à Windows (CP 1251)"
 
-#: ../src/common/fmapbase.cpp:174
+#: ../src/common/fmapbase.cpp:171
 msgid "Windows Greek (CP 1253)"
 msgstr "Grec limité à Windows (CP 1253)"
 
-#: ../src/common/fmapbase.cpp:176
+#: ../src/common/fmapbase.cpp:173
 msgid "Windows Hebrew (CP 1255)"
 msgstr "Hébreu limité à Windows (CP 1255)"
 
-#: ../src/common/fmapbase.cpp:167
+#: ../src/common/fmapbase.cpp:164
 msgid "Windows Japanese (CP 932) or Shift-JIS"
 msgstr "Japonais Windows (CP 932) ou Shift-JIS"
 
-#: ../src/common/fmapbase.cpp:180
+#: ../src/common/fmapbase.cpp:177
 msgid "Windows Johab (CP 1361)"
 msgstr "Johab Windows (CP 1361)"
 
-#: ../src/common/fmapbase.cpp:169
+#: ../src/common/fmapbase.cpp:166
 msgid "Windows Korean (CP 949)"
 msgstr "Coréen limité à Windows (CP 949)"
 
-#: ../src/common/fmapbase.cpp:166
+#: ../src/common/fmapbase.cpp:163
 msgid "Windows Thai (CP 874)"
 msgstr "Windows Thai (CP 874)"
 
-#: ../src/common/fmapbase.cpp:175
+#: ../src/common/fmapbase.cpp:172
 msgid "Windows Turkish (CP 1254)"
 msgstr "Turc limité à Windows (CP 1254)"
 
-#: ../src/common/fmapbase.cpp:179
+#: ../src/common/fmapbase.cpp:176
 msgid "Windows Vietnamese (CP 1258)"
 msgstr "Vietnamien Windows (CP 1258)"
 
-#: ../src/common/fmapbase.cpp:173
+#: ../src/common/fmapbase.cpp:170
 msgid "Windows Western European (CP 1252)"
 msgstr "Européen occidental limité à Windows (CP 1252 )"
 
-#: ../src/common/fmapbase.cpp:181
+#: ../src/common/fmapbase.cpp:178
 msgid "Windows/DOS OEM (CP 437)"
 msgstr "Windows/DOS OEM (CP 437)"
 
-#: ../src/common/fmapbase.cpp:165
+#: ../src/common/fmapbase.cpp:162
 msgid "Windows/DOS OEM Cyrillic (CP 866)"
 msgstr "Cyrillique OEM Windows/DOS (CP 866)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:111
+#: ../src/common/accelcmn.cpp:109
 msgid "Windows_Left"
 msgstr "Windows_Left"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:113
+#: ../src/common/accelcmn.cpp:111
 msgid "Windows_Menu"
 msgstr "Windows_Menu"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:112
+#: ../src/common/accelcmn.cpp:110
 msgid "Windows_Right"
 msgstr "Windows_Right"
 
-#: ../src/common/ffile.cpp:150
+#: ../src/common/ffile.cpp:149
 #, c-format
 msgid "Write error on file '%s'"
 msgstr "Erreur d'écriture dans le fichier « %s »"
 
-#: ../src/xml/xml.cpp:914
+#: ../src/xml/xml.cpp:925
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "Erreur d'analyse XML : « %s » à la ligne %d"
 
-#: ../src/common/xpmdecod.cpp:796
+#: ../src/common/xpmdecod.cpp:794
 msgid "XPM: Malformed pixel data!"
 msgstr "XPM : données de pixel malformées !"
 
-#: ../src/common/xpmdecod.cpp:705
+#: ../src/common/xpmdecod.cpp:702
 #, c-format
 msgid "XPM: incorrect colour description in line %d"
 msgstr "XPM : définition de couleur incorrecte à la ligne %d"
 
-#: ../src/common/xpmdecod.cpp:680
+#: ../src/common/xpmdecod.cpp:677
 msgid "XPM: incorrect header format!"
 msgstr "XPM : format de l'entête incorrect !"
 
-#: ../src/common/xpmdecod.cpp:716 ../src/common/xpmdecod.cpp:725
+#: ../src/common/xpmdecod.cpp:714 ../src/common/xpmdecod.cpp:723
 #, c-format
 msgid "XPM: malformed colour definition '%s' at line %d!"
 msgstr "XPM : définition de couleur « %s » malformée à la ligne %d !"
 
-#: ../src/common/xpmdecod.cpp:755
+#: ../src/common/xpmdecod.cpp:753
 msgid "XPM: no colors left to use for mask!"
 msgstr "XPM : pas de couleur restant à utiliser comme masque !"
 
-#: ../src/common/xpmdecod.cpp:782
+#: ../src/common/xpmdecod.cpp:780
 #, c-format
 msgid "XPM: truncated image data at line %d!"
 msgstr "XPM : les données de l'image sont tronquées à la ligne %d !"
 
-#: ../src/propgrid/advprops.cpp:1610
+#: ../src/propgrid/advprops.cpp:1516
 msgid "Yellow"
 msgstr "Jaune"
 
-#: ../include/wx/msgdlg.h:276 ../src/common/stockitem.cpp:206
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:203
 #: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Oui"
 
-#: ../src/osx/carbon/overlay.cpp:155
-msgid "You cannot Clear an overlay that is not inited"
-msgstr ""
-"Il n'est pas possible d'effectuer un effacement sur une superposition "
-"(overlay) avant qu'elle ne soit initialisée"
-
-#: ../src/osx/carbon/overlay.cpp:107 ../src/dfb/overlay.cpp:61
-msgid "You cannot Init an overlay twice"
-msgstr ""
-"Il n'est pas possible d'initialiser deux fois une superpopsition (overlay)"
-
-#: ../src/generic/dirdlgg.cpp:287
+#: ../src/generic/dirdlgg.cpp:284
 msgid "You cannot add a new directory to this section."
 msgstr "Il n'est pas possible d'ajouter un nouveau dossier à cette section."
 
-#: ../src/propgrid/propgrid.cpp:3299
+#: ../src/propgrid/propgrid.cpp:3276
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 "Une valeur incorrecte a été saisie. Presser ESC pour annuler l'édition."
 
-#: ../src/common/stockitem.cpp:209
+#: ../src/osx/cocoa/menu.mm:286
+#, fuzzy
+msgid "Zoom"
+msgstr "Zoom Avant"
+
+#: ../src/common/stockitem.cpp:206
 msgid "Zoom &In"
 msgstr "Zoom &avant"
 
-#: ../src/common/stockitem.cpp:210
+#: ../src/common/stockitem.cpp:207
 msgid "Zoom &Out"
 msgstr "Zoom a&rrière"
 
-#: ../src/common/stockitem.cpp:209 ../src/common/prntbase.cpp:1594
+#: ../src/common/stockitem.cpp:206 ../src/common/prntbase.cpp:1619
 msgid "Zoom In"
 msgstr "Zoom Avant"
 
-#: ../src/common/stockitem.cpp:210 ../src/common/prntbase.cpp:1580
+#: ../src/common/stockitem.cpp:207 ../src/common/prntbase.cpp:1605
 msgid "Zoom Out"
 msgstr "Zoom Arrière"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to &Fit"
 msgstr "Zoom a&justé"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to Fit"
 msgstr "Zoom Ajusté"
 
-#: ../src/msw/dde.cpp:1141
+#: ../src/msw/dde.cpp:1205
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "une application DDEML a créé une situation de concurrence prolongée."
 
-#: ../src/msw/dde.cpp:1129
+#: ../src/msw/dde.cpp:1193
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -8035,39 +8223,39 @@ msgstr ""
 "DdeInitialize, ou un identifiant non valable a été fourni à la fonction\n"
 "DDEML."
 
-#: ../src/msw/dde.cpp:1147
+#: ../src/msw/dde.cpp:1211
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "une tentative d'un client pour établir une conversation a échoué."
 
-#: ../src/msw/dde.cpp:1144
+#: ../src/msw/dde.cpp:1208
 msgid "a memory allocation failed."
 msgstr "une allocation de mémoire a échoué."
 
-#: ../src/msw/dde.cpp:1138
+#: ../src/msw/dde.cpp:1202
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "un paramètre n'a pas pu être validé par la DDEML."
 
-#: ../src/msw/dde.cpp:1120
+#: ../src/msw/dde.cpp:1184
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "une demande de transaction synchrone d'instructions a expiré."
 
-#: ../src/msw/dde.cpp:1126
+#: ../src/msw/dde.cpp:1190
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "une demande de transaction synchrone de données a expiré."
 
-#: ../src/msw/dde.cpp:1135
+#: ../src/msw/dde.cpp:1199
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "une demande de transaction synchrone d'exécutions a expiré."
 
-#: ../src/msw/dde.cpp:1153
+#: ../src/msw/dde.cpp:1217
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "une demande de transaction synchrone de stockage a expiré."
 
-#: ../src/msw/dde.cpp:1168
+#: ../src/msw/dde.cpp:1232
 msgid "a request to end an advise transaction has timed out."
 msgstr "une demande pour terminer une transaction d'instructions a expiré."
 
-#: ../src/msw/dde.cpp:1162
+#: ../src/msw/dde.cpp:1226
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -8076,15 +8264,15 @@ msgstr ""
 "une transaction a été tentée du côté serveur lors d'une conversation déjà\n"
 "terminée par le client, ou le serveur a achevé la transaction avant la fin."
 
-#: ../src/msw/dde.cpp:1150
+#: ../src/msw/dde.cpp:1214
 msgid "a transaction failed."
 msgstr "une transaction a échoué."
 
-#: ../src/common/accelcmn.cpp:189
+#: ../src/common/accelcmn.cpp:188
 msgid "alt"
 msgstr "alt"
 
-#: ../src/msw/dde.cpp:1132
+#: ../src/msw/dde.cpp:1196
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -8095,15 +8283,15 @@ msgstr ""
 "d'effectuer une transaction DDE, ou une application initialisée en tant\n"
 "que APPCMD_CLIENTONLY a tenté d'effectuer des transactions serveur."
 
-#: ../src/msw/dde.cpp:1156
+#: ../src/msw/dde.cpp:1220
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "un appel interne à la fonction PostMessage a échoué. "
 
-#: ../src/msw/dde.cpp:1165
+#: ../src/msw/dde.cpp:1229
 msgid "an internal error has occurred in the DDEML."
 msgstr "une erreur interne s'est produite dans le DDEML."
 
-#: ../src/msw/dde.cpp:1171
+#: ../src/msw/dde.cpp:1235
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -8113,56 +8301,56 @@ msgstr ""
 "Quand l'application sort d'un rappel XTYP_XACT_COMPLETE, l'identifiant de\n"
 "transaction pour ce rappel n'est plus valable."
 
-#: ../src/common/zipstrm.cpp:1483
+#: ../src/common/zipstrm.cpp:1522
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "suppose qu'il s'agit d'un zip recombiné"
 
-#: ../src/common/fileconf.cpp:1847
+#: ../src/common/fileconf.cpp:1849
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "tentative de modifier la touche non configurable « %s » ignorée."
 
-#: ../src/html/chm.cpp:329
+#: ../src/html/chm.cpp:326
 msgid "bad arguments to library function"
 msgstr "mauvais paramètres à la fonction de bibliothèque"
 
-#: ../src/html/chm.cpp:341
+#: ../src/html/chm.cpp:338
 msgid "bad signature"
 msgstr "mauvaise signature"
 
-#: ../src/common/zipstrm.cpp:1918
+#: ../src/common/zipstrm.cpp:1988
 msgid "bad zipfile offset to entry"
 msgstr "mauvais décalage de fichier zip dans l'entrée"
 
-#: ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400
 msgid "binary"
 msgstr "binaire"
 
-#: ../src/common/fontcmn.cpp:996
+#: ../src/common/fontcmn.cpp:1195
 msgid "bold"
 msgstr "gras"
 
-#: ../src/msw/utils.cpp:1144
+#: ../src/msw/utils.cpp:1135
 #, c-format
 msgid "build %lu"
 msgstr "version %lu"
 
-#: ../src/common/ffile.cpp:75
+#: ../src/common/ffile.cpp:73
 #, c-format
 msgid "can't close file '%s'"
 msgstr "impossible de fermer le fichier « %s »"
 
-#: ../src/common/file.cpp:245
+#: ../src/common/file.cpp:242
 #, c-format
 msgid "can't close file descriptor %d"
 msgstr "impossible de fermer le descripteur de fichier %d"
 
-#: ../src/common/file.cpp:586
+#: ../src/common/ffile.cpp:382 ../src/common/file.cpp:613
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "impossible d'appliquer les changements au fichier « %s »"
 
-#: ../src/common/file.cpp:178
+#: ../src/common/file.cpp:175
 #, c-format
 msgid "can't create file '%s'"
 msgstr "impossible de créer le fichier « %s »"
@@ -8172,57 +8360,57 @@ msgstr "impossible de créer le fichier « %s »"
 msgid "can't delete user configuration file '%s'"
 msgstr "impossible d'effacer le fichier de configuration utilisateur « %s »"
 
-#: ../src/common/file.cpp:495
+#: ../src/common/file.cpp:522
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr ""
 "impossible de déterminer si la fin du fichier est atteinte dans le "
 "descripteur %d"
 
-#: ../src/common/zipstrm.cpp:1692
+#: ../src/common/zipstrm.cpp:1747
 msgid "can't find central directory in zip"
 msgstr "impossible de trouver le répertoire principale dans le zip"
 
-#: ../src/common/file.cpp:465
+#: ../src/common/file.cpp:492
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr ""
 "impossible de trouver la taille du fichier dans le descripteur de fichier %d"
 
-#: ../src/msw/utils.cpp:341
+#: ../src/msw/utils.cpp:336
 msgid "can't find user's HOME, using current directory."
 msgstr ""
 "impossible de trouver le répertoire HOME de l'utilisateur - utilisation du "
 "répertoire courant."
 
-#: ../src/common/file.cpp:366
+#: ../src/common/file.cpp:407
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr ""
 "impossible de forcer l'écriture sur disque du descripteur de fichier %d"
 
-#: ../src/common/file.cpp:422
+#: ../src/common/file.cpp:463
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr ""
 "impossible de trouver la position de recherche sur le descripteur de fichier "
 "%d"
 
-#: ../src/common/fontmap.cpp:325
+#: ../src/common/fontmap.cpp:322
 msgid "can't load any font, aborting"
 msgstr "impossible de charger une police de caractères - abandon"
 
-#: ../src/common/file.cpp:231 ../src/common/ffile.cpp:59
+#: ../src/common/ffile.cpp:57 ../src/common/file.cpp:228
 #, c-format
 msgid "can't open file '%s'"
 msgstr "impossible d'ouvrir le fichier « %s »"
 
-#: ../src/common/fileconf.cpp:320
+#: ../src/common/fileconf.cpp:314
 #, c-format
 msgid "can't open global configuration file '%s'."
 msgstr "impossible d'ouvrir le fichier de configuration global « %s »."
 
-#: ../src/common/fileconf.cpp:336
+#: ../src/common/fileconf.cpp:330
 #, c-format
 msgid "can't open user configuration file '%s'."
 msgstr "impossible d'ouvrir le fichier de configuration utilisateur « %s »."
@@ -8231,40 +8419,40 @@ msgstr "impossible d'ouvrir le fichier de configuration utilisateur « %s »."
 msgid "can't open user configuration file."
 msgstr "impossible d'ouvrir le fichier de configuration utilisateur."
 
-#: ../src/common/zipstrm.cpp:579
+#: ../src/common/zipstrm.cpp:572
 msgid "can't re-initialize zlib deflate stream"
 msgstr "impossible de réinitialiser le flux de déchargement de zlib"
 
-#: ../src/common/zipstrm.cpp:604
+#: ../src/common/zipstrm.cpp:597
 msgid "can't re-initialize zlib inflate stream"
 msgstr "impossible de réinitialiser le flux de chargement de zlib"
 
-#: ../src/common/file.cpp:304
+#: ../src/common/file.cpp:345
 #, c-format
 msgid "can't read from file descriptor %d"
 msgstr "impossible de lire le descripteur de fichier %d"
 
-#: ../src/common/file.cpp:581
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:608
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "impossible de supprimer le fichier « %s »"
 
-#: ../src/common/file.cpp:598
+#: ../src/common/ffile.cpp:394 ../src/common/file.cpp:625
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "impossible de supprimer le fichier temporaire « %s »"
 
-#: ../src/common/file.cpp:408
+#: ../src/common/file.cpp:449
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "recherche impossible sur le descripteur de fichier %d"
 
-#: ../src/common/textfile.cpp:273
+#: ../src/common/textfile.cpp:161
 #, c-format
 msgid "can't write buffer '%s' to disk."
 msgstr "impossible d'écrire le tampon « %s » sur le disque."
 
-#: ../src/common/file.cpp:323
+#: ../src/common/file.cpp:364
 #, c-format
 msgid "can't write to file descriptor %d"
 msgstr "impossible d'écrire dans le descripteur de fichier %d"
@@ -8274,23 +8462,29 @@ msgid "can't write user configuration file."
 msgstr "impossible d'écrire le fichier de configuration utilisateur."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:482 ../src/generic/datavgen.cpp:1261
+#: ../src/common/datavcmn.cpp:2064 ../src/generic/datavgen.cpp:1384
 msgid "checked"
 msgstr "coché"
 
-#: ../src/html/chm.cpp:345
+#: ../src/html/chm.cpp:342
 msgid "checksum error"
 msgstr "erreur de la somme de contrôle"
 
-#: ../src/common/tarstrm.cpp:820
+#: ../src/common/tarstrm.cpp:814
 msgid "checksum failure reading tar header block"
 msgstr ""
 "erreur de la somme de contrôle lors de la lecture du bloc d'entête de tar"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:226
-#: ../src/richtext/richtextbackgroundpage.cpp:249
-#: ../src/richtext/richtextbackgroundpage.cpp:289
-#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
 #: ../src/richtext/richtextborderspage.cpp:254
 #: ../src/richtext/richtextborderspage.cpp:288
 #: ../src/richtext/richtextborderspage.cpp:322
@@ -8308,104 +8502,127 @@ msgstr ""
 #: ../src/richtext/richtextmarginspage.cpp:340
 #: ../src/richtext/richtextmarginspage.cpp:363
 #: ../src/richtext/richtextmarginspage.cpp:388
-#: ../src/richtext/richtextsizepage.cpp:339
-#: ../src/richtext/richtextsizepage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:400
-#: ../src/richtext/richtextsizepage.cpp:427
-#: ../src/richtext/richtextsizepage.cpp:454
-#: ../src/richtext/richtextsizepage.cpp:481
-#: ../src/richtext/richtextsizepage.cpp:555
-#: ../src/richtext/richtextsizepage.cpp:590
-#: ../src/richtext/richtextsizepage.cpp:625
-#: ../src/richtext/richtextsizepage.cpp:660
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
 msgid "cm"
 msgstr "cm"
 
-#: ../src/html/chm.cpp:347
+#: ../src/html/chm.cpp:344
 msgid "compression error"
 msgstr "erreur de compression"
 
-#: ../src/common/regex.cpp:236
+#: ../src/common/regex.cpp:233
 msgid "conversion to 8-bit encoding failed"
 msgstr "échec de la conversion dans un codage 8 bits"
 
-#: ../src/common/accelcmn.cpp:187
+#: ../src/common/accelcmn.cpp:186
 msgid "ctrl"
 msgstr "ctrl"
 
-#: ../src/common/cmdline.cpp:1500
+#: ../src/common/cmdline.cpp:1496
 msgid "date"
 msgstr "date"
 
-#: ../src/html/chm.cpp:349
+#: ../src/html/chm.cpp:346
 msgid "decompression error"
 msgstr "erreur de décompression"
 
-#: ../src/richtext/richtextstyles.cpp:780 ../src/common/fmapbase.cpp:820
+#: ../src/common/fmapbase.cpp:816 ../src/richtext/richtextstyles.cpp:777
 msgid "default"
 msgstr "défaut"
 
-#: ../src/common/cmdline.cpp:1496
+#: ../src/common/cmdline.cpp:1492
 msgid "double"
 msgstr "double"
 
-#: ../src/common/debugrpt.cpp:538
+#: ../src/common/debugrpt.cpp:539
 msgid "dump of the process state (binary)"
 msgstr "décharger l'état du processus (binaire)"
 
-#: ../src/common/datetimefmt.cpp:1969
+#: ../src/common/datetimefmt.cpp:1992
 msgid "eighteenth"
 msgstr "dix-huitième"
 
-#: ../src/common/datetimefmt.cpp:1959
+#: ../src/common/datetimefmt.cpp:1982
 msgid "eighth"
 msgstr "huitième"
 
-#: ../src/common/datetimefmt.cpp:1962
+#: ../src/common/datetimefmt.cpp:1985
 msgid "eleventh"
 msgstr "onzième"
 
-#: ../src/common/fileconf.cpp:1833
+#: ../src/common/fileconf.cpp:1835
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "l'entrée « %s » apparaît plus d'une fois dans le groupe « %s »"
 
-#: ../src/html/chm.cpp:343
+#: ../src/html/chm.cpp:340
 msgid "error in data format"
 msgstr "erreur dans le format des données"
 
-#: ../src/html/chm.cpp:331
+#: ../src/html/chm.cpp:328
 msgid "error opening file"
 msgstr "erreur à l'ouverture du fichier"
 
-#: ../src/common/zipstrm.cpp:1778
+#: ../src/common/zipstrm.cpp:1836
 msgid "error reading zip central directory"
 msgstr "erreur à la lecture du répertoire principale du zip"
 
-#: ../src/common/zipstrm.cpp:1870
+#: ../src/common/zipstrm.cpp:1940
 msgid "error reading zip local header"
 msgstr "erreur à la lecture de l'en-tête local du zip"
 
-#: ../src/common/zipstrm.cpp:2531
+#: ../src/common/zipstrm.cpp:2615
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "erreur à l'écriture de l'entrée zip « %s » : mauvaise crc ou longueur"
 
-#: ../src/common/ffile.cpp:188
+#: ../src/common/zipstrm.cpp:2608
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "erreur à l'écriture de l'entrée zip « %s » : mauvaise crc ou longueur"
+
+#: ../src/common/fontcmn.cpp:1205
+#, fuzzy
+msgid "extrabold"
+msgstr "gras"
+
+#: ../src/common/fontcmn.cpp:1223
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1167
+#, fuzzy
+msgid "extralight"
+msgstr "léger"
+
+#: ../src/msw/webview_ie.cpp:1036
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "Échec de l'exécution de « %s »\n"
+
+#: ../src/common/ffile.cpp:187
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "échec de la mise à jour du fichier « %s »"
 
+#: ../src/msw/webview_ie.cpp:1045
+#, fuzzy
+msgid "failed to retrieve execution result"
+msgstr "Échec de la récupération du texte du message d'erreur RAS"
+
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1030
+#: ../src/generic/datavgen.cpp:1150
 msgid "false"
 msgstr "faux"
 
-#: ../src/common/datetimefmt.cpp:1966
+#: ../src/common/datetimefmt.cpp:1989
 msgid "fifteenth"
 msgstr "quinzième"
 
-#: ../src/common/datetimefmt.cpp:1956
+#: ../src/common/datetimefmt.cpp:1979
 msgid "fifth"
 msgstr "cinquième"
 
@@ -8438,131 +8655,150 @@ msgstr ""
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "fichier '%s' : caractère %c inattendu à la ligne %zu."
 
-#: ../src/richtext/richtextbuffer.cpp:8738
+#: ../src/richtext/richtextbuffer.cpp:8736
 msgid "files"
 msgstr "fichiers"
 
-#: ../src/common/datetimefmt.cpp:1952
+#: ../src/common/datetimefmt.cpp:1975
 msgid "first"
 msgstr "premier"
 
-#: ../src/html/helpwnd.cpp:1252
+#: ../src/html/helpwnd.cpp:1250
 msgid "font size"
 msgstr "taille de police"
 
-#: ../src/common/datetimefmt.cpp:1965
+#: ../src/common/datetimefmt.cpp:1988
 msgid "fourteenth"
 msgstr "quatorzième"
 
-#: ../src/common/datetimefmt.cpp:1955
+#: ../src/common/datetimefmt.cpp:1978
 msgid "fourth"
 msgstr "quatrième"
 
-#: ../src/common/appbase.cpp:783
+#: ../src/common/appbase.cpp:784
 msgid "generate verbose log messages"
 msgstr "créer des messages de journalisation verbeux"
 
-#: ../src/richtext/richtextbuffer.cpp:13138
-#: ../src/richtext/richtextbuffer.cpp:13248
+#: ../src/common/fontcmn.cpp:1215
+msgid "heavy"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:13133
+#: ../src/richtext/richtextbuffer.cpp:13243
 msgid "image"
 msgstr "image"
 
-#: ../src/common/tarstrm.cpp:796
+#: ../src/common/tarstrm.cpp:790
 msgid "incomplete header block in tar"
 msgstr "le bloc d'entête de tar est incomplet"
 
-#: ../src/common/xtixml.cpp:489
+#: ../src/common/xtixml.cpp:485
 msgid "incorrect event handler string, missing dot"
 msgstr "chaîne de gestion des événements non valable, point manquant"
 
-#: ../src/common/tarstrm.cpp:1381
+#: ../src/common/tarstrm.cpp:1375
 msgid "incorrect size given for tar entry"
 msgstr "la taille fournie pour l'entrée tar est incorrecte"
 
-#: ../src/common/tarstrm.cpp:993
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:987
 msgid "invalid data in extended tar header"
 msgstr "donnée incorrectes dans l'entête étendu de tar"
 
-#: ../src/generic/logg.cpp:1030
+#: ../src/generic/logg.cpp:1027
 msgid "invalid message box return value"
 msgstr "la boîte de message a renvoyé une valeur non valable"
 
-#: ../src/common/zipstrm.cpp:1647
+#: ../src/common/zipstrm.cpp:1688
 msgid "invalid zip file"
 msgstr "fichier zip non valable"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:1228
 msgid "italic"
 msgstr "italique"
 
-#: ../src/common/fontcmn.cpp:991
+#: ../src/common/webrequest_curl.cpp:374
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "La description de la colonne n'a pas pu être initialisée."
+
+#: ../src/common/fontcmn.cpp:1172
 msgid "light"
 msgstr "léger"
 
-#: ../src/common/intl.cpp:303
-#, c-format
-msgid "locale '%s' cannot be set."
-msgstr "la localisation « %s » ne peut pas être établie."
+#: ../src/common/fontcmn.cpp:1185
+msgid "medium"
+msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2125
+#: ../src/common/datetimefmt.cpp:2148
 msgid "midnight"
 msgstr "minuit"
 
-#: ../src/common/datetimefmt.cpp:1970
+#: ../src/common/datetimefmt.cpp:1993
 msgid "nineteenth"
 msgstr "dix-neuvième"
 
-#: ../src/common/datetimefmt.cpp:1960
+#: ../src/common/datetimefmt.cpp:1983
 msgid "ninth"
 msgstr "neuvième"
 
-#: ../src/msw/dde.cpp:1116
+#: ../src/msw/dde.cpp:1180
 msgid "no DDE error."
 msgstr "erreur - pas de DDE."
 
-#: ../src/html/chm.cpp:327
+#: ../src/html/chm.cpp:324
 msgid "no error"
 msgstr "aucune erreur"
 
-#: ../src/dfb/fontmgr.cpp:174
+#: ../src/dfb/fontmgr.cpp:171
 #, c-format
 msgid "no fonts found in %s, using builtin font"
 msgstr "aucune police trouvée dans %s, utilisation d'une police interne"
 
-#: ../src/html/helpdata.cpp:657
+#: ../src/html/helpdata.cpp:650
 msgid "noname"
 msgstr "pas de nom"
 
-#: ../src/common/datetimefmt.cpp:2124
+#: ../src/common/datetimefmt.cpp:2147
 msgid "noon"
 msgstr "midi"
 
-#: ../src/richtext/richtextstyles.cpp:779
+#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "normal"
 
-#: ../src/common/cmdline.cpp:1492
+#: ../src/common/cmdline.cpp:1488
 msgid "num"
 msgstr "num"
 
-#: ../src/common/xtixml.cpp:259
+#: ../src/common/accelcmn.cpp:194
+msgid "num "
+msgstr ""
+
+#: ../src/common/xtixml.cpp:255
 msgid "objects cannot have XML Text Nodes"
 msgstr "les objets ne peuvent pas avoir de noeuds texte XML"
 
-#: ../src/html/chm.cpp:339
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
 msgid "out of memory"
 msgstr "capacité mémoire dépassée"
 
-#: ../src/common/debugrpt.cpp:514
+#: ../src/common/debugrpt.cpp:515
 msgid "process context description"
 msgstr "description du contexte du processus"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:227
-#: ../src/richtext/richtextbackgroundpage.cpp:250
-#: ../src/richtext/richtextbackgroundpage.cpp:290
-#: ../src/richtext/richtextbackgroundpage.cpp:317
-#: ../src/richtext/richtextfontpage.cpp:177
-#: ../src/richtext/richtextfontpage.cpp:180
 #: ../src/richtext/richtextborderspage.cpp:255
 #: ../src/richtext/richtextborderspage.cpp:289
 #: ../src/richtext/richtextborderspage.cpp:323
@@ -8572,22 +8808,45 @@ msgstr "description du contexte du processus"
 #: ../src/richtext/richtextborderspage.cpp:491
 #: ../src/richtext/richtextborderspage.cpp:525
 #: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextfontpage.cpp:180
 msgid "pt"
 msgstr "pt"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:225
-#: ../src/richtext/richtextbackgroundpage.cpp:228
-#: ../src/richtext/richtextbackgroundpage.cpp:229
-#: ../src/richtext/richtextbackgroundpage.cpp:248
-#: ../src/richtext/richtextbackgroundpage.cpp:251
-#: ../src/richtext/richtextbackgroundpage.cpp:252
-#: ../src/richtext/richtextbackgroundpage.cpp:288
-#: ../src/richtext/richtextbackgroundpage.cpp:291
-#: ../src/richtext/richtextbackgroundpage.cpp:292
-#: ../src/richtext/richtextbackgroundpage.cpp:315
-#: ../src/richtext/richtextbackgroundpage.cpp:318
-#: ../src/richtext/richtextbackgroundpage.cpp:319
-#: ../src/richtext/richtextfontpage.cpp:178
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:659
+#: ../src/richtext/richtextsizepage.cpp:662
+#: ../src/richtext/richtextsizepage.cpp:663
 #: ../src/richtext/richtextborderspage.cpp:253
 #: ../src/richtext/richtextborderspage.cpp:256
 #: ../src/richtext/richtextborderspage.cpp:257
@@ -8639,260 +8898,270 @@ msgstr "pt"
 #: ../src/richtext/richtextmarginspage.cpp:387
 #: ../src/richtext/richtextmarginspage.cpp:389
 #: ../src/richtext/richtextmarginspage.cpp:390
-#: ../src/richtext/richtextsizepage.cpp:338
-#: ../src/richtext/richtextsizepage.cpp:341
-#: ../src/richtext/richtextsizepage.cpp:342
-#: ../src/richtext/richtextsizepage.cpp:372
-#: ../src/richtext/richtextsizepage.cpp:375
-#: ../src/richtext/richtextsizepage.cpp:376
-#: ../src/richtext/richtextsizepage.cpp:399
-#: ../src/richtext/richtextsizepage.cpp:402
-#: ../src/richtext/richtextsizepage.cpp:403
-#: ../src/richtext/richtextsizepage.cpp:426
-#: ../src/richtext/richtextsizepage.cpp:429
-#: ../src/richtext/richtextsizepage.cpp:430
-#: ../src/richtext/richtextsizepage.cpp:453
-#: ../src/richtext/richtextsizepage.cpp:456
-#: ../src/richtext/richtextsizepage.cpp:457
-#: ../src/richtext/richtextsizepage.cpp:480
-#: ../src/richtext/richtextsizepage.cpp:483
-#: ../src/richtext/richtextsizepage.cpp:484
-#: ../src/richtext/richtextsizepage.cpp:554
-#: ../src/richtext/richtextsizepage.cpp:557
-#: ../src/richtext/richtextsizepage.cpp:558
-#: ../src/richtext/richtextsizepage.cpp:589
-#: ../src/richtext/richtextsizepage.cpp:592
-#: ../src/richtext/richtextsizepage.cpp:593
-#: ../src/richtext/richtextsizepage.cpp:624
-#: ../src/richtext/richtextsizepage.cpp:627
-#: ../src/richtext/richtextsizepage.cpp:628
-#: ../src/richtext/richtextsizepage.cpp:659
-#: ../src/richtext/richtextsizepage.cpp:662
-#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextfontpage.cpp:178
 msgid "px"
 msgstr "px"
 
-#: ../src/common/accelcmn.cpp:193
+#: ../src/common/accelcmn.cpp:192
 msgid "rawctrl"
 msgstr "rawctrl"
 
-#: ../src/html/chm.cpp:333
+#: ../src/html/chm.cpp:330
 msgid "read error"
 msgstr "erreur de lecture"
 
-#: ../src/common/zipstrm.cpp:2085
+#: ../src/common/zipstrm.cpp:2155
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "lecture du flux zip (entrée %s) : mauvaise crc"
 
-#: ../src/common/zipstrm.cpp:2080
+#: ../src/common/zipstrm.cpp:2150
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "lecture du flux zip (entrée %s) : mauvaise longueur"
 
-#: ../src/msw/dde.cpp:1159
+#: ../src/msw/dde.cpp:1223
 msgid "reentrancy problem."
 msgstr "problème de double entrée."
 
-#: ../src/common/datetimefmt.cpp:1953
+#: ../src/common/datetimefmt.cpp:1976
 msgid "second"
 msgstr "deuxième"
 
-#: ../src/html/chm.cpp:337
+#: ../src/html/chm.cpp:334
 msgid "seek error"
 msgstr "erreur de recherche"
 
-#: ../src/common/datetimefmt.cpp:1968
+#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#, fuzzy
+msgid "semibold"
+msgstr "gras"
+
+#: ../src/common/datetimefmt.cpp:1991
 msgid "seventeenth"
 msgstr "dix-septième"
 
-#: ../src/common/datetimefmt.cpp:1958
+#: ../src/common/datetimefmt.cpp:1981
 msgid "seventh"
 msgstr "septième"
 
-#: ../src/common/accelcmn.cpp:191
+#: ../src/common/accelcmn.cpp:190
 msgid "shift"
 msgstr "majuscule"
 
-#: ../src/common/appbase.cpp:773
+#: ../src/common/appbase.cpp:774
 msgid "show this help message"
 msgstr "montrer ce message d'aide"
 
-#: ../src/common/datetimefmt.cpp:1967
+#: ../src/common/datetimefmt.cpp:1990
 msgid "sixteenth"
 msgstr "seizième"
 
-#: ../src/common/datetimefmt.cpp:1957
+#: ../src/common/datetimefmt.cpp:1980
 msgid "sixth"
 msgstr "sixième"
 
-#: ../src/common/appcmn.cpp:234
+#: ../src/common/appcmn.cpp:255
 msgid "specify display mode to use (e.g. 640x480-16)"
 msgstr "spécifier le mode d'affichage à utiliser (par ex. 640x480-16)"
 
-#: ../src/common/appcmn.cpp:220
+#: ../src/common/appcmn.cpp:241
 msgid "specify the theme to use"
 msgstr "spécifier le thème à utiliser"
 
-#: ../src/richtext/richtextbuffer.cpp:9340
+#: ../src/richtext/richtextbuffer.cpp:9337
 msgid "standard/circle"
 msgstr "standard/circulaire"
 
-#: ../src/richtext/richtextbuffer.cpp:9341
+#: ../src/richtext/richtextbuffer.cpp:9338
 msgid "standard/circle-outline"
 msgstr "standard/contour circulaire"
 
-#: ../src/richtext/richtextbuffer.cpp:9343
+#: ../src/richtext/richtextbuffer.cpp:9340
 msgid "standard/diamond"
 msgstr "standard/diamant"
 
-#: ../src/richtext/richtextbuffer.cpp:9342
+#: ../src/richtext/richtextbuffer.cpp:9339
 msgid "standard/square"
 msgstr "standard/carré"
 
-#: ../src/richtext/richtextbuffer.cpp:9344
+#: ../src/richtext/richtextbuffer.cpp:9341
 msgid "standard/triangle"
 msgstr "standard/triangle"
 
-#: ../src/common/zipstrm.cpp:1985
+#: ../src/common/zipstrm.cpp:2055
 msgid "stored file length not in Zip header"
 msgstr "longueur du fichier enregistré absente de l'entête du Zip"
 
-#: ../src/common/cmdline.cpp:1488
+#: ../src/common/cmdline.cpp:1484
 msgid "str"
 msgstr "str"
 
-#: ../src/common/fontcmn.cpp:982
+#: ../src/common/fontcmn.cpp:1145
 msgid "strikethrough"
 msgstr "barré"
 
-#: ../src/common/tarstrm.cpp:1003 ../src/common/tarstrm.cpp:1025
-#: ../src/common/tarstrm.cpp:1507 ../src/common/tarstrm.cpp:1529
+#: ../src/common/tarstrm.cpp:997 ../src/common/tarstrm.cpp:1019
+#: ../src/common/tarstrm.cpp:1501 ../src/common/tarstrm.cpp:1523
 msgid "tar entry not open"
 msgstr "l'entrée tar n'est pas ouverte"
 
-#: ../src/common/datetimefmt.cpp:1961
+#: ../src/common/datetimefmt.cpp:1984
 msgid "tenth"
 msgstr "dixième"
 
-#: ../src/msw/dde.cpp:1123
+#: ../src/msw/dde.cpp:1187
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr ""
 "la réponse à la transaction a provoqué la spécification du bit DDE_FBUSY."
 
-#: ../src/common/datetimefmt.cpp:1954
+#: ../src/common/fontcmn.cpp:1154
+msgid "thin"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:1977
 msgid "third"
 msgstr "troisième"
 
-#: ../src/common/datetimefmt.cpp:1964
+#: ../src/common/datetimefmt.cpp:1987
 msgid "thirteenth"
 msgstr "treizième"
 
-#: ../src/common/datetimefmt.cpp:1758
+#: ../src/common/datetimefmt.cpp:1781
 msgid "today"
 msgstr "aujourd'hui"
 
-#: ../src/common/datetimefmt.cpp:1760
+#: ../src/common/datetimefmt.cpp:1783
 msgid "tomorrow"
 msgstr "demain"
 
-#: ../src/common/fileconf.cpp:1944
+#: ../src/common/fileconf.cpp:1946
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "anti-slash de fin ignoré dans '%s'"
 
-#: ../src/gtk/aboutdlg.cpp:218
+#: ../src/gtk/aboutdlg.cpp:216
 msgid "translator-credits"
 msgstr "liste des traducteurs"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1028
+#: ../src/generic/datavgen.cpp:1148
 msgid "true"
 msgstr "vrai"
 
-#: ../src/common/datetimefmt.cpp:1963
+#: ../src/common/datetimefmt.cpp:1986
 msgid "twelfth"
 msgstr "douzième"
 
-#: ../src/common/datetimefmt.cpp:1971
+#: ../src/common/datetimefmt.cpp:1994
 msgid "twentieth"
 msgstr "vingtième"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:486 ../src/generic/datavgen.cpp:1263
+#: ../src/common/datavcmn.cpp:2068 ../src/generic/datavgen.cpp:1386
 msgid "unchecked"
 msgstr "décoché"
 
-#: ../src/common/fontcmn.cpp:802 ../src/common/fontcmn.cpp:978
+#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
 msgid "underlined"
 msgstr "souligné"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:490
+#: ../src/common/datavcmn.cpp:2072
 msgid "undetermined"
 msgstr "indéterminé"
 
-#: ../src/common/fileconf.cpp:1979
+#: ../src/common/fileconf.cpp:1981
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "symbole \" inattendu à la position %d dans « %s »."
 
-#: ../src/common/tarstrm.cpp:1045
+#: ../src/common/tarstrm.cpp:1039
 msgid "unexpected end of file"
 msgstr "fin de fichier inattendue"
 
-#: ../src/generic/progdlgg.cpp:370 ../src/common/tarstrm.cpp:371
-#: ../src/common/tarstrm.cpp:394 ../src/common/tarstrm.cpp:425
+#: ../src/common/tarstrm.cpp:366 ../src/common/tarstrm.cpp:389
+#: ../src/common/tarstrm.cpp:420 ../src/generic/progdlgg.cpp:376
 msgid "unknown"
 msgstr "inconnu"
 
-#: ../src/msw/registry.cpp:150
+#: ../src/msw/registry.cpp:139
 #, c-format
 msgid "unknown (%lu)"
 msgstr "inconnu (%lu)"
 
-#: ../src/common/xtixml.cpp:253
+#: ../src/common/xtixml.cpp:249
 #, c-format
 msgid "unknown class %s"
 msgstr "classe « %s » inconnue"
 
-#: ../src/common/regex.cpp:258 ../src/html/chm.cpp:351
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "erreur de compression"
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "erreur de décompression"
+
+#: ../src/common/regex.cpp:255 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "erreur inconnue"
 
-#: ../src/msw/dialup.cpp:471
+#: ../src/msw/dialup.cpp:465
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "erreur inconnue (code d'erreur %08x)."
 
-#: ../src/common/fmapbase.cpp:834
+#: ../src/common/fmapbase.cpp:830
 #, c-format
 msgid "unknown-%d"
 msgstr "inconnu-%d"
 
-#: ../src/common/docview.cpp:509
+#: ../src/common/docview.cpp:502
 msgid "unnamed"
 msgstr "sans nom"
 
-#: ../src/common/docview.cpp:1624
+#: ../src/common/docview.cpp:1618
 #, c-format
 msgid "unnamed%d"
 msgstr "sans nom %d"
 
-#: ../src/common/zipstrm.cpp:1999 ../src/common/zipstrm.cpp:2319
+#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
 msgid "unsupported Zip compression method"
 msgstr "méthode de compression zip non gérée"
 
-#: ../src/common/translation.cpp:1892
+#: ../src/common/translation.cpp:1942
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "utilisation du catalogue « %s » de « %s »."
 
-#: ../src/html/chm.cpp:335
+#: ../src/html/chm.cpp:332
 msgid "write error"
 msgstr "erreur d'écriture"
 
-#: ../src/common/time.cpp:292
+#: ../src/gtk/glcanvas.cpp:187
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/common/time.cpp:285
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay a échoué."
 
@@ -8905,15 +9174,15 @@ msgstr "wxWidgets n'a pas pu ouvrir d'affichage pour %s : abandon."
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets n'a pas pu ouvrir d'affichage : abandon."
 
-#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:431
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/common/datetimefmt.cpp:1759
+#: ../src/common/datetimefmt.cpp:1782
 msgid "yesterday"
 msgstr "hier"
 
-#: ../src/common/zstream.cpp:251 ../src/common/zstream.cpp:426
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
 #, c-format
 msgid "zlib error %d"
 msgstr "erreur zlib %d"
@@ -8922,6 +9191,81 @@ msgstr "erreur zlib %d"
 #: ../src/richtext/richtextbulletspage.cpp:288
 msgid "~"
 msgstr "~"
+
+#~ msgid " (while overwriting an existing item)"
+#~ msgstr " (lors de la réécriture d'un élément existant)"
+
+#~ msgid "&Save as"
+#~ msgstr "Enregistrer &Sous"
+
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' ne consiste pas uniquement de caractères valables"
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "« %s » doit être numérique."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "« %s » ne doit contenir que des caractères ASCII."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "« %s » ne doit contenir que des caractères alphabétiques."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "« %s » ne doit contenir que des caractères alphanumériques."
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "« %s » ne doit contenir que des chiffres."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "Impossible de créer la fenêtre de classe %s"
+
+#~ msgid "Could not initalize libnotify."
+#~ msgstr "N'a pas pu initialiser libnotify."
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "Impossible de créer une fenêtre de recouvrement"
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "Impossible d'initialiser le contexte de la fenêtre de recouvrement"
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "Échec de la conversion du fichier « %s » en Unicode."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "Échec: le texte n'a pas pu être placé dans le contrôle de texte."
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr "Option de ligne de commandeGTK+ non valable, utiliser « %s --help »"
+
+#~ msgid "No unused colour in image."
+#~ msgstr "Aucune couleur n'est disponible dans l'image."
+
+#~ msgid "Not available"
+#~ msgstr "Non disponible"
+
+#~ msgid "Replace selection"
+#~ msgstr "Remplacer la sélection"
+
+#~ msgid "Save as"
+#~ msgstr "Enregistrer sous"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Organiseur de styles"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "Les options standards GTK+ suivantes sont également reconnues :\n"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr ""
+#~ "Il n'est pas possible d'effectuer un effacement sur une superposition "
+#~ "(overlay) avant qu'elle ne soit initialisée"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr ""
+#~ "Il n'est pas possible d'initialiser deux fois une superpopsition (overlay)"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "la localisation « %s » ne peut pas être établie."
 
 #~ msgid "Adding flavor TEXT failed"
 #~ msgstr "Échec de l'ajout de la variété TEXT"
@@ -8942,9 +9286,6 @@ msgstr "~"
 
 #~ msgid "Column could not be added."
 #~ msgstr "La colonne n'a pas pu être ajoutée."
-
-#~ msgid "Column description could not be initialized."
-#~ msgstr "La description de la colonne n'a pas pu être initialisée."
 
 #~ msgid "Column index not found."
 #~ msgstr "Index de colonne non trouvé."
@@ -9502,9 +9843,6 @@ msgstr "~"
 #~ msgid "Directory '%s' doesn't exist!"
 #~ msgstr "Répertoire « %s » inexistant."
 
-#~ msgid "File %s does not exist."
-#~ msgstr "Fichier « %s » inexistant."
-
 #~ msgid "Mode %ix%i-%i not available."
 #~ msgstr "Le mode %ix%i-%i n'est pas disponible."
 
@@ -9600,9 +9938,6 @@ msgstr "~"
 
 #~ msgid "Failed to register OpenGL window class."
 #~ msgstr "Échec de l'enregistrement de la classe de fenêtres OpenGL."
-
-#~ msgid "Fatal error"
-#~ msgstr "Erreur fatale"
 
 #~ msgid "Fatal error: "
 #~ msgstr "Erreur fatale : "
@@ -9794,9 +10129,6 @@ msgstr "~"
 
 #~ msgid "&Print"
 #~ msgstr "&Imprimer"
-
-#~ msgid "*** A debug report has been generated\n"
-#~ msgstr "*** Un rapport de débogage a été créé\n"
 
 #~ msgid "*** It can be found in \"%s\"\n"
 #~ msgstr "*** Il peut être trouvé dans « %s »\n"

--- a/locale/gl_ES.po
+++ b/locale/gl_ES.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-21 14:25+0200\n"
+"POT-Creation-Date: 2020-10-18 23:11+0300\n"
 "PO-Revision-Date: 2013-11-01 21:34+0100\n"
 "Last-Translator: Nuria Andión <nandiez@gmail.com>\n"
 "Language-Team: Proxecto Trasno <proxecto@trasno.net>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "X-Generator: Poedit 1.5.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: ../src/common/debugrpt.cpp:586
+#: ../src/common/debugrpt.cpp:587
 msgid ""
 "\n"
 "Please send this report to the program maintainer, thank you!\n"
@@ -25,8 +25,8 @@ msgstr ""
 "\n"
 "Por favor, envíe este informe ao mantedor do programa, grazas!\n"
 
-#: ../src/richtext/richtextstyledlg.cpp:210
-#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:206
+#: ../src/richtext/richtextstyledlg.cpp:218
 msgid " "
 msgstr " "
 
@@ -34,70 +34,96 @@ msgstr " "
 msgid "              Thank you and we're sorry for the inconvenience!\n"
 msgstr "              Grazas e sentimos a molestia!\n"
 
-#: ../src/common/prntbase.cpp:573
+#: ../src/common/prntbase.cpp:568
 #, c-format
 msgid " (copy %d of %d)"
 msgstr " (copiar %d de %d)"
 
-#: ../src/common/log.cpp:421
+#: ../src/common/log.cpp:440
 #, c-format
 msgid " (error %ld: %s)"
 msgstr " (erro %ld: %s)"
 
-#: ../src/common/imagtiff.cpp:72
+#: ../src/common/imagtiff.cpp:69
 #, c-format
 msgid " (in module \"%s\")"
 msgstr " (en módulo \"%s\")"
 
-#: ../src/osx/core/secretstore.cpp:138
-msgid " (while overwriting an existing item)"
-msgstr ""
-
-#: ../src/common/docview.cpp:1642
+#: ../src/common/docview.cpp:1636
 msgid " - "
 msgstr " - "
 
-#: ../src/richtext/richtextprint.cpp:593 ../src/html/htmprint.cpp:714
+#: ../src/html/htmprint.cpp:712 ../src/richtext/richtextprint.cpp:589
 msgid " Preview"
 msgstr " Previsualización"
 
-#: ../src/common/fontcmn.cpp:824
+#: ../src/common/fontcmn.cpp:973
 msgid " bold"
 msgstr " grosa"
 
-#: ../src/common/fontcmn.cpp:840
+#: ../src/common/fontcmn.cpp:977
+#, fuzzy
+msgid " extra bold"
+msgstr " grosa"
+
+#: ../src/common/fontcmn.cpp:985
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:957
+#, fuzzy
+msgid " extra light"
+msgstr " clara"
+
+#: ../src/common/fontcmn.cpp:981
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1001
 msgid " italic"
 msgstr " cursiva"
 
-#: ../src/common/fontcmn.cpp:820
+#: ../src/common/fontcmn.cpp:961
 msgid " light"
 msgstr " clara"
 
-#: ../src/common/fontcmn.cpp:807
+#: ../src/common/fontcmn.cpp:965
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:969
+#, fuzzy
+msgid " semi bold"
+msgstr " grosa"
+
+#: ../src/common/fontcmn.cpp:940
 msgid " strikethrough"
 msgstr " riscado"
 
-#: ../src/common/paper.cpp:117
+#: ../src/common/fontcmn.cpp:953
+msgid " thin"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
 msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
 msgstr "Sobre #10, 4 1/8 x 9 1/2 polgadas"
 
-#: ../src/common/paper.cpp:118
+#: ../src/common/paper.cpp:115
 msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
 msgstr "Sobre #11, 4 1/2 x 10 3/8 in"
 
-#: ../src/common/paper.cpp:119
+#: ../src/common/paper.cpp:116
 msgid "#12 Envelope, 4 3/4 x 11 in"
 msgstr "Sobre #12, 4 3/4 x 11 in"
 
-#: ../src/common/paper.cpp:120
+#: ../src/common/paper.cpp:117
 msgid "#14 Envelope, 5 x 11 1/2 in"
 msgstr "Sobre #14, 5 x 11 1/2 in"
 
-#: ../src/common/paper.cpp:116
+#: ../src/common/paper.cpp:113
 msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
 msgstr "Sobre #9, 3 7/8 x 8 7/8 in"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:341
 #: ../src/richtext/richtextsizepage.cpp:340
 #: ../src/richtext/richtextsizepage.cpp:374
 #: ../src/richtext/richtextsizepage.cpp:401
@@ -108,81 +134,82 @@ msgstr "Sobre #9, 3 7/8 x 8 7/8 in"
 #: ../src/richtext/richtextsizepage.cpp:591
 #: ../src/richtext/richtextsizepage.cpp:626
 #: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextbackgroundpage.cpp:341
 msgid "%"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1031
+#: ../src/html/helpwnd.cpp:1029
 #, c-format
 msgid "%d of %lu"
 msgstr "%d de %lu"
 
-#: ../src/html/helpwnd.cpp:1678
+#: ../src/html/helpwnd.cpp:1676
 #, fuzzy, c-format
 msgid "%i of %u"
 msgstr "%i de %i"
 
-#: ../src/generic/filectrlg.cpp:279
+#: ../src/generic/filectrlg.cpp:275
 #, c-format
 msgid "%ld byte"
 msgid_plural "%ld bytes"
 msgstr[0] "%ld byte"
 msgstr[1] "%ld bytes"
 
-#: ../src/html/helpwnd.cpp:1033
+#: ../src/html/helpwnd.cpp:1031
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu de %lu"
 
-#: ../src/generic/datavgen.cpp:6028
+#: ../src/generic/datavgen.cpp:6833
 #, fuzzy, c-format
 msgid "%s (%d items)"
 msgstr "%s (ou %s)"
 
-#: ../src/common/cmdline.cpp:1221
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (ou %s)"
 
-#: ../src/generic/logg.cpp:224
+#: ../src/generic/logg.cpp:221
 #, c-format
 msgid "%s Error"
 msgstr "%s Erro"
 
-#: ../src/generic/logg.cpp:236
+#: ../src/generic/logg.cpp:233
 #, c-format
 msgid "%s Information"
 msgstr "%s Información"
 
-#: ../src/generic/preferencesg.cpp:113
+#: ../src/generic/preferencesg.cpp:110
 #, c-format
 msgid "%s Preferences"
 msgstr "%s preferencias"
 
-#: ../src/generic/logg.cpp:228
+#: ../src/generic/logg.cpp:225
 #, c-format
 msgid "%s Warning"
 msgstr "%s Aviso"
 
-#: ../src/common/tarstrm.cpp:1319
+#: ../src/common/tarstrm.cpp:1313
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s non se axeitou á cabeceira de ficheiro tar na entrada '%s'"
 
-#: ../src/common/fldlgcmn.cpp:124
+#: ../src/common/fldlgcmn.cpp:121
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s ficheiros (%s)|%s"
 
-#: ../src/html/helpwnd.cpp:1716
+#: ../src/html/helpwnd.cpp:1714
 #, fuzzy, c-format
 msgid "%u of %u"
 msgstr "%lu de %lu"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "&About"
 msgstr "&Sobre"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "&Actual Size"
 msgstr "Tamaño &Actual"
 
@@ -190,28 +217,28 @@ msgstr "Tamaño &Actual"
 msgid "&After a paragraph:"
 msgstr "&Despois dun parágrafo:"
 
-#: ../src/richtext/richtextindentspage.cpp:128
 #: ../src/richtext/richtextliststylepage.cpp:319
+#: ../src/richtext/richtextindentspage.cpp:128
 msgid "&Alignment"
 msgstr "&Aliñamento"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "&Apply"
 msgstr "&Aplicar"
 
-#: ../src/richtext/richtextstyledlg.cpp:251
+#: ../src/richtext/richtextstyledlg.cpp:247
 msgid "&Apply Style"
 msgstr "&Aplicar estilo"
 
-#: ../src/msw/mdi.cpp:179
+#: ../src/msw/mdi.cpp:174
 msgid "&Arrange Icons"
 msgstr "&Ordenar iconas"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "&Ascending"
 msgstr "&Ascendente"
 
-#: ../src/common/stockitem.cpp:142
+#: ../src/common/stockitem.cpp:139
 msgid "&Back"
 msgstr "&Atrás"
 
@@ -231,24 +258,24 @@ msgstr "Cor de &fondo:"
 msgid "&Blur distance:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:143
+#: ../src/common/stockitem.cpp:140
 msgid "&Bold"
 msgstr "&Grosa"
 
-#: ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141
 msgid "&Bottom"
 msgstr "&Abaixo"
 
+#: ../src/richtext/richtextsizepage.cpp:637
+#: ../src/richtext/richtextsizepage.cpp:644
 #: ../src/richtext/richtextborderspage.cpp:345
 #: ../src/richtext/richtextborderspage.cpp:513
 #: ../src/richtext/richtextmarginspage.cpp:259
 #: ../src/richtext/richtextmarginspage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:637
-#: ../src/richtext/richtextsizepage.cpp:644
 msgid "&Bottom:"
 msgstr "&Abaixo:"
 
-#: ../include/wx/richtext/richtextbuffer.h:3866
+#: ../include/wx/richtext/richtextbuffer.h:3861
 msgid "&Box"
 msgstr "&Caixa"
 
@@ -257,38 +284,38 @@ msgstr "&Caixa"
 msgid "&Bullet style:"
 msgstr "&Estilo de viñeta:"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "&CD-Rom"
 msgstr "&CD-Rom"
 
-#: ../src/generic/wizard.cpp:434 ../src/generic/fontdlgg.cpp:470
-#: ../src/generic/fontdlgg.cpp:489 ../src/osx/carbon/fontdlg.cpp:402
-#: ../src/common/dlgcmn.cpp:279 ../src/common/stockitem.cpp:145
+#: ../src/osx/carbon/fontdlg.cpp:399 ../src/common/stockitem.cpp:142
+#: ../src/generic/wizard.cpp:433 ../src/generic/fontdlgg.cpp:466
+#: ../src/generic/fontdlgg.cpp:485 ../src/osx/cocoa/button.mm:200
 msgid "&Cancel"
 msgstr "&Cancelar"
 
-#: ../src/msw/mdi.cpp:175
+#: ../src/msw/mdi.cpp:170
 msgid "&Cascade"
 msgstr "En &cadoiro"
 
-#: ../include/wx/richtext/richtextbuffer.h:5960
+#: ../include/wx/richtext/richtextbuffer.h:5955
 msgid "&Cell"
 msgstr "&Cela"
 
-#: ../src/richtext/richtextsymboldlg.cpp:439
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "&Character code:"
 msgstr "&Código de caracter:"
 
-#: ../src/common/stockitem.cpp:147
+#: ../src/common/stockitem.cpp:144
 msgid "&Clear"
 msgstr "&Limpar"
 
-#: ../src/generic/logg.cpp:516 ../src/common/stockitem.cpp:148
-#: ../src/common/prntbase.cpp:1600 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/stockitem.cpp:145 ../src/common/prntbase.cpp:1625
+#: ../src/univ/themes/win32.cpp:3753 ../src/generic/logg.cpp:513
 msgid "&Close"
 msgstr "&Pechar"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "&Color"
 msgstr "C&or"
 
@@ -296,20 +323,20 @@ msgstr "C&or"
 msgid "&Colour:"
 msgstr "C&or:"
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "&Convert"
 msgstr "&Con&verter"
 
-#: ../src/richtext/richtextctrl.cpp:333 ../src/osx/textctrl_osx.cpp:577
-#: ../src/common/stockitem.cpp:150 ../src/msw/textctrl.cpp:2508
+#: ../src/osx/textctrl_osx.cpp:595 ../src/common/stockitem.cpp:147
+#: ../src/msw/textctrl.cpp:2773 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Copiar"
 
-#: ../src/generic/hyperlinkg.cpp:156
+#: ../src/generic/hyperlinkg.cpp:153
 msgid "&Copy URL"
 msgstr "&Copiar URL"
 
-#: ../src/common/headerctrlcmn.cpp:306
+#: ../src/common/headerctrlcmn.cpp:304
 msgid "&Customize..."
 msgstr "&Personalizar..."
 
@@ -317,53 +344,54 @@ msgstr "&Personalizar..."
 msgid "&Debug report preview:"
 msgstr "Previsualización do informe de &depuración:"
 
-#: ../src/richtext/richtexttabspage.cpp:138
-#: ../src/richtext/richtextctrl.cpp:335 ../src/osx/textctrl_osx.cpp:579
-#: ../src/common/stockitem.cpp:152 ../src/msw/textctrl.cpp:2510
+#: ../src/osx/textctrl_osx.cpp:597 ../src/common/stockitem.cpp:149
+#: ../src/msw/textctrl.cpp:2775 ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtextctrl.cpp:334
 msgid "&Delete"
 msgstr "&Eliminar"
 
-#: ../src/richtext/richtextstyledlg.cpp:269
+#: ../src/richtext/richtextstyledlg.cpp:265
 msgid "&Delete Style..."
 msgstr "&Eliminar estilo..."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "&Descending"
 msgstr "&Descendente"
 
-#: ../src/generic/logg.cpp:682
+#: ../src/generic/logg.cpp:679
 msgid "&Details"
 msgstr "&Detalles"
 
-#: ../src/common/stockitem.cpp:153
+#: ../src/common/stockitem.cpp:150
 msgid "&Down"
 msgstr "A&baixo"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "&Edit"
 msgstr "&Editar"
 
-#: ../src/richtext/richtextstyledlg.cpp:263
+#: ../src/richtext/richtextstyledlg.cpp:259
 msgid "&Edit Style..."
 msgstr "&Editar estilo..."
 
-#: ../src/common/stockitem.cpp:155
+#: ../src/common/stockitem.cpp:152
 msgid "&Execute"
 msgstr "&Executar"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/common/stockitem.cpp:154
 msgid "&File"
 msgstr "&Ficheiro"
 
-#: ../src/common/stockitem.cpp:158
-msgid "&Find"
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "&Find..."
 msgstr "&Buscar"
 
-#: ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:430
 msgid "&Finish"
 msgstr "&Finalizar"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:156
 msgid "&First"
 msgstr "&Primeiro"
 
@@ -371,15 +399,15 @@ msgstr "&Primeiro"
 msgid "&Floating mode:"
 msgstr "&Modo flotante:"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "&Floppy"
 msgstr "&Disquete"
 
-#: ../src/common/stockitem.cpp:194
+#: ../src/common/stockitem.cpp:191
 msgid "&Font"
 msgstr "&Tipo de letra"
 
-#: ../src/generic/fontdlgg.cpp:371
+#: ../src/generic/fontdlgg.cpp:367
 msgid "&Font family:"
 msgstr "&Familia de tipo de letra:"
 
@@ -387,20 +415,20 @@ msgstr "&Familia de tipo de letra:"
 msgid "&Font for Level..."
 msgstr "&Tipo de letra para nivel..."
 
+#: ../src/richtext/richtextsymboldlg.cpp:397
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:400
 msgid "&Font:"
 msgstr "&Tipo de letra:"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "&Forward"
 msgstr "&Adiante"
 
-#: ../src/richtext/richtextsymboldlg.cpp:451
+#: ../src/richtext/richtextsymboldlg.cpp:448
 msgid "&From:"
 msgstr "&Dende:"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "&Harddisk"
 msgstr "&Disco duro"
 
@@ -409,9 +437,9 @@ msgstr "&Disco duro"
 msgid "&Height:"
 msgstr "&Altura:"
 
-#: ../src/generic/wizard.cpp:441 ../src/richtext/richtextstyledlg.cpp:303
-#: ../src/richtext/richtextsymboldlg.cpp:479 ../src/osx/menu_osx.cpp:734
-#: ../src/common/stockitem.cpp:163
+#: ../src/common/stockitem.cpp:160 ../src/generic/wizard.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextstyledlg.cpp:299 ../src/osx/cocoa/menu.mm:226
 msgid "&Help"
 msgstr "A&xuda"
 
@@ -419,7 +447,7 @@ msgstr "A&xuda"
 msgid "&Hide details"
 msgstr "&Ocultar detalles"
 
-#: ../src/common/stockitem.cpp:164
+#: ../src/common/stockitem.cpp:161
 msgid "&Home"
 msgstr "&Inicio"
 
@@ -427,54 +455,54 @@ msgstr "&Inicio"
 msgid "&Horizontal offset:"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:184
 #: ../src/richtext/richtextliststylepage.cpp:372
+#: ../src/richtext/richtextindentspage.cpp:184
 msgid "&Indentation (tenths of a mm)"
 msgstr "&Sangría (décimas de mm)"
 
-#: ../src/richtext/richtextindentspage.cpp:167
 #: ../src/richtext/richtextliststylepage.cpp:356
+#: ../src/richtext/richtextindentspage.cpp:167
 msgid "&Indeterminate"
 msgstr "&Indeterminado"
 
-#: ../src/common/stockitem.cpp:166
+#: ../src/common/stockitem.cpp:163
 msgid "&Index"
 msgstr "&Índice"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "&Info"
 msgstr "&Información"
 
-#: ../src/common/stockitem.cpp:168
+#: ../src/common/stockitem.cpp:165
 msgid "&Italic"
 msgstr "&Cursiva"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "&Jump to"
 msgstr "&Ir a"
 
-#: ../src/richtext/richtextindentspage.cpp:153
 #: ../src/richtext/richtextliststylepage.cpp:342
+#: ../src/richtext/richtextindentspage.cpp:153
 msgid "&Justified"
 msgstr "&Xustificado"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "&Last"
 msgstr "Ú&ltimo"
 
-#: ../src/richtext/richtextindentspage.cpp:139
 #: ../src/richtext/richtextliststylepage.cpp:328
+#: ../src/richtext/richtextindentspage.cpp:139
 msgid "&Left"
 msgstr "&Esquerda"
 
-#: ../src/richtext/richtextindentspage.cpp:195
+#: ../src/richtext/richtextsizepage.cpp:532
+#: ../src/richtext/richtextsizepage.cpp:539
 #: ../src/richtext/richtextborderspage.cpp:243
 #: ../src/richtext/richtextborderspage.cpp:411
 #: ../src/richtext/richtextliststylepage.cpp:381
+#: ../src/richtext/richtextindentspage.cpp:195
 #: ../src/richtext/richtextmarginspage.cpp:186
 #: ../src/richtext/richtextmarginspage.cpp:300
-#: ../src/richtext/richtextsizepage.cpp:532
-#: ../src/richtext/richtextsizepage.cpp:539
 msgid "&Left:"
 msgstr "&Esquerda:"
 
@@ -482,11 +510,11 @@ msgstr "&Esquerda:"
 msgid "&List level:"
 msgstr "&Nivel de lista:"
 
-#: ../src/generic/logg.cpp:517
+#: ../src/generic/logg.cpp:514
 msgid "&Log"
 msgstr "&Rexistro"
 
-#: ../src/univ/themes/win32.cpp:3748
+#: ../src/univ/themes/win32.cpp:3745
 msgid "&Move"
 msgstr "&Mover"
 
@@ -494,20 +522,19 @@ msgstr "&Mover"
 msgid "&Move the object to:"
 msgstr "&Mover o obxecto a:"
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "&Network"
 msgstr "&Rede"
 
-#: ../src/richtext/richtexttabspage.cpp:132 ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173 ../src/richtext/richtexttabspage.cpp:132
 msgid "&New"
 msgstr "&Novo"
 
-#: ../src/aui/tabmdi.cpp:111 ../src/generic/mdig.cpp:100
-#: ../src/msw/mdi.cpp:180
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
 msgid "&Next"
 msgstr "&Seguinte"
 
-#: ../src/generic/wizard.cpp:432 ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:429
 msgid "&Next >"
 msgstr "&Seguinte >"
 
@@ -515,7 +542,7 @@ msgstr "&Seguinte >"
 msgid "&Next Paragraph"
 msgstr "&Parágrafo seguinte"
 
-#: ../src/generic/tipdlg.cpp:240
+#: ../src/generic/tipdlg.cpp:237
 msgid "&Next Tip"
 msgstr "&Seguinte Consello"
 
@@ -523,11 +550,11 @@ msgstr "&Seguinte Consello"
 msgid "&Next style:"
 msgstr "&Seguinte estilo:"
 
-#: ../src/common/stockitem.cpp:177 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:174 ../src/msw/msgdlg.cpp:435
 msgid "&No"
 msgstr "&Non"
 
-#: ../src/generic/dbgrptg.cpp:356
+#: ../src/generic/dbgrptg.cpp:360
 msgid "&Notes:"
 msgstr "&Notas:"
 
@@ -535,12 +562,12 @@ msgstr "&Notas:"
 msgid "&Number:"
 msgstr "&Número:"
 
-#: ../src/generic/fontdlgg.cpp:475 ../src/generic/fontdlgg.cpp:482
-#: ../src/osx/carbon/fontdlg.cpp:408 ../src/common/stockitem.cpp:178
+#: ../src/osx/carbon/fontdlg.cpp:405 ../src/common/stockitem.cpp:175
+#: ../src/generic/fontdlgg.cpp:471 ../src/generic/fontdlgg.cpp:478
 msgid "&OK"
 msgstr "&Aceptar"
 
-#: ../src/generic/dbgrptg.cpp:342 ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176 ../src/generic/dbgrptg.cpp:342
 msgid "&Open..."
 msgstr "&Abrir..."
 
@@ -552,16 +579,16 @@ msgstr "&Nivel do esquema:"
 msgid "&Page Break"
 msgstr "&Quebra de páxina"
 
-#: ../src/richtext/richtextctrl.cpp:334 ../src/osx/textctrl_osx.cpp:578
-#: ../src/common/stockitem.cpp:180 ../src/msw/textctrl.cpp:2509
+#: ../src/osx/textctrl_osx.cpp:596 ../src/common/stockitem.cpp:177
+#: ../src/msw/textctrl.cpp:2774 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&Pegar"
 
-#: ../include/wx/richtext/richtextbuffer.h:5010
+#: ../include/wx/richtext/richtextbuffer.h:5005
 msgid "&Picture"
 msgstr "&Imaxe"
 
-#: ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:419
 msgid "&Point size:"
 msgstr "Tamaño do &punto:"
 
@@ -573,12 +600,11 @@ msgstr "&Posición (décimas de mm):"
 msgid "&Position mode:"
 msgstr "Modo de &posición:"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178
 msgid "&Preferences"
 msgstr "&Preferencias"
 
-#: ../src/aui/tabmdi.cpp:112 ../src/generic/mdig.cpp:101
-#: ../src/msw/mdi.cpp:181
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
 msgid "&Previous"
 msgstr "&Anterior"
 
@@ -586,78 +612,74 @@ msgstr "&Anterior"
 msgid "&Previous Paragraph"
 msgstr "&Parágrafo anterior"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "&Print..."
 msgstr "&Imprimir..."
 
-#: ../src/richtext/richtextctrl.cpp:339 ../src/richtext/richtextctrl.cpp:5514
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtextctrl.cpp:338
+#: ../src/richtext/richtextctrl.cpp:5512
 msgid "&Properties"
 msgstr "&Propiedades"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "&Quit"
 msgstr "&Saír"
 
-#: ../src/richtext/richtextctrl.cpp:330 ../src/osx/textctrl_osx.cpp:574
-#: ../src/common/stockitem.cpp:185 ../src/common/cmdproc.cpp:293
-#: ../src/common/cmdproc.cpp:300 ../src/msw/textctrl.cpp:2505
+#: ../src/osx/textctrl_osx.cpp:592 ../src/common/stockitem.cpp:182
+#: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
+#: ../src/msw/textctrl.cpp:2770 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Refacer"
 
-#: ../src/common/cmdproc.cpp:289 ../src/common/cmdproc.cpp:309
+#: ../src/common/cmdproc.cpp:282 ../src/common/cmdproc.cpp:302
 msgid "&Redo "
 msgstr "&Refacer "
 
-#: ../src/richtext/richtextstyledlg.cpp:257
+#: ../src/richtext/richtextstyledlg.cpp:253
 msgid "&Rename Style..."
 msgstr "&Renomear estilo..."
 
-#: ../src/generic/fdrepdlg.cpp:179
+#: ../src/generic/fdrepdlg.cpp:176
 msgid "&Replace"
 msgstr "&Substituír"
 
-#: ../src/richtext/richtextstyledlg.cpp:287
+#: ../src/richtext/richtextstyledlg.cpp:283
 msgid "&Restart numbering"
 msgstr "&Reiniciar numeración"
 
-#: ../src/univ/themes/win32.cpp:3747
+#: ../src/univ/themes/win32.cpp:3744
 msgid "&Restore"
 msgstr "&Restabelecer"
 
-#: ../src/richtext/richtextindentspage.cpp:146
 #: ../src/richtext/richtextliststylepage.cpp:335
+#: ../src/richtext/richtextindentspage.cpp:146
 msgid "&Right"
 msgstr "&Dereita"
 
-#: ../src/richtext/richtextindentspage.cpp:213
+#: ../src/richtext/richtextsizepage.cpp:602
+#: ../src/richtext/richtextsizepage.cpp:609
 #: ../src/richtext/richtextborderspage.cpp:277
 #: ../src/richtext/richtextborderspage.cpp:445
 #: ../src/richtext/richtextliststylepage.cpp:399
+#: ../src/richtext/richtextindentspage.cpp:213
 #: ../src/richtext/richtextmarginspage.cpp:211
 #: ../src/richtext/richtextmarginspage.cpp:325
-#: ../src/richtext/richtextsizepage.cpp:602
-#: ../src/richtext/richtextsizepage.cpp:609
 msgid "&Right:"
 msgstr "&Dereita:"
 
-#: ../src/common/stockitem.cpp:190
+#: ../src/common/stockitem.cpp:187
 msgid "&Save"
 msgstr "&Gardar"
-
-#: ../src/common/stockitem.cpp:191
-msgid "&Save as"
-msgstr "Gardar &como"
 
 #: ../include/wx/richmsgdlg.h:29
 msgid "&See details"
 msgstr "Ver &detalles"
 
-#: ../src/generic/tipdlg.cpp:236
+#: ../src/generic/tipdlg.cpp:233
 msgid "&Show tips at startup"
 msgstr "&Amosar os consellos ao comezo"
 
-#: ../src/univ/themes/win32.cpp:3750
+#: ../src/univ/themes/win32.cpp:3747
 msgid "&Size"
 msgstr "&Tamaño"
 
@@ -665,36 +687,36 @@ msgstr "&Tamaño"
 msgid "&Size:"
 msgstr "&Tamaño:"
 
-#: ../src/generic/progdlgg.cpp:252
+#: ../src/generic/progdlgg.cpp:249
 msgid "&Skip"
 msgstr "&Omitir"
 
-#: ../src/richtext/richtextindentspage.cpp:242
 #: ../src/richtext/richtextliststylepage.cpp:417
+#: ../src/richtext/richtextindentspage.cpp:242
 msgid "&Spacing (tenths of a mm)"
 msgstr "&Espazamento (décimas de mm)"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "&Spell Check"
 msgstr "&Revisar ortografía"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "&Stop"
 msgstr "&Parar"
 
-#: ../src/richtext/richtextfontpage.cpp:275 ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196 ../src/richtext/richtextfontpage.cpp:275
 msgid "&Strikethrough"
 msgstr "&Riscado"
 
-#: ../src/generic/fontdlgg.cpp:382 ../src/richtext/richtextstylepage.cpp:106
+#: ../src/generic/fontdlgg.cpp:378 ../src/richtext/richtextstylepage.cpp:106
 msgid "&Style:"
 msgstr "&Estilo:"
 
-#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:194
 msgid "&Styles:"
 msgstr "&Estilos:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:413
+#: ../src/richtext/richtextsymboldlg.cpp:410
 msgid "&Subset:"
 msgstr "&Subconxunto:"
 
@@ -708,24 +730,24 @@ msgstr "&Símbolo:"
 msgid "&Synchronize values"
 msgstr ""
 
-#: ../include/wx/richtext/richtextbuffer.h:6069
+#: ../include/wx/richtext/richtextbuffer.h:6064
 msgid "&Table"
 msgstr "&Táboa"
 
-#: ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197
 msgid "&Top"
 msgstr "&Arriba"
 
+#: ../src/richtext/richtextsizepage.cpp:567
+#: ../src/richtext/richtextsizepage.cpp:574
 #: ../src/richtext/richtextborderspage.cpp:311
 #: ../src/richtext/richtextborderspage.cpp:479
 #: ../src/richtext/richtextmarginspage.cpp:234
 #: ../src/richtext/richtextmarginspage.cpp:348
-#: ../src/richtext/richtextsizepage.cpp:567
-#: ../src/richtext/richtextsizepage.cpp:574
 msgid "&Top:"
 msgstr "&Arriba:"
 
-#: ../src/generic/fontdlgg.cpp:444 ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199 ../src/generic/fontdlgg.cpp:441
 msgid "&Underline"
 msgstr "&Subliñar"
 
@@ -733,21 +755,21 @@ msgstr "&Subliñar"
 msgid "&Underlining:"
 msgstr "&Subliñado:"
 
-#: ../src/richtext/richtextctrl.cpp:329 ../src/osx/textctrl_osx.cpp:573
-#: ../src/common/stockitem.cpp:203 ../src/common/cmdproc.cpp:271
-#: ../src/msw/textctrl.cpp:2504
+#: ../src/osx/textctrl_osx.cpp:591 ../src/common/stockitem.cpp:200
+#: ../src/common/cmdproc.cpp:264 ../src/msw/textctrl.cpp:2769
+#: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Desfacer"
 
-#: ../src/common/cmdproc.cpp:265
+#: ../src/common/cmdproc.cpp:258
 msgid "&Undo "
 msgstr "&Desfacer "
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "&Unindent"
 msgstr "&Eliminar sangría"
 
-#: ../src/common/stockitem.cpp:205
+#: ../src/common/stockitem.cpp:202
 msgid "&Up"
 msgstr "&Arriba"
 
@@ -764,7 +786,7 @@ msgstr "Aliñamento &vertical:"
 msgid "&View..."
 msgstr "&Ver…"
 
-#: ../src/generic/fontdlgg.cpp:393
+#: ../src/generic/fontdlgg.cpp:389
 msgid "&Weight:"
 msgstr "&Grosor:"
 
@@ -773,88 +795,58 @@ msgstr "&Grosor:"
 msgid "&Width:"
 msgstr "&Anchura:"
 
-#: ../src/aui/tabmdi.cpp:311 ../src/aui/tabmdi.cpp:327
-#: ../src/aui/tabmdi.cpp:329 ../src/generic/mdig.cpp:294
-#: ../src/generic/mdig.cpp:310 ../src/generic/mdig.cpp:314
-#: ../src/msw/mdi.cpp:78
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
 msgid "&Window"
 msgstr "&Xanela"
 
-#: ../src/common/stockitem.cpp:206 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:203 ../src/msw/msgdlg.cpp:435
 msgid "&Yes"
 msgstr "&Si"
 
-#: ../src/common/valtext.cpp:256
+#: ../src/common/valtext.cpp:197
 #, fuzzy, c-format
-msgid "'%s' contains illegal characters"
+msgid "'%s' contains invalid character(s)"
 msgstr "'%s' debe conter só caracteres alfabéticos."
 
-#: ../src/common/valtext.cpp:254
-#, fuzzy, c-format
-msgid "'%s' doesn't consist only of valid characters"
-msgstr "'%s' debe conter só caracteres alfabéticos."
-
-#: ../src/common/config.cpp:519 ../src/msw/regconf.cpp:258
+#: ../src/common/config.cpp:515 ../src/msw/regconf.cpp:255
 #, c-format
 msgid "'%s' has extra '..', ignored."
 msgstr "'%s' ten '..' adicional, ignórase."
 
-#: ../src/common/cmdline.cpp:1113 ../src/common/cmdline.cpp:1131
+#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' non é un valor numérico correcto para a opción '%s'."
 
-#: ../src/common/translation.cpp:1100
+#: ../src/common/translation.cpp:1142
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' non é un catálogo de mensaxes correcto."
 
-#: ../src/common/valtext.cpp:165
+#: ../src/common/valtext.cpp:188
 #, fuzzy, c-format
 msgid "'%s' is not one of the valid strings"
 msgstr "'%s' non é un catálogo de mensaxes correcto."
 
-#: ../src/common/valtext.cpp:167
+#: ../src/common/valtext.cpp:186
 #, fuzzy, c-format
 msgid "'%s' is one of the invalid strings"
 msgstr "'%s' é incorrecto"
 
-#: ../src/common/textbuf.cpp:237
+#: ../src/common/textbuf.cpp:233
 #, c-format
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' é probábelmente un búfer binario."
-
-#: ../src/common/valtext.cpp:252
-#, c-format
-msgid "'%s' should be numeric."
-msgstr "'%s' debe ser numérico."
-
-#: ../src/common/valtext.cpp:244
-#, c-format
-msgid "'%s' should only contain ASCII characters."
-msgstr "'%s' debe conter só caracteres ASCII."
-
-#: ../src/common/valtext.cpp:246
-#, c-format
-msgid "'%s' should only contain alphabetic characters."
-msgstr "'%s' debe conter só caracteres alfabéticos."
-
-#: ../src/common/valtext.cpp:248
-#, c-format
-msgid "'%s' should only contain alphabetic or numeric characters."
-msgstr "'%s' debe conter só caracteres alfanuméricos."
-
-#: ../src/common/valtext.cpp:250
-#, c-format
-msgid "'%s' should only contain digits."
-msgstr "'%s' debe conter díxitos unicamente."
 
 #: ../src/richtext/richtextliststylepage.cpp:229
 #: ../src/richtext/richtextbulletspage.cpp:166
 msgid "(*)"
 msgstr "(*)"
 
-#: ../src/html/helpwnd.cpp:963
+#: ../src/html/helpwnd.cpp:961
 msgid "(Help)"
 msgstr "(Axuda)"
 
@@ -863,27 +855,32 @@ msgstr "(Axuda)"
 msgid "(None)"
 msgstr "(Ningún)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:504
+#: ../src/richtext/richtextsymboldlg.cpp:503
 msgid "(Normal text)"
 msgstr "(Texto normal)"
 
-#: ../src/html/helpwnd.cpp:419 ../src/html/helpwnd.cpp:1106
-#: ../src/html/helpwnd.cpp:1742
+#: ../src/html/helpwnd.cpp:417 ../src/html/helpwnd.cpp:1104
+#: ../src/html/helpwnd.cpp:1740
 msgid "(bookmarks)"
 msgstr "(marcadores)"
 
+#: ../src/msw/dlmsw.cpp:167
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (erro %ld: %s)"
+
+#: ../src/richtext/richtextformatdlg.cpp:876
+#: ../src/richtext/richtextliststylepage.cpp:448
+#: ../src/richtext/richtextliststylepage.cpp:460
+#: ../src/richtext/richtextliststylepage.cpp:461
 #: ../src/richtext/richtextindentspage.cpp:274
 #: ../src/richtext/richtextindentspage.cpp:286
 #: ../src/richtext/richtextindentspage.cpp:287
 #: ../src/richtext/richtextindentspage.cpp:311
 #: ../src/richtext/richtextindentspage.cpp:326
-#: ../src/richtext/richtextformatdlg.cpp:884
 #: ../src/richtext/richtextfontpage.cpp:349
 #: ../src/richtext/richtextfontpage.cpp:353
 #: ../src/richtext/richtextfontpage.cpp:357
-#: ../src/richtext/richtextliststylepage.cpp:448
-#: ../src/richtext/richtextliststylepage.cpp:460
-#: ../src/richtext/richtextliststylepage.cpp:461
 msgid "(none)"
 msgstr "(ningún)"
 
@@ -902,7 +899,7 @@ msgstr "*)"
 msgid "+"
 msgstr "+"
 
-#: ../src/msw/utils.cpp:1152
+#: ../src/msw/utils.cpp:1143
 msgid ", 64-bit edition"
 msgstr ", edición de 64 bits"
 
@@ -911,163 +908,163 @@ msgstr ", edición de 64 bits"
 msgid "-"
 msgstr "-"
 
-#: ../src/generic/filepickerg.cpp:66
+#: ../src/generic/filepickerg.cpp:63
 msgid "..."
 msgstr "..."
 
-#: ../src/richtext/richtextindentspage.cpp:276
 #: ../src/richtext/richtextliststylepage.cpp:450
+#: ../src/richtext/richtextindentspage.cpp:276
 msgid "1.1"
 msgstr "1.1"
 
-#: ../src/richtext/richtextindentspage.cpp:277
 #: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextindentspage.cpp:277
 msgid "1.2"
 msgstr "1.2"
 
-#: ../src/richtext/richtextindentspage.cpp:278
 #: ../src/richtext/richtextliststylepage.cpp:452
+#: ../src/richtext/richtextindentspage.cpp:278
 msgid "1.3"
 msgstr "1.3"
 
-#: ../src/richtext/richtextindentspage.cpp:279
 #: ../src/richtext/richtextliststylepage.cpp:453
+#: ../src/richtext/richtextindentspage.cpp:279
 msgid "1.4"
 msgstr "1.4"
 
-#: ../src/richtext/richtextindentspage.cpp:280
 #: ../src/richtext/richtextliststylepage.cpp:454
+#: ../src/richtext/richtextindentspage.cpp:280
 msgid "1.5"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:281
 #: ../src/richtext/richtextliststylepage.cpp:455
+#: ../src/richtext/richtextindentspage.cpp:281
 msgid "1.6"
 msgstr "1.6"
 
-#: ../src/richtext/richtextindentspage.cpp:282
 #: ../src/richtext/richtextliststylepage.cpp:456
+#: ../src/richtext/richtextindentspage.cpp:282
 msgid "1.7"
 msgstr "1.7"
 
-#: ../src/richtext/richtextindentspage.cpp:283
 #: ../src/richtext/richtextliststylepage.cpp:457
+#: ../src/richtext/richtextindentspage.cpp:283
 msgid "1.8"
 msgstr "1.8"
 
-#: ../src/richtext/richtextindentspage.cpp:284
 #: ../src/richtext/richtextliststylepage.cpp:458
+#: ../src/richtext/richtextindentspage.cpp:284
 msgid "1.9"
 msgstr "1.9"
 
-#: ../src/common/paper.cpp:140
+#: ../src/common/paper.cpp:137
 msgid "10 x 11 in"
 msgstr "10 x 11 polgadas"
 
-#: ../src/common/paper.cpp:113
+#: ../src/common/paper.cpp:110
 msgid "10 x 14 in"
 msgstr "10 x 14 polgadas"
 
-#: ../src/common/paper.cpp:114
+#: ../src/common/paper.cpp:111
 msgid "11 x 17 in"
 msgstr "11 x 17 polgadas"
 
-#: ../src/common/paper.cpp:184
+#: ../src/common/paper.cpp:181
 msgid "12 x 11 in"
 msgstr "12 x 11 polgadas"
 
-#: ../src/common/paper.cpp:141
+#: ../src/common/paper.cpp:138
 msgid "15 x 11 in"
 msgstr "15 x 11 polgadas"
 
-#: ../src/richtext/richtextindentspage.cpp:285
 #: ../src/richtext/richtextliststylepage.cpp:459
+#: ../src/richtext/richtextindentspage.cpp:285
 msgid "2"
 msgstr "2"
 
-#: ../src/common/paper.cpp:132
+#: ../src/common/paper.cpp:129
 msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
 msgstr "Sobre 6 3/4, 3 5/8 x 6 1/2 in"
 
-#: ../src/common/paper.cpp:139
+#: ../src/common/paper.cpp:136
 msgid "9 x 11 in"
 msgstr "9 x 11 polgadas"
 
-#: ../src/html/htmprint.cpp:431
+#: ../src/html/htmprint.cpp:443
 msgid ": file does not exist!"
 msgstr ": o ficheiro non existe!"
 
-#: ../src/common/fontmap.cpp:199
+#: ../src/common/fontmap.cpp:196
 msgid ": unknown charset"
 msgstr ": xogo de caracteres descoñecido"
 
-#: ../src/common/fontmap.cpp:413
+#: ../src/common/fontmap.cpp:410
 msgid ": unknown encoding"
 msgstr ": codificación descoñecida"
 
-#: ../src/generic/wizard.cpp:443
+#: ../src/generic/wizard.cpp:438
 msgid "< &Back"
 msgstr "< &Atrás"
 
-#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:628
-#: ../src/osx/carbon/fontdlg.cpp:648
+#: ../src/osx/carbon/fontdlg.cpp:419 ../src/osx/carbon/fontdlg.cpp:625
+#: ../src/osx/carbon/fontdlg.cpp:645
 msgid "<Any Decorative>"
 msgstr "<Any Decorative>"
 
-#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:630
-#: ../src/osx/carbon/fontdlg.cpp:650
+#: ../src/osx/carbon/fontdlg.cpp:420 ../src/osx/carbon/fontdlg.cpp:627
+#: ../src/osx/carbon/fontdlg.cpp:647
 msgid "<Any Modern>"
 msgstr "<Any Modern>"
 
-#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:626
-#: ../src/osx/carbon/fontdlg.cpp:646
+#: ../src/osx/carbon/fontdlg.cpp:418 ../src/osx/carbon/fontdlg.cpp:623
+#: ../src/osx/carbon/fontdlg.cpp:643
 msgid "<Any Roman>"
 msgstr "<Any Roman>"
 
-#: ../src/osx/carbon/fontdlg.cpp:424 ../src/osx/carbon/fontdlg.cpp:632
-#: ../src/osx/carbon/fontdlg.cpp:652
+#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:629
+#: ../src/osx/carbon/fontdlg.cpp:649
 msgid "<Any Script>"
 msgstr "<Any Script>"
 
-#: ../src/osx/carbon/fontdlg.cpp:425 ../src/osx/carbon/fontdlg.cpp:637
-#: ../src/osx/carbon/fontdlg.cpp:656
+#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:634
+#: ../src/osx/carbon/fontdlg.cpp:653
 msgid "<Any Swiss>"
 msgstr "<Any Swiss>"
 
-#: ../src/osx/carbon/fontdlg.cpp:426 ../src/osx/carbon/fontdlg.cpp:634
-#: ../src/osx/carbon/fontdlg.cpp:654
+#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:631
+#: ../src/osx/carbon/fontdlg.cpp:651
 msgid "<Any Teletype>"
 msgstr "<Any Teletype>"
 
-#: ../src/osx/carbon/fontdlg.cpp:420
+#: ../src/osx/carbon/fontdlg.cpp:417
 msgid "<Any>"
 msgstr "<Calquera>"
 
-#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
 msgid "<DIR>"
 msgstr "<DIR>"
 
-#: ../src/generic/filectrlg.cpp:254 ../src/generic/filectrlg.cpp:277
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
 msgid "<DRIVE>"
 msgstr "<UNIDADE>"
 
-#: ../src/generic/filectrlg.cpp:252 ../src/generic/filectrlg.cpp:275
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
 msgid "<LINK>"
 msgstr "<ENLACE>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1264
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Cursiva grosa.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1270
+#: ../src/html/helpwnd.cpp:1268
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>cursiva grosa<u>subliñado</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1265
+#: ../src/html/helpwnd.cpp:1263
 msgid "<b>Bold face.</b> "
 msgstr "<b>Grosa.</b> "
 
-#: ../src/html/helpwnd.cpp:1264
+#: ../src/html/helpwnd.cpp:1262
 msgid "<i>Italic face.</i> "
 msgstr "<i>Cursiva.</i> "
 
@@ -1076,15 +1073,15 @@ msgstr "<i>Cursiva.</i> "
 msgid ">"
 msgstr ">"
 
-#: ../src/generic/dbgrptg.cpp:318
+#: ../src/generic/dbgrptg.cpp:317
 msgid "A debug report has been generated in the directory\n"
 msgstr "Xerouse un informe de depuración no cartafol\n"
 
-#: ../src/common/debugrpt.cpp:573
+#: ../src/common/debugrpt.cpp:574
 msgid "A debug report has been generated. It can be found in"
 msgstr "Xerouse un informe de depuración que se atopa en"
 
-#: ../src/common/xtixml.cpp:418
+#: ../src/common/xtixml.cpp:414
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Unha colección non baleara debe consistir en nodos do tipo \"element\""
 
@@ -1095,106 +1092,106 @@ msgstr "Unha colección non baleara debe consistir en nodos do tipo \"element\""
 msgid "A standard bullet name."
 msgstr "Un nome de viñeta estándar."
 
-#: ../src/common/paper.cpp:217
+#: ../src/common/paper.cpp:214
 msgid "A0 sheet, 841 x 1189 mm"
 msgstr "Folla A0, 841 x 1189 mm"
 
-#: ../src/common/paper.cpp:218
+#: ../src/common/paper.cpp:215
 msgid "A1 sheet, 594 x 841 mm"
 msgstr "Folla A1, 594 x 841 mm"
 
-#: ../src/common/paper.cpp:159
+#: ../src/common/paper.cpp:156
 msgid "A2 420 x 594 mm"
 msgstr "A2 420 x 594 mm"
 
-#: ../src/common/paper.cpp:156
+#: ../src/common/paper.cpp:153
 msgid "A3 Extra 322 x 445 mm"
 msgstr "A3 Extra 322 x 445 mm"
 
-#: ../src/common/paper.cpp:161
+#: ../src/common/paper.cpp:158
 msgid "A3 Extra Transverse 322 x 445 mm"
 msgstr "A3 Extra Transversal 322 x 445 mm"
 
-#: ../src/common/paper.cpp:170
+#: ../src/common/paper.cpp:167
 msgid "A3 Rotated 420 x 297 mm"
 msgstr "A3 Apaisado 420 x 297 mm"
 
-#: ../src/common/paper.cpp:160
+#: ../src/common/paper.cpp:157
 msgid "A3 Transverse 297 x 420 mm"
 msgstr "A3 Transversal 297 x 420 mm"
 
-#: ../src/common/paper.cpp:106
+#: ../src/common/paper.cpp:103
 msgid "A3 sheet, 297 x 420 mm"
 msgstr "Folla A3, 297 x 420 mm"
 
-#: ../src/common/paper.cpp:146
+#: ../src/common/paper.cpp:143
 msgid "A4 Extra 9.27 x 12.69 in"
 msgstr "A4 Extra 9,27 x 12,69 polgadas"
 
-#: ../src/common/paper.cpp:153
+#: ../src/common/paper.cpp:150
 msgid "A4 Plus 210 x 330 mm"
 msgstr "A4 Plus 210 x 330 mm"
 
-#: ../src/common/paper.cpp:171
+#: ../src/common/paper.cpp:168
 msgid "A4 Rotated 297 x 210 mm"
 msgstr "A4 Apaisada 297 x 210 mm"
 
-#: ../src/common/paper.cpp:148
+#: ../src/common/paper.cpp:145
 msgid "A4 Transverse 210 x 297 mm"
 msgstr "A4 Transversal, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:97
+#: ../src/common/paper.cpp:94
 msgid "A4 sheet, 210 x 297 mm"
 msgstr "Folla A4, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:107
+#: ../src/common/paper.cpp:104
 msgid "A4 small sheet, 210 x 297 mm"
 msgstr "Folla pequena A4, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:157
+#: ../src/common/paper.cpp:154
 msgid "A5 Extra 174 x 235 mm"
 msgstr "A5 Extra 174 x 235 mm"
 
-#: ../src/common/paper.cpp:172
+#: ../src/common/paper.cpp:169
 msgid "A5 Rotated 210 x 148 mm"
 msgstr "A5 Apaisada, 210 x 148 mm"
 
-#: ../src/common/paper.cpp:154
+#: ../src/common/paper.cpp:151
 msgid "A5 Transverse 148 x 210 mm"
 msgstr "A5 Transversal, 148 x 210 mm"
 
-#: ../src/common/paper.cpp:108
+#: ../src/common/paper.cpp:105
 msgid "A5 sheet, 148 x 210 mm"
 msgstr "Folla A5, 148 x 210 mm"
 
-#: ../src/common/paper.cpp:164
+#: ../src/common/paper.cpp:161
 msgid "A6 105 x 148 mm"
 msgstr "A6 105 x 148 mm"
 
-#: ../src/common/paper.cpp:177
+#: ../src/common/paper.cpp:174
 msgid "A6 Rotated 148 x 105 mm"
 msgstr "A6 Apaisada 148 x 105 mm"
 
-#: ../src/generic/fontdlgg.cpp:83 ../src/richtext/richtextformatdlg.cpp:529
-#: ../src/osx/carbon/fontdlg.cpp:153
+#: ../src/osx/carbon/fontdlg.cpp:150 ../src/generic/fontdlgg.cpp:79
+#: ../src/richtext/richtextformatdlg.cpp:521
 msgid "ABCDEFGabcdefg12345"
 msgstr "ABCDEFGabcdefg12345"
 
-#: ../src/richtext/richtextsymboldlg.cpp:458 ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
 msgid "ASCII"
 msgstr "ASCII"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "About"
 msgstr "Sobre"
 
-#: ../src/generic/aboutdlgg.cpp:140 ../src/osx/menu_osx.cpp:558
-#: ../src/msw/aboutdlg.cpp:64
+#: ../src/osx/menu_osx.cpp:450 ../src/generic/aboutdlgg.cpp:137
+#: ../src/msw/aboutdlg.cpp:61
 #, c-format
 msgid "About %s"
 msgstr "Sobre %s"
 
-#: ../src/osx/menu_osx.cpp:560
+#: ../src/osx/menu_osx.cpp:452
 #, fuzzy
 msgid "About..."
 msgstr "Sobre"
@@ -1204,38 +1201,38 @@ msgid "Absolute"
 msgstr "Absoluto"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:873
+#: ../src/propgrid/advprops.cpp:774
 #, fuzzy
 msgid "ActiveBorder"
 msgstr "Bordo"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:874
+#: ../src/propgrid/advprops.cpp:775
 msgid "ActiveCaption"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "Actual Size"
 msgstr "Tamaño &Actual"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:140 ../src/common/accelcmn.cpp:81
+#: ../src/common/stockitem.cpp:137 ../src/common/accelcmn.cpp:78
 msgid "Add"
 msgstr "Engadir"
 
-#: ../src/richtext/richtextbuffer.cpp:11455
+#: ../src/richtext/richtextbuffer.cpp:11454
 msgid "Add Column"
 msgstr "Engadir columna"
 
-#: ../src/richtext/richtextbuffer.cpp:11392
+#: ../src/richtext/richtextbuffer.cpp:11391
 msgid "Add Row"
 msgstr "Engadir fila"
 
-#: ../src/html/helpwnd.cpp:432
+#: ../src/html/helpwnd.cpp:430
 msgid "Add current page to bookmarks"
 msgstr "Engadir a páxina actual aos marcadores"
 
-#: ../src/generic/colrdlgg.cpp:366
+#: ../src/generic/colrdlgg.cpp:386
 msgid "Add to custom colours"
 msgstr "Engadir ás cores personalizadas"
 
@@ -1247,12 +1244,12 @@ msgstr "AddToPropertyCollection chamou a un método de acceso xenérico"
 msgid "AddToPropertyCollection called w/o valid adder"
 msgstr "AddToPropertyCollection chamado sen un adder axeitado"
 
-#: ../src/html/helpctrl.cpp:159
+#: ../src/html/helpctrl.cpp:155
 #, c-format
 msgid "Adding book %s"
 msgstr "Engadindo o libro %s"
 
-#: ../src/common/preferencescmn.cpp:43
+#: ../src/common/preferencescmn.cpp:40
 msgid "Advanced"
 msgstr "Avanzado"
 
@@ -1260,11 +1257,11 @@ msgstr "Avanzado"
 msgid "After a paragraph:"
 msgstr "Despois dun parágrafo:"
 
-#: ../src/common/stockitem.cpp:172
+#: ../src/common/stockitem.cpp:169
 msgid "Align Left"
 msgstr "Aliñar á Esquerda"
 
-#: ../src/common/stockitem.cpp:173
+#: ../src/common/stockitem.cpp:170
 msgid "Align Right"
 msgstr "Aliñar á Dereita"
 
@@ -1272,40 +1269,40 @@ msgstr "Aliñar á Dereita"
 msgid "Alignment"
 msgstr "Aliñado"
 
-#: ../src/generic/prntdlgg.cpp:215
+#: ../src/generic/prntdlgg.cpp:208
 msgid "All"
 msgstr "Todos"
 
-#: ../src/generic/filectrlg.cpp:1197 ../src/common/fldlgcmn.cpp:107
+#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1186
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Todos os ficheiros (%s)|%s"
 
-#: ../include/wx/defs.h:2886
+#: ../include/wx/defs.h:2582
 msgid "All files (*)|*"
 msgstr "Todos os ficheiros (*)|*"
 
-#: ../include/wx/defs.h:2883
+#: ../include/wx/defs.h:2579
 msgid "All files (*.*)|*.*"
 msgstr "Todos os ficheiros (*.*)|*.*"
 
-#: ../src/richtext/richtextstyles.cpp:1061
+#: ../src/richtext/richtextstyles.cpp:1058
 msgid "All styles"
 msgstr "Todos os estilos"
 
-#: ../src/propgrid/manager.cpp:1528
+#: ../src/propgrid/manager.cpp:1544
 msgid "Alphabetic Mode"
 msgstr "Modo alfabético"
 
-#: ../src/common/xtistrm.cpp:425
+#: ../src/common/xtistrm.cpp:422
 msgid "Already Registered Object passed to SetObjectClassInfo"
 msgstr "Pasouse obxecto xa rexistrado a SetObjectClassInfo"
 
-#: ../src/unix/dialup.cpp:353
+#: ../src/unix/dialup.cpp:352
 msgid "Already dialling ISP."
 msgstr "Chamando ao provedor de internet."
 
-#: ../src/common/accelcmn.cpp:331 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/accelcmn.cpp:345 ../src/univ/themes/win32.cpp:3753
 msgid "Alt+"
 msgstr "Alt+"
 
@@ -1314,34 +1311,34 @@ msgstr "Alt+"
 msgid "An optional corner radius for adding rounded corners."
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:576
+#: ../src/common/debugrpt.cpp:577
 msgid "And includes the following files:\n"
 msgstr "E inclúe os seguintes ficheiros:\n"
 
-#: ../src/generic/animateg.cpp:162
+#: ../src/generic/animateg.cpp:145
 #, c-format
 msgid "Animation file is not of type %ld."
 msgstr "O fichero de animación non é do tipo %ld."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:872
+#: ../src/propgrid/advprops.cpp:773
 msgid "AppWorkspace"
 msgstr ""
 
-#: ../src/generic/logg.cpp:1014
+#: ../src/generic/logg.cpp:1011
 #, c-format
 msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
 msgstr "Engadir rexistro ao ficheiro '%s'? (Se elixe [Non] sobreescribirase)"
 
-#: ../src/osx/menu_osx.cpp:577 ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:469 ../src/osx/menu_osx.cpp:477
 msgid "Application"
 msgstr "Aplicativo"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "Apply"
 msgstr "Aplicar"
 
-#: ../src/propgrid/advprops.cpp:1609
+#: ../src/propgrid/advprops.cpp:1515
 msgid "Aqua"
 msgstr ""
 
@@ -1350,30 +1347,30 @@ msgstr ""
 msgid "Arabic"
 msgstr "Árabe"
 
-#: ../src/common/fmapbase.cpp:153
+#: ../src/common/fmapbase.cpp:150
 msgid "Arabic (ISO-8859-6)"
 msgstr "Árabe (ISO-8859-6)"
 
-#: ../src/msw/ole/automtn.cpp:672
+#: ../src/msw/ole/automtn.cpp:663
 #, c-format
 msgid "Argument %u not found."
 msgstr "Non se atopou o argumento %u."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1753
+#: ../src/propgrid/advprops.cpp:1654
 #, fuzzy
 msgid "Arrow"
 msgstr "mañá"
 
-#: ../src/generic/aboutdlgg.cpp:184
+#: ../src/generic/aboutdlgg.cpp:181
 msgid "Artists"
 msgstr "Artistas"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "Ascending"
 msgstr "Ascendente"
 
-#: ../src/generic/filectrlg.cpp:433
+#: ../src/generic/filectrlg.cpp:429
 msgid "Attributes"
 msgstr "Atributos"
 
@@ -1383,90 +1380,90 @@ msgstr "Atributos"
 msgid "Available fonts."
 msgstr "Tipos de letra dispoñíbeis."
 
-#: ../src/common/paper.cpp:137
+#: ../src/common/paper.cpp:134
 msgid "B4 (ISO) 250 x 353 mm"
 msgstr "B4 (ISO) 250 x 353 mm"
 
-#: ../src/common/paper.cpp:173
+#: ../src/common/paper.cpp:170
 msgid "B4 (JIS) Rotated 364 x 257 mm"
 msgstr "B4 (JIS) Apaisada 364 x 257 mm"
 
-#: ../src/common/paper.cpp:127
+#: ../src/common/paper.cpp:124
 msgid "B4 Envelope, 250 x 353 mm"
 msgstr "Sobre B4, 250 x 353 mm"
 
-#: ../src/common/paper.cpp:109
+#: ../src/common/paper.cpp:106
 msgid "B4 sheet, 250 x 354 mm"
 msgstr "Folla B4, 250 x 354 mm"
 
-#: ../src/common/paper.cpp:158
+#: ../src/common/paper.cpp:155
 msgid "B5 (ISO) Extra 201 x 276 mm"
 msgstr "B5 (ISO) Extra 201 x 276 mm"
 
-#: ../src/common/paper.cpp:174
+#: ../src/common/paper.cpp:171
 msgid "B5 (JIS) Rotated 257 x 182 mm"
 msgstr "B5 (JIS) Apaisada 257 x 182 mm"
 
-#: ../src/common/paper.cpp:155
+#: ../src/common/paper.cpp:152
 msgid "B5 (JIS) Transverse 182 x 257 mm"
 msgstr "B5 (JIS) Transversal 182 x 257 mm"
 
-#: ../src/common/paper.cpp:128
+#: ../src/common/paper.cpp:125
 msgid "B5 Envelope, 176 x 250 mm"
 msgstr "Sobre B5, 176 x 250 mm"
 
-#: ../src/common/paper.cpp:110
+#: ../src/common/paper.cpp:107
 msgid "B5 sheet, 182 x 257 millimeter"
 msgstr "Folla B5, 182 x 257 millimetros"
 
-#: ../src/common/paper.cpp:182
+#: ../src/common/paper.cpp:179
 msgid "B6 (JIS) 128 x 182 mm"
 msgstr "B6 (JIS) 128 x 182 mm"
 
-#: ../src/common/paper.cpp:183
+#: ../src/common/paper.cpp:180
 msgid "B6 (JIS) Rotated 182 x 128 mm"
 msgstr "B6 (JIS) Apaisada 182 x 128 mm"
 
-#: ../src/common/paper.cpp:129
+#: ../src/common/paper.cpp:126
 msgid "B6 Envelope, 176 x 125 mm"
 msgstr "Sobre B6, 176 x 125 mm"
 
-#: ../src/common/imagbmp.cpp:531 ../src/common/imagbmp.cpp:561
-#: ../src/common/imagbmp.cpp:576
+#: ../src/common/imagbmp.cpp:528 ../src/common/imagbmp.cpp:558
+#: ../src/common/imagbmp.cpp:573
 msgid "BMP: Couldn't allocate memory."
 msgstr "BMP: Non se puido asignar memoria."
 
-#: ../src/common/imagbmp.cpp:100
+#: ../src/common/imagbmp.cpp:97
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: Non se puido gardar imaxe non válida."
 
-#: ../src/common/imagbmp.cpp:356
+#: ../src/common/imagbmp.cpp:353
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: No se puido escribir o mapa de cor RGB."
 
-#: ../src/common/imagbmp.cpp:490
+#: ../src/common/imagbmp.cpp:487
 msgid "BMP: Couldn't write data."
 msgstr "BMP: Non se puideron escribir os datos."
 
-#: ../src/common/imagbmp.cpp:246
+#: ../src/common/imagbmp.cpp:243
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: Non se puido escribir a cabeceira (Bitmap) do arquito."
 
-#: ../src/common/imagbmp.cpp:269
+#: ../src/common/imagbmp.cpp:266
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: Non se puido escribir a cabeceira (BitmapInfo) do ficheiro."
 
-#: ../src/common/imagbmp.cpp:140
+#: ../src/common/imagbmp.cpp:137
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage non ten a súa propia wxPalette."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:142 ../src/common/accelcmn.cpp:52
+#: ../src/common/stockitem.cpp:139 ../src/common/accelcmn.cpp:49
 msgid "Back"
 msgstr "Atrás"
 
+#: ../src/richtext/richtextformatdlg.cpp:377
 #: ../src/richtext/richtextbackgroundpage.cpp:148
-#: ../src/richtext/richtextformatdlg.cpp:384
 msgid "Background"
 msgstr "Fondo"
 
@@ -1474,21 +1471,21 @@ msgstr "Fondo"
 msgid "Background &colour:"
 msgstr "Cor de fondo:"
 
-#: ../src/osx/carbon/fontdlg.cpp:220
+#: ../src/osx/carbon/fontdlg.cpp:217
 msgid "Background colour"
 msgstr "Cor de fondo"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:52
+#: ../src/common/accelcmn.cpp:49
 #, fuzzy
 msgid "Backspace"
 msgstr "Atrás"
 
-#: ../src/common/fmapbase.cpp:160
+#: ../src/common/fmapbase.cpp:157
 msgid "Baltic (ISO-8859-13)"
 msgstr "Báltico (ISO-8859-13)"
 
-#: ../src/common/fmapbase.cpp:151
+#: ../src/common/fmapbase.cpp:148
 msgid "Baltic (old) (ISO-8859-4)"
 msgstr "Báltico (antigo) (ISO-8859-4)"
 
@@ -1501,25 +1498,25 @@ msgstr "Antes dun parágrafo:"
 msgid "Bitmap"
 msgstr "Mapa de bits"
 
-#: ../src/propgrid/advprops.cpp:1594
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Black"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1755
+#: ../src/propgrid/advprops.cpp:1656
 msgid "Blank"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1603
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Blue"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:345
+#: ../src/generic/colrdlgg.cpp:365
 msgid "Blue:"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:333 ../src/richtext/richtextfontpage.cpp:355
-#: ../src/osx/carbon/fontdlg.cpp:354 ../src/common/stockitem.cpp:143
+#: ../src/osx/carbon/fontdlg.cpp:351 ../src/common/stockitem.cpp:140
+#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:355
 msgid "Bold"
 msgstr "Grosa"
 
@@ -1528,32 +1525,36 @@ msgstr "Grosa"
 msgid "Border"
 msgstr "Bordo"
 
-#: ../src/richtext/richtextformatdlg.cpp:379
+#: ../src/richtext/richtextformatdlg.cpp:372
 msgid "Borders"
 msgstr "Bordos"
 
-#: ../src/richtext/richtextsizepage.cpp:288 ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141 ../src/richtext/richtextsizepage.cpp:288
 msgid "Bottom"
 msgstr "Abaixo"
 
-#: ../src/generic/prntdlgg.cpp:893
+#: ../src/generic/prntdlgg.cpp:886
 msgid "Bottom margin (mm):"
 msgstr "Marxe inferior (mm):"
 
-#: ../src/richtext/richtextbuffer.cpp:9383
+#: ../src/richtext/richtextbuffer.cpp:9380
 msgid "Box Properties"
 msgstr "Propiedades da caixa"
 
-#: ../src/richtext/richtextstyles.cpp:1065
+#: ../src/richtext/richtextstyles.cpp:1062
 msgid "Box styles"
 msgstr "Estilos de caixa"
 
-#: ../src/propgrid/advprops.cpp:1602
+#: ../src/osx/cocoa/menu.mm:292
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1508
 #, fuzzy
 msgid "Brown"
 msgstr "Explorar"
 
-#: ../src/common/filepickercmn.cpp:43 ../src/common/filepickercmn.cpp:44
+#: ../src/common/filepickercmn.cpp:40 ../src/common/filepickercmn.cpp:41
 msgid "Browse"
 msgstr "Explorar"
 
@@ -1566,73 +1567,73 @@ msgstr "&Aliñamento de viñetas:"
 msgid "Bullet style"
 msgstr "Estilo de viñetas"
 
-#: ../src/richtext/richtextformatdlg.cpp:359
+#: ../src/richtext/richtextformatdlg.cpp:352
 msgid "Bullets"
 msgstr "Viñetas"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1756
+#: ../src/propgrid/advprops.cpp:1657
 #, fuzzy
 msgid "Bullseye"
 msgstr "Estilo de viñetas"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:875
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonFace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:876
+#: ../src/propgrid/advprops.cpp:777
 msgid "ButtonHighlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:877
+#: ../src/propgrid/advprops.cpp:778
 msgid "ButtonShadow"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:878
+#: ../src/propgrid/advprops.cpp:779
 msgid "ButtonText"
 msgstr ""
 
-#: ../src/common/paper.cpp:98
+#: ../src/common/paper.cpp:95
 msgid "C sheet, 17 x 22 in"
 msgstr "Folla C, 17 x 22 polgadas"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "C&lear"
 msgstr "&Borrar"
 
-#: ../src/generic/fontdlgg.cpp:406
+#: ../src/generic/fontdlgg.cpp:403
 msgid "C&olour:"
 msgstr "C&or:"
 
-#: ../src/common/paper.cpp:123
+#: ../src/common/paper.cpp:120
 msgid "C3 Envelope, 324 x 458 mm"
 msgstr "Sobre C3, 324 x 458 mm"
 
-#: ../src/common/paper.cpp:124
+#: ../src/common/paper.cpp:121
 msgid "C4 Envelope, 229 x 324 mm"
 msgstr "Sobre C4, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:122
+#: ../src/common/paper.cpp:119
 msgid "C5 Envelope, 162 x 229 mm"
 msgstr "Sobre C5, 162 x 229 mm"
 
-#: ../src/common/paper.cpp:125
+#: ../src/common/paper.cpp:122
 msgid "C6 Envelope, 114 x 162 mm"
 msgstr "Sobre C6, 114 x 162 mm"
 
-#: ../src/common/paper.cpp:126
+#: ../src/common/paper.cpp:123
 msgid "C65 Envelope, 114 x 229 mm"
 msgstr "Sobre C65, 114 x 229 mm"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "CD-Rom"
 msgstr "CD-Rom"
 
-#: ../src/html/chm.cpp:815 ../src/html/chm.cpp:874
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:865
 msgid "CHM handler currently supports only local files!"
 msgstr "O manexador CHM só admite ficheiros locais!"
 
@@ -1640,194 +1641,198 @@ msgstr "O manexador CHM só admite ficheiros locais!"
 msgid "Ca&pitals"
 msgstr "Ma&iúsculas"
 
-#: ../src/common/cmdproc.cpp:267
+#: ../src/common/cmdproc.cpp:260
 msgid "Can't &Undo "
 msgstr "Non se puido &desfacer "
 
-#: ../src/common/image.cpp:2824
+#: ../src/common/image.cpp:2924
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 "Non é posíbel determinar automaticamente o formato da imaxe debido a unha "
 "entrada non localizábel."
 
-#: ../src/msw/registry.cpp:506
+#: ../src/msw/registry.cpp:495
 #, c-format
 msgid "Can't close registry key '%s'"
 msgstr "Non se puido pechar a clave '%s' do rexistro"
 
-#: ../src/msw/registry.cpp:584
+#: ../src/msw/registry.cpp:573
 #, c-format
 msgid "Can't copy values of unsupported type %d."
 msgstr "Non se poden copiar valores do tipo non admitido %d."
 
-#: ../src/msw/registry.cpp:487
+#: ../src/msw/registry.cpp:476
 #, c-format
 msgid "Can't create registry key '%s'"
 msgstr "Non se puido crear a clave do rexistro '%s'"
 
-#: ../src/msw/thread.cpp:665
+#: ../src/msw/thread.cpp:657
 msgid "Can't create thread"
 msgstr "Non se pode crear o fío de execución"
 
-#: ../src/msw/window.cpp:3691
-#, c-format
-msgid "Can't create window of class %s"
-msgstr "Non se puido crear unha xanela de clase %s"
-
-#: ../src/msw/registry.cpp:777
+#: ../src/msw/registry.cpp:765
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Non se puido eliminar a clave '%s'"
 
-#: ../src/msw/iniconf.cpp:458
+#: ../src/msw/iniconf.cpp:455
 #, c-format
 msgid "Can't delete the INI file '%s'"
 msgstr "Non se puido eliminar o ficheiro INI '%s'"
 
-#: ../src/msw/registry.cpp:805
+#: ../src/msw/registry.cpp:793
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Non se puido eliminar o valor '%s' da clave '%s'"
 
-#: ../src/msw/registry.cpp:1171
+#: ../src/msw/registry.cpp:1159
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Non se puido enumerar as subclaves da clave '%s'"
 
-#: ../src/msw/registry.cpp:1132
+#: ../src/msw/registry.cpp:1120
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Non se puido enumerar os valores da clave '%s'"
 
-#: ../src/msw/registry.cpp:1389
+#: ../src/msw/registry.cpp:1377
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Non se pode exportar o valor do tipo non admitido %d."
 
-#: ../src/common/ffile.cpp:254
+#: ../src/common/ffile.cpp:253
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Non se puido atopar a posición actual no ficheiro '%s'"
 
-#: ../src/msw/registry.cpp:418
+#: ../src/msw/registry.cpp:407
 #, c-format
 msgid "Can't get info about registry key '%s'"
 msgstr "Non se puido obter información sobre a clave do rexistro '%s'"
 
-#: ../src/common/zstream.cpp:346
+#: ../src/msw/webview_ie.cpp:1024
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "Non se pode especificar a prioridade dos fíos de execución"
+
+#: ../src/common/zstream.cpp:343
 msgid "Can't initialize zlib deflate stream."
 msgstr "Non se pode inicar o fluxo de compresión de zlib."
 
-#: ../src/common/zstream.cpp:185
+#: ../src/common/zstream.cpp:182
 msgid "Can't initialize zlib inflate stream."
 msgstr "Non se pode inicializar o fluxo de descompresión de zlib."
 
-#: ../src/msw/fswatcher.cpp:476
+#: ../src/msw/fswatcher.cpp:475
 #, c-format
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "Non se poden monitorizar os cambios no cartafol inexistente \"%s\"."
 
-#: ../src/msw/registry.cpp:454
+#: ../src/msw/registry.cpp:443
 #, c-format
 msgid "Can't open registry key '%s'"
 msgstr "Non se puido abrir a clave '%s' do rexistro"
 
-#: ../src/common/zstream.cpp:252
+#: ../src/common/zstream.cpp:249
 #, c-format
 msgid "Can't read from inflate stream: %s"
 msgstr "Non se pode ler dende o fluxo de descompresión: %s"
 
-#: ../src/common/zstream.cpp:244
+#: ../src/common/zstream.cpp:241
 msgid "Can't read inflate stream: unexpected EOF in underlying stream."
 msgstr ""
 "Non se pode ler o fluxo de descompresión: EOF inesperado no fluxo subxacente."
 
-#: ../src/msw/registry.cpp:1064
+#: ../src/msw/registry.cpp:1052
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Non se puido ler o valor de '%s'"
 
-#: ../src/msw/registry.cpp:878 ../src/msw/registry.cpp:910
-#: ../src/msw/registry.cpp:975
+#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
+#: ../src/msw/registry.cpp:963
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Non se puido ler o valor da clave '%s'"
 
-#: ../src/common/image.cpp:2620
+#: ../src/msw/webview_ie.cpp:1017
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/common/image.cpp:2715
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "Non se puido gardar a imaxe no ficheiro '%s': extensión descoñecida."
 
-#: ../src/generic/logg.cpp:573 ../src/generic/logg.cpp:976
+#: ../src/generic/logg.cpp:570 ../src/generic/logg.cpp:973
 msgid "Can't save log contents to file."
 msgstr "Non se puido gardar o contido do rexistro nun ficheiro."
 
-#: ../src/msw/thread.cpp:629
+#: ../src/msw/thread.cpp:621
 msgid "Can't set thread priority"
 msgstr "Non se pode especificar a prioridade dos fíos de execución"
 
-#: ../src/msw/registry.cpp:896 ../src/msw/registry.cpp:938
-#: ../src/msw/registry.cpp:1081
+#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
+#: ../src/msw/registry.cpp:1069
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Non se puido estabelecer o valor de '%s'"
 
-#: ../src/unix/utilsunx.cpp:351
+#: ../src/unix/utilsunx.cpp:353
 msgid "Can't write to child process's stdin"
 msgstr "Non se pode escribir na entrada estándar do proceso fillo"
 
-#: ../src/common/zstream.cpp:427
+#: ../src/common/zstream.cpp:424
 #, c-format
 msgid "Can't write to deflate stream: %s"
 msgstr "Non se pode escribir no fluxo de compresión: %s"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:279 ../src/richtext/richtextstyledlg.cpp:300
-#: ../src/common/stockitem.cpp:145 ../src/common/accelcmn.cpp:71
-#: ../src/msw/msgdlg.cpp:454 ../src/msw/progdlg.cpp:673
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:142
+#: ../src/common/accelcmn.cpp:68 ../src/motif/msgdlg.cpp:196
+#: ../src/gtk1/fontdlg.cpp:144 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/progdlg.cpp:940 ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: ../src/common/filefn.cpp:1261
+#: ../src/common/filefn.cpp:1149
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Non se puideron enumerar os ficheiros '%s'"
 
-#: ../src/msw/dir.cpp:263
+#: ../src/msw/dir.cpp:260
 #, c-format
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Non se puideron enumerar os ficheiros do cartafol '%s'"
 
-#: ../src/msw/dialup.cpp:523
+#: ../src/msw/dialup.cpp:517
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Non se atopa conexión telefónica activa: %s"
 
-#: ../src/msw/dialup.cpp:827
+#: ../src/msw/dialup.cpp:821
 msgid "Cannot find the location of address book file"
 msgstr "Non se puido atopar a localización do ficheiro de axenda"
 
-#: ../src/msw/ole/automtn.cpp:562
+#: ../src/msw/ole/automtn.cpp:553
 #, c-format
 msgid "Cannot get an active instance of \"%s\""
 msgstr "Non se pode atopar unha instancia activa de \"%s\""
 
-#: ../src/unix/threadpsx.cpp:1035
+#: ../src/unix/threadpsx.cpp:1053
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr ""
 "Non se pode obter un rango de prioridade para a política de planificación %d."
 
-#: ../src/unix/utilsunx.cpp:987
+#: ../src/unix/utilsunx.cpp:989
 msgid "Cannot get the hostname"
 msgstr "Non se puido obter o nome de máquina"
 
-#: ../src/unix/utilsunx.cpp:1023
+#: ../src/unix/utilsunx.cpp:1025
 msgid "Cannot get the official hostname"
 msgstr "Non se puido obter o nome oficial da máquina"
 
-#: ../src/msw/dialup.cpp:928
+#: ../src/msw/dialup.cpp:922
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Non se pode colgar - non hai conexión telefónica."
 
@@ -1835,128 +1840,128 @@ msgstr "Non se pode colgar - non hai conexión telefónica."
 msgid "Cannot initialize OLE"
 msgstr "Non se puido inicializar OLE"
 
-#: ../src/common/socket.cpp:853
+#: ../src/common/socket.cpp:850
 msgid "Cannot initialize sockets"
 msgstr "Non se poden inicializar os sockets"
 
-#: ../src/msw/volume.cpp:619
+#: ../src/msw/volume.cpp:627
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Non se puido cargar a icona dende '%s'."
 
-#: ../src/xrc/xmlres.cpp:360
+#: ../src/xrc/xmlres.cpp:358
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Non se poden cargar os recursos de '%s'."
 
-#: ../src/xrc/xmlres.cpp:742
+#: ../src/xrc/xmlres.cpp:740
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Non se poden cargar os recursos dende o ficheiro '%s'."
 
-#: ../src/html/htmlfilt.cpp:137
+#: ../src/html/htmlfilt.cpp:134
 #, c-format
 msgid "Cannot open HTML document: %s"
 msgstr "Non se puido abrir o documento HTML: %s"
 
-#: ../src/html/helpdata.cpp:667
+#: ../src/html/helpdata.cpp:660
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Non se puido abrir o libro de axuda HTML: %s"
 
-#: ../src/html/helpdata.cpp:299
+#: ../src/html/helpdata.cpp:296
 #, c-format
 msgid "Cannot open contents file: %s"
 msgstr "Non se pode abrir o ficheiro de contido: %s"
 
-#: ../src/generic/dcpsg.cpp:1667
+#: ../src/generic/dcpsg.cpp:1665
 msgid "Cannot open file for PostScript printing!"
 msgstr "Non se pode abrir o ficheiro para a impresión PostScript!"
 
-#: ../src/html/helpdata.cpp:313
+#: ../src/html/helpdata.cpp:310
 #, c-format
 msgid "Cannot open index file: %s"
 msgstr "Non se puido abrir o ficheiro de índice: %s"
 
-#: ../src/xrc/xmlres.cpp:724
+#: ../src/xrc/xmlres.cpp:722
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Non se pode abrir o ficheiro de recursos '%s'."
 
-#: ../src/html/helpwnd.cpp:1534
+#: ../src/html/helpwnd.cpp:1532
 msgid "Cannot print empty page."
 msgstr "Non se pode imprimir unha páxina en branco."
 
-#: ../src/msw/volume.cpp:507
+#: ../src/msw/volume.cpp:515
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Non se pode ler a clase de '%s'!"
 
-#: ../src/msw/thread.cpp:888
+#: ../src/msw/thread.cpp:894
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Non se pode retomar o fío de execución %lx"
 
-#: ../src/unix/threadpsx.cpp:1016
+#: ../src/unix/threadpsx.cpp:1028
 msgid "Cannot retrieve thread scheduling policy."
 msgstr ""
 "Non se pode recuperar a política de planificación de fíos de execución."
 
-#: ../src/common/intl.cpp:558
+#: ../src/common/intl.cpp:365
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "Non se pode configurar o idioma \"%s\"."
 
-#: ../src/unix/threadpsx.cpp:831 ../src/msw/thread.cpp:546
+#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
 msgid "Cannot start thread: error writing TLS."
 msgstr "Non se pode iniciar o fío de execución: erro ao escribit TLS."
 
-#: ../src/msw/thread.cpp:872
+#: ../src/msw/thread.cpp:864
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Non se pode suspender o fío de execución %lx"
 
-#: ../src/msw/thread.cpp:794
+#: ../src/msw/thread.cpp:786
 msgid "Cannot wait for thread termination"
 msgstr "Non se pode agardar pola finalización do fío de execución"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:75
+#: ../src/common/accelcmn.cpp:72
 #, fuzzy
 msgid "Capital"
 msgstr "Ma&iúsculas"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:879
+#: ../src/propgrid/advprops.cpp:780
 msgid "CaptionText"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:531
 msgid "Case sensitive"
 msgstr "Sensíbel a maiúsculas/minúsculas"
 
-#: ../src/propgrid/manager.cpp:1509
+#: ../src/propgrid/manager.cpp:1527
 msgid "Categorized Mode"
 msgstr "Modo categorizado"
 
-#: ../src/richtext/richtextbuffer.cpp:9968
+#: ../src/richtext/richtextbuffer.cpp:9965
 msgid "Cell Properties"
 msgstr "Propiedades de &cela"
 
-#: ../src/common/fmapbase.cpp:161
+#: ../src/common/fmapbase.cpp:158
 msgid "Celtic (ISO-8859-14)"
 msgstr "Céltico (ISO-8859-14)"
 
-#: ../src/richtext/richtextindentspage.cpp:160
 #: ../src/richtext/richtextliststylepage.cpp:349
+#: ../src/richtext/richtextindentspage.cpp:160
 msgid "Cen&tred"
 msgstr "Cen&trado"
 
-#: ../src/common/stockitem.cpp:170
+#: ../src/common/stockitem.cpp:167
 msgid "Centered"
 msgstr "Centrado"
 
-#: ../src/common/fmapbase.cpp:149
+#: ../src/common/fmapbase.cpp:146
 msgid "Central European (ISO-8859-2)"
 msgstr "Centroeuropeo (ISO-8859-2)"
 
@@ -1965,10 +1970,10 @@ msgstr "Centroeuropeo (ISO-8859-2)"
 msgid "Centre"
 msgstr "Centrar"
 
-#: ../src/richtext/richtextindentspage.cpp:162
-#: ../src/richtext/richtextindentspage.cpp:164
 #: ../src/richtext/richtextliststylepage.cpp:351
 #: ../src/richtext/richtextliststylepage.cpp:353
+#: ../src/richtext/richtextindentspage.cpp:162
+#: ../src/richtext/richtextindentspage.cpp:164
 msgid "Centre text."
 msgstr "Centrar texto."
 
@@ -1981,24 +1986,24 @@ msgstr "Centrado"
 msgid "Ch&oose..."
 msgstr "&Elixir..."
 
-#: ../src/richtext/richtextbuffer.cpp:4354
+#: ../src/richtext/richtextbuffer.cpp:4351
 msgid "Change List Style"
 msgstr "Cambiar estilo de lista"
 
-#: ../src/richtext/richtextbuffer.cpp:3709
+#: ../src/richtext/richtextbuffer.cpp:3706
 msgid "Change Object Style"
 msgstr "Cambiar estilo de obxecto"
 
-#: ../src/richtext/richtextbuffer.cpp:3982
-#: ../src/richtext/richtextbuffer.cpp:8129
+#: ../src/richtext/richtextbuffer.cpp:3979
+#: ../src/richtext/richtextbuffer.cpp:8125
 msgid "Change Properties"
 msgstr "Cambiar propiedades"
 
-#: ../src/richtext/richtextbuffer.cpp:3526
+#: ../src/richtext/richtextbuffer.cpp:3523
 msgid "Change Style"
 msgstr "Cambiar estilo"
 
-#: ../src/common/fileconf.cpp:341
+#: ../src/common/fileconf.cpp:335
 #, c-format
 msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
 msgstr ""
@@ -2010,12 +2015,12 @@ msgid "Changing current directory to \"%s\" failed"
 msgstr "Erro ao crear o cartafol \"%s\""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1757
+#: ../src/propgrid/advprops.cpp:1658
 #, fuzzy
 msgid "Character"
 msgstr "&Código de caracter:"
 
-#: ../src/richtext/richtextstyles.cpp:1063
+#: ../src/richtext/richtextstyles.cpp:1060
 msgid "Character styles"
 msgstr "Estilos de caracter"
 
@@ -2053,20 +2058,20 @@ msgstr "Marcar para meter a viñeta entre parénteses."
 msgid "Check to indicate right-to-left text layout."
 msgstr "Prema para cambiar a cor do texto."
 
-#: ../src/osx/carbon/fontdlg.cpp:356 ../src/osx/carbon/fontdlg.cpp:358
+#: ../src/osx/carbon/fontdlg.cpp:353 ../src/osx/carbon/fontdlg.cpp:355
 msgid "Check to make the font bold."
 msgstr "Marcar para letra grosa."
 
-#: ../src/osx/carbon/fontdlg.cpp:363 ../src/osx/carbon/fontdlg.cpp:365
+#: ../src/osx/carbon/fontdlg.cpp:360 ../src/osx/carbon/fontdlg.cpp:362
 msgid "Check to make the font italic."
 msgstr "Marcar para letra cursiva."
 
-#: ../src/osx/carbon/fontdlg.cpp:372 ../src/osx/carbon/fontdlg.cpp:374
+#: ../src/osx/carbon/fontdlg.cpp:369 ../src/osx/carbon/fontdlg.cpp:371
 msgid "Check to make the font underlined."
 msgstr "Marcar para subliñado."
 
-#: ../src/richtext/richtextstyledlg.cpp:289
-#: ../src/richtext/richtextstyledlg.cpp:291
+#: ../src/richtext/richtextstyledlg.cpp:285
+#: ../src/richtext/richtextstyledlg.cpp:287
 msgid "Check to restart numbering."
 msgstr "Marcar para reiniciar numeración."
 
@@ -2100,51 +2105,51 @@ msgstr "Marcar para amosar superíndices."
 msgid "Check to suppress hyphenation."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:763
+#: ../src/msw/dialup.cpp:757
 msgid "Choose ISP to dial"
 msgstr "Elixir ISP ao que conectar"
 
-#: ../src/propgrid/props.cpp:1922
+#: ../src/propgrid/props.cpp:1904
 msgid "Choose a directory:"
 msgstr "Elixir un cartafol:"
 
-#: ../src/propgrid/props.cpp:1975
+#: ../src/propgrid/props.cpp:2199
 msgid "Choose a file"
 msgstr "Elixir un ficheiro"
 
-#: ../src/generic/colrdlgg.cpp:158 ../src/gtk/colordlg.cpp:54
+#: ../src/generic/colrdlgg.cpp:156 ../src/gtk/colordlg.cpp:49
 msgid "Choose colour"
 msgstr "Elixa unha cor"
 
-#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/gtk1/fontdlg.cpp:125 ../src/generic/fontpickerg.cpp:47
+#: ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Elixa un tipo de letra"
 
-#: ../src/common/module.cpp:74
+#: ../src/common/module.cpp:71
 #, c-format
 msgid "Circular dependency involving module \"%s\" detected."
 msgstr "Detectada dependencia circular relacionada co módulo \"%s\"."
 
-#: ../src/aui/tabmdi.cpp:108 ../src/generic/mdig.cpp:97
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
 msgid "Cl&ose"
 msgstr "&Pechar"
 
-#: ../src/msw/ole/automtn.cpp:684
+#: ../src/msw/ole/automtn.cpp:675
 msgid "Class not registered."
 msgstr "Clase non rexistrada."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:147 ../src/common/accelcmn.cpp:72
+#: ../src/common/stockitem.cpp:144 ../src/common/accelcmn.cpp:69
 msgid "Clear"
 msgstr "Borrar"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "Clear the log contents"
 msgstr "Borrar o contido do rexistro"
 
-#: ../src/richtext/richtextstyledlg.cpp:252
-#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:248
+#: ../src/richtext/richtextstyledlg.cpp:250
 msgid "Click to apply the selected style."
 msgstr "Prema para aplicar o estilo seleccionado."
 
@@ -2155,15 +2160,15 @@ msgstr "Prema para aplicar o estilo seleccionado."
 msgid "Click to browse for a symbol."
 msgstr "Prema para atopar un símbolo."
 
-#: ../src/osx/carbon/fontdlg.cpp:403 ../src/osx/carbon/fontdlg.cpp:405
+#: ../src/osx/carbon/fontdlg.cpp:400 ../src/osx/carbon/fontdlg.cpp:402
 msgid "Click to cancel changes to the font."
 msgstr "Prema para cancelar cambios no tipo de letra."
 
-#: ../src/generic/fontdlgg.cpp:472 ../src/generic/fontdlgg.cpp:491
+#: ../src/generic/fontdlgg.cpp:468 ../src/generic/fontdlgg.cpp:487
 msgid "Click to cancel the font selection."
 msgstr "Clique para cancelar a selección de tipo de letra."
 
-#: ../src/osx/carbon/fontdlg.cpp:384 ../src/osx/carbon/fontdlg.cpp:386
+#: ../src/osx/carbon/fontdlg.cpp:381 ../src/osx/carbon/fontdlg.cpp:383
 msgid "Click to change the font colour."
 msgstr "Prema para cambiar a cor da letra."
 
@@ -2182,37 +2187,37 @@ msgstr "Prema para cambiar a cor do texto."
 msgid "Click to choose the font for this level."
 msgstr "Prema para elixir o tipo de letra para este nivel."
 
-#: ../src/richtext/richtextstyledlg.cpp:279
-#: ../src/richtext/richtextstyledlg.cpp:281
+#: ../src/richtext/richtextstyledlg.cpp:275
+#: ../src/richtext/richtextstyledlg.cpp:277
 msgid "Click to close this window."
 msgstr "Prema para pechar esta xanela."
 
-#: ../src/osx/carbon/fontdlg.cpp:410 ../src/osx/carbon/fontdlg.cpp:412
+#: ../src/osx/carbon/fontdlg.cpp:407 ../src/osx/carbon/fontdlg.cpp:409
 msgid "Click to confirm changes to the font."
 msgstr "Prema para confirmar cambios no tipo de letra."
 
-#: ../src/generic/fontdlgg.cpp:477 ../src/generic/fontdlgg.cpp:479
-#: ../src/generic/fontdlgg.cpp:484 ../src/generic/fontdlgg.cpp:486
+#: ../src/generic/fontdlgg.cpp:473 ../src/generic/fontdlgg.cpp:475
+#: ../src/generic/fontdlgg.cpp:480 ../src/generic/fontdlgg.cpp:482
 msgid "Click to confirm the font selection."
 msgstr "Prema para confirmar a selección de tipo de letra."
 
-#: ../src/richtext/richtextstyledlg.cpp:244
-#: ../src/richtext/richtextstyledlg.cpp:246
+#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:242
 msgid "Click to create a new box style."
 msgstr "Prema para crear un novo estilo de caixa."
 
-#: ../src/richtext/richtextstyledlg.cpp:226
-#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:224
 msgid "Click to create a new character style."
 msgstr "Prema para crear un novo estilo de caracteres."
 
-#: ../src/richtext/richtextstyledlg.cpp:238
-#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:236
 msgid "Click to create a new list style."
 msgstr "Prema para crear un novo estilo de lista."
 
-#: ../src/richtext/richtextstyledlg.cpp:232
-#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:230
 msgid "Click to create a new paragraph style."
 msgstr "Prema para crear un novo estilo de parágrafo."
 
@@ -2226,8 +2231,8 @@ msgstr "Prema para crear unha nova tabulación."
 msgid "Click to delete all tab positions."
 msgstr "Prema para eliminar todas as tabulacións."
 
-#: ../src/richtext/richtextstyledlg.cpp:270
-#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:268
 msgid "Click to delete the selected style."
 msgstr "Prema para eliminar o estilo seleccionado."
 
@@ -2236,25 +2241,25 @@ msgstr "Prema para eliminar o estilo seleccionado."
 msgid "Click to delete the selected tab position."
 msgstr "Prema para eliminar a tabulación seleccionada."
 
-#: ../src/richtext/richtextstyledlg.cpp:264
-#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:262
 msgid "Click to edit the selected style."
 msgstr "Prema para editar o estilo seleccionado."
 
-#: ../src/richtext/richtextstyledlg.cpp:258
-#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:256
 msgid "Click to rename the selected style."
 msgstr "Prema para renomear o estilo seleccionado."
 
-#: ../src/generic/dbgrptg.cpp:97 ../src/generic/progdlgg.cpp:759
-#: ../src/richtext/richtextstyledlg.cpp:277
-#: ../src/richtext/richtextsymboldlg.cpp:476 ../src/common/stockitem.cpp:148
-#: ../src/msw/progdlg.cpp:170 ../src/msw/progdlg.cpp:679
-#: ../src/html/helpdlg.cpp:90
+#: ../src/common/stockitem.cpp:145 ../src/generic/dbgrptg.cpp:94
+#: ../src/generic/progdlgg.cpp:781 ../src/msw/progdlg.cpp:211
+#: ../src/msw/progdlg.cpp:946 ../src/html/helpdlg.cpp:87
+#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextstyledlg.cpp:273
 msgid "Close"
 msgstr "Pechar"
 
-#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:98
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
 msgid "Close All"
 msgstr "Pechar todo"
 
@@ -2262,43 +2267,43 @@ msgstr "Pechar todo"
 msgid "Close current document"
 msgstr "Pechar o documento actual"
 
-#: ../src/generic/logg.cpp:516
+#: ../src/generic/logg.cpp:513
 msgid "Close this window"
 msgstr "Pechar esta xanela"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6006
+#: ../src/generic/datavgen.cpp:6811
 msgid "Collapse"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "Color"
 msgstr "Cor"
 
-#: ../src/richtext/richtextformatdlg.cpp:776
+#: ../src/richtext/richtextformatdlg.cpp:768
 msgid "Colour"
 msgstr "Cor"
 
-#: ../src/msw/colordlg.cpp:158
+#: ../src/msw/colordlg.cpp:227
 #, c-format
 msgid "Colour selection dialog failed with error %0lx."
 msgstr "Fallou o diálogo de selección de cor co erro %0lx."
 
-#: ../src/osx/carbon/fontdlg.cpp:380
+#: ../src/osx/carbon/fontdlg.cpp:377
 msgid "Colour:"
 msgstr "Cor:"
 
-#: ../src/generic/datavgen.cpp:6077
+#: ../src/generic/datavgen.cpp:6882
 #, fuzzy, c-format
 msgid "Column %u"
 msgstr "Engadir columna"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:114
+#: ../src/common/accelcmn.cpp:112
 msgid "Command"
 msgstr ""
 
-#: ../src/common/init.cpp:196
+#: ../src/common/init.cpp:193
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
@@ -2307,12 +2312,12 @@ msgstr ""
 "O argumento %d da liña de comandos non se puido converter a Unicode e "
 "ignorarase."
 
-#: ../src/msw/fontdlg.cpp:120
+#: ../src/msw/fontdlg.cpp:170
 #, c-format
 msgid "Common dialog failed with error code %0lx."
 msgstr "Fallo no diálogo común co código de erro %0lx."
 
-#: ../src/gtk/window.cpp:4649
+#: ../src/gtk/window.cpp:5653
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
@@ -2320,11 +2325,11 @@ msgstr ""
 "Este sistema non admite a composición, por favor, actívea no seu xestor de "
 "xanelas."
 
-#: ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:1549
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Ficheiro de Axuda HTML Comprimido (*.chm)|*.chm|"
 
-#: ../src/generic/dirctrlg.cpp:444
+#: ../src/generic/dirctrlg.cpp:410
 msgid "Computer"
 msgstr "Ordenador"
 
@@ -2333,53 +2338,57 @@ msgstr "Ordenador"
 msgid "Config entry name cannot start with '%c'."
 msgstr "O nome da entrada de configuración non pode comezar por '%c'."
 
-#: ../src/generic/filedlgg.cpp:349 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
 msgid "Confirm"
 msgstr "Confirmar"
 
-#: ../src/html/htmlwin.cpp:566
+#: ../src/html/htmlwin.cpp:569
 msgid "Connecting..."
 msgstr "Conectando..."
 
-#: ../src/html/helpwnd.cpp:475
+#: ../src/html/helpwnd.cpp:473
 msgid "Contents"
 msgstr "Contidos"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:880
+#: ../src/propgrid/advprops.cpp:781
 msgid "ControlDark"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:881
+#: ../src/propgrid/advprops.cpp:782
 msgid "ControlLight"
 msgstr ""
 
-#: ../src/common/strconv.cpp:2262
+#: ../src/common/strconv.cpp:2208
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Non funciona a conversión ao xogo de caracteres '%s'."
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "Convert"
 msgstr "Converter"
 
-#: ../src/html/htmlwin.cpp:1079
+#: ../src/html/htmlwin.cpp:1020
 #, c-format
 msgid "Copied to clipboard:\"%s\""
 msgstr "Copiouse no portapapeis:\"%s\""
 
-#: ../src/generic/prntdlgg.cpp:247
+#: ../src/generic/prntdlgg.cpp:240
 msgid "Copies:"
 msgstr "Copias:"
 
-#: ../src/common/stockitem.cpp:150 ../src/stc/stc_i18n.cpp:18
+#: ../src/common/stockitem.cpp:147 ../src/stc/stc_i18n.cpp:18
 msgid "Copy"
 msgstr "Copiar"
 
-#: ../src/common/stockitem.cpp:258
+#: ../src/common/stockitem.cpp:255
 msgid "Copy selection"
 msgstr "Copiar selección"
+
+#: ../src/generic/grid.cpp:5945
+msgid "Copying more than one selected block to clipboard is not supported."
+msgstr ""
 
 #: ../src/richtext/richtextborderspage.cpp:566
 #: ../src/richtext/richtextborderspage.cpp:601
@@ -2390,201 +2399,197 @@ msgstr ""
 msgid "Corner &radius:"
 msgstr ""
 
-#: ../src/html/chm.cpp:718
+#: ../src/html/chm.cpp:711
 #, c-format
 msgid "Could not create temporary file '%s'"
 msgstr "Non se puido crear o ficheiro temporal '%s'"
 
-#: ../src/html/chm.cpp:273
+#: ../src/html/chm.cpp:270
 #, c-format
 msgid "Could not extract %s into %s: %s"
 msgstr "Non se puido extraer %s a %s: %s"
 
-#: ../src/generic/tabg.cpp:1048
+#: ../src/generic/tabg.cpp:1045
 msgid "Could not find tab for id"
 msgstr "Non se atopou lapela para id"
 
-#: ../src/gtk/notifmsg.cpp:108
-#, fuzzy
-msgid "Could not initalize libnotify."
-msgstr "Non se puido estabelecer o aliñamento."
-
-#: ../src/html/chm.cpp:444
+#: ../src/html/chm.cpp:437
 #, c-format
 msgid "Could not locate file '%s'."
 msgstr "Non se puido localizar o ficheiro '%s'."
 
-#: ../src/common/filefn.cpp:1403
+#: ../src/msw/graphicsd2d.cpp:604
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/common/filefn.cpp:1291
 msgid "Could not set current working directory"
 msgstr "Non se atopou o cartafol de traballo actual"
 
-#: ../src/common/prntbase.cpp:2015
+#: ../src/common/prntbase.cpp:2037
 msgid "Could not start document preview."
 msgstr "Non se puido iniciar a previsualización do documento."
 
-#: ../src/generic/printps.cpp:178 ../src/msw/printwin.cpp:210
-#: ../src/gtk/print.cpp:1132
+#: ../src/generic/printps.cpp:159 ../src/msw/printwin.cpp:184
+#: ../src/gtk/print.cpp:1129
 msgid "Could not start printing."
 msgstr "Non se puido comezar a impresión."
 
-#: ../src/common/wincmn.cpp:2125
+#: ../src/common/wincmn.cpp:2126
 msgid "Could not transfer data to window"
 msgstr "Non se puideron transferir os datos á xanela"
 
-#: ../src/msw/imaglist.cpp:187 ../src/msw/imaglist.cpp:224
-#: ../src/msw/imaglist.cpp:249 ../src/msw/dragimag.cpp:185
-#: ../src/msw/dragimag.cpp:220
+#: ../src/msw/imaglist.cpp:223 ../src/msw/imaglist.cpp:245
+#: ../src/msw/imaglist.cpp:270 ../src/msw/dragimag.cpp:182
+#: ../src/msw/dragimag.cpp:217
 msgid "Couldn't add an image to the image list."
 msgstr "Non se puido engadir unha imaxe á lista de imaxes."
 
-#: ../src/osx/glcanvas_osx.cpp:414 ../src/unix/glx11.cpp:558
-#: ../src/msw/glcanvas.cpp:616
+#: ../src/osx/glcanvas_osx.cpp:411 ../src/msw/glcanvas.cpp:631
+#: ../src/unix/glegl.cpp:315 ../src/unix/glx11.cpp:559
 #, fuzzy
 msgid "Couldn't create OpenGL context"
 msgstr "Non se puido crear un temporizador"
 
-#: ../src/msw/timer.cpp:134
+#: ../src/msw/timer.cpp:131
 msgid "Couldn't create a timer"
 msgstr "Non se puido crear un temporizador"
 
-#: ../src/osx/carbon/overlay.cpp:122
-msgid "Couldn't create the overlay window"
-msgstr "Non se puido crear a xanela de superposición"
-
-#: ../src/common/translation.cpp:2024
+#: ../src/common/translation.cpp:2074
 msgid "Couldn't enumerate translations"
 msgstr "Non se puideron enumerar traducións"
 
-#: ../src/common/dynlib.cpp:120
+#: ../src/common/dynlib.cpp:110
 #, c-format
 msgid "Couldn't find symbol '%s' in a dynamic library"
 msgstr "Non se puido atopar o símbolo '%s' nunha biblioteca dinámica"
 
-#: ../src/msw/thread.cpp:915
+#: ../src/msw/thread.cpp:921
 msgid "Couldn't get the current thread pointer"
 msgstr "Non se atopou o punteiro do fío de execución actual"
 
-#: ../src/osx/carbon/overlay.cpp:129
-msgid "Couldn't init the context on the overlay window"
-msgstr "Non se puido inicializar o contexto na xanela superposta"
-
-#: ../src/common/imaggif.cpp:244
+#: ../src/common/imaggif.cpp:241
 msgid "Couldn't initialize GIF hash table."
 msgstr "Non se puido inicializar a táboa hash de GIF."
 
-#: ../src/common/imagpng.cpp:409
+#: ../src/common/imagpng.cpp:437
 msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
 msgstr ""
 "Non se puido cargar unha imaxe PNG - o ficheiro está danado ou non hai "
 "memoria dabondo."
 
-#: ../src/unix/sound.cpp:470
+#: ../src/unix/sound.cpp:459
 #, c-format
 msgid "Couldn't load sound data from '%s'."
 msgstr "Non se puideron cargar os datos de son dende '%s'."
 
-#: ../src/msw/dirdlg.cpp:435
+#: ../src/msw/dirdlg.cpp:287
 msgid "Couldn't obtain folder name"
 msgstr "Non se puido obter o nome do cartafol"
 
-#: ../src/unix/sound_sdl.cpp:229
+#: ../src/unix/sound_sdl.cpp:226
 #, c-format
 msgid "Couldn't open audio: %s"
 msgstr "Non se puido abrir o audio: %s"
 
-#: ../src/msw/ole/dataobj.cpp:377
+#: ../src/msw/ole/dataobj.cpp:385
 #, c-format
 msgid "Couldn't register clipboard format '%s'."
 msgstr "Non se puido rexistrar o formato do portapapeis '%s'."
 
-#: ../src/msw/listctrl.cpp:869
+#: ../src/msw/listctrl.cpp:933
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr ""
 "Non se puido recuperar información sobre o elemento %d de control de listas."
 
-#: ../src/common/imagpng.cpp:498 ../src/common/imagpng.cpp:509
-#: ../src/common/imagpng.cpp:519
+#: ../src/common/imagpng.cpp:511 ../src/common/imagpng.cpp:522
+#: ../src/common/imagpng.cpp:532
 msgid "Couldn't save PNG image."
 msgstr "Non se puido gardar a imaxe PNG."
 
-#: ../src/msw/thread.cpp:684
+#: ../src/msw/thread.cpp:676
 msgid "Couldn't terminate thread"
 msgstr "Non se puido finalizar o fío de execución"
 
-#: ../src/common/xtistrm.cpp:166
+#: ../src/common/xtistrm.cpp:163
 #, c-format
 msgid "Create Parameter %s not found in declared RTTI Parameters"
 msgstr ""
 "Non se atopou o parámetro de creación %s nos parámetros RTTI declarados"
 
-#: ../src/generic/dirdlgg.cpp:288
+#: ../src/generic/dirdlgg.cpp:285
 msgid "Create directory"
 msgstr "Crear cartafol"
 
-#: ../src/generic/filedlgg.cpp:212 ../src/generic/dirdlgg.cpp:111
+#: ../src/generic/filedlgg.cpp:209 ../src/generic/dirdlgg.cpp:108
 msgid "Create new directory"
 msgstr "Crear novo cartafol"
 
-#: ../src/xrc/xmlres.cpp:2460
+#: ../src/common/stockitem.cpp:264
+#, fuzzy
+msgid "Create new document"
+msgstr "Crear novo cartafol"
+
+#: ../src/xrc/xmlres.cpp:2515
 #, fuzzy, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Fallou a extración de '%s' a '%s'."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1758
+#: ../src/propgrid/advprops.cpp:1659
 msgid "Cross"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:333
+#: ../src/common/accelcmn.cpp:347
 msgid "Ctrl+"
 msgstr "Ctrl+"
 
-#: ../src/richtext/richtextctrl.cpp:332 ../src/osx/textctrl_osx.cpp:576
-#: ../src/common/stockitem.cpp:151 ../src/msw/textctrl.cpp:2507
+#: ../src/osx/textctrl_osx.cpp:594 ../src/common/stockitem.cpp:148
+#: ../src/msw/textctrl.cpp:2772 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "Cor&tar"
 
-#: ../src/generic/filectrlg.cpp:940
+#: ../src/generic/filectrlg.cpp:936
 msgid "Current directory:"
 msgstr "Cartafol actual:"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:896 ../src/propgrid/advprops.cpp:1574
-#: ../src/propgrid/advprops.cpp:1612
+#: ../src/propgrid/advprops.cpp:797 ../src/propgrid/advprops.cpp:1475
+#: ../src/propgrid/advprops.cpp:1518
 #, fuzzy
 msgid "Custom"
 msgstr "Tamaño personalizado"
 
-#: ../src/gtk/print.cpp:217
+#: ../src/gtk/print.cpp:211
 msgid "Custom size"
 msgstr "Tamaño personalizado"
 
-#: ../src/common/headerctrlcmn.cpp:60
+#: ../src/common/headerctrlcmn.cpp:58
 msgid "Customize Columns"
 msgstr "Columnas personalizadas"
 
-#: ../src/common/stockitem.cpp:151 ../src/stc/stc_i18n.cpp:17
+#: ../src/common/stockitem.cpp:148 ../src/stc/stc_i18n.cpp:17
 msgid "Cut"
 msgstr "Cortar"
 
-#: ../src/common/stockitem.cpp:259
+#: ../src/common/stockitem.cpp:256
 msgid "Cut selection"
 msgstr "Cortar selección"
 
-#: ../src/common/fmapbase.cpp:152
+#: ../src/common/fmapbase.cpp:149
 msgid "Cyrillic (ISO-8859-5)"
 msgstr "Cirílico (ISO-8859-5)"
 
-#: ../src/common/paper.cpp:99
+#: ../src/common/paper.cpp:96
 msgid "D sheet, 22 x 34 in"
 msgstr "Folla D, 22 x 34 polgadas"
 
-#: ../src/msw/dde.cpp:703
+#: ../src/msw/dde.cpp:698
 msgid "DDE poke request failed"
 msgstr "Erro na soicitude de envío de DDE"
 
-#: ../src/common/imagbmp.cpp:1169
+#: ../src/common/imagbmp.cpp:1181
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr ""
 "Cabeceira DIB: A codificación non coincide co número de bits por píxel."
@@ -2605,7 +2610,7 @@ msgstr "Cabeceira DIB: Número de bits por píxel descoñecido no ficheiro."
 msgid "DIB Header: Unknown encoding in file."
 msgstr "Cabeceira DIB: Codificación descoñecida en ficheiro."
 
-#: ../src/common/paper.cpp:121
+#: ../src/common/paper.cpp:118
 msgid "DL Envelope, 110 x 220 mm"
 msgstr "Sobre DL, 110 x 220 mm"
 
@@ -2613,55 +2618,55 @@ msgstr "Sobre DL, 110 x 220 mm"
 msgid "Dashed"
 msgstr "A trazos"
 
-#: ../src/generic/dbgrptg.cpp:300
+#: ../src/generic/dbgrptg.cpp:301
 #, c-format
 msgid "Debug report \"%s\""
 msgstr "Informe de depuración \"%s\""
 
-#: ../src/common/debugrpt.cpp:210
+#: ../src/common/debugrpt.cpp:211
 msgid "Debug report couldn't be created."
 msgstr "Non se puido crear o informe de depuración."
 
-#: ../src/common/debugrpt.cpp:553
+#: ../src/common/debugrpt.cpp:554
 msgid "Debug report generation has failed."
 msgstr "Fallou a xeración do informe de depuración."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:84
+#: ../src/common/accelcmn.cpp:81
 msgid "Decimal"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:323
+#: ../src/generic/fontdlgg.cpp:319
 msgid "Decorative"
 msgstr "Decorativo"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1752
+#: ../src/propgrid/advprops.cpp:1653
 #, fuzzy
 msgid "Default"
 msgstr "predeterminado"
 
-#: ../src/common/fmapbase.cpp:796
+#: ../src/common/fmapbase.cpp:792
 msgid "Default encoding"
 msgstr "Codificación predeterminada"
 
-#: ../src/dfb/fontmgr.cpp:180
+#: ../src/dfb/fontmgr.cpp:177
 msgid "Default font"
 msgstr "Tipo de letra predeterminado"
 
-#: ../src/generic/prntdlgg.cpp:510
+#: ../src/generic/prntdlgg.cpp:503
 msgid "Default printer"
 msgstr "Impresora predeterminada"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:51
+#: ../src/common/accelcmn.cpp:48
 #, fuzzy
 msgid "Del"
 msgstr "Eliminar"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextbuffer.cpp:8221 ../src/common/stockitem.cpp:152
-#: ../src/common/accelcmn.cpp:50 ../src/stc/stc_i18n.cpp:20
+#: ../src/common/stockitem.cpp:149 ../src/common/accelcmn.cpp:47
+#: ../src/richtext/richtextbuffer.cpp:8217 ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Eliminar"
 
@@ -2669,68 +2674,68 @@ msgstr "Eliminar"
 msgid "Delete A&ll"
 msgstr "Eliminar &todo"
 
-#: ../src/richtext/richtextbuffer.cpp:11341
+#: ../src/richtext/richtextbuffer.cpp:11340
 msgid "Delete Column"
 msgstr "Eliminar columna"
 
-#: ../src/richtext/richtextbuffer.cpp:11291
+#: ../src/richtext/richtextbuffer.cpp:11290
 msgid "Delete Row"
 msgstr "Eliminar fila"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 msgid "Delete Style"
 msgstr "Eliminar estilo"
 
-#: ../src/richtext/richtextctrl.cpp:1345 ../src/richtext/richtextctrl.cpp:1584
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
 msgid "Delete Text"
 msgstr "Eliminar texto"
 
-#: ../src/generic/editlbox.cpp:170
+#: ../src/generic/editlbox.cpp:147
 msgid "Delete item"
 msgstr "Eliminar elemento"
 
-#: ../src/common/stockitem.cpp:260
+#: ../src/common/stockitem.cpp:257
 msgid "Delete selection"
 msgstr "Eliminar selección"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 #, c-format
 msgid "Delete style %s?"
 msgstr "Eliminar estilo %s?"
 
-#: ../src/unix/snglinst.cpp:301
+#: ../src/unix/snglinst.cpp:298
 #, c-format
 msgid "Deleted stale lock file '%s'."
 msgstr "Fichero de bloqueo antiguo '%s' eliminado."
 
-#: ../src/common/secretstore.cpp:220
+#: ../src/common/secretstore.cpp:234
 #, fuzzy, c-format
-msgid "Deleting password for \"%s/%s\" failed: %s."
+msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Fallou a extración de '%s' a '%s'."
 
-#: ../src/common/module.cpp:124
+#: ../src/common/module.cpp:121
 #, c-format
 msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
 msgstr "A dependencia \"%s\" do módulo \"%s\" non existe."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "Descending"
 msgstr "Descendente"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:526 ../src/propgrid/advprops.cpp:882
+#: ../src/generic/dirctrlg.cpp:492 ../src/propgrid/advprops.cpp:783
 msgid "Desktop"
 msgstr "Escritorio"
 
-#: ../src/generic/aboutdlgg.cpp:70
+#: ../src/generic/aboutdlgg.cpp:67
 msgid "Developed by "
 msgstr "Desenvolvido por "
 
-#: ../src/generic/aboutdlgg.cpp:176
+#: ../src/generic/aboutdlgg.cpp:173
 msgid "Developers"
 msgstr "Desenvolvedores"
 
-#: ../src/msw/dialup.cpp:374
+#: ../src/msw/dialup.cpp:368
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -2738,11 +2743,11 @@ msgstr ""
 "As funcións de marcado non están dispoñíbeis porque o servidor de acceso "
 "remoto (SAR) non está instalado nesta máquina. Por favor, instáleo."
 
-#: ../src/generic/tipdlg.cpp:211
+#: ../src/generic/tipdlg.cpp:208
 msgid "Did you know..."
 msgstr "Sabía..."
 
-#: ../src/dfb/wrapdfb.cpp:63
+#: ../src/dfb/wrapdfb.cpp:60
 #, c-format
 msgid "DirectFB error %d occurred."
 msgstr "Error %d en DirectFB."
@@ -2751,29 +2756,29 @@ msgstr "Error %d en DirectFB."
 msgid "Directories"
 msgstr "Cartafoles"
 
-#: ../src/common/filefn.cpp:1183
+#: ../src/common/filefn.cpp:1071
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Non se puido crear o cartafol '%s'"
 
-#: ../src/common/filefn.cpp:1197
+#: ../src/common/filefn.cpp:1085
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "Non se puido eliminar o cartafol '%s'"
 
-#: ../src/generic/dirdlgg.cpp:204
+#: ../src/generic/dirdlgg.cpp:201
 msgid "Directory does not exist"
 msgstr "O cartafol non existe"
 
-#: ../src/generic/filectrlg.cpp:1399
+#: ../src/generic/filectrlg.cpp:1388
 msgid "Directory doesn't exist."
 msgstr "O cartafol non existe."
 
-#: ../src/common/docview.cpp:457
+#: ../src/common/docview.cpp:450
 msgid "Discard changes and reload the last saved version?"
 msgstr "Omitir os cambios e cargar a última versión gardada?"
 
-#: ../src/html/helpwnd.cpp:502
+#: ../src/html/helpwnd.cpp:500
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -2781,45 +2786,45 @@ msgstr ""
 "Amosar todo os elementos do índice que conteñen esta subcadea. A busca non é "
 "sensíbel a maiúsculas/minúsculas."
 
-#: ../src/html/helpwnd.cpp:679
+#: ../src/html/helpwnd.cpp:677
 msgid "Display options dialog"
 msgstr "Amosar o diálogo de opcións"
 
-#: ../src/html/helpwnd.cpp:322
+#: ../src/html/helpwnd.cpp:320
 msgid "Displays help as you browse the books on the left."
 msgstr "Amosa a axuda cando explora os libros da esquerda."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:85
+#: ../src/common/accelcmn.cpp:83
 msgid "Divide"
 msgstr ""
 
-#: ../src/common/docview.cpp:533
+#: ../src/common/docview.cpp:526
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Quere gardar os cambios en %s?"
 
-#: ../src/common/prntbase.cpp:542
+#: ../src/common/prntbase.cpp:537
 msgid "Document:"
 msgstr "Documento:"
 
-#: ../src/generic/aboutdlgg.cpp:73
+#: ../src/generic/aboutdlgg.cpp:70
 msgid "Documentation by "
 msgstr "Documentación de "
 
-#: ../src/generic/aboutdlgg.cpp:180
+#: ../src/generic/aboutdlgg.cpp:177
 msgid "Documentation writers"
 msgstr "Autores da documentación"
 
-#: ../src/common/sizer.cpp:2799
+#: ../src/common/sizer.cpp:2916
 msgid "Don't Save"
 msgstr "Non gardar"
 
-#: ../src/html/htmlwin.cpp:633
+#: ../src/html/htmlwin.cpp:643
 msgid "Done"
 msgstr "Feito"
 
-#: ../src/generic/progdlgg.cpp:448 ../src/msw/progdlg.cpp:407
+#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
 msgid "Done."
 msgstr "Feito."
 
@@ -2831,42 +2836,42 @@ msgstr "Punteado"
 msgid "Double"
 msgstr "Dobre"
 
-#: ../src/common/paper.cpp:176
+#: ../src/common/paper.cpp:173
 msgid "Double Japanese Postcard Rotated 148 x 200 mm"
 msgstr "Postal xaponesa dobre apaisada 148 x 200 mm"
 
-#: ../src/common/xtixml.cpp:273
+#: ../src/common/xtixml.cpp:269
 #, c-format
 msgid "Doubly used id : %d"
 msgstr "ID usado dúas veces: %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:153
-#: ../src/common/accelcmn.cpp:64
+#: ../src/common/stockitem.cpp:150 ../src/common/accelcmn.cpp:61
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Down"
 msgstr "Abaixo"
 
-#: ../src/richtext/richtextctrl.cpp:865
+#: ../src/richtext/richtextctrl.cpp:864
 msgid "Drag"
 msgstr "Arrastrar"
 
-#: ../src/common/paper.cpp:100
+#: ../src/common/paper.cpp:97
 msgid "E sheet, 34 x 44 in"
 msgstr "Folla E, 34 x 44 polgadas"
 
-#: ../src/unix/fswatcher_inotify.cpp:561
+#: ../src/unix/fswatcher_inotify.cpp:558
 msgid "EOF while reading from inotify descriptor"
 msgstr "EOF ao ler dende descritor inotify"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "Edit"
 msgstr "Editar"
 
-#: ../src/generic/editlbox.cpp:168
+#: ../src/generic/editlbox.cpp:131
 msgid "Edit item"
 msgstr "Editar elemento"
 
-#: ../include/wx/generic/progdlgg.h:84
+#: ../include/wx/generic/progdlgg.h:85
 msgid "Elapsed time:"
 msgstr "Tempo transcorrido:"
 
@@ -2938,50 +2943,50 @@ msgid "Enables the shadow spread."
 msgstr "Activar valor de anchura."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:66
+#: ../src/common/accelcmn.cpp:63
 msgid "End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:55
+#: ../src/common/accelcmn.cpp:52
 #, fuzzy
 msgid "Enter"
 msgstr "Impresora"
 
-#: ../src/richtext/richtextstyledlg.cpp:934
+#: ../src/richtext/richtextstyledlg.cpp:930
 msgid "Enter a box style name"
 msgstr "Inserir un nome de estilo de caixa"
 
-#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:602
 msgid "Enter a character style name"
 msgstr "Inserir un nome de estilo de caracter"
 
-#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:816
 msgid "Enter a list style name"
 msgstr "Inserir un nome de estilos de lista"
 
-#: ../src/richtext/richtextstyledlg.cpp:893
+#: ../src/richtext/richtextstyledlg.cpp:889
 msgid "Enter a new style name"
 msgstr "Inserir un novo nome de estilo"
 
-#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:650
 msgid "Enter a paragraph style name"
 msgstr "Inserir un nome de estilos de parágrafo"
 
-#: ../src/generic/dbgrptg.cpp:174
+#: ../src/generic/dbgrptg.cpp:171
 #, c-format
 msgid "Enter command to open file \"%s\":"
 msgstr "Inserir o comando para abrir o ficheiro \"%s\":"
 
-#: ../src/generic/helpext.cpp:459
+#: ../src/generic/helpext.cpp:457
 msgid "Entries found"
 msgstr "Entradas atopadas"
 
-#: ../src/common/paper.cpp:142
+#: ../src/common/paper.cpp:139
 msgid "Envelope Invite 220 x 220 mm"
 msgstr "Sobre de invitación 220 x 220 mm"
 
-#: ../src/common/config.cpp:469
+#: ../src/common/config.cpp:465
 #, c-format
 msgid ""
 "Environment variables expansion failed: missing '%c' at position %u in '%s'."
@@ -2989,13 +2994,13 @@ msgstr ""
 "Erro na ampliación das variábeis de entorno: falla '%c' na posición %u en "
 "'%s'."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/generic/dirctrlg.cpp:570
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/dirctrlg.cpp:599
-#: ../src/generic/dirdlgg.cpp:323 ../src/generic/filectrlg.cpp:642
-#: ../src/generic/filectrlg.cpp:756 ../src/generic/filectrlg.cpp:770
-#: ../src/generic/filectrlg.cpp:786 ../src/generic/filectrlg.cpp:1368
-#: ../src/generic/filectrlg.cpp:1399 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/gtk1/fontdlg.cpp:74 ../src/generic/dirctrlg.cpp:536
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/dirctrlg.cpp:565
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1357 ../src/generic/filectrlg.cpp:1388
+#: ../src/generic/filedlgg.cpp:354 ../src/generic/dirdlgg.cpp:320
+#: ../src/gtk/filedlg.cpp:74
 msgid "Error"
 msgstr "Erro"
 
@@ -3003,87 +3008,98 @@ msgstr "Erro"
 msgid "Error closing epoll descriptor"
 msgstr "Erro ao pechar o descritor epoll"
 
-#: ../src/unix/fswatcher_kqueue.cpp:114
+#: ../src/unix/fswatcher_kqueue.cpp:131
 msgid "Error closing kqueue instance"
 msgstr "Erro ao pechar instancia de kqueue"
 
-#: ../src/common/filefn.cpp:1049
+#: ../src/common/filefn.cpp:938
 #, fuzzy, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Fallo ao copiar o ficheiro '%s' a '%s'"
 
-#: ../src/generic/dirdlgg.cpp:222
+#: ../src/generic/dirdlgg.cpp:219
 msgid "Error creating directory"
 msgstr "Erro ao crear o cartafol"
 
-#: ../src/common/imagbmp.cpp:1181
+#: ../src/common/imagbmp.cpp:1193
 msgid "Error in reading image DIB."
 msgstr "Erro ao ler a imaxe DIB."
 
-#: ../src/propgrid/propgrid.cpp:6696
+#: ../src/propgrid/propgrid.cpp:6665
 #, c-format
 msgid "Error in resource: %s"
 msgstr "Erro no recurso: %s"
 
-#: ../src/common/fileconf.cpp:422
+#: ../src/common/fileconf.cpp:421
 msgid "Error reading config options."
 msgstr "Erro ao ler as opcións de configuración."
+
+#: ../src/msw/webview_ie.cpp:1057 ../src/msw/webview_edge.cpp:850
+#: ../src/gtk/webview_webkit2.cpp:1262 ../src/osx/webview_webkit.mm:383
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
 
 #: ../src/common/fileconf.cpp:1029
 msgid "Error saving user configuration data."
 msgstr "Erro ao gardar os datos de configuración do usuario."
 
-#: ../src/gtk/print.cpp:722
+#: ../src/gtk/print.cpp:720
 msgid "Error while printing: "
 msgstr "Erro ao imprimir:"
 
-#: ../src/common/log.cpp:219
+#: ../src/common/log.cpp:237
 msgid "Error: "
 msgstr "Erro: "
 
+#: ../src/common/webrequest.cpp:98
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Erro: "
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:69
+#: ../src/common/accelcmn.cpp:66
 msgid "Esc"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:70
+#: ../src/common/accelcmn.cpp:67
 #, fuzzy
 msgid "Escape"
 msgstr "Horizontal"
 
-#: ../src/common/fmapbase.cpp:150
+#: ../src/common/fmapbase.cpp:147
 msgid "Esperanto (ISO-8859-3)"
 msgstr "Esperanto (ISO-8859-3)"
 
-#: ../include/wx/generic/progdlgg.h:85
+#: ../include/wx/generic/progdlgg.h:86
 msgid "Estimated time:"
 msgstr "Tempo estimado:"
 
-#: ../src/generic/dbgrptg.cpp:234
+#: ../src/generic/dbgrptg.cpp:231
 msgid "Executable files (*.exe)|*.exe|"
 msgstr "Ficheiros executábeis (*.exe)|*.exe|"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:155 ../src/common/accelcmn.cpp:78
+#: ../src/common/stockitem.cpp:152 ../src/common/accelcmn.cpp:75
 msgid "Execute"
 msgstr "Executar"
 
-#: ../src/msw/utilsexc.cpp:876
+#: ../src/msw/utilsexc.cpp:873
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Fallou a execución do comando '%s'"
 
-#: ../src/common/paper.cpp:105
+#: ../src/common/paper.cpp:102
 msgid "Executive, 7 1/4 x 10 1/2 in"
 msgstr "Executivo, 7 1/4 x 10 1/2 polgadas"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6009
+#: ../src/generic/datavgen.cpp:6814
 msgid "Expand"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1240
+#: ../src/msw/registry.cpp:1228
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
@@ -3091,147 +3107,157 @@ msgstr ""
 "Exportando a clave do rexistro: o ficheiro \"%s\" xa existe e non se vai "
 "sobreescribir."
 
-#: ../src/common/fmapbase.cpp:195
+#: ../src/common/fmapbase.cpp:192
 msgid "Extended Unix Codepage for Japanese (EUC-JP)"
 msgstr "Páxina de códigos Unix estendidos para o xaponés (EUC-JP)"
 
-#: ../src/html/chm.cpp:725
+#: ../src/html/chm.cpp:718
 #, c-format
 msgid "Extraction of '%s' into '%s' failed."
 msgstr "Fallou a extración de '%s' a '%s'."
 
-#: ../src/common/accelcmn.cpp:249 ../src/common/accelcmn.cpp:344
+#: ../src/common/accelcmn.cpp:259 ../src/common/accelcmn.cpp:358
 msgid "F"
 msgstr "F"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:672
+#: ../src/propgrid/advprops.cpp:582
 msgid "Face Name"
 msgstr "Nome da faz"
 
-#: ../src/unix/snglinst.cpp:269
+#: ../src/unix/snglinst.cpp:266
 msgid "Failed to access lock file."
 msgstr "Erro ao acceder ao ficheiro de bloqueo."
+
+#: ../src/gtk/font.cpp:572
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Erro ao cargar documento dende o ficheiro \"%s\"."
 
 #: ../src/unix/epolldispatcher.cpp:116
 #, c-format
 msgid "Failed to add descriptor %d to epoll descriptor %d"
 msgstr "Erro ao engadir descritor %d ao descritor epoll %d"
 
-#: ../src/msw/dib.cpp:489
+#: ../src/msw/dib.cpp:535
 #, c-format
 msgid "Failed to allocate %luKb of memory for bitmap data."
 msgstr "Erro ao asignar %luKb de memoria aos datos do mapa de bits."
 
-#: ../src/common/glcmn.cpp:115
+#: ../src/common/glcmn.cpp:112
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Erro ao asignar cor para OpenGL"
 
-#: ../src/unix/displayx11.cpp:236
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Erro ao asignar cor para OpenGL"
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Erro ao asignar cor para OpenGL"
+
+#: ../include/wx/unix/private/displayx11.h:89
 msgid "Failed to change video mode"
 msgstr "Erro ao cambiar o modo de vídeo"
 
-#: ../src/common/image.cpp:3277
+#: ../src/common/image.cpp:3396
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Erro ao comprobar o formato do ficheiro de imaxe \"%s\"."
 
-#: ../src/common/debugrpt.cpp:239
+#: ../src/common/debugrpt.cpp:240
 #, c-format
 msgid "Failed to clean up debug report directory \"%s\""
 msgstr "Erro ao limpar o cartafol de depuración \"%s\""
 
-#: ../src/common/filename.cpp:192
+#: ../src/common/filename.cpp:189
 msgid "Failed to close file handle"
 msgstr "Erro ao pechar manexador de ficheiros"
 
-#: ../src/unix/snglinst.cpp:340
+#: ../src/unix/snglinst.cpp:337
 #, c-format
 msgid "Failed to close lock file '%s'"
 msgstr "Erro ao pechar o ficheiro de bloqueo '%s'"
 
-#: ../src/msw/clipbrd.cpp:112
+#: ../src/msw/clipbrd.cpp:110
 msgid "Failed to close the clipboard."
 msgstr "Fallo ao pechar o portapapeis."
 
-#: ../src/x11/utils.cpp:208
+#: ../src/x11/utils.cpp:170
 #, c-format
 msgid "Failed to close the display \"%s\""
 msgstr "Erro ao pechar a presentación \"%s\""
 
-#: ../src/msw/dialup.cpp:797
+#: ../src/msw/dialup.cpp:791
 msgid "Failed to connect: missing username/password."
 msgstr "Erro ao conectar: falta o nome de usuario/contrasinal."
 
-#: ../src/msw/dialup.cpp:743
+#: ../src/msw/dialup.cpp:737
 msgid "Failed to connect: no ISP to dial."
 msgstr "Erro de conexión: non hai ISP ao que chamar."
 
-#: ../src/common/textfile.cpp:203
-#, c-format
-msgid "Failed to convert file \"%s\" to Unicode."
-msgstr "Erro ao converter ficheiro \"%s\" a Unicode."
-
-#: ../src/generic/logg.cpp:956
+#: ../src/generic/logg.cpp:953
 msgid "Failed to copy dialog contents to the clipboard."
 msgstr "Erro ao copiar o contido do diálogo no portapapeis."
 
-#: ../src/msw/registry.cpp:692
+#: ../src/msw/registry.cpp:681
 #, c-format
 msgid "Failed to copy registry value '%s'"
 msgstr "Fallo ao copiar o valor do rexistro '%s'"
 
-#: ../src/msw/registry.cpp:701
+#: ../src/msw/registry.cpp:690
 #, c-format
 msgid "Failed to copy the contents of registry key '%s' to '%s'."
 msgstr "Fallo ao copiar o contido da clave do rexistro '%s' a '%s'."
 
-#: ../src/common/filefn.cpp:1015
+#: ../src/common/filefn.cpp:904
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Fallo ao copiar o ficheiro '%s' a '%s'"
 
-#: ../src/msw/registry.cpp:679
+#: ../src/msw/registry.cpp:668
 #, c-format
 msgid "Failed to copy the registry subkey '%s' to '%s'."
 msgstr "Fallo ao copiar a subclave do rexistro '%s' a '%s'."
 
-#: ../src/msw/dde.cpp:1070
+#: ../src/msw/dde.cpp:1134
 msgid "Failed to create DDE string"
 msgstr "Erro ao crear cadea DDE"
 
-#: ../src/msw/mdi.cpp:616
+#: ../src/msw/mdi.cpp:621
 msgid "Failed to create MDI parent frame."
 msgstr "Erro ao crear marco pai MDI."
 
-#: ../src/common/filename.cpp:1027
+#: ../src/common/filename.cpp:1024
 msgid "Failed to create a temporary file name"
 msgstr "Erro ao crear un nome de ficheiro temporal"
 
-#: ../src/msw/utilsexc.cpp:228
+#: ../src/msw/utilsexc.cpp:225
 msgid "Failed to create an anonymous pipe"
 msgstr "Erro ao crear canalización anónima"
 
-#: ../src/msw/ole/automtn.cpp:522
+#: ../src/msw/ole/automtn.cpp:513
 #, c-format
 msgid "Failed to create an instance of \"%s\""
 msgstr "Erro ao crear unha instancia de \"%s\""
 
-#: ../src/msw/dde.cpp:437
+#: ../src/msw/dde.cpp:432
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "Erro ao crear a conexión co servidor '%s' co tema '%s'"
 
-#: ../src/msw/cursor.cpp:204
+#: ../src/msw/cursor.cpp:195
 msgid "Failed to create cursor."
 msgstr "Fallo ao crear un cursor."
 
-#: ../src/common/debugrpt.cpp:209
+#: ../src/common/debugrpt.cpp:210
 #, c-format
 msgid "Failed to create directory \"%s\""
 msgstr "Erro ao crear o cartafol \"%s\""
 
-#: ../src/generic/dirdlgg.cpp:220
+#: ../src/generic/dirdlgg.cpp:217
 #, c-format
 msgid ""
 "Failed to create directory '%s'\n"
@@ -3244,116 +3270,135 @@ msgstr ""
 msgid "Failed to create epoll descriptor"
 msgstr "Erro ao crear descritor epoll"
 
-#: ../src/msw/mimetype.cpp:238
+#: ../src/gtk/font.cpp:562
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "Erro ao actualizar o ficheiro de configuración de usuario."
+
+#: ../src/msw/mimetype.cpp:235
 #, c-format
 msgid "Failed to create registry entry for '%s' files."
 msgstr "Erro ao crear entrada de rexistro para os ficheiros '%s'."
 
-#: ../src/msw/fdrepdlg.cpp:409
+#: ../src/msw/fdrepdlg.cpp:408
 #, c-format
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr "Erro ao crear o diálogo estándar buscar/substituír (código de erro %d)"
 
-#: ../src/unix/wakeuppipe.cpp:52
+#: ../src/unix/wakeuppipe.cpp:49
 msgid "Failed to create wake up pipe used by event loop."
 msgstr "Erro ao crear canalización de activación usada por bucle de eventos."
 
-#: ../src/html/winpars.cpp:730
+#: ../src/html/winpars.cpp:727
 #, c-format
 msgid "Failed to display HTML document in %s encoding"
 msgstr "Erro ao amosar o documento HTML coa codificación %s"
 
-#: ../src/msw/clipbrd.cpp:124
+#: ../src/msw/clipbrd.cpp:122
 msgid "Failed to empty the clipboard."
 msgstr "Fallo ao baleirar o portapapeis."
 
-#: ../src/unix/displayx11.cpp:212
+#: ../include/wx/unix/private/displayx11.h:65
 msgid "Failed to enumerate video modes"
 msgstr "Erro ao enumerar os modos de vídeo"
 
-#: ../src/msw/dde.cpp:722
+#: ../src/msw/dde.cpp:717
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "Erro ao estabelecer un bucle de aviso co servidor DDE"
 
-#: ../src/msw/dialup.cpp:629 ../src/msw/dialup.cpp:863
+#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Erro ao estabelecer conexión telefónica: %s"
 
-#: ../src/unix/utilsunx.cpp:611
+#: ../src/unix/utilsunx.cpp:613
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Erro ao executar '%s'\n"
 
-#: ../src/common/debugrpt.cpp:720
+#: ../src/common/debugrpt.cpp:730
 msgid "Failed to execute curl, please install it in PATH."
 msgstr "Erro ao executar curl, por favor, instáleo no PATH."
 
-#: ../src/msw/ole/automtn.cpp:505
+#: ../src/msw/ole/automtn.cpp:496
 #, c-format
 msgid "Failed to find CLSID of \"%s\""
 msgstr "Non se atopou o CLSID de \"%s\""
 
-#: ../src/common/regex.cpp:431 ../src/common/regex.cpp:479
+#: ../src/common/regex.cpp:428 ../src/common/regex.cpp:476
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "Non se atopou correspondencia para a expresión regular: %s"
 
-#: ../src/msw/dialup.cpp:695
+#: ../src/msw/webview_ie.cpp:978
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:689
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Erro ao obter nomes de ISP: %s"
 
-#: ../src/msw/ole/automtn.cpp:574
+#: ../src/msw/ole/automtn.cpp:565
 #, c-format
 msgid "Failed to get OLE automation interface for \"%s\""
 msgstr "Erro ao crear o cartafol \"%s\""
 
-#: ../src/msw/clipbrd.cpp:711
+#: ../src/msw/clipbrd.cpp:731
 msgid "Failed to get data from the clipboard"
 msgstr "Fallo ao obter datos do portapapeis"
 
-#: ../src/common/time.cpp:223
+#: ../src/common/time.cpp:216
 msgid "Failed to get the local system time"
 msgstr "Erro ao obter a hora local do sistema"
 
-#: ../src/common/filefn.cpp:1345
+#: ../src/common/filefn.cpp:1233
 msgid "Failed to get the working directory"
 msgstr "Erro ao obter o cartafol de traballo"
 
-#: ../src/univ/theme.cpp:114
+#: ../src/univ/theme.cpp:111
 msgid "Failed to initialize GUI: no built-in themes found."
 msgstr ""
 "Erro ao inicializar interface gráfica de usuario: non se atoparon temas "
 "incorporados."
 
-#: ../src/msw/helpchm.cpp:63
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:60
 msgid "Failed to initialize MS HTML Help."
 msgstr "Erro ao inicializar a axuda HTML de MS."
 
-#: ../src/msw/glcanvas.cpp:1381
+#: ../src/msw/glcanvas.cpp:1391
 msgid "Failed to initialize OpenGL"
 msgstr "Erro ao inicializar OpenGL"
 
-#: ../src/msw/dialup.cpp:858
+#: ../src/msw/dialup.cpp:852
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Erro ao iniciar conexión telefónica: %s"
 
-#: ../src/gtk/textctrl.cpp:1128
+#: ../src/gtk/textctrl.cpp:1209
 msgid "Failed to insert text in the control."
 msgstr "Erro ao obter o cartafol de traballo."
 
-#: ../src/unix/snglinst.cpp:241
+#: ../src/unix/snglinst.cpp:238
 #, c-format
 msgid "Failed to inspect the lock file '%s'"
 msgstr "Erro ao inspeccionar ficheiro de bloqueo '%s'"
 
-#: ../src/unix/appunix.cpp:182
+#: ../src/unix/appunix.cpp:179
 msgid "Failed to install signal handler"
 msgstr "Erro ao instalar manexador de sinal"
 
-#: ../src/unix/threadpsx.cpp:1167
+#: ../src/unix/threadpsx.cpp:1216
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -3361,71 +3406,71 @@ msgstr ""
 "Erro ao conectar cun fío de execución, detectada perda potencial de memoria. "
 "Por favor, reinicie o programa"
 
-#: ../src/msw/utils.cpp:629
+#: ../src/msw/utils.cpp:619
 #, c-format
 msgid "Failed to kill process %d"
 msgstr "Erro ao matar o proceso %d"
 
-#: ../src/common/image.cpp:2500
+#: ../src/common/image.cpp:2595
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Non foi posíbel cargar o mapa de bits \"%s\" dos recursos."
 
-#: ../src/common/image.cpp:2509
+#: ../src/common/image.cpp:2604
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Non foi posíbel cargar a icona \"%s\" dos recursos."
 
-#: ../src/common/iconbndl.cpp:225
+#: ../src/common/iconbndl.cpp:224
 #, fuzzy, c-format
 msgid "Failed to load icons from resource '%s'."
 msgstr "Non foi posíbel cargar a icona \"%s\" dos recursos."
 
-#: ../src/common/iconbndl.cpp:200
+#: ../src/common/iconbndl.cpp:198
 #, c-format
 msgid "Failed to load image %%d from file '%s'."
 msgstr "Non foi posíbel cargar a imaxe %%d do ficheiro '%s'."
 
-#: ../src/common/iconbndl.cpp:208
+#: ../src/common/iconbndl.cpp:206
 #, c-format
 msgid "Failed to load image %d from stream."
 msgstr "Non foi posíbel cargar a imaxe %d do fluxo."
 
-#: ../src/common/image.cpp:2587 ../src/common/image.cpp:2606
+#: ../src/common/image.cpp:2682 ../src/common/image.cpp:2701
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Non foi posíbel cargar a imaxe dende o ficheiro \"%s\"."
 
-#: ../src/msw/enhmeta.cpp:97
+#: ../src/msw/enhmeta.cpp:94
 #, c-format
 msgid "Failed to load metafile from file \"%s\"."
 msgstr "Erro ao cargar metaficheiro do ficheiro \"%s\"."
 
-#: ../src/msw/volume.cpp:327
+#: ../src/msw/volume.cpp:335
 msgid "Failed to load mpr.dll."
 msgstr "Erro ao cargar mpr.dll."
 
-#: ../src/msw/utils.cpp:953
+#: ../src/msw/utils.cpp:943
 #, c-format
 msgid "Failed to load resource \"%s\"."
 msgstr "Erro ao cargar recurso \"%s\"."
 
-#: ../src/common/dynlib.cpp:92
+#: ../src/common/dynlib.cpp:86
 #, c-format
 msgid "Failed to load shared library '%s'"
 msgstr "Erro ao cargar a biblioteca compartida '%s'"
 
-#: ../src/osx/core/sound.cpp:145
+#: ../src/osx/core/sound.cpp:143
 #, fuzzy, c-format
 msgid "Failed to load sound from \"%s\" (error %d)."
 msgstr "Erro ao cargar recurso \"%s\"."
 
-#: ../src/msw/utils.cpp:960
+#: ../src/msw/utils.cpp:950
 #, c-format
 msgid "Failed to lock resource \"%s\"."
 msgstr "Erro ao bloquear recurso \"%s\"."
 
-#: ../src/unix/snglinst.cpp:198
+#: ../src/unix/snglinst.cpp:195
 #, c-format
 msgid "Failed to lock the lock file '%s'"
 msgstr "Erro ao bloquear o ficheiro de bloqueo '%s'"
@@ -3435,33 +3480,38 @@ msgstr "Erro ao bloquear o ficheiro de bloqueo '%s'"
 msgid "Failed to modify descriptor %d in epoll descriptor %d"
 msgstr "Erro ao modificar o descritor %d no descritor epoll %d"
 
-#: ../src/common/filename.cpp:2575
+#: ../src/common/filename.cpp:2658
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Erro ao modificar o ficheiro de tempos para '%s'"
 
-#: ../src/common/selectdispatcher.cpp:258
+#: ../src/common/selectdispatcher.cpp:255
 msgid "Failed to monitor I/O channels"
 msgstr "Non se puido monitorizar as canles I/O"
 
-#: ../src/common/filename.cpp:175
+#: ../src/common/filename.cpp:172
 #, c-format
 msgid "Failed to open '%s' for reading"
 msgstr "Erro ao abrir '%s' para lectura"
 
-#: ../src/common/filename.cpp:180
+#: ../src/common/filename.cpp:177
 #, c-format
 msgid "Failed to open '%s' for writing"
 msgstr "Erro ao abrir '%s' para escritura"
 
-#: ../src/html/chm.cpp:141
+#: ../src/html/chm.cpp:138
 #, c-format
 msgid "Failed to open CHM archive '%s'."
 msgstr "Erro ao abrir o arquivo CHM '%s'."
 
-#: ../src/common/utilscmn.cpp:1126
+#: ../src/common/utilscmn.cpp:1140
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Erro ao abrir URL \"%s\" no navegador predeterminado."
+
+#: ../src/common/hyperlnkcmn.cpp:133
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Erro ao abrir URL \"%s\" no navegador predeterminado."
 
 #: ../include/wx/msw/private/fswatcher.h:92
@@ -3469,93 +3519,103 @@ msgstr "Erro ao abrir URL \"%s\" no navegador predeterminado."
 msgid "Failed to open directory \"%s\" for monitoring."
 msgstr "Erro ao abrir cartafol \"%s\" para monitorización."
 
-#: ../src/x11/utils.cpp:227
+#: ../src/x11/utils.cpp:189
 #, c-format
 msgid "Failed to open display \"%s\"."
 msgstr "Erro ao abrir a presentación \"%s\"."
 
-#: ../src/common/filename.cpp:1062
+#: ../src/common/filename.cpp:1059
 msgid "Failed to open temporary file."
 msgstr "Erro ao abrir o ficheiro temporal."
 
-#: ../src/msw/clipbrd.cpp:91
+#: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Fallo ao abrir o portapapeis."
 
-#: ../src/common/translation.cpp:1184
+#: ../src/common/translation.cpp:1226
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Erro ao analizar formas plurais: '%s'"
 
-#: ../src/unix/mediactrl.cpp:1214
+#: ../src/unix/mediactrl.cpp:1239
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Erro ao preparar reprodución \"%s\"."
 
-#: ../src/msw/clipbrd.cpp:600
+#: ../src/msw/clipbrd.cpp:610
 msgid "Failed to put data on the clipboard"
 msgstr "Fallo ao poñer datos no portapapeis"
 
-#: ../src/unix/snglinst.cpp:278
+#: ../src/unix/snglinst.cpp:275
 msgid "Failed to read PID from lock file."
 msgstr "Erro ao ler PID dende o ficheiro de bloqueo."
 
-#: ../src/common/fileconf.cpp:433
+#: ../src/common/fileconf.cpp:432
 msgid "Failed to read config options."
 msgstr "Erro ao ler as opcións da configuración."
 
-#: ../src/common/docview.cpp:681
+#: ../src/common/docview.cpp:676
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Erro ao cargar documento dende o ficheiro \"%s\"."
 
-#: ../src/dfb/evtloop.cpp:98
+#: ../src/dfb/evtloop.cpp:99
 msgid "Failed to read event from DirectFB pipe"
 msgstr "Erro ao ler evento dende a canalización DirectFB"
 
-#: ../src/unix/wakeuppipe.cpp:120
+#: ../src/unix/wakeuppipe.cpp:117
 msgid "Failed to read from wake-up pipe"
 msgstr "Erro ao ler dende a canalización de activación"
 
-#: ../src/unix/utilsunx.cpp:679
+#: ../src/common/textfile.cpp:96
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Erro ao cargar documento dende o ficheiro \"%s\"."
+
+#: ../src/unix/utilsunx.cpp:681
 msgid "Failed to redirect child process input/output"
 msgstr "Erro ao redirecionar proceso fillo de entrada/saída"
 
-#: ../src/msw/utilsexc.cpp:701
+#: ../src/msw/utilsexc.cpp:698
 msgid "Failed to redirect the child process IO"
 msgstr "Erro ao redirecionar E/S do proceso fillo"
 
-#: ../src/msw/dde.cpp:288
+#: ../src/msw/dde.cpp:283
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Erro ao rexistrar servidor DDE '%s'"
 
-#: ../src/common/fontmap.cpp:245
+#: ../src/gtk/font.cpp:580
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "Erro ao actualizar o ficheiro de configuración de usuario."
+
+#: ../src/common/fontmap.cpp:242
 #, c-format
 msgid "Failed to remember the encoding for the charset '%s'."
 msgstr "Erro ao recordar a codificación para o conxunto de caracteres '%s'."
 
-#: ../src/common/debugrpt.cpp:227
+#: ../src/common/debugrpt.cpp:228
 #, c-format
 msgid "Failed to remove debug report file \"%s\""
 msgstr "Fallo ao eliminar o ficheiro de informe de depuración \"%s\""
 
-#: ../src/unix/snglinst.cpp:328
+#: ../src/unix/snglinst.cpp:325
 #, c-format
 msgid "Failed to remove lock file '%s'"
 msgstr "Erro ao eliminar o ficheiro de bloqueo '%s'"
 
-#: ../src/unix/snglinst.cpp:288
+#: ../src/unix/snglinst.cpp:285
 #, c-format
 msgid "Failed to remove stale lock file '%s'."
 msgstr "Erro ao eliminar o ficheiro de bloqueo obsoleto '%s'."
 
-#: ../src/msw/registry.cpp:529
+#: ../src/msw/registry.cpp:518
 #, c-format
 msgid "Failed to rename registry value '%s' to '%s'."
 msgstr "Erro ao renomear o valor de rexistro '%s' a '%s'."
 
-#: ../src/common/filefn.cpp:1122
+#: ../src/common/filefn.cpp:1011
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -3564,118 +3624,127 @@ msgstr ""
 "Non se puido cambiar o nome do ficheiro de '%s' a '%s' porque o ficheiro de "
 "destino xa existe. "
 
-#: ../src/msw/registry.cpp:634
+#: ../src/msw/registry.cpp:623
 #, c-format
 msgid "Failed to rename the registry key '%s' to '%s'."
 msgstr "Fallo ao renomear a clave do rexistro '%s' a '%s'."
 
-#: ../src/common/filename.cpp:2671
+#: ../src/msw/webview_ie.cpp:995
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/common/filename.cpp:2754
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Erro ao obter tempos de ficheiro para '%s'"
 
-#: ../src/msw/dialup.cpp:468
+#: ../src/msw/dialup.cpp:462
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Erro ao recuperar texto de mensaxe de erro RAS"
 
-#: ../src/msw/clipbrd.cpp:748
+#: ../src/msw/clipbrd.cpp:768
 msgid "Failed to retrieve the supported clipboard formats"
 msgstr "Erro ao recuperar os formatos de portapapeis compatíbeis"
 
-#: ../src/common/docview.cpp:652
+#: ../src/common/docview.cpp:647
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Erro ao gardar a imaxe de mapa de bits no ficheiro \"%s\"."
 
-#: ../src/msw/dib.cpp:269
+#: ../src/msw/dib.cpp:312
 #, c-format
 msgid "Failed to save the bitmap image to file \"%s\"."
 msgstr "Erro ao gardar a imaxe de mapa de bits no ficheiro \"%s\"."
 
-#: ../src/msw/dde.cpp:763
+#: ../src/msw/dde.cpp:811
 msgid "Failed to send DDE advise notification"
 msgstr "Erro ao enviar notificación de recomendación de DDE "
 
-#: ../src/common/ftp.cpp:402
+#: ../src/common/ftp.cpp:399
 #, c-format
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Fallo ao estabelecer o modo de tranferencia FTP como %s."
 
-#: ../src/msw/clipbrd.cpp:427
+#: ../src/msw/clipbrd.cpp:443
 msgid "Failed to set clipboard data."
 msgstr "Erro ao estabelecer datos do portapapeis."
 
-#: ../src/unix/snglinst.cpp:181
+#: ../src/unix/snglinst.cpp:178
 #, c-format
 msgid "Failed to set permissions on lock file '%s'"
 msgstr "Erro ao estabelecer permisos no ficheiro de bloqueo '%s'"
 
-#: ../src/unix/utilsunx.cpp:668
+#: ../src/unix/utilsunx.cpp:670
 msgid "Failed to set process priority"
 msgstr "Erro ao estabelecer prioridade de procesos"
 
-#: ../src/common/file.cpp:559
+#: ../src/common/ffile.cpp:355 ../src/common/file.cpp:586
 msgid "Failed to set temporary file permissions"
 msgstr "Erro ao estabelecer os permisos do ficheiro temporal"
 
-#: ../src/gtk/textctrl.cpp:1072
-msgid "Failed to set text in the text control."
-msgstr "Non se puido fixar texto no control de texto."
-
-#: ../src/unix/threadpsx.cpp:1298
+#: ../src/unix/threadpsx.cpp:1347
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Erro ao estabelecer nivel de concurrencia de fíos de execución en %lu"
 
-#: ../src/unix/threadpsx.cpp:1424
+#: ../src/unix/threadpsx.cpp:1473
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Non se puido estabelecer a prioridade de fíos de execución %d."
 
-#: ../src/unix/utilsunx.cpp:783
+#: ../src/unix/utilsunx.cpp:785
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 "Non foi posíbel configurar canalización non bloqueante, o programa pode "
 "ficar trabado."
 
-#: ../src/common/fs_mem.cpp:261
+#: ../src/msw/webview_ie.cpp:987
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:256
 #, c-format
 msgid "Failed to store image '%s' to memory VFS!"
 msgstr "Non se puido almacenar imaxe '%s' na memoria VFS!"
 
-#: ../src/dfb/evtloop.cpp:170
+#: ../src/dfb/evtloop.cpp:171
 msgid "Failed to switch DirectFB pipe to non-blocking mode"
 msgstr ""
 "Non foi posíbel conectar a canalización DirectFB ao modo non bloqueante"
 
-#: ../src/unix/wakeuppipe.cpp:59
+#: ../src/unix/wakeuppipe.cpp:56
 msgid "Failed to switch wake up pipe to non-blocking mode"
 msgstr "Erro ao cambiar canalización de activación a modo non bloqueante"
 
-#: ../src/unix/threadpsx.cpp:1605
+#: ../src/unix/threadpsx.cpp:1654
 msgid "Failed to terminate a thread."
 msgstr "Non se puido terminar un fío de execución."
 
-#: ../src/msw/dde.cpp:741
+#: ../src/msw/dde.cpp:736
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "Non se puido terminar o bucle de aviso co servidor DDE"
 
-#: ../src/msw/dialup.cpp:938
+#: ../src/msw/dialup.cpp:932
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Non se puido terminar a conexión telefónica: %s"
 
-#: ../src/common/filename.cpp:2590
+#: ../src/common/filename.cpp:2673
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Erro ao tocar o ficheiro '%s'"
 
-#: ../src/unix/snglinst.cpp:334
+#: ../src/unix/dlunix.cpp:90
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "Erro ao cargar a biblioteca compartida '%s'"
+
+#: ../src/unix/snglinst.cpp:331
 #, c-format
 msgid "Failed to unlock lock file '%s'"
 msgstr "Non se puido desbloquear o ficheiro de bloqueo '%s'"
 
-#: ../src/msw/dde.cpp:309
+#: ../src/msw/dde.cpp:304
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Non foi posíbel cancelar o rexistro do servidor '%s'"
@@ -3691,77 +3760,87 @@ msgstr ""
 msgid "Failed to update user configuration file."
 msgstr "Erro ao actualizar o ficheiro de configuración de usuario."
 
-#: ../src/common/debugrpt.cpp:733
+#: ../src/common/debugrpt.cpp:743
 #, c-format
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Erro ao enviar o informe de depuración (código de erro %d)."
 
-#: ../src/unix/snglinst.cpp:168
+#: ../src/unix/snglinst.cpp:165
 #, c-format
 msgid "Failed to write to lock file '%s'"
 msgstr "Non se puido escribir no ficheiro de bloqueo '%s'"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:209
+#: ../src/propgrid/propgrid.cpp:190
 msgid "False"
 msgstr "Falso"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:694
+#: ../src/propgrid/advprops.cpp:604
 msgid "Family"
 msgstr "Familia"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/gtk/glcanvas.cpp:176 ../src/gtk/glcanvas.cpp:187
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Erro moi grave"
+
+#: ../src/common/stockitem.cpp:154
 msgid "File"
 msgstr "Ficheiro"
 
-#: ../src/common/docview.cpp:669
+#: ../src/common/docview.cpp:664
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Non foi posíbel abrir o ficheiro \"%s\" para lectura."
 
-#: ../src/common/docview.cpp:646
+#: ../src/common/docview.cpp:641
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Non foi posíbel abrir o ficheiro \"%s\" para escritura."
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "O ficheiro '%s' xa existe, desexa sobreescribilo?"
 
-#: ../src/common/filefn.cpp:1156
+#: ../src/common/filefn.cpp:1044
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Non foi posíbel eliminar o ficheiro '%s'"
 
-#: ../src/common/filefn.cpp:1139
+#: ../src/common/filefn.cpp:1028
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Non se puido renomear o ficheiro '%s' a '%s'"
 
-#: ../src/richtext/richtextctrl.cpp:3081 ../src/common/textcmn.cpp:953
+#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
 msgid "File couldn't be loaded."
 msgstr "Non foi posíbel cargar o ficheiro."
 
-#: ../src/msw/filedlg.cpp:393
+#: ../src/msw/filedlg.cpp:414
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Houbo un erro no ficheiro de diálogo co código %0lx."
 
-#: ../src/common/docview.cpp:1789
+#: ../src/common/docview.cpp:1783
 msgid "File error"
 msgstr "Erro de ficheiro"
 
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/filectrlg.cpp:770
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/filectrlg.cpp:766
 msgid "File name exists already."
 msgstr "O nome de ficheiro xa existe."
+
+#: ../src/osx/cocoa/filedlg.mm:264
+#, fuzzy
+msgid "File type:"
+msgstr "Teletipo"
 
 #: ../src/motif/filedlg.cpp:220
 msgid "Files"
 msgstr "Ficheiros"
 
-#: ../src/common/filefn.cpp:1591
+#: ../src/common/filefn.cpp:1479
 #, c-format
 msgid "Files (%s)"
 msgstr "Ficheiros (%s)"
@@ -3770,15 +3849,29 @@ msgstr "Ficheiros (%s)"
 msgid "Filter"
 msgstr "Filtro"
 
-#: ../src/common/stockitem.cpp:158 ../src/html/helpwnd.cpp:490
+#: ../src/html/helpwnd.cpp:488
 msgid "Find"
 msgstr "Buscar"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:259
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:258
+#, fuzzy
+msgid "Find in document"
+msgstr "Abrir documento HTML"
+
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "Find..."
+msgstr "Buscar"
+
+#: ../src/common/stockitem.cpp:156
 msgid "First"
 msgstr "Primeiro"
 
-#: ../src/common/prntbase.cpp:1548
+#: ../src/common/prntbase.cpp:1573
 msgid "First page"
 msgstr "Primeira páxina"
 
@@ -3786,11 +3879,11 @@ msgstr "Primeira páxina"
 msgid "Fixed"
 msgstr "Fixo"
 
-#: ../src/html/helpwnd.cpp:1206
+#: ../src/html/helpwnd.cpp:1204
 msgid "Fixed font:"
 msgstr "Tipo de letra estabelecido:"
 
-#: ../src/html/helpwnd.cpp:1269
+#: ../src/html/helpwnd.cpp:1267
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Tamaño estabelecido.<br> <b>grosa</b> <i>cursiva</i> "
 
@@ -3798,16 +3891,16 @@ msgstr "Tamaño estabelecido.<br> <b>grosa</b> <i>cursiva</i> "
 msgid "Floating"
 msgstr "Flotante"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "Floppy"
 msgstr "Disquete"
 
-#: ../src/common/paper.cpp:111
+#: ../src/common/paper.cpp:108
 msgid "Folio, 8 1/2 x 13 in"
 msgstr "Folio, 8 1/2 x 13 polgadas"
 
-#: ../src/richtext/richtextformatdlg.cpp:344 ../src/osx/carbon/fontdlg.cpp:287
-#: ../src/common/stockitem.cpp:194
+#: ../src/osx/carbon/fontdlg.cpp:284 ../src/common/stockitem.cpp:191
+#: ../src/richtext/richtextformatdlg.cpp:337
 msgid "Font"
 msgstr "Tipo de letra"
 
@@ -3815,7 +3908,24 @@ msgstr "Tipo de letra"
 msgid "Font &weight:"
 msgstr "&Grosor do tipo de letra:"
 
-#: ../src/html/helpwnd.cpp:1207
+#: ../src/osx/fontutil.cpp:89
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
+"\"."
+msgstr ""
+
+#: ../src/msw/font.cpp:1126
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Non foi posíbel cargar o ficheiro."
+
+#: ../src/osx/fontutil.cpp:81
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "O ficheiro %s non existe."
+
+#: ../src/html/helpwnd.cpp:1205
 msgid "Font size:"
 msgstr "Tamaño da letra:"
 
@@ -3823,53 +3933,53 @@ msgstr "Tamaño da letra:"
 msgid "Font st&yle:"
 msgstr "&Estilo de tipo de letra:"
 
-#: ../src/osx/carbon/fontdlg.cpp:329
+#: ../src/osx/carbon/fontdlg.cpp:326
 msgid "Font:"
 msgstr "Tipo de letra:"
 
-#: ../src/dfb/fontmgr.cpp:198
+#: ../src/dfb/fontmgr.cpp:195
 #, c-format
 msgid "Fonts index file %s disappeared while loading fonts."
 msgstr "Desapareceu o arquivo de índice de tipos de letra %s mentres cargaba."
 
-#: ../src/unix/utilsunx.cpp:645
+#: ../src/unix/utilsunx.cpp:647
 msgid "Fork failed"
 msgstr "Erro ao facer fork"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "Forward"
 msgstr "Adiante"
 
-#: ../src/common/xtixml.cpp:235
+#: ../src/common/xtixml.cpp:231
 msgid "Forward hrefs are not supported"
 msgstr "Redirección de hrefs non é compatíbel"
 
-#: ../src/html/helpwnd.cpp:875
+#: ../src/html/helpwnd.cpp:873
 #, c-format
 msgid "Found %i matches"
 msgstr "Atopáronse %i coincidencias"
 
-#: ../src/generic/prntdlgg.cpp:238
+#: ../src/generic/prntdlgg.cpp:231
 msgid "From:"
 msgstr "Dende:"
 
-#: ../src/propgrid/advprops.cpp:1604
+#: ../src/propgrid/advprops.cpp:1510
 msgid "Fuchsia"
 msgstr ""
 
-#: ../src/common/imaggif.cpp:138
+#: ../src/common/imaggif.cpp:135
 msgid "GIF: data stream seems to be truncated."
 msgstr "GIF: o fluxo de datos semella truncado."
 
-#: ../src/common/imaggif.cpp:128
+#: ../src/common/imaggif.cpp:125
 msgid "GIF: error in GIF image format."
 msgstr "GIF: erro no formato da imaxe GIF."
 
-#: ../src/common/imaggif.cpp:133
+#: ../src/common/imaggif.cpp:130
 msgid "GIF: not enough memory."
 msgstr "GIF: memoria insuficiente."
 
-#: ../src/gtk/window.cpp:4631
+#: ../src/gtk/window.cpp:5635
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -3878,23 +3988,23 @@ msgstr ""
 "compatíbel coa composición de pantalla. Por favor, instale GTK+ 2.12 ou "
 "posterior."
 
-#: ../src/univ/themes/gtk.cpp:525
+#: ../src/univ/themes/gtk.cpp:522
 msgid "GTK+ theme"
 msgstr "Tema GTK+"
 
-#: ../src/common/preferencescmn.cpp:40
+#: ../src/common/preferencescmn.cpp:37
 msgid "General"
 msgstr "Xeral"
 
-#: ../src/common/prntbase.cpp:258
+#: ../src/common/prntbase.cpp:253
 msgid "Generic PostScript"
 msgstr "PostScript xenérico"
 
-#: ../src/common/paper.cpp:135
+#: ../src/common/paper.cpp:132
 msgid "German Legal Fanfold, 8 1/2 x 13 in"
 msgstr "FanFold alemán legal, 8 1/2 x 13 polgadas"
 
-#: ../src/common/paper.cpp:134
+#: ../src/common/paper.cpp:131
 msgid "German Std Fanfold, 8 1/2 x 12 in"
 msgstr "FanFold alemán estándar, 8 1/2 x 12 polgadas"
 
@@ -3910,49 +4020,49 @@ msgstr "GetPropertyCollection chamou a un método de acceso xenérico"
 msgid "GetPropertyCollection called w/o valid collection getter"
 msgstr "GetPropertyCollection chamado sen un getter axeitado"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:658
 msgid "Go back"
 msgstr "Volver"
 
-#: ../src/html/helpwnd.cpp:661
+#: ../src/html/helpwnd.cpp:659
 msgid "Go forward"
 msgstr "Continuar"
 
-#: ../src/html/helpwnd.cpp:663
+#: ../src/html/helpwnd.cpp:661
 msgid "Go one level up in document hierarchy"
 msgstr "Subir un nivel na xerarquía do documento"
 
-#: ../src/generic/filedlgg.cpp:208 ../src/generic/dirdlgg.cpp:116
+#: ../src/generic/filedlgg.cpp:205 ../src/generic/dirdlgg.cpp:113
 msgid "Go to home directory"
 msgstr "Ir ao cartafol inicial"
 
-#: ../src/generic/filedlgg.cpp:205
+#: ../src/generic/filedlgg.cpp:202
 msgid "Go to parent directory"
 msgstr "Ir ao cartafol superior"
 
-#: ../src/generic/aboutdlgg.cpp:76
+#: ../src/generic/aboutdlgg.cpp:73
 msgid "Graphics art by "
 msgstr "Gráficos de"
 
-#: ../src/propgrid/advprops.cpp:1599
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Gray"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:883
+#: ../src/propgrid/advprops.cpp:784
 msgid "GrayText"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:154
+#: ../src/common/fmapbase.cpp:151
 msgid "Greek (ISO-8859-7)"
 msgstr "Grego (ISO-8859-7)"
 
-#: ../src/propgrid/advprops.cpp:1600
+#: ../src/propgrid/advprops.cpp:1506
 #, fuzzy
 msgid "Green"
 msgstr "Mac grego"
 
-#: ../src/generic/colrdlgg.cpp:342
+#: ../src/generic/colrdlgg.cpp:362
 #, fuzzy
 msgid "Green:"
 msgstr "Mac grego"
@@ -3961,109 +4071,109 @@ msgstr "Mac grego"
 msgid "Groove"
 msgstr "Con suco"
 
-#: ../src/common/zstream.cpp:158 ../src/common/zstream.cpp:318
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
 msgid "Gzip not supported by this version of zlib"
 msgstr "Gzip non é compatíbel con esta versión de zlib"
 
-#: ../src/html/helpwnd.cpp:1549
+#: ../src/html/helpwnd.cpp:1547
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "Proxecto de Axuda HTML (*.hhp)|*.hhp|"
 
-#: ../src/html/htmlwin.cpp:681
+#: ../src/html/htmlwin.cpp:691
 #, c-format
 msgid "HTML anchor %s does not exist."
 msgstr "A áncora de HTML %s non existe."
 
-#: ../src/html/helpwnd.cpp:1547
+#: ../src/html/helpwnd.cpp:1545
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "Ficheiros HTML (*.html;*.htm)|*.html;*.htm|"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1759
+#: ../src/propgrid/advprops.cpp:1660
 msgid "Hand"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "Harddisk"
 msgstr "Disco duro"
 
-#: ../src/common/fmapbase.cpp:155
+#: ../src/common/fmapbase.cpp:152
 msgid "Hebrew (ISO-8859-8)"
 msgstr "Hebreo (ISO-8859-8)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:280 ../src/osx/button_osx.cpp:39
-#: ../src/common/stockitem.cpp:163 ../src/common/accelcmn.cpp:80
-#: ../src/html/helpdlg.cpp:66 ../src/html/helpfrm.cpp:111
+#: ../include/wx/msgdlg.h:282 ../src/osx/button_osx.cpp:39
+#: ../src/common/stockitem.cpp:160 ../src/common/accelcmn.cpp:77
+#: ../src/html/helpfrm.cpp:108 ../src/html/helpdlg.cpp:63
 msgid "Help"
 msgstr "Axuda"
 
-#: ../src/html/helpwnd.cpp:1200
+#: ../src/html/helpwnd.cpp:1198
 msgid "Help Browser Options"
 msgstr "Opcións do navegador de axuda"
 
-#: ../src/generic/helpext.cpp:454 ../src/generic/helpext.cpp:455
+#: ../src/generic/helpext.cpp:452 ../src/generic/helpext.cpp:453
 msgid "Help Index"
 msgstr "Índice da axuda"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1529
 msgid "Help Printing"
 msgstr "Axuda de impresión"
 
-#: ../src/html/helpwnd.cpp:801
+#: ../src/html/helpwnd.cpp:799
 msgid "Help Topics"
 msgstr "Temas da axuda"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1546
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Libros de axuda (*.htb)|*.htb|Libros de axuda (*.zip)|*.zip|"
 
-#: ../src/generic/helpext.cpp:267
+#: ../src/generic/helpext.cpp:265
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "Non se atopou o cartafol de axuda \"%s\"."
 
-#: ../src/generic/helpext.cpp:275
+#: ../src/generic/helpext.cpp:273
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "Non se atopou o ficheiro de axuda \"%s\"."
 
-#: ../src/html/helpctrl.cpp:63
+#: ../src/html/helpctrl.cpp:59
 #, c-format
 msgid "Help: %s"
 msgstr "Axuda: %s"
 
-#: ../src/osx/menu_osx.cpp:577
+#: ../src/osx/menu_osx.cpp:469
 #, c-format
 msgid "Hide %s"
 msgstr "Agochar %s"
 
-#: ../src/osx/menu_osx.cpp:579
+#: ../src/osx/menu_osx.cpp:471
 msgid "Hide Others"
 msgstr "Agochar outros"
 
-#: ../src/generic/infobar.cpp:84
+#: ../src/generic/infobar.cpp:81
 msgid "Hide this notification message."
 msgstr "Agochar esta mensaxe de notificación."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:884
+#: ../src/propgrid/advprops.cpp:785
 #, fuzzy
 msgid "Highlight"
 msgstr "clara"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:885
+#: ../src/propgrid/advprops.cpp:786
 #, fuzzy
 msgid "HighlightText"
 msgstr "Aliñar texto á dereita."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:164 ../src/common/accelcmn.cpp:65
+#: ../src/common/stockitem.cpp:161 ../src/common/accelcmn.cpp:62
 msgid "Home"
 msgstr "Inicio"
 
-#: ../src/generic/dirctrlg.cpp:524
+#: ../src/generic/dirctrlg.cpp:490
 msgid "Home directory"
 msgstr "Cartafol inicial"
 
@@ -4073,55 +4183,55 @@ msgid "How the object will float relative to the text."
 msgstr "Como debe flotar o obxecto con relación ao texto."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1760
+#: ../src/propgrid/advprops.cpp:1661
 msgid "I-Beam"
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1196
+#: ../src/common/imagbmp.cpp:1208
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: Erro ao ler máscara DIB."
 
-#: ../src/common/imagbmp.cpp:1290 ../src/common/imagbmp.cpp:1390
-#: ../src/common/imagbmp.cpp:1405 ../src/common/imagbmp.cpp:1416
-#: ../src/common/imagbmp.cpp:1430 ../src/common/imagbmp.cpp:1478
-#: ../src/common/imagbmp.cpp:1493 ../src/common/imagbmp.cpp:1507
-#: ../src/common/imagbmp.cpp:1518
+#: ../src/common/imagbmp.cpp:1302 ../src/common/imagbmp.cpp:1402
+#: ../src/common/imagbmp.cpp:1417 ../src/common/imagbmp.cpp:1428
+#: ../src/common/imagbmp.cpp:1442 ../src/common/imagbmp.cpp:1490
+#: ../src/common/imagbmp.cpp:1505 ../src/common/imagbmp.cpp:1519
+#: ../src/common/imagbmp.cpp:1530
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: Erro ao escribir o ficheiro de imaxe!"
 
-#: ../src/common/imagbmp.cpp:1255
+#: ../src/common/imagbmp.cpp:1267
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: A imaxe é alta de máis para unha icona."
 
-#: ../src/common/imagbmp.cpp:1263
+#: ../src/common/imagbmp.cpp:1275
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: A imaxe é ancha de máis para unha icona."
 
-#: ../src/common/imagbmp.cpp:1603
+#: ../src/common/imagbmp.cpp:1615
 msgid "ICO: Invalid icon index."
 msgstr "ICO: Índice de iconas incorrecto."
 
-#: ../src/common/imagiff.cpp:758
+#: ../src/common/imagiff.cpp:755
 msgid "IFF: data stream seems to be truncated."
 msgstr "IFF: o fluxo de datos semella truncado."
 
-#: ../src/common/imagiff.cpp:742
+#: ../src/common/imagiff.cpp:739
 msgid "IFF: error in IFF image format."
 msgstr "IFF: erro no formato da imaxe IFF."
 
-#: ../src/common/imagiff.cpp:745
+#: ../src/common/imagiff.cpp:742
 msgid "IFF: not enough memory."
 msgstr "IFF: memoria insuficiente."
 
-#: ../src/common/imagiff.cpp:748
+#: ../src/common/imagiff.cpp:745
 msgid "IFF: unknown error!!!"
 msgstr "IFF: erro descoñecido!!!"
 
-#: ../src/common/fmapbase.cpp:197
+#: ../src/common/fmapbase.cpp:194
 msgid "ISO-2022-JP"
 msgstr "ISO-2022-JP"
 
-#: ../src/html/htmprint.cpp:282
+#: ../src/html/htmprint.cpp:294
 msgid ""
 "If possible, try changing the layout parameters to make the printout more "
 "narrow."
@@ -4129,7 +4239,7 @@ msgstr ""
 "Se é posíbel, intente cambiar os parámetros de deseño para facer a impresión "
 "máis estreita."
 
-#: ../src/generic/dbgrptg.cpp:358
+#: ../src/generic/dbgrptg.cpp:362
 msgid ""
 "If you have any additional information pertaining to this bug\n"
 "report, please enter it here and it will be joined to it:"
@@ -4150,46 +4260,50 @@ msgstr ""
 "que,\n"
 "se é posíbel continúe coa xeración do informe.\n"
 
-#: ../src/msw/registry.cpp:1405
+#: ../src/common/zipstrm.cpp:1043
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1393
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Ignorando o valor \"%s\" da clave \"%s\"."
 
-#: ../src/common/xtistrm.cpp:295
+#: ../src/common/xtistrm.cpp:292
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Clase de obxecto inaceptábel como orixe do evento (non-wxEvtHandler)"
 
-#: ../src/common/xti.cpp:513
+#: ../src/common/xti.cpp:510
 msgid "Illegal Parameter Count for ConstructObject Method"
 msgstr "Número de parámetros inaceptábel para o método ConstructObject"
 
-#: ../src/common/xti.cpp:501
+#: ../src/common/xti.cpp:498
 msgid "Illegal Parameter Count for Create Method"
 msgstr "Número de parámetros inaceptábel para o método Create"
 
-#: ../src/generic/dirctrlg.cpp:570 ../src/generic/filectrlg.cpp:756
+#: ../src/generic/dirctrlg.cpp:536 ../src/generic/filectrlg.cpp:752
 msgid "Illegal directory name."
 msgstr "Nome de cartafol inaceptábel."
 
-#: ../src/generic/filectrlg.cpp:1367
+#: ../src/generic/filectrlg.cpp:1356
 msgid "Illegal file specification."
 msgstr "Especificación de ficheiro inaceptábel."
 
-#: ../src/common/image.cpp:2269
+#: ../src/common/image.cpp:2363
 msgid "Image and mask have different sizes."
 msgstr "A imaxe e a máscara teñen tamaños diferentes."
 
-#: ../src/common/image.cpp:2746
+#: ../src/common/image.cpp:2841
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "O ficheiro de imaxe non é do tipo %d."
 
-#: ../src/common/image.cpp:2877
+#: ../src/common/image.cpp:2995
 #, c-format
 msgid "Image is not of type %s."
 msgstr "A imaxe non é do tipo %s."
 
-#: ../src/msw/textctrl.cpp:488
+#: ../src/msw/textctrl.cpp:534
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -4197,102 +4311,102 @@ msgstr ""
 "Non é posíbel crear un control do editor visual, no seu lugar usouse un "
 "control de texto simple. Por favor, instale riched32.dll"
 
-#: ../src/unix/utilsunx.cpp:301
+#: ../src/unix/utilsunx.cpp:303
 msgid "Impossible to get child process input"
 msgstr "Non é posíbel obter a entrada do proceso fillo"
 
-#: ../src/common/filefn.cpp:1028
+#: ../src/common/filefn.cpp:917
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Non é posíbel obter permisos para o ficheiro '%s'"
 
-#: ../src/common/filefn.cpp:1042
+#: ../src/common/filefn.cpp:931
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "É imposíbel sobreescribir o ficheiro '%s'"
 
-#: ../src/common/filefn.cpp:1097
+#: ../src/common/filefn.cpp:986
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Foi imposíbel estabelecer os permisos para o ficheiro '%s'"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:886
+#: ../src/propgrid/advprops.cpp:787
 #, fuzzy
 msgid "InactiveBorder"
 msgstr "Bordo"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:887
+#: ../src/propgrid/advprops.cpp:788
 msgid "InactiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:888
+#: ../src/propgrid/advprops.cpp:789
 msgid "InactiveCaptionText"
 msgstr ""
 
-#: ../src/common/gifdecod.cpp:792
+#: ../src/common/gifdecod.cpp:826
 #, c-format
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "Tamaño de marco de GIF incorrecto (%u, %d) para o marco #%u"
 
-#: ../src/msw/ole/automtn.cpp:635
+#: ../src/msw/ole/automtn.cpp:626
 msgid "Incorrect number of arguments."
 msgstr "Número de argumentos incorrecto."
 
-#: ../src/common/stockitem.cpp:165
+#: ../src/common/stockitem.cpp:162
 msgid "Indent"
 msgstr "Sangrar"
 
-#: ../src/richtext/richtextformatdlg.cpp:349
+#: ../src/richtext/richtextformatdlg.cpp:342
 msgid "Indents && Spacing"
 msgstr "Sangría && Espazamento"
 
-#: ../src/common/stockitem.cpp:166 ../src/html/helpwnd.cpp:515
+#: ../src/common/stockitem.cpp:163 ../src/html/helpwnd.cpp:513
 msgid "Index"
 msgstr "Índice"
 
-#: ../src/common/fmapbase.cpp:159
+#: ../src/common/fmapbase.cpp:156
 msgid "Indian (ISO-8859-12)"
 msgstr "Indio (ISO-8859-12)"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "Info"
 msgstr "Info"
 
-#: ../src/common/init.cpp:287
+#: ../src/common/init.cpp:284
 msgid "Initialization failed in post init, aborting."
 msgstr "Erro ao inicializar post init, cancelando."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:54
+#: ../src/common/accelcmn.cpp:51
 #, fuzzy
 msgid "Ins"
 msgstr "Inserido"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextsymboldlg.cpp:472 ../src/common/accelcmn.cpp:53
+#: ../src/common/accelcmn.cpp:50 ../src/richtext/richtextsymboldlg.cpp:469
 msgid "Insert"
 msgstr "Inserir"
 
-#: ../src/richtext/richtextbuffer.cpp:8067
+#: ../src/richtext/richtextbuffer.cpp:8063
 msgid "Insert Field"
 msgstr "Inserir campo"
 
-#: ../src/richtext/richtextbuffer.cpp:7978
-#: ../src/richtext/richtextbuffer.cpp:8936
+#: ../src/richtext/richtextbuffer.cpp:7974
+#: ../src/richtext/richtextbuffer.cpp:8934
 msgid "Insert Image"
 msgstr "Inserir imaxe"
 
-#: ../src/richtext/richtextbuffer.cpp:8025
+#: ../src/richtext/richtextbuffer.cpp:8021
 msgid "Insert Object"
 msgstr "Inserir obxecto"
 
-#: ../src/richtext/richtextctrl.cpp:1286 ../src/richtext/richtextctrl.cpp:1494
-#: ../src/richtext/richtextbuffer.cpp:7822
-#: ../src/richtext/richtextbuffer.cpp:7852
-#: ../src/richtext/richtextbuffer.cpp:7894
+#: ../src/richtext/richtextbuffer.cpp:7818
+#: ../src/richtext/richtextbuffer.cpp:7848
+#: ../src/richtext/richtextbuffer.cpp:7890
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
 msgid "Insert Text"
 msgstr "Inserir texto"
 
@@ -4305,16 +4419,11 @@ msgstr "Insire un salto de páxina antes do parágrafo."
 msgid "Inset"
 msgstr "Inserido"
 
-#: ../src/gtk/app.cpp:425
-#, c-format
-msgid "Invalid GTK+ command line option, use \"%s --help\""
-msgstr "Opción de liña de comando de GTK+ incorrecta, utilice \"%s --help\""
-
-#: ../src/common/imagtiff.cpp:311
+#: ../src/common/imagtiff.cpp:308
 msgid "Invalid TIFF image index."
 msgstr "Índice de imaxe TIFF incorrecto."
 
-#: ../src/common/appcmn.cpp:273
+#: ../src/common/appcmn.cpp:294
 #, c-format
 msgid "Invalid display mode specification '%s'."
 msgstr "Especificación de modo de visor incorrecta: '%s'."
@@ -4324,259 +4433,263 @@ msgstr "Especificación de modo de visor incorrecta: '%s'."
 msgid "Invalid geometry specification '%s'"
 msgstr "Especificación de xeometría incorrecta: '%s'"
 
-#: ../src/unix/fswatcher_inotify.cpp:323
+#: ../src/unix/fswatcher_inotify.cpp:320
 #, c-format
 msgid "Invalid inotify event for \"%s\""
 msgstr "Evento de inotify incorrecto para \"%s\""
 
-#: ../src/unix/snglinst.cpp:312
+#: ../src/unix/snglinst.cpp:309
 #, c-format
 msgid "Invalid lock file '%s'."
 msgstr "Ficheiro de bloqueo '%s' incorrecto."
 
-#: ../src/common/translation.cpp:1125
+#: ../src/common/translation.cpp:1167
 msgid "Invalid message catalog."
 msgstr "Catálogo de mensaxes incorrecto."
 
-#: ../src/common/xtistrm.cpp:405 ../src/common/xtistrm.cpp:420
+#: ../src/common/xtistrm.cpp:402 ../src/common/xtistrm.cpp:417
 msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
 msgstr "ID de obxecto incorrecto ou nulo pasada a GetObjectClassInfo"
 
-#: ../src/common/xtistrm.cpp:435
+#: ../src/common/xtistrm.cpp:432
 msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
 msgstr "ID de obxecto incorrrecto ou nulo pasada a HasObjectClassInfo"
 
-#: ../src/common/regex.cpp:310
+#: ../src/common/regex.cpp:307
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Expresión regular incorrecta '%s': %s"
 
-#: ../src/common/config.cpp:226
+#: ../src/common/config.cpp:222
 #, c-format
 msgid "Invalid value %ld for a boolean key \"%s\" in config file."
 msgstr ""
 "Valor %ld incorrecto para a clave booleana \"%s\" no ficheiro de "
 "configuración."
 
-#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:351
-#: ../src/osx/carbon/fontdlg.cpp:361 ../src/common/stockitem.cpp:168
+#: ../src/osx/carbon/fontdlg.cpp:358 ../src/common/stockitem.cpp:165
+#: ../src/generic/fontdlgg.cpp:325 ../src/richtext/richtextfontpage.cpp:351
 msgid "Italic"
 msgstr "Cursiva"
 
-#: ../src/common/paper.cpp:130
+#: ../src/common/paper.cpp:127
 msgid "Italy Envelope, 110 x 230 mm"
 msgstr "Sobre italiano, 110 x 230 mm"
 
-#: ../src/common/imagjpeg.cpp:270
+#: ../src/common/imagjpeg.cpp:257
 msgid "JPEG: Couldn't load - file is probably corrupted."
 msgstr "JPEG: Non se puido cargar - probabelmente o ficheiro estea danado."
 
-#: ../src/common/imagjpeg.cpp:449
+#: ../src/common/imagjpeg.cpp:436
 msgid "JPEG: Couldn't save image."
 msgstr "JPEG: Non se puido gardar a imaxe."
 
-#: ../src/common/paper.cpp:163
+#: ../src/common/paper.cpp:160
 msgid "Japanese Double Postcard 200 x 148 mm"
 msgstr "Postal dobre xaponesa 200 x 148 mm"
 
-#: ../src/common/paper.cpp:167
+#: ../src/common/paper.cpp:164
 msgid "Japanese Envelope Chou #3"
 msgstr "Sobre xaponés Chou #3"
 
-#: ../src/common/paper.cpp:180
+#: ../src/common/paper.cpp:177
 msgid "Japanese Envelope Chou #3 Rotated"
 msgstr "Sobre xaponés Chou #3 apaisado"
 
-#: ../src/common/paper.cpp:168
+#: ../src/common/paper.cpp:165
 msgid "Japanese Envelope Chou #4"
 msgstr "Sobre xaponés Chou #4"
 
-#: ../src/common/paper.cpp:181
+#: ../src/common/paper.cpp:178
 msgid "Japanese Envelope Chou #4 Rotated"
 msgstr "Sobre xaponés Chou #4 apaisado"
 
-#: ../src/common/paper.cpp:165
+#: ../src/common/paper.cpp:162
 msgid "Japanese Envelope Kaku #2"
 msgstr "Sobre xaponés Kaku #2"
 
-#: ../src/common/paper.cpp:178
+#: ../src/common/paper.cpp:175
 msgid "Japanese Envelope Kaku #2 Rotated"
 msgstr "Sobre xaponés Kaku #2 apaisado"
 
-#: ../src/common/paper.cpp:166
+#: ../src/common/paper.cpp:163
 msgid "Japanese Envelope Kaku #3"
 msgstr "Sobre xaponés Kaku #3"
 
-#: ../src/common/paper.cpp:179
+#: ../src/common/paper.cpp:176
 msgid "Japanese Envelope Kaku #3 Rotated"
 msgstr "Sobre xaponés Kaku #3 apaisado"
 
-#: ../src/common/paper.cpp:185
+#: ../src/common/paper.cpp:182
 msgid "Japanese Envelope You #4"
 msgstr "Sobre xaponés You #4"
 
-#: ../src/common/paper.cpp:186
+#: ../src/common/paper.cpp:183
 msgid "Japanese Envelope You #4 Rotated"
 msgstr "Sobre xaponés You #4 apaisado"
 
-#: ../src/common/paper.cpp:138
+#: ../src/common/paper.cpp:135
 msgid "Japanese Postcard 100 x 148 mm"
 msgstr "Postal xaponesa 100 x 148 mm"
 
-#: ../src/common/paper.cpp:175
+#: ../src/common/paper.cpp:172
 msgid "Japanese Postcard Rotated 148 x 100 mm"
 msgstr "Postal xaponesa apaisada 148 x 100 mm"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "Jump to"
 msgstr "Ir a"
 
-#: ../src/common/stockitem.cpp:171
+#: ../src/common/stockitem.cpp:168
 msgid "Justified"
 msgstr "Xustificado"
 
-#: ../src/richtext/richtextindentspage.cpp:155
-#: ../src/richtext/richtextindentspage.cpp:157
 #: ../src/richtext/richtextliststylepage.cpp:344
 #: ../src/richtext/richtextliststylepage.cpp:346
+#: ../src/richtext/richtextindentspage.cpp:155
+#: ../src/richtext/richtextindentspage.cpp:157
 msgid "Justify text left and right."
 msgstr "Xustificar texto á esquerda e á dereita."
 
-#: ../src/common/fmapbase.cpp:163
+#: ../src/common/fmapbase.cpp:160
 msgid "KOI8-R"
 msgstr "KOI8-R"
 
-#: ../src/common/fmapbase.cpp:164
+#: ../src/common/fmapbase.cpp:161
 msgid "KOI8-U"
 msgstr "KOI8-U"
 
-#: ../src/common/accelcmn.cpp:265 ../src/common/accelcmn.cpp:347
+#: ../src/common/accelcmn.cpp:279 ../src/common/accelcmn.cpp:364
 msgid "KP_"
 msgstr "KP_"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 #, fuzzy
 msgid "KP_Add"
 msgstr "KP_ADD"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "KP_Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "KP_Decimal"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 #, fuzzy
 msgid "KP_Delete"
 msgstr "Eliminar"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "KP_Divide"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 #, fuzzy
 msgid "KP_Down"
 msgstr "Abaixo"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 #, fuzzy
 msgid "KP_End"
 msgstr "KP_END"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 #, fuzzy
 msgid "KP_Enter"
 msgstr "Impresora"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "KP_Equal"
 msgstr ""
 
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
-#, fuzzy
-msgid "KP_Home"
-msgstr "Inicio"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
-#, fuzzy
-msgid "KP_Insert"
-msgstr "Inserir"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
-#, fuzzy
-msgid "KP_Left"
-msgstr "Esquerda"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
-msgid "KP_Multiply"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:99
-#, fuzzy
-msgid "KP_Next"
-msgstr "Seguinte"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
-msgid "KP_PageDown"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
-msgid "KP_PageUp"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:98
-msgid "KP_Prior"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
-#, fuzzy
-msgid "KP_Right"
-msgstr "Clara"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
-msgid "KP_Separator"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
-msgid "KP_Space"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
-msgid "KP_Subtract"
+#: ../src/common/accelcmn.cpp:276 ../src/common/accelcmn.cpp:361
+msgid "KP_F"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
 #: ../src/common/accelcmn.cpp:89
 #, fuzzy
+msgid "KP_Home"
+msgstr "Inicio"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:100
+#, fuzzy
+msgid "KP_Insert"
+msgstr "Inserir"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:90
+#, fuzzy
+msgid "KP_Left"
+msgstr "Esquerda"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:103
+msgid "KP_Multiply"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:97
+#, fuzzy
+msgid "KP_Next"
+msgstr "Seguinte"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:95
+msgid "KP_PageDown"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:94
+msgid "KP_PageUp"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:96
+msgid "KP_Prior"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:92
+#, fuzzy
+msgid "KP_Right"
+msgstr "Clara"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:105
+msgid "KP_Separator"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:86
+msgid "KP_Space"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:106
+msgid "KP_Subtract"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:87
+#, fuzzy
 msgid "KP_Tab"
 msgstr "KP_TAB"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 #, fuzzy
 msgid "KP_Up"
 msgstr "KP_UP"
@@ -4585,112 +4698,127 @@ msgstr "KP_UP"
 msgid "L&ine spacing:"
 msgstr "Espazamento entre &liñas:"
 
-#: ../src/generic/prntdlgg.cpp:613 ../src/generic/prntdlgg.cpp:868
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "erro de compresión"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "erro de descompresión"
+
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:861
 msgid "Landscape"
 msgstr "Horizontal"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "Last"
 msgstr "Último"
 
-#: ../src/common/prntbase.cpp:1572
+#: ../src/common/prntbase.cpp:1597
 msgid "Last page"
 msgstr "Última páxina"
 
-#: ../src/common/log.cpp:305
+#: ../src/common/log.cpp:324
 #, fuzzy, c-format
 msgid "Last repeated message (\"%s\", %u time) wasn't output"
 msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
 msgstr[0] "A última mensaxe repetida (\"%s\", %lu vez) non se enviou á saída"
 msgstr[1] "A última mensaxe repetida (\"%s\", %lu veces) non se enviou á saída"
 
-#: ../src/common/paper.cpp:103
+#: ../src/common/paper.cpp:100
 msgid "Ledger, 17 x 11 in"
 msgstr "Libro maior, 17 x 11 polgadas"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6146
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:58 ../src/generic/datavgen.cpp:6951
+#: ../src/richtext/richtextsizepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:252
 #: ../src/richtext/richtextliststylepage.cpp:253
 #: ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
-#: ../src/richtext/richtextsizepage.cpp:249 ../src/common/accelcmn.cpp:61
 msgid "Left"
 msgstr "Esquerda"
 
-#: ../src/richtext/richtextindentspage.cpp:204
 #: ../src/richtext/richtextliststylepage.cpp:390
+#: ../src/richtext/richtextindentspage.cpp:204
 msgid "Left (&first line):"
 msgstr "Esquerda (&primeira liña):"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1761
+#: ../src/propgrid/advprops.cpp:1662
 msgid "Left Button"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:880
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Left margin (mm):"
 msgstr "Marxe esquerda (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:141
-#: ../src/richtext/richtextindentspage.cpp:143
 #: ../src/richtext/richtextliststylepage.cpp:330
 #: ../src/richtext/richtextliststylepage.cpp:332
+#: ../src/richtext/richtextindentspage.cpp:141
+#: ../src/richtext/richtextindentspage.cpp:143
 msgid "Left-align text."
 msgstr "Aliñar o texto á esquerda."
 
-#: ../src/common/paper.cpp:144
+#: ../src/common/paper.cpp:141
 msgid "Legal Extra 9 1/2 x 15 in"
 msgstr "Legal extra 9 1/2 x 15 polgadas"
 
-#: ../src/common/paper.cpp:96
+#: ../src/common/paper.cpp:93
 msgid "Legal, 8 1/2 x 14 in"
 msgstr "Legal, 8 1/2 x 14 polgadas"
 
-#: ../src/common/paper.cpp:143
+#: ../src/common/paper.cpp:140
 msgid "Letter Extra 9 1/2 x 12 in"
 msgstr "Carta extra 9 1/2 x 12 polgadas"
 
-#: ../src/common/paper.cpp:149
+#: ../src/common/paper.cpp:146
 msgid "Letter Extra Transverse 9.275 x 12 in"
 msgstr "Carta extra transversal 9,275 x 12 polgadas"
 
-#: ../src/common/paper.cpp:152
+#: ../src/common/paper.cpp:149
 msgid "Letter Plus 8 1/2 x 12.69 in"
 msgstr "Carta Plus 8 1/2 x 12,69 polgadas"
 
-#: ../src/common/paper.cpp:169
+#: ../src/common/paper.cpp:166
 msgid "Letter Rotated 11 x 8 1/2 in"
 msgstr "Sobre apaisado, 11 x 8 1/2 in"
 
-#: ../src/common/paper.cpp:101
+#: ../src/common/paper.cpp:98
 msgid "Letter Small, 8 1/2 x 11 in"
 msgstr "Sobre pequeno, 8 1/2 x 11 polgadas"
 
-#: ../src/common/paper.cpp:147
+#: ../src/common/paper.cpp:144
 msgid "Letter Transverse 8 1/2 x 11 in"
 msgstr "Sobre transversal, 8 1/2 x 11 polgadas"
 
-#: ../src/common/paper.cpp:95
+#: ../src/common/paper.cpp:92
 msgid "Letter, 8 1/2 x 11 in"
 msgstr "Carta, 8 1/2 x 11 polgadas"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "License"
 msgstr "Licencia"
 
-#: ../src/generic/fontdlgg.cpp:332
+#: ../src/generic/fontdlgg.cpp:328
 msgid "Light"
 msgstr "Clara"
 
-#: ../src/propgrid/advprops.cpp:1608
+#: ../src/propgrid/advprops.cpp:1514
 msgid "Lime"
 msgstr ""
 
-#: ../src/generic/helpext.cpp:294
+#: ../src/generic/helpext.cpp:292
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr ""
@@ -4701,15 +4829,15 @@ msgstr ""
 msgid "Line spacing:"
 msgstr "Espazamento entre liñas:"
 
-#: ../src/html/chm.cpp:838
+#: ../src/html/chm.cpp:829
 msgid "Link contained '//', converted to absolute link."
 msgstr "O enlace contiña '//', convertido a enlace absoluto."
 
-#: ../src/richtext/richtextformatdlg.cpp:364
+#: ../src/richtext/richtextformatdlg.cpp:357
 msgid "List Style"
 msgstr "Estilo de lista"
 
-#: ../src/richtext/richtextstyles.cpp:1064
+#: ../src/richtext/richtextstyles.cpp:1061
 msgid "List styles"
 msgstr "Estilos de lista"
 
@@ -4723,26 +4851,26 @@ msgstr "Fai un listado de tamaños de letra en puntos."
 msgid "Lists the available fonts."
 msgstr "Enumera os tipos de letra dispoñíbeis."
 
-#: ../src/common/fldlgcmn.cpp:340
+#: ../src/common/fldlgcmn.cpp:337
 #, c-format
 msgid "Load %s file"
 msgstr "Cargar o ficheiro %s"
 
-#: ../src/html/htmlwin.cpp:597
+#: ../src/html/htmlwin.cpp:600
 msgid "Loading : "
 msgstr "Cargando: "
 
-#: ../src/unix/snglinst.cpp:246
+#: ../src/unix/snglinst.cpp:243
 #, c-format
 msgid "Lock file '%s' has incorrect owner."
 msgstr "O ficheiro de bloqueo '%s' ten un propietario incorrecto."
 
-#: ../src/unix/snglinst.cpp:251
+#: ../src/unix/snglinst.cpp:248
 #, c-format
 msgid "Lock file '%s' has incorrect permissions."
 msgstr "O ficheiro de bloqueo '%s' ten permisos incorrectos."
 
-#: ../src/generic/logg.cpp:576
+#: ../src/generic/logg.cpp:573
 #, c-format
 msgid "Log saved to the file '%s'."
 msgstr "O rexistro gardouse no ficheiro '%s'."
@@ -4757,11 +4885,11 @@ msgstr "Letras minúsculas"
 msgid "Lower case roman numerals"
 msgstr "Núeros romanos en minúscula"
 
-#: ../src/gtk/mdi.cpp:422 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk1/mdi.cpp:431 ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "Fillo MDI"
 
-#: ../src/msw/helpchm.cpp:56
+#: ../src/msw/helpchm.cpp:53
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -4770,189 +4898,189 @@ msgstr ""
 "instalada nesta máquina a biblioteca de Axuda HTML de MS. Por favor, "
 "instálea."
 
-#: ../src/univ/themes/win32.cpp:3754
+#: ../src/univ/themes/win32.cpp:3751
 msgid "Ma&ximize"
 msgstr "Ma&ximizar"
 
-#: ../src/common/fmapbase.cpp:203
+#: ../src/common/fmapbase.cpp:200
 msgid "MacArabic"
 msgstr "Mac árabe"
 
-#: ../src/common/fmapbase.cpp:222
+#: ../src/common/fmapbase.cpp:219
 msgid "MacArmenian"
 msgstr "Mac armenio"
 
-#: ../src/common/fmapbase.cpp:211
+#: ../src/common/fmapbase.cpp:208
 msgid "MacBengali"
 msgstr "Mac bengalí"
 
-#: ../src/common/fmapbase.cpp:217
+#: ../src/common/fmapbase.cpp:214
 msgid "MacBurmese"
 msgstr "Mac birmano"
 
-#: ../src/common/fmapbase.cpp:236
+#: ../src/common/fmapbase.cpp:233
 msgid "MacCeltic"
 msgstr "Mac céltico"
 
-#: ../src/common/fmapbase.cpp:227
+#: ../src/common/fmapbase.cpp:224
 msgid "MacCentralEurRoman"
 msgstr "Mac ASCII Europa Central"
 
-#: ../src/common/fmapbase.cpp:223
+#: ../src/common/fmapbase.cpp:220
 msgid "MacChineseSimp"
 msgstr "Mac chinés simple"
 
-#: ../src/common/fmapbase.cpp:201
+#: ../src/common/fmapbase.cpp:198
 msgid "MacChineseTrad"
 msgstr "Mac chinés tradicional"
 
-#: ../src/common/fmapbase.cpp:233
+#: ../src/common/fmapbase.cpp:230
 msgid "MacCroatian"
 msgstr "Mac croata"
 
-#: ../src/common/fmapbase.cpp:206
+#: ../src/common/fmapbase.cpp:203
 msgid "MacCyrillic"
 msgstr "Mac cirílico"
 
-#: ../src/common/fmapbase.cpp:207
+#: ../src/common/fmapbase.cpp:204
 msgid "MacDevanagari"
 msgstr "Mac devanágari"
 
-#: ../src/common/fmapbase.cpp:231
+#: ../src/common/fmapbase.cpp:228
 msgid "MacDingbats"
 msgstr "Mac pictogramas"
 
-#: ../src/common/fmapbase.cpp:226
+#: ../src/common/fmapbase.cpp:223
 msgid "MacEthiopic"
 msgstr "Mac etíope"
 
-#: ../src/common/fmapbase.cpp:229
+#: ../src/common/fmapbase.cpp:226
 msgid "MacExtArabic"
 msgstr "Mac árabe est."
 
-#: ../src/common/fmapbase.cpp:237
+#: ../src/common/fmapbase.cpp:234
 msgid "MacGaelic"
 msgstr "Mac gaélico"
 
-#: ../src/common/fmapbase.cpp:221
+#: ../src/common/fmapbase.cpp:218
 msgid "MacGeorgian"
 msgstr "Mac xeorxiano"
 
-#: ../src/common/fmapbase.cpp:205
+#: ../src/common/fmapbase.cpp:202
 msgid "MacGreek"
 msgstr "Mac grego"
 
-#: ../src/common/fmapbase.cpp:209
+#: ../src/common/fmapbase.cpp:206
 msgid "MacGujarati"
 msgstr "Mac gujarati"
 
-#: ../src/common/fmapbase.cpp:208
+#: ../src/common/fmapbase.cpp:205
 msgid "MacGurmukhi"
 msgstr "Mac gurmukhi"
 
-#: ../src/common/fmapbase.cpp:204
+#: ../src/common/fmapbase.cpp:201
 msgid "MacHebrew"
 msgstr "Mac hebreo"
 
-#: ../src/common/fmapbase.cpp:234
+#: ../src/common/fmapbase.cpp:231
 msgid "MacIcelandic"
 msgstr "Mac islandés"
 
-#: ../src/common/fmapbase.cpp:200
+#: ../src/common/fmapbase.cpp:197
 msgid "MacJapanese"
 msgstr "Mac xaponés"
 
-#: ../src/common/fmapbase.cpp:214
+#: ../src/common/fmapbase.cpp:211
 msgid "MacKannada"
 msgstr "Mac kanada"
 
-#: ../src/common/fmapbase.cpp:238
+#: ../src/common/fmapbase.cpp:235
 msgid "MacKeyboardGlyphs"
 msgstr "Mac caracteres especiais"
 
-#: ../src/common/fmapbase.cpp:218
+#: ../src/common/fmapbase.cpp:215
 msgid "MacKhmer"
 msgstr "Mac cambodjano"
 
-#: ../src/common/fmapbase.cpp:202
+#: ../src/common/fmapbase.cpp:199
 msgid "MacKorean"
 msgstr "Mac coreano"
 
-#: ../src/common/fmapbase.cpp:220
+#: ../src/common/fmapbase.cpp:217
 msgid "MacLaotian"
 msgstr "Mac laosiano"
 
-#: ../src/common/fmapbase.cpp:215
+#: ../src/common/fmapbase.cpp:212
 msgid "MacMalayalam"
 msgstr "Mac malaialam"
 
-#: ../src/common/fmapbase.cpp:225
+#: ../src/common/fmapbase.cpp:222
 msgid "MacMongolian"
 msgstr "Mac mongol"
 
-#: ../src/common/fmapbase.cpp:210
+#: ../src/common/fmapbase.cpp:207
 msgid "MacOriya"
 msgstr "Mac orissa"
 
-#: ../src/common/fmapbase.cpp:199
+#: ../src/common/fmapbase.cpp:196
 msgid "MacRoman"
 msgstr "Mac ASCII"
 
-#: ../src/common/fmapbase.cpp:235
+#: ../src/common/fmapbase.cpp:232
 msgid "MacRomanian"
 msgstr "Mac romanés"
 
-#: ../src/common/fmapbase.cpp:216
+#: ../src/common/fmapbase.cpp:213
 msgid "MacSinhalese"
 msgstr "Mac cingalés"
 
-#: ../src/common/fmapbase.cpp:230
+#: ../src/common/fmapbase.cpp:227
 msgid "MacSymbol"
 msgstr "Mac símbolos"
 
-#: ../src/common/fmapbase.cpp:212
+#: ../src/common/fmapbase.cpp:209
 msgid "MacTamil"
 msgstr "Mac támil"
 
-#: ../src/common/fmapbase.cpp:213
+#: ../src/common/fmapbase.cpp:210
 msgid "MacTelugu"
 msgstr "Mac telugu"
 
-#: ../src/common/fmapbase.cpp:219
+#: ../src/common/fmapbase.cpp:216
 msgid "MacThai"
 msgstr "Mac tai"
 
-#: ../src/common/fmapbase.cpp:224
+#: ../src/common/fmapbase.cpp:221
 msgid "MacTibetan"
 msgstr "Mac tibetano"
 
-#: ../src/common/fmapbase.cpp:232
+#: ../src/common/fmapbase.cpp:229
 msgid "MacTurkish"
 msgstr "Mac turco"
 
-#: ../src/common/fmapbase.cpp:228
+#: ../src/common/fmapbase.cpp:225
 msgid "MacVietnamese"
 msgstr "Mac vietnamita"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1762
+#: ../src/propgrid/advprops.cpp:1663
 msgid "Magnifier"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:2143
+#: ../src/propgrid/advprops.cpp:2050
 msgid "Make a selection:"
 msgstr "Seleccionar:"
 
-#: ../src/richtext/richtextformatdlg.cpp:374
+#: ../src/richtext/richtextformatdlg.cpp:367
 #: ../src/richtext/richtextmarginspage.cpp:171
 msgid "Margins"
 msgstr "Marxes"
 
-#: ../src/propgrid/advprops.cpp:1595
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Maroon"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:147
+#: ../src/generic/fdrepdlg.cpp:144
 msgid "Match case"
 msgstr "Coincidir Maiúsculas/Minúsculas"
 
@@ -4964,40 +5092,40 @@ msgstr "Altura máx.:"
 msgid "Max width:"
 msgstr "Ancho máx.:"
 
-#: ../src/unix/mediactrl.cpp:947
+#: ../src/unix/mediactrl.cpp:972
 #, c-format
 msgid "Media playback error: %s"
 msgstr "Erro na reprodución multimedia: %s"
 
-#: ../src/common/fs_mem.cpp:175
+#: ../src/common/fs_mem.cpp:170
 #, c-format
 msgid "Memory VFS already contains file '%s'!"
 msgstr "A memoria VFS xa contén o ficheiro '%s'!"
 
 #. TRANSLATORS: Name of keyboard key
 #. TRANSLATORS: Keyword of system colour
-#: ../src/common/accelcmn.cpp:73 ../src/propgrid/advprops.cpp:889
+#: ../src/common/accelcmn.cpp:70 ../src/propgrid/advprops.cpp:790
 msgid "Menu"
 msgstr "Menú"
 
-#: ../src/common/msgout.cpp:124
+#: ../src/common/msgout.cpp:121
 msgid "Message"
 msgstr "Mensaxe"
 
-#: ../src/univ/themes/metal.cpp:168
+#: ../src/univ/themes/metal.cpp:165
 msgid "Metal theme"
 msgstr "Presentación Metal"
 
-#: ../src/msw/ole/automtn.cpp:652
+#: ../src/msw/ole/automtn.cpp:643
 msgid "Method or property not found."
 msgstr "Non se atopou o método ou propiedade."
 
-#: ../src/univ/themes/win32.cpp:3752
+#: ../src/univ/themes/win32.cpp:3749
 msgid "Mi&nimize"
 msgstr "Mi&nimizar"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1763
+#: ../src/propgrid/advprops.cpp:1664
 msgid "Middle Button"
 msgstr ""
 
@@ -5009,36 +5137,41 @@ msgstr "Altura mín.:"
 msgid "Min width:"
 msgstr "Ancho mínimo:"
 
-#: ../src/msw/ole/automtn.cpp:668
+#: ../src/osx/cocoa/menu.mm:281
+#, fuzzy
+msgid "Minimize"
+msgstr "Mi&nimizar"
+
+#: ../src/msw/ole/automtn.cpp:659
 msgid "Missing a required parameter."
 msgstr "Falta un parámetro requerido."
 
-#: ../src/generic/fontdlgg.cpp:324
+#: ../src/generic/fontdlgg.cpp:320
 msgid "Modern"
 msgstr "Moderno"
 
-#: ../src/generic/filectrlg.cpp:427
+#: ../src/generic/filectrlg.cpp:423
 msgid "Modified"
 msgstr "Modificado"
 
-#: ../src/common/module.cpp:133
+#: ../src/common/module.cpp:130
 #, c-format
 msgid "Module \"%s\" initialization failed"
 msgstr "Fallou a inicialización do módulo \"%s\""
 
-#: ../src/common/paper.cpp:131
+#: ../src/common/paper.cpp:128
 msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
 msgstr "Sobre Monarca, 3 7/8 x 7 1/2 polgadas"
 
-#: ../src/msw/fswatcher.cpp:143
+#: ../src/msw/fswatcher.cpp:140
 msgid "Monitoring individual files for changes is not supported currently."
 msgstr "Non é posíbel neste momento monitorizar ficheiros na busca de cambios."
 
-#: ../src/generic/editlbox.cpp:172
+#: ../src/generic/editlbox.cpp:160
 msgid "Move down"
 msgstr "Mover abaixo"
 
-#: ../src/generic/editlbox.cpp:171
+#: ../src/generic/editlbox.cpp:155
 msgid "Move up"
 msgstr "Mover arriba"
 
@@ -5052,97 +5185,102 @@ msgstr "Move o obxecto ao seguinte parágrafo."
 msgid "Moves the object to the previous paragraph."
 msgstr "Move o obxecto ao parágrafo anterior."
 
-#: ../src/richtext/richtextbuffer.cpp:9966
+#: ../src/richtext/richtextbuffer.cpp:9963
 msgid "Multiple Cell Properties"
 msgstr "Propiedades múltiples de cela"
 
-#: ../src/generic/filectrlg.cpp:424
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:82
+msgid "Multiply"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:420
 msgid "Name"
 msgstr "Nome"
 
-#: ../src/propgrid/advprops.cpp:1596
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Navy"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "Network"
 msgstr "Rede"
 
-#: ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173
 msgid "New"
 msgstr "Novo"
 
-#: ../src/richtext/richtextstyledlg.cpp:243
+#: ../src/richtext/richtextstyledlg.cpp:239
 msgid "New &Box Style..."
 msgstr "Novo estilo de &caixa..."
 
-#: ../src/richtext/richtextstyledlg.cpp:225
+#: ../src/richtext/richtextstyledlg.cpp:221
 msgid "New &Character Style..."
 msgstr "Novo estilo de &caracter..."
 
-#: ../src/richtext/richtextstyledlg.cpp:237
+#: ../src/richtext/richtextstyledlg.cpp:233
 msgid "New &List Style..."
 msgstr "Novo estilo de &lista..."
 
-#: ../src/richtext/richtextstyledlg.cpp:231
+#: ../src/richtext/richtextstyledlg.cpp:227
 msgid "New &Paragraph Style..."
 msgstr "Novo estilo de &parágrafo..."
 
-#: ../src/richtext/richtextstyledlg.cpp:606
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:654
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:820
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:893
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:934
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:602
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:650
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:816
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:889
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:930
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "New Style"
 msgstr "Novo estilo"
 
-#: ../src/generic/editlbox.cpp:169
+#: ../src/generic/editlbox.cpp:139
 msgid "New item"
 msgstr "Novo elemento"
 
-#: ../src/generic/dirdlgg.cpp:297 ../src/generic/dirdlgg.cpp:307
-#: ../src/generic/filectrlg.cpp:618 ../src/generic/filectrlg.cpp:627
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+#: ../src/generic/dirdlgg.cpp:294 ../src/generic/dirdlgg.cpp:304
 msgid "NewName"
 msgstr "NovoNome"
 
-#: ../src/common/prntbase.cpp:1567 ../src/html/helpwnd.cpp:665
+#: ../src/common/prntbase.cpp:1592 ../src/html/helpwnd.cpp:663
 msgid "Next page"
 msgstr "Seguinte páxina"
 
-#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:177
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:174
 #: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Non"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1764
+#: ../src/propgrid/advprops.cpp:1665
 msgid "No Entry"
 msgstr ""
 
-#: ../src/generic/animateg.cpp:150
+#: ../src/generic/animateg.cpp:133
 #, c-format
 msgid "No animation handler for type %ld defined."
 msgstr "Non hai manexador de animación para o tipo %ld definido."
 
-#: ../src/dfb/bitmap.cpp:642 ../src/dfb/bitmap.cpp:676
+#: ../src/dfb/bitmap.cpp:639 ../src/dfb/bitmap.cpp:673
 #, c-format
 msgid "No bitmap handler for type %d defined."
 msgstr "Non hai manexador de mapa de bits para o tipo %d definido."
 
-#: ../src/common/utilscmn.cpp:1077
+#: ../src/common/utilscmn.cpp:1095
 msgid "No default application configured for HTML files."
 msgstr "Non hai aplicación predeterminada para ficheiros HTML."
 
-#: ../src/generic/helpext.cpp:445
+#: ../src/generic/helpext.cpp:443
 msgid "No entries found."
 msgstr "Non se atoparon entradas."
 
-#: ../src/common/fontmap.cpp:421
+#: ../src/common/fontmap.cpp:418
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found,\n"
@@ -5154,7 +5292,7 @@ msgstr ""
 "pero a codificación alternativa '%s' está dispoñíbel.\n"
 "Quere utilizar esta configuración? (Se non é así deberá elixir outra)"
 
-#: ../src/common/fontmap.cpp:426
+#: ../src/common/fontmap.cpp:423
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found.\n"
@@ -5165,206 +5303,206 @@ msgstr ""
 "Quere seleccionar un tipo de letra para usar con esta codificación?\n"
 "(Doutro modo o texto non se verá correctamente)"
 
-#: ../src/generic/animateg.cpp:142
+#: ../src/generic/animateg.cpp:125
 msgid "No handler found for animation type."
 msgstr "Non se atopou un manexador para o tipo de animación."
 
-#: ../src/common/image.cpp:2728
+#: ../src/common/image.cpp:2823
 msgid "No handler found for image type."
 msgstr "Non se atopou un manexador para o tipo de imaxe."
 
-#: ../src/common/image.cpp:2736 ../src/common/image.cpp:2848
-#: ../src/common/image.cpp:2901
+#: ../src/common/image.cpp:2831 ../src/common/image.cpp:2954
+#: ../src/common/image.cpp:3020
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "Non se definiu ningún manexador para o tipo %d."
 
-#: ../src/common/image.cpp:2871 ../src/common/image.cpp:2915
+#: ../src/common/image.cpp:2986 ../src/common/image.cpp:3034
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "Non se definiu ningún manexador para o tipo %s."
 
-#: ../src/html/helpwnd.cpp:858
+#: ../src/html/helpwnd.cpp:856
 msgid "No matching page found yet"
 msgstr "Aínda non se atopou ningunha páxina que concorde"
 
-#: ../src/unix/sound.cpp:81
+#: ../src/unix/sound.cpp:78
 msgid "No sound"
 msgstr "Sen son"
 
-#: ../src/common/image.cpp:2277 ../src/common/image.cpp:2318
+#: ../src/common/image.cpp:2371 ../src/common/image.cpp:2412
 msgid "No unused colour in image being masked."
 msgstr "Non se enmascarou ningunha cor non utilizada na imaxe."
 
-#: ../src/common/image.cpp:3374
-msgid "No unused colour in image."
-msgstr "Non hai cores sen usar na imaxe."
-
-#: ../src/generic/helpext.cpp:302
+#: ../src/generic/helpext.cpp:300
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "Non se atoparon asociacións no ficheiro \"%s\"."
 
-#: ../src/richtext/richtextborderspage.cpp:610
 #: ../src/richtext/richtextsizepage.cpp:248
 #: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:610
 msgid "None"
 msgstr "Ningún"
 
-#: ../src/common/fmapbase.cpp:157
+#: ../src/common/fmapbase.cpp:154
 msgid "Nordic (ISO-8859-10)"
 msgstr "Nórdico (ISO-8859-10)"
 
-#: ../src/generic/fontdlgg.cpp:328 ../src/generic/fontdlgg.cpp:331
+#: ../src/generic/fontdlgg.cpp:324 ../src/generic/fontdlgg.cpp:327
 msgid "Normal"
 msgstr "Normal"
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1261
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Normal<br>e <u>subliñado</u>. "
 
-#: ../src/html/helpwnd.cpp:1205
+#: ../src/html/helpwnd.cpp:1203
 msgid "Normal font:"
 msgstr "Letra normal:"
 
-#: ../src/propgrid/props.cpp:1128
+#: ../src/propgrid/props.cpp:1115
 #, c-format
 msgid "Not %s"
 msgstr "Non %s"
 
-#: ../include/wx/filename.h:573 ../include/wx/filename.h:578
-msgid "Not available"
-msgstr "Non está dispoñíbel"
+#: ../src/common/secretstore.cpp:168
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/webrequest.cpp:605
+msgid "Not enough free disk space for download."
+msgstr ""
 
 #: ../src/richtext/richtextfontpage.cpp:358
 msgid "Not underlined"
 msgstr "Non subliñado"
 
-#: ../src/common/paper.cpp:115
+#: ../src/common/paper.cpp:112
 msgid "Note, 8 1/2 x 11 in"
 msgstr "Nota, 8 1/2 x 11 polgadas"
 
-#: ../src/generic/notifmsgg.cpp:132
+#: ../src/generic/notifmsgg.cpp:129
 msgid "Notice"
 msgstr "Aviso"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "Num *"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "Num +"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "Num ,"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "Num -"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "Num ."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "Num /"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "Num ="
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "Num Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 #, fuzzy
 msgid "Num Delete"
 msgstr "Eliminar"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 #, fuzzy
 msgid "Num Down"
 msgstr "Abaixo"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "Num End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "Num Enter"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 #, fuzzy
 msgid "Num Home"
 msgstr "Inicio"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 #, fuzzy
 msgid "Num Insert"
 msgstr "Inserir"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num Lock"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "Num Page Down"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "Num Page Up"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 #, fuzzy
 msgid "Num Right"
 msgstr "Clara"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "Num Space"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "Num Tab"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "Num Up"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "Num left"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num_lock"
 msgstr ""
 
@@ -5373,13 +5511,13 @@ msgstr ""
 msgid "Numbered outline"
 msgstr "Esquema numerado"
 
-#: ../include/wx/msgdlg.h:278 ../src/richtext/richtextstyledlg.cpp:297
-#: ../src/common/stockitem.cpp:178 ../src/msw/msgdlg.cpp:454
-#: ../src/msw/msgdlg.cpp:747 ../src/gtk1/fontdlg.cpp:138
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:175
+#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/msgdlg.cpp:741 ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "Aceptar"
 
-#: ../src/msw/ole/automtn.cpp:692
+#: ../src/msw/ole/automtn.cpp:683
 #, c-format
 msgid "OLE Automation error in %s: %s"
 msgstr "Erro de automatización de OLE en %s: %s"
@@ -5388,15 +5526,15 @@ msgstr "Erro de automatización de OLE en %s: %s"
 msgid "Object Properties"
 msgstr "Propiedades do obxecto"
 
-#: ../src/msw/ole/automtn.cpp:660
+#: ../src/msw/ole/automtn.cpp:651
 msgid "Object implementation does not support named arguments."
 msgstr "A implementación do obxecto non admite os argumentos citados."
 
-#: ../src/common/xtixml.cpp:264
+#: ../src/common/xtixml.cpp:260
 msgid "Objects must have an id attribute"
 msgstr "Os obxectos deben ter un atributo id"
 
-#: ../src/propgrid/advprops.cpp:1601
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Olive"
 msgstr ""
 
@@ -5404,64 +5542,69 @@ msgstr ""
 msgid "Opaci&ty:"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:354
+#: ../src/generic/colrdlgg.cpp:374
 msgid "Opacity:"
 msgstr ""
 
-#: ../src/common/docview.cpp:1773 ../src/common/docview.cpp:1815
+#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
 msgid "Open File"
 msgstr "Abrir ficheiro"
 
-#: ../src/html/helpwnd.cpp:671 ../src/html/helpwnd.cpp:1554
+#: ../src/html/helpwnd.cpp:669 ../src/html/helpwnd.cpp:1552
 msgid "Open HTML document"
 msgstr "Abrir documento HTML"
 
-#: ../src/generic/dbgrptg.cpp:163
+#: ../src/common/stockitem.cpp:265
+#, fuzzy
+msgid "Open an existing document"
+msgstr "Abrir documento HTML"
+
+#: ../src/generic/dbgrptg.cpp:160
 #, c-format
 msgid "Open file \"%s\""
 msgstr "Abrir o ficheiro \"%s\""
 
-#: ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176
 msgid "Open..."
 msgstr "Abrir..."
 
-#: ../src/unix/glx11.cpp:506 ../src/msw/glcanvas.cpp:592
+#: ../src/msw/glcanvas.cpp:607 ../src/unix/glx11.cpp:513
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr ""
 
-#: ../src/generic/dirctrlg.cpp:599 ../src/generic/dirdlgg.cpp:323
-#: ../src/generic/filectrlg.cpp:642 ../src/generic/filectrlg.cpp:786
+#: ../src/generic/dirctrlg.cpp:565 ../src/generic/filectrlg.cpp:638
+#: ../src/generic/filectrlg.cpp:782 ../src/generic/dirdlgg.cpp:320
 msgid "Operation not permitted."
 msgstr "Operación non permitida."
 
-#: ../src/common/cmdline.cpp:900
+#: ../src/common/cmdline.cpp:896
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "A opción '%s' non se pode contrarrestar"
 
-#: ../src/common/cmdline.cpp:1064
+#: ../src/common/cmdline.cpp:1060
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "A opción '%s' require un valor."
 
-#: ../src/common/cmdline.cpp:1147
+#: ../src/common/cmdline.cpp:1143
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Opción '%s': '%s' non se pode converter en data."
 
-#: ../src/generic/prntdlgg.cpp:618
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Opcións"
 
-#: ../src/propgrid/advprops.cpp:1606
+#: ../src/propgrid/advprops.cpp:1512
 msgid "Orange"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:615 ../src/generic/prntdlgg.cpp:869
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:862
 msgid "Orientation"
 msgstr "Orientación"
 
-#: ../src/common/windowid.cpp:242
+#: ../src/common/windowid.cpp:237
 msgid "Out of window IDs.  Recommend shutting down application."
 msgstr "Non hai IDs de xanela. Recoméndase pechar o aplicativo."
 
@@ -5474,148 +5617,148 @@ msgstr "Esquema"
 msgid "Outset"
 msgstr "Externo"
 
-#: ../src/msw/ole/automtn.cpp:656
+#: ../src/msw/ole/automtn.cpp:647
 msgid "Overflow while coercing argument values."
 msgstr "Desbordamento ao forzar valores de argumentos."
 
-#: ../src/common/imagpcx.cpp:457 ../src/common/imagpcx.cpp:480
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:479
 msgid "PCX: couldn't allocate memory"
 msgstr "PCX: non se puido asignar memoria"
 
-#: ../src/common/imagpcx.cpp:456
+#: ../src/common/imagpcx.cpp:455
 msgid "PCX: image format unsupported"
 msgstr "PCX: formato de imaxe non compatíbel"
 
-#: ../src/common/imagpcx.cpp:479
+#: ../src/common/imagpcx.cpp:478
 msgid "PCX: invalid image"
 msgstr "PCX: imaxe incorrecta"
 
-#: ../src/common/imagpcx.cpp:442
+#: ../src/common/imagpcx.cpp:441
 msgid "PCX: this is not a PCX file."
 msgstr "PCX: isto non é un ficheiro PCX."
 
-#: ../src/common/imagpcx.cpp:459 ../src/common/imagpcx.cpp:481
+#: ../src/common/imagpcx.cpp:458 ../src/common/imagpcx.cpp:480
 msgid "PCX: unknown error !!!"
 msgstr "PCX: erro descoñecido !!!"
 
-#: ../src/common/imagpcx.cpp:458
+#: ../src/common/imagpcx.cpp:457
 msgid "PCX: version number too low"
 msgstr "PCX: número de versión demasiado baixo"
 
-#: ../src/common/imagpnm.cpp:91
+#: ../src/common/imagpnm.cpp:89
 msgid "PNM: Couldn't allocate memory."
 msgstr "PNM: Non se puido asignar memoria."
 
-#: ../src/common/imagpnm.cpp:73
+#: ../src/common/imagpnm.cpp:71
 msgid "PNM: File format is not recognized."
 msgstr "PNM: Non se recoñeceu o formato do ficheiro."
 
-#: ../src/common/imagpnm.cpp:112 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
 #: ../src/common/imagpnm.cpp:156
 msgid "PNM: File seems truncated."
 msgstr "PNM: O ficheiro semella truncado."
 
-#: ../src/common/paper.cpp:187
+#: ../src/common/paper.cpp:184
 msgid "PRC 16K 146 x 215 mm"
 msgstr "PRC 16K 146 x 215 mm"
 
-#: ../src/common/paper.cpp:200
+#: ../src/common/paper.cpp:197
 msgid "PRC 16K Rotated"
 msgstr "PRC 16K apaisado"
 
-#: ../src/common/paper.cpp:188
+#: ../src/common/paper.cpp:185
 msgid "PRC 32K 97 x 151 mm"
 msgstr "PRC 32K 97 x 151 mm"
 
-#: ../src/common/paper.cpp:201
+#: ../src/common/paper.cpp:198
 msgid "PRC 32K Rotated"
 msgstr "PRC 32K apaisado"
 
-#: ../src/common/paper.cpp:189
+#: ../src/common/paper.cpp:186
 msgid "PRC 32K(Big) 97 x 151 mm"
 msgstr "PRC 32K(Grande) 97 x 151 mm"
 
-#: ../src/common/paper.cpp:202
+#: ../src/common/paper.cpp:199
 msgid "PRC 32K(Big) Rotated"
 msgstr "PRC 32K(Grande) apaisado"
 
-#: ../src/common/paper.cpp:190
+#: ../src/common/paper.cpp:187
 msgid "PRC Envelope #1 102 x 165 mm"
 msgstr "Sobre PRC #1 102 x 165 mm"
 
-#: ../src/common/paper.cpp:203
+#: ../src/common/paper.cpp:200
 msgid "PRC Envelope #1 Rotated 165 x 102 mm"
 msgstr "Sobre PRC #1 apaisado 165 x 102 mm"
 
-#: ../src/common/paper.cpp:199
+#: ../src/common/paper.cpp:196
 msgid "PRC Envelope #10 324 x 458 mm"
 msgstr "Sobre PRC #10 324 x 458 mm"
 
-#: ../src/common/paper.cpp:212
+#: ../src/common/paper.cpp:209
 msgid "PRC Envelope #10 Rotated 458 x 324 mm"
 msgstr "Sobre PRC #10 apaisado 458 x 324 mm"
 
-#: ../src/common/paper.cpp:191
+#: ../src/common/paper.cpp:188
 msgid "PRC Envelope #2 102 x 176 mm"
 msgstr "Sobre PRC #2 102 x 176 mm"
 
-#: ../src/common/paper.cpp:204
+#: ../src/common/paper.cpp:201
 msgid "PRC Envelope #2 Rotated 176 x 102 mm"
 msgstr "Sobre PRC #2 apaisado 176 x 102 mm"
 
-#: ../src/common/paper.cpp:192
+#: ../src/common/paper.cpp:189
 msgid "PRC Envelope #3 125 x 176 mm"
 msgstr "Sobre PRC #3 125 x 176 mm"
 
-#: ../src/common/paper.cpp:205
+#: ../src/common/paper.cpp:202
 msgid "PRC Envelope #3 Rotated 176 x 125 mm"
 msgstr "Sobre PRC #3 apaisado 176 x 125 mm"
 
-#: ../src/common/paper.cpp:193
+#: ../src/common/paper.cpp:190
 msgid "PRC Envelope #4 110 x 208 mm"
 msgstr "Sobre PRC #4 110 x 208 mm"
 
-#: ../src/common/paper.cpp:206
+#: ../src/common/paper.cpp:203
 msgid "PRC Envelope #4 Rotated 208 x 110 mm"
 msgstr "Sobre PRC #4 apaisado 208 x 110 mm"
 
-#: ../src/common/paper.cpp:194
+#: ../src/common/paper.cpp:191
 msgid "PRC Envelope #5 110 x 220 mm"
 msgstr "Sobre PRC #5 110 x 220 mm"
 
-#: ../src/common/paper.cpp:207
+#: ../src/common/paper.cpp:204
 msgid "PRC Envelope #5 Rotated 220 x 110 mm"
 msgstr "Sobre PRC #5 apaisado 220 x 110 mm"
 
-#: ../src/common/paper.cpp:195
+#: ../src/common/paper.cpp:192
 msgid "PRC Envelope #6 120 x 230 mm"
 msgstr "Sobre PRC #6 120 x 230 mm"
 
-#: ../src/common/paper.cpp:208
+#: ../src/common/paper.cpp:205
 msgid "PRC Envelope #6 Rotated 230 x 120 mm"
 msgstr "Sobre PRC #6 apaisado 230 x 120 mm"
 
-#: ../src/common/paper.cpp:196
+#: ../src/common/paper.cpp:193
 msgid "PRC Envelope #7 160 x 230 mm"
 msgstr "Sobre PRC #7 160 x 230 mm"
 
-#: ../src/common/paper.cpp:209
+#: ../src/common/paper.cpp:206
 msgid "PRC Envelope #7 Rotated 230 x 160 mm"
 msgstr "Sobre PRC #7 apaisado 230 x 160 mm"
 
-#: ../src/common/paper.cpp:197
+#: ../src/common/paper.cpp:194
 msgid "PRC Envelope #8 120 x 309 mm"
 msgstr "Sobre PRC #8 120 x 309 mm"
 
-#: ../src/common/paper.cpp:210
+#: ../src/common/paper.cpp:207
 msgid "PRC Envelope #8 Rotated 309 x 120 mm"
 msgstr "Sobre PRC #8 apaisado 309 x 120 mm"
 
-#: ../src/common/paper.cpp:198
+#: ../src/common/paper.cpp:195
 msgid "PRC Envelope #9 229 x 324 mm"
 msgstr "Sobre PRC #9 229 x 324 mm"
 
-#: ../src/common/paper.cpp:211
+#: ../src/common/paper.cpp:208
 msgid "PRC Envelope #9 Rotated 324 x 229 mm"
 msgstr "Cobertura PRC #9 Rotada 324 x 229 mm"
 
@@ -5623,91 +5766,95 @@ msgstr "Cobertura PRC #9 Rotada 324 x 229 mm"
 msgid "Padding"
 msgstr "Recheo"
 
-#: ../src/common/prntbase.cpp:2074
+#: ../src/common/prntbase.cpp:2096
 #, c-format
 msgid "Page %d"
 msgstr "Páxina %d"
 
-#: ../src/common/prntbase.cpp:2072
+#: ../src/common/prntbase.cpp:2094
 #, c-format
 msgid "Page %d of %d"
 msgstr "Páxina %d de %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 #, fuzzy
 msgid "Page Down"
 msgstr "Páxina %d"
 
-#: ../src/gtk/print.cpp:826
+#: ../src/gtk/print.cpp:829
 msgid "Page Setup"
 msgstr "Configuración de páxina"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 #, fuzzy
 msgid "Page Up"
 msgstr "Páxina %d"
 
-#: ../src/generic/prntdlgg.cpp:828 ../src/common/prntbase.cpp:484
+#: ../src/common/prntbase.cpp:479 ../src/generic/prntdlgg.cpp:821
 msgid "Page setup"
 msgstr "Configuración de páxina"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 #, fuzzy
 msgid "PageDown"
 msgstr "Abaixo"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 #, fuzzy
 msgid "PageUp"
 msgstr "Páxinas"
 
-#: ../src/generic/prntdlgg.cpp:216
+#: ../src/generic/prntdlgg.cpp:209
 msgid "Pages"
 msgstr "Páxinas"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1765
+#: ../src/propgrid/advprops.cpp:1666
 msgid "Paint Brush"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:602 ../src/generic/prntdlgg.cpp:801
-#: ../src/generic/prntdlgg.cpp:842 ../src/generic/prntdlgg.cpp:855
-#: ../src/generic/prntdlgg.cpp:1052 ../src/generic/prntdlgg.cpp:1057
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:794
+#: ../src/generic/prntdlgg.cpp:835 ../src/generic/prntdlgg.cpp:848
+#: ../src/generic/prntdlgg.cpp:1045 ../src/generic/prntdlgg.cpp:1050
 msgid "Paper size"
 msgstr "Tamaño do papel"
 
-#: ../src/richtext/richtextstyles.cpp:1062
+#: ../src/richtext/richtextstyles.cpp:1059
 msgid "Paragraph styles"
 msgstr "Estilos de parágrafo"
 
-#: ../src/common/xtistrm.cpp:465
+#: ../src/common/xtistrm.cpp:462
 msgid "Passing a already registered object to SetObject"
 msgstr "Paso dun obxecto xa rexistrado a SetObject"
 
-#: ../src/common/xtistrm.cpp:476
+#: ../src/common/xtistrm.cpp:473
 msgid "Passing an unknown object to GetObject"
 msgstr "Paso dun obxecto descoñecido a GetObject"
 
-#: ../src/richtext/richtextctrl.cpp:3513 ../src/common/stockitem.cpp:180
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:177 ../src/richtext/richtextctrl.cpp:3514
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Pegar"
 
-#: ../src/common/stockitem.cpp:262
+#: ../src/common/stockitem.cpp:260
 msgid "Paste selection"
 msgstr "Pegar selección"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:74
+#: ../src/common/accelcmn.cpp:71
 msgid "Pause"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1766
+#: ../src/propgrid/advprops.cpp:1667
 msgid "Pencil"
 msgstr ""
 
@@ -5716,21 +5863,21 @@ msgstr ""
 msgid "Peri&od"
 msgstr "Perí&odo"
 
-#: ../src/generic/filectrlg.cpp:430
+#: ../src/generic/filectrlg.cpp:426
 msgid "Permissions"
 msgstr "Permisos"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:60
+#: ../src/common/accelcmn.cpp:57
 msgid "PgDn"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:59
+#: ../src/common/accelcmn.cpp:56
 msgid "PgUp"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:12868
+#: ../src/richtext/richtextbuffer.cpp:12863
 msgid "Picture Properties"
 msgstr "Propiedades do debuxo"
 
@@ -5742,44 +5889,44 @@ msgstr "Erro ao crear a canalización"
 msgid "Please choose a valid font."
 msgstr "Escolla un tipo de letra correcto."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
 msgid "Please choose an existing file."
 msgstr "Escolla un ficheiro existente."
 
-#: ../src/html/helpwnd.cpp:800
+#: ../src/html/helpwnd.cpp:798
 msgid "Please choose the page to display:"
 msgstr "Por favor, elixa a páxina que quere amosar:"
 
-#: ../src/msw/dialup.cpp:764
+#: ../src/msw/dialup.cpp:758
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Por favor, elixa o provedor de Internet ao que desexa conectarse"
 
-#: ../src/common/headerctrlcmn.cpp:59
+#: ../src/common/headerctrlcmn.cpp:57
 msgid "Please select the columns to show and define their order:"
 msgstr "Por favor, seleccione as columnas para amosar e defina a súa orde:"
 
-#: ../src/common/prntbase.cpp:538
+#: ../src/common/prntbase.cpp:533
 msgid "Please wait while printing..."
 msgstr "Por favor, agarde mentre se imprime..."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1767
+#: ../src/propgrid/advprops.cpp:1668
 #, fuzzy
 msgid "Point Left"
 msgstr "Tamaño do punto"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1768
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgid "Point Right"
 msgstr "Aliñar á Dereita"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:662
+#: ../src/propgrid/advprops.cpp:572
 msgid "Point Size"
 msgstr "Tamaño do punto"
 
-#: ../src/generic/prntdlgg.cpp:612 ../src/generic/prntdlgg.cpp:867
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:860
 msgid "Portrait"
 msgstr "Vertical"
 
@@ -5787,150 +5934,160 @@ msgstr "Vertical"
 msgid "Position"
 msgstr "Posición"
 
-#: ../src/generic/prntdlgg.cpp:298
+#: ../src/generic/prntdlgg.cpp:291
 msgid "PostScript file"
 msgstr "Ficheiro PostScript"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178 ../src/osx/cocoa/preferences.mm:303
 msgid "Preferences"
 msgstr "Preferencias"
 
-#: ../src/osx/menu_osx.cpp:568
+#: ../src/osx/menu_osx.cpp:460
 msgid "Preferences..."
 msgstr "Preferencias..."
 
-#: ../src/common/prntbase.cpp:546
+#: ../src/common/prntbase.cpp:541
 msgid "Preparing"
 msgstr "Preparando"
 
-#: ../src/generic/fontdlgg.cpp:455 ../src/osx/carbon/fontdlg.cpp:390
-#: ../src/html/helpwnd.cpp:1222
+#: ../src/osx/carbon/fontdlg.cpp:387 ../src/generic/fontdlgg.cpp:452
+#: ../src/html/helpwnd.cpp:1220
 msgid "Preview:"
 msgstr "Previsualización:"
 
-#: ../src/common/prntbase.cpp:1553 ../src/html/helpwnd.cpp:664
+#: ../src/common/prntbase.cpp:1578 ../src/html/helpwnd.cpp:662
 msgid "Previous page"
 msgstr "Páxina anterior"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/prntdlgg.cpp:143 ../src/generic/prntdlgg.cpp:157
-#: ../src/common/prntbase.cpp:426 ../src/common/prntbase.cpp:1541
-#: ../src/common/accelcmn.cpp:77 ../src/gtk/print.cpp:620
-#: ../src/gtk/print.cpp:638
+#: ../src/common/prntbase.cpp:421 ../src/common/prntbase.cpp:1566
+#: ../src/common/accelcmn.cpp:74 ../src/generic/prntdlgg.cpp:136
+#: ../src/generic/prntdlgg.cpp:150 ../src/gtk/print.cpp:616
+#: ../src/gtk/print.cpp:634
 msgid "Print"
 msgstr "Imprimir"
 
-#: ../include/wx/prntbase.h:399 ../src/common/docview.cpp:1268
+#: ../src/common/docview.cpp:1262
 msgid "Print Preview"
 msgstr "Previsualización de impresión"
 
-#: ../src/common/prntbase.cpp:2015 ../src/common/prntbase.cpp:2057
-#: ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2037 ../src/common/prntbase.cpp:2079
+#: ../src/common/prntbase.cpp:2087
 msgid "Print Preview Failure"
 msgstr "Fallo na previsualización de impresión"
 
-#: ../src/generic/prntdlgg.cpp:224
+#: ../src/generic/prntdlgg.cpp:217
 msgid "Print Range"
 msgstr "Rango de impresión"
 
-#: ../src/generic/prntdlgg.cpp:449
+#: ../src/generic/prntdlgg.cpp:442
 msgid "Print Setup"
 msgstr "Configuración da impresión"
 
-#: ../src/generic/prntdlgg.cpp:621
+#: ../src/generic/prntdlgg.cpp:614
 msgid "Print in colour"
 msgstr "Imprimir a cor"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/osx/webview_webkit.mm:260
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "Non se puido inicializar a descrición da columna."
+
+#: ../src/common/stockitem.cpp:179
 msgid "Print previe&w..."
 msgstr "Pre&visualización de impresión..."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1256
 msgid "Print preview creation failed."
 msgstr "Fallo na previsualización de impresión."
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/common/stockitem.cpp:179
 msgid "Print preview..."
 msgstr "Previsualización de impresión..."
 
-#: ../src/generic/prntdlgg.cpp:630
+#: ../src/generic/prntdlgg.cpp:623
 msgid "Print spooling"
 msgstr "Cola de impresión"
 
-#: ../src/html/helpwnd.cpp:675
+#: ../src/html/helpwnd.cpp:673
 msgid "Print this page"
 msgstr "Imprimir esta páxina"
 
-#: ../src/generic/prntdlgg.cpp:185
+#: ../src/generic/prntdlgg.cpp:178
 msgid "Print to File"
 msgstr "Imprimir a un ficheiro"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "Print..."
 msgstr "Imprimir..."
 
-#: ../src/generic/prntdlgg.cpp:493
+#: ../src/generic/prntdlgg.cpp:486
 msgid "Printer"
 msgstr "Impresora"
 
-#: ../src/generic/prntdlgg.cpp:633
+#: ../src/generic/prntdlgg.cpp:626
 msgid "Printer command:"
 msgstr "Comando de impresión:"
 
-#: ../src/generic/prntdlgg.cpp:180
+#: ../src/generic/prntdlgg.cpp:173
 msgid "Printer options"
 msgstr "Opcións da impresora"
 
-#: ../src/generic/prntdlgg.cpp:645
+#: ../src/generic/prntdlgg.cpp:638
 msgid "Printer options:"
 msgstr "Opcións da impresora:"
 
-#: ../src/generic/prntdlgg.cpp:916
+#: ../src/generic/prntdlgg.cpp:909
 msgid "Printer..."
 msgstr "Impresora..."
 
-#: ../src/generic/prntdlgg.cpp:196
+#: ../src/generic/prntdlgg.cpp:189
 msgid "Printer:"
 msgstr "Impresora:"
 
-#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:535
-#: ../src/html/htmprint.cpp:277
+#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:530
+#: ../src/html/htmprint.cpp:289
 msgid "Printing"
 msgstr "Imprimindo"
 
-#: ../src/common/prntbase.cpp:612
+#: ../src/common/prntbase.cpp:607
 msgid "Printing "
 msgstr "Imprimindo "
 
-#: ../src/common/prntbase.cpp:347
+#: ../src/common/prntbase.cpp:342
 msgid "Printing Error"
 msgstr "Erro de impresión"
 
-#: ../src/common/prntbase.cpp:565
+#: ../src/osx/webview_webkit.mm:251
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "Gzip non é compatíbel con esta versión de zlib"
+
+#: ../src/common/prntbase.cpp:560
 #, fuzzy, c-format
 msgid "Printing page %d"
 msgstr "Imprimindo a páxina %d..."
 
-#: ../src/common/prntbase.cpp:570
+#: ../src/common/prntbase.cpp:565
 #, c-format
 msgid "Printing page %d of %d"
 msgstr "Imprimindo páxina %d de %d"
 
-#: ../src/generic/printps.cpp:201
+#: ../src/generic/printps.cpp:182
 #, c-format
 msgid "Printing page %d..."
 msgstr "Imprimindo a páxina %d..."
 
-#: ../src/generic/printps.cpp:161
+#: ../src/generic/printps.cpp:142
 msgid "Printing..."
 msgstr "Imprimindo..."
 
-#: ../include/wx/richtext/richtextprint.h:109 ../include/wx/prntbase.h:267
-#: ../src/common/docview.cpp:2132
+#: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
+#: ../src/common/docview.cpp:2137
 msgid "Printout"
 msgstr "Saída de impresión"
 
-#: ../src/common/debugrpt.cpp:560
+#: ../src/common/debugrpt.cpp:561
 #, c-format
 msgid ""
 "Processing debug report has failed, leaving the files in \"%s\" directory."
@@ -5938,104 +6095,104 @@ msgstr ""
 "Houbo un fallo de proceso do informe de deputación, os ficheiros fican no "
 "cartafol\"%s\"."
 
-#: ../src/common/prntbase.cpp:545
+#: ../src/common/prntbase.cpp:540
 msgid "Progress:"
 msgstr "Progreso:"
 
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181
 msgid "Properties"
 msgstr "Propiedades"
 
-#: ../src/propgrid/manager.cpp:237
+#: ../src/propgrid/manager.cpp:223
 msgid "Property"
 msgstr "Propiedade"
 
 #. TRANSLATORS: Caption of message box displaying any property error
-#: ../src/propgrid/propgrid.cpp:3185 ../src/propgrid/propgrid.cpp:3318
+#: ../src/propgrid/propgrid.cpp:3162 ../src/propgrid/propgrid.cpp:3299
 msgid "Property Error"
 msgstr "Erro de propiedade"
 
-#: ../src/propgrid/advprops.cpp:1597
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Purple"
 msgstr ""
 
-#: ../src/common/paper.cpp:112
+#: ../src/common/paper.cpp:109
 msgid "Quarto, 215 x 275 mm"
 msgstr "Quarto, 215 x 275 mm"
 
-#: ../src/generic/logg.cpp:1016
+#: ../src/generic/logg.cpp:1013
 msgid "Question"
 msgstr "Pregunta"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1769
+#: ../src/propgrid/advprops.cpp:1670
 #, fuzzy
 msgid "Question Arrow"
 msgstr "Pregunta"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "Quit"
 msgstr "Saír"
 
-#: ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:477
 #, c-format
 msgid "Quit %s"
 msgstr "Saír de %s"
 
-#: ../src/common/stockitem.cpp:263
+#: ../src/common/stockitem.cpp:261
 msgid "Quit this program"
 msgstr "Saír deste aplicativo"
 
-#: ../src/common/accelcmn.cpp:338
+#: ../src/common/accelcmn.cpp:352
 msgid "RawCtrl+"
 msgstr "Ctrl+"
 
-#: ../src/common/ffile.cpp:109 ../src/common/ffile.cpp:133
+#: ../src/common/ffile.cpp:107 ../src/common/ffile.cpp:132
 #, c-format
 msgid "Read error on file '%s'"
 msgstr "Erro de lectura no ficheiro '%s'"
 
-#: ../src/common/secretstore.cpp:199
+#: ../src/common/secretstore.cpp:211
 #, fuzzy, c-format
-msgid "Reading password for \"%s/%s\" failed: %s."
+msgid "Reading password for \"%s\" failed: %s."
 msgstr "Fallou a extración de '%s' a '%s'."
 
-#: ../src/common/prntbase.cpp:272
+#: ../src/common/prntbase.cpp:267
 msgid "Ready"
 msgstr "Preparado"
 
-#: ../src/propgrid/advprops.cpp:1605
+#: ../src/propgrid/advprops.cpp:1511
 #, fuzzy
 msgid "Red"
 msgstr "Refacer"
 
-#: ../src/generic/colrdlgg.cpp:339
+#: ../src/generic/colrdlgg.cpp:359
 msgid "Red:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:185 ../src/stc/stc_i18n.cpp:16
+#: ../src/common/stockitem.cpp:182 ../src/stc/stc_i18n.cpp:16
 msgid "Redo"
 msgstr "Refacer"
 
-#: ../src/common/stockitem.cpp:264
+#: ../src/common/stockitem.cpp:262
 msgid "Redo last action"
 msgstr "Desfacer a acción anterior"
 
-#: ../src/common/stockitem.cpp:186
+#: ../src/common/stockitem.cpp:183
 msgid "Refresh"
 msgstr "Actualizar"
 
-#: ../src/msw/registry.cpp:626
+#: ../src/msw/registry.cpp:615
 #, c-format
 msgid "Registry key '%s' already exists."
 msgstr "A clave do rexistro '%s' xa existe."
 
-#: ../src/msw/registry.cpp:595
+#: ../src/msw/registry.cpp:584
 #, c-format
 msgid "Registry key '%s' does not exist, cannot rename it."
 msgstr "A clave do rexistro '%s' non existe, non se puido renomear."
 
-#: ../src/msw/registry.cpp:727
+#: ../src/msw/registry.cpp:716
 #, c-format
 msgid ""
 "Registry key '%s' is needed for normal system operation,\n"
@@ -6046,22 +6203,22 @@ msgstr ""
 "se se borra pode deixar o sistema inutilizábel:\n"
 "operación cancelada."
 
-#: ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:942
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:917
+#: ../src/msw/registry.cpp:905
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1003
+#: ../src/msw/registry.cpp:991
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:521
+#: ../src/msw/registry.cpp:510
 #, c-format
 msgid "Registry value '%s' already exists."
 msgstr "A clave do rexistro '%s' xa existe."
@@ -6075,72 +6232,78 @@ msgstr "Regular"
 msgid "Relative"
 msgstr "Relativo"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:456
 msgid "Relevant entries:"
 msgstr "Entradas significativas:"
 
-#: ../include/wx/generic/progdlgg.h:86
+#: ../include/wx/generic/progdlgg.h:87
 msgid "Remaining time:"
 msgstr "Tempo restante:"
 
-#: ../src/common/stockitem.cpp:187
+#: ../src/common/stockitem.cpp:184
 msgid "Remove"
 msgstr "Eliminar"
 
-#: ../src/richtext/richtextctrl.cpp:1562
+#: ../src/richtext/richtextctrl.cpp:1563
 msgid "Remove Bullet"
 msgstr "Eliminar viñeta"
 
-#: ../src/html/helpwnd.cpp:433
+#: ../src/html/helpwnd.cpp:431
 msgid "Remove current page from bookmarks"
 msgstr "Eliminar a páxina actual dos marcadores"
 
-#: ../src/common/rendcmn.cpp:194
+#: ../src/common/rendcmn.cpp:191
 #, c-format
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 "O renderizador \"%s\" ten unha versión incompatíbel, %d.%d e non se puido "
 "cargar."
 
-#: ../src/richtext/richtextbuffer.cpp:4527
+#: ../src/richtext/richtextbuffer.cpp:4524
 msgid "Renumber List"
 msgstr "Renumerar lista"
 
-#: ../src/common/stockitem.cpp:188
-msgid "Rep&lace"
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Rep&lace..."
 msgstr "Su&bstituír"
 
-#: ../src/richtext/richtextctrl.cpp:3673 ../src/common/stockitem.cpp:188
+#: ../src/richtext/richtextctrl.cpp:3674
 msgid "Replace"
 msgstr "Substituír"
 
-#: ../src/generic/fdrepdlg.cpp:182
+#: ../src/generic/fdrepdlg.cpp:179
 msgid "Replace &all"
 msgstr "Substituír &todo"
 
-#: ../src/common/stockitem.cpp:261
-msgid "Replace selection"
-msgstr "Substituír selección"
-
-#: ../src/generic/fdrepdlg.cpp:124
+#: ../src/generic/fdrepdlg.cpp:121
 msgid "Replace with:"
 msgstr "Substituír por:"
 
-#: ../src/common/valtext.cpp:163
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Replace..."
+msgstr "Substituír"
+
+#: ../src/common/valtext.cpp:184
 msgid "Required information entry is empty."
 msgstr "A entrada da información requirida está baleira."
 
-#: ../src/common/translation.cpp:1975
+#: ../src/common/translation.cpp:2025
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "O recurso '%s' non é un catálogo de mensaxes correcto."
 
+#: ../src/gtk/webview_webkit.cpp:985
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:56
+#: ../src/common/accelcmn.cpp:53
 msgid "Return"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:189
+#: ../src/common/stockitem.cpp:186
 msgid "Revert to Saved"
 msgstr "Volver á versión gardada"
 
@@ -6152,42 +6315,42 @@ msgstr "Crista"
 msgid "Rig&ht-to-left"
 msgstr ""
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6149
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:59 ../src/generic/datavgen.cpp:6954
+#: ../src/richtext/richtextsizepage.cpp:250
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextbulletspage.cpp:188
-#: ../src/richtext/richtextsizepage.cpp:250 ../src/common/accelcmn.cpp:62
 msgid "Right"
 msgstr "Clara"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1754
+#: ../src/propgrid/advprops.cpp:1655
 #, fuzzy
 msgid "Right Arrow"
 msgstr "Clara"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1770
+#: ../src/propgrid/advprops.cpp:1671
 msgid "Right Button"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:892
+#: ../src/generic/prntdlgg.cpp:885
 msgid "Right margin (mm):"
 msgstr "Marxe dereita (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:148
-#: ../src/richtext/richtextindentspage.cpp:150
 #: ../src/richtext/richtextliststylepage.cpp:337
 #: ../src/richtext/richtextliststylepage.cpp:339
+#: ../src/richtext/richtextindentspage.cpp:148
+#: ../src/richtext/richtextindentspage.cpp:150
 msgid "Right-align text."
 msgstr "Aliñar texto á dereita."
 
-#: ../src/generic/fontdlgg.cpp:322
+#: ../src/generic/fontdlgg.cpp:318
 msgid "Roman"
 msgstr "Redonda"
 
-#: ../src/generic/datavgen.cpp:5916
+#: ../src/generic/datavgen.cpp:6721
 #, c-format
 msgid "Row %i"
 msgstr ""
@@ -6197,30 +6360,31 @@ msgstr ""
 msgid "S&tandard bullet name:"
 msgstr "Nome estándar de viñeta:"
 
-#: ../src/common/accelcmn.cpp:268 ../src/common/accelcmn.cpp:350
+#: ../src/common/accelcmn.cpp:282 ../src/common/accelcmn.cpp:367
 msgid "SPECIAL"
 msgstr "ESPECIAL"
 
-#: ../src/common/stockitem.cpp:190 ../src/common/sizer.cpp:2797
+#: ../src/common/stockitem.cpp:187 ../src/common/sizer.cpp:2914
 msgid "Save"
 msgstr "Gardar"
 
-#: ../src/common/fldlgcmn.cpp:342
+#: ../src/common/fldlgcmn.cpp:339
 #, c-format
 msgid "Save %s file"
 msgstr "Gardar o ficheiro %s"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/common/stockitem.cpp:188 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Gardar &como..."
 
-#: ../src/common/docview.cpp:366
+#: ../src/common/docview.cpp:359
 msgid "Save As"
 msgstr "Gardar como"
 
-#: ../src/common/stockitem.cpp:191
-msgid "Save as"
-msgstr "Gardar como"
+#: ../src/common/stockitem.cpp:188
+#, fuzzy
+msgid "Save As..."
+msgstr "Gardar &como..."
 
 #: ../src/common/stockitem.cpp:267
 msgid "Save current document"
@@ -6230,40 +6394,40 @@ msgstr "Gardar o documento actual"
 msgid "Save current document with a different filename"
 msgstr "Gardar o documento actual cun nome de ficheiro diferente"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/generic/logg.cpp:509
 msgid "Save log contents to file"
 msgstr "Gardar o contido do rexistro nun ficheiro"
 
-#: ../src/common/secretstore.cpp:179
+#: ../src/common/secretstore.cpp:189
 #, fuzzy, c-format
-msgid "Saving password for \"%s/%s\" failed: %s."
+msgid "Saving password for \"%s\" failed: %s."
 msgstr "Fallou a extración de '%s' a '%s'."
 
-#: ../src/generic/fontdlgg.cpp:325
+#: ../src/generic/fontdlgg.cpp:321
 msgid "Script"
 msgstr "Script"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll Lock"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll_lock"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:890
+#: ../src/propgrid/advprops.cpp:791
 msgid "Scrollbar"
 msgstr ""
 
-#: ../src/generic/srchctlg.cpp:56 ../src/html/helpwnd.cpp:535
-#: ../src/html/helpwnd.cpp:550
+#: ../src/generic/srchctlg.cpp:55 ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:548 ../src/gtk/srchctrl.cpp:182
 msgid "Search"
 msgstr "Buscar"
 
-#: ../src/html/helpwnd.cpp:537
+#: ../src/html/helpwnd.cpp:535
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
@@ -6271,32 +6435,32 @@ msgstr ""
 "Busca nos contidos do(s) libro(s) de axuda todas as aparicións do texto que "
 "escribiu enriba"
 
-#: ../src/generic/fdrepdlg.cpp:160
+#: ../src/generic/fdrepdlg.cpp:157
 msgid "Search direction"
 msgstr "Dirección de busca"
 
-#: ../src/generic/fdrepdlg.cpp:112
+#: ../src/generic/fdrepdlg.cpp:109
 msgid "Search for:"
 msgstr "Buscar:"
 
-#: ../src/html/helpwnd.cpp:1052
+#: ../src/html/helpwnd.cpp:1050
 msgid "Search in all books"
 msgstr "Buscar en todos os libros"
 
-#: ../src/html/helpwnd.cpp:857
+#: ../src/html/helpwnd.cpp:855
 msgid "Searching..."
 msgstr "Buscando..."
 
-#: ../src/generic/dirctrlg.cpp:446
+#: ../src/generic/dirctrlg.cpp:412
 msgid "Sections"
 msgstr "Seccións"
 
-#: ../src/common/ffile.cpp:238
+#: ../src/common/ffile.cpp:237
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Erro de busca no ficheiro '%s'"
 
-#: ../src/common/ffile.cpp:228
+#: ../src/common/ffile.cpp:227
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
@@ -6304,25 +6468,25 @@ msgstr ""
 "stdio)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:76
+#: ../src/common/accelcmn.cpp:73
 #, fuzzy
 msgid "Select"
 msgstr "Selección"
 
-#: ../src/richtext/richtextctrl.cpp:337 ../src/osx/textctrl_osx.cpp:581
-#: ../src/common/stockitem.cpp:192 ../src/msw/textctrl.cpp:2512
+#: ../src/osx/textctrl_osx.cpp:599 ../src/common/stockitem.cpp:189
+#: ../src/msw/textctrl.cpp:2777 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Seleccionar &todo"
 
-#: ../src/common/stockitem.cpp:192 ../src/stc/stc_i18n.cpp:21
+#: ../src/common/stockitem.cpp:189 ../src/stc/stc_i18n.cpp:21
 msgid "Select All"
 msgstr "Seleccionar todo"
 
-#: ../src/common/docview.cpp:1895
+#: ../src/common/docview.cpp:1900
 msgid "Select a document template"
 msgstr "Seleccione un patrón de documento"
 
-#: ../src/common/docview.cpp:1969
+#: ../src/common/docview.cpp:1974
 msgid "Select a document view"
 msgstr "Seleccionar unha vista de documento"
 
@@ -6351,20 +6515,20 @@ msgid "Selects the list level to edit."
 msgstr "Selecciona o nivel de lista para editar."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:82
+#: ../src/common/accelcmn.cpp:79
 msgid "Separator"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1083
+#: ../src/common/cmdline.cpp:1079
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Esperábase un separador despois da opción '%s'."
 
-#: ../src/osx/menu_osx.cpp:572
+#: ../src/osx/menu_osx.cpp:464
 msgid "Services"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11217
+#: ../src/richtext/richtextbuffer.cpp:11216
 msgid "Set Cell Style"
 msgstr "Estabelecer estilo de celas"
 
@@ -6372,11 +6536,11 @@ msgstr "Estabelecer estilo de celas"
 msgid "SetProperty called w/o valid setter"
 msgstr "SetProperty chamado sen un setter axeitado"
 
-#: ../src/generic/prntdlgg.cpp:188
+#: ../src/generic/prntdlgg.cpp:181
 msgid "Setup..."
 msgstr "Configuración..."
 
-#: ../src/msw/dialup.cpp:544
+#: ../src/msw/dialup.cpp:538
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr "Atopáronse varias conexións activas e elixíuse unha ao chou."
 
@@ -6393,40 +6557,40 @@ msgstr ""
 msgid "Shadow c&olour:"
 msgstr "Elixa unha cor"
 
-#: ../src/common/accelcmn.cpp:335
+#: ../src/common/accelcmn.cpp:349
 msgid "Shift+"
 msgstr "Shift+"
 
-#: ../src/generic/dirdlgg.cpp:147
+#: ../src/generic/dirdlgg.cpp:144
 msgid "Show &hidden directories"
 msgstr "Amosar os cartafoles &agochados"
 
-#: ../src/generic/filectrlg.cpp:983
+#: ../src/generic/filectrlg.cpp:979
 msgid "Show &hidden files"
 msgstr "Amosar os ficheiros &agochados"
 
-#: ../src/osx/menu_osx.cpp:580
+#: ../src/osx/menu_osx.cpp:472
 msgid "Show All"
 msgstr "Amosar todo"
 
-#: ../src/common/stockitem.cpp:257
+#: ../src/common/stockitem.cpp:254
 msgid "Show about dialog"
 msgstr "Amosar diálogo Sobre"
 
-#: ../src/html/helpwnd.cpp:492
+#: ../src/html/helpwnd.cpp:490
 msgid "Show all"
 msgstr "Amosar todo"
 
-#: ../src/html/helpwnd.cpp:503
+#: ../src/html/helpwnd.cpp:501
 msgid "Show all items in index"
 msgstr "Amosar todos os elementos do índice"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:656
 msgid "Show/hide navigation panel"
 msgstr "Amosar/agochar o panel de navegación"
 
-#: ../src/richtext/richtextsymboldlg.cpp:421
-#: ../src/richtext/richtextsymboldlg.cpp:423
+#: ../src/richtext/richtextsymboldlg.cpp:418
+#: ../src/richtext/richtextsymboldlg.cpp:420
 msgid "Shows a Unicode subset."
 msgstr "Amosa un subconxunto de Unicode."
 
@@ -6442,7 +6606,7 @@ msgstr "Amosa unha vista previa da configuración das viñetas."
 msgid "Shows a preview of the font settings."
 msgstr "Amosa unha vista previa da configuración de tipos de letra."
 
-#: ../src/osx/carbon/fontdlg.cpp:394 ../src/osx/carbon/fontdlg.cpp:396
+#: ../src/osx/carbon/fontdlg.cpp:391 ../src/osx/carbon/fontdlg.cpp:393
 msgid "Shows a preview of the font."
 msgstr "Amosa unha vista previa do tipo de letra."
 
@@ -6451,62 +6615,62 @@ msgstr "Amosa unha vista previa do tipo de letra."
 msgid "Shows a preview of the paragraph settings."
 msgstr "Amosa unha vista previa da configuración dos parágrafos."
 
-#: ../src/generic/fontdlgg.cpp:460 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:456 ../src/generic/fontdlgg.cpp:458
 msgid "Shows the font preview."
 msgstr "Amosa unha previsualización do tipo de letra."
 
-#: ../src/propgrid/advprops.cpp:1607
+#: ../src/propgrid/advprops.cpp:1513
 msgid "Silver"
 msgstr ""
 
-#: ../src/univ/themes/mono.cpp:516
+#: ../src/univ/themes/mono.cpp:513
 msgid "Simple monochrome theme"
 msgstr "Tema simple monocromo"
 
-#: ../src/richtext/richtextindentspage.cpp:275
 #: ../src/richtext/richtextliststylepage.cpp:449
+#: ../src/richtext/richtextindentspage.cpp:275
 msgid "Single"
 msgstr "Simple"
 
-#: ../src/generic/filectrlg.cpp:425 ../src/richtext/richtextformatdlg.cpp:369
-#: ../src/richtext/richtextsizepage.cpp:299
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextsizepage.cpp:299
+#: ../src/richtext/richtextformatdlg.cpp:362
 msgid "Size"
 msgstr "Tamaño"
 
-#: ../src/osx/carbon/fontdlg.cpp:339
+#: ../src/osx/carbon/fontdlg.cpp:336
 msgid "Size:"
 msgstr "Tamaño:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1775
+#: ../src/propgrid/advprops.cpp:1676
 msgid "Sizing"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1772
+#: ../src/propgrid/advprops.cpp:1673
 msgid "Sizing N-S"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1771
+#: ../src/propgrid/advprops.cpp:1672
 msgid "Sizing NE-SW"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1773
+#: ../src/propgrid/advprops.cpp:1674
 msgid "Sizing NW-SE"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1774
+#: ../src/propgrid/advprops.cpp:1675
 msgid "Sizing W-E"
 msgstr ""
 
-#: ../src/msw/progdlg.cpp:801
+#: ../src/msw/progdlg.cpp:1088
 msgid "Skip"
 msgstr "Omitir"
 
-#: ../src/generic/fontdlgg.cpp:330
+#: ../src/generic/fontdlgg.cpp:326
 msgid "Slant"
 msgstr "Inclinación"
 
@@ -6515,7 +6679,7 @@ msgid "Small C&apitals"
 msgstr "Versaletas"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:79
+#: ../src/common/accelcmn.cpp:76
 msgid "Snapshot"
 msgstr ""
 
@@ -6523,37 +6687,37 @@ msgstr ""
 msgid "Solid"
 msgstr "Sólido"
 
-#: ../src/common/docview.cpp:1791
+#: ../src/common/docview.cpp:1785
 msgid "Sorry, could not open this file."
 msgstr "Non se puido abrir este ficheiro."
 
-#: ../src/common/prntbase.cpp:2057 ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2079 ../src/common/prntbase.cpp:2087
 msgid "Sorry, not enough memory to create a preview."
 msgstr "Non hai memoria dabondo para crear unha previsualización."
 
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "Sorry, that name is taken. Please choose another."
 msgstr "Ese nome xa existe. Por favor, elixa outro."
 
-#: ../src/common/docview.cpp:1814
+#: ../src/common/docview.cpp:1819
 msgid "Sorry, the format for this file is unknown."
 msgstr "O formato deste ficheiro é descoñecido."
 
-#: ../src/unix/sound.cpp:492
+#: ../src/unix/sound.cpp:481
 msgid "Sound data are in unsupported format."
 msgstr "Os datos de son están nun formato non compatíbel."
 
-#: ../src/unix/sound.cpp:477
+#: ../src/unix/sound.cpp:466
 #, c-format
 msgid "Sound file '%s' is in unsupported format."
 msgstr "O ficheiro de son '%s' está nun formato non compatíbel."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:67
+#: ../src/common/accelcmn.cpp:64
 #, fuzzy
 msgid "Space"
 msgstr "Espazamento"
@@ -6562,12 +6726,12 @@ msgstr "Espazamento"
 msgid "Spacing"
 msgstr "Espazamento"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "Spell Check"
 msgstr "Revisión ortográfica"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1776
+#: ../src/propgrid/advprops.cpp:1677
 msgid "Spraycan"
 msgstr ""
 
@@ -6576,7 +6740,7 @@ msgstr ""
 msgid "Standard"
 msgstr "Estándar"
 
-#: ../src/common/paper.cpp:104
+#: ../src/common/paper.cpp:101
 msgid "Statement, 5 1/2 x 8 1/2 in"
 msgstr "Media carta, 5 1/2 x 8 1/2 polgadas"
 
@@ -6585,33 +6749,29 @@ msgstr "Media carta, 5 1/2 x 8 1/2 polgadas"
 msgid "Static"
 msgstr "Estático"
 
-#: ../src/generic/prntdlgg.cpp:204
+#: ../src/generic/prntdlgg.cpp:197
 msgid "Status:"
 msgstr "Estado:"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "Stop"
 msgstr "Parar"
 
-#: ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196
 msgid "Strikethrough"
 msgstr "Riscado"
 
-#: ../src/common/colourcmn.cpp:45
+#: ../src/common/colourcmn.cpp:42
 #, c-format
 msgid "String To Colour : Incorrect colour specification : %s"
 msgstr "Cadea para cor: Especificación de cor incorrecta: %s"
 
 #. TRANSLATORS: Label of font style
-#: ../src/richtext/richtextformatdlg.cpp:339 ../src/propgrid/advprops.cpp:680
+#: ../src/propgrid/advprops.cpp:590 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Estilo"
 
-#: ../include/wx/richtext/richtextstyledlg.h:46
-msgid "Style Organiser"
-msgstr "Organizador de estilos"
-
-#: ../src/osx/carbon/fontdlg.cpp:348
+#: ../src/osx/carbon/fontdlg.cpp:345
 msgid "Style:"
 msgstr "Estilo:"
 
@@ -6620,7 +6780,7 @@ msgid "Subscrip&t"
 msgstr "Su&bíndice"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:83
+#: ../src/common/accelcmn.cpp:80
 msgid "Subtract"
 msgstr ""
 
@@ -6628,11 +6788,11 @@ msgstr ""
 msgid "Supe&rscript"
 msgstr "Supe&ríndice"
 
-#: ../src/common/paper.cpp:150
+#: ../src/common/paper.cpp:147
 msgid "SuperA/SuperA/A4 227 x 356 mm"
 msgstr "SuperA/SuperA/A4 227 x 356 mm"
 
-#: ../src/common/paper.cpp:151
+#: ../src/common/paper.cpp:148
 msgid "SuperB/SuperB/A3 305 x 487 mm"
 msgstr "SuperB/SuperB/A3 305 x 487 mm"
 
@@ -6640,7 +6800,7 @@ msgstr "SuperB/SuperB/A3 305 x 487 mm"
 msgid "Suppress hyphe&nation"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:326
+#: ../src/generic/fontdlgg.cpp:322
 msgid "Swiss"
 msgstr "Suízo"
 
@@ -6658,74 +6818,74 @@ msgstr "&Símbolos:"
 msgid "Symbols"
 msgstr "Símbolos"
 
-#: ../src/common/imagtiff.cpp:369 ../src/common/imagtiff.cpp:382
-#: ../src/common/imagtiff.cpp:741
+#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
+#: ../src/common/imagtiff.cpp:738
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: Non se puido asignar memoria."
 
-#: ../src/common/imagtiff.cpp:301
+#: ../src/common/imagtiff.cpp:298
 msgid "TIFF: Error loading image."
 msgstr "TIFF: Erro ao cargar a imaxe."
 
-#: ../src/common/imagtiff.cpp:468
+#: ../src/common/imagtiff.cpp:465
 msgid "TIFF: Error reading image."
 msgstr "TIFF: Erro ao ler a imaxe."
 
-#: ../src/common/imagtiff.cpp:608
+#: ../src/common/imagtiff.cpp:605
 msgid "TIFF: Error saving image."
 msgstr "TIFF: Erro ao gardar a imaxe."
 
-#: ../src/common/imagtiff.cpp:846
+#: ../src/common/imagtiff.cpp:843
 msgid "TIFF: Error writing image."
 msgstr "TIFF: Erro ao escribir na imaxe."
 
-#: ../src/common/imagtiff.cpp:355
+#: ../src/common/imagtiff.cpp:352
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: A imaxe ten un tamaño anormalmente grande."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:68
+#: ../src/common/accelcmn.cpp:65
 #, fuzzy
 msgid "Tab"
 msgstr "Lapelas"
 
-#: ../src/richtext/richtextbuffer.cpp:11498
+#: ../src/richtext/richtextbuffer.cpp:11497
 msgid "Table Properties"
 msgstr "Propiedades de táboa"
 
-#: ../src/common/paper.cpp:145
+#: ../src/common/paper.cpp:142
 msgid "Tabloid Extra 11.69 x 18 in"
 msgstr "Tabloide Extra 11,69 x 18 polgadas"
 
-#: ../src/common/paper.cpp:102
+#: ../src/common/paper.cpp:99
 msgid "Tabloid, 11 x 17 in"
 msgstr "Tabloide, 11 x 17 polgadas"
 
-#: ../src/richtext/richtextformatdlg.cpp:354
+#: ../src/richtext/richtextformatdlg.cpp:347
 msgid "Tabs"
 msgstr "Lapelas"
 
-#: ../src/propgrid/advprops.cpp:1598
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Teal"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:327
+#: ../src/generic/fontdlgg.cpp:323
 msgid "Teletype"
 msgstr "Teletipo"
 
-#: ../src/common/docview.cpp:1896
+#: ../src/common/docview.cpp:1901
 msgid "Templates"
 msgstr "Patróns"
 
-#: ../src/common/fmapbase.cpp:158
+#: ../src/common/fmapbase.cpp:155
 msgid "Thai (ISO-8859-11)"
 msgstr "Tailandés (ISO-8859-11)"
 
-#: ../src/common/ftp.cpp:619
+#: ../src/common/ftp.cpp:622
 msgid "The FTP server doesn't support passive mode."
 msgstr "O servidor FTP non é compatíbel co modo pasivo."
 
-#: ../src/common/ftp.cpp:605
+#: ../src/common/ftp.cpp:608
 msgid "The FTP server doesn't support the PORT command."
 msgstr "O servidor FTP non é compatíbel co comando PORT."
 
@@ -6736,8 +6896,8 @@ msgstr "O servidor FTP non é compatíbel co comando PORT."
 msgid "The available bullet styles."
 msgstr "Os estilos de viñeta dispoñíbeis."
 
-#: ../src/richtext/richtextstyledlg.cpp:202
-#: ../src/richtext/richtextstyledlg.cpp:204
+#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:200
 msgid "The available styles."
 msgstr "Os estilos dispoñíbeis."
 
@@ -6794,12 +6954,12 @@ msgstr "A posición inferior."
 msgid "The bullet character."
 msgstr "O caracter das viñetas."
 
-#: ../src/richtext/richtextsymboldlg.cpp:443
-#: ../src/richtext/richtextsymboldlg.cpp:445
+#: ../src/richtext/richtextsymboldlg.cpp:440
+#: ../src/richtext/richtextsymboldlg.cpp:442
 msgid "The character code."
 msgstr "O código do caracter."
 
-#: ../src/common/fontmap.cpp:203
+#: ../src/common/fontmap.cpp:200
 #, c-format
 msgid ""
 "The charset '%s' is unknown. You may select\n"
@@ -6811,7 +6971,7 @@ msgstr ""
 "para substituílo ou premer en [Cancelar] se\n"
 "non se pode substituír"
 
-#: ../src/msw/ole/dataobj.cpp:394
+#: ../src/msw/ole/dataobj.cpp:402
 #, c-format
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "O formato '%d' do portapapeis non existe."
@@ -6821,7 +6981,7 @@ msgstr "O formato '%d' do portapapeis non existe."
 msgid "The default style for the next paragraph."
 msgstr "O estilo predeterminado para o seguinte parágrafo."
 
-#: ../src/generic/dirdlgg.cpp:202
+#: ../src/generic/dirdlgg.cpp:199
 #, c-format
 msgid ""
 "The directory '%s' does not exist\n"
@@ -6830,7 +6990,7 @@ msgstr ""
 "O cartafol '%s' non existe\n"
 "Desexa crealo agora?"
 
-#: ../src/html/htmprint.cpp:271
+#: ../src/html/htmprint.cpp:283
 #, c-format
 msgid ""
 "The document \"%s\" doesn't fit on the page horizontally and will be "
@@ -6843,7 +7003,7 @@ msgstr ""
 "\n"
 "Quere continuar coa impresión en calquera caso?"
 
-#: ../src/common/docview.cpp:1202
+#: ../src/common/docview.cpp:1196
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -6852,36 +7012,37 @@ msgstr ""
 "O ficheiro '%s' non existe e non se puido abrir.\n"
 "Foi eliminado da lista de ficheiros recentes."
 
-#: ../src/richtext/richtextindentspage.cpp:208
-#: ../src/richtext/richtextindentspage.cpp:210
 #: ../src/richtext/richtextliststylepage.cpp:394
 #: ../src/richtext/richtextliststylepage.cpp:396
+#: ../src/richtext/richtextindentspage.cpp:208
+#: ../src/richtext/richtextindentspage.cpp:210
 msgid "The first line indent."
 msgstr "A sangría de primeira liña."
 
-#: ../src/gtk/utilsgtk.cpp:481
-msgid "The following standard GTK+ options are also supported:\n"
-msgstr "As seguintes opcións do estándar GTK+ tamén se admiten:\n"
+#: ../src/generic/dbgrptg.cpp:318
+#, fuzzy
+msgid "The following debug report will be generated\n"
+msgstr "*** Xerouse un informe de depuración\n"
 
-#: ../src/generic/fontdlgg.cpp:414 ../src/generic/fontdlgg.cpp:416
+#: ../src/generic/fontdlgg.cpp:411 ../src/generic/fontdlgg.cpp:413
 msgid "The font colour."
 msgstr "A cor do tipo de letra."
 
-#: ../src/generic/fontdlgg.cpp:375 ../src/generic/fontdlgg.cpp:377
+#: ../src/generic/fontdlgg.cpp:371 ../src/generic/fontdlgg.cpp:373
 msgid "The font family."
 msgstr "A familia do tipo de letra."
 
-#: ../src/richtext/richtextsymboldlg.cpp:405
-#: ../src/richtext/richtextsymboldlg.cpp:407
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "The font from which to take the symbol."
 msgstr "O tipo de letra do que tomar o símbolo."
 
-#: ../src/generic/fontdlgg.cpp:427 ../src/generic/fontdlgg.cpp:429
-#: ../src/generic/fontdlgg.cpp:434 ../src/generic/fontdlgg.cpp:436
+#: ../src/generic/fontdlgg.cpp:424 ../src/generic/fontdlgg.cpp:426
+#: ../src/generic/fontdlgg.cpp:430 ../src/generic/fontdlgg.cpp:432
 msgid "The font point size."
 msgstr "O tamaño de letra."
 
-#: ../src/osx/carbon/fontdlg.cpp:343 ../src/osx/carbon/fontdlg.cpp:345
+#: ../src/osx/carbon/fontdlg.cpp:340 ../src/osx/carbon/fontdlg.cpp:342
 msgid "The font size in points."
 msgstr "O tamaño en puntos."
 
@@ -6890,15 +7051,15 @@ msgstr "O tamaño en puntos."
 msgid "The font size units, points or pixels."
 msgstr "As unidades de tamaño de letra: puntos ou píxeles."
 
-#: ../src/generic/fontdlgg.cpp:386 ../src/generic/fontdlgg.cpp:388
+#: ../src/generic/fontdlgg.cpp:382 ../src/generic/fontdlgg.cpp:384
 msgid "The font style."
 msgstr "Estilo do tipo de letra."
 
-#: ../src/generic/fontdlgg.cpp:397 ../src/generic/fontdlgg.cpp:399
+#: ../src/generic/fontdlgg.cpp:393 ../src/generic/fontdlgg.cpp:395
 msgid "The font weight."
 msgstr "O peso do tipo de letra."
 
-#: ../src/common/docview.cpp:1483
+#: ../src/common/docview.cpp:1477
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Non se puido determinar o formato do ficheiro '%s'."
@@ -6909,10 +7070,10 @@ msgstr "Non se puido determinar o formato do ficheiro '%s'."
 msgid "The horizontal offset."
 msgstr "Mosaico &horizontal"
 
-#: ../src/richtext/richtextindentspage.cpp:199
-#: ../src/richtext/richtextindentspage.cpp:201
 #: ../src/richtext/richtextliststylepage.cpp:385
 #: ../src/richtext/richtextliststylepage.cpp:387
+#: ../src/richtext/richtextindentspage.cpp:199
+#: ../src/richtext/richtextindentspage.cpp:201
 msgid "The left indent."
 msgstr "A sangría esquerda."
 
@@ -6933,10 +7094,10 @@ msgstr "O recheo esquerdo."
 msgid "The left position."
 msgstr "A posición esquerda."
 
-#: ../src/richtext/richtextindentspage.cpp:288
-#: ../src/richtext/richtextindentspage.cpp:290
 #: ../src/richtext/richtextliststylepage.cpp:462
 #: ../src/richtext/richtextliststylepage.cpp:464
+#: ../src/richtext/richtextindentspage.cpp:288
+#: ../src/richtext/richtextindentspage.cpp:290
 msgid "The line spacing."
 msgstr "O espazamento de liñas."
 
@@ -6945,7 +7106,7 @@ msgstr "O espazamento de liñas."
 msgid "The list item number."
 msgstr "O número de ítem da lista."
 
-#: ../src/msw/ole/automtn.cpp:664
+#: ../src/msw/ole/automtn.cpp:655
 msgid "The locale ID is unknown."
 msgstr "A ID local non se coñece."
 
@@ -6984,19 +7145,19 @@ msgstr "O ancho do obxecto."
 msgid "The outline level."
 msgstr "O nivel de esquema."
 
-#: ../src/common/log.cpp:277
+#: ../src/common/log.cpp:296
 #, fuzzy, c-format
 msgid "The previous message repeated %u time."
 msgid_plural "The previous message repeated %u times."
 msgstr[0] "A mensaxe anterior repetida %lu vez."
 msgstr[1] "A mensaxe anterior repetida %lu veces."
 
-#: ../src/common/log.cpp:270
+#: ../src/common/log.cpp:289
 msgid "The previous message repeated once."
 msgstr "A mensaxe anterior repetida unha vez."
 
-#: ../src/richtext/richtextsymboldlg.cpp:462
-#: ../src/richtext/richtextsymboldlg.cpp:464
+#: ../src/richtext/richtextsymboldlg.cpp:459
+#: ../src/richtext/richtextsymboldlg.cpp:461
 msgid "The range to show."
 msgstr "O rango para amosar."
 
@@ -7010,15 +7171,15 @@ msgstr ""
 "contén\n"
 "información privada, desmárqueo e quedará eliminado do informe.\n"
 
-#: ../src/common/cmdline.cpp:1254
+#: ../src/common/cmdline.cpp:1250
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "Non se especificou o parámetro requirido '%s'."
 
-#: ../src/richtext/richtextindentspage.cpp:217
-#: ../src/richtext/richtextindentspage.cpp:219
 #: ../src/richtext/richtextliststylepage.cpp:403
 #: ../src/richtext/richtextliststylepage.cpp:405
+#: ../src/richtext/richtextindentspage.cpp:217
+#: ../src/richtext/richtextindentspage.cpp:219
 msgid "The right indent."
 msgstr "A sangría dereita."
 
@@ -7060,16 +7221,16 @@ msgstr ""
 msgid "The shadow spread."
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:267
 #: ../src/richtext/richtextliststylepage.cpp:439
 #: ../src/richtext/richtextliststylepage.cpp:441
+#: ../src/richtext/richtextindentspage.cpp:267
 msgid "The spacing after the paragraph."
 msgstr "O espazamento despois do parágrafo."
 
-#: ../src/richtext/richtextindentspage.cpp:257
-#: ../src/richtext/richtextindentspage.cpp:259
 #: ../src/richtext/richtextliststylepage.cpp:430
 #: ../src/richtext/richtextliststylepage.cpp:432
+#: ../src/richtext/richtextindentspage.cpp:257
+#: ../src/richtext/richtextindentspage.cpp:259
 msgid "The spacing before the paragraph."
 msgstr "O espazamento antes do parágrafo."
 
@@ -7083,12 +7244,12 @@ msgstr "O nome do estilo."
 msgid "The style on which this style is based."
 msgstr "O estilo no que se basea este estilo."
 
-#: ../src/richtext/richtextstyledlg.cpp:214
-#: ../src/richtext/richtextstyledlg.cpp:216
+#: ../src/richtext/richtextstyledlg.cpp:210
+#: ../src/richtext/richtextstyledlg.cpp:212
 msgid "The style preview."
 msgstr "A previsualización do estilo."
 
-#: ../src/msw/ole/automtn.cpp:680
+#: ../src/msw/ole/automtn.cpp:671
 msgid "The system cannot find the file specified."
 msgstr "O sistema non atopa o ficheiro especificado."
 
@@ -7101,7 +7262,7 @@ msgstr "A posición da lapela."
 msgid "The tab positions."
 msgstr "As posicións das lapelas."
 
-#: ../src/richtext/richtextctrl.cpp:3098
+#: ../src/richtext/richtextctrl.cpp:3099
 msgid "The text couldn't be saved."
 msgstr "Non se puido gardar o texto."
 
@@ -7122,7 +7283,7 @@ msgstr "O recheo superior."
 msgid "The top position."
 msgstr "A posición superior."
 
-#: ../src/common/cmdline.cpp:1232
+#: ../src/common/cmdline.cpp:1228
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "Debe especificarse o valor para a opción '%s'."
@@ -7132,7 +7293,7 @@ msgstr "Debe especificarse o valor para a opción '%s'."
 msgid "The value of the corner radius."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:433
+#: ../src/msw/dialup.cpp:427
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -7148,14 +7309,14 @@ msgstr ""
 msgid "The vertical offset."
 msgstr "Activar aliñamento vertical."
 
-#: ../src/richtext/richtextprint.cpp:619 ../src/html/htmprint.cpp:745
+#: ../src/html/htmprint.cpp:749 ../src/richtext/richtextprint.cpp:615
 msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr ""
 "Houbo un problema mentres se configuraba a páxina: cómpre estabelecer unha "
 "impresora predeterminada."
 
-#: ../src/html/htmprint.cpp:255
+#: ../src/html/htmprint.cpp:267
 msgid ""
 "This document doesn't fit on the page horizontally and will be truncated "
 "when it is printed."
@@ -7163,16 +7324,16 @@ msgstr ""
 "Este documento non se axeita horizontalmente á páxina e cortarase cando se "
 "imprima."
 
-#: ../src/common/image.cpp:2854
+#: ../src/common/image.cpp:2963
 #, c-format
 msgid "This is not a %s."
 msgstr "Isto non é un %s."
 
-#: ../src/common/wincmn.cpp:1653
+#: ../src/common/wincmn.cpp:1654
 msgid "This platform does not support background transparency."
 msgstr "Esta plataforma non admite a transparencia de fondo."
 
-#: ../src/gtk/window.cpp:4660
+#: ../src/gtk/window.cpp:5664
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
@@ -7180,7 +7341,15 @@ msgstr ""
 "Este programa compilouse cunha versión moi antiga de GTK+. Por favor, "
 "utilice GTK+ 2.12 ou posterior."
 
-#: ../src/msw/thread.cpp:1240
+#: ../src/gtk/glcanvas.cpp:176
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/msw/thread.cpp:1246
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -7188,13 +7357,13 @@ msgstr ""
 "Erro ao inicializar o módulo de fíos de execución: non se pode almacenar o "
 "valor no almacén local de fíos"
 
-#: ../src/unix/threadpsx.cpp:1794
+#: ../src/unix/threadpsx.cpp:1843
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 "Erro ao inicar o módulo de fíos de execución: non se puido crear clave de "
 "fíos"
 
-#: ../src/msw/thread.cpp:1228
+#: ../src/msw/thread.cpp:1234
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -7202,83 +7371,83 @@ msgstr ""
 "Erro ao inicar o módulo de fíos de execución: imposíbel asignar índice no "
 "almacén local de fíos"
 
-#: ../src/unix/threadpsx.cpp:1043
+#: ../src/unix/threadpsx.cpp:1061
 msgid "Thread priority setting is ignored."
 msgstr "Ignorouse a configuración de prioridade de fíos de execución."
 
-#: ../src/msw/mdi.cpp:176
+#: ../src/msw/mdi.cpp:171
 msgid "Tile &Horizontally"
 msgstr "Mosaico &horizontal"
 
-#: ../src/msw/mdi.cpp:177
+#: ../src/msw/mdi.cpp:172
 msgid "Tile &Vertically"
 msgstr "Mosaico &vertical"
 
-#: ../src/common/ftp.cpp:200
+#: ../src/common/ftp.cpp:197
 msgid "Timeout while waiting for FTP server to connect, try passive mode."
 msgstr ""
 "Superouse o tempo de espera para a conexión ao servidor FTP, inténteo co "
 "modo pasivo."
 
-#: ../src/generic/tipdlg.cpp:201
+#: ../src/generic/tipdlg.cpp:198
 msgid "Tip of the Day"
 msgstr "Consello do día"
 
-#: ../src/generic/tipdlg.cpp:140
+#: ../src/generic/tipdlg.cpp:137
 msgid "Tips not available, sorry!"
 msgstr "Os consellos non están dispoñíbeis!"
 
-#: ../src/generic/prntdlgg.cpp:242
+#: ../src/generic/prntdlgg.cpp:235
 msgid "To:"
 msgstr "Para:"
 
-#: ../src/richtext/richtextbuffer.cpp:8363
+#: ../src/richtext/richtextbuffer.cpp:8361
 msgid "Too many EndStyle calls!"
 msgstr "Demasiadas chamadas a EndStyle!"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:891
+#: ../src/propgrid/advprops.cpp:792
 msgid "Tooltip"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:892
+#: ../src/propgrid/advprops.cpp:793
 msgid "TooltipText"
 msgstr ""
 
-#: ../src/richtext/richtextsizepage.cpp:286
-#: ../src/richtext/richtextsizepage.cpp:290 ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197 ../src/richtext/richtextsizepage.cpp:286
+#: ../src/richtext/richtextsizepage.cpp:290
 msgid "Top"
 msgstr "Arriba"
 
-#: ../src/generic/prntdlgg.cpp:881
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Top margin (mm):"
 msgstr "Marxe superior (mm):"
 
-#: ../src/generic/aboutdlgg.cpp:79
+#: ../src/generic/aboutdlgg.cpp:76
 msgid "Translations by "
 msgstr "Traducións de "
 
-#: ../src/generic/aboutdlgg.cpp:188
+#: ../src/generic/aboutdlgg.cpp:185
 msgid "Translators"
 msgstr "Tradutores/as"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:211
+#: ../src/propgrid/propgrid.cpp:192
 msgid "True"
 msgstr "Certo"
 
-#: ../src/common/fs_mem.cpp:227
+#: ../src/common/fs_mem.cpp:222
 #, c-format
 msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
 msgstr ""
 "Tentouse eliminar o ficheiro '%s' da memoria VFS, pero non está cargado!"
 
-#: ../src/common/fmapbase.cpp:156
+#: ../src/common/fmapbase.cpp:153
 msgid "Turkish (ISO-8859-9)"
 msgstr "Turco (ISO-8859-9)"
 
-#: ../src/generic/filectrlg.cpp:426
+#: ../src/generic/filectrlg.cpp:422
 msgid "Type"
 msgstr "Tipo"
 
@@ -7292,17 +7461,17 @@ msgstr "Inserir unha familia de tipo de letra."
 msgid "Type a size in points."
 msgstr "Inserir un tamaño en puntos."
 
-#: ../src/msw/ole/automtn.cpp:676
+#: ../src/msw/ole/automtn.cpp:667
 #, c-format
 msgid "Type mismatch in argument %u."
 msgstr "Os tipos non coinciden no argumento %u."
 
-#: ../src/common/xtixml.cpp:356 ../src/common/xtixml.cpp:509
-#: ../src/common/xtistrm.cpp:318
+#: ../src/common/xtixml.cpp:352 ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315
 msgid "Type must have enum - long conversion"
 msgstr "O tipo debe ter un conversor enum - long"
 
-#: ../src/propgrid/propgridiface.cpp:401
+#: ../src/propgrid/propgridiface.cpp:385
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
@@ -7311,19 +7480,19 @@ msgstr ""
 "O tipo de operación \"%s\" fallou: A propiedade coa etiqueta \"%s\" é de "
 "tipo \"%s\", NON \"%s\"."
 
-#: ../src/common/paper.cpp:133
+#: ../src/common/paper.cpp:130
 msgid "US Std Fanfold, 14 7/8 x 11 in"
 msgstr "US Std Fanfold, 14 7/8 x 11 polgadas"
 
-#: ../src/common/fmapbase.cpp:196
+#: ../src/common/fmapbase.cpp:193
 msgid "US-ASCII"
 msgstr "ASCII"
 
-#: ../src/unix/fswatcher_inotify.cpp:109
+#: ../src/unix/fswatcher_inotify.cpp:106
 msgid "Unable to add inotify watch"
 msgstr "Non se puido engadir monitorización de inotify"
 
-#: ../src/unix/fswatcher_kqueue.cpp:136
+#: ../src/unix/fswatcher_kqueue.cpp:153
 msgid "Unable to add kqueue watch"
 msgstr "Non se puido engadir monitorización de kqueue"
 
@@ -7335,7 +7504,7 @@ msgstr "Non é posíbel asociar manexador con porto E/S"
 msgid "Unable to close I/O completion port handle"
 msgstr "Non é posíbel pechar manexador de porto E/S"
 
-#: ../src/unix/fswatcher_inotify.cpp:97
+#: ../src/unix/fswatcher_inotify.cpp:94
 msgid "Unable to close inotify instance"
 msgstr "Non se puido pechar instancia de inotify"
 
@@ -7353,15 +7522,15 @@ msgstr "Non se puido pechar o manexador para '%s'"
 msgid "Unable to create I/O completion port"
 msgstr "Fallo ao crear un porto de E/S"
 
-#: ../src/msw/fswatcher.cpp:84
+#: ../src/msw/fswatcher.cpp:81
 msgid "Unable to create IOCP worker thread"
 msgstr "Non se puido crear fío de traballo de IOCP"
 
-#: ../src/unix/fswatcher_inotify.cpp:74
+#: ../src/unix/fswatcher_inotify.cpp:71
 msgid "Unable to create inotify instance"
 msgstr "Non se puido crear instancia de inotify"
 
-#: ../src/unix/fswatcher_kqueue.cpp:97
+#: ../src/unix/fswatcher_kqueue.cpp:114
 msgid "Unable to create kqueue instance"
 msgstr "Non se puido crear instancia de kqueue"
 
@@ -7369,11 +7538,11 @@ msgstr "Non se puido crear instancia de kqueue"
 msgid "Unable to dequeue completion packet"
 msgstr "Non se puido retirar da cola o paquete de completado"
 
-#: ../src/unix/fswatcher_kqueue.cpp:185
+#: ../src/unix/fswatcher_kqueue.cpp:202
 msgid "Unable to get events from kqueue"
 msgstr "Non se puideron tomar eventos do kqueue"
 
-#: ../src/gtk/app.cpp:435
+#: ../src/gtk/app.cpp:431
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "Non se puido inicializar GTK+, está instalado DISPLAY correctamente?"
 
@@ -7382,12 +7551,12 @@ msgstr "Non se puido inicializar GTK+, está instalado DISPLAY correctamente?"
 msgid "Unable to open path '%s'"
 msgstr "Erro ao abrir a ruta '%s'"
 
-#: ../src/html/htmlwin.cpp:583
+#: ../src/html/htmlwin.cpp:586
 #, c-format
 msgid "Unable to open requested HTML document: %s"
 msgstr "Non foi posíbel abrir o documento HTML solicitado: %s"
 
-#: ../src/unix/sound.cpp:368
+#: ../src/unix/sound.cpp:365
 msgid "Unable to play sound asynchronously."
 msgstr "Non se puido reproducir o son de xeito asíncrono."
 
@@ -7395,62 +7564,62 @@ msgstr "Non se puido reproducir o son de xeito asíncrono."
 msgid "Unable to post completion status"
 msgstr "Non se puido enviar o estatus de terminación"
 
-#: ../src/unix/fswatcher_inotify.cpp:556
+#: ../src/unix/fswatcher_inotify.cpp:553
 msgid "Unable to read from inotify descriptor"
 msgstr "Non foi posíbel ler dende o descritor de inotify"
 
-#: ../src/unix/fswatcher_inotify.cpp:141
+#: ../src/unix/fswatcher_inotify.cpp:138
 #, fuzzy, c-format
 msgid "Unable to remove inotify watch %i"
 msgstr "Non é posíbel eliminar monitorización de inotify"
 
-#: ../src/unix/fswatcher_kqueue.cpp:153
+#: ../src/unix/fswatcher_kqueue.cpp:170
 msgid "Unable to remove kqueue watch"
 msgstr "Non se puido eliminar a monitorización de kqueue"
 
-#: ../src/msw/fswatcher.cpp:168
+#: ../src/msw/fswatcher.cpp:165
 #, c-format
 msgid "Unable to set up watch for '%s'"
 msgstr "Non foi posíbel estabelecer monitorización para '%s'"
 
-#: ../src/msw/fswatcher.cpp:91
+#: ../src/msw/fswatcher.cpp:88
 msgid "Unable to start IOCP worker thread"
 msgstr "Non se puido iniciar o fío de traballo de IOCP"
 
-#: ../src/common/stockitem.cpp:201
+#: ../src/common/stockitem.cpp:198
 msgid "Undelete"
 msgstr "Deshacer eliminar"
 
-#: ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199
 msgid "Underline"
 msgstr "Subliñar"
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/richtext/richtextfontpage.cpp:359 ../src/osx/carbon/fontdlg.cpp:370
-#: ../src/propgrid/advprops.cpp:690
+#: ../src/osx/carbon/fontdlg.cpp:367 ../src/propgrid/advprops.cpp:600
+#: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Subliñado"
 
-#: ../src/common/stockitem.cpp:203 ../src/stc/stc_i18n.cpp:15
+#: ../src/common/stockitem.cpp:200 ../src/stc/stc_i18n.cpp:15
 msgid "Undo"
 msgstr "Desfacer"
 
-#: ../src/common/stockitem.cpp:265
+#: ../src/common/stockitem.cpp:263
 msgid "Undo last action"
 msgstr "Desfacer a acción anterior"
 
-#: ../src/common/cmdline.cpp:1029
+#: ../src/common/cmdline.cpp:1025
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Caracteres inesperados despois da opción '%s'."
 
-#: ../src/unix/fswatcher_inotify.cpp:274
+#: ../src/unix/fswatcher_inotify.cpp:271
 #, c-format
 msgid "Unexpected event for \"%s\": no matching watch descriptor."
 msgstr ""
 "Evento non esperado para \"%s\" non hai descritor de vixilancia que concorde."
 
-#: ../src/common/cmdline.cpp:1195
+#: ../src/common/cmdline.cpp:1191
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Parámetro '%s' inesperado"
@@ -7459,49 +7628,49 @@ msgstr "Parámetro '%s' inesperado"
 msgid "Unexpectedly new I/O completion port was created"
 msgstr "Creouse inesperadamente un novo porto E/S"
 
-#: ../src/msw/fswatcher.cpp:70
+#: ../src/msw/fswatcher.cpp:67
 msgid "Ungraceful worker thread termination"
 msgstr "Finalización do fíos de execución efectivos incorrecta"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:460
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:456
+#: ../src/richtext/richtextsymboldlg.cpp:457
+#: ../src/richtext/richtextsymboldlg.cpp:458
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../src/common/fmapbase.cpp:185 ../src/common/fmapbase.cpp:191
+#: ../src/common/fmapbase.cpp:182 ../src/common/fmapbase.cpp:188
 msgid "Unicode 16 bit (UTF-16)"
 msgstr "Unicode de 16 bits (UTF-16)"
 
-#: ../src/common/fmapbase.cpp:190
+#: ../src/common/fmapbase.cpp:187
 msgid "Unicode 16 bit Big Endian (UTF-16BE)"
 msgstr "Unicode 16 bits Big Endian (UTF-16BE)"
 
-#: ../src/common/fmapbase.cpp:186
+#: ../src/common/fmapbase.cpp:183
 msgid "Unicode 16 bit Little Endian (UTF-16LE)"
 msgstr "Unicode 16 bits Little Endian (UTF-16LE)"
 
-#: ../src/common/fmapbase.cpp:187 ../src/common/fmapbase.cpp:193
+#: ../src/common/fmapbase.cpp:184 ../src/common/fmapbase.cpp:190
 msgid "Unicode 32 bit (UTF-32)"
 msgstr "Unicode de 32 bits (UTF-32)"
 
-#: ../src/common/fmapbase.cpp:192
+#: ../src/common/fmapbase.cpp:189
 msgid "Unicode 32 bit Big Endian (UTF-32BE)"
 msgstr "Unicode 32 bits Big Endian (UTF-32BE)"
 
-#: ../src/common/fmapbase.cpp:188
+#: ../src/common/fmapbase.cpp:185
 msgid "Unicode 32 bit Little Endian (UTF-32LE)"
 msgstr "Unicode 32 bits Little Endian (UTF-32LE)"
 
-#: ../src/common/fmapbase.cpp:182
+#: ../src/common/fmapbase.cpp:179
 msgid "Unicode 7 bit (UTF-7)"
 msgstr "Unicode de 7 bits (UTF-7)"
 
-#: ../src/common/fmapbase.cpp:183
+#: ../src/common/fmapbase.cpp:180
 msgid "Unicode 8 bit (UTF-8)"
 msgstr "Unicode de 8 bits (UTF-8)"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "Unindent"
 msgstr "Eliminar sangría"
 
@@ -7653,97 +7822,102 @@ msgstr "Unidades para a posición superior."
 msgid "Units for this value."
 msgstr "Unidades para a marxe esquerda."
 
-#: ../src/generic/progdlgg.cpp:353 ../src/generic/progdlgg.cpp:622
+#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
 msgid "Unknown"
 msgstr "Descoñecido"
 
-#: ../src/msw/dde.cpp:1174
+#: ../src/msw/dde.cpp:1238
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Erro DDE descoñecido %08x"
 
-#: ../src/common/xtistrm.cpp:410
+#: ../src/common/xtistrm.cpp:407
 msgid "Unknown Object passed to GetObjectClassInfo"
 msgstr "Obxecto descoñecido pasado a GetObjectClassInfo"
 
-#: ../src/common/imagpng.cpp:366
+#: ../src/common/imagpng.cpp:383
 #, c-format
 msgid "Unknown PNG resolution unit %d"
 msgstr "Unidade de resolución de PNG %d descoñecida"
 
-#: ../src/common/xtixml.cpp:327
+#: ../src/common/xtixml.cpp:323
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Propiedade descoñecida %s"
 
-#: ../src/common/imagtiff.cpp:529
+#: ../src/common/imagtiff.cpp:526
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "A unidade de resolución de TIFF %d descoñecida foi ignorada"
 
-#: ../src/unix/dlunix.cpp:160
+#: ../src/propgrid/props.cpp:155
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/unix/dlunix.cpp:118
 msgid "Unknown dynamic library error"
 msgstr "Erro descoñecido de biblioteca dinámica"
 
-#: ../src/common/fmapbase.cpp:810
+#: ../src/common/fmapbase.cpp:806
 #, c-format
 msgid "Unknown encoding (%d)"
 msgstr "Codificación descoñecida (%d)"
 
-#: ../src/msw/ole/automtn.cpp:688
+#: ../src/msw/ole/automtn.cpp:679
 #, c-format
 msgid "Unknown error %08x"
 msgstr "Erro desconocido %08x"
 
-#: ../src/msw/ole/automtn.cpp:647
+#: ../src/msw/ole/automtn.cpp:638
 msgid "Unknown exception"
 msgstr "Excepción descoñecida"
 
-#: ../src/common/image.cpp:2839
+#: ../src/common/image.cpp:2942
 msgid "Unknown image data format."
 msgstr "Formato de datos de imaxe descoñecido."
 
-#: ../src/common/cmdline.cpp:914
+#: ../src/common/cmdline.cpp:910
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Opción longa '%s' descoñecida"
 
-#: ../src/msw/ole/automtn.cpp:631
+#: ../src/msw/ole/automtn.cpp:622
 msgid "Unknown name or named argument."
 msgstr "Nome ou argumento citado descoñecido."
 
-#: ../src/common/cmdline.cpp:929 ../src/common/cmdline.cpp:951
+#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Opción descoñecida '%s'"
 
-#: ../src/common/mimecmn.cpp:225
+#: ../src/common/mimecmn.cpp:221
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "'{' non emparellado nunha entrada para o tipo mime %s."
 
-#: ../src/common/cmdproc.cpp:262 ../src/common/cmdproc.cpp:288
-#: ../src/common/cmdproc.cpp:308
+#: ../src/common/cmdproc.cpp:255 ../src/common/cmdproc.cpp:281
+#: ../src/common/cmdproc.cpp:301
 msgid "Unnamed command"
 msgstr "Comando sen nome"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:413
+#: ../src/propgrid/propgrid.cpp:392
 msgid "Unspecified"
 msgstr "Non especificado"
 
-#: ../src/msw/clipbrd.cpp:311
+#: ../src/msw/clipbrd.cpp:325
 msgid "Unsupported clipboard format."
 msgstr "Formato de portapapeis non compatíbel."
 
-#: ../src/common/appcmn.cpp:256
+#: ../src/common/appcmn.cpp:277
 #, c-format
 msgid "Unsupported theme '%s'."
 msgstr "Tema '%s' non compatíbel."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:205
-#: ../src/common/accelcmn.cpp:63
+#: ../src/common/stockitem.cpp:202 ../src/common/accelcmn.cpp:60
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Up"
 msgstr "Arriba"
 
@@ -7757,7 +7931,7 @@ msgstr "Maiúsculas"
 msgid "Upper case roman numerals"
 msgstr "Números romanos en maiúscula"
 
-#: ../src/common/cmdline.cpp:1326
+#: ../src/common/cmdline.cpp:1322
 #, c-format
 msgid "Usage: %s"
 msgstr "Uso: %s"
@@ -7766,38 +7940,47 @@ msgstr "Uso: %s"
 msgid "Use &shadow"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:169
-#: ../src/richtext/richtextindentspage.cpp:171
 #: ../src/richtext/richtextliststylepage.cpp:358
 #: ../src/richtext/richtextliststylepage.cpp:360
+#: ../src/richtext/richtextindentspage.cpp:169
+#: ../src/richtext/richtextindentspage.cpp:171
 msgid "Use the current alignment setting."
 msgstr "Usar a configuración de aliñamento actual."
 
-#: ../src/common/valtext.cpp:179
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/gtk/font.cpp:552
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/common/valtext.cpp:142
 msgid "Validation conflict"
 msgstr "Conflito de validación"
 
-#: ../src/propgrid/manager.cpp:238
+#: ../src/propgrid/manager.cpp:224
 msgid "Value"
 msgstr "Valor"
 
-#: ../src/propgrid/props.cpp:386 ../src/propgrid/props.cpp:500
+#: ../src/propgrid/props.cpp:309
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "O valor debe ser %s ou superior."
 
-#: ../src/propgrid/props.cpp:417 ../src/propgrid/props.cpp:531
+#: ../src/propgrid/props.cpp:336
 #, c-format
 msgid "Value must be %s or less."
 msgstr "O valor debe ser %s ou inferior."
 
-#: ../src/propgrid/props.cpp:393 ../src/propgrid/props.cpp:424
-#: ../src/propgrid/props.cpp:507 ../src/propgrid/props.cpp:538
+#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "O valor debe estar entre %s e %s."
 
-#: ../src/generic/aboutdlgg.cpp:128
+#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Versión"
 
@@ -7806,25 +7989,32 @@ msgstr "Versión"
 msgid "Vertical alignment."
 msgstr "Aliñamento vertical."
 
-#: ../src/generic/filedlgg.cpp:202
+#: ../src/generic/filedlgg.cpp:199
 msgid "View files as a detailed view"
 msgstr "Ver os ficheiros coma unha lista detallada"
 
-#: ../src/generic/filedlgg.cpp:200
+#: ../src/generic/filedlgg.cpp:197
 msgid "View files as a list view"
 msgstr "Ver os ficheiros coma unha lista"
 
-#: ../src/common/docview.cpp:1970
+#: ../src/common/docview.cpp:1975
 msgid "Views"
 msgstr "Vistas"
 
+#: ../src/gtk/app.cpp:348
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1777
+#: ../src/propgrid/advprops.cpp:1678
 msgid "Wait"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1779
+#: ../src/propgrid/advprops.cpp:1680
 msgid "Wait Arrow"
 msgstr ""
 
@@ -7833,243 +8023,240 @@ msgstr ""
 msgid "Waiting for IO on epoll descriptor %d failed"
 msgstr "Houbo un erro na espera de E/S no descritor epoll %d"
 
-#: ../src/common/log.cpp:223
+#: ../src/common/log.cpp:241
 msgid "Warning: "
 msgstr "Aviso: "
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1778
+#: ../src/propgrid/advprops.cpp:1679
 msgid "Watch"
 msgstr ""
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:685
+#: ../src/propgrid/advprops.cpp:595
 msgid "Weight"
 msgstr "Peso"
 
-#: ../src/common/fmapbase.cpp:148
+#: ../src/common/fmapbase.cpp:145
 msgid "Western European (ISO-8859-1)"
 msgstr "Europeo occidental (ISO-8859-1)"
 
-#: ../src/common/fmapbase.cpp:162
+#: ../src/common/fmapbase.cpp:159
 msgid "Western European with Euro (ISO-8859-15)"
 msgstr "Europeo occidental con euro (ISO-8859-15)"
 
-#: ../src/generic/fontdlgg.cpp:446 ../src/generic/fontdlgg.cpp:448
+#: ../src/generic/fontdlgg.cpp:443 ../src/generic/fontdlgg.cpp:445
 msgid "Whether the font is underlined."
 msgstr "Se a letra está subliñada."
 
-#: ../src/propgrid/advprops.cpp:1611
+#: ../src/propgrid/advprops.cpp:1517
 msgid "White"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:144
+#: ../src/generic/fdrepdlg.cpp:141
 msgid "Whole word"
 msgstr "Palabra completa"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:532
 msgid "Whole words only"
 msgstr "Só palabras completas"
 
-#: ../src/univ/themes/win32.cpp:1102
+#: ../src/univ/themes/win32.cpp:1099
 msgid "Win32 theme"
 msgstr "Tema de Win32"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:893
+#: ../src/propgrid/advprops.cpp:794
 #, fuzzy
 msgid "Window"
 msgstr "&Xanela"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:894
+#: ../src/propgrid/advprops.cpp:795
 #, fuzzy
 msgid "WindowFrame"
 msgstr "&Xanela"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:895
+#: ../src/propgrid/advprops.cpp:796
 #, fuzzy
 msgid "WindowText"
 msgstr "&Xanela"
 
-#: ../src/common/fmapbase.cpp:177
+#: ../src/common/fmapbase.cpp:174
 msgid "Windows Arabic (CP 1256)"
 msgstr "Windows árabe (CP 1256)"
 
-#: ../src/common/fmapbase.cpp:178
+#: ../src/common/fmapbase.cpp:175
 msgid "Windows Baltic (CP 1257)"
 msgstr "Windows báltico (CP 1257)"
 
-#: ../src/common/fmapbase.cpp:171
+#: ../src/common/fmapbase.cpp:168
 msgid "Windows Central European (CP 1250)"
 msgstr "Windows Europa Central (CP 1250)"
 
-#: ../src/common/fmapbase.cpp:168
+#: ../src/common/fmapbase.cpp:165
 msgid "Windows Chinese Simplified (CP 936) or GB-2312"
 msgstr "Windows chinés simplificado (CP 936) ou GB-2312"
 
-#: ../src/common/fmapbase.cpp:170
+#: ../src/common/fmapbase.cpp:167
 msgid "Windows Chinese Traditional (CP 950) or Big-5"
 msgstr "Windows chinés tradicional (CP 950) ou Big-5"
 
-#: ../src/common/fmapbase.cpp:172
+#: ../src/common/fmapbase.cpp:169
 msgid "Windows Cyrillic (CP 1251)"
 msgstr "Windows cirílico (CP 1251)"
 
-#: ../src/common/fmapbase.cpp:174
+#: ../src/common/fmapbase.cpp:171
 msgid "Windows Greek (CP 1253)"
 msgstr "Windows grego (CP 1253)"
 
-#: ../src/common/fmapbase.cpp:176
+#: ../src/common/fmapbase.cpp:173
 msgid "Windows Hebrew (CP 1255)"
 msgstr "Windows hebreo (CP 1255)"
 
-#: ../src/common/fmapbase.cpp:167
+#: ../src/common/fmapbase.cpp:164
 msgid "Windows Japanese (CP 932) or Shift-JIS"
 msgstr "Windows xaponés (CP 932)"
 
-#: ../src/common/fmapbase.cpp:180
+#: ../src/common/fmapbase.cpp:177
 msgid "Windows Johab (CP 1361)"
 msgstr "Windows johab (CP 1361)"
 
-#: ../src/common/fmapbase.cpp:169
+#: ../src/common/fmapbase.cpp:166
 msgid "Windows Korean (CP 949)"
 msgstr "Windows coreano (CP 949)"
 
-#: ../src/common/fmapbase.cpp:166
+#: ../src/common/fmapbase.cpp:163
 msgid "Windows Thai (CP 874)"
 msgstr "Windows tailandés (CP 874)"
 
-#: ../src/common/fmapbase.cpp:175
+#: ../src/common/fmapbase.cpp:172
 msgid "Windows Turkish (CP 1254)"
 msgstr "Windows turco (CP 1254)"
 
-#: ../src/common/fmapbase.cpp:179
+#: ../src/common/fmapbase.cpp:176
 msgid "Windows Vietnamese (CP 1258)"
 msgstr "Windows vietnamita (CP 1258)"
 
-#: ../src/common/fmapbase.cpp:173
+#: ../src/common/fmapbase.cpp:170
 msgid "Windows Western European (CP 1252)"
 msgstr "Windows Europa occidental (CP 1252)"
 
-#: ../src/common/fmapbase.cpp:181
+#: ../src/common/fmapbase.cpp:178
 msgid "Windows/DOS OEM (CP 437)"
 msgstr "Windows/DOS OEM (CP 437)"
 
-#: ../src/common/fmapbase.cpp:165
+#: ../src/common/fmapbase.cpp:162
 msgid "Windows/DOS OEM Cyrillic (CP 866)"
 msgstr "Windows/DOS OEM cirílico (CP 866)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:111
+#: ../src/common/accelcmn.cpp:109
 #, fuzzy
 msgid "Windows_Left"
 msgstr "Windows 7"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:113
+#: ../src/common/accelcmn.cpp:111
 #, fuzzy
 msgid "Windows_Menu"
 msgstr "Windows ME"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:112
+#: ../src/common/accelcmn.cpp:110
 #, fuzzy
 msgid "Windows_Right"
 msgstr "Windows Vista"
 
-#: ../src/common/ffile.cpp:150
+#: ../src/common/ffile.cpp:149
 #, c-format
 msgid "Write error on file '%s'"
 msgstr "Erro de escritura no ficheiro '%s'"
 
-#: ../src/xml/xml.cpp:914
+#: ../src/xml/xml.cpp:925
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "Erro de análise de XML: '%s' na liña %d"
 
-#: ../src/common/xpmdecod.cpp:796
+#: ../src/common/xpmdecod.cpp:794
 msgid "XPM: Malformed pixel data!"
 msgstr "XPM: Datos de píxel incorrectos!"
 
-#: ../src/common/xpmdecod.cpp:705
+#: ../src/common/xpmdecod.cpp:702
 #, c-format
 msgid "XPM: incorrect colour description in line %d"
 msgstr "XPM: Descrición de cor incorrecta na liña %d"
 
-#: ../src/common/xpmdecod.cpp:680
+#: ../src/common/xpmdecod.cpp:677
 msgid "XPM: incorrect header format!"
 msgstr "XPM: formato de cabeceira incorrecto!"
 
-#: ../src/common/xpmdecod.cpp:716 ../src/common/xpmdecod.cpp:725
+#: ../src/common/xpmdecod.cpp:714 ../src/common/xpmdecod.cpp:723
 #, c-format
 msgid "XPM: malformed colour definition '%s' at line %d!"
 msgstr "XPM: Definición de cor '%s' incorrecta na liña %d!"
 
-#: ../src/common/xpmdecod.cpp:755
+#: ../src/common/xpmdecod.cpp:753
 msgid "XPM: no colors left to use for mask!"
 msgstr "XPM: non se deixaron cores para usar na máscara!"
 
-#: ../src/common/xpmdecod.cpp:782
+#: ../src/common/xpmdecod.cpp:780
 #, c-format
 msgid "XPM: truncated image data at line %d!"
 msgstr "XPM: datos de imaxe truncados na liña %d!"
 
-#: ../src/propgrid/advprops.cpp:1610
+#: ../src/propgrid/advprops.cpp:1516
 msgid "Yellow"
 msgstr ""
 
-#: ../include/wx/msgdlg.h:276 ../src/common/stockitem.cpp:206
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:203
 #: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Si"
 
-#: ../src/osx/carbon/overlay.cpp:155
-msgid "You cannot Clear an overlay that is not inited"
-msgstr "Non se pode eliminar unha superposición que non se iniciou"
-
-#: ../src/osx/carbon/overlay.cpp:107 ../src/dfb/overlay.cpp:61
-msgid "You cannot Init an overlay twice"
-msgstr "Non se pode iniciar unha superposición dúas veces"
-
-#: ../src/generic/dirdlgg.cpp:287
+#: ../src/generic/dirdlgg.cpp:284
 msgid "You cannot add a new directory to this section."
 msgstr "Non pode engadir un novo cartafol a esta sección."
 
-#: ../src/propgrid/propgrid.cpp:3299
+#: ../src/propgrid/propgrid.cpp:3276
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr "Introduciu un valor non válido. Pulse ESC para cacear a edición."
 
-#: ../src/common/stockitem.cpp:209
+#: ../src/osx/cocoa/menu.mm:286
+#, fuzzy
+msgid "Zoom"
+msgstr "Achegar"
+
+#: ../src/common/stockitem.cpp:206
 msgid "Zoom &In"
 msgstr "A&chegar"
 
-#: ../src/common/stockitem.cpp:210
+#: ../src/common/stockitem.cpp:207
 msgid "Zoom &Out"
 msgstr "A&fastar"
 
-#: ../src/common/stockitem.cpp:209 ../src/common/prntbase.cpp:1594
+#: ../src/common/stockitem.cpp:206 ../src/common/prntbase.cpp:1619
 msgid "Zoom In"
 msgstr "Achegar"
 
-#: ../src/common/stockitem.cpp:210 ../src/common/prntbase.cpp:1580
+#: ../src/common/stockitem.cpp:207 ../src/common/prntbase.cpp:1605
 msgid "Zoom Out"
 msgstr "Afastar"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to &Fit"
 msgstr "Axustar &zoom"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to Fit"
 msgstr "Axustar zoom"
 
-#: ../src/msw/dde.cpp:1141
+#: ../src/msw/dde.cpp:1205
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "un aplicativo DDEML creou unha situación de posíbel inconsistencia."
 
-#: ../src/msw/dde.cpp:1129
+#: ../src/msw/dde.cpp:1193
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -8080,39 +8267,39 @@ msgstr ""
 "ou un identificador de instancia incorrecto\n"
 "pasouse a unha función DDEML."
 
-#: ../src/msw/dde.cpp:1147
+#: ../src/msw/dde.cpp:1211
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "fallou o intento de estabelecemento de conversación dun cliente."
 
-#: ../src/msw/dde.cpp:1144
+#: ../src/msw/dde.cpp:1208
 msgid "a memory allocation failed."
 msgstr "erro ao asignar memoria."
 
-#: ../src/msw/dde.cpp:1138
+#: ../src/msw/dde.cpp:1202
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "erro ao validar un parámetro polo DDEML."
 
-#: ../src/msw/dde.cpp:1120
+#: ../src/msw/dde.cpp:1184
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "expirou unha solicitude de transacción síncrona de recomendación."
 
-#: ../src/msw/dde.cpp:1126
+#: ../src/msw/dde.cpp:1190
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "expirou unha solicitude de transacción síncrona de datos."
 
-#: ../src/msw/dde.cpp:1135
+#: ../src/msw/dde.cpp:1199
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "expirou unha solicitude de transacción de execución síncrona."
 
-#: ../src/msw/dde.cpp:1153
+#: ../src/msw/dde.cpp:1217
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "expirou unha solicitude de transacción síncrona de asignación."
 
-#: ../src/msw/dde.cpp:1168
+#: ../src/msw/dde.cpp:1232
 msgid "a request to end an advise transaction has timed out."
 msgstr "expirou unha solicitude de fin de transacción de aviso."
 
-#: ../src/msw/dde.cpp:1162
+#: ../src/msw/dde.cpp:1226
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -8122,15 +8309,15 @@ msgstr ""
 "que foi finalizada polo cliente, ou o servidor finalizou\n"
 "antes de completar a transacción."
 
-#: ../src/msw/dde.cpp:1150
+#: ../src/msw/dde.cpp:1214
 msgid "a transaction failed."
 msgstr "erro nunha transacción."
 
-#: ../src/common/accelcmn.cpp:189
+#: ../src/common/accelcmn.cpp:188
 msgid "alt"
 msgstr "alt"
 
-#: ../src/msw/dde.cpp:1132
+#: ../src/msw/dde.cpp:1196
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -8142,15 +8329,15 @@ msgstr ""
 "ou un aplicativo inicializado como APPCMD_CLIENTONLY tentou\n"
 "realizar transaccións de servidor."
 
-#: ../src/msw/dde.cpp:1156
+#: ../src/msw/dde.cpp:1220
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "erro nunha chamada interna á función PostMessage."
 
-#: ../src/msw/dde.cpp:1165
+#: ../src/msw/dde.cpp:1229
 msgid "an internal error has occurred in the DDEML."
 msgstr "ocorreu un erro interno no DDEML."
 
-#: ../src/msw/dde.cpp:1171
+#: ../src/msw/dde.cpp:1235
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -8160,56 +8347,56 @@ msgstr ""
 "Unha vez que o aplicativo volva dende unha chamada XTYP_XACT_COMPLETE,\n"
 "o identificador da transacción para esa chamada deixa de ser válido."
 
-#: ../src/common/zipstrm.cpp:1483
+#: ../src/common/zipstrm.cpp:1522
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "supoñendo que isto é un ficheiro zip con varias partes concatenadas"
 
-#: ../src/common/fileconf.cpp:1847
+#: ../src/common/fileconf.cpp:1849
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "intento de cambiar a clave inmutábel '%s', ignorado."
 
-#: ../src/html/chm.cpp:329
+#: ../src/html/chm.cpp:326
 msgid "bad arguments to library function"
 msgstr "argumentos incorrectos para a función de biblioteca"
 
-#: ../src/html/chm.cpp:341
+#: ../src/html/chm.cpp:338
 msgid "bad signature"
 msgstr "sinatura incorrecta"
 
-#: ../src/common/zipstrm.cpp:1918
+#: ../src/common/zipstrm.cpp:1988
 msgid "bad zipfile offset to entry"
 msgstr "desprazamento incorrecto de ficheiro zip á entrada"
 
-#: ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400
 msgid "binary"
 msgstr "binario"
 
-#: ../src/common/fontcmn.cpp:996
+#: ../src/common/fontcmn.cpp:1195
 msgid "bold"
 msgstr "grosa"
 
-#: ../src/msw/utils.cpp:1144
+#: ../src/msw/utils.cpp:1135
 #, c-format
 msgid "build %lu"
 msgstr "compilar %lu"
 
-#: ../src/common/ffile.cpp:75
+#: ../src/common/ffile.cpp:73
 #, c-format
 msgid "can't close file '%s'"
 msgstr "non se puido pechar o ficheiro '%s'"
 
-#: ../src/common/file.cpp:245
+#: ../src/common/file.cpp:242
 #, c-format
 msgid "can't close file descriptor %d"
 msgstr "non se pode pechar descritor de ficheiro %d"
 
-#: ../src/common/file.cpp:586
+#: ../src/common/ffile.cpp:382 ../src/common/file.cpp:613
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "non se poden remitir os cambios ao ficheiro '%s'"
 
-#: ../src/common/file.cpp:178
+#: ../src/common/file.cpp:175
 #, c-format
 msgid "can't create file '%s'"
 msgstr "non se puido crear o ficheiro '%s'"
@@ -8219,51 +8406,51 @@ msgstr "non se puido crear o ficheiro '%s'"
 msgid "can't delete user configuration file '%s'"
 msgstr "non se puido eliminar o ficheiro de configuración de usuario '%s'"
 
-#: ../src/common/file.cpp:495
+#: ../src/common/file.cpp:522
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr ""
 "non se pode determinar se se chegou ao final do ficheiro no descritor %d"
 
-#: ../src/common/zipstrm.cpp:1692
+#: ../src/common/zipstrm.cpp:1747
 msgid "can't find central directory in zip"
 msgstr "non é posíbel atopar o cartafol central en zip"
 
-#: ../src/common/file.cpp:465
+#: ../src/common/file.cpp:492
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "non se atopa lonxitude do ficheiro no descritor %d"
 
-#: ../src/msw/utils.cpp:341
+#: ../src/msw/utils.cpp:336
 msgid "can't find user's HOME, using current directory."
 msgstr ""
 "non se puido atopar o CARTAFOL INICIAL do usuario, usarase o cartafol actual."
 
-#: ../src/common/file.cpp:366
+#: ../src/common/file.cpp:407
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "non é posíbel baleirar o descritor de ficheiro %d"
 
-#: ../src/common/file.cpp:422
+#: ../src/common/file.cpp:463
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "non se pode atopar a posición do descritor de ficheiro %d"
 
-#: ../src/common/fontmap.cpp:325
+#: ../src/common/fontmap.cpp:322
 msgid "can't load any font, aborting"
 msgstr "non se pode cargar ningún tipo de letra, cancelando"
 
-#: ../src/common/file.cpp:231 ../src/common/ffile.cpp:59
+#: ../src/common/ffile.cpp:57 ../src/common/file.cpp:228
 #, c-format
 msgid "can't open file '%s'"
 msgstr "non se puido abrir o ficheiro '%s'"
 
-#: ../src/common/fileconf.cpp:320
+#: ../src/common/fileconf.cpp:314
 #, c-format
 msgid "can't open global configuration file '%s'."
 msgstr "non se puido abrir o ficheiro de configuración global '%s'."
 
-#: ../src/common/fileconf.cpp:336
+#: ../src/common/fileconf.cpp:330
 #, c-format
 msgid "can't open user configuration file '%s'."
 msgstr "non se puido abrir o ficheiro de configuración de usuario '%s'."
@@ -8272,40 +8459,40 @@ msgstr "non se puido abrir o ficheiro de configuración de usuario '%s'."
 msgid "can't open user configuration file."
 msgstr "non se puido abrir o ficheiro de configuración de usuario."
 
-#: ../src/common/zipstrm.cpp:579
+#: ../src/common/zipstrm.cpp:572
 msgid "can't re-initialize zlib deflate stream"
 msgstr "non é posíbel reinicializar o fluxo de compresión de zlib"
 
-#: ../src/common/zipstrm.cpp:604
+#: ../src/common/zipstrm.cpp:597
 msgid "can't re-initialize zlib inflate stream"
 msgstr "non é posíbel reinicializar o fluxo de descompresión de zlib"
 
-#: ../src/common/file.cpp:304
+#: ../src/common/file.cpp:345
 #, c-format
 msgid "can't read from file descriptor %d"
 msgstr "non é posíbel ler dende o descritor de ficheiro %d"
 
-#: ../src/common/file.cpp:581
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:608
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "non se puido eliminar o ficheiro '%s'"
 
-#: ../src/common/file.cpp:598
+#: ../src/common/ffile.cpp:394 ../src/common/file.cpp:625
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "non se puido eliminar o ficheiro temporal '%s'"
 
-#: ../src/common/file.cpp:408
+#: ../src/common/file.cpp:449
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "non é posíbel buscar no descritor de ficheiro %d"
 
-#: ../src/common/textfile.cpp:273
+#: ../src/common/textfile.cpp:161
 #, c-format
 msgid "can't write buffer '%s' to disk."
 msgstr "non se pode escribir o búfer '%s' no disco."
 
-#: ../src/common/file.cpp:323
+#: ../src/common/file.cpp:364
 #, c-format
 msgid "can't write to file descriptor %d"
 msgstr "non é posíbel escribir no descritor de ficheiro %d"
@@ -8315,22 +8502,28 @@ msgid "can't write user configuration file."
 msgstr "non se puido escribir o ficheiro de configuración do usuario."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:482 ../src/generic/datavgen.cpp:1261
+#: ../src/common/datavcmn.cpp:2064 ../src/generic/datavgen.cpp:1384
 msgid "checked"
 msgstr ""
 
-#: ../src/html/chm.cpp:345
+#: ../src/html/chm.cpp:342
 msgid "checksum error"
 msgstr "erro na suma de verificación"
 
-#: ../src/common/tarstrm.cpp:820
+#: ../src/common/tarstrm.cpp:814
 msgid "checksum failure reading tar header block"
 msgstr "erro na suma de comprobación ao ler o bloque de cabeceira de tar"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:226
-#: ../src/richtext/richtextbackgroundpage.cpp:249
-#: ../src/richtext/richtextbackgroundpage.cpp:289
-#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
 #: ../src/richtext/richtextborderspage.cpp:254
 #: ../src/richtext/richtextborderspage.cpp:288
 #: ../src/richtext/richtextborderspage.cpp:322
@@ -8348,105 +8541,128 @@ msgstr "erro na suma de comprobación ao ler o bloque de cabeceira de tar"
 #: ../src/richtext/richtextmarginspage.cpp:340
 #: ../src/richtext/richtextmarginspage.cpp:363
 #: ../src/richtext/richtextmarginspage.cpp:388
-#: ../src/richtext/richtextsizepage.cpp:339
-#: ../src/richtext/richtextsizepage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:400
-#: ../src/richtext/richtextsizepage.cpp:427
-#: ../src/richtext/richtextsizepage.cpp:454
-#: ../src/richtext/richtextsizepage.cpp:481
-#: ../src/richtext/richtextsizepage.cpp:555
-#: ../src/richtext/richtextsizepage.cpp:590
-#: ../src/richtext/richtextsizepage.cpp:625
-#: ../src/richtext/richtextsizepage.cpp:660
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
 msgid "cm"
 msgstr "cm"
 
-#: ../src/html/chm.cpp:347
+#: ../src/html/chm.cpp:344
 msgid "compression error"
 msgstr "erro de compresión"
 
-#: ../src/common/regex.cpp:236
+#: ../src/common/regex.cpp:233
 msgid "conversion to 8-bit encoding failed"
 msgstr "fallou a conversión á codificación de 8 bits"
 
-#: ../src/common/accelcmn.cpp:187
+#: ../src/common/accelcmn.cpp:186
 msgid "ctrl"
 msgstr "ctrl"
 
-#: ../src/common/cmdline.cpp:1500
+#: ../src/common/cmdline.cpp:1496
 msgid "date"
 msgstr "data"
 
-#: ../src/html/chm.cpp:349
+#: ../src/html/chm.cpp:346
 msgid "decompression error"
 msgstr "erro de descompresión"
 
-#: ../src/richtext/richtextstyles.cpp:780 ../src/common/fmapbase.cpp:820
+#: ../src/common/fmapbase.cpp:816 ../src/richtext/richtextstyles.cpp:777
 msgid "default"
 msgstr "predeterminado"
 
-#: ../src/common/cmdline.cpp:1496
+#: ../src/common/cmdline.cpp:1492
 msgid "double"
 msgstr "dobre"
 
-#: ../src/common/debugrpt.cpp:538
+#: ../src/common/debugrpt.cpp:539
 msgid "dump of the process state (binary)"
 msgstr "envorcado do estado do proceso (binario)"
 
-#: ../src/common/datetimefmt.cpp:1969
+#: ../src/common/datetimefmt.cpp:1992
 msgid "eighteenth"
 msgstr "décimo oitavo"
 
-#: ../src/common/datetimefmt.cpp:1959
+#: ../src/common/datetimefmt.cpp:1982
 msgid "eighth"
 msgstr "oitavo"
 
-#: ../src/common/datetimefmt.cpp:1962
+#: ../src/common/datetimefmt.cpp:1985
 msgid "eleventh"
 msgstr "décimo primeiro"
 
-#: ../src/common/fileconf.cpp:1833
+#: ../src/common/fileconf.cpp:1835
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "a entrada '%s' aparece máis de unha vez no grupo '%s'"
 
-#: ../src/html/chm.cpp:343
+#: ../src/html/chm.cpp:340
 msgid "error in data format"
 msgstr "erro no formato dos datos"
 
-#: ../src/html/chm.cpp:331
+#: ../src/html/chm.cpp:328
 msgid "error opening file"
 msgstr "erro ao abrir o ficheiro"
 
-#: ../src/common/zipstrm.cpp:1778
+#: ../src/common/zipstrm.cpp:1836
 msgid "error reading zip central directory"
 msgstr "erro ao ler o cartafol central de zip"
 
-#: ../src/common/zipstrm.cpp:1870
+#: ../src/common/zipstrm.cpp:1940
 msgid "error reading zip local header"
 msgstr "erro ao ler a cabeceira local de zip"
 
-#: ../src/common/zipstrm.cpp:2531
+#: ../src/common/zipstrm.cpp:2615
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "erro ao escribir a entrada de zip '%s': crc ou lonxitude incorrectos"
 
-#: ../src/common/ffile.cpp:188
+#: ../src/common/zipstrm.cpp:2608
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "erro ao escribir a entrada de zip '%s': crc ou lonxitude incorrectos"
+
+#: ../src/common/fontcmn.cpp:1205
+#, fuzzy
+msgid "extrabold"
+msgstr "grosa"
+
+#: ../src/common/fontcmn.cpp:1223
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1167
+#, fuzzy
+msgid "extralight"
+msgstr "clara"
+
+#: ../src/msw/webview_ie.cpp:1036
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "Erro ao executar '%s'\n"
+
+#: ../src/common/ffile.cpp:187
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "erro ao baleirar a memoria do ficheiro '%s'"
 
+#: ../src/msw/webview_ie.cpp:1045
+#, fuzzy
+msgid "failed to retrieve execution result"
+msgstr "Erro ao recuperar texto de mensaxe de erro RAS"
+
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1030
+#: ../src/generic/datavgen.cpp:1150
 #, fuzzy
 msgid "false"
 msgstr "Falso"
 
-#: ../src/common/datetimefmt.cpp:1966
+#: ../src/common/datetimefmt.cpp:1989
 msgid "fifteenth"
 msgstr "décimo quinto"
 
-#: ../src/common/datetimefmt.cpp:1956
+#: ../src/common/datetimefmt.cpp:1979
 msgid "fifth"
 msgstr "quinto"
 
@@ -8476,132 +8692,151 @@ msgstr "ficheiro '%s', liña %d: valor para clave inmutábel '%s' ignorado."
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "ficheiro '%s': caracter inesperado %c na liña %d."
 
-#: ../src/richtext/richtextbuffer.cpp:8738
+#: ../src/richtext/richtextbuffer.cpp:8736
 msgid "files"
 msgstr "ficheiros"
 
-#: ../src/common/datetimefmt.cpp:1952
+#: ../src/common/datetimefmt.cpp:1975
 msgid "first"
 msgstr "primeiro"
 
-#: ../src/html/helpwnd.cpp:1252
+#: ../src/html/helpwnd.cpp:1250
 msgid "font size"
 msgstr "tamaño de letra"
 
-#: ../src/common/datetimefmt.cpp:1965
+#: ../src/common/datetimefmt.cpp:1988
 msgid "fourteenth"
 msgstr "décimo cuarto"
 
-#: ../src/common/datetimefmt.cpp:1955
+#: ../src/common/datetimefmt.cpp:1978
 msgid "fourth"
 msgstr "cuarto"
 
-#: ../src/common/appbase.cpp:783
+#: ../src/common/appbase.cpp:784
 msgid "generate verbose log messages"
 msgstr "xerar mensaxes de rexistro detalladas"
 
-#: ../src/richtext/richtextbuffer.cpp:13138
-#: ../src/richtext/richtextbuffer.cpp:13248
+#: ../src/common/fontcmn.cpp:1215
+msgid "heavy"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:13133
+#: ../src/richtext/richtextbuffer.cpp:13243
 msgid "image"
 msgstr "imaxe"
 
-#: ../src/common/tarstrm.cpp:796
+#: ../src/common/tarstrm.cpp:790
 msgid "incomplete header block in tar"
 msgstr "bloque de cabeceira incompleto en tar"
 
-#: ../src/common/xtixml.cpp:489
+#: ../src/common/xtixml.cpp:485
 msgid "incorrect event handler string, missing dot"
 msgstr "cadea manexadora de evento incorrecta, falta o punto"
 
-#: ../src/common/tarstrm.cpp:1381
+#: ../src/common/tarstrm.cpp:1375
 msgid "incorrect size given for tar entry"
 msgstr "tamaño de entrada tar incorrecto"
 
-#: ../src/common/tarstrm.cpp:993
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:987
 msgid "invalid data in extended tar header"
 msgstr "datos incorrectos na cabeceira extendida de tar"
 
-#: ../src/generic/logg.cpp:1030
+#: ../src/generic/logg.cpp:1027
 msgid "invalid message box return value"
 msgstr "valor de retorno incorrecto da caixa de correo"
 
-#: ../src/common/zipstrm.cpp:1647
+#: ../src/common/zipstrm.cpp:1688
 msgid "invalid zip file"
 msgstr "ficheiro zip incorrecto"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:1228
 msgid "italic"
 msgstr "cursiva"
 
-#: ../src/common/fontcmn.cpp:991
+#: ../src/common/webrequest_curl.cpp:374
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "Non se puido inicializar a descrición da columna."
+
+#: ../src/common/fontcmn.cpp:1172
 msgid "light"
 msgstr "clara"
 
-#: ../src/common/intl.cpp:303
-#, c-format
-msgid "locale '%s' cannot be set."
-msgstr "non se pode estabelecer configuración rexional '%s'."
+#: ../src/common/fontcmn.cpp:1185
+msgid "medium"
+msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2125
+#: ../src/common/datetimefmt.cpp:2148
 msgid "midnight"
 msgstr "media noite"
 
-#: ../src/common/datetimefmt.cpp:1970
+#: ../src/common/datetimefmt.cpp:1993
 msgid "nineteenth"
 msgstr "décimo noveno"
 
-#: ../src/common/datetimefmt.cpp:1960
+#: ../src/common/datetimefmt.cpp:1983
 msgid "ninth"
 msgstr "noveno"
 
-#: ../src/msw/dde.cpp:1116
+#: ../src/msw/dde.cpp:1180
 msgid "no DDE error."
 msgstr "non hai erro DDE."
 
-#: ../src/html/chm.cpp:327
+#: ../src/html/chm.cpp:324
 msgid "no error"
 msgstr "sen erros"
 
-#: ../src/dfb/fontmgr.cpp:174
+#: ../src/dfb/fontmgr.cpp:171
 #, c-format
 msgid "no fonts found in %s, using builtin font"
 msgstr ""
 "non se atoparon tipos de letra en %s, utilizarase un tipo de letra integrado"
 
-#: ../src/html/helpdata.cpp:657
+#: ../src/html/helpdata.cpp:650
 msgid "noname"
 msgstr "sen nome"
 
-#: ../src/common/datetimefmt.cpp:2124
+#: ../src/common/datetimefmt.cpp:2147
 msgid "noon"
 msgstr "mediodía"
 
-#: ../src/richtext/richtextstyles.cpp:779
+#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "normal"
 
-#: ../src/common/cmdline.cpp:1492
+#: ../src/common/cmdline.cpp:1488
 msgid "num"
 msgstr "núm"
 
-#: ../src/common/xtixml.cpp:259
+#: ../src/common/accelcmn.cpp:194
+msgid "num "
+msgstr ""
+
+#: ../src/common/xtixml.cpp:255
 msgid "objects cannot have XML Text Nodes"
 msgstr "os obxectos non poden ter nodos de texto XML"
 
-#: ../src/html/chm.cpp:339
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
 msgid "out of memory"
 msgstr "sen memoria"
 
-#: ../src/common/debugrpt.cpp:514
+#: ../src/common/debugrpt.cpp:515
 msgid "process context description"
 msgstr "descrición do contexto do proceso"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:227
-#: ../src/richtext/richtextbackgroundpage.cpp:250
-#: ../src/richtext/richtextbackgroundpage.cpp:290
-#: ../src/richtext/richtextbackgroundpage.cpp:317
-#: ../src/richtext/richtextfontpage.cpp:177
-#: ../src/richtext/richtextfontpage.cpp:180
 #: ../src/richtext/richtextborderspage.cpp:255
 #: ../src/richtext/richtextborderspage.cpp:289
 #: ../src/richtext/richtextborderspage.cpp:323
@@ -8611,22 +8846,45 @@ msgstr "descrición do contexto do proceso"
 #: ../src/richtext/richtextborderspage.cpp:491
 #: ../src/richtext/richtextborderspage.cpp:525
 #: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextfontpage.cpp:180
 msgid "pt"
 msgstr "pt"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:225
-#: ../src/richtext/richtextbackgroundpage.cpp:228
-#: ../src/richtext/richtextbackgroundpage.cpp:229
-#: ../src/richtext/richtextbackgroundpage.cpp:248
-#: ../src/richtext/richtextbackgroundpage.cpp:251
-#: ../src/richtext/richtextbackgroundpage.cpp:252
-#: ../src/richtext/richtextbackgroundpage.cpp:288
-#: ../src/richtext/richtextbackgroundpage.cpp:291
-#: ../src/richtext/richtextbackgroundpage.cpp:292
-#: ../src/richtext/richtextbackgroundpage.cpp:315
-#: ../src/richtext/richtextbackgroundpage.cpp:318
-#: ../src/richtext/richtextbackgroundpage.cpp:319
-#: ../src/richtext/richtextfontpage.cpp:178
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:659
+#: ../src/richtext/richtextsizepage.cpp:662
+#: ../src/richtext/richtextsizepage.cpp:663
 #: ../src/richtext/richtextborderspage.cpp:253
 #: ../src/richtext/richtextborderspage.cpp:256
 #: ../src/richtext/richtextborderspage.cpp:257
@@ -8678,260 +8936,270 @@ msgstr "pt"
 #: ../src/richtext/richtextmarginspage.cpp:387
 #: ../src/richtext/richtextmarginspage.cpp:389
 #: ../src/richtext/richtextmarginspage.cpp:390
-#: ../src/richtext/richtextsizepage.cpp:338
-#: ../src/richtext/richtextsizepage.cpp:341
-#: ../src/richtext/richtextsizepage.cpp:342
-#: ../src/richtext/richtextsizepage.cpp:372
-#: ../src/richtext/richtextsizepage.cpp:375
-#: ../src/richtext/richtextsizepage.cpp:376
-#: ../src/richtext/richtextsizepage.cpp:399
-#: ../src/richtext/richtextsizepage.cpp:402
-#: ../src/richtext/richtextsizepage.cpp:403
-#: ../src/richtext/richtextsizepage.cpp:426
-#: ../src/richtext/richtextsizepage.cpp:429
-#: ../src/richtext/richtextsizepage.cpp:430
-#: ../src/richtext/richtextsizepage.cpp:453
-#: ../src/richtext/richtextsizepage.cpp:456
-#: ../src/richtext/richtextsizepage.cpp:457
-#: ../src/richtext/richtextsizepage.cpp:480
-#: ../src/richtext/richtextsizepage.cpp:483
-#: ../src/richtext/richtextsizepage.cpp:484
-#: ../src/richtext/richtextsizepage.cpp:554
-#: ../src/richtext/richtextsizepage.cpp:557
-#: ../src/richtext/richtextsizepage.cpp:558
-#: ../src/richtext/richtextsizepage.cpp:589
-#: ../src/richtext/richtextsizepage.cpp:592
-#: ../src/richtext/richtextsizepage.cpp:593
-#: ../src/richtext/richtextsizepage.cpp:624
-#: ../src/richtext/richtextsizepage.cpp:627
-#: ../src/richtext/richtextsizepage.cpp:628
-#: ../src/richtext/richtextsizepage.cpp:659
-#: ../src/richtext/richtextsizepage.cpp:662
-#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextfontpage.cpp:178
 msgid "px"
 msgstr "px"
 
-#: ../src/common/accelcmn.cpp:193
+#: ../src/common/accelcmn.cpp:192
 msgid "rawctrl"
 msgstr "ctrl"
 
-#: ../src/html/chm.cpp:333
+#: ../src/html/chm.cpp:330
 msgid "read error"
 msgstr "erro de lectura"
 
-#: ../src/common/zipstrm.cpp:2085
+#: ../src/common/zipstrm.cpp:2155
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "lendo o fluxo de zip (entrada %s): crc incorrecto"
 
-#: ../src/common/zipstrm.cpp:2080
+#: ../src/common/zipstrm.cpp:2150
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "lendo o fluxo de zip (entrada %s): lonxitude incorrecta"
 
-#: ../src/msw/dde.cpp:1159
+#: ../src/msw/dde.cpp:1223
 msgid "reentrancy problem."
 msgstr "problema de reentrada."
 
-#: ../src/common/datetimefmt.cpp:1953
+#: ../src/common/datetimefmt.cpp:1976
 msgid "second"
 msgstr "segundo"
 
-#: ../src/html/chm.cpp:337
+#: ../src/html/chm.cpp:334
 msgid "seek error"
 msgstr "erro de busca"
 
-#: ../src/common/datetimefmt.cpp:1968
+#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#, fuzzy
+msgid "semibold"
+msgstr "grosa"
+
+#: ../src/common/datetimefmt.cpp:1991
 msgid "seventeenth"
 msgstr "décimo sétimo"
 
-#: ../src/common/datetimefmt.cpp:1958
+#: ../src/common/datetimefmt.cpp:1981
 msgid "seventh"
 msgstr "sétimo"
 
-#: ../src/common/accelcmn.cpp:191
+#: ../src/common/accelcmn.cpp:190
 msgid "shift"
 msgstr "maiús."
 
-#: ../src/common/appbase.cpp:773
+#: ../src/common/appbase.cpp:774
 msgid "show this help message"
 msgstr "amosar esta mensaxe de axuda"
 
-#: ../src/common/datetimefmt.cpp:1967
+#: ../src/common/datetimefmt.cpp:1990
 msgid "sixteenth"
 msgstr "décimo sexto"
 
-#: ../src/common/datetimefmt.cpp:1957
+#: ../src/common/datetimefmt.cpp:1980
 msgid "sixth"
 msgstr "sexto"
 
-#: ../src/common/appcmn.cpp:234
+#: ../src/common/appcmn.cpp:255
 msgid "specify display mode to use (e.g. 640x480-16)"
 msgstr "especifique a resolución da pantalla (ex.: 640x480-16)"
 
-#: ../src/common/appcmn.cpp:220
+#: ../src/common/appcmn.cpp:241
 msgid "specify the theme to use"
 msgstr "especifique o tema que vai usar"
 
-#: ../src/richtext/richtextbuffer.cpp:9340
+#: ../src/richtext/richtextbuffer.cpp:9337
 msgid "standard/circle"
 msgstr "estándar/círculo"
 
-#: ../src/richtext/richtextbuffer.cpp:9341
+#: ../src/richtext/richtextbuffer.cpp:9338
 msgid "standard/circle-outline"
 msgstr "estándar/contorno circular"
 
-#: ../src/richtext/richtextbuffer.cpp:9343
+#: ../src/richtext/richtextbuffer.cpp:9340
 msgid "standard/diamond"
 msgstr "estándar/rombo"
 
-#: ../src/richtext/richtextbuffer.cpp:9342
+#: ../src/richtext/richtextbuffer.cpp:9339
 msgid "standard/square"
 msgstr "estándar/cadrado"
 
-#: ../src/richtext/richtextbuffer.cpp:9344
+#: ../src/richtext/richtextbuffer.cpp:9341
 msgid "standard/triangle"
 msgstr "estándar/triángulo"
 
-#: ../src/common/zipstrm.cpp:1985
+#: ../src/common/zipstrm.cpp:2055
 msgid "stored file length not in Zip header"
 msgstr "a lonxitude do ficheiro almacenado non está na cabeceira de zip"
 
-#: ../src/common/cmdline.cpp:1488
+#: ../src/common/cmdline.cpp:1484
 msgid "str"
 msgstr "cadea"
 
-#: ../src/common/fontcmn.cpp:982
+#: ../src/common/fontcmn.cpp:1145
 msgid "strikethrough"
 msgstr "riscado"
 
-#: ../src/common/tarstrm.cpp:1003 ../src/common/tarstrm.cpp:1025
-#: ../src/common/tarstrm.cpp:1507 ../src/common/tarstrm.cpp:1529
+#: ../src/common/tarstrm.cpp:997 ../src/common/tarstrm.cpp:1019
+#: ../src/common/tarstrm.cpp:1501 ../src/common/tarstrm.cpp:1523
 msgid "tar entry not open"
 msgstr "non se abríu a entrada tar"
 
-#: ../src/common/datetimefmt.cpp:1961
+#: ../src/common/datetimefmt.cpp:1984
 msgid "tenth"
 msgstr "décimo"
 
-#: ../src/msw/dde.cpp:1123
+#: ../src/msw/dde.cpp:1187
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "a resposta á transacción causou que se activase o bit de DDE_FBUSY."
 
-#: ../src/common/datetimefmt.cpp:1954
+#: ../src/common/fontcmn.cpp:1154
+msgid "thin"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:1977
 msgid "third"
 msgstr "terceiro"
 
-#: ../src/common/datetimefmt.cpp:1964
+#: ../src/common/datetimefmt.cpp:1987
 msgid "thirteenth"
 msgstr "décimo terceiro"
 
-#: ../src/common/datetimefmt.cpp:1758
+#: ../src/common/datetimefmt.cpp:1781
 msgid "today"
 msgstr "hoxe"
 
-#: ../src/common/datetimefmt.cpp:1760
+#: ../src/common/datetimefmt.cpp:1783
 msgid "tomorrow"
 msgstr "mañá"
 
-#: ../src/common/fileconf.cpp:1944
+#: ../src/common/fileconf.cpp:1946
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "ignorouse a barra invertida sobrante en '%s'"
 
-#: ../src/gtk/aboutdlg.cpp:218
+#: ../src/gtk/aboutdlg.cpp:216
 msgid "translator-credits"
 msgstr "traducción - créditos"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1028
+#: ../src/generic/datavgen.cpp:1148
 msgid "true"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1963
+#: ../src/common/datetimefmt.cpp:1986
 msgid "twelfth"
 msgstr "décimo segundo"
 
-#: ../src/common/datetimefmt.cpp:1971
+#: ../src/common/datetimefmt.cpp:1994
 msgid "twentieth"
 msgstr "vixésimo"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:486 ../src/generic/datavgen.cpp:1263
+#: ../src/common/datavcmn.cpp:2068 ../src/generic/datavgen.cpp:1386
 msgid "unchecked"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:802 ../src/common/fontcmn.cpp:978
+#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
 msgid "underlined"
 msgstr "subliñado"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:490
+#: ../src/common/datavcmn.cpp:2072
 #, fuzzy
 msgid "undetermined"
 msgstr "subliñado"
 
-#: ../src/common/fileconf.cpp:1979
+#: ../src/common/fileconf.cpp:1981
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "\" inesperado na posición %d en '%s'."
 
-#: ../src/common/tarstrm.cpp:1045
+#: ../src/common/tarstrm.cpp:1039
 msgid "unexpected end of file"
 msgstr "fin de ficheiro inesperado"
 
-#: ../src/generic/progdlgg.cpp:370 ../src/common/tarstrm.cpp:371
-#: ../src/common/tarstrm.cpp:394 ../src/common/tarstrm.cpp:425
+#: ../src/common/tarstrm.cpp:366 ../src/common/tarstrm.cpp:389
+#: ../src/common/tarstrm.cpp:420 ../src/generic/progdlgg.cpp:376
 msgid "unknown"
 msgstr "descoñecido"
 
-#: ../src/msw/registry.cpp:150
+#: ../src/msw/registry.cpp:139
 #, fuzzy, c-format
 msgid "unknown (%lu)"
 msgstr "descoñecido"
 
-#: ../src/common/xtixml.cpp:253
+#: ../src/common/xtixml.cpp:249
 #, c-format
 msgid "unknown class %s"
 msgstr "clase %s descoñecida"
 
-#: ../src/common/regex.cpp:258 ../src/html/chm.cpp:351
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "erro de compresión"
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "erro de descompresión"
+
+#: ../src/common/regex.cpp:255 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "erro descoñecido"
 
-#: ../src/msw/dialup.cpp:471
+#: ../src/msw/dialup.cpp:465
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "erro descoñecido (código de erro %08x)."
 
-#: ../src/common/fmapbase.cpp:834
+#: ../src/common/fmapbase.cpp:830
 #, c-format
 msgid "unknown-%d"
 msgstr "descoñecido-%d"
 
-#: ../src/common/docview.cpp:509
+#: ../src/common/docview.cpp:502
 msgid "unnamed"
 msgstr "sen nome"
 
-#: ../src/common/docview.cpp:1624
+#: ../src/common/docview.cpp:1618
 #, c-format
 msgid "unnamed%d"
 msgstr "sen nome%d"
 
-#: ../src/common/zipstrm.cpp:1999 ../src/common/zipstrm.cpp:2319
+#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
 msgid "unsupported Zip compression method"
 msgstr "método de compresión Zip non compatíbel"
 
-#: ../src/common/translation.cpp:1892
+#: ../src/common/translation.cpp:1942
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "empregando catálogo '%s' de '%s'."
 
-#: ../src/html/chm.cpp:335
+#: ../src/html/chm.cpp:332
 msgid "write error"
 msgstr "erro de escritura"
 
-#: ../src/common/time.cpp:292
+#: ../src/gtk/glcanvas.cpp:187
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/common/time.cpp:285
 msgid "wxGetTimeOfDay failed."
 msgstr "Fallou wxGetTimeOfDay."
 
@@ -8944,15 +9212,15 @@ msgstr "wxWidgets non puido abrir a visualización para '%s': saíndo."
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets non puido abrir a visualización. Saíndo."
 
-#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:431
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/common/datetimefmt.cpp:1759
+#: ../src/common/datetimefmt.cpp:1782
 msgid "yesterday"
 msgstr "onte"
 
-#: ../src/common/zstream.cpp:251 ../src/common/zstream.cpp:426
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
 #, c-format
 msgid "zlib error %d"
 msgstr "erro de zlib %d"
@@ -8961,6 +9229,77 @@ msgstr "erro de zlib %d"
 #: ../src/richtext/richtextbulletspage.cpp:288
 msgid "~"
 msgstr "~"
+
+#~ msgid "&Save as"
+#~ msgstr "Gardar &como"
+
+#, fuzzy
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' debe conter só caracteres alfabéticos."
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' debe ser numérico."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' debe conter só caracteres ASCII."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' debe conter só caracteres alfabéticos."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' debe conter só caracteres alfanuméricos."
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' debe conter díxitos unicamente."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "Non se puido crear unha xanela de clase %s"
+
+#, fuzzy
+#~ msgid "Could not initalize libnotify."
+#~ msgstr "Non se puido estabelecer o aliñamento."
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "Non se puido crear a xanela de superposición"
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "Non se puido inicializar o contexto na xanela superposta"
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "Erro ao converter ficheiro \"%s\" a Unicode."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "Non se puido fixar texto no control de texto."
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr "Opción de liña de comando de GTK+ incorrecta, utilice \"%s --help\""
+
+#~ msgid "No unused colour in image."
+#~ msgstr "Non hai cores sen usar na imaxe."
+
+#~ msgid "Not available"
+#~ msgstr "Non está dispoñíbel"
+
+#~ msgid "Replace selection"
+#~ msgstr "Substituír selección"
+
+#~ msgid "Save as"
+#~ msgstr "Gardar como"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Organizador de estilos"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "As seguintes opcións do estándar GTK+ tamén se admiten:\n"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "Non se pode eliminar unha superposición que non se iniciou"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "Non se pode iniciar unha superposición dúas veces"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "non se pode estabelecer configuración rexional '%s'."
 
 #~ msgid "Adding flavor TEXT failed"
 #~ msgstr "Erro ao engadir decoración de TEXT"
@@ -8978,9 +9317,6 @@ msgstr "~"
 
 #~ msgid "Column could not be added."
 #~ msgstr "Non se puido engadir a columna."
-
-#~ msgid "Column description could not be initialized."
-#~ msgstr "Non se puido inicializar a descrición da columna."
 
 #~ msgid "Column index not found."
 #~ msgstr "Índece de columnas non atopado."
@@ -9537,9 +9873,6 @@ msgstr "~"
 #~ msgid "Directory '%s' doesn't exist!"
 #~ msgstr "O directorio '%s' non existe!"
 
-#~ msgid "File %s does not exist."
-#~ msgstr "O ficheiro %s non existe."
-
 #, fuzzy
 #~ msgid "Mode %ix%i-%i not available."
 #~ msgstr "Modo %ix%i-%i no disponible."
@@ -9628,9 +9961,6 @@ msgstr "~"
 #, fuzzy
 #~ msgid "Failed to register OpenGL window class."
 #~ msgstr "Fallo al registrar la clase de ventana OpenGL."
-
-#~ msgid "Fatal error"
-#~ msgstr "Erro moi grave"
 
 #~ msgid "Fatal error: "
 #~ msgstr "Erro moi grave: "
@@ -9818,9 +10148,6 @@ msgstr "~"
 
 #~ msgid "&Print"
 #~ msgstr "&Imprimir"
-
-#~ msgid "*** A debug report has been generated\n"
-#~ msgstr "*** Xerouse un informe de depuración\n"
 
 #~ msgid "*** It can be found in \"%s\"\n"
 #~ msgstr "*** Pode atoparse en \"%s\"\n"

--- a/locale/hi.po
+++ b/locale/hi.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-21 14:25+0200\n"
+"POT-Creation-Date: 2020-10-18 23:11+0300\n"
 "PO-Revision-Date: 2008-07-28 23:09+0530\n"
 "Last-Translator: Priyank Bolia <priyank.bolia@gmail.com>\n"
 "Language-Team: हिन्दी (Hindi) <dysxhi@yahoo.co.in>\n"
@@ -20,7 +20,7 @@ msgstr ""
 "X-Poedit-Language: Hindi\n"
 "X-Poedit-Country: INDIA\n"
 
-#: ../src/common/debugrpt.cpp:586
+#: ../src/common/debugrpt.cpp:587
 msgid ""
 "\n"
 "Please send this report to the program maintainer, thank you!\n"
@@ -28,8 +28,8 @@ msgstr ""
 "\n"
 "आपका धन्यवाद, कृपया इस विवरण को प्रोग्राम संरक्षक को भेजे।\n"
 
-#: ../src/richtext/richtextstyledlg.cpp:210
-#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:206
+#: ../src/richtext/richtextstyledlg.cpp:218
 msgid " "
 msgstr " "
 
@@ -37,71 +37,97 @@ msgstr " "
 msgid "              Thank you and we're sorry for the inconvenience!\n"
 msgstr "              आपका धन्यवाद, कृपया असुविधा के लिए क्षमा करें।\n"
 
-#: ../src/common/prntbase.cpp:573
+#: ../src/common/prntbase.cpp:568
 #, fuzzy, c-format
 msgid " (copy %d of %d)"
 msgstr "पृष्ट %d / %d"
 
-#: ../src/common/log.cpp:421
+#: ../src/common/log.cpp:440
 #, c-format
 msgid " (error %ld: %s)"
 msgstr "(त्रुटि %ld: %s)"
 
-#: ../src/common/imagtiff.cpp:72
+#: ../src/common/imagtiff.cpp:69
 #, fuzzy, c-format
 msgid " (in module \"%s\")"
 msgstr "टिफ़्फ़ माड्यूल: %s"
 
-#: ../src/osx/core/secretstore.cpp:138
-msgid " (while overwriting an existing item)"
-msgstr ""
-
-#: ../src/common/docview.cpp:1642
+#: ../src/common/docview.cpp:1636
 msgid " - "
 msgstr " - "
 
-#: ../src/richtext/richtextprint.cpp:593 ../src/html/htmprint.cpp:714
+#: ../src/html/htmprint.cpp:712 ../src/richtext/richtextprint.cpp:589
 msgid " Preview"
 msgstr " पूर्वालोकन"
 
-#: ../src/common/fontcmn.cpp:824
+#: ../src/common/fontcmn.cpp:973
 msgid " bold"
 msgstr "गहरा"
 
-#: ../src/common/fontcmn.cpp:840
+#: ../src/common/fontcmn.cpp:977
+#, fuzzy
+msgid " extra bold"
+msgstr "गहरा"
+
+#: ../src/common/fontcmn.cpp:985
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:957
+#, fuzzy
+msgid " extra light"
+msgstr "हल्का"
+
+#: ../src/common/fontcmn.cpp:981
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1001
 msgid " italic"
 msgstr "तिरछा"
 
-#: ../src/common/fontcmn.cpp:820
+#: ../src/common/fontcmn.cpp:961
 msgid " light"
 msgstr "हल्का"
 
-#: ../src/common/fontcmn.cpp:807
+#: ../src/common/fontcmn.cpp:965
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:969
+#, fuzzy
+msgid " semi bold"
+msgstr "गहरा"
+
+#: ../src/common/fontcmn.cpp:940
 #, fuzzy
 msgid " strikethrough"
 msgstr " स्ट्राइक थुःरु"
 
-#: ../src/common/paper.cpp:117
+#: ../src/common/fontcmn.cpp:953
+msgid " thin"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
 msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
 msgstr "#१० लिफ़ाफ़ा, ४ १/८ x 9 1/2 इंच"
 
-#: ../src/common/paper.cpp:118
+#: ../src/common/paper.cpp:115
 msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
 msgstr "#११ लिफ़ाफ़ा, ४ १/२ x १० ३/८ इंच"
 
-#: ../src/common/paper.cpp:119
+#: ../src/common/paper.cpp:116
 msgid "#12 Envelope, 4 3/4 x 11 in"
 msgstr "#१२ लिफ़ाफ़ा, ४ ३/४ x ११ इंच"
 
-#: ../src/common/paper.cpp:120
+#: ../src/common/paper.cpp:117
 msgid "#14 Envelope, 5 x 11 1/2 in"
 msgstr "#१४ लिफ़ाफ़ा, ५ x ११ 1/2 इंच"
 
-#: ../src/common/paper.cpp:116
+#: ../src/common/paper.cpp:113
 msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
 msgstr "#९ लिफ़ाफ़ा, ३ ७/८ x ८ ७/८ इंच"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:341
 #: ../src/richtext/richtextsizepage.cpp:340
 #: ../src/richtext/richtextsizepage.cpp:374
 #: ../src/richtext/richtextsizepage.cpp:401
@@ -112,81 +138,82 @@ msgstr "#९ लिफ़ाफ़ा, ३ ७/८ x ८ ७/८ इंच"
 #: ../src/richtext/richtextsizepage.cpp:591
 #: ../src/richtext/richtextsizepage.cpp:626
 #: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextbackgroundpage.cpp:341
 msgid "%"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1031
+#: ../src/html/helpwnd.cpp:1029
 #, fuzzy, c-format
 msgid "%d of %lu"
 msgstr "%i का %i"
 
-#: ../src/html/helpwnd.cpp:1678
+#: ../src/html/helpwnd.cpp:1676
 #, fuzzy, c-format
 msgid "%i of %u"
 msgstr "%i का %i"
 
-#: ../src/generic/filectrlg.cpp:279
+#: ../src/generic/filectrlg.cpp:275
 #, c-format
 msgid "%ld byte"
 msgid_plural "%ld bytes"
 msgstr[0] "%ld बाईट"
 msgstr[1] "%ld बाईट्स"
 
-#: ../src/html/helpwnd.cpp:1033
+#: ../src/html/helpwnd.cpp:1031
 #, fuzzy, c-format
 msgid "%lu of %lu"
 msgstr "%i का %i"
 
-#: ../src/generic/datavgen.cpp:6028
+#: ../src/generic/datavgen.cpp:6833
 #, fuzzy, c-format
 msgid "%s (%d items)"
 msgstr "%s (या %s)"
 
-#: ../src/common/cmdline.cpp:1221
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (या %s)"
 
-#: ../src/generic/logg.cpp:224
+#: ../src/generic/logg.cpp:221
 #, c-format
 msgid "%s Error"
 msgstr "%s त्रुटि"
 
-#: ../src/generic/logg.cpp:236
+#: ../src/generic/logg.cpp:233
 #, c-format
 msgid "%s Information"
 msgstr "%s सूचना"
 
-#: ../src/generic/preferencesg.cpp:113
+#: ../src/generic/preferencesg.cpp:110
 #, fuzzy, c-format
 msgid "%s Preferences"
 msgstr "प्राथमिकता (&P)"
 
-#: ../src/generic/logg.cpp:228
+#: ../src/generic/logg.cpp:225
 #, c-format
 msgid "%s Warning"
 msgstr "%s चेतावनी"
 
-#: ../src/common/tarstrm.cpp:1319
+#: ../src/common/tarstrm.cpp:1313
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr ""
 
-#: ../src/common/fldlgcmn.cpp:124
+#: ../src/common/fldlgcmn.cpp:121
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s फ़ाइलें (%s)|%s"
 
-#: ../src/html/helpwnd.cpp:1716
+#: ../src/html/helpwnd.cpp:1714
 #, fuzzy, c-format
 msgid "%u of %u"
 msgstr "%i का %i"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "&About"
 msgstr "के बारे में (&A)"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "&Actual Size"
 msgstr "वास्तविक आकार (&A)"
 
@@ -194,28 +221,28 @@ msgstr "वास्तविक आकार (&A)"
 msgid "&After a paragraph:"
 msgstr "अनुच्छेद के बाद में (&A):"
 
-#: ../src/richtext/richtextindentspage.cpp:128
 #: ../src/richtext/richtextliststylepage.cpp:319
+#: ../src/richtext/richtextindentspage.cpp:128
 msgid "&Alignment"
 msgstr "पंक्तिबद्ध करें (&A)"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "&Apply"
 msgstr "लागु करें (&A)"
 
-#: ../src/richtext/richtextstyledlg.cpp:251
+#: ../src/richtext/richtextstyledlg.cpp:247
 msgid "&Apply Style"
 msgstr "शैली लागु करें (&A)"
 
-#: ../src/msw/mdi.cpp:179
+#: ../src/msw/mdi.cpp:174
 msgid "&Arrange Icons"
 msgstr "आइकॉनों को व्यवस्थित करें (&A)"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "&Ascending"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:142
+#: ../src/common/stockitem.cpp:139
 msgid "&Back"
 msgstr "पीछे (&B)"
 
@@ -236,24 +263,24 @@ msgstr "रंग (&C):"
 msgid "&Blur distance:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:143
+#: ../src/common/stockitem.cpp:140
 msgid "&Bold"
 msgstr "गहरा"
 
-#: ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141
 msgid "&Bottom"
 msgstr ""
 
+#: ../src/richtext/richtextsizepage.cpp:637
+#: ../src/richtext/richtextsizepage.cpp:644
 #: ../src/richtext/richtextborderspage.cpp:345
 #: ../src/richtext/richtextborderspage.cpp:513
 #: ../src/richtext/richtextmarginspage.cpp:259
 #: ../src/richtext/richtextmarginspage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:637
-#: ../src/richtext/richtextsizepage.cpp:644
 msgid "&Bottom:"
 msgstr ""
 
-#: ../include/wx/richtext/richtextbuffer.h:3866
+#: ../include/wx/richtext/richtextbuffer.h:3861
 #, fuzzy
 msgid "&Box"
 msgstr "गहरा"
@@ -263,39 +290,39 @@ msgstr "गहरा"
 msgid "&Bullet style:"
 msgstr "बुल्लेट शैली (&B):"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "&CD-Rom"
 msgstr ""
 
-#: ../src/generic/wizard.cpp:434 ../src/generic/fontdlgg.cpp:470
-#: ../src/generic/fontdlgg.cpp:489 ../src/osx/carbon/fontdlg.cpp:402
-#: ../src/common/dlgcmn.cpp:279 ../src/common/stockitem.cpp:145
+#: ../src/osx/carbon/fontdlg.cpp:399 ../src/common/stockitem.cpp:142
+#: ../src/generic/wizard.cpp:433 ../src/generic/fontdlgg.cpp:466
+#: ../src/generic/fontdlgg.cpp:485 ../src/osx/cocoa/button.mm:200
 msgid "&Cancel"
 msgstr "निरस्त करें (&C)"
 
-#: ../src/msw/mdi.cpp:175
+#: ../src/msw/mdi.cpp:170
 msgid "&Cascade"
 msgstr "कास्केड करें (&C)"
 
-#: ../include/wx/richtext/richtextbuffer.h:5960
+#: ../include/wx/richtext/richtextbuffer.h:5955
 #, fuzzy
 msgid "&Cell"
 msgstr "निरस्त करें (&C)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:439
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "&Character code:"
 msgstr "संप्रतीक कूट (&C):"
 
-#: ../src/common/stockitem.cpp:147
+#: ../src/common/stockitem.cpp:144
 msgid "&Clear"
 msgstr "साफ़ करें (&C)"
 
-#: ../src/generic/logg.cpp:516 ../src/common/stockitem.cpp:148
-#: ../src/common/prntbase.cpp:1600 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/stockitem.cpp:145 ../src/common/prntbase.cpp:1625
+#: ../src/univ/themes/win32.cpp:3753 ../src/generic/logg.cpp:513
 msgid "&Close"
 msgstr "बन्द करे (&C)"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 #, fuzzy
 msgid "&Color"
 msgstr "रंग (&C):"
@@ -304,21 +331,21 @@ msgstr "रंग (&C):"
 msgid "&Colour:"
 msgstr "रंग (&C):"
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 #, fuzzy
 msgid "&Convert"
 msgstr "विषय-वस्तु"
 
-#: ../src/richtext/richtextctrl.cpp:333 ../src/osx/textctrl_osx.cpp:577
-#: ../src/common/stockitem.cpp:150 ../src/msw/textctrl.cpp:2508
+#: ../src/osx/textctrl_osx.cpp:595 ../src/common/stockitem.cpp:147
+#: ../src/msw/textctrl.cpp:2773 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "प्रतिलिपि बनाएँ (&C)"
 
-#: ../src/generic/hyperlinkg.cpp:156
+#: ../src/generic/hyperlinkg.cpp:153
 msgid "&Copy URL"
 msgstr "URL की प्रतिलिपि बनाएँ (&C)"
 
-#: ../src/common/headerctrlcmn.cpp:306
+#: ../src/common/headerctrlcmn.cpp:304
 msgid "&Customize..."
 msgstr ""
 
@@ -326,53 +353,54 @@ msgstr ""
 msgid "&Debug report preview:"
 msgstr "दोषमार्जन विवरण पूर्वालोकन (&D):"
 
-#: ../src/richtext/richtexttabspage.cpp:138
-#: ../src/richtext/richtextctrl.cpp:335 ../src/osx/textctrl_osx.cpp:579
-#: ../src/common/stockitem.cpp:152 ../src/msw/textctrl.cpp:2510
+#: ../src/osx/textctrl_osx.cpp:597 ../src/common/stockitem.cpp:149
+#: ../src/msw/textctrl.cpp:2775 ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtextctrl.cpp:334
 msgid "&Delete"
 msgstr "मिटाएँं (&D)"
 
-#: ../src/richtext/richtextstyledlg.cpp:269
+#: ../src/richtext/richtextstyledlg.cpp:265
 msgid "&Delete Style..."
 msgstr "शैली हटाएँ (&D)..."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "&Descending"
 msgstr ""
 
-#: ../src/generic/logg.cpp:682
+#: ../src/generic/logg.cpp:679
 msgid "&Details"
 msgstr "विवरण (&D)"
 
-#: ../src/common/stockitem.cpp:153
+#: ../src/common/stockitem.cpp:150
 msgid "&Down"
 msgstr "नीचे (&D)"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "&Edit"
 msgstr "संपादन (&E)"
 
-#: ../src/richtext/richtextstyledlg.cpp:263
+#: ../src/richtext/richtextstyledlg.cpp:259
 msgid "&Edit Style..."
 msgstr "शैली संपादन (&E)..."
 
-#: ../src/common/stockitem.cpp:155
+#: ../src/common/stockitem.cpp:152
 msgid "&Execute"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/common/stockitem.cpp:154
 msgid "&File"
 msgstr "फ़ाइल (&F)"
 
-#: ../src/common/stockitem.cpp:158
-msgid "&Find"
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "&Find..."
 msgstr "खोजें (&F)"
 
-#: ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:430
 msgid "&Finish"
 msgstr "समाप्त करें (&F)"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:156
 #, fuzzy
 msgid "&First"
 msgstr "प्रथम"
@@ -381,17 +409,17 @@ msgstr "प्रथम"
 msgid "&Floating mode:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 #, fuzzy
 msgid "&Floppy"
 msgstr "प्रतिलिपि बनाएँ (&C)"
 
-#: ../src/common/stockitem.cpp:194
+#: ../src/common/stockitem.cpp:191
 #, fuzzy
 msgid "&Font"
 msgstr "फ़ॉन्ट: (&F)"
 
-#: ../src/generic/fontdlgg.cpp:371
+#: ../src/generic/fontdlgg.cpp:367
 msgid "&Font family:"
 msgstr "फ़ॉन्ट वंश:"
 
@@ -399,20 +427,20 @@ msgstr "फ़ॉन्ट वंश:"
 msgid "&Font for Level..."
 msgstr "स्तर के लिए फ़ॉन्ट (&F)..."
 
+#: ../src/richtext/richtextsymboldlg.cpp:397
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:400
 msgid "&Font:"
 msgstr "फ़ॉन्ट: (&F)"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "&Forward"
 msgstr "आगे (&F)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:451
+#: ../src/richtext/richtextsymboldlg.cpp:448
 msgid "&From:"
 msgstr "से (&F):"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "&Harddisk"
 msgstr ""
 
@@ -422,9 +450,9 @@ msgstr ""
 msgid "&Height:"
 msgstr "भार (&W):"
 
-#: ../src/generic/wizard.cpp:441 ../src/richtext/richtextstyledlg.cpp:303
-#: ../src/richtext/richtextsymboldlg.cpp:479 ../src/osx/menu_osx.cpp:734
-#: ../src/common/stockitem.cpp:163
+#: ../src/common/stockitem.cpp:160 ../src/generic/wizard.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextstyledlg.cpp:299 ../src/osx/cocoa/menu.mm:226
 msgid "&Help"
 msgstr "सहायता (&H)"
 
@@ -433,7 +461,7 @@ msgstr "सहायता (&H)"
 msgid "&Hide details"
 msgstr "विवरण (&D)"
 
-#: ../src/common/stockitem.cpp:164
+#: ../src/common/stockitem.cpp:161
 msgid "&Home"
 msgstr "गृह (&H)"
 
@@ -441,56 +469,56 @@ msgstr "गृह (&H)"
 msgid "&Horizontal offset:"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:184
 #: ../src/richtext/richtextliststylepage.cpp:372
+#: ../src/richtext/richtextindentspage.cpp:184
 msgid "&Indentation (tenths of a mm)"
 msgstr "इंडेंटेशन (मिलीमीटर का दसवाँ भाग) (&I):"
 
-#: ../src/richtext/richtextindentspage.cpp:167
 #: ../src/richtext/richtextliststylepage.cpp:356
+#: ../src/richtext/richtextindentspage.cpp:167
 msgid "&Indeterminate"
 msgstr "अनिश्चित (&I)"
 
-#: ../src/common/stockitem.cpp:166
+#: ../src/common/stockitem.cpp:163
 msgid "&Index"
 msgstr "अनुक्रमणिका (&I)"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 #, fuzzy
 msgid "&Info"
 msgstr "पहिले जैसा करें (&U)"
 
-#: ../src/common/stockitem.cpp:168
+#: ../src/common/stockitem.cpp:165
 msgid "&Italic"
 msgstr "तिरछा"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "&Jump to"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:153
 #: ../src/richtext/richtextliststylepage.cpp:342
+#: ../src/richtext/richtextindentspage.cpp:153
 msgid "&Justified"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 #, fuzzy
 msgid "&Last"
 msgstr "चिपकाएँ (&P)"
 
-#: ../src/richtext/richtextindentspage.cpp:139
 #: ../src/richtext/richtextliststylepage.cpp:328
+#: ../src/richtext/richtextindentspage.cpp:139
 msgid "&Left"
 msgstr "बायें (&L)"
 
-#: ../src/richtext/richtextindentspage.cpp:195
+#: ../src/richtext/richtextsizepage.cpp:532
+#: ../src/richtext/richtextsizepage.cpp:539
 #: ../src/richtext/richtextborderspage.cpp:243
 #: ../src/richtext/richtextborderspage.cpp:411
 #: ../src/richtext/richtextliststylepage.cpp:381
+#: ../src/richtext/richtextindentspage.cpp:195
 #: ../src/richtext/richtextmarginspage.cpp:186
 #: ../src/richtext/richtextmarginspage.cpp:300
-#: ../src/richtext/richtextsizepage.cpp:532
-#: ../src/richtext/richtextsizepage.cpp:539
 msgid "&Left:"
 msgstr "बायें: (&L)"
 
@@ -498,11 +526,11 @@ msgstr "बायें: (&L)"
 msgid "&List level:"
 msgstr "सूची स्तर (&L):"
 
-#: ../src/generic/logg.cpp:517
+#: ../src/generic/logg.cpp:514
 msgid "&Log"
 msgstr "लॉग (&L)"
 
-#: ../src/univ/themes/win32.cpp:3748
+#: ../src/univ/themes/win32.cpp:3745
 msgid "&Move"
 msgstr "इधर-उधर ले जाएँ (&M)"
 
@@ -510,21 +538,20 @@ msgstr "इधर-उधर ले जाएँ (&M)"
 msgid "&Move the object to:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 #, fuzzy
 msgid "&Network"
 msgstr "नया (&N)"
 
-#: ../src/richtext/richtexttabspage.cpp:132 ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173 ../src/richtext/richtexttabspage.cpp:132
 msgid "&New"
 msgstr "नया (&N)"
 
-#: ../src/aui/tabmdi.cpp:111 ../src/generic/mdig.cpp:100
-#: ../src/msw/mdi.cpp:180
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
 msgid "&Next"
 msgstr "अगला (&N)"
 
-#: ../src/generic/wizard.cpp:432 ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:429
 msgid "&Next >"
 msgstr "अगला (&N) >"
 
@@ -533,7 +560,7 @@ msgstr "अगला (&N) >"
 msgid "&Next Paragraph"
 msgstr "अनुच्छेद के बाद में (&A):"
 
-#: ../src/generic/tipdlg.cpp:240
+#: ../src/generic/tipdlg.cpp:237
 msgid "&Next Tip"
 msgstr "अगला संकेत (&N)"
 
@@ -541,11 +568,11 @@ msgstr "अगला संकेत (&N)"
 msgid "&Next style:"
 msgstr "अगली शैली (&N):"
 
-#: ../src/common/stockitem.cpp:177 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:174 ../src/msw/msgdlg.cpp:435
 msgid "&No"
 msgstr "नहीं (&N)"
 
-#: ../src/generic/dbgrptg.cpp:356
+#: ../src/generic/dbgrptg.cpp:360
 msgid "&Notes:"
 msgstr "टिप्पणी (&N)"
 
@@ -553,12 +580,12 @@ msgstr "टिप्पणी (&N)"
 msgid "&Number:"
 msgstr "अंक (&N):"
 
-#: ../src/generic/fontdlgg.cpp:475 ../src/generic/fontdlgg.cpp:482
-#: ../src/osx/carbon/fontdlg.cpp:408 ../src/common/stockitem.cpp:178
+#: ../src/osx/carbon/fontdlg.cpp:405 ../src/common/stockitem.cpp:175
+#: ../src/generic/fontdlgg.cpp:471 ../src/generic/fontdlgg.cpp:478
 msgid "&OK"
 msgstr "ठीक (&O)"
 
-#: ../src/generic/dbgrptg.cpp:342 ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176 ../src/generic/dbgrptg.cpp:342
 msgid "&Open..."
 msgstr "खोलें (&O)..."
 
@@ -570,16 +597,16 @@ msgstr "रूपरेखा स्तर (&O):"
 msgid "&Page Break"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:334 ../src/osx/textctrl_osx.cpp:578
-#: ../src/common/stockitem.cpp:180 ../src/msw/textctrl.cpp:2509
+#: ../src/osx/textctrl_osx.cpp:596 ../src/common/stockitem.cpp:177
+#: ../src/msw/textctrl.cpp:2774 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "चिपकाएँ (&P)"
 
-#: ../include/wx/richtext/richtextbuffer.h:5010
+#: ../include/wx/richtext/richtextbuffer.h:5005
 msgid "&Picture"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:419
 msgid "&Point size:"
 msgstr "फ़ॉन्ट आकार (&P):"
 
@@ -592,12 +619,11 @@ msgstr "स्थिति (मिलीमीटर का दसवाँ भ�
 msgid "&Position mode:"
 msgstr "प्रश्न"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178
 msgid "&Preferences"
 msgstr "प्राथमिकता (&P)"
 
-#: ../src/aui/tabmdi.cpp:112 ../src/generic/mdig.cpp:101
-#: ../src/msw/mdi.cpp:181
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
 msgid "&Previous"
 msgstr "पिछला (&P)"
 
@@ -606,80 +632,75 @@ msgstr "पिछला (&P)"
 msgid "&Previous Paragraph"
 msgstr "पिछला पॄष्ट"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "&Print..."
 msgstr "मुद्रण (&P)..."
 
-#: ../src/richtext/richtextctrl.cpp:339 ../src/richtext/richtextctrl.cpp:5514
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtextctrl.cpp:338
+#: ../src/richtext/richtextctrl.cpp:5512
 msgid "&Properties"
 msgstr "गुणधर्म (&P)"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "&Quit"
 msgstr "छोड़ दे (&Q)"
 
-#: ../src/richtext/richtextctrl.cpp:330 ../src/osx/textctrl_osx.cpp:574
-#: ../src/common/stockitem.cpp:185 ../src/common/cmdproc.cpp:293
-#: ../src/common/cmdproc.cpp:300 ../src/msw/textctrl.cpp:2505
+#: ../src/osx/textctrl_osx.cpp:592 ../src/common/stockitem.cpp:182
+#: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
+#: ../src/msw/textctrl.cpp:2770 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "पुनःकरें (&R)"
 
-#: ../src/common/cmdproc.cpp:289 ../src/common/cmdproc.cpp:309
+#: ../src/common/cmdproc.cpp:282 ../src/common/cmdproc.cpp:302
 msgid "&Redo "
 msgstr "पुनःकरें (&R)"
 
-#: ../src/richtext/richtextstyledlg.cpp:257
+#: ../src/richtext/richtextstyledlg.cpp:253
 msgid "&Rename Style..."
 msgstr "शैली का पुनःनामकरण (&R)..."
 
-#: ../src/generic/fdrepdlg.cpp:179
+#: ../src/generic/fdrepdlg.cpp:176
 msgid "&Replace"
 msgstr "बदलें (&R)"
 
-#: ../src/richtext/richtextstyledlg.cpp:287
+#: ../src/richtext/richtextstyledlg.cpp:283
 msgid "&Restart numbering"
 msgstr "पुनः प्रारम्भन संख्यांकन (&R)"
 
-#: ../src/univ/themes/win32.cpp:3747
+#: ../src/univ/themes/win32.cpp:3744
 msgid "&Restore"
 msgstr "पुनःस्थापित करें (&R)"
 
-#: ../src/richtext/richtextindentspage.cpp:146
 #: ../src/richtext/richtextliststylepage.cpp:335
+#: ../src/richtext/richtextindentspage.cpp:146
 msgid "&Right"
 msgstr "दायें (&R)"
 
-#: ../src/richtext/richtextindentspage.cpp:213
+#: ../src/richtext/richtextsizepage.cpp:602
+#: ../src/richtext/richtextsizepage.cpp:609
 #: ../src/richtext/richtextborderspage.cpp:277
 #: ../src/richtext/richtextborderspage.cpp:445
 #: ../src/richtext/richtextliststylepage.cpp:399
+#: ../src/richtext/richtextindentspage.cpp:213
 #: ../src/richtext/richtextmarginspage.cpp:211
 #: ../src/richtext/richtextmarginspage.cpp:325
-#: ../src/richtext/richtextsizepage.cpp:602
-#: ../src/richtext/richtextsizepage.cpp:609
 msgid "&Right:"
 msgstr "दायें (&R):"
 
-#: ../src/common/stockitem.cpp:190
+#: ../src/common/stockitem.cpp:187
 msgid "&Save"
 msgstr "सुरक्षित करें (&S)"
-
-#: ../src/common/stockitem.cpp:191
-#, fuzzy
-msgid "&Save as"
-msgstr "जैसा सुरक्षित करें"
 
 #: ../include/wx/richmsgdlg.h:29
 #, fuzzy
 msgid "&See details"
 msgstr "विवरण (&D)"
 
-#: ../src/generic/tipdlg.cpp:236
+#: ../src/generic/tipdlg.cpp:233
 msgid "&Show tips at startup"
 msgstr "संकेतो को शुरूवात में दिखाएँ (&S)"
 
-#: ../src/univ/themes/win32.cpp:3750
+#: ../src/univ/themes/win32.cpp:3747
 msgid "&Size"
 msgstr "आकार (&S)"
 
@@ -687,37 +708,37 @@ msgstr "आकार (&S)"
 msgid "&Size:"
 msgstr "आकार: (&S)"
 
-#: ../src/generic/progdlgg.cpp:252
+#: ../src/generic/progdlgg.cpp:249
 #, fuzzy
 msgid "&Skip"
 msgstr "छोड़ दे"
 
-#: ../src/richtext/richtextindentspage.cpp:242
 #: ../src/richtext/richtextliststylepage.cpp:417
+#: ../src/richtext/richtextindentspage.cpp:242
 msgid "&Spacing (tenths of a mm)"
 msgstr "अन्तराल (मिलीमीटर का दसवाँ भाग) (&S)"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "&Spell Check"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "&Stop"
 msgstr "रोक दें (&S)"
 
-#: ../src/richtext/richtextfontpage.cpp:275 ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196 ../src/richtext/richtextfontpage.cpp:275
 msgid "&Strikethrough"
 msgstr "स्ट्राइक थुःरु (S)"
 
-#: ../src/generic/fontdlgg.cpp:382 ../src/richtext/richtextstylepage.cpp:106
+#: ../src/generic/fontdlgg.cpp:378 ../src/richtext/richtextstylepage.cpp:106
 msgid "&Style:"
 msgstr "शैली: (&S)"
 
-#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:194
 msgid "&Styles:"
 msgstr "शैलियाँ (&S):"
 
-#: ../src/richtext/richtextsymboldlg.cpp:413
+#: ../src/richtext/richtextsymboldlg.cpp:410
 msgid "&Subset:"
 msgstr "उप समुच्चय (&S):"
 
@@ -731,27 +752,27 @@ msgstr "चिह्न: (&S)"
 msgid "&Synchronize values"
 msgstr ""
 
-#: ../include/wx/richtext/richtextbuffer.h:6069
+#: ../include/wx/richtext/richtextbuffer.h:6064
 #, fuzzy
 msgid "&Table"
 msgstr "टेब्स"
 
-#: ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197
 #, fuzzy
 msgid "&Top"
 msgstr "प्रतिलिपि बनाएँ (&C)"
 
+#: ../src/richtext/richtextsizepage.cpp:567
+#: ../src/richtext/richtextsizepage.cpp:574
 #: ../src/richtext/richtextborderspage.cpp:311
 #: ../src/richtext/richtextborderspage.cpp:479
 #: ../src/richtext/richtextmarginspage.cpp:234
 #: ../src/richtext/richtextmarginspage.cpp:348
-#: ../src/richtext/richtextsizepage.cpp:567
-#: ../src/richtext/richtextsizepage.cpp:574
 #, fuzzy
 msgid "&Top:"
 msgstr "प्राप्तकर्ता:"
 
-#: ../src/generic/fontdlgg.cpp:444 ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199 ../src/generic/fontdlgg.cpp:441
 msgid "&Underline"
 msgstr "रेखांकित (&U)"
 
@@ -759,21 +780,21 @@ msgstr "रेखांकित (&U)"
 msgid "&Underlining:"
 msgstr "रेखांकन (&U):"
 
-#: ../src/richtext/richtextctrl.cpp:329 ../src/osx/textctrl_osx.cpp:573
-#: ../src/common/stockitem.cpp:203 ../src/common/cmdproc.cpp:271
-#: ../src/msw/textctrl.cpp:2504
+#: ../src/osx/textctrl_osx.cpp:591 ../src/common/stockitem.cpp:200
+#: ../src/common/cmdproc.cpp:264 ../src/msw/textctrl.cpp:2769
+#: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "पहिले जैसा करें (&U)"
 
-#: ../src/common/cmdproc.cpp:265
+#: ../src/common/cmdproc.cpp:258
 msgid "&Undo "
 msgstr "पहिले जैसा करें (&U) "
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "&Unindent"
 msgstr "अन-इंडेंट (&U)"
 
-#: ../src/common/stockitem.cpp:205
+#: ../src/common/stockitem.cpp:202
 msgid "&Up"
 msgstr "ऊपर (&U)"
 
@@ -792,7 +813,7 @@ msgstr "बुल्लेट सरेखण (&A):"
 msgid "&View..."
 msgstr "खोलें (&O)..."
 
-#: ../src/generic/fontdlgg.cpp:393
+#: ../src/generic/fontdlgg.cpp:389
 msgid "&Weight:"
 msgstr "भार (&W):"
 
@@ -802,88 +823,58 @@ msgstr "भार (&W):"
 msgid "&Width:"
 msgstr "भार (&W):"
 
-#: ../src/aui/tabmdi.cpp:311 ../src/aui/tabmdi.cpp:327
-#: ../src/aui/tabmdi.cpp:329 ../src/generic/mdig.cpp:294
-#: ../src/generic/mdig.cpp:310 ../src/generic/mdig.cpp:314
-#: ../src/msw/mdi.cpp:78
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
 msgid "&Window"
 msgstr "खिड़की (&W)"
 
-#: ../src/common/stockitem.cpp:206 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:203 ../src/msw/msgdlg.cpp:435
 msgid "&Yes"
 msgstr "हाँ (&Y)"
 
-#: ../src/common/valtext.cpp:256
+#: ../src/common/valtext.cpp:197
 #, fuzzy, c-format
-msgid "'%s' contains illegal characters"
+msgid "'%s' contains invalid character(s)"
 msgstr "'%s' में सिर्फ़ आल्फ़ाबेटिक अक्षरों को ही सम्मिलित होना चाहिए।"
 
-#: ../src/common/valtext.cpp:254
-#, fuzzy, c-format
-msgid "'%s' doesn't consist only of valid characters"
-msgstr "'%s' में सिर्फ़ आल्फ़ाबेटिक अक्षरों को ही सम्मिलित होना चाहिए।"
-
-#: ../src/common/config.cpp:519 ../src/msw/regconf.cpp:258
+#: ../src/common/config.cpp:515 ../src/msw/regconf.cpp:255
 #, c-format
 msgid "'%s' has extra '..', ignored."
 msgstr "'%s' में अतिरिक्त '..' है, ध्यान नहीं दिया गया।"
 
-#: ../src/common/cmdline.cpp:1113 ../src/common/cmdline.cpp:1131
+#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' एक सही सांख्यानिक मूल्य '%s' विकल्प के लिए नहीं है।"
 
-#: ../src/common/translation.cpp:1100
+#: ../src/common/translation.cpp:1142
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' एक वैध संदेश सूचीपत्र नहीं है।"
 
-#: ../src/common/valtext.cpp:165
+#: ../src/common/valtext.cpp:188
 #, fuzzy, c-format
 msgid "'%s' is not one of the valid strings"
 msgstr "'%s' एक वैध संदेश सूचीपत्र नहीं है।"
 
-#: ../src/common/valtext.cpp:167
+#: ../src/common/valtext.cpp:186
 #, fuzzy, c-format
 msgid "'%s' is one of the invalid strings"
 msgstr "'%s' अवैध है"
 
-#: ../src/common/textbuf.cpp:237
+#: ../src/common/textbuf.cpp:233
 #, c-format
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' सम्भवता एक बायनरी बफ़र है।"
-
-#: ../src/common/valtext.cpp:252
-#, c-format
-msgid "'%s' should be numeric."
-msgstr "'%s' को एक संख्या होना चाहिए।"
-
-#: ../src/common/valtext.cpp:244
-#, c-format
-msgid "'%s' should only contain ASCII characters."
-msgstr "'%s' में सिर्फ़ आस्की अक्षरों को ही सम्मिलित होना चाहिए।"
-
-#: ../src/common/valtext.cpp:246
-#, c-format
-msgid "'%s' should only contain alphabetic characters."
-msgstr "'%s' में सिर्फ़ आल्फ़ाबेटिक अक्षरों को ही सम्मिलित होना चाहिए।"
-
-#: ../src/common/valtext.cpp:248
-#, c-format
-msgid "'%s' should only contain alphabetic or numeric characters."
-msgstr "'%s' में सिर्फ़ आल्फ़ाबेटिक या न्यूमेरिक अक्षरों को ही सम्मिलित होना चाहिए।"
-
-#: ../src/common/valtext.cpp:250
-#, fuzzy, c-format
-msgid "'%s' should only contain digits."
-msgstr "'%s' में सिर्फ़ आस्की अक्षरों को ही सम्मिलित होना चाहिए।"
 
 #: ../src/richtext/richtextliststylepage.cpp:229
 #: ../src/richtext/richtextbulletspage.cpp:166
 msgid "(*)"
 msgstr "(*)"
 
-#: ../src/html/helpwnd.cpp:963
+#: ../src/html/helpwnd.cpp:961
 msgid "(Help)"
 msgstr "(सहायता)"
 
@@ -892,27 +883,32 @@ msgstr "(सहायता)"
 msgid "(None)"
 msgstr "(कुछ नहीं)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:504
+#: ../src/richtext/richtextsymboldlg.cpp:503
 msgid "(Normal text)"
 msgstr "(सामान्य पाठ)"
 
-#: ../src/html/helpwnd.cpp:419 ../src/html/helpwnd.cpp:1106
-#: ../src/html/helpwnd.cpp:1742
+#: ../src/html/helpwnd.cpp:417 ../src/html/helpwnd.cpp:1104
+#: ../src/html/helpwnd.cpp:1740
 msgid "(bookmarks)"
 msgstr "(बुकमार्क)"
 
+#: ../src/msw/dlmsw.cpp:167
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr "(त्रुटि %ld: %s)"
+
+#: ../src/richtext/richtextformatdlg.cpp:876
+#: ../src/richtext/richtextliststylepage.cpp:448
+#: ../src/richtext/richtextliststylepage.cpp:460
+#: ../src/richtext/richtextliststylepage.cpp:461
 #: ../src/richtext/richtextindentspage.cpp:274
 #: ../src/richtext/richtextindentspage.cpp:286
 #: ../src/richtext/richtextindentspage.cpp:287
 #: ../src/richtext/richtextindentspage.cpp:311
 #: ../src/richtext/richtextindentspage.cpp:326
-#: ../src/richtext/richtextformatdlg.cpp:884
 #: ../src/richtext/richtextfontpage.cpp:349
 #: ../src/richtext/richtextfontpage.cpp:353
 #: ../src/richtext/richtextfontpage.cpp:357
-#: ../src/richtext/richtextliststylepage.cpp:448
-#: ../src/richtext/richtextliststylepage.cpp:460
-#: ../src/richtext/richtextliststylepage.cpp:461
 msgid "(none)"
 msgstr "(कोई नाम नहीं)"
 
@@ -931,7 +927,7 @@ msgstr "*)"
 msgid "+"
 msgstr "+"
 
-#: ../src/msw/utils.cpp:1152
+#: ../src/msw/utils.cpp:1143
 msgid ", 64-bit edition"
 msgstr ""
 
@@ -940,172 +936,172 @@ msgstr ""
 msgid "-"
 msgstr "-"
 
-#: ../src/generic/filepickerg.cpp:66
+#: ../src/generic/filepickerg.cpp:63
 #, fuzzy
 msgid "..."
 msgstr ".."
 
-#: ../src/richtext/richtextindentspage.cpp:276
 #: ../src/richtext/richtextliststylepage.cpp:450
+#: ../src/richtext/richtextindentspage.cpp:276
 #, fuzzy
 msgid "1.1"
 msgstr "१.५"
 
-#: ../src/richtext/richtextindentspage.cpp:277
 #: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextindentspage.cpp:277
 #, fuzzy
 msgid "1.2"
 msgstr "१.५"
 
-#: ../src/richtext/richtextindentspage.cpp:278
 #: ../src/richtext/richtextliststylepage.cpp:452
+#: ../src/richtext/richtextindentspage.cpp:278
 #, fuzzy
 msgid "1.3"
 msgstr "१.५"
 
-#: ../src/richtext/richtextindentspage.cpp:279
 #: ../src/richtext/richtextliststylepage.cpp:453
+#: ../src/richtext/richtextindentspage.cpp:279
 #, fuzzy
 msgid "1.4"
 msgstr "१.५"
 
-#: ../src/richtext/richtextindentspage.cpp:280
 #: ../src/richtext/richtextliststylepage.cpp:454
+#: ../src/richtext/richtextindentspage.cpp:280
 msgid "1.5"
 msgstr "१.५"
 
-#: ../src/richtext/richtextindentspage.cpp:281
 #: ../src/richtext/richtextliststylepage.cpp:455
+#: ../src/richtext/richtextindentspage.cpp:281
 #, fuzzy
 msgid "1.6"
 msgstr "१.५"
 
-#: ../src/richtext/richtextindentspage.cpp:282
 #: ../src/richtext/richtextliststylepage.cpp:456
+#: ../src/richtext/richtextindentspage.cpp:282
 #, fuzzy
 msgid "1.7"
 msgstr "१.५"
 
-#: ../src/richtext/richtextindentspage.cpp:283
 #: ../src/richtext/richtextliststylepage.cpp:457
+#: ../src/richtext/richtextindentspage.cpp:283
 #, fuzzy
 msgid "1.8"
 msgstr "१.५"
 
-#: ../src/richtext/richtextindentspage.cpp:284
 #: ../src/richtext/richtextliststylepage.cpp:458
+#: ../src/richtext/richtextindentspage.cpp:284
 #, fuzzy
 msgid "1.9"
 msgstr "१.५"
 
-#: ../src/common/paper.cpp:140
+#: ../src/common/paper.cpp:137
 msgid "10 x 11 in"
 msgstr "१२ x १४ इंच"
 
-#: ../src/common/paper.cpp:113
+#: ../src/common/paper.cpp:110
 msgid "10 x 14 in"
 msgstr "१० x १४ इंच"
 
-#: ../src/common/paper.cpp:114
+#: ../src/common/paper.cpp:111
 msgid "11 x 17 in"
 msgstr "११ x १७ इंच"
 
-#: ../src/common/paper.cpp:184
+#: ../src/common/paper.cpp:181
 msgid "12 x 11 in"
 msgstr "१२ x ११ इंच"
 
-#: ../src/common/paper.cpp:141
+#: ../src/common/paper.cpp:138
 msgid "15 x 11 in"
 msgstr "१५ x ११ इंच"
 
-#: ../src/richtext/richtextindentspage.cpp:285
 #: ../src/richtext/richtextliststylepage.cpp:459
+#: ../src/richtext/richtextindentspage.cpp:285
 msgid "2"
 msgstr "२"
 
-#: ../src/common/paper.cpp:132
+#: ../src/common/paper.cpp:129
 msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
 msgstr "६ ३/४ लिफ़ाफ़ा, ३ ५/८ x ६ १/२ इंच"
 
-#: ../src/common/paper.cpp:139
+#: ../src/common/paper.cpp:136
 msgid "9 x 11 in"
 msgstr "९ x ११ इंच"
 
-#: ../src/html/htmprint.cpp:431
+#: ../src/html/htmprint.cpp:443
 msgid ": file does not exist!"
 msgstr ": फ़ाइल विद्यमान नहीं है! "
 
-#: ../src/common/fontmap.cpp:199
+#: ../src/common/fontmap.cpp:196
 msgid ": unknown charset"
 msgstr ": अज्ञात शब्दसमुच्चय"
 
-#: ../src/common/fontmap.cpp:413
+#: ../src/common/fontmap.cpp:410
 msgid ": unknown encoding"
 msgstr ": अज्ञात एन्कोडिंग"
 
-#: ../src/generic/wizard.cpp:443
+#: ../src/generic/wizard.cpp:438
 msgid "< &Back"
 msgstr "< पीछे (&B)"
 
-#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:628
-#: ../src/osx/carbon/fontdlg.cpp:648
+#: ../src/osx/carbon/fontdlg.cpp:419 ../src/osx/carbon/fontdlg.cpp:625
+#: ../src/osx/carbon/fontdlg.cpp:645
 msgid "<Any Decorative>"
 msgstr "<कोई साज-सजावट>"
 
-#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:630
-#: ../src/osx/carbon/fontdlg.cpp:650
+#: ../src/osx/carbon/fontdlg.cpp:420 ../src/osx/carbon/fontdlg.cpp:627
+#: ../src/osx/carbon/fontdlg.cpp:647
 msgid "<Any Modern>"
 msgstr "<कोई आधुनिक>"
 
-#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:626
-#: ../src/osx/carbon/fontdlg.cpp:646
+#: ../src/osx/carbon/fontdlg.cpp:418 ../src/osx/carbon/fontdlg.cpp:623
+#: ../src/osx/carbon/fontdlg.cpp:643
 msgid "<Any Roman>"
 msgstr "<कोई रोमन>"
 
-#: ../src/osx/carbon/fontdlg.cpp:424 ../src/osx/carbon/fontdlg.cpp:632
-#: ../src/osx/carbon/fontdlg.cpp:652
+#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:629
+#: ../src/osx/carbon/fontdlg.cpp:649
 msgid "<Any Script>"
 msgstr "<कोई लिपि>"
 
-#: ../src/osx/carbon/fontdlg.cpp:425 ../src/osx/carbon/fontdlg.cpp:637
-#: ../src/osx/carbon/fontdlg.cpp:656
+#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:634
+#: ../src/osx/carbon/fontdlg.cpp:653
 msgid "<Any Swiss>"
 msgstr "<कोई स्वीस>"
 
-#: ../src/osx/carbon/fontdlg.cpp:426 ../src/osx/carbon/fontdlg.cpp:634
-#: ../src/osx/carbon/fontdlg.cpp:654
+#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:631
+#: ../src/osx/carbon/fontdlg.cpp:651
 msgid "<Any Teletype>"
 msgstr "<कोई टेलीटाइप>"
 
-#: ../src/osx/carbon/fontdlg.cpp:420
+#: ../src/osx/carbon/fontdlg.cpp:417
 msgid "<Any>"
 msgstr "<कोई भी>"
 
-#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
 msgid "<DIR>"
 msgstr "<निर्देशिका> (<DIR>"
 
-#: ../src/generic/filectrlg.cpp:254 ../src/generic/filectrlg.cpp:277
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
 msgid "<DRIVE>"
 msgstr "<ड्राइव>"
 
-#: ../src/generic/filectrlg.cpp:252 ../src/generic/filectrlg.cpp:275
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
 msgid "<LINK>"
 msgstr "<कड़ी>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1264
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>गहरा इटैलिक फ़ेस।</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1270
+#: ../src/html/helpwnd.cpp:1268
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>गहरा इटैलिक <u>रेखांकित</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1265
+#: ../src/html/helpwnd.cpp:1263
 msgid "<b>Bold face.</b> "
 msgstr "<b>गहरा फ़ेस।</b> "
 
-#: ../src/html/helpwnd.cpp:1264
+#: ../src/html/helpwnd.cpp:1262
 msgid "<i>Italic face.</i> "
 msgstr "<i>इटैलिक फ़ेस।</i> "
 
@@ -1114,15 +1110,15 @@ msgstr "<i>इटैलिक फ़ेस।</i> "
 msgid ">"
 msgstr ">"
 
-#: ../src/generic/dbgrptg.cpp:318
+#: ../src/generic/dbgrptg.cpp:317
 msgid "A debug report has been generated in the directory\n"
 msgstr "एक दोषमार्जन विवरण इस निर्देशिका में बन गया हें\n"
 
-#: ../src/common/debugrpt.cpp:573
+#: ../src/common/debugrpt.cpp:574
 msgid "A debug report has been generated. It can be found in"
 msgstr "एक दोषमार्जन विवरण बन गया हें। ये इस निर्देशिका में पाया जा सकता हें: "
 
-#: ../src/common/xtixml.cpp:418
+#: ../src/common/xtixml.cpp:414
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "एक भरे हुए संग्रह को 'तत्व' नोडो से मिलकर बना होना चाहिए"
 
@@ -1133,119 +1129,119 @@ msgstr "एक भरे हुए संग्रह को 'तत्व' न�
 msgid "A standard bullet name."
 msgstr "एक मानक बुल्लेट का नाम।"
 
-#: ../src/common/paper.cpp:217
+#: ../src/common/paper.cpp:214
 #, fuzzy
 msgid "A0 sheet, 841 x 1189 mm"
 msgstr "ऐ४ पत्र २१० x २९७ मिलीमीटर"
 
-#: ../src/common/paper.cpp:218
+#: ../src/common/paper.cpp:215
 #, fuzzy
 msgid "A1 sheet, 594 x 841 mm"
 msgstr "ऐ३ पत्र २९७ x ४२० मिलीमीटर"
 
-#: ../src/common/paper.cpp:159
+#: ../src/common/paper.cpp:156
 msgid "A2 420 x 594 mm"
 msgstr "ऐ२ 420 x 594 मिलीमीटर"
 
-#: ../src/common/paper.cpp:156
+#: ../src/common/paper.cpp:153
 #, fuzzy
 msgid "A3 Extra 322 x 445 mm"
 msgstr "सी३ लिफ़ाफ़ा, ३२४ x ४५८ मिलीमीटर"
 
-#: ../src/common/paper.cpp:161
+#: ../src/common/paper.cpp:158
 #, fuzzy
 msgid "A3 Extra Transverse 322 x 445 mm"
 msgstr "सी३ लिफ़ाफ़ा, ३२४ x ४५८ मिलीमीटर"
 
-#: ../src/common/paper.cpp:170
+#: ../src/common/paper.cpp:167
 #, fuzzy
 msgid "A3 Rotated 420 x 297 mm"
 msgstr "ऐ४ पत्र २१० x २९७ मिलीमीटर"
 
-#: ../src/common/paper.cpp:160
+#: ../src/common/paper.cpp:157
 #, fuzzy
 msgid "A3 Transverse 297 x 420 mm"
 msgstr "ऐ३ पत्र २९७ x ४२० मिलीमीटर"
 
-#: ../src/common/paper.cpp:106
+#: ../src/common/paper.cpp:103
 msgid "A3 sheet, 297 x 420 mm"
 msgstr "ऐ३ पत्र २९७ x ४२० मिलीमीटर"
 
-#: ../src/common/paper.cpp:146
+#: ../src/common/paper.cpp:143
 msgid "A4 Extra 9.27 x 12.69 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:153
+#: ../src/common/paper.cpp:150
 #, fuzzy
 msgid "A4 Plus 210 x 330 mm"
 msgstr "ऐ४ पत्र २१० x २९७ मिलीमीटर"
 
-#: ../src/common/paper.cpp:171
+#: ../src/common/paper.cpp:168
 #, fuzzy
 msgid "A4 Rotated 297 x 210 mm"
 msgstr "ऐ३ पत्र २९७ x ४२० मिलीमीटर"
 
-#: ../src/common/paper.cpp:148
+#: ../src/common/paper.cpp:145
 #, fuzzy
 msgid "A4 Transverse 210 x 297 mm"
 msgstr "ऐ४ पत्र २१० x २९७ मिलीमीटर"
 
-#: ../src/common/paper.cpp:97
+#: ../src/common/paper.cpp:94
 msgid "A4 sheet, 210 x 297 mm"
 msgstr "ऐ४ पत्र २१० x २९७ मिलीमीटर"
 
-#: ../src/common/paper.cpp:107
+#: ../src/common/paper.cpp:104
 msgid "A4 small sheet, 210 x 297 mm"
 msgstr "ऐ४ लघु पत्र २१० x  २९७ मिलीमीटर"
 
-#: ../src/common/paper.cpp:157
+#: ../src/common/paper.cpp:154
 #, fuzzy
 msgid "A5 Extra 174 x 235 mm"
 msgstr "ऐ५ पत्र १४८ x २१० मिलीमीटर"
 
-#: ../src/common/paper.cpp:172
+#: ../src/common/paper.cpp:169
 msgid "A5 Rotated 210 x 148 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:154
+#: ../src/common/paper.cpp:151
 #, fuzzy
 msgid "A5 Transverse 148 x 210 mm"
 msgstr "ऐ५ पत्र १४८ x २१० मिलीमीटर"
 
-#: ../src/common/paper.cpp:108
+#: ../src/common/paper.cpp:105
 msgid "A5 sheet, 148 x 210 mm"
 msgstr "ऐ५ पत्र १४८ x २१० मिलीमीटर"
 
-#: ../src/common/paper.cpp:164
+#: ../src/common/paper.cpp:161
 msgid "A6 105 x 148 mm"
 msgstr "ऐ६ 105 x 148 मिलीमीटर"
 
-#: ../src/common/paper.cpp:177
+#: ../src/common/paper.cpp:174
 #, fuzzy
 msgid "A6 Rotated 148 x 105 mm"
 msgstr "ऐ५ पत्र १४८ x २१० मिलीमीटर"
 
-#: ../src/generic/fontdlgg.cpp:83 ../src/richtext/richtextformatdlg.cpp:529
-#: ../src/osx/carbon/fontdlg.cpp:153
+#: ../src/osx/carbon/fontdlg.cpp:150 ../src/generic/fontdlgg.cpp:79
+#: ../src/richtext/richtextformatdlg.cpp:521
 msgid "ABCDEFGabcdefg12345"
 msgstr "ABCDEFGabcdefg12345"
 
-#: ../src/richtext/richtextsymboldlg.cpp:458 ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
 msgid "ASCII"
 msgstr "आस्की (ASCII)"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 #, fuzzy
 msgid "About"
 msgstr "के बारे में (&A)"
 
-#: ../src/generic/aboutdlgg.cpp:140 ../src/osx/menu_osx.cpp:558
-#: ../src/msw/aboutdlg.cpp:64
+#: ../src/osx/menu_osx.cpp:450 ../src/generic/aboutdlgg.cpp:137
+#: ../src/msw/aboutdlg.cpp:61
 #, fuzzy, c-format
 msgid "About %s"
 msgstr "के बारे में"
 
-#: ../src/osx/menu_osx.cpp:560
+#: ../src/osx/menu_osx.cpp:452
 #, fuzzy
 msgid "About..."
 msgstr "के बारे में (&A)"
@@ -1255,39 +1251,39 @@ msgid "Absolute"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:873
+#: ../src/propgrid/advprops.cpp:774
 #, fuzzy
 msgid "ActiveBorder"
 msgstr "आधुनिक"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:874
+#: ../src/propgrid/advprops.cpp:775
 msgid "ActiveCaption"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 #, fuzzy
 msgid "Actual Size"
 msgstr "वास्तविक आकार (&A)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:140 ../src/common/accelcmn.cpp:81
+#: ../src/common/stockitem.cpp:137 ../src/common/accelcmn.cpp:78
 msgid "Add"
 msgstr "जोड़ें"
 
-#: ../src/richtext/richtextbuffer.cpp:11455
+#: ../src/richtext/richtextbuffer.cpp:11454
 msgid "Add Column"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11392
+#: ../src/richtext/richtextbuffer.cpp:11391
 msgid "Add Row"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:432
+#: ../src/html/helpwnd.cpp:430
 msgid "Add current page to bookmarks"
 msgstr "वर्तमान पृष्ट को बुकमार्कों में जोड़ें"
 
-#: ../src/generic/colrdlgg.cpp:366
+#: ../src/generic/colrdlgg.cpp:386
 msgid "Add to custom colours"
 msgstr "ऐच्छिक रंगों में जोड़ें"
 
@@ -1299,12 +1295,12 @@ msgstr "AddToPropertyCollection को एक सामान्य ऐसेस
 msgid "AddToPropertyCollection called w/o valid adder"
 msgstr "AddToPropertyCollection को बिना वैध ऐडर के कॉल किया गया"
 
-#: ../src/html/helpctrl.cpp:159
+#: ../src/html/helpctrl.cpp:155
 #, c-format
 msgid "Adding book %s"
 msgstr "%s बुक को जोड़ा जा रहा है"
 
-#: ../src/common/preferencescmn.cpp:43
+#: ../src/common/preferencescmn.cpp:40
 msgid "Advanced"
 msgstr ""
 
@@ -1312,11 +1308,11 @@ msgstr ""
 msgid "After a paragraph:"
 msgstr "अनुच्छेद के बाद में:"
 
-#: ../src/common/stockitem.cpp:172
+#: ../src/common/stockitem.cpp:169
 msgid "Align Left"
 msgstr "बायें पंक्तिबद्ध करें"
 
-#: ../src/common/stockitem.cpp:173
+#: ../src/common/stockitem.cpp:170
 msgid "Align Right"
 msgstr "दायें पंक्तिबद्ध करें"
 
@@ -1325,40 +1321,40 @@ msgstr "दायें पंक्तिबद्ध करें"
 msgid "Alignment"
 msgstr "पंक्तिबद्ध करें (&A)"
 
-#: ../src/generic/prntdlgg.cpp:215
+#: ../src/generic/prntdlgg.cpp:208
 msgid "All"
 msgstr "सभी"
 
-#: ../src/generic/filectrlg.cpp:1197 ../src/common/fldlgcmn.cpp:107
+#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1186
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "सभी फ़ाइलें (%s)|%s"
 
-#: ../include/wx/defs.h:2886
+#: ../include/wx/defs.h:2582
 msgid "All files (*)|*"
 msgstr "सभी फ़ाइलें (*)|*"
 
-#: ../include/wx/defs.h:2883
+#: ../include/wx/defs.h:2579
 msgid "All files (*.*)|*.*"
 msgstr "सभी फ़ाइलें (*.*)|*.*"
 
-#: ../src/richtext/richtextstyles.cpp:1061
+#: ../src/richtext/richtextstyles.cpp:1058
 msgid "All styles"
 msgstr "सभी शैलियाँ"
 
-#: ../src/propgrid/manager.cpp:1528
+#: ../src/propgrid/manager.cpp:1544
 msgid "Alphabetic Mode"
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:425
+#: ../src/common/xtistrm.cpp:422
 msgid "Already Registered Object passed to SetObjectClassInfo"
 msgstr "SetObjectClassInfo को पहिले से पंजीकॄत ऑब्जेक्ट पास कर दिये गये है"
 
-#: ../src/unix/dialup.cpp:353
+#: ../src/unix/dialup.cpp:352
 msgid "Already dialling ISP."
 msgstr "आईएसपी को पहिले से डायल किया जा रहा है।"
 
-#: ../src/common/accelcmn.cpp:331 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/accelcmn.cpp:345 ../src/univ/themes/win32.cpp:3753
 #, fuzzy
 msgid "Alt+"
 msgstr "Alt-"
@@ -1368,37 +1364,37 @@ msgstr "Alt-"
 msgid "An optional corner radius for adding rounded corners."
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:576
+#: ../src/common/debugrpt.cpp:577
 msgid "And includes the following files:\n"
 msgstr "और नीचे दी गयी फ़ाइलें सम्मिलित हें:\n"
 
-#: ../src/generic/animateg.cpp:162
+#: ../src/generic/animateg.cpp:145
 #, c-format
 msgid "Animation file is not of type %ld."
 msgstr "सजीवन आकृति फ़ाइल %ld प्रकार की नहीं है।"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:872
+#: ../src/propgrid/advprops.cpp:773
 msgid "AppWorkspace"
 msgstr ""
 
-#: ../src/generic/logg.cpp:1014
+#: ../src/generic/logg.cpp:1011
 #, c-format
 msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
 msgstr ""
 "लॉग को '%s' फ़ाइल के अंत में जोड़ें ([नहीं] का चयन करने से इस पर मिटाकर लिख दिया जायेगा)?"
 
-#: ../src/osx/menu_osx.cpp:577 ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:469 ../src/osx/menu_osx.cpp:477
 #, fuzzy
 msgid "Application"
 msgstr "चयन"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 #, fuzzy
 msgid "Apply"
 msgstr "लागु करें (&A)"
 
-#: ../src/propgrid/advprops.cpp:1609
+#: ../src/propgrid/advprops.cpp:1515
 msgid "Aqua"
 msgstr ""
 
@@ -1407,31 +1403,31 @@ msgstr ""
 msgid "Arabic"
 msgstr "अरबी"
 
-#: ../src/common/fmapbase.cpp:153
+#: ../src/common/fmapbase.cpp:150
 msgid "Arabic (ISO-8859-6)"
 msgstr "अरबी (आईसो-८८५९-६)"
 
-#: ../src/msw/ole/automtn.cpp:672
+#: ../src/msw/ole/automtn.cpp:663
 #, fuzzy, c-format
 msgid "Argument %u not found."
 msgstr "सहायता निर्देशिका \"%s\" नहीं मिली।"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1753
+#: ../src/propgrid/advprops.cpp:1654
 #, fuzzy
 msgid "Arrow"
 msgstr "कल"
 
-#: ../src/generic/aboutdlgg.cpp:184
+#: ../src/generic/aboutdlgg.cpp:181
 msgid "Artists"
 msgstr "कलाकार"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 #, fuzzy
 msgid "Ascending"
 msgstr "पढ़ा जा रहा है"
 
-#: ../src/generic/filectrlg.cpp:433
+#: ../src/generic/filectrlg.cpp:429
 msgid "Attributes"
 msgstr "विशेषतायें"
 
@@ -1441,93 +1437,93 @@ msgstr "विशेषतायें"
 msgid "Available fonts."
 msgstr "उपलब्ध फ़ॉन्ट"
 
-#: ../src/common/paper.cpp:137
+#: ../src/common/paper.cpp:134
 #, fuzzy
 msgid "B4 (ISO) 250 x 353 mm"
 msgstr "बी४ पत्र, २५० x ३५४ मिलीमीटर"
 
-#: ../src/common/paper.cpp:173
+#: ../src/common/paper.cpp:170
 msgid "B4 (JIS) Rotated 364 x 257 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:127
+#: ../src/common/paper.cpp:124
 msgid "B4 Envelope, 250 x 353 mm"
 msgstr "बी४ लिफ़ाफ़ा, २५० x ३५३ मिलीमीटर"
 
-#: ../src/common/paper.cpp:109
+#: ../src/common/paper.cpp:106
 msgid "B4 sheet, 250 x 354 mm"
 msgstr "बी४ पत्र, २५० x ३५४ मिलीमीटर"
 
-#: ../src/common/paper.cpp:158
+#: ../src/common/paper.cpp:155
 msgid "B5 (ISO) Extra 201 x 276 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:174
+#: ../src/common/paper.cpp:171
 msgid "B5 (JIS) Rotated 257 x 182 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:155
+#: ../src/common/paper.cpp:152
 #, fuzzy
 msgid "B5 (JIS) Transverse 182 x 257 mm"
 msgstr "बी५ पत्र, १८२ x २५७ मिलीमीटर"
 
-#: ../src/common/paper.cpp:128
+#: ../src/common/paper.cpp:125
 msgid "B5 Envelope, 176 x 250 mm"
 msgstr "बी५ लिफ़ाफ़ा, १७६ x 250 मिलीमीटर"
 
-#: ../src/common/paper.cpp:110
+#: ../src/common/paper.cpp:107
 msgid "B5 sheet, 182 x 257 millimeter"
 msgstr "बी५ पत्र, १८२ x २५७ मिलीमीटर"
 
-#: ../src/common/paper.cpp:182
+#: ../src/common/paper.cpp:179
 msgid "B6 (JIS) 128 x 182 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:183
+#: ../src/common/paper.cpp:180
 msgid "B6 (JIS) Rotated 182 x 128 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:129
+#: ../src/common/paper.cpp:126
 msgid "B6 Envelope, 176 x 125 mm"
 msgstr "बी६ लिफ़ाफ़ा, १७६ x १२५ मिलीमीटर"
 
-#: ../src/common/imagbmp.cpp:531 ../src/common/imagbmp.cpp:561
-#: ../src/common/imagbmp.cpp:576
+#: ../src/common/imagbmp.cpp:528 ../src/common/imagbmp.cpp:558
+#: ../src/common/imagbmp.cpp:573
 msgid "BMP: Couldn't allocate memory."
 msgstr "बीएमपी: स्मॄति का आवंटन नहीं हो सका।"
 
-#: ../src/common/imagbmp.cpp:100
+#: ../src/common/imagbmp.cpp:97
 msgid "BMP: Couldn't save invalid image."
 msgstr "बीएमपी: अवैध आकॄति को सुरक्षित नहीं किया जा सका।"
 
-#: ../src/common/imagbmp.cpp:356
+#: ../src/common/imagbmp.cpp:353
 msgid "BMP: Couldn't write RGB color map."
 msgstr "बीएमपी: आरजीबी रंग मानचित्र को नहीं लिखा जा सका।"
 
-#: ../src/common/imagbmp.cpp:490
+#: ../src/common/imagbmp.cpp:487
 msgid "BMP: Couldn't write data."
 msgstr "बीएमपी: सूचना को नहीं लिखा जा सका।"
 
-#: ../src/common/imagbmp.cpp:246
+#: ../src/common/imagbmp.cpp:243
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "बीएमपी: इस फ़ाइल के (बिट्मैप) शीर्षक को नहीं लिखा जा सका।"
 
-#: ../src/common/imagbmp.cpp:269
+#: ../src/common/imagbmp.cpp:266
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "बीएमपी: इस फ़ाइल के (बिट्मैपइन्फ़ो) शीर्षक को नहीं लिखा जा सका।"
 
-#: ../src/common/imagbmp.cpp:140
+#: ../src/common/imagbmp.cpp:137
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "बीएमपी: डब्लूएक्सइमेज के पास स्वंम का डब्लूएक्सपैलेट नहीं है।"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:142 ../src/common/accelcmn.cpp:52
+#: ../src/common/stockitem.cpp:139 ../src/common/accelcmn.cpp:49
 #, fuzzy
 msgid "Back"
 msgstr "पीछे (&B)"
 
+#: ../src/richtext/richtextformatdlg.cpp:377
 #: ../src/richtext/richtextbackgroundpage.cpp:148
-#: ../src/richtext/richtextformatdlg.cpp:384
 #, fuzzy
 msgid "Background"
 msgstr "पृष्टभूमि रंग"
@@ -1537,21 +1533,21 @@ msgstr "पृष्टभूमि रंग"
 msgid "Background &colour:"
 msgstr "पृष्टभूमि रंग"
 
-#: ../src/osx/carbon/fontdlg.cpp:220
+#: ../src/osx/carbon/fontdlg.cpp:217
 msgid "Background colour"
 msgstr "पृष्टभूमि रंग"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:52
+#: ../src/common/accelcmn.cpp:49
 #, fuzzy
 msgid "Backspace"
 msgstr "पीछे (&B)"
 
-#: ../src/common/fmapbase.cpp:160
+#: ../src/common/fmapbase.cpp:157
 msgid "Baltic (ISO-8859-13)"
 msgstr "बाल्टिक (आईसो-८८५९-१३)"
 
-#: ../src/common/fmapbase.cpp:151
+#: ../src/common/fmapbase.cpp:148
 msgid "Baltic (old) (ISO-8859-4)"
 msgstr "बाल्टिक (प्राचीन) (आईसो-८८५९-४)"
 
@@ -1564,25 +1560,25 @@ msgstr "अनुच्छेद के पहले:"
 msgid "Bitmap"
 msgstr "बिट्मैप"
 
-#: ../src/propgrid/advprops.cpp:1594
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Black"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1755
+#: ../src/propgrid/advprops.cpp:1656
 msgid "Blank"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1603
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Blue"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:345
+#: ../src/generic/colrdlgg.cpp:365
 msgid "Blue:"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:333 ../src/richtext/richtextfontpage.cpp:355
-#: ../src/osx/carbon/fontdlg.cpp:354 ../src/common/stockitem.cpp:143
+#: ../src/osx/carbon/fontdlg.cpp:351 ../src/common/stockitem.cpp:140
+#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:355
 msgid "Bold"
 msgstr "गहरा"
 
@@ -1592,34 +1588,38 @@ msgstr "गहरा"
 msgid "Border"
 msgstr "आधुनिक"
 
-#: ../src/richtext/richtextformatdlg.cpp:379
+#: ../src/richtext/richtextformatdlg.cpp:372
 #, fuzzy
 msgid "Borders"
 msgstr "आधुनिक"
 
-#: ../src/richtext/richtextsizepage.cpp:288 ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141 ../src/richtext/richtextsizepage.cpp:288
 msgid "Bottom"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:893
+#: ../src/generic/prntdlgg.cpp:886
 msgid "Bottom margin (mm):"
 msgstr "तल मार्जिन (मिलीमीटर):"
 
-#: ../src/richtext/richtextbuffer.cpp:9383
+#: ../src/richtext/richtextbuffer.cpp:9380
 #, fuzzy
 msgid "Box Properties"
 msgstr "गुणधर्म (&P)"
 
-#: ../src/richtext/richtextstyles.cpp:1065
+#: ../src/richtext/richtextstyles.cpp:1062
 #, fuzzy
 msgid "Box styles"
 msgstr "सभी शैलियाँ"
 
-#: ../src/propgrid/advprops.cpp:1602
+#: ../src/osx/cocoa/menu.mm:292
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Brown"
 msgstr ""
 
-#: ../src/common/filepickercmn.cpp:43 ../src/common/filepickercmn.cpp:44
+#: ../src/common/filepickercmn.cpp:40 ../src/common/filepickercmn.cpp:41
 msgid "Browse"
 msgstr ""
 
@@ -1632,73 +1632,73 @@ msgstr "बुल्लेट सरेखण (&A):"
 msgid "Bullet style"
 msgstr "बुल्लेट शैली"
 
-#: ../src/richtext/richtextformatdlg.cpp:359
+#: ../src/richtext/richtextformatdlg.cpp:352
 msgid "Bullets"
 msgstr "बुल्लेतो"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1756
+#: ../src/propgrid/advprops.cpp:1657
 #, fuzzy
 msgid "Bullseye"
 msgstr "बुल्लेट शैली"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:875
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonFace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:876
+#: ../src/propgrid/advprops.cpp:777
 msgid "ButtonHighlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:877
+#: ../src/propgrid/advprops.cpp:778
 msgid "ButtonShadow"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:878
+#: ../src/propgrid/advprops.cpp:779
 msgid "ButtonText"
 msgstr ""
 
-#: ../src/common/paper.cpp:98
+#: ../src/common/paper.cpp:95
 msgid "C sheet, 17 x 22 in"
 msgstr "सी पत्र, १७ x २२ इंच"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "C&lear"
 msgstr "साफ़ करें (&l)"
 
-#: ../src/generic/fontdlgg.cpp:406
+#: ../src/generic/fontdlgg.cpp:403
 msgid "C&olour:"
 msgstr "रंग (&o):"
 
-#: ../src/common/paper.cpp:123
+#: ../src/common/paper.cpp:120
 msgid "C3 Envelope, 324 x 458 mm"
 msgstr "सी३ लिफ़ाफ़ा, ३२४ x ४५८ मिलीमीटर"
 
-#: ../src/common/paper.cpp:124
+#: ../src/common/paper.cpp:121
 msgid "C4 Envelope, 229 x 324 mm"
 msgstr "सी४ लिफ़ाफ़ा, २२९ x ३२४ मिलीमीटर"
 
-#: ../src/common/paper.cpp:122
+#: ../src/common/paper.cpp:119
 msgid "C5 Envelope, 162 x 229 mm"
 msgstr "सी५ लिफ़ाफ़ा, १६२ x २२९ मिलीमीटर"
 
-#: ../src/common/paper.cpp:125
+#: ../src/common/paper.cpp:122
 msgid "C6 Envelope, 114 x 162 mm"
 msgstr "सी६ लिफ़ाफ़ा, ११४ x १६२ मिलीमीटर"
 
-#: ../src/common/paper.cpp:126
+#: ../src/common/paper.cpp:123
 msgid "C65 Envelope, 114 x 229 mm"
 msgstr "सी६५ लिफ़ाफ़ा, ११४ x 229 मिलीमीटर"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "CD-Rom"
 msgstr ""
 
-#: ../src/html/chm.cpp:815 ../src/html/chm.cpp:874
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:865
 msgid "CHM handler currently supports only local files!"
 msgstr "सीएचएम हैन्डलर वर्तमान में सिर्फ़ स्थानीय फ़ाइलों को ही समर्थन देता है!"
 
@@ -1706,191 +1706,195 @@ msgstr "सीएचएम हैन्डलर वर्तमान में
 msgid "Ca&pitals"
 msgstr "बड़े अक्षर (&P)"
 
-#: ../src/common/cmdproc.cpp:267
+#: ../src/common/cmdproc.cpp:260
 msgid "Can't &Undo "
 msgstr "पहिले जैसा नहीं किया जा सकता है (&U)"
 
-#: ../src/common/image.cpp:2824
+#: ../src/common/image.cpp:2924
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 
-#: ../src/msw/registry.cpp:506
+#: ../src/msw/registry.cpp:495
 #, c-format
 msgid "Can't close registry key '%s'"
 msgstr "'%s' रजिस्ट्री कुँजी को बन्द नहीं किया जा सकता है"
 
-#: ../src/msw/registry.cpp:584
+#: ../src/msw/registry.cpp:573
 #, c-format
 msgid "Can't copy values of unsupported type %d."
 msgstr "%d असमर्थित प्रकार के मूल्यों की प्रतिलिपि नहीं बनायी जा सकती है।"
 
-#: ../src/msw/registry.cpp:487
+#: ../src/msw/registry.cpp:476
 #, c-format
 msgid "Can't create registry key '%s'"
 msgstr "'%s' रजिस्ट्री कुँजी का निर्माण नहीं किया जा सकता है"
 
-#: ../src/msw/thread.cpp:665
+#: ../src/msw/thread.cpp:657
 msgid "Can't create thread"
 msgstr "थ्रेड का निर्माण नहीं किया जा सकता है"
 
-#: ../src/msw/window.cpp:3691
-#, c-format
-msgid "Can't create window of class %s"
-msgstr "%s वर्ग की खिड़की का निर्माण नहीं किया जा सकता है"
-
-#: ../src/msw/registry.cpp:777
+#: ../src/msw/registry.cpp:765
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "'%s' कुँजी को हटाया नहीं जा सकता है"
 
-#: ../src/msw/iniconf.cpp:458
+#: ../src/msw/iniconf.cpp:455
 #, c-format
 msgid "Can't delete the INI file '%s'"
 msgstr " '%s' आईएनआई फ़ाइल को हटाया नहीं जा सकता है"
 
-#: ../src/msw/registry.cpp:805
+#: ../src/msw/registry.cpp:793
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "'%s' मूल्य को '%s' कुँजी से हटाया नहीं जा सकता है"
 
-#: ../src/msw/registry.cpp:1171
+#: ../src/msw/registry.cpp:1159
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "'%s' कुँजी की उपकुँजियों की परिगणना नहीं की जा सकती है"
 
-#: ../src/msw/registry.cpp:1132
+#: ../src/msw/registry.cpp:1120
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "'%s' कुँजी के मूल्यों की परिगणना नहीं की जा सकती है"
 
-#: ../src/msw/registry.cpp:1389
+#: ../src/msw/registry.cpp:1377
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "%d असमर्थित प्रकार के मूल्यों की प्रतिलिपि नहीं बनायी जा सकती है।"
 
-#: ../src/common/ffile.cpp:254
+#: ../src/common/ffile.cpp:253
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr " '%s' फ़ाइल में वर्तमान स्थिति नहीं खोजी जा सकती है"
 
-#: ../src/msw/registry.cpp:418
+#: ../src/msw/registry.cpp:407
 #, c-format
 msgid "Can't get info about registry key '%s'"
 msgstr "'%s' पंजीकरण कुँजी के बारे में सूचना प्राप्त नहीं की जा सकती है"
 
-#: ../src/common/zstream.cpp:346
+#: ../src/msw/webview_ie.cpp:1024
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "थ्रेड की वरीयता की स्थापना नहीं की जा सकती है"
+
+#: ../src/common/zstream.cpp:343
 msgid "Can't initialize zlib deflate stream."
 msgstr "जेडलिब् डीफ़्लेट धारा का आरम्भीकरण नहीं किया जा सकता है।"
 
-#: ../src/common/zstream.cpp:185
+#: ../src/common/zstream.cpp:182
 msgid "Can't initialize zlib inflate stream."
 msgstr "जेडलिब् इनफ़्लेट धारा का आरम्भीकरण नहीं किया जा सकता है।"
 
-#: ../src/msw/fswatcher.cpp:476
+#: ../src/msw/fswatcher.cpp:475
 #, c-format
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr ""
 
-#: ../src/msw/registry.cpp:454
+#: ../src/msw/registry.cpp:443
 #, c-format
 msgid "Can't open registry key '%s'"
 msgstr "'%s' पंजीकरण कुँजी को खोला नहीं जा सकता है"
 
-#: ../src/common/zstream.cpp:252
+#: ../src/common/zstream.cpp:249
 #, c-format
 msgid "Can't read from inflate stream: %s"
 msgstr "इनफ़्लेट धारा से पढ़ा नहीं जा सकता है: %s"
 
-#: ../src/common/zstream.cpp:244
+#: ../src/common/zstream.cpp:241
 msgid "Can't read inflate stream: unexpected EOF in underlying stream."
 msgstr "इनफ़्लेट धारा को पढ़ा नहीं जा सकता है: नीचेवाली स्ट्रीम में आकस्मिक फ़ाइल का अंत।"
 
-#: ../src/msw/registry.cpp:1064
+#: ../src/msw/registry.cpp:1052
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "'%s' के मूल्य को पढ़ा नहीं जा सकता है"
 
-#: ../src/msw/registry.cpp:878 ../src/msw/registry.cpp:910
-#: ../src/msw/registry.cpp:975
+#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
+#: ../src/msw/registry.cpp:963
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "'%s' कुँजी के मूल्य को पढ़ा नहीं जा सकता है"
 
-#: ../src/common/image.cpp:2620
+#: ../src/msw/webview_ie.cpp:1017
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/common/image.cpp:2715
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "आकॄति को '%s' फ़ाइले में सुरक्षित नहीं किया जा सकता है: अज्ञात उपनाम।"
 
-#: ../src/generic/logg.cpp:573 ../src/generic/logg.cpp:976
+#: ../src/generic/logg.cpp:570 ../src/generic/logg.cpp:973
 msgid "Can't save log contents to file."
 msgstr "लॉग विषयवस्तुओं को फ़ाइल में सुरक्षित नहीं किया जा सकता है। "
 
-#: ../src/msw/thread.cpp:629
+#: ../src/msw/thread.cpp:621
 msgid "Can't set thread priority"
 msgstr "थ्रेड की वरीयता की स्थापना नहीं की जा सकती है"
 
-#: ../src/msw/registry.cpp:896 ../src/msw/registry.cpp:938
-#: ../src/msw/registry.cpp:1081
+#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
+#: ../src/msw/registry.cpp:1069
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "'%s' के मूल्य की स्थापना नहीं की जा सकती है"
 
-#: ../src/unix/utilsunx.cpp:351
+#: ../src/unix/utilsunx.cpp:353
 #, fuzzy
 msgid "Can't write to child process's stdin"
 msgstr "%d प्रोसेस को खत्म करने में असफ़ल"
 
-#: ../src/common/zstream.cpp:427
+#: ../src/common/zstream.cpp:424
 #, c-format
 msgid "Can't write to deflate stream: %s"
 msgstr "डीफ़्लेट धारा पर लिखा नहीं जा सकता है: %s"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:279 ../src/richtext/richtextstyledlg.cpp:300
-#: ../src/common/stockitem.cpp:145 ../src/common/accelcmn.cpp:71
-#: ../src/msw/msgdlg.cpp:454 ../src/msw/progdlg.cpp:673
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:142
+#: ../src/common/accelcmn.cpp:68 ../src/motif/msgdlg.cpp:196
+#: ../src/gtk1/fontdlg.cpp:144 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/progdlg.cpp:940 ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "निरस्त"
 
-#: ../src/common/filefn.cpp:1261
+#: ../src/common/filefn.cpp:1149
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "'%s' फ़ाइलों की परिगणना नहीं की जा सकती है"
 
-#: ../src/msw/dir.cpp:263
+#: ../src/msw/dir.cpp:260
 #, c-format
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "'%s' निर्देशिका में फ़ाइलों की परिगणना नहीं की जा सकती है"
 
-#: ../src/msw/dialup.cpp:523
+#: ../src/msw/dialup.cpp:517
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "सक्रिय डायल-अप कनेक्शन को खोजा नहीं जा सका: %s"
 
-#: ../src/msw/dialup.cpp:827
+#: ../src/msw/dialup.cpp:821
 msgid "Cannot find the location of address book file"
 msgstr "पता पुस्तिका फ़ाइल के स्थान को नहीं खोजा जा सका"
 
-#: ../src/msw/ole/automtn.cpp:562
+#: ../src/msw/ole/automtn.cpp:553
 #, fuzzy, c-format
 msgid "Cannot get an active instance of \"%s\""
 msgstr "सक्रिय डायल-अप कनेक्शन को खोजा नहीं जा सका: %s"
 
-#: ../src/unix/threadpsx.cpp:1035
+#: ../src/unix/threadpsx.cpp:1053
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "%d नीति की समय-सारणी के लिए वरीयता सीमा को नहीं प्राप्त किया जा सका"
 
-#: ../src/unix/utilsunx.cpp:987
+#: ../src/unix/utilsunx.cpp:989
 msgid "Cannot get the hostname"
 msgstr "होस्टनाम को प्राप्त नहीं किया जा सका"
 
-#: ../src/unix/utilsunx.cpp:1023
+#: ../src/unix/utilsunx.cpp:1025
 msgid "Cannot get the official hostname"
 msgstr "अधिकारिक होस्टनाम को प्राप्त नहीं किया जा सका"
 
-#: ../src/msw/dialup.cpp:928
+#: ../src/msw/dialup.cpp:922
 msgid "Cannot hang up - no active dialup connection."
 msgstr "संबंध-विच्छेद नहीं किया जा सका - कोई सक्रिय डायल-अप कनेक्शन नहीं।"
 
@@ -1898,129 +1902,129 @@ msgstr "संबंध-विच्छेद नहीं किया जा �
 msgid "Cannot initialize OLE"
 msgstr "ओएलई का आरम्भीकरण नहीं किया जा सकता है"
 
-#: ../src/common/socket.cpp:853
+#: ../src/common/socket.cpp:850
 #, fuzzy
 msgid "Cannot initialize sockets"
 msgstr "ओएलई का आरम्भीकरण नहीं किया जा सकता है"
 
-#: ../src/msw/volume.cpp:619
+#: ../src/msw/volume.cpp:627
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "'%s' से आइकॉन को लाया नहीं जा सकता है।"
 
-#: ../src/xrc/xmlres.cpp:360
+#: ../src/xrc/xmlres.cpp:358
 #, fuzzy, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "'%s' फ़ाइल से स्रोत संसाधनों को नहीं लाया जा सकता है।"
 
-#: ../src/xrc/xmlres.cpp:742
+#: ../src/xrc/xmlres.cpp:740
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "'%s' फ़ाइल से स्रोत संसाधनों को नहीं लाया जा सकता है।"
 
-#: ../src/html/htmlfilt.cpp:137
+#: ../src/html/htmlfilt.cpp:134
 #, c-format
 msgid "Cannot open HTML document: %s"
 msgstr "एचटीएमएल प्रलेख को नहीं खोला जा सका: %s"
 
-#: ../src/html/helpdata.cpp:667
+#: ../src/html/helpdata.cpp:660
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "एचटीएमएल सहायता प्रलेख को नहीं खोला जा सका: %s"
 
-#: ../src/html/helpdata.cpp:299
+#: ../src/html/helpdata.cpp:296
 #, c-format
 msgid "Cannot open contents file: %s"
 msgstr "विषयवस्तु फ़ाइल को नहीं खोला जा सका: %s"
 
-#: ../src/generic/dcpsg.cpp:1667
+#: ../src/generic/dcpsg.cpp:1665
 msgid "Cannot open file for PostScript printing!"
 msgstr "पोस्टस्क्रिप्ट मुद्रण के लिए फ़ाइल को खोला नहीं जा सका!"
 
-#: ../src/html/helpdata.cpp:313
+#: ../src/html/helpdata.cpp:310
 #, c-format
 msgid "Cannot open index file: %s"
 msgstr "इंडेक्स फ़ाइल को खोला नहीं जा सका: %s"
 
-#: ../src/xrc/xmlres.cpp:724
+#: ../src/xrc/xmlres.cpp:722
 #, fuzzy, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "'%s' फ़ाइल से स्रोत संसाधनों को नहीं लाया जा सकता है।"
 
-#: ../src/html/helpwnd.cpp:1534
+#: ../src/html/helpwnd.cpp:1532
 msgid "Cannot print empty page."
 msgstr "खाली पृष्ट को मुद्रित नहीं किया जा सकता है।"
 
-#: ../src/msw/volume.cpp:507
+#: ../src/msw/volume.cpp:515
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "'%s' से टाइपनाम को पढ़ा नहीं जा सका!"
 
-#: ../src/msw/thread.cpp:888
+#: ../src/msw/thread.cpp:894
 #, fuzzy, c-format
 msgid "Cannot resume thread %lx"
 msgstr "%x थ्रेड को समान-बिन्दु से पुनः आरम्भ नहीं किया जा सकता है"
 
-#: ../src/unix/threadpsx.cpp:1016
+#: ../src/unix/threadpsx.cpp:1028
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "थ्रेड समय-सारणी नीति को प्राप्त नहीं किया जा सकता है।"
 
-#: ../src/common/intl.cpp:558
+#: ../src/common/intl.cpp:365
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:831 ../src/msw/thread.cpp:546
+#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
 msgid "Cannot start thread: error writing TLS."
 msgstr "थ्रेड को आरम्भ नहीं किया जा सकता है: टीएलएस लेखन में त्रुटि"
 
-#: ../src/msw/thread.cpp:872
+#: ../src/msw/thread.cpp:864
 #, fuzzy, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "%x थ्रेड को अधर में नहीं छोड़ा जा सकता है"
 
-#: ../src/msw/thread.cpp:794
+#: ../src/msw/thread.cpp:786
 msgid "Cannot wait for thread termination"
 msgstr "थ्रेड समाप्ति की प्रतीक्षा नहीं की जा सकती है"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:75
+#: ../src/common/accelcmn.cpp:72
 #, fuzzy
 msgid "Capital"
 msgstr "बड़े अक्षर (&P)"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:879
+#: ../src/propgrid/advprops.cpp:780
 msgid "CaptionText"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:531
 msgid "Case sensitive"
 msgstr "छोटा-बड़ा संवेदी"
 
-#: ../src/propgrid/manager.cpp:1509
+#: ../src/propgrid/manager.cpp:1527
 msgid "Categorized Mode"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9968
+#: ../src/richtext/richtextbuffer.cpp:9965
 #, fuzzy
 msgid "Cell Properties"
 msgstr "गुणधर्म (&P)"
 
-#: ../src/common/fmapbase.cpp:161
+#: ../src/common/fmapbase.cpp:158
 msgid "Celtic (ISO-8859-14)"
 msgstr "सेल्टिक (आईसो-८८५९-१४)"
 
-#: ../src/richtext/richtextindentspage.cpp:160
 #: ../src/richtext/richtextliststylepage.cpp:349
+#: ../src/richtext/richtextindentspage.cpp:160
 msgid "Cen&tred"
 msgstr "केन्द्रित करें (&T)"
 
-#: ../src/common/stockitem.cpp:170
+#: ../src/common/stockitem.cpp:167
 msgid "Centered"
 msgstr "केन्द्रित करें"
 
-#: ../src/common/fmapbase.cpp:149
+#: ../src/common/fmapbase.cpp:146
 msgid "Central European (ISO-8859-2)"
 msgstr "केन्द्रीय यूरोपियन (आईसो-८८५९-२)"
 
@@ -2029,10 +2033,10 @@ msgstr "केन्द्रीय यूरोपियन (आईसो-८�
 msgid "Centre"
 msgstr "केन्द्रित करें"
 
-#: ../src/richtext/richtextindentspage.cpp:162
-#: ../src/richtext/richtextindentspage.cpp:164
 #: ../src/richtext/richtextliststylepage.cpp:351
 #: ../src/richtext/richtextliststylepage.cpp:353
+#: ../src/richtext/richtextindentspage.cpp:162
+#: ../src/richtext/richtextindentspage.cpp:164
 msgid "Centre text."
 msgstr "पाठ को केन्द्रित करें।"
 
@@ -2046,26 +2050,26 @@ msgstr "केन्द्रित करें (&T)"
 msgid "Ch&oose..."
 msgstr "चयन करें (&O)..."
 
-#: ../src/richtext/richtextbuffer.cpp:4354
+#: ../src/richtext/richtextbuffer.cpp:4351
 msgid "Change List Style"
 msgstr "सूची शैली बदले"
 
-#: ../src/richtext/richtextbuffer.cpp:3709
+#: ../src/richtext/richtextbuffer.cpp:3706
 #, fuzzy
 msgid "Change Object Style"
 msgstr "सूची शैली बदले"
 
-#: ../src/richtext/richtextbuffer.cpp:3982
-#: ../src/richtext/richtextbuffer.cpp:8129
+#: ../src/richtext/richtextbuffer.cpp:3979
+#: ../src/richtext/richtextbuffer.cpp:8125
 #, fuzzy
 msgid "Change Properties"
 msgstr "गुणधर्म (&P)"
 
-#: ../src/richtext/richtextbuffer.cpp:3526
+#: ../src/richtext/richtextbuffer.cpp:3523
 msgid "Change Style"
 msgstr "शैली बदले"
 
-#: ../src/common/fileconf.cpp:341
+#: ../src/common/fileconf.cpp:335
 #, c-format
 msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
 msgstr ""
@@ -2076,12 +2080,12 @@ msgid "Changing current directory to \"%s\" failed"
 msgstr "\"%s\" निर्देशिका का निर्माण करने में असफ़ल।"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1757
+#: ../src/propgrid/advprops.cpp:1658
 #, fuzzy
 msgid "Character"
 msgstr "संप्रतीक कूट (&C):"
 
-#: ../src/richtext/richtextstyles.cpp:1063
+#: ../src/richtext/richtextstyles.cpp:1060
 msgid "Character styles"
 msgstr "संप्रतीक शैलियाँ"
 
@@ -2118,20 +2122,20 @@ msgstr ""
 msgid "Check to indicate right-to-left text layout."
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:356 ../src/osx/carbon/fontdlg.cpp:358
+#: ../src/osx/carbon/fontdlg.cpp:353 ../src/osx/carbon/fontdlg.cpp:355
 msgid "Check to make the font bold."
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:363 ../src/osx/carbon/fontdlg.cpp:365
+#: ../src/osx/carbon/fontdlg.cpp:360 ../src/osx/carbon/fontdlg.cpp:362
 msgid "Check to make the font italic."
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:372 ../src/osx/carbon/fontdlg.cpp:374
+#: ../src/osx/carbon/fontdlg.cpp:369 ../src/osx/carbon/fontdlg.cpp:371
 msgid "Check to make the font underlined."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:289
-#: ../src/richtext/richtextstyledlg.cpp:291
+#: ../src/richtext/richtextstyledlg.cpp:285
+#: ../src/richtext/richtextstyledlg.cpp:287
 msgid "Check to restart numbering."
 msgstr "संख्यांकन पुनः प्रारम्भन करने के लिए चेक करें।"
 
@@ -2165,55 +2169,55 @@ msgstr ""
 msgid "Check to suppress hyphenation."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:763
+#: ../src/msw/dialup.cpp:757
 msgid "Choose ISP to dial"
 msgstr "डायल करने के लिए आईएसपी का चयन करें"
 
-#: ../src/propgrid/props.cpp:1922
+#: ../src/propgrid/props.cpp:1904
 #, fuzzy
 msgid "Choose a directory:"
 msgstr "निर्देशिका का निर्माण करें"
 
-#: ../src/propgrid/props.cpp:1975
+#: ../src/propgrid/props.cpp:2199
 #, fuzzy
 msgid "Choose a file"
 msgstr "फ़ॉन्ट का चयन करें"
 
-#: ../src/generic/colrdlgg.cpp:158 ../src/gtk/colordlg.cpp:54
+#: ../src/generic/colrdlgg.cpp:156 ../src/gtk/colordlg.cpp:49
 msgid "Choose colour"
 msgstr "रंग का चयन करें"
 
-#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/gtk1/fontdlg.cpp:125 ../src/generic/fontpickerg.cpp:47
+#: ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "फ़ॉन्ट का चयन करें"
 
-#: ../src/common/module.cpp:74
+#: ../src/common/module.cpp:71
 #, c-format
 msgid "Circular dependency involving module \"%s\" detected."
 msgstr ""
 
-#: ../src/aui/tabmdi.cpp:108 ../src/generic/mdig.cpp:97
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
 msgid "Cl&ose"
 msgstr "समाप्त करें (&o)"
 
-#: ../src/msw/ole/automtn.cpp:684
+#: ../src/msw/ole/automtn.cpp:675
 #, fuzzy
 msgid "Class not registered."
 msgstr "थ्रेड का निर्माण नहीं किया जा सकता है"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:147 ../src/common/accelcmn.cpp:72
+#: ../src/common/stockitem.cpp:144 ../src/common/accelcmn.cpp:69
 #, fuzzy
 msgid "Clear"
 msgstr "साफ़ करें (&C)"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "Clear the log contents"
 msgstr "लॉग विषय-वस्तुओं को साफ़ करें"
 
-#: ../src/richtext/richtextstyledlg.cpp:252
-#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:248
+#: ../src/richtext/richtextstyledlg.cpp:250
 msgid "Click to apply the selected style."
 msgstr ""
 
@@ -2224,15 +2228,15 @@ msgstr ""
 msgid "Click to browse for a symbol."
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:403 ../src/osx/carbon/fontdlg.cpp:405
+#: ../src/osx/carbon/fontdlg.cpp:400 ../src/osx/carbon/fontdlg.cpp:402
 msgid "Click to cancel changes to the font."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:472 ../src/generic/fontdlgg.cpp:491
+#: ../src/generic/fontdlgg.cpp:468 ../src/generic/fontdlgg.cpp:487
 msgid "Click to cancel the font selection."
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:384 ../src/osx/carbon/fontdlg.cpp:386
+#: ../src/osx/carbon/fontdlg.cpp:381 ../src/osx/carbon/fontdlg.cpp:383
 msgid "Click to change the font colour."
 msgstr ""
 
@@ -2251,37 +2255,37 @@ msgstr ""
 msgid "Click to choose the font for this level."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:279
-#: ../src/richtext/richtextstyledlg.cpp:281
+#: ../src/richtext/richtextstyledlg.cpp:275
+#: ../src/richtext/richtextstyledlg.cpp:277
 msgid "Click to close this window."
 msgstr "इस खिड़की को बंद करने के लिए क्लिक करें।"
 
-#: ../src/osx/carbon/fontdlg.cpp:410 ../src/osx/carbon/fontdlg.cpp:412
+#: ../src/osx/carbon/fontdlg.cpp:407 ../src/osx/carbon/fontdlg.cpp:409
 msgid "Click to confirm changes to the font."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:477 ../src/generic/fontdlgg.cpp:479
-#: ../src/generic/fontdlgg.cpp:484 ../src/generic/fontdlgg.cpp:486
+#: ../src/generic/fontdlgg.cpp:473 ../src/generic/fontdlgg.cpp:475
+#: ../src/generic/fontdlgg.cpp:480 ../src/generic/fontdlgg.cpp:482
 msgid "Click to confirm the font selection."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:244
-#: ../src/richtext/richtextstyledlg.cpp:246
+#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:242
 msgid "Click to create a new box style."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:226
-#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:224
 msgid "Click to create a new character style."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:238
-#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:236
 msgid "Click to create a new list style."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:232
-#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:230
 msgid "Click to create a new paragraph style."
 msgstr ""
 
@@ -2295,8 +2299,8 @@ msgstr ""
 msgid "Click to delete all tab positions."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:270
-#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:268
 msgid "Click to delete the selected style."
 msgstr ""
 
@@ -2305,25 +2309,25 @@ msgstr ""
 msgid "Click to delete the selected tab position."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:264
-#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:262
 msgid "Click to edit the selected style."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:258
-#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:256
 msgid "Click to rename the selected style."
 msgstr ""
 
-#: ../src/generic/dbgrptg.cpp:97 ../src/generic/progdlgg.cpp:759
-#: ../src/richtext/richtextstyledlg.cpp:277
-#: ../src/richtext/richtextsymboldlg.cpp:476 ../src/common/stockitem.cpp:148
-#: ../src/msw/progdlg.cpp:170 ../src/msw/progdlg.cpp:679
-#: ../src/html/helpdlg.cpp:90
+#: ../src/common/stockitem.cpp:145 ../src/generic/dbgrptg.cpp:94
+#: ../src/generic/progdlgg.cpp:781 ../src/msw/progdlg.cpp:211
+#: ../src/msw/progdlg.cpp:946 ../src/html/helpdlg.cpp:87
+#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextstyledlg.cpp:273
 msgid "Close"
 msgstr "समाप्त"
 
-#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:98
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
 msgid "Close All"
 msgstr "सभी समाप्त"
 
@@ -2331,66 +2335,66 @@ msgstr "सभी समाप्त"
 msgid "Close current document"
 msgstr "वर्तमान प्रलेख बंद करें"
 
-#: ../src/generic/logg.cpp:516
+#: ../src/generic/logg.cpp:513
 msgid "Close this window"
 msgstr "इस खिड़की को बन्द करें"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6006
+#: ../src/generic/datavgen.cpp:6811
 msgid "Collapse"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 #, fuzzy
 msgid "Color"
 msgstr "रंग"
 
-#: ../src/richtext/richtextformatdlg.cpp:776
+#: ../src/richtext/richtextformatdlg.cpp:768
 msgid "Colour"
 msgstr "रंग"
 
-#: ../src/msw/colordlg.cpp:158
+#: ../src/msw/colordlg.cpp:227
 #, fuzzy, c-format
 msgid "Colour selection dialog failed with error %0lx."
 msgstr "'%s' निर्देश का निष्पादन त्रुटि के साथ असफ़ल रहा: %ul"
 
-#: ../src/osx/carbon/fontdlg.cpp:380
+#: ../src/osx/carbon/fontdlg.cpp:377
 msgid "Colour:"
 msgstr "रंग:"
 
-#: ../src/generic/datavgen.cpp:6077
+#: ../src/generic/datavgen.cpp:6882
 #, c-format
 msgid "Column %u"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:114
+#: ../src/common/accelcmn.cpp:112
 msgid "Command"
 msgstr ""
 
-#: ../src/common/init.cpp:196
+#: ../src/common/init.cpp:193
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
 "ignored."
 msgstr ""
 
-#: ../src/msw/fontdlg.cpp:120
+#: ../src/msw/fontdlg.cpp:170
 #, c-format
 msgid "Common dialog failed with error code %0lx."
 msgstr ""
 
-#: ../src/gtk/window.cpp:4649
+#: ../src/gtk/window.cpp:5653
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:1549
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "संकुचित एचटीएमएल सहायता फ़ाइल (*.chm)|*.chm|"
 
-#: ../src/generic/dirctrlg.cpp:444
+#: ../src/generic/dirctrlg.cpp:410
 msgid "Computer"
 msgstr "कम्प्यूटर"
 
@@ -2399,55 +2403,59 @@ msgstr "कम्प्यूटर"
 msgid "Config entry name cannot start with '%c'."
 msgstr "संरचना प्रविष्टी नाम '%c' से आरम्भ नहीं हो सकता है।"
 
-#: ../src/generic/filedlgg.cpp:349 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
 msgid "Confirm"
 msgstr "संपुष्टी दें"
 
-#: ../src/html/htmlwin.cpp:566
+#: ../src/html/htmlwin.cpp:569
 msgid "Connecting..."
 msgstr "जुड़ा जा रहा है..."
 
-#: ../src/html/helpwnd.cpp:475
+#: ../src/html/helpwnd.cpp:473
 msgid "Contents"
 msgstr "विषय-वस्तु"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:880
+#: ../src/propgrid/advprops.cpp:781
 msgid "ControlDark"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:881
+#: ../src/propgrid/advprops.cpp:782
 msgid "ControlLight"
 msgstr ""
 
-#: ../src/common/strconv.cpp:2262
+#: ../src/common/strconv.cpp:2208
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "'%s' शब्दसमुच्चय में रूपांतरण ने कार्य नहीं किया।"
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 #, fuzzy
 msgid "Convert"
 msgstr "विषय-वस्तु"
 
-#: ../src/html/htmlwin.cpp:1079
+#: ../src/html/htmlwin.cpp:1020
 #, c-format
 msgid "Copied to clipboard:\"%s\""
 msgstr "क्लिपबोर्ड में प्रतिलिपि बनायी गयी:\"%s\""
 
-#: ../src/generic/prntdlgg.cpp:247
+#: ../src/generic/prntdlgg.cpp:240
 msgid "Copies:"
 msgstr "प्रतिलिपियां:"
 
-#: ../src/common/stockitem.cpp:150 ../src/stc/stc_i18n.cpp:18
+#: ../src/common/stockitem.cpp:147 ../src/stc/stc_i18n.cpp:18
 #, fuzzy
 msgid "Copy"
 msgstr "प्रतिलिपि बनाएँ (&C)"
 
-#: ../src/common/stockitem.cpp:258
+#: ../src/common/stockitem.cpp:255
 msgid "Copy selection"
 msgstr "चयन की प्रतिलिपि बनाएँ"
+
+#: ../src/generic/grid.cpp:5945
+msgid "Copying more than one selected block to clipboard is not supported."
+msgstr ""
 
 #: ../src/richtext/richtextborderspage.cpp:566
 #: ../src/richtext/richtextborderspage.cpp:601
@@ -2458,208 +2466,202 @@ msgstr ""
 msgid "Corner &radius:"
 msgstr ""
 
-#: ../src/html/chm.cpp:718
+#: ../src/html/chm.cpp:711
 #, c-format
 msgid "Could not create temporary file '%s'"
 msgstr "'%s' अस्थायी फ़ाइल का निर्माण नहीं हो सका"
 
-#: ../src/html/chm.cpp:273
+#: ../src/html/chm.cpp:270
 #, c-format
 msgid "Could not extract %s into %s: %s"
 msgstr "%s का %s में निष्कर्षण नहीं किया जा सका: %s"
 
-#: ../src/generic/tabg.cpp:1048
+#: ../src/generic/tabg.cpp:1045
 msgid "Could not find tab for id"
 msgstr "आईडी के लिए टैब को नहीं पाया जा सका"
 
-#: ../src/gtk/notifmsg.cpp:108
-#, fuzzy
-msgid "Could not initalize libnotify."
-msgstr "मुद्रण को आरम्भ नहीं किया जा सका।"
-
-#: ../src/html/chm.cpp:444
+#: ../src/html/chm.cpp:437
 #, c-format
 msgid "Could not locate file '%s'."
 msgstr "'%s' फ़ाइल का स्थान नहीं खोजा जा सका।"
 
-#: ../src/common/filefn.cpp:1403
+#: ../src/msw/graphicsd2d.cpp:604
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/common/filefn.cpp:1291
 #, fuzzy
 msgid "Could not set current working directory"
 msgstr "कार्यशील निर्देशिका को प्राप्त करने में असफ़ल"
 
-#: ../src/common/prntbase.cpp:2015
+#: ../src/common/prntbase.cpp:2037
 msgid "Could not start document preview."
 msgstr "प्रलेख पूर्वालोकन को आरम्भ नहीं किया जा सका।"
 
-#: ../src/generic/printps.cpp:178 ../src/msw/printwin.cpp:210
-#: ../src/gtk/print.cpp:1132
+#: ../src/generic/printps.cpp:159 ../src/msw/printwin.cpp:184
+#: ../src/gtk/print.cpp:1129
 msgid "Could not start printing."
 msgstr "मुद्रण को आरम्भ नहीं किया जा सका।"
 
-#: ../src/common/wincmn.cpp:2125
+#: ../src/common/wincmn.cpp:2126
 msgid "Could not transfer data to window"
 msgstr "डाटा को खिड़की पर स्थानान्तरित किया जा सका"
 
-#: ../src/msw/imaglist.cpp:187 ../src/msw/imaglist.cpp:224
-#: ../src/msw/imaglist.cpp:249 ../src/msw/dragimag.cpp:185
-#: ../src/msw/dragimag.cpp:220
+#: ../src/msw/imaglist.cpp:223 ../src/msw/imaglist.cpp:245
+#: ../src/msw/imaglist.cpp:270 ../src/msw/dragimag.cpp:182
+#: ../src/msw/dragimag.cpp:217
 msgid "Couldn't add an image to the image list."
 msgstr "आकॄतियों की सूची में एक आकॄति को जोड़ा नहीं जा सका।"
 
-#: ../src/osx/glcanvas_osx.cpp:414 ../src/unix/glx11.cpp:558
-#: ../src/msw/glcanvas.cpp:616
+#: ../src/osx/glcanvas_osx.cpp:411 ../src/msw/glcanvas.cpp:631
+#: ../src/unix/glegl.cpp:315 ../src/unix/glx11.cpp:559
 #, fuzzy
 msgid "Couldn't create OpenGL context"
 msgstr "एक समय-सचेतक का निर्माण नहीं किया जा सका"
 
-#: ../src/msw/timer.cpp:134
+#: ../src/msw/timer.cpp:131
 msgid "Couldn't create a timer"
 msgstr "एक समय-सचेतक का निर्माण नहीं किया जा सका"
 
-#: ../src/osx/carbon/overlay.cpp:122
-#, fuzzy
-msgid "Couldn't create the overlay window"
-msgstr "एक समय-सचेतक का निर्माण नहीं किया जा सका"
-
-#: ../src/common/translation.cpp:2024
+#: ../src/common/translation.cpp:2074
 #, fuzzy
 msgid "Couldn't enumerate translations"
 msgstr "थ्रेड को समाप्त नहीं किया जा सका"
 
-#: ../src/common/dynlib.cpp:120
+#: ../src/common/dynlib.cpp:110
 #, c-format
 msgid "Couldn't find symbol '%s' in a dynamic library"
 msgstr "एक गतिक लेखागार में '%s' चिह्न को नहीं खोजा जा सका"
 
-#: ../src/msw/thread.cpp:915
+#: ../src/msw/thread.cpp:921
 msgid "Couldn't get the current thread pointer"
 msgstr "वर्तमान थ्रेड सूचक को प्राप्त नहीं किया जा सका"
 
-#: ../src/osx/carbon/overlay.cpp:129
-#, fuzzy
-msgid "Couldn't init the context on the overlay window"
-msgstr "वर्तमान थ्रेड सूचक को प्राप्त नहीं किया जा सका"
-
-#: ../src/common/imaggif.cpp:244
+#: ../src/common/imaggif.cpp:241
 #, fuzzy
 msgid "Couldn't initialize GIF hash table."
 msgstr "जेडलिब् डीफ़्लेट धारा का आरम्भीकरण नहीं किया जा सकता है।"
 
-#: ../src/common/imagpng.cpp:409
+#: ../src/common/imagpng.cpp:437
 msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
 msgstr ""
 "एक पीएनजी आकॄति को लोड नहीं किया जा सका - या तो फ़ाइल निकृष्ट है या फ़िर आवश्यक स्मॄति "
 "का अभाव है।"
 
-#: ../src/unix/sound.cpp:470
+#: ../src/unix/sound.cpp:459
 #, c-format
 msgid "Couldn't load sound data from '%s'."
 msgstr "'%s' से ध्वनि डाटा को लोड नहीं किया जा सका।"
 
-#: ../src/msw/dirdlg.cpp:435
+#: ../src/msw/dirdlg.cpp:287
 #, fuzzy
 msgid "Couldn't obtain folder name"
 msgstr "एक समय-सचेतक का निर्माण नहीं किया जा सका"
 
-#: ../src/unix/sound_sdl.cpp:229
+#: ../src/unix/sound_sdl.cpp:226
 #, c-format
 msgid "Couldn't open audio: %s"
 msgstr "आडियो को नहीं खोला जा सका: %s"
 
-#: ../src/msw/ole/dataobj.cpp:377
+#: ../src/msw/ole/dataobj.cpp:385
 #, c-format
 msgid "Couldn't register clipboard format '%s'."
 msgstr "'%s' क्लिपबोर्ड प्रारूप को पंजीकृत नहीं किया जा सका।"
 
-#: ../src/msw/listctrl.cpp:869
+#: ../src/msw/listctrl.cpp:933
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "%d सूची नियंत्रण आयट्म के बारे में सूचना प्राप्त नहीं की जा सकी।"
 
-#: ../src/common/imagpng.cpp:498 ../src/common/imagpng.cpp:509
-#: ../src/common/imagpng.cpp:519
+#: ../src/common/imagpng.cpp:511 ../src/common/imagpng.cpp:522
+#: ../src/common/imagpng.cpp:532
 msgid "Couldn't save PNG image."
 msgstr "पीएनजी आकॄति को सुरक्षित नहीं किया जा सका।"
 
-#: ../src/msw/thread.cpp:684
+#: ../src/msw/thread.cpp:676
 msgid "Couldn't terminate thread"
 msgstr "थ्रेड को समाप्त नहीं किया जा सका"
 
-#: ../src/common/xtistrm.cpp:166
+#: ../src/common/xtistrm.cpp:163
 #, fuzzy, c-format
 msgid "Create Parameter %s not found in declared RTTI Parameters"
 msgstr "घोषित आरटीटीआई पैरामीटरों में निर्माण पैरामीटर नहीं मिला"
 
-#: ../src/generic/dirdlgg.cpp:288
+#: ../src/generic/dirdlgg.cpp:285
 msgid "Create directory"
 msgstr "निर्देशिका का निर्माण करें"
 
-#: ../src/generic/filedlgg.cpp:212 ../src/generic/dirdlgg.cpp:111
+#: ../src/generic/filedlgg.cpp:209 ../src/generic/dirdlgg.cpp:108
 msgid "Create new directory"
 msgstr "नयी निर्देशिका का निर्माण करें"
 
-#: ../src/xrc/xmlres.cpp:2460
+#: ../src/common/stockitem.cpp:264
+#, fuzzy
+msgid "Create new document"
+msgstr "नयी निर्देशिका का निर्माण करें"
+
+#: ../src/xrc/xmlres.cpp:2515
 #, fuzzy, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "'%s' का निष्कर्षण '%s' में असफ़ल रहा।"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1758
+#: ../src/propgrid/advprops.cpp:1659
 msgid "Cross"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:333
+#: ../src/common/accelcmn.cpp:347
 #, fuzzy
 msgid "Ctrl+"
 msgstr "Ctrl-"
 
-#: ../src/richtext/richtextctrl.cpp:332 ../src/osx/textctrl_osx.cpp:576
-#: ../src/common/stockitem.cpp:151 ../src/msw/textctrl.cpp:2507
+#: ../src/osx/textctrl_osx.cpp:594 ../src/common/stockitem.cpp:148
+#: ../src/msw/textctrl.cpp:2772 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "काटें (&t)"
 
-#: ../src/generic/filectrlg.cpp:940
+#: ../src/generic/filectrlg.cpp:936
 msgid "Current directory:"
 msgstr "वर्तमान निर्देशिका:"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:896 ../src/propgrid/advprops.cpp:1574
-#: ../src/propgrid/advprops.cpp:1612
+#: ../src/propgrid/advprops.cpp:797 ../src/propgrid/advprops.cpp:1475
+#: ../src/propgrid/advprops.cpp:1518
 #, fuzzy
 msgid "Custom"
 msgstr "फ़ॉन्ट आकार"
 
-#: ../src/gtk/print.cpp:217
+#: ../src/gtk/print.cpp:211
 #, fuzzy
 msgid "Custom size"
 msgstr "फ़ॉन्ट आकार"
 
-#: ../src/common/headerctrlcmn.cpp:60
+#: ../src/common/headerctrlcmn.cpp:58
 msgid "Customize Columns"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:151 ../src/stc/stc_i18n.cpp:17
+#: ../src/common/stockitem.cpp:148 ../src/stc/stc_i18n.cpp:17
 #, fuzzy
 msgid "Cut"
 msgstr "काटें (&t)"
 
-#: ../src/common/stockitem.cpp:259
+#: ../src/common/stockitem.cpp:256
 msgid "Cut selection"
 msgstr "चयन काटें"
 
-#: ../src/common/fmapbase.cpp:152
+#: ../src/common/fmapbase.cpp:149
 msgid "Cyrillic (ISO-8859-5)"
 msgstr "सायरिलिक (आईसो-८८५९-५)"
 
-#: ../src/common/paper.cpp:99
+#: ../src/common/paper.cpp:96
 msgid "D sheet, 22 x 34 in"
 msgstr "डी पत्र, २२ x 34 इंच"
 
-#: ../src/msw/dde.cpp:703
+#: ../src/msw/dde.cpp:698
 msgid "DDE poke request failed"
 msgstr "डीडीई पोक निवेदन असफ़ल रहा"
 
-#: ../src/common/imagbmp.cpp:1169
+#: ../src/common/imagbmp.cpp:1181
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr "डीआईबी शीर्ष: एन्कोडिंग बिटगहराई से मेल नहीं खाती है।"
 
@@ -2679,7 +2681,7 @@ msgstr "डीआईबी शीर्ष: फ़ाइल में अज्ञ�
 msgid "DIB Header: Unknown encoding in file."
 msgstr "डीआईबी शीर्ष: फ़ाइल में अज्ञात एन्कोडिंग।"
 
-#: ../src/common/paper.cpp:121
+#: ../src/common/paper.cpp:118
 msgid "DL Envelope, 110 x 220 mm"
 msgstr "डीएल लिफ़ाफ़ा, ११० x २२० मिलीमीटर"
 
@@ -2687,56 +2689,56 @@ msgstr "डीएल लिफ़ाफ़ा, ११० x २२० मिलीम�
 msgid "Dashed"
 msgstr ""
 
-#: ../src/generic/dbgrptg.cpp:300
+#: ../src/generic/dbgrptg.cpp:301
 #, c-format
 msgid "Debug report \"%s\""
 msgstr "दोषमार्जन विवरण \"%s\""
 
-#: ../src/common/debugrpt.cpp:210
+#: ../src/common/debugrpt.cpp:211
 msgid "Debug report couldn't be created."
 msgstr "दोषमार्जन विवरण नहीं बनाया जा सका।"
 
-#: ../src/common/debugrpt.cpp:553
+#: ../src/common/debugrpt.cpp:554
 msgid "Debug report generation has failed."
 msgstr "दोषमार्जन विवरण बनाने में असफ़ल।"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:84
+#: ../src/common/accelcmn.cpp:81
 msgid "Decimal"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:323
+#: ../src/generic/fontdlgg.cpp:319
 msgid "Decorative"
 msgstr "साज-सजावट"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1752
+#: ../src/propgrid/advprops.cpp:1653
 #, fuzzy
 msgid "Default"
 msgstr "डिफ़ाल्ट"
 
-#: ../src/common/fmapbase.cpp:796
+#: ../src/common/fmapbase.cpp:792
 msgid "Default encoding"
 msgstr "डिफ़ाल्ट एन्कोडिंग"
 
-#: ../src/dfb/fontmgr.cpp:180
+#: ../src/dfb/fontmgr.cpp:177
 #, fuzzy
 msgid "Default font"
 msgstr "डिफ़ाल्ट मुद्रक"
 
-#: ../src/generic/prntdlgg.cpp:510
+#: ../src/generic/prntdlgg.cpp:503
 msgid "Default printer"
 msgstr "डिफ़ाल्ट मुद्रक"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:51
+#: ../src/common/accelcmn.cpp:48
 #, fuzzy
 msgid "Del"
 msgstr "मिटाएँं"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextbuffer.cpp:8221 ../src/common/stockitem.cpp:152
-#: ../src/common/accelcmn.cpp:50 ../src/stc/stc_i18n.cpp:20
+#: ../src/common/stockitem.cpp:149 ../src/common/accelcmn.cpp:47
+#: ../src/richtext/richtextbuffer.cpp:8217 ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "मिटाएँं"
 
@@ -2744,71 +2746,71 @@ msgstr "मिटाएँं"
 msgid "Delete A&ll"
 msgstr "सभी मिटाएँ (&L)"
 
-#: ../src/richtext/richtextbuffer.cpp:11341
+#: ../src/richtext/richtextbuffer.cpp:11340
 #, fuzzy
 msgid "Delete Column"
 msgstr "चयन मिटाएँ"
 
-#: ../src/richtext/richtextbuffer.cpp:11291
+#: ../src/richtext/richtextbuffer.cpp:11290
 #, fuzzy
 msgid "Delete Row"
 msgstr "मिटाएँं"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 msgid "Delete Style"
 msgstr "शैली हटाएँ"
 
-#: ../src/richtext/richtextctrl.cpp:1345 ../src/richtext/richtextctrl.cpp:1584
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
 msgid "Delete Text"
 msgstr "पाठ मिटाएँ"
 
-#: ../src/generic/editlbox.cpp:170
+#: ../src/generic/editlbox.cpp:147
 msgid "Delete item"
 msgstr "आयट्म को हटाएँ"
 
-#: ../src/common/stockitem.cpp:260
+#: ../src/common/stockitem.cpp:257
 msgid "Delete selection"
 msgstr "चयन मिटाएँ"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 #, c-format
 msgid "Delete style %s?"
 msgstr "शैली हटाएँ %s?"
 
-#: ../src/unix/snglinst.cpp:301
+#: ../src/unix/snglinst.cpp:298
 #, c-format
 msgid "Deleted stale lock file '%s'."
 msgstr "हटायी जा चुकी स्टेल लॉक फ़ाइल '%s'।"
 
-#: ../src/common/secretstore.cpp:220
+#: ../src/common/secretstore.cpp:234
 #, fuzzy, c-format
-msgid "Deleting password for \"%s/%s\" failed: %s."
+msgid "Deleting password for \"%s\" failed: %s."
 msgstr "'%s' का निष्कर्षण '%s' में असफ़ल रहा।"
 
-#: ../src/common/module.cpp:124
+#: ../src/common/module.cpp:121
 #, c-format
 msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 #, fuzzy
 msgid "Descending"
 msgstr "डिफ़ाल्ट एन्कोडिंग"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:526 ../src/propgrid/advprops.cpp:882
+#: ../src/generic/dirctrlg.cpp:492 ../src/propgrid/advprops.cpp:783
 msgid "Desktop"
 msgstr "डेस्कटॉप"
 
-#: ../src/generic/aboutdlgg.cpp:70
+#: ../src/generic/aboutdlgg.cpp:67
 msgid "Developed by "
 msgstr "द्वारा विकसित"
 
-#: ../src/generic/aboutdlgg.cpp:176
+#: ../src/generic/aboutdlgg.cpp:173
 msgid "Developers"
 msgstr "विकासक"
 
-#: ../src/msw/dialup.cpp:374
+#: ../src/msw/dialup.cpp:368
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -2816,11 +2818,11 @@ msgstr ""
 "डायल-अप क्रियाऐं अनुपलब्ध है क्योंकि इस मशीन पर सुदूर पहुँच सेवा (आरऐएस)संसाधित नहीं है। "
 "कॄपया इसे संसाधित करें।"
 
-#: ../src/generic/tipdlg.cpp:211
+#: ../src/generic/tipdlg.cpp:208
 msgid "Did you know..."
 msgstr "क्या आप जानते है..."
 
-#: ../src/dfb/wrapdfb.cpp:63
+#: ../src/dfb/wrapdfb.cpp:60
 #, c-format
 msgid "DirectFB error %d occurred."
 msgstr ""
@@ -2829,75 +2831,75 @@ msgstr ""
 msgid "Directories"
 msgstr "निर्देशिकाओं"
 
-#: ../src/common/filefn.cpp:1183
+#: ../src/common/filefn.cpp:1071
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "'%s' निर्देशिका का निर्माण नहीं किया जा सकता था"
 
-#: ../src/common/filefn.cpp:1197
+#: ../src/common/filefn.cpp:1085
 #, fuzzy, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "'%s' निर्देशिका का निर्माण नहीं किया जा सकता था"
 
-#: ../src/generic/dirdlgg.cpp:204
+#: ../src/generic/dirdlgg.cpp:201
 msgid "Directory does not exist"
 msgstr "निर्देशिका विद्यमान नहीं है"
 
-#: ../src/generic/filectrlg.cpp:1399
+#: ../src/generic/filectrlg.cpp:1388
 msgid "Directory doesn't exist."
 msgstr "निर्देशिका विद्यमान नहीं है।"
 
-#: ../src/common/docview.cpp:457
+#: ../src/common/docview.cpp:450
 msgid "Discard changes and reload the last saved version?"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:502
+#: ../src/html/helpwnd.cpp:500
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
 msgstr ""
 "सभी इंडेक्स आयट्मों को दिखाएँ जिनमें दी गयी उपश्रेणी शामिल हो।खोज छोटा-बड़ा संवेदी है।"
 
-#: ../src/html/helpwnd.cpp:679
+#: ../src/html/helpwnd.cpp:677
 msgid "Display options dialog"
 msgstr "विकल्पों का संवाद दिखाएँ"
 
-#: ../src/html/helpwnd.cpp:322
+#: ../src/html/helpwnd.cpp:320
 msgid "Displays help as you browse the books on the left."
 msgstr "सहायता दिखाएँ जब आप सरसरी नजर से बायें में किताबें देखे।"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:85
+#: ../src/common/accelcmn.cpp:83
 msgid "Divide"
 msgstr ""
 
-#: ../src/common/docview.cpp:533
+#: ../src/common/docview.cpp:526
 #, fuzzy, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "क्या आप %s प्रलेख पर परिवर्तनों को सुरक्षित करना चाहते है?"
 
-#: ../src/common/prntbase.cpp:542
+#: ../src/common/prntbase.cpp:537
 #, fuzzy
 msgid "Document:"
 msgstr "द्वारा प्रलेखन"
 
-#: ../src/generic/aboutdlgg.cpp:73
+#: ../src/generic/aboutdlgg.cpp:70
 msgid "Documentation by "
 msgstr "द्वारा प्रलेखन"
 
-#: ../src/generic/aboutdlgg.cpp:180
+#: ../src/generic/aboutdlgg.cpp:177
 msgid "Documentation writers"
 msgstr "प्रलेख लेखक"
 
-#: ../src/common/sizer.cpp:2799
+#: ../src/common/sizer.cpp:2916
 msgid "Don't Save"
 msgstr "सुरक्षित न करें"
 
-#: ../src/html/htmlwin.cpp:633
+#: ../src/html/htmlwin.cpp:643
 msgid "Done"
 msgstr "किया गया"
 
-#: ../src/generic/progdlgg.cpp:448 ../src/msw/progdlg.cpp:407
+#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
 msgid "Done."
 msgstr "किया गया।"
 
@@ -2911,44 +2913,44 @@ msgstr "किया गया"
 msgid "Double"
 msgstr "किया गया"
 
-#: ../src/common/paper.cpp:176
+#: ../src/common/paper.cpp:173
 msgid "Double Japanese Postcard Rotated 148 x 200 mm"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:273
+#: ../src/common/xtixml.cpp:269
 #, c-format
 msgid "Doubly used id : %d"
 msgstr "दोहरी उपयोग में लायी गयी पहचानसंख्या : %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:153
-#: ../src/common/accelcmn.cpp:64
+#: ../src/common/stockitem.cpp:150 ../src/common/accelcmn.cpp:61
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Down"
 msgstr "नीचे"
 
-#: ../src/richtext/richtextctrl.cpp:865
+#: ../src/richtext/richtextctrl.cpp:864
 msgid "Drag"
 msgstr ""
 
-#: ../src/common/paper.cpp:100
+#: ../src/common/paper.cpp:97
 msgid "E sheet, 34 x 44 in"
 msgstr "ई पत्र, ३४ x ४४ इंच"
 
-#: ../src/unix/fswatcher_inotify.cpp:561
+#: ../src/unix/fswatcher_inotify.cpp:558
 #, fuzzy
 msgid "EOF while reading from inotify descriptor"
 msgstr "फ़ाइल विवरणकर्ता %d से पढ़ा नहीं जा सकता है"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 #, fuzzy
 msgid "Edit"
 msgstr "संपादन (&E)"
 
-#: ../src/generic/editlbox.cpp:168
+#: ../src/generic/editlbox.cpp:131
 msgid "Edit item"
 msgstr "आयट्म को संपादित करें"
 
-#: ../include/wx/generic/progdlgg.h:84
+#: ../include/wx/generic/progdlgg.h:85
 #, fuzzy
 msgid "Elapsed time:"
 msgstr "बीता हुआ समय : "
@@ -3022,64 +3024,64 @@ msgid "Enables the shadow spread."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:66
+#: ../src/common/accelcmn.cpp:63
 msgid "End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:55
+#: ../src/common/accelcmn.cpp:52
 #, fuzzy
 msgid "Enter"
 msgstr "मुद्रक"
 
-#: ../src/richtext/richtextstyledlg.cpp:934
+#: ../src/richtext/richtextstyledlg.cpp:930
 #, fuzzy
 msgid "Enter a box style name"
 msgstr "एक नयी शैली का नाम बताएँ"
 
-#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:602
 msgid "Enter a character style name"
 msgstr "एक संप्रतीक सूची का नाम बताएँ"
 
-#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:816
 msgid "Enter a list style name"
 msgstr "एक सूची शैली का नाम बताएँ"
 
-#: ../src/richtext/richtextstyledlg.cpp:893
+#: ../src/richtext/richtextstyledlg.cpp:889
 msgid "Enter a new style name"
 msgstr "एक नयी शैली का नाम बताएँ"
 
-#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:650
 msgid "Enter a paragraph style name"
 msgstr "एक अनुच्छेद शैली का नाम बताएँ"
 
-#: ../src/generic/dbgrptg.cpp:174
+#: ../src/generic/dbgrptg.cpp:171
 #, c-format
 msgid "Enter command to open file \"%s\":"
 msgstr "फ़ाइल \"%s\" को खोलने के लिए निर्देश बताएँ:"
 
-#: ../src/generic/helpext.cpp:459
+#: ../src/generic/helpext.cpp:457
 msgid "Entries found"
 msgstr "प्रविष्टियां मिली"
 
-#: ../src/common/paper.cpp:142
+#: ../src/common/paper.cpp:139
 #, fuzzy
 msgid "Envelope Invite 220 x 220 mm"
 msgstr "डीएल लिफ़ाफ़ा, ११० x २२० मिलीमीटर"
 
-#: ../src/common/config.cpp:469
+#: ../src/common/config.cpp:465
 #, c-format
 msgid ""
 "Environment variables expansion failed: missing '%c' at position %u in '%s'."
 msgstr "वातावरण चरों का विस्तार असफ़ल रहा: '%c' विलुप्त %u स्थान पर '%s' में।"
 
-#: ../src/generic/filedlgg.cpp:357 ../src/generic/dirctrlg.cpp:570
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/dirctrlg.cpp:599
-#: ../src/generic/dirdlgg.cpp:323 ../src/generic/filectrlg.cpp:642
-#: ../src/generic/filectrlg.cpp:756 ../src/generic/filectrlg.cpp:770
-#: ../src/generic/filectrlg.cpp:786 ../src/generic/filectrlg.cpp:1368
-#: ../src/generic/filectrlg.cpp:1399 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/gtk1/fontdlg.cpp:74 ../src/generic/dirctrlg.cpp:536
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/dirctrlg.cpp:565
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1357 ../src/generic/filectrlg.cpp:1388
+#: ../src/generic/filedlgg.cpp:354 ../src/generic/dirdlgg.cpp:320
+#: ../src/gtk/filedlg.cpp:74
 msgid "Error"
 msgstr "त्रुटि"
 
@@ -3088,239 +3090,260 @@ msgstr "त्रुटि"
 msgid "Error closing epoll descriptor"
 msgstr "निर्देशिका निर्माण में त्रुटि"
 
-#: ../src/unix/fswatcher_kqueue.cpp:114
+#: ../src/unix/fswatcher_kqueue.cpp:131
 msgid "Error closing kqueue instance"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1049
+#: ../src/common/filefn.cpp:938
 #, fuzzy, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "'%s' फ़ाइल की '%s' पर प्रतिलिपि बनाने में असफ़ल"
 
-#: ../src/generic/dirdlgg.cpp:222
+#: ../src/generic/dirdlgg.cpp:219
 msgid "Error creating directory"
 msgstr "निर्देशिका निर्माण में त्रुटि"
 
-#: ../src/common/imagbmp.cpp:1181
+#: ../src/common/imagbmp.cpp:1193
 msgid "Error in reading image DIB."
 msgstr "आकॄति डीआईबी को पढ़ने में त्रुटि।"
 
-#: ../src/propgrid/propgrid.cpp:6696
+#: ../src/propgrid/propgrid.cpp:6665
 #, c-format
 msgid "Error in resource: %s"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:422
+#: ../src/common/fileconf.cpp:421
 msgid "Error reading config options."
 msgstr "संरचना के विकल्पों को पढ़नें में त्रुटि।"
+
+#: ../src/msw/webview_ie.cpp:1057 ../src/msw/webview_edge.cpp:850
+#: ../src/gtk/webview_webkit2.cpp:1262 ../src/osx/webview_webkit.mm:383
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
 
 #: ../src/common/fileconf.cpp:1029
 msgid "Error saving user configuration data."
 msgstr "प्रयोक्ता की संरचना के विकल्पों को सुरक्षित करने में त्रुटि।"
 
-#: ../src/gtk/print.cpp:722
+#: ../src/gtk/print.cpp:720
 #, fuzzy
 msgid "Error while printing: "
 msgstr "कॄपया प्रतीक्षा करें जबतक कि प्रिंटींग हो रही है\n"
 
-#: ../src/common/log.cpp:219
+#: ../src/common/log.cpp:237
 msgid "Error: "
 msgstr "त्रुटि: "
 
+#: ../src/common/webrequest.cpp:98
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "त्रुटि: "
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:69
+#: ../src/common/accelcmn.cpp:66
 msgid "Esc"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:70
+#: ../src/common/accelcmn.cpp:67
 #, fuzzy
 msgid "Escape"
 msgstr "लैडस्केप"
 
-#: ../src/common/fmapbase.cpp:150
+#: ../src/common/fmapbase.cpp:147
 msgid "Esperanto (ISO-8859-3)"
 msgstr "ऐस्पेरान्तो (आईसो-८८५९-३)"
 
-#: ../include/wx/generic/progdlgg.h:85
+#: ../include/wx/generic/progdlgg.h:86
 #, fuzzy
 msgid "Estimated time:"
 msgstr "अनुमानित समय : "
 
-#: ../src/generic/dbgrptg.cpp:234
+#: ../src/generic/dbgrptg.cpp:231
 #, fuzzy
 msgid "Executable files (*.exe)|*.exe|"
 msgstr "निष्पाद्य फ़ाइलें (*.exe)|*.exe|सभी फ़ाइलें (*.*)|*.*||"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:155 ../src/common/accelcmn.cpp:78
+#: ../src/common/stockitem.cpp:152 ../src/common/accelcmn.cpp:75
 msgid "Execute"
 msgstr ""
 
-#: ../src/msw/utilsexc.cpp:876
+#: ../src/msw/utilsexc.cpp:873
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "'%s' निर्देश का निष्पादन असफ़ल रहा"
 
-#: ../src/common/paper.cpp:105
+#: ../src/common/paper.cpp:102
 msgid "Executive, 7 1/4 x 10 1/2 in"
 msgstr "कार्यकारी, ७ १/४ x १० १/२ इंच"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6009
+#: ../src/generic/datavgen.cpp:6814
 msgid "Expand"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1240
+#: ../src/msw/registry.cpp:1228
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:195
+#: ../src/common/fmapbase.cpp:192
 msgid "Extended Unix Codepage for Japanese (EUC-JP)"
 msgstr "जापानी (ईयूसी-जेपी) के लिए विस्तॄत यूनिक्स कूटपृष्ट"
 
-#: ../src/html/chm.cpp:725
+#: ../src/html/chm.cpp:718
 #, c-format
 msgid "Extraction of '%s' into '%s' failed."
 msgstr "'%s' का निष्कर्षण '%s' में असफ़ल रहा।"
 
-#: ../src/common/accelcmn.cpp:249 ../src/common/accelcmn.cpp:344
+#: ../src/common/accelcmn.cpp:259 ../src/common/accelcmn.cpp:358
 msgid "F"
 msgstr "F"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:672
+#: ../src/propgrid/advprops.cpp:582
 #, fuzzy
 msgid "Face Name"
 msgstr "नयानाम"
 
-#: ../src/unix/snglinst.cpp:269
+#: ../src/unix/snglinst.cpp:266
 msgid "Failed to access lock file."
 msgstr "लॉक फ़ाइल तक पहुँच में असफ़ल।"
+
+#: ../src/gtk/font.cpp:572
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "%d आकॄति को '%s' फ़ाइल से लोड करने में असफ़ल।"
 
 #: ../src/unix/epolldispatcher.cpp:116
 #, fuzzy, c-format
 msgid "Failed to add descriptor %d to epoll descriptor %d"
 msgstr "फ़ाइल विवरणकर्ता %d पर लिखा नहीं जा सकता है"
 
-#: ../src/msw/dib.cpp:489
+#: ../src/msw/dib.cpp:535
 #, fuzzy, c-format
 msgid "Failed to allocate %luKb of memory for bitmap data."
 msgstr "बिट्मैप डाटा के लिए %lu केबी स्मृति का आवंटन करने में असफ़ल।"
 
-#: ../src/common/glcmn.cpp:115
+#: ../src/common/glcmn.cpp:112
 #, fuzzy
 msgid "Failed to allocate colour for OpenGL"
 msgstr "कर्सर का निर्माण करने में असफ़ल।"
 
-#: ../src/unix/displayx11.cpp:236
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "कर्सर का निर्माण करने में असफ़ल।"
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "कर्सर का निर्माण करने में असफ़ल।"
+
+#: ../include/wx/unix/private/displayx11.h:89
 msgid "Failed to change video mode"
 msgstr "विडियो विधा को परिवर्तित करने में असफ़ल"
 
-#: ../src/common/image.cpp:3277
+#: ../src/common/image.cpp:3396
 #, fuzzy, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "बिट्मैप आकॄति को \"%s\" फ़ाइल पर सुरक्षित करने में असफ़ल।"
 
-#: ../src/common/debugrpt.cpp:239
+#: ../src/common/debugrpt.cpp:240
 #, c-format
 msgid "Failed to clean up debug report directory \"%s\""
 msgstr "दोषमार्जन विवरण निर्देशिका \"%s\" को साफ करने में असफ़ल।"
 
-#: ../src/common/filename.cpp:192
+#: ../src/common/filename.cpp:189
 msgid "Failed to close file handle"
 msgstr "फ़ाइल हैन्डल को बन्द करने में असफ़ल"
 
-#: ../src/unix/snglinst.cpp:340
+#: ../src/unix/snglinst.cpp:337
 #, c-format
 msgid "Failed to close lock file '%s'"
 msgstr "'%s' लॉक फ़ाइल को बन्द करने में असफ़ल"
 
-#: ../src/msw/clipbrd.cpp:112
+#: ../src/msw/clipbrd.cpp:110
 msgid "Failed to close the clipboard."
 msgstr "क्लिपबोर्ड को बन्द करने में असफ़ल।"
 
-#: ../src/x11/utils.cpp:208
+#: ../src/x11/utils.cpp:170
 #, c-format
 msgid "Failed to close the display \"%s\""
 msgstr "डिस्प्ले \"%s\" को बन्द करने में असफ़ल।"
 
-#: ../src/msw/dialup.cpp:797
+#: ../src/msw/dialup.cpp:791
 msgid "Failed to connect: missing username/password."
 msgstr "कनेक्ट करने में असफ़ल: विलुप्त उपयोगकर्तानाम/कूटशब्द।"
 
-#: ../src/msw/dialup.cpp:743
+#: ../src/msw/dialup.cpp:737
 msgid "Failed to connect: no ISP to dial."
 msgstr "कनेक्ट करने में असफ़ल: डायल करने के लिए कोई आईएसपी नहीं।"
 
-#: ../src/common/textfile.cpp:203
-#, c-format
-msgid "Failed to convert file \"%s\" to Unicode."
-msgstr "फ़ाइल  \"%s\" को यूनिकोड में बदलने में असफ़ल।"
-
-#: ../src/generic/logg.cpp:956
+#: ../src/generic/logg.cpp:953
 #, fuzzy
 msgid "Failed to copy dialog contents to the clipboard."
 msgstr "क्लिपबोर्ड को खोलने में असफ़ल।"
 
-#: ../src/msw/registry.cpp:692
+#: ../src/msw/registry.cpp:681
 #, c-format
 msgid "Failed to copy registry value '%s'"
 msgstr "'%s' रजिस्ट्री वैल्यू की प्रतिलिपि बनाने में असफ़ल"
 
-#: ../src/msw/registry.cpp:701
+#: ../src/msw/registry.cpp:690
 #, c-format
 msgid "Failed to copy the contents of registry key '%s' to '%s'."
 msgstr "'%s' रजिस्ट्री कुँजी के विषयवस्तुओं को प्रतिलिपि '%s' पर बनाने में असफ़ल।"
 
-#: ../src/common/filefn.cpp:1015
+#: ../src/common/filefn.cpp:904
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "'%s' फ़ाइल की '%s' पर प्रतिलिपि बनाने में असफ़ल"
 
-#: ../src/msw/registry.cpp:679
+#: ../src/msw/registry.cpp:668
 #, c-format
 msgid "Failed to copy the registry subkey '%s' to '%s'."
 msgstr "'%s' रजिस्ट्री कुँजी की प्रतिलिपि '%s' करने में असफ़ल।"
 
-#: ../src/msw/dde.cpp:1070
+#: ../src/msw/dde.cpp:1134
 msgid "Failed to create DDE string"
 msgstr "डीडीई श्रेणी का निर्माण करने में असफ़ल"
 
-#: ../src/msw/mdi.cpp:616
+#: ../src/msw/mdi.cpp:621
 msgid "Failed to create MDI parent frame."
 msgstr "एमडीआई मूल खाके का निर्माण करने में असफ़ल।"
 
-#: ../src/common/filename.cpp:1027
+#: ../src/common/filename.cpp:1024
 msgid "Failed to create a temporary file name"
 msgstr "एक अस्थायी फ़ाइल नाम का निर्माण करने में असफ़ल"
 
-#: ../src/msw/utilsexc.cpp:228
+#: ../src/msw/utilsexc.cpp:225
 msgid "Failed to create an anonymous pipe"
 msgstr "एक अज्ञात पाइप का निर्माण करने में असफ़ल"
 
-#: ../src/msw/ole/automtn.cpp:522
+#: ../src/msw/ole/automtn.cpp:513
 #, fuzzy, c-format
 msgid "Failed to create an instance of \"%s\""
 msgstr "\"%s\" निर्देशिका का निर्माण करने में असफ़ल।"
 
-#: ../src/msw/dde.cpp:437
+#: ../src/msw/dde.cpp:432
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "'%s' सर्वर से '%s' विषय पर कनेक्शन जोड़ने में असफ़ल"
 
-#: ../src/msw/cursor.cpp:204
+#: ../src/msw/cursor.cpp:195
 msgid "Failed to create cursor."
 msgstr "कर्सर का निर्माण करने में असफ़ल।"
 
-#: ../src/common/debugrpt.cpp:209
+#: ../src/common/debugrpt.cpp:210
 #, c-format
 msgid "Failed to create directory \"%s\""
 msgstr "\"%s\" निर्देशिका का निर्माण करने में असफ़ल।"
 
-#: ../src/generic/dirdlgg.cpp:220
+#: ../src/generic/dirdlgg.cpp:217
 #, c-format
 msgid ""
 "Failed to create directory '%s'\n"
@@ -3334,117 +3357,136 @@ msgstr ""
 msgid "Failed to create epoll descriptor"
 msgstr "कर्सर का निर्माण करने में असफ़ल।"
 
-#: ../src/msw/mimetype.cpp:238
+#: ../src/gtk/font.cpp:562
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "उपयोगकर्ता संरचना फ़ाइल को अपडेट करने में असफ़ल।"
+
+#: ../src/msw/mimetype.cpp:235
 #, c-format
 msgid "Failed to create registry entry for '%s' files."
 msgstr "'%s' फ़ाइलों के लिए रजिस्ट्री प्रविष्टी का निर्माण करने में असफ़ल।"
 
-#: ../src/msw/fdrepdlg.cpp:409
+#: ../src/msw/fdrepdlg.cpp:408
 #, c-format
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr "मानक खोज/बदलाव संवाद का निर्माण करने में असफ़ल (त्रुटि कूट %d)"
 
-#: ../src/unix/wakeuppipe.cpp:52
+#: ../src/unix/wakeuppipe.cpp:49
 #, fuzzy
 msgid "Failed to create wake up pipe used by event loop."
 msgstr "एक स्थिति पट्टी का निर्माण करने में असफ़ल।"
 
-#: ../src/html/winpars.cpp:730
+#: ../src/html/winpars.cpp:727
 #, c-format
 msgid "Failed to display HTML document in %s encoding"
 msgstr "एचटीएमएल प्रलेख को %s एन्कोडिंग में दिखाने में असफ़ल"
 
-#: ../src/msw/clipbrd.cpp:124
+#: ../src/msw/clipbrd.cpp:122
 msgid "Failed to empty the clipboard."
 msgstr "क्लिपबोर्ड को खाली करने में असफ़ल।"
 
-#: ../src/unix/displayx11.cpp:212
+#: ../include/wx/unix/private/displayx11.h:65
 msgid "Failed to enumerate video modes"
 msgstr "विडियो विधाओं की परिगणना करने में असफ़ल"
 
-#: ../src/msw/dde.cpp:722
+#: ../src/msw/dde.cpp:717
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "डीडीई सर्वर के साथ एक परामर्श लूप को स्थापित करने में असफ़ल"
 
-#: ../src/msw/dialup.cpp:629 ../src/msw/dialup.cpp:863
+#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "डायल-अप कनेक्शन को स्थापित करने में असफ़ल: %s"
 
-#: ../src/unix/utilsunx.cpp:611
+#: ../src/unix/utilsunx.cpp:613
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "'%s' का निष्पादन करने में असफ़ल\n"
 
-#: ../src/common/debugrpt.cpp:720
+#: ../src/common/debugrpt.cpp:730
 msgid "Failed to execute curl, please install it in PATH."
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:505
+#: ../src/msw/ole/automtn.cpp:496
 #, fuzzy, c-format
 msgid "Failed to find CLSID of \"%s\""
 msgstr "'%s' को %s के लिए खोलने में असफ़ल"
 
-#: ../src/common/regex.cpp:431 ../src/common/regex.cpp:479
+#: ../src/common/regex.cpp:428 ../src/common/regex.cpp:476
 #, fuzzy, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "'%s' को सामान्य व्यंजक में मिलाने में असफ़ल: %s"
 
-#: ../src/msw/dialup.cpp:695
+#: ../src/msw/webview_ie.cpp:978
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:689
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "आईएसपी नामों को प्राप्त करने में असफ़ल: %s"
 
-#: ../src/msw/ole/automtn.cpp:574
+#: ../src/msw/ole/automtn.cpp:565
 #, fuzzy, c-format
 msgid "Failed to get OLE automation interface for \"%s\""
 msgstr "\"%s\" निर्देशिका का निर्माण करने में असफ़ल।"
 
-#: ../src/msw/clipbrd.cpp:711
+#: ../src/msw/clipbrd.cpp:731
 msgid "Failed to get data from the clipboard"
 msgstr "क्लिपबोर्ड से डाटा प्राप्त करने में असफ़ल"
 
-#: ../src/common/time.cpp:223
+#: ../src/common/time.cpp:216
 msgid "Failed to get the local system time"
 msgstr "स्थानीय तंत्र समय प्राप्त करने में असफ़ल"
 
-#: ../src/common/filefn.cpp:1345
+#: ../src/common/filefn.cpp:1233
 msgid "Failed to get the working directory"
 msgstr "कार्यशील निर्देशिका को प्राप्त करने में असफ़ल"
 
-#: ../src/univ/theme.cpp:114
+#: ../src/univ/theme.cpp:111
 msgid "Failed to initialize GUI: no built-in themes found."
 msgstr "जीयूआई का आरम्भीकरण करने में असफ़ल: कोई अंत-निर्मित थीमें नहीं मिली।"
 
-#: ../src/msw/helpchm.cpp:63
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:60
 msgid "Failed to initialize MS HTML Help."
 msgstr "एमएस एचटीएमएल सहायता का आरम्भीकरण करने में असफ़ल।"
 
-#: ../src/msw/glcanvas.cpp:1381
+#: ../src/msw/glcanvas.cpp:1391
 msgid "Failed to initialize OpenGL"
 msgstr "ओपनजीएल का आरम्भीकरण करने में असफ़ल।"
 
-#: ../src/msw/dialup.cpp:858
+#: ../src/msw/dialup.cpp:852
 #, fuzzy, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "डायल-अप कनेक्शन को समाप्त करने में असफ़ल: %s"
 
-#: ../src/gtk/textctrl.cpp:1128
+#: ../src/gtk/textctrl.cpp:1209
 #, fuzzy
 msgid "Failed to insert text in the control."
 msgstr "कार्यशील निर्देशिका को प्राप्त करने में असफ़ल"
 
-#: ../src/unix/snglinst.cpp:241
+#: ../src/unix/snglinst.cpp:238
 #, c-format
 msgid "Failed to inspect the lock file '%s'"
 msgstr "लॉक फ़ाइल '%s' को निरीक्षण करने में असफ़ल"
 
-#: ../src/unix/appunix.cpp:182
+#: ../src/unix/appunix.cpp:179
 #, fuzzy
 msgid "Failed to install signal handler"
 msgstr "फ़ाइल हैन्डल को बन्द करने में असफ़ल"
 
-#: ../src/unix/threadpsx.cpp:1167
+#: ../src/unix/threadpsx.cpp:1216
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -3452,71 +3494,71 @@ msgstr ""
 "एक थ्रेड में शामिल होने में असफ़ल, अत्याधिक स्मॄति रिसाव पाया गया -कॄपया इस कार्यक्रम को "
 "पुनः आरम्भ करें"
 
-#: ../src/msw/utils.cpp:629
+#: ../src/msw/utils.cpp:619
 #, c-format
 msgid "Failed to kill process %d"
 msgstr "%d प्रोसेस को खत्म करने में असफ़ल"
 
-#: ../src/common/image.cpp:2500
+#: ../src/common/image.cpp:2595
 #, fuzzy, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "%d आकॄति को '%s' फ़ाइल से लोड करने में असफ़ल।"
 
-#: ../src/common/image.cpp:2509
+#: ../src/common/image.cpp:2604
 #, fuzzy, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "%d आकॄति को '%s' फ़ाइल से लोड करने में असफ़ल।"
 
-#: ../src/common/iconbndl.cpp:225
+#: ../src/common/iconbndl.cpp:224
 #, fuzzy, c-format
 msgid "Failed to load icons from resource '%s'."
 msgstr "%d आकॄति को '%s' फ़ाइल से लोड करने में असफ़ल।"
 
-#: ../src/common/iconbndl.cpp:200
+#: ../src/common/iconbndl.cpp:198
 #, fuzzy, c-format
 msgid "Failed to load image %%d from file '%s'."
 msgstr "%d आकॄति को '%s' फ़ाइल से लोड करने में असफ़ल।"
 
-#: ../src/common/iconbndl.cpp:208
+#: ../src/common/iconbndl.cpp:206
 #, fuzzy, c-format
 msgid "Failed to load image %d from stream."
 msgstr "%d आकॄति को '%s' फ़ाइल से लोड करने में असफ़ल।"
 
-#: ../src/common/image.cpp:2587 ../src/common/image.cpp:2606
+#: ../src/common/image.cpp:2682 ../src/common/image.cpp:2701
 #, fuzzy, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "%d आकॄति को '%s' फ़ाइल से लोड करने में असफ़ल।"
 
-#: ../src/msw/enhmeta.cpp:97
+#: ../src/msw/enhmeta.cpp:94
 #, fuzzy, c-format
 msgid "Failed to load metafile from file \"%s\"."
 msgstr "%d आकॄति को '%s' फ़ाइल से लोड करने में असफ़ल।"
 
-#: ../src/msw/volume.cpp:327
+#: ../src/msw/volume.cpp:335
 msgid "Failed to load mpr.dll."
 msgstr "mpr.dll को लोड करने में असफ़ल।"
 
-#: ../src/msw/utils.cpp:953
+#: ../src/msw/utils.cpp:943
 #, fuzzy, c-format
 msgid "Failed to load resource \"%s\"."
 msgstr "%d आकॄति को '%s' फ़ाइल से लोड करने में असफ़ल।"
 
-#: ../src/common/dynlib.cpp:92
+#: ../src/common/dynlib.cpp:86
 #, c-format
 msgid "Failed to load shared library '%s'"
 msgstr "'%s' साझा लायबरी को लोड करने में असफ़ल"
 
-#: ../src/osx/core/sound.cpp:145
+#: ../src/osx/core/sound.cpp:143
 #, fuzzy, c-format
 msgid "Failed to load sound from \"%s\" (error %d)."
 msgstr "%d आकॄति को '%s' फ़ाइल से लोड करने में असफ़ल।"
 
-#: ../src/msw/utils.cpp:960
+#: ../src/msw/utils.cpp:950
 #, fuzzy, c-format
 msgid "Failed to lock resource \"%s\"."
 msgstr "'%s' फ़ाइल को लॉक करने में असफ़ल"
 
-#: ../src/unix/snglinst.cpp:198
+#: ../src/unix/snglinst.cpp:195
 #, c-format
 msgid "Failed to lock the lock file '%s'"
 msgstr "'%s' फ़ाइल को लॉक करने में असफ़ल"
@@ -3526,33 +3568,38 @@ msgstr "'%s' फ़ाइल को लॉक करने में असफ़ल"
 msgid "Failed to modify descriptor %d in epoll descriptor %d"
 msgstr ""
 
-#: ../src/common/filename.cpp:2575
+#: ../src/common/filename.cpp:2658
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr " '%s' के लिए फ़ाइल टाइम्स को परिवर्तित करने में असफ़ल"
 
-#: ../src/common/selectdispatcher.cpp:258
+#: ../src/common/selectdispatcher.cpp:255
 msgid "Failed to monitor I/O channels"
 msgstr ""
 
-#: ../src/common/filename.cpp:175
+#: ../src/common/filename.cpp:172
 #, fuzzy, c-format
 msgid "Failed to open '%s' for reading"
 msgstr "'%s' को %s के लिए खोलने में असफ़ल"
 
-#: ../src/common/filename.cpp:180
+#: ../src/common/filename.cpp:177
 #, fuzzy, c-format
 msgid "Failed to open '%s' for writing"
 msgstr "'%s' को %s के लिए खोलने में असफ़ल"
 
-#: ../src/html/chm.cpp:141
+#: ../src/html/chm.cpp:138
 #, c-format
 msgid "Failed to open CHM archive '%s'."
 msgstr "'%s' सीएचएम लेखागार को खोलने में असफ़ल।"
 
-#: ../src/common/utilscmn.cpp:1126
+#: ../src/common/utilscmn.cpp:1140
 #, fuzzy, c-format
 msgid "Failed to open URL \"%s\" in default browser."
+msgstr "'%s' को %s के लिए खोलने में असफ़ल"
+
+#: ../src/common/hyperlnkcmn.cpp:133
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "'%s' को %s के लिए खोलने में असफ़ल"
 
 #: ../include/wx/msw/private/fswatcher.h:92
@@ -3560,212 +3607,230 @@ msgstr "'%s' को %s के लिए खोलने में असफ़ल"
 msgid "Failed to open directory \"%s\" for monitoring."
 msgstr "\"%s\" निर्देशिका का निर्माण करने में असफ़ल।"
 
-#: ../src/x11/utils.cpp:227
+#: ../src/x11/utils.cpp:189
 #, c-format
 msgid "Failed to open display \"%s\"."
 msgstr "प्रदर्श युक्ति \"%s\" को खोलने में असफ़ल।"
 
-#: ../src/common/filename.cpp:1062
+#: ../src/common/filename.cpp:1059
 msgid "Failed to open temporary file."
 msgstr "अस्थायी फ़ाइल को खोलने में असफ़ल।"
 
-#: ../src/msw/clipbrd.cpp:91
+#: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "क्लिपबोर्ड को खोलने में असफ़ल।"
 
-#: ../src/common/translation.cpp:1184
+#: ../src/common/translation.cpp:1226
 #, fuzzy, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "प्ल्यूलर-फ़ार्मों का पदभंजन नहीं किया जा सका:'%s'"
 
-#: ../src/unix/mediactrl.cpp:1214
+#: ../src/unix/mediactrl.cpp:1239
 #, fuzzy, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "प्रदर्श युक्ति \"%s\" को खोलने में असफ़ल।"
 
-#: ../src/msw/clipbrd.cpp:600
+#: ../src/msw/clipbrd.cpp:610
 msgid "Failed to put data on the clipboard"
 msgstr "क्लिपबोर्ड पर डाटा डालने में असफ़ल"
 
-#: ../src/unix/snglinst.cpp:278
+#: ../src/unix/snglinst.cpp:275
 msgid "Failed to read PID from lock file."
 msgstr "लॉक फ़ाइल से पीआईडी को पढ़ने में असफ़ल।"
 
-#: ../src/common/fileconf.cpp:433
+#: ../src/common/fileconf.cpp:432
 msgid "Failed to read config options."
 msgstr "संरचना के विकल्पों को पढ़नें में त्रुटि।"
 
-#: ../src/common/docview.cpp:681
+#: ../src/common/docview.cpp:676
 #, fuzzy, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "%d आकॄति को '%s' फ़ाइल से लोड करने में असफ़ल।"
 
-#: ../src/dfb/evtloop.cpp:98
+#: ../src/dfb/evtloop.cpp:99
 #, fuzzy
 msgid "Failed to read event from DirectFB pipe"
 msgstr "लॉक फ़ाइल से पीआईडी को पढ़ने में असफ़ल।"
 
-#: ../src/unix/wakeuppipe.cpp:120
+#: ../src/unix/wakeuppipe.cpp:117
 #, fuzzy
 msgid "Failed to read from wake-up pipe"
 msgstr "लॉक फ़ाइल से पीआईडी को पढ़ने में असफ़ल।"
 
-#: ../src/unix/utilsunx.cpp:679
+#: ../src/common/textfile.cpp:96
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "%d आकॄति को '%s' फ़ाइल से लोड करने में असफ़ल।"
+
+#: ../src/unix/utilsunx.cpp:681
 msgid "Failed to redirect child process input/output"
 msgstr "बाल प्रोसेस इनपुट/आउटपुट को दिशानिर्देश देने में असफ़ल"
 
-#: ../src/msw/utilsexc.cpp:701
+#: ../src/msw/utilsexc.cpp:698
 msgid "Failed to redirect the child process IO"
 msgstr "बाल प्रोसेस आईओ को दिशानिर्देश देने में असफ़ल"
 
-#: ../src/msw/dde.cpp:288
+#: ../src/msw/dde.cpp:283
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "'%s' डीडीई सर्वर को पंजीकॄत करने में असफ़ल"
 
-#: ../src/common/fontmap.cpp:245
+#: ../src/gtk/font.cpp:580
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "उपयोगकर्ता संरचना फ़ाइल को अपडेट करने में असफ़ल।"
+
+#: ../src/common/fontmap.cpp:242
 #, c-format
 msgid "Failed to remember the encoding for the charset '%s'."
 msgstr "'%s' शब्दसमुच्चय के लिए एन्कोडिंग को याद रखने में असफ़ल।"
 
-#: ../src/common/debugrpt.cpp:227
+#: ../src/common/debugrpt.cpp:228
 #, c-format
 msgid "Failed to remove debug report file \"%s\""
 msgstr "दोषमार्जन विवरण फ़ाइल \"%s\" को हटाने में असफ़ल"
 
-#: ../src/unix/snglinst.cpp:328
+#: ../src/unix/snglinst.cpp:325
 #, c-format
 msgid "Failed to remove lock file '%s'"
 msgstr "'%s' लॉक फ़ाइल को हटाने में असफ़ल"
 
-#: ../src/unix/snglinst.cpp:288
+#: ../src/unix/snglinst.cpp:285
 #, c-format
 msgid "Failed to remove stale lock file '%s'."
 msgstr "'%s' स्टेल लॉक फ़ाइल को हटाने में असफ़ल।"
 
-#: ../src/msw/registry.cpp:529
+#: ../src/msw/registry.cpp:518
 #, c-format
 msgid "Failed to rename registry value '%s' to '%s'."
 msgstr "'%s' रजिस्ट्री वैल्यू को नाम बदल कर '%s' करने में असफ़ल।"
 
-#: ../src/common/filefn.cpp:1122
+#: ../src/common/filefn.cpp:1011
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
 "exists."
 msgstr ""
 
-#: ../src/msw/registry.cpp:634
+#: ../src/msw/registry.cpp:623
 #, c-format
 msgid "Failed to rename the registry key '%s' to '%s'."
 msgstr "'%s' रजिस्ट्री कुँजी को नाम बदल कर '%s' करने में असफ़ल।"
 
-#: ../src/common/filename.cpp:2671
+#: ../src/msw/webview_ie.cpp:995
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/common/filename.cpp:2754
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "'%s' के लिए फ़ाइल टाइम्स को पुनःप्राप्त करने में असफ़ल"
 
-#: ../src/msw/dialup.cpp:468
+#: ../src/msw/dialup.cpp:462
 msgid "Failed to retrieve text of RAS error message"
 msgstr "आरऐएस त्रुटि संदेश के पाठ को पुनःप्राप्त करने में असफ़ल"
 
-#: ../src/msw/clipbrd.cpp:748
+#: ../src/msw/clipbrd.cpp:768
 msgid "Failed to retrieve the supported clipboard formats"
 msgstr "मैट्स के लिए समर्थित क्लिपबोर्ड को पुनःप्राप्त करने में असफ़ल"
 
-#: ../src/common/docview.cpp:652
+#: ../src/common/docview.cpp:647
 #, fuzzy, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "बिट्मैप आकॄति को \"%s\" फ़ाइल पर सुरक्षित करने में असफ़ल।"
 
-#: ../src/msw/dib.cpp:269
+#: ../src/msw/dib.cpp:312
 #, c-format
 msgid "Failed to save the bitmap image to file \"%s\"."
 msgstr "बिट्मैप आकॄति को \"%s\" फ़ाइल पर सुरक्षित करने में असफ़ल।"
 
-#: ../src/msw/dde.cpp:763
+#: ../src/msw/dde.cpp:811
 msgid "Failed to send DDE advise notification"
 msgstr "डीडीई परामर्श घोषणा को प्रेषित करने में असफ़ल"
 
-#: ../src/common/ftp.cpp:402
+#: ../src/common/ftp.cpp:399
 #, c-format
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "एफ़टीपी स्थानान्तरण विधा को %s पर स्थापित करने में असफ़ल।"
 
-#: ../src/msw/clipbrd.cpp:427
+#: ../src/msw/clipbrd.cpp:443
 msgid "Failed to set clipboard data."
 msgstr "क्लिपबोर्ड डाटा को स्थापित करने में असफ़ल।"
 
-#: ../src/unix/snglinst.cpp:181
+#: ../src/unix/snglinst.cpp:178
 #, fuzzy, c-format
 msgid "Failed to set permissions on lock file '%s'"
 msgstr "'%s' फ़ाइल के लिए अनुमतियों को स्थापित करना असम्भव"
 
-#: ../src/unix/utilsunx.cpp:668
+#: ../src/unix/utilsunx.cpp:670
 #, fuzzy
 msgid "Failed to set process priority"
 msgstr "%d थ्रेड वरीयता को स्थापित करने में असफ़ल।"
 
-#: ../src/common/file.cpp:559
+#: ../src/common/ffile.cpp:355 ../src/common/file.cpp:586
 msgid "Failed to set temporary file permissions"
 msgstr "अस्थायी फ़ाइल अनुमतियों को स्थापित करने में असफ़ल"
 
-#: ../src/gtk/textctrl.cpp:1072
-#, fuzzy
-msgid "Failed to set text in the text control."
-msgstr "यूटीसी तंत्र समय प्राप्त करने में असफ़ल।"
-
-#: ../src/unix/threadpsx.cpp:1298
+#: ../src/unix/threadpsx.cpp:1347
 #, fuzzy, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "%d थ्रेड वरीयता को स्थापित करने में असफ़ल।"
 
-#: ../src/unix/threadpsx.cpp:1424
+#: ../src/unix/threadpsx.cpp:1473
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "%d थ्रेड वरीयता को स्थापित करने में असफ़ल।"
 
-#: ../src/unix/utilsunx.cpp:783
+#: ../src/unix/utilsunx.cpp:785
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 
-#: ../src/common/fs_mem.cpp:261
+#: ../src/msw/webview_ie.cpp:987
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:256
 #, c-format
 msgid "Failed to store image '%s' to memory VFS!"
 msgstr "'%s' आकॄति को वीएफ़एस स्मॄति में सुरक्षित करने में असफ़ल!"
 
-#: ../src/dfb/evtloop.cpp:170
+#: ../src/dfb/evtloop.cpp:171
 msgid "Failed to switch DirectFB pipe to non-blocking mode"
 msgstr ""
 
-#: ../src/unix/wakeuppipe.cpp:59
+#: ../src/unix/wakeuppipe.cpp:56
 msgid "Failed to switch wake up pipe to non-blocking mode"
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1605
+#: ../src/unix/threadpsx.cpp:1654
 msgid "Failed to terminate a thread."
 msgstr "एक थ्रेड को समाप्त करने में असफ़ल।"
 
-#: ../src/msw/dde.cpp:741
+#: ../src/msw/dde.cpp:736
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "डीडीई सर्वर के साथ परामर्श लूप को समाप्त करने में असफ़ल"
 
-#: ../src/msw/dialup.cpp:938
+#: ../src/msw/dialup.cpp:932
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "डायल-अप कनेक्शन को समाप्त करने में असफ़ल: %s"
 
-#: ../src/common/filename.cpp:2590
+#: ../src/common/filename.cpp:2673
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "'%s' फ़ाइल को छूने में असफ़ल"
 
-#: ../src/unix/snglinst.cpp:334
+#: ../src/unix/dlunix.cpp:90
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "'%s' साझा लायबरी को लोड करने में असफ़ल"
+
+#: ../src/unix/snglinst.cpp:331
 #, c-format
 msgid "Failed to unlock lock file '%s'"
 msgstr "'%s' लॉक फ़ाइल को अन-लॉक करने में असफ़ल"
 
-#: ../src/msw/dde.cpp:309
+#: ../src/msw/dde.cpp:304
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "'%s' डीडीई सर्वर को अपंजीकॄत करने में असफ़ल"
@@ -3779,79 +3844,89 @@ msgstr "क्लिपबोर्ड से डाटा को पुनः�
 msgid "Failed to update user configuration file."
 msgstr "उपयोगकर्ता संरचना फ़ाइल को अपडेट करने में असफ़ल।"
 
-#: ../src/common/debugrpt.cpp:733
+#: ../src/common/debugrpt.cpp:743
 #, c-format
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "दोषमार्जन विवरण को अपलोड करने में असफ़ल (त्रुटि कूट %d)।"
 
-#: ../src/unix/snglinst.cpp:168
+#: ../src/unix/snglinst.cpp:165
 #, c-format
 msgid "Failed to write to lock file '%s'"
 msgstr "'%s' लॉक फ़ाइल पर लिखने में असफ़ल"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:209
+#: ../src/propgrid/propgrid.cpp:190
 #, fuzzy
 msgid "False"
 msgstr "फ़ाइल"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:694
+#: ../src/propgrid/advprops.cpp:604
 #, fuzzy
 msgid "Family"
 msgstr "फ़ॉन्ट वंश:"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/gtk/glcanvas.cpp:176 ../src/gtk/glcanvas.cpp:187
+#, fuzzy
+msgid "Fatal Error"
+msgstr "घातक त्रुटि"
+
+#: ../src/common/stockitem.cpp:154
 msgid "File"
 msgstr "फ़ाइल"
 
-#: ../src/common/docview.cpp:669
+#: ../src/common/docview.cpp:664
 #, fuzzy, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "फ़ाइल को लोड नहीं किया जा सका।"
 
-#: ../src/common/docview.cpp:646
+#: ../src/common/docview.cpp:641
 #, fuzzy, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "wxWidgets '%s' के लिए अवलोकन को खोल नहीं पाया: बाहर निकल रहा है।"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "'%s' फ़ाइल पहिले से विद्यमान है, क्या आप वास्तव में इसके ऊपर फ़िर से लिखना चाहते है?"
 
-#: ../src/common/filefn.cpp:1156
+#: ../src/common/filefn.cpp:1044
 #, fuzzy, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "'%s' निर्देशिका का निर्माण नहीं किया जा सकता था"
 
-#: ../src/common/filefn.cpp:1139
+#: ../src/common/filefn.cpp:1028
 #, fuzzy, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "'%s' निर्देशिका का निर्माण नहीं किया जा सकता था"
 
-#: ../src/richtext/richtextctrl.cpp:3081 ../src/common/textcmn.cpp:953
+#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
 msgid "File couldn't be loaded."
 msgstr "फ़ाइल को लोड नहीं किया जा सका।"
 
-#: ../src/msw/filedlg.cpp:393
+#: ../src/msw/filedlg.cpp:414
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr ""
 
-#: ../src/common/docview.cpp:1789
+#: ../src/common/docview.cpp:1783
 msgid "File error"
 msgstr "फ़ाइल त्रुटि"
 
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/filectrlg.cpp:770
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/filectrlg.cpp:766
 msgid "File name exists already."
 msgstr "फ़ाइल नाम पहिले से विद्यमान है।"
+
+#: ../src/osx/cocoa/filedlg.mm:264
+#, fuzzy
+msgid "File type:"
+msgstr "टेलीटाइप"
 
 #: ../src/motif/filedlg.cpp:220
 msgid "Files"
 msgstr "फ़ाइलें"
 
-#: ../src/common/filefn.cpp:1591
+#: ../src/common/filefn.cpp:1479
 #, c-format
 msgid "Files (%s)"
 msgstr "फ़ाइलें (%s)"
@@ -3860,16 +3935,30 @@ msgstr "फ़ाइलें (%s)"
 msgid "Filter"
 msgstr "फ़िल्टर"
 
-#: ../src/common/stockitem.cpp:158 ../src/html/helpwnd.cpp:490
+#: ../src/html/helpwnd.cpp:488
 msgid "Find"
 msgstr "खोज"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:259
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:258
+#, fuzzy
+msgid "Find in document"
+msgstr "एचटीएमएल प्रलेख को खोलें"
+
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "Find..."
+msgstr "खोज"
+
+#: ../src/common/stockitem.cpp:156
 #, fuzzy
 msgid "First"
 msgstr "प्रथम"
 
-#: ../src/common/prntbase.cpp:1548
+#: ../src/common/prntbase.cpp:1573
 #, fuzzy
 msgid "First page"
 msgstr "अगला पृष्ट"
@@ -3879,11 +3968,11 @@ msgstr "अगला पृष्ट"
 msgid "Fixed"
 msgstr "नियत फ़ॉन्ट:"
 
-#: ../src/html/helpwnd.cpp:1206
+#: ../src/html/helpwnd.cpp:1204
 msgid "Fixed font:"
 msgstr "नियत फ़ॉन्ट:"
 
-#: ../src/html/helpwnd.cpp:1269
+#: ../src/html/helpwnd.cpp:1267
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "नियत आकार फ़ेस<br> <b>गहरा</b> <i>इटैलिक</i> "
 
@@ -3891,16 +3980,16 @@ msgstr "नियत आकार फ़ेस<br> <b>गहरा</b> <i>इटै
 msgid "Floating"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "Floppy"
 msgstr ""
 
-#: ../src/common/paper.cpp:111
+#: ../src/common/paper.cpp:108
 msgid "Folio, 8 1/2 x 13 in"
 msgstr "फ़ोलियो, ८ १/२ x १३ इंच"
 
-#: ../src/richtext/richtextformatdlg.cpp:344 ../src/osx/carbon/fontdlg.cpp:287
-#: ../src/common/stockitem.cpp:194
+#: ../src/osx/carbon/fontdlg.cpp:284 ../src/common/stockitem.cpp:191
+#: ../src/richtext/richtextformatdlg.cpp:337
 msgid "Font"
 msgstr "फ़ॉन्ट"
 
@@ -3908,7 +3997,24 @@ msgstr "फ़ॉन्ट"
 msgid "Font &weight:"
 msgstr "फ़ॉन्ट भार (&W):"
 
-#: ../src/html/helpwnd.cpp:1207
+#: ../src/osx/fontutil.cpp:89
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
+"\"."
+msgstr ""
+
+#: ../src/msw/font.cpp:1126
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "फ़ाइल को लोड नहीं किया जा सका।"
+
+#: ../src/osx/fontutil.cpp:81
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr " %s फ़ाइल विद्यमान नहीं है।"
+
+#: ../src/html/helpwnd.cpp:1205
 msgid "Font size:"
 msgstr "फ़ॉन्ट आकार:"
 
@@ -3916,76 +4022,76 @@ msgstr "फ़ॉन्ट आकार:"
 msgid "Font st&yle:"
 msgstr "फ़ॉन्ट शैली: (&Y)"
 
-#: ../src/osx/carbon/fontdlg.cpp:329
+#: ../src/osx/carbon/fontdlg.cpp:326
 msgid "Font:"
 msgstr "फ़ॉन्ट:"
 
-#: ../src/dfb/fontmgr.cpp:198
+#: ../src/dfb/fontmgr.cpp:195
 #, c-format
 msgid "Fonts index file %s disappeared while loading fonts."
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:645
+#: ../src/unix/utilsunx.cpp:647
 msgid "Fork failed"
 msgstr "फ़ार्क असफ़ल रहा"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 #, fuzzy
 msgid "Forward"
 msgstr "आगे (&F)"
 
-#: ../src/common/xtixml.cpp:235
+#: ../src/common/xtixml.cpp:231
 msgid "Forward hrefs are not supported"
 msgstr "अग्र एचरेफ़्स समर्थित नहीं है"
 
-#: ../src/html/helpwnd.cpp:875
+#: ../src/html/helpwnd.cpp:873
 #, c-format
 msgid "Found %i matches"
 msgstr "%i मेल मिलें"
 
-#: ../src/generic/prntdlgg.cpp:238
+#: ../src/generic/prntdlgg.cpp:231
 msgid "From:"
 msgstr "प्रेषणकर्ता:"
 
-#: ../src/propgrid/advprops.cpp:1604
+#: ../src/propgrid/advprops.cpp:1510
 msgid "Fuchsia"
 msgstr ""
 
-#: ../src/common/imaggif.cpp:138
+#: ../src/common/imaggif.cpp:135
 msgid "GIF: data stream seems to be truncated."
 msgstr "जीआईएफ़:  डाटा धारा सम्भवता टूटी-फ़ूटी लगती है।"
 
-#: ../src/common/imaggif.cpp:128
+#: ../src/common/imaggif.cpp:125
 msgid "GIF: error in GIF image format."
 msgstr "जीआईएफ़: जीआईएफ़ आकॄति प्रारूप में त्रुटि।"
 
-#: ../src/common/imaggif.cpp:133
+#: ../src/common/imaggif.cpp:130
 msgid "GIF: not enough memory."
 msgstr "जीआईएफ़: आवश्यकतानुसार स्मॄति अनुपलब्ध"
 
-#: ../src/gtk/window.cpp:4631
+#: ../src/gtk/window.cpp:5635
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
 msgstr ""
 
-#: ../src/univ/themes/gtk.cpp:525
+#: ../src/univ/themes/gtk.cpp:522
 msgid "GTK+ theme"
 msgstr "जीटीके+ थीम"
 
-#: ../src/common/preferencescmn.cpp:40
+#: ../src/common/preferencescmn.cpp:37
 msgid "General"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:258
+#: ../src/common/prntbase.cpp:253
 msgid "Generic PostScript"
 msgstr "सामान्य पोस्टस्क्रिप्ट"
 
-#: ../src/common/paper.cpp:135
+#: ../src/common/paper.cpp:132
 msgid "German Legal Fanfold, 8 1/2 x 13 in"
 msgstr "जर्मन लीगल फ़ैनफ़ोल्ड, ८ १/२ x १३ इंच"
 
-#: ../src/common/paper.cpp:134
+#: ../src/common/paper.cpp:131
 msgid "German Std Fanfold, 8 1/2 x 12 in"
 msgstr "जर्मन मानक फ़ैनफ़ोल्ड, ८ १/२ x १२ इंच"
 
@@ -4001,48 +4107,48 @@ msgstr "GetPropertyCollection ने एक सामान्य ऐसेस�
 msgid "GetPropertyCollection called w/o valid collection getter"
 msgstr "GetPropertyCollection को बिना किसी वैध कलेक्शन गेटर के बुलाया गया"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:658
 msgid "Go back"
 msgstr "पीछे जाएँ"
 
-#: ../src/html/helpwnd.cpp:661
+#: ../src/html/helpwnd.cpp:659
 msgid "Go forward"
 msgstr "आगे जाएँ"
 
-#: ../src/html/helpwnd.cpp:663
+#: ../src/html/helpwnd.cpp:661
 msgid "Go one level up in document hierarchy"
 msgstr "प्रलेख पदानुक्रम में एक स्तर ऊपर जाएँ"
 
-#: ../src/generic/filedlgg.cpp:208 ../src/generic/dirdlgg.cpp:116
+#: ../src/generic/filedlgg.cpp:205 ../src/generic/dirdlgg.cpp:113
 msgid "Go to home directory"
 msgstr "गॄह निर्देशिका पर जाएँ"
 
-#: ../src/generic/filedlgg.cpp:205
+#: ../src/generic/filedlgg.cpp:202
 msgid "Go to parent directory"
 msgstr "मूल निर्देशिका पर जाएँ"
 
-#: ../src/generic/aboutdlgg.cpp:76
+#: ../src/generic/aboutdlgg.cpp:73
 msgid "Graphics art by "
 msgstr "आलेख कला के द्वारा"
 
-#: ../src/propgrid/advprops.cpp:1599
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Gray"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:883
+#: ../src/propgrid/advprops.cpp:784
 msgid "GrayText"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:154
+#: ../src/common/fmapbase.cpp:151
 msgid "Greek (ISO-8859-7)"
 msgstr "ग्रीक (आईओ-८८५९-७)"
 
-#: ../src/propgrid/advprops.cpp:1600
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Green"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:342
+#: ../src/generic/colrdlgg.cpp:362
 msgid "Green:"
 msgstr ""
 
@@ -4050,109 +4156,109 @@ msgstr ""
 msgid "Groove"
 msgstr ""
 
-#: ../src/common/zstream.cpp:158 ../src/common/zstream.cpp:318
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
 msgid "Gzip not supported by this version of zlib"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1549
+#: ../src/html/helpwnd.cpp:1547
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "एचटीएमएल सहायता परियोजना (*.hhp)|*.hhp|"
 
-#: ../src/html/htmlwin.cpp:681
+#: ../src/html/htmlwin.cpp:691
 #, c-format
 msgid "HTML anchor %s does not exist."
 msgstr "%s एचटीएमएल एंकर विद्यमान नहीं है।"
 
-#: ../src/html/helpwnd.cpp:1547
+#: ../src/html/helpwnd.cpp:1545
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "एचटीएमएल फ़ाइलें (*.html;*.htm)|*.html;*.htm|"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1759
+#: ../src/propgrid/advprops.cpp:1660
 msgid "Hand"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "Harddisk"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:155
+#: ../src/common/fmapbase.cpp:152
 msgid "Hebrew (ISO-8859-8)"
 msgstr "हिब्रू (आईसो-८८५९-८)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:280 ../src/osx/button_osx.cpp:39
-#: ../src/common/stockitem.cpp:163 ../src/common/accelcmn.cpp:80
-#: ../src/html/helpdlg.cpp:66 ../src/html/helpfrm.cpp:111
+#: ../include/wx/msgdlg.h:282 ../src/osx/button_osx.cpp:39
+#: ../src/common/stockitem.cpp:160 ../src/common/accelcmn.cpp:77
+#: ../src/html/helpfrm.cpp:108 ../src/html/helpdlg.cpp:63
 msgid "Help"
 msgstr "सहायता"
 
-#: ../src/html/helpwnd.cpp:1200
+#: ../src/html/helpwnd.cpp:1198
 msgid "Help Browser Options"
 msgstr "सहायता ब्राउजर के विकल्प"
 
-#: ../src/generic/helpext.cpp:454 ../src/generic/helpext.cpp:455
+#: ../src/generic/helpext.cpp:452 ../src/generic/helpext.cpp:453
 msgid "Help Index"
 msgstr "सहायता इंडेक्स"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1529
 msgid "Help Printing"
 msgstr "सहायता मुद्रण"
 
-#: ../src/html/helpwnd.cpp:801
+#: ../src/html/helpwnd.cpp:799
 msgid "Help Topics"
 msgstr "सहायता विषयवस्तु"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1546
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "सहायता पुस्तकें (*.htb)|*.htb|सहायता पुस्तकें (*.zip)|*.zip|"
 
-#: ../src/generic/helpext.cpp:267
+#: ../src/generic/helpext.cpp:265
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "सहायता निर्देशिका \"%s\" नहीं मिली।"
 
-#: ../src/generic/helpext.cpp:275
+#: ../src/generic/helpext.cpp:273
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "सहायता फ़ाइल \"%s\" नहीं मिली।"
 
-#: ../src/html/helpctrl.cpp:63
+#: ../src/html/helpctrl.cpp:59
 #, c-format
 msgid "Help: %s"
 msgstr "सहायता: %s"
 
-#: ../src/osx/menu_osx.cpp:577
+#: ../src/osx/menu_osx.cpp:469
 #, fuzzy, c-format
 msgid "Hide %s"
 msgstr "सहायता: %s"
 
-#: ../src/osx/menu_osx.cpp:579
+#: ../src/osx/menu_osx.cpp:471
 msgid "Hide Others"
 msgstr ""
 
-#: ../src/generic/infobar.cpp:84
+#: ../src/generic/infobar.cpp:81
 msgid "Hide this notification message."
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:884
+#: ../src/propgrid/advprops.cpp:785
 #, fuzzy
 msgid "Highlight"
 msgstr "हल्का"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:885
+#: ../src/propgrid/advprops.cpp:786
 #, fuzzy
 msgid "HighlightText"
 msgstr "पाठ को दायें पंक्तिबद्ध करें।"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:164 ../src/common/accelcmn.cpp:65
+#: ../src/common/stockitem.cpp:161 ../src/common/accelcmn.cpp:62
 msgid "Home"
 msgstr "गृह"
 
-#: ../src/generic/dirctrlg.cpp:524
+#: ../src/generic/dirctrlg.cpp:490
 msgid "Home directory"
 msgstr "गृह निर्देशिका"
 
@@ -4162,61 +4268,61 @@ msgid "How the object will float relative to the text."
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1760
+#: ../src/propgrid/advprops.cpp:1661
 msgid "I-Beam"
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1196
+#: ../src/common/imagbmp.cpp:1208
 msgid "ICO: Error in reading mask DIB."
 msgstr "आईसीओ: मास्क डीआईबी को पढ़ने में त्रुटि।"
 
-#: ../src/common/imagbmp.cpp:1290 ../src/common/imagbmp.cpp:1390
-#: ../src/common/imagbmp.cpp:1405 ../src/common/imagbmp.cpp:1416
-#: ../src/common/imagbmp.cpp:1430 ../src/common/imagbmp.cpp:1478
-#: ../src/common/imagbmp.cpp:1493 ../src/common/imagbmp.cpp:1507
-#: ../src/common/imagbmp.cpp:1518
+#: ../src/common/imagbmp.cpp:1302 ../src/common/imagbmp.cpp:1402
+#: ../src/common/imagbmp.cpp:1417 ../src/common/imagbmp.cpp:1428
+#: ../src/common/imagbmp.cpp:1442 ../src/common/imagbmp.cpp:1490
+#: ../src/common/imagbmp.cpp:1505 ../src/common/imagbmp.cpp:1519
+#: ../src/common/imagbmp.cpp:1530
 msgid "ICO: Error writing the image file!"
 msgstr "आईसीओ: आकॄति फ़ाइल को लिखने में त्रुटि!"
 
-#: ../src/common/imagbmp.cpp:1255
+#: ../src/common/imagbmp.cpp:1267
 msgid "ICO: Image too tall for an icon."
 msgstr "आईसीओ: आकॄति एक आईकॉन के लिए बहुत बड़ी है।"
 
-#: ../src/common/imagbmp.cpp:1263
+#: ../src/common/imagbmp.cpp:1275
 msgid "ICO: Image too wide for an icon."
 msgstr "आईसीओ: आकॄति एक आईकॉन के लिए बहुत चौड़ी है।"
 
-#: ../src/common/imagbmp.cpp:1603
+#: ../src/common/imagbmp.cpp:1615
 msgid "ICO: Invalid icon index."
 msgstr "ICO: अवैध आईकॉन इंडेक्स।"
 
-#: ../src/common/imagiff.cpp:758
+#: ../src/common/imagiff.cpp:755
 msgid "IFF: data stream seems to be truncated."
 msgstr "आईएफ़एफ़: डाटा धारा लगता है कि टूट गई है।"
 
-#: ../src/common/imagiff.cpp:742
+#: ../src/common/imagiff.cpp:739
 msgid "IFF: error in IFF image format."
 msgstr "आईएफ़एफ़: आईएफ़एफ़ आकॄति प्रारूप में त्रुटि।"
 
-#: ../src/common/imagiff.cpp:745
+#: ../src/common/imagiff.cpp:742
 msgid "IFF: not enough memory."
 msgstr "आईएफ़एफ़: आवश्यकतानुसार स्मॄति का अभाव।"
 
-#: ../src/common/imagiff.cpp:748
+#: ../src/common/imagiff.cpp:745
 msgid "IFF: unknown error!!!"
 msgstr "आईएफ़एफ़: अज्ञात त्रुटि!!!"
 
-#: ../src/common/fmapbase.cpp:197
+#: ../src/common/fmapbase.cpp:194
 msgid "ISO-2022-JP"
 msgstr ""
 
-#: ../src/html/htmprint.cpp:282
+#: ../src/html/htmprint.cpp:294
 msgid ""
 "If possible, try changing the layout parameters to make the printout more "
 "narrow."
 msgstr ""
 
-#: ../src/generic/dbgrptg.cpp:358
+#: ../src/generic/dbgrptg.cpp:362
 msgid ""
 "If you have any additional information pertaining to this bug\n"
 "report, please enter it here and it will be joined to it:"
@@ -4234,46 +4340,50 @@ msgstr ""
 "लेकिन ध्यान रखे, यह इस प्रोग्राम को उत्कृष्ट बनाने में बाधा पहुँचायेंगी,\n"
 "इसलिए जब तक हो सके कृपया विवरण निर्माण जारी रखे।\n"
 
-#: ../src/msw/registry.cpp:1405
+#: ../src/common/zipstrm.cpp:1043
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1393
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:295
+#: ../src/common/xtistrm.cpp:292
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "घटना स्रोत की भांति अवैध ऑबजेक्ट वर्ग (Non-wxEvtHandler)"
 
-#: ../src/common/xti.cpp:513
+#: ../src/common/xti.cpp:510
 msgid "Illegal Parameter Count for ConstructObject Method"
 msgstr "ConstructObject विधि के लिए अवैध पैरामीटर गणक"
 
-#: ../src/common/xti.cpp:501
+#: ../src/common/xti.cpp:498
 msgid "Illegal Parameter Count for Create Method"
 msgstr "निर्माण विधि के लिए अवैध पैरामीटर गणक"
 
-#: ../src/generic/dirctrlg.cpp:570 ../src/generic/filectrlg.cpp:756
+#: ../src/generic/dirctrlg.cpp:536 ../src/generic/filectrlg.cpp:752
 msgid "Illegal directory name."
 msgstr "अवैध निर्देशिका नाम।"
 
-#: ../src/generic/filectrlg.cpp:1367
+#: ../src/generic/filectrlg.cpp:1356
 msgid "Illegal file specification."
 msgstr "अवैध फ़ाइल विशिष्टता"
 
-#: ../src/common/image.cpp:2269
+#: ../src/common/image.cpp:2363
 msgid "Image and mask have different sizes."
 msgstr "आकृति और मास्क के आकार भिन्न है।"
 
-#: ../src/common/image.cpp:2746
+#: ../src/common/image.cpp:2841
 #, fuzzy, c-format
 msgid "Image file is not of type %d."
 msgstr "आकृति फ़ाइल %ld प्रकार की नहीं है।"
 
-#: ../src/common/image.cpp:2877
+#: ../src/common/image.cpp:2995
 #, fuzzy, c-format
 msgid "Image is not of type %s."
 msgstr "आकृति फ़ाइल %s प्रकार की नहीं है।"
 
-#: ../src/msw/textctrl.cpp:488
+#: ../src/msw/textctrl.cpp:534
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -4281,104 +4391,104 @@ msgstr ""
 "एक रिच ऐडीट कन्ट्रोल का निर्माण असम्भव है, इसके बज़ाय सामान्य पाठ कन्ट्रोल का उपयोग "
 "किया जा रहा है। कृपया riched32.dll को पुनः संसाधित करें"
 
-#: ../src/unix/utilsunx.cpp:301
+#: ../src/unix/utilsunx.cpp:303
 msgid "Impossible to get child process input"
 msgstr "बाल प्रोसेस इनपुट का प्राप्त करना असम्भव"
 
-#: ../src/common/filefn.cpp:1028
+#: ../src/common/filefn.cpp:917
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "'%s' फ़ाइले के लिए अनुमतियों को प्राप्त करना असम्भव"
 
-#: ../src/common/filefn.cpp:1042
+#: ../src/common/filefn.cpp:931
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "'%s' फ़ाइल को पुनः आरम्भ से लिखना असम्भव"
 
-#: ../src/common/filefn.cpp:1097
+#: ../src/common/filefn.cpp:986
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "'%s' फ़ाइल के लिए अनुमतियों को स्थापित करना असम्भव"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:886
+#: ../src/propgrid/advprops.cpp:787
 #, fuzzy
 msgid "InactiveBorder"
 msgstr "आधुनिक"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:887
+#: ../src/propgrid/advprops.cpp:788
 msgid "InactiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:888
+#: ../src/propgrid/advprops.cpp:789
 msgid "InactiveCaptionText"
 msgstr ""
 
-#: ../src/common/gifdecod.cpp:792
+#: ../src/common/gifdecod.cpp:826
 #, c-format
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:635
+#: ../src/msw/ole/automtn.cpp:626
 msgid "Incorrect number of arguments."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:165
+#: ../src/common/stockitem.cpp:162
 msgid "Indent"
 msgstr "जगह छोड़ कर लिखें"
 
-#: ../src/richtext/richtextformatdlg.cpp:349
+#: ../src/richtext/richtextformatdlg.cpp:342
 msgid "Indents && Spacing"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:166 ../src/html/helpwnd.cpp:515
+#: ../src/common/stockitem.cpp:163 ../src/html/helpwnd.cpp:513
 msgid "Index"
 msgstr "इंडेक्स"
 
-#: ../src/common/fmapbase.cpp:159
+#: ../src/common/fmapbase.cpp:156
 msgid "Indian (ISO-8859-12)"
 msgstr "भारतीय (आईसो-८८५९-१२)"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "Info"
 msgstr ""
 
-#: ../src/common/init.cpp:287
+#: ../src/common/init.cpp:284
 msgid "Initialization failed in post init, aborting."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:54
+#: ../src/common/accelcmn.cpp:51
 #, fuzzy
 msgid "Ins"
 msgstr "डाले"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextsymboldlg.cpp:472 ../src/common/accelcmn.cpp:53
+#: ../src/common/accelcmn.cpp:50 ../src/richtext/richtextsymboldlg.cpp:469
 msgid "Insert"
 msgstr "डाले"
 
-#: ../src/richtext/richtextbuffer.cpp:8067
+#: ../src/richtext/richtextbuffer.cpp:8063
 #, fuzzy
 msgid "Insert Field"
 msgstr "पाठ डाले"
 
-#: ../src/richtext/richtextbuffer.cpp:7978
-#: ../src/richtext/richtextbuffer.cpp:8936
+#: ../src/richtext/richtextbuffer.cpp:7974
+#: ../src/richtext/richtextbuffer.cpp:8934
 msgid "Insert Image"
 msgstr "आकृति डाले"
 
-#: ../src/richtext/richtextbuffer.cpp:8025
+#: ../src/richtext/richtextbuffer.cpp:8021
 #, fuzzy
 msgid "Insert Object"
 msgstr "पाठ डाले"
 
-#: ../src/richtext/richtextctrl.cpp:1286 ../src/richtext/richtextctrl.cpp:1494
-#: ../src/richtext/richtextbuffer.cpp:7822
-#: ../src/richtext/richtextbuffer.cpp:7852
-#: ../src/richtext/richtextbuffer.cpp:7894
+#: ../src/richtext/richtextbuffer.cpp:7818
+#: ../src/richtext/richtextbuffer.cpp:7848
+#: ../src/richtext/richtextbuffer.cpp:7890
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
 msgid "Insert Text"
 msgstr "पाठ डाले"
 
@@ -4393,16 +4503,11 @@ msgstr "अनुच्छेद के पहले का अन्तरा�
 msgid "Inset"
 msgstr "डाले"
 
-#: ../src/gtk/app.cpp:425
-#, c-format
-msgid "Invalid GTK+ command line option, use \"%s --help\""
-msgstr ""
-
-#: ../src/common/imagtiff.cpp:311
+#: ../src/common/imagtiff.cpp:308
 msgid "Invalid TIFF image index."
 msgstr "अवैध टीआईएफ़एफ़ आकॄति इंडेक्स।"
 
-#: ../src/common/appcmn.cpp:273
+#: ../src/common/appcmn.cpp:294
 #, fuzzy, c-format
 msgid "Invalid display mode specification '%s'."
 msgstr "अवैध जयामिति विशिष्टतायें '%s'"
@@ -4412,258 +4517,262 @@ msgstr "अवैध जयामिति विशिष्टतायें 
 msgid "Invalid geometry specification '%s'"
 msgstr "अवैध जयामिति विशिष्टतायें '%s'"
 
-#: ../src/unix/fswatcher_inotify.cpp:323
+#: ../src/unix/fswatcher_inotify.cpp:320
 #, c-format
 msgid "Invalid inotify event for \"%s\""
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:312
+#: ../src/unix/snglinst.cpp:309
 #, c-format
 msgid "Invalid lock file '%s'."
 msgstr "'%s' अवैध लॉक फ़ाइल।"
 
-#: ../src/common/translation.cpp:1125
+#: ../src/common/translation.cpp:1167
 #, fuzzy
 msgid "Invalid message catalog."
 msgstr "'%s' एक वैध संदेश सूचीपत्र नहीं है।"
 
-#: ../src/common/xtistrm.cpp:405 ../src/common/xtistrm.cpp:420
+#: ../src/common/xtistrm.cpp:402 ../src/common/xtistrm.cpp:417
 msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
 msgstr "GetObjectClassInfo को अवैध या रिक्त ऑबजेक्ट आईडी दी गयी"
 
-#: ../src/common/xtistrm.cpp:435
+#: ../src/common/xtistrm.cpp:432
 msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
 msgstr "HasObjectClassInfo को अवैध या रिक्त ऑबजेक्ट आईडी दी गयी"
 
-#: ../src/common/regex.cpp:310
+#: ../src/common/regex.cpp:307
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "'%s' अवैध सामान्य व्यंजक: %s"
 
-#: ../src/common/config.cpp:226
+#: ../src/common/config.cpp:222
 #, c-format
 msgid "Invalid value %ld for a boolean key \"%s\" in config file."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:351
-#: ../src/osx/carbon/fontdlg.cpp:361 ../src/common/stockitem.cpp:168
+#: ../src/osx/carbon/fontdlg.cpp:358 ../src/common/stockitem.cpp:165
+#: ../src/generic/fontdlgg.cpp:325 ../src/richtext/richtextfontpage.cpp:351
 msgid "Italic"
 msgstr "इटैलिक"
 
-#: ../src/common/paper.cpp:130
+#: ../src/common/paper.cpp:127
 msgid "Italy Envelope, 110 x 230 mm"
 msgstr "इटली लिफ़ाफ़ा, ११० x २३० मिलीमीटर"
 
-#: ../src/common/imagjpeg.cpp:270
+#: ../src/common/imagjpeg.cpp:257
 msgid "JPEG: Couldn't load - file is probably corrupted."
 msgstr "जेपीईजी: लोड नहीं किया जा सका - सम्भवता फ़ाइल निकॄष्ट है।"
 
-#: ../src/common/imagjpeg.cpp:449
+#: ../src/common/imagjpeg.cpp:436
 msgid "JPEG: Couldn't save image."
 msgstr "जेपीईजी: आकॄति को सुरक्षित नहीं किया जा सका।"
 
-#: ../src/common/paper.cpp:163
+#: ../src/common/paper.cpp:160
 msgid "Japanese Double Postcard 200 x 148 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:167
+#: ../src/common/paper.cpp:164
 msgid "Japanese Envelope Chou #3"
 msgstr ""
 
-#: ../src/common/paper.cpp:180
+#: ../src/common/paper.cpp:177
 msgid "Japanese Envelope Chou #3 Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:168
+#: ../src/common/paper.cpp:165
 msgid "Japanese Envelope Chou #4"
 msgstr ""
 
-#: ../src/common/paper.cpp:181
+#: ../src/common/paper.cpp:178
 msgid "Japanese Envelope Chou #4 Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:165
+#: ../src/common/paper.cpp:162
 msgid "Japanese Envelope Kaku #2"
 msgstr ""
 
-#: ../src/common/paper.cpp:178
+#: ../src/common/paper.cpp:175
 msgid "Japanese Envelope Kaku #2 Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:166
+#: ../src/common/paper.cpp:163
 msgid "Japanese Envelope Kaku #3"
 msgstr ""
 
-#: ../src/common/paper.cpp:179
+#: ../src/common/paper.cpp:176
 msgid "Japanese Envelope Kaku #3 Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:185
+#: ../src/common/paper.cpp:182
 msgid "Japanese Envelope You #4"
 msgstr ""
 
-#: ../src/common/paper.cpp:186
+#: ../src/common/paper.cpp:183
 msgid "Japanese Envelope You #4 Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:138
+#: ../src/common/paper.cpp:135
 msgid "Japanese Postcard 100 x 148 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:175
+#: ../src/common/paper.cpp:172
 msgid "Japanese Postcard Rotated 148 x 100 mm"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "Jump to"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:171
+#: ../src/common/stockitem.cpp:168
 msgid "Justified"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:155
-#: ../src/richtext/richtextindentspage.cpp:157
 #: ../src/richtext/richtextliststylepage.cpp:344
 #: ../src/richtext/richtextliststylepage.cpp:346
+#: ../src/richtext/richtextindentspage.cpp:155
+#: ../src/richtext/richtextindentspage.cpp:157
 msgid "Justify text left and right."
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:163
+#: ../src/common/fmapbase.cpp:160
 msgid "KOI8-R"
 msgstr "केओआई८-आर"
 
-#: ../src/common/fmapbase.cpp:164
+#: ../src/common/fmapbase.cpp:161
 msgid "KOI8-U"
 msgstr "केओआई८-यू"
 
-#: ../src/common/accelcmn.cpp:265 ../src/common/accelcmn.cpp:347
+#: ../src/common/accelcmn.cpp:279 ../src/common/accelcmn.cpp:364
 msgid "KP_"
 msgstr "KP_"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 #, fuzzy
 msgid "KP_Add"
 msgstr "KP_ADD"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "KP_Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "KP_Decimal"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 #, fuzzy
 msgid "KP_Delete"
 msgstr "मिटाएँं"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "KP_Divide"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 #, fuzzy
 msgid "KP_Down"
 msgstr "नीचे"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 #, fuzzy
 msgid "KP_End"
 msgstr "KP_END"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 #, fuzzy
 msgid "KP_Enter"
 msgstr "मुद्रक"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "KP_Equal"
 msgstr ""
 
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
-#, fuzzy
-msgid "KP_Home"
-msgstr "गृह"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
-#, fuzzy
-msgid "KP_Insert"
-msgstr "डाले"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
-#, fuzzy
-msgid "KP_Left"
-msgstr "बायें"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
-msgid "KP_Multiply"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:99
-#, fuzzy
-msgid "KP_Next"
-msgstr "अगला"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
-msgid "KP_PageDown"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
-msgid "KP_PageUp"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:98
-msgid "KP_Prior"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
-#, fuzzy
-msgid "KP_Right"
-msgstr "दायें"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
-msgid "KP_Separator"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
-msgid "KP_Space"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
-msgid "KP_Subtract"
+#: ../src/common/accelcmn.cpp:276 ../src/common/accelcmn.cpp:361
+msgid "KP_F"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
 #: ../src/common/accelcmn.cpp:89
 #, fuzzy
+msgid "KP_Home"
+msgstr "गृह"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:100
+#, fuzzy
+msgid "KP_Insert"
+msgstr "डाले"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:90
+#, fuzzy
+msgid "KP_Left"
+msgstr "बायें"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:103
+msgid "KP_Multiply"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:97
+#, fuzzy
+msgid "KP_Next"
+msgstr "अगला"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:95
+msgid "KP_PageDown"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:94
+msgid "KP_PageUp"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:96
+msgid "KP_Prior"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:92
+#, fuzzy
+msgid "KP_Right"
+msgstr "दायें"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:105
+msgid "KP_Separator"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:86
+msgid "KP_Space"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:106
+msgid "KP_Subtract"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:87
+#, fuzzy
 msgid "KP_Tab"
 msgstr "KP_TAB"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 #, fuzzy
 msgid "KP_Up"
 msgstr "KP_UP"
@@ -4672,119 +4781,134 @@ msgstr "KP_UP"
 msgid "L&ine spacing:"
 msgstr "पंक्ति अन्तराल (&I):"
 
-#: ../src/generic/prntdlgg.cpp:613 ../src/generic/prntdlgg.cpp:868
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "संकुचन त्रुटि"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "फ़ैलाव त्रुटि"
+
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:861
 msgid "Landscape"
 msgstr "लैडस्केप"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 #, fuzzy
 msgid "Last"
 msgstr "चिपकाएँ"
 
-#: ../src/common/prntbase.cpp:1572
+#: ../src/common/prntbase.cpp:1597
 #, fuzzy
 msgid "Last page"
 msgstr "अगला पृष्ट"
 
-#: ../src/common/log.cpp:305
+#: ../src/common/log.cpp:324
 #, c-format
 msgid "Last repeated message (\"%s\", %u time) wasn't output"
 msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/common/paper.cpp:103
+#: ../src/common/paper.cpp:100
 msgid "Ledger, 17 x 11 in"
 msgstr "लेजर, १७ x ११ इंच"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6146
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:58 ../src/generic/datavgen.cpp:6951
+#: ../src/richtext/richtextsizepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:252
 #: ../src/richtext/richtextliststylepage.cpp:253
 #: ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
-#: ../src/richtext/richtextsizepage.cpp:249 ../src/common/accelcmn.cpp:61
 msgid "Left"
 msgstr "बायें"
 
-#: ../src/richtext/richtextindentspage.cpp:204
 #: ../src/richtext/richtextliststylepage.cpp:390
+#: ../src/richtext/richtextindentspage.cpp:204
 msgid "Left (&first line):"
 msgstr "बायें (पहली पंक्ति) (&F):"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1761
+#: ../src/propgrid/advprops.cpp:1662
 msgid "Left Button"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:880
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Left margin (mm):"
 msgstr "बायाँ हाशिया (मिलीमीटर):"
 
-#: ../src/richtext/richtextindentspage.cpp:141
-#: ../src/richtext/richtextindentspage.cpp:143
 #: ../src/richtext/richtextliststylepage.cpp:330
 #: ../src/richtext/richtextliststylepage.cpp:332
+#: ../src/richtext/richtextindentspage.cpp:141
+#: ../src/richtext/richtextindentspage.cpp:143
 msgid "Left-align text."
 msgstr "पाठ को बायें पंक्तिबद्ध करें।"
 
-#: ../src/common/paper.cpp:144
+#: ../src/common/paper.cpp:141
 #, fuzzy
 msgid "Legal Extra 9 1/2 x 15 in"
 msgstr "लीगल, ८ १/२ x १४ इंच"
 
-#: ../src/common/paper.cpp:96
+#: ../src/common/paper.cpp:93
 msgid "Legal, 8 1/2 x 14 in"
 msgstr "लीगल, ८ १/२ x १४ इंच"
 
-#: ../src/common/paper.cpp:143
+#: ../src/common/paper.cpp:140
 #, fuzzy
 msgid "Letter Extra 9 1/2 x 12 in"
 msgstr "लेटर, ८ १/२ x ११ इंच"
 
-#: ../src/common/paper.cpp:149
+#: ../src/common/paper.cpp:146
 msgid "Letter Extra Transverse 9.275 x 12 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:152
+#: ../src/common/paper.cpp:149
 #, fuzzy
 msgid "Letter Plus 8 1/2 x 12.69 in"
 msgstr "लेटर, ८ १/२ x ११ इंच"
 
-#: ../src/common/paper.cpp:169
+#: ../src/common/paper.cpp:166
 #, fuzzy
 msgid "Letter Rotated 11 x 8 1/2 in"
 msgstr "लेटर, ८ १/२ x ११ इंच"
 
-#: ../src/common/paper.cpp:101
+#: ../src/common/paper.cpp:98
 msgid "Letter Small, 8 1/2 x 11 in"
 msgstr "लेटर छोटा, ८ १/२ x ११ इंच"
 
-#: ../src/common/paper.cpp:147
+#: ../src/common/paper.cpp:144
 #, fuzzy
 msgid "Letter Transverse 8 1/2 x 11 in"
 msgstr "लेटर, ८ १/२ x ११ इंच"
 
-#: ../src/common/paper.cpp:95
+#: ../src/common/paper.cpp:92
 msgid "Letter, 8 1/2 x 11 in"
 msgstr "लेटर, ८ १/२ x ११ इंच"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "License"
 msgstr "लाइसेंस"
 
-#: ../src/generic/fontdlgg.cpp:332
+#: ../src/generic/fontdlgg.cpp:328
 msgid "Light"
 msgstr "हल्का"
 
-#: ../src/propgrid/advprops.cpp:1608
+#: ../src/propgrid/advprops.cpp:1514
 msgid "Lime"
 msgstr ""
 
-#: ../src/generic/helpext.cpp:294
+#: ../src/generic/helpext.cpp:292
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr ""
@@ -4793,15 +4917,15 @@ msgstr ""
 msgid "Line spacing:"
 msgstr "पंक्ति अन्तराल:"
 
-#: ../src/html/chm.cpp:838
+#: ../src/html/chm.cpp:829
 msgid "Link contained '//', converted to absolute link."
 msgstr "कड़ी में '//' शामिल है, निरपेक्ष कड़ी में बदल दिया गया।"
 
-#: ../src/richtext/richtextformatdlg.cpp:364
+#: ../src/richtext/richtextformatdlg.cpp:357
 msgid "List Style"
 msgstr "सूची शैली"
 
-#: ../src/richtext/richtextstyles.cpp:1064
+#: ../src/richtext/richtextstyles.cpp:1061
 msgid "List styles"
 msgstr "सूची शैलियाँ"
 
@@ -4815,26 +4939,26 @@ msgstr "फ़ॉन्ट का आकार बिंदुओं में द�
 msgid "Lists the available fonts."
 msgstr "उपलब्ध फ़ॉन्ट की सूची दिखाएँ।"
 
-#: ../src/common/fldlgcmn.cpp:340
+#: ../src/common/fldlgcmn.cpp:337
 #, c-format
 msgid "Load %s file"
 msgstr "%s फ़ाइल को लोड करें"
 
-#: ../src/html/htmlwin.cpp:597
+#: ../src/html/htmlwin.cpp:600
 msgid "Loading : "
 msgstr "लोड किया जा रहा है : "
 
-#: ../src/unix/snglinst.cpp:246
+#: ../src/unix/snglinst.cpp:243
 #, fuzzy, c-format
 msgid "Lock file '%s' has incorrect owner."
 msgstr "साउन्ड फ़ाइल '%s' एक असमर्थित प्रारूप में है।"
 
-#: ../src/unix/snglinst.cpp:251
+#: ../src/unix/snglinst.cpp:248
 #, c-format
 msgid "Lock file '%s' has incorrect permissions."
 msgstr "लॉक फ़ाइल '%s' पे गलत अनुमतियाँ हें।"
 
-#: ../src/generic/logg.cpp:576
+#: ../src/generic/logg.cpp:573
 #, c-format
 msgid "Log saved to the file '%s'."
 msgstr "लॉग को '%s' पर सुरक्षित किया गया।"
@@ -4849,11 +4973,11 @@ msgstr "छोटे आकार के अक्षर"
 msgid "Lower case roman numerals"
 msgstr ""
 
-#: ../src/gtk/mdi.cpp:422 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk1/mdi.cpp:431 ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "एमडीआई चाइल्ड"
 
-#: ../src/msw/helpchm.cpp:56
+#: ../src/msw/helpchm.cpp:53
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -4861,196 +4985,196 @@ msgstr ""
 "एमएस एचटीएमएल सहायता क्रियाऐं अनुपलब्ध है क्योंकि एमएस एचटीएमएल सहायता लायबरी इस "
 "मशीन परसंसाधित नहीं है। कॄपया इसे संसाधित करें।"
 
-#: ../src/univ/themes/win32.cpp:3754
+#: ../src/univ/themes/win32.cpp:3751
 msgid "Ma&ximize"
 msgstr "बड़ा करें (&x)"
 
-#: ../src/common/fmapbase.cpp:203
+#: ../src/common/fmapbase.cpp:200
 #, fuzzy
 msgid "MacArabic"
 msgstr "अरबी"
 
-#: ../src/common/fmapbase.cpp:222
+#: ../src/common/fmapbase.cpp:219
 msgid "MacArmenian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:211
+#: ../src/common/fmapbase.cpp:208
 msgid "MacBengali"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:217
+#: ../src/common/fmapbase.cpp:214
 msgid "MacBurmese"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:236
+#: ../src/common/fmapbase.cpp:233
 msgid "MacCeltic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:227
+#: ../src/common/fmapbase.cpp:224
 msgid "MacCentralEurRoman"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:223
+#: ../src/common/fmapbase.cpp:220
 msgid "MacChineseSimp"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:201
+#: ../src/common/fmapbase.cpp:198
 msgid "MacChineseTrad"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:233
+#: ../src/common/fmapbase.cpp:230
 msgid "MacCroatian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:206
+#: ../src/common/fmapbase.cpp:203
 msgid "MacCyrillic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:207
+#: ../src/common/fmapbase.cpp:204
 msgid "MacDevanagari"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:231
+#: ../src/common/fmapbase.cpp:228
 msgid "MacDingbats"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:226
+#: ../src/common/fmapbase.cpp:223
 msgid "MacEthiopic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:229
+#: ../src/common/fmapbase.cpp:226
 #, fuzzy
 msgid "MacExtArabic"
 msgstr "अरबी"
 
-#: ../src/common/fmapbase.cpp:237
+#: ../src/common/fmapbase.cpp:234
 msgid "MacGaelic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:221
+#: ../src/common/fmapbase.cpp:218
 msgid "MacGeorgian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:205
+#: ../src/common/fmapbase.cpp:202
 msgid "MacGreek"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:209
+#: ../src/common/fmapbase.cpp:206
 msgid "MacGujarati"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:208
+#: ../src/common/fmapbase.cpp:205
 msgid "MacGurmukhi"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:204
+#: ../src/common/fmapbase.cpp:201
 msgid "MacHebrew"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:234
+#: ../src/common/fmapbase.cpp:231
 msgid "MacIcelandic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:200
+#: ../src/common/fmapbase.cpp:197
 msgid "MacJapanese"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:214
+#: ../src/common/fmapbase.cpp:211
 msgid "MacKannada"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:238
+#: ../src/common/fmapbase.cpp:235
 msgid "MacKeyboardGlyphs"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:218
+#: ../src/common/fmapbase.cpp:215
 msgid "MacKhmer"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:202
+#: ../src/common/fmapbase.cpp:199
 msgid "MacKorean"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:220
+#: ../src/common/fmapbase.cpp:217
 msgid "MacLaotian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:215
+#: ../src/common/fmapbase.cpp:212
 msgid "MacMalayalam"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:225
+#: ../src/common/fmapbase.cpp:222
 msgid "MacMongolian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:210
+#: ../src/common/fmapbase.cpp:207
 msgid "MacOriya"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:199
+#: ../src/common/fmapbase.cpp:196
 #, fuzzy
 msgid "MacRoman"
 msgstr "रोमन"
 
-#: ../src/common/fmapbase.cpp:235
+#: ../src/common/fmapbase.cpp:232
 #, fuzzy
 msgid "MacRomanian"
 msgstr "रोमन"
 
-#: ../src/common/fmapbase.cpp:216
+#: ../src/common/fmapbase.cpp:213
 #, fuzzy
 msgid "MacSinhalese"
 msgstr "बड़ा-छोटा का मिलान करें"
 
-#: ../src/common/fmapbase.cpp:230
+#: ../src/common/fmapbase.cpp:227
 #, fuzzy
 msgid "MacSymbol"
 msgstr "चिह्न"
 
-#: ../src/common/fmapbase.cpp:212
+#: ../src/common/fmapbase.cpp:209
 msgid "MacTamil"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:213
+#: ../src/common/fmapbase.cpp:210
 msgid "MacTelugu"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:219
+#: ../src/common/fmapbase.cpp:216
 msgid "MacThai"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:224
+#: ../src/common/fmapbase.cpp:221
 msgid "MacTibetan"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:232
+#: ../src/common/fmapbase.cpp:229
 msgid "MacTurkish"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:228
+#: ../src/common/fmapbase.cpp:225
 msgid "MacVietnamese"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1762
+#: ../src/propgrid/advprops.cpp:1663
 msgid "Magnifier"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:2143
+#: ../src/propgrid/advprops.cpp:2050
 #, fuzzy
 msgid "Make a selection:"
 msgstr "चयन चिपकाएँ"
 
-#: ../src/richtext/richtextformatdlg.cpp:374
+#: ../src/richtext/richtextformatdlg.cpp:367
 #: ../src/richtext/richtextmarginspage.cpp:171
 msgid "Margins"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1595
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Maroon"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:147
+#: ../src/generic/fdrepdlg.cpp:144
 msgid "Match case"
 msgstr "बड़ा-छोटा का मिलान करें"
 
@@ -5064,41 +5188,41 @@ msgstr "भार (&W):"
 msgid "Max width:"
 msgstr "से बदलें:"
 
-#: ../src/unix/mediactrl.cpp:947
+#: ../src/unix/mediactrl.cpp:972
 #, c-format
 msgid "Media playback error: %s"
 msgstr ""
 
-#: ../src/common/fs_mem.cpp:175
+#: ../src/common/fs_mem.cpp:170
 #, c-format
 msgid "Memory VFS already contains file '%s'!"
 msgstr "स्मृति वीएफ़एस में पहिले से '%s' फ़ाइल शामिल है!"
 
 #. TRANSLATORS: Name of keyboard key
 #. TRANSLATORS: Keyword of system colour
-#: ../src/common/accelcmn.cpp:73 ../src/propgrid/advprops.cpp:889
+#: ../src/common/accelcmn.cpp:70 ../src/propgrid/advprops.cpp:790
 msgid "Menu"
 msgstr "विकल्प सूची"
 
-#: ../src/common/msgout.cpp:124
+#: ../src/common/msgout.cpp:121
 #, fuzzy
 msgid "Message"
 msgstr "%s संदेश"
 
-#: ../src/univ/themes/metal.cpp:168
+#: ../src/univ/themes/metal.cpp:165
 msgid "Metal theme"
 msgstr "मेटल थीम"
 
-#: ../src/msw/ole/automtn.cpp:652
+#: ../src/msw/ole/automtn.cpp:643
 msgid "Method or property not found."
 msgstr ""
 
-#: ../src/univ/themes/win32.cpp:3752
+#: ../src/univ/themes/win32.cpp:3749
 msgid "Mi&nimize"
 msgstr "छोटा करें (&n)"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1763
+#: ../src/propgrid/advprops.cpp:1664
 msgid "Middle Button"
 msgstr ""
 
@@ -5111,36 +5235,41 @@ msgstr "फ़ॉन्ट भार (&W):"
 msgid "Min width:"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:668
+#: ../src/osx/cocoa/menu.mm:281
+#, fuzzy
+msgid "Minimize"
+msgstr "छोटा करें (&n)"
+
+#: ../src/msw/ole/automtn.cpp:659
 msgid "Missing a required parameter."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:324
+#: ../src/generic/fontdlgg.cpp:320
 msgid "Modern"
 msgstr "आधुनिक"
 
-#: ../src/generic/filectrlg.cpp:427
+#: ../src/generic/filectrlg.cpp:423
 msgid "Modified"
 msgstr "परिवर्तित"
 
-#: ../src/common/module.cpp:133
+#: ../src/common/module.cpp:130
 #, c-format
 msgid "Module \"%s\" initialization failed"
 msgstr ""
 
-#: ../src/common/paper.cpp:131
+#: ../src/common/paper.cpp:128
 msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
 msgstr "मोनार्च लिफ़ाफ़ा, ३ ७/८ x ७ १/२ इंच"
 
-#: ../src/msw/fswatcher.cpp:143
+#: ../src/msw/fswatcher.cpp:140
 msgid "Monitoring individual files for changes is not supported currently."
 msgstr ""
 
-#: ../src/generic/editlbox.cpp:172
+#: ../src/generic/editlbox.cpp:160
 msgid "Move down"
 msgstr "नीचे लाएँ"
 
-#: ../src/generic/editlbox.cpp:171
+#: ../src/generic/editlbox.cpp:155
 msgid "Move up"
 msgstr "ऊपर लाएँ"
 
@@ -5155,99 +5284,104 @@ msgstr "अगले अनुच्छेद के लिए डिफ़ाल�
 msgid "Moves the object to the previous paragraph."
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9966
+#: ../src/richtext/richtextbuffer.cpp:9963
 msgid "Multiple Cell Properties"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:424
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:82
+msgid "Multiply"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:420
 msgid "Name"
 msgstr "नाम"
 
-#: ../src/propgrid/advprops.cpp:1596
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Navy"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "Network"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173
 #, fuzzy
 msgid "New"
 msgstr "नया (&N)"
 
-#: ../src/richtext/richtextstyledlg.cpp:243
+#: ../src/richtext/richtextstyledlg.cpp:239
 #, fuzzy
 msgid "New &Box Style..."
 msgstr "नयी सूची शैली (&L)..."
 
-#: ../src/richtext/richtextstyledlg.cpp:225
+#: ../src/richtext/richtextstyledlg.cpp:221
 msgid "New &Character Style..."
 msgstr "नयी संप्रतीक शैली (&C)..."
 
-#: ../src/richtext/richtextstyledlg.cpp:237
+#: ../src/richtext/richtextstyledlg.cpp:233
 msgid "New &List Style..."
 msgstr "नयी सूची शैली (&L)..."
 
-#: ../src/richtext/richtextstyledlg.cpp:231
+#: ../src/richtext/richtextstyledlg.cpp:227
 msgid "New &Paragraph Style..."
 msgstr "नयी अनुच्छेद शैली (&P)..."
 
-#: ../src/richtext/richtextstyledlg.cpp:606
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:654
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:820
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:893
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:934
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:602
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:650
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:816
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:889
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:930
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "New Style"
 msgstr "नयी शैली"
 
-#: ../src/generic/editlbox.cpp:169
+#: ../src/generic/editlbox.cpp:139
 msgid "New item"
 msgstr "नया आयट्म"
 
-#: ../src/generic/dirdlgg.cpp:297 ../src/generic/dirdlgg.cpp:307
-#: ../src/generic/filectrlg.cpp:618 ../src/generic/filectrlg.cpp:627
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+#: ../src/generic/dirdlgg.cpp:294 ../src/generic/dirdlgg.cpp:304
 msgid "NewName"
 msgstr "नयानाम"
 
-#: ../src/common/prntbase.cpp:1567 ../src/html/helpwnd.cpp:665
+#: ../src/common/prntbase.cpp:1592 ../src/html/helpwnd.cpp:663
 msgid "Next page"
 msgstr "अगला पृष्ट"
 
-#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:177
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:174
 #: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "नहीं"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1764
+#: ../src/propgrid/advprops.cpp:1665
 msgid "No Entry"
 msgstr ""
 
-#: ../src/generic/animateg.cpp:150
+#: ../src/generic/animateg.cpp:133
 #, c-format
 msgid "No animation handler for type %ld defined."
 msgstr "%ld प्रकार के लिए कोई सजीवन आकृति हैन्डलर परिभाषित नहीं।"
 
-#: ../src/dfb/bitmap.cpp:642 ../src/dfb/bitmap.cpp:676
+#: ../src/dfb/bitmap.cpp:639 ../src/dfb/bitmap.cpp:673
 #, fuzzy, c-format
 msgid "No bitmap handler for type %d defined."
 msgstr "%d प्रकार के लिए कोई आकृति हैन्डलर परिभाषित नहीं।"
 
-#: ../src/common/utilscmn.cpp:1077
+#: ../src/common/utilscmn.cpp:1095
 msgid "No default application configured for HTML files."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:445
+#: ../src/generic/helpext.cpp:443
 msgid "No entries found."
 msgstr "कोई प्रविष्टियां नहीं मिली।"
 
-#: ../src/common/fontmap.cpp:421
+#: ../src/common/fontmap.cpp:418
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found,\n"
@@ -5259,7 +5393,7 @@ msgstr ""
 "परन्तु एक वैकल्पिक एन्कोडिंग '%s' उपलब्ध है।\n"
 "क्या आप इस एन्कोडिंग को उपयोग करना चाहते है (अन्यथा आपकोएक अन्य का चयन करना पड़ेगा)?"
 
-#: ../src/common/fontmap.cpp:426
+#: ../src/common/fontmap.cpp:423
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found.\n"
@@ -5270,210 +5404,209 @@ msgstr ""
 "क्या आप इस एन्कोडिंग के लिए एक फ़ॉन्ट का चयन करना चाहेगें\n"
 "(अन्यथा यह पाठ इस एन्कोडिंग में भली-भांति नहीं दिखेगा)?"
 
-#: ../src/generic/animateg.cpp:142
+#: ../src/generic/animateg.cpp:125
 msgid "No handler found for animation type."
 msgstr "सजीवन आकृति प्रकार के लिए कोई हैन्डलर नहीं मिला।"
 
-#: ../src/common/image.cpp:2728
+#: ../src/common/image.cpp:2823
 msgid "No handler found for image type."
 msgstr "आकृति प्रकार के लिए कोई हैन्डलर नहीं मिला।"
 
-#: ../src/common/image.cpp:2736 ../src/common/image.cpp:2848
-#: ../src/common/image.cpp:2901
+#: ../src/common/image.cpp:2831 ../src/common/image.cpp:2954
+#: ../src/common/image.cpp:3020
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "%d प्रकार के लिए कोई आकृति हैन्डलर परिभाषित नहीं।"
 
-#: ../src/common/image.cpp:2871 ../src/common/image.cpp:2915
+#: ../src/common/image.cpp:2986 ../src/common/image.cpp:3034
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "%s प्रकार के लिए कोई आकृति हैन्डलर परिभाषित नहीं।"
 
-#: ../src/html/helpwnd.cpp:858
+#: ../src/html/helpwnd.cpp:856
 msgid "No matching page found yet"
 msgstr "कोई मिलता-जुलता पृष्ट अभी तक नहीं मिला"
 
-#: ../src/unix/sound.cpp:81
+#: ../src/unix/sound.cpp:78
 msgid "No sound"
 msgstr "कोई ध्वनि नहीं"
 
-#: ../src/common/image.cpp:2277 ../src/common/image.cpp:2318
+#: ../src/common/image.cpp:2371 ../src/common/image.cpp:2412
 #, fuzzy
 msgid "No unused colour in image being masked."
 msgstr "आकृति में कोई बिना उपयोग किया हुआ रंग छुपाया गया"
 
-#: ../src/common/image.cpp:3374
-msgid "No unused colour in image."
-msgstr "आकृति में कोई बिना उपयोग किया हुआ रंग नहीं हें।"
-
-#: ../src/generic/helpext.cpp:302
+#: ../src/generic/helpext.cpp:300
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr ""
 
-#: ../src/richtext/richtextborderspage.cpp:610
 #: ../src/richtext/richtextsizepage.cpp:248
 #: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:610
 #, fuzzy
 msgid "None"
 msgstr "(कुछ नहीं)"
 
-#: ../src/common/fmapbase.cpp:157
+#: ../src/common/fmapbase.cpp:154
 msgid "Nordic (ISO-8859-10)"
 msgstr "नोर्डिक (आईसो-८८५९-१०)"
 
-#: ../src/generic/fontdlgg.cpp:328 ../src/generic/fontdlgg.cpp:331
+#: ../src/generic/fontdlgg.cpp:324 ../src/generic/fontdlgg.cpp:327
 msgid "Normal"
 msgstr "सामान्य"
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1261
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "सामान्य फ़ेस<br>और <u>रेखांकित</u>। "
 
-#: ../src/html/helpwnd.cpp:1205
+#: ../src/html/helpwnd.cpp:1203
 msgid "Normal font:"
 msgstr "सामान्य फ़ॉन्ट: "
 
-#: ../src/propgrid/props.cpp:1128
+#: ../src/propgrid/props.cpp:1115
 #, fuzzy, c-format
 msgid "Not %s"
 msgstr "टिप्पणी (&N)"
 
-#: ../include/wx/filename.h:573 ../include/wx/filename.h:578
-#, fuzzy
-msgid "Not available"
-msgstr "संकेत उपलब्ध नहीं हैं, क्षमा करें!"
+#: ../src/common/secretstore.cpp:168
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/webrequest.cpp:605
+msgid "Not enough free disk space for download."
+msgstr ""
 
 #: ../src/richtext/richtextfontpage.cpp:358
 msgid "Not underlined"
 msgstr "रेखांकन नहीं"
 
-#: ../src/common/paper.cpp:115
+#: ../src/common/paper.cpp:112
 msgid "Note, 8 1/2 x 11 in"
 msgstr "नोट, ८ १/२ x ११ इंच"
 
-#: ../src/generic/notifmsgg.cpp:132
+#: ../src/generic/notifmsgg.cpp:129
 #, fuzzy
 msgid "Notice"
 msgstr "टिप्पणी (&N)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "Num *"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "Num +"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "Num ,"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "Num -"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "Num ."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "Num /"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "Num ="
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "Num Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 #, fuzzy
 msgid "Num Delete"
 msgstr "मिटाएँं"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 #, fuzzy
 msgid "Num Down"
 msgstr "नीचे"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "Num End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "Num Enter"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 #, fuzzy
 msgid "Num Home"
 msgstr "गृह"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 #, fuzzy
 msgid "Num Insert"
 msgstr "डाले"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num Lock"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "Num Page Down"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "Num Page Up"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 #, fuzzy
 msgid "Num Right"
 msgstr "दायें"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "Num Space"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "Num Tab"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "Num Up"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "Num left"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num_lock"
 msgstr ""
 
@@ -5482,13 +5615,13 @@ msgstr ""
 msgid "Numbered outline"
 msgstr "संख्यांकित रूपरेखा"
 
-#: ../include/wx/msgdlg.h:278 ../src/richtext/richtextstyledlg.cpp:297
-#: ../src/common/stockitem.cpp:178 ../src/msw/msgdlg.cpp:454
-#: ../src/msw/msgdlg.cpp:747 ../src/gtk1/fontdlg.cpp:138
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:175
+#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/msgdlg.cpp:741 ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "ठीक"
 
-#: ../src/msw/ole/automtn.cpp:692
+#: ../src/msw/ole/automtn.cpp:683
 #, c-format
 msgid "OLE Automation error in %s: %s"
 msgstr ""
@@ -5498,15 +5631,15 @@ msgstr ""
 msgid "Object Properties"
 msgstr "गुणधर्म (&P)"
 
-#: ../src/msw/ole/automtn.cpp:660
+#: ../src/msw/ole/automtn.cpp:651
 msgid "Object implementation does not support named arguments."
 msgstr ""
 
-#: ../src/common/xtixml.cpp:264
+#: ../src/common/xtixml.cpp:260
 msgid "Objects must have an id attribute"
 msgstr "ऑबजेक्टों के पास एक पहचान-संख्या विशेषता होनी चाहिए"
 
-#: ../src/propgrid/advprops.cpp:1601
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Olive"
 msgstr ""
 
@@ -5514,65 +5647,70 @@ msgstr ""
 msgid "Opaci&ty:"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:354
+#: ../src/generic/colrdlgg.cpp:374
 msgid "Opacity:"
 msgstr ""
 
-#: ../src/common/docview.cpp:1773 ../src/common/docview.cpp:1815
+#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
 msgid "Open File"
 msgstr "फ़ाइल खोलें"
 
-#: ../src/html/helpwnd.cpp:671 ../src/html/helpwnd.cpp:1554
+#: ../src/html/helpwnd.cpp:669 ../src/html/helpwnd.cpp:1552
 msgid "Open HTML document"
 msgstr "एचटीएमएल प्रलेख को खोलें"
 
-#: ../src/generic/dbgrptg.cpp:163
+#: ../src/common/stockitem.cpp:265
+#, fuzzy
+msgid "Open an existing document"
+msgstr "एचटीएमएल प्रलेख को खोलें"
+
+#: ../src/generic/dbgrptg.cpp:160
 #, c-format
 msgid "Open file \"%s\""
 msgstr "फ़ाइल खोलें \"%s\""
 
-#: ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176
 #, fuzzy
 msgid "Open..."
 msgstr "खोलें (&O)..."
 
-#: ../src/unix/glx11.cpp:506 ../src/msw/glcanvas.cpp:592
+#: ../src/msw/glcanvas.cpp:607 ../src/unix/glx11.cpp:513
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr ""
 
-#: ../src/generic/dirctrlg.cpp:599 ../src/generic/dirdlgg.cpp:323
-#: ../src/generic/filectrlg.cpp:642 ../src/generic/filectrlg.cpp:786
+#: ../src/generic/dirctrlg.cpp:565 ../src/generic/filectrlg.cpp:638
+#: ../src/generic/filectrlg.cpp:782 ../src/generic/dirdlgg.cpp:320
 msgid "Operation not permitted."
 msgstr "संक्रिया को अनुमति नहीं है।"
 
-#: ../src/common/cmdline.cpp:900
+#: ../src/common/cmdline.cpp:896
 #, fuzzy, c-format
 msgid "Option '%s' can't be negated"
 msgstr "'%s' निर्देशिका का निर्माण नहीं किया जा सकता था"
 
-#: ../src/common/cmdline.cpp:1064
+#: ../src/common/cmdline.cpp:1060
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "'%s' विकल्प को एक वैल्यू की आवश्यकता है।"
 
-#: ../src/common/cmdline.cpp:1147
+#: ../src/common/cmdline.cpp:1143
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "विकल्प '%s': '%s' को एक तिथि में नहीं बदला जा सका।"
 
-#: ../src/generic/prntdlgg.cpp:618
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "विकल्प"
 
-#: ../src/propgrid/advprops.cpp:1606
+#: ../src/propgrid/advprops.cpp:1512
 msgid "Orange"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:615 ../src/generic/prntdlgg.cpp:869
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:862
 msgid "Orientation"
 msgstr "अभिविन्यास"
 
-#: ../src/common/windowid.cpp:242
+#: ../src/common/windowid.cpp:237
 msgid "Out of window IDs.  Recommend shutting down application."
 msgstr ""
 
@@ -5586,157 +5724,157 @@ msgstr "रूपरेखा स्तर (&O):"
 msgid "Outset"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:656
+#: ../src/msw/ole/automtn.cpp:647
 msgid "Overflow while coercing argument values."
 msgstr ""
 
-#: ../src/common/imagpcx.cpp:457 ../src/common/imagpcx.cpp:480
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:479
 msgid "PCX: couldn't allocate memory"
 msgstr "पीसीएक्स: स्मृति का आवंटन नहीं किया जा सका"
 
-#: ../src/common/imagpcx.cpp:456
+#: ../src/common/imagpcx.cpp:455
 msgid "PCX: image format unsupported"
 msgstr "पीसीएक्स: आकृति प्रारूप असमर्थित है"
 
-#: ../src/common/imagpcx.cpp:479
+#: ../src/common/imagpcx.cpp:478
 msgid "PCX: invalid image"
 msgstr "पीसीएक्स: अवैध आकृति"
 
-#: ../src/common/imagpcx.cpp:442
+#: ../src/common/imagpcx.cpp:441
 msgid "PCX: this is not a PCX file."
 msgstr "पीसीएक्स: यह एक पीसीएक्स फ़ाइल नहीं है।"
 
-#: ../src/common/imagpcx.cpp:459 ../src/common/imagpcx.cpp:481
+#: ../src/common/imagpcx.cpp:458 ../src/common/imagpcx.cpp:480
 msgid "PCX: unknown error !!!"
 msgstr "पीसीएक्स: अज्ञात त्रुटि !!!"
 
-#: ../src/common/imagpcx.cpp:458
+#: ../src/common/imagpcx.cpp:457
 msgid "PCX: version number too low"
 msgstr "पीसीएक्स: संस्मरण संख्या अति निम्न है"
 
-#: ../src/common/imagpnm.cpp:91
+#: ../src/common/imagpnm.cpp:89
 msgid "PNM: Couldn't allocate memory."
 msgstr "पीएनएम: स्मृति का आवंटन नहीं किया जा सका।"
 
-#: ../src/common/imagpnm.cpp:73
+#: ../src/common/imagpnm.cpp:71
 msgid "PNM: File format is not recognized."
 msgstr "पीएनएम: फ़ाइल प्रारूप को पहचाना नहीं जा सका।"
 
-#: ../src/common/imagpnm.cpp:112 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
 #: ../src/common/imagpnm.cpp:156
 msgid "PNM: File seems truncated."
 msgstr "पीएनएम: फ़ाइल लगता है टूट गई है।"
 
-#: ../src/common/paper.cpp:187
+#: ../src/common/paper.cpp:184
 msgid "PRC 16K 146 x 215 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:200
+#: ../src/common/paper.cpp:197
 msgid "PRC 16K Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:188
+#: ../src/common/paper.cpp:185
 msgid "PRC 32K 97 x 151 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:201
+#: ../src/common/paper.cpp:198
 msgid "PRC 32K Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:189
+#: ../src/common/paper.cpp:186
 msgid "PRC 32K(Big) 97 x 151 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:202
+#: ../src/common/paper.cpp:199
 msgid "PRC 32K(Big) Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:190
+#: ../src/common/paper.cpp:187
 msgid "PRC Envelope #1 102 x 165 mm"
 msgstr "पीआरसी  लिफ़ाफ़ा #1 102 x 165 मिलीमीटर"
 
-#: ../src/common/paper.cpp:203
+#: ../src/common/paper.cpp:200
 #, fuzzy
 msgid "PRC Envelope #1 Rotated 165 x 102 mm"
 msgstr "सी६ लिफ़ाफ़ा, ११४ x १६२ मिलीमीटर"
 
-#: ../src/common/paper.cpp:199
+#: ../src/common/paper.cpp:196
 msgid "PRC Envelope #10 324 x 458 mm"
 msgstr "पीआरसी  लिफ़ाफ़ा #10 324 x 458 मिलीमीटर"
 
-#: ../src/common/paper.cpp:212
+#: ../src/common/paper.cpp:209
 #, fuzzy
 msgid "PRC Envelope #10 Rotated 458 x 324 mm"
 msgstr "सी४ लिफ़ाफ़ा, २२९ x ३२४ मिलीमीटर"
 
-#: ../src/common/paper.cpp:191
+#: ../src/common/paper.cpp:188
 msgid "PRC Envelope #2 102 x 176 mm"
 msgstr "पीआरसी  लिफ़ाफ़ा #2 102 x 176 मिलीमीटर"
 
-#: ../src/common/paper.cpp:204
+#: ../src/common/paper.cpp:201
 #, fuzzy
 msgid "PRC Envelope #2 Rotated 176 x 102 mm"
 msgstr "बी६ लिफ़ाफ़ा, १७६ x १२५ मिलीमीटर"
 
-#: ../src/common/paper.cpp:192
+#: ../src/common/paper.cpp:189
 msgid "PRC Envelope #3 125 x 176 mm"
 msgstr "पीआरसी  लिफ़ाफ़ा #3 125 x 176 मिलीमीटर"
 
-#: ../src/common/paper.cpp:205
+#: ../src/common/paper.cpp:202
 #, fuzzy
 msgid "PRC Envelope #3 Rotated 176 x 125 mm"
 msgstr "बी६ लिफ़ाफ़ा, १७६ x १२५ मिलीमीटर"
 
-#: ../src/common/paper.cpp:193
+#: ../src/common/paper.cpp:190
 msgid "PRC Envelope #4 110 x 208 mm"
 msgstr "पीआरसी  लिफ़ाफ़ा #4 110 x 208 मिलीमीटर"
 
-#: ../src/common/paper.cpp:206
+#: ../src/common/paper.cpp:203
 #, fuzzy
 msgid "PRC Envelope #4 Rotated 208 x 110 mm"
 msgstr "सी६ लिफ़ाफ़ा, ११४ x १६२ मिलीमीटर"
 
-#: ../src/common/paper.cpp:194
+#: ../src/common/paper.cpp:191
 msgid "PRC Envelope #5 110 x 220 mm"
 msgstr "पीआरसी  लिफ़ाफ़ा #5 110 x 220 मिलीमीटर"
 
-#: ../src/common/paper.cpp:207
+#: ../src/common/paper.cpp:204
 #, fuzzy
 msgid "PRC Envelope #5 Rotated 220 x 110 mm"
 msgstr "सी४ लिफ़ाफ़ा, २२९ x ३२४ मिलीमीटर"
 
-#: ../src/common/paper.cpp:195
+#: ../src/common/paper.cpp:192
 msgid "PRC Envelope #6 120 x 230 mm"
 msgstr "पीआरसी  लिफ़ाफ़ा #6 120 x 230 मिलीमीटर"
 
-#: ../src/common/paper.cpp:208
+#: ../src/common/paper.cpp:205
 #, fuzzy
 msgid "PRC Envelope #6 Rotated 230 x 120 mm"
 msgstr "सी५ लिफ़ाफ़ा, १६२ x २२९ मिलीमीटर"
 
-#: ../src/common/paper.cpp:196
+#: ../src/common/paper.cpp:193
 msgid "PRC Envelope #7 160 x 230 mm"
 msgstr "पीआरसी  लिफ़ाफ़ा #7 160 x 230 मिलीमीटर"
 
-#: ../src/common/paper.cpp:209
+#: ../src/common/paper.cpp:206
 #, fuzzy
 msgid "PRC Envelope #7 Rotated 230 x 160 mm"
 msgstr "सी६ लिफ़ाफ़ा, ११४ x १६२ मिलीमीटर"
 
-#: ../src/common/paper.cpp:197
+#: ../src/common/paper.cpp:194
 msgid "PRC Envelope #8 120 x 309 mm"
 msgstr "पीआरसी  लिफ़ाफ़ा #8 120 x 309 मिलीमीटर"
 
-#: ../src/common/paper.cpp:210
+#: ../src/common/paper.cpp:207
 #, fuzzy
 msgid "PRC Envelope #8 Rotated 309 x 120 mm"
 msgstr "सी४ लिफ़ाफ़ा, २२९ x ३२४ मिलीमीटर"
 
-#: ../src/common/paper.cpp:198
+#: ../src/common/paper.cpp:195
 msgid "PRC Envelope #9 229 x 324 mm"
 msgstr "पीआरसी  लिफ़ाफ़ा #9 229 x 324 मिलीमीटर"
 
-#: ../src/common/paper.cpp:211
+#: ../src/common/paper.cpp:208
 #, fuzzy
 msgid "PRC Envelope #9 Rotated 324 x 229 mm"
 msgstr "सी५ लिफ़ाफ़ा, १६२ x २२९ मिलीमीटर"
@@ -5746,92 +5884,96 @@ msgstr "सी५ लिफ़ाफ़ा, १६२ x २२९ मिलीमी�
 msgid "Padding"
 msgstr "पढ़ा जा रहा है"
 
-#: ../src/common/prntbase.cpp:2074
+#: ../src/common/prntbase.cpp:2096
 #, c-format
 msgid "Page %d"
 msgstr "पृष्ट %d"
 
-#: ../src/common/prntbase.cpp:2072
+#: ../src/common/prntbase.cpp:2094
 #, c-format
 msgid "Page %d of %d"
 msgstr "पृष्ट %d / %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 #, fuzzy
 msgid "Page Down"
 msgstr "पृष्ट %d"
 
-#: ../src/gtk/print.cpp:826
+#: ../src/gtk/print.cpp:829
 msgid "Page Setup"
 msgstr "पॄष्ट स्थापना"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 #, fuzzy
 msgid "Page Up"
 msgstr "पृष्ट %d"
 
-#: ../src/generic/prntdlgg.cpp:828 ../src/common/prntbase.cpp:484
+#: ../src/common/prntbase.cpp:479 ../src/generic/prntdlgg.cpp:821
 msgid "Page setup"
 msgstr "पॄष्ट स्थापना"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 #, fuzzy
 msgid "PageDown"
 msgstr "नीचे"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 #, fuzzy
 msgid "PageUp"
 msgstr "अनेक पृष्ट"
 
-#: ../src/generic/prntdlgg.cpp:216
+#: ../src/generic/prntdlgg.cpp:209
 msgid "Pages"
 msgstr "अनेक पृष्ट"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1765
+#: ../src/propgrid/advprops.cpp:1666
 msgid "Paint Brush"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:602 ../src/generic/prntdlgg.cpp:801
-#: ../src/generic/prntdlgg.cpp:842 ../src/generic/prntdlgg.cpp:855
-#: ../src/generic/prntdlgg.cpp:1052 ../src/generic/prntdlgg.cpp:1057
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:794
+#: ../src/generic/prntdlgg.cpp:835 ../src/generic/prntdlgg.cpp:848
+#: ../src/generic/prntdlgg.cpp:1045 ../src/generic/prntdlgg.cpp:1050
 msgid "Paper size"
 msgstr "पृष्ट आकार"
 
-#: ../src/richtext/richtextstyles.cpp:1062
+#: ../src/richtext/richtextstyles.cpp:1059
 msgid "Paragraph styles"
 msgstr "अनुच्छेद शैलियाँ"
 
-#: ../src/common/xtistrm.cpp:465
+#: ../src/common/xtistrm.cpp:462
 msgid "Passing a already registered object to SetObject"
 msgstr "SetObject को एक पहिले से पंजीकॄत ऑबजेक्ट को दिया जा रहा है"
 
-#: ../src/common/xtistrm.cpp:476
+#: ../src/common/xtistrm.cpp:473
 #, fuzzy
 msgid "Passing an unknown object to GetObject"
 msgstr "GetObject को एक अज्ञात ऑबजेक्ट को दिया जा रहा है"
 
-#: ../src/richtext/richtextctrl.cpp:3513 ../src/common/stockitem.cpp:180
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:177 ../src/richtext/richtextctrl.cpp:3514
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "चिपकाएँ"
 
-#: ../src/common/stockitem.cpp:262
+#: ../src/common/stockitem.cpp:260
 msgid "Paste selection"
 msgstr "चयन चिपकाएँ"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:74
+#: ../src/common/accelcmn.cpp:71
 msgid "Pause"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1766
+#: ../src/propgrid/advprops.cpp:1667
 msgid "Pencil"
 msgstr ""
 
@@ -5840,21 +5982,21 @@ msgstr ""
 msgid "Peri&od"
 msgstr "पूर्णविराम (&O)"
 
-#: ../src/generic/filectrlg.cpp:430
+#: ../src/generic/filectrlg.cpp:426
 msgid "Permissions"
 msgstr "अनुमतियां"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:60
+#: ../src/common/accelcmn.cpp:57
 msgid "PgDn"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:59
+#: ../src/common/accelcmn.cpp:56
 msgid "PgUp"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:12868
+#: ../src/richtext/richtextbuffer.cpp:12863
 #, fuzzy
 msgid "Picture Properties"
 msgstr "गुणधर्म (&P)"
@@ -5867,46 +6009,46 @@ msgstr "पाइप का निर्माण असफ़ल रहा"
 msgid "Please choose a valid font."
 msgstr "कॄपया एक वैध फ़ॉन्ट का चयन करें।"
 
-#: ../src/generic/filedlgg.cpp:357 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
 msgid "Please choose an existing file."
 msgstr "कॄपया एक विद्यमान फ़ाइल का चयन करें।"
 
-#: ../src/html/helpwnd.cpp:800
+#: ../src/html/helpwnd.cpp:798
 msgid "Please choose the page to display:"
 msgstr "कॄपया एक विद्यमान फ़ाइल का चयन करें:"
 
-#: ../src/msw/dialup.cpp:764
+#: ../src/msw/dialup.cpp:758
 msgid "Please choose which ISP do you want to connect to"
 msgstr "कॄपया उस आईएसपी का चयन करें जिससे आप जुड़ना चाहते है"
 
-#: ../src/common/headerctrlcmn.cpp:59
+#: ../src/common/headerctrlcmn.cpp:57
 msgid "Please select the columns to show and define their order:"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:538
+#: ../src/common/prntbase.cpp:533
 #, fuzzy
 msgid "Please wait while printing..."
 msgstr "कॄपया प्रतीक्षा करें जबतक कि प्रिंटींग हो रही है\n"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1767
+#: ../src/propgrid/advprops.cpp:1668
 #, fuzzy
 msgid "Point Left"
 msgstr "फ़ॉन्ट आकार (&P):"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1768
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgid "Point Right"
 msgstr "दायें पंक्तिबद्ध करें"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:662
+#: ../src/propgrid/advprops.cpp:572
 #, fuzzy
 msgid "Point Size"
 msgstr "फ़ॉन्ट आकार (&P):"
 
-#: ../src/generic/prntdlgg.cpp:612 ../src/generic/prntdlgg.cpp:867
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:860
 msgid "Portrait"
 msgstr "पोर्ट्रेट"
 
@@ -5915,158 +6057,166 @@ msgstr "पोर्ट्रेट"
 msgid "Position"
 msgstr "प्रश्न"
 
-#: ../src/generic/prntdlgg.cpp:298
+#: ../src/generic/prntdlgg.cpp:291
 msgid "PostScript file"
 msgstr "पोस्टस्क्रिप्ट फ़ाइल"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178 ../src/osx/cocoa/preferences.mm:303
 #, fuzzy
 msgid "Preferences"
 msgstr "प्राथमिकता (&P)"
 
-#: ../src/osx/menu_osx.cpp:568
+#: ../src/osx/menu_osx.cpp:460
 #, fuzzy
 msgid "Preferences..."
 msgstr "प्राथमिकता (&P)"
 
-#: ../src/common/prntbase.cpp:546
+#: ../src/common/prntbase.cpp:541
 msgid "Preparing"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:455 ../src/osx/carbon/fontdlg.cpp:390
-#: ../src/html/helpwnd.cpp:1222
+#: ../src/osx/carbon/fontdlg.cpp:387 ../src/generic/fontdlgg.cpp:452
+#: ../src/html/helpwnd.cpp:1220
 msgid "Preview:"
 msgstr "पूर्वालोकन:"
 
-#: ../src/common/prntbase.cpp:1553 ../src/html/helpwnd.cpp:664
+#: ../src/common/prntbase.cpp:1578 ../src/html/helpwnd.cpp:662
 msgid "Previous page"
 msgstr "पिछला पॄष्ट"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/prntdlgg.cpp:143 ../src/generic/prntdlgg.cpp:157
-#: ../src/common/prntbase.cpp:426 ../src/common/prntbase.cpp:1541
-#: ../src/common/accelcmn.cpp:77 ../src/gtk/print.cpp:620
-#: ../src/gtk/print.cpp:638
+#: ../src/common/prntbase.cpp:421 ../src/common/prntbase.cpp:1566
+#: ../src/common/accelcmn.cpp:74 ../src/generic/prntdlgg.cpp:136
+#: ../src/generic/prntdlgg.cpp:150 ../src/gtk/print.cpp:616
+#: ../src/gtk/print.cpp:634
 msgid "Print"
 msgstr "मुद्रण"
 
-#: ../include/wx/prntbase.h:399 ../src/common/docview.cpp:1268
+#: ../src/common/docview.cpp:1262
 msgid "Print Preview"
 msgstr "मुद्रण पूर्वालोकन"
 
-#: ../src/common/prntbase.cpp:2015 ../src/common/prntbase.cpp:2057
-#: ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2037 ../src/common/prntbase.cpp:2079
+#: ../src/common/prntbase.cpp:2087
 msgid "Print Preview Failure"
 msgstr "मुद्रण पूर्वालोकन असफ़लता"
 
-#: ../src/generic/prntdlgg.cpp:224
+#: ../src/generic/prntdlgg.cpp:217
 msgid "Print Range"
 msgstr "मुद्रण सीमा"
 
-#: ../src/generic/prntdlgg.cpp:449
+#: ../src/generic/prntdlgg.cpp:442
 msgid "Print Setup"
 msgstr "मुद्रण स्थापना"
 
-#: ../src/generic/prntdlgg.cpp:621
+#: ../src/generic/prntdlgg.cpp:614
 msgid "Print in colour"
 msgstr "मुद्रण रंगों में"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/osx/webview_webkit.mm:260
+msgid "Print operation could not be initialized"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:179
 #, fuzzy
 msgid "Print previe&w..."
 msgstr "मुद्रण पूर्वालोकन (&w)"
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1256
 #, fuzzy
 msgid "Print preview creation failed."
 msgstr "पाइप का निर्माण असफ़ल रहा"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/common/stockitem.cpp:179
 #, fuzzy
 msgid "Print preview..."
 msgstr "मुद्रण पूर्वालोकन"
 
-#: ../src/generic/prntdlgg.cpp:630
+#: ../src/generic/prntdlgg.cpp:623
 msgid "Print spooling"
 msgstr "मुद्रण स्पूलिंग"
 
-#: ../src/html/helpwnd.cpp:675
+#: ../src/html/helpwnd.cpp:673
 msgid "Print this page"
 msgstr "इस पृष्ट को मुद्रित करें"
 
-#: ../src/generic/prntdlgg.cpp:185
+#: ../src/generic/prntdlgg.cpp:178
 msgid "Print to File"
 msgstr "फ़ाइल पर मुद्रित करें"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 #, fuzzy
 msgid "Print..."
 msgstr "मुद्रण (&P)..."
 
-#: ../src/generic/prntdlgg.cpp:493
+#: ../src/generic/prntdlgg.cpp:486
 msgid "Printer"
 msgstr "मुद्रक"
 
-#: ../src/generic/prntdlgg.cpp:633
+#: ../src/generic/prntdlgg.cpp:626
 msgid "Printer command:"
 msgstr "प्रिंटर निर्देश:"
 
-#: ../src/generic/prntdlgg.cpp:180
+#: ../src/generic/prntdlgg.cpp:173
 msgid "Printer options"
 msgstr "प्रिंटर के विकल्प"
 
-#: ../src/generic/prntdlgg.cpp:645
+#: ../src/generic/prntdlgg.cpp:638
 msgid "Printer options:"
 msgstr "प्रिंटर के विकल्प:"
 
-#: ../src/generic/prntdlgg.cpp:916
+#: ../src/generic/prntdlgg.cpp:909
 msgid "Printer..."
 msgstr "प्रिंटर..."
 
-#: ../src/generic/prntdlgg.cpp:196
+#: ../src/generic/prntdlgg.cpp:189
 msgid "Printer:"
 msgstr "प्रिंटर:"
 
-#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:535
-#: ../src/html/htmprint.cpp:277
+#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:530
+#: ../src/html/htmprint.cpp:289
 #, fuzzy
 msgid "Printing"
 msgstr "मुद्रण हो रहा है "
 
-#: ../src/common/prntbase.cpp:612
+#: ../src/common/prntbase.cpp:607
 msgid "Printing "
 msgstr "मुद्रण हो रहा है "
 
-#: ../src/common/prntbase.cpp:347
+#: ../src/common/prntbase.cpp:342
 msgid "Printing Error"
 msgstr "मुद्रण त्रुटि"
 
-#: ../src/common/prntbase.cpp:565
+#: ../src/osx/webview_webkit.mm:251
+msgid "Printing is not supported by the system web control"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:560
 #, fuzzy, c-format
 msgid "Printing page %d"
 msgstr "%d पृष्ट को मुद्रित किया जा रहा है..."
 
-#: ../src/common/prntbase.cpp:570
+#: ../src/common/prntbase.cpp:565
 #, fuzzy, c-format
 msgid "Printing page %d of %d"
 msgstr "%d पृष्ट को मुद्रित किया जा रहा है..."
 
-#: ../src/generic/printps.cpp:201
+#: ../src/generic/printps.cpp:182
 #, c-format
 msgid "Printing page %d..."
 msgstr "%d पृष्ट को मुद्रित किया जा रहा है..."
 
-#: ../src/generic/printps.cpp:161
+#: ../src/generic/printps.cpp:142
 msgid "Printing..."
 msgstr "मुद्रण किया जा रहा है..."
 
-#: ../include/wx/richtext/richtextprint.h:109 ../include/wx/prntbase.h:267
-#: ../src/common/docview.cpp:2132
+#: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
+#: ../src/common/docview.cpp:2137
 #, fuzzy
 msgid "Printout"
 msgstr "मुद्रण"
 
-#: ../src/common/debugrpt.cpp:560
+#: ../src/common/debugrpt.cpp:561
 #, c-format
 msgid ""
 "Processing debug report has failed, leaving the files in \"%s\" directory."
@@ -6074,110 +6224,110 @@ msgstr ""
 "दोषमार्जन विवरण संसाधित करने में असफ़ल, फ़ाइलों को \"%s\" निर्देशिका में ही छोड़ा जा रहा "
 "हें।"
 
-#: ../src/common/prntbase.cpp:545
+#: ../src/common/prntbase.cpp:540
 msgid "Progress:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181
 #, fuzzy
 msgid "Properties"
 msgstr "गुणधर्म (&P)"
 
-#: ../src/propgrid/manager.cpp:237
+#: ../src/propgrid/manager.cpp:223
 #, fuzzy
 msgid "Property"
 msgstr "गुणधर्म (&P)"
 
 #. TRANSLATORS: Caption of message box displaying any property error
-#: ../src/propgrid/propgrid.cpp:3185 ../src/propgrid/propgrid.cpp:3318
+#: ../src/propgrid/propgrid.cpp:3162 ../src/propgrid/propgrid.cpp:3299
 #, fuzzy
 msgid "Property Error"
 msgstr "मुद्रण त्रुटि"
 
-#: ../src/propgrid/advprops.cpp:1597
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Purple"
 msgstr ""
 
-#: ../src/common/paper.cpp:112
+#: ../src/common/paper.cpp:109
 msgid "Quarto, 215 x 275 mm"
 msgstr "क्वार्टो, २१५ x २७५ मिलीमीटर"
 
-#: ../src/generic/logg.cpp:1016
+#: ../src/generic/logg.cpp:1013
 msgid "Question"
 msgstr "प्रश्न"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1769
+#: ../src/propgrid/advprops.cpp:1670
 #, fuzzy
 msgid "Question Arrow"
 msgstr "प्रश्न"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 #, fuzzy
 msgid "Quit"
 msgstr "छोड़ दे (&Q)"
 
-#: ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:477
 #, fuzzy, c-format
 msgid "Quit %s"
 msgstr "छोड़ दे (&Q)"
 
-#: ../src/common/stockitem.cpp:263
+#: ../src/common/stockitem.cpp:261
 msgid "Quit this program"
 msgstr "प्रोग्राम बंद करें"
 
-#: ../src/common/accelcmn.cpp:338
+#: ../src/common/accelcmn.cpp:352
 #, fuzzy
 msgid "RawCtrl+"
 msgstr "Ctrl-"
 
-#: ../src/common/ffile.cpp:109 ../src/common/ffile.cpp:133
+#: ../src/common/ffile.cpp:107 ../src/common/ffile.cpp:132
 #, c-format
 msgid "Read error on file '%s'"
 msgstr "'%s' फ़ाइल पर पठन त्रुटि"
 
-#: ../src/common/secretstore.cpp:199
+#: ../src/common/secretstore.cpp:211
 #, fuzzy, c-format
-msgid "Reading password for \"%s/%s\" failed: %s."
+msgid "Reading password for \"%s\" failed: %s."
 msgstr "'%s' का निष्कर्षण '%s' में असफ़ल रहा।"
 
-#: ../src/common/prntbase.cpp:272
+#: ../src/common/prntbase.cpp:267
 msgid "Ready"
 msgstr "तैयार"
 
-#: ../src/propgrid/advprops.cpp:1605
+#: ../src/propgrid/advprops.cpp:1511
 #, fuzzy
 msgid "Red"
 msgstr "पुनःकरें (&R)"
 
-#: ../src/generic/colrdlgg.cpp:339
+#: ../src/generic/colrdlgg.cpp:359
 msgid "Red:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:185 ../src/stc/stc_i18n.cpp:16
+#: ../src/common/stockitem.cpp:182 ../src/stc/stc_i18n.cpp:16
 #, fuzzy
 msgid "Redo"
 msgstr "पुनःकरें (&R)"
 
-#: ../src/common/stockitem.cpp:264
+#: ../src/common/stockitem.cpp:262
 msgid "Redo last action"
 msgstr "पिछला कार्य फिर से करें"
 
-#: ../src/common/stockitem.cpp:186
+#: ../src/common/stockitem.cpp:183
 msgid "Refresh"
 msgstr "ताज़ा करें"
 
-#: ../src/msw/registry.cpp:626
+#: ../src/msw/registry.cpp:615
 #, c-format
 msgid "Registry key '%s' already exists."
 msgstr "'%s' रजिस्ट्री कुँजी पहिले से विद्यमान है।"
 
-#: ../src/msw/registry.cpp:595
+#: ../src/msw/registry.cpp:584
 #, c-format
 msgid "Registry key '%s' does not exist, cannot rename it."
 msgstr "'%s' रजिस्ट्री कुँजी विद्यमान नहीं है, इसका नाम नहीं बदला जा सकता है।"
 
-#: ../src/msw/registry.cpp:727
+#: ../src/msw/registry.cpp:716
 #, c-format
 msgid ""
 "Registry key '%s' is needed for normal system operation,\n"
@@ -6188,22 +6338,22 @@ msgstr ""
 "इसको हटाने से आपका तंत्र कार्य ना करने की अवस्था में रह जायेगा:\n"
 "संक्रिया को निरस्त किया गया।"
 
-#: ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:942
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:917
+#: ../src/msw/registry.cpp:905
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1003
+#: ../src/msw/registry.cpp:991
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:521
+#: ../src/msw/registry.cpp:510
 #, c-format
 msgid "Registry value '%s' already exists."
 msgstr "'%s' रजिस्ट्री वैल्यू पहिले से विद्यमान है।"
@@ -6218,72 +6368,78 @@ msgstr "नियमित"
 msgid "Relative"
 msgstr "साज-सजावट"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:456
 msgid "Relevant entries:"
 msgstr "संबंधित प्रविष्टियां:"
 
-#: ../include/wx/generic/progdlgg.h:86
+#: ../include/wx/generic/progdlgg.h:87
 #, fuzzy
 msgid "Remaining time:"
 msgstr "शेष समय : "
 
-#: ../src/common/stockitem.cpp:187
+#: ../src/common/stockitem.cpp:184
 msgid "Remove"
 msgstr "निकाल दें"
 
-#: ../src/richtext/richtextctrl.cpp:1562
+#: ../src/richtext/richtextctrl.cpp:1563
 #, fuzzy
 msgid "Remove Bullet"
 msgstr "निकाल दें"
 
-#: ../src/html/helpwnd.cpp:433
+#: ../src/html/helpwnd.cpp:431
 msgid "Remove current page from bookmarks"
 msgstr "बुकमार्कों से वर्तमान पृष्ट को हटाएँ"
 
-#: ../src/common/rendcmn.cpp:194
+#: ../src/common/rendcmn.cpp:191
 #, c-format
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr "\"%s\" रेन्डर्र का %d.%d संस्मरण असुसंगत है और लोड नहीं किया जा सका।"
 
-#: ../src/richtext/richtextbuffer.cpp:4527
+#: ../src/richtext/richtextbuffer.cpp:4524
 msgid "Renumber List"
 msgstr "सूची पुनः संख्यांकन करें"
 
-#: ../src/common/stockitem.cpp:188
-msgid "Rep&lace"
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Rep&lace..."
 msgstr "बदलें (&l)"
 
-#: ../src/richtext/richtextctrl.cpp:3673 ../src/common/stockitem.cpp:188
+#: ../src/richtext/richtextctrl.cpp:3674
 msgid "Replace"
 msgstr "बदलें"
 
-#: ../src/generic/fdrepdlg.cpp:182
+#: ../src/generic/fdrepdlg.cpp:179
 msgid "Replace &all"
 msgstr "सभी को बदलें (&a)"
 
-#: ../src/common/stockitem.cpp:261
-msgid "Replace selection"
-msgstr "चयन बदलें"
-
-#: ../src/generic/fdrepdlg.cpp:124
+#: ../src/generic/fdrepdlg.cpp:121
 msgid "Replace with:"
 msgstr "से बदलें:"
 
-#: ../src/common/valtext.cpp:163
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Replace..."
+msgstr "बदलें"
+
+#: ../src/common/valtext.cpp:184
 msgid "Required information entry is empty."
 msgstr ""
 
-#: ../src/common/translation.cpp:1975
+#: ../src/common/translation.cpp:2025
 #, fuzzy, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "'%s' एक वैध संदेश सूचीपत्र नहीं है।"
 
+#: ../src/gtk/webview_webkit.cpp:985
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:56
+#: ../src/common/accelcmn.cpp:53
 msgid "Return"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:189
+#: ../src/common/stockitem.cpp:186
 msgid "Revert to Saved"
 msgstr "संरक्षित पर लौटे"
 
@@ -6296,42 +6452,42 @@ msgstr "दायें"
 msgid "Rig&ht-to-left"
 msgstr ""
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6149
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:59 ../src/generic/datavgen.cpp:6954
+#: ../src/richtext/richtextsizepage.cpp:250
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextbulletspage.cpp:188
-#: ../src/richtext/richtextsizepage.cpp:250 ../src/common/accelcmn.cpp:62
 msgid "Right"
 msgstr "दायें"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1754
+#: ../src/propgrid/advprops.cpp:1655
 #, fuzzy
 msgid "Right Arrow"
 msgstr "दायें"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1770
+#: ../src/propgrid/advprops.cpp:1671
 msgid "Right Button"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:892
+#: ../src/generic/prntdlgg.cpp:885
 msgid "Right margin (mm):"
 msgstr "दायाँ हाशिया (मिलीमीटर):"
 
-#: ../src/richtext/richtextindentspage.cpp:148
-#: ../src/richtext/richtextindentspage.cpp:150
 #: ../src/richtext/richtextliststylepage.cpp:337
 #: ../src/richtext/richtextliststylepage.cpp:339
+#: ../src/richtext/richtextindentspage.cpp:148
+#: ../src/richtext/richtextindentspage.cpp:150
 msgid "Right-align text."
 msgstr "पाठ को दायें पंक्तिबद्ध करें।"
 
-#: ../src/generic/fontdlgg.cpp:322
+#: ../src/generic/fontdlgg.cpp:318
 msgid "Roman"
 msgstr "रोमन"
 
-#: ../src/generic/datavgen.cpp:5916
+#: ../src/generic/datavgen.cpp:6721
 #, c-format
 msgid "Row %i"
 msgstr ""
@@ -6341,31 +6497,32 @@ msgstr ""
 msgid "S&tandard bullet name:"
 msgstr "मानक बुल्लेट नाम (&T):"
 
-#: ../src/common/accelcmn.cpp:268 ../src/common/accelcmn.cpp:350
+#: ../src/common/accelcmn.cpp:282 ../src/common/accelcmn.cpp:367
 msgid "SPECIAL"
 msgstr "SPECIAL"
 
-#: ../src/common/stockitem.cpp:190 ../src/common/sizer.cpp:2797
+#: ../src/common/stockitem.cpp:187 ../src/common/sizer.cpp:2914
 msgid "Save"
 msgstr "सुरक्षित करें"
 
-#: ../src/common/fldlgcmn.cpp:342
+#: ../src/common/fldlgcmn.cpp:339
 #, c-format
 msgid "Save %s file"
 msgstr "%s फ़ाइल को सुरक्षित करें"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/common/stockitem.cpp:188 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "इस जैसा सुरक्षित करें (&A)..."
 
-#: ../src/common/docview.cpp:366
+#: ../src/common/docview.cpp:359
 #, fuzzy
 msgid "Save As"
 msgstr "जैसा सुरक्षित करें"
 
-#: ../src/common/stockitem.cpp:191
-msgid "Save as"
-msgstr "जैसा सुरक्षित करें"
+#: ../src/common/stockitem.cpp:188
+#, fuzzy
+msgid "Save As..."
+msgstr "इस जैसा सुरक्षित करें (&A)..."
 
 #: ../src/common/stockitem.cpp:267
 msgid "Save current document"
@@ -6375,40 +6532,40 @@ msgstr "वर्तमान प्रलेख को सुरक्षित
 msgid "Save current document with a different filename"
 msgstr "वर्तमान प्रलेख को अलग नाम से सुरक्षित करें"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/generic/logg.cpp:509
 msgid "Save log contents to file"
 msgstr "लॉग विषयवस्तुओं को फ़ाइल पर सुरक्षित करें"
 
-#: ../src/common/secretstore.cpp:179
+#: ../src/common/secretstore.cpp:189
 #, fuzzy, c-format
-msgid "Saving password for \"%s/%s\" failed: %s."
+msgid "Saving password for \"%s\" failed: %s."
 msgstr "'%s' का निष्कर्षण '%s' में असफ़ल रहा।"
 
-#: ../src/generic/fontdlgg.cpp:325
+#: ../src/generic/fontdlgg.cpp:321
 msgid "Script"
 msgstr "लिपि"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll Lock"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll_lock"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:890
+#: ../src/propgrid/advprops.cpp:791
 msgid "Scrollbar"
 msgstr ""
 
-#: ../src/generic/srchctlg.cpp:56 ../src/html/helpwnd.cpp:535
-#: ../src/html/helpwnd.cpp:550
+#: ../src/generic/srchctlg.cpp:55 ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:548 ../src/gtk/srchctrl.cpp:182
 msgid "Search"
 msgstr "खोजें"
 
-#: ../src/html/helpwnd.cpp:537
+#: ../src/html/helpwnd.cpp:535
 #, fuzzy
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
@@ -6417,57 +6574,57 @@ msgstr ""
 "सहायक पुस्तक(पुस्तकों) के विषयवस्तु में आपके द्वारा बताया हुआ उपरोक्त पाठ  जितनी बार आया "
 "हो खोजें "
 
-#: ../src/generic/fdrepdlg.cpp:160
+#: ../src/generic/fdrepdlg.cpp:157
 msgid "Search direction"
 msgstr "खोज की दिशा"
 
-#: ../src/generic/fdrepdlg.cpp:112
+#: ../src/generic/fdrepdlg.cpp:109
 msgid "Search for:"
 msgstr "के लिए खोज: "
 
-#: ../src/html/helpwnd.cpp:1052
+#: ../src/html/helpwnd.cpp:1050
 msgid "Search in all books"
 msgstr "सभी पुस्तकों में खोजें"
 
-#: ../src/html/helpwnd.cpp:857
+#: ../src/html/helpwnd.cpp:855
 msgid "Searching..."
 msgstr "खोजा जा रहा है..."
 
-#: ../src/generic/dirctrlg.cpp:446
+#: ../src/generic/dirctrlg.cpp:412
 msgid "Sections"
 msgstr "विभाग"
 
-#: ../src/common/ffile.cpp:238
+#: ../src/common/ffile.cpp:237
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "'%s' फ़ाइल पर खोज त्रुटि"
 
-#: ../src/common/ffile.cpp:228
+#: ../src/common/ffile.cpp:227
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:76
+#: ../src/common/accelcmn.cpp:73
 #, fuzzy
 msgid "Select"
 msgstr "चयन"
 
-#: ../src/richtext/richtextctrl.cpp:337 ../src/osx/textctrl_osx.cpp:581
-#: ../src/common/stockitem.cpp:192 ../src/msw/textctrl.cpp:2512
+#: ../src/osx/textctrl_osx.cpp:599 ../src/common/stockitem.cpp:189
+#: ../src/msw/textctrl.cpp:2777 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "सभी का चयन (&A)"
 
-#: ../src/common/stockitem.cpp:192 ../src/stc/stc_i18n.cpp:21
+#: ../src/common/stockitem.cpp:189 ../src/stc/stc_i18n.cpp:21
 #, fuzzy
 msgid "Select All"
 msgstr "सभी का चयन (&A)"
 
-#: ../src/common/docview.cpp:1895
+#: ../src/common/docview.cpp:1900
 msgid "Select a document template"
 msgstr "एक प्रलेख टेम्पलेट का चयन करें"
 
-#: ../src/common/docview.cpp:1969
+#: ../src/common/docview.cpp:1974
 msgid "Select a document view"
 msgstr "एक प्रलेख व्यू का चयन करें"
 
@@ -6496,20 +6653,20 @@ msgid "Selects the list level to edit."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:82
+#: ../src/common/accelcmn.cpp:79
 msgid "Separator"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1083
+#: ../src/common/cmdline.cpp:1079
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "'%s' के बाद एक पृथककारी चिह्न की आशा की जाती है।"
 
-#: ../src/osx/menu_osx.cpp:572
+#: ../src/osx/menu_osx.cpp:464
 msgid "Services"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11217
+#: ../src/richtext/richtextbuffer.cpp:11216
 #, fuzzy
 msgid "Set Cell Style"
 msgstr "शैली हटाएँ"
@@ -6518,11 +6675,11 @@ msgstr "शैली हटाएँ"
 msgid "SetProperty called w/o valid setter"
 msgstr "SetProperty को बिना किसी वैध सेटर के बुलाया गया"
 
-#: ../src/generic/prntdlgg.cpp:188
+#: ../src/generic/prntdlgg.cpp:181
 msgid "Setup..."
 msgstr "स्थापना..."
 
-#: ../src/msw/dialup.cpp:544
+#: ../src/msw/dialup.cpp:538
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr "अनेकों सक्रिय डायल-अप कनेक्श मिलें, बेतरतीब से एक का चयन किया जा रहा है।"
 
@@ -6539,42 +6696,42 @@ msgstr ""
 msgid "Shadow c&olour:"
 msgstr "रंग का चयन करें"
 
-#: ../src/common/accelcmn.cpp:335
+#: ../src/common/accelcmn.cpp:349
 #, fuzzy
 msgid "Shift+"
 msgstr "Shift-"
 
-#: ../src/generic/dirdlgg.cpp:147
+#: ../src/generic/dirdlgg.cpp:144
 msgid "Show &hidden directories"
 msgstr "छुपी हुई निर्देशिकाओं को दिखाएँ (&H)"
 
-#: ../src/generic/filectrlg.cpp:983
+#: ../src/generic/filectrlg.cpp:979
 msgid "Show &hidden files"
 msgstr "छुपी हुई फ़ाइलों को दिखाएँ (&H)"
 
-#: ../src/osx/menu_osx.cpp:580
+#: ../src/osx/menu_osx.cpp:472
 #, fuzzy
 msgid "Show All"
 msgstr "सभी को दिखाएँ"
 
-#: ../src/common/stockitem.cpp:257
+#: ../src/common/stockitem.cpp:254
 msgid "Show about dialog"
 msgstr "प्रोग्राम के बारे में वाला संवाद दिखाएँ"
 
-#: ../src/html/helpwnd.cpp:492
+#: ../src/html/helpwnd.cpp:490
 msgid "Show all"
 msgstr "सभी को दिखाएँ"
 
-#: ../src/html/helpwnd.cpp:503
+#: ../src/html/helpwnd.cpp:501
 msgid "Show all items in index"
 msgstr "इंडेक्स में सभी आयट्मों को दिखाएँ"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:656
 msgid "Show/hide navigation panel"
 msgstr "नैवीगेशन पैनल को दिखाएँ/छुपाएँ"
 
-#: ../src/richtext/richtextsymboldlg.cpp:421
-#: ../src/richtext/richtextsymboldlg.cpp:423
+#: ../src/richtext/richtextsymboldlg.cpp:418
+#: ../src/richtext/richtextsymboldlg.cpp:420
 msgid "Shows a Unicode subset."
 msgstr "एक यूनिकोड उप समुच्चय दिखाएँ।"
 
@@ -6590,7 +6747,7 @@ msgstr ""
 msgid "Shows a preview of the font settings."
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:394 ../src/osx/carbon/fontdlg.cpp:396
+#: ../src/osx/carbon/fontdlg.cpp:391 ../src/osx/carbon/fontdlg.cpp:393
 msgid "Shows a preview of the font."
 msgstr "फ़ॉन्ट का पूर्वालोकन दिखाएँ।"
 
@@ -6599,62 +6756,62 @@ msgstr "फ़ॉन्ट का पूर्वालोकन दिखाएँ
 msgid "Shows a preview of the paragraph settings."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:460 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:456 ../src/generic/fontdlgg.cpp:458
 msgid "Shows the font preview."
 msgstr "फ़ॉन्ट का पूर्वालोकन दिखाएँ।"
 
-#: ../src/propgrid/advprops.cpp:1607
+#: ../src/propgrid/advprops.cpp:1513
 msgid "Silver"
 msgstr ""
 
-#: ../src/univ/themes/mono.cpp:516
+#: ../src/univ/themes/mono.cpp:513
 msgid "Simple monochrome theme"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:275
 #: ../src/richtext/richtextliststylepage.cpp:449
+#: ../src/richtext/richtextindentspage.cpp:275
 msgid "Single"
 msgstr "अकेला"
 
-#: ../src/generic/filectrlg.cpp:425 ../src/richtext/richtextformatdlg.cpp:369
-#: ../src/richtext/richtextsizepage.cpp:299
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextsizepage.cpp:299
+#: ../src/richtext/richtextformatdlg.cpp:362
 msgid "Size"
 msgstr "आकार"
 
-#: ../src/osx/carbon/fontdlg.cpp:339
+#: ../src/osx/carbon/fontdlg.cpp:336
 msgid "Size:"
 msgstr "आकार:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1775
+#: ../src/propgrid/advprops.cpp:1676
 msgid "Sizing"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1772
+#: ../src/propgrid/advprops.cpp:1673
 msgid "Sizing N-S"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1771
+#: ../src/propgrid/advprops.cpp:1672
 msgid "Sizing NE-SW"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1773
+#: ../src/propgrid/advprops.cpp:1674
 msgid "Sizing NW-SE"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1774
+#: ../src/propgrid/advprops.cpp:1675
 msgid "Sizing W-E"
 msgstr ""
 
-#: ../src/msw/progdlg.cpp:801
+#: ../src/msw/progdlg.cpp:1088
 msgid "Skip"
 msgstr "छोड़ दे"
 
-#: ../src/generic/fontdlgg.cpp:330
+#: ../src/generic/fontdlgg.cpp:326
 msgid "Slant"
 msgstr "स्लॉट"
 
@@ -6664,7 +6821,7 @@ msgid "Small C&apitals"
 msgstr "बड़े अक्षर (&P)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:79
+#: ../src/common/accelcmn.cpp:76
 msgid "Snapshot"
 msgstr ""
 
@@ -6673,37 +6830,37 @@ msgstr ""
 msgid "Solid"
 msgstr "गहरा"
 
-#: ../src/common/docview.cpp:1791
+#: ../src/common/docview.cpp:1785
 msgid "Sorry, could not open this file."
 msgstr "क्षमा करें, इस फ़ाइल को खोला नहीं जा सका।"
 
-#: ../src/common/prntbase.cpp:2057 ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2079 ../src/common/prntbase.cpp:2087
 msgid "Sorry, not enough memory to create a preview."
 msgstr "क्षमा करें, एक पूर्वालोकन को निर्माण करने के लिए आवश्यकतानुसार स्मॄति नहीं है।"
 
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "Sorry, that name is taken. Please choose another."
 msgstr "क्षमा करें, यह नाम चुना जा चुका हें। कृपया कोई दूसरा नाम चुने।"
 
-#: ../src/common/docview.cpp:1814
+#: ../src/common/docview.cpp:1819
 msgid "Sorry, the format for this file is unknown."
 msgstr "क्षमा करें, इस फ़ाइल का प्रारूप अज्ञात है।"
 
-#: ../src/unix/sound.cpp:492
+#: ../src/unix/sound.cpp:481
 msgid "Sound data are in unsupported format."
 msgstr "साउन्ड डाटा एक असमर्थित प्रारूप में है।"
 
-#: ../src/unix/sound.cpp:477
+#: ../src/unix/sound.cpp:466
 #, c-format
 msgid "Sound file '%s' is in unsupported format."
 msgstr "साउन्ड फ़ाइल '%s' एक असमर्थित प्रारूप में है।"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:67
+#: ../src/common/accelcmn.cpp:64
 #, fuzzy
 msgid "Space"
 msgstr "अन्तराल"
@@ -6712,12 +6869,12 @@ msgstr "अन्तराल"
 msgid "Spacing"
 msgstr "अन्तराल"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "Spell Check"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1776
+#: ../src/propgrid/advprops.cpp:1677
 msgid "Spraycan"
 msgstr ""
 
@@ -6726,7 +6883,7 @@ msgstr ""
 msgid "Standard"
 msgstr "मानक"
 
-#: ../src/common/paper.cpp:104
+#: ../src/common/paper.cpp:101
 msgid "Statement, 5 1/2 x 8 1/2 in"
 msgstr "स्टेटमेन्ट, ५ १/२ x ८ १/२ इंच"
 
@@ -6736,35 +6893,31 @@ msgstr "स्टेटमेन्ट, ५ १/२ x ८ १/२ इंच"
 msgid "Static"
 msgstr "अवस्था:"
 
-#: ../src/generic/prntdlgg.cpp:204
+#: ../src/generic/prntdlgg.cpp:197
 msgid "Status:"
 msgstr "अवस्था:"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 #, fuzzy
 msgid "Stop"
 msgstr "रोक दें (&S)"
 
-#: ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196
 #, fuzzy
 msgid "Strikethrough"
 msgstr "स्ट्राइक थुःरु (S)"
 
-#: ../src/common/colourcmn.cpp:45
+#: ../src/common/colourcmn.cpp:42
 #, c-format
 msgid "String To Colour : Incorrect colour specification : %s"
 msgstr "स्ट्रींग से रंग : अमान्य रंग विशिष्टतायें : %s"
 
 #. TRANSLATORS: Label of font style
-#: ../src/richtext/richtextformatdlg.cpp:339 ../src/propgrid/advprops.cpp:680
+#: ../src/propgrid/advprops.cpp:590 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "शैली"
 
-#: ../include/wx/richtext/richtextstyledlg.h:46
-msgid "Style Organiser"
-msgstr ""
-
-#: ../src/osx/carbon/fontdlg.cpp:348
+#: ../src/osx/carbon/fontdlg.cpp:345
 msgid "Style:"
 msgstr "शैली:"
 
@@ -6774,7 +6927,7 @@ msgid "Subscrip&t"
 msgstr "लिपि"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:83
+#: ../src/common/accelcmn.cpp:80
 msgid "Subtract"
 msgstr ""
 
@@ -6783,11 +6936,11 @@ msgstr ""
 msgid "Supe&rscript"
 msgstr "लिपि"
 
-#: ../src/common/paper.cpp:150
+#: ../src/common/paper.cpp:147
 msgid "SuperA/SuperA/A4 227 x 356 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:151
+#: ../src/common/paper.cpp:148
 msgid "SuperB/SuperB/A3 305 x 487 mm"
 msgstr ""
 
@@ -6795,7 +6948,7 @@ msgstr ""
 msgid "Suppress hyphe&nation"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:326
+#: ../src/generic/fontdlgg.cpp:322
 msgid "Swiss"
 msgstr "स्वीस"
 
@@ -6813,76 +6966,76 @@ msgstr "चिह्न फ़ॉन्ट: (&F)"
 msgid "Symbols"
 msgstr "प्रतीकों"
 
-#: ../src/common/imagtiff.cpp:369 ../src/common/imagtiff.cpp:382
-#: ../src/common/imagtiff.cpp:741
+#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
+#: ../src/common/imagtiff.cpp:738
 msgid "TIFF: Couldn't allocate memory."
 msgstr "टीआईएफ़एफ़: स्मॄति का आवंटन महीं किया जा सका।"
 
-#: ../src/common/imagtiff.cpp:301
+#: ../src/common/imagtiff.cpp:298
 msgid "TIFF: Error loading image."
 msgstr "टीआईएफ़एफ़: आकॄति को लोड करने में त्रुटि।"
 
-#: ../src/common/imagtiff.cpp:468
+#: ../src/common/imagtiff.cpp:465
 msgid "TIFF: Error reading image."
 msgstr "टीआईएफ़एफ़: आकॄति को पढ़ने में त्रुटि।"
 
-#: ../src/common/imagtiff.cpp:608
+#: ../src/common/imagtiff.cpp:605
 msgid "TIFF: Error saving image."
 msgstr "टीआईएफ़एफ़: आकॄति को सुरक्षित करने में त्रुटि।"
 
-#: ../src/common/imagtiff.cpp:846
+#: ../src/common/imagtiff.cpp:843
 msgid "TIFF: Error writing image."
 msgstr "टीआईएफ़एफ़: आकॄति को लिखने में त्रुटि।"
 
-#: ../src/common/imagtiff.cpp:355
+#: ../src/common/imagtiff.cpp:352
 msgid "TIFF: Image size is abnormally big."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:68
+#: ../src/common/accelcmn.cpp:65
 #, fuzzy
 msgid "Tab"
 msgstr "टेब्स"
 
-#: ../src/richtext/richtextbuffer.cpp:11498
+#: ../src/richtext/richtextbuffer.cpp:11497
 #, fuzzy
 msgid "Table Properties"
 msgstr "गुणधर्म (&P)"
 
-#: ../src/common/paper.cpp:145
+#: ../src/common/paper.cpp:142
 #, fuzzy
 msgid "Tabloid Extra 11.69 x 18 in"
 msgstr "टैब्लायड, ११ x १७ इंच"
 
-#: ../src/common/paper.cpp:102
+#: ../src/common/paper.cpp:99
 msgid "Tabloid, 11 x 17 in"
 msgstr "टैब्लायड, ११ x १७ इंच"
 
-#: ../src/richtext/richtextformatdlg.cpp:354
+#: ../src/richtext/richtextformatdlg.cpp:347
 msgid "Tabs"
 msgstr "टेब्स"
 
-#: ../src/propgrid/advprops.cpp:1598
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Teal"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:327
+#: ../src/generic/fontdlgg.cpp:323
 msgid "Teletype"
 msgstr "टेलीटाइप"
 
-#: ../src/common/docview.cpp:1896
+#: ../src/common/docview.cpp:1901
 msgid "Templates"
 msgstr "टेम्पलेट्स"
 
-#: ../src/common/fmapbase.cpp:158
+#: ../src/common/fmapbase.cpp:155
 msgid "Thai (ISO-8859-11)"
 msgstr "थाई (आईसो-८८५९-११)"
 
-#: ../src/common/ftp.cpp:619
+#: ../src/common/ftp.cpp:622
 msgid "The FTP server doesn't support passive mode."
 msgstr "यह एफ़टीपी सर्वर निश्चेष्ट विधा का समर्थन नहीं करता है।"
 
-#: ../src/common/ftp.cpp:605
+#: ../src/common/ftp.cpp:608
 msgid "The FTP server doesn't support the PORT command."
 msgstr "यह एफ़टीपी सर्वर पोर्ट समादेश को समर्थन नहीं करता है।"
 
@@ -6893,8 +7046,8 @@ msgstr "यह एफ़टीपी सर्वर पोर्ट समाद�
 msgid "The available bullet styles."
 msgstr "उपलब्ध बुल्लेट शैलियाँ।"
 
-#: ../src/richtext/richtextstyledlg.cpp:202
-#: ../src/richtext/richtextstyledlg.cpp:204
+#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:200
 msgid "The available styles."
 msgstr "उपलब्ध शैलियाँ।"
 
@@ -6955,12 +7108,12 @@ msgstr "टैब की स्थिति।"
 msgid "The bullet character."
 msgstr "बुल्लेट संप्रतीक।"
 
-#: ../src/richtext/richtextsymboldlg.cpp:443
-#: ../src/richtext/richtextsymboldlg.cpp:445
+#: ../src/richtext/richtextsymboldlg.cpp:440
+#: ../src/richtext/richtextsymboldlg.cpp:442
 msgid "The character code."
 msgstr "का संप्रतीक कूट।"
 
-#: ../src/common/fontmap.cpp:203
+#: ../src/common/fontmap.cpp:200
 #, c-format
 msgid ""
 "The charset '%s' is unknown. You may select\n"
@@ -6971,7 +7124,7 @@ msgstr ""
 "आपको अन्य शब्दसमुच्चय का चयन या यदि यह बदला\n"
 "नहीं जा सकता है, तो [निरस्त] का चयन करना चाहिए"
 
-#: ../src/msw/ole/dataobj.cpp:394
+#: ../src/msw/ole/dataobj.cpp:402
 #, c-format
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "क्लिपबोर्ड प्रारूप '%d' विद्यमान नहीं है।"
@@ -6981,7 +7134,7 @@ msgstr "क्लिपबोर्ड प्रारूप '%d' विद्�
 msgid "The default style for the next paragraph."
 msgstr "अगले अनुच्छेद के लिए डिफ़ाल्ट शैली।"
 
-#: ../src/generic/dirdlgg.cpp:202
+#: ../src/generic/dirdlgg.cpp:199
 #, c-format
 msgid ""
 "The directory '%s' does not exist\n"
@@ -6990,7 +7143,7 @@ msgstr ""
 "'%s' यह निर्देशिका विद्यमान नहीं है\n"
 "अभी इसका निर्माण किया जाएँ?"
 
-#: ../src/html/htmprint.cpp:271
+#: ../src/html/htmprint.cpp:283
 #, c-format
 msgid ""
 "The document \"%s\" doesn't fit on the page horizontally and will be "
@@ -6999,7 +7152,7 @@ msgid ""
 "Would you like to proceed with printing it nevertheless?"
 msgstr ""
 
-#: ../src/common/docview.cpp:1202
+#: ../src/common/docview.cpp:1196
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -7008,36 +7161,36 @@ msgstr ""
 "'%s' यह निर्देशिका विद्यमान नहीं है और इसे खोला नहीं जा सका।\n"
 "इसे हाल ही में उपयोग में लायी गयी हुई फ़ाइलों की सूची में से हटा दिया गया है।"
 
-#: ../src/richtext/richtextindentspage.cpp:208
-#: ../src/richtext/richtextindentspage.cpp:210
 #: ../src/richtext/richtextliststylepage.cpp:394
 #: ../src/richtext/richtextliststylepage.cpp:396
+#: ../src/richtext/richtextindentspage.cpp:208
+#: ../src/richtext/richtextindentspage.cpp:210
 msgid "The first line indent."
 msgstr "पहली पंक्ति का इंडेंट।"
 
-#: ../src/gtk/utilsgtk.cpp:481
-msgid "The following standard GTK+ options are also supported:\n"
+#: ../src/generic/dbgrptg.cpp:318
+msgid "The following debug report will be generated\n"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:414 ../src/generic/fontdlgg.cpp:416
+#: ../src/generic/fontdlgg.cpp:411 ../src/generic/fontdlgg.cpp:413
 msgid "The font colour."
 msgstr "फ़ॉन्ट का रंग"
 
-#: ../src/generic/fontdlgg.cpp:375 ../src/generic/fontdlgg.cpp:377
+#: ../src/generic/fontdlgg.cpp:371 ../src/generic/fontdlgg.cpp:373
 msgid "The font family."
 msgstr "फ़ॉन्ट का वंश"
 
-#: ../src/richtext/richtextsymboldlg.cpp:405
-#: ../src/richtext/richtextsymboldlg.cpp:407
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "The font from which to take the symbol."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:427 ../src/generic/fontdlgg.cpp:429
-#: ../src/generic/fontdlgg.cpp:434 ../src/generic/fontdlgg.cpp:436
+#: ../src/generic/fontdlgg.cpp:424 ../src/generic/fontdlgg.cpp:426
+#: ../src/generic/fontdlgg.cpp:430 ../src/generic/fontdlgg.cpp:432
 msgid "The font point size."
 msgstr "फ़ॉन्ट बिन्दु का आकार।"
 
-#: ../src/osx/carbon/fontdlg.cpp:343 ../src/osx/carbon/fontdlg.cpp:345
+#: ../src/osx/carbon/fontdlg.cpp:340 ../src/osx/carbon/fontdlg.cpp:342
 msgid "The font size in points."
 msgstr "फ़ॉन्ट का आकार बिंदुओं में।"
 
@@ -7047,15 +7200,15 @@ msgstr "फ़ॉन्ट का आकार बिंदुओं में।"
 msgid "The font size units, points or pixels."
 msgstr "फ़ॉन्ट का आकार बिंदुओं में।"
 
-#: ../src/generic/fontdlgg.cpp:386 ../src/generic/fontdlgg.cpp:388
+#: ../src/generic/fontdlgg.cpp:382 ../src/generic/fontdlgg.cpp:384
 msgid "The font style."
 msgstr "फ़ॉन्ट की शैली"
 
-#: ../src/generic/fontdlgg.cpp:397 ../src/generic/fontdlgg.cpp:399
+#: ../src/generic/fontdlgg.cpp:393 ../src/generic/fontdlgg.cpp:395
 msgid "The font weight."
 msgstr "फ़ॉन्ट का भार"
 
-#: ../src/common/docview.cpp:1483
+#: ../src/common/docview.cpp:1477
 #, fuzzy, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "'%s' निर्देशिका का निर्माण नहीं किया जा सकता था"
@@ -7066,10 +7219,10 @@ msgstr "'%s' निर्देशिका का निर्माण नह�
 msgid "The horizontal offset."
 msgstr "क्षैतिज रूप से टाइल (&H)"
 
-#: ../src/richtext/richtextindentspage.cpp:199
-#: ../src/richtext/richtextindentspage.cpp:201
 #: ../src/richtext/richtextliststylepage.cpp:385
 #: ../src/richtext/richtextliststylepage.cpp:387
+#: ../src/richtext/richtextindentspage.cpp:199
+#: ../src/richtext/richtextindentspage.cpp:201
 msgid "The left indent."
 msgstr "बायें इंडेंट।"
 
@@ -7093,10 +7246,10 @@ msgstr "फ़ॉन्ट बिन्दु का आकार।"
 msgid "The left position."
 msgstr "टैब की स्थिति।"
 
-#: ../src/richtext/richtextindentspage.cpp:288
-#: ../src/richtext/richtextindentspage.cpp:290
 #: ../src/richtext/richtextliststylepage.cpp:462
 #: ../src/richtext/richtextliststylepage.cpp:464
+#: ../src/richtext/richtextindentspage.cpp:288
+#: ../src/richtext/richtextindentspage.cpp:290
 msgid "The line spacing."
 msgstr "पंक्ति का अन्तराल।"
 
@@ -7105,7 +7258,7 @@ msgstr "पंक्ति का अन्तराल।"
 msgid "The list item number."
 msgstr "सूची की पद संख्या।"
 
-#: ../src/msw/ole/automtn.cpp:664
+#: ../src/msw/ole/automtn.cpp:655
 msgid "The locale ID is unknown."
 msgstr ""
 
@@ -7150,19 +7303,19 @@ msgstr "फ़ॉन्ट का भार"
 msgid "The outline level."
 msgstr "रूपरेखा का स्तर।"
 
-#: ../src/common/log.cpp:277
+#: ../src/common/log.cpp:296
 #, c-format
 msgid "The previous message repeated %u time."
 msgid_plural "The previous message repeated %u times."
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/common/log.cpp:270
+#: ../src/common/log.cpp:289
 msgid "The previous message repeated once."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:462
-#: ../src/richtext/richtextsymboldlg.cpp:464
+#: ../src/richtext/richtextsymboldlg.cpp:459
+#: ../src/richtext/richtextsymboldlg.cpp:461
 msgid "The range to show."
 msgstr ""
 
@@ -7176,15 +7329,15 @@ msgstr ""
 "जानकारी हें तो,\n"
 "कृपया उन्हें अन्चेक कर दे और वे इस विवरण से हटा दी जायेंगी।\n"
 
-#: ../src/common/cmdline.cpp:1254
+#: ../src/common/cmdline.cpp:1250
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "आवश्यक पैरामीटर '%s' को निर्दिष्ट नहीं किया गया था।"
 
-#: ../src/richtext/richtextindentspage.cpp:217
-#: ../src/richtext/richtextindentspage.cpp:219
 #: ../src/richtext/richtextliststylepage.cpp:403
 #: ../src/richtext/richtextliststylepage.cpp:405
+#: ../src/richtext/richtextindentspage.cpp:217
+#: ../src/richtext/richtextindentspage.cpp:219
 msgid "The right indent."
 msgstr "दायें इंडेंट।"
 
@@ -7229,16 +7382,16 @@ msgstr ""
 msgid "The shadow spread."
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:267
 #: ../src/richtext/richtextliststylepage.cpp:439
 #: ../src/richtext/richtextliststylepage.cpp:441
+#: ../src/richtext/richtextindentspage.cpp:267
 msgid "The spacing after the paragraph."
 msgstr "अनुच्छेद के बाद का अन्तराल।"
 
-#: ../src/richtext/richtextindentspage.cpp:257
-#: ../src/richtext/richtextindentspage.cpp:259
 #: ../src/richtext/richtextliststylepage.cpp:430
 #: ../src/richtext/richtextliststylepage.cpp:432
+#: ../src/richtext/richtextindentspage.cpp:257
+#: ../src/richtext/richtextindentspage.cpp:259
 msgid "The spacing before the paragraph."
 msgstr "अनुच्छेद के पहले का अन्तराल।"
 
@@ -7252,12 +7405,12 @@ msgstr "शैली का नाम।"
 msgid "The style on which this style is based."
 msgstr "वो शैली जिस पर ये शैली आधारित हें।"
 
-#: ../src/richtext/richtextstyledlg.cpp:214
-#: ../src/richtext/richtextstyledlg.cpp:216
+#: ../src/richtext/richtextstyledlg.cpp:210
+#: ../src/richtext/richtextstyledlg.cpp:212
 msgid "The style preview."
 msgstr "शैली का पूर्वालोकन।"
 
-#: ../src/msw/ole/automtn.cpp:680
+#: ../src/msw/ole/automtn.cpp:671
 msgid "The system cannot find the file specified."
 msgstr ""
 
@@ -7270,7 +7423,7 @@ msgstr "टैब की स्थिति।"
 msgid "The tab positions."
 msgstr "टैब की स्थितियाँ।"
 
-#: ../src/richtext/richtextctrl.cpp:3098
+#: ../src/richtext/richtextctrl.cpp:3099
 msgid "The text couldn't be saved."
 msgstr "इस पाठ को सुरक्षित किया जा सका।"
 
@@ -7294,7 +7447,7 @@ msgstr "फ़ॉन्ट बिन्दु का आकार।"
 msgid "The top position."
 msgstr "टैब की स्थिति।"
 
-#: ../src/common/cmdline.cpp:1232
+#: ../src/common/cmdline.cpp:1228
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "'%s' विकल्प के लिए इस मूल्य को निर्दिष्ट करना अनिवार्य है।"
@@ -7304,7 +7457,7 @@ msgstr "'%s' विकल्प के लिए इस मूल्य को �
 msgid "The value of the corner radius."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:433
+#: ../src/msw/dialup.cpp:427
 #, fuzzy, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -7319,128 +7472,136 @@ msgstr ""
 msgid "The vertical offset."
 msgstr "अगले अनुच्छेद के लिए डिफ़ाल्ट शैली।"
 
-#: ../src/richtext/richtextprint.cpp:619 ../src/html/htmprint.cpp:745
+#: ../src/html/htmprint.cpp:749 ../src/richtext/richtextprint.cpp:615
 msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr ""
 "पॄष्ट स्थापना के दौरान एक समस्या थी: आपको एक डिफ़ाल्ट प्रिंटर को स्थापित करने की "
 "आवश्यकता है।"
 
-#: ../src/html/htmprint.cpp:255
+#: ../src/html/htmprint.cpp:267
 msgid ""
 "This document doesn't fit on the page horizontally and will be truncated "
 "when it is printed."
 msgstr ""
 
-#: ../src/common/image.cpp:2854
+#: ../src/common/image.cpp:2963
 #, fuzzy, c-format
 msgid "This is not a %s."
 msgstr "पीसीएक्स: यह एक पीसीएक्स फ़ाइल नहीं है।"
 
-#: ../src/common/wincmn.cpp:1653
+#: ../src/common/wincmn.cpp:1654
 msgid "This platform does not support background transparency."
 msgstr ""
 
-#: ../src/gtk/window.cpp:4660
+#: ../src/gtk/window.cpp:5664
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
 
-#: ../src/msw/thread.cpp:1240
+#: ../src/gtk/glcanvas.cpp:176
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/msw/thread.cpp:1246
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
 msgstr ""
 "थ्रेड माड्यूल आरम्भीकरण असफ़ल रहा: स्थानीय थ्रेड में मूल्य को सुरक्षित नहीं किया जा सका "
 
-#: ../src/unix/threadpsx.cpp:1794
+#: ../src/unix/threadpsx.cpp:1843
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr "थ्रेड माड्यूल आरम्भीकरण असफ़ल रहा: थ्रेड कुँजी का निर्माण नहीं किया जा सका"
 
-#: ../src/msw/thread.cpp:1228
+#: ../src/msw/thread.cpp:1234
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
 msgstr "थ्रेड माड्यूल आरम्भीकरण असफ़ल रहा: स्थानीय थ्रेड भंडार में इंडेक्स का आवंटन असम्भव"
 
-#: ../src/unix/threadpsx.cpp:1043
+#: ../src/unix/threadpsx.cpp:1061
 msgid "Thread priority setting is ignored."
 msgstr "थ्रेड वरीयता समायोजना पर ध्यान नहीं दिया गया।"
 
-#: ../src/msw/mdi.cpp:176
+#: ../src/msw/mdi.cpp:171
 msgid "Tile &Horizontally"
 msgstr "क्षैतिज रूप से टाइल (&H)"
 
-#: ../src/msw/mdi.cpp:177
+#: ../src/msw/mdi.cpp:172
 msgid "Tile &Vertically"
 msgstr "खड़े रूप से टाइल (&V)"
 
-#: ../src/common/ftp.cpp:200
+#: ../src/common/ftp.cpp:197
 #, fuzzy
 msgid "Timeout while waiting for FTP server to connect, try passive mode."
 msgstr "यह एफ़टीपी सर्वर निश्चेष्ट विधा का समर्थन नहीं करता है।"
 
-#: ../src/generic/tipdlg.cpp:201
+#: ../src/generic/tipdlg.cpp:198
 msgid "Tip of the Day"
 msgstr "आज का संकेत"
 
-#: ../src/generic/tipdlg.cpp:140
+#: ../src/generic/tipdlg.cpp:137
 msgid "Tips not available, sorry!"
 msgstr "संकेत उपलब्ध नहीं हैं, क्षमा करें!"
 
-#: ../src/generic/prntdlgg.cpp:242
+#: ../src/generic/prntdlgg.cpp:235
 msgid "To:"
 msgstr "प्राप्तकर्ता:"
 
-#: ../src/richtext/richtextbuffer.cpp:8363
+#: ../src/richtext/richtextbuffer.cpp:8361
 msgid "Too many EndStyle calls!"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:891
+#: ../src/propgrid/advprops.cpp:792
 msgid "Tooltip"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:892
+#: ../src/propgrid/advprops.cpp:793
 msgid "TooltipText"
 msgstr ""
 
-#: ../src/richtext/richtextsizepage.cpp:286
-#: ../src/richtext/richtextsizepage.cpp:290 ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197 ../src/richtext/richtextsizepage.cpp:286
+#: ../src/richtext/richtextsizepage.cpp:290
 #, fuzzy
 msgid "Top"
 msgstr "प्राप्तकर्ता:"
 
-#: ../src/generic/prntdlgg.cpp:881
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Top margin (mm):"
 msgstr "ऊपरी हाशिया (मिलीमीटर):"
 
-#: ../src/generic/aboutdlgg.cpp:79
+#: ../src/generic/aboutdlgg.cpp:76
 msgid "Translations by "
 msgstr "द्वारा अनुवाद"
 
-#: ../src/generic/aboutdlgg.cpp:188
+#: ../src/generic/aboutdlgg.cpp:185
 msgid "Translators"
 msgstr "अनुवादक"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:211
+#: ../src/propgrid/propgrid.cpp:192
 msgid "True"
 msgstr ""
 
-#: ../src/common/fs_mem.cpp:227
+#: ../src/common/fs_mem.cpp:222
 #, c-format
 msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
 msgstr ""
 "वीएफ़एस स्मॄति से  '%s' फ़ाइल को हटाने का प्रयास किया जा रहा है, परन्तु यह लोड नहीं है!"
 
-#: ../src/common/fmapbase.cpp:156
+#: ../src/common/fmapbase.cpp:153
 msgid "Turkish (ISO-8859-9)"
 msgstr "टर्क्रिश (आईओ-८८५९-९)"
 
-#: ../src/generic/filectrlg.cpp:426
+#: ../src/generic/filectrlg.cpp:422
 msgid "Type"
 msgstr "प्रकार"
 
@@ -7454,36 +7615,36 @@ msgstr "फ़ॉन्ट का नाम टाइप करें"
 msgid "Type a size in points."
 msgstr "आकार बिंदुओं में टाइप करें।"
 
-#: ../src/msw/ole/automtn.cpp:676
+#: ../src/msw/ole/automtn.cpp:667
 #, c-format
 msgid "Type mismatch in argument %u."
 msgstr ""
 
-#: ../src/common/xtixml.cpp:356 ../src/common/xtixml.cpp:509
-#: ../src/common/xtistrm.cpp:318
+#: ../src/common/xtixml.cpp:352 ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315
 msgid "Type must have enum - long conversion"
 msgstr "प्रकार के पास ईनम - लंबा रूपांतरण अवश्य होना चाहिए"
 
-#: ../src/propgrid/propgridiface.cpp:401
+#: ../src/propgrid/propgridiface.cpp:385
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
 "\"%s\"."
 msgstr ""
 
-#: ../src/common/paper.cpp:133
+#: ../src/common/paper.cpp:130
 msgid "US Std Fanfold, 14 7/8 x 11 in"
 msgstr "यूएस सामान्य फ़ैनफ़ोल्ड, १४ ७/८ x ११ इंच"
 
-#: ../src/common/fmapbase.cpp:196
+#: ../src/common/fmapbase.cpp:193
 msgid "US-ASCII"
 msgstr "यू स-आस्की (ASCII)"
 
-#: ../src/unix/fswatcher_inotify.cpp:109
+#: ../src/unix/fswatcher_inotify.cpp:106
 msgid "Unable to add inotify watch"
 msgstr ""
 
-#: ../src/unix/fswatcher_kqueue.cpp:136
+#: ../src/unix/fswatcher_kqueue.cpp:153
 msgid "Unable to add kqueue watch"
 msgstr ""
 
@@ -7496,7 +7657,7 @@ msgstr ""
 msgid "Unable to close I/O completion port handle"
 msgstr "फ़ाइल हैन्डल को बन्द करने में असफ़ल"
 
-#: ../src/unix/fswatcher_inotify.cpp:97
+#: ../src/unix/fswatcher_inotify.cpp:94
 #, fuzzy
 msgid "Unable to close inotify instance"
 msgstr "फ़ाइल हैन्डल को बन्द करने में असफ़ल"
@@ -7516,17 +7677,17 @@ msgstr "फ़ाइल हैन्डल को बन्द करने मे�
 msgid "Unable to create I/O completion port"
 msgstr "एमडीआई मूल खाके का निर्माण करने में असफ़ल।"
 
-#: ../src/msw/fswatcher.cpp:84
+#: ../src/msw/fswatcher.cpp:81
 #, fuzzy
 msgid "Unable to create IOCP worker thread"
 msgstr "एमडीआई मूल खाके का निर्माण करने में असफ़ल।"
 
-#: ../src/unix/fswatcher_inotify.cpp:74
+#: ../src/unix/fswatcher_inotify.cpp:71
 #, fuzzy
 msgid "Unable to create inotify instance"
 msgstr "डीडीई श्रेणी का निर्माण करने में असफ़ल"
 
-#: ../src/unix/fswatcher_kqueue.cpp:97
+#: ../src/unix/fswatcher_kqueue.cpp:114
 #, fuzzy
 msgid "Unable to create kqueue instance"
 msgstr "डीडीई श्रेणी का निर्माण करने में असफ़ल"
@@ -7535,11 +7696,11 @@ msgstr "डीडीई श्रेणी का निर्माण कर�
 msgid "Unable to dequeue completion packet"
 msgstr ""
 
-#: ../src/unix/fswatcher_kqueue.cpp:185
+#: ../src/unix/fswatcher_kqueue.cpp:202
 msgid "Unable to get events from kqueue"
 msgstr ""
 
-#: ../src/gtk/app.cpp:435
+#: ../src/gtk/app.cpp:431
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr ""
 
@@ -7548,12 +7709,12 @@ msgstr ""
 msgid "Unable to open path '%s'"
 msgstr "'%s' सीएचएम लेखागार को खोलने में असफ़ल।"
 
-#: ../src/html/htmlwin.cpp:583
+#: ../src/html/htmlwin.cpp:586
 #, c-format
 msgid "Unable to open requested HTML document: %s"
 msgstr "निवेदित एचटीएमएल प्रलेख को खोलने में असमर्थ: %s"
 
-#: ../src/unix/sound.cpp:368
+#: ../src/unix/sound.cpp:365
 msgid "Unable to play sound asynchronously."
 msgstr "ध्वनि को अतुल्यकालिक रूप से चलाने में असमर्थ।"
 
@@ -7561,64 +7722,64 @@ msgstr "ध्वनि को अतुल्यकालिक रूप स�
 msgid "Unable to post completion status"
 msgstr ""
 
-#: ../src/unix/fswatcher_inotify.cpp:556
+#: ../src/unix/fswatcher_inotify.cpp:553
 #, fuzzy
 msgid "Unable to read from inotify descriptor"
 msgstr "फ़ाइल विवरणकर्ता %d से पढ़ा नहीं जा सकता है"
 
-#: ../src/unix/fswatcher_inotify.cpp:141
+#: ../src/unix/fswatcher_inotify.cpp:138
 #, fuzzy, c-format
 msgid "Unable to remove inotify watch %i"
 msgstr "डीडीई श्रेणी का निर्माण करने में असफ़ल"
 
-#: ../src/unix/fswatcher_kqueue.cpp:153
+#: ../src/unix/fswatcher_kqueue.cpp:170
 msgid "Unable to remove kqueue watch"
 msgstr ""
 
-#: ../src/msw/fswatcher.cpp:168
+#: ../src/msw/fswatcher.cpp:165
 #, fuzzy, c-format
 msgid "Unable to set up watch for '%s'"
 msgstr "'%s' फ़ाइल को छूने में असफ़ल"
 
-#: ../src/msw/fswatcher.cpp:91
+#: ../src/msw/fswatcher.cpp:88
 msgid "Unable to start IOCP worker thread"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:201
+#: ../src/common/stockitem.cpp:198
 msgid "Undelete"
 msgstr "अविलोप"
 
-#: ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199
 #, fuzzy
 msgid "Underline"
 msgstr "रेखांकित (&U)"
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/richtext/richtextfontpage.cpp:359 ../src/osx/carbon/fontdlg.cpp:370
-#: ../src/propgrid/advprops.cpp:690
+#: ../src/osx/carbon/fontdlg.cpp:367 ../src/propgrid/advprops.cpp:600
+#: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "रेखांकित"
 
-#: ../src/common/stockitem.cpp:203 ../src/stc/stc_i18n.cpp:15
+#: ../src/common/stockitem.cpp:200 ../src/stc/stc_i18n.cpp:15
 #, fuzzy
 msgid "Undo"
 msgstr "पहिले जैसा करें (&U)"
 
-#: ../src/common/stockitem.cpp:265
+#: ../src/common/stockitem.cpp:263
 msgid "Undo last action"
 msgstr "पिछला कार्य रद्द करें"
 
-#: ../src/common/cmdline.cpp:1029
+#: ../src/common/cmdline.cpp:1025
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "विकल्प के पश्चात अप्रत्याशित संप्रतीक '%s'।"
 
-#: ../src/unix/fswatcher_inotify.cpp:274
+#: ../src/unix/fswatcher_inotify.cpp:271
 #, c-format
 msgid "Unexpected event for \"%s\": no matching watch descriptor."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1195
+#: ../src/common/cmdline.cpp:1191
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "अप्रत्याशित पैरामीटर '%s'"
@@ -7627,50 +7788,50 @@ msgstr "अप्रत्याशित पैरामीटर '%s'"
 msgid "Unexpectedly new I/O completion port was created"
 msgstr ""
 
-#: ../src/msw/fswatcher.cpp:70
+#: ../src/msw/fswatcher.cpp:67
 #, fuzzy
 msgid "Ungraceful worker thread termination"
 msgstr "थ्रेड समाप्ति की प्रतीक्षा नहीं की जा सकती है"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:460
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:456
+#: ../src/richtext/richtextsymboldlg.cpp:457
+#: ../src/richtext/richtextsymboldlg.cpp:458
 msgid "Unicode"
 msgstr "यूनिकोड"
 
-#: ../src/common/fmapbase.cpp:185 ../src/common/fmapbase.cpp:191
+#: ../src/common/fmapbase.cpp:182 ../src/common/fmapbase.cpp:188
 msgid "Unicode 16 bit (UTF-16)"
 msgstr "यूनीकोड १६ बिट् (यूटीएफ़-१६)"
 
-#: ../src/common/fmapbase.cpp:190
+#: ../src/common/fmapbase.cpp:187
 msgid "Unicode 16 bit Big Endian (UTF-16BE)"
 msgstr "यूनीकोड १६ बिट् बड़ा इंडीयन (यूटीएफ़-१६बीई)"
 
-#: ../src/common/fmapbase.cpp:186
+#: ../src/common/fmapbase.cpp:183
 msgid "Unicode 16 bit Little Endian (UTF-16LE)"
 msgstr "यूनीकोड १६ बिट् छोटा इंडीयन (यूटीएफ़-१६एलई)"
 
-#: ../src/common/fmapbase.cpp:187 ../src/common/fmapbase.cpp:193
+#: ../src/common/fmapbase.cpp:184 ../src/common/fmapbase.cpp:190
 msgid "Unicode 32 bit (UTF-32)"
 msgstr "यूनीकोड ३२ बिट् (यूटीएफ़-३२)"
 
-#: ../src/common/fmapbase.cpp:192
+#: ../src/common/fmapbase.cpp:189
 msgid "Unicode 32 bit Big Endian (UTF-32BE)"
 msgstr "यूनीकोड ३२ बिट् बड़ा इंडीयन (यूटीएफ़-३२बीई)"
 
-#: ../src/common/fmapbase.cpp:188
+#: ../src/common/fmapbase.cpp:185
 msgid "Unicode 32 bit Little Endian (UTF-32LE)"
 msgstr "यूनीकोड ३२ बिट् छोटा इंडीयन (यूटीएफ़-३२एलई)"
 
-#: ../src/common/fmapbase.cpp:182
+#: ../src/common/fmapbase.cpp:179
 msgid "Unicode 7 bit (UTF-7)"
 msgstr "यूनीकोड ७ बिट् (यूटीएफ़-७)"
 
-#: ../src/common/fmapbase.cpp:183
+#: ../src/common/fmapbase.cpp:180
 msgid "Unicode 8 bit (UTF-8)"
 msgstr "यूनीकोड ८ बिट् (यूटीएफ़-८)"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 #, fuzzy
 msgid "Unindent"
 msgstr "अन-इंडेंट (&U)"
@@ -7832,99 +7993,104 @@ msgstr "थ्रेड समाप्ति की प्रतीक्षा
 msgid "Units for this value."
 msgstr "थ्रेड समाप्ति की प्रतीक्षा नहीं की जा सकती है।"
 
-#: ../src/generic/progdlgg.cpp:353 ../src/generic/progdlgg.cpp:622
+#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
 msgid "Unknown"
 msgstr "अज्ञात"
 
-#: ../src/msw/dde.cpp:1174
+#: ../src/msw/dde.cpp:1238
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "अज्ञात डीडीई त्रुटि %08x"
 
-#: ../src/common/xtistrm.cpp:410
+#: ../src/common/xtistrm.cpp:407
 msgid "Unknown Object passed to GetObjectClassInfo"
 msgstr "GetObjectClassInfo को अज्ञात ऑबजेक्ट दिया किया गया"
 
-#: ../src/common/imagpng.cpp:366
+#: ../src/common/imagpng.cpp:383
 #, fuzzy, c-format
 msgid "Unknown PNG resolution unit %d"
 msgstr "अज्ञात विकल्प '%s'"
 
-#: ../src/common/xtixml.cpp:327
+#: ../src/common/xtixml.cpp:323
 #, fuzzy, c-format
 msgid "Unknown Property %s"
 msgstr "अज्ञात विशेषतायें %s"
 
-#: ../src/common/imagtiff.cpp:529
+#: ../src/common/imagtiff.cpp:526
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr ""
 
-#: ../src/unix/dlunix.cpp:160
+#: ../src/propgrid/props.cpp:155
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/unix/dlunix.cpp:118
 msgid "Unknown dynamic library error"
 msgstr "अज्ञात गतिक लेखागार दोष"
 
-#: ../src/common/fmapbase.cpp:810
+#: ../src/common/fmapbase.cpp:806
 #, c-format
 msgid "Unknown encoding (%d)"
 msgstr "अज्ञात एन्कोडिंग (%d)"
 
-#: ../src/msw/ole/automtn.cpp:688
+#: ../src/msw/ole/automtn.cpp:679
 #, fuzzy, c-format
 msgid "Unknown error %08x"
 msgstr "अज्ञात डीडीई त्रुटि %08x"
 
-#: ../src/msw/ole/automtn.cpp:647
+#: ../src/msw/ole/automtn.cpp:638
 #, fuzzy
 msgid "Unknown exception"
 msgstr "अज्ञात विकल्प '%s'"
 
-#: ../src/common/image.cpp:2839
+#: ../src/common/image.cpp:2942
 #, fuzzy
 msgid "Unknown image data format."
 msgstr "डाटा प्रारूप में त्रुटि"
 
-#: ../src/common/cmdline.cpp:914
+#: ../src/common/cmdline.cpp:910
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "अज्ञात लंबा विकल्प '%s'"
 
-#: ../src/msw/ole/automtn.cpp:631
+#: ../src/msw/ole/automtn.cpp:622
 msgid "Unknown name or named argument."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:929 ../src/common/cmdline.cpp:951
+#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "अज्ञात विकल्प '%s'"
 
-#: ../src/common/mimecmn.cpp:225
+#: ../src/common/mimecmn.cpp:221
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "माइम प्रकार %s के लिए एक प्रविष्टी में बेमेल '{' ।"
 
-#: ../src/common/cmdproc.cpp:262 ../src/common/cmdproc.cpp:288
-#: ../src/common/cmdproc.cpp:308
+#: ../src/common/cmdproc.cpp:255 ../src/common/cmdproc.cpp:281
+#: ../src/common/cmdproc.cpp:301
 msgid "Unnamed command"
 msgstr "बेनाम निर्देश"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:413
+#: ../src/propgrid/propgrid.cpp:392
 msgid "Unspecified"
 msgstr ""
 
-#: ../src/msw/clipbrd.cpp:311
+#: ../src/msw/clipbrd.cpp:325
 msgid "Unsupported clipboard format."
 msgstr "असमर्थित क्लिपबोर्ड प्रारूप।"
 
-#: ../src/common/appcmn.cpp:256
+#: ../src/common/appcmn.cpp:277
 #, c-format
 msgid "Unsupported theme '%s'."
 msgstr "असमर्थित थीम '%s' ।"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:205
-#: ../src/common/accelcmn.cpp:63
+#: ../src/common/stockitem.cpp:202 ../src/common/accelcmn.cpp:60
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Up"
 msgstr "ऊपर"
 
@@ -7938,7 +8104,7 @@ msgstr "बड़े आकार के अक्षर"
 msgid "Upper case roman numerals"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1326
+#: ../src/common/cmdline.cpp:1322
 #, c-format
 msgid "Usage: %s"
 msgstr "उपयोगिता: %s"
@@ -7947,38 +8113,47 @@ msgstr "उपयोगिता: %s"
 msgid "Use &shadow"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:169
-#: ../src/richtext/richtextindentspage.cpp:171
 #: ../src/richtext/richtextliststylepage.cpp:358
 #: ../src/richtext/richtextliststylepage.cpp:360
+#: ../src/richtext/richtextindentspage.cpp:169
+#: ../src/richtext/richtextindentspage.cpp:171
 msgid "Use the current alignment setting."
 msgstr "वर्तमान सरेखण समायोजना को प्रयोग करें।"
 
-#: ../src/common/valtext.cpp:179
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/gtk/font.cpp:552
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/common/valtext.cpp:142
 msgid "Validation conflict"
 msgstr "सत्यापन टकराव"
 
-#: ../src/propgrid/manager.cpp:238
+#: ../src/propgrid/manager.cpp:224
 msgid "Value"
 msgstr ""
 
-#: ../src/propgrid/props.cpp:386 ../src/propgrid/props.cpp:500
+#: ../src/propgrid/props.cpp:309
 #, c-format
 msgid "Value must be %s or higher."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:417 ../src/propgrid/props.cpp:531
+#: ../src/propgrid/props.cpp:336
 #, c-format
 msgid "Value must be %s or less."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:393 ../src/propgrid/props.cpp:424
-#: ../src/propgrid/props.cpp:507 ../src/propgrid/props.cpp:538
+#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
 #, fuzzy, c-format
 msgid "Value must be between %s and %s."
 msgstr "%d से %d के मध्य में एक पृष्ट संख्या बताएँ:"
 
-#: ../src/generic/aboutdlgg.cpp:128
+#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
 #, fuzzy
 msgid "Version "
 msgstr "संस्मरण"
@@ -7988,25 +8163,32 @@ msgstr "संस्मरण"
 msgid "Vertical alignment."
 msgstr ""
 
-#: ../src/generic/filedlgg.cpp:202
+#: ../src/generic/filedlgg.cpp:199
 msgid "View files as a detailed view"
 msgstr "फ़ाइलों को एक विस्तॄत अवलोकन की भांति देखें"
 
-#: ../src/generic/filedlgg.cpp:200
+#: ../src/generic/filedlgg.cpp:197
 msgid "View files as a list view"
 msgstr "फ़ाइलों को एक अवलोकन सूची की भांति देखें"
 
-#: ../src/common/docview.cpp:1970
+#: ../src/common/docview.cpp:1975
 msgid "Views"
 msgstr "अवलोकन"
 
+#: ../src/gtk/app.cpp:348
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1777
+#: ../src/propgrid/advprops.cpp:1678
 msgid "Wait"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1779
+#: ../src/propgrid/advprops.cpp:1680
 msgid "Wait Arrow"
 msgstr ""
 
@@ -8015,254 +8197,251 @@ msgstr ""
 msgid "Waiting for IO on epoll descriptor %d failed"
 msgstr "उपप्रक्रिया के समाप्त होने की प्रतीक्षा असफ़ल रही"
 
-#: ../src/common/log.cpp:223
+#: ../src/common/log.cpp:241
 msgid "Warning: "
 msgstr "चेतावनी: "
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1778
+#: ../src/propgrid/advprops.cpp:1679
 msgid "Watch"
 msgstr ""
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:685
+#: ../src/propgrid/advprops.cpp:595
 #, fuzzy
 msgid "Weight"
 msgstr "भार (&W):"
 
-#: ../src/common/fmapbase.cpp:148
+#: ../src/common/fmapbase.cpp:145
 msgid "Western European (ISO-8859-1)"
 msgstr "वेस्टर्न यूरोपियन (आईसो-८८५९-१)"
 
-#: ../src/common/fmapbase.cpp:162
+#: ../src/common/fmapbase.cpp:159
 msgid "Western European with Euro (ISO-8859-15)"
 msgstr "वेस्टर्न यूरोपियन यूरो सहित (आईसो-८८५९-१५)"
 
-#: ../src/generic/fontdlgg.cpp:446 ../src/generic/fontdlgg.cpp:448
+#: ../src/generic/fontdlgg.cpp:443 ../src/generic/fontdlgg.cpp:445
 msgid "Whether the font is underlined."
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1611
+#: ../src/propgrid/advprops.cpp:1517
 msgid "White"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:144
+#: ../src/generic/fdrepdlg.cpp:141
 msgid "Whole word"
 msgstr "पूर्ण शब्द"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:532
 msgid "Whole words only"
 msgstr "सिर्फ़ पूर्ण शब्द "
 
-#: ../src/univ/themes/win32.cpp:1102
+#: ../src/univ/themes/win32.cpp:1099
 msgid "Win32 theme"
 msgstr "विन३२ थीम"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:893
+#: ../src/propgrid/advprops.cpp:794
 #, fuzzy
 msgid "Window"
 msgstr "खिड़की (&W)"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:894
+#: ../src/propgrid/advprops.cpp:795
 #, fuzzy
 msgid "WindowFrame"
 msgstr "खिड़की (&W)"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:895
+#: ../src/propgrid/advprops.cpp:796
 #, fuzzy
 msgid "WindowText"
 msgstr "खिड़की (&W)"
 
-#: ../src/common/fmapbase.cpp:177
+#: ../src/common/fmapbase.cpp:174
 msgid "Windows Arabic (CP 1256)"
 msgstr "विण्डो अरबी (सीपी १२५६)"
 
-#: ../src/common/fmapbase.cpp:178
+#: ../src/common/fmapbase.cpp:175
 msgid "Windows Baltic (CP 1257)"
 msgstr "विण्डो बाल्टिक (सीपी १२५७)"
 
-#: ../src/common/fmapbase.cpp:171
+#: ../src/common/fmapbase.cpp:168
 msgid "Windows Central European (CP 1250)"
 msgstr "विण्डो सेन्ट्रल यूरोपियन (सीपी १२५०)"
 
-#: ../src/common/fmapbase.cpp:168
+#: ../src/common/fmapbase.cpp:165
 #, fuzzy
 msgid "Windows Chinese Simplified (CP 936) or GB-2312"
 msgstr "विण्डो चीनी सरलीकॄत (सीपी ९३६)"
 
-#: ../src/common/fmapbase.cpp:170
+#: ../src/common/fmapbase.cpp:167
 #, fuzzy
 msgid "Windows Chinese Traditional (CP 950) or Big-5"
 msgstr "विण्डो चीनी पारम्परिक (सीपी ९५०)"
 
-#: ../src/common/fmapbase.cpp:172
+#: ../src/common/fmapbase.cpp:169
 msgid "Windows Cyrillic (CP 1251)"
 msgstr "विण्डो सायरिलिक (सीपी १२५१)"
 
-#: ../src/common/fmapbase.cpp:174
+#: ../src/common/fmapbase.cpp:171
 msgid "Windows Greek (CP 1253)"
 msgstr "विण्डो ग्रीक (सीपी १२५३)"
 
-#: ../src/common/fmapbase.cpp:176
+#: ../src/common/fmapbase.cpp:173
 msgid "Windows Hebrew (CP 1255)"
 msgstr "विण्डो हिब्रू (सीपी १२५५)"
 
-#: ../src/common/fmapbase.cpp:167
+#: ../src/common/fmapbase.cpp:164
 #, fuzzy
 msgid "Windows Japanese (CP 932) or Shift-JIS"
 msgstr "विण्डो जापानी (सीपी ९३२)"
 
-#: ../src/common/fmapbase.cpp:180
+#: ../src/common/fmapbase.cpp:177
 #, fuzzy
 msgid "Windows Johab (CP 1361)"
 msgstr "विण्डो अरबी (सीपी १२५६)"
 
-#: ../src/common/fmapbase.cpp:169
+#: ../src/common/fmapbase.cpp:166
 msgid "Windows Korean (CP 949)"
 msgstr "विण्डो कोरियन (सीपी ९४९)"
 
-#: ../src/common/fmapbase.cpp:166
+#: ../src/common/fmapbase.cpp:163
 msgid "Windows Thai (CP 874)"
 msgstr "विण्डो थाई (सीपी १२५७)"
 
-#: ../src/common/fmapbase.cpp:175
+#: ../src/common/fmapbase.cpp:172
 msgid "Windows Turkish (CP 1254)"
 msgstr "विण्डो टर्किस (सीपी १२५४)"
 
-#: ../src/common/fmapbase.cpp:179
+#: ../src/common/fmapbase.cpp:176
 #, fuzzy
 msgid "Windows Vietnamese (CP 1258)"
 msgstr "विण्डो ग्रीक (सीपी १२५३)"
 
-#: ../src/common/fmapbase.cpp:173
+#: ../src/common/fmapbase.cpp:170
 msgid "Windows Western European (CP 1252)"
 msgstr "विण्डो वेस्टर्न यूरोपियन (सीपी १२५२)"
 
-#: ../src/common/fmapbase.cpp:181
+#: ../src/common/fmapbase.cpp:178
 msgid "Windows/DOS OEM (CP 437)"
 msgstr "विण्डो/डास ओईएम (सीपी ४३७)"
 
-#: ../src/common/fmapbase.cpp:165
+#: ../src/common/fmapbase.cpp:162
 #, fuzzy
 msgid "Windows/DOS OEM Cyrillic (CP 866)"
 msgstr "विण्डो सायरिलिक (सीपी १२५१)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:111
+#: ../src/common/accelcmn.cpp:109
 #, fuzzy
 msgid "Windows_Left"
 msgstr "विण्डो 95"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:113
+#: ../src/common/accelcmn.cpp:111
 #, fuzzy
 msgid "Windows_Menu"
 msgstr "विण्डो एम ई"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:112
+#: ../src/common/accelcmn.cpp:110
 #, fuzzy
 msgid "Windows_Right"
 msgstr "विण्डो 95"
 
-#: ../src/common/ffile.cpp:150
+#: ../src/common/ffile.cpp:149
 #, c-format
 msgid "Write error on file '%s'"
 msgstr "'%s' फ़ाइल पर लेखन त्रुटि"
 
-#: ../src/xml/xml.cpp:914
+#: ../src/xml/xml.cpp:925
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "एक्सएम एल पदभंजन त्रुटि: '%s' %d पंक्ति पर"
 
-#: ../src/common/xpmdecod.cpp:796
+#: ../src/common/xpmdecod.cpp:794
 msgid "XPM: Malformed pixel data!"
 msgstr "एक्सपीएम: गलत रूप से निर्मित पीक्सेल डाटा!"
 
-#: ../src/common/xpmdecod.cpp:705
+#: ../src/common/xpmdecod.cpp:702
 #, c-format
 msgid "XPM: incorrect colour description in line %d"
 msgstr "एक्सपीएम: पंक्ति %d में गलत रूप से निर्मित रंग परिभाषा"
 
-#: ../src/common/xpmdecod.cpp:680
+#: ../src/common/xpmdecod.cpp:677
 msgid "XPM: incorrect header format!"
 msgstr "एक्सपीएम: गलत शीर्ष प्रारूप!"
 
-#: ../src/common/xpmdecod.cpp:716 ../src/common/xpmdecod.cpp:725
+#: ../src/common/xpmdecod.cpp:714 ../src/common/xpmdecod.cpp:723
 #, c-format
 msgid "XPM: malformed colour definition '%s' at line %d!"
 msgstr "एक्सपीएम: विकृत रंग परिभाषा '%s' पंक्ति %d में!"
 
-#: ../src/common/xpmdecod.cpp:755
+#: ../src/common/xpmdecod.cpp:753
 #, fuzzy
 msgid "XPM: no colors left to use for mask!"
 msgstr "एक्सपीएम: गलत शीर्ष प्रारूप!"
 
-#: ../src/common/xpmdecod.cpp:782
+#: ../src/common/xpmdecod.cpp:780
 #, c-format
 msgid "XPM: truncated image data at line %d!"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1610
+#: ../src/propgrid/advprops.cpp:1516
 msgid "Yellow"
 msgstr ""
 
-#: ../include/wx/msgdlg.h:276 ../src/common/stockitem.cpp:206
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:203
 #: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "हाँ"
 
-#: ../src/osx/carbon/overlay.cpp:155
-msgid "You cannot Clear an overlay that is not inited"
-msgstr ""
-
-#: ../src/osx/carbon/overlay.cpp:107 ../src/dfb/overlay.cpp:61
-msgid "You cannot Init an overlay twice"
-msgstr ""
-
-#: ../src/generic/dirdlgg.cpp:287
+#: ../src/generic/dirdlgg.cpp:284
 msgid "You cannot add a new directory to this section."
 msgstr "आप इस भाग में एक नयी निर्देशिका को जोड़ नहीं सकते है।"
 
-#: ../src/propgrid/propgrid.cpp:3299
+#: ../src/propgrid/propgrid.cpp:3276
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:209
+#: ../src/osx/cocoa/menu.mm:286
+#, fuzzy
+msgid "Zoom"
+msgstr "बड़ा करें (&I)"
+
+#: ../src/common/stockitem.cpp:206
 msgid "Zoom &In"
 msgstr "बड़ा करें (&I)"
 
-#: ../src/common/stockitem.cpp:210
+#: ../src/common/stockitem.cpp:207
 msgid "Zoom &Out"
 msgstr "छोटा करें (&O)"
 
-#: ../src/common/stockitem.cpp:209 ../src/common/prntbase.cpp:1594
+#: ../src/common/stockitem.cpp:206 ../src/common/prntbase.cpp:1619
 #, fuzzy
 msgid "Zoom In"
 msgstr "बड़ा करें (&I)"
 
-#: ../src/common/stockitem.cpp:210 ../src/common/prntbase.cpp:1580
+#: ../src/common/stockitem.cpp:207 ../src/common/prntbase.cpp:1605
 #, fuzzy
 msgid "Zoom Out"
 msgstr "छोटा करें (&O)"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to &Fit"
 msgstr "अनुरूप आकार करें (&F)"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 #, fuzzy
 msgid "Zoom to Fit"
 msgstr "अनुरूप आकार करें (&F)"
 
-#: ../src/msw/dde.cpp:1141
+#: ../src/msw/dde.cpp:1205
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "एक डीडीईएमएल कार्यक्रम ने एक बहुत लंबी रेस दशा का निर्माण कर दिया है।"
 
-#: ../src/msw/dde.cpp:1129
+#: ../src/msw/dde.cpp:1193
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -8272,40 +8451,40 @@ msgstr ""
 "एक डीडीईएमएल संक्रिया को बिना डीडीईआरम्भीकरण संक्रिया को पुकारे हुएपुकारा गया है,\n"
 "या फ़िर एक डीडीईएमएल संक्रिया को एक अवैध दॄष्टांत आइडेन्टीफ़ायरदिया गया है।"
 
-#: ../src/msw/dde.cpp:1147
+#: ../src/msw/dde.cpp:1211
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "एक ग्राहक का एक संवाद स्थापित करने का प्रयास असफ़ल रहा।"
 
-#: ../src/msw/dde.cpp:1144
+#: ../src/msw/dde.cpp:1208
 msgid "a memory allocation failed."
 msgstr "एक स्मृति आवंटन असफ़ल रहा।"
 
-#: ../src/msw/dde.cpp:1138
+#: ../src/msw/dde.cpp:1202
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "डीडीईएमएल द्वारा एक पैरामीटर का सत्यापन करना असफ़ल रहा।"
 
-#: ../src/msw/dde.cpp:1120
+#: ../src/msw/dde.cpp:1184
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "एक तुल्यकालिक परामर्श कार्यसंपादन हेतु एक निवेदन की समय-सीमा समाप्त हो चुकी है।"
 
-#: ../src/msw/dde.cpp:1126
+#: ../src/msw/dde.cpp:1190
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "एक तुल्यकालिक डाटा कार्यसंपादन हेतु एक निवेदन की समय-सीमा समाप्त हो चुकी है।"
 
-#: ../src/msw/dde.cpp:1135
+#: ../src/msw/dde.cpp:1199
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "एक तुल्यकालिक निष्पादन कार्यसंपादन हेतु एक निवेदन की समय-सीमा समाप्त हो चुकी है।"
 
-#: ../src/msw/dde.cpp:1153
+#: ../src/msw/dde.cpp:1217
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "एक तुल्यकालिक पोक कार्यसंपादन हेतु एक निवेदन की समय-सीमा समाप्त हो चुकी है।"
 
-#: ../src/msw/dde.cpp:1168
+#: ../src/msw/dde.cpp:1232
 msgid "a request to end an advise transaction has timed out."
 msgstr ""
 "एक परामर्श कार्यसंपादन को समाप्त करने हेतु एक निवेदन की समय-सीमा समाप्त हो चुकी है।"
 
-#: ../src/msw/dde.cpp:1162
+#: ../src/msw/dde.cpp:1226
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -8315,15 +8494,15 @@ msgstr ""
 "या फ़िर सर्वर ने एक कार्यसंपादन के खत्म होने के पहिले अचानक समाप्त कर दिया  था,\n"
 "एक सर्वर की तरफ़ से एक कार्यसंपादन का प्रयास किया गया था।"
 
-#: ../src/msw/dde.cpp:1150
+#: ../src/msw/dde.cpp:1214
 msgid "a transaction failed."
 msgstr "एक कार्यसंपादन असफ़ल रहा।"
 
-#: ../src/common/accelcmn.cpp:189
+#: ../src/common/accelcmn.cpp:188
 msgid "alt"
 msgstr "alt"
 
-#: ../src/msw/dde.cpp:1132
+#: ../src/msw/dde.cpp:1196
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -8335,15 +8514,15 @@ msgstr ""
 "या एक कार्यक्रम जिसका आरम्भीकरण APPCMD_CLIENTONLY की भांति किया गया था, \n"
 "सर्वर कार्यसंपादनों को करने का प्रयास कर चुका है।"
 
-#: ../src/msw/dde.cpp:1156
+#: ../src/msw/dde.cpp:1220
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "PostMessage चलन को एक आंतरिक कॉल असफ़ल रही। "
 
-#: ../src/msw/dde.cpp:1165
+#: ../src/msw/dde.cpp:1229
 msgid "an internal error has occurred in the DDEML."
 msgstr "डीडीईएमएल में एक आंतरिक त्रुटि उत्पन्न हो गयी है।"
 
-#: ../src/msw/dde.cpp:1171
+#: ../src/msw/dde.cpp:1235
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -8353,56 +8532,56 @@ msgstr ""
 "जब यह कार्यक्रम एक XTYP_XACT_COMPLETE कॉलबैक से वापस आ चुका होगा,\n"
 "इस कॉलबैक के लिए यह कार्य संपादन पहचानकर्ता मान्य नहीं रह जायेगा।"
 
-#: ../src/common/zipstrm.cpp:1483
+#: ../src/common/zipstrm.cpp:1522
 msgid "assuming this is a multi-part zip concatenated"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1847
+#: ../src/common/fileconf.cpp:1849
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "निर्विकल्प कुँजी '%s' को परिवर्तित करने के प्रयास पर ध्यान नहीं दिया गया। "
 
-#: ../src/html/chm.cpp:329
+#: ../src/html/chm.cpp:326
 msgid "bad arguments to library function"
 msgstr "लायबरी फ़लन को निकॄष्ट आरग्य़ूमेन्ट"
 
-#: ../src/html/chm.cpp:341
+#: ../src/html/chm.cpp:338
 msgid "bad signature"
 msgstr "खराब हस्ताक्षर"
 
-#: ../src/common/zipstrm.cpp:1918
+#: ../src/common/zipstrm.cpp:1988
 msgid "bad zipfile offset to entry"
 msgstr ""
 
-#: ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400
 msgid "binary"
 msgstr "बायनरी"
 
-#: ../src/common/fontcmn.cpp:996
+#: ../src/common/fontcmn.cpp:1195
 msgid "bold"
 msgstr "गहरा"
 
-#: ../src/msw/utils.cpp:1144
+#: ../src/msw/utils.cpp:1135
 #, fuzzy, c-format
 msgid "build %lu"
 msgstr "विण्डो एक्स पी (निर्माण %lu"
 
-#: ../src/common/ffile.cpp:75
+#: ../src/common/ffile.cpp:73
 #, c-format
 msgid "can't close file '%s'"
 msgstr "'%s' फ़ाइल को बन्द नहीं किया जा सकता है"
 
-#: ../src/common/file.cpp:245
+#: ../src/common/file.cpp:242
 #, c-format
 msgid "can't close file descriptor %d"
 msgstr "फ़ाइल विवरणकर्ता %d को बन्द नहीं किया जा सकता है"
 
-#: ../src/common/file.cpp:586
+#: ../src/common/ffile.cpp:382 ../src/common/file.cpp:613
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "'%s' फ़ाइल पर परिवर्तनों को प्रतिबद्धित नहीं किया जा सकता है"
 
-#: ../src/common/file.cpp:178
+#: ../src/common/file.cpp:175
 #, c-format
 msgid "can't create file '%s'"
 msgstr "'%s' फ़ाइल का निर्माण किया जा सकता है"
@@ -8412,50 +8591,50 @@ msgstr "'%s' फ़ाइल का निर्माण किया जा स�
 msgid "can't delete user configuration file '%s'"
 msgstr "'%s' उपयोगकर्ता संरचना फ़ाइल को मिटाय नहीं जा सकता है"
 
-#: ../src/common/file.cpp:495
+#: ../src/common/file.cpp:522
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr "निश्चय नहीं किया जा सकता है कि %d विवरणकर्ता पर फ़ाइल की समाप्ति पहुँच गयी है"
 
-#: ../src/common/zipstrm.cpp:1692
+#: ../src/common/zipstrm.cpp:1747
 msgid "can't find central directory in zip"
 msgstr "केन्द्र निर्देशिका को जीज़िप में खोजा नहीं जा सका"
 
-#: ../src/common/file.cpp:465
+#: ../src/common/file.cpp:492
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "%d फ़ाइल विवरणकर्ता पर फ़ाइल की लंबाई को पाया नहीं जा सकता है"
 
-#: ../src/msw/utils.cpp:341
+#: ../src/msw/utils.cpp:336
 msgid "can't find user's HOME, using current directory."
 msgstr ""
 "वर्तमान निर्देशिका का उपयोग करके, उपयोगकर्ता के गॄह (HOME) को पाया नहीं जा सकता है।"
 
-#: ../src/common/file.cpp:366
+#: ../src/common/file.cpp:407
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "फ़ाइल विवरणकर्ता %d को फ़्लैश नहीं किया जा सकता है"
 
-#: ../src/common/file.cpp:422
+#: ../src/common/file.cpp:463
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "फ़ाइल विवरणकर्ता %d पर स्थिति को खोजा नहीं जा सकता है"
 
-#: ../src/common/fontmap.cpp:325
+#: ../src/common/fontmap.cpp:322
 msgid "can't load any font, aborting"
 msgstr "किसी फ़ॉन्ट को लोड नहीं किया जा सकता है, निरस्त किया जा रहा है"
 
-#: ../src/common/file.cpp:231 ../src/common/ffile.cpp:59
+#: ../src/common/ffile.cpp:57 ../src/common/file.cpp:228
 #, c-format
 msgid "can't open file '%s'"
 msgstr "'%s' फ़ाइल को खोला नहीं जा सकता है"
 
-#: ../src/common/fileconf.cpp:320
+#: ../src/common/fileconf.cpp:314
 #, c-format
 msgid "can't open global configuration file '%s'."
 msgstr "विश्वव्यापी संरचना फ़ाइल '%s' को खोला नहीं जा सकता है।"
 
-#: ../src/common/fileconf.cpp:336
+#: ../src/common/fileconf.cpp:330
 #, c-format
 msgid "can't open user configuration file '%s'."
 msgstr "उपयोगकर्ता संरचना फ़ाइल '%s' को खोला नहीं जा सकता है।"
@@ -8464,40 +8643,40 @@ msgstr "उपयोगकर्ता संरचना फ़ाइल '%s' क�
 msgid "can't open user configuration file."
 msgstr "विश्वव्यापी संरचना फ़ाइल को खोला नहीं जा सकता है।"
 
-#: ../src/common/zipstrm.cpp:579
+#: ../src/common/zipstrm.cpp:572
 msgid "can't re-initialize zlib deflate stream"
 msgstr "जेडलिब् डीफ़्लेट धारा का आरम्भीकरण नहीं किया जा सकता है"
 
-#: ../src/common/zipstrm.cpp:604
+#: ../src/common/zipstrm.cpp:597
 msgid "can't re-initialize zlib inflate stream"
 msgstr "जेडलिब् इनफ़्लेट धारा का आरम्भीकरण नहीं किया जा सकता है"
 
-#: ../src/common/file.cpp:304
+#: ../src/common/file.cpp:345
 #, c-format
 msgid "can't read from file descriptor %d"
 msgstr "फ़ाइल विवरणकर्ता %d से पढ़ा नहीं जा सकता है"
 
-#: ../src/common/file.cpp:581
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:608
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "'%s' फ़ाइल को हटाया नहीं जा सकता है"
 
-#: ../src/common/file.cpp:598
+#: ../src/common/ffile.cpp:394 ../src/common/file.cpp:625
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "'%s' अस्थायी फ़ाइल को हटाया नहीं जा सकता है"
 
-#: ../src/common/file.cpp:408
+#: ../src/common/file.cpp:449
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "फ़ाइल विवरणकर्ता %d पर खोज नहीं की जा सकती है"
 
-#: ../src/common/textfile.cpp:273
+#: ../src/common/textfile.cpp:161
 #, c-format
 msgid "can't write buffer '%s' to disk."
 msgstr "'%s' बफ़र को डिस्क पर नहीं लिखा जा सकता है।"
 
-#: ../src/common/file.cpp:323
+#: ../src/common/file.cpp:364
 #, c-format
 msgid "can't write to file descriptor %d"
 msgstr "फ़ाइल विवरणकर्ता %d पर लिखा नहीं जा सकता है"
@@ -8507,22 +8686,28 @@ msgid "can't write user configuration file."
 msgstr "उपयोगकर्ता संरचना फ़ाइल को लिखा नहीं जा सकता है।"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:482 ../src/generic/datavgen.cpp:1261
+#: ../src/common/datavcmn.cpp:2064 ../src/generic/datavgen.cpp:1384
 msgid "checked"
 msgstr ""
 
-#: ../src/html/chm.cpp:345
+#: ../src/html/chm.cpp:342
 msgid "checksum error"
 msgstr "चेकसम त्रुटि"
 
-#: ../src/common/tarstrm.cpp:820
+#: ../src/common/tarstrm.cpp:814
 msgid "checksum failure reading tar header block"
 msgstr ""
 
-#: ../src/richtext/richtextbackgroundpage.cpp:226
-#: ../src/richtext/richtextbackgroundpage.cpp:249
-#: ../src/richtext/richtextbackgroundpage.cpp:289
-#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
 #: ../src/richtext/richtextborderspage.cpp:254
 #: ../src/richtext/richtextborderspage.cpp:288
 #: ../src/richtext/richtextborderspage.cpp:322
@@ -8540,105 +8725,128 @@ msgstr ""
 #: ../src/richtext/richtextmarginspage.cpp:340
 #: ../src/richtext/richtextmarginspage.cpp:363
 #: ../src/richtext/richtextmarginspage.cpp:388
-#: ../src/richtext/richtextsizepage.cpp:339
-#: ../src/richtext/richtextsizepage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:400
-#: ../src/richtext/richtextsizepage.cpp:427
-#: ../src/richtext/richtextsizepage.cpp:454
-#: ../src/richtext/richtextsizepage.cpp:481
-#: ../src/richtext/richtextsizepage.cpp:555
-#: ../src/richtext/richtextsizepage.cpp:590
-#: ../src/richtext/richtextsizepage.cpp:625
-#: ../src/richtext/richtextsizepage.cpp:660
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
 msgid "cm"
 msgstr ""
 
-#: ../src/html/chm.cpp:347
+#: ../src/html/chm.cpp:344
 msgid "compression error"
 msgstr "संकुचन त्रुटि"
 
-#: ../src/common/regex.cpp:236
+#: ../src/common/regex.cpp:233
 msgid "conversion to 8-bit encoding failed"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:187
+#: ../src/common/accelcmn.cpp:186
 msgid "ctrl"
 msgstr "ctrl"
 
-#: ../src/common/cmdline.cpp:1500
+#: ../src/common/cmdline.cpp:1496
 msgid "date"
 msgstr "तिथि"
 
-#: ../src/html/chm.cpp:349
+#: ../src/html/chm.cpp:346
 msgid "decompression error"
 msgstr "फ़ैलाव त्रुटि"
 
-#: ../src/richtext/richtextstyles.cpp:780 ../src/common/fmapbase.cpp:820
+#: ../src/common/fmapbase.cpp:816 ../src/richtext/richtextstyles.cpp:777
 msgid "default"
 msgstr "डिफ़ाल्ट"
 
-#: ../src/common/cmdline.cpp:1496
+#: ../src/common/cmdline.cpp:1492
 msgid "double"
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:538
+#: ../src/common/debugrpt.cpp:539
 msgid "dump of the process state (binary)"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1969
+#: ../src/common/datetimefmt.cpp:1992
 msgid "eighteenth"
 msgstr "अठारहवाँ"
 
-#: ../src/common/datetimefmt.cpp:1959
+#: ../src/common/datetimefmt.cpp:1982
 msgid "eighth"
 msgstr "आठवाँ"
 
-#: ../src/common/datetimefmt.cpp:1962
+#: ../src/common/datetimefmt.cpp:1985
 msgid "eleventh"
 msgstr "ग्यारहवाँ"
 
-#: ../src/common/fileconf.cpp:1833
+#: ../src/common/fileconf.cpp:1835
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "'%s' प्रविष्टी '%s' समूह में एक से अधिक बार आयी है"
 
-#: ../src/html/chm.cpp:343
+#: ../src/html/chm.cpp:340
 msgid "error in data format"
 msgstr "डाटा प्रारूप में त्रुटि"
 
-#: ../src/html/chm.cpp:331
+#: ../src/html/chm.cpp:328
 msgid "error opening file"
 msgstr "फ़ाइल खोलने में त्रुटि"
 
-#: ../src/common/zipstrm.cpp:1778
+#: ../src/common/zipstrm.cpp:1836
 msgid "error reading zip central directory"
 msgstr "जीज़िप केन्द्र निर्देशिका को पढ़नें में त्रुटि"
 
-#: ../src/common/zipstrm.cpp:1870
+#: ../src/common/zipstrm.cpp:1940
 msgid "error reading zip local header"
 msgstr "जीज़िप स्थानीय शीर्ष को पढ़नें में त्रुटि"
 
-#: ../src/common/zipstrm.cpp:2531
+#: ../src/common/zipstrm.cpp:2615
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "जीज़िप प्रविष्टी '%s' के लेखन में त्रुटि: निकृष्ट सीआरसी या गलत लंबाई"
 
-#: ../src/common/ffile.cpp:188
+#: ../src/common/zipstrm.cpp:2608
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "जीज़िप प्रविष्टी '%s' के लेखन में त्रुटि: निकृष्ट सीआरसी या गलत लंबाई"
+
+#: ../src/common/fontcmn.cpp:1205
+#, fuzzy
+msgid "extrabold"
+msgstr "गहरा"
+
+#: ../src/common/fontcmn.cpp:1223
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1167
+#, fuzzy
+msgid "extralight"
+msgstr "हल्का"
+
+#: ../src/msw/webview_ie.cpp:1036
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "'%s' का निष्पादन करने में असफ़ल\n"
+
+#: ../src/common/ffile.cpp:187
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "'%s' फ़ाइल को फ़्लैश करने में असफ़लता"
 
+#: ../src/msw/webview_ie.cpp:1045
+#, fuzzy
+msgid "failed to retrieve execution result"
+msgstr "आरऐएस त्रुटि संदेश के पाठ को पुनःप्राप्त करने में असफ़ल"
+
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1030
+#: ../src/generic/datavgen.cpp:1150
 #, fuzzy
 msgid "false"
 msgstr "फ़ाइल"
 
-#: ../src/common/datetimefmt.cpp:1966
+#: ../src/common/datetimefmt.cpp:1989
 msgid "fifteenth"
 msgstr "पन्द्रहवाँ"
 
-#: ../src/common/datetimefmt.cpp:1956
+#: ../src/common/datetimefmt.cpp:1979
 msgid "fifth"
 msgstr "पाँचवाँ"
 
@@ -8667,132 +8875,151 @@ msgstr "फ़ाइल '%s', पंक्ति %d: निर्विकल्प
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "फ़ाइल '%s': अप्रत्याशित %c शब्द %d पंक्ति पर।"
 
-#: ../src/richtext/richtextbuffer.cpp:8738
+#: ../src/richtext/richtextbuffer.cpp:8736
 msgid "files"
 msgstr "फ़ाइलें"
 
-#: ../src/common/datetimefmt.cpp:1952
+#: ../src/common/datetimefmt.cpp:1975
 msgid "first"
 msgstr "प्रथम"
 
-#: ../src/html/helpwnd.cpp:1252
+#: ../src/html/helpwnd.cpp:1250
 msgid "font size"
 msgstr "फ़ॉन्ट आकार"
 
-#: ../src/common/datetimefmt.cpp:1965
+#: ../src/common/datetimefmt.cpp:1988
 msgid "fourteenth"
 msgstr "चौदहवाँ"
 
-#: ../src/common/datetimefmt.cpp:1955
+#: ../src/common/datetimefmt.cpp:1978
 msgid "fourth"
 msgstr "चौथा"
 
-#: ../src/common/appbase.cpp:783
+#: ../src/common/appbase.cpp:784
 msgid "generate verbose log messages"
 msgstr "वर्णनात्मक लॉग संदेशो का जनन करें"
 
-#: ../src/richtext/richtextbuffer.cpp:13138
-#: ../src/richtext/richtextbuffer.cpp:13248
+#: ../src/common/fontcmn.cpp:1215
+msgid "heavy"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:13133
+#: ../src/richtext/richtextbuffer.cpp:13243
 msgid "image"
 msgstr "आकृति"
 
-#: ../src/common/tarstrm.cpp:796
+#: ../src/common/tarstrm.cpp:790
 msgid "incomplete header block in tar"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:489
+#: ../src/common/xtixml.cpp:485
 msgid "incorrect event handler string, missing dot"
 msgstr "गलत घटना हैन्डलर स्ट्रीनिंग, विलुप्त डॉट"
 
-#: ../src/common/tarstrm.cpp:1381
+#: ../src/common/tarstrm.cpp:1375
 msgid "incorrect size given for tar entry"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:993
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:987
 msgid "invalid data in extended tar header"
 msgstr ""
 
-#: ../src/generic/logg.cpp:1030
+#: ../src/generic/logg.cpp:1027
 msgid "invalid message box return value"
 msgstr "अवैध संदेश बॉक्स रीटर्न वैल्यू"
 
-#: ../src/common/zipstrm.cpp:1647
+#: ../src/common/zipstrm.cpp:1688
 msgid "invalid zip file"
 msgstr "अवैध जीज़िप फ़ाइल"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:1228
 msgid "italic"
 msgstr "तिरछा"
 
-#: ../src/common/fontcmn.cpp:991
+#: ../src/common/webrequest_curl.cpp:374
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "फ़ाइल को लोड नहीं किया जा सका।"
+
+#: ../src/common/fontcmn.cpp:1172
 msgid "light"
 msgstr "हल्का"
 
-#: ../src/common/intl.cpp:303
-#, c-format
-msgid "locale '%s' cannot be set."
-msgstr "'%s' लोकेल को स्थापित नहीं किया जा सका।"
+#: ../src/common/fontcmn.cpp:1185
+msgid "medium"
+msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2125
+#: ../src/common/datetimefmt.cpp:2148
 msgid "midnight"
 msgstr "अर्धरात्रि"
 
-#: ../src/common/datetimefmt.cpp:1970
+#: ../src/common/datetimefmt.cpp:1993
 msgid "nineteenth"
 msgstr "उन्नीसवाँ"
 
-#: ../src/common/datetimefmt.cpp:1960
+#: ../src/common/datetimefmt.cpp:1983
 msgid "ninth"
 msgstr "नौवाँ"
 
-#: ../src/msw/dde.cpp:1116
+#: ../src/msw/dde.cpp:1180
 msgid "no DDE error."
 msgstr "कोई डीडीई नहीं त्रुटि।"
 
-#: ../src/html/chm.cpp:327
+#: ../src/html/chm.cpp:324
 msgid "no error"
 msgstr "कोई त्रुटि नहीं"
 
-#: ../src/dfb/fontmgr.cpp:174
+#: ../src/dfb/fontmgr.cpp:171
 #, fuzzy, c-format
 msgid "no fonts found in %s, using builtin font"
 msgstr "कोई फ़ॉन्ट %s में नहीं मिले।"
 
-#: ../src/html/helpdata.cpp:657
+#: ../src/html/helpdata.cpp:650
 msgid "noname"
 msgstr "कोईनामनहीं"
 
-#: ../src/common/datetimefmt.cpp:2124
+#: ../src/common/datetimefmt.cpp:2147
 msgid "noon"
 msgstr "दोपहर"
 
-#: ../src/richtext/richtextstyles.cpp:779
+#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
 #, fuzzy
 msgid "normal"
 msgstr "सामान्य"
 
-#: ../src/common/cmdline.cpp:1492
+#: ../src/common/cmdline.cpp:1488
 msgid "num"
 msgstr "num"
 
-#: ../src/common/xtixml.cpp:259
+#: ../src/common/accelcmn.cpp:194
+msgid "num "
+msgstr ""
+
+#: ../src/common/xtixml.cpp:255
 msgid "objects cannot have XML Text Nodes"
 msgstr "एक्सएमएल पाठ नोडो को ऑबजेक्ट नहीं रख सकते है"
 
-#: ../src/html/chm.cpp:339
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
 msgid "out of memory"
 msgstr "स्मॄति समाप्त"
 
-#: ../src/common/debugrpt.cpp:514
+#: ../src/common/debugrpt.cpp:515
 msgid "process context description"
 msgstr "प्रक्रम संदर्भ वर्णन"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:227
-#: ../src/richtext/richtextbackgroundpage.cpp:250
-#: ../src/richtext/richtextbackgroundpage.cpp:290
-#: ../src/richtext/richtextbackgroundpage.cpp:317
-#: ../src/richtext/richtextfontpage.cpp:177
-#: ../src/richtext/richtextfontpage.cpp:180
 #: ../src/richtext/richtextborderspage.cpp:255
 #: ../src/richtext/richtextborderspage.cpp:289
 #: ../src/richtext/richtextborderspage.cpp:323
@@ -8802,22 +9029,45 @@ msgstr "प्रक्रम संदर्भ वर्णन"
 #: ../src/richtext/richtextborderspage.cpp:491
 #: ../src/richtext/richtextborderspage.cpp:525
 #: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextfontpage.cpp:180
 msgid "pt"
 msgstr ""
 
-#: ../src/richtext/richtextbackgroundpage.cpp:225
-#: ../src/richtext/richtextbackgroundpage.cpp:228
-#: ../src/richtext/richtextbackgroundpage.cpp:229
-#: ../src/richtext/richtextbackgroundpage.cpp:248
-#: ../src/richtext/richtextbackgroundpage.cpp:251
-#: ../src/richtext/richtextbackgroundpage.cpp:252
-#: ../src/richtext/richtextbackgroundpage.cpp:288
-#: ../src/richtext/richtextbackgroundpage.cpp:291
-#: ../src/richtext/richtextbackgroundpage.cpp:292
-#: ../src/richtext/richtextbackgroundpage.cpp:315
-#: ../src/richtext/richtextbackgroundpage.cpp:318
-#: ../src/richtext/richtextbackgroundpage.cpp:319
-#: ../src/richtext/richtextfontpage.cpp:178
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:659
+#: ../src/richtext/richtextsizepage.cpp:662
+#: ../src/richtext/richtextsizepage.cpp:663
 #: ../src/richtext/richtextborderspage.cpp:253
 #: ../src/richtext/richtextborderspage.cpp:256
 #: ../src/richtext/richtextborderspage.cpp:257
@@ -8869,264 +9119,274 @@ msgstr ""
 #: ../src/richtext/richtextmarginspage.cpp:387
 #: ../src/richtext/richtextmarginspage.cpp:389
 #: ../src/richtext/richtextmarginspage.cpp:390
-#: ../src/richtext/richtextsizepage.cpp:338
-#: ../src/richtext/richtextsizepage.cpp:341
-#: ../src/richtext/richtextsizepage.cpp:342
-#: ../src/richtext/richtextsizepage.cpp:372
-#: ../src/richtext/richtextsizepage.cpp:375
-#: ../src/richtext/richtextsizepage.cpp:376
-#: ../src/richtext/richtextsizepage.cpp:399
-#: ../src/richtext/richtextsizepage.cpp:402
-#: ../src/richtext/richtextsizepage.cpp:403
-#: ../src/richtext/richtextsizepage.cpp:426
-#: ../src/richtext/richtextsizepage.cpp:429
-#: ../src/richtext/richtextsizepage.cpp:430
-#: ../src/richtext/richtextsizepage.cpp:453
-#: ../src/richtext/richtextsizepage.cpp:456
-#: ../src/richtext/richtextsizepage.cpp:457
-#: ../src/richtext/richtextsizepage.cpp:480
-#: ../src/richtext/richtextsizepage.cpp:483
-#: ../src/richtext/richtextsizepage.cpp:484
-#: ../src/richtext/richtextsizepage.cpp:554
-#: ../src/richtext/richtextsizepage.cpp:557
-#: ../src/richtext/richtextsizepage.cpp:558
-#: ../src/richtext/richtextsizepage.cpp:589
-#: ../src/richtext/richtextsizepage.cpp:592
-#: ../src/richtext/richtextsizepage.cpp:593
-#: ../src/richtext/richtextsizepage.cpp:624
-#: ../src/richtext/richtextsizepage.cpp:627
-#: ../src/richtext/richtextsizepage.cpp:628
-#: ../src/richtext/richtextsizepage.cpp:659
-#: ../src/richtext/richtextsizepage.cpp:662
-#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextfontpage.cpp:178
 msgid "px"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:193
+#: ../src/common/accelcmn.cpp:192
 #, fuzzy
 msgid "rawctrl"
 msgstr "ctrl"
 
-#: ../src/html/chm.cpp:333
+#: ../src/html/chm.cpp:330
 msgid "read error"
 msgstr "पठन त्रुटि"
 
-#: ../src/common/zipstrm.cpp:2085
+#: ../src/common/zipstrm.cpp:2155
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "जीज़िप धारा को पढ़ा जा रहा है (प्रविष्टी %s): निकृष्ट सीआरसी"
 
-#: ../src/common/zipstrm.cpp:2080
+#: ../src/common/zipstrm.cpp:2150
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "जीज़िप धारा को पढ़ा जा रहा है (प्रविष्टी  %s): गलत लंबाई"
 
-#: ../src/msw/dde.cpp:1159
+#: ../src/msw/dde.cpp:1223
 msgid "reentrancy problem."
 msgstr "पुनःअन्दर आने की समस्या।"
 
-#: ../src/common/datetimefmt.cpp:1953
+#: ../src/common/datetimefmt.cpp:1976
 msgid "second"
 msgstr "सेकन्ड"
 
-#: ../src/html/chm.cpp:337
+#: ../src/html/chm.cpp:334
 msgid "seek error"
 msgstr "खोज त्रुटि"
 
-#: ../src/common/datetimefmt.cpp:1968
+#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#, fuzzy
+msgid "semibold"
+msgstr "गहरा"
+
+#: ../src/common/datetimefmt.cpp:1991
 msgid "seventeenth"
 msgstr "सत्रहवाँ"
 
-#: ../src/common/datetimefmt.cpp:1958
+#: ../src/common/datetimefmt.cpp:1981
 msgid "seventh"
 msgstr "सातवाँ"
 
-#: ../src/common/accelcmn.cpp:191
+#: ../src/common/accelcmn.cpp:190
 msgid "shift"
 msgstr "shift"
 
-#: ../src/common/appbase.cpp:773
+#: ../src/common/appbase.cpp:774
 msgid "show this help message"
 msgstr "इस सहायता संदेश को दिखाएँ"
 
-#: ../src/common/datetimefmt.cpp:1967
+#: ../src/common/datetimefmt.cpp:1990
 msgid "sixteenth"
 msgstr "सोलहवाँ"
 
-#: ../src/common/datetimefmt.cpp:1957
+#: ../src/common/datetimefmt.cpp:1980
 msgid "sixth"
 msgstr "छठवाँ"
 
-#: ../src/common/appcmn.cpp:234
+#: ../src/common/appcmn.cpp:255
 msgid "specify display mode to use (e.g. 640x480-16)"
 msgstr "उपयोगार्थ अवलोकन विधा को निर्दिष्ट करें (उदाहरण हेतु ६४०x४८०-१६)"
 
-#: ../src/common/appcmn.cpp:220
+#: ../src/common/appcmn.cpp:241
 msgid "specify the theme to use"
 msgstr "उपयोगार्थ थीम को निर्दिष्ट करें"
 
-#: ../src/richtext/richtextbuffer.cpp:9340
+#: ../src/richtext/richtextbuffer.cpp:9337
 #, fuzzy
 msgid "standard/circle"
 msgstr "मानक"
 
-#: ../src/richtext/richtextbuffer.cpp:9341
+#: ../src/richtext/richtextbuffer.cpp:9338
 msgid "standard/circle-outline"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9343
+#: ../src/richtext/richtextbuffer.cpp:9340
 msgid "standard/diamond"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9342
+#: ../src/richtext/richtextbuffer.cpp:9339
 #, fuzzy
 msgid "standard/square"
 msgstr "मानक"
 
-#: ../src/richtext/richtextbuffer.cpp:9344
+#: ../src/richtext/richtextbuffer.cpp:9341
 msgid "standard/triangle"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1985
+#: ../src/common/zipstrm.cpp:2055
 msgid "stored file length not in Zip header"
 msgstr "सुरक्षित फ़ाइल की लंबाई जीज़िप शीर्ष में नहीं है"
 
-#: ../src/common/cmdline.cpp:1488
+#: ../src/common/cmdline.cpp:1484
 msgid "str"
 msgstr "str"
 
-#: ../src/common/fontcmn.cpp:982
+#: ../src/common/fontcmn.cpp:1145
 #, fuzzy
 msgid "strikethrough"
 msgstr "स्ट्राइक थुःरु (S)"
 
-#: ../src/common/tarstrm.cpp:1003 ../src/common/tarstrm.cpp:1025
-#: ../src/common/tarstrm.cpp:1507 ../src/common/tarstrm.cpp:1529
+#: ../src/common/tarstrm.cpp:997 ../src/common/tarstrm.cpp:1019
+#: ../src/common/tarstrm.cpp:1501 ../src/common/tarstrm.cpp:1523
 msgid "tar entry not open"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1961
+#: ../src/common/datetimefmt.cpp:1984
 msgid "tenth"
 msgstr "दसवाँ"
 
-#: ../src/msw/dde.cpp:1123
+#: ../src/msw/dde.cpp:1187
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "इस कार्य संपादन को दिये हुए उत्तर ने DDE_FBUSY बिट् को स्थापित कर दिया।"
 
-#: ../src/common/datetimefmt.cpp:1954
+#: ../src/common/fontcmn.cpp:1154
+msgid "thin"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:1977
 msgid "third"
 msgstr "तीसरा"
 
-#: ../src/common/datetimefmt.cpp:1964
+#: ../src/common/datetimefmt.cpp:1987
 msgid "thirteenth"
 msgstr "तेरहवाँ"
 
-#: ../src/common/datetimefmt.cpp:1758
+#: ../src/common/datetimefmt.cpp:1781
 msgid "today"
 msgstr "आज"
 
-#: ../src/common/datetimefmt.cpp:1760
+#: ../src/common/datetimefmt.cpp:1783
 msgid "tomorrow"
 msgstr "कल"
 
-#: ../src/common/fileconf.cpp:1944
+#: ../src/common/fileconf.cpp:1946
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr ""
 
-#: ../src/gtk/aboutdlg.cpp:218
+#: ../src/gtk/aboutdlg.cpp:216
 msgid "translator-credits"
 msgstr "अनुवाद श्रेय"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1028
+#: ../src/generic/datavgen.cpp:1148
 msgid "true"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1963
+#: ../src/common/datetimefmt.cpp:1986
 msgid "twelfth"
 msgstr "बारहवाँ"
 
-#: ../src/common/datetimefmt.cpp:1971
+#: ../src/common/datetimefmt.cpp:1994
 msgid "twentieth"
 msgstr "बीसवाँ"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:486 ../src/generic/datavgen.cpp:1263
+#: ../src/common/datavcmn.cpp:2068 ../src/generic/datavgen.cpp:1386
 msgid "unchecked"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:802 ../src/common/fontcmn.cpp:978
+#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
 msgid "underlined"
 msgstr "रेखांकित"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:490
+#: ../src/common/datavcmn.cpp:2072
 #, fuzzy
 msgid "undetermined"
 msgstr "रेखांकित"
 
-#: ../src/common/fileconf.cpp:1979
+#: ../src/common/fileconf.cpp:1981
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "अप्रत्याशित \" %d पर '%s' में ।"
 
-#: ../src/common/tarstrm.cpp:1045
+#: ../src/common/tarstrm.cpp:1039
 msgid "unexpected end of file"
 msgstr "अनपेक्षित फ़ाइल अंत"
 
-#: ../src/generic/progdlgg.cpp:370 ../src/common/tarstrm.cpp:371
-#: ../src/common/tarstrm.cpp:394 ../src/common/tarstrm.cpp:425
+#: ../src/common/tarstrm.cpp:366 ../src/common/tarstrm.cpp:389
+#: ../src/common/tarstrm.cpp:420 ../src/generic/progdlgg.cpp:376
 msgid "unknown"
 msgstr "अज्ञात"
 
-#: ../src/msw/registry.cpp:150
+#: ../src/msw/registry.cpp:139
 #, fuzzy, c-format
 msgid "unknown (%lu)"
 msgstr "अज्ञात"
 
-#: ../src/common/xtixml.cpp:253
+#: ../src/common/xtixml.cpp:249
 #, c-format
 msgid "unknown class %s"
 msgstr "अज्ञात वर्ग %s"
 
-#: ../src/common/regex.cpp:258 ../src/html/chm.cpp:351
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "संकुचन त्रुटि"
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "फ़ैलाव त्रुटि"
+
+#: ../src/common/regex.cpp:255 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "अज्ञात त्रुटि"
 
-#: ../src/msw/dialup.cpp:471
+#: ../src/msw/dialup.cpp:465
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "अज्ञात त्रुटि (त्रुटि कूट %08x)।"
 
-#: ../src/common/fmapbase.cpp:834
+#: ../src/common/fmapbase.cpp:830
 #, c-format
 msgid "unknown-%d"
 msgstr "अज्ञात-%d"
 
-#: ../src/common/docview.cpp:509
+#: ../src/common/docview.cpp:502
 msgid "unnamed"
 msgstr "बिनानामदियाहुआ"
 
-#: ../src/common/docview.cpp:1624
+#: ../src/common/docview.cpp:1618
 #, c-format
 msgid "unnamed%d"
 msgstr "बिनानामदियाहुआ %d"
 
-#: ../src/common/zipstrm.cpp:1999 ../src/common/zipstrm.cpp:2319
+#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
 msgid "unsupported Zip compression method"
 msgstr "असमर्थित जीज़िप संकुचन विधि"
 
-#: ../src/common/translation.cpp:1892
+#: ../src/common/translation.cpp:1942
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "'%s' से '%s' तक सूचीपत्र का उपयोग किया जा रहा है।"
 
-#: ../src/html/chm.cpp:335
+#: ../src/html/chm.cpp:332
 msgid "write error"
 msgstr "लेखन त्रुटि"
 
-#: ../src/common/time.cpp:292
+#: ../src/gtk/glcanvas.cpp:187
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/common/time.cpp:285
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay असफ़ल रहा।"
 
@@ -9139,15 +9399,15 @@ msgstr "wxWidgets '%s' के लिए अवलोकन को खोल न�
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets के लिए अवलोकन को खोल नहीं पाया: बाहर निकल रहा है।"
 
-#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:431
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/common/datetimefmt.cpp:1759
+#: ../src/common/datetimefmt.cpp:1782
 msgid "yesterday"
 msgstr "बीताहुआकल"
 
-#: ../src/common/zstream.cpp:251 ../src/common/zstream.cpp:426
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
 #, c-format
 msgid "zlib error %d"
 msgstr "ज़ेडलिब त्रुटि  %d"
@@ -9158,8 +9418,66 @@ msgid "~"
 msgstr "~"
 
 #, fuzzy
-#~ msgid "Column could not be added."
-#~ msgstr "फ़ाइल को लोड नहीं किया जा सका।"
+#~ msgid "&Save as"
+#~ msgstr "जैसा सुरक्षित करें"
+
+#, fuzzy
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' में सिर्फ़ आल्फ़ाबेटिक अक्षरों को ही सम्मिलित होना चाहिए।"
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' को एक संख्या होना चाहिए।"
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' में सिर्फ़ आस्की अक्षरों को ही सम्मिलित होना चाहिए।"
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' में सिर्फ़ आल्फ़ाबेटिक अक्षरों को ही सम्मिलित होना चाहिए।"
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' में सिर्फ़ आल्फ़ाबेटिक या न्यूमेरिक अक्षरों को ही सम्मिलित होना चाहिए।"
+
+#, fuzzy
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' में सिर्फ़ आस्की अक्षरों को ही सम्मिलित होना चाहिए।"
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "%s वर्ग की खिड़की का निर्माण नहीं किया जा सकता है"
+
+#, fuzzy
+#~ msgid "Could not initalize libnotify."
+#~ msgstr "मुद्रण को आरम्भ नहीं किया जा सका।"
+
+#, fuzzy
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "एक समय-सचेतक का निर्माण नहीं किया जा सका"
+
+#, fuzzy
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "वर्तमान थ्रेड सूचक को प्राप्त नहीं किया जा सका"
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "फ़ाइल  \"%s\" को यूनिकोड में बदलने में असफ़ल।"
+
+#, fuzzy
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "यूटीसी तंत्र समय प्राप्त करने में असफ़ल।"
+
+#~ msgid "No unused colour in image."
+#~ msgstr "आकृति में कोई बिना उपयोग किया हुआ रंग नहीं हें।"
+
+#, fuzzy
+#~ msgid "Not available"
+#~ msgstr "संकेत उपलब्ध नहीं हैं, क्षमा करें!"
+
+#~ msgid "Replace selection"
+#~ msgstr "चयन बदलें"
+
+#~ msgid "Save as"
+#~ msgstr "जैसा सुरक्षित करें"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "'%s' लोकेल को स्थापित नहीं किया जा सका।"
 
 #, fuzzy
 #~ msgid "Column index not found."
@@ -9647,9 +9965,6 @@ msgstr "~"
 #~ msgid "Directory '%s' doesn't exist!"
 #~ msgstr "'%s' निर्देशिका विद्यमान नहीं है!"
 
-#~ msgid "File %s does not exist."
-#~ msgstr " %s फ़ाइल विद्यमान नहीं है।"
-
 #~ msgid "Mode %ix%i-%i not available."
 #~ msgstr "%ix%i-%i विधा उपलब्ध नहीं।"
 
@@ -9768,9 +10083,6 @@ msgstr "~"
 #, fuzzy
 #~ msgid "Failed to register OpenGL window class."
 #~ msgstr "ओपनजीएल का आरम्भीकरण करने में असफ़ल।"
-
-#~ msgid "Fatal error"
-#~ msgstr "घातक त्रुटि"
 
 #~ msgid "Fatal error: "
 #~ msgstr "घातक त्रुटि: "

--- a/locale/hr.po
+++ b/locale/hr.po
@@ -7,19 +7,19 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1.x\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-21 14:25+0200\n"
+"POT-Creation-Date: 2020-10-18 23:11+0300\n"
 "PO-Revision-Date: 2019-04-06 17:57+0200\n"
+"Last-Translator: Milo Ivir <mail@milotype.de>\n"
 "Language-Team: \n"
+"Language: hr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
 "%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
 "X-Generator: Poedit 2.2.1\n"
-"Last-Translator: Milo Ivir <mail@milotype.de>\n"
-"Language: hr\n"
 
-#: ../src/common/debugrpt.cpp:586
+#: ../src/common/debugrpt.cpp:587
 msgid ""
 "\n"
 "Please send this report to the program maintainer, thank you!\n"
@@ -27,8 +27,8 @@ msgstr ""
 "\n"
 "Molimo te da ovaj izvještaj pošalješ održavatelju aplikacije. Hvala!\n"
 
-#: ../src/richtext/richtextstyledlg.cpp:210
-#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:206
+#: ../src/richtext/richtextstyledlg.cpp:218
 msgid " "
 msgstr " "
 
@@ -36,70 +36,96 @@ msgstr " "
 msgid "              Thank you and we're sorry for the inconvenience!\n"
 msgstr "              Hvala, i žao nam je zbog nastalih neugodnosti!\n"
 
-#: ../src/common/prntbase.cpp:573
+#: ../src/common/prntbase.cpp:568
 #, c-format
 msgid " (copy %d of %d)"
 msgstr " (kopija %d od %d)"
 
-#: ../src/common/log.cpp:421
+#: ../src/common/log.cpp:440
 #, c-format
 msgid " (error %ld: %s)"
 msgstr " (greška %ld: %s)"
 
-#: ../src/common/imagtiff.cpp:72
+#: ../src/common/imagtiff.cpp:69
 #, c-format
 msgid " (in module \"%s\")"
 msgstr " (u modulu „%s”)"
 
-#: ../src/osx/core/secretstore.cpp:138
-msgid " (while overwriting an existing item)"
-msgstr " (prilikom prepisivanja preko postojeće stavke)"
-
-#: ../src/common/docview.cpp:1642
+#: ../src/common/docview.cpp:1636
 msgid " - "
 msgstr " – "
 
-#: ../src/richtext/richtextprint.cpp:593 ../src/html/htmprint.cpp:714
+#: ../src/html/htmprint.cpp:712 ../src/richtext/richtextprint.cpp:589
 msgid " Preview"
 msgstr " Pregled"
 
-#: ../src/common/fontcmn.cpp:824
+#: ../src/common/fontcmn.cpp:973
 msgid " bold"
 msgstr " debeli"
 
-#: ../src/common/fontcmn.cpp:840
+#: ../src/common/fontcmn.cpp:977
+#, fuzzy
+msgid " extra bold"
+msgstr " debeli"
+
+#: ../src/common/fontcmn.cpp:985
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:957
+#, fuzzy
+msgid " extra light"
+msgstr " svjetli"
+
+#: ../src/common/fontcmn.cpp:981
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1001
 msgid " italic"
 msgstr " kurziv"
 
-#: ../src/common/fontcmn.cpp:820
+#: ../src/common/fontcmn.cpp:961
 msgid " light"
 msgstr " svjetli"
 
-#: ../src/common/fontcmn.cpp:807
+#: ../src/common/fontcmn.cpp:965
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:969
+#, fuzzy
+msgid " semi bold"
+msgstr " debeli"
+
+#: ../src/common/fontcmn.cpp:940
 msgid " strikethrough"
 msgstr " precrtano"
 
-#: ../src/common/paper.cpp:117
+#: ../src/common/fontcmn.cpp:953
+msgid " thin"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
 msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
 msgstr "#10 kuverta, 4 1/8 × 9 1/2 in"
 
-#: ../src/common/paper.cpp:118
+#: ../src/common/paper.cpp:115
 msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
 msgstr "#11 kuverta, 4 1/2 × 10 3/8 in"
 
-#: ../src/common/paper.cpp:119
+#: ../src/common/paper.cpp:116
 msgid "#12 Envelope, 4 3/4 x 11 in"
 msgstr "#12 kuverta, 4 3/4 × 11 in"
 
-#: ../src/common/paper.cpp:120
+#: ../src/common/paper.cpp:117
 msgid "#14 Envelope, 5 x 11 1/2 in"
 msgstr "#14 kuverta, 5 × 11 1/2 in"
 
-#: ../src/common/paper.cpp:116
+#: ../src/common/paper.cpp:113
 msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
 msgstr "#9 kuverta, 3 7/8 × 8 7/8 in"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:341
 #: ../src/richtext/richtextsizepage.cpp:340
 #: ../src/richtext/richtextsizepage.cpp:374
 #: ../src/richtext/richtextsizepage.cpp:401
@@ -110,20 +136,21 @@ msgstr "#9 kuverta, 3 7/8 × 8 7/8 in"
 #: ../src/richtext/richtextsizepage.cpp:591
 #: ../src/richtext/richtextsizepage.cpp:626
 #: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextbackgroundpage.cpp:341
 msgid "%"
 msgstr "%"
 
-#: ../src/html/helpwnd.cpp:1031
+#: ../src/html/helpwnd.cpp:1029
 #, c-format
 msgid "%d of %lu"
 msgstr "%d od %lu"
 
-#: ../src/html/helpwnd.cpp:1678
+#: ../src/html/helpwnd.cpp:1676
 #, c-format
 msgid "%i of %u"
 msgstr "%i od %u"
 
-#: ../src/generic/filectrlg.cpp:279
+#: ../src/generic/filectrlg.cpp:275
 #, c-format
 msgid "%ld byte"
 msgid_plural "%ld bytes"
@@ -131,61 +158,61 @@ msgstr[0] "%ld bajt"
 msgstr[1] "%ld bajta"
 msgstr[2] "%ld bajtova"
 
-#: ../src/html/helpwnd.cpp:1033
+#: ../src/html/helpwnd.cpp:1031
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu od %lu"
 
-#: ../src/generic/datavgen.cpp:6028
+#: ../src/generic/datavgen.cpp:6833
 #, c-format
 msgid "%s (%d items)"
 msgstr "%s (%d stavki)"
 
-#: ../src/common/cmdline.cpp:1221
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (ili %s)"
 
-#: ../src/generic/logg.cpp:224
+#: ../src/generic/logg.cpp:221
 #, c-format
 msgid "%s Error"
 msgstr "%s greška"
 
-#: ../src/generic/logg.cpp:236
+#: ../src/generic/logg.cpp:233
 #, c-format
 msgid "%s Information"
 msgstr "%s informacija"
 
-#: ../src/generic/preferencesg.cpp:113
+#: ../src/generic/preferencesg.cpp:110
 #, c-format
 msgid "%s Preferences"
 msgstr "%s postavke"
 
-#: ../src/generic/logg.cpp:228
+#: ../src/generic/logg.cpp:225
 #, c-format
 msgid "%s Warning"
 msgstr "%s upozorenje"
 
-#: ../src/common/tarstrm.cpp:1319
+#: ../src/common/tarstrm.cpp:1313
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s ne paše tar zaglavlju za unos „%s”"
 
-#: ../src/common/fldlgcmn.cpp:124
+#: ../src/common/fldlgcmn.cpp:121
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s datoteka (%s)|%s"
 
-#: ../src/html/helpwnd.cpp:1716
+#: ../src/html/helpwnd.cpp:1714
 #, c-format
 msgid "%u of %u"
 msgstr "%u od %u"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "&About"
 msgstr "&O programu"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "&Actual Size"
 msgstr "&Stvarna veličina"
 
@@ -193,28 +220,28 @@ msgstr "&Stvarna veličina"
 msgid "&After a paragraph:"
 msgstr "&Nakon odlomka:"
 
-#: ../src/richtext/richtextindentspage.cpp:128
 #: ../src/richtext/richtextliststylepage.cpp:319
+#: ../src/richtext/richtextindentspage.cpp:128
 msgid "&Alignment"
 msgstr "&Poravnanje"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "&Apply"
 msgstr "&Primijeni"
 
-#: ../src/richtext/richtextstyledlg.cpp:251
+#: ../src/richtext/richtextstyledlg.cpp:247
 msgid "&Apply Style"
 msgstr "&Primijeni stil"
 
-#: ../src/msw/mdi.cpp:179
+#: ../src/msw/mdi.cpp:174
 msgid "&Arrange Icons"
 msgstr "&Rasporedi ikone"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "&Ascending"
 msgstr "&Uzlazno"
 
-#: ../src/common/stockitem.cpp:142
+#: ../src/common/stockitem.cpp:139
 msgid "&Back"
 msgstr "&Natrag"
 
@@ -234,24 +261,24 @@ msgstr "&Boja pozadine:"
 msgid "&Blur distance:"
 msgstr "&Udaljenost mutnoće:"
 
-#: ../src/common/stockitem.cpp:143
+#: ../src/common/stockitem.cpp:140
 msgid "&Bold"
 msgstr "&Debeli"
 
-#: ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141
 msgid "&Bottom"
 msgstr "&Dolje"
 
+#: ../src/richtext/richtextsizepage.cpp:637
+#: ../src/richtext/richtextsizepage.cpp:644
 #: ../src/richtext/richtextborderspage.cpp:345
 #: ../src/richtext/richtextborderspage.cpp:513
 #: ../src/richtext/richtextmarginspage.cpp:259
 #: ../src/richtext/richtextmarginspage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:637
-#: ../src/richtext/richtextsizepage.cpp:644
 msgid "&Bottom:"
 msgstr "&Dolje:"
 
-#: ../include/wx/richtext/richtextbuffer.h:3866
+#: ../include/wx/richtext/richtextbuffer.h:3861
 msgid "&Box"
 msgstr "&Okvir"
 
@@ -260,38 +287,38 @@ msgstr "&Okvir"
 msgid "&Bullet style:"
 msgstr "&Stil znaka nabrajanja:"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "&CD-Rom"
 msgstr "&CD-Rom"
 
-#: ../src/generic/wizard.cpp:434 ../src/generic/fontdlgg.cpp:470
-#: ../src/generic/fontdlgg.cpp:489 ../src/osx/carbon/fontdlg.cpp:402
-#: ../src/common/dlgcmn.cpp:279 ../src/common/stockitem.cpp:145
+#: ../src/osx/carbon/fontdlg.cpp:399 ../src/common/stockitem.cpp:142
+#: ../src/generic/wizard.cpp:433 ../src/generic/fontdlgg.cpp:466
+#: ../src/generic/fontdlgg.cpp:485 ../src/osx/cocoa/button.mm:200
 msgid "&Cancel"
 msgstr "&Odustani"
 
-#: ../src/msw/mdi.cpp:175
+#: ../src/msw/mdi.cpp:170
 msgid "&Cascade"
 msgstr "&Kaskada"
 
-#: ../include/wx/richtext/richtextbuffer.h:5960
+#: ../include/wx/richtext/richtextbuffer.h:5955
 msgid "&Cell"
 msgstr "Ć&elija"
 
-#: ../src/richtext/richtextsymboldlg.cpp:439
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "&Character code:"
 msgstr "&Slovni znak:"
 
-#: ../src/common/stockitem.cpp:147
+#: ../src/common/stockitem.cpp:144
 msgid "&Clear"
 msgstr "&Ukloni"
 
-#: ../src/generic/logg.cpp:516 ../src/common/stockitem.cpp:148
-#: ../src/common/prntbase.cpp:1600 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/stockitem.cpp:145 ../src/common/prntbase.cpp:1625
+#: ../src/univ/themes/win32.cpp:3753 ../src/generic/logg.cpp:513
 msgid "&Close"
 msgstr "&Zatvori"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "&Color"
 msgstr "&Boja"
 
@@ -299,20 +326,20 @@ msgstr "&Boja"
 msgid "&Colour:"
 msgstr "&Boja:"
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "&Convert"
 msgstr "&Pretvori"
 
-#: ../src/richtext/richtextctrl.cpp:333 ../src/osx/textctrl_osx.cpp:577
-#: ../src/common/stockitem.cpp:150 ../src/msw/textctrl.cpp:2508
+#: ../src/osx/textctrl_osx.cpp:595 ../src/common/stockitem.cpp:147
+#: ../src/msw/textctrl.cpp:2773 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Kopiraj"
 
-#: ../src/generic/hyperlinkg.cpp:156
+#: ../src/generic/hyperlinkg.cpp:153
 msgid "&Copy URL"
 msgstr "&Kopiraj URL"
 
-#: ../src/common/headerctrlcmn.cpp:306
+#: ../src/common/headerctrlcmn.cpp:304
 msgid "&Customize..."
 msgstr "&Prilagodi …"
 
@@ -320,53 +347,54 @@ msgstr "&Prilagodi …"
 msgid "&Debug report preview:"
 msgstr "&Pregled izvještaja o otklanjanju grešaka:"
 
-#: ../src/richtext/richtexttabspage.cpp:138
-#: ../src/richtext/richtextctrl.cpp:335 ../src/osx/textctrl_osx.cpp:579
-#: ../src/common/stockitem.cpp:152 ../src/msw/textctrl.cpp:2510
+#: ../src/osx/textctrl_osx.cpp:597 ../src/common/stockitem.cpp:149
+#: ../src/msw/textctrl.cpp:2775 ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtextctrl.cpp:334
 msgid "&Delete"
 msgstr "&Izbriši"
 
-#: ../src/richtext/richtextstyledlg.cpp:269
+#: ../src/richtext/richtextstyledlg.cpp:265
 msgid "&Delete Style..."
 msgstr "&Izbriši stil …"
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "&Descending"
 msgstr "&Silazno"
 
-#: ../src/generic/logg.cpp:682
+#: ../src/generic/logg.cpp:679
 msgid "&Details"
 msgstr "&Detalji"
 
-#: ../src/common/stockitem.cpp:153
+#: ../src/common/stockitem.cpp:150
 msgid "&Down"
 msgstr "&Dolje"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "&Edit"
 msgstr "&Uredi"
 
-#: ../src/richtext/richtextstyledlg.cpp:263
+#: ../src/richtext/richtextstyledlg.cpp:259
 msgid "&Edit Style..."
 msgstr "&Uredi stil …"
 
-#: ../src/common/stockitem.cpp:155
+#: ../src/common/stockitem.cpp:152
 msgid "&Execute"
 msgstr "&Izvrši"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/common/stockitem.cpp:154
 msgid "&File"
 msgstr "&Datoteka"
 
-#: ../src/common/stockitem.cpp:158
-msgid "&Find"
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "&Find..."
 msgstr "&Nađi"
 
-#: ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:430
 msgid "&Finish"
 msgstr "&Završi"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:156
 msgid "&First"
 msgstr "&Prvi"
 
@@ -374,15 +402,15 @@ msgstr "&Prvi"
 msgid "&Floating mode:"
 msgstr "&Lebdeći modus:"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "&Floppy"
 msgstr "&Floppy"
 
-#: ../src/common/stockitem.cpp:194
+#: ../src/common/stockitem.cpp:191
 msgid "&Font"
 msgstr "&Font"
 
-#: ../src/generic/fontdlgg.cpp:371
+#: ../src/generic/fontdlgg.cpp:367
 msgid "&Font family:"
 msgstr "&Font obitelj:"
 
@@ -390,20 +418,20 @@ msgstr "&Font obitelj:"
 msgid "&Font for Level..."
 msgstr "&Font za razinu …"
 
+#: ../src/richtext/richtextsymboldlg.cpp:397
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:400
 msgid "&Font:"
 msgstr "&Font:"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "&Forward"
 msgstr "&Naprijed"
 
-#: ../src/richtext/richtextsymboldlg.cpp:451
+#: ../src/richtext/richtextsymboldlg.cpp:448
 msgid "&From:"
 msgstr "&Od:"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "&Harddisk"
 msgstr "Čvrsti &disk"
 
@@ -412,9 +440,9 @@ msgstr "Čvrsti &disk"
 msgid "&Height:"
 msgstr "&Visina:"
 
-#: ../src/generic/wizard.cpp:441 ../src/richtext/richtextstyledlg.cpp:303
-#: ../src/richtext/richtextsymboldlg.cpp:479 ../src/osx/menu_osx.cpp:734
-#: ../src/common/stockitem.cpp:163
+#: ../src/common/stockitem.cpp:160 ../src/generic/wizard.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextstyledlg.cpp:299 ../src/osx/cocoa/menu.mm:226
 msgid "&Help"
 msgstr "&Pomoć"
 
@@ -422,7 +450,7 @@ msgstr "&Pomoć"
 msgid "&Hide details"
 msgstr "&Sakrij detalje"
 
-#: ../src/common/stockitem.cpp:164
+#: ../src/common/stockitem.cpp:161
 msgid "&Home"
 msgstr "&Početna"
 
@@ -430,54 +458,54 @@ msgstr "&Početna"
 msgid "&Horizontal offset:"
 msgstr "&Vodoravni odmak:"
 
-#: ../src/richtext/richtextindentspage.cpp:184
 #: ../src/richtext/richtextliststylepage.cpp:372
+#: ../src/richtext/richtextindentspage.cpp:184
 msgid "&Indentation (tenths of a mm)"
 msgstr "&Uvlaka (u destinkama mm)"
 
-#: ../src/richtext/richtextindentspage.cpp:167
 #: ../src/richtext/richtextliststylepage.cpp:356
+#: ../src/richtext/richtextindentspage.cpp:167
 msgid "&Indeterminate"
 msgstr "&Neodredi"
 
-#: ../src/common/stockitem.cpp:166
+#: ../src/common/stockitem.cpp:163
 msgid "&Index"
 msgstr "&Indeks"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "&Info"
 msgstr "&Informacije"
 
-#: ../src/common/stockitem.cpp:168
+#: ../src/common/stockitem.cpp:165
 msgid "&Italic"
 msgstr "&Kurziv"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "&Jump to"
 msgstr "&Prijeđi na"
 
-#: ../src/richtext/richtextindentspage.cpp:153
 #: ../src/richtext/richtextliststylepage.cpp:342
+#: ../src/richtext/richtextindentspage.cpp:153
 msgid "&Justified"
 msgstr "&Puni format"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "&Last"
 msgstr "&Zadnji"
 
-#: ../src/richtext/richtextindentspage.cpp:139
 #: ../src/richtext/richtextliststylepage.cpp:328
+#: ../src/richtext/richtextindentspage.cpp:139
 msgid "&Left"
 msgstr "&Lijevo"
 
-#: ../src/richtext/richtextindentspage.cpp:195
+#: ../src/richtext/richtextsizepage.cpp:532
+#: ../src/richtext/richtextsizepage.cpp:539
 #: ../src/richtext/richtextborderspage.cpp:243
 #: ../src/richtext/richtextborderspage.cpp:411
 #: ../src/richtext/richtextliststylepage.cpp:381
+#: ../src/richtext/richtextindentspage.cpp:195
 #: ../src/richtext/richtextmarginspage.cpp:186
 #: ../src/richtext/richtextmarginspage.cpp:300
-#: ../src/richtext/richtextsizepage.cpp:532
-#: ../src/richtext/richtextsizepage.cpp:539
 msgid "&Left:"
 msgstr "&Lijevo:"
 
@@ -485,11 +513,11 @@ msgstr "&Lijevo:"
 msgid "&List level:"
 msgstr "&Razina popisa:"
 
-#: ../src/generic/logg.cpp:517
+#: ../src/generic/logg.cpp:514
 msgid "&Log"
 msgstr "&Log"
 
-#: ../src/univ/themes/win32.cpp:3748
+#: ../src/univ/themes/win32.cpp:3745
 msgid "&Move"
 msgstr "&Premjesti"
 
@@ -497,19 +525,19 @@ msgstr "&Premjesti"
 msgid "&Move the object to:"
 msgstr "&Premjesti objekt u:"
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "&Network"
 msgstr "&Mreža"
 
-#: ../src/richtext/richtexttabspage.cpp:132 ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173 ../src/richtext/richtexttabspage.cpp:132
 msgid "&New"
 msgstr "&Nova"
 
-#: ../src/aui/tabmdi.cpp:111 ../src/generic/mdig.cpp:100 ../src/msw/mdi.cpp:180
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
 msgid "&Next"
 msgstr "&Sljedeće"
 
-#: ../src/generic/wizard.cpp:432 ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:429
 msgid "&Next >"
 msgstr "&Sljedeće >"
 
@@ -517,7 +545,7 @@ msgstr "&Sljedeće >"
 msgid "&Next Paragraph"
 msgstr "&Sljedeći odlomak"
 
-#: ../src/generic/tipdlg.cpp:240
+#: ../src/generic/tipdlg.cpp:237
 msgid "&Next Tip"
 msgstr "&Sljedeći savjet"
 
@@ -525,11 +553,11 @@ msgstr "&Sljedeći savjet"
 msgid "&Next style:"
 msgstr "&Sljedeći stil:"
 
-#: ../src/common/stockitem.cpp:177 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:174 ../src/msw/msgdlg.cpp:435
 msgid "&No"
 msgstr "&Ne"
 
-#: ../src/generic/dbgrptg.cpp:356
+#: ../src/generic/dbgrptg.cpp:360
 msgid "&Notes:"
 msgstr "&Napomene:"
 
@@ -537,12 +565,12 @@ msgstr "&Napomene:"
 msgid "&Number:"
 msgstr "&Broj:"
 
-#: ../src/generic/fontdlgg.cpp:475 ../src/generic/fontdlgg.cpp:482
-#: ../src/osx/carbon/fontdlg.cpp:408 ../src/common/stockitem.cpp:178
+#: ../src/osx/carbon/fontdlg.cpp:405 ../src/common/stockitem.cpp:175
+#: ../src/generic/fontdlgg.cpp:471 ../src/generic/fontdlgg.cpp:478
 msgid "&OK"
 msgstr "&U redu"
 
-#: ../src/generic/dbgrptg.cpp:342 ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176 ../src/generic/dbgrptg.cpp:342
 msgid "&Open..."
 msgstr "&Otvori …"
 
@@ -554,16 +582,16 @@ msgstr "&Razina sadržaja:"
 msgid "&Page Break"
 msgstr "&Prijelom stranice"
 
-#: ../src/richtext/richtextctrl.cpp:334 ../src/osx/textctrl_osx.cpp:578
-#: ../src/common/stockitem.cpp:180 ../src/msw/textctrl.cpp:2509
+#: ../src/osx/textctrl_osx.cpp:596 ../src/common/stockitem.cpp:177
+#: ../src/msw/textctrl.cpp:2774 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&Zalijepi"
 
-#: ../include/wx/richtext/richtextbuffer.h:5010
+#: ../include/wx/richtext/richtextbuffer.h:5005
 msgid "&Picture"
 msgstr "&Slika"
 
-#: ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:419
 msgid "&Point size:"
 msgstr "&Veličina:"
 
@@ -575,11 +603,11 @@ msgstr "&Položaj (u desetinkama mm):"
 msgid "&Position mode:"
 msgstr "&Modus položaja:"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178
 msgid "&Preferences"
 msgstr "&Postavke"
 
-#: ../src/aui/tabmdi.cpp:112 ../src/generic/mdig.cpp:101 ../src/msw/mdi.cpp:181
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
 msgid "&Previous"
 msgstr "&Prethodno"
 
@@ -587,78 +615,74 @@ msgstr "&Prethodno"
 msgid "&Previous Paragraph"
 msgstr "&Prethodni odlomak"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "&Print..."
 msgstr "&Ispiši …"
 
-#: ../src/richtext/richtextctrl.cpp:339 ../src/richtext/richtextctrl.cpp:5514
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtextctrl.cpp:338
+#: ../src/richtext/richtextctrl.cpp:5512
 msgid "&Properties"
 msgstr "&Svojstva"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "&Quit"
 msgstr "&Zatvori"
 
-#: ../src/richtext/richtextctrl.cpp:330 ../src/osx/textctrl_osx.cpp:574
-#: ../src/common/stockitem.cpp:185 ../src/common/cmdproc.cpp:293
-#: ../src/common/cmdproc.cpp:300 ../src/msw/textctrl.cpp:2505
+#: ../src/osx/textctrl_osx.cpp:592 ../src/common/stockitem.cpp:182
+#: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
+#: ../src/msw/textctrl.cpp:2770 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Ponovi"
 
-#: ../src/common/cmdproc.cpp:289 ../src/common/cmdproc.cpp:309
+#: ../src/common/cmdproc.cpp:282 ../src/common/cmdproc.cpp:302
 msgid "&Redo "
 msgstr "&Ponovi "
 
-#: ../src/richtext/richtextstyledlg.cpp:257
+#: ../src/richtext/richtextstyledlg.cpp:253
 msgid "&Rename Style..."
 msgstr "&Preimenuj stil …"
 
-#: ../src/generic/fdrepdlg.cpp:179
+#: ../src/generic/fdrepdlg.cpp:176
 msgid "&Replace"
 msgstr "&Zamijeni"
 
-#: ../src/richtext/richtextstyledlg.cpp:287
+#: ../src/richtext/richtextstyledlg.cpp:283
 msgid "&Restart numbering"
 msgstr "&Ponovi numeriranje"
 
-#: ../src/univ/themes/win32.cpp:3747
+#: ../src/univ/themes/win32.cpp:3744
 msgid "&Restore"
 msgstr "&Obnovi"
 
-#: ../src/richtext/richtextindentspage.cpp:146
 #: ../src/richtext/richtextliststylepage.cpp:335
+#: ../src/richtext/richtextindentspage.cpp:146
 msgid "&Right"
 msgstr "&Desno"
 
-#: ../src/richtext/richtextindentspage.cpp:213
+#: ../src/richtext/richtextsizepage.cpp:602
+#: ../src/richtext/richtextsizepage.cpp:609
 #: ../src/richtext/richtextborderspage.cpp:277
 #: ../src/richtext/richtextborderspage.cpp:445
 #: ../src/richtext/richtextliststylepage.cpp:399
+#: ../src/richtext/richtextindentspage.cpp:213
 #: ../src/richtext/richtextmarginspage.cpp:211
 #: ../src/richtext/richtextmarginspage.cpp:325
-#: ../src/richtext/richtextsizepage.cpp:602
-#: ../src/richtext/richtextsizepage.cpp:609
 msgid "&Right:"
 msgstr "&Desno:"
 
-#: ../src/common/stockitem.cpp:190
+#: ../src/common/stockitem.cpp:187
 msgid "&Save"
 msgstr "&Spremi"
-
-#: ../src/common/stockitem.cpp:191
-msgid "&Save as"
-msgstr "&Spremi pod"
 
 #: ../include/wx/richmsgdlg.h:29
 msgid "&See details"
 msgstr "&Prikaži detalje"
 
-#: ../src/generic/tipdlg.cpp:236
+#: ../src/generic/tipdlg.cpp:233
 msgid "&Show tips at startup"
 msgstr "&Prikaži savjete prilikom pokretanja"
 
-#: ../src/univ/themes/win32.cpp:3750
+#: ../src/univ/themes/win32.cpp:3747
 msgid "&Size"
 msgstr "&Veličina"
 
@@ -666,36 +690,36 @@ msgstr "&Veličina"
 msgid "&Size:"
 msgstr "&Veličina:"
 
-#: ../src/generic/progdlgg.cpp:252
+#: ../src/generic/progdlgg.cpp:249
 msgid "&Skip"
 msgstr "&Preskoči"
 
-#: ../src/richtext/richtextindentspage.cpp:242
 #: ../src/richtext/richtextliststylepage.cpp:417
+#: ../src/richtext/richtextindentspage.cpp:242
 msgid "&Spacing (tenths of a mm)"
 msgstr "&Spacioniranje (u desetinkama mm)"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "&Spell Check"
 msgstr "&Provjera pravopisa"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "&Stop"
 msgstr "&Zaustavi"
 
-#: ../src/richtext/richtextfontpage.cpp:275 ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196 ../src/richtext/richtextfontpage.cpp:275
 msgid "&Strikethrough"
 msgstr "&Precrtano"
 
-#: ../src/generic/fontdlgg.cpp:382 ../src/richtext/richtextstylepage.cpp:106
+#: ../src/generic/fontdlgg.cpp:378 ../src/richtext/richtextstylepage.cpp:106
 msgid "&Style:"
 msgstr "&Stil:"
 
-#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:194
 msgid "&Styles:"
 msgstr "&Stilovi:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:413
+#: ../src/richtext/richtextsymboldlg.cpp:410
 msgid "&Subset:"
 msgstr "&Podskupina:"
 
@@ -709,24 +733,24 @@ msgstr "&Simbol:"
 msgid "&Synchronize values"
 msgstr "&Sinkroniziraj vrijednosti"
 
-#: ../include/wx/richtext/richtextbuffer.h:6069
+#: ../include/wx/richtext/richtextbuffer.h:6064
 msgid "&Table"
 msgstr "&Tablica"
 
-#: ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197
 msgid "&Top"
 msgstr "&Gore"
 
+#: ../src/richtext/richtextsizepage.cpp:567
+#: ../src/richtext/richtextsizepage.cpp:574
 #: ../src/richtext/richtextborderspage.cpp:311
 #: ../src/richtext/richtextborderspage.cpp:479
 #: ../src/richtext/richtextmarginspage.cpp:234
 #: ../src/richtext/richtextmarginspage.cpp:348
-#: ../src/richtext/richtextsizepage.cpp:567
-#: ../src/richtext/richtextsizepage.cpp:574
 msgid "&Top:"
 msgstr "&Gore:"
 
-#: ../src/generic/fontdlgg.cpp:444 ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199 ../src/generic/fontdlgg.cpp:441
 msgid "&Underline"
 msgstr "&Podcrtaj"
 
@@ -734,21 +758,21 @@ msgstr "&Podcrtaj"
 msgid "&Underlining:"
 msgstr "&Podcrtavanje:"
 
-#: ../src/richtext/richtextctrl.cpp:329 ../src/osx/textctrl_osx.cpp:573
-#: ../src/common/stockitem.cpp:203 ../src/common/cmdproc.cpp:271
-#: ../src/msw/textctrl.cpp:2504
+#: ../src/osx/textctrl_osx.cpp:591 ../src/common/stockitem.cpp:200
+#: ../src/common/cmdproc.cpp:264 ../src/msw/textctrl.cpp:2769
+#: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Poništi"
 
-#: ../src/common/cmdproc.cpp:265
+#: ../src/common/cmdproc.cpp:258
 msgid "&Undo "
 msgstr "&Poništi "
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "&Unindent"
 msgstr "&Ukloni uvlaku"
 
-#: ../src/common/stockitem.cpp:205
+#: ../src/common/stockitem.cpp:202
 msgid "&Up"
 msgstr "&Gore"
 
@@ -764,7 +788,7 @@ msgstr "&Uspravni odmak:"
 msgid "&View..."
 msgstr "&Prikaz …"
 
-#: ../src/generic/fontdlgg.cpp:393
+#: ../src/generic/fontdlgg.cpp:389
 msgid "&Weight:"
 msgstr "&Debljina:"
 
@@ -773,88 +797,58 @@ msgstr "&Debljina:"
 msgid "&Width:"
 msgstr "&Širina:"
 
-#: ../src/aui/tabmdi.cpp:311 ../src/aui/tabmdi.cpp:327
-#: ../src/aui/tabmdi.cpp:329 ../src/generic/mdig.cpp:294
-#: ../src/generic/mdig.cpp:310 ../src/generic/mdig.cpp:314
-#: ../src/msw/mdi.cpp:78
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
 msgid "&Window"
 msgstr "&Prozor"
 
-#: ../src/common/stockitem.cpp:206 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:203 ../src/msw/msgdlg.cpp:435
 msgid "&Yes"
 msgstr "&Da"
 
-#: ../src/common/valtext.cpp:256
-#, c-format
-msgid "'%s' contains illegal characters"
+#: ../src/common/valtext.cpp:197
+#, fuzzy, c-format
+msgid "'%s' contains invalid character(s)"
 msgstr "„%s” sadržava nedozvoljene slovne znakove"
 
-#: ../src/common/valtext.cpp:254
-#, c-format
-msgid "'%s' doesn't consist only of valid characters"
-msgstr "„%s” ne sadržava samo dozvoljene slovne znakove"
-
-#: ../src/common/config.cpp:519 ../src/msw/regconf.cpp:258
+#: ../src/common/config.cpp:515 ../src/msw/regconf.cpp:255
 #, c-format
 msgid "'%s' has extra '..', ignored."
 msgstr "„%s” ima dodatne „..”, zanemareno."
 
-#: ../src/common/cmdline.cpp:1113 ../src/common/cmdline.cpp:1131
+#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "„%s” nije ispravna numerička vrijednost za opciju „%s”."
 
-#: ../src/common/translation.cpp:1100
+#: ../src/common/translation.cpp:1142
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "„%s” nije valjan katalog obavijesti."
 
-#: ../src/common/valtext.cpp:165
+#: ../src/common/valtext.cpp:188
 #, c-format
 msgid "'%s' is not one of the valid strings"
 msgstr "„%s” nije jedan od valjanih znakovnih nizova"
 
-#: ../src/common/valtext.cpp:167
+#: ../src/common/valtext.cpp:186
 #, c-format
 msgid "'%s' is one of the invalid strings"
 msgstr "„%s” je jedan od nevaljanih znakovnih nizova"
 
-#: ../src/common/textbuf.cpp:237
+#: ../src/common/textbuf.cpp:233
 #, c-format
 msgid "'%s' is probably a binary buffer."
 msgstr "„%s” je vjerojatno jedan binaran međuspremnik."
-
-#: ../src/common/valtext.cpp:252
-#, c-format
-msgid "'%s' should be numeric."
-msgstr "„%s” treba biti numerički."
-
-#: ../src/common/valtext.cpp:244
-#, c-format
-msgid "'%s' should only contain ASCII characters."
-msgstr "„%s” treba sadržavati samo ASCII slovne znakove."
-
-#: ../src/common/valtext.cpp:246
-#, c-format
-msgid "'%s' should only contain alphabetic characters."
-msgstr "„%s” treba sadržavati samo slovne znakove."
-
-#: ../src/common/valtext.cpp:248
-#, c-format
-msgid "'%s' should only contain alphabetic or numeric characters."
-msgstr "„%s” treba sadržavati samo alfanumeričke znakove."
-
-#: ../src/common/valtext.cpp:250
-#, c-format
-msgid "'%s' should only contain digits."
-msgstr "„%s” treba sadržavati samo brojke."
 
 #: ../src/richtext/richtextliststylepage.cpp:229
 #: ../src/richtext/richtextbulletspage.cpp:166
 msgid "(*)"
 msgstr "(*)"
 
-#: ../src/html/helpwnd.cpp:963
+#: ../src/html/helpwnd.cpp:961
 msgid "(Help)"
 msgstr "(pomoć)"
 
@@ -863,27 +857,32 @@ msgstr "(pomoć)"
 msgid "(None)"
 msgstr "(Bez)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:504
+#: ../src/richtext/richtextsymboldlg.cpp:503
 msgid "(Normal text)"
 msgstr "(Normalan tekst)"
 
-#: ../src/html/helpwnd.cpp:419 ../src/html/helpwnd.cpp:1106
-#: ../src/html/helpwnd.cpp:1742
+#: ../src/html/helpwnd.cpp:417 ../src/html/helpwnd.cpp:1104
+#: ../src/html/helpwnd.cpp:1740
 msgid "(bookmarks)"
 msgstr "(knjižne oznake)"
 
+#: ../src/msw/dlmsw.cpp:167
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (greška %ld: %s)"
+
+#: ../src/richtext/richtextformatdlg.cpp:876
+#: ../src/richtext/richtextliststylepage.cpp:448
+#: ../src/richtext/richtextliststylepage.cpp:460
+#: ../src/richtext/richtextliststylepage.cpp:461
 #: ../src/richtext/richtextindentspage.cpp:274
 #: ../src/richtext/richtextindentspage.cpp:286
 #: ../src/richtext/richtextindentspage.cpp:287
 #: ../src/richtext/richtextindentspage.cpp:311
 #: ../src/richtext/richtextindentspage.cpp:326
-#: ../src/richtext/richtextformatdlg.cpp:884
 #: ../src/richtext/richtextfontpage.cpp:349
 #: ../src/richtext/richtextfontpage.cpp:353
 #: ../src/richtext/richtextfontpage.cpp:357
-#: ../src/richtext/richtextliststylepage.cpp:448
-#: ../src/richtext/richtextliststylepage.cpp:460
-#: ../src/richtext/richtextliststylepage.cpp:461
 msgid "(none)"
 msgstr "(bez)"
 
@@ -902,7 +901,7 @@ msgstr "*)"
 msgid "+"
 msgstr "+"
 
-#: ../src/msw/utils.cpp:1152
+#: ../src/msw/utils.cpp:1143
 msgid ", 64-bit edition"
 msgstr ", 64-bitno izdanje"
 
@@ -911,163 +910,163 @@ msgstr ", 64-bitno izdanje"
 msgid "-"
 msgstr "-"
 
-#: ../src/generic/filepickerg.cpp:66
+#: ../src/generic/filepickerg.cpp:63
 msgid "..."
 msgstr "…"
 
-#: ../src/richtext/richtextindentspage.cpp:276
 #: ../src/richtext/richtextliststylepage.cpp:450
+#: ../src/richtext/richtextindentspage.cpp:276
 msgid "1.1"
 msgstr "1.1"
 
-#: ../src/richtext/richtextindentspage.cpp:277
 #: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextindentspage.cpp:277
 msgid "1.2"
 msgstr "1.2"
 
-#: ../src/richtext/richtextindentspage.cpp:278
 #: ../src/richtext/richtextliststylepage.cpp:452
+#: ../src/richtext/richtextindentspage.cpp:278
 msgid "1.3"
 msgstr "1.3"
 
-#: ../src/richtext/richtextindentspage.cpp:279
 #: ../src/richtext/richtextliststylepage.cpp:453
+#: ../src/richtext/richtextindentspage.cpp:279
 msgid "1.4"
 msgstr "1.4"
 
-#: ../src/richtext/richtextindentspage.cpp:280
 #: ../src/richtext/richtextliststylepage.cpp:454
+#: ../src/richtext/richtextindentspage.cpp:280
 msgid "1.5"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:281
 #: ../src/richtext/richtextliststylepage.cpp:455
+#: ../src/richtext/richtextindentspage.cpp:281
 msgid "1.6"
 msgstr "1.6"
 
-#: ../src/richtext/richtextindentspage.cpp:282
 #: ../src/richtext/richtextliststylepage.cpp:456
+#: ../src/richtext/richtextindentspage.cpp:282
 msgid "1.7"
 msgstr "1.7"
 
-#: ../src/richtext/richtextindentspage.cpp:283
 #: ../src/richtext/richtextliststylepage.cpp:457
+#: ../src/richtext/richtextindentspage.cpp:283
 msgid "1.8"
 msgstr "1.8"
 
-#: ../src/richtext/richtextindentspage.cpp:284
 #: ../src/richtext/richtextliststylepage.cpp:458
+#: ../src/richtext/richtextindentspage.cpp:284
 msgid "1.9"
 msgstr "1.9"
 
-#: ../src/common/paper.cpp:140
+#: ../src/common/paper.cpp:137
 msgid "10 x 11 in"
 msgstr "10 × 11 in"
 
-#: ../src/common/paper.cpp:113
+#: ../src/common/paper.cpp:110
 msgid "10 x 14 in"
 msgstr "10 × 14 in"
 
-#: ../src/common/paper.cpp:114
+#: ../src/common/paper.cpp:111
 msgid "11 x 17 in"
 msgstr "11 × 17 in"
 
-#: ../src/common/paper.cpp:184
+#: ../src/common/paper.cpp:181
 msgid "12 x 11 in"
 msgstr "12 × 11 in"
 
-#: ../src/common/paper.cpp:141
+#: ../src/common/paper.cpp:138
 msgid "15 x 11 in"
 msgstr "15 × 11 in"
 
-#: ../src/richtext/richtextindentspage.cpp:285
 #: ../src/richtext/richtextliststylepage.cpp:459
+#: ../src/richtext/richtextindentspage.cpp:285
 msgid "2"
 msgstr "2"
 
-#: ../src/common/paper.cpp:132
+#: ../src/common/paper.cpp:129
 msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
 msgstr "6 3/4 kuverta, 3 5/8 × 6 1/2 in"
 
-#: ../src/common/paper.cpp:139
+#: ../src/common/paper.cpp:136
 msgid "9 x 11 in"
 msgstr "9 × 11 in"
 
-#: ../src/html/htmprint.cpp:431
+#: ../src/html/htmprint.cpp:443
 msgid ": file does not exist!"
 msgstr ": datoteka ne postoji!"
 
-#: ../src/common/fontmap.cpp:199
+#: ../src/common/fontmap.cpp:196
 msgid ": unknown charset"
 msgstr ": nepoznata kodna stranica"
 
-#: ../src/common/fontmap.cpp:413
+#: ../src/common/fontmap.cpp:410
 msgid ": unknown encoding"
 msgstr ": nepoznato kodiranje"
 
-#: ../src/generic/wizard.cpp:443
+#: ../src/generic/wizard.cpp:438
 msgid "< &Back"
 msgstr "< &Natrag"
 
-#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:628
-#: ../src/osx/carbon/fontdlg.cpp:648
+#: ../src/osx/carbon/fontdlg.cpp:419 ../src/osx/carbon/fontdlg.cpp:625
+#: ../src/osx/carbon/fontdlg.cpp:645
 msgid "<Any Decorative>"
 msgstr "<Bilo koji dekorativni>"
 
-#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:630
-#: ../src/osx/carbon/fontdlg.cpp:650
+#: ../src/osx/carbon/fontdlg.cpp:420 ../src/osx/carbon/fontdlg.cpp:627
+#: ../src/osx/carbon/fontdlg.cpp:647
 msgid "<Any Modern>"
 msgstr "<Bilo koji moderni>"
 
-#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:626
-#: ../src/osx/carbon/fontdlg.cpp:646
+#: ../src/osx/carbon/fontdlg.cpp:418 ../src/osx/carbon/fontdlg.cpp:623
+#: ../src/osx/carbon/fontdlg.cpp:643
 msgid "<Any Roman>"
 msgstr "<Bilo koji serifni>"
 
-#: ../src/osx/carbon/fontdlg.cpp:424 ../src/osx/carbon/fontdlg.cpp:632
-#: ../src/osx/carbon/fontdlg.cpp:652
+#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:629
+#: ../src/osx/carbon/fontdlg.cpp:649
 msgid "<Any Script>"
 msgstr "<Bilo koji krasopisni>"
 
-#: ../src/osx/carbon/fontdlg.cpp:425 ../src/osx/carbon/fontdlg.cpp:637
-#: ../src/osx/carbon/fontdlg.cpp:656
+#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:634
+#: ../src/osx/carbon/fontdlg.cpp:653
 msgid "<Any Swiss>"
 msgstr "<Bilo koji bezserifni>"
 
-#: ../src/osx/carbon/fontdlg.cpp:426 ../src/osx/carbon/fontdlg.cpp:634
-#: ../src/osx/carbon/fontdlg.cpp:654
+#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:631
+#: ../src/osx/carbon/fontdlg.cpp:651
 msgid "<Any Teletype>"
 msgstr "<Bilo koji strojopisni>"
 
-#: ../src/osx/carbon/fontdlg.cpp:420
+#: ../src/osx/carbon/fontdlg.cpp:417
 msgid "<Any>"
 msgstr "<Bilo koji>"
 
-#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
 msgid "<DIR>"
 msgstr "<DIR>"
 
-#: ../src/generic/filectrlg.cpp:254 ../src/generic/filectrlg.cpp:277
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
 msgid "<DRIVE>"
 msgstr "<DRIVE>"
 
-#: ../src/generic/filectrlg.cpp:252 ../src/generic/filectrlg.cpp:275
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
 msgid "<LINK>"
 msgstr "<POVEZNICA>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1264
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Debeli kurziv.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1270
+#: ../src/html/helpwnd.cpp:1268
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>debeli kurziv <u>podcrtano</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1265
+#: ../src/html/helpwnd.cpp:1263
 msgid "<b>Bold face.</b> "
 msgstr "<b>Debeli.</b> "
 
-#: ../src/html/helpwnd.cpp:1264
+#: ../src/html/helpwnd.cpp:1262
 msgid "<i>Italic face.</i> "
 msgstr "<i>Kurziv.</i> "
 
@@ -1076,15 +1075,15 @@ msgstr "<i>Kurziv.</i> "
 msgid ">"
 msgstr ">"
 
-#: ../src/generic/dbgrptg.cpp:318
+#: ../src/generic/dbgrptg.cpp:317
 msgid "A debug report has been generated in the directory\n"
 msgstr "Izvještaj o otklanjanju grešaka je stvoren u mapi\n"
 
-#: ../src/common/debugrpt.cpp:573
+#: ../src/common/debugrpt.cpp:574
 msgid "A debug report has been generated. It can be found in"
 msgstr "Izvještaj o otklanjanju grešaka je stvoren. Nalazi se u"
 
-#: ../src/common/xtixml.cpp:418
+#: ../src/common/xtixml.cpp:414
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Ne prazna kolekcija mora sadržavati „element” čvorove"
 
@@ -1095,106 +1094,106 @@ msgstr "Ne prazna kolekcija mora sadržavati „element” čvorove"
 msgid "A standard bullet name."
 msgstr "Standardno ime znaka nabrajanja."
 
-#: ../src/common/paper.cpp:217
+#: ../src/common/paper.cpp:214
 msgid "A0 sheet, 841 x 1189 mm"
 msgstr "A0 arak, 841 × 1189 mm"
 
-#: ../src/common/paper.cpp:218
+#: ../src/common/paper.cpp:215
 msgid "A1 sheet, 594 x 841 mm"
 msgstr "A1 arak, 594 × 841 mm"
 
-#: ../src/common/paper.cpp:159
+#: ../src/common/paper.cpp:156
 msgid "A2 420 x 594 mm"
 msgstr "A2 420 × 594 mm"
 
-#: ../src/common/paper.cpp:156
+#: ../src/common/paper.cpp:153
 msgid "A3 Extra 322 x 445 mm"
 msgstr "A3 ekstra 322 × 445 mm"
 
-#: ../src/common/paper.cpp:161
+#: ../src/common/paper.cpp:158
 msgid "A3 Extra Transverse 322 x 445 mm"
 msgstr "A3 ekstra poprečno 322 × 445 mm"
 
-#: ../src/common/paper.cpp:170
+#: ../src/common/paper.cpp:167
 msgid "A3 Rotated 420 x 297 mm"
 msgstr "A3 rotirano 420 × 297 mm"
 
-#: ../src/common/paper.cpp:160
+#: ../src/common/paper.cpp:157
 msgid "A3 Transverse 297 x 420 mm"
 msgstr "A3 poprečno 297 × 420 mm"
 
-#: ../src/common/paper.cpp:106
+#: ../src/common/paper.cpp:103
 msgid "A3 sheet, 297 x 420 mm"
 msgstr "A3 sheet, 297 × 420 mm"
 
-#: ../src/common/paper.cpp:146
+#: ../src/common/paper.cpp:143
 msgid "A4 Extra 9.27 x 12.69 in"
 msgstr "A4 ekstra 9.27 × 12.69 in"
 
-#: ../src/common/paper.cpp:153
+#: ../src/common/paper.cpp:150
 msgid "A4 Plus 210 x 330 mm"
 msgstr "A4 plus 210 × 330 mm"
 
-#: ../src/common/paper.cpp:171
+#: ../src/common/paper.cpp:168
 msgid "A4 Rotated 297 x 210 mm"
 msgstr "A4 rotirano 297 × 210 mm"
 
-#: ../src/common/paper.cpp:148
+#: ../src/common/paper.cpp:145
 msgid "A4 Transverse 210 x 297 mm"
 msgstr "A4 poprečno 210 × 297 mm"
 
-#: ../src/common/paper.cpp:97
+#: ../src/common/paper.cpp:94
 msgid "A4 sheet, 210 x 297 mm"
 msgstr "A4 arak, 210 × 297 mm"
 
-#: ../src/common/paper.cpp:107
+#: ../src/common/paper.cpp:104
 msgid "A4 small sheet, 210 x 297 mm"
 msgstr "A4 mali arak, 210 × 297 mm"
 
-#: ../src/common/paper.cpp:157
+#: ../src/common/paper.cpp:154
 msgid "A5 Extra 174 x 235 mm"
 msgstr "A5 ekstra 174 × 235 mm"
 
-#: ../src/common/paper.cpp:172
+#: ../src/common/paper.cpp:169
 msgid "A5 Rotated 210 x 148 mm"
 msgstr "A5 rotirano 210 × 148 mm"
 
-#: ../src/common/paper.cpp:154
+#: ../src/common/paper.cpp:151
 msgid "A5 Transverse 148 x 210 mm"
 msgstr "A5 poprečno 148 × 210 mm"
 
-#: ../src/common/paper.cpp:108
+#: ../src/common/paper.cpp:105
 msgid "A5 sheet, 148 x 210 mm"
 msgstr "A5 arak, 148 × 210 mm"
 
-#: ../src/common/paper.cpp:164
+#: ../src/common/paper.cpp:161
 msgid "A6 105 x 148 mm"
 msgstr "A6 105 × 148 mm"
 
-#: ../src/common/paper.cpp:177
+#: ../src/common/paper.cpp:174
 msgid "A6 Rotated 148 x 105 mm"
 msgstr "A6 rotirano 148 × 105 mm"
 
-#: ../src/generic/fontdlgg.cpp:83 ../src/richtext/richtextformatdlg.cpp:529
-#: ../src/osx/carbon/fontdlg.cpp:153
+#: ../src/osx/carbon/fontdlg.cpp:150 ../src/generic/fontdlgg.cpp:79
+#: ../src/richtext/richtextformatdlg.cpp:521
 msgid "ABCDEFGabcdefg12345"
 msgstr "ABĆĐEŠGabčdežg12345"
 
-#: ../src/richtext/richtextsymboldlg.cpp:458 ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
 msgid "ASCII"
 msgstr "ASCII"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "About"
 msgstr "O programu"
 
-#: ../src/generic/aboutdlgg.cpp:140 ../src/osx/menu_osx.cpp:558
-#: ../src/msw/aboutdlg.cpp:64
+#: ../src/osx/menu_osx.cpp:450 ../src/generic/aboutdlgg.cpp:137
+#: ../src/msw/aboutdlg.cpp:61
 #, c-format
 msgid "About %s"
 msgstr "O programu %su"
 
-#: ../src/osx/menu_osx.cpp:560
+#: ../src/osx/menu_osx.cpp:452
 msgid "About..."
 msgstr "O programu …"
 
@@ -1203,37 +1202,37 @@ msgid "Absolute"
 msgstr "Apsolutno"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:873
+#: ../src/propgrid/advprops.cpp:774
 msgid "ActiveBorder"
 msgstr "Aktivni rub"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:874
+#: ../src/propgrid/advprops.cpp:775
 msgid "ActiveCaption"
 msgstr "Aktivni podnaslov"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "Actual Size"
 msgstr "Stvarna veličina"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:140 ../src/common/accelcmn.cpp:81
+#: ../src/common/stockitem.cpp:137 ../src/common/accelcmn.cpp:78
 msgid "Add"
 msgstr "Dodaj"
 
-#: ../src/richtext/richtextbuffer.cpp:11455
+#: ../src/richtext/richtextbuffer.cpp:11454
 msgid "Add Column"
 msgstr "Dodaj stupac"
 
-#: ../src/richtext/richtextbuffer.cpp:11392
+#: ../src/richtext/richtextbuffer.cpp:11391
 msgid "Add Row"
 msgstr "Dodaj red"
 
-#: ../src/html/helpwnd.cpp:432
+#: ../src/html/helpwnd.cpp:430
 msgid "Add current page to bookmarks"
 msgstr "Dodaj trenutačnu stranicu u knjižne oznake"
 
-#: ../src/generic/colrdlgg.cpp:366
+#: ../src/generic/colrdlgg.cpp:386
 msgid "Add to custom colours"
 msgstr "Dodaj proizvoljnu boju"
 
@@ -1245,12 +1244,12 @@ msgstr "AddToPropertyCollection je pozvano na generički pristupnik"
 msgid "AddToPropertyCollection called w/o valid adder"
 msgstr "AddToPropertyCollection je pozvano bez valjanog dodavača"
 
-#: ../src/html/helpctrl.cpp:159
+#: ../src/html/helpctrl.cpp:155
 #, c-format
 msgid "Adding book %s"
 msgstr "Dodavanje knjige %s"
 
-#: ../src/common/preferencescmn.cpp:43
+#: ../src/common/preferencescmn.cpp:40
 msgid "Advanced"
 msgstr "Napredno"
 
@@ -1258,11 +1257,11 @@ msgstr "Napredno"
 msgid "After a paragraph:"
 msgstr "Nakon odlomka:"
 
-#: ../src/common/stockitem.cpp:172
+#: ../src/common/stockitem.cpp:169
 msgid "Align Left"
 msgstr "Poravnaj u lijevo"
 
-#: ../src/common/stockitem.cpp:173
+#: ../src/common/stockitem.cpp:170
 msgid "Align Right"
 msgstr "Poravnaj u desno"
 
@@ -1270,40 +1269,40 @@ msgstr "Poravnaj u desno"
 msgid "Alignment"
 msgstr "Poravnanje"
 
-#: ../src/generic/prntdlgg.cpp:215
+#: ../src/generic/prntdlgg.cpp:208
 msgid "All"
 msgstr "Sve"
 
-#: ../src/generic/filectrlg.cpp:1197 ../src/common/fldlgcmn.cpp:107
+#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1186
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Sve datoteke (%s)|%s"
 
-#: ../include/wx/defs.h:2886
+#: ../include/wx/defs.h:2582
 msgid "All files (*)|*"
 msgstr "Sve datoteke (*)|*"
 
-#: ../include/wx/defs.h:2883
+#: ../include/wx/defs.h:2579
 msgid "All files (*.*)|*.*"
 msgstr "Sve datoteke (*.*)|*.*"
 
-#: ../src/richtext/richtextstyles.cpp:1061
+#: ../src/richtext/richtextstyles.cpp:1058
 msgid "All styles"
 msgstr "Svi stilovi"
 
-#: ../src/propgrid/manager.cpp:1528
+#: ../src/propgrid/manager.cpp:1544
 msgid "Alphabetic Mode"
 msgstr "Slovni modus"
 
-#: ../src/common/xtistrm.cpp:425
+#: ../src/common/xtistrm.cpp:422
 msgid "Already Registered Object passed to SetObjectClassInfo"
 msgstr "Već registrirani objekt je proslijeđen na SetObjectClassInfo"
 
-#: ../src/unix/dialup.cpp:353
+#: ../src/unix/dialup.cpp:352
 msgid "Already dialling ISP."
 msgstr "Već se bira ISP."
 
-#: ../src/common/accelcmn.cpp:331 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/accelcmn.cpp:345 ../src/univ/themes/win32.cpp:3753
 msgid "Alt+"
 msgstr "Alt+"
 
@@ -1312,34 +1311,34 @@ msgstr "Alt+"
 msgid "An optional corner radius for adding rounded corners."
 msgstr "Opcionalni polumjer kuta za dodavanje zaobljenih kutova."
 
-#: ../src/common/debugrpt.cpp:576
+#: ../src/common/debugrpt.cpp:577
 msgid "And includes the following files:\n"
 msgstr "I sadržava sljedeće datoteke:\n"
 
-#: ../src/generic/animateg.cpp:162
+#: ../src/generic/animateg.cpp:145
 #, c-format
 msgid "Animation file is not of type %ld."
 msgstr "Datoteka animacije nije vrste %ld."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:872
+#: ../src/propgrid/advprops.cpp:773
 msgid "AppWorkspace"
 msgstr "Radna površina aplikacije"
 
-#: ../src/generic/logg.cpp:1014
+#: ../src/generic/logg.cpp:1011
 #, c-format
 msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
 msgstr "Pridodaj log-zapis datoteci „%s” (odabirom [Ne] će biti prepisana)?"
 
-#: ../src/osx/menu_osx.cpp:577 ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:469 ../src/osx/menu_osx.cpp:477
 msgid "Application"
 msgstr "Aplikacija"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "Apply"
 msgstr "Primijeni"
 
-#: ../src/propgrid/advprops.cpp:1609
+#: ../src/propgrid/advprops.cpp:1515
 msgid "Aqua"
 msgstr "Plavkasta"
 
@@ -1348,29 +1347,29 @@ msgstr "Plavkasta"
 msgid "Arabic"
 msgstr "Arapski"
 
-#: ../src/common/fmapbase.cpp:153
+#: ../src/common/fmapbase.cpp:150
 msgid "Arabic (ISO-8859-6)"
 msgstr "Arapski (ISO-8859-6)"
 
-#: ../src/msw/ole/automtn.cpp:672
+#: ../src/msw/ole/automtn.cpp:663
 #, c-format
 msgid "Argument %u not found."
 msgstr "Argument %u nije nađen."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1753
+#: ../src/propgrid/advprops.cpp:1654
 msgid "Arrow"
 msgstr "Strelica"
 
-#: ../src/generic/aboutdlgg.cpp:184
+#: ../src/generic/aboutdlgg.cpp:181
 msgid "Artists"
 msgstr "Umjetnici"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "Ascending"
 msgstr "Uzlazno"
 
-#: ../src/generic/filectrlg.cpp:433
+#: ../src/generic/filectrlg.cpp:429
 msgid "Attributes"
 msgstr "Svojstva"
 
@@ -1380,90 +1379,90 @@ msgstr "Svojstva"
 msgid "Available fonts."
 msgstr "Dostupni fontovi."
 
-#: ../src/common/paper.cpp:137
+#: ../src/common/paper.cpp:134
 msgid "B4 (ISO) 250 x 353 mm"
 msgstr "B4 (ISO) 250 × 353 mm"
 
-#: ../src/common/paper.cpp:173
+#: ../src/common/paper.cpp:170
 msgid "B4 (JIS) Rotated 364 x 257 mm"
 msgstr "B4 (JIS) rotirano 364 × 257 mm"
 
-#: ../src/common/paper.cpp:127
+#: ../src/common/paper.cpp:124
 msgid "B4 Envelope, 250 x 353 mm"
 msgstr "B4 kuverta, 250 × 353 mm"
 
-#: ../src/common/paper.cpp:109
+#: ../src/common/paper.cpp:106
 msgid "B4 sheet, 250 x 354 mm"
 msgstr "B4 arak, 250 × 354 mm"
 
-#: ../src/common/paper.cpp:158
+#: ../src/common/paper.cpp:155
 msgid "B5 (ISO) Extra 201 x 276 mm"
 msgstr "B5 (ISO) ekstra 201 × 276 mm"
 
-#: ../src/common/paper.cpp:174
+#: ../src/common/paper.cpp:171
 msgid "B5 (JIS) Rotated 257 x 182 mm"
 msgstr "B5 (JIS) rotirano 257 × 182 mm"
 
-#: ../src/common/paper.cpp:155
+#: ../src/common/paper.cpp:152
 msgid "B5 (JIS) Transverse 182 x 257 mm"
 msgstr "B5 (JIS) poprečno 182 × 257 mm"
 
-#: ../src/common/paper.cpp:128
+#: ../src/common/paper.cpp:125
 msgid "B5 Envelope, 176 x 250 mm"
 msgstr "B5 kuverta, 176 × 250 mm"
 
-#: ../src/common/paper.cpp:110
+#: ../src/common/paper.cpp:107
 msgid "B5 sheet, 182 x 257 millimeter"
 msgstr "B5 arak, 182 × 257 millimeter"
 
-#: ../src/common/paper.cpp:182
+#: ../src/common/paper.cpp:179
 msgid "B6 (JIS) 128 x 182 mm"
 msgstr "B6 (JIS) 128 × 182 mm"
 
-#: ../src/common/paper.cpp:183
+#: ../src/common/paper.cpp:180
 msgid "B6 (JIS) Rotated 182 x 128 mm"
 msgstr "B6 (JIS) rotirano 182 × 128 mm"
 
-#: ../src/common/paper.cpp:129
+#: ../src/common/paper.cpp:126
 msgid "B6 Envelope, 176 x 125 mm"
 msgstr "B6 kuverta, 176 × 125 mm"
 
-#: ../src/common/imagbmp.cpp:531 ../src/common/imagbmp.cpp:561
-#: ../src/common/imagbmp.cpp:576
+#: ../src/common/imagbmp.cpp:528 ../src/common/imagbmp.cpp:558
+#: ../src/common/imagbmp.cpp:573
 msgid "BMP: Couldn't allocate memory."
 msgstr "BMP: Nije bilo moguće alocirati memoriju."
 
-#: ../src/common/imagbmp.cpp:100
+#: ../src/common/imagbmp.cpp:97
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: Nije bilo moguće spremiti nevaljanu sliku."
 
-#: ../src/common/imagbmp.cpp:356
+#: ../src/common/imagbmp.cpp:353
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: Nije bilo moguće zapisati RGB mapu boja."
 
-#: ../src/common/imagbmp.cpp:490
+#: ../src/common/imagbmp.cpp:487
 msgid "BMP: Couldn't write data."
 msgstr "BMP: Nije bilo moguće zapisati podatke."
 
-#: ../src/common/imagbmp.cpp:246
+#: ../src/common/imagbmp.cpp:243
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: Nije bilo moguće zapisati zaglavlje (bitmap) datoteke."
 
-#: ../src/common/imagbmp.cpp:269
+#: ../src/common/imagbmp.cpp:266
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: Nije bilo moguće zapisati zaglavlje (bitmapinfo) datoteke."
 
-#: ../src/common/imagbmp.cpp:140
+#: ../src/common/imagbmp.cpp:137
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage nema vlastitu wxPalette."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:142 ../src/common/accelcmn.cpp:52
+#: ../src/common/stockitem.cpp:139 ../src/common/accelcmn.cpp:49
 msgid "Back"
 msgstr "Natrag"
 
+#: ../src/richtext/richtextformatdlg.cpp:377
 #: ../src/richtext/richtextbackgroundpage.cpp:148
-#: ../src/richtext/richtextformatdlg.cpp:384
 msgid "Background"
 msgstr "Pozadina"
 
@@ -1471,20 +1470,20 @@ msgstr "Pozadina"
 msgid "Background &colour:"
 msgstr "&Boja pozadine:"
 
-#: ../src/osx/carbon/fontdlg.cpp:220
+#: ../src/osx/carbon/fontdlg.cpp:217
 msgid "Background colour"
 msgstr "Boja pozadine"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:52
+#: ../src/common/accelcmn.cpp:49
 msgid "Backspace"
 msgstr "Brisanje"
 
-#: ../src/common/fmapbase.cpp:160
+#: ../src/common/fmapbase.cpp:157
 msgid "Baltic (ISO-8859-13)"
 msgstr "Baltički (ISO-8859-13)"
 
-#: ../src/common/fmapbase.cpp:151
+#: ../src/common/fmapbase.cpp:148
 msgid "Baltic (old) (ISO-8859-4)"
 msgstr "Baltički (ISO-8859-4)"
 
@@ -1497,25 +1496,25 @@ msgstr "Prije odlomka:"
 msgid "Bitmap"
 msgstr "Bitmap"
 
-#: ../src/propgrid/advprops.cpp:1594
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Black"
 msgstr "Crna"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1755
+#: ../src/propgrid/advprops.cpp:1656
 msgid "Blank"
 msgstr "Prazno"
 
-#: ../src/propgrid/advprops.cpp:1603
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Blue"
 msgstr "Plava"
 
-#: ../src/generic/colrdlgg.cpp:345
+#: ../src/generic/colrdlgg.cpp:365
 msgid "Blue:"
 msgstr "Plava:"
 
-#: ../src/generic/fontdlgg.cpp:333 ../src/richtext/richtextfontpage.cpp:355
-#: ../src/osx/carbon/fontdlg.cpp:354 ../src/common/stockitem.cpp:143
+#: ../src/osx/carbon/fontdlg.cpp:351 ../src/common/stockitem.cpp:140
+#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:355
 msgid "Bold"
 msgstr "Debeli"
 
@@ -1524,31 +1523,35 @@ msgstr "Debeli"
 msgid "Border"
 msgstr "Obrub"
 
-#: ../src/richtext/richtextformatdlg.cpp:379
+#: ../src/richtext/richtextformatdlg.cpp:372
 msgid "Borders"
 msgstr "Obrubi"
 
-#: ../src/richtext/richtextsizepage.cpp:288 ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141 ../src/richtext/richtextsizepage.cpp:288
 msgid "Bottom"
 msgstr "Dolje"
 
-#: ../src/generic/prntdlgg.cpp:893
+#: ../src/generic/prntdlgg.cpp:886
 msgid "Bottom margin (mm):"
 msgstr "Donja margina (mm):"
 
-#: ../src/richtext/richtextbuffer.cpp:9383
+#: ../src/richtext/richtextbuffer.cpp:9380
 msgid "Box Properties"
 msgstr "Svojstva okvira"
 
-#: ../src/richtext/richtextstyles.cpp:1065
+#: ../src/richtext/richtextstyles.cpp:1062
 msgid "Box styles"
 msgstr "Stil okvira"
 
-#: ../src/propgrid/advprops.cpp:1602
+#: ../src/osx/cocoa/menu.mm:292
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Brown"
 msgstr "Smeđa"
 
-#: ../src/common/filepickercmn.cpp:43 ../src/common/filepickercmn.cpp:44
+#: ../src/common/filepickercmn.cpp:40 ../src/common/filepickercmn.cpp:41
 msgid "Browse"
 msgstr "Pregledaj"
 
@@ -1561,72 +1564,72 @@ msgstr "Poravnanje znaka nabrajanja:"
 msgid "Bullet style"
 msgstr "Stil znaka nabrajanja"
 
-#: ../src/richtext/richtextformatdlg.cpp:359
+#: ../src/richtext/richtextformatdlg.cpp:352
 msgid "Bullets"
 msgstr "Znakovi nabrajanja"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1756
+#: ../src/propgrid/advprops.cpp:1657
 msgid "Bullseye"
 msgstr "Meta"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:875
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonFace"
 msgstr "Ploha gumba"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:876
+#: ../src/propgrid/advprops.cpp:777
 msgid "ButtonHighlight"
 msgstr "Isticanje gumba"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:877
+#: ../src/propgrid/advprops.cpp:778
 msgid "ButtonShadow"
 msgstr "Sjena gumba"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:878
+#: ../src/propgrid/advprops.cpp:779
 msgid "ButtonText"
 msgstr "Tekst gumba"
 
-#: ../src/common/paper.cpp:98
+#: ../src/common/paper.cpp:95
 msgid "C sheet, 17 x 22 in"
 msgstr "C arak, 17 × 22 in"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "C&lear"
 msgstr "U&kloni"
 
-#: ../src/generic/fontdlgg.cpp:406
+#: ../src/generic/fontdlgg.cpp:403
 msgid "C&olour:"
 msgstr "B&oja:"
 
-#: ../src/common/paper.cpp:123
+#: ../src/common/paper.cpp:120
 msgid "C3 Envelope, 324 x 458 mm"
 msgstr "C3 kuverta, 324 × 458 mm"
 
-#: ../src/common/paper.cpp:124
+#: ../src/common/paper.cpp:121
 msgid "C4 Envelope, 229 x 324 mm"
 msgstr "C4 kuverta, 229 × 324 mm"
 
-#: ../src/common/paper.cpp:122
+#: ../src/common/paper.cpp:119
 msgid "C5 Envelope, 162 x 229 mm"
 msgstr "C5 kuverta, 162 × 229 mm"
 
-#: ../src/common/paper.cpp:125
+#: ../src/common/paper.cpp:122
 msgid "C6 Envelope, 114 x 162 mm"
 msgstr "C6 kuverta, 114 × 162 mm"
 
-#: ../src/common/paper.cpp:126
+#: ../src/common/paper.cpp:123
 msgid "C65 Envelope, 114 x 229 mm"
 msgstr "C65 kuverta, 114 × 229 mm"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "CD-Rom"
 msgstr "CD-Rom"
 
-#: ../src/html/chm.cpp:815 ../src/html/chm.cpp:874
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:865
 msgid "CHM handler currently supports only local files!"
 msgstr "CHM upravljač trenutačno podržava samo lokalne datoteke!"
 
@@ -1634,194 +1637,198 @@ msgstr "CHM upravljač trenutačno podržava samo lokalne datoteke!"
 msgid "Ca&pitals"
 msgstr "Velika s&lova"
 
-#: ../src/common/cmdproc.cpp:267
+#: ../src/common/cmdproc.cpp:260
 msgid "Can't &Undo "
 msgstr "&Poništavanje nije moguće "
 
-#: ../src/common/image.cpp:2824
+#: ../src/common/image.cpp:2924
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 "Nije moguće automatski odrediti format slike za unos, koji se ne može "
 "tražiti."
 
-#: ../src/msw/registry.cpp:506
+#: ../src/msw/registry.cpp:495
 #, c-format
 msgid "Can't close registry key '%s'"
 msgstr "Nije moguće zatvoriti registarski ključ „%s”"
 
-#: ../src/msw/registry.cpp:584
+#: ../src/msw/registry.cpp:573
 #, c-format
 msgid "Can't copy values of unsupported type %d."
 msgstr "Nije moguće kopirati vrijednosti nepodržane vrste %d."
 
-#: ../src/msw/registry.cpp:487
+#: ../src/msw/registry.cpp:476
 #, c-format
 msgid "Can't create registry key '%s'"
 msgstr "Nije moguće stvoriti registarski ključ „%s”"
 
-#: ../src/msw/thread.cpp:665
+#: ../src/msw/thread.cpp:657
 msgid "Can't create thread"
 msgstr "Nije moguće stvoriti tijek"
 
-#: ../src/msw/window.cpp:3691
-#, c-format
-msgid "Can't create window of class %s"
-msgstr "Nije moguće stvoriti prozor vrste %s"
-
-#: ../src/msw/registry.cpp:777
+#: ../src/msw/registry.cpp:765
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Nije moguće izbrisati ključ „%s”"
 
-#: ../src/msw/iniconf.cpp:458
+#: ../src/msw/iniconf.cpp:455
 #, c-format
 msgid "Can't delete the INI file '%s'"
 msgstr "Nije moguće izbrisati INI datoteku „%s”"
 
-#: ../src/msw/registry.cpp:805
+#: ../src/msw/registry.cpp:793
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Nije moguće izbrisati vrijednost „%s” ključa „%s”"
 
-#: ../src/msw/registry.cpp:1171
+#: ../src/msw/registry.cpp:1159
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Nije moguće numeriranje podključeva ključa „%s”"
 
-#: ../src/msw/registry.cpp:1132
+#: ../src/msw/registry.cpp:1120
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Nije moguće numeriranje vrijednosti ključa „%s”"
 
-#: ../src/msw/registry.cpp:1389
+#: ../src/msw/registry.cpp:1377
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Nije moguće izvesti vrijednost nepodržane vrste %d."
 
-#: ../src/common/ffile.cpp:254
+#: ../src/common/ffile.cpp:253
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Nije moguće naći trenutačni položaj u datoteci „%s”"
 
-#: ../src/msw/registry.cpp:418
+#: ../src/msw/registry.cpp:407
 #, c-format
 msgid "Can't get info about registry key '%s'"
 msgstr "Nije moguće dobiti informacije o ključu „%s”"
 
-#: ../src/common/zstream.cpp:346
+#: ../src/msw/webview_ie.cpp:1024
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "Nije moguće postaviti prioritet tijeka"
+
+#: ../src/common/zstream.cpp:343
 msgid "Can't initialize zlib deflate stream."
 msgstr "Nije moguće inicijalizirati zlib deflate tijek."
 
-#: ../src/common/zstream.cpp:185
+#: ../src/common/zstream.cpp:182
 msgid "Can't initialize zlib inflate stream."
 msgstr "Nije moguće inicijalizirati zlib inflate tijek."
 
-#: ../src/msw/fswatcher.cpp:476
+#: ../src/msw/fswatcher.cpp:475
 #, c-format
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "Nije moguće praćenje promjena za nepostojeći direktorij „%s”."
 
-#: ../src/msw/registry.cpp:454
+#: ../src/msw/registry.cpp:443
 #, c-format
 msgid "Can't open registry key '%s'"
 msgstr "Nije moguće otvoriti registarski ključ „%s”"
 
-#: ../src/common/zstream.cpp:252
+#: ../src/common/zstream.cpp:249
 #, c-format
 msgid "Can't read from inflate stream: %s"
 msgstr "Nije moguće čitati iz inflate tijeka: %s"
 
-#: ../src/common/zstream.cpp:244
+#: ../src/common/zstream.cpp:241
 msgid "Can't read inflate stream: unexpected EOF in underlying stream."
 msgstr ""
 "Nije moguće čitati iz inflate tijeka: neočekivani kraj datoteke u osnovnom "
 "tijeku."
 
-#: ../src/msw/registry.cpp:1064
+#: ../src/msw/registry.cpp:1052
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Nije moguće čitanje vrijednosti od „%s”"
 
-#: ../src/msw/registry.cpp:878 ../src/msw/registry.cpp:910
-#: ../src/msw/registry.cpp:975
+#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
+#: ../src/msw/registry.cpp:963
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Nije moguće čitanje vrijednosti od ključa „%s”"
 
-#: ../src/common/image.cpp:2620
+#: ../src/msw/webview_ie.cpp:1017
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/common/image.cpp:2715
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "Nije moguće spremanje slikovne datoteke „%s”: nepoznati sufiks."
 
-#: ../src/generic/logg.cpp:573 ../src/generic/logg.cpp:976
+#: ../src/generic/logg.cpp:570 ../src/generic/logg.cpp:973
 msgid "Can't save log contents to file."
 msgstr "Nije moguće spremiti log sadržaj u datoteku."
 
-#: ../src/msw/thread.cpp:629
+#: ../src/msw/thread.cpp:621
 msgid "Can't set thread priority"
 msgstr "Nije moguće postaviti prioritet tijeka"
 
-#: ../src/msw/registry.cpp:896 ../src/msw/registry.cpp:938
-#: ../src/msw/registry.cpp:1081
+#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
+#: ../src/msw/registry.cpp:1069
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Nije moguće postavljanje vrijednosti od „%s”"
 
-#: ../src/unix/utilsunx.cpp:351
+#: ../src/unix/utilsunx.cpp:353
 msgid "Can't write to child process's stdin"
 msgstr "Nije moguće pisanje u stdin podređenog procesa"
 
-#: ../src/common/zstream.cpp:427
+#: ../src/common/zstream.cpp:424
 #, c-format
 msgid "Can't write to deflate stream: %s"
 msgstr "Nije moguće pisati u deflate tijek: %s"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:279 ../src/richtext/richtextstyledlg.cpp:300
-#: ../src/common/stockitem.cpp:145 ../src/common/accelcmn.cpp:71
-#: ../src/msw/msgdlg.cpp:454 ../src/msw/progdlg.cpp:673
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:142
+#: ../src/common/accelcmn.cpp:68 ../src/motif/msgdlg.cpp:196
+#: ../src/gtk1/fontdlg.cpp:144 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/progdlg.cpp:940 ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Odustani"
 
-#: ../src/common/filefn.cpp:1261
+#: ../src/common/filefn.cpp:1149
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Nije moguće numerirati datoteke „%s”"
 
-#: ../src/msw/dir.cpp:263
+#: ../src/msw/dir.cpp:260
 #, c-format
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Nije moguće numerirati datoteke u mapi „%s”"
 
-#: ../src/msw/dialup.cpp:523
+#: ../src/msw/dialup.cpp:517
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Nije moguće naći aktivnu vezu pozivanja: %s"
 
-#: ../src/msw/dialup.cpp:827
+#: ../src/msw/dialup.cpp:821
 msgid "Cannot find the location of address book file"
 msgstr "Nije moguće naći mjesto datoteke adresara"
 
-#: ../src/msw/ole/automtn.cpp:562
+#: ../src/msw/ole/automtn.cpp:553
 #, c-format
 msgid "Cannot get an active instance of \"%s\""
 msgstr "Nije moguće dobiti aktivnu instancu „%s”"
 
-#: ../src/unix/threadpsx.cpp:1035
+#: ../src/unix/threadpsx.cpp:1053
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "Nije moguće dobiti raspon prioriteta za pravilo rasporeda %d."
 
-#: ../src/unix/utilsunx.cpp:987
+#: ../src/unix/utilsunx.cpp:989
 msgid "Cannot get the hostname"
 msgstr "Nije moguće dobiti ime hosta"
 
-#: ../src/unix/utilsunx.cpp:1023
+#: ../src/unix/utilsunx.cpp:1025
 msgid "Cannot get the official hostname"
 msgstr "Nije moguće dobiti službeno ime hosta"
 
-#: ../src/msw/dialup.cpp:928
+#: ../src/msw/dialup.cpp:922
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Nije moguće prekinuti poziv – nema aktivne veze pozivanja."
 
@@ -1829,126 +1836,126 @@ msgstr "Nije moguće prekinuti poziv – nema aktivne veze pozivanja."
 msgid "Cannot initialize OLE"
 msgstr "Nije moguće inicijalizirati OLE"
 
-#: ../src/common/socket.cpp:853
+#: ../src/common/socket.cpp:850
 msgid "Cannot initialize sockets"
 msgstr "Nije moguće inicijalizirati priključke"
 
-#: ../src/msw/volume.cpp:619
+#: ../src/msw/volume.cpp:627
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Nije moguće učitati ikone iz „%s”."
 
-#: ../src/xrc/xmlres.cpp:360
+#: ../src/xrc/xmlres.cpp:358
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Nije moguće učitati resurse iz „%s”."
 
-#: ../src/xrc/xmlres.cpp:742
+#: ../src/xrc/xmlres.cpp:740
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Nije moguće učitati resurse iz datoteke „%s”."
 
-#: ../src/html/htmlfilt.cpp:137
+#: ../src/html/htmlfilt.cpp:134
 #, c-format
 msgid "Cannot open HTML document: %s"
 msgstr "Nije moguće otvoriti HTML dokument: %s"
 
-#: ../src/html/helpdata.cpp:667
+#: ../src/html/helpdata.cpp:660
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Nije moguće otvoriti HTML knjigu pomoći: %s"
 
-#: ../src/html/helpdata.cpp:299
+#: ../src/html/helpdata.cpp:296
 #, c-format
 msgid "Cannot open contents file: %s"
 msgstr "Nije moguće otvoriti datoteku sadržaja: %s"
 
-#: ../src/generic/dcpsg.cpp:1667
+#: ../src/generic/dcpsg.cpp:1665
 msgid "Cannot open file for PostScript printing!"
 msgstr "Nije moguće otvoriti datoteku za ispis u PostScriptu!"
 
-#: ../src/html/helpdata.cpp:313
+#: ../src/html/helpdata.cpp:310
 #, c-format
 msgid "Cannot open index file: %s"
 msgstr "Nije moguće otvoriti datoteku indeksa: %s"
 
-#: ../src/xrc/xmlres.cpp:724
+#: ../src/xrc/xmlres.cpp:722
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Nije moguće otvoriti datoteku resursa „%s”."
 
-#: ../src/html/helpwnd.cpp:1534
+#: ../src/html/helpwnd.cpp:1532
 msgid "Cannot print empty page."
 msgstr "Nije moguće ispisati praznu stranicu."
 
-#: ../src/msw/volume.cpp:507
+#: ../src/msw/volume.cpp:515
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Nije moguće čitati ime vrste od „%s”!"
 
-#: ../src/msw/thread.cpp:888
+#: ../src/msw/thread.cpp:894
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Nije moguće nastaviti tijek %lx"
 
-#: ../src/unix/threadpsx.cpp:1016
+#: ../src/unix/threadpsx.cpp:1028
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Nije moguće pronaći pravila rasporeda tijeka."
 
-#: ../src/common/intl.cpp:558
+#: ../src/common/intl.cpp:365
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "Nije moguće postaviti lokalizaciju za „%s” jezik."
 
-#: ../src/unix/threadpsx.cpp:831 ../src/msw/thread.cpp:546
+#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
 msgid "Cannot start thread: error writing TLS."
 msgstr "Nije moguće započeti tijek: greška prilikom pisanja TLS."
 
-#: ../src/msw/thread.cpp:872
+#: ../src/msw/thread.cpp:864
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Nije moguće obustaviti tijek %lx"
 
-#: ../src/msw/thread.cpp:794
+#: ../src/msw/thread.cpp:786
 msgid "Cannot wait for thread termination"
 msgstr "Nije moguće čekati na prekid tijeka"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:75
+#: ../src/common/accelcmn.cpp:72
 msgid "Capital"
 msgstr "Verzali"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:879
+#: ../src/propgrid/advprops.cpp:780
 msgid "CaptionText"
 msgstr "Tekst podnaslova"
 
-#: ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:531
 msgid "Case sensitive"
 msgstr "Razlikovanje veličine slova"
 
-#: ../src/propgrid/manager.cpp:1509
+#: ../src/propgrid/manager.cpp:1527
 msgid "Categorized Mode"
 msgstr "Modus kategorizacije"
 
-#: ../src/richtext/richtextbuffer.cpp:9968
+#: ../src/richtext/richtextbuffer.cpp:9965
 msgid "Cell Properties"
 msgstr "Svojstva ćelije"
 
-#: ../src/common/fmapbase.cpp:161
+#: ../src/common/fmapbase.cpp:158
 msgid "Celtic (ISO-8859-14)"
 msgstr "Keltski (ISO-8859-14)"
 
-#: ../src/richtext/richtextindentspage.cpp:160
 #: ../src/richtext/richtextliststylepage.cpp:349
+#: ../src/richtext/richtextindentspage.cpp:160
 msgid "Cen&tred"
 msgstr "Cen&trirano"
 
-#: ../src/common/stockitem.cpp:170
+#: ../src/common/stockitem.cpp:167
 msgid "Centered"
 msgstr "Centrirano"
 
-#: ../src/common/fmapbase.cpp:149
+#: ../src/common/fmapbase.cpp:146
 msgid "Central European (ISO-8859-2)"
 msgstr "Srednjeeuropski (ISO-8859-2)"
 
@@ -1957,10 +1964,10 @@ msgstr "Srednjeeuropski (ISO-8859-2)"
 msgid "Centre"
 msgstr "Centriraj"
 
-#: ../src/richtext/richtextindentspage.cpp:162
-#: ../src/richtext/richtextindentspage.cpp:164
 #: ../src/richtext/richtextliststylepage.cpp:351
 #: ../src/richtext/richtextliststylepage.cpp:353
+#: ../src/richtext/richtextindentspage.cpp:162
+#: ../src/richtext/richtextindentspage.cpp:164
 msgid "Centre text."
 msgstr "Centriraj tekst."
 
@@ -1973,24 +1980,24 @@ msgstr "Centrirano"
 msgid "Ch&oose..."
 msgstr "O&daberi …"
 
-#: ../src/richtext/richtextbuffer.cpp:4354
+#: ../src/richtext/richtextbuffer.cpp:4351
 msgid "Change List Style"
 msgstr "Promijeni stil popisa"
 
-#: ../src/richtext/richtextbuffer.cpp:3709
+#: ../src/richtext/richtextbuffer.cpp:3706
 msgid "Change Object Style"
 msgstr "Promijeni stil objekta"
 
-#: ../src/richtext/richtextbuffer.cpp:3982
-#: ../src/richtext/richtextbuffer.cpp:8129
+#: ../src/richtext/richtextbuffer.cpp:3979
+#: ../src/richtext/richtextbuffer.cpp:8125
 msgid "Change Properties"
 msgstr "Promijeni svojstva"
 
-#: ../src/richtext/richtextbuffer.cpp:3526
+#: ../src/richtext/richtextbuffer.cpp:3523
 msgid "Change Style"
 msgstr "Promijeni stil"
 
-#: ../src/common/fileconf.cpp:341
+#: ../src/common/fileconf.cpp:335
 #, c-format
 msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
 msgstr ""
@@ -2003,11 +2010,11 @@ msgid "Changing current directory to \"%s\" failed"
 msgstr "Mijenjanje trenutačne mape u „%s”"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1757
+#: ../src/propgrid/advprops.cpp:1658
 msgid "Character"
 msgstr "Slovni znak"
 
-#: ../src/richtext/richtextstyles.cpp:1063
+#: ../src/richtext/richtextstyles.cpp:1060
 msgid "Character styles"
 msgstr "Stilovi slovnih znakova"
 
@@ -2044,20 +2051,20 @@ msgstr "Aktiviraj za postavljanje znaka za nabrajanje između zagrada."
 msgid "Check to indicate right-to-left text layout."
 msgstr "Aktiviraj za određivanje smjera teksta s desna nalijevo."
 
-#: ../src/osx/carbon/fontdlg.cpp:356 ../src/osx/carbon/fontdlg.cpp:358
+#: ../src/osx/carbon/fontdlg.cpp:353 ../src/osx/carbon/fontdlg.cpp:355
 msgid "Check to make the font bold."
 msgstr "Aktiviraj za korištenje debelog fonta."
 
-#: ../src/osx/carbon/fontdlg.cpp:363 ../src/osx/carbon/fontdlg.cpp:365
+#: ../src/osx/carbon/fontdlg.cpp:360 ../src/osx/carbon/fontdlg.cpp:362
 msgid "Check to make the font italic."
 msgstr "Aktiviraj za korištenje kurzivnog fonta."
 
-#: ../src/osx/carbon/fontdlg.cpp:372 ../src/osx/carbon/fontdlg.cpp:374
+#: ../src/osx/carbon/fontdlg.cpp:369 ../src/osx/carbon/fontdlg.cpp:371
 msgid "Check to make the font underlined."
 msgstr "Aktiviraj za korištenje podcrtanog fonta."
 
-#: ../src/richtext/richtextstyledlg.cpp:289
-#: ../src/richtext/richtextstyledlg.cpp:291
+#: ../src/richtext/richtextstyledlg.cpp:285
+#: ../src/richtext/richtextstyledlg.cpp:287
 msgid "Check to restart numbering."
 msgstr "Aktiviraj za ponovo numeriranje."
 
@@ -2091,51 +2098,51 @@ msgstr "Aktiviraj za prikaz teksta spušteno."
 msgid "Check to suppress hyphenation."
 msgstr "Aktiviraj za izostavljanje rastavljanja riječi."
 
-#: ../src/msw/dialup.cpp:763
+#: ../src/msw/dialup.cpp:757
 msgid "Choose ISP to dial"
 msgstr "Odaberi ISP za biranje"
 
-#: ../src/propgrid/props.cpp:1922
+#: ../src/propgrid/props.cpp:1904
 msgid "Choose a directory:"
 msgstr "Odaberi mapu:"
 
-#: ../src/propgrid/props.cpp:1975
+#: ../src/propgrid/props.cpp:2199
 msgid "Choose a file"
 msgstr "Odaberi datoteku"
 
-#: ../src/generic/colrdlgg.cpp:158 ../src/gtk/colordlg.cpp:54
+#: ../src/generic/colrdlgg.cpp:156 ../src/gtk/colordlg.cpp:49
 msgid "Choose colour"
 msgstr "Odaberi boju"
 
-#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/gtk1/fontdlg.cpp:125 ../src/generic/fontpickerg.cpp:47
+#: ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Odaberi font"
 
-#: ../src/common/module.cpp:74
+#: ../src/common/module.cpp:71
 #, c-format
 msgid "Circular dependency involving module \"%s\" detected."
 msgstr "Ustanovljena je beskonačna ovisnost u modulu „%s”."
 
-#: ../src/aui/tabmdi.cpp:108 ../src/generic/mdig.cpp:97
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
 msgid "Cl&ose"
 msgstr "Zatv&ori"
 
-#: ../src/msw/ole/automtn.cpp:684
+#: ../src/msw/ole/automtn.cpp:675
 msgid "Class not registered."
 msgstr "Klasa nije registrirana."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:147 ../src/common/accelcmn.cpp:72
+#: ../src/common/stockitem.cpp:144 ../src/common/accelcmn.cpp:69
 msgid "Clear"
 msgstr "Izbriši"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "Clear the log contents"
 msgstr "Očisti log sadržaj"
 
-#: ../src/richtext/richtextstyledlg.cpp:252
-#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:248
+#: ../src/richtext/richtextstyledlg.cpp:250
 msgid "Click to apply the selected style."
 msgstr "Klikni za primjenu stila."
 
@@ -2146,15 +2153,15 @@ msgstr "Klikni za primjenu stila."
 msgid "Click to browse for a symbol."
 msgstr "Klikni za potragu za simbolom."
 
-#: ../src/osx/carbon/fontdlg.cpp:403 ../src/osx/carbon/fontdlg.cpp:405
+#: ../src/osx/carbon/fontdlg.cpp:400 ../src/osx/carbon/fontdlg.cpp:402
 msgid "Click to cancel changes to the font."
 msgstr "Klikni za odustajanje od fontovskih izmjena."
 
-#: ../src/generic/fontdlgg.cpp:472 ../src/generic/fontdlgg.cpp:491
+#: ../src/generic/fontdlgg.cpp:468 ../src/generic/fontdlgg.cpp:487
 msgid "Click to cancel the font selection."
 msgstr "Klikni za odustajanje od odabira fonta."
 
-#: ../src/osx/carbon/fontdlg.cpp:384 ../src/osx/carbon/fontdlg.cpp:386
+#: ../src/osx/carbon/fontdlg.cpp:381 ../src/osx/carbon/fontdlg.cpp:383
 msgid "Click to change the font colour."
 msgstr "Klikni za promjenu boje fonta."
 
@@ -2173,37 +2180,37 @@ msgstr "Klikni za promjenu boje teksta."
 msgid "Click to choose the font for this level."
 msgstr "Klikni za odabir fonta za ovu razinu."
 
-#: ../src/richtext/richtextstyledlg.cpp:279
-#: ../src/richtext/richtextstyledlg.cpp:281
+#: ../src/richtext/richtextstyledlg.cpp:275
+#: ../src/richtext/richtextstyledlg.cpp:277
 msgid "Click to close this window."
 msgstr "Klikni za zatvaranje ovog prozora."
 
-#: ../src/osx/carbon/fontdlg.cpp:410 ../src/osx/carbon/fontdlg.cpp:412
+#: ../src/osx/carbon/fontdlg.cpp:407 ../src/osx/carbon/fontdlg.cpp:409
 msgid "Click to confirm changes to the font."
 msgstr "Klikni za potvrdu fontovske promjene."
 
-#: ../src/generic/fontdlgg.cpp:477 ../src/generic/fontdlgg.cpp:479
-#: ../src/generic/fontdlgg.cpp:484 ../src/generic/fontdlgg.cpp:486
+#: ../src/generic/fontdlgg.cpp:473 ../src/generic/fontdlgg.cpp:475
+#: ../src/generic/fontdlgg.cpp:480 ../src/generic/fontdlgg.cpp:482
 msgid "Click to confirm the font selection."
 msgstr "Klikni za potvrdu odabira fonta."
 
-#: ../src/richtext/richtextstyledlg.cpp:244
-#: ../src/richtext/richtextstyledlg.cpp:246
+#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:242
 msgid "Click to create a new box style."
 msgstr "Klikni za stvaranje novog stila okvira."
 
-#: ../src/richtext/richtextstyledlg.cpp:226
-#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:224
 msgid "Click to create a new character style."
 msgstr "Klikni za stvaranje novog stila slovnih znakova."
 
-#: ../src/richtext/richtextstyledlg.cpp:238
-#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:236
 msgid "Click to create a new list style."
 msgstr "Klikni za stvaranje novog stila popisa."
 
-#: ../src/richtext/richtextstyledlg.cpp:232
-#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:230
 msgid "Click to create a new paragraph style."
 msgstr "Klikni za stvaranje novog stila odlomka."
 
@@ -2217,8 +2224,8 @@ msgstr "Klikni za stvaranje novog tabulatora."
 msgid "Click to delete all tab positions."
 msgstr "Klikni za uklanjanje svih tabulatora."
 
-#: ../src/richtext/richtextstyledlg.cpp:270
-#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:268
 msgid "Click to delete the selected style."
 msgstr "Klikni za uklanjanje odabranog stila."
 
@@ -2227,25 +2234,25 @@ msgstr "Klikni za uklanjanje odabranog stila."
 msgid "Click to delete the selected tab position."
 msgstr "Klikni za uklanjanje odabranog tabulatora."
 
-#: ../src/richtext/richtextstyledlg.cpp:264
-#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:262
 msgid "Click to edit the selected style."
 msgstr "Klikni za uređivanje odabranog stila."
 
-#: ../src/richtext/richtextstyledlg.cpp:258
-#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:256
 msgid "Click to rename the selected style."
 msgstr "Klikni za preimenovanje odabranog stila."
 
-#: ../src/generic/dbgrptg.cpp:97 ../src/generic/progdlgg.cpp:759
-#: ../src/richtext/richtextstyledlg.cpp:277
-#: ../src/richtext/richtextsymboldlg.cpp:476 ../src/common/stockitem.cpp:148
-#: ../src/msw/progdlg.cpp:170 ../src/msw/progdlg.cpp:679
-#: ../src/html/helpdlg.cpp:90
+#: ../src/common/stockitem.cpp:145 ../src/generic/dbgrptg.cpp:94
+#: ../src/generic/progdlgg.cpp:781 ../src/msw/progdlg.cpp:211
+#: ../src/msw/progdlg.cpp:946 ../src/html/helpdlg.cpp:87
+#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextstyledlg.cpp:273
 msgid "Close"
 msgstr "Zatvori"
 
-#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:98
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
 msgid "Close All"
 msgstr "Zatvori sve"
 
@@ -2253,43 +2260,43 @@ msgstr "Zatvori sve"
 msgid "Close current document"
 msgstr "Zatvori trenutačni dokument"
 
-#: ../src/generic/logg.cpp:516
+#: ../src/generic/logg.cpp:513
 msgid "Close this window"
 msgstr "Zatvori ovaj prozor"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6006
+#: ../src/generic/datavgen.cpp:6811
 msgid "Collapse"
 msgstr "Sažmi"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "Color"
 msgstr "Boja"
 
-#: ../src/richtext/richtextformatdlg.cpp:776
+#: ../src/richtext/richtextformatdlg.cpp:768
 msgid "Colour"
 msgstr "Boja"
 
-#: ../src/msw/colordlg.cpp:158
+#: ../src/msw/colordlg.cpp:227
 #, c-format
 msgid "Colour selection dialog failed with error %0lx."
 msgstr "Dijalog za boju odabira nije uspjeo, zbog greške %0lx."
 
-#: ../src/osx/carbon/fontdlg.cpp:380
+#: ../src/osx/carbon/fontdlg.cpp:377
 msgid "Colour:"
 msgstr "Boja:"
 
-#: ../src/generic/datavgen.cpp:6077
+#: ../src/generic/datavgen.cpp:6882
 #, c-format
 msgid "Column %u"
 msgstr "Stupac %u"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:114
+#: ../src/common/accelcmn.cpp:112
 msgid "Command"
 msgstr "Naredba"
 
-#: ../src/common/init.cpp:196
+#: ../src/common/init.cpp:193
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
@@ -2298,12 +2305,12 @@ msgstr ""
 "Argument naredbenog retka %d nije bilo moguće konvertirati u Unicode i bit "
 "će zanemaren."
 
-#: ../src/msw/fontdlg.cpp:120
+#: ../src/msw/fontdlg.cpp:170
 #, c-format
 msgid "Common dialog failed with error code %0lx."
 msgstr "Uobičajeni dijalog nije uspjeo, sa šifrom greške %0lx."
 
-#: ../src/gtk/window.cpp:4649
+#: ../src/gtk/window.cpp:5653
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
@@ -2311,11 +2318,11 @@ msgstr ""
 "Dijeljenje nije podržano u ovom sustavu. Aktiviraj ga u tvom upravljaču "
 "prozora."
 
-#: ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:1549
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Komprimirana HTML datoteka pomoći (*.chm)|*.chm|"
 
-#: ../src/generic/dirctrlg.cpp:444
+#: ../src/generic/dirctrlg.cpp:410
 msgid "Computer"
 msgstr "Računalo"
 
@@ -2324,53 +2331,57 @@ msgstr "Računalo"
 msgid "Config entry name cannot start with '%c'."
 msgstr "Konfiguracijsko ulazno ime ne može početi s „%c”."
 
-#: ../src/generic/filedlgg.cpp:349 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
 msgid "Confirm"
 msgstr "Potvrdi"
 
-#: ../src/html/htmlwin.cpp:566
+#: ../src/html/htmlwin.cpp:569
 msgid "Connecting..."
 msgstr "Spajanje …"
 
-#: ../src/html/helpwnd.cpp:475
+#: ../src/html/helpwnd.cpp:473
 msgid "Contents"
 msgstr "Sadržaj"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:880
+#: ../src/propgrid/advprops.cpp:781
 msgid "ControlDark"
 msgstr "Upravljač tamno"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:881
+#: ../src/propgrid/advprops.cpp:782
 msgid "ControlLight"
 msgstr "Upravljač svjetlo"
 
-#: ../src/common/strconv.cpp:2262
+#: ../src/common/strconv.cpp:2208
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Konverzija u kodnu stranicu „%s” ne radi."
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "Convert"
 msgstr "Pretvori"
 
-#: ../src/html/htmlwin.cpp:1079
+#: ../src/html/htmlwin.cpp:1020
 #, c-format
 msgid "Copied to clipboard:\"%s\""
 msgstr "Kopirano u međuspremnik:„%s”"
 
-#: ../src/generic/prntdlgg.cpp:247
+#: ../src/generic/prntdlgg.cpp:240
 msgid "Copies:"
 msgstr "Kopije:"
 
-#: ../src/common/stockitem.cpp:150 ../src/stc/stc_i18n.cpp:18
+#: ../src/common/stockitem.cpp:147 ../src/stc/stc_i18n.cpp:18
 msgid "Copy"
 msgstr "Kopiraj"
 
-#: ../src/common/stockitem.cpp:258
+#: ../src/common/stockitem.cpp:255
 msgid "Copy selection"
 msgstr "Kopiraj odabir"
+
+#: ../src/generic/grid.cpp:5945
+msgid "Copying more than one selected block to clipboard is not supported."
+msgstr ""
 
 #: ../src/richtext/richtextborderspage.cpp:566
 #: ../src/richtext/richtextborderspage.cpp:601
@@ -2381,196 +2392,193 @@ msgstr "Kut"
 msgid "Corner &radius:"
 msgstr "Polumjer kuta:"
 
-#: ../src/html/chm.cpp:718
+#: ../src/html/chm.cpp:711
 #, c-format
 msgid "Could not create temporary file '%s'"
 msgstr "Nije bilo moguće stvoriti privremenu datoteku „%s”"
 
-#: ../src/html/chm.cpp:273
+#: ../src/html/chm.cpp:270
 #, c-format
 msgid "Could not extract %s into %s: %s"
 msgstr "Nije bilo moguće izdvojiti %s u %s: %s"
 
-#: ../src/generic/tabg.cpp:1048
+#: ../src/generic/tabg.cpp:1045
 msgid "Could not find tab for id"
 msgstr "Nije bilo moguće naći karticu za id"
 
-#: ../src/gtk/notifmsg.cpp:108
-msgid "Could not initalize libnotify."
-msgstr "Nije bilo moguće inicijalizirati libnotify."
-
-#: ../src/html/chm.cpp:444
+#: ../src/html/chm.cpp:437
 #, c-format
 msgid "Could not locate file '%s'."
 msgstr "Nije bilo moguće pronaći datoteku „%s”."
 
-#: ../src/common/filefn.cpp:1403
+#: ../src/msw/graphicsd2d.cpp:604
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/common/filefn.cpp:1291
 msgid "Could not set current working directory"
 msgstr "Nije bilo moguće postaviti trenutačno radnu mapu"
 
-#: ../src/common/prntbase.cpp:2015
+#: ../src/common/prntbase.cpp:2037
 msgid "Could not start document preview."
 msgstr "Nije bilo moguće započeti pregled dokumenta."
 
-#: ../src/generic/printps.cpp:178 ../src/msw/printwin.cpp:210
-#: ../src/gtk/print.cpp:1132
+#: ../src/generic/printps.cpp:159 ../src/msw/printwin.cpp:184
+#: ../src/gtk/print.cpp:1129
 msgid "Could not start printing."
 msgstr "Nije bilo moguće započeti ispis."
 
-#: ../src/common/wincmn.cpp:2125
+#: ../src/common/wincmn.cpp:2126
 msgid "Could not transfer data to window"
 msgstr "Nije bilo moguće prebaciti podatke u prozor"
 
-#: ../src/msw/imaglist.cpp:187 ../src/msw/imaglist.cpp:224
-#: ../src/msw/imaglist.cpp:249 ../src/msw/dragimag.cpp:185
-#: ../src/msw/dragimag.cpp:220
+#: ../src/msw/imaglist.cpp:223 ../src/msw/imaglist.cpp:245
+#: ../src/msw/imaglist.cpp:270 ../src/msw/dragimag.cpp:182
+#: ../src/msw/dragimag.cpp:217
 msgid "Couldn't add an image to the image list."
 msgstr "Nije bilo moguće dodati sliku u popis slika."
 
-#: ../src/osx/glcanvas_osx.cpp:414 ../src/unix/glx11.cpp:558
-#: ../src/msw/glcanvas.cpp:616
+#: ../src/osx/glcanvas_osx.cpp:411 ../src/msw/glcanvas.cpp:631
+#: ../src/unix/glegl.cpp:315 ../src/unix/glx11.cpp:559
 msgid "Couldn't create OpenGL context"
 msgstr "Nije bilo moguće stvoriti OpenGL sadržaj"
 
-#: ../src/msw/timer.cpp:134
+#: ../src/msw/timer.cpp:131
 msgid "Couldn't create a timer"
 msgstr "Nije bilo moguće stvoriti brojač vremena"
 
-#: ../src/osx/carbon/overlay.cpp:122
-msgid "Couldn't create the overlay window"
-msgstr "Nije bilo moguće stvoriti pokrivni prozor"
-
-#: ../src/common/translation.cpp:2024
+#: ../src/common/translation.cpp:2074
 msgid "Couldn't enumerate translations"
 msgstr "Nije bilo moguće numerirati prijevode"
 
-#: ../src/common/dynlib.cpp:120
+#: ../src/common/dynlib.cpp:110
 #, c-format
 msgid "Couldn't find symbol '%s' in a dynamic library"
 msgstr "Nije bilo moguće naći simbol „%s” u dinamičkoj biblioteci"
 
-#: ../src/msw/thread.cpp:915
+#: ../src/msw/thread.cpp:921
 msgid "Couldn't get the current thread pointer"
 msgstr "Nije bilo moguće dobiti trenutačni označivač tijeka"
 
-#: ../src/osx/carbon/overlay.cpp:129
-msgid "Couldn't init the context on the overlay window"
-msgstr "Nije bilo moguće initijalizirati sadržaj pokrivnog prozora"
-
-#: ../src/common/imaggif.cpp:244
+#: ../src/common/imaggif.cpp:241
 msgid "Couldn't initialize GIF hash table."
 msgstr "Nije bilo moguće initijalizirati GIF hash tablicu."
 
-#: ../src/common/imagpng.cpp:409
+#: ../src/common/imagpng.cpp:437
 msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
 msgstr ""
 "Nije bilo moguće učitati PNG sliku – datoteka je pokvarena ili nema dovoljno "
 "memorije."
 
-#: ../src/unix/sound.cpp:470
+#: ../src/unix/sound.cpp:459
 #, c-format
 msgid "Couldn't load sound data from '%s'."
 msgstr "Nije bilo moguće učitati zvukovne podatke od „%s”."
 
-#: ../src/msw/dirdlg.cpp:435
+#: ../src/msw/dirdlg.cpp:287
 msgid "Couldn't obtain folder name"
 msgstr "Nije bilo moguće dobiti ime mape"
 
-#: ../src/unix/sound_sdl.cpp:229
+#: ../src/unix/sound_sdl.cpp:226
 #, c-format
 msgid "Couldn't open audio: %s"
 msgstr "Nije bilo moguće otvoriti audio: %s"
 
-#: ../src/msw/ole/dataobj.cpp:377
+#: ../src/msw/ole/dataobj.cpp:385
 #, c-format
 msgid "Couldn't register clipboard format '%s'."
 msgstr "Nije bilo moguće registrirati format međuspremnika „%s”."
 
-#: ../src/msw/listctrl.cpp:869
+#: ../src/msw/listctrl.cpp:933
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "Nije bilo moguće pronaći informacije o kontrolnoj stavci popisa %d."
 
-#: ../src/common/imagpng.cpp:498 ../src/common/imagpng.cpp:509
-#: ../src/common/imagpng.cpp:519
+#: ../src/common/imagpng.cpp:511 ../src/common/imagpng.cpp:522
+#: ../src/common/imagpng.cpp:532
 msgid "Couldn't save PNG image."
 msgstr "Nije bilo moguće spremiti PNG sliku."
 
-#: ../src/msw/thread.cpp:684
+#: ../src/msw/thread.cpp:676
 msgid "Couldn't terminate thread"
 msgstr "Nije bilo moguće završiti tijek"
 
-#: ../src/common/xtistrm.cpp:166
+#: ../src/common/xtistrm.cpp:163
 #, c-format
 msgid "Create Parameter %s not found in declared RTTI Parameters"
 msgstr "Parametar za stvaranje %s, nije nađen u prijavljenim RTTI parametrima"
 
-#: ../src/generic/dirdlgg.cpp:288
+#: ../src/generic/dirdlgg.cpp:285
 msgid "Create directory"
 msgstr "Stvori mapu"
 
-#: ../src/generic/filedlgg.cpp:212 ../src/generic/dirdlgg.cpp:111
+#: ../src/generic/filedlgg.cpp:209 ../src/generic/dirdlgg.cpp:108
 msgid "Create new directory"
 msgstr "Stvori novu mapu"
 
-#: ../src/xrc/xmlres.cpp:2460
+#: ../src/common/stockitem.cpp:264
+#, fuzzy
+msgid "Create new document"
+msgstr "Stvori novu mapu"
+
+#: ../src/xrc/xmlres.cpp:2515
 #, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Stvaranje %s „%s” nije uspjelo."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1758
+#: ../src/propgrid/advprops.cpp:1659
 msgid "Cross"
 msgstr "Križić"
 
-#: ../src/common/accelcmn.cpp:333
+#: ../src/common/accelcmn.cpp:347
 msgid "Ctrl+"
 msgstr "Ctrl+"
 
-#: ../src/richtext/richtextctrl.cpp:332 ../src/osx/textctrl_osx.cpp:576
-#: ../src/common/stockitem.cpp:151 ../src/msw/textctrl.cpp:2507
+#: ../src/osx/textctrl_osx.cpp:594 ../src/common/stockitem.cpp:148
+#: ../src/msw/textctrl.cpp:2772 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "Izr&eži"
 
-#: ../src/generic/filectrlg.cpp:940
+#: ../src/generic/filectrlg.cpp:936
 msgid "Current directory:"
 msgstr "Trenutačna mapa:"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:896 ../src/propgrid/advprops.cpp:1574
-#: ../src/propgrid/advprops.cpp:1612
+#: ../src/propgrid/advprops.cpp:797 ../src/propgrid/advprops.cpp:1475
+#: ../src/propgrid/advprops.cpp:1518
 msgid "Custom"
 msgstr "Prilagođeno"
 
-#: ../src/gtk/print.cpp:217
+#: ../src/gtk/print.cpp:211
 msgid "Custom size"
 msgstr "Prilagođena veličina"
 
-#: ../src/common/headerctrlcmn.cpp:60
+#: ../src/common/headerctrlcmn.cpp:58
 msgid "Customize Columns"
 msgstr "Prilagodi stupce"
 
-#: ../src/common/stockitem.cpp:151 ../src/stc/stc_i18n.cpp:17
+#: ../src/common/stockitem.cpp:148 ../src/stc/stc_i18n.cpp:17
 msgid "Cut"
 msgstr "Izreži"
 
-#: ../src/common/stockitem.cpp:259
+#: ../src/common/stockitem.cpp:256
 msgid "Cut selection"
 msgstr "Izreži odabir"
 
-#: ../src/common/fmapbase.cpp:152
+#: ../src/common/fmapbase.cpp:149
 msgid "Cyrillic (ISO-8859-5)"
 msgstr "Ćirilica (ISO-8859-5)"
 
-#: ../src/common/paper.cpp:99
+#: ../src/common/paper.cpp:96
 msgid "D sheet, 22 x 34 in"
 msgstr "D arak, 22 × 34 in"
 
-#: ../src/msw/dde.cpp:703
+#: ../src/msw/dde.cpp:698
 msgid "DDE poke request failed"
 msgstr "DDE poke upit nije uspjeo"
 
-#: ../src/common/imagbmp.cpp:1169
+#: ../src/common/imagbmp.cpp:1181
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr "DIB zaglavlje: Kodiranje se ne poklapa s bit-dubinom."
 
@@ -2590,7 +2598,7 @@ msgstr "DIB zaglavlje: Nepoznata bit-dubina u datoteci."
 msgid "DIB Header: Unknown encoding in file."
 msgstr "DIB zaglavlje: Nepoznato kodiranje u datoteci."
 
-#: ../src/common/paper.cpp:121
+#: ../src/common/paper.cpp:118
 msgid "DL Envelope, 110 x 220 mm"
 msgstr "DL kuverta, 110 × 220 mm"
 
@@ -2598,53 +2606,53 @@ msgstr "DL kuverta, 110 × 220 mm"
 msgid "Dashed"
 msgstr "Isprekidano"
 
-#: ../src/generic/dbgrptg.cpp:300
+#: ../src/generic/dbgrptg.cpp:301
 #, c-format
 msgid "Debug report \"%s\""
 msgstr "Izvještaj o otklanjanju grešaka „%s”"
 
-#: ../src/common/debugrpt.cpp:210
+#: ../src/common/debugrpt.cpp:211
 msgid "Debug report couldn't be created."
 msgstr "Izvještaj o otklanjanju grešaka nije bilo moguće stvoriti."
 
-#: ../src/common/debugrpt.cpp:553
+#: ../src/common/debugrpt.cpp:554
 msgid "Debug report generation has failed."
 msgstr "Stvaranje izvještaja o otklanjanju grešaka."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:84
+#: ../src/common/accelcmn.cpp:81
 msgid "Decimal"
 msgstr "Decimala"
 
-#: ../src/generic/fontdlgg.cpp:323
+#: ../src/generic/fontdlgg.cpp:319
 msgid "Decorative"
 msgstr "Dekorativni"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1752
+#: ../src/propgrid/advprops.cpp:1653
 msgid "Default"
 msgstr "Zadano"
 
-#: ../src/common/fmapbase.cpp:796
+#: ../src/common/fmapbase.cpp:792
 msgid "Default encoding"
 msgstr "Zadano kodiranje"
 
-#: ../src/dfb/fontmgr.cpp:180
+#: ../src/dfb/fontmgr.cpp:177
 msgid "Default font"
 msgstr "Zadani font"
 
-#: ../src/generic/prntdlgg.cpp:510
+#: ../src/generic/prntdlgg.cpp:503
 msgid "Default printer"
 msgstr "Zadani pisač"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:51
+#: ../src/common/accelcmn.cpp:48
 msgid "Del"
 msgstr "Izbriši"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextbuffer.cpp:8221 ../src/common/stockitem.cpp:152
-#: ../src/common/accelcmn.cpp:50 ../src/stc/stc_i18n.cpp:20
+#: ../src/common/stockitem.cpp:149 ../src/common/accelcmn.cpp:47
+#: ../src/richtext/richtextbuffer.cpp:8217 ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Izbriši"
 
@@ -2652,68 +2660,68 @@ msgstr "Izbriši"
 msgid "Delete A&ll"
 msgstr "Izbriši s&ve"
 
-#: ../src/richtext/richtextbuffer.cpp:11341
+#: ../src/richtext/richtextbuffer.cpp:11340
 msgid "Delete Column"
 msgstr "Izbriši stupac"
 
-#: ../src/richtext/richtextbuffer.cpp:11291
+#: ../src/richtext/richtextbuffer.cpp:11290
 msgid "Delete Row"
 msgstr "Izbriši red"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 msgid "Delete Style"
 msgstr "Izbriši stil"
 
-#: ../src/richtext/richtextctrl.cpp:1345 ../src/richtext/richtextctrl.cpp:1584
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
 msgid "Delete Text"
 msgstr "Izbriši tekst"
 
-#: ../src/generic/editlbox.cpp:170
+#: ../src/generic/editlbox.cpp:147
 msgid "Delete item"
 msgstr "Izbriši stavku"
 
-#: ../src/common/stockitem.cpp:260
+#: ../src/common/stockitem.cpp:257
 msgid "Delete selection"
 msgstr "Izbriši  odabir"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 #, c-format
 msgid "Delete style %s?"
 msgstr "Izbrisati stil %s?"
 
-#: ../src/unix/snglinst.cpp:301
+#: ../src/unix/snglinst.cpp:298
 #, c-format
 msgid "Deleted stale lock file '%s'."
 msgstr "Izbrisana je stara datoteka zaključavanja „%s”."
 
-#: ../src/common/secretstore.cpp:220
-#, c-format
-msgid "Deleting password for \"%s/%s\" failed: %s."
+#: ../src/common/secretstore.cpp:234
+#, fuzzy, c-format
+msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Brisanje lozinke za „%s/%s”: %s."
 
-#: ../src/common/module.cpp:124
+#: ../src/common/module.cpp:121
 #, c-format
 msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
 msgstr "Ovisnost „%s” o modulu „%s” ne postoji."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "Descending"
 msgstr "Silazno"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:526 ../src/propgrid/advprops.cpp:882
+#: ../src/generic/dirctrlg.cpp:492 ../src/propgrid/advprops.cpp:783
 msgid "Desktop"
 msgstr "Desktop"
 
-#: ../src/generic/aboutdlgg.cpp:70
+#: ../src/generic/aboutdlgg.cpp:67
 msgid "Developed by "
 msgstr "Razvijatelji "
 
-#: ../src/generic/aboutdlgg.cpp:176
+#: ../src/generic/aboutdlgg.cpp:173
 msgid "Developers"
 msgstr "Razvijatelji"
 
-#: ../src/msw/dialup.cpp:374
+#: ../src/msw/dialup.cpp:368
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -2721,11 +2729,11 @@ msgstr ""
 "Funkcije nazivanja nisu dostupne jer usluga daljinskog pristupa (RAS) nije "
 "instalirana na ovom računalu. Instaliraj ga."
 
-#: ../src/generic/tipdlg.cpp:211
+#: ../src/generic/tipdlg.cpp:208
 msgid "Did you know..."
 msgstr "Je li znaš …"
 
-#: ../src/dfb/wrapdfb.cpp:63
+#: ../src/dfb/wrapdfb.cpp:60
 #, c-format
 msgid "DirectFB error %d occurred."
 msgstr "Došlo je do DirectFB greške %d."
@@ -2734,29 +2742,29 @@ msgstr "Došlo je do DirectFB greške %d."
 msgid "Directories"
 msgstr "Mape"
 
-#: ../src/common/filefn.cpp:1183
+#: ../src/common/filefn.cpp:1071
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Nije bilo moguće stvoriti mapu „%s”"
 
-#: ../src/common/filefn.cpp:1197
+#: ../src/common/filefn.cpp:1085
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "Nije bilo moguće izbrisati mapu „%s”"
 
-#: ../src/generic/dirdlgg.cpp:204
+#: ../src/generic/dirdlgg.cpp:201
 msgid "Directory does not exist"
 msgstr "Mapa ne postoji"
 
-#: ../src/generic/filectrlg.cpp:1399
+#: ../src/generic/filectrlg.cpp:1388
 msgid "Directory doesn't exist."
 msgstr "Mapa ne postoji."
 
-#: ../src/common/docview.cpp:457
+#: ../src/common/docview.cpp:450
 msgid "Discard changes and reload the last saved version?"
 msgstr "Zanemari promjene i ponovo učitaj posljednju spremljenu verziju?"
 
-#: ../src/html/helpwnd.cpp:502
+#: ../src/html/helpwnd.cpp:500
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -2764,45 +2772,45 @@ msgstr ""
 "Prikaži sve indicirane stavke koje sadržavaju zadani znakovni niz. Pretraga "
 "ne razlikuje veličinu slova."
 
-#: ../src/html/helpwnd.cpp:679
+#: ../src/html/helpwnd.cpp:677
 msgid "Display options dialog"
 msgstr "Dijalog za opcije prikaza"
 
-#: ../src/html/helpwnd.cpp:322
+#: ../src/html/helpwnd.cpp:320
 msgid "Displays help as you browse the books on the left."
 msgstr "Prikazuje pomoć prilikom pregledavanja knjiga na lijevo strani."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:85
+#: ../src/common/accelcmn.cpp:83
 msgid "Divide"
 msgstr "Dijeli"
 
-#: ../src/common/docview.cpp:533
+#: ../src/common/docview.cpp:526
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Želiš li spremiti promjene u %s?"
 
-#: ../src/common/prntbase.cpp:542
+#: ../src/common/prntbase.cpp:537
 msgid "Document:"
 msgstr "Dokument:"
 
-#: ../src/generic/aboutdlgg.cpp:73
+#: ../src/generic/aboutdlgg.cpp:70
 msgid "Documentation by "
 msgstr "Autori dokumentacije "
 
-#: ../src/generic/aboutdlgg.cpp:180
+#: ../src/generic/aboutdlgg.cpp:177
 msgid "Documentation writers"
 msgstr "Autori dokumentacije"
 
-#: ../src/common/sizer.cpp:2799
+#: ../src/common/sizer.cpp:2916
 msgid "Don't Save"
 msgstr "Nemoj spremiti"
 
-#: ../src/html/htmlwin.cpp:633
+#: ../src/html/htmlwin.cpp:643
 msgid "Done"
 msgstr "Gotovo"
 
-#: ../src/generic/progdlgg.cpp:448 ../src/msw/progdlg.cpp:407
+#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
 msgid "Done."
 msgstr "Gotovo."
 
@@ -2814,42 +2822,42 @@ msgstr "Točkasto"
 msgid "Double"
 msgstr "Duplo"
 
-#: ../src/common/paper.cpp:176
+#: ../src/common/paper.cpp:173
 msgid "Double Japanese Postcard Rotated 148 x 200 mm"
 msgstr "Japanska dupla razglednica rotirano 148 × 200 mm"
 
-#: ../src/common/xtixml.cpp:273
+#: ../src/common/xtixml.cpp:269
 #, c-format
 msgid "Doubly used id : %d"
 msgstr "Dvostruko korišten id : %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:153
-#: ../src/common/accelcmn.cpp:64
+#: ../src/common/stockitem.cpp:150 ../src/common/accelcmn.cpp:61
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Down"
 msgstr "Dolje"
 
-#: ../src/richtext/richtextctrl.cpp:865
+#: ../src/richtext/richtextctrl.cpp:864
 msgid "Drag"
 msgstr "Povuci"
 
-#: ../src/common/paper.cpp:100
+#: ../src/common/paper.cpp:97
 msgid "E sheet, 34 x 44 in"
 msgstr "E arak, 34 × 44 in"
 
-#: ../src/unix/fswatcher_inotify.cpp:561
+#: ../src/unix/fswatcher_inotify.cpp:558
 msgid "EOF while reading from inotify descriptor"
 msgstr "EOF prilikom čitanja inotify deskriptora"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "Edit"
 msgstr "Uredi"
 
-#: ../src/generic/editlbox.cpp:168
+#: ../src/generic/editlbox.cpp:131
 msgid "Edit item"
 msgstr "Uredi stavku"
 
-#: ../include/wx/generic/progdlgg.h:84
+#: ../include/wx/generic/progdlgg.h:85
 msgid "Elapsed time:"
 msgstr "Proteklo vrijeme:"
 
@@ -2916,49 +2924,49 @@ msgid "Enables the shadow spread."
 msgstr "Aktivira rasprostiranje sjene."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:66
+#: ../src/common/accelcmn.cpp:63
 msgid "End"
 msgstr "Kraj"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:55
+#: ../src/common/accelcmn.cpp:52
 msgid "Enter"
 msgstr "Unesi"
 
-#: ../src/richtext/richtextstyledlg.cpp:934
+#: ../src/richtext/richtextstyledlg.cpp:930
 msgid "Enter a box style name"
 msgstr "Unesi ime stila okvira"
 
-#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:602
 msgid "Enter a character style name"
 msgstr "Unesi ime stila slovnih znakova"
 
-#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:816
 msgid "Enter a list style name"
 msgstr "Unesi ime stila popisa"
 
-#: ../src/richtext/richtextstyledlg.cpp:893
+#: ../src/richtext/richtextstyledlg.cpp:889
 msgid "Enter a new style name"
 msgstr "Unesi novo ime stila"
 
-#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:650
 msgid "Enter a paragraph style name"
 msgstr "Unesi ime stila odlomka"
 
-#: ../src/generic/dbgrptg.cpp:174
+#: ../src/generic/dbgrptg.cpp:171
 #, c-format
 msgid "Enter command to open file \"%s\":"
 msgstr "Unesi naredbu za otvaranje datoteke „%s”:"
 
-#: ../src/generic/helpext.cpp:459
+#: ../src/generic/helpext.cpp:457
 msgid "Entries found"
 msgstr "Nađeni unosi"
 
-#: ../src/common/paper.cpp:142
+#: ../src/common/paper.cpp:139
 msgid "Envelope Invite 220 x 220 mm"
 msgstr "Kuverta pozivnice 220 × 220 mm"
 
-#: ../src/common/config.cpp:469
+#: ../src/common/config.cpp:465
 #, c-format
 msgid ""
 "Environment variables expansion failed: missing '%c' at position %u in '%s'."
@@ -2966,13 +2974,13 @@ msgstr ""
 "Proširenje varijable okruženja nije uspjelo: nedostaje „%c” na položaju %u u "
 "„%s”."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/generic/dirctrlg.cpp:570
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/dirctrlg.cpp:599
-#: ../src/generic/dirdlgg.cpp:323 ../src/generic/filectrlg.cpp:642
-#: ../src/generic/filectrlg.cpp:756 ../src/generic/filectrlg.cpp:770
-#: ../src/generic/filectrlg.cpp:786 ../src/generic/filectrlg.cpp:1368
-#: ../src/generic/filectrlg.cpp:1399 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/gtk1/fontdlg.cpp:74 ../src/generic/dirctrlg.cpp:536
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/dirctrlg.cpp:565
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1357 ../src/generic/filectrlg.cpp:1388
+#: ../src/generic/filedlgg.cpp:354 ../src/generic/dirdlgg.cpp:320
+#: ../src/gtk/filedlg.cpp:74
 msgid "Error"
 msgstr "Greška"
 
@@ -2980,233 +2988,254 @@ msgstr "Greška"
 msgid "Error closing epoll descriptor"
 msgstr "Greška prilikom zatvaranja epoll deskriptora"
 
-#: ../src/unix/fswatcher_kqueue.cpp:114
+#: ../src/unix/fswatcher_kqueue.cpp:131
 msgid "Error closing kqueue instance"
 msgstr "Greška prilikom zatvaranja kqueue instance"
 
-#: ../src/common/filefn.cpp:1049
+#: ../src/common/filefn.cpp:938
 #, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Greška prilikom kopiranja datoteke „%s” u „%s”."
 
-#: ../src/generic/dirdlgg.cpp:222
+#: ../src/generic/dirdlgg.cpp:219
 msgid "Error creating directory"
 msgstr "Greška prilikom stvaranja mape"
 
-#: ../src/common/imagbmp.cpp:1181
+#: ../src/common/imagbmp.cpp:1193
 msgid "Error in reading image DIB."
 msgstr "Greška u čitanju DIB slike."
 
-#: ../src/propgrid/propgrid.cpp:6696
+#: ../src/propgrid/propgrid.cpp:6665
 #, c-format
 msgid "Error in resource: %s"
 msgstr "Greška u resursu: %s"
 
-#: ../src/common/fileconf.cpp:422
+#: ../src/common/fileconf.cpp:421
 msgid "Error reading config options."
 msgstr "Greška prilikom čitanja opcija konfiguracije."
+
+#: ../src/msw/webview_ie.cpp:1057 ../src/msw/webview_edge.cpp:850
+#: ../src/gtk/webview_webkit2.cpp:1262 ../src/osx/webview_webkit.mm:383
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
 
 #: ../src/common/fileconf.cpp:1029
 msgid "Error saving user configuration data."
 msgstr "Greška prilikom spremanja podataka korisničke konfiguracije."
 
-#: ../src/gtk/print.cpp:722
+#: ../src/gtk/print.cpp:720
 msgid "Error while printing: "
 msgstr "Greška prilikom spisa: "
 
-#: ../src/common/log.cpp:219
+#: ../src/common/log.cpp:237
 msgid "Error: "
 msgstr "Greška: "
 
+#: ../src/common/webrequest.cpp:98
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Greška: "
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:69
+#: ../src/common/accelcmn.cpp:66
 msgid "Esc"
 msgstr "Esc"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:70
+#: ../src/common/accelcmn.cpp:67
 msgid "Escape"
 msgstr "Escape"
 
-#: ../src/common/fmapbase.cpp:150
+#: ../src/common/fmapbase.cpp:147
 msgid "Esperanto (ISO-8859-3)"
 msgstr "Esperanto (ISO-8859-3)"
 
-#: ../include/wx/generic/progdlgg.h:85
+#: ../include/wx/generic/progdlgg.h:86
 msgid "Estimated time:"
 msgstr "Procijenjeno vrijeme:"
 
-#: ../src/generic/dbgrptg.cpp:234
+#: ../src/generic/dbgrptg.cpp:231
 msgid "Executable files (*.exe)|*.exe|"
 msgstr "Izvršavajuće datoteke (*.exe)|*.exe|"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:155 ../src/common/accelcmn.cpp:78
+#: ../src/common/stockitem.cpp:152 ../src/common/accelcmn.cpp:75
 msgid "Execute"
 msgstr "Izvrši"
 
-#: ../src/msw/utilsexc.cpp:876
+#: ../src/msw/utilsexc.cpp:873
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Izvršenje naredbe %s"
 
-#: ../src/common/paper.cpp:105
+#: ../src/common/paper.cpp:102
 msgid "Executive, 7 1/4 x 10 1/2 in"
 msgstr "Executive, 7 1/4 × 10 1/2 in"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6009
+#: ../src/generic/datavgen.cpp:6814
 msgid "Expand"
 msgstr "Proširi"
 
-#: ../src/msw/registry.cpp:1240
+#: ../src/msw/registry.cpp:1228
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
 msgstr ""
 "Izvoz ključa registra: datoteka „%s” već postoji i neće biti prepisana."
 
-#: ../src/common/fmapbase.cpp:195
+#: ../src/common/fmapbase.cpp:192
 msgid "Extended Unix Codepage for Japanese (EUC-JP)"
 msgstr "Proširena Unix kodna strana za japanski (EUC-JP)"
 
-#: ../src/html/chm.cpp:725
+#: ../src/html/chm.cpp:718
 #, c-format
 msgid "Extraction of '%s' into '%s' failed."
 msgstr "Izvlačenje iz „%s” u „%s”."
 
-#: ../src/common/accelcmn.cpp:249 ../src/common/accelcmn.cpp:344
+#: ../src/common/accelcmn.cpp:259 ../src/common/accelcmn.cpp:358
 msgid "F"
 msgstr "F"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:672
+#: ../src/propgrid/advprops.cpp:582
 msgid "Face Name"
 msgstr "Ime fonta"
 
-#: ../src/unix/snglinst.cpp:269
+#: ../src/unix/snglinst.cpp:266
 msgid "Failed to access lock file."
 msgstr "Neuspjeli pristup zaključnoj datoteci."
+
+#: ../src/gtk/font.cpp:572
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Neuspjelo čitanje dokumenta iz datoteke „%s”."
 
 #: ../src/unix/epolldispatcher.cpp:116
 #, c-format
 msgid "Failed to add descriptor %d to epoll descriptor %d"
 msgstr "Neuspjelo dodavanje deskriptora %d epoll deskriptoru %d"
 
-#: ../src/msw/dib.cpp:489
+#: ../src/msw/dib.cpp:535
 #, c-format
 msgid "Failed to allocate %luKb of memory for bitmap data."
 msgstr "Neuspjelo alociranje %luKb memorije za bitmap."
 
-#: ../src/common/glcmn.cpp:115
+#: ../src/common/glcmn.cpp:112
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Neuspjelo određivanje boje za OpenGL"
 
-#: ../src/unix/displayx11.cpp:236
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Neuspjelo određivanje boje za OpenGL"
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Neuspjelo određivanje boje za OpenGL"
+
+#: ../include/wx/unix/private/displayx11.h:89
 msgid "Failed to change video mode"
 msgstr "Neuspjelo mijenjanje video modusa"
 
-#: ../src/common/image.cpp:3277
+#: ../src/common/image.cpp:3396
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Neuspjela provjera formata datoteke slike „%s”."
 
-#: ../src/common/debugrpt.cpp:239
+#: ../src/common/debugrpt.cpp:240
 #, c-format
 msgid "Failed to clean up debug report directory \"%s\""
 msgstr "Neuspjelo sređivanje mape za izještaje o otklanjanju grešaka „%s”."
 
-#: ../src/common/filename.cpp:192
+#: ../src/common/filename.cpp:189
 msgid "Failed to close file handle"
 msgstr "Neuspjelo zatvaranje upravljača datotekama"
 
-#: ../src/unix/snglinst.cpp:340
+#: ../src/unix/snglinst.cpp:337
 #, c-format
 msgid "Failed to close lock file '%s'"
 msgstr "Neuspjelo zatvaranje zaključne datoteke „%s”"
 
-#: ../src/msw/clipbrd.cpp:112
+#: ../src/msw/clipbrd.cpp:110
 msgid "Failed to close the clipboard."
 msgstr "Neuspjelo zatvaranje međuspremnika."
 
-#: ../src/x11/utils.cpp:208
+#: ../src/x11/utils.cpp:170
 #, c-format
 msgid "Failed to close the display \"%s\""
 msgstr "Neuspjelo zatvaranje prikaza „%s”"
 
-#: ../src/msw/dialup.cpp:797
+#: ../src/msw/dialup.cpp:791
 msgid "Failed to connect: missing username/password."
 msgstr "Neuspjelo povezivanje: nedostaje korisničko ime/lozinka."
 
-#: ../src/msw/dialup.cpp:743
+#: ../src/msw/dialup.cpp:737
 msgid "Failed to connect: no ISP to dial."
 msgstr "Neuspjelo povezivanje: nema ISP za biranje."
 
-#: ../src/common/textfile.cpp:203
-#, c-format
-msgid "Failed to convert file \"%s\" to Unicode."
-msgstr "Neuspjelo konvertiranje datoteke „%s” u Unicode."
-
-#: ../src/generic/logg.cpp:956
+#: ../src/generic/logg.cpp:953
 msgid "Failed to copy dialog contents to the clipboard."
 msgstr "Neuspjelo kopiranje sadržaja dijaloga u međuspremnik."
 
-#: ../src/msw/registry.cpp:692
+#: ../src/msw/registry.cpp:681
 #, c-format
 msgid "Failed to copy registry value '%s'"
 msgstr "Neuspjelo kopiranje registarske vrijednost „%s”"
 
-#: ../src/msw/registry.cpp:701
+#: ../src/msw/registry.cpp:690
 #, c-format
 msgid "Failed to copy the contents of registry key '%s' to '%s'."
 msgstr "Neuspjelo kopiranje sadržaja registarskog ključa „%s” u „%s”."
 
-#: ../src/common/filefn.cpp:1015
+#: ../src/common/filefn.cpp:904
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Neuspjelo kopiranje datoteke „%s” u „%s”"
 
-#: ../src/msw/registry.cpp:679
+#: ../src/msw/registry.cpp:668
 #, c-format
 msgid "Failed to copy the registry subkey '%s' to '%s'."
 msgstr "Neuspjelo kopiranje registarskog pod-ključa „%s” u „%s”."
 
-#: ../src/msw/dde.cpp:1070
+#: ../src/msw/dde.cpp:1134
 msgid "Failed to create DDE string"
 msgstr "Neuspjelo stvaranje DDE znakovnog niza"
 
-#: ../src/msw/mdi.cpp:616
+#: ../src/msw/mdi.cpp:621
 msgid "Failed to create MDI parent frame."
 msgstr "Neuspjela izrada MDI matičnog okvira."
 
-#: ../src/common/filename.cpp:1027
+#: ../src/common/filename.cpp:1024
 msgid "Failed to create a temporary file name"
 msgstr "Neuspjelo stvaranje imena privremene datoteke"
 
-#: ../src/msw/utilsexc.cpp:228
+#: ../src/msw/utilsexc.cpp:225
 msgid "Failed to create an anonymous pipe"
 msgstr "Neuspjelo stvaranje anonimnog cjevovoda"
 
-#: ../src/msw/ole/automtn.cpp:522
+#: ../src/msw/ole/automtn.cpp:513
 #, c-format
 msgid "Failed to create an instance of \"%s\""
 msgstr "Neuspjelo stvaranje instance od „%s”"
 
-#: ../src/msw/dde.cpp:437
+#: ../src/msw/dde.cpp:432
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "Neuspjelo povezivanje na server „%s” na temu „%s”"
 
-#: ../src/msw/cursor.cpp:204
+#: ../src/msw/cursor.cpp:195
 msgid "Failed to create cursor."
 msgstr "Neuspjelo stvaranje pokazivača."
 
-#: ../src/common/debugrpt.cpp:209
+#: ../src/common/debugrpt.cpp:210
 #, c-format
 msgid "Failed to create directory \"%s\""
 msgstr "Neuspjelo stvaranje direktorija „%s”"
 
-#: ../src/generic/dirdlgg.cpp:220
+#: ../src/generic/dirdlgg.cpp:217
 #, c-format
 msgid ""
 "Failed to create directory '%s'\n"
@@ -3219,114 +3248,133 @@ msgstr ""
 msgid "Failed to create epoll descriptor"
 msgstr "Neuspjelo stvaranje epoll deskriptora"
 
-#: ../src/msw/mimetype.cpp:238
+#: ../src/gtk/font.cpp:562
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "Neuspjelo aktualiziranje datoteke korisničke konfiguracije."
+
+#: ../src/msw/mimetype.cpp:235
 #, c-format
 msgid "Failed to create registry entry for '%s' files."
 msgstr "Neuspjela izrada registarskog unosa za „%s” datoteka."
 
-#: ../src/msw/fdrepdlg.cpp:409
+#: ../src/msw/fdrepdlg.cpp:408
 #, c-format
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr "Neuspjela izrada standardnog traži/nađi dijaloga (kodna greška %d)"
 
-#: ../src/unix/wakeuppipe.cpp:52
+#: ../src/unix/wakeuppipe.cpp:49
 msgid "Failed to create wake up pipe used by event loop."
 msgstr "Neuspjelo stvaranje wake up cjevovoda koju koristi petlja događaja."
 
-#: ../src/html/winpars.cpp:730
+#: ../src/html/winpars.cpp:727
 #, c-format
 msgid "Failed to display HTML document in %s encoding"
 msgstr "Neuspjeo prikaz HTML dokumenta %s kodiranjem"
 
-#: ../src/msw/clipbrd.cpp:124
+#: ../src/msw/clipbrd.cpp:122
 msgid "Failed to empty the clipboard."
 msgstr "Neuspjelo pražnjenje međuspremnika."
 
-#: ../src/unix/displayx11.cpp:212
+#: ../include/wx/unix/private/displayx11.h:65
 msgid "Failed to enumerate video modes"
 msgstr "Neuspjelo pobrojavanje video modusa"
 
-#: ../src/msw/dde.cpp:722
+#: ../src/msw/dde.cpp:717
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "Neuspjelo stvoriti advise petlju s DDE serverom"
 
-#: ../src/msw/dialup.cpp:629 ../src/msw/dialup.cpp:863
+#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Neuspjelo stvaranje aktivne veze pozivanja: %s"
 
-#: ../src/unix/utilsunx.cpp:611
+#: ../src/unix/utilsunx.cpp:613
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Neuspjelo izvršavanje „%s”\n"
 
-#: ../src/common/debugrpt.cpp:720
+#: ../src/common/debugrpt.cpp:730
 msgid "Failed to execute curl, please install it in PATH."
 msgstr "Neuspjelo izvršavanje curl-a, instaliraj ga u PATH."
 
-#: ../src/msw/ole/automtn.cpp:505
+#: ../src/msw/ole/automtn.cpp:496
 #, c-format
 msgid "Failed to find CLSID of \"%s\""
 msgstr "Neuspjelo pronalaženje CLSID-a od „%s”"
 
-#: ../src/common/regex.cpp:431 ../src/common/regex.cpp:479
+#: ../src/common/regex.cpp:428 ../src/common/regex.cpp:476
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "Neuspjeo nalaženje poklapanja ragularnog izraza: %s"
 
-#: ../src/msw/dialup.cpp:695
+#: ../src/msw/webview_ie.cpp:978
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:689
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Neuspjelo dobivanje ISP imena: %s"
 
-#: ../src/msw/ole/automtn.cpp:574
+#: ../src/msw/ole/automtn.cpp:565
 #, c-format
 msgid "Failed to get OLE automation interface for \"%s\""
 msgstr "Neuspjelo dobivanje OLE sučelje automatizacije za „%s”"
 
-#: ../src/msw/clipbrd.cpp:711
+#: ../src/msw/clipbrd.cpp:731
 msgid "Failed to get data from the clipboard"
 msgstr "Neuspjelo dobivanje podataka iz međuspremnika"
 
-#: ../src/common/time.cpp:223
+#: ../src/common/time.cpp:216
 msgid "Failed to get the local system time"
 msgstr "Neuspjelo dobivanje lokalnog vremena sustava"
 
-#: ../src/common/filefn.cpp:1345
+#: ../src/common/filefn.cpp:1233
 msgid "Failed to get the working directory"
 msgstr "Neuspjelo dohvaćanje radnog direktorija"
 
-#: ../src/univ/theme.cpp:114
+#: ../src/univ/theme.cpp:111
 msgid "Failed to initialize GUI: no built-in themes found."
 msgstr "Neuspjelo inicijaliziranje grafičkog sučelja: nema ugrađenih tema."
 
-#: ../src/msw/helpchm.cpp:63
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:60
 msgid "Failed to initialize MS HTML Help."
 msgstr "Neuspjelo inicijaliziranje MS HTML pomoći."
 
-#: ../src/msw/glcanvas.cpp:1381
+#: ../src/msw/glcanvas.cpp:1391
 msgid "Failed to initialize OpenGL"
 msgstr "Neuspjelo inicijaliziranje OpenGL-a"
 
-#: ../src/msw/dialup.cpp:858
+#: ../src/msw/dialup.cpp:852
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Neuspjelo inicijaliziranje povezivanja: %s"
 
-#: ../src/gtk/textctrl.cpp:1128
+#: ../src/gtk/textctrl.cpp:1209
 msgid "Failed to insert text in the control."
 msgstr "Neuspjelo umetanje teksta u kontrolu."
 
-#: ../src/unix/snglinst.cpp:241
+#: ../src/unix/snglinst.cpp:238
 #, c-format
 msgid "Failed to inspect the lock file '%s'"
 msgstr "Neuspjelo provjeravanje zaključne datoteke „%s”"
 
-#: ../src/unix/appunix.cpp:182
+#: ../src/unix/appunix.cpp:179
 msgid "Failed to install signal handler"
 msgstr "Neuspjelo instaliranje signalnog upravljača"
 
-#: ../src/unix/threadpsx.cpp:1167
+#: ../src/unix/threadpsx.cpp:1216
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -3334,71 +3382,71 @@ msgstr ""
 "Neuspjelo povezivanje tijeka, otkrivena ja moguća nedostatna memorija – "
 "ponovo pokreni program"
 
-#: ../src/msw/utils.cpp:629
+#: ../src/msw/utils.cpp:619
 #, c-format
 msgid "Failed to kill process %d"
 msgstr "Neuspjelo nasilno prekidanje procesa %d"
 
-#: ../src/common/image.cpp:2500
+#: ../src/common/image.cpp:2595
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Neuspjelo učitavanje bitmapa „%s” iz resursa."
 
-#: ../src/common/image.cpp:2509
+#: ../src/common/image.cpp:2604
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Neuspjelo učitavanje ikone „%s” iz resursa."
 
-#: ../src/common/iconbndl.cpp:225
+#: ../src/common/iconbndl.cpp:224
 #, c-format
 msgid "Failed to load icons from resource '%s'."
 msgstr "Neuspjelo učitavanje ikona iz resursa „%s”."
 
-#: ../src/common/iconbndl.cpp:200
+#: ../src/common/iconbndl.cpp:198
 #, c-format
 msgid "Failed to load image %%d from file '%s'."
 msgstr "Neuspjelo učitavanje slike %%d iz datoteke „%s”."
 
-#: ../src/common/iconbndl.cpp:208
+#: ../src/common/iconbndl.cpp:206
 #, c-format
 msgid "Failed to load image %d from stream."
 msgstr "Neuspjelo učitavanje slike %d iz tijeka."
 
-#: ../src/common/image.cpp:2587 ../src/common/image.cpp:2606
+#: ../src/common/image.cpp:2682 ../src/common/image.cpp:2701
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Neuspjelo učitavanje slike iz datoteke „%s”."
 
-#: ../src/msw/enhmeta.cpp:97
+#: ../src/msw/enhmeta.cpp:94
 #, c-format
 msgid "Failed to load metafile from file \"%s\"."
 msgstr "Neuspjelo učitavanje metafile iz datoteke „%s”."
 
-#: ../src/msw/volume.cpp:327
+#: ../src/msw/volume.cpp:335
 msgid "Failed to load mpr.dll."
 msgstr "Neuspjelo učitavanje mpr.dll."
 
-#: ../src/msw/utils.cpp:953
+#: ../src/msw/utils.cpp:943
 #, c-format
 msgid "Failed to load resource \"%s\"."
 msgstr "Neuspjelo učitavanje resursa „%s”."
 
-#: ../src/common/dynlib.cpp:92
+#: ../src/common/dynlib.cpp:86
 #, c-format
 msgid "Failed to load shared library '%s'"
 msgstr "Neuspjelo učitavanje dijeljenje biblioteke „%s”."
 
-#: ../src/osx/core/sound.cpp:145
+#: ../src/osx/core/sound.cpp:143
 #, c-format
 msgid "Failed to load sound from \"%s\" (error %d)."
 msgstr "Neuspjelo učitavanje zvuka iz „%s”. (greška %d)."
 
-#: ../src/msw/utils.cpp:960
+#: ../src/msw/utils.cpp:950
 #, c-format
 msgid "Failed to lock resource \"%s\"."
 msgstr "Neuspjelo zaključavanje resursa „%s”."
 
-#: ../src/unix/snglinst.cpp:198
+#: ../src/unix/snglinst.cpp:195
 #, c-format
 msgid "Failed to lock the lock file '%s'"
 msgstr "Neuspjelo zaključavanje zaključne datoteke „%s”."
@@ -3408,33 +3456,38 @@ msgstr "Neuspjelo zaključavanje zaključne datoteke „%s”."
 msgid "Failed to modify descriptor %d in epoll descriptor %d"
 msgstr "Neuspjelo mijenjanje deskriptora %d u epoll deskriptoru %d"
 
-#: ../src/common/filename.cpp:2575
+#: ../src/common/filename.cpp:2658
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Neuspjelo mijenjanje vremena datoteke za „%s”"
 
-#: ../src/common/selectdispatcher.cpp:258
+#: ../src/common/selectdispatcher.cpp:255
 msgid "Failed to monitor I/O channels"
 msgstr "Neuspjelo praćenje ulaznih/izlaznih kanala"
 
-#: ../src/common/filename.cpp:175
+#: ../src/common/filename.cpp:172
 #, c-format
 msgid "Failed to open '%s' for reading"
 msgstr "Neuspjelo otvaranje „%s” za čitanje"
 
-#: ../src/common/filename.cpp:180
+#: ../src/common/filename.cpp:177
 #, c-format
 msgid "Failed to open '%s' for writing"
 msgstr "Neuspjelo otvaranje „%s” za pisanje"
 
-#: ../src/html/chm.cpp:141
+#: ../src/html/chm.cpp:138
 #, c-format
 msgid "Failed to open CHM archive '%s'."
 msgstr "Neuspjelo otvaranje CHM arhive „%s”."
 
-#: ../src/common/utilscmn.cpp:1126
+#: ../src/common/utilscmn.cpp:1140
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Neuspjelo otvaranje URL-a „%s” u zadanom pregledniku."
+
+#: ../src/common/hyperlnkcmn.cpp:133
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Neuspjelo otvaranje URL-a „%s” u zadanom pregledniku."
 
 #: ../include/wx/msw/private/fswatcher.h:92
@@ -3442,93 +3495,103 @@ msgstr "Neuspjelo otvaranje URL-a „%s” u zadanom pregledniku."
 msgid "Failed to open directory \"%s\" for monitoring."
 msgstr "Neuspjelo otvaranje direktorija „%s” za praćenje."
 
-#: ../src/x11/utils.cpp:227
+#: ../src/x11/utils.cpp:189
 #, c-format
 msgid "Failed to open display \"%s\"."
 msgstr "Neuspjelo otvaranje ekrana „%s”."
 
-#: ../src/common/filename.cpp:1062
+#: ../src/common/filename.cpp:1059
 msgid "Failed to open temporary file."
 msgstr "Neuspjelo otvaranje privremene datoteke."
 
-#: ../src/msw/clipbrd.cpp:91
+#: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Neuspjelo otvaranje međuspremnika."
 
-#: ../src/common/translation.cpp:1184
+#: ../src/common/translation.cpp:1226
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Neuspjela obrada oblika množine: „%s”"
 
-#: ../src/unix/mediactrl.cpp:1214
+#: ../src/unix/mediactrl.cpp:1239
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Neuspjela priprema pokretanja „%s”."
 
-#: ../src/msw/clipbrd.cpp:600
+#: ../src/msw/clipbrd.cpp:610
 msgid "Failed to put data on the clipboard"
 msgstr "Neuspjelo spremanje podataka u međuspremnik"
 
-#: ../src/unix/snglinst.cpp:278
+#: ../src/unix/snglinst.cpp:275
 msgid "Failed to read PID from lock file."
 msgstr "Neuspjelo čitanje PID-a iz zaključne datoteke."
 
-#: ../src/common/fileconf.cpp:433
+#: ../src/common/fileconf.cpp:432
 msgid "Failed to read config options."
 msgstr "Neuspjelo čitanje opcija koniguracije."
 
-#: ../src/common/docview.cpp:681
+#: ../src/common/docview.cpp:676
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Neuspjelo čitanje dokumenta iz datoteke „%s”."
 
-#: ../src/dfb/evtloop.cpp:98
+#: ../src/dfb/evtloop.cpp:99
 msgid "Failed to read event from DirectFB pipe"
 msgstr "Neuspjelo čitanje događaja iz DirectFB cjevovoda"
 
-#: ../src/unix/wakeuppipe.cpp:120
+#: ../src/unix/wakeuppipe.cpp:117
 msgid "Failed to read from wake-up pipe"
 msgstr "Neuspjelo čitanje iz wake-up cjevovoda"
 
-#: ../src/unix/utilsunx.cpp:679
+#: ../src/common/textfile.cpp:96
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Neuspjelo čitanje dokumenta iz datoteke „%s”."
+
+#: ../src/unix/utilsunx.cpp:681
 msgid "Failed to redirect child process input/output"
 msgstr "Neuspjelo preusmjeravanje unosa/iznošaja podređenog procesa"
 
-#: ../src/msw/utilsexc.cpp:701
+#: ../src/msw/utilsexc.cpp:698
 msgid "Failed to redirect the child process IO"
 msgstr "Neuspjelo preusmjeravanje podređenog procesa ulaza/izlaza"
 
-#: ../src/msw/dde.cpp:288
+#: ../src/msw/dde.cpp:283
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Neuspjelo registriranje DDE servera „%s”"
 
-#: ../src/common/fontmap.cpp:245
+#: ../src/gtk/font.cpp:580
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "Neuspjelo aktualiziranje datoteke korisničke konfiguracije."
+
+#: ../src/common/fontmap.cpp:242
 #, c-format
 msgid "Failed to remember the encoding for the charset '%s'."
 msgstr "Neuspjelo pamćenje kodiranja za skupinu znakova „%s”."
 
-#: ../src/common/debugrpt.cpp:227
+#: ../src/common/debugrpt.cpp:228
 #, c-format
 msgid "Failed to remove debug report file \"%s\""
 msgstr "Neuspjelo uklanjanje datoteke za izvještaj o otklanjanju grešaka „%s”"
 
-#: ../src/unix/snglinst.cpp:328
+#: ../src/unix/snglinst.cpp:325
 #, c-format
 msgid "Failed to remove lock file '%s'"
 msgstr "Neuspjelo uklanjanje zaključne datoteke „%s”"
 
-#: ../src/unix/snglinst.cpp:288
+#: ../src/unix/snglinst.cpp:285
 #, c-format
 msgid "Failed to remove stale lock file '%s'."
 msgstr "Neuspjelo uklanjanje stare zaključne datoteke „%s”."
 
-#: ../src/msw/registry.cpp:529
+#: ../src/msw/registry.cpp:518
 #, c-format
 msgid "Failed to rename registry value '%s' to '%s'."
 msgstr "Neuspjelo preimenovanje registarske vrijednost „%s” u „%s”."
 
-#: ../src/common/filefn.cpp:1122
+#: ../src/common/filefn.cpp:1011
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -3537,116 +3600,125 @@ msgstr ""
 "Neuspjelo preimenovanje datoteke „%s” u „%s”, jer odredišna datoteka već "
 "postoji."
 
-#: ../src/msw/registry.cpp:634
+#: ../src/msw/registry.cpp:623
 #, c-format
 msgid "Failed to rename the registry key '%s' to '%s'."
 msgstr "Neuspjelo preimenovanje registarskog ključa „%s” u „%s”."
 
-#: ../src/common/filename.cpp:2671
+#: ../src/msw/webview_ie.cpp:995
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/common/filename.cpp:2754
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Neuspjelo dohvaćanje vremena datoteke za „%s”"
 
-#: ../src/msw/dialup.cpp:468
+#: ../src/msw/dialup.cpp:462
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Neuspjelo dohvaćanje teksta iz RAS poruke o greškama"
 
-#: ../src/msw/clipbrd.cpp:748
+#: ../src/msw/clipbrd.cpp:768
 msgid "Failed to retrieve the supported clipboard formats"
 msgstr "Neuspjelo dohvaćanje podržavajućih formata za međuspremnik"
 
-#: ../src/common/docview.cpp:652
+#: ../src/common/docview.cpp:647
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Neuspjelo spremanje dokumenta u datoteku „%s”."
 
-#: ../src/msw/dib.cpp:269
+#: ../src/msw/dib.cpp:312
 #, c-format
 msgid "Failed to save the bitmap image to file \"%s\"."
 msgstr "Neuspjelo spremanje bitmap slike u datoteku „%s”."
 
-#: ../src/msw/dde.cpp:763
+#: ../src/msw/dde.cpp:811
 msgid "Failed to send DDE advise notification"
 msgstr "Neuspjelo slanje DDE advise napomena"
 
-#: ../src/common/ftp.cpp:402
+#: ../src/common/ftp.cpp:399
 #, c-format
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Neuspjelo postavljanje modusa za FTP prijenos na %s."
 
-#: ../src/msw/clipbrd.cpp:427
+#: ../src/msw/clipbrd.cpp:443
 msgid "Failed to set clipboard data."
 msgstr "Neuspjelo postavljanje podataka međuspremnika."
 
-#: ../src/unix/snglinst.cpp:181
+#: ../src/unix/snglinst.cpp:178
 #, c-format
 msgid "Failed to set permissions on lock file '%s'"
 msgstr "Neuspjelo postavljanje korisničkih prava na zaključnu datoteku „%s”."
 
-#: ../src/unix/utilsunx.cpp:668
+#: ../src/unix/utilsunx.cpp:670
 msgid "Failed to set process priority"
 msgstr "Neuspjelo postavljanje prioriteta za proces"
 
-#: ../src/common/file.cpp:559
+#: ../src/common/ffile.cpp:355 ../src/common/file.cpp:586
 msgid "Failed to set temporary file permissions"
 msgstr "Neuspjelo postavljanje privremenih korisničkih prava"
 
-#: ../src/gtk/textctrl.cpp:1072
-msgid "Failed to set text in the text control."
-msgstr "Neuspjelo postavljanje teksta u tekst kontrole."
-
-#: ../src/unix/threadpsx.cpp:1298
+#: ../src/unix/threadpsx.cpp:1347
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Neuspjelo postavljanje razine podudarnosti tijeka na% lu"
 
-#: ../src/unix/threadpsx.cpp:1424
+#: ../src/unix/threadpsx.cpp:1473
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Neuspjelo postavljanje prioriteta tijeka %d."
 
-#: ../src/unix/utilsunx.cpp:783
+#: ../src/unix/utilsunx.cpp:785
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 "Neuspjelo postavljanje ne-blokirajućeg cjevovoda. Program će možda zastati."
 
-#: ../src/common/fs_mem.cpp:261
+#: ../src/msw/webview_ie.cpp:987
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:256
 #, c-format
 msgid "Failed to store image '%s' to memory VFS!"
 msgstr "Neuspjelo spremanje slike „%s” u VFS memoriju!"
 
-#: ../src/dfb/evtloop.cpp:170
+#: ../src/dfb/evtloop.cpp:171
 msgid "Failed to switch DirectFB pipe to non-blocking mode"
 msgstr "Neuspjelo prebacivanje DirectFB cjevovod u ne-blokirajući modus"
 
-#: ../src/unix/wakeuppipe.cpp:59
+#: ../src/unix/wakeuppipe.cpp:56
 msgid "Failed to switch wake up pipe to non-blocking mode"
 msgstr "Neuspjelo prebacivanje wake up cjevovoda u ne-blokirajući modus"
 
-#: ../src/unix/threadpsx.cpp:1605
+#: ../src/unix/threadpsx.cpp:1654
 msgid "Failed to terminate a thread."
 msgstr "Neuspjelo prekidanje tijeka."
 
-#: ../src/msw/dde.cpp:741
+#: ../src/msw/dde.cpp:736
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "Neuspjelo prekidanje advise petlje s DDE serverom"
 
-#: ../src/msw/dialup.cpp:938
+#: ../src/msw/dialup.cpp:932
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Neuspjelo prekidanje veze pozivanja: %s"
 
-#: ../src/common/filename.cpp:2590
+#: ../src/common/filename.cpp:2673
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Neuspjelo dodirivanje datoteke „%s”"
 
-#: ../src/unix/snglinst.cpp:334
+#: ../src/unix/dlunix.cpp:90
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "Neuspjelo učitavanje dijeljenje biblioteke „%s”."
+
+#: ../src/unix/snglinst.cpp:331
 #, c-format
 msgid "Failed to unlock lock file '%s'"
 msgstr "Neuspjelo otključavanje zaključne datoteke „%s”"
 
-#: ../src/msw/dde.cpp:309
+#: ../src/msw/dde.cpp:304
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Neuspjelo odjavljivanje DDE servera „%s”"
@@ -3660,77 +3732,87 @@ msgstr "Neuspjelo odjavljivanje deskriptora %d iz epoll deskriptora %d"
 msgid "Failed to update user configuration file."
 msgstr "Neuspjelo aktualiziranje datoteke korisničke konfiguracije."
 
-#: ../src/common/debugrpt.cpp:733
+#: ../src/common/debugrpt.cpp:743
 #, c-format
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Neuspjeli prijenos izvještaja o ispravljanju grešaka (kôd greške %d)."
 
-#: ../src/unix/snglinst.cpp:168
+#: ../src/unix/snglinst.cpp:165
 #, c-format
 msgid "Failed to write to lock file '%s'"
 msgstr "Neuspjelo pisanje u datoteku za zaključavanje „%s”."
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:209
+#: ../src/propgrid/propgrid.cpp:190
 msgid "False"
 msgstr "Netočno"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:694
+#: ../src/propgrid/advprops.cpp:604
 msgid "Family"
 msgstr "Obitelj"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/gtk/glcanvas.cpp:176 ../src/gtk/glcanvas.cpp:187
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Greška datoteke"
+
+#: ../src/common/stockitem.cpp:154
 msgid "File"
 msgstr "Datoteka"
 
-#: ../src/common/docview.cpp:669
+#: ../src/common/docview.cpp:664
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Nije bilo moguće otvoriti datoteku „%s”, za čitanje."
 
-#: ../src/common/docview.cpp:646
+#: ../src/common/docview.cpp:641
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Nije bilo moguće otvoriti datoteku „%s”, za zapisivanje."
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "Datoteka „%s”već postoji. Sigurno je želiš prepisati?"
 
-#: ../src/common/filefn.cpp:1156
+#: ../src/common/filefn.cpp:1044
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Nije bilo moguće ukloniti datoteku „%s”"
 
-#: ../src/common/filefn.cpp:1139
+#: ../src/common/filefn.cpp:1028
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Datoteku „%s” nije bilo moguće preimenovati „%s”"
 
-#: ../src/richtext/richtextctrl.cpp:3081 ../src/common/textcmn.cpp:953
+#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
 msgid "File couldn't be loaded."
 msgstr "Nije bilo moguće učitati datoteku."
 
-#: ../src/msw/filedlg.cpp:393
+#: ../src/msw/filedlg.cpp:414
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Greška u dijalogu, sa šifrom greške %0lx."
 
-#: ../src/common/docview.cpp:1789
+#: ../src/common/docview.cpp:1783
 msgid "File error"
 msgstr "Greška datoteke"
 
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/filectrlg.cpp:770
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/filectrlg.cpp:766
 msgid "File name exists already."
 msgstr "Ime datoteke već postoji."
+
+#: ../src/osx/cocoa/filedlg.mm:264
+#, fuzzy
+msgid "File type:"
+msgstr "Pisaći stroj"
 
 #: ../src/motif/filedlg.cpp:220
 msgid "Files"
 msgstr "Datoteke"
 
-#: ../src/common/filefn.cpp:1591
+#: ../src/common/filefn.cpp:1479
 #, c-format
 msgid "Files (%s)"
 msgstr "Datoteke (%s)"
@@ -3739,15 +3821,29 @@ msgstr "Datoteke (%s)"
 msgid "Filter"
 msgstr "Filtar"
 
-#: ../src/common/stockitem.cpp:158 ../src/html/helpwnd.cpp:490
+#: ../src/html/helpwnd.cpp:488
 msgid "Find"
 msgstr "Nađi"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:259
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:258
+#, fuzzy
+msgid "Find in document"
+msgstr "Otvori HTML datoteku"
+
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "Find..."
+msgstr "Nađi"
+
+#: ../src/common/stockitem.cpp:156
 msgid "First"
 msgstr "Prvi"
 
-#: ../src/common/prntbase.cpp:1548
+#: ../src/common/prntbase.cpp:1573
 msgid "First page"
 msgstr "Prva stranica"
 
@@ -3755,11 +3851,11 @@ msgstr "Prva stranica"
 msgid "Fixed"
 msgstr "Fiksni"
 
-#: ../src/html/helpwnd.cpp:1206
+#: ../src/html/helpwnd.cpp:1204
 msgid "Fixed font:"
 msgstr "Font fiksne širine:"
 
-#: ../src/html/helpwnd.cpp:1269
+#: ../src/html/helpwnd.cpp:1267
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Font fiksne širine.<br> <b>debeli</b> <i>kurziv</i> "
 
@@ -3767,16 +3863,16 @@ msgstr "Font fiksne širine.<br> <b>debeli</b> <i>kurziv</i> "
 msgid "Floating"
 msgstr "Lebdeći"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "Floppy"
 msgstr "Flopi disk"
 
-#: ../src/common/paper.cpp:111
+#: ../src/common/paper.cpp:108
 msgid "Folio, 8 1/2 x 13 in"
 msgstr "Folio, 8 1/2 × 13 in"
 
-#: ../src/richtext/richtextformatdlg.cpp:344 ../src/osx/carbon/fontdlg.cpp:287
-#: ../src/common/stockitem.cpp:194
+#: ../src/osx/carbon/fontdlg.cpp:284 ../src/common/stockitem.cpp:191
+#: ../src/richtext/richtextformatdlg.cpp:337
 msgid "Font"
 msgstr "Font"
 
@@ -3784,7 +3880,24 @@ msgstr "Font"
 msgid "Font &weight:"
 msgstr "&Debljina fonta:"
 
-#: ../src/html/helpwnd.cpp:1207
+#: ../src/osx/fontutil.cpp:89
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
+"\"."
+msgstr ""
+
+#: ../src/msw/font.cpp:1126
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Nije bilo moguće učitati datoteku."
+
+#: ../src/osx/fontutil.cpp:81
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr ": datoteka ne postoji!"
+
+#: ../src/html/helpwnd.cpp:1205
 msgid "Font size:"
 msgstr "Veličina fonta:"
 
@@ -3792,53 +3905,53 @@ msgstr "Veličina fonta:"
 msgid "Font st&yle:"
 msgstr "St&il fonta:"
 
-#: ../src/osx/carbon/fontdlg.cpp:329
+#: ../src/osx/carbon/fontdlg.cpp:326
 msgid "Font:"
 msgstr "Font:"
 
-#: ../src/dfb/fontmgr.cpp:198
+#: ../src/dfb/fontmgr.cpp:195
 #, c-format
 msgid "Fonts index file %s disappeared while loading fonts."
 msgstr "Indeksna datoteka fontova %s je nestala prilikom učitavanja fontova."
 
-#: ../src/unix/utilsunx.cpp:645
+#: ../src/unix/utilsunx.cpp:647
 msgid "Fork failed"
 msgstr "Račvanje nije uspjelo"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "Forward"
 msgstr "Naprijed"
 
-#: ../src/common/xtixml.cpp:235
+#: ../src/common/xtixml.cpp:231
 msgid "Forward hrefs are not supported"
 msgstr "Hrefs prema naprijed nisu podržani"
 
-#: ../src/html/helpwnd.cpp:875
+#: ../src/html/helpwnd.cpp:873
 #, c-format
 msgid "Found %i matches"
 msgstr "Nađena su %i poklapanja"
 
-#: ../src/generic/prntdlgg.cpp:238
+#: ../src/generic/prntdlgg.cpp:231
 msgid "From:"
 msgstr "Od:"
 
-#: ../src/propgrid/advprops.cpp:1604
+#: ../src/propgrid/advprops.cpp:1510
 msgid "Fuchsia"
 msgstr "Fuksija"
 
-#: ../src/common/imaggif.cpp:138
+#: ../src/common/imaggif.cpp:135
 msgid "GIF: data stream seems to be truncated."
 msgstr "GIF: čini se, da je prijenos podataka odrezan."
 
-#: ../src/common/imaggif.cpp:128
+#: ../src/common/imaggif.cpp:125
 msgid "GIF: error in GIF image format."
 msgstr "GIF: greška u GIF formatu slike."
 
-#: ../src/common/imaggif.cpp:133
+#: ../src/common/imaggif.cpp:130
 msgid "GIF: not enough memory."
 msgstr "GIF: nema dovoljno memorije."
 
-#: ../src/gtk/window.cpp:4631
+#: ../src/gtk/window.cpp:5635
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -3846,23 +3959,23 @@ msgstr ""
 "Na ovom računalu instalirani GTK+ je pre star za podržavanje dijeljenja "
 "ekrana, instaliraj GTK+ 2.12 ili noviju verziju."
 
-#: ../src/univ/themes/gtk.cpp:525
+#: ../src/univ/themes/gtk.cpp:522
 msgid "GTK+ theme"
 msgstr "GTK+ tema"
 
-#: ../src/common/preferencescmn.cpp:40
+#: ../src/common/preferencescmn.cpp:37
 msgid "General"
 msgstr "Općenito"
 
-#: ../src/common/prntbase.cpp:258
+#: ../src/common/prntbase.cpp:253
 msgid "Generic PostScript"
 msgstr "Generički PostScript"
 
-#: ../src/common/paper.cpp:135
+#: ../src/common/paper.cpp:132
 msgid "German Legal Fanfold, 8 1/2 x 13 in"
 msgstr "Njemački Legal presavijen, 8 1/2 × 13 in"
 
-#: ../src/common/paper.cpp:134
+#: ../src/common/paper.cpp:131
 msgid "German Std Fanfold, 8 1/2 x 12 in"
 msgstr "Njemački Std presavijen, 8 1/2 × 12 in"
 
@@ -3878,48 +3991,48 @@ msgstr "GetPropertyCollection je pozvano na generički pristupnik"
 msgid "GetPropertyCollection called w/o valid collection getter"
 msgstr "GetPropertyCollection je pozvano bez valjanog dobavljača kolekcija"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:658
 msgid "Go back"
 msgstr "Idi natrag"
 
-#: ../src/html/helpwnd.cpp:661
+#: ../src/html/helpwnd.cpp:659
 msgid "Go forward"
 msgstr "Idi naprijed"
 
-#: ../src/html/helpwnd.cpp:663
+#: ../src/html/helpwnd.cpp:661
 msgid "Go one level up in document hierarchy"
 msgstr "Idi jednu razinu prema gore u hijerarhiji dokumenata"
 
-#: ../src/generic/filedlgg.cpp:208 ../src/generic/dirdlgg.cpp:116
+#: ../src/generic/filedlgg.cpp:205 ../src/generic/dirdlgg.cpp:113
 msgid "Go to home directory"
 msgstr "Idi na osnovnu mapu"
 
-#: ../src/generic/filedlgg.cpp:205
+#: ../src/generic/filedlgg.cpp:202
 msgid "Go to parent directory"
 msgstr "Idi na matičnu mapu"
 
-#: ../src/generic/aboutdlgg.cpp:76
+#: ../src/generic/aboutdlgg.cpp:73
 msgid "Graphics art by "
 msgstr "Grafike su izrađene od "
 
-#: ../src/propgrid/advprops.cpp:1599
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Gray"
 msgstr "Siva"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:883
+#: ../src/propgrid/advprops.cpp:784
 msgid "GrayText"
 msgstr "Sivi tekst"
 
-#: ../src/common/fmapbase.cpp:154
+#: ../src/common/fmapbase.cpp:151
 msgid "Greek (ISO-8859-7)"
 msgstr "Grčki (ISO-8859-7)"
 
-#: ../src/propgrid/advprops.cpp:1600
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Green"
 msgstr "Zelena"
 
-#: ../src/generic/colrdlgg.cpp:342
+#: ../src/generic/colrdlgg.cpp:362
 msgid "Green:"
 msgstr "Zelena:"
 
@@ -3927,107 +4040,107 @@ msgstr "Zelena:"
 msgid "Groove"
 msgstr "Groove"
 
-#: ../src/common/zstream.cpp:158 ../src/common/zstream.cpp:318
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
 msgid "Gzip not supported by this version of zlib"
 msgstr "Gzip nije podržan od ove verzije zlib-a"
 
-#: ../src/html/helpwnd.cpp:1549
+#: ../src/html/helpwnd.cpp:1547
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "HTML pomoćni projekt (*.hhp)|*.hhp|"
 
-#: ../src/html/htmlwin.cpp:681
+#: ../src/html/htmlwin.cpp:691
 #, c-format
 msgid "HTML anchor %s does not exist."
 msgstr "HTML sidro %s ne postoji."
 
-#: ../src/html/helpwnd.cpp:1547
+#: ../src/html/helpwnd.cpp:1545
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "HTML datoteke (*.html;*.htm)|*.html;*.htm|"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1759
+#: ../src/propgrid/advprops.cpp:1660
 msgid "Hand"
 msgstr "Ruka"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "Harddisk"
 msgstr "Čvrsti disk"
 
-#: ../src/common/fmapbase.cpp:155
+#: ../src/common/fmapbase.cpp:152
 msgid "Hebrew (ISO-8859-8)"
 msgstr "Hebrejski (ISO-8859-8-E)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:280 ../src/osx/button_osx.cpp:39
-#: ../src/common/stockitem.cpp:163 ../src/common/accelcmn.cpp:80
-#: ../src/html/helpdlg.cpp:66 ../src/html/helpfrm.cpp:111
+#: ../include/wx/msgdlg.h:282 ../src/osx/button_osx.cpp:39
+#: ../src/common/stockitem.cpp:160 ../src/common/accelcmn.cpp:77
+#: ../src/html/helpfrm.cpp:108 ../src/html/helpdlg.cpp:63
 msgid "Help"
 msgstr "Pomoć"
 
-#: ../src/html/helpwnd.cpp:1200
+#: ../src/html/helpwnd.cpp:1198
 msgid "Help Browser Options"
 msgstr "Pomoć za opcije preglednika"
 
-#: ../src/generic/helpext.cpp:454 ../src/generic/helpext.cpp:455
+#: ../src/generic/helpext.cpp:452 ../src/generic/helpext.cpp:453
 msgid "Help Index"
 msgstr "Pomoć za index"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1529
 msgid "Help Printing"
 msgstr "Pomoć za ispis"
 
-#: ../src/html/helpwnd.cpp:801
+#: ../src/html/helpwnd.cpp:799
 msgid "Help Topics"
 msgstr "Pomoć za teme"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1546
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Pomoćne knjige (*.htb)|*.htb|Pomoćne knjige (*.zip)|*.zip|"
 
-#: ../src/generic/helpext.cpp:267
+#: ../src/generic/helpext.cpp:265
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "Mapa pomoći „%s” nije nađena."
 
-#: ../src/generic/helpext.cpp:275
+#: ../src/generic/helpext.cpp:273
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "Datoteka pomoći „%s” nije nađena."
 
-#: ../src/html/helpctrl.cpp:63
+#: ../src/html/helpctrl.cpp:59
 #, c-format
 msgid "Help: %s"
 msgstr "Pomoć: %s"
 
-#: ../src/osx/menu_osx.cpp:577
+#: ../src/osx/menu_osx.cpp:469
 #, c-format
 msgid "Hide %s"
 msgstr "Sakrij %s"
 
-#: ../src/osx/menu_osx.cpp:579
+#: ../src/osx/menu_osx.cpp:471
 msgid "Hide Others"
 msgstr "Sakrij ostalo"
 
-#: ../src/generic/infobar.cpp:84
+#: ../src/generic/infobar.cpp:81
 msgid "Hide this notification message."
 msgstr "Sakrij ovu obavijest."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:884
+#: ../src/propgrid/advprops.cpp:785
 msgid "Highlight"
 msgstr "Istakni"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:885
+#: ../src/propgrid/advprops.cpp:786
 msgid "HighlightText"
 msgstr "Istakni tekst"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:164 ../src/common/accelcmn.cpp:65
+#: ../src/common/stockitem.cpp:161 ../src/common/accelcmn.cpp:62
 msgid "Home"
 msgstr "Početna"
 
-#: ../src/generic/dirctrlg.cpp:524
+#: ../src/generic/dirctrlg.cpp:490
 msgid "Home directory"
 msgstr "Početna mapa (home)"
 
@@ -4037,55 +4150,55 @@ msgid "How the object will float relative to the text."
 msgstr "Kako će se objekt postaviti u odnosu na tekst."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1760
+#: ../src/propgrid/advprops.cpp:1661
 msgid "I-Beam"
 msgstr "I-greda"
 
-#: ../src/common/imagbmp.cpp:1196
+#: ../src/common/imagbmp.cpp:1208
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: Greška prilikom čitanja DIB maske."
 
-#: ../src/common/imagbmp.cpp:1290 ../src/common/imagbmp.cpp:1390
-#: ../src/common/imagbmp.cpp:1405 ../src/common/imagbmp.cpp:1416
-#: ../src/common/imagbmp.cpp:1430 ../src/common/imagbmp.cpp:1478
-#: ../src/common/imagbmp.cpp:1493 ../src/common/imagbmp.cpp:1507
-#: ../src/common/imagbmp.cpp:1518
+#: ../src/common/imagbmp.cpp:1302 ../src/common/imagbmp.cpp:1402
+#: ../src/common/imagbmp.cpp:1417 ../src/common/imagbmp.cpp:1428
+#: ../src/common/imagbmp.cpp:1442 ../src/common/imagbmp.cpp:1490
+#: ../src/common/imagbmp.cpp:1505 ../src/common/imagbmp.cpp:1519
+#: ../src/common/imagbmp.cpp:1530
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: Greška prilikom zapisivanja slike!"
 
-#: ../src/common/imagbmp.cpp:1255
+#: ../src/common/imagbmp.cpp:1267
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: Slika je pre visoka za ikonu."
 
-#: ../src/common/imagbmp.cpp:1263
+#: ../src/common/imagbmp.cpp:1275
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: Slika je pre široka za ikonu."
 
-#: ../src/common/imagbmp.cpp:1603
+#: ../src/common/imagbmp.cpp:1615
 msgid "ICO: Invalid icon index."
 msgstr "ICO: Nevaljani indeks ikone."
 
-#: ../src/common/imagiff.cpp:758
+#: ../src/common/imagiff.cpp:755
 msgid "IFF: data stream seems to be truncated."
 msgstr "IFF: čini se, da je prijenos podataka odrezan."
 
-#: ../src/common/imagiff.cpp:742
+#: ../src/common/imagiff.cpp:739
 msgid "IFF: error in IFF image format."
 msgstr "IFF: greška u IFF formatu slike."
 
-#: ../src/common/imagiff.cpp:745
+#: ../src/common/imagiff.cpp:742
 msgid "IFF: not enough memory."
 msgstr "IFF: nema dovoljno memorije."
 
-#: ../src/common/imagiff.cpp:748
+#: ../src/common/imagiff.cpp:745
 msgid "IFF: unknown error!!!"
 msgstr "IFF: nepoznata greška!!!"
 
-#: ../src/common/fmapbase.cpp:197
+#: ../src/common/fmapbase.cpp:194
 msgid "ISO-2022-JP"
 msgstr "Japanski (ISO-2022-JP)"
 
-#: ../src/html/htmprint.cpp:282
+#: ../src/html/htmprint.cpp:294
 msgid ""
 "If possible, try changing the layout parameters to make the printout more "
 "narrow."
@@ -4093,7 +4206,7 @@ msgstr ""
 "Ako moguće, pokušj promijeniti parametre za poredak stranice, kako bi ispis "
 "ispao uži."
 
-#: ../src/generic/dbgrptg.cpp:358
+#: ../src/generic/dbgrptg.cpp:362
 msgid ""
 "If you have any additional information pertaining to this bug\n"
 "report, please enter it here and it will be joined to it:"
@@ -4113,46 +4226,50 @@ msgstr ""
 "Time na žalost onemogućuješ ispravljanje grešaka u budućnosti.\n"
 "Ako možeš, molimo te da nastaviš s izradom izvještaja.\n"
 
-#: ../src/msw/registry.cpp:1405
+#: ../src/common/zipstrm.cpp:1043
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1393
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Zanemarivanje vrijednosti „%s” tipke „%s”."
 
-#: ../src/common/xtistrm.cpp:295
+#: ../src/common/xtistrm.cpp:292
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Nevažeći razred objekta (Non-wxEvtHandler) kao izvor događaja"
 
-#: ../src/common/xti.cpp:513
+#: ../src/common/xti.cpp:510
 msgid "Illegal Parameter Count for ConstructObject Method"
 msgstr "Nevažeće brojenje parametara za ConstructObject metodu"
 
-#: ../src/common/xti.cpp:501
+#: ../src/common/xti.cpp:498
 msgid "Illegal Parameter Count for Create Method"
 msgstr "Nevažeće brojenje parametara za Create metodu"
 
-#: ../src/generic/dirctrlg.cpp:570 ../src/generic/filectrlg.cpp:756
+#: ../src/generic/dirctrlg.cpp:536 ../src/generic/filectrlg.cpp:752
 msgid "Illegal directory name."
 msgstr "Nevažeće ime mape."
 
-#: ../src/generic/filectrlg.cpp:1367
+#: ../src/generic/filectrlg.cpp:1356
 msgid "Illegal file specification."
 msgstr "Nevažeća specifikacija datoteke."
 
-#: ../src/common/image.cpp:2269
+#: ../src/common/image.cpp:2363
 msgid "Image and mask have different sizes."
 msgstr "Slika i maska imaju različite veličine."
 
-#: ../src/common/image.cpp:2746
+#: ../src/common/image.cpp:2841
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "Datoteka slike nije vrste %d."
 
-#: ../src/common/image.cpp:2877
+#: ../src/common/image.cpp:2995
 #, c-format
 msgid "Image is not of type %s."
 msgstr "Slika nije vrste %s."
 
-#: ../src/msw/textctrl.cpp:488
+#: ../src/msw/textctrl.cpp:534
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -4160,100 +4277,100 @@ msgstr ""
 "Stvaranje uređivača bogatog teksta nije moguće, koristi se jednostavni "
 "uređivač. Instaliraj riched32.dll ponovo"
 
-#: ../src/unix/utilsunx.cpp:301
+#: ../src/unix/utilsunx.cpp:303
 msgid "Impossible to get child process input"
 msgstr "Nije moguće dobiti unos podređenog procesa"
 
-#: ../src/common/filefn.cpp:1028
+#: ../src/common/filefn.cpp:917
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Nije moguće dobiti dozvolu za datoteku „%s”"
 
-#: ../src/common/filefn.cpp:1042
+#: ../src/common/filefn.cpp:931
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Nije moguće prepisati datoteku „%s”"
 
-#: ../src/common/filefn.cpp:1097
+#: ../src/common/filefn.cpp:986
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Nije moguće postaviti korisnička prava za datoteku „%s”"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:886
+#: ../src/propgrid/advprops.cpp:787
 msgid "InactiveBorder"
 msgstr "InactiveBorder"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:887
+#: ../src/propgrid/advprops.cpp:788
 msgid "InactiveCaption"
 msgstr "InactiveCaption"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:888
+#: ../src/propgrid/advprops.cpp:789
 msgid "InactiveCaptionText"
 msgstr "InactiveCaptionText"
 
-#: ../src/common/gifdecod.cpp:792
+#: ../src/common/gifdecod.cpp:826
 #, c-format
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "Nepravilna veličina GIF okvira (%u, %d) za okvir #%u"
 
-#: ../src/msw/ole/automtn.cpp:635
+#: ../src/msw/ole/automtn.cpp:626
 msgid "Incorrect number of arguments."
 msgstr "Nepravilan broj argumenata."
 
-#: ../src/common/stockitem.cpp:165
+#: ../src/common/stockitem.cpp:162
 msgid "Indent"
 msgstr "Uvlaka"
 
-#: ../src/richtext/richtextformatdlg.cpp:349
+#: ../src/richtext/richtextformatdlg.cpp:342
 msgid "Indents && Spacing"
 msgstr "Uvlake &i razmaci"
 
-#: ../src/common/stockitem.cpp:166 ../src/html/helpwnd.cpp:515
+#: ../src/common/stockitem.cpp:163 ../src/html/helpwnd.cpp:513
 msgid "Index"
 msgstr "Indeks"
 
-#: ../src/common/fmapbase.cpp:159
+#: ../src/common/fmapbase.cpp:156
 msgid "Indian (ISO-8859-12)"
 msgstr "Indijski (ISO-8859-12)"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "Info"
 msgstr "Informacije"
 
-#: ../src/common/init.cpp:287
+#: ../src/common/init.cpp:284
 msgid "Initialization failed in post init, aborting."
 msgstr "Inicijalizacija naknadne inicijalizacije nije uspjela, prekid."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:54
+#: ../src/common/accelcmn.cpp:51
 msgid "Ins"
 msgstr "Umetni"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextsymboldlg.cpp:472 ../src/common/accelcmn.cpp:53
+#: ../src/common/accelcmn.cpp:50 ../src/richtext/richtextsymboldlg.cpp:469
 msgid "Insert"
 msgstr "Umetni"
 
-#: ../src/richtext/richtextbuffer.cpp:8067
+#: ../src/richtext/richtextbuffer.cpp:8063
 msgid "Insert Field"
 msgstr "Umetni polje"
 
-#: ../src/richtext/richtextbuffer.cpp:7978
-#: ../src/richtext/richtextbuffer.cpp:8936
+#: ../src/richtext/richtextbuffer.cpp:7974
+#: ../src/richtext/richtextbuffer.cpp:8934
 msgid "Insert Image"
 msgstr "Umetni sliku"
 
-#: ../src/richtext/richtextbuffer.cpp:8025
+#: ../src/richtext/richtextbuffer.cpp:8021
 msgid "Insert Object"
 msgstr "Umetni objekt"
 
-#: ../src/richtext/richtextctrl.cpp:1286 ../src/richtext/richtextctrl.cpp:1494
-#: ../src/richtext/richtextbuffer.cpp:7822
-#: ../src/richtext/richtextbuffer.cpp:7852
-#: ../src/richtext/richtextbuffer.cpp:7894
+#: ../src/richtext/richtextbuffer.cpp:7818
+#: ../src/richtext/richtextbuffer.cpp:7848
+#: ../src/richtext/richtextbuffer.cpp:7890
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
 msgid "Insert Text"
 msgstr "Umetni tekst"
 
@@ -4266,16 +4383,11 @@ msgstr "Umetni prijelom stranice prije odlomka."
 msgid "Inset"
 msgstr "Sužavanje"
 
-#: ../src/gtk/app.cpp:425
-#, c-format
-msgid "Invalid GTK+ command line option, use \"%s --help\""
-msgstr "Nevaljana GTK+ opcija naredbenog retka, koristi „%s --help”"
-
-#: ../src/common/imagtiff.cpp:311
+#: ../src/common/imagtiff.cpp:308
 msgid "Invalid TIFF image index."
 msgstr "Nevaljani index TIFF slike."
 
-#: ../src/common/appcmn.cpp:273
+#: ../src/common/appcmn.cpp:294
 #, c-format
 msgid "Invalid display mode specification '%s'."
 msgstr "Nevaljana specifikacija modusa prikaza „%s”."
@@ -4285,247 +4397,251 @@ msgstr "Nevaljana specifikacija modusa prikaza „%s”."
 msgid "Invalid geometry specification '%s'"
 msgstr "Nevaljana specifikacija geometrije „%s”"
 
-#: ../src/unix/fswatcher_inotify.cpp:323
+#: ../src/unix/fswatcher_inotify.cpp:320
 #, c-format
 msgid "Invalid inotify event for \"%s\""
 msgstr "Nevaljani inotify događaj za „%s”"
 
-#: ../src/unix/snglinst.cpp:312
+#: ../src/unix/snglinst.cpp:309
 #, c-format
 msgid "Invalid lock file '%s'."
 msgstr "Nevaljana datoteka za zaključavanje „%s”."
 
-#: ../src/common/translation.cpp:1125
+#: ../src/common/translation.cpp:1167
 msgid "Invalid message catalog."
 msgstr "Nevaljani katalog obavijesti."
 
-#: ../src/common/xtistrm.cpp:405 ../src/common/xtistrm.cpp:420
+#: ../src/common/xtistrm.cpp:402 ../src/common/xtistrm.cpp:417
 msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
 msgstr "Nevaljani ili Null ID objekta je proslijeđen na GetObjectClassInfo"
 
-#: ../src/common/xtistrm.cpp:435
+#: ../src/common/xtistrm.cpp:432
 msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
 msgstr "Nevaljani ili Null ID objekta je proslijeđen na HasObjectClassInfo"
 
-#: ../src/common/regex.cpp:310
+#: ../src/common/regex.cpp:307
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Nevaljan regularni izraz „%s”: %s"
 
-#: ../src/common/config.cpp:226
+#: ../src/common/config.cpp:222
 #, c-format
 msgid "Invalid value %ld for a boolean key \"%s\" in config file."
 msgstr ""
 "Nevaljana vrijedonst %ld za booleov ključ „%s” u konfiguracijskoj datoteci."
 
-#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:351
-#: ../src/osx/carbon/fontdlg.cpp:361 ../src/common/stockitem.cpp:168
+#: ../src/osx/carbon/fontdlg.cpp:358 ../src/common/stockitem.cpp:165
+#: ../src/generic/fontdlgg.cpp:325 ../src/richtext/richtextfontpage.cpp:351
 msgid "Italic"
 msgstr "Kurziv"
 
-#: ../src/common/paper.cpp:130
+#: ../src/common/paper.cpp:127
 msgid "Italy Envelope, 110 x 230 mm"
 msgstr "Talijanska kuverta, 110 × 230 mm"
 
-#: ../src/common/imagjpeg.cpp:270
+#: ../src/common/imagjpeg.cpp:257
 msgid "JPEG: Couldn't load - file is probably corrupted."
 msgstr "JPEG: Nije bilo moguće učitati – datoteka je vjerojatno oštećena."
 
-#: ../src/common/imagjpeg.cpp:449
+#: ../src/common/imagjpeg.cpp:436
 msgid "JPEG: Couldn't save image."
 msgstr "JPEG: Nije bilo moguće spremiti sliku."
 
-#: ../src/common/paper.cpp:163
+#: ../src/common/paper.cpp:160
 msgid "Japanese Double Postcard 200 x 148 mm"
 msgstr "Japanska dupla razglednica 200 × 148 mm"
 
-#: ../src/common/paper.cpp:167
+#: ../src/common/paper.cpp:164
 msgid "Japanese Envelope Chou #3"
 msgstr "Japanska kuverta Chou #3"
 
-#: ../src/common/paper.cpp:180
+#: ../src/common/paper.cpp:177
 msgid "Japanese Envelope Chou #3 Rotated"
 msgstr "Japanska kuverta Chou #3 rotirano"
 
-#: ../src/common/paper.cpp:168
+#: ../src/common/paper.cpp:165
 msgid "Japanese Envelope Chou #4"
 msgstr "Japanska kuverta Chou #4"
 
-#: ../src/common/paper.cpp:181
+#: ../src/common/paper.cpp:178
 msgid "Japanese Envelope Chou #4 Rotated"
 msgstr "Japanska kuverta Chou #4 rotirano"
 
-#: ../src/common/paper.cpp:165
+#: ../src/common/paper.cpp:162
 msgid "Japanese Envelope Kaku #2"
 msgstr "Japanska kuverta Kaku #2"
 
-#: ../src/common/paper.cpp:178
+#: ../src/common/paper.cpp:175
 msgid "Japanese Envelope Kaku #2 Rotated"
 msgstr "Japanska kuverta Kaku #2 rotirano"
 
-#: ../src/common/paper.cpp:166
+#: ../src/common/paper.cpp:163
 msgid "Japanese Envelope Kaku #3"
 msgstr "Japanska kuverta Kaku #3"
 
-#: ../src/common/paper.cpp:179
+#: ../src/common/paper.cpp:176
 msgid "Japanese Envelope Kaku #3 Rotated"
 msgstr "Japanska kuverta Kaku #3 rotirano"
 
-#: ../src/common/paper.cpp:185
+#: ../src/common/paper.cpp:182
 msgid "Japanese Envelope You #4"
 msgstr "Japanska kuverta You #4"
 
-#: ../src/common/paper.cpp:186
+#: ../src/common/paper.cpp:183
 msgid "Japanese Envelope You #4 Rotated"
 msgstr "Japanska kuverta You #4 rotirano"
 
-#: ../src/common/paper.cpp:138
+#: ../src/common/paper.cpp:135
 msgid "Japanese Postcard 100 x 148 mm"
 msgstr "Japanska razglednica 100 × 148 mm"
 
-#: ../src/common/paper.cpp:175
+#: ../src/common/paper.cpp:172
 msgid "Japanese Postcard Rotated 148 x 100 mm"
 msgstr "Japanska razglednica rotirano 148 × 100 mm"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "Jump to"
 msgstr "Prijeđi na"
 
-#: ../src/common/stockitem.cpp:171
+#: ../src/common/stockitem.cpp:168
 msgid "Justified"
 msgstr "Poravnato"
 
-#: ../src/richtext/richtextindentspage.cpp:155
-#: ../src/richtext/richtextindentspage.cpp:157
 #: ../src/richtext/richtextliststylepage.cpp:344
 #: ../src/richtext/richtextliststylepage.cpp:346
+#: ../src/richtext/richtextindentspage.cpp:155
+#: ../src/richtext/richtextindentspage.cpp:157
 msgid "Justify text left and right."
 msgstr "Poravnaj tekst lijevo i desno."
 
-#: ../src/common/fmapbase.cpp:163
+#: ../src/common/fmapbase.cpp:160
 msgid "KOI8-R"
 msgstr "KOI8-R"
 
-#: ../src/common/fmapbase.cpp:164
+#: ../src/common/fmapbase.cpp:161
 msgid "KOI8-U"
 msgstr "KOI8-U"
 
-#: ../src/common/accelcmn.cpp:265 ../src/common/accelcmn.cpp:347
+#: ../src/common/accelcmn.cpp:279 ../src/common/accelcmn.cpp:364
 msgid "KP_"
 msgstr "BT_"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "KP_Add"
 msgstr "BT_Dodaj"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "KP_Begin"
 msgstr "BT_Počni"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "KP_Decimal"
 msgstr "BT_Decimala"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 msgid "KP_Delete"
 msgstr "BT_Izbriši"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "KP_Divide"
 msgstr "BT_Dijeli"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 msgid "KP_Down"
 msgstr "BT_Dolje"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "KP_End"
 msgstr "BT_Kraj"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "KP_Enter"
 msgstr "BT_Unesi"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "KP_Equal"
 msgstr "BT_Jednako"
 
+#: ../src/common/accelcmn.cpp:276 ../src/common/accelcmn.cpp:361
+msgid "KP_F"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 msgid "KP_Home"
 msgstr "BT_Početna"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 msgid "KP_Insert"
 msgstr "BT_Umetni"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "KP_Left"
 msgstr "BT_Lijevo"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "KP_Multiply"
 msgstr "BT_Množi"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:99
+#: ../src/common/accelcmn.cpp:97
 msgid "KP_Next"
 msgstr "BT_Sljedeće"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "KP_PageDown"
 msgstr "BT_Sljedeća stranica"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "KP_PageUp"
 msgstr "BT_Prethodna stranica"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:98
+#: ../src/common/accelcmn.cpp:96
 msgid "KP_Prior"
 msgstr "BT_Prethodno"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 msgid "KP_Right"
 msgstr "BT_Desno"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "KP_Separator"
 msgstr "BT_Razdvojnik"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "KP_Space"
 msgstr "BT_Razmaknica"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "KP_Subtract"
 msgstr "BT_Oduzmi"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "KP_Tab"
 msgstr "BT_Tabulator"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "KP_Up"
 msgstr "BT_Gore"
 
@@ -4533,19 +4649,34 @@ msgstr "BT_Gore"
 msgid "L&ine spacing:"
 msgstr "Prore&d:"
 
-#: ../src/generic/prntdlgg.cpp:613 ../src/generic/prntdlgg.cpp:868
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "greška u komprimiranju"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "greška u dekomprimiranju"
+
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:861
 msgid "Landscape"
 msgstr "Položeno"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "Last"
 msgstr "Zadnji"
 
-#: ../src/common/prntbase.cpp:1572
+#: ../src/common/prntbase.cpp:1597
 msgid "Last page"
 msgstr "Zadnja stranica"
 
-#: ../src/common/log.cpp:305
+#: ../src/common/log.cpp:324
 #, c-format
 msgid "Last repeated message (\"%s\", %u time) wasn't output"
 msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
@@ -4553,93 +4684,93 @@ msgstr[0] "Zadnja ponovljena poruka („%s”, %u puta) nije iznešena"
 msgstr[1] "Zadnja ponovljena poruka („%s”, %u puta) nije iznešena"
 msgstr[2] "Zadnja ponovljena poruka („%s”, %u puta) nije iznešena"
 
-#: ../src/common/paper.cpp:103
+#: ../src/common/paper.cpp:100
 msgid "Ledger, 17 x 11 in"
 msgstr "Ledger, 17 × 11 in"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6146
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:58 ../src/generic/datavgen.cpp:6951
+#: ../src/richtext/richtextsizepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:252
 #: ../src/richtext/richtextliststylepage.cpp:253
 #: ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
-#: ../src/richtext/richtextsizepage.cpp:249 ../src/common/accelcmn.cpp:61
 msgid "Left"
 msgstr "Lijevo"
 
-#: ../src/richtext/richtextindentspage.cpp:204
 #: ../src/richtext/richtextliststylepage.cpp:390
+#: ../src/richtext/richtextindentspage.cpp:204
 msgid "Left (&first line):"
 msgstr "Lijevo (prvi redak):"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1761
+#: ../src/propgrid/advprops.cpp:1662
 msgid "Left Button"
 msgstr "Gumb-Lijevo"
 
-#: ../src/generic/prntdlgg.cpp:880
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Left margin (mm):"
 msgstr "Lijeva margina (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:141
-#: ../src/richtext/richtextindentspage.cpp:143
 #: ../src/richtext/richtextliststylepage.cpp:330
 #: ../src/richtext/richtextliststylepage.cpp:332
+#: ../src/richtext/richtextindentspage.cpp:141
+#: ../src/richtext/richtextindentspage.cpp:143
 msgid "Left-align text."
 msgstr "Poravnaj tekst u lijevo."
 
-#: ../src/common/paper.cpp:144
+#: ../src/common/paper.cpp:141
 msgid "Legal Extra 9 1/2 x 15 in"
 msgstr "Legal Extra 9 1/2 x 15 in"
 
-#: ../src/common/paper.cpp:96
+#: ../src/common/paper.cpp:93
 msgid "Legal, 8 1/2 x 14 in"
 msgstr "Legal, 8 1/2 x 14 in"
 
-#: ../src/common/paper.cpp:143
+#: ../src/common/paper.cpp:140
 msgid "Letter Extra 9 1/2 x 12 in"
 msgstr "Letter Extra 9 1/2 x 12 in"
 
-#: ../src/common/paper.cpp:149
+#: ../src/common/paper.cpp:146
 msgid "Letter Extra Transverse 9.275 x 12 in"
 msgstr "Letter Extra Transverse 9.275 x 12 in"
 
-#: ../src/common/paper.cpp:152
+#: ../src/common/paper.cpp:149
 msgid "Letter Plus 8 1/2 x 12.69 in"
 msgstr "Letter Plus 8 1/2 x 12.69 in"
 
-#: ../src/common/paper.cpp:169
+#: ../src/common/paper.cpp:166
 msgid "Letter Rotated 11 x 8 1/2 in"
 msgstr "Letter Rotated 11 x 8 1/2 in"
 
-#: ../src/common/paper.cpp:101
+#: ../src/common/paper.cpp:98
 msgid "Letter Small, 8 1/2 x 11 in"
 msgstr "Letter Small, 8 1/2 x 11 in"
 
-#: ../src/common/paper.cpp:147
+#: ../src/common/paper.cpp:144
 msgid "Letter Transverse 8 1/2 x 11 in"
 msgstr "Letter Transverse 8 1/2 x 11 in"
 
-#: ../src/common/paper.cpp:95
+#: ../src/common/paper.cpp:92
 msgid "Letter, 8 1/2 x 11 in"
 msgstr "Letter, 8 1/2 x 11 in"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "License"
 msgstr "Licenca"
 
-#: ../src/generic/fontdlgg.cpp:332
+#: ../src/generic/fontdlgg.cpp:328
 msgid "Light"
 msgstr "Svijetli"
 
-#: ../src/propgrid/advprops.cpp:1608
+#: ../src/propgrid/advprops.cpp:1514
 msgid "Lime"
 msgstr "Limun"
 
-#: ../src/generic/helpext.cpp:294
+#: ../src/generic/helpext.cpp:292
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr "%lu. redak datoteke „%s” ima nevaljanu sintaksu, preskočeno."
@@ -4648,15 +4779,15 @@ msgstr "%lu. redak datoteke „%s” ima nevaljanu sintaksu, preskočeno."
 msgid "Line spacing:"
 msgstr "Prored:"
 
-#: ../src/html/chm.cpp:838
+#: ../src/html/chm.cpp:829
 msgid "Link contained '//', converted to absolute link."
 msgstr "Poveznica je sadržavala „//”; pretvorena je u apsolutnu poveznicu."
 
-#: ../src/richtext/richtextformatdlg.cpp:364
+#: ../src/richtext/richtextformatdlg.cpp:357
 msgid "List Style"
 msgstr "Stil popisa"
 
-#: ../src/richtext/richtextstyles.cpp:1064
+#: ../src/richtext/richtextstyles.cpp:1061
 msgid "List styles"
 msgstr "Stilovi popisa"
 
@@ -4670,26 +4801,26 @@ msgstr "Popisuje veličine fonta u tiplografskim točkama."
 msgid "Lists the available fonts."
 msgstr "Popisuje dostupne fontove."
 
-#: ../src/common/fldlgcmn.cpp:340
+#: ../src/common/fldlgcmn.cpp:337
 #, c-format
 msgid "Load %s file"
 msgstr "Učitaj %s datoteku"
 
-#: ../src/html/htmlwin.cpp:597
+#: ../src/html/htmlwin.cpp:600
 msgid "Loading : "
 msgstr "Učitavanje : "
 
-#: ../src/unix/snglinst.cpp:246
+#: ../src/unix/snglinst.cpp:243
 #, c-format
 msgid "Lock file '%s' has incorrect owner."
 msgstr "Datoteka za zaključavanje „%s” ima neipravnog vlasnika."
 
-#: ../src/unix/snglinst.cpp:251
+#: ../src/unix/snglinst.cpp:248
 #, c-format
 msgid "Lock file '%s' has incorrect permissions."
 msgstr "Datoteka za zaključavanje „%s” ima neipravna korisnička prava."
 
-#: ../src/generic/logg.cpp:576
+#: ../src/generic/logg.cpp:573
 #, c-format
 msgid "Log saved to the file '%s'."
 msgstr "Log je spremljen u datoteku „%s”."
@@ -4704,11 +4835,11 @@ msgstr "Mala slova"
 msgid "Lower case roman numerals"
 msgstr "Mali rimski brojevi"
 
-#: ../src/gtk/mdi.cpp:422 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk1/mdi.cpp:431 ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "MDI child"
 
-#: ../src/msw/helpchm.cpp:56
+#: ../src/msw/helpchm.cpp:53
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -4716,189 +4847,189 @@ msgstr ""
 "Funkcije za MS HTML pomoć nisu dostupne, jer biblioteka za MS HTML pomoć "
 "nije instalirana na ovom računalu. Instaliraj je."
 
-#: ../src/univ/themes/win32.cpp:3754
+#: ../src/univ/themes/win32.cpp:3751
 msgid "Ma&ximize"
 msgstr "Ma&ksimiraj"
 
-#: ../src/common/fmapbase.cpp:203
+#: ../src/common/fmapbase.cpp:200
 msgid "MacArabic"
 msgstr "MacArapski"
 
-#: ../src/common/fmapbase.cpp:222
+#: ../src/common/fmapbase.cpp:219
 msgid "MacArmenian"
 msgstr "MacArmenski"
 
-#: ../src/common/fmapbase.cpp:211
+#: ../src/common/fmapbase.cpp:208
 msgid "MacBengali"
 msgstr "MacBengalski"
 
-#: ../src/common/fmapbase.cpp:217
+#: ../src/common/fmapbase.cpp:214
 msgid "MacBurmese"
 msgstr "MacBurmanski"
 
-#: ../src/common/fmapbase.cpp:236
+#: ../src/common/fmapbase.cpp:233
 msgid "MacCeltic"
 msgstr "MacKeltski"
 
-#: ../src/common/fmapbase.cpp:227
+#: ../src/common/fmapbase.cpp:224
 msgid "MacCentralEurRoman"
 msgstr "MacSrednjeeuropskiLatinični"
 
-#: ../src/common/fmapbase.cpp:223
+#: ../src/common/fmapbase.cpp:220
 msgid "MacChineseSimp"
 msgstr "MacKineskiPojednostavljeni"
 
-#: ../src/common/fmapbase.cpp:201
+#: ../src/common/fmapbase.cpp:198
 msgid "MacChineseTrad"
 msgstr "MacKineskiTradicionalni"
 
-#: ../src/common/fmapbase.cpp:233
+#: ../src/common/fmapbase.cpp:230
 msgid "MacCroatian"
 msgstr "MacHrvatski"
 
-#: ../src/common/fmapbase.cpp:206
+#: ../src/common/fmapbase.cpp:203
 msgid "MacCyrillic"
 msgstr "MacĆirilica"
 
-#: ../src/common/fmapbase.cpp:207
+#: ../src/common/fmapbase.cpp:204
 msgid "MacDevanagari"
 msgstr "MacDevanagarski"
 
-#: ../src/common/fmapbase.cpp:231
+#: ../src/common/fmapbase.cpp:228
 msgid "MacDingbats"
 msgstr "MacDingbats"
 
-#: ../src/common/fmapbase.cpp:226
+#: ../src/common/fmapbase.cpp:223
 msgid "MacEthiopic"
 msgstr "MacEtiopski"
 
-#: ../src/common/fmapbase.cpp:229
+#: ../src/common/fmapbase.cpp:226
 msgid "MacExtArabic"
 msgstr "MacProšireniArapski"
 
-#: ../src/common/fmapbase.cpp:237
+#: ../src/common/fmapbase.cpp:234
 msgid "MacGaelic"
 msgstr "MacGalski"
 
-#: ../src/common/fmapbase.cpp:221
+#: ../src/common/fmapbase.cpp:218
 msgid "MacGeorgian"
 msgstr "MacGruzijski"
 
-#: ../src/common/fmapbase.cpp:205
+#: ../src/common/fmapbase.cpp:202
 msgid "MacGreek"
 msgstr "MacGrčki"
 
-#: ../src/common/fmapbase.cpp:209
+#: ../src/common/fmapbase.cpp:206
 msgid "MacGujarati"
 msgstr "MacGudžaratski"
 
-#: ../src/common/fmapbase.cpp:208
+#: ../src/common/fmapbase.cpp:205
 msgid "MacGurmukhi"
 msgstr "MacGurmuški"
 
-#: ../src/common/fmapbase.cpp:204
+#: ../src/common/fmapbase.cpp:201
 msgid "MacHebrew"
 msgstr "MacHebrejski"
 
-#: ../src/common/fmapbase.cpp:234
+#: ../src/common/fmapbase.cpp:231
 msgid "MacIcelandic"
 msgstr "MacIslandski"
 
-#: ../src/common/fmapbase.cpp:200
+#: ../src/common/fmapbase.cpp:197
 msgid "MacJapanese"
 msgstr "MacJapanski"
 
-#: ../src/common/fmapbase.cpp:214
+#: ../src/common/fmapbase.cpp:211
 msgid "MacKannada"
 msgstr "MacKanarezijski"
 
-#: ../src/common/fmapbase.cpp:238
+#: ../src/common/fmapbase.cpp:235
 msgid "MacKeyboardGlyphs"
 msgstr "MacGrafemiTipkovnice"
 
-#: ../src/common/fmapbase.cpp:218
+#: ../src/common/fmapbase.cpp:215
 msgid "MacKhmer"
 msgstr "MacKmerski"
 
-#: ../src/common/fmapbase.cpp:202
+#: ../src/common/fmapbase.cpp:199
 msgid "MacKorean"
 msgstr "MacKorejanski"
 
-#: ../src/common/fmapbase.cpp:220
+#: ../src/common/fmapbase.cpp:217
 msgid "MacLaotian"
 msgstr "MacLaoški"
 
-#: ../src/common/fmapbase.cpp:215
+#: ../src/common/fmapbase.cpp:212
 msgid "MacMalayalam"
 msgstr "MacMalajalamski"
 
-#: ../src/common/fmapbase.cpp:225
+#: ../src/common/fmapbase.cpp:222
 msgid "MacMongolian"
 msgstr "MacMongolski"
 
-#: ../src/common/fmapbase.cpp:210
+#: ../src/common/fmapbase.cpp:207
 msgid "MacOriya"
 msgstr "MacOrijski"
 
-#: ../src/common/fmapbase.cpp:199
+#: ../src/common/fmapbase.cpp:196
 msgid "MacRoman"
 msgstr "MacLatinični"
 
-#: ../src/common/fmapbase.cpp:235
+#: ../src/common/fmapbase.cpp:232
 msgid "MacRomanian"
 msgstr "MacRumunjski"
 
-#: ../src/common/fmapbase.cpp:216
+#: ../src/common/fmapbase.cpp:213
 msgid "MacSinhalese"
 msgstr "MacSinhalski"
 
-#: ../src/common/fmapbase.cpp:230
+#: ../src/common/fmapbase.cpp:227
 msgid "MacSymbol"
 msgstr "MacSimbolni"
 
-#: ../src/common/fmapbase.cpp:212
+#: ../src/common/fmapbase.cpp:209
 msgid "MacTamil"
 msgstr "MacTamilski"
 
-#: ../src/common/fmapbase.cpp:213
+#: ../src/common/fmapbase.cpp:210
 msgid "MacTelugu"
 msgstr "MacTeluški"
 
-#: ../src/common/fmapbase.cpp:219
+#: ../src/common/fmapbase.cpp:216
 msgid "MacThai"
 msgstr "MacTajski"
 
-#: ../src/common/fmapbase.cpp:224
+#: ../src/common/fmapbase.cpp:221
 msgid "MacTibetan"
 msgstr "MacTibetanski"
 
-#: ../src/common/fmapbase.cpp:232
+#: ../src/common/fmapbase.cpp:229
 msgid "MacTurkish"
 msgstr "MacTurski"
 
-#: ../src/common/fmapbase.cpp:228
+#: ../src/common/fmapbase.cpp:225
 msgid "MacVietnamese"
 msgstr "MacVijetnamski"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1762
+#: ../src/propgrid/advprops.cpp:1663
 msgid "Magnifier"
 msgstr "Povećalo"
 
-#: ../src/propgrid/advprops.cpp:2143
+#: ../src/propgrid/advprops.cpp:2050
 msgid "Make a selection:"
 msgstr "Stvori odabir:"
 
-#: ../src/richtext/richtextformatdlg.cpp:374
+#: ../src/richtext/richtextformatdlg.cpp:367
 #: ../src/richtext/richtextmarginspage.cpp:171
 msgid "Margins"
 msgstr "Margine"
 
-#: ../src/propgrid/advprops.cpp:1595
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Maroon"
 msgstr "Kestenjasta"
 
-#: ../src/generic/fdrepdlg.cpp:147
+#: ../src/generic/fdrepdlg.cpp:144
 msgid "Match case"
 msgstr "Usporedi veličinu slova"
 
@@ -4910,40 +5041,40 @@ msgstr "Maks. visina:"
 msgid "Max width:"
 msgstr "Maks. širina:"
 
-#: ../src/unix/mediactrl.cpp:947
+#: ../src/unix/mediactrl.cpp:972
 #, c-format
 msgid "Media playback error: %s"
 msgstr "Greška u pokretanju medija: %s"
 
-#: ../src/common/fs_mem.cpp:175
+#: ../src/common/fs_mem.cpp:170
 #, c-format
 msgid "Memory VFS already contains file '%s'!"
 msgstr "Memorija VFS već sadržava datoteku „%s”!"
 
 #. TRANSLATORS: Name of keyboard key
 #. TRANSLATORS: Keyword of system colour
-#: ../src/common/accelcmn.cpp:73 ../src/propgrid/advprops.cpp:889
+#: ../src/common/accelcmn.cpp:70 ../src/propgrid/advprops.cpp:790
 msgid "Menu"
 msgstr "Izbornik"
 
-#: ../src/common/msgout.cpp:124
+#: ../src/common/msgout.cpp:121
 msgid "Message"
 msgstr "Poruka"
 
-#: ../src/univ/themes/metal.cpp:168
+#: ../src/univ/themes/metal.cpp:165
 msgid "Metal theme"
 msgstr "Metalna tema"
 
-#: ../src/msw/ole/automtn.cpp:652
+#: ../src/msw/ole/automtn.cpp:643
 msgid "Method or property not found."
 msgstr "Metoda ili svojstvo nisu nađeni."
 
-#: ../src/univ/themes/win32.cpp:3752
+#: ../src/univ/themes/win32.cpp:3749
 msgid "Mi&nimize"
 msgstr "Mi&nimiraj"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1763
+#: ../src/propgrid/advprops.cpp:1664
 msgid "Middle Button"
 msgstr "Gumb-Sredina"
 
@@ -4955,36 +5086,41 @@ msgstr "Min. visina:"
 msgid "Min width:"
 msgstr "Min. širina:"
 
-#: ../src/msw/ole/automtn.cpp:668
+#: ../src/osx/cocoa/menu.mm:281
+#, fuzzy
+msgid "Minimize"
+msgstr "Mi&nimiraj"
+
+#: ../src/msw/ole/automtn.cpp:659
 msgid "Missing a required parameter."
 msgstr "Nedostaje obavezan parametar."
 
-#: ../src/generic/fontdlgg.cpp:324
+#: ../src/generic/fontdlgg.cpp:320
 msgid "Modern"
 msgstr "Moderni"
 
-#: ../src/generic/filectrlg.cpp:427
+#: ../src/generic/filectrlg.cpp:423
 msgid "Modified"
 msgstr "Izmijenjeno"
 
-#: ../src/common/module.cpp:133
+#: ../src/common/module.cpp:130
 #, c-format
 msgid "Module \"%s\" initialization failed"
 msgstr "Inicijalizacija modula „%s” nije uspjela"
 
-#: ../src/common/paper.cpp:131
+#: ../src/common/paper.cpp:128
 msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
 msgstr "Monarch kuverta, 3 7/8 × 7 1/2 in"
 
-#: ../src/msw/fswatcher.cpp:143
+#: ../src/msw/fswatcher.cpp:140
 msgid "Monitoring individual files for changes is not supported currently."
 msgstr "Praćenje promjena pojedinih datoteka se trenutačno ne podržava."
 
-#: ../src/generic/editlbox.cpp:172
+#: ../src/generic/editlbox.cpp:160
 msgid "Move down"
 msgstr "Premjesti se dolje"
 
-#: ../src/generic/editlbox.cpp:171
+#: ../src/generic/editlbox.cpp:155
 msgid "Move up"
 msgstr "Premjesti se gore"
 
@@ -4998,97 +5134,103 @@ msgstr "Premješta objekt u sljedeći odlomak."
 msgid "Moves the object to the previous paragraph."
 msgstr "Premješta objekt u prethodni odlomak."
 
-#: ../src/richtext/richtextbuffer.cpp:9966
+#: ../src/richtext/richtextbuffer.cpp:9963
 msgid "Multiple Cell Properties"
 msgstr "Višestruka svojstva ćelije"
 
-#: ../src/generic/filectrlg.cpp:424
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:82
+#, fuzzy
+msgid "Multiply"
+msgstr "BT_Množi"
+
+#: ../src/generic/filectrlg.cpp:420
 msgid "Name"
 msgstr "Ime"
 
-#: ../src/propgrid/advprops.cpp:1596
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Navy"
 msgstr "Mornarsko plava"
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "Network"
 msgstr "Mreža"
 
-#: ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173
 msgid "New"
 msgstr "Novo"
 
-#: ../src/richtext/richtextstyledlg.cpp:243
+#: ../src/richtext/richtextstyledlg.cpp:239
 msgid "New &Box Style..."
 msgstr "Novi stil &okvira …"
 
-#: ../src/richtext/richtextstyledlg.cpp:225
+#: ../src/richtext/richtextstyledlg.cpp:221
 msgid "New &Character Style..."
 msgstr "Novi stil &slovnih znakova …"
 
-#: ../src/richtext/richtextstyledlg.cpp:237
+#: ../src/richtext/richtextstyledlg.cpp:233
 msgid "New &List Style..."
 msgstr "Novi stil &popisa …"
 
-#: ../src/richtext/richtextstyledlg.cpp:231
+#: ../src/richtext/richtextstyledlg.cpp:227
 msgid "New &Paragraph Style..."
 msgstr "Novi stil &odlomka …"
 
-#: ../src/richtext/richtextstyledlg.cpp:606
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:654
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:820
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:893
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:934
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:602
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:650
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:816
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:889
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:930
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "New Style"
 msgstr "Novi stil"
 
-#: ../src/generic/editlbox.cpp:169
+#: ../src/generic/editlbox.cpp:139
 msgid "New item"
 msgstr "Nova stavka"
 
-#: ../src/generic/dirdlgg.cpp:297 ../src/generic/dirdlgg.cpp:307
-#: ../src/generic/filectrlg.cpp:618 ../src/generic/filectrlg.cpp:627
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+#: ../src/generic/dirdlgg.cpp:294 ../src/generic/dirdlgg.cpp:304
 msgid "NewName"
 msgstr "NovoIme"
 
-#: ../src/common/prntbase.cpp:1567 ../src/html/helpwnd.cpp:665
+#: ../src/common/prntbase.cpp:1592 ../src/html/helpwnd.cpp:663
 msgid "Next page"
 msgstr "Sljedeća stranica"
 
-#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:177
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:174
 #: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Ne"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1764
+#: ../src/propgrid/advprops.cpp:1665
 msgid "No Entry"
 msgstr "Zabranjen ulaz"
 
-#: ../src/generic/animateg.cpp:150
+#: ../src/generic/animateg.cpp:133
 #, c-format
 msgid "No animation handler for type %ld defined."
 msgstr "Nijedan upravljač animacijama za vrstu %ld nije određen."
 
-#: ../src/dfb/bitmap.cpp:642 ../src/dfb/bitmap.cpp:676
+#: ../src/dfb/bitmap.cpp:639 ../src/dfb/bitmap.cpp:673
 #, c-format
 msgid "No bitmap handler for type %d defined."
 msgstr "Nijedan upravljač bitmapa za vrstu %d nije određen."
 
-#: ../src/common/utilscmn.cpp:1077
+#: ../src/common/utilscmn.cpp:1095
 msgid "No default application configured for HTML files."
 msgstr "Nije konfigurirana standardna aplikacija za HTML datoteke."
 
-#: ../src/generic/helpext.cpp:445
+#: ../src/generic/helpext.cpp:443
 msgid "No entries found."
 msgstr "Unosi nisu nađeni."
 
-#: ../src/common/fontmap.cpp:421
+#: ../src/common/fontmap.cpp:418
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found,\n"
@@ -5100,7 +5242,7 @@ msgstr ""
 "no dostupno je alternativno kodiranje „%s”.\n"
 "Želiš li koristiti ovo kodiranje (inače ćeš morati odabrati neko drugo)?"
 
-#: ../src/common/fontmap.cpp:426
+#: ../src/common/fontmap.cpp:423
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found.\n"
@@ -5111,201 +5253,201 @@ msgstr ""
 "Želiš li odabrati font za ovo kodiranje (inače se tekst s ovim\n"
 "kodiranjem neće pravilno prikazati)?"
 
-#: ../src/generic/animateg.cpp:142
+#: ../src/generic/animateg.cpp:125
 msgid "No handler found for animation type."
 msgstr "Nijedan upravljač za vrstu animacije nije određen."
 
-#: ../src/common/image.cpp:2728
+#: ../src/common/image.cpp:2823
 msgid "No handler found for image type."
 msgstr "Nije nađen upravljač za vrstu slike."
 
-#: ../src/common/image.cpp:2736 ../src/common/image.cpp:2848
-#: ../src/common/image.cpp:2901
+#: ../src/common/image.cpp:2831 ../src/common/image.cpp:2954
+#: ../src/common/image.cpp:3020
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "Nijedan upravljač slikama za vrstu %d nije određen."
 
-#: ../src/common/image.cpp:2871 ../src/common/image.cpp:2915
+#: ../src/common/image.cpp:2986 ../src/common/image.cpp:3034
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "Nijedan upravljač slikama za vrstu %s nije određen."
 
-#: ../src/html/helpwnd.cpp:858
+#: ../src/html/helpwnd.cpp:856
 msgid "No matching page found yet"
 msgstr "Dosada nije nađena odgovarajuće stranica"
 
-#: ../src/unix/sound.cpp:81
+#: ../src/unix/sound.cpp:78
 msgid "No sound"
 msgstr "Bez zvuka"
 
-#: ../src/common/image.cpp:2277 ../src/common/image.cpp:2318
+#: ../src/common/image.cpp:2371 ../src/common/image.cpp:2412
 msgid "No unused colour in image being masked."
 msgstr "Nema nekorištenih boja u slici, koja se maskira."
 
-#: ../src/common/image.cpp:3374
-msgid "No unused colour in image."
-msgstr "Nema nekorištenih boja u slici."
-
-#: ../src/generic/helpext.cpp:302
+#: ../src/generic/helpext.cpp:300
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "Nije nađeno valjano mapiranje u datoteci „%s”."
 
-#: ../src/richtext/richtextborderspage.cpp:610
 #: ../src/richtext/richtextsizepage.cpp:248
 #: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:610
 msgid "None"
 msgstr "Bez"
 
-#: ../src/common/fmapbase.cpp:157
+#: ../src/common/fmapbase.cpp:154
 msgid "Nordic (ISO-8859-10)"
 msgstr "Nordic (ISO-8859-10)"
 
-#: ../src/generic/fontdlgg.cpp:328 ../src/generic/fontdlgg.cpp:331
+#: ../src/generic/fontdlgg.cpp:324 ../src/generic/fontdlgg.cpp:327
 msgid "Normal"
 msgstr "Normalni"
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1261
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Normalni font<br>i <u>podcrtano</u>. "
 
-#: ../src/html/helpwnd.cpp:1205
+#: ../src/html/helpwnd.cpp:1203
 msgid "Normal font:"
 msgstr "Normalni font:"
 
-#: ../src/propgrid/props.cpp:1128
+#: ../src/propgrid/props.cpp:1115
 #, c-format
 msgid "Not %s"
 msgstr "Nije %s"
 
-#: ../include/wx/filename.h:573 ../include/wx/filename.h:578
-msgid "Not available"
-msgstr "Nije dostupno"
+#: ../src/common/secretstore.cpp:168
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/webrequest.cpp:605
+msgid "Not enough free disk space for download."
+msgstr ""
 
 #: ../src/richtext/richtextfontpage.cpp:358
 msgid "Not underlined"
 msgstr "Nije podcrtano"
 
-#: ../src/common/paper.cpp:115
+#: ../src/common/paper.cpp:112
 msgid "Note, 8 1/2 x 11 in"
 msgstr "Note, 8 1/2 × 11 in"
 
-#: ../src/generic/notifmsgg.cpp:132
+#: ../src/generic/notifmsgg.cpp:129
 msgid "Notice"
 msgstr "Napomena"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "Num *"
 msgstr "Num *"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "Num +"
 msgstr "Num +"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "Num ,"
 msgstr "Num ,"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "Num -"
 msgstr "Num -"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "Num ."
 msgstr "Num ."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "Num /"
 msgstr "Num /"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "Num ="
 msgstr "Num ="
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "Num Begin"
 msgstr "Num Počni"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 msgid "Num Delete"
 msgstr "Num Izbriši"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 msgid "Num Down"
 msgstr "Num Dolje"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "Num End"
 msgstr "Num Kraj"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "Num Enter"
 msgstr "Num Unesi"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 msgid "Num Home"
 msgstr "Num Početna"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 msgid "Num Insert"
 msgstr "Num Umetni"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num Lock"
 msgstr "Num Zaključaj"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "Num Page Down"
 msgstr "Num Sljedeća stranica"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "Num Page Up"
 msgstr "Num Prethodna stranica"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 msgid "Num Right"
 msgstr "Num Desno"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "Num Space"
 msgstr "Num Razmak"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "Num Tab"
 msgstr "Num Tabulator"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "Num Up"
 msgstr "Num Gore"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "Num left"
 msgstr "Num Lijevo"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num_lock"
 msgstr "Num_zaključaj"
 
@@ -5314,13 +5456,13 @@ msgstr "Num_zaključaj"
 msgid "Numbered outline"
 msgstr "Numerirani sadržaj"
 
-#: ../include/wx/msgdlg.h:278 ../src/richtext/richtextstyledlg.cpp:297
-#: ../src/common/stockitem.cpp:178 ../src/msw/msgdlg.cpp:454
-#: ../src/msw/msgdlg.cpp:747 ../src/gtk1/fontdlg.cpp:138
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:175
+#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/msgdlg.cpp:741 ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "U redu"
 
-#: ../src/msw/ole/automtn.cpp:692
+#: ../src/msw/ole/automtn.cpp:683
 #, c-format
 msgid "OLE Automation error in %s: %s"
 msgstr "Greška OLE automatizacije u %s: %s"
@@ -5329,15 +5471,15 @@ msgstr "Greška OLE automatizacije u %s: %s"
 msgid "Object Properties"
 msgstr "Svojstva objekta"
 
-#: ../src/msw/ole/automtn.cpp:660
+#: ../src/msw/ole/automtn.cpp:651
 msgid "Object implementation does not support named arguments."
 msgstr "Implementacija objekta ne podržava imenovane argumente."
 
-#: ../src/common/xtixml.cpp:264
+#: ../src/common/xtixml.cpp:260
 msgid "Objects must have an id attribute"
 msgstr "Objekt mora imati id svojstvo"
 
-#: ../src/propgrid/advprops.cpp:1601
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Olive"
 msgstr "Maslinasta"
 
@@ -5345,64 +5487,69 @@ msgstr "Maslinasta"
 msgid "Opaci&ty:"
 msgstr "Neprozirnos&t:"
 
-#: ../src/generic/colrdlgg.cpp:354
+#: ../src/generic/colrdlgg.cpp:374
 msgid "Opacity:"
 msgstr "Neprozirnost:"
 
-#: ../src/common/docview.cpp:1773 ../src/common/docview.cpp:1815
+#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
 msgid "Open File"
 msgstr "Otvori datoteku"
 
-#: ../src/html/helpwnd.cpp:671 ../src/html/helpwnd.cpp:1554
+#: ../src/html/helpwnd.cpp:669 ../src/html/helpwnd.cpp:1552
 msgid "Open HTML document"
 msgstr "Otvori HTML datoteku"
 
-#: ../src/generic/dbgrptg.cpp:163
+#: ../src/common/stockitem.cpp:265
+#, fuzzy
+msgid "Open an existing document"
+msgstr "Otvori HTML datoteku"
+
+#: ../src/generic/dbgrptg.cpp:160
 #, c-format
 msgid "Open file \"%s\""
 msgstr "Otvori datoteku „%s”"
 
-#: ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176
 msgid "Open..."
 msgstr "Otvori …"
 
-#: ../src/unix/glx11.cpp:506 ../src/msw/glcanvas.cpp:592
+#: ../src/msw/glcanvas.cpp:607 ../src/unix/glx11.cpp:513
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr "OpenGL driver ne podržava OpenGL 3.0 i novije."
 
-#: ../src/generic/dirctrlg.cpp:599 ../src/generic/dirdlgg.cpp:323
-#: ../src/generic/filectrlg.cpp:642 ../src/generic/filectrlg.cpp:786
+#: ../src/generic/dirctrlg.cpp:565 ../src/generic/filectrlg.cpp:638
+#: ../src/generic/filectrlg.cpp:782 ../src/generic/dirdlgg.cpp:320
 msgid "Operation not permitted."
 msgstr "Operacija nije dozvoljena."
 
-#: ../src/common/cmdline.cpp:900
+#: ../src/common/cmdline.cpp:896
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "Nije moguće negirati opciju „%s”"
 
-#: ../src/common/cmdline.cpp:1064
+#: ../src/common/cmdline.cpp:1060
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "Opcija „%s” zahtijeva vrijednost."
 
-#: ../src/common/cmdline.cpp:1147
+#: ../src/common/cmdline.cpp:1143
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Opcija „%s”: Nije moguće konvertirati ’%s’ u datum."
 
-#: ../src/generic/prntdlgg.cpp:618
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Opcije"
 
-#: ../src/propgrid/advprops.cpp:1606
+#: ../src/propgrid/advprops.cpp:1512
 msgid "Orange"
 msgstr "Narančasta"
 
-#: ../src/generic/prntdlgg.cpp:615 ../src/generic/prntdlgg.cpp:869
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:862
 msgid "Orientation"
 msgstr "Položaj"
 
-#: ../src/common/windowid.cpp:242
+#: ../src/common/windowid.cpp:237
 msgid "Out of window IDs.  Recommend shutting down application."
 msgstr "Van prozorskih ID-a. Preporučava se zatvaranje aplikacije."
 
@@ -5415,148 +5562,148 @@ msgstr "Kontura"
 msgid "Outset"
 msgstr "Širenje"
 
-#: ../src/msw/ole/automtn.cpp:656
+#: ../src/msw/ole/automtn.cpp:647
 msgid "Overflow while coercing argument values."
 msgstr "Prekoračenje prilikom prisiljivanja vrijedonsti argumenta."
 
-#: ../src/common/imagpcx.cpp:457 ../src/common/imagpcx.cpp:480
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:479
 msgid "PCX: couldn't allocate memory"
 msgstr "BMP: Nije bilo moguće alocirati memoriju"
 
-#: ../src/common/imagpcx.cpp:456
+#: ../src/common/imagpcx.cpp:455
 msgid "PCX: image format unsupported"
 msgstr "PCX: format slike nije podržan"
 
-#: ../src/common/imagpcx.cpp:479
+#: ../src/common/imagpcx.cpp:478
 msgid "PCX: invalid image"
 msgstr "PCX: nevaljana slika"
 
-#: ../src/common/imagpcx.cpp:442
+#: ../src/common/imagpcx.cpp:441
 msgid "PCX: this is not a PCX file."
 msgstr "PCX: ovo nije PCX datoteka."
 
-#: ../src/common/imagpcx.cpp:459 ../src/common/imagpcx.cpp:481
+#: ../src/common/imagpcx.cpp:458 ../src/common/imagpcx.cpp:480
 msgid "PCX: unknown error !!!"
 msgstr "PCX: nepoznata greška !!!"
 
-#: ../src/common/imagpcx.cpp:458
+#: ../src/common/imagpcx.cpp:457
 msgid "PCX: version number too low"
 msgstr "PCX: broj verzije je pre nizak"
 
-#: ../src/common/imagpnm.cpp:91
+#: ../src/common/imagpnm.cpp:89
 msgid "PNM: Couldn't allocate memory."
 msgstr "PNM: Nije moguće alocirati memoriju."
 
-#: ../src/common/imagpnm.cpp:73
+#: ../src/common/imagpnm.cpp:71
 msgid "PNM: File format is not recognized."
 msgstr "PNM: Format datoteke nije prepoznat."
 
-#: ../src/common/imagpnm.cpp:112 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
 #: ../src/common/imagpnm.cpp:156
 msgid "PNM: File seems truncated."
 msgstr "PNM: Datoteka se čini odrezanom."
 
-#: ../src/common/paper.cpp:187
+#: ../src/common/paper.cpp:184
 msgid "PRC 16K 146 x 215 mm"
 msgstr "PRC 16K 146 × 215 mm"
 
-#: ../src/common/paper.cpp:200
+#: ../src/common/paper.cpp:197
 msgid "PRC 16K Rotated"
 msgstr "PRC 16K rotirano"
 
-#: ../src/common/paper.cpp:188
+#: ../src/common/paper.cpp:185
 msgid "PRC 32K 97 x 151 mm"
 msgstr "PRC 32K 97 × 151 mm"
 
-#: ../src/common/paper.cpp:201
+#: ../src/common/paper.cpp:198
 msgid "PRC 32K Rotated"
 msgstr "PRC 32K rotirano"
 
-#: ../src/common/paper.cpp:189
+#: ../src/common/paper.cpp:186
 msgid "PRC 32K(Big) 97 x 151 mm"
 msgstr "PRC 32K(veliki) 97 × 151 mm"
 
-#: ../src/common/paper.cpp:202
+#: ../src/common/paper.cpp:199
 msgid "PRC 32K(Big) Rotated"
 msgstr "PRC 32K(veliki) rotirano"
 
-#: ../src/common/paper.cpp:190
+#: ../src/common/paper.cpp:187
 msgid "PRC Envelope #1 102 x 165 mm"
 msgstr "PRC kuverta #1 102 × 165 mm"
 
-#: ../src/common/paper.cpp:203
+#: ../src/common/paper.cpp:200
 msgid "PRC Envelope #1 Rotated 165 x 102 mm"
 msgstr "PRC kuverta #1 rotirano 165 × 102 mm"
 
-#: ../src/common/paper.cpp:199
+#: ../src/common/paper.cpp:196
 msgid "PRC Envelope #10 324 x 458 mm"
 msgstr "PRC kuverta #10 324 × 458 mm"
 
-#: ../src/common/paper.cpp:212
+#: ../src/common/paper.cpp:209
 msgid "PRC Envelope #10 Rotated 458 x 324 mm"
 msgstr "PRC kuverta #10 rotirano 458 × 324 mm"
 
-#: ../src/common/paper.cpp:191
+#: ../src/common/paper.cpp:188
 msgid "PRC Envelope #2 102 x 176 mm"
 msgstr "PRC kuverta #2 102 × 176 mm"
 
-#: ../src/common/paper.cpp:204
+#: ../src/common/paper.cpp:201
 msgid "PRC Envelope #2 Rotated 176 x 102 mm"
 msgstr "PRC kuverta #2 rotirano 176 × 102 mm"
 
-#: ../src/common/paper.cpp:192
+#: ../src/common/paper.cpp:189
 msgid "PRC Envelope #3 125 x 176 mm"
 msgstr "PRC kuverta #3 125 × 176 mm"
 
-#: ../src/common/paper.cpp:205
+#: ../src/common/paper.cpp:202
 msgid "PRC Envelope #3 Rotated 176 x 125 mm"
 msgstr "PRC kuverta #3 rotirano 176 × 125 mm"
 
-#: ../src/common/paper.cpp:193
+#: ../src/common/paper.cpp:190
 msgid "PRC Envelope #4 110 x 208 mm"
 msgstr "PRC kuverta #4 110 × 208 mm"
 
-#: ../src/common/paper.cpp:206
+#: ../src/common/paper.cpp:203
 msgid "PRC Envelope #4 Rotated 208 x 110 mm"
 msgstr "PRC kuverta #4 rotirano 208 × 110 mm"
 
-#: ../src/common/paper.cpp:194
+#: ../src/common/paper.cpp:191
 msgid "PRC Envelope #5 110 x 220 mm"
 msgstr "PRC kuverta #5 110 × 220 mm"
 
-#: ../src/common/paper.cpp:207
+#: ../src/common/paper.cpp:204
 msgid "PRC Envelope #5 Rotated 220 x 110 mm"
 msgstr "PRC kuverta #5 rotirano 220 × 110 mm"
 
-#: ../src/common/paper.cpp:195
+#: ../src/common/paper.cpp:192
 msgid "PRC Envelope #6 120 x 230 mm"
 msgstr "PRC kuverta #6 120 × 230 mm"
 
-#: ../src/common/paper.cpp:208
+#: ../src/common/paper.cpp:205
 msgid "PRC Envelope #6 Rotated 230 x 120 mm"
 msgstr "PRC kuverta #6 rotirano 230 × 120 mm"
 
-#: ../src/common/paper.cpp:196
+#: ../src/common/paper.cpp:193
 msgid "PRC Envelope #7 160 x 230 mm"
 msgstr "PRC kuverta #7 160 × 230 mm"
 
-#: ../src/common/paper.cpp:209
+#: ../src/common/paper.cpp:206
 msgid "PRC Envelope #7 Rotated 230 x 160 mm"
 msgstr "PRC kuverta #7 rotirano 230 × 160 mm"
 
-#: ../src/common/paper.cpp:197
+#: ../src/common/paper.cpp:194
 msgid "PRC Envelope #8 120 x 309 mm"
 msgstr "PRC kuverta #8 120 × 309 mm"
 
-#: ../src/common/paper.cpp:210
+#: ../src/common/paper.cpp:207
 msgid "PRC Envelope #8 Rotated 309 x 120 mm"
 msgstr "PRC kuverta #8 rotirano 309 × 120 mm"
 
-#: ../src/common/paper.cpp:198
+#: ../src/common/paper.cpp:195
 msgid "PRC Envelope #9 229 x 324 mm"
 msgstr "PRC kuverta #9 229 × 324 mm"
 
-#: ../src/common/paper.cpp:211
+#: ../src/common/paper.cpp:208
 msgid "PRC Envelope #9 Rotated 324 x 229 mm"
 msgstr "PRC kuverta #9 rotirano 324 × 229 mm"
 
@@ -5564,87 +5711,91 @@ msgstr "PRC kuverta #9 rotirano 324 × 229 mm"
 msgid "Padding"
 msgstr "Odmak"
 
-#: ../src/common/prntbase.cpp:2074
+#: ../src/common/prntbase.cpp:2096
 #, c-format
 msgid "Page %d"
 msgstr "Stranica %d"
 
-#: ../src/common/prntbase.cpp:2072
+#: ../src/common/prntbase.cpp:2094
 #, c-format
 msgid "Page %d of %d"
 msgstr "%d. stranica od %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 msgid "Page Down"
 msgstr "Sljedeća stranica"
 
-#: ../src/gtk/print.cpp:826
+#: ../src/gtk/print.cpp:829
 msgid "Page Setup"
 msgstr "Postavke stranice"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 msgid "Page Up"
 msgstr "Prethodna stranica"
 
-#: ../src/generic/prntdlgg.cpp:828 ../src/common/prntbase.cpp:484
+#: ../src/common/prntbase.cpp:479 ../src/generic/prntdlgg.cpp:821
 msgid "Page setup"
 msgstr "Postavke stranice"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 msgid "PageDown"
 msgstr "Sljedeća stranica"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 msgid "PageUp"
 msgstr "Prethodna stranica"
 
-#: ../src/generic/prntdlgg.cpp:216
+#: ../src/generic/prntdlgg.cpp:209
 msgid "Pages"
 msgstr "Stranice"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1765
+#: ../src/propgrid/advprops.cpp:1666
 msgid "Paint Brush"
 msgstr "Kist za bojenje"
 
-#: ../src/generic/prntdlgg.cpp:602 ../src/generic/prntdlgg.cpp:801
-#: ../src/generic/prntdlgg.cpp:842 ../src/generic/prntdlgg.cpp:855
-#: ../src/generic/prntdlgg.cpp:1052 ../src/generic/prntdlgg.cpp:1057
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:794
+#: ../src/generic/prntdlgg.cpp:835 ../src/generic/prntdlgg.cpp:848
+#: ../src/generic/prntdlgg.cpp:1045 ../src/generic/prntdlgg.cpp:1050
 msgid "Paper size"
 msgstr "Veličina papira"
 
-#: ../src/richtext/richtextstyles.cpp:1062
+#: ../src/richtext/richtextstyles.cpp:1059
 msgid "Paragraph styles"
 msgstr "Stilovi odlomaka"
 
-#: ../src/common/xtistrm.cpp:465
+#: ../src/common/xtistrm.cpp:462
 msgid "Passing a already registered object to SetObject"
 msgstr "Slanje već registriranog objekta na SetObject"
 
-#: ../src/common/xtistrm.cpp:476
+#: ../src/common/xtistrm.cpp:473
 msgid "Passing an unknown object to GetObject"
 msgstr "Dodavanje nepoznatog objekta GetObject-u"
 
-#: ../src/richtext/richtextctrl.cpp:3513 ../src/common/stockitem.cpp:180
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:177 ../src/richtext/richtextctrl.cpp:3514
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Zalijepi"
 
-#: ../src/common/stockitem.cpp:262
+#: ../src/common/stockitem.cpp:260
 msgid "Paste selection"
 msgstr "Zalijepi odabir"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:74
+#: ../src/common/accelcmn.cpp:71
 msgid "Pause"
 msgstr "Pauza"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1766
+#: ../src/propgrid/advprops.cpp:1667
 msgid "Pencil"
 msgstr "Olovka"
 
@@ -5653,21 +5804,21 @@ msgstr "Olovka"
 msgid "Peri&od"
 msgstr "T&očka"
 
-#: ../src/generic/filectrlg.cpp:430
+#: ../src/generic/filectrlg.cpp:426
 msgid "Permissions"
 msgstr "Korisnička prava"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:60
+#: ../src/common/accelcmn.cpp:57
 msgid "PgDn"
 msgstr "Sljedeća stranica"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:59
+#: ../src/common/accelcmn.cpp:56
 msgid "PgUp"
 msgstr "Prethodna stranica"
 
-#: ../src/richtext/richtextbuffer.cpp:12868
+#: ../src/richtext/richtextbuffer.cpp:12863
 msgid "Picture Properties"
 msgstr "Svojstva slike"
 
@@ -5679,42 +5830,42 @@ msgstr "Stvaranje cjevovoda nije uspjelo"
 msgid "Please choose a valid font."
 msgstr "Odaberi valjani font."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
 msgid "Please choose an existing file."
 msgstr "Odaberi postojeću datoteku."
 
-#: ../src/html/helpwnd.cpp:800
+#: ../src/html/helpwnd.cpp:798
 msgid "Please choose the page to display:"
 msgstr "Odaberi stranicu za prikazivanje:"
 
-#: ../src/msw/dialup.cpp:764
+#: ../src/msw/dialup.cpp:758
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Odaberi davatelja internetskih usluga s kojim se želiš povezati"
 
-#: ../src/common/headerctrlcmn.cpp:59
+#: ../src/common/headerctrlcmn.cpp:57
 msgid "Please select the columns to show and define their order:"
 msgstr "Odaberi stupce koje želiš prikazati i odredi njihov raspored:"
 
-#: ../src/common/prntbase.cpp:538
+#: ../src/common/prntbase.cpp:533
 msgid "Please wait while printing..."
 msgstr "Pričekaj dok traje ispis …"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1767
+#: ../src/propgrid/advprops.cpp:1668
 msgid "Point Left"
 msgstr "Ukaži na lijevo"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1768
+#: ../src/propgrid/advprops.cpp:1669
 msgid "Point Right"
 msgstr "Ukaži na desno"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:662
+#: ../src/propgrid/advprops.cpp:572
 msgid "Point Size"
 msgstr "Veličina u tipografskim točkama"
 
-#: ../src/generic/prntdlgg.cpp:612 ../src/generic/prntdlgg.cpp:867
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:860
 msgid "Portrait"
 msgstr "Uspravno"
 
@@ -5722,150 +5873,159 @@ msgstr "Uspravno"
 msgid "Position"
 msgstr "Položaj"
 
-#: ../src/generic/prntdlgg.cpp:298
+#: ../src/generic/prntdlgg.cpp:291
 msgid "PostScript file"
 msgstr "PostScript datoteka"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178 ../src/osx/cocoa/preferences.mm:303
 msgid "Preferences"
 msgstr "Postavke"
 
-#: ../src/osx/menu_osx.cpp:568
+#: ../src/osx/menu_osx.cpp:460
 msgid "Preferences..."
 msgstr "Postavke …"
 
-#: ../src/common/prntbase.cpp:546
+#: ../src/common/prntbase.cpp:541
 msgid "Preparing"
 msgstr "Pripremanje"
 
-#: ../src/generic/fontdlgg.cpp:455 ../src/osx/carbon/fontdlg.cpp:390
-#: ../src/html/helpwnd.cpp:1222
+#: ../src/osx/carbon/fontdlg.cpp:387 ../src/generic/fontdlgg.cpp:452
+#: ../src/html/helpwnd.cpp:1220
 msgid "Preview:"
 msgstr "Pregled:"
 
-#: ../src/common/prntbase.cpp:1553 ../src/html/helpwnd.cpp:664
+#: ../src/common/prntbase.cpp:1578 ../src/html/helpwnd.cpp:662
 msgid "Previous page"
 msgstr "Prethodna stranica"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/prntdlgg.cpp:143 ../src/generic/prntdlgg.cpp:157
-#: ../src/common/prntbase.cpp:426 ../src/common/prntbase.cpp:1541
-#: ../src/common/accelcmn.cpp:77 ../src/gtk/print.cpp:620
-#: ../src/gtk/print.cpp:638
+#: ../src/common/prntbase.cpp:421 ../src/common/prntbase.cpp:1566
+#: ../src/common/accelcmn.cpp:74 ../src/generic/prntdlgg.cpp:136
+#: ../src/generic/prntdlgg.cpp:150 ../src/gtk/print.cpp:616
+#: ../src/gtk/print.cpp:634
 msgid "Print"
 msgstr "Ispiši"
 
-#: ../include/wx/prntbase.h:399 ../src/common/docview.cpp:1268
+#: ../src/common/docview.cpp:1262
 msgid "Print Preview"
 msgstr "Pregled ispisa"
 
-#: ../src/common/prntbase.cpp:2015 ../src/common/prntbase.cpp:2057
-#: ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2037 ../src/common/prntbase.cpp:2079
+#: ../src/common/prntbase.cpp:2087
 msgid "Print Preview Failure"
 msgstr "Neuspjeli pregled ispisa"
 
-#: ../src/generic/prntdlgg.cpp:224
+#: ../src/generic/prntdlgg.cpp:217
 msgid "Print Range"
 msgstr "Opseg ispisa"
 
-#: ../src/generic/prntdlgg.cpp:449
+#: ../src/generic/prntdlgg.cpp:442
 msgid "Print Setup"
 msgstr "Postavke ispisa"
 
-#: ../src/generic/prntdlgg.cpp:621
+#: ../src/generic/prntdlgg.cpp:614
 msgid "Print in colour"
 msgstr "Ispiši u boji"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/osx/webview_webkit.mm:260
+msgid "Print operation could not be initialized"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:179
 msgid "Print previe&w..."
 msgstr "Pregled ispis&a …"
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1256
 msgid "Print preview creation failed."
 msgstr "Stvaranje pregleda ispisa."
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/common/stockitem.cpp:179
 msgid "Print preview..."
 msgstr "Pregled ispisa …"
 
-#: ../src/generic/prntdlgg.cpp:630
+#: ../src/generic/prntdlgg.cpp:623
 msgid "Print spooling"
 msgstr "Pripremanje ispisa"
 
-#: ../src/html/helpwnd.cpp:675
+#: ../src/html/helpwnd.cpp:673
 msgid "Print this page"
 msgstr "Ispiši ovu stranicu"
 
-#: ../src/generic/prntdlgg.cpp:185
+#: ../src/generic/prntdlgg.cpp:178
 msgid "Print to File"
 msgstr "Ispiši u datoteku"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "Print..."
 msgstr "Ispiši …"
 
-#: ../src/generic/prntdlgg.cpp:493
+#: ../src/generic/prntdlgg.cpp:486
 msgid "Printer"
 msgstr "Pisač"
 
-#: ../src/generic/prntdlgg.cpp:633
+#: ../src/generic/prntdlgg.cpp:626
 msgid "Printer command:"
 msgstr "Naredba pisača:"
 
-#: ../src/generic/prntdlgg.cpp:180
+#: ../src/generic/prntdlgg.cpp:173
 msgid "Printer options"
 msgstr "Opcije pisača"
 
-#: ../src/generic/prntdlgg.cpp:645
+#: ../src/generic/prntdlgg.cpp:638
 msgid "Printer options:"
 msgstr "Opcije pisača:"
 
-#: ../src/generic/prntdlgg.cpp:916
+#: ../src/generic/prntdlgg.cpp:909
 msgid "Printer..."
 msgstr "Pisač …"
 
-#: ../src/generic/prntdlgg.cpp:196
+#: ../src/generic/prntdlgg.cpp:189
 msgid "Printer:"
 msgstr "Pisač:"
 
-#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:535
-#: ../src/html/htmprint.cpp:277
+#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:530
+#: ../src/html/htmprint.cpp:289
 msgid "Printing"
 msgstr "Ispisivanje"
 
-#: ../src/common/prntbase.cpp:612
+#: ../src/common/prntbase.cpp:607
 msgid "Printing "
 msgstr "Ispisivanje "
 
-#: ../src/common/prntbase.cpp:347
+#: ../src/common/prntbase.cpp:342
 msgid "Printing Error"
 msgstr "Greška prilikom ispisa"
 
-#: ../src/common/prntbase.cpp:565
+#: ../src/osx/webview_webkit.mm:251
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "Gzip nije podržan od ove verzije zlib-a"
+
+#: ../src/common/prntbase.cpp:560
 #, c-format
 msgid "Printing page %d"
 msgstr "Ispisivanje %d. stranice"
 
-#: ../src/common/prntbase.cpp:570
+#: ../src/common/prntbase.cpp:565
 #, c-format
 msgid "Printing page %d of %d"
 msgstr "Ispisivanje %d. stranice od %d"
 
-#: ../src/generic/printps.cpp:201
+#: ../src/generic/printps.cpp:182
 #, c-format
 msgid "Printing page %d..."
 msgstr "Ispisivanje %d. stranice …"
 
-#: ../src/generic/printps.cpp:161
+#: ../src/generic/printps.cpp:142
 msgid "Printing..."
 msgstr "Ispisivanje …"
 
-#: ../include/wx/richtext/richtextprint.h:109 ../include/wx/prntbase.h:267
-#: ../src/common/docview.cpp:2132
+#: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
+#: ../src/common/docview.cpp:2137
 msgid "Printout"
 msgstr "Ispis"
 
-#: ../src/common/debugrpt.cpp:560
+#: ../src/common/debugrpt.cpp:561
 #, c-format
 msgid ""
 "Processing debug report has failed, leaving the files in \"%s\" directory."
@@ -5873,102 +6033,102 @@ msgstr ""
 "Obrada izvještaja o otklanjanju grešaka nije uspjela. Datoteke ostaju u "
 "direktoriju „%s”."
 
-#: ../src/common/prntbase.cpp:545
+#: ../src/common/prntbase.cpp:540
 msgid "Progress:"
 msgstr "Tok:"
 
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181
 msgid "Properties"
 msgstr "Svojstva"
 
-#: ../src/propgrid/manager.cpp:237
+#: ../src/propgrid/manager.cpp:223
 msgid "Property"
 msgstr "Svojstvo"
 
 #. TRANSLATORS: Caption of message box displaying any property error
-#: ../src/propgrid/propgrid.cpp:3185 ../src/propgrid/propgrid.cpp:3318
+#: ../src/propgrid/propgrid.cpp:3162 ../src/propgrid/propgrid.cpp:3299
 msgid "Property Error"
 msgstr "Greška svojstva"
 
-#: ../src/propgrid/advprops.cpp:1597
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Purple"
 msgstr "Ljubičasta"
 
-#: ../src/common/paper.cpp:112
+#: ../src/common/paper.cpp:109
 msgid "Quarto, 215 x 275 mm"
 msgstr "Quarto, 215 × 275 mm"
 
-#: ../src/generic/logg.cpp:1016
+#: ../src/generic/logg.cpp:1013
 msgid "Question"
 msgstr "Pitanje"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1769
+#: ../src/propgrid/advprops.cpp:1670
 msgid "Question Arrow"
 msgstr "Strelica-Upitnik"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "Quit"
 msgstr "Zatvori"
 
-#: ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:477
 #, c-format
 msgid "Quit %s"
 msgstr "Zatvori %s"
 
-#: ../src/common/stockitem.cpp:263
+#: ../src/common/stockitem.cpp:261
 msgid "Quit this program"
 msgstr "Zatvori ovaj program"
 
-#: ../src/common/accelcmn.cpp:338
+#: ../src/common/accelcmn.cpp:352
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/ffile.cpp:109 ../src/common/ffile.cpp:133
+#: ../src/common/ffile.cpp:107 ../src/common/ffile.cpp:132
 #, c-format
 msgid "Read error on file '%s'"
 msgstr "Greška u čitanju datoteke „%s”"
 
-#: ../src/common/secretstore.cpp:199
-#, c-format
-msgid "Reading password for \"%s/%s\" failed: %s."
+#: ../src/common/secretstore.cpp:211
+#, fuzzy, c-format
+msgid "Reading password for \"%s\" failed: %s."
 msgstr "Čitanje lozinke za „%s/%s”: %s."
 
-#: ../src/common/prntbase.cpp:272
+#: ../src/common/prntbase.cpp:267
 msgid "Ready"
 msgstr "Spremno"
 
-#: ../src/propgrid/advprops.cpp:1605
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Red"
 msgstr "Crvena"
 
-#: ../src/generic/colrdlgg.cpp:339
+#: ../src/generic/colrdlgg.cpp:359
 msgid "Red:"
 msgstr "Crvena:"
 
-#: ../src/common/stockitem.cpp:185 ../src/stc/stc_i18n.cpp:16
+#: ../src/common/stockitem.cpp:182 ../src/stc/stc_i18n.cpp:16
 msgid "Redo"
 msgstr "Ponovi"
 
-#: ../src/common/stockitem.cpp:264
+#: ../src/common/stockitem.cpp:262
 msgid "Redo last action"
 msgstr "Ponovi zadnju radnju"
 
-#: ../src/common/stockitem.cpp:186
+#: ../src/common/stockitem.cpp:183
 msgid "Refresh"
 msgstr "Osvježi"
 
-#: ../src/msw/registry.cpp:626
+#: ../src/msw/registry.cpp:615
 #, c-format
 msgid "Registry key '%s' already exists."
 msgstr "Registarski ključ „%s” već postoji."
 
-#: ../src/msw/registry.cpp:595
+#: ../src/msw/registry.cpp:584
 #, c-format
 msgid "Registry key '%s' does not exist, cannot rename it."
 msgstr "Registarski ključ „%s” ne postoji; nije ga moguće preimenovati."
 
-#: ../src/msw/registry.cpp:727
+#: ../src/msw/registry.cpp:716
 #, c-format
 msgid ""
 "Registry key '%s' is needed for normal system operation,\n"
@@ -5979,22 +6139,22 @@ msgstr ""
 "Brisanjem će tvoj sustav postati nestabilan:\n"
 "operacija je prekinuta."
 
-#: ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:942
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr "Registarska vrijednost „%s” nije binarna (ali je vrste %s)"
 
-#: ../src/msw/registry.cpp:917
+#: ../src/msw/registry.cpp:905
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr "Registarska vrijednost „%s” nije numerička (ali je vrste %s)"
 
-#: ../src/msw/registry.cpp:1003
+#: ../src/msw/registry.cpp:991
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr "Registarska vrijednost „%s” nije tekst (ali je vrste %s)"
 
-#: ../src/msw/registry.cpp:521
+#: ../src/msw/registry.cpp:510
 #, c-format
 msgid "Registry value '%s' already exists."
 msgstr "Registarska vrijednost „%s” već postoji."
@@ -6008,71 +6168,77 @@ msgstr "Regular"
 msgid "Relative"
 msgstr "Relativno"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:456
 msgid "Relevant entries:"
 msgstr "Relevantni unosi:"
 
-#: ../include/wx/generic/progdlgg.h:86
+#: ../include/wx/generic/progdlgg.h:87
 msgid "Remaining time:"
 msgstr "Preostalo vrijeme:"
 
-#: ../src/common/stockitem.cpp:187
+#: ../src/common/stockitem.cpp:184
 msgid "Remove"
 msgstr "Ukloni"
 
-#: ../src/richtext/richtextctrl.cpp:1562
+#: ../src/richtext/richtextctrl.cpp:1563
 msgid "Remove Bullet"
 msgstr "Ukloni znak nabrajanja"
 
-#: ../src/html/helpwnd.cpp:433
+#: ../src/html/helpwnd.cpp:431
 msgid "Remove current page from bookmarks"
 msgstr "Ukloni trenutačnu stranicu iz knjižnih oznaka"
 
-#: ../src/common/rendcmn.cpp:194
+#: ../src/common/rendcmn.cpp:191
 #, c-format
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 "Iscrtač „%s” ima nekompatibilnu verziju %d.%d i nije ga moguće učitati."
 
-#: ../src/richtext/richtextbuffer.cpp:4527
+#: ../src/richtext/richtextbuffer.cpp:4524
 msgid "Renumber List"
 msgstr "Ponovi numeriranje"
 
-#: ../src/common/stockitem.cpp:188
-msgid "Rep&lace"
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Rep&lace..."
 msgstr "Zamije&ni"
 
-#: ../src/richtext/richtextctrl.cpp:3673 ../src/common/stockitem.cpp:188
+#: ../src/richtext/richtextctrl.cpp:3674
 msgid "Replace"
 msgstr "Zamijeni"
 
-#: ../src/generic/fdrepdlg.cpp:182
+#: ../src/generic/fdrepdlg.cpp:179
 msgid "Replace &all"
 msgstr "Zamijeni &sve"
 
-#: ../src/common/stockitem.cpp:261
-msgid "Replace selection"
-msgstr "Zamijeni odabir"
-
-#: ../src/generic/fdrepdlg.cpp:124
+#: ../src/generic/fdrepdlg.cpp:121
 msgid "Replace with:"
 msgstr "Zamijeni sa:"
 
-#: ../src/common/valtext.cpp:163
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Replace..."
+msgstr "Zamijeni"
+
+#: ../src/common/valtext.cpp:184
 msgid "Required information entry is empty."
 msgstr "Obavezan unos informacija je prazan."
 
-#: ../src/common/translation.cpp:1975
+#: ../src/common/translation.cpp:2025
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "Resurs „%s” nije valjani katalog obavijesti."
 
+#: ../src/gtk/webview_webkit.cpp:985
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:56
+#: ../src/common/accelcmn.cpp:53
 msgid "Return"
 msgstr "Potvrdi"
 
-#: ../src/common/stockitem.cpp:189
+#: ../src/common/stockitem.cpp:186
 msgid "Revert to Saved"
 msgstr "Vrati na spremljeno"
 
@@ -6084,41 +6250,41 @@ msgstr "Hrbat"
 msgid "Rig&ht-to-left"
 msgstr "Desn&o-Lijevo"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6149
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:59 ../src/generic/datavgen.cpp:6954
+#: ../src/richtext/richtextsizepage.cpp:250
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextbulletspage.cpp:188
-#: ../src/richtext/richtextsizepage.cpp:250 ../src/common/accelcmn.cpp:62
 msgid "Right"
 msgstr "Desno"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1754
+#: ../src/propgrid/advprops.cpp:1655
 msgid "Right Arrow"
 msgstr "Strelica-Desno"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1770
+#: ../src/propgrid/advprops.cpp:1671
 msgid "Right Button"
 msgstr "Gumb-Desno"
 
-#: ../src/generic/prntdlgg.cpp:892
+#: ../src/generic/prntdlgg.cpp:885
 msgid "Right margin (mm):"
 msgstr "Desna margina (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:148
-#: ../src/richtext/richtextindentspage.cpp:150
 #: ../src/richtext/richtextliststylepage.cpp:337
 #: ../src/richtext/richtextliststylepage.cpp:339
+#: ../src/richtext/richtextindentspage.cpp:148
+#: ../src/richtext/richtextindentspage.cpp:150
 msgid "Right-align text."
 msgstr "Poravnaj tekst u desno."
 
-#: ../src/generic/fontdlgg.cpp:322
+#: ../src/generic/fontdlgg.cpp:318
 msgid "Roman"
 msgstr "Serifni"
 
-#: ../src/generic/datavgen.cpp:5916
+#: ../src/generic/datavgen.cpp:6721
 #, c-format
 msgid "Row %i"
 msgstr "Red %i"
@@ -6128,30 +6294,31 @@ msgstr "Red %i"
 msgid "S&tandard bullet name:"
 msgstr "S&tandardno ime znaka nabrajanja:"
 
-#: ../src/common/accelcmn.cpp:268 ../src/common/accelcmn.cpp:350
+#: ../src/common/accelcmn.cpp:282 ../src/common/accelcmn.cpp:367
 msgid "SPECIAL"
 msgstr "SPECIJALNO"
 
-#: ../src/common/stockitem.cpp:190 ../src/common/sizer.cpp:2797
+#: ../src/common/stockitem.cpp:187 ../src/common/sizer.cpp:2914
 msgid "Save"
 msgstr "Spremi"
 
-#: ../src/common/fldlgcmn.cpp:342
+#: ../src/common/fldlgcmn.cpp:339
 #, c-format
 msgid "Save %s file"
 msgstr "Spremi %s datoteku"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/common/stockitem.cpp:188 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Spremi &pod …"
 
-#: ../src/common/docview.cpp:366
+#: ../src/common/docview.cpp:359
 msgid "Save As"
 msgstr "Spremi pod"
 
-#: ../src/common/stockitem.cpp:191
-msgid "Save as"
-msgstr "Spremi pod"
+#: ../src/common/stockitem.cpp:188
+#, fuzzy
+msgid "Save As..."
+msgstr "Spremi &pod …"
 
 #: ../src/common/stockitem.cpp:267
 msgid "Save current document"
@@ -6161,40 +6328,40 @@ msgstr "Spremi trenutačan dokument"
 msgid "Save current document with a different filename"
 msgstr "Spremi trenutačan dokument pod drugim imenom"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/generic/logg.cpp:509
 msgid "Save log contents to file"
 msgstr "Spremi log-sadržaj u datoteku"
 
-#: ../src/common/secretstore.cpp:179
-#, c-format
-msgid "Saving password for \"%s/%s\" failed: %s."
+#: ../src/common/secretstore.cpp:189
+#, fuzzy, c-format
+msgid "Saving password for \"%s\" failed: %s."
 msgstr "Spremanje lozinke za „%s/%s”: %s."
 
-#: ../src/generic/fontdlgg.cpp:325
+#: ../src/generic/fontdlgg.cpp:321
 msgid "Script"
 msgstr "Pismo"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll Lock"
 msgstr "Zaključavanje klizača"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll_lock"
 msgstr "Zaključavanje klizača"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:890
+#: ../src/propgrid/advprops.cpp:791
 msgid "Scrollbar"
 msgstr "Traka klizača"
 
-#: ../src/generic/srchctlg.cpp:56 ../src/html/helpwnd.cpp:535
-#: ../src/html/helpwnd.cpp:550
+#: ../src/generic/srchctlg.cpp:55 ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:548 ../src/gtk/srchctrl.cpp:182
 msgid "Search"
 msgstr "Traži"
 
-#: ../src/html/helpwnd.cpp:537
+#: ../src/html/helpwnd.cpp:535
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
@@ -6202,55 +6369,55 @@ msgstr ""
 "Pretraži sadržaj svih knjiga pomoći, i nađi sva pojavljivanja gore utipkanog "
 "teksta"
 
-#: ../src/generic/fdrepdlg.cpp:160
+#: ../src/generic/fdrepdlg.cpp:157
 msgid "Search direction"
 msgstr "Smjer traženja"
 
-#: ../src/generic/fdrepdlg.cpp:112
+#: ../src/generic/fdrepdlg.cpp:109
 msgid "Search for:"
 msgstr "Traži:"
 
-#: ../src/html/helpwnd.cpp:1052
+#: ../src/html/helpwnd.cpp:1050
 msgid "Search in all books"
 msgstr "Traži u svim knjigama"
 
-#: ../src/html/helpwnd.cpp:857
+#: ../src/html/helpwnd.cpp:855
 msgid "Searching..."
 msgstr "Traženje …"
 
-#: ../src/generic/dirctrlg.cpp:446
+#: ../src/generic/dirctrlg.cpp:412
 msgid "Sections"
 msgstr "Odjeljci"
 
-#: ../src/common/ffile.cpp:238
+#: ../src/common/ffile.cpp:237
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Traži grešku u datoteci „%s”"
 
-#: ../src/common/ffile.cpp:228
+#: ../src/common/ffile.cpp:227
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr "Traži grešku u datoteci „%s” (stdio ne podržava velike datoteke)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:76
+#: ../src/common/accelcmn.cpp:73
 msgid "Select"
 msgstr "Odaberi"
 
-#: ../src/richtext/richtextctrl.cpp:337 ../src/osx/textctrl_osx.cpp:581
-#: ../src/common/stockitem.cpp:192 ../src/msw/textctrl.cpp:2512
+#: ../src/osx/textctrl_osx.cpp:599 ../src/common/stockitem.cpp:189
+#: ../src/msw/textctrl.cpp:2777 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Odaberi &sve"
 
-#: ../src/common/stockitem.cpp:192 ../src/stc/stc_i18n.cpp:21
+#: ../src/common/stockitem.cpp:189 ../src/stc/stc_i18n.cpp:21
 msgid "Select All"
 msgstr "Odaberi sve"
 
-#: ../src/common/docview.cpp:1895
+#: ../src/common/docview.cpp:1900
 msgid "Select a document template"
 msgstr "Odaberi jedan predložak"
 
-#: ../src/common/docview.cpp:1969
+#: ../src/common/docview.cpp:1974
 msgid "Select a document view"
 msgstr "Odaberi jedan pogled"
 
@@ -6279,20 +6446,20 @@ msgid "Selects the list level to edit."
 msgstr "Odabire razinu popisa za uređivanje."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:82
+#: ../src/common/accelcmn.cpp:79
 msgid "Separator"
 msgstr "Razdvojnik"
 
-#: ../src/common/cmdline.cpp:1083
+#: ../src/common/cmdline.cpp:1079
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Potreban je razdvojnik nakon opcije „%s”."
 
-#: ../src/osx/menu_osx.cpp:572
+#: ../src/osx/menu_osx.cpp:464
 msgid "Services"
 msgstr "Usluge"
 
-#: ../src/richtext/richtextbuffer.cpp:11217
+#: ../src/richtext/richtextbuffer.cpp:11216
 msgid "Set Cell Style"
 msgstr "Postavi stil ćelija"
 
@@ -6300,11 +6467,11 @@ msgstr "Postavi stil ćelija"
 msgid "SetProperty called w/o valid setter"
 msgstr "SetProperty je pozvano bez valjanog postavljača"
 
-#: ../src/generic/prntdlgg.cpp:188
+#: ../src/generic/prntdlgg.cpp:181
 msgid "Setup..."
 msgstr "Postavljanje …"
 
-#: ../src/msw/dialup.cpp:544
+#: ../src/msw/dialup.cpp:538
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr "Pronađeno je nekoliko aktivnih veza, jedna je nasumce odabrana."
 
@@ -6320,40 +6487,40 @@ msgstr "Sjena"
 msgid "Shadow c&olour:"
 msgstr "&Boja sjene:"
 
-#: ../src/common/accelcmn.cpp:335
+#: ../src/common/accelcmn.cpp:349
 msgid "Shift+"
 msgstr "Shift+"
 
-#: ../src/generic/dirdlgg.cpp:147
+#: ../src/generic/dirdlgg.cpp:144
 msgid "Show &hidden directories"
 msgstr "Prikaži &skrivene mape"
 
-#: ../src/generic/filectrlg.cpp:983
+#: ../src/generic/filectrlg.cpp:979
 msgid "Show &hidden files"
 msgstr "Prikaži &skrivene datoteke"
 
-#: ../src/osx/menu_osx.cpp:580
+#: ../src/osx/menu_osx.cpp:472
 msgid "Show All"
 msgstr "Prikaži sve"
 
-#: ../src/common/stockitem.cpp:257
+#: ../src/common/stockitem.cpp:254
 msgid "Show about dialog"
 msgstr "Prikaži informativni dijalog"
 
-#: ../src/html/helpwnd.cpp:492
+#: ../src/html/helpwnd.cpp:490
 msgid "Show all"
 msgstr "Prikaži sve"
 
-#: ../src/html/helpwnd.cpp:503
+#: ../src/html/helpwnd.cpp:501
 msgid "Show all items in index"
 msgstr "Prikaži sve stavke u indeksu"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:656
 msgid "Show/hide navigation panel"
 msgstr "Prikaži/sakrij navigaciju"
 
-#: ../src/richtext/richtextsymboldlg.cpp:421
-#: ../src/richtext/richtextsymboldlg.cpp:423
+#: ../src/richtext/richtextsymboldlg.cpp:418
+#: ../src/richtext/richtextsymboldlg.cpp:420
 msgid "Shows a Unicode subset."
 msgstr "Prikazuje Unicode podskupinu."
 
@@ -6369,7 +6536,7 @@ msgstr "Prikazuje pregled postavaka znakova nabrajanja."
 msgid "Shows a preview of the font settings."
 msgstr "Prikazuje pregled font postavaka."
 
-#: ../src/osx/carbon/fontdlg.cpp:394 ../src/osx/carbon/fontdlg.cpp:396
+#: ../src/osx/carbon/fontdlg.cpp:391 ../src/osx/carbon/fontdlg.cpp:393
 msgid "Shows a preview of the font."
 msgstr "Prikazuje pregled fonta."
 
@@ -6378,62 +6545,62 @@ msgstr "Prikazuje pregled fonta."
 msgid "Shows a preview of the paragraph settings."
 msgstr "Prikazuje pregled postavaka odlomka."
 
-#: ../src/generic/fontdlgg.cpp:460 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:456 ../src/generic/fontdlgg.cpp:458
 msgid "Shows the font preview."
 msgstr "Prikazuje pregled fonta."
 
-#: ../src/propgrid/advprops.cpp:1607
+#: ../src/propgrid/advprops.cpp:1513
 msgid "Silver"
 msgstr "Srebrna"
 
-#: ../src/univ/themes/mono.cpp:516
+#: ../src/univ/themes/mono.cpp:513
 msgid "Simple monochrome theme"
 msgstr "Jednostavna jednobojna tema"
 
-#: ../src/richtext/richtextindentspage.cpp:275
 #: ../src/richtext/richtextliststylepage.cpp:449
+#: ../src/richtext/richtextindentspage.cpp:275
 msgid "Single"
 msgstr "Jedno"
 
-#: ../src/generic/filectrlg.cpp:425 ../src/richtext/richtextformatdlg.cpp:369
-#: ../src/richtext/richtextsizepage.cpp:299
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextsizepage.cpp:299
+#: ../src/richtext/richtextformatdlg.cpp:362
 msgid "Size"
 msgstr "Veličina"
 
-#: ../src/osx/carbon/fontdlg.cpp:339
+#: ../src/osx/carbon/fontdlg.cpp:336
 msgid "Size:"
 msgstr "Veličina:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1775
+#: ../src/propgrid/advprops.cpp:1676
 msgid "Sizing"
 msgstr "Skaliranje"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1772
+#: ../src/propgrid/advprops.cpp:1673
 msgid "Sizing N-S"
 msgstr "Skaliranje S-J"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1771
+#: ../src/propgrid/advprops.cpp:1672
 msgid "Sizing NE-SW"
 msgstr "Skaliranje SI-JZ"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1773
+#: ../src/propgrid/advprops.cpp:1674
 msgid "Sizing NW-SE"
 msgstr "Skaliranje SZ-JI"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1774
+#: ../src/propgrid/advprops.cpp:1675
 msgid "Sizing W-E"
 msgstr "Skaliranje Z-I"
 
-#: ../src/msw/progdlg.cpp:801
+#: ../src/msw/progdlg.cpp:1088
 msgid "Skip"
 msgstr "Preskoči"
 
-#: ../src/generic/fontdlgg.cpp:330
+#: ../src/generic/fontdlgg.cpp:326
 msgid "Slant"
 msgstr "Nagib"
 
@@ -6442,7 +6609,7 @@ msgid "Small C&apitals"
 msgstr "Kapitalke"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:79
+#: ../src/common/accelcmn.cpp:76
 msgid "Snapshot"
 msgstr "Snimka zaslona"
 
@@ -6450,37 +6617,37 @@ msgstr "Snimka zaslona"
 msgid "Solid"
 msgstr "Ispunjeno"
 
-#: ../src/common/docview.cpp:1791
+#: ../src/common/docview.cpp:1785
 msgid "Sorry, could not open this file."
 msgstr "Nažalost nije moguće otvoriti ovu datoteku."
 
-#: ../src/common/prntbase.cpp:2057 ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2079 ../src/common/prntbase.cpp:2087
 msgid "Sorry, not enough memory to create a preview."
 msgstr "Nažalost nema dovoljno memorije za stvaranje pregleda."
 
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "Sorry, that name is taken. Please choose another."
 msgstr "Nažalost je to ime zauzeto. Odaberi drugo ime."
 
-#: ../src/common/docview.cpp:1814
+#: ../src/common/docview.cpp:1819
 msgid "Sorry, the format for this file is unknown."
 msgstr "Nažalost je format datoteke nepoznat."
 
-#: ../src/unix/sound.cpp:492
+#: ../src/unix/sound.cpp:481
 msgid "Sound data are in unsupported format."
 msgstr "Zvukovni podaci imaju nepodržani format."
 
-#: ../src/unix/sound.cpp:477
+#: ../src/unix/sound.cpp:466
 #, c-format
 msgid "Sound file '%s' is in unsupported format."
 msgstr "Zvukovna datoteka „%s” ima nepodržani format."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:67
+#: ../src/common/accelcmn.cpp:64
 msgid "Space"
 msgstr "Razmaknica"
 
@@ -6488,12 +6655,12 @@ msgstr "Razmaknica"
 msgid "Spacing"
 msgstr "Spacioniranje"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "Spell Check"
 msgstr "Provjera pravopisa"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1776
+#: ../src/propgrid/advprops.cpp:1677
 msgid "Spraycan"
 msgstr "Sprej-limenka"
 
@@ -6502,7 +6669,7 @@ msgstr "Sprej-limenka"
 msgid "Standard"
 msgstr "Standardno"
 
-#: ../src/common/paper.cpp:104
+#: ../src/common/paper.cpp:101
 msgid "Statement, 5 1/2 x 8 1/2 in"
 msgstr "Statement, 5 1/2 × 8 1/2 in"
 
@@ -6511,33 +6678,29 @@ msgstr "Statement, 5 1/2 × 8 1/2 in"
 msgid "Static"
 msgstr "Statično"
 
-#: ../src/generic/prntdlgg.cpp:204
+#: ../src/generic/prntdlgg.cpp:197
 msgid "Status:"
 msgstr "Stanje:"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "Stop"
 msgstr "Zaustavi"
 
-#: ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196
 msgid "Strikethrough"
 msgstr "Precrtano"
 
-#: ../src/common/colourcmn.cpp:45
+#: ../src/common/colourcmn.cpp:42
 #, c-format
 msgid "String To Colour : Incorrect colour specification : %s"
 msgstr "Znakovni niz u boju : Netočna specifikacija boje : %s"
 
 #. TRANSLATORS: Label of font style
-#: ../src/richtext/richtextformatdlg.cpp:339 ../src/propgrid/advprops.cpp:680
+#: ../src/propgrid/advprops.cpp:590 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Stil"
 
-#: ../include/wx/richtext/richtextstyledlg.h:46
-msgid "Style Organiser"
-msgstr "Upravljač stilova"
-
-#: ../src/osx/carbon/fontdlg.cpp:348
+#: ../src/osx/carbon/fontdlg.cpp:345
 msgid "Style:"
 msgstr "Stil:"
 
@@ -6546,7 +6709,7 @@ msgid "Subscrip&t"
 msgstr "Spuš&teno"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:83
+#: ../src/common/accelcmn.cpp:80
 msgid "Subtract"
 msgstr "Oduzmi"
 
@@ -6554,11 +6717,11 @@ msgstr "Oduzmi"
 msgid "Supe&rscript"
 msgstr "Na&dignuto"
 
-#: ../src/common/paper.cpp:150
+#: ../src/common/paper.cpp:147
 msgid "SuperA/SuperA/A4 227 x 356 mm"
 msgstr "SuperA/SuperA/A4 227 × 356 mm"
 
-#: ../src/common/paper.cpp:151
+#: ../src/common/paper.cpp:148
 msgid "SuperB/SuperB/A3 305 x 487 mm"
 msgstr "SuperB/SuperB/A3 305 × 487 mm"
 
@@ -6566,7 +6729,7 @@ msgstr "SuperB/SuperB/A3 305 × 487 mm"
 msgid "Suppress hyphe&nation"
 msgstr "Izostavi rastavljanje riječi"
 
-#: ../src/generic/fontdlgg.cpp:326
+#: ../src/generic/fontdlgg.cpp:322
 msgid "Swiss"
 msgstr "Švicarski"
 
@@ -6584,73 +6747,73 @@ msgstr "Simbol-&font:"
 msgid "Symbols"
 msgstr "Simboli"
 
-#: ../src/common/imagtiff.cpp:369 ../src/common/imagtiff.cpp:382
-#: ../src/common/imagtiff.cpp:741
+#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
+#: ../src/common/imagtiff.cpp:738
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: Nije moguće alocirati memoriju."
 
-#: ../src/common/imagtiff.cpp:301
+#: ../src/common/imagtiff.cpp:298
 msgid "TIFF: Error loading image."
 msgstr "TIFF: Greška prilikom učitavanja slike."
 
-#: ../src/common/imagtiff.cpp:468
+#: ../src/common/imagtiff.cpp:465
 msgid "TIFF: Error reading image."
 msgstr "TIFF: Greška prilikom čitanja slike."
 
-#: ../src/common/imagtiff.cpp:608
+#: ../src/common/imagtiff.cpp:605
 msgid "TIFF: Error saving image."
 msgstr "TIFF: Greška prilikom spremanja slike."
 
-#: ../src/common/imagtiff.cpp:846
+#: ../src/common/imagtiff.cpp:843
 msgid "TIFF: Error writing image."
 msgstr "TIFF: Greška prilikom zapisivanja slike."
 
-#: ../src/common/imagtiff.cpp:355
+#: ../src/common/imagtiff.cpp:352
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: Slika je abnormalno velika."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:68
+#: ../src/common/accelcmn.cpp:65
 msgid "Tab"
 msgstr "Tabulator"
 
-#: ../src/richtext/richtextbuffer.cpp:11498
+#: ../src/richtext/richtextbuffer.cpp:11497
 msgid "Table Properties"
 msgstr "Svojstva tablice"
 
-#: ../src/common/paper.cpp:145
+#: ../src/common/paper.cpp:142
 msgid "Tabloid Extra 11.69 x 18 in"
 msgstr "Tabloid Ekstra 11.69 × 18 in"
 
-#: ../src/common/paper.cpp:102
+#: ../src/common/paper.cpp:99
 msgid "Tabloid, 11 x 17 in"
 msgstr "Tabloid, 11 × 17 in"
 
-#: ../src/richtext/richtextformatdlg.cpp:354
+#: ../src/richtext/richtextformatdlg.cpp:347
 msgid "Tabs"
 msgstr "Tabulatori"
 
-#: ../src/propgrid/advprops.cpp:1598
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Teal"
 msgstr "Plavozelena"
 
-#: ../src/generic/fontdlgg.cpp:327
+#: ../src/generic/fontdlgg.cpp:323
 msgid "Teletype"
 msgstr "Pisaći stroj"
 
-#: ../src/common/docview.cpp:1896
+#: ../src/common/docview.cpp:1901
 msgid "Templates"
 msgstr "Predlošci"
 
-#: ../src/common/fmapbase.cpp:158
+#: ../src/common/fmapbase.cpp:155
 msgid "Thai (ISO-8859-11)"
 msgstr "Tajlandski (ISO-8859-11)"
 
-#: ../src/common/ftp.cpp:619
+#: ../src/common/ftp.cpp:622
 msgid "The FTP server doesn't support passive mode."
 msgstr "FTP server ne podržava pasivni modus."
 
-#: ../src/common/ftp.cpp:605
+#: ../src/common/ftp.cpp:608
 msgid "The FTP server doesn't support the PORT command."
 msgstr "FTP server ne podržava PORT naredbe."
 
@@ -6661,8 +6824,8 @@ msgstr "FTP server ne podržava PORT naredbe."
 msgid "The available bullet styles."
 msgstr "Dostupni stilovi znakova nabrajanja."
 
-#: ../src/richtext/richtextstyledlg.cpp:202
-#: ../src/richtext/richtextstyledlg.cpp:204
+#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:200
 msgid "The available styles."
 msgstr "Dostupni stilovi."
 
@@ -6718,12 +6881,12 @@ msgstr "Donji položaj."
 msgid "The bullet character."
 msgstr "Znak nabrajanja."
 
-#: ../src/richtext/richtextsymboldlg.cpp:443
-#: ../src/richtext/richtextsymboldlg.cpp:445
+#: ../src/richtext/richtextsymboldlg.cpp:440
+#: ../src/richtext/richtextsymboldlg.cpp:442
 msgid "The character code."
 msgstr "Kȏd slovnog znaka."
 
-#: ../src/common/fontmap.cpp:203
+#: ../src/common/fontmap.cpp:200
 #, c-format
 msgid ""
 "The charset '%s' is unknown. You may select\n"
@@ -6734,7 +6897,7 @@ msgstr ""
 "neku drugu kodnu stranicu kao zamjenu ili\n"
 "[Odustani] ako izmjena nije moguća"
 
-#: ../src/msw/ole/dataobj.cpp:394
+#: ../src/msw/ole/dataobj.cpp:402
 #, c-format
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "Format međuspremnika „%d” ne postoji."
@@ -6744,7 +6907,7 @@ msgstr "Format međuspremnika „%d” ne postoji."
 msgid "The default style for the next paragraph."
 msgstr "Zadani stil za sljedeći odlomak."
 
-#: ../src/generic/dirdlgg.cpp:202
+#: ../src/generic/dirdlgg.cpp:199
 #, c-format
 msgid ""
 "The directory '%s' does not exist\n"
@@ -6753,7 +6916,7 @@ msgstr ""
 "Mapa „%s” ne postoji.\n"
 "Želiš li je sada stvoriti?"
 
-#: ../src/html/htmprint.cpp:271
+#: ../src/html/htmprint.cpp:283
 #, c-format
 msgid ""
 "The document \"%s\" doesn't fit on the page horizontally and will be "
@@ -6765,7 +6928,7 @@ msgstr ""
 "\n"
 "Želiš li ipak nastaviti s ispisom?"
 
-#: ../src/common/docview.cpp:1202
+#: ../src/common/docview.cpp:1196
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -6774,36 +6937,36 @@ msgstr ""
 "Datoteka „%s” ne postoji i ne može se otvoriti.\n"
 "Uklonjena je iz popisa nedavno otvorenih datoteka."
 
-#: ../src/richtext/richtextindentspage.cpp:208
-#: ../src/richtext/richtextindentspage.cpp:210
 #: ../src/richtext/richtextliststylepage.cpp:394
 #: ../src/richtext/richtextliststylepage.cpp:396
+#: ../src/richtext/richtextindentspage.cpp:208
+#: ../src/richtext/richtextindentspage.cpp:210
 msgid "The first line indent."
 msgstr "Uvlaka za prvi redak."
 
-#: ../src/gtk/utilsgtk.cpp:481
-msgid "The following standard GTK+ options are also supported:\n"
-msgstr "Sljedeće standardne GTK+ opcije se također podržavaju:\n"
+#: ../src/generic/dbgrptg.cpp:318
+msgid "The following debug report will be generated\n"
+msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:414 ../src/generic/fontdlgg.cpp:416
+#: ../src/generic/fontdlgg.cpp:411 ../src/generic/fontdlgg.cpp:413
 msgid "The font colour."
 msgstr "Boja fonta."
 
-#: ../src/generic/fontdlgg.cpp:375 ../src/generic/fontdlgg.cpp:377
+#: ../src/generic/fontdlgg.cpp:371 ../src/generic/fontdlgg.cpp:373
 msgid "The font family."
 msgstr "Obitelj fontova."
 
-#: ../src/richtext/richtextsymboldlg.cpp:405
-#: ../src/richtext/richtextsymboldlg.cpp:407
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "The font from which to take the symbol."
 msgstr "Font, iz kojeg se preuzima simbol."
 
-#: ../src/generic/fontdlgg.cpp:427 ../src/generic/fontdlgg.cpp:429
-#: ../src/generic/fontdlgg.cpp:434 ../src/generic/fontdlgg.cpp:436
+#: ../src/generic/fontdlgg.cpp:424 ../src/generic/fontdlgg.cpp:426
+#: ../src/generic/fontdlgg.cpp:430 ../src/generic/fontdlgg.cpp:432
 msgid "The font point size."
 msgstr "Veličina fonta."
 
-#: ../src/osx/carbon/fontdlg.cpp:343 ../src/osx/carbon/fontdlg.cpp:345
+#: ../src/osx/carbon/fontdlg.cpp:340 ../src/osx/carbon/fontdlg.cpp:342
 msgid "The font size in points."
 msgstr "Veličina fonta u točkama."
 
@@ -6812,15 +6975,15 @@ msgstr "Veličina fonta u točkama."
 msgid "The font size units, points or pixels."
 msgstr "Jedinice veličine fonta, u točkama ili pikselima."
 
-#: ../src/generic/fontdlgg.cpp:386 ../src/generic/fontdlgg.cpp:388
+#: ../src/generic/fontdlgg.cpp:382 ../src/generic/fontdlgg.cpp:384
 msgid "The font style."
 msgstr "Stil fonta."
 
-#: ../src/generic/fontdlgg.cpp:397 ../src/generic/fontdlgg.cpp:399
+#: ../src/generic/fontdlgg.cpp:393 ../src/generic/fontdlgg.cpp:395
 msgid "The font weight."
 msgstr "Rez fonta."
 
-#: ../src/common/docview.cpp:1483
+#: ../src/common/docview.cpp:1477
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Format datoteke „%s” nije bilo moguće ustanoviti."
@@ -6830,10 +6993,10 @@ msgstr "Format datoteke „%s” nije bilo moguće ustanoviti."
 msgid "The horizontal offset."
 msgstr "Vodoravni odmak."
 
-#: ../src/richtext/richtextindentspage.cpp:199
-#: ../src/richtext/richtextindentspage.cpp:201
 #: ../src/richtext/richtextliststylepage.cpp:385
 #: ../src/richtext/richtextliststylepage.cpp:387
+#: ../src/richtext/richtextindentspage.cpp:199
+#: ../src/richtext/richtextindentspage.cpp:201
 msgid "The left indent."
 msgstr "Lijeva uvlaka."
 
@@ -6854,10 +7017,10 @@ msgstr "Veličina lijevog odmaka."
 msgid "The left position."
 msgstr "Lijevi položaj."
 
-#: ../src/richtext/richtextindentspage.cpp:288
-#: ../src/richtext/richtextindentspage.cpp:290
 #: ../src/richtext/richtextliststylepage.cpp:462
 #: ../src/richtext/richtextliststylepage.cpp:464
+#: ../src/richtext/richtextindentspage.cpp:288
+#: ../src/richtext/richtextindentspage.cpp:290
 msgid "The line spacing."
 msgstr "Prored."
 
@@ -6866,7 +7029,7 @@ msgstr "Prored."
 msgid "The list item number."
 msgstr "Broj stavke u popisu."
 
-#: ../src/msw/ole/automtn.cpp:664
+#: ../src/msw/ole/automtn.cpp:655
 msgid "The locale ID is unknown."
 msgstr "ID lokalizacije nije poznat."
 
@@ -6905,7 +7068,7 @@ msgstr "Širina objekta."
 msgid "The outline level."
 msgstr "Razina sadržaja."
 
-#: ../src/common/log.cpp:277
+#: ../src/common/log.cpp:296
 #, c-format
 msgid "The previous message repeated %u time."
 msgid_plural "The previous message repeated %u times."
@@ -6913,12 +7076,12 @@ msgstr[0] "Prethodna obavijest se ponovila %u puta."
 msgstr[1] "Prethodna obavijest se ponovila %u puta."
 msgstr[2] "Prethodna obavijest se ponovila %u puta."
 
-#: ../src/common/log.cpp:270
+#: ../src/common/log.cpp:289
 msgid "The previous message repeated once."
 msgstr "Prethodna obavijest se ponovila jednom."
 
-#: ../src/richtext/richtextsymboldlg.cpp:462
-#: ../src/richtext/richtextsymboldlg.cpp:464
+#: ../src/richtext/richtextsymboldlg.cpp:459
+#: ../src/richtext/richtextsymboldlg.cpp:461
 msgid "The range to show."
 msgstr "Prikazani opseg."
 
@@ -6932,15 +7095,15 @@ msgstr ""
 "privatne informacije,\n"
 "odznači ih i one će biti uklonjene iz izvještaja.\n"
 
-#: ../src/common/cmdline.cpp:1254
+#: ../src/common/cmdline.cpp:1250
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "Obavezan parametar „%s” nije bio određen."
 
-#: ../src/richtext/richtextindentspage.cpp:217
-#: ../src/richtext/richtextindentspage.cpp:219
 #: ../src/richtext/richtextliststylepage.cpp:403
 #: ../src/richtext/richtextliststylepage.cpp:405
+#: ../src/richtext/richtextindentspage.cpp:217
+#: ../src/richtext/richtextindentspage.cpp:219
 msgid "The right indent."
 msgstr "Desna uvlaka."
 
@@ -6981,16 +7144,16 @@ msgstr "Neprozirnost sjene."
 msgid "The shadow spread."
 msgstr "Rasprostranjenost sjene."
 
-#: ../src/richtext/richtextindentspage.cpp:267
 #: ../src/richtext/richtextliststylepage.cpp:439
 #: ../src/richtext/richtextliststylepage.cpp:441
+#: ../src/richtext/richtextindentspage.cpp:267
 msgid "The spacing after the paragraph."
 msgstr "Razmak nakon odlomka."
 
-#: ../src/richtext/richtextindentspage.cpp:257
-#: ../src/richtext/richtextindentspage.cpp:259
 #: ../src/richtext/richtextliststylepage.cpp:430
 #: ../src/richtext/richtextliststylepage.cpp:432
+#: ../src/richtext/richtextindentspage.cpp:257
+#: ../src/richtext/richtextindentspage.cpp:259
 msgid "The spacing before the paragraph."
 msgstr "Razmak prije odlomka."
 
@@ -7004,12 +7167,12 @@ msgstr "Ime stila."
 msgid "The style on which this style is based."
 msgstr "Stil, na kojem se ovaj stil zasniva."
 
-#: ../src/richtext/richtextstyledlg.cpp:214
-#: ../src/richtext/richtextstyledlg.cpp:216
+#: ../src/richtext/richtextstyledlg.cpp:210
+#: ../src/richtext/richtextstyledlg.cpp:212
 msgid "The style preview."
 msgstr "Pregled stilova."
 
-#: ../src/msw/ole/automtn.cpp:680
+#: ../src/msw/ole/automtn.cpp:671
 msgid "The system cannot find the file specified."
 msgstr "Sustav ne može naći određenu datoteku."
 
@@ -7022,7 +7185,7 @@ msgstr "Položaj tabulatora."
 msgid "The tab positions."
 msgstr "Položaji tabulatora."
 
-#: ../src/richtext/richtextctrl.cpp:3098
+#: ../src/richtext/richtextctrl.cpp:3099
 msgid "The text couldn't be saved."
 msgstr "Nije bilo moguće spremiti tekst."
 
@@ -7043,7 +7206,7 @@ msgstr "Veličina gornjeg odmaka."
 msgid "The top position."
 msgstr "Gornji položaj."
 
-#: ../src/common/cmdline.cpp:1232
+#: ../src/common/cmdline.cpp:1228
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "Vrijednost opcije „%s” mora biti određena."
@@ -7053,7 +7216,7 @@ msgstr "Vrijednost opcije „%s” mora biti određena."
 msgid "The value of the corner radius."
 msgstr "Vrijednost radijusa kutova."
 
-#: ../src/msw/dialup.cpp:433
+#: ../src/msw/dialup.cpp:427
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -7067,30 +7230,30 @@ msgstr ""
 msgid "The vertical offset."
 msgstr "Uspravni odmak."
 
-#: ../src/richtext/richtextprint.cpp:619 ../src/html/htmprint.cpp:745
+#: ../src/html/htmprint.cpp:749 ../src/richtext/richtextprint.cpp:615
 msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr ""
 "Došlo je do problema prilikom postavljanja stranice: možda moraš postaviti "
 "zadani pisač."
 
-#: ../src/html/htmprint.cpp:255
+#: ../src/html/htmprint.cpp:267
 msgid ""
 "This document doesn't fit on the page horizontally and will be truncated "
 "when it is printed."
 msgstr ""
 "Ovaj dokument ne paše na stranicu vodoravno, te će biti odrezana u ispisu."
 
-#: ../src/common/image.cpp:2854
+#: ../src/common/image.cpp:2963
 #, c-format
 msgid "This is not a %s."
 msgstr "Ovo nije %s."
 
-#: ../src/common/wincmn.cpp:1653
+#: ../src/common/wincmn.cpp:1654
 msgid "This platform does not support background transparency."
 msgstr "Platforma ne podržava neprozirnost pozadine."
 
-#: ../src/gtk/window.cpp:4660
+#: ../src/gtk/window.cpp:5664
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
@@ -7098,7 +7261,15 @@ msgstr ""
 "Ovaj je program kompiliran s pre starom verzijom GTK+, ponovo izgradi s GTK+ "
 "2.12 ili novijom verzijom."
 
-#: ../src/msw/thread.cpp:1240
+#: ../src/gtk/glcanvas.cpp:176
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/msw/thread.cpp:1246
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -7106,12 +7277,12 @@ msgstr ""
 "Inicijalizacija modula tijeka nije uspjela: nije moguće spremiti vrijednost "
 "u tijek lokalnog spremišta"
 
-#: ../src/unix/threadpsx.cpp:1794
+#: ../src/unix/threadpsx.cpp:1843
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 "Inicijalizacija modula tijeka nije uspjela: izrada ključa tijeka nije uspjela"
 
-#: ../src/msw/thread.cpp:1228
+#: ../src/msw/thread.cpp:1234
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -7119,82 +7290,82 @@ msgstr ""
 "Inicijalizacija modula tijeka nije uspjela: nije moguće alocirati indeks u "
 "tijeku lokalnog spremišta"
 
-#: ../src/unix/threadpsx.cpp:1043
+#: ../src/unix/threadpsx.cpp:1061
 msgid "Thread priority setting is ignored."
 msgstr "Postavka prioriteta tijeka je zanemarena."
 
-#: ../src/msw/mdi.cpp:176
+#: ../src/msw/mdi.cpp:171
 msgid "Tile &Horizontally"
 msgstr "Poploči vodoravno"
 
-#: ../src/msw/mdi.cpp:177
+#: ../src/msw/mdi.cpp:172
 msgid "Tile &Vertically"
 msgstr "Poploči uspravno"
 
-#: ../src/common/ftp.cpp:200
+#: ../src/common/ftp.cpp:197
 msgid "Timeout while waiting for FTP server to connect, try passive mode."
 msgstr ""
 "Prekoračenje vremena prilikom čekanja na spajanje s FTP serverom, pokušaj u "
 "pasivnom modusu."
 
-#: ../src/generic/tipdlg.cpp:201
+#: ../src/generic/tipdlg.cpp:198
 msgid "Tip of the Day"
 msgstr "Savjet dana"
 
-#: ../src/generic/tipdlg.cpp:140
+#: ../src/generic/tipdlg.cpp:137
 msgid "Tips not available, sorry!"
 msgstr "Na žalost nema savjeta!"
 
-#: ../src/generic/prntdlgg.cpp:242
+#: ../src/generic/prntdlgg.cpp:235
 msgid "To:"
 msgstr "Do:"
 
-#: ../src/richtext/richtextbuffer.cpp:8363
+#: ../src/richtext/richtextbuffer.cpp:8361
 msgid "Too many EndStyle calls!"
 msgstr "Previše EndStyle poziva!"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:891
+#: ../src/propgrid/advprops.cpp:792
 msgid "Tooltip"
 msgstr "Savjetni oblačić"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:892
+#: ../src/propgrid/advprops.cpp:793
 msgid "TooltipText"
 msgstr "Tekst u savjetnom oblačiću"
 
-#: ../src/richtext/richtextsizepage.cpp:286
-#: ../src/richtext/richtextsizepage.cpp:290 ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197 ../src/richtext/richtextsizepage.cpp:286
+#: ../src/richtext/richtextsizepage.cpp:290
 msgid "Top"
 msgstr "Gore"
 
-#: ../src/generic/prntdlgg.cpp:881
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Top margin (mm):"
 msgstr "Gornja margina (mm):"
 
-#: ../src/generic/aboutdlgg.cpp:79
+#: ../src/generic/aboutdlgg.cpp:76
 msgid "Translations by "
 msgstr "Prevoditelji "
 
-#: ../src/generic/aboutdlgg.cpp:188
+#: ../src/generic/aboutdlgg.cpp:185
 msgid "Translators"
 msgstr "Prevoditelji"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:211
+#: ../src/propgrid/propgrid.cpp:192
 msgid "True"
 msgstr "Točno"
 
-#: ../src/common/fs_mem.cpp:227
+#: ../src/common/fs_mem.cpp:222
 #, c-format
 msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
 msgstr "Pokušaj uklanjanja datoteke „%s” iz memorije VFS, ali nije učitana!"
 
-#: ../src/common/fmapbase.cpp:156
+#: ../src/common/fmapbase.cpp:153
 msgid "Turkish (ISO-8859-9)"
 msgstr "Turski (ISO-8859-9)"
 
-#: ../src/generic/filectrlg.cpp:426
+#: ../src/generic/filectrlg.cpp:422
 msgid "Type"
 msgstr "Vrsta"
 
@@ -7208,17 +7379,17 @@ msgstr "Upiši ime fonta."
 msgid "Type a size in points."
 msgstr "Upiši veličinu u točkama."
 
-#: ../src/msw/ole/automtn.cpp:676
+#: ../src/msw/ole/automtn.cpp:667
 #, c-format
 msgid "Type mismatch in argument %u."
 msgstr "Nepodudaranje vrste u argumentu %u."
 
-#: ../src/common/xtixml.cpp:356 ../src/common/xtixml.cpp:509
-#: ../src/common/xtistrm.cpp:318
+#: ../src/common/xtixml.cpp:352 ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315
 msgid "Type must have enum - long conversion"
 msgstr "Vrsta mora imati enum - long konverziju"
 
-#: ../src/propgrid/propgridiface.cpp:401
+#: ../src/propgrid/propgridiface.cpp:385
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
@@ -7227,19 +7398,19 @@ msgstr ""
 "Operacija vrste „%s” nije uspjela: Svojstvo s oznakom „%s” je vrste „%s”, NE "
 "„%s”."
 
-#: ../src/common/paper.cpp:133
+#: ../src/common/paper.cpp:130
 msgid "US Std Fanfold, 14 7/8 x 11 in"
 msgstr "US Std presavijen, 14 7/8 × 11 in"
 
-#: ../src/common/fmapbase.cpp:196
+#: ../src/common/fmapbase.cpp:193
 msgid "US-ASCII"
 msgstr "US-ASCII"
 
-#: ../src/unix/fswatcher_inotify.cpp:109
+#: ../src/unix/fswatcher_inotify.cpp:106
 msgid "Unable to add inotify watch"
 msgstr "Nije moguće dodati inotify nadzor"
 
-#: ../src/unix/fswatcher_kqueue.cpp:136
+#: ../src/unix/fswatcher_kqueue.cpp:153
 msgid "Unable to add kqueue watch"
 msgstr "Nije moguće dodati kqueue nadzor"
 
@@ -7251,7 +7422,7 @@ msgstr "Nije moguće povezati ručku sa završnim priključkom ulaza/izlaza"
 msgid "Unable to close I/O completion port handle"
 msgstr "Nije moguće stvoriti ručku završnog priključka ulaza/izlaza"
 
-#: ../src/unix/fswatcher_inotify.cpp:97
+#: ../src/unix/fswatcher_inotify.cpp:94
 msgid "Unable to close inotify instance"
 msgstr "Nije moguće zatvoriti inotify instancu"
 
@@ -7269,15 +7440,15 @@ msgstr "Nije moguće zatvoriti upravljač za „%s”"
 msgid "Unable to create I/O completion port"
 msgstr "Nije moguće stvoriti završni priključak ulaza/izlaza"
 
-#: ../src/msw/fswatcher.cpp:84
+#: ../src/msw/fswatcher.cpp:81
 msgid "Unable to create IOCP worker thread"
 msgstr "Nije moguće stvoriti tijek završnog priključka ulaza/izlaza"
 
-#: ../src/unix/fswatcher_inotify.cpp:74
+#: ../src/unix/fswatcher_inotify.cpp:71
 msgid "Unable to create inotify instance"
 msgstr "Nije moguće stvoriti inotify instancu"
 
-#: ../src/unix/fswatcher_kqueue.cpp:97
+#: ../src/unix/fswatcher_kqueue.cpp:114
 msgid "Unable to create kqueue instance"
 msgstr "Nije moguće stvoriti kqueue instancu"
 
@@ -7285,11 +7456,11 @@ msgstr "Nije moguće stvoriti kqueue instancu"
 msgid "Unable to dequeue completion packet"
 msgstr "Nije moguće odraditi dequeue za završni paket"
 
-#: ../src/unix/fswatcher_kqueue.cpp:185
+#: ../src/unix/fswatcher_kqueue.cpp:202
 msgid "Unable to get events from kqueue"
 msgstr "Nije moguće dobiti događaje iz kqueue"
 
-#: ../src/gtk/app.cpp:435
+#: ../src/gtk/app.cpp:431
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "Nije moguće inicijalizirati GTK+, je li DISPLAY ispravno postavljen?"
 
@@ -7298,12 +7469,12 @@ msgstr "Nije moguće inicijalizirati GTK+, je li DISPLAY ispravno postavljen?"
 msgid "Unable to open path '%s'"
 msgstr "Nije moguće otvoriti stazu „%s”"
 
-#: ../src/html/htmlwin.cpp:583
+#: ../src/html/htmlwin.cpp:586
 #, c-format
 msgid "Unable to open requested HTML document: %s"
 msgstr "Nije moguće otvoriti traženi HTML dokument: %s"
 
-#: ../src/unix/sound.cpp:368
+#: ../src/unix/sound.cpp:365
 msgid "Unable to play sound asynchronously."
 msgstr "Nije moguće pokrenuti zvuk asinkronično."
 
@@ -7311,61 +7482,61 @@ msgstr "Nije moguće pokrenuti zvuk asinkronično."
 msgid "Unable to post completion status"
 msgstr "Nije moguće objaviti status svršetka"
 
-#: ../src/unix/fswatcher_inotify.cpp:556
+#: ../src/unix/fswatcher_inotify.cpp:553
 msgid "Unable to read from inotify descriptor"
 msgstr "Nije moguće čitati iz inotify opisnika"
 
-#: ../src/unix/fswatcher_inotify.cpp:141
+#: ../src/unix/fswatcher_inotify.cpp:138
 #, c-format
 msgid "Unable to remove inotify watch %i"
 msgstr "Nije moguće ukloniti inotify nadzor %i"
 
-#: ../src/unix/fswatcher_kqueue.cpp:153
+#: ../src/unix/fswatcher_kqueue.cpp:170
 msgid "Unable to remove kqueue watch"
 msgstr "Nije moguće ukloniti kqueue nadzor"
 
-#: ../src/msw/fswatcher.cpp:168
+#: ../src/msw/fswatcher.cpp:165
 #, c-format
 msgid "Unable to set up watch for '%s'"
 msgstr "Nije moguće postaviti sat za „%s”"
 
-#: ../src/msw/fswatcher.cpp:91
+#: ../src/msw/fswatcher.cpp:88
 msgid "Unable to start IOCP worker thread"
 msgstr "Nije moguće pokrenuti tijek završnog priključka ulaza/izlaza"
 
-#: ../src/common/stockitem.cpp:201
+#: ../src/common/stockitem.cpp:198
 msgid "Undelete"
 msgstr "Vrati izbrisano"
 
-#: ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199
 msgid "Underline"
 msgstr "Podcrtaj"
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/richtext/richtextfontpage.cpp:359 ../src/osx/carbon/fontdlg.cpp:370
-#: ../src/propgrid/advprops.cpp:690
+#: ../src/osx/carbon/fontdlg.cpp:367 ../src/propgrid/advprops.cpp:600
+#: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Podcrtano"
 
-#: ../src/common/stockitem.cpp:203 ../src/stc/stc_i18n.cpp:15
+#: ../src/common/stockitem.cpp:200 ../src/stc/stc_i18n.cpp:15
 msgid "Undo"
 msgstr "Poništi"
 
-#: ../src/common/stockitem.cpp:265
+#: ../src/common/stockitem.cpp:263
 msgid "Undo last action"
 msgstr "Poništi posljednju radnju"
 
-#: ../src/common/cmdline.cpp:1029
+#: ../src/common/cmdline.cpp:1025
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Neočekivani znakovi slijede opciju „%s”."
 
-#: ../src/unix/fswatcher_inotify.cpp:274
+#: ../src/unix/fswatcher_inotify.cpp:271
 #, c-format
 msgid "Unexpected event for \"%s\": no matching watch descriptor."
 msgstr "Neočekivani događaj za „%s”: nema poklapajućih nadzornih opisnika."
 
-#: ../src/common/cmdline.cpp:1195
+#: ../src/common/cmdline.cpp:1191
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Neočekivani parametar „%s”"
@@ -7374,49 +7545,49 @@ msgstr "Neočekivani parametar „%s”"
 msgid "Unexpectedly new I/O completion port was created"
 msgstr "Stvoren je neočekivani završni priključak ulaza/izlaza"
 
-#: ../src/msw/fswatcher.cpp:70
+#: ../src/msw/fswatcher.cpp:67
 msgid "Ungraceful worker thread termination"
 msgstr "Neuredan prekid tijeka"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:460
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:456
+#: ../src/richtext/richtextsymboldlg.cpp:457
+#: ../src/richtext/richtextsymboldlg.cpp:458
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../src/common/fmapbase.cpp:185 ../src/common/fmapbase.cpp:191
+#: ../src/common/fmapbase.cpp:182 ../src/common/fmapbase.cpp:188
 msgid "Unicode 16 bit (UTF-16)"
 msgstr "Unicode 16 bit (UTF-16)"
 
-#: ../src/common/fmapbase.cpp:190
+#: ../src/common/fmapbase.cpp:187
 msgid "Unicode 16 bit Big Endian (UTF-16BE)"
 msgstr "Unicode 16 bit Big Endian (UTF-16BE)"
 
-#: ../src/common/fmapbase.cpp:186
+#: ../src/common/fmapbase.cpp:183
 msgid "Unicode 16 bit Little Endian (UTF-16LE)"
 msgstr "Unicode 16 bit Little Endian (UTF-16LE)"
 
-#: ../src/common/fmapbase.cpp:187 ../src/common/fmapbase.cpp:193
+#: ../src/common/fmapbase.cpp:184 ../src/common/fmapbase.cpp:190
 msgid "Unicode 32 bit (UTF-32)"
 msgstr "Unicode 32 bit (UTF-32)"
 
-#: ../src/common/fmapbase.cpp:192
+#: ../src/common/fmapbase.cpp:189
 msgid "Unicode 32 bit Big Endian (UTF-32BE)"
 msgstr "Unicode 32 bit Big Endian (UTF-32BE)"
 
-#: ../src/common/fmapbase.cpp:188
+#: ../src/common/fmapbase.cpp:185
 msgid "Unicode 32 bit Little Endian (UTF-32LE)"
 msgstr "Unicode 32 bit Little Endian (UTF-32LE)"
 
-#: ../src/common/fmapbase.cpp:182
+#: ../src/common/fmapbase.cpp:179
 msgid "Unicode 7 bit (UTF-7)"
 msgstr "Unicode 7 bit (UTF-7)"
 
-#: ../src/common/fmapbase.cpp:183
+#: ../src/common/fmapbase.cpp:180
 msgid "Unicode 8 bit (UTF-8)"
 msgstr "Unicode 8 bit (UTF-8)"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "Unindent"
 msgstr "Ukloni uvlaku"
 
@@ -7566,97 +7737,102 @@ msgstr "Jedinice za gornji položaj."
 msgid "Units for this value."
 msgstr "Jedinice za ovu vrijednost."
 
-#: ../src/generic/progdlgg.cpp:353 ../src/generic/progdlgg.cpp:622
+#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
 msgid "Unknown"
 msgstr "Nepoznato"
 
-#: ../src/msw/dde.cpp:1174
+#: ../src/msw/dde.cpp:1238
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Nepoznata DDE greška %08x"
 
-#: ../src/common/xtistrm.cpp:410
+#: ../src/common/xtistrm.cpp:407
 msgid "Unknown Object passed to GetObjectClassInfo"
 msgstr "Nepoznati objekt je proslijeđen na GetObjectClassInfo"
 
-#: ../src/common/imagpng.cpp:366
+#: ../src/common/imagpng.cpp:383
 #, c-format
 msgid "Unknown PNG resolution unit %d"
 msgstr "Nepoznata PNG jedinica rezolucije %d"
 
-#: ../src/common/xtixml.cpp:327
+#: ../src/common/xtixml.cpp:323
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Nepoznato svojstvo %s"
 
-#: ../src/common/imagtiff.cpp:529
+#: ../src/common/imagtiff.cpp:526
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "Nepoznata TIFF jedinica rezolucije %d je zanemarena"
 
-#: ../src/unix/dlunix.cpp:160
+#: ../src/propgrid/props.cpp:155
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/unix/dlunix.cpp:118
 msgid "Unknown dynamic library error"
 msgstr "Nepoznata greška dinamičke biblioteke"
 
-#: ../src/common/fmapbase.cpp:810
+#: ../src/common/fmapbase.cpp:806
 #, c-format
 msgid "Unknown encoding (%d)"
 msgstr "Nepoznat kodiranje (%d)"
 
-#: ../src/msw/ole/automtn.cpp:688
+#: ../src/msw/ole/automtn.cpp:679
 #, c-format
 msgid "Unknown error %08x"
 msgstr "Nepoznata greška %08x"
 
-#: ../src/msw/ole/automtn.cpp:647
+#: ../src/msw/ole/automtn.cpp:638
 msgid "Unknown exception"
 msgstr "Nepoznata iznimka"
 
-#: ../src/common/image.cpp:2839
+#: ../src/common/image.cpp:2942
 msgid "Unknown image data format."
 msgstr "Nepoznati format slikovnih podataka."
 
-#: ../src/common/cmdline.cpp:914
+#: ../src/common/cmdline.cpp:910
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Nepoznata dugačka opcija „%s”"
 
-#: ../src/msw/ole/automtn.cpp:631
+#: ../src/msw/ole/automtn.cpp:622
 msgid "Unknown name or named argument."
 msgstr "Nepoznato ime ili imenovani argument."
 
-#: ../src/common/cmdline.cpp:929 ../src/common/cmdline.cpp:951
+#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Nepoznata opcija „%s”"
 
-#: ../src/common/mimecmn.cpp:225
+#: ../src/common/mimecmn.cpp:221
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "Nezatvorena „{” u jednom unosu za mime vrstu %s."
 
-#: ../src/common/cmdproc.cpp:262 ../src/common/cmdproc.cpp:288
-#: ../src/common/cmdproc.cpp:308
+#: ../src/common/cmdproc.cpp:255 ../src/common/cmdproc.cpp:281
+#: ../src/common/cmdproc.cpp:301
 msgid "Unnamed command"
 msgstr "Bezimena naredba"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:413
+#: ../src/propgrid/propgrid.cpp:392
 msgid "Unspecified"
 msgstr "Neodređeno"
 
-#: ../src/msw/clipbrd.cpp:311
+#: ../src/msw/clipbrd.cpp:325
 msgid "Unsupported clipboard format."
 msgstr "Nepodržani format međuspremnika."
 
-#: ../src/common/appcmn.cpp:256
+#: ../src/common/appcmn.cpp:277
 #, c-format
 msgid "Unsupported theme '%s'."
 msgstr "Nepodržana tema „%s”."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:205
-#: ../src/common/accelcmn.cpp:63
+#: ../src/common/stockitem.cpp:202 ../src/common/accelcmn.cpp:60
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Up"
 msgstr "Gore"
 
@@ -7670,7 +7846,7 @@ msgstr "Velika slova"
 msgid "Upper case roman numerals"
 msgstr "Veliki rimski brojevi"
 
-#: ../src/common/cmdline.cpp:1326
+#: ../src/common/cmdline.cpp:1322
 #, c-format
 msgid "Usage: %s"
 msgstr "Upotreba: %s"
@@ -7679,38 +7855,47 @@ msgstr "Upotreba: %s"
 msgid "Use &shadow"
 msgstr "Koristi &sjenu"
 
-#: ../src/richtext/richtextindentspage.cpp:169
-#: ../src/richtext/richtextindentspage.cpp:171
 #: ../src/richtext/richtextliststylepage.cpp:358
 #: ../src/richtext/richtextliststylepage.cpp:360
+#: ../src/richtext/richtextindentspage.cpp:169
+#: ../src/richtext/richtextindentspage.cpp:171
 msgid "Use the current alignment setting."
 msgstr "Koristi trenutačne postavke poravnanja."
 
-#: ../src/common/valtext.cpp:179
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/gtk/font.cpp:552
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/common/valtext.cpp:142
 msgid "Validation conflict"
 msgstr "Konflikt u provjeri valjanosti"
 
-#: ../src/propgrid/manager.cpp:238
+#: ../src/propgrid/manager.cpp:224
 msgid "Value"
 msgstr "Vrijednost"
 
-#: ../src/propgrid/props.cpp:386 ../src/propgrid/props.cpp:500
+#: ../src/propgrid/props.cpp:309
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "Vrijednost mora biti %s ili veće."
 
-#: ../src/propgrid/props.cpp:417 ../src/propgrid/props.cpp:531
+#: ../src/propgrid/props.cpp:336
 #, c-format
 msgid "Value must be %s or less."
 msgstr "Vrijednost mora biti %s ili manje."
 
-#: ../src/propgrid/props.cpp:393 ../src/propgrid/props.cpp:424
-#: ../src/propgrid/props.cpp:507 ../src/propgrid/props.cpp:538
+#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "Vrijednost mora biti između %s i %s."
 
-#: ../src/generic/aboutdlgg.cpp:128
+#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Verzija "
 
@@ -7719,25 +7904,32 @@ msgstr "Verzija "
 msgid "Vertical alignment."
 msgstr "Uspravno poravnanje."
 
-#: ../src/generic/filedlgg.cpp:202
+#: ../src/generic/filedlgg.cpp:199
 msgid "View files as a detailed view"
 msgstr "Prikaži datoteke s detaljima"
 
-#: ../src/generic/filedlgg.cpp:200
+#: ../src/generic/filedlgg.cpp:197
 msgid "View files as a list view"
 msgstr "Prikaži datoteke kao popis"
 
-#: ../src/common/docview.cpp:1970
+#: ../src/common/docview.cpp:1975
 msgid "Views"
 msgstr "Prikazi"
 
+#: ../src/gtk/app.cpp:348
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1777
+#: ../src/propgrid/advprops.cpp:1678
 msgid "Wait"
 msgstr "Čekaj"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1779
+#: ../src/propgrid/advprops.cpp:1680
 msgid "Wait Arrow"
 msgstr "Strelica-Čekaj"
 
@@ -7746,238 +7938,235 @@ msgstr "Strelica-Čekaj"
 msgid "Waiting for IO on epoll descriptor %d failed"
 msgstr "Čekanje ulaza/izlaza na epoll deskriptor %d"
 
-#: ../src/common/log.cpp:223
+#: ../src/common/log.cpp:241
 msgid "Warning: "
 msgstr "Upozorenje: "
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1778
+#: ../src/propgrid/advprops.cpp:1679
 msgid "Watch"
 msgstr "Sat"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:685
+#: ../src/propgrid/advprops.cpp:595
 msgid "Weight"
 msgstr "Debljina"
 
-#: ../src/common/fmapbase.cpp:148
+#: ../src/common/fmapbase.cpp:145
 msgid "Western European (ISO-8859-1)"
 msgstr "Zapadnoeuropski (ISO-8859-1)"
 
-#: ../src/common/fmapbase.cpp:162
+#: ../src/common/fmapbase.cpp:159
 msgid "Western European with Euro (ISO-8859-15)"
 msgstr "Zapadnoeuropski s eurom (ISO 8859-15)"
 
-#: ../src/generic/fontdlgg.cpp:446 ../src/generic/fontdlgg.cpp:448
+#: ../src/generic/fontdlgg.cpp:443 ../src/generic/fontdlgg.cpp:445
 msgid "Whether the font is underlined."
 msgstr "Je li font podcrtan."
 
-#: ../src/propgrid/advprops.cpp:1611
+#: ../src/propgrid/advprops.cpp:1517
 msgid "White"
 msgstr "Bijela"
 
-#: ../src/generic/fdrepdlg.cpp:144
+#: ../src/generic/fdrepdlg.cpp:141
 msgid "Whole word"
 msgstr "Cijela riječ"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:532
 msgid "Whole words only"
 msgstr "Samo cijele riječi"
 
-#: ../src/univ/themes/win32.cpp:1102
+#: ../src/univ/themes/win32.cpp:1099
 msgid "Win32 theme"
 msgstr "Win32 tema"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:893
+#: ../src/propgrid/advprops.cpp:794
 msgid "Window"
 msgstr "Window"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:894
+#: ../src/propgrid/advprops.cpp:795
 msgid "WindowFrame"
 msgstr "Okvir prozora"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:895
+#: ../src/propgrid/advprops.cpp:796
 msgid "WindowText"
 msgstr "Tekst prozora"
 
-#: ../src/common/fmapbase.cpp:177
+#: ../src/common/fmapbase.cpp:174
 msgid "Windows Arabic (CP 1256)"
 msgstr "Windows arapski (CP 1256)"
 
-#: ../src/common/fmapbase.cpp:178
+#: ../src/common/fmapbase.cpp:175
 msgid "Windows Baltic (CP 1257)"
 msgstr "Windows baltički (CP 1257)"
 
-#: ../src/common/fmapbase.cpp:171
+#: ../src/common/fmapbase.cpp:168
 msgid "Windows Central European (CP 1250)"
 msgstr "Windows srednjeeuropski (CP 1250)"
 
-#: ../src/common/fmapbase.cpp:168
+#: ../src/common/fmapbase.cpp:165
 msgid "Windows Chinese Simplified (CP 936) or GB-2312"
 msgstr "Windows kineski pojednostavljeni (CP 936) or GB-2312"
 
-#: ../src/common/fmapbase.cpp:170
+#: ../src/common/fmapbase.cpp:167
 msgid "Windows Chinese Traditional (CP 950) or Big-5"
 msgstr "Windows kineski tradicionalni (CP 950) or Big-5"
 
-#: ../src/common/fmapbase.cpp:172
+#: ../src/common/fmapbase.cpp:169
 msgid "Windows Cyrillic (CP 1251)"
 msgstr "Windows ćirilica (CP 1251)"
 
-#: ../src/common/fmapbase.cpp:174
+#: ../src/common/fmapbase.cpp:171
 msgid "Windows Greek (CP 1253)"
 msgstr "Windows grčki (CP 1253)"
 
-#: ../src/common/fmapbase.cpp:176
+#: ../src/common/fmapbase.cpp:173
 msgid "Windows Hebrew (CP 1255)"
 msgstr "Windows hebrejski (CP 1255)"
 
-#: ../src/common/fmapbase.cpp:167
+#: ../src/common/fmapbase.cpp:164
 msgid "Windows Japanese (CP 932) or Shift-JIS"
 msgstr "Windows japanski (CP 932) or Shift-JIS"
 
-#: ../src/common/fmapbase.cpp:180
+#: ../src/common/fmapbase.cpp:177
 msgid "Windows Johab (CP 1361)"
 msgstr "Windows johapski (CP 1361)"
 
-#: ../src/common/fmapbase.cpp:169
+#: ../src/common/fmapbase.cpp:166
 msgid "Windows Korean (CP 949)"
 msgstr "Windows koreanski (CP 949)"
 
-#: ../src/common/fmapbase.cpp:166
+#: ../src/common/fmapbase.cpp:163
 msgid "Windows Thai (CP 874)"
 msgstr "Windows tajlandski (CP 874)"
 
-#: ../src/common/fmapbase.cpp:175
+#: ../src/common/fmapbase.cpp:172
 msgid "Windows Turkish (CP 1254)"
 msgstr "Windows turski (CP 1254)"
 
-#: ../src/common/fmapbase.cpp:179
+#: ../src/common/fmapbase.cpp:176
 msgid "Windows Vietnamese (CP 1258)"
 msgstr "Windows vijetnamski (CP 1258)"
 
-#: ../src/common/fmapbase.cpp:173
+#: ../src/common/fmapbase.cpp:170
 msgid "Windows Western European (CP 1252)"
 msgstr "Windows zapadnoeuropski (CP 1252)"
 
-#: ../src/common/fmapbase.cpp:181
+#: ../src/common/fmapbase.cpp:178
 msgid "Windows/DOS OEM (CP 437)"
 msgstr "Windows/DOS OEM (CP 437)"
 
-#: ../src/common/fmapbase.cpp:165
+#: ../src/common/fmapbase.cpp:162
 msgid "Windows/DOS OEM Cyrillic (CP 866)"
 msgstr "Windows/DOS OEM ćirilica (CP 866)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:111
+#: ../src/common/accelcmn.cpp:109
 msgid "Windows_Left"
 msgstr "Windows_Lijevo"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:113
+#: ../src/common/accelcmn.cpp:111
 msgid "Windows_Menu"
 msgstr "Windows_Izbornik"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:112
+#: ../src/common/accelcmn.cpp:110
 msgid "Windows_Right"
 msgstr "Windows_Desno"
 
-#: ../src/common/ffile.cpp:150
+#: ../src/common/ffile.cpp:149
 #, c-format
 msgid "Write error on file '%s'"
 msgstr "Zapiši grešku za datoteku „%s”"
 
-#: ../src/xml/xml.cpp:914
+#: ../src/xml/xml.cpp:925
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "Greška u XML obradi: „%s” u retku br. %d"
 
-#: ../src/common/xpmdecod.cpp:796
+#: ../src/common/xpmdecod.cpp:794
 msgid "XPM: Malformed pixel data!"
 msgstr "XPM: nepravilni piksel podaci!"
 
-#: ../src/common/xpmdecod.cpp:705
+#: ../src/common/xpmdecod.cpp:702
 #, c-format
 msgid "XPM: incorrect colour description in line %d"
 msgstr "XPM: neipravan opis boje u retku br. %d"
 
-#: ../src/common/xpmdecod.cpp:680
+#: ../src/common/xpmdecod.cpp:677
 msgid "XPM: incorrect header format!"
 msgstr "XPM: neispravan format zaglavlja!"
 
-#: ../src/common/xpmdecod.cpp:716 ../src/common/xpmdecod.cpp:725
+#: ../src/common/xpmdecod.cpp:714 ../src/common/xpmdecod.cpp:723
 #, c-format
 msgid "XPM: malformed colour definition '%s' at line %d!"
 msgstr "XPM: nepravilna definicija boje „%s” u retku br. %d!"
 
-#: ../src/common/xpmdecod.cpp:755
+#: ../src/common/xpmdecod.cpp:753
 msgid "XPM: no colors left to use for mask!"
 msgstr "XPM: za masku nije preostala nijedna boja!"
 
-#: ../src/common/xpmdecod.cpp:782
+#: ../src/common/xpmdecod.cpp:780
 #, c-format
 msgid "XPM: truncated image data at line %d!"
 msgstr "XPM: odrezani podaci slike u retku br. %d!"
 
-#: ../src/propgrid/advprops.cpp:1610
+#: ../src/propgrid/advprops.cpp:1516
 msgid "Yellow"
 msgstr "Žuta"
 
-#: ../include/wx/msgdlg.h:276 ../src/common/stockitem.cpp:206
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:203
 #: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Da"
 
-#: ../src/osx/carbon/overlay.cpp:155
-msgid "You cannot Clear an overlay that is not inited"
-msgstr "Ne možeš ukloniti pokrivač, koji nije inicijaliziran"
-
-#: ../src/osx/carbon/overlay.cpp:107 ../src/dfb/overlay.cpp:61
-msgid "You cannot Init an overlay twice"
-msgstr "Ne možeš inicijirati jedan pokrivač dvaput"
-
-#: ../src/generic/dirdlgg.cpp:287
+#: ../src/generic/dirdlgg.cpp:284
 msgid "You cannot add a new directory to this section."
 msgstr "Ne možeš dodati novu mapu ovom odjeljku."
 
-#: ../src/propgrid/propgrid.cpp:3299
+#: ../src/propgrid/propgrid.cpp:3276
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 "Uneseni su nevaljane vrijednosti. Pritisni ESC za odustajanje od uređivanja."
 
-#: ../src/common/stockitem.cpp:209
+#: ../src/osx/cocoa/menu.mm:286
+#, fuzzy
+msgid "Zoom"
+msgstr "Povećaj"
+
+#: ../src/common/stockitem.cpp:206
 msgid "Zoom &In"
 msgstr "P&ovećaj"
 
-#: ../src/common/stockitem.cpp:210
+#: ../src/common/stockitem.cpp:207
 msgid "Zoom &Out"
 msgstr "U&manji"
 
-#: ../src/common/stockitem.cpp:209 ../src/common/prntbase.cpp:1594
+#: ../src/common/stockitem.cpp:206 ../src/common/prntbase.cpp:1619
 msgid "Zoom In"
 msgstr "Povećaj"
 
-#: ../src/common/stockitem.cpp:210 ../src/common/prntbase.cpp:1580
+#: ../src/common/stockitem.cpp:207 ../src/common/prntbase.cpp:1605
 msgid "Zoom Out"
 msgstr "Umanji"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to &Fit"
 msgstr "Prilagodi &zumiranje"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to Fit"
 msgstr "Prilagodi zumiranje"
 
-#: ../src/msw/dde.cpp:1141
+#: ../src/msw/dde.cpp:1205
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "jedna DDEML aplikacija je stvorila produljeno stanje."
 
-#: ../src/msw/dde.cpp:1129
+#: ../src/msw/dde.cpp:1193
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -7989,39 +8178,39 @@ msgstr ""
 "ili je jedan nevažeći identifikator instance\n"
 "proslijeđen DDEML funkciji."
 
-#: ../src/msw/dde.cpp:1147
+#: ../src/msw/dde.cpp:1211
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "pokušaj klijenta da uspostavi razgovor nije uspjeo."
 
-#: ../src/msw/dde.cpp:1144
+#: ../src/msw/dde.cpp:1208
 msgid "a memory allocation failed."
 msgstr "alocijranje memorije nije uspjelo."
 
-#: ../src/msw/dde.cpp:1138
+#: ../src/msw/dde.cpp:1202
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "jedan parametar nije validiran od DDEML-a."
 
-#: ../src/msw/dde.cpp:1120
+#: ../src/msw/dde.cpp:1184
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "vrijeme zahtjeva za sinkroniziranu preporučenu transakciju je isteklo."
 
-#: ../src/msw/dde.cpp:1126
+#: ../src/msw/dde.cpp:1190
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "vrijeme zahtjeva za sinkroniziranu transakciju podataka je isteklo."
 
-#: ../src/msw/dde.cpp:1135
+#: ../src/msw/dde.cpp:1199
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "vrijeme zahtjeva za sinkroniziranu izvršnu transakciju je isteklo."
 
-#: ../src/msw/dde.cpp:1153
+#: ../src/msw/dde.cpp:1217
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "vrijeme zahtjeva za sinkroniziranu guranu transakciju je isteklo."
 
-#: ../src/msw/dde.cpp:1168
+#: ../src/msw/dde.cpp:1232
 msgid "a request to end an advise transaction has timed out."
 msgstr "vrijeme zahtjeva za prekidom preporučene transakcije je isteklo."
 
-#: ../src/msw/dde.cpp:1162
+#: ../src/msw/dde.cpp:1226
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -8031,15 +8220,15 @@ msgstr ""
 "koji je prekinut od strane klijenta ili ga je server prekinuo\n"
 "prije završetka transakcije."
 
-#: ../src/msw/dde.cpp:1150
+#: ../src/msw/dde.cpp:1214
 msgid "a transaction failed."
 msgstr "jedna transakcija nije uspjela."
 
-#: ../src/common/accelcmn.cpp:189
+#: ../src/common/accelcmn.cpp:188
 msgid "alt"
 msgstr "alt"
 
-#: ../src/msw/dde.cpp:1132
+#: ../src/msw/dde.cpp:1196
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -8051,15 +8240,15 @@ msgstr ""
 "ili aplikacija inicijalizirana kao APPCMD_CLIENTONLY\n"
 "je pokušala izvršiti transakcije servera."
 
-#: ../src/msw/dde.cpp:1156
+#: ../src/msw/dde.cpp:1220
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "interni poziv na funkciju PostMessage nije uspjeo. "
 
-#: ../src/msw/dde.cpp:1165
+#: ../src/msw/dde.cpp:1229
 msgid "an internal error has occurred in the DDEML."
 msgstr "dogodila se interna greška u DDEML-u."
 
-#: ../src/msw/dde.cpp:1171
+#: ../src/msw/dde.cpp:1235
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -8069,56 +8258,56 @@ msgstr ""
 "Nakon što se aplikacija vrati iz povratnog poziva XTYP_XACT_COMPLETE,\n"
 "identifikator transakcije za taj povratni poziv više nije valjan."
 
-#: ../src/common/zipstrm.cpp:1483
+#: ../src/common/zipstrm.cpp:1522
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "pod pretpostavkom da se radi o višedjelnom lančanom zipu"
 
-#: ../src/common/fileconf.cpp:1847
+#: ../src/common/fileconf.cpp:1849
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "pokušaj mijenjanja nepromjenljivog ključa „%s” je zanemaren."
 
-#: ../src/html/chm.cpp:329
+#: ../src/html/chm.cpp:326
 msgid "bad arguments to library function"
 msgstr "neispravni argumenti za funkciju biblioteke"
 
-#: ../src/html/chm.cpp:341
+#: ../src/html/chm.cpp:338
 msgid "bad signature"
 msgstr "neispravna signatura"
 
-#: ../src/common/zipstrm.cpp:1918
+#: ../src/common/zipstrm.cpp:1988
 msgid "bad zipfile offset to entry"
 msgstr "neispravni odmak zip datoteke na unos"
 
-#: ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400
 msgid "binary"
 msgstr "binarno"
 
-#: ../src/common/fontcmn.cpp:996
+#: ../src/common/fontcmn.cpp:1195
 msgid "bold"
 msgstr "debeli"
 
-#: ../src/msw/utils.cpp:1144
+#: ../src/msw/utils.cpp:1135
 #, c-format
 msgid "build %lu"
 msgstr "gradnja %lu"
 
-#: ../src/common/ffile.cpp:75
+#: ../src/common/ffile.cpp:73
 #, c-format
 msgid "can't close file '%s'"
 msgstr "nije moguće zatvoriti datoteku „%s”"
 
-#: ../src/common/file.cpp:245
+#: ../src/common/file.cpp:242
 #, c-format
 msgid "can't close file descriptor %d"
 msgstr "nije moguće zatvoriti desriptora datoteka %d"
 
-#: ../src/common/file.cpp:586
+#: ../src/common/ffile.cpp:382 ../src/common/file.cpp:613
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "nije moguće potvrditi promjene za datoteku „%s”"
 
-#: ../src/common/file.cpp:178
+#: ../src/common/file.cpp:175
 #, c-format
 msgid "can't create file '%s'"
 msgstr "nije moguće stvoriti datoteku „%s”"
@@ -8128,49 +8317,49 @@ msgstr "nije moguće stvoriti datoteku „%s”"
 msgid "can't delete user configuration file '%s'"
 msgstr "nije moguće izbrisati datoteku konfiguracije „%s”"
 
-#: ../src/common/file.cpp:495
+#: ../src/common/file.cpp:522
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr "nije moguće odrediti dosezanje kraja datoteke na deskriptoru %d"
 
-#: ../src/common/zipstrm.cpp:1692
+#: ../src/common/zipstrm.cpp:1747
 msgid "can't find central directory in zip"
 msgstr "nije moguće naći osnovnu mapu u zipu"
 
-#: ../src/common/file.cpp:465
+#: ../src/common/file.cpp:492
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "nije moguće naći duljinu datoteke na deskriptoru datoteka %d"
 
-#: ../src/msw/utils.cpp:341
+#: ../src/msw/utils.cpp:336
 msgid "can't find user's HOME, using current directory."
 msgstr "nije moguće pronaći korisnički HOME, koristi se trenutačna mapa."
 
-#: ../src/common/file.cpp:366
+#: ../src/common/file.cpp:407
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "nije moguće isprazniti deskriptor datoteka %d"
 
-#: ../src/common/file.cpp:422
+#: ../src/common/file.cpp:463
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "nije moguće dobiti poziciju traženja na deskriptoru datoteka %d"
 
-#: ../src/common/fontmap.cpp:325
+#: ../src/common/fontmap.cpp:322
 msgid "can't load any font, aborting"
 msgstr "nije moguće učitavanje fontova, prekida se"
 
-#: ../src/common/file.cpp:231 ../src/common/ffile.cpp:59
+#: ../src/common/ffile.cpp:57 ../src/common/file.cpp:228
 #, c-format
 msgid "can't open file '%s'"
 msgstr "nije moguće otvoriti datoteku „%s”"
 
-#: ../src/common/fileconf.cpp:320
+#: ../src/common/fileconf.cpp:314
 #, c-format
 msgid "can't open global configuration file '%s'."
 msgstr "nije moguće otvoriti datoteku globalne konfiguracije „%s”."
 
-#: ../src/common/fileconf.cpp:336
+#: ../src/common/fileconf.cpp:330
 #, c-format
 msgid "can't open user configuration file '%s'."
 msgstr "nije moguće otvoriti datoteku korisničke konfiguracije „%s”."
@@ -8179,40 +8368,40 @@ msgstr "nije moguće otvoriti datoteku korisničke konfiguracije „%s”."
 msgid "can't open user configuration file."
 msgstr "nije moguće otvoriti datoteku korisničke konfiguracije."
 
-#: ../src/common/zipstrm.cpp:579
+#: ../src/common/zipstrm.cpp:572
 msgid "can't re-initialize zlib deflate stream"
 msgstr "nije moguće ponovo inicijalizirati zlib deflate tijek"
 
-#: ../src/common/zipstrm.cpp:604
+#: ../src/common/zipstrm.cpp:597
 msgid "can't re-initialize zlib inflate stream"
 msgstr "nije moguće ponovo inicijalizirati zlib inflate tijek"
 
-#: ../src/common/file.cpp:304
+#: ../src/common/file.cpp:345
 #, c-format
 msgid "can't read from file descriptor %d"
 msgstr "nije moguće čitanje iz deskriptora datoteka %d"
 
-#: ../src/common/file.cpp:581
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:608
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "nije moguće ukloniti datoteku „%s”"
 
-#: ../src/common/file.cpp:598
+#: ../src/common/ffile.cpp:394 ../src/common/file.cpp:625
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "nije moguće ukloniti privremenu datoteku „%s”"
 
-#: ../src/common/file.cpp:408
+#: ../src/common/file.cpp:449
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "nije moguće traženje na deskriptor datoteka %d"
 
-#: ../src/common/textfile.cpp:273
+#: ../src/common/textfile.cpp:161
 #, c-format
 msgid "can't write buffer '%s' to disk."
 msgstr "nije moguće zapisivanje međuspremnika „%s” na disk."
 
-#: ../src/common/file.cpp:323
+#: ../src/common/file.cpp:364
 #, c-format
 msgid "can't write to file descriptor %d"
 msgstr "nije moguće zapisivanje u deskriptor datoteka %d"
@@ -8222,22 +8411,28 @@ msgid "can't write user configuration file."
 msgstr "nije moguće zapisivanje datoteke korisničke konfiguracije."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:482 ../src/generic/datavgen.cpp:1261
+#: ../src/common/datavcmn.cpp:2064 ../src/generic/datavgen.cpp:1384
 msgid "checked"
 msgstr "aktivirano"
 
-#: ../src/html/chm.cpp:345
+#: ../src/html/chm.cpp:342
 msgid "checksum error"
 msgstr "greška u ispitnom zbroju"
 
-#: ../src/common/tarstrm.cpp:820
+#: ../src/common/tarstrm.cpp:814
 msgid "checksum failure reading tar header block"
 msgstr "greška u ispitnom zbroju prilikom čitanja zaglavnog bloka"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:226
-#: ../src/richtext/richtextbackgroundpage.cpp:249
-#: ../src/richtext/richtextbackgroundpage.cpp:289
-#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
 #: ../src/richtext/richtextborderspage.cpp:254
 #: ../src/richtext/richtextborderspage.cpp:288
 #: ../src/richtext/richtextborderspage.cpp:322
@@ -8255,104 +8450,127 @@ msgstr "greška u ispitnom zbroju prilikom čitanja zaglavnog bloka"
 #: ../src/richtext/richtextmarginspage.cpp:340
 #: ../src/richtext/richtextmarginspage.cpp:363
 #: ../src/richtext/richtextmarginspage.cpp:388
-#: ../src/richtext/richtextsizepage.cpp:339
-#: ../src/richtext/richtextsizepage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:400
-#: ../src/richtext/richtextsizepage.cpp:427
-#: ../src/richtext/richtextsizepage.cpp:454
-#: ../src/richtext/richtextsizepage.cpp:481
-#: ../src/richtext/richtextsizepage.cpp:555
-#: ../src/richtext/richtextsizepage.cpp:590
-#: ../src/richtext/richtextsizepage.cpp:625
-#: ../src/richtext/richtextsizepage.cpp:660
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
 msgid "cm"
 msgstr "cm"
 
-#: ../src/html/chm.cpp:347
+#: ../src/html/chm.cpp:344
 msgid "compression error"
 msgstr "greška u komprimiranju"
 
-#: ../src/common/regex.cpp:236
+#: ../src/common/regex.cpp:233
 msgid "conversion to 8-bit encoding failed"
 msgstr "konverzija u 8-bitno kodiranje"
 
-#: ../src/common/accelcmn.cpp:187
+#: ../src/common/accelcmn.cpp:186
 msgid "ctrl"
 msgstr "ctrl"
 
-#: ../src/common/cmdline.cpp:1500
+#: ../src/common/cmdline.cpp:1496
 msgid "date"
 msgstr "datum"
 
-#: ../src/html/chm.cpp:349
+#: ../src/html/chm.cpp:346
 msgid "decompression error"
 msgstr "greška u dekomprimiranju"
 
-#: ../src/richtext/richtextstyles.cpp:780 ../src/common/fmapbase.cpp:820
+#: ../src/common/fmapbase.cpp:816 ../src/richtext/richtextstyles.cpp:777
 msgid "default"
 msgstr "zadano"
 
-#: ../src/common/cmdline.cpp:1496
+#: ../src/common/cmdline.cpp:1492
 msgid "double"
 msgstr "duplo"
 
-#: ../src/common/debugrpt.cpp:538
+#: ../src/common/debugrpt.cpp:539
 msgid "dump of the process state (binary)"
 msgstr "izvadak statusa procesa (binarno)"
 
-#: ../src/common/datetimefmt.cpp:1969
+#: ../src/common/datetimefmt.cpp:1992
 msgid "eighteenth"
 msgstr "osamnaesti"
 
-#: ../src/common/datetimefmt.cpp:1959
+#: ../src/common/datetimefmt.cpp:1982
 msgid "eighth"
 msgstr "osmi"
 
-#: ../src/common/datetimefmt.cpp:1962
+#: ../src/common/datetimefmt.cpp:1985
 msgid "eleventh"
 msgstr "jedanaesti"
 
-#: ../src/common/fileconf.cpp:1833
+#: ../src/common/fileconf.cpp:1835
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "unos „%s” se pojavljuje višestruko u grupi „%s”"
 
-#: ../src/html/chm.cpp:343
+#: ../src/html/chm.cpp:340
 msgid "error in data format"
 msgstr "greška u formatu podataka"
 
-#: ../src/html/chm.cpp:331
+#: ../src/html/chm.cpp:328
 msgid "error opening file"
 msgstr "greška prilikom otvaranja datoteke"
 
-#: ../src/common/zipstrm.cpp:1778
+#: ../src/common/zipstrm.cpp:1836
 msgid "error reading zip central directory"
 msgstr "greška prilikom čitanja osnovne mape zip-a"
 
-#: ../src/common/zipstrm.cpp:1870
+#: ../src/common/zipstrm.cpp:1940
 msgid "error reading zip local header"
 msgstr "greška prilikom čitanja lokalnog zaglavlja zip-a"
 
-#: ../src/common/zipstrm.cpp:2531
+#: ../src/common/zipstrm.cpp:2615
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "greška prilikom zapisivanja zip unosa „%s”: krivi izvor ili duljina"
 
-#: ../src/common/ffile.cpp:188
+#: ../src/common/zipstrm.cpp:2608
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "greška prilikom zapisivanja zip unosa „%s”: krivi izvor ili duljina"
+
+#: ../src/common/fontcmn.cpp:1205
+#, fuzzy
+msgid "extrabold"
+msgstr "debeli"
+
+#: ../src/common/fontcmn.cpp:1223
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1167
+#, fuzzy
+msgid "extralight"
+msgstr "svijetli"
+
+#: ../src/msw/webview_ie.cpp:1036
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "Neuspjelo izvršavanje „%s”\n"
+
+#: ../src/common/ffile.cpp:187
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "pražnjenje datoteke „%s”"
 
+#: ../src/msw/webview_ie.cpp:1045
+#, fuzzy
+msgid "failed to retrieve execution result"
+msgstr "Neuspjelo dohvaćanje teksta iz RAS poruke o greškama"
+
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1030
+#: ../src/generic/datavgen.cpp:1150
 msgid "false"
 msgstr "netočno"
 
-#: ../src/common/datetimefmt.cpp:1966
+#: ../src/common/datetimefmt.cpp:1989
 msgid "fifteenth"
 msgstr "petnaesti"
 
-#: ../src/common/datetimefmt.cpp:1956
+#: ../src/common/datetimefmt.cpp:1979
 msgid "fifth"
 msgstr "peti"
 
@@ -8383,131 +8601,150 @@ msgstr ""
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "datoteka „%s”: neočevani znak %c u %zu. retku."
 
-#: ../src/richtext/richtextbuffer.cpp:8738
+#: ../src/richtext/richtextbuffer.cpp:8736
 msgid "files"
 msgstr "datoteke"
 
-#: ../src/common/datetimefmt.cpp:1952
+#: ../src/common/datetimefmt.cpp:1975
 msgid "first"
 msgstr "prvi"
 
-#: ../src/html/helpwnd.cpp:1252
+#: ../src/html/helpwnd.cpp:1250
 msgid "font size"
 msgstr "veličina fonta"
 
-#: ../src/common/datetimefmt.cpp:1965
+#: ../src/common/datetimefmt.cpp:1988
 msgid "fourteenth"
 msgstr "četrnaesti"
 
-#: ../src/common/datetimefmt.cpp:1955
+#: ../src/common/datetimefmt.cpp:1978
 msgid "fourth"
 msgstr "četvrti"
 
-#: ../src/common/appbase.cpp:783
+#: ../src/common/appbase.cpp:784
 msgid "generate verbose log messages"
 msgstr "stvori opširne log-poruke"
 
-#: ../src/richtext/richtextbuffer.cpp:13138
-#: ../src/richtext/richtextbuffer.cpp:13248
+#: ../src/common/fontcmn.cpp:1215
+msgid "heavy"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:13133
+#: ../src/richtext/richtextbuffer.cpp:13243
 msgid "image"
 msgstr "slika"
 
-#: ../src/common/tarstrm.cpp:796
+#: ../src/common/tarstrm.cpp:790
 msgid "incomplete header block in tar"
 msgstr "nepotpuni zaglavni blok u tar"
 
-#: ../src/common/xtixml.cpp:489
+#: ../src/common/xtixml.cpp:485
 msgid "incorrect event handler string, missing dot"
 msgstr "nepravilan znakovni niz upravljača događaja, nedostaje točka"
 
-#: ../src/common/tarstrm.cpp:1381
+#: ../src/common/tarstrm.cpp:1375
 msgid "incorrect size given for tar entry"
 msgstr "nepravilna veličina, zadan za tar ulaz"
 
-#: ../src/common/tarstrm.cpp:993
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:987
 msgid "invalid data in extended tar header"
 msgstr "nevaljani podaci u proširenom tar zaglavlju"
 
-#: ../src/generic/logg.cpp:1030
+#: ../src/generic/logg.cpp:1027
 msgid "invalid message box return value"
 msgstr "nevaljana povratna vrijednost okvira za poruke"
 
-#: ../src/common/zipstrm.cpp:1647
+#: ../src/common/zipstrm.cpp:1688
 msgid "invalid zip file"
 msgstr "nevaljana zip datoteka"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:1228
 msgid "italic"
 msgstr "kurziv"
 
-#: ../src/common/fontcmn.cpp:991
+#: ../src/common/webrequest_curl.cpp:374
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "Nije bilo moguće učitati datoteku."
+
+#: ../src/common/fontcmn.cpp:1172
 msgid "light"
 msgstr "svijetli"
 
-#: ../src/common/intl.cpp:303
-#, c-format
-msgid "locale '%s' cannot be set."
-msgstr "lokalizaciju „%s” nije moguće postaviti."
+#: ../src/common/fontcmn.cpp:1185
+msgid "medium"
+msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2125
+#: ../src/common/datetimefmt.cpp:2148
 msgid "midnight"
 msgstr "ponoć"
 
-#: ../src/common/datetimefmt.cpp:1970
+#: ../src/common/datetimefmt.cpp:1993
 msgid "nineteenth"
 msgstr "devetnaesti"
 
-#: ../src/common/datetimefmt.cpp:1960
+#: ../src/common/datetimefmt.cpp:1983
 msgid "ninth"
 msgstr "deveti"
 
-#: ../src/msw/dde.cpp:1116
+#: ../src/msw/dde.cpp:1180
 msgid "no DDE error."
 msgstr "bez DDE greške."
 
-#: ../src/html/chm.cpp:327
+#: ../src/html/chm.cpp:324
 msgid "no error"
 msgstr "bez greške"
 
-#: ../src/dfb/fontmgr.cpp:174
+#: ../src/dfb/fontmgr.cpp:171
 #, c-format
 msgid "no fonts found in %s, using builtin font"
 msgstr "nisu nađeni fontovi u %s, koristi se ugrađeni font"
 
-#: ../src/html/helpdata.cpp:657
+#: ../src/html/helpdata.cpp:650
 msgid "noname"
 msgstr "bezimeno"
 
-#: ../src/common/datetimefmt.cpp:2124
+#: ../src/common/datetimefmt.cpp:2147
 msgid "noon"
 msgstr "podne"
 
-#: ../src/richtext/richtextstyles.cpp:779
+#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "normalni"
 
-#: ../src/common/cmdline.cpp:1492
+#: ../src/common/cmdline.cpp:1488
 msgid "num"
 msgstr "num"
 
-#: ../src/common/xtixml.cpp:259
+#: ../src/common/accelcmn.cpp:194
+msgid "num "
+msgstr ""
+
+#: ../src/common/xtixml.cpp:255
 msgid "objects cannot have XML Text Nodes"
 msgstr "objekti ne mogu imati XML tekstualne čvorove"
 
-#: ../src/html/chm.cpp:339
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
 msgid "out of memory"
 msgstr "nema više memorije"
 
-#: ../src/common/debugrpt.cpp:514
+#: ../src/common/debugrpt.cpp:515
 msgid "process context description"
 msgstr "obradi sadržaj opisa"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:227
-#: ../src/richtext/richtextbackgroundpage.cpp:250
-#: ../src/richtext/richtextbackgroundpage.cpp:290
-#: ../src/richtext/richtextbackgroundpage.cpp:317
-#: ../src/richtext/richtextfontpage.cpp:177
-#: ../src/richtext/richtextfontpage.cpp:180
 #: ../src/richtext/richtextborderspage.cpp:255
 #: ../src/richtext/richtextborderspage.cpp:289
 #: ../src/richtext/richtextborderspage.cpp:323
@@ -8517,22 +8754,45 @@ msgstr "obradi sadržaj opisa"
 #: ../src/richtext/richtextborderspage.cpp:491
 #: ../src/richtext/richtextborderspage.cpp:525
 #: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextfontpage.cpp:180
 msgid "pt"
 msgstr "pt"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:225
-#: ../src/richtext/richtextbackgroundpage.cpp:228
-#: ../src/richtext/richtextbackgroundpage.cpp:229
-#: ../src/richtext/richtextbackgroundpage.cpp:248
-#: ../src/richtext/richtextbackgroundpage.cpp:251
-#: ../src/richtext/richtextbackgroundpage.cpp:252
-#: ../src/richtext/richtextbackgroundpage.cpp:288
-#: ../src/richtext/richtextbackgroundpage.cpp:291
-#: ../src/richtext/richtextbackgroundpage.cpp:292
-#: ../src/richtext/richtextbackgroundpage.cpp:315
-#: ../src/richtext/richtextbackgroundpage.cpp:318
-#: ../src/richtext/richtextbackgroundpage.cpp:319
-#: ../src/richtext/richtextfontpage.cpp:178
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:659
+#: ../src/richtext/richtextsizepage.cpp:662
+#: ../src/richtext/richtextsizepage.cpp:663
 #: ../src/richtext/richtextborderspage.cpp:253
 #: ../src/richtext/richtextborderspage.cpp:256
 #: ../src/richtext/richtextborderspage.cpp:257
@@ -8584,259 +8844,269 @@ msgstr "pt"
 #: ../src/richtext/richtextmarginspage.cpp:387
 #: ../src/richtext/richtextmarginspage.cpp:389
 #: ../src/richtext/richtextmarginspage.cpp:390
-#: ../src/richtext/richtextsizepage.cpp:338
-#: ../src/richtext/richtextsizepage.cpp:341
-#: ../src/richtext/richtextsizepage.cpp:342
-#: ../src/richtext/richtextsizepage.cpp:372
-#: ../src/richtext/richtextsizepage.cpp:375
-#: ../src/richtext/richtextsizepage.cpp:376
-#: ../src/richtext/richtextsizepage.cpp:399
-#: ../src/richtext/richtextsizepage.cpp:402
-#: ../src/richtext/richtextsizepage.cpp:403
-#: ../src/richtext/richtextsizepage.cpp:426
-#: ../src/richtext/richtextsizepage.cpp:429
-#: ../src/richtext/richtextsizepage.cpp:430
-#: ../src/richtext/richtextsizepage.cpp:453
-#: ../src/richtext/richtextsizepage.cpp:456
-#: ../src/richtext/richtextsizepage.cpp:457
-#: ../src/richtext/richtextsizepage.cpp:480
-#: ../src/richtext/richtextsizepage.cpp:483
-#: ../src/richtext/richtextsizepage.cpp:484
-#: ../src/richtext/richtextsizepage.cpp:554
-#: ../src/richtext/richtextsizepage.cpp:557
-#: ../src/richtext/richtextsizepage.cpp:558
-#: ../src/richtext/richtextsizepage.cpp:589
-#: ../src/richtext/richtextsizepage.cpp:592
-#: ../src/richtext/richtextsizepage.cpp:593
-#: ../src/richtext/richtextsizepage.cpp:624
-#: ../src/richtext/richtextsizepage.cpp:627
-#: ../src/richtext/richtextsizepage.cpp:628
-#: ../src/richtext/richtextsizepage.cpp:659
-#: ../src/richtext/richtextsizepage.cpp:662
-#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextfontpage.cpp:178
 msgid "px"
 msgstr "px"
 
-#: ../src/common/accelcmn.cpp:193
+#: ../src/common/accelcmn.cpp:192
 msgid "rawctrl"
 msgstr "rawctrl"
 
-#: ../src/html/chm.cpp:333
+#: ../src/html/chm.cpp:330
 msgid "read error"
 msgstr "greška u čitanju"
 
-#: ../src/common/zipstrm.cpp:2085
+#: ../src/common/zipstrm.cpp:2155
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "čitanje zip tijeka (unos %s): loš crc"
 
-#: ../src/common/zipstrm.cpp:2080
+#: ../src/common/zipstrm.cpp:2150
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "čitanje zip tijeka (unos %s): loša duljina"
 
-#: ../src/msw/dde.cpp:1159
+#: ../src/msw/dde.cpp:1223
 msgid "reentrancy problem."
 msgstr "problema prilikom ponovnog ulaženja."
 
-#: ../src/common/datetimefmt.cpp:1953
+#: ../src/common/datetimefmt.cpp:1976
 msgid "second"
 msgstr "drugi"
 
-#: ../src/html/chm.cpp:337
+#: ../src/html/chm.cpp:334
 msgid "seek error"
 msgstr "traži grešku"
 
-#: ../src/common/datetimefmt.cpp:1968
+#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#, fuzzy
+msgid "semibold"
+msgstr "debeli"
+
+#: ../src/common/datetimefmt.cpp:1991
 msgid "seventeenth"
 msgstr "sedamnaesti"
 
-#: ../src/common/datetimefmt.cpp:1958
+#: ../src/common/datetimefmt.cpp:1981
 msgid "seventh"
 msgstr "sedmi"
 
-#: ../src/common/accelcmn.cpp:191
+#: ../src/common/accelcmn.cpp:190
 msgid "shift"
 msgstr "shift"
 
-#: ../src/common/appbase.cpp:773
+#: ../src/common/appbase.cpp:774
 msgid "show this help message"
 msgstr "prikaži ovu obavijest za pomoć"
 
-#: ../src/common/datetimefmt.cpp:1967
+#: ../src/common/datetimefmt.cpp:1990
 msgid "sixteenth"
 msgstr "šesnaesti"
 
-#: ../src/common/datetimefmt.cpp:1957
+#: ../src/common/datetimefmt.cpp:1980
 msgid "sixth"
 msgstr "šesti"
 
-#: ../src/common/appcmn.cpp:234
+#: ../src/common/appcmn.cpp:255
 msgid "specify display mode to use (e.g. 640x480-16)"
 msgstr "odredi modus zaslona, koja će se koristiti (npr. 640×480-16)"
 
-#: ../src/common/appcmn.cpp:220
+#: ../src/common/appcmn.cpp:241
 msgid "specify the theme to use"
 msgstr "odredi temu, koja će se koristiti"
 
-#: ../src/richtext/richtextbuffer.cpp:9340
+#: ../src/richtext/richtextbuffer.cpp:9337
 msgid "standard/circle"
 msgstr "standardno/krug"
 
-#: ../src/richtext/richtextbuffer.cpp:9341
+#: ../src/richtext/richtextbuffer.cpp:9338
 msgid "standard/circle-outline"
 msgstr "standardno/krug-obrisni"
 
-#: ../src/richtext/richtextbuffer.cpp:9343
+#: ../src/richtext/richtextbuffer.cpp:9340
 msgid "standard/diamond"
 msgstr "standardno/romb"
 
-#: ../src/richtext/richtextbuffer.cpp:9342
+#: ../src/richtext/richtextbuffer.cpp:9339
 msgid "standard/square"
 msgstr "standardno/kvadrat"
 
-#: ../src/richtext/richtextbuffer.cpp:9344
+#: ../src/richtext/richtextbuffer.cpp:9341
 msgid "standard/triangle"
 msgstr "standardno/trokut"
 
-#: ../src/common/zipstrm.cpp:1985
+#: ../src/common/zipstrm.cpp:2055
 msgid "stored file length not in Zip header"
 msgstr "spremljena dužina datoteke nije u Zip zaglavlju"
 
-#: ../src/common/cmdline.cpp:1488
+#: ../src/common/cmdline.cpp:1484
 msgid "str"
 msgstr "str"
 
-#: ../src/common/fontcmn.cpp:982
+#: ../src/common/fontcmn.cpp:1145
 msgid "strikethrough"
 msgstr "precrtano"
 
-#: ../src/common/tarstrm.cpp:1003 ../src/common/tarstrm.cpp:1025
-#: ../src/common/tarstrm.cpp:1507 ../src/common/tarstrm.cpp:1529
+#: ../src/common/tarstrm.cpp:997 ../src/common/tarstrm.cpp:1019
+#: ../src/common/tarstrm.cpp:1501 ../src/common/tarstrm.cpp:1523
 msgid "tar entry not open"
 msgstr "tar unos nije otvoren"
 
-#: ../src/common/datetimefmt.cpp:1961
+#: ../src/common/datetimefmt.cpp:1984
 msgid "tenth"
 msgstr "deseti"
 
-#: ../src/msw/dde.cpp:1123
+#: ../src/msw/dde.cpp:1187
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "odgovor transakciji je prouzročilo, da se postavio DDE_FBUSY bit."
 
-#: ../src/common/datetimefmt.cpp:1954
+#: ../src/common/fontcmn.cpp:1154
+msgid "thin"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:1977
 msgid "third"
 msgstr "treći"
 
-#: ../src/common/datetimefmt.cpp:1964
+#: ../src/common/datetimefmt.cpp:1987
 msgid "thirteenth"
 msgstr "trinaesti"
 
-#: ../src/common/datetimefmt.cpp:1758
+#: ../src/common/datetimefmt.cpp:1781
 msgid "today"
 msgstr "danas"
 
-#: ../src/common/datetimefmt.cpp:1760
+#: ../src/common/datetimefmt.cpp:1783
 msgid "tomorrow"
 msgstr "sutra"
 
-#: ../src/common/fileconf.cpp:1944
+#: ../src/common/fileconf.cpp:1946
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "prateća obrnuta kosa crta je zanemarena u „%s”"
 
-#: ../src/gtk/aboutdlg.cpp:218
+#: ../src/gtk/aboutdlg.cpp:216
 msgid "translator-credits"
 msgstr "prevoditelji"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1028
+#: ../src/generic/datavgen.cpp:1148
 msgid "true"
 msgstr "točno"
 
-#: ../src/common/datetimefmt.cpp:1963
+#: ../src/common/datetimefmt.cpp:1986
 msgid "twelfth"
 msgstr "dvanaesti"
 
-#: ../src/common/datetimefmt.cpp:1971
+#: ../src/common/datetimefmt.cpp:1994
 msgid "twentieth"
 msgstr "dvadeseti"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:486 ../src/generic/datavgen.cpp:1263
+#: ../src/common/datavcmn.cpp:2068 ../src/generic/datavgen.cpp:1386
 msgid "unchecked"
 msgstr "neaktivirano"
 
-#: ../src/common/fontcmn.cpp:802 ../src/common/fontcmn.cpp:978
+#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
 msgid "underlined"
 msgstr "podcrtano"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:490
+#: ../src/common/datavcmn.cpp:2072
 msgid "undetermined"
 msgstr "neodređeno"
 
-#: ../src/common/fileconf.cpp:1979
+#: ../src/common/fileconf.cpp:1981
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "neočekivani \" na poziciji %d u „%s”."
 
-#: ../src/common/tarstrm.cpp:1045
+#: ../src/common/tarstrm.cpp:1039
 msgid "unexpected end of file"
 msgstr "neočekivani kraj datoteke"
 
-#: ../src/generic/progdlgg.cpp:370 ../src/common/tarstrm.cpp:371
-#: ../src/common/tarstrm.cpp:394 ../src/common/tarstrm.cpp:425
+#: ../src/common/tarstrm.cpp:366 ../src/common/tarstrm.cpp:389
+#: ../src/common/tarstrm.cpp:420 ../src/generic/progdlgg.cpp:376
 msgid "unknown"
 msgstr "nepoznato"
 
-#: ../src/msw/registry.cpp:150
+#: ../src/msw/registry.cpp:139
 #, c-format
 msgid "unknown (%lu)"
 msgstr "nepoznato (%lu)"
 
-#: ../src/common/xtixml.cpp:253
+#: ../src/common/xtixml.cpp:249
 #, c-format
 msgid "unknown class %s"
 msgstr "nepoznati razred %s"
 
-#: ../src/common/regex.cpp:258 ../src/html/chm.cpp:351
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "greška u komprimiranju"
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "greška u dekomprimiranju"
+
+#: ../src/common/regex.cpp:255 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "nepoznata greška"
 
-#: ../src/msw/dialup.cpp:471
+#: ../src/msw/dialup.cpp:465
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "nepoznata greška (kod greške %08x)."
 
-#: ../src/common/fmapbase.cpp:834
+#: ../src/common/fmapbase.cpp:830
 #, c-format
 msgid "unknown-%d"
 msgstr "nepoznat-%d"
 
-#: ../src/common/docview.cpp:509
+#: ../src/common/docview.cpp:502
 msgid "unnamed"
 msgstr "neimenovano"
 
-#: ../src/common/docview.cpp:1624
+#: ../src/common/docview.cpp:1618
 #, c-format
 msgid "unnamed%d"
 msgstr "neimenovano%d"
 
-#: ../src/common/zipstrm.cpp:1999 ../src/common/zipstrm.cpp:2319
+#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
 msgid "unsupported Zip compression method"
 msgstr "nepodržana metoda Zip kompresije"
 
-#: ../src/common/translation.cpp:1892
+#: ../src/common/translation.cpp:1942
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "koristi se katalog „%s” od „%s”."
 
-#: ../src/html/chm.cpp:335
+#: ../src/html/chm.cpp:332
 msgid "write error"
 msgstr "greška u pisanju"
 
-#: ../src/common/time.cpp:292
+#: ../src/gtk/glcanvas.cpp:187
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/common/time.cpp:285
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay nije uspjelo."
 
@@ -8849,15 +9119,15 @@ msgstr "wxWidgets nije uspio otvoriti zaslon za „%s”: prekid."
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets nije uspio otvoriti zaslon. Prekid."
 
-#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:431
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/common/datetimefmt.cpp:1759
+#: ../src/common/datetimefmt.cpp:1782
 msgid "yesterday"
 msgstr "jučer"
 
-#: ../src/common/zstream.cpp:251 ../src/common/zstream.cpp:426
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
 #, c-format
 msgid "zlib error %d"
 msgstr "zlib greška %d"
@@ -8866,3 +9136,75 @@ msgstr "zlib greška %d"
 #: ../src/richtext/richtextbulletspage.cpp:288
 msgid "~"
 msgstr "~"
+
+#~ msgid " (while overwriting an existing item)"
+#~ msgstr " (prilikom prepisivanja preko postojeće stavke)"
+
+#~ msgid "&Save as"
+#~ msgstr "&Spremi pod"
+
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "„%s” ne sadržava samo dozvoljene slovne znakove"
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "„%s” treba biti numerički."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "„%s” treba sadržavati samo ASCII slovne znakove."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "„%s” treba sadržavati samo slovne znakove."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "„%s” treba sadržavati samo alfanumeričke znakove."
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "„%s” treba sadržavati samo brojke."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "Nije moguće stvoriti prozor vrste %s"
+
+#~ msgid "Could not initalize libnotify."
+#~ msgstr "Nije bilo moguće inicijalizirati libnotify."
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "Nije bilo moguće stvoriti pokrivni prozor"
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "Nije bilo moguće initijalizirati sadržaj pokrivnog prozora"
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "Neuspjelo konvertiranje datoteke „%s” u Unicode."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "Neuspjelo postavljanje teksta u tekst kontrole."
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr "Nevaljana GTK+ opcija naredbenog retka, koristi „%s --help”"
+
+#~ msgid "No unused colour in image."
+#~ msgstr "Nema nekorištenih boja u slici."
+
+#~ msgid "Not available"
+#~ msgstr "Nije dostupno"
+
+#~ msgid "Replace selection"
+#~ msgstr "Zamijeni odabir"
+
+#~ msgid "Save as"
+#~ msgstr "Spremi pod"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Upravljač stilova"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "Sljedeće standardne GTK+ opcije se također podržavaju:\n"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "Ne možeš ukloniti pokrivač, koji nije inicijaliziran"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "Ne možeš inicijirati jedan pokrivač dvaput"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "lokalizaciju „%s” nije moguće postaviti."

--- a/locale/hu.po
+++ b/locale/hu.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-21 14:25+0200\n"
+"POT-Creation-Date: 2020-10-18 23:11+0300\n"
 "PO-Revision-Date: 2009-07-26 20:12+0100\n"
 "Last-Translator: Oaron <oaron1@gmail.com>\n"
 "Language-Team: wxWidgets translators <wx-translators@wxwidgets.org>\n"
@@ -11,7 +11,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../src/common/debugrpt.cpp:586
+#: ../src/common/debugrpt.cpp:587
 msgid ""
 "\n"
 "Please send this report to the program maintainer, thank you!\n"
@@ -19,8 +19,8 @@ msgstr ""
 "\n"
 "Kérem küldje el ezt a jelentést a program karbantartójának! Köszönöm.\n"
 
-#: ../src/richtext/richtextstyledlg.cpp:210
-#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:206
+#: ../src/richtext/richtextstyledlg.cpp:218
 msgid " "
 msgstr " "
 
@@ -28,73 +28,99 @@ msgstr " "
 msgid "              Thank you and we're sorry for the inconvenience!\n"
 msgstr "              Köszönjük és elnézést kérünk a kényelmetlenségért!\n"
 
-#: ../src/common/prntbase.cpp:573
+#: ../src/common/prntbase.cpp:568
 #, fuzzy, c-format
 msgid " (copy %d of %d)"
 msgstr "%d. oldal (%d-ből)"
 
-#: ../src/common/log.cpp:421
+#: ../src/common/log.cpp:440
 #, c-format
 msgid " (error %ld: %s)"
 msgstr "(hiba %ld: %s) "
 
-#: ../src/common/imagtiff.cpp:72
+#: ../src/common/imagtiff.cpp:69
 #, fuzzy, c-format
 msgid " (in module \"%s\")"
 msgstr "tiff modul: %s"
 
-#: ../src/osx/core/secretstore.cpp:138
-msgid " (while overwriting an existing item)"
-msgstr ""
-
-#: ../src/common/docview.cpp:1642
+#: ../src/common/docview.cpp:1636
 msgid " - "
 msgstr " - "
 
-#: ../src/richtext/richtextprint.cpp:593 ../src/html/htmprint.cpp:714
+#: ../src/html/htmprint.cpp:712 ../src/richtext/richtextprint.cpp:589
 msgid " Preview"
 msgstr " Nyomtatási előkép"
 
-#: ../src/common/fontcmn.cpp:824
+#: ../src/common/fontcmn.cpp:973
 #, fuzzy
 msgid " bold"
 msgstr "félkövér"
 
-#: ../src/common/fontcmn.cpp:840
+#: ../src/common/fontcmn.cpp:977
+#, fuzzy
+msgid " extra bold"
+msgstr "félkövér"
+
+#: ../src/common/fontcmn.cpp:985
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:957
+#, fuzzy
+msgid " extra light"
+msgstr "vékony"
+
+#: ../src/common/fontcmn.cpp:981
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1001
 #, fuzzy
 msgid " italic"
 msgstr "dőlt"
 
-#: ../src/common/fontcmn.cpp:820
+#: ../src/common/fontcmn.cpp:961
 #, fuzzy
 msgid " light"
 msgstr "vékony"
 
-#: ../src/common/fontcmn.cpp:807
+#: ../src/common/fontcmn.cpp:965
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:969
+#, fuzzy
+msgid " semi bold"
+msgstr "félkövér"
+
+#: ../src/common/fontcmn.cpp:940
 msgid " strikethrough"
 msgstr ""
 
-#: ../src/common/paper.cpp:117
+#: ../src/common/fontcmn.cpp:953
+msgid " thin"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
 msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
 msgstr "#10 Boriték, 4 1/8 x 9 1/2 hüvelyk"
 
-#: ../src/common/paper.cpp:118
+#: ../src/common/paper.cpp:115
 msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
 msgstr "#11 Boriték, 4 1/2 x 10 3/8 hüvelyk"
 
-#: ../src/common/paper.cpp:119
+#: ../src/common/paper.cpp:116
 msgid "#12 Envelope, 4 3/4 x 11 in"
 msgstr "#12 Boriték, 4 3/4 x 11 hüvelyk"
 
-#: ../src/common/paper.cpp:120
+#: ../src/common/paper.cpp:117
 msgid "#14 Envelope, 5 x 11 1/2 in"
 msgstr "#14 Boriték, 5 x 11 1/2 hüvelyk"
 
-#: ../src/common/paper.cpp:116
+#: ../src/common/paper.cpp:113
 msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
 msgstr "#10 Boriték, 3 7/8 x 8 7/8 hüvelyk"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:341
 #: ../src/richtext/richtextsizepage.cpp:340
 #: ../src/richtext/richtextsizepage.cpp:374
 #: ../src/richtext/richtextsizepage.cpp:401
@@ -105,81 +131,82 @@ msgstr "#10 Boriték, 3 7/8 x 8 7/8 hüvelyk"
 #: ../src/richtext/richtextsizepage.cpp:591
 #: ../src/richtext/richtextsizepage.cpp:626
 #: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextbackgroundpage.cpp:341
 msgid "%"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1031
+#: ../src/html/helpwnd.cpp:1029
 #, fuzzy, c-format
 msgid "%d of %lu"
 msgstr "%i. (össz %i)"
 
-#: ../src/html/helpwnd.cpp:1678
+#: ../src/html/helpwnd.cpp:1676
 #, fuzzy, c-format
 msgid "%i of %u"
 msgstr "%i. (össz %i)"
 
-#: ../src/generic/filectrlg.cpp:279
+#: ../src/generic/filectrlg.cpp:275
 #, fuzzy, c-format
 msgid "%ld byte"
 msgid_plural "%ld bytes"
 msgstr[0] "%ld bájt"
 msgstr[1] "%ld bájt"
 
-#: ../src/html/helpwnd.cpp:1033
+#: ../src/html/helpwnd.cpp:1031
 #, fuzzy, c-format
 msgid "%lu of %lu"
 msgstr "%i. (össz %i)"
 
-#: ../src/generic/datavgen.cpp:6028
+#: ../src/generic/datavgen.cpp:6833
 #, fuzzy, c-format
 msgid "%s (%d items)"
 msgstr "%s (vagy %s)"
 
-#: ../src/common/cmdline.cpp:1221
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (vagy %s)"
 
-#: ../src/generic/logg.cpp:224
+#: ../src/generic/logg.cpp:221
 #, c-format
 msgid "%s Error"
 msgstr "%s Hiba"
 
-#: ../src/generic/logg.cpp:236
+#: ../src/generic/logg.cpp:233
 #, c-format
 msgid "%s Information"
 msgstr "%s Információ"
 
-#: ../src/generic/preferencesg.cpp:113
+#: ../src/generic/preferencesg.cpp:110
 #, fuzzy, c-format
 msgid "%s Preferences"
 msgstr "&Előválasztás"
 
-#: ../src/generic/logg.cpp:228
+#: ../src/generic/logg.cpp:225
 #, c-format
 msgid "%s Warning"
 msgstr "%s Figyelmeztetés"
 
-#: ../src/common/tarstrm.cpp:1319
+#: ../src/common/tarstrm.cpp:1313
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr ""
 
-#: ../src/common/fldlgcmn.cpp:124
+#: ../src/common/fldlgcmn.cpp:121
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s fájl (%s)|%s"
 
-#: ../src/html/helpwnd.cpp:1716
+#: ../src/html/helpwnd.cpp:1714
 #, fuzzy, c-format
 msgid "%u of %u"
 msgstr "%i. (össz %i)"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "&About"
 msgstr "&Névjegy"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "&Actual Size"
 msgstr "&Aktuális méret"
 
@@ -187,30 +214,30 @@ msgstr "&Aktuális méret"
 msgid "&After a paragraph:"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:128
 #: ../src/richtext/richtextliststylepage.cpp:319
+#: ../src/richtext/richtextindentspage.cpp:128
 #, fuzzy
 msgid "&Alignment"
 msgstr "Balra igazítsd"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "&Apply"
 msgstr "&Alkalmazd"
 
-#: ../src/richtext/richtextstyledlg.cpp:251
+#: ../src/richtext/richtextstyledlg.cpp:247
 #, fuzzy
 msgid "&Apply Style"
 msgstr "&Alkalmazd"
 
-#: ../src/msw/mdi.cpp:179
+#: ../src/msw/mdi.cpp:174
 msgid "&Arrange Icons"
 msgstr "Ikonok &elrendezése"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "&Ascending"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:142
+#: ../src/common/stockitem.cpp:139
 msgid "&Back"
 msgstr "&Vissza"
 
@@ -231,24 +258,24 @@ msgstr "S&zín"
 msgid "&Blur distance:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:143
+#: ../src/common/stockitem.cpp:140
 msgid "&Bold"
 msgstr "Kövér"
 
-#: ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141
 msgid "&Bottom"
 msgstr ""
 
+#: ../src/richtext/richtextsizepage.cpp:637
+#: ../src/richtext/richtextsizepage.cpp:644
 #: ../src/richtext/richtextborderspage.cpp:345
 #: ../src/richtext/richtextborderspage.cpp:513
 #: ../src/richtext/richtextmarginspage.cpp:259
 #: ../src/richtext/richtextmarginspage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:637
-#: ../src/richtext/richtextsizepage.cpp:644
 msgid "&Bottom:"
 msgstr ""
 
-#: ../include/wx/richtext/richtextbuffer.h:3866
+#: ../include/wx/richtext/richtextbuffer.h:3861
 #, fuzzy
 msgid "&Box"
 msgstr "Kövér"
@@ -258,39 +285,39 @@ msgstr "Kövér"
 msgid "&Bullet style:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "&CD-Rom"
 msgstr ""
 
-#: ../src/generic/wizard.cpp:434 ../src/generic/fontdlgg.cpp:470
-#: ../src/generic/fontdlgg.cpp:489 ../src/osx/carbon/fontdlg.cpp:402
-#: ../src/common/dlgcmn.cpp:279 ../src/common/stockitem.cpp:145
+#: ../src/osx/carbon/fontdlg.cpp:399 ../src/common/stockitem.cpp:142
+#: ../src/generic/wizard.cpp:433 ../src/generic/fontdlgg.cpp:466
+#: ../src/generic/fontdlgg.cpp:485 ../src/osx/cocoa/button.mm:200
 msgid "&Cancel"
 msgstr "&Mégsem"
 
-#: ../src/msw/mdi.cpp:175
+#: ../src/msw/mdi.cpp:170
 msgid "&Cascade"
 msgstr "&Zuhatag"
 
-#: ../include/wx/richtext/richtextbuffer.h:5960
+#: ../include/wx/richtext/richtextbuffer.h:5955
 #, fuzzy
 msgid "&Cell"
 msgstr "&Mégsem"
 
-#: ../src/richtext/richtextsymboldlg.cpp:439
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "&Character code:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:147
+#: ../src/common/stockitem.cpp:144
 msgid "&Clear"
 msgstr "&Törlés"
 
-#: ../src/generic/logg.cpp:516 ../src/common/stockitem.cpp:148
-#: ../src/common/prntbase.cpp:1600 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/stockitem.cpp:145 ../src/common/prntbase.cpp:1625
+#: ../src/univ/themes/win32.cpp:3753 ../src/generic/logg.cpp:513
 msgid "&Close"
 msgstr "&Bezár"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 #, fuzzy
 msgid "&Color"
 msgstr "S&zín"
@@ -300,22 +327,22 @@ msgstr "S&zín"
 msgid "&Colour:"
 msgstr "S&zín"
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 #, fuzzy
 msgid "&Convert"
 msgstr "Tartalom"
 
-#: ../src/richtext/richtextctrl.cpp:333 ../src/osx/textctrl_osx.cpp:577
-#: ../src/common/stockitem.cpp:150 ../src/msw/textctrl.cpp:2508
+#: ../src/osx/textctrl_osx.cpp:595 ../src/common/stockitem.cpp:147
+#: ../src/msw/textctrl.cpp:2773 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Másolás"
 
-#: ../src/generic/hyperlinkg.cpp:156
+#: ../src/generic/hyperlinkg.cpp:153
 #, fuzzy
 msgid "&Copy URL"
 msgstr "&Másolás"
 
-#: ../src/common/headerctrlcmn.cpp:306
+#: ../src/common/headerctrlcmn.cpp:304
 #, fuzzy
 msgid "&Customize..."
 msgstr "Jelkészlet méret"
@@ -324,55 +351,56 @@ msgstr "Jelkészlet méret"
 msgid "&Debug report preview:"
 msgstr "&Előkép a hiba jelentésről:"
 
-#: ../src/richtext/richtexttabspage.cpp:138
-#: ../src/richtext/richtextctrl.cpp:335 ../src/osx/textctrl_osx.cpp:579
-#: ../src/common/stockitem.cpp:152 ../src/msw/textctrl.cpp:2510
+#: ../src/osx/textctrl_osx.cpp:597 ../src/common/stockitem.cpp:149
+#: ../src/msw/textctrl.cpp:2775 ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtextctrl.cpp:334
 msgid "&Delete"
 msgstr "&Törlés"
 
-#: ../src/richtext/richtextstyledlg.cpp:269
+#: ../src/richtext/richtextstyledlg.cpp:265
 #, fuzzy
 msgid "&Delete Style..."
 msgstr "Bejegyzés törlése"
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "&Descending"
 msgstr ""
 
-#: ../src/generic/logg.cpp:682
+#: ../src/generic/logg.cpp:679
 msgid "&Details"
 msgstr "&Részletek"
 
-#: ../src/common/stockitem.cpp:153
+#: ../src/common/stockitem.cpp:150
 msgid "&Down"
 msgstr "&Le"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "&Edit"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:263
+#: ../src/richtext/richtextstyledlg.cpp:259
 #, fuzzy
 msgid "&Edit Style..."
 msgstr "Bejegyzés szerkesztése"
 
-#: ../src/common/stockitem.cpp:155
+#: ../src/common/stockitem.cpp:152
 msgid "&Execute"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/common/stockitem.cpp:154
 msgid "&File"
 msgstr "&Fájl"
 
-#: ../src/common/stockitem.cpp:158
-msgid "&Find"
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "&Find..."
 msgstr "&Keres"
 
-#: ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:430
 msgid "&Finish"
 msgstr "Be&fejez"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:156
 #, fuzzy
 msgid "&First"
 msgstr "első"
@@ -381,17 +409,17 @@ msgstr "első"
 msgid "&Floating mode:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 #, fuzzy
 msgid "&Floppy"
 msgstr "&Másolás"
 
-#: ../src/common/stockitem.cpp:194
+#: ../src/common/stockitem.cpp:191
 #, fuzzy
 msgid "&Font"
 msgstr "Jelkészlet család:"
 
-#: ../src/generic/fontdlgg.cpp:371
+#: ../src/generic/fontdlgg.cpp:367
 msgid "&Font family:"
 msgstr "Jelkészlet család:"
 
@@ -399,22 +427,22 @@ msgstr "Jelkészlet család:"
 msgid "&Font for Level..."
 msgstr ""
 
+#: ../src/richtext/richtextsymboldlg.cpp:397
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:400
 #, fuzzy
 msgid "&Font:"
 msgstr "Jelkészlet család:"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "&Forward"
 msgstr "&Előre"
 
-#: ../src/richtext/richtextsymboldlg.cpp:451
+#: ../src/richtext/richtextsymboldlg.cpp:448
 #, fuzzy
 msgid "&From:"
 msgstr "Tól:"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "&Harddisk"
 msgstr ""
 
@@ -424,9 +452,9 @@ msgstr ""
 msgid "&Height:"
 msgstr "Hang&súly:"
 
-#: ../src/generic/wizard.cpp:441 ../src/richtext/richtextstyledlg.cpp:303
-#: ../src/richtext/richtextsymboldlg.cpp:479 ../src/osx/menu_osx.cpp:734
-#: ../src/common/stockitem.cpp:163
+#: ../src/common/stockitem.cpp:160 ../src/generic/wizard.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextstyledlg.cpp:299 ../src/osx/cocoa/menu.mm:226
 msgid "&Help"
 msgstr "&Súgó"
 
@@ -435,7 +463,7 @@ msgstr "&Súgó"
 msgid "&Hide details"
 msgstr "&Részletek"
 
-#: ../src/common/stockitem.cpp:164
+#: ../src/common/stockitem.cpp:161
 msgid "&Home"
 msgstr "&Haza"
 
@@ -443,58 +471,58 @@ msgstr "&Haza"
 msgid "&Horizontal offset:"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:184
 #: ../src/richtext/richtextliststylepage.cpp:372
+#: ../src/richtext/richtextindentspage.cpp:184
 msgid "&Indentation (tenths of a mm)"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:167
 #: ../src/richtext/richtextliststylepage.cpp:356
+#: ../src/richtext/richtextindentspage.cpp:167
 #, fuzzy
 msgid "&Indeterminate"
 msgstr "Alá&húzás"
 
-#: ../src/common/stockitem.cpp:166
+#: ../src/common/stockitem.cpp:163
 msgid "&Index"
 msgstr "&Tartalom mutató"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 #, fuzzy
 msgid "&Info"
 msgstr "&Visszavonás"
 
-#: ../src/common/stockitem.cpp:168
+#: ../src/common/stockitem.cpp:165
 msgid "&Italic"
 msgstr "&Dőlt"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "&Jump to"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:153
 #: ../src/richtext/richtextliststylepage.cpp:342
+#: ../src/richtext/richtextindentspage.cpp:153
 #, fuzzy
 msgid "&Justified"
 msgstr "Jóváhagyva"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 #, fuzzy
 msgid "&Last"
 msgstr "&Beillesztés"
 
-#: ../src/richtext/richtextindentspage.cpp:139
 #: ../src/richtext/richtextliststylepage.cpp:328
+#: ../src/richtext/richtextindentspage.cpp:139
 msgid "&Left"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:195
+#: ../src/richtext/richtextsizepage.cpp:532
+#: ../src/richtext/richtextsizepage.cpp:539
 #: ../src/richtext/richtextborderspage.cpp:243
 #: ../src/richtext/richtextborderspage.cpp:411
 #: ../src/richtext/richtextliststylepage.cpp:381
+#: ../src/richtext/richtextindentspage.cpp:195
 #: ../src/richtext/richtextmarginspage.cpp:186
 #: ../src/richtext/richtextmarginspage.cpp:300
-#: ../src/richtext/richtextsizepage.cpp:532
-#: ../src/richtext/richtextsizepage.cpp:539
 msgid "&Left:"
 msgstr ""
 
@@ -502,11 +530,11 @@ msgstr ""
 msgid "&List level:"
 msgstr ""
 
-#: ../src/generic/logg.cpp:517
+#: ../src/generic/logg.cpp:514
 msgid "&Log"
 msgstr "&Napló"
 
-#: ../src/univ/themes/win32.cpp:3748
+#: ../src/univ/themes/win32.cpp:3745
 msgid "&Move"
 msgstr "&Áthelyezés"
 
@@ -514,21 +542,20 @@ msgstr "&Áthelyezés"
 msgid "&Move the object to:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 #, fuzzy
 msgid "&Network"
 msgstr "Ú&j "
 
-#: ../src/richtext/richtexttabspage.cpp:132 ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173 ../src/richtext/richtexttabspage.cpp:132
 msgid "&New"
 msgstr "Ú&j "
 
-#: ../src/aui/tabmdi.cpp:111 ../src/generic/mdig.cpp:100
-#: ../src/msw/mdi.cpp:180
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
 msgid "&Next"
 msgstr "&Következő "
 
-#: ../src/generic/wizard.cpp:432 ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:429
 msgid "&Next >"
 msgstr "&Következő >"
 
@@ -536,7 +563,7 @@ msgstr "&Következő >"
 msgid "&Next Paragraph"
 msgstr ""
 
-#: ../src/generic/tipdlg.cpp:240
+#: ../src/generic/tipdlg.cpp:237
 msgid "&Next Tip"
 msgstr "&Következő ötlet"
 
@@ -545,11 +572,11 @@ msgstr "&Következő ötlet"
 msgid "&Next style:"
 msgstr "&Következő >"
 
-#: ../src/common/stockitem.cpp:177 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:174 ../src/msw/msgdlg.cpp:435
 msgid "&No"
 msgstr "&Nem"
 
-#: ../src/generic/dbgrptg.cpp:356
+#: ../src/generic/dbgrptg.cpp:360
 msgid "&Notes:"
 msgstr "&Megjegyzések:"
 
@@ -557,12 +584,12 @@ msgstr "&Megjegyzések:"
 msgid "&Number:"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:475 ../src/generic/fontdlgg.cpp:482
-#: ../src/osx/carbon/fontdlg.cpp:408 ../src/common/stockitem.cpp:178
+#: ../src/osx/carbon/fontdlg.cpp:405 ../src/common/stockitem.cpp:175
+#: ../src/generic/fontdlgg.cpp:471 ../src/generic/fontdlgg.cpp:478
 msgid "&OK"
 msgstr "&Ok"
 
-#: ../src/generic/dbgrptg.cpp:342 ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176 ../src/generic/dbgrptg.cpp:342
 msgid "&Open..."
 msgstr "&Megnyitás..."
 
@@ -574,16 +601,16 @@ msgstr ""
 msgid "&Page Break"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:334 ../src/osx/textctrl_osx.cpp:578
-#: ../src/common/stockitem.cpp:180 ../src/msw/textctrl.cpp:2509
+#: ../src/osx/textctrl_osx.cpp:596 ../src/common/stockitem.cpp:177
+#: ../src/msw/textctrl.cpp:2774 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&Beillesztés"
 
-#: ../include/wx/richtext/richtextbuffer.h:5010
+#: ../include/wx/richtext/richtextbuffer.h:5005
 msgid "&Picture"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:419
 msgid "&Point size:"
 msgstr "Jelkészlet &pontmérete:"
 
@@ -596,12 +623,11 @@ msgstr ""
 msgid "&Position mode:"
 msgstr "Kérdés"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178
 msgid "&Preferences"
 msgstr "&Előválasztás"
 
-#: ../src/aui/tabmdi.cpp:112 ../src/generic/mdig.cpp:101
-#: ../src/msw/mdi.cpp:181
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
 msgid "&Previous"
 msgstr "&Előző"
 
@@ -610,82 +636,77 @@ msgstr "&Előző"
 msgid "&Previous Paragraph"
 msgstr "Előző oldal"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "&Print..."
 msgstr "&Nyomtatás..."
 
-#: ../src/richtext/richtextctrl.cpp:339 ../src/richtext/richtextctrl.cpp:5514
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtextctrl.cpp:338
+#: ../src/richtext/richtextctrl.cpp:5512
 msgid "&Properties"
 msgstr "&Tulajdonságok"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "&Quit"
 msgstr "&Kilépés"
 
-#: ../src/richtext/richtextctrl.cpp:330 ../src/osx/textctrl_osx.cpp:574
-#: ../src/common/stockitem.cpp:185 ../src/common/cmdproc.cpp:293
-#: ../src/common/cmdproc.cpp:300 ../src/msw/textctrl.cpp:2505
+#: ../src/osx/textctrl_osx.cpp:592 ../src/common/stockitem.cpp:182
+#: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
+#: ../src/msw/textctrl.cpp:2770 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Újra"
 
-#: ../src/common/cmdproc.cpp:289 ../src/common/cmdproc.cpp:309
+#: ../src/common/cmdproc.cpp:282 ../src/common/cmdproc.cpp:302
 msgid "&Redo "
 msgstr "&Újra"
 
-#: ../src/richtext/richtextstyledlg.cpp:257
+#: ../src/richtext/richtextstyledlg.cpp:253
 msgid "&Rename Style..."
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:179
+#: ../src/generic/fdrepdlg.cpp:176
 msgid "&Replace"
 msgstr "&Helyettesítés"
 
-#: ../src/richtext/richtextstyledlg.cpp:287
+#: ../src/richtext/richtextstyledlg.cpp:283
 msgid "&Restart numbering"
 msgstr ""
 
-#: ../src/univ/themes/win32.cpp:3747
+#: ../src/univ/themes/win32.cpp:3744
 msgid "&Restore"
 msgstr "&Helyreállítás"
 
-#: ../src/richtext/richtextindentspage.cpp:146
 #: ../src/richtext/richtextliststylepage.cpp:335
+#: ../src/richtext/richtextindentspage.cpp:146
 #, fuzzy
 msgid "&Right"
 msgstr "Vékony"
 
-#: ../src/richtext/richtextindentspage.cpp:213
+#: ../src/richtext/richtextsizepage.cpp:602
+#: ../src/richtext/richtextsizepage.cpp:609
 #: ../src/richtext/richtextborderspage.cpp:277
 #: ../src/richtext/richtextborderspage.cpp:445
 #: ../src/richtext/richtextliststylepage.cpp:399
+#: ../src/richtext/richtextindentspage.cpp:213
 #: ../src/richtext/richtextmarginspage.cpp:211
 #: ../src/richtext/richtextmarginspage.cpp:325
-#: ../src/richtext/richtextsizepage.cpp:602
-#: ../src/richtext/richtextsizepage.cpp:609
 #, fuzzy
 msgid "&Right:"
 msgstr "Hang&súly:"
 
-#: ../src/common/stockitem.cpp:190
+#: ../src/common/stockitem.cpp:187
 msgid "&Save"
 msgstr "&Mentés"
-
-#: ../src/common/stockitem.cpp:191
-#, fuzzy
-msgid "&Save as"
-msgstr "Mentés Másként"
 
 #: ../include/wx/richmsgdlg.h:29
 #, fuzzy
 msgid "&See details"
 msgstr "&Részletek"
 
-#: ../src/generic/tipdlg.cpp:236
+#: ../src/generic/tipdlg.cpp:233
 msgid "&Show tips at startup"
 msgstr "&Mutass ötleteket inditáskor"
 
-#: ../src/univ/themes/win32.cpp:3750
+#: ../src/univ/themes/win32.cpp:3747
 msgid "&Size"
 msgstr "&Méret"
 
@@ -694,38 +715,38 @@ msgstr "&Méret"
 msgid "&Size:"
 msgstr "&Méret"
 
-#: ../src/generic/progdlgg.cpp:252
+#: ../src/generic/progdlgg.cpp:249
 #, fuzzy
 msgid "&Skip"
 msgstr "Ugrás"
 
-#: ../src/richtext/richtextindentspage.cpp:242
 #: ../src/richtext/richtextliststylepage.cpp:417
+#: ../src/richtext/richtextindentspage.cpp:242
 msgid "&Spacing (tenths of a mm)"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "&Spell Check"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "&Stop"
 msgstr "&Leállítás"
 
-#: ../src/richtext/richtextfontpage.cpp:275 ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196 ../src/richtext/richtextfontpage.cpp:275
 msgid "&Strikethrough"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:382 ../src/richtext/richtextstylepage.cpp:106
+#: ../src/generic/fontdlgg.cpp:378 ../src/richtext/richtextstylepage.cpp:106
 msgid "&Style:"
 msgstr "&Stílus:"
 
-#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:194
 #, fuzzy
 msgid "&Styles:"
 msgstr "&Stílus:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:413
+#: ../src/richtext/richtextsymboldlg.cpp:410
 msgid "&Subset:"
 msgstr ""
 
@@ -740,26 +761,26 @@ msgstr "&Stílus:"
 msgid "&Synchronize values"
 msgstr ""
 
-#: ../include/wx/richtext/richtextbuffer.h:6069
+#: ../include/wx/richtext/richtextbuffer.h:6064
 msgid "&Table"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197
 #, fuzzy
 msgid "&Top"
 msgstr "&Másolás"
 
+#: ../src/richtext/richtextsizepage.cpp:567
+#: ../src/richtext/richtextsizepage.cpp:574
 #: ../src/richtext/richtextborderspage.cpp:311
 #: ../src/richtext/richtextborderspage.cpp:479
 #: ../src/richtext/richtextmarginspage.cpp:234
 #: ../src/richtext/richtextmarginspage.cpp:348
-#: ../src/richtext/richtextsizepage.cpp:567
-#: ../src/richtext/richtextsizepage.cpp:574
 #, fuzzy
 msgid "&Top:"
 msgstr "Ig:"
 
-#: ../src/generic/fontdlgg.cpp:444 ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199 ../src/generic/fontdlgg.cpp:441
 msgid "&Underline"
 msgstr "Alá&húzás"
 
@@ -768,21 +789,21 @@ msgstr "Alá&húzás"
 msgid "&Underlining:"
 msgstr "Alá&húzás"
 
-#: ../src/richtext/richtextctrl.cpp:329 ../src/osx/textctrl_osx.cpp:573
-#: ../src/common/stockitem.cpp:203 ../src/common/cmdproc.cpp:271
-#: ../src/msw/textctrl.cpp:2504
+#: ../src/osx/textctrl_osx.cpp:591 ../src/common/stockitem.cpp:200
+#: ../src/common/cmdproc.cpp:264 ../src/msw/textctrl.cpp:2769
+#: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Visszavonás"
 
-#: ../src/common/cmdproc.cpp:265
+#: ../src/common/cmdproc.cpp:258
 msgid "&Undo "
 msgstr "&Visszavonás"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "&Unindent"
 msgstr "&Kikezdés"
 
-#: ../src/common/stockitem.cpp:205
+#: ../src/common/stockitem.cpp:202
 msgid "&Up"
 msgstr "&Fel"
 
@@ -801,7 +822,7 @@ msgstr "Balra igazítsd"
 msgid "&View..."
 msgstr "&Megnyitás..."
 
-#: ../src/generic/fontdlgg.cpp:393
+#: ../src/generic/fontdlgg.cpp:389
 msgid "&Weight:"
 msgstr "Hang&súly:"
 
@@ -811,88 +832,58 @@ msgstr "Hang&súly:"
 msgid "&Width:"
 msgstr "Hang&súly:"
 
-#: ../src/aui/tabmdi.cpp:311 ../src/aui/tabmdi.cpp:327
-#: ../src/aui/tabmdi.cpp:329 ../src/generic/mdig.cpp:294
-#: ../src/generic/mdig.cpp:310 ../src/generic/mdig.cpp:314
-#: ../src/msw/mdi.cpp:78
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
 msgid "&Window"
 msgstr "&Ablak"
 
-#: ../src/common/stockitem.cpp:206 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:203 ../src/msw/msgdlg.cpp:435
 msgid "&Yes"
 msgstr "&Igen"
 
-#: ../src/common/valtext.cpp:256
+#: ../src/common/valtext.cpp:197
 #, fuzzy, c-format
-msgid "'%s' contains illegal characters"
+msgid "'%s' contains invalid character(s)"
 msgstr "'%s' csak betűket tartalmazhat."
 
-#: ../src/common/valtext.cpp:254
-#, fuzzy, c-format
-msgid "'%s' doesn't consist only of valid characters"
-msgstr "'%s' csak betűket tartalmazhat."
-
-#: ../src/common/config.cpp:519 ../src/msw/regconf.cpp:258
+#: ../src/common/config.cpp:515 ../src/msw/regconf.cpp:255
 #, c-format
 msgid "'%s' has extra '..', ignored."
 msgstr "'%s' után felesleges '..'-t találtam, elhanyagoltam."
 
-#: ../src/common/cmdline.cpp:1113 ../src/common/cmdline.cpp:1131
+#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' nem megfelelő számérték a(z) '%s' beállításához."
 
-#: ../src/common/translation.cpp:1100
+#: ../src/common/translation.cpp:1142
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' érvénytelen üzenet katalógus."
 
-#: ../src/common/valtext.cpp:165
+#: ../src/common/valtext.cpp:188
 #, fuzzy, c-format
 msgid "'%s' is not one of the valid strings"
 msgstr "'%s' érvénytelen üzenet katalógus."
 
-#: ../src/common/valtext.cpp:167
+#: ../src/common/valtext.cpp:186
 #, fuzzy, c-format
 msgid "'%s' is one of the invalid strings"
 msgstr "'%s' érvénytelen"
 
-#: ../src/common/textbuf.cpp:237
+#: ../src/common/textbuf.cpp:233
 #, c-format
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' valószínűleg bináris fájl."
-
-#: ../src/common/valtext.cpp:252
-#, c-format
-msgid "'%s' should be numeric."
-msgstr "'%s' csak számérték lehet."
-
-#: ../src/common/valtext.cpp:244
-#, c-format
-msgid "'%s' should only contain ASCII characters."
-msgstr "'%s' csak ASCII jeleket tartalmazhat."
-
-#: ../src/common/valtext.cpp:246
-#, c-format
-msgid "'%s' should only contain alphabetic characters."
-msgstr "'%s' csak betűket tartalmazhat."
-
-#: ../src/common/valtext.cpp:248
-#, c-format
-msgid "'%s' should only contain alphabetic or numeric characters."
-msgstr "'%s' csak betűket vagy számokat tartalmazhat."
-
-#: ../src/common/valtext.cpp:250
-#, fuzzy, c-format
-msgid "'%s' should only contain digits."
-msgstr "'%s' csak ASCII jeleket tartalmazhat."
 
 #: ../src/richtext/richtextliststylepage.cpp:229
 #: ../src/richtext/richtextbulletspage.cpp:166
 msgid "(*)"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:963
+#: ../src/html/helpwnd.cpp:961
 msgid "(Help)"
 msgstr "(Súgó)"
 
@@ -901,28 +892,33 @@ msgstr "(Súgó)"
 msgid "(None)"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:504
+#: ../src/richtext/richtextsymboldlg.cpp:503
 #, fuzzy
 msgid "(Normal text)"
 msgstr "Normál jelkészlet:"
 
-#: ../src/html/helpwnd.cpp:419 ../src/html/helpwnd.cpp:1106
-#: ../src/html/helpwnd.cpp:1742
+#: ../src/html/helpwnd.cpp:417 ../src/html/helpwnd.cpp:1104
+#: ../src/html/helpwnd.cpp:1740
 msgid "(bookmarks)"
 msgstr "(könyvjelzők)"
 
+#: ../src/msw/dlmsw.cpp:167
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr "(hiba %ld: %s) "
+
+#: ../src/richtext/richtextformatdlg.cpp:876
+#: ../src/richtext/richtextliststylepage.cpp:448
+#: ../src/richtext/richtextliststylepage.cpp:460
+#: ../src/richtext/richtextliststylepage.cpp:461
 #: ../src/richtext/richtextindentspage.cpp:274
 #: ../src/richtext/richtextindentspage.cpp:286
 #: ../src/richtext/richtextindentspage.cpp:287
 #: ../src/richtext/richtextindentspage.cpp:311
 #: ../src/richtext/richtextindentspage.cpp:326
-#: ../src/richtext/richtextformatdlg.cpp:884
 #: ../src/richtext/richtextfontpage.cpp:349
 #: ../src/richtext/richtextfontpage.cpp:353
 #: ../src/richtext/richtextfontpage.cpp:357
-#: ../src/richtext/richtextliststylepage.cpp:448
-#: ../src/richtext/richtextliststylepage.cpp:460
-#: ../src/richtext/richtextliststylepage.cpp:461
 #, fuzzy
 msgid "(none)"
 msgstr "névtelen"
@@ -942,7 +938,7 @@ msgstr ""
 msgid "+"
 msgstr ""
 
-#: ../src/msw/utils.cpp:1152
+#: ../src/msw/utils.cpp:1143
 msgid ", 64-bit edition"
 msgstr ""
 
@@ -951,170 +947,170 @@ msgstr ""
 msgid "-"
 msgstr ""
 
-#: ../src/generic/filepickerg.cpp:66
+#: ../src/generic/filepickerg.cpp:63
 #, fuzzy
 msgid "..."
 msgstr ".."
 
-#: ../src/richtext/richtextindentspage.cpp:276
 #: ../src/richtext/richtextliststylepage.cpp:450
+#: ../src/richtext/richtextindentspage.cpp:276
 msgid "1.1"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:277
 #: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextindentspage.cpp:277
 msgid "1.2"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:278
 #: ../src/richtext/richtextliststylepage.cpp:452
+#: ../src/richtext/richtextindentspage.cpp:278
 msgid "1.3"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:279
 #: ../src/richtext/richtextliststylepage.cpp:453
+#: ../src/richtext/richtextindentspage.cpp:279
 msgid "1.4"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:280
 #: ../src/richtext/richtextliststylepage.cpp:454
+#: ../src/richtext/richtextindentspage.cpp:280
 msgid "1.5"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:281
 #: ../src/richtext/richtextliststylepage.cpp:455
+#: ../src/richtext/richtextindentspage.cpp:281
 msgid "1.6"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:282
 #: ../src/richtext/richtextliststylepage.cpp:456
+#: ../src/richtext/richtextindentspage.cpp:282
 msgid "1.7"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:283
 #: ../src/richtext/richtextliststylepage.cpp:457
+#: ../src/richtext/richtextindentspage.cpp:283
 msgid "1.8"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:284
 #: ../src/richtext/richtextliststylepage.cpp:458
+#: ../src/richtext/richtextindentspage.cpp:284
 msgid "1.9"
 msgstr ""
 
-#: ../src/common/paper.cpp:140
+#: ../src/common/paper.cpp:137
 msgid "10 x 11 in"
 msgstr "10 x 11 hüvelyk"
 
-#: ../src/common/paper.cpp:113
+#: ../src/common/paper.cpp:110
 msgid "10 x 14 in"
 msgstr "10 x 14 hüvelyk"
 
-#: ../src/common/paper.cpp:114
+#: ../src/common/paper.cpp:111
 msgid "11 x 17 in"
 msgstr "11 x 17 hüvelyk"
 
-#: ../src/common/paper.cpp:184
+#: ../src/common/paper.cpp:181
 msgid "12 x 11 in"
 msgstr "12 x 11 hüvelyk"
 
-#: ../src/common/paper.cpp:141
+#: ../src/common/paper.cpp:138
 msgid "15 x 11 in"
 msgstr "15 x 11 hüvelyk"
 
-#: ../src/richtext/richtextindentspage.cpp:285
 #: ../src/richtext/richtextliststylepage.cpp:459
+#: ../src/richtext/richtextindentspage.cpp:285
 msgid "2"
 msgstr ""
 
-#: ../src/common/paper.cpp:132
+#: ../src/common/paper.cpp:129
 msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
 msgstr "6 3/4 Boríték, 3 5/8 x 6 1/2 hüvelyk"
 
-#: ../src/common/paper.cpp:139
+#: ../src/common/paper.cpp:136
 msgid "9 x 11 in"
 msgstr "9 x 11 hüvelyk"
 
-#: ../src/html/htmprint.cpp:431
+#: ../src/html/htmprint.cpp:443
 msgid ": file does not exist!"
 msgstr ": a file nem létezik!"
 
-#: ../src/common/fontmap.cpp:199
+#: ../src/common/fontmap.cpp:196
 msgid ": unknown charset"
 msgstr ": ismeretlen jelkészlet"
 
-#: ../src/common/fontmap.cpp:413
+#: ../src/common/fontmap.cpp:410
 msgid ": unknown encoding"
 msgstr ": ismeretlen kódolás"
 
-#: ../src/generic/wizard.cpp:443
+#: ../src/generic/wizard.cpp:438
 msgid "< &Back"
 msgstr "< &Vissza"
 
-#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:628
-#: ../src/osx/carbon/fontdlg.cpp:648
+#: ../src/osx/carbon/fontdlg.cpp:419 ../src/osx/carbon/fontdlg.cpp:625
+#: ../src/osx/carbon/fontdlg.cpp:645
 #, fuzzy
 msgid "<Any Decorative>"
 msgstr "Dekoratív"
 
-#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:630
-#: ../src/osx/carbon/fontdlg.cpp:650
+#: ../src/osx/carbon/fontdlg.cpp:420 ../src/osx/carbon/fontdlg.cpp:627
+#: ../src/osx/carbon/fontdlg.cpp:647
 #, fuzzy
 msgid "<Any Modern>"
 msgstr "Modern"
 
-#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:626
-#: ../src/osx/carbon/fontdlg.cpp:646
+#: ../src/osx/carbon/fontdlg.cpp:418 ../src/osx/carbon/fontdlg.cpp:623
+#: ../src/osx/carbon/fontdlg.cpp:643
 #, fuzzy
 msgid "<Any Roman>"
 msgstr "Roman"
 
-#: ../src/osx/carbon/fontdlg.cpp:424 ../src/osx/carbon/fontdlg.cpp:632
-#: ../src/osx/carbon/fontdlg.cpp:652
+#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:629
+#: ../src/osx/carbon/fontdlg.cpp:649
 #, fuzzy
 msgid "<Any Script>"
 msgstr "Script"
 
-#: ../src/osx/carbon/fontdlg.cpp:425 ../src/osx/carbon/fontdlg.cpp:637
-#: ../src/osx/carbon/fontdlg.cpp:656
+#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:634
+#: ../src/osx/carbon/fontdlg.cpp:653
 #, fuzzy
 msgid "<Any Swiss>"
 msgstr "Svájci"
 
-#: ../src/osx/carbon/fontdlg.cpp:426 ../src/osx/carbon/fontdlg.cpp:634
-#: ../src/osx/carbon/fontdlg.cpp:654
+#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:631
+#: ../src/osx/carbon/fontdlg.cpp:651
 #, fuzzy
 msgid "<Any Teletype>"
 msgstr "Teletype"
 
-#: ../src/osx/carbon/fontdlg.cpp:420
+#: ../src/osx/carbon/fontdlg.cpp:417
 msgid "<Any>"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
 msgid "<DIR>"
 msgstr "<DIR>"
 
-#: ../src/generic/filectrlg.cpp:254 ../src/generic/filectrlg.cpp:277
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
 msgid "<DRIVE>"
 msgstr "<MEGHAJTÓ>"
 
-#: ../src/generic/filectrlg.cpp:252 ../src/generic/filectrlg.cpp:275
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
 msgid "<LINK>"
 msgstr "<LINK>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1264
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Félkövér dőlt betű.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1270
+#: ../src/html/helpwnd.cpp:1268
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>félkövér dőlt <u>aláhúzott</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1265
+#: ../src/html/helpwnd.cpp:1263
 msgid "<b>Bold face.</b> "
 msgstr "<b>Félkövér betű.</b> "
 
-#: ../src/html/helpwnd.cpp:1264
+#: ../src/html/helpwnd.cpp:1262
 msgid "<i>Italic face.</i> "
 msgstr "<i>Dőlt betű.</i> "
 
@@ -1124,16 +1120,16 @@ msgstr "<i>Dőlt betű.</i> "
 msgid ">"
 msgstr ">>"
 
-#: ../src/generic/dbgrptg.cpp:318
+#: ../src/generic/dbgrptg.cpp:317
 msgid "A debug report has been generated in the directory\n"
 msgstr "A hibakeresésről a jelentés ebben a könyvtárban van\n"
 
-#: ../src/common/debugrpt.cpp:573
+#: ../src/common/debugrpt.cpp:574
 #, fuzzy
 msgid "A debug report has been generated. It can be found in"
 msgstr "A hibakeresésről a jelentés ebben a könyvtárban van\n"
 
-#: ../src/common/xtixml.cpp:418
+#: ../src/common/xtixml.cpp:414
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Egy nem-üres gyűjteménynek 'elem' csomópontokból kell állnia"
 
@@ -1144,109 +1140,109 @@ msgstr "Egy nem-üres gyűjteménynek 'elem' csomópontokból kell állnia"
 msgid "A standard bullet name."
 msgstr ""
 
-#: ../src/common/paper.cpp:217
+#: ../src/common/paper.cpp:214
 #, fuzzy
 msgid "A0 sheet, 841 x 1189 mm"
 msgstr "A4 lap, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:218
+#: ../src/common/paper.cpp:215
 #, fuzzy
 msgid "A1 sheet, 594 x 841 mm"
 msgstr "A3 lap, 297 x 420 mm"
 
-#: ../src/common/paper.cpp:159
+#: ../src/common/paper.cpp:156
 msgid "A2 420 x 594 mm"
 msgstr "A2 420 x 594 mm"
 
-#: ../src/common/paper.cpp:156
+#: ../src/common/paper.cpp:153
 msgid "A3 Extra 322 x 445 mm"
 msgstr "A3 Extra, 322 x 445 mm"
 
-#: ../src/common/paper.cpp:161
+#: ../src/common/paper.cpp:158
 msgid "A3 Extra Transverse 322 x 445 mm"
 msgstr "A3 Extra Transverse 322 x 445 mm"
 
-#: ../src/common/paper.cpp:170
+#: ../src/common/paper.cpp:167
 msgid "A3 Rotated 420 x 297 mm"
 msgstr "A3 elfordított, 420 x 297 mm"
 
-#: ../src/common/paper.cpp:160
+#: ../src/common/paper.cpp:157
 msgid "A3 Transverse 297 x 420 mm"
 msgstr "A3 Transverse 297 x 420 mm"
 
-#: ../src/common/paper.cpp:106
+#: ../src/common/paper.cpp:103
 msgid "A3 sheet, 297 x 420 mm"
 msgstr "A3 lap, 297 x 420 mm"
 
-#: ../src/common/paper.cpp:146
+#: ../src/common/paper.cpp:143
 msgid "A4 Extra 9.27 x 12.69 in"
 msgstr "A4 Extra 9.27 x 12.69 in"
 
-#: ../src/common/paper.cpp:153
+#: ../src/common/paper.cpp:150
 msgid "A4 Plus 210 x 330 mm"
 msgstr "A4 plus, 210 x 330 mm"
 
-#: ../src/common/paper.cpp:171
+#: ../src/common/paper.cpp:168
 msgid "A4 Rotated 297 x 210 mm"
 msgstr "A4 297 x 210 mm, elfordított"
 
-#: ../src/common/paper.cpp:148
+#: ../src/common/paper.cpp:145
 msgid "A4 Transverse 210 x 297 mm"
 msgstr "A4 Transverse 210 x 297 mm"
 
-#: ../src/common/paper.cpp:97
+#: ../src/common/paper.cpp:94
 msgid "A4 sheet, 210 x 297 mm"
 msgstr "A4 lap, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:107
+#: ../src/common/paper.cpp:104
 msgid "A4 small sheet, 210 x 297 mm"
 msgstr "A4 kis lap, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:157
+#: ../src/common/paper.cpp:154
 msgid "A5 Extra 174 x 235 mm"
 msgstr "A5 Extra 174 x 235 mm"
 
-#: ../src/common/paper.cpp:172
+#: ../src/common/paper.cpp:169
 msgid "A5 Rotated 210 x 148 mm"
 msgstr "A5 Elfordított 210 x 148 mm"
 
-#: ../src/common/paper.cpp:154
+#: ../src/common/paper.cpp:151
 msgid "A5 Transverse 148 x 210 mm"
 msgstr "A5 Transverse 148 x 210 mm"
 
-#: ../src/common/paper.cpp:108
+#: ../src/common/paper.cpp:105
 msgid "A5 sheet, 148 x 210 mm"
 msgstr "A5 lap, 148 x 210 mm"
 
-#: ../src/common/paper.cpp:164
+#: ../src/common/paper.cpp:161
 msgid "A6 105 x 148 mm"
 msgstr "A6 105 x 148 mm"
 
-#: ../src/common/paper.cpp:177
+#: ../src/common/paper.cpp:174
 msgid "A6 Rotated 148 x 105 mm"
 msgstr "A6 elfordított 148 x 105 mm"
 
-#: ../src/generic/fontdlgg.cpp:83 ../src/richtext/richtextformatdlg.cpp:529
-#: ../src/osx/carbon/fontdlg.cpp:153
+#: ../src/osx/carbon/fontdlg.cpp:150 ../src/generic/fontdlgg.cpp:79
+#: ../src/richtext/richtextformatdlg.cpp:521
 msgid "ABCDEFGabcdefg12345"
 msgstr "ABCDEFGabcdefg12345"
 
-#: ../src/richtext/richtextsymboldlg.cpp:458 ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
 msgid "ASCII"
 msgstr "ASCII"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 #, fuzzy
 msgid "About"
 msgstr "&Névjegy"
 
-#: ../src/generic/aboutdlgg.cpp:140 ../src/osx/menu_osx.cpp:558
-#: ../src/msw/aboutdlg.cpp:64
+#: ../src/osx/menu_osx.cpp:450 ../src/generic/aboutdlgg.cpp:137
+#: ../src/msw/aboutdlg.cpp:61
 #, fuzzy, c-format
 msgid "About %s"
 msgstr "&Névjegy..."
 
-#: ../src/osx/menu_osx.cpp:560
+#: ../src/osx/menu_osx.cpp:452
 #, fuzzy
 msgid "About..."
 msgstr "&Névjegy"
@@ -1256,39 +1252,39 @@ msgid "Absolute"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:873
+#: ../src/propgrid/advprops.cpp:774
 #, fuzzy
 msgid "ActiveBorder"
 msgstr "Modern"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:874
+#: ../src/propgrid/advprops.cpp:775
 msgid "ActiveCaption"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 #, fuzzy
 msgid "Actual Size"
 msgstr "&Aktuális méret"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:140 ../src/common/accelcmn.cpp:81
+#: ../src/common/stockitem.cpp:137 ../src/common/accelcmn.cpp:78
 msgid "Add"
 msgstr "Add hozzá"
 
-#: ../src/richtext/richtextbuffer.cpp:11455
+#: ../src/richtext/richtextbuffer.cpp:11454
 msgid "Add Column"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11392
+#: ../src/richtext/richtextbuffer.cpp:11391
 msgid "Add Row"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:432
+#: ../src/html/helpwnd.cpp:430
 msgid "Add current page to bookmarks"
 msgstr "Add hozzá ezt a lapot a könyvjelzőkhöz"
 
-#: ../src/generic/colrdlgg.cpp:366
+#: ../src/generic/colrdlgg.cpp:386
 msgid "Add to custom colours"
 msgstr "Add hozzá a felhasználói színekhez"
 
@@ -1300,12 +1296,12 @@ msgstr "AddToPropertyCollection hívás generikus hozzáféréssel"
 msgid "AddToPropertyCollection called w/o valid adder"
 msgstr "AddToPropertyCollection hívás érvényes hozzáadás nélkül"
 
-#: ../src/html/helpctrl.cpp:159
+#: ../src/html/helpctrl.cpp:155
 #, c-format
 msgid "Adding book %s"
 msgstr "Add hozzá a %s könyvet"
 
-#: ../src/common/preferencescmn.cpp:43
+#: ../src/common/preferencescmn.cpp:40
 msgid "Advanced"
 msgstr ""
 
@@ -1313,11 +1309,11 @@ msgstr ""
 msgid "After a paragraph:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:172
+#: ../src/common/stockitem.cpp:169
 msgid "Align Left"
 msgstr "Balra igazítsd"
 
-#: ../src/common/stockitem.cpp:173
+#: ../src/common/stockitem.cpp:170
 msgid "Align Right"
 msgstr "Jobbra igazíts"
 
@@ -1326,40 +1322,40 @@ msgstr "Jobbra igazíts"
 msgid "Alignment"
 msgstr "Balra igazítsd"
 
-#: ../src/generic/prntdlgg.cpp:215
+#: ../src/generic/prntdlgg.cpp:208
 msgid "All"
 msgstr "Mindet"
 
-#: ../src/generic/filectrlg.cpp:1197 ../src/common/fldlgcmn.cpp:107
+#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1186
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Minden fájlt (%s)|%s"
 
-#: ../include/wx/defs.h:2886
+#: ../include/wx/defs.h:2582
 msgid "All files (*)|*"
 msgstr "Minden fájlt (*)|*"
 
-#: ../include/wx/defs.h:2883
+#: ../include/wx/defs.h:2579
 msgid "All files (*.*)|*.*"
 msgstr "Minden fájlt (*.*)|*.*"
 
-#: ../src/richtext/richtextstyles.cpp:1061
+#: ../src/richtext/richtextstyles.cpp:1058
 msgid "All styles"
 msgstr ""
 
-#: ../src/propgrid/manager.cpp:1528
+#: ../src/propgrid/manager.cpp:1544
 msgid "Alphabetic Mode"
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:425
+#: ../src/common/xtistrm.cpp:422
 msgid "Already Registered Object passed to SetObjectClassInfo"
 msgstr "Egy már regisztrált objektumot adott át a SetObjectClassInfo-nak"
 
-#: ../src/unix/dialup.cpp:353
+#: ../src/unix/dialup.cpp:352
 msgid "Already dialling ISP."
 msgstr "Már tárcsázom az ISPt."
 
-#: ../src/common/accelcmn.cpp:331 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/accelcmn.cpp:345 ../src/univ/themes/win32.cpp:3753
 msgid "Alt+"
 msgstr ""
 
@@ -1368,38 +1364,38 @@ msgstr ""
 msgid "An optional corner radius for adding rounded corners."
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:576
+#: ../src/common/debugrpt.cpp:577
 #, fuzzy
 msgid "And includes the following files:\n"
 msgstr "*** És a következő fájlokat tartalmazza:\n"
 
-#: ../src/generic/animateg.cpp:162
+#: ../src/generic/animateg.cpp:145
 #, fuzzy, c-format
 msgid "Animation file is not of type %ld."
 msgstr "A kép nem %d típusú."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:872
+#: ../src/propgrid/advprops.cpp:773
 msgid "AppWorkspace"
 msgstr ""
 
-#: ../src/generic/logg.cpp:1014
+#: ../src/generic/logg.cpp:1011
 #, c-format
 msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
 msgstr ""
 "A naplót  a(z) '%s' file végéhez írjam? (Ha [Nem]-et választ, felülírom!)"
 
-#: ../src/osx/menu_osx.cpp:577 ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:469 ../src/osx/menu_osx.cpp:477
 #, fuzzy
 msgid "Application"
 msgstr "Kiválasztott"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 #, fuzzy
 msgid "Apply"
 msgstr "&Alkalmazd"
 
-#: ../src/propgrid/advprops.cpp:1609
+#: ../src/propgrid/advprops.cpp:1515
 msgid "Aqua"
 msgstr ""
 
@@ -1408,31 +1404,31 @@ msgstr ""
 msgid "Arabic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:153
+#: ../src/common/fmapbase.cpp:150
 msgid "Arabic (ISO-8859-6)"
 msgstr "Arab (ISO-8859-6)"
 
-#: ../src/msw/ole/automtn.cpp:672
+#: ../src/msw/ole/automtn.cpp:663
 #, fuzzy, c-format
 msgid "Argument %u not found."
 msgstr "a(z) '%s' domén konfigurációs fájlját nem találom."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1753
+#: ../src/propgrid/advprops.cpp:1654
 #, fuzzy
 msgid "Arrow"
 msgstr "holnap"
 
-#: ../src/generic/aboutdlgg.cpp:184
+#: ../src/generic/aboutdlgg.cpp:181
 msgid "Artists"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 #, fuzzy
 msgid "Ascending"
 msgstr "olvasok"
 
-#: ../src/generic/filectrlg.cpp:433
+#: ../src/generic/filectrlg.cpp:429
 msgid "Attributes"
 msgstr "Tulajdonságok"
 
@@ -1442,91 +1438,91 @@ msgstr "Tulajdonságok"
 msgid "Available fonts."
 msgstr ""
 
-#: ../src/common/paper.cpp:137
+#: ../src/common/paper.cpp:134
 msgid "B4 (ISO) 250 x 353 mm"
 msgstr "B4 (ISO) 250 x 353 mm"
 
-#: ../src/common/paper.cpp:173
+#: ../src/common/paper.cpp:170
 msgid "B4 (JIS) Rotated 364 x 257 mm"
 msgstr "B4 (JIS) Elfordított 364 x 257 mm"
 
-#: ../src/common/paper.cpp:127
+#: ../src/common/paper.cpp:124
 msgid "B4 Envelope, 250 x 353 mm"
 msgstr "B4 Boríték, 250 x 353 mm"
 
-#: ../src/common/paper.cpp:109
+#: ../src/common/paper.cpp:106
 msgid "B4 sheet, 250 x 354 mm"
 msgstr "B4 lap, 250 x 354 mm"
 
-#: ../src/common/paper.cpp:158
+#: ../src/common/paper.cpp:155
 msgid "B5 (ISO) Extra 201 x 276 mm"
 msgstr "B5 (ISO) Extra 201 x 276 mm"
 
-#: ../src/common/paper.cpp:174
+#: ../src/common/paper.cpp:171
 msgid "B5 (JIS) Rotated 257 x 182 mm"
 msgstr "B5 (JIS) Elfordított 257 x 182 mm"
 
-#: ../src/common/paper.cpp:155
+#: ../src/common/paper.cpp:152
 msgid "B5 (JIS) Transverse 182 x 257 mm"
 msgstr "B5 (JIS) Transverse 182 x 257 mm"
 
-#: ../src/common/paper.cpp:128
+#: ../src/common/paper.cpp:125
 msgid "B5 Envelope, 176 x 250 mm"
 msgstr "B5 Boriték, 176 x 250 mm"
 
-#: ../src/common/paper.cpp:110
+#: ../src/common/paper.cpp:107
 msgid "B5 sheet, 182 x 257 millimeter"
 msgstr "B5 lap, 182 x 257 milliméter"
 
-#: ../src/common/paper.cpp:182
+#: ../src/common/paper.cpp:179
 msgid "B6 (JIS) 128 x 182 mm"
 msgstr "B6 (JIS) 128 x 182 mm"
 
-#: ../src/common/paper.cpp:183
+#: ../src/common/paper.cpp:180
 msgid "B6 (JIS) Rotated 182 x 128 mm"
 msgstr "B6 (JIS) Elfordított 182 x 128 mm"
 
-#: ../src/common/paper.cpp:129
+#: ../src/common/paper.cpp:126
 msgid "B6 Envelope, 176 x 125 mm"
 msgstr "B6 Boriték, 176 x 125 mm"
 
-#: ../src/common/imagbmp.cpp:531 ../src/common/imagbmp.cpp:561
-#: ../src/common/imagbmp.cpp:576
+#: ../src/common/imagbmp.cpp:528 ../src/common/imagbmp.cpp:558
+#: ../src/common/imagbmp.cpp:573
 msgid "BMP: Couldn't allocate memory."
 msgstr "BMP: Nem sikerült memóriát foglalni."
 
-#: ../src/common/imagbmp.cpp:100
+#: ../src/common/imagbmp.cpp:97
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: Nem tudtam elmenteni a hibás képet."
 
-#: ../src/common/imagbmp.cpp:356
+#: ../src/common/imagbmp.cpp:353
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: Nem tudtam kiírni az RGB színtérképet."
 
-#: ../src/common/imagbmp.cpp:490
+#: ../src/common/imagbmp.cpp:487
 msgid "BMP: Couldn't write data."
 msgstr "BMP: Nem tudtam kiírni az adatokat."
 
-#: ../src/common/imagbmp.cpp:246
+#: ../src/common/imagbmp.cpp:243
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: Nem tudtam kiírni a fájl (bittérkép) fejet."
 
-#: ../src/common/imagbmp.cpp:269
+#: ../src/common/imagbmp.cpp:266
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: Nem tudtam kiírni a fájl (bittérkép info) fejet."
 
-#: ../src/common/imagbmp.cpp:140
+#: ../src/common/imagbmp.cpp:137
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: a wxImage-nek nincs saját wxPalette-je."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:142 ../src/common/accelcmn.cpp:52
+#: ../src/common/stockitem.cpp:139 ../src/common/accelcmn.cpp:49
 #, fuzzy
 msgid "Back"
 msgstr "&Vissza"
 
+#: ../src/richtext/richtextformatdlg.cpp:377
 #: ../src/richtext/richtextbackgroundpage.cpp:148
-#: ../src/richtext/richtextformatdlg.cpp:384
 msgid "Background"
 msgstr ""
 
@@ -1534,21 +1530,21 @@ msgstr ""
 msgid "Background &colour:"
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:220
+#: ../src/osx/carbon/fontdlg.cpp:217
 msgid "Background colour"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:52
+#: ../src/common/accelcmn.cpp:49
 #, fuzzy
 msgid "Backspace"
 msgstr "&Vissza"
 
-#: ../src/common/fmapbase.cpp:160
+#: ../src/common/fmapbase.cpp:157
 msgid "Baltic (ISO-8859-13)"
 msgstr "Balti (ISO-8859-13)"
 
-#: ../src/common/fmapbase.cpp:151
+#: ../src/common/fmapbase.cpp:148
 msgid "Baltic (old) (ISO-8859-4)"
 msgstr "Balti (régi) (ISO-8859-4)"
 
@@ -1561,25 +1557,25 @@ msgstr ""
 msgid "Bitmap"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1594
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Black"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1755
+#: ../src/propgrid/advprops.cpp:1656
 msgid "Blank"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1603
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Blue"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:345
+#: ../src/generic/colrdlgg.cpp:365
 msgid "Blue:"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:333 ../src/richtext/richtextfontpage.cpp:355
-#: ../src/osx/carbon/fontdlg.cpp:354 ../src/common/stockitem.cpp:143
+#: ../src/osx/carbon/fontdlg.cpp:351 ../src/common/stockitem.cpp:140
+#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:355
 msgid "Bold"
 msgstr "Félkövér"
 
@@ -1589,34 +1585,38 @@ msgstr "Félkövér"
 msgid "Border"
 msgstr "Modern"
 
-#: ../src/richtext/richtextformatdlg.cpp:379
+#: ../src/richtext/richtextformatdlg.cpp:372
 #, fuzzy
 msgid "Borders"
 msgstr "Modern"
 
-#: ../src/richtext/richtextsizepage.cpp:288 ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141 ../src/richtext/richtextsizepage.cpp:288
 msgid "Bottom"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:893
+#: ../src/generic/prntdlgg.cpp:886
 msgid "Bottom margin (mm):"
 msgstr "Alsó margó (mm):"
 
-#: ../src/richtext/richtextbuffer.cpp:9383
+#: ../src/richtext/richtextbuffer.cpp:9380
 #, fuzzy
 msgid "Box Properties"
 msgstr "&Tulajdonságok"
 
-#: ../src/richtext/richtextstyles.cpp:1065
+#: ../src/richtext/richtextstyles.cpp:1062
 #, fuzzy
 msgid "Box styles"
 msgstr "&Következő >"
 
-#: ../src/propgrid/advprops.cpp:1602
+#: ../src/osx/cocoa/menu.mm:292
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Brown"
 msgstr ""
 
-#: ../src/common/filepickercmn.cpp:43 ../src/common/filepickercmn.cpp:44
+#: ../src/common/filepickercmn.cpp:40 ../src/common/filepickercmn.cpp:41
 msgid "Browse"
 msgstr ""
 
@@ -1629,72 +1629,72 @@ msgstr ""
 msgid "Bullet style"
 msgstr ""
 
-#: ../src/richtext/richtextformatdlg.cpp:359
+#: ../src/richtext/richtextformatdlg.cpp:352
 msgid "Bullets"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1756
+#: ../src/propgrid/advprops.cpp:1657
 msgid "Bullseye"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:875
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonFace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:876
+#: ../src/propgrid/advprops.cpp:777
 msgid "ButtonHighlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:877
+#: ../src/propgrid/advprops.cpp:778
 msgid "ButtonShadow"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:878
+#: ../src/propgrid/advprops.cpp:779
 msgid "ButtonText"
 msgstr ""
 
-#: ../src/common/paper.cpp:98
+#: ../src/common/paper.cpp:95
 msgid "C sheet, 17 x 22 in"
 msgstr "C lap,  17 x 22 hüvelyk"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "C&lear"
 msgstr "Tör&lés"
 
-#: ../src/generic/fontdlgg.cpp:406
+#: ../src/generic/fontdlgg.cpp:403
 msgid "C&olour:"
 msgstr "S&zín"
 
-#: ../src/common/paper.cpp:123
+#: ../src/common/paper.cpp:120
 msgid "C3 Envelope, 324 x 458 mm"
 msgstr "C3 Boríték, 324 x 458 mm"
 
-#: ../src/common/paper.cpp:124
+#: ../src/common/paper.cpp:121
 msgid "C4 Envelope, 229 x 324 mm"
 msgstr "C4 Boríték, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:122
+#: ../src/common/paper.cpp:119
 msgid "C5 Envelope, 162 x 229 mm"
 msgstr "C5 Boríték, 162 x 229 mm"
 
-#: ../src/common/paper.cpp:125
+#: ../src/common/paper.cpp:122
 msgid "C6 Envelope, 114 x 162 mm"
 msgstr "C6 Boríték, 114 x 162 mm"
 
-#: ../src/common/paper.cpp:126
+#: ../src/common/paper.cpp:123
 msgid "C65 Envelope, 114 x 229 mm"
 msgstr "C65 Boríték, 114 x 229 mm"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "CD-Rom"
 msgstr ""
 
-#: ../src/html/chm.cpp:815 ../src/html/chm.cpp:874
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:865
 msgid "CHM handler currently supports only local files!"
 msgstr "A CHM kezelő jelenleg csak helyi fájlokat támogat!"
 
@@ -1702,192 +1702,196 @@ msgstr "A CHM kezelő jelenleg csak helyi fájlokat támogat!"
 msgid "Ca&pitals"
 msgstr ""
 
-#: ../src/common/cmdproc.cpp:267
+#: ../src/common/cmdproc.cpp:260
 msgid "Can't &Undo "
 msgstr "Nem lehet &Visszavonni"
 
-#: ../src/common/image.cpp:2824
+#: ../src/common/image.cpp:2924
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 
-#: ../src/msw/registry.cpp:506
+#: ../src/msw/registry.cpp:495
 #, c-format
 msgid "Can't close registry key '%s'"
 msgstr "Nem tudom lezárni a(z) '%s' registry kulcsot"
 
-#: ../src/msw/registry.cpp:584
+#: ../src/msw/registry.cpp:573
 #, c-format
 msgid "Can't copy values of unsupported type %d."
 msgstr "Nem tudom a nem támogatott %d típusú értékeket lemásolni."
 
-#: ../src/msw/registry.cpp:487
+#: ../src/msw/registry.cpp:476
 #, c-format
 msgid "Can't create registry key '%s'"
 msgstr "Nem tudom létrehozni a '%s' registry kulcsot"
 
-#: ../src/msw/thread.cpp:665
+#: ../src/msw/thread.cpp:657
 msgid "Can't create thread"
 msgstr "Nem tudom létrehozni a szálat"
 
-#: ../src/msw/window.cpp:3691
-#, c-format
-msgid "Can't create window of class %s"
-msgstr "Nem tudom létrehozni a(z) %s osztályhoz tartozó fájlt"
-
-#: ../src/msw/registry.cpp:777
+#: ../src/msw/registry.cpp:765
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Nem tudom törölni a(z) '%s' kulcsot"
 
-#: ../src/msw/iniconf.cpp:458
+#: ../src/msw/iniconf.cpp:455
 #, c-format
 msgid "Can't delete the INI file '%s'"
 msgstr "Nem tudom törölni a '%s' INI fájt"
 
-#: ../src/msw/registry.cpp:805
+#: ../src/msw/registry.cpp:793
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Nem tudom törölni a '%s' értéket a '%s' kulcsból"
 
-#: ../src/msw/registry.cpp:1171
+#: ../src/msw/registry.cpp:1159
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Nem tudtam megszámlálni a(z) '%s' kulcs alkulcsait"
 
-#: ../src/msw/registry.cpp:1132
+#: ../src/msw/registry.cpp:1120
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Nem tudtam megszámlálni a(z) '%s' kulcs értékeit"
 
-#: ../src/msw/registry.cpp:1389
+#: ../src/msw/registry.cpp:1377
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Nem tudom a nem támogatott %d típusú értékeket exportálni."
 
-#: ../src/common/ffile.cpp:254
+#: ../src/common/ffile.cpp:253
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Nem találom a(z) '%s' fájlban a jelenlegi pozíciót"
 
-#: ../src/msw/registry.cpp:418
+#: ../src/msw/registry.cpp:407
 #, c-format
 msgid "Can't get info about registry key '%s'"
 msgstr "Nincs információm a '%s' registry kulcsról"
 
-#: ../src/common/zstream.cpp:346
+#: ../src/msw/webview_ie.cpp:1024
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "Nem tudom a szál prioritását beállítani"
+
+#: ../src/common/zstream.cpp:343
 msgid "Can't initialize zlib deflate stream."
 msgstr "Nem tudom elindítani a zlib folyam tömörítését."
 
-#: ../src/common/zstream.cpp:185
+#: ../src/common/zstream.cpp:182
 msgid "Can't initialize zlib inflate stream."
 msgstr "Nem tudom elindítani a zlib folyam kifejtését."
 
-#: ../src/msw/fswatcher.cpp:476
+#: ../src/msw/fswatcher.cpp:475
 #, c-format
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr ""
 
-#: ../src/msw/registry.cpp:454
+#: ../src/msw/registry.cpp:443
 #, c-format
 msgid "Can't open registry key '%s'"
 msgstr "Nem tudom megnyitni a(z) '%s' registry kulcsot"
 
-#: ../src/common/zstream.cpp:252
+#: ../src/common/zstream.cpp:249
 #, c-format
 msgid "Can't read from inflate stream: %s"
 msgstr "Nem tudok olvasni a(z) %s tömörített folyamból"
 
-#: ../src/common/zstream.cpp:244
+#: ../src/common/zstream.cpp:241
 msgid "Can't read inflate stream: unexpected EOF in underlying stream."
 msgstr "Nem tudom olvasni a folyamot, nem várt EOF-t találtam"
 
-#: ../src/msw/registry.cpp:1064
+#: ../src/msw/registry.cpp:1052
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Nem tudom olvasni a(z) '%s' értékét"
 
-#: ../src/msw/registry.cpp:878 ../src/msw/registry.cpp:910
-#: ../src/msw/registry.cpp:975
+#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
+#: ../src/msw/registry.cpp:963
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Nem tudom olvasni a(z) '%s' kulcs értékét"
 
-#: ../src/common/image.cpp:2620
+#: ../src/msw/webview_ie.cpp:1017
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/common/image.cpp:2715
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr ""
 "Nem tudom elmenteni a képet a(z) '%s' fájlba: nincs ilyen kiterjesztés."
 
-#: ../src/generic/logg.cpp:573 ../src/generic/logg.cpp:976
+#: ../src/generic/logg.cpp:570 ../src/generic/logg.cpp:973
 msgid "Can't save log contents to file."
 msgstr "Nem tudom a napló tartalmát fájlba menteni."
 
-#: ../src/msw/thread.cpp:629
+#: ../src/msw/thread.cpp:621
 msgid "Can't set thread priority"
 msgstr "Nem tudom a szál prioritását beállítani"
 
-#: ../src/msw/registry.cpp:896 ../src/msw/registry.cpp:938
-#: ../src/msw/registry.cpp:1081
+#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
+#: ../src/msw/registry.cpp:1069
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Nem tudom a(z) '%s' értéket beállítani"
 
-#: ../src/unix/utilsunx.cpp:351
+#: ../src/unix/utilsunx.cpp:353
 #, fuzzy
 msgid "Can't write to child process's stdin"
 msgstr "Nem tudtam megölni a '%d' folyamatot."
 
-#: ../src/common/zstream.cpp:427
+#: ../src/common/zstream.cpp:424
 #, c-format
 msgid "Can't write to deflate stream: %s"
 msgstr "Nem tudok írni a(z) %s tömörített folyamba"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:279 ../src/richtext/richtextstyledlg.cpp:300
-#: ../src/common/stockitem.cpp:145 ../src/common/accelcmn.cpp:71
-#: ../src/msw/msgdlg.cpp:454 ../src/msw/progdlg.cpp:673
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:142
+#: ../src/common/accelcmn.cpp:68 ../src/motif/msgdlg.cpp:196
+#: ../src/gtk1/fontdlg.cpp:144 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/progdlg.cpp:940 ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Mégsem"
 
-#: ../src/common/filefn.cpp:1261
+#: ../src/common/filefn.cpp:1149
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Nem tudom megszámolni a(z) '%s'  fájlokat"
 
-#: ../src/msw/dir.cpp:263
+#: ../src/msw/dir.cpp:260
 #, c-format
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Nem tudom megszámolni a(z) '%s' könyvtárban a fájlokat"
 
-#: ../src/msw/dialup.cpp:523
+#: ../src/msw/dialup.cpp:517
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Nem találom a(z) %s aktív telefonos kapcsolatot"
 
-#: ../src/msw/dialup.cpp:827
+#: ../src/msw/dialup.cpp:821
 msgid "Cannot find the location of address book file"
 msgstr "Nem találom a címjegyzék fájl helyét"
 
-#: ../src/msw/ole/automtn.cpp:562
+#: ../src/msw/ole/automtn.cpp:553
 #, fuzzy, c-format
 msgid "Cannot get an active instance of \"%s\""
 msgstr "Nem találom a(z) %s aktív telefonos kapcsolatot"
 
-#: ../src/unix/threadpsx.cpp:1035
+#: ../src/unix/threadpsx.cpp:1053
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "Nincs prioritási tartomány a(z) %d ütemezési előíráshoz."
 
-#: ../src/unix/utilsunx.cpp:987
+#: ../src/unix/utilsunx.cpp:989
 msgid "Cannot get the hostname"
 msgstr "Nem ismerem a gazdagép nevét"
 
-#: ../src/unix/utilsunx.cpp:1023
+#: ../src/unix/utilsunx.cpp:1025
 msgid "Cannot get the official hostname"
 msgstr "Nem ismerem a gazdagép hivatalos nevét"
 
-#: ../src/msw/dialup.cpp:928
+#: ../src/msw/dialup.cpp:922
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Nem tudom letenni - nincs aktív telefonkapcsolat."
 
@@ -1895,130 +1899,130 @@ msgstr "Nem tudom letenni - nincs aktív telefonkapcsolat."
 msgid "Cannot initialize OLE"
 msgstr "Nem tudom inicializálni az OLEt"
 
-#: ../src/common/socket.cpp:853
+#: ../src/common/socket.cpp:850
 #, fuzzy
 msgid "Cannot initialize sockets"
 msgstr "Nem tudom inicializálni az OLEt"
 
-#: ../src/msw/volume.cpp:619
+#: ../src/msw/volume.cpp:627
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Nem tudom betölteni az ikont '%s'-ből."
 
-#: ../src/xrc/xmlres.cpp:360
+#: ../src/xrc/xmlres.cpp:358
 #, fuzzy, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Nem tudom betölteni az erőforrást a(z) '%s' fájlból."
 
-#: ../src/xrc/xmlres.cpp:742
+#: ../src/xrc/xmlres.cpp:740
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Nem tudom betölteni az erőforrást a(z) '%s' fájlból."
 
-#: ../src/html/htmlfilt.cpp:137
+#: ../src/html/htmlfilt.cpp:134
 #, c-format
 msgid "Cannot open HTML document: %s"
 msgstr "Nem tudom megnyitni a(z) %s HTML dokumentumot"
 
-#: ../src/html/helpdata.cpp:667
+#: ../src/html/helpdata.cpp:660
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Nem tudom megnyitni a(z) %s súgó könyvet"
 
-#: ../src/html/helpdata.cpp:299
+#: ../src/html/helpdata.cpp:296
 #, c-format
 msgid "Cannot open contents file: %s"
 msgstr "Nem tudom megnyitni a(z) %s tartalom fájlt"
 
-#: ../src/generic/dcpsg.cpp:1667
+#: ../src/generic/dcpsg.cpp:1665
 msgid "Cannot open file for PostScript printing!"
 msgstr "Nem tudom a fájlt PostScript nyomtatásra megnyitni!"
 
-#: ../src/html/helpdata.cpp:313
+#: ../src/html/helpdata.cpp:310
 #, c-format
 msgid "Cannot open index file: %s"
 msgstr "Nem tudom a(z) %s index fájlt megnyitni"
 
-#: ../src/xrc/xmlres.cpp:724
+#: ../src/xrc/xmlres.cpp:722
 #, fuzzy, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Nem tudom betölteni az erőforrást a(z) '%s' fájlból."
 
-#: ../src/html/helpwnd.cpp:1534
+#: ../src/html/helpwnd.cpp:1532
 msgid "Cannot print empty page."
 msgstr "Nem tudok üres oldalt nyomtatni."
 
-#: ../src/msw/volume.cpp:507
+#: ../src/msw/volume.cpp:515
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Nem tudom elolvasni '%s' típusának nevét."
 
-#: ../src/msw/thread.cpp:888
+#: ../src/msw/thread.cpp:894
 #, fuzzy, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Nem tudom folytatni a(z) %x szálat"
 
-#: ../src/unix/threadpsx.cpp:1016
+#: ../src/unix/threadpsx.cpp:1028
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Nem találom a szál ütemezés előírásait."
 
-#: ../src/common/intl.cpp:558
+#: ../src/common/intl.cpp:365
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:831 ../src/msw/thread.cpp:546
+#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
 msgid "Cannot start thread: error writing TLS."
 msgstr "Nem tudom elindítani a szálat: hiba a TLS írásakor."
 
-#: ../src/msw/thread.cpp:872
+#: ../src/msw/thread.cpp:864
 #, fuzzy, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Nem tudom felfüggeszteni a(z) %x szálat"
 
-#: ../src/msw/thread.cpp:794
+#: ../src/msw/thread.cpp:786
 msgid "Cannot wait for thread termination"
 msgstr "Nem tudom megvárni a szál befejeződését"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:75
+#: ../src/common/accelcmn.cpp:72
 #, fuzzy
 msgid "Capital"
 msgstr "dőlt"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:879
+#: ../src/propgrid/advprops.cpp:780
 msgid "CaptionText"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:531
 msgid "Case sensitive"
 msgstr "Kis/nagybetűk különbözőek"
 
-#: ../src/propgrid/manager.cpp:1509
+#: ../src/propgrid/manager.cpp:1527
 msgid "Categorized Mode"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9968
+#: ../src/richtext/richtextbuffer.cpp:9965
 #, fuzzy
 msgid "Cell Properties"
 msgstr "&Tulajdonságok"
 
-#: ../src/common/fmapbase.cpp:161
+#: ../src/common/fmapbase.cpp:158
 msgid "Celtic (ISO-8859-14)"
 msgstr "Kelta (ISO-8859-14)"
 
-#: ../src/richtext/richtextindentspage.cpp:160
 #: ../src/richtext/richtextliststylepage.cpp:349
+#: ../src/richtext/richtextindentspage.cpp:160
 #, fuzzy
 msgid "Cen&tred"
 msgstr "Középre igazítva"
 
-#: ../src/common/stockitem.cpp:170
+#: ../src/common/stockitem.cpp:167
 msgid "Centered"
 msgstr "Középre igazítva"
 
-#: ../src/common/fmapbase.cpp:149
+#: ../src/common/fmapbase.cpp:146
 msgid "Central European (ISO-8859-2)"
 msgstr "Közép-európai (ISO-8859-2)"
 
@@ -2028,10 +2032,10 @@ msgstr "Közép-európai (ISO-8859-2)"
 msgid "Centre"
 msgstr "Középre igazítva"
 
-#: ../src/richtext/richtextindentspage.cpp:162
-#: ../src/richtext/richtextindentspage.cpp:164
 #: ../src/richtext/richtextliststylepage.cpp:351
 #: ../src/richtext/richtextliststylepage.cpp:353
+#: ../src/richtext/richtextindentspage.cpp:162
+#: ../src/richtext/richtextindentspage.cpp:164
 #, fuzzy
 msgid "Centre text."
 msgstr "Nem tudom létrehozni a mutex-et"
@@ -2047,25 +2051,25 @@ msgstr "Középre igazítva"
 msgid "Ch&oose..."
 msgstr "&Válasszon oldalszámot... "
 
-#: ../src/richtext/richtextbuffer.cpp:4354
+#: ../src/richtext/richtextbuffer.cpp:4351
 msgid "Change List Style"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:3709
+#: ../src/richtext/richtextbuffer.cpp:3706
 msgid "Change Object Style"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:3982
-#: ../src/richtext/richtextbuffer.cpp:8129
+#: ../src/richtext/richtextbuffer.cpp:3979
+#: ../src/richtext/richtextbuffer.cpp:8125
 #, fuzzy
 msgid "Change Properties"
 msgstr "&Tulajdonságok"
 
-#: ../src/richtext/richtextbuffer.cpp:3526
+#: ../src/richtext/richtextbuffer.cpp:3523
 msgid "Change Style"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:341
+#: ../src/common/fileconf.cpp:335
 #, c-format
 msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
 msgstr ""
@@ -2076,11 +2080,11 @@ msgid "Changing current directory to \"%s\" failed"
 msgstr "Nem sikerült létrehozni a(z) \"%s\" könyvtárat"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1757
+#: ../src/propgrid/advprops.cpp:1658
 msgid "Character"
 msgstr ""
 
-#: ../src/richtext/richtextstyles.cpp:1063
+#: ../src/richtext/richtextstyles.cpp:1060
 msgid "Character styles"
 msgstr ""
 
@@ -2118,23 +2122,23 @@ msgstr ""
 msgid "Check to indicate right-to-left text layout."
 msgstr "Kattints ide a betűtípus választás törléséhez"
 
-#: ../src/osx/carbon/fontdlg.cpp:356 ../src/osx/carbon/fontdlg.cpp:358
+#: ../src/osx/carbon/fontdlg.cpp:353 ../src/osx/carbon/fontdlg.cpp:355
 #, fuzzy
 msgid "Check to make the font bold."
 msgstr "Kattints ide a betűtípus választás törléséhez"
 
-#: ../src/osx/carbon/fontdlg.cpp:363 ../src/osx/carbon/fontdlg.cpp:365
+#: ../src/osx/carbon/fontdlg.cpp:360 ../src/osx/carbon/fontdlg.cpp:362
 #, fuzzy
 msgid "Check to make the font italic."
 msgstr "Kattints ide a betűtípus választás törléséhez"
 
-#: ../src/osx/carbon/fontdlg.cpp:372 ../src/osx/carbon/fontdlg.cpp:374
+#: ../src/osx/carbon/fontdlg.cpp:369 ../src/osx/carbon/fontdlg.cpp:371
 #, fuzzy
 msgid "Check to make the font underlined."
 msgstr "Hogy aláhúzza-e a betűket."
 
-#: ../src/richtext/richtextstyledlg.cpp:289
-#: ../src/richtext/richtextstyledlg.cpp:291
+#: ../src/richtext/richtextstyledlg.cpp:285
+#: ../src/richtext/richtextstyledlg.cpp:287
 msgid "Check to restart numbering."
 msgstr ""
 
@@ -2173,55 +2177,55 @@ msgstr "Kattints ide a betűtípus választás törléséhez"
 msgid "Check to suppress hyphenation."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:763
+#: ../src/msw/dialup.cpp:757
 msgid "Choose ISP to dial"
 msgstr "Válassza ki a tárcsázandó szolgáltatót (ISPt)!"
 
-#: ../src/propgrid/props.cpp:1922
+#: ../src/propgrid/props.cpp:1904
 #, fuzzy
 msgid "Choose a directory:"
 msgstr "Hozzon létre könyvtárat"
 
-#: ../src/propgrid/props.cpp:1975
+#: ../src/propgrid/props.cpp:2199
 #, fuzzy
 msgid "Choose a file"
 msgstr "Válasszon betűtípust"
 
-#: ../src/generic/colrdlgg.cpp:158 ../src/gtk/colordlg.cpp:54
+#: ../src/generic/colrdlgg.cpp:156 ../src/gtk/colordlg.cpp:49
 msgid "Choose colour"
 msgstr "Válasszon színt"
 
-#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/gtk1/fontdlg.cpp:125 ../src/generic/fontpickerg.cpp:47
+#: ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Válasszon betűtípust"
 
-#: ../src/common/module.cpp:74
+#: ../src/common/module.cpp:71
 #, c-format
 msgid "Circular dependency involving module \"%s\" detected."
 msgstr ""
 
-#: ../src/aui/tabmdi.cpp:108 ../src/generic/mdig.cpp:97
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
 msgid "Cl&ose"
 msgstr "Be&zárás"
 
-#: ../src/msw/ole/automtn.cpp:684
+#: ../src/msw/ole/automtn.cpp:675
 #, fuzzy
 msgid "Class not registered."
 msgstr "Nem tudom létrehozni a szálat"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:147 ../src/common/accelcmn.cpp:72
+#: ../src/common/stockitem.cpp:144 ../src/common/accelcmn.cpp:69
 #, fuzzy
 msgid "Clear"
 msgstr "&Törlés"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "Clear the log contents"
 msgstr "A napló fájl törlése"
 
-#: ../src/richtext/richtextstyledlg.cpp:252
-#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:248
+#: ../src/richtext/richtextstyledlg.cpp:250
 #, fuzzy
 msgid "Click to apply the selected style."
 msgstr "Kattints ide a betűtípus választás törléséhez"
@@ -2233,16 +2237,16 @@ msgstr "Kattints ide a betűtípus választás törléséhez"
 msgid "Click to browse for a symbol."
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:403 ../src/osx/carbon/fontdlg.cpp:405
+#: ../src/osx/carbon/fontdlg.cpp:400 ../src/osx/carbon/fontdlg.cpp:402
 #, fuzzy
 msgid "Click to cancel changes to the font."
 msgstr "Kattints ide a betűtípus választás törléséhez"
 
-#: ../src/generic/fontdlgg.cpp:472 ../src/generic/fontdlgg.cpp:491
+#: ../src/generic/fontdlgg.cpp:468 ../src/generic/fontdlgg.cpp:487
 msgid "Click to cancel the font selection."
 msgstr "Kattints ide a betűtípus választás törléséhez"
 
-#: ../src/osx/carbon/fontdlg.cpp:384 ../src/osx/carbon/fontdlg.cpp:386
+#: ../src/osx/carbon/fontdlg.cpp:381 ../src/osx/carbon/fontdlg.cpp:383
 #, fuzzy
 msgid "Click to change the font colour."
 msgstr "Kattints ide a betűtípus választás törléséhez"
@@ -2265,41 +2269,41 @@ msgstr "Kattints ide a betűtípus választás törléséhez"
 msgid "Click to choose the font for this level."
 msgstr "Kattints ide a betűtípus választás törléséhez"
 
-#: ../src/richtext/richtextstyledlg.cpp:279
-#: ../src/richtext/richtextstyledlg.cpp:281
+#: ../src/richtext/richtextstyledlg.cpp:275
+#: ../src/richtext/richtextstyledlg.cpp:277
 #, fuzzy
 msgid "Click to close this window."
 msgstr "Zárja be ezt az ablakot"
 
-#: ../src/osx/carbon/fontdlg.cpp:410 ../src/osx/carbon/fontdlg.cpp:412
+#: ../src/osx/carbon/fontdlg.cpp:407 ../src/osx/carbon/fontdlg.cpp:409
 #, fuzzy
 msgid "Click to confirm changes to the font."
 msgstr "Kattints ide a betűtípus választás megerősítéséhez"
 
-#: ../src/generic/fontdlgg.cpp:477 ../src/generic/fontdlgg.cpp:479
-#: ../src/generic/fontdlgg.cpp:484 ../src/generic/fontdlgg.cpp:486
+#: ../src/generic/fontdlgg.cpp:473 ../src/generic/fontdlgg.cpp:475
+#: ../src/generic/fontdlgg.cpp:480 ../src/generic/fontdlgg.cpp:482
 msgid "Click to confirm the font selection."
 msgstr "Kattints ide a betűtípus választás megerősítéséhez"
 
-#: ../src/richtext/richtextstyledlg.cpp:244
-#: ../src/richtext/richtextstyledlg.cpp:246
+#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:242
 #, fuzzy
 msgid "Click to create a new box style."
 msgstr "Kattints ide a betűtípus választás törléséhez"
 
-#: ../src/richtext/richtextstyledlg.cpp:226
-#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:224
 msgid "Click to create a new character style."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:238
-#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:236
 #, fuzzy
 msgid "Click to create a new list style."
 msgstr "Kattints ide a betűtípus választás törléséhez"
 
-#: ../src/richtext/richtextstyledlg.cpp:232
-#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:230
 msgid "Click to create a new paragraph style."
 msgstr ""
 
@@ -2315,8 +2319,8 @@ msgstr "Kattints ide a betűtípus választás törléséhez"
 msgid "Click to delete all tab positions."
 msgstr "Kattints ide a betűtípus választás törléséhez"
 
-#: ../src/richtext/richtextstyledlg.cpp:270
-#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:268
 #, fuzzy
 msgid "Click to delete the selected style."
 msgstr "Kattints ide a betűtípus választás törléséhez"
@@ -2327,27 +2331,27 @@ msgstr "Kattints ide a betűtípus választás törléséhez"
 msgid "Click to delete the selected tab position."
 msgstr "Kattints ide a betűtípus választás törléséhez"
 
-#: ../src/richtext/richtextstyledlg.cpp:264
-#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:262
 #, fuzzy
 msgid "Click to edit the selected style."
 msgstr "Kattints ide a betűtípus választás törléséhez"
 
-#: ../src/richtext/richtextstyledlg.cpp:258
-#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:256
 #, fuzzy
 msgid "Click to rename the selected style."
 msgstr "Kattints ide a betűtípus választás törléséhez"
 
-#: ../src/generic/dbgrptg.cpp:97 ../src/generic/progdlgg.cpp:759
-#: ../src/richtext/richtextstyledlg.cpp:277
-#: ../src/richtext/richtextsymboldlg.cpp:476 ../src/common/stockitem.cpp:148
-#: ../src/msw/progdlg.cpp:170 ../src/msw/progdlg.cpp:679
-#: ../src/html/helpdlg.cpp:90
+#: ../src/common/stockitem.cpp:145 ../src/generic/dbgrptg.cpp:94
+#: ../src/generic/progdlgg.cpp:781 ../src/msw/progdlg.cpp:211
+#: ../src/msw/progdlg.cpp:946 ../src/html/helpdlg.cpp:87
+#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextstyledlg.cpp:273
 msgid "Close"
 msgstr "Bezárás"
 
-#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:98
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
 msgid "Close All"
 msgstr "Minden fájl bezárása"
 
@@ -2355,68 +2359,68 @@ msgstr "Minden fájl bezárása"
 msgid "Close current document"
 msgstr ""
 
-#: ../src/generic/logg.cpp:516
+#: ../src/generic/logg.cpp:513
 msgid "Close this window"
 msgstr "Zárja be ezt az ablakot"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6006
+#: ../src/generic/datavgen.cpp:6811
 msgid "Collapse"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 #, fuzzy
 msgid "Color"
 msgstr "S&zín"
 
-#: ../src/richtext/richtextformatdlg.cpp:776
+#: ../src/richtext/richtextformatdlg.cpp:768
 #, fuzzy
 msgid "Colour"
 msgstr "S&zín"
 
-#: ../src/msw/colordlg.cpp:158
+#: ../src/msw/colordlg.cpp:227
 #, fuzzy, c-format
 msgid "Colour selection dialog failed with error %0lx."
 msgstr "Nem sikerült végrehajtani a(z) '%s' parancsot, hibakód: %ul"
 
-#: ../src/osx/carbon/fontdlg.cpp:380
+#: ../src/osx/carbon/fontdlg.cpp:377
 #, fuzzy
 msgid "Colour:"
 msgstr "S&zín"
 
-#: ../src/generic/datavgen.cpp:6077
+#: ../src/generic/datavgen.cpp:6882
 #, c-format
 msgid "Column %u"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:114
+#: ../src/common/accelcmn.cpp:112
 msgid "Command"
 msgstr ""
 
-#: ../src/common/init.cpp:196
+#: ../src/common/init.cpp:193
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
 "ignored."
 msgstr ""
 
-#: ../src/msw/fontdlg.cpp:120
+#: ../src/msw/fontdlg.cpp:170
 #, fuzzy, c-format
 msgid "Common dialog failed with error code %0lx."
 msgstr "Nem sikerült végrehajtani a(z) '%s' parancsot, hibakód: %ul"
 
-#: ../src/gtk/window.cpp:4649
+#: ../src/gtk/window.cpp:5653
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:1549
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Tömörített HTML súgó file (*.chm)|*.chm|"
 
-#: ../src/generic/dirctrlg.cpp:444
+#: ../src/generic/dirctrlg.cpp:410
 msgid "Computer"
 msgstr "Számítógép"
 
@@ -2425,56 +2429,60 @@ msgstr "Számítógép"
 msgid "Config entry name cannot start with '%c'."
 msgstr "Konfigurációs bejegyzés nem kezdődhet '%c'-vel."
 
-#: ../src/generic/filedlgg.cpp:349 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
 msgid "Confirm"
 msgstr "Megerősítés"
 
-#: ../src/html/htmlwin.cpp:566
+#: ../src/html/htmlwin.cpp:569
 msgid "Connecting..."
 msgstr "Kapcsolódás..."
 
-#: ../src/html/helpwnd.cpp:475
+#: ../src/html/helpwnd.cpp:473
 msgid "Contents"
 msgstr "Tartalom"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:880
+#: ../src/propgrid/advprops.cpp:781
 msgid "ControlDark"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:881
+#: ../src/propgrid/advprops.cpp:782
 msgid "ControlLight"
 msgstr ""
 
-#: ../src/common/strconv.cpp:2262
+#: ../src/common/strconv.cpp:2208
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "A  '%s' jelkészletté alakítás nem működik."
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 #, fuzzy
 msgid "Convert"
 msgstr "Tartalom"
 
-#: ../src/html/htmlwin.cpp:1079
+#: ../src/html/htmlwin.cpp:1020
 #, c-format
 msgid "Copied to clipboard:\"%s\""
 msgstr "Átmásolva a \"%s\" vágólapra"
 
-#: ../src/generic/prntdlgg.cpp:247
+#: ../src/generic/prntdlgg.cpp:240
 msgid "Copies:"
 msgstr "Másolat(ok):"
 
-#: ../src/common/stockitem.cpp:150 ../src/stc/stc_i18n.cpp:18
+#: ../src/common/stockitem.cpp:147 ../src/stc/stc_i18n.cpp:18
 #, fuzzy
 msgid "Copy"
 msgstr "&Másolás"
 
-#: ../src/common/stockitem.cpp:258
+#: ../src/common/stockitem.cpp:255
 #, fuzzy
 msgid "Copy selection"
 msgstr "Kiválasztott"
+
+#: ../src/generic/grid.cpp:5945
+msgid "Copying more than one selected block to clipboard is not supported."
+msgstr ""
 
 #: ../src/richtext/richtextborderspage.cpp:566
 #: ../src/richtext/richtextborderspage.cpp:601
@@ -2485,209 +2493,203 @@ msgstr ""
 msgid "Corner &radius:"
 msgstr ""
 
-#: ../src/html/chm.cpp:718
+#: ../src/html/chm.cpp:711
 #, c-format
 msgid "Could not create temporary file '%s'"
 msgstr "Nem tudom létrehozni a(z) '%s' átmeneti fájlt"
 
-#: ../src/html/chm.cpp:273
+#: ../src/html/chm.cpp:270
 #, c-format
 msgid "Could not extract %s into %s: %s"
 msgstr "Nem tudtam kifejteni %s-t %s-be: %s"
 
-#: ../src/generic/tabg.cpp:1048
+#: ../src/generic/tabg.cpp:1045
 msgid "Could not find tab for id"
 msgstr "Nem találok lapválasztót az azonosítóhoz"
 
-#: ../src/gtk/notifmsg.cpp:108
-#, fuzzy
-msgid "Could not initalize libnotify."
-msgstr "Nem tudom elindítani a nyomtatást."
-
-#: ../src/html/chm.cpp:444
+#: ../src/html/chm.cpp:437
 #, c-format
 msgid "Could not locate file '%s'."
 msgstr "Nem tudtam megtalálni a(z) '%s' fájlt."
 
-#: ../src/common/filefn.cpp:1403
+#: ../src/msw/graphicsd2d.cpp:604
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/common/filefn.cpp:1291
 #, fuzzy
 msgid "Could not set current working directory"
 msgstr "Nem sikerült létrehozni a munkakönyvtárat."
 
-#: ../src/common/prntbase.cpp:2015
+#: ../src/common/prntbase.cpp:2037
 msgid "Could not start document preview."
 msgstr "Nem tudom a dokument megtekintését kezdeményezni."
 
-#: ../src/generic/printps.cpp:178 ../src/msw/printwin.cpp:210
-#: ../src/gtk/print.cpp:1132
+#: ../src/generic/printps.cpp:159 ../src/msw/printwin.cpp:184
+#: ../src/gtk/print.cpp:1129
 msgid "Could not start printing."
 msgstr "Nem tudom elindítani a nyomtatást."
 
-#: ../src/common/wincmn.cpp:2125
+#: ../src/common/wincmn.cpp:2126
 msgid "Could not transfer data to window"
 msgstr "Nem tudtam adatot átvinni az ablakba"
 
-#: ../src/msw/imaglist.cpp:187 ../src/msw/imaglist.cpp:224
-#: ../src/msw/imaglist.cpp:249 ../src/msw/dragimag.cpp:185
-#: ../src/msw/dragimag.cpp:220
+#: ../src/msw/imaglist.cpp:223 ../src/msw/imaglist.cpp:245
+#: ../src/msw/imaglist.cpp:270 ../src/msw/dragimag.cpp:182
+#: ../src/msw/dragimag.cpp:217
 msgid "Couldn't add an image to the image list."
 msgstr "Nem tudok egy képet a képek listájához hozzáadni."
 
-#: ../src/osx/glcanvas_osx.cpp:414 ../src/unix/glx11.cpp:558
-#: ../src/msw/glcanvas.cpp:616
+#: ../src/osx/glcanvas_osx.cpp:411 ../src/msw/glcanvas.cpp:631
+#: ../src/unix/glegl.cpp:315 ../src/unix/glx11.cpp:559
 #, fuzzy
 msgid "Couldn't create OpenGL context"
 msgstr "Nem tudtam időzítőt létrehozni"
 
-#: ../src/msw/timer.cpp:134
+#: ../src/msw/timer.cpp:131
 msgid "Couldn't create a timer"
 msgstr "Nem tudtam időzítőt létrehozni"
 
-#: ../src/osx/carbon/overlay.cpp:122
-#, fuzzy
-msgid "Couldn't create the overlay window"
-msgstr "Nem tudtam időzítőt létrehozni"
-
-#: ../src/common/translation.cpp:2024
+#: ../src/common/translation.cpp:2074
 #, fuzzy
 msgid "Couldn't enumerate translations"
 msgstr "Nem tudtam befejezni a szálat"
 
-#: ../src/common/dynlib.cpp:120
+#: ../src/common/dynlib.cpp:110
 #, c-format
 msgid "Couldn't find symbol '%s' in a dynamic library"
 msgstr "Nem találom a(z) '%s' szimbólumot a dinamikus könyvtárban"
 
-#: ../src/msw/thread.cpp:915
+#: ../src/msw/thread.cpp:921
 msgid "Couldn't get the current thread pointer"
 msgstr "Nem kaptam meg a mutatót a jelenlegi szálhoz"
 
-#: ../src/osx/carbon/overlay.cpp:129
-#, fuzzy
-msgid "Couldn't init the context on the overlay window"
-msgstr "Nem kaptam meg a mutatót a jelenlegi szálhoz"
-
-#: ../src/common/imaggif.cpp:244
+#: ../src/common/imaggif.cpp:241
 #, fuzzy
 msgid "Couldn't initialize GIF hash table."
 msgstr "Nem tudom elindítani a zlib folyam tömörítését."
 
-#: ../src/common/imagpng.cpp:409
+#: ../src/common/imagpng.cpp:437
 msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
 msgstr ""
 "Nem tudtam betölteni a PNG képet - hibás a fájl vagy nincs elég memória."
 
-#: ../src/unix/sound.cpp:470
+#: ../src/unix/sound.cpp:459
 #, c-format
 msgid "Couldn't load sound data from '%s'."
 msgstr "Nem tudtam betölteni hangot '%s'-ből."
 
-#: ../src/msw/dirdlg.cpp:435
+#: ../src/msw/dirdlg.cpp:287
 #, fuzzy
 msgid "Couldn't obtain folder name"
 msgstr "Nem tudtam időzítőt létrehozni"
 
-#: ../src/unix/sound_sdl.cpp:229
+#: ../src/unix/sound_sdl.cpp:226
 #, c-format
 msgid "Couldn't open audio: %s"
 msgstr "Nem tudtam megnyitni a(z) '%s' audiot"
 
-#: ../src/msw/ole/dataobj.cpp:377
+#: ../src/msw/ole/dataobj.cpp:385
 #, c-format
 msgid "Couldn't register clipboard format '%s'."
 msgstr "Nem tudtam regisztrálni a(z) '%s' vágólap formátumot."
 
-#: ../src/msw/listctrl.cpp:869
+#: ../src/msw/listctrl.cpp:933
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "Nem kaptam információt a lista vezérlő %d eleméről."
 
-#: ../src/common/imagpng.cpp:498 ../src/common/imagpng.cpp:509
-#: ../src/common/imagpng.cpp:519
+#: ../src/common/imagpng.cpp:511 ../src/common/imagpng.cpp:522
+#: ../src/common/imagpng.cpp:532
 msgid "Couldn't save PNG image."
 msgstr "Nem tudtam elmenteni a PNG képet."
 
-#: ../src/msw/thread.cpp:684
+#: ../src/msw/thread.cpp:676
 msgid "Couldn't terminate thread"
 msgstr "Nem tudtam befejezni a szálat"
 
-#: ../src/common/xtistrm.cpp:166
+#: ../src/common/xtistrm.cpp:163
 #, fuzzy, c-format
 msgid "Create Parameter %s not found in declared RTTI Parameters"
 msgstr "Nem találtam"
 
-#: ../src/generic/dirdlgg.cpp:288
+#: ../src/generic/dirdlgg.cpp:285
 msgid "Create directory"
 msgstr "Hozzon létre könyvtárat"
 
-#: ../src/generic/filedlgg.cpp:212 ../src/generic/dirdlgg.cpp:111
+#: ../src/generic/filedlgg.cpp:209 ../src/generic/dirdlgg.cpp:108
 msgid "Create new directory"
 msgstr "Hozzon létre egy új könyvtárat"
 
-#: ../src/xrc/xmlres.cpp:2460
+#: ../src/common/stockitem.cpp:264
+#, fuzzy
+msgid "Create new document"
+msgstr "Hozzon létre egy új könyvtárat"
+
+#: ../src/xrc/xmlres.cpp:2515
 #, fuzzy, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Nem sikerült kifejteni  '%s'-t '%s'-be"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1758
+#: ../src/propgrid/advprops.cpp:1659
 msgid "Cross"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:333
+#: ../src/common/accelcmn.cpp:347
 #, fuzzy
 msgid "Ctrl+"
 msgstr "ctrl"
 
-#: ../src/richtext/richtextctrl.cpp:332 ../src/osx/textctrl_osx.cpp:576
-#: ../src/common/stockitem.cpp:151 ../src/msw/textctrl.cpp:2507
+#: ../src/osx/textctrl_osx.cpp:594 ../src/common/stockitem.cpp:148
+#: ../src/msw/textctrl.cpp:2772 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "&Kivágás"
 
-#: ../src/generic/filectrlg.cpp:940
+#: ../src/generic/filectrlg.cpp:936
 msgid "Current directory:"
 msgstr "A jelenlegi könyvtár:"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:896 ../src/propgrid/advprops.cpp:1574
-#: ../src/propgrid/advprops.cpp:1612
+#: ../src/propgrid/advprops.cpp:797 ../src/propgrid/advprops.cpp:1475
+#: ../src/propgrid/advprops.cpp:1518
 #, fuzzy
 msgid "Custom"
 msgstr "Jelkészlet méret"
 
-#: ../src/gtk/print.cpp:217
+#: ../src/gtk/print.cpp:211
 #, fuzzy
 msgid "Custom size"
 msgstr "Jelkészlet méret"
 
-#: ../src/common/headerctrlcmn.cpp:60
+#: ../src/common/headerctrlcmn.cpp:58
 #, fuzzy
 msgid "Customize Columns"
 msgstr "Jelkészlet méret"
 
-#: ../src/common/stockitem.cpp:151 ../src/stc/stc_i18n.cpp:17
+#: ../src/common/stockitem.cpp:148 ../src/stc/stc_i18n.cpp:17
 #, fuzzy
 msgid "Cut"
 msgstr "&Kivágás"
 
-#: ../src/common/stockitem.cpp:259
+#: ../src/common/stockitem.cpp:256
 #, fuzzy
 msgid "Cut selection"
 msgstr "Kiválasztott"
 
-#: ../src/common/fmapbase.cpp:152
+#: ../src/common/fmapbase.cpp:149
 msgid "Cyrillic (ISO-8859-5)"
 msgstr "Ciril (ISO-8859-5)"
 
-#: ../src/common/paper.cpp:99
+#: ../src/common/paper.cpp:96
 msgid "D sheet, 22 x 34 in"
 msgstr "D lap, 22 x 34 hüvelyk"
 
-#: ../src/msw/dde.cpp:703
+#: ../src/msw/dde.cpp:698
 msgid "DDE poke request failed"
 msgstr "DDE adatbeírás nem sikerült"
 
-#: ../src/common/imagbmp.cpp:1169
+#: ../src/common/imagbmp.cpp:1181
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr "DIB fej: A kódolás nem felel meg a bitmélységnek."
 
@@ -2707,7 +2709,7 @@ msgstr "DIB fej: Ismeretlen bitmélység a fájl-ban."
 msgid "DIB Header: Unknown encoding in file."
 msgstr "DIB fej: Ismeretlen kódolás a fájl-ban."
 
-#: ../src/common/paper.cpp:121
+#: ../src/common/paper.cpp:118
 msgid "DL Envelope, 110 x 220 mm"
 msgstr "DL Boríték,  110 x 220 mm"
 
@@ -2715,56 +2717,56 @@ msgstr "DL Boríték,  110 x 220 mm"
 msgid "Dashed"
 msgstr ""
 
-#: ../src/generic/dbgrptg.cpp:300
+#: ../src/generic/dbgrptg.cpp:301
 #, c-format
 msgid "Debug report \"%s\""
 msgstr "Hibakeresési jelentés \"%s\""
 
-#: ../src/common/debugrpt.cpp:210
+#: ../src/common/debugrpt.cpp:211
 msgid "Debug report couldn't be created."
 msgstr "Nem sikerült létrehozni a(z) '%s' könyvtárat."
 
-#: ../src/common/debugrpt.cpp:553
+#: ../src/common/debugrpt.cpp:554
 msgid "Debug report generation has failed."
 msgstr "A hibakeresésről nem sikerült jelentést készíteni."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:84
+#: ../src/common/accelcmn.cpp:81
 msgid "Decimal"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:323
+#: ../src/generic/fontdlgg.cpp:319
 msgid "Decorative"
 msgstr "Dekoratív"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1752
+#: ../src/propgrid/advprops.cpp:1653
 #, fuzzy
 msgid "Default"
 msgstr "alapértelmezés"
 
-#: ../src/common/fmapbase.cpp:796
+#: ../src/common/fmapbase.cpp:792
 msgid "Default encoding"
 msgstr "Az alapértelmezett kódolás"
 
-#: ../src/dfb/fontmgr.cpp:180
+#: ../src/dfb/fontmgr.cpp:177
 #, fuzzy
 msgid "Default font"
 msgstr "Az alapértelmezett nyomtató"
 
-#: ../src/generic/prntdlgg.cpp:510
+#: ../src/generic/prntdlgg.cpp:503
 msgid "Default printer"
 msgstr "Az alapértelmezett nyomtató"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:51
+#: ../src/common/accelcmn.cpp:48
 #, fuzzy
 msgid "Del"
 msgstr "&Törlés"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextbuffer.cpp:8221 ../src/common/stockitem.cpp:152
-#: ../src/common/accelcmn.cpp:50 ../src/stc/stc_i18n.cpp:20
+#: ../src/common/stockitem.cpp:149 ../src/common/accelcmn.cpp:47
+#: ../src/richtext/richtextbuffer.cpp:8217 ../src/stc/stc_i18n.cpp:20
 #, fuzzy
 msgid "Delete"
 msgstr "&Törlés"
@@ -2774,74 +2776,74 @@ msgstr "&Törlés"
 msgid "Delete A&ll"
 msgstr "Válassz ki &minden fájlt"
 
-#: ../src/richtext/richtextbuffer.cpp:11341
+#: ../src/richtext/richtextbuffer.cpp:11340
 #, fuzzy
 msgid "Delete Column"
 msgstr "Kiválasztott"
 
-#: ../src/richtext/richtextbuffer.cpp:11291
+#: ../src/richtext/richtextbuffer.cpp:11290
 #, fuzzy
 msgid "Delete Row"
 msgstr "&Törlés"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 #, fuzzy
 msgid "Delete Style"
 msgstr "Bejegyzés törlése"
 
-#: ../src/richtext/richtextctrl.cpp:1345 ../src/richtext/richtextctrl.cpp:1584
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
 #, fuzzy
 msgid "Delete Text"
 msgstr "Bejegyzés törlése"
 
-#: ../src/generic/editlbox.cpp:170
+#: ../src/generic/editlbox.cpp:147
 msgid "Delete item"
 msgstr "Bejegyzés törlése"
 
-#: ../src/common/stockitem.cpp:260
+#: ../src/common/stockitem.cpp:257
 #, fuzzy
 msgid "Delete selection"
 msgstr "Kiválasztott"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 #, fuzzy, c-format
 msgid "Delete style %s?"
 msgstr "Bejegyzés törlése"
 
-#: ../src/unix/snglinst.cpp:301
+#: ../src/unix/snglinst.cpp:298
 #, c-format
 msgid "Deleted stale lock file '%s'."
 msgstr "A régi '%s' lakat fájt töröltem."
 
-#: ../src/common/secretstore.cpp:220
+#: ../src/common/secretstore.cpp:234
 #, fuzzy, c-format
-msgid "Deleting password for \"%s/%s\" failed: %s."
+msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Nem sikerült kifejteni  '%s'-t '%s'-be"
 
-#: ../src/common/module.cpp:124
+#: ../src/common/module.cpp:121
 #, c-format
 msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 #, fuzzy
 msgid "Descending"
 msgstr "Az alapértelmezett kódolás"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:526 ../src/propgrid/advprops.cpp:882
+#: ../src/generic/dirctrlg.cpp:492 ../src/propgrid/advprops.cpp:783
 msgid "Desktop"
 msgstr "Asztal"
 
-#: ../src/generic/aboutdlgg.cpp:70
+#: ../src/generic/aboutdlgg.cpp:67
 msgid "Developed by "
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:176
+#: ../src/generic/aboutdlgg.cpp:173
 msgid "Developers"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:374
+#: ../src/msw/dialup.cpp:368
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -2849,11 +2851,11 @@ msgstr ""
 "A tárcsázó funkciók nem használhatók, mert a távoli elérés szolgáltatás "
 "(RAS) nincs installálva ezen a gépen. Kérem installálja."
 
-#: ../src/generic/tipdlg.cpp:211
+#: ../src/generic/tipdlg.cpp:208
 msgid "Did you know..."
 msgstr "Tudta Ön, hogy..."
 
-#: ../src/dfb/wrapdfb.cpp:63
+#: ../src/dfb/wrapdfb.cpp:60
 #, c-format
 msgid "DirectFB error %d occurred."
 msgstr ""
@@ -2862,29 +2864,29 @@ msgstr ""
 msgid "Directories"
 msgstr "Könyvtárak"
 
-#: ../src/common/filefn.cpp:1183
+#: ../src/common/filefn.cpp:1071
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Nem sikerült létrehozni a(z) '%s' könyvtárat"
 
-#: ../src/common/filefn.cpp:1197
+#: ../src/common/filefn.cpp:1085
 #, fuzzy, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "Nem sikerült létrehozni a(z) '%s' könyvtárat"
 
-#: ../src/generic/dirdlgg.cpp:204
+#: ../src/generic/dirdlgg.cpp:201
 msgid "Directory does not exist"
 msgstr "A könyvtár nem létezik"
 
-#: ../src/generic/filectrlg.cpp:1399
+#: ../src/generic/filectrlg.cpp:1388
 msgid "Directory doesn't exist."
 msgstr "A könyvtár nem létezik."
 
-#: ../src/common/docview.cpp:457
+#: ../src/common/docview.cpp:450
 msgid "Discard changes and reload the last saved version?"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:502
+#: ../src/html/helpwnd.cpp:500
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -2892,45 +2894,45 @@ msgstr ""
 "Írja ki az összes index bejegyzést, ami tartalmazza az adott bejegyzést. A "
 "keresés kis/nagy betűre nem érzékeny."
 
-#: ../src/html/helpwnd.cpp:679
+#: ../src/html/helpwnd.cpp:677
 msgid "Display options dialog"
 msgstr "Képernyő beállítási párbeszédablak"
 
-#: ../src/html/helpwnd.cpp:322
+#: ../src/html/helpwnd.cpp:320
 msgid "Displays help as you browse the books on the left."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:85
+#: ../src/common/accelcmn.cpp:83
 msgid "Divide"
 msgstr ""
 
-#: ../src/common/docview.cpp:533
+#: ../src/common/docview.cpp:526
 #, fuzzy, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Elmentsem a(z) %s dokument változásait?"
 
-#: ../src/common/prntbase.cpp:542
+#: ../src/common/prntbase.cpp:537
 msgid "Document:"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:73
+#: ../src/generic/aboutdlgg.cpp:70
 msgid "Documentation by "
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:180
+#: ../src/generic/aboutdlgg.cpp:177
 msgid "Documentation writers"
 msgstr ""
 
-#: ../src/common/sizer.cpp:2799
+#: ../src/common/sizer.cpp:2916
 msgid "Don't Save"
 msgstr "Ne mentsd el"
 
-#: ../src/html/htmlwin.cpp:633
+#: ../src/html/htmlwin.cpp:643
 msgid "Done"
 msgstr "Kész"
 
-#: ../src/generic/progdlgg.cpp:448 ../src/msw/progdlg.cpp:407
+#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
 msgid "Done."
 msgstr "Kész."
 
@@ -2944,44 +2946,44 @@ msgstr "Kész"
 msgid "Double"
 msgstr "Kész"
 
-#: ../src/common/paper.cpp:176
+#: ../src/common/paper.cpp:173
 msgid "Double Japanese Postcard Rotated 148 x 200 mm"
 msgstr "Kétszeres méretű japán levelezőlap, elfordított 148 x 200 mm"
 
-#: ../src/common/xtixml.cpp:273
+#: ../src/common/xtixml.cpp:269
 #, c-format
 msgid "Doubly used id : %d"
 msgstr "Másodszor használt azonosító : %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:153
-#: ../src/common/accelcmn.cpp:64
+#: ../src/common/stockitem.cpp:150 ../src/common/accelcmn.cpp:61
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Down"
 msgstr "Le"
 
-#: ../src/richtext/richtextctrl.cpp:865
+#: ../src/richtext/richtextctrl.cpp:864
 msgid "Drag"
 msgstr ""
 
-#: ../src/common/paper.cpp:100
+#: ../src/common/paper.cpp:97
 msgid "E sheet, 34 x 44 in"
 msgstr "E lap, 34 x 44 hüvelyk"
 
-#: ../src/unix/fswatcher_inotify.cpp:561
+#: ../src/unix/fswatcher_inotify.cpp:558
 #, fuzzy
 msgid "EOF while reading from inotify descriptor"
 msgstr "nem tudok olvasni a(z) %d leíróval megadott fájból"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 #, fuzzy
 msgid "Edit"
 msgstr "Bejegyzés szerkesztése"
 
-#: ../src/generic/editlbox.cpp:168
+#: ../src/generic/editlbox.cpp:131
 msgid "Edit item"
 msgstr "Bejegyzés szerkesztése"
 
-#: ../include/wx/generic/progdlgg.h:84
+#: ../include/wx/generic/progdlgg.h:85
 #, fuzzy
 msgid "Elapsed time:"
 msgstr "Az eltelt idő : "
@@ -3053,52 +3055,52 @@ msgid "Enables the shadow spread."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:66
+#: ../src/common/accelcmn.cpp:63
 msgid "End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:55
+#: ../src/common/accelcmn.cpp:52
 #, fuzzy
 msgid "Enter"
 msgstr "Nyomtató"
 
-#: ../src/richtext/richtextstyledlg.cpp:934
+#: ../src/richtext/richtextstyledlg.cpp:930
 #, fuzzy
 msgid "Enter a box style name"
 msgstr "A betűkészlet stílusa."
 
-#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:602
 msgid "Enter a character style name"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:816
 msgid "Enter a list style name"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:893
+#: ../src/richtext/richtextstyledlg.cpp:889
 #, fuzzy
 msgid "Enter a new style name"
 msgstr "A betűkészlet stílusa."
 
-#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:650
 msgid "Enter a paragraph style name"
 msgstr ""
 
-#: ../src/generic/dbgrptg.cpp:174
+#: ../src/generic/dbgrptg.cpp:171
 #, c-format
 msgid "Enter command to open file \"%s\":"
 msgstr "Írja be a(z) \"%s\" fájlt megnyitó parancsot:"
 
-#: ../src/generic/helpext.cpp:459
+#: ../src/generic/helpext.cpp:457
 msgid "Entries found"
 msgstr "A talált bejegyzések"
 
-#: ../src/common/paper.cpp:142
+#: ../src/common/paper.cpp:139
 msgid "Envelope Invite 220 x 220 mm"
 msgstr "Meghívó Boríték,  220 x 220 mm"
 
-#: ../src/common/config.cpp:469
+#: ../src/common/config.cpp:465
 #, c-format
 msgid ""
 "Environment variables expansion failed: missing '%c' at position %u in '%s'."
@@ -3106,13 +3108,13 @@ msgstr ""
 "A környezeti változók kifejtése nem sikerült: hiányzik '%c' a(z) %u helyen "
 "'%s'-ból."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/generic/dirctrlg.cpp:570
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/dirctrlg.cpp:599
-#: ../src/generic/dirdlgg.cpp:323 ../src/generic/filectrlg.cpp:642
-#: ../src/generic/filectrlg.cpp:756 ../src/generic/filectrlg.cpp:770
-#: ../src/generic/filectrlg.cpp:786 ../src/generic/filectrlg.cpp:1368
-#: ../src/generic/filectrlg.cpp:1399 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/gtk1/fontdlg.cpp:74 ../src/generic/dirctrlg.cpp:536
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/dirctrlg.cpp:565
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1357 ../src/generic/filectrlg.cpp:1388
+#: ../src/generic/filedlgg.cpp:354 ../src/generic/dirdlgg.cpp:320
+#: ../src/gtk/filedlg.cpp:74
 msgid "Error"
 msgstr "Hiba"
 
@@ -3121,247 +3123,268 @@ msgstr "Hiba"
 msgid "Error closing epoll descriptor"
 msgstr "Hiba a könyvtár létrehozásakor"
 
-#: ../src/unix/fswatcher_kqueue.cpp:114
+#: ../src/unix/fswatcher_kqueue.cpp:131
 #, fuzzy
 msgid "Error closing kqueue instance"
 msgstr "Hiba a könyvtár létrehozásakor"
 
-#: ../src/common/filefn.cpp:1049
+#: ../src/common/filefn.cpp:938
 #, fuzzy, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Nem sikerült lemásolni a(z) '%s' fájlt  '%s'-be."
 
-#: ../src/generic/dirdlgg.cpp:222
+#: ../src/generic/dirdlgg.cpp:219
 msgid "Error creating directory"
 msgstr "Hiba a könyvtár létrehozásakor"
 
-#: ../src/common/imagbmp.cpp:1181
+#: ../src/common/imagbmp.cpp:1193
 #, fuzzy
 msgid "Error in reading image DIB."
 msgstr "Hiba a DIB kép olvasásakor."
 
-#: ../src/propgrid/propgrid.cpp:6696
+#: ../src/propgrid/propgrid.cpp:6665
 #, c-format
 msgid "Error in resource: %s"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:422
+#: ../src/common/fileconf.cpp:421
 msgid "Error reading config options."
 msgstr "Hiba a konfigurációs beállítások olvasásakor."
+
+#: ../src/msw/webview_ie.cpp:1057 ../src/msw/webview_edge.cpp:850
+#: ../src/gtk/webview_webkit2.cpp:1262 ../src/osx/webview_webkit.mm:383
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
 
 #: ../src/common/fileconf.cpp:1029
 msgid "Error saving user configuration data."
 msgstr "Hiba a felhasználói konfigurációs beállítások elmentésekor."
 
-#: ../src/gtk/print.cpp:722
+#: ../src/gtk/print.cpp:720
 #, fuzzy
 msgid "Error while printing: "
 msgstr "Hiba történt a semaforra várakozás során"
 
-#: ../src/common/log.cpp:219
+#: ../src/common/log.cpp:237
 msgid "Error: "
 msgstr "Hiba: "
 
+#: ../src/common/webrequest.cpp:98
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Hiba: "
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:69
+#: ../src/common/accelcmn.cpp:66
 msgid "Esc"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:70
+#: ../src/common/accelcmn.cpp:67
 #, fuzzy
 msgid "Escape"
 msgstr "Tájkép"
 
-#: ../src/common/fmapbase.cpp:150
+#: ../src/common/fmapbase.cpp:147
 msgid "Esperanto (ISO-8859-3)"
 msgstr "Eszperantó (ISO-8859-3)"
 
-#: ../include/wx/generic/progdlgg.h:85
+#: ../include/wx/generic/progdlgg.h:86
 #, fuzzy
 msgid "Estimated time:"
 msgstr "A becsült idő : "
 
-#: ../src/generic/dbgrptg.cpp:234
+#: ../src/generic/dbgrptg.cpp:231
 #, fuzzy
 msgid "Executable files (*.exe)|*.exe|"
 msgstr "Végrehajtható fájlok (*.exe)|*.exe|Minden fájl (*.*)|*.*||"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:155 ../src/common/accelcmn.cpp:78
+#: ../src/common/stockitem.cpp:152 ../src/common/accelcmn.cpp:75
 msgid "Execute"
 msgstr ""
 
-#: ../src/msw/utilsexc.cpp:876
+#: ../src/msw/utilsexc.cpp:873
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Nem sikerült végrehajtani a(z) '%s' parancsot"
 
-#: ../src/common/paper.cpp:105
+#: ../src/common/paper.cpp:102
 msgid "Executive, 7 1/4 x 10 1/2 in"
 msgstr "Executive, 7 1/4 x 10 1/2 hüvelyk"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6009
+#: ../src/generic/datavgen.cpp:6814
 msgid "Expand"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1240
+#: ../src/msw/registry.cpp:1228
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
 msgstr ""
 "Registry kulcs exportálás: a fájl \"%s\" már létezik és nem írom felül."
 
-#: ../src/common/fmapbase.cpp:195
+#: ../src/common/fmapbase.cpp:192
 msgid "Extended Unix Codepage for Japanese (EUC-JP)"
 msgstr "Kiterjesztett japán Unix kódlap (EUC-JP)"
 
-#: ../src/html/chm.cpp:725
+#: ../src/html/chm.cpp:718
 #, c-format
 msgid "Extraction of '%s' into '%s' failed."
 msgstr "Nem sikerült kifejteni  '%s'-t '%s'-be"
 
-#: ../src/common/accelcmn.cpp:249 ../src/common/accelcmn.cpp:344
+#: ../src/common/accelcmn.cpp:259 ../src/common/accelcmn.cpp:358
 msgid "F"
 msgstr ""
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:672
+#: ../src/propgrid/advprops.cpp:582
 #, fuzzy
 msgid "Face Name"
 msgstr "ÚjNév"
 
-#: ../src/unix/snglinst.cpp:269
+#: ../src/unix/snglinst.cpp:266
 msgid "Failed to access lock file."
 msgstr "Nem sikerült elérni a lakat fájlt."
+
+#: ../src/gtk/font.cpp:572
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Nem tudtam betölteni a metafájlt a(z)  '%s' fájlból."
 
 #: ../src/unix/epolldispatcher.cpp:116
 #, fuzzy, c-format
 msgid "Failed to add descriptor %d to epoll descriptor %d"
 msgstr "nem tudok írni a(z) %d leíróval megadott fájba"
 
-#: ../src/msw/dib.cpp:489
+#: ../src/msw/dib.cpp:535
 #, fuzzy, c-format
 msgid "Failed to allocate %luKb of memory for bitmap data."
 msgstr "Nem sikerült %luKb tárterületet foglalni a memóriatérkép adatoknak."
 
-#: ../src/common/glcmn.cpp:115
+#: ../src/common/glcmn.cpp:112
 #, fuzzy
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Nem sikerült lérehozni egér mutatót."
 
-#: ../src/unix/displayx11.cpp:236
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Nem sikerült lérehozni egér mutatót."
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Nem sikerült lérehozni egér mutatót."
+
+#: ../include/wx/unix/private/displayx11.h:89
 msgid "Failed to change video mode"
 msgstr "Nem sikerült megváltoztatni a video módot."
 
-#: ../src/common/image.cpp:3277
+#: ../src/common/image.cpp:3396
 #, fuzzy, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Nem tudtam elmenteni a bittérképet a(z)  '%s' fájlba."
 
-#: ../src/common/debugrpt.cpp:239
+#: ../src/common/debugrpt.cpp:240
 #, c-format
 msgid "Failed to clean up debug report directory \"%s\""
 msgstr "Nem sikerült létrehozni a(z) hibakeresési jelentések \"%s\" könyvtárát"
 
-#: ../src/common/filename.cpp:192
+#: ../src/common/filename.cpp:189
 msgid "Failed to close file handle"
 msgstr "Nem sikerült lezárni a file kezelőt."
 
-#: ../src/unix/snglinst.cpp:340
+#: ../src/unix/snglinst.cpp:337
 #, c-format
 msgid "Failed to close lock file '%s'"
 msgstr "Nem sikerült lezárni a(z) '%s' lakat fájlt."
 
-#: ../src/msw/clipbrd.cpp:112
+#: ../src/msw/clipbrd.cpp:110
 msgid "Failed to close the clipboard."
 msgstr "Nem sikerült lezárni a vágólapot."
 
-#: ../src/x11/utils.cpp:208
+#: ../src/x11/utils.cpp:170
 #, fuzzy, c-format
 msgid "Failed to close the display \"%s\""
 msgstr "Nem sikerült lezárni a vágólapot."
 
-#: ../src/msw/dialup.cpp:797
+#: ../src/msw/dialup.cpp:791
 msgid "Failed to connect: missing username/password."
 msgstr ""
 "Nem sikerült létrehozni a kapcsolatot: hiányzik a felhasználói név vagy a "
 "jelszó."
 
-#: ../src/msw/dialup.cpp:743
+#: ../src/msw/dialup.cpp:737
 msgid "Failed to connect: no ISP to dial."
 msgstr ""
 "Nem sikerült létrehozni a kapcsolatot: nincs tárcsázható szolgáltató (ISP)."
 
-#: ../src/common/textfile.cpp:203
-#, fuzzy, c-format
-msgid "Failed to convert file \"%s\" to Unicode."
-msgstr "Nem sikerült lezárni a file kezelőt."
-
-#: ../src/generic/logg.cpp:956
+#: ../src/generic/logg.cpp:953
 #, fuzzy
 msgid "Failed to copy dialog contents to the clipboard."
 msgstr "Nem tudtam megnyitni a vágólapot."
 
-#: ../src/msw/registry.cpp:692
+#: ../src/msw/registry.cpp:681
 #, c-format
 msgid "Failed to copy registry value '%s'"
 msgstr "Nem sikerült lemásolni a(z) '%s' registry bejegyzést"
 
-#: ../src/msw/registry.cpp:701
+#: ../src/msw/registry.cpp:690
 #, c-format
 msgid "Failed to copy the contents of registry key '%s' to '%s'."
 msgstr ""
 "Nem sikerült lemásolni a(z) '%s' registry kulcs tartalmát a(z) '%s'-be."
 
-#: ../src/common/filefn.cpp:1015
+#: ../src/common/filefn.cpp:904
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Nem sikerült lemásolni a(z) '%s' fájlt  '%s'-be."
 
-#: ../src/msw/registry.cpp:679
+#: ../src/msw/registry.cpp:668
 #, c-format
 msgid "Failed to copy the registry subkey '%s' to '%s'."
 msgstr "Nem tudtam a(z) '%s' registry kulcsot '%s'-re átmásolni."
 
-#: ../src/msw/dde.cpp:1070
+#: ../src/msw/dde.cpp:1134
 msgid "Failed to create DDE string"
 msgstr "Nem sikerült létrehozni a DDE láncot"
 
-#: ../src/msw/mdi.cpp:616
+#: ../src/msw/mdi.cpp:621
 msgid "Failed to create MDI parent frame."
 msgstr "Nem sikerült létrehozni az MDI szülő keretet."
 
-#: ../src/common/filename.cpp:1027
+#: ../src/common/filename.cpp:1024
 msgid "Failed to create a temporary file name"
 msgstr "Nem sikerült létrehozni átmeneti fájlnevet."
 
-#: ../src/msw/utilsexc.cpp:228
+#: ../src/msw/utilsexc.cpp:225
 msgid "Failed to create an anonymous pipe"
 msgstr "Nem sikerült lérehozni a névtelen csövet."
 
-#: ../src/msw/ole/automtn.cpp:522
+#: ../src/msw/ole/automtn.cpp:513
 #, fuzzy, c-format
 msgid "Failed to create an instance of \"%s\""
 msgstr "Nem sikerült létrehozni a(z) \"%s\" könyvtárat"
 
-#: ../src/msw/dde.cpp:437
+#: ../src/msw/dde.cpp:432
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr ""
 "Nem sikerült kapcsolatot létrehozni a '%s' kiszolgálóval a '%s' témában"
 
-#: ../src/msw/cursor.cpp:204
+#: ../src/msw/cursor.cpp:195
 msgid "Failed to create cursor."
 msgstr "Nem sikerült lérehozni egér mutatót."
 
-#: ../src/common/debugrpt.cpp:209
+#: ../src/common/debugrpt.cpp:210
 #, c-format
 msgid "Failed to create directory \"%s\""
 msgstr "Nem sikerült létrehozni a(z) \"%s\" könyvtárat"
 
-#: ../src/generic/dirdlgg.cpp:220
+#: ../src/generic/dirdlgg.cpp:217
 #, c-format
 msgid ""
 "Failed to create directory '%s'\n"
@@ -3375,119 +3398,138 @@ msgstr ""
 msgid "Failed to create epoll descriptor"
 msgstr "Nem sikerült lérehozni egér mutatót."
 
-#: ../src/msw/mimetype.cpp:238
+#: ../src/gtk/font.cpp:562
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "Nem tudom frissíteni a felhasználó konfigurációs fájlját."
+
+#: ../src/msw/mimetype.cpp:235
 #, c-format
 msgid "Failed to create registry entry for '%s' files."
 msgstr "Nem tudtam létrehozni registry bejegyzést a(z) '%s' fájlokra."
 
-#: ../src/msw/fdrepdlg.cpp:409
+#: ../src/msw/fdrepdlg.cpp:408
 #, c-format
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr ""
 "Nem sikerült létrehozni a keresés-helyettesítés párbeszéd ablakot (hibakód : "
 "%d) "
 
-#: ../src/unix/wakeuppipe.cpp:52
+#: ../src/unix/wakeuppipe.cpp:49
 #, fuzzy
 msgid "Failed to create wake up pipe used by event loop."
 msgstr "Nem sikerült lérehozni az állapotsort."
 
-#: ../src/html/winpars.cpp:730
+#: ../src/html/winpars.cpp:727
 #, c-format
 msgid "Failed to display HTML document in %s encoding"
 msgstr "Nem sikerült a HTML dokumentumot %s kódolással megjeleníteni"
 
-#: ../src/msw/clipbrd.cpp:124
+#: ../src/msw/clipbrd.cpp:122
 msgid "Failed to empty the clipboard."
 msgstr "Nem sikerült kiüríteni a vágólapot."
 
-#: ../src/unix/displayx11.cpp:212
+#: ../include/wx/unix/private/displayx11.h:65
 msgid "Failed to enumerate video modes"
 msgstr "Nem sikerült megszámlálni a video módokat."
 
-#: ../src/msw/dde.cpp:722
+#: ../src/msw/dde.cpp:717
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "Nem sikerült létrehozni tanácsadói kapcsolatot a DDE kiszolgálóval"
 
-#: ../src/msw/dialup.cpp:629 ../src/msw/dialup.cpp:863
+#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Nem sikerült létrehozni a telefonos kapcsolatot: %s"
 
-#: ../src/unix/utilsunx.cpp:611
+#: ../src/unix/utilsunx.cpp:613
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Nem sikerült végrehajtani '%s'-t\n"
 
-#: ../src/common/debugrpt.cpp:720
+#: ../src/common/debugrpt.cpp:730
 msgid "Failed to execute curl, please install it in PATH."
 msgstr "Nem sikerült a curl-t végrehajtani, kérem tegye elérhetővé a PATH-on."
 
-#: ../src/msw/ole/automtn.cpp:505
+#: ../src/msw/ole/automtn.cpp:496
 #, fuzzy, c-format
 msgid "Failed to find CLSID of \"%s\""
 msgstr "Nem tudtam megnyitni '%s'-t %s-ként."
 
-#: ../src/common/regex.cpp:431 ../src/common/regex.cpp:479
+#: ../src/common/regex.cpp:428 ../src/common/regex.cpp:476
 #, fuzzy, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "Nem sikerült megtalálni '%s'-t  a(z) '%s' szabályos kifejezésben."
 
-#: ../src/msw/dialup.cpp:695
+#: ../src/msw/webview_ie.cpp:978
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:689
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Nem kaptam meg a(z) %s ISP(szolgáltató) neveket"
 
-#: ../src/msw/ole/automtn.cpp:574
+#: ../src/msw/ole/automtn.cpp:565
 #, fuzzy, c-format
 msgid "Failed to get OLE automation interface for \"%s\""
 msgstr "Nem sikerült létrehozni a(z) \"%s\" könyvtárat"
 
-#: ../src/msw/clipbrd.cpp:711
+#: ../src/msw/clipbrd.cpp:731
 msgid "Failed to get data from the clipboard"
 msgstr "Nem kaptam a vágólapról adatokat"
 
-#: ../src/common/time.cpp:223
+#: ../src/common/time.cpp:216
 msgid "Failed to get the local system time"
 msgstr "Nem kaptam meg a helyi rendszer időt."
 
-#: ../src/common/filefn.cpp:1345
+#: ../src/common/filefn.cpp:1233
 msgid "Failed to get the working directory"
 msgstr "Nem sikerült létrehozni a munkakönyvtárat."
 
-#: ../src/univ/theme.cpp:114
+#: ../src/univ/theme.cpp:111
 msgid "Failed to initialize GUI: no built-in themes found."
 msgstr "Nem sikerült elindítani a GUIt: nem találtam beépített bőrt."
 
-#: ../src/msw/helpchm.cpp:63
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:60
 msgid "Failed to initialize MS HTML Help."
 msgstr "Nem sikerült elindítani az MS HTML súgót."
 
-#: ../src/msw/glcanvas.cpp:1381
+#: ../src/msw/glcanvas.cpp:1391
 msgid "Failed to initialize OpenGL"
 msgstr "Nem tudom elindítani az OpenGLt."
 
-#: ../src/msw/dialup.cpp:858
+#: ../src/msw/dialup.cpp:852
 #, fuzzy, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Nem tudtam befejezni a(z) %s telefon kapcsolatot."
 
-#: ../src/gtk/textctrl.cpp:1128
+#: ../src/gtk/textctrl.cpp:1209
 #, fuzzy
 msgid "Failed to insert text in the control."
 msgstr "Nem sikerült létrehozni a munkakönyvtárat."
 
-#: ../src/unix/snglinst.cpp:241
+#: ../src/unix/snglinst.cpp:238
 #, c-format
 msgid "Failed to inspect the lock file '%s'"
 msgstr "Nem sikerült megvizsgálni a(z) '%s' lezáró fájlt."
 
-#: ../src/unix/appunix.cpp:182
+#: ../src/unix/appunix.cpp:179
 #, fuzzy
 msgid "Failed to install signal handler"
 msgstr "Nem sikerült lezárni a file kezelőt."
 
-#: ../src/unix/threadpsx.cpp:1167
+#: ../src/unix/threadpsx.cpp:1216
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -3495,71 +3537,71 @@ msgstr ""
 "Nem tudtam a szálhoz csatlakozni, valószínűleg memória lyukat találtam - "
 "kérem indítsa újra a programot"
 
-#: ../src/msw/utils.cpp:629
+#: ../src/msw/utils.cpp:619
 #, c-format
 msgid "Failed to kill process %d"
 msgstr "Nem tudtam megölni a '%d' folyamatot."
 
-#: ../src/common/image.cpp:2500
+#: ../src/common/image.cpp:2595
 #, fuzzy, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Nem tudtam betölteni a(z) %d képet a  '%s' fájlból."
 
-#: ../src/common/image.cpp:2509
+#: ../src/common/image.cpp:2604
 #, fuzzy, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Nem tudtam betölteni a(z) %d képet a  '%s' fájlból."
 
-#: ../src/common/iconbndl.cpp:225
+#: ../src/common/iconbndl.cpp:224
 #, fuzzy, c-format
 msgid "Failed to load icons from resource '%s'."
 msgstr "Nem tudtam betölteni a(z) %d képet a  '%s' fájlból."
 
-#: ../src/common/iconbndl.cpp:200
+#: ../src/common/iconbndl.cpp:198
 #, fuzzy, c-format
 msgid "Failed to load image %%d from file '%s'."
 msgstr "Nem tudtam betölteni a(z) %d képet a  '%s' fájlból."
 
-#: ../src/common/iconbndl.cpp:208
+#: ../src/common/iconbndl.cpp:206
 #, fuzzy, c-format
 msgid "Failed to load image %d from stream."
 msgstr "Nem tudtam betölteni a(z) %d képet a  '%s' fájlból."
 
-#: ../src/common/image.cpp:2587 ../src/common/image.cpp:2606
+#: ../src/common/image.cpp:2682 ../src/common/image.cpp:2701
 #, fuzzy, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Nem tudtam betölteni a(z) %d képet a  '%s' fájlból."
 
-#: ../src/msw/enhmeta.cpp:97
+#: ../src/msw/enhmeta.cpp:94
 #, c-format
 msgid "Failed to load metafile from file \"%s\"."
 msgstr "Nem tudtam betölteni a metafájlt a(z)  '%s' fájlból."
 
-#: ../src/msw/volume.cpp:327
+#: ../src/msw/volume.cpp:335
 msgid "Failed to load mpr.dll."
 msgstr "Nem tudtam betölteni az mpr.dll-t."
 
-#: ../src/msw/utils.cpp:953
+#: ../src/msw/utils.cpp:943
 #, fuzzy, c-format
 msgid "Failed to load resource \"%s\"."
 msgstr "Nem tudtam betölteni a metafájlt a(z)  '%s' fájlból."
 
-#: ../src/common/dynlib.cpp:92
+#: ../src/common/dynlib.cpp:86
 #, c-format
 msgid "Failed to load shared library '%s'"
 msgstr "Nem tudtam betölteni a(z) '%s' osztott könyvtárat."
 
-#: ../src/osx/core/sound.cpp:145
+#: ../src/osx/core/sound.cpp:143
 #, fuzzy, c-format
 msgid "Failed to load sound from \"%s\" (error %d)."
 msgstr "Nem tudtam betölteni a metafájlt a(z)  '%s' fájlból."
 
-#: ../src/msw/utils.cpp:960
+#: ../src/msw/utils.cpp:950
 #, fuzzy, c-format
 msgid "Failed to lock resource \"%s\"."
 msgstr "Nem sikerült lelakatolni a(z) '%s' lakat fájlt."
 
-#: ../src/unix/snglinst.cpp:198
+#: ../src/unix/snglinst.cpp:195
 #, c-format
 msgid "Failed to lock the lock file '%s'"
 msgstr "Nem sikerült lelakatolni a(z) '%s' lakat fájlt."
@@ -3569,33 +3611,38 @@ msgstr "Nem sikerült lelakatolni a(z) '%s' lakat fájlt."
 msgid "Failed to modify descriptor %d in epoll descriptor %d"
 msgstr ""
 
-#: ../src/common/filename.cpp:2575
+#: ../src/common/filename.cpp:2658
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Nem sikerült módosítani a(z) időket '%s'-re."
 
-#: ../src/common/selectdispatcher.cpp:258
+#: ../src/common/selectdispatcher.cpp:255
 msgid "Failed to monitor I/O channels"
 msgstr ""
 
-#: ../src/common/filename.cpp:175
+#: ../src/common/filename.cpp:172
 #, fuzzy, c-format
 msgid "Failed to open '%s' for reading"
 msgstr "Nem tudtam megnyitni '%s'-t %s-ként."
 
-#: ../src/common/filename.cpp:180
+#: ../src/common/filename.cpp:177
 #, fuzzy, c-format
 msgid "Failed to open '%s' for writing"
 msgstr "Nem tudtam megnyitni '%s'-t %s-ként."
 
-#: ../src/html/chm.cpp:141
+#: ../src/html/chm.cpp:138
 #, c-format
 msgid "Failed to open CHM archive '%s'."
 msgstr "Nem tudtam megnyitni a(z) '%s' CHM archive fájlt."
 
-#: ../src/common/utilscmn.cpp:1126
+#: ../src/common/utilscmn.cpp:1140
 #, fuzzy, c-format
 msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Nem tudtam megnyitni '%s'-t %s-ként."
+
+#: ../src/common/hyperlnkcmn.cpp:133
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Nem tudtam megnyitni '%s'-t %s-ként."
 
 #: ../include/wx/msw/private/fswatcher.h:92
@@ -3603,214 +3650,232 @@ msgstr "Nem tudtam megnyitni '%s'-t %s-ként."
 msgid "Failed to open directory \"%s\" for monitoring."
 msgstr "Nem tudtam megnyitni '%s'-t %s-ként."
 
-#: ../src/x11/utils.cpp:227
+#: ../src/x11/utils.cpp:189
 #, fuzzy, c-format
 msgid "Failed to open display \"%s\"."
 msgstr "Nem tudtam megnyitni '%s'-t %s-ként."
 
-#: ../src/common/filename.cpp:1062
+#: ../src/common/filename.cpp:1059
 msgid "Failed to open temporary file."
 msgstr "Nem tudtam megnyitni az átmeneti fájlt."
 
-#: ../src/msw/clipbrd.cpp:91
+#: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Nem tudtam megnyitni a vágólapot."
 
-#: ../src/common/translation.cpp:1184
+#: ../src/common/translation.cpp:1226
 #, fuzzy, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Nem tudom értelmezni a(z)  '%s' többes számú alakotat"
 
-#: ../src/unix/mediactrl.cpp:1214
+#: ../src/unix/mediactrl.cpp:1239
 #, fuzzy, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Nem tudtam megnyitni '%s'-t %s-ként."
 
-#: ../src/msw/clipbrd.cpp:600
+#: ../src/msw/clipbrd.cpp:610
 msgid "Failed to put data on the clipboard"
 msgstr "Nem tudtam adatokat tenni a vágólapra."
 
-#: ../src/unix/snglinst.cpp:278
+#: ../src/unix/snglinst.cpp:275
 msgid "Failed to read PID from lock file."
 msgstr "Nem sikerült elolvasni a PID-t a lakat fájlból."
 
-#: ../src/common/fileconf.cpp:433
+#: ../src/common/fileconf.cpp:432
 #, fuzzy
 msgid "Failed to read config options."
 msgstr "Hiba a konfigurációs beállítások olvasásakor."
 
-#: ../src/common/docview.cpp:681
+#: ../src/common/docview.cpp:676
 #, fuzzy, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Nem tudtam betölteni a metafájlt a(z)  '%s' fájlból."
 
-#: ../src/dfb/evtloop.cpp:98
+#: ../src/dfb/evtloop.cpp:99
 #, fuzzy
 msgid "Failed to read event from DirectFB pipe"
 msgstr "Nem sikerült elolvasni a PID-t a lakat fájlból."
 
-#: ../src/unix/wakeuppipe.cpp:120
+#: ../src/unix/wakeuppipe.cpp:117
 #, fuzzy
 msgid "Failed to read from wake-up pipe"
 msgstr "Nem sikerült elolvasni a PID-t a lakat fájlból."
 
-#: ../src/unix/utilsunx.cpp:679
+#: ../src/common/textfile.cpp:96
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Nem tudtam betölteni a metafájlt a(z)  '%s' fájlból."
+
+#: ../src/unix/utilsunx.cpp:681
 msgid "Failed to redirect child process input/output"
 msgstr "Nem tudtam átirányítani a gyermek processz be/kimenetét."
 
-#: ../src/msw/utilsexc.cpp:701
+#: ../src/msw/utilsexc.cpp:698
 msgid "Failed to redirect the child process IO"
 msgstr "Nem tudtam átirányítani a gyermek processz be/kimenetét"
 
-#: ../src/msw/dde.cpp:288
+#: ../src/msw/dde.cpp:283
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Nem tudtam regisztrálni a(z) '%s' DDE kiszolgálót"
 
-#: ../src/common/fontmap.cpp:245
+#: ../src/gtk/font.cpp:580
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "Nem tudom frissíteni a felhasználó konfigurációs fájlját."
+
+#: ../src/common/fontmap.cpp:242
 #, c-format
 msgid "Failed to remember the encoding for the charset '%s'."
 msgstr "Nem emlékszem a '%s' jelkészlet kódolására."
 
-#: ../src/common/debugrpt.cpp:227
+#: ../src/common/debugrpt.cpp:228
 #, c-format
 msgid "Failed to remove debug report file \"%s\""
 msgstr ""
 "Nem tudom eltávolítani a(z) '%s' hibekeresési jelentést tartalmazó fájlt."
 
-#: ../src/unix/snglinst.cpp:328
+#: ../src/unix/snglinst.cpp:325
 #, c-format
 msgid "Failed to remove lock file '%s'"
 msgstr "Nem tudom eltávolítani a(z) '%s' lakat fájlt."
 
-#: ../src/unix/snglinst.cpp:288
+#: ../src/unix/snglinst.cpp:285
 #, c-format
 msgid "Failed to remove stale lock file '%s'."
 msgstr "Nem tudtam eltávolítani az elavult  '%s' lakat fájlt."
 
-#: ../src/msw/registry.cpp:529
+#: ../src/msw/registry.cpp:518
 #, c-format
 msgid "Failed to rename registry value '%s' to '%s'."
 msgstr "Nem tudtam a(z) '%s' registry értéket '%s'-re átnevezni."
 
-#: ../src/common/filefn.cpp:1122
+#: ../src/common/filefn.cpp:1011
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
 "exists."
 msgstr ""
 
-#: ../src/msw/registry.cpp:634
+#: ../src/msw/registry.cpp:623
 #, c-format
 msgid "Failed to rename the registry key '%s' to '%s'."
 msgstr "Nem tudtam a(z) '%s' registry kulcsot '%s'-re átnevezni."
 
-#: ../src/common/filename.cpp:2671
+#: ../src/msw/webview_ie.cpp:995
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/common/filename.cpp:2754
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Nem sikerült helyrehozni a fájl időket '%s'-re."
 
-#: ../src/msw/dialup.cpp:468
+#: ../src/msw/dialup.cpp:462
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Nem sikerült értelmezni a RAS hibaüzenet szövegét."
 
-#: ../src/msw/clipbrd.cpp:748
+#: ../src/msw/clipbrd.cpp:768
 msgid "Failed to retrieve the supported clipboard formats"
 msgstr "Nem tudtam meghatározni a támogatott vágólap formátumokat."
 
-#: ../src/common/docview.cpp:652
+#: ../src/common/docview.cpp:647
 #, fuzzy, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Nem tudtam elmenteni a bittérképet a(z)  '%s' fájlba."
 
-#: ../src/msw/dib.cpp:269
+#: ../src/msw/dib.cpp:312
 #, c-format
 msgid "Failed to save the bitmap image to file \"%s\"."
 msgstr "Nem tudtam elmenteni a bittérképet a(z)  '%s' fájlba."
 
-#: ../src/msw/dde.cpp:763
+#: ../src/msw/dde.cpp:811
 msgid "Failed to send DDE advise notification"
 msgstr "Nem sikerült DDE tanácsot küldeni."
 
-#: ../src/common/ftp.cpp:402
+#: ../src/common/ftp.cpp:399
 #, c-format
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Nem tudtam a(z) '%s' FTP átviteli módot beállítani."
 
-#: ../src/msw/clipbrd.cpp:427
+#: ../src/msw/clipbrd.cpp:443
 msgid "Failed to set clipboard data."
 msgstr "Nem tudtam a vágólap adatot beállítani."
 
-#: ../src/unix/snglinst.cpp:181
+#: ../src/unix/snglinst.cpp:178
 #, c-format
 msgid "Failed to set permissions on lock file '%s'"
 msgstr "Nem lehet beállítani a(z)  '%s' lezáró fájl engedélyeit"
 
-#: ../src/unix/utilsunx.cpp:668
+#: ../src/unix/utilsunx.cpp:670
 #, fuzzy
 msgid "Failed to set process priority"
 msgstr "Nem tudtam a(z) %d szál prioritást beállítani."
 
-#: ../src/common/file.cpp:559
+#: ../src/common/ffile.cpp:355 ../src/common/file.cpp:586
 msgid "Failed to set temporary file permissions"
 msgstr "Nem tudtam az átmeneti fájl engedélyeit beállítani."
 
-#: ../src/gtk/textctrl.cpp:1072
-#, fuzzy
-msgid "Failed to set text in the text control."
-msgstr "Nem sikerült létrehozni a munkakönyvtárat."
-
-#: ../src/unix/threadpsx.cpp:1298
+#: ../src/unix/threadpsx.cpp:1347
 #, fuzzy, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Nem tudtam a(z) %d szál prioritást beállítani."
 
-#: ../src/unix/threadpsx.cpp:1424
+#: ../src/unix/threadpsx.cpp:1473
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Nem tudtam a(z) %d szál prioritást beállítani."
 
-#: ../src/unix/utilsunx.cpp:783
+#: ../src/unix/utilsunx.cpp:785
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 
-#: ../src/common/fs_mem.cpp:261
+#: ../src/msw/webview_ie.cpp:987
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:256
 #, c-format
 msgid "Failed to store image '%s' to memory VFS!"
 msgstr "Nem tudtam a '%s' képet a VFS memóriába tárolni!"
 
-#: ../src/dfb/evtloop.cpp:170
+#: ../src/dfb/evtloop.cpp:171
 msgid "Failed to switch DirectFB pipe to non-blocking mode"
 msgstr ""
 
-#: ../src/unix/wakeuppipe.cpp:59
+#: ../src/unix/wakeuppipe.cpp:56
 msgid "Failed to switch wake up pipe to non-blocking mode"
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1605
+#: ../src/unix/threadpsx.cpp:1654
 msgid "Failed to terminate a thread."
 msgstr "Nem tudtam befejezni a szálat."
 
-#: ../src/msw/dde.cpp:741
+#: ../src/msw/dde.cpp:736
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "Nem tudtam befejezni a tanácskozási ciklust a DDE kiszolgálóval."
 
-#: ../src/msw/dialup.cpp:938
+#: ../src/msw/dialup.cpp:932
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Nem tudtam befejezni a(z) %s telefon kapcsolatot."
 
-#: ../src/common/filename.cpp:2590
+#: ../src/common/filename.cpp:2673
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Nem sikerült megérinteni a(z) '%s't."
 
-#: ../src/unix/snglinst.cpp:334
+#: ../src/unix/dlunix.cpp:90
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "Nem tudtam betölteni a(z) '%s' osztott könyvtárat."
+
+#: ../src/unix/snglinst.cpp:331
 #, c-format
 msgid "Failed to unlock lock file '%s'"
 msgstr "Nem sikerült felnyitni a(z) '%s'  lakat fájlt."
 
-#: ../src/msw/dde.cpp:309
+#: ../src/msw/dde.cpp:304
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Nem tudtam a(z) '%s' DDE kiszolgáló regisztrációját megszüntetni."
@@ -3824,79 +3889,89 @@ msgstr "Nem tudtam adatot elővenni a vágólapról."
 msgid "Failed to update user configuration file."
 msgstr "Nem tudom frissíteni a felhasználó konfigurációs fájlját."
 
-#: ../src/common/debugrpt.cpp:733
+#: ../src/common/debugrpt.cpp:743
 #, c-format
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Nem sikerült létrehozni a hibakereső jelentéstt (hibakód : %d) "
 
-#: ../src/unix/snglinst.cpp:168
+#: ../src/unix/snglinst.cpp:165
 #, c-format
 msgid "Failed to write to lock file '%s'"
 msgstr "Nem sikerült írni a(z) '%s' lakat fájlba."
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:209
+#: ../src/propgrid/propgrid.cpp:190
 #, fuzzy
 msgid "False"
 msgstr "Fájl"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:694
+#: ../src/propgrid/advprops.cpp:604
 #, fuzzy
 msgid "Family"
 msgstr "Jelkészlet család:"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/gtk/glcanvas.cpp:176 ../src/gtk/glcanvas.cpp:187
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Végzetes hiba"
+
+#: ../src/common/stockitem.cpp:154
 msgid "File"
 msgstr "Fájl"
 
-#: ../src/common/docview.cpp:669
+#: ../src/common/docview.cpp:664
 #, fuzzy, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Nem tudtam megnyitni '%s'-t %s-ként."
 
-#: ../src/common/docview.cpp:646
+#: ../src/common/docview.cpp:641
 #, fuzzy, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Nem tudtam megnyitni '%s'-t %s-ként."
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "A(z) '%s file már létezik, valóban  felül akarja írni?"
 
-#: ../src/common/filefn.cpp:1156
+#: ../src/common/filefn.cpp:1044
 #, fuzzy, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Nem sikerült létrehozni a(z) '%s' könyvtárat"
 
-#: ../src/common/filefn.cpp:1139
+#: ../src/common/filefn.cpp:1028
 #, fuzzy, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Nem sikerült létrehozni a(z) '%s' könyvtárat"
 
-#: ../src/richtext/richtextctrl.cpp:3081 ../src/common/textcmn.cpp:953
+#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
 msgid "File couldn't be loaded."
 msgstr "A fájlt nem tudtam betölteni."
 
-#: ../src/msw/filedlg.cpp:393
+#: ../src/msw/filedlg.cpp:414
 #, fuzzy, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Nem sikerült végrehajtani a(z) '%s' parancsot, hibakód: %ul"
 
-#: ../src/common/docview.cpp:1789
+#: ../src/common/docview.cpp:1783
 msgid "File error"
 msgstr "Fájl hiba"
 
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/filectrlg.cpp:770
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/filectrlg.cpp:766
 msgid "File name exists already."
 msgstr "Már van ilyen nevű fájl."
+
+#: ../src/osx/cocoa/filedlg.mm:264
+#, fuzzy
+msgid "File type:"
+msgstr "Teletype"
 
 #: ../src/motif/filedlg.cpp:220
 msgid "Files"
 msgstr "Fájlok"
 
-#: ../src/common/filefn.cpp:1591
+#: ../src/common/filefn.cpp:1479
 #, c-format
 msgid "Files (%s)"
 msgstr "Fájlok (%s)"
@@ -3905,16 +3980,30 @@ msgstr "Fájlok (%s)"
 msgid "Filter"
 msgstr "Szűrő"
 
-#: ../src/common/stockitem.cpp:158 ../src/html/helpwnd.cpp:490
+#: ../src/html/helpwnd.cpp:488
 msgid "Find"
 msgstr "Keres"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:259
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:258
+#, fuzzy
+msgid "Find in document"
+msgstr "Nyisd meg a HTML dokumentumot"
+
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "Find..."
+msgstr "Keres"
+
+#: ../src/common/stockitem.cpp:156
 #, fuzzy
 msgid "First"
 msgstr "első"
 
-#: ../src/common/prntbase.cpp:1548
+#: ../src/common/prntbase.cpp:1573
 #, fuzzy
 msgid "First page"
 msgstr "Következő oldal"
@@ -3924,11 +4013,11 @@ msgstr "Következő oldal"
 msgid "Fixed"
 msgstr "Nem skálázható jelkészlet:"
 
-#: ../src/html/helpwnd.cpp:1206
+#: ../src/html/helpwnd.cpp:1204
 msgid "Fixed font:"
 msgstr "Nem skálázható jelkészlet:"
 
-#: ../src/html/helpwnd.cpp:1269
+#: ../src/html/helpwnd.cpp:1267
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Rögzített méretű betű.<br> <b>bold</b> <i>dőlt</i> "
 
@@ -3936,17 +4025,17 @@ msgstr "Rögzített méretű betű.<br> <b>bold</b> <i>dőlt</i> "
 msgid "Floating"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 #, fuzzy
 msgid "Floppy"
 msgstr "&Másolás"
 
-#: ../src/common/paper.cpp:111
+#: ../src/common/paper.cpp:108
 msgid "Folio, 8 1/2 x 13 in"
 msgstr "Folio, 8 1/2 x 13 hüvelyk"
 
-#: ../src/richtext/richtextformatdlg.cpp:344 ../src/osx/carbon/fontdlg.cpp:287
-#: ../src/common/stockitem.cpp:194
+#: ../src/osx/carbon/fontdlg.cpp:284 ../src/common/stockitem.cpp:191
+#: ../src/richtext/richtextformatdlg.cpp:337
 msgid "Font"
 msgstr ""
 
@@ -3955,7 +4044,24 @@ msgstr ""
 msgid "Font &weight:"
 msgstr "A betűkészlet hangsúlya."
 
-#: ../src/html/helpwnd.cpp:1207
+#: ../src/osx/fontutil.cpp:89
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
+"\"."
+msgstr ""
+
+#: ../src/msw/font.cpp:1126
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "A fájlt nem tudtam betölteni."
+
+#: ../src/osx/fontutil.cpp:81
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "A(z) '%s' file nem létezik."
+
+#: ../src/html/helpwnd.cpp:1205
 msgid "Font size:"
 msgstr "Jelkészlet mérete:"
 
@@ -3964,77 +4070,77 @@ msgstr "Jelkészlet mérete:"
 msgid "Font st&yle:"
 msgstr "Jelkészlet mérete:"
 
-#: ../src/osx/carbon/fontdlg.cpp:329
+#: ../src/osx/carbon/fontdlg.cpp:326
 #, fuzzy
 msgid "Font:"
 msgstr "Jelkészlet mérete:"
 
-#: ../src/dfb/fontmgr.cpp:198
+#: ../src/dfb/fontmgr.cpp:195
 #, c-format
 msgid "Fonts index file %s disappeared while loading fonts."
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:645
+#: ../src/unix/utilsunx.cpp:647
 msgid "Fork failed"
 msgstr "A folyamat elágaztatása nem sikerült"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 #, fuzzy
 msgid "Forward"
 msgstr "&Előre"
 
-#: ../src/common/xtixml.cpp:235
+#: ../src/common/xtixml.cpp:231
 msgid "Forward hrefs are not supported"
 msgstr "Előre mutató href-eket nem tudok használni"
 
-#: ../src/html/helpwnd.cpp:875
+#: ../src/html/helpwnd.cpp:873
 #, c-format
 msgid "Found %i matches"
 msgstr "%i megfelelőt találtam"
 
-#: ../src/generic/prntdlgg.cpp:238
+#: ../src/generic/prntdlgg.cpp:231
 msgid "From:"
 msgstr "Tól:"
 
-#: ../src/propgrid/advprops.cpp:1604
+#: ../src/propgrid/advprops.cpp:1510
 msgid "Fuchsia"
 msgstr ""
 
-#: ../src/common/imaggif.cpp:138
+#: ../src/common/imaggif.cpp:135
 msgid "GIF: data stream seems to be truncated."
 msgstr "GIF: az adatfolyam csonkítottnak tűnik."
 
-#: ../src/common/imaggif.cpp:128
+#: ../src/common/imaggif.cpp:125
 msgid "GIF: error in GIF image format."
 msgstr "GIF: hiba a GIF képformátumban."
 
-#: ../src/common/imaggif.cpp:133
+#: ../src/common/imaggif.cpp:130
 msgid "GIF: not enough memory."
 msgstr "GIF: nincs elég tároló."
 
-#: ../src/gtk/window.cpp:4631
+#: ../src/gtk/window.cpp:5635
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
 msgstr ""
 
-#: ../src/univ/themes/gtk.cpp:525
+#: ../src/univ/themes/gtk.cpp:522
 msgid "GTK+ theme"
 msgstr "GTK+ bőr"
 
-#: ../src/common/preferencescmn.cpp:40
+#: ../src/common/preferencescmn.cpp:37
 msgid "General"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:258
+#: ../src/common/prntbase.cpp:253
 msgid "Generic PostScript"
 msgstr "Generikus PostScript"
 
-#: ../src/common/paper.cpp:135
+#: ../src/common/paper.cpp:132
 msgid "German Legal Fanfold, 8 1/2 x 13 in"
 msgstr "Német bírósági leporelló, 8 1/2 x 13 hüvelyk"
 
-#: ../src/common/paper.cpp:134
+#: ../src/common/paper.cpp:131
 msgid "German Std Fanfold, 8 1/2 x 12 in"
 msgstr "Német standard leporelló, 8 1/2 x 12 hüvelyk"
 
@@ -4050,48 +4156,48 @@ msgstr "GetPropertyCollection generikus accessor hívás"
 msgid "GetPropertyCollection called w/o valid collection getter"
 msgstr "GetProperty híváskor nincs érvényes gyűjtő fogadó"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:658
 msgid "Go back"
 msgstr "Menj vissza"
 
-#: ../src/html/helpwnd.cpp:661
+#: ../src/html/helpwnd.cpp:659
 msgid "Go forward"
 msgstr "Menj előre"
 
-#: ../src/html/helpwnd.cpp:663
+#: ../src/html/helpwnd.cpp:661
 msgid "Go one level up in document hierarchy"
 msgstr "Menj a dokumentum hierarchia eggyel magasabb szintjére"
 
-#: ../src/generic/filedlgg.cpp:208 ../src/generic/dirdlgg.cpp:116
+#: ../src/generic/filedlgg.cpp:205 ../src/generic/dirdlgg.cpp:113
 msgid "Go to home directory"
 msgstr "Menj a saját (hon) könyvtárba"
 
-#: ../src/generic/filedlgg.cpp:205
+#: ../src/generic/filedlgg.cpp:202
 msgid "Go to parent directory"
 msgstr "Menj a szülő könyvtárba"
 
-#: ../src/generic/aboutdlgg.cpp:76
+#: ../src/generic/aboutdlgg.cpp:73
 msgid "Graphics art by "
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1599
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Gray"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:883
+#: ../src/propgrid/advprops.cpp:784
 msgid "GrayText"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:154
+#: ../src/common/fmapbase.cpp:151
 msgid "Greek (ISO-8859-7)"
 msgstr "Görög (ISO-8859-7)"
 
-#: ../src/propgrid/advprops.cpp:1600
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Green"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:342
+#: ../src/generic/colrdlgg.cpp:362
 msgid "Green:"
 msgstr ""
 
@@ -4099,108 +4205,108 @@ msgstr ""
 msgid "Groove"
 msgstr ""
 
-#: ../src/common/zstream.cpp:158 ../src/common/zstream.cpp:318
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
 msgid "Gzip not supported by this version of zlib"
 msgstr "A zlib ezen változata nem támogatja gzip-et"
 
-#: ../src/html/helpwnd.cpp:1549
+#: ../src/html/helpwnd.cpp:1547
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "HTML Help Project (*.hhp)|*.hhp|"
 
-#: ../src/html/htmlwin.cpp:681
+#: ../src/html/htmlwin.cpp:691
 #, c-format
 msgid "HTML anchor %s does not exist."
 msgstr "A(z) %s horgony nem létezik."
 
-#: ../src/html/helpwnd.cpp:1547
+#: ../src/html/helpwnd.cpp:1545
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "HTML fájlok (*.html;*.htm)|*.html;*.htm|"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1759
+#: ../src/propgrid/advprops.cpp:1660
 msgid "Hand"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "Harddisk"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:155
+#: ../src/common/fmapbase.cpp:152
 msgid "Hebrew (ISO-8859-8)"
 msgstr "Héber (ISO-8859-8)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:280 ../src/osx/button_osx.cpp:39
-#: ../src/common/stockitem.cpp:163 ../src/common/accelcmn.cpp:80
-#: ../src/html/helpdlg.cpp:66 ../src/html/helpfrm.cpp:111
+#: ../include/wx/msgdlg.h:282 ../src/osx/button_osx.cpp:39
+#: ../src/common/stockitem.cpp:160 ../src/common/accelcmn.cpp:77
+#: ../src/html/helpfrm.cpp:108 ../src/html/helpdlg.cpp:63
 msgid "Help"
 msgstr "Súgó"
 
-#: ../src/html/helpwnd.cpp:1200
+#: ../src/html/helpwnd.cpp:1198
 msgid "Help Browser Options"
 msgstr "Súgó Böngésző beállítások"
 
-#: ../src/generic/helpext.cpp:454 ../src/generic/helpext.cpp:455
+#: ../src/generic/helpext.cpp:452 ../src/generic/helpext.cpp:453
 msgid "Help Index"
 msgstr "Súgó tartalomjegyzék"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1529
 msgid "Help Printing"
 msgstr "Súgó nyomtatás"
 
-#: ../src/html/helpwnd.cpp:801
+#: ../src/html/helpwnd.cpp:799
 msgid "Help Topics"
 msgstr "Súgó témakörök"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1546
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Súgó könyvek (*.htb)|*.htb|Súgó könyvek (*.zip)|*.zip|"
 
-#: ../src/generic/helpext.cpp:267
+#: ../src/generic/helpext.cpp:265
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:275
+#: ../src/generic/helpext.cpp:273
 #, fuzzy, c-format
 msgid "Help file \"%s\" not found."
 msgstr "a(z) '%s' domén konfigurációs fájlját nem találom."
 
-#: ../src/html/helpctrl.cpp:63
+#: ../src/html/helpctrl.cpp:59
 #, c-format
 msgid "Help: %s"
 msgstr "Súgó: %s"
 
-#: ../src/osx/menu_osx.cpp:577
+#: ../src/osx/menu_osx.cpp:469
 #, fuzzy, c-format
 msgid "Hide %s"
 msgstr "Súgó: %s"
 
-#: ../src/osx/menu_osx.cpp:579
+#: ../src/osx/menu_osx.cpp:471
 msgid "Hide Others"
 msgstr ""
 
-#: ../src/generic/infobar.cpp:84
+#: ../src/generic/infobar.cpp:81
 msgid "Hide this notification message."
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:884
+#: ../src/propgrid/advprops.cpp:785
 #, fuzzy
 msgid "Highlight"
 msgstr "vékony"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:885
+#: ../src/propgrid/advprops.cpp:786
 msgid "HighlightText"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:164 ../src/common/accelcmn.cpp:65
+#: ../src/common/stockitem.cpp:161 ../src/common/accelcmn.cpp:62
 msgid "Home"
 msgstr "Haza"
 
-#: ../src/generic/dirctrlg.cpp:524
+#: ../src/generic/dirctrlg.cpp:490
 msgid "Home directory"
 msgstr "Saját könyvtár"
 
@@ -4210,61 +4316,61 @@ msgid "How the object will float relative to the text."
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1760
+#: ../src/propgrid/advprops.cpp:1661
 msgid "I-Beam"
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1196
+#: ../src/common/imagbmp.cpp:1208
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: Hiba a DIB maszk olvasásakor."
 
-#: ../src/common/imagbmp.cpp:1290 ../src/common/imagbmp.cpp:1390
-#: ../src/common/imagbmp.cpp:1405 ../src/common/imagbmp.cpp:1416
-#: ../src/common/imagbmp.cpp:1430 ../src/common/imagbmp.cpp:1478
-#: ../src/common/imagbmp.cpp:1493 ../src/common/imagbmp.cpp:1507
-#: ../src/common/imagbmp.cpp:1518
+#: ../src/common/imagbmp.cpp:1302 ../src/common/imagbmp.cpp:1402
+#: ../src/common/imagbmp.cpp:1417 ../src/common/imagbmp.cpp:1428
+#: ../src/common/imagbmp.cpp:1442 ../src/common/imagbmp.cpp:1490
+#: ../src/common/imagbmp.cpp:1505 ../src/common/imagbmp.cpp:1519
+#: ../src/common/imagbmp.cpp:1530
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: Hiba a kép írásakor!"
 
-#: ../src/common/imagbmp.cpp:1255
+#: ../src/common/imagbmp.cpp:1267
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: A kép túl magas az ikon számára."
 
-#: ../src/common/imagbmp.cpp:1263
+#: ../src/common/imagbmp.cpp:1275
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: A kép túl széles az ikon számára."
 
-#: ../src/common/imagbmp.cpp:1603
+#: ../src/common/imagbmp.cpp:1615
 msgid "ICO: Invalid icon index."
 msgstr "ICO: Hibás icon index."
 
-#: ../src/common/imagiff.cpp:758
+#: ../src/common/imagiff.cpp:755
 msgid "IFF: data stream seems to be truncated."
 msgstr "IFF: az adatfolyam csonkítottnak tűnik."
 
-#: ../src/common/imagiff.cpp:742
+#: ../src/common/imagiff.cpp:739
 msgid "IFF: error in IFF image format."
 msgstr "IFF: hiba a GIFF képformátumban."
 
-#: ../src/common/imagiff.cpp:745
+#: ../src/common/imagiff.cpp:742
 msgid "IFF: not enough memory."
 msgstr "IFF: nincs elég tároló."
 
-#: ../src/common/imagiff.cpp:748
+#: ../src/common/imagiff.cpp:745
 msgid "IFF: unknown error!!!"
 msgstr "IFF: ismeretlen hiba!!!"
 
-#: ../src/common/fmapbase.cpp:197
+#: ../src/common/fmapbase.cpp:194
 msgid "ISO-2022-JP"
 msgstr ""
 
-#: ../src/html/htmprint.cpp:282
+#: ../src/html/htmprint.cpp:294
 msgid ""
 "If possible, try changing the layout parameters to make the printout more "
 "narrow."
 msgstr ""
 
-#: ../src/generic/dbgrptg.cpp:358
+#: ../src/generic/dbgrptg.cpp:362
 msgid ""
 "If you have any additional information pertaining to this bug\n"
 "report, please enter it here and it will be joined to it:"
@@ -4285,46 +4391,50 @@ msgstr ""
 "tehát\n"
 "ha csak lehetséges, kérem folytassa a jelentés előállítását.\n"
 
-#: ../src/msw/registry.cpp:1405
+#: ../src/common/zipstrm.cpp:1043
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1393
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Nem írom be a \"%s\" értéket a \"%s\" kulcsba."
 
-#: ../src/common/xtistrm.cpp:295
+#: ../src/common/xtistrm.cpp:292
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Hibás objektum osztály (Nem-wxEvtHandler) szerepel esemény forrásként"
 
-#: ../src/common/xti.cpp:513
+#: ../src/common/xti.cpp:510
 msgid "Illegal Parameter Count for ConstructObject Method"
 msgstr "A ConstructObject módszer hibás paraméterszámot kapott"
 
-#: ../src/common/xti.cpp:501
+#: ../src/common/xti.cpp:498
 msgid "Illegal Parameter Count for Create Method"
 msgstr "A Create módszer hibás paraméter számot kapott"
 
-#: ../src/generic/dirctrlg.cpp:570 ../src/generic/filectrlg.cpp:756
+#: ../src/generic/dirctrlg.cpp:536 ../src/generic/filectrlg.cpp:752
 msgid "Illegal directory name."
 msgstr "Hibás könyvtár név."
 
-#: ../src/generic/filectrlg.cpp:1367
+#: ../src/generic/filectrlg.cpp:1356
 msgid "Illegal file specification."
 msgstr "Hibás fájl meghatározás."
 
-#: ../src/common/image.cpp:2269
+#: ../src/common/image.cpp:2363
 msgid "Image and mask have different sizes."
 msgstr "A kép és a maszk mérete különböző."
 
-#: ../src/common/image.cpp:2746
+#: ../src/common/image.cpp:2841
 #, fuzzy, c-format
 msgid "Image file is not of type %d."
 msgstr "A kép nem %d típusú."
 
-#: ../src/common/image.cpp:2877
+#: ../src/common/image.cpp:2995
 #, fuzzy, c-format
 msgid "Image is not of type %s."
 msgstr "A kép nem %d típusú."
 
-#: ../src/msw/textctrl.cpp:488
+#: ../src/msw/textctrl.cpp:534
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -4332,105 +4442,105 @@ msgstr ""
 "Nem tudok formázott szövegkontrollt készíteni, egyszerű szövegkontrollt "
 "használok helyette. Kérem installálja újra a riched32.dll fájlt"
 
-#: ../src/unix/utilsunx.cpp:301
+#: ../src/unix/utilsunx.cpp:303
 msgid "Impossible to get child process input"
 msgstr "Nem kapom meg a gyermek processz bemenetét."
 
-#: ../src/common/filefn.cpp:1028
+#: ../src/common/filefn.cpp:917
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Nem kapom meg a '%s' fájl engedélyeit."
 
-#: ../src/common/filefn.cpp:1042
+#: ../src/common/filefn.cpp:931
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Nem sikerült felülírni ni a(z) '%s' fájlt."
 
-#: ../src/common/filefn.cpp:1097
+#: ../src/common/filefn.cpp:986
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Nem lehet beállítani a  '%s' fájl engedélyeit."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:886
+#: ../src/propgrid/advprops.cpp:787
 #, fuzzy
 msgid "InactiveBorder"
 msgstr "Modern"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:887
+#: ../src/propgrid/advprops.cpp:788
 msgid "InactiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:888
+#: ../src/propgrid/advprops.cpp:789
 msgid "InactiveCaptionText"
 msgstr ""
 
-#: ../src/common/gifdecod.cpp:792
+#: ../src/common/gifdecod.cpp:826
 #, c-format
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:635
+#: ../src/msw/ole/automtn.cpp:626
 msgid "Incorrect number of arguments."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:165
+#: ../src/common/stockitem.cpp:162
 msgid "Indent"
 msgstr "Bekezdés"
 
-#: ../src/richtext/richtextformatdlg.cpp:349
+#: ../src/richtext/richtextformatdlg.cpp:342
 msgid "Indents && Spacing"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:166 ../src/html/helpwnd.cpp:515
+#: ../src/common/stockitem.cpp:163 ../src/html/helpwnd.cpp:513
 msgid "Index"
 msgstr "Tartalom mutató"
 
-#: ../src/common/fmapbase.cpp:159
+#: ../src/common/fmapbase.cpp:156
 msgid "Indian (ISO-8859-12)"
 msgstr "Indiai  (ISO-8859-12)"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "Info"
 msgstr ""
 
-#: ../src/common/init.cpp:287
+#: ../src/common/init.cpp:284
 msgid "Initialization failed in post init, aborting."
 msgstr "Az inicializálás utolsó fázisa nem sikerült, kilépek."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:54
+#: ../src/common/accelcmn.cpp:51
 #, fuzzy
 msgid "Ins"
 msgstr "Bekezdés"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextsymboldlg.cpp:472 ../src/common/accelcmn.cpp:53
+#: ../src/common/accelcmn.cpp:50 ../src/richtext/richtextsymboldlg.cpp:469
 #, fuzzy
 msgid "Insert"
 msgstr "Bekezdés"
 
-#: ../src/richtext/richtextbuffer.cpp:8067
+#: ../src/richtext/richtextbuffer.cpp:8063
 #, fuzzy
 msgid "Insert Field"
 msgstr "Bekezdés"
 
-#: ../src/richtext/richtextbuffer.cpp:7978
-#: ../src/richtext/richtextbuffer.cpp:8936
+#: ../src/richtext/richtextbuffer.cpp:7974
+#: ../src/richtext/richtextbuffer.cpp:8934
 msgid "Insert Image"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:8025
+#: ../src/richtext/richtextbuffer.cpp:8021
 #, fuzzy
 msgid "Insert Object"
 msgstr "Bekezdés"
 
-#: ../src/richtext/richtextctrl.cpp:1286 ../src/richtext/richtextctrl.cpp:1494
-#: ../src/richtext/richtextbuffer.cpp:7822
-#: ../src/richtext/richtextbuffer.cpp:7852
-#: ../src/richtext/richtextbuffer.cpp:7894
+#: ../src/richtext/richtextbuffer.cpp:7818
+#: ../src/richtext/richtextbuffer.cpp:7848
+#: ../src/richtext/richtextbuffer.cpp:7890
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
 msgid "Insert Text"
 msgstr ""
 
@@ -4444,16 +4554,11 @@ msgstr ""
 msgid "Inset"
 msgstr "Bekezdés"
 
-#: ../src/gtk/app.cpp:425
-#, c-format
-msgid "Invalid GTK+ command line option, use \"%s --help\""
-msgstr ""
-
-#: ../src/common/imagtiff.cpp:311
+#: ../src/common/imagtiff.cpp:308
 msgid "Invalid TIFF image index."
 msgstr "Hibás TIFF kép index."
 
-#: ../src/common/appcmn.cpp:273
+#: ../src/common/appcmn.cpp:294
 #, c-format
 msgid "Invalid display mode specification '%s'."
 msgstr "Hibás megjelenítési mód meghatározás: '%s'."
@@ -4463,254 +4568,258 @@ msgstr "Hibás megjelenítési mód meghatározás: '%s'."
 msgid "Invalid geometry specification '%s'"
 msgstr "Hibás geometriai meghatározás: '%s'."
 
-#: ../src/unix/fswatcher_inotify.cpp:323
+#: ../src/unix/fswatcher_inotify.cpp:320
 #, c-format
 msgid "Invalid inotify event for \"%s\""
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:312
+#: ../src/unix/snglinst.cpp:309
 #, c-format
 msgid "Invalid lock file '%s'."
 msgstr "Hibás a(z) '%s' lakat fájl."
 
-#: ../src/common/translation.cpp:1125
+#: ../src/common/translation.cpp:1167
 #, fuzzy
 msgid "Invalid message catalog."
 msgstr "'%s' érvénytelen üzenet katalógus."
 
-#: ../src/common/xtistrm.cpp:405 ../src/common/xtistrm.cpp:420
+#: ../src/common/xtistrm.cpp:402 ../src/common/xtistrm.cpp:417
 msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
 msgstr "Érvénytelen vagy Null Object ID-t kapott GetObjectClassInfo"
 
-#: ../src/common/xtistrm.cpp:435
+#: ../src/common/xtistrm.cpp:432
 msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
 msgstr "Érvénytelen vagy Null Object ID-t kapott HasObjectClassInfo"
 
-#: ../src/common/regex.cpp:310
+#: ../src/common/regex.cpp:307
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Hibás szabályos kifejezés '%s': %s"
 
-#: ../src/common/config.cpp:226
+#: ../src/common/config.cpp:222
 #, c-format
 msgid "Invalid value %ld for a boolean key \"%s\" in config file."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:351
-#: ../src/osx/carbon/fontdlg.cpp:361 ../src/common/stockitem.cpp:168
+#: ../src/osx/carbon/fontdlg.cpp:358 ../src/common/stockitem.cpp:165
+#: ../src/generic/fontdlgg.cpp:325 ../src/richtext/richtextfontpage.cpp:351
 msgid "Italic"
 msgstr "Dőlt"
 
-#: ../src/common/paper.cpp:130
+#: ../src/common/paper.cpp:127
 msgid "Italy Envelope, 110 x 230 mm"
 msgstr "Olasz boríték, 110 x 230 mm"
 
-#: ../src/common/imagjpeg.cpp:270
+#: ../src/common/imagjpeg.cpp:257
 msgid "JPEG: Couldn't load - file is probably corrupted."
 msgstr "JPEG: nem tudtam betölteni - a fájl valószínűleg hibás"
 
-#: ../src/common/imagjpeg.cpp:449
+#: ../src/common/imagjpeg.cpp:436
 msgid "JPEG: Couldn't save image."
 msgstr "JPEG: Nem tudtam elmenteni a képet."
 
-#: ../src/common/paper.cpp:163
+#: ../src/common/paper.cpp:160
 msgid "Japanese Double Postcard 200 x 148 mm"
 msgstr "Kétszeres méretű japán levelezőlap 200 x 148 mm"
 
-#: ../src/common/paper.cpp:167
+#: ../src/common/paper.cpp:164
 msgid "Japanese Envelope Chou #3"
 msgstr "Japán chou boríték  #3"
 
-#: ../src/common/paper.cpp:180
+#: ../src/common/paper.cpp:177
 msgid "Japanese Envelope Chou #3 Rotated"
 msgstr "Japán chou boríték #3 elfordított"
 
-#: ../src/common/paper.cpp:168
+#: ../src/common/paper.cpp:165
 msgid "Japanese Envelope Chou #4"
 msgstr "Japán chou boríték #4"
 
-#: ../src/common/paper.cpp:181
+#: ../src/common/paper.cpp:178
 msgid "Japanese Envelope Chou #4 Rotated"
 msgstr "Japán chou boríték #4 elfordított"
 
-#: ../src/common/paper.cpp:165
+#: ../src/common/paper.cpp:162
 msgid "Japanese Envelope Kaku #2"
 msgstr "Japán kaku boríték #2"
 
-#: ../src/common/paper.cpp:178
+#: ../src/common/paper.cpp:175
 msgid "Japanese Envelope Kaku #2 Rotated"
 msgstr "Japán kaku boríték #2 elfordított"
 
-#: ../src/common/paper.cpp:166
+#: ../src/common/paper.cpp:163
 msgid "Japanese Envelope Kaku #3"
 msgstr "Japán kaku boríték #3"
 
-#: ../src/common/paper.cpp:179
+#: ../src/common/paper.cpp:176
 msgid "Japanese Envelope Kaku #3 Rotated"
 msgstr "Japán kaku boríték #3 elfordított"
 
-#: ../src/common/paper.cpp:185
+#: ../src/common/paper.cpp:182
 msgid "Japanese Envelope You #4"
 msgstr "Japán you boríték #4"
 
-#: ../src/common/paper.cpp:186
+#: ../src/common/paper.cpp:183
 msgid "Japanese Envelope You #4 Rotated"
 msgstr "Japán you boríték #4 elfordított"
 
-#: ../src/common/paper.cpp:138
+#: ../src/common/paper.cpp:135
 msgid "Japanese Postcard 100 x 148 mm"
 msgstr "Japán levelezőlap 100 x 148 mm"
 
-#: ../src/common/paper.cpp:175
+#: ../src/common/paper.cpp:172
 msgid "Japanese Postcard Rotated 148 x 100 mm"
 msgstr "Japán levelezőlap 148 x 100 mm c"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "Jump to"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:171
+#: ../src/common/stockitem.cpp:168
 msgid "Justified"
 msgstr "Jóváhagyva"
 
-#: ../src/richtext/richtextindentspage.cpp:155
-#: ../src/richtext/richtextindentspage.cpp:157
 #: ../src/richtext/richtextliststylepage.cpp:344
 #: ../src/richtext/richtextliststylepage.cpp:346
+#: ../src/richtext/richtextindentspage.cpp:155
+#: ../src/richtext/richtextindentspage.cpp:157
 msgid "Justify text left and right."
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:163
+#: ../src/common/fmapbase.cpp:160
 msgid "KOI8-R"
 msgstr "KOI8-R"
 
-#: ../src/common/fmapbase.cpp:164
+#: ../src/common/fmapbase.cpp:161
 msgid "KOI8-U"
 msgstr "KOI8-U"
 
-#: ../src/common/accelcmn.cpp:265 ../src/common/accelcmn.cpp:347
+#: ../src/common/accelcmn.cpp:279 ../src/common/accelcmn.cpp:364
 msgid "KP_"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "KP_Add"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "KP_Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "KP_Decimal"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 #, fuzzy
 msgid "KP_Delete"
 msgstr "&Törlés"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "KP_Divide"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 #, fuzzy
 msgid "KP_Down"
 msgstr "Le"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "KP_End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 #, fuzzy
 msgid "KP_Enter"
 msgstr "Nyomtató"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "KP_Equal"
 msgstr ""
 
+#: ../src/common/accelcmn.cpp:276 ../src/common/accelcmn.cpp:361
+msgid "KP_F"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 #, fuzzy
 msgid "KP_Home"
 msgstr "Haza"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 #, fuzzy
 msgid "KP_Insert"
 msgstr "Bekezdés"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "KP_Left"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "KP_Multiply"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:99
+#: ../src/common/accelcmn.cpp:97
 #, fuzzy
 msgid "KP_Next"
 msgstr "Következő "
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "KP_PageDown"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "KP_PageUp"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:98
+#: ../src/common/accelcmn.cpp:96
 msgid "KP_Prior"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 #, fuzzy
 msgid "KP_Right"
 msgstr "Vékony"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "KP_Separator"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "KP_Space"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "KP_Subtract"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "KP_Tab"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "KP_Up"
 msgstr ""
 
@@ -4718,114 +4827,129 @@ msgstr ""
 msgid "L&ine spacing:"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:613 ../src/generic/prntdlgg.cpp:868
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "tömörítési hiba"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "kifejtési hiba"
+
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:861
 msgid "Landscape"
 msgstr "Tájkép"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 #, fuzzy
 msgid "Last"
 msgstr "&Beillesztés"
 
-#: ../src/common/prntbase.cpp:1572
+#: ../src/common/prntbase.cpp:1597
 #, fuzzy
 msgid "Last page"
 msgstr "Következő oldal"
 
-#: ../src/common/log.cpp:305
+#: ../src/common/log.cpp:324
 #, c-format
 msgid "Last repeated message (\"%s\", %u time) wasn't output"
 msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/common/paper.cpp:103
+#: ../src/common/paper.cpp:100
 msgid "Ledger, 17 x 11 in"
 msgstr "Ledger, 17 x 11 hüvelyk"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6146
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:58 ../src/generic/datavgen.cpp:6951
+#: ../src/richtext/richtextsizepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:252
 #: ../src/richtext/richtextliststylepage.cpp:253
 #: ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
-#: ../src/richtext/richtextsizepage.cpp:249 ../src/common/accelcmn.cpp:61
 msgid "Left"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:204
 #: ../src/richtext/richtextliststylepage.cpp:390
+#: ../src/richtext/richtextindentspage.cpp:204
 msgid "Left (&first line):"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1761
+#: ../src/propgrid/advprops.cpp:1662
 msgid "Left Button"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:880
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Left margin (mm):"
 msgstr "Bal margó (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:141
-#: ../src/richtext/richtextindentspage.cpp:143
 #: ../src/richtext/richtextliststylepage.cpp:330
 #: ../src/richtext/richtextliststylepage.cpp:332
+#: ../src/richtext/richtextindentspage.cpp:141
+#: ../src/richtext/richtextindentspage.cpp:143
 msgid "Left-align text."
 msgstr ""
 
-#: ../src/common/paper.cpp:144
+#: ../src/common/paper.cpp:141
 msgid "Legal Extra 9 1/2 x 15 in"
 msgstr "Jogi extra, 9 1/2 x 15 hüvelyk"
 
-#: ../src/common/paper.cpp:96
+#: ../src/common/paper.cpp:93
 msgid "Legal, 8 1/2 x 14 in"
 msgstr "Jogi, 8 1/2 x 14 hüvelyk"
 
-#: ../src/common/paper.cpp:143
+#: ../src/common/paper.cpp:140
 msgid "Letter Extra 9 1/2 x 12 in"
 msgstr "Levél extra, 9 1/2 x 12 hüvelyk"
 
-#: ../src/common/paper.cpp:149
+#: ../src/common/paper.cpp:146
 msgid "Letter Extra Transverse 9.275 x 12 in"
 msgstr "Levél Extra Transverse 9.275 x 12 in"
 
-#: ../src/common/paper.cpp:152
+#: ../src/common/paper.cpp:149
 msgid "Letter Plus 8 1/2 x 12.69 in"
 msgstr "Levél plusz, 8 1/2 x 12.69 hüvelyk"
 
-#: ../src/common/paper.cpp:169
+#: ../src/common/paper.cpp:166
 msgid "Letter Rotated 11 x 8 1/2 in"
 msgstr "Levél 11 x 8 1/2 hüvelyk, elfordított"
 
-#: ../src/common/paper.cpp:101
+#: ../src/common/paper.cpp:98
 msgid "Letter Small, 8 1/2 x 11 in"
 msgstr "Kisméretű levél, 8 1/2 x 11 hüvelyk"
 
-#: ../src/common/paper.cpp:147
+#: ../src/common/paper.cpp:144
 msgid "Letter Transverse 8 1/2 x 11 in"
 msgstr "Levél Transverse 8 1/2 x 11 in"
 
-#: ../src/common/paper.cpp:95
+#: ../src/common/paper.cpp:92
 msgid "Letter, 8 1/2 x 11 in"
 msgstr "Levél, 8 1/2 x 11 hüvelyk"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "License"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:332
+#: ../src/generic/fontdlgg.cpp:328
 msgid "Light"
 msgstr "Vékony"
 
-#: ../src/propgrid/advprops.cpp:1608
+#: ../src/propgrid/advprops.cpp:1514
 msgid "Lime"
 msgstr ""
 
-#: ../src/generic/helpext.cpp:294
+#: ../src/generic/helpext.cpp:292
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr ""
@@ -4834,15 +4958,15 @@ msgstr ""
 msgid "Line spacing:"
 msgstr ""
 
-#: ../src/html/chm.cpp:838
+#: ../src/html/chm.cpp:829
 msgid "Link contained '//', converted to absolute link."
 msgstr "A mutató '//'-t tartalmazott, abszolút mutatóvá alakítottam."
 
-#: ../src/richtext/richtextformatdlg.cpp:364
+#: ../src/richtext/richtextformatdlg.cpp:357
 msgid "List Style"
 msgstr ""
 
-#: ../src/richtext/richtextstyles.cpp:1064
+#: ../src/richtext/richtextstyles.cpp:1061
 msgid "List styles"
 msgstr ""
 
@@ -4857,26 +4981,26 @@ msgstr ""
 msgid "Lists the available fonts."
 msgstr "Nincsenek tippek, sajnálom!"
 
-#: ../src/common/fldlgcmn.cpp:340
+#: ../src/common/fldlgcmn.cpp:337
 #, c-format
 msgid "Load %s file"
 msgstr "A(z) %s fájl betöltése"
 
-#: ../src/html/htmlwin.cpp:597
+#: ../src/html/htmlwin.cpp:600
 msgid "Loading : "
 msgstr "Betöltés : "
 
-#: ../src/unix/snglinst.cpp:246
+#: ../src/unix/snglinst.cpp:243
 #, c-format
 msgid "Lock file '%s' has incorrect owner."
 msgstr "A(z) '%s' lezáró fájl tulajdonosa hibás."
 
-#: ../src/unix/snglinst.cpp:251
+#: ../src/unix/snglinst.cpp:248
 #, c-format
 msgid "Lock file '%s' has incorrect permissions."
 msgstr "A(z) '%s' lezáró file hozzáférése hibás."
 
-#: ../src/generic/logg.cpp:576
+#: ../src/generic/logg.cpp:573
 #, c-format
 msgid "Log saved to the file '%s'."
 msgstr "A naplót a(z) '%s' fájl-ba mentettem."
@@ -4891,11 +5015,11 @@ msgstr ""
 msgid "Lower case roman numerals"
 msgstr ""
 
-#: ../src/gtk/mdi.cpp:422 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk1/mdi.cpp:431 ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "MDI gyermek"
 
-#: ../src/msw/helpchm.cpp:56
+#: ../src/msw/helpchm.cpp:53
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -4903,194 +5027,194 @@ msgstr ""
 "A MS HTML funkciók nem használhatók, mert a MS HTML Help könyvtár nincs "
 "installálva ezen a gépen. Kérem installálja."
 
-#: ../src/univ/themes/win32.cpp:3754
+#: ../src/univ/themes/win32.cpp:3751
 msgid "Ma&ximize"
 msgstr "Ma&ximalizál"
 
-#: ../src/common/fmapbase.cpp:203
+#: ../src/common/fmapbase.cpp:200
 msgid "MacArabic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:222
+#: ../src/common/fmapbase.cpp:219
 msgid "MacArmenian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:211
+#: ../src/common/fmapbase.cpp:208
 msgid "MacBengali"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:217
+#: ../src/common/fmapbase.cpp:214
 msgid "MacBurmese"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:236
+#: ../src/common/fmapbase.cpp:233
 msgid "MacCeltic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:227
+#: ../src/common/fmapbase.cpp:224
 msgid "MacCentralEurRoman"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:223
+#: ../src/common/fmapbase.cpp:220
 msgid "MacChineseSimp"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:201
+#: ../src/common/fmapbase.cpp:198
 msgid "MacChineseTrad"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:233
+#: ../src/common/fmapbase.cpp:230
 msgid "MacCroatian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:206
+#: ../src/common/fmapbase.cpp:203
 msgid "MacCyrillic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:207
+#: ../src/common/fmapbase.cpp:204
 msgid "MacDevanagari"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:231
+#: ../src/common/fmapbase.cpp:228
 msgid "MacDingbats"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:226
+#: ../src/common/fmapbase.cpp:223
 msgid "MacEthiopic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:229
+#: ../src/common/fmapbase.cpp:226
 msgid "MacExtArabic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:237
+#: ../src/common/fmapbase.cpp:234
 msgid "MacGaelic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:221
+#: ../src/common/fmapbase.cpp:218
 msgid "MacGeorgian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:205
+#: ../src/common/fmapbase.cpp:202
 msgid "MacGreek"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:209
+#: ../src/common/fmapbase.cpp:206
 msgid "MacGujarati"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:208
+#: ../src/common/fmapbase.cpp:205
 msgid "MacGurmukhi"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:204
+#: ../src/common/fmapbase.cpp:201
 msgid "MacHebrew"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:234
+#: ../src/common/fmapbase.cpp:231
 msgid "MacIcelandic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:200
+#: ../src/common/fmapbase.cpp:197
 msgid "MacJapanese"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:214
+#: ../src/common/fmapbase.cpp:211
 msgid "MacKannada"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:238
+#: ../src/common/fmapbase.cpp:235
 msgid "MacKeyboardGlyphs"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:218
+#: ../src/common/fmapbase.cpp:215
 msgid "MacKhmer"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:202
+#: ../src/common/fmapbase.cpp:199
 msgid "MacKorean"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:220
+#: ../src/common/fmapbase.cpp:217
 msgid "MacLaotian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:215
+#: ../src/common/fmapbase.cpp:212
 msgid "MacMalayalam"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:225
+#: ../src/common/fmapbase.cpp:222
 msgid "MacMongolian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:210
+#: ../src/common/fmapbase.cpp:207
 msgid "MacOriya"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:199
+#: ../src/common/fmapbase.cpp:196
 #, fuzzy
 msgid "MacRoman"
 msgstr "Roman"
 
-#: ../src/common/fmapbase.cpp:235
+#: ../src/common/fmapbase.cpp:232
 #, fuzzy
 msgid "MacRomanian"
 msgstr "Roman"
 
-#: ../src/common/fmapbase.cpp:216
+#: ../src/common/fmapbase.cpp:213
 #, fuzzy
 msgid "MacSinhalese"
 msgstr "Kis/nagybetű megkülönböztetés"
 
-#: ../src/common/fmapbase.cpp:230
+#: ../src/common/fmapbase.cpp:227
 #, fuzzy
 msgid "MacSymbol"
 msgstr "&Stílus:"
 
-#: ../src/common/fmapbase.cpp:212
+#: ../src/common/fmapbase.cpp:209
 msgid "MacTamil"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:213
+#: ../src/common/fmapbase.cpp:210
 msgid "MacTelugu"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:219
+#: ../src/common/fmapbase.cpp:216
 msgid "MacThai"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:224
+#: ../src/common/fmapbase.cpp:221
 msgid "MacTibetan"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:232
+#: ../src/common/fmapbase.cpp:229
 msgid "MacTurkish"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:228
+#: ../src/common/fmapbase.cpp:225
 msgid "MacVietnamese"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1762
+#: ../src/propgrid/advprops.cpp:1663
 msgid "Magnifier"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:2143
+#: ../src/propgrid/advprops.cpp:2050
 #, fuzzy
 msgid "Make a selection:"
 msgstr "Kiválasztott"
 
-#: ../src/richtext/richtextformatdlg.cpp:374
+#: ../src/richtext/richtextformatdlg.cpp:367
 #: ../src/richtext/richtextmarginspage.cpp:171
 msgid "Margins"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1595
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Maroon"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:147
+#: ../src/generic/fdrepdlg.cpp:144
 msgid "Match case"
 msgstr "Kis/nagybetű megkülönböztetés"
 
@@ -5104,41 +5228,41 @@ msgstr "Hang&súly:"
 msgid "Max width:"
 msgstr "Helyette:"
 
-#: ../src/unix/mediactrl.cpp:947
+#: ../src/unix/mediactrl.cpp:972
 #, c-format
 msgid "Media playback error: %s"
 msgstr ""
 
-#: ../src/common/fs_mem.cpp:175
+#: ../src/common/fs_mem.cpp:170
 #, c-format
 msgid "Memory VFS already contains file '%s'!"
 msgstr "A VFS memóriában már van '%s' fájl!"
 
 #. TRANSLATORS: Name of keyboard key
 #. TRANSLATORS: Keyword of system colour
-#: ../src/common/accelcmn.cpp:73 ../src/propgrid/advprops.cpp:889
+#: ../src/common/accelcmn.cpp:70 ../src/propgrid/advprops.cpp:790
 msgid "Menu"
 msgstr "Menu"
 
-#: ../src/common/msgout.cpp:124
+#: ../src/common/msgout.cpp:121
 #, fuzzy
 msgid "Message"
 msgstr "%s üzenet"
 
-#: ../src/univ/themes/metal.cpp:168
+#: ../src/univ/themes/metal.cpp:165
 msgid "Metal theme"
 msgstr "Fém bőr"
 
-#: ../src/msw/ole/automtn.cpp:652
+#: ../src/msw/ole/automtn.cpp:643
 msgid "Method or property not found."
 msgstr ""
 
-#: ../src/univ/themes/win32.cpp:3752
+#: ../src/univ/themes/win32.cpp:3749
 msgid "Mi&nimize"
 msgstr "Mi&nimalizál"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1763
+#: ../src/propgrid/advprops.cpp:1664
 msgid "Middle Button"
 msgstr ""
 
@@ -5151,36 +5275,41 @@ msgstr "A betűkészlet hangsúlya."
 msgid "Min width:"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:668
+#: ../src/osx/cocoa/menu.mm:281
+#, fuzzy
+msgid "Minimize"
+msgstr "Mi&nimalizál"
+
+#: ../src/msw/ole/automtn.cpp:659
 msgid "Missing a required parameter."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:324
+#: ../src/generic/fontdlgg.cpp:320
 msgid "Modern"
 msgstr "Modern"
 
-#: ../src/generic/filectrlg.cpp:427
+#: ../src/generic/filectrlg.cpp:423
 msgid "Modified"
 msgstr "Módosítva"
 
-#: ../src/common/module.cpp:133
+#: ../src/common/module.cpp:130
 #, c-format
 msgid "Module \"%s\" initialization failed"
 msgstr "Nem sikerült inicializálni a \"%s\" modult"
 
-#: ../src/common/paper.cpp:131
+#: ../src/common/paper.cpp:128
 msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
 msgstr "Birodalmi boríték, 3 7/8 x 7 1/2 hüvelyk"
 
-#: ../src/msw/fswatcher.cpp:143
+#: ../src/msw/fswatcher.cpp:140
 msgid "Monitoring individual files for changes is not supported currently."
 msgstr ""
 
-#: ../src/generic/editlbox.cpp:172
+#: ../src/generic/editlbox.cpp:160
 msgid "Move down"
 msgstr "Mozgasd lefelé"
 
-#: ../src/generic/editlbox.cpp:171
+#: ../src/generic/editlbox.cpp:155
 msgid "Move up"
 msgstr "Vidd &feljebb"
 
@@ -5194,100 +5323,105 @@ msgstr ""
 msgid "Moves the object to the previous paragraph."
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9966
+#: ../src/richtext/richtextbuffer.cpp:9963
 msgid "Multiple Cell Properties"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:424
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:82
+msgid "Multiply"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:420
 msgid "Name"
 msgstr "Név"
 
-#: ../src/propgrid/advprops.cpp:1596
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Navy"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "Network"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173
 #, fuzzy
 msgid "New"
 msgstr "Ú&j "
 
-#: ../src/richtext/richtextstyledlg.cpp:243
+#: ../src/richtext/richtextstyledlg.cpp:239
 #, fuzzy
 msgid "New &Box Style..."
 msgstr "Új bejegyzés"
 
-#: ../src/richtext/richtextstyledlg.cpp:225
+#: ../src/richtext/richtextstyledlg.cpp:221
 msgid "New &Character Style..."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:237
+#: ../src/richtext/richtextstyledlg.cpp:233
 msgid "New &List Style..."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:231
+#: ../src/richtext/richtextstyledlg.cpp:227
 msgid "New &Paragraph Style..."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:606
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:654
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:820
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:893
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:934
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:602
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:650
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:816
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:889
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:930
+#: ../src/richtext/richtextstyledlg.cpp:935
 #, fuzzy
 msgid "New Style"
 msgstr "Új bejegyzés"
 
-#: ../src/generic/editlbox.cpp:169
+#: ../src/generic/editlbox.cpp:139
 msgid "New item"
 msgstr "Új bejegyzés"
 
-#: ../src/generic/dirdlgg.cpp:297 ../src/generic/dirdlgg.cpp:307
-#: ../src/generic/filectrlg.cpp:618 ../src/generic/filectrlg.cpp:627
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+#: ../src/generic/dirdlgg.cpp:294 ../src/generic/dirdlgg.cpp:304
 msgid "NewName"
 msgstr "ÚjNév"
 
-#: ../src/common/prntbase.cpp:1567 ../src/html/helpwnd.cpp:665
+#: ../src/common/prntbase.cpp:1592 ../src/html/helpwnd.cpp:663
 msgid "Next page"
 msgstr "Következő oldal"
 
-#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:177
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:174
 #: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Nem"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1764
+#: ../src/propgrid/advprops.cpp:1665
 msgid "No Entry"
 msgstr ""
 
-#: ../src/generic/animateg.cpp:150
+#: ../src/generic/animateg.cpp:133
 #, fuzzy, c-format
 msgid "No animation handler for type %ld defined."
 msgstr "%d  típusú képhez nincs kezelő meghatározva."
 
-#: ../src/dfb/bitmap.cpp:642 ../src/dfb/bitmap.cpp:676
+#: ../src/dfb/bitmap.cpp:639 ../src/dfb/bitmap.cpp:673
 #, fuzzy, c-format
 msgid "No bitmap handler for type %d defined."
 msgstr "%d  típusú képhez nincs kezelő meghatározva."
 
-#: ../src/common/utilscmn.cpp:1077
+#: ../src/common/utilscmn.cpp:1095
 msgid "No default application configured for HTML files."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:445
+#: ../src/generic/helpext.cpp:443
 msgid "No entries found."
 msgstr "Nem találtam elemet."
 
-#: ../src/common/fontmap.cpp:421
+#: ../src/common/fontmap.cpp:418
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found,\n"
@@ -5299,7 +5433,7 @@ msgstr ""
 "de a vagylagos '%s' kódolás elérhető.\n"
 "Akarja használni ezt a kódolást  (egyébként másikat kell választania)?"
 
-#: ../src/common/fontmap.cpp:426
+#: ../src/common/fontmap.cpp:423
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found.\n"
@@ -5310,211 +5444,210 @@ msgstr ""
 "Szeretne választani egy jelkészletet ehhez a kódoláshoz\n"
 "(különben az e kódolással készített szöveg nem jelezhető ki helyesen)?"
 
-#: ../src/generic/animateg.cpp:142
+#: ../src/generic/animateg.cpp:125
 #, fuzzy
 msgid "No handler found for animation type."
 msgstr "Ilyen típusú képhez nem találtam kezelőt."
 
-#: ../src/common/image.cpp:2728
+#: ../src/common/image.cpp:2823
 msgid "No handler found for image type."
 msgstr "Ilyen típusú képhez nem találtam kezelőt."
 
-#: ../src/common/image.cpp:2736 ../src/common/image.cpp:2848
-#: ../src/common/image.cpp:2901
+#: ../src/common/image.cpp:2831 ../src/common/image.cpp:2954
+#: ../src/common/image.cpp:3020
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "%d  típusú képhez nincs kezelő meghatározva."
 
-#: ../src/common/image.cpp:2871 ../src/common/image.cpp:2915
+#: ../src/common/image.cpp:2986 ../src/common/image.cpp:3034
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "%s  típusú képhez nincs kezelő meghatározva."
 
-#: ../src/html/helpwnd.cpp:858
+#: ../src/html/helpwnd.cpp:856
 msgid "No matching page found yet"
 msgstr "Még nem találtam egy megfelelő oldalt"
 
-#: ../src/unix/sound.cpp:81
+#: ../src/unix/sound.cpp:78
 msgid "No sound"
 msgstr "Nincs hang"
 
-#: ../src/common/image.cpp:2277 ../src/common/image.cpp:2318
+#: ../src/common/image.cpp:2371 ../src/common/image.cpp:2412
 msgid "No unused colour in image being masked."
 msgstr "A képben nincs maszkolva nem használt szín."
 
-#: ../src/common/image.cpp:3374
-msgid "No unused colour in image."
-msgstr "A képben nincs nem használt szín."
-
-#: ../src/generic/helpext.cpp:302
+#: ../src/generic/helpext.cpp:300
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr ""
 
-#: ../src/richtext/richtextborderspage.cpp:610
 #: ../src/richtext/richtextsizepage.cpp:248
 #: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:610
 #, fuzzy
 msgid "None"
 msgstr "Kész"
 
-#: ../src/common/fmapbase.cpp:157
+#: ../src/common/fmapbase.cpp:154
 msgid "Nordic (ISO-8859-10)"
 msgstr "Északi (ISO-8859-10)"
 
-#: ../src/generic/fontdlgg.cpp:328 ../src/generic/fontdlgg.cpp:331
+#: ../src/generic/fontdlgg.cpp:324 ../src/generic/fontdlgg.cpp:327
 msgid "Normal"
 msgstr "Normál"
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1261
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Normál btű<br>and <u>aláhúzva</u>. "
 
-#: ../src/html/helpwnd.cpp:1205
+#: ../src/html/helpwnd.cpp:1203
 msgid "Normal font:"
 msgstr "Normál jelkészlet:"
 
-#: ../src/propgrid/props.cpp:1128
+#: ../src/propgrid/props.cpp:1115
 #, fuzzy, c-format
 msgid "Not %s"
 msgstr "&Névjegy..."
 
-#: ../include/wx/filename.h:573 ../include/wx/filename.h:578
-#, fuzzy
-msgid "Not available"
-msgstr "Nincs XBM lehetőség!"
+#: ../src/common/secretstore.cpp:168
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/webrequest.cpp:605
+msgid "Not enough free disk space for download."
+msgstr ""
 
 #: ../src/richtext/richtextfontpage.cpp:358
 #, fuzzy
 msgid "Not underlined"
 msgstr "aláhúzott"
 
-#: ../src/common/paper.cpp:115
+#: ../src/common/paper.cpp:112
 msgid "Note, 8 1/2 x 11 in"
 msgstr "Feljegyzés, 8 1/2 x 11 hüvelyk"
 
-#: ../src/generic/notifmsgg.cpp:132
+#: ../src/generic/notifmsgg.cpp:129
 #, fuzzy
 msgid "Notice"
 msgstr "&Megjegyzések:"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "Num *"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "Num +"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "Num ,"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "Num -"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "Num ."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "Num /"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "Num ="
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "Num Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 #, fuzzy
 msgid "Num Delete"
 msgstr "&Törlés"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 #, fuzzy
 msgid "Num Down"
 msgstr "Le"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "Num End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "Num Enter"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 #, fuzzy
 msgid "Num Home"
 msgstr "Haza"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 #, fuzzy
 msgid "Num Insert"
 msgstr "Bekezdés"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num Lock"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "Num Page Down"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "Num Page Up"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 #, fuzzy
 msgid "Num Right"
 msgstr "Vékony"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "Num Space"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "Num Tab"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "Num Up"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "Num left"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num_lock"
 msgstr ""
 
@@ -5523,13 +5656,13 @@ msgstr ""
 msgid "Numbered outline"
 msgstr ""
 
-#: ../include/wx/msgdlg.h:278 ../src/richtext/richtextstyledlg.cpp:297
-#: ../src/common/stockitem.cpp:178 ../src/msw/msgdlg.cpp:454
-#: ../src/msw/msgdlg.cpp:747 ../src/gtk1/fontdlg.cpp:138
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:175
+#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/msgdlg.cpp:741 ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "Ok"
 
-#: ../src/msw/ole/automtn.cpp:692
+#: ../src/msw/ole/automtn.cpp:683
 #, c-format
 msgid "OLE Automation error in %s: %s"
 msgstr ""
@@ -5539,15 +5672,15 @@ msgstr ""
 msgid "Object Properties"
 msgstr "&Tulajdonságok"
 
-#: ../src/msw/ole/automtn.cpp:660
+#: ../src/msw/ole/automtn.cpp:651
 msgid "Object implementation does not support named arguments."
 msgstr ""
 
-#: ../src/common/xtixml.cpp:264
+#: ../src/common/xtixml.cpp:260
 msgid "Objects must have an id attribute"
 msgstr "Az objektumoknak id jellemzúvel is rendelkezniük kell"
 
-#: ../src/propgrid/advprops.cpp:1601
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Olive"
 msgstr ""
 
@@ -5555,65 +5688,70 @@ msgstr ""
 msgid "Opaci&ty:"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:354
+#: ../src/generic/colrdlgg.cpp:374
 msgid "Opacity:"
 msgstr ""
 
-#: ../src/common/docview.cpp:1773 ../src/common/docview.cpp:1815
+#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
 msgid "Open File"
 msgstr "Fájl Megnyitás"
 
-#: ../src/html/helpwnd.cpp:671 ../src/html/helpwnd.cpp:1554
+#: ../src/html/helpwnd.cpp:669 ../src/html/helpwnd.cpp:1552
 msgid "Open HTML document"
 msgstr "Nyisd meg a HTML dokumentumot"
 
-#: ../src/generic/dbgrptg.cpp:163
+#: ../src/common/stockitem.cpp:265
+#, fuzzy
+msgid "Open an existing document"
+msgstr "Nyisd meg a HTML dokumentumot"
+
+#: ../src/generic/dbgrptg.cpp:160
 #, c-format
 msgid "Open file \"%s\""
 msgstr "A(z) \"%s\" fájl megnyitása"
 
-#: ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176
 #, fuzzy
 msgid "Open..."
 msgstr "&Megnyitás..."
 
-#: ../src/unix/glx11.cpp:506 ../src/msw/glcanvas.cpp:592
+#: ../src/msw/glcanvas.cpp:607 ../src/unix/glx11.cpp:513
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr ""
 
-#: ../src/generic/dirctrlg.cpp:599 ../src/generic/dirdlgg.cpp:323
-#: ../src/generic/filectrlg.cpp:642 ../src/generic/filectrlg.cpp:786
+#: ../src/generic/dirctrlg.cpp:565 ../src/generic/filectrlg.cpp:638
+#: ../src/generic/filectrlg.cpp:782 ../src/generic/dirdlgg.cpp:320
 msgid "Operation not permitted."
 msgstr "Ez a művelet nincs megengedve."
 
-#: ../src/common/cmdline.cpp:900
+#: ../src/common/cmdline.cpp:896
 #, fuzzy, c-format
 msgid "Option '%s' can't be negated"
 msgstr "Nem sikerült létrehozni a(z) '%s' könyvtárat"
 
-#: ../src/common/cmdline.cpp:1064
+#: ../src/common/cmdline.cpp:1060
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "A(z) '%s' beállítás egy értéket kér."
 
-#: ../src/common/cmdline.cpp:1147
+#: ../src/common/cmdline.cpp:1143
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "A(z) '%s' beállítása: '%s' nem alakítható át dátummá."
 
-#: ../src/generic/prntdlgg.cpp:618
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Lehetőségek"
 
-#: ../src/propgrid/advprops.cpp:1606
+#: ../src/propgrid/advprops.cpp:1512
 msgid "Orange"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:615 ../src/generic/prntdlgg.cpp:869
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:862
 msgid "Orientation"
 msgstr "Irányultság"
 
-#: ../src/common/windowid.cpp:242
+#: ../src/common/windowid.cpp:237
 msgid "Out of window IDs.  Recommend shutting down application."
 msgstr ""
 
@@ -5626,148 +5764,148 @@ msgstr ""
 msgid "Outset"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:656
+#: ../src/msw/ole/automtn.cpp:647
 msgid "Overflow while coercing argument values."
 msgstr ""
 
-#: ../src/common/imagpcx.cpp:457 ../src/common/imagpcx.cpp:480
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:479
 msgid "PCX: couldn't allocate memory"
 msgstr "PCX: nem tudtam memóriát foglalni"
 
-#: ../src/common/imagpcx.cpp:456
+#: ../src/common/imagpcx.cpp:455
 msgid "PCX: image format unsupported"
 msgstr "PCX: nem támogatott kép formátum"
 
-#: ../src/common/imagpcx.cpp:479
+#: ../src/common/imagpcx.cpp:478
 msgid "PCX: invalid image"
 msgstr "PCX: érvénytelen kép"
 
-#: ../src/common/imagpcx.cpp:442
+#: ../src/common/imagpcx.cpp:441
 msgid "PCX: this is not a PCX file."
 msgstr "PCX: ez nem PCX fájl."
 
-#: ../src/common/imagpcx.cpp:459 ../src/common/imagpcx.cpp:481
+#: ../src/common/imagpcx.cpp:458 ../src/common/imagpcx.cpp:480
 msgid "PCX: unknown error !!!"
 msgstr "PCX: ismeretlen hiba !!!"
 
-#: ../src/common/imagpcx.cpp:458
+#: ../src/common/imagpcx.cpp:457
 msgid "PCX: version number too low"
 msgstr "PCX: túl alacsony verziószám"
 
-#: ../src/common/imagpnm.cpp:91
+#: ../src/common/imagpnm.cpp:89
 msgid "PNM: Couldn't allocate memory."
 msgstr "PNM: nem tudtam memóriát foglalni."
 
-#: ../src/common/imagpnm.cpp:73
+#: ../src/common/imagpnm.cpp:71
 msgid "PNM: File format is not recognized."
 msgstr "PNM: Azonosítalan fájl formátum."
 
-#: ../src/common/imagpnm.cpp:112 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
 #: ../src/common/imagpnm.cpp:156
 msgid "PNM: File seems truncated."
 msgstr "PNM: A fájl csonkítottnak tűnik."
 
-#: ../src/common/paper.cpp:187
+#: ../src/common/paper.cpp:184
 msgid "PRC 16K 146 x 215 mm"
 msgstr "PRC 16K 146 x 215 mm"
 
-#: ../src/common/paper.cpp:200
+#: ../src/common/paper.cpp:197
 msgid "PRC 16K Rotated"
 msgstr "PRC 16K elfordított"
 
-#: ../src/common/paper.cpp:188
+#: ../src/common/paper.cpp:185
 msgid "PRC 32K 97 x 151 mm"
 msgstr "PRC 32K 97 x 151 mm"
 
-#: ../src/common/paper.cpp:201
+#: ../src/common/paper.cpp:198
 msgid "PRC 32K Rotated"
 msgstr "PRC 32K elfordított"
 
-#: ../src/common/paper.cpp:189
+#: ../src/common/paper.cpp:186
 msgid "PRC 32K(Big) 97 x 151 mm"
 msgstr "PRC 32K(Nagy) 97 x 151 mm"
 
-#: ../src/common/paper.cpp:202
+#: ../src/common/paper.cpp:199
 msgid "PRC 32K(Big) Rotated"
 msgstr "PRC 32K(Nagy) elfordított"
 
-#: ../src/common/paper.cpp:190
+#: ../src/common/paper.cpp:187
 msgid "PRC Envelope #1 102 x 165 mm"
 msgstr "PRC Boríték #1 102 x 165 mm"
 
-#: ../src/common/paper.cpp:203
+#: ../src/common/paper.cpp:200
 msgid "PRC Envelope #1 Rotated 165 x 102 mm"
 msgstr "PRC Boríték #1 165 x 102 mm, elfordított"
 
-#: ../src/common/paper.cpp:199
+#: ../src/common/paper.cpp:196
 msgid "PRC Envelope #10 324 x 458 mm"
 msgstr "PRC Boríték #10 324 x 458 mm"
 
-#: ../src/common/paper.cpp:212
+#: ../src/common/paper.cpp:209
 msgid "PRC Envelope #10 Rotated 458 x 324 mm"
 msgstr "PRC Boríték #10 458 x 324 m, elfordított"
 
-#: ../src/common/paper.cpp:191
+#: ../src/common/paper.cpp:188
 msgid "PRC Envelope #2 102 x 176 mm"
 msgstr "PRC Boríték #2 102 x 176 mm"
 
-#: ../src/common/paper.cpp:204
+#: ../src/common/paper.cpp:201
 msgid "PRC Envelope #2 Rotated 176 x 102 mm"
 msgstr "PRC Boríték #2 176 x 102 mm, elfordított"
 
-#: ../src/common/paper.cpp:192
+#: ../src/common/paper.cpp:189
 msgid "PRC Envelope #3 125 x 176 mm"
 msgstr "PRC Boríték #3 125 x 176 mm"
 
-#: ../src/common/paper.cpp:205
+#: ../src/common/paper.cpp:202
 msgid "PRC Envelope #3 Rotated 176 x 125 mm"
 msgstr "PRC Boríték #3 176 x 125 mm, elfordított"
 
-#: ../src/common/paper.cpp:193
+#: ../src/common/paper.cpp:190
 msgid "PRC Envelope #4 110 x 208 mm"
 msgstr "PRC Boríték #4 110 x 208 mm"
 
-#: ../src/common/paper.cpp:206
+#: ../src/common/paper.cpp:203
 msgid "PRC Envelope #4 Rotated 208 x 110 mm"
 msgstr "PRC Boríték #4 208 x 110 mm, elfordított"
 
-#: ../src/common/paper.cpp:194
+#: ../src/common/paper.cpp:191
 msgid "PRC Envelope #5 110 x 220 mm"
 msgstr "PRC Boríték #5 110 x 220 mm"
 
-#: ../src/common/paper.cpp:207
+#: ../src/common/paper.cpp:204
 msgid "PRC Envelope #5 Rotated 220 x 110 mm"
 msgstr "PRC Boríték #5 220 x 110 mm, elfordított"
 
-#: ../src/common/paper.cpp:195
+#: ../src/common/paper.cpp:192
 msgid "PRC Envelope #6 120 x 230 mm"
 msgstr "PRC Boríték #6 120 x 230 mm"
 
-#: ../src/common/paper.cpp:208
+#: ../src/common/paper.cpp:205
 msgid "PRC Envelope #6 Rotated 230 x 120 mm"
 msgstr "PRC Boríték #6 230 x 120 mm, elfordított"
 
-#: ../src/common/paper.cpp:196
+#: ../src/common/paper.cpp:193
 msgid "PRC Envelope #7 160 x 230 mm"
 msgstr "PRC Boríték #7 160 x 230 mm"
 
-#: ../src/common/paper.cpp:209
+#: ../src/common/paper.cpp:206
 msgid "PRC Envelope #7 Rotated 230 x 160 mm"
 msgstr "PRC Boríték #7 230 x 160 mm, elfordított"
 
-#: ../src/common/paper.cpp:197
+#: ../src/common/paper.cpp:194
 msgid "PRC Envelope #8 120 x 309 mm"
 msgstr "PRC Boríték #8 120 x 309 mm"
 
-#: ../src/common/paper.cpp:210
+#: ../src/common/paper.cpp:207
 msgid "PRC Envelope #8 Rotated 309 x 120 mm"
 msgstr "PRC Boríték #8 309 x 120 mm, elfordított"
 
-#: ../src/common/paper.cpp:198
+#: ../src/common/paper.cpp:195
 msgid "PRC Envelope #9 229 x 324 mm"
 msgstr "PRC Boríték #9 229 x 324 mm"
 
-#: ../src/common/paper.cpp:211
+#: ../src/common/paper.cpp:208
 msgid "PRC Envelope #9 Rotated 324 x 229 mm"
 msgstr "PRC Boríték #9 324 x 229 mm, elfordított"
 
@@ -5776,94 +5914,98 @@ msgstr "PRC Boríték #9 324 x 229 mm, elfordított"
 msgid "Padding"
 msgstr "olvasok"
 
-#: ../src/common/prntbase.cpp:2074
+#: ../src/common/prntbase.cpp:2096
 #, c-format
 msgid "Page %d"
 msgstr "%d. oldal"
 
-#: ../src/common/prntbase.cpp:2072
+#: ../src/common/prntbase.cpp:2094
 #, c-format
 msgid "Page %d of %d"
 msgstr "%d. oldal (%d-ből)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 #, fuzzy
 msgid "Page Down"
 msgstr "%d. oldal"
 
-#: ../src/gtk/print.cpp:826
+#: ../src/gtk/print.cpp:829
 msgid "Page Setup"
 msgstr "Oldal beállítás"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 #, fuzzy
 msgid "Page Up"
 msgstr "%d. oldal"
 
-#: ../src/generic/prntdlgg.cpp:828 ../src/common/prntbase.cpp:484
+#: ../src/common/prntbase.cpp:479 ../src/generic/prntdlgg.cpp:821
 msgid "Page setup"
 msgstr "Oldal beállítás "
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 #, fuzzy
 msgid "PageDown"
 msgstr "Le"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 #, fuzzy
 msgid "PageUp"
 msgstr "Oldalak"
 
-#: ../src/generic/prntdlgg.cpp:216
+#: ../src/generic/prntdlgg.cpp:209
 msgid "Pages"
 msgstr "Oldalak"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1765
+#: ../src/propgrid/advprops.cpp:1666
 msgid "Paint Brush"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:602 ../src/generic/prntdlgg.cpp:801
-#: ../src/generic/prntdlgg.cpp:842 ../src/generic/prntdlgg.cpp:855
-#: ../src/generic/prntdlgg.cpp:1052 ../src/generic/prntdlgg.cpp:1057
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:794
+#: ../src/generic/prntdlgg.cpp:835 ../src/generic/prntdlgg.cpp:848
+#: ../src/generic/prntdlgg.cpp:1045 ../src/generic/prntdlgg.cpp:1050
 msgid "Paper size"
 msgstr "Papír méret"
 
-#: ../src/richtext/richtextstyles.cpp:1062
+#: ../src/richtext/richtextstyles.cpp:1059
 msgid "Paragraph styles"
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:465
+#: ../src/common/xtistrm.cpp:462
 msgid "Passing a already registered object to SetObject"
 msgstr "SetObject már regisztrált objektumot kapott"
 
-#: ../src/common/xtistrm.cpp:476
+#: ../src/common/xtistrm.cpp:473
 #, fuzzy
 msgid "Passing an unknown object to GetObject"
 msgstr "GetObject ismeretlen objektumot kapott"
 
-#: ../src/richtext/richtextctrl.cpp:3513 ../src/common/stockitem.cpp:180
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:177 ../src/richtext/richtextctrl.cpp:3514
 #: ../src/stc/stc_i18n.cpp:19
 #, fuzzy
 msgid "Paste"
 msgstr "&Beillesztés"
 
-#: ../src/common/stockitem.cpp:262
+#: ../src/common/stockitem.cpp:260
 #, fuzzy
 msgid "Paste selection"
 msgstr "Kiválasztott"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:74
+#: ../src/common/accelcmn.cpp:71
 msgid "Pause"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1766
+#: ../src/propgrid/advprops.cpp:1667
 msgid "Pencil"
 msgstr ""
 
@@ -5872,21 +6014,21 @@ msgstr ""
 msgid "Peri&od"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:430
+#: ../src/generic/filectrlg.cpp:426
 msgid "Permissions"
 msgstr "Jogosultságok"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:60
+#: ../src/common/accelcmn.cpp:57
 msgid "PgDn"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:59
+#: ../src/common/accelcmn.cpp:56
 msgid "PgUp"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:12868
+#: ../src/richtext/richtextbuffer.cpp:12863
 #, fuzzy
 msgid "Picture Properties"
 msgstr "&Tulajdonságok"
@@ -5899,46 +6041,46 @@ msgstr "A cső létrehozása nem sikerült"
 msgid "Please choose a valid font."
 msgstr "Kérem válasszon egy érvényes jelkészletet."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
 msgid "Please choose an existing file."
 msgstr "Kérem válasszon egy létező fájlt."
 
-#: ../src/html/helpwnd.cpp:800
+#: ../src/html/helpwnd.cpp:798
 msgid "Please choose the page to display:"
 msgstr "Kérem válassza ki a látni kívánt oldalt:"
 
-#: ../src/msw/dialup.cpp:764
+#: ../src/msw/dialup.cpp:758
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Kérem válassza ki, melyik szolgáltatóhoz (ISP) akar kapcsolódni."
 
-#: ../src/common/headerctrlcmn.cpp:59
+#: ../src/common/headerctrlcmn.cpp:57
 msgid "Please select the columns to show and define their order:"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:538
+#: ../src/common/prntbase.cpp:533
 #, fuzzy
 msgid "Please wait while printing..."
 msgstr "Kérem várjon amíg nyomtatok\n"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1767
+#: ../src/propgrid/advprops.cpp:1668
 #, fuzzy
 msgid "Point Left"
 msgstr "Jelkészlet &pontmérete:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1768
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgid "Point Right"
 msgstr "Jobbra igazíts"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:662
+#: ../src/propgrid/advprops.cpp:572
 #, fuzzy
 msgid "Point Size"
 msgstr "Jelkészlet &pontmérete:"
 
-#: ../src/generic/prntdlgg.cpp:612 ../src/generic/prntdlgg.cpp:867
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:860
 msgid "Portrait"
 msgstr "Álló"
 
@@ -5947,158 +6089,168 @@ msgstr "Álló"
 msgid "Position"
 msgstr "Kérdés"
 
-#: ../src/generic/prntdlgg.cpp:298
+#: ../src/generic/prntdlgg.cpp:291
 msgid "PostScript file"
 msgstr "PostScript fájl"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178 ../src/osx/cocoa/preferences.mm:303
 #, fuzzy
 msgid "Preferences"
 msgstr "&Előválasztás"
 
-#: ../src/osx/menu_osx.cpp:568
+#: ../src/osx/menu_osx.cpp:460
 #, fuzzy
 msgid "Preferences..."
 msgstr "&Előválasztás"
 
-#: ../src/common/prntbase.cpp:546
+#: ../src/common/prntbase.cpp:541
 msgid "Preparing"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:455 ../src/osx/carbon/fontdlg.cpp:390
-#: ../src/html/helpwnd.cpp:1222
+#: ../src/osx/carbon/fontdlg.cpp:387 ../src/generic/fontdlgg.cpp:452
+#: ../src/html/helpwnd.cpp:1220
 msgid "Preview:"
 msgstr "Előkép:"
 
-#: ../src/common/prntbase.cpp:1553 ../src/html/helpwnd.cpp:664
+#: ../src/common/prntbase.cpp:1578 ../src/html/helpwnd.cpp:662
 msgid "Previous page"
 msgstr "Előző oldal"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/prntdlgg.cpp:143 ../src/generic/prntdlgg.cpp:157
-#: ../src/common/prntbase.cpp:426 ../src/common/prntbase.cpp:1541
-#: ../src/common/accelcmn.cpp:77 ../src/gtk/print.cpp:620
-#: ../src/gtk/print.cpp:638
+#: ../src/common/prntbase.cpp:421 ../src/common/prntbase.cpp:1566
+#: ../src/common/accelcmn.cpp:74 ../src/generic/prntdlgg.cpp:136
+#: ../src/generic/prntdlgg.cpp:150 ../src/gtk/print.cpp:616
+#: ../src/gtk/print.cpp:634
 msgid "Print"
 msgstr "Nyomtatás"
 
-#: ../include/wx/prntbase.h:399 ../src/common/docview.cpp:1268
+#: ../src/common/docview.cpp:1262
 msgid "Print Preview"
 msgstr "Nyomtatási kép"
 
-#: ../src/common/prntbase.cpp:2015 ../src/common/prntbase.cpp:2057
-#: ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2037 ../src/common/prntbase.cpp:2079
+#: ../src/common/prntbase.cpp:2087
 msgid "Print Preview Failure"
 msgstr "Nyomtatási kép hiba"
 
-#: ../src/generic/prntdlgg.cpp:224
+#: ../src/generic/prntdlgg.cpp:217
 msgid "Print Range"
 msgstr "Nyomtatási tartomány"
 
-#: ../src/generic/prntdlgg.cpp:449
+#: ../src/generic/prntdlgg.cpp:442
 msgid "Print Setup"
 msgstr "Nyomtatási beállítások"
 
-#: ../src/generic/prntdlgg.cpp:621
+#: ../src/generic/prntdlgg.cpp:614
 msgid "Print in colour"
 msgstr "Színes nyomtatás"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/osx/webview_webkit.mm:260
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "Nem tudom elindítani a megjelenítést."
+
+#: ../src/common/stockitem.cpp:179
 #, fuzzy
 msgid "Print previe&w..."
 msgstr "Nyomtatási &kép"
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1256
 #, fuzzy
 msgid "Print preview creation failed."
 msgstr "A cső létrehozása nem sikerült"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/common/stockitem.cpp:179
 #, fuzzy
 msgid "Print preview..."
 msgstr "Nyomtatási elő&kép"
 
-#: ../src/generic/prntdlgg.cpp:630
+#: ../src/generic/prntdlgg.cpp:623
 msgid "Print spooling"
 msgstr "Nyomtatás sorbaállítással"
 
-#: ../src/html/helpwnd.cpp:675
+#: ../src/html/helpwnd.cpp:673
 msgid "Print this page"
 msgstr "Nyomtasd ezt az oldalt"
 
-#: ../src/generic/prntdlgg.cpp:185
+#: ../src/generic/prntdlgg.cpp:178
 msgid "Print to File"
 msgstr "Nyomtatás fájlba"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 #, fuzzy
 msgid "Print..."
 msgstr "&Nyomtatás..."
 
-#: ../src/generic/prntdlgg.cpp:493
+#: ../src/generic/prntdlgg.cpp:486
 msgid "Printer"
 msgstr "Nyomtató"
 
-#: ../src/generic/prntdlgg.cpp:633
+#: ../src/generic/prntdlgg.cpp:626
 msgid "Printer command:"
 msgstr "Nyomtató parancs:"
 
-#: ../src/generic/prntdlgg.cpp:180
+#: ../src/generic/prntdlgg.cpp:173
 msgid "Printer options"
 msgstr "Nyomtató lehetőségek"
 
-#: ../src/generic/prntdlgg.cpp:645
+#: ../src/generic/prntdlgg.cpp:638
 msgid "Printer options:"
 msgstr "Nyomtató lehetőségek:"
 
-#: ../src/generic/prntdlgg.cpp:916
+#: ../src/generic/prntdlgg.cpp:909
 msgid "Printer..."
 msgstr "Nyomtató..."
 
-#: ../src/generic/prntdlgg.cpp:196
+#: ../src/generic/prntdlgg.cpp:189
 msgid "Printer:"
 msgstr "Nyomtató:"
 
-#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:535
-#: ../src/html/htmprint.cpp:277
+#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:530
+#: ../src/html/htmprint.cpp:289
 #, fuzzy
 msgid "Printing"
 msgstr "Nyomtatás"
 
-#: ../src/common/prntbase.cpp:612
+#: ../src/common/prntbase.cpp:607
 msgid "Printing "
 msgstr "Nyomtatás"
 
-#: ../src/common/prntbase.cpp:347
+#: ../src/common/prntbase.cpp:342
 msgid "Printing Error"
 msgstr "Nyomtatási hiba"
 
-#: ../src/common/prntbase.cpp:565
+#: ../src/osx/webview_webkit.mm:251
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "A zlib ezen változata nem támogatja gzip-et"
+
+#: ../src/common/prntbase.cpp:560
 #, fuzzy, c-format
 msgid "Printing page %d"
 msgstr "A(z) %d. oldalt nyomtatom..."
 
-#: ../src/common/prntbase.cpp:570
+#: ../src/common/prntbase.cpp:565
 #, fuzzy, c-format
 msgid "Printing page %d of %d"
 msgstr "A(z) %d. oldalt nyomtatom..."
 
-#: ../src/generic/printps.cpp:201
+#: ../src/generic/printps.cpp:182
 #, c-format
 msgid "Printing page %d..."
 msgstr "A(z) %d. oldalt nyomtatom..."
 
-#: ../src/generic/printps.cpp:161
+#: ../src/generic/printps.cpp:142
 msgid "Printing..."
 msgstr "Nyomtatás..."
 
-#: ../include/wx/richtext/richtextprint.h:109 ../include/wx/prntbase.h:267
-#: ../src/common/docview.cpp:2132
+#: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
+#: ../src/common/docview.cpp:2137
 #, fuzzy
 msgid "Printout"
 msgstr "Nyomtatás"
 
-#: ../src/common/debugrpt.cpp:560
+#: ../src/common/debugrpt.cpp:561
 #, c-format
 msgid ""
 "Processing debug report has failed, leaving the files in \"%s\" directory."
@@ -6106,111 +6258,111 @@ msgstr ""
 "A hibakeresési jelentés feldolgozása nem sikerült, a fájlokat a(z) \"%s\" "
 "könyvtárban hagytam."
 
-#: ../src/common/prntbase.cpp:545
+#: ../src/common/prntbase.cpp:540
 msgid "Progress:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181
 #, fuzzy
 msgid "Properties"
 msgstr "&Tulajdonságok"
 
-#: ../src/propgrid/manager.cpp:237
+#: ../src/propgrid/manager.cpp:223
 #, fuzzy
 msgid "Property"
 msgstr "&Tulajdonságok"
 
 #. TRANSLATORS: Caption of message box displaying any property error
-#: ../src/propgrid/propgrid.cpp:3185 ../src/propgrid/propgrid.cpp:3318
+#: ../src/propgrid/propgrid.cpp:3162 ../src/propgrid/propgrid.cpp:3299
 #, fuzzy
 msgid "Property Error"
 msgstr "Nyomtatási hiba"
 
-#: ../src/propgrid/advprops.cpp:1597
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Purple"
 msgstr ""
 
-#: ../src/common/paper.cpp:112
+#: ../src/common/paper.cpp:109
 msgid "Quarto, 215 x 275 mm"
 msgstr "Quarto, 215 x 275 mm"
 
-#: ../src/generic/logg.cpp:1016
+#: ../src/generic/logg.cpp:1013
 msgid "Question"
 msgstr "Kérdés"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1769
+#: ../src/propgrid/advprops.cpp:1670
 #, fuzzy
 msgid "Question Arrow"
 msgstr "Kérdés"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 #, fuzzy
 msgid "Quit"
 msgstr "&Kilépés"
 
-#: ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:477
 #, fuzzy, c-format
 msgid "Quit %s"
 msgstr "&Kilépés"
 
-#: ../src/common/stockitem.cpp:263
+#: ../src/common/stockitem.cpp:261
 #, fuzzy
 msgid "Quit this program"
 msgstr "Nyomtasd ezt az oldalt"
 
-#: ../src/common/accelcmn.cpp:338
+#: ../src/common/accelcmn.cpp:352
 #, fuzzy
 msgid "RawCtrl+"
 msgstr "ctrl"
 
-#: ../src/common/ffile.cpp:109 ../src/common/ffile.cpp:133
+#: ../src/common/ffile.cpp:107 ../src/common/ffile.cpp:132
 #, c-format
 msgid "Read error on file '%s'"
 msgstr "Olvasási hiba a(z) '%s' fájlban"
 
-#: ../src/common/secretstore.cpp:199
+#: ../src/common/secretstore.cpp:211
 #, fuzzy, c-format
-msgid "Reading password for \"%s/%s\" failed: %s."
+msgid "Reading password for \"%s\" failed: %s."
 msgstr "Nem sikerült kifejteni  '%s'-t '%s'-be"
 
-#: ../src/common/prntbase.cpp:272
+#: ../src/common/prntbase.cpp:267
 msgid "Ready"
 msgstr "Kész"
 
-#: ../src/propgrid/advprops.cpp:1605
+#: ../src/propgrid/advprops.cpp:1511
 #, fuzzy
 msgid "Red"
 msgstr "&Újra"
 
-#: ../src/generic/colrdlgg.cpp:339
+#: ../src/generic/colrdlgg.cpp:359
 msgid "Red:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:185 ../src/stc/stc_i18n.cpp:16
+#: ../src/common/stockitem.cpp:182 ../src/stc/stc_i18n.cpp:16
 #, fuzzy
 msgid "Redo"
 msgstr "&Újra"
 
-#: ../src/common/stockitem.cpp:264
+#: ../src/common/stockitem.cpp:262
 msgid "Redo last action"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:186
+#: ../src/common/stockitem.cpp:183
 msgid "Refresh"
 msgstr "Frissíts"
 
-#: ../src/msw/registry.cpp:626
+#: ../src/msw/registry.cpp:615
 #, c-format
 msgid "Registry key '%s' already exists."
 msgstr "Már létezik a(z) '%s' registry kulcs."
 
-#: ../src/msw/registry.cpp:595
+#: ../src/msw/registry.cpp:584
 #, c-format
 msgid "Registry key '%s' does not exist, cannot rename it."
 msgstr "A(z) '%s' registry kulcs még nem létezik, nem tudom átnevezni."
 
-#: ../src/msw/registry.cpp:727
+#: ../src/msw/registry.cpp:716
 #, c-format
 msgid ""
 "Registry key '%s' is needed for normal system operation,\n"
@@ -6221,22 +6373,22 @@ msgstr ""
 "annak törlése használhatatlanná teszi az Ön rendszerét:\n"
 "a műveletet nem hajtom végre."
 
-#: ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:942
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:917
+#: ../src/msw/registry.cpp:905
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1003
+#: ../src/msw/registry.cpp:991
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:521
+#: ../src/msw/registry.cpp:510
 #, c-format
 msgid "Registry value '%s' already exists."
 msgstr "Már létezik a(z) '%s' registry érték."
@@ -6251,75 +6403,80 @@ msgstr ""
 msgid "Relative"
 msgstr "Dekoratív"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:456
 msgid "Relevant entries:"
 msgstr "A megfelelő tagok:"
 
-#: ../include/wx/generic/progdlgg.h:86
+#: ../include/wx/generic/progdlgg.h:87
 #, fuzzy
 msgid "Remaining time:"
 msgstr "A hátralevő idő : "
 
-#: ../src/common/stockitem.cpp:187
+#: ../src/common/stockitem.cpp:184
 msgid "Remove"
 msgstr "Töröld"
 
-#: ../src/richtext/richtextctrl.cpp:1562
+#: ../src/richtext/richtextctrl.cpp:1563
 #, fuzzy
 msgid "Remove Bullet"
 msgstr "Töröld"
 
-#: ../src/html/helpwnd.cpp:433
+#: ../src/html/helpwnd.cpp:431
 msgid "Remove current page from bookmarks"
 msgstr "Töröld ezt az oldalt a könyvjelzők közül"
 
-#: ../src/common/rendcmn.cpp:194
+#: ../src/common/rendcmn.cpp:191
 #, c-format
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 "A \"%s\" renderer  verziója %d.%d nem megfelelő és ezért nem lehet betölteni."
 
-#: ../src/richtext/richtextbuffer.cpp:4527
+#: ../src/richtext/richtextbuffer.cpp:4524
 msgid "Renumber List"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:188
-msgid "Rep&lace"
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Rep&lace..."
 msgstr "&Helyettesítsd"
 
-#: ../src/richtext/richtextctrl.cpp:3673 ../src/common/stockitem.cpp:188
+#: ../src/richtext/richtextctrl.cpp:3674
 #, fuzzy
 msgid "Replace"
 msgstr "&Helyettesítés"
 
-#: ../src/generic/fdrepdlg.cpp:182
+#: ../src/generic/fdrepdlg.cpp:179
 msgid "Replace &all"
 msgstr "Helyettesítsem &mindet"
 
-#: ../src/common/stockitem.cpp:261
-#, fuzzy
-msgid "Replace selection"
-msgstr "Helyettesítsem &mindet"
-
-#: ../src/generic/fdrepdlg.cpp:124
+#: ../src/generic/fdrepdlg.cpp:121
 msgid "Replace with:"
 msgstr "Helyette:"
 
-#: ../src/common/valtext.cpp:163
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Replace..."
+msgstr "&Helyettesítés"
+
+#: ../src/common/valtext.cpp:184
 msgid "Required information entry is empty."
 msgstr ""
 
-#: ../src/common/translation.cpp:1975
+#: ../src/common/translation.cpp:2025
 #, fuzzy, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "'%s' érvénytelen üzenet katalógus."
 
+#: ../src/gtk/webview_webkit.cpp:985
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:56
+#: ../src/common/accelcmn.cpp:53
 msgid "Return"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:189
+#: ../src/common/stockitem.cpp:186
 msgid "Revert to Saved"
 msgstr "Cseréld vissza az elmentettre"
 
@@ -6332,43 +6489,43 @@ msgstr "Vékony"
 msgid "Rig&ht-to-left"
 msgstr ""
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6149
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:59 ../src/generic/datavgen.cpp:6954
+#: ../src/richtext/richtextsizepage.cpp:250
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextbulletspage.cpp:188
-#: ../src/richtext/richtextsizepage.cpp:250 ../src/common/accelcmn.cpp:62
 #, fuzzy
 msgid "Right"
 msgstr "Vékony"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1754
+#: ../src/propgrid/advprops.cpp:1655
 #, fuzzy
 msgid "Right Arrow"
 msgstr "Vékony"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1770
+#: ../src/propgrid/advprops.cpp:1671
 msgid "Right Button"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:892
+#: ../src/generic/prntdlgg.cpp:885
 msgid "Right margin (mm):"
 msgstr "Jobb margó (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:148
-#: ../src/richtext/richtextindentspage.cpp:150
 #: ../src/richtext/richtextliststylepage.cpp:337
 #: ../src/richtext/richtextliststylepage.cpp:339
+#: ../src/richtext/richtextindentspage.cpp:148
+#: ../src/richtext/richtextindentspage.cpp:150
 msgid "Right-align text."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:322
+#: ../src/generic/fontdlgg.cpp:318
 msgid "Roman"
 msgstr "Roman"
 
-#: ../src/generic/datavgen.cpp:5916
+#: ../src/generic/datavgen.cpp:6721
 #, c-format
 msgid "Row %i"
 msgstr ""
@@ -6378,31 +6535,31 @@ msgstr ""
 msgid "S&tandard bullet name:"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:268 ../src/common/accelcmn.cpp:350
+#: ../src/common/accelcmn.cpp:282 ../src/common/accelcmn.cpp:367
 msgid "SPECIAL"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:190 ../src/common/sizer.cpp:2797
+#: ../src/common/stockitem.cpp:187 ../src/common/sizer.cpp:2914
 msgid "Save"
 msgstr "Mentés"
 
-#: ../src/common/fldlgcmn.cpp:342
+#: ../src/common/fldlgcmn.cpp:339
 #, c-format
 msgid "Save %s file"
 msgstr "A(z) %s fájl elmentése"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/common/stockitem.cpp:188 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "&Mentés másként..."
 
-#: ../src/common/docview.cpp:366
+#: ../src/common/docview.cpp:359
 msgid "Save As"
 msgstr "Mentés Másként"
 
-#: ../src/common/stockitem.cpp:191
+#: ../src/common/stockitem.cpp:188
 #, fuzzy
-msgid "Save as"
-msgstr "Mentés Másként"
+msgid "Save As..."
+msgstr "&Mentés másként..."
 
 #: ../src/common/stockitem.cpp:267
 #, fuzzy
@@ -6413,40 +6570,40 @@ msgstr "Válasszon dokumentum nézetet"
 msgid "Save current document with a different filename"
 msgstr ""
 
-#: ../src/generic/logg.cpp:512
+#: ../src/generic/logg.cpp:509
 msgid "Save log contents to file"
 msgstr "Mentsd a napló tartalmát fájlba"
 
-#: ../src/common/secretstore.cpp:179
+#: ../src/common/secretstore.cpp:189
 #, fuzzy, c-format
-msgid "Saving password for \"%s/%s\" failed: %s."
+msgid "Saving password for \"%s\" failed: %s."
 msgstr "Nem sikerült kifejteni  '%s'-t '%s'-be"
 
-#: ../src/generic/fontdlgg.cpp:325
+#: ../src/generic/fontdlgg.cpp:321
 msgid "Script"
 msgstr "Script"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll Lock"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll_lock"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:890
+#: ../src/propgrid/advprops.cpp:791
 msgid "Scrollbar"
 msgstr ""
 
-#: ../src/generic/srchctlg.cpp:56 ../src/html/helpwnd.cpp:535
-#: ../src/html/helpwnd.cpp:550
+#: ../src/generic/srchctlg.cpp:55 ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:548 ../src/gtk/srchctrl.cpp:182
 msgid "Search"
 msgstr "Keresés"
 
-#: ../src/html/helpwnd.cpp:537
+#: ../src/html/helpwnd.cpp:535
 #, fuzzy
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
@@ -6455,58 +6612,58 @@ msgstr ""
 "Keresd meg a fentebb beírt szöveg valamennyi előfordulását a súgó "
 "könyv(ek)ben"
 
-#: ../src/generic/fdrepdlg.cpp:160
+#: ../src/generic/fdrepdlg.cpp:157
 msgid "Search direction"
 msgstr "Keresési irány"
 
-#: ../src/generic/fdrepdlg.cpp:112
+#: ../src/generic/fdrepdlg.cpp:109
 msgid "Search for:"
 msgstr "Keresés:"
 
-#: ../src/html/helpwnd.cpp:1052
+#: ../src/html/helpwnd.cpp:1050
 msgid "Search in all books"
 msgstr "Keresés az összes könyvben"
 
-#: ../src/html/helpwnd.cpp:857
+#: ../src/html/helpwnd.cpp:855
 msgid "Searching..."
 msgstr "Keresek..."
 
-#: ../src/generic/dirctrlg.cpp:446
+#: ../src/generic/dirctrlg.cpp:412
 msgid "Sections"
 msgstr "Szakaszok"
 
-#: ../src/common/ffile.cpp:238
+#: ../src/common/ffile.cpp:237
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Keresési hiba a(z) '%s' fájlban"
 
-#: ../src/common/ffile.cpp:228
+#: ../src/common/ffile.cpp:227
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
 "Keresési hiba a(z) '%s' fájlban (a nagy fájlokat nem támogatja a stdio)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:76
+#: ../src/common/accelcmn.cpp:73
 #, fuzzy
 msgid "Select"
 msgstr "Kiválasztott"
 
-#: ../src/richtext/richtextctrl.cpp:337 ../src/osx/textctrl_osx.cpp:581
-#: ../src/common/stockitem.cpp:192 ../src/msw/textctrl.cpp:2512
+#: ../src/osx/textctrl_osx.cpp:599 ../src/common/stockitem.cpp:189
+#: ../src/msw/textctrl.cpp:2777 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Válassz ki &minden fájlt"
 
-#: ../src/common/stockitem.cpp:192 ../src/stc/stc_i18n.cpp:21
+#: ../src/common/stockitem.cpp:189 ../src/stc/stc_i18n.cpp:21
 #, fuzzy
 msgid "Select All"
 msgstr "Válassz ki &minden fájlt"
 
-#: ../src/common/docview.cpp:1895
+#: ../src/common/docview.cpp:1900
 msgid "Select a document template"
 msgstr "Válasszon dokumentum mintát"
 
-#: ../src/common/docview.cpp:1969
+#: ../src/common/docview.cpp:1974
 msgid "Select a document view"
 msgstr "Válasszon dokumentum nézetet"
 
@@ -6535,20 +6692,20 @@ msgid "Selects the list level to edit."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:82
+#: ../src/common/accelcmn.cpp:79
 msgid "Separator"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1083
+#: ../src/common/cmdline.cpp:1079
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "A(z) '%s' választási lehetőség után elválasztó jelet vártam."
 
-#: ../src/osx/menu_osx.cpp:572
+#: ../src/osx/menu_osx.cpp:464
 msgid "Services"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11217
+#: ../src/richtext/richtextbuffer.cpp:11216
 #, fuzzy
 msgid "Set Cell Style"
 msgstr "Bejegyzés törlése"
@@ -6557,11 +6714,11 @@ msgstr "Bejegyzés törlése"
 msgid "SetProperty called w/o valid setter"
 msgstr "GetProperty híváskor nincs érvényes küldő"
 
-#: ../src/generic/prntdlgg.cpp:188
+#: ../src/generic/prntdlgg.cpp:181
 msgid "Setup..."
 msgstr "Beállítás..."
 
-#: ../src/msw/dialup.cpp:544
+#: ../src/msw/dialup.cpp:538
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr ""
 "Több aktív telefonkapcsolatot találtam, az egyiket véletlenszerűen "
@@ -6580,44 +6737,44 @@ msgstr ""
 msgid "Shadow c&olour:"
 msgstr "Válasszon színt"
 
-#: ../src/common/accelcmn.cpp:335
+#: ../src/common/accelcmn.cpp:349
 #, fuzzy
 msgid "Shift+"
 msgstr "eltol"
 
-#: ../src/generic/dirdlgg.cpp:147
+#: ../src/generic/dirdlgg.cpp:144
 #, fuzzy
 msgid "Show &hidden directories"
 msgstr "Mutasd meg a rejtett könyvtárokat"
 
-#: ../src/generic/filectrlg.cpp:983
+#: ../src/generic/filectrlg.cpp:979
 #, fuzzy
 msgid "Show &hidden files"
 msgstr "Mutasd meg a rejtett fájlokat"
 
-#: ../src/osx/menu_osx.cpp:580
+#: ../src/osx/menu_osx.cpp:472
 #, fuzzy
 msgid "Show All"
 msgstr "Mutatsd mindet"
 
-#: ../src/common/stockitem.cpp:257
+#: ../src/common/stockitem.cpp:254
 msgid "Show about dialog"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:492
+#: ../src/html/helpwnd.cpp:490
 msgid "Show all"
 msgstr "Mutatsd mindet"
 
-#: ../src/html/helpwnd.cpp:503
+#: ../src/html/helpwnd.cpp:501
 msgid "Show all items in index"
 msgstr "Mutasd meg a tartalom mutató valamennyi elemét"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:656
 msgid "Show/hide navigation panel"
 msgstr "Bemutatja/elrejti az irányító elemeket"
 
-#: ../src/richtext/richtextsymboldlg.cpp:421
-#: ../src/richtext/richtextsymboldlg.cpp:423
+#: ../src/richtext/richtextsymboldlg.cpp:418
+#: ../src/richtext/richtextsymboldlg.cpp:420
 msgid "Shows a Unicode subset."
 msgstr ""
 
@@ -6633,7 +6790,7 @@ msgstr ""
 msgid "Shows a preview of the font settings."
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:394 ../src/osx/carbon/fontdlg.cpp:396
+#: ../src/osx/carbon/fontdlg.cpp:391 ../src/osx/carbon/fontdlg.cpp:393
 msgid "Shows a preview of the font."
 msgstr ""
 
@@ -6642,63 +6799,63 @@ msgstr ""
 msgid "Shows a preview of the paragraph settings."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:460 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:456 ../src/generic/fontdlgg.cpp:458
 msgid "Shows the font preview."
 msgstr "Betűkészlet előkép bemutatás"
 
-#: ../src/propgrid/advprops.cpp:1607
+#: ../src/propgrid/advprops.cpp:1513
 msgid "Silver"
 msgstr ""
 
-#: ../src/univ/themes/mono.cpp:516
+#: ../src/univ/themes/mono.cpp:513
 msgid "Simple monochrome theme"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:275
 #: ../src/richtext/richtextliststylepage.cpp:449
+#: ../src/richtext/richtextindentspage.cpp:275
 msgid "Single"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:425 ../src/richtext/richtextformatdlg.cpp:369
-#: ../src/richtext/richtextsizepage.cpp:299
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextsizepage.cpp:299
+#: ../src/richtext/richtextformatdlg.cpp:362
 msgid "Size"
 msgstr "Méret"
 
-#: ../src/osx/carbon/fontdlg.cpp:339
+#: ../src/osx/carbon/fontdlg.cpp:336
 #, fuzzy
 msgid "Size:"
 msgstr "Méret"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1775
+#: ../src/propgrid/advprops.cpp:1676
 msgid "Sizing"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1772
+#: ../src/propgrid/advprops.cpp:1673
 msgid "Sizing N-S"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1771
+#: ../src/propgrid/advprops.cpp:1672
 msgid "Sizing NE-SW"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1773
+#: ../src/propgrid/advprops.cpp:1674
 msgid "Sizing NW-SE"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1774
+#: ../src/propgrid/advprops.cpp:1675
 msgid "Sizing W-E"
 msgstr ""
 
-#: ../src/msw/progdlg.cpp:801
+#: ../src/msw/progdlg.cpp:1088
 msgid "Skip"
 msgstr "Ugrás"
 
-#: ../src/generic/fontdlgg.cpp:330
+#: ../src/generic/fontdlgg.cpp:326
 msgid "Slant"
 msgstr "Ferde"
 
@@ -6707,7 +6864,7 @@ msgid "Small C&apitals"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:79
+#: ../src/common/accelcmn.cpp:76
 msgid "Snapshot"
 msgstr ""
 
@@ -6716,37 +6873,37 @@ msgstr ""
 msgid "Solid"
 msgstr "Félkövér"
 
-#: ../src/common/docview.cpp:1791
+#: ../src/common/docview.cpp:1785
 msgid "Sorry, could not open this file."
 msgstr "Sajnálom, nem tudtam megnyitni ezt a fájlt."
 
-#: ../src/common/prntbase.cpp:2057 ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2079 ../src/common/prntbase.cpp:2087
 msgid "Sorry, not enough memory to create a preview."
 msgstr "Sajnálom, nincs elég memória az előkép létrehozásához."
 
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "Sorry, that name is taken. Please choose another."
 msgstr ""
 
-#: ../src/common/docview.cpp:1814
+#: ../src/common/docview.cpp:1819
 msgid "Sorry, the format for this file is unknown."
 msgstr "Sajnálom, ezt a fájl formátumot nem ismerem."
 
-#: ../src/unix/sound.cpp:492
+#: ../src/unix/sound.cpp:481
 msgid "Sound data are in unsupported format."
 msgstr "A hang adat ismeretlen formátumban van."
 
-#: ../src/unix/sound.cpp:477
+#: ../src/unix/sound.cpp:466
 #, c-format
 msgid "Sound file '%s' is in unsupported format."
 msgstr "A(z) '%s' hang fájl ismeretlen formátumban van."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:67
+#: ../src/common/accelcmn.cpp:64
 #, fuzzy
 msgid "Space"
 msgstr "Keresek..."
@@ -6756,12 +6913,12 @@ msgstr "Keresek..."
 msgid "Spacing"
 msgstr "Keresek..."
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "Spell Check"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1776
+#: ../src/propgrid/advprops.cpp:1677
 msgid "Spraycan"
 msgstr ""
 
@@ -6770,7 +6927,7 @@ msgstr ""
 msgid "Standard"
 msgstr ""
 
-#: ../src/common/paper.cpp:104
+#: ../src/common/paper.cpp:101
 msgid "Statement, 5 1/2 x 8 1/2 in"
 msgstr "Bejelentés, 5 1/2 x 8 1/2 hüvelyk"
 
@@ -6780,35 +6937,31 @@ msgstr "Bejelentés, 5 1/2 x 8 1/2 hüvelyk"
 msgid "Static"
 msgstr "Állapot:"
 
-#: ../src/generic/prntdlgg.cpp:204
+#: ../src/generic/prntdlgg.cpp:197
 msgid "Status:"
 msgstr "Állapot:"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 #, fuzzy
 msgid "Stop"
 msgstr "&Leállítás"
 
-#: ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196
 msgid "Strikethrough"
 msgstr ""
 
-#: ../src/common/colourcmn.cpp:45
+#: ../src/common/colourcmn.cpp:42
 #, c-format
 msgid "String To Colour : Incorrect colour specification : %s"
 msgstr "Szöveget színné: Helytelen szín meghatározás '%s'"
 
 #. TRANSLATORS: Label of font style
-#: ../src/richtext/richtextformatdlg.cpp:339 ../src/propgrid/advprops.cpp:680
+#: ../src/propgrid/advprops.cpp:590 ../src/richtext/richtextformatdlg.cpp:332
 #, fuzzy
 msgid "Style"
 msgstr "&Stílus:"
 
-#: ../include/wx/richtext/richtextstyledlg.h:46
-msgid "Style Organiser"
-msgstr ""
-
-#: ../src/osx/carbon/fontdlg.cpp:348
+#: ../src/osx/carbon/fontdlg.cpp:345
 #, fuzzy
 msgid "Style:"
 msgstr "&Stílus:"
@@ -6819,7 +6972,7 @@ msgid "Subscrip&t"
 msgstr "Script"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:83
+#: ../src/common/accelcmn.cpp:80
 msgid "Subtract"
 msgstr ""
 
@@ -6828,11 +6981,11 @@ msgstr ""
 msgid "Supe&rscript"
 msgstr "Script"
 
-#: ../src/common/paper.cpp:150
+#: ../src/common/paper.cpp:147
 msgid "SuperA/SuperA/A4 227 x 356 mm"
 msgstr "SuperA/SuperA/A4 227 x 356 mm"
 
-#: ../src/common/paper.cpp:151
+#: ../src/common/paper.cpp:148
 msgid "SuperB/SuperB/A3 305 x 487 mm"
 msgstr "SuperB/SuperB/A3 305 x 487 mm"
 
@@ -6840,7 +6993,7 @@ msgstr "SuperB/SuperB/A3 305 x 487 mm"
 msgid "Suppress hyphe&nation"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:326
+#: ../src/generic/fontdlgg.cpp:322
 msgid "Swiss"
 msgstr "Svájci"
 
@@ -6860,74 +7013,74 @@ msgstr "Normál jelkészlet:"
 msgid "Symbols"
 msgstr "&Stílus:"
 
-#: ../src/common/imagtiff.cpp:369 ../src/common/imagtiff.cpp:382
-#: ../src/common/imagtiff.cpp:741
+#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
+#: ../src/common/imagtiff.cpp:738
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: Nem tudtam memóriát foglalni."
 
-#: ../src/common/imagtiff.cpp:301
+#: ../src/common/imagtiff.cpp:298
 msgid "TIFF: Error loading image."
 msgstr "TIFF: Hiba a kép betöltésekor."
 
-#: ../src/common/imagtiff.cpp:468
+#: ../src/common/imagtiff.cpp:465
 msgid "TIFF: Error reading image."
 msgstr "TIFF: Hiba a kép olvasásakor."
 
-#: ../src/common/imagtiff.cpp:608
+#: ../src/common/imagtiff.cpp:605
 msgid "TIFF: Error saving image."
 msgstr "TIFF: Hiba a kép elmentésekor."
 
-#: ../src/common/imagtiff.cpp:846
+#: ../src/common/imagtiff.cpp:843
 msgid "TIFF: Error writing image."
 msgstr "TIFF: Hiba a kép írásakor."
 
-#: ../src/common/imagtiff.cpp:355
+#: ../src/common/imagtiff.cpp:352
 msgid "TIFF: Image size is abnormally big."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:68
+#: ../src/common/accelcmn.cpp:65
 msgid "Tab"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11498
+#: ../src/richtext/richtextbuffer.cpp:11497
 #, fuzzy
 msgid "Table Properties"
 msgstr "&Tulajdonságok"
 
-#: ../src/common/paper.cpp:145
+#: ../src/common/paper.cpp:142
 msgid "Tabloid Extra 11.69 x 18 in"
 msgstr "Tabloid Extra 11.69 x 18 in"
 
-#: ../src/common/paper.cpp:102
+#: ../src/common/paper.cpp:99
 msgid "Tabloid, 11 x 17 in"
 msgstr "Tabloid, 11 x 17 hüvelyk"
 
-#: ../src/richtext/richtextformatdlg.cpp:354
+#: ../src/richtext/richtextformatdlg.cpp:347
 msgid "Tabs"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1598
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Teal"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:327
+#: ../src/generic/fontdlgg.cpp:323
 msgid "Teletype"
 msgstr "Teletype"
 
-#: ../src/common/docview.cpp:1896
+#: ../src/common/docview.cpp:1901
 msgid "Templates"
 msgstr "Minták"
 
-#: ../src/common/fmapbase.cpp:158
+#: ../src/common/fmapbase.cpp:155
 msgid "Thai (ISO-8859-11)"
 msgstr "Thai (ISO-8859-11)"
 
-#: ../src/common/ftp.cpp:619
+#: ../src/common/ftp.cpp:622
 msgid "The FTP server doesn't support passive mode."
 msgstr "Az FTP kiszolgáló nem támogatja a passzív módot."
 
-#: ../src/common/ftp.cpp:605
+#: ../src/common/ftp.cpp:608
 msgid "The FTP server doesn't support the PORT command."
 msgstr "Az FTP kiszolgáló nem támogatja a PORT parancsot."
 
@@ -6938,8 +7091,8 @@ msgstr "Az FTP kiszolgáló nem támogatja a PORT parancsot."
 msgid "The available bullet styles."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:202
-#: ../src/richtext/richtextstyledlg.cpp:204
+#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:200
 #, fuzzy
 msgid "The available styles."
 msgstr "A betűkészlet stílusa."
@@ -7001,12 +7154,12 @@ msgstr "A jelkészlet mérete."
 msgid "The bullet character."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:443
-#: ../src/richtext/richtextsymboldlg.cpp:445
+#: ../src/richtext/richtextsymboldlg.cpp:440
+#: ../src/richtext/richtextsymboldlg.cpp:442
 msgid "The character code."
 msgstr ""
 
-#: ../src/common/fontmap.cpp:203
+#: ../src/common/fontmap.cpp:200
 #, c-format
 msgid ""
 "The charset '%s' is unknown. You may select\n"
@@ -7017,7 +7170,7 @@ msgstr ""
 "készletet ennek helyettesítésére vagy\n"
 "[Mégsem]-t ha nem helyettesíthető"
 
-#: ../src/msw/ole/dataobj.cpp:394
+#: ../src/msw/ole/dataobj.cpp:402
 #, c-format
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "A(z) '%d' vágólap formátum nem létezik."
@@ -7027,7 +7180,7 @@ msgstr "A(z) '%d' vágólap formátum nem létezik."
 msgid "The default style for the next paragraph."
 msgstr ""
 
-#: ../src/generic/dirdlgg.cpp:202
+#: ../src/generic/dirdlgg.cpp:199
 #, c-format
 msgid ""
 "The directory '%s' does not exist\n"
@@ -7036,7 +7189,7 @@ msgstr ""
 "A '%s' könyvtár nem létezik.\n"
 "Létrehozzam most?"
 
-#: ../src/html/htmprint.cpp:271
+#: ../src/html/htmprint.cpp:283
 #, c-format
 msgid ""
 "The document \"%s\" doesn't fit on the page horizontally and will be "
@@ -7045,7 +7198,7 @@ msgid ""
 "Would you like to proceed with printing it nevertheless?"
 msgstr ""
 
-#: ../src/common/docview.cpp:1202
+#: ../src/common/docview.cpp:1196
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -7054,37 +7207,38 @@ msgstr ""
 "A(z) '%s' fájl nem létezik és nem nyitható meg.\n"
 "A legutóbb használt fájlok listájáról is el van távolítva."
 
-#: ../src/richtext/richtextindentspage.cpp:208
-#: ../src/richtext/richtextindentspage.cpp:210
 #: ../src/richtext/richtextliststylepage.cpp:394
 #: ../src/richtext/richtextliststylepage.cpp:396
+#: ../src/richtext/richtextindentspage.cpp:208
+#: ../src/richtext/richtextindentspage.cpp:210
 #, fuzzy
 msgid "The first line indent."
 msgstr "A jelkészlet mérete."
 
-#: ../src/gtk/utilsgtk.cpp:481
-msgid "The following standard GTK+ options are also supported:\n"
-msgstr ""
+#: ../src/generic/dbgrptg.cpp:318
+#, fuzzy
+msgid "The following debug report will be generated\n"
+msgstr "*** Elkészült a hibakeresésről a jelentés\n"
 
-#: ../src/generic/fontdlgg.cpp:414 ../src/generic/fontdlgg.cpp:416
+#: ../src/generic/fontdlgg.cpp:411 ../src/generic/fontdlgg.cpp:413
 msgid "The font colour."
 msgstr "A betűkészlet színe."
 
-#: ../src/generic/fontdlgg.cpp:375 ../src/generic/fontdlgg.cpp:377
+#: ../src/generic/fontdlgg.cpp:371 ../src/generic/fontdlgg.cpp:373
 msgid "The font family."
 msgstr "A betűkészlet családja."
 
-#: ../src/richtext/richtextsymboldlg.cpp:405
-#: ../src/richtext/richtextsymboldlg.cpp:407
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "The font from which to take the symbol."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:427 ../src/generic/fontdlgg.cpp:429
-#: ../src/generic/fontdlgg.cpp:434 ../src/generic/fontdlgg.cpp:436
+#: ../src/generic/fontdlgg.cpp:424 ../src/generic/fontdlgg.cpp:426
+#: ../src/generic/fontdlgg.cpp:430 ../src/generic/fontdlgg.cpp:432
 msgid "The font point size."
 msgstr "A jelkészlet mérete."
 
-#: ../src/osx/carbon/fontdlg.cpp:343 ../src/osx/carbon/fontdlg.cpp:345
+#: ../src/osx/carbon/fontdlg.cpp:340 ../src/osx/carbon/fontdlg.cpp:342
 #, fuzzy
 msgid "The font size in points."
 msgstr "A jelkészlet mérete."
@@ -7095,15 +7249,15 @@ msgstr "A jelkészlet mérete."
 msgid "The font size units, points or pixels."
 msgstr "A jelkészlet mérete."
 
-#: ../src/generic/fontdlgg.cpp:386 ../src/generic/fontdlgg.cpp:388
+#: ../src/generic/fontdlgg.cpp:382 ../src/generic/fontdlgg.cpp:384
 msgid "The font style."
 msgstr "A betűkészlet stílusa."
 
-#: ../src/generic/fontdlgg.cpp:397 ../src/generic/fontdlgg.cpp:399
+#: ../src/generic/fontdlgg.cpp:393 ../src/generic/fontdlgg.cpp:395
 msgid "The font weight."
 msgstr "A betűkészlet hangsúlya."
 
-#: ../src/common/docview.cpp:1483
+#: ../src/common/docview.cpp:1477
 #, fuzzy, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Nem sikerült létrehozni a(z) '%s' könyvtárat"
@@ -7114,10 +7268,10 @@ msgstr "Nem sikerült létrehozni a(z) '%s' könyvtárat"
 msgid "The horizontal offset."
 msgstr "Csempék &Vízszintesen"
 
-#: ../src/richtext/richtextindentspage.cpp:199
-#: ../src/richtext/richtextindentspage.cpp:201
 #: ../src/richtext/richtextliststylepage.cpp:385
 #: ../src/richtext/richtextliststylepage.cpp:387
+#: ../src/richtext/richtextindentspage.cpp:199
+#: ../src/richtext/richtextindentspage.cpp:201
 #, fuzzy
 msgid "The left indent."
 msgstr "A betűkészlet hangsúlya."
@@ -7142,10 +7296,10 @@ msgstr "A jelkészlet mérete."
 msgid "The left position."
 msgstr "A jelkészlet mérete."
 
-#: ../src/richtext/richtextindentspage.cpp:288
-#: ../src/richtext/richtextindentspage.cpp:290
 #: ../src/richtext/richtextliststylepage.cpp:462
 #: ../src/richtext/richtextliststylepage.cpp:464
+#: ../src/richtext/richtextindentspage.cpp:288
+#: ../src/richtext/richtextindentspage.cpp:290
 msgid "The line spacing."
 msgstr ""
 
@@ -7154,7 +7308,7 @@ msgstr ""
 msgid "The list item number."
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:664
+#: ../src/msw/ole/automtn.cpp:655
 msgid "The locale ID is unknown."
 msgstr ""
 
@@ -7200,19 +7354,19 @@ msgstr "A betűkészlet hangsúlya."
 msgid "The outline level."
 msgstr "Betűkészlet előkép bemutatás"
 
-#: ../src/common/log.cpp:277
+#: ../src/common/log.cpp:296
 #, c-format
 msgid "The previous message repeated %u time."
 msgid_plural "The previous message repeated %u times."
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/common/log.cpp:270
+#: ../src/common/log.cpp:289
 msgid "The previous message repeated once."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:462
-#: ../src/richtext/richtextsymboldlg.cpp:464
+#: ../src/richtext/richtextsymboldlg.cpp:459
+#: ../src/richtext/richtextsymboldlg.cpp:461
 msgid "The range to show."
 msgstr ""
 
@@ -7226,15 +7380,15 @@ msgstr ""
 "magánjellegű információt tartalmaz,\n"
 "szüntesse meg a kijelölését ls az nem fog szerepelni a jelentésben.\n"
 
-#: ../src/common/cmdline.cpp:1254
+#: ../src/common/cmdline.cpp:1250
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "A szükséges '%s' paraméter nincs megadva."
 
-#: ../src/richtext/richtextindentspage.cpp:217
-#: ../src/richtext/richtextindentspage.cpp:219
 #: ../src/richtext/richtextliststylepage.cpp:403
 #: ../src/richtext/richtextliststylepage.cpp:405
+#: ../src/richtext/richtextindentspage.cpp:217
+#: ../src/richtext/richtextindentspage.cpp:219
 msgid "The right indent."
 msgstr ""
 
@@ -7279,16 +7433,16 @@ msgstr ""
 msgid "The shadow spread."
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:267
 #: ../src/richtext/richtextliststylepage.cpp:439
 #: ../src/richtext/richtextliststylepage.cpp:441
+#: ../src/richtext/richtextindentspage.cpp:267
 msgid "The spacing after the paragraph."
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:257
-#: ../src/richtext/richtextindentspage.cpp:259
 #: ../src/richtext/richtextliststylepage.cpp:430
 #: ../src/richtext/richtextliststylepage.cpp:432
+#: ../src/richtext/richtextindentspage.cpp:257
+#: ../src/richtext/richtextindentspage.cpp:259
 msgid "The spacing before the paragraph."
 msgstr ""
 
@@ -7303,13 +7457,13 @@ msgstr "A betűkészlet stílusa."
 msgid "The style on which this style is based."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:214
-#: ../src/richtext/richtextstyledlg.cpp:216
+#: ../src/richtext/richtextstyledlg.cpp:210
+#: ../src/richtext/richtextstyledlg.cpp:212
 #, fuzzy
 msgid "The style preview."
 msgstr "Betűkészlet előkép bemutatás"
 
-#: ../src/msw/ole/automtn.cpp:680
+#: ../src/msw/ole/automtn.cpp:671
 msgid "The system cannot find the file specified."
 msgstr ""
 
@@ -7324,7 +7478,7 @@ msgstr "A jelkészlet mérete."
 msgid "The tab positions."
 msgstr "A jelkészlet mérete."
 
-#: ../src/richtext/richtextctrl.cpp:3098
+#: ../src/richtext/richtextctrl.cpp:3099
 msgid "The text couldn't be saved."
 msgstr "A szöveget nem tudom elmenteni."
 
@@ -7348,7 +7502,7 @@ msgstr "A jelkészlet mérete."
 msgid "The top position."
 msgstr "A jelkészlet mérete."
 
-#: ../src/common/cmdline.cpp:1232
+#: ../src/common/cmdline.cpp:1228
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "A(z) '%s' beállítás értékét meg kell adni."
@@ -7358,7 +7512,7 @@ msgstr "A(z) '%s' beállítás értékét meg kell adni."
 msgid "The value of the corner radius."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:433
+#: ../src/msw/dialup.cpp:427
 #, fuzzy, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -7373,35 +7527,43 @@ msgstr ""
 msgid "The vertical offset."
 msgstr "Nem tudom elindítani a nyomtatást."
 
-#: ../src/richtext/richtextprint.cpp:619 ../src/html/htmprint.cpp:745
+#: ../src/html/htmprint.cpp:749 ../src/richtext/richtextprint.cpp:615
 msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr ""
 "Az oldal beállításakor hiba történt: lehet hogy az alapértelmezett nyomtatót "
 "kellene beállítania."
 
-#: ../src/html/htmprint.cpp:255
+#: ../src/html/htmprint.cpp:267
 msgid ""
 "This document doesn't fit on the page horizontally and will be truncated "
 "when it is printed."
 msgstr ""
 
-#: ../src/common/image.cpp:2854
+#: ../src/common/image.cpp:2963
 #, fuzzy, c-format
 msgid "This is not a %s."
 msgstr "PCX: ez nem PCX fájl."
 
-#: ../src/common/wincmn.cpp:1653
+#: ../src/common/wincmn.cpp:1654
 msgid "This platform does not support background transparency."
 msgstr ""
 
-#: ../src/gtk/window.cpp:4660
+#: ../src/gtk/window.cpp:5664
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
 
-#: ../src/msw/thread.cpp:1240
+#: ../src/gtk/glcanvas.cpp:176
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/msw/thread.cpp:1246
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -7409,13 +7571,13 @@ msgstr ""
 "A szál modul inicializálása nem sikerült: nem tudok értéket tárolni a szál "
 "helyi tárolójába"
 
-#: ../src/unix/threadpsx.cpp:1794
+#: ../src/unix/threadpsx.cpp:1843
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 "A szál modul inicializálása nem sikerült: nem sikerült a szálhoz kulcsot "
 "készíteni"
 
-#: ../src/msw/thread.cpp:1228
+#: ../src/msw/thread.cpp:1234
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -7423,84 +7585,84 @@ msgstr ""
 "A szál modul inicializálása nem sikerült: nem lehet indexet foglalni a szál "
 "helyi tárolájában"
 
-#: ../src/unix/threadpsx.cpp:1043
+#: ../src/unix/threadpsx.cpp:1061
 msgid "Thread priority setting is ignored."
 msgstr "A szál prioritás beállítását elhanyagoltam."
 
-#: ../src/msw/mdi.cpp:176
+#: ../src/msw/mdi.cpp:171
 msgid "Tile &Horizontally"
 msgstr "Csempék &Vízszintesen"
 
-#: ../src/msw/mdi.cpp:177
+#: ../src/msw/mdi.cpp:172
 msgid "Tile &Vertically"
 msgstr "Csempék &Függőlegesen"
 
-#: ../src/common/ftp.cpp:200
+#: ../src/common/ftp.cpp:197
 msgid "Timeout while waiting for FTP server to connect, try passive mode."
 msgstr ""
 "Időkifutás az FTP kiszolgálóhoz való kapcsolódáskor, próbálja meg a passzív "
 "módot."
 
-#: ../src/generic/tipdlg.cpp:201
+#: ../src/generic/tipdlg.cpp:198
 msgid "Tip of the Day"
 msgstr "A Nap Tippje"
 
-#: ../src/generic/tipdlg.cpp:140
+#: ../src/generic/tipdlg.cpp:137
 msgid "Tips not available, sorry!"
 msgstr "Nincsenek tippek, sajnálom!"
 
-#: ../src/generic/prntdlgg.cpp:242
+#: ../src/generic/prntdlgg.cpp:235
 msgid "To:"
 msgstr "Ig:"
 
-#: ../src/richtext/richtextbuffer.cpp:8363
+#: ../src/richtext/richtextbuffer.cpp:8361
 msgid "Too many EndStyle calls!"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:891
+#: ../src/propgrid/advprops.cpp:792
 msgid "Tooltip"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:892
+#: ../src/propgrid/advprops.cpp:793
 msgid "TooltipText"
 msgstr ""
 
-#: ../src/richtext/richtextsizepage.cpp:286
-#: ../src/richtext/richtextsizepage.cpp:290 ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197 ../src/richtext/richtextsizepage.cpp:286
+#: ../src/richtext/richtextsizepage.cpp:290
 #, fuzzy
 msgid "Top"
 msgstr "Ig:"
 
-#: ../src/generic/prntdlgg.cpp:881
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Top margin (mm):"
 msgstr "Felső margó (mm):"
 
-#: ../src/generic/aboutdlgg.cpp:79
+#: ../src/generic/aboutdlgg.cpp:76
 msgid "Translations by "
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:188
+#: ../src/generic/aboutdlgg.cpp:185
 msgid "Translators"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:211
+#: ../src/propgrid/propgrid.cpp:192
 msgid "True"
 msgstr ""
 
-#: ../src/common/fs_mem.cpp:227
+#: ../src/common/fs_mem.cpp:222
 #, c-format
 msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
 msgstr ""
 "Megpróbáltam eltávolítani a(z) '%s' fájlt a VFS tárolóból, de nincs betöltve!"
 
-#: ../src/common/fmapbase.cpp:156
+#: ../src/common/fmapbase.cpp:153
 msgid "Turkish (ISO-8859-9)"
 msgstr "Török (ISO-8859-9)"
 
-#: ../src/generic/filectrlg.cpp:426
+#: ../src/generic/filectrlg.cpp:422
 msgid "Type"
 msgstr "Típus"
 
@@ -7515,37 +7677,37 @@ msgstr "A betűkészlet családja."
 msgid "Type a size in points."
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:676
+#: ../src/msw/ole/automtn.cpp:667
 #, c-format
 msgid "Type mismatch in argument %u."
 msgstr ""
 
-#: ../src/common/xtixml.cpp:356 ../src/common/xtixml.cpp:509
-#: ../src/common/xtistrm.cpp:318
+#: ../src/common/xtixml.cpp:352 ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315
 msgid "Type must have enum - long conversion"
 msgstr "A típust enum-ról long-ra kell alakítani"
 
-#: ../src/propgrid/propgridiface.cpp:401
+#: ../src/propgrid/propgridiface.cpp:385
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
 "\"%s\"."
 msgstr ""
 
-#: ../src/common/paper.cpp:133
+#: ../src/common/paper.cpp:130
 msgid "US Std Fanfold, 14 7/8 x 11 in"
 msgstr "USA standard leporelló, 14 7/8 x 11 hüvelyk"
 
-#: ../src/common/fmapbase.cpp:196
+#: ../src/common/fmapbase.cpp:193
 #, fuzzy
 msgid "US-ASCII"
 msgstr "ASCII"
 
-#: ../src/unix/fswatcher_inotify.cpp:109
+#: ../src/unix/fswatcher_inotify.cpp:106
 msgid "Unable to add inotify watch"
 msgstr ""
 
-#: ../src/unix/fswatcher_kqueue.cpp:136
+#: ../src/unix/fswatcher_kqueue.cpp:153
 msgid "Unable to add kqueue watch"
 msgstr ""
 
@@ -7558,7 +7720,7 @@ msgstr ""
 msgid "Unable to close I/O completion port handle"
 msgstr "Nem sikerült lezárni a file kezelőt."
 
-#: ../src/unix/fswatcher_inotify.cpp:97
+#: ../src/unix/fswatcher_inotify.cpp:94
 #, fuzzy
 msgid "Unable to close inotify instance"
 msgstr "Nem sikerült lezárni a file kezelőt."
@@ -7578,17 +7740,17 @@ msgstr "Nem sikerült lezárni a file kezelőt."
 msgid "Unable to create I/O completion port"
 msgstr "Nem sikerült lérehozni egér mutatót."
 
-#: ../src/msw/fswatcher.cpp:84
+#: ../src/msw/fswatcher.cpp:81
 #, fuzzy
 msgid "Unable to create IOCP worker thread"
 msgstr "Nem sikerült létrehozni az MDI szülő keretet."
 
-#: ../src/unix/fswatcher_inotify.cpp:74
+#: ../src/unix/fswatcher_inotify.cpp:71
 #, fuzzy
 msgid "Unable to create inotify instance"
 msgstr "Nem sikerült létrehozni a DDE láncot"
 
-#: ../src/unix/fswatcher_kqueue.cpp:97
+#: ../src/unix/fswatcher_kqueue.cpp:114
 #, fuzzy
 msgid "Unable to create kqueue instance"
 msgstr "Nem sikerült létrehozni a DDE láncot"
@@ -7597,11 +7759,11 @@ msgstr "Nem sikerült létrehozni a DDE láncot"
 msgid "Unable to dequeue completion packet"
 msgstr ""
 
-#: ../src/unix/fswatcher_kqueue.cpp:185
+#: ../src/unix/fswatcher_kqueue.cpp:202
 msgid "Unable to get events from kqueue"
 msgstr ""
 
-#: ../src/gtk/app.cpp:435
+#: ../src/gtk/app.cpp:431
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr ""
 
@@ -7610,12 +7772,12 @@ msgstr ""
 msgid "Unable to open path '%s'"
 msgstr "Nem tudtam megnyitni a(z) '%s' CHM archive fájlt."
 
-#: ../src/html/htmlwin.cpp:583
+#: ../src/html/htmlwin.cpp:586
 #, c-format
 msgid "Unable to open requested HTML document: %s"
 msgstr "Nem tudom megnyitni a kért %s HTML dokumentumot."
 
-#: ../src/unix/sound.cpp:368
+#: ../src/unix/sound.cpp:365
 msgid "Unable to play sound asynchronously."
 msgstr "Nem tudok aszinkron módon hangot játszani."
 
@@ -7623,65 +7785,65 @@ msgstr "Nem tudok aszinkron módon hangot játszani."
 msgid "Unable to post completion status"
 msgstr ""
 
-#: ../src/unix/fswatcher_inotify.cpp:556
+#: ../src/unix/fswatcher_inotify.cpp:553
 #, fuzzy
 msgid "Unable to read from inotify descriptor"
 msgstr "nem tudok olvasni a(z) %d leíróval megadott fájból"
 
-#: ../src/unix/fswatcher_inotify.cpp:141
+#: ../src/unix/fswatcher_inotify.cpp:138
 #, fuzzy, c-format
 msgid "Unable to remove inotify watch %i"
 msgstr "Nem sikerült létrehozni a DDE láncot"
 
-#: ../src/unix/fswatcher_kqueue.cpp:153
+#: ../src/unix/fswatcher_kqueue.cpp:170
 msgid "Unable to remove kqueue watch"
 msgstr ""
 
-#: ../src/msw/fswatcher.cpp:168
+#: ../src/msw/fswatcher.cpp:165
 #, fuzzy, c-format
 msgid "Unable to set up watch for '%s'"
 msgstr "Nem sikerült megérinteni a(z) '%s't."
 
-#: ../src/msw/fswatcher.cpp:91
+#: ../src/msw/fswatcher.cpp:88
 msgid "Unable to start IOCP worker thread"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:201
+#: ../src/common/stockitem.cpp:198
 msgid "Undelete"
 msgstr "Törlés vissza"
 
-#: ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199
 #, fuzzy
 msgid "Underline"
 msgstr "Alá&húzás"
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/richtext/richtextfontpage.cpp:359 ../src/osx/carbon/fontdlg.cpp:370
-#: ../src/propgrid/advprops.cpp:690
+#: ../src/osx/carbon/fontdlg.cpp:367 ../src/propgrid/advprops.cpp:600
+#: ../src/richtext/richtextfontpage.cpp:359
 #, fuzzy
 msgid "Underlined"
 msgstr "Alá&húzás"
 
-#: ../src/common/stockitem.cpp:203 ../src/stc/stc_i18n.cpp:15
+#: ../src/common/stockitem.cpp:200 ../src/stc/stc_i18n.cpp:15
 #, fuzzy
 msgid "Undo"
 msgstr "&Visszavonás"
 
-#: ../src/common/stockitem.cpp:265
+#: ../src/common/stockitem.cpp:263
 msgid "Undo last action"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1029
+#: ../src/common/cmdline.cpp:1025
 #, fuzzy, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Váratlan '%s' paraméter"
 
-#: ../src/unix/fswatcher_inotify.cpp:274
+#: ../src/unix/fswatcher_inotify.cpp:271
 #, c-format
 msgid "Unexpected event for \"%s\": no matching watch descriptor."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1195
+#: ../src/common/cmdline.cpp:1191
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Váratlan '%s' paraméter"
@@ -7690,51 +7852,51 @@ msgstr "Váratlan '%s' paraméter"
 msgid "Unexpectedly new I/O completion port was created"
 msgstr ""
 
-#: ../src/msw/fswatcher.cpp:70
+#: ../src/msw/fswatcher.cpp:67
 #, fuzzy
 msgid "Ungraceful worker thread termination"
 msgstr "Nem tudom megvárni a szál befejeződését"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:460
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:456
+#: ../src/richtext/richtextsymboldlg.cpp:457
+#: ../src/richtext/richtextsymboldlg.cpp:458
 #, fuzzy
 msgid "Unicode"
 msgstr "&Kikezdés"
 
-#: ../src/common/fmapbase.cpp:185 ../src/common/fmapbase.cpp:191
+#: ../src/common/fmapbase.cpp:182 ../src/common/fmapbase.cpp:188
 msgid "Unicode 16 bit (UTF-16)"
 msgstr "Unicode 16 bit (UTF-16)"
 
-#: ../src/common/fmapbase.cpp:190
+#: ../src/common/fmapbase.cpp:187
 msgid "Unicode 16 bit Big Endian (UTF-16BE)"
 msgstr "Unicode 16 bit Big Endian (UTF-16BE)"
 
-#: ../src/common/fmapbase.cpp:186
+#: ../src/common/fmapbase.cpp:183
 msgid "Unicode 16 bit Little Endian (UTF-16LE)"
 msgstr "Unicode 16 bit Little Endian (UTF-16LE)"
 
-#: ../src/common/fmapbase.cpp:187 ../src/common/fmapbase.cpp:193
+#: ../src/common/fmapbase.cpp:184 ../src/common/fmapbase.cpp:190
 msgid "Unicode 32 bit (UTF-32)"
 msgstr "Unicode 32 bit (UTF-32)"
 
-#: ../src/common/fmapbase.cpp:192
+#: ../src/common/fmapbase.cpp:189
 msgid "Unicode 32 bit Big Endian (UTF-32BE)"
 msgstr "Unicode 32 bit Big Endian (UTF-32BE)"
 
-#: ../src/common/fmapbase.cpp:188
+#: ../src/common/fmapbase.cpp:185
 msgid "Unicode 32 bit Little Endian (UTF-32LE)"
 msgstr "Unicode 32 bit Little Endian (UTF-32LE)"
 
-#: ../src/common/fmapbase.cpp:182
+#: ../src/common/fmapbase.cpp:179
 msgid "Unicode 7 bit (UTF-7)"
 msgstr "Unicode 7 bit (UTF-7)"
 
-#: ../src/common/fmapbase.cpp:183
+#: ../src/common/fmapbase.cpp:180
 msgid "Unicode 8 bit (UTF-8)"
 msgstr "Unicode 8 bit (UTF-8)"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 #, fuzzy
 msgid "Unindent"
 msgstr "&Kikezdés"
@@ -7896,101 +8058,106 @@ msgstr "Nem tudom megvárni a szál befejeződését."
 msgid "Units for this value."
 msgstr "Nem tudom megvárni a szál befejeződését."
 
-#: ../src/generic/progdlgg.cpp:353 ../src/generic/progdlgg.cpp:622
+#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
 #, fuzzy
 msgid "Unknown"
 msgstr "ismeretlen"
 
-#: ../src/msw/dde.cpp:1174
+#: ../src/msw/dde.cpp:1238
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Ismeretlen DDE hiba %08x"
 
-#: ../src/common/xtistrm.cpp:410
+#: ../src/common/xtistrm.cpp:407
 msgid "Unknown Object passed to GetObjectClassInfo"
 msgstr "GetObjectClassInfo ismeretlen objektumot kapott"
 
-#: ../src/common/imagpng.cpp:366
+#: ../src/common/imagpng.cpp:383
 #, fuzzy, c-format
 msgid "Unknown PNG resolution unit %d"
 msgstr "Ismeretlen opció '%s'"
 
-#: ../src/common/xtixml.cpp:327
+#: ../src/common/xtixml.cpp:323
 #, fuzzy, c-format
 msgid "Unknown Property %s"
 msgstr "Ismeretlen tulajdonság %s"
 
-#: ../src/common/imagtiff.cpp:529
+#: ../src/common/imagtiff.cpp:526
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr ""
 
-#: ../src/unix/dlunix.cpp:160
+#: ../src/propgrid/props.cpp:155
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/unix/dlunix.cpp:118
 msgid "Unknown dynamic library error"
 msgstr "Ismeretlen dinamikus könyvtár hiba"
 
-#: ../src/common/fmapbase.cpp:810
+#: ../src/common/fmapbase.cpp:806
 #, c-format
 msgid "Unknown encoding (%d)"
 msgstr "Ismeretlen (%d) kódolás"
 
-#: ../src/msw/ole/automtn.cpp:688
+#: ../src/msw/ole/automtn.cpp:679
 #, fuzzy, c-format
 msgid "Unknown error %08x"
 msgstr "Ismeretlen DDE hiba %08x"
 
-#: ../src/msw/ole/automtn.cpp:647
+#: ../src/msw/ole/automtn.cpp:638
 #, fuzzy
 msgid "Unknown exception"
 msgstr "Ismeretlen opció '%s'"
 
-#: ../src/common/image.cpp:2839
+#: ../src/common/image.cpp:2942
 #, fuzzy
 msgid "Unknown image data format."
 msgstr "adatformátum hiba"
 
-#: ../src/common/cmdline.cpp:914
+#: ../src/common/cmdline.cpp:910
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Ismeretlen hosszú opció '%s'"
 
-#: ../src/msw/ole/automtn.cpp:631
+#: ../src/msw/ole/automtn.cpp:622
 msgid "Unknown name or named argument."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:929 ../src/common/cmdline.cpp:951
+#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Ismeretlen opció '%s'"
 
-#: ../src/common/mimecmn.cpp:225
+#: ../src/common/mimecmn.cpp:221
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "Páratlan '{' a(z) %s mime típus egyik elemében."
 
-#: ../src/common/cmdproc.cpp:262 ../src/common/cmdproc.cpp:288
-#: ../src/common/cmdproc.cpp:308
+#: ../src/common/cmdproc.cpp:255 ../src/common/cmdproc.cpp:281
+#: ../src/common/cmdproc.cpp:301
 msgid "Unnamed command"
 msgstr "Név nélküli parancs"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:413
+#: ../src/propgrid/propgrid.cpp:392
 #, fuzzy
 msgid "Unspecified"
 msgstr "Jóváhagyva"
 
-#: ../src/msw/clipbrd.cpp:311
+#: ../src/msw/clipbrd.cpp:325
 msgid "Unsupported clipboard format."
 msgstr "Nem támogatott vágólap formátum."
 
-#: ../src/common/appcmn.cpp:256
+#: ../src/common/appcmn.cpp:277
 #, c-format
 msgid "Unsupported theme '%s'."
 msgstr "A(z) '%s' bőr nem támogatott."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:205
-#: ../src/common/accelcmn.cpp:63
+#: ../src/common/stockitem.cpp:202 ../src/common/accelcmn.cpp:60
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Up"
 msgstr "Fel"
 
@@ -8004,7 +8171,7 @@ msgstr ""
 msgid "Upper case roman numerals"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1326
+#: ../src/common/cmdline.cpp:1322
 #, c-format
 msgid "Usage: %s"
 msgstr "Használat: %s"
@@ -8013,38 +8180,47 @@ msgstr "Használat: %s"
 msgid "Use &shadow"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:169
-#: ../src/richtext/richtextindentspage.cpp:171
 #: ../src/richtext/richtextliststylepage.cpp:358
 #: ../src/richtext/richtextliststylepage.cpp:360
+#: ../src/richtext/richtextindentspage.cpp:169
+#: ../src/richtext/richtextindentspage.cpp:171
 msgid "Use the current alignment setting."
 msgstr ""
 
-#: ../src/common/valtext.cpp:179
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/gtk/font.cpp:552
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/common/valtext.cpp:142
 msgid "Validation conflict"
 msgstr "Érvényességi ütközés"
 
-#: ../src/propgrid/manager.cpp:238
+#: ../src/propgrid/manager.cpp:224
 msgid "Value"
 msgstr ""
 
-#: ../src/propgrid/props.cpp:386 ../src/propgrid/props.cpp:500
+#: ../src/propgrid/props.cpp:309
 #, c-format
 msgid "Value must be %s or higher."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:417 ../src/propgrid/props.cpp:531
+#: ../src/propgrid/props.cpp:336
 #, c-format
 msgid "Value must be %s or less."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:393 ../src/propgrid/props.cpp:424
-#: ../src/propgrid/props.cpp:507 ../src/propgrid/props.cpp:538
+#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
 #, fuzzy, c-format
 msgid "Value must be between %s and %s."
 msgstr "Adjon meg egy oldalszámot %d és %d között:"
 
-#: ../src/generic/aboutdlgg.cpp:128
+#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
 #, fuzzy
 msgid "Version "
 msgstr "Jogosultságok"
@@ -8055,25 +8231,32 @@ msgstr "Jogosultságok"
 msgid "Vertical alignment."
 msgstr "Nem tudom elindítani a nyomtatást."
 
-#: ../src/generic/filedlgg.cpp:202
+#: ../src/generic/filedlgg.cpp:199
 msgid "View files as a detailed view"
 msgstr "A fájlok bemutatása részletezve"
 
-#: ../src/generic/filedlgg.cpp:200
+#: ../src/generic/filedlgg.cpp:197
 msgid "View files as a list view"
 msgstr "A fájlok bemutatása lista szerűen"
 
-#: ../src/common/docview.cpp:1970
+#: ../src/common/docview.cpp:1975
 msgid "Views"
 msgstr "Nézetek"
 
+#: ../src/gtk/app.cpp:348
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1777
+#: ../src/propgrid/advprops.cpp:1678
 msgid "Wait"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1779
+#: ../src/propgrid/advprops.cpp:1680
 msgid "Wait Arrow"
 msgstr ""
 
@@ -8082,254 +8265,250 @@ msgstr ""
 msgid "Waiting for IO on epoll descriptor %d failed"
 msgstr "Nem sikerült megvárni az alprocessz befejeződését"
 
-#: ../src/common/log.cpp:223
+#: ../src/common/log.cpp:241
 msgid "Warning: "
 msgstr "Figyelmeztetés: "
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1778
+#: ../src/propgrid/advprops.cpp:1679
 msgid "Watch"
 msgstr ""
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:685
+#: ../src/propgrid/advprops.cpp:595
 #, fuzzy
 msgid "Weight"
 msgstr "Hang&súly:"
 
-#: ../src/common/fmapbase.cpp:148
+#: ../src/common/fmapbase.cpp:145
 msgid "Western European (ISO-8859-1)"
 msgstr "Nyugat-európai (ISO-8859-1)"
 
-#: ../src/common/fmapbase.cpp:162
+#: ../src/common/fmapbase.cpp:159
 msgid "Western European with Euro (ISO-8859-15)"
 msgstr "Nyugat-európai Euro-val (ISO-8859-15)"
 
-#: ../src/generic/fontdlgg.cpp:446 ../src/generic/fontdlgg.cpp:448
+#: ../src/generic/fontdlgg.cpp:443 ../src/generic/fontdlgg.cpp:445
 msgid "Whether the font is underlined."
 msgstr "Hogy aláhúzza-e a betűket."
 
-#: ../src/propgrid/advprops.cpp:1611
+#: ../src/propgrid/advprops.cpp:1517
 msgid "White"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:144
+#: ../src/generic/fdrepdlg.cpp:141
 msgid "Whole word"
 msgstr "Egész szó"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:532
 msgid "Whole words only"
 msgstr "Csak egész szavak"
 
-#: ../src/univ/themes/win32.cpp:1102
+#: ../src/univ/themes/win32.cpp:1099
 msgid "Win32 theme"
 msgstr "Win32 bőr"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:893
+#: ../src/propgrid/advprops.cpp:794
 #, fuzzy
 msgid "Window"
 msgstr "&Ablak"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:894
+#: ../src/propgrid/advprops.cpp:795
 #, fuzzy
 msgid "WindowFrame"
 msgstr "&Ablak"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:895
+#: ../src/propgrid/advprops.cpp:796
 #, fuzzy
 msgid "WindowText"
 msgstr "&Ablak"
 
-#: ../src/common/fmapbase.cpp:177
+#: ../src/common/fmapbase.cpp:174
 msgid "Windows Arabic (CP 1256)"
 msgstr "Windows Arab (CP 1256)"
 
-#: ../src/common/fmapbase.cpp:178
+#: ../src/common/fmapbase.cpp:175
 msgid "Windows Baltic (CP 1257)"
 msgstr "Windows Balti (CP 1257)"
 
-#: ../src/common/fmapbase.cpp:171
+#: ../src/common/fmapbase.cpp:168
 msgid "Windows Central European (CP 1250)"
 msgstr "Windows Közép-európai (CP 1250)"
 
-#: ../src/common/fmapbase.cpp:168
+#: ../src/common/fmapbase.cpp:165
 #, fuzzy
 msgid "Windows Chinese Simplified (CP 936) or GB-2312"
 msgstr "Windows egyszerűsített kínai (CP 936)"
 
-#: ../src/common/fmapbase.cpp:170
+#: ../src/common/fmapbase.cpp:167
 #, fuzzy
 msgid "Windows Chinese Traditional (CP 950) or Big-5"
 msgstr "Windows hagyományos kínai (CP 950)"
 
-#: ../src/common/fmapbase.cpp:172
+#: ../src/common/fmapbase.cpp:169
 msgid "Windows Cyrillic (CP 1251)"
 msgstr "Windows Orosz (CP 1251)"
 
-#: ../src/common/fmapbase.cpp:174
+#: ../src/common/fmapbase.cpp:171
 msgid "Windows Greek (CP 1253)"
 msgstr "Windows Görög (CP 1253)"
 
-#: ../src/common/fmapbase.cpp:176
+#: ../src/common/fmapbase.cpp:173
 msgid "Windows Hebrew (CP 1255)"
 msgstr "Windows Héber (CP 1255)"
 
-#: ../src/common/fmapbase.cpp:167
+#: ../src/common/fmapbase.cpp:164
 #, fuzzy
 msgid "Windows Japanese (CP 932) or Shift-JIS"
 msgstr "Windows japán (CP 932)"
 
-#: ../src/common/fmapbase.cpp:180
+#: ../src/common/fmapbase.cpp:177
 #, fuzzy
 msgid "Windows Johab (CP 1361)"
 msgstr "Windows Arab (CP 1256)"
 
-#: ../src/common/fmapbase.cpp:169
+#: ../src/common/fmapbase.cpp:166
 msgid "Windows Korean (CP 949)"
 msgstr "Windows koreai (CP 949)"
 
-#: ../src/common/fmapbase.cpp:166
+#: ../src/common/fmapbase.cpp:163
 msgid "Windows Thai (CP 874)"
 msgstr "Windows Thai (CP 874)"
 
-#: ../src/common/fmapbase.cpp:175
+#: ../src/common/fmapbase.cpp:172
 msgid "Windows Turkish (CP 1254)"
 msgstr "Windows Török (CP 1254)"
 
-#: ../src/common/fmapbase.cpp:179
+#: ../src/common/fmapbase.cpp:176
 #, fuzzy
 msgid "Windows Vietnamese (CP 1258)"
 msgstr "Windows Görög (CP 1253)"
 
-#: ../src/common/fmapbase.cpp:173
+#: ../src/common/fmapbase.cpp:170
 msgid "Windows Western European (CP 1252)"
 msgstr "Windows Nyugat-európai (CP 1252)"
 
-#: ../src/common/fmapbase.cpp:181
+#: ../src/common/fmapbase.cpp:178
 msgid "Windows/DOS OEM (CP 437)"
 msgstr "Windows/DOS OEM (CP 437)"
 
-#: ../src/common/fmapbase.cpp:165
+#: ../src/common/fmapbase.cpp:162
 #, fuzzy
 msgid "Windows/DOS OEM Cyrillic (CP 866)"
 msgstr "Windows Orosz (CP 1251)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:111
+#: ../src/common/accelcmn.cpp:109
 #, fuzzy
 msgid "Windows_Left"
 msgstr "Windows 95"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:113
+#: ../src/common/accelcmn.cpp:111
 #, fuzzy
 msgid "Windows_Menu"
 msgstr "Windows ME"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:112
+#: ../src/common/accelcmn.cpp:110
 #, fuzzy
 msgid "Windows_Right"
 msgstr "Windows 95"
 
-#: ../src/common/ffile.cpp:150
+#: ../src/common/ffile.cpp:149
 #, c-format
 msgid "Write error on file '%s'"
 msgstr "Irási hiba a(z) '%s' fájlban"
 
-#: ../src/xml/xml.cpp:914
+#: ../src/xml/xml.cpp:925
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "XML értelmezési hiba: '%s' a(z) %d sorban"
 
-#: ../src/common/xpmdecod.cpp:796
+#: ../src/common/xpmdecod.cpp:794
 msgid "XPM: Malformed pixel data!"
 msgstr "XPM: Hiányos pixel adat!"
 
-#: ../src/common/xpmdecod.cpp:705
+#: ../src/common/xpmdecod.cpp:702
 #, fuzzy, c-format
 msgid "XPM: incorrect colour description in line %d"
 msgstr "XPM: hiányos szín meghatározás '%s'!"
 
-#: ../src/common/xpmdecod.cpp:680
+#: ../src/common/xpmdecod.cpp:677
 msgid "XPM: incorrect header format!"
 msgstr ""
 
-#: ../src/common/xpmdecod.cpp:716 ../src/common/xpmdecod.cpp:725
+#: ../src/common/xpmdecod.cpp:714 ../src/common/xpmdecod.cpp:723
 #, fuzzy, c-format
 msgid "XPM: malformed colour definition '%s' at line %d!"
 msgstr "XPM: hiányos szín meghatározás '%s'!"
 
-#: ../src/common/xpmdecod.cpp:755
+#: ../src/common/xpmdecod.cpp:753
 msgid "XPM: no colors left to use for mask!"
 msgstr ""
 
-#: ../src/common/xpmdecod.cpp:782
+#: ../src/common/xpmdecod.cpp:780
 #, c-format
 msgid "XPM: truncated image data at line %d!"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1610
+#: ../src/propgrid/advprops.cpp:1516
 msgid "Yellow"
 msgstr ""
 
-#: ../include/wx/msgdlg.h:276 ../src/common/stockitem.cpp:206
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:203
 #: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Igen"
 
-#: ../src/osx/carbon/overlay.cpp:155
-#, fuzzy
-msgid "You cannot Clear an overlay that is not inited"
-msgstr "Nem tud könyvtárat hozzáadni ehhez a szakaszhoz."
-
-#: ../src/osx/carbon/overlay.cpp:107 ../src/dfb/overlay.cpp:61
-msgid "You cannot Init an overlay twice"
-msgstr ""
-
-#: ../src/generic/dirdlgg.cpp:287
+#: ../src/generic/dirdlgg.cpp:284
 msgid "You cannot add a new directory to this section."
 msgstr "Nem tud könyvtárat hozzáadni ehhez a szakaszhoz."
 
-#: ../src/propgrid/propgrid.cpp:3299
+#: ../src/propgrid/propgrid.cpp:3276
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:209
+#: ../src/osx/cocoa/menu.mm:286
+#, fuzzy
+msgid "Zoom"
+msgstr "&Nagyítás"
+
+#: ../src/common/stockitem.cpp:206
 msgid "Zoom &In"
 msgstr "&Nagyítás"
 
-#: ../src/common/stockitem.cpp:210
+#: ../src/common/stockitem.cpp:207
 msgid "Zoom &Out"
 msgstr "&Kicsinyítés"
 
-#: ../src/common/stockitem.cpp:209 ../src/common/prntbase.cpp:1594
+#: ../src/common/stockitem.cpp:206 ../src/common/prntbase.cpp:1619
 #, fuzzy
 msgid "Zoom In"
 msgstr "&Nagyítás"
 
-#: ../src/common/stockitem.cpp:210 ../src/common/prntbase.cpp:1580
+#: ../src/common/stockitem.cpp:207 ../src/common/prntbase.cpp:1605
 #, fuzzy
 msgid "Zoom Out"
 msgstr "&Kicsinyítés"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to &Fit"
 msgstr "&Ablakméretű nagyítás"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 #, fuzzy
 msgid "Zoom to Fit"
 msgstr "&Ablakméretű nagyítás"
 
-#: ../src/msw/dde.cpp:1141
+#: ../src/msw/dde.cpp:1205
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "a DDEML alkalmazás meghosszabított versenyhelyzetet teremtett."
 
-#: ../src/msw/dde.cpp:1129
+#: ../src/msw/dde.cpp:1193
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -8341,40 +8520,40 @@ msgstr ""
 "vagy érvénytelen instance azonosítót \n"
 "adott át a DDEML függvénynek."
 
-#: ../src/msw/dde.cpp:1147
+#: ../src/msw/dde.cpp:1211
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "nem sikerült az ügyfél próbálkozása a párbeszéd létrehozására."
 
-#: ../src/msw/dde.cpp:1144
+#: ../src/msw/dde.cpp:1208
 msgid "a memory allocation failed."
 msgstr "a memória lefoglalása nem sikerült."
 
-#: ../src/msw/dde.cpp:1138
+#: ../src/msw/dde.cpp:1202
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "a paramétert nem sikerült érvényesíttetni a DDEML-lel."
 
-#: ../src/msw/dde.cpp:1120
+#: ../src/msw/dde.cpp:1184
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "a szinkron tanácskérési tranzakció nem fejeződött be időre."
 
-#: ../src/msw/dde.cpp:1126
+#: ../src/msw/dde.cpp:1190
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "a szinkron adatkérési tranzakció nem fejeződött be időre."
 
-#: ../src/msw/dde.cpp:1135
+#: ../src/msw/dde.cpp:1199
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "a szinkron végrehajtás kérési tranzakció nem fejeződött be időre."
 
-#: ../src/msw/dde.cpp:1153
+#: ../src/msw/dde.cpp:1217
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "a szinkron adatlerakás kérési tranzakció nem fejeződött be időre."
 
-#: ../src/msw/dde.cpp:1168
+#: ../src/msw/dde.cpp:1232
 msgid "a request to end an advise transaction has timed out."
 msgstr ""
 "a  tanácskozási tranzakció befejezésének kérése nem fejeződött be időre."
 
-#: ../src/msw/dde.cpp:1162
+#: ../src/msw/dde.cpp:1226
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -8384,15 +8563,15 @@ msgstr ""
 "amelyiket az ügyfél már befejezett, vagy a kiszolgáló\n"
 "a tranzakció befejezése előtt kilépett."
 
-#: ../src/msw/dde.cpp:1150
+#: ../src/msw/dde.cpp:1214
 msgid "a transaction failed."
 msgstr "sikertelen tranzakció."
 
-#: ../src/common/accelcmn.cpp:189
+#: ../src/common/accelcmn.cpp:188
 msgid "alt"
 msgstr "alt"
 
-#: ../src/msw/dde.cpp:1132
+#: ../src/msw/dde.cpp:1196
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -8404,15 +8583,15 @@ msgstr ""
 "vagy  APPCMD_CLIENTONLY-ként inicializált alkalmazás\n"
 "próbált meg kiszolgáló tranzakciót végezni."
 
-#: ../src/msw/dde.cpp:1156
+#: ../src/msw/dde.cpp:1220
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "egy belső PostMessage függvényhívás nem sikerült. "
 
-#: ../src/msw/dde.cpp:1165
+#: ../src/msw/dde.cpp:1229
 msgid "an internal error has occurred in the DDEML."
 msgstr "belső hiba történt a DDEML-ben."
 
-#: ../src/msw/dde.cpp:1171
+#: ../src/msw/dde.cpp:1235
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -8422,58 +8601,58 @@ msgstr ""
 "Ha az alkalmazás visszatért egy XTYP_XACT_COMPLETE visszahívásból,\n"
 "a tranzakció azonosítója erre a hívásra már nem érvényes."
 
-#: ../src/common/zipstrm.cpp:1483
+#: ../src/common/zipstrm.cpp:1522
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "azt hiszem ez egy több-részes zip egymás után pakolva"
 
-#: ../src/common/fileconf.cpp:1847
+#: ../src/common/fileconf.cpp:1849
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr ""
 "elhanyagoltam a változtathatatlan '%s' kulcs megváltoztatására tett "
 "kísérletét."
 
-#: ../src/html/chm.cpp:329
+#: ../src/html/chm.cpp:326
 msgid "bad arguments to library function"
 msgstr "hibás argumentumok a könyvtári függvényben"
 
-#: ../src/html/chm.cpp:341
+#: ../src/html/chm.cpp:338
 msgid "bad signature"
 msgstr "hibás aláírás"
 
-#: ../src/common/zipstrm.cpp:1918
+#: ../src/common/zipstrm.cpp:1988
 msgid "bad zipfile offset to entry"
 msgstr "hibás zip-fájl offset"
 
-#: ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400
 msgid "binary"
 msgstr "bináris"
 
-#: ../src/common/fontcmn.cpp:996
+#: ../src/common/fontcmn.cpp:1195
 msgid "bold"
 msgstr "félkövér"
 
-#: ../src/msw/utils.cpp:1144
+#: ../src/msw/utils.cpp:1135
 #, fuzzy, c-format
 msgid "build %lu"
 msgstr "Windows XP (build %lu"
 
-#: ../src/common/ffile.cpp:75
+#: ../src/common/ffile.cpp:73
 #, c-format
 msgid "can't close file '%s'"
 msgstr "nem tudom lezárni a(z) '%s' fájlt."
 
-#: ../src/common/file.cpp:245
+#: ../src/common/file.cpp:242
 #, c-format
 msgid "can't close file descriptor %d"
 msgstr "nem tudom lezárni a(z) %d fájl leírót"
 
-#: ../src/common/file.cpp:586
+#: ../src/common/ffile.cpp:382 ../src/common/file.cpp:613
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "nem tudom érvényre juttatni a(z) '%s' fájl változásait"
 
-#: ../src/common/file.cpp:178
+#: ../src/common/file.cpp:175
 #, c-format
 msgid "can't create file '%s'"
 msgstr "nem tudom létrehozni a(z) '%s' fájl-t"
@@ -8483,54 +8662,54 @@ msgstr "nem tudom létrehozni a(z) '%s' fájl-t"
 msgid "can't delete user configuration file '%s'"
 msgstr "nem tudom törölni a(z) '%s' felhasználói konfigurációs fájlt"
 
-#: ../src/common/file.cpp:495
+#: ../src/common/file.cpp:522
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr ""
 "nem tudom meghatározni, hogy a fájl végét értük-e el a(z) %d leíróval "
 "megadott fájlban"
 
-#: ../src/common/zipstrm.cpp:1692
+#: ../src/common/zipstrm.cpp:1747
 msgid "can't find central directory in zip"
 msgstr "nem találom a fő könyvtárat a zip-ben"
 
-#: ../src/common/file.cpp:465
+#: ../src/common/file.cpp:492
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr ""
 "nem tudom meghatározni a fájl hosszát a(z) %d leíróval megadott fájlban"
 
-#: ../src/msw/utils.cpp:341
+#: ../src/msw/utils.cpp:336
 msgid "can't find user's HOME, using current directory."
 msgstr ""
 "nem tudom meghatározni a felhasználó saját könyvtárát, a jelenlegit "
 "használom tovább."
 
-#: ../src/common/file.cpp:366
+#: ../src/common/file.cpp:407
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "nem tudom kiüríteni a(z) %d leíróval megadott fájl pufferét"
 
-#: ../src/common/file.cpp:422
+#: ../src/common/file.cpp:463
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "nem találom a keresési pozíciót a(z) %d leíróval megadott fájlban"
 
-#: ../src/common/fontmap.cpp:325
+#: ../src/common/fontmap.cpp:322
 msgid "can't load any font, aborting"
 msgstr "egyetlen jelkészletet sem tudok betölteni, kilépek"
 
-#: ../src/common/file.cpp:231 ../src/common/ffile.cpp:59
+#: ../src/common/ffile.cpp:57 ../src/common/file.cpp:228
 #, c-format
 msgid "can't open file '%s'"
 msgstr "nem tudom megnyitni a(z) '%s' fájlt"
 
-#: ../src/common/fileconf.cpp:320
+#: ../src/common/fileconf.cpp:314
 #, c-format
 msgid "can't open global configuration file '%s'."
 msgstr "nem tudom megnyitni a(z) '%s' globális konfigurációs fájlt."
 
-#: ../src/common/fileconf.cpp:336
+#: ../src/common/fileconf.cpp:330
 #, c-format
 msgid "can't open user configuration file '%s'."
 msgstr "nem tudom megnyitni a(z) '%s' felhasználói konfigurációs fájlt."
@@ -8539,40 +8718,40 @@ msgstr "nem tudom megnyitni a(z) '%s' felhasználói konfigurációs fájlt."
 msgid "can't open user configuration file."
 msgstr "nem tudom megnyitni a felhasználó konfigurációs fájlját."
 
-#: ../src/common/zipstrm.cpp:579
+#: ../src/common/zipstrm.cpp:572
 msgid "can't re-initialize zlib deflate stream"
 msgstr "Nem tudom megkezdenii a zlib folyam kifejtését."
 
-#: ../src/common/zipstrm.cpp:604
+#: ../src/common/zipstrm.cpp:597
 msgid "can't re-initialize zlib inflate stream"
 msgstr "Nem tudom elindítani a zlib folyam tömörítését."
 
-#: ../src/common/file.cpp:304
+#: ../src/common/file.cpp:345
 #, c-format
 msgid "can't read from file descriptor %d"
 msgstr "nem tudok olvasni a(z) %d leíróval megadott fájból"
 
-#: ../src/common/file.cpp:581
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:608
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "nem tudom eltávolítani a(z) '%s' fájlt"
 
-#: ../src/common/file.cpp:598
+#: ../src/common/ffile.cpp:394 ../src/common/file.cpp:625
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "nem tudom eltávolítani a(z) '%s' átmeneti fájlt"
 
-#: ../src/common/file.cpp:408
+#: ../src/common/file.cpp:449
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "nem tudok keresni a(z) %d leíróval megadott fájlban"
 
-#: ../src/common/textfile.cpp:273
+#: ../src/common/textfile.cpp:161
 #, c-format
 msgid "can't write buffer '%s' to disk."
 msgstr "nem tudom a mágneslemezre írni a(z) '%s' puffert."
 
-#: ../src/common/file.cpp:323
+#: ../src/common/file.cpp:364
 #, c-format
 msgid "can't write to file descriptor %d"
 msgstr "nem tudok írni a(z) %d leíróval megadott fájba"
@@ -8582,22 +8761,28 @@ msgid "can't write user configuration file."
 msgstr "nem tudom írni a felhasználó konfigurációs fájlját."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:482 ../src/generic/datavgen.cpp:1261
+#: ../src/common/datavcmn.cpp:2064 ../src/generic/datavgen.cpp:1384
 msgid "checked"
 msgstr ""
 
-#: ../src/html/chm.cpp:345
+#: ../src/html/chm.cpp:342
 msgid "checksum error"
 msgstr "hibás ellenőrző összeg"
 
-#: ../src/common/tarstrm.cpp:820
+#: ../src/common/tarstrm.cpp:814
 msgid "checksum failure reading tar header block"
 msgstr ""
 
-#: ../src/richtext/richtextbackgroundpage.cpp:226
-#: ../src/richtext/richtextbackgroundpage.cpp:249
-#: ../src/richtext/richtextbackgroundpage.cpp:289
-#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
 #: ../src/richtext/richtextborderspage.cpp:254
 #: ../src/richtext/richtextborderspage.cpp:288
 #: ../src/richtext/richtextborderspage.cpp:322
@@ -8615,105 +8800,128 @@ msgstr ""
 #: ../src/richtext/richtextmarginspage.cpp:340
 #: ../src/richtext/richtextmarginspage.cpp:363
 #: ../src/richtext/richtextmarginspage.cpp:388
-#: ../src/richtext/richtextsizepage.cpp:339
-#: ../src/richtext/richtextsizepage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:400
-#: ../src/richtext/richtextsizepage.cpp:427
-#: ../src/richtext/richtextsizepage.cpp:454
-#: ../src/richtext/richtextsizepage.cpp:481
-#: ../src/richtext/richtextsizepage.cpp:555
-#: ../src/richtext/richtextsizepage.cpp:590
-#: ../src/richtext/richtextsizepage.cpp:625
-#: ../src/richtext/richtextsizepage.cpp:660
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
 msgid "cm"
 msgstr ""
 
-#: ../src/html/chm.cpp:347
+#: ../src/html/chm.cpp:344
 msgid "compression error"
 msgstr "tömörítési hiba"
 
-#: ../src/common/regex.cpp:236
+#: ../src/common/regex.cpp:233
 msgid "conversion to 8-bit encoding failed"
 msgstr "nem sikerült 8 bites kódolásúvá alakítani"
 
-#: ../src/common/accelcmn.cpp:187
+#: ../src/common/accelcmn.cpp:186
 msgid "ctrl"
 msgstr "ctrl"
 
-#: ../src/common/cmdline.cpp:1500
+#: ../src/common/cmdline.cpp:1496
 msgid "date"
 msgstr "dátum"
 
-#: ../src/html/chm.cpp:349
+#: ../src/html/chm.cpp:346
 msgid "decompression error"
 msgstr "kifejtési hiba"
 
-#: ../src/richtext/richtextstyles.cpp:780 ../src/common/fmapbase.cpp:820
+#: ../src/common/fmapbase.cpp:816 ../src/richtext/richtextstyles.cpp:777
 msgid "default"
 msgstr "alapértelmezés"
 
-#: ../src/common/cmdline.cpp:1496
+#: ../src/common/cmdline.cpp:1492
 msgid "double"
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:538
+#: ../src/common/debugrpt.cpp:539
 msgid "dump of the process state (binary)"
 msgstr "a folyamat állapotának (bináris) nyomtatása"
 
-#: ../src/common/datetimefmt.cpp:1969
+#: ../src/common/datetimefmt.cpp:1992
 msgid "eighteenth"
 msgstr "tizennyolcadik"
 
-#: ../src/common/datetimefmt.cpp:1959
+#: ../src/common/datetimefmt.cpp:1982
 msgid "eighth"
 msgstr "nyolcadik"
 
-#: ../src/common/datetimefmt.cpp:1962
+#: ../src/common/datetimefmt.cpp:1985
 msgid "eleventh"
 msgstr "tizenegyedik"
 
-#: ../src/common/fileconf.cpp:1833
+#: ../src/common/fileconf.cpp:1835
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "a(z) '%s' elem egynél többször jelenik meg a(z) '%s' csoportban"
 
-#: ../src/html/chm.cpp:343
+#: ../src/html/chm.cpp:340
 msgid "error in data format"
 msgstr "adatformátum hiba"
 
-#: ../src/html/chm.cpp:331
+#: ../src/html/chm.cpp:328
 msgid "error opening file"
 msgstr "fájl megnyitási hiba"
 
-#: ../src/common/zipstrm.cpp:1778
+#: ../src/common/zipstrm.cpp:1836
 msgid "error reading zip central directory"
 msgstr "hiba a zip fő könyvtár olvasásakor"
 
-#: ../src/common/zipstrm.cpp:1870
+#: ../src/common/zipstrm.cpp:1940
 msgid "error reading zip local header"
 msgstr "hiba a zip lokális fejrészének olvasásakor"
 
-#: ../src/common/zipstrm.cpp:2531
+#: ../src/common/zipstrm.cpp:2615
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "hiba a(z) '%s' zip adat írásakor: hibás crc vagy hossz"
 
-#: ../src/common/ffile.cpp:188
+#: ../src/common/zipstrm.cpp:2608
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "hiba a(z) '%s' zip adat írásakor: hibás crc vagy hossz"
+
+#: ../src/common/fontcmn.cpp:1205
+#, fuzzy
+msgid "extrabold"
+msgstr "félkövér"
+
+#: ../src/common/fontcmn.cpp:1223
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1167
+#, fuzzy
+msgid "extralight"
+msgstr "vékony"
+
+#: ../src/msw/webview_ie.cpp:1036
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "Nem sikerült végrehajtani '%s'-t\n"
+
+#: ../src/common/ffile.cpp:187
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "nem sikerült kiüríteni a(z) '%s' fájl pufferét"
 
+#: ../src/msw/webview_ie.cpp:1045
+#, fuzzy
+msgid "failed to retrieve execution result"
+msgstr "Nem sikerült értelmezni a RAS hibaüzenet szövegét."
+
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1030
+#: ../src/generic/datavgen.cpp:1150
 #, fuzzy
 msgid "false"
 msgstr "Fájl"
 
-#: ../src/common/datetimefmt.cpp:1966
+#: ../src/common/datetimefmt.cpp:1989
 msgid "fifteenth"
 msgstr "tizenötödik"
 
-#: ../src/common/datetimefmt.cpp:1956
+#: ../src/common/datetimefmt.cpp:1979
 msgid "fifth"
 msgstr "ötödik"
 
@@ -8744,133 +8952,152 @@ msgstr ""
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "'%s' fájl: a(z) %c nem várt jel a(z) %d sorban."
 
-#: ../src/richtext/richtextbuffer.cpp:8738
+#: ../src/richtext/richtextbuffer.cpp:8736
 #, fuzzy
 msgid "files"
 msgstr "Fájlok"
 
-#: ../src/common/datetimefmt.cpp:1952
+#: ../src/common/datetimefmt.cpp:1975
 msgid "first"
 msgstr "első"
 
-#: ../src/html/helpwnd.cpp:1252
+#: ../src/html/helpwnd.cpp:1250
 msgid "font size"
 msgstr "Jelkészlet méret"
 
-#: ../src/common/datetimefmt.cpp:1965
+#: ../src/common/datetimefmt.cpp:1988
 msgid "fourteenth"
 msgstr "tizennegyedik"
 
-#: ../src/common/datetimefmt.cpp:1955
+#: ../src/common/datetimefmt.cpp:1978
 msgid "fourth"
 msgstr "negyedik"
 
-#: ../src/common/appbase.cpp:783
+#: ../src/common/appbase.cpp:784
 msgid "generate verbose log messages"
 msgstr "készíts bőbeszédű naplóbejegyzéseket "
 
-#: ../src/richtext/richtextbuffer.cpp:13138
-#: ../src/richtext/richtextbuffer.cpp:13248
+#: ../src/common/fontcmn.cpp:1215
+msgid "heavy"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:13133
+#: ../src/richtext/richtextbuffer.cpp:13243
 msgid "image"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:796
+#: ../src/common/tarstrm.cpp:790
 msgid "incomplete header block in tar"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:489
+#: ../src/common/xtixml.cpp:485
 msgid "incorrect event handler string, missing dot"
 msgstr "hibás eseménykezelő szöveg, a pont hiányzik"
 
-#: ../src/common/tarstrm.cpp:1381
+#: ../src/common/tarstrm.cpp:1375
 msgid "incorrect size given for tar entry"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:993
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:987
 msgid "invalid data in extended tar header"
 msgstr ""
 
-#: ../src/generic/logg.cpp:1030
+#: ../src/generic/logg.cpp:1027
 msgid "invalid message box return value"
 msgstr "érvénytelen üzenet ablak visszatérési érték"
 
-#: ../src/common/zipstrm.cpp:1647
+#: ../src/common/zipstrm.cpp:1688
 msgid "invalid zip file"
 msgstr "Hibás zip fájl."
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:1228
 msgid "italic"
 msgstr "dőlt"
 
-#: ../src/common/fontcmn.cpp:991
+#: ../src/common/webrequest_curl.cpp:374
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "A fájlt nem tudtam betölteni."
+
+#: ../src/common/fontcmn.cpp:1172
 msgid "light"
 msgstr "vékony"
 
-#: ../src/common/intl.cpp:303
-#, c-format
-msgid "locale '%s' cannot be set."
-msgstr "A(z) '%s' helyi változó nem állítható be."
+#: ../src/common/fontcmn.cpp:1185
+msgid "medium"
+msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2125
+#: ../src/common/datetimefmt.cpp:2148
 msgid "midnight"
 msgstr "éjfél"
 
-#: ../src/common/datetimefmt.cpp:1970
+#: ../src/common/datetimefmt.cpp:1993
 msgid "nineteenth"
 msgstr "tizenkilencedik"
 
-#: ../src/common/datetimefmt.cpp:1960
+#: ../src/common/datetimefmt.cpp:1983
 msgid "ninth"
 msgstr "kilencedik"
 
-#: ../src/msw/dde.cpp:1116
+#: ../src/msw/dde.cpp:1180
 msgid "no DDE error."
 msgstr "nincs DDE hiba."
 
-#: ../src/html/chm.cpp:327
+#: ../src/html/chm.cpp:324
 msgid "no error"
 msgstr "nincs hiba"
 
-#: ../src/dfb/fontmgr.cpp:174
+#: ../src/dfb/fontmgr.cpp:171
 #, c-format
 msgid "no fonts found in %s, using builtin font"
 msgstr ""
 
-#: ../src/html/helpdata.cpp:657
+#: ../src/html/helpdata.cpp:650
 msgid "noname"
 msgstr "névtelen"
 
-#: ../src/common/datetimefmt.cpp:2124
+#: ../src/common/datetimefmt.cpp:2147
 msgid "noon"
 msgstr "dél"
 
-#: ../src/richtext/richtextstyles.cpp:779
+#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
 #, fuzzy
 msgid "normal"
 msgstr "Normál"
 
-#: ../src/common/cmdline.cpp:1492
+#: ../src/common/cmdline.cpp:1488
 msgid "num"
 msgstr "num"
 
-#: ../src/common/xtixml.cpp:259
+#: ../src/common/accelcmn.cpp:194
+msgid "num "
+msgstr ""
+
+#: ../src/common/xtixml.cpp:255
 msgid "objects cannot have XML Text Nodes"
 msgstr "az objektumoknak nem lehet XML szöveg csomópontjuk"
 
-#: ../src/html/chm.cpp:339
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
 msgid "out of memory"
 msgstr "nincs elég tároló."
 
-#: ../src/common/debugrpt.cpp:514
+#: ../src/common/debugrpt.cpp:515
 msgid "process context description"
 msgstr "a folyamat jellemzőinek leírása"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:227
-#: ../src/richtext/richtextbackgroundpage.cpp:250
-#: ../src/richtext/richtextbackgroundpage.cpp:290
-#: ../src/richtext/richtextbackgroundpage.cpp:317
-#: ../src/richtext/richtextfontpage.cpp:177
-#: ../src/richtext/richtextfontpage.cpp:180
 #: ../src/richtext/richtextborderspage.cpp:255
 #: ../src/richtext/richtextborderspage.cpp:289
 #: ../src/richtext/richtextborderspage.cpp:323
@@ -8880,22 +9107,45 @@ msgstr "a folyamat jellemzőinek leírása"
 #: ../src/richtext/richtextborderspage.cpp:491
 #: ../src/richtext/richtextborderspage.cpp:525
 #: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextfontpage.cpp:180
 msgid "pt"
 msgstr ""
 
-#: ../src/richtext/richtextbackgroundpage.cpp:225
-#: ../src/richtext/richtextbackgroundpage.cpp:228
-#: ../src/richtext/richtextbackgroundpage.cpp:229
-#: ../src/richtext/richtextbackgroundpage.cpp:248
-#: ../src/richtext/richtextbackgroundpage.cpp:251
-#: ../src/richtext/richtextbackgroundpage.cpp:252
-#: ../src/richtext/richtextbackgroundpage.cpp:288
-#: ../src/richtext/richtextbackgroundpage.cpp:291
-#: ../src/richtext/richtextbackgroundpage.cpp:292
-#: ../src/richtext/richtextbackgroundpage.cpp:315
-#: ../src/richtext/richtextbackgroundpage.cpp:318
-#: ../src/richtext/richtextbackgroundpage.cpp:319
-#: ../src/richtext/richtextfontpage.cpp:178
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:659
+#: ../src/richtext/richtextsizepage.cpp:662
+#: ../src/richtext/richtextsizepage.cpp:663
 #: ../src/richtext/richtextborderspage.cpp:253
 #: ../src/richtext/richtextborderspage.cpp:256
 #: ../src/richtext/richtextborderspage.cpp:257
@@ -8947,262 +9197,272 @@ msgstr ""
 #: ../src/richtext/richtextmarginspage.cpp:387
 #: ../src/richtext/richtextmarginspage.cpp:389
 #: ../src/richtext/richtextmarginspage.cpp:390
-#: ../src/richtext/richtextsizepage.cpp:338
-#: ../src/richtext/richtextsizepage.cpp:341
-#: ../src/richtext/richtextsizepage.cpp:342
-#: ../src/richtext/richtextsizepage.cpp:372
-#: ../src/richtext/richtextsizepage.cpp:375
-#: ../src/richtext/richtextsizepage.cpp:376
-#: ../src/richtext/richtextsizepage.cpp:399
-#: ../src/richtext/richtextsizepage.cpp:402
-#: ../src/richtext/richtextsizepage.cpp:403
-#: ../src/richtext/richtextsizepage.cpp:426
-#: ../src/richtext/richtextsizepage.cpp:429
-#: ../src/richtext/richtextsizepage.cpp:430
-#: ../src/richtext/richtextsizepage.cpp:453
-#: ../src/richtext/richtextsizepage.cpp:456
-#: ../src/richtext/richtextsizepage.cpp:457
-#: ../src/richtext/richtextsizepage.cpp:480
-#: ../src/richtext/richtextsizepage.cpp:483
-#: ../src/richtext/richtextsizepage.cpp:484
-#: ../src/richtext/richtextsizepage.cpp:554
-#: ../src/richtext/richtextsizepage.cpp:557
-#: ../src/richtext/richtextsizepage.cpp:558
-#: ../src/richtext/richtextsizepage.cpp:589
-#: ../src/richtext/richtextsizepage.cpp:592
-#: ../src/richtext/richtextsizepage.cpp:593
-#: ../src/richtext/richtextsizepage.cpp:624
-#: ../src/richtext/richtextsizepage.cpp:627
-#: ../src/richtext/richtextsizepage.cpp:628
-#: ../src/richtext/richtextsizepage.cpp:659
-#: ../src/richtext/richtextsizepage.cpp:662
-#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextfontpage.cpp:178
 msgid "px"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:193
+#: ../src/common/accelcmn.cpp:192
 #, fuzzy
 msgid "rawctrl"
 msgstr "ctrl"
 
-#: ../src/html/chm.cpp:333
+#: ../src/html/chm.cpp:330
 msgid "read error"
 msgstr "olvasás hiba"
 
-#: ../src/common/zipstrm.cpp:2085
+#: ../src/common/zipstrm.cpp:2155
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "a zip folyam olvasása ( a(z) %s adat): hibás crc"
 
-#: ../src/common/zipstrm.cpp:2080
+#: ../src/common/zipstrm.cpp:2150
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "a zip folyam olvasása ( a(z) %s adat): hibáshossz"
 
-#: ../src/msw/dde.cpp:1159
+#: ../src/msw/dde.cpp:1223
 msgid "reentrancy problem."
 msgstr "újrabelépési probléma."
 
-#: ../src/common/datetimefmt.cpp:1953
+#: ../src/common/datetimefmt.cpp:1976
 msgid "second"
 msgstr "második"
 
-#: ../src/html/chm.cpp:337
+#: ../src/html/chm.cpp:334
 msgid "seek error"
 msgstr "keresési hiba"
 
-#: ../src/common/datetimefmt.cpp:1968
+#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#, fuzzy
+msgid "semibold"
+msgstr "félkövér"
+
+#: ../src/common/datetimefmt.cpp:1991
 msgid "seventeenth"
 msgstr "tizenhetedik"
 
-#: ../src/common/datetimefmt.cpp:1958
+#: ../src/common/datetimefmt.cpp:1981
 msgid "seventh"
 msgstr "hetedik"
 
-#: ../src/common/accelcmn.cpp:191
+#: ../src/common/accelcmn.cpp:190
 msgid "shift"
 msgstr "eltol"
 
-#: ../src/common/appbase.cpp:773
+#: ../src/common/appbase.cpp:774
 msgid "show this help message"
 msgstr "mutassa meg ezt az üzenetet a súgóban"
 
-#: ../src/common/datetimefmt.cpp:1967
+#: ../src/common/datetimefmt.cpp:1990
 msgid "sixteenth"
 msgstr "tizenhatodik"
 
-#: ../src/common/datetimefmt.cpp:1957
+#: ../src/common/datetimefmt.cpp:1980
 msgid "sixth"
 msgstr "hatodik"
 
-#: ../src/common/appcmn.cpp:234
+#: ../src/common/appcmn.cpp:255
 msgid "specify display mode to use (e.g. 640x480-16)"
 msgstr "jelölje ki a használandó megjelenítési módot (pl.. 640x480-16)"
 
-#: ../src/common/appcmn.cpp:220
+#: ../src/common/appcmn.cpp:241
 msgid "specify the theme to use"
 msgstr "jelölje ki a használandó bőrt"
 
-#: ../src/richtext/richtextbuffer.cpp:9340
+#: ../src/richtext/richtextbuffer.cpp:9337
 msgid "standard/circle"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9341
+#: ../src/richtext/richtextbuffer.cpp:9338
 msgid "standard/circle-outline"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9343
+#: ../src/richtext/richtextbuffer.cpp:9340
 msgid "standard/diamond"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9342
+#: ../src/richtext/richtextbuffer.cpp:9339
 msgid "standard/square"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9344
+#: ../src/richtext/richtextbuffer.cpp:9341
 msgid "standard/triangle"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1985
+#: ../src/common/zipstrm.cpp:2055
 msgid "stored file length not in Zip header"
 msgstr "a Zip fejrészben nincs meg a tárolt fájl hossza"
 
-#: ../src/common/cmdline.cpp:1488
+#: ../src/common/cmdline.cpp:1484
 msgid "str"
 msgstr "str"
 
-#: ../src/common/fontcmn.cpp:982
+#: ../src/common/fontcmn.cpp:1145
 msgid "strikethrough"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:1003 ../src/common/tarstrm.cpp:1025
-#: ../src/common/tarstrm.cpp:1507 ../src/common/tarstrm.cpp:1529
+#: ../src/common/tarstrm.cpp:997 ../src/common/tarstrm.cpp:1019
+#: ../src/common/tarstrm.cpp:1501 ../src/common/tarstrm.cpp:1523
 msgid "tar entry not open"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1961
+#: ../src/common/datetimefmt.cpp:1984
 msgid "tenth"
 msgstr "tizedik"
 
-#: ../src/msw/dde.cpp:1123
+#: ../src/msw/dde.cpp:1187
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "a tranzakció eredményeként a DDE_FBUSY bit beállítódott."
 
-#: ../src/common/datetimefmt.cpp:1954
+#: ../src/common/fontcmn.cpp:1154
+msgid "thin"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:1977
 msgid "third"
 msgstr "harmadik"
 
-#: ../src/common/datetimefmt.cpp:1964
+#: ../src/common/datetimefmt.cpp:1987
 msgid "thirteenth"
 msgstr "tizenharmadik"
 
-#: ../src/common/datetimefmt.cpp:1758
+#: ../src/common/datetimefmt.cpp:1781
 msgid "today"
 msgstr "ma"
 
-#: ../src/common/datetimefmt.cpp:1760
+#: ../src/common/datetimefmt.cpp:1783
 msgid "tomorrow"
 msgstr "holnap"
 
-#: ../src/common/fileconf.cpp:1944
+#: ../src/common/fileconf.cpp:1946
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr ""
 
-#: ../src/gtk/aboutdlg.cpp:218
+#: ../src/gtk/aboutdlg.cpp:216
 msgid "translator-credits"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1028
+#: ../src/generic/datavgen.cpp:1148
 msgid "true"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1963
+#: ../src/common/datetimefmt.cpp:1986
 msgid "twelfth"
 msgstr "tizenkettedik"
 
-#: ../src/common/datetimefmt.cpp:1971
+#: ../src/common/datetimefmt.cpp:1994
 msgid "twentieth"
 msgstr "huszadik"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:486 ../src/generic/datavgen.cpp:1263
+#: ../src/common/datavcmn.cpp:2068 ../src/generic/datavgen.cpp:1386
 msgid "unchecked"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:802 ../src/common/fontcmn.cpp:978
+#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
 msgid "underlined"
 msgstr "aláhúzott"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:490
+#: ../src/common/datavcmn.cpp:2072
 #, fuzzy
 msgid "undetermined"
 msgstr "aláhúzott"
 
-#: ../src/common/fileconf.cpp:1979
+#: ../src/common/fileconf.cpp:1981
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "váratlan \" a(z) %d pozícióban, a(z) '%s' fájlban."
 
-#: ../src/common/tarstrm.cpp:1045
+#: ../src/common/tarstrm.cpp:1039
 #, fuzzy
 msgid "unexpected end of file"
 msgstr "Váratlanul véget ért a fájl az erőforrás értelmezése során. "
 
-#: ../src/generic/progdlgg.cpp:370 ../src/common/tarstrm.cpp:371
-#: ../src/common/tarstrm.cpp:394 ../src/common/tarstrm.cpp:425
+#: ../src/common/tarstrm.cpp:366 ../src/common/tarstrm.cpp:389
+#: ../src/common/tarstrm.cpp:420 ../src/generic/progdlgg.cpp:376
 msgid "unknown"
 msgstr "ismeretlen"
 
-#: ../src/msw/registry.cpp:150
+#: ../src/msw/registry.cpp:139
 #, fuzzy, c-format
 msgid "unknown (%lu)"
 msgstr "ismeretlen"
 
-#: ../src/common/xtixml.cpp:253
+#: ../src/common/xtixml.cpp:249
 #, c-format
 msgid "unknown class %s"
 msgstr "ismeretlen osztály: %s"
 
-#: ../src/common/regex.cpp:258 ../src/html/chm.cpp:351
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "tömörítési hiba"
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "kifejtési hiba"
+
+#: ../src/common/regex.cpp:255 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "ismeretlen hiba"
 
-#: ../src/msw/dialup.cpp:471
+#: ../src/msw/dialup.cpp:465
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "ismeretlen hiba (hiba kód %08x)."
 
-#: ../src/common/fmapbase.cpp:834
+#: ../src/common/fmapbase.cpp:830
 #, c-format
 msgid "unknown-%d"
 msgstr "ismeretlen-%d"
 
-#: ../src/common/docview.cpp:509
+#: ../src/common/docview.cpp:502
 msgid "unnamed"
 msgstr "névtelen"
 
-#: ../src/common/docview.cpp:1624
+#: ../src/common/docview.cpp:1618
 #, c-format
 msgid "unnamed%d"
 msgstr "névtelen%d"
 
-#: ../src/common/zipstrm.cpp:1999 ../src/common/zipstrm.cpp:2319
+#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
 msgid "unsupported Zip compression method"
 msgstr "nem támogatott Zip tömörítési módszer"
 
-#: ../src/common/translation.cpp:1892
+#: ../src/common/translation.cpp:1942
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "a(z) '%s' katalógust használom (a(z) '%s' közül)."
 
-#: ../src/html/chm.cpp:335
+#: ../src/html/chm.cpp:332
 msgid "write error"
 msgstr "írási hiba"
 
-#: ../src/common/time.cpp:292
+#: ../src/gtk/glcanvas.cpp:187
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/common/time.cpp:285
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay hibát eredményezett."
 
@@ -9215,15 +9475,15 @@ msgstr "a wxWidgets nem tudott képernyőt nyitni '%s' számára: kilépés."
 msgid "wxWidgets could not open display. Exiting."
 msgstr "A wxWidgets nem tudott képernyőt nyitni. Kilépés."
 
-#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:431
 msgid "xxxx"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1759
+#: ../src/common/datetimefmt.cpp:1782
 msgid "yesterday"
 msgstr "tegnap"
 
-#: ../src/common/zstream.cpp:251 ../src/common/zstream.cpp:426
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
 #, c-format
 msgid "zlib error %d"
 msgstr "zlib hiba %d"
@@ -9234,8 +9494,73 @@ msgid "~"
 msgstr ""
 
 #, fuzzy
-#~ msgid "Column could not be added."
-#~ msgstr "A fájlt nem tudtam betölteni."
+#~ msgid "&Save as"
+#~ msgstr "Mentés Másként"
+
+#, fuzzy
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' csak betűket tartalmazhat."
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' csak számérték lehet."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' csak ASCII jeleket tartalmazhat."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' csak betűket tartalmazhat."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' csak betűket vagy számokat tartalmazhat."
+
+#, fuzzy
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' csak ASCII jeleket tartalmazhat."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "Nem tudom létrehozni a(z) %s osztályhoz tartozó fájlt"
+
+#, fuzzy
+#~ msgid "Could not initalize libnotify."
+#~ msgstr "Nem tudom elindítani a nyomtatást."
+
+#, fuzzy
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "Nem tudtam időzítőt létrehozni"
+
+#, fuzzy
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "Nem kaptam meg a mutatót a jelenlegi szálhoz"
+
+#, fuzzy
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "Nem sikerült lezárni a file kezelőt."
+
+#, fuzzy
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "Nem sikerült létrehozni a munkakönyvtárat."
+
+#~ msgid "No unused colour in image."
+#~ msgstr "A képben nincs nem használt szín."
+
+#, fuzzy
+#~ msgid "Not available"
+#~ msgstr "Nincs XBM lehetőség!"
+
+#, fuzzy
+#~ msgid "Replace selection"
+#~ msgstr "Helyettesítsem &mindet"
+
+#, fuzzy
+#~ msgid "Save as"
+#~ msgstr "Mentés Másként"
+
+#, fuzzy
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "Nem tud könyvtárat hozzáadni ehhez a szakaszhoz."
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "A(z) '%s' helyi változó nem állítható be."
 
 #, fuzzy
 #~ msgid "Column index not found."
@@ -9463,10 +9788,6 @@ msgstr ""
 #~ msgid "unknown seek origin"
 #~ msgstr "ismeretlen keresési kezdőpont"
 
-#, fuzzy
-#~ msgid "wxWidget's control not initialized."
-#~ msgstr "Nem tudom elindítani a megjelenítést."
-
 #~ msgid "Cannot create mutex."
 #~ msgstr "Nem tudom létrehozni a mutex-et"
 
@@ -9538,9 +9859,6 @@ msgstr ""
 
 #~ msgid "Directory '%s' doesn't exist!"
 #~ msgstr "A(z) '%s' könyvtár nem létezik!"
-
-#~ msgid "File %s does not exist."
-#~ msgstr "A(z) '%s' file nem létezik."
 
 #~ msgid "Mode %ix%i-%i not available."
 #~ msgstr "A %ix%i-%i mód nem létezik."
@@ -9617,9 +9935,6 @@ msgstr ""
 
 #~ msgid "Failed to register OpenGL window class."
 #~ msgstr "Nem tudom regisztrálani az OpenGL ablak osztályt."
-
-#~ msgid "Fatal error"
-#~ msgstr "Végzetes hiba"
 
 #~ msgid "Fatal error: "
 #~ msgstr "Végzetes hiba:"
@@ -9787,9 +10102,6 @@ msgstr ""
 
 #~ msgid "&Print"
 #~ msgstr "&Nyomtatás"
-
-#~ msgid "*** A debug report has been generated\n"
-#~ msgstr "*** Elkészült a hibakeresésről a jelentés\n"
 
 #~ msgid "*** It can be found in \"%s\"\n"
 #~ msgstr "*** Ez a \"%s\"-ben található\n"

--- a/locale/id.po
+++ b/locale/id.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-21 14:25+0200\n"
+"POT-Creation-Date: 2020-10-18 23:11+0300\n"
 "PO-Revision-Date: 2020-06-26 21:31+0700\n"
 "Last-Translator: Hertatijanto Hartono <dvertx@gmail.com>\n"
 "Language-Team: ID <doplank@gmx.com>\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Poedit-Bookmarks: 912,-1,-1,-1,-1,-1,-1,-1,-1,1004\n"
 
-#: ../src/common/debugrpt.cpp:586
+#: ../src/common/debugrpt.cpp:587
 msgid ""
 "\n"
 "Please send this report to the program maintainer, thank you!\n"
@@ -24,157 +24,191 @@ msgstr ""
 "\n"
 "Tolong kirimkan laporan ini kepada pemelihara program, terima kasih!\n"
 
-#: ../src/richtext/richtextstyledlg.cpp:210 ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:206
+#: ../src/richtext/richtextstyledlg.cpp:218
 msgid " "
 msgstr " "
 
 #: ../src/generic/dbgrptg.cpp:326
 msgid "              Thank you and we're sorry for the inconvenience!\n"
-msgstr "              Terima kasih dan kami mohon maaf atas ketidaknyamanannya!\n"
+msgstr ""
+"              Terima kasih dan kami mohon maaf atas ketidaknyamanannya!\n"
 
-#: ../src/common/prntbase.cpp:573
+#: ../src/common/prntbase.cpp:568
 #, c-format
 msgid " (copy %d of %d)"
 msgstr " (salinan %d dari %d)"
 
-#: ../src/common/log.cpp:421
+#: ../src/common/log.cpp:440
 #, c-format
 msgid " (error %ld: %s)"
 msgstr " (galat %ld: %s)"
 
-#: ../src/common/imagtiff.cpp:72
+#: ../src/common/imagtiff.cpp:69
 #, c-format
 msgid " (in module \"%s\")"
 msgstr " (dalam modul \"%s\")"
 
-#: ../src/osx/core/secretstore.cpp:138
-msgid " (while overwriting an existing item)"
-msgstr " (saat menimpa obyek yang ada)"
-
-#: ../src/common/docview.cpp:1642
+#: ../src/common/docview.cpp:1636
 msgid " - "
 msgstr " - "
 
-#: ../src/richtext/richtextprint.cpp:593 ../src/html/htmprint.cpp:714
+#: ../src/html/htmprint.cpp:712 ../src/richtext/richtextprint.cpp:589
 msgid " Preview"
 msgstr " Pratinjau"
 
-#: ../src/common/fontcmn.cpp:824
+#: ../src/common/fontcmn.cpp:973
 msgid " bold"
 msgstr " tebal"
 
-#: ../src/common/fontcmn.cpp:840
+#: ../src/common/fontcmn.cpp:977
+#, fuzzy
+msgid " extra bold"
+msgstr " tebal"
+
+#: ../src/common/fontcmn.cpp:985
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:957
+#, fuzzy
+msgid " extra light"
+msgstr " ringan"
+
+#: ../src/common/fontcmn.cpp:981
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1001
 msgid " italic"
 msgstr " miring"
 
-#: ../src/common/fontcmn.cpp:820
+#: ../src/common/fontcmn.cpp:961
 msgid " light"
 msgstr " ringan"
 
-#: ../src/common/fontcmn.cpp:807
+#: ../src/common/fontcmn.cpp:965
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:969
+#, fuzzy
+msgid " semi bold"
+msgstr " tebal"
+
+#: ../src/common/fontcmn.cpp:940
 msgid " strikethrough"
 msgstr " teks coret"
 
-#: ../src/common/paper.cpp:117
+#: ../src/common/fontcmn.cpp:953
+msgid " thin"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
 msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
 msgstr "Amplop #10, 4 1/8 x 9 1/2 in"
 
-#: ../src/common/paper.cpp:118
+#: ../src/common/paper.cpp:115
 msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
 msgstr "Amplop #11, 4 1/2 x 10 3/8 in"
 
-#: ../src/common/paper.cpp:119
+#: ../src/common/paper.cpp:116
 msgid "#12 Envelope, 4 3/4 x 11 in"
 msgstr "Amplop #12, 4 3/4 x 11 in"
 
-#: ../src/common/paper.cpp:120
+#: ../src/common/paper.cpp:117
 msgid "#14 Envelope, 5 x 11 1/2 in"
 msgstr "Amplop #14, 5 x 11 1/2 in"
 
-#: ../src/common/paper.cpp:116
+#: ../src/common/paper.cpp:113
 msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
 msgstr "Amplop #9, 3 7/8 x 8 7/8 in"
 
+#: ../src/richtext/richtextsizepage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:374
+#: ../src/richtext/richtextsizepage.cpp:401
+#: ../src/richtext/richtextsizepage.cpp:428
+#: ../src/richtext/richtextsizepage.cpp:455
+#: ../src/richtext/richtextsizepage.cpp:482
+#: ../src/richtext/richtextsizepage.cpp:556
+#: ../src/richtext/richtextsizepage.cpp:591
+#: ../src/richtext/richtextsizepage.cpp:626
+#: ../src/richtext/richtextsizepage.cpp:661
 #: ../src/richtext/richtextbackgroundpage.cpp:341
-#: ../src/richtext/richtextsizepage.cpp:340 ../src/richtext/richtextsizepage.cpp:374
-#: ../src/richtext/richtextsizepage.cpp:401 ../src/richtext/richtextsizepage.cpp:428
-#: ../src/richtext/richtextsizepage.cpp:455 ../src/richtext/richtextsizepage.cpp:482
-#: ../src/richtext/richtextsizepage.cpp:556 ../src/richtext/richtextsizepage.cpp:591
-#: ../src/richtext/richtextsizepage.cpp:626 ../src/richtext/richtextsizepage.cpp:661
 msgid "%"
 msgstr "%"
 
-#: ../src/html/helpwnd.cpp:1031
+#: ../src/html/helpwnd.cpp:1029
 #, c-format
 msgid "%d of %lu"
 msgstr "%d dari %lu"
 
-#: ../src/html/helpwnd.cpp:1678
+#: ../src/html/helpwnd.cpp:1676
 #, c-format
 msgid "%i of %u"
 msgstr "%i dari %u"
 
-#: ../src/generic/filectrlg.cpp:279
+#: ../src/generic/filectrlg.cpp:275
 #, c-format
 msgid "%ld byte"
 msgid_plural "%ld bytes"
 msgstr[0] "%ld byte"
 
-#: ../src/html/helpwnd.cpp:1033
+#: ../src/html/helpwnd.cpp:1031
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu dari %lu"
 
-#: ../src/generic/datavgen.cpp:6028
+#: ../src/generic/datavgen.cpp:6833
 #, c-format
 msgid "%s (%d items)"
 msgstr "%s (%d obyek)"
 
-#: ../src/common/cmdline.cpp:1221
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (atau %s)"
 
-#: ../src/generic/logg.cpp:224
+#: ../src/generic/logg.cpp:221
 #, c-format
 msgid "%s Error"
 msgstr "Kesalahan %s"
 
-#: ../src/generic/logg.cpp:236
+#: ../src/generic/logg.cpp:233
 #, c-format
 msgid "%s Information"
 msgstr "Informasi %s"
 
-#: ../src/generic/preferencesg.cpp:113
+#: ../src/generic/preferencesg.cpp:110
 #, c-format
 msgid "%s Preferences"
 msgstr "Preferensi %s"
 
-#: ../src/generic/logg.cpp:228
+#: ../src/generic/logg.cpp:225
 #, c-format
 msgid "%s Warning"
 msgstr "Peringatan %s"
 
-#: ../src/common/tarstrm.cpp:1319
+#: ../src/common/tarstrm.cpp:1313
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s tidak pas dengan header tar untuk entri '%s'"
 
-#: ../src/common/fldlgcmn.cpp:124
+#: ../src/common/fldlgcmn.cpp:121
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "berkas %s (%s)|%s"
 
-#: ../src/html/helpwnd.cpp:1716
+#: ../src/html/helpwnd.cpp:1714
 #, c-format
 msgid "%u of %u"
 msgstr "%u dari %u"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "&About"
 msgstr "Tent&ang"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "&Actual Size"
 msgstr "Ukuran Seben&arnya"
 
@@ -182,28 +216,28 @@ msgstr "Ukuran Seben&arnya"
 msgid "&After a paragraph:"
 msgstr "Setel&ah paragraf:"
 
-#: ../src/richtext/richtextindentspage.cpp:128
 #: ../src/richtext/richtextliststylepage.cpp:319
+#: ../src/richtext/richtextindentspage.cpp:128
 msgid "&Alignment"
 msgstr "Perat&aan"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "&Apply"
 msgstr "Ter&apkan"
 
-#: ../src/richtext/richtextstyledlg.cpp:251
+#: ../src/richtext/richtextstyledlg.cpp:247
 msgid "&Apply Style"
 msgstr "Ter&apkan Gaya"
 
-#: ../src/msw/mdi.cpp:179
+#: ../src/msw/mdi.cpp:174
 msgid "&Arrange Icons"
 msgstr "&Atur Ikon"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "&Ascending"
 msgstr "Urut N&aik"
 
-#: ../src/common/stockitem.cpp:142
+#: ../src/common/stockitem.cpp:139
 msgid "&Back"
 msgstr "&Mundur"
 
@@ -223,23 +257,24 @@ msgstr "&Warna latar:"
 msgid "&Blur distance:"
 msgstr "Jarak &blur:"
 
-#: ../src/common/stockitem.cpp:143
+#: ../src/common/stockitem.cpp:140
 msgid "&Bold"
 msgstr "Te&bal"
 
-#: ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141
 msgid "&Bottom"
 msgstr "&Bawah"
 
+#: ../src/richtext/richtextsizepage.cpp:637
+#: ../src/richtext/richtextsizepage.cpp:644
 #: ../src/richtext/richtextborderspage.cpp:345
 #: ../src/richtext/richtextborderspage.cpp:513
 #: ../src/richtext/richtextmarginspage.cpp:259
 #: ../src/richtext/richtextmarginspage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:637 ../src/richtext/richtextsizepage.cpp:644
 msgid "&Bottom:"
 msgstr "&Bawah:"
 
-#: ../include/wx/richtext/richtextbuffer.h:3866
+#: ../include/wx/richtext/richtextbuffer.h:3861
 msgid "&Box"
 msgstr "&Kotak"
 
@@ -248,38 +283,38 @@ msgstr "&Kotak"
 msgid "&Bullet style:"
 msgstr "&Gaya bullet:"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "&CD-Rom"
 msgstr "&CD-Rom"
 
-#: ../src/generic/wizard.cpp:434 ../src/generic/fontdlgg.cpp:470
-#: ../src/generic/fontdlgg.cpp:489 ../src/osx/carbon/fontdlg.cpp:402
-#: ../src/common/dlgcmn.cpp:279 ../src/common/stockitem.cpp:145
+#: ../src/osx/carbon/fontdlg.cpp:399 ../src/common/stockitem.cpp:142
+#: ../src/generic/wizard.cpp:433 ../src/generic/fontdlgg.cpp:466
+#: ../src/generic/fontdlgg.cpp:485 ../src/osx/cocoa/button.mm:200
 msgid "&Cancel"
 msgstr "&Batal"
 
-#: ../src/msw/mdi.cpp:175
+#: ../src/msw/mdi.cpp:170
 msgid "&Cascade"
 msgstr "&Bertingkat"
 
-#: ../include/wx/richtext/richtextbuffer.h:5960
+#: ../include/wx/richtext/richtextbuffer.h:5955
 msgid "&Cell"
 msgstr "&Sel"
 
-#: ../src/richtext/richtextsymboldlg.cpp:439
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "&Character code:"
 msgstr "&Kode karakter:"
 
-#: ../src/common/stockitem.cpp:147
+#: ../src/common/stockitem.cpp:144
 msgid "&Clear"
 msgstr "&Bersihkan"
 
-#: ../src/generic/logg.cpp:516 ../src/common/stockitem.cpp:148
-#: ../src/common/prntbase.cpp:1600 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/stockitem.cpp:145 ../src/common/prntbase.cpp:1625
+#: ../src/univ/themes/win32.cpp:3753 ../src/generic/logg.cpp:513
 msgid "&Close"
 msgstr "&Tutup"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "&Color"
 msgstr "&Warna"
 
@@ -287,20 +322,20 @@ msgstr "&Warna"
 msgid "&Colour:"
 msgstr "&Warna:"
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "&Convert"
 msgstr "&Ubah"
 
-#: ../src/richtext/richtextctrl.cpp:333 ../src/osx/textctrl_osx.cpp:577
-#: ../src/common/stockitem.cpp:150 ../src/msw/textctrl.cpp:2508
+#: ../src/osx/textctrl_osx.cpp:595 ../src/common/stockitem.cpp:147
+#: ../src/msw/textctrl.cpp:2773 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Salin"
 
-#: ../src/generic/hyperlinkg.cpp:156
+#: ../src/generic/hyperlinkg.cpp:153
 msgid "&Copy URL"
 msgstr "&Salin URL"
 
-#: ../src/common/headerctrlcmn.cpp:306
+#: ../src/common/headerctrlcmn.cpp:304
 msgid "&Customize..."
 msgstr "&Kustomisasi..."
 
@@ -308,53 +343,54 @@ msgstr "&Kustomisasi..."
 msgid "&Debug report preview:"
 msgstr "&Pratinjau laporan debug:"
 
-#: ../src/richtext/richtexttabspage.cpp:138 ../src/richtext/richtextctrl.cpp:335
-#: ../src/osx/textctrl_osx.cpp:579 ../src/common/stockitem.cpp:152
-#: ../src/msw/textctrl.cpp:2510
+#: ../src/osx/textctrl_osx.cpp:597 ../src/common/stockitem.cpp:149
+#: ../src/msw/textctrl.cpp:2775 ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtextctrl.cpp:334
 msgid "&Delete"
 msgstr "&Hapus"
 
-#: ../src/richtext/richtextstyledlg.cpp:269
+#: ../src/richtext/richtextstyledlg.cpp:265
 msgid "&Delete Style..."
 msgstr "&Hapus Gaya..."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "&Descending"
 msgstr "Urut &Turun"
 
-#: ../src/generic/logg.cpp:682
+#: ../src/generic/logg.cpp:679
 msgid "&Details"
 msgstr "&Rinci"
 
-#: ../src/common/stockitem.cpp:153
+#: ../src/common/stockitem.cpp:150
 msgid "&Down"
 msgstr "&Turun"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "&Edit"
 msgstr "&Sunting"
 
-#: ../src/richtext/richtextstyledlg.cpp:263
+#: ../src/richtext/richtextstyledlg.cpp:259
 msgid "&Edit Style..."
 msgstr "&Sunting Gaya..."
 
-#: ../src/common/stockitem.cpp:155
+#: ../src/common/stockitem.cpp:152
 msgid "&Execute"
 msgstr "&Jalankan"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/common/stockitem.cpp:154
 msgid "&File"
 msgstr "&Berkas"
 
-#: ../src/common/stockitem.cpp:158
-msgid "&Find"
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "&Find..."
 msgstr "&Temukan"
 
-#: ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:430
 msgid "&Finish"
 msgstr "&Selesai"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:156
 msgid "&First"
 msgstr "&Pertama"
 
@@ -362,15 +398,15 @@ msgstr "&Pertama"
 msgid "&Floating mode:"
 msgstr "&Mode mengambang:"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "&Floppy"
 msgstr "&Floppy"
 
-#: ../src/common/stockitem.cpp:194
+#: ../src/common/stockitem.cpp:191
 msgid "&Font"
 msgstr "&Font"
 
-#: ../src/generic/fontdlgg.cpp:371
+#: ../src/generic/fontdlgg.cpp:367
 msgid "&Font family:"
 msgstr "&Keluarga font:"
 
@@ -378,29 +414,31 @@ msgstr "&Keluarga font:"
 msgid "&Font for Level..."
 msgstr "&Font untuk Level..."
 
-#: ../src/richtext/richtextfontpage.cpp:147 ../src/richtext/richtextsymboldlg.cpp:400
+#: ../src/richtext/richtextsymboldlg.cpp:397
+#: ../src/richtext/richtextfontpage.cpp:147
 msgid "&Font:"
 msgstr "&Font:"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "&Forward"
 msgstr "&Maju"
 
-#: ../src/richtext/richtextsymboldlg.cpp:451
+#: ../src/richtext/richtextsymboldlg.cpp:448
 msgid "&From:"
 msgstr "&Dari:"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "&Harddisk"
 msgstr "&Harddisk"
 
-#: ../src/richtext/richtextsizepage.cpp:351 ../src/richtext/richtextsizepage.cpp:358
+#: ../src/richtext/richtextsizepage.cpp:351
+#: ../src/richtext/richtextsizepage.cpp:358
 msgid "&Height:"
 msgstr "&Tinggi:"
 
-#: ../src/generic/wizard.cpp:441 ../src/richtext/richtextstyledlg.cpp:303
-#: ../src/richtext/richtextsymboldlg.cpp:479 ../src/osx/menu_osx.cpp:734
-#: ../src/common/stockitem.cpp:163
+#: ../src/common/stockitem.cpp:160 ../src/generic/wizard.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextstyledlg.cpp:299 ../src/osx/cocoa/menu.mm:226
 msgid "&Help"
 msgstr "&Bantuan"
 
@@ -408,7 +446,7 @@ msgstr "&Bantuan"
 msgid "&Hide details"
 msgstr "&Sembunyikan detail"
 
-#: ../src/common/stockitem.cpp:164
+#: ../src/common/stockitem.cpp:161
 msgid "&Home"
 msgstr "&Home"
 
@@ -416,53 +454,54 @@ msgstr "&Home"
 msgid "&Horizontal offset:"
 msgstr "Jarak &horizontal:"
 
-#: ../src/richtext/richtextindentspage.cpp:184
 #: ../src/richtext/richtextliststylepage.cpp:372
+#: ../src/richtext/richtextindentspage.cpp:184
 msgid "&Indentation (tenths of a mm)"
 msgstr "&Indentasi (persepuluh mm)"
 
-#: ../src/richtext/richtextindentspage.cpp:167
 #: ../src/richtext/richtextliststylepage.cpp:356
+#: ../src/richtext/richtextindentspage.cpp:167
 msgid "&Indeterminate"
 msgstr "&Tidak tentu"
 
-#: ../src/common/stockitem.cpp:166
+#: ../src/common/stockitem.cpp:163
 msgid "&Index"
 msgstr "&Indeks"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "&Info"
 msgstr "&Info"
 
-#: ../src/common/stockitem.cpp:168
+#: ../src/common/stockitem.cpp:165
 msgid "&Italic"
 msgstr "&Miring"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "&Jump to"
 msgstr "&Lompat ke"
 
-#: ../src/richtext/richtextindentspage.cpp:153
 #: ../src/richtext/richtextliststylepage.cpp:342
+#: ../src/richtext/richtextindentspage.cpp:153
 msgid "&Justified"
 msgstr "&Rata kanan kiri"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "&Last"
 msgstr "Terak&hir"
 
-#: ../src/richtext/richtextindentspage.cpp:139
 #: ../src/richtext/richtextliststylepage.cpp:328
+#: ../src/richtext/richtextindentspage.cpp:139
 msgid "&Left"
 msgstr "&Kiri"
 
-#: ../src/richtext/richtextindentspage.cpp:195
+#: ../src/richtext/richtextsizepage.cpp:532
+#: ../src/richtext/richtextsizepage.cpp:539
 #: ../src/richtext/richtextborderspage.cpp:243
 #: ../src/richtext/richtextborderspage.cpp:411
 #: ../src/richtext/richtextliststylepage.cpp:381
+#: ../src/richtext/richtextindentspage.cpp:195
 #: ../src/richtext/richtextmarginspage.cpp:186
 #: ../src/richtext/richtextmarginspage.cpp:300
-#: ../src/richtext/richtextsizepage.cpp:532 ../src/richtext/richtextsizepage.cpp:539
 msgid "&Left:"
 msgstr "&Kiri:"
 
@@ -470,11 +509,11 @@ msgstr "&Kiri:"
 msgid "&List level:"
 msgstr "&Level daftar:"
 
-#: ../src/generic/logg.cpp:517
+#: ../src/generic/logg.cpp:514
 msgid "&Log"
 msgstr "&Log"
 
-#: ../src/univ/themes/win32.cpp:3748
+#: ../src/univ/themes/win32.cpp:3745
 msgid "&Move"
 msgstr "&Pindah"
 
@@ -482,19 +521,19 @@ msgstr "&Pindah"
 msgid "&Move the object to:"
 msgstr "&Pindahkan obyek ke:"
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "&Network"
 msgstr "&Jaringan"
 
-#: ../src/richtext/richtexttabspage.cpp:132 ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173 ../src/richtext/richtexttabspage.cpp:132
 msgid "&New"
 msgstr "&Baru"
 
-#: ../src/aui/tabmdi.cpp:111 ../src/generic/mdig.cpp:100 ../src/msw/mdi.cpp:180
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
 msgid "&Next"
 msgstr "&Berikut"
 
-#: ../src/generic/wizard.cpp:432 ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:429
 msgid "&Next >"
 msgstr "&Berikutnya >"
 
@@ -502,7 +541,7 @@ msgstr "&Berikutnya >"
 msgid "&Next Paragraph"
 msgstr "&Paragraf berikutnya"
 
-#: ../src/generic/tipdlg.cpp:240
+#: ../src/generic/tipdlg.cpp:237
 msgid "&Next Tip"
 msgstr "&Tip Berikutnya"
 
@@ -510,11 +549,11 @@ msgstr "&Tip Berikutnya"
 msgid "&Next style:"
 msgstr "&Gaya berikutnya:"
 
-#: ../src/common/stockitem.cpp:177 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:174 ../src/msw/msgdlg.cpp:435
 msgid "&No"
 msgstr "&Tidak"
 
-#: ../src/generic/dbgrptg.cpp:356
+#: ../src/generic/dbgrptg.cpp:360
 msgid "&Notes:"
 msgstr "Catata&n:"
 
@@ -522,12 +561,12 @@ msgstr "Catata&n:"
 msgid "&Number:"
 msgstr "&Nomor:"
 
-#: ../src/generic/fontdlgg.cpp:475 ../src/generic/fontdlgg.cpp:482
-#: ../src/osx/carbon/fontdlg.cpp:408 ../src/common/stockitem.cpp:178
+#: ../src/osx/carbon/fontdlg.cpp:405 ../src/common/stockitem.cpp:175
+#: ../src/generic/fontdlgg.cpp:471 ../src/generic/fontdlgg.cpp:478
 msgid "&OK"
 msgstr "&OK"
 
-#: ../src/generic/dbgrptg.cpp:342 ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176 ../src/generic/dbgrptg.cpp:342
 msgid "&Open..."
 msgstr "&Buka..."
 
@@ -539,16 +578,16 @@ msgstr "Level &ikhtisar:"
 msgid "&Page Break"
 msgstr "&Ganti Halaman"
 
-#: ../src/richtext/richtextctrl.cpp:334 ../src/osx/textctrl_osx.cpp:578
-#: ../src/common/stockitem.cpp:180 ../src/msw/textctrl.cpp:2509
+#: ../src/osx/textctrl_osx.cpp:596 ../src/common/stockitem.cpp:177
+#: ../src/msw/textctrl.cpp:2774 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&Tempel"
 
-#: ../include/wx/richtext/richtextbuffer.h:5010
+#: ../include/wx/richtext/richtextbuffer.h:5005
 msgid "&Picture"
 msgstr "&Citra"
 
-#: ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:419
 msgid "&Point size:"
 msgstr "&Ukuran titik:"
 
@@ -560,11 +599,11 @@ msgstr "&Posisi (persepuluh mm):"
 msgid "&Position mode:"
 msgstr "&Mode posisi:"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178
 msgid "&Preferences"
 msgstr "&Preferensi"
 
-#: ../src/aui/tabmdi.cpp:112 ../src/generic/mdig.cpp:101 ../src/msw/mdi.cpp:181
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
 msgid "&Previous"
 msgstr "&Sebelumnya"
 
@@ -572,77 +611,74 @@ msgstr "&Sebelumnya"
 msgid "&Previous Paragraph"
 msgstr "&Paragraf Sebelumnya"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "&Print..."
 msgstr "&Cetak..."
 
-#: ../src/richtext/richtextctrl.cpp:339 ../src/richtext/richtextctrl.cpp:5514
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtextctrl.cpp:338
+#: ../src/richtext/richtextctrl.cpp:5512
 msgid "&Properties"
 msgstr "&Properti"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "&Quit"
 msgstr "&Keluar"
 
-#: ../src/richtext/richtextctrl.cpp:330 ../src/osx/textctrl_osx.cpp:574
-#: ../src/common/stockitem.cpp:185 ../src/common/cmdproc.cpp:293
-#: ../src/common/cmdproc.cpp:300 ../src/msw/textctrl.cpp:2505
+#: ../src/osx/textctrl_osx.cpp:592 ../src/common/stockitem.cpp:182
+#: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
+#: ../src/msw/textctrl.cpp:2770 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Kerjakan Lagi"
 
-#: ../src/common/cmdproc.cpp:289 ../src/common/cmdproc.cpp:309
+#: ../src/common/cmdproc.cpp:282 ../src/common/cmdproc.cpp:302
 msgid "&Redo "
 msgstr "&Kerjakan Lagi "
 
-#: ../src/richtext/richtextstyledlg.cpp:257
+#: ../src/richtext/richtextstyledlg.cpp:253
 msgid "&Rename Style..."
 msgstr "&Ubah Nama Gaya..."
 
-#: ../src/generic/fdrepdlg.cpp:179
+#: ../src/generic/fdrepdlg.cpp:176
 msgid "&Replace"
 msgstr "&Ganti"
 
-#: ../src/richtext/richtextstyledlg.cpp:287
+#: ../src/richtext/richtextstyledlg.cpp:283
 msgid "&Restart numbering"
 msgstr "&Ulangi penomoran"
 
-#: ../src/univ/themes/win32.cpp:3747
+#: ../src/univ/themes/win32.cpp:3744
 msgid "&Restore"
 msgstr "&Pulihkan"
 
-#: ../src/richtext/richtextindentspage.cpp:146
 #: ../src/richtext/richtextliststylepage.cpp:335
+#: ../src/richtext/richtextindentspage.cpp:146
 msgid "&Right"
 msgstr "&Kanan"
 
-#: ../src/richtext/richtextindentspage.cpp:213
+#: ../src/richtext/richtextsizepage.cpp:602
+#: ../src/richtext/richtextsizepage.cpp:609
 #: ../src/richtext/richtextborderspage.cpp:277
 #: ../src/richtext/richtextborderspage.cpp:445
 #: ../src/richtext/richtextliststylepage.cpp:399
+#: ../src/richtext/richtextindentspage.cpp:213
 #: ../src/richtext/richtextmarginspage.cpp:211
 #: ../src/richtext/richtextmarginspage.cpp:325
-#: ../src/richtext/richtextsizepage.cpp:602 ../src/richtext/richtextsizepage.cpp:609
 msgid "&Right:"
 msgstr "&Kanan:"
 
-#: ../src/common/stockitem.cpp:190
+#: ../src/common/stockitem.cpp:187
 msgid "&Save"
 msgstr "&Simpan"
-
-#: ../src/common/stockitem.cpp:191
-msgid "&Save as"
-msgstr "&Simpan sebagai"
 
 #: ../include/wx/richmsgdlg.h:29
 msgid "&See details"
 msgstr "&Lihat detail"
 
-#: ../src/generic/tipdlg.cpp:236
+#: ../src/generic/tipdlg.cpp:233
 msgid "&Show tips at startup"
 msgstr "&Tampilkan tip saat awal mula"
 
-#: ../src/univ/themes/win32.cpp:3750
+#: ../src/univ/themes/win32.cpp:3747
 msgid "&Size"
 msgstr "&Ukuran"
 
@@ -650,36 +686,36 @@ msgstr "&Ukuran"
 msgid "&Size:"
 msgstr "&Ukuran:"
 
-#: ../src/generic/progdlgg.cpp:252
+#: ../src/generic/progdlgg.cpp:249
 msgid "&Skip"
 msgstr "&Lewati"
 
-#: ../src/richtext/richtextindentspage.cpp:242
 #: ../src/richtext/richtextliststylepage.cpp:417
+#: ../src/richtext/richtextindentspage.cpp:242
 msgid "&Spacing (tenths of a mm)"
 msgstr "&Spasi (persepuluh mm)"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "&Spell Check"
 msgstr "Perik&sa Ejaan"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "&Stop"
 msgstr "&Stop"
 
-#: ../src/richtext/richtextfontpage.cpp:275 ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196 ../src/richtext/richtextfontpage.cpp:275
 msgid "&Strikethrough"
 msgstr "&Coret"
 
-#: ../src/generic/fontdlgg.cpp:382 ../src/richtext/richtextstylepage.cpp:106
+#: ../src/generic/fontdlgg.cpp:378 ../src/richtext/richtextstylepage.cpp:106
 msgid "&Style:"
 msgstr "&Gaya:"
 
-#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:194
 msgid "&Styles:"
 msgstr "&Gaya:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:413
+#: ../src/richtext/richtextsymboldlg.cpp:410
 msgid "&Subset:"
 msgstr "&Subset:"
 
@@ -693,23 +729,24 @@ msgstr "&Simbol:"
 msgid "&Synchronize values"
 msgstr "&Sinkronisasikan nilai"
 
-#: ../include/wx/richtext/richtextbuffer.h:6069
+#: ../include/wx/richtext/richtextbuffer.h:6064
 msgid "&Table"
 msgstr "&Tabel"
 
-#: ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197
 msgid "&Top"
 msgstr "A&tas"
 
+#: ../src/richtext/richtextsizepage.cpp:567
+#: ../src/richtext/richtextsizepage.cpp:574
 #: ../src/richtext/richtextborderspage.cpp:311
 #: ../src/richtext/richtextborderspage.cpp:479
 #: ../src/richtext/richtextmarginspage.cpp:234
 #: ../src/richtext/richtextmarginspage.cpp:348
-#: ../src/richtext/richtextsizepage.cpp:567 ../src/richtext/richtextsizepage.cpp:574
 msgid "&Top:"
 msgstr "A&tas:"
 
-#: ../src/generic/fontdlgg.cpp:444 ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199 ../src/generic/fontdlgg.cpp:441
 msgid "&Underline"
 msgstr "&Garisbawahi"
 
@@ -717,21 +754,21 @@ msgstr "&Garisbawahi"
 msgid "&Underlining:"
 msgstr "&Garis bawah:"
 
-#: ../src/richtext/richtextctrl.cpp:329 ../src/osx/textctrl_osx.cpp:573
-#: ../src/common/stockitem.cpp:203 ../src/common/cmdproc.cpp:271
-#: ../src/msw/textctrl.cpp:2504
+#: ../src/osx/textctrl_osx.cpp:591 ../src/common/stockitem.cpp:200
+#: ../src/common/cmdproc.cpp:264 ../src/msw/textctrl.cpp:2769
+#: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Urungkan"
 
-#: ../src/common/cmdproc.cpp:265
+#: ../src/common/cmdproc.cpp:258
 msgid "&Undo "
 msgstr "&Urungkan "
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "&Unindent"
 msgstr "&Unindent"
 
-#: ../src/common/stockitem.cpp:205
+#: ../src/common/stockitem.cpp:202
 msgid "&Up"
 msgstr "&Naik"
 
@@ -747,95 +784,67 @@ msgstr "Jarak &vertikal:"
 msgid "&View..."
 msgstr "&Tampilan."
 
-#: ../src/generic/fontdlgg.cpp:393
+#: ../src/generic/fontdlgg.cpp:389
 msgid "&Weight:"
 msgstr "&Bobot:"
 
-#: ../src/richtext/richtextsizepage.cpp:317 ../src/richtext/richtextsizepage.cpp:324
+#: ../src/richtext/richtextsizepage.cpp:317
+#: ../src/richtext/richtextsizepage.cpp:324
 msgid "&Width:"
 msgstr "&Lebar:"
 
-#: ../src/aui/tabmdi.cpp:311 ../src/aui/tabmdi.cpp:327 ../src/aui/tabmdi.cpp:329
-#: ../src/generic/mdig.cpp:294 ../src/generic/mdig.cpp:310
-#: ../src/generic/mdig.cpp:314 ../src/msw/mdi.cpp:78
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
 msgid "&Window"
 msgstr "&Jendela"
 
-#: ../src/common/stockitem.cpp:206 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:203 ../src/msw/msgdlg.cpp:435
 msgid "&Yes"
 msgstr "&Ya"
 
-#: ../src/common/valtext.cpp:256
-#, c-format
-msgid "'%s' contains illegal characters"
+#: ../src/common/valtext.cpp:197
+#, fuzzy, c-format
+msgid "'%s' contains invalid character(s)"
 msgstr "'%s' mengandung karakter ilegal"
 
-#: ../src/common/valtext.cpp:254
-#, c-format
-msgid "'%s' doesn't consist only of valid characters"
-msgstr "'%s' tidak terdiri dari karakter yang sah"
-
-#: ../src/common/config.cpp:519 ../src/msw/regconf.cpp:258
+#: ../src/common/config.cpp:515 ../src/msw/regconf.cpp:255
 #, c-format
 msgid "'%s' has extra '..', ignored."
 msgstr "'%s' mempunyai '..' ekstra, diabaikan."
 
-#: ../src/common/cmdline.cpp:1113 ../src/common/cmdline.cpp:1131
+#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' bukan suatu nilai numerik yang benar untuk pilihan '%s'."
 
-#: ../src/common/translation.cpp:1100
+#: ../src/common/translation.cpp:1142
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' bukan suatu katalog pesan yang sah."
 
-#: ../src/common/valtext.cpp:165
+#: ../src/common/valtext.cpp:188
 #, c-format
 msgid "'%s' is not one of the valid strings"
 msgstr "'%s' bukan merupakan string yang sah"
 
-#: ../src/common/valtext.cpp:167
+#: ../src/common/valtext.cpp:186
 #, c-format
 msgid "'%s' is one of the invalid strings"
 msgstr "'%s' merupakan string tidak sah"
 
-#: ../src/common/textbuf.cpp:237
+#: ../src/common/textbuf.cpp:233
 #, c-format
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' kemungkinan suatu penyangga biner."
-
-#: ../src/common/valtext.cpp:252
-#, c-format
-msgid "'%s' should be numeric."
-msgstr "'%s' harus numerik."
-
-#: ../src/common/valtext.cpp:244
-#, c-format
-msgid "'%s' should only contain ASCII characters."
-msgstr "'%s' harus hanya berisi karakter ASCII."
-
-#: ../src/common/valtext.cpp:246
-#, c-format
-msgid "'%s' should only contain alphabetic characters."
-msgstr "'%s' harus hanya berisi karakter alfabet."
-
-#: ../src/common/valtext.cpp:248
-#, c-format
-msgid "'%s' should only contain alphabetic or numeric characters."
-msgstr "'%s' harus hanya berisi karakter alfabet atau numerik."
-
-#: ../src/common/valtext.cpp:250
-#, c-format
-msgid "'%s' should only contain digits."
-msgstr "'%s' hanya boleh berisi angka."
 
 #: ../src/richtext/richtextliststylepage.cpp:229
 #: ../src/richtext/richtextbulletspage.cpp:166
 msgid "(*)"
 msgstr "(*)"
 
-#: ../src/html/helpwnd.cpp:963
+#: ../src/html/helpwnd.cpp:961
 msgid "(Help)"
 msgstr "(Bantuan)"
 
@@ -844,25 +853,32 @@ msgstr "(Bantuan)"
 msgid "(None)"
 msgstr "(Nihil)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:504
+#: ../src/richtext/richtextsymboldlg.cpp:503
 msgid "(Normal text)"
 msgstr "(Teks normal)"
 
-#: ../src/html/helpwnd.cpp:419 ../src/html/helpwnd.cpp:1106
-#: ../src/html/helpwnd.cpp:1742
+#: ../src/html/helpwnd.cpp:417 ../src/html/helpwnd.cpp:1104
+#: ../src/html/helpwnd.cpp:1740
 msgid "(bookmarks)"
 msgstr "(tanda taut)"
 
+#: ../src/msw/dlmsw.cpp:167
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (galat %ld: %s)"
+
+#: ../src/richtext/richtextformatdlg.cpp:876
+#: ../src/richtext/richtextliststylepage.cpp:448
+#: ../src/richtext/richtextliststylepage.cpp:460
+#: ../src/richtext/richtextliststylepage.cpp:461
 #: ../src/richtext/richtextindentspage.cpp:274
 #: ../src/richtext/richtextindentspage.cpp:286
 #: ../src/richtext/richtextindentspage.cpp:287
 #: ../src/richtext/richtextindentspage.cpp:311
 #: ../src/richtext/richtextindentspage.cpp:326
-#: ../src/richtext/richtextformatdlg.cpp:884 ../src/richtext/richtextfontpage.cpp:349
-#: ../src/richtext/richtextfontpage.cpp:353 ../src/richtext/richtextfontpage.cpp:357
-#: ../src/richtext/richtextliststylepage.cpp:448
-#: ../src/richtext/richtextliststylepage.cpp:460
-#: ../src/richtext/richtextliststylepage.cpp:461
+#: ../src/richtext/richtextfontpage.cpp:349
+#: ../src/richtext/richtextfontpage.cpp:353
+#: ../src/richtext/richtextfontpage.cpp:357
 msgid "(none)"
 msgstr "(nihil)"
 
@@ -881,7 +897,7 @@ msgstr "*)"
 msgid "+"
 msgstr "+"
 
-#: ../src/msw/utils.cpp:1152
+#: ../src/msw/utils.cpp:1143
 msgid ", 64-bit edition"
 msgstr ", edisi 64-bit"
 
@@ -890,163 +906,163 @@ msgstr ", edisi 64-bit"
 msgid "-"
 msgstr "-"
 
-#: ../src/generic/filepickerg.cpp:66
+#: ../src/generic/filepickerg.cpp:63
 msgid "..."
 msgstr "..."
 
-#: ../src/richtext/richtextindentspage.cpp:276
 #: ../src/richtext/richtextliststylepage.cpp:450
+#: ../src/richtext/richtextindentspage.cpp:276
 msgid "1.1"
 msgstr "1.1"
 
-#: ../src/richtext/richtextindentspage.cpp:277
 #: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextindentspage.cpp:277
 msgid "1.2"
 msgstr "1.2"
 
-#: ../src/richtext/richtextindentspage.cpp:278
 #: ../src/richtext/richtextliststylepage.cpp:452
+#: ../src/richtext/richtextindentspage.cpp:278
 msgid "1.3"
 msgstr "1.3"
 
-#: ../src/richtext/richtextindentspage.cpp:279
 #: ../src/richtext/richtextliststylepage.cpp:453
+#: ../src/richtext/richtextindentspage.cpp:279
 msgid "1.4"
 msgstr "1.4"
 
-#: ../src/richtext/richtextindentspage.cpp:280
 #: ../src/richtext/richtextliststylepage.cpp:454
+#: ../src/richtext/richtextindentspage.cpp:280
 msgid "1.5"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:281
 #: ../src/richtext/richtextliststylepage.cpp:455
+#: ../src/richtext/richtextindentspage.cpp:281
 msgid "1.6"
 msgstr "1.6"
 
-#: ../src/richtext/richtextindentspage.cpp:282
 #: ../src/richtext/richtextliststylepage.cpp:456
+#: ../src/richtext/richtextindentspage.cpp:282
 msgid "1.7"
 msgstr "1.7"
 
-#: ../src/richtext/richtextindentspage.cpp:283
 #: ../src/richtext/richtextliststylepage.cpp:457
+#: ../src/richtext/richtextindentspage.cpp:283
 msgid "1.8"
 msgstr "1.8"
 
-#: ../src/richtext/richtextindentspage.cpp:284
 #: ../src/richtext/richtextliststylepage.cpp:458
+#: ../src/richtext/richtextindentspage.cpp:284
 msgid "1.9"
 msgstr "1.9"
 
-#: ../src/common/paper.cpp:140
+#: ../src/common/paper.cpp:137
 msgid "10 x 11 in"
 msgstr "10 x 11 in"
 
-#: ../src/common/paper.cpp:113
+#: ../src/common/paper.cpp:110
 msgid "10 x 14 in"
 msgstr "10 x 14 in"
 
-#: ../src/common/paper.cpp:114
+#: ../src/common/paper.cpp:111
 msgid "11 x 17 in"
 msgstr "11 x 17 in"
 
-#: ../src/common/paper.cpp:184
+#: ../src/common/paper.cpp:181
 msgid "12 x 11 in"
 msgstr "12 x 11 in"
 
-#: ../src/common/paper.cpp:141
+#: ../src/common/paper.cpp:138
 msgid "15 x 11 in"
 msgstr "15 x 11 in"
 
-#: ../src/richtext/richtextindentspage.cpp:285
 #: ../src/richtext/richtextliststylepage.cpp:459
+#: ../src/richtext/richtextindentspage.cpp:285
 msgid "2"
 msgstr "2"
 
-#: ../src/common/paper.cpp:132
+#: ../src/common/paper.cpp:129
 msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
 msgstr "Amplop 6 3/4, 3 5/8 x 6 1/2 in"
 
-#: ../src/common/paper.cpp:139
+#: ../src/common/paper.cpp:136
 msgid "9 x 11 in"
 msgstr "9 x 11 in"
 
-#: ../src/html/htmprint.cpp:431
+#: ../src/html/htmprint.cpp:443
 msgid ": file does not exist!"
 msgstr ": berkas tidak ada!"
 
-#: ../src/common/fontmap.cpp:199
+#: ../src/common/fontmap.cpp:196
 msgid ": unknown charset"
 msgstr ": charset tidak dikenal"
 
-#: ../src/common/fontmap.cpp:413
+#: ../src/common/fontmap.cpp:410
 msgid ": unknown encoding"
 msgstr ": pengkodean tidak diketahui"
 
-#: ../src/generic/wizard.cpp:443
+#: ../src/generic/wizard.cpp:438
 msgid "< &Back"
 msgstr "< &Mundur"
 
-#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:628
-#: ../src/osx/carbon/fontdlg.cpp:648
+#: ../src/osx/carbon/fontdlg.cpp:419 ../src/osx/carbon/fontdlg.cpp:625
+#: ../src/osx/carbon/fontdlg.cpp:645
 msgid "<Any Decorative>"
 msgstr "<Sebarang Dekoratif>"
 
-#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:630
-#: ../src/osx/carbon/fontdlg.cpp:650
+#: ../src/osx/carbon/fontdlg.cpp:420 ../src/osx/carbon/fontdlg.cpp:627
+#: ../src/osx/carbon/fontdlg.cpp:647
 msgid "<Any Modern>"
 msgstr "<Sebarang Modern>"
 
-#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:626
-#: ../src/osx/carbon/fontdlg.cpp:646
+#: ../src/osx/carbon/fontdlg.cpp:418 ../src/osx/carbon/fontdlg.cpp:623
+#: ../src/osx/carbon/fontdlg.cpp:643
 msgid "<Any Roman>"
 msgstr "<Sebarang Roman>"
 
-#: ../src/osx/carbon/fontdlg.cpp:424 ../src/osx/carbon/fontdlg.cpp:632
-#: ../src/osx/carbon/fontdlg.cpp:652
+#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:629
+#: ../src/osx/carbon/fontdlg.cpp:649
 msgid "<Any Script>"
 msgstr "<Sebarang Skrip>"
 
-#: ../src/osx/carbon/fontdlg.cpp:425 ../src/osx/carbon/fontdlg.cpp:637
-#: ../src/osx/carbon/fontdlg.cpp:656
+#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:634
+#: ../src/osx/carbon/fontdlg.cpp:653
 msgid "<Any Swiss>"
 msgstr "<Sebarang Swiss>"
 
-#: ../src/osx/carbon/fontdlg.cpp:426 ../src/osx/carbon/fontdlg.cpp:634
-#: ../src/osx/carbon/fontdlg.cpp:654
+#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:631
+#: ../src/osx/carbon/fontdlg.cpp:651
 msgid "<Any Teletype>"
 msgstr "<Sebarang Teletype>"
 
-#: ../src/osx/carbon/fontdlg.cpp:420
+#: ../src/osx/carbon/fontdlg.cpp:417
 msgid "<Any>"
 msgstr "<Apapun>"
 
-#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
 msgid "<DIR>"
 msgstr "<DIR>"
 
-#: ../src/generic/filectrlg.cpp:254 ../src/generic/filectrlg.cpp:277
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
 msgid "<DRIVE>"
 msgstr "<DRIVE>"
 
-#: ../src/generic/filectrlg.cpp:252 ../src/generic/filectrlg.cpp:275
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
 msgid "<LINK>"
 msgstr "<TAUT>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1264
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Contoh miring tebal.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1270
+#: ../src/html/helpwnd.cpp:1268
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>miring tebal <u>digarisbawahi</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1265
+#: ../src/html/helpwnd.cpp:1263
 msgid "<b>Bold face.</b> "
 msgstr "<b>Contoh tebal.</b> "
 
-#: ../src/html/helpwnd.cpp:1264
+#: ../src/html/helpwnd.cpp:1262
 msgid "<i>Italic face.</i> "
 msgstr "<i>Contoh miring.</i> "
 
@@ -1055,15 +1071,15 @@ msgstr "<i>Contoh miring.</i> "
 msgid ">"
 msgstr ">"
 
-#: ../src/generic/dbgrptg.cpp:318
+#: ../src/generic/dbgrptg.cpp:317
 msgid "A debug report has been generated in the directory\n"
 msgstr "Laporan debug telah dihasilkan di dalam direktori\n"
 
-#: ../src/common/debugrpt.cpp:573
+#: ../src/common/debugrpt.cpp:574
 msgid "A debug report has been generated. It can be found in"
 msgstr "Laporan debug berhasil dibuat. Laporan dapat ditemukan di"
 
-#: ../src/common/xtixml.cpp:418
+#: ../src/common/xtixml.cpp:414
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Suatu koleksi tak kosong mesti terdiri dari node 'elemen'"
 
@@ -1074,106 +1090,106 @@ msgstr "Suatu koleksi tak kosong mesti terdiri dari node 'elemen'"
 msgid "A standard bullet name."
 msgstr "Nama bullet standar."
 
-#: ../src/common/paper.cpp:217
+#: ../src/common/paper.cpp:214
 msgid "A0 sheet, 841 x 1189 mm"
 msgstr "Lembar A0, 841 x 1189 mm"
 
-#: ../src/common/paper.cpp:218
+#: ../src/common/paper.cpp:215
 msgid "A1 sheet, 594 x 841 mm"
 msgstr "Lembar A1, 594 x 841 mm"
 
-#: ../src/common/paper.cpp:159
+#: ../src/common/paper.cpp:156
 msgid "A2 420 x 594 mm"
 msgstr "A2 420 x 594 mm"
 
-#: ../src/common/paper.cpp:156
+#: ../src/common/paper.cpp:153
 msgid "A3 Extra 322 x 445 mm"
 msgstr "A3 Ekstra 322 x 445 mm"
 
-#: ../src/common/paper.cpp:161
+#: ../src/common/paper.cpp:158
 msgid "A3 Extra Transverse 322 x 445 mm"
 msgstr "A3 Ekstra Transverse 322 x 445 mm"
 
-#: ../src/common/paper.cpp:170
+#: ../src/common/paper.cpp:167
 msgid "A3 Rotated 420 x 297 mm"
 msgstr "A3 Diputar 420 x 297 mm"
 
-#: ../src/common/paper.cpp:160
+#: ../src/common/paper.cpp:157
 msgid "A3 Transverse 297 x 420 mm"
 msgstr "A3 Transverse 297 x 420 mm"
 
-#: ../src/common/paper.cpp:106
+#: ../src/common/paper.cpp:103
 msgid "A3 sheet, 297 x 420 mm"
 msgstr "Lembar A3, 297 x 420 mm"
 
-#: ../src/common/paper.cpp:146
+#: ../src/common/paper.cpp:143
 msgid "A4 Extra 9.27 x 12.69 in"
 msgstr "A4 Ekstra 9.27 x 12.69 in"
 
-#: ../src/common/paper.cpp:153
+#: ../src/common/paper.cpp:150
 msgid "A4 Plus 210 x 330 mm"
 msgstr "A4 Plus 210 x 330 mm"
 
-#: ../src/common/paper.cpp:171
+#: ../src/common/paper.cpp:168
 msgid "A4 Rotated 297 x 210 mm"
 msgstr "A4 Diputar 297 x 210 mm"
 
-#: ../src/common/paper.cpp:148
+#: ../src/common/paper.cpp:145
 msgid "A4 Transverse 210 x 297 mm"
 msgstr "A4 Transverse 210 x 297 mm"
 
-#: ../src/common/paper.cpp:97
+#: ../src/common/paper.cpp:94
 msgid "A4 sheet, 210 x 297 mm"
 msgstr "Lembar A4, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:107
+#: ../src/common/paper.cpp:104
 msgid "A4 small sheet, 210 x 297 mm"
 msgstr "Lembar kecil A4, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:157
+#: ../src/common/paper.cpp:154
 msgid "A5 Extra 174 x 235 mm"
 msgstr "A5 Ekstra 174 x 235 mm"
 
-#: ../src/common/paper.cpp:172
+#: ../src/common/paper.cpp:169
 msgid "A5 Rotated 210 x 148 mm"
 msgstr "A5 Diputar 210 x 148 mm"
 
-#: ../src/common/paper.cpp:154
+#: ../src/common/paper.cpp:151
 msgid "A5 Transverse 148 x 210 mm"
 msgstr "A5 Transverse 148 x 210 mm"
 
-#: ../src/common/paper.cpp:108
+#: ../src/common/paper.cpp:105
 msgid "A5 sheet, 148 x 210 mm"
 msgstr "Lembar A5, 148 x 210 mm"
 
-#: ../src/common/paper.cpp:164
+#: ../src/common/paper.cpp:161
 msgid "A6 105 x 148 mm"
 msgstr "A6 105 x 148 mm"
 
-#: ../src/common/paper.cpp:177
+#: ../src/common/paper.cpp:174
 msgid "A6 Rotated 148 x 105 mm"
 msgstr "A6 Diputar 148 x 105 mm"
 
-#: ../src/generic/fontdlgg.cpp:83 ../src/richtext/richtextformatdlg.cpp:529
-#: ../src/osx/carbon/fontdlg.cpp:153
+#: ../src/osx/carbon/fontdlg.cpp:150 ../src/generic/fontdlgg.cpp:79
+#: ../src/richtext/richtextformatdlg.cpp:521
 msgid "ABCDEFGabcdefg12345"
 msgstr "ABCDEFGabcdefg12345"
 
-#: ../src/richtext/richtextsymboldlg.cpp:458 ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
 msgid "ASCII"
 msgstr "ASCII"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "About"
 msgstr "Tentang"
 
-#: ../src/generic/aboutdlgg.cpp:140 ../src/osx/menu_osx.cpp:558
-#: ../src/msw/aboutdlg.cpp:64
+#: ../src/osx/menu_osx.cpp:450 ../src/generic/aboutdlgg.cpp:137
+#: ../src/msw/aboutdlg.cpp:61
 #, c-format
 msgid "About %s"
 msgstr "Tentang %s"
 
-#: ../src/osx/menu_osx.cpp:560
+#: ../src/osx/menu_osx.cpp:452
 msgid "About..."
 msgstr "Tentang..."
 
@@ -1182,37 +1198,37 @@ msgid "Absolute"
 msgstr "Absolut"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:873
+#: ../src/propgrid/advprops.cpp:774
 msgid "ActiveBorder"
 msgstr "TepiAktif"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:874
+#: ../src/propgrid/advprops.cpp:775
 msgid "ActiveCaption"
 msgstr "JudulAktif"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "Actual Size"
 msgstr "Ukuran Asli"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:140 ../src/common/accelcmn.cpp:81
+#: ../src/common/stockitem.cpp:137 ../src/common/accelcmn.cpp:78
 msgid "Add"
 msgstr "Add"
 
-#: ../src/richtext/richtextbuffer.cpp:11455
+#: ../src/richtext/richtextbuffer.cpp:11454
 msgid "Add Column"
 msgstr "Tambah Kolom"
 
-#: ../src/richtext/richtextbuffer.cpp:11392
+#: ../src/richtext/richtextbuffer.cpp:11391
 msgid "Add Row"
 msgstr "Tambah Baris"
 
-#: ../src/html/helpwnd.cpp:432
+#: ../src/html/helpwnd.cpp:430
 msgid "Add current page to bookmarks"
 msgstr "Tambahkan halaman ini ke penanda taut"
 
-#: ../src/generic/colrdlgg.cpp:366
+#: ../src/generic/colrdlgg.cpp:386
 msgid "Add to custom colours"
 msgstr "Tambahkan ke warna kustom"
 
@@ -1224,12 +1240,12 @@ msgstr "AddToPropertyCollection dipanggil pada suatu pengakses generik"
 msgid "AddToPropertyCollection called w/o valid adder"
 msgstr "AddToPropertyCollection dipanggil tanpa penambah yang sah"
 
-#: ../src/html/helpctrl.cpp:159
+#: ../src/html/helpctrl.cpp:155
 #, c-format
 msgid "Adding book %s"
 msgstr "Menambahkan buku %s"
 
-#: ../src/common/preferencescmn.cpp:43
+#: ../src/common/preferencescmn.cpp:40
 msgid "Advanced"
 msgstr "Tingkat lanjut"
 
@@ -1237,11 +1253,11 @@ msgstr "Tingkat lanjut"
 msgid "After a paragraph:"
 msgstr "Setelah paragraf:"
 
-#: ../src/common/stockitem.cpp:172
+#: ../src/common/stockitem.cpp:169
 msgid "Align Left"
 msgstr "Rata Kiri"
 
-#: ../src/common/stockitem.cpp:173
+#: ../src/common/stockitem.cpp:170
 msgid "Align Right"
 msgstr "Rata Kanan"
 
@@ -1249,40 +1265,40 @@ msgstr "Rata Kanan"
 msgid "Alignment"
 msgstr "Perataan"
 
-#: ../src/generic/prntdlgg.cpp:215
+#: ../src/generic/prntdlgg.cpp:208
 msgid "All"
 msgstr "Semua"
 
-#: ../src/generic/filectrlg.cpp:1197 ../src/common/fldlgcmn.cpp:107
+#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1186
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Semua berkas (%s)|%s"
 
-#: ../include/wx/defs.h:2886
+#: ../include/wx/defs.h:2582
 msgid "All files (*)|*"
 msgstr "Semua berkas (*)|*"
 
-#: ../include/wx/defs.h:2883
+#: ../include/wx/defs.h:2579
 msgid "All files (*.*)|*.*"
 msgstr "Semua berkas (*.*)|*.*"
 
-#: ../src/richtext/richtextstyles.cpp:1061
+#: ../src/richtext/richtextstyles.cpp:1058
 msgid "All styles"
 msgstr "Semua gaya"
 
-#: ../src/propgrid/manager.cpp:1528
+#: ../src/propgrid/manager.cpp:1544
 msgid "Alphabetic Mode"
 msgstr "Mode Alfabet"
 
-#: ../src/common/xtistrm.cpp:425
+#: ../src/common/xtistrm.cpp:422
 msgid "Already Registered Object passed to SetObjectClassInfo"
 msgstr "Obyek Yang Sudah Terdaftar disampaikan ke SetObjectClassInfo"
 
-#: ../src/unix/dialup.cpp:353
+#: ../src/unix/dialup.cpp:352
 msgid "Already dialling ISP."
 msgstr "Sedang menghubungi ISP."
 
-#: ../src/common/accelcmn.cpp:331 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/accelcmn.cpp:345 ../src/univ/themes/win32.cpp:3753
 msgid "Alt+"
 msgstr "Alt+"
 
@@ -1291,34 +1307,34 @@ msgstr "Alt+"
 msgid "An optional corner radius for adding rounded corners."
 msgstr "Opsi radius pojok untuk menambahkan pojokan melengkung."
 
-#: ../src/common/debugrpt.cpp:576
+#: ../src/common/debugrpt.cpp:577
 msgid "And includes the following files:\n"
 msgstr "Dan sertakan berkas berikut:\n"
 
-#: ../src/generic/animateg.cpp:162
+#: ../src/generic/animateg.cpp:145
 #, c-format
 msgid "Animation file is not of type %ld."
 msgstr "Berkas animasi bukan bertipe %ld."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:872
+#: ../src/propgrid/advprops.cpp:773
 msgid "AppWorkspace"
 msgstr "RuangKerjaApp"
 
-#: ../src/generic/logg.cpp:1014
+#: ../src/generic/logg.cpp:1011
 #, c-format
 msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
 msgstr "Tambahkan log ke berkas '%s' (memilih [Tidak] akan menimpanya)?"
 
-#: ../src/osx/menu_osx.cpp:577 ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:469 ../src/osx/menu_osx.cpp:477
 msgid "Application"
 msgstr "Aplikasi"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "Apply"
 msgstr "Terapkan"
 
-#: ../src/propgrid/advprops.cpp:1609
+#: ../src/propgrid/advprops.cpp:1515
 msgid "Aqua"
 msgstr "Biru Muda"
 
@@ -1327,29 +1343,29 @@ msgstr "Biru Muda"
 msgid "Arabic"
 msgstr "Arab"
 
-#: ../src/common/fmapbase.cpp:153
+#: ../src/common/fmapbase.cpp:150
 msgid "Arabic (ISO-8859-6)"
 msgstr "Arab (ISO-8859-6)"
 
-#: ../src/msw/ole/automtn.cpp:672
+#: ../src/msw/ole/automtn.cpp:663
 #, c-format
 msgid "Argument %u not found."
 msgstr "Argumen %u tidak ditemukan."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1753
+#: ../src/propgrid/advprops.cpp:1654
 msgid "Arrow"
 msgstr "Panah"
 
-#: ../src/generic/aboutdlgg.cpp:184
+#: ../src/generic/aboutdlgg.cpp:181
 msgid "Artists"
 msgstr "Artis"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "Ascending"
 msgstr "Urut naik"
 
-#: ../src/generic/filectrlg.cpp:433
+#: ../src/generic/filectrlg.cpp:429
 msgid "Attributes"
 msgstr "Atribut"
 
@@ -1359,90 +1375,90 @@ msgstr "Atribut"
 msgid "Available fonts."
 msgstr "Font yang tesedia."
 
-#: ../src/common/paper.cpp:137
+#: ../src/common/paper.cpp:134
 msgid "B4 (ISO) 250 x 353 mm"
 msgstr "B4 (ISO) 250 x 353 mm"
 
-#: ../src/common/paper.cpp:173
+#: ../src/common/paper.cpp:170
 msgid "B4 (JIS) Rotated 364 x 257 mm"
 msgstr "B4 (JIS) Diputar 364 x 257 mm"
 
-#: ../src/common/paper.cpp:127
+#: ../src/common/paper.cpp:124
 msgid "B4 Envelope, 250 x 353 mm"
 msgstr "Amplop B4, 250 x 353 mm"
 
-#: ../src/common/paper.cpp:109
+#: ../src/common/paper.cpp:106
 msgid "B4 sheet, 250 x 354 mm"
 msgstr "Lembar B4, 250 x 354 mm"
 
-#: ../src/common/paper.cpp:158
+#: ../src/common/paper.cpp:155
 msgid "B5 (ISO) Extra 201 x 276 mm"
 msgstr "B5 (ISO) Ekstra 201 x 276 mm"
 
-#: ../src/common/paper.cpp:174
+#: ../src/common/paper.cpp:171
 msgid "B5 (JIS) Rotated 257 x 182 mm"
 msgstr "B5 (JIS) Diputar 257 x 182 mm"
 
-#: ../src/common/paper.cpp:155
+#: ../src/common/paper.cpp:152
 msgid "B5 (JIS) Transverse 182 x 257 mm"
 msgstr "B5 (JIS) Transverse 182 x 257 mm"
 
-#: ../src/common/paper.cpp:128
+#: ../src/common/paper.cpp:125
 msgid "B5 Envelope, 176 x 250 mm"
 msgstr "Amplop B5, 176 x 250 mm"
 
-#: ../src/common/paper.cpp:110
+#: ../src/common/paper.cpp:107
 msgid "B5 sheet, 182 x 257 millimeter"
 msgstr "Lembar B5, 182 x 257 millimeter"
 
-#: ../src/common/paper.cpp:182
+#: ../src/common/paper.cpp:179
 msgid "B6 (JIS) 128 x 182 mm"
 msgstr "B6 (JIS) 128 x 182 mm"
 
-#: ../src/common/paper.cpp:183
+#: ../src/common/paper.cpp:180
 msgid "B6 (JIS) Rotated 182 x 128 mm"
 msgstr "B6 (JIS) Diputar 182 x 128 mm"
 
-#: ../src/common/paper.cpp:129
+#: ../src/common/paper.cpp:126
 msgid "B6 Envelope, 176 x 125 mm"
 msgstr "Amplop B6, 176 x 125 mm"
 
-#: ../src/common/imagbmp.cpp:531 ../src/common/imagbmp.cpp:561
-#: ../src/common/imagbmp.cpp:576
+#: ../src/common/imagbmp.cpp:528 ../src/common/imagbmp.cpp:558
+#: ../src/common/imagbmp.cpp:573
 msgid "BMP: Couldn't allocate memory."
 msgstr "BMP: Gagal mengalokasikan memori."
 
-#: ../src/common/imagbmp.cpp:100
+#: ../src/common/imagbmp.cpp:97
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: Gagal menympan citra tidak sah."
 
-#: ../src/common/imagbmp.cpp:356
+#: ../src/common/imagbmp.cpp:353
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: Gagal menulis peta warna RGB."
 
-#: ../src/common/imagbmp.cpp:490
+#: ../src/common/imagbmp.cpp:487
 msgid "BMP: Couldn't write data."
 msgstr "BMP: Gagal menulis data."
 
-#: ../src/common/imagbmp.cpp:246
+#: ../src/common/imagbmp.cpp:243
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: Gagal menulis header berkas (Bitmap)."
 
-#: ../src/common/imagbmp.cpp:269
+#: ../src/common/imagbmp.cpp:266
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: Gagal menulis header berkas (BitmapInfo)"
 
-#: ../src/common/imagbmp.cpp:140
+#: ../src/common/imagbmp.cpp:137
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage tidak mempunyai wxPallete."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:142 ../src/common/accelcmn.cpp:52
+#: ../src/common/stockitem.cpp:139 ../src/common/accelcmn.cpp:49
 msgid "Back"
 msgstr "Back"
 
+#: ../src/richtext/richtextformatdlg.cpp:377
 #: ../src/richtext/richtextbackgroundpage.cpp:148
-#: ../src/richtext/richtextformatdlg.cpp:384
 msgid "Background"
 msgstr "Latar belakang"
 
@@ -1450,20 +1466,20 @@ msgstr "Latar belakang"
 msgid "Background &colour:"
 msgstr "Warna &latar belakang:"
 
-#: ../src/osx/carbon/fontdlg.cpp:220
+#: ../src/osx/carbon/fontdlg.cpp:217
 msgid "Background colour"
 msgstr "Warna latar belakang"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:52
+#: ../src/common/accelcmn.cpp:49
 msgid "Backspace"
 msgstr "Backspace"
 
-#: ../src/common/fmapbase.cpp:160
+#: ../src/common/fmapbase.cpp:157
 msgid "Baltic (ISO-8859-13)"
 msgstr "Baltik (ISO-8859-13)"
 
-#: ../src/common/fmapbase.cpp:151
+#: ../src/common/fmapbase.cpp:148
 msgid "Baltic (old) (ISO-8859-4)"
 msgstr "Baltik (tua) (ISO-8859-4)"
 
@@ -1476,25 +1492,25 @@ msgstr "Sebelum paragraf:"
 msgid "Bitmap"
 msgstr "Bitmap"
 
-#: ../src/propgrid/advprops.cpp:1594
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Black"
 msgstr "Hitam"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1755
+#: ../src/propgrid/advprops.cpp:1656
 msgid "Blank"
 msgstr "Kosong"
 
-#: ../src/propgrid/advprops.cpp:1603
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Blue"
 msgstr "Biru"
 
-#: ../src/generic/colrdlgg.cpp:345
+#: ../src/generic/colrdlgg.cpp:365
 msgid "Blue:"
 msgstr "Biru:"
 
-#: ../src/generic/fontdlgg.cpp:333 ../src/richtext/richtextfontpage.cpp:355
-#: ../src/osx/carbon/fontdlg.cpp:354 ../src/common/stockitem.cpp:143
+#: ../src/osx/carbon/fontdlg.cpp:351 ../src/common/stockitem.cpp:140
+#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:355
 msgid "Bold"
 msgstr "Tebal"
 
@@ -1503,31 +1519,35 @@ msgstr "Tebal"
 msgid "Border"
 msgstr "Tepi"
 
-#: ../src/richtext/richtextformatdlg.cpp:379
+#: ../src/richtext/richtextformatdlg.cpp:372
 msgid "Borders"
 msgstr "Tepi"
 
-#: ../src/richtext/richtextsizepage.cpp:288 ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141 ../src/richtext/richtextsizepage.cpp:288
 msgid "Bottom"
 msgstr "Bawah"
 
-#: ../src/generic/prntdlgg.cpp:893
+#: ../src/generic/prntdlgg.cpp:886
 msgid "Bottom margin (mm):"
 msgstr "Batas bawah (mm):"
 
-#: ../src/richtext/richtextbuffer.cpp:9383
+#: ../src/richtext/richtextbuffer.cpp:9380
 msgid "Box Properties"
 msgstr "Properti Kotak"
 
-#: ../src/richtext/richtextstyles.cpp:1065
+#: ../src/richtext/richtextstyles.cpp:1062
 msgid "Box styles"
 msgstr "Gaya kotak"
 
-#: ../src/propgrid/advprops.cpp:1602
+#: ../src/osx/cocoa/menu.mm:292
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Brown"
 msgstr "Coklat"
 
-#: ../src/common/filepickercmn.cpp:43 ../src/common/filepickercmn.cpp:44
+#: ../src/common/filepickercmn.cpp:40 ../src/common/filepickercmn.cpp:41
 msgid "Browse"
 msgstr "Ramban"
 
@@ -1540,72 +1560,72 @@ msgstr "Per&ataan Bullet:"
 msgid "Bullet style"
 msgstr "Gaya bullet"
 
-#: ../src/richtext/richtextformatdlg.cpp:359
+#: ../src/richtext/richtextformatdlg.cpp:352
 msgid "Bullets"
 msgstr "Bulet"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1756
+#: ../src/propgrid/advprops.cpp:1657
 msgid "Bullseye"
 msgstr "Sasaran"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:875
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonFace"
 msgstr "TampakMukaTombol"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:876
+#: ../src/propgrid/advprops.cpp:777
 msgid "ButtonHighlight"
 msgstr "KilauTombol"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:877
+#: ../src/propgrid/advprops.cpp:778
 msgid "ButtonShadow"
 msgstr "BayanganTombol"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:878
+#: ../src/propgrid/advprops.cpp:779
 msgid "ButtonText"
 msgstr "TeksTombol"
 
-#: ../src/common/paper.cpp:98
+#: ../src/common/paper.cpp:95
 msgid "C sheet, 17 x 22 in"
 msgstr "Lembar C, 17 x 22 inci"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "C&lear"
 msgstr "B&ersihkan"
 
-#: ../src/generic/fontdlgg.cpp:406
+#: ../src/generic/fontdlgg.cpp:403
 msgid "C&olour:"
 msgstr "W&arna:"
 
-#: ../src/common/paper.cpp:123
+#: ../src/common/paper.cpp:120
 msgid "C3 Envelope, 324 x 458 mm"
 msgstr "Amplop C3, 324 x 458 mm"
 
-#: ../src/common/paper.cpp:124
+#: ../src/common/paper.cpp:121
 msgid "C4 Envelope, 229 x 324 mm"
 msgstr "Amplop C4, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:122
+#: ../src/common/paper.cpp:119
 msgid "C5 Envelope, 162 x 229 mm"
 msgstr "Amplop C5, 162 x 229 mm"
 
-#: ../src/common/paper.cpp:125
+#: ../src/common/paper.cpp:122
 msgid "C6 Envelope, 114 x 162 mm"
 msgstr "Amplop C6, 114 x 162 mm"
 
-#: ../src/common/paper.cpp:126
+#: ../src/common/paper.cpp:123
 msgid "C65 Envelope, 114 x 229 mm"
 msgstr "Amplop C65, 114 x 229 mm"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "CD-Rom"
 msgstr "CD-Rom"
 
-#: ../src/html/chm.cpp:815 ../src/html/chm.cpp:874
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:865
 msgid "CHM handler currently supports only local files!"
 msgstr "Penangan CHM saat ini hanya mendukung berkas lokal!"
 
@@ -1613,192 +1633,196 @@ msgstr "Penangan CHM saat ini hanya mendukung berkas lokal!"
 msgid "Ca&pitals"
 msgstr "Ka&pital"
 
-#: ../src/common/cmdproc.cpp:267
+#: ../src/common/cmdproc.cpp:260
 msgid "Can't &Undo "
 msgstr "Tidak Bisa &Urungkan "
 
-#: ../src/common/image.cpp:2824
+#: ../src/common/image.cpp:2924
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr "Gagal menentukan format citra bagi masukan yang tak bisa dirambah."
 
-#: ../src/msw/registry.cpp:506
+#: ../src/msw/registry.cpp:495
 #, c-format
 msgid "Can't close registry key '%s'"
 msgstr "Gagal menutup kunci registri '%s'"
 
-#: ../src/msw/registry.cpp:584
+#: ../src/msw/registry.cpp:573
 #, c-format
 msgid "Can't copy values of unsupported type %d."
 msgstr "Gagal menyalin nilai dari tipe %d yang tidak didukung."
 
-#: ../src/msw/registry.cpp:487
+#: ../src/msw/registry.cpp:476
 #, c-format
 msgid "Can't create registry key '%s'"
 msgstr "Gagal menciptakan kunci registri '%s'"
 
-#: ../src/msw/thread.cpp:665
+#: ../src/msw/thread.cpp:657
 msgid "Can't create thread"
 msgstr "Gagal menciptakan thread"
 
-#: ../src/msw/window.cpp:3691
-#, c-format
-msgid "Can't create window of class %s"
-msgstr "Gagal menciptakan jendela dari class %s"
-
-#: ../src/msw/registry.cpp:777
+#: ../src/msw/registry.cpp:765
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Gagal menghapus kunci '%s'"
 
-#: ../src/msw/iniconf.cpp:458
+#: ../src/msw/iniconf.cpp:455
 #, c-format
 msgid "Can't delete the INI file '%s'"
 msgstr "Gagal menghapus berkas INI '%s'"
 
-#: ../src/msw/registry.cpp:805
+#: ../src/msw/registry.cpp:793
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Gagal menghapus nilai '%s' dari kunci '%s'"
 
-#: ../src/msw/registry.cpp:1171
+#: ../src/msw/registry.cpp:1159
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Gagal mengenumerasi subkunci dari kunci '%s'"
 
-#: ../src/msw/registry.cpp:1132
+#: ../src/msw/registry.cpp:1120
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Gagal mengenumerasi nilai dari kunci '%s'"
 
-#: ../src/msw/registry.cpp:1389
+#: ../src/msw/registry.cpp:1377
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Gagal mengekspor nilai dari tipe %d yang tidak didukung."
 
-#: ../src/common/ffile.cpp:254
+#: ../src/common/ffile.cpp:253
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Gagal menemukan posisi saat ini dalam berkas '%s'"
 
-#: ../src/msw/registry.cpp:418
+#: ../src/msw/registry.cpp:407
 #, c-format
 msgid "Can't get info about registry key '%s'"
 msgstr "Gagal memperoleh info tentang kunci registri '%s'"
 
-#: ../src/common/zstream.cpp:346
+#: ../src/msw/webview_ie.cpp:1024
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "Gagal menetapkan prioritas thread"
+
+#: ../src/common/zstream.cpp:343
 msgid "Can't initialize zlib deflate stream."
 msgstr "Gagal menginisialisasi stream deflate zlib."
 
-#: ../src/common/zstream.cpp:185
+#: ../src/common/zstream.cpp:182
 msgid "Can't initialize zlib inflate stream."
 msgstr "Gagal menginisialisasi stream inflate zlib."
 
-#: ../src/msw/fswatcher.cpp:476
+#: ../src/msw/fswatcher.cpp:475
 #, c-format
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "Gagal memantau perubahan pada direktori yang tidak ada \"%s\"."
 
-#: ../src/msw/registry.cpp:454
+#: ../src/msw/registry.cpp:443
 #, c-format
 msgid "Can't open registry key '%s'"
 msgstr "Gagal membuka kunci registri '%s'"
 
-#: ../src/common/zstream.cpp:252
+#: ../src/common/zstream.cpp:249
 #, c-format
 msgid "Can't read from inflate stream: %s"
 msgstr "Tak bisa membaca dari stream inflate: %s"
 
-#: ../src/common/zstream.cpp:244
+#: ../src/common/zstream.cpp:241
 msgid "Can't read inflate stream: unexpected EOF in underlying stream."
 msgstr ""
 "Gagal membaca stream inflate: EOF yang tak diharapkan pada stream yang "
 "mendasarinya."
 
-#: ../src/msw/registry.cpp:1064
+#: ../src/msw/registry.cpp:1052
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Gagal membaca nilai dari '%s'"
 
-#: ../src/msw/registry.cpp:878 ../src/msw/registry.cpp:910
-#: ../src/msw/registry.cpp:975
+#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
+#: ../src/msw/registry.cpp:963
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Gagal membaca nilai dari kunci '%s'"
 
-#: ../src/common/image.cpp:2620
+#: ../src/msw/webview_ie.cpp:1017
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/common/image.cpp:2715
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "Gagal menyimpan citra ke berkas '%s': ekstensi tidak diketahui."
 
-#: ../src/generic/logg.cpp:573 ../src/generic/logg.cpp:976
+#: ../src/generic/logg.cpp:570 ../src/generic/logg.cpp:973
 msgid "Can't save log contents to file."
 msgstr "Gagal menyimpan isi log ke berkas."
 
-#: ../src/msw/thread.cpp:629
+#: ../src/msw/thread.cpp:621
 msgid "Can't set thread priority"
 msgstr "Gagal menetapkan prioritas thread"
 
-#: ../src/msw/registry.cpp:896 ../src/msw/registry.cpp:938
-#: ../src/msw/registry.cpp:1081
+#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
+#: ../src/msw/registry.cpp:1069
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Gagal menetapkan nilai dari '%s'"
 
-#: ../src/unix/utilsunx.cpp:351
+#: ../src/unix/utilsunx.cpp:353
 msgid "Can't write to child process's stdin"
 msgstr "Gagal menulis ke stdin proses anak"
 
-#: ../src/common/zstream.cpp:427
+#: ../src/common/zstream.cpp:424
 #, c-format
 msgid "Can't write to deflate stream: %s"
 msgstr "Gagal menulis ke stream deflate: %s"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:279 ../src/richtext/richtextstyledlg.cpp:300
-#: ../src/common/stockitem.cpp:145 ../src/common/accelcmn.cpp:71
-#: ../src/msw/msgdlg.cpp:454 ../src/msw/progdlg.cpp:673 ../src/gtk1/fontdlg.cpp:144
-#: ../src/motif/msgdlg.cpp:196
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:142
+#: ../src/common/accelcmn.cpp:68 ../src/motif/msgdlg.cpp:196
+#: ../src/gtk1/fontdlg.cpp:144 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/progdlg.cpp:940 ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Cancel"
 
-#: ../src/common/filefn.cpp:1261
+#: ../src/common/filefn.cpp:1149
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Gagal mengenumerasi berkas '%s'"
 
-#: ../src/msw/dir.cpp:263
+#: ../src/msw/dir.cpp:260
 #, c-format
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Gagal mengenumerasi berkas di direktori '%s'"
 
-#: ../src/msw/dialup.cpp:523
+#: ../src/msw/dialup.cpp:517
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Gagal menemukan koneksi dialup yang aktif: %s"
 
-#: ../src/msw/dialup.cpp:827
+#: ../src/msw/dialup.cpp:821
 msgid "Cannot find the location of address book file"
 msgstr "Gagal menemukan lokasi dari berkas buku alamat"
 
-#: ../src/msw/ole/automtn.cpp:562
+#: ../src/msw/ole/automtn.cpp:553
 #, c-format
 msgid "Cannot get an active instance of \"%s\""
 msgstr "Gagal memperoleh instan aktif dari \"%s\""
 
-#: ../src/unix/threadpsx.cpp:1035
+#: ../src/unix/threadpsx.cpp:1053
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "Gagal memperoleh jangkauan prioritas untuk kebijakan penjadwalan %d."
 
-#: ../src/unix/utilsunx.cpp:987
+#: ../src/unix/utilsunx.cpp:989
 msgid "Cannot get the hostname"
 msgstr "Gagal memperoleh nama host"
 
-#: ../src/unix/utilsunx.cpp:1023
+#: ../src/unix/utilsunx.cpp:1025
 msgid "Cannot get the official hostname"
 msgstr "Gagal memperoleh nama host resmi"
 
-#: ../src/msw/dialup.cpp:928
+#: ../src/msw/dialup.cpp:922
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Gagal memutus - tidak ada koneksi dialup yang aktif."
 
@@ -1806,126 +1830,126 @@ msgstr "Gagal memutus - tidak ada koneksi dialup yang aktif."
 msgid "Cannot initialize OLE"
 msgstr "Gagal menginisialisasi OLE"
 
-#: ../src/common/socket.cpp:853
+#: ../src/common/socket.cpp:850
 msgid "Cannot initialize sockets"
 msgstr "Gagal menginisialisasi soket"
 
-#: ../src/msw/volume.cpp:619
+#: ../src/msw/volume.cpp:627
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Gagal memuat ikon dari '%s'."
 
-#: ../src/xrc/xmlres.cpp:360
+#: ../src/xrc/xmlres.cpp:358
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Gagal memuat sumber daya dari '%s'."
 
-#: ../src/xrc/xmlres.cpp:742
+#: ../src/xrc/xmlres.cpp:740
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Gagal memuat sumber daya dari berkas '%s'."
 
-#: ../src/html/htmlfilt.cpp:137
+#: ../src/html/htmlfilt.cpp:134
 #, c-format
 msgid "Cannot open HTML document: %s"
 msgstr "Gagal membuka dokumen HTML: %s"
 
-#: ../src/html/helpdata.cpp:667
+#: ../src/html/helpdata.cpp:660
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Gagal membuka buku bantuan HTML: %s"
 
-#: ../src/html/helpdata.cpp:299
+#: ../src/html/helpdata.cpp:296
 #, c-format
 msgid "Cannot open contents file: %s"
 msgstr "Gagal membuka isi berkas: %s"
 
-#: ../src/generic/dcpsg.cpp:1667
+#: ../src/generic/dcpsg.cpp:1665
 msgid "Cannot open file for PostScript printing!"
 msgstr "Gagal membuka berkas untuk pencetakan PostScript!"
 
-#: ../src/html/helpdata.cpp:313
+#: ../src/html/helpdata.cpp:310
 #, c-format
 msgid "Cannot open index file: %s"
 msgstr "Gagal membuka berkas indeks: %s"
 
-#: ../src/xrc/xmlres.cpp:724
+#: ../src/xrc/xmlres.cpp:722
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Gagal membuka berkas sumber daya '%s'."
 
-#: ../src/html/helpwnd.cpp:1534
+#: ../src/html/helpwnd.cpp:1532
 msgid "Cannot print empty page."
 msgstr "Gagal mencetak halaman kosong."
 
-#: ../src/msw/volume.cpp:507
+#: ../src/msw/volume.cpp:515
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Gagal membaca typename dari '%s'!"
 
-#: ../src/msw/thread.cpp:888
+#: ../src/msw/thread.cpp:894
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Gagal meneruskan thread %lx"
 
-#: ../src/unix/threadpsx.cpp:1016
+#: ../src/unix/threadpsx.cpp:1028
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Gagal mengambil kebijakan penjadwalan thread."
 
-#: ../src/common/intl.cpp:558
+#: ../src/common/intl.cpp:365
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "Gagal mengatur bahasa ke \"%s\"."
 
-#: ../src/unix/threadpsx.cpp:831 ../src/msw/thread.cpp:546
+#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
 msgid "Cannot start thread: error writing TLS."
 msgstr "Gagal memulai thread: kesalahan menulis TLS."
 
-#: ../src/msw/thread.cpp:872
+#: ../src/msw/thread.cpp:864
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Gagal menunda thread %lx"
 
-#: ../src/msw/thread.cpp:794
+#: ../src/msw/thread.cpp:786
 msgid "Cannot wait for thread termination"
 msgstr "Gagal menunggu penghentian thread"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:75
+#: ../src/common/accelcmn.cpp:72
 msgid "Capital"
 msgstr "Capital"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:879
+#: ../src/propgrid/advprops.cpp:780
 msgid "CaptionText"
 msgstr "TeksJudul"
 
-#: ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:531
 msgid "Case sensitive"
 msgstr "Membedakan huruf besar dan kecil"
 
-#: ../src/propgrid/manager.cpp:1509
+#: ../src/propgrid/manager.cpp:1527
 msgid "Categorized Mode"
 msgstr "Mode Terkategorisasi"
 
-#: ../src/richtext/richtextbuffer.cpp:9968
+#: ../src/richtext/richtextbuffer.cpp:9965
 msgid "Cell Properties"
 msgstr "Properti Sel"
 
-#: ../src/common/fmapbase.cpp:161
+#: ../src/common/fmapbase.cpp:158
 msgid "Celtic (ISO-8859-14)"
 msgstr "Celtic (ISO-8859-14)"
 
-#: ../src/richtext/richtextindentspage.cpp:160
 #: ../src/richtext/richtextliststylepage.cpp:349
+#: ../src/richtext/richtextindentspage.cpp:160
 msgid "Cen&tred"
 msgstr "Te&ngah"
 
-#: ../src/common/stockitem.cpp:170
+#: ../src/common/stockitem.cpp:167
 msgid "Centered"
 msgstr "Tengah"
 
-#: ../src/common/fmapbase.cpp:149
+#: ../src/common/fmapbase.cpp:146
 msgid "Central European (ISO-8859-2)"
 msgstr "Eropa Tengah (ISO-8859-2)"
 
@@ -1934,10 +1958,10 @@ msgstr "Eropa Tengah (ISO-8859-2)"
 msgid "Centre"
 msgstr "Tengah"
 
-#: ../src/richtext/richtextindentspage.cpp:162
-#: ../src/richtext/richtextindentspage.cpp:164
 #: ../src/richtext/richtextliststylepage.cpp:351
 #: ../src/richtext/richtextliststylepage.cpp:353
+#: ../src/richtext/richtextindentspage.cpp:162
+#: ../src/richtext/richtextindentspage.cpp:164
 msgid "Centre text."
 msgstr "Tengahi teks."
 
@@ -1950,28 +1974,29 @@ msgstr "Tengahkan"
 msgid "Ch&oose..."
 msgstr "Pi&lih..."
 
-#: ../src/richtext/richtextbuffer.cpp:4354
+#: ../src/richtext/richtextbuffer.cpp:4351
 msgid "Change List Style"
 msgstr "Ubah Gaya Daftar"
 
-#: ../src/richtext/richtextbuffer.cpp:3709
+#: ../src/richtext/richtextbuffer.cpp:3706
 msgid "Change Object Style"
 msgstr "Ubah Gaya Obyek"
 
-#: ../src/richtext/richtextbuffer.cpp:3982 ../src/richtext/richtextbuffer.cpp:8129
+#: ../src/richtext/richtextbuffer.cpp:3979
+#: ../src/richtext/richtextbuffer.cpp:8125
 msgid "Change Properties"
 msgstr "Ubah Properti"
 
-#: ../src/richtext/richtextbuffer.cpp:3526
+#: ../src/richtext/richtextbuffer.cpp:3523
 msgid "Change Style"
 msgstr "Ubah Gaya"
 
-#: ../src/common/fileconf.cpp:341
+#: ../src/common/fileconf.cpp:335
 #, c-format
 msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
 msgstr ""
-"Perubahan tidak dapat disimpan untuk menghindari penimpaan berkas yang sudah ada "
-"\"%s\""
+"Perubahan tidak dapat disimpan untuk menghindari penimpaan berkas yang sudah "
+"ada \"%s\""
 
 #: ../src/gtk/filepicker.cpp:190 ../src/gtk/filedlg.cpp:87
 #, c-format
@@ -1979,11 +2004,11 @@ msgid "Changing current directory to \"%s\" failed"
 msgstr "Gagal pindah ke direktori \"%s\""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1757
+#: ../src/propgrid/advprops.cpp:1658
 msgid "Character"
 msgstr "Karakter"
 
-#: ../src/richtext/richtextstyles.cpp:1063
+#: ../src/richtext/richtextstyles.cpp:1060
 msgid "Character styles"
 msgstr "Gaya karakter"
 
@@ -2015,94 +2040,103 @@ msgstr "Centang untuk menyunting tepi secara bersamaan."
 msgid "Check to enclose the bullet in parentheses."
 msgstr "Centang untuk mengapit bullet dalam tanda kurung."
 
-#: ../src/richtext/richtextfontpage.cpp:315 ../src/richtext/richtextfontpage.cpp:317
+#: ../src/richtext/richtextfontpage.cpp:315
+#: ../src/richtext/richtextfontpage.cpp:317
 msgid "Check to indicate right-to-left text layout."
 msgstr "Centang untuk penulisan teks dari kanan-ke-kiri."
 
-#: ../src/osx/carbon/fontdlg.cpp:356 ../src/osx/carbon/fontdlg.cpp:358
+#: ../src/osx/carbon/fontdlg.cpp:353 ../src/osx/carbon/fontdlg.cpp:355
 msgid "Check to make the font bold."
 msgstr "Centang untuk membuat font tebal."
 
-#: ../src/osx/carbon/fontdlg.cpp:363 ../src/osx/carbon/fontdlg.cpp:365
+#: ../src/osx/carbon/fontdlg.cpp:360 ../src/osx/carbon/fontdlg.cpp:362
 msgid "Check to make the font italic."
 msgstr "Centang untuk membuat font miring."
 
-#: ../src/osx/carbon/fontdlg.cpp:372 ../src/osx/carbon/fontdlg.cpp:374
+#: ../src/osx/carbon/fontdlg.cpp:369 ../src/osx/carbon/fontdlg.cpp:371
 msgid "Check to make the font underlined."
 msgstr "Centang untuk membuat font bergarisbawah."
 
-#: ../src/richtext/richtextstyledlg.cpp:289 ../src/richtext/richtextstyledlg.cpp:291
+#: ../src/richtext/richtextstyledlg.cpp:285
+#: ../src/richtext/richtextstyledlg.cpp:287
 msgid "Check to restart numbering."
 msgstr "Centang untuk memulai lagi penomoran."
 
-#: ../src/richtext/richtextfontpage.cpp:277 ../src/richtext/richtextfontpage.cpp:279
+#: ../src/richtext/richtextfontpage.cpp:277
+#: ../src/richtext/richtextfontpage.cpp:279
 msgid "Check to show a line through the text."
 msgstr "Centang untuk menampilkan garis menembus teks."
 
-#: ../src/richtext/richtextfontpage.cpp:284 ../src/richtext/richtextfontpage.cpp:286
+#: ../src/richtext/richtextfontpage.cpp:284
+#: ../src/richtext/richtextfontpage.cpp:286
 msgid "Check to show the text in capitals."
 msgstr "Centang untuk menampilkan teks dalam huruf besar."
 
-#: ../src/richtext/richtextfontpage.cpp:291 ../src/richtext/richtextfontpage.cpp:293
+#: ../src/richtext/richtextfontpage.cpp:291
+#: ../src/richtext/richtextfontpage.cpp:293
 msgid "Check to show the text in small capitals."
 msgstr "Centang untuk menampilkan teks dalam huruf besar ukuran kecil."
 
-#: ../src/richtext/richtextfontpage.cpp:305 ../src/richtext/richtextfontpage.cpp:307
+#: ../src/richtext/richtextfontpage.cpp:305
+#: ../src/richtext/richtextfontpage.cpp:307
 msgid "Check to show the text in subscript."
 msgstr "Centang untuk menampilkan teks dalam subscript."
 
-#: ../src/richtext/richtextfontpage.cpp:298 ../src/richtext/richtextfontpage.cpp:300
+#: ../src/richtext/richtextfontpage.cpp:298
+#: ../src/richtext/richtextfontpage.cpp:300
 msgid "Check to show the text in superscript."
 msgstr "Centang untuk menampilkan teks dalam superscript."
 
-#: ../src/richtext/richtextfontpage.cpp:322 ../src/richtext/richtextfontpage.cpp:324
+#: ../src/richtext/richtextfontpage.cpp:322
+#: ../src/richtext/richtextfontpage.cpp:324
 msgid "Check to suppress hyphenation."
 msgstr "Centang untuk menghindari tanda sambung."
 
-#: ../src/msw/dialup.cpp:763
+#: ../src/msw/dialup.cpp:757
 msgid "Choose ISP to dial"
 msgstr "Pilih ISP yang akan dihubungi"
 
-#: ../src/propgrid/props.cpp:1922
+#: ../src/propgrid/props.cpp:1904
 msgid "Choose a directory:"
 msgstr "Pilih direktori:"
 
-#: ../src/propgrid/props.cpp:1975
+#: ../src/propgrid/props.cpp:2199
 msgid "Choose a file"
 msgstr "Pilih berkas"
 
-#: ../src/generic/colrdlgg.cpp:158 ../src/gtk/colordlg.cpp:54
+#: ../src/generic/colrdlgg.cpp:156 ../src/gtk/colordlg.cpp:49
 msgid "Choose colour"
 msgstr "Pilih warna"
 
-#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/gtk1/fontdlg.cpp:125 ../src/generic/fontpickerg.cpp:47
+#: ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Pilih font"
 
-#: ../src/common/module.cpp:74
+#: ../src/common/module.cpp:71
 #, c-format
 msgid "Circular dependency involving module \"%s\" detected."
 msgstr "Terdeteksi kebergantungan melingkar melibatkan modul \"%s\"."
 
-#: ../src/aui/tabmdi.cpp:108 ../src/generic/mdig.cpp:97
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
 msgid "Cl&ose"
 msgstr "Tutu&p"
 
-#: ../src/msw/ole/automtn.cpp:684
+#: ../src/msw/ole/automtn.cpp:675
 msgid "Class not registered."
 msgstr "Kelas tidak terdaftar."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:147 ../src/common/accelcmn.cpp:72
+#: ../src/common/stockitem.cpp:144 ../src/common/accelcmn.cpp:69
 msgid "Clear"
 msgstr "Clear"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "Clear the log contents"
 msgstr "Bersihkan isi log"
 
-#: ../src/richtext/richtextstyledlg.cpp:252 ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:248
+#: ../src/richtext/richtextstyledlg.cpp:250
 msgid "Click to apply the selected style."
 msgstr "Klik untuk menerapkan gaya yang dipilih."
 
@@ -2113,23 +2147,25 @@ msgstr "Klik untuk menerapkan gaya yang dipilih."
 msgid "Click to browse for a symbol."
 msgstr "Klik untuk meramban simbol."
 
-#: ../src/osx/carbon/fontdlg.cpp:403 ../src/osx/carbon/fontdlg.cpp:405
+#: ../src/osx/carbon/fontdlg.cpp:400 ../src/osx/carbon/fontdlg.cpp:402
 msgid "Click to cancel changes to the font."
 msgstr "Klik untuk membatalkan perubahan font."
 
-#: ../src/generic/fontdlgg.cpp:472 ../src/generic/fontdlgg.cpp:491
+#: ../src/generic/fontdlgg.cpp:468 ../src/generic/fontdlgg.cpp:487
 msgid "Click to cancel the font selection."
 msgstr "Klik untuk membatalkan font yang dipilih."
 
-#: ../src/osx/carbon/fontdlg.cpp:384 ../src/osx/carbon/fontdlg.cpp:386
+#: ../src/osx/carbon/fontdlg.cpp:381 ../src/osx/carbon/fontdlg.cpp:383
 msgid "Click to change the font colour."
 msgstr "Klik untuk mengubah warna font."
 
-#: ../src/richtext/richtextfontpage.cpp:267 ../src/richtext/richtextfontpage.cpp:269
+#: ../src/richtext/richtextfontpage.cpp:267
+#: ../src/richtext/richtextfontpage.cpp:269
 msgid "Click to change the text background colour."
 msgstr "Klik untuk mengubah warna latar belakang teks."
 
-#: ../src/richtext/richtextfontpage.cpp:254 ../src/richtext/richtextfontpage.cpp:256
+#: ../src/richtext/richtextfontpage.cpp:254
+#: ../src/richtext/richtextfontpage.cpp:256
 msgid "Click to change the text colour."
 msgstr "Klik untuk mengubah warna teks."
 
@@ -2138,67 +2174,79 @@ msgstr "Klik untuk mengubah warna teks."
 msgid "Click to choose the font for this level."
 msgstr "Klik untuk memilih font bagi tingkatan ini."
 
-#: ../src/richtext/richtextstyledlg.cpp:279 ../src/richtext/richtextstyledlg.cpp:281
+#: ../src/richtext/richtextstyledlg.cpp:275
+#: ../src/richtext/richtextstyledlg.cpp:277
 msgid "Click to close this window."
 msgstr "Klik untuk menutup jendela ini."
 
-#: ../src/osx/carbon/fontdlg.cpp:410 ../src/osx/carbon/fontdlg.cpp:412
+#: ../src/osx/carbon/fontdlg.cpp:407 ../src/osx/carbon/fontdlg.cpp:409
 msgid "Click to confirm changes to the font."
 msgstr "Klik untuk mengkonfirmasi perubahan atas font."
 
-#: ../src/generic/fontdlgg.cpp:477 ../src/generic/fontdlgg.cpp:479
-#: ../src/generic/fontdlgg.cpp:484 ../src/generic/fontdlgg.cpp:486
+#: ../src/generic/fontdlgg.cpp:473 ../src/generic/fontdlgg.cpp:475
+#: ../src/generic/fontdlgg.cpp:480 ../src/generic/fontdlgg.cpp:482
 msgid "Click to confirm the font selection."
 msgstr "Klik untuk mengkonfirmasi pemilihan font."
 
-#: ../src/richtext/richtextstyledlg.cpp:244 ../src/richtext/richtextstyledlg.cpp:246
+#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:242
 msgid "Click to create a new box style."
 msgstr "Klik untuk membuat gaya kotak yang baru."
 
-#: ../src/richtext/richtextstyledlg.cpp:226 ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:224
 msgid "Click to create a new character style."
 msgstr "Klik untuk membuat gaya karakter yang baru."
 
-#: ../src/richtext/richtextstyledlg.cpp:238 ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:236
 msgid "Click to create a new list style."
 msgstr "Klik untuk membuat gaya daftar yang baru."
 
-#: ../src/richtext/richtextstyledlg.cpp:232 ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:230
 msgid "Click to create a new paragraph style."
 msgstr "Klik untuk membuat gaya paragraf yang baru."
 
-#: ../src/richtext/richtexttabspage.cpp:133 ../src/richtext/richtexttabspage.cpp:135
+#: ../src/richtext/richtexttabspage.cpp:133
+#: ../src/richtext/richtexttabspage.cpp:135
 msgid "Click to create a new tab position."
 msgstr "Klik untuk membuat posisi tab baru."
 
-#: ../src/richtext/richtexttabspage.cpp:145 ../src/richtext/richtexttabspage.cpp:147
+#: ../src/richtext/richtexttabspage.cpp:145
+#: ../src/richtext/richtexttabspage.cpp:147
 msgid "Click to delete all tab positions."
 msgstr "Klik untuk menghapus semua posisi tab."
 
-#: ../src/richtext/richtextstyledlg.cpp:270 ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:268
 msgid "Click to delete the selected style."
 msgstr "Klik untuk menghapus gaya yang dipilih."
 
-#: ../src/richtext/richtexttabspage.cpp:139 ../src/richtext/richtexttabspage.cpp:141
+#: ../src/richtext/richtexttabspage.cpp:139
+#: ../src/richtext/richtexttabspage.cpp:141
 msgid "Click to delete the selected tab position."
 msgstr "Klik menghapus posisi tab yang dipilih."
 
-#: ../src/richtext/richtextstyledlg.cpp:264 ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:262
 msgid "Click to edit the selected style."
 msgstr "Klik untuk menyunting gaya yang dipilih."
 
-#: ../src/richtext/richtextstyledlg.cpp:258 ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:256
 msgid "Click to rename the selected style."
 msgstr "Klik untuk mengubah nama gaya yang dipilih."
 
-#: ../src/generic/dbgrptg.cpp:97 ../src/generic/progdlgg.cpp:759
-#: ../src/richtext/richtextstyledlg.cpp:277 ../src/richtext/richtextsymboldlg.cpp:476
-#: ../src/common/stockitem.cpp:148 ../src/msw/progdlg.cpp:170
-#: ../src/msw/progdlg.cpp:679 ../src/html/helpdlg.cpp:90
+#: ../src/common/stockitem.cpp:145 ../src/generic/dbgrptg.cpp:94
+#: ../src/generic/progdlgg.cpp:781 ../src/msw/progdlg.cpp:211
+#: ../src/msw/progdlg.cpp:946 ../src/html/helpdlg.cpp:87
+#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextstyledlg.cpp:273
 msgid "Close"
 msgstr "Tutup"
 
-#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:98
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
 msgid "Close All"
 msgstr "Tutup Semua"
 
@@ -2206,66 +2254,70 @@ msgstr "Tutup Semua"
 msgid "Close current document"
 msgstr "Tutup dokumen saat ini"
 
-#: ../src/generic/logg.cpp:516
+#: ../src/generic/logg.cpp:513
 msgid "Close this window"
 msgstr "Tutup jendela ini"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6006
+#: ../src/generic/datavgen.cpp:6811
 msgid "Collapse"
 msgstr "Perkecil"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "Color"
 msgstr "Warna"
 
-#: ../src/richtext/richtextformatdlg.cpp:776
+#: ../src/richtext/richtextformatdlg.cpp:768
 msgid "Colour"
 msgstr "Warna"
 
-#: ../src/msw/colordlg.cpp:158
+#: ../src/msw/colordlg.cpp:227
 #, c-format
 msgid "Colour selection dialog failed with error %0lx."
 msgstr "Dialog pemilihan warna gagal dengan galat %0lx."
 
-#: ../src/osx/carbon/fontdlg.cpp:380
+#: ../src/osx/carbon/fontdlg.cpp:377
 msgid "Colour:"
 msgstr "Warna:"
 
-#: ../src/generic/datavgen.cpp:6077
+#: ../src/generic/datavgen.cpp:6882
 #, c-format
 msgid "Column %u"
 msgstr "Kolom %u"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:114
+#: ../src/common/accelcmn.cpp:112
 msgid "Command"
 msgstr "Command"
 
 # verifikasi terjemahan s/d 2156
 # 20131008
-#: ../src/common/init.cpp:196
+#: ../src/common/init.cpp:193
 #, c-format
 msgid ""
-"Command line argument %d couldn't be converted to Unicode and will be ignored."
-msgstr "Perintah Command Line %d tidak dapat diubah ke Unicode dan akan dibiarkan."
+"Command line argument %d couldn't be converted to Unicode and will be "
+"ignored."
+msgstr ""
+"Perintah Command Line %d tidak dapat diubah ke Unicode dan akan dibiarkan."
 
-#: ../src/msw/fontdlg.cpp:120
+#: ../src/msw/fontdlg.cpp:170
 #, c-format
 msgid "Common dialog failed with error code %0lx."
 msgstr "Dialog umum gagal dengan kode galat %0lx."
 
-#: ../src/gtk/window.cpp:4649
+#: ../src/gtk/window.cpp:5653
 msgid ""
-"Compositing not supported by this system, please enable it in your Window Manager."
+"Compositing not supported by this system, please enable it in your Window "
+"Manager."
 msgstr ""
-"Komposisi tidak didukung oleh sistem ini, tolong hidupkan pada WIndow Manager anda."
+"Komposisi tidak didukung oleh sistem ini, tolong hidupkan pada WIndow "
+"Manager anda."
 
-#: ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:1549
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Berkas Bantuan HML Terkompresi (*.chm)|*.chm|"
 
-#: ../src/generic/dirctrlg.cpp:444
+#: ../src/generic/dirctrlg.cpp:410
 msgid "Computer"
 msgstr "Komputer"
 
@@ -2274,53 +2326,57 @@ msgstr "Komputer"
 msgid "Config entry name cannot start with '%c'."
 msgstr "Nama entri konfigurasi tidak bisa diawali dengan '%c'."
 
-#: ../src/generic/filedlgg.cpp:349 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
 msgid "Confirm"
 msgstr "Konfirmasi"
 
-#: ../src/html/htmlwin.cpp:566
+#: ../src/html/htmlwin.cpp:569
 msgid "Connecting..."
 msgstr "Membuat koneksi..."
 
-#: ../src/html/helpwnd.cpp:475
+#: ../src/html/helpwnd.cpp:473
 msgid "Contents"
 msgstr "Isi"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:880
+#: ../src/propgrid/advprops.cpp:781
 msgid "ControlDark"
 msgstr "KendaliGelap"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:881
+#: ../src/propgrid/advprops.cpp:782
 msgid "ControlLight"
 msgstr "KendaliTerang"
 
-#: ../src/common/strconv.cpp:2262
+#: ../src/common/strconv.cpp:2208
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Konversi ke charset '%s' tidak dimungkinkan."
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "Convert"
 msgstr "Ubah"
 
-#: ../src/html/htmlwin.cpp:1079
+#: ../src/html/htmlwin.cpp:1020
 #, c-format
 msgid "Copied to clipboard:\"%s\""
 msgstr "Tersalin ke clipboard: \"%s\""
 
-#: ../src/generic/prntdlgg.cpp:247
+#: ../src/generic/prntdlgg.cpp:240
 msgid "Copies:"
 msgstr "Salinan:"
 
-#: ../src/common/stockitem.cpp:150 ../src/stc/stc_i18n.cpp:18
+#: ../src/common/stockitem.cpp:147 ../src/stc/stc_i18n.cpp:18
 msgid "Copy"
 msgstr "Salin"
 
-#: ../src/common/stockitem.cpp:258
+#: ../src/common/stockitem.cpp:255
 msgid "Copy selection"
 msgstr "Salin seleksi"
+
+#: ../src/generic/grid.cpp:5945
+msgid "Copying more than one selected block to clipboard is not supported."
+msgstr ""
 
 #: ../src/richtext/richtextborderspage.cpp:566
 #: ../src/richtext/richtextborderspage.cpp:601
@@ -2331,194 +2387,191 @@ msgstr "Pojok"
 msgid "Corner &radius:"
 msgstr "&Radius pojokan:"
 
-#: ../src/html/chm.cpp:718
+#: ../src/html/chm.cpp:711
 #, c-format
 msgid "Could not create temporary file '%s'"
 msgstr "Gagal membuat berkas sementara '%s'"
 
-#: ../src/html/chm.cpp:273
+#: ../src/html/chm.cpp:270
 #, c-format
 msgid "Could not extract %s into %s: %s"
 msgstr "Gagal mengekstrak %s ke dalam %s: %s"
 
-#: ../src/generic/tabg.cpp:1048
+#: ../src/generic/tabg.cpp:1045
 msgid "Could not find tab for id"
 msgstr "Gagal menemukan tab untuk id"
 
-#: ../src/gtk/notifmsg.cpp:108
-msgid "Could not initalize libnotify."
-msgstr "Gagal menginisialisasi libnotify."
-
-#: ../src/html/chm.cpp:444
+#: ../src/html/chm.cpp:437
 #, c-format
 msgid "Could not locate file '%s'."
 msgstr "Gagal menemukan file '%s'."
 
-#: ../src/common/filefn.cpp:1403
+#: ../src/msw/graphicsd2d.cpp:604
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/common/filefn.cpp:1291
 msgid "Could not set current working directory"
 msgstr "Gagal mengatur lokasi direktori ini"
 
-#: ../src/common/prntbase.cpp:2015
+#: ../src/common/prntbase.cpp:2037
 msgid "Could not start document preview."
 msgstr "Gagal memulai pratinjau dokumen."
 
-#: ../src/generic/printps.cpp:178 ../src/msw/printwin.cpp:210
-#: ../src/gtk/print.cpp:1132
+#: ../src/generic/printps.cpp:159 ../src/msw/printwin.cpp:184
+#: ../src/gtk/print.cpp:1129
 msgid "Could not start printing."
 msgstr "Gagal memulai pencetakan."
 
-#: ../src/common/wincmn.cpp:2125
+#: ../src/common/wincmn.cpp:2126
 msgid "Could not transfer data to window"
 msgstr "Gagal mentransfer data ke jendela"
 
-#: ../src/msw/imaglist.cpp:187 ../src/msw/imaglist.cpp:224
-#: ../src/msw/imaglist.cpp:249 ../src/msw/dragimag.cpp:185
-#: ../src/msw/dragimag.cpp:220
+#: ../src/msw/imaglist.cpp:223 ../src/msw/imaglist.cpp:245
+#: ../src/msw/imaglist.cpp:270 ../src/msw/dragimag.cpp:182
+#: ../src/msw/dragimag.cpp:217
 msgid "Couldn't add an image to the image list."
 msgstr "Gagal menambahkan citra ke daftar citra."
 
-#: ../src/osx/glcanvas_osx.cpp:414 ../src/unix/glx11.cpp:558
-#: ../src/msw/glcanvas.cpp:616
+#: ../src/osx/glcanvas_osx.cpp:411 ../src/msw/glcanvas.cpp:631
+#: ../src/unix/glegl.cpp:315 ../src/unix/glx11.cpp:559
 msgid "Couldn't create OpenGL context"
 msgstr "Gagal menciptakan konteks OpenGL"
 
-#: ../src/msw/timer.cpp:134
+#: ../src/msw/timer.cpp:131
 msgid "Couldn't create a timer"
 msgstr "Gagal menciptakan pewaktu"
 
-#: ../src/osx/carbon/overlay.cpp:122
-msgid "Couldn't create the overlay window"
-msgstr "Gagal membuat overlay window"
-
-#: ../src/common/translation.cpp:2024
+#: ../src/common/translation.cpp:2074
 msgid "Couldn't enumerate translations"
 msgstr "Gagal menghitung terjemahan"
 
-#: ../src/common/dynlib.cpp:120
+#: ../src/common/dynlib.cpp:110
 #, c-format
 msgid "Couldn't find symbol '%s' in a dynamic library"
 msgstr "Gagal menemukan simbol '%s' dalam pustaka dinamis"
 
-#: ../src/msw/thread.cpp:915
+#: ../src/msw/thread.cpp:921
 msgid "Couldn't get the current thread pointer"
 msgstr "Gagal memperoleh penunjuk thread saat ini"
 
-#: ../src/osx/carbon/overlay.cpp:129
-msgid "Couldn't init the context on the overlay window"
-msgstr "Gagal menjalankan konteks di overlay window"
-
-#: ../src/common/imaggif.cpp:244
+#: ../src/common/imaggif.cpp:241
 msgid "Couldn't initialize GIF hash table."
 msgstr "Gagal menjalankan GIF has table."
 
-#: ../src/common/imagpng.cpp:409
+#: ../src/common/imagpng.cpp:437
 msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
 msgstr "Gagal memuat citra PNG - berkas rusak atau memori tidak cukup."
 
-#: ../src/unix/sound.cpp:470
+#: ../src/unix/sound.cpp:459
 #, c-format
 msgid "Couldn't load sound data from '%s'."
 msgstr "Gagal memuat data suara dari '%s'."
 
-#: ../src/msw/dirdlg.cpp:435
+#: ../src/msw/dirdlg.cpp:287
 msgid "Couldn't obtain folder name"
 msgstr "Gagal mendapatkan nama direktori"
 
-#: ../src/unix/sound_sdl.cpp:229
+#: ../src/unix/sound_sdl.cpp:226
 #, c-format
 msgid "Couldn't open audio: %s"
 msgstr "Gagal membuka audio: %s"
 
-#: ../src/msw/ole/dataobj.cpp:377
+#: ../src/msw/ole/dataobj.cpp:385
 #, c-format
 msgid "Couldn't register clipboard format '%s'."
 msgstr "Gagal meregister format clipboard '%s'."
 
-#: ../src/msw/listctrl.cpp:869
+#: ../src/msw/listctrl.cpp:933
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "Gagal mengambil informasi tentang obyek list control %d."
 
-#: ../src/common/imagpng.cpp:498 ../src/common/imagpng.cpp:509
-#: ../src/common/imagpng.cpp:519
+#: ../src/common/imagpng.cpp:511 ../src/common/imagpng.cpp:522
+#: ../src/common/imagpng.cpp:532
 msgid "Couldn't save PNG image."
 msgstr "Gagal menyimpan citra PNG."
 
-#: ../src/msw/thread.cpp:684
+#: ../src/msw/thread.cpp:676
 msgid "Couldn't terminate thread"
 msgstr "Gagal menghentikan thread"
 
-#: ../src/common/xtistrm.cpp:166
+#: ../src/common/xtistrm.cpp:163
 #, c-format
 msgid "Create Parameter %s not found in declared RTTI Parameters"
 msgstr "Membuat Parameter %s tidak dideklarasikan di RTTI Parameter"
 
-#: ../src/generic/dirdlgg.cpp:288
+#: ../src/generic/dirdlgg.cpp:285
 msgid "Create directory"
 msgstr "Buat direktori"
 
-#: ../src/generic/filedlgg.cpp:212 ../src/generic/dirdlgg.cpp:111
+#: ../src/generic/filedlgg.cpp:209 ../src/generic/dirdlgg.cpp:108
 msgid "Create new directory"
 msgstr "Buat direktori baru"
 
-#: ../src/xrc/xmlres.cpp:2460
+#: ../src/common/stockitem.cpp:264
+#, fuzzy
+msgid "Create new document"
+msgstr "Buat direktori baru"
+
+#: ../src/xrc/xmlres.cpp:2515
 #, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Gagal membuat %s \"%s\"."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1758
+#: ../src/propgrid/advprops.cpp:1659
 msgid "Cross"
 msgstr "Silang"
 
-#: ../src/common/accelcmn.cpp:333
+#: ../src/common/accelcmn.cpp:347
 msgid "Ctrl+"
 msgstr "Ctrl+"
 
-#: ../src/richtext/richtextctrl.cpp:332 ../src/osx/textctrl_osx.cpp:576
-#: ../src/common/stockitem.cpp:151 ../src/msw/textctrl.cpp:2507
+#: ../src/osx/textctrl_osx.cpp:594 ../src/common/stockitem.cpp:148
+#: ../src/msw/textctrl.cpp:2772 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "Po&tong"
 
-#: ../src/generic/filectrlg.cpp:940
+#: ../src/generic/filectrlg.cpp:936
 msgid "Current directory:"
 msgstr "Direktori saat ini:"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:896 ../src/propgrid/advprops.cpp:1574
-#: ../src/propgrid/advprops.cpp:1612
+#: ../src/propgrid/advprops.cpp:797 ../src/propgrid/advprops.cpp:1475
+#: ../src/propgrid/advprops.cpp:1518
 msgid "Custom"
 msgstr "Kustom"
 
-#: ../src/gtk/print.cpp:217
+#: ../src/gtk/print.cpp:211
 msgid "Custom size"
 msgstr "Ukuran kustom"
 
-#: ../src/common/headerctrlcmn.cpp:60
+#: ../src/common/headerctrlcmn.cpp:58
 msgid "Customize Columns"
 msgstr "Kustomisasi Kolom"
 
-#: ../src/common/stockitem.cpp:151 ../src/stc/stc_i18n.cpp:17
+#: ../src/common/stockitem.cpp:148 ../src/stc/stc_i18n.cpp:17
 msgid "Cut"
 msgstr "Potong"
 
-#: ../src/common/stockitem.cpp:259
+#: ../src/common/stockitem.cpp:256
 msgid "Cut selection"
 msgstr "Potong seleksi"
 
-#: ../src/common/fmapbase.cpp:152
+#: ../src/common/fmapbase.cpp:149
 msgid "Cyrillic (ISO-8859-5)"
 msgstr "Cyrillic (ISO-8859-5)"
 
-#: ../src/common/paper.cpp:99
+#: ../src/common/paper.cpp:96
 msgid "D sheet, 22 x 34 in"
 msgstr "Kertas D, 22 x 34 in"
 
-#: ../src/msw/dde.cpp:703
+#: ../src/msw/dde.cpp:698
 msgid "DDE poke request failed"
 msgstr "Permintaan poke DDE gagal"
 
-#: ../src/common/imagbmp.cpp:1169
+#: ../src/common/imagbmp.cpp:1181
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr "Header DIB: Pengkodean tidak sesuai dengan bitdepth."
 
@@ -2538,7 +2591,7 @@ msgstr "DIB Header: bitdepth dalam berkas tidak diketahui."
 msgid "DIB Header: Unknown encoding in file."
 msgstr "Header DIB: Pengkodean dalam file tidak diketahui."
 
-#: ../src/common/paper.cpp:121
+#: ../src/common/paper.cpp:118
 msgid "DL Envelope, 110 x 220 mm"
 msgstr "Amplop DL, 110 x 220 mm"
 
@@ -2546,53 +2599,53 @@ msgstr "Amplop DL, 110 x 220 mm"
 msgid "Dashed"
 msgstr "Melesat"
 
-#: ../src/generic/dbgrptg.cpp:300
+#: ../src/generic/dbgrptg.cpp:301
 #, c-format
 msgid "Debug report \"%s\""
 msgstr "Laporan debug \"%s\""
 
-#: ../src/common/debugrpt.cpp:210
+#: ../src/common/debugrpt.cpp:211
 msgid "Debug report couldn't be created."
 msgstr "Laporan debut tidak dapat dibuat."
 
-#: ../src/common/debugrpt.cpp:553
+#: ../src/common/debugrpt.cpp:554
 msgid "Debug report generation has failed."
 msgstr "Pembuatan laporan debut gagal."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:84
+#: ../src/common/accelcmn.cpp:81
 msgid "Decimal"
 msgstr "Decimal"
 
-#: ../src/generic/fontdlgg.cpp:323
+#: ../src/generic/fontdlgg.cpp:319
 msgid "Decorative"
 msgstr "Dekoratif"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1752
+#: ../src/propgrid/advprops.cpp:1653
 msgid "Default"
 msgstr "Standar"
 
-#: ../src/common/fmapbase.cpp:796
+#: ../src/common/fmapbase.cpp:792
 msgid "Default encoding"
 msgstr "Pengkodean default"
 
-#: ../src/dfb/fontmgr.cpp:180
+#: ../src/dfb/fontmgr.cpp:177
 msgid "Default font"
 msgstr "Font standar"
 
-#: ../src/generic/prntdlgg.cpp:510
+#: ../src/generic/prntdlgg.cpp:503
 msgid "Default printer"
 msgstr "Printer default"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:51
+#: ../src/common/accelcmn.cpp:48
 msgid "Del"
 msgstr "Del"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextbuffer.cpp:8221 ../src/common/stockitem.cpp:152
-#: ../src/common/accelcmn.cpp:50 ../src/stc/stc_i18n.cpp:20
+#: ../src/common/stockitem.cpp:149 ../src/common/accelcmn.cpp:47
+#: ../src/richtext/richtextbuffer.cpp:8217 ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Delete"
 
@@ -2600,80 +2653,80 @@ msgstr "Delete"
 msgid "Delete A&ll"
 msgstr "Hapus Semu&a"
 
-#: ../src/richtext/richtextbuffer.cpp:11341
+#: ../src/richtext/richtextbuffer.cpp:11340
 msgid "Delete Column"
 msgstr "Hapus Kolom"
 
-#: ../src/richtext/richtextbuffer.cpp:11291
+#: ../src/richtext/richtextbuffer.cpp:11290
 msgid "Delete Row"
 msgstr "Hapus Baris"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 msgid "Delete Style"
 msgstr "Hapus Gaya"
 
-#: ../src/richtext/richtextctrl.cpp:1345 ../src/richtext/richtextctrl.cpp:1584
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
 msgid "Delete Text"
 msgstr "Hapus Teks"
 
-#: ../src/generic/editlbox.cpp:170
+#: ../src/generic/editlbox.cpp:147
 msgid "Delete item"
 msgstr "Hapus obyek"
 
-#: ../src/common/stockitem.cpp:260
+#: ../src/common/stockitem.cpp:257
 msgid "Delete selection"
 msgstr "Hapus seleksi"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 #, c-format
 msgid "Delete style %s?"
 msgstr "Hapus gaya %s?"
 
-#: ../src/unix/snglinst.cpp:301
+#: ../src/unix/snglinst.cpp:298
 #, c-format
 msgid "Deleted stale lock file '%s'."
 msgstr "Menghapus file lock '%s' yang terhenti."
 
-#: ../src/common/secretstore.cpp:220
-#, c-format
-msgid "Deleting password for \"%s/%s\" failed: %s."
+#: ../src/common/secretstore.cpp:234
+#, fuzzy, c-format
+msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Menghapus password untuk \"%s/%s\" gagal: %s."
 
-#: ../src/common/module.cpp:124
+#: ../src/common/module.cpp:121
 #, c-format
 msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
 msgstr "Ketergantungan \"%s\" dari modul \"%s\" tidak ada."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "Descending"
 msgstr "Urut turun"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:526 ../src/propgrid/advprops.cpp:882
+#: ../src/generic/dirctrlg.cpp:492 ../src/propgrid/advprops.cpp:783
 msgid "Desktop"
 msgstr "Desktop"
 
-#: ../src/generic/aboutdlgg.cpp:70
+#: ../src/generic/aboutdlgg.cpp:67
 msgid "Developed by "
 msgstr "Dikembangkan oleh "
 
-#: ../src/generic/aboutdlgg.cpp:176
+#: ../src/generic/aboutdlgg.cpp:173
 msgid "Developers"
 msgstr "Pengembang"
 
-#: ../src/msw/dialup.cpp:374
+#: ../src/msw/dialup.cpp:368
 msgid ""
-"Dial up functions are unavailable because the remote access service (RAS) is not "
-"installed on this machine. Please install it."
+"Dial up functions are unavailable because the remote access service (RAS) is "
+"not installed on this machine. Please install it."
 msgstr ""
-"Fungsi dial up tidak tersedia karena remote access service (RAS) tidak terinstall "
-"pada mesin ini. Silahkan menginstall."
+"Fungsi dial up tidak tersedia karena remote access service (RAS) tidak "
+"terinstall pada mesin ini. Silahkan menginstall."
 
-#: ../src/generic/tipdlg.cpp:211
+#: ../src/generic/tipdlg.cpp:208
 msgid "Did you know..."
 msgstr "Tahukah anda..."
 
-#: ../src/dfb/wrapdfb.cpp:63
+#: ../src/dfb/wrapdfb.cpp:60
 #, c-format
 msgid "DirectFB error %d occurred."
 msgstr "Galat DirectFB %d terjadi."
@@ -2682,74 +2735,75 @@ msgstr "Galat DirectFB %d terjadi."
 msgid "Directories"
 msgstr "Direktori"
 
-#: ../src/common/filefn.cpp:1183
+#: ../src/common/filefn.cpp:1071
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Direktori '%s' tidak bisa dibuat"
 
-#: ../src/common/filefn.cpp:1197
+#: ../src/common/filefn.cpp:1085
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "Direktori '%s' tidak dapat dihapus"
 
-#: ../src/generic/dirdlgg.cpp:204
+#: ../src/generic/dirdlgg.cpp:201
 msgid "Directory does not exist"
 msgstr "Direktori tidak ada"
 
-#: ../src/generic/filectrlg.cpp:1399
+#: ../src/generic/filectrlg.cpp:1388
 msgid "Directory doesn't exist."
 msgstr "Direktori tidak ada."
 
-#: ../src/common/docview.cpp:457
+#: ../src/common/docview.cpp:450
 msgid "Discard changes and reload the last saved version?"
 msgstr "Batalkan semua perubahan dan buka ulang simpanan versi terakhir?"
 
-#: ../src/html/helpwnd.cpp:502
+#: ../src/html/helpwnd.cpp:500
 msgid ""
-"Display all index items that contain given substring. Search is case insensitive."
+"Display all index items that contain given substring. Search is case "
+"insensitive."
 msgstr ""
 "Tampilkan semua obyek indeks yang berisi substring tersebut. Pencarian tidak "
 "membedakan pemakaian huruf besar dan kecil."
 
-#: ../src/html/helpwnd.cpp:679
+#: ../src/html/helpwnd.cpp:677
 msgid "Display options dialog"
 msgstr "Tampilkan dialog opsi"
 
-#: ../src/html/helpwnd.cpp:322
+#: ../src/html/helpwnd.cpp:320
 msgid "Displays help as you browse the books on the left."
 msgstr "Tampilkan bantuan saat melihat buku di jendela sebelah kiri."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:85
+#: ../src/common/accelcmn.cpp:83
 msgid "Divide"
 msgstr "Divide"
 
-#: ../src/common/docview.cpp:533
+#: ../src/common/docview.cpp:526
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Apakah anda ingin menyimpan perubahan ke %s?"
 
-#: ../src/common/prntbase.cpp:542
+#: ../src/common/prntbase.cpp:537
 msgid "Document:"
 msgstr "Dokumen:"
 
-#: ../src/generic/aboutdlgg.cpp:73
+#: ../src/generic/aboutdlgg.cpp:70
 msgid "Documentation by "
 msgstr "Dokumentasi oleh "
 
-#: ../src/generic/aboutdlgg.cpp:180
+#: ../src/generic/aboutdlgg.cpp:177
 msgid "Documentation writers"
 msgstr "Penulis Dokumentasi"
 
-#: ../src/common/sizer.cpp:2799
+#: ../src/common/sizer.cpp:2916
 msgid "Don't Save"
 msgstr "Jangan Save"
 
-#: ../src/html/htmlwin.cpp:633
+#: ../src/html/htmlwin.cpp:643
 msgid "Done"
 msgstr "Selesai"
 
-#: ../src/generic/progdlgg.cpp:448 ../src/msw/progdlg.cpp:407
+#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
 msgid "Done."
 msgstr "Selesai."
 
@@ -2761,67 +2815,74 @@ msgstr "Titik"
 msgid "Double"
 msgstr "Ganda"
 
-#: ../src/common/paper.cpp:176
+#: ../src/common/paper.cpp:173
 msgid "Double Japanese Postcard Rotated 148 x 200 mm"
 msgstr "Kartu Pos Jepang Ganda Diputar 148 x 200 mm"
 
-#: ../src/common/xtixml.cpp:273
+#: ../src/common/xtixml.cpp:269
 #, c-format
 msgid "Doubly used id : %d"
 msgstr "User id ganda : %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:153
-#: ../src/common/accelcmn.cpp:64
+#: ../src/common/stockitem.cpp:150 ../src/common/accelcmn.cpp:61
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Down"
 msgstr "Down"
 
-#: ../src/richtext/richtextctrl.cpp:865
+#: ../src/richtext/richtextctrl.cpp:864
 msgid "Drag"
 msgstr "Geser"
 
-#: ../src/common/paper.cpp:100
+#: ../src/common/paper.cpp:97
 msgid "E sheet, 34 x 44 in"
 msgstr "Kertas E, 34 x 44 inci"
 
-#: ../src/unix/fswatcher_inotify.cpp:561
+#: ../src/unix/fswatcher_inotify.cpp:558
 msgid "EOF while reading from inotify descriptor"
 msgstr "EOF ketika membaca dari deskriptor inotify"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "Edit"
 msgstr "Sunting"
 
-#: ../src/generic/editlbox.cpp:168
+#: ../src/generic/editlbox.cpp:131
 msgid "Edit item"
 msgstr "Sunting butir"
 
-#: ../include/wx/generic/progdlgg.h:84
+#: ../include/wx/generic/progdlgg.h:85
 msgid "Elapsed time:"
 msgstr "Waktu terpakai:"
 
-#: ../src/richtext/richtextsizepage.cpp:353 ../src/richtext/richtextsizepage.cpp:355
-#: ../src/richtext/richtextsizepage.cpp:465 ../src/richtext/richtextsizepage.cpp:467
+#: ../src/richtext/richtextsizepage.cpp:353
+#: ../src/richtext/richtextsizepage.cpp:355
+#: ../src/richtext/richtextsizepage.cpp:465
+#: ../src/richtext/richtextsizepage.cpp:467
 msgid "Enable the height value."
 msgstr "Aktifkan nilai tinggi."
 
-#: ../src/richtext/richtextsizepage.cpp:438 ../src/richtext/richtextsizepage.cpp:440
+#: ../src/richtext/richtextsizepage.cpp:438
+#: ../src/richtext/richtextsizepage.cpp:440
 msgid "Enable the maximum width value."
 msgstr "Aktifkan nilai lebar maksimum."
 
-#: ../src/richtext/richtextsizepage.cpp:411 ../src/richtext/richtextsizepage.cpp:413
+#: ../src/richtext/richtextsizepage.cpp:411
+#: ../src/richtext/richtextsizepage.cpp:413
 msgid "Enable the minimum height value."
 msgstr "Aktifkan nilai tinggi minimum."
 
-#: ../src/richtext/richtextsizepage.cpp:384 ../src/richtext/richtextsizepage.cpp:386
+#: ../src/richtext/richtextsizepage.cpp:384
+#: ../src/richtext/richtextsizepage.cpp:386
 msgid "Enable the minimum width value."
 msgstr "Aktifkan nilai lebar minimum."
 
-#: ../src/richtext/richtextsizepage.cpp:319 ../src/richtext/richtextsizepage.cpp:321
+#: ../src/richtext/richtextsizepage.cpp:319
+#: ../src/richtext/richtextsizepage.cpp:321
 msgid "Enable the width value."
 msgstr "Aktifkan nilai lebar."
 
-#: ../src/richtext/richtextsizepage.cpp:280 ../src/richtext/richtextsizepage.cpp:282
+#: ../src/richtext/richtextsizepage.cpp:280
+#: ../src/richtext/richtextsizepage.cpp:282
 msgid "Enable vertical alignment."
 msgstr "Aktifkan penjajaran vertikal."
 
@@ -2856,62 +2917,63 @@ msgid "Enables the shadow spread."
 msgstr "Aktifkan sebaran bayangan."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:66
+#: ../src/common/accelcmn.cpp:63
 msgid "End"
 msgstr "End"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:55
+#: ../src/common/accelcmn.cpp:52
 msgid "Enter"
 msgstr "Enter"
 
-#: ../src/richtext/richtextstyledlg.cpp:934
+#: ../src/richtext/richtextstyledlg.cpp:930
 msgid "Enter a box style name"
 msgstr "Masukkan nama kotak gaya"
 
-#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:602
 msgid "Enter a character style name"
 msgstr "Masukkan nama gaya karakter"
 
-#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:816
 msgid "Enter a list style name"
 msgstr "Masukkan daftar nama gaya"
 
-#: ../src/richtext/richtextstyledlg.cpp:893
+#: ../src/richtext/richtextstyledlg.cpp:889
 msgid "Enter a new style name"
 msgstr "Masukkan nama gaya baru"
 
-#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:650
 msgid "Enter a paragraph style name"
 msgstr "Masukkan nama gaya paragraf"
 
-#: ../src/generic/dbgrptg.cpp:174
+#: ../src/generic/dbgrptg.cpp:171
 #, c-format
 msgid "Enter command to open file \"%s\":"
 msgstr "Masukkan perintah untuk membuka file '%s':"
 
-#: ../src/generic/helpext.cpp:459
+#: ../src/generic/helpext.cpp:457
 msgid "Entries found"
 msgstr "Entri ditemukan"
 
-#: ../src/common/paper.cpp:142
+#: ../src/common/paper.cpp:139
 msgid "Envelope Invite 220 x 220 mm"
 msgstr "Amplop Undangan 220 x 220 mm"
 
-#: ../src/common/config.cpp:469
+#: ../src/common/config.cpp:465
 #, c-format
-msgid "Environment variables expansion failed: missing '%c' at position %u in '%s'."
+msgid ""
+"Environment variables expansion failed: missing '%c' at position %u in '%s'."
 msgstr ""
-"Pengembangan variabel lingkungan gagal: tidak ditemukan '%c' pada posisi %u di "
-"'%s'."
+"Pengembangan variabel lingkungan gagal: tidak ditemukan '%c' pada posisi %u "
+"di '%s'."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/generic/dirctrlg.cpp:570
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/dirctrlg.cpp:599
-#: ../src/generic/dirdlgg.cpp:323 ../src/generic/filectrlg.cpp:642
-#: ../src/generic/filectrlg.cpp:756 ../src/generic/filectrlg.cpp:770
-#: ../src/generic/filectrlg.cpp:786 ../src/generic/filectrlg.cpp:1368
-#: ../src/generic/filectrlg.cpp:1399 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/gtk1/fontdlg.cpp:74 ../src/generic/dirctrlg.cpp:536
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/dirctrlg.cpp:565
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1357 ../src/generic/filectrlg.cpp:1388
+#: ../src/generic/filedlgg.cpp:354 ../src/generic/dirdlgg.cpp:320
+#: ../src/gtk/filedlg.cpp:74
 msgid "Error"
 msgstr "Kesalahan"
 
@@ -2919,231 +2981,254 @@ msgstr "Kesalahan"
 msgid "Error closing epoll descriptor"
 msgstr "Galat ketika menutup epoll deskriptor"
 
-#: ../src/unix/fswatcher_kqueue.cpp:114
+#: ../src/unix/fswatcher_kqueue.cpp:131
 msgid "Error closing kqueue instance"
 msgstr "Galat ketika menutup kqueue instance"
 
-#: ../src/common/filefn.cpp:1049
+#: ../src/common/filefn.cpp:938
 #, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Gagal menyalin berkas dari '%s' ke ‘%s’."
 
-#: ../src/generic/dirdlgg.cpp:222
+#: ../src/generic/dirdlgg.cpp:219
 msgid "Error creating directory"
 msgstr "Kesalahan dalam menciptakan direktori"
 
-#: ../src/common/imagbmp.cpp:1181
+#: ../src/common/imagbmp.cpp:1193
 msgid "Error in reading image DIB."
 msgstr "Galat ketika membaca citra DIB."
 
-#: ../src/propgrid/propgrid.cpp:6696
+#: ../src/propgrid/propgrid.cpp:6665
 #, c-format
 msgid "Error in resource: %s"
 msgstr "Galat pada sumber %s"
 
-#: ../src/common/fileconf.cpp:422
+#: ../src/common/fileconf.cpp:421
 msgid "Error reading config options."
 msgstr "Galat saat membaca opsi config."
+
+#: ../src/msw/webview_ie.cpp:1057 ../src/msw/webview_edge.cpp:850
+#: ../src/gtk/webview_webkit2.cpp:1262 ../src/osx/webview_webkit.mm:383
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
 
 #: ../src/common/fileconf.cpp:1029
 msgid "Error saving user configuration data."
 msgstr "Galat saat menyimpan data konfigurasi pengguna."
 
-#: ../src/gtk/print.cpp:722
+#: ../src/gtk/print.cpp:720
 msgid "Error while printing: "
 msgstr "Galat ketika mencetak: "
 
-#: ../src/common/log.cpp:219
+#: ../src/common/log.cpp:237
 msgid "Error: "
 msgstr "Kesalahan: "
 
+#: ../src/common/webrequest.cpp:98
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Kesalahan: "
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:69
+#: ../src/common/accelcmn.cpp:66
 msgid "Esc"
 msgstr "Esc"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:70
+#: ../src/common/accelcmn.cpp:67
 msgid "Escape"
 msgstr "Escape"
 
-#: ../src/common/fmapbase.cpp:150
+#: ../src/common/fmapbase.cpp:147
 msgid "Esperanto (ISO-8859-3)"
 msgstr "Esperanto (ISO-8859-3)"
 
-#: ../include/wx/generic/progdlgg.h:85
+#: ../include/wx/generic/progdlgg.h:86
 msgid "Estimated time:"
 msgstr "Waktu perkiraan:"
 
-#: ../src/generic/dbgrptg.cpp:234
+#: ../src/generic/dbgrptg.cpp:231
 msgid "Executable files (*.exe)|*.exe|"
 msgstr "Berkas yang dapat dieksekusi (*.exe)|*.exe|"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:155 ../src/common/accelcmn.cpp:78
+#: ../src/common/stockitem.cpp:152 ../src/common/accelcmn.cpp:75
 msgid "Execute"
 msgstr "Execute"
 
-#: ../src/msw/utilsexc.cpp:876
+#: ../src/msw/utilsexc.cpp:873
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Eksekusi perintah '%s' gagal"
 
-#: ../src/common/paper.cpp:105
+#: ../src/common/paper.cpp:102
 msgid "Executive, 7 1/4 x 10 1/2 in"
 msgstr "Eksekutif, 7 1/4 x 10 1/2 in"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6009
+#: ../src/generic/datavgen.cpp:6814
 msgid "Expand"
 msgstr "Perluas"
 
-#: ../src/msw/registry.cpp:1240
+#: ../src/msw/registry.cpp:1228
 #, c-format
-msgid "Exporting registry key: file \"%s\" already exists and won't be overwritten."
-msgstr "Mengekspor kunci registri: berkas \"%s\" sudah ada dan tidak akan ditimpa."
+msgid ""
+"Exporting registry key: file \"%s\" already exists and won't be overwritten."
+msgstr ""
+"Mengekspor kunci registri: berkas \"%s\" sudah ada dan tidak akan ditimpa."
 
-#: ../src/common/fmapbase.cpp:195
+#: ../src/common/fmapbase.cpp:192
 msgid "Extended Unix Codepage for Japanese (EUC-JP)"
 msgstr "Extended Unix Codepage for Japanese (EUC-JP)"
 
-#: ../src/html/chm.cpp:725
+#: ../src/html/chm.cpp:718
 #, c-format
 msgid "Extraction of '%s' into '%s' failed."
 msgstr "Hasil ekstrak dari '%s' ke dalam '%s' gagal."
 
-#: ../src/common/accelcmn.cpp:249 ../src/common/accelcmn.cpp:344
+#: ../src/common/accelcmn.cpp:259 ../src/common/accelcmn.cpp:358
 msgid "F"
 msgstr "F"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:672
+#: ../src/propgrid/advprops.cpp:582
 msgid "Face Name"
 msgstr "Nama Face"
 
-#: ../src/unix/snglinst.cpp:269
+#: ../src/unix/snglinst.cpp:266
 msgid "Failed to access lock file."
 msgstr "Gagal mengakses file lock."
+
+#: ../src/gtk/font.cpp:572
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Gagal untuk membaca dokumen dari berkas \"%s\"."
 
 #: ../src/unix/epolldispatcher.cpp:116
 #, c-format
 msgid "Failed to add descriptor %d to epoll descriptor %d"
 msgstr "Gagal menambahkan deskriptor %d ke epool deskriptor %d"
 
-#: ../src/msw/dib.cpp:489
+#: ../src/msw/dib.cpp:535
 #, c-format
 msgid "Failed to allocate %luKb of memory for bitmap data."
 msgstr "Gagal mengalokasikan %luKB dari memori untuk data bitmap."
 
-#: ../src/common/glcmn.cpp:115
+#: ../src/common/glcmn.cpp:112
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Gagal mengalokasikan warna untuk OpenGL"
 
-#: ../src/unix/displayx11.cpp:236
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Gagal mengalokasikan warna untuk OpenGL"
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Gagal mengalokasikan warna untuk OpenGL"
+
+#: ../include/wx/unix/private/displayx11.h:89
 msgid "Failed to change video mode"
 msgstr "Gagal merubah mode video"
 
-#: ../src/common/image.cpp:3277
+#: ../src/common/image.cpp:3396
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Gagal mengecek format citra \"%s\"."
 
-#: ../src/common/debugrpt.cpp:239
+#: ../src/common/debugrpt.cpp:240
 #, c-format
 msgid "Failed to clean up debug report directory \"%s\""
 msgstr "Gagal membersihkan direktori laporan debug \"%s\""
 
-#: ../src/common/filename.cpp:192
+#: ../src/common/filename.cpp:189
 msgid "Failed to close file handle"
 msgstr "Gagal menutup file handle"
 
-#: ../src/unix/snglinst.cpp:340
+#: ../src/unix/snglinst.cpp:337
 #, c-format
 msgid "Failed to close lock file '%s'"
 msgstr "Gagal menutup file lock '%s'"
 
-#: ../src/msw/clipbrd.cpp:112
+#: ../src/msw/clipbrd.cpp:110
 msgid "Failed to close the clipboard."
 msgstr "Gagal menutup clipboard."
 
-#: ../src/x11/utils.cpp:208
+#: ../src/x11/utils.cpp:170
 #, c-format
 msgid "Failed to close the display \"%s\""
 msgstr "Gagal menutup \"%s\""
 
-#: ../src/msw/dialup.cpp:797
+#: ../src/msw/dialup.cpp:791
 msgid "Failed to connect: missing username/password."
 msgstr "Gagal koneksi: kurang nama user/kata kunci."
 
-#: ../src/msw/dialup.cpp:743
+#: ../src/msw/dialup.cpp:737
 msgid "Failed to connect: no ISP to dial."
 msgstr "Gagal koneksi: tidak ada ISP untuk didial."
 
-#: ../src/common/textfile.cpp:203
-#, c-format
-msgid "Failed to convert file \"%s\" to Unicode."
-msgstr "Gagal mengubah berkas \"%s\" ke Unicode."
-
-#: ../src/generic/logg.cpp:956
+#: ../src/generic/logg.cpp:953
 msgid "Failed to copy dialog contents to the clipboard."
 msgstr "Gagal menyalin konten dialog ke clipboard."
 
-#: ../src/msw/registry.cpp:692
+#: ../src/msw/registry.cpp:681
 #, c-format
 msgid "Failed to copy registry value '%s'"
 msgstr "Gagal menyalin nilai registri '%s'"
 
-#: ../src/msw/registry.cpp:701
+#: ../src/msw/registry.cpp:690
 #, c-format
 msgid "Failed to copy the contents of registry key '%s' to '%s'."
 msgstr "Gagal menyalin isi dari kunci registri '%s' ke '%s'."
 
-#: ../src/common/filefn.cpp:1015
+#: ../src/common/filefn.cpp:904
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Gagal menyalin berkas '%s' ke '%s'"
 
-#: ../src/msw/registry.cpp:679
+#: ../src/msw/registry.cpp:668
 #, c-format
 msgid "Failed to copy the registry subkey '%s' to '%s'."
 msgstr "Gagal mennyalin subkunci registri '%s' ke '%s'."
 
-#: ../src/msw/dde.cpp:1070
+#: ../src/msw/dde.cpp:1134
 msgid "Failed to create DDE string"
 msgstr "Gagal menciptakan string DDE"
 
-#: ../src/msw/mdi.cpp:616
+#: ../src/msw/mdi.cpp:621
 msgid "Failed to create MDI parent frame."
 msgstr "Gagal menciptakan frame parent MDI."
 
-#: ../src/common/filename.cpp:1027
+#: ../src/common/filename.cpp:1024
 msgid "Failed to create a temporary file name"
 msgstr "Gagal menciptakan suatu nama file sementara"
 
-#: ../src/msw/utilsexc.cpp:228
+#: ../src/msw/utilsexc.cpp:225
 msgid "Failed to create an anonymous pipe"
 msgstr "Gagal menciptakan pipa anonymous"
 
-#: ../src/msw/ole/automtn.cpp:522
+#: ../src/msw/ole/automtn.cpp:513
 #, c-format
 msgid "Failed to create an instance of \"%s\""
 msgstr "Gagal membuat  \"%s\""
 
-#: ../src/msw/dde.cpp:437
+#: ../src/msw/dde.cpp:432
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "Gagal menciptakan koneksi ke server '%s' untuk topik '%s'"
 
-#: ../src/msw/cursor.cpp:204
+#: ../src/msw/cursor.cpp:195
 msgid "Failed to create cursor."
 msgstr "Gagal membuat kursor."
 
-#: ../src/common/debugrpt.cpp:209
+#: ../src/common/debugrpt.cpp:210
 #, c-format
 msgid "Failed to create directory \"%s\""
 msgstr "Gagal membuat direktori \"%s\""
 
-#: ../src/generic/dirdlgg.cpp:220
+#: ../src/generic/dirdlgg.cpp:217
 #, c-format
 msgid ""
 "Failed to create directory '%s'\n"
@@ -3156,186 +3241,205 @@ msgstr ""
 msgid "Failed to create epoll descriptor"
 msgstr "Gagal membuat epoll deskriptor"
 
-#: ../src/msw/mimetype.cpp:238
+#: ../src/gtk/font.cpp:562
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "Gagal memperbaharui berkas konfigurasi."
+
+#: ../src/msw/mimetype.cpp:235
 #, c-format
 msgid "Failed to create registry entry for '%s' files."
 msgstr "Gagal menciptakan entri registri untuk file '%s'."
 
-#: ../src/msw/fdrepdlg.cpp:409
+#: ../src/msw/fdrepdlg.cpp:408
 #, c-format
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr "Gagal menciptakan dialog standar temukan/ganti (kode kesalahan %d)"
 
-#: ../src/unix/wakeuppipe.cpp:52
+#: ../src/unix/wakeuppipe.cpp:49
 msgid "Failed to create wake up pipe used by event loop."
 msgstr "Gagal membuat wake up pipe yang digunakan oleh event loop."
 
-#: ../src/html/winpars.cpp:730
+#: ../src/html/winpars.cpp:727
 #, c-format
 msgid "Failed to display HTML document in %s encoding"
 msgstr "Gagal menampilkan dokumen HTML dalam pengkodean %s"
 
-#: ../src/msw/clipbrd.cpp:124
+#: ../src/msw/clipbrd.cpp:122
 msgid "Failed to empty the clipboard."
 msgstr "Gagal mengosongkan clipboard."
 
-#: ../src/unix/displayx11.cpp:212
+#: ../include/wx/unix/private/displayx11.h:65
 msgid "Failed to enumerate video modes"
 msgstr "Gagal menghitung jumlah mode video"
 
-#: ../src/msw/dde.cpp:722
+#: ../src/msw/dde.cpp:717
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "Gagal mengadakan advise loop dengan server DDE"
 
-#: ../src/msw/dialup.cpp:629 ../src/msw/dialup.cpp:863
+#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Gagal membentuk koneksi dialup: %s"
 
-#: ../src/unix/utilsunx.cpp:611
+#: ../src/unix/utilsunx.cpp:613
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Gagal mengeksekusi '%s'\n"
 
-#: ../src/common/debugrpt.cpp:720
+#: ../src/common/debugrpt.cpp:730
 msgid "Failed to execute curl, please install it in PATH."
 msgstr "Gagal mengeksekusi curl, tolong install di PATH."
 
-#: ../src/msw/ole/automtn.cpp:505
+#: ../src/msw/ole/automtn.cpp:496
 #, c-format
 msgid "Failed to find CLSID of \"%s\""
 msgstr "Gagal mencari CLSID  \"%s\""
 
-#: ../src/common/regex.cpp:431 ../src/common/regex.cpp:479
+#: ../src/common/regex.cpp:428 ../src/common/regex.cpp:476
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "Gagal mencari ekspresi yang cocok: %s"
 
-#: ../src/msw/dialup.cpp:695
+#: ../src/msw/webview_ie.cpp:978
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:689
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Gagal memperoleh nama ISO: %s"
 
-#: ../src/msw/ole/automtn.cpp:574
+#: ../src/msw/ole/automtn.cpp:565
 #, c-format
 msgid "Failed to get OLE automation interface for \"%s\""
 msgstr "Gagal mendapatkan tatap muka OLE automation untuk \"%s\""
 
-#: ../src/msw/clipbrd.cpp:711
+#: ../src/msw/clipbrd.cpp:731
 msgid "Failed to get data from the clipboard"
 msgstr "Gagal memperoleh data dari clipboard"
 
-#: ../src/common/time.cpp:223
+#: ../src/common/time.cpp:216
 msgid "Failed to get the local system time"
 msgstr "Gagal memperoleh waktu lokal sistem"
 
-#: ../src/common/filefn.cpp:1345
+#: ../src/common/filefn.cpp:1233
 msgid "Failed to get the working directory"
 msgstr "Gagal memperoleh direktori kerja"
 
-#: ../src/univ/theme.cpp:114
+#: ../src/univ/theme.cpp:111
 msgid "Failed to initialize GUI: no built-in themes found."
 msgstr "Gagal menginisialisasi GUI: tidak ditemukan tema built-in."
 
-#: ../src/msw/helpchm.cpp:63
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:60
 msgid "Failed to initialize MS HTML Help."
 msgstr "Gagal menginisialisasi MS HTML Help."
 
-#: ../src/msw/glcanvas.cpp:1381
+#: ../src/msw/glcanvas.cpp:1391
 msgid "Failed to initialize OpenGL"
 msgstr "Gagal menginisialisasi OpenGL"
 
-#: ../src/msw/dialup.cpp:858
+#: ../src/msw/dialup.cpp:852
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Gagal memulai koneksi dialup: %s"
 
-#: ../src/gtk/textctrl.cpp:1128
+#: ../src/gtk/textctrl.cpp:1209
 msgid "Failed to insert text in the control."
 msgstr "Gagal menyisipkan teks ke dalam kontrol."
 
-#: ../src/unix/snglinst.cpp:241
+#: ../src/unix/snglinst.cpp:238
 #, c-format
 msgid "Failed to inspect the lock file '%s'"
 msgstr "Gagal memeriksa berkas terkunci '%s'"
 
-#: ../src/unix/appunix.cpp:182
+#: ../src/unix/appunix.cpp:179
 msgid "Failed to install signal handler"
 msgstr "Gagal memasang pengendali sinyal"
 
-#: ../src/unix/threadpsx.cpp:1167
+#: ../src/unix/threadpsx.cpp:1216
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
 msgstr ""
-"Gagal bergabung ke thread, terdeteksi potensi kebocoran memori - silahkan jalankan "
-"ulang program"
+"Gagal bergabung ke thread, terdeteksi potensi kebocoran memori - silahkan "
+"jalankan ulang program"
 
-#: ../src/msw/utils.cpp:629
+#: ../src/msw/utils.cpp:619
 #, c-format
 msgid "Failed to kill process %d"
 msgstr "Gagal untuk mematikan proses %d"
 
-#: ../src/common/image.cpp:2500
+#: ../src/common/image.cpp:2595
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Gagal memuat bitmap \"%s\" dari sumber."
 
-#: ../src/common/image.cpp:2509
+#: ../src/common/image.cpp:2604
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Gagal memuat ikon \"%s\" dari sumber."
 
-#: ../src/common/iconbndl.cpp:225
+#: ../src/common/iconbndl.cpp:224
 #, c-format
 msgid "Failed to load icons from resource '%s'."
 msgstr "Gagal memuat ikon dari sumber “%s”."
 
-#: ../src/common/iconbndl.cpp:200
+#: ../src/common/iconbndl.cpp:198
 #, c-format
 msgid "Failed to load image %%d from file '%s'."
 msgstr "Gagal memuat citra %%d dari berkas '%s'."
 
-#: ../src/common/iconbndl.cpp:208
+#: ../src/common/iconbndl.cpp:206
 #, c-format
 msgid "Failed to load image %d from stream."
 msgstr "Gagal memuat citra %d dari stream."
 
-#: ../src/common/image.cpp:2587 ../src/common/image.cpp:2606
+#: ../src/common/image.cpp:2682 ../src/common/image.cpp:2701
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Gagal memuat citra dari berkas \"%s\"."
 
-#: ../src/msw/enhmeta.cpp:97
+#: ../src/msw/enhmeta.cpp:94
 #, c-format
 msgid "Failed to load metafile from file \"%s\"."
 msgstr "Gagal memuat metafile dari berkas \"%s\"."
 
-#: ../src/msw/volume.cpp:327
+#: ../src/msw/volume.cpp:335
 msgid "Failed to load mpr.dll."
 msgstr "Gagal memuat mpr.dll."
 
-#: ../src/msw/utils.cpp:953
+#: ../src/msw/utils.cpp:943
 #, c-format
 msgid "Failed to load resource \"%s\"."
 msgstr "Gagal memuat sumber \"%s\"."
 
-#: ../src/common/dynlib.cpp:92
+#: ../src/common/dynlib.cpp:86
 #, c-format
 msgid "Failed to load shared library '%s'"
 msgstr "Gagal memuat shared library '%s'"
 
-#: ../src/osx/core/sound.cpp:145
+#: ../src/osx/core/sound.cpp:143
 #, c-format
 msgid "Failed to load sound from \"%s\" (error %d)."
 msgstr "Gagal memuat suara dari \"%s\" (galat %d)."
 
-#: ../src/msw/utils.cpp:960
+#: ../src/msw/utils.cpp:950
 #, c-format
 msgid "Failed to lock resource \"%s\"."
 msgstr "Gagal menyunci sumber \"%s\"."
 
-#: ../src/unix/snglinst.cpp:198
+#: ../src/unix/snglinst.cpp:195
 #, c-format
 msgid "Failed to lock the lock file '%s'"
 msgstr "Gagal mengunci lock file '%s'"
@@ -3345,33 +3449,38 @@ msgstr "Gagal mengunci lock file '%s'"
 msgid "Failed to modify descriptor %d in epoll descriptor %d"
 msgstr "Gagal mengubah deskriptor %d dalam epoll deskriptor %d"
 
-#: ../src/common/filename.cpp:2575
+#: ../src/common/filename.cpp:2658
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Gagal untuk memodifikasi waktu file untuk '%s'"
 
-#: ../src/common/selectdispatcher.cpp:258
+#: ../src/common/selectdispatcher.cpp:255
 msgid "Failed to monitor I/O channels"
 msgstr "Gagal memonitor saluran I/O"
 
-#: ../src/common/filename.cpp:175
+#: ../src/common/filename.cpp:172
 #, c-format
 msgid "Failed to open '%s' for reading"
 msgstr "Gagal membuka '%s' untuk dibaca"
 
-#: ../src/common/filename.cpp:180
+#: ../src/common/filename.cpp:177
 #, c-format
 msgid "Failed to open '%s' for writing"
 msgstr "Gagal membuka '%s' untuk menulis"
 
-#: ../src/html/chm.cpp:141
+#: ../src/html/chm.cpp:138
 #, c-format
 msgid "Failed to open CHM archive '%s'."
 msgstr "Gagal membuka arsip CHM '%s'."
 
-#: ../src/common/utilscmn.cpp:1126
+#: ../src/common/utilscmn.cpp:1140
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Gagal membuka URL \"%s\" pada browser."
+
+#: ../src/common/hyperlnkcmn.cpp:133
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Gagal membuka URL \"%s\" pada browser."
 
 #: ../include/wx/msw/private/fswatcher.h:92
@@ -3379,207 +3488,228 @@ msgstr "Gagal membuka URL \"%s\" pada browser."
 msgid "Failed to open directory \"%s\" for monitoring."
 msgstr "Gagal membuka direktori \"%s\" untuk dipantau."
 
-#: ../src/x11/utils.cpp:227
+#: ../src/x11/utils.cpp:189
 #, c-format
 msgid "Failed to open display \"%s\"."
 msgstr "Gagal membuka \"%s\"."
 
-#: ../src/common/filename.cpp:1062
+#: ../src/common/filename.cpp:1059
 msgid "Failed to open temporary file."
 msgstr "Gagal membuka file sementara."
 
-#: ../src/msw/clipbrd.cpp:91
+#: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Gagal membuka clipboard."
 
-#: ../src/common/translation.cpp:1184
+#: ../src/common/translation.cpp:1226
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Gagal mengurai Plural-Forms: '%s'"
 
-#: ../src/unix/mediactrl.cpp:1214
+#: ../src/unix/mediactrl.cpp:1239
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Gagal memutar \"%s\"."
 
-#: ../src/msw/clipbrd.cpp:600
+#: ../src/msw/clipbrd.cpp:610
 msgid "Failed to put data on the clipboard"
 msgstr "Gagal menempatkan data pada clipboard"
 
-#: ../src/unix/snglinst.cpp:278
+#: ../src/unix/snglinst.cpp:275
 msgid "Failed to read PID from lock file."
 msgstr "Gagal membaca PID dari file lock."
 
-#: ../src/common/fileconf.cpp:433
+#: ../src/common/fileconf.cpp:432
 msgid "Failed to read config options."
 msgstr "Gagal membaca opsi konfigurasi."
 
-#: ../src/common/docview.cpp:681
+#: ../src/common/docview.cpp:676
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Gagal untuk membaca dokumen dari berkas \"%s\"."
 
-#: ../src/dfb/evtloop.cpp:98
+#: ../src/dfb/evtloop.cpp:99
 msgid "Failed to read event from DirectFB pipe"
 msgstr "Gagal membaca event dari DirectFB pipe"
 
-#: ../src/unix/wakeuppipe.cpp:120
+#: ../src/unix/wakeuppipe.cpp:117
 msgid "Failed to read from wake-up pipe"
 msgstr "Gagal membaca dari wake-up pipe"
 
-#: ../src/unix/utilsunx.cpp:679
+#: ../src/common/textfile.cpp:96
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Gagal untuk membaca dokumen dari berkas \"%s\"."
+
+#: ../src/unix/utilsunx.cpp:681
 msgid "Failed to redirect child process input/output"
 msgstr "Gagal mengarahkan kembali proses masukan/keluaran child"
 
-#: ../src/msw/utilsexc.cpp:701
+#: ../src/msw/utilsexc.cpp:698
 msgid "Failed to redirect the child process IO"
 msgstr "Gagal mengarahkan kembali proses IO child"
 
-#: ../src/msw/dde.cpp:288
+#: ../src/msw/dde.cpp:283
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Gagal meregister server DDE '%s'"
 
-#: ../src/common/fontmap.cpp:245
+#: ../src/gtk/font.cpp:580
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "Gagal memperbaharui berkas konfigurasi."
+
+#: ../src/common/fontmap.cpp:242
 #, c-format
 msgid "Failed to remember the encoding for the charset '%s'."
 msgstr "Gagal mengingat pengkodean untuk charset '%s'."
 
-#: ../src/common/debugrpt.cpp:227
+#: ../src/common/debugrpt.cpp:228
 #, c-format
 msgid "Failed to remove debug report file \"%s\""
 msgstr "Gagal mengapus berkas laporan debug \"%s\""
 
-#: ../src/unix/snglinst.cpp:328
+#: ../src/unix/snglinst.cpp:325
 #, c-format
 msgid "Failed to remove lock file '%s'"
 msgstr "Gagal menghilangkan file lock '%s'"
 
-#: ../src/unix/snglinst.cpp:288
+#: ../src/unix/snglinst.cpp:285
 #, c-format
 msgid "Failed to remove stale lock file '%s'."
 msgstr "Gagal menghapus berkas pengunci ‘%s’."
 
-#: ../src/msw/registry.cpp:529
+#: ../src/msw/registry.cpp:518
 #, c-format
 msgid "Failed to rename registry value '%s' to '%s'."
 msgstr "Gagal mengganti nama nilai registri '%s' ke '%s'."
 
-#: ../src/common/filefn.cpp:1122
+#: ../src/common/filefn.cpp:1011
 #, c-format
 msgid ""
-"Failed to rename the file '%s' to '%s' because the destination file already exists."
-msgstr "Gagal mengubah nama berkas '%s' ke '%s' karena berkas tujuan sudah ada."
+"Failed to rename the file '%s' to '%s' because the destination file already "
+"exists."
+msgstr ""
+"Gagal mengubah nama berkas '%s' ke '%s' karena berkas tujuan sudah ada."
 
-#: ../src/msw/registry.cpp:634
+#: ../src/msw/registry.cpp:623
 #, c-format
 msgid "Failed to rename the registry key '%s' to '%s'."
 msgstr "Gagal mengganti nama kunci registri '%s' ke '%s'."
 
-#: ../src/common/filename.cpp:2671
+#: ../src/msw/webview_ie.cpp:995
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/common/filename.cpp:2754
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Gagal mengambil waktu file untuk '%s'"
 
-#: ../src/msw/dialup.cpp:468
+#: ../src/msw/dialup.cpp:462
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Gagal mengambil teks dari pesan kesalahan RAS"
 
-#: ../src/msw/clipbrd.cpp:748
+#: ../src/msw/clipbrd.cpp:768
 msgid "Failed to retrieve the supported clipboard formats"
 msgstr "Gagal mengambil format clipboard yang didukung"
 
-#: ../src/common/docview.cpp:652
+#: ../src/common/docview.cpp:647
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Gagal menyimpan dokumen ke berkas \"%s\"."
 
-#: ../src/msw/dib.cpp:269
+#: ../src/msw/dib.cpp:312
 #, c-format
 msgid "Failed to save the bitmap image to file \"%s\"."
 msgstr "Gagal menyimpan citra bitmap ke berkas \"%s\"."
 
-#: ../src/msw/dde.cpp:763
+#: ../src/msw/dde.cpp:811
 msgid "Failed to send DDE advise notification"
 msgstr "Gagal mengirimkan pemberitahuan DDE advise"
 
-#: ../src/common/ftp.cpp:402
+#: ../src/common/ftp.cpp:399
 #, c-format
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Gagal menetapkan mode transfer FTP ke %s."
 
-#: ../src/msw/clipbrd.cpp:427
+#: ../src/msw/clipbrd.cpp:443
 msgid "Failed to set clipboard data."
 msgstr "Gagal menetapkan data clipboard."
 
-#: ../src/unix/snglinst.cpp:181
+#: ../src/unix/snglinst.cpp:178
 #, c-format
 msgid "Failed to set permissions on lock file '%s'"
 msgstr "Gagal mengatur izin mengunci berkas '%s'"
 
-#: ../src/unix/utilsunx.cpp:668
+#: ../src/unix/utilsunx.cpp:670
 msgid "Failed to set process priority"
 msgstr "Gagal menetapkan prioritas proses"
 
-#: ../src/common/file.cpp:559
+#: ../src/common/ffile.cpp:355 ../src/common/file.cpp:586
 msgid "Failed to set temporary file permissions"
 msgstr "Gagal menetapkan permisi file sementara"
 
-#: ../src/gtk/textctrl.cpp:1072
-msgid "Failed to set text in the text control."
-msgstr "Gagal mengatur teks pada teks kontrol."
-
-#: ../src/unix/threadpsx.cpp:1298
+#: ../src/unix/threadpsx.cpp:1347
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Gagal mengatur thread concurrency level pada %lu"
 
-#: ../src/unix/threadpsx.cpp:1424
+#: ../src/unix/threadpsx.cpp:1473
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Gagal menetapkan prioritas thread %d."
 
-#: ../src/unix/utilsunx.cpp:783
+#: ../src/unix/utilsunx.cpp:785
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr "Gagal mengatur no-blocking pipe, program mungkin akan mengalami galat."
 
-#: ../src/common/fs_mem.cpp:261
+#: ../src/msw/webview_ie.cpp:987
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:256
 #, c-format
 msgid "Failed to store image '%s' to memory VFS!"
 msgstr "Gagal menyimpan citra '%s' ke memori VFS!"
 
-#: ../src/dfb/evtloop.cpp:170
+#: ../src/dfb/evtloop.cpp:171
 msgid "Failed to switch DirectFB pipe to non-blocking mode"
 msgstr "Gagal mengubah DirectFB pipe ke mode non-blocking"
 
-#: ../src/unix/wakeuppipe.cpp:59
+#: ../src/unix/wakeuppipe.cpp:56
 msgid "Failed to switch wake up pipe to non-blocking mode"
 msgstr "Gagal mengubah wake up pipe ke mode non-blocking"
 
-#: ../src/unix/threadpsx.cpp:1605
+#: ../src/unix/threadpsx.cpp:1654
 msgid "Failed to terminate a thread."
 msgstr "Gagal menghentikan thread."
 
-#: ../src/msw/dde.cpp:741
+#: ../src/msw/dde.cpp:736
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "Gagal menghentikan advise loop dengan server DDE"
 
-#: ../src/msw/dialup.cpp:938
+#: ../src/msw/dialup.cpp:932
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Gagal menghentikan koneksi dialup: %s"
 
-#: ../src/common/filename.cpp:2590
+#: ../src/common/filename.cpp:2673
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Gagal membuat file kosong '%s'"
 
-#: ../src/unix/snglinst.cpp:334
+#: ../src/unix/dlunix.cpp:90
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "Gagal memuat shared library '%s'"
+
+#: ../src/unix/snglinst.cpp:331
 #, c-format
 msgid "Failed to unlock lock file '%s'"
 msgstr "Gagal membuka kunci dari file lock '%s'"
 
-#: ../src/msw/dde.cpp:309
+#: ../src/msw/dde.cpp:304
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Gagal melepas register server DDE '%s'"
@@ -3587,83 +3717,94 @@ msgstr "Gagal melepas register server DDE '%s'"
 #: ../src/unix/epolldispatcher.cpp:155
 #, c-format
 msgid "Failed to unregister descriptor %d from epoll descriptor %d"
-msgstr "Gagal untuk membatalkan pendaftara deskriptor %d dari epoll deskriptor %d"
+msgstr ""
+"Gagal untuk membatalkan pendaftara deskriptor %d dari epoll deskriptor %d"
 
 #: ../src/common/fileconf.cpp:1006
 msgid "Failed to update user configuration file."
 msgstr "Gagal memperbaharui berkas konfigurasi."
 
-#: ../src/common/debugrpt.cpp:733
+#: ../src/common/debugrpt.cpp:743
 #, c-format
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Gagal mengupload laporan debut (kode error %d)."
 
-#: ../src/unix/snglinst.cpp:168
+#: ../src/unix/snglinst.cpp:165
 #, c-format
 msgid "Failed to write to lock file '%s'"
 msgstr "Gagal menulis file lock '%s'"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:209
+#: ../src/propgrid/propgrid.cpp:190
 msgid "False"
 msgstr "False"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:694
+#: ../src/propgrid/advprops.cpp:604
 msgid "Family"
 msgstr "Keluarga"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/gtk/glcanvas.cpp:176 ../src/gtk/glcanvas.cpp:187
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Galat berkas"
+
+#: ../src/common/stockitem.cpp:154
 msgid "File"
 msgstr "Berkas"
 
-#: ../src/common/docview.cpp:669
+#: ../src/common/docview.cpp:664
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Berkas \"%s\" tidak dapat dibuka untuk dibaca."
 
-#: ../src/common/docview.cpp:646
+#: ../src/common/docview.cpp:641
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Berkas \"%s\" tidak dapat dibuka untuk ditulisi."
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "Berkas '%s' sudah ada, apakah benar anda ingin menimpanya?"
 
-#: ../src/common/filefn.cpp:1156
+#: ../src/common/filefn.cpp:1044
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Berkas '%s' tidak dapat dihapus"
 
-#: ../src/common/filefn.cpp:1139
+#: ../src/common/filefn.cpp:1028
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Berkas '%s' tidak dapat diubah nama menjadi '%s'"
 
-#: ../src/richtext/richtextctrl.cpp:3081 ../src/common/textcmn.cpp:953
+#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
 msgid "File couldn't be loaded."
 msgstr "Berkas tidak bisa dimuat."
 
-#: ../src/msw/filedlg.cpp:393
+#: ../src/msw/filedlg.cpp:414
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Dialog berkas gagal dengan kode galat %0lx."
 
-#: ../src/common/docview.cpp:1789
+#: ../src/common/docview.cpp:1783
 msgid "File error"
 msgstr "Galat berkas"
 
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/filectrlg.cpp:770
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/filectrlg.cpp:766
 msgid "File name exists already."
 msgstr "Nama berkas sudah ada."
+
+#: ../src/osx/cocoa/filedlg.mm:264
+#, fuzzy
+msgid "File type:"
+msgstr "Teletype"
 
 #: ../src/motif/filedlg.cpp:220
 msgid "Files"
 msgstr "Berkas"
 
-#: ../src/common/filefn.cpp:1591
+#: ../src/common/filefn.cpp:1479
 #, c-format
 msgid "Files (%s)"
 msgstr "Berkas (%s)"
@@ -3672,15 +3813,29 @@ msgstr "Berkas (%s)"
 msgid "Filter"
 msgstr "Penyaring"
 
-#: ../src/common/stockitem.cpp:158 ../src/html/helpwnd.cpp:490
+#: ../src/html/helpwnd.cpp:488
 msgid "Find"
 msgstr "Temukan"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:259
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:258
+#, fuzzy
+msgid "Find in document"
+msgstr "Buka dokumen HTML"
+
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "Find..."
+msgstr "Temukan"
+
+#: ../src/common/stockitem.cpp:156
 msgid "First"
 msgstr "Pertama"
 
-#: ../src/common/prntbase.cpp:1548
+#: ../src/common/prntbase.cpp:1573
 msgid "First page"
 msgstr "Halaman pertama"
 
@@ -3688,11 +3843,11 @@ msgstr "Halaman pertama"
 msgid "Fixed"
 msgstr "Tetap"
 
-#: ../src/html/helpwnd.cpp:1206
+#: ../src/html/helpwnd.cpp:1204
 msgid "Fixed font:"
 msgstr "Huruf tetap:"
 
-#: ../src/html/helpwnd.cpp:1269
+#: ../src/html/helpwnd.cpp:1267
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Font ukuran tetap.<br> <b>tebal</b> <i>miring</i> "
 
@@ -3700,16 +3855,16 @@ msgstr "Font ukuran tetap.<br> <b>tebal</b> <i>miring</i> "
 msgid "Floating"
 msgstr "Mengambang"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "Floppy"
 msgstr "Floppy"
 
-#: ../src/common/paper.cpp:111
+#: ../src/common/paper.cpp:108
 msgid "Folio, 8 1/2 x 13 in"
 msgstr "Folio, 8 1/2 x 13 inci"
 
-#: ../src/richtext/richtextformatdlg.cpp:344 ../src/osx/carbon/fontdlg.cpp:287
-#: ../src/common/stockitem.cpp:194
+#: ../src/osx/carbon/fontdlg.cpp:284 ../src/common/stockitem.cpp:191
+#: ../src/richtext/richtextformatdlg.cpp:337
 msgid "Font"
 msgstr "Font"
 
@@ -3717,7 +3872,24 @@ msgstr "Font"
 msgid "Font &weight:"
 msgstr "Berat &font:"
 
-#: ../src/html/helpwnd.cpp:1207
+#: ../src/osx/fontutil.cpp:89
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
+"\"."
+msgstr ""
+
+#: ../src/msw/font.cpp:1126
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Berkas tidak bisa dimuat."
+
+#: ../src/osx/fontutil.cpp:81
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr ": berkas tidak ada!"
+
+#: ../src/html/helpwnd.cpp:1205
 msgid "Font size:"
 msgstr "Ukuran huruf:"
 
@@ -3725,79 +3897,79 @@ msgstr "Ukuran huruf:"
 msgid "Font st&yle:"
 msgstr "Ga&ya font:"
 
-#: ../src/osx/carbon/fontdlg.cpp:329
+#: ../src/osx/carbon/fontdlg.cpp:326
 msgid "Font:"
 msgstr "Font:"
 
-#: ../src/dfb/fontmgr.cpp:198
+#: ../src/dfb/fontmgr.cpp:195
 #, c-format
 msgid "Fonts index file %s disappeared while loading fonts."
 msgstr "Berkas indeks font %s hilang ketika memuat font."
 
 # sort by translation
 # checked up to here 20131006-1302
-#: ../src/unix/utilsunx.cpp:645
+#: ../src/unix/utilsunx.cpp:647
 msgid "Fork failed"
 msgstr "Fork gagal"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "Forward"
 msgstr "Maju"
 
-#: ../src/common/xtixml.cpp:235
+#: ../src/common/xtixml.cpp:231
 msgid "Forward hrefs are not supported"
 msgstr "Forward hrefs tidak didukung"
 
-#: ../src/html/helpwnd.cpp:875
+#: ../src/html/helpwnd.cpp:873
 #, c-format
 msgid "Found %i matches"
 msgstr "Menemukan %i sesuai"
 
-#: ../src/generic/prntdlgg.cpp:238
+#: ../src/generic/prntdlgg.cpp:231
 msgid "From:"
 msgstr "Dari:"
 
-#: ../src/propgrid/advprops.cpp:1604
+#: ../src/propgrid/advprops.cpp:1510
 msgid "Fuchsia"
 msgstr "Merah Muda"
 
-#: ../src/common/imaggif.cpp:138
+#: ../src/common/imaggif.cpp:135
 msgid "GIF: data stream seems to be truncated."
 msgstr "GIF: stream data kelihatannya terpotong."
 
-#: ../src/common/imaggif.cpp:128
+#: ../src/common/imaggif.cpp:125
 msgid "GIF: error in GIF image format."
 msgstr "GIF: kesalahan pada format citra GIF."
 
-#: ../src/common/imaggif.cpp:133
+#: ../src/common/imaggif.cpp:130
 msgid "GIF: not enough memory."
 msgstr "GIF: tidak cukup memori."
 
-#: ../src/gtk/window.cpp:4631
+#: ../src/gtk/window.cpp:5635
 msgid ""
-"GTK+ installed on this machine is too old to support screen compositing, please "
-"install GTK+ 2.12 or later."
+"GTK+ installed on this machine is too old to support screen compositing, "
+"please install GTK+ 2.12 or later."
 msgstr ""
 "GTK+ terpasang dimesin ini dan terlalu tua untuk mendukung fitur screen "
 "compositing, mohon memasang GTK+ 2.12 atau versi ke atasnya."
 
-#: ../src/univ/themes/gtk.cpp:525
+#: ../src/univ/themes/gtk.cpp:522
 msgid "GTK+ theme"
 msgstr "Tema GTK+"
 
-#: ../src/common/preferencescmn.cpp:40
+#: ../src/common/preferencescmn.cpp:37
 msgid "General"
 msgstr "Umum"
 
-#: ../src/common/prntbase.cpp:258
+#: ../src/common/prntbase.cpp:253
 msgid "Generic PostScript"
 msgstr "Postcript Generik"
 
-#: ../src/common/paper.cpp:135
+#: ../src/common/paper.cpp:132
 msgid "German Legal Fanfold, 8 1/2 x 13 in"
 msgstr "German Legal Fanfold, 8 1/2 x 13 inci"
 
-#: ../src/common/paper.cpp:134
+#: ../src/common/paper.cpp:131
 msgid "German Std Fanfold, 8 1/2 x 12 in"
 msgstr "German Std Fanfold, 8 1/2 x 12 inci"
 
@@ -3813,48 +3985,48 @@ msgstr "GetPropertyCollection disebut dengan generic accessor"
 msgid "GetPropertyCollection called w/o valid collection getter"
 msgstr "GetPropertyCollection dipanggil tanda valid collection getter"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:658
 msgid "Go back"
 msgstr "Kembali"
 
-#: ../src/html/helpwnd.cpp:661
+#: ../src/html/helpwnd.cpp:659
 msgid "Go forward"
 msgstr "Ke depan"
 
-#: ../src/html/helpwnd.cpp:663
+#: ../src/html/helpwnd.cpp:661
 msgid "Go one level up in document hierarchy"
 msgstr "Ke satu tingkat diatas dalam hirarki dokumen"
 
-#: ../src/generic/filedlgg.cpp:208 ../src/generic/dirdlgg.cpp:116
+#: ../src/generic/filedlgg.cpp:205 ../src/generic/dirdlgg.cpp:113
 msgid "Go to home directory"
 msgstr "Ke direktori home"
 
-#: ../src/generic/filedlgg.cpp:205
+#: ../src/generic/filedlgg.cpp:202
 msgid "Go to parent directory"
 msgstr "Ke direktori atasnya"
 
-#: ../src/generic/aboutdlgg.cpp:76
+#: ../src/generic/aboutdlgg.cpp:73
 msgid "Graphics art by "
 msgstr "Grafis oleh "
 
-#: ../src/propgrid/advprops.cpp:1599
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Gray"
 msgstr "Abu-abu"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:883
+#: ../src/propgrid/advprops.cpp:784
 msgid "GrayText"
 msgstr "TeksAbu"
 
-#: ../src/common/fmapbase.cpp:154
+#: ../src/common/fmapbase.cpp:151
 msgid "Greek (ISO-8859-7)"
 msgstr "Greek (ISO-8859-7)"
 
-#: ../src/propgrid/advprops.cpp:1600
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Green"
 msgstr "Hijau"
 
-#: ../src/generic/colrdlgg.cpp:342
+#: ../src/generic/colrdlgg.cpp:362
 msgid "Green:"
 msgstr "Hijau:"
 
@@ -3862,171 +4034,173 @@ msgstr "Hijau:"
 msgid "Groove"
 msgstr "Groove"
 
-#: ../src/common/zstream.cpp:158 ../src/common/zstream.cpp:318
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
 msgid "Gzip not supported by this version of zlib"
 msgstr "Gzip tidak didukung oleh versi zlib ini"
 
-#: ../src/html/helpwnd.cpp:1549
+#: ../src/html/helpwnd.cpp:1547
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "Proyek Bantuan HTML (*.hhp)|*.hhp|"
 
-#: ../src/html/htmlwin.cpp:681
+#: ../src/html/htmlwin.cpp:691
 #, c-format
 msgid "HTML anchor %s does not exist."
 msgstr "Anchor HTML %s tidak ada."
 
-#: ../src/html/helpwnd.cpp:1547
+#: ../src/html/helpwnd.cpp:1545
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "Berkas HTML (*.html;*.htm)|*.html;*.htm|"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1759
+#: ../src/propgrid/advprops.cpp:1660
 msgid "Hand"
 msgstr "Tangan"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "Harddisk"
 msgstr "Harddisk"
 
-#: ../src/common/fmapbase.cpp:155
+#: ../src/common/fmapbase.cpp:152
 msgid "Hebrew (ISO-8859-8)"
 msgstr "Hebrew (ISO-8859-8)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:280 ../src/osx/button_osx.cpp:39
-#: ../src/common/stockitem.cpp:163 ../src/common/accelcmn.cpp:80
-#: ../src/html/helpdlg.cpp:66 ../src/html/helpfrm.cpp:111
+#: ../include/wx/msgdlg.h:282 ../src/osx/button_osx.cpp:39
+#: ../src/common/stockitem.cpp:160 ../src/common/accelcmn.cpp:77
+#: ../src/html/helpfrm.cpp:108 ../src/html/helpdlg.cpp:63
 msgid "Help"
 msgstr "Help"
 
-#: ../src/html/helpwnd.cpp:1200
+#: ../src/html/helpwnd.cpp:1198
 msgid "Help Browser Options"
 msgstr "Opsi Bantuan Browser"
 
-#: ../src/generic/helpext.cpp:454 ../src/generic/helpext.cpp:455
+#: ../src/generic/helpext.cpp:452 ../src/generic/helpext.cpp:453
 msgid "Help Index"
 msgstr "Indeks Bantuan"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1529
 msgid "Help Printing"
 msgstr "Bantuan Pencetakan"
 
-#: ../src/html/helpwnd.cpp:801
+#: ../src/html/helpwnd.cpp:799
 msgid "Help Topics"
 msgstr "Topik Bantuan"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1546
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Buku bantuan (*.htb)|*.htb|Buku bantuan (*.zip)|*.zip|"
 
-#: ../src/generic/helpext.cpp:267
+#: ../src/generic/helpext.cpp:265
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "Direktori bantuan \"%s\" tidak ditemukan."
 
-#: ../src/generic/helpext.cpp:275
+#: ../src/generic/helpext.cpp:273
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "Berkas bantuan \"%s\" tidak ditemukan."
 
-#: ../src/html/helpctrl.cpp:63
+#: ../src/html/helpctrl.cpp:59
 #, c-format
 msgid "Help: %s"
 msgstr "Bantuan: %s"
 
-#: ../src/osx/menu_osx.cpp:577
+#: ../src/osx/menu_osx.cpp:469
 #, c-format
 msgid "Hide %s"
 msgstr "Sembunyi: %s"
 
-#: ../src/osx/menu_osx.cpp:579
+#: ../src/osx/menu_osx.cpp:471
 msgid "Hide Others"
 msgstr "Sembunyikan Lainnya"
 
-#: ../src/generic/infobar.cpp:84
+#: ../src/generic/infobar.cpp:81
 msgid "Hide this notification message."
 msgstr "Sembunyikan pesan pemberitahuan ini."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:884
+#: ../src/propgrid/advprops.cpp:785
 msgid "Highlight"
 msgstr "Kilau"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:885
+#: ../src/propgrid/advprops.cpp:786
 msgid "HighlightText"
 msgstr "KilauTeks"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:164 ../src/common/accelcmn.cpp:65
+#: ../src/common/stockitem.cpp:161 ../src/common/accelcmn.cpp:62
 msgid "Home"
 msgstr "Home"
 
-#: ../src/generic/dirctrlg.cpp:524
+#: ../src/generic/dirctrlg.cpp:490
 msgid "Home directory"
 msgstr "Direktori rumah"
 
-#: ../src/richtext/richtextsizepage.cpp:253 ../src/richtext/richtextsizepage.cpp:255
+#: ../src/richtext/richtextsizepage.cpp:253
+#: ../src/richtext/richtextsizepage.cpp:255
 msgid "How the object will float relative to the text."
 msgstr "Bagaimana obyek akan mengapung relatif terhadap teks."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1760
+#: ../src/propgrid/advprops.cpp:1661
 msgid "I-Beam"
 msgstr "Batang-I"
 
-#: ../src/common/imagbmp.cpp:1196
+#: ../src/common/imagbmp.cpp:1208
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: Kesalahan dalam membaca mask DIB."
 
-#: ../src/common/imagbmp.cpp:1290 ../src/common/imagbmp.cpp:1390
-#: ../src/common/imagbmp.cpp:1405 ../src/common/imagbmp.cpp:1416
-#: ../src/common/imagbmp.cpp:1430 ../src/common/imagbmp.cpp:1478
-#: ../src/common/imagbmp.cpp:1493 ../src/common/imagbmp.cpp:1507
-#: ../src/common/imagbmp.cpp:1518
+#: ../src/common/imagbmp.cpp:1302 ../src/common/imagbmp.cpp:1402
+#: ../src/common/imagbmp.cpp:1417 ../src/common/imagbmp.cpp:1428
+#: ../src/common/imagbmp.cpp:1442 ../src/common/imagbmp.cpp:1490
+#: ../src/common/imagbmp.cpp:1505 ../src/common/imagbmp.cpp:1519
+#: ../src/common/imagbmp.cpp:1530
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: Kesalahan dalam menulis berkas citra!"
 
-#: ../src/common/imagbmp.cpp:1255
+#: ../src/common/imagbmp.cpp:1267
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: Citra terlalu tinggi untuk suatu ikon."
 
-#: ../src/common/imagbmp.cpp:1263
+#: ../src/common/imagbmp.cpp:1275
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: Citra terlalu lebar untuk suatu ikon."
 
-#: ../src/common/imagbmp.cpp:1603
+#: ../src/common/imagbmp.cpp:1615
 msgid "ICO: Invalid icon index."
 msgstr "ICO: Indeks ikon tidak sah."
 
-#: ../src/common/imagiff.cpp:758
+#: ../src/common/imagiff.cpp:755
 msgid "IFF: data stream seems to be truncated."
 msgstr "IFF: stream data kelihatannya terpotong."
 
-#: ../src/common/imagiff.cpp:742
+#: ../src/common/imagiff.cpp:739
 msgid "IFF: error in IFF image format."
 msgstr "IFF: kesalahan dalam format citra IFF."
 
-#: ../src/common/imagiff.cpp:745
+#: ../src/common/imagiff.cpp:742
 msgid "IFF: not enough memory."
 msgstr "IFF: memori tidak cukup."
 
-#: ../src/common/imagiff.cpp:748
+#: ../src/common/imagiff.cpp:745
 msgid "IFF: unknown error!!!"
 msgstr "IFF: kesalahan yang tidak diketahui!!!"
 
-#: ../src/common/fmapbase.cpp:197
+#: ../src/common/fmapbase.cpp:194
 msgid "ISO-2022-JP"
 msgstr "ISO-2022-JP"
 
-#: ../src/html/htmprint.cpp:282
+#: ../src/html/htmprint.cpp:294
 msgid ""
-"If possible, try changing the layout parameters to make the printout more narrow."
+"If possible, try changing the layout parameters to make the printout more "
+"narrow."
 msgstr ""
-"Jika memungkinkan, cobalah untuk mengubah parameter untuk membuat hasil cetakan "
-"mengecil."
+"Jika memungkinkan, cobalah untuk mengubah parameter untuk membuat hasil "
+"cetakan mengecil."
 
-#: ../src/generic/dbgrptg.cpp:358
+#: ../src/generic/dbgrptg.cpp:362
 msgid ""
 "If you have any additional information pertaining to this bug\n"
 "report, please enter it here and it will be joined to it:"
@@ -4036,56 +4210,60 @@ msgstr ""
 
 #: ../src/generic/dbgrptg.cpp:324
 msgid ""
-"If you wish to suppress this debug report completely, please choose the \"Cancel\" "
-"button,\n"
+"If you wish to suppress this debug report completely, please choose the "
+"\"Cancel\" button,\n"
 "but be warned that it may hinder improving the program, so if\n"
 "at all possible please do continue with the report generation.\n"
 msgstr ""
-"Jika anda ingin mendiamkan laporan debug seluruhnya, silakan pilih tombol \"Cancel"
-"\", \n"
+"Jika anda ingin mendiamkan laporan debug seluruhnya, silakan pilih tombol "
+"\"Cancel\", \n"
 "tetapi hal tersebut dapat menghalangi pengembangan program, jadi jika\n"
 "memungkinkan tolong lanjutkan dengan pembuatan laporan.\n"
 
-#: ../src/msw/registry.cpp:1405
+#: ../src/common/zipstrm.cpp:1043
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1393
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Mengabaikan nilai \"%s\" dari kunci \"%s\"."
 
-#: ../src/common/xtistrm.cpp:295
+#: ../src/common/xtistrm.cpp:292
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Kelas Obyek Ilegal (Non-wxEvtHandler) sebagai Event Source"
 
-#: ../src/common/xti.cpp:513
+#: ../src/common/xti.cpp:510
 msgid "Illegal Parameter Count for ConstructObject Method"
 msgstr "Parameter Ilegal untuk metode ConstructObject"
 
-#: ../src/common/xti.cpp:501
+#: ../src/common/xti.cpp:498
 msgid "Illegal Parameter Count for Create Method"
 msgstr "Parameter Ilegal untuk moteode Create"
 
-#: ../src/generic/dirctrlg.cpp:570 ../src/generic/filectrlg.cpp:756
+#: ../src/generic/dirctrlg.cpp:536 ../src/generic/filectrlg.cpp:752
 msgid "Illegal directory name."
 msgstr "Nama direktori tidak sah."
 
-#: ../src/generic/filectrlg.cpp:1367
+#: ../src/generic/filectrlg.cpp:1356
 msgid "Illegal file specification."
 msgstr "Spesifikasi file tidak sah."
 
-#: ../src/common/image.cpp:2269
+#: ../src/common/image.cpp:2363
 msgid "Image and mask have different sizes."
 msgstr "Citra dan mask mempunyai ukuran yang berbeda."
 
-#: ../src/common/image.cpp:2746
+#: ../src/common/image.cpp:2841
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "Berkas citra bukan bertipe %d."
 
-#: ../src/common/image.cpp:2877
+#: ../src/common/image.cpp:2995
 #, c-format
 msgid "Image is not of type %s."
 msgstr "Citra bukan dari tipe %s."
 
-#: ../src/msw/textctrl.cpp:488
+#: ../src/msw/textctrl.cpp:534
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -4093,98 +4271,100 @@ msgstr ""
 "Tidak mungkin menciptakan suatu kontrol rich edit, menggunakan kontrol text "
 "sederhana sebagai gantinya. Silahkan install ulang riched32.dll"
 
-#: ../src/unix/utilsunx.cpp:301
+#: ../src/unix/utilsunx.cpp:303
 msgid "Impossible to get child process input"
 msgstr "Tidak mungkin memperoleh masukan dari proses anak"
 
-#: ../src/common/filefn.cpp:1028
+#: ../src/common/filefn.cpp:917
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Tidak mungkin memperoleh permisi file '%s'"
 
-#: ../src/common/filefn.cpp:1042
+#: ../src/common/filefn.cpp:931
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Tidak mungkin menimpa file '%s'"
 
-#: ../src/common/filefn.cpp:1097
+#: ../src/common/filefn.cpp:986
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Tidak mungkin mengubah permisi file '%s'"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:886
+#: ../src/propgrid/advprops.cpp:787
 msgid "InactiveBorder"
 msgstr "TepiTakAktif"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:887
+#: ../src/propgrid/advprops.cpp:788
 msgid "InactiveCaption"
 msgstr "JudulTakAktif"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:888
+#: ../src/propgrid/advprops.cpp:789
 msgid "InactiveCaptionText"
 msgstr "TeksJudulTakAktif"
 
-#: ../src/common/gifdecod.cpp:792
+#: ../src/common/gifdecod.cpp:826
 #, c-format
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "Ukuran frame GIF salah (%u, %d) untuk frame #%u"
 
-#: ../src/msw/ole/automtn.cpp:635
+#: ../src/msw/ole/automtn.cpp:626
 msgid "Incorrect number of arguments."
 msgstr "Nomor argumen salah."
 
-#: ../src/common/stockitem.cpp:165
+#: ../src/common/stockitem.cpp:162
 msgid "Indent"
 msgstr "Inden"
 
-#: ../src/richtext/richtextformatdlg.cpp:349
+#: ../src/richtext/richtextformatdlg.cpp:342
 msgid "Indents && Spacing"
 msgstr "Inden && Spasi"
 
-#: ../src/common/stockitem.cpp:166 ../src/html/helpwnd.cpp:515
+#: ../src/common/stockitem.cpp:163 ../src/html/helpwnd.cpp:513
 msgid "Index"
 msgstr "Indeks"
 
-#: ../src/common/fmapbase.cpp:159
+#: ../src/common/fmapbase.cpp:156
 msgid "Indian (ISO-8859-12)"
 msgstr "Indian (ISO-8859-12)"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "Info"
 msgstr "Info"
 
-#: ../src/common/init.cpp:287
+#: ../src/common/init.cpp:284
 msgid "Initialization failed in post init, aborting."
 msgstr "Inisialisasi gagal saat init, membatalkan."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:54
+#: ../src/common/accelcmn.cpp:51
 msgid "Ins"
 msgstr "Ins"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextsymboldlg.cpp:472 ../src/common/accelcmn.cpp:53
+#: ../src/common/accelcmn.cpp:50 ../src/richtext/richtextsymboldlg.cpp:469
 msgid "Insert"
 msgstr "Insert"
 
-#: ../src/richtext/richtextbuffer.cpp:8067
+#: ../src/richtext/richtextbuffer.cpp:8063
 msgid "Insert Field"
 msgstr "Sisipkan Kolom"
 
-#: ../src/richtext/richtextbuffer.cpp:7978 ../src/richtext/richtextbuffer.cpp:8936
+#: ../src/richtext/richtextbuffer.cpp:7974
+#: ../src/richtext/richtextbuffer.cpp:8934
 msgid "Insert Image"
 msgstr "Sisipkan Citra"
 
-#: ../src/richtext/richtextbuffer.cpp:8025
+#: ../src/richtext/richtextbuffer.cpp:8021
 msgid "Insert Object"
 msgstr "Sisipkan Obyek"
 
-#: ../src/richtext/richtextctrl.cpp:1286 ../src/richtext/richtextctrl.cpp:1494
-#: ../src/richtext/richtextbuffer.cpp:7822 ../src/richtext/richtextbuffer.cpp:7852
-#: ../src/richtext/richtextbuffer.cpp:7894
+#: ../src/richtext/richtextbuffer.cpp:7818
+#: ../src/richtext/richtextbuffer.cpp:7848
+#: ../src/richtext/richtextbuffer.cpp:7890
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
 msgid "Insert Text"
 msgstr "Sisipkan Teks"
 
@@ -4197,16 +4377,11 @@ msgstr "Sisipkan pemisah halaman sebelum paragraf."
 msgid "Inset"
 msgstr "Inset"
 
-#: ../src/gtk/app.cpp:425
-#, c-format
-msgid "Invalid GTK+ command line option, use \"%s --help\""
-msgstr "Opsi perintah GTK+ salah, gunakan \"%s --help\""
-
-#: ../src/common/imagtiff.cpp:311
+#: ../src/common/imagtiff.cpp:308
 msgid "Invalid TIFF image index."
 msgstr "Indeks citra TIFF tidak sah."
 
-#: ../src/common/appcmn.cpp:273
+#: ../src/common/appcmn.cpp:294
 #, c-format
 msgid "Invalid display mode specification '%s'."
 msgstr "Spesifikasi mode tampilan %s tidak sah."
@@ -4216,246 +4391,250 @@ msgstr "Spesifikasi mode tampilan %s tidak sah."
 msgid "Invalid geometry specification '%s'"
 msgstr "Spesifikasi geometri '%s' tidak sah"
 
-#: ../src/unix/fswatcher_inotify.cpp:323
+#: ../src/unix/fswatcher_inotify.cpp:320
 #, c-format
 msgid "Invalid inotify event for \"%s\""
 msgstr "Event inotify “%s” tidak sah"
 
-#: ../src/unix/snglinst.cpp:312
+#: ../src/unix/snglinst.cpp:309
 #, c-format
 msgid "Invalid lock file '%s'."
 msgstr "Berkas lock '%s' tidak sah."
 
-#: ../src/common/translation.cpp:1125
+#: ../src/common/translation.cpp:1167
 msgid "Invalid message catalog."
 msgstr "Kesalahan katalog pesan."
 
-#: ../src/common/xtistrm.cpp:405 ../src/common/xtistrm.cpp:420
+#: ../src/common/xtistrm.cpp:402 ../src/common/xtistrm.cpp:417
 msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
 msgstr "Tidak valid atau Null Object ID disampaikan ke HasObjectClassInfo"
 
-#: ../src/common/xtistrm.cpp:435
+#: ../src/common/xtistrm.cpp:432
 msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
 msgstr "Tidak valid atau Null Object ID disampaikan ke HasObjectClassInfo"
 
-#: ../src/common/regex.cpp:310
+#: ../src/common/regex.cpp:307
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Regular expression tidak sah '%s': %s"
 
-#: ../src/common/config.cpp:226
+#: ../src/common/config.cpp:222
 #, c-format
 msgid "Invalid value %ld for a boolean key \"%s\" in config file."
 msgstr "Kesalahan nilai %ld untuk kunci boolean \"%s\" di berkas config."
 
-#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:351
-#: ../src/osx/carbon/fontdlg.cpp:361 ../src/common/stockitem.cpp:168
+#: ../src/osx/carbon/fontdlg.cpp:358 ../src/common/stockitem.cpp:165
+#: ../src/generic/fontdlgg.cpp:325 ../src/richtext/richtextfontpage.cpp:351
 msgid "Italic"
 msgstr "Miring"
 
-#: ../src/common/paper.cpp:130
+#: ../src/common/paper.cpp:127
 msgid "Italy Envelope, 110 x 230 mm"
 msgstr "Amplop Italia,  110 x 230 mm"
 
-#: ../src/common/imagjpeg.cpp:270
+#: ../src/common/imagjpeg.cpp:257
 msgid "JPEG: Couldn't load - file is probably corrupted."
 msgstr "JPEG: Gagal memuat - berkas mungkin rusak."
 
-#: ../src/common/imagjpeg.cpp:449
+#: ../src/common/imagjpeg.cpp:436
 msgid "JPEG: Couldn't save image."
 msgstr "JPEG: Gagal menyimpan citra."
 
-#: ../src/common/paper.cpp:163
+#: ../src/common/paper.cpp:160
 msgid "Japanese Double Postcard 200 x 148 mm"
 msgstr "Japanese Double Postcard 200 x 148 mm"
 
-#: ../src/common/paper.cpp:167
+#: ../src/common/paper.cpp:164
 msgid "Japanese Envelope Chou #3"
 msgstr "Japanese Envelope Chou #3"
 
-#: ../src/common/paper.cpp:180
+#: ../src/common/paper.cpp:177
 msgid "Japanese Envelope Chou #3 Rotated"
 msgstr "Japanese Envelope Chou #3 Rotated"
 
-#: ../src/common/paper.cpp:168
+#: ../src/common/paper.cpp:165
 msgid "Japanese Envelope Chou #4"
 msgstr "Japanese Envelope Chou #4"
 
-#: ../src/common/paper.cpp:181
+#: ../src/common/paper.cpp:178
 msgid "Japanese Envelope Chou #4 Rotated"
 msgstr "Japanese Envelope Chou #4 Rotated"
 
-#: ../src/common/paper.cpp:165
+#: ../src/common/paper.cpp:162
 msgid "Japanese Envelope Kaku #2"
 msgstr "Japanese Envelope Kaku #2"
 
-#: ../src/common/paper.cpp:178
+#: ../src/common/paper.cpp:175
 msgid "Japanese Envelope Kaku #2 Rotated"
 msgstr "Japanese Envelope Kaku #2 Rotated"
 
-#: ../src/common/paper.cpp:166
+#: ../src/common/paper.cpp:163
 msgid "Japanese Envelope Kaku #3"
 msgstr "Japanese Envelope Kaku #3"
 
-#: ../src/common/paper.cpp:179
+#: ../src/common/paper.cpp:176
 msgid "Japanese Envelope Kaku #3 Rotated"
 msgstr "Japanese Envelope Kaku #3 Rotated"
 
-#: ../src/common/paper.cpp:185
+#: ../src/common/paper.cpp:182
 msgid "Japanese Envelope You #4"
 msgstr "Japanese Envelope You #4"
 
-#: ../src/common/paper.cpp:186
+#: ../src/common/paper.cpp:183
 msgid "Japanese Envelope You #4 Rotated"
 msgstr "Japanese Envelope You #4 Rotated"
 
-#: ../src/common/paper.cpp:138
+#: ../src/common/paper.cpp:135
 msgid "Japanese Postcard 100 x 148 mm"
 msgstr "Japanese Postcard 100 x 148 mm"
 
-#: ../src/common/paper.cpp:175
+#: ../src/common/paper.cpp:172
 msgid "Japanese Postcard Rotated 148 x 100 mm"
 msgstr "Japanese Postcard Rotated 148 x 100 mm"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "Jump to"
 msgstr "Lompat ke"
 
-#: ../src/common/stockitem.cpp:171
+#: ../src/common/stockitem.cpp:168
 msgid "Justified"
 msgstr "Rata kanan kiri"
 
-#: ../src/richtext/richtextindentspage.cpp:155
-#: ../src/richtext/richtextindentspage.cpp:157
 #: ../src/richtext/richtextliststylepage.cpp:344
 #: ../src/richtext/richtextliststylepage.cpp:346
+#: ../src/richtext/richtextindentspage.cpp:155
+#: ../src/richtext/richtextindentspage.cpp:157
 msgid "Justify text left and right."
 msgstr "Ratakan teks kanan dan kiri."
 
-#: ../src/common/fmapbase.cpp:163
+#: ../src/common/fmapbase.cpp:160
 msgid "KOI8-R"
 msgstr "KOI8-R"
 
-#: ../src/common/fmapbase.cpp:164
+#: ../src/common/fmapbase.cpp:161
 msgid "KOI8-U"
 msgstr "KOI8-U"
 
-#: ../src/common/accelcmn.cpp:265 ../src/common/accelcmn.cpp:347
+#: ../src/common/accelcmn.cpp:279 ../src/common/accelcmn.cpp:364
 msgid "KP_"
 msgstr "KP_"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "KP_Add"
 msgstr "KP_Add"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "KP_Begin"
 msgstr "KP_Begin"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "KP_Decimal"
 msgstr "KP_Decimal"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 msgid "KP_Delete"
 msgstr "KP_Delete"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "KP_Divide"
 msgstr "KP_Divide"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 msgid "KP_Down"
 msgstr "KP_Down"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "KP_End"
 msgstr "KP_End"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "KP_Enter"
 msgstr "KP_Enter"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "KP_Equal"
 msgstr "KP_Equal"
 
+#: ../src/common/accelcmn.cpp:276 ../src/common/accelcmn.cpp:361
+msgid "KP_F"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 msgid "KP_Home"
 msgstr "KP_Home"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 msgid "KP_Insert"
 msgstr "KP_Insert"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "KP_Left"
 msgstr "KP_Left"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "KP_Multiply"
 msgstr "KP_Multiply"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:99
+#: ../src/common/accelcmn.cpp:97
 msgid "KP_Next"
 msgstr "KP_Next"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "KP_PageDown"
 msgstr "KP_PageDown"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "KP_PageUp"
 msgstr "KP_PageUp"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:98
+#: ../src/common/accelcmn.cpp:96
 msgid "KP_Prior"
 msgstr "KP_Prior"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 msgid "KP_Right"
 msgstr "KP_Right"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "KP_Separator"
 msgstr "KP_Separator"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "KP_Space"
 msgstr "KP_Space"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "KP_Subtract"
 msgstr "KP_Subtract"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "KP_Tab"
 msgstr "KP_Tab"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "KP_Up"
 msgstr "KP_Up"
 
@@ -4463,158 +4642,177 @@ msgstr "KP_Up"
 msgid "L&ine spacing:"
 msgstr "Spasi b&aris:"
 
-#: ../src/generic/prntdlgg.cpp:613 ../src/generic/prntdlgg.cpp:868
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "galat kompresi"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "galat dekompresi"
+
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:861
 msgid "Landscape"
 msgstr "Memanjang"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "Last"
 msgstr "Terakhir"
 
-#: ../src/common/prntbase.cpp:1572
+#: ../src/common/prntbase.cpp:1597
 msgid "Last page"
 msgstr "Halaman terakhir"
 
-#: ../src/common/log.cpp:305
+#: ../src/common/log.cpp:324
 #, c-format
 msgid "Last repeated message (\"%s\", %u time) wasn't output"
 msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
 msgstr[0] "Pesan terakhir (\"%s\", %u waktu) bukan merupakan hasil"
 
-#: ../src/common/paper.cpp:103
+#: ../src/common/paper.cpp:100
 msgid "Ledger, 17 x 11 in"
 msgstr "Ledger, 17 x 11 in"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6146 ../src/richtext/richtextliststylepage.cpp:249
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:58 ../src/generic/datavgen.cpp:6951
+#: ../src/richtext/richtextsizepage.cpp:249
+#: ../src/richtext/richtextliststylepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:252
 #: ../src/richtext/richtextliststylepage.cpp:253
 #: ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
-#: ../src/richtext/richtextsizepage.cpp:249 ../src/common/accelcmn.cpp:61
 msgid "Left"
 msgstr "Kiri"
 
-#: ../src/richtext/richtextindentspage.cpp:204
 #: ../src/richtext/richtextliststylepage.cpp:390
+#: ../src/richtext/richtextindentspage.cpp:204
 msgid "Left (&first line):"
 msgstr "Kiri (&baris pertama):"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1761
+#: ../src/propgrid/advprops.cpp:1662
 msgid "Left Button"
 msgstr "Tombol Kiri"
 
-#: ../src/generic/prntdlgg.cpp:880
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Left margin (mm):"
 msgstr "Batas kiri (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:141
-#: ../src/richtext/richtextindentspage.cpp:143
 #: ../src/richtext/richtextliststylepage.cpp:330
 #: ../src/richtext/richtextliststylepage.cpp:332
+#: ../src/richtext/richtextindentspage.cpp:141
+#: ../src/richtext/richtextindentspage.cpp:143
 msgid "Left-align text."
 msgstr "Sejajarkan teks ke kiri."
 
-#: ../src/common/paper.cpp:144
+#: ../src/common/paper.cpp:141
 msgid "Legal Extra 9 1/2 x 15 in"
 msgstr "Legal Extra 9 1/2 x 15 in"
 
-#: ../src/common/paper.cpp:96
+#: ../src/common/paper.cpp:93
 msgid "Legal, 8 1/2 x 14 in"
 msgstr "Legal, 8 1/2 x 14 inci"
 
-#: ../src/common/paper.cpp:143
+#: ../src/common/paper.cpp:140
 msgid "Letter Extra 9 1/2 x 12 in"
 msgstr "Letter Extra 9 1/2 x 12 in"
 
-#: ../src/common/paper.cpp:149
+#: ../src/common/paper.cpp:146
 msgid "Letter Extra Transverse 9.275 x 12 in"
 msgstr "Letter Extra Transverse 9.275 x 12 in"
 
-#: ../src/common/paper.cpp:152
+#: ../src/common/paper.cpp:149
 msgid "Letter Plus 8 1/2 x 12.69 in"
 msgstr "Letter Plus 8 1/2 x 12.69 in"
 
-#: ../src/common/paper.cpp:169
+#: ../src/common/paper.cpp:166
 msgid "Letter Rotated 11 x 8 1/2 in"
 msgstr "Letter Rotated 11 x 8 1/2 in"
 
-#: ../src/common/paper.cpp:101
+#: ../src/common/paper.cpp:98
 msgid "Letter Small, 8 1/2 x 11 in"
 msgstr "Letter Kecil, 8 1/2 x 11 inci"
 
-#: ../src/common/paper.cpp:147
+#: ../src/common/paper.cpp:144
 msgid "Letter Transverse 8 1/2 x 11 in"
 msgstr "Letter Transverse 8 1/2 x 11 in"
 
-#: ../src/common/paper.cpp:95
+#: ../src/common/paper.cpp:92
 msgid "Letter, 8 1/2 x 11 in"
 msgstr "Letter, 8 1/2 x 11 inci"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "License"
 msgstr "Lisensi"
 
-#: ../src/generic/fontdlgg.cpp:332
+#: ../src/generic/fontdlgg.cpp:328
 msgid "Light"
 msgstr "Ringan"
 
-#: ../src/propgrid/advprops.cpp:1608
+#: ../src/propgrid/advprops.cpp:1514
 msgid "Lime"
 msgstr "Kunig Kehijauan"
 
-#: ../src/generic/helpext.cpp:294
+#: ../src/generic/helpext.cpp:292
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
-msgstr "Baris %lu dari berkas peta \"%s\" mempunyai sintaks yang salah, dilewati."
+msgstr ""
+"Baris %lu dari berkas peta \"%s\" mempunyai sintaks yang salah, dilewati."
 
 #: ../src/richtext/richtextliststylepage.cpp:444
 msgid "Line spacing:"
 msgstr "Spasi baris:"
 
-#: ../src/html/chm.cpp:838
+#: ../src/html/chm.cpp:829
 msgid "Link contained '//', converted to absolute link."
 msgstr "Tautan berisi '//', diubah ke tautan absolut."
 
-#: ../src/richtext/richtextformatdlg.cpp:364
+#: ../src/richtext/richtextformatdlg.cpp:357
 msgid "List Style"
 msgstr "Daftar Gaya"
 
-#: ../src/richtext/richtextstyles.cpp:1064
+#: ../src/richtext/richtextstyles.cpp:1061
 msgid "List styles"
 msgstr "Daftar gaya"
 
-#: ../src/richtext/richtextfontpage.cpp:197 ../src/richtext/richtextfontpage.cpp:199
+#: ../src/richtext/richtextfontpage.cpp:197
+#: ../src/richtext/richtextfontpage.cpp:199
 msgid "Lists font sizes in points."
 msgstr "Daftar ukuran font dalam point."
 
-#: ../src/richtext/richtextfontpage.cpp:190 ../src/richtext/richtextfontpage.cpp:192
+#: ../src/richtext/richtextfontpage.cpp:190
+#: ../src/richtext/richtextfontpage.cpp:192
 msgid "Lists the available fonts."
 msgstr "Daftar font yang tersedia."
 
-#: ../src/common/fldlgcmn.cpp:340
+#: ../src/common/fldlgcmn.cpp:337
 #, c-format
 msgid "Load %s file"
 msgstr "Memuat berkas %s"
 
-#: ../src/html/htmlwin.cpp:597
+#: ../src/html/htmlwin.cpp:600
 msgid "Loading : "
 msgstr "Memuat: "
 
-#: ../src/unix/snglinst.cpp:246
+#: ../src/unix/snglinst.cpp:243
 #, c-format
 msgid "Lock file '%s' has incorrect owner."
 msgstr "Kesalahan pemilik pada berkas kunci ‘%s’."
 
-#: ../src/unix/snglinst.cpp:251
+#: ../src/unix/snglinst.cpp:248
 #, c-format
 msgid "Lock file '%s' has incorrect permissions."
 msgstr "Kesalahan hak akses pada berkas kunci '%s'."
 
-#: ../src/generic/logg.cpp:576
+#: ../src/generic/logg.cpp:573
 #, c-format
 msgid "Log saved to the file '%s'."
 msgstr "Log disimpan ke berkas '%s'."
@@ -4629,201 +4827,201 @@ msgstr "Huruf kecil"
 msgid "Lower case roman numerals"
 msgstr "Huruf kecil angka romawi"
 
-#: ../src/gtk/mdi.cpp:422 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk1/mdi.cpp:431 ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "MDI child"
 
-#: ../src/msw/helpchm.cpp:56
+#: ../src/msw/helpchm.cpp:53
 msgid ""
-"MS HTML Help functions are unavailable because the MS HTML Help library is not "
-"installed on this machine. Please install it."
+"MS HTML Help functions are unavailable because the MS HTML Help library is "
+"not installed on this machine. Please install it."
 msgstr ""
-"Fungsi MS HTML Help tidak tersedia karena pustaka MS HTML Help tidak terinstal di "
-"mesin ini. Silahkan instal."
+"Fungsi MS HTML Help tidak tersedia karena pustaka MS HTML Help tidak "
+"terinstal di mesin ini. Silahkan instal."
 
-#: ../src/univ/themes/win32.cpp:3754
+#: ../src/univ/themes/win32.cpp:3751
 msgid "Ma&ximize"
 msgstr "Ma&ksimalkan"
 
-#: ../src/common/fmapbase.cpp:203
+#: ../src/common/fmapbase.cpp:200
 msgid "MacArabic"
 msgstr "MacArabic"
 
-#: ../src/common/fmapbase.cpp:222
+#: ../src/common/fmapbase.cpp:219
 msgid "MacArmenian"
 msgstr "MacArmenian"
 
-#: ../src/common/fmapbase.cpp:211
+#: ../src/common/fmapbase.cpp:208
 msgid "MacBengali"
 msgstr "MacBengali"
 
-#: ../src/common/fmapbase.cpp:217
+#: ../src/common/fmapbase.cpp:214
 msgid "MacBurmese"
 msgstr "MacBurmese"
 
-#: ../src/common/fmapbase.cpp:236
+#: ../src/common/fmapbase.cpp:233
 msgid "MacCeltic"
 msgstr "MacCeltic"
 
-#: ../src/common/fmapbase.cpp:227
+#: ../src/common/fmapbase.cpp:224
 msgid "MacCentralEurRoman"
 msgstr "MacCentralEurRoman"
 
-#: ../src/common/fmapbase.cpp:223
+#: ../src/common/fmapbase.cpp:220
 msgid "MacChineseSimp"
 msgstr "MacChineseSimp"
 
-#: ../src/common/fmapbase.cpp:201
+#: ../src/common/fmapbase.cpp:198
 msgid "MacChineseTrad"
 msgstr "MacChineseTrad"
 
-#: ../src/common/fmapbase.cpp:233
+#: ../src/common/fmapbase.cpp:230
 msgid "MacCroatian"
 msgstr "MacCroatian"
 
-#: ../src/common/fmapbase.cpp:206
+#: ../src/common/fmapbase.cpp:203
 msgid "MacCyrillic"
 msgstr "MacCyrillic"
 
-#: ../src/common/fmapbase.cpp:207
+#: ../src/common/fmapbase.cpp:204
 msgid "MacDevanagari"
 msgstr "MacDevanagari"
 
-#: ../src/common/fmapbase.cpp:231
+#: ../src/common/fmapbase.cpp:228
 msgid "MacDingbats"
 msgstr "MacDingbats"
 
-#: ../src/common/fmapbase.cpp:226
+#: ../src/common/fmapbase.cpp:223
 msgid "MacEthiopic"
 msgstr "MacEthiopic"
 
-#: ../src/common/fmapbase.cpp:229
+#: ../src/common/fmapbase.cpp:226
 msgid "MacExtArabic"
 msgstr "MacExtArabic"
 
-#: ../src/common/fmapbase.cpp:237
+#: ../src/common/fmapbase.cpp:234
 msgid "MacGaelic"
 msgstr "MacGaelic"
 
-#: ../src/common/fmapbase.cpp:221
+#: ../src/common/fmapbase.cpp:218
 msgid "MacGeorgian"
 msgstr "MacGeorgian"
 
-#: ../src/common/fmapbase.cpp:205
+#: ../src/common/fmapbase.cpp:202
 msgid "MacGreek"
 msgstr "MacGreek"
 
-#: ../src/common/fmapbase.cpp:209
+#: ../src/common/fmapbase.cpp:206
 msgid "MacGujarati"
 msgstr "MacGujarati"
 
-#: ../src/common/fmapbase.cpp:208
+#: ../src/common/fmapbase.cpp:205
 msgid "MacGurmukhi"
 msgstr "MacGurmukhi"
 
-#: ../src/common/fmapbase.cpp:204
+#: ../src/common/fmapbase.cpp:201
 msgid "MacHebrew"
 msgstr "MacHebrew"
 
-#: ../src/common/fmapbase.cpp:234
+#: ../src/common/fmapbase.cpp:231
 msgid "MacIcelandic"
 msgstr "MacIcelandic"
 
-#: ../src/common/fmapbase.cpp:200
+#: ../src/common/fmapbase.cpp:197
 msgid "MacJapanese"
 msgstr "MacJapanese"
 
-#: ../src/common/fmapbase.cpp:214
+#: ../src/common/fmapbase.cpp:211
 msgid "MacKannada"
 msgstr "MacKannada"
 
-#: ../src/common/fmapbase.cpp:238
+#: ../src/common/fmapbase.cpp:235
 msgid "MacKeyboardGlyphs"
 msgstr "MacKeyboardGlyphs"
 
-#: ../src/common/fmapbase.cpp:218
+#: ../src/common/fmapbase.cpp:215
 msgid "MacKhmer"
 msgstr "MacKhmer"
 
-#: ../src/common/fmapbase.cpp:202
+#: ../src/common/fmapbase.cpp:199
 msgid "MacKorean"
 msgstr "MacKorean"
 
-#: ../src/common/fmapbase.cpp:220
+#: ../src/common/fmapbase.cpp:217
 msgid "MacLaotian"
 msgstr "MacLaotian"
 
-#: ../src/common/fmapbase.cpp:215
+#: ../src/common/fmapbase.cpp:212
 msgid "MacMalayalam"
 msgstr "MacMalayalam"
 
-#: ../src/common/fmapbase.cpp:225
+#: ../src/common/fmapbase.cpp:222
 msgid "MacMongolian"
 msgstr "MacMongolian"
 
-#: ../src/common/fmapbase.cpp:210
+#: ../src/common/fmapbase.cpp:207
 msgid "MacOriya"
 msgstr "MacOriya"
 
-#: ../src/common/fmapbase.cpp:199
+#: ../src/common/fmapbase.cpp:196
 msgid "MacRoman"
 msgstr "MacRoman"
 
-#: ../src/common/fmapbase.cpp:235
+#: ../src/common/fmapbase.cpp:232
 msgid "MacRomanian"
 msgstr "MacRomanian"
 
-#: ../src/common/fmapbase.cpp:216
+#: ../src/common/fmapbase.cpp:213
 msgid "MacSinhalese"
 msgstr "MacSinhalese"
 
-#: ../src/common/fmapbase.cpp:230
+#: ../src/common/fmapbase.cpp:227
 msgid "MacSymbol"
 msgstr "MacSymbol"
 
-#: ../src/common/fmapbase.cpp:212
+#: ../src/common/fmapbase.cpp:209
 msgid "MacTamil"
 msgstr "MacTamil"
 
-#: ../src/common/fmapbase.cpp:213
+#: ../src/common/fmapbase.cpp:210
 msgid "MacTelugu"
 msgstr "MacTelugu"
 
-#: ../src/common/fmapbase.cpp:219
+#: ../src/common/fmapbase.cpp:216
 msgid "MacThai"
 msgstr "MacThai"
 
-#: ../src/common/fmapbase.cpp:224
+#: ../src/common/fmapbase.cpp:221
 msgid "MacTibetan"
 msgstr "MacTibetan"
 
-#: ../src/common/fmapbase.cpp:232
+#: ../src/common/fmapbase.cpp:229
 msgid "MacTurkish"
 msgstr "MacTurkish"
 
-#: ../src/common/fmapbase.cpp:228
+#: ../src/common/fmapbase.cpp:225
 msgid "MacVietnamese"
 msgstr "MacVietnamese"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1762
+#: ../src/propgrid/advprops.cpp:1663
 msgid "Magnifier"
 msgstr "Kaca Pembesar"
 
-#: ../src/propgrid/advprops.cpp:2143
+#: ../src/propgrid/advprops.cpp:2050
 msgid "Make a selection:"
 msgstr "Buat seleksi:"
 
-#: ../src/richtext/richtextformatdlg.cpp:374
+#: ../src/richtext/richtextformatdlg.cpp:367
 #: ../src/richtext/richtextmarginspage.cpp:171
 msgid "Margins"
 msgstr "Batas"
 
-#: ../src/propgrid/advprops.cpp:1595
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Maroon"
 msgstr "Ungu Kemerahan"
 
-#: ../src/generic/fdrepdlg.cpp:147
+#: ../src/generic/fdrepdlg.cpp:144
 msgid "Match case"
 msgstr "Sesuaikan besar kecil huruf"
 
@@ -4835,40 +5033,40 @@ msgstr "Tinggi maksimum:"
 msgid "Max width:"
 msgstr "Lebar maksimum:"
 
-#: ../src/unix/mediactrl.cpp:947
+#: ../src/unix/mediactrl.cpp:972
 #, c-format
 msgid "Media playback error: %s"
 msgstr "Galat media pemutar: %s"
 
-#: ../src/common/fs_mem.cpp:175
+#: ../src/common/fs_mem.cpp:170
 #, c-format
 msgid "Memory VFS already contains file '%s'!"
 msgstr "Memory VFS telah terisi berkas '%s'!"
 
 #. TRANSLATORS: Name of keyboard key
 #. TRANSLATORS: Keyword of system colour
-#: ../src/common/accelcmn.cpp:73 ../src/propgrid/advprops.cpp:889
+#: ../src/common/accelcmn.cpp:70 ../src/propgrid/advprops.cpp:790
 msgid "Menu"
 msgstr "Menu"
 
-#: ../src/common/msgout.cpp:124
+#: ../src/common/msgout.cpp:121
 msgid "Message"
 msgstr "Pesan"
 
-#: ../src/univ/themes/metal.cpp:168
+#: ../src/univ/themes/metal.cpp:165
 msgid "Metal theme"
 msgstr "Tema Metal"
 
-#: ../src/msw/ole/automtn.cpp:652
+#: ../src/msw/ole/automtn.cpp:643
 msgid "Method or property not found."
 msgstr "Metode atau properti tidak ditemukan."
 
-#: ../src/univ/themes/win32.cpp:3752
+#: ../src/univ/themes/win32.cpp:3749
 msgid "Mi&nimize"
 msgstr "Mi%nimalkan"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1763
+#: ../src/propgrid/advprops.cpp:1664
 msgid "Middle Button"
 msgstr "Tombol Kanan"
 
@@ -4880,145 +5078,164 @@ msgstr "Tinggi minimal:"
 msgid "Min width:"
 msgstr "Lebar minimal:"
 
-#: ../src/msw/ole/automtn.cpp:668
+#: ../src/osx/cocoa/menu.mm:281
+#, fuzzy
+msgid "Minimize"
+msgstr "Mi%nimalkan"
+
+#: ../src/msw/ole/automtn.cpp:659
 msgid "Missing a required parameter."
 msgstr "Berikan parameter yang dibutuhkan."
 
-#: ../src/generic/fontdlgg.cpp:324
+#: ../src/generic/fontdlgg.cpp:320
 msgid "Modern"
 msgstr "Modern"
 
-#: ../src/generic/filectrlg.cpp:427
+#: ../src/generic/filectrlg.cpp:423
 msgid "Modified"
 msgstr "Diubah"
 
-#: ../src/common/module.cpp:133
+#: ../src/common/module.cpp:130
 #, c-format
 msgid "Module \"%s\" initialization failed"
 msgstr "Modul \"%s\" gagal terpasang"
 
-#: ../src/common/paper.cpp:131
+#: ../src/common/paper.cpp:128
 msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
 msgstr "Amplop Monarch, 3 7/8 x 7 1/2 inci"
 
-#: ../src/msw/fswatcher.cpp:143
+#: ../src/msw/fswatcher.cpp:140
 msgid "Monitoring individual files for changes is not supported currently."
 msgstr "Saat ini pemantauan perubahan terhadap berkas tidak didukung."
 
-#: ../src/generic/editlbox.cpp:172
+#: ../src/generic/editlbox.cpp:160
 msgid "Move down"
 msgstr "Gerakkan ke bawah"
 
-#: ../src/generic/editlbox.cpp:171
+#: ../src/generic/editlbox.cpp:155
 msgid "Move up"
 msgstr "Gerakkan ke atas"
 
-#: ../src/richtext/richtextsizepage.cpp:682 ../src/richtext/richtextsizepage.cpp:684
+#: ../src/richtext/richtextsizepage.cpp:682
+#: ../src/richtext/richtextsizepage.cpp:684
 msgid "Moves the object to the next paragraph."
 msgstr "Pindahkan obyek ke paragraf selanjutnya."
 
-#: ../src/richtext/richtextsizepage.cpp:676 ../src/richtext/richtextsizepage.cpp:678
+#: ../src/richtext/richtextsizepage.cpp:676
+#: ../src/richtext/richtextsizepage.cpp:678
 msgid "Moves the object to the previous paragraph."
 msgstr "Pindahkan obyek ke paragraf sebelumnya."
 
-#: ../src/richtext/richtextbuffer.cpp:9966
+#: ../src/richtext/richtextbuffer.cpp:9963
 msgid "Multiple Cell Properties"
 msgstr "Properti Multi Sel"
 
-#: ../src/generic/filectrlg.cpp:424
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:82
+#, fuzzy
+msgid "Multiply"
+msgstr "KP_Multiply"
+
+#: ../src/generic/filectrlg.cpp:420
 msgid "Name"
 msgstr "Nama"
 
-#: ../src/propgrid/advprops.cpp:1596
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Navy"
 msgstr "Biru Tua"
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "Network"
 msgstr "Jaringan"
 
-#: ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173
 msgid "New"
 msgstr "Baru"
 
-#: ../src/richtext/richtextstyledlg.cpp:243
+#: ../src/richtext/richtextstyledlg.cpp:239
 msgid "New &Box Style..."
 msgstr "Gaya &Box Baru..."
 
-#: ../src/richtext/richtextstyledlg.cpp:225
+#: ../src/richtext/richtextstyledlg.cpp:221
 msgid "New &Character Style..."
 msgstr "Gaya &Karakter Baru..."
 
-#: ../src/richtext/richtextstyledlg.cpp:237
+#: ../src/richtext/richtextstyledlg.cpp:233
 msgid "New &List Style..."
 msgstr "Gaya &Daftar Baru..."
 
-#: ../src/richtext/richtextstyledlg.cpp:231
+#: ../src/richtext/richtextstyledlg.cpp:227
 msgid "New &Paragraph Style..."
 msgstr "Gaya &Paragraf Baru..."
 
-#: ../src/richtext/richtextstyledlg.cpp:606 ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:654 ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:820 ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:893 ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:934 ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:602
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:650
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:816
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:889
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:930
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "New Style"
 msgstr "Gaya Baru"
 
-#: ../src/generic/editlbox.cpp:169
+#: ../src/generic/editlbox.cpp:139
 msgid "New item"
 msgstr "Butir baru"
 
-#: ../src/generic/dirdlgg.cpp:297 ../src/generic/dirdlgg.cpp:307
-#: ../src/generic/filectrlg.cpp:618 ../src/generic/filectrlg.cpp:627
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+#: ../src/generic/dirdlgg.cpp:294 ../src/generic/dirdlgg.cpp:304
 msgid "NewName"
 msgstr "NamaBaru"
 
-#: ../src/common/prntbase.cpp:1567 ../src/html/helpwnd.cpp:665
+#: ../src/common/prntbase.cpp:1592 ../src/html/helpwnd.cpp:663
 msgid "Next page"
 msgstr "Halaman berikut"
 
-#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:177
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:174
 #: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Tidak"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1764
+#: ../src/propgrid/advprops.cpp:1665
 msgid "No Entry"
 msgstr "Dilarang Masuk"
 
-#: ../src/generic/animateg.cpp:150
+#: ../src/generic/animateg.cpp:133
 #, c-format
 msgid "No animation handler for type %ld defined."
 msgstr "Tidak ada handler animasi ntuk tipe %ld yang definisikan."
 
-#: ../src/dfb/bitmap.cpp:642 ../src/dfb/bitmap.cpp:676
+#: ../src/dfb/bitmap.cpp:639 ../src/dfb/bitmap.cpp:673
 #, c-format
 msgid "No bitmap handler for type %d defined."
 msgstr "Tidak ada handler bitmap untuk tipe %d yang definisikan."
 
-#: ../src/common/utilscmn.cpp:1077
+#: ../src/common/utilscmn.cpp:1095
 msgid "No default application configured for HTML files."
 msgstr "Aplikasi standar untuk membuka berkas HTML tidak tersedia."
 
-#: ../src/generic/helpext.cpp:445
+#: ../src/generic/helpext.cpp:443
 msgid "No entries found."
 msgstr "Tidak ada entri yang ditemukan."
 
-#: ../src/common/fontmap.cpp:421
+#: ../src/common/fontmap.cpp:418
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found,\n"
 "but an alternative encoding '%s' is available.\n"
-"Do you want to use this encoding (otherwise you will have to choose another one)?"
+"Do you want to use this encoding (otherwise you will have to choose another "
+"one)?"
 msgstr ""
 "Tidak ditemukan font untuk menampilkan teks dalam pengkodean ‘%s’,\n"
 "tetapi alternatif pengkodean '%s' tersedia.\n"
 "Apakah anda ingin menggunakan pengkodean ini (jika tidak anda harus memilih "
 "lainnya)?"
 
-#: ../src/common/fontmap.cpp:426
+#: ../src/common/fontmap.cpp:423
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found.\n"
@@ -5029,200 +5246,201 @@ msgstr ""
 "Apakah anda mau memilih font untuk pengkodean ini\n"
 "(jika tidak teks dalam pengkodean tidak akan tampil secara benar)?"
 
-#: ../src/generic/animateg.cpp:142
+#: ../src/generic/animateg.cpp:125
 msgid "No handler found for animation type."
 msgstr "Tidak ditemukan handler untuk tipe animasi tsb."
 
-#: ../src/common/image.cpp:2728
+#: ../src/common/image.cpp:2823
 msgid "No handler found for image type."
 msgstr "Tidak ditemukan handler untuk tipe citra tsb."
 
-#: ../src/common/image.cpp:2736 ../src/common/image.cpp:2848
-#: ../src/common/image.cpp:2901
+#: ../src/common/image.cpp:2831 ../src/common/image.cpp:2954
+#: ../src/common/image.cpp:3020
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "Tidak ada handler citra untuk tipe %d yang didefinisikan."
 
-#: ../src/common/image.cpp:2871 ../src/common/image.cpp:2915
+#: ../src/common/image.cpp:2986 ../src/common/image.cpp:3034
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "Tidak ada handler citra untuk tipe %s yang didefinisikan."
 
-#: ../src/html/helpwnd.cpp:858
+#: ../src/html/helpwnd.cpp:856
 msgid "No matching page found yet"
 msgstr "Tidak ditemukan halaman yang sesuai"
 
-#: ../src/unix/sound.cpp:81
+#: ../src/unix/sound.cpp:78
 msgid "No sound"
 msgstr "Tidak bersuara"
 
-#: ../src/common/image.cpp:2277 ../src/common/image.cpp:2318
+#: ../src/common/image.cpp:2371 ../src/common/image.cpp:2412
 msgid "No unused colour in image being masked."
 msgstr "Tidak tersedia warna pada citra yang di mask."
 
-#: ../src/common/image.cpp:3374
-msgid "No unused colour in image."
-msgstr "Tidak tersedia warna di dalam citra."
-
-#: ../src/generic/helpext.cpp:302
+#: ../src/generic/helpext.cpp:300
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "Tidak ada mapping yang sesuai di berkas ini \"%s\"."
 
+#: ../src/richtext/richtextsizepage.cpp:248
+#: ../src/richtext/richtextsizepage.cpp:252
 #: ../src/richtext/richtextborderspage.cpp:610
-#: ../src/richtext/richtextsizepage.cpp:248 ../src/richtext/richtextsizepage.cpp:252
 msgid "None"
 msgstr "Tidak ada"
 
-#: ../src/common/fmapbase.cpp:157
+#: ../src/common/fmapbase.cpp:154
 msgid "Nordic (ISO-8859-10)"
 msgstr "Nordic (ISO-8859-10)"
 
-#: ../src/generic/fontdlgg.cpp:328 ../src/generic/fontdlgg.cpp:331
+#: ../src/generic/fontdlgg.cpp:324 ../src/generic/fontdlgg.cpp:327
 msgid "Normal"
 msgstr "Normal"
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1261
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Huruf normal<br>dan <u>digarisbawahi</u>. "
 
-#: ../src/html/helpwnd.cpp:1205
+#: ../src/html/helpwnd.cpp:1203
 msgid "Normal font:"
 msgstr "Font normal:"
 
-#: ../src/propgrid/props.cpp:1128
+#: ../src/propgrid/props.cpp:1115
 #, c-format
 msgid "Not %s"
 msgstr "Bukan %s"
 
-#: ../include/wx/filename.h:573 ../include/wx/filename.h:578
-msgid "Not available"
-msgstr "Tidak tersedia"
+#: ../src/common/secretstore.cpp:168
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/webrequest.cpp:605
+msgid "Not enough free disk space for download."
+msgstr ""
 
 #: ../src/richtext/richtextfontpage.cpp:358
 msgid "Not underlined"
 msgstr "Tidak digarisbawahi"
 
-#: ../src/common/paper.cpp:115
+#: ../src/common/paper.cpp:112
 msgid "Note, 8 1/2 x 11 in"
 msgstr "Catatan, 8 1/2 x 11 in"
 
-#: ../src/generic/notifmsgg.cpp:132
+#: ../src/generic/notifmsgg.cpp:129
 msgid "Notice"
 msgstr "Pemberitahuan"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "Num *"
 msgstr "Num *"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "Num +"
 msgstr "Num +"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "Num ,"
 msgstr "Num ,"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "Num -"
 msgstr "Num -"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "Num ."
 msgstr "Num ."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "Num /"
 msgstr "Num /"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "Num ="
 msgstr "Num ="
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "Num Begin"
 msgstr "Num Begin"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 msgid "Num Delete"
 msgstr "Num Delete"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 msgid "Num Down"
 msgstr "Num Down"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "Num End"
 msgstr "Num End"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "Num Enter"
 msgstr "Num Enter"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 msgid "Num Home"
 msgstr "Num Home"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 msgid "Num Insert"
 msgstr "Num Insert"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num Lock"
 msgstr "Num Lock"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "Num Page Down"
 msgstr "Num Page Down"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "Num Page Up"
 msgstr "Num Page Up"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 msgid "Num Right"
 msgstr "Num Right"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "Num Space"
 msgstr "Num Space"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "Num Tab"
 msgstr "Num Tab"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "Num Up"
 msgstr "Num Up"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "Num left"
 msgstr "Num left"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num_lock"
 msgstr "Num_lock"
 
@@ -5231,13 +5449,13 @@ msgstr "Num_lock"
 msgid "Numbered outline"
 msgstr "Ikhtisar bernomor"
 
-#: ../include/wx/msgdlg.h:278 ../src/richtext/richtextstyledlg.cpp:297
-#: ../src/common/stockitem.cpp:178 ../src/msw/msgdlg.cpp:454
-#: ../src/msw/msgdlg.cpp:747 ../src/gtk1/fontdlg.cpp:138
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:175
+#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/msgdlg.cpp:741 ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "OK"
 
-#: ../src/msw/ole/automtn.cpp:692
+#: ../src/msw/ole/automtn.cpp:683
 #, c-format
 msgid "OLE Automation error in %s: %s"
 msgstr "Galat OLE Otomatisasi di %s: %s"
@@ -5246,15 +5464,15 @@ msgstr "Galat OLE Otomatisasi di %s: %s"
 msgid "Object Properties"
 msgstr "Properti Obyek"
 
-#: ../src/msw/ole/automtn.cpp:660
+#: ../src/msw/ole/automtn.cpp:651
 msgid "Object implementation does not support named arguments."
 msgstr "Implementasi obyek tidak mendukung argumen bernama."
 
-#: ../src/common/xtixml.cpp:264
+#: ../src/common/xtixml.cpp:260
 msgid "Objects must have an id attribute"
 msgstr "Obyek harus memiliki atribut id"
 
-#: ../src/propgrid/advprops.cpp:1601
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Olive"
 msgstr "Coklat Muda"
 
@@ -5262,64 +5480,69 @@ msgstr "Coklat Muda"
 msgid "Opaci&ty:"
 msgstr "Opaci&tas:"
 
-#: ../src/generic/colrdlgg.cpp:354
+#: ../src/generic/colrdlgg.cpp:374
 msgid "Opacity:"
 msgstr "Opacitas:"
 
-#: ../src/common/docview.cpp:1773 ../src/common/docview.cpp:1815
+#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
 msgid "Open File"
 msgstr "Buka Berkas"
 
-#: ../src/html/helpwnd.cpp:671 ../src/html/helpwnd.cpp:1554
+#: ../src/html/helpwnd.cpp:669 ../src/html/helpwnd.cpp:1552
 msgid "Open HTML document"
 msgstr "Buka dokumen HTML"
 
-#: ../src/generic/dbgrptg.cpp:163
+#: ../src/common/stockitem.cpp:265
+#, fuzzy
+msgid "Open an existing document"
+msgstr "Buka dokumen HTML"
+
+#: ../src/generic/dbgrptg.cpp:160
 #, c-format
 msgid "Open file \"%s\""
 msgstr "Buka berkas \"%s\""
 
-#: ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176
 msgid "Open..."
 msgstr "Buka..."
 
-#: ../src/unix/glx11.cpp:506 ../src/msw/glcanvas.cpp:592
+#: ../src/msw/glcanvas.cpp:607 ../src/unix/glx11.cpp:513
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr "OpenGL 3.0 atau lebih baru tidak didukung oleh driver OpenGL."
 
-#: ../src/generic/dirctrlg.cpp:599 ../src/generic/dirdlgg.cpp:323
-#: ../src/generic/filectrlg.cpp:642 ../src/generic/filectrlg.cpp:786
+#: ../src/generic/dirctrlg.cpp:565 ../src/generic/filectrlg.cpp:638
+#: ../src/generic/filectrlg.cpp:782 ../src/generic/dirdlgg.cpp:320
 msgid "Operation not permitted."
 msgstr "Operasi tidak diijinkan."
 
-#: ../src/common/cmdline.cpp:900
+#: ../src/common/cmdline.cpp:896
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "Opsi '%s' tidak boleh negatif"
 
-#: ../src/common/cmdline.cpp:1064
+#: ../src/common/cmdline.cpp:1060
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "Pilihan '%s' memerlukan suatu nilai."
 
-#: ../src/common/cmdline.cpp:1147
+#: ../src/common/cmdline.cpp:1143
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Pilihan '%s': '%s' tidak bisa dikonversi ke suatu tanggal."
 
-#: ../src/generic/prntdlgg.cpp:618
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Opsi"
 
-#: ../src/propgrid/advprops.cpp:1606
+#: ../src/propgrid/advprops.cpp:1512
 msgid "Orange"
 msgstr "Jingga"
 
-#: ../src/generic/prntdlgg.cpp:615 ../src/generic/prntdlgg.cpp:869
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:862
 msgid "Orientation"
 msgstr "Orientasi"
 
-#: ../src/common/windowid.cpp:242
+#: ../src/common/windowid.cpp:237
 msgid "Out of window IDs.  Recommend shutting down application."
 msgstr "Kehabisan window ID. Mohon segera matikan aplikasi."
 
@@ -5332,148 +5555,148 @@ msgstr "Outline"
 msgid "Outset"
 msgstr "Outset"
 
-#: ../src/msw/ole/automtn.cpp:656
+#: ../src/msw/ole/automtn.cpp:647
 msgid "Overflow while coercing argument values."
 msgstr "Overflow saat memaksa nilai argumen."
 
-#: ../src/common/imagpcx.cpp:457 ../src/common/imagpcx.cpp:480
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:479
 msgid "PCX: couldn't allocate memory"
 msgstr "PCX: tidak bisa mengalokasikan memori"
 
-#: ../src/common/imagpcx.cpp:456
+#: ../src/common/imagpcx.cpp:455
 msgid "PCX: image format unsupported"
 msgstr "PCX: format citra tidak didukung"
 
-#: ../src/common/imagpcx.cpp:479
+#: ../src/common/imagpcx.cpp:478
 msgid "PCX: invalid image"
 msgstr "PCX: citra tidak sah"
 
-#: ../src/common/imagpcx.cpp:442
+#: ../src/common/imagpcx.cpp:441
 msgid "PCX: this is not a PCX file."
 msgstr "PCX: ini bukan file PCX."
 
-#: ../src/common/imagpcx.cpp:459 ../src/common/imagpcx.cpp:481
+#: ../src/common/imagpcx.cpp:458 ../src/common/imagpcx.cpp:480
 msgid "PCX: unknown error !!!"
 msgstr "PCX: kesalahan tidak diketahui !!!"
 
-#: ../src/common/imagpcx.cpp:458
+#: ../src/common/imagpcx.cpp:457
 msgid "PCX: version number too low"
 msgstr "PCX: nomor versi terlalu rendah"
 
-#: ../src/common/imagpnm.cpp:91
+#: ../src/common/imagpnm.cpp:89
 msgid "PNM: Couldn't allocate memory."
 msgstr "PNM: Gagal mengalokasikan memori."
 
-#: ../src/common/imagpnm.cpp:73
+#: ../src/common/imagpnm.cpp:71
 msgid "PNM: File format is not recognized."
 msgstr "PNM: format file tidak dikenal."
 
-#: ../src/common/imagpnm.cpp:112 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
 #: ../src/common/imagpnm.cpp:156
 msgid "PNM: File seems truncated."
 msgstr "PNM: Kelihatannya file terpotong."
 
-#: ../src/common/paper.cpp:187
+#: ../src/common/paper.cpp:184
 msgid "PRC 16K 146 x 215 mm"
 msgstr "PRC 16K 146 x 215 mm"
 
-#: ../src/common/paper.cpp:200
+#: ../src/common/paper.cpp:197
 msgid "PRC 16K Rotated"
 msgstr "PRC 16K Rotated"
 
-#: ../src/common/paper.cpp:188
+#: ../src/common/paper.cpp:185
 msgid "PRC 32K 97 x 151 mm"
 msgstr "PRC 32K 97 x 151 mm"
 
-#: ../src/common/paper.cpp:201
+#: ../src/common/paper.cpp:198
 msgid "PRC 32K Rotated"
 msgstr "PRC 32K Rotated"
 
-#: ../src/common/paper.cpp:189
+#: ../src/common/paper.cpp:186
 msgid "PRC 32K(Big) 97 x 151 mm"
 msgstr "PRC 32K(Big) 97 x 151 mm"
 
-#: ../src/common/paper.cpp:202
+#: ../src/common/paper.cpp:199
 msgid "PRC 32K(Big) Rotated"
 msgstr "PRC 32K(Big) Rotated"
 
-#: ../src/common/paper.cpp:190
+#: ../src/common/paper.cpp:187
 msgid "PRC Envelope #1 102 x 165 mm"
 msgstr "PRC Envelope #1 102 x 165 mm"
 
-#: ../src/common/paper.cpp:203
+#: ../src/common/paper.cpp:200
 msgid "PRC Envelope #1 Rotated 165 x 102 mm"
 msgstr "PRC Envelope #1 Rotated 165 x 102 mm"
 
-#: ../src/common/paper.cpp:199
+#: ../src/common/paper.cpp:196
 msgid "PRC Envelope #10 324 x 458 mm"
 msgstr "PRC Envelope #10 324 x 458 mm"
 
-#: ../src/common/paper.cpp:212
+#: ../src/common/paper.cpp:209
 msgid "PRC Envelope #10 Rotated 458 x 324 mm"
 msgstr "PRC Envelope #10 Rotated 458 x 324 mm"
 
-#: ../src/common/paper.cpp:191
+#: ../src/common/paper.cpp:188
 msgid "PRC Envelope #2 102 x 176 mm"
 msgstr "PRC Envelope #2 102 x 176 mm"
 
-#: ../src/common/paper.cpp:204
+#: ../src/common/paper.cpp:201
 msgid "PRC Envelope #2 Rotated 176 x 102 mm"
 msgstr "PRC Envelope #2 Rotated 176 x 102 mm"
 
-#: ../src/common/paper.cpp:192
+#: ../src/common/paper.cpp:189
 msgid "PRC Envelope #3 125 x 176 mm"
 msgstr "PRC Envelope #3 125 x 176 mm"
 
-#: ../src/common/paper.cpp:205
+#: ../src/common/paper.cpp:202
 msgid "PRC Envelope #3 Rotated 176 x 125 mm"
 msgstr "PRC Envelope #3 Rotated 176 x 125 mm"
 
-#: ../src/common/paper.cpp:193
+#: ../src/common/paper.cpp:190
 msgid "PRC Envelope #4 110 x 208 mm"
 msgstr "PRC Envelope #4 110 x 208 mm"
 
-#: ../src/common/paper.cpp:206
+#: ../src/common/paper.cpp:203
 msgid "PRC Envelope #4 Rotated 208 x 110 mm"
 msgstr "PRC Envelope #4 Rotated 208 x 110 mm"
 
-#: ../src/common/paper.cpp:194
+#: ../src/common/paper.cpp:191
 msgid "PRC Envelope #5 110 x 220 mm"
 msgstr "PRC Envelope #5 110 x 220 mm"
 
-#: ../src/common/paper.cpp:207
+#: ../src/common/paper.cpp:204
 msgid "PRC Envelope #5 Rotated 220 x 110 mm"
 msgstr "PRC Envelope #5 Rotated 220 x 110 mm"
 
-#: ../src/common/paper.cpp:195
+#: ../src/common/paper.cpp:192
 msgid "PRC Envelope #6 120 x 230 mm"
 msgstr "PRC Envelope #6 120 x 230 mm"
 
-#: ../src/common/paper.cpp:208
+#: ../src/common/paper.cpp:205
 msgid "PRC Envelope #6 Rotated 230 x 120 mm"
 msgstr "PRC Envelope #6 Rotated 230 x 120 mm"
 
-#: ../src/common/paper.cpp:196
+#: ../src/common/paper.cpp:193
 msgid "PRC Envelope #7 160 x 230 mm"
 msgstr "PRC Envelope #7 160 x 230 mm"
 
-#: ../src/common/paper.cpp:209
+#: ../src/common/paper.cpp:206
 msgid "PRC Envelope #7 Rotated 230 x 160 mm"
 msgstr "PRC Envelope #7 Rotated 230 x 160 mm"
 
-#: ../src/common/paper.cpp:197
+#: ../src/common/paper.cpp:194
 msgid "PRC Envelope #8 120 x 309 mm"
 msgstr "PRC Envelope #8 120 x 309 mm"
 
-#: ../src/common/paper.cpp:210
+#: ../src/common/paper.cpp:207
 msgid "PRC Envelope #8 Rotated 309 x 120 mm"
 msgstr "PRC Envelope #8 Rotated 309 x 120 mm"
 
-#: ../src/common/paper.cpp:198
+#: ../src/common/paper.cpp:195
 msgid "PRC Envelope #9 229 x 324 mm"
 msgstr "PRC Envelope #9 229 x 324 mm"
 
-#: ../src/common/paper.cpp:211
+#: ../src/common/paper.cpp:208
 msgid "PRC Envelope #9 Rotated 324 x 229 mm"
 msgstr "PRC Envelope #9 Rotated 324 x 229 mm"
 
@@ -5481,87 +5704,91 @@ msgstr "PRC Envelope #9 Rotated 324 x 229 mm"
 msgid "Padding"
 msgstr "Padding"
 
-#: ../src/common/prntbase.cpp:2074
+#: ../src/common/prntbase.cpp:2096
 #, c-format
 msgid "Page %d"
 msgstr "Halaman %d"
 
-#: ../src/common/prntbase.cpp:2072
+#: ../src/common/prntbase.cpp:2094
 #, c-format
 msgid "Page %d of %d"
 msgstr "Halaman %d dari %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 msgid "Page Down"
 msgstr "Page Down"
 
-#: ../src/gtk/print.cpp:826
+#: ../src/gtk/print.cpp:829
 msgid "Page Setup"
 msgstr "Pengaturan Halaman"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 msgid "Page Up"
 msgstr "Page Up"
 
-#: ../src/generic/prntdlgg.cpp:828 ../src/common/prntbase.cpp:484
+#: ../src/common/prntbase.cpp:479 ../src/generic/prntdlgg.cpp:821
 msgid "Page setup"
 msgstr "Pengaturan halaman"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 msgid "PageDown"
 msgstr "PageDown"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 msgid "PageUp"
 msgstr "PageUp"
 
-#: ../src/generic/prntdlgg.cpp:216
+#: ../src/generic/prntdlgg.cpp:209
 msgid "Pages"
 msgstr "Halaman"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1765
+#: ../src/propgrid/advprops.cpp:1666
 msgid "Paint Brush"
 msgstr "Kuas"
 
-#: ../src/generic/prntdlgg.cpp:602 ../src/generic/prntdlgg.cpp:801
-#: ../src/generic/prntdlgg.cpp:842 ../src/generic/prntdlgg.cpp:855
-#: ../src/generic/prntdlgg.cpp:1052 ../src/generic/prntdlgg.cpp:1057
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:794
+#: ../src/generic/prntdlgg.cpp:835 ../src/generic/prntdlgg.cpp:848
+#: ../src/generic/prntdlgg.cpp:1045 ../src/generic/prntdlgg.cpp:1050
 msgid "Paper size"
 msgstr "Ukuran kertas"
 
-#: ../src/richtext/richtextstyles.cpp:1062
+#: ../src/richtext/richtextstyles.cpp:1059
 msgid "Paragraph styles"
 msgstr "Gaya paragraf"
 
-#: ../src/common/xtistrm.cpp:465
+#: ../src/common/xtistrm.cpp:462
 msgid "Passing a already registered object to SetObject"
 msgstr "Menyampaikan obyek sudah teregister ke SetObject"
 
-#: ../src/common/xtistrm.cpp:476
+#: ../src/common/xtistrm.cpp:473
 msgid "Passing an unknown object to GetObject"
 msgstr "Menyampaikan obyek tidak dikenal ke GetObject"
 
-#: ../src/richtext/richtextctrl.cpp:3513 ../src/common/stockitem.cpp:180
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:177 ../src/richtext/richtextctrl.cpp:3514
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Tempel"
 
-#: ../src/common/stockitem.cpp:262
+#: ../src/common/stockitem.cpp:260
 msgid "Paste selection"
 msgstr "Tempel seleksi"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:74
+#: ../src/common/accelcmn.cpp:71
 msgid "Pause"
 msgstr "Pause"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1766
+#: ../src/propgrid/advprops.cpp:1667
 msgid "Pencil"
 msgstr "Pensil"
 
@@ -5570,21 +5797,21 @@ msgstr "Pensil"
 msgid "Peri&od"
 msgstr "Peri&ode"
 
-#: ../src/generic/filectrlg.cpp:430
+#: ../src/generic/filectrlg.cpp:426
 msgid "Permissions"
 msgstr "Permisi"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:60
+#: ../src/common/accelcmn.cpp:57
 msgid "PgDn"
 msgstr "PgDn"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:59
+#: ../src/common/accelcmn.cpp:56
 msgid "PgUp"
 msgstr "PgUp"
 
-#: ../src/richtext/richtextbuffer.cpp:12868
+#: ../src/richtext/richtextbuffer.cpp:12863
 msgid "Picture Properties"
 msgstr "Properti Citra"
 
@@ -5596,42 +5823,42 @@ msgstr "Pembuatan pipa gagal"
 msgid "Please choose a valid font."
 msgstr "Silahkan pilih font yang sah."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
 msgid "Please choose an existing file."
 msgstr "Silahkan pilih file yang ada."
 
-#: ../src/html/helpwnd.cpp:800
+#: ../src/html/helpwnd.cpp:798
 msgid "Please choose the page to display:"
 msgstr "Silakan pilih lembar yang mau ditampilkan:"
 
-#: ../src/msw/dialup.cpp:764
+#: ../src/msw/dialup.cpp:758
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Silahkan pilih ingin koneksi ke ISP mana"
 
-#: ../src/common/headerctrlcmn.cpp:59
+#: ../src/common/headerctrlcmn.cpp:57
 msgid "Please select the columns to show and define their order:"
 msgstr "Silakan pilih kolom untuk ditampilkan dan definisikan urutannya:"
 
-#: ../src/common/prntbase.cpp:538
+#: ../src/common/prntbase.cpp:533
 msgid "Please wait while printing..."
 msgstr "Mohon tunggu sedang dicetak..."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1767
+#: ../src/propgrid/advprops.cpp:1668
 msgid "Point Left"
 msgstr "Tunjuk Kiri"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1768
+#: ../src/propgrid/advprops.cpp:1669
 msgid "Point Right"
 msgstr "Tunjuk Kanan"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:662
+#: ../src/propgrid/advprops.cpp:572
 msgid "Point Size"
 msgstr "Ukuran Point"
 
-#: ../src/generic/prntdlgg.cpp:612 ../src/generic/prntdlgg.cpp:867
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:860
 msgid "Portrait"
 msgstr "Tegak"
 
@@ -5639,249 +5866,261 @@ msgstr "Tegak"
 msgid "Position"
 msgstr "Posisi"
 
-#: ../src/generic/prntdlgg.cpp:298
+#: ../src/generic/prntdlgg.cpp:291
 msgid "PostScript file"
 msgstr "Berkas PostScript"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178 ../src/osx/cocoa/preferences.mm:303
 msgid "Preferences"
 msgstr "Preferensi"
 
-#: ../src/osx/menu_osx.cpp:568
+#: ../src/osx/menu_osx.cpp:460
 msgid "Preferences..."
 msgstr "Preferensi..."
 
-#: ../src/common/prntbase.cpp:546
+#: ../src/common/prntbase.cpp:541
 msgid "Preparing"
 msgstr "Mempersiapkan"
 
-#: ../src/generic/fontdlgg.cpp:455 ../src/osx/carbon/fontdlg.cpp:390
-#: ../src/html/helpwnd.cpp:1222
+#: ../src/osx/carbon/fontdlg.cpp:387 ../src/generic/fontdlgg.cpp:452
+#: ../src/html/helpwnd.cpp:1220
 msgid "Preview:"
 msgstr "Pratinjau:"
 
-#: ../src/common/prntbase.cpp:1553 ../src/html/helpwnd.cpp:664
+#: ../src/common/prntbase.cpp:1578 ../src/html/helpwnd.cpp:662
 msgid "Previous page"
 msgstr "Halaman sebelumnya"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/prntdlgg.cpp:143 ../src/generic/prntdlgg.cpp:157
-#: ../src/common/prntbase.cpp:426 ../src/common/prntbase.cpp:1541
-#: ../src/common/accelcmn.cpp:77 ../src/gtk/print.cpp:620 ../src/gtk/print.cpp:638
+#: ../src/common/prntbase.cpp:421 ../src/common/prntbase.cpp:1566
+#: ../src/common/accelcmn.cpp:74 ../src/generic/prntdlgg.cpp:136
+#: ../src/generic/prntdlgg.cpp:150 ../src/gtk/print.cpp:616
+#: ../src/gtk/print.cpp:634
 msgid "Print"
 msgstr "Print"
 
-#: ../include/wx/prntbase.h:399 ../src/common/docview.cpp:1268
+#: ../src/common/docview.cpp:1262
 msgid "Print Preview"
 msgstr "Pratinjau Pencetakan"
 
-#: ../src/common/prntbase.cpp:2015 ../src/common/prntbase.cpp:2057
-#: ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2037 ../src/common/prntbase.cpp:2079
+#: ../src/common/prntbase.cpp:2087
 msgid "Print Preview Failure"
 msgstr "Gagal Pratinjau Pencetakan"
 
-#: ../src/generic/prntdlgg.cpp:224
+#: ../src/generic/prntdlgg.cpp:217
 msgid "Print Range"
 msgstr "Jangkauan Cetakan"
 
-#: ../src/generic/prntdlgg.cpp:449
+#: ../src/generic/prntdlgg.cpp:442
 msgid "Print Setup"
 msgstr "Pengaturan Cetakan"
 
-#: ../src/generic/prntdlgg.cpp:621
+#: ../src/generic/prntdlgg.cpp:614
 msgid "Print in colour"
 msgstr "Cetak berwarna"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/osx/webview_webkit.mm:260
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "Deskripsi kolom tidak dapat diinisialisasi."
+
+#: ../src/common/stockitem.cpp:179
 msgid "Print previe&w..."
 msgstr "Prat&injau cetakan..."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1256
 msgid "Print preview creation failed."
 msgstr "Membuat pratinjau cetakan gagal."
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/common/stockitem.cpp:179
 msgid "Print preview..."
 msgstr "Pratinjau cetakan..."
 
-#: ../src/generic/prntdlgg.cpp:630
+#: ../src/generic/prntdlgg.cpp:623
 msgid "Print spooling"
 msgstr "Antrian pencetakan"
 
-#: ../src/html/helpwnd.cpp:675
+#: ../src/html/helpwnd.cpp:673
 msgid "Print this page"
 msgstr "Cetak halaman ini"
 
-#: ../src/generic/prntdlgg.cpp:185
+#: ../src/generic/prntdlgg.cpp:178
 msgid "Print to File"
 msgstr "Cetak ke Berkas"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "Print..."
 msgstr "Cetak..."
 
-#: ../src/generic/prntdlgg.cpp:493
+#: ../src/generic/prntdlgg.cpp:486
 msgid "Printer"
 msgstr "Printer"
 
-#: ../src/generic/prntdlgg.cpp:633
+#: ../src/generic/prntdlgg.cpp:626
 msgid "Printer command:"
 msgstr "Perintah pencetak:"
 
-#: ../src/generic/prntdlgg.cpp:180
+#: ../src/generic/prntdlgg.cpp:173
 msgid "Printer options"
 msgstr "Opsi pencetak"
 
-#: ../src/generic/prntdlgg.cpp:645
+#: ../src/generic/prntdlgg.cpp:638
 msgid "Printer options:"
 msgstr "Opsi pencetak:"
 
-#: ../src/generic/prntdlgg.cpp:916
+#: ../src/generic/prntdlgg.cpp:909
 msgid "Printer..."
 msgstr "Pencetak..."
 
-#: ../src/generic/prntdlgg.cpp:196
+#: ../src/generic/prntdlgg.cpp:189
 msgid "Printer:"
 msgstr "Mesin cetak:"
 
-#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:535
-#: ../src/html/htmprint.cpp:277
+#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:530
+#: ../src/html/htmprint.cpp:289
 msgid "Printing"
 msgstr "Mencetak"
 
-#: ../src/common/prntbase.cpp:612
+#: ../src/common/prntbase.cpp:607
 msgid "Printing "
 msgstr "Mencetak "
 
-#: ../src/common/prntbase.cpp:347
+#: ../src/common/prntbase.cpp:342
 msgid "Printing Error"
 msgstr "Galat Mencetak"
 
-#: ../src/common/prntbase.cpp:565
+#: ../src/osx/webview_webkit.mm:251
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "Gzip tidak didukung oleh versi zlib ini"
+
+#: ../src/common/prntbase.cpp:560
 #, c-format
 msgid "Printing page %d"
 msgstr "Mencetak halaman %d"
 
-#: ../src/common/prntbase.cpp:570
+#: ../src/common/prntbase.cpp:565
 #, c-format
 msgid "Printing page %d of %d"
 msgstr "Mencetak halaman %d dari %d"
 
-#: ../src/generic/printps.cpp:201
+#: ../src/generic/printps.cpp:182
 #, c-format
 msgid "Printing page %d..."
 msgstr "Mencetak halaman %d..."
 
-#: ../src/generic/printps.cpp:161
+#: ../src/generic/printps.cpp:142
 msgid "Printing..."
 msgstr "Mencetak..."
 
-#: ../include/wx/richtext/richtextprint.h:109 ../include/wx/prntbase.h:267
-#: ../src/common/docview.cpp:2132
+#: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
+#: ../src/common/docview.cpp:2137
 msgid "Printout"
 msgstr "Hasil cetakan"
 
-#: ../src/common/debugrpt.cpp:560
+#: ../src/common/debugrpt.cpp:561
 #, c-format
-msgid "Processing debug report has failed, leaving the files in \"%s\" directory."
+msgid ""
+"Processing debug report has failed, leaving the files in \"%s\" directory."
 msgstr "Gagal memproses laporan debug, membiarkan berkas di direktori \"%s\"."
 
-#: ../src/common/prntbase.cpp:545
+#: ../src/common/prntbase.cpp:540
 msgid "Progress:"
 msgstr "Progres:"
 
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181
 msgid "Properties"
 msgstr "Properti"
 
-#: ../src/propgrid/manager.cpp:237
+#: ../src/propgrid/manager.cpp:223
 msgid "Property"
 msgstr "Properti"
 
 #. TRANSLATORS: Caption of message box displaying any property error
-#: ../src/propgrid/propgrid.cpp:3185 ../src/propgrid/propgrid.cpp:3318
+#: ../src/propgrid/propgrid.cpp:3162 ../src/propgrid/propgrid.cpp:3299
 msgid "Property Error"
 msgstr "Galat Properti"
 
-#: ../src/propgrid/advprops.cpp:1597
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Purple"
 msgstr "Ungu"
 
-#: ../src/common/paper.cpp:112
+#: ../src/common/paper.cpp:109
 msgid "Quarto, 215 x 275 mm"
 msgstr "Kuarto, 215 x 275 mm"
 
-#: ../src/generic/logg.cpp:1016
+#: ../src/generic/logg.cpp:1013
 msgid "Question"
 msgstr "Pertanyaan"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1769
+#: ../src/propgrid/advprops.cpp:1670
 msgid "Question Arrow"
 msgstr "Panah Tanda Tanya"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "Quit"
 msgstr "Keluar"
 
-#: ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:477
 #, c-format
 msgid "Quit %s"
 msgstr "Keluar %s"
 
-#: ../src/common/stockitem.cpp:263
+#: ../src/common/stockitem.cpp:261
 msgid "Quit this program"
 msgstr "Keluar dari program ini"
 
-#: ../src/common/accelcmn.cpp:338
+#: ../src/common/accelcmn.cpp:352
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/ffile.cpp:109 ../src/common/ffile.cpp:133
+#: ../src/common/ffile.cpp:107 ../src/common/ffile.cpp:132
 #, c-format
 msgid "Read error on file '%s'"
 msgstr "Kesalahan membaca pada file '%s'"
 
-#: ../src/common/secretstore.cpp:199
-#, c-format
-msgid "Reading password for \"%s/%s\" failed: %s."
+#: ../src/common/secretstore.cpp:211
+#, fuzzy, c-format
+msgid "Reading password for \"%s\" failed: %s."
 msgstr "Membaca password untuk \"%s/%s\" gagal: %s."
 
-#: ../src/common/prntbase.cpp:272
+#: ../src/common/prntbase.cpp:267
 msgid "Ready"
 msgstr "Siap"
 
-#: ../src/propgrid/advprops.cpp:1605
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Red"
 msgstr "Merah"
 
-#: ../src/generic/colrdlgg.cpp:339
+#: ../src/generic/colrdlgg.cpp:359
 msgid "Red:"
 msgstr "Merah:"
 
-#: ../src/common/stockitem.cpp:185 ../src/stc/stc_i18n.cpp:16
+#: ../src/common/stockitem.cpp:182 ../src/stc/stc_i18n.cpp:16
 msgid "Redo"
 msgstr "Ulangi"
 
-#: ../src/common/stockitem.cpp:264
+#: ../src/common/stockitem.cpp:262
 msgid "Redo last action"
 msgstr "Ulangi aksi terakhir"
 
-#: ../src/common/stockitem.cpp:186
+#: ../src/common/stockitem.cpp:183
 msgid "Refresh"
 msgstr "Refresh"
 
-#: ../src/msw/registry.cpp:626
+#: ../src/msw/registry.cpp:615
 #, c-format
 msgid "Registry key '%s' already exists."
 msgstr "Kunci registri '%s' sudah ada."
 
-#: ../src/msw/registry.cpp:595
+#: ../src/msw/registry.cpp:584
 #, c-format
 msgid "Registry key '%s' does not exist, cannot rename it."
 msgstr "Kunci registri '%s' tidak ada, tidak bisa mengubah namanya."
 
-#: ../src/msw/registry.cpp:727
+#: ../src/msw/registry.cpp:716
 #, c-format
 msgid ""
 "Registry key '%s' is needed for normal system operation,\n"
@@ -5892,27 +6131,28 @@ msgstr ""
 "menghapusnya akan menyebabkan sistem anda tidak stabil:\n"
 "operasi dibatalkan."
 
-#: ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:942
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr "Nilai registri \"%s\" bukan biner (melainkan tipe %s)"
 
-#: ../src/msw/registry.cpp:917
+#: ../src/msw/registry.cpp:905
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr "Nilai registri “%s” bukan numerik (melainkan tipe %s)"
 
-#: ../src/msw/registry.cpp:1003
+#: ../src/msw/registry.cpp:991
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr "Nilai registri “%s” bukan teks (melainkan tipe %s)"
 
-#: ../src/msw/registry.cpp:521
+#: ../src/msw/registry.cpp:510
 #, c-format
 msgid "Registry value '%s' already exists."
 msgstr "Nilai registri '%s' sudah ada."
 
-#: ../src/richtext/richtextfontpage.cpp:350 ../src/richtext/richtextfontpage.cpp:354
+#: ../src/richtext/richtextfontpage.cpp:350
+#: ../src/richtext/richtextfontpage.cpp:354
 msgid "Regular"
 msgstr "Regular"
 
@@ -5920,71 +6160,78 @@ msgstr "Regular"
 msgid "Relative"
 msgstr "Relatif"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:456
 msgid "Relevant entries:"
 msgstr "Entri yang relevan:"
 
-#: ../include/wx/generic/progdlgg.h:86
+#: ../include/wx/generic/progdlgg.h:87
 msgid "Remaining time:"
 msgstr "Waktu tersisa:"
 
-#: ../src/common/stockitem.cpp:187
+#: ../src/common/stockitem.cpp:184
 msgid "Remove"
 msgstr "Hapus"
 
-#: ../src/richtext/richtextctrl.cpp:1562
+#: ../src/richtext/richtextctrl.cpp:1563
 msgid "Remove Bullet"
 msgstr "Hapus Bullet"
 
-#: ../src/html/helpwnd.cpp:433
+#: ../src/html/helpwnd.cpp:431
 msgid "Remove current page from bookmarks"
 msgstr "Hilangkan halaman saat ini dari bookmark"
 
-#: ../src/common/rendcmn.cpp:194
+#: ../src/common/rendcmn.cpp:191
 #, c-format
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
-"Perender \"%s\" memiliki versi yang tidak kompatibel %d.%d dan tidak dapat dimuat."
+"Perender \"%s\" memiliki versi yang tidak kompatibel %d.%d dan tidak dapat "
+"dimuat."
 
-#: ../src/richtext/richtextbuffer.cpp:4527
+#: ../src/richtext/richtextbuffer.cpp:4524
 msgid "Renumber List"
 msgstr "Nomori Ulang Daftar"
 
-#: ../src/common/stockitem.cpp:188
-msgid "Rep&lace"
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Rep&lace..."
 msgstr "Tim&pa"
 
-#: ../src/richtext/richtextctrl.cpp:3673 ../src/common/stockitem.cpp:188
+#: ../src/richtext/richtextctrl.cpp:3674
 msgid "Replace"
 msgstr "Timpa"
 
-#: ../src/generic/fdrepdlg.cpp:182
+#: ../src/generic/fdrepdlg.cpp:179
 msgid "Replace &all"
 msgstr "Ganti semu&a"
 
-#: ../src/common/stockitem.cpp:261
-msgid "Replace selection"
-msgstr "Timpa seleksi"
-
-#: ../src/generic/fdrepdlg.cpp:124
+#: ../src/generic/fdrepdlg.cpp:121
 msgid "Replace with:"
 msgstr "Ganti dengan:"
 
-#: ../src/common/valtext.cpp:163
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Replace..."
+msgstr "Timpa"
+
+#: ../src/common/valtext.cpp:184
 msgid "Required information entry is empty."
 msgstr "Entri informasi yang dibutuhkan kosong."
 
-#: ../src/common/translation.cpp:1975
+#: ../src/common/translation.cpp:2025
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "Sumber '%s' bukan pesan katalog yang valid."
 
+#: ../src/gtk/webview_webkit.cpp:985
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:56
+#: ../src/common/accelcmn.cpp:53
 msgid "Return"
 msgstr "Return"
 
-#: ../src/common/stockitem.cpp:189
+#: ../src/common/stockitem.cpp:186
 msgid "Revert to Saved"
 msgstr "Kembali ke yang tersimpan"
 
@@ -5996,40 +6243,41 @@ msgstr "Punggung"
 msgid "Rig&ht-to-left"
 msgstr "&Kanan-ke-kiri"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6149 ../src/richtext/richtextliststylepage.cpp:251
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:59 ../src/generic/datavgen.cpp:6954
+#: ../src/richtext/richtextsizepage.cpp:250
+#: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextbulletspage.cpp:188
-#: ../src/richtext/richtextsizepage.cpp:250 ../src/common/accelcmn.cpp:62
 msgid "Right"
 msgstr "Kanan"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1754
+#: ../src/propgrid/advprops.cpp:1655
 msgid "Right Arrow"
 msgstr "Panah Kanan"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1770
+#: ../src/propgrid/advprops.cpp:1671
 msgid "Right Button"
 msgstr "Tombol Kanan"
 
-#: ../src/generic/prntdlgg.cpp:892
+#: ../src/generic/prntdlgg.cpp:885
 msgid "Right margin (mm):"
 msgstr "Batas kanan (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:148
-#: ../src/richtext/richtextindentspage.cpp:150
 #: ../src/richtext/richtextliststylepage.cpp:337
 #: ../src/richtext/richtextliststylepage.cpp:339
+#: ../src/richtext/richtextindentspage.cpp:148
+#: ../src/richtext/richtextindentspage.cpp:150
 msgid "Right-align text."
 msgstr "Teks rata kanan."
 
-#: ../src/generic/fontdlgg.cpp:322
+#: ../src/generic/fontdlgg.cpp:318
 msgid "Roman"
 msgstr "Roman"
 
-#: ../src/generic/datavgen.cpp:5916
+#: ../src/generic/datavgen.cpp:6721
 #, c-format
 msgid "Row %i"
 msgstr "Baris %i"
@@ -6039,30 +6287,31 @@ msgstr "Baris %i"
 msgid "S&tandard bullet name:"
 msgstr "Nama s&tandar bullet:"
 
-#: ../src/common/accelcmn.cpp:268 ../src/common/accelcmn.cpp:350
+#: ../src/common/accelcmn.cpp:282 ../src/common/accelcmn.cpp:367
 msgid "SPECIAL"
 msgstr "SPESIAL"
 
-#: ../src/common/stockitem.cpp:190 ../src/common/sizer.cpp:2797
+#: ../src/common/stockitem.cpp:187 ../src/common/sizer.cpp:2914
 msgid "Save"
 msgstr "Simpan"
 
-#: ../src/common/fldlgcmn.cpp:342
+#: ../src/common/fldlgcmn.cpp:339
 #, c-format
 msgid "Save %s file"
 msgstr "Simpan berkas %s"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/common/stockitem.cpp:188 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Simpan Seb&agai..."
 
-#: ../src/common/docview.cpp:366
+#: ../src/common/docview.cpp:359
 msgid "Save As"
 msgstr "Simpan Sebagai"
 
-#: ../src/common/stockitem.cpp:191
-msgid "Save as"
-msgstr "Simpan sebagai"
+#: ../src/common/stockitem.cpp:188
+#, fuzzy
+msgid "Save As..."
+msgstr "Simpan Seb&agai..."
 
 #: ../src/common/stockitem.cpp:267
 msgid "Save current document"
@@ -6072,107 +6321,112 @@ msgstr "Simpan dokumen ini"
 msgid "Save current document with a different filename"
 msgstr "Simpan dokumen ini dengan nama berkas berbeda"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/generic/logg.cpp:509
 msgid "Save log contents to file"
 msgstr "Simpan isi log ke berkas"
 
-#: ../src/common/secretstore.cpp:179
-#, c-format
-msgid "Saving password for \"%s/%s\" failed: %s."
+#: ../src/common/secretstore.cpp:189
+#, fuzzy, c-format
+msgid "Saving password for \"%s\" failed: %s."
 msgstr "Penyimpanan password untuk “%s/%s” gagal: %s."
 
-#: ../src/generic/fontdlgg.cpp:325
+#: ../src/generic/fontdlgg.cpp:321
 msgid "Script"
 msgstr "Skrip"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll Lock"
 msgstr "Scroll Lock"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll_lock"
 msgstr "Scroll_lock"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:890
+#: ../src/propgrid/advprops.cpp:791
 msgid "Scrollbar"
 msgstr "BatangScroll"
 
-#: ../src/generic/srchctlg.cpp:56 ../src/html/helpwnd.cpp:535
-#: ../src/html/helpwnd.cpp:550
+#: ../src/generic/srchctlg.cpp:55 ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:548 ../src/gtk/srchctrl.cpp:182
 msgid "Search"
 msgstr "Cari"
 
-#: ../src/html/helpwnd.cpp:537
+#: ../src/html/helpwnd.cpp:535
 msgid ""
-"Search contents of help book(s) for all occurrences of the text you typed above"
+"Search contents of help book(s) for all occurrences of the text you typed "
+"above"
 msgstr ""
-"Cari isi dari konten bantuan untuk semua pemunculan dari teks yang diketikkan "
-"diatas"
+"Cari isi dari konten bantuan untuk semua pemunculan dari teks yang "
+"diketikkan diatas"
 
-#: ../src/generic/fdrepdlg.cpp:160
+#: ../src/generic/fdrepdlg.cpp:157
 msgid "Search direction"
 msgstr "Arah pencarian"
 
-#: ../src/generic/fdrepdlg.cpp:112
+#: ../src/generic/fdrepdlg.cpp:109
 msgid "Search for:"
 msgstr "Cari:"
 
-#: ../src/html/helpwnd.cpp:1052
+#: ../src/html/helpwnd.cpp:1050
 msgid "Search in all books"
 msgstr "Cari di semua buku"
 
-#: ../src/html/helpwnd.cpp:857
+#: ../src/html/helpwnd.cpp:855
 msgid "Searching..."
 msgstr "Mencari..."
 
-#: ../src/generic/dirctrlg.cpp:446
+#: ../src/generic/dirctrlg.cpp:412
 msgid "Sections"
 msgstr "Bagian"
 
-#: ../src/common/ffile.cpp:238
+#: ../src/common/ffile.cpp:237
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Galat pencarian pada file '%s'"
 
-#: ../src/common/ffile.cpp:228
+#: ../src/common/ffile.cpp:227
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
-msgstr "Galat pencarian pada berkas '%s' (berkas besar tidak didukung oleh stdio)"
+msgstr ""
+"Galat pencarian pada berkas '%s' (berkas besar tidak didukung oleh stdio)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:76
+#: ../src/common/accelcmn.cpp:73
 msgid "Select"
 msgstr "Select"
 
-#: ../src/richtext/richtextctrl.cpp:337 ../src/osx/textctrl_osx.cpp:581
-#: ../src/common/stockitem.cpp:192 ../src/msw/textctrl.cpp:2512
+#: ../src/osx/textctrl_osx.cpp:599 ../src/common/stockitem.cpp:189
+#: ../src/msw/textctrl.cpp:2777 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Pilih Semu&a"
 
-#: ../src/common/stockitem.cpp:192 ../src/stc/stc_i18n.cpp:21
+#: ../src/common/stockitem.cpp:189 ../src/stc/stc_i18n.cpp:21
 msgid "Select All"
 msgstr "Pilih Semua"
 
-#: ../src/common/docview.cpp:1895
+#: ../src/common/docview.cpp:1900
 msgid "Select a document template"
 msgstr "Pilih template dokumen"
 
-#: ../src/common/docview.cpp:1969
+#: ../src/common/docview.cpp:1974
 msgid "Select a document view"
 msgstr "Pilih tampilan dokumen"
 
-#: ../src/richtext/richtextfontpage.cpp:226 ../src/richtext/richtextfontpage.cpp:228
+#: ../src/richtext/richtextfontpage.cpp:226
+#: ../src/richtext/richtextfontpage.cpp:228
 msgid "Select regular or bold."
 msgstr "Pilih teks tebal atau tidak."
 
-#: ../src/richtext/richtextfontpage.cpp:213 ../src/richtext/richtextfontpage.cpp:215
+#: ../src/richtext/richtextfontpage.cpp:213
+#: ../src/richtext/richtextfontpage.cpp:215
 msgid "Select regular or italic style."
 msgstr "Pilih teks miring atau tidak."
 
-#: ../src/richtext/richtextfontpage.cpp:239 ../src/richtext/richtextfontpage.cpp:241
+#: ../src/richtext/richtextfontpage.cpp:239
+#: ../src/richtext/richtextfontpage.cpp:241
 msgid "Select underlining or no underlining."
 msgstr "Pilih digarisbawahi atau tidak."
 
@@ -6186,20 +6440,20 @@ msgid "Selects the list level to edit."
 msgstr "Pilih tingkat daftar yang akan disunting."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:82
+#: ../src/common/accelcmn.cpp:79
 msgid "Separator"
 msgstr "Separator"
 
-#: ../src/common/cmdline.cpp:1083
+#: ../src/common/cmdline.cpp:1079
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Pemisah diharapkan setelah pilihan '%s'."
 
-#: ../src/osx/menu_osx.cpp:572
+#: ../src/osx/menu_osx.cpp:464
 msgid "Services"
 msgstr "Layanan"
 
-#: ../src/richtext/richtextbuffer.cpp:11217
+#: ../src/richtext/richtextbuffer.cpp:11216
 msgid "Set Cell Style"
 msgstr "Atur Gaya Sel"
 
@@ -6207,11 +6461,11 @@ msgstr "Atur Gaya Sel"
 msgid "SetProperty called w/o valid setter"
 msgstr "SetProperty dipanggil tanpa pengatur yang valid"
 
-#: ../src/generic/prntdlgg.cpp:188
+#: ../src/generic/prntdlgg.cpp:181
 msgid "Setup..."
 msgstr "Pengaturan..."
 
-#: ../src/msw/dialup.cpp:544
+#: ../src/msw/dialup.cpp:538
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr "Dijumpai beberapa koneksi dialup aktif, pilih satu secara acak."
 
@@ -6227,40 +6481,40 @@ msgstr "Bayangan"
 msgid "Shadow c&olour:"
 msgstr "&Warna bayangan:"
 
-#: ../src/common/accelcmn.cpp:335
+#: ../src/common/accelcmn.cpp:349
 msgid "Shift+"
 msgstr "Shift+"
 
-#: ../src/generic/dirdlgg.cpp:147
+#: ../src/generic/dirdlgg.cpp:144
 msgid "Show &hidden directories"
 msgstr "Tampilkan &direktor yang disembunyikan"
 
-#: ../src/generic/filectrlg.cpp:983
+#: ../src/generic/filectrlg.cpp:979
 msgid "Show &hidden files"
 msgstr "Tampilkan &berkas yang disembunyikan"
 
-#: ../src/osx/menu_osx.cpp:580
+#: ../src/osx/menu_osx.cpp:472
 msgid "Show All"
 msgstr "Tampilkan Semua"
 
-#: ../src/common/stockitem.cpp:257
+#: ../src/common/stockitem.cpp:254
 msgid "Show about dialog"
 msgstr "Tampilkan dialog tentang"
 
-#: ../src/html/helpwnd.cpp:492
+#: ../src/html/helpwnd.cpp:490
 msgid "Show all"
 msgstr "Tampilkan semua"
 
-#: ../src/html/helpwnd.cpp:503
+#: ../src/html/helpwnd.cpp:501
 msgid "Show all items in index"
 msgstr "Tampilkan semua butir dalam indeks"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:656
 msgid "Show/hide navigation panel"
 msgstr "Tampilkan/sembunyikan panel navigasi"
 
-#: ../src/richtext/richtextsymboldlg.cpp:421
-#: ../src/richtext/richtextsymboldlg.cpp:423
+#: ../src/richtext/richtextsymboldlg.cpp:418
+#: ../src/richtext/richtextsymboldlg.cpp:420
 msgid "Shows a Unicode subset."
 msgstr "Tampilkan subset Unicode."
 
@@ -6271,11 +6525,12 @@ msgstr "Tampilkan subset Unicode."
 msgid "Shows a preview of the bullet settings."
 msgstr "Tampilkan pratinjau pengaturan bullet."
 
-#: ../src/richtext/richtextfontpage.cpp:330 ../src/richtext/richtextfontpage.cpp:332
+#: ../src/richtext/richtextfontpage.cpp:330
+#: ../src/richtext/richtextfontpage.cpp:332
 msgid "Shows a preview of the font settings."
 msgstr "Tampilkan pratinjau pengaturan font."
 
-#: ../src/osx/carbon/fontdlg.cpp:394 ../src/osx/carbon/fontdlg.cpp:396
+#: ../src/osx/carbon/fontdlg.cpp:391 ../src/osx/carbon/fontdlg.cpp:393
 msgid "Shows a preview of the font."
 msgstr "Tampilkan pratinjau font."
 
@@ -6284,62 +6539,62 @@ msgstr "Tampilkan pratinjau font."
 msgid "Shows a preview of the paragraph settings."
 msgstr "Tampilkan pratinjau pengaturan paragraf."
 
-#: ../src/generic/fontdlgg.cpp:460 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:456 ../src/generic/fontdlgg.cpp:458
 msgid "Shows the font preview."
 msgstr "Tampilkan pratinjau font."
 
-#: ../src/propgrid/advprops.cpp:1607
+#: ../src/propgrid/advprops.cpp:1513
 msgid "Silver"
 msgstr "Perak"
 
-#: ../src/univ/themes/mono.cpp:516
+#: ../src/univ/themes/mono.cpp:513
 msgid "Simple monochrome theme"
 msgstr "Tema monochrome sederhana"
 
-#: ../src/richtext/richtextindentspage.cpp:275
 #: ../src/richtext/richtextliststylepage.cpp:449
+#: ../src/richtext/richtextindentspage.cpp:275
 msgid "Single"
 msgstr "Tunggal"
 
-#: ../src/generic/filectrlg.cpp:425 ../src/richtext/richtextformatdlg.cpp:369
-#: ../src/richtext/richtextsizepage.cpp:299
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextsizepage.cpp:299
+#: ../src/richtext/richtextformatdlg.cpp:362
 msgid "Size"
 msgstr "Ukuran"
 
-#: ../src/osx/carbon/fontdlg.cpp:339
+#: ../src/osx/carbon/fontdlg.cpp:336
 msgid "Size:"
 msgstr "Ukuran:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1775
+#: ../src/propgrid/advprops.cpp:1676
 msgid "Sizing"
 msgstr "Sizing"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1772
+#: ../src/propgrid/advprops.cpp:1673
 msgid "Sizing N-S"
 msgstr "Ubah Utara-Selatan"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1771
+#: ../src/propgrid/advprops.cpp:1672
 msgid "Sizing NE-SW"
 msgstr "Sizing NE-SW"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1773
+#: ../src/propgrid/advprops.cpp:1674
 msgid "Sizing NW-SE"
 msgstr "Sizing NW-SE"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1774
+#: ../src/propgrid/advprops.cpp:1675
 msgid "Sizing W-E"
 msgstr "Sizing W-E"
 
-#: ../src/msw/progdlg.cpp:801
+#: ../src/msw/progdlg.cpp:1088
 msgid "Skip"
 msgstr "Lewati"
 
-#: ../src/generic/fontdlgg.cpp:330
+#: ../src/generic/fontdlgg.cpp:326
 msgid "Slant"
 msgstr "Sudut pandang"
 
@@ -6348,7 +6603,7 @@ msgid "Small C&apitals"
 msgstr "Ka&pital Ukuran Kecil"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:79
+#: ../src/common/accelcmn.cpp:76
 msgid "Snapshot"
 msgstr "Snapshot"
 
@@ -6356,35 +6611,37 @@ msgstr "Snapshot"
 msgid "Solid"
 msgstr "Padat"
 
-#: ../src/common/docview.cpp:1791
+#: ../src/common/docview.cpp:1785
 msgid "Sorry, could not open this file."
 msgstr "Maaf, gagal membuka file ini."
 
-#: ../src/common/prntbase.cpp:2057 ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2079 ../src/common/prntbase.cpp:2087
 msgid "Sorry, not enough memory to create a preview."
 msgstr "Maaf, tidak cukup memori untuk membuat pratinjau."
 
-#: ../src/richtext/richtextstyledlg.cpp:611 ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:825 ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "Sorry, that name is taken. Please choose another."
 msgstr "Maaf, nama sudah ada. Tolong pilih yang lain."
 
-#: ../src/common/docview.cpp:1814
+#: ../src/common/docview.cpp:1819
 msgid "Sorry, the format for this file is unknown."
 msgstr "Maaf, format dari berkas ini tidak diketahui."
 
-#: ../src/unix/sound.cpp:492
+#: ../src/unix/sound.cpp:481
 msgid "Sound data are in unsupported format."
 msgstr "Data suara tidak didukung."
 
-#: ../src/unix/sound.cpp:477
+#: ../src/unix/sound.cpp:466
 #, c-format
 msgid "Sound file '%s' is in unsupported format."
 msgstr "Format berkas suara '%s' tidak didukung."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:67
+#: ../src/common/accelcmn.cpp:64
 msgid "Space"
 msgstr "Spacebar"
 
@@ -6392,12 +6649,12 @@ msgstr "Spacebar"
 msgid "Spacing"
 msgstr "Jarak"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "Spell Check"
 msgstr "Periksa Ejaan"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1776
+#: ../src/propgrid/advprops.cpp:1677
 msgid "Spraycan"
 msgstr "Kaleng Cat"
 
@@ -6406,41 +6663,38 @@ msgstr "Kaleng Cat"
 msgid "Standard"
 msgstr "Standar"
 
-#: ../src/common/paper.cpp:104
+#: ../src/common/paper.cpp:101
 msgid "Statement, 5 1/2 x 8 1/2 in"
 msgstr "Pernyataan, 5 1/2 x 8 1/2 inci"
 
-#: ../src/richtext/richtextsizepage.cpp:518 ../src/richtext/richtextsizepage.cpp:523
+#: ../src/richtext/richtextsizepage.cpp:518
+#: ../src/richtext/richtextsizepage.cpp:523
 msgid "Static"
 msgstr "Statik"
 
-#: ../src/generic/prntdlgg.cpp:204
+#: ../src/generic/prntdlgg.cpp:197
 msgid "Status:"
 msgstr "Status:"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "Stop"
 msgstr "Stop"
 
-#: ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196
 msgid "Strikethrough"
 msgstr "Teks coret"
 
-#: ../src/common/colourcmn.cpp:45
+#: ../src/common/colourcmn.cpp:42
 #, c-format
 msgid "String To Colour : Incorrect colour specification : %s"
 msgstr "Warna String : Spesifikasi warna salah : %s"
 
 #. TRANSLATORS: Label of font style
-#: ../src/richtext/richtextformatdlg.cpp:339 ../src/propgrid/advprops.cpp:680
+#: ../src/propgrid/advprops.cpp:590 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Gaya"
 
-#: ../include/wx/richtext/richtextstyledlg.h:46
-msgid "Style Organiser"
-msgstr "Pengelola Gaya"
-
-#: ../src/osx/carbon/fontdlg.cpp:348
+#: ../src/osx/carbon/fontdlg.cpp:345
 msgid "Style:"
 msgstr "Gaya:"
 
@@ -6449,7 +6703,7 @@ msgid "Subscrip&t"
 msgstr "Subscrip&t"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:83
+#: ../src/common/accelcmn.cpp:80
 msgid "Subtract"
 msgstr "Subtract"
 
@@ -6457,11 +6711,11 @@ msgstr "Subtract"
 msgid "Supe&rscript"
 msgstr "Supe&rscript"
 
-#: ../src/common/paper.cpp:150
+#: ../src/common/paper.cpp:147
 msgid "SuperA/SuperA/A4 227 x 356 mm"
 msgstr "SuperA/SuperA/A4 227 x 356 mm"
 
-#: ../src/common/paper.cpp:151
+#: ../src/common/paper.cpp:148
 msgid "SuperB/SuperB/A3 305 x 487 mm"
 msgstr "SuperB/SuperB/A3 305 x 487 mm"
 
@@ -6469,7 +6723,7 @@ msgstr "SuperB/SuperB/A3 305 x 487 mm"
 msgid "Suppress hyphe&nation"
 msgstr "Hindari ta&nda sambung"
 
-#: ../src/generic/fontdlgg.cpp:326
+#: ../src/generic/fontdlgg.cpp:322
 msgid "Swiss"
 msgstr "Swiss"
 
@@ -6487,73 +6741,73 @@ msgstr "Simbol &font:"
 msgid "Symbols"
 msgstr "Simbol"
 
-#: ../src/common/imagtiff.cpp:369 ../src/common/imagtiff.cpp:382
-#: ../src/common/imagtiff.cpp:741
+#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
+#: ../src/common/imagtiff.cpp:738
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: Gagal mengalokasikan memori."
 
-#: ../src/common/imagtiff.cpp:301
+#: ../src/common/imagtiff.cpp:298
 msgid "TIFF: Error loading image."
 msgstr "TIFF: Galat memuat citra."
 
-#: ../src/common/imagtiff.cpp:468
+#: ../src/common/imagtiff.cpp:465
 msgid "TIFF: Error reading image."
 msgstr "TIFF: Galat membaca citra."
 
-#: ../src/common/imagtiff.cpp:608
+#: ../src/common/imagtiff.cpp:605
 msgid "TIFF: Error saving image."
 msgstr "TIFF: Galat menyimpan citra."
 
-#: ../src/common/imagtiff.cpp:846
+#: ../src/common/imagtiff.cpp:843
 msgid "TIFF: Error writing image."
 msgstr "TIFF: Galat menulis citra."
 
-#: ../src/common/imagtiff.cpp:355
+#: ../src/common/imagtiff.cpp:352
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: Ukuran citra terlalu besar."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:68
+#: ../src/common/accelcmn.cpp:65
 msgid "Tab"
 msgstr "Tab"
 
-#: ../src/richtext/richtextbuffer.cpp:11498
+#: ../src/richtext/richtextbuffer.cpp:11497
 msgid "Table Properties"
 msgstr "Properti Tabel"
 
-#: ../src/common/paper.cpp:145
+#: ../src/common/paper.cpp:142
 msgid "Tabloid Extra 11.69 x 18 in"
 msgstr "Tabloid Extra 11.69 x 18 in"
 
-#: ../src/common/paper.cpp:102
+#: ../src/common/paper.cpp:99
 msgid "Tabloid, 11 x 17 in"
 msgstr "Tabloid, 11 x 17 inci"
 
-#: ../src/richtext/richtextformatdlg.cpp:354
+#: ../src/richtext/richtextformatdlg.cpp:347
 msgid "Tabs"
 msgstr "Tab"
 
-#: ../src/propgrid/advprops.cpp:1598
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Teal"
 msgstr "Hijau Kebiruan"
 
-#: ../src/generic/fontdlgg.cpp:327
+#: ../src/generic/fontdlgg.cpp:323
 msgid "Teletype"
 msgstr "Teletype"
 
-#: ../src/common/docview.cpp:1896
+#: ../src/common/docview.cpp:1901
 msgid "Templates"
 msgstr "Template"
 
-#: ../src/common/fmapbase.cpp:158
+#: ../src/common/fmapbase.cpp:155
 msgid "Thai (ISO-8859-11)"
 msgstr "Thai (ISO-8859-11)"
 
-#: ../src/common/ftp.cpp:619
+#: ../src/common/ftp.cpp:622
 msgid "The FTP server doesn't support passive mode."
 msgstr "Server FTP tidak mendukung mode passive."
 
-#: ../src/common/ftp.cpp:605
+#: ../src/common/ftp.cpp:608
 msgid "The FTP server doesn't support the PORT command."
 msgstr "Server FTP tersebut tidak mengdukung perintah PORT."
 
@@ -6564,7 +6818,8 @@ msgstr "Server FTP tersebut tidak mengdukung perintah PORT."
 msgid "The available bullet styles."
 msgstr "Gaya bullet yang tersedia."
 
-#: ../src/richtext/richtextstyledlg.cpp:202 ../src/richtext/richtextstyledlg.cpp:204
+#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:200
 msgid "The available styles."
 msgstr "Gaya bullet yang tersedia."
 
@@ -6602,8 +6857,10 @@ msgstr "Ukuran margin bawah."
 msgid "The bottom padding size."
 msgstr "Ukuran padding bawah."
 
-#: ../src/richtext/richtextsizepage.cpp:639 ../src/richtext/richtextsizepage.cpp:641
-#: ../src/richtext/richtextsizepage.cpp:653 ../src/richtext/richtextsizepage.cpp:655
+#: ../src/richtext/richtextsizepage.cpp:639
+#: ../src/richtext/richtextsizepage.cpp:641
+#: ../src/richtext/richtextsizepage.cpp:653
+#: ../src/richtext/richtextsizepage.cpp:655
 msgid "The bottom position."
 msgstr "Posisi bawah."
 
@@ -6618,12 +6875,12 @@ msgstr "Posisi bawah."
 msgid "The bullet character."
 msgstr "Karakter bullet."
 
-#: ../src/richtext/richtextsymboldlg.cpp:443
-#: ../src/richtext/richtextsymboldlg.cpp:445
+#: ../src/richtext/richtextsymboldlg.cpp:440
+#: ../src/richtext/richtextsymboldlg.cpp:442
 msgid "The character code."
 msgstr "Kode karakter."
 
-#: ../src/common/fontmap.cpp:203
+#: ../src/common/fontmap.cpp:200
 #, c-format
 msgid ""
 "The charset '%s' is unknown. You may select\n"
@@ -6634,7 +6891,7 @@ msgstr ""
 "charset lain untuk menggantinya atau memilih\n"
 "[Batal] jika tidak bisa diganti"
 
-#: ../src/msw/ole/dataobj.cpp:394
+#: ../src/msw/ole/dataobj.cpp:402
 #, c-format
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "Format clipboard '%d' tidak ada."
@@ -6644,7 +6901,7 @@ msgstr "Format clipboard '%d' tidak ada."
 msgid "The default style for the next paragraph."
 msgstr "Gaya standar untuk paragraf selanjutnya."
 
-#: ../src/generic/dirdlgg.cpp:202
+#: ../src/generic/dirdlgg.cpp:199
 #, c-format
 msgid ""
 "The directory '%s' does not exist\n"
@@ -6653,20 +6910,20 @@ msgstr ""
 "Direktori '%s' tidak ada\n"
 "Buat sekarang?"
 
-#: ../src/html/htmprint.cpp:271
+#: ../src/html/htmprint.cpp:283
 #, c-format
 msgid ""
-"The document \"%s\" doesn't fit on the page horizontally and will be truncated if "
-"printed.\n"
+"The document \"%s\" doesn't fit on the page horizontally and will be "
+"truncated if printed.\n"
 "\n"
 "Would you like to proceed with printing it nevertheless?"
 msgstr ""
-"Dokumen \"%s\" tidak pas pada halaman secara horisontal dan akan terpotong jika "
-"dicetak.\n"
+"Dokumen \"%s\" tidak pas pada halaman secara horisontal dan akan terpotong "
+"jika dicetak.\n"
 "\n"
 "Apakah akan dilanjutkan?"
 
-#: ../src/common/docview.cpp:1202
+#: ../src/common/docview.cpp:1196
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -6675,52 +6932,53 @@ msgstr ""
 "Berkas '%s' tidak ada dan tidak bisa dibuka.\n"
 "Itu telah dihapus dari daftar berkas yang baru terpakai."
 
-#: ../src/richtext/richtextindentspage.cpp:208
-#: ../src/richtext/richtextindentspage.cpp:210
 #: ../src/richtext/richtextliststylepage.cpp:394
 #: ../src/richtext/richtextliststylepage.cpp:396
+#: ../src/richtext/richtextindentspage.cpp:208
+#: ../src/richtext/richtextindentspage.cpp:210
 msgid "The first line indent."
 msgstr "Inden baris pertama."
 
-#: ../src/gtk/utilsgtk.cpp:481
-msgid "The following standard GTK+ options are also supported:\n"
-msgstr "Standar opsi GTK+ yang didukung:\n"
+#: ../src/generic/dbgrptg.cpp:318
+msgid "The following debug report will be generated\n"
+msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:414 ../src/generic/fontdlgg.cpp:416
+#: ../src/generic/fontdlgg.cpp:411 ../src/generic/fontdlgg.cpp:413
 msgid "The font colour."
 msgstr "Warna font."
 
-#: ../src/generic/fontdlgg.cpp:375 ../src/generic/fontdlgg.cpp:377
+#: ../src/generic/fontdlgg.cpp:371 ../src/generic/fontdlgg.cpp:373
 msgid "The font family."
 msgstr "Keluarga font."
 
-#: ../src/richtext/richtextsymboldlg.cpp:405
-#: ../src/richtext/richtextsymboldlg.cpp:407
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "The font from which to take the symbol."
 msgstr "Pilih font untuk mengambil simbol."
 
-#: ../src/generic/fontdlgg.cpp:427 ../src/generic/fontdlgg.cpp:429
-#: ../src/generic/fontdlgg.cpp:434 ../src/generic/fontdlgg.cpp:436
+#: ../src/generic/fontdlgg.cpp:424 ../src/generic/fontdlgg.cpp:426
+#: ../src/generic/fontdlgg.cpp:430 ../src/generic/fontdlgg.cpp:432
 msgid "The font point size."
 msgstr "Ukuran point font."
 
-#: ../src/osx/carbon/fontdlg.cpp:343 ../src/osx/carbon/fontdlg.cpp:345
+#: ../src/osx/carbon/fontdlg.cpp:340 ../src/osx/carbon/fontdlg.cpp:342
 msgid "The font size in points."
 msgstr "Ukuran font dalam point."
 
-#: ../src/richtext/richtextfontpage.cpp:181 ../src/richtext/richtextfontpage.cpp:183
+#: ../src/richtext/richtextfontpage.cpp:181
+#: ../src/richtext/richtextfontpage.cpp:183
 msgid "The font size units, points or pixels."
 msgstr "Ukuran font, dalam point atau pixel."
 
-#: ../src/generic/fontdlgg.cpp:386 ../src/generic/fontdlgg.cpp:388
+#: ../src/generic/fontdlgg.cpp:382 ../src/generic/fontdlgg.cpp:384
 msgid "The font style."
 msgstr "Gaya font."
 
-#: ../src/generic/fontdlgg.cpp:397 ../src/generic/fontdlgg.cpp:399
+#: ../src/generic/fontdlgg.cpp:393 ../src/generic/fontdlgg.cpp:395
 msgid "The font weight."
 msgstr "Berat font."
 
-#: ../src/common/docview.cpp:1483
+#: ../src/common/docview.cpp:1477
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Format berkas '%s' tidak dapat ditentukan."
@@ -6730,10 +6988,10 @@ msgstr "Format berkas '%s' tidak dapat ditentukan."
 msgid "The horizontal offset."
 msgstr "Jarak horizontal."
 
-#: ../src/richtext/richtextindentspage.cpp:199
-#: ../src/richtext/richtextindentspage.cpp:201
 #: ../src/richtext/richtextliststylepage.cpp:385
 #: ../src/richtext/richtextliststylepage.cpp:387
+#: ../src/richtext/richtextindentspage.cpp:199
+#: ../src/richtext/richtextindentspage.cpp:201
 msgid "The left indent."
 msgstr "Indent kiri."
 
@@ -6747,15 +7005,17 @@ msgstr "Ukurang margin kiri."
 msgid "The left padding size."
 msgstr "Ukurang padding kiri."
 
-#: ../src/richtext/richtextsizepage.cpp:534 ../src/richtext/richtextsizepage.cpp:536
-#: ../src/richtext/richtextsizepage.cpp:548 ../src/richtext/richtextsizepage.cpp:550
+#: ../src/richtext/richtextsizepage.cpp:534
+#: ../src/richtext/richtextsizepage.cpp:536
+#: ../src/richtext/richtextsizepage.cpp:548
+#: ../src/richtext/richtextsizepage.cpp:550
 msgid "The left position."
 msgstr "Posisi kiri."
 
-#: ../src/richtext/richtextindentspage.cpp:288
-#: ../src/richtext/richtextindentspage.cpp:290
 #: ../src/richtext/richtextliststylepage.cpp:462
 #: ../src/richtext/richtextliststylepage.cpp:464
+#: ../src/richtext/richtextindentspage.cpp:288
+#: ../src/richtext/richtextindentspage.cpp:290
 msgid "The line spacing."
 msgstr "Spasi baris."
 
@@ -6764,31 +7024,37 @@ msgstr "Spasi baris."
 msgid "The list item number."
 msgstr "Nomor butir daftar."
 
-#: ../src/msw/ole/automtn.cpp:664
+#: ../src/msw/ole/automtn.cpp:655
 msgid "The locale ID is unknown."
 msgstr "ID bahasa tidak dikenali."
 
-#: ../src/richtext/richtextsizepage.cpp:366 ../src/richtext/richtextsizepage.cpp:368
+#: ../src/richtext/richtextsizepage.cpp:366
+#: ../src/richtext/richtextsizepage.cpp:368
 msgid "The object height."
 msgstr "Tinggi obyek."
 
-#: ../src/richtext/richtextsizepage.cpp:474 ../src/richtext/richtextsizepage.cpp:476
+#: ../src/richtext/richtextsizepage.cpp:474
+#: ../src/richtext/richtextsizepage.cpp:476
 msgid "The object maximum height."
 msgstr "Tinggi maksimum obyek."
 
-#: ../src/richtext/richtextsizepage.cpp:447 ../src/richtext/richtextsizepage.cpp:449
+#: ../src/richtext/richtextsizepage.cpp:447
+#: ../src/richtext/richtextsizepage.cpp:449
 msgid "The object maximum width."
 msgstr "Lebar maksimum obyek."
 
-#: ../src/richtext/richtextsizepage.cpp:420 ../src/richtext/richtextsizepage.cpp:422
+#: ../src/richtext/richtextsizepage.cpp:420
+#: ../src/richtext/richtextsizepage.cpp:422
 msgid "The object minimum height."
 msgstr "Tinggi minimum obyek."
 
-#: ../src/richtext/richtextsizepage.cpp:393 ../src/richtext/richtextsizepage.cpp:395
+#: ../src/richtext/richtextsizepage.cpp:393
+#: ../src/richtext/richtextsizepage.cpp:395
 msgid "The object minimum width."
 msgstr "Lebar minimum obyek."
 
-#: ../src/richtext/richtextsizepage.cpp:332 ../src/richtext/richtextsizepage.cpp:334
+#: ../src/richtext/richtextsizepage.cpp:332
+#: ../src/richtext/richtextsizepage.cpp:334
 msgid "The object width."
 msgstr "Lebar obyek."
 
@@ -6797,40 +7063,40 @@ msgstr "Lebar obyek."
 msgid "The outline level."
 msgstr "Level ikhtisar."
 
-#: ../src/common/log.cpp:277
+#: ../src/common/log.cpp:296
 #, c-format
 msgid "The previous message repeated %u time."
 msgid_plural "The previous message repeated %u times."
 msgstr[0] "Pesan sebelumnya diulang %u kali."
 
-#: ../src/common/log.cpp:270
+#: ../src/common/log.cpp:289
 msgid "The previous message repeated once."
 msgstr "Pesan sebelumnya diulang sekali."
 
-#: ../src/richtext/richtextsymboldlg.cpp:462
-#: ../src/richtext/richtextsymboldlg.cpp:464
+#: ../src/richtext/richtextsymboldlg.cpp:459
+#: ../src/richtext/richtextsymboldlg.cpp:461
 msgid "The range to show."
 msgstr "Jangkauan yang akan diperlihatkan."
 
 #: ../src/generic/dbgrptg.cpp:322
 msgid ""
-"The report contains the files listed below. If any of these files contain private "
-"information,\n"
+"The report contains the files listed below. If any of these files contain "
+"private information,\n"
 "please uncheck them and they will be removed from the report.\n"
 msgstr ""
-"Laporan ini berisi berkas yang terdaftar dibawah. Jika ada berkas yang berisi "
-"informasi rahasia,\n"
+"Laporan ini berisi berkas yang terdaftar dibawah. Jika ada berkas yang "
+"berisi informasi rahasia,\n"
 "tolong matikan centang dan berkas tersebut akan dihapus dari laporan.\n"
 
-#: ../src/common/cmdline.cpp:1254
+#: ../src/common/cmdline.cpp:1250
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "Parameter '%s' yang dibutuhkan tidak dispesifikasikan."
 
-#: ../src/richtext/richtextindentspage.cpp:217
-#: ../src/richtext/richtextindentspage.cpp:219
 #: ../src/richtext/richtextliststylepage.cpp:403
 #: ../src/richtext/richtextliststylepage.cpp:405
+#: ../src/richtext/richtextindentspage.cpp:217
+#: ../src/richtext/richtextindentspage.cpp:219
 msgid "The right indent."
 msgstr "Indent kanan."
 
@@ -6844,8 +7110,10 @@ msgstr "Ukuran margin kanan."
 msgid "The right padding size."
 msgstr "Ukurang padding kanan."
 
-#: ../src/richtext/richtextsizepage.cpp:604 ../src/richtext/richtextsizepage.cpp:606
-#: ../src/richtext/richtextsizepage.cpp:618 ../src/richtext/richtextsizepage.cpp:620
+#: ../src/richtext/richtextsizepage.cpp:604
+#: ../src/richtext/richtextsizepage.cpp:606
+#: ../src/richtext/richtextsizepage.cpp:618
+#: ../src/richtext/richtextsizepage.cpp:620
 msgid "The right position."
 msgstr "Posisi kanan."
 
@@ -6869,16 +7137,16 @@ msgstr "Opasitas bayangan."
 msgid "The shadow spread."
 msgstr "Sebaran bayangan."
 
-#: ../src/richtext/richtextindentspage.cpp:267
 #: ../src/richtext/richtextliststylepage.cpp:439
 #: ../src/richtext/richtextliststylepage.cpp:441
+#: ../src/richtext/richtextindentspage.cpp:267
 msgid "The spacing after the paragraph."
 msgstr "Spasi setelah paragraf."
 
-#: ../src/richtext/richtextindentspage.cpp:257
-#: ../src/richtext/richtextindentspage.cpp:259
 #: ../src/richtext/richtextliststylepage.cpp:430
 #: ../src/richtext/richtextliststylepage.cpp:432
+#: ../src/richtext/richtextindentspage.cpp:257
+#: ../src/richtext/richtextindentspage.cpp:259
 msgid "The spacing before the paragraph."
 msgstr "Spasi sebelum paragraf."
 
@@ -6892,15 +7160,17 @@ msgstr "Nama gaya."
 msgid "The style on which this style is based."
 msgstr "Gaya dimana gaya ini didasarkan."
 
-#: ../src/richtext/richtextstyledlg.cpp:214 ../src/richtext/richtextstyledlg.cpp:216
+#: ../src/richtext/richtextstyledlg.cpp:210
+#: ../src/richtext/richtextstyledlg.cpp:212
 msgid "The style preview."
 msgstr "Pratinjau gaya."
 
-#: ../src/msw/ole/automtn.cpp:680
+#: ../src/msw/ole/automtn.cpp:671
 msgid "The system cannot find the file specified."
 msgstr "Sistem tidak menemukan berkas yang dicari."
 
-#: ../src/richtext/richtexttabspage.cpp:114 ../src/richtext/richtexttabspage.cpp:116
+#: ../src/richtext/richtexttabspage.cpp:114
+#: ../src/richtext/richtexttabspage.cpp:116
 msgid "The tab position."
 msgstr "Posisi tab."
 
@@ -6908,7 +7178,7 @@ msgstr "Posisi tab."
 msgid "The tab positions."
 msgstr "Posisi tab."
 
-#: ../src/richtext/richtextctrl.cpp:3098
+#: ../src/richtext/richtextctrl.cpp:3099
 msgid "The text couldn't be saved."
 msgstr "Teks tidak bisa disimpan."
 
@@ -6922,12 +7192,14 @@ msgstr "Ukuran margin atas."
 msgid "The top padding size."
 msgstr "Ukurang padding atas."
 
-#: ../src/richtext/richtextsizepage.cpp:569 ../src/richtext/richtextsizepage.cpp:571
-#: ../src/richtext/richtextsizepage.cpp:583 ../src/richtext/richtextsizepage.cpp:585
+#: ../src/richtext/richtextsizepage.cpp:569
+#: ../src/richtext/richtextsizepage.cpp:571
+#: ../src/richtext/richtextsizepage.cpp:583
+#: ../src/richtext/richtextsizepage.cpp:585
 msgid "The top position."
 msgstr "Posisi teratas."
 
-#: ../src/common/cmdline.cpp:1232
+#: ../src/common/cmdline.cpp:1228
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "Nilai untuk pilihan '%s' harus dispesifikasikan."
@@ -6937,186 +7209,201 @@ msgstr "Nilai untuk pilihan '%s' harus dispesifikasikan."
 msgid "The value of the corner radius."
 msgstr "Nilai radius pojokan."
 
-#: ../src/msw/dialup.cpp:433
+#: ../src/msw/dialup.cpp:427
 #, c-format
 msgid ""
-"The version of remote access service (RAS) installed on this machine is too old, "
-"please upgrade (the following required function is missing: %s)."
+"The version of remote access service (RAS) installed on this machine is too "
+"old, please upgrade (the following required function is missing: %s)."
 msgstr ""
-"Versi remote access service (RAS) terinstall di mesin ini terlalu tua, silahkan "
-"perbarui (fungsi yang dibutuhkan berikut ini hilang: %s)."
+"Versi remote access service (RAS) terinstall di mesin ini terlalu tua, "
+"silahkan perbarui (fungsi yang dibutuhkan berikut ini hilang: %s)."
 
 #: ../src/richtext/richtextbackgroundpage.cpp:242
 #: ../src/richtext/richtextbackgroundpage.cpp:244
 msgid "The vertical offset."
 msgstr "Jarak vertikal."
 
-#: ../src/richtext/richtextprint.cpp:619 ../src/html/htmprint.cpp:745
-msgid "There was a problem during page setup: you may need to set a default printer."
-msgstr ""
-"Ada masalah pada saat mengatur halaman: mungkin perlu ditetapkan pencetak default."
-
-#: ../src/html/htmprint.cpp:255
+#: ../src/html/htmprint.cpp:749 ../src/richtext/richtextprint.cpp:615
 msgid ""
-"This document doesn't fit on the page horizontally and will be truncated when it "
-"is printed."
+"There was a problem during page setup: you may need to set a default printer."
 msgstr ""
-"Dokumen tidak pas pada halaman secara horisontal dan akan terpotong ketika dicetak."
+"Ada masalah pada saat mengatur halaman: mungkin perlu ditetapkan pencetak "
+"default."
 
-#: ../src/common/image.cpp:2854
+#: ../src/html/htmprint.cpp:267
+msgid ""
+"This document doesn't fit on the page horizontally and will be truncated "
+"when it is printed."
+msgstr ""
+"Dokumen tidak pas pada halaman secara horisontal dan akan terpotong ketika "
+"dicetak."
+
+#: ../src/common/image.cpp:2963
 #, c-format
 msgid "This is not a %s."
 msgstr "Ini bukan %s."
 
-#: ../src/common/wincmn.cpp:1653
+#: ../src/common/wincmn.cpp:1654
 msgid "This platform does not support background transparency."
 msgstr "Platform ini tidak mendukung transparansi background."
 
-#: ../src/gtk/window.cpp:4660
+#: ../src/gtk/window.cpp:5664
 msgid ""
-"This program was compiled with a too old version of GTK+, please rebuild with GTK+ "
-"2.12 or newer."
+"This program was compiled with a too old version of GTK+, please rebuild "
+"with GTK+ 2.12 or newer."
 msgstr ""
-"Program ini telah dibuat dengan GTK+ lama, mohon dibuat kembali dengan GTK+ 2.12 "
-"atau lebih baru."
+"Program ini telah dibuat dengan GTK+ lama, mohon dibuat kembali dengan GTK+ "
+"2.12 atau lebih baru."
 
-#: ../src/msw/thread.cpp:1240
+#: ../src/gtk/glcanvas.cpp:176
 msgid ""
-"Thread module initialization failed: cannot store value in thread local storage"
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
 msgstr ""
-"Inisialisasi modul thread gagal: tidak bisa menyimpan nilai dalam penyimpanan "
-"thread lokal"
 
-#: ../src/unix/threadpsx.cpp:1794
+#: ../src/msw/thread.cpp:1246
+msgid ""
+"Thread module initialization failed: cannot store value in thread local "
+"storage"
+msgstr ""
+"Inisialisasi modul thread gagal: tidak bisa menyimpan nilai dalam "
+"penyimpanan thread lokal"
+
+#: ../src/unix/threadpsx.cpp:1843
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr "Inisialisasi modul thread gagal: gagal menciptakan kunci thread"
 
-#: ../src/msw/thread.cpp:1228
+#: ../src/msw/thread.cpp:1234
 msgid ""
-"Thread module initialization failed: impossible to allocate index in thread local "
-"storage"
+"Thread module initialization failed: impossible to allocate index in thread "
+"local storage"
 msgstr ""
 "Inisialisasi modul thread gagal: tidak mungkin mengalokasikan indeks dalam "
 "penyimpanan thread lokal"
 
-#: ../src/unix/threadpsx.cpp:1043
+#: ../src/unix/threadpsx.cpp:1061
 msgid "Thread priority setting is ignored."
 msgstr "Setelan prioritas thread diabaikan."
 
-#: ../src/msw/mdi.cpp:176
+#: ../src/msw/mdi.cpp:171
 msgid "Tile &Horizontally"
 msgstr "Tile &Horizontal"
 
-#: ../src/msw/mdi.cpp:177
+#: ../src/msw/mdi.cpp:172
 msgid "Tile &Vertically"
 msgstr "Tile &Vertikal"
 
-#: ../src/common/ftp.cpp:200
+#: ../src/common/ftp.cpp:197
 msgid "Timeout while waiting for FTP server to connect, try passive mode."
 msgstr ""
-"Terjadi galat batas waktu ketika menghubungi FTP server, cobalah mode passive."
+"Terjadi galat batas waktu ketika menghubungi FTP server, cobalah mode "
+"passive."
 
-#: ../src/generic/tipdlg.cpp:201
+#: ../src/generic/tipdlg.cpp:198
 msgid "Tip of the Day"
 msgstr "Tip Hari Ini"
 
-#: ../src/generic/tipdlg.cpp:140
+#: ../src/generic/tipdlg.cpp:137
 msgid "Tips not available, sorry!"
 msgstr "Tip tidak tersedia, maaf!"
 
-#: ../src/generic/prntdlgg.cpp:242
+#: ../src/generic/prntdlgg.cpp:235
 msgid "To:"
 msgstr "Kepada:"
 
-#: ../src/richtext/richtextbuffer.cpp:8363
+#: ../src/richtext/richtextbuffer.cpp:8361
 msgid "Too many EndStyle calls!"
 msgstr "Terlalu banyak pemanggilan EndStyle!"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:891
+#: ../src/propgrid/advprops.cpp:792
 msgid "Tooltip"
 msgstr "Tooltip"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:892
+#: ../src/propgrid/advprops.cpp:793
 msgid "TooltipText"
 msgstr "TeksTooltip"
 
-#: ../src/richtext/richtextsizepage.cpp:286 ../src/richtext/richtextsizepage.cpp:290
-#: ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197 ../src/richtext/richtextsizepage.cpp:286
+#: ../src/richtext/richtextsizepage.cpp:290
 msgid "Top"
 msgstr "Atas"
 
-#: ../src/generic/prntdlgg.cpp:881
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Top margin (mm):"
 msgstr "Batas atas (mm):"
 
-#: ../src/generic/aboutdlgg.cpp:79
+#: ../src/generic/aboutdlgg.cpp:76
 msgid "Translations by "
 msgstr "Diterjemahkan oleh "
 
-#: ../src/generic/aboutdlgg.cpp:188
+#: ../src/generic/aboutdlgg.cpp:185
 msgid "Translators"
 msgstr "Penerjemah"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:211
+#: ../src/propgrid/propgrid.cpp:192
 msgid "True"
 msgstr "True"
 
-#: ../src/common/fs_mem.cpp:227
+#: ../src/common/fs_mem.cpp:222
 #, c-format
 msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
 msgstr "Mencoba menghapus berkas '%s' dari memori VFS, walau tidak termuat!"
 
-#: ../src/common/fmapbase.cpp:156
+#: ../src/common/fmapbase.cpp:153
 msgid "Turkish (ISO-8859-9)"
 msgstr "Turkish (ISO-8859-9)"
 
-#: ../src/generic/filectrlg.cpp:426
+#: ../src/generic/filectrlg.cpp:422
 msgid "Type"
 msgstr "Tipe"
 
-#: ../src/richtext/richtextfontpage.cpp:151 ../src/richtext/richtextfontpage.cpp:153
+#: ../src/richtext/richtextfontpage.cpp:151
+#: ../src/richtext/richtextfontpage.cpp:153
 msgid "Type a font name."
 msgstr "Ketik nama font."
 
-#: ../src/richtext/richtextfontpage.cpp:166 ../src/richtext/richtextfontpage.cpp:168
+#: ../src/richtext/richtextfontpage.cpp:166
+#: ../src/richtext/richtextfontpage.cpp:168
 msgid "Type a size in points."
 msgstr "Ketik ukuran dalam point."
 
-#: ../src/msw/ole/automtn.cpp:676
+#: ../src/msw/ole/automtn.cpp:667
 #, c-format
 msgid "Type mismatch in argument %u."
 msgstr "Tipe tidak sesuai pada argumen %u."
 
-#: ../src/common/xtixml.cpp:356 ../src/common/xtixml.cpp:509
-#: ../src/common/xtistrm.cpp:318
+#: ../src/common/xtixml.cpp:352 ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315
 msgid "Type must have enum - long conversion"
 msgstr "Tipe harus memiliki konversi enum - long"
 
-#: ../src/propgrid/propgridiface.cpp:401
+#: ../src/propgrid/propgridiface.cpp:385
 #, c-format
 msgid ""
-"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT \"%s"
-"\"."
+"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
+"\"%s\"."
 msgstr ""
-"Tipe operasi \"%s\" gagal: Label properti \"%s\" seharusnya tipe \"%s\", BUKAN \"%s"
-"\"."
+"Tipe operasi \"%s\" gagal: Label properti \"%s\" seharusnya tipe \"%s\", "
+"BUKAN \"%s\"."
 
-#: ../src/common/paper.cpp:133
+#: ../src/common/paper.cpp:130
 msgid "US Std Fanfold, 14 7/8 x 11 in"
 msgstr "US Std Fanfold, 14 7/8 x 11 inci"
 
-#: ../src/common/fmapbase.cpp:196
+#: ../src/common/fmapbase.cpp:193
 msgid "US-ASCII"
 msgstr "US-ASCII"
 
-#: ../src/unix/fswatcher_inotify.cpp:109
+#: ../src/unix/fswatcher_inotify.cpp:106
 msgid "Unable to add inotify watch"
 msgstr "Gagal menambahkan pengamat inotify"
 
-#: ../src/unix/fswatcher_kqueue.cpp:136
+#: ../src/unix/fswatcher_kqueue.cpp:153
 msgid "Unable to add kqueue watch"
 msgstr "Gagal menambahkan pengamat kqueue"
 
@@ -7128,7 +7415,7 @@ msgstr "Gagal mengasosiasikan handle dengan port I/O"
 msgid "Unable to close I/O completion port handle"
 msgstr "Gagal menutup handle penyelesaian port I/O"
 
-#: ../src/unix/fswatcher_inotify.cpp:97
+#: ../src/unix/fswatcher_inotify.cpp:94
 msgid "Unable to close inotify instance"
 msgstr "Gagal menutup instan inotify"
 
@@ -7146,15 +7433,15 @@ msgstr "Gagal menutup handle untuk '%s'"
 msgid "Unable to create I/O completion port"
 msgstr "Gagal membuat penyelesaian port I/O"
 
-#: ../src/msw/fswatcher.cpp:84
+#: ../src/msw/fswatcher.cpp:81
 msgid "Unable to create IOCP worker thread"
 msgstr "Gagal membuat thread IOCP"
 
-#: ../src/unix/fswatcher_inotify.cpp:74
+#: ../src/unix/fswatcher_inotify.cpp:71
 msgid "Unable to create inotify instance"
 msgstr "Gagal membuat instan inotify"
 
-#: ../src/unix/fswatcher_kqueue.cpp:97
+#: ../src/unix/fswatcher_kqueue.cpp:114
 msgid "Unable to create kqueue instance"
 msgstr "Gagal membuat instan kqueue"
 
@@ -7162,11 +7449,11 @@ msgstr "Gagal membuat instan kqueue"
 msgid "Unable to dequeue completion packet"
 msgstr "Gagal men-dequeue paket penyelesaian"
 
-#: ../src/unix/fswatcher_kqueue.cpp:185
+#: ../src/unix/fswatcher_kqueue.cpp:202
 msgid "Unable to get events from kqueue"
 msgstr "Gagal mendapatkan even dari kqueue"
 
-#: ../src/gtk/app.cpp:435
+#: ../src/gtk/app.cpp:431
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "Gagal menginisiasi GTK+, apakah DISPLAY sudah benar?"
 
@@ -7175,12 +7462,12 @@ msgstr "Gagal menginisiasi GTK+, apakah DISPLAY sudah benar?"
 msgid "Unable to open path '%s'"
 msgstr "Gagal membuka jalur '%s'"
 
-#: ../src/html/htmlwin.cpp:583
+#: ../src/html/htmlwin.cpp:586
 #, c-format
 msgid "Unable to open requested HTML document: %s"
 msgstr "Gagal membuka dokumen HTML yang diminta: %s"
 
-#: ../src/unix/sound.cpp:368
+#: ../src/unix/sound.cpp:365
 msgid "Unable to play sound asynchronously."
 msgstr "Gagal memainkan audio secara asinkron."
 
@@ -7188,62 +7475,63 @@ msgstr "Gagal memainkan audio secara asinkron."
 msgid "Unable to post completion status"
 msgstr "Gagal memasang status penyelesaian"
 
-#: ../src/unix/fswatcher_inotify.cpp:556
+#: ../src/unix/fswatcher_inotify.cpp:553
 msgid "Unable to read from inotify descriptor"
 msgstr "Gagal membaca deskriptor inotify"
 
-#: ../src/unix/fswatcher_inotify.cpp:141
+#: ../src/unix/fswatcher_inotify.cpp:138
 #, c-format
 msgid "Unable to remove inotify watch %i"
 msgstr "Gagal menghapus pengamat inotify %i"
 
-#: ../src/unix/fswatcher_kqueue.cpp:153
+#: ../src/unix/fswatcher_kqueue.cpp:170
 msgid "Unable to remove kqueue watch"
 msgstr "Gagal menghapus pengamat kqueue"
 
-#: ../src/msw/fswatcher.cpp:168
+#: ../src/msw/fswatcher.cpp:165
 #, c-format
 msgid "Unable to set up watch for '%s'"
 msgstr "Gagal mengatur pengamatan untuk '%s'"
 
-#: ../src/msw/fswatcher.cpp:91
+#: ../src/msw/fswatcher.cpp:88
 msgid "Unable to start IOCP worker thread"
 msgstr "Gagal memulai thread IOCP"
 
-#: ../src/common/stockitem.cpp:201
+#: ../src/common/stockitem.cpp:198
 msgid "Undelete"
 msgstr "Batal penghapusan"
 
-#: ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199
 msgid "Underline"
 msgstr "Garis bawah"
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/richtext/richtextfontpage.cpp:359 ../src/osx/carbon/fontdlg.cpp:370
-#: ../src/propgrid/advprops.cpp:690
+#: ../src/osx/carbon/fontdlg.cpp:367 ../src/propgrid/advprops.cpp:600
+#: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Garis dibawahi"
 
-#: ../src/common/stockitem.cpp:203 ../src/stc/stc_i18n.cpp:15
+#: ../src/common/stockitem.cpp:200 ../src/stc/stc_i18n.cpp:15
 msgid "Undo"
 msgstr "Urungkan"
 
-#: ../src/common/stockitem.cpp:265
+#: ../src/common/stockitem.cpp:263
 msgid "Undo last action"
 msgstr "Urungkan aksi terakhir"
 
-#: ../src/common/cmdline.cpp:1029
+#: ../src/common/cmdline.cpp:1025
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Karakter tidak diharapkan setelah opsi '%s'."
 
-#: ../src/unix/fswatcher_inotify.cpp:274
+#: ../src/unix/fswatcher_inotify.cpp:271
 #, c-format
 msgid "Unexpected event for \"%s\": no matching watch descriptor."
 msgstr ""
-"Kejadian yang tak diharapkan bagi \"%s\": tak ada deskriptor pengamat yang sesuai."
+"Kejadian yang tak diharapkan bagi \"%s\": tak ada deskriptor pengamat yang "
+"sesuai."
 
-#: ../src/common/cmdline.cpp:1195
+#: ../src/common/cmdline.cpp:1191
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Parameter ‘%s’ tidak diharapkan"
@@ -7252,49 +7540,49 @@ msgstr "Parameter ‘%s’ tidak diharapkan"
 msgid "Unexpectedly new I/O completion port was created"
 msgstr "Port penyeesaian I/O baru dibuat tanpa diharapkan"
 
-#: ../src/msw/fswatcher.cpp:70
+#: ../src/msw/fswatcher.cpp:67
 msgid "Ungraceful worker thread termination"
 msgstr "Thread pekerja dihentikan"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:460
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:456
+#: ../src/richtext/richtextsymboldlg.cpp:457
+#: ../src/richtext/richtextsymboldlg.cpp:458
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../src/common/fmapbase.cpp:185 ../src/common/fmapbase.cpp:191
+#: ../src/common/fmapbase.cpp:182 ../src/common/fmapbase.cpp:188
 msgid "Unicode 16 bit (UTF-16)"
 msgstr "Unicode 16 bit (UTF-16)"
 
-#: ../src/common/fmapbase.cpp:190
+#: ../src/common/fmapbase.cpp:187
 msgid "Unicode 16 bit Big Endian (UTF-16BE)"
 msgstr "Unicode 16 bit Big Endian (UTF-16BE)"
 
-#: ../src/common/fmapbase.cpp:186
+#: ../src/common/fmapbase.cpp:183
 msgid "Unicode 16 bit Little Endian (UTF-16LE)"
 msgstr "Unicode 16 bit Little Endian (UTF-16LE)"
 
-#: ../src/common/fmapbase.cpp:187 ../src/common/fmapbase.cpp:193
+#: ../src/common/fmapbase.cpp:184 ../src/common/fmapbase.cpp:190
 msgid "Unicode 32 bit (UTF-32)"
 msgstr "Unicode 32 bit (UTF-32)"
 
-#: ../src/common/fmapbase.cpp:192
+#: ../src/common/fmapbase.cpp:189
 msgid "Unicode 32 bit Big Endian (UTF-32BE)"
 msgstr "Unicode 32 bit Big Endian (UTF-32BE)"
 
-#: ../src/common/fmapbase.cpp:188
+#: ../src/common/fmapbase.cpp:185
 msgid "Unicode 32 bit Little Endian (UTF-32LE)"
 msgstr "Unicode 32 bit Little Endian (UTF-32LE)"
 
-#: ../src/common/fmapbase.cpp:182
+#: ../src/common/fmapbase.cpp:179
 msgid "Unicode 7 bit (UTF-7)"
 msgstr "Unicode 7 bit (UTF-7)"
 
-#: ../src/common/fmapbase.cpp:183
+#: ../src/common/fmapbase.cpp:180
 msgid "Unicode 8 bit (UTF-8)"
 msgstr "Unicode 8 bit (UTF-8)"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "Unindent"
 msgstr "Unindent"
 
@@ -7318,7 +7606,8 @@ msgstr "Unit untuk lebar ikhtisar bawah."
 msgid "Units for the bottom padding."
 msgstr "Unit untuk padding bawah."
 
-#: ../src/richtext/richtextsizepage.cpp:664 ../src/richtext/richtextsizepage.cpp:666
+#: ../src/richtext/richtextsizepage.cpp:664
+#: ../src/richtext/richtextsizepage.cpp:666
 msgid "Units for the bottom position."
 msgstr "Unit untuk posisi dibawah."
 
@@ -7347,31 +7636,38 @@ msgstr "Unit untuk lebar ikhtisar kiri."
 msgid "Units for the left padding."
 msgstr "Unit untuk padding kiri."
 
-#: ../src/richtext/richtextsizepage.cpp:559 ../src/richtext/richtextsizepage.cpp:561
+#: ../src/richtext/richtextsizepage.cpp:559
+#: ../src/richtext/richtextsizepage.cpp:561
 msgid "Units for the left position."
 msgstr "Unit untuk posisi dikiri."
 
-#: ../src/richtext/richtextsizepage.cpp:485 ../src/richtext/richtextsizepage.cpp:487
+#: ../src/richtext/richtextsizepage.cpp:485
+#: ../src/richtext/richtextsizepage.cpp:487
 msgid "Units for the maximum object height."
 msgstr "Unit untuk tinggi maksimum obyek."
 
-#: ../src/richtext/richtextsizepage.cpp:458 ../src/richtext/richtextsizepage.cpp:460
+#: ../src/richtext/richtextsizepage.cpp:458
+#: ../src/richtext/richtextsizepage.cpp:460
 msgid "Units for the maximum object width."
 msgstr "Unit untuk lebar maksimum obyek."
 
-#: ../src/richtext/richtextsizepage.cpp:431 ../src/richtext/richtextsizepage.cpp:433
+#: ../src/richtext/richtextsizepage.cpp:431
+#: ../src/richtext/richtextsizepage.cpp:433
 msgid "Units for the minimum object height."
 msgstr "Unit untuk tinggi minimum obyek."
 
-#: ../src/richtext/richtextsizepage.cpp:404 ../src/richtext/richtextsizepage.cpp:406
+#: ../src/richtext/richtextsizepage.cpp:404
+#: ../src/richtext/richtextsizepage.cpp:406
 msgid "Units for the minimum object width."
 msgstr "Unit untuk lebar minimum obyek."
 
-#: ../src/richtext/richtextsizepage.cpp:377 ../src/richtext/richtextsizepage.cpp:379
+#: ../src/richtext/richtextsizepage.cpp:377
+#: ../src/richtext/richtextsizepage.cpp:379
 msgid "Units for the object height."
 msgstr "Unit untuk tinggi obyek."
 
-#: ../src/richtext/richtextsizepage.cpp:343 ../src/richtext/richtextsizepage.cpp:345
+#: ../src/richtext/richtextsizepage.cpp:343
+#: ../src/richtext/richtextsizepage.cpp:345
 msgid "Units for the object width."
 msgstr "Unit untuk lebar obyek."
 
@@ -7395,7 +7691,8 @@ msgstr "Unit untuk lebar ikhtisar kanan."
 msgid "Units for the right padding."
 msgstr "Unit untuk padding kiri."
 
-#: ../src/richtext/richtextsizepage.cpp:629 ../src/richtext/richtextsizepage.cpp:631
+#: ../src/richtext/richtextsizepage.cpp:629
+#: ../src/richtext/richtextsizepage.cpp:631
 msgid "Units for the right position."
 msgstr "Unit untuk untuk posisi kanan."
 
@@ -7419,7 +7716,8 @@ msgstr "Unit untuk lebar ikhtisar atas."
 msgid "Units for the top padding."
 msgstr "Unit untuk padding atas."
 
-#: ../src/richtext/richtextsizepage.cpp:594 ../src/richtext/richtextsizepage.cpp:596
+#: ../src/richtext/richtextsizepage.cpp:594
+#: ../src/richtext/richtextsizepage.cpp:596
 msgid "Units for the top position."
 msgstr "Unit untuk posisi atas."
 
@@ -7434,97 +7732,102 @@ msgstr "Unit untuk posisi atas."
 msgid "Units for this value."
 msgstr "Unit untuk nilai ini."
 
-#: ../src/generic/progdlgg.cpp:353 ../src/generic/progdlgg.cpp:622
+#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
 msgid "Unknown"
 msgstr "Tidak dikenal"
 
-#: ../src/msw/dde.cpp:1174
+#: ../src/msw/dde.cpp:1238
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Galat DDE %08x tidak dikenal"
 
-#: ../src/common/xtistrm.cpp:410
+#: ../src/common/xtistrm.cpp:407
 msgid "Unknown Object passed to GetObjectClassInfo"
 msgstr "Obyek tidak dikenal disampaikan ke GetObjectClassInfo"
 
-#: ../src/common/imagpng.cpp:366
+#: ../src/common/imagpng.cpp:383
 #, c-format
 msgid "Unknown PNG resolution unit %d"
 msgstr "Ukuran resolusi PNG %d tidak dikenal"
 
-#: ../src/common/xtixml.cpp:327
+#: ../src/common/xtixml.cpp:323
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Properti %s tidak dikenal"
 
-#: ../src/common/imagtiff.cpp:529
+#: ../src/common/imagtiff.cpp:526
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "Ukuran resolusi TIFF %d yang tidak dikenal diabaikan"
 
-#: ../src/unix/dlunix.cpp:160
+#: ../src/propgrid/props.cpp:155
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/unix/dlunix.cpp:118
 msgid "Unknown dynamic library error"
 msgstr "Galat kepustakaan dinamis tidak dikenal"
 
-#: ../src/common/fmapbase.cpp:810
+#: ../src/common/fmapbase.cpp:806
 #, c-format
 msgid "Unknown encoding (%d)"
 msgstr "Pengkodean (%d) tidak dikenal"
 
-#: ../src/msw/ole/automtn.cpp:688
+#: ../src/msw/ole/automtn.cpp:679
 #, c-format
 msgid "Unknown error %08x"
 msgstr "Galat tidak dikenali %08x"
 
-#: ../src/msw/ole/automtn.cpp:647
+#: ../src/msw/ole/automtn.cpp:638
 msgid "Unknown exception"
 msgstr "Pengecualian yang tidak dikenali"
 
-#: ../src/common/image.cpp:2839
+#: ../src/common/image.cpp:2942
 msgid "Unknown image data format."
 msgstr "Format citra data tidak dikenal."
 
-#: ../src/common/cmdline.cpp:914
+#: ../src/common/cmdline.cpp:910
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Pilihan panjang '%s' tidak dikenal"
 
-#: ../src/msw/ole/automtn.cpp:631
+#: ../src/msw/ole/automtn.cpp:622
 msgid "Unknown name or named argument."
 msgstr "Nama atau argumen tidak dikenali."
 
-#: ../src/common/cmdline.cpp:929 ../src/common/cmdline.cpp:951
+#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Pilihan '%s' tidak diketahui"
 
-#: ../src/common/mimecmn.cpp:225
+#: ../src/common/mimecmn.cpp:221
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "'{' tanpa pasangan dalam entri mime type %s."
 
-#: ../src/common/cmdproc.cpp:262 ../src/common/cmdproc.cpp:288
-#: ../src/common/cmdproc.cpp:308
+#: ../src/common/cmdproc.cpp:255 ../src/common/cmdproc.cpp:281
+#: ../src/common/cmdproc.cpp:301
 msgid "Unnamed command"
 msgstr "Perintah tak bernama"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:413
+#: ../src/propgrid/propgrid.cpp:392
 msgid "Unspecified"
 msgstr "Tidak dijabarkan"
 
-#: ../src/msw/clipbrd.cpp:311
+#: ../src/msw/clipbrd.cpp:325
 msgid "Unsupported clipboard format."
 msgstr "Format clipboard tidak didukung."
 
-#: ../src/common/appcmn.cpp:256
+#: ../src/common/appcmn.cpp:277
 #, c-format
 msgid "Unsupported theme '%s'."
 msgstr "Tema '%s' tidak didukung."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:205
-#: ../src/common/accelcmn.cpp:63
+#: ../src/common/stockitem.cpp:202 ../src/common/accelcmn.cpp:60
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Up"
 msgstr "Up"
 
@@ -7538,7 +7841,7 @@ msgstr "Huruf besar"
 msgid "Upper case roman numerals"
 msgstr "Huruf besar romawi"
 
-#: ../src/common/cmdline.cpp:1326
+#: ../src/common/cmdline.cpp:1322
 #, c-format
 msgid "Usage: %s"
 msgstr "Penggunaan: %s"
@@ -7547,64 +7850,81 @@ msgstr "Penggunaan: %s"
 msgid "Use &shadow"
 msgstr "Gunakan &bayangan"
 
-#: ../src/richtext/richtextindentspage.cpp:169
-#: ../src/richtext/richtextindentspage.cpp:171
 #: ../src/richtext/richtextliststylepage.cpp:358
 #: ../src/richtext/richtextliststylepage.cpp:360
+#: ../src/richtext/richtextindentspage.cpp:169
+#: ../src/richtext/richtextindentspage.cpp:171
 msgid "Use the current alignment setting."
 msgstr "Gunakan pengaturan penjajaran."
 
-#: ../src/common/valtext.cpp:179
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/gtk/font.cpp:552
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/common/valtext.cpp:142
 msgid "Validation conflict"
 msgstr "Konflik validasi"
 
-#: ../src/propgrid/manager.cpp:238
+#: ../src/propgrid/manager.cpp:224
 msgid "Value"
 msgstr "Nilai"
 
-#: ../src/propgrid/props.cpp:386 ../src/propgrid/props.cpp:500
+#: ../src/propgrid/props.cpp:309
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "Nilai harus %s atau lebih besar."
 
-#: ../src/propgrid/props.cpp:417 ../src/propgrid/props.cpp:531
+#: ../src/propgrid/props.cpp:336
 #, c-format
 msgid "Value must be %s or less."
 msgstr "Nilai harus %s atau lebih kecil."
 
-#: ../src/propgrid/props.cpp:393 ../src/propgrid/props.cpp:424
-#: ../src/propgrid/props.cpp:507 ../src/propgrid/props.cpp:538
+#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "Nilai harus di antara %s dan %s."
 
-#: ../src/generic/aboutdlgg.cpp:128
+#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Versi "
 
-#: ../src/richtext/richtextsizepage.cpp:291 ../src/richtext/richtextsizepage.cpp:293
+#: ../src/richtext/richtextsizepage.cpp:291
+#: ../src/richtext/richtextsizepage.cpp:293
 msgid "Vertical alignment."
 msgstr "Penjajaran vertikal."
 
-#: ../src/generic/filedlgg.cpp:202
+#: ../src/generic/filedlgg.cpp:199
 msgid "View files as a detailed view"
 msgstr "Tampilkan berkas dalam tampilan rinci"
 
-#: ../src/generic/filedlgg.cpp:200
+#: ../src/generic/filedlgg.cpp:197
 msgid "View files as a list view"
 msgstr "Tampilkan berkas dalam tampilan daftar"
 
-#: ../src/common/docview.cpp:1970
+#: ../src/common/docview.cpp:1975
 msgid "Views"
 msgstr "Tampilan"
 
+#: ../src/gtk/app.cpp:348
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1777
+#: ../src/propgrid/advprops.cpp:1678
 msgid "Wait"
 msgstr "Tunggu"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1779
+#: ../src/propgrid/advprops.cpp:1680
 msgid "Wait Arrow"
 msgstr "Panah Tunggu"
 
@@ -7613,239 +7933,238 @@ msgstr "Panah Tunggu"
 msgid "Waiting for IO on epoll descriptor %d failed"
 msgstr "Menunggu IO di deskriptor epoll %d gagal"
 
-#: ../src/common/log.cpp:223
+#: ../src/common/log.cpp:241
 msgid "Warning: "
 msgstr "Peringatan: "
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1778
+#: ../src/propgrid/advprops.cpp:1679
 msgid "Watch"
 msgstr "Jam"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:685
+#: ../src/propgrid/advprops.cpp:595
 msgid "Weight"
 msgstr "Berat"
 
-#: ../src/common/fmapbase.cpp:148
+#: ../src/common/fmapbase.cpp:145
 msgid "Western European (ISO-8859-1)"
 msgstr "Western European (ISO-8859-1)"
 
-#: ../src/common/fmapbase.cpp:162
+#: ../src/common/fmapbase.cpp:159
 msgid "Western European with Euro (ISO-8859-15)"
 msgstr "Western European with Euro (ISO-8859-15)"
 
-#: ../src/generic/fontdlgg.cpp:446 ../src/generic/fontdlgg.cpp:448
+#: ../src/generic/fontdlgg.cpp:443 ../src/generic/fontdlgg.cpp:445
 msgid "Whether the font is underlined."
 msgstr "Apakah font bergarisbawah."
 
-#: ../src/propgrid/advprops.cpp:1611
+#: ../src/propgrid/advprops.cpp:1517
 msgid "White"
 msgstr "Putih"
 
-#: ../src/generic/fdrepdlg.cpp:144
+#: ../src/generic/fdrepdlg.cpp:141
 msgid "Whole word"
 msgstr "Seluruh kata"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:532
 msgid "Whole words only"
 msgstr "Hanya seluruh kata"
 
-#: ../src/univ/themes/win32.cpp:1102
+#: ../src/univ/themes/win32.cpp:1099
 msgid "Win32 theme"
 msgstr "Tema Win32"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:893
+#: ../src/propgrid/advprops.cpp:794
 msgid "Window"
 msgstr "Window"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:894
+#: ../src/propgrid/advprops.cpp:795
 msgid "WindowFrame"
 msgstr "WindowFrame"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:895
+#: ../src/propgrid/advprops.cpp:796
 msgid "WindowText"
 msgstr "WindowText"
 
-#: ../src/common/fmapbase.cpp:177
+#: ../src/common/fmapbase.cpp:174
 msgid "Windows Arabic (CP 1256)"
 msgstr "Windows Arabic (CP 1256)"
 
-#: ../src/common/fmapbase.cpp:178
+#: ../src/common/fmapbase.cpp:175
 msgid "Windows Baltic (CP 1257)"
 msgstr "Windows Baltic (CP 1257)"
 
-#: ../src/common/fmapbase.cpp:171
+#: ../src/common/fmapbase.cpp:168
 msgid "Windows Central European (CP 1250)"
 msgstr "Windows Central European (CP 1250)"
 
-#: ../src/common/fmapbase.cpp:168
+#: ../src/common/fmapbase.cpp:165
 msgid "Windows Chinese Simplified (CP 936) or GB-2312"
 msgstr "Windows Chinese Simplified (CP 936) or GB-2312"
 
-#: ../src/common/fmapbase.cpp:170
+#: ../src/common/fmapbase.cpp:167
 msgid "Windows Chinese Traditional (CP 950) or Big-5"
 msgstr "Windows Chinese Traditional (CP 950) or Big-5"
 
-#: ../src/common/fmapbase.cpp:172
+#: ../src/common/fmapbase.cpp:169
 msgid "Windows Cyrillic (CP 1251)"
 msgstr "Windows Cyrillic (CP 1251)"
 
-#: ../src/common/fmapbase.cpp:174
+#: ../src/common/fmapbase.cpp:171
 msgid "Windows Greek (CP 1253)"
 msgstr "Windows Greek (CP 1253)"
 
-#: ../src/common/fmapbase.cpp:176
+#: ../src/common/fmapbase.cpp:173
 msgid "Windows Hebrew (CP 1255)"
 msgstr "Windows Hebrew (CP 1255)"
 
-#: ../src/common/fmapbase.cpp:167
+#: ../src/common/fmapbase.cpp:164
 msgid "Windows Japanese (CP 932) or Shift-JIS"
 msgstr "Windows Japanese (CP 932) or Shift-JIS"
 
-#: ../src/common/fmapbase.cpp:180
+#: ../src/common/fmapbase.cpp:177
 msgid "Windows Johab (CP 1361)"
 msgstr "Windows Johab (CP 1361)"
 
-#: ../src/common/fmapbase.cpp:169
+#: ../src/common/fmapbase.cpp:166
 msgid "Windows Korean (CP 949)"
 msgstr "Windows Korean (CP 949)"
 
-#: ../src/common/fmapbase.cpp:166
+#: ../src/common/fmapbase.cpp:163
 msgid "Windows Thai (CP 874)"
 msgstr "Windows Thai (CP 874)"
 
-#: ../src/common/fmapbase.cpp:175
+#: ../src/common/fmapbase.cpp:172
 msgid "Windows Turkish (CP 1254)"
 msgstr "Windows Turkish (CP 1254)"
 
-#: ../src/common/fmapbase.cpp:179
+#: ../src/common/fmapbase.cpp:176
 msgid "Windows Vietnamese (CP 1258)"
 msgstr "Windows Vietnamese (CP 1258)"
 
-#: ../src/common/fmapbase.cpp:173
+#: ../src/common/fmapbase.cpp:170
 msgid "Windows Western European (CP 1252)"
 msgstr "Windows Western European (CP 1252)"
 
-#: ../src/common/fmapbase.cpp:181
+#: ../src/common/fmapbase.cpp:178
 msgid "Windows/DOS OEM (CP 437)"
 msgstr "Windows/DOS OEM (CP 437)"
 
-#: ../src/common/fmapbase.cpp:165
+#: ../src/common/fmapbase.cpp:162
 msgid "Windows/DOS OEM Cyrillic (CP 866)"
 msgstr "Windows/DOS OEM Cyrillic (CP 866)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:111
+#: ../src/common/accelcmn.cpp:109
 msgid "Windows_Left"
 msgstr "Windows_Left"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:113
+#: ../src/common/accelcmn.cpp:111
 msgid "Windows_Menu"
 msgstr "Windows_Menu"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:112
+#: ../src/common/accelcmn.cpp:110
 msgid "Windows_Right"
 msgstr "Windows_Right"
 
-#: ../src/common/ffile.cpp:150
+#: ../src/common/ffile.cpp:149
 #, c-format
 msgid "Write error on file '%s'"
 msgstr "Kesalahan menulis pada file '%s'"
 
-#: ../src/xml/xml.cpp:914
+#: ../src/xml/xml.cpp:925
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "Kesalahan parsing XML: '%s' pada baris %d"
 
-#: ../src/common/xpmdecod.cpp:796
+#: ../src/common/xpmdecod.cpp:794
 msgid "XPM: Malformed pixel data!"
 msgstr "XPM: Data pixel salah bentuk!"
 
-#: ../src/common/xpmdecod.cpp:705
+#: ../src/common/xpmdecod.cpp:702
 #, c-format
 msgid "XPM: incorrect colour description in line %d"
 msgstr "XPM: deskripsi warna salah pada baris %d"
 
-#: ../src/common/xpmdecod.cpp:680
+#: ../src/common/xpmdecod.cpp:677
 msgid "XPM: incorrect header format!"
 msgstr "XPM: format header salah!"
 
-#: ../src/common/xpmdecod.cpp:716 ../src/common/xpmdecod.cpp:725
+#: ../src/common/xpmdecod.cpp:714 ../src/common/xpmdecod.cpp:723
 #, c-format
 msgid "XPM: malformed colour definition '%s' at line %d!"
 msgstr "XPM: definisi warna cacat '%s' pada baris %d!"
 
-#: ../src/common/xpmdecod.cpp:755
+#: ../src/common/xpmdecod.cpp:753
 msgid "XPM: no colors left to use for mask!"
 msgstr "XPM: tidak ada sisa warna untuk mask!"
 
-#: ../src/common/xpmdecod.cpp:782
+#: ../src/common/xpmdecod.cpp:780
 #, c-format
 msgid "XPM: truncated image data at line %d!"
 msgstr "XPM: citra terpotong pada baris %d!"
 
-#: ../src/propgrid/advprops.cpp:1610
+#: ../src/propgrid/advprops.cpp:1516
 msgid "Yellow"
 msgstr "Kuning"
 
-#: ../include/wx/msgdlg.h:276 ../src/common/stockitem.cpp:206
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:203
 #: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Ya"
 
-#: ../src/osx/carbon/overlay.cpp:155
-msgid "You cannot Clear an overlay that is not inited"
-msgstr "Kamu tidak dapat membersihkan overlay yang belum di init"
-
-#: ../src/osx/carbon/overlay.cpp:107 ../src/dfb/overlay.cpp:61
-msgid "You cannot Init an overlay twice"
-msgstr "Jangan menginisiasi overlay dua kali"
-
-#: ../src/generic/dirdlgg.cpp:287
+#: ../src/generic/dirdlgg.cpp:284
 msgid "You cannot add a new directory to this section."
 msgstr "Anda tidak dapat menambah direktori baru ke bagian ini."
 
-#: ../src/propgrid/propgrid.cpp:3299
+#: ../src/propgrid/propgrid.cpp:3276
 msgid "You have entered invalid value. Press ESC to cancel editing."
-msgstr "Kamu telah mengisi nilai yang salah. Tekan ESC untuk membatalkan suntingan."
+msgstr ""
+"Kamu telah mengisi nilai yang salah. Tekan ESC untuk membatalkan suntingan."
 
-#: ../src/common/stockitem.cpp:209
+#: ../src/osx/cocoa/menu.mm:286
+#, fuzzy
+msgid "Zoom"
+msgstr "Perbesar"
+
+#: ../src/common/stockitem.cpp:206
 msgid "Zoom &In"
 msgstr "Per&besar"
 
-#: ../src/common/stockitem.cpp:210
+#: ../src/common/stockitem.cpp:207
 msgid "Zoom &Out"
 msgstr "Per&kecil"
 
-#: ../src/common/stockitem.cpp:209 ../src/common/prntbase.cpp:1594
+#: ../src/common/stockitem.cpp:206 ../src/common/prntbase.cpp:1619
 msgid "Zoom In"
 msgstr "Perbesar"
 
-#: ../src/common/stockitem.cpp:210 ../src/common/prntbase.cpp:1580
+#: ../src/common/stockitem.cpp:207 ../src/common/prntbase.cpp:1605
 msgid "Zoom Out"
 msgstr "Perkecil"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to &Fit"
 msgstr "Perbesar agar &Pas"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to Fit"
 msgstr "Perbesar agar Pas"
 
-#: ../src/msw/dde.cpp:1141
+#: ../src/msw/dde.cpp:1205
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "aplikasi DDEML telah menciptakan kondisi race berkesinambungan."
 
-#: ../src/msw/dde.cpp:1129
+#: ../src/msw/dde.cpp:1193
 msgid ""
-"a DDEML function was called without first calling the DdeInitialize function,\n"
+"a DDEML function was called without first calling the DdeInitialize "
+"function,\n"
 "or an invalid instance identifier\n"
 "was passed to a DDEML function."
 msgstr ""
@@ -7853,39 +8172,39 @@ msgstr ""
 "atau suatu identifikasi instan yang tidak sah\n"
 "disampaikan ke suatu fungsi DDEML."
 
-#: ../src/msw/dde.cpp:1147
+#: ../src/msw/dde.cpp:1211
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "usaha dari klien untuk memulai percakapan telah gagal."
 
-#: ../src/msw/dde.cpp:1144
+#: ../src/msw/dde.cpp:1208
 msgid "a memory allocation failed."
 msgstr "alokasi memori gagal."
 
-#: ../src/msw/dde.cpp:1138
+#: ../src/msw/dde.cpp:1202
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "parameter gagal divalidasi oleh DDEML."
 
-#: ../src/msw/dde.cpp:1120
+#: ../src/msw/dde.cpp:1184
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "permintaan untuk transaksi advise sinkron telah habis waktunya."
 
-#: ../src/msw/dde.cpp:1126
+#: ../src/msw/dde.cpp:1190
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "permintaan untuk transaksi data sinkron telah habis waktunya."
 
-#: ../src/msw/dde.cpp:1135
+#: ../src/msw/dde.cpp:1199
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "permintaan untuk transaksi eksekusi sinkron telah habis waktunya."
 
-#: ../src/msw/dde.cpp:1153
+#: ../src/msw/dde.cpp:1217
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "permintaan untuk transaksi poke sinkron telah habis waktunya."
 
-#: ../src/msw/dde.cpp:1168
+#: ../src/msw/dde.cpp:1232
 msgid "a request to end an advise transaction has timed out."
 msgstr "permintaan untuk mengakhiri transaksi advise telah habis waktunya."
 
-#: ../src/msw/dde.cpp:1162
+#: ../src/msw/dde.cpp:1226
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -7895,15 +8214,15 @@ msgstr ""
 "yang dihentikan oleh klien, atau server\n"
 "dihentikan sebelum menyelesaikan transaksi."
 
-#: ../src/msw/dde.cpp:1150
+#: ../src/msw/dde.cpp:1214
 msgid "a transaction failed."
 msgstr "transaksi gagal."
 
-#: ../src/common/accelcmn.cpp:189
+#: ../src/common/accelcmn.cpp:188
 msgid "alt"
 msgstr "alt"
 
-#: ../src/msw/dde.cpp:1132
+#: ../src/msw/dde.cpp:1196
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -7915,15 +8234,15 @@ msgstr ""
 "atau aplikasi yang diinisialisasi sebagai APPCMD_CLIENTONLY telah \n"
 "berusaha melaksanakan transaksi server."
 
-#: ../src/msw/dde.cpp:1156
+#: ../src/msw/dde.cpp:1220
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "panggilan internal ke fungsi PostMessage telah gagal. "
 
-#: ../src/msw/dde.cpp:1165
+#: ../src/msw/dde.cpp:1229
 msgid "an internal error has occurred in the DDEML."
 msgstr "kesalahan internal muncul dalam DDEML."
 
-#: ../src/msw/dde.cpp:1171
+#: ../src/msw/dde.cpp:1235
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -7933,56 +8252,56 @@ msgstr ""
 "Saat aplikasi kembali dari callback XTYP_XACT_COMPLETE,\n"
 "pengenal transaksi untuk callback tersebut tidak lagi sah."
 
-#: ../src/common/zipstrm.cpp:1483
+#: ../src/common/zipstrm.cpp:1522
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "mengasumsikan ini adalah berbagai berkas zip yang disambung"
 
-#: ../src/common/fileconf.cpp:1847
+#: ../src/common/fileconf.cpp:1849
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "mengabaikan usaha untuk mengubah kunci immutable '%s'."
 
-#: ../src/html/chm.cpp:329
+#: ../src/html/chm.cpp:326
 msgid "bad arguments to library function"
 msgstr "salah argumen ke fungsi pustaka"
 
-#: ../src/html/chm.cpp:341
+#: ../src/html/chm.cpp:338
 msgid "bad signature"
 msgstr "tanda tangan salah"
 
-#: ../src/common/zipstrm.cpp:1918
+#: ../src/common/zipstrm.cpp:1988
 msgid "bad zipfile offset to entry"
 msgstr "salah offset di berkas zip terhadap entri"
 
-#: ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400
 msgid "binary"
 msgstr "biner"
 
-#: ../src/common/fontcmn.cpp:996
+#: ../src/common/fontcmn.cpp:1195
 msgid "bold"
 msgstr "tebal"
 
-#: ../src/msw/utils.cpp:1144
+#: ../src/msw/utils.cpp:1135
 #, c-format
 msgid "build %lu"
 msgstr "versi %lu"
 
-#: ../src/common/ffile.cpp:75
+#: ../src/common/ffile.cpp:73
 #, c-format
 msgid "can't close file '%s'"
 msgstr "gagal menutup berkas '%s'"
 
-#: ../src/common/file.cpp:245
+#: ../src/common/file.cpp:242
 #, c-format
 msgid "can't close file descriptor %d"
 msgstr "gagal menutup file descriptor %d"
 
-#: ../src/common/file.cpp:586
+#: ../src/common/ffile.cpp:382 ../src/common/file.cpp:613
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "gagal menerapkan perubahan ke berkas '%s'"
 
-#: ../src/common/file.cpp:178
+#: ../src/common/file.cpp:175
 #, c-format
 msgid "can't create file '%s'"
 msgstr "gagal menciptakan berkas '%s'"
@@ -7992,49 +8311,49 @@ msgstr "gagal menciptakan berkas '%s'"
 msgid "can't delete user configuration file '%s'"
 msgstr "gagal menghapus berkas konfigurasi pemakai '%s'"
 
-#: ../src/common/file.cpp:495
+#: ../src/common/file.cpp:522
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr "gagal menentukan apakah akhir berkas telah dicapai pada descriptor %d"
 
-#: ../src/common/zipstrm.cpp:1692
+#: ../src/common/zipstrm.cpp:1747
 msgid "can't find central directory in zip"
 msgstr "gagal menemukan sentral direktori pada zip"
 
-#: ../src/common/file.cpp:465
+#: ../src/common/file.cpp:492
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "gagal menentukan panjang berkas pada file descriptor %d"
 
-#: ../src/msw/utils.cpp:341
+#: ../src/msw/utils.cpp:336
 msgid "can't find user's HOME, using current directory."
 msgstr "gagal menemukan HOME pemakai, menggunakan direktori aktif saat ini."
 
-#: ../src/common/file.cpp:366
+#: ../src/common/file.cpp:407
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "gagal mem-flush file descriptor %d"
 
-#: ../src/common/file.cpp:422
+#: ../src/common/file.cpp:463
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "gagal memperoleh posisi seek pada file descriptor %d"
 
-#: ../src/common/fontmap.cpp:325
+#: ../src/common/fontmap.cpp:322
 msgid "can't load any font, aborting"
 msgstr "gagal memuat font apapun, menggugurkan"
 
-#: ../src/common/file.cpp:231 ../src/common/ffile.cpp:59
+#: ../src/common/ffile.cpp:57 ../src/common/file.cpp:228
 #, c-format
 msgid "can't open file '%s'"
 msgstr "gagal membuka berkas '%s'"
 
-#: ../src/common/fileconf.cpp:320
+#: ../src/common/fileconf.cpp:314
 #, c-format
 msgid "can't open global configuration file '%s'."
 msgstr "gagal membuka berkas konfigurasi global '%s'."
 
-#: ../src/common/fileconf.cpp:336
+#: ../src/common/fileconf.cpp:330
 #, c-format
 msgid "can't open user configuration file '%s'."
 msgstr "gagal membuka berkas konfigurasi pemakai '%s'."
@@ -8043,40 +8362,40 @@ msgstr "gagal membuka berkas konfigurasi pemakai '%s'."
 msgid "can't open user configuration file."
 msgstr "gagal membuka berkas konfigurasi pemakai."
 
-#: ../src/common/zipstrm.cpp:579
+#: ../src/common/zipstrm.cpp:572
 msgid "can't re-initialize zlib deflate stream"
 msgstr "gagal menyiapkan zlib deflate stream"
 
-#: ../src/common/zipstrm.cpp:604
+#: ../src/common/zipstrm.cpp:597
 msgid "can't re-initialize zlib inflate stream"
 msgstr "gagal menyiapkan zlib inflate stream"
 
-#: ../src/common/file.cpp:304
+#: ../src/common/file.cpp:345
 #, c-format
 msgid "can't read from file descriptor %d"
 msgstr "gagal membaca dari file descriptor %d"
 
-#: ../src/common/file.cpp:581
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:608
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "gagal menghapus file '%s'"
 
-#: ../src/common/file.cpp:598
+#: ../src/common/ffile.cpp:394 ../src/common/file.cpp:625
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "gagal menghapus berkas sementara '%s'"
 
-#: ../src/common/file.cpp:408
+#: ../src/common/file.cpp:449
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "gagal melakukan seek pada file descriptor %d"
 
-#: ../src/common/textfile.cpp:273
+#: ../src/common/textfile.cpp:161
 #, c-format
 msgid "can't write buffer '%s' to disk."
 msgstr "gagal menulis buffer '%s' ke disk."
 
-#: ../src/common/file.cpp:323
+#: ../src/common/file.cpp:364
 #, c-format
 msgid "can't write to file descriptor %d"
 msgstr "gagal menulis ke file descriptor %d"
@@ -8086,22 +8405,28 @@ msgid "can't write user configuration file."
 msgstr "gagal menulis berkas konfigurasi pemakai."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:482 ../src/generic/datavgen.cpp:1261
+#: ../src/common/datavcmn.cpp:2064 ../src/generic/datavgen.cpp:1384
 msgid "checked"
 msgstr "tercentang"
 
-#: ../src/html/chm.cpp:345
+#: ../src/html/chm.cpp:342
 msgid "checksum error"
 msgstr "galat checksum"
 
-#: ../src/common/tarstrm.cpp:820
+#: ../src/common/tarstrm.cpp:814
 msgid "checksum failure reading tar header block"
 msgstr "gagal checksum berkas tar"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:226
-#: ../src/richtext/richtextbackgroundpage.cpp:249
-#: ../src/richtext/richtextbackgroundpage.cpp:289
-#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
 #: ../src/richtext/richtextborderspage.cpp:254
 #: ../src/richtext/richtextborderspage.cpp:288
 #: ../src/richtext/richtextborderspage.cpp:322
@@ -8119,99 +8444,127 @@ msgstr "gagal checksum berkas tar"
 #: ../src/richtext/richtextmarginspage.cpp:340
 #: ../src/richtext/richtextmarginspage.cpp:363
 #: ../src/richtext/richtextmarginspage.cpp:388
-#: ../src/richtext/richtextsizepage.cpp:339 ../src/richtext/richtextsizepage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:400 ../src/richtext/richtextsizepage.cpp:427
-#: ../src/richtext/richtextsizepage.cpp:454 ../src/richtext/richtextsizepage.cpp:481
-#: ../src/richtext/richtextsizepage.cpp:555 ../src/richtext/richtextsizepage.cpp:590
-#: ../src/richtext/richtextsizepage.cpp:625 ../src/richtext/richtextsizepage.cpp:660
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
 msgid "cm"
 msgstr "cm"
 
-#: ../src/html/chm.cpp:347
+#: ../src/html/chm.cpp:344
 msgid "compression error"
 msgstr "galat kompresi"
 
-#: ../src/common/regex.cpp:236
+#: ../src/common/regex.cpp:233
 msgid "conversion to 8-bit encoding failed"
 msgstr "konversi ke enkoding 8-bit gagal"
 
-#: ../src/common/accelcmn.cpp:187
+#: ../src/common/accelcmn.cpp:186
 msgid "ctrl"
 msgstr "ctrl"
 
-#: ../src/common/cmdline.cpp:1500
+#: ../src/common/cmdline.cpp:1496
 msgid "date"
 msgstr "tanggal"
 
-#: ../src/html/chm.cpp:349
+#: ../src/html/chm.cpp:346
 msgid "decompression error"
 msgstr "galat dekompresi"
 
-#: ../src/richtext/richtextstyles.cpp:780 ../src/common/fmapbase.cpp:820
+#: ../src/common/fmapbase.cpp:816 ../src/richtext/richtextstyles.cpp:777
 msgid "default"
 msgstr "default"
 
-#: ../src/common/cmdline.cpp:1496
+#: ../src/common/cmdline.cpp:1492
 msgid "double"
 msgstr "ganda"
 
-#: ../src/common/debugrpt.cpp:538
+#: ../src/common/debugrpt.cpp:539
 msgid "dump of the process state (binary)"
 msgstr "dump dari keadaan proses (biner)"
 
-#: ../src/common/datetimefmt.cpp:1969
+#: ../src/common/datetimefmt.cpp:1992
 msgid "eighteenth"
 msgstr "kedelapanbelas"
 
-#: ../src/common/datetimefmt.cpp:1959
+#: ../src/common/datetimefmt.cpp:1982
 msgid "eighth"
 msgstr "kedelapan"
 
-#: ../src/common/datetimefmt.cpp:1962
+#: ../src/common/datetimefmt.cpp:1985
 msgid "eleventh"
 msgstr "kesebelas"
 
-#: ../src/common/fileconf.cpp:1833
+#: ../src/common/fileconf.cpp:1835
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "entri '%s' muncul lebih dari sekali dalam grup '%s'"
 
-#: ../src/html/chm.cpp:343
+#: ../src/html/chm.cpp:340
 msgid "error in data format"
 msgstr "galat pada format data"
 
-#: ../src/html/chm.cpp:331
+#: ../src/html/chm.cpp:328
 msgid "error opening file"
 msgstr "galat membuka berkas"
 
-#: ../src/common/zipstrm.cpp:1778
+#: ../src/common/zipstrm.cpp:1836
 msgid "error reading zip central directory"
 msgstr "galat membaca sentral direktori zip"
 
-#: ../src/common/zipstrm.cpp:1870
+#: ../src/common/zipstrm.cpp:1940
 msgid "error reading zip local header"
 msgstr "galat membaca berkas zip"
 
-#: ../src/common/zipstrm.cpp:2531
+#: ../src/common/zipstrm.cpp:2615
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "galat membuat berkas zip '%s': crc rusak"
 
-#: ../src/common/ffile.cpp:188
+#: ../src/common/zipstrm.cpp:2608
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "galat membuat berkas zip '%s': crc rusak"
+
+#: ../src/common/fontcmn.cpp:1205
+#, fuzzy
+msgid "extrabold"
+msgstr "tebal"
+
+#: ../src/common/fontcmn.cpp:1223
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1167
+#, fuzzy
+msgid "extralight"
+msgstr "ringan"
+
+#: ../src/msw/webview_ie.cpp:1036
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "Gagal mengeksekusi '%s'\n"
+
+#: ../src/common/ffile.cpp:187
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "gagal mem-flush berkas '%s'"
 
+#: ../src/msw/webview_ie.cpp:1045
+#, fuzzy
+msgid "failed to retrieve execution result"
+msgstr "Gagal mengambil teks dari pesan kesalahan RAS"
+
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1030
+#: ../src/generic/datavgen.cpp:1150
 msgid "false"
 msgstr "false"
 
-#: ../src/common/datetimefmt.cpp:1966
+#: ../src/common/datetimefmt.cpp:1989
 msgid "fifteenth"
 msgstr "kelimabelas"
 
-#: ../src/common/datetimefmt.cpp:1956
+#: ../src/common/datetimefmt.cpp:1979
 msgid "fifth"
 msgstr "kelima"
 
@@ -8240,129 +8593,150 @@ msgstr "berkas '%s', baris %zu: nilai untuk kunci immutable '%s' diabaikan."
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "berkas '%s': karakter %c tidak diharapkan pada baris %zu."
 
-#: ../src/richtext/richtextbuffer.cpp:8738
+#: ../src/richtext/richtextbuffer.cpp:8736
 msgid "files"
 msgstr "berkas"
 
-#: ../src/common/datetimefmt.cpp:1952
+#: ../src/common/datetimefmt.cpp:1975
 msgid "first"
 msgstr "pertama"
 
-#: ../src/html/helpwnd.cpp:1252
+#: ../src/html/helpwnd.cpp:1250
 msgid "font size"
 msgstr "ukuran font"
 
-#: ../src/common/datetimefmt.cpp:1965
+#: ../src/common/datetimefmt.cpp:1988
 msgid "fourteenth"
 msgstr "keempatbelas"
 
-#: ../src/common/datetimefmt.cpp:1955
+#: ../src/common/datetimefmt.cpp:1978
 msgid "fourth"
 msgstr "keempat"
 
-#: ../src/common/appbase.cpp:783
+#: ../src/common/appbase.cpp:784
 msgid "generate verbose log messages"
 msgstr "hasilkan pesan log lengkap"
 
-#: ../src/richtext/richtextbuffer.cpp:13138 ../src/richtext/richtextbuffer.cpp:13248
+#: ../src/common/fontcmn.cpp:1215
+msgid "heavy"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:13133
+#: ../src/richtext/richtextbuffer.cpp:13243
 msgid "image"
 msgstr "citra"
 
-#: ../src/common/tarstrm.cpp:796
+#: ../src/common/tarstrm.cpp:790
 msgid "incomplete header block in tar"
 msgstr "galat berkas tar"
 
-#: ../src/common/xtixml.cpp:489
+#: ../src/common/xtixml.cpp:485
 msgid "incorrect event handler string, missing dot"
 msgstr "string event handler salah, kurang titik"
 
-#: ../src/common/tarstrm.cpp:1381
+#: ../src/common/tarstrm.cpp:1375
 msgid "incorrect size given for tar entry"
 msgstr "salah ukuran pada isian tar"
 
-#: ../src/common/tarstrm.cpp:993
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:987
 msgid "invalid data in extended tar header"
 msgstr "data tidak valid pada header tar yang diperluas"
 
-#: ../src/generic/logg.cpp:1030
+#: ../src/generic/logg.cpp:1027
 msgid "invalid message box return value"
 msgstr "nilai kembali message box tidak sah"
 
-#: ../src/common/zipstrm.cpp:1647
+#: ../src/common/zipstrm.cpp:1688
 msgid "invalid zip file"
 msgstr "berkas zip tidak valid"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:1228
 msgid "italic"
 msgstr "miring"
 
-#: ../src/common/fontcmn.cpp:991
+#: ../src/common/webrequest_curl.cpp:374
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "Deskripsi kolom tidak dapat diinisialisasi."
+
+#: ../src/common/fontcmn.cpp:1172
 msgid "light"
 msgstr "ringan"
 
-#: ../src/common/intl.cpp:303
-#, c-format
-msgid "locale '%s' cannot be set."
-msgstr "bahasa '%s' tidak bisa ditetapkan."
+#: ../src/common/fontcmn.cpp:1185
+msgid "medium"
+msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2125
+#: ../src/common/datetimefmt.cpp:2148
 msgid "midnight"
 msgstr "tengah malam"
 
-#: ../src/common/datetimefmt.cpp:1970
+#: ../src/common/datetimefmt.cpp:1993
 msgid "nineteenth"
 msgstr "kesembilanbelas"
 
-#: ../src/common/datetimefmt.cpp:1960
+#: ../src/common/datetimefmt.cpp:1983
 msgid "ninth"
 msgstr "kesembilan"
 
-#: ../src/msw/dde.cpp:1116
+#: ../src/msw/dde.cpp:1180
 msgid "no DDE error."
 msgstr "tidak ada kesalahan DDE."
 
-#: ../src/html/chm.cpp:327
+#: ../src/html/chm.cpp:324
 msgid "no error"
 msgstr "tidak ada galat"
 
-#: ../src/dfb/fontmgr.cpp:174
+#: ../src/dfb/fontmgr.cpp:171
 #, c-format
 msgid "no fonts found in %s, using builtin font"
 msgstr "font tidak ditemukan di %s, menggunakan font standar"
 
-#: ../src/html/helpdata.cpp:657
+#: ../src/html/helpdata.cpp:650
 msgid "noname"
 msgstr "tanpa nama"
 
-#: ../src/common/datetimefmt.cpp:2124
+#: ../src/common/datetimefmt.cpp:2147
 msgid "noon"
 msgstr "siang"
 
-#: ../src/richtext/richtextstyles.cpp:779
+#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "normal"
 
-#: ../src/common/cmdline.cpp:1492
+#: ../src/common/cmdline.cpp:1488
 msgid "num"
 msgstr "angka"
 
-#: ../src/common/xtixml.cpp:259
+#: ../src/common/accelcmn.cpp:194
+msgid "num "
+msgstr ""
+
+#: ../src/common/xtixml.cpp:255
 msgid "objects cannot have XML Text Nodes"
 msgstr "obyek tidak boleh mengandung node teks XML"
 
-#: ../src/html/chm.cpp:339
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
 msgid "out of memory"
 msgstr "memori tidak cukup"
 
-#: ../src/common/debugrpt.cpp:514
+#: ../src/common/debugrpt.cpp:515
 msgid "process context description"
 msgstr "deskripsi konteks proses"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:227
-#: ../src/richtext/richtextbackgroundpage.cpp:250
-#: ../src/richtext/richtextbackgroundpage.cpp:290
-#: ../src/richtext/richtextbackgroundpage.cpp:317
-#: ../src/richtext/richtextfontpage.cpp:177 ../src/richtext/richtextfontpage.cpp:180
 #: ../src/richtext/richtextborderspage.cpp:255
 #: ../src/richtext/richtextborderspage.cpp:289
 #: ../src/richtext/richtextborderspage.cpp:323
@@ -8372,22 +8746,45 @@ msgstr "deskripsi konteks proses"
 #: ../src/richtext/richtextborderspage.cpp:491
 #: ../src/richtext/richtextborderspage.cpp:525
 #: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextfontpage.cpp:180
 msgid "pt"
 msgstr "pt"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:225
-#: ../src/richtext/richtextbackgroundpage.cpp:228
-#: ../src/richtext/richtextbackgroundpage.cpp:229
-#: ../src/richtext/richtextbackgroundpage.cpp:248
-#: ../src/richtext/richtextbackgroundpage.cpp:251
-#: ../src/richtext/richtextbackgroundpage.cpp:252
-#: ../src/richtext/richtextbackgroundpage.cpp:288
-#: ../src/richtext/richtextbackgroundpage.cpp:291
-#: ../src/richtext/richtextbackgroundpage.cpp:292
-#: ../src/richtext/richtextbackgroundpage.cpp:315
-#: ../src/richtext/richtextbackgroundpage.cpp:318
-#: ../src/richtext/richtextbackgroundpage.cpp:319
-#: ../src/richtext/richtextfontpage.cpp:178
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:659
+#: ../src/richtext/richtextsizepage.cpp:662
+#: ../src/richtext/richtextsizepage.cpp:663
 #: ../src/richtext/richtextborderspage.cpp:253
 #: ../src/richtext/richtextborderspage.cpp:256
 #: ../src/richtext/richtextborderspage.cpp:257
@@ -8439,244 +8836,269 @@ msgstr "pt"
 #: ../src/richtext/richtextmarginspage.cpp:387
 #: ../src/richtext/richtextmarginspage.cpp:389
 #: ../src/richtext/richtextmarginspage.cpp:390
-#: ../src/richtext/richtextsizepage.cpp:338 ../src/richtext/richtextsizepage.cpp:341
-#: ../src/richtext/richtextsizepage.cpp:342 ../src/richtext/richtextsizepage.cpp:372
-#: ../src/richtext/richtextsizepage.cpp:375 ../src/richtext/richtextsizepage.cpp:376
-#: ../src/richtext/richtextsizepage.cpp:399 ../src/richtext/richtextsizepage.cpp:402
-#: ../src/richtext/richtextsizepage.cpp:403 ../src/richtext/richtextsizepage.cpp:426
-#: ../src/richtext/richtextsizepage.cpp:429 ../src/richtext/richtextsizepage.cpp:430
-#: ../src/richtext/richtextsizepage.cpp:453 ../src/richtext/richtextsizepage.cpp:456
-#: ../src/richtext/richtextsizepage.cpp:457 ../src/richtext/richtextsizepage.cpp:480
-#: ../src/richtext/richtextsizepage.cpp:483 ../src/richtext/richtextsizepage.cpp:484
-#: ../src/richtext/richtextsizepage.cpp:554 ../src/richtext/richtextsizepage.cpp:557
-#: ../src/richtext/richtextsizepage.cpp:558 ../src/richtext/richtextsizepage.cpp:589
-#: ../src/richtext/richtextsizepage.cpp:592 ../src/richtext/richtextsizepage.cpp:593
-#: ../src/richtext/richtextsizepage.cpp:624 ../src/richtext/richtextsizepage.cpp:627
-#: ../src/richtext/richtextsizepage.cpp:628 ../src/richtext/richtextsizepage.cpp:659
-#: ../src/richtext/richtextsizepage.cpp:662 ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextfontpage.cpp:178
 msgid "px"
 msgstr "px"
 
-#: ../src/common/accelcmn.cpp:193
+#: ../src/common/accelcmn.cpp:192
 msgid "rawctrl"
 msgstr "rawctrl"
 
-#: ../src/html/chm.cpp:333
+#: ../src/html/chm.cpp:330
 msgid "read error"
 msgstr "galat ketika membaca"
 
-#: ../src/common/zipstrm.cpp:2085
+#: ../src/common/zipstrm.cpp:2155
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "membaca berkas zip (entri %s): crc buruk"
 
-#: ../src/common/zipstrm.cpp:2080
+#: ../src/common/zipstrm.cpp:2150
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "membaca berkas zip (entri %s): ukuran buruk"
 
-#: ../src/msw/dde.cpp:1159
+#: ../src/msw/dde.cpp:1223
 msgid "reentrancy problem."
 msgstr "masalah reentransi kembali."
 
-#: ../src/common/datetimefmt.cpp:1953
+#: ../src/common/datetimefmt.cpp:1976
 msgid "second"
 msgstr "kedua"
 
-#: ../src/html/chm.cpp:337
+#: ../src/html/chm.cpp:334
 msgid "seek error"
 msgstr "galat ketika mencari"
 
-#: ../src/common/datetimefmt.cpp:1968
+#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#, fuzzy
+msgid "semibold"
+msgstr "tebal"
+
+#: ../src/common/datetimefmt.cpp:1991
 msgid "seventeenth"
 msgstr "ketujuhbelas"
 
-#: ../src/common/datetimefmt.cpp:1958
+#: ../src/common/datetimefmt.cpp:1981
 msgid "seventh"
 msgstr "ketujuh"
 
-#: ../src/common/accelcmn.cpp:191
+#: ../src/common/accelcmn.cpp:190
 msgid "shift"
 msgstr "geser"
 
-#: ../src/common/appbase.cpp:773
+#: ../src/common/appbase.cpp:774
 msgid "show this help message"
 msgstr "tampilkan pesan bantuan ini"
 
-#: ../src/common/datetimefmt.cpp:1967
+#: ../src/common/datetimefmt.cpp:1990
 msgid "sixteenth"
 msgstr "keenambelas"
 
-#: ../src/common/datetimefmt.cpp:1957
+#: ../src/common/datetimefmt.cpp:1980
 msgid "sixth"
 msgstr "keenam"
 
-#: ../src/common/appcmn.cpp:234
+#: ../src/common/appcmn.cpp:255
 msgid "specify display mode to use (e.g. 640x480-16)"
 msgstr "spesifikasikan mode tampilan yang digunakan (misalnya 640x480- 16)"
 
-#: ../src/common/appcmn.cpp:220
+#: ../src/common/appcmn.cpp:241
 msgid "specify the theme to use"
 msgstr "spesifikasikan tema yang digunakan"
 
-#: ../src/richtext/richtextbuffer.cpp:9340
+#: ../src/richtext/richtextbuffer.cpp:9337
 msgid "standard/circle"
 msgstr "standar/lingkaran"
 
-#: ../src/richtext/richtextbuffer.cpp:9341
+#: ../src/richtext/richtextbuffer.cpp:9338
 msgid "standard/circle-outline"
 msgstr "standar/lingkaran-ikhtisar"
 
-#: ../src/richtext/richtextbuffer.cpp:9343
+#: ../src/richtext/richtextbuffer.cpp:9340
 msgid "standard/diamond"
 msgstr "standar/intan"
 
-#: ../src/richtext/richtextbuffer.cpp:9342
+#: ../src/richtext/richtextbuffer.cpp:9339
 msgid "standard/square"
 msgstr "standar/bujur sangkar"
 
-#: ../src/richtext/richtextbuffer.cpp:9344
+#: ../src/richtext/richtextbuffer.cpp:9341
 msgid "standard/triangle"
 msgstr "standar/segitiga"
 
-#: ../src/common/zipstrm.cpp:1985
+#: ../src/common/zipstrm.cpp:2055
 msgid "stored file length not in Zip header"
 msgstr "stored file length not in Zip header"
 
-#: ../src/common/cmdline.cpp:1488
+#: ../src/common/cmdline.cpp:1484
 msgid "str"
 msgstr "str"
 
-#: ../src/common/fontcmn.cpp:982
+#: ../src/common/fontcmn.cpp:1145
 msgid "strikethrough"
 msgstr "teks coret"
 
-#: ../src/common/tarstrm.cpp:1003 ../src/common/tarstrm.cpp:1025
-#: ../src/common/tarstrm.cpp:1507 ../src/common/tarstrm.cpp:1529
+#: ../src/common/tarstrm.cpp:997 ../src/common/tarstrm.cpp:1019
+#: ../src/common/tarstrm.cpp:1501 ../src/common/tarstrm.cpp:1523
 msgid "tar entry not open"
 msgstr "entri tar tidak terbuka"
 
-#: ../src/common/datetimefmt.cpp:1961
+#: ../src/common/datetimefmt.cpp:1984
 msgid "tenth"
 msgstr "kesepuluh"
 
-#: ../src/msw/dde.cpp:1123
+#: ../src/msw/dde.cpp:1187
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "tanggapan terhadap transaksi menyebabkan bit DDE_FBUSY ditetapkan."
 
-#: ../src/common/datetimefmt.cpp:1954
+#: ../src/common/fontcmn.cpp:1154
+msgid "thin"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:1977
 msgid "third"
 msgstr "ketiga"
 
-#: ../src/common/datetimefmt.cpp:1964
+#: ../src/common/datetimefmt.cpp:1987
 msgid "thirteenth"
 msgstr "ketigabelas"
 
-#: ../src/common/datetimefmt.cpp:1758
+#: ../src/common/datetimefmt.cpp:1781
 msgid "today"
 msgstr "hari ini"
 
-#: ../src/common/datetimefmt.cpp:1760
+#: ../src/common/datetimefmt.cpp:1783
 msgid "tomorrow"
 msgstr "esok"
 
-#: ../src/common/fileconf.cpp:1944
+#: ../src/common/fileconf.cpp:1946
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "backslash yang mengekor diabaikan dalam '%s'"
 
-#: ../src/gtk/aboutdlg.cpp:218
+#: ../src/gtk/aboutdlg.cpp:216
 msgid "translator-credits"
 msgstr "penerjemah"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1028
+#: ../src/generic/datavgen.cpp:1148
 msgid "true"
 msgstr "true"
 
-#: ../src/common/datetimefmt.cpp:1963
+#: ../src/common/datetimefmt.cpp:1986
 msgid "twelfth"
 msgstr "keduabelas"
 
-#: ../src/common/datetimefmt.cpp:1971
+#: ../src/common/datetimefmt.cpp:1994
 msgid "twentieth"
 msgstr "keduapuluh"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:486 ../src/generic/datavgen.cpp:1263
+#: ../src/common/datavcmn.cpp:2068 ../src/generic/datavgen.cpp:1386
 msgid "unchecked"
 msgstr "tidak dicentang"
 
-#: ../src/common/fontcmn.cpp:802 ../src/common/fontcmn.cpp:978
+#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
 msgid "underlined"
 msgstr "bergarisbawah"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:490
+#: ../src/common/datavcmn.cpp:2072
 msgid "undetermined"
 msgstr "tidak diketahui"
 
-#: ../src/common/fileconf.cpp:1979
+#: ../src/common/fileconf.cpp:1981
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "\" tidak diharapkan pada posisi %d dalam '%s'."
 
-#: ../src/common/tarstrm.cpp:1045
+#: ../src/common/tarstrm.cpp:1039
 msgid "unexpected end of file"
 msgstr "akhir berkas yang tak diharapkan"
 
-#: ../src/generic/progdlgg.cpp:370 ../src/common/tarstrm.cpp:371
-#: ../src/common/tarstrm.cpp:394 ../src/common/tarstrm.cpp:425
+#: ../src/common/tarstrm.cpp:366 ../src/common/tarstrm.cpp:389
+#: ../src/common/tarstrm.cpp:420 ../src/generic/progdlgg.cpp:376
 msgid "unknown"
 msgstr "tidak dikenal"
 
-#: ../src/msw/registry.cpp:150
+#: ../src/msw/registry.cpp:139
 #, c-format
 msgid "unknown (%lu)"
 msgstr "tidak dikenal (%lu)"
 
-#: ../src/common/xtixml.cpp:253
+#: ../src/common/xtixml.cpp:249
 #, c-format
 msgid "unknown class %s"
 msgstr "kelas %s tidak dikenal"
 
-#: ../src/common/regex.cpp:258 ../src/html/chm.cpp:351
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "galat kompresi"
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "galat dekompresi"
+
+#: ../src/common/regex.cpp:255 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "galat tidak dikenal"
 
-#: ../src/msw/dialup.cpp:471
+#: ../src/msw/dialup.cpp:465
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "galat tidak dikenal (kode kesalahan %08x)."
 
-#: ../src/common/fmapbase.cpp:834
+#: ../src/common/fmapbase.cpp:830
 #, c-format
 msgid "unknown-%d"
 msgstr "%d-tidak dikenal"
 
-#: ../src/common/docview.cpp:509
+#: ../src/common/docview.cpp:502
 msgid "unnamed"
 msgstr "tanpa nama"
 
-#: ../src/common/docview.cpp:1624
+#: ../src/common/docview.cpp:1618
 #, c-format
 msgid "unnamed%d"
 msgstr "tanpa nama%d"
 
-#: ../src/common/zipstrm.cpp:1999 ../src/common/zipstrm.cpp:2319
+#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
 msgid "unsupported Zip compression method"
 msgstr "metode kompresi zip tidak didukung"
 
-#: ../src/common/translation.cpp:1892
+#: ../src/common/translation.cpp:1942
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "menggunakan katalog '%s' dari '%s'."
 
-#: ../src/html/chm.cpp:335
+#: ../src/html/chm.cpp:332
 msgid "write error"
 msgstr "galat penulisan"
 
-#: ../src/common/time.cpp:292
+#: ../src/gtk/glcanvas.cpp:187
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/common/time.cpp:285
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay gagal."
 
@@ -8689,15 +9111,15 @@ msgstr "wxWidgets tidak bisa membuka tampilan untuk '%s': keluar."
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets tidak bisa membuka tampilan. Keluar."
 
-#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:431
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/common/datetimefmt.cpp:1759
+#: ../src/common/datetimefmt.cpp:1782
 msgid "yesterday"
 msgstr "kemarin"
 
-#: ../src/common/zstream.cpp:251 ../src/common/zstream.cpp:426
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
 #, c-format
 msgid "zlib error %d"
 msgstr "galat zlib %d"
@@ -8706,6 +9128,78 @@ msgstr "galat zlib %d"
 #: ../src/richtext/richtextbulletspage.cpp:288
 msgid "~"
 msgstr "~"
+
+#~ msgid " (while overwriting an existing item)"
+#~ msgstr " (saat menimpa obyek yang ada)"
+
+#~ msgid "&Save as"
+#~ msgstr "&Simpan sebagai"
+
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' tidak terdiri dari karakter yang sah"
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' harus numerik."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' harus hanya berisi karakter ASCII."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' harus hanya berisi karakter alfabet."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' harus hanya berisi karakter alfabet atau numerik."
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' hanya boleh berisi angka."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "Gagal menciptakan jendela dari class %s"
+
+#~ msgid "Could not initalize libnotify."
+#~ msgstr "Gagal menginisialisasi libnotify."
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "Gagal membuat overlay window"
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "Gagal menjalankan konteks di overlay window"
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "Gagal mengubah berkas \"%s\" ke Unicode."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "Gagal mengatur teks pada teks kontrol."
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr "Opsi perintah GTK+ salah, gunakan \"%s --help\""
+
+#~ msgid "No unused colour in image."
+#~ msgstr "Tidak tersedia warna di dalam citra."
+
+#~ msgid "Not available"
+#~ msgstr "Tidak tersedia"
+
+#~ msgid "Replace selection"
+#~ msgstr "Timpa seleksi"
+
+#~ msgid "Save as"
+#~ msgstr "Simpan sebagai"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Pengelola Gaya"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "Standar opsi GTK+ yang didukung:\n"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "Kamu tidak dapat membersihkan overlay yang belum di init"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "Jangan menginisiasi overlay dua kali"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "bahasa '%s' tidak bisa ditetapkan."
 
 #~ msgid "Adding flavor TEXT failed"
 #~ msgstr "Penambahan rasa TEKS gagal"
@@ -8716,15 +9210,14 @@ msgstr "~"
 #~ msgid "Bitmap renderer cannot render value; value type: "
 #~ msgstr "Perender Bitmap tidak dapat merender nilai; tipe nilai:"
 
-#~ msgid "Cannot create new column's ID. Probably max. number of columns reached."
+#~ msgid ""
+#~ "Cannot create new column's ID. Probably max. number of columns reached."
 #~ msgstr ""
-#~ "Gagal membuat ID kolom baru. Mungkin banyak kolom sudah mencapai batas maksimum."
+#~ "Gagal membuat ID kolom baru. Mungkin banyak kolom sudah mencapai batas "
+#~ "maksimum."
 
 #~ msgid "Column could not be added."
 #~ msgstr "Kolom tidak bisa ditambahkan."
-
-#~ msgid "Column description could not be initialized."
-#~ msgstr "Deskripsi kolom tidak dapat diinisialisasi."
 
 #~ msgid "Column index not found."
 #~ msgstr "Indeks kolom tidak ditemukan."
@@ -8793,7 +9286,8 @@ msgstr "~"
 #~ msgstr "Gagal merender nilai penanggalan; tipe nilai: "
 
 #~ msgid ""
-#~ "Do you want to overwrite the command used to %s files with extension \"%s\" ?\n"
+#~ "Do you want to overwrite the command used to %s files with extension \"%s"
+#~ "\" ?\n"
 #~ "Current value is \n"
 #~ "%s, \n"
 #~ "New value is \n"
@@ -8836,8 +9330,10 @@ msgstr "~"
 #~ msgid "No column for the specified column position existing."
 #~ msgstr "Tidak ada kolom pada posisi kolom yang dipilih."
 
-#~ msgid "No renderer or invalid renderer type specified for custom data column."
-#~ msgstr "Renderer belum ditentukan atau tidak sesuai untuk kolom data kustom ini."
+#~ msgid ""
+#~ "No renderer or invalid renderer type specified for custom data column."
+#~ msgstr ""
+#~ "Renderer belum ditentukan atau tidak sesuai untuk kolom data kustom ini."
 
 #~ msgid "No renderer specified for column."
 #~ msgstr "Renderer belum ditentukan untuk kolom ini."
@@ -8869,7 +9365,8 @@ msgstr "~"
 #~ msgid "Rendering failed."
 #~ msgstr "Rendering gagal."
 
-#~ msgid "Setting directory access times is not supported under this OS version"
+#~ msgid ""
+#~ "Setting directory access times is not supported under this OS version"
 #~ msgstr "Menata waktu akses direktori tidak didukung oleh versi OS ini"
 
 #~ msgid "Show hidden directories"
@@ -8885,8 +9382,8 @@ msgstr "~"
 #~ "This system doesn't support date controls, please upgrade your version of "
 #~ "comctl32.dll"
 #~ msgstr ""
-#~ "Sistem ini tidak mendukung kontrol penanggalan, mohon perbaharui versi comctl32."
-#~ "dll anda"
+#~ "Sistem ini tidak mendukung kontrol penanggalan, mohon perbaharui versi "
+#~ "comctl32.dll anda"
 
 #~ msgid "Toggle renderer cannot render value; value type: "
 #~ msgstr "Gagal merender nilai toggle; tipe nilai:"

--- a/locale/it.po
+++ b/locale/it.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1 -revised 01.08.2017 by bovirus\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-21 14:25+0200\n"
+"POT-Creation-Date: 2020-10-18 23:11+0300\n"
 "PO-Revision-Date: 2017-08-01 10:37+0200\n"
 "Last-Translator: bovirus <bovirus@gmail.com>\n"
 "Language-Team: wxWidgets translators <wx-translators@googlegroups.com>\n"
@@ -14,7 +14,7 @@ msgstr ""
 "X-Generator: Poedit 2.0.3\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: ../src/common/debugrpt.cpp:586
+#: ../src/common/debugrpt.cpp:587
 msgid ""
 "\n"
 "Please send this report to the program maintainer, thank you!\n"
@@ -22,8 +22,8 @@ msgstr ""
 "\n"
 "Invia questa segnalazione all'autore del programma. Grazie!\n"
 
-#: ../src/richtext/richtextstyledlg.cpp:210
-#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:206
+#: ../src/richtext/richtextstyledlg.cpp:218
 msgid " "
 msgstr " "
 
@@ -31,70 +31,96 @@ msgstr " "
 msgid "              Thank you and we're sorry for the inconvenience!\n"
 msgstr "              Grazie, e ci scusiamo per il disturbo!\n"
 
-#: ../src/common/prntbase.cpp:573
+#: ../src/common/prntbase.cpp:568
 #, c-format
 msgid " (copy %d of %d)"
 msgstr " (copia %d di %d)"
 
-#: ../src/common/log.cpp:421
+#: ../src/common/log.cpp:440
 #, c-format
 msgid " (error %ld: %s)"
 msgstr " (errore %ld: %s)"
 
-#: ../src/common/imagtiff.cpp:72
+#: ../src/common/imagtiff.cpp:69
 #, c-format
 msgid " (in module \"%s\")"
 msgstr " (nel modulo \"%s\")"
 
-#: ../src/osx/core/secretstore.cpp:138
-msgid " (while overwriting an existing item)"
-msgstr " (mentre viene sovrascritto un elemento esistente)"
-
-#: ../src/common/docview.cpp:1642
+#: ../src/common/docview.cpp:1636
 msgid " - "
 msgstr " - "
 
-#: ../src/richtext/richtextprint.cpp:593 ../src/html/htmprint.cpp:714
+#: ../src/html/htmprint.cpp:712 ../src/richtext/richtextprint.cpp:589
 msgid " Preview"
 msgstr " Anteprima"
 
-#: ../src/common/fontcmn.cpp:824
+#: ../src/common/fontcmn.cpp:973
 msgid " bold"
 msgstr " grassetto"
 
-#: ../src/common/fontcmn.cpp:840
+#: ../src/common/fontcmn.cpp:977
+#, fuzzy
+msgid " extra bold"
+msgstr " grassetto"
+
+#: ../src/common/fontcmn.cpp:985
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:957
+#, fuzzy
+msgid " extra light"
+msgstr " leggero"
+
+#: ../src/common/fontcmn.cpp:981
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1001
 msgid " italic"
 msgstr " corsivo"
 
-#: ../src/common/fontcmn.cpp:820
+#: ../src/common/fontcmn.cpp:961
 msgid " light"
 msgstr " leggero"
 
-#: ../src/common/fontcmn.cpp:807
+#: ../src/common/fontcmn.cpp:965
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:969
+#, fuzzy
+msgid " semi bold"
+msgstr " grassetto"
+
+#: ../src/common/fontcmn.cpp:940
 msgid " strikethrough"
 msgstr " barrato"
 
-#: ../src/common/paper.cpp:117
+#: ../src/common/fontcmn.cpp:953
+msgid " thin"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
 msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
 msgstr "Busta #10, 4 1/8 x 9 1/2 pollici"
 
-#: ../src/common/paper.cpp:118
+#: ../src/common/paper.cpp:115
 msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
 msgstr "Busta #11, 4 1/2 x 10 3/8 pollici"
 
-#: ../src/common/paper.cpp:119
+#: ../src/common/paper.cpp:116
 msgid "#12 Envelope, 4 3/4 x 11 in"
 msgstr "Busta #12, 4 3/4 x 11 pollici"
 
-#: ../src/common/paper.cpp:120
+#: ../src/common/paper.cpp:117
 msgid "#14 Envelope, 5 x 11 1/2 in"
 msgstr "Busta #14, 5 x 11 1/2 pollici"
 
-#: ../src/common/paper.cpp:116
+#: ../src/common/paper.cpp:113
 msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
 msgstr "Busta #9, 3 7/8 x 8 7/8 pollici"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:341
 #: ../src/richtext/richtextsizepage.cpp:340
 #: ../src/richtext/richtextsizepage.cpp:374
 #: ../src/richtext/richtextsizepage.cpp:401
@@ -105,81 +131,82 @@ msgstr "Busta #9, 3 7/8 x 8 7/8 pollici"
 #: ../src/richtext/richtextsizepage.cpp:591
 #: ../src/richtext/richtextsizepage.cpp:626
 #: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextbackgroundpage.cpp:341
 msgid "%"
 msgstr "%"
 
-#: ../src/html/helpwnd.cpp:1031
+#: ../src/html/helpwnd.cpp:1029
 #, c-format
 msgid "%d of %lu"
 msgstr "%d di %lu"
 
-#: ../src/html/helpwnd.cpp:1678
+#: ../src/html/helpwnd.cpp:1676
 #, c-format
 msgid "%i of %u"
 msgstr "%i di %u"
 
-#: ../src/generic/filectrlg.cpp:279
+#: ../src/generic/filectrlg.cpp:275
 #, c-format
 msgid "%ld byte"
 msgid_plural "%ld bytes"
 msgstr[0] "%ld byte"
 msgstr[1] "%ld byte"
 
-#: ../src/html/helpwnd.cpp:1033
+#: ../src/html/helpwnd.cpp:1031
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu di %lu"
 
-#: ../src/generic/datavgen.cpp:6028
+#: ../src/generic/datavgen.cpp:6833
 #, c-format
 msgid "%s (%d items)"
 msgstr "%s (%d elementi)"
 
-#: ../src/common/cmdline.cpp:1221
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (o %s)"
 
-#: ../src/generic/logg.cpp:224
+#: ../src/generic/logg.cpp:221
 #, c-format
 msgid "%s Error"
 msgstr "Errore %s"
 
-#: ../src/generic/logg.cpp:236
+#: ../src/generic/logg.cpp:233
 #, c-format
 msgid "%s Information"
 msgstr "Informazioni %s"
 
-#: ../src/generic/preferencesg.cpp:113
+#: ../src/generic/preferencesg.cpp:110
 #, c-format
 msgid "%s Preferences"
 msgstr "Impostazioni %s"
 
-#: ../src/generic/logg.cpp:228
+#: ../src/generic/logg.cpp:225
 #, c-format
 msgid "%s Warning"
 msgstr "Avviso %s"
 
-#: ../src/common/tarstrm.cpp:1319
+#: ../src/common/tarstrm.cpp:1313
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s non ha trovato l'intestazione del file tar per l'elemento '%s'"
 
-#: ../src/common/fldlgcmn.cpp:124
+#: ../src/common/fldlgcmn.cpp:121
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s file (%s)|%s"
 
-#: ../src/html/helpwnd.cpp:1716
+#: ../src/html/helpwnd.cpp:1714
 #, c-format
 msgid "%u of %u"
 msgstr "%u di %u"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "&About"
 msgstr "Inform&azioni su"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "&Actual Size"
 msgstr "Dimensione &attuale"
 
@@ -187,28 +214,28 @@ msgstr "Dimensione &attuale"
 msgid "&After a paragraph:"
 msgstr "Dopo un p&aragrafo:"
 
-#: ../src/richtext/richtextindentspage.cpp:128
 #: ../src/richtext/richtextliststylepage.cpp:319
+#: ../src/richtext/richtextindentspage.cpp:128
 msgid "&Alignment"
 msgstr "&Allineamento"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "&Apply"
 msgstr "&Applica"
 
-#: ../src/richtext/richtextstyledlg.cpp:251
+#: ../src/richtext/richtextstyledlg.cpp:247
 msgid "&Apply Style"
 msgstr "&Applica lo stile"
 
-#: ../src/msw/mdi.cpp:179
+#: ../src/msw/mdi.cpp:174
 msgid "&Arrange Icons"
 msgstr "&Disponi icone"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "&Ascending"
 msgstr "&Ascendente"
 
-#: ../src/common/stockitem.cpp:142
+#: ../src/common/stockitem.cpp:139
 msgid "&Back"
 msgstr "&Indietro"
 
@@ -228,24 +255,24 @@ msgstr "&Colore sfondo:"
 msgid "&Blur distance:"
 msgstr "Distanza &sfocatura:"
 
-#: ../src/common/stockitem.cpp:143
+#: ../src/common/stockitem.cpp:140
 msgid "&Bold"
 msgstr "&Grassetto"
 
-#: ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141
 msgid "&Bottom"
 msgstr "&Basso"
 
+#: ../src/richtext/richtextsizepage.cpp:637
+#: ../src/richtext/richtextsizepage.cpp:644
 #: ../src/richtext/richtextborderspage.cpp:345
 #: ../src/richtext/richtextborderspage.cpp:513
 #: ../src/richtext/richtextmarginspage.cpp:259
 #: ../src/richtext/richtextmarginspage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:637
-#: ../src/richtext/richtextsizepage.cpp:644
 msgid "&Bottom:"
 msgstr "&Basso:"
 
-#: ../include/wx/richtext/richtextbuffer.h:3866
+#: ../include/wx/richtext/richtextbuffer.h:3861
 msgid "&Box"
 msgstr "&Riquadro"
 
@@ -254,38 +281,38 @@ msgstr "&Riquadro"
 msgid "&Bullet style:"
 msgstr "Stile del &punto:"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "&CD-Rom"
 msgstr "&CD-ROM"
 
-#: ../src/generic/wizard.cpp:434 ../src/generic/fontdlgg.cpp:470
-#: ../src/generic/fontdlgg.cpp:489 ../src/osx/carbon/fontdlg.cpp:402
-#: ../src/common/dlgcmn.cpp:279 ../src/common/stockitem.cpp:145
+#: ../src/osx/carbon/fontdlg.cpp:399 ../src/common/stockitem.cpp:142
+#: ../src/generic/wizard.cpp:433 ../src/generic/fontdlgg.cpp:466
+#: ../src/generic/fontdlgg.cpp:485 ../src/osx/cocoa/button.mm:200
 msgid "&Cancel"
 msgstr "&Annulla"
 
-#: ../src/msw/mdi.cpp:175
+#: ../src/msw/mdi.cpp:170
 msgid "&Cascade"
 msgstr "&Sovrapponi finestre"
 
-#: ../include/wx/richtext/richtextbuffer.h:5960
+#: ../include/wx/richtext/richtextbuffer.h:5955
 msgid "&Cell"
 msgstr "&Cella"
 
-#: ../src/richtext/richtextsymboldlg.cpp:439
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "&Character code:"
 msgstr "&Codice carattere:"
 
-#: ../src/common/stockitem.cpp:147
+#: ../src/common/stockitem.cpp:144
 msgid "&Clear"
 msgstr "&Azzera"
 
-#: ../src/generic/logg.cpp:516 ../src/common/stockitem.cpp:148
-#: ../src/common/prntbase.cpp:1600 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/stockitem.cpp:145 ../src/common/prntbase.cpp:1625
+#: ../src/univ/themes/win32.cpp:3753 ../src/generic/logg.cpp:513
 msgid "&Close"
 msgstr "&Chiudi"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "&Color"
 msgstr "&Colore"
 
@@ -293,20 +320,20 @@ msgstr "&Colore"
 msgid "&Colour:"
 msgstr "&Colore:"
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "&Convert"
 msgstr "&Converti"
 
-#: ../src/richtext/richtextctrl.cpp:333 ../src/osx/textctrl_osx.cpp:577
-#: ../src/common/stockitem.cpp:150 ../src/msw/textctrl.cpp:2508
+#: ../src/osx/textctrl_osx.cpp:595 ../src/common/stockitem.cpp:147
+#: ../src/msw/textctrl.cpp:2773 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Copia"
 
-#: ../src/generic/hyperlinkg.cpp:156
+#: ../src/generic/hyperlinkg.cpp:153
 msgid "&Copy URL"
 msgstr "&Copia URL"
 
-#: ../src/common/headerctrlcmn.cpp:306
+#: ../src/common/headerctrlcmn.cpp:304
 msgid "&Customize..."
 msgstr "&Personalizza..."
 
@@ -314,53 +341,54 @@ msgstr "&Personalizza..."
 msgid "&Debug report preview:"
 msgstr "Anteprima &della segnalazione di errore:"
 
-#: ../src/richtext/richtexttabspage.cpp:138
-#: ../src/richtext/richtextctrl.cpp:335 ../src/osx/textctrl_osx.cpp:579
-#: ../src/common/stockitem.cpp:152 ../src/msw/textctrl.cpp:2510
+#: ../src/osx/textctrl_osx.cpp:597 ../src/common/stockitem.cpp:149
+#: ../src/msw/textctrl.cpp:2775 ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtextctrl.cpp:334
 msgid "&Delete"
 msgstr "&Elimina"
 
-#: ../src/richtext/richtextstyledlg.cpp:269
+#: ../src/richtext/richtextstyledlg.cpp:265
 msgid "&Delete Style..."
 msgstr "&Elimina lo stile..."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "&Descending"
 msgstr "&Discendente"
 
-#: ../src/generic/logg.cpp:682
+#: ../src/generic/logg.cpp:679
 msgid "&Details"
 msgstr "&Dettagli"
 
-#: ../src/common/stockitem.cpp:153
+#: ../src/common/stockitem.cpp:150
 msgid "&Down"
 msgstr "&Giù"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "&Edit"
 msgstr "&Modifica"
 
-#: ../src/richtext/richtextstyledlg.cpp:263
+#: ../src/richtext/richtextstyledlg.cpp:259
 msgid "&Edit Style..."
 msgstr "&Modifica lo stile..."
 
-#: ../src/common/stockitem.cpp:155
+#: ../src/common/stockitem.cpp:152
 msgid "&Execute"
 msgstr "&Esegui"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/common/stockitem.cpp:154
 msgid "&File"
 msgstr "&File"
 
-#: ../src/common/stockitem.cpp:158
-msgid "&Find"
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "&Find..."
 msgstr "&Trova"
 
-#: ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:430
 msgid "&Finish"
 msgstr "&Fine"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:156
 msgid "&First"
 msgstr "&Primo"
 
@@ -368,15 +396,15 @@ msgstr "&Primo"
 msgid "&Floating mode:"
 msgstr "Modo &flottante:"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "&Floppy"
 msgstr "&Floppy"
 
-#: ../src/common/stockitem.cpp:194
+#: ../src/common/stockitem.cpp:191
 msgid "&Font"
 msgstr "&Font"
 
-#: ../src/generic/fontdlgg.cpp:371
+#: ../src/generic/fontdlgg.cpp:367
 msgid "&Font family:"
 msgstr "&Tipo carattere:"
 
@@ -384,20 +412,20 @@ msgstr "&Tipo carattere:"
 msgid "&Font for Level..."
 msgstr "&Font per questo livello..."
 
+#: ../src/richtext/richtextsymboldlg.cpp:397
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:400
 msgid "&Font:"
 msgstr "&Font:"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "&Forward"
 msgstr "&Avanti"
 
-#: ../src/richtext/richtextsymboldlg.cpp:451
+#: ../src/richtext/richtextsymboldlg.cpp:448
 msgid "&From:"
 msgstr "&Da:"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "&Harddisk"
 msgstr "&Disco fisso"
 
@@ -406,9 +434,9 @@ msgstr "&Disco fisso"
 msgid "&Height:"
 msgstr "&Altezza:"
 
-#: ../src/generic/wizard.cpp:441 ../src/richtext/richtextstyledlg.cpp:303
-#: ../src/richtext/richtextsymboldlg.cpp:479 ../src/osx/menu_osx.cpp:734
-#: ../src/common/stockitem.cpp:163
+#: ../src/common/stockitem.cpp:160 ../src/generic/wizard.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextstyledlg.cpp:299 ../src/osx/cocoa/menu.mm:226
 msgid "&Help"
 msgstr "&Aiuto"
 
@@ -416,7 +444,7 @@ msgstr "&Aiuto"
 msgid "&Hide details"
 msgstr "&Nascondi dettagli"
 
-#: ../src/common/stockitem.cpp:164
+#: ../src/common/stockitem.cpp:161
 msgid "&Home"
 msgstr "&Home"
 
@@ -424,54 +452,54 @@ msgstr "&Home"
 msgid "&Horizontal offset:"
 msgstr "Offset &verticale:"
 
-#: ../src/richtext/richtextindentspage.cpp:184
 #: ../src/richtext/richtextliststylepage.cpp:372
+#: ../src/richtext/richtextindentspage.cpp:184
 msgid "&Indentation (tenths of a mm)"
 msgstr "&Rientro (decimi di millimetro)"
 
-#: ../src/richtext/richtextindentspage.cpp:167
 #: ../src/richtext/richtextliststylepage.cpp:356
+#: ../src/richtext/richtextindentspage.cpp:167
 msgid "&Indeterminate"
 msgstr "&Indeterminato"
 
-#: ../src/common/stockitem.cpp:166
+#: ../src/common/stockitem.cpp:163
 msgid "&Index"
 msgstr "&Indice"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "&Info"
 msgstr "&Info"
 
-#: ../src/common/stockitem.cpp:168
+#: ../src/common/stockitem.cpp:165
 msgid "&Italic"
 msgstr "&Corsivo"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "&Jump to"
 msgstr "&Vai a"
 
-#: ../src/richtext/richtextindentspage.cpp:153
 #: ../src/richtext/richtextliststylepage.cpp:342
+#: ../src/richtext/richtextindentspage.cpp:153
 msgid "&Justified"
 msgstr "&Giustificato"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "&Last"
 msgstr "&Ultimo"
 
-#: ../src/richtext/richtextindentspage.cpp:139
 #: ../src/richtext/richtextliststylepage.cpp:328
+#: ../src/richtext/richtextindentspage.cpp:139
 msgid "&Left"
 msgstr "&Sinistra"
 
-#: ../src/richtext/richtextindentspage.cpp:195
+#: ../src/richtext/richtextsizepage.cpp:532
+#: ../src/richtext/richtextsizepage.cpp:539
 #: ../src/richtext/richtextborderspage.cpp:243
 #: ../src/richtext/richtextborderspage.cpp:411
 #: ../src/richtext/richtextliststylepage.cpp:381
+#: ../src/richtext/richtextindentspage.cpp:195
 #: ../src/richtext/richtextmarginspage.cpp:186
 #: ../src/richtext/richtextmarginspage.cpp:300
-#: ../src/richtext/richtextsizepage.cpp:532
-#: ../src/richtext/richtextsizepage.cpp:539
 msgid "&Left:"
 msgstr "&Sinistra:"
 
@@ -479,11 +507,11 @@ msgstr "&Sinistra:"
 msgid "&List level:"
 msgstr "&Livello elenco:"
 
-#: ../src/generic/logg.cpp:517
+#: ../src/generic/logg.cpp:514
 msgid "&Log"
 msgstr "&Registro"
 
-#: ../src/univ/themes/win32.cpp:3748
+#: ../src/univ/themes/win32.cpp:3745
 msgid "&Move"
 msgstr "&Sposta"
 
@@ -491,19 +519,19 @@ msgstr "&Sposta"
 msgid "&Move the object to:"
 msgstr "&Sposta l'oggetto in:"
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "&Network"
 msgstr "&Rete"
 
-#: ../src/richtext/richtexttabspage.cpp:132 ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173 ../src/richtext/richtexttabspage.cpp:132
 msgid "&New"
 msgstr "&Nuovo"
 
-#: ../src/aui/tabmdi.cpp:111 ../src/generic/mdig.cpp:100 ../src/msw/mdi.cpp:180
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
 msgid "&Next"
 msgstr "&Avanti"
 
-#: ../src/generic/wizard.cpp:432 ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:429
 msgid "&Next >"
 msgstr "&Avanti >"
 
@@ -511,7 +539,7 @@ msgstr "&Avanti >"
 msgid "&Next Paragraph"
 msgstr "&Paragrafo successivo"
 
-#: ../src/generic/tipdlg.cpp:240
+#: ../src/generic/tipdlg.cpp:237
 msgid "&Next Tip"
 msgstr "&Suggerimento successivo"
 
@@ -519,11 +547,11 @@ msgstr "&Suggerimento successivo"
 msgid "&Next style:"
 msgstr "Stile &successivo:"
 
-#: ../src/common/stockitem.cpp:177 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:174 ../src/msw/msgdlg.cpp:435
 msgid "&No"
 msgstr "&No"
 
-#: ../src/generic/dbgrptg.cpp:356
+#: ../src/generic/dbgrptg.cpp:360
 msgid "&Notes:"
 msgstr "&Note:"
 
@@ -531,12 +559,12 @@ msgstr "&Note:"
 msgid "&Number:"
 msgstr "&Numero:"
 
-#: ../src/generic/fontdlgg.cpp:475 ../src/generic/fontdlgg.cpp:482
-#: ../src/osx/carbon/fontdlg.cpp:408 ../src/common/stockitem.cpp:178
+#: ../src/osx/carbon/fontdlg.cpp:405 ../src/common/stockitem.cpp:175
+#: ../src/generic/fontdlgg.cpp:471 ../src/generic/fontdlgg.cpp:478
 msgid "&OK"
 msgstr "&OK"
 
-#: ../src/generic/dbgrptg.cpp:342 ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176 ../src/generic/dbgrptg.cpp:342
 msgid "&Open..."
 msgstr "&Apri..."
 
@@ -548,16 +576,16 @@ msgstr "&Livello contorno:"
 msgid "&Page Break"
 msgstr "Interruzione di &pagina"
 
-#: ../src/richtext/richtextctrl.cpp:334 ../src/osx/textctrl_osx.cpp:578
-#: ../src/common/stockitem.cpp:180 ../src/msw/textctrl.cpp:2509
+#: ../src/osx/textctrl_osx.cpp:596 ../src/common/stockitem.cpp:177
+#: ../src/msw/textctrl.cpp:2774 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "Incoll&a"
 
-#: ../include/wx/richtext/richtextbuffer.h:5010
+#: ../include/wx/richtext/richtextbuffer.h:5005
 msgid "&Picture"
 msgstr "&Immagine"
 
-#: ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:419
 msgid "&Point size:"
 msgstr "Dimensione &punto:"
 
@@ -569,11 +597,11 @@ msgstr "&Posizione (decimi di millimetro):"
 msgid "&Position mode:"
 msgstr "Modo &posizione:"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178
 msgid "&Preferences"
 msgstr "&Preferenze"
 
-#: ../src/aui/tabmdi.cpp:112 ../src/generic/mdig.cpp:101 ../src/msw/mdi.cpp:181
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
 msgid "&Previous"
 msgstr "&Precedente"
 
@@ -581,78 +609,74 @@ msgstr "&Precedente"
 msgid "&Previous Paragraph"
 msgstr "&Paragrafo precedente"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "&Print..."
 msgstr "&Stampa..."
 
-#: ../src/richtext/richtextctrl.cpp:339 ../src/richtext/richtextctrl.cpp:5514
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtextctrl.cpp:338
+#: ../src/richtext/richtextctrl.cpp:5512
 msgid "&Properties"
 msgstr "&Proprietà"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "&Quit"
 msgstr "&Esci"
 
-#: ../src/richtext/richtextctrl.cpp:330 ../src/osx/textctrl_osx.cpp:574
-#: ../src/common/stockitem.cpp:185 ../src/common/cmdproc.cpp:293
-#: ../src/common/cmdproc.cpp:300 ../src/msw/textctrl.cpp:2505
+#: ../src/osx/textctrl_osx.cpp:592 ../src/common/stockitem.cpp:182
+#: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
+#: ../src/msw/textctrl.cpp:2770 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Ripeti"
 
-#: ../src/common/cmdproc.cpp:289 ../src/common/cmdproc.cpp:309
+#: ../src/common/cmdproc.cpp:282 ../src/common/cmdproc.cpp:302
 msgid "&Redo "
 msgstr "&Ripeti "
 
-#: ../src/richtext/richtextstyledlg.cpp:257
+#: ../src/richtext/richtextstyledlg.cpp:253
 msgid "&Rename Style..."
 msgstr "&Rinomina lo stile..."
 
-#: ../src/generic/fdrepdlg.cpp:179
+#: ../src/generic/fdrepdlg.cpp:176
 msgid "&Replace"
 msgstr "&Sostituisci"
 
-#: ../src/richtext/richtextstyledlg.cpp:287
+#: ../src/richtext/richtextstyledlg.cpp:283
 msgid "&Restart numbering"
 msgstr "&Ricomincia la numerazione"
 
-#: ../src/univ/themes/win32.cpp:3747
+#: ../src/univ/themes/win32.cpp:3744
 msgid "&Restore"
 msgstr "&Ripristina"
 
-#: ../src/richtext/richtextindentspage.cpp:146
 #: ../src/richtext/richtextliststylepage.cpp:335
+#: ../src/richtext/richtextindentspage.cpp:146
 msgid "&Right"
 msgstr "&Destra"
 
-#: ../src/richtext/richtextindentspage.cpp:213
+#: ../src/richtext/richtextsizepage.cpp:602
+#: ../src/richtext/richtextsizepage.cpp:609
 #: ../src/richtext/richtextborderspage.cpp:277
 #: ../src/richtext/richtextborderspage.cpp:445
 #: ../src/richtext/richtextliststylepage.cpp:399
+#: ../src/richtext/richtextindentspage.cpp:213
 #: ../src/richtext/richtextmarginspage.cpp:211
 #: ../src/richtext/richtextmarginspage.cpp:325
-#: ../src/richtext/richtextsizepage.cpp:602
-#: ../src/richtext/richtextsizepage.cpp:609
 msgid "&Right:"
 msgstr "&Destra:"
 
-#: ../src/common/stockitem.cpp:190
+#: ../src/common/stockitem.cpp:187
 msgid "&Save"
 msgstr "&Salva"
-
-#: ../src/common/stockitem.cpp:191
-msgid "&Save as"
-msgstr "&Salva come"
 
 #: ../include/wx/richmsgdlg.h:29
 msgid "&See details"
 msgstr "&Visualizza dettagli"
 
-#: ../src/generic/tipdlg.cpp:236
+#: ../src/generic/tipdlg.cpp:233
 msgid "&Show tips at startup"
 msgstr "Vi&sualizza suggerimenti all'avvio"
 
-#: ../src/univ/themes/win32.cpp:3750
+#: ../src/univ/themes/win32.cpp:3747
 msgid "&Size"
 msgstr "Dimen&sione"
 
@@ -660,36 +684,36 @@ msgstr "Dimen&sione"
 msgid "&Size:"
 msgstr "Dimen&sione:"
 
-#: ../src/generic/progdlgg.cpp:252
+#: ../src/generic/progdlgg.cpp:249
 msgid "&Skip"
 msgstr "&Salta"
 
-#: ../src/richtext/richtextindentspage.cpp:242
 #: ../src/richtext/richtextliststylepage.cpp:417
+#: ../src/richtext/richtextindentspage.cpp:242
 msgid "&Spacing (tenths of a mm)"
 msgstr "&Spaziatura (decimi di millimetro)"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "&Spell Check"
 msgstr "&Controllo ortografia"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "&Stop"
 msgstr "&Stop"
 
-#: ../src/richtext/richtextfontpage.cpp:275 ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196 ../src/richtext/richtextfontpage.cpp:275
 msgid "&Strikethrough"
 msgstr "&Barrato"
 
-#: ../src/generic/fontdlgg.cpp:382 ../src/richtext/richtextstylepage.cpp:106
+#: ../src/generic/fontdlgg.cpp:378 ../src/richtext/richtextstylepage.cpp:106
 msgid "&Style:"
 msgstr "&Stile:"
 
-#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:194
 msgid "&Styles:"
 msgstr "&Stili:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:413
+#: ../src/richtext/richtextsymboldlg.cpp:410
 msgid "&Subset:"
 msgstr "&Sottoinsieme:"
 
@@ -703,24 +727,24 @@ msgstr "&Simbolo:"
 msgid "&Synchronize values"
 msgstr "&Sincronizza valori"
 
-#: ../include/wx/richtext/richtextbuffer.h:6069
+#: ../include/wx/richtext/richtextbuffer.h:6064
 msgid "&Table"
 msgstr "&Tabella"
 
-#: ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197
 msgid "&Top"
 msgstr "Al&to"
 
+#: ../src/richtext/richtextsizepage.cpp:567
+#: ../src/richtext/richtextsizepage.cpp:574
 #: ../src/richtext/richtextborderspage.cpp:311
 #: ../src/richtext/richtextborderspage.cpp:479
 #: ../src/richtext/richtextmarginspage.cpp:234
 #: ../src/richtext/richtextmarginspage.cpp:348
-#: ../src/richtext/richtextsizepage.cpp:567
-#: ../src/richtext/richtextsizepage.cpp:574
 msgid "&Top:"
 msgstr "Al&to:"
 
-#: ../src/generic/fontdlgg.cpp:444 ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199 ../src/generic/fontdlgg.cpp:441
 msgid "&Underline"
 msgstr "&Sottolinea"
 
@@ -728,21 +752,21 @@ msgstr "&Sottolinea"
 msgid "&Underlining:"
 msgstr "&Sottolineatura:"
 
-#: ../src/richtext/richtextctrl.cpp:329 ../src/osx/textctrl_osx.cpp:573
-#: ../src/common/stockitem.cpp:203 ../src/common/cmdproc.cpp:271
-#: ../src/msw/textctrl.cpp:2504
+#: ../src/osx/textctrl_osx.cpp:591 ../src/common/stockitem.cpp:200
+#: ../src/common/cmdproc.cpp:264 ../src/msw/textctrl.cpp:2769
+#: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Annulla"
 
-#: ../src/common/cmdproc.cpp:265
+#: ../src/common/cmdproc.cpp:258
 msgid "&Undo "
 msgstr "&Annulla "
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "&Unindent"
 msgstr "&Rimuovi indentazione"
 
-#: ../src/common/stockitem.cpp:205
+#: ../src/common/stockitem.cpp:202
 msgid "&Up"
 msgstr "&Su"
 
@@ -758,7 +782,7 @@ msgstr "Offset &verticale:"
 msgid "&View..."
 msgstr "&Visalizza..."
 
-#: ../src/generic/fontdlgg.cpp:393
+#: ../src/generic/fontdlgg.cpp:389
 msgid "&Weight:"
 msgstr "&Peso:"
 
@@ -767,88 +791,58 @@ msgstr "&Peso:"
 msgid "&Width:"
 msgstr "&Larghezza:"
 
-#: ../src/aui/tabmdi.cpp:311 ../src/aui/tabmdi.cpp:327
-#: ../src/aui/tabmdi.cpp:329 ../src/generic/mdig.cpp:294
-#: ../src/generic/mdig.cpp:310 ../src/generic/mdig.cpp:314
-#: ../src/msw/mdi.cpp:78
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
 msgid "&Window"
 msgstr "&Finestra"
 
-#: ../src/common/stockitem.cpp:206 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:203 ../src/msw/msgdlg.cpp:435
 msgid "&Yes"
 msgstr "&Si"
 
-#: ../src/common/valtext.cpp:256
-#, c-format
-msgid "'%s' contains illegal characters"
+#: ../src/common/valtext.cpp:197
+#, fuzzy, c-format
+msgid "'%s' contains invalid character(s)"
 msgstr "'%s' contiene caratteri non validi"
 
-#: ../src/common/valtext.cpp:254
-#, c-format
-msgid "'%s' doesn't consist only of valid characters"
-msgstr "'%s' non consiste solo in caratteri validi"
-
-#: ../src/common/config.cpp:519 ../src/msw/regconf.cpp:258
+#: ../src/common/config.cpp:515 ../src/msw/regconf.cpp:255
 #, c-format
 msgid "'%s' has extra '..', ignored."
 msgstr "'%s' ha troppi '..', ignorati."
 
-#: ../src/common/cmdline.cpp:1113 ../src/common/cmdline.cpp:1131
+#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' non è un valore numerico corretto per l'opzione '%s'."
 
-#: ../src/common/translation.cpp:1100
+#: ../src/common/translation.cpp:1142
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' non è un catalogo di messaggi valido."
 
-#: ../src/common/valtext.cpp:165
+#: ../src/common/valtext.cpp:188
 #, c-format
 msgid "'%s' is not one of the valid strings"
 msgstr "'%s' non è una delle stringhe non valide"
 
-#: ../src/common/valtext.cpp:167
+#: ../src/common/valtext.cpp:186
 #, c-format
 msgid "'%s' is one of the invalid strings"
 msgstr "'%s' è una delle stringhe non valide"
 
-#: ../src/common/textbuf.cpp:237
+#: ../src/common/textbuf.cpp:233
 #, c-format
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' probabilmente è un buffer binario."
-
-#: ../src/common/valtext.cpp:252
-#, c-format
-msgid "'%s' should be numeric."
-msgstr "'%s' deve essere numerico."
-
-#: ../src/common/valtext.cpp:244
-#, c-format
-msgid "'%s' should only contain ASCII characters."
-msgstr "'%s' deve contenere unicamente caratteri ASCII."
-
-#: ../src/common/valtext.cpp:246
-#, c-format
-msgid "'%s' should only contain alphabetic characters."
-msgstr "'%s' deve contenere unicamente caratteri alfabetici."
-
-#: ../src/common/valtext.cpp:248
-#, c-format
-msgid "'%s' should only contain alphabetic or numeric characters."
-msgstr "'%s' deve contenere unicamente caratteri alfabetici o numerici."
-
-#: ../src/common/valtext.cpp:250
-#, c-format
-msgid "'%s' should only contain digits."
-msgstr "'%s' deve contenere unicamente numeri."
 
 #: ../src/richtext/richtextliststylepage.cpp:229
 #: ../src/richtext/richtextbulletspage.cpp:166
 msgid "(*)"
 msgstr "(*)"
 
-#: ../src/html/helpwnd.cpp:963
+#: ../src/html/helpwnd.cpp:961
 msgid "(Help)"
 msgstr "(Aiuto)"
 
@@ -857,27 +851,32 @@ msgstr "(Aiuto)"
 msgid "(None)"
 msgstr "(Nessuno)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:504
+#: ../src/richtext/richtextsymboldlg.cpp:503
 msgid "(Normal text)"
 msgstr "(Testo normale)"
 
-#: ../src/html/helpwnd.cpp:419 ../src/html/helpwnd.cpp:1106
-#: ../src/html/helpwnd.cpp:1742
+#: ../src/html/helpwnd.cpp:417 ../src/html/helpwnd.cpp:1104
+#: ../src/html/helpwnd.cpp:1740
 msgid "(bookmarks)"
 msgstr "(segnalibri)"
 
+#: ../src/msw/dlmsw.cpp:167
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (errore %ld: %s)"
+
+#: ../src/richtext/richtextformatdlg.cpp:876
+#: ../src/richtext/richtextliststylepage.cpp:448
+#: ../src/richtext/richtextliststylepage.cpp:460
+#: ../src/richtext/richtextliststylepage.cpp:461
 #: ../src/richtext/richtextindentspage.cpp:274
 #: ../src/richtext/richtextindentspage.cpp:286
 #: ../src/richtext/richtextindentspage.cpp:287
 #: ../src/richtext/richtextindentspage.cpp:311
 #: ../src/richtext/richtextindentspage.cpp:326
-#: ../src/richtext/richtextformatdlg.cpp:884
 #: ../src/richtext/richtextfontpage.cpp:349
 #: ../src/richtext/richtextfontpage.cpp:353
 #: ../src/richtext/richtextfontpage.cpp:357
-#: ../src/richtext/richtextliststylepage.cpp:448
-#: ../src/richtext/richtextliststylepage.cpp:460
-#: ../src/richtext/richtextliststylepage.cpp:461
 msgid "(none)"
 msgstr "(nessuno)"
 
@@ -896,7 +895,7 @@ msgstr "*)"
 msgid "+"
 msgstr "+"
 
-#: ../src/msw/utils.cpp:1152
+#: ../src/msw/utils.cpp:1143
 msgid ", 64-bit edition"
 msgstr ", versione 64-bit"
 
@@ -905,163 +904,163 @@ msgstr ", versione 64-bit"
 msgid "-"
 msgstr "-"
 
-#: ../src/generic/filepickerg.cpp:66
+#: ../src/generic/filepickerg.cpp:63
 msgid "..."
 msgstr "..."
 
-#: ../src/richtext/richtextindentspage.cpp:276
 #: ../src/richtext/richtextliststylepage.cpp:450
+#: ../src/richtext/richtextindentspage.cpp:276
 msgid "1.1"
 msgstr "1.1"
 
-#: ../src/richtext/richtextindentspage.cpp:277
 #: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextindentspage.cpp:277
 msgid "1.2"
 msgstr "1.2"
 
-#: ../src/richtext/richtextindentspage.cpp:278
 #: ../src/richtext/richtextliststylepage.cpp:452
+#: ../src/richtext/richtextindentspage.cpp:278
 msgid "1.3"
 msgstr "1.3"
 
-#: ../src/richtext/richtextindentspage.cpp:279
 #: ../src/richtext/richtextliststylepage.cpp:453
+#: ../src/richtext/richtextindentspage.cpp:279
 msgid "1.4"
 msgstr "1.4"
 
-#: ../src/richtext/richtextindentspage.cpp:280
 #: ../src/richtext/richtextliststylepage.cpp:454
+#: ../src/richtext/richtextindentspage.cpp:280
 msgid "1.5"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:281
 #: ../src/richtext/richtextliststylepage.cpp:455
+#: ../src/richtext/richtextindentspage.cpp:281
 msgid "1.6"
 msgstr "1.6"
 
-#: ../src/richtext/richtextindentspage.cpp:282
 #: ../src/richtext/richtextliststylepage.cpp:456
+#: ../src/richtext/richtextindentspage.cpp:282
 msgid "1.7"
 msgstr "1.7"
 
-#: ../src/richtext/richtextindentspage.cpp:283
 #: ../src/richtext/richtextliststylepage.cpp:457
+#: ../src/richtext/richtextindentspage.cpp:283
 msgid "1.8"
 msgstr "1.8"
 
-#: ../src/richtext/richtextindentspage.cpp:284
 #: ../src/richtext/richtextliststylepage.cpp:458
+#: ../src/richtext/richtextindentspage.cpp:284
 msgid "1.9"
 msgstr "1.9"
 
-#: ../src/common/paper.cpp:140
+#: ../src/common/paper.cpp:137
 msgid "10 x 11 in"
 msgstr "10 x 11 pollici"
 
-#: ../src/common/paper.cpp:113
+#: ../src/common/paper.cpp:110
 msgid "10 x 14 in"
 msgstr "10 x 14 pollici"
 
-#: ../src/common/paper.cpp:114
+#: ../src/common/paper.cpp:111
 msgid "11 x 17 in"
 msgstr "11 x 17 pollici"
 
-#: ../src/common/paper.cpp:184
+#: ../src/common/paper.cpp:181
 msgid "12 x 11 in"
 msgstr "12 x 11 pollici"
 
-#: ../src/common/paper.cpp:141
+#: ../src/common/paper.cpp:138
 msgid "15 x 11 in"
 msgstr "15 x 11 pollici"
 
-#: ../src/richtext/richtextindentspage.cpp:285
 #: ../src/richtext/richtextliststylepage.cpp:459
+#: ../src/richtext/richtextindentspage.cpp:285
 msgid "2"
 msgstr "2"
 
-#: ../src/common/paper.cpp:132
+#: ../src/common/paper.cpp:129
 msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
 msgstr "Busta 6 3/4, 3 5/8 x 6 1/2 pollici"
 
-#: ../src/common/paper.cpp:139
+#: ../src/common/paper.cpp:136
 msgid "9 x 11 in"
 msgstr "9 x 11 pollici"
 
-#: ../src/html/htmprint.cpp:431
+#: ../src/html/htmprint.cpp:443
 msgid ": file does not exist!"
 msgstr ": il file non esiste!"
 
-#: ../src/common/fontmap.cpp:199
+#: ../src/common/fontmap.cpp:196
 msgid ": unknown charset"
 msgstr ": set di caratteri sconosciuto"
 
-#: ../src/common/fontmap.cpp:413
+#: ../src/common/fontmap.cpp:410
 msgid ": unknown encoding"
 msgstr ": codifica sconosciuta"
 
-#: ../src/generic/wizard.cpp:443
+#: ../src/generic/wizard.cpp:438
 msgid "< &Back"
 msgstr "< &Indietro"
 
-#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:628
-#: ../src/osx/carbon/fontdlg.cpp:648
+#: ../src/osx/carbon/fontdlg.cpp:419 ../src/osx/carbon/fontdlg.cpp:625
+#: ../src/osx/carbon/fontdlg.cpp:645
 msgid "<Any Decorative>"
 msgstr "<Qualunque decorativo>"
 
-#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:630
-#: ../src/osx/carbon/fontdlg.cpp:650
+#: ../src/osx/carbon/fontdlg.cpp:420 ../src/osx/carbon/fontdlg.cpp:627
+#: ../src/osx/carbon/fontdlg.cpp:647
 msgid "<Any Modern>"
 msgstr "<Qualunque modern>"
 
-#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:626
-#: ../src/osx/carbon/fontdlg.cpp:646
+#: ../src/osx/carbon/fontdlg.cpp:418 ../src/osx/carbon/fontdlg.cpp:623
+#: ../src/osx/carbon/fontdlg.cpp:643
 msgid "<Any Roman>"
 msgstr "<Qualunque Roman>"
 
-#: ../src/osx/carbon/fontdlg.cpp:424 ../src/osx/carbon/fontdlg.cpp:632
-#: ../src/osx/carbon/fontdlg.cpp:652
+#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:629
+#: ../src/osx/carbon/fontdlg.cpp:649
 msgid "<Any Script>"
 msgstr "<Qualunque script>"
 
-#: ../src/osx/carbon/fontdlg.cpp:425 ../src/osx/carbon/fontdlg.cpp:637
-#: ../src/osx/carbon/fontdlg.cpp:656
+#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:634
+#: ../src/osx/carbon/fontdlg.cpp:653
 msgid "<Any Swiss>"
 msgstr "<Qualunque Svizzero>"
 
-#: ../src/osx/carbon/fontdlg.cpp:426 ../src/osx/carbon/fontdlg.cpp:634
-#: ../src/osx/carbon/fontdlg.cpp:654
+#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:631
+#: ../src/osx/carbon/fontdlg.cpp:651
 msgid "<Any Teletype>"
 msgstr "<Qualunque teletype>"
 
-#: ../src/osx/carbon/fontdlg.cpp:420
+#: ../src/osx/carbon/fontdlg.cpp:417
 msgid "<Any>"
 msgstr "<Qualunque>"
 
-#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
 msgid "<DIR>"
 msgstr "<CARTELLA>"
 
-#: ../src/generic/filectrlg.cpp:254 ../src/generic/filectrlg.cpp:277
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
 msgid "<DRIVE>"
 msgstr "<UNITA'>"
 
-#: ../src/generic/filectrlg.cpp:252 ../src/generic/filectrlg.cpp:275
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
 msgid "<LINK>"
 msgstr "<LINK>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1264
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Grassetto corsivo.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1270
+#: ../src/html/helpwnd.cpp:1268
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>grassetto corsivo <u>sottolineato</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1265
+#: ../src/html/helpwnd.cpp:1263
 msgid "<b>Bold face.</b> "
 msgstr "<b>Grassetto.</b> "
 
-#: ../src/html/helpwnd.cpp:1264
+#: ../src/html/helpwnd.cpp:1262
 msgid "<i>Italic face.</i> "
 msgstr "<i>Corsivo.</i> "
 
@@ -1070,15 +1069,15 @@ msgstr "<i>Corsivo.</i> "
 msgid ">"
 msgstr ">"
 
-#: ../src/generic/dbgrptg.cpp:318
+#: ../src/generic/dbgrptg.cpp:317
 msgid "A debug report has been generated in the directory\n"
 msgstr "È stata generata nella cartella una segnalazione di errore \n"
 
-#: ../src/common/debugrpt.cpp:573
+#: ../src/common/debugrpt.cpp:574
 msgid "A debug report has been generated. It can be found in"
 msgstr "È stata generato un rapporto di debug  nella cartella"
 
-#: ../src/common/xtixml.cpp:418
+#: ../src/common/xtixml.cpp:414
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Una collezione non vuota deve contenere nodi 'element'"
 
@@ -1089,106 +1088,106 @@ msgstr "Una collezione non vuota deve contenere nodi 'element'"
 msgid "A standard bullet name."
 msgstr "Il nome di una elenco puntato standard."
 
-#: ../src/common/paper.cpp:217
+#: ../src/common/paper.cpp:214
 msgid "A0 sheet, 841 x 1189 mm"
 msgstr "Foglio A0, 841 x 1189 mm"
 
-#: ../src/common/paper.cpp:218
+#: ../src/common/paper.cpp:215
 msgid "A1 sheet, 594 x 841 mm"
 msgstr "Foglio A1, 594 x 841 mm"
 
-#: ../src/common/paper.cpp:159
+#: ../src/common/paper.cpp:156
 msgid "A2 420 x 594 mm"
 msgstr "Foglio A2 420 x 594 mm"
 
-#: ../src/common/paper.cpp:156
+#: ../src/common/paper.cpp:153
 msgid "A3 Extra 322 x 445 mm"
 msgstr "Foglio A3 Extra 322 x 445 mm"
 
-#: ../src/common/paper.cpp:161
+#: ../src/common/paper.cpp:158
 msgid "A3 Extra Transverse 322 x 445 mm"
 msgstr "Foglio A3 Extra Transverse 322 x 445 mm"
 
-#: ../src/common/paper.cpp:170
+#: ../src/common/paper.cpp:167
 msgid "A3 Rotated 420 x 297 mm"
 msgstr "Foglio A3 Ruotato 420 x 297 mm"
 
-#: ../src/common/paper.cpp:160
+#: ../src/common/paper.cpp:157
 msgid "A3 Transverse 297 x 420 mm"
 msgstr "Foglio A3 Transverse 297 x 420 mm"
 
-#: ../src/common/paper.cpp:106
+#: ../src/common/paper.cpp:103
 msgid "A3 sheet, 297 x 420 mm"
 msgstr "Foglio A3, 297 x 420 mm"
 
-#: ../src/common/paper.cpp:146
+#: ../src/common/paper.cpp:143
 msgid "A4 Extra 9.27 x 12.69 in"
 msgstr "Foglio A4 Extra 235 x 322 mm"
 
-#: ../src/common/paper.cpp:153
+#: ../src/common/paper.cpp:150
 msgid "A4 Plus 210 x 330 mm"
 msgstr "Foglio A4 Plus 210 x 330 mm"
 
-#: ../src/common/paper.cpp:171
+#: ../src/common/paper.cpp:168
 msgid "A4 Rotated 297 x 210 mm"
 msgstr "Foglio A4 ruotato 297 x 210 mm"
 
-#: ../src/common/paper.cpp:148
+#: ../src/common/paper.cpp:145
 msgid "A4 Transverse 210 x 297 mm"
 msgstr "Foglio A4 Transverse 210 x 297 mm"
 
-#: ../src/common/paper.cpp:97
+#: ../src/common/paper.cpp:94
 msgid "A4 sheet, 210 x 297 mm"
 msgstr "Foglio A4, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:107
+#: ../src/common/paper.cpp:104
 msgid "A4 small sheet, 210 x 297 mm"
 msgstr "Foglio A4, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:157
+#: ../src/common/paper.cpp:154
 msgid "A5 Extra 174 x 235 mm"
 msgstr "Foglio A5 Extra 174 x 235 mm"
 
-#: ../src/common/paper.cpp:172
+#: ../src/common/paper.cpp:169
 msgid "A5 Rotated 210 x 148 mm"
 msgstr "Foglio A5 ruotato 210 x 148 mm"
 
-#: ../src/common/paper.cpp:154
+#: ../src/common/paper.cpp:151
 msgid "A5 Transverse 148 x 210 mm"
 msgstr "Foglio A5 Transverse 148 x 210 mm"
 
-#: ../src/common/paper.cpp:108
+#: ../src/common/paper.cpp:105
 msgid "A5 sheet, 148 x 210 mm"
 msgstr "Foglio A5, 148 x 210 mm"
 
-#: ../src/common/paper.cpp:164
+#: ../src/common/paper.cpp:161
 msgid "A6 105 x 148 mm"
 msgstr "Foglio A6 105 x 148 mm"
 
-#: ../src/common/paper.cpp:177
+#: ../src/common/paper.cpp:174
 msgid "A6 Rotated 148 x 105 mm"
 msgstr "Foglio A6 ruotato 148 x 105 mm"
 
-#: ../src/generic/fontdlgg.cpp:83 ../src/richtext/richtextformatdlg.cpp:529
-#: ../src/osx/carbon/fontdlg.cpp:153
+#: ../src/osx/carbon/fontdlg.cpp:150 ../src/generic/fontdlgg.cpp:79
+#: ../src/richtext/richtextformatdlg.cpp:521
 msgid "ABCDEFGabcdefg12345"
 msgstr "ABCDEFGabcdefg12345"
 
-#: ../src/richtext/richtextsymboldlg.cpp:458 ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
 msgid "ASCII"
 msgstr "ASCII"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "About"
 msgstr "Informazioni su"
 
-#: ../src/generic/aboutdlgg.cpp:140 ../src/osx/menu_osx.cpp:558
-#: ../src/msw/aboutdlg.cpp:64
+#: ../src/osx/menu_osx.cpp:450 ../src/generic/aboutdlgg.cpp:137
+#: ../src/msw/aboutdlg.cpp:61
 #, c-format
 msgid "About %s"
 msgstr "Informazioni su %s"
 
-#: ../src/osx/menu_osx.cpp:560
+#: ../src/osx/menu_osx.cpp:452
 msgid "About..."
 msgstr "Informazioni su..."
 
@@ -1197,37 +1196,37 @@ msgid "Absolute"
 msgstr "Assoluto"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:873
+#: ../src/propgrid/advprops.cpp:774
 msgid "ActiveBorder"
 msgstr "Bordo attivo"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:874
+#: ../src/propgrid/advprops.cpp:775
 msgid "ActiveCaption"
 msgstr "Titolo attivo"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "Actual Size"
 msgstr "Dimensione attuale"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:140 ../src/common/accelcmn.cpp:81
+#: ../src/common/stockitem.cpp:137 ../src/common/accelcmn.cpp:78
 msgid "Add"
 msgstr "Aggiungi"
 
-#: ../src/richtext/richtextbuffer.cpp:11455
+#: ../src/richtext/richtextbuffer.cpp:11454
 msgid "Add Column"
 msgstr "Aggiungi colonna"
 
-#: ../src/richtext/richtextbuffer.cpp:11392
+#: ../src/richtext/richtextbuffer.cpp:11391
 msgid "Add Row"
 msgstr "Aggiungi riga"
 
-#: ../src/html/helpwnd.cpp:432
+#: ../src/html/helpwnd.cpp:430
 msgid "Add current page to bookmarks"
 msgstr "Aggiungi la pagina corrente ai segnalibri"
 
-#: ../src/generic/colrdlgg.cpp:366
+#: ../src/generic/colrdlgg.cpp:386
 msgid "Add to custom colours"
 msgstr "Aggiungi ai colori personalizzati"
 
@@ -1239,12 +1238,12 @@ msgstr "AddToPropertyCollection chiamata su generic accessor"
 msgid "AddToPropertyCollection called w/o valid adder"
 msgstr "AddToPropertyCollection chiamata senza valid adder"
 
-#: ../src/html/helpctrl.cpp:159
+#: ../src/html/helpctrl.cpp:155
 #, c-format
 msgid "Adding book %s"
 msgstr "Aggiunta del libro %s in corso"
 
-#: ../src/common/preferencescmn.cpp:43
+#: ../src/common/preferencescmn.cpp:40
 msgid "Advanced"
 msgstr "Avanzate"
 
@@ -1252,11 +1251,11 @@ msgstr "Avanzate"
 msgid "After a paragraph:"
 msgstr "Dopo un paragrafo:"
 
-#: ../src/common/stockitem.cpp:172
+#: ../src/common/stockitem.cpp:169
 msgid "Align Left"
 msgstr "Allinea a destra"
 
-#: ../src/common/stockitem.cpp:173
+#: ../src/common/stockitem.cpp:170
 msgid "Align Right"
 msgstr "Allinea a destra"
 
@@ -1264,40 +1263,40 @@ msgstr "Allinea a destra"
 msgid "Alignment"
 msgstr "Allineamento"
 
-#: ../src/generic/prntdlgg.cpp:215
+#: ../src/generic/prntdlgg.cpp:208
 msgid "All"
 msgstr "Tutto"
 
-#: ../src/generic/filectrlg.cpp:1197 ../src/common/fldlgcmn.cpp:107
+#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1186
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Tutti i file (%s)|%s"
 
-#: ../include/wx/defs.h:2886
+#: ../include/wx/defs.h:2582
 msgid "All files (*)|*"
 msgstr "Tutti i file (*)|*"
 
-#: ../include/wx/defs.h:2883
+#: ../include/wx/defs.h:2579
 msgid "All files (*.*)|*.*"
 msgstr "Tutti i file (*.*)|*.*"
 
-#: ../src/richtext/richtextstyles.cpp:1061
+#: ../src/richtext/richtextstyles.cpp:1058
 msgid "All styles"
 msgstr "Tutti gli stili"
 
-#: ../src/propgrid/manager.cpp:1528
+#: ../src/propgrid/manager.cpp:1544
 msgid "Alphabetic Mode"
 msgstr "Modo alfabetico"
 
-#: ../src/common/xtistrm.cpp:425
+#: ../src/common/xtistrm.cpp:422
 msgid "Already Registered Object passed to SetObjectClassInfo"
 msgstr "Oggetto già registrato passato a SetObjectClassInfo"
 
-#: ../src/unix/dialup.cpp:353
+#: ../src/unix/dialup.cpp:352
 msgid "Already dialling ISP."
 msgstr "Chiamata verso l'ISP già in corso."
 
-#: ../src/common/accelcmn.cpp:331 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/accelcmn.cpp:345 ../src/univ/themes/win32.cpp:3753
 msgid "Alt+"
 msgstr "Alt+"
 
@@ -1306,34 +1305,34 @@ msgstr "Alt+"
 msgid "An optional corner radius for adding rounded corners."
 msgstr "Un raggio angolo opzionale per aggiungere angoli arrotondati."
 
-#: ../src/common/debugrpt.cpp:576
+#: ../src/common/debugrpt.cpp:577
 msgid "And includes the following files:\n"
 msgstr "E includi i seguenti file:\n"
 
-#: ../src/generic/animateg.cpp:162
+#: ../src/generic/animateg.cpp:145
 #, c-format
 msgid "Animation file is not of type %ld."
 msgstr "Il file animazione non è di tipo %ld."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:872
+#: ../src/propgrid/advprops.cpp:773
 msgid "AppWorkspace"
 msgstr "SpazioLavoroApp"
 
-#: ../src/generic/logg.cpp:1014
+#: ../src/generic/logg.cpp:1011
 #, c-format
 msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
 msgstr "Aggiungere registro al file '%s' (scegli [No] per sovrascriverlo)?"
 
-#: ../src/osx/menu_osx.cpp:577 ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:469 ../src/osx/menu_osx.cpp:477
 msgid "Application"
 msgstr "Applicazione"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "Apply"
 msgstr "Applica"
 
-#: ../src/propgrid/advprops.cpp:1609
+#: ../src/propgrid/advprops.cpp:1515
 msgid "Aqua"
 msgstr "Acqua"
 
@@ -1342,29 +1341,29 @@ msgstr "Acqua"
 msgid "Arabic"
 msgstr "Numeri arabi"
 
-#: ../src/common/fmapbase.cpp:153
+#: ../src/common/fmapbase.cpp:150
 msgid "Arabic (ISO-8859-6)"
 msgstr "Arabo (ISO-8859-6)"
 
-#: ../src/msw/ole/automtn.cpp:672
+#: ../src/msw/ole/automtn.cpp:663
 #, c-format
 msgid "Argument %u not found."
 msgstr "Argomento %u non trovato."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1753
+#: ../src/propgrid/advprops.cpp:1654
 msgid "Arrow"
 msgstr "Freccia"
 
-#: ../src/generic/aboutdlgg.cpp:184
+#: ../src/generic/aboutdlgg.cpp:181
 msgid "Artists"
 msgstr "Artisti"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "Ascending"
 msgstr "Ascendente"
 
-#: ../src/generic/filectrlg.cpp:433
+#: ../src/generic/filectrlg.cpp:429
 msgid "Attributes"
 msgstr "Attributi"
 
@@ -1374,90 +1373,90 @@ msgstr "Attributi"
 msgid "Available fonts."
 msgstr "Font disponibili."
 
-#: ../src/common/paper.cpp:137
+#: ../src/common/paper.cpp:134
 msgid "B4 (ISO) 250 x 353 mm"
 msgstr "Foglio B4 (ISO) 250 x 354 mm"
 
-#: ../src/common/paper.cpp:173
+#: ../src/common/paper.cpp:170
 msgid "B4 (JIS) Rotated 364 x 257 mm"
 msgstr "Foglio B4 (JIS) Ruotato 364 x 257 mm"
 
-#: ../src/common/paper.cpp:127
+#: ../src/common/paper.cpp:124
 msgid "B4 Envelope, 250 x 353 mm"
 msgstr "Busta B4, 250 x 353 mm"
 
-#: ../src/common/paper.cpp:109
+#: ../src/common/paper.cpp:106
 msgid "B4 sheet, 250 x 354 mm"
 msgstr "Foglio B4, 250 x 354 mm"
 
-#: ../src/common/paper.cpp:158
+#: ../src/common/paper.cpp:155
 msgid "B5 (ISO) Extra 201 x 276 mm"
 msgstr "Foglio B5 (ISO) Extra 201 x 276 mm"
 
-#: ../src/common/paper.cpp:174
+#: ../src/common/paper.cpp:171
 msgid "B5 (JIS) Rotated 257 x 182 mm"
 msgstr "Foglio B5 (JIS) Ruotato 257 x 182 mm"
 
-#: ../src/common/paper.cpp:155
+#: ../src/common/paper.cpp:152
 msgid "B5 (JIS) Transverse 182 x 257 mm"
 msgstr "Foglio B5 (JIS) 182 x 257 millimeter"
 
-#: ../src/common/paper.cpp:128
+#: ../src/common/paper.cpp:125
 msgid "B5 Envelope, 176 x 250 mm"
 msgstr "Busta B5, 176 x 250 mm"
 
-#: ../src/common/paper.cpp:110
+#: ../src/common/paper.cpp:107
 msgid "B5 sheet, 182 x 257 millimeter"
 msgstr "Foglio B5, 182 x 257 mm"
 
-#: ../src/common/paper.cpp:182
+#: ../src/common/paper.cpp:179
 msgid "B6 (JIS) 128 x 182 mm"
 msgstr "Foglio B6 (JIS) 128 x 182 mm"
 
-#: ../src/common/paper.cpp:183
+#: ../src/common/paper.cpp:180
 msgid "B6 (JIS) Rotated 182 x 128 mm"
 msgstr "Foglio B6 (JIS) Ruotato 182 x 128 mm"
 
-#: ../src/common/paper.cpp:129
+#: ../src/common/paper.cpp:126
 msgid "B6 Envelope, 176 x 125 mm"
 msgstr "Busta B6, 176 x 125 mm"
 
-#: ../src/common/imagbmp.cpp:531 ../src/common/imagbmp.cpp:561
-#: ../src/common/imagbmp.cpp:576
+#: ../src/common/imagbmp.cpp:528 ../src/common/imagbmp.cpp:558
+#: ../src/common/imagbmp.cpp:573
 msgid "BMP: Couldn't allocate memory."
 msgstr "BMP: Impossibile allocare la memoria."
 
-#: ../src/common/imagbmp.cpp:100
+#: ../src/common/imagbmp.cpp:97
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: Impossibile salvare un'immagine non valida."
 
-#: ../src/common/imagbmp.cpp:356
+#: ../src/common/imagbmp.cpp:353
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: Impossibile scrivere la mappa dei colori RGB."
 
-#: ../src/common/imagbmp.cpp:490
+#: ../src/common/imagbmp.cpp:487
 msgid "BMP: Couldn't write data."
 msgstr "BMP: Impossibile scrivere i dati."
 
-#: ../src/common/imagbmp.cpp:246
+#: ../src/common/imagbmp.cpp:243
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: Impossibile scrivere l'header (Bitmap) del file."
 
-#: ../src/common/imagbmp.cpp:269
+#: ../src/common/imagbmp.cpp:266
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: Impossibile scrivere l'header (BitmapInfo) del file."
 
-#: ../src/common/imagbmp.cpp:140
+#: ../src/common/imagbmp.cpp:137
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: l'oggetto wxImage non ha una propria wxPalette."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:142 ../src/common/accelcmn.cpp:52
+#: ../src/common/stockitem.cpp:139 ../src/common/accelcmn.cpp:49
 msgid "Back"
 msgstr "Indietro"
 
+#: ../src/richtext/richtextformatdlg.cpp:377
 #: ../src/richtext/richtextbackgroundpage.cpp:148
-#: ../src/richtext/richtextformatdlg.cpp:384
 msgid "Background"
 msgstr "Sfondo"
 
@@ -1465,20 +1464,20 @@ msgstr "Sfondo"
 msgid "Background &colour:"
 msgstr "Colore di &sfondo:"
 
-#: ../src/osx/carbon/fontdlg.cpp:220
+#: ../src/osx/carbon/fontdlg.cpp:217
 msgid "Background colour"
 msgstr "Colore di sfondo"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:52
+#: ../src/common/accelcmn.cpp:49
 msgid "Backspace"
 msgstr "Backspace"
 
-#: ../src/common/fmapbase.cpp:160
+#: ../src/common/fmapbase.cpp:157
 msgid "Baltic (ISO-8859-13)"
 msgstr "Baltico (ISO-8859-13)"
 
-#: ../src/common/fmapbase.cpp:151
+#: ../src/common/fmapbase.cpp:148
 msgid "Baltic (old) (ISO-8859-4)"
 msgstr "Baltico (vecchio) (ISO-8859-4)"
 
@@ -1491,25 +1490,25 @@ msgstr "Prima di un paragrafo:"
 msgid "Bitmap"
 msgstr "Immagine"
 
-#: ../src/propgrid/advprops.cpp:1594
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Black"
 msgstr "Nero"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1755
+#: ../src/propgrid/advprops.cpp:1656
 msgid "Blank"
 msgstr "Vuoto"
 
-#: ../src/propgrid/advprops.cpp:1603
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Blue"
 msgstr "Blu"
 
-#: ../src/generic/colrdlgg.cpp:345
+#: ../src/generic/colrdlgg.cpp:365
 msgid "Blue:"
 msgstr "Blu:"
 
-#: ../src/generic/fontdlgg.cpp:333 ../src/richtext/richtextfontpage.cpp:355
-#: ../src/osx/carbon/fontdlg.cpp:354 ../src/common/stockitem.cpp:143
+#: ../src/osx/carbon/fontdlg.cpp:351 ../src/common/stockitem.cpp:140
+#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:355
 msgid "Bold"
 msgstr "Grassetto"
 
@@ -1518,31 +1517,35 @@ msgstr "Grassetto"
 msgid "Border"
 msgstr "Bordo"
 
-#: ../src/richtext/richtextformatdlg.cpp:379
+#: ../src/richtext/richtextformatdlg.cpp:372
 msgid "Borders"
 msgstr "Bordi"
 
-#: ../src/richtext/richtextsizepage.cpp:288 ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141 ../src/richtext/richtextsizepage.cpp:288
 msgid "Bottom"
 msgstr "Basso"
 
-#: ../src/generic/prntdlgg.cpp:893
+#: ../src/generic/prntdlgg.cpp:886
 msgid "Bottom margin (mm):"
 msgstr "Margine inferiore (mm):"
 
-#: ../src/richtext/richtextbuffer.cpp:9383
+#: ../src/richtext/richtextbuffer.cpp:9380
 msgid "Box Properties"
 msgstr "Proprietà riquadro"
 
-#: ../src/richtext/richtextstyles.cpp:1065
+#: ../src/richtext/richtextstyles.cpp:1062
 msgid "Box styles"
 msgstr "Stile riquadro"
 
-#: ../src/propgrid/advprops.cpp:1602
+#: ../src/osx/cocoa/menu.mm:292
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Brown"
 msgstr "Marrone"
 
-#: ../src/common/filepickercmn.cpp:43 ../src/common/filepickercmn.cpp:44
+#: ../src/common/filepickercmn.cpp:40 ../src/common/filepickercmn.cpp:41
 msgid "Browse"
 msgstr "Sfoglia"
 
@@ -1555,72 +1558,72 @@ msgstr "&Allineamento elenco puntato:"
 msgid "Bullet style"
 msgstr "Stile del punto"
 
-#: ../src/richtext/richtextformatdlg.cpp:359
+#: ../src/richtext/richtextformatdlg.cpp:352
 msgid "Bullets"
 msgstr "Puntatura"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1756
+#: ../src/propgrid/advprops.cpp:1657
 msgid "Bullseye"
 msgstr "Stile punto elenco"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:875
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonFace"
 msgstr "ApparenzaPulsante"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:876
+#: ../src/propgrid/advprops.cpp:777
 msgid "ButtonHighlight"
 msgstr "EvidenziazionePulsante"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:877
+#: ../src/propgrid/advprops.cpp:778
 msgid "ButtonShadow"
 msgstr "OmbreggiaturaPulasnte"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:878
+#: ../src/propgrid/advprops.cpp:779
 msgid "ButtonText"
 msgstr "TestoPulsante"
 
-#: ../src/common/paper.cpp:98
+#: ../src/common/paper.cpp:95
 msgid "C sheet, 17 x 22 in"
 msgstr "Foglio C, 17 x 22 pollici"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "C&lear"
 msgstr "A&zzera"
 
-#: ../src/generic/fontdlgg.cpp:406
+#: ../src/generic/fontdlgg.cpp:403
 msgid "C&olour:"
 msgstr "C&olore:"
 
-#: ../src/common/paper.cpp:123
+#: ../src/common/paper.cpp:120
 msgid "C3 Envelope, 324 x 458 mm"
 msgstr "Busta C3, 324 x 458 mm"
 
-#: ../src/common/paper.cpp:124
+#: ../src/common/paper.cpp:121
 msgid "C4 Envelope, 229 x 324 mm"
 msgstr "Busta C4, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:122
+#: ../src/common/paper.cpp:119
 msgid "C5 Envelope, 162 x 229 mm"
 msgstr "Busta C5, 162 x 229 mm"
 
-#: ../src/common/paper.cpp:125
+#: ../src/common/paper.cpp:122
 msgid "C6 Envelope, 114 x 162 mm"
 msgstr "Busta C6, 114 x 162 mm"
 
-#: ../src/common/paper.cpp:126
+#: ../src/common/paper.cpp:123
 msgid "C65 Envelope, 114 x 229 mm"
 msgstr "Busta C65, 114 x 229 mm"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "CD-Rom"
 msgstr "CD-ROM"
 
-#: ../src/html/chm.cpp:815 ../src/html/chm.cpp:874
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:865
 msgid "CHM handler currently supports only local files!"
 msgstr "Il gestore di file CHM supporta unicamente file locali!"
 
@@ -1628,196 +1631,200 @@ msgstr "Il gestore di file CHM supporta unicamente file locali!"
 msgid "Ca&pitals"
 msgstr "&Maiuscole"
 
-#: ../src/common/cmdproc.cpp:267
+#: ../src/common/cmdproc.cpp:260
 msgid "Can't &Undo "
 msgstr "Impossibile &annullare "
 
-#: ../src/common/image.cpp:2824
+#: ../src/common/image.cpp:2924
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 "Impossibile determinare il formato immaggine per input non- selezionabile."
 
-#: ../src/msw/registry.cpp:506
+#: ../src/msw/registry.cpp:495
 #, c-format
 msgid "Can't close registry key '%s'"
 msgstr "Impossibile chiudere la chiave '%s' del registro di sistema"
 
-#: ../src/msw/registry.cpp:584
+#: ../src/msw/registry.cpp:573
 #, c-format
 msgid "Can't copy values of unsupported type %d."
 msgstr "Impossibile copiare valori del tipo non supportato %d."
 
-#: ../src/msw/registry.cpp:487
+#: ../src/msw/registry.cpp:476
 #, c-format
 msgid "Can't create registry key '%s'"
 msgstr "Impossibile creare la chiave '%s' del registro di sistema"
 
-#: ../src/msw/thread.cpp:665
+#: ../src/msw/thread.cpp:657
 msgid "Can't create thread"
 msgstr "Impossibile creare il thread"
 
-#: ../src/msw/window.cpp:3691
-#, c-format
-msgid "Can't create window of class %s"
-msgstr "Impossibile creare una finestra di classe %s"
-
-#: ../src/msw/registry.cpp:777
+#: ../src/msw/registry.cpp:765
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Impossibile eliminare la chiave '%s'"
 
-#: ../src/msw/iniconf.cpp:458
+#: ../src/msw/iniconf.cpp:455
 #, c-format
 msgid "Can't delete the INI file '%s'"
 msgstr "Impossibile eliminare il file INI '%s'"
 
-#: ../src/msw/registry.cpp:805
+#: ../src/msw/registry.cpp:793
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Impossibile eliminare il valore '%s' dalla chiave '%s'"
 
-#: ../src/msw/registry.cpp:1171
+#: ../src/msw/registry.cpp:1159
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Impossibile elencare le sottochiavi della chiave '%s'"
 
-#: ../src/msw/registry.cpp:1132
+#: ../src/msw/registry.cpp:1120
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Impossibile elencare i valori della chiave '%s'"
 
-#: ../src/msw/registry.cpp:1389
+#: ../src/msw/registry.cpp:1377
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Impossibile esportare valori del tipo non supportato %d."
 
-#: ../src/common/ffile.cpp:254
+#: ../src/common/ffile.cpp:253
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Impossibile determinare la posizione corrente del file '%s'"
 
-#: ../src/msw/registry.cpp:418
+#: ../src/msw/registry.cpp:407
 #, c-format
 msgid "Can't get info about registry key '%s'"
 msgstr ""
 "Impossibile ottenere informazioni sulla chiave '%s' del registro di sistema"
 
-#: ../src/common/zstream.cpp:346
+#: ../src/msw/webview_ie.cpp:1024
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "Impossibile impostare la priorità del thread"
+
+#: ../src/common/zstream.cpp:343
 msgid "Can't initialize zlib deflate stream."
 msgstr "Impossibile inizializzare il flusso zlib di decompressione."
 
-#: ../src/common/zstream.cpp:185
+#: ../src/common/zstream.cpp:182
 msgid "Can't initialize zlib inflate stream."
 msgstr "Impossibile inizializzare il flusso di compressione zlib."
 
-#: ../src/msw/fswatcher.cpp:476
+#: ../src/msw/fswatcher.cpp:475
 #, c-format
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "Impossibile monitorare la cartella \"%s\" per le modifiche."
 
-#: ../src/msw/registry.cpp:454
+#: ../src/msw/registry.cpp:443
 #, c-format
 msgid "Can't open registry key '%s'"
 msgstr "Impossibile aprire la chiave '%s' del registro di sistema"
 
-#: ../src/common/zstream.cpp:252
+#: ../src/common/zstream.cpp:249
 #, c-format
 msgid "Can't read from inflate stream: %s"
 msgstr "Impossibile leggere dal flusso di decompressione: %s"
 
-#: ../src/common/zstream.cpp:244
+#: ../src/common/zstream.cpp:241
 msgid "Can't read inflate stream: unexpected EOF in underlying stream."
 msgstr ""
 "Impossibile leggere il flusso di decompressione: fine del file inattesa nel "
 "flusso di ingresso."
 
-#: ../src/msw/registry.cpp:1064
+#: ../src/msw/registry.cpp:1052
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Impossibile leggere il valore di '%s'"
 
-#: ../src/msw/registry.cpp:878 ../src/msw/registry.cpp:910
-#: ../src/msw/registry.cpp:975
+#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
+#: ../src/msw/registry.cpp:963
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Impossibile leggere il valore della chiave '%s'"
 
-#: ../src/common/image.cpp:2620
+#: ../src/msw/webview_ie.cpp:1017
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/common/image.cpp:2715
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "Impossibile salvare l'immagine nel file '%s': estensione sconosciuta."
 
-#: ../src/generic/logg.cpp:573 ../src/generic/logg.cpp:976
+#: ../src/generic/logg.cpp:570 ../src/generic/logg.cpp:973
 msgid "Can't save log contents to file."
 msgstr "Impossibile salvare il contenuto del registro su file."
 
-#: ../src/msw/thread.cpp:629
+#: ../src/msw/thread.cpp:621
 msgid "Can't set thread priority"
 msgstr "Impossibile impostare la priorità del thread"
 
-#: ../src/msw/registry.cpp:896 ../src/msw/registry.cpp:938
-#: ../src/msw/registry.cpp:1081
+#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
+#: ../src/msw/registry.cpp:1069
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Impossibile impostare il valore di '%s'"
 
-#: ../src/unix/utilsunx.cpp:351
+#: ../src/unix/utilsunx.cpp:353
 msgid "Can't write to child process's stdin"
 msgstr "Impossibile scrivere nello stdin del processo figlio"
 
-#: ../src/common/zstream.cpp:427
+#: ../src/common/zstream.cpp:424
 #, c-format
 msgid "Can't write to deflate stream: %s"
 msgstr "Impossibile scrivere new flusso di compressione: %s"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:279 ../src/richtext/richtextstyledlg.cpp:300
-#: ../src/common/stockitem.cpp:145 ../src/common/accelcmn.cpp:71
-#: ../src/msw/msgdlg.cpp:454 ../src/msw/progdlg.cpp:673
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:142
+#: ../src/common/accelcmn.cpp:68 ../src/motif/msgdlg.cpp:196
+#: ../src/gtk1/fontdlg.cpp:144 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/progdlg.cpp:940 ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Annulla"
 
-#: ../src/common/filefn.cpp:1261
+#: ../src/common/filefn.cpp:1149
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Impossibile elencare i file '%s'"
 
-#: ../src/msw/dir.cpp:263
+#: ../src/msw/dir.cpp:260
 #, c-format
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Impossibile elencare i file nella cartella '%s'"
 
-#: ../src/msw/dialup.cpp:523
+#: ../src/msw/dialup.cpp:517
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Impossibile trovare la connessione attiva: %s"
 
-#: ../src/msw/dialup.cpp:827
+#: ../src/msw/dialup.cpp:821
 msgid "Cannot find the location of address book file"
 msgstr "Impossibile trovare il file degli indirizzi"
 
-#: ../src/msw/ole/automtn.cpp:562
+#: ../src/msw/ole/automtn.cpp:553
 #, c-format
 msgid "Cannot get an active instance of \"%s\""
 msgstr "Impossibile ottenere una istanza attiva di \"%s\""
 
-#: ../src/unix/threadpsx.cpp:1035
+#: ../src/unix/threadpsx.cpp:1053
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr ""
 "Impossibile ottenere un intervallo di priorità per la strategia di "
 "pianificazione %d."
 
-#: ../src/unix/utilsunx.cpp:987
+#: ../src/unix/utilsunx.cpp:989
 msgid "Cannot get the hostname"
 msgstr "Impossibile ottenere il nome dell'host"
 
-#: ../src/unix/utilsunx.cpp:1023
+#: ../src/unix/utilsunx.cpp:1025
 msgid "Cannot get the official hostname"
 msgstr "Impossibile ottenere il nome ufficiale dell'host"
 
-#: ../src/msw/dialup.cpp:928
+#: ../src/msw/dialup.cpp:922
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Impossibile disconnettersi - nessuna connessione attiva."
 
@@ -1825,126 +1832,126 @@ msgstr "Impossibile disconnettersi - nessuna connessione attiva."
 msgid "Cannot initialize OLE"
 msgstr "Impossibile inizializzare OLE"
 
-#: ../src/common/socket.cpp:853
+#: ../src/common/socket.cpp:850
 msgid "Cannot initialize sockets"
 msgstr "Impossibile inizializzare socket"
 
-#: ../src/msw/volume.cpp:619
+#: ../src/msw/volume.cpp:627
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Impossibile caricare l'icona da '%s'."
 
-#: ../src/xrc/xmlres.cpp:360
+#: ../src/xrc/xmlres.cpp:358
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Impossibile caricare le risorse da '%s'."
 
-#: ../src/xrc/xmlres.cpp:742
+#: ../src/xrc/xmlres.cpp:740
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Impossibile caricare le risorse dal file '%s'."
 
-#: ../src/html/htmlfilt.cpp:137
+#: ../src/html/htmlfilt.cpp:134
 #, c-format
 msgid "Cannot open HTML document: %s"
 msgstr "Impossibile aprire il documento HTML: %s"
 
-#: ../src/html/helpdata.cpp:667
+#: ../src/html/helpdata.cpp:660
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Impossibile aprire il libro di help HTML: %s"
 
-#: ../src/html/helpdata.cpp:299
+#: ../src/html/helpdata.cpp:296
 #, c-format
 msgid "Cannot open contents file: %s"
 msgstr "Impossibile aprire il file sommario: %s"
 
-#: ../src/generic/dcpsg.cpp:1667
+#: ../src/generic/dcpsg.cpp:1665
 msgid "Cannot open file for PostScript printing!"
 msgstr "Impossibile aprire il file per la stampa PostScript!"
 
-#: ../src/html/helpdata.cpp:313
+#: ../src/html/helpdata.cpp:310
 #, c-format
 msgid "Cannot open index file: %s"
 msgstr "Impossibile aprire il file indice: %s"
 
-#: ../src/xrc/xmlres.cpp:724
+#: ../src/xrc/xmlres.cpp:722
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Impossibile aprire il file risorse '%s'."
 
-#: ../src/html/helpwnd.cpp:1534
+#: ../src/html/helpwnd.cpp:1532
 msgid "Cannot print empty page."
 msgstr "Impossibile stampare una pagina vuota."
 
-#: ../src/msw/volume.cpp:507
+#: ../src/msw/volume.cpp:515
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Impossibile leggere l'identificatore di tipo da '%s'!"
 
-#: ../src/msw/thread.cpp:888
+#: ../src/msw/thread.cpp:894
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Impossibile riprendere il thread %lx"
 
-#: ../src/unix/threadpsx.cpp:1016
+#: ../src/unix/threadpsx.cpp:1028
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Impossibile determinare la strategia di scheduling."
 
-#: ../src/common/intl.cpp:558
+#: ../src/common/intl.cpp:365
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "Impossibile impostare locale a lingua  \"%s\"."
 
-#: ../src/unix/threadpsx.cpp:831 ../src/msw/thread.cpp:546
+#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
 msgid "Cannot start thread: error writing TLS."
 msgstr "Impossibile avviare il thread: errore nella scrittura del TLS."
 
-#: ../src/msw/thread.cpp:872
+#: ../src/msw/thread.cpp:864
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Impossibile sospendere il thread %lx"
 
-#: ../src/msw/thread.cpp:794
+#: ../src/msw/thread.cpp:786
 msgid "Cannot wait for thread termination"
 msgstr "Impossibile attendere la fine del thread"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:75
+#: ../src/common/accelcmn.cpp:72
 msgid "Capital"
 msgstr "Miauscole"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:879
+#: ../src/propgrid/advprops.cpp:780
 msgid "CaptionText"
 msgstr "TitoloTesto"
 
-#: ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:531
 msgid "Case sensitive"
 msgstr "Maiuscole/minuscole"
 
-#: ../src/propgrid/manager.cpp:1509
+#: ../src/propgrid/manager.cpp:1527
 msgid "Categorized Mode"
 msgstr "Modo categorizzato"
 
-#: ../src/richtext/richtextbuffer.cpp:9968
+#: ../src/richtext/richtextbuffer.cpp:9965
 msgid "Cell Properties"
 msgstr "Proprietà cella"
 
-#: ../src/common/fmapbase.cpp:161
+#: ../src/common/fmapbase.cpp:158
 msgid "Celtic (ISO-8859-14)"
 msgstr "Celtico (ISO-8859-14)"
 
-#: ../src/richtext/richtextindentspage.cpp:160
 #: ../src/richtext/richtextliststylepage.cpp:349
+#: ../src/richtext/richtextindentspage.cpp:160
 msgid "Cen&tred"
 msgstr "Cen&trato"
 
-#: ../src/common/stockitem.cpp:170
+#: ../src/common/stockitem.cpp:167
 msgid "Centered"
 msgstr "Centrato"
 
-#: ../src/common/fmapbase.cpp:149
+#: ../src/common/fmapbase.cpp:146
 msgid "Central European (ISO-8859-2)"
 msgstr "Europeo Centrale (ISO-8859-2)"
 
@@ -1953,10 +1960,10 @@ msgstr "Europeo Centrale (ISO-8859-2)"
 msgid "Centre"
 msgstr "Centro"
 
-#: ../src/richtext/richtextindentspage.cpp:162
-#: ../src/richtext/richtextindentspage.cpp:164
 #: ../src/richtext/richtextliststylepage.cpp:351
 #: ../src/richtext/richtextliststylepage.cpp:353
+#: ../src/richtext/richtextindentspage.cpp:162
+#: ../src/richtext/richtextindentspage.cpp:164
 msgid "Centre text."
 msgstr "Centra il testo."
 
@@ -1969,24 +1976,24 @@ msgstr "Centrato"
 msgid "Ch&oose..."
 msgstr "&Scegli..."
 
-#: ../src/richtext/richtextbuffer.cpp:4354
+#: ../src/richtext/richtextbuffer.cpp:4351
 msgid "Change List Style"
 msgstr "Modifica lo stile dell'elenco"
 
-#: ../src/richtext/richtextbuffer.cpp:3709
+#: ../src/richtext/richtextbuffer.cpp:3706
 msgid "Change Object Style"
 msgstr "Modifica stile oggetto"
 
-#: ../src/richtext/richtextbuffer.cpp:3982
-#: ../src/richtext/richtextbuffer.cpp:8129
+#: ../src/richtext/richtextbuffer.cpp:3979
+#: ../src/richtext/richtextbuffer.cpp:8125
 msgid "Change Properties"
 msgstr "Modifica proprietà"
 
-#: ../src/richtext/richtextbuffer.cpp:3526
+#: ../src/richtext/richtextbuffer.cpp:3523
 msgid "Change Style"
 msgstr "Modifica lo stile"
 
-#: ../src/common/fileconf.cpp:341
+#: ../src/common/fileconf.cpp:335
 #, c-format
 msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
 msgstr ""
@@ -1999,11 +2006,11 @@ msgid "Changing current directory to \"%s\" failed"
 msgstr "Impossibile modificare la cartella attuale a \"%s\""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1757
+#: ../src/propgrid/advprops.cpp:1658
 msgid "Character"
 msgstr "Carattere"
 
-#: ../src/richtext/richtextstyles.cpp:1063
+#: ../src/richtext/richtextstyles.cpp:1060
 msgid "Character styles"
 msgstr "Stili di carattere"
 
@@ -2040,20 +2047,20 @@ msgstr "Spunta pe racchiudere la puntatura in una coppia di parentesi."
 msgid "Check to indicate right-to-left text layout."
 msgstr "Seleziona per indicare layout testo destra-a-sinistra."
 
-#: ../src/osx/carbon/fontdlg.cpp:356 ../src/osx/carbon/fontdlg.cpp:358
+#: ../src/osx/carbon/fontdlg.cpp:353 ../src/osx/carbon/fontdlg.cpp:355
 msgid "Check to make the font bold."
 msgstr "Clic per rendere il font grassetto."
 
-#: ../src/osx/carbon/fontdlg.cpp:363 ../src/osx/carbon/fontdlg.cpp:365
+#: ../src/osx/carbon/fontdlg.cpp:360 ../src/osx/carbon/fontdlg.cpp:362
 msgid "Check to make the font italic."
 msgstr "Seleziona per rendere il font corsivo."
 
-#: ../src/osx/carbon/fontdlg.cpp:372 ../src/osx/carbon/fontdlg.cpp:374
+#: ../src/osx/carbon/fontdlg.cpp:369 ../src/osx/carbon/fontdlg.cpp:371
 msgid "Check to make the font underlined."
 msgstr "Seleziona per rendere il font sottolineato."
 
-#: ../src/richtext/richtextstyledlg.cpp:289
-#: ../src/richtext/richtextstyledlg.cpp:291
+#: ../src/richtext/richtextstyledlg.cpp:285
+#: ../src/richtext/richtextstyledlg.cpp:287
 msgid "Check to restart numbering."
 msgstr "Spunta per ricominciare la numerazione."
 
@@ -2087,52 +2094,52 @@ msgstr "Spunta pe visualizzare il testo ome apice."
 msgid "Check to suppress hyphenation."
 msgstr "Seleziona per disabliltare la sillabazione."
 
-#: ../src/msw/dialup.cpp:763
+#: ../src/msw/dialup.cpp:757
 msgid "Choose ISP to dial"
 msgstr "Scegli l'ISP da chiamare"
 
-#: ../src/propgrid/props.cpp:1922
+#: ../src/propgrid/props.cpp:1904
 msgid "Choose a directory:"
 msgstr "Scegli una cartella:"
 
-#: ../src/propgrid/props.cpp:1975
+#: ../src/propgrid/props.cpp:2199
 msgid "Choose a file"
 msgstr "Scegli un file"
 
-#: ../src/generic/colrdlgg.cpp:158 ../src/gtk/colordlg.cpp:54
+#: ../src/generic/colrdlgg.cpp:156 ../src/gtk/colordlg.cpp:49
 msgid "Choose colour"
 msgstr "Scegli un colore"
 
-#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/gtk1/fontdlg.cpp:125 ../src/generic/fontpickerg.cpp:47
+#: ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Carattere"
 
-#: ../src/common/module.cpp:74
+#: ../src/common/module.cpp:71
 #, c-format
 msgid "Circular dependency involving module \"%s\" detected."
 msgstr ""
 "È stata trovata una dipendenza circolare che coinvolge il modulo \"%s\"."
 
-#: ../src/aui/tabmdi.cpp:108 ../src/generic/mdig.cpp:97
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
 msgid "Cl&ose"
 msgstr "C&hiudi"
 
-#: ../src/msw/ole/automtn.cpp:684
+#: ../src/msw/ole/automtn.cpp:675
 msgid "Class not registered."
 msgstr "Classe non registrata."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:147 ../src/common/accelcmn.cpp:72
+#: ../src/common/stockitem.cpp:144 ../src/common/accelcmn.cpp:69
 msgid "Clear"
 msgstr "Azzera"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "Clear the log contents"
 msgstr "Eliminare il contenuto del registro"
 
-#: ../src/richtext/richtextstyledlg.cpp:252
-#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:248
+#: ../src/richtext/richtextstyledlg.cpp:250
 msgid "Click to apply the selected style."
 msgstr "Seleziona per applicare lo stile corrente."
 
@@ -2143,15 +2150,15 @@ msgstr "Seleziona per applicare lo stile corrente."
 msgid "Click to browse for a symbol."
 msgstr "Seleziona per selezionare un simbolo."
 
-#: ../src/osx/carbon/fontdlg.cpp:403 ../src/osx/carbon/fontdlg.cpp:405
+#: ../src/osx/carbon/fontdlg.cpp:400 ../src/osx/carbon/fontdlg.cpp:402
 msgid "Click to cancel changes to the font."
 msgstr "Seleziona per annullare le modifiche al font."
 
-#: ../src/generic/fontdlgg.cpp:472 ../src/generic/fontdlgg.cpp:491
+#: ../src/generic/fontdlgg.cpp:468 ../src/generic/fontdlgg.cpp:487
 msgid "Click to cancel the font selection."
 msgstr "Seleziona per annullare la selezione del font."
 
-#: ../src/osx/carbon/fontdlg.cpp:384 ../src/osx/carbon/fontdlg.cpp:386
+#: ../src/osx/carbon/fontdlg.cpp:381 ../src/osx/carbon/fontdlg.cpp:383
 msgid "Click to change the font colour."
 msgstr "Seleziona per modificare il colore del font."
 
@@ -2170,37 +2177,37 @@ msgstr "Seleziona per modificare il colore del testo."
 msgid "Click to choose the font for this level."
 msgstr "Seleziona per selezionare il font per il livello corrente."
 
-#: ../src/richtext/richtextstyledlg.cpp:279
-#: ../src/richtext/richtextstyledlg.cpp:281
+#: ../src/richtext/richtextstyledlg.cpp:275
+#: ../src/richtext/richtextstyledlg.cpp:277
 msgid "Click to close this window."
 msgstr "Seleziona per chiudere questa finestra."
 
-#: ../src/osx/carbon/fontdlg.cpp:410 ../src/osx/carbon/fontdlg.cpp:412
+#: ../src/osx/carbon/fontdlg.cpp:407 ../src/osx/carbon/fontdlg.cpp:409
 msgid "Click to confirm changes to the font."
 msgstr "Seleziona per confermare le modifiche al font."
 
-#: ../src/generic/fontdlgg.cpp:477 ../src/generic/fontdlgg.cpp:479
-#: ../src/generic/fontdlgg.cpp:484 ../src/generic/fontdlgg.cpp:486
+#: ../src/generic/fontdlgg.cpp:473 ../src/generic/fontdlgg.cpp:475
+#: ../src/generic/fontdlgg.cpp:480 ../src/generic/fontdlgg.cpp:482
 msgid "Click to confirm the font selection."
 msgstr "Seleziona per confermare la selezione del font."
 
-#: ../src/richtext/richtextstyledlg.cpp:244
-#: ../src/richtext/richtextstyledlg.cpp:246
+#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:242
 msgid "Click to create a new box style."
 msgstr "Seleziona per creare un nuovo stile riquadro."
 
-#: ../src/richtext/richtextstyledlg.cpp:226
-#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:224
 msgid "Click to create a new character style."
 msgstr "Seleziona per creare un nuovo stile di carattere."
 
-#: ../src/richtext/richtextstyledlg.cpp:238
-#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:236
 msgid "Click to create a new list style."
 msgstr "Clic per creare un nuovo stile di elenco."
 
-#: ../src/richtext/richtextstyledlg.cpp:232
-#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:230
 msgid "Click to create a new paragraph style."
 msgstr "Clic per creare un nuovo stile di paragrafo."
 
@@ -2214,8 +2221,8 @@ msgstr "Clic per creare un nuovo punto di tabulazione."
 msgid "Click to delete all tab positions."
 msgstr "Clic per eliminare tutti i punti di tabulazione."
 
-#: ../src/richtext/richtextstyledlg.cpp:270
-#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:268
 msgid "Click to delete the selected style."
 msgstr "Clic per eliminare lo stile selezionato."
 
@@ -2224,25 +2231,25 @@ msgstr "Clic per eliminare lo stile selezionato."
 msgid "Click to delete the selected tab position."
 msgstr "Clic per eliminare il punto di tabulazione selezionato."
 
-#: ../src/richtext/richtextstyledlg.cpp:264
-#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:262
 msgid "Click to edit the selected style."
 msgstr "Clic per modificare lo stile selezionato."
 
-#: ../src/richtext/richtextstyledlg.cpp:258
-#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:256
 msgid "Click to rename the selected style."
 msgstr "Clic per rinominare lo stile selezionato."
 
-#: ../src/generic/dbgrptg.cpp:97 ../src/generic/progdlgg.cpp:759
-#: ../src/richtext/richtextstyledlg.cpp:277
-#: ../src/richtext/richtextsymboldlg.cpp:476 ../src/common/stockitem.cpp:148
-#: ../src/msw/progdlg.cpp:170 ../src/msw/progdlg.cpp:679
-#: ../src/html/helpdlg.cpp:90
+#: ../src/common/stockitem.cpp:145 ../src/generic/dbgrptg.cpp:94
+#: ../src/generic/progdlgg.cpp:781 ../src/msw/progdlg.cpp:211
+#: ../src/msw/progdlg.cpp:946 ../src/html/helpdlg.cpp:87
+#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextstyledlg.cpp:273
 msgid "Close"
 msgstr "Chiudi"
 
-#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:98
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
 msgid "Close All"
 msgstr "Chiudi &tutto"
 
@@ -2250,43 +2257,43 @@ msgstr "Chiudi &tutto"
 msgid "Close current document"
 msgstr "Chiudi il documento attuale"
 
-#: ../src/generic/logg.cpp:516
+#: ../src/generic/logg.cpp:513
 msgid "Close this window"
 msgstr "Chiudi questa finestra"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6006
+#: ../src/generic/datavgen.cpp:6811
 msgid "Collapse"
 msgstr "Riduci"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "Color"
 msgstr "Colore"
 
-#: ../src/richtext/richtextformatdlg.cpp:776
+#: ../src/richtext/richtextformatdlg.cpp:768
 msgid "Colour"
 msgstr "Colore"
 
-#: ../src/msw/colordlg.cpp:158
+#: ../src/msw/colordlg.cpp:227
 #, c-format
 msgid "Colour selection dialog failed with error %0lx."
 msgstr "Finestra selezione colore fallita con errore %0lx."
 
-#: ../src/osx/carbon/fontdlg.cpp:380
+#: ../src/osx/carbon/fontdlg.cpp:377
 msgid "Colour:"
 msgstr "Colore:"
 
-#: ../src/generic/datavgen.cpp:6077
+#: ../src/generic/datavgen.cpp:6882
 #, c-format
 msgid "Column %u"
 msgstr "Colonna %u"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:114
+#: ../src/common/accelcmn.cpp:112
 msgid "Command"
 msgstr "Comando"
 
-#: ../src/common/init.cpp:196
+#: ../src/common/init.cpp:193
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
@@ -2295,12 +2302,12 @@ msgstr ""
 "L'argomento %d della linea di comando non può essere convertito in Unicode e "
 "verrà ignorato."
 
-#: ../src/msw/fontdlg.cpp:120
+#: ../src/msw/fontdlg.cpp:170
 #, c-format
 msgid "Common dialog failed with error code %0lx."
 msgstr "Finestra di dialogo comune fallita con codice errore %0lx."
 
-#: ../src/gtk/window.cpp:4649
+#: ../src/gtk/window.cpp:5653
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
@@ -2308,11 +2315,11 @@ msgstr ""
 "Composizione non supportata da questo sistema. Abilitala nel tuo gestore "
 "finestra."
 
-#: ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:1549
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Guida HTML (*.chm)|*.chm|"
 
-#: ../src/generic/dirctrlg.cpp:444
+#: ../src/generic/dirctrlg.cpp:410
 msgid "Computer"
 msgstr "Computer"
 
@@ -2321,53 +2328,57 @@ msgstr "Computer"
 msgid "Config entry name cannot start with '%c'."
 msgstr "Il nome di una voce di configurazione non può iniziare con '%c'."
 
-#: ../src/generic/filedlgg.cpp:349 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
 msgid "Confirm"
 msgstr "Conferma"
 
-#: ../src/html/htmlwin.cpp:566
+#: ../src/html/htmlwin.cpp:569
 msgid "Connecting..."
 msgstr "Connessione..."
 
-#: ../src/html/helpwnd.cpp:475
+#: ../src/html/helpwnd.cpp:473
 msgid "Contents"
 msgstr "Sommario"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:880
+#: ../src/propgrid/advprops.cpp:781
 msgid "ControlDark"
 msgstr "ControlloScuro"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:881
+#: ../src/propgrid/advprops.cpp:782
 msgid "ControlLight"
 msgstr "ControlloChiaro"
 
-#: ../src/common/strconv.cpp:2262
+#: ../src/common/strconv.cpp:2208
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "La conversione nella codifica '%s' non funziona."
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "Convert"
 msgstr "Converti"
 
-#: ../src/html/htmlwin.cpp:1079
+#: ../src/html/htmlwin.cpp:1020
 #, c-format
 msgid "Copied to clipboard:\"%s\""
 msgstr "Copiato negli Appunti:\"%s\""
 
-#: ../src/generic/prntdlgg.cpp:247
+#: ../src/generic/prntdlgg.cpp:240
 msgid "Copies:"
 msgstr "Copie:"
 
-#: ../src/common/stockitem.cpp:150 ../src/stc/stc_i18n.cpp:18
+#: ../src/common/stockitem.cpp:147 ../src/stc/stc_i18n.cpp:18
 msgid "Copy"
 msgstr "Copia"
 
-#: ../src/common/stockitem.cpp:258
+#: ../src/common/stockitem.cpp:255
 msgid "Copy selection"
 msgstr "Copia selezione"
+
+#: ../src/generic/grid.cpp:5945
+msgid "Copying more than one selected block to clipboard is not supported."
+msgstr ""
 
 #: ../src/richtext/richtextborderspage.cpp:566
 #: ../src/richtext/richtextborderspage.cpp:601
@@ -2378,196 +2389,193 @@ msgstr "Angolo"
 msgid "Corner &radius:"
 msgstr "&Raggio angolo:"
 
-#: ../src/html/chm.cpp:718
+#: ../src/html/chm.cpp:711
 #, c-format
 msgid "Could not create temporary file '%s'"
 msgstr "Impossibile creare il file temporaneo '%s'"
 
-#: ../src/html/chm.cpp:273
+#: ../src/html/chm.cpp:270
 #, c-format
 msgid "Could not extract %s into %s: %s"
 msgstr "Impossibile estrarre %s in %s: %s"
 
-#: ../src/generic/tabg.cpp:1048
+#: ../src/generic/tabg.cpp:1045
 msgid "Could not find tab for id"
 msgstr "Impossibile trovare l'etichetta per l'id"
 
-#: ../src/gtk/notifmsg.cpp:108
-msgid "Could not initalize libnotify."
-msgstr "Impossibile impostare allineamento."
-
-#: ../src/html/chm.cpp:444
+#: ../src/html/chm.cpp:437
 #, c-format
 msgid "Could not locate file '%s'."
 msgstr "Impossibile trovare il file '%s'."
 
-#: ../src/common/filefn.cpp:1403
+#: ../src/msw/graphicsd2d.cpp:604
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/common/filefn.cpp:1291
 msgid "Could not set current working directory"
 msgstr "Impossibile impostare la cartella di lavoro"
 
-#: ../src/common/prntbase.cpp:2015
+#: ../src/common/prntbase.cpp:2037
 msgid "Could not start document preview."
 msgstr "Impossibile visualizzare l'anteprima del documento."
 
-#: ../src/generic/printps.cpp:178 ../src/msw/printwin.cpp:210
-#: ../src/gtk/print.cpp:1132
+#: ../src/generic/printps.cpp:159 ../src/msw/printwin.cpp:184
+#: ../src/gtk/print.cpp:1129
 msgid "Could not start printing."
 msgstr "Impossibile avviare la stampa."
 
-#: ../src/common/wincmn.cpp:2125
+#: ../src/common/wincmn.cpp:2126
 msgid "Could not transfer data to window"
 msgstr "Impossibile trasferire i dati verso la finestra"
 
-#: ../src/msw/imaglist.cpp:187 ../src/msw/imaglist.cpp:224
-#: ../src/msw/imaglist.cpp:249 ../src/msw/dragimag.cpp:185
-#: ../src/msw/dragimag.cpp:220
+#: ../src/msw/imaglist.cpp:223 ../src/msw/imaglist.cpp:245
+#: ../src/msw/imaglist.cpp:270 ../src/msw/dragimag.cpp:182
+#: ../src/msw/dragimag.cpp:217
 msgid "Couldn't add an image to the image list."
 msgstr "Impossibile aggiungere un'immagine all'elenco."
 
-#: ../src/osx/glcanvas_osx.cpp:414 ../src/unix/glx11.cpp:558
-#: ../src/msw/glcanvas.cpp:616
+#: ../src/osx/glcanvas_osx.cpp:411 ../src/msw/glcanvas.cpp:631
+#: ../src/unix/glegl.cpp:315 ../src/unix/glx11.cpp:559
 msgid "Couldn't create OpenGL context"
 msgstr "Impossibile creare contesto OpenGL"
 
-#: ../src/msw/timer.cpp:134
+#: ../src/msw/timer.cpp:131
 msgid "Couldn't create a timer"
 msgstr "Impossibile creare un timer"
 
-#: ../src/osx/carbon/overlay.cpp:122
-msgid "Couldn't create the overlay window"
-msgstr "Impossibile creare la finestra di overlay"
-
-#: ../src/common/translation.cpp:2024
+#: ../src/common/translation.cpp:2074
 msgid "Couldn't enumerate translations"
 msgstr "Impossibile enumerare la traduzione"
 
-#: ../src/common/dynlib.cpp:120
+#: ../src/common/dynlib.cpp:110
 #, c-format
 msgid "Couldn't find symbol '%s' in a dynamic library"
 msgstr "Impossibile trovare il simbolo '%s' nella libreria dinamica"
 
-#: ../src/msw/thread.cpp:915
+#: ../src/msw/thread.cpp:921
 msgid "Couldn't get the current thread pointer"
 msgstr "Impossibile ottenere un puntatore al thread corrente"
 
-#: ../src/osx/carbon/overlay.cpp:129
-msgid "Couldn't init the context on the overlay window"
-msgstr "Impossibile inizializzare il contesto della finestra di overlay"
-
-#: ../src/common/imaggif.cpp:244
+#: ../src/common/imaggif.cpp:241
 msgid "Couldn't initialize GIF hash table."
 msgstr "Impossibile inizializzare la tabella GIF hash."
 
-#: ../src/common/imagpng.cpp:409
+#: ../src/common/imagpng.cpp:437
 msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
 msgstr ""
 "Impossibile caricare un'immagine PNG - file danneggiato o memoria "
 "insufficiente."
 
-#: ../src/unix/sound.cpp:470
+#: ../src/unix/sound.cpp:459
 #, c-format
 msgid "Couldn't load sound data from '%s'."
 msgstr "Impossibile leggere dati sonori da '%s'."
 
-#: ../src/msw/dirdlg.cpp:435
+#: ../src/msw/dirdlg.cpp:287
 msgid "Couldn't obtain folder name"
 msgstr "Impossibile ottenere nome cartella"
 
-#: ../src/unix/sound_sdl.cpp:229
+#: ../src/unix/sound_sdl.cpp:226
 #, c-format
 msgid "Couldn't open audio: %s"
 msgstr "Impossibile inizializzare l'audio: %s"
 
-#: ../src/msw/ole/dataobj.cpp:377
+#: ../src/msw/ole/dataobj.cpp:385
 #, c-format
 msgid "Couldn't register clipboard format '%s'."
 msgstr "Impossibile registrare il formato '%s' degli appunti."
 
-#: ../src/msw/listctrl.cpp:869
+#: ../src/msw/listctrl.cpp:933
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "Impossibile ottenere informazioni sull'elemento %d del list control."
 
-#: ../src/common/imagpng.cpp:498 ../src/common/imagpng.cpp:509
-#: ../src/common/imagpng.cpp:519
+#: ../src/common/imagpng.cpp:511 ../src/common/imagpng.cpp:522
+#: ../src/common/imagpng.cpp:532
 msgid "Couldn't save PNG image."
 msgstr "Impossibile salvare l'immagine PNG."
 
-#: ../src/msw/thread.cpp:684
+#: ../src/msw/thread.cpp:676
 msgid "Couldn't terminate thread"
 msgstr "Impossibile terminare il thread"
 
-#: ../src/common/xtistrm.cpp:166
+#: ../src/common/xtistrm.cpp:163
 #, c-format
 msgid "Create Parameter %s not found in declared RTTI Parameters"
 msgstr "Create Parameter %s non trovato nella dichiarazione dei parametri RTTI"
 
-#: ../src/generic/dirdlgg.cpp:288
+#: ../src/generic/dirdlgg.cpp:285
 msgid "Create directory"
 msgstr "Crea cartella"
 
-#: ../src/generic/filedlgg.cpp:212 ../src/generic/dirdlgg.cpp:111
+#: ../src/generic/filedlgg.cpp:209 ../src/generic/dirdlgg.cpp:108
 msgid "Create new directory"
 msgstr "Crea nuova cartella"
 
-#: ../src/xrc/xmlres.cpp:2460
+#: ../src/common/stockitem.cpp:264
+#, fuzzy
+msgid "Create new document"
+msgstr "Crea nuova cartella"
+
+#: ../src/xrc/xmlres.cpp:2515
 #, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Creazione di %s \"%s\" fallita."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1758
+#: ../src/propgrid/advprops.cpp:1659
 msgid "Cross"
 msgstr "Incrocio"
 
-#: ../src/common/accelcmn.cpp:333
+#: ../src/common/accelcmn.cpp:347
 msgid "Ctrl+"
 msgstr "Ctrl+"
 
-#: ../src/richtext/richtextctrl.cpp:332 ../src/osx/textctrl_osx.cpp:576
-#: ../src/common/stockitem.cpp:151 ../src/msw/textctrl.cpp:2507
+#: ../src/osx/textctrl_osx.cpp:594 ../src/common/stockitem.cpp:148
+#: ../src/msw/textctrl.cpp:2772 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "Ta&glia"
 
-#: ../src/generic/filectrlg.cpp:940
+#: ../src/generic/filectrlg.cpp:936
 msgid "Current directory:"
 msgstr "Cartella attuale:"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:896 ../src/propgrid/advprops.cpp:1574
-#: ../src/propgrid/advprops.cpp:1612
+#: ../src/propgrid/advprops.cpp:797 ../src/propgrid/advprops.cpp:1475
+#: ../src/propgrid/advprops.cpp:1518
 msgid "Custom"
 msgstr "Personalizzata"
 
-#: ../src/gtk/print.cpp:217
+#: ../src/gtk/print.cpp:211
 msgid "Custom size"
 msgstr "Dimensione personalizzata"
 
-#: ../src/common/headerctrlcmn.cpp:60
+#: ../src/common/headerctrlcmn.cpp:58
 msgid "Customize Columns"
 msgstr "Personalizzazione colonne"
 
-#: ../src/common/stockitem.cpp:151 ../src/stc/stc_i18n.cpp:17
+#: ../src/common/stockitem.cpp:148 ../src/stc/stc_i18n.cpp:17
 msgid "Cut"
 msgstr "Taglia"
 
-#: ../src/common/stockitem.cpp:259
+#: ../src/common/stockitem.cpp:256
 msgid "Cut selection"
 msgstr "Taglia selezione"
 
-#: ../src/common/fmapbase.cpp:152
+#: ../src/common/fmapbase.cpp:149
 msgid "Cyrillic (ISO-8859-5)"
 msgstr "Cirillico (ISO-8859-5)"
 
-#: ../src/common/paper.cpp:99
+#: ../src/common/paper.cpp:96
 msgid "D sheet, 22 x 34 in"
 msgstr "Foglio D, 22 x 34 pollici"
 
-#: ../src/msw/dde.cpp:703
+#: ../src/msw/dde.cpp:698
 msgid "DDE poke request failed"
 msgstr "Richiesta DDE (poke) fallita"
 
-#: ../src/common/imagbmp.cpp:1169
+#: ../src/common/imagbmp.cpp:1181
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr ""
 "Intestazione DIB: la codifica non corrisponde al numero di bit per pixel."
@@ -2589,7 +2597,7 @@ msgstr "Intestazione DIB: numero di bit per pixel nel file sconosciuto."
 msgid "DIB Header: Unknown encoding in file."
 msgstr "Inetstazione DIB: Codifica del file sconosciuta."
 
-#: ../src/common/paper.cpp:121
+#: ../src/common/paper.cpp:118
 msgid "DL Envelope, 110 x 220 mm"
 msgstr "Busta DL, 110 x 220 mm"
 
@@ -2597,53 +2605,53 @@ msgstr "Busta DL, 110 x 220 mm"
 msgid "Dashed"
 msgstr "Tratteggiato"
 
-#: ../src/generic/dbgrptg.cpp:300
+#: ../src/generic/dbgrptg.cpp:301
 #, c-format
 msgid "Debug report \"%s\""
 msgstr "Segnalazione di errore \"%s\""
 
-#: ../src/common/debugrpt.cpp:210
+#: ../src/common/debugrpt.cpp:211
 msgid "Debug report couldn't be created."
 msgstr "Impossibile creare la segnalazione di errore."
 
-#: ../src/common/debugrpt.cpp:553
+#: ../src/common/debugrpt.cpp:554
 msgid "Debug report generation has failed."
 msgstr "Generazione della segnalazione di errore fallita."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:84
+#: ../src/common/accelcmn.cpp:81
 msgid "Decimal"
 msgstr "Decimale"
 
-#: ../src/generic/fontdlgg.cpp:323
+#: ../src/generic/fontdlgg.cpp:319
 msgid "Decorative"
 msgstr "Decorativo"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1752
+#: ../src/propgrid/advprops.cpp:1653
 msgid "Default"
 msgstr "Predefinito"
 
-#: ../src/common/fmapbase.cpp:796
+#: ../src/common/fmapbase.cpp:792
 msgid "Default encoding"
 msgstr "Codifca predefinita"
 
-#: ../src/dfb/fontmgr.cpp:180
+#: ../src/dfb/fontmgr.cpp:177
 msgid "Default font"
 msgstr "Font predefinita"
 
-#: ../src/generic/prntdlgg.cpp:510
+#: ../src/generic/prntdlgg.cpp:503
 msgid "Default printer"
 msgstr "Stampante predefinita"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:51
+#: ../src/common/accelcmn.cpp:48
 msgid "Del"
 msgstr "Canc"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextbuffer.cpp:8221 ../src/common/stockitem.cpp:152
-#: ../src/common/accelcmn.cpp:50 ../src/stc/stc_i18n.cpp:20
+#: ../src/common/stockitem.cpp:149 ../src/common/accelcmn.cpp:47
+#: ../src/richtext/richtextbuffer.cpp:8217 ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Elimina"
 
@@ -2651,68 +2659,68 @@ msgstr "Elimina"
 msgid "Delete A&ll"
 msgstr "&Elimina tutti"
 
-#: ../src/richtext/richtextbuffer.cpp:11341
+#: ../src/richtext/richtextbuffer.cpp:11340
 msgid "Delete Column"
 msgstr "Elimina colonna"
 
-#: ../src/richtext/richtextbuffer.cpp:11291
+#: ../src/richtext/richtextbuffer.cpp:11290
 msgid "Delete Row"
 msgstr "Elimina riga"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 msgid "Delete Style"
 msgstr "Elimina stile"
 
-#: ../src/richtext/richtextctrl.cpp:1345 ../src/richtext/richtextctrl.cpp:1584
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
 msgid "Delete Text"
 msgstr "Elimina testo"
 
-#: ../src/generic/editlbox.cpp:170
+#: ../src/generic/editlbox.cpp:147
 msgid "Delete item"
 msgstr "Elimina elemento"
 
-#: ../src/common/stockitem.cpp:260
+#: ../src/common/stockitem.cpp:257
 msgid "Delete selection"
 msgstr "Elimina selezione"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 #, c-format
 msgid "Delete style %s?"
 msgstr "Eliminare stile %s?"
 
-#: ../src/unix/snglinst.cpp:301
+#: ../src/unix/snglinst.cpp:298
 #, c-format
 msgid "Deleted stale lock file '%s'."
 msgstr "Eliminato file di lock obsoleto '%s'"
 
-#: ../src/common/secretstore.cpp:220
-#, c-format
-msgid "Deleting password for \"%s/%s\" failed: %s."
+#: ../src/common/secretstore.cpp:234
+#, fuzzy, c-format
+msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Eliminazione fallita password per \"%s/\"%s\": %s."
 
-#: ../src/common/module.cpp:124
+#: ../src/common/module.cpp:121
 #, c-format
 msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
 msgstr "La dipendenza \"%s\" del modulo \"%s\" non esiste."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "Descending"
 msgstr "Discendente"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:526 ../src/propgrid/advprops.cpp:882
+#: ../src/generic/dirctrlg.cpp:492 ../src/propgrid/advprops.cpp:783
 msgid "Desktop"
 msgstr "Desktop"
 
-#: ../src/generic/aboutdlgg.cpp:70
+#: ../src/generic/aboutdlgg.cpp:67
 msgid "Developed by "
 msgstr "Sviluppato da "
 
-#: ../src/generic/aboutdlgg.cpp:176
+#: ../src/generic/aboutdlgg.cpp:173
 msgid "Developers"
 msgstr "Sviluppatori"
 
-#: ../src/msw/dialup.cpp:374
+#: ../src/msw/dialup.cpp:368
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -2721,11 +2729,11 @@ msgstr ""
 "di Accesso Remoto (RAS) non è installato su questo computer. Installa il "
 "servizio."
 
-#: ../src/generic/tipdlg.cpp:211
+#: ../src/generic/tipdlg.cpp:208
 msgid "Did you know..."
 msgstr "Lo sapevi che..."
 
-#: ../src/dfb/wrapdfb.cpp:63
+#: ../src/dfb/wrapdfb.cpp:60
 #, c-format
 msgid "DirectFB error %d occurred."
 msgstr "Si è verificato un errore DirectFB %d."
@@ -2734,29 +2742,29 @@ msgstr "Si è verificato un errore DirectFB %d."
 msgid "Directories"
 msgstr "Cartelle"
 
-#: ../src/common/filefn.cpp:1183
+#: ../src/common/filefn.cpp:1071
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Impossibile creare la cartella '%s'"
 
-#: ../src/common/filefn.cpp:1197
+#: ../src/common/filefn.cpp:1085
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "La cartella '%s' non può essere eliminata"
 
-#: ../src/generic/dirdlgg.cpp:204
+#: ../src/generic/dirdlgg.cpp:201
 msgid "Directory does not exist"
 msgstr "Cartella non esistente"
 
-#: ../src/generic/filectrlg.cpp:1399
+#: ../src/generic/filectrlg.cpp:1388
 msgid "Directory doesn't exist."
 msgstr "Cartella non esistente."
 
-#: ../src/common/docview.cpp:457
+#: ../src/common/docview.cpp:450
 msgid "Discard changes and reload the last saved version?"
 msgstr "Annullare le modifiche e ricaricare l'ultima versione salvata?"
 
-#: ../src/html/helpwnd.cpp:502
+#: ../src/html/helpwnd.cpp:500
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -2764,45 +2772,45 @@ msgstr ""
 "Visualizza tutte le voci dell'indice contenenti un dato testo. La ricerca "
 "non distingue maiuscole e minuscole."
 
-#: ../src/html/helpwnd.cpp:679
+#: ../src/html/helpwnd.cpp:677
 msgid "Display options dialog"
 msgstr "Visualizza riquadro di dialogo per le opzioni"
 
-#: ../src/html/helpwnd.cpp:322
+#: ../src/html/helpwnd.cpp:320
 msgid "Displays help as you browse the books on the left."
 msgstr "Visualizza la guida mentre sfogli i manuali sulla sinistra."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:85
+#: ../src/common/accelcmn.cpp:83
 msgid "Divide"
 msgstr "Dividi"
 
-#: ../src/common/docview.cpp:533
+#: ../src/common/docview.cpp:526
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Salvare le modifiche in %s?"
 
-#: ../src/common/prntbase.cpp:542
+#: ../src/common/prntbase.cpp:537
 msgid "Document:"
 msgstr "Documento:"
 
-#: ../src/generic/aboutdlgg.cpp:73
+#: ../src/generic/aboutdlgg.cpp:70
 msgid "Documentation by "
 msgstr "Documentazione di "
 
-#: ../src/generic/aboutdlgg.cpp:180
+#: ../src/generic/aboutdlgg.cpp:177
 msgid "Documentation writers"
 msgstr "Autori documentazione"
 
-#: ../src/common/sizer.cpp:2799
+#: ../src/common/sizer.cpp:2916
 msgid "Don't Save"
 msgstr "Non salvare"
 
-#: ../src/html/htmlwin.cpp:633
+#: ../src/html/htmlwin.cpp:643
 msgid "Done"
 msgstr "Completato"
 
-#: ../src/generic/progdlgg.cpp:448 ../src/msw/progdlg.cpp:407
+#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
 msgid "Done."
 msgstr "Completato."
 
@@ -2814,42 +2822,42 @@ msgstr "Punteggiato"
 msgid "Double"
 msgstr "Doppio"
 
-#: ../src/common/paper.cpp:176
+#: ../src/common/paper.cpp:173
 msgid "Double Japanese Postcard Rotated 148 x 200 mm"
 msgstr "Doppia cartolina giapponese ruotata 148 x 200 mm"
 
-#: ../src/common/xtixml.cpp:273
+#: ../src/common/xtixml.cpp:269
 #, c-format
 msgid "Doubly used id : %d"
 msgstr "Doppio utilizzo di id : %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:153
-#: ../src/common/accelcmn.cpp:64
+#: ../src/common/stockitem.cpp:150 ../src/common/accelcmn.cpp:61
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Down"
 msgstr "Giù"
 
-#: ../src/richtext/richtextctrl.cpp:865
+#: ../src/richtext/richtextctrl.cpp:864
 msgid "Drag"
 msgstr "Trascina"
 
-#: ../src/common/paper.cpp:100
+#: ../src/common/paper.cpp:97
 msgid "E sheet, 34 x 44 in"
 msgstr "Foglio E, 34 x 44 pollici"
 
-#: ../src/unix/fswatcher_inotify.cpp:561
+#: ../src/unix/fswatcher_inotify.cpp:558
 msgid "EOF while reading from inotify descriptor"
 msgstr "Fine file durante lettura da descrittore inotify"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "Edit"
 msgstr "Modifica"
 
-#: ../src/generic/editlbox.cpp:168
+#: ../src/generic/editlbox.cpp:131
 msgid "Edit item"
 msgstr "Modifica elemento"
 
-#: ../include/wx/generic/progdlgg.h:84
+#: ../include/wx/generic/progdlgg.h:85
 msgid "Elapsed time:"
 msgstr "Tempo trascorso:"
 
@@ -2916,49 +2924,49 @@ msgid "Enables the shadow spread."
 msgstr "Abilita diffusione ombra."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:66
+#: ../src/common/accelcmn.cpp:63
 msgid "End"
 msgstr "Fine"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:55
+#: ../src/common/accelcmn.cpp:52
 msgid "Enter"
 msgstr "Invio"
 
-#: ../src/richtext/richtextstyledlg.cpp:934
+#: ../src/richtext/richtextstyledlg.cpp:930
 msgid "Enter a box style name"
 msgstr "Inserisci il nome di un nuovo stile"
 
-#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:602
 msgid "Enter a character style name"
 msgstr "Immetti il nome dello stile di carattere"
 
-#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:816
 msgid "Enter a list style name"
 msgstr "Immetti il nome dello stile dell'eelnco"
 
-#: ../src/richtext/richtextstyledlg.cpp:893
+#: ../src/richtext/richtextstyledlg.cpp:889
 msgid "Enter a new style name"
 msgstr "Inserisci il nome di un nuovo stile"
 
-#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:650
 msgid "Enter a paragraph style name"
 msgstr "Immetti il nome dello stile di paragrafo"
 
-#: ../src/generic/dbgrptg.cpp:174
+#: ../src/generic/dbgrptg.cpp:171
 #, c-format
 msgid "Enter command to open file \"%s\":"
 msgstr "Specifica il comando per aprire il file \"%s\":"
 
-#: ../src/generic/helpext.cpp:459
+#: ../src/generic/helpext.cpp:457
 msgid "Entries found"
 msgstr "Trovati"
 
-#: ../src/common/paper.cpp:142
+#: ../src/common/paper.cpp:139
 msgid "Envelope Invite 220 x 220 mm"
 msgstr "Busta Invite 220 x 220 mm"
 
-#: ../src/common/config.cpp:469
+#: ../src/common/config.cpp:465
 #, c-format
 msgid ""
 "Environment variables expansion failed: missing '%c' at position %u in '%s'."
@@ -2966,13 +2974,13 @@ msgstr ""
 "Espansione delle variabili di ambiente fallita: carattere '%c' non trovato "
 "alla posizione %u in '%s'."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/generic/dirctrlg.cpp:570
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/dirctrlg.cpp:599
-#: ../src/generic/dirdlgg.cpp:323 ../src/generic/filectrlg.cpp:642
-#: ../src/generic/filectrlg.cpp:756 ../src/generic/filectrlg.cpp:770
-#: ../src/generic/filectrlg.cpp:786 ../src/generic/filectrlg.cpp:1368
-#: ../src/generic/filectrlg.cpp:1399 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/gtk1/fontdlg.cpp:74 ../src/generic/dirctrlg.cpp:536
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/dirctrlg.cpp:565
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1357 ../src/generic/filectrlg.cpp:1388
+#: ../src/generic/filedlgg.cpp:354 ../src/generic/dirdlgg.cpp:320
+#: ../src/gtk/filedlg.cpp:74
 msgid "Error"
 msgstr "Errore"
 
@@ -2980,86 +2988,97 @@ msgstr "Errore"
 msgid "Error closing epoll descriptor"
 msgstr "Errore nella chiusura descrittore epoll"
 
-#: ../src/unix/fswatcher_kqueue.cpp:114
+#: ../src/unix/fswatcher_kqueue.cpp:131
 msgid "Error closing kqueue instance"
 msgstr "Errore chiusra istanza kqueue"
 
-#: ../src/common/filefn.cpp:1049
+#: ../src/common/filefn.cpp:938
 #, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Impossibile copiare copiare il file '%s' in '%s'."
 
-#: ../src/generic/dirdlgg.cpp:222
+#: ../src/generic/dirdlgg.cpp:219
 msgid "Error creating directory"
 msgstr "Errore nella creazione della cartella"
 
-#: ../src/common/imagbmp.cpp:1181
+#: ../src/common/imagbmp.cpp:1193
 msgid "Error in reading image DIB."
 msgstr "Errore durante la lettura dell'immagine DIB."
 
-#: ../src/propgrid/propgrid.cpp:6696
+#: ../src/propgrid/propgrid.cpp:6665
 #, c-format
 msgid "Error in resource: %s"
 msgstr "Errore nella risorsa: %s"
 
-#: ../src/common/fileconf.cpp:422
+#: ../src/common/fileconf.cpp:421
 msgid "Error reading config options."
 msgstr "Errore durante la lettura del file di configurazione."
+
+#: ../src/msw/webview_ie.cpp:1057 ../src/msw/webview_edge.cpp:850
+#: ../src/gtk/webview_webkit2.cpp:1262 ../src/osx/webview_webkit.mm:383
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
 
 #: ../src/common/fileconf.cpp:1029
 msgid "Error saving user configuration data."
 msgstr "Errore durante il salvataggio del file di configurazione."
 
-#: ../src/gtk/print.cpp:722
+#: ../src/gtk/print.cpp:720
 msgid "Error while printing: "
 msgstr "Errore durante la stampa: "
 
-#: ../src/common/log.cpp:219
+#: ../src/common/log.cpp:237
 msgid "Error: "
 msgstr "Errore: "
 
+#: ../src/common/webrequest.cpp:98
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Errore: "
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:69
+#: ../src/common/accelcmn.cpp:66
 msgid "Esc"
 msgstr "Esc"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:70
+#: ../src/common/accelcmn.cpp:67
 msgid "Escape"
 msgstr "Esci"
 
-#: ../src/common/fmapbase.cpp:150
+#: ../src/common/fmapbase.cpp:147
 msgid "Esperanto (ISO-8859-3)"
 msgstr "Esperanto (ISO-8859-3)"
 
-#: ../include/wx/generic/progdlgg.h:85
+#: ../include/wx/generic/progdlgg.h:86
 msgid "Estimated time:"
 msgstr "Tempo stimato:"
 
-#: ../src/generic/dbgrptg.cpp:234
+#: ../src/generic/dbgrptg.cpp:231
 msgid "Executable files (*.exe)|*.exe|"
 msgstr "File eseguibili (*.exe)|*.exe|"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:155 ../src/common/accelcmn.cpp:78
+#: ../src/common/stockitem.cpp:152 ../src/common/accelcmn.cpp:75
 msgid "Execute"
 msgstr "Esegui"
 
-#: ../src/msw/utilsexc.cpp:876
+#: ../src/msw/utilsexc.cpp:873
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Esecuzione del comando '%s' fallita"
 
-#: ../src/common/paper.cpp:105
+#: ../src/common/paper.cpp:102
 msgid "Executive, 7 1/4 x 10 1/2 in"
 msgstr "Executive, 7 1/4 x 10 1/2 pollici"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6009
+#: ../src/generic/datavgen.cpp:6814
 msgid "Expand"
 msgstr "Espandi"
 
-#: ../src/msw/registry.cpp:1240
+#: ../src/msw/registry.cpp:1228
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
@@ -3067,149 +3086,159 @@ msgstr ""
 "Durante l'esportazione dela chiave di registro: il file \"%s\" esiste e non "
 "verrà sovrascritto."
 
-#: ../src/common/fmapbase.cpp:195
+#: ../src/common/fmapbase.cpp:192
 msgid "Extended Unix Codepage for Japanese (EUC-JP)"
 msgstr "Pagina codici Unix estesa per il Giapponese (EUC-JP)"
 
-#: ../src/html/chm.cpp:725
+#: ../src/html/chm.cpp:718
 #, c-format
 msgid "Extraction of '%s' into '%s' failed."
 msgstr "Estrazione di '%s' in '%s' fallita."
 
-#: ../src/common/accelcmn.cpp:249 ../src/common/accelcmn.cpp:344
+#: ../src/common/accelcmn.cpp:259 ../src/common/accelcmn.cpp:358
 msgid "F"
 msgstr "F"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:672
+#: ../src/propgrid/advprops.cpp:582
 msgid "Face Name"
 msgstr "Nome faccia"
 
-#: ../src/unix/snglinst.cpp:269
+#: ../src/unix/snglinst.cpp:266
 msgid "Failed to access lock file."
 msgstr "Impossibile accedere al file di lock."
+
+#: ../src/gtk/font.cpp:572
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Impossibile leggere il documento dal file \"%s\"."
 
 #: ../src/unix/epolldispatcher.cpp:116
 #, c-format
 msgid "Failed to add descriptor %d to epoll descriptor %d"
 msgstr "Impossibile aggiungere descrittore %d al descrittore epoll %d"
 
-#: ../src/msw/dib.cpp:489
+#: ../src/msw/dib.cpp:535
 #, c-format
 msgid "Failed to allocate %luKb of memory for bitmap data."
 msgstr "Impossibile allocare %luKb di memoria per i dati bitmap."
 
-#: ../src/common/glcmn.cpp:115
+#: ../src/common/glcmn.cpp:112
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Impossibile allocare colore per OpenGL"
 
-#: ../src/unix/displayx11.cpp:236
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Impossibile allocare colore per OpenGL"
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Impossibile allocare colore per OpenGL"
+
+#: ../include/wx/unix/private/displayx11.h:89
 msgid "Failed to change video mode"
 msgstr "Impossibile cambiare la modalità video"
 
-#: ../src/common/image.cpp:3277
+#: ../src/common/image.cpp:3396
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Impossibile verificare formato immagine file \"%s\"."
 
-#: ../src/common/debugrpt.cpp:239
+#: ../src/common/debugrpt.cpp:240
 #, c-format
 msgid "Failed to clean up debug report directory \"%s\""
 msgstr "Impossibile svuotare la cartella \"%s\" delle segnalazioni di errore"
 
-#: ../src/common/filename.cpp:192
+#: ../src/common/filename.cpp:189
 msgid "Failed to close file handle"
 msgstr "Impossibile chiudere il file"
 
-#: ../src/unix/snglinst.cpp:340
+#: ../src/unix/snglinst.cpp:337
 #, c-format
 msgid "Failed to close lock file '%s'"
 msgstr "Impossibile chiudere il file di lock '%s'"
 
-#: ../src/msw/clipbrd.cpp:112
+#: ../src/msw/clipbrd.cpp:110
 msgid "Failed to close the clipboard."
 msgstr "Impossibile chiudere gli Appunti."
 
-#: ../src/x11/utils.cpp:208
+#: ../src/x11/utils.cpp:170
 #, c-format
 msgid "Failed to close the display \"%s\""
 msgstr "Impossibile chiudere il display \"%s\""
 
-#: ../src/msw/dialup.cpp:797
+#: ../src/msw/dialup.cpp:791
 msgid "Failed to connect: missing username/password."
 msgstr "Connessione impossibile: mancano nome utente/password."
 
-#: ../src/msw/dialup.cpp:743
+#: ../src/msw/dialup.cpp:737
 msgid "Failed to connect: no ISP to dial."
 msgstr "Connessione impossibile: numero dell'ISP mancante."
 
-#: ../src/common/textfile.cpp:203
-#, c-format
-msgid "Failed to convert file \"%s\" to Unicode."
-msgstr "Impossibile convertire il file \"%s\" in Unicode."
-
-#: ../src/generic/logg.cpp:956
+#: ../src/generic/logg.cpp:953
 msgid "Failed to copy dialog contents to the clipboard."
 msgstr "Impossibile copiare contenuto finestra di dialogo negli Appunti."
 
-#: ../src/msw/registry.cpp:692
+#: ../src/msw/registry.cpp:681
 #, c-format
 msgid "Failed to copy registry value '%s'"
 msgstr "Impossibile copiare il valore '%s' del registro di sistema"
 
-#: ../src/msw/registry.cpp:701
+#: ../src/msw/registry.cpp:690
 #, c-format
 msgid "Failed to copy the contents of registry key '%s' to '%s'."
 msgstr ""
 "Impossibile copiare il contenuto della chiave '%s' del registro di sistema "
 "in '%s'."
 
-#: ../src/common/filefn.cpp:1015
+#: ../src/common/filefn.cpp:904
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Impossibile copiare copiare il file '%s' in '%s'"
 
-#: ../src/msw/registry.cpp:679
+#: ../src/msw/registry.cpp:668
 #, c-format
 msgid "Failed to copy the registry subkey '%s' to '%s'."
 msgstr "Impossibile copiare la chiave '%s' del registro di sistema in '%s'."
 
-#: ../src/msw/dde.cpp:1070
+#: ../src/msw/dde.cpp:1134
 msgid "Failed to create DDE string"
 msgstr "Impossibile creare la stringa DDE"
 
-#: ../src/msw/mdi.cpp:616
+#: ../src/msw/mdi.cpp:621
 msgid "Failed to create MDI parent frame."
 msgstr "Impossibile creare la finestra MDI madre."
 
-#: ../src/common/filename.cpp:1027
+#: ../src/common/filename.cpp:1024
 msgid "Failed to create a temporary file name"
 msgstr "Impossibile creare il nome per il file temporaneo"
 
-#: ../src/msw/utilsexc.cpp:228
+#: ../src/msw/utilsexc.cpp:225
 msgid "Failed to create an anonymous pipe"
 msgstr "Impossibile creare una pipe anonima"
 
-#: ../src/msw/ole/automtn.cpp:522
+#: ../src/msw/ole/automtn.cpp:513
 #, c-format
 msgid "Failed to create an instance of \"%s\""
 msgstr "Impossibile creare una istanza di \"%s\""
 
-#: ../src/msw/dde.cpp:437
+#: ../src/msw/dde.cpp:432
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "Impossibile creare la connessione al server '%s' sull'argomento '%s'"
 
-#: ../src/msw/cursor.cpp:204
+#: ../src/msw/cursor.cpp:195
 msgid "Failed to create cursor."
 msgstr "Impossibile creare il cursore."
 
-#: ../src/common/debugrpt.cpp:209
+#: ../src/common/debugrpt.cpp:210
 #, c-format
 msgid "Failed to create directory \"%s\""
 msgstr "Impossibile creare la cartella \"%s\""
 
-#: ../src/generic/dirdlgg.cpp:220
+#: ../src/generic/dirdlgg.cpp:217
 #, c-format
 msgid ""
 "Failed to create directory '%s'\n"
@@ -3222,120 +3251,139 @@ msgstr ""
 msgid "Failed to create epoll descriptor"
 msgstr "Impossibile creare descrittore epoll"
 
-#: ../src/msw/mimetype.cpp:238
+#: ../src/gtk/font.cpp:562
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "Impossibile aggiornare il file di configurazione utente."
+
+#: ../src/msw/mimetype.cpp:235
 #, c-format
 msgid "Failed to create registry entry for '%s' files."
 msgstr "Impossibile creare la voce del registro di sistema per i file '%s'."
 
-#: ../src/msw/fdrepdlg.cpp:409
+#: ../src/msw/fdrepdlg.cpp:408
 #, c-format
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr ""
 "Impossibile creare riquadro di ricerca/sostituzione standard (codice di "
 "errore %d)"
 
-#: ../src/unix/wakeuppipe.cpp:52
+#: ../src/unix/wakeuppipe.cpp:49
 msgid "Failed to create wake up pipe used by event loop."
 msgstr "Impossibile creare coda risveglio usato da un loop evento."
 
-#: ../src/html/winpars.cpp:730
+#: ../src/html/winpars.cpp:727
 #, c-format
 msgid "Failed to display HTML document in %s encoding"
 msgstr "Impossibile visualizzare la pagina HTML con la codifica %s"
 
-#: ../src/msw/clipbrd.cpp:124
+#: ../src/msw/clipbrd.cpp:122
 msgid "Failed to empty the clipboard."
 msgstr "Impossibile eliminare il contenuto degli appunti."
 
-#: ../src/unix/displayx11.cpp:212
+#: ../include/wx/unix/private/displayx11.h:65
 msgid "Failed to enumerate video modes"
 msgstr "Impossibile enumerare le modalità video"
 
-#: ../src/msw/dde.cpp:722
+#: ../src/msw/dde.cpp:717
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "Impossibile stabilire un ciclo advise con il server DDE"
 
-#: ../src/msw/dialup.cpp:629 ../src/msw/dialup.cpp:863
+#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Impossibile connettersi: %s"
 
-#: ../src/unix/utilsunx.cpp:611
+#: ../src/unix/utilsunx.cpp:613
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Impossibile eseguire '%s'\n"
 
-#: ../src/common/debugrpt.cpp:720
+#: ../src/common/debugrpt.cpp:730
 msgid "Failed to execute curl, please install it in PATH."
 msgstr "Impossibile eseguire 'curl'. Insersicilo nel PATH."
 
-#: ../src/msw/ole/automtn.cpp:505
+#: ../src/msw/ole/automtn.cpp:496
 #, c-format
 msgid "Failed to find CLSID of \"%s\""
 msgstr "Impossibile trovare CLSID di \"%s\""
 
-#: ../src/common/regex.cpp:431 ../src/common/regex.cpp:479
+#: ../src/common/regex.cpp:428 ../src/common/regex.cpp:476
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr ""
 "Impossibile trovare una corrispondenza per l'espressione regolare (regular "
 "expression): %s"
 
-#: ../src/msw/dialup.cpp:695
+#: ../src/msw/webview_ie.cpp:978
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:689
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Impossibile ottenere i nomi degli ISP: %s"
 
-#: ../src/msw/ole/automtn.cpp:574
+#: ../src/msw/ole/automtn.cpp:565
 #, c-format
 msgid "Failed to get OLE automation interface for \"%s\""
 msgstr "Impossibile ottenere intrefaccia automazione OLE per \"%s\""
 
-#: ../src/msw/clipbrd.cpp:711
+#: ../src/msw/clipbrd.cpp:731
 msgid "Failed to get data from the clipboard"
 msgstr "Impossibile ottenere i dati dagli appunti"
 
-#: ../src/common/time.cpp:223
+#: ../src/common/time.cpp:216
 msgid "Failed to get the local system time"
 msgstr "Impossibile ottenere l'ora locale di sistema"
 
-#: ../src/common/filefn.cpp:1345
+#: ../src/common/filefn.cpp:1233
 msgid "Failed to get the working directory"
 msgstr "Impossibile determinare la cartella di lavoro"
 
-#: ../src/univ/theme.cpp:114
+#: ../src/univ/theme.cpp:111
 msgid "Failed to initialize GUI: no built-in themes found."
 msgstr ""
 "Impossibile inizializzare l'interfaccia grafica (GUI): temi predefiniti non "
 "trovati."
 
-#: ../src/msw/helpchm.cpp:63
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:60
 msgid "Failed to initialize MS HTML Help."
 msgstr "Impossibile inizializzare MS HTML Help."
 
-#: ../src/msw/glcanvas.cpp:1381
+#: ../src/msw/glcanvas.cpp:1391
 msgid "Failed to initialize OpenGL"
 msgstr "Impossibile inizializzare OpenGL"
 
-#: ../src/msw/dialup.cpp:858
+#: ../src/msw/dialup.cpp:852
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Impossibile inizializzare connessione dialup: %s"
 
-#: ../src/gtk/textctrl.cpp:1128
+#: ../src/gtk/textctrl.cpp:1209
 msgid "Failed to insert text in the control."
 msgstr "Impossibile inserire il testo nella casella di testo."
 
-#: ../src/unix/snglinst.cpp:241
+#: ../src/unix/snglinst.cpp:238
 #, c-format
 msgid "Failed to inspect the lock file '%s'"
 msgstr "Impossibile leggere il file di lock '%s'"
 
-#: ../src/unix/appunix.cpp:182
+#: ../src/unix/appunix.cpp:179
 msgid "Failed to install signal handler"
 msgstr "Impossibile installare gestore segnale"
 
-#: ../src/unix/threadpsx.cpp:1167
+#: ../src/unix/threadpsx.cpp:1216
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -3343,71 +3391,71 @@ msgstr ""
 "Impossibile esegure la join su di un thread, possibile memoria persa (leak) "
 "- esegui nuovamente il programma"
 
-#: ../src/msw/utils.cpp:629
+#: ../src/msw/utils.cpp:619
 #, c-format
 msgid "Failed to kill process %d"
 msgstr "Impossibile terminare il processo %d"
 
-#: ../src/common/image.cpp:2500
+#: ../src/common/image.cpp:2595
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Impossibile caricare bitmap  \"%s\" dalle risorse."
 
-#: ../src/common/image.cpp:2509
+#: ../src/common/image.cpp:2604
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Impossibile caricare icona  \"%s\" dalle risorse."
 
-#: ../src/common/iconbndl.cpp:225
+#: ../src/common/iconbndl.cpp:224
 #, c-format
 msgid "Failed to load icons from resource '%s'."
 msgstr "Impossibile caricare icona per la risorsa '%s'."
 
-#: ../src/common/iconbndl.cpp:200
+#: ../src/common/iconbndl.cpp:198
 #, c-format
 msgid "Failed to load image %%d from file '%s'."
 msgstr "Impossibile caricare immagine %%d dal file '%s'."
 
-#: ../src/common/iconbndl.cpp:208
+#: ../src/common/iconbndl.cpp:206
 #, c-format
 msgid "Failed to load image %d from stream."
 msgstr "Impossibile caricare immagine %d dallo stream."
 
-#: ../src/common/image.cpp:2587 ../src/common/image.cpp:2606
+#: ../src/common/image.cpp:2682 ../src/common/image.cpp:2701
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Impossibile caricare il file immagine \"%s\"."
 
-#: ../src/msw/enhmeta.cpp:97
+#: ../src/msw/enhmeta.cpp:94
 #, c-format
 msgid "Failed to load metafile from file \"%s\"."
 msgstr "Impossibile leggere il metafile dal file '%s'."
 
-#: ../src/msw/volume.cpp:327
+#: ../src/msw/volume.cpp:335
 msgid "Failed to load mpr.dll."
 msgstr "Impossibile caricare mpr.dll."
 
-#: ../src/msw/utils.cpp:953
+#: ../src/msw/utils.cpp:943
 #, c-format
 msgid "Failed to load resource \"%s\"."
 msgstr "Impossibile caricare risorsa  \"%s\"."
 
-#: ../src/common/dynlib.cpp:92
+#: ../src/common/dynlib.cpp:86
 #, c-format
 msgid "Failed to load shared library '%s'"
 msgstr "Impossibile caricare la libreria dinamica '%s'"
 
-#: ../src/osx/core/sound.cpp:145
+#: ../src/osx/core/sound.cpp:143
 #, c-format
 msgid "Failed to load sound from \"%s\" (error %d)."
 msgstr "Impossibile caricare suono da \"%s\" (errore %d)."
 
-#: ../src/msw/utils.cpp:960
+#: ../src/msw/utils.cpp:950
 #, c-format
 msgid "Failed to lock resource \"%s\"."
 msgstr "Impossibile bloccare risorsa \"%s\"."
 
-#: ../src/unix/snglinst.cpp:198
+#: ../src/unix/snglinst.cpp:195
 #, c-format
 msgid "Failed to lock the lock file '%s'"
 msgstr "Impossibile bloccare il file di blocco '%s'"
@@ -3417,33 +3465,38 @@ msgstr "Impossibile bloccare il file di blocco '%s'"
 msgid "Failed to modify descriptor %d in epoll descriptor %d"
 msgstr "Impossibile modificare il descrittore %d nel descrittore epoll %d"
 
-#: ../src/common/filename.cpp:2575
+#: ../src/common/filename.cpp:2658
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Impossibile modificare le date del file '%s'"
 
-#: ../src/common/selectdispatcher.cpp:258
+#: ../src/common/selectdispatcher.cpp:255
 msgid "Failed to monitor I/O channels"
 msgstr "Impossibile monitorare canali I/O"
 
-#: ../src/common/filename.cpp:175
+#: ../src/common/filename.cpp:172
 #, c-format
 msgid "Failed to open '%s' for reading"
 msgstr "Impossibile aprire '%s' in lettura"
 
-#: ../src/common/filename.cpp:180
+#: ../src/common/filename.cpp:177
 #, c-format
 msgid "Failed to open '%s' for writing"
 msgstr "Impossibile aprire '%s' in scrittura"
 
-#: ../src/html/chm.cpp:141
+#: ../src/html/chm.cpp:138
 #, c-format
 msgid "Failed to open CHM archive '%s'."
 msgstr "Impossibile aprire l'archivio CHM '%s'."
 
-#: ../src/common/utilscmn.cpp:1126
+#: ../src/common/utilscmn.cpp:1140
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Impossibile aprire URL '%s' nel browser predefinito."
+
+#: ../src/common/hyperlnkcmn.cpp:133
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Impossibile aprire URL '%s' nel browser predefinito."
 
 #: ../include/wx/msw/private/fswatcher.h:92
@@ -3451,93 +3504,103 @@ msgstr "Impossibile aprire URL '%s' nel browser predefinito."
 msgid "Failed to open directory \"%s\" for monitoring."
 msgstr "Impossibile aprire cartella \"%s\" per il monitoraggio."
 
-#: ../src/x11/utils.cpp:227
+#: ../src/x11/utils.cpp:189
 #, c-format
 msgid "Failed to open display \"%s\"."
 msgstr "Impossibile aprire il display \"%s\"."
 
-#: ../src/common/filename.cpp:1062
+#: ../src/common/filename.cpp:1059
 msgid "Failed to open temporary file."
 msgstr "Impossibile aprire un file temporaneo."
 
-#: ../src/msw/clipbrd.cpp:91
+#: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Impossibile aprire gli Appunti."
 
-#: ../src/common/translation.cpp:1184
+#: ../src/common/translation.cpp:1226
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Impossibile lanalizzare forme plurali: '%s'"
 
-#: ../src/unix/mediactrl.cpp:1214
+#: ../src/unix/mediactrl.cpp:1239
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Impossibile preparare riproduzione \"%s\"."
 
-#: ../src/msw/clipbrd.cpp:600
+#: ../src/msw/clipbrd.cpp:610
 msgid "Failed to put data on the clipboard"
 msgstr "Impossibile mettere dati negli Appunti"
 
-#: ../src/unix/snglinst.cpp:278
+#: ../src/unix/snglinst.cpp:275
 msgid "Failed to read PID from lock file."
 msgstr "Impossibile leggere il PID dal file di blocco."
 
-#: ../src/common/fileconf.cpp:433
+#: ../src/common/fileconf.cpp:432
 msgid "Failed to read config options."
 msgstr "Impossibile leggere opzioni configurazione."
 
-#: ../src/common/docview.cpp:681
+#: ../src/common/docview.cpp:676
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Impossibile leggere il documento dal file \"%s\"."
 
-#: ../src/dfb/evtloop.cpp:98
+#: ../src/dfb/evtloop.cpp:99
 msgid "Failed to read event from DirectFB pipe"
 msgstr "Impossibile leggere evento dalla coda DirectFB"
 
-#: ../src/unix/wakeuppipe.cpp:120
+#: ../src/unix/wakeuppipe.cpp:117
 msgid "Failed to read from wake-up pipe"
 msgstr "Impossibile leggere dalla coda di risveglio"
 
-#: ../src/unix/utilsunx.cpp:679
+#: ../src/common/textfile.cpp:96
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Impossibile leggere il documento dal file \"%s\"."
+
+#: ../src/unix/utilsunx.cpp:681
 msgid "Failed to redirect child process input/output"
 msgstr "Impossibile redirigere l'input/output del processo figlio"
 
-#: ../src/msw/utilsexc.cpp:701
+#: ../src/msw/utilsexc.cpp:698
 msgid "Failed to redirect the child process IO"
 msgstr "Impossibile redirigere l'input/output del processo figlio"
 
-#: ../src/msw/dde.cpp:288
+#: ../src/msw/dde.cpp:283
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Impossibile registrare il server DDE '%s'"
 
-#: ../src/common/fontmap.cpp:245
+#: ../src/gtk/font.cpp:580
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "Impossibile aggiornare il file di configurazione utente."
+
+#: ../src/common/fontmap.cpp:242
 #, c-format
 msgid "Failed to remember the encoding for the charset '%s'."
 msgstr "Impossibile ricordare la codifica per il set di caratteri '%s'."
 
-#: ../src/common/debugrpt.cpp:227
+#: ../src/common/debugrpt.cpp:228
 #, c-format
 msgid "Failed to remove debug report file \"%s\""
 msgstr "Impossibile eliminare il file \"%s\" della segnalazione di errore"
 
-#: ../src/unix/snglinst.cpp:328
+#: ../src/unix/snglinst.cpp:325
 #, c-format
 msgid "Failed to remove lock file '%s'"
 msgstr "Impossibile eliminare il file di blocco '%s'"
 
-#: ../src/unix/snglinst.cpp:288
+#: ../src/unix/snglinst.cpp:285
 #, c-format
 msgid "Failed to remove stale lock file '%s'."
 msgstr "Impossibile eliminare il file di blocco obsoleto '%s'."
 
-#: ../src/msw/registry.cpp:529
+#: ../src/msw/registry.cpp:518
 #, c-format
 msgid "Failed to rename registry value '%s' to '%s'."
 msgstr "Impossibile rinominare il valore '%s' del registro di sistema in '%s'."
 
-#: ../src/common/filefn.cpp:1122
+#: ../src/common/filefn.cpp:1011
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -3546,117 +3609,126 @@ msgstr ""
 "Impossibile rinominare il file '%s' in '%s' perchè la destinazione esiste "
 "già."
 
-#: ../src/msw/registry.cpp:634
+#: ../src/msw/registry.cpp:623
 #, c-format
 msgid "Failed to rename the registry key '%s' to '%s'."
 msgstr "Impossibile rinominare la chiave '%s' del registro di sistema in '%s'."
 
-#: ../src/common/filename.cpp:2671
+#: ../src/msw/webview_ie.cpp:995
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/common/filename.cpp:2754
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Impossibile ottenere le date del file '%s'"
 
-#: ../src/msw/dialup.cpp:468
+#: ../src/msw/dialup.cpp:462
 msgid "Failed to retrieve text of RAS error message"
 msgstr ""
 "Impossibile ottenere il testo del messaggio di errore di Accesso Remoto (RAS)"
 
-#: ../src/msw/clipbrd.cpp:748
+#: ../src/msw/clipbrd.cpp:768
 msgid "Failed to retrieve the supported clipboard formats"
 msgstr "Impossibile ottenere i formati supportati dagli appunti"
 
-#: ../src/common/docview.cpp:652
+#: ../src/common/docview.cpp:647
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Impossibile salvare il dcoumento nel file \"%s\"."
 
-#: ../src/msw/dib.cpp:269
+#: ../src/msw/dib.cpp:312
 #, c-format
 msgid "Failed to save the bitmap image to file \"%s\"."
 msgstr "Impossibile salvare l'immagine bitmap nel file '%s'."
 
-#: ../src/msw/dde.cpp:763
+#: ../src/msw/dde.cpp:811
 msgid "Failed to send DDE advise notification"
 msgstr "Impossibile inviare una notifica advise DDE"
 
-#: ../src/common/ftp.cpp:402
+#: ../src/common/ftp.cpp:399
 #, c-format
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Impossibile impostare la modalità di trasferimneto FTP %s.."
 
-#: ../src/msw/clipbrd.cpp:427
+#: ../src/msw/clipbrd.cpp:443
 msgid "Failed to set clipboard data."
 msgstr "Impossibile scrivere i dati degli appunti."
 
-#: ../src/unix/snglinst.cpp:181
+#: ../src/unix/snglinst.cpp:178
 #, c-format
 msgid "Failed to set permissions on lock file '%s'"
 msgstr "Impossibile impostare i permessi per il file di lock '%s'"
 
-#: ../src/unix/utilsunx.cpp:668
+#: ../src/unix/utilsunx.cpp:670
 msgid "Failed to set process priority"
 msgstr "Impossibile impostare la priorità"
 
-#: ../src/common/file.cpp:559
+#: ../src/common/ffile.cpp:355 ../src/common/file.cpp:586
 msgid "Failed to set temporary file permissions"
 msgstr "Impossibile impostare i permessi del file temporaneo"
 
-#: ../src/gtk/textctrl.cpp:1072
-msgid "Failed to set text in the text control."
-msgstr "Impossibile impostare il testo nella casella di testo."
-
-#: ../src/unix/threadpsx.cpp:1298
+#: ../src/unix/threadpsx.cpp:1347
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Impossibile impostare livello concorrenza a %lu"
 
-#: ../src/unix/threadpsx.cpp:1424
+#: ../src/unix/threadpsx.cpp:1473
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Impossibile assegnare la priorità %d al thread."
 
-#: ../src/unix/utilsunx.cpp:783
+#: ../src/unix/utilsunx.cpp:785
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 "Impossibile impostare pipe non bloccante, il programma potrebbe bloccarsi."
 
-#: ../src/common/fs_mem.cpp:261
+#: ../src/msw/webview_ie.cpp:987
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:256
 #, c-format
 msgid "Failed to store image '%s' to memory VFS!"
 msgstr "Impossibile memorizzare l'immagine '%s' nella memoria VFS!"
 
-#: ../src/dfb/evtloop.cpp:170
+#: ../src/dfb/evtloop.cpp:171
 msgid "Failed to switch DirectFB pipe to non-blocking mode"
 msgstr "Impossibile commutare coda DirectFB in modalità non bloccante"
 
-#: ../src/unix/wakeuppipe.cpp:59
+#: ../src/unix/wakeuppipe.cpp:56
 msgid "Failed to switch wake up pipe to non-blocking mode"
 msgstr "Impossibile commutare coda risevglio in modalità non bloccante"
 
-#: ../src/unix/threadpsx.cpp:1605
+#: ../src/unix/threadpsx.cpp:1654
 msgid "Failed to terminate a thread."
 msgstr "Impossibile terminare il thread."
 
-#: ../src/msw/dde.cpp:741
+#: ../src/msw/dde.cpp:736
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "Impossibile terminare il ciclo advise con il server DDE"
 
-#: ../src/msw/dialup.cpp:938
+#: ../src/msw/dialup.cpp:932
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Impossibile terminare la connessione: %s"
 
-#: ../src/common/filename.cpp:2590
+#: ../src/common/filename.cpp:2673
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Impossibile eseguire 'touch' sul file '%s'"
 
-#: ../src/unix/snglinst.cpp:334
+#: ../src/unix/dlunix.cpp:90
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "Impossibile caricare la libreria dinamica '%s'"
+
+#: ../src/unix/snglinst.cpp:331
 #, c-format
 msgid "Failed to unlock lock file '%s'"
 msgstr "Impossibile sbloccare il file di lock '%s'"
 
-#: ../src/msw/dde.cpp:309
+#: ../src/msw/dde.cpp:304
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Impossibile deregistrare il server DDE '%s'"
@@ -3670,77 +3742,87 @@ msgstr "Impossibile deregistrare descrittore %d dal descrittore epoll %d"
 msgid "Failed to update user configuration file."
 msgstr "Impossibile aggiornare il file di configurazione utente."
 
-#: ../src/common/debugrpt.cpp:733
+#: ../src/common/debugrpt.cpp:743
 #, c-format
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Impossibile inviare la segnalazione di errore (codice di errore %d)."
 
-#: ../src/unix/snglinst.cpp:168
+#: ../src/unix/snglinst.cpp:165
 #, c-format
 msgid "Failed to write to lock file '%s'"
 msgstr "Impossibile scrivere nel file di blocco '%s'"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:209
+#: ../src/propgrid/propgrid.cpp:190
 msgid "False"
 msgstr "Falso"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:694
+#: ../src/propgrid/advprops.cpp:604
 msgid "Family"
 msgstr "Famiglia"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/gtk/glcanvas.cpp:176 ../src/gtk/glcanvas.cpp:187
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Errore Fatale"
+
+#: ../src/common/stockitem.cpp:154
 msgid "File"
 msgstr "File"
 
-#: ../src/common/docview.cpp:669
+#: ../src/common/docview.cpp:664
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Impossibile aprire il file  \"%s\" per la lettura."
 
-#: ../src/common/docview.cpp:646
+#: ../src/common/docview.cpp:641
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Impossibile aprire il file \"%s\" per la scrittura."
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "File '%s' esistente. Vuoi sovrascriverlo?"
 
-#: ../src/common/filefn.cpp:1156
+#: ../src/common/filefn.cpp:1044
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Il file '%s' non può essere rimosso"
 
-#: ../src/common/filefn.cpp:1139
+#: ../src/common/filefn.cpp:1028
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Il file '%s' non può essere rinominato '%s'"
 
-#: ../src/richtext/richtextctrl.cpp:3081 ../src/common/textcmn.cpp:953
+#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
 msgid "File couldn't be loaded."
 msgstr "Impossibile caricare il file."
 
-#: ../src/msw/filedlg.cpp:393
+#: ../src/msw/filedlg.cpp:414
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Finestra dialogo file fallita con codice errore %0lx."
 
-#: ../src/common/docview.cpp:1789
+#: ../src/common/docview.cpp:1783
 msgid "File error"
 msgstr "Errore di file"
 
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/filectrlg.cpp:770
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/filectrlg.cpp:766
 msgid "File name exists already."
 msgstr "Nome file esistente."
+
+#: ../src/osx/cocoa/filedlg.mm:264
+#, fuzzy
+msgid "File type:"
+msgstr "Teletype"
 
 #: ../src/motif/filedlg.cpp:220
 msgid "Files"
 msgstr "File"
 
-#: ../src/common/filefn.cpp:1591
+#: ../src/common/filefn.cpp:1479
 #, c-format
 msgid "Files (%s)"
 msgstr "File (%s)"
@@ -3749,15 +3831,29 @@ msgstr "File (%s)"
 msgid "Filter"
 msgstr "Filtra"
 
-#: ../src/common/stockitem.cpp:158 ../src/html/helpwnd.cpp:490
+#: ../src/html/helpwnd.cpp:488
 msgid "Find"
 msgstr "Trova"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:259
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:258
+#, fuzzy
+msgid "Find in document"
+msgstr "Apri un documento HTML"
+
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "Find..."
+msgstr "Trova"
+
+#: ../src/common/stockitem.cpp:156
 msgid "First"
 msgstr "Primo"
 
-#: ../src/common/prntbase.cpp:1548
+#: ../src/common/prntbase.cpp:1573
 msgid "First page"
 msgstr "Prima pagina"
 
@@ -3765,11 +3861,11 @@ msgstr "Prima pagina"
 msgid "Fixed"
 msgstr "Fisso"
 
-#: ../src/html/helpwnd.cpp:1206
+#: ../src/html/helpwnd.cpp:1204
 msgid "Fixed font:"
 msgstr "Font a corpo fisso:"
 
-#: ../src/html/helpwnd.cpp:1269
+#: ../src/html/helpwnd.cpp:1267
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Larghezza fissa.<br> <b>grassetto</b> <i>corsivo</i> "
 
@@ -3777,16 +3873,16 @@ msgstr "Larghezza fissa.<br> <b>grassetto</b> <i>corsivo</i> "
 msgid "Floating"
 msgstr "Flottuante"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "Floppy"
 msgstr "Floppy"
 
-#: ../src/common/paper.cpp:111
+#: ../src/common/paper.cpp:108
 msgid "Folio, 8 1/2 x 13 in"
 msgstr "Foglio, 8 1/2 x 13 pollici"
 
-#: ../src/richtext/richtextformatdlg.cpp:344 ../src/osx/carbon/fontdlg.cpp:287
-#: ../src/common/stockitem.cpp:194
+#: ../src/osx/carbon/fontdlg.cpp:284 ../src/common/stockitem.cpp:191
+#: ../src/richtext/richtextformatdlg.cpp:337
 msgid "Font"
 msgstr "Font"
 
@@ -3794,7 +3890,24 @@ msgstr "Font"
 msgid "Font &weight:"
 msgstr "&Peso del font:"
 
-#: ../src/html/helpwnd.cpp:1207
+#: ../src/osx/fontutil.cpp:89
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
+"\"."
+msgstr ""
+
+#: ../src/msw/font.cpp:1126
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Impossibile caricare il file."
+
+#: ../src/osx/fontutil.cpp:81
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "Il file %s non esiste."
+
+#: ../src/html/helpwnd.cpp:1205
 msgid "Font size:"
 msgstr "Corpo:"
 
@@ -3802,53 +3915,53 @@ msgstr "Corpo:"
 msgid "Font st&yle:"
 msgstr "St&ile:"
 
-#: ../src/osx/carbon/fontdlg.cpp:329
+#: ../src/osx/carbon/fontdlg.cpp:326
 msgid "Font:"
 msgstr "Font:"
 
-#: ../src/dfb/fontmgr.cpp:198
+#: ../src/dfb/fontmgr.cpp:195
 #, c-format
 msgid "Fonts index file %s disappeared while loading fonts."
 msgstr "Il file indice font %s è sparito durante il caricamento delle font."
 
-#: ../src/unix/utilsunx.cpp:645
+#: ../src/unix/utilsunx.cpp:647
 msgid "Fork failed"
 msgstr "Fork fallita"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "Forward"
 msgstr "Avanti"
 
-#: ../src/common/xtixml.cpp:235
+#: ../src/common/xtixml.cpp:231
 msgid "Forward hrefs are not supported"
 msgstr "Forward hrefs non supportata"
 
-#: ../src/html/helpwnd.cpp:875
+#: ../src/html/helpwnd.cpp:873
 #, c-format
 msgid "Found %i matches"
 msgstr "Trovate %i corrispondenze"
 
-#: ../src/generic/prntdlgg.cpp:238
+#: ../src/generic/prntdlgg.cpp:231
 msgid "From:"
 msgstr "Da:"
 
-#: ../src/propgrid/advprops.cpp:1604
+#: ../src/propgrid/advprops.cpp:1510
 msgid "Fuchsia"
 msgstr "Fucsia"
 
-#: ../src/common/imaggif.cpp:138
+#: ../src/common/imaggif.cpp:135
 msgid "GIF: data stream seems to be truncated."
 msgstr "GIF: il flusso dati dembra essere interrotto."
 
-#: ../src/common/imaggif.cpp:128
+#: ../src/common/imaggif.cpp:125
 msgid "GIF: error in GIF image format."
 msgstr "GIF: errore nel formato GIF dell'immagine."
 
-#: ../src/common/imaggif.cpp:133
+#: ../src/common/imaggif.cpp:130
 msgid "GIF: not enough memory."
 msgstr "GIF: memoria insufficiente."
 
-#: ../src/gtk/window.cpp:4631
+#: ../src/gtk/window.cpp:5635
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -3856,23 +3969,23 @@ msgstr ""
 "GTK+ installato su questo computer è troppo vecchio per supportare "
 "composizione schermo. Installa GTK+ 2.12 o superiore."
 
-#: ../src/univ/themes/gtk.cpp:525
+#: ../src/univ/themes/gtk.cpp:522
 msgid "GTK+ theme"
 msgstr "Tema GTK+"
 
-#: ../src/common/preferencescmn.cpp:40
+#: ../src/common/preferencescmn.cpp:37
 msgid "General"
 msgstr "Generale"
 
-#: ../src/common/prntbase.cpp:258
+#: ../src/common/prntbase.cpp:253
 msgid "Generic PostScript"
 msgstr "PostScript generico"
 
-#: ../src/common/paper.cpp:135
+#: ../src/common/paper.cpp:132
 msgid "German Legal Fanfold, 8 1/2 x 13 in"
 msgstr "German Legal Fanfold, 8 1/2 x 13 pollici"
 
-#: ../src/common/paper.cpp:134
+#: ../src/common/paper.cpp:131
 msgid "German Std Fanfold, 8 1/2 x 12 in"
 msgstr "German Std Fanfold, 8 1/2 x 12 pollici"
 
@@ -3888,48 +4001,48 @@ msgstr "GetPropertyCollection chiamato su generic accessor"
 msgid "GetPropertyCollection called w/o valid collection getter"
 msgstr "GetPropertyCollection chiamato senza un valido collection getter"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:658
 msgid "Go back"
 msgstr "Indietro"
 
-#: ../src/html/helpwnd.cpp:661
+#: ../src/html/helpwnd.cpp:659
 msgid "Go forward"
 msgstr "Avanti"
 
-#: ../src/html/helpwnd.cpp:663
+#: ../src/html/helpwnd.cpp:661
 msgid "Go one level up in document hierarchy"
 msgstr "Livello superiore nella gerarchia di documenti"
 
-#: ../src/generic/filedlgg.cpp:208 ../src/generic/dirdlgg.cpp:116
+#: ../src/generic/filedlgg.cpp:205 ../src/generic/dirdlgg.cpp:113
 msgid "Go to home directory"
 msgstr "Vai alla cartella Home"
 
-#: ../src/generic/filedlgg.cpp:205
+#: ../src/generic/filedlgg.cpp:202
 msgid "Go to parent directory"
 msgstr "Cartella superiore"
 
-#: ../src/generic/aboutdlgg.cpp:76
+#: ../src/generic/aboutdlgg.cpp:73
 msgid "Graphics art by "
 msgstr "Grafica di "
 
-#: ../src/propgrid/advprops.cpp:1599
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Gray"
 msgstr "Grigio"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:883
+#: ../src/propgrid/advprops.cpp:784
 msgid "GrayText"
 msgstr "Testo grigio"
 
-#: ../src/common/fmapbase.cpp:154
+#: ../src/common/fmapbase.cpp:151
 msgid "Greek (ISO-8859-7)"
 msgstr "Greco (ISO-8859-7)"
 
-#: ../src/propgrid/advprops.cpp:1600
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Green"
 msgstr "Verde"
 
-#: ../src/generic/colrdlgg.cpp:342
+#: ../src/generic/colrdlgg.cpp:362
 msgid "Green:"
 msgstr "Verde:"
 
@@ -3937,107 +4050,107 @@ msgstr "Verde:"
 msgid "Groove"
 msgstr "Scanalatura"
 
-#: ../src/common/zstream.cpp:158 ../src/common/zstream.cpp:318
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
 msgid "Gzip not supported by this version of zlib"
 msgstr "Gzip non è supportato da questa versione della libreria zlib"
 
-#: ../src/html/helpwnd.cpp:1549
+#: ../src/html/helpwnd.cpp:1547
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "Progetto HTML Help (*.hhp)|*.hhp|"
 
-#: ../src/html/htmlwin.cpp:681
+#: ../src/html/htmlwin.cpp:691
 #, c-format
 msgid "HTML anchor %s does not exist."
 msgstr "Ancora HTML %s non esistente."
 
-#: ../src/html/helpwnd.cpp:1547
+#: ../src/html/helpwnd.cpp:1545
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "File HTML (*.html;*.htm)|*.html;*.htm|"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1759
+#: ../src/propgrid/advprops.cpp:1660
 msgid "Hand"
 msgstr "Mano"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "Harddisk"
 msgstr "Disco fisso"
 
-#: ../src/common/fmapbase.cpp:155
+#: ../src/common/fmapbase.cpp:152
 msgid "Hebrew (ISO-8859-8)"
 msgstr "Ebraico (ISO-8859-8)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:280 ../src/osx/button_osx.cpp:39
-#: ../src/common/stockitem.cpp:163 ../src/common/accelcmn.cpp:80
-#: ../src/html/helpdlg.cpp:66 ../src/html/helpfrm.cpp:111
+#: ../include/wx/msgdlg.h:282 ../src/osx/button_osx.cpp:39
+#: ../src/common/stockitem.cpp:160 ../src/common/accelcmn.cpp:77
+#: ../src/html/helpfrm.cpp:108 ../src/html/helpdlg.cpp:63
 msgid "Help"
 msgstr "Aiuto"
 
-#: ../src/html/helpwnd.cpp:1200
+#: ../src/html/helpwnd.cpp:1198
 msgid "Help Browser Options"
 msgstr "Opzioni del browser della Guida"
 
-#: ../src/generic/helpext.cpp:454 ../src/generic/helpext.cpp:455
+#: ../src/generic/helpext.cpp:452 ../src/generic/helpext.cpp:453
 msgid "Help Index"
 msgstr "Indice"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1529
 msgid "Help Printing"
 msgstr "Stampa"
 
-#: ../src/html/helpwnd.cpp:801
+#: ../src/html/helpwnd.cpp:799
 msgid "Help Topics"
 msgstr "Contenuti"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1546
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Libro Guida (*.htb)|*.htb|Libro Guida (*.zip)|*.zip|"
 
-#: ../src/generic/helpext.cpp:267
+#: ../src/generic/helpext.cpp:265
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "Cartella \"%s\" della Guida non trovata."
 
-#: ../src/generic/helpext.cpp:275
+#: ../src/generic/helpext.cpp:273
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "File della Guida \"%s\" non trovato."
 
-#: ../src/html/helpctrl.cpp:63
+#: ../src/html/helpctrl.cpp:59
 #, c-format
 msgid "Help: %s"
 msgstr "Aiuto: %s"
 
-#: ../src/osx/menu_osx.cpp:577
+#: ../src/osx/menu_osx.cpp:469
 #, c-format
 msgid "Hide %s"
 msgstr "Nascondi %s"
 
-#: ../src/osx/menu_osx.cpp:579
+#: ../src/osx/menu_osx.cpp:471
 msgid "Hide Others"
 msgstr "Nascondi altri"
 
-#: ../src/generic/infobar.cpp:84
+#: ../src/generic/infobar.cpp:81
 msgid "Hide this notification message."
 msgstr "Nascondi questo messaggio di notifica."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:884
+#: ../src/propgrid/advprops.cpp:785
 msgid "Highlight"
 msgstr "Evidenzia"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:885
+#: ../src/propgrid/advprops.cpp:786
 msgid "HighlightText"
 msgstr "Testo evidenziato"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:164 ../src/common/accelcmn.cpp:65
+#: ../src/common/stockitem.cpp:161 ../src/common/accelcmn.cpp:62
 msgid "Home"
 msgstr "Home"
 
-#: ../src/generic/dirctrlg.cpp:524
+#: ../src/generic/dirctrlg.cpp:490
 msgid "Home directory"
 msgstr "Cartella home"
 
@@ -4047,55 +4160,55 @@ msgid "How the object will float relative to the text."
 msgstr "Come l'oggetto sarà flottante rispetto al testo."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1760
+#: ../src/propgrid/advprops.cpp:1661
 msgid "I-Beam"
 msgstr "I-Beam"
 
-#: ../src/common/imagbmp.cpp:1196
+#: ../src/common/imagbmp.cpp:1208
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: errore durante la lettura della maschera DIB."
 
-#: ../src/common/imagbmp.cpp:1290 ../src/common/imagbmp.cpp:1390
-#: ../src/common/imagbmp.cpp:1405 ../src/common/imagbmp.cpp:1416
-#: ../src/common/imagbmp.cpp:1430 ../src/common/imagbmp.cpp:1478
-#: ../src/common/imagbmp.cpp:1493 ../src/common/imagbmp.cpp:1507
-#: ../src/common/imagbmp.cpp:1518
+#: ../src/common/imagbmp.cpp:1302 ../src/common/imagbmp.cpp:1402
+#: ../src/common/imagbmp.cpp:1417 ../src/common/imagbmp.cpp:1428
+#: ../src/common/imagbmp.cpp:1442 ../src/common/imagbmp.cpp:1490
+#: ../src/common/imagbmp.cpp:1505 ../src/common/imagbmp.cpp:1519
+#: ../src/common/imagbmp.cpp:1530
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: Errore durante la scrittura dell'immagine!"
 
-#: ../src/common/imagbmp.cpp:1255
+#: ../src/common/imagbmp.cpp:1267
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: immagine troppo alta per essere un'icona."
 
-#: ../src/common/imagbmp.cpp:1263
+#: ../src/common/imagbmp.cpp:1275
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: immagine troppo larga per essere un'icona."
 
-#: ../src/common/imagbmp.cpp:1603
+#: ../src/common/imagbmp.cpp:1615
 msgid "ICO: Invalid icon index."
 msgstr "ICO: indice dell'icona non valido."
 
-#: ../src/common/imagiff.cpp:758
+#: ../src/common/imagiff.cpp:755
 msgid "IFF: data stream seems to be truncated."
 msgstr "IFF: il flusso dati dembra essere interrotto."
 
-#: ../src/common/imagiff.cpp:742
+#: ../src/common/imagiff.cpp:739
 msgid "IFF: error in IFF image format."
 msgstr "IFF: errore nel formato IFF dell'immagine."
 
-#: ../src/common/imagiff.cpp:745
+#: ../src/common/imagiff.cpp:742
 msgid "IFF: not enough memory."
 msgstr "IFF: memoria insufficiente."
 
-#: ../src/common/imagiff.cpp:748
+#: ../src/common/imagiff.cpp:745
 msgid "IFF: unknown error!!!"
 msgstr "IFF: errore sconosciuto!!!"
 
-#: ../src/common/fmapbase.cpp:197
+#: ../src/common/fmapbase.cpp:194
 msgid "ISO-2022-JP"
 msgstr "ISO-2022-JP"
 
-#: ../src/html/htmprint.cpp:282
+#: ../src/html/htmprint.cpp:294
 msgid ""
 "If possible, try changing the layout parameters to make the printout more "
 "narrow."
@@ -4103,7 +4216,7 @@ msgstr ""
 "Se possibile prova a modificare i parametri del layout per rendere la stampa "
 "più stretta."
 
-#: ../src/generic/dbgrptg.cpp:358
+#: ../src/generic/dbgrptg.cpp:362
 msgid ""
 "If you have any additional information pertaining to this bug\n"
 "report, please enter it here and it will be joined to it:"
@@ -4123,46 +4236,50 @@ msgstr ""
 "anche se questo potrebbe ostacolare il miglioramento del programma. Ti\n"
 "invitiamo pertanto a continuare con la generazione della segnalazione.\n"
 
-#: ../src/msw/registry.cpp:1405
+#: ../src/common/zipstrm.cpp:1043
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1393
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Il valore \"%s\" della chiave \"%s\" è stato ignorato."
 
-#: ../src/common/xtistrm.cpp:295
+#: ../src/common/xtistrm.cpp:292
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Object Class (Non-wxEvtHandler) come Event Source non consentito"
 
-#: ../src/common/xti.cpp:513
+#: ../src/common/xti.cpp:510
 msgid "Illegal Parameter Count for ConstructObject Method"
 msgstr "Parameter Count per ConstructObject non consentito"
 
-#: ../src/common/xti.cpp:501
+#: ../src/common/xti.cpp:498
 msgid "Illegal Parameter Count for Create Method"
 msgstr "Parameter Count per Create Method non consentito"
 
-#: ../src/generic/dirctrlg.cpp:570 ../src/generic/filectrlg.cpp:756
+#: ../src/generic/dirctrlg.cpp:536 ../src/generic/filectrlg.cpp:752
 msgid "Illegal directory name."
 msgstr "Nome di cartella non valido."
 
-#: ../src/generic/filectrlg.cpp:1367
+#: ../src/generic/filectrlg.cpp:1356
 msgid "Illegal file specification."
 msgstr "Specifica di file non valida."
 
-#: ../src/common/image.cpp:2269
+#: ../src/common/image.cpp:2363
 msgid "Image and mask have different sizes."
 msgstr "L'immagine e la maschera hanno dimensioni diverse."
 
-#: ../src/common/image.cpp:2746
+#: ../src/common/image.cpp:2841
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "Il file immagine non è di tipo %d."
 
-#: ../src/common/image.cpp:2877
+#: ../src/common/image.cpp:2995
 #, c-format
 msgid "Image is not of type %s."
 msgstr "L'immagine non è di tipo %s."
 
-#: ../src/msw/textctrl.cpp:488
+#: ../src/msw/textctrl.cpp:534
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -4170,100 +4287,100 @@ msgstr ""
 "Impossibile creare un controllo rich edit, impiegato un controllo di tipo "
 "testo semplice. Per favore reinstallare riched32.dll"
 
-#: ../src/unix/utilsunx.cpp:301
+#: ../src/unix/utilsunx.cpp:303
 msgid "Impossible to get child process input"
 msgstr "Impossibile ottenere l'input del processo figlio"
 
-#: ../src/common/filefn.cpp:1028
+#: ../src/common/filefn.cpp:917
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Impossibile determinare i permessi per il file '%s'"
 
-#: ../src/common/filefn.cpp:1042
+#: ../src/common/filefn.cpp:931
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Impossibile sovrascrivere il file '%s'"
 
-#: ../src/common/filefn.cpp:1097
+#: ../src/common/filefn.cpp:986
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Impossibile impostare i permessi per il file '%s'"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:886
+#: ../src/propgrid/advprops.cpp:787
 msgid "InactiveBorder"
 msgstr "Bordo non attivo"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:887
+#: ../src/propgrid/advprops.cpp:788
 msgid "InactiveCaption"
 msgstr "TitoloNonAttivo"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:888
+#: ../src/propgrid/advprops.cpp:789
 msgid "InactiveCaptionText"
 msgstr "TestoTitoloNonAttivo"
 
-#: ../src/common/gifdecod.cpp:792
+#: ../src/common/gifdecod.cpp:826
 #, c-format
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "Dimensione frame GTK non valida  (%u, %d) per il frame #%u"
 
-#: ../src/msw/ole/automtn.cpp:635
+#: ../src/msw/ole/automtn.cpp:626
 msgid "Incorrect number of arguments."
 msgstr "Numeri non validi degli argomenti."
 
-#: ../src/common/stockitem.cpp:165
+#: ../src/common/stockitem.cpp:162
 msgid "Indent"
 msgstr "Indenta"
 
-#: ../src/richtext/richtextformatdlg.cpp:349
+#: ../src/richtext/richtextformatdlg.cpp:342
 msgid "Indents && Spacing"
 msgstr "Rientri e spaziature"
 
-#: ../src/common/stockitem.cpp:166 ../src/html/helpwnd.cpp:515
+#: ../src/common/stockitem.cpp:163 ../src/html/helpwnd.cpp:513
 msgid "Index"
 msgstr "Indice"
 
-#: ../src/common/fmapbase.cpp:159
+#: ../src/common/fmapbase.cpp:156
 msgid "Indian (ISO-8859-12)"
 msgstr "Indiano (ISO-8859-12)"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "Info"
 msgstr "Info"
 
-#: ../src/common/init.cpp:287
+#: ../src/common/init.cpp:284
 msgid "Initialization failed in post init, aborting."
 msgstr "Inizializzazione fallita in \"post init\", esco."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:54
+#: ../src/common/accelcmn.cpp:51
 msgid "Ins"
 msgstr "Aggiungi"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextsymboldlg.cpp:472 ../src/common/accelcmn.cpp:53
+#: ../src/common/accelcmn.cpp:50 ../src/richtext/richtextsymboldlg.cpp:469
 msgid "Insert"
 msgstr "Inserisci"
 
-#: ../src/richtext/richtextbuffer.cpp:8067
+#: ../src/richtext/richtextbuffer.cpp:8063
 msgid "Insert Field"
 msgstr "Inserisci campo"
 
-#: ../src/richtext/richtextbuffer.cpp:7978
-#: ../src/richtext/richtextbuffer.cpp:8936
+#: ../src/richtext/richtextbuffer.cpp:7974
+#: ../src/richtext/richtextbuffer.cpp:8934
 msgid "Insert Image"
 msgstr "Inserisci un'immagine"
 
-#: ../src/richtext/richtextbuffer.cpp:8025
+#: ../src/richtext/richtextbuffer.cpp:8021
 msgid "Insert Object"
 msgstr "Inserisci oggetto"
 
-#: ../src/richtext/richtextctrl.cpp:1286 ../src/richtext/richtextctrl.cpp:1494
-#: ../src/richtext/richtextbuffer.cpp:7822
-#: ../src/richtext/richtextbuffer.cpp:7852
-#: ../src/richtext/richtextbuffer.cpp:7894
+#: ../src/richtext/richtextbuffer.cpp:7818
+#: ../src/richtext/richtextbuffer.cpp:7848
+#: ../src/richtext/richtextbuffer.cpp:7890
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
 msgid "Insert Text"
 msgstr "Inserisci testo"
 
@@ -4276,16 +4393,11 @@ msgstr "Inserisci una interruzione pagina prima del paragrafo."
 msgid "Inset"
 msgstr "Aggiunta"
 
-#: ../src/gtk/app.cpp:425
-#, c-format
-msgid "Invalid GTK+ command line option, use \"%s --help\""
-msgstr "Opzione non valida linea di comando GTK, usare \"%s --help\""
-
-#: ../src/common/imagtiff.cpp:311
+#: ../src/common/imagtiff.cpp:308
 msgid "Invalid TIFF image index."
 msgstr "Indice dell'immagine TIFF non valido."
 
-#: ../src/common/appcmn.cpp:273
+#: ../src/common/appcmn.cpp:294
 #, c-format
 msgid "Invalid display mode specification '%s'."
 msgstr "Specifica della modalità video '%s' non valida."
@@ -4295,248 +4407,252 @@ msgstr "Specifica della modalità video '%s' non valida."
 msgid "Invalid geometry specification '%s'"
 msgstr "Specifica della posizione e/o dimensioni '%s' non valida"
 
-#: ../src/unix/fswatcher_inotify.cpp:323
+#: ../src/unix/fswatcher_inotify.cpp:320
 #, c-format
 msgid "Invalid inotify event for \"%s\""
 msgstr "Evento 'inotify' non valido per \"%s\""
 
-#: ../src/unix/snglinst.cpp:312
+#: ../src/unix/snglinst.cpp:309
 #, c-format
 msgid "Invalid lock file '%s'."
 msgstr "File di blocco '%s' non valido."
 
-#: ../src/common/translation.cpp:1125
+#: ../src/common/translation.cpp:1167
 msgid "Invalid message catalog."
 msgstr "Messaggio catalogo non valido."
 
-#: ../src/common/xtistrm.cpp:405 ../src/common/xtistrm.cpp:420
+#: ../src/common/xtistrm.cpp:402 ../src/common/xtistrm.cpp:417
 msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
 msgstr "ID Oggetto Invalid o Null passato a GetObjectClassInfo"
 
-#: ../src/common/xtistrm.cpp:435
+#: ../src/common/xtistrm.cpp:432
 msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
 msgstr "ID Oggetto Invalid o Null passato a HasObjectClassInfo"
 
-#: ../src/common/regex.cpp:310
+#: ../src/common/regex.cpp:307
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Espressione regolare ( regular expression ) '%s' non valida: %s"
 
-#: ../src/common/config.cpp:226
+#: ../src/common/config.cpp:222
 #, c-format
 msgid "Invalid value %ld for a boolean key \"%s\" in config file."
 msgstr ""
 "Valore non valido %ld per la chiave booleana \"%s\"  nel file di "
 "configurazione."
 
-#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:351
-#: ../src/osx/carbon/fontdlg.cpp:361 ../src/common/stockitem.cpp:168
+#: ../src/osx/carbon/fontdlg.cpp:358 ../src/common/stockitem.cpp:165
+#: ../src/generic/fontdlgg.cpp:325 ../src/richtext/richtextfontpage.cpp:351
 msgid "Italic"
 msgstr "Corsivo"
 
-#: ../src/common/paper.cpp:130
+#: ../src/common/paper.cpp:127
 msgid "Italy Envelope, 110 x 230 mm"
 msgstr "Busta Italiana, 110 x 230 mm"
 
-#: ../src/common/imagjpeg.cpp:270
+#: ../src/common/imagjpeg.cpp:257
 msgid "JPEG: Couldn't load - file is probably corrupted."
 msgstr "JPEG: Caricamento impossibile - probabilmente il file è danneggiato."
 
-#: ../src/common/imagjpeg.cpp:449
+#: ../src/common/imagjpeg.cpp:436
 msgid "JPEG: Couldn't save image."
 msgstr "JPEG: Impossibile salvare l'immagine."
 
-#: ../src/common/paper.cpp:163
+#: ../src/common/paper.cpp:160
 msgid "Japanese Double Postcard 200 x 148 mm"
 msgstr "Doppia cartolina giapponese 200 x 148 mm"
 
-#: ../src/common/paper.cpp:167
+#: ../src/common/paper.cpp:164
 msgid "Japanese Envelope Chou #3"
 msgstr "Busta giapponese Chou #3"
 
-#: ../src/common/paper.cpp:180
+#: ../src/common/paper.cpp:177
 msgid "Japanese Envelope Chou #3 Rotated"
 msgstr "Busta giapponese  Chou #3 Ruotata"
 
-#: ../src/common/paper.cpp:168
+#: ../src/common/paper.cpp:165
 msgid "Japanese Envelope Chou #4"
 msgstr "Busta giapponese  Chou #4"
 
-#: ../src/common/paper.cpp:181
+#: ../src/common/paper.cpp:178
 msgid "Japanese Envelope Chou #4 Rotated"
 msgstr "Busta giapponese  Chou #4 Ruotata"
 
-#: ../src/common/paper.cpp:165
+#: ../src/common/paper.cpp:162
 msgid "Japanese Envelope Kaku #2"
 msgstr "Busta giapponese  Kaku #2"
 
-#: ../src/common/paper.cpp:178
+#: ../src/common/paper.cpp:175
 msgid "Japanese Envelope Kaku #2 Rotated"
 msgstr "Busta giapponese  Kaku #2 Ruotata"
 
-#: ../src/common/paper.cpp:166
+#: ../src/common/paper.cpp:163
 msgid "Japanese Envelope Kaku #3"
 msgstr "Busta giapponese  Kaku #3"
 
-#: ../src/common/paper.cpp:179
+#: ../src/common/paper.cpp:176
 msgid "Japanese Envelope Kaku #3 Rotated"
 msgstr "Busta giapponese  Kaku #3 Ruotata"
 
-#: ../src/common/paper.cpp:185
+#: ../src/common/paper.cpp:182
 msgid "Japanese Envelope You #4"
 msgstr "Busta giapponese You #4"
 
-#: ../src/common/paper.cpp:186
+#: ../src/common/paper.cpp:183
 msgid "Japanese Envelope You #4 Rotated"
 msgstr "Busta giapponese You #4 Ruotata"
 
-#: ../src/common/paper.cpp:138
+#: ../src/common/paper.cpp:135
 msgid "Japanese Postcard 100 x 148 mm"
 msgstr "Cartolina giapponese 100 x 148 mm"
 
-#: ../src/common/paper.cpp:175
+#: ../src/common/paper.cpp:172
 msgid "Japanese Postcard Rotated 148 x 100 mm"
 msgstr "Cartolina giapponese ruotata 148 x 100 mm"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "Jump to"
 msgstr "Vai a"
 
-#: ../src/common/stockitem.cpp:171
+#: ../src/common/stockitem.cpp:168
 msgid "Justified"
 msgstr "Giustificato"
 
-#: ../src/richtext/richtextindentspage.cpp:155
-#: ../src/richtext/richtextindentspage.cpp:157
 #: ../src/richtext/richtextliststylepage.cpp:344
 #: ../src/richtext/richtextliststylepage.cpp:346
+#: ../src/richtext/richtextindentspage.cpp:155
+#: ../src/richtext/richtextindentspage.cpp:157
 msgid "Justify text left and right."
 msgstr "Justifica il testo a sinistra e a destra."
 
-#: ../src/common/fmapbase.cpp:163
+#: ../src/common/fmapbase.cpp:160
 msgid "KOI8-R"
 msgstr "KOI8-R"
 
-#: ../src/common/fmapbase.cpp:164
+#: ../src/common/fmapbase.cpp:161
 msgid "KOI8-U"
 msgstr "KOI8-U"
 
-#: ../src/common/accelcmn.cpp:265 ../src/common/accelcmn.cpp:347
+#: ../src/common/accelcmn.cpp:279 ../src/common/accelcmn.cpp:364
 msgid "KP_"
 msgstr "KP_"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "KP_Add"
 msgstr "KP_Aggiungi"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "KP_Begin"
 msgstr "KP_Inizio"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "KP_Decimal"
 msgstr "KP_decimale"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 msgid "KP_Delete"
 msgstr "KP_Elimina"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "KP_Divide"
 msgstr "KP_Dividi"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 msgid "KP_Down"
 msgstr "KP_Giù"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "KP_End"
 msgstr "KP_Fine"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "KP_Enter"
 msgstr "KP_Invio"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "KP_Equal"
 msgstr "KP_Uguale"
 
+#: ../src/common/accelcmn.cpp:276 ../src/common/accelcmn.cpp:361
+msgid "KP_F"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 msgid "KP_Home"
 msgstr "KP_Home"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 msgid "KP_Insert"
 msgstr "KP_Inserisci"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "KP_Left"
 msgstr "KP_Sinistra"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "KP_Multiply"
 msgstr "KP_Moltiplica"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:99
+#: ../src/common/accelcmn.cpp:97
 msgid "KP_Next"
 msgstr "KP_Successivo"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "KP_PageDown"
 msgstr "KP_PagGiù"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "KP_PageUp"
 msgstr "KP_PagSu"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:98
+#: ../src/common/accelcmn.cpp:96
 msgid "KP_Prior"
 msgstr "KP_Precedente"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 msgid "KP_Right"
 msgstr "K_Destra"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "KP_Separator"
 msgstr "KP_Separatore"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "KP_Space"
 msgstr "KP_Spazio"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "KP_Subtract"
 msgstr "KP_Sottrai"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "KP_Tab"
 msgstr "KP_Tab"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "KP_Up"
 msgstr "KP_Su"
 
@@ -4544,112 +4660,127 @@ msgstr "KP_Su"
 msgid "L&ine spacing:"
 msgstr "&Interlinea:"
 
-#: ../src/generic/prntdlgg.cpp:613 ../src/generic/prntdlgg.cpp:868
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "errore di compressione"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "errore di decompressione"
+
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:861
 msgid "Landscape"
 msgstr "Orizzontale"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "Last"
 msgstr "Ultimo"
 
-#: ../src/common/prntbase.cpp:1572
+#: ../src/common/prntbase.cpp:1597
 msgid "Last page"
 msgstr "Ultima pagina"
 
-#: ../src/common/log.cpp:305
+#: ../src/common/log.cpp:324
 #, c-format
 msgid "Last repeated message (\"%s\", %u time) wasn't output"
 msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
 msgstr[0] "L'ultimo messaggio ripetuto  (\"%s\", %u volta) non è stato inviato"
 msgstr[1] "L'ultimo messaggio ripetuto  (\"%s\", %u volte) non è stato inviato"
 
-#: ../src/common/paper.cpp:103
+#: ../src/common/paper.cpp:100
 msgid "Ledger, 17 x 11 in"
 msgstr "Ledger, 17 x 11 pollici"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6146
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:58 ../src/generic/datavgen.cpp:6951
+#: ../src/richtext/richtextsizepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:252
 #: ../src/richtext/richtextliststylepage.cpp:253
 #: ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
-#: ../src/richtext/richtextsizepage.cpp:249 ../src/common/accelcmn.cpp:61
 msgid "Left"
 msgstr "Sinistra"
 
-#: ../src/richtext/richtextindentspage.cpp:204
 #: ../src/richtext/richtextliststylepage.cpp:390
+#: ../src/richtext/richtextindentspage.cpp:204
 msgid "Left (&first line):"
 msgstr "Sinistra (&prima riga):"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1761
+#: ../src/propgrid/advprops.cpp:1662
 msgid "Left Button"
 msgstr "Pulsante sinistro"
 
-#: ../src/generic/prntdlgg.cpp:880
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Left margin (mm):"
 msgstr "Margine sinistro (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:141
-#: ../src/richtext/richtextindentspage.cpp:143
 #: ../src/richtext/richtextliststylepage.cpp:330
 #: ../src/richtext/richtextliststylepage.cpp:332
+#: ../src/richtext/richtextindentspage.cpp:141
+#: ../src/richtext/richtextindentspage.cpp:143
 msgid "Left-align text."
 msgstr "Allinea a sinistra."
 
-#: ../src/common/paper.cpp:144
+#: ../src/common/paper.cpp:141
 msgid "Legal Extra 9 1/2 x 15 in"
 msgstr "Legal Extra 9 1/2 x 15 pollici"
 
-#: ../src/common/paper.cpp:96
+#: ../src/common/paper.cpp:93
 msgid "Legal, 8 1/2 x 14 in"
 msgstr "Legal, 8 1/2 x 14 pollici"
 
-#: ../src/common/paper.cpp:143
+#: ../src/common/paper.cpp:140
 msgid "Letter Extra 9 1/2 x 12 in"
 msgstr "Letter Extra 9 1/2 x 12 pollici"
 
-#: ../src/common/paper.cpp:149
+#: ../src/common/paper.cpp:146
 msgid "Letter Extra Transverse 9.275 x 12 in"
 msgstr "Letter Extra Transverse 235 x 305 mm"
 
-#: ../src/common/paper.cpp:152
+#: ../src/common/paper.cpp:149
 msgid "Letter Plus 8 1/2 x 12.69 in"
 msgstr "Letter Plus 8 1/2 x 12.69 pollici"
 
-#: ../src/common/paper.cpp:169
+#: ../src/common/paper.cpp:166
 msgid "Letter Rotated 11 x 8 1/2 in"
 msgstr "Letter ruotato 11 x 8 1/2 pollici"
 
-#: ../src/common/paper.cpp:101
+#: ../src/common/paper.cpp:98
 msgid "Letter Small, 8 1/2 x 11 in"
 msgstr "Letter Small, 8 1/2 x 11 pollici"
 
-#: ../src/common/paper.cpp:147
+#: ../src/common/paper.cpp:144
 msgid "Letter Transverse 8 1/2 x 11 in"
 msgstr "Letter Transverse 8 1/2 x 11 pollici"
 
-#: ../src/common/paper.cpp:95
+#: ../src/common/paper.cpp:92
 msgid "Letter, 8 1/2 x 11 in"
 msgstr "Letter, 8 1/2 x 11 pollici"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "License"
 msgstr "Licenza"
 
-#: ../src/generic/fontdlgg.cpp:332
+#: ../src/generic/fontdlgg.cpp:328
 msgid "Light"
 msgstr "Leggero"
 
-#: ../src/propgrid/advprops.cpp:1608
+#: ../src/propgrid/advprops.cpp:1514
 msgid "Lime"
 msgstr "Lime"
 
-#: ../src/generic/helpext.cpp:294
+#: ../src/generic/helpext.cpp:292
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr ""
@@ -4659,16 +4790,16 @@ msgstr ""
 msgid "Line spacing:"
 msgstr "Interlinea:"
 
-#: ../src/html/chm.cpp:838
+#: ../src/html/chm.cpp:829
 msgid "Link contained '//', converted to absolute link."
 msgstr ""
 "Il collegamnto conteneva '//', è stato convertito a un collegamento assoluto."
 
-#: ../src/richtext/richtextformatdlg.cpp:364
+#: ../src/richtext/richtextformatdlg.cpp:357
 msgid "List Style"
 msgstr "Stile elenco"
 
-#: ../src/richtext/richtextstyles.cpp:1064
+#: ../src/richtext/richtextstyles.cpp:1061
 msgid "List styles"
 msgstr "Stili elenco"
 
@@ -4682,26 +4813,26 @@ msgstr "Elenca le dimensioni in punti del font."
 msgid "Lists the available fonts."
 msgstr "Elenca i font disponibili."
 
-#: ../src/common/fldlgcmn.cpp:340
+#: ../src/common/fldlgcmn.cpp:337
 #, c-format
 msgid "Load %s file"
 msgstr "Carica file %s"
 
-#: ../src/html/htmlwin.cpp:597
+#: ../src/html/htmlwin.cpp:600
 msgid "Loading : "
 msgstr "Caricamento : "
 
-#: ../src/unix/snglinst.cpp:246
+#: ../src/unix/snglinst.cpp:243
 #, c-format
 msgid "Lock file '%s' has incorrect owner."
 msgstr "Il file di blocco '%s' ha un proprietario errato."
 
-#: ../src/unix/snglinst.cpp:251
+#: ../src/unix/snglinst.cpp:248
 #, c-format
 msgid "Lock file '%s' has incorrect permissions."
 msgstr "Il file di blocco '%s' ha permessi scorretti."
 
-#: ../src/generic/logg.cpp:576
+#: ../src/generic/logg.cpp:573
 #, c-format
 msgid "Log saved to the file '%s'."
 msgstr "Registro salvato nel file '%s'."
@@ -4716,11 +4847,11 @@ msgstr "Lettere minuscole"
 msgid "Lower case roman numerals"
 msgstr "Numeri romani minuscoli"
 
-#: ../src/gtk/mdi.cpp:422 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk1/mdi.cpp:431 ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "Figlio MDI"
 
-#: ../src/msw/helpchm.cpp:56
+#: ../src/msw/helpchm.cpp:53
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -4728,189 +4859,189 @@ msgstr ""
 "Funzionalità Guida HTML MS non disponibili perchè la relativa libreria non è "
 "installata in questo computer. Installa la libreria."
 
-#: ../src/univ/themes/win32.cpp:3754
+#: ../src/univ/themes/win32.cpp:3751
 msgid "Ma&ximize"
 msgstr "&Ingrandisci"
 
-#: ../src/common/fmapbase.cpp:203
+#: ../src/common/fmapbase.cpp:200
 msgid "MacArabic"
 msgstr "Numeri arabi Mac"
 
-#: ../src/common/fmapbase.cpp:222
+#: ../src/common/fmapbase.cpp:219
 msgid "MacArmenian"
 msgstr "Mac armeno"
 
-#: ../src/common/fmapbase.cpp:211
+#: ../src/common/fmapbase.cpp:208
 msgid "MacBengali"
 msgstr "Mac bengali"
 
-#: ../src/common/fmapbase.cpp:217
+#: ../src/common/fmapbase.cpp:214
 msgid "MacBurmese"
 msgstr "Mac burmese"
 
-#: ../src/common/fmapbase.cpp:236
+#: ../src/common/fmapbase.cpp:233
 msgid "MacCeltic"
 msgstr "Mac celtico"
 
-#: ../src/common/fmapbase.cpp:227
+#: ../src/common/fmapbase.cpp:224
 msgid "MacCentralEurRoman"
 msgstr "Mac Europa centrale roman"
 
-#: ../src/common/fmapbase.cpp:223
+#: ../src/common/fmapbase.cpp:220
 msgid "MacChineseSimp"
 msgstr "Mac cinese simplificato"
 
-#: ../src/common/fmapbase.cpp:201
+#: ../src/common/fmapbase.cpp:198
 msgid "MacChineseTrad"
 msgstr "Mac cinese tradizionale"
 
-#: ../src/common/fmapbase.cpp:233
+#: ../src/common/fmapbase.cpp:230
 msgid "MacCroatian"
 msgstr "Mac croato"
 
-#: ../src/common/fmapbase.cpp:206
+#: ../src/common/fmapbase.cpp:203
 msgid "MacCyrillic"
 msgstr "Mac cirilico"
 
-#: ../src/common/fmapbase.cpp:207
+#: ../src/common/fmapbase.cpp:204
 msgid "MacDevanagari"
 msgstr "Mac devangari"
 
-#: ../src/common/fmapbase.cpp:231
+#: ../src/common/fmapbase.cpp:228
 msgid "MacDingbats"
 msgstr "Mac Dingbats"
 
-#: ../src/common/fmapbase.cpp:226
+#: ../src/common/fmapbase.cpp:223
 msgid "MacEthiopic"
 msgstr "Mac etiopico"
 
-#: ../src/common/fmapbase.cpp:229
+#: ../src/common/fmapbase.cpp:226
 msgid "MacExtArabic"
 msgstr "Mac arabico esteso"
 
-#: ../src/common/fmapbase.cpp:237
+#: ../src/common/fmapbase.cpp:234
 msgid "MacGaelic"
 msgstr "Mac gaelico"
 
-#: ../src/common/fmapbase.cpp:221
+#: ../src/common/fmapbase.cpp:218
 msgid "MacGeorgian"
 msgstr "Mac georgiano"
 
-#: ../src/common/fmapbase.cpp:205
+#: ../src/common/fmapbase.cpp:202
 msgid "MacGreek"
 msgstr "Mac greco"
 
-#: ../src/common/fmapbase.cpp:209
+#: ../src/common/fmapbase.cpp:206
 msgid "MacGujarati"
 msgstr "Mac gujarati"
 
-#: ../src/common/fmapbase.cpp:208
+#: ../src/common/fmapbase.cpp:205
 msgid "MacGurmukhi"
 msgstr "Mac gurmukhi"
 
-#: ../src/common/fmapbase.cpp:204
+#: ../src/common/fmapbase.cpp:201
 msgid "MacHebrew"
 msgstr "Mac ebraico"
 
-#: ../src/common/fmapbase.cpp:234
+#: ../src/common/fmapbase.cpp:231
 msgid "MacIcelandic"
 msgstr "Ma islandese"
 
-#: ../src/common/fmapbase.cpp:200
+#: ../src/common/fmapbase.cpp:197
 msgid "MacJapanese"
 msgstr "Mac giapponese"
 
-#: ../src/common/fmapbase.cpp:214
+#: ../src/common/fmapbase.cpp:211
 msgid "MacKannada"
 msgstr "Mac kannadia"
 
-#: ../src/common/fmapbase.cpp:238
+#: ../src/common/fmapbase.cpp:235
 msgid "MacKeyboardGlyphs"
 msgstr "Mac tastiera glyphs"
 
-#: ../src/common/fmapbase.cpp:218
+#: ../src/common/fmapbase.cpp:215
 msgid "MacKhmer"
 msgstr "Mac khmer"
 
-#: ../src/common/fmapbase.cpp:202
+#: ../src/common/fmapbase.cpp:199
 msgid "MacKorean"
 msgstr "Mac coreano"
 
-#: ../src/common/fmapbase.cpp:220
+#: ../src/common/fmapbase.cpp:217
 msgid "MacLaotian"
 msgstr "Mac loatiano"
 
-#: ../src/common/fmapbase.cpp:215
+#: ../src/common/fmapbase.cpp:212
 msgid "MacMalayalam"
 msgstr "Mac malayalam"
 
-#: ../src/common/fmapbase.cpp:225
+#: ../src/common/fmapbase.cpp:222
 msgid "MacMongolian"
 msgstr "Mac mongolo"
 
-#: ../src/common/fmapbase.cpp:210
+#: ../src/common/fmapbase.cpp:207
 msgid "MacOriya"
 msgstr "Mac oriya"
 
-#: ../src/common/fmapbase.cpp:199
+#: ../src/common/fmapbase.cpp:196
 msgid "MacRoman"
 msgstr "Mac Roman"
 
-#: ../src/common/fmapbase.cpp:235
+#: ../src/common/fmapbase.cpp:232
 msgid "MacRomanian"
 msgstr "Mac Romanian"
 
-#: ../src/common/fmapbase.cpp:216
+#: ../src/common/fmapbase.cpp:213
 msgid "MacSinhalese"
 msgstr "Mac Sinhalese"
 
-#: ../src/common/fmapbase.cpp:230
+#: ../src/common/fmapbase.cpp:227
 msgid "MacSymbol"
 msgstr "Mac Symbol"
 
-#: ../src/common/fmapbase.cpp:212
+#: ../src/common/fmapbase.cpp:209
 msgid "MacTamil"
 msgstr "Mac tamil"
 
-#: ../src/common/fmapbase.cpp:213
+#: ../src/common/fmapbase.cpp:210
 msgid "MacTelugu"
 msgstr "Mac telegu"
 
-#: ../src/common/fmapbase.cpp:219
+#: ../src/common/fmapbase.cpp:216
 msgid "MacThai"
 msgstr "Mac tailandese"
 
-#: ../src/common/fmapbase.cpp:224
+#: ../src/common/fmapbase.cpp:221
 msgid "MacTibetan"
 msgstr "Mac tibetano"
 
-#: ../src/common/fmapbase.cpp:232
+#: ../src/common/fmapbase.cpp:229
 msgid "MacTurkish"
 msgstr "Mac turco"
 
-#: ../src/common/fmapbase.cpp:228
+#: ../src/common/fmapbase.cpp:225
 msgid "MacVietnamese"
 msgstr "Mac vietnamita"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1762
+#: ../src/propgrid/advprops.cpp:1663
 msgid "Magnifier"
 msgstr "Ingrandimento"
 
-#: ../src/propgrid/advprops.cpp:2143
+#: ../src/propgrid/advprops.cpp:2050
 msgid "Make a selection:"
 msgstr "Effettua una selezione:"
 
-#: ../src/richtext/richtextformatdlg.cpp:374
+#: ../src/richtext/richtextformatdlg.cpp:367
 #: ../src/richtext/richtextmarginspage.cpp:171
 msgid "Margins"
 msgstr "Margini"
 
-#: ../src/propgrid/advprops.cpp:1595
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Maroon"
 msgstr "Marrone"
 
-#: ../src/generic/fdrepdlg.cpp:147
+#: ../src/generic/fdrepdlg.cpp:144
 msgid "Match case"
 msgstr "&Maiuscole/minuscole"
 
@@ -4922,40 +5053,40 @@ msgstr "Altezza max:"
 msgid "Max width:"
 msgstr "Larghezza max:"
 
-#: ../src/unix/mediactrl.cpp:947
+#: ../src/unix/mediactrl.cpp:972
 #, c-format
 msgid "Media playback error: %s"
 msgstr "Errore riproduzione: %s"
 
-#: ../src/common/fs_mem.cpp:175
+#: ../src/common/fs_mem.cpp:170
 #, c-format
 msgid "Memory VFS already contains file '%s'!"
 msgstr "La memoria VFS contiene già il file '%s'!"
 
 #. TRANSLATORS: Name of keyboard key
 #. TRANSLATORS: Keyword of system colour
-#: ../src/common/accelcmn.cpp:73 ../src/propgrid/advprops.cpp:889
+#: ../src/common/accelcmn.cpp:70 ../src/propgrid/advprops.cpp:790
 msgid "Menu"
 msgstr "Menu"
 
-#: ../src/common/msgout.cpp:124
+#: ../src/common/msgout.cpp:121
 msgid "Message"
 msgstr "Messaggio"
 
-#: ../src/univ/themes/metal.cpp:168
+#: ../src/univ/themes/metal.cpp:165
 msgid "Metal theme"
 msgstr "Tema metallico"
 
-#: ../src/msw/ole/automtn.cpp:652
+#: ../src/msw/ole/automtn.cpp:643
 msgid "Method or property not found."
 msgstr "Metodo o proprietà non trovata."
 
-#: ../src/univ/themes/win32.cpp:3752
+#: ../src/univ/themes/win32.cpp:3749
 msgid "Mi&nimize"
 msgstr "Riduci a &icona"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1763
+#: ../src/propgrid/advprops.cpp:1664
 msgid "Middle Button"
 msgstr "Pulsante centrale"
 
@@ -4967,38 +5098,43 @@ msgstr "Altezza min.:"
 msgid "Min width:"
 msgstr "Larghezza min.:"
 
-#: ../src/msw/ole/automtn.cpp:668
+#: ../src/osx/cocoa/menu.mm:281
+#, fuzzy
+msgid "Minimize"
+msgstr "Riduci a &icona"
+
+#: ../src/msw/ole/automtn.cpp:659
 msgid "Missing a required parameter."
 msgstr "Parametro richiesto mancante."
 
-#: ../src/generic/fontdlgg.cpp:324
+#: ../src/generic/fontdlgg.cpp:320
 msgid "Modern"
 msgstr "Modern"
 
-#: ../src/generic/filectrlg.cpp:427
+#: ../src/generic/filectrlg.cpp:423
 msgid "Modified"
 msgstr "Modificato"
 
-#: ../src/common/module.cpp:133
+#: ../src/common/module.cpp:130
 #, c-format
 msgid "Module \"%s\" initialization failed"
 msgstr "Inizializzazione del modulo \"%s\" fallita"
 
-#: ../src/common/paper.cpp:131
+#: ../src/common/paper.cpp:128
 msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
 msgstr "Busta Monarch, 3 7/8 x 7 1/2 pollici"
 
-#: ../src/msw/fswatcher.cpp:143
+#: ../src/msw/fswatcher.cpp:140
 msgid "Monitoring individual files for changes is not supported currently."
 msgstr ""
 "Il controllo dei cambiamenti dei file individuali non è attualmente "
 "supportato."
 
-#: ../src/generic/editlbox.cpp:172
+#: ../src/generic/editlbox.cpp:160
 msgid "Move down"
 msgstr "Sposta verso il basso"
 
-#: ../src/generic/editlbox.cpp:171
+#: ../src/generic/editlbox.cpp:155
 msgid "Move up"
 msgstr "Sposta verso il basso"
 
@@ -5012,97 +5148,103 @@ msgstr "Sposta l'oggetto nel prossimo paragrafo."
 msgid "Moves the object to the previous paragraph."
 msgstr "Sposta l'oggetto nel paragrafo precedente."
 
-#: ../src/richtext/richtextbuffer.cpp:9966
+#: ../src/richtext/richtextbuffer.cpp:9963
 msgid "Multiple Cell Properties"
 msgstr "Proprietà celle multiple"
 
-#: ../src/generic/filectrlg.cpp:424
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:82
+#, fuzzy
+msgid "Multiply"
+msgstr "KP_Moltiplica"
+
+#: ../src/generic/filectrlg.cpp:420
 msgid "Name"
 msgstr "Nome"
 
-#: ../src/propgrid/advprops.cpp:1596
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Navy"
 msgstr "Navy"
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "Network"
 msgstr "Rete"
 
-#: ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173
 msgid "New"
 msgstr "Nuovo"
 
-#: ../src/richtext/richtextstyledlg.cpp:243
+#: ../src/richtext/richtextstyledlg.cpp:239
 msgid "New &Box Style..."
 msgstr "Nuovo stile &riquadro..."
 
-#: ../src/richtext/richtextstyledlg.cpp:225
+#: ../src/richtext/richtextstyledlg.cpp:221
 msgid "New &Character Style..."
 msgstr "Nuovo stile &carattere..."
 
-#: ../src/richtext/richtextstyledlg.cpp:237
+#: ../src/richtext/richtextstyledlg.cpp:233
 msgid "New &List Style..."
 msgstr "Nuovo stile di e&lenco..."
 
-#: ../src/richtext/richtextstyledlg.cpp:231
+#: ../src/richtext/richtextstyledlg.cpp:227
 msgid "New &Paragraph Style..."
 msgstr "Nuovo stile di &paragrafo..."
 
-#: ../src/richtext/richtextstyledlg.cpp:606
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:654
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:820
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:893
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:934
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:602
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:650
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:816
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:889
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:930
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "New Style"
 msgstr "Nuovo stile"
 
-#: ../src/generic/editlbox.cpp:169
+#: ../src/generic/editlbox.cpp:139
 msgid "New item"
 msgstr "Nuova elemento"
 
-#: ../src/generic/dirdlgg.cpp:297 ../src/generic/dirdlgg.cpp:307
-#: ../src/generic/filectrlg.cpp:618 ../src/generic/filectrlg.cpp:627
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+#: ../src/generic/dirdlgg.cpp:294 ../src/generic/dirdlgg.cpp:304
 msgid "NewName"
 msgstr "NuovoNome"
 
-#: ../src/common/prntbase.cpp:1567 ../src/html/helpwnd.cpp:665
+#: ../src/common/prntbase.cpp:1592 ../src/html/helpwnd.cpp:663
 msgid "Next page"
 msgstr "Pagina successiva"
 
-#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:177
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:174
 #: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "No"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1764
+#: ../src/propgrid/advprops.cpp:1665
 msgid "No Entry"
 msgstr "Nessun elemento"
 
-#: ../src/generic/animateg.cpp:150
+#: ../src/generic/animateg.cpp:133
 #, c-format
 msgid "No animation handler for type %ld defined."
 msgstr "Gestore non disponibile per il formato di immagine %ld."
 
-#: ../src/dfb/bitmap.cpp:642 ../src/dfb/bitmap.cpp:676
+#: ../src/dfb/bitmap.cpp:639 ../src/dfb/bitmap.cpp:673
 #, c-format
 msgid "No bitmap handler for type %d defined."
 msgstr "Nessun gestore bitmap definito per il tipo %d."
 
-#: ../src/common/utilscmn.cpp:1077
+#: ../src/common/utilscmn.cpp:1095
 msgid "No default application configured for HTML files."
 msgstr "Nessuna applicazione predefinita configurata per i file HTML."
 
-#: ../src/generic/helpext.cpp:445
+#: ../src/generic/helpext.cpp:443
 msgid "No entries found."
 msgstr "Voci non trovate."
 
-#: ../src/common/fontmap.cpp:421
+#: ../src/common/fontmap.cpp:418
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found,\n"
@@ -5115,7 +5257,7 @@ msgstr ""
 "Vuoi utilizzare tale codifica (altrimenti sarà necessario sceglierne una "
 "differente)?"
 
-#: ../src/common/fontmap.cpp:426
+#: ../src/common/fontmap.cpp:423
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found.\n"
@@ -5126,201 +5268,201 @@ msgstr ""
 "Vuoi scegliere un carattere da utilizzare per questa codifica\n"
 "(altrimenti il testo con tale codifica non verrà visualizzato correttamente)?"
 
-#: ../src/generic/animateg.cpp:142
+#: ../src/generic/animateg.cpp:125
 msgid "No handler found for animation type."
 msgstr "Gestore non disponibile per questo formato di animazione."
 
-#: ../src/common/image.cpp:2728
+#: ../src/common/image.cpp:2823
 msgid "No handler found for image type."
 msgstr "Funzionalità non disponibili per questo formato di immagine."
 
-#: ../src/common/image.cpp:2736 ../src/common/image.cpp:2848
-#: ../src/common/image.cpp:2901
+#: ../src/common/image.cpp:2831 ../src/common/image.cpp:2954
+#: ../src/common/image.cpp:3020
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "Funzionalità non disponibili per il formato di immagine %d."
 
-#: ../src/common/image.cpp:2871 ../src/common/image.cpp:2915
+#: ../src/common/image.cpp:2986 ../src/common/image.cpp:3034
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "Funzionalità non disponibili per il formato di immagine %s."
 
-#: ../src/html/helpwnd.cpp:858
+#: ../src/html/helpwnd.cpp:856
 msgid "No matching page found yet"
 msgstr "Pagina corrispondente non ancora trovata"
 
-#: ../src/unix/sound.cpp:81
+#: ../src/unix/sound.cpp:78
 msgid "No sound"
 msgstr "Nessun suono"
 
-#: ../src/common/image.cpp:2277 ../src/common/image.cpp:2318
+#: ../src/common/image.cpp:2371 ../src/common/image.cpp:2412
 msgid "No unused colour in image being masked."
 msgstr "Nessun colore inutilizzato nell'immagine da mascherare."
 
-#: ../src/common/image.cpp:3374
-msgid "No unused colour in image."
-msgstr "Nessun colore inutilizzato nell'immagine."
-
-#: ../src/generic/helpext.cpp:302
+#: ../src/generic/helpext.cpp:300
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "Il file \"%s\" non contiene mappature valide."
 
-#: ../src/richtext/richtextborderspage.cpp:610
 #: ../src/richtext/richtextsizepage.cpp:248
 #: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:610
 msgid "None"
 msgstr "Nessuno"
 
-#: ../src/common/fmapbase.cpp:157
+#: ../src/common/fmapbase.cpp:154
 msgid "Nordic (ISO-8859-10)"
 msgstr "Nordico (ISO-8859-10)"
 
-#: ../src/generic/fontdlgg.cpp:328 ../src/generic/fontdlgg.cpp:331
+#: ../src/generic/fontdlgg.cpp:324 ../src/generic/fontdlgg.cpp:327
 msgid "Normal"
 msgstr "Normale"
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1261
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Normale <br>e <u>sottolineato</u>. "
 
-#: ../src/html/helpwnd.cpp:1205
+#: ../src/html/helpwnd.cpp:1203
 msgid "Normal font:"
 msgstr "Carattere normale:"
 
-#: ../src/propgrid/props.cpp:1128
+#: ../src/propgrid/props.cpp:1115
 #, c-format
 msgid "Not %s"
 msgstr "Non %s"
 
-#: ../include/wx/filename.h:573 ../include/wx/filename.h:578
-msgid "Not available"
-msgstr "Non disponibile"
+#: ../src/common/secretstore.cpp:168
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/webrequest.cpp:605
+msgid "Not enough free disk space for download."
+msgstr ""
 
 #: ../src/richtext/richtextfontpage.cpp:358
 msgid "Not underlined"
 msgstr "Non sottolineato"
 
-#: ../src/common/paper.cpp:115
+#: ../src/common/paper.cpp:112
 msgid "Note, 8 1/2 x 11 in"
 msgstr "Nota, 8 1/2 x 11 pollici"
 
-#: ../src/generic/notifmsgg.cpp:132
+#: ../src/generic/notifmsgg.cpp:129
 msgid "Notice"
 msgstr "Nota"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "Num *"
 msgstr "Num *"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "Num +"
 msgstr "Num +"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "Num ,"
 msgstr "Num ,"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "Num -"
 msgstr "Num -"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "Num ."
 msgstr "Num ."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "Num /"
 msgstr "Num /"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "Num ="
 msgstr "Num ="
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "Num Begin"
 msgstr "Num Inizio"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 msgid "Num Delete"
 msgstr "Cancella"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 msgid "Num Down"
 msgstr "Giù"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "Num End"
 msgstr "Num Fine"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "Num Enter"
 msgstr "Num Invio"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 msgid "Num Home"
 msgstr "Num Home"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 msgid "Num Insert"
 msgstr "Num Inserisci"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num Lock"
 msgstr "Num Blocco"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "Num Page Down"
 msgstr "Num Pag giù"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "Num Page Up"
 msgstr "Num Pag su"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 msgid "Num Right"
 msgstr "Num Destra"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "Num Space"
 msgstr "Num Spazio"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "Num Tab"
 msgstr "Num Tab"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "Num Up"
 msgstr "Num Su"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "Num left"
 msgstr "Num sinistra"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num_lock"
 msgstr "Blocco_Num"
 
@@ -5329,13 +5471,13 @@ msgstr "Blocco_Num"
 msgid "Numbered outline"
 msgstr "Numeri gerarchici"
 
-#: ../include/wx/msgdlg.h:278 ../src/richtext/richtextstyledlg.cpp:297
-#: ../src/common/stockitem.cpp:178 ../src/msw/msgdlg.cpp:454
-#: ../src/msw/msgdlg.cpp:747 ../src/gtk1/fontdlg.cpp:138
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:175
+#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/msgdlg.cpp:741 ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "OK"
 
-#: ../src/msw/ole/automtn.cpp:692
+#: ../src/msw/ole/automtn.cpp:683
 #, c-format
 msgid "OLE Automation error in %s: %s"
 msgstr "Errore automazione OLE in %s: %s"
@@ -5344,15 +5486,15 @@ msgstr "Errore automazione OLE in %s: %s"
 msgid "Object Properties"
 msgstr "Proprietà oggetto"
 
-#: ../src/msw/ole/automtn.cpp:660
+#: ../src/msw/ole/automtn.cpp:651
 msgid "Object implementation does not support named arguments."
 msgstr "L'implementazione dell'oggetto non supporta argomenti nominali."
 
-#: ../src/common/xtixml.cpp:264
+#: ../src/common/xtixml.cpp:260
 msgid "Objects must have an id attribute"
 msgstr "L'oggetto deve avere un ID ed un attributo"
 
-#: ../src/propgrid/advprops.cpp:1601
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Olive"
 msgstr "Oliva"
 
@@ -5360,64 +5502,69 @@ msgstr "Oliva"
 msgid "Opaci&ty:"
 msgstr "Opaci&tà:"
 
-#: ../src/generic/colrdlgg.cpp:354
+#: ../src/generic/colrdlgg.cpp:374
 msgid "Opacity:"
 msgstr "Opacità:"
 
-#: ../src/common/docview.cpp:1773 ../src/common/docview.cpp:1815
+#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
 msgid "Open File"
 msgstr "Apri file"
 
-#: ../src/html/helpwnd.cpp:671 ../src/html/helpwnd.cpp:1554
+#: ../src/html/helpwnd.cpp:669 ../src/html/helpwnd.cpp:1552
 msgid "Open HTML document"
 msgstr "Apri un documento HTML"
 
-#: ../src/generic/dbgrptg.cpp:163
+#: ../src/common/stockitem.cpp:265
+#, fuzzy
+msgid "Open an existing document"
+msgstr "Apri un documento HTML"
+
+#: ../src/generic/dbgrptg.cpp:160
 #, c-format
 msgid "Open file \"%s\""
 msgstr "Apri il file \"%s\""
 
-#: ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176
 msgid "Open..."
 msgstr "Apri..."
 
-#: ../src/unix/glx11.cpp:506 ../src/msw/glcanvas.cpp:592
+#: ../src/msw/glcanvas.cpp:607 ../src/unix/glx11.cpp:513
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr "Il driver OpenGL non supporta OpenGL 3.0 o superiore."
 
-#: ../src/generic/dirctrlg.cpp:599 ../src/generic/dirdlgg.cpp:323
-#: ../src/generic/filectrlg.cpp:642 ../src/generic/filectrlg.cpp:786
+#: ../src/generic/dirctrlg.cpp:565 ../src/generic/filectrlg.cpp:638
+#: ../src/generic/filectrlg.cpp:782 ../src/generic/dirdlgg.cpp:320
 msgid "Operation not permitted."
 msgstr "Operazione non permessa."
 
-#: ../src/common/cmdline.cpp:900
+#: ../src/common/cmdline.cpp:896
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "L'opzione '%s' non può essere negata"
 
-#: ../src/common/cmdline.cpp:1064
+#: ../src/common/cmdline.cpp:1060
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "L'opzione '%s' richiede un valore."
 
-#: ../src/common/cmdline.cpp:1147
+#: ../src/common/cmdline.cpp:1143
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Opzione '%s': impossibile convertire '%s' in una data."
 
-#: ../src/generic/prntdlgg.cpp:618
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Opzioni"
 
-#: ../src/propgrid/advprops.cpp:1606
+#: ../src/propgrid/advprops.cpp:1512
 msgid "Orange"
 msgstr "Arancio"
 
-#: ../src/generic/prntdlgg.cpp:615 ../src/generic/prntdlgg.cpp:869
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:862
 msgid "Orientation"
 msgstr "Orientamento"
 
-#: ../src/common/windowid.cpp:242
+#: ../src/common/windowid.cpp:237
 msgid "Out of window IDs.  Recommend shutting down application."
 msgstr "ID fuori della finestra. Si raccomanda la chiusura dell'applicazione."
 
@@ -5430,148 +5577,148 @@ msgstr "Contorno"
 msgid "Outset"
 msgstr "Rimozione"
 
-#: ../src/msw/ole/automtn.cpp:656
+#: ../src/msw/ole/automtn.cpp:647
 msgid "Overflow while coercing argument values."
 msgstr "Overflow durante forzatura valori argomento."
 
-#: ../src/common/imagpcx.cpp:457 ../src/common/imagpcx.cpp:480
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:479
 msgid "PCX: couldn't allocate memory"
 msgstr "PCX: impossibile allocare la memoria"
 
-#: ../src/common/imagpcx.cpp:456
+#: ../src/common/imagpcx.cpp:455
 msgid "PCX: image format unsupported"
 msgstr "PCX: formato non supportato"
 
-#: ../src/common/imagpcx.cpp:479
+#: ../src/common/imagpcx.cpp:478
 msgid "PCX: invalid image"
 msgstr "PCX: immagine non valida"
 
-#: ../src/common/imagpcx.cpp:442
+#: ../src/common/imagpcx.cpp:441
 msgid "PCX: this is not a PCX file."
 msgstr "PCX: questo non è un file PCX."
 
-#: ../src/common/imagpcx.cpp:459 ../src/common/imagpcx.cpp:481
+#: ../src/common/imagpcx.cpp:458 ../src/common/imagpcx.cpp:480
 msgid "PCX: unknown error !!!"
 msgstr "PCX: errore sconosciuto!!!"
 
-#: ../src/common/imagpcx.cpp:458
+#: ../src/common/imagpcx.cpp:457
 msgid "PCX: version number too low"
 msgstr "PCX: numero di versione troppo piccolo"
 
-#: ../src/common/imagpnm.cpp:91
+#: ../src/common/imagpnm.cpp:89
 msgid "PNM: Couldn't allocate memory."
 msgstr "PNM: Impossibile allocare la memoria."
 
-#: ../src/common/imagpnm.cpp:73
+#: ../src/common/imagpnm.cpp:71
 msgid "PNM: File format is not recognized."
 msgstr "PNM: Formato del file sconosciuto."
 
-#: ../src/common/imagpnm.cpp:112 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
 #: ../src/common/imagpnm.cpp:156
 msgid "PNM: File seems truncated."
 msgstr "PNM: Il file sembra troncato."
 
-#: ../src/common/paper.cpp:187
+#: ../src/common/paper.cpp:184
 msgid "PRC 16K 146 x 215 mm"
 msgstr "Foglio Rep. Pop. Cinese 16K 146 x 215 mm"
 
-#: ../src/common/paper.cpp:200
+#: ../src/common/paper.cpp:197
 msgid "PRC 16K Rotated"
 msgstr "Foglio Rep. Pop. Cinese 16K Ruotato"
 
-#: ../src/common/paper.cpp:188
+#: ../src/common/paper.cpp:185
 msgid "PRC 32K 97 x 151 mm"
 msgstr "Foglio Rep. Pop. Cinese 32K 97 x 151 mm"
 
-#: ../src/common/paper.cpp:201
+#: ../src/common/paper.cpp:198
 msgid "PRC 32K Rotated"
 msgstr "Foglio Rep. Pop. Cinese 32K Ruotato"
 
-#: ../src/common/paper.cpp:189
+#: ../src/common/paper.cpp:186
 msgid "PRC 32K(Big) 97 x 151 mm"
 msgstr "Foglio Rep. Pop. Cinese 32K(grande) 97 x 151 mm"
 
-#: ../src/common/paper.cpp:202
+#: ../src/common/paper.cpp:199
 msgid "PRC 32K(Big) Rotated"
 msgstr "Foglio Rep. Pop. Cinese 32K(grande) ruotato"
 
-#: ../src/common/paper.cpp:190
+#: ../src/common/paper.cpp:187
 msgid "PRC Envelope #1 102 x 165 mm"
 msgstr "Busta Rep. Pop. Cinese #1 102 x 165 mm"
 
-#: ../src/common/paper.cpp:203
+#: ../src/common/paper.cpp:200
 msgid "PRC Envelope #1 Rotated 165 x 102 mm"
 msgstr "Busta Rep. Pop. Cinese #1 Ruotata 165 x 102 mm"
 
-#: ../src/common/paper.cpp:199
+#: ../src/common/paper.cpp:196
 msgid "PRC Envelope #10 324 x 458 mm"
 msgstr "Busta Rep. Pop. Cinese #10 324 x 458 mm"
 
-#: ../src/common/paper.cpp:212
+#: ../src/common/paper.cpp:209
 msgid "PRC Envelope #10 Rotated 458 x 324 mm"
 msgstr "Busta Rep. Pop. Cinese #10 Ruotata 458 x 324 mm"
 
-#: ../src/common/paper.cpp:191
+#: ../src/common/paper.cpp:188
 msgid "PRC Envelope #2 102 x 176 mm"
 msgstr "Busta Rep. Pop. Cinese #2 102 x 176 mm"
 
-#: ../src/common/paper.cpp:204
+#: ../src/common/paper.cpp:201
 msgid "PRC Envelope #2 Rotated 176 x 102 mm"
 msgstr "Busta Rep. Pop. Cinese #2 Ruotata 176 x 102 mm"
 
-#: ../src/common/paper.cpp:192
+#: ../src/common/paper.cpp:189
 msgid "PRC Envelope #3 125 x 176 mm"
 msgstr "Busta Rep. Pop. Cinese #3 125 x 176 mm"
 
-#: ../src/common/paper.cpp:205
+#: ../src/common/paper.cpp:202
 msgid "PRC Envelope #3 Rotated 176 x 125 mm"
 msgstr "Busta Rep. Pop. Cinese #3 Ruotata 176 x 125 mm"
 
-#: ../src/common/paper.cpp:193
+#: ../src/common/paper.cpp:190
 msgid "PRC Envelope #4 110 x 208 mm"
 msgstr "Busta Rep. Pop. Cinese #4 110 x 208 mm"
 
-#: ../src/common/paper.cpp:206
+#: ../src/common/paper.cpp:203
 msgid "PRC Envelope #4 Rotated 208 x 110 mm"
 msgstr "Busta Rep. Pop. Cinese #4 Ruotata 208 x 110 mm"
 
-#: ../src/common/paper.cpp:194
+#: ../src/common/paper.cpp:191
 msgid "PRC Envelope #5 110 x 220 mm"
 msgstr "Busta Rep. Pop. Cinese #5 110 x 220 mm"
 
-#: ../src/common/paper.cpp:207
+#: ../src/common/paper.cpp:204
 msgid "PRC Envelope #5 Rotated 220 x 110 mm"
 msgstr "Busta Rep. Pop. Cinese #5 Ruotata 220 x 110 mm"
 
-#: ../src/common/paper.cpp:195
+#: ../src/common/paper.cpp:192
 msgid "PRC Envelope #6 120 x 230 mm"
 msgstr "Busta Rep. Pop. Cinese #6 120 x 230 mm"
 
-#: ../src/common/paper.cpp:208
+#: ../src/common/paper.cpp:205
 msgid "PRC Envelope #6 Rotated 230 x 120 mm"
 msgstr "Busta Rep. Pop. Cinese #6 Ruotata 230 x 120 mm"
 
-#: ../src/common/paper.cpp:196
+#: ../src/common/paper.cpp:193
 msgid "PRC Envelope #7 160 x 230 mm"
 msgstr "Busta Rep. Pop. Cinese #7 160 x 230 mm"
 
-#: ../src/common/paper.cpp:209
+#: ../src/common/paper.cpp:206
 msgid "PRC Envelope #7 Rotated 230 x 160 mm"
 msgstr "Busta Rep. Pop. Cinese #7 Ruotata 230 x 160 mm"
 
-#: ../src/common/paper.cpp:197
+#: ../src/common/paper.cpp:194
 msgid "PRC Envelope #8 120 x 309 mm"
 msgstr "Busta Rep. Pop. Cinese #8 120 x 309 mm"
 
-#: ../src/common/paper.cpp:210
+#: ../src/common/paper.cpp:207
 msgid "PRC Envelope #8 Rotated 309 x 120 mm"
 msgstr "Busta Rep. Pop. Cinese #8 Ruotata 309 x 120 mm"
 
-#: ../src/common/paper.cpp:198
+#: ../src/common/paper.cpp:195
 msgid "PRC Envelope #9 229 x 324 mm"
 msgstr "Busta Rep. Pop. Cinese #9 229 x 324 mm"
 
-#: ../src/common/paper.cpp:211
+#: ../src/common/paper.cpp:208
 msgid "PRC Envelope #9 Rotated 324 x 229 mm"
 msgstr "Busta Rep. Pop. Cinese #9 Ruotata 324 x 229 mm"
 
@@ -5579,87 +5726,91 @@ msgstr "Busta Rep. Pop. Cinese #9 Ruotata 324 x 229 mm"
 msgid "Padding"
 msgstr "Riempimento"
 
-#: ../src/common/prntbase.cpp:2074
+#: ../src/common/prntbase.cpp:2096
 #, c-format
 msgid "Page %d"
 msgstr "Pagina %d"
 
-#: ../src/common/prntbase.cpp:2072
+#: ../src/common/prntbase.cpp:2094
 #, c-format
 msgid "Page %d of %d"
 msgstr "Pagina %d di %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 msgid "Page Down"
 msgstr "Pagina giù"
 
-#: ../src/gtk/print.cpp:826
+#: ../src/gtk/print.cpp:829
 msgid "Page Setup"
 msgstr "Impostazioni pagina"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 msgid "Page Up"
 msgstr "Pagina su"
 
-#: ../src/generic/prntdlgg.cpp:828 ../src/common/prntbase.cpp:484
+#: ../src/common/prntbase.cpp:479 ../src/generic/prntdlgg.cpp:821
 msgid "Page setup"
 msgstr "Impostazioni pagina"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 msgid "PageDown"
 msgstr "PaginaGiù"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 msgid "PageUp"
 msgstr "PaginaSu"
 
-#: ../src/generic/prntdlgg.cpp:216
+#: ../src/generic/prntdlgg.cpp:209
 msgid "Pages"
 msgstr "Pagine"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1765
+#: ../src/propgrid/advprops.cpp:1666
 msgid "Paint Brush"
 msgstr "Pennello"
 
-#: ../src/generic/prntdlgg.cpp:602 ../src/generic/prntdlgg.cpp:801
-#: ../src/generic/prntdlgg.cpp:842 ../src/generic/prntdlgg.cpp:855
-#: ../src/generic/prntdlgg.cpp:1052 ../src/generic/prntdlgg.cpp:1057
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:794
+#: ../src/generic/prntdlgg.cpp:835 ../src/generic/prntdlgg.cpp:848
+#: ../src/generic/prntdlgg.cpp:1045 ../src/generic/prntdlgg.cpp:1050
 msgid "Paper size"
 msgstr "Dimensione foglio"
 
-#: ../src/richtext/richtextstyles.cpp:1062
+#: ../src/richtext/richtextstyles.cpp:1059
 msgid "Paragraph styles"
 msgstr "Stili paragrafo"
 
-#: ../src/common/xtistrm.cpp:465
+#: ../src/common/xtistrm.cpp:462
 msgid "Passing a already registered object to SetObject"
 msgstr "Passato un oggetto già registrato a SetObject"
 
-#: ../src/common/xtistrm.cpp:476
+#: ../src/common/xtistrm.cpp:473
 msgid "Passing an unknown object to GetObject"
 msgstr "Passato un oggetto sconosciuto a GetObject"
 
-#: ../src/richtext/richtextctrl.cpp:3513 ../src/common/stockitem.cpp:180
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:177 ../src/richtext/richtextctrl.cpp:3514
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Incolla"
 
-#: ../src/common/stockitem.cpp:262
+#: ../src/common/stockitem.cpp:260
 msgid "Paste selection"
 msgstr "Incolla la selezione"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:74
+#: ../src/common/accelcmn.cpp:71
 msgid "Pause"
 msgstr "Pausa"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1766
+#: ../src/propgrid/advprops.cpp:1667
 msgid "Pencil"
 msgstr "Penna"
 
@@ -5668,21 +5819,21 @@ msgstr "Penna"
 msgid "Peri&od"
 msgstr "Punt&o"
 
-#: ../src/generic/filectrlg.cpp:430
+#: ../src/generic/filectrlg.cpp:426
 msgid "Permissions"
 msgstr "Permessi"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:60
+#: ../src/common/accelcmn.cpp:57
 msgid "PgDn"
 msgstr "PgGiù"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:59
+#: ../src/common/accelcmn.cpp:56
 msgid "PgUp"
 msgstr "PgSu"
 
-#: ../src/richtext/richtextbuffer.cpp:12868
+#: ../src/richtext/richtextbuffer.cpp:12863
 msgid "Picture Properties"
 msgstr "Proprietà immagine"
 
@@ -5694,42 +5845,42 @@ msgstr "Creazione della pipe fallita"
 msgid "Please choose a valid font."
 msgstr "Scegli un carattere valido."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
 msgid "Please choose an existing file."
 msgstr "Segli un file esistente."
 
-#: ../src/html/helpwnd.cpp:800
+#: ../src/html/helpwnd.cpp:798
 msgid "Please choose the page to display:"
 msgstr "Scegli la pagina da visualizzare:"
 
-#: ../src/msw/dialup.cpp:764
+#: ../src/msw/dialup.cpp:758
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Scegli l'ISP a cui connettersi"
 
-#: ../src/common/headerctrlcmn.cpp:59
+#: ../src/common/headerctrlcmn.cpp:57
 msgid "Please select the columns to show and define their order:"
 msgstr "Seleziona le colonne da visualizzare e il loro ordine:"
 
-#: ../src/common/prntbase.cpp:538
+#: ../src/common/prntbase.cpp:533
 msgid "Please wait while printing..."
 msgstr "Stampa in corso..."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1767
+#: ../src/propgrid/advprops.cpp:1668
 msgid "Point Left"
 msgstr "Allinea a sinistra"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1768
+#: ../src/propgrid/advprops.cpp:1669
 msgid "Point Right"
 msgstr "Allinea a destra"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:662
+#: ../src/propgrid/advprops.cpp:572
 msgid "Point Size"
 msgstr "Dimensione corpo"
 
-#: ../src/generic/prntdlgg.cpp:612 ../src/generic/prntdlgg.cpp:867
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:860
 msgid "Portrait"
 msgstr "Verticale"
 
@@ -5737,150 +5888,160 @@ msgstr "Verticale"
 msgid "Position"
 msgstr "Posizione"
 
-#: ../src/generic/prntdlgg.cpp:298
+#: ../src/generic/prntdlgg.cpp:291
 msgid "PostScript file"
 msgstr "File PostScript"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178 ../src/osx/cocoa/preferences.mm:303
 msgid "Preferences"
 msgstr "Preferenze"
 
-#: ../src/osx/menu_osx.cpp:568
+#: ../src/osx/menu_osx.cpp:460
 msgid "Preferences..."
 msgstr "Preferenze..."
 
-#: ../src/common/prntbase.cpp:546
+#: ../src/common/prntbase.cpp:541
 msgid "Preparing"
 msgstr "Preparazione"
 
-#: ../src/generic/fontdlgg.cpp:455 ../src/osx/carbon/fontdlg.cpp:390
-#: ../src/html/helpwnd.cpp:1222
+#: ../src/osx/carbon/fontdlg.cpp:387 ../src/generic/fontdlgg.cpp:452
+#: ../src/html/helpwnd.cpp:1220
 msgid "Preview:"
 msgstr "Anteprima:"
 
-#: ../src/common/prntbase.cpp:1553 ../src/html/helpwnd.cpp:664
+#: ../src/common/prntbase.cpp:1578 ../src/html/helpwnd.cpp:662
 msgid "Previous page"
 msgstr "Pagina precedente"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/prntdlgg.cpp:143 ../src/generic/prntdlgg.cpp:157
-#: ../src/common/prntbase.cpp:426 ../src/common/prntbase.cpp:1541
-#: ../src/common/accelcmn.cpp:77 ../src/gtk/print.cpp:620
-#: ../src/gtk/print.cpp:638
+#: ../src/common/prntbase.cpp:421 ../src/common/prntbase.cpp:1566
+#: ../src/common/accelcmn.cpp:74 ../src/generic/prntdlgg.cpp:136
+#: ../src/generic/prntdlgg.cpp:150 ../src/gtk/print.cpp:616
+#: ../src/gtk/print.cpp:634
 msgid "Print"
 msgstr "Stampa"
 
-#: ../include/wx/prntbase.h:399 ../src/common/docview.cpp:1268
+#: ../src/common/docview.cpp:1262
 msgid "Print Preview"
 msgstr "Anteprima di stampa"
 
-#: ../src/common/prntbase.cpp:2015 ../src/common/prntbase.cpp:2057
-#: ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2037 ../src/common/prntbase.cpp:2079
+#: ../src/common/prntbase.cpp:2087
 msgid "Print Preview Failure"
 msgstr "Errore durante l'anteprima di stampa"
 
-#: ../src/generic/prntdlgg.cpp:224
+#: ../src/generic/prntdlgg.cpp:217
 msgid "Print Range"
 msgstr "Intervallo stampa"
 
-#: ../src/generic/prntdlgg.cpp:449
+#: ../src/generic/prntdlgg.cpp:442
 msgid "Print Setup"
 msgstr "Impostazioni di stampa"
 
-#: ../src/generic/prntdlgg.cpp:621
+#: ../src/generic/prntdlgg.cpp:614
 msgid "Print in colour"
 msgstr "Stampa a colori"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/osx/webview_webkit.mm:260
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "La descrizione colonna non può essere inzializzata."
+
+#: ../src/common/stockitem.cpp:179
 msgid "Print previe&w..."
 msgstr "Ante&prima di stampa..."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1256
 msgid "Print preview creation failed."
 msgstr "Creazione anteprima di stampa fallita."
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/common/stockitem.cpp:179
 msgid "Print preview..."
 msgstr "Anteprima di stampa..."
 
-#: ../src/generic/prntdlgg.cpp:630
+#: ../src/generic/prntdlgg.cpp:623
 msgid "Print spooling"
 msgstr "Coda di stampa"
 
-#: ../src/html/helpwnd.cpp:675
+#: ../src/html/helpwnd.cpp:673
 msgid "Print this page"
 msgstr "Stampa questa pagina"
 
-#: ../src/generic/prntdlgg.cpp:185
+#: ../src/generic/prntdlgg.cpp:178
 msgid "Print to File"
 msgstr "Stampa su file"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "Print..."
 msgstr "Stampa..."
 
-#: ../src/generic/prntdlgg.cpp:493
+#: ../src/generic/prntdlgg.cpp:486
 msgid "Printer"
 msgstr "Stampante"
 
-#: ../src/generic/prntdlgg.cpp:633
+#: ../src/generic/prntdlgg.cpp:626
 msgid "Printer command:"
 msgstr "Comando stampante:"
 
-#: ../src/generic/prntdlgg.cpp:180
+#: ../src/generic/prntdlgg.cpp:173
 msgid "Printer options"
 msgstr "Opzioni stampante"
 
-#: ../src/generic/prntdlgg.cpp:645
+#: ../src/generic/prntdlgg.cpp:638
 msgid "Printer options:"
 msgstr "Opzioni stampante:"
 
-#: ../src/generic/prntdlgg.cpp:916
+#: ../src/generic/prntdlgg.cpp:909
 msgid "Printer..."
 msgstr "Stampante..."
 
-#: ../src/generic/prntdlgg.cpp:196
+#: ../src/generic/prntdlgg.cpp:189
 msgid "Printer:"
 msgstr "Stampante:"
 
-#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:535
-#: ../src/html/htmprint.cpp:277
+#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:530
+#: ../src/html/htmprint.cpp:289
 msgid "Printing"
 msgstr "Stampa"
 
-#: ../src/common/prntbase.cpp:612
+#: ../src/common/prntbase.cpp:607
 msgid "Printing "
 msgstr "Stampa "
 
-#: ../src/common/prntbase.cpp:347
+#: ../src/common/prntbase.cpp:342
 msgid "Printing Error"
 msgstr "Errore durante la stampa"
 
-#: ../src/common/prntbase.cpp:565
+#: ../src/osx/webview_webkit.mm:251
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "Gzip non è supportato da questa versione della libreria zlib"
+
+#: ../src/common/prntbase.cpp:560
 #, c-format
 msgid "Printing page %d"
 msgstr "Stampa pagina %d"
 
-#: ../src/common/prntbase.cpp:570
+#: ../src/common/prntbase.cpp:565
 #, c-format
 msgid "Printing page %d of %d"
 msgstr "Stampa pagina %d di %d"
 
-#: ../src/generic/printps.cpp:201
+#: ../src/generic/printps.cpp:182
 #, c-format
 msgid "Printing page %d..."
 msgstr "Stampa della pagina %d..."
 
-#: ../src/generic/printps.cpp:161
+#: ../src/generic/printps.cpp:142
 msgid "Printing..."
 msgstr "Stampa..."
 
-#: ../include/wx/richtext/richtextprint.h:109 ../include/wx/prntbase.h:267
-#: ../src/common/docview.cpp:2132
+#: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
+#: ../src/common/docview.cpp:2137
 msgid "Printout"
 msgstr "Stampa"
 
-#: ../src/common/debugrpt.cpp:560
+#: ../src/common/debugrpt.cpp:561
 #, c-format
 msgid ""
 "Processing debug report has failed, leaving the files in \"%s\" directory."
@@ -5888,103 +6049,103 @@ msgstr ""
 "L'elaborazione della segnalazione di errore è fallita, i file sono "
 "memorizzati nella cartella \"%s\"."
 
-#: ../src/common/prntbase.cpp:545
+#: ../src/common/prntbase.cpp:540
 msgid "Progress:"
 msgstr "Progresso:"
 
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181
 msgid "Properties"
 msgstr "Proprietà"
 
-#: ../src/propgrid/manager.cpp:237
+#: ../src/propgrid/manager.cpp:223
 msgid "Property"
 msgstr "Proprietà"
 
 #. TRANSLATORS: Caption of message box displaying any property error
-#: ../src/propgrid/propgrid.cpp:3185 ../src/propgrid/propgrid.cpp:3318
+#: ../src/propgrid/propgrid.cpp:3162 ../src/propgrid/propgrid.cpp:3299
 msgid "Property Error"
 msgstr "Errore proprietà"
 
-#: ../src/propgrid/advprops.cpp:1597
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Purple"
 msgstr "Viola"
 
-#: ../src/common/paper.cpp:112
+#: ../src/common/paper.cpp:109
 msgid "Quarto, 215 x 275 mm"
 msgstr "Quarto, 215 x 275 mm"
 
-#: ../src/generic/logg.cpp:1016
+#: ../src/generic/logg.cpp:1013
 msgid "Question"
 msgstr "Domanda"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1769
+#: ../src/propgrid/advprops.cpp:1670
 msgid "Question Arrow"
 msgstr "Freccaid omanda"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "Quit"
 msgstr "Esci"
 
-#: ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:477
 #, c-format
 msgid "Quit %s"
 msgstr "Esci da %s"
 
-#: ../src/common/stockitem.cpp:263
+#: ../src/common/stockitem.cpp:261
 msgid "Quit this program"
 msgstr "Esci dal programma"
 
-#: ../src/common/accelcmn.cpp:338
+#: ../src/common/accelcmn.cpp:352
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/ffile.cpp:109 ../src/common/ffile.cpp:133
+#: ../src/common/ffile.cpp:107 ../src/common/ffile.cpp:132
 #, c-format
 msgid "Read error on file '%s'"
 msgstr "Errore di lettura nel file '%s'"
 
-#: ../src/common/secretstore.cpp:199
-#, c-format
-msgid "Reading password for \"%s/%s\" failed: %s."
+#: ../src/common/secretstore.cpp:211
+#, fuzzy, c-format
+msgid "Reading password for \"%s\" failed: %s."
 msgstr "Lettura fallita password per \"%s/%s\": %s."
 
-#: ../src/common/prntbase.cpp:272
+#: ../src/common/prntbase.cpp:267
 msgid "Ready"
 msgstr "Pronto"
 
-#: ../src/propgrid/advprops.cpp:1605
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Red"
 msgstr "Rosso"
 
-#: ../src/generic/colrdlgg.cpp:339
+#: ../src/generic/colrdlgg.cpp:359
 msgid "Red:"
 msgstr "Rosso:"
 
-#: ../src/common/stockitem.cpp:185 ../src/stc/stc_i18n.cpp:16
+#: ../src/common/stockitem.cpp:182 ../src/stc/stc_i18n.cpp:16
 msgid "Redo"
 msgstr "Ripeti"
 
-#: ../src/common/stockitem.cpp:264
+#: ../src/common/stockitem.cpp:262
 msgid "Redo last action"
 msgstr "Ripristina l'ultima azione"
 
-#: ../src/common/stockitem.cpp:186
+#: ../src/common/stockitem.cpp:183
 msgid "Refresh"
 msgstr "Aggiorna"
 
-#: ../src/msw/registry.cpp:626
+#: ../src/msw/registry.cpp:615
 #, c-format
 msgid "Registry key '%s' already exists."
 msgstr "Chiave '%s' del registro di sistema già presente."
 
-#: ../src/msw/registry.cpp:595
+#: ../src/msw/registry.cpp:584
 #, c-format
 msgid "Registry key '%s' does not exist, cannot rename it."
 msgstr ""
 "Chiave '%s' del registro di sistema non esistente. Impossibile rinominarla."
 
-#: ../src/msw/registry.cpp:727
+#: ../src/msw/registry.cpp:716
 #, c-format
 msgid ""
 "Registry key '%s' is needed for normal system operation,\n"
@@ -5996,22 +6157,22 @@ msgstr ""
 "La cancellazione renderebbe il sistema inutilizzabile:\n"
 "Operazione abbandonata."
 
-#: ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:942
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr "Il valore registro \"%s\" non è di tipo binario (ma di tipo %s)"
 
-#: ../src/msw/registry.cpp:917
+#: ../src/msw/registry.cpp:905
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr "Il valore registro \"%s\" non è di tipo numerico (ma di tipo %s)"
 
-#: ../src/msw/registry.cpp:1003
+#: ../src/msw/registry.cpp:991
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr "Il valore registro \"%s\" non è di tipo testo (ma di tipo %s)"
 
-#: ../src/msw/registry.cpp:521
+#: ../src/msw/registry.cpp:510
 #, c-format
 msgid "Registry value '%s' already exists."
 msgstr "Valore '%s' del registro di sistema già presente."
@@ -6025,72 +6186,78 @@ msgstr "Normale"
 msgid "Relative"
 msgstr "Relativo"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:456
 msgid "Relevant entries:"
 msgstr "Voci pertinenti:"
 
-#: ../include/wx/generic/progdlgg.h:86
+#: ../include/wx/generic/progdlgg.h:87
 msgid "Remaining time:"
 msgstr "Tempo rimanente :"
 
-#: ../src/common/stockitem.cpp:187
+#: ../src/common/stockitem.cpp:184
 msgid "Remove"
 msgstr "Rimuovi"
 
-#: ../src/richtext/richtextctrl.cpp:1562
+#: ../src/richtext/richtextctrl.cpp:1563
 msgid "Remove Bullet"
 msgstr "Rimuovi puntino"
 
-#: ../src/html/helpwnd.cpp:433
+#: ../src/html/helpwnd.cpp:431
 msgid "Remove current page from bookmarks"
 msgstr "Rimuovi la pagina corrente dai segnalibri"
 
-#: ../src/common/rendcmn.cpp:194
+#: ../src/common/rendcmn.cpp:191
 #, c-format
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 "Il renderer \"%s\" ha una versione %d.%d che non è compatibile, quindi non è "
 "stato caricato."
 
-#: ../src/richtext/richtextbuffer.cpp:4527
+#: ../src/richtext/richtextbuffer.cpp:4524
 msgid "Renumber List"
 msgstr "Rinumera l'elenco"
 
-#: ../src/common/stockitem.cpp:188
-msgid "Rep&lace"
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Rep&lace..."
 msgstr "&Sostituisci"
 
-#: ../src/richtext/richtextctrl.cpp:3673 ../src/common/stockitem.cpp:188
+#: ../src/richtext/richtextctrl.cpp:3674
 msgid "Replace"
 msgstr "Sostituisci"
 
-#: ../src/generic/fdrepdlg.cpp:182
+#: ../src/generic/fdrepdlg.cpp:179
 msgid "Replace &all"
 msgstr "Sostituisci t&utto"
 
-#: ../src/common/stockitem.cpp:261
-msgid "Replace selection"
-msgstr "Sostituisci la selezione"
-
-#: ../src/generic/fdrepdlg.cpp:124
+#: ../src/generic/fdrepdlg.cpp:121
 msgid "Replace with:"
 msgstr "Sostituisci con:"
 
-#: ../src/common/valtext.cpp:163
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Replace..."
+msgstr "Sostituisci"
+
+#: ../src/common/valtext.cpp:184
 msgid "Required information entry is empty."
 msgstr "Campo informazioni richieste vuoto."
 
-#: ../src/common/translation.cpp:1975
+#: ../src/common/translation.cpp:2025
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "La risorsa '%s' non è un catalogo di messaggi valido."
 
+#: ../src/gtk/webview_webkit.cpp:985
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:56
+#: ../src/common/accelcmn.cpp:53
 msgid "Return"
 msgstr "Invio"
 
-#: ../src/common/stockitem.cpp:189
+#: ../src/common/stockitem.cpp:186
 msgid "Revert to Saved"
 msgstr "Ritorna alla versione salvata"
 
@@ -6102,41 +6269,41 @@ msgstr "Crinale"
 msgid "Rig&ht-to-left"
 msgstr "&Destra-a-sinistra"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6149
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:59 ../src/generic/datavgen.cpp:6954
+#: ../src/richtext/richtextsizepage.cpp:250
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextbulletspage.cpp:188
-#: ../src/richtext/richtextsizepage.cpp:250 ../src/common/accelcmn.cpp:62
 msgid "Right"
 msgstr "Destra"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1754
+#: ../src/propgrid/advprops.cpp:1655
 msgid "Right Arrow"
 msgstr "Freccia destra"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1770
+#: ../src/propgrid/advprops.cpp:1671
 msgid "Right Button"
 msgstr "Pulsante destro"
 
-#: ../src/generic/prntdlgg.cpp:892
+#: ../src/generic/prntdlgg.cpp:885
 msgid "Right margin (mm):"
 msgstr "Margine destro (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:148
-#: ../src/richtext/richtextindentspage.cpp:150
 #: ../src/richtext/richtextliststylepage.cpp:337
 #: ../src/richtext/richtextliststylepage.cpp:339
+#: ../src/richtext/richtextindentspage.cpp:148
+#: ../src/richtext/richtextindentspage.cpp:150
 msgid "Right-align text."
 msgstr "Allinea a destra."
 
-#: ../src/generic/fontdlgg.cpp:322
+#: ../src/generic/fontdlgg.cpp:318
 msgid "Roman"
 msgstr "Roman"
 
-#: ../src/generic/datavgen.cpp:5916
+#: ../src/generic/datavgen.cpp:6721
 #, c-format
 msgid "Row %i"
 msgstr "Colonna %i"
@@ -6146,30 +6313,31 @@ msgstr "Colonna %i"
 msgid "S&tandard bullet name:"
 msgstr "Nome di una puntatura s&tandard:"
 
-#: ../src/common/accelcmn.cpp:268 ../src/common/accelcmn.cpp:350
+#: ../src/common/accelcmn.cpp:282 ../src/common/accelcmn.cpp:367
 msgid "SPECIAL"
 msgstr "SPECIALE"
 
-#: ../src/common/stockitem.cpp:190 ../src/common/sizer.cpp:2797
+#: ../src/common/stockitem.cpp:187 ../src/common/sizer.cpp:2914
 msgid "Save"
 msgstr "Salva"
 
-#: ../src/common/fldlgcmn.cpp:342
+#: ../src/common/fldlgcmn.cpp:339
 #, c-format
 msgid "Save %s file"
 msgstr "Salva il file %s"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/common/stockitem.cpp:188 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Salva con n&ome..."
 
-#: ../src/common/docview.cpp:366
+#: ../src/common/docview.cpp:359
 msgid "Save As"
 msgstr "Salva come"
 
-#: ../src/common/stockitem.cpp:191
-msgid "Save as"
-msgstr "Salva come"
+#: ../src/common/stockitem.cpp:188
+#, fuzzy
+msgid "Save As..."
+msgstr "Salva con n&ome..."
 
 #: ../src/common/stockitem.cpp:267
 msgid "Save current document"
@@ -6179,40 +6347,40 @@ msgstr "Salva il documento attuale"
 msgid "Save current document with a different filename"
 msgstr "Salva il documento con un nome differente"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/generic/logg.cpp:509
 msgid "Save log contents to file"
 msgstr "Salva il registro su file"
 
-#: ../src/common/secretstore.cpp:179
-#, c-format
-msgid "Saving password for \"%s/%s\" failed: %s."
+#: ../src/common/secretstore.cpp:189
+#, fuzzy, c-format
+msgid "Saving password for \"%s\" failed: %s."
 msgstr "Salvataggio fallito password \"%s/%s\": %s."
 
-#: ../src/generic/fontdlgg.cpp:325
+#: ../src/generic/fontdlgg.cpp:321
 msgid "Script"
 msgstr "Script"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll Lock"
 msgstr "Blocco scorrimento"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll_lock"
 msgstr "Blocco_scorrimento"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:890
+#: ../src/propgrid/advprops.cpp:791
 msgid "Scrollbar"
 msgstr "Barra scorrimento"
 
-#: ../src/generic/srchctlg.cpp:56 ../src/html/helpwnd.cpp:535
-#: ../src/html/helpwnd.cpp:550
+#: ../src/generic/srchctlg.cpp:55 ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:548 ../src/gtk/srchctrl.cpp:182
 msgid "Search"
 msgstr "Cerca"
 
-#: ../src/html/helpwnd.cpp:537
+#: ../src/html/helpwnd.cpp:535
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
@@ -6220,32 +6388,32 @@ msgstr ""
 "Cerca i contenuti nelle Guida/e per tutte le occorrenze del testo digitato "
 "di seguito"
 
-#: ../src/generic/fdrepdlg.cpp:160
+#: ../src/generic/fdrepdlg.cpp:157
 msgid "Search direction"
 msgstr "Direzione"
 
-#: ../src/generic/fdrepdlg.cpp:112
+#: ../src/generic/fdrepdlg.cpp:109
 msgid "Search for:"
 msgstr "Trova:"
 
-#: ../src/html/helpwnd.cpp:1052
+#: ../src/html/helpwnd.cpp:1050
 msgid "Search in all books"
 msgstr "Cerca in tutti i libri"
 
-#: ../src/html/helpwnd.cpp:857
+#: ../src/html/helpwnd.cpp:855
 msgid "Searching..."
 msgstr "Ricerca in corso..."
 
-#: ../src/generic/dirctrlg.cpp:446
+#: ../src/generic/dirctrlg.cpp:412
 msgid "Sections"
 msgstr "Sezioni"
 
-#: ../src/common/ffile.cpp:238
+#: ../src/common/ffile.cpp:237
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Errore durante la ricerca nel file '%s'"
 
-#: ../src/common/ffile.cpp:228
+#: ../src/common/ffile.cpp:227
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
@@ -6253,24 +6421,24 @@ msgstr ""
 "dimensioni))"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:76
+#: ../src/common/accelcmn.cpp:73
 msgid "Select"
 msgstr "Seleziona"
 
-#: ../src/richtext/richtextctrl.cpp:337 ../src/osx/textctrl_osx.cpp:581
-#: ../src/common/stockitem.cpp:192 ../src/msw/textctrl.cpp:2512
+#: ../src/osx/textctrl_osx.cpp:599 ../src/common/stockitem.cpp:189
+#: ../src/msw/textctrl.cpp:2777 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "&Seleziona tutto"
 
-#: ../src/common/stockitem.cpp:192 ../src/stc/stc_i18n.cpp:21
+#: ../src/common/stockitem.cpp:189 ../src/stc/stc_i18n.cpp:21
 msgid "Select All"
 msgstr "Seleziona tutto"
 
-#: ../src/common/docview.cpp:1895
+#: ../src/common/docview.cpp:1900
 msgid "Select a document template"
 msgstr "Scegli un modello di documento"
 
-#: ../src/common/docview.cpp:1969
+#: ../src/common/docview.cpp:1974
 msgid "Select a document view"
 msgstr "Scegli una visualizzazione del documento"
 
@@ -6299,20 +6467,20 @@ msgid "Selects the list level to edit."
 msgstr "Seleziona il livello da modificare."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:82
+#: ../src/common/accelcmn.cpp:79
 msgid "Separator"
 msgstr "Separatore"
 
-#: ../src/common/cmdline.cpp:1083
+#: ../src/common/cmdline.cpp:1079
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Atteso separatore dopo l'opzione '%s'."
 
-#: ../src/osx/menu_osx.cpp:572
+#: ../src/osx/menu_osx.cpp:464
 msgid "Services"
 msgstr "Servizi"
 
-#: ../src/richtext/richtextbuffer.cpp:11217
+#: ../src/richtext/richtextbuffer.cpp:11216
 msgid "Set Cell Style"
 msgstr "Imposta stile cella"
 
@@ -6320,11 +6488,11 @@ msgstr "Imposta stile cella"
 msgid "SetProperty called w/o valid setter"
 msgstr "SetProperty chiamata senza un valid setter"
 
-#: ../src/generic/prntdlgg.cpp:188
+#: ../src/generic/prntdlgg.cpp:181
 msgid "Setup..."
 msgstr "Configurazione..."
 
-#: ../src/msw/dialup.cpp:544
+#: ../src/msw/dialup.cpp:538
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr "Trovate più connessioni attive. Ne viene scelta una a caso."
 
@@ -6340,40 +6508,40 @@ msgstr "Ombra"
 msgid "Shadow c&olour:"
 msgstr "C&olore ombreggiatura:"
 
-#: ../src/common/accelcmn.cpp:335
+#: ../src/common/accelcmn.cpp:349
 msgid "Shift+"
 msgstr "Maiusc+"
 
-#: ../src/generic/dirdlgg.cpp:147
+#: ../src/generic/dirdlgg.cpp:144
 msgid "Show &hidden directories"
 msgstr "Visualizza le &cartelle nascoste"
 
-#: ../src/generic/filectrlg.cpp:983
+#: ../src/generic/filectrlg.cpp:979
 msgid "Show &hidden files"
 msgstr "Visualizza i &file nascosti"
 
-#: ../src/osx/menu_osx.cpp:580
+#: ../src/osx/menu_osx.cpp:472
 msgid "Show All"
 msgstr "Visualizza tutto"
 
-#: ../src/common/stockitem.cpp:257
+#: ../src/common/stockitem.cpp:254
 msgid "Show about dialog"
 msgstr "Visualizza la finestra di informazioni sul programma"
 
-#: ../src/html/helpwnd.cpp:492
+#: ../src/html/helpwnd.cpp:490
 msgid "Show all"
 msgstr "Visualizza tutto"
 
-#: ../src/html/helpwnd.cpp:503
+#: ../src/html/helpwnd.cpp:501
 msgid "Show all items in index"
 msgstr "Visualizza tutti le voci dell'indice"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:656
 msgid "Show/hide navigation panel"
 msgstr "Visualizza/nascondi la barra di navigazione"
 
-#: ../src/richtext/richtextsymboldlg.cpp:421
-#: ../src/richtext/richtextsymboldlg.cpp:423
+#: ../src/richtext/richtextsymboldlg.cpp:418
+#: ../src/richtext/richtextsymboldlg.cpp:420
 msgid "Shows a Unicode subset."
 msgstr "Visualizza un sottoinsieme di Unicode."
 
@@ -6389,7 +6557,7 @@ msgstr "Visualizza l'anteprima delle impostazioni di puntatura."
 msgid "Shows a preview of the font settings."
 msgstr "Visualizza l'anteprima delle impostazioni del font."
 
-#: ../src/osx/carbon/fontdlg.cpp:394 ../src/osx/carbon/fontdlg.cpp:396
+#: ../src/osx/carbon/fontdlg.cpp:391 ../src/osx/carbon/fontdlg.cpp:393
 msgid "Shows a preview of the font."
 msgstr "Visualizza l'anteprima del font."
 
@@ -6398,62 +6566,62 @@ msgstr "Visualizza l'anteprima del font."
 msgid "Shows a preview of the paragraph settings."
 msgstr "Visualizza l'anteprima delle impostazioni di paragrafo."
 
-#: ../src/generic/fontdlgg.cpp:460 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:456 ../src/generic/fontdlgg.cpp:458
 msgid "Shows the font preview."
 msgstr "Visualizza l'anteprima della font."
 
-#: ../src/propgrid/advprops.cpp:1607
+#: ../src/propgrid/advprops.cpp:1513
 msgid "Silver"
 msgstr "Argento"
 
-#: ../src/univ/themes/mono.cpp:516
+#: ../src/univ/themes/mono.cpp:513
 msgid "Simple monochrome theme"
 msgstr "Tema monocromatico"
 
-#: ../src/richtext/richtextindentspage.cpp:275
 #: ../src/richtext/richtextliststylepage.cpp:449
+#: ../src/richtext/richtextindentspage.cpp:275
 msgid "Single"
 msgstr "Singola"
 
-#: ../src/generic/filectrlg.cpp:425 ../src/richtext/richtextformatdlg.cpp:369
-#: ../src/richtext/richtextsizepage.cpp:299
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextsizepage.cpp:299
+#: ../src/richtext/richtextformatdlg.cpp:362
 msgid "Size"
 msgstr "Dimensione"
 
-#: ../src/osx/carbon/fontdlg.cpp:339
+#: ../src/osx/carbon/fontdlg.cpp:336
 msgid "Size:"
 msgstr "Dimensione:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1775
+#: ../src/propgrid/advprops.cpp:1676
 msgid "Sizing"
 msgstr "Posizionamento"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1772
+#: ../src/propgrid/advprops.cpp:1673
 msgid "Sizing N-S"
 msgstr "Posizionamento N-S"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1771
+#: ../src/propgrid/advprops.cpp:1672
 msgid "Sizing NE-SW"
 msgstr "Posizionamento NE-SO"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1773
+#: ../src/propgrid/advprops.cpp:1674
 msgid "Sizing NW-SE"
 msgstr "Posizionamento NO-SE"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1774
+#: ../src/propgrid/advprops.cpp:1675
 msgid "Sizing W-E"
 msgstr "Posizionamento O-E"
 
-#: ../src/msw/progdlg.cpp:801
+#: ../src/msw/progdlg.cpp:1088
 msgid "Skip"
 msgstr "Salta"
 
-#: ../src/generic/fontdlgg.cpp:330
+#: ../src/generic/fontdlgg.cpp:326
 msgid "Slant"
 msgstr "Slant"
 
@@ -6462,7 +6630,7 @@ msgid "Small C&apitals"
 msgstr "M&aiuscoletto"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:79
+#: ../src/common/accelcmn.cpp:76
 msgid "Snapshot"
 msgstr "Cattura"
 
@@ -6470,37 +6638,37 @@ msgstr "Cattura"
 msgid "Solid"
 msgstr "Grassetto"
 
-#: ../src/common/docview.cpp:1791
+#: ../src/common/docview.cpp:1785
 msgid "Sorry, could not open this file."
 msgstr "Impossibile aprire il file."
 
-#: ../src/common/prntbase.cpp:2057 ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2079 ../src/common/prntbase.cpp:2087
 msgid "Sorry, not enough memory to create a preview."
 msgstr "Memoria insufficente per la creazione di un'anteprima."
 
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "Sorry, that name is taken. Please choose another."
 msgstr "Il nome è già in uso. Scegli un nome differente."
 
-#: ../src/common/docview.cpp:1814
+#: ../src/common/docview.cpp:1819
 msgid "Sorry, the format for this file is unknown."
 msgstr "Formato del file sconosciuto."
 
-#: ../src/unix/sound.cpp:492
+#: ../src/unix/sound.cpp:481
 msgid "Sound data are in unsupported format."
 msgstr "Formato dei dati sonori non supportato."
 
-#: ../src/unix/sound.cpp:477
+#: ../src/unix/sound.cpp:466
 #, c-format
 msgid "Sound file '%s' is in unsupported format."
 msgstr "File sonoro '%s' ha un formato non supportato."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:67
+#: ../src/common/accelcmn.cpp:64
 msgid "Space"
 msgstr "Spazio"
 
@@ -6508,12 +6676,12 @@ msgstr "Spazio"
 msgid "Spacing"
 msgstr "Spaziatura"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "Spell Check"
 msgstr "Controllo ortografia"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1776
+#: ../src/propgrid/advprops.cpp:1677
 msgid "Spraycan"
 msgstr "Bombola spray"
 
@@ -6522,7 +6690,7 @@ msgstr "Bombola spray"
 msgid "Standard"
 msgstr "Standard"
 
-#: ../src/common/paper.cpp:104
+#: ../src/common/paper.cpp:101
 msgid "Statement, 5 1/2 x 8 1/2 in"
 msgstr "Statement, 5 1/2 x 8 1/2 pollici"
 
@@ -6531,33 +6699,29 @@ msgstr "Statement, 5 1/2 x 8 1/2 pollici"
 msgid "Static"
 msgstr "Statico"
 
-#: ../src/generic/prntdlgg.cpp:204
+#: ../src/generic/prntdlgg.cpp:197
 msgid "Status:"
 msgstr "Stato:"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "Stop"
 msgstr "Stop"
 
-#: ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196
 msgid "Strikethrough"
 msgstr "Barrato"
 
-#: ../src/common/colourcmn.cpp:45
+#: ../src/common/colourcmn.cpp:42
 #, c-format
 msgid "String To Colour : Incorrect colour specification : %s"
 msgstr "Specifica di colore '%s' non valida"
 
 #. TRANSLATORS: Label of font style
-#: ../src/richtext/richtextformatdlg.cpp:339 ../src/propgrid/advprops.cpp:680
+#: ../src/propgrid/advprops.cpp:590 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Stile"
 
-#: ../include/wx/richtext/richtextstyledlg.h:46
-msgid "Style Organiser"
-msgstr "Gestore degli stili"
-
-#: ../src/osx/carbon/fontdlg.cpp:348
+#: ../src/osx/carbon/fontdlg.cpp:345
 msgid "Style:"
 msgstr "Stile:"
 
@@ -6566,7 +6730,7 @@ msgid "Subscrip&t"
 msgstr "&Pedice"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:83
+#: ../src/common/accelcmn.cpp:80
 msgid "Subtract"
 msgstr "Sottrai"
 
@@ -6574,11 +6738,11 @@ msgstr "Sottrai"
 msgid "Supe&rscript"
 msgstr "&Apice"
 
-#: ../src/common/paper.cpp:150
+#: ../src/common/paper.cpp:147
 msgid "SuperA/SuperA/A4 227 x 356 mm"
 msgstr "Foglio SuperA/SuperA/A4 227 x 356 mm"
 
-#: ../src/common/paper.cpp:151
+#: ../src/common/paper.cpp:148
 msgid "SuperB/SuperB/A3 305 x 487 mm"
 msgstr "Foglio SuperB/SuperB/A3 305 x 487 mm"
 
@@ -6586,7 +6750,7 @@ msgstr "Foglio SuperB/SuperB/A3 305 x 487 mm"
 msgid "Suppress hyphe&nation"
 msgstr "Disabilita sillabazio&ne"
 
-#: ../src/generic/fontdlgg.cpp:326
+#: ../src/generic/fontdlgg.cpp:322
 msgid "Swiss"
 msgstr "Svizzero"
 
@@ -6604,73 +6768,73 @@ msgstr "Font simboli:"
 msgid "Symbols"
 msgstr "Simboli"
 
-#: ../src/common/imagtiff.cpp:369 ../src/common/imagtiff.cpp:382
-#: ../src/common/imagtiff.cpp:741
+#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
+#: ../src/common/imagtiff.cpp:738
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: impossibile allocare la memoria."
 
-#: ../src/common/imagtiff.cpp:301
+#: ../src/common/imagtiff.cpp:298
 msgid "TIFF: Error loading image."
 msgstr "TIFF: errore nel caricamento dell'immagine."
 
-#: ../src/common/imagtiff.cpp:468
+#: ../src/common/imagtiff.cpp:465
 msgid "TIFF: Error reading image."
 msgstr "TIFF: errore durante la lettura dell'immagine."
 
-#: ../src/common/imagtiff.cpp:608
+#: ../src/common/imagtiff.cpp:605
 msgid "TIFF: Error saving image."
 msgstr "TIFF: errore nel salvataggio dell'immagine."
 
-#: ../src/common/imagtiff.cpp:846
+#: ../src/common/imagtiff.cpp:843
 msgid "TIFF: Error writing image."
 msgstr "TIFF: errore durante la scrittura dell'immagine."
 
-#: ../src/common/imagtiff.cpp:355
+#: ../src/common/imagtiff.cpp:352
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: dimensione immaggine esageratamenet grande."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:68
+#: ../src/common/accelcmn.cpp:65
 msgid "Tab"
 msgstr "Tabulazione"
 
-#: ../src/richtext/richtextbuffer.cpp:11498
+#: ../src/richtext/richtextbuffer.cpp:11497
 msgid "Table Properties"
 msgstr "Proprietà tabella"
 
-#: ../src/common/paper.cpp:145
+#: ../src/common/paper.cpp:142
 msgid "Tabloid Extra 11.69 x 18 in"
 msgstr "Tabloid Extra 11,69 x 18 pollici"
 
-#: ../src/common/paper.cpp:102
+#: ../src/common/paper.cpp:99
 msgid "Tabloid, 11 x 17 in"
 msgstr "Tabloid, 11 x 17 pollici"
 
-#: ../src/richtext/richtextformatdlg.cpp:354
+#: ../src/richtext/richtextformatdlg.cpp:347
 msgid "Tabs"
 msgstr "Tabulazioni"
 
-#: ../src/propgrid/advprops.cpp:1598
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Teal"
 msgstr "Tè"
 
-#: ../src/generic/fontdlgg.cpp:327
+#: ../src/generic/fontdlgg.cpp:323
 msgid "Teletype"
 msgstr "Teletype"
 
-#: ../src/common/docview.cpp:1896
+#: ../src/common/docview.cpp:1901
 msgid "Templates"
 msgstr "Modelli"
 
-#: ../src/common/fmapbase.cpp:158
+#: ../src/common/fmapbase.cpp:155
 msgid "Thai (ISO-8859-11)"
 msgstr "Thai (ISO-8859-11)"
 
-#: ../src/common/ftp.cpp:619
+#: ../src/common/ftp.cpp:622
 msgid "The FTP server doesn't support passive mode."
 msgstr "Il server FTP non supporta la modalità di trasferimento passiva."
 
-#: ../src/common/ftp.cpp:605
+#: ../src/common/ftp.cpp:608
 msgid "The FTP server doesn't support the PORT command."
 msgstr "Il server FTP non supporta il comando PORT."
 
@@ -6681,8 +6845,8 @@ msgstr "Il server FTP non supporta il comando PORT."
 msgid "The available bullet styles."
 msgstr "Tipi di puntatura disponibili."
 
-#: ../src/richtext/richtextstyledlg.cpp:202
-#: ../src/richtext/richtextstyledlg.cpp:204
+#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:200
 msgid "The available styles."
 msgstr "Gli stili disponibili."
 
@@ -6738,12 +6902,12 @@ msgstr "La posizione inferiore."
 msgid "The bullet character."
 msgstr "Il carattere puntio elenco."
 
-#: ../src/richtext/richtextsymboldlg.cpp:443
-#: ../src/richtext/richtextsymboldlg.cpp:445
+#: ../src/richtext/richtextsymboldlg.cpp:440
+#: ../src/richtext/richtextsymboldlg.cpp:442
 msgid "The character code."
 msgstr "Il codice del carattere."
 
-#: ../src/common/fontmap.cpp:203
+#: ../src/common/fontmap.cpp:200
 #, c-format
 msgid ""
 "The charset '%s' is unknown. You may select\n"
@@ -6754,7 +6918,7 @@ msgstr ""
 "un altro in sostituzione oppure scegliere [Annulla]\n"
 "se non può essere sostituito"
 
-#: ../src/msw/ole/dataobj.cpp:394
+#: ../src/msw/ole/dataobj.cpp:402
 #, c-format
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "Il formato '%d' degli appunti non esiste."
@@ -6764,7 +6928,7 @@ msgstr "Il formato '%d' degli appunti non esiste."
 msgid "The default style for the next paragraph."
 msgstr "Lo stile predefinito per il paragrafo successivo."
 
-#: ../src/generic/dirdlgg.cpp:202
+#: ../src/generic/dirdlgg.cpp:199
 #, c-format
 msgid ""
 "The directory '%s' does not exist\n"
@@ -6773,7 +6937,7 @@ msgstr ""
 "La cartella '%s' non esiste.\n"
 "Crearla adesso?"
 
-#: ../src/html/htmprint.cpp:271
+#: ../src/html/htmprint.cpp:283
 #, c-format
 msgid ""
 "The document \"%s\" doesn't fit on the page horizontally and will be "
@@ -6786,7 +6950,7 @@ msgstr ""
 "\n"
 "Procedere comunue con la stampa?"
 
-#: ../src/common/docview.cpp:1202
+#: ../src/common/docview.cpp:1196
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -6795,36 +6959,36 @@ msgstr ""
 "Il file file '%s' non esiste e non può essere aperto.\n"
 "È stato rimosso dall'elenco dei file recentemente usati."
 
-#: ../src/richtext/richtextindentspage.cpp:208
-#: ../src/richtext/richtextindentspage.cpp:210
 #: ../src/richtext/richtextliststylepage.cpp:394
 #: ../src/richtext/richtextliststylepage.cpp:396
+#: ../src/richtext/richtextindentspage.cpp:208
+#: ../src/richtext/richtextindentspage.cpp:210
 msgid "The first line indent."
 msgstr "Il rientro della prima riga."
 
-#: ../src/gtk/utilsgtk.cpp:481
-msgid "The following standard GTK+ options are also supported:\n"
-msgstr "Sono inoltre supportate le seguenti opzioni standard GTK+:\n"
+#: ../src/generic/dbgrptg.cpp:318
+msgid "The following debug report will be generated\n"
+msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:414 ../src/generic/fontdlgg.cpp:416
+#: ../src/generic/fontdlgg.cpp:411 ../src/generic/fontdlgg.cpp:413
 msgid "The font colour."
 msgstr "Il colore della font."
 
-#: ../src/generic/fontdlgg.cpp:375 ../src/generic/fontdlgg.cpp:377
+#: ../src/generic/fontdlgg.cpp:371 ../src/generic/fontdlgg.cpp:373
 msgid "The font family."
 msgstr "La famiglia di font."
 
-#: ../src/richtext/richtextsymboldlg.cpp:405
-#: ../src/richtext/richtextsymboldlg.cpp:407
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "The font from which to take the symbol."
 msgstr "Il font da cui prendere il simbolo."
 
-#: ../src/generic/fontdlgg.cpp:427 ../src/generic/fontdlgg.cpp:429
-#: ../src/generic/fontdlgg.cpp:434 ../src/generic/fontdlgg.cpp:436
+#: ../src/generic/fontdlgg.cpp:424 ../src/generic/fontdlgg.cpp:426
+#: ../src/generic/fontdlgg.cpp:430 ../src/generic/fontdlgg.cpp:432
 msgid "The font point size."
 msgstr "Il corpo della font."
 
-#: ../src/osx/carbon/fontdlg.cpp:343 ../src/osx/carbon/fontdlg.cpp:345
+#: ../src/osx/carbon/fontdlg.cpp:340 ../src/osx/carbon/fontdlg.cpp:342
 msgid "The font size in points."
 msgstr "La dimensione in punti del font."
 
@@ -6833,15 +6997,15 @@ msgstr "La dimensione in punti del font."
 msgid "The font size units, points or pixels."
 msgstr "L'unità di misura del carattere, punti o pixel."
 
-#: ../src/generic/fontdlgg.cpp:386 ../src/generic/fontdlgg.cpp:388
+#: ../src/generic/fontdlgg.cpp:382 ../src/generic/fontdlgg.cpp:384
 msgid "The font style."
 msgstr "Lo stile della font."
 
-#: ../src/generic/fontdlgg.cpp:397 ../src/generic/fontdlgg.cpp:399
+#: ../src/generic/fontdlgg.cpp:393 ../src/generic/fontdlgg.cpp:395
 msgid "The font weight."
 msgstr "Il peso della font."
 
-#: ../src/common/docview.cpp:1483
+#: ../src/common/docview.cpp:1477
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Impossibile determinare il formato del file '%s'."
@@ -6851,10 +7015,10 @@ msgstr "Impossibile determinare il formato del file '%s'."
 msgid "The horizontal offset."
 msgstr "L'offset orizzontale."
 
-#: ../src/richtext/richtextindentspage.cpp:199
-#: ../src/richtext/richtextindentspage.cpp:201
 #: ../src/richtext/richtextliststylepage.cpp:385
 #: ../src/richtext/richtextliststylepage.cpp:387
+#: ../src/richtext/richtextindentspage.cpp:199
+#: ../src/richtext/richtextindentspage.cpp:201
 msgid "The left indent."
 msgstr "Il rientro dal margine sinistro."
 
@@ -6875,10 +7039,10 @@ msgstr "La dimensione del riempimento a sinistra."
 msgid "The left position."
 msgstr "La posizione sinistra."
 
-#: ../src/richtext/richtextindentspage.cpp:288
-#: ../src/richtext/richtextindentspage.cpp:290
 #: ../src/richtext/richtextliststylepage.cpp:462
 #: ../src/richtext/richtextliststylepage.cpp:464
+#: ../src/richtext/richtextindentspage.cpp:288
+#: ../src/richtext/richtextindentspage.cpp:290
 msgid "The line spacing."
 msgstr "L'interlinea."
 
@@ -6887,7 +7051,7 @@ msgstr "L'interlinea."
 msgid "The list item number."
 msgstr "Il numero della voce dell'elenco."
 
-#: ../src/msw/ole/automtn.cpp:664
+#: ../src/msw/ole/automtn.cpp:655
 msgid "The locale ID is unknown."
 msgstr "L'ID locale è sconosciuto."
 
@@ -6926,19 +7090,19 @@ msgstr "La larghezza dell'oggetto."
 msgid "The outline level."
 msgstr "Livello contorni."
 
-#: ../src/common/log.cpp:277
+#: ../src/common/log.cpp:296
 #, c-format
 msgid "The previous message repeated %u time."
 msgid_plural "The previous message repeated %u times."
 msgstr[0] "Il messaggio precedente è stato ripetuto %u volta."
 msgstr[1] "Il messaggio precedente è stato ripetuto %u volte."
 
-#: ../src/common/log.cpp:270
+#: ../src/common/log.cpp:289
 msgid "The previous message repeated once."
 msgstr "Il messaggio precedente è stato ripetuto una volta."
 
-#: ../src/richtext/richtextsymboldlg.cpp:462
-#: ../src/richtext/richtextsymboldlg.cpp:464
+#: ../src/richtext/richtextsymboldlg.cpp:459
+#: ../src/richtext/richtextsymboldlg.cpp:461
 msgid "The range to show."
 msgstr "Intervallo da visualizzare."
 
@@ -6953,15 +7117,15 @@ msgstr ""
 "private, rimuovi il segno di spunta per prevenirne l'inclusione nella "
 "segnalazione.\n"
 
-#: ../src/common/cmdline.cpp:1254
+#: ../src/common/cmdline.cpp:1250
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "Il parametro '%s' è obbligatorio."
 
-#: ../src/richtext/richtextindentspage.cpp:217
-#: ../src/richtext/richtextindentspage.cpp:219
 #: ../src/richtext/richtextliststylepage.cpp:403
 #: ../src/richtext/richtextliststylepage.cpp:405
+#: ../src/richtext/richtextindentspage.cpp:217
+#: ../src/richtext/richtextindentspage.cpp:219
 msgid "The right indent."
 msgstr "Rientro da destra."
 
@@ -7002,16 +7166,16 @@ msgstr "L'opacità ombreggiatura."
 msgid "The shadow spread."
 msgstr "La diffusione ombraggiatura."
 
-#: ../src/richtext/richtextindentspage.cpp:267
 #: ../src/richtext/richtextliststylepage.cpp:439
 #: ../src/richtext/richtextliststylepage.cpp:441
+#: ../src/richtext/richtextindentspage.cpp:267
 msgid "The spacing after the paragraph."
 msgstr "Spazio dopo il paragrafo."
 
-#: ../src/richtext/richtextindentspage.cpp:257
-#: ../src/richtext/richtextindentspage.cpp:259
 #: ../src/richtext/richtextliststylepage.cpp:430
 #: ../src/richtext/richtextliststylepage.cpp:432
+#: ../src/richtext/richtextindentspage.cpp:257
+#: ../src/richtext/richtextindentspage.cpp:259
 msgid "The spacing before the paragraph."
 msgstr "Spazio prima del paragrafo."
 
@@ -7025,12 +7189,12 @@ msgstr "Il nome dello stile."
 msgid "The style on which this style is based."
 msgstr "Lo stile su cui si basa questo stile."
 
-#: ../src/richtext/richtextstyledlg.cpp:214
-#: ../src/richtext/richtextstyledlg.cpp:216
+#: ../src/richtext/richtextstyledlg.cpp:210
+#: ../src/richtext/richtextstyledlg.cpp:212
 msgid "The style preview."
 msgstr "Le anteprime degli stili."
 
-#: ../src/msw/ole/automtn.cpp:680
+#: ../src/msw/ole/automtn.cpp:671
 msgid "The system cannot find the file specified."
 msgstr "Il sistema non trova il file specificato."
 
@@ -7043,7 +7207,7 @@ msgstr "Il punto di tabulazione."
 msgid "The tab positions."
 msgstr "I punti di tabulazione."
 
-#: ../src/richtext/richtextctrl.cpp:3098
+#: ../src/richtext/richtextctrl.cpp:3099
 msgid "The text couldn't be saved."
 msgstr "Il testo non può essere salvato."
 
@@ -7064,7 +7228,7 @@ msgstr "La dimensione del riempimento in alto."
 msgid "The top position."
 msgstr "La posizione alta."
 
-#: ../src/common/cmdline.cpp:1232
+#: ../src/common/cmdline.cpp:1228
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "L'opzione '%s' richiede un parametro."
@@ -7074,7 +7238,7 @@ msgstr "L'opzione '%s' richiede un parametro."
 msgid "The value of the corner radius."
 msgstr "Il valore del raggio angolo."
 
-#: ../src/msw/dialup.cpp:433
+#: ../src/msw/dialup.cpp:427
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -7088,14 +7252,14 @@ msgstr ""
 msgid "The vertical offset."
 msgstr "L'offset verticale."
 
-#: ../src/richtext/richtextprint.cpp:619 ../src/html/htmprint.cpp:745
+#: ../src/html/htmprint.cpp:749 ../src/richtext/richtextprint.cpp:615
 msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr ""
 "Si è verificato un problema: potrebbe essere necessario impostare una "
 "stampante predefinita."
 
-#: ../src/html/htmprint.cpp:255
+#: ../src/html/htmprint.cpp:267
 msgid ""
 "This document doesn't fit on the page horizontally and will be truncated "
 "when it is printed."
@@ -7103,16 +7267,16 @@ msgstr ""
 "Il documento non è adattato alla pagina in orizzontale e verrà troncato in "
 "fase di stampa."
 
-#: ../src/common/image.cpp:2854
+#: ../src/common/image.cpp:2963
 #, c-format
 msgid "This is not a %s."
 msgstr "Questo non è un %s."
 
-#: ../src/common/wincmn.cpp:1653
+#: ../src/common/wincmn.cpp:1654
 msgid "This platform does not support background transparency."
 msgstr "La piattaforma non supporta la trasparenza sfondo."
 
-#: ../src/gtk/window.cpp:4660
+#: ../src/gtk/window.cpp:5664
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
@@ -7120,7 +7284,15 @@ msgstr ""
 "Questo programma è stato compilato con una versione troppo vecchia di GTK+. "
 "Ricompila con GTK+ 2.12 o superiore."
 
-#: ../src/msw/thread.cpp:1240
+#: ../src/gtk/glcanvas.cpp:176
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/msw/thread.cpp:1246
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -7128,13 +7300,13 @@ msgstr ""
 "Inizializzazione modulo dei thread fallita: impossibile memorizzare un "
 "valore nella memoria locale del thread"
 
-#: ../src/unix/threadpsx.cpp:1794
+#: ../src/unix/threadpsx.cpp:1843
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 "Inizializzazione del modulo dei thread fallita: errore nella creazione della "
 "chiave dei thread"
 
-#: ../src/msw/thread.cpp:1228
+#: ../src/msw/thread.cpp:1234
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -7142,84 +7314,84 @@ msgstr ""
 "Inizializzazione del modulo dei thread fallita: impossibile allocare "
 "l'indice nella memoria locale del thread"
 
-#: ../src/unix/threadpsx.cpp:1043
+#: ../src/unix/threadpsx.cpp:1061
 msgid "Thread priority setting is ignored."
 msgstr "Priorità del thread ignorata."
 
-#: ../src/msw/mdi.cpp:176
+#: ../src/msw/mdi.cpp:171
 msgid "Tile &Horizontally"
 msgstr "Affianca orizzontalmente"
 
-#: ../src/msw/mdi.cpp:177
+#: ../src/msw/mdi.cpp:172
 msgid "Tile &Vertically"
 msgstr "Affianca verticalmente"
 
-#: ../src/common/ftp.cpp:200
+#: ../src/common/ftp.cpp:197
 msgid "Timeout while waiting for FTP server to connect, try passive mode."
 msgstr ""
 "Tempo di attesa eccessivo durante l'attesa per la connessione del server "
 "FTP. Provare la modalità passiva."
 
-#: ../src/generic/tipdlg.cpp:201
+#: ../src/generic/tipdlg.cpp:198
 msgid "Tip of the Day"
 msgstr "Suggerimento del giorno"
 
-#: ../src/generic/tipdlg.cpp:140
+#: ../src/generic/tipdlg.cpp:137
 msgid "Tips not available, sorry!"
 msgstr "Suggerimenti non disponibili!"
 
-#: ../src/generic/prntdlgg.cpp:242
+#: ../src/generic/prntdlgg.cpp:235
 msgid "To:"
 msgstr "Per:"
 
-#: ../src/richtext/richtextbuffer.cpp:8363
+#: ../src/richtext/richtextbuffer.cpp:8361
 msgid "Too many EndStyle calls!"
 msgstr "Troppe chiamate a EndStyle!"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:891
+#: ../src/propgrid/advprops.cpp:792
 msgid "Tooltip"
 msgstr "Suggerimento"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:892
+#: ../src/propgrid/advprops.cpp:793
 msgid "TooltipText"
 msgstr "Testo suggerimento"
 
-#: ../src/richtext/richtextsizepage.cpp:286
-#: ../src/richtext/richtextsizepage.cpp:290 ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197 ../src/richtext/richtextsizepage.cpp:286
+#: ../src/richtext/richtextsizepage.cpp:290
 msgid "Top"
 msgstr "Alto"
 
-#: ../src/generic/prntdlgg.cpp:881
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Top margin (mm):"
 msgstr "Margine superiore (mm):"
 
-#: ../src/generic/aboutdlgg.cpp:79
+#: ../src/generic/aboutdlgg.cpp:76
 msgid "Translations by "
 msgstr "Tradotto da "
 
-#: ../src/generic/aboutdlgg.cpp:188
+#: ../src/generic/aboutdlgg.cpp:185
 msgid "Translators"
 msgstr "Traduttori"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:211
+#: ../src/propgrid/propgrid.cpp:192
 msgid "True"
 msgstr "Vero"
 
-#: ../src/common/fs_mem.cpp:227
+#: ../src/common/fs_mem.cpp:222
 #, c-format
 msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
 msgstr ""
 "Tentata la rimozione del file '%s' dalla memoria VFS, ma il file non è "
 "caricato!"
 
-#: ../src/common/fmapbase.cpp:156
+#: ../src/common/fmapbase.cpp:153
 msgid "Turkish (ISO-8859-9)"
 msgstr "Turco (ISO-8859-9)"
 
-#: ../src/generic/filectrlg.cpp:426
+#: ../src/generic/filectrlg.cpp:422
 msgid "Type"
 msgstr "Tipo"
 
@@ -7233,17 +7405,17 @@ msgstr "Digita un nome font."
 msgid "Type a size in points."
 msgstr "Digita la dimensione in punti."
 
-#: ../src/msw/ole/automtn.cpp:676
+#: ../src/msw/ole/automtn.cpp:667
 #, c-format
 msgid "Type mismatch in argument %u."
 msgstr "Tipo non corrispondente nell'argomento %u."
 
-#: ../src/common/xtixml.cpp:356 ../src/common/xtixml.cpp:509
-#: ../src/common/xtistrm.cpp:318
+#: ../src/common/xtixml.cpp:352 ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315
 msgid "Type must have enum - long conversion"
 msgstr "Tipo deve avere enumeratore - convertito a long"
 
-#: ../src/propgrid/propgridiface.cpp:401
+#: ../src/propgrid/propgridiface.cpp:385
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
@@ -7252,19 +7424,19 @@ msgstr ""
 "Tipo operazione \"%s\" fallita: etichetta proprietà:  \"%s\" è del tipo  \"%s"
 "\", NON \"%s\"."
 
-#: ../src/common/paper.cpp:133
+#: ../src/common/paper.cpp:130
 msgid "US Std Fanfold, 14 7/8 x 11 in"
 msgstr "US Std Fanfold, 14 7/8 x 11 pollici"
 
-#: ../src/common/fmapbase.cpp:196
+#: ../src/common/fmapbase.cpp:193
 msgid "US-ASCII"
 msgstr "ASCII"
 
-#: ../src/unix/fswatcher_inotify.cpp:109
+#: ../src/unix/fswatcher_inotify.cpp:106
 msgid "Unable to add inotify watch"
 msgstr "Impossibile aggiungere monitor inotify"
 
-#: ../src/unix/fswatcher_kqueue.cpp:136
+#: ../src/unix/fswatcher_kqueue.cpp:153
 msgid "Unable to add kqueue watch"
 msgstr "Impossibile aggiungere montor kqueue"
 
@@ -7276,7 +7448,7 @@ msgstr "Impossibile associare gestore completamento porta I/O"
 msgid "Unable to close I/O completion port handle"
 msgstr "Impossibile chiudere gestore porta completamento I/O"
 
-#: ../src/unix/fswatcher_inotify.cpp:97
+#: ../src/unix/fswatcher_inotify.cpp:94
 msgid "Unable to close inotify instance"
 msgstr "Impossibile chiudere istanza inotify"
 
@@ -7294,15 +7466,15 @@ msgstr "Impossibile chiudere gestore di '%s'"
 msgid "Unable to create I/O completion port"
 msgstr "Impossibile creare porta completamento I/O"
 
-#: ../src/msw/fswatcher.cpp:84
+#: ../src/msw/fswatcher.cpp:81
 msgid "Unable to create IOCP worker thread"
 msgstr "Impossibile creare thread attività IOCP"
 
-#: ../src/unix/fswatcher_inotify.cpp:74
+#: ../src/unix/fswatcher_inotify.cpp:71
 msgid "Unable to create inotify instance"
 msgstr "Impossibile creare istanza inotify"
 
-#: ../src/unix/fswatcher_kqueue.cpp:97
+#: ../src/unix/fswatcher_kqueue.cpp:114
 msgid "Unable to create kqueue instance"
 msgstr "Impossibile creare istanza kqueue"
 
@@ -7310,11 +7482,11 @@ msgstr "Impossibile creare istanza kqueue"
 msgid "Unable to dequeue completion packet"
 msgstr "Impossibile eliminare dalla coda pachetto completamento"
 
-#: ../src/unix/fswatcher_kqueue.cpp:185
+#: ../src/unix/fswatcher_kqueue.cpp:202
 msgid "Unable to get events from kqueue"
 msgstr "Impossibile ottenere eventi da kqueue"
 
-#: ../src/gtk/app.cpp:435
+#: ../src/gtk/app.cpp:431
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "Impossibile inzializzare GTK+, DISPLAY impostato correttamente?"
 
@@ -7323,12 +7495,12 @@ msgstr "Impossibile inzializzare GTK+, DISPLAY impostato correttamente?"
 msgid "Unable to open path '%s'"
 msgstr "Impossibile aprire percorso '%s'"
 
-#: ../src/html/htmlwin.cpp:583
+#: ../src/html/htmlwin.cpp:586
 #, c-format
 msgid "Unable to open requested HTML document: %s"
 msgstr "Impossibile aprire il documento HTML richiesto: %s"
 
-#: ../src/unix/sound.cpp:368
+#: ../src/unix/sound.cpp:365
 msgid "Unable to play sound asynchronously."
 msgstr "Impossibile riprodurre il suono in modalità asincrona."
 
@@ -7336,63 +7508,63 @@ msgstr "Impossibile riprodurre il suono in modalità asincrona."
 msgid "Unable to post completion status"
 msgstr "Impossibiile comunicare stato completamento"
 
-#: ../src/unix/fswatcher_inotify.cpp:556
+#: ../src/unix/fswatcher_inotify.cpp:553
 msgid "Unable to read from inotify descriptor"
 msgstr "Impossibile leggere dal descrittore inotify"
 
-#: ../src/unix/fswatcher_inotify.cpp:141
+#: ../src/unix/fswatcher_inotify.cpp:138
 #, c-format
 msgid "Unable to remove inotify watch %i"
 msgstr "Impossibile rimuovere monitoraggio inotify %i"
 
-#: ../src/unix/fswatcher_kqueue.cpp:153
+#: ../src/unix/fswatcher_kqueue.cpp:170
 msgid "Unable to remove kqueue watch"
 msgstr "Impossibile rimuovere controllo kqueue"
 
-#: ../src/msw/fswatcher.cpp:168
+#: ../src/msw/fswatcher.cpp:165
 #, c-format
 msgid "Unable to set up watch for '%s'"
 msgstr "Impossibile impostare controllo  per '%s'"
 
-#: ../src/msw/fswatcher.cpp:91
+#: ../src/msw/fswatcher.cpp:88
 msgid "Unable to start IOCP worker thread"
 msgstr "Impossibile avviare thread attività IOCP"
 
-#: ../src/common/stockitem.cpp:201
+#: ../src/common/stockitem.cpp:198
 msgid "Undelete"
 msgstr "Annulla elimina"
 
-#: ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199
 msgid "Underline"
 msgstr "Sottolineato"
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/richtext/richtextfontpage.cpp:359 ../src/osx/carbon/fontdlg.cpp:370
-#: ../src/propgrid/advprops.cpp:690
+#: ../src/osx/carbon/fontdlg.cpp:367 ../src/propgrid/advprops.cpp:600
+#: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Sottolineato"
 
-#: ../src/common/stockitem.cpp:203 ../src/stc/stc_i18n.cpp:15
+#: ../src/common/stockitem.cpp:200 ../src/stc/stc_i18n.cpp:15
 msgid "Undo"
 msgstr "Annulla"
 
-#: ../src/common/stockitem.cpp:265
+#: ../src/common/stockitem.cpp:263
 msgid "Undo last action"
 msgstr "Annulla l'ultima azione"
 
-#: ../src/common/cmdline.cpp:1029
+#: ../src/common/cmdline.cpp:1025
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Caratteri non attesi dopo l'opzione '%s'."
 
-#: ../src/unix/fswatcher_inotify.cpp:274
+#: ../src/unix/fswatcher_inotify.cpp:271
 #, c-format
 msgid "Unexpected event for \"%s\": no matching watch descriptor."
 msgstr ""
 "Evento inaspettato per \"%s\": nessun descrittore monitoraggio "
 "corrispondente."
 
-#: ../src/common/cmdline.cpp:1195
+#: ../src/common/cmdline.cpp:1191
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Parametro '%s' non atteso"
@@ -7401,49 +7573,49 @@ msgstr "Parametro '%s' non atteso"
 msgid "Unexpectedly new I/O completion port was created"
 msgstr "Una nuova inaspettata porta completamento I/O è stata creata"
 
-#: ../src/msw/fswatcher.cpp:70
+#: ../src/msw/fswatcher.cpp:67
 msgid "Ungraceful worker thread termination"
 msgstr "Chiusra del thread inaspettata"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:460
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:456
+#: ../src/richtext/richtextsymboldlg.cpp:457
+#: ../src/richtext/richtextsymboldlg.cpp:458
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../src/common/fmapbase.cpp:185 ../src/common/fmapbase.cpp:191
+#: ../src/common/fmapbase.cpp:182 ../src/common/fmapbase.cpp:188
 msgid "Unicode 16 bit (UTF-16)"
 msgstr "Unicode 16 bit (UTF-16)"
 
-#: ../src/common/fmapbase.cpp:190
+#: ../src/common/fmapbase.cpp:187
 msgid "Unicode 16 bit Big Endian (UTF-16BE)"
 msgstr "Unicode 16 bit Big Endian (UTF-16BE)"
 
-#: ../src/common/fmapbase.cpp:186
+#: ../src/common/fmapbase.cpp:183
 msgid "Unicode 16 bit Little Endian (UTF-16LE)"
 msgstr "Unicode 16 bit Little Endian (UTF-16LE)"
 
-#: ../src/common/fmapbase.cpp:187 ../src/common/fmapbase.cpp:193
+#: ../src/common/fmapbase.cpp:184 ../src/common/fmapbase.cpp:190
 msgid "Unicode 32 bit (UTF-32)"
 msgstr "Unicode 32 bit (UTF-32)"
 
-#: ../src/common/fmapbase.cpp:192
+#: ../src/common/fmapbase.cpp:189
 msgid "Unicode 32 bit Big Endian (UTF-32BE)"
 msgstr "Unicode 32 bit Big Endian (UTF-32BE)"
 
-#: ../src/common/fmapbase.cpp:188
+#: ../src/common/fmapbase.cpp:185
 msgid "Unicode 32 bit Little Endian (UTF-32LE)"
 msgstr "Unicode 32 bit Little Endian (UTF-32LE)"
 
-#: ../src/common/fmapbase.cpp:182
+#: ../src/common/fmapbase.cpp:179
 msgid "Unicode 7 bit (UTF-7)"
 msgstr "Unicode 7 bit (UTF-7)"
 
-#: ../src/common/fmapbase.cpp:183
+#: ../src/common/fmapbase.cpp:180
 msgid "Unicode 8 bit (UTF-8)"
 msgstr "Unicode 8 bit (UTF-8)"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "Unindent"
 msgstr "Rimuovi indentazione"
 
@@ -7593,97 +7765,102 @@ msgstr "Unità posizione alta."
 msgid "Units for this value."
 msgstr "Unità per questo valore."
 
-#: ../src/generic/progdlgg.cpp:353 ../src/generic/progdlgg.cpp:622
+#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
 msgid "Unknown"
 msgstr "Sconosciuta"
 
-#: ../src/msw/dde.cpp:1174
+#: ../src/msw/dde.cpp:1238
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Errore DDE %08x sconosciuto"
 
-#: ../src/common/xtistrm.cpp:410
+#: ../src/common/xtistrm.cpp:407
 msgid "Unknown Object passed to GetObjectClassInfo"
 msgstr "Oggetto non conosciuto passato a GetObjectClassInfo"
 
-#: ../src/common/imagpng.cpp:366
+#: ../src/common/imagpng.cpp:383
 #, c-format
 msgid "Unknown PNG resolution unit %d"
 msgstr "Unità %d risoluzione PNG sconosciuta"
 
-#: ../src/common/xtixml.cpp:327
+#: ../src/common/xtixml.cpp:323
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Proprietà %s sconosciuta"
 
-#: ../src/common/imagtiff.cpp:529
+#: ../src/common/imagtiff.cpp:526
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "Risoluzione TIFF sconosciuta - unità %d ignorata"
 
-#: ../src/unix/dlunix.cpp:160
+#: ../src/propgrid/props.cpp:155
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/unix/dlunix.cpp:118
 msgid "Unknown dynamic library error"
 msgstr "Errore sconosciuto nella libreria dinamica"
 
-#: ../src/common/fmapbase.cpp:810
+#: ../src/common/fmapbase.cpp:806
 #, c-format
 msgid "Unknown encoding (%d)"
 msgstr "Codifica sconosciuta (%d)"
 
-#: ../src/msw/ole/automtn.cpp:688
+#: ../src/msw/ole/automtn.cpp:679
 #, c-format
 msgid "Unknown error %08x"
 msgstr "Errore %08x sconosciuto"
 
-#: ../src/msw/ole/automtn.cpp:647
+#: ../src/msw/ole/automtn.cpp:638
 msgid "Unknown exception"
 msgstr "Eccezione sconosciuta"
 
-#: ../src/common/image.cpp:2839
+#: ../src/common/image.cpp:2942
 msgid "Unknown image data format."
 msgstr "Formato dati immagine sconosciuto."
 
-#: ../src/common/cmdline.cpp:914
+#: ../src/common/cmdline.cpp:910
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Opzione lunga '%s' sconosciuta"
 
-#: ../src/msw/ole/automtn.cpp:631
+#: ../src/msw/ole/automtn.cpp:622
 msgid "Unknown name or named argument."
 msgstr "Nome sconosciuto o argomento nominale."
 
-#: ../src/common/cmdline.cpp:929 ../src/common/cmdline.cpp:951
+#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Opzione '%s' sconosciuta"
 
-#: ../src/common/mimecmn.cpp:225
+#: ../src/common/mimecmn.cpp:221
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "'{' spaiata in una voce per il tipo MIME %s."
 
-#: ../src/common/cmdproc.cpp:262 ../src/common/cmdproc.cpp:288
-#: ../src/common/cmdproc.cpp:308
+#: ../src/common/cmdproc.cpp:255 ../src/common/cmdproc.cpp:281
+#: ../src/common/cmdproc.cpp:301
 msgid "Unnamed command"
 msgstr "Comando privo di nome"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:413
+#: ../src/propgrid/propgrid.cpp:392
 msgid "Unspecified"
 msgstr "Non specificato"
 
-#: ../src/msw/clipbrd.cpp:311
+#: ../src/msw/clipbrd.cpp:325
 msgid "Unsupported clipboard format."
 msgstr "Formato degli Appunti non supportato."
 
-#: ../src/common/appcmn.cpp:256
+#: ../src/common/appcmn.cpp:277
 #, c-format
 msgid "Unsupported theme '%s'."
 msgstr "Tema '%s' non supportato."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:205
-#: ../src/common/accelcmn.cpp:63
+#: ../src/common/stockitem.cpp:202 ../src/common/accelcmn.cpp:60
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Up"
 msgstr "Su"
 
@@ -7697,7 +7874,7 @@ msgstr "Lettere maiuscole"
 msgid "Upper case roman numerals"
 msgstr "Numeri romani maiuscoli"
 
-#: ../src/common/cmdline.cpp:1326
+#: ../src/common/cmdline.cpp:1322
 #, c-format
 msgid "Usage: %s"
 msgstr "Utilizzo: %s"
@@ -7706,38 +7883,47 @@ msgstr "Utilizzo: %s"
 msgid "Use &shadow"
 msgstr "U&sa ombreggiatura"
 
-#: ../src/richtext/richtextindentspage.cpp:169
-#: ../src/richtext/richtextindentspage.cpp:171
 #: ../src/richtext/richtextliststylepage.cpp:358
 #: ../src/richtext/richtextliststylepage.cpp:360
+#: ../src/richtext/richtextindentspage.cpp:169
+#: ../src/richtext/richtextindentspage.cpp:171
 msgid "Use the current alignment setting."
 msgstr "Utilizza le impostazioni di allineamento correnti."
 
-#: ../src/common/valtext.cpp:179
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/gtk/font.cpp:552
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/common/valtext.cpp:142
 msgid "Validation conflict"
 msgstr "Conflitto durante la validazione"
 
-#: ../src/propgrid/manager.cpp:238
+#: ../src/propgrid/manager.cpp:224
 msgid "Value"
 msgstr "Valore"
 
-#: ../src/propgrid/props.cpp:386 ../src/propgrid/props.cpp:500
+#: ../src/propgrid/props.cpp:309
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "Il valore deve essere %s o superiore."
 
-#: ../src/propgrid/props.cpp:417 ../src/propgrid/props.cpp:531
+#: ../src/propgrid/props.cpp:336
 #, c-format
 msgid "Value must be %s or less."
 msgstr "Il valore deve essere %s o inferiore."
 
-#: ../src/propgrid/props.cpp:393 ../src/propgrid/props.cpp:424
-#: ../src/propgrid/props.cpp:507 ../src/propgrid/props.cpp:538
+#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "Il valore deve essere tra %s e %s."
 
-#: ../src/generic/aboutdlgg.cpp:128
+#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Versione "
 
@@ -7746,25 +7932,32 @@ msgstr "Versione "
 msgid "Vertical alignment."
 msgstr "Allineamento verticale."
 
-#: ../src/generic/filedlgg.cpp:202
+#: ../src/generic/filedlgg.cpp:199
 msgid "View files as a detailed view"
 msgstr "Visalizza file - dettagli"
 
-#: ../src/generic/filedlgg.cpp:200
+#: ../src/generic/filedlgg.cpp:197
 msgid "View files as a list view"
 msgstr "Visualizza i file - elenco"
 
-#: ../src/common/docview.cpp:1970
+#: ../src/common/docview.cpp:1975
 msgid "Views"
 msgstr "Visualizzazioni"
 
+#: ../src/gtk/app.cpp:348
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1777
+#: ../src/propgrid/advprops.cpp:1678
 msgid "Wait"
 msgstr "Attendi"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1779
+#: ../src/propgrid/advprops.cpp:1680
 msgid "Wait Arrow"
 msgstr "Attendi freccia"
 
@@ -7773,238 +7966,235 @@ msgstr "Attendi freccia"
 msgid "Waiting for IO on epoll descriptor %d failed"
 msgstr "Attesa IO descrittore epoll %d fallita"
 
-#: ../src/common/log.cpp:223
+#: ../src/common/log.cpp:241
 msgid "Warning: "
 msgstr "Avviso: "
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1778
+#: ../src/propgrid/advprops.cpp:1679
 msgid "Watch"
 msgstr "Monitorizza"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:685
+#: ../src/propgrid/advprops.cpp:595
 msgid "Weight"
 msgstr "Peso"
 
-#: ../src/common/fmapbase.cpp:148
+#: ../src/common/fmapbase.cpp:145
 msgid "Western European (ISO-8859-1)"
 msgstr "Europeo Occidentale (ISO-8859-1)"
 
-#: ../src/common/fmapbase.cpp:162
+#: ../src/common/fmapbase.cpp:159
 msgid "Western European with Euro (ISO-8859-15)"
 msgstr "Europeo Occidentale con Euro (ISO-8859-15)"
 
-#: ../src/generic/fontdlgg.cpp:446 ../src/generic/fontdlgg.cpp:448
+#: ../src/generic/fontdlgg.cpp:443 ../src/generic/fontdlgg.cpp:445
 msgid "Whether the font is underlined."
 msgstr "Sottolineato."
 
-#: ../src/propgrid/advprops.cpp:1611
+#: ../src/propgrid/advprops.cpp:1517
 msgid "White"
 msgstr "Bianco"
 
-#: ../src/generic/fdrepdlg.cpp:144
+#: ../src/generic/fdrepdlg.cpp:141
 msgid "Whole word"
 msgstr "Parola intera"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:532
 msgid "Whole words only"
 msgstr "Solo parole intere"
 
-#: ../src/univ/themes/win32.cpp:1102
+#: ../src/univ/themes/win32.cpp:1099
 msgid "Win32 theme"
 msgstr "Tema Win32"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:893
+#: ../src/propgrid/advprops.cpp:794
 msgid "Window"
 msgstr "Finestra"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:894
+#: ../src/propgrid/advprops.cpp:795
 msgid "WindowFrame"
 msgstr "FrameFinestra"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:895
+#: ../src/propgrid/advprops.cpp:796
 msgid "WindowText"
 msgstr "TestoFinestra"
 
-#: ../src/common/fmapbase.cpp:177
+#: ../src/common/fmapbase.cpp:174
 msgid "Windows Arabic (CP 1256)"
 msgstr "Windows Arabo (CP 1256)"
 
-#: ../src/common/fmapbase.cpp:178
+#: ../src/common/fmapbase.cpp:175
 msgid "Windows Baltic (CP 1257)"
 msgstr "Windows Baltico (CP 1257)"
 
-#: ../src/common/fmapbase.cpp:171
+#: ../src/common/fmapbase.cpp:168
 msgid "Windows Central European (CP 1250)"
 msgstr "Windows Europeo Centrale (CP 1250)"
 
-#: ../src/common/fmapbase.cpp:168
+#: ../src/common/fmapbase.cpp:165
 msgid "Windows Chinese Simplified (CP 936) or GB-2312"
 msgstr "Windows Cinese Semplificato (CP 936) o GB-2312"
 
-#: ../src/common/fmapbase.cpp:170
+#: ../src/common/fmapbase.cpp:167
 msgid "Windows Chinese Traditional (CP 950) or Big-5"
 msgstr "Windows Cinese tradizionale (CP 950) o Big-5"
 
-#: ../src/common/fmapbase.cpp:172
+#: ../src/common/fmapbase.cpp:169
 msgid "Windows Cyrillic (CP 1251)"
 msgstr "Windows Cirillico (CP 1251)"
 
-#: ../src/common/fmapbase.cpp:174
+#: ../src/common/fmapbase.cpp:171
 msgid "Windows Greek (CP 1253)"
 msgstr "Windows Greco (CP 1253)"
 
-#: ../src/common/fmapbase.cpp:176
+#: ../src/common/fmapbase.cpp:173
 msgid "Windows Hebrew (CP 1255)"
 msgstr "Windows Ebraico (CP 1255)"
 
-#: ../src/common/fmapbase.cpp:167
+#: ../src/common/fmapbase.cpp:164
 msgid "Windows Japanese (CP 932) or Shift-JIS"
 msgstr "Windows Giapponese (CP 932) o Shift-JIS"
 
-#: ../src/common/fmapbase.cpp:180
+#: ../src/common/fmapbase.cpp:177
 msgid "Windows Johab (CP 1361)"
 msgstr "Windows Johab (CP 1231)"
 
-#: ../src/common/fmapbase.cpp:169
+#: ../src/common/fmapbase.cpp:166
 msgid "Windows Korean (CP 949)"
 msgstr "Windows Coreano (CP 949)"
 
-#: ../src/common/fmapbase.cpp:166
+#: ../src/common/fmapbase.cpp:163
 msgid "Windows Thai (CP 874)"
 msgstr "Windows Tailandese (CP 874)"
 
-#: ../src/common/fmapbase.cpp:175
+#: ../src/common/fmapbase.cpp:172
 msgid "Windows Turkish (CP 1254)"
 msgstr "Windows Turco (CP 1254)"
 
-#: ../src/common/fmapbase.cpp:179
+#: ../src/common/fmapbase.cpp:176
 msgid "Windows Vietnamese (CP 1258)"
 msgstr "Windows vietnamita (CP 1258)"
 
-#: ../src/common/fmapbase.cpp:173
+#: ../src/common/fmapbase.cpp:170
 msgid "Windows Western European (CP 1252)"
 msgstr "Windows Europeo Occidentale (CP 1252)"
 
-#: ../src/common/fmapbase.cpp:181
+#: ../src/common/fmapbase.cpp:178
 msgid "Windows/DOS OEM (CP 437)"
 msgstr "Windows/DOS OEM (CP 437)"
 
-#: ../src/common/fmapbase.cpp:165
+#: ../src/common/fmapbase.cpp:162
 msgid "Windows/DOS OEM Cyrillic (CP 866)"
 msgstr "Windows/DOS OEM Cirillico (CP 866)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:111
+#: ../src/common/accelcmn.cpp:109
 msgid "Windows_Left"
 msgstr "Windows_Sinistra"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:113
+#: ../src/common/accelcmn.cpp:111
 msgid "Windows_Menu"
 msgstr "Windows_Menu"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:112
+#: ../src/common/accelcmn.cpp:110
 msgid "Windows_Right"
 msgstr "Windows_Destra"
 
-#: ../src/common/ffile.cpp:150
+#: ../src/common/ffile.cpp:149
 #, c-format
 msgid "Write error on file '%s'"
 msgstr "Errore di scrittura nel file '%s'"
 
-#: ../src/xml/xml.cpp:914
+#: ../src/xml/xml.cpp:925
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "Errore durante l'analisi XML: %s alla riga %d"
 
-#: ../src/common/xpmdecod.cpp:796
+#: ../src/common/xpmdecod.cpp:794
 msgid "XPM: Malformed pixel data!"
 msgstr "XPM: dati pixel malformati!"
 
-#: ../src/common/xpmdecod.cpp:705
+#: ../src/common/xpmdecod.cpp:702
 #, c-format
 msgid "XPM: incorrect colour description in line %d"
 msgstr "XPM: definizione di colore scorretta alla riga %d"
 
-#: ../src/common/xpmdecod.cpp:680
+#: ../src/common/xpmdecod.cpp:677
 msgid "XPM: incorrect header format!"
 msgstr "XPM: errore nel formato dell'intestazione!"
 
-#: ../src/common/xpmdecod.cpp:716 ../src/common/xpmdecod.cpp:725
+#: ../src/common/xpmdecod.cpp:714 ../src/common/xpmdecod.cpp:723
 #, c-format
 msgid "XPM: malformed colour definition '%s' at line %d!"
 msgstr "XPM: definizione di colore '%s' malformata alla riga %d!"
 
-#: ../src/common/xpmdecod.cpp:755
+#: ../src/common/xpmdecod.cpp:753
 msgid "XPM: no colors left to use for mask!"
 msgstr "XPM: nessun colore restante da usare per la amschera!"
 
-#: ../src/common/xpmdecod.cpp:782
+#: ../src/common/xpmdecod.cpp:780
 #, c-format
 msgid "XPM: truncated image data at line %d!"
 msgstr "XPM: i dati dell'immagine sono troncati alla riga %d!"
 
-#: ../src/propgrid/advprops.cpp:1610
+#: ../src/propgrid/advprops.cpp:1516
 msgid "Yellow"
 msgstr "Giallo"
 
-#: ../include/wx/msgdlg.h:276 ../src/common/stockitem.cpp:206
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:203
 #: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Si"
 
-#: ../src/osx/carbon/overlay.cpp:155
-msgid "You cannot Clear an overlay that is not inited"
-msgstr "Impossibile richiamare Clear su un overlay non inizializzato"
-
-#: ../src/osx/carbon/overlay.cpp:107 ../src/dfb/overlay.cpp:61
-msgid "You cannot Init an overlay twice"
-msgstr "Impossibile richiamare Init due volte sullo stesso overlay"
-
-#: ../src/generic/dirdlgg.cpp:287
+#: ../src/generic/dirdlgg.cpp:284
 msgid "You cannot add a new directory to this section."
 msgstr "Impossibile aggiungere una nuova cartella a questa sezione."
 
-#: ../src/propgrid/propgrid.cpp:3299
+#: ../src/propgrid/propgrid.cpp:3276
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 "È stato inserito un valore non valido. Premi 'ESC' per annullare la modifica."
 
-#: ../src/common/stockitem.cpp:209
+#: ../src/osx/cocoa/menu.mm:286
+#, fuzzy
+msgid "Zoom"
+msgstr "Ingrandisci"
+
+#: ../src/common/stockitem.cpp:206
 msgid "Zoom &In"
 msgstr "&Ingrandisci"
 
-#: ../src/common/stockitem.cpp:210
+#: ../src/common/stockitem.cpp:207
 msgid "Zoom &Out"
 msgstr "&Rimpicciolisci"
 
-#: ../src/common/stockitem.cpp:209 ../src/common/prntbase.cpp:1594
+#: ../src/common/stockitem.cpp:206 ../src/common/prntbase.cpp:1619
 msgid "Zoom In"
 msgstr "Ingrandisci"
 
-#: ../src/common/stockitem.cpp:210 ../src/common/prntbase.cpp:1580
+#: ../src/common/stockitem.cpp:207 ../src/common/prntbase.cpp:1605
 msgid "Zoom Out"
 msgstr "Riduci"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to &Fit"
 msgstr "Adatta alla &finestra"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to Fit"
 msgstr "Adatta alla finestra"
 
-#: ../src/msw/dde.cpp:1141
+#: ../src/msw/dde.cpp:1205
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "un'applicazione DDEML ha creato una 'race condition' prolungata."
 
-#: ../src/msw/dde.cpp:1129
+#: ../src/msw/dde.cpp:1193
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -8015,45 +8205,45 @@ msgstr ""
 "oppure è stato passato ad una funzione DDEML\n"
 "un identificatore di istanza non valido."
 
-#: ../src/msw/dde.cpp:1147
+#: ../src/msw/dde.cpp:1211
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "tentativo del client di stabilire una connessione fallito."
 
-#: ../src/msw/dde.cpp:1144
+#: ../src/msw/dde.cpp:1208
 msgid "a memory allocation failed."
 msgstr "allocazione di memoria è fallita."
 
-#: ../src/msw/dde.cpp:1138
+#: ../src/msw/dde.cpp:1202
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "un parametro ha fallito la validazione da parte del DDEML."
 
-#: ../src/msw/dde.cpp:1120
+#: ../src/msw/dde.cpp:1184
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr ""
 "una richiesta di transazione sincrona (advise) ha superato il tempo massimo."
 
-#: ../src/msw/dde.cpp:1126
+#: ../src/msw/dde.cpp:1190
 msgid "a request for a synchronous data transaction has timed out."
 msgstr ""
 "una richiesta di transazione sincrona (data) ha superato il tempo massimo."
 
-#: ../src/msw/dde.cpp:1135
+#: ../src/msw/dde.cpp:1199
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr ""
 "una richiesta di transazione sincrona (execute) ha superato il tempo massimo."
 
-#: ../src/msw/dde.cpp:1153
+#: ../src/msw/dde.cpp:1217
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr ""
 "una richiesta di transazione sincrona (poke) ha superato il tempo massimo."
 
-#: ../src/msw/dde.cpp:1168
+#: ../src/msw/dde.cpp:1232
 msgid "a request to end an advise transaction has timed out."
 msgstr ""
 "una richiesta di terminazione di transazione (advise) ha superato il tempo "
 "massimo."
 
-#: ../src/msw/dde.cpp:1162
+#: ../src/msw/dde.cpp:1226
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -8063,15 +8253,15 @@ msgstr ""
 "già terminata dal client, oppure il server\n"
 "è terminato prima di portare a termine la transazione."
 
-#: ../src/msw/dde.cpp:1150
+#: ../src/msw/dde.cpp:1214
 msgid "a transaction failed."
 msgstr "una transazione è fallita."
 
-#: ../src/common/accelcmn.cpp:189
+#: ../src/common/accelcmn.cpp:188
 msgid "alt"
 msgstr "alt"
 
-#: ../src/msw/dde.cpp:1132
+#: ../src/msw/dde.cpp:1196
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -8083,15 +8273,15 @@ msgstr ""
 "oppure un'applicazione inizializzata come APPCMD_CLIENTONLY\n"
 "ha cercato di effettuare una transazione server."
 
-#: ../src/msw/dde.cpp:1156
+#: ../src/msw/dde.cpp:1220
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "una chiamata interna alla funzione PostMessage è fallita. "
 
-#: ../src/msw/dde.cpp:1165
+#: ../src/msw/dde.cpp:1229
 msgid "an internal error has occurred in the DDEML."
 msgstr "è avvenuto un errore interno nel DDEML."
 
-#: ../src/msw/dde.cpp:1171
+#: ../src/msw/dde.cpp:1235
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -8102,56 +8292,56 @@ msgstr ""
 "Una volta che l'applicazione è uscita da una callback XTYP_XACT_COMPLETE,\n"
 "l'identificatore di transazione per questa callback non è più valido."
 
-#: ../src/common/zipstrm.cpp:1483
+#: ../src/common/zipstrm.cpp:1522
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "si assume che queste siano più parti di un archivio ZIP concatenato"
 
-#: ../src/common/fileconf.cpp:1847
+#: ../src/common/fileconf.cpp:1849
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "tentativo di modificare la chiave non modificabile '%s' ignorato."
 
-#: ../src/html/chm.cpp:329
+#: ../src/html/chm.cpp:326
 msgid "bad arguments to library function"
 msgstr "funzione di libreria richiamata con argomento errato"
 
-#: ../src/html/chm.cpp:341
+#: ../src/html/chm.cpp:338
 msgid "bad signature"
 msgstr "firma errata"
 
-#: ../src/common/zipstrm.cpp:1918
+#: ../src/common/zipstrm.cpp:1988
 msgid "bad zipfile offset to entry"
 msgstr "offset scorretto per il file nell'archivio ZIP"
 
-#: ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400
 msgid "binary"
 msgstr "binario"
 
-#: ../src/common/fontcmn.cpp:996
+#: ../src/common/fontcmn.cpp:1195
 msgid "bold"
 msgstr "grassetto"
 
-#: ../src/msw/utils.cpp:1144
+#: ../src/msw/utils.cpp:1135
 #, c-format
 msgid "build %lu"
 msgstr "build %lu"
 
-#: ../src/common/ffile.cpp:75
+#: ../src/common/ffile.cpp:73
 #, c-format
 msgid "can't close file '%s'"
 msgstr "impossibile chiudere il file '%s'"
 
-#: ../src/common/file.cpp:245
+#: ../src/common/file.cpp:242
 #, c-format
 msgid "can't close file descriptor %d"
 msgstr "impossibile chiudere il descrittore di file %d"
 
-#: ../src/common/file.cpp:586
+#: ../src/common/ffile.cpp:382 ../src/common/file.cpp:613
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "impossibile applicare i cambiamenti al file '%s'"
 
-#: ../src/common/file.cpp:178
+#: ../src/common/file.cpp:175
 #, c-format
 msgid "can't create file '%s'"
 msgstr "impossibile creare il file '%s'"
@@ -8161,54 +8351,54 @@ msgstr "impossibile creare il file '%s'"
 msgid "can't delete user configuration file '%s'"
 msgstr "impossibile eliminare il file di configurazione utente '%s'"
 
-#: ../src/common/file.cpp:495
+#: ../src/common/file.cpp:522
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr ""
 "impossibile determinare se il descrittore di file %d ha raggiunto la fine "
 "del file"
 
-#: ../src/common/zipstrm.cpp:1692
+#: ../src/common/zipstrm.cpp:1747
 msgid "can't find central directory in zip"
 msgstr "impossibile trovare il catalogo all'interno del file ZIP"
 
-#: ../src/common/file.cpp:465
+#: ../src/common/file.cpp:492
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "impossibile determinare la dimensione del file del descritore %d"
 
-#: ../src/msw/utils.cpp:341
+#: ../src/msw/utils.cpp:336
 msgid "can't find user's HOME, using current directory."
 msgstr ""
 "impossibile trovare la HOME dell'utente, viene impiegata la cartella "
 "corrente."
 
-#: ../src/common/file.cpp:366
+#: ../src/common/file.cpp:407
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "impossibile forzare la scrittura su disco del descrittore di file %d"
 
-#: ../src/common/file.cpp:422
+#: ../src/common/file.cpp:463
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr ""
 "impossibile determinare la posizione corrente del descrittore di file %d"
 
-#: ../src/common/fontmap.cpp:325
+#: ../src/common/fontmap.cpp:322
 msgid "can't load any font, aborting"
 msgstr "impossibile caricare un qualunque tipo di carattere, abbandono"
 
-#: ../src/common/file.cpp:231 ../src/common/ffile.cpp:59
+#: ../src/common/ffile.cpp:57 ../src/common/file.cpp:228
 #, c-format
 msgid "can't open file '%s'"
 msgstr "impossibile aprire il file '%s'"
 
-#: ../src/common/fileconf.cpp:320
+#: ../src/common/fileconf.cpp:314
 #, c-format
 msgid "can't open global configuration file '%s'."
 msgstr "impossibile aprire il file globale di configurazione '%s'."
 
-#: ../src/common/fileconf.cpp:336
+#: ../src/common/fileconf.cpp:330
 #, c-format
 msgid "can't open user configuration file '%s'."
 msgstr "impossibile aprire il file di configurazione utente '%s'."
@@ -8217,40 +8407,40 @@ msgstr "impossibile aprire il file di configurazione utente '%s'."
 msgid "can't open user configuration file."
 msgstr "impossibile aprire il file di configurazione utente."
 
-#: ../src/common/zipstrm.cpp:579
+#: ../src/common/zipstrm.cpp:572
 msgid "can't re-initialize zlib deflate stream"
 msgstr "impossibile reinizializzare il flusso zlib di compressione"
 
-#: ../src/common/zipstrm.cpp:604
+#: ../src/common/zipstrm.cpp:597
 msgid "can't re-initialize zlib inflate stream"
 msgstr "impossibile reinizializzare il flusso di decompressione zlib"
 
-#: ../src/common/file.cpp:304
+#: ../src/common/file.cpp:345
 #, c-format
 msgid "can't read from file descriptor %d"
 msgstr "impossibile leggere dal descrittore di file %d"
 
-#: ../src/common/file.cpp:581
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:608
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "impossibile eliminare il file '%s'"
 
-#: ../src/common/file.cpp:598
+#: ../src/common/ffile.cpp:394 ../src/common/file.cpp:625
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "impossibile eliminare il file temporaneo '%s'"
 
-#: ../src/common/file.cpp:408
+#: ../src/common/file.cpp:449
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "impossibile eseguire una seek sul descrittore di file %d"
 
-#: ../src/common/textfile.cpp:273
+#: ../src/common/textfile.cpp:161
 #, c-format
 msgid "can't write buffer '%s' to disk."
 msgstr "impossibile scrivere su disco il buffer '%s'."
 
-#: ../src/common/file.cpp:323
+#: ../src/common/file.cpp:364
 #, c-format
 msgid "can't write to file descriptor %d"
 msgstr "impossibile scrivere sul descrittore di file %d"
@@ -8260,22 +8450,28 @@ msgid "can't write user configuration file."
 msgstr "impossibile scrivere il file di configurazione utente."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:482 ../src/generic/datavgen.cpp:1261
+#: ../src/common/datavcmn.cpp:2064 ../src/generic/datavgen.cpp:1384
 msgid "checked"
 msgstr "verificato"
 
-#: ../src/html/chm.cpp:345
+#: ../src/html/chm.cpp:342
 msgid "checksum error"
 msgstr "errore checksum"
 
-#: ../src/common/tarstrm.cpp:820
+#: ../src/common/tarstrm.cpp:814
 msgid "checksum failure reading tar header block"
 msgstr "checksum errato durante la lettura dell'intestazione del file TAR"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:226
-#: ../src/richtext/richtextbackgroundpage.cpp:249
-#: ../src/richtext/richtextbackgroundpage.cpp:289
-#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
 #: ../src/richtext/richtextborderspage.cpp:254
 #: ../src/richtext/richtextborderspage.cpp:288
 #: ../src/richtext/richtextborderspage.cpp:322
@@ -8293,104 +8489,128 @@ msgstr "checksum errato durante la lettura dell'intestazione del file TAR"
 #: ../src/richtext/richtextmarginspage.cpp:340
 #: ../src/richtext/richtextmarginspage.cpp:363
 #: ../src/richtext/richtextmarginspage.cpp:388
-#: ../src/richtext/richtextsizepage.cpp:339
-#: ../src/richtext/richtextsizepage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:400
-#: ../src/richtext/richtextsizepage.cpp:427
-#: ../src/richtext/richtextsizepage.cpp:454
-#: ../src/richtext/richtextsizepage.cpp:481
-#: ../src/richtext/richtextsizepage.cpp:555
-#: ../src/richtext/richtextsizepage.cpp:590
-#: ../src/richtext/richtextsizepage.cpp:625
-#: ../src/richtext/richtextsizepage.cpp:660
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
 msgid "cm"
 msgstr "cm"
 
-#: ../src/html/chm.cpp:347
+#: ../src/html/chm.cpp:344
 msgid "compression error"
 msgstr "errore di compressione"
 
-#: ../src/common/regex.cpp:236
+#: ../src/common/regex.cpp:233
 msgid "conversion to 8-bit encoding failed"
 msgstr "la conversione in una codifica ad 8 bit è fallita"
 
-#: ../src/common/accelcmn.cpp:187
+#: ../src/common/accelcmn.cpp:186
 msgid "ctrl"
 msgstr "ctrl"
 
-#: ../src/common/cmdline.cpp:1500
+#: ../src/common/cmdline.cpp:1496
 msgid "date"
 msgstr "data"
 
-#: ../src/html/chm.cpp:349
+#: ../src/html/chm.cpp:346
 msgid "decompression error"
 msgstr "errore di decompressione"
 
-#: ../src/richtext/richtextstyles.cpp:780 ../src/common/fmapbase.cpp:820
+#: ../src/common/fmapbase.cpp:816 ../src/richtext/richtextstyles.cpp:777
 msgid "default"
 msgstr "predefinito"
 
-#: ../src/common/cmdline.cpp:1496
+#: ../src/common/cmdline.cpp:1492
 msgid "double"
 msgstr "doppio"
 
-#: ../src/common/debugrpt.cpp:538
+#: ../src/common/debugrpt.cpp:539
 msgid "dump of the process state (binary)"
 msgstr "dump dello stato del programma (binario)"
 
-#: ../src/common/datetimefmt.cpp:1969
+#: ../src/common/datetimefmt.cpp:1992
 msgid "eighteenth"
 msgstr "diciotto"
 
-#: ../src/common/datetimefmt.cpp:1959
+#: ../src/common/datetimefmt.cpp:1982
 msgid "eighth"
 msgstr "otto"
 
-#: ../src/common/datetimefmt.cpp:1962
+#: ../src/common/datetimefmt.cpp:1985
 msgid "eleventh"
 msgstr "undici"
 
-#: ../src/common/fileconf.cpp:1833
+#: ../src/common/fileconf.cpp:1835
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "la voce '%s' è presente più volte nel gruppo '%s'"
 
-#: ../src/html/chm.cpp:343
+#: ../src/html/chm.cpp:340
 msgid "error in data format"
 msgstr "errore nel formato dei dati"
 
-#: ../src/html/chm.cpp:331
+#: ../src/html/chm.cpp:328
 msgid "error opening file"
 msgstr "errore nell'apertura file"
 
-#: ../src/common/zipstrm.cpp:1778
+#: ../src/common/zipstrm.cpp:1836
 msgid "error reading zip central directory"
 msgstr "errore durante la lettura del catalogo del file ZIP"
 
-#: ../src/common/zipstrm.cpp:1870
+#: ../src/common/zipstrm.cpp:1940
 msgid "error reading zip local header"
 msgstr "errore durante la lettura dell'intestazione ZIP locale"
 
-#: ../src/common/zipstrm.cpp:2531
+#: ../src/common/zipstrm.cpp:2615
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "errore durante la scrittura del file '%s': CRC o lunghezza errati"
 
-#: ../src/common/ffile.cpp:188
+#: ../src/common/zipstrm.cpp:2608
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "errore durante la scrittura del file '%s': CRC o lunghezza errati"
+
+#: ../src/common/fontcmn.cpp:1205
+#, fuzzy
+msgid "extrabold"
+msgstr "grassetto"
+
+#: ../src/common/fontcmn.cpp:1223
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1167
+#, fuzzy
+msgid "extralight"
+msgstr "leggero"
+
+#: ../src/msw/webview_ie.cpp:1036
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "Impossibile eseguire '%s'\n"
+
+#: ../src/common/ffile.cpp:187
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "impossibile forzare la scrittura su disco del file '%s'"
 
+#: ../src/msw/webview_ie.cpp:1045
+#, fuzzy
+msgid "failed to retrieve execution result"
+msgstr ""
+"Impossibile ottenere il testo del messaggio di errore di Accesso Remoto (RAS)"
+
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1030
+#: ../src/generic/datavgen.cpp:1150
 msgid "false"
 msgstr "falso"
 
-#: ../src/common/datetimefmt.cpp:1966
+#: ../src/common/datetimefmt.cpp:1989
 msgid "fifteenth"
 msgstr "quindici"
 
-#: ../src/common/datetimefmt.cpp:1956
+#: ../src/common/datetimefmt.cpp:1979
 msgid "fifth"
 msgstr "cinque"
 
@@ -8420,131 +8640,150 @@ msgstr ""
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "file '%s': carattere %c non atteso alla linea %zu."
 
-#: ../src/richtext/richtextbuffer.cpp:8738
+#: ../src/richtext/richtextbuffer.cpp:8736
 msgid "files"
 msgstr "file"
 
-#: ../src/common/datetimefmt.cpp:1952
+#: ../src/common/datetimefmt.cpp:1975
 msgid "first"
 msgstr "primo"
 
-#: ../src/html/helpwnd.cpp:1252
+#: ../src/html/helpwnd.cpp:1250
 msgid "font size"
 msgstr "corpo"
 
-#: ../src/common/datetimefmt.cpp:1965
+#: ../src/common/datetimefmt.cpp:1988
 msgid "fourteenth"
 msgstr "quattordici"
 
-#: ../src/common/datetimefmt.cpp:1955
+#: ../src/common/datetimefmt.cpp:1978
 msgid "fourth"
 msgstr "quattro"
 
-#: ../src/common/appbase.cpp:783
+#: ../src/common/appbase.cpp:784
 msgid "generate verbose log messages"
 msgstr "genera messaggi registro eventi dettagliati"
 
-#: ../src/richtext/richtextbuffer.cpp:13138
-#: ../src/richtext/richtextbuffer.cpp:13248
+#: ../src/common/fontcmn.cpp:1215
+msgid "heavy"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:13133
+#: ../src/richtext/richtextbuffer.cpp:13243
 msgid "image"
 msgstr "immagine"
 
-#: ../src/common/tarstrm.cpp:796
+#: ../src/common/tarstrm.cpp:790
 msgid "incomplete header block in tar"
 msgstr "blocco di intestazione errato nel file tar"
 
-#: ../src/common/xtixml.cpp:489
+#: ../src/common/xtixml.cpp:485
 msgid "incorrect event handler string, missing dot"
 msgstr "event handler stringa non corretto - manca punto"
 
-#: ../src/common/tarstrm.cpp:1381
+#: ../src/common/tarstrm.cpp:1375
 msgid "incorrect size given for tar entry"
 msgstr "valore della dimensione errato per una voce del file TAR"
 
-#: ../src/common/tarstrm.cpp:993
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:987
 msgid "invalid data in extended tar header"
 msgstr "dati errati nell'intestazione estesa del file TAR"
 
-#: ../src/generic/logg.cpp:1030
+#: ../src/generic/logg.cpp:1027
 msgid "invalid message box return value"
 msgstr "il riquadro di dialogo ha ritornato un valore non valido"
 
-#: ../src/common/zipstrm.cpp:1647
+#: ../src/common/zipstrm.cpp:1688
 msgid "invalid zip file"
 msgstr "file ZIP non valido"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:1228
 msgid "italic"
 msgstr "corsivo"
 
-#: ../src/common/fontcmn.cpp:991
+#: ../src/common/webrequest_curl.cpp:374
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "La descrizione colonna non può essere inzializzata."
+
+#: ../src/common/fontcmn.cpp:1172
 msgid "light"
 msgstr "leggero"
 
-#: ../src/common/intl.cpp:303
-#, c-format
-msgid "locale '%s' cannot be set."
-msgstr "impossibile impostare '%s' locale."
+#: ../src/common/fontcmn.cpp:1185
+msgid "medium"
+msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2125
+#: ../src/common/datetimefmt.cpp:2148
 msgid "midnight"
 msgstr "mezzanotte"
 
-#: ../src/common/datetimefmt.cpp:1970
+#: ../src/common/datetimefmt.cpp:1993
 msgid "nineteenth"
 msgstr "diciannove"
 
-#: ../src/common/datetimefmt.cpp:1960
+#: ../src/common/datetimefmt.cpp:1983
 msgid "ninth"
 msgstr "nove"
 
-#: ../src/msw/dde.cpp:1116
+#: ../src/msw/dde.cpp:1180
 msgid "no DDE error."
 msgstr "nessun errore DDE."
 
-#: ../src/html/chm.cpp:327
+#: ../src/html/chm.cpp:324
 msgid "no error"
 msgstr "nessun errore"
 
-#: ../src/dfb/fontmgr.cpp:174
+#: ../src/dfb/fontmgr.cpp:171
 #, c-format
 msgid "no fonts found in %s, using builtin font"
 msgstr "nessuna font trovata in %s - uso font integrata"
 
-#: ../src/html/helpdata.cpp:657
+#: ../src/html/helpdata.cpp:650
 msgid "noname"
 msgstr "senzanome"
 
-#: ../src/common/datetimefmt.cpp:2124
+#: ../src/common/datetimefmt.cpp:2147
 msgid "noon"
 msgstr "mezzogiorno"
 
-#: ../src/richtext/richtextstyles.cpp:779
+#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "normale"
 
-#: ../src/common/cmdline.cpp:1492
+#: ../src/common/cmdline.cpp:1488
 msgid "num"
 msgstr "num"
 
-#: ../src/common/xtixml.cpp:259
+#: ../src/common/accelcmn.cpp:194
+msgid "num "
+msgstr ""
+
+#: ../src/common/xtixml.cpp:255
 msgid "objects cannot have XML Text Nodes"
 msgstr "l'oggetto non può avere nodi XML Text"
 
-#: ../src/html/chm.cpp:339
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
 msgid "out of memory"
 msgstr "memoria insufficiente"
 
-#: ../src/common/debugrpt.cpp:514
+#: ../src/common/debugrpt.cpp:515
 msgid "process context description"
 msgstr "descrizione del contesto del programma"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:227
-#: ../src/richtext/richtextbackgroundpage.cpp:250
-#: ../src/richtext/richtextbackgroundpage.cpp:290
-#: ../src/richtext/richtextbackgroundpage.cpp:317
-#: ../src/richtext/richtextfontpage.cpp:177
-#: ../src/richtext/richtextfontpage.cpp:180
 #: ../src/richtext/richtextborderspage.cpp:255
 #: ../src/richtext/richtextborderspage.cpp:289
 #: ../src/richtext/richtextborderspage.cpp:323
@@ -8554,22 +8793,45 @@ msgstr "descrizione del contesto del programma"
 #: ../src/richtext/richtextborderspage.cpp:491
 #: ../src/richtext/richtextborderspage.cpp:525
 #: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextfontpage.cpp:180
 msgid "pt"
 msgstr "pt"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:225
-#: ../src/richtext/richtextbackgroundpage.cpp:228
-#: ../src/richtext/richtextbackgroundpage.cpp:229
-#: ../src/richtext/richtextbackgroundpage.cpp:248
-#: ../src/richtext/richtextbackgroundpage.cpp:251
-#: ../src/richtext/richtextbackgroundpage.cpp:252
-#: ../src/richtext/richtextbackgroundpage.cpp:288
-#: ../src/richtext/richtextbackgroundpage.cpp:291
-#: ../src/richtext/richtextbackgroundpage.cpp:292
-#: ../src/richtext/richtextbackgroundpage.cpp:315
-#: ../src/richtext/richtextbackgroundpage.cpp:318
-#: ../src/richtext/richtextbackgroundpage.cpp:319
-#: ../src/richtext/richtextfontpage.cpp:178
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:659
+#: ../src/richtext/richtextsizepage.cpp:662
+#: ../src/richtext/richtextsizepage.cpp:663
 #: ../src/richtext/richtextborderspage.cpp:253
 #: ../src/richtext/richtextborderspage.cpp:256
 #: ../src/richtext/richtextborderspage.cpp:257
@@ -8621,260 +8883,270 @@ msgstr "pt"
 #: ../src/richtext/richtextmarginspage.cpp:387
 #: ../src/richtext/richtextmarginspage.cpp:389
 #: ../src/richtext/richtextmarginspage.cpp:390
-#: ../src/richtext/richtextsizepage.cpp:338
-#: ../src/richtext/richtextsizepage.cpp:341
-#: ../src/richtext/richtextsizepage.cpp:342
-#: ../src/richtext/richtextsizepage.cpp:372
-#: ../src/richtext/richtextsizepage.cpp:375
-#: ../src/richtext/richtextsizepage.cpp:376
-#: ../src/richtext/richtextsizepage.cpp:399
-#: ../src/richtext/richtextsizepage.cpp:402
-#: ../src/richtext/richtextsizepage.cpp:403
-#: ../src/richtext/richtextsizepage.cpp:426
-#: ../src/richtext/richtextsizepage.cpp:429
-#: ../src/richtext/richtextsizepage.cpp:430
-#: ../src/richtext/richtextsizepage.cpp:453
-#: ../src/richtext/richtextsizepage.cpp:456
-#: ../src/richtext/richtextsizepage.cpp:457
-#: ../src/richtext/richtextsizepage.cpp:480
-#: ../src/richtext/richtextsizepage.cpp:483
-#: ../src/richtext/richtextsizepage.cpp:484
-#: ../src/richtext/richtextsizepage.cpp:554
-#: ../src/richtext/richtextsizepage.cpp:557
-#: ../src/richtext/richtextsizepage.cpp:558
-#: ../src/richtext/richtextsizepage.cpp:589
-#: ../src/richtext/richtextsizepage.cpp:592
-#: ../src/richtext/richtextsizepage.cpp:593
-#: ../src/richtext/richtextsizepage.cpp:624
-#: ../src/richtext/richtextsizepage.cpp:627
-#: ../src/richtext/richtextsizepage.cpp:628
-#: ../src/richtext/richtextsizepage.cpp:659
-#: ../src/richtext/richtextsizepage.cpp:662
-#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextfontpage.cpp:178
 msgid "px"
 msgstr "px"
 
-#: ../src/common/accelcmn.cpp:193
+#: ../src/common/accelcmn.cpp:192
 msgid "rawctrl"
 msgstr "controllo raw"
 
-#: ../src/html/chm.cpp:333
+#: ../src/html/chm.cpp:330
 msgid "read error"
 msgstr "errore di lettura"
 
-#: ../src/common/zipstrm.cpp:2085
+#: ../src/common/zipstrm.cpp:2155
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "lettura stream zip (elemento %s): CRC errato"
 
-#: ../src/common/zipstrm.cpp:2080
+#: ../src/common/zipstrm.cpp:2150
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "lunghezza errata durante la lettura del file %s dal file ZIP"
 
-#: ../src/msw/dde.cpp:1159
+#: ../src/msw/dde.cpp:1223
 msgid "reentrancy problem."
 msgstr "problema di rientranza."
 
-#: ../src/common/datetimefmt.cpp:1953
+#: ../src/common/datetimefmt.cpp:1976
 msgid "second"
 msgstr "due"
 
-#: ../src/html/chm.cpp:337
+#: ../src/html/chm.cpp:334
 msgid "seek error"
 msgstr "errore nel riposizionamento"
 
-#: ../src/common/datetimefmt.cpp:1968
+#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#, fuzzy
+msgid "semibold"
+msgstr "grassetto"
+
+#: ../src/common/datetimefmt.cpp:1991
 msgid "seventeenth"
 msgstr "diciassette"
 
-#: ../src/common/datetimefmt.cpp:1958
+#: ../src/common/datetimefmt.cpp:1981
 msgid "seventh"
 msgstr "sette"
 
-#: ../src/common/accelcmn.cpp:191
+#: ../src/common/accelcmn.cpp:190
 msgid "shift"
 msgstr "maiusc"
 
-#: ../src/common/appbase.cpp:773
+#: ../src/common/appbase.cpp:774
 msgid "show this help message"
 msgstr "visualizza questo messaggio di aiuto"
 
-#: ../src/common/datetimefmt.cpp:1967
+#: ../src/common/datetimefmt.cpp:1990
 msgid "sixteenth"
 msgstr "sedici"
 
-#: ../src/common/datetimefmt.cpp:1957
+#: ../src/common/datetimefmt.cpp:1980
 msgid "sixth"
 msgstr "sei"
 
-#: ../src/common/appcmn.cpp:234
+#: ../src/common/appcmn.cpp:255
 msgid "specify display mode to use (e.g. 640x480-16)"
 msgstr "specifica la modalità video da utilizzare (es. 640x480-16)"
 
-#: ../src/common/appcmn.cpp:220
+#: ../src/common/appcmn.cpp:241
 msgid "specify the theme to use"
 msgstr "specifica il tema da utilizzare"
 
-#: ../src/richtext/richtextbuffer.cpp:9340
+#: ../src/richtext/richtextbuffer.cpp:9337
 msgid "standard/circle"
 msgstr "standard/cerchio"
 
-#: ../src/richtext/richtextbuffer.cpp:9341
+#: ../src/richtext/richtextbuffer.cpp:9338
 msgid "standard/circle-outline"
 msgstr "standard/cerchio con contorno"
 
-#: ../src/richtext/richtextbuffer.cpp:9343
+#: ../src/richtext/richtextbuffer.cpp:9340
 msgid "standard/diamond"
 msgstr "standard/diamante"
 
-#: ../src/richtext/richtextbuffer.cpp:9342
+#: ../src/richtext/richtextbuffer.cpp:9339
 msgid "standard/square"
 msgstr "standard/quadrato"
 
-#: ../src/richtext/richtextbuffer.cpp:9344
+#: ../src/richtext/richtextbuffer.cpp:9341
 msgid "standard/triangle"
 msgstr "standard/triangolo"
 
-#: ../src/common/zipstrm.cpp:1985
+#: ../src/common/zipstrm.cpp:2055
 msgid "stored file length not in Zip header"
 msgstr "la lunghezza del file non è memorizzata nell'intestazione del file ZIP"
 
-#: ../src/common/cmdline.cpp:1488
+#: ../src/common/cmdline.cpp:1484
 msgid "str"
 msgstr "str"
 
-#: ../src/common/fontcmn.cpp:982
+#: ../src/common/fontcmn.cpp:1145
 msgid "strikethrough"
 msgstr "barrato"
 
-#: ../src/common/tarstrm.cpp:1003 ../src/common/tarstrm.cpp:1025
-#: ../src/common/tarstrm.cpp:1507 ../src/common/tarstrm.cpp:1529
+#: ../src/common/tarstrm.cpp:997 ../src/common/tarstrm.cpp:1019
+#: ../src/common/tarstrm.cpp:1501 ../src/common/tarstrm.cpp:1523
 msgid "tar entry not open"
 msgstr "voce del file TAR non aperta"
 
-#: ../src/common/datetimefmt.cpp:1961
+#: ../src/common/datetimefmt.cpp:1984
 msgid "tenth"
 msgstr "dieci"
 
-#: ../src/msw/dde.cpp:1123
+#: ../src/msw/dde.cpp:1187
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr ""
 "la risposta alla transazione ha causato l'impostazione del bit DDE_FBUSY."
 
-#: ../src/common/datetimefmt.cpp:1954
+#: ../src/common/fontcmn.cpp:1154
+msgid "thin"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:1977
 msgid "third"
 msgstr "tre"
 
-#: ../src/common/datetimefmt.cpp:1964
+#: ../src/common/datetimefmt.cpp:1987
 msgid "thirteenth"
 msgstr "tredici"
 
-#: ../src/common/datetimefmt.cpp:1758
+#: ../src/common/datetimefmt.cpp:1781
 msgid "today"
 msgstr "oggi"
 
-#: ../src/common/datetimefmt.cpp:1760
+#: ../src/common/datetimefmt.cpp:1783
 msgid "tomorrow"
 msgstr "domani"
 
-#: ../src/common/fileconf.cpp:1944
+#: ../src/common/fileconf.cpp:1946
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "barra retroversa finale ignorata in '%s'"
 
-#: ../src/gtk/aboutdlg.cpp:218
+#: ../src/gtk/aboutdlg.cpp:216
 msgid "translator-credits"
 msgstr "ringraziamenti-traduttore"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1028
+#: ../src/generic/datavgen.cpp:1148
 msgid "true"
 msgstr "vero"
 
-#: ../src/common/datetimefmt.cpp:1963
+#: ../src/common/datetimefmt.cpp:1986
 msgid "twelfth"
 msgstr "dodici"
 
-#: ../src/common/datetimefmt.cpp:1971
+#: ../src/common/datetimefmt.cpp:1994
 msgid "twentieth"
 msgstr "venti"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:486 ../src/generic/datavgen.cpp:1263
+#: ../src/common/datavcmn.cpp:2068 ../src/generic/datavgen.cpp:1386
 msgid "unchecked"
 msgstr "non verificato"
 
-#: ../src/common/fontcmn.cpp:802 ../src/common/fontcmn.cpp:978
+#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
 msgid "underlined"
 msgstr "sottolineato"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:490
+#: ../src/common/datavcmn.cpp:2072
 msgid "undetermined"
 msgstr "non determinato"
 
-#: ../src/common/fileconf.cpp:1979
+#: ../src/common/fileconf.cpp:1981
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "\" non atteso alla posizione %d in '%s'."
 
-#: ../src/common/tarstrm.cpp:1045
+#: ../src/common/tarstrm.cpp:1039
 msgid "unexpected end of file"
 msgstr "fine del file non attesa"
 
-#: ../src/generic/progdlgg.cpp:370 ../src/common/tarstrm.cpp:371
-#: ../src/common/tarstrm.cpp:394 ../src/common/tarstrm.cpp:425
+#: ../src/common/tarstrm.cpp:366 ../src/common/tarstrm.cpp:389
+#: ../src/common/tarstrm.cpp:420 ../src/generic/progdlgg.cpp:376
 msgid "unknown"
 msgstr "sconosciuto"
 
-#: ../src/msw/registry.cpp:150
+#: ../src/msw/registry.cpp:139
 #, c-format
 msgid "unknown (%lu)"
 msgstr "sconosciuto (%lu)"
 
-#: ../src/common/xtixml.cpp:253
+#: ../src/common/xtixml.cpp:249
 #, c-format
 msgid "unknown class %s"
 msgstr "classe %s sconosciuta"
 
-#: ../src/common/regex.cpp:258 ../src/html/chm.cpp:351
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "errore di compressione"
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "errore di decompressione"
+
+#: ../src/common/regex.cpp:255 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "errore sconosciuto"
 
-#: ../src/msw/dialup.cpp:471
+#: ../src/msw/dialup.cpp:465
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "errore sconosciuto (codice %08x)."
 
-#: ../src/common/fmapbase.cpp:834
+#: ../src/common/fmapbase.cpp:830
 #, c-format
 msgid "unknown-%d"
 msgstr "sconosciuto-%d"
 
-#: ../src/common/docview.cpp:509
+#: ../src/common/docview.cpp:502
 msgid "unnamed"
 msgstr "senzanome"
 
-#: ../src/common/docview.cpp:1624
+#: ../src/common/docview.cpp:1618
 #, c-format
 msgid "unnamed%d"
 msgstr "senzanome%d"
 
-#: ../src/common/zipstrm.cpp:1999 ../src/common/zipstrm.cpp:2319
+#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
 msgid "unsupported Zip compression method"
 msgstr "metodo di compressione non supportato per il file ZIP"
 
-#: ../src/common/translation.cpp:1892
+#: ../src/common/translation.cpp:1942
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "utilizzato catalogo '%s' in '%s'."
 
-#: ../src/html/chm.cpp:335
+#: ../src/html/chm.cpp:332
 msgid "write error"
 msgstr "errore di scrittura"
 
-#: ../src/common/time.cpp:292
+#: ../src/gtk/glcanvas.cpp:187
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/common/time.cpp:285
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay fallita."
 
@@ -8887,15 +9159,15 @@ msgstr "wxWidgets non può aprire il display per '%s': abbandona."
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets non può aprire il display. Abbandona."
 
-#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:431
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/common/datetimefmt.cpp:1759
+#: ../src/common/datetimefmt.cpp:1782
 msgid "yesterday"
 msgstr "ieri"
 
-#: ../src/common/zstream.cpp:251 ../src/common/zstream.cpp:426
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
 #, c-format
 msgid "zlib error %d"
 msgstr "errore zlib %d"
@@ -8904,6 +9176,78 @@ msgstr "errore zlib %d"
 #: ../src/richtext/richtextbulletspage.cpp:288
 msgid "~"
 msgstr "~"
+
+#~ msgid " (while overwriting an existing item)"
+#~ msgstr " (mentre viene sovrascritto un elemento esistente)"
+
+#~ msgid "&Save as"
+#~ msgstr "&Salva come"
+
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' non consiste solo in caratteri validi"
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' deve essere numerico."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' deve contenere unicamente caratteri ASCII."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' deve contenere unicamente caratteri alfabetici."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' deve contenere unicamente caratteri alfabetici o numerici."
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' deve contenere unicamente numeri."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "Impossibile creare una finestra di classe %s"
+
+#~ msgid "Could not initalize libnotify."
+#~ msgstr "Impossibile impostare allineamento."
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "Impossibile creare la finestra di overlay"
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "Impossibile inizializzare il contesto della finestra di overlay"
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "Impossibile convertire il file \"%s\" in Unicode."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "Impossibile impostare il testo nella casella di testo."
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr "Opzione non valida linea di comando GTK, usare \"%s --help\""
+
+#~ msgid "No unused colour in image."
+#~ msgstr "Nessun colore inutilizzato nell'immagine."
+
+#~ msgid "Not available"
+#~ msgstr "Non disponibile"
+
+#~ msgid "Replace selection"
+#~ msgstr "Sostituisci la selezione"
+
+#~ msgid "Save as"
+#~ msgstr "Salva come"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Gestore degli stili"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "Sono inoltre supportate le seguenti opzioni standard GTK+:\n"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "Impossibile richiamare Clear su un overlay non inizializzato"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "Impossibile richiamare Init due volte sullo stesso overlay"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "impossibile impostare '%s' locale."
 
 #~ msgid "Adding flavor TEXT failed"
 #~ msgstr "Aggiunta TESTO fallita"
@@ -8922,9 +9266,6 @@ msgstr "~"
 
 #~ msgid "Column could not be added."
 #~ msgstr "la colonna non può essere aggiunta."
-
-#~ msgid "Column description could not be initialized."
-#~ msgstr "La descrizione colonna non può essere inzializzata."
 
 #~ msgid "Column index not found."
 #~ msgstr "Indice colonna non trovato."
@@ -9516,9 +9857,6 @@ msgstr "~"
 #~ msgid "Directory '%s' doesn't exist!"
 #~ msgstr "La cartella '%s' non esiste!"
 
-#~ msgid "File %s does not exist."
-#~ msgstr "Il file %s non esiste."
-
 #~ msgid "Mode %ix%i-%i not available."
 #~ msgstr "Modalità video %ix%i-%i  non disponibile."
 
@@ -9724,9 +10062,6 @@ msgstr "~"
 
 #~ msgid "Failed to register OpenGL window class."
 #~ msgstr "Impossibile inizializzare la window class OpenGL."
-
-#~ msgid "Fatal error"
-#~ msgstr "Errore Fatale"
 
 #~ msgid "Fatal error: "
 #~ msgstr "Errore fatale: "

--- a/locale/ja.po
+++ b/locale/ja.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-21 14:25+0200\n"
+"POT-Creation-Date: 2020-10-18 23:11+0300\n"
 "PO-Revision-Date: 2011-03-02 18:30+0900\n"
 "Last-Translator: Suzumizaki-Kimitaka(鈴見咲君高) <suzumizaki@free."
 "japandesign.ne.jp>\n"
@@ -14,7 +14,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: ../src/common/debugrpt.cpp:586
+#: ../src/common/debugrpt.cpp:587
 msgid ""
 "\n"
 "Please send this report to the program maintainer, thank you!\n"
@@ -22,8 +22,8 @@ msgstr ""
 "\n"
 "お手数ですがこのレポートをプログラムの保守担当者に送信ください。\n"
 
-#: ../src/richtext/richtextstyledlg.cpp:210
-#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:206
+#: ../src/richtext/richtextstyledlg.cpp:218
 msgid " "
 msgstr " "
 
@@ -31,70 +31,96 @@ msgstr " "
 msgid "              Thank you and we're sorry for the inconvenience!\n"
 msgstr "              ご不便をおかけして申し訳ございません。\n"
 
-#: ../src/common/prntbase.cpp:573
+#: ../src/common/prntbase.cpp:568
 #, fuzzy, c-format
 msgid " (copy %d of %d)"
 msgstr "%dページ (%dページ中)"
 
-#: ../src/common/log.cpp:421
+#: ../src/common/log.cpp:440
 #, c-format
 msgid " (error %ld: %s)"
 msgstr " (エラー %ld: %s)"
 
-#: ../src/common/imagtiff.cpp:72
+#: ../src/common/imagtiff.cpp:69
 #, c-format
 msgid " (in module \"%s\")"
 msgstr "(モジュール \"%s\")"
 
-#: ../src/osx/core/secretstore.cpp:138
-msgid " (while overwriting an existing item)"
-msgstr ""
-
-#: ../src/common/docview.cpp:1642
+#: ../src/common/docview.cpp:1636
 msgid " - "
 msgstr " - "
 
-#: ../src/richtext/richtextprint.cpp:593 ../src/html/htmprint.cpp:714
+#: ../src/html/htmprint.cpp:712 ../src/richtext/richtextprint.cpp:589
 msgid " Preview"
 msgstr " プレビュー"
 
-#: ../src/common/fontcmn.cpp:824
+#: ../src/common/fontcmn.cpp:973
 msgid " bold"
 msgstr " 太字"
 
-#: ../src/common/fontcmn.cpp:840
+#: ../src/common/fontcmn.cpp:977
+#, fuzzy
+msgid " extra bold"
+msgstr " 太字"
+
+#: ../src/common/fontcmn.cpp:985
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:957
+#, fuzzy
+msgid " extra light"
+msgstr " 軽量"
+
+#: ../src/common/fontcmn.cpp:981
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1001
 msgid " italic"
 msgstr " イタリック"
 
-#: ../src/common/fontcmn.cpp:820
+#: ../src/common/fontcmn.cpp:961
 msgid " light"
 msgstr " 軽量"
 
-#: ../src/common/fontcmn.cpp:807
+#: ../src/common/fontcmn.cpp:965
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:969
+#, fuzzy
+msgid " semi bold"
+msgstr " 太字"
+
+#: ../src/common/fontcmn.cpp:940
 msgid " strikethrough"
 msgstr " 打ち消し線"
 
-#: ../src/common/paper.cpp:117
+#: ../src/common/fontcmn.cpp:953
+msgid " thin"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
 msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
 msgstr "#10 封筒, 4 1/8 x 9 1/2 インチ"
 
-#: ../src/common/paper.cpp:118
+#: ../src/common/paper.cpp:115
 msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
 msgstr "#11 封筒, 4 1/2 x 10 3/8 インチ"
 
-#: ../src/common/paper.cpp:119
+#: ../src/common/paper.cpp:116
 msgid "#12 Envelope, 4 3/4 x 11 in"
 msgstr "#12 封筒, 4 3/4 x 11 インチ"
 
-#: ../src/common/paper.cpp:120
+#: ../src/common/paper.cpp:117
 msgid "#14 Envelope, 5 x 11 1/2 in"
 msgstr "#14 封筒, 5 x 11 1/2 インチ"
 
-#: ../src/common/paper.cpp:116
+#: ../src/common/paper.cpp:113
 msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
 msgstr "#9 封筒, 3 7/8 x 8 7/8 インチ"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:341
 #: ../src/richtext/richtextsizepage.cpp:340
 #: ../src/richtext/richtextsizepage.cpp:374
 #: ../src/richtext/richtextsizepage.cpp:401
@@ -105,81 +131,82 @@ msgstr "#9 封筒, 3 7/8 x 8 7/8 インチ"
 #: ../src/richtext/richtextsizepage.cpp:591
 #: ../src/richtext/richtextsizepage.cpp:626
 #: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextbackgroundpage.cpp:341
 #, fuzzy
 msgid "%"
 msgstr "%s"
 
-#: ../src/html/helpwnd.cpp:1031
+#: ../src/html/helpwnd.cpp:1029
 #, fuzzy, c-format
 msgid "%d of %lu"
 msgstr "%i / %i"
 
-#: ../src/html/helpwnd.cpp:1678
+#: ../src/html/helpwnd.cpp:1676
 #, fuzzy, c-format
 msgid "%i of %u"
 msgstr "%i / %i"
 
-#: ../src/generic/filectrlg.cpp:279
+#: ../src/generic/filectrlg.cpp:275
 #, c-format
 msgid "%ld byte"
 msgid_plural "%ld bytes"
 msgstr[0] "%ld バイト"
 
-#: ../src/html/helpwnd.cpp:1033
+#: ../src/html/helpwnd.cpp:1031
 #, fuzzy, c-format
 msgid "%lu of %lu"
 msgstr "%i / %i"
 
-#: ../src/generic/datavgen.cpp:6028
+#: ../src/generic/datavgen.cpp:6833
 #, fuzzy, c-format
 msgid "%s (%d items)"
 msgstr "%s (または %s)"
 
-#: ../src/common/cmdline.cpp:1221
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (または %s)"
 
-#: ../src/generic/logg.cpp:224
+#: ../src/generic/logg.cpp:221
 #, c-format
 msgid "%s Error"
 msgstr "%s エラー"
 
-#: ../src/generic/logg.cpp:236
+#: ../src/generic/logg.cpp:233
 #, c-format
 msgid "%s Information"
 msgstr "%s 情報"
 
-#: ../src/generic/preferencesg.cpp:113
+#: ../src/generic/preferencesg.cpp:110
 #, fuzzy, c-format
 msgid "%s Preferences"
 msgstr "設定 (&P)"
 
-#: ../src/generic/logg.cpp:228
+#: ../src/generic/logg.cpp:225
 #, c-format
 msgid "%s Warning"
 msgstr "%s 警告"
 
-#: ../src/common/tarstrm.cpp:1319
+#: ../src/common/tarstrm.cpp:1313
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s は tar のヘッダとして認識できませんでした '%s'"
 
-#: ../src/common/fldlgcmn.cpp:124
+#: ../src/common/fldlgcmn.cpp:121
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s 形式 (%s)|%s"
 
-#: ../src/html/helpwnd.cpp:1716
+#: ../src/html/helpwnd.cpp:1714
 #, fuzzy, c-format
 msgid "%u of %u"
 msgstr "%i / %i"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "&About"
 msgstr "詳細 (&A)"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "&Actual Size"
 msgstr "原寸 (&A)"
 
@@ -187,28 +214,28 @@ msgstr "原寸 (&A)"
 msgid "&After a paragraph:"
 msgstr "段落の後 (&A):"
 
-#: ../src/richtext/richtextindentspage.cpp:128
 #: ../src/richtext/richtextliststylepage.cpp:319
+#: ../src/richtext/richtextindentspage.cpp:128
 msgid "&Alignment"
 msgstr "整列 (&A)"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "&Apply"
 msgstr "適用 (&A)"
 
-#: ../src/richtext/richtextstyledlg.cpp:251
+#: ../src/richtext/richtextstyledlg.cpp:247
 msgid "&Apply Style"
 msgstr "スタイルの適用 (&A)"
 
-#: ../src/msw/mdi.cpp:179
+#: ../src/msw/mdi.cpp:174
 msgid "&Arrange Icons"
 msgstr "アイコンの整列 (&A)"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "&Ascending"
 msgstr "昇順 (&A)"
 
-#: ../src/common/stockitem.cpp:142
+#: ../src/common/stockitem.cpp:139
 msgid "&Back"
 msgstr "戻る (&B)"
 
@@ -228,25 +255,25 @@ msgstr "背景色 (&C):"
 msgid "&Blur distance:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:143
+#: ../src/common/stockitem.cpp:140
 msgid "&Bold"
 msgstr "太字 (&B)"
 
-#: ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141
 msgid "&Bottom"
 msgstr "下端 (&B)"
 
+#: ../src/richtext/richtextsizepage.cpp:637
+#: ../src/richtext/richtextsizepage.cpp:644
 #: ../src/richtext/richtextborderspage.cpp:345
 #: ../src/richtext/richtextborderspage.cpp:513
 #: ../src/richtext/richtextmarginspage.cpp:259
 #: ../src/richtext/richtextmarginspage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:637
-#: ../src/richtext/richtextsizepage.cpp:644
 #, fuzzy
 msgid "&Bottom:"
 msgstr "下端 (&B)"
 
-#: ../include/wx/richtext/richtextbuffer.h:3866
+#: ../include/wx/richtext/richtextbuffer.h:3861
 #, fuzzy
 msgid "&Box"
 msgstr "太字 (&B)"
@@ -256,39 +283,39 @@ msgstr "太字 (&B)"
 msgid "&Bullet style:"
 msgstr "行頭文字のスタイル (&B):"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "&CD-Rom"
 msgstr "CD-ROM (&C)"
 
-#: ../src/generic/wizard.cpp:434 ../src/generic/fontdlgg.cpp:470
-#: ../src/generic/fontdlgg.cpp:489 ../src/osx/carbon/fontdlg.cpp:402
-#: ../src/common/dlgcmn.cpp:279 ../src/common/stockitem.cpp:145
+#: ../src/osx/carbon/fontdlg.cpp:399 ../src/common/stockitem.cpp:142
+#: ../src/generic/wizard.cpp:433 ../src/generic/fontdlgg.cpp:466
+#: ../src/generic/fontdlgg.cpp:485 ../src/osx/cocoa/button.mm:200
 msgid "&Cancel"
 msgstr "キャンセル (&C)"
 
-#: ../src/msw/mdi.cpp:175
+#: ../src/msw/mdi.cpp:170
 msgid "&Cascade"
 msgstr "重ねて表示 (&C)"
 
-#: ../include/wx/richtext/richtextbuffer.h:5960
+#: ../include/wx/richtext/richtextbuffer.h:5955
 #, fuzzy
 msgid "&Cell"
 msgstr "キャンセル (&C)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:439
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "&Character code:"
 msgstr "文字コード (&C):"
 
-#: ../src/common/stockitem.cpp:147
+#: ../src/common/stockitem.cpp:144
 msgid "&Clear"
 msgstr "消去 (&C)"
 
-#: ../src/generic/logg.cpp:516 ../src/common/stockitem.cpp:148
-#: ../src/common/prntbase.cpp:1600 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/stockitem.cpp:145 ../src/common/prntbase.cpp:1625
+#: ../src/univ/themes/win32.cpp:3753 ../src/generic/logg.cpp:513
 msgid "&Close"
 msgstr "閉じる (&C)"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "&Color"
 msgstr "色 (&C)"
 
@@ -296,20 +323,20 @@ msgstr "色 (&C)"
 msgid "&Colour:"
 msgstr "色 (&C):"
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "&Convert"
 msgstr "変換 (&C)"
 
-#: ../src/richtext/richtextctrl.cpp:333 ../src/osx/textctrl_osx.cpp:577
-#: ../src/common/stockitem.cpp:150 ../src/msw/textctrl.cpp:2508
+#: ../src/osx/textctrl_osx.cpp:595 ../src/common/stockitem.cpp:147
+#: ../src/msw/textctrl.cpp:2773 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "コピー (&C)"
 
-#: ../src/generic/hyperlinkg.cpp:156
+#: ../src/generic/hyperlinkg.cpp:153
 msgid "&Copy URL"
 msgstr "URLをコピー (&C)"
 
-#: ../src/common/headerctrlcmn.cpp:306
+#: ../src/common/headerctrlcmn.cpp:304
 msgid "&Customize..."
 msgstr "列の編集 (&C) ..."
 
@@ -317,53 +344,54 @@ msgstr "列の編集 (&C) ..."
 msgid "&Debug report preview:"
 msgstr "デバッグレポートプレビュー (&D):"
 
-#: ../src/richtext/richtexttabspage.cpp:138
-#: ../src/richtext/richtextctrl.cpp:335 ../src/osx/textctrl_osx.cpp:579
-#: ../src/common/stockitem.cpp:152 ../src/msw/textctrl.cpp:2510
+#: ../src/osx/textctrl_osx.cpp:597 ../src/common/stockitem.cpp:149
+#: ../src/msw/textctrl.cpp:2775 ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtextctrl.cpp:334
 msgid "&Delete"
 msgstr "削除 (&D)"
 
-#: ../src/richtext/richtextstyledlg.cpp:269
+#: ../src/richtext/richtextstyledlg.cpp:265
 msgid "&Delete Style..."
 msgstr "スタイルの削除 (&D)..."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "&Descending"
 msgstr "降順 (&D)"
 
-#: ../src/generic/logg.cpp:682
+#: ../src/generic/logg.cpp:679
 msgid "&Details"
 msgstr "詳細 (&D)"
 
-#: ../src/common/stockitem.cpp:153
+#: ../src/common/stockitem.cpp:150
 msgid "&Down"
 msgstr "下(&D)"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "&Edit"
 msgstr "編集(&E)"
 
-#: ../src/richtext/richtextstyledlg.cpp:263
+#: ../src/richtext/richtextstyledlg.cpp:259
 msgid "&Edit Style..."
 msgstr "スタイルの編集 (&E) ..."
 
-#: ../src/common/stockitem.cpp:155
+#: ../src/common/stockitem.cpp:152
 msgid "&Execute"
 msgstr "実行 (&E)"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/common/stockitem.cpp:154
 msgid "&File"
 msgstr "ファイル(&F)"
 
-#: ../src/common/stockitem.cpp:158
-msgid "&Find"
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "&Find..."
 msgstr "検索(&F)"
 
-#: ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:430
 msgid "&Finish"
 msgstr "完了 (&F)"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:156
 msgid "&First"
 msgstr "最初 (&F)"
 
@@ -371,15 +399,15 @@ msgstr "最初 (&F)"
 msgid "&Floating mode:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "&Floppy"
 msgstr "フロッピーディスク (&F)"
 
-#: ../src/common/stockitem.cpp:194
+#: ../src/common/stockitem.cpp:191
 msgid "&Font"
 msgstr "フォント (&F)"
 
-#: ../src/generic/fontdlgg.cpp:371
+#: ../src/generic/fontdlgg.cpp:367
 msgid "&Font family:"
 msgstr "フォントファミリー (&F):"
 
@@ -387,20 +415,20 @@ msgstr "フォントファミリー (&F):"
 msgid "&Font for Level..."
 msgstr "レベル毎のフォント (&F)..."
 
+#: ../src/richtext/richtextsymboldlg.cpp:397
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:400
 msgid "&Font:"
 msgstr "フォント (&F):"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "&Forward"
 msgstr "進行 (&F)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:451
+#: ../src/richtext/richtextsymboldlg.cpp:448
 msgid "&From:"
 msgstr "取得元 (&F):"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "&Harddisk"
 msgstr "ハードディスク (&H)"
 
@@ -410,9 +438,9 @@ msgstr "ハードディスク (&H)"
 msgid "&Height:"
 msgstr "ウエイト (&W):"
 
-#: ../src/generic/wizard.cpp:441 ../src/richtext/richtextstyledlg.cpp:303
-#: ../src/richtext/richtextsymboldlg.cpp:479 ../src/osx/menu_osx.cpp:734
-#: ../src/common/stockitem.cpp:163
+#: ../src/common/stockitem.cpp:160 ../src/generic/wizard.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextstyledlg.cpp:299 ../src/osx/cocoa/menu.mm:226
 msgid "&Help"
 msgstr "ヘルプ (&H)"
 
@@ -421,7 +449,7 @@ msgstr "ヘルプ (&H)"
 msgid "&Hide details"
 msgstr "詳細 (&D)"
 
-#: ../src/common/stockitem.cpp:164
+#: ../src/common/stockitem.cpp:161
 msgid "&Home"
 msgstr "ホーム (&H)"
 
@@ -429,54 +457,54 @@ msgstr "ホーム (&H)"
 msgid "&Horizontal offset:"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:184
 #: ../src/richtext/richtextliststylepage.cpp:372
+#: ../src/richtext/richtextindentspage.cpp:184
 msgid "&Indentation (tenths of a mm)"
 msgstr "字下げ(1/10ミリ単位) (&I)"
 
-#: ../src/richtext/richtextindentspage.cpp:167
 #: ../src/richtext/richtextliststylepage.cpp:356
+#: ../src/richtext/richtextindentspage.cpp:167
 msgid "&Indeterminate"
 msgstr "指定しない (&I)"
 
-#: ../src/common/stockitem.cpp:166
+#: ../src/common/stockitem.cpp:163
 msgid "&Index"
 msgstr "索引 (&I)"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "&Info"
 msgstr "情報 (&I)"
 
-#: ../src/common/stockitem.cpp:168
+#: ../src/common/stockitem.cpp:165
 msgid "&Italic"
 msgstr "イタリック (&I)"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "&Jump to"
 msgstr "移動 (&J)"
 
-#: ../src/richtext/richtextindentspage.cpp:153
 #: ../src/richtext/richtextliststylepage.cpp:342
+#: ../src/richtext/richtextindentspage.cpp:153
 msgid "&Justified"
 msgstr "両端揃え (&J)"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "&Last"
 msgstr "最後 (&L)"
 
-#: ../src/richtext/richtextindentspage.cpp:139
 #: ../src/richtext/richtextliststylepage.cpp:328
+#: ../src/richtext/richtextindentspage.cpp:139
 msgid "&Left"
 msgstr "左 (&L)"
 
-#: ../src/richtext/richtextindentspage.cpp:195
+#: ../src/richtext/richtextsizepage.cpp:532
+#: ../src/richtext/richtextsizepage.cpp:539
 #: ../src/richtext/richtextborderspage.cpp:243
 #: ../src/richtext/richtextborderspage.cpp:411
 #: ../src/richtext/richtextliststylepage.cpp:381
+#: ../src/richtext/richtextindentspage.cpp:195
 #: ../src/richtext/richtextmarginspage.cpp:186
 #: ../src/richtext/richtextmarginspage.cpp:300
-#: ../src/richtext/richtextsizepage.cpp:532
-#: ../src/richtext/richtextsizepage.cpp:539
 msgid "&Left:"
 msgstr "左 (&L):"
 
@@ -484,11 +512,11 @@ msgstr "左 (&L):"
 msgid "&List level:"
 msgstr "リストレベル (&L):"
 
-#: ../src/generic/logg.cpp:517
+#: ../src/generic/logg.cpp:514
 msgid "&Log"
 msgstr "ログ (&L)"
 
-#: ../src/univ/themes/win32.cpp:3748
+#: ../src/univ/themes/win32.cpp:3745
 msgid "&Move"
 msgstr "移動 (&M)"
 
@@ -496,20 +524,19 @@ msgstr "移動 (&M)"
 msgid "&Move the object to:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "&Network"
 msgstr "ネットワーク (&N)"
 
-#: ../src/richtext/richtexttabspage.cpp:132 ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173 ../src/richtext/richtexttabspage.cpp:132
 msgid "&New"
 msgstr "新規作成 (&N)"
 
-#: ../src/aui/tabmdi.cpp:111 ../src/generic/mdig.cpp:100
-#: ../src/msw/mdi.cpp:180
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
 msgid "&Next"
 msgstr "次 (&N)"
 
-#: ../src/generic/wizard.cpp:432 ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:429
 msgid "&Next >"
 msgstr "次へ (&N) >"
 
@@ -518,7 +545,7 @@ msgstr "次へ (&N) >"
 msgid "&Next Paragraph"
 msgstr "段落の後 (&A):"
 
-#: ../src/generic/tipdlg.cpp:240
+#: ../src/generic/tipdlg.cpp:237
 msgid "&Next Tip"
 msgstr "次のチップ (&N)"
 
@@ -526,11 +553,11 @@ msgstr "次のチップ (&N)"
 msgid "&Next style:"
 msgstr "次のスタイル (&N):"
 
-#: ../src/common/stockitem.cpp:177 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:174 ../src/msw/msgdlg.cpp:435
 msgid "&No"
 msgstr "いいえ (&N)"
 
-#: ../src/generic/dbgrptg.cpp:356
+#: ../src/generic/dbgrptg.cpp:360
 msgid "&Notes:"
 msgstr "注意書き (&N):"
 
@@ -538,12 +565,12 @@ msgstr "注意書き (&N):"
 msgid "&Number:"
 msgstr "番号 (&N):"
 
-#: ../src/generic/fontdlgg.cpp:475 ../src/generic/fontdlgg.cpp:482
-#: ../src/osx/carbon/fontdlg.cpp:408 ../src/common/stockitem.cpp:178
+#: ../src/osx/carbon/fontdlg.cpp:405 ../src/common/stockitem.cpp:175
+#: ../src/generic/fontdlgg.cpp:471 ../src/generic/fontdlgg.cpp:478
 msgid "&OK"
 msgstr "OK (&O)"
 
-#: ../src/generic/dbgrptg.cpp:342 ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176 ../src/generic/dbgrptg.cpp:342
 msgid "&Open..."
 msgstr "開く (&O) ..."
 
@@ -555,16 +582,16 @@ msgstr "アウトラインレベル (&O):"
 msgid "&Page Break"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:334 ../src/osx/textctrl_osx.cpp:578
-#: ../src/common/stockitem.cpp:180 ../src/msw/textctrl.cpp:2509
+#: ../src/osx/textctrl_osx.cpp:596 ../src/common/stockitem.cpp:177
+#: ../src/msw/textctrl.cpp:2774 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "貼り付け (&P)"
 
-#: ../include/wx/richtext/richtextbuffer.h:5010
+#: ../include/wx/richtext/richtextbuffer.h:5005
 msgid "&Picture"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:419
 msgid "&Point size:"
 msgstr "大きさ-ポイント (&P):"
 
@@ -577,12 +604,11 @@ msgstr "位置(1/10ミリ単位) (&P)"
 msgid "&Position mode:"
 msgstr "印刷"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178
 msgid "&Preferences"
 msgstr "設定 (&P)"
 
-#: ../src/aui/tabmdi.cpp:112 ../src/generic/mdig.cpp:101
-#: ../src/msw/mdi.cpp:181
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
 msgid "&Previous"
 msgstr "前 (&P)"
 
@@ -591,80 +617,75 @@ msgstr "前 (&P)"
 msgid "&Previous Paragraph"
 msgstr "前のページ"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "&Print..."
 msgstr "印刷 (&P) ..."
 
-#: ../src/richtext/richtextctrl.cpp:339 ../src/richtext/richtextctrl.cpp:5514
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtextctrl.cpp:338
+#: ../src/richtext/richtextctrl.cpp:5512
 msgid "&Properties"
 msgstr "プロパティー (&P)"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "&Quit"
 msgstr "終了 (&Q)"
 
-#: ../src/richtext/richtextctrl.cpp:330 ../src/osx/textctrl_osx.cpp:574
-#: ../src/common/stockitem.cpp:185 ../src/common/cmdproc.cpp:293
-#: ../src/common/cmdproc.cpp:300 ../src/msw/textctrl.cpp:2505
+#: ../src/osx/textctrl_osx.cpp:592 ../src/common/stockitem.cpp:182
+#: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
+#: ../src/msw/textctrl.cpp:2770 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "再実行 (&R)"
 
-#: ../src/common/cmdproc.cpp:289 ../src/common/cmdproc.cpp:309
+#: ../src/common/cmdproc.cpp:282 ../src/common/cmdproc.cpp:302
 msgid "&Redo "
 msgstr "再実行 (&R)"
 
-#: ../src/richtext/richtextstyledlg.cpp:257
+#: ../src/richtext/richtextstyledlg.cpp:253
 msgid "&Rename Style..."
 msgstr "スタイル名を変更 (&R)..."
 
-#: ../src/generic/fdrepdlg.cpp:179
+#: ../src/generic/fdrepdlg.cpp:176
 msgid "&Replace"
 msgstr "置換 (&R)"
 
-#: ../src/richtext/richtextstyledlg.cpp:287
+#: ../src/richtext/richtextstyledlg.cpp:283
 msgid "&Restart numbering"
 msgstr "番号付けのリセット (&R)"
 
-#: ../src/univ/themes/win32.cpp:3747
+#: ../src/univ/themes/win32.cpp:3744
 msgid "&Restore"
 msgstr "復元 (&R)"
 
-#: ../src/richtext/richtextindentspage.cpp:146
 #: ../src/richtext/richtextliststylepage.cpp:335
+#: ../src/richtext/richtextindentspage.cpp:146
 msgid "&Right"
 msgstr "右 (&R)"
 
-#: ../src/richtext/richtextindentspage.cpp:213
+#: ../src/richtext/richtextsizepage.cpp:602
+#: ../src/richtext/richtextsizepage.cpp:609
 #: ../src/richtext/richtextborderspage.cpp:277
 #: ../src/richtext/richtextborderspage.cpp:445
 #: ../src/richtext/richtextliststylepage.cpp:399
+#: ../src/richtext/richtextindentspage.cpp:213
 #: ../src/richtext/richtextmarginspage.cpp:211
 #: ../src/richtext/richtextmarginspage.cpp:325
-#: ../src/richtext/richtextsizepage.cpp:602
-#: ../src/richtext/richtextsizepage.cpp:609
 msgid "&Right:"
 msgstr "右 (&R):"
 
-#: ../src/common/stockitem.cpp:190
+#: ../src/common/stockitem.cpp:187
 msgid "&Save"
 msgstr "保存 (&S)"
-
-#: ../src/common/stockitem.cpp:191
-#, fuzzy
-msgid "&Save as"
-msgstr "Save As"
 
 #: ../include/wx/richmsgdlg.h:29
 #, fuzzy
 msgid "&See details"
 msgstr "詳細 (&D)"
 
-#: ../src/generic/tipdlg.cpp:236
+#: ../src/generic/tipdlg.cpp:233
 msgid "&Show tips at startup"
 msgstr "チップを起動時に表示 (&S)"
 
-#: ../src/univ/themes/win32.cpp:3750
+#: ../src/univ/themes/win32.cpp:3747
 msgid "&Size"
 msgstr "大きさ (&S)"
 
@@ -672,36 +693,36 @@ msgstr "大きさ (&S)"
 msgid "&Size:"
 msgstr "大きさ (&S):"
 
-#: ../src/generic/progdlgg.cpp:252
+#: ../src/generic/progdlgg.cpp:249
 msgid "&Skip"
 msgstr "スキップ (&S)"
 
-#: ../src/richtext/richtextindentspage.cpp:242
 #: ../src/richtext/richtextliststylepage.cpp:417
+#: ../src/richtext/richtextindentspage.cpp:242
 msgid "&Spacing (tenths of a mm)"
 msgstr "間隔 - 1/10mm単位 (&S)"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "&Spell Check"
 msgstr "スペルチェック (&S)"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "&Stop"
 msgstr "停止 (&S)"
 
-#: ../src/richtext/richtextfontpage.cpp:275 ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196 ../src/richtext/richtextfontpage.cpp:275
 msgid "&Strikethrough"
 msgstr "打ち消し線 (&S)"
 
-#: ../src/generic/fontdlgg.cpp:382 ../src/richtext/richtextstylepage.cpp:106
+#: ../src/generic/fontdlgg.cpp:378 ../src/richtext/richtextstylepage.cpp:106
 msgid "&Style:"
 msgstr "スタイル (&S):"
 
-#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:194
 msgid "&Styles:"
 msgstr "スタイル一覧 (&S):"
 
-#: ../src/richtext/richtextsymboldlg.cpp:413
+#: ../src/richtext/richtextsymboldlg.cpp:410
 msgid "&Subset:"
 msgstr "部分表示 (&S):"
 
@@ -715,26 +736,26 @@ msgstr "記号 (&S):"
 msgid "&Synchronize values"
 msgstr ""
 
-#: ../include/wx/richtext/richtextbuffer.h:6069
+#: ../include/wx/richtext/richtextbuffer.h:6064
 #, fuzzy
 msgid "&Table"
 msgstr "タブ"
 
-#: ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197
 msgid "&Top"
 msgstr "上端 (&T)"
 
+#: ../src/richtext/richtextsizepage.cpp:567
+#: ../src/richtext/richtextsizepage.cpp:574
 #: ../src/richtext/richtextborderspage.cpp:311
 #: ../src/richtext/richtextborderspage.cpp:479
 #: ../src/richtext/richtextmarginspage.cpp:234
 #: ../src/richtext/richtextmarginspage.cpp:348
-#: ../src/richtext/richtextsizepage.cpp:567
-#: ../src/richtext/richtextsizepage.cpp:574
 #, fuzzy
 msgid "&Top:"
 msgstr "上端 (&T)"
 
-#: ../src/generic/fontdlgg.cpp:444 ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199 ../src/generic/fontdlgg.cpp:441
 msgid "&Underline"
 msgstr "下線 (&U)"
 
@@ -742,21 +763,21 @@ msgstr "下線 (&U)"
 msgid "&Underlining:"
 msgstr "下線 (&U):"
 
-#: ../src/richtext/richtextctrl.cpp:329 ../src/osx/textctrl_osx.cpp:573
-#: ../src/common/stockitem.cpp:203 ../src/common/cmdproc.cpp:271
-#: ../src/msw/textctrl.cpp:2504
+#: ../src/osx/textctrl_osx.cpp:591 ../src/common/stockitem.cpp:200
+#: ../src/common/cmdproc.cpp:264 ../src/msw/textctrl.cpp:2769
+#: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "元に戻す (&U)"
 
-#: ../src/common/cmdproc.cpp:265
+#: ../src/common/cmdproc.cpp:258
 msgid "&Undo "
 msgstr "元に戻す (&U)"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "&Unindent"
 msgstr "字下げ解除 (&U)"
 
-#: ../src/common/stockitem.cpp:205
+#: ../src/common/stockitem.cpp:202
 msgid "&Up"
 msgstr "上 (&U)"
 
@@ -774,7 +795,7 @@ msgstr "行頭文字の位置(&A):"
 msgid "&View..."
 msgstr "見る (&V) ..."
 
-#: ../src/generic/fontdlgg.cpp:393
+#: ../src/generic/fontdlgg.cpp:389
 msgid "&Weight:"
 msgstr "ウエイト (&W):"
 
@@ -784,88 +805,58 @@ msgstr "ウエイト (&W):"
 msgid "&Width:"
 msgstr "ウエイト (&W):"
 
-#: ../src/aui/tabmdi.cpp:311 ../src/aui/tabmdi.cpp:327
-#: ../src/aui/tabmdi.cpp:329 ../src/generic/mdig.cpp:294
-#: ../src/generic/mdig.cpp:310 ../src/generic/mdig.cpp:314
-#: ../src/msw/mdi.cpp:78
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
 msgid "&Window"
 msgstr "ウィンドウ (&W)"
 
-#: ../src/common/stockitem.cpp:206 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:203 ../src/msw/msgdlg.cpp:435
 msgid "&Yes"
 msgstr "はい (&Y)"
 
-#: ../src/common/valtext.cpp:256
+#: ../src/common/valtext.cpp:197
 #, fuzzy, c-format
-msgid "'%s' contains illegal characters"
+msgid "'%s' contains invalid character(s)"
 msgstr "'%s' はアルファベット以外を受け付けません。"
 
-#: ../src/common/valtext.cpp:254
-#, fuzzy, c-format
-msgid "'%s' doesn't consist only of valid characters"
-msgstr "'%s' はアルファベット以外を受け付けません。"
-
-#: ../src/common/config.cpp:519 ../src/msw/regconf.cpp:258
+#: ../src/common/config.cpp:515 ../src/msw/regconf.cpp:255
 #, c-format
 msgid "'%s' has extra '..', ignored."
 msgstr "'%s' に余分な '..' がありました。無視します。"
 
-#: ../src/common/cmdline.cpp:1113 ../src/common/cmdline.cpp:1131
+#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' はオプション '%s' に使えない数値です。"
 
-#: ../src/common/translation.cpp:1100
+#: ../src/common/translation.cpp:1142
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' は正しいメッセージカタログではありません。"
 
-#: ../src/common/valtext.cpp:165
+#: ../src/common/valtext.cpp:188
 #, fuzzy, c-format
 msgid "'%s' is not one of the valid strings"
 msgstr "'%s' は正しいメッセージカタログではありません。"
 
-#: ../src/common/valtext.cpp:167
+#: ../src/common/valtext.cpp:186
 #, fuzzy, c-format
 msgid "'%s' is one of the invalid strings"
 msgstr "'%s' は不正です"
 
-#: ../src/common/textbuf.cpp:237
+#: ../src/common/textbuf.cpp:233
 #, c-format
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' はおそらくバイナリーバッファーです。"
-
-#: ../src/common/valtext.cpp:252
-#, c-format
-msgid "'%s' should be numeric."
-msgstr "'%s' は数字でなくてはなりません。"
-
-#: ../src/common/valtext.cpp:244
-#, c-format
-msgid "'%s' should only contain ASCII characters."
-msgstr "'%s' は ASCII 文字以外を受け付けません。"
-
-#: ../src/common/valtext.cpp:246
-#, c-format
-msgid "'%s' should only contain alphabetic characters."
-msgstr "'%s' はアルファベット以外を受け付けません。"
-
-#: ../src/common/valtext.cpp:248
-#, c-format
-msgid "'%s' should only contain alphabetic or numeric characters."
-msgstr "'%s' はアルファベットと数字のみ受け付けます。"
-
-#: ../src/common/valtext.cpp:250
-#, c-format
-msgid "'%s' should only contain digits."
-msgstr "'%s' は数字以外を受け付けません。"
 
 #: ../src/richtext/richtextliststylepage.cpp:229
 #: ../src/richtext/richtextbulletspage.cpp:166
 msgid "(*)"
 msgstr "(*)"
 
-#: ../src/html/helpwnd.cpp:963
+#: ../src/html/helpwnd.cpp:961
 msgid "(Help)"
 msgstr "(ヘルプ)"
 
@@ -874,27 +865,32 @@ msgstr "(ヘルプ)"
 msgid "(None)"
 msgstr "(なし)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:504
+#: ../src/richtext/richtextsymboldlg.cpp:503
 msgid "(Normal text)"
 msgstr "(通常のテキスト)"
 
-#: ../src/html/helpwnd.cpp:419 ../src/html/helpwnd.cpp:1106
-#: ../src/html/helpwnd.cpp:1742
+#: ../src/html/helpwnd.cpp:417 ../src/html/helpwnd.cpp:1104
+#: ../src/html/helpwnd.cpp:1740
 msgid "(bookmarks)"
 msgstr "(ブックマーク)"
 
+#: ../src/msw/dlmsw.cpp:167
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (エラー %ld: %s)"
+
+#: ../src/richtext/richtextformatdlg.cpp:876
+#: ../src/richtext/richtextliststylepage.cpp:448
+#: ../src/richtext/richtextliststylepage.cpp:460
+#: ../src/richtext/richtextliststylepage.cpp:461
 #: ../src/richtext/richtextindentspage.cpp:274
 #: ../src/richtext/richtextindentspage.cpp:286
 #: ../src/richtext/richtextindentspage.cpp:287
 #: ../src/richtext/richtextindentspage.cpp:311
 #: ../src/richtext/richtextindentspage.cpp:326
-#: ../src/richtext/richtextformatdlg.cpp:884
 #: ../src/richtext/richtextfontpage.cpp:349
 #: ../src/richtext/richtextfontpage.cpp:353
 #: ../src/richtext/richtextfontpage.cpp:357
-#: ../src/richtext/richtextliststylepage.cpp:448
-#: ../src/richtext/richtextliststylepage.cpp:460
-#: ../src/richtext/richtextliststylepage.cpp:461
 msgid "(none)"
 msgstr "(なし)"
 
@@ -913,7 +909,7 @@ msgstr "*)"
 msgid "+"
 msgstr "+"
 
-#: ../src/msw/utils.cpp:1152
+#: ../src/msw/utils.cpp:1143
 msgid ", 64-bit edition"
 msgstr ", 64ビットエディション"
 
@@ -922,163 +918,163 @@ msgstr ", 64ビットエディション"
 msgid "-"
 msgstr "-"
 
-#: ../src/generic/filepickerg.cpp:66
+#: ../src/generic/filepickerg.cpp:63
 msgid "..."
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:276
 #: ../src/richtext/richtextliststylepage.cpp:450
+#: ../src/richtext/richtextindentspage.cpp:276
 msgid "1.1"
 msgstr "1.1"
 
-#: ../src/richtext/richtextindentspage.cpp:277
 #: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextindentspage.cpp:277
 msgid "1.2"
 msgstr "1.2"
 
-#: ../src/richtext/richtextindentspage.cpp:278
 #: ../src/richtext/richtextliststylepage.cpp:452
+#: ../src/richtext/richtextindentspage.cpp:278
 msgid "1.3"
 msgstr "1.3"
 
-#: ../src/richtext/richtextindentspage.cpp:279
 #: ../src/richtext/richtextliststylepage.cpp:453
+#: ../src/richtext/richtextindentspage.cpp:279
 msgid "1.4"
 msgstr "1.4"
 
-#: ../src/richtext/richtextindentspage.cpp:280
 #: ../src/richtext/richtextliststylepage.cpp:454
+#: ../src/richtext/richtextindentspage.cpp:280
 msgid "1.5"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:281
 #: ../src/richtext/richtextliststylepage.cpp:455
+#: ../src/richtext/richtextindentspage.cpp:281
 msgid "1.6"
 msgstr "1.6"
 
-#: ../src/richtext/richtextindentspage.cpp:282
 #: ../src/richtext/richtextliststylepage.cpp:456
+#: ../src/richtext/richtextindentspage.cpp:282
 msgid "1.7"
 msgstr "1.7"
 
-#: ../src/richtext/richtextindentspage.cpp:283
 #: ../src/richtext/richtextliststylepage.cpp:457
+#: ../src/richtext/richtextindentspage.cpp:283
 msgid "1.8"
 msgstr "1.8"
 
-#: ../src/richtext/richtextindentspage.cpp:284
 #: ../src/richtext/richtextliststylepage.cpp:458
+#: ../src/richtext/richtextindentspage.cpp:284
 msgid "1.9"
 msgstr "1.9"
 
-#: ../src/common/paper.cpp:140
+#: ../src/common/paper.cpp:137
 msgid "10 x 11 in"
 msgstr "10×11インチ"
 
-#: ../src/common/paper.cpp:113
+#: ../src/common/paper.cpp:110
 msgid "10 x 14 in"
 msgstr "10×14インチ"
 
-#: ../src/common/paper.cpp:114
+#: ../src/common/paper.cpp:111
 msgid "11 x 17 in"
 msgstr "11×17インチ"
 
-#: ../src/common/paper.cpp:184
+#: ../src/common/paper.cpp:181
 msgid "12 x 11 in"
 msgstr "12×11インチ"
 
-#: ../src/common/paper.cpp:141
+#: ../src/common/paper.cpp:138
 msgid "15 x 11 in"
 msgstr "15×11インチ"
 
-#: ../src/richtext/richtextindentspage.cpp:285
 #: ../src/richtext/richtextliststylepage.cpp:459
+#: ../src/richtext/richtextindentspage.cpp:285
 msgid "2"
 msgstr "2"
 
-#: ../src/common/paper.cpp:132
+#: ../src/common/paper.cpp:129
 msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
 msgstr "6 3/4 封筒, 3 5/8 × 6 1/2インチ"
 
-#: ../src/common/paper.cpp:139
+#: ../src/common/paper.cpp:136
 msgid "9 x 11 in"
 msgstr "9×11インチ"
 
-#: ../src/html/htmprint.cpp:431
+#: ../src/html/htmprint.cpp:443
 msgid ": file does not exist!"
 msgstr ": ファイルがありません。"
 
-#: ../src/common/fontmap.cpp:199
+#: ../src/common/fontmap.cpp:196
 msgid ": unknown charset"
 msgstr ": 未知の文字集合"
 
-#: ../src/common/fontmap.cpp:413
+#: ../src/common/fontmap.cpp:410
 msgid ": unknown encoding"
 msgstr ": 未知のエンコーディング"
 
-#: ../src/generic/wizard.cpp:443
+#: ../src/generic/wizard.cpp:438
 msgid "< &Back"
 msgstr "< 戻る (&B)"
 
-#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:628
-#: ../src/osx/carbon/fontdlg.cpp:648
+#: ../src/osx/carbon/fontdlg.cpp:419 ../src/osx/carbon/fontdlg.cpp:625
+#: ../src/osx/carbon/fontdlg.cpp:645
 msgid "<Any Decorative>"
 msgstr "<Decorativeのいずれか>"
 
-#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:630
-#: ../src/osx/carbon/fontdlg.cpp:650
+#: ../src/osx/carbon/fontdlg.cpp:420 ../src/osx/carbon/fontdlg.cpp:627
+#: ../src/osx/carbon/fontdlg.cpp:647
 msgid "<Any Modern>"
 msgstr "<Modernのいずれか>"
 
-#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:626
-#: ../src/osx/carbon/fontdlg.cpp:646
+#: ../src/osx/carbon/fontdlg.cpp:418 ../src/osx/carbon/fontdlg.cpp:623
+#: ../src/osx/carbon/fontdlg.cpp:643
 msgid "<Any Roman>"
 msgstr "<Romanのいずれか>"
 
-#: ../src/osx/carbon/fontdlg.cpp:424 ../src/osx/carbon/fontdlg.cpp:632
-#: ../src/osx/carbon/fontdlg.cpp:652
+#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:629
+#: ../src/osx/carbon/fontdlg.cpp:649
 msgid "<Any Script>"
 msgstr "<Scriptのいずれか>"
 
-#: ../src/osx/carbon/fontdlg.cpp:425 ../src/osx/carbon/fontdlg.cpp:637
-#: ../src/osx/carbon/fontdlg.cpp:656
+#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:634
+#: ../src/osx/carbon/fontdlg.cpp:653
 msgid "<Any Swiss>"
 msgstr "<Swissのいずれか>"
 
-#: ../src/osx/carbon/fontdlg.cpp:426 ../src/osx/carbon/fontdlg.cpp:634
-#: ../src/osx/carbon/fontdlg.cpp:654
+#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:631
+#: ../src/osx/carbon/fontdlg.cpp:651
 msgid "<Any Teletype>"
 msgstr "<Teletypeのいずれか>"
 
-#: ../src/osx/carbon/fontdlg.cpp:420
+#: ../src/osx/carbon/fontdlg.cpp:417
 msgid "<Any>"
 msgstr "<いずれか>"
 
-#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
 msgid "<DIR>"
 msgstr "<ディレクトリー>"
 
-#: ../src/generic/filectrlg.cpp:254 ../src/generic/filectrlg.cpp:277
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
 msgid "<DRIVE>"
 msgstr "<ドライブ>"
 
-#: ../src/generic/filectrlg.cpp:252 ../src/generic/filectrlg.cpp:275
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
 msgid "<LINK>"
 msgstr "<リンク>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1264
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>太字でイタリック体。</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1270
+#: ../src/html/helpwnd.cpp:1268
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>太字でイタリック体 <u>下線</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1265
+#: ../src/html/helpwnd.cpp:1263
 msgid "<b>Bold face.</b> "
 msgstr "<b>太字。</b> "
 
-#: ../src/html/helpwnd.cpp:1264
+#: ../src/html/helpwnd.cpp:1262
 msgid "<i>Italic face.</i> "
 msgstr "<i>イタリック体。</i> "
 
@@ -1087,15 +1083,15 @@ msgstr "<i>イタリック体。</i> "
 msgid ">"
 msgstr ">"
 
-#: ../src/generic/dbgrptg.cpp:318
+#: ../src/generic/dbgrptg.cpp:317
 msgid "A debug report has been generated in the directory\n"
 msgstr "デバッグレポートが次のディレクトリーに作成されます\n"
 
-#: ../src/common/debugrpt.cpp:573
+#: ../src/common/debugrpt.cpp:574
 msgid "A debug report has been generated. It can be found in"
 msgstr "デバッグレポートが作成されました。次の場所にあります:"
 
-#: ../src/common/xtixml.cpp:418
+#: ../src/common/xtixml.cpp:414
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "空でないコレクションは 'element' ノードを必須とします"
 
@@ -1106,107 +1102,107 @@ msgstr "空でないコレクションは 'element' ノードを必須としま�
 msgid "A standard bullet name."
 msgstr "標準の行頭文字名を指定します。"
 
-#: ../src/common/paper.cpp:217
+#: ../src/common/paper.cpp:214
 msgid "A0 sheet, 841 x 1189 mm"
 msgstr "A0 シート, 841 x 1189 mm"
 
-#: ../src/common/paper.cpp:218
+#: ../src/common/paper.cpp:215
 msgid "A1 sheet, 594 x 841 mm"
 msgstr "A1 シート, 594 x 841 mm"
 
-#: ../src/common/paper.cpp:159
+#: ../src/common/paper.cpp:156
 msgid "A2 420 x 594 mm"
 msgstr "A2 420×594 mm"
 
-#: ../src/common/paper.cpp:156
+#: ../src/common/paper.cpp:153
 msgid "A3 Extra 322 x 445 mm"
 msgstr "A3 Extra 322 x 445 mm"
 
-#: ../src/common/paper.cpp:161
+#: ../src/common/paper.cpp:158
 msgid "A3 Extra Transverse 322 x 445 mm"
 msgstr "A3 Extra Transverse 322 x 445 mm"
 
-#: ../src/common/paper.cpp:170
+#: ../src/common/paper.cpp:167
 msgid "A3 Rotated 420 x 297 mm"
 msgstr "A3横置き 420×297mm"
 
-#: ../src/common/paper.cpp:160
+#: ../src/common/paper.cpp:157
 msgid "A3 Transverse 297 x 420 mm"
 msgstr "A3 Transverse 297 x 420 mm"
 
-#: ../src/common/paper.cpp:106
+#: ../src/common/paper.cpp:103
 msgid "A3 sheet, 297 x 420 mm"
 msgstr "A3 シート, 297 x 420 mm"
 
-#: ../src/common/paper.cpp:146
+#: ../src/common/paper.cpp:143
 msgid "A4 Extra 9.27 x 12.69 in"
 msgstr "A4 Extra 9.27 x 12.69インチ"
 
-#: ../src/common/paper.cpp:153
+#: ../src/common/paper.cpp:150
 msgid "A4 Plus 210 x 330 mm"
 msgstr "A4 Plus 210 x 330 mm"
 
-#: ../src/common/paper.cpp:171
+#: ../src/common/paper.cpp:168
 msgid "A4 Rotated 297 x 210 mm"
 msgstr "A4横置き 297×210mm"
 
-#: ../src/common/paper.cpp:148
+#: ../src/common/paper.cpp:145
 msgid "A4 Transverse 210 x 297 mm"
 msgstr "A4 Transverse 210 x 297 mm"
 
-#: ../src/common/paper.cpp:97
+#: ../src/common/paper.cpp:94
 msgid "A4 sheet, 210 x 297 mm"
 msgstr "A4 シート, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:107
+#: ../src/common/paper.cpp:104
 msgid "A4 small sheet, 210 x 297 mm"
 msgstr "A4 small sheet, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:157
+#: ../src/common/paper.cpp:154
 msgid "A5 Extra 174 x 235 mm"
 msgstr "A5 Extra 174 x 235 mm"
 
-#: ../src/common/paper.cpp:172
+#: ../src/common/paper.cpp:169
 msgid "A5 Rotated 210 x 148 mm"
 msgstr "A5横置き 210×148mm"
 
-#: ../src/common/paper.cpp:154
+#: ../src/common/paper.cpp:151
 msgid "A5 Transverse 148 x 210 mm"
 msgstr "A5 Transverse 148 x 210 mm"
 
-#: ../src/common/paper.cpp:108
+#: ../src/common/paper.cpp:105
 msgid "A5 sheet, 148 x 210 mm"
 msgstr "A5 シート, 148 x 210 mm"
 
-#: ../src/common/paper.cpp:164
+#: ../src/common/paper.cpp:161
 msgid "A6 105 x 148 mm"
 msgstr "A6 105×148mm"
 
-#: ../src/common/paper.cpp:177
+#: ../src/common/paper.cpp:174
 msgid "A6 Rotated 148 x 105 mm"
 msgstr "A6横置き 148×105mm"
 
-#: ../src/generic/fontdlgg.cpp:83 ../src/richtext/richtextformatdlg.cpp:529
-#: ../src/osx/carbon/fontdlg.cpp:153
+#: ../src/osx/carbon/fontdlg.cpp:150 ../src/generic/fontdlgg.cpp:79
+#: ../src/richtext/richtextformatdlg.cpp:521
 msgid "ABCDEFGabcdefg12345"
 msgstr "ABCDEFGabcdefg12345"
 
-#: ../src/richtext/richtextsymboldlg.cpp:458 ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
 msgid "ASCII"
 msgstr "ASCII"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 #, fuzzy
 msgid "About"
 msgstr "詳細 (&A)"
 
-#: ../src/generic/aboutdlgg.cpp:140 ../src/osx/menu_osx.cpp:558
-#: ../src/msw/aboutdlg.cpp:64
+#: ../src/osx/menu_osx.cpp:450 ../src/generic/aboutdlgg.cpp:137
+#: ../src/msw/aboutdlg.cpp:61
 #, c-format
 msgid "About %s"
 msgstr "%s について"
 
-#: ../src/osx/menu_osx.cpp:560
+#: ../src/osx/menu_osx.cpp:452
 #, fuzzy
 msgid "About..."
 msgstr "詳細 (&A)"
@@ -1216,39 +1212,39 @@ msgid "Absolute"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:873
+#: ../src/propgrid/advprops.cpp:774
 #, fuzzy
 msgid "ActiveBorder"
 msgstr "Modern"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:874
+#: ../src/propgrid/advprops.cpp:775
 msgid "ActiveCaption"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 #, fuzzy
 msgid "Actual Size"
 msgstr "原寸 (&A)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:140 ../src/common/accelcmn.cpp:81
+#: ../src/common/stockitem.cpp:137 ../src/common/accelcmn.cpp:78
 msgid "Add"
 msgstr "追加"
 
-#: ../src/richtext/richtextbuffer.cpp:11455
+#: ../src/richtext/richtextbuffer.cpp:11454
 msgid "Add Column"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11392
+#: ../src/richtext/richtextbuffer.cpp:11391
 msgid "Add Row"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:432
+#: ../src/html/helpwnd.cpp:430
 msgid "Add current page to bookmarks"
 msgstr "現在のページをブックマークに追加します"
 
-#: ../src/generic/colrdlgg.cpp:366
+#: ../src/generic/colrdlgg.cpp:386
 msgid "Add to custom colours"
 msgstr "カスタムカラーへ追加します"
 
@@ -1260,12 +1256,12 @@ msgstr "非特殊化アクセサーの AddToPropertyCollection が呼び出さ�
 msgid "AddToPropertyCollection called w/o valid adder"
 msgstr "不適切な adder から AddToPropertyCollection が呼び出されました"
 
-#: ../src/html/helpctrl.cpp:159
+#: ../src/html/helpctrl.cpp:155
 #, c-format
 msgid "Adding book %s"
 msgstr "ブック %s を追加しています"
 
-#: ../src/common/preferencescmn.cpp:43
+#: ../src/common/preferencescmn.cpp:40
 msgid "Advanced"
 msgstr ""
 
@@ -1273,11 +1269,11 @@ msgstr ""
 msgid "After a paragraph:"
 msgstr "段落の後:"
 
-#: ../src/common/stockitem.cpp:172
+#: ../src/common/stockitem.cpp:169
 msgid "Align Left"
 msgstr "左寄せ"
 
-#: ../src/common/stockitem.cpp:173
+#: ../src/common/stockitem.cpp:170
 msgid "Align Right"
 msgstr "右寄せ"
 
@@ -1286,40 +1282,40 @@ msgstr "右寄せ"
 msgid "Alignment"
 msgstr "整列 (&A)"
 
-#: ../src/generic/prntdlgg.cpp:215
+#: ../src/generic/prntdlgg.cpp:208
 msgid "All"
 msgstr "すべて"
 
-#: ../src/generic/filectrlg.cpp:1197 ../src/common/fldlgcmn.cpp:107
+#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1186
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "すべてのファイル (%s)|%s"
 
-#: ../include/wx/defs.h:2886
+#: ../include/wx/defs.h:2582
 msgid "All files (*)|*"
 msgstr "すべてのファイル (*)|*"
 
-#: ../include/wx/defs.h:2883
+#: ../include/wx/defs.h:2579
 msgid "All files (*.*)|*.*"
 msgstr "すべてのファイル (*.*)|*.*"
 
-#: ../src/richtext/richtextstyles.cpp:1061
+#: ../src/richtext/richtextstyles.cpp:1058
 msgid "All styles"
 msgstr "すべてのスタイル"
 
-#: ../src/propgrid/manager.cpp:1528
+#: ../src/propgrid/manager.cpp:1544
 msgid "Alphabetic Mode"
 msgstr "名前順"
 
-#: ../src/common/xtistrm.cpp:425
+#: ../src/common/xtistrm.cpp:422
 msgid "Already Registered Object passed to SetObjectClassInfo"
 msgstr "登録済みのオブジェクトが SetObjectClassInfo に渡されました"
 
-#: ../src/unix/dialup.cpp:353
+#: ../src/unix/dialup.cpp:352
 msgid "Already dialling ISP."
 msgstr "すでに ISP にダイヤル中です。"
 
-#: ../src/common/accelcmn.cpp:331 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/accelcmn.cpp:345 ../src/univ/themes/win32.cpp:3753
 msgid "Alt+"
 msgstr "Alt+"
 
@@ -1328,38 +1324,38 @@ msgstr "Alt+"
 msgid "An optional corner radius for adding rounded corners."
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:576
+#: ../src/common/debugrpt.cpp:577
 msgid "And includes the following files:\n"
 msgstr "次のファイルが含まれています:\n"
 
-#: ../src/generic/animateg.cpp:162
+#: ../src/generic/animateg.cpp:145
 #, c-format
 msgid "Animation file is not of type %ld."
 msgstr "アニメーションファイルが %ld 型ではありません｡"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:872
+#: ../src/propgrid/advprops.cpp:773
 msgid "AppWorkspace"
 msgstr ""
 
-#: ../src/generic/logg.cpp:1014
+#: ../src/generic/logg.cpp:1011
 #, c-format
 msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
 msgstr ""
 "ログをファイル '%s' に追加しますか? [いいえ]を選択すると再作成で上書きしま"
 "す。"
 
-#: ../src/osx/menu_osx.cpp:577 ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:469 ../src/osx/menu_osx.cpp:477
 #, fuzzy
 msgid "Application"
 msgstr "選択"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 #, fuzzy
 msgid "Apply"
 msgstr "適用 (&A)"
 
-#: ../src/propgrid/advprops.cpp:1609
+#: ../src/propgrid/advprops.cpp:1515
 msgid "Aqua"
 msgstr ""
 
@@ -1368,31 +1364,31 @@ msgstr ""
 msgid "Arabic"
 msgstr "算用数字"
 
-#: ../src/common/fmapbase.cpp:153
+#: ../src/common/fmapbase.cpp:150
 msgid "Arabic (ISO-8859-6)"
 msgstr "アラビア語 (ISO-8859-6)"
 
-#: ../src/msw/ole/automtn.cpp:672
+#: ../src/msw/ole/automtn.cpp:663
 #, fuzzy, c-format
 msgid "Argument %u not found."
 msgstr "列の索引が見つかりません。"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1753
+#: ../src/propgrid/advprops.cpp:1654
 #, fuzzy
 msgid "Arrow"
 msgstr "明日"
 
-#: ../src/generic/aboutdlgg.cpp:184
+#: ../src/generic/aboutdlgg.cpp:181
 msgid "Artists"
 msgstr "デザイン"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 #, fuzzy
 msgid "Ascending"
 msgstr "昇順 (&A)"
 
-#: ../src/generic/filectrlg.cpp:433
+#: ../src/generic/filectrlg.cpp:429
 msgid "Attributes"
 msgstr "属性"
 
@@ -1402,91 +1398,91 @@ msgstr "属性"
 msgid "Available fonts."
 msgstr "有効なフォントです。"
 
-#: ../src/common/paper.cpp:137
+#: ../src/common/paper.cpp:134
 msgid "B4 (ISO) 250 x 353 mm"
 msgstr "B4 (ISO) 250 x 353 mm"
 
-#: ../src/common/paper.cpp:173
+#: ../src/common/paper.cpp:170
 msgid "B4 (JIS) Rotated 364 x 257 mm"
 msgstr "B4 (JIS) 横置き 364×257mm"
 
-#: ../src/common/paper.cpp:127
+#: ../src/common/paper.cpp:124
 msgid "B4 Envelope, 250 x 353 mm"
 msgstr "B4 封筒, 250 x 353 mm"
 
-#: ../src/common/paper.cpp:109
+#: ../src/common/paper.cpp:106
 msgid "B4 sheet, 250 x 354 mm"
 msgstr "B4 シート, 250 x 354 mm"
 
-#: ../src/common/paper.cpp:158
+#: ../src/common/paper.cpp:155
 msgid "B5 (ISO) Extra 201 x 276 mm"
 msgstr "B5 (ISO) Extra 201 x 276 mm"
 
-#: ../src/common/paper.cpp:174
+#: ../src/common/paper.cpp:171
 msgid "B5 (JIS) Rotated 257 x 182 mm"
 msgstr "B5 (JIS) 横置き 257×182mm"
 
-#: ../src/common/paper.cpp:155
+#: ../src/common/paper.cpp:152
 msgid "B5 (JIS) Transverse 182 x 257 mm"
 msgstr "B5 (JIS) Transverse 182 x 257 mm"
 
-#: ../src/common/paper.cpp:128
+#: ../src/common/paper.cpp:125
 msgid "B5 Envelope, 176 x 250 mm"
 msgstr "B5 封筒, 176 x 250 mm"
 
-#: ../src/common/paper.cpp:110
+#: ../src/common/paper.cpp:107
 msgid "B5 sheet, 182 x 257 millimeter"
 msgstr "B5 シート, 182 x 257 mm"
 
-#: ../src/common/paper.cpp:182
+#: ../src/common/paper.cpp:179
 msgid "B6 (JIS) 128 x 182 mm"
 msgstr "B6 (JIS) 128×182 mm"
 
-#: ../src/common/paper.cpp:183
+#: ../src/common/paper.cpp:180
 msgid "B6 (JIS) Rotated 182 x 128 mm"
 msgstr "B6 (JIS) 横置き 182×128mm"
 
-#: ../src/common/paper.cpp:129
+#: ../src/common/paper.cpp:126
 msgid "B6 Envelope, 176 x 125 mm"
 msgstr "B6 封筒, 176 x 125 mm"
 
-#: ../src/common/imagbmp.cpp:531 ../src/common/imagbmp.cpp:561
-#: ../src/common/imagbmp.cpp:576
+#: ../src/common/imagbmp.cpp:528 ../src/common/imagbmp.cpp:558
+#: ../src/common/imagbmp.cpp:573
 msgid "BMP: Couldn't allocate memory."
 msgstr "BMP: メモリ割り当てに失敗しました。"
 
-#: ../src/common/imagbmp.cpp:100
+#: ../src/common/imagbmp.cpp:97
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: 不正な画像で保存できませんでした。"
 
-#: ../src/common/imagbmp.cpp:356
+#: ../src/common/imagbmp.cpp:353
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: RGB色索引を書き出せませんでした。"
 
-#: ../src/common/imagbmp.cpp:490
+#: ../src/common/imagbmp.cpp:487
 msgid "BMP: Couldn't write data."
 msgstr "BMP: データ書き出しに失敗しました。"
 
-#: ../src/common/imagbmp.cpp:246
+#: ../src/common/imagbmp.cpp:243
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: Bitmapヘッダの書き出しに失敗しました。"
 
-#: ../src/common/imagbmp.cpp:269
+#: ../src/common/imagbmp.cpp:266
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: BitmapInfoヘッダの書き出しに失敗しました。"
 
-#: ../src/common/imagbmp.cpp:140
+#: ../src/common/imagbmp.cpp:137
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage は自身の wxPalette を保有していません。"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:142 ../src/common/accelcmn.cpp:52
+#: ../src/common/stockitem.cpp:139 ../src/common/accelcmn.cpp:49
 #, fuzzy
 msgid "Back"
 msgstr "戻る (&B)"
 
+#: ../src/richtext/richtextformatdlg.cpp:377
 #: ../src/richtext/richtextbackgroundpage.cpp:148
-#: ../src/richtext/richtextformatdlg.cpp:384
 #, fuzzy
 msgid "Background"
 msgstr "背景色"
@@ -1496,21 +1492,21 @@ msgstr "背景色"
 msgid "Background &colour:"
 msgstr "背景色"
 
-#: ../src/osx/carbon/fontdlg.cpp:220
+#: ../src/osx/carbon/fontdlg.cpp:217
 msgid "Background colour"
 msgstr "背景色"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:52
+#: ../src/common/accelcmn.cpp:49
 #, fuzzy
 msgid "Backspace"
 msgstr "戻る (&B)"
 
-#: ../src/common/fmapbase.cpp:160
+#: ../src/common/fmapbase.cpp:157
 msgid "Baltic (ISO-8859-13)"
 msgstr "バルト言語 (ISO-8859-13)"
 
-#: ../src/common/fmapbase.cpp:151
+#: ../src/common/fmapbase.cpp:148
 msgid "Baltic (old) (ISO-8859-4)"
 msgstr "バルト言語(旧規格) (ISO-8859-4)"
 
@@ -1523,25 +1519,25 @@ msgstr "段落の前:"
 msgid "Bitmap"
 msgstr "ビットマップ"
 
-#: ../src/propgrid/advprops.cpp:1594
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Black"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1755
+#: ../src/propgrid/advprops.cpp:1656
 msgid "Blank"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1603
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Blue"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:345
+#: ../src/generic/colrdlgg.cpp:365
 msgid "Blue:"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:333 ../src/richtext/richtextfontpage.cpp:355
-#: ../src/osx/carbon/fontdlg.cpp:354 ../src/common/stockitem.cpp:143
+#: ../src/osx/carbon/fontdlg.cpp:351 ../src/common/stockitem.cpp:140
+#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:355
 msgid "Bold"
 msgstr "太字"
 
@@ -1551,36 +1547,40 @@ msgstr "太字"
 msgid "Border"
 msgstr "Modern"
 
-#: ../src/richtext/richtextformatdlg.cpp:379
+#: ../src/richtext/richtextformatdlg.cpp:372
 #, fuzzy
 msgid "Borders"
 msgstr "Modern"
 
-#: ../src/richtext/richtextsizepage.cpp:288 ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141 ../src/richtext/richtextsizepage.cpp:288
 #, fuzzy
 msgid "Bottom"
 msgstr "下端 (&B)"
 
-#: ../src/generic/prntdlgg.cpp:893
+#: ../src/generic/prntdlgg.cpp:886
 msgid "Bottom margin (mm):"
 msgstr "余白-地 (mm):"
 
-#: ../src/richtext/richtextbuffer.cpp:9383
+#: ../src/richtext/richtextbuffer.cpp:9380
 #, fuzzy
 msgid "Box Properties"
 msgstr "プロパティー (&P)"
 
-#: ../src/richtext/richtextstyles.cpp:1065
+#: ../src/richtext/richtextstyles.cpp:1062
 #, fuzzy
 msgid "Box styles"
 msgstr "すべてのスタイル"
 
-#: ../src/propgrid/advprops.cpp:1602
+#: ../src/osx/cocoa/menu.mm:292
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1508
 #, fuzzy
 msgid "Brown"
 msgstr "ファイルの選択"
 
-#: ../src/common/filepickercmn.cpp:43 ../src/common/filepickercmn.cpp:44
+#: ../src/common/filepickercmn.cpp:40 ../src/common/filepickercmn.cpp:41
 msgid "Browse"
 msgstr "ファイルの選択"
 
@@ -1593,74 +1593,74 @@ msgstr "行頭文字の位置(&A):"
 msgid "Bullet style"
 msgstr "行頭文字のスタイル"
 
-#: ../src/richtext/richtextformatdlg.cpp:359
+#: ../src/richtext/richtextformatdlg.cpp:352
 msgid "Bullets"
 msgstr "行頭文字"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1756
+#: ../src/propgrid/advprops.cpp:1657
 #, fuzzy
 msgid "Bullseye"
 msgstr "行頭文字のスタイル"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:875
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonFace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:876
+#: ../src/propgrid/advprops.cpp:777
 msgid "ButtonHighlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:877
+#: ../src/propgrid/advprops.cpp:778
 msgid "ButtonShadow"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:878
+#: ../src/propgrid/advprops.cpp:779
 msgid "ButtonText"
 msgstr ""
 
-#: ../src/common/paper.cpp:98
+#: ../src/common/paper.cpp:95
 msgid "C sheet, 17 x 22 in"
 msgstr "Cサイズシート, 17 x 22インチ"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "C&lear"
 msgstr "消去 (&L)"
 
-#: ../src/generic/fontdlgg.cpp:406
+#: ../src/generic/fontdlgg.cpp:403
 msgid "C&olour:"
 msgstr "色 (&C):"
 
-#: ../src/common/paper.cpp:123
+#: ../src/common/paper.cpp:120
 msgid "C3 Envelope, 324 x 458 mm"
 msgstr "C3 封筒, 324×458mm"
 
-#: ../src/common/paper.cpp:124
+#: ../src/common/paper.cpp:121
 msgid "C4 Envelope, 229 x 324 mm"
 msgstr "C4 封筒, 229×324mm"
 
-#: ../src/common/paper.cpp:122
+#: ../src/common/paper.cpp:119
 msgid "C5 Envelope, 162 x 229 mm"
 msgstr "C5 封筒, 162×229mm"
 
-#: ../src/common/paper.cpp:125
+#: ../src/common/paper.cpp:122
 msgid "C6 Envelope, 114 x 162 mm"
 msgstr "消去 (&L)"
 
-#: ../src/common/paper.cpp:126
+#: ../src/common/paper.cpp:123
 msgid "C65 Envelope, 114 x 229 mm"
 msgstr "C65 封筒, 114×229mm"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 #, fuzzy
 msgid "CD-Rom"
 msgstr "CD-ROM (&C)"
 
-#: ../src/html/chm.cpp:815 ../src/html/chm.cpp:874
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:865
 msgid "CHM handler currently supports only local files!"
 msgstr "CHM ハンドラーは現在ローカルファイルのみに対応しています。"
 
@@ -1668,193 +1668,197 @@ msgstr "CHM ハンドラーは現在ローカルファイルのみに対応し�
 msgid "Ca&pitals"
 msgstr "大文字化 (&P)"
 
-#: ../src/common/cmdproc.cpp:267
+#: ../src/common/cmdproc.cpp:260
 msgid "Can't &Undo "
 msgstr "戻せません (&U)"
 
-#: ../src/common/image.cpp:2824
+#: ../src/common/image.cpp:2924
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 
-#: ../src/msw/registry.cpp:506
+#: ../src/msw/registry.cpp:495
 #, c-format
 msgid "Can't close registry key '%s'"
 msgstr "レジストリーキー '%s' を閉じることができません"
 
-#: ../src/msw/registry.cpp:584
+#: ../src/msw/registry.cpp:573
 #, c-format
 msgid "Can't copy values of unsupported type %d."
 msgstr "未対応型 %d の値はコピーできません"
 
-#: ../src/msw/registry.cpp:487
+#: ../src/msw/registry.cpp:476
 #, c-format
 msgid "Can't create registry key '%s'"
 msgstr "レジストリーキー '%s' を作成できません"
 
-#: ../src/msw/thread.cpp:665
+#: ../src/msw/thread.cpp:657
 msgid "Can't create thread"
 msgstr "スレッドを作成できません"
 
-#: ../src/msw/window.cpp:3691
-#, c-format
-msgid "Can't create window of class %s"
-msgstr "%s クラスのウィンドウを作成できません"
-
-#: ../src/msw/registry.cpp:777
+#: ../src/msw/registry.cpp:765
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "キー '%s' を削除できません"
 
-#: ../src/msw/iniconf.cpp:458
+#: ../src/msw/iniconf.cpp:455
 #, c-format
 msgid "Can't delete the INI file '%s'"
 msgstr "INIファイル '%s' を削除できません"
 
-#: ../src/msw/registry.cpp:805
+#: ../src/msw/registry.cpp:793
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "値 '%s' をキー '%s' から削除できません"
 
-#: ../src/msw/registry.cpp:1171
+#: ../src/msw/registry.cpp:1159
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "キー '%s' のサブキーを列挙できません"
 
-#: ../src/msw/registry.cpp:1132
+#: ../src/msw/registry.cpp:1120
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "キー '%s' の値を列挙できません"
 
-#: ../src/msw/registry.cpp:1389
+#: ../src/msw/registry.cpp:1377
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "未対応型 %d の値はエクスポートできません。"
 
-#: ../src/common/ffile.cpp:254
+#: ../src/common/ffile.cpp:253
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "ファイル '%s' の現在位置を見つけられません"
 
-#: ../src/msw/registry.cpp:418
+#: ../src/msw/registry.cpp:407
 #, c-format
 msgid "Can't get info about registry key '%s'"
 msgstr "レジストリーキー '%s' の情報を取得できません"
 
-#: ../src/common/zstream.cpp:346
+#: ../src/msw/webview_ie.cpp:1024
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "スレッド優先度を設定できません"
+
+#: ../src/common/zstream.cpp:343
 msgid "Can't initialize zlib deflate stream."
 msgstr "zlib の deflate ストリームを初期化できません。"
 
-#: ../src/common/zstream.cpp:185
+#: ../src/common/zstream.cpp:182
 msgid "Can't initialize zlib inflate stream."
 msgstr "zlib の inflate ストリームを初期化できません。"
 
-#: ../src/msw/fswatcher.cpp:476
+#: ../src/msw/fswatcher.cpp:475
 #, fuzzy, c-format
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "監視対象のディレクトリー \"%s\" を開くことができませんでした。"
 
-#: ../src/msw/registry.cpp:454
+#: ../src/msw/registry.cpp:443
 #, c-format
 msgid "Can't open registry key '%s'"
 msgstr "レジストリーキー '%s' を開くことができません"
 
-#: ../src/common/zstream.cpp:252
+#: ../src/common/zstream.cpp:249
 #, c-format
 msgid "Can't read from inflate stream: %s"
 msgstr "inflateストリームから読み取ることができません: %s"
 
-#: ../src/common/zstream.cpp:244
+#: ../src/common/zstream.cpp:241
 msgid "Can't read inflate stream: unexpected EOF in underlying stream."
 msgstr ""
 "inflate ストリームを読み取ることができません: 想定外の条件でEOFが元のストリー"
 "ムから検出されました。"
 
-#: ../src/msw/registry.cpp:1064
+#: ../src/msw/registry.cpp:1052
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "'%s' の値を読み取ることができません"
 
-#: ../src/msw/registry.cpp:878 ../src/msw/registry.cpp:910
-#: ../src/msw/registry.cpp:975
+#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
+#: ../src/msw/registry.cpp:963
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "キー '%s' の値を読み取ることができません"
 
-#: ../src/common/image.cpp:2620
+#: ../src/msw/webview_ie.cpp:1017
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/common/image.cpp:2715
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "画像を保存できません。'%s' は未対応の拡張子を持っています。"
 
-#: ../src/generic/logg.cpp:573 ../src/generic/logg.cpp:976
+#: ../src/generic/logg.cpp:570 ../src/generic/logg.cpp:973
 msgid "Can't save log contents to file."
 msgstr "ログの内容をファイルに保存できませんでした。"
 
-#: ../src/msw/thread.cpp:629
+#: ../src/msw/thread.cpp:621
 msgid "Can't set thread priority"
 msgstr "スレッド優先度を設定できません"
 
-#: ../src/msw/registry.cpp:896 ../src/msw/registry.cpp:938
-#: ../src/msw/registry.cpp:1081
+#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
+#: ../src/msw/registry.cpp:1069
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "'%s' の値を設定できません"
 
-#: ../src/unix/utilsunx.cpp:351
+#: ../src/unix/utilsunx.cpp:353
 #, fuzzy
 msgid "Can't write to child process's stdin"
 msgstr "プロセス %d の kill に失敗しました"
 
-#: ../src/common/zstream.cpp:427
+#: ../src/common/zstream.cpp:424
 #, c-format
 msgid "Can't write to deflate stream: %s"
 msgstr "deflateストリームに書き出すことができません: %s"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:279 ../src/richtext/richtextstyledlg.cpp:300
-#: ../src/common/stockitem.cpp:145 ../src/common/accelcmn.cpp:71
-#: ../src/msw/msgdlg.cpp:454 ../src/msw/progdlg.cpp:673
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:142
+#: ../src/common/accelcmn.cpp:68 ../src/motif/msgdlg.cpp:196
+#: ../src/gtk1/fontdlg.cpp:144 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/progdlg.cpp:940 ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "キャンセル"
 
-#: ../src/common/filefn.cpp:1261
+#: ../src/common/filefn.cpp:1149
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "ファイルを列挙できません '%s'"
 
-#: ../src/msw/dir.cpp:263
+#: ../src/msw/dir.cpp:260
 #, c-format
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "ディレクトリー '%s' のファイルは列挙できません"
 
-#: ../src/msw/dialup.cpp:523
+#: ../src/msw/dialup.cpp:517
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "使用中のダイヤルアップ接続が見つかりません: %s"
 
-#: ../src/msw/dialup.cpp:827
+#: ../src/msw/dialup.cpp:821
 msgid "Cannot find the location of address book file"
 msgstr "住所録の位置を特定できません"
 
-#: ../src/msw/ole/automtn.cpp:562
+#: ../src/msw/ole/automtn.cpp:553
 #, fuzzy, c-format
 msgid "Cannot get an active instance of \"%s\""
 msgstr "使用中のダイヤルアップ接続が見つかりません: %s"
 
-#: ../src/unix/threadpsx.cpp:1035
+#: ../src/unix/threadpsx.cpp:1053
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "スケジューリングポリシー %d への優先度範囲を取得できません。"
 
-#: ../src/unix/utilsunx.cpp:987
+#: ../src/unix/utilsunx.cpp:989
 msgid "Cannot get the hostname"
 msgstr "ホスト名を取得できません"
 
-#: ../src/unix/utilsunx.cpp:1023
+#: ../src/unix/utilsunx.cpp:1025
 msgid "Cannot get the official hostname"
 msgstr "公的なホスト名を取得できません"
 
-#: ../src/msw/dialup.cpp:928
+#: ../src/msw/dialup.cpp:922
 msgid "Cannot hang up - no active dialup connection."
 msgstr "接続を切るよう指示されましたが、有効なダイヤルアップ接続がありません。"
 
@@ -1862,128 +1866,128 @@ msgstr "接続を切るよう指示されましたが、有効なダイヤルア
 msgid "Cannot initialize OLE"
 msgstr "OLEを初期化できません"
 
-#: ../src/common/socket.cpp:853
+#: ../src/common/socket.cpp:850
 msgid "Cannot initialize sockets"
 msgstr "socket を初期化できません"
 
-#: ../src/msw/volume.cpp:619
+#: ../src/msw/volume.cpp:627
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "'%s' からアイコンを読み取れません。"
 
-#: ../src/xrc/xmlres.cpp:360
+#: ../src/xrc/xmlres.cpp:358
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "ファイル '%s' からリソースを読み取れません。"
 
-#: ../src/xrc/xmlres.cpp:742
+#: ../src/xrc/xmlres.cpp:740
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "ファイル '%s' からリソースを読み取れません。"
 
-#: ../src/html/htmlfilt.cpp:137
+#: ../src/html/htmlfilt.cpp:134
 #, c-format
 msgid "Cannot open HTML document: %s"
 msgstr "HTML文書を開くことができません: %s"
 
-#: ../src/html/helpdata.cpp:667
+#: ../src/html/helpdata.cpp:660
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "HTMLヘルプブックを開くことができません: %s"
 
-#: ../src/html/helpdata.cpp:299
+#: ../src/html/helpdata.cpp:296
 #, c-format
 msgid "Cannot open contents file: %s"
 msgstr "目次ファイルを開くことができません: %s"
 
-#: ../src/generic/dcpsg.cpp:1667
+#: ../src/generic/dcpsg.cpp:1665
 msgid "Cannot open file for PostScript printing!"
 msgstr "PostScript 印刷のためのファイルを開くことができません。"
 
-#: ../src/html/helpdata.cpp:313
+#: ../src/html/helpdata.cpp:310
 #, c-format
 msgid "Cannot open index file: %s"
 msgstr "索引ファイルを開くことができません: %s"
 
-#: ../src/xrc/xmlres.cpp:724
+#: ../src/xrc/xmlres.cpp:722
 #, fuzzy, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "ファイル '%s' からリソースを読み取れません。"
 
-#: ../src/html/helpwnd.cpp:1534
+#: ../src/html/helpwnd.cpp:1532
 msgid "Cannot print empty page."
 msgstr "空のページは印刷できません。"
 
-#: ../src/msw/volume.cpp:507
+#: ../src/msw/volume.cpp:515
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "'%s' の型名を読み出すことができません。"
 
-#: ../src/msw/thread.cpp:888
+#: ../src/msw/thread.cpp:894
 #, fuzzy, c-format
 msgid "Cannot resume thread %lx"
 msgstr "スレッド %x のリジュームができません"
 
-#: ../src/unix/threadpsx.cpp:1016
+#: ../src/unix/threadpsx.cpp:1028
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "スレッドスケジュールポリシーを取得できません。"
 
-#: ../src/common/intl.cpp:558
+#: ../src/common/intl.cpp:365
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "ロケールを言語 \"%s\" に設定できません。"
 
-#: ../src/unix/threadpsx.cpp:831 ../src/msw/thread.cpp:546
+#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
 msgid "Cannot start thread: error writing TLS."
 msgstr "スレッドを開始できませんでした: TLS への書き込みに失敗しています。"
 
-#: ../src/msw/thread.cpp:872
+#: ../src/msw/thread.cpp:864
 #, fuzzy, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "スレッド %x のサスペンドができません"
 
-#: ../src/msw/thread.cpp:794
+#: ../src/msw/thread.cpp:786
 msgid "Cannot wait for thread termination"
 msgstr "スレッドの終了を待つことはできません"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:75
+#: ../src/common/accelcmn.cpp:72
 #, fuzzy
 msgid "Capital"
 msgstr "大文字化 (&P)"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:879
+#: ../src/propgrid/advprops.cpp:780
 msgid "CaptionText"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:531
 msgid "Case sensitive"
 msgstr "大文字小文字を区別"
 
-#: ../src/propgrid/manager.cpp:1509
+#: ../src/propgrid/manager.cpp:1527
 msgid "Categorized Mode"
 msgstr "種類順"
 
-#: ../src/richtext/richtextbuffer.cpp:9968
+#: ../src/richtext/richtextbuffer.cpp:9965
 #, fuzzy
 msgid "Cell Properties"
 msgstr "プロパティー (&P)"
 
-#: ../src/common/fmapbase.cpp:161
+#: ../src/common/fmapbase.cpp:158
 msgid "Celtic (ISO-8859-14)"
 msgstr "ケルト語 (ISO-8859-14)"
 
-#: ../src/richtext/richtextindentspage.cpp:160
 #: ../src/richtext/richtextliststylepage.cpp:349
+#: ../src/richtext/richtextindentspage.cpp:160
 msgid "Cen&tred"
 msgstr "中央寄せ (&T)"
 
-#: ../src/common/stockitem.cpp:170
+#: ../src/common/stockitem.cpp:167
 msgid "Centered"
 msgstr "中央寄せ"
 
-#: ../src/common/fmapbase.cpp:149
+#: ../src/common/fmapbase.cpp:146
 msgid "Central European (ISO-8859-2)"
 msgstr "中央ヨーロッパ (ISO-8859-2)"
 
@@ -1992,10 +1996,10 @@ msgstr "中央ヨーロッパ (ISO-8859-2)"
 msgid "Centre"
 msgstr "中央寄せ"
 
-#: ../src/richtext/richtextindentspage.cpp:162
-#: ../src/richtext/richtextindentspage.cpp:164
 #: ../src/richtext/richtextliststylepage.cpp:351
 #: ../src/richtext/richtextliststylepage.cpp:353
+#: ../src/richtext/richtextindentspage.cpp:162
+#: ../src/richtext/richtextindentspage.cpp:164
 msgid "Centre text."
 msgstr "テキストを中央寄せにします。"
 
@@ -2009,26 +2013,26 @@ msgstr "中央寄せ (&T)"
 msgid "Ch&oose..."
 msgstr "選択 (&O)..."
 
-#: ../src/richtext/richtextbuffer.cpp:4354
+#: ../src/richtext/richtextbuffer.cpp:4351
 msgid "Change List Style"
 msgstr "リストスタイルを変更します"
 
-#: ../src/richtext/richtextbuffer.cpp:3709
+#: ../src/richtext/richtextbuffer.cpp:3706
 #, fuzzy
 msgid "Change Object Style"
 msgstr "リストスタイルを変更します"
 
-#: ../src/richtext/richtextbuffer.cpp:3982
-#: ../src/richtext/richtextbuffer.cpp:8129
+#: ../src/richtext/richtextbuffer.cpp:3979
+#: ../src/richtext/richtextbuffer.cpp:8125
 #, fuzzy
 msgid "Change Properties"
 msgstr "プロパティー (&P)"
 
-#: ../src/richtext/richtextbuffer.cpp:3526
+#: ../src/richtext/richtextbuffer.cpp:3523
 msgid "Change Style"
 msgstr "スタイルの変更"
 
-#: ../src/common/fileconf.cpp:341
+#: ../src/common/fileconf.cpp:335
 #, c-format
 msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
 msgstr "ファイル \"%s\" への上書きが拒否されたため変更内容は保存されていません"
@@ -2039,12 +2043,12 @@ msgid "Changing current directory to \"%s\" failed"
 msgstr "ディレクトリー \"%s\" を作成できませんでした。"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1757
+#: ../src/propgrid/advprops.cpp:1658
 #, fuzzy
 msgid "Character"
 msgstr "文字コード (&C):"
 
-#: ../src/richtext/richtextstyles.cpp:1063
+#: ../src/richtext/richtextstyles.cpp:1060
 msgid "Character styles"
 msgstr "文字のスタイル"
 
@@ -2082,20 +2086,20 @@ msgstr "行頭文字を丸括弧でくくる場合にチェックしてくださ
 msgid "Check to indicate right-to-left text layout."
 msgstr "クリックで文字色を変更します。"
 
-#: ../src/osx/carbon/fontdlg.cpp:356 ../src/osx/carbon/fontdlg.cpp:358
+#: ../src/osx/carbon/fontdlg.cpp:353 ../src/osx/carbon/fontdlg.cpp:355
 msgid "Check to make the font bold."
 msgstr "フォントを太字にするときにチェックしてください｡"
 
-#: ../src/osx/carbon/fontdlg.cpp:363 ../src/osx/carbon/fontdlg.cpp:365
+#: ../src/osx/carbon/fontdlg.cpp:360 ../src/osx/carbon/fontdlg.cpp:362
 msgid "Check to make the font italic."
 msgstr "フォントをイタリックにするときにチェックしてください。"
 
-#: ../src/osx/carbon/fontdlg.cpp:372 ../src/osx/carbon/fontdlg.cpp:374
+#: ../src/osx/carbon/fontdlg.cpp:369 ../src/osx/carbon/fontdlg.cpp:371
 msgid "Check to make the font underlined."
 msgstr "フォントに下線を付けるときにチェックしてください。"
 
-#: ../src/richtext/richtextstyledlg.cpp:289
-#: ../src/richtext/richtextstyledlg.cpp:291
+#: ../src/richtext/richtextstyledlg.cpp:285
+#: ../src/richtext/richtextstyledlg.cpp:287
 msgid "Check to restart numbering."
 msgstr "連番の初期化を指示する場合にチェックしてください。"
 
@@ -2130,53 +2134,53 @@ msgstr "テキストを上付き文字にする場合にチェックしてくだ
 msgid "Check to suppress hyphenation."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:763
+#: ../src/msw/dialup.cpp:757
 msgid "Choose ISP to dial"
 msgstr "ダイヤル先のISPを選んでください"
 
-#: ../src/propgrid/props.cpp:1922
+#: ../src/propgrid/props.cpp:1904
 msgid "Choose a directory:"
 msgstr "ディレクトリーを選んでください:"
 
-#: ../src/propgrid/props.cpp:1975
+#: ../src/propgrid/props.cpp:2199
 msgid "Choose a file"
 msgstr "フォントを選んでください"
 
-#: ../src/generic/colrdlgg.cpp:158 ../src/gtk/colordlg.cpp:54
+#: ../src/generic/colrdlgg.cpp:156 ../src/gtk/colordlg.cpp:49
 msgid "Choose colour"
 msgstr "色を選んでください"
 
-#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/gtk1/fontdlg.cpp:125 ../src/generic/fontpickerg.cpp:47
+#: ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "フォントを選んでください"
 
-#: ../src/common/module.cpp:74
+#: ../src/common/module.cpp:71
 #, c-format
 msgid "Circular dependency involving module \"%s\" detected."
 msgstr "モジュール \"%s\" の解決を試みているときに循環参照を検出しました。"
 
-#: ../src/aui/tabmdi.cpp:108 ../src/generic/mdig.cpp:97
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
 msgid "Cl&ose"
 msgstr "閉じる(&O)"
 
-#: ../src/msw/ole/automtn.cpp:684
+#: ../src/msw/ole/automtn.cpp:675
 #, fuzzy
 msgid "Class not registered."
 msgstr "スレッドを作成できません"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:147 ../src/common/accelcmn.cpp:72
+#: ../src/common/stockitem.cpp:144 ../src/common/accelcmn.cpp:69
 #, fuzzy
 msgid "Clear"
 msgstr "消去 (&C)"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "Clear the log contents"
 msgstr "ログの内容を消去します"
 
-#: ../src/richtext/richtextstyledlg.cpp:252
-#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:248
+#: ../src/richtext/richtextstyledlg.cpp:250
 msgid "Click to apply the selected style."
 msgstr "クリックで選択したスタイルを適用します。"
 
@@ -2187,15 +2191,15 @@ msgstr "クリックで選択したスタイルを適用します。"
 msgid "Click to browse for a symbol."
 msgstr "クリックで記号を一覧できます。"
 
-#: ../src/osx/carbon/fontdlg.cpp:403 ../src/osx/carbon/fontdlg.cpp:405
+#: ../src/osx/carbon/fontdlg.cpp:400 ../src/osx/carbon/fontdlg.cpp:402
 msgid "Click to cancel changes to the font."
 msgstr "クリックでフォントの変更をキャンセルします。"
 
-#: ../src/generic/fontdlgg.cpp:472 ../src/generic/fontdlgg.cpp:491
+#: ../src/generic/fontdlgg.cpp:468 ../src/generic/fontdlgg.cpp:487
 msgid "Click to cancel the font selection."
 msgstr "クリックでフォントの選択をキャンセルします。"
 
-#: ../src/osx/carbon/fontdlg.cpp:384 ../src/osx/carbon/fontdlg.cpp:386
+#: ../src/osx/carbon/fontdlg.cpp:381 ../src/osx/carbon/fontdlg.cpp:383
 msgid "Click to change the font colour."
 msgstr "クリックでフォントの色を変更します。"
 
@@ -2214,38 +2218,38 @@ msgstr "クリックで文字色を変更します。"
 msgid "Click to choose the font for this level."
 msgstr "クリックでこのレベルのフォントを選択します。"
 
-#: ../src/richtext/richtextstyledlg.cpp:279
-#: ../src/richtext/richtextstyledlg.cpp:281
+#: ../src/richtext/richtextstyledlg.cpp:275
+#: ../src/richtext/richtextstyledlg.cpp:277
 msgid "Click to close this window."
 msgstr "クリックでこのウィンドウを閉じます。"
 
-#: ../src/osx/carbon/fontdlg.cpp:410 ../src/osx/carbon/fontdlg.cpp:412
+#: ../src/osx/carbon/fontdlg.cpp:407 ../src/osx/carbon/fontdlg.cpp:409
 msgid "Click to confirm changes to the font."
 msgstr "クリックでフォントの変更を確定します。"
 
-#: ../src/generic/fontdlgg.cpp:477 ../src/generic/fontdlgg.cpp:479
-#: ../src/generic/fontdlgg.cpp:484 ../src/generic/fontdlgg.cpp:486
+#: ../src/generic/fontdlgg.cpp:473 ../src/generic/fontdlgg.cpp:475
+#: ../src/generic/fontdlgg.cpp:480 ../src/generic/fontdlgg.cpp:482
 msgid "Click to confirm the font selection."
 msgstr "クリックでフォントの選択を確定します。"
 
-#: ../src/richtext/richtextstyledlg.cpp:244
-#: ../src/richtext/richtextstyledlg.cpp:246
+#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:242
 #, fuzzy
 msgid "Click to create a new box style."
 msgstr "クリックで新しいリストスタイルを作成できます。"
 
-#: ../src/richtext/richtextstyledlg.cpp:226
-#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:224
 msgid "Click to create a new character style."
 msgstr "クリックで新しい文字スタイルを作成できます。"
 
-#: ../src/richtext/richtextstyledlg.cpp:238
-#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:236
 msgid "Click to create a new list style."
 msgstr "クリックで新しいリストスタイルを作成できます。"
 
-#: ../src/richtext/richtextstyledlg.cpp:232
-#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:230
 msgid "Click to create a new paragraph style."
 msgstr "クリックで新しい段落スタイルを作成できます。"
 
@@ -2259,8 +2263,8 @@ msgstr "クリックで新しいタブ位置を作成できます。"
 msgid "Click to delete all tab positions."
 msgstr "クリックですべてのタブ位置を削除できます。"
 
-#: ../src/richtext/richtextstyledlg.cpp:270
-#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:268
 msgid "Click to delete the selected style."
 msgstr "クリックで選択したスタイルを削除できます。"
 
@@ -2269,25 +2273,25 @@ msgstr "クリックで選択したスタイルを削除できます。"
 msgid "Click to delete the selected tab position."
 msgstr "クリックで選択した他部位置を削除できます。"
 
-#: ../src/richtext/richtextstyledlg.cpp:264
-#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:262
 msgid "Click to edit the selected style."
 msgstr "クリックで選択したスタイルを編集できます。"
 
-#: ../src/richtext/richtextstyledlg.cpp:258
-#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:256
 msgid "Click to rename the selected style."
 msgstr "クリックで選択したスタイルの名前を変更できます。"
 
-#: ../src/generic/dbgrptg.cpp:97 ../src/generic/progdlgg.cpp:759
-#: ../src/richtext/richtextstyledlg.cpp:277
-#: ../src/richtext/richtextsymboldlg.cpp:476 ../src/common/stockitem.cpp:148
-#: ../src/msw/progdlg.cpp:170 ../src/msw/progdlg.cpp:679
-#: ../src/html/helpdlg.cpp:90
+#: ../src/common/stockitem.cpp:145 ../src/generic/dbgrptg.cpp:94
+#: ../src/generic/progdlgg.cpp:781 ../src/msw/progdlg.cpp:211
+#: ../src/msw/progdlg.cpp:946 ../src/html/helpdlg.cpp:87
+#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextstyledlg.cpp:273
 msgid "Close"
 msgstr "閉じる"
 
-#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:98
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
 msgid "Close All"
 msgstr "すべて閉じる"
 
@@ -2295,66 +2299,66 @@ msgstr "すべて閉じる"
 msgid "Close current document"
 msgstr "現在の文書を閉じます"
 
-#: ../src/generic/logg.cpp:516
+#: ../src/generic/logg.cpp:513
 msgid "Close this window"
 msgstr "このウィンドウを閉じます"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6006
+#: ../src/generic/datavgen.cpp:6811
 msgid "Collapse"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 #, fuzzy
 msgid "Color"
 msgstr "色 (&C)"
 
-#: ../src/richtext/richtextformatdlg.cpp:776
+#: ../src/richtext/richtextformatdlg.cpp:768
 msgid "Colour"
 msgstr "色"
 
-#: ../src/msw/colordlg.cpp:158
+#: ../src/msw/colordlg.cpp:227
 #, c-format
 msgid "Colour selection dialog failed with error %0lx."
 msgstr "色選択ダイアログがエラー %0lx で失敗しました。"
 
-#: ../src/osx/carbon/fontdlg.cpp:380
+#: ../src/osx/carbon/fontdlg.cpp:377
 msgid "Colour:"
 msgstr "色:"
 
-#: ../src/generic/datavgen.cpp:6077
+#: ../src/generic/datavgen.cpp:6882
 #, c-format
 msgid "Column %u"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:114
+#: ../src/common/accelcmn.cpp:112
 msgid "Command"
 msgstr ""
 
-#: ../src/common/init.cpp:196
+#: ../src/common/init.cpp:193
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
 "ignored."
 msgstr "コマンドライン引数 %d はユニコードに変換できません。無視されます。"
 
-#: ../src/msw/fontdlg.cpp:120
+#: ../src/msw/fontdlg.cpp:170
 #, c-format
 msgid "Common dialog failed with error code %0lx."
 msgstr "共通ダイアログがエラー %0lx で失敗しました。"
 
-#: ../src/gtk/window.cpp:4649
+#: ../src/gtk/window.cpp:5653
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:1549
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "圧縮HTMLヘルプ (*.chm)|*.chm|"
 
-#: ../src/generic/dirctrlg.cpp:444
+#: ../src/generic/dirctrlg.cpp:410
 msgid "Computer"
 msgstr "コンピューター"
 
@@ -2363,54 +2367,58 @@ msgstr "コンピューター"
 msgid "Config entry name cannot start with '%c'."
 msgstr "設定項目名は '%c' で始めることができません。"
 
-#: ../src/generic/filedlgg.cpp:349 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
 msgid "Confirm"
 msgstr "確定"
 
-#: ../src/html/htmlwin.cpp:566
+#: ../src/html/htmlwin.cpp:569
 msgid "Connecting..."
 msgstr "接続中 ..."
 
-#: ../src/html/helpwnd.cpp:475
+#: ../src/html/helpwnd.cpp:473
 msgid "Contents"
 msgstr "目次"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:880
+#: ../src/propgrid/advprops.cpp:781
 msgid "ControlDark"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:881
+#: ../src/propgrid/advprops.cpp:782
 msgid "ControlLight"
 msgstr ""
 
-#: ../src/common/strconv.cpp:2262
+#: ../src/common/strconv.cpp:2208
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "文字集合 '%s' への変換が機能していません。"
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 #, fuzzy
 msgid "Convert"
 msgstr "変換 (&C)"
 
-#: ../src/html/htmlwin.cpp:1079
+#: ../src/html/htmlwin.cpp:1020
 #, c-format
 msgid "Copied to clipboard:\"%s\""
 msgstr "クリップボードへコピー:\"%s\""
 
-#: ../src/generic/prntdlgg.cpp:247
+#: ../src/generic/prntdlgg.cpp:240
 msgid "Copies:"
 msgstr "部数:"
 
-#: ../src/common/stockitem.cpp:150 ../src/stc/stc_i18n.cpp:18
+#: ../src/common/stockitem.cpp:147 ../src/stc/stc_i18n.cpp:18
 msgid "Copy"
 msgstr "コピー"
 
-#: ../src/common/stockitem.cpp:258
+#: ../src/common/stockitem.cpp:255
 msgid "Copy selection"
 msgstr "選択範囲をコピーします"
+
+#: ../src/generic/grid.cpp:5945
+msgid "Copying more than one selected block to clipboard is not supported."
+msgstr ""
 
 #: ../src/richtext/richtextborderspage.cpp:566
 #: ../src/richtext/richtextborderspage.cpp:601
@@ -2421,201 +2429,197 @@ msgstr ""
 msgid "Corner &radius:"
 msgstr ""
 
-#: ../src/html/chm.cpp:718
+#: ../src/html/chm.cpp:711
 #, c-format
 msgid "Could not create temporary file '%s'"
 msgstr "一時ファイル '%s' を作成できませんでした"
 
-#: ../src/html/chm.cpp:273
+#: ../src/html/chm.cpp:270
 #, c-format
 msgid "Could not extract %s into %s: %s"
 msgstr "%s を %s に展開できませんでした: %s"
 
-#: ../src/generic/tabg.cpp:1048
+#: ../src/generic/tabg.cpp:1045
 msgid "Could not find tab for id"
 msgstr "識別子に対応したタブが見つかりませんでした。"
 
-#: ../src/gtk/notifmsg.cpp:108
-#, fuzzy
-msgid "Could not initalize libnotify."
-msgstr "整列方法を設定できませんでした。"
-
-#: ../src/html/chm.cpp:444
+#: ../src/html/chm.cpp:437
 #, c-format
 msgid "Could not locate file '%s'."
 msgstr "ファイル '%s' の場所を特定できません。"
 
-#: ../src/common/filefn.cpp:1403
+#: ../src/msw/graphicsd2d.cpp:604
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/common/filefn.cpp:1291
 #, fuzzy
 msgid "Could not set current working directory"
 msgstr "作業ディレクトリーを取得できませんでした。"
 
-#: ../src/common/prntbase.cpp:2015
+#: ../src/common/prntbase.cpp:2037
 msgid "Could not start document preview."
 msgstr "文書プレビューを開始できませんでした。"
 
-#: ../src/generic/printps.cpp:178 ../src/msw/printwin.cpp:210
-#: ../src/gtk/print.cpp:1132
+#: ../src/generic/printps.cpp:159 ../src/msw/printwin.cpp:184
+#: ../src/gtk/print.cpp:1129
 msgid "Could not start printing."
 msgstr "印刷を始められませんでした。"
 
-#: ../src/common/wincmn.cpp:2125
+#: ../src/common/wincmn.cpp:2126
 msgid "Could not transfer data to window"
 msgstr "ウィンドウへデータを転送できませんでした。"
 
-#: ../src/msw/imaglist.cpp:187 ../src/msw/imaglist.cpp:224
-#: ../src/msw/imaglist.cpp:249 ../src/msw/dragimag.cpp:185
-#: ../src/msw/dragimag.cpp:220
+#: ../src/msw/imaglist.cpp:223 ../src/msw/imaglist.cpp:245
+#: ../src/msw/imaglist.cpp:270 ../src/msw/dragimag.cpp:182
+#: ../src/msw/dragimag.cpp:217
 msgid "Couldn't add an image to the image list."
 msgstr "イメージリストに画像を追加できませんでした。"
 
-#: ../src/osx/glcanvas_osx.cpp:414 ../src/unix/glx11.cpp:558
-#: ../src/msw/glcanvas.cpp:616
+#: ../src/osx/glcanvas_osx.cpp:411 ../src/msw/glcanvas.cpp:631
+#: ../src/unix/glegl.cpp:315 ../src/unix/glx11.cpp:559
 #, fuzzy
 msgid "Couldn't create OpenGL context"
 msgstr "タイマーを作成できませんでした"
 
-#: ../src/msw/timer.cpp:134
+#: ../src/msw/timer.cpp:131
 msgid "Couldn't create a timer"
 msgstr "タイマーを作成できませんでした"
 
-#: ../src/osx/carbon/overlay.cpp:122
-msgid "Couldn't create the overlay window"
-msgstr "オーバーレイウィンドウを作成できませんでした"
-
-#: ../src/common/translation.cpp:2024
+#: ../src/common/translation.cpp:2074
 #, fuzzy
 msgid "Couldn't enumerate translations"
 msgstr "スレッドを終了できませんでした"
 
-#: ../src/common/dynlib.cpp:120
+#: ../src/common/dynlib.cpp:110
 #, c-format
 msgid "Couldn't find symbol '%s' in a dynamic library"
 msgstr "シンボル '%s' が動的ライブラリーの中に見つかりませんでした"
 
-#: ../src/msw/thread.cpp:915
+#: ../src/msw/thread.cpp:921
 msgid "Couldn't get the current thread pointer"
 msgstr "現在のスレッドを示すポインタを取得できませんでした。"
 
-#: ../src/osx/carbon/overlay.cpp:129
-msgid "Couldn't init the context on the overlay window"
-msgstr "オーバーレイウィンドウの内容を初期化できませんでした。"
-
-#: ../src/common/imaggif.cpp:244
+#: ../src/common/imaggif.cpp:241
 #, fuzzy
 msgid "Couldn't initialize GIF hash table."
 msgstr "zlib の deflate ストリームを初期化できません。"
 
-#: ../src/common/imagpng.cpp:409
+#: ../src/common/imagpng.cpp:437
 msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
 msgstr "PNG画像を読み出せませんでした。ファイルが壊れているかメモリ不足です。"
 
-#: ../src/unix/sound.cpp:470
+#: ../src/unix/sound.cpp:459
 #, c-format
 msgid "Couldn't load sound data from '%s'."
 msgstr "音声データを '%s' から取得できませんでした。"
 
-#: ../src/msw/dirdlg.cpp:435
+#: ../src/msw/dirdlg.cpp:287
 #, fuzzy
 msgid "Couldn't obtain folder name"
 msgstr "タイマーを作成できませんでした"
 
-#: ../src/unix/sound_sdl.cpp:229
+#: ../src/unix/sound_sdl.cpp:226
 #, c-format
 msgid "Couldn't open audio: %s"
 msgstr "音声を開くことができませんでした: %s"
 
-#: ../src/msw/ole/dataobj.cpp:377
+#: ../src/msw/ole/dataobj.cpp:385
 #, c-format
 msgid "Couldn't register clipboard format '%s'."
 msgstr "クリップボードの様式 '%s' を登録できませんでした。"
 
-#: ../src/msw/listctrl.cpp:869
+#: ../src/msw/listctrl.cpp:933
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "リストコントロールの項目 %d に関する情報を取得できませんでした。"
 
-#: ../src/common/imagpng.cpp:498 ../src/common/imagpng.cpp:509
-#: ../src/common/imagpng.cpp:519
+#: ../src/common/imagpng.cpp:511 ../src/common/imagpng.cpp:522
+#: ../src/common/imagpng.cpp:532
 msgid "Couldn't save PNG image."
 msgstr "PNG画像を保存できませんでした"
 
-#: ../src/msw/thread.cpp:684
+#: ../src/msw/thread.cpp:676
 msgid "Couldn't terminate thread"
 msgstr "スレッドを終了できませんでした"
 
-#: ../src/common/xtistrm.cpp:166
+#: ../src/common/xtistrm.cpp:163
 #, fuzzy, c-format
 msgid "Create Parameter %s not found in declared RTTI Parameters"
 msgstr "宣言された RTTI 変数の中には Create で指定されたものがありません"
 
-#: ../src/generic/dirdlgg.cpp:288
+#: ../src/generic/dirdlgg.cpp:285
 msgid "Create directory"
 msgstr "ディレクトリーを作成します"
 
-#: ../src/generic/filedlgg.cpp:212 ../src/generic/dirdlgg.cpp:111
+#: ../src/generic/filedlgg.cpp:209 ../src/generic/dirdlgg.cpp:108
 msgid "Create new directory"
 msgstr "新しいディレクトリーを作成します"
 
-#: ../src/xrc/xmlres.cpp:2460
+#: ../src/common/stockitem.cpp:264
+#, fuzzy
+msgid "Create new document"
+msgstr "新しいディレクトリーを作成します"
+
+#: ../src/xrc/xmlres.cpp:2515
 #, fuzzy, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "'%s' を '%s' に展開できませんでした。"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1758
+#: ../src/propgrid/advprops.cpp:1659
 msgid "Cross"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:333
+#: ../src/common/accelcmn.cpp:347
 msgid "Ctrl+"
 msgstr "Ctrl+"
 
-#: ../src/richtext/richtextctrl.cpp:332 ../src/osx/textctrl_osx.cpp:576
-#: ../src/common/stockitem.cpp:151 ../src/msw/textctrl.cpp:2507
+#: ../src/osx/textctrl_osx.cpp:594 ../src/common/stockitem.cpp:148
+#: ../src/msw/textctrl.cpp:2772 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "切り取り (&T)"
 
-#: ../src/generic/filectrlg.cpp:940
+#: ../src/generic/filectrlg.cpp:936
 msgid "Current directory:"
 msgstr "カレントディレクトリー:"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:896 ../src/propgrid/advprops.cpp:1574
-#: ../src/propgrid/advprops.cpp:1612
+#: ../src/propgrid/advprops.cpp:797 ../src/propgrid/advprops.cpp:1475
+#: ../src/propgrid/advprops.cpp:1518
 #, fuzzy
 msgid "Custom"
 msgstr "任意の寸法指定"
 
-#: ../src/gtk/print.cpp:217
+#: ../src/gtk/print.cpp:211
 msgid "Custom size"
 msgstr "任意の寸法指定"
 
-#: ../src/common/headerctrlcmn.cpp:60
+#: ../src/common/headerctrlcmn.cpp:58
 msgid "Customize Columns"
 msgstr "列の編集"
 
-#: ../src/common/stockitem.cpp:151 ../src/stc/stc_i18n.cpp:17
+#: ../src/common/stockitem.cpp:148 ../src/stc/stc_i18n.cpp:17
 msgid "Cut"
 msgstr "切り取り"
 
-#: ../src/common/stockitem.cpp:259
+#: ../src/common/stockitem.cpp:256
 msgid "Cut selection"
 msgstr "選択範囲を切り取ります"
 
-#: ../src/common/fmapbase.cpp:152
+#: ../src/common/fmapbase.cpp:149
 msgid "Cyrillic (ISO-8859-5)"
 msgstr "キリル言語 (ISO-8859-5)"
 
-#: ../src/common/paper.cpp:99
+#: ../src/common/paper.cpp:96
 msgid "D sheet, 22 x 34 in"
 msgstr "Dサイズシート, 22 x 34インチ"
 
-#: ../src/msw/dde.cpp:703
+#: ../src/msw/dde.cpp:698
 msgid "DDE poke request failed"
 msgstr "DDE の poke 要求が失敗しました"
 
-#: ../src/common/imagbmp.cpp:1169
+#: ../src/common/imagbmp.cpp:1181
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr "DIB ヘッダー: エンコーディングがビット深さに対応していません。"
 
@@ -2635,7 +2639,7 @@ msgstr "DIB ヘッダー: 未知のビット深さがファイルに含まれて
 msgid "DIB Header: Unknown encoding in file."
 msgstr "DIB ヘッダー: 未知のエンコーディングがファイルに含まれています。"
 
-#: ../src/common/paper.cpp:121
+#: ../src/common/paper.cpp:118
 msgid "DL Envelope, 110 x 220 mm"
 msgstr "DL 封筒, 110×220mm"
 
@@ -2643,55 +2647,55 @@ msgstr "DL 封筒, 110×220mm"
 msgid "Dashed"
 msgstr ""
 
-#: ../src/generic/dbgrptg.cpp:300
+#: ../src/generic/dbgrptg.cpp:301
 #, c-format
 msgid "Debug report \"%s\""
 msgstr "デバッグレポート \"%s\""
 
-#: ../src/common/debugrpt.cpp:210
+#: ../src/common/debugrpt.cpp:211
 msgid "Debug report couldn't be created."
 msgstr "デバッグレポートを作成できません。"
 
-#: ../src/common/debugrpt.cpp:553
+#: ../src/common/debugrpt.cpp:554
 msgid "Debug report generation has failed."
 msgstr "デバッグレポートの作成に失敗しました。"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:84
+#: ../src/common/accelcmn.cpp:81
 msgid "Decimal"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:323
+#: ../src/generic/fontdlgg.cpp:319
 msgid "Decorative"
 msgstr "Decorative"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1752
+#: ../src/propgrid/advprops.cpp:1653
 #, fuzzy
 msgid "Default"
 msgstr "規定"
 
-#: ../src/common/fmapbase.cpp:796
+#: ../src/common/fmapbase.cpp:792
 msgid "Default encoding"
 msgstr "既定のエンコーディング"
 
-#: ../src/dfb/fontmgr.cpp:180
+#: ../src/dfb/fontmgr.cpp:177
 msgid "Default font"
 msgstr "既定のフォント"
 
-#: ../src/generic/prntdlgg.cpp:510
+#: ../src/generic/prntdlgg.cpp:503
 msgid "Default printer"
 msgstr "既定のプリンター"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:51
+#: ../src/common/accelcmn.cpp:48
 #, fuzzy
 msgid "Del"
 msgstr "削除"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextbuffer.cpp:8221 ../src/common/stockitem.cpp:152
-#: ../src/common/accelcmn.cpp:50 ../src/stc/stc_i18n.cpp:20
+#: ../src/common/stockitem.cpp:149 ../src/common/accelcmn.cpp:47
+#: ../src/richtext/richtextbuffer.cpp:8217 ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "削除"
 
@@ -2699,71 +2703,71 @@ msgstr "削除"
 msgid "Delete A&ll"
 msgstr "すべて削除(&L)"
 
-#: ../src/richtext/richtextbuffer.cpp:11341
+#: ../src/richtext/richtextbuffer.cpp:11340
 #, fuzzy
 msgid "Delete Column"
 msgstr "選択範囲の削除"
 
-#: ../src/richtext/richtextbuffer.cpp:11291
+#: ../src/richtext/richtextbuffer.cpp:11290
 #, fuzzy
 msgid "Delete Row"
 msgstr "削除"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 msgid "Delete Style"
 msgstr "スタイルの削除"
 
-#: ../src/richtext/richtextctrl.cpp:1345 ../src/richtext/richtextctrl.cpp:1584
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
 msgid "Delete Text"
 msgstr "テキストの削除"
 
-#: ../src/generic/editlbox.cpp:170
+#: ../src/generic/editlbox.cpp:147
 msgid "Delete item"
 msgstr "項目の削除"
 
-#: ../src/common/stockitem.cpp:260
+#: ../src/common/stockitem.cpp:257
 msgid "Delete selection"
 msgstr "選択範囲の削除"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 #, c-format
 msgid "Delete style %s?"
 msgstr "スタイル %s を削除しますか?"
 
-#: ../src/unix/snglinst.cpp:301
+#: ../src/unix/snglinst.cpp:298
 #, c-format
 msgid "Deleted stale lock file '%s'."
 msgstr "無効なロックファイル '%s' を削除しました。"
 
-#: ../src/common/secretstore.cpp:220
+#: ../src/common/secretstore.cpp:234
 #, fuzzy, c-format
-msgid "Deleting password for \"%s/%s\" failed: %s."
+msgid "Deleting password for \"%s\" failed: %s."
 msgstr "'%s' を '%s' に展開できませんでした。"
 
-#: ../src/common/module.cpp:124
+#: ../src/common/module.cpp:121
 #, c-format
 msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
 msgstr "依存先の \"%s\" (モジュール \"%s\" 内) は存在しません。"
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 #, fuzzy
 msgid "Descending"
 msgstr "降順 (&D)"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:526 ../src/propgrid/advprops.cpp:882
+#: ../src/generic/dirctrlg.cpp:492 ../src/propgrid/advprops.cpp:783
 msgid "Desktop"
 msgstr "デスクトップ"
 
-#: ../src/generic/aboutdlgg.cpp:70
+#: ../src/generic/aboutdlgg.cpp:67
 msgid "Developed by "
 msgstr "開発 : "
 
-#: ../src/generic/aboutdlgg.cpp:176
+#: ../src/generic/aboutdlgg.cpp:173
 msgid "Developers"
 msgstr "開発者"
 
-#: ../src/msw/dialup.cpp:374
+#: ../src/msw/dialup.cpp:368
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -2771,11 +2775,11 @@ msgstr ""
 "リモートアクセスサービス(RAS)がインストールされていないため、ダイヤルアップは"
 "機能しません。RASをインストールしてください。"
 
-#: ../src/generic/tipdlg.cpp:211
+#: ../src/generic/tipdlg.cpp:208
 msgid "Did you know..."
 msgstr "ご存じですか?"
 
-#: ../src/dfb/wrapdfb.cpp:63
+#: ../src/dfb/wrapdfb.cpp:60
 #, fuzzy, c-format
 msgid "DirectFB error %d occurred."
 msgstr "DirectFB エラー %d が発生しました。"
@@ -2784,75 +2788,75 @@ msgstr "DirectFB エラー %d が発生しました。"
 msgid "Directories"
 msgstr "ディレクトリー"
 
-#: ../src/common/filefn.cpp:1183
+#: ../src/common/filefn.cpp:1071
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "ディレクトリー '%s' を作成できませんでした"
 
-#: ../src/common/filefn.cpp:1197
+#: ../src/common/filefn.cpp:1085
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "ディレクトリー '%s' を削除できませんでした"
 
-#: ../src/generic/dirdlgg.cpp:204
+#: ../src/generic/dirdlgg.cpp:201
 msgid "Directory does not exist"
 msgstr "ディレクトリーが存在しません"
 
-#: ../src/generic/filectrlg.cpp:1399
+#: ../src/generic/filectrlg.cpp:1388
 msgid "Directory doesn't exist."
 msgstr "ディレクトリーが存在しません。"
 
-#: ../src/common/docview.cpp:457
+#: ../src/common/docview.cpp:450
 msgid "Discard changes and reload the last saved version?"
 msgstr "変更を破棄して最後に保存したものを読み直しますか?"
 
-#: ../src/html/helpwnd.cpp:502
+#: ../src/html/helpwnd.cpp:500
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
 msgstr ""
 "与えられた文字列を含む索引項目を表示します。大文字小文字は区別しません。"
 
-#: ../src/html/helpwnd.cpp:679
+#: ../src/html/helpwnd.cpp:677
 msgid "Display options dialog"
 msgstr "オプションダイアログを表示します"
 
-#: ../src/html/helpwnd.cpp:322
+#: ../src/html/helpwnd.cpp:320
 msgid "Displays help as you browse the books on the left."
 msgstr "横に置く本のようにヘルプを表示します。"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:85
+#: ../src/common/accelcmn.cpp:83
 msgid "Divide"
 msgstr ""
 
-#: ../src/common/docview.cpp:533
+#: ../src/common/docview.cpp:526
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "変更結果を %s へ保存しますか?"
 
-#: ../src/common/prntbase.cpp:542
+#: ../src/common/prntbase.cpp:537
 #, fuzzy
 msgid "Document:"
 msgstr "説明書 : "
 
-#: ../src/generic/aboutdlgg.cpp:73
+#: ../src/generic/aboutdlgg.cpp:70
 msgid "Documentation by "
 msgstr "説明書 : "
 
-#: ../src/generic/aboutdlgg.cpp:180
+#: ../src/generic/aboutdlgg.cpp:177
 msgid "Documentation writers"
 msgstr "説明書の著者"
 
-#: ../src/common/sizer.cpp:2799
+#: ../src/common/sizer.cpp:2916
 msgid "Don't Save"
 msgstr "保存しない"
 
-#: ../src/html/htmlwin.cpp:633
+#: ../src/html/htmlwin.cpp:643
 msgid "Done"
 msgstr "完了"
 
-#: ../src/generic/progdlgg.cpp:448 ../src/msw/progdlg.cpp:407
+#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
 msgid "Done."
 msgstr "完了しました。"
 
@@ -2866,43 +2870,43 @@ msgstr "完了"
 msgid "Double"
 msgstr "double値"
 
-#: ../src/common/paper.cpp:176
+#: ../src/common/paper.cpp:173
 msgid "Double Japanese Postcard Rotated 148 x 200 mm"
 msgstr "往復はがき横置き 148×200mm"
 
-#: ../src/common/xtixml.cpp:273
+#: ../src/common/xtixml.cpp:269
 #, c-format
 msgid "Doubly used id : %d"
 msgstr "識別子が重複しています: %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:153
-#: ../src/common/accelcmn.cpp:64
+#: ../src/common/stockitem.cpp:150 ../src/common/accelcmn.cpp:61
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Down"
 msgstr "下へ"
 
-#: ../src/richtext/richtextctrl.cpp:865
+#: ../src/richtext/richtextctrl.cpp:864
 msgid "Drag"
 msgstr ""
 
-#: ../src/common/paper.cpp:100
+#: ../src/common/paper.cpp:97
 msgid "E sheet, 34 x 44 in"
 msgstr "Eサイズシート, 34 x 44インチ"
 
-#: ../src/unix/fswatcher_inotify.cpp:561
+#: ../src/unix/fswatcher_inotify.cpp:558
 msgid "EOF while reading from inotify descriptor"
 msgstr "inotify 記述子 %d の読み取り中にEOFを検出しました"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 #, fuzzy
 msgid "Edit"
 msgstr "編集(&E)"
 
-#: ../src/generic/editlbox.cpp:168
+#: ../src/generic/editlbox.cpp:131
 msgid "Edit item"
 msgstr "項目の編集"
 
-#: ../include/wx/generic/progdlgg.h:84
+#: ../include/wx/generic/progdlgg.h:85
 msgid "Elapsed time:"
 msgstr "経過時間:"
 
@@ -2976,64 +2980,64 @@ msgid "Enables the shadow spread."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:66
+#: ../src/common/accelcmn.cpp:63
 msgid "End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:55
+#: ../src/common/accelcmn.cpp:52
 #, fuzzy
 msgid "Enter"
 msgstr "プリンター"
 
-#: ../src/richtext/richtextstyledlg.cpp:934
+#: ../src/richtext/richtextstyledlg.cpp:930
 #, fuzzy
 msgid "Enter a box style name"
 msgstr "新しいスタイル名を入力してください。"
 
-#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:602
 msgid "Enter a character style name"
 msgstr "文字スタイル名を入力してください。"
 
-#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:816
 msgid "Enter a list style name"
 msgstr "リストスタイル名を入力してください。"
 
-#: ../src/richtext/richtextstyledlg.cpp:893
+#: ../src/richtext/richtextstyledlg.cpp:889
 msgid "Enter a new style name"
 msgstr "新しいスタイル名を入力してください。"
 
-#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:650
 msgid "Enter a paragraph style name"
 msgstr "段落スタイル名を指定してください。"
 
-#: ../src/generic/dbgrptg.cpp:174
+#: ../src/generic/dbgrptg.cpp:171
 #, c-format
 msgid "Enter command to open file \"%s\":"
 msgstr "\"%s\" ファイルを開くためのコマンドを入力してください:"
 
-#: ../src/generic/helpext.cpp:459
+#: ../src/generic/helpext.cpp:457
 msgid "Entries found"
 msgstr "候補が見つかりました"
 
-#: ../src/common/paper.cpp:142
+#: ../src/common/paper.cpp:139
 msgid "Envelope Invite 220 x 220 mm"
 msgstr "封筒 Invite 220 x 220 mm"
 
-#: ../src/common/config.cpp:469
+#: ../src/common/config.cpp:465
 #, c-format
 msgid ""
 "Environment variables expansion failed: missing '%c' at position %u in '%s'."
 msgstr ""
 "環境変数拡張に失敗しました: '%c' が %u 文字目 ('%s' 内) に欠けています。"
 
-#: ../src/generic/filedlgg.cpp:357 ../src/generic/dirctrlg.cpp:570
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/dirctrlg.cpp:599
-#: ../src/generic/dirdlgg.cpp:323 ../src/generic/filectrlg.cpp:642
-#: ../src/generic/filectrlg.cpp:756 ../src/generic/filectrlg.cpp:770
-#: ../src/generic/filectrlg.cpp:786 ../src/generic/filectrlg.cpp:1368
-#: ../src/generic/filectrlg.cpp:1399 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/gtk1/fontdlg.cpp:74 ../src/generic/dirctrlg.cpp:536
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/dirctrlg.cpp:565
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1357 ../src/generic/filectrlg.cpp:1388
+#: ../src/generic/filedlgg.cpp:354 ../src/generic/dirdlgg.cpp:320
+#: ../src/gtk/filedlg.cpp:74
 msgid "Error"
 msgstr "エラー"
 
@@ -3041,89 +3045,100 @@ msgstr "エラー"
 msgid "Error closing epoll descriptor"
 msgstr "epoll記述子を閉じる際のエラー"
 
-#: ../src/unix/fswatcher_kqueue.cpp:114
+#: ../src/unix/fswatcher_kqueue.cpp:131
 msgid "Error closing kqueue instance"
 msgstr "kqueue 実体を閉じる際のエラー"
 
-#: ../src/common/filefn.cpp:1049
+#: ../src/common/filefn.cpp:938
 #, fuzzy, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "ファイル '%s' を '%s' へコピーできませんでした。"
 
-#: ../src/generic/dirdlgg.cpp:222
+#: ../src/generic/dirdlgg.cpp:219
 msgid "Error creating directory"
 msgstr "ディレクトリー作成エラー"
 
-#: ../src/common/imagbmp.cpp:1181
+#: ../src/common/imagbmp.cpp:1193
 msgid "Error in reading image DIB."
 msgstr "画像のDIB読み取りエラー。"
 
-#: ../src/propgrid/propgrid.cpp:6696
+#: ../src/propgrid/propgrid.cpp:6665
 #, c-format
 msgid "Error in resource: %s"
 msgstr "リソースにエラー: %s"
 
-#: ../src/common/fileconf.cpp:422
+#: ../src/common/fileconf.cpp:421
 msgid "Error reading config options."
 msgstr "設定オプションの読み取りエラー"
+
+#: ../src/msw/webview_ie.cpp:1057 ../src/msw/webview_edge.cpp:850
+#: ../src/gtk/webview_webkit2.cpp:1262 ../src/osx/webview_webkit.mm:383
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
 
 #: ../src/common/fileconf.cpp:1029
 msgid "Error saving user configuration data."
 msgstr "ユーザー設定データの保存中にエラーが発生しました。"
 
-#: ../src/gtk/print.cpp:722
+#: ../src/gtk/print.cpp:720
 msgid "Error while printing: "
 msgstr "印刷中にエラー発生: "
 
-#: ../src/common/log.cpp:219
+#: ../src/common/log.cpp:237
 msgid "Error: "
 msgstr "エラー:"
 
+#: ../src/common/webrequest.cpp:98
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "エラー:"
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:69
+#: ../src/common/accelcmn.cpp:66
 msgid "Esc"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:70
+#: ../src/common/accelcmn.cpp:67
 #, fuzzy
 msgid "Escape"
 msgstr "横置き"
 
-#: ../src/common/fmapbase.cpp:150
+#: ../src/common/fmapbase.cpp:147
 msgid "Esperanto (ISO-8859-3)"
 msgstr "エスペラントほか (Latin-3, ISO-8859-3)"
 
-#: ../include/wx/generic/progdlgg.h:85
+#: ../include/wx/generic/progdlgg.h:86
 msgid "Estimated time:"
 msgstr "予定時間:"
 
-#: ../src/generic/dbgrptg.cpp:234
+#: ../src/generic/dbgrptg.cpp:231
 #, fuzzy
 msgid "Executable files (*.exe)|*.exe|"
 msgstr "実行ファイル (*.exe)|*.exe|すべてのファイル (*.*)|*.*||"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:155 ../src/common/accelcmn.cpp:78
+#: ../src/common/stockitem.cpp:152 ../src/common/accelcmn.cpp:75
 #, fuzzy
 msgid "Execute"
 msgstr "実行 (&E)"
 
-#: ../src/msw/utilsexc.cpp:876
+#: ../src/msw/utilsexc.cpp:873
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "コマンド '%s' を実行できませんでした。"
 
-#: ../src/common/paper.cpp:105
+#: ../src/common/paper.cpp:102
 msgid "Executive, 7 1/4 x 10 1/2 in"
 msgstr "エグゼキュティブ, 7 1/4 x 10 1/2インチ"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6009
+#: ../src/generic/datavgen.cpp:6814
 msgid "Expand"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1240
+#: ../src/msw/registry.cpp:1228
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
@@ -3131,147 +3146,157 @@ msgstr ""
 "レジストリーのエクスポート: ファイル \"%s\" はすでに存在します。上書きも行い"
 "ません。"
 
-#: ../src/common/fmapbase.cpp:195
+#: ../src/common/fmapbase.cpp:192
 msgid "Extended Unix Codepage for Japanese (EUC-JP)"
 msgstr "日本語EUC (EUC-JP)"
 
-#: ../src/html/chm.cpp:725
+#: ../src/html/chm.cpp:718
 #, c-format
 msgid "Extraction of '%s' into '%s' failed."
 msgstr "'%s' を '%s' に展開できませんでした。"
 
-#: ../src/common/accelcmn.cpp:249 ../src/common/accelcmn.cpp:344
+#: ../src/common/accelcmn.cpp:259 ../src/common/accelcmn.cpp:358
 msgid "F"
 msgstr "F"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:672
+#: ../src/propgrid/advprops.cpp:582
 msgid "Face Name"
 msgstr "フォント名"
 
-#: ../src/unix/snglinst.cpp:269
+#: ../src/unix/snglinst.cpp:266
 msgid "Failed to access lock file."
 msgstr "ロックファイルへアクセスできませんでした。"
+
+#: ../src/gtk/font.cpp:572
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "ファイル \"%s\" から文書を読み取れませんでした。"
 
 #: ../src/unix/epolldispatcher.cpp:116
 #, c-format
 msgid "Failed to add descriptor %d to epoll descriptor %d"
 msgstr "記述子 %d を epoll 記述子 %d に追加できませんでした"
 
-#: ../src/msw/dib.cpp:489
+#: ../src/msw/dib.cpp:535
 #, c-format
 msgid "Failed to allocate %luKb of memory for bitmap data."
 msgstr "ビットマップデータ用のメモリ割り当て(%luKb)に失敗しました。"
 
-#: ../src/common/glcmn.cpp:115
+#: ../src/common/glcmn.cpp:112
 msgid "Failed to allocate colour for OpenGL"
 msgstr "OpenGL に色を割り当てることができませんでした。"
 
-#: ../src/unix/displayx11.cpp:236
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "OpenGL に色を割り当てることができませんでした。"
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "OpenGL に色を割り当てることができませんでした。"
+
+#: ../include/wx/unix/private/displayx11.h:89
 msgid "Failed to change video mode"
 msgstr "画面モード変更に失敗しました。"
 
-#: ../src/common/image.cpp:3277
+#: ../src/common/image.cpp:3396
 #, fuzzy, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "ファイル \"%s\" にビットマップイメージを保存できませんでした。"
 
-#: ../src/common/debugrpt.cpp:239
+#: ../src/common/debugrpt.cpp:240
 #, c-format
 msgid "Failed to clean up debug report directory \"%s\""
 msgstr "デバッグレポートディレクトリーを全削除できませんでした \"%s\""
 
-#: ../src/common/filename.cpp:192
+#: ../src/common/filename.cpp:189
 msgid "Failed to close file handle"
 msgstr "ファイルハンドルを閉じることができませんでした。"
 
-#: ../src/unix/snglinst.cpp:340
+#: ../src/unix/snglinst.cpp:337
 #, c-format
 msgid "Failed to close lock file '%s'"
 msgstr "ロックファイル '%s' を閉じることができませんでした。"
 
-#: ../src/msw/clipbrd.cpp:112
+#: ../src/msw/clipbrd.cpp:110
 msgid "Failed to close the clipboard."
 msgstr "クリップボードを閉じることができませんでした。"
 
-#: ../src/x11/utils.cpp:208
+#: ../src/x11/utils.cpp:170
 #, c-format
 msgid "Failed to close the display \"%s\""
 msgstr "ディスプレイ \"%s\" を閉じることができませんでした。"
 
-#: ../src/msw/dialup.cpp:797
+#: ../src/msw/dialup.cpp:791
 msgid "Failed to connect: missing username/password."
 msgstr "接続に失敗: username/password が欠けています。"
 
-#: ../src/msw/dialup.cpp:743
+#: ../src/msw/dialup.cpp:737
 msgid "Failed to connect: no ISP to dial."
 msgstr "接続失敗: ダイヤル先のISPがありません。"
 
-#: ../src/common/textfile.cpp:203
-#, c-format
-msgid "Failed to convert file \"%s\" to Unicode."
-msgstr "ファイル \"%s\" を Unicode に変換できませんでした。"
-
-#: ../src/generic/logg.cpp:956
+#: ../src/generic/logg.cpp:953
 msgid "Failed to copy dialog contents to the clipboard."
 msgstr "ダイアログの内容をクリップボードにコピーできませんでした。"
 
-#: ../src/msw/registry.cpp:692
+#: ../src/msw/registry.cpp:681
 #, c-format
 msgid "Failed to copy registry value '%s'"
 msgstr "レジストリーの値 '%s' をコピーできませんでした。"
 
-#: ../src/msw/registry.cpp:701
+#: ../src/msw/registry.cpp:690
 #, c-format
 msgid "Failed to copy the contents of registry key '%s' to '%s'."
 msgstr "レジストリーキー '%s' の内容を '%s' へコピーできませんでした。"
 
-#: ../src/common/filefn.cpp:1015
+#: ../src/common/filefn.cpp:904
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "ファイル '%s' を '%s' へコピーできませんでした。"
 
-#: ../src/msw/registry.cpp:679
+#: ../src/msw/registry.cpp:668
 #, c-format
 msgid "Failed to copy the registry subkey '%s' to '%s'."
 msgstr "レジストリーのサブキー '%s' を '%s' へコピーできませんでした。"
 
-#: ../src/msw/dde.cpp:1070
+#: ../src/msw/dde.cpp:1134
 msgid "Failed to create DDE string"
 msgstr "DDE文字列を作成できませんでした。"
 
-#: ../src/msw/mdi.cpp:616
+#: ../src/msw/mdi.cpp:621
 msgid "Failed to create MDI parent frame."
 msgstr "MDI親フレームを作成できませんでした。"
 
-#: ../src/common/filename.cpp:1027
+#: ../src/common/filename.cpp:1024
 msgid "Failed to create a temporary file name"
 msgstr "一時ファイルの名前を作成できませんでした。"
 
-#: ../src/msw/utilsexc.cpp:228
+#: ../src/msw/utilsexc.cpp:225
 msgid "Failed to create an anonymous pipe"
 msgstr "匿名パイプを作成できませんでした。"
 
-#: ../src/msw/ole/automtn.cpp:522
+#: ../src/msw/ole/automtn.cpp:513
 #, fuzzy, c-format
 msgid "Failed to create an instance of \"%s\""
 msgstr "ディレクトリー \"%s\" を作成できませんでした。"
 
-#: ../src/msw/dde.cpp:437
+#: ../src/msw/dde.cpp:432
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "サーバー '%s' へのトピック '%s' 接続を確立できませんでした。"
 
-#: ../src/msw/cursor.cpp:204
+#: ../src/msw/cursor.cpp:195
 msgid "Failed to create cursor."
 msgstr "カーソルを作成できませんでした。"
 
-#: ../src/common/debugrpt.cpp:209
+#: ../src/common/debugrpt.cpp:210
 #, c-format
 msgid "Failed to create directory \"%s\""
 msgstr "ディレクトリー \"%s\" を作成できませんでした。"
 
-#: ../src/generic/dirdlgg.cpp:220
+#: ../src/generic/dirdlgg.cpp:217
 #, c-format
 msgid ""
 "Failed to create directory '%s'\n"
@@ -3284,114 +3309,133 @@ msgstr ""
 msgid "Failed to create epoll descriptor"
 msgstr "epoll 記述子を作成できませんでした"
 
-#: ../src/msw/mimetype.cpp:238
+#: ../src/gtk/font.cpp:562
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "ユーザー設定ファイルを更新できませんでした。"
+
+#: ../src/msw/mimetype.cpp:235
 #, c-format
 msgid "Failed to create registry entry for '%s' files."
 msgstr "'%s' 用のレジストリエントリを作成できませんでした。"
 
-#: ../src/msw/fdrepdlg.cpp:409
+#: ../src/msw/fdrepdlg.cpp:408
 #, c-format
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr "標準の検索置換ダイアログを作成できませんでした (エラーコード %d)"
 
-#: ../src/unix/wakeuppipe.cpp:52
+#: ../src/unix/wakeuppipe.cpp:49
 msgid "Failed to create wake up pipe used by event loop."
 msgstr "イベントループが使う起動パイプの作成に失敗しました。"
 
-#: ../src/html/winpars.cpp:730
+#: ../src/html/winpars.cpp:727
 #, c-format
 msgid "Failed to display HTML document in %s encoding"
 msgstr "%s エンコーディングで HTML 文書を表示できませんでした。"
 
-#: ../src/msw/clipbrd.cpp:124
+#: ../src/msw/clipbrd.cpp:122
 msgid "Failed to empty the clipboard."
 msgstr "クリップボードを空にできませんでした。"
 
-#: ../src/unix/displayx11.cpp:212
+#: ../include/wx/unix/private/displayx11.h:65
 msgid "Failed to enumerate video modes"
 msgstr "画面モードを列挙できませんでした。"
 
-#: ../src/msw/dde.cpp:722
+#: ../src/msw/dde.cpp:717
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "DDE サーバーとのアドバイスループを確立できませんでした。"
 
-#: ../src/msw/dialup.cpp:629 ../src/msw/dialup.cpp:863
+#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "ダイヤルアップ接続を確立できませんでした: %s"
 
-#: ../src/unix/utilsunx.cpp:611
+#: ../src/unix/utilsunx.cpp:613
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "'%s' の実行に失敗しました\n"
 
-#: ../src/common/debugrpt.cpp:720
+#: ../src/common/debugrpt.cpp:730
 msgid "Failed to execute curl, please install it in PATH."
 msgstr "curl を実行できません。PATHの参照先にインストールしてください。"
 
-#: ../src/msw/ole/automtn.cpp:505
+#: ../src/msw/ole/automtn.cpp:496
 #, fuzzy, c-format
 msgid "Failed to find CLSID of \"%s\""
 msgstr "リソース \"%s\" を読み取れませんでした。"
 
-#: ../src/common/regex.cpp:431 ../src/common/regex.cpp:479
+#: ../src/common/regex.cpp:428 ../src/common/regex.cpp:476
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "正規表現に合致する部分が見つかりませんでした: %s"
 
-#: ../src/msw/dialup.cpp:695
+#: ../src/msw/webview_ie.cpp:978
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:689
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "ISP名を取得できませんでした: %s"
 
-#: ../src/msw/ole/automtn.cpp:574
+#: ../src/msw/ole/automtn.cpp:565
 #, fuzzy, c-format
 msgid "Failed to get OLE automation interface for \"%s\""
 msgstr "ディレクトリー \"%s\" を作成できませんでした。"
 
-#: ../src/msw/clipbrd.cpp:711
+#: ../src/msw/clipbrd.cpp:731
 msgid "Failed to get data from the clipboard"
 msgstr "クリップボードからデータを取得できませんでした。"
 
-#: ../src/common/time.cpp:223
+#: ../src/common/time.cpp:216
 msgid "Failed to get the local system time"
 msgstr "ローカルのシステム時刻を取得できませんでした。"
 
-#: ../src/common/filefn.cpp:1345
+#: ../src/common/filefn.cpp:1233
 msgid "Failed to get the working directory"
 msgstr "作業ディレクトリーを取得できませんでした。"
 
-#: ../src/univ/theme.cpp:114
+#: ../src/univ/theme.cpp:111
 msgid "Failed to initialize GUI: no built-in themes found."
 msgstr "GUIの初期化に失敗: ビルトインテーマがありません。"
 
-#: ../src/msw/helpchm.cpp:63
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:60
 msgid "Failed to initialize MS HTML Help."
 msgstr "Microsoft HTML Help を初期化できませんでした。"
 
-#: ../src/msw/glcanvas.cpp:1381
+#: ../src/msw/glcanvas.cpp:1391
 msgid "Failed to initialize OpenGL"
 msgstr "OpenGLを初期化できませんでした。"
 
-#: ../src/msw/dialup.cpp:858
+#: ../src/msw/dialup.cpp:852
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "ダイヤルアップ接続の初期化に失敗しました: %s "
 
-#: ../src/gtk/textctrl.cpp:1128
+#: ../src/gtk/textctrl.cpp:1209
 msgid "Failed to insert text in the control."
 msgstr "そのコントロールにテキストを挿入できませんでした。"
 
-#: ../src/unix/snglinst.cpp:241
+#: ../src/unix/snglinst.cpp:238
 #, c-format
 msgid "Failed to inspect the lock file '%s'"
 msgstr "ロックファイル '%s' を検査できませんでした"
 
-#: ../src/unix/appunix.cpp:182
+#: ../src/unix/appunix.cpp:179
 msgid "Failed to install signal handler"
 msgstr "シグナルハンドラーのインストールに失敗しました。"
 
-#: ../src/unix/threadpsx.cpp:1167
+#: ../src/unix/threadpsx.cpp:1216
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -3399,71 +3443,71 @@ msgstr ""
 "スレッド接合に失敗しました。メモリリーク発生の可能性があります。プログラムを"
 "再起動してください。"
 
-#: ../src/msw/utils.cpp:629
+#: ../src/msw/utils.cpp:619
 #, c-format
 msgid "Failed to kill process %d"
 msgstr "プロセス %d の kill に失敗しました"
 
-#: ../src/common/image.cpp:2500
+#: ../src/common/image.cpp:2595
 #, fuzzy, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "画像 %d をストリームから読み取れませんでした。"
 
-#: ../src/common/image.cpp:2509
+#: ../src/common/image.cpp:2604
 #, fuzzy, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "画像 %d をストリームから読み取れませんでした。"
 
-#: ../src/common/iconbndl.cpp:225
+#: ../src/common/iconbndl.cpp:224
 #, fuzzy, c-format
 msgid "Failed to load icons from resource '%s'."
 msgstr "画像 %d をストリームから読み取れませんでした。"
 
-#: ../src/common/iconbndl.cpp:200
+#: ../src/common/iconbndl.cpp:198
 #, c-format
 msgid "Failed to load image %%d from file '%s'."
 msgstr "画像 %%d をファイル '%s' から読み取れませんでした。"
 
-#: ../src/common/iconbndl.cpp:208
+#: ../src/common/iconbndl.cpp:206
 #, c-format
 msgid "Failed to load image %d from stream."
 msgstr "画像 %d をストリームから読み取れませんでした。"
 
-#: ../src/common/image.cpp:2587 ../src/common/image.cpp:2606
+#: ../src/common/image.cpp:2682 ../src/common/image.cpp:2701
 #, fuzzy, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "ファイル \"%s\" からメタファイルを読み取れませんでした。"
 
-#: ../src/msw/enhmeta.cpp:97
+#: ../src/msw/enhmeta.cpp:94
 #, c-format
 msgid "Failed to load metafile from file \"%s\"."
 msgstr "ファイル \"%s\" からメタファイルを読み取れませんでした。"
 
-#: ../src/msw/volume.cpp:327
+#: ../src/msw/volume.cpp:335
 msgid "Failed to load mpr.dll."
 msgstr "mpr.dll を読み取れませんでした。"
 
-#: ../src/msw/utils.cpp:953
+#: ../src/msw/utils.cpp:943
 #, c-format
 msgid "Failed to load resource \"%s\"."
 msgstr "リソース \"%s\" を読み取れませんでした。"
 
-#: ../src/common/dynlib.cpp:92
+#: ../src/common/dynlib.cpp:86
 #, c-format
 msgid "Failed to load shared library '%s'"
 msgstr "共有ライブラリ '%s' を読み取れませんでした。"
 
-#: ../src/osx/core/sound.cpp:145
+#: ../src/osx/core/sound.cpp:143
 #, fuzzy, c-format
 msgid "Failed to load sound from \"%s\" (error %d)."
 msgstr "リソース \"%s\" を読み取れませんでした。"
 
-#: ../src/msw/utils.cpp:960
+#: ../src/msw/utils.cpp:950
 #, c-format
 msgid "Failed to lock resource \"%s\"."
 msgstr "リソース \"%s\" をロックできませんでした。"
 
-#: ../src/unix/snglinst.cpp:198
+#: ../src/unix/snglinst.cpp:195
 #, c-format
 msgid "Failed to lock the lock file '%s'"
 msgstr "ロックファイル '%s' をロックできませんでした"
@@ -3473,33 +3517,38 @@ msgstr "ロックファイル '%s' をロックできませんでした"
 msgid "Failed to modify descriptor %d in epoll descriptor %d"
 msgstr "記述子 %d の変更が epoll 記述子 %d 内でできませんでした"
 
-#: ../src/common/filename.cpp:2575
+#: ../src/common/filename.cpp:2658
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "'%s' のファイル時刻を変更できませんでした"
 
-#: ../src/common/selectdispatcher.cpp:258
+#: ../src/common/selectdispatcher.cpp:255
 msgid "Failed to monitor I/O channels"
 msgstr "I/O チャンネルの監視に失敗しました。"
 
-#: ../src/common/filename.cpp:175
+#: ../src/common/filename.cpp:172
 #, c-format
 msgid "Failed to open '%s' for reading"
 msgstr "読み取りのためのファイル '%s' を開くことができません"
 
-#: ../src/common/filename.cpp:180
+#: ../src/common/filename.cpp:177
 #, c-format
 msgid "Failed to open '%s' for writing"
 msgstr "ファイル '%s' を書き込み用に開くことができません"
 
-#: ../src/html/chm.cpp:141
+#: ../src/html/chm.cpp:138
 #, c-format
 msgid "Failed to open CHM archive '%s'."
 msgstr "CHM 書庫 '%s' を開くことができませんでした。"
 
-#: ../src/common/utilscmn.cpp:1126
+#: ../src/common/utilscmn.cpp:1140
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
+msgstr "デフォルトブラウザでURL \"%s\" を開けませんでした。"
+
+#: ../src/common/hyperlnkcmn.cpp:133
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "デフォルトブラウザでURL \"%s\" を開けませんでした。"
 
 #: ../include/wx/msw/private/fswatcher.h:92
@@ -3507,93 +3556,103 @@ msgstr "デフォルトブラウザでURL \"%s\" を開けませんでした。"
 msgid "Failed to open directory \"%s\" for monitoring."
 msgstr "監視対象のディレクトリー \"%s\" を開くことができませんでした。"
 
-#: ../src/x11/utils.cpp:227
+#: ../src/x11/utils.cpp:189
 #, c-format
 msgid "Failed to open display \"%s\"."
 msgstr "ディスプレイ \"%s\" を開くことができませんでした。"
 
-#: ../src/common/filename.cpp:1062
+#: ../src/common/filename.cpp:1059
 msgid "Failed to open temporary file."
 msgstr "一時ファイルを開くことができませんでした。"
 
-#: ../src/msw/clipbrd.cpp:91
+#: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "クリップボードを開くことができませんでした。"
 
-#: ../src/common/translation.cpp:1184
+#: ../src/common/translation.cpp:1226
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "複数形を解析できません: '%s'"
 
-#: ../src/unix/mediactrl.cpp:1214
+#: ../src/unix/mediactrl.cpp:1239
 #, fuzzy, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "ディスプレイ \"%s\" を開くことができませんでした。"
 
-#: ../src/msw/clipbrd.cpp:600
+#: ../src/msw/clipbrd.cpp:610
 msgid "Failed to put data on the clipboard"
 msgstr "データをクリップボードに置けませんでした。"
 
-#: ../src/unix/snglinst.cpp:278
+#: ../src/unix/snglinst.cpp:275
 msgid "Failed to read PID from lock file."
 msgstr "ロックファイルからPIDを読み取れませんでした。"
 
-#: ../src/common/fileconf.cpp:433
+#: ../src/common/fileconf.cpp:432
 msgid "Failed to read config options."
 msgstr "設定オプションを読み取ることができませんでした。"
 
-#: ../src/common/docview.cpp:681
+#: ../src/common/docview.cpp:676
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "ファイル \"%s\" から文書を読み取れませんでした。"
 
-#: ../src/dfb/evtloop.cpp:98
+#: ../src/dfb/evtloop.cpp:99
 msgid "Failed to read event from DirectFB pipe"
 msgstr "DirectFB パイプからのイベント読み取りに失敗しました。"
 
-#: ../src/unix/wakeuppipe.cpp:120
+#: ../src/unix/wakeuppipe.cpp:117
 msgid "Failed to read from wake-up pipe"
 msgstr "起動パイプからの読み取りに失敗しました。"
 
-#: ../src/unix/utilsunx.cpp:679
+#: ../src/common/textfile.cpp:96
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "ファイル \"%s\" から文書を読み取れませんでした。"
+
+#: ../src/unix/utilsunx.cpp:681
 msgid "Failed to redirect child process input/output"
 msgstr "子プロセスの入出力をリダイレクトできませんでした。"
 
-#: ../src/msw/utilsexc.cpp:701
+#: ../src/msw/utilsexc.cpp:698
 msgid "Failed to redirect the child process IO"
 msgstr "子プロセスの入出力をリダイレクトできませんでした。"
 
-#: ../src/msw/dde.cpp:288
+#: ../src/msw/dde.cpp:283
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "DDEサーバー '%s' を登録できませんでした。"
 
-#: ../src/common/fontmap.cpp:245
+#: ../src/gtk/font.cpp:580
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "ユーザー設定ファイルを更新できませんでした。"
+
+#: ../src/common/fontmap.cpp:242
 #, c-format
 msgid "Failed to remember the encoding for the charset '%s'."
 msgstr "文字集合 '%s' に対するエンコーディングの記録に失敗しました。"
 
-#: ../src/common/debugrpt.cpp:227
+#: ../src/common/debugrpt.cpp:228
 #, c-format
 msgid "Failed to remove debug report file \"%s\""
 msgstr "デバッグレポートファイル \"%s\" を削除できませんでした。"
 
-#: ../src/unix/snglinst.cpp:328
+#: ../src/unix/snglinst.cpp:325
 #, c-format
 msgid "Failed to remove lock file '%s'"
 msgstr "ロックファイル '%s' を削除できませんでした。"
 
-#: ../src/unix/snglinst.cpp:288
+#: ../src/unix/snglinst.cpp:285
 #, c-format
 msgid "Failed to remove stale lock file '%s'."
 msgstr "失効ロックファイル '%s' を削除できませんでした。"
 
-#: ../src/msw/registry.cpp:529
+#: ../src/msw/registry.cpp:518
 #, c-format
 msgid "Failed to rename registry value '%s' to '%s'."
 msgstr "レジストリーの値を '%s' から '%s' に改名できませんでした。"
 
-#: ../src/common/filefn.cpp:1122
+#: ../src/common/filefn.cpp:1011
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -3602,117 +3661,126 @@ msgstr ""
 "ファイル '%s' を '%s' に改名できませんでした。改名先のファイルがすでに存在し"
 "ています。"
 
-#: ../src/msw/registry.cpp:634
+#: ../src/msw/registry.cpp:623
 #, c-format
 msgid "Failed to rename the registry key '%s' to '%s'."
 msgstr "レジストリーキー '%s' を '%s' に改名できませんでした。"
 
-#: ../src/common/filename.cpp:2671
+#: ../src/msw/webview_ie.cpp:995
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/common/filename.cpp:2754
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "'%s' のファイル時刻を取得できませんでした。"
 
-#: ../src/msw/dialup.cpp:468
+#: ../src/msw/dialup.cpp:462
 msgid "Failed to retrieve text of RAS error message"
 msgstr "RAS エラーメッセージのテキストを取得できませんでした。"
 
-#: ../src/msw/clipbrd.cpp:748
+#: ../src/msw/clipbrd.cpp:768
 msgid "Failed to retrieve the supported clipboard formats"
 msgstr "対応しているクリップボードの様式を取得できませんでした。"
 
-#: ../src/common/docview.cpp:652
+#: ../src/common/docview.cpp:647
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "文書をファイル \"%s\" に保存できませんでした。"
 
-#: ../src/msw/dib.cpp:269
+#: ../src/msw/dib.cpp:312
 #, c-format
 msgid "Failed to save the bitmap image to file \"%s\"."
 msgstr "ファイル \"%s\" にビットマップイメージを保存できませんでした。"
 
-#: ../src/msw/dde.cpp:763
+#: ../src/msw/dde.cpp:811
 msgid "Failed to send DDE advise notification"
 msgstr "DDE アドバイス通知を送信できませんでした。"
 
-#: ../src/common/ftp.cpp:402
+#: ../src/common/ftp.cpp:399
 #, c-format
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "FTP転送モードを %s に変更できませんでした。"
 
-#: ../src/msw/clipbrd.cpp:427
+#: ../src/msw/clipbrd.cpp:443
 msgid "Failed to set clipboard data."
 msgstr "クリップボードデータを設定できませんでした。"
 
-#: ../src/unix/snglinst.cpp:181
+#: ../src/unix/snglinst.cpp:178
 #, c-format
 msgid "Failed to set permissions on lock file '%s'"
 msgstr "ロックファイル '%s' のパーミッションを設定できませんでした。"
 
-#: ../src/unix/utilsunx.cpp:668
+#: ../src/unix/utilsunx.cpp:670
 #, fuzzy
 msgid "Failed to set process priority"
 msgstr "スレッド優先度を %d に設定できませんでした。"
 
-#: ../src/common/file.cpp:559
+#: ../src/common/ffile.cpp:355 ../src/common/file.cpp:586
 msgid "Failed to set temporary file permissions"
 msgstr "一時ファイルのパーミッションを設定できませんでした。"
 
-#: ../src/gtk/textctrl.cpp:1072
-msgid "Failed to set text in the text control."
-msgstr "そのテキストコントロールにテキストを設定できませんでした。"
-
-#: ../src/unix/threadpsx.cpp:1298
+#: ../src/unix/threadpsx.cpp:1347
 #, fuzzy, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "スレッド優先度を %d に設定できませんでした。"
 
-#: ../src/unix/threadpsx.cpp:1424
+#: ../src/unix/threadpsx.cpp:1473
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "スレッド優先度を %d に設定できませんでした。"
 
-#: ../src/unix/utilsunx.cpp:783
+#: ../src/unix/utilsunx.cpp:785
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 
-#: ../src/common/fs_mem.cpp:261
+#: ../src/msw/webview_ie.cpp:987
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:256
 #, c-format
 msgid "Failed to store image '%s' to memory VFS!"
 msgstr "メモリーVFS にイメージ '%s' を格納できませんでした。"
 
-#: ../src/dfb/evtloop.cpp:170
+#: ../src/dfb/evtloop.cpp:171
 msgid "Failed to switch DirectFB pipe to non-blocking mode"
 msgstr ""
 "DirectFB パイプを non-blocking モードに切り替えることができませんでした"
 
-#: ../src/unix/wakeuppipe.cpp:59
+#: ../src/unix/wakeuppipe.cpp:56
 msgid "Failed to switch wake up pipe to non-blocking mode"
 msgstr "起動パイプをnon-blockingモードに切り替えることができませんでした"
 
-#: ../src/unix/threadpsx.cpp:1605
+#: ../src/unix/threadpsx.cpp:1654
 msgid "Failed to terminate a thread."
 msgstr "スレッドを終了できませんでした。"
 
-#: ../src/msw/dde.cpp:741
+#: ../src/msw/dde.cpp:736
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "DDE サーバ他とのアドバイスループを終了できませんでした。"
 
-#: ../src/msw/dialup.cpp:938
+#: ../src/msw/dialup.cpp:932
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "ダイヤルアップ接続を終了できませんでした: %s"
 
-#: ../src/common/filename.cpp:2590
+#: ../src/common/filename.cpp:2673
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "ファイル '%s' の属性を変更できませんでした。"
 
-#: ../src/unix/snglinst.cpp:334
+#: ../src/unix/dlunix.cpp:90
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "共有ライブラリ '%s' を読み取れませんでした。"
+
+#: ../src/unix/snglinst.cpp:331
 #, c-format
 msgid "Failed to unlock lock file '%s'"
 msgstr "ロックファイル '%s' のロック解除ができませんでした。"
 
-#: ../src/msw/dde.cpp:309
+#: ../src/msw/dde.cpp:304
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "DDE サーバ '%s' の登録を削除できませんでした。"
@@ -3726,77 +3794,87 @@ msgstr "記述子 %d を epoll記述子 %d から削除できませんでした�
 msgid "Failed to update user configuration file."
 msgstr "ユーザー設定ファイルを更新できませんでした。"
 
-#: ../src/common/debugrpt.cpp:733
+#: ../src/common/debugrpt.cpp:743
 #, c-format
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "デバッグレポートのアップロードができませんでした (エラーコード %d)。"
 
-#: ../src/unix/snglinst.cpp:168
+#: ../src/unix/snglinst.cpp:165
 #, c-format
 msgid "Failed to write to lock file '%s'"
 msgstr "ロックファイル '%s' に書き込めませんでした。"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:209
+#: ../src/propgrid/propgrid.cpp:190
 msgid "False"
 msgstr "偽"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:694
+#: ../src/propgrid/advprops.cpp:604
 msgid "Family"
 msgstr "フォントファミリー"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/gtk/glcanvas.cpp:176 ../src/gtk/glcanvas.cpp:187
+#, fuzzy
+msgid "Fatal Error"
+msgstr "重大なエラー"
+
+#: ../src/common/stockitem.cpp:154
 msgid "File"
 msgstr "ファイル"
 
-#: ../src/common/docview.cpp:669
+#: ../src/common/docview.cpp:664
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "ファイル '%s' を読み取ろうとしましたが開くことができません"
 
-#: ../src/common/docview.cpp:646
+#: ../src/common/docview.cpp:641
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "ファイル '%s' に書き込もうとしましたが開くことができません"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "ファイル %s はすでに存在します。上書きしてよろしいですか?"
 
-#: ../src/common/filefn.cpp:1156
+#: ../src/common/filefn.cpp:1044
 #, fuzzy, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "ファイル '%s' を開くことができません。"
 
-#: ../src/common/filefn.cpp:1139
+#: ../src/common/filefn.cpp:1028
 #, fuzzy, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "ファイル '%s' を開くことができません。"
 
-#: ../src/richtext/richtextctrl.cpp:3081 ../src/common/textcmn.cpp:953
+#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
 msgid "File couldn't be loaded."
 msgstr "ファイルを読み取ることができません。"
 
-#: ../src/msw/filedlg.cpp:393
+#: ../src/msw/filedlg.cpp:414
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "ファイルダイアログがエラー %0lx で失敗しました。"
 
-#: ../src/common/docview.cpp:1789
+#: ../src/common/docview.cpp:1783
 msgid "File error"
 msgstr "ファイルエラー"
 
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/filectrlg.cpp:770
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/filectrlg.cpp:766
 msgid "File name exists already."
 msgstr "その名前のファイルはすでに存在します。"
+
+#: ../src/osx/cocoa/filedlg.mm:264
+#, fuzzy
+msgid "File type:"
+msgstr "Teletype"
 
 #: ../src/motif/filedlg.cpp:220
 msgid "Files"
 msgstr "ファイル"
 
-#: ../src/common/filefn.cpp:1591
+#: ../src/common/filefn.cpp:1479
 #, c-format
 msgid "Files (%s)"
 msgstr "ファイル (%s)"
@@ -3805,16 +3883,30 @@ msgstr "ファイル (%s)"
 msgid "Filter"
 msgstr "フィルター"
 
-#: ../src/common/stockitem.cpp:158 ../src/html/helpwnd.cpp:490
+#: ../src/html/helpwnd.cpp:488
 msgid "Find"
 msgstr "検索"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:259
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:258
+#, fuzzy
+msgid "Find in document"
+msgstr "HTML文書を開く"
+
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "Find..."
+msgstr "検索"
+
+#: ../src/common/stockitem.cpp:156
 #, fuzzy
 msgid "First"
 msgstr "最初 (&F)"
 
-#: ../src/common/prntbase.cpp:1548
+#: ../src/common/prntbase.cpp:1573
 #, fuzzy
 msgid "First page"
 msgstr "次のページ"
@@ -3824,11 +3916,11 @@ msgstr "次のページ"
 msgid "Fixed"
 msgstr "固定幅フォント:"
 
-#: ../src/html/helpwnd.cpp:1206
+#: ../src/html/helpwnd.cpp:1204
 msgid "Fixed font:"
 msgstr "固定幅フォント:"
 
-#: ../src/html/helpwnd.cpp:1269
+#: ../src/html/helpwnd.cpp:1267
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "固定幅。<br> <b>太字</b><i>イタリック</i>"
 
@@ -3836,17 +3928,17 @@ msgstr "固定幅。<br> <b>太字</b><i>イタリック</i>"
 msgid "Floating"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 #, fuzzy
 msgid "Floppy"
 msgstr "フロッピーディスク (&F)"
 
-#: ../src/common/paper.cpp:111
+#: ../src/common/paper.cpp:108
 msgid "Folio, 8 1/2 x 13 in"
 msgstr "フォリオ, 8 1/2 x 13インチ"
 
-#: ../src/richtext/richtextformatdlg.cpp:344 ../src/osx/carbon/fontdlg.cpp:287
-#: ../src/common/stockitem.cpp:194
+#: ../src/osx/carbon/fontdlg.cpp:284 ../src/common/stockitem.cpp:191
+#: ../src/richtext/richtextformatdlg.cpp:337
 msgid "Font"
 msgstr "フォント"
 
@@ -3854,7 +3946,24 @@ msgstr "フォント"
 msgid "Font &weight:"
 msgstr "フォントのウエイト(&W):"
 
-#: ../src/html/helpwnd.cpp:1207
+#: ../src/osx/fontutil.cpp:89
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
+"\"."
+msgstr ""
+
+#: ../src/msw/font.cpp:1126
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "ファイルを読み取ることができません。"
+
+#: ../src/osx/fontutil.cpp:81
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "ファイル %s は存在しません。"
+
+#: ../src/html/helpwnd.cpp:1205
 msgid "Font size:"
 msgstr "フォントの大きさ:"
 
@@ -3862,76 +3971,76 @@ msgstr "フォントの大きさ:"
 msgid "Font st&yle:"
 msgstr "フォントのスタイル(&Y):"
 
-#: ../src/osx/carbon/fontdlg.cpp:329
+#: ../src/osx/carbon/fontdlg.cpp:326
 msgid "Font:"
 msgstr "フォント:"
 
-#: ../src/dfb/fontmgr.cpp:198
+#: ../src/dfb/fontmgr.cpp:195
 #, c-format
 msgid "Fonts index file %s disappeared while loading fonts."
 msgstr "フォントの読み取り中に索引ファイル %s が失われました。"
 
-#: ../src/unix/utilsunx.cpp:645
+#: ../src/unix/utilsunx.cpp:647
 msgid "Fork failed"
 msgstr "フォークに失敗しました"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 #, fuzzy
 msgid "Forward"
 msgstr "進行 (&F)"
 
-#: ../src/common/xtixml.cpp:235
+#: ../src/common/xtixml.cpp:231
 msgid "Forward hrefs are not supported"
 msgstr "前方参照のhrefには未対応です"
 
-#: ../src/html/helpwnd.cpp:875
+#: ../src/html/helpwnd.cpp:873
 #, c-format
 msgid "Found %i matches"
 msgstr "%i 件の該当部を発見"
 
-#: ../src/generic/prntdlgg.cpp:238
+#: ../src/generic/prntdlgg.cpp:231
 msgid "From:"
 msgstr "開始ページ:"
 
-#: ../src/propgrid/advprops.cpp:1604
+#: ../src/propgrid/advprops.cpp:1510
 msgid "Fuchsia"
 msgstr ""
 
-#: ../src/common/imaggif.cpp:138
+#: ../src/common/imaggif.cpp:135
 msgid "GIF: data stream seems to be truncated."
 msgstr "GIF: データストリームに欠落があるようです。"
 
-#: ../src/common/imaggif.cpp:128
+#: ../src/common/imaggif.cpp:125
 msgid "GIF: error in GIF image format."
 msgstr "GIF: GIF画像形式にエラーがありました。"
 
-#: ../src/common/imaggif.cpp:133
+#: ../src/common/imaggif.cpp:130
 msgid "GIF: not enough memory."
 msgstr "GIF: メモリ不足です。"
 
-#: ../src/gtk/window.cpp:4631
+#: ../src/gtk/window.cpp:5635
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
 msgstr ""
 
-#: ../src/univ/themes/gtk.cpp:525
+#: ../src/univ/themes/gtk.cpp:522
 msgid "GTK+ theme"
 msgstr "GTK+ テーマ"
 
-#: ../src/common/preferencescmn.cpp:40
+#: ../src/common/preferencescmn.cpp:37
 msgid "General"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:258
+#: ../src/common/prntbase.cpp:253
 msgid "Generic PostScript"
 msgstr "汎用 PostScipt"
 
-#: ../src/common/paper.cpp:135
+#: ../src/common/paper.cpp:132
 msgid "German Legal Fanfold, 8 1/2 x 13 in"
 msgstr "ドイツリーガル折りたたみ連続紙, 8 1/2 x 13インチ"
 
-#: ../src/common/paper.cpp:134
+#: ../src/common/paper.cpp:131
 msgid "German Std Fanfold, 8 1/2 x 12 in"
 msgstr "ドイツ標準折りたたみ連続紙, 8 1/2 x 12インチ"
 
@@ -3948,49 +4057,49 @@ msgid "GetPropertyCollection called w/o valid collection getter"
 msgstr ""
 "適切なコレクション getter なしに GetPropertyCollection が呼び出されました。"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:658
 msgid "Go back"
 msgstr "戻る"
 
-#: ../src/html/helpwnd.cpp:661
+#: ../src/html/helpwnd.cpp:659
 msgid "Go forward"
 msgstr "進む"
 
-#: ../src/html/helpwnd.cpp:663
+#: ../src/html/helpwnd.cpp:661
 msgid "Go one level up in document hierarchy"
 msgstr "文書構造のひとつ上へ"
 
-#: ../src/generic/filedlgg.cpp:208 ../src/generic/dirdlgg.cpp:116
+#: ../src/generic/filedlgg.cpp:205 ../src/generic/dirdlgg.cpp:113
 msgid "Go to home directory"
 msgstr "ホームディレクトリーへ移動"
 
-#: ../src/generic/filedlgg.cpp:205
+#: ../src/generic/filedlgg.cpp:202
 msgid "Go to parent directory"
 msgstr "親ディレクトリーへ移動"
 
-#: ../src/generic/aboutdlgg.cpp:76
+#: ../src/generic/aboutdlgg.cpp:73
 msgid "Graphics art by "
 msgstr "デザイナー"
 
-#: ../src/propgrid/advprops.cpp:1599
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Gray"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:883
+#: ../src/propgrid/advprops.cpp:784
 msgid "GrayText"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:154
+#: ../src/common/fmapbase.cpp:151
 msgid "Greek (ISO-8859-7)"
 msgstr "ギリシャ語 (ISO-8859-7)"
 
-#: ../src/propgrid/advprops.cpp:1600
+#: ../src/propgrid/advprops.cpp:1506
 #, fuzzy
 msgid "Green"
 msgstr "MacGreek"
 
-#: ../src/generic/colrdlgg.cpp:342
+#: ../src/generic/colrdlgg.cpp:362
 #, fuzzy
 msgid "Green:"
 msgstr "MacGreek"
@@ -3999,110 +4108,110 @@ msgstr "MacGreek"
 msgid "Groove"
 msgstr ""
 
-#: ../src/common/zstream.cpp:158 ../src/common/zstream.cpp:318
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
 msgid "Gzip not supported by this version of zlib"
 msgstr "このバージョンの zlib は Gzip を処理できません"
 
-#: ../src/html/helpwnd.cpp:1549
+#: ../src/html/helpwnd.cpp:1547
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "HTMLヘルププロジェクト (*.hhp)|*.hhp|"
 
-#: ../src/html/htmlwin.cpp:681
+#: ../src/html/htmlwin.cpp:691
 #, c-format
 msgid "HTML anchor %s does not exist."
 msgstr "HTMLアンカー %s は存在しません。"
 
-#: ../src/html/helpwnd.cpp:1547
+#: ../src/html/helpwnd.cpp:1545
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "HTML ファイル (*.html;*.htm)|*.html;*.htm|"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1759
+#: ../src/propgrid/advprops.cpp:1660
 msgid "Hand"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 #, fuzzy
 msgid "Harddisk"
 msgstr "ハードディスク (&H)"
 
-#: ../src/common/fmapbase.cpp:155
+#: ../src/common/fmapbase.cpp:152
 msgid "Hebrew (ISO-8859-8)"
 msgstr "ヘブライ語 (ISO-8859-8)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:280 ../src/osx/button_osx.cpp:39
-#: ../src/common/stockitem.cpp:163 ../src/common/accelcmn.cpp:80
-#: ../src/html/helpdlg.cpp:66 ../src/html/helpfrm.cpp:111
+#: ../include/wx/msgdlg.h:282 ../src/osx/button_osx.cpp:39
+#: ../src/common/stockitem.cpp:160 ../src/common/accelcmn.cpp:77
+#: ../src/html/helpfrm.cpp:108 ../src/html/helpdlg.cpp:63
 msgid "Help"
 msgstr "ヘルプ"
 
-#: ../src/html/helpwnd.cpp:1200
+#: ../src/html/helpwnd.cpp:1198
 msgid "Help Browser Options"
 msgstr "ヘルプブラウザのオプション"
 
-#: ../src/generic/helpext.cpp:454 ../src/generic/helpext.cpp:455
+#: ../src/generic/helpext.cpp:452 ../src/generic/helpext.cpp:453
 msgid "Help Index"
 msgstr "ヘルプの索引"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1529
 msgid "Help Printing"
 msgstr "ヘルプの印刷"
 
-#: ../src/html/helpwnd.cpp:801
+#: ../src/html/helpwnd.cpp:799
 msgid "Help Topics"
 msgstr "ヘルプトピック"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1546
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "ヘルプブック (*.htb)|*.htb|ヘルプブック (*.zip)|*.zip|"
 
-#: ../src/generic/helpext.cpp:267
+#: ../src/generic/helpext.cpp:265
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "ヘルプディレクトリー \"%s\" が見つかりません。"
 
-#: ../src/generic/helpext.cpp:275
+#: ../src/generic/helpext.cpp:273
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "ヘルプファイル \"%s\" が見つかりません。"
 
-#: ../src/html/helpctrl.cpp:63
+#: ../src/html/helpctrl.cpp:59
 #, c-format
 msgid "Help: %s"
 msgstr "ヘルプ: %s"
 
-#: ../src/osx/menu_osx.cpp:577
+#: ../src/osx/menu_osx.cpp:469
 #, fuzzy, c-format
 msgid "Hide %s"
 msgstr "ヘルプ: %s"
 
-#: ../src/osx/menu_osx.cpp:579
+#: ../src/osx/menu_osx.cpp:471
 msgid "Hide Others"
 msgstr ""
 
-#: ../src/generic/infobar.cpp:84
+#: ../src/generic/infobar.cpp:81
 msgid "Hide this notification message."
 msgstr "この通知メッセージを隠します。"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:884
+#: ../src/propgrid/advprops.cpp:785
 #, fuzzy
 msgid "Highlight"
 msgstr "軽量"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:885
+#: ../src/propgrid/advprops.cpp:786
 #, fuzzy
 msgid "HighlightText"
 msgstr "右寄せにします。"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:164 ../src/common/accelcmn.cpp:65
+#: ../src/common/stockitem.cpp:161 ../src/common/accelcmn.cpp:62
 msgid "Home"
 msgstr "ホーム"
 
-#: ../src/generic/dirctrlg.cpp:524
+#: ../src/generic/dirctrlg.cpp:490
 msgid "Home directory"
 msgstr "ホームディレクトリー"
 
@@ -4112,61 +4221,61 @@ msgid "How the object will float relative to the text."
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1760
+#: ../src/propgrid/advprops.cpp:1661
 msgid "I-Beam"
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1196
+#: ../src/common/imagbmp.cpp:1208
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: マスクDIBの読み取り中にエラーを検出しました。"
 
-#: ../src/common/imagbmp.cpp:1290 ../src/common/imagbmp.cpp:1390
-#: ../src/common/imagbmp.cpp:1405 ../src/common/imagbmp.cpp:1416
-#: ../src/common/imagbmp.cpp:1430 ../src/common/imagbmp.cpp:1478
-#: ../src/common/imagbmp.cpp:1493 ../src/common/imagbmp.cpp:1507
-#: ../src/common/imagbmp.cpp:1518
+#: ../src/common/imagbmp.cpp:1302 ../src/common/imagbmp.cpp:1402
+#: ../src/common/imagbmp.cpp:1417 ../src/common/imagbmp.cpp:1428
+#: ../src/common/imagbmp.cpp:1442 ../src/common/imagbmp.cpp:1490
+#: ../src/common/imagbmp.cpp:1505 ../src/common/imagbmp.cpp:1519
+#: ../src/common/imagbmp.cpp:1530
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: 画像ファイルの書き出し中にエラーが発生しました。"
 
-#: ../src/common/imagbmp.cpp:1255
+#: ../src/common/imagbmp.cpp:1267
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: 縦に長すぎます。アイコンに変換できません。"
 
-#: ../src/common/imagbmp.cpp:1263
+#: ../src/common/imagbmp.cpp:1275
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: 幅が大きすぎます。アイコンに変換できません。"
 
-#: ../src/common/imagbmp.cpp:1603
+#: ../src/common/imagbmp.cpp:1615
 msgid "ICO: Invalid icon index."
 msgstr "ICO: アイコンの索引が不正のようです。"
 
-#: ../src/common/imagiff.cpp:758
+#: ../src/common/imagiff.cpp:755
 msgid "IFF: data stream seems to be truncated."
 msgstr "IFF: データストリームに欠落があるようです。"
 
-#: ../src/common/imagiff.cpp:742
+#: ../src/common/imagiff.cpp:739
 msgid "IFF: error in IFF image format."
 msgstr "IFF: IFF画像形式にエラーがありました。"
 
-#: ../src/common/imagiff.cpp:745
+#: ../src/common/imagiff.cpp:742
 msgid "IFF: not enough memory."
 msgstr "IFF: メモリ不足です。"
 
-#: ../src/common/imagiff.cpp:748
+#: ../src/common/imagiff.cpp:745
 msgid "IFF: unknown error!!!"
 msgstr "IFF: 未対応のエラーが発生しました。"
 
-#: ../src/common/fmapbase.cpp:197
+#: ../src/common/fmapbase.cpp:194
 msgid "ISO-2022-JP"
 msgstr "ISO-2022-JP"
 
-#: ../src/html/htmprint.cpp:282
+#: ../src/html/htmprint.cpp:294
 msgid ""
 "If possible, try changing the layout parameters to make the printout more "
 "narrow."
 msgstr "出力結果がより狭い範囲に収まるように印刷設定値を変更してください。"
 
-#: ../src/generic/dbgrptg.cpp:358
+#: ../src/generic/dbgrptg.cpp:362
 msgid ""
 "If you have any additional information pertaining to this bug\n"
 "report, please enter it here and it will be joined to it:"
@@ -4186,46 +4295,50 @@ msgstr ""
 "ただし、その抑制指示はプログラムの修正を遠ざけることになりますので\n"
 "できる限りレポート生成を続けるようにしてください。\n"
 
-#: ../src/msw/registry.cpp:1405
+#: ../src/common/zipstrm.cpp:1043
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1393
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "値 \"%s\" を無視します (キー \"%s\")。"
 
-#: ../src/common/xtistrm.cpp:295
+#: ../src/common/xtistrm.cpp:292
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "wxEvtHandler ではないオブジェクトクラスがイベントソースになっています"
 
-#: ../src/common/xti.cpp:513
+#: ../src/common/xti.cpp:510
 msgid "Illegal Parameter Count for ConstructObject Method"
 msgstr "ConstructObject メソッドに不正なカウント引数が与えられました。"
 
-#: ../src/common/xti.cpp:501
+#: ../src/common/xti.cpp:498
 msgid "Illegal Parameter Count for Create Method"
 msgstr "Create メソッドに不正なカウント引数が与えられました。"
 
-#: ../src/generic/dirctrlg.cpp:570 ../src/generic/filectrlg.cpp:756
+#: ../src/generic/dirctrlg.cpp:536 ../src/generic/filectrlg.cpp:752
 msgid "Illegal directory name."
 msgstr "不正なディレクトリー名です。"
 
-#: ../src/generic/filectrlg.cpp:1367
+#: ../src/generic/filectrlg.cpp:1356
 msgid "Illegal file specification."
 msgstr "ファイル記述子が不正です。"
 
-#: ../src/common/image.cpp:2269
+#: ../src/common/image.cpp:2363
 msgid "Image and mask have different sizes."
 msgstr "画像とマスクが異なる大きさになっています。"
 
-#: ../src/common/image.cpp:2746
+#: ../src/common/image.cpp:2841
 #, fuzzy, c-format
 msgid "Image file is not of type %d."
 msgstr "画像ファイルは %ld 形式ではないようです。"
 
-#: ../src/common/image.cpp:2877
+#: ../src/common/image.cpp:2995
 #, fuzzy, c-format
 msgid "Image is not of type %s."
 msgstr "画像ファイルは %s 形式ではないようです。"
 
-#: ../src/msw/textctrl.cpp:488
+#: ../src/msw/textctrl.cpp:534
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -4233,105 +4346,105 @@ msgstr ""
 "リッチエディットコントロールを作成できませんでした。代わりに簡素なテキストコ"
 "ントロールを使います。 riched32.dllを再インストールしてください。"
 
-#: ../src/unix/utilsunx.cpp:301
+#: ../src/unix/utilsunx.cpp:303
 msgid "Impossible to get child process input"
 msgstr "子プロセスの入力は取得不可能です。"
 
-#: ../src/common/filefn.cpp:1028
+#: ../src/common/filefn.cpp:917
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "ファイル '%s' へのパーミッションは取得不可能です"
 
-#: ../src/common/filefn.cpp:1042
+#: ../src/common/filefn.cpp:931
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "ファイル '%s' の上書きは不可能です"
 
-#: ../src/common/filefn.cpp:1097
+#: ../src/common/filefn.cpp:986
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "ファイル '%s' へのパーミッションは設定不可能です"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:886
+#: ../src/propgrid/advprops.cpp:787
 #, fuzzy
 msgid "InactiveBorder"
 msgstr "Modern"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:887
+#: ../src/propgrid/advprops.cpp:788
 msgid "InactiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:888
+#: ../src/propgrid/advprops.cpp:789
 msgid "InactiveCaptionText"
 msgstr ""
 
-#: ../src/common/gifdecod.cpp:792
+#: ../src/common/gifdecod.cpp:826
 #, c-format
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "GIF フレームの大きさ (%u, %d) が不適切です (フレーム #%u)"
 
-#: ../src/msw/ole/automtn.cpp:635
+#: ../src/msw/ole/automtn.cpp:626
 msgid "Incorrect number of arguments."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:165
+#: ../src/common/stockitem.cpp:162
 msgid "Indent"
 msgstr "字下げ"
 
-#: ../src/richtext/richtextformatdlg.cpp:349
+#: ../src/richtext/richtextformatdlg.cpp:342
 msgid "Indents && Spacing"
 msgstr "字下げと間隔"
 
-#: ../src/common/stockitem.cpp:166 ../src/html/helpwnd.cpp:515
+#: ../src/common/stockitem.cpp:163 ../src/html/helpwnd.cpp:513
 msgid "Index"
 msgstr "索引"
 
-#: ../src/common/fmapbase.cpp:159
+#: ../src/common/fmapbase.cpp:156
 msgid "Indian (ISO-8859-12)"
 msgstr "ISO-8859-12 (ケルト語→14/デーヴァナーガリー→破棄)"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 #, fuzzy
 msgid "Info"
 msgstr "情報 (&I)"
 
-#: ../src/common/init.cpp:287
+#: ../src/common/init.cpp:284
 msgid "Initialization failed in post init, aborting."
 msgstr "PostInit の初期化に失敗しました。中断します。"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:54
+#: ../src/common/accelcmn.cpp:51
 #, fuzzy
 msgid "Ins"
 msgstr "挿入"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextsymboldlg.cpp:472 ../src/common/accelcmn.cpp:53
+#: ../src/common/accelcmn.cpp:50 ../src/richtext/richtextsymboldlg.cpp:469
 msgid "Insert"
 msgstr "挿入"
 
-#: ../src/richtext/richtextbuffer.cpp:8067
+#: ../src/richtext/richtextbuffer.cpp:8063
 #, fuzzy
 msgid "Insert Field"
 msgstr "テキストの挿入"
 
-#: ../src/richtext/richtextbuffer.cpp:7978
-#: ../src/richtext/richtextbuffer.cpp:8936
+#: ../src/richtext/richtextbuffer.cpp:7974
+#: ../src/richtext/richtextbuffer.cpp:8934
 msgid "Insert Image"
 msgstr "画像の挿入"
 
-#: ../src/richtext/richtextbuffer.cpp:8025
+#: ../src/richtext/richtextbuffer.cpp:8021
 #, fuzzy
 msgid "Insert Object"
 msgstr "テキストの挿入"
 
-#: ../src/richtext/richtextctrl.cpp:1286 ../src/richtext/richtextctrl.cpp:1494
-#: ../src/richtext/richtextbuffer.cpp:7822
-#: ../src/richtext/richtextbuffer.cpp:7852
-#: ../src/richtext/richtextbuffer.cpp:7894
+#: ../src/richtext/richtextbuffer.cpp:7818
+#: ../src/richtext/richtextbuffer.cpp:7848
+#: ../src/richtext/richtextbuffer.cpp:7890
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
 msgid "Insert Text"
 msgstr "テキストの挿入"
 
@@ -4346,18 +4459,11 @@ msgstr "段落の前の空間を指定します。"
 msgid "Inset"
 msgstr "挿入"
 
-#: ../src/gtk/app.cpp:425
-#, c-format
-msgid "Invalid GTK+ command line option, use \"%s --help\""
-msgstr ""
-"不適切な GTK+ コマンドラインオプションです。\"%s --help\" で確認してくださ"
-"い。"
-
-#: ../src/common/imagtiff.cpp:311
+#: ../src/common/imagtiff.cpp:308
 msgid "Invalid TIFF image index."
 msgstr "TIFF 画像索引が不正です。"
 
-#: ../src/common/appcmn.cpp:273
+#: ../src/common/appcmn.cpp:294
 #, c-format
 msgid "Invalid display mode specification '%s'."
 msgstr "画面モード '%s' は正しい指定ではありません。"
@@ -4367,260 +4473,264 @@ msgstr "画面モード '%s' は正しい指定ではありません。"
 msgid "Invalid geometry specification '%s'"
 msgstr "画面設定 '%s' は正しい指定ではありません"
 
-#: ../src/unix/fswatcher_inotify.cpp:323
+#: ../src/unix/fswatcher_inotify.cpp:320
 #, c-format
 msgid "Invalid inotify event for \"%s\""
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:312
+#: ../src/unix/snglinst.cpp:309
 #, c-format
 msgid "Invalid lock file '%s'."
 msgstr "不正なロックファイルです: '%s'"
 
-#: ../src/common/translation.cpp:1125
+#: ../src/common/translation.cpp:1167
 msgid "Invalid message catalog."
 msgstr "正しいメッセージカタログではありません。"
 
-#: ../src/common/xtistrm.cpp:405 ../src/common/xtistrm.cpp:420
+#: ../src/common/xtistrm.cpp:402 ../src/common/xtistrm.cpp:417
 msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
 msgstr ""
 "Null または不正なオブジェクト識別子が GetObjectClassInfo に渡されました。"
 
-#: ../src/common/xtistrm.cpp:435
+#: ../src/common/xtistrm.cpp:432
 msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
 msgstr ""
 "Null または不正なオブジェクト識別子が HasObjectClassInfo に渡されました。"
 
-#: ../src/common/regex.cpp:310
+#: ../src/common/regex.cpp:307
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "不正な正規表現です '%s': %s"
 
-#: ../src/common/config.cpp:226
+#: ../src/common/config.cpp:222
 #, c-format
 msgid "Invalid value %ld for a boolean key \"%s\" in config file."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:351
-#: ../src/osx/carbon/fontdlg.cpp:361 ../src/common/stockitem.cpp:168
+#: ../src/osx/carbon/fontdlg.cpp:358 ../src/common/stockitem.cpp:165
+#: ../src/generic/fontdlgg.cpp:325 ../src/richtext/richtextfontpage.cpp:351
 msgid "Italic"
 msgstr "イタリック"
 
-#: ../src/common/paper.cpp:130
+#: ../src/common/paper.cpp:127
 msgid "Italy Envelope, 110 x 230 mm"
 msgstr "イタリア封筒, 110 x 230mm"
 
-#: ../src/common/imagjpeg.cpp:270
+#: ../src/common/imagjpeg.cpp:257
 msgid "JPEG: Couldn't load - file is probably corrupted."
 msgstr "JPEG: 読み取れません。おそらくファイルが壊れています。"
 
-#: ../src/common/imagjpeg.cpp:449
+#: ../src/common/imagjpeg.cpp:436
 msgid "JPEG: Couldn't save image."
 msgstr "JPEG: 画像を保存できません。"
 
-#: ../src/common/paper.cpp:163
+#: ../src/common/paper.cpp:160
 msgid "Japanese Double Postcard 200 x 148 mm"
 msgstr "往復はがき 200×248mm"
 
-#: ../src/common/paper.cpp:167
+#: ../src/common/paper.cpp:164
 msgid "Japanese Envelope Chou #3"
 msgstr "長形3号"
 
-#: ../src/common/paper.cpp:180
+#: ../src/common/paper.cpp:177
 msgid "Japanese Envelope Chou #3 Rotated"
 msgstr "長形3号横置き"
 
-#: ../src/common/paper.cpp:168
+#: ../src/common/paper.cpp:165
 msgid "Japanese Envelope Chou #4"
 msgstr "長形4号"
 
-#: ../src/common/paper.cpp:181
+#: ../src/common/paper.cpp:178
 msgid "Japanese Envelope Chou #4 Rotated"
 msgstr "長形4号横置き"
 
-#: ../src/common/paper.cpp:165
+#: ../src/common/paper.cpp:162
 msgid "Japanese Envelope Kaku #2"
 msgstr "角形2号"
 
-#: ../src/common/paper.cpp:178
+#: ../src/common/paper.cpp:175
 msgid "Japanese Envelope Kaku #2 Rotated"
 msgstr "角形2号横置き"
 
-#: ../src/common/paper.cpp:166
+#: ../src/common/paper.cpp:163
 msgid "Japanese Envelope Kaku #3"
 msgstr "角形3号"
 
-#: ../src/common/paper.cpp:179
+#: ../src/common/paper.cpp:176
 msgid "Japanese Envelope Kaku #3 Rotated"
 msgstr "角形3号横置き"
 
-#: ../src/common/paper.cpp:185
+#: ../src/common/paper.cpp:182
 msgid "Japanese Envelope You #4"
 msgstr "洋形4号"
 
-#: ../src/common/paper.cpp:186
+#: ../src/common/paper.cpp:183
 msgid "Japanese Envelope You #4 Rotated"
 msgstr "洋形4号横置き"
 
-#: ../src/common/paper.cpp:138
+#: ../src/common/paper.cpp:135
 msgid "Japanese Postcard 100 x 148 mm"
 msgstr "はがき 100×148mm"
 
-#: ../src/common/paper.cpp:175
+#: ../src/common/paper.cpp:172
 msgid "Japanese Postcard Rotated 148 x 100 mm"
 msgstr "はがき横置き 148×100mm"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 #, fuzzy
 msgid "Jump to"
 msgstr "移動 (&J)"
 
-#: ../src/common/stockitem.cpp:171
+#: ../src/common/stockitem.cpp:168
 msgid "Justified"
 msgstr "両端揃え"
 
-#: ../src/richtext/richtextindentspage.cpp:155
-#: ../src/richtext/richtextindentspage.cpp:157
 #: ../src/richtext/richtextliststylepage.cpp:344
 #: ../src/richtext/richtextliststylepage.cpp:346
+#: ../src/richtext/richtextindentspage.cpp:155
+#: ../src/richtext/richtextindentspage.cpp:157
 msgid "Justify text left and right."
 msgstr "左右端いっぱいにテキストを表示します。"
 
-#: ../src/common/fmapbase.cpp:163
+#: ../src/common/fmapbase.cpp:160
 msgid "KOI8-R"
 msgstr "KOI8-R"
 
-#: ../src/common/fmapbase.cpp:164
+#: ../src/common/fmapbase.cpp:161
 msgid "KOI8-U"
 msgstr "KOI8-U"
 
-#: ../src/common/accelcmn.cpp:265 ../src/common/accelcmn.cpp:347
+#: ../src/common/accelcmn.cpp:279 ../src/common/accelcmn.cpp:364
 msgid "KP_"
 msgstr "Num"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 #, fuzzy
 msgid "KP_Add"
 msgstr "Num+"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "KP_Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "KP_Decimal"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 #, fuzzy
 msgid "KP_Delete"
 msgstr "削除"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "KP_Divide"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 #, fuzzy
 msgid "KP_Down"
 msgstr "下へ"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 #, fuzzy
 msgid "KP_End"
 msgstr "NumEnd"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 #, fuzzy
 msgid "KP_Enter"
 msgstr "プリンター"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "KP_Equal"
 msgstr ""
 
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
-#, fuzzy
-msgid "KP_Home"
-msgstr "ホーム"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
-#, fuzzy
-msgid "KP_Insert"
-msgstr "挿入"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
-#, fuzzy
-msgid "KP_Left"
-msgstr "左"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
-msgid "KP_Multiply"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:99
-#, fuzzy
-msgid "KP_Next"
-msgstr "次"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
-msgid "KP_PageDown"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
-msgid "KP_PageUp"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:98
-msgid "KP_Prior"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
-#, fuzzy
-msgid "KP_Right"
-msgstr "右"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
-msgid "KP_Separator"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
-msgid "KP_Space"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
-msgid "KP_Subtract"
+#: ../src/common/accelcmn.cpp:276 ../src/common/accelcmn.cpp:361
+msgid "KP_F"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
 #: ../src/common/accelcmn.cpp:89
 #, fuzzy
+msgid "KP_Home"
+msgstr "ホーム"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:100
+#, fuzzy
+msgid "KP_Insert"
+msgstr "挿入"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:90
+#, fuzzy
+msgid "KP_Left"
+msgstr "左"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:103
+msgid "KP_Multiply"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:97
+#, fuzzy
+msgid "KP_Next"
+msgstr "次"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:95
+msgid "KP_PageDown"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:94
+msgid "KP_PageUp"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:96
+msgid "KP_Prior"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:92
+#, fuzzy
+msgid "KP_Right"
+msgstr "右"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:105
+msgid "KP_Separator"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:86
+msgid "KP_Space"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:106
+msgid "KP_Subtract"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:87
+#, fuzzy
 msgid "KP_Tab"
 msgstr "KP_TAB"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 #, fuzzy
 msgid "KP_Up"
 msgstr "Num↑"
@@ -4629,113 +4739,128 @@ msgstr "Num↑"
 msgid "L&ine spacing:"
 msgstr "行間隔 (&I):"
 
-#: ../src/generic/prntdlgg.cpp:613 ../src/generic/prntdlgg.cpp:868
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "圧縮エラー"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "展開エラー"
+
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:861
 msgid "Landscape"
 msgstr "横置き"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 #, fuzzy
 msgid "Last"
 msgstr "最後 (&L)"
 
-#: ../src/common/prntbase.cpp:1572
+#: ../src/common/prntbase.cpp:1597
 #, fuzzy
 msgid "Last page"
 msgstr "次のページ"
 
-#: ../src/common/log.cpp:305
+#: ../src/common/log.cpp:324
 #, c-format
 msgid "Last repeated message (\"%s\", %u time) wasn't output"
 msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
 msgstr[0] ""
 
-#: ../src/common/paper.cpp:103
+#: ../src/common/paper.cpp:100
 msgid "Ledger, 17 x 11 in"
 msgstr "Ledger(帳簿), 17 x 11インチ"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6146
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:58 ../src/generic/datavgen.cpp:6951
+#: ../src/richtext/richtextsizepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:252
 #: ../src/richtext/richtextliststylepage.cpp:253
 #: ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
-#: ../src/richtext/richtextsizepage.cpp:249 ../src/common/accelcmn.cpp:61
 msgid "Left"
 msgstr "左"
 
-#: ../src/richtext/richtextindentspage.cpp:204
 #: ../src/richtext/richtextliststylepage.cpp:390
+#: ../src/richtext/richtextindentspage.cpp:204
 msgid "Left (&first line):"
 msgstr "左-一行目 (&F):"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1761
+#: ../src/propgrid/advprops.cpp:1662
 msgid "Left Button"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:880
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Left margin (mm):"
 msgstr "余白-左 (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:141
-#: ../src/richtext/richtextindentspage.cpp:143
 #: ../src/richtext/richtextliststylepage.cpp:330
 #: ../src/richtext/richtextliststylepage.cpp:332
+#: ../src/richtext/richtextindentspage.cpp:141
+#: ../src/richtext/richtextindentspage.cpp:143
 msgid "Left-align text."
 msgstr "テキストを左寄せにします。"
 
-#: ../src/common/paper.cpp:144
+#: ../src/common/paper.cpp:141
 msgid "Legal Extra 9 1/2 x 15 in"
 msgstr "リーガル Extra 9 1/2 x 15インチ"
 
-#: ../src/common/paper.cpp:96
+#: ../src/common/paper.cpp:93
 msgid "Legal, 8 1/2 x 14 in"
 msgstr "リーガル, 8 1/2 x 14インチ"
 
-#: ../src/common/paper.cpp:143
+#: ../src/common/paper.cpp:140
 msgid "Letter Extra 9 1/2 x 12 in"
 msgstr "レター Extra 9 1/2 x 12インチ"
 
-#: ../src/common/paper.cpp:149
+#: ../src/common/paper.cpp:146
 msgid "Letter Extra Transverse 9.275 x 12 in"
 msgstr "レター Extra Transverse 9.275 x 12 インチ"
 
-#: ../src/common/paper.cpp:152
+#: ../src/common/paper.cpp:149
 msgid "Letter Plus 8 1/2 x 12.69 in"
 msgstr "レター Plus 8 1/2 x 12.69インチ"
 
-#: ../src/common/paper.cpp:169
+#: ../src/common/paper.cpp:166
 msgid "Letter Rotated 11 x 8 1/2 in"
 msgstr "レター 横置き 11 x 8 1/2インチ"
 
-#: ../src/common/paper.cpp:101
+#: ../src/common/paper.cpp:98
 msgid "Letter Small, 8 1/2 x 11 in"
 msgstr "レター Small, 8 1/2 x 11インチ"
 
-#: ../src/common/paper.cpp:147
+#: ../src/common/paper.cpp:144
 msgid "Letter Transverse 8 1/2 x 11 in"
 msgstr "レター Transverse 8 1/2 x 11インチ"
 
-#: ../src/common/paper.cpp:95
+#: ../src/common/paper.cpp:92
 msgid "Letter, 8 1/2 x 11 in"
 msgstr "レター, 8 1/2 x 11インチ"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "License"
 msgstr "許諾"
 
-#: ../src/generic/fontdlgg.cpp:332
+#: ../src/generic/fontdlgg.cpp:328
 msgid "Light"
 msgstr "軽量"
 
-#: ../src/propgrid/advprops.cpp:1608
+#: ../src/propgrid/advprops.cpp:1514
 msgid "Lime"
 msgstr ""
 
-#: ../src/generic/helpext.cpp:294
+#: ../src/generic/helpext.cpp:292
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr ""
@@ -4745,15 +4870,15 @@ msgstr ""
 msgid "Line spacing:"
 msgstr "行間隔:"
 
-#: ../src/html/chm.cpp:838
+#: ../src/html/chm.cpp:829
 msgid "Link contained '//', converted to absolute link."
 msgstr "リンクは '//' を含んでいます。絶対パスリンクに変換しました。"
 
-#: ../src/richtext/richtextformatdlg.cpp:364
+#: ../src/richtext/richtextformatdlg.cpp:357
 msgid "List Style"
 msgstr "リストスタイル"
 
-#: ../src/richtext/richtextstyles.cpp:1064
+#: ../src/richtext/richtextstyles.cpp:1061
 msgid "List styles"
 msgstr "リストスタイル"
 
@@ -4767,26 +4892,26 @@ msgstr "利用できるポイント指定の大きさ一覧です。"
 msgid "Lists the available fonts."
 msgstr "利用できるフォントの一覧です。"
 
-#: ../src/common/fldlgcmn.cpp:340
+#: ../src/common/fldlgcmn.cpp:337
 #, c-format
 msgid "Load %s file"
 msgstr "%s ファイルの読み取り"
 
-#: ../src/html/htmlwin.cpp:597
+#: ../src/html/htmlwin.cpp:600
 msgid "Loading : "
 msgstr "読み取り中 : "
 
-#: ../src/unix/snglinst.cpp:246
+#: ../src/unix/snglinst.cpp:243
 #, c-format
 msgid "Lock file '%s' has incorrect owner."
 msgstr "ロックファイル '%s' は不正な所有者を示しています。"
 
-#: ../src/unix/snglinst.cpp:251
+#: ../src/unix/snglinst.cpp:248
 #, c-format
 msgid "Lock file '%s' has incorrect permissions."
 msgstr "ロックファイル '%s' は不正なパーミッションを示しています。"
 
-#: ../src/generic/logg.cpp:576
+#: ../src/generic/logg.cpp:573
 #, c-format
 msgid "Log saved to the file '%s'."
 msgstr "ファイル '%s' にログを保存しました。"
@@ -4801,11 +4926,11 @@ msgstr "小文字単語"
 msgid "Lower case roman numerals"
 msgstr "小文字ローマ数字"
 
-#: ../src/gtk/mdi.cpp:422 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk1/mdi.cpp:431 ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "MDI子ウィンドウ"
 
-#: ../src/msw/helpchm.cpp:56
+#: ../src/msw/helpchm.cpp:53
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -4813,190 +4938,190 @@ msgstr ""
 "Microsoft Help ライブラリーがインストールされていないので Microsoft HTML "
 "Help 機能が使えません。そのライブラリーをインストールしてください。"
 
-#: ../src/univ/themes/win32.cpp:3754
+#: ../src/univ/themes/win32.cpp:3751
 msgid "Ma&ximize"
 msgstr "最大化 (&X)"
 
-#: ../src/common/fmapbase.cpp:203
+#: ../src/common/fmapbase.cpp:200
 msgid "MacArabic"
 msgstr "MacArabic"
 
-#: ../src/common/fmapbase.cpp:222
+#: ../src/common/fmapbase.cpp:219
 msgid "MacArmenian"
 msgstr "MacArmenian"
 
-#: ../src/common/fmapbase.cpp:211
+#: ../src/common/fmapbase.cpp:208
 msgid "MacBengali"
 msgstr "MacBengali"
 
-#: ../src/common/fmapbase.cpp:217
+#: ../src/common/fmapbase.cpp:214
 msgid "MacBurmese"
 msgstr "MacBurmese"
 
-#: ../src/common/fmapbase.cpp:236
+#: ../src/common/fmapbase.cpp:233
 msgid "MacCeltic"
 msgstr "MacCeltic"
 
-#: ../src/common/fmapbase.cpp:227
+#: ../src/common/fmapbase.cpp:224
 msgid "MacCentralEurRoman"
 msgstr "MacCentralEurRoman"
 
-#: ../src/common/fmapbase.cpp:223
+#: ../src/common/fmapbase.cpp:220
 msgid "MacChineseSimp"
 msgstr "MacChineseSimp"
 
-#: ../src/common/fmapbase.cpp:201
+#: ../src/common/fmapbase.cpp:198
 msgid "MacChineseTrad"
 msgstr "MacChineseTrad"
 
-#: ../src/common/fmapbase.cpp:233
+#: ../src/common/fmapbase.cpp:230
 msgid "MacCroatian"
 msgstr "MacCroatian"
 
-#: ../src/common/fmapbase.cpp:206
+#: ../src/common/fmapbase.cpp:203
 msgid "MacCyrillic"
 msgstr "MacCyrillic"
 
-#: ../src/common/fmapbase.cpp:207
+#: ../src/common/fmapbase.cpp:204
 msgid "MacDevanagari"
 msgstr "MacDevanagari"
 
-#: ../src/common/fmapbase.cpp:231
+#: ../src/common/fmapbase.cpp:228
 msgid "MacDingbats"
 msgstr "MacDingbats"
 
-#: ../src/common/fmapbase.cpp:226
+#: ../src/common/fmapbase.cpp:223
 msgid "MacEthiopic"
 msgstr "MacEthiopic"
 
-#: ../src/common/fmapbase.cpp:229
+#: ../src/common/fmapbase.cpp:226
 msgid "MacExtArabic"
 msgstr "MacExtArabic"
 
-#: ../src/common/fmapbase.cpp:237
+#: ../src/common/fmapbase.cpp:234
 msgid "MacGaelic"
 msgstr "MacGaelic"
 
-#: ../src/common/fmapbase.cpp:221
+#: ../src/common/fmapbase.cpp:218
 msgid "MacGeorgian"
 msgstr "MacGeorgian"
 
-#: ../src/common/fmapbase.cpp:205
+#: ../src/common/fmapbase.cpp:202
 msgid "MacGreek"
 msgstr "MacGreek"
 
-#: ../src/common/fmapbase.cpp:209
+#: ../src/common/fmapbase.cpp:206
 msgid "MacGujarati"
 msgstr "MacGujarati"
 
-#: ../src/common/fmapbase.cpp:208
+#: ../src/common/fmapbase.cpp:205
 msgid "MacGurmukhi"
 msgstr "MacGurmukhi"
 
-#: ../src/common/fmapbase.cpp:204
+#: ../src/common/fmapbase.cpp:201
 msgid "MacHebrew"
 msgstr "MacHebrew"
 
-#: ../src/common/fmapbase.cpp:234
+#: ../src/common/fmapbase.cpp:231
 msgid "MacIcelandic"
 msgstr "MacIcelandic"
 
-#: ../src/common/fmapbase.cpp:200
+#: ../src/common/fmapbase.cpp:197
 msgid "MacJapanese"
 msgstr "MacJapanese"
 
-#: ../src/common/fmapbase.cpp:214
+#: ../src/common/fmapbase.cpp:211
 msgid "MacKannada"
 msgstr "MacKannada"
 
-#: ../src/common/fmapbase.cpp:238
+#: ../src/common/fmapbase.cpp:235
 msgid "MacKeyboardGlyphs"
 msgstr "MacKeyboardGlyphs"
 
-#: ../src/common/fmapbase.cpp:218
+#: ../src/common/fmapbase.cpp:215
 msgid "MacKhmer"
 msgstr "MacKhmer"
 
-#: ../src/common/fmapbase.cpp:202
+#: ../src/common/fmapbase.cpp:199
 msgid "MacKorean"
 msgstr "MacKorean"
 
-#: ../src/common/fmapbase.cpp:220
+#: ../src/common/fmapbase.cpp:217
 msgid "MacLaotian"
 msgstr "MacLaotian"
 
-#: ../src/common/fmapbase.cpp:215
+#: ../src/common/fmapbase.cpp:212
 msgid "MacMalayalam"
 msgstr "MacMalayalam"
 
-#: ../src/common/fmapbase.cpp:225
+#: ../src/common/fmapbase.cpp:222
 msgid "MacMongolian"
 msgstr "MacMongolian"
 
-#: ../src/common/fmapbase.cpp:210
+#: ../src/common/fmapbase.cpp:207
 msgid "MacOriya"
 msgstr "MacOriya"
 
-#: ../src/common/fmapbase.cpp:199
+#: ../src/common/fmapbase.cpp:196
 msgid "MacRoman"
 msgstr "MacRoman"
 
-#: ../src/common/fmapbase.cpp:235
+#: ../src/common/fmapbase.cpp:232
 msgid "MacRomanian"
 msgstr "MacRomanian"
 
-#: ../src/common/fmapbase.cpp:216
+#: ../src/common/fmapbase.cpp:213
 msgid "MacSinhalese"
 msgstr "MacSinhalese"
 
-#: ../src/common/fmapbase.cpp:230
+#: ../src/common/fmapbase.cpp:227
 msgid "MacSymbol"
 msgstr "MacSymbol"
 
-#: ../src/common/fmapbase.cpp:212
+#: ../src/common/fmapbase.cpp:209
 msgid "MacTamil"
 msgstr "MacTamil"
 
-#: ../src/common/fmapbase.cpp:213
+#: ../src/common/fmapbase.cpp:210
 msgid "MacTelugu"
 msgstr "MacTelugu"
 
-#: ../src/common/fmapbase.cpp:219
+#: ../src/common/fmapbase.cpp:216
 msgid "MacThai"
 msgstr "MacThai"
 
-#: ../src/common/fmapbase.cpp:224
+#: ../src/common/fmapbase.cpp:221
 msgid "MacTibetan"
 msgstr "MacTibetan"
 
-#: ../src/common/fmapbase.cpp:232
+#: ../src/common/fmapbase.cpp:229
 msgid "MacTurkish"
 msgstr "MacTurkish"
 
-#: ../src/common/fmapbase.cpp:228
+#: ../src/common/fmapbase.cpp:225
 msgid "MacVietnamese"
 msgstr "MacVietnamese"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1762
+#: ../src/propgrid/advprops.cpp:1663
 msgid "Magnifier"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:2143
+#: ../src/propgrid/advprops.cpp:2050
 msgid "Make a selection:"
 msgstr "選択してください:"
 
-#: ../src/richtext/richtextformatdlg.cpp:374
+#: ../src/richtext/richtextformatdlg.cpp:367
 #: ../src/richtext/richtextmarginspage.cpp:171
 #, fuzzy
 msgid "Margins"
 msgstr "MacGeorgian"
 
-#: ../src/propgrid/advprops.cpp:1595
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Maroon"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:147
+#: ../src/generic/fdrepdlg.cpp:144
 msgid "Match case"
 msgstr "大文字小文字を区別"
 
@@ -5010,41 +5135,41 @@ msgstr "ウエイト (&W):"
 msgid "Max width:"
 msgstr "置換先:"
 
-#: ../src/unix/mediactrl.cpp:947
+#: ../src/unix/mediactrl.cpp:972
 #, c-format
 msgid "Media playback error: %s"
 msgstr ""
 
-#: ../src/common/fs_mem.cpp:175
+#: ../src/common/fs_mem.cpp:170
 #, c-format
 msgid "Memory VFS already contains file '%s'!"
 msgstr "メモリーVFSにはファイル '%s' がすでにあります。"
 
 #. TRANSLATORS: Name of keyboard key
 #. TRANSLATORS: Keyword of system colour
-#: ../src/common/accelcmn.cpp:73 ../src/propgrid/advprops.cpp:889
+#: ../src/common/accelcmn.cpp:70 ../src/propgrid/advprops.cpp:790
 msgid "Menu"
 msgstr "メニュー"
 
-#: ../src/common/msgout.cpp:124
+#: ../src/common/msgout.cpp:121
 #, fuzzy
 msgid "Message"
 msgstr "%s からの通知"
 
-#: ../src/univ/themes/metal.cpp:168
+#: ../src/univ/themes/metal.cpp:165
 msgid "Metal theme"
 msgstr "メタルテーマ"
 
-#: ../src/msw/ole/automtn.cpp:652
+#: ../src/msw/ole/automtn.cpp:643
 msgid "Method or property not found."
 msgstr ""
 
-#: ../src/univ/themes/win32.cpp:3752
+#: ../src/univ/themes/win32.cpp:3749
 msgid "Mi&nimize"
 msgstr "最小化 (&N)"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1763
+#: ../src/propgrid/advprops.cpp:1664
 msgid "Middle Button"
 msgstr ""
 
@@ -5057,36 +5182,41 @@ msgstr "フォントのウエイト(&W):"
 msgid "Min width:"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:668
+#: ../src/osx/cocoa/menu.mm:281
+#, fuzzy
+msgid "Minimize"
+msgstr "最小化 (&N)"
+
+#: ../src/msw/ole/automtn.cpp:659
 msgid "Missing a required parameter."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:324
+#: ../src/generic/fontdlgg.cpp:320
 msgid "Modern"
 msgstr "Modern"
 
-#: ../src/generic/filectrlg.cpp:427
+#: ../src/generic/filectrlg.cpp:423
 msgid "Modified"
 msgstr "更新"
 
-#: ../src/common/module.cpp:133
+#: ../src/common/module.cpp:130
 #, c-format
 msgid "Module \"%s\" initialization failed"
 msgstr "モジュール \"%s\" の初期化に失敗しました"
 
-#: ../src/common/paper.cpp:131
+#: ../src/common/paper.cpp:128
 msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
 msgstr "Monarch 封筒, 3 7/8 x 7 1/2インチ"
 
-#: ../src/msw/fswatcher.cpp:143
+#: ../src/msw/fswatcher.cpp:140
 msgid "Monitoring individual files for changes is not supported currently."
 msgstr ""
 
-#: ../src/generic/editlbox.cpp:172
+#: ../src/generic/editlbox.cpp:160
 msgid "Move down"
 msgstr "下に移動"
 
-#: ../src/generic/editlbox.cpp:171
+#: ../src/generic/editlbox.cpp:155
 msgid "Move up"
 msgstr "上に移動"
 
@@ -5102,100 +5232,105 @@ msgstr "次の段落に適用されるスタイルを指定します。"
 msgid "Moves the object to the previous paragraph."
 msgstr "前のHTMLページに戻る"
 
-#: ../src/richtext/richtextbuffer.cpp:9966
+#: ../src/richtext/richtextbuffer.cpp:9963
 msgid "Multiple Cell Properties"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:424
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:82
+msgid "Multiply"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:420
 msgid "Name"
 msgstr "名前"
 
-#: ../src/propgrid/advprops.cpp:1596
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Navy"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 #, fuzzy
 msgid "Network"
 msgstr "ネットワーク (&N)"
 
-#: ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173
 #, fuzzy
 msgid "New"
 msgstr "新規作成 (&N)"
 
-#: ../src/richtext/richtextstyledlg.cpp:243
+#: ../src/richtext/richtextstyledlg.cpp:239
 #, fuzzy
 msgid "New &Box Style..."
 msgstr "新規リストスタイル (&L) ..."
 
-#: ../src/richtext/richtextstyledlg.cpp:225
+#: ../src/richtext/richtextstyledlg.cpp:221
 msgid "New &Character Style..."
 msgstr "新規文字スタイル (&C) ..."
 
-#: ../src/richtext/richtextstyledlg.cpp:237
+#: ../src/richtext/richtextstyledlg.cpp:233
 msgid "New &List Style..."
 msgstr "新規リストスタイル (&L) ..."
 
-#: ../src/richtext/richtextstyledlg.cpp:231
+#: ../src/richtext/richtextstyledlg.cpp:227
 msgid "New &Paragraph Style..."
 msgstr "新規段落スタイル (&P) ..."
 
-#: ../src/richtext/richtextstyledlg.cpp:606
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:654
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:820
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:893
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:934
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:602
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:650
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:816
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:889
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:930
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "New Style"
 msgstr "新規スタイル"
 
-#: ../src/generic/editlbox.cpp:169
+#: ../src/generic/editlbox.cpp:139
 msgid "New item"
 msgstr "新規項目"
 
-#: ../src/generic/dirdlgg.cpp:297 ../src/generic/dirdlgg.cpp:307
-#: ../src/generic/filectrlg.cpp:618 ../src/generic/filectrlg.cpp:627
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+#: ../src/generic/dirdlgg.cpp:294 ../src/generic/dirdlgg.cpp:304
 msgid "NewName"
 msgstr "新しい名前"
 
-#: ../src/common/prntbase.cpp:1567 ../src/html/helpwnd.cpp:665
+#: ../src/common/prntbase.cpp:1592 ../src/html/helpwnd.cpp:663
 msgid "Next page"
 msgstr "次のページ"
 
-#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:177
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:174
 #: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "いいえ"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1764
+#: ../src/propgrid/advprops.cpp:1665
 msgid "No Entry"
 msgstr ""
 
-#: ../src/generic/animateg.cpp:150
+#: ../src/generic/animateg.cpp:133
 #, c-format
 msgid "No animation handler for type %ld defined."
 msgstr "%ld 型のアニメーションハンドラーは未定義です。"
 
-#: ../src/dfb/bitmap.cpp:642 ../src/dfb/bitmap.cpp:676
+#: ../src/dfb/bitmap.cpp:639 ../src/dfb/bitmap.cpp:673
 #, c-format
 msgid "No bitmap handler for type %d defined."
 msgstr "'%d' 型のイメージハンドラは定義されていません。"
 
-#: ../src/common/utilscmn.cpp:1077
+#: ../src/common/utilscmn.cpp:1095
 msgid "No default application configured for HTML files."
 msgstr "HTMLファイルに対する既定のアプリケーション設定がありません。"
 
-#: ../src/generic/helpext.cpp:445
+#: ../src/generic/helpext.cpp:443
 msgid "No entries found."
 msgstr "項目が見つかりません。"
 
-#: ../src/common/fontmap.cpp:421
+#: ../src/common/fontmap.cpp:418
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found,\n"
@@ -5207,7 +5342,7 @@ msgstr ""
 "他のエンコーディング '%s' でありば利用可能です。\n"
 "このエンコーディングを使いますか(そうでなければ別のものを選びます)?"
 
-#: ../src/common/fontmap.cpp:426
+#: ../src/common/fontmap.cpp:423
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found.\n"
@@ -5218,207 +5353,207 @@ msgstr ""
 "このエンコーディングに使うフォントを選択しますか\n"
 "(そうでなければこのエンコーディングのテキストは正しく表示されません)?"
 
-#: ../src/generic/animateg.cpp:142
+#: ../src/generic/animateg.cpp:125
 msgid "No handler found for animation type."
 msgstr "アニメーションタイプのハンドラーが見つかりません。"
 
-#: ../src/common/image.cpp:2728
+#: ../src/common/image.cpp:2823
 msgid "No handler found for image type."
 msgstr "イメージタイプのハンドラーが見つかりません。"
 
-#: ../src/common/image.cpp:2736 ../src/common/image.cpp:2848
-#: ../src/common/image.cpp:2901
+#: ../src/common/image.cpp:2831 ../src/common/image.cpp:2954
+#: ../src/common/image.cpp:3020
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "%d 型のイメージハンドラーが定義されていません。"
 
-#: ../src/common/image.cpp:2871 ../src/common/image.cpp:2915
+#: ../src/common/image.cpp:2986 ../src/common/image.cpp:3034
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "%s 型のイメージハンドラーが定義されていません。"
 
-#: ../src/html/helpwnd.cpp:858
+#: ../src/html/helpwnd.cpp:856
 msgid "No matching page found yet"
 msgstr "一致するページがまだありません。"
 
-#: ../src/unix/sound.cpp:81
+#: ../src/unix/sound.cpp:78
 msgid "No sound"
 msgstr "音声なし"
 
-#: ../src/common/image.cpp:2277 ../src/common/image.cpp:2318
+#: ../src/common/image.cpp:2371 ../src/common/image.cpp:2412
 msgid "No unused colour in image being masked."
 msgstr "マスクされるべき未使用色が画像にありません。"
 
-#: ../src/common/image.cpp:3374
-msgid "No unused colour in image."
-msgstr "画像に未使用色がありません。"
-
-#: ../src/generic/helpext.cpp:302
+#: ../src/generic/helpext.cpp:300
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "ファイル \"%s\" には適切なマップが含まれていません。"
 
-#: ../src/richtext/richtextborderspage.cpp:610
 #: ../src/richtext/richtextsizepage.cpp:248
 #: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:610
 #, fuzzy
 msgid "None"
 msgstr "(なし)"
 
-#: ../src/common/fmapbase.cpp:157
+#: ../src/common/fmapbase.cpp:154
 msgid "Nordic (ISO-8859-10)"
 msgstr "北欧言語 (Latin-6, ISO-8859-10)"
 
-#: ../src/generic/fontdlgg.cpp:328 ../src/generic/fontdlgg.cpp:331
+#: ../src/generic/fontdlgg.cpp:324 ../src/generic/fontdlgg.cpp:327
 msgid "Normal"
 msgstr "通常"
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1261
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "通常<br> と <u>下線付き</u>"
 
-#: ../src/html/helpwnd.cpp:1205
+#: ../src/html/helpwnd.cpp:1203
 msgid "Normal font:"
 msgstr "通常のフォント:"
 
-#: ../src/propgrid/props.cpp:1128
+#: ../src/propgrid/props.cpp:1115
 #, c-format
 msgid "Not %s"
 msgstr "%sではない"
 
-#: ../include/wx/filename.h:573 ../include/wx/filename.h:578
-msgid "Not available"
-msgstr "利用できません"
+#: ../src/common/secretstore.cpp:168
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/webrequest.cpp:605
+msgid "Not enough free disk space for download."
+msgstr ""
 
 #: ../src/richtext/richtextfontpage.cpp:358
 msgid "Not underlined"
 msgstr "下線なし"
 
-#: ../src/common/paper.cpp:115
+#: ../src/common/paper.cpp:112
 msgid "Note, 8 1/2 x 11 in"
 msgstr "ノート, 8 1/2×11インチ"
 
-#: ../src/generic/notifmsgg.cpp:132
+#: ../src/generic/notifmsgg.cpp:129
 msgid "Notice"
 msgstr "お知らせ"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "Num *"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "Num +"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "Num ,"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "Num -"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "Num ."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "Num /"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "Num ="
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "Num Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 #, fuzzy
 msgid "Num Delete"
 msgstr "削除"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 #, fuzzy
 msgid "Num Down"
 msgstr "下へ"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "Num End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "Num Enter"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 #, fuzzy
 msgid "Num Home"
 msgstr "ホーム"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 #, fuzzy
 msgid "Num Insert"
 msgstr "挿入"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num Lock"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "Num Page Down"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "Num Page Up"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 #, fuzzy
 msgid "Num Right"
 msgstr "右"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "Num Space"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "Num Tab"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "Num Up"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "Num left"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num_lock"
 msgstr ""
 
@@ -5427,13 +5562,13 @@ msgstr ""
 msgid "Numbered outline"
 msgstr "番号付きアウトライン"
 
-#: ../include/wx/msgdlg.h:278 ../src/richtext/richtextstyledlg.cpp:297
-#: ../src/common/stockitem.cpp:178 ../src/msw/msgdlg.cpp:454
-#: ../src/msw/msgdlg.cpp:747 ../src/gtk1/fontdlg.cpp:138
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:175
+#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/msgdlg.cpp:741 ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "OK"
 
-#: ../src/msw/ole/automtn.cpp:692
+#: ../src/msw/ole/automtn.cpp:683
 #, c-format
 msgid "OLE Automation error in %s: %s"
 msgstr ""
@@ -5443,15 +5578,15 @@ msgstr ""
 msgid "Object Properties"
 msgstr "プロパティー (&P)"
 
-#: ../src/msw/ole/automtn.cpp:660
+#: ../src/msw/ole/automtn.cpp:651
 msgid "Object implementation does not support named arguments."
 msgstr ""
 
-#: ../src/common/xtixml.cpp:264
+#: ../src/common/xtixml.cpp:260
 msgid "Objects must have an id attribute"
 msgstr "オブジェクトには id 属性が必須です。"
 
-#: ../src/propgrid/advprops.cpp:1601
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Olive"
 msgstr ""
 
@@ -5459,65 +5594,70 @@ msgstr ""
 msgid "Opaci&ty:"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:354
+#: ../src/generic/colrdlgg.cpp:374
 msgid "Opacity:"
 msgstr ""
 
-#: ../src/common/docview.cpp:1773 ../src/common/docview.cpp:1815
+#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
 msgid "Open File"
 msgstr "ファイルを開く"
 
-#: ../src/html/helpwnd.cpp:671 ../src/html/helpwnd.cpp:1554
+#: ../src/html/helpwnd.cpp:669 ../src/html/helpwnd.cpp:1552
 msgid "Open HTML document"
 msgstr "HTML文書を開く"
 
-#: ../src/generic/dbgrptg.cpp:163
+#: ../src/common/stockitem.cpp:265
+#, fuzzy
+msgid "Open an existing document"
+msgstr "HTML文書を開く"
+
+#: ../src/generic/dbgrptg.cpp:160
 #, c-format
 msgid "Open file \"%s\""
 msgstr "ファイル \"%s\" を開く"
 
-#: ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176
 #, fuzzy
 msgid "Open..."
 msgstr "開く (&O) ..."
 
-#: ../src/unix/glx11.cpp:506 ../src/msw/glcanvas.cpp:592
+#: ../src/msw/glcanvas.cpp:607 ../src/unix/glx11.cpp:513
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr ""
 
-#: ../src/generic/dirctrlg.cpp:599 ../src/generic/dirdlgg.cpp:323
-#: ../src/generic/filectrlg.cpp:642 ../src/generic/filectrlg.cpp:786
+#: ../src/generic/dirctrlg.cpp:565 ../src/generic/filectrlg.cpp:638
+#: ../src/generic/filectrlg.cpp:782 ../src/generic/dirdlgg.cpp:320
 msgid "Operation not permitted."
 msgstr "処理が許可されていません。"
 
-#: ../src/common/cmdline.cpp:900
+#: ../src/common/cmdline.cpp:896
 #, fuzzy, c-format
 msgid "Option '%s' can't be negated"
 msgstr "ディレクトリー '%s' を作成できませんでした"
 
-#: ../src/common/cmdline.cpp:1064
+#: ../src/common/cmdline.cpp:1060
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "オプション '%s' には値の指定が必要です。"
 
-#: ../src/common/cmdline.cpp:1147
+#: ../src/common/cmdline.cpp:1143
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "オプション '%s': '%s' という表現は日付に変換できません。"
 
-#: ../src/generic/prntdlgg.cpp:618
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "オプション"
 
-#: ../src/propgrid/advprops.cpp:1606
+#: ../src/propgrid/advprops.cpp:1512
 msgid "Orange"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:615 ../src/generic/prntdlgg.cpp:869
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:862
 msgid "Orientation"
 msgstr "向き"
 
-#: ../src/common/windowid.cpp:242
+#: ../src/common/windowid.cpp:237
 msgid "Out of window IDs.  Recommend shutting down application."
 msgstr ""
 "ウィンドウIDが制限範囲を超えました。アプリケーションの再起動をおすすめしま"
@@ -5533,148 +5673,148 @@ msgstr "アウトラインレベル (&O):"
 msgid "Outset"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:656
+#: ../src/msw/ole/automtn.cpp:647
 msgid "Overflow while coercing argument values."
 msgstr ""
 
-#: ../src/common/imagpcx.cpp:457 ../src/common/imagpcx.cpp:480
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:479
 msgid "PCX: couldn't allocate memory"
 msgstr "PCX: メモリを割り当てることができません"
 
-#: ../src/common/imagpcx.cpp:456
+#: ../src/common/imagpcx.cpp:455
 msgid "PCX: image format unsupported"
 msgstr "PCX: 画像形式は未対応です"
 
-#: ../src/common/imagpcx.cpp:479
+#: ../src/common/imagpcx.cpp:478
 msgid "PCX: invalid image"
 msgstr "PCX: 不正な画像です"
 
-#: ../src/common/imagpcx.cpp:442
+#: ../src/common/imagpcx.cpp:441
 msgid "PCX: this is not a PCX file."
 msgstr "PCX: PCXファイルではないようです。"
 
-#: ../src/common/imagpcx.cpp:459 ../src/common/imagpcx.cpp:481
+#: ../src/common/imagpcx.cpp:458 ../src/common/imagpcx.cpp:480
 msgid "PCX: unknown error !!!"
 msgstr "PCX: 未対応のエラーが発生しました。"
 
-#: ../src/common/imagpcx.cpp:458
+#: ../src/common/imagpcx.cpp:457
 msgid "PCX: version number too low"
 msgstr "PCX: バージョン番号が低すぎるようです。"
 
-#: ../src/common/imagpnm.cpp:91
+#: ../src/common/imagpnm.cpp:89
 msgid "PNM: Couldn't allocate memory."
 msgstr "PNM: メモリを割り当てることができません。"
 
-#: ../src/common/imagpnm.cpp:73
+#: ../src/common/imagpnm.cpp:71
 msgid "PNM: File format is not recognized."
 msgstr "PNM: ファイル形式を解析できません。"
 
-#: ../src/common/imagpnm.cpp:112 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
 #: ../src/common/imagpnm.cpp:156
 msgid "PNM: File seems truncated."
 msgstr "PNM: ファイルが欠けているようです。"
 
-#: ../src/common/paper.cpp:187
+#: ../src/common/paper.cpp:184
 msgid "PRC 16K 146 x 215 mm"
 msgstr "中国 16K 146 x 215 mm"
 
-#: ../src/common/paper.cpp:200
+#: ../src/common/paper.cpp:197
 msgid "PRC 16K Rotated"
 msgstr "中国 16K 横置き"
 
-#: ../src/common/paper.cpp:188
+#: ../src/common/paper.cpp:185
 msgid "PRC 32K 97 x 151 mm"
 msgstr "中国 32K 97 x 151 mm"
 
-#: ../src/common/paper.cpp:201
+#: ../src/common/paper.cpp:198
 msgid "PRC 32K Rotated"
 msgstr "中国 32K 横置き"
 
-#: ../src/common/paper.cpp:189
+#: ../src/common/paper.cpp:186
 msgid "PRC 32K(Big) 97 x 151 mm"
 msgstr "中国 32K(Big) 97 x 151 mm"
 
-#: ../src/common/paper.cpp:202
+#: ../src/common/paper.cpp:199
 msgid "PRC 32K(Big) Rotated"
 msgstr "中国 32K(Big) 横置き"
 
-#: ../src/common/paper.cpp:190
+#: ../src/common/paper.cpp:187
 msgid "PRC Envelope #1 102 x 165 mm"
 msgstr "中国封筒 #1 102 x 165 mm"
 
-#: ../src/common/paper.cpp:203
+#: ../src/common/paper.cpp:200
 msgid "PRC Envelope #1 Rotated 165 x 102 mm"
 msgstr "中国封筒 #1 横置き 165 x 102 mm"
 
-#: ../src/common/paper.cpp:199
+#: ../src/common/paper.cpp:196
 msgid "PRC Envelope #10 324 x 458 mm"
 msgstr "中国封筒 #10 324 x 458 mm"
 
-#: ../src/common/paper.cpp:212
+#: ../src/common/paper.cpp:209
 msgid "PRC Envelope #10 Rotated 458 x 324 mm"
 msgstr "中国封筒 #10 横置き 458 x 324 mm"
 
-#: ../src/common/paper.cpp:191
+#: ../src/common/paper.cpp:188
 msgid "PRC Envelope #2 102 x 176 mm"
 msgstr "中国封筒 #2 102 x 176 mm"
 
-#: ../src/common/paper.cpp:204
+#: ../src/common/paper.cpp:201
 msgid "PRC Envelope #2 Rotated 176 x 102 mm"
 msgstr "中国封筒 #2 横置き 176 x 102 mm"
 
-#: ../src/common/paper.cpp:192
+#: ../src/common/paper.cpp:189
 msgid "PRC Envelope #3 125 x 176 mm"
 msgstr "中国封筒 #3 125 x 176 mm"
 
-#: ../src/common/paper.cpp:205
+#: ../src/common/paper.cpp:202
 msgid "PRC Envelope #3 Rotated 176 x 125 mm"
 msgstr "中国封筒 #3 横置き 176 x 125 mm"
 
-#: ../src/common/paper.cpp:193
+#: ../src/common/paper.cpp:190
 msgid "PRC Envelope #4 110 x 208 mm"
 msgstr "中国封筒 #4 110 x 208 mm"
 
-#: ../src/common/paper.cpp:206
+#: ../src/common/paper.cpp:203
 msgid "PRC Envelope #4 Rotated 208 x 110 mm"
 msgstr "中国封筒 #4 横置き 208 x 110 mm"
 
-#: ../src/common/paper.cpp:194
+#: ../src/common/paper.cpp:191
 msgid "PRC Envelope #5 110 x 220 mm"
 msgstr "中国封筒 #5 110 x 220 mm"
 
-#: ../src/common/paper.cpp:207
+#: ../src/common/paper.cpp:204
 msgid "PRC Envelope #5 Rotated 220 x 110 mm"
 msgstr "中国封筒 #5 横置き 220 x 110 mm"
 
-#: ../src/common/paper.cpp:195
+#: ../src/common/paper.cpp:192
 msgid "PRC Envelope #6 120 x 230 mm"
 msgstr "中国封筒 #6 120 x 230 mm"
 
-#: ../src/common/paper.cpp:208
+#: ../src/common/paper.cpp:205
 msgid "PRC Envelope #6 Rotated 230 x 120 mm"
 msgstr "中国封筒 #6 横置き 230 x 120 mm"
 
-#: ../src/common/paper.cpp:196
+#: ../src/common/paper.cpp:193
 msgid "PRC Envelope #7 160 x 230 mm"
 msgstr "中国封筒 #7 160 x 230 mm"
 
-#: ../src/common/paper.cpp:209
+#: ../src/common/paper.cpp:206
 msgid "PRC Envelope #7 Rotated 230 x 160 mm"
 msgstr "中国封筒 #7 横置き 230 x 160 mm"
 
-#: ../src/common/paper.cpp:197
+#: ../src/common/paper.cpp:194
 msgid "PRC Envelope #8 120 x 309 mm"
 msgstr "中国封筒 #8 120 x 309 mm"
 
-#: ../src/common/paper.cpp:210
+#: ../src/common/paper.cpp:207
 msgid "PRC Envelope #8 Rotated 309 x 120 mm"
 msgstr "中国封筒 #8 横置き 309 x 120 mm"
 
-#: ../src/common/paper.cpp:198
+#: ../src/common/paper.cpp:195
 msgid "PRC Envelope #9 229 x 324 mm"
 msgstr "中国封筒 #9 229 x 324 mm"
 
-#: ../src/common/paper.cpp:211
+#: ../src/common/paper.cpp:208
 msgid "PRC Envelope #9 Rotated 324 x 229 mm"
 msgstr "中国封筒 #9 横置き 324 x 229 mm"
 
@@ -5683,91 +5823,95 @@ msgstr "中国封筒 #9 横置き 324 x 229 mm"
 msgid "Padding"
 msgstr "読み取り"
 
-#: ../src/common/prntbase.cpp:2074
+#: ../src/common/prntbase.cpp:2096
 #, c-format
 msgid "Page %d"
 msgstr "%dページ"
 
-#: ../src/common/prntbase.cpp:2072
+#: ../src/common/prntbase.cpp:2094
 #, c-format
 msgid "Page %d of %d"
 msgstr "%dページ (%dページ中)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 #, fuzzy
 msgid "Page Down"
 msgstr "%dページ"
 
-#: ../src/gtk/print.cpp:826
+#: ../src/gtk/print.cpp:829
 msgid "Page Setup"
 msgstr "ページの設定"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 #, fuzzy
 msgid "Page Up"
 msgstr "%dページ"
 
-#: ../src/generic/prntdlgg.cpp:828 ../src/common/prntbase.cpp:484
+#: ../src/common/prntbase.cpp:479 ../src/generic/prntdlgg.cpp:821
 msgid "Page setup"
 msgstr "ページの設定"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 #, fuzzy
 msgid "PageDown"
 msgstr "下へ"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 #, fuzzy
 msgid "PageUp"
 msgstr "指定"
 
-#: ../src/generic/prntdlgg.cpp:216
+#: ../src/generic/prntdlgg.cpp:209
 msgid "Pages"
 msgstr "指定"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1765
+#: ../src/propgrid/advprops.cpp:1666
 msgid "Paint Brush"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:602 ../src/generic/prntdlgg.cpp:801
-#: ../src/generic/prntdlgg.cpp:842 ../src/generic/prntdlgg.cpp:855
-#: ../src/generic/prntdlgg.cpp:1052 ../src/generic/prntdlgg.cpp:1057
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:794
+#: ../src/generic/prntdlgg.cpp:835 ../src/generic/prntdlgg.cpp:848
+#: ../src/generic/prntdlgg.cpp:1045 ../src/generic/prntdlgg.cpp:1050
 msgid "Paper size"
 msgstr "用紙サイズ"
 
-#: ../src/richtext/richtextstyles.cpp:1062
+#: ../src/richtext/richtextstyles.cpp:1059
 msgid "Paragraph styles"
 msgstr "段落スタイル"
 
-#: ../src/common/xtistrm.cpp:465
+#: ../src/common/xtistrm.cpp:462
 msgid "Passing a already registered object to SetObject"
 msgstr "SetObject に登録済みのオブジェクトが渡されました"
 
-#: ../src/common/xtistrm.cpp:476
+#: ../src/common/xtistrm.cpp:473
 msgid "Passing an unknown object to GetObject"
 msgstr "GetObject に未知のオブジェクトが渡されました"
 
-#: ../src/richtext/richtextctrl.cpp:3513 ../src/common/stockitem.cpp:180
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:177 ../src/richtext/richtextctrl.cpp:3514
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "貼り付け"
 
-#: ../src/common/stockitem.cpp:262
+#: ../src/common/stockitem.cpp:260
 msgid "Paste selection"
 msgstr "選択部分を貼り付け"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:74
+#: ../src/common/accelcmn.cpp:71
 msgid "Pause"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1766
+#: ../src/propgrid/advprops.cpp:1667
 msgid "Pencil"
 msgstr ""
 
@@ -5776,21 +5920,21 @@ msgstr ""
 msgid "Peri&od"
 msgstr "ピリオド (&O)"
 
-#: ../src/generic/filectrlg.cpp:430
+#: ../src/generic/filectrlg.cpp:426
 msgid "Permissions"
 msgstr "パーミッション"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:60
+#: ../src/common/accelcmn.cpp:57
 msgid "PgDn"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:59
+#: ../src/common/accelcmn.cpp:56
 msgid "PgUp"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:12868
+#: ../src/richtext/richtextbuffer.cpp:12863
 #, fuzzy
 msgid "Picture Properties"
 msgstr "プロパティー (&P)"
@@ -5803,45 +5947,45 @@ msgstr "パイプを作成できませんでした"
 msgid "Please choose a valid font."
 msgstr "有効なフォントを選んでください。"
 
-#: ../src/generic/filedlgg.cpp:357 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
 msgid "Please choose an existing file."
 msgstr "存在するファイルを選んでください。"
 
-#: ../src/html/helpwnd.cpp:800
+#: ../src/html/helpwnd.cpp:798
 msgid "Please choose the page to display:"
 msgstr "表示するページを選んでください:"
 
-#: ../src/msw/dialup.cpp:764
+#: ../src/msw/dialup.cpp:758
 msgid "Please choose which ISP do you want to connect to"
 msgstr "接続したいISPを選んでください"
 
-#: ../src/common/headerctrlcmn.cpp:59
+#: ../src/common/headerctrlcmn.cpp:57
 msgid "Please select the columns to show and define their order:"
 msgstr "表示する列とその順番を選んでください:"
 
-#: ../src/common/prntbase.cpp:538
+#: ../src/common/prntbase.cpp:533
 #, fuzzy
 msgid "Please wait while printing..."
 msgstr "印刷が終わるまでお待ちください\n"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1767
+#: ../src/propgrid/advprops.cpp:1668
 #, fuzzy
 msgid "Point Left"
 msgstr "大きさ(ポイント):"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1768
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgid "Point Right"
 msgstr "右寄せ"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:662
+#: ../src/propgrid/advprops.cpp:572
 msgid "Point Size"
 msgstr "大きさ(ポイント):"
 
-#: ../src/generic/prntdlgg.cpp:612 ../src/generic/prntdlgg.cpp:867
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:860
 msgid "Portrait"
 msgstr "縦置き"
 
@@ -5850,155 +5994,165 @@ msgstr "縦置き"
 msgid "Position"
 msgstr "印刷"
 
-#: ../src/generic/prntdlgg.cpp:298
+#: ../src/generic/prntdlgg.cpp:291
 msgid "PostScript file"
 msgstr "PostScript ファイル"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178 ../src/osx/cocoa/preferences.mm:303
 #, fuzzy
 msgid "Preferences"
 msgstr "設定 (&P)"
 
-#: ../src/osx/menu_osx.cpp:568
+#: ../src/osx/menu_osx.cpp:460
 #, fuzzy
 msgid "Preferences..."
 msgstr "設定 (&P)"
 
-#: ../src/common/prntbase.cpp:546
+#: ../src/common/prntbase.cpp:541
 msgid "Preparing"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:455 ../src/osx/carbon/fontdlg.cpp:390
-#: ../src/html/helpwnd.cpp:1222
+#: ../src/osx/carbon/fontdlg.cpp:387 ../src/generic/fontdlgg.cpp:452
+#: ../src/html/helpwnd.cpp:1220
 msgid "Preview:"
 msgstr "プレビュー:"
 
-#: ../src/common/prntbase.cpp:1553 ../src/html/helpwnd.cpp:664
+#: ../src/common/prntbase.cpp:1578 ../src/html/helpwnd.cpp:662
 msgid "Previous page"
 msgstr "前のページ"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/prntdlgg.cpp:143 ../src/generic/prntdlgg.cpp:157
-#: ../src/common/prntbase.cpp:426 ../src/common/prntbase.cpp:1541
-#: ../src/common/accelcmn.cpp:77 ../src/gtk/print.cpp:620
-#: ../src/gtk/print.cpp:638
+#: ../src/common/prntbase.cpp:421 ../src/common/prntbase.cpp:1566
+#: ../src/common/accelcmn.cpp:74 ../src/generic/prntdlgg.cpp:136
+#: ../src/generic/prntdlgg.cpp:150 ../src/gtk/print.cpp:616
+#: ../src/gtk/print.cpp:634
 msgid "Print"
 msgstr "印刷"
 
-#: ../include/wx/prntbase.h:399 ../src/common/docview.cpp:1268
+#: ../src/common/docview.cpp:1262
 msgid "Print Preview"
 msgstr "印刷プレビュー"
 
-#: ../src/common/prntbase.cpp:2015 ../src/common/prntbase.cpp:2057
-#: ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2037 ../src/common/prntbase.cpp:2079
+#: ../src/common/prntbase.cpp:2087
 msgid "Print Preview Failure"
 msgstr "印刷プレビュー失敗"
 
-#: ../src/generic/prntdlgg.cpp:224
+#: ../src/generic/prntdlgg.cpp:217
 msgid "Print Range"
 msgstr "印刷範囲"
 
-#: ../src/generic/prntdlgg.cpp:449
+#: ../src/generic/prntdlgg.cpp:442
 msgid "Print Setup"
 msgstr "印刷設定"
 
-#: ../src/generic/prntdlgg.cpp:621
+#: ../src/generic/prntdlgg.cpp:614
 msgid "Print in colour"
 msgstr "カラー印刷"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/osx/webview_webkit.mm:260
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "列の記述を初期化できませんでした。"
+
+#: ../src/common/stockitem.cpp:179
 #, fuzzy
 msgid "Print previe&w..."
 msgstr "印刷プレビュー(&W)"
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1256
 msgid "Print preview creation failed."
 msgstr "印刷プレビューを作成できませんでした。"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/common/stockitem.cpp:179
 #, fuzzy
 msgid "Print preview..."
 msgstr "印刷プレビュー"
 
-#: ../src/generic/prntdlgg.cpp:630
+#: ../src/generic/prntdlgg.cpp:623
 msgid "Print spooling"
 msgstr "印刷予約設定"
 
-#: ../src/html/helpwnd.cpp:675
+#: ../src/html/helpwnd.cpp:673
 msgid "Print this page"
 msgstr "このページを印刷"
 
-#: ../src/generic/prntdlgg.cpp:185
+#: ../src/generic/prntdlgg.cpp:178
 msgid "Print to File"
 msgstr "ファイルへ印刷"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 #, fuzzy
 msgid "Print..."
 msgstr "印刷 (&P) ..."
 
-#: ../src/generic/prntdlgg.cpp:493
+#: ../src/generic/prntdlgg.cpp:486
 msgid "Printer"
 msgstr "プリンター"
 
-#: ../src/generic/prntdlgg.cpp:633
+#: ../src/generic/prntdlgg.cpp:626
 msgid "Printer command:"
 msgstr "プリンターへのコマンド:"
 
-#: ../src/generic/prntdlgg.cpp:180
+#: ../src/generic/prntdlgg.cpp:173
 msgid "Printer options"
 msgstr "プリンターのオプション"
 
-#: ../src/generic/prntdlgg.cpp:645
+#: ../src/generic/prntdlgg.cpp:638
 msgid "Printer options:"
 msgstr "プリンターのオプション:"
 
-#: ../src/generic/prntdlgg.cpp:916
+#: ../src/generic/prntdlgg.cpp:909
 msgid "Printer..."
 msgstr "プリンター ..."
 
-#: ../src/generic/prntdlgg.cpp:196
+#: ../src/generic/prntdlgg.cpp:189
 msgid "Printer:"
 msgstr "プリンター:"
 
-#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:535
-#: ../src/html/htmprint.cpp:277
+#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:530
+#: ../src/html/htmprint.cpp:289
 msgid "Printing"
 msgstr "印刷"
 
-#: ../src/common/prntbase.cpp:612
+#: ../src/common/prntbase.cpp:607
 msgid "Printing "
 msgstr "印刷"
 
-#: ../src/common/prntbase.cpp:347
+#: ../src/common/prntbase.cpp:342
 msgid "Printing Error"
 msgstr "印刷エラー"
 
-#: ../src/common/prntbase.cpp:565
+#: ../src/osx/webview_webkit.mm:251
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "このバージョンの zlib は Gzip を処理できません"
+
+#: ../src/common/prntbase.cpp:560
 #, fuzzy, c-format
 msgid "Printing page %d"
 msgstr "%d ページを印刷中 ..."
 
-#: ../src/common/prntbase.cpp:570
+#: ../src/common/prntbase.cpp:565
 #, fuzzy, c-format
 msgid "Printing page %d of %d"
 msgstr "%d ページを印刷中 ..."
 
-#: ../src/generic/printps.cpp:201
+#: ../src/generic/printps.cpp:182
 #, c-format
 msgid "Printing page %d..."
 msgstr "%d ページを印刷中 ..."
 
-#: ../src/generic/printps.cpp:161
+#: ../src/generic/printps.cpp:142
 msgid "Printing..."
 msgstr "印刷中 ..."
 
-#: ../include/wx/richtext/richtextprint.h:109 ../include/wx/prntbase.h:267
-#: ../src/common/docview.cpp:2132
+#: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
+#: ../src/common/docview.cpp:2137
 msgid "Printout"
 msgstr "印刷出力"
 
-#: ../src/common/debugrpt.cpp:560
+#: ../src/common/debugrpt.cpp:561
 #, c-format
 msgid ""
 "Processing debug report has failed, leaving the files in \"%s\" directory."
@@ -6006,108 +6160,108 @@ msgstr ""
 "デバッグレポートの処理に失敗しました。ディレクトリー \"%s\" にファイルを残し"
 "ます。"
 
-#: ../src/common/prntbase.cpp:545
+#: ../src/common/prntbase.cpp:540
 msgid "Progress:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181
 #, fuzzy
 msgid "Properties"
 msgstr "プロパティー (&P)"
 
-#: ../src/propgrid/manager.cpp:237
+#: ../src/propgrid/manager.cpp:223
 msgid "Property"
 msgstr "プロパティー"
 
 #. TRANSLATORS: Caption of message box displaying any property error
-#: ../src/propgrid/propgrid.cpp:3185 ../src/propgrid/propgrid.cpp:3318
+#: ../src/propgrid/propgrid.cpp:3162 ../src/propgrid/propgrid.cpp:3299
 #, fuzzy
 msgid "Property Error"
 msgstr "プロパティー"
 
-#: ../src/propgrid/advprops.cpp:1597
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Purple"
 msgstr ""
 
-#: ../src/common/paper.cpp:112
+#: ../src/common/paper.cpp:109
 msgid "Quarto, 215 x 275 mm"
 msgstr "クォート(四つ折り版), 215 x 275 mm"
 
-#: ../src/generic/logg.cpp:1016
+#: ../src/generic/logg.cpp:1013
 msgid "Question"
 msgstr "お尋ねします"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1769
+#: ../src/propgrid/advprops.cpp:1670
 #, fuzzy
 msgid "Question Arrow"
 msgstr "お尋ねします"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 #, fuzzy
 msgid "Quit"
 msgstr "終了 (&Q)"
 
-#: ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:477
 #, fuzzy, c-format
 msgid "Quit %s"
 msgstr "終了 (&Q)"
 
-#: ../src/common/stockitem.cpp:263
+#: ../src/common/stockitem.cpp:261
 msgid "Quit this program"
 msgstr "このプログラムを終了します"
 
-#: ../src/common/accelcmn.cpp:338
+#: ../src/common/accelcmn.cpp:352
 #, fuzzy
 msgid "RawCtrl+"
 msgstr "Ctrl+"
 
-#: ../src/common/ffile.cpp:109 ../src/common/ffile.cpp:133
+#: ../src/common/ffile.cpp:107 ../src/common/ffile.cpp:132
 #, c-format
 msgid "Read error on file '%s'"
 msgstr "ファイル '%s' の読み取りエラー"
 
-#: ../src/common/secretstore.cpp:199
+#: ../src/common/secretstore.cpp:211
 #, fuzzy, c-format
-msgid "Reading password for \"%s/%s\" failed: %s."
+msgid "Reading password for \"%s\" failed: %s."
 msgstr "'%s' を '%s' に展開できませんでした。"
 
-#: ../src/common/prntbase.cpp:272
+#: ../src/common/prntbase.cpp:267
 msgid "Ready"
 msgstr "準備完了"
 
-#: ../src/propgrid/advprops.cpp:1605
+#: ../src/propgrid/advprops.cpp:1511
 #, fuzzy
 msgid "Red"
 msgstr "再実行"
 
-#: ../src/generic/colrdlgg.cpp:339
+#: ../src/generic/colrdlgg.cpp:359
 msgid "Red:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:185 ../src/stc/stc_i18n.cpp:16
+#: ../src/common/stockitem.cpp:182 ../src/stc/stc_i18n.cpp:16
 msgid "Redo"
 msgstr "再実行"
 
-#: ../src/common/stockitem.cpp:264
+#: ../src/common/stockitem.cpp:262
 msgid "Redo last action"
 msgstr "最後に取り消した編集を再実行します"
 
-#: ../src/common/stockitem.cpp:186
+#: ../src/common/stockitem.cpp:183
 msgid "Refresh"
 msgstr "更新"
 
-#: ../src/msw/registry.cpp:626
+#: ../src/msw/registry.cpp:615
 #, c-format
 msgid "Registry key '%s' already exists."
 msgstr "レジストリーキー '%s' はすでに存在します。"
 
-#: ../src/msw/registry.cpp:595
+#: ../src/msw/registry.cpp:584
 #, c-format
 msgid "Registry key '%s' does not exist, cannot rename it."
 msgstr "改名元に指定されたレジストリーキー '%s' は存在しません。"
 
-#: ../src/msw/registry.cpp:727
+#: ../src/msw/registry.cpp:716
 #, c-format
 msgid ""
 "Registry key '%s' is needed for normal system operation,\n"
@@ -6118,22 +6272,22 @@ msgstr ""
 "これを削除するとシステムを不安定にします:\n"
 "処理を中断しました。"
 
-#: ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:942
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:917
+#: ../src/msw/registry.cpp:905
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1003
+#: ../src/msw/registry.cpp:991
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:521
+#: ../src/msw/registry.cpp:510
 #, c-format
 msgid "Registry value '%s' already exists."
 msgstr "レジストリの値 '%s' はすでに存在します。"
@@ -6148,73 +6302,79 @@ msgstr "通常"
 msgid "Relative"
 msgstr "Decorative"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:456
 msgid "Relevant entries:"
 msgstr "関連項目:"
 
-#: ../include/wx/generic/progdlgg.h:86
+#: ../include/wx/generic/progdlgg.h:87
 msgid "Remaining time:"
 msgstr "残り時間:"
 
-#: ../src/common/stockitem.cpp:187
+#: ../src/common/stockitem.cpp:184
 msgid "Remove"
 msgstr "削除"
 
-#: ../src/richtext/richtextctrl.cpp:1562
+#: ../src/richtext/richtextctrl.cpp:1563
 #, fuzzy
 msgid "Remove Bullet"
 msgstr "削除"
 
-#: ../src/html/helpwnd.cpp:433
+#: ../src/html/helpwnd.cpp:431
 msgid "Remove current page from bookmarks"
 msgstr "ブックマークから現在のページを削除します"
 
-#: ../src/common/rendcmn.cpp:194
+#: ../src/common/rendcmn.cpp:191
 #, c-format
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 "レンダラー \"%s\" は非互換バージョン %d.%d で実装されているため読み取ることが"
 "できません。"
 
-#: ../src/richtext/richtextbuffer.cpp:4527
+#: ../src/richtext/richtextbuffer.cpp:4524
 msgid "Renumber List"
 msgstr "リスト連番の初期化"
 
-#: ../src/common/stockitem.cpp:188
-msgid "Rep&lace"
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Rep&lace..."
 msgstr "置換(&L)"
 
-#: ../src/richtext/richtextctrl.cpp:3673 ../src/common/stockitem.cpp:188
+#: ../src/richtext/richtextctrl.cpp:3674
 msgid "Replace"
 msgstr "置換"
 
-#: ../src/generic/fdrepdlg.cpp:182
+#: ../src/generic/fdrepdlg.cpp:179
 msgid "Replace &all"
 msgstr "すべて置換(&A)"
 
-#: ../src/common/stockitem.cpp:261
-msgid "Replace selection"
-msgstr "選択範囲を置換します"
-
-#: ../src/generic/fdrepdlg.cpp:124
+#: ../src/generic/fdrepdlg.cpp:121
 msgid "Replace with:"
 msgstr "置換先:"
 
-#: ../src/common/valtext.cpp:163
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Replace..."
+msgstr "置換"
+
+#: ../src/common/valtext.cpp:184
 msgid "Required information entry is empty."
 msgstr "必須情報項目が空です。"
 
-#: ../src/common/translation.cpp:1975
+#: ../src/common/translation.cpp:2025
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "'%s' は正しいメッセージカタログではありません。"
 
+#: ../src/gtk/webview_webkit.cpp:985
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:56
+#: ../src/common/accelcmn.cpp:53
 msgid "Return"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:189
+#: ../src/common/stockitem.cpp:186
 msgid "Revert to Saved"
 msgstr "保存した状態まで戻します"
 
@@ -6227,42 +6387,42 @@ msgstr "右"
 msgid "Rig&ht-to-left"
 msgstr ""
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6149
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:59 ../src/generic/datavgen.cpp:6954
+#: ../src/richtext/richtextsizepage.cpp:250
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextbulletspage.cpp:188
-#: ../src/richtext/richtextsizepage.cpp:250 ../src/common/accelcmn.cpp:62
 msgid "Right"
 msgstr "右"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1754
+#: ../src/propgrid/advprops.cpp:1655
 #, fuzzy
 msgid "Right Arrow"
 msgstr "右"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1770
+#: ../src/propgrid/advprops.cpp:1671
 msgid "Right Button"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:892
+#: ../src/generic/prntdlgg.cpp:885
 msgid "Right margin (mm):"
 msgstr "余白-右 (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:148
-#: ../src/richtext/richtextindentspage.cpp:150
 #: ../src/richtext/richtextliststylepage.cpp:337
 #: ../src/richtext/richtextliststylepage.cpp:339
+#: ../src/richtext/richtextindentspage.cpp:148
+#: ../src/richtext/richtextindentspage.cpp:150
 msgid "Right-align text."
 msgstr "右寄せにします。"
 
-#: ../src/generic/fontdlgg.cpp:322
+#: ../src/generic/fontdlgg.cpp:318
 msgid "Roman"
 msgstr "Roman"
 
-#: ../src/generic/datavgen.cpp:5916
+#: ../src/generic/datavgen.cpp:6721
 #, c-format
 msgid "Row %i"
 msgstr ""
@@ -6272,31 +6432,31 @@ msgstr ""
 msgid "S&tandard bullet name:"
 msgstr "標準行頭文字名(&T):"
 
-#: ../src/common/accelcmn.cpp:268 ../src/common/accelcmn.cpp:350
+#: ../src/common/accelcmn.cpp:282 ../src/common/accelcmn.cpp:367
 msgid "SPECIAL"
 msgstr "SPECIAL"
 
-#: ../src/common/stockitem.cpp:190 ../src/common/sizer.cpp:2797
+#: ../src/common/stockitem.cpp:187 ../src/common/sizer.cpp:2914
 msgid "Save"
 msgstr "保存"
 
-#: ../src/common/fldlgcmn.cpp:342
+#: ../src/common/fldlgcmn.cpp:339
 #, c-format
 msgid "Save %s file"
 msgstr "%s ファイルを保存"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/common/stockitem.cpp:188 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "別名で保存(&A) ..."
 
-#: ../src/common/docview.cpp:366
+#: ../src/common/docview.cpp:359
 msgid "Save As"
 msgstr "Save As"
 
-#: ../src/common/stockitem.cpp:191
+#: ../src/common/stockitem.cpp:188
 #, fuzzy
-msgid "Save as"
-msgstr "Save As"
+msgid "Save As..."
+msgstr "別名で保存(&A) ..."
 
 #: ../src/common/stockitem.cpp:267
 msgid "Save current document"
@@ -6306,95 +6466,95 @@ msgstr "現在の文書を保存します"
 msgid "Save current document with a different filename"
 msgstr "現在の文書を別名で保存します"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/generic/logg.cpp:509
 msgid "Save log contents to file"
 msgstr "ログの内容をファイルに保存します"
 
-#: ../src/common/secretstore.cpp:179
+#: ../src/common/secretstore.cpp:189
 #, fuzzy, c-format
-msgid "Saving password for \"%s/%s\" failed: %s."
+msgid "Saving password for \"%s\" failed: %s."
 msgstr "'%s' を '%s' に展開できませんでした。"
 
-#: ../src/generic/fontdlgg.cpp:325
+#: ../src/generic/fontdlgg.cpp:321
 msgid "Script"
 msgstr "Script"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll Lock"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll_lock"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:890
+#: ../src/propgrid/advprops.cpp:791
 msgid "Scrollbar"
 msgstr ""
 
-#: ../src/generic/srchctlg.cpp:56 ../src/html/helpwnd.cpp:535
-#: ../src/html/helpwnd.cpp:550
+#: ../src/generic/srchctlg.cpp:55 ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:548 ../src/gtk/srchctrl.cpp:182
 msgid "Search"
 msgstr "検索"
 
-#: ../src/html/helpwnd.cpp:537
+#: ../src/html/helpwnd.cpp:535
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
 msgstr "上で入力したテキストがある部分をヘルプブックの全体に渡って検索します"
 
-#: ../src/generic/fdrepdlg.cpp:160
+#: ../src/generic/fdrepdlg.cpp:157
 msgid "Search direction"
 msgstr "検索の方向"
 
-#: ../src/generic/fdrepdlg.cpp:112
+#: ../src/generic/fdrepdlg.cpp:109
 msgid "Search for:"
 msgstr "検索内容:"
 
-#: ../src/html/helpwnd.cpp:1052
+#: ../src/html/helpwnd.cpp:1050
 msgid "Search in all books"
 msgstr "すべてのブックを検索"
 
-#: ../src/html/helpwnd.cpp:857
+#: ../src/html/helpwnd.cpp:855
 msgid "Searching..."
 msgstr "検索中..."
 
-#: ../src/generic/dirctrlg.cpp:446
+#: ../src/generic/dirctrlg.cpp:412
 msgid "Sections"
 msgstr "セクション"
 
-#: ../src/common/ffile.cpp:238
+#: ../src/common/ffile.cpp:237
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "ファイル '%s' のシークエラー"
 
-#: ../src/common/ffile.cpp:228
+#: ../src/common/ffile.cpp:227
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr "ファイル '%s' のシークエラー(stdioでは大きなファイルに対応できません)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:76
+#: ../src/common/accelcmn.cpp:73
 #, fuzzy
 msgid "Select"
 msgstr "選択"
 
-#: ../src/richtext/richtextctrl.cpp:337 ../src/osx/textctrl_osx.cpp:581
-#: ../src/common/stockitem.cpp:192 ../src/msw/textctrl.cpp:2512
+#: ../src/osx/textctrl_osx.cpp:599 ../src/common/stockitem.cpp:189
+#: ../src/msw/textctrl.cpp:2777 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "すべて選択(&A)"
 
-#: ../src/common/stockitem.cpp:192 ../src/stc/stc_i18n.cpp:21
+#: ../src/common/stockitem.cpp:189 ../src/stc/stc_i18n.cpp:21
 msgid "Select All"
 msgstr "すべて選択"
 
-#: ../src/common/docview.cpp:1895
+#: ../src/common/docview.cpp:1900
 msgid "Select a document template"
 msgstr "文書の雛形を選んでください"
 
-#: ../src/common/docview.cpp:1969
+#: ../src/common/docview.cpp:1974
 msgid "Select a document view"
 msgstr "文書ビューの選択"
 
@@ -6423,20 +6583,20 @@ msgid "Selects the list level to edit."
 msgstr "編集したいリストレベルを選んでください。"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:82
+#: ../src/common/accelcmn.cpp:79
 msgid "Separator"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1083
+#: ../src/common/cmdline.cpp:1079
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "オプション '%s' の後には区切り文字が必要です。"
 
-#: ../src/osx/menu_osx.cpp:572
+#: ../src/osx/menu_osx.cpp:464
 msgid "Services"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11217
+#: ../src/richtext/richtextbuffer.cpp:11216
 #, fuzzy
 msgid "Set Cell Style"
 msgstr "スタイルの削除"
@@ -6445,11 +6605,11 @@ msgstr "スタイルの削除"
 msgid "SetProperty called w/o valid setter"
 msgstr "SetProperty が適切なsetterなしで呼び出されました"
 
-#: ../src/generic/prntdlgg.cpp:188
+#: ../src/generic/prntdlgg.cpp:181
 msgid "Setup..."
 msgstr "設定 ..."
 
-#: ../src/msw/dialup.cpp:544
+#: ../src/msw/dialup.cpp:538
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr "複数のダイヤルアップ接続が有効です。乱数でひとつ選びます。"
 
@@ -6466,41 +6626,41 @@ msgstr ""
 msgid "Shadow c&olour:"
 msgstr "色を選んでください"
 
-#: ../src/common/accelcmn.cpp:335
+#: ../src/common/accelcmn.cpp:349
 msgid "Shift+"
 msgstr "Shift+"
 
-#: ../src/generic/dirdlgg.cpp:147
+#: ../src/generic/dirdlgg.cpp:144
 msgid "Show &hidden directories"
 msgstr "隠しディレクトリーを表示する(&H)"
 
-#: ../src/generic/filectrlg.cpp:983
+#: ../src/generic/filectrlg.cpp:979
 msgid "Show &hidden files"
 msgstr "隠しファイルを表示する(&H)"
 
-#: ../src/osx/menu_osx.cpp:580
+#: ../src/osx/menu_osx.cpp:472
 #, fuzzy
 msgid "Show All"
 msgstr "すべて表示"
 
-#: ../src/common/stockitem.cpp:257
+#: ../src/common/stockitem.cpp:254
 msgid "Show about dialog"
 msgstr "詳細ダイアログを表示します。"
 
-#: ../src/html/helpwnd.cpp:492
+#: ../src/html/helpwnd.cpp:490
 msgid "Show all"
 msgstr "すべて表示"
 
-#: ../src/html/helpwnd.cpp:503
+#: ../src/html/helpwnd.cpp:501
 msgid "Show all items in index"
 msgstr "索引に全項目を表示します"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:656
 msgid "Show/hide navigation panel"
 msgstr "ナビゲーションパネルの表示/非表示を切り替えます"
 
-#: ../src/richtext/richtextsymboldlg.cpp:421
-#: ../src/richtext/richtextsymboldlg.cpp:423
+#: ../src/richtext/richtextsymboldlg.cpp:418
+#: ../src/richtext/richtextsymboldlg.cpp:420
 msgid "Shows a Unicode subset."
 msgstr "ユニコードの部分集合を表示します。"
 
@@ -6516,7 +6676,7 @@ msgstr "行頭文字設定のプレビューを表示します。"
 msgid "Shows a preview of the font settings."
 msgstr "フォント設定のプレビューを表示します｡"
 
-#: ../src/osx/carbon/fontdlg.cpp:394 ../src/osx/carbon/fontdlg.cpp:396
+#: ../src/osx/carbon/fontdlg.cpp:391 ../src/osx/carbon/fontdlg.cpp:393
 msgid "Shows a preview of the font."
 msgstr "フォントのプレビューを表示します。"
 
@@ -6525,62 +6685,62 @@ msgstr "フォントのプレビューを表示します。"
 msgid "Shows a preview of the paragraph settings."
 msgstr "段落設定のプレビューを表示します。"
 
-#: ../src/generic/fontdlgg.cpp:460 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:456 ../src/generic/fontdlgg.cpp:458
 msgid "Shows the font preview."
 msgstr "フォントのプレビューを表示します。"
 
-#: ../src/propgrid/advprops.cpp:1607
+#: ../src/propgrid/advprops.cpp:1513
 msgid "Silver"
 msgstr ""
 
-#: ../src/univ/themes/mono.cpp:516
+#: ../src/univ/themes/mono.cpp:513
 msgid "Simple monochrome theme"
 msgstr "簡素なモノクロのテーマ"
 
-#: ../src/richtext/richtextindentspage.cpp:275
 #: ../src/richtext/richtextliststylepage.cpp:449
+#: ../src/richtext/richtextindentspage.cpp:275
 msgid "Single"
 msgstr "1"
 
-#: ../src/generic/filectrlg.cpp:425 ../src/richtext/richtextformatdlg.cpp:369
-#: ../src/richtext/richtextsizepage.cpp:299
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextsizepage.cpp:299
+#: ../src/richtext/richtextformatdlg.cpp:362
 msgid "Size"
 msgstr "大きさ"
 
-#: ../src/osx/carbon/fontdlg.cpp:339
+#: ../src/osx/carbon/fontdlg.cpp:336
 msgid "Size:"
 msgstr "大きさ:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1775
+#: ../src/propgrid/advprops.cpp:1676
 msgid "Sizing"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1772
+#: ../src/propgrid/advprops.cpp:1673
 msgid "Sizing N-S"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1771
+#: ../src/propgrid/advprops.cpp:1672
 msgid "Sizing NE-SW"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1773
+#: ../src/propgrid/advprops.cpp:1674
 msgid "Sizing NW-SE"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1774
+#: ../src/propgrid/advprops.cpp:1675
 msgid "Sizing W-E"
 msgstr ""
 
-#: ../src/msw/progdlg.cpp:801
+#: ../src/msw/progdlg.cpp:1088
 msgid "Skip"
 msgstr "スキップ"
 
-#: ../src/generic/fontdlgg.cpp:330
+#: ../src/generic/fontdlgg.cpp:326
 msgid "Slant"
 msgstr "斜体"
 
@@ -6590,7 +6750,7 @@ msgid "Small C&apitals"
 msgstr "大文字化 (&P)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:79
+#: ../src/common/accelcmn.cpp:76
 msgid "Snapshot"
 msgstr ""
 
@@ -6599,37 +6759,37 @@ msgstr ""
 msgid "Solid"
 msgstr "太字"
 
-#: ../src/common/docview.cpp:1791
+#: ../src/common/docview.cpp:1785
 msgid "Sorry, could not open this file."
 msgstr "ファイルを開くことができませんでした。"
 
-#: ../src/common/prntbase.cpp:2057 ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2079 ../src/common/prntbase.cpp:2087
 msgid "Sorry, not enough memory to create a preview."
 msgstr "プレビューのためのメモリが足りません。"
 
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "Sorry, that name is taken. Please choose another."
 msgstr "その名前はすでに使われています。他の名前を選んでください。"
 
-#: ../src/common/docview.cpp:1814
+#: ../src/common/docview.cpp:1819
 msgid "Sorry, the format for this file is unknown."
 msgstr "このファイルの形式は未対応です。"
 
-#: ../src/unix/sound.cpp:492
+#: ../src/unix/sound.cpp:481
 msgid "Sound data are in unsupported format."
 msgstr "未対応の様式が使われている音声データです。"
 
-#: ../src/unix/sound.cpp:477
+#: ../src/unix/sound.cpp:466
 #, c-format
 msgid "Sound file '%s' is in unsupported format."
 msgstr "'%s' は未対応の様式が使われている音声ファイルです。"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:67
+#: ../src/common/accelcmn.cpp:64
 #, fuzzy
 msgid "Space"
 msgstr "間隔"
@@ -6638,13 +6798,13 @@ msgstr "間隔"
 msgid "Spacing"
 msgstr "間隔"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 #, fuzzy
 msgid "Spell Check"
 msgstr "スペルチェック (&S)"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1776
+#: ../src/propgrid/advprops.cpp:1677
 msgid "Spraycan"
 msgstr ""
 
@@ -6653,7 +6813,7 @@ msgstr ""
 msgid "Standard"
 msgstr "標準"
 
-#: ../src/common/paper.cpp:104
+#: ../src/common/paper.cpp:101
 msgid "Statement, 5 1/2 x 8 1/2 in"
 msgstr "ステートメント(計算書), 5 1/2 x 8 1/2インチ"
 
@@ -6663,35 +6823,31 @@ msgstr "ステートメント(計算書), 5 1/2 x 8 1/2インチ"
 msgid "Static"
 msgstr "状態:"
 
-#: ../src/generic/prntdlgg.cpp:204
+#: ../src/generic/prntdlgg.cpp:197
 msgid "Status:"
 msgstr "状態:"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 #, fuzzy
 msgid "Stop"
 msgstr "停止 (&S)"
 
-#: ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196
 #, fuzzy
 msgid "Strikethrough"
 msgstr "打ち消し線 (&S)"
 
-#: ../src/common/colourcmn.cpp:45
+#: ../src/common/colourcmn.cpp:42
 #, c-format
 msgid "String To Colour : Incorrect colour specification : %s"
 msgstr "文字列から色へ : 変換に失敗しました : %s"
 
 #. TRANSLATORS: Label of font style
-#: ../src/richtext/richtextformatdlg.cpp:339 ../src/propgrid/advprops.cpp:680
+#: ../src/propgrid/advprops.cpp:590 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "スタイル"
 
-#: ../include/wx/richtext/richtextstyledlg.h:46
-msgid "Style Organiser"
-msgstr "スタイルの構成"
-
-#: ../src/osx/carbon/fontdlg.cpp:348
+#: ../src/osx/carbon/fontdlg.cpp:345
 msgid "Style:"
 msgstr "スタイル:"
 
@@ -6700,7 +6856,7 @@ msgid "Subscrip&t"
 msgstr "下付き文字(&T)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:83
+#: ../src/common/accelcmn.cpp:80
 msgid "Subtract"
 msgstr ""
 
@@ -6708,11 +6864,11 @@ msgstr ""
 msgid "Supe&rscript"
 msgstr "上付き文字(&R)"
 
-#: ../src/common/paper.cpp:150
+#: ../src/common/paper.cpp:147
 msgid "SuperA/SuperA/A4 227 x 356 mm"
 msgstr "SuperA/SuperA/A4 227 x 356 mm"
 
-#: ../src/common/paper.cpp:151
+#: ../src/common/paper.cpp:148
 msgid "SuperB/SuperB/A3 305 x 487 mm"
 msgstr "SuperB/SuperB/A3 305 x 487 mm"
 
@@ -6720,7 +6876,7 @@ msgstr "SuperB/SuperB/A3 305 x 487 mm"
 msgid "Suppress hyphe&nation"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:326
+#: ../src/generic/fontdlgg.cpp:322
 msgid "Swiss"
 msgstr "Swiss"
 
@@ -6738,75 +6894,75 @@ msgstr "記号フォント (&F) :"
 msgid "Symbols"
 msgstr "記号"
 
-#: ../src/common/imagtiff.cpp:369 ../src/common/imagtiff.cpp:382
-#: ../src/common/imagtiff.cpp:741
+#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
+#: ../src/common/imagtiff.cpp:738
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: メモリ割り当てに失敗しました。"
 
-#: ../src/common/imagtiff.cpp:301
+#: ../src/common/imagtiff.cpp:298
 msgid "TIFF: Error loading image."
 msgstr "TIFF: 画像の読み取りエラーを検出しました。"
 
-#: ../src/common/imagtiff.cpp:468
+#: ../src/common/imagtiff.cpp:465
 msgid "TIFF: Error reading image."
 msgstr "TIFF: 画像の読み取りエラーを検出しました。"
 
-#: ../src/common/imagtiff.cpp:608
+#: ../src/common/imagtiff.cpp:605
 msgid "TIFF: Error saving image."
 msgstr "TIFF: 画像の書き出しエラーを検出しました。"
 
-#: ../src/common/imagtiff.cpp:846
+#: ../src/common/imagtiff.cpp:843
 msgid "TIFF: Error writing image."
 msgstr "TIFF: 画像の書き出しエラーを検出しました。"
 
-#: ../src/common/imagtiff.cpp:355
+#: ../src/common/imagtiff.cpp:352
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: 画像の大きさが極端に大きいようです。"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:68
+#: ../src/common/accelcmn.cpp:65
 #, fuzzy
 msgid "Tab"
 msgstr "タブ"
 
-#: ../src/richtext/richtextbuffer.cpp:11498
+#: ../src/richtext/richtextbuffer.cpp:11497
 #, fuzzy
 msgid "Table Properties"
 msgstr "プロパティー (&P)"
 
-#: ../src/common/paper.cpp:145
+#: ../src/common/paper.cpp:142
 msgid "Tabloid Extra 11.69 x 18 in"
 msgstr "タブロイド Extra 11.69 x 18インチ"
 
-#: ../src/common/paper.cpp:102
+#: ../src/common/paper.cpp:99
 msgid "Tabloid, 11 x 17 in"
 msgstr "タブロイド, 11 x 17インチ"
 
-#: ../src/richtext/richtextformatdlg.cpp:354
+#: ../src/richtext/richtextformatdlg.cpp:347
 msgid "Tabs"
 msgstr "タブ"
 
-#: ../src/propgrid/advprops.cpp:1598
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Teal"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:327
+#: ../src/generic/fontdlgg.cpp:323
 msgid "Teletype"
 msgstr "Teletype"
 
-#: ../src/common/docview.cpp:1896
+#: ../src/common/docview.cpp:1901
 msgid "Templates"
 msgstr "雛形"
 
-#: ../src/common/fmapbase.cpp:158
+#: ../src/common/fmapbase.cpp:155
 msgid "Thai (ISO-8859-11)"
 msgstr "タイ語 (ISO-8859-11)"
 
-#: ../src/common/ftp.cpp:619
+#: ../src/common/ftp.cpp:622
 msgid "The FTP server doesn't support passive mode."
 msgstr "そのFTPサーバーはPASSIVEモードに対応していません。"
 
-#: ../src/common/ftp.cpp:605
+#: ../src/common/ftp.cpp:608
 msgid "The FTP server doesn't support the PORT command."
 msgstr "そのFTPサーバーはPORTコマンドに対応していません。"
 
@@ -6817,8 +6973,8 @@ msgstr "そのFTPサーバーはPORTコマンドに対応していません。"
 msgid "The available bullet styles."
 msgstr "使用できる行頭文字スタイルです。"
 
-#: ../src/richtext/richtextstyledlg.cpp:202
-#: ../src/richtext/richtextstyledlg.cpp:204
+#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:200
 msgid "The available styles."
 msgstr "使用できるスタイルです。"
 
@@ -6879,12 +7035,12 @@ msgstr "タブ位置です。"
 msgid "The bullet character."
 msgstr "行頭文字を指定します。"
 
-#: ../src/richtext/richtextsymboldlg.cpp:443
-#: ../src/richtext/richtextsymboldlg.cpp:445
+#: ../src/richtext/richtextsymboldlg.cpp:440
+#: ../src/richtext/richtextsymboldlg.cpp:442
 msgid "The character code."
 msgstr "文字コードです。"
 
-#: ../src/common/fontmap.cpp:203
+#: ../src/common/fontmap.cpp:200
 #, c-format
 msgid ""
 "The charset '%s' is unknown. You may select\n"
@@ -6895,7 +7051,7 @@ msgstr ""
 "他の文字集合で置き換えるかそれができないときは\n"
 "キャンセルしてください"
 
-#: ../src/msw/ole/dataobj.cpp:394
+#: ../src/msw/ole/dataobj.cpp:402
 #, c-format
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "クリップボード様式 '%d' は存在しません。"
@@ -6905,7 +7061,7 @@ msgstr "クリップボード様式 '%d' は存在しません。"
 msgid "The default style for the next paragraph."
 msgstr "次の段落に適用されるスタイルを指定します。"
 
-#: ../src/generic/dirdlgg.cpp:202
+#: ../src/generic/dirdlgg.cpp:199
 #, c-format
 msgid ""
 "The directory '%s' does not exist\n"
@@ -6914,7 +7070,7 @@ msgstr ""
 "ディレクトリー '%s' は存在しません\n"
 "作成しますか?"
 
-#: ../src/html/htmprint.cpp:271
+#: ../src/html/htmprint.cpp:283
 #, c-format
 msgid ""
 "The document \"%s\" doesn't fit on the page horizontally and will be "
@@ -6927,43 +7083,43 @@ msgstr ""
 "\n"
 "ご承知の上で印刷処理を進めますか?"
 
-#: ../src/common/docview.cpp:1202
+#: ../src/common/docview.cpp:1196
 #, fuzzy, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
 "It has been removed from the most recently used files list."
 msgstr "最近使ったファイルのリストから削除されています。"
 
-#: ../src/richtext/richtextindentspage.cpp:208
-#: ../src/richtext/richtextindentspage.cpp:210
 #: ../src/richtext/richtextliststylepage.cpp:394
 #: ../src/richtext/richtextliststylepage.cpp:396
+#: ../src/richtext/richtextindentspage.cpp:208
+#: ../src/richtext/richtextindentspage.cpp:210
 msgid "The first line indent."
 msgstr "最初の行の字下げです。"
 
-#: ../src/gtk/utilsgtk.cpp:481
-msgid "The following standard GTK+ options are also supported:\n"
-msgstr "次の標準GTK+オプションも利用できます:\n"
+#: ../src/generic/dbgrptg.cpp:318
+msgid "The following debug report will be generated\n"
+msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:414 ../src/generic/fontdlgg.cpp:416
+#: ../src/generic/fontdlgg.cpp:411 ../src/generic/fontdlgg.cpp:413
 msgid "The font colour."
 msgstr "フォントの色を指定できます。"
 
-#: ../src/generic/fontdlgg.cpp:375 ../src/generic/fontdlgg.cpp:377
+#: ../src/generic/fontdlgg.cpp:371 ../src/generic/fontdlgg.cpp:373
 msgid "The font family."
 msgstr "フォントのファミリーを指定できます。"
 
-#: ../src/richtext/richtextsymboldlg.cpp:405
-#: ../src/richtext/richtextsymboldlg.cpp:407
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "The font from which to take the symbol."
 msgstr "記号の取得元フォントを指定できます。"
 
-#: ../src/generic/fontdlgg.cpp:427 ../src/generic/fontdlgg.cpp:429
-#: ../src/generic/fontdlgg.cpp:434 ../src/generic/fontdlgg.cpp:436
+#: ../src/generic/fontdlgg.cpp:424 ../src/generic/fontdlgg.cpp:426
+#: ../src/generic/fontdlgg.cpp:430 ../src/generic/fontdlgg.cpp:432
 msgid "The font point size."
 msgstr "フォントの大きさをポイントで記します。"
 
-#: ../src/osx/carbon/fontdlg.cpp:343 ../src/osx/carbon/fontdlg.cpp:345
+#: ../src/osx/carbon/fontdlg.cpp:340 ../src/osx/carbon/fontdlg.cpp:342
 msgid "The font size in points."
 msgstr "フォントの大きさをポイントで記します。"
 
@@ -6973,15 +7129,15 @@ msgstr "フォントの大きさをポイントで記します。"
 msgid "The font size units, points or pixels."
 msgstr "フォントの大きさをポイントで記します。"
 
-#: ../src/generic/fontdlgg.cpp:386 ../src/generic/fontdlgg.cpp:388
+#: ../src/generic/fontdlgg.cpp:382 ../src/generic/fontdlgg.cpp:384
 msgid "The font style."
 msgstr "フォントのスタイルを指定できます。"
 
-#: ../src/generic/fontdlgg.cpp:397 ../src/generic/fontdlgg.cpp:399
+#: ../src/generic/fontdlgg.cpp:393 ../src/generic/fontdlgg.cpp:395
 msgid "The font weight."
 msgstr "フォントのウエイトを指定できます。"
 
-#: ../src/common/docview.cpp:1483
+#: ../src/common/docview.cpp:1477
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "ファイル '%s' の様式を決定できませんでした。"
@@ -6992,10 +7148,10 @@ msgstr "ファイル '%s' の様式を決定できませんでした。"
 msgid "The horizontal offset."
 msgstr "横に並べる(&H)"
 
-#: ../src/richtext/richtextindentspage.cpp:199
-#: ../src/richtext/richtextindentspage.cpp:201
 #: ../src/richtext/richtextliststylepage.cpp:385
 #: ../src/richtext/richtextliststylepage.cpp:387
+#: ../src/richtext/richtextindentspage.cpp:199
+#: ../src/richtext/richtextindentspage.cpp:201
 msgid "The left indent."
 msgstr "左側の字下げを指定できます。"
 
@@ -7019,10 +7175,10 @@ msgstr "フォントの大きさをポイントで記します。"
 msgid "The left position."
 msgstr "タブ位置です。"
 
-#: ../src/richtext/richtextindentspage.cpp:288
-#: ../src/richtext/richtextindentspage.cpp:290
 #: ../src/richtext/richtextliststylepage.cpp:462
 #: ../src/richtext/richtextliststylepage.cpp:464
+#: ../src/richtext/richtextindentspage.cpp:288
+#: ../src/richtext/richtextindentspage.cpp:290
 msgid "The line spacing."
 msgstr "行間隔を指定できます。"
 
@@ -7031,7 +7187,7 @@ msgstr "行間隔を指定できます。"
 msgid "The list item number."
 msgstr "連番の番号を指定できます。"
 
-#: ../src/msw/ole/automtn.cpp:664
+#: ../src/msw/ole/automtn.cpp:655
 msgid "The locale ID is unknown."
 msgstr ""
 
@@ -7076,19 +7232,19 @@ msgstr "フォントのウエイトを指定できます。"
 msgid "The outline level."
 msgstr "アウトラインレベルを指定できます。"
 
-#: ../src/common/log.cpp:277
+#: ../src/common/log.cpp:296
 #, fuzzy, c-format
 msgid "The previous message repeated %u time."
 msgid_plural "The previous message repeated %u times."
 msgstr[0] "直前のメッセージは %lu 回繰り返されました。"
 
-#: ../src/common/log.cpp:270
+#: ../src/common/log.cpp:289
 #, fuzzy
 msgid "The previous message repeated once."
 msgstr "直前のメッセージは %lu 回繰り返されました。"
 
-#: ../src/richtext/richtextsymboldlg.cpp:462
-#: ../src/richtext/richtextsymboldlg.cpp:464
+#: ../src/richtext/richtextsymboldlg.cpp:459
+#: ../src/richtext/richtextsymboldlg.cpp:461
 msgid "The range to show."
 msgstr "表示する範囲を指定できます。"
 
@@ -7102,15 +7258,15 @@ msgstr ""
 "ている場合は\n"
 "そのファイルのチェックを外せばレポートから取り除かれます。\n"
 
-#: ../src/common/cmdline.cpp:1254
+#: ../src/common/cmdline.cpp:1250
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "必須引数 '%s' が与えられていません。"
 
-#: ../src/richtext/richtextindentspage.cpp:217
-#: ../src/richtext/richtextindentspage.cpp:219
 #: ../src/richtext/richtextliststylepage.cpp:403
 #: ../src/richtext/richtextliststylepage.cpp:405
+#: ../src/richtext/richtextindentspage.cpp:217
+#: ../src/richtext/richtextindentspage.cpp:219
 msgid "The right indent."
 msgstr "右側の字下げです。"
 
@@ -7155,16 +7311,16 @@ msgstr ""
 msgid "The shadow spread."
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:267
 #: ../src/richtext/richtextliststylepage.cpp:439
 #: ../src/richtext/richtextliststylepage.cpp:441
+#: ../src/richtext/richtextindentspage.cpp:267
 msgid "The spacing after the paragraph."
 msgstr "段落の後の空間を指定します。"
 
-#: ../src/richtext/richtextindentspage.cpp:257
-#: ../src/richtext/richtextindentspage.cpp:259
 #: ../src/richtext/richtextliststylepage.cpp:430
 #: ../src/richtext/richtextliststylepage.cpp:432
+#: ../src/richtext/richtextindentspage.cpp:257
+#: ../src/richtext/richtextindentspage.cpp:259
 msgid "The spacing before the paragraph."
 msgstr "段落の前の空間を指定します。"
 
@@ -7178,12 +7334,12 @@ msgstr "スタイル名です。"
 msgid "The style on which this style is based."
 msgstr "このスタイルの元となるスタイルです。"
 
-#: ../src/richtext/richtextstyledlg.cpp:214
-#: ../src/richtext/richtextstyledlg.cpp:216
+#: ../src/richtext/richtextstyledlg.cpp:210
+#: ../src/richtext/richtextstyledlg.cpp:212
 msgid "The style preview."
 msgstr "スタイルのプレビューです。"
 
-#: ../src/msw/ole/automtn.cpp:680
+#: ../src/msw/ole/automtn.cpp:671
 msgid "The system cannot find the file specified."
 msgstr ""
 
@@ -7196,7 +7352,7 @@ msgstr "タブ位置です。"
 msgid "The tab positions."
 msgstr "タブ位置の一覧です。"
 
-#: ../src/richtext/richtextctrl.cpp:3098
+#: ../src/richtext/richtextctrl.cpp:3099
 msgid "The text couldn't be saved."
 msgstr "テキストが保存できませんでした。"
 
@@ -7220,7 +7376,7 @@ msgstr "フォントの大きさをポイントで記します。"
 msgid "The top position."
 msgstr "タブ位置です。"
 
-#: ../src/common/cmdline.cpp:1232
+#: ../src/common/cmdline.cpp:1228
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "オプション '%s' とその値は必ず指定してください。"
@@ -7230,7 +7386,7 @@ msgstr "オプション '%s' とその値は必ず指定してください。"
 msgid "The value of the corner radius."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:433
+#: ../src/msw/dialup.cpp:427
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -7245,14 +7401,14 @@ msgstr ""
 msgid "The vertical offset."
 msgstr "整列方法を設定できませんでした。"
 
-#: ../src/richtext/richtextprint.cpp:619 ../src/html/htmprint.cpp:745
+#: ../src/html/htmprint.cpp:749 ../src/richtext/richtextprint.cpp:615
 msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr ""
 "ページの準備中に問題が検出されました: 既定のプリンターが未指定なら指定してく"
 "ださい。"
 
-#: ../src/html/htmprint.cpp:255
+#: ../src/html/htmprint.cpp:267
 msgid ""
 "This document doesn't fit on the page horizontally and will be truncated "
 "when it is printed."
@@ -7260,22 +7416,30 @@ msgstr ""
 "この文書はページの水平方向にあわせることができません。印刷すると切り詰められ"
 "ます。"
 
-#: ../src/common/image.cpp:2854
+#: ../src/common/image.cpp:2963
 #, fuzzy, c-format
 msgid "This is not a %s."
 msgstr "PCX: PCXファイルではないようです。"
 
-#: ../src/common/wincmn.cpp:1653
+#: ../src/common/wincmn.cpp:1654
 msgid "This platform does not support background transparency."
 msgstr ""
 
-#: ../src/gtk/window.cpp:4660
+#: ../src/gtk/window.cpp:5664
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
 
-#: ../src/msw/thread.cpp:1240
+#: ../src/gtk/glcanvas.cpp:176
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/msw/thread.cpp:1246
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -7283,11 +7447,11 @@ msgstr ""
 "スレッドモジュールの初期化に失敗: スレッドローカルストレージに値を保存できま"
 "せんでした"
 
-#: ../src/unix/threadpsx.cpp:1794
+#: ../src/unix/threadpsx.cpp:1843
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr "スレッドモジュールの初期化に失敗: スレッドキーを作成できませんでした"
 
-#: ../src/msw/thread.cpp:1228
+#: ../src/msw/thread.cpp:1234
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -7295,83 +7459,83 @@ msgstr ""
 "スレッドモジュールの初期化に失敗: スレッドローカルストレージに索引を割り当て"
 "られませんでした"
 
-#: ../src/unix/threadpsx.cpp:1043
+#: ../src/unix/threadpsx.cpp:1061
 msgid "Thread priority setting is ignored."
 msgstr "スレッド優先度の設定は無視されました。"
 
-#: ../src/msw/mdi.cpp:176
+#: ../src/msw/mdi.cpp:171
 msgid "Tile &Horizontally"
 msgstr "横に並べる(&H)"
 
-#: ../src/msw/mdi.cpp:177
+#: ../src/msw/mdi.cpp:172
 msgid "Tile &Vertically"
 msgstr "縦に並べる(&V)"
 
-#: ../src/common/ftp.cpp:200
+#: ../src/common/ftp.cpp:197
 msgid "Timeout while waiting for FTP server to connect, try passive mode."
 msgstr ""
 "FTPサーバーとの接続を待機中に時間切れになりました。PASSIVEモードで試してみて"
 "ください。"
 
-#: ../src/generic/tipdlg.cpp:201
+#: ../src/generic/tipdlg.cpp:198
 msgid "Tip of the Day"
 msgstr "今日のチップ"
 
-#: ../src/generic/tipdlg.cpp:140
+#: ../src/generic/tipdlg.cpp:137
 msgid "Tips not available, sorry!"
 msgstr "チップが使えません、ごめんね!"
 
-#: ../src/generic/prntdlgg.cpp:242
+#: ../src/generic/prntdlgg.cpp:235
 msgid "To:"
 msgstr "末尾ページ:"
 
-#: ../src/richtext/richtextbuffer.cpp:8363
+#: ../src/richtext/richtextbuffer.cpp:8361
 msgid "Too many EndStyle calls!"
 msgstr "EndStyle の呼び出しが多すぎます。"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:891
+#: ../src/propgrid/advprops.cpp:792
 msgid "Tooltip"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:892
+#: ../src/propgrid/advprops.cpp:793
 msgid "TooltipText"
 msgstr ""
 
-#: ../src/richtext/richtextsizepage.cpp:286
-#: ../src/richtext/richtextsizepage.cpp:290 ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197 ../src/richtext/richtextsizepage.cpp:286
+#: ../src/richtext/richtextsizepage.cpp:290
 #, fuzzy
 msgid "Top"
 msgstr "上端 (&T)"
 
-#: ../src/generic/prntdlgg.cpp:881
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Top margin (mm):"
 msgstr "余白-天 (mm):"
 
-#: ../src/generic/aboutdlgg.cpp:79
+#: ../src/generic/aboutdlgg.cpp:76
 msgid "Translations by "
 msgstr "翻訳 : "
 
-#: ../src/generic/aboutdlgg.cpp:188
+#: ../src/generic/aboutdlgg.cpp:185
 msgid "Translators"
 msgstr "翻訳者"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:211
+#: ../src/propgrid/propgrid.cpp:192
 msgid "True"
 msgstr "真"
 
-#: ../src/common/fs_mem.cpp:227
+#: ../src/common/fs_mem.cpp:222
 #, c-format
 msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
 msgstr "メモリVFSにまだ読み込まれていない '%s' の削除を要求されました。"
 
-#: ../src/common/fmapbase.cpp:156
+#: ../src/common/fmapbase.cpp:153
 msgid "Turkish (ISO-8859-9)"
 msgstr "トルコ語 (ISO-8859-9)"
 
-#: ../src/generic/filectrlg.cpp:426
+#: ../src/generic/filectrlg.cpp:422
 msgid "Type"
 msgstr "種類"
 
@@ -7385,17 +7549,17 @@ msgstr "フォント名を指定します。"
 msgid "Type a size in points."
 msgstr "ポイントで大きさを指定します。"
 
-#: ../src/msw/ole/automtn.cpp:676
+#: ../src/msw/ole/automtn.cpp:667
 #, c-format
 msgid "Type mismatch in argument %u."
 msgstr ""
 
-#: ../src/common/xtixml.cpp:356 ../src/common/xtixml.cpp:509
-#: ../src/common/xtistrm.cpp:318
+#: ../src/common/xtixml.cpp:352 ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315
 msgid "Type must have enum - long conversion"
 msgstr "型は列挙からlongへの変換が可能でなくてはなりません。"
 
-#: ../src/propgrid/propgridiface.cpp:401
+#: ../src/propgrid/propgridiface.cpp:385
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
@@ -7404,19 +7568,19 @@ msgstr ""
 "型の処理 \"%s\" に失敗:  \"%s\" とラベルされたプロパティーは \"%s\" 型で"
 "す。\"%s\" ではありません。"
 
-#: ../src/common/paper.cpp:133
+#: ../src/common/paper.cpp:130
 msgid "US Std Fanfold, 14 7/8 x 11 in"
 msgstr "米国標準折りたたみ連続紙, 14 7/8 x 11インチ"
 
-#: ../src/common/fmapbase.cpp:196
+#: ../src/common/fmapbase.cpp:193
 msgid "US-ASCII"
 msgstr "US-ASCII"
 
-#: ../src/unix/fswatcher_inotify.cpp:109
+#: ../src/unix/fswatcher_inotify.cpp:106
 msgid "Unable to add inotify watch"
 msgstr "inotify 監視を追加できませんでした"
 
-#: ../src/unix/fswatcher_kqueue.cpp:136
+#: ../src/unix/fswatcher_kqueue.cpp:153
 msgid "Unable to add kqueue watch"
 msgstr "kqueue 監視を追加できませんでした"
 
@@ -7428,7 +7592,7 @@ msgstr "ハンドルをI/O完了ポートに関連づけることができませ
 msgid "Unable to close I/O completion port handle"
 msgstr "I/O完了ポートハンドルを閉じることができませんでした"
 
-#: ../src/unix/fswatcher_inotify.cpp:97
+#: ../src/unix/fswatcher_inotify.cpp:94
 msgid "Unable to close inotify instance"
 msgstr "inotify 実体を閉じることができませんでした。"
 
@@ -7446,15 +7610,15 @@ msgstr "'%s' へのハンドルを閉じることができませんでした。"
 msgid "Unable to create I/O completion port"
 msgstr "I/O完了ポートを作成できません"
 
-#: ../src/msw/fswatcher.cpp:84
+#: ../src/msw/fswatcher.cpp:81
 msgid "Unable to create IOCP worker thread"
 msgstr "IOCP ワーカースレッドを作成できません"
 
-#: ../src/unix/fswatcher_inotify.cpp:74
+#: ../src/unix/fswatcher_inotify.cpp:71
 msgid "Unable to create inotify instance"
 msgstr "inotify 実体を作成できません"
 
-#: ../src/unix/fswatcher_kqueue.cpp:97
+#: ../src/unix/fswatcher_kqueue.cpp:114
 msgid "Unable to create kqueue instance"
 msgstr "kqueue 実体を作成できません"
 
@@ -7462,11 +7626,11 @@ msgstr "kqueue 実体を作成できません"
 msgid "Unable to dequeue completion packet"
 msgstr "完了パケットを双方向に扱えませんでした"
 
-#: ../src/unix/fswatcher_kqueue.cpp:185
+#: ../src/unix/fswatcher_kqueue.cpp:202
 msgid "Unable to get events from kqueue"
 msgstr "kqueue からのイベントを取得できませんでした"
 
-#: ../src/gtk/app.cpp:435
+#: ../src/gtk/app.cpp:431
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "GTK+を初期化できません。 DISPLAY の設定が不適切の可能性があります。"
 
@@ -7475,12 +7639,12 @@ msgstr "GTK+を初期化できません。 DISPLAY の設定が不適切の可�
 msgid "Unable to open path '%s'"
 msgstr "パス '%s' を開くことができません"
 
-#: ../src/html/htmlwin.cpp:583
+#: ../src/html/htmlwin.cpp:586
 #, c-format
 msgid "Unable to open requested HTML document: %s"
 msgstr "要求されたHTML文書を開くことができません: %s"
 
-#: ../src/unix/sound.cpp:368
+#: ../src/unix/sound.cpp:365
 msgid "Unable to play sound asynchronously."
 msgstr "音の非同期演奏はできません。"
 
@@ -7488,62 +7652,62 @@ msgstr "音の非同期演奏はできません。"
 msgid "Unable to post completion status"
 msgstr "完了状態を post できませんでした"
 
-#: ../src/unix/fswatcher_inotify.cpp:556
+#: ../src/unix/fswatcher_inotify.cpp:553
 msgid "Unable to read from inotify descriptor"
 msgstr "inotify 記述子から読み取ることができません"
 
-#: ../src/unix/fswatcher_inotify.cpp:141
+#: ../src/unix/fswatcher_inotify.cpp:138
 #, fuzzy, c-format
 msgid "Unable to remove inotify watch %i"
 msgstr "inotify 監視を削除できませんでした"
 
-#: ../src/unix/fswatcher_kqueue.cpp:153
+#: ../src/unix/fswatcher_kqueue.cpp:170
 msgid "Unable to remove kqueue watch"
 msgstr "kqueue 監視を削除できませんでした"
 
-#: ../src/msw/fswatcher.cpp:168
+#: ../src/msw/fswatcher.cpp:165
 #, c-format
 msgid "Unable to set up watch for '%s'"
 msgstr "'%s' の監視を準備できませんでした。"
 
-#: ../src/msw/fswatcher.cpp:91
+#: ../src/msw/fswatcher.cpp:88
 msgid "Unable to start IOCP worker thread"
 msgstr "IOCP ワーカースレッドを開始できませんでした"
 
-#: ../src/common/stockitem.cpp:201
+#: ../src/common/stockitem.cpp:198
 msgid "Undelete"
 msgstr "削除の取り消し"
 
-#: ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199
 #, fuzzy
 msgid "Underline"
 msgstr "下線 (&U)"
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/richtext/richtextfontpage.cpp:359 ../src/osx/carbon/fontdlg.cpp:370
-#: ../src/propgrid/advprops.cpp:690
+#: ../src/osx/carbon/fontdlg.cpp:367 ../src/propgrid/advprops.cpp:600
+#: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "下線付き"
 
-#: ../src/common/stockitem.cpp:203 ../src/stc/stc_i18n.cpp:15
+#: ../src/common/stockitem.cpp:200 ../src/stc/stc_i18n.cpp:15
 msgid "Undo"
 msgstr "元に戻す"
 
-#: ../src/common/stockitem.cpp:265
+#: ../src/common/stockitem.cpp:263
 msgid "Undo last action"
 msgstr "最後の編集を取り消します"
 
-#: ../src/common/cmdline.cpp:1029
+#: ../src/common/cmdline.cpp:1025
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "オプション '%s' に想定外の文字が続いています。"
 
-#: ../src/unix/fswatcher_inotify.cpp:274
+#: ../src/unix/fswatcher_inotify.cpp:271
 #, c-format
 msgid "Unexpected event for \"%s\": no matching watch descriptor."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1195
+#: ../src/common/cmdline.cpp:1191
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "想定外の変数 '%s' があります"
@@ -7552,49 +7716,49 @@ msgstr "想定外の変数 '%s' があります"
 msgid "Unexpectedly new I/O completion port was created"
 msgstr "予期しない新しいI/O完了ポートが作成されました"
 
-#: ../src/msw/fswatcher.cpp:70
+#: ../src/msw/fswatcher.cpp:67
 msgid "Ungraceful worker thread termination"
 msgstr "ワーカースレッドを強引に停止させます"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:460
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:456
+#: ../src/richtext/richtextsymboldlg.cpp:457
+#: ../src/richtext/richtextsymboldlg.cpp:458
 msgid "Unicode"
 msgstr "ユニコード"
 
-#: ../src/common/fmapbase.cpp:185 ../src/common/fmapbase.cpp:191
+#: ../src/common/fmapbase.cpp:182 ../src/common/fmapbase.cpp:188
 msgid "Unicode 16 bit (UTF-16)"
 msgstr "ユニコード 16 ビット (UTF-16)"
 
-#: ../src/common/fmapbase.cpp:190
+#: ../src/common/fmapbase.cpp:187
 msgid "Unicode 16 bit Big Endian (UTF-16BE)"
 msgstr "ユニコード 16 ビット Big Endian (UTF-16BE)"
 
-#: ../src/common/fmapbase.cpp:186
+#: ../src/common/fmapbase.cpp:183
 msgid "Unicode 16 bit Little Endian (UTF-16LE)"
 msgstr "ユニコード 16ビット Little Endian (UTF-16LE)"
 
-#: ../src/common/fmapbase.cpp:187 ../src/common/fmapbase.cpp:193
+#: ../src/common/fmapbase.cpp:184 ../src/common/fmapbase.cpp:190
 msgid "Unicode 32 bit (UTF-32)"
 msgstr "ユニコード 32 ビット (UTF-32)"
 
-#: ../src/common/fmapbase.cpp:192
+#: ../src/common/fmapbase.cpp:189
 msgid "Unicode 32 bit Big Endian (UTF-32BE)"
 msgstr "ユニコード 32 ビット Big Endian (UTF-32BE)"
 
-#: ../src/common/fmapbase.cpp:188
+#: ../src/common/fmapbase.cpp:185
 msgid "Unicode 32 bit Little Endian (UTF-32LE)"
 msgstr "ユニコード 32 ビット Little Endian (UTF-32LE)"
 
-#: ../src/common/fmapbase.cpp:182
+#: ../src/common/fmapbase.cpp:179
 msgid "Unicode 7 bit (UTF-7)"
 msgstr "ユニコード 7 ビット (UTF-7)"
 
-#: ../src/common/fmapbase.cpp:183
+#: ../src/common/fmapbase.cpp:180
 msgid "Unicode 8 bit (UTF-8)"
 msgstr "ユニコード 8 ビット (UTF-8)"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 #, fuzzy
 msgid "Unindent"
 msgstr "字下げ解除 (&U)"
@@ -7756,100 +7920,105 @@ msgstr "スレッドの終了待ちに失敗しました。"
 msgid "Units for this value."
 msgstr "スレッドの終了待ちに失敗しました。"
 
-#: ../src/generic/progdlgg.cpp:353 ../src/generic/progdlgg.cpp:622
+#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
 msgid "Unknown"
 msgstr "不明"
 
-#: ../src/msw/dde.cpp:1174
+#: ../src/msw/dde.cpp:1238
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "想定外のDDE エラー 0x%08x"
 
-#: ../src/common/xtistrm.cpp:410
+#: ../src/common/xtistrm.cpp:407
 msgid "Unknown Object passed to GetObjectClassInfo"
 msgstr "未知のオブジェクトが GetObjectClassInfo に渡されました"
 
-#: ../src/common/imagpng.cpp:366
+#: ../src/common/imagpng.cpp:383
 #, fuzzy, c-format
 msgid "Unknown PNG resolution unit %d"
 msgstr "未知の解像度単位 %d を無視しました"
 
-#: ../src/common/xtixml.cpp:327
+#: ../src/common/xtixml.cpp:323
 #, c-format
 msgid "Unknown Property %s"
 msgstr "未知のプロパティ %s"
 
-#: ../src/common/imagtiff.cpp:529
+#: ../src/common/imagtiff.cpp:526
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "未知の解像度単位 %d を無視しました"
 
-#: ../src/unix/dlunix.cpp:160
+#: ../src/propgrid/props.cpp:155
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/unix/dlunix.cpp:118
 msgid "Unknown dynamic library error"
 msgstr "想定外の動的ライブラリーエラー"
 
-#: ../src/common/fmapbase.cpp:810
+#: ../src/common/fmapbase.cpp:806
 #, c-format
 msgid "Unknown encoding (%d)"
 msgstr "未知のエンコーディング (%d)"
 
-#: ../src/msw/ole/automtn.cpp:688
+#: ../src/msw/ole/automtn.cpp:679
 #, fuzzy, c-format
 msgid "Unknown error %08x"
 msgstr "想定外のDDE エラー 0x%08x"
 
-#: ../src/msw/ole/automtn.cpp:647
+#: ../src/msw/ole/automtn.cpp:638
 #, fuzzy
 msgid "Unknown exception"
 msgstr "未定義の簡易オプション名 '%s'"
 
-#: ../src/common/image.cpp:2839
+#: ../src/common/image.cpp:2942
 #, fuzzy
 msgid "Unknown image data format."
 msgstr "未知のデータ様式です"
 
-#: ../src/common/cmdline.cpp:914
+#: ../src/common/cmdline.cpp:910
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "未定義の詳細オプション名 '%s'"
 
-#: ../src/msw/ole/automtn.cpp:631
+#: ../src/msw/ole/automtn.cpp:622
 #, fuzzy
 msgid "Unknown name or named argument."
 msgstr "未知のデータ様式です"
 
-#: ../src/common/cmdline.cpp:929 ../src/common/cmdline.cpp:951
+#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "未定義の簡易オプション名 '%s'"
 
-#: ../src/common/mimecmn.cpp:225
+#: ../src/common/mimecmn.cpp:221
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "MIME型 %s の項目に閉じていない '{' がありました。"
 
-#: ../src/common/cmdproc.cpp:262 ../src/common/cmdproc.cpp:288
-#: ../src/common/cmdproc.cpp:308
+#: ../src/common/cmdproc.cpp:255 ../src/common/cmdproc.cpp:281
+#: ../src/common/cmdproc.cpp:301
 msgid "Unnamed command"
 msgstr "無名コマンド"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:413
+#: ../src/propgrid/propgrid.cpp:392
 msgid "Unspecified"
 msgstr "未指定"
 
-#: ../src/msw/clipbrd.cpp:311
+#: ../src/msw/clipbrd.cpp:325
 msgid "Unsupported clipboard format."
 msgstr "未対応のクリップボード様式です。"
 
-#: ../src/common/appcmn.cpp:256
+#: ../src/common/appcmn.cpp:277
 #, c-format
 msgid "Unsupported theme '%s'."
 msgstr "テーマ '%s' は未対応です。"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:205
-#: ../src/common/accelcmn.cpp:63
+#: ../src/common/stockitem.cpp:202 ../src/common/accelcmn.cpp:60
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Up"
 msgstr "上へ"
 
@@ -7863,7 +8032,7 @@ msgstr "大文字単語"
 msgid "Upper case roman numerals"
 msgstr "大文字ローマ数字"
 
-#: ../src/common/cmdline.cpp:1326
+#: ../src/common/cmdline.cpp:1322
 #, c-format
 msgid "Usage: %s"
 msgstr "使い方: %s"
@@ -7872,38 +8041,47 @@ msgstr "使い方: %s"
 msgid "Use &shadow"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:169
-#: ../src/richtext/richtextindentspage.cpp:171
 #: ../src/richtext/richtextliststylepage.cpp:358
 #: ../src/richtext/richtextliststylepage.cpp:360
+#: ../src/richtext/richtextindentspage.cpp:169
+#: ../src/richtext/richtextindentspage.cpp:171
 msgid "Use the current alignment setting."
 msgstr "現在の整列設定を用います。"
 
-#: ../src/common/valtext.cpp:179
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/gtk/font.cpp:552
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/common/valtext.cpp:142
 msgid "Validation conflict"
 msgstr "確認処理に矛盾があります"
 
-#: ../src/propgrid/manager.cpp:238
+#: ../src/propgrid/manager.cpp:224
 msgid "Value"
 msgstr "値"
 
-#: ../src/propgrid/props.cpp:386 ../src/propgrid/props.cpp:500
+#: ../src/propgrid/props.cpp:309
 #, fuzzy, c-format
 msgid "Value must be %s or higher."
 msgstr "%f 以上の値にしてください"
 
-#: ../src/propgrid/props.cpp:417 ../src/propgrid/props.cpp:531
+#: ../src/propgrid/props.cpp:336
 #, fuzzy, c-format
 msgid "Value must be %s or less."
 msgstr "%f 以下の値にしてください"
 
-#: ../src/propgrid/props.cpp:393 ../src/propgrid/props.cpp:424
-#: ../src/propgrid/props.cpp:507 ../src/propgrid/props.cpp:538
+#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
 #, fuzzy, c-format
 msgid "Value must be between %s and %s."
 msgstr "%f 以下の値にしてください"
 
-#: ../src/generic/aboutdlgg.cpp:128
+#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "バージョン "
 
@@ -7913,25 +8091,32 @@ msgstr "バージョン "
 msgid "Vertical alignment."
 msgstr "整列方法を設定できませんでした。"
 
-#: ../src/generic/filedlgg.cpp:202
+#: ../src/generic/filedlgg.cpp:199
 msgid "View files as a detailed view"
 msgstr "詳細情報付きでファイル一覧を見る"
 
-#: ../src/generic/filedlgg.cpp:200
+#: ../src/generic/filedlgg.cpp:197
 msgid "View files as a list view"
 msgstr "リスト形式でファイル一覧を見る"
 
-#: ../src/common/docview.cpp:1970
+#: ../src/common/docview.cpp:1975
 msgid "Views"
 msgstr "ビュー"
 
+#: ../src/gtk/app.cpp:348
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1777
+#: ../src/propgrid/advprops.cpp:1678
 msgid "Wait"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1779
+#: ../src/propgrid/advprops.cpp:1680
 msgid "Wait Arrow"
 msgstr ""
 
@@ -7940,252 +8125,249 @@ msgstr ""
 msgid "Waiting for IO on epoll descriptor %d failed"
 msgstr "epoll 記述子 %d の IO 待ちに失敗しました"
 
-#: ../src/common/log.cpp:223
+#: ../src/common/log.cpp:241
 msgid "Warning: "
 msgstr "警告:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1778
+#: ../src/propgrid/advprops.cpp:1679
 msgid "Watch"
 msgstr ""
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:685
+#: ../src/propgrid/advprops.cpp:595
 msgid "Weight"
 msgstr "ウエイト"
 
-#: ../src/common/fmapbase.cpp:148
+#: ../src/common/fmapbase.cpp:145
 msgid "Western European (ISO-8859-1)"
 msgstr "西ヨーロッパ言語 (ISO-8859-1)"
 
-#: ../src/common/fmapbase.cpp:162
+#: ../src/common/fmapbase.cpp:159
 msgid "Western European with Euro (ISO-8859-15)"
 msgstr "西ヨーロッパ言語ユーロ記号付き (Latin-9, ISO-8859-15)"
 
-#: ../src/generic/fontdlgg.cpp:446 ../src/generic/fontdlgg.cpp:448
+#: ../src/generic/fontdlgg.cpp:443 ../src/generic/fontdlgg.cpp:445
 msgid "Whether the font is underlined."
 msgstr "フォントに下線が付くかどうか。"
 
-#: ../src/propgrid/advprops.cpp:1611
+#: ../src/propgrid/advprops.cpp:1517
 msgid "White"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:144
+#: ../src/generic/fdrepdlg.cpp:141
 msgid "Whole word"
 msgstr "単語全体"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:532
 msgid "Whole words only"
 msgstr "全体一致のみ"
 
-#: ../src/univ/themes/win32.cpp:1102
+#: ../src/univ/themes/win32.cpp:1099
 msgid "Win32 theme"
 msgstr "Win32 テーマ"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:893
+#: ../src/propgrid/advprops.cpp:794
 #, fuzzy
 msgid "Window"
 msgstr "ウィンドウ (&W)"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:894
+#: ../src/propgrid/advprops.cpp:795
 #, fuzzy
 msgid "WindowFrame"
 msgstr "ウィンドウ (&W)"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:895
+#: ../src/propgrid/advprops.cpp:796
 #, fuzzy
 msgid "WindowText"
 msgstr "ウィンドウ (&W)"
 
-#: ../src/common/fmapbase.cpp:177
+#: ../src/common/fmapbase.cpp:174
 msgid "Windows Arabic (CP 1256)"
 msgstr "Windows アラビア語 (CP 1256)"
 
-#: ../src/common/fmapbase.cpp:178
+#: ../src/common/fmapbase.cpp:175
 msgid "Windows Baltic (CP 1257)"
 msgstr "Windows バルト言語 (CP 1257)"
 
-#: ../src/common/fmapbase.cpp:171
+#: ../src/common/fmapbase.cpp:168
 msgid "Windows Central European (CP 1250)"
 msgstr "Windows 中央ヨーロッパ言語 (CP 1250)"
 
-#: ../src/common/fmapbase.cpp:168
+#: ../src/common/fmapbase.cpp:165
 #, fuzzy
 msgid "Windows Chinese Simplified (CP 936) or GB-2312"
 msgstr "Windows 簡体字中国語 (CP 936)"
 
-#: ../src/common/fmapbase.cpp:170
+#: ../src/common/fmapbase.cpp:167
 #, fuzzy
 msgid "Windows Chinese Traditional (CP 950) or Big-5"
 msgstr "Windows 繁体字中国語 (CP 950)"
 
-#: ../src/common/fmapbase.cpp:172
+#: ../src/common/fmapbase.cpp:169
 msgid "Windows Cyrillic (CP 1251)"
 msgstr "Windows キリル言語 (CP 1251)"
 
-#: ../src/common/fmapbase.cpp:174
+#: ../src/common/fmapbase.cpp:171
 msgid "Windows Greek (CP 1253)"
 msgstr "Windows ギリシャ語 (CP 1253)"
 
-#: ../src/common/fmapbase.cpp:176
+#: ../src/common/fmapbase.cpp:173
 msgid "Windows Hebrew (CP 1255)"
 msgstr "Windows ヘブライ語 (CP 1255)"
 
-#: ../src/common/fmapbase.cpp:167
+#: ../src/common/fmapbase.cpp:164
 #, fuzzy
 msgid "Windows Japanese (CP 932) or Shift-JIS"
 msgstr "Windows 日本語/Windows シフトJIS (CP 932)"
 
-#: ../src/common/fmapbase.cpp:180
+#: ../src/common/fmapbase.cpp:177
 #, fuzzy
 msgid "Windows Johab (CP 1361)"
 msgstr "Windows アラビア語 (CP 1256)"
 
-#: ../src/common/fmapbase.cpp:169
+#: ../src/common/fmapbase.cpp:166
 msgid "Windows Korean (CP 949)"
 msgstr "Windows 韓国語 (CP 949)"
 
-#: ../src/common/fmapbase.cpp:166
+#: ../src/common/fmapbase.cpp:163
 msgid "Windows Thai (CP 874)"
 msgstr "Windows タイ語 (CP 874)"
 
-#: ../src/common/fmapbase.cpp:175
+#: ../src/common/fmapbase.cpp:172
 msgid "Windows Turkish (CP 1254)"
 msgstr "Windows トルコ語 (CP 1254)"
 
-#: ../src/common/fmapbase.cpp:179
+#: ../src/common/fmapbase.cpp:176
 #, fuzzy
 msgid "Windows Vietnamese (CP 1258)"
 msgstr "Windows ギリシャ語 (CP 1253)"
 
-#: ../src/common/fmapbase.cpp:173
+#: ../src/common/fmapbase.cpp:170
 msgid "Windows Western European (CP 1252)"
 msgstr "Windows 西ヨーロッパ言語 (CP 1252)"
 
-#: ../src/common/fmapbase.cpp:181
+#: ../src/common/fmapbase.cpp:178
 msgid "Windows/DOS OEM (CP 437)"
 msgstr "Windows/DOS OEM (CP 437)"
 
-#: ../src/common/fmapbase.cpp:165
+#: ../src/common/fmapbase.cpp:162
 #, fuzzy
 msgid "Windows/DOS OEM Cyrillic (CP 866)"
 msgstr "Windows キリル言語 (CP 1251)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:111
+#: ../src/common/accelcmn.cpp:109
 #, fuzzy
 msgid "Windows_Left"
 msgstr "Windows 95"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:113
+#: ../src/common/accelcmn.cpp:111
 #, fuzzy
 msgid "Windows_Menu"
 msgstr "Windows ME"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:112
+#: ../src/common/accelcmn.cpp:110
 #, fuzzy
 msgid "Windows_Right"
 msgstr "Windows Vista (ビルド %lu"
 
-#: ../src/common/ffile.cpp:150
+#: ../src/common/ffile.cpp:149
 #, c-format
 msgid "Write error on file '%s'"
 msgstr "ファイル '%s' への書き出しエラー"
 
-#: ../src/xml/xml.cpp:914
+#: ../src/xml/xml.cpp:925
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "XML 解析エラー: '%s' (%d行目)"
 
-#: ../src/common/xpmdecod.cpp:796
+#: ../src/common/xpmdecod.cpp:794
 msgid "XPM: Malformed pixel data!"
 msgstr "XPM: 定形外のピクセルデータがありました"
 
-#: ../src/common/xpmdecod.cpp:705
+#: ../src/common/xpmdecod.cpp:702
 #, c-format
 msgid "XPM: incorrect colour description in line %d"
 msgstr "XPM: %d行目の色記述に問題があります"
 
-#: ../src/common/xpmdecod.cpp:680
+#: ../src/common/xpmdecod.cpp:677
 msgid "XPM: incorrect header format!"
 msgstr "XPM: ヘッダーが必要な様式を満たしていません。"
 
-#: ../src/common/xpmdecod.cpp:716 ../src/common/xpmdecod.cpp:725
+#: ../src/common/xpmdecod.cpp:714 ../src/common/xpmdecod.cpp:723
 #, c-format
 msgid "XPM: malformed colour definition '%s' at line %d!"
 msgstr "XPM: 定形外の色定義 '%s' が%d行目にありました。"
 
-#: ../src/common/xpmdecod.cpp:755
+#: ../src/common/xpmdecod.cpp:753
 msgid "XPM: no colors left to use for mask!"
 msgstr "XPM: マスクに使うための色が残っていません。"
 
-#: ../src/common/xpmdecod.cpp:782
+#: ../src/common/xpmdecod.cpp:780
 #, c-format
 msgid "XPM: truncated image data at line %d!"
 msgstr "XPM: %d行目に不完全な画像データがありました。"
 
-#: ../src/propgrid/advprops.cpp:1610
+#: ../src/propgrid/advprops.cpp:1516
 msgid "Yellow"
 msgstr ""
 
-#: ../include/wx/msgdlg.h:276 ../src/common/stockitem.cpp:206
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:203
 #: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "はい"
 
-#: ../src/osx/carbon/overlay.cpp:155
-msgid "You cannot Clear an overlay that is not inited"
-msgstr "オーバーレイは初期化する前に Clear できません"
-
-#: ../src/osx/carbon/overlay.cpp:107 ../src/dfb/overlay.cpp:61
-msgid "You cannot Init an overlay twice"
-msgstr "オーバーレイは二度 Init できません"
-
-#: ../src/generic/dirdlgg.cpp:287
+#: ../src/generic/dirdlgg.cpp:284
 msgid "You cannot add a new directory to this section."
 msgstr "このセクションに新しいディレクトリーは追加できません。"
 
-#: ../src/propgrid/propgrid.cpp:3299
+#: ../src/propgrid/propgrid.cpp:3276
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:209
+#: ../src/osx/cocoa/menu.mm:286
+#, fuzzy
+msgid "Zoom"
+msgstr "拡大(&I)"
+
+#: ../src/common/stockitem.cpp:206
 msgid "Zoom &In"
 msgstr "拡大(&I)"
 
-#: ../src/common/stockitem.cpp:210
+#: ../src/common/stockitem.cpp:207
 msgid "Zoom &Out"
 msgstr "縮小(&O)"
 
-#: ../src/common/stockitem.cpp:209 ../src/common/prntbase.cpp:1594
+#: ../src/common/stockitem.cpp:206 ../src/common/prntbase.cpp:1619
 #, fuzzy
 msgid "Zoom In"
 msgstr "拡大(&I)"
 
-#: ../src/common/stockitem.cpp:210 ../src/common/prntbase.cpp:1580
+#: ../src/common/stockitem.cpp:207 ../src/common/prntbase.cpp:1605
 #, fuzzy
 msgid "Zoom Out"
 msgstr "縮小(&O)"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to &Fit"
 msgstr "画面に合わせる(&F)"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 #, fuzzy
 msgid "Zoom to Fit"
 msgstr "画面に合わせる(&F)"
 
-#: ../src/msw/dde.cpp:1141
+#: ../src/msw/dde.cpp:1205
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "DDEML アプリケーションが競合状態の延長として作成されています｡"
 
-#: ../src/msw/dde.cpp:1129
+#: ../src/msw/dde.cpp:1193
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -8196,39 +8378,39 @@ msgstr ""
 "無効な実体識別子が DDEML 関数に渡されました。\n"
 "　"
 
-#: ../src/msw/dde.cpp:1147
+#: ../src/msw/dde.cpp:1211
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "クライアントによる通信対話の確立が試みられましたが失敗しました。"
 
-#: ../src/msw/dde.cpp:1144
+#: ../src/msw/dde.cpp:1208
 msgid "a memory allocation failed."
 msgstr "メモリ割り当てに失敗しました。"
 
-#: ../src/msw/dde.cpp:1138
+#: ../src/msw/dde.cpp:1202
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "DDEML の評価により引数の失敗が検出されました。"
 
-#: ../src/msw/dde.cpp:1120
+#: ../src/msw/dde.cpp:1184
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "非同期 advise トランザクションの要求が時間切れになりました。"
 
-#: ../src/msw/dde.cpp:1126
+#: ../src/msw/dde.cpp:1190
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "非同期 data トランザクションの要求が時間切れになりました。"
 
-#: ../src/msw/dde.cpp:1135
+#: ../src/msw/dde.cpp:1199
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "非同期 execute トランザクションの要求が時間切れになりました。"
 
-#: ../src/msw/dde.cpp:1153
+#: ../src/msw/dde.cpp:1217
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "非同期 poke トランザクションの要求が時間切れになりました。"
 
-#: ../src/msw/dde.cpp:1168
+#: ../src/msw/dde.cpp:1232
 msgid "a request to end an advise transaction has timed out."
 msgstr "advise トランザクション終了の要求が時間切れになりました。"
 
-#: ../src/msw/dde.cpp:1162
+#: ../src/msw/dde.cpp:1226
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -8238,15 +8420,15 @@ msgstr ""
 "クライアントによって終了されたかトランザクション成立前に\n"
 "終了してしまいました。"
 
-#: ../src/msw/dde.cpp:1150
+#: ../src/msw/dde.cpp:1214
 msgid "a transaction failed."
 msgstr "トランザクションが失敗しました。"
 
-#: ../src/common/accelcmn.cpp:189
+#: ../src/common/accelcmn.cpp:188
 msgid "alt"
 msgstr "Alt"
 
-#: ../src/msw/dde.cpp:1132
+#: ../src/msw/dde.cpp:1196
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -8258,15 +8440,15 @@ msgstr ""
 "APPCMD_CLIENTONLY で初期化されたものが\n"
 "サーバートランザクションの実現を試みようとしました。"
 
-#: ../src/msw/dde.cpp:1156
+#: ../src/msw/dde.cpp:1220
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "PostMessage関数の内部呼び出しが失敗しました。"
 
-#: ../src/msw/dde.cpp:1165
+#: ../src/msw/dde.cpp:1229
 msgid "an internal error has occurred in the DDEML."
 msgstr "DDEMLの内部エラーが発生しました。"
 
-#: ../src/msw/dde.cpp:1171
+#: ../src/msw/dde.cpp:1235
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -8276,56 +8458,56 @@ msgstr ""
 "XTYP_XACT_COMPLETE コールバックで識別子を使った後復帰した\n"
 "アプリケーションはその識別子を以後の呼び出しで使うことができません。"
 
-#: ../src/common/zipstrm.cpp:1483
+#: ../src/common/zipstrm.cpp:1522
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "複数のzipファイルが結合されるよう意図されたデータです"
 
-#: ../src/common/fileconf.cpp:1847
+#: ../src/common/fileconf.cpp:1849
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "不変キー '%s' への変更要求を無視しました。"
 
-#: ../src/html/chm.cpp:329
+#: ../src/html/chm.cpp:326
 msgid "bad arguments to library function"
 msgstr "ライブラリ関数への引数に問題があります"
 
-#: ../src/html/chm.cpp:341
+#: ../src/html/chm.cpp:338
 msgid "bad signature"
 msgstr "未対応の識別文字です"
 
-#: ../src/common/zipstrm.cpp:1918
+#: ../src/common/zipstrm.cpp:1988
 msgid "bad zipfile offset to entry"
 msgstr "項目へのzipfileオフセットが不適当です"
 
-#: ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400
 msgid "binary"
 msgstr "バイナリー"
 
-#: ../src/common/fontcmn.cpp:996
+#: ../src/common/fontcmn.cpp:1195
 msgid "bold"
 msgstr "太字"
 
-#: ../src/msw/utils.cpp:1144
+#: ../src/msw/utils.cpp:1135
 #, fuzzy, c-format
 msgid "build %lu"
 msgstr "Windows XP (ビルド %lu"
 
-#: ../src/common/ffile.cpp:75
+#: ../src/common/ffile.cpp:73
 #, c-format
 msgid "can't close file '%s'"
 msgstr "ファイル '%s' を閉じることができません"
 
-#: ../src/common/file.cpp:245
+#: ../src/common/file.cpp:242
 #, c-format
 msgid "can't close file descriptor %d"
 msgstr "記述子 %d のファイルを閉じることができません"
 
-#: ../src/common/file.cpp:586
+#: ../src/common/ffile.cpp:382 ../src/common/file.cpp:613
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "変更をファイル '%s' に反映できません。"
 
-#: ../src/common/file.cpp:178
+#: ../src/common/file.cpp:175
 #, c-format
 msgid "can't create file '%s'"
 msgstr "ファイル '%s' を作成できません"
@@ -8335,49 +8517,49 @@ msgstr "ファイル '%s' を作成できません"
 msgid "can't delete user configuration file '%s'"
 msgstr "ユーザー設定ファイル '%s' を削除できません"
 
-#: ../src/common/file.cpp:495
+#: ../src/common/file.cpp:522
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr "記述子 %d のファイルがEOFに達したかどうかを判断できません"
 
-#: ../src/common/zipstrm.cpp:1692
+#: ../src/common/zipstrm.cpp:1747
 msgid "can't find central directory in zip"
 msgstr "zip内にセントラルディレクトリー部が見つかりません。"
 
-#: ../src/common/file.cpp:465
+#: ../src/common/file.cpp:492
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "記述子 %d のファイルから長さを取得できません"
 
-#: ../src/msw/utils.cpp:341
+#: ../src/msw/utils.cpp:336
 msgid "can't find user's HOME, using current directory."
 msgstr "ユーザーのHOMEが見つかりません。カレントディレクトリーを使用します。"
 
-#: ../src/common/file.cpp:366
+#: ../src/common/file.cpp:407
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "記述子 %d のファイルをフラッシュできません"
 
-#: ../src/common/file.cpp:422
+#: ../src/common/file.cpp:463
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "記述子 %d のファイルからシーク位置を取得できません"
 
-#: ../src/common/fontmap.cpp:325
+#: ../src/common/fontmap.cpp:322
 msgid "can't load any font, aborting"
 msgstr "フォントが一切読み取れません、中止します"
 
-#: ../src/common/file.cpp:231 ../src/common/ffile.cpp:59
+#: ../src/common/ffile.cpp:57 ../src/common/file.cpp:228
 #, c-format
 msgid "can't open file '%s'"
 msgstr "ファイル '%s' を開くことができません。"
 
-#: ../src/common/fileconf.cpp:320
+#: ../src/common/fileconf.cpp:314
 #, c-format
 msgid "can't open global configuration file '%s'."
 msgstr "共有設定ファイル '%s' を開くことができません。"
 
-#: ../src/common/fileconf.cpp:336
+#: ../src/common/fileconf.cpp:330
 #, c-format
 msgid "can't open user configuration file '%s'."
 msgstr "ユーザー設定ファイル '%s' を開くことができません。"
@@ -8386,40 +8568,40 @@ msgstr "ユーザー設定ファイル '%s' を開くことができません。
 msgid "can't open user configuration file."
 msgstr "ユーザー設定ファイルを開くことができません。"
 
-#: ../src/common/zipstrm.cpp:579
+#: ../src/common/zipstrm.cpp:572
 msgid "can't re-initialize zlib deflate stream"
 msgstr "zlibをdeflateストリームで再初期化できません"
 
-#: ../src/common/zipstrm.cpp:604
+#: ../src/common/zipstrm.cpp:597
 msgid "can't re-initialize zlib inflate stream"
 msgstr "zlibをinflateストリームで再初期化できません"
 
-#: ../src/common/file.cpp:304
+#: ../src/common/file.cpp:345
 #, c-format
 msgid "can't read from file descriptor %d"
 msgstr "記述子 %d のファイルから読み取ることができません"
 
-#: ../src/common/file.cpp:581
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:608
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "ファイル '%s' を削除できません"
 
-#: ../src/common/file.cpp:598
+#: ../src/common/ffile.cpp:394 ../src/common/file.cpp:625
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "一時ファイル '%s' を削除できません"
 
-#: ../src/common/file.cpp:408
+#: ../src/common/file.cpp:449
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "記述子 %d のファイル上をシークできません"
 
-#: ../src/common/textfile.cpp:273
+#: ../src/common/textfile.cpp:161
 #, c-format
 msgid "can't write buffer '%s' to disk."
 msgstr "バッファー '%s' をディスクに書き出すことができません。"
 
-#: ../src/common/file.cpp:323
+#: ../src/common/file.cpp:364
 #, c-format
 msgid "can't write to file descriptor %d"
 msgstr "記述子 %d のファイルへ書き出すことができません。"
@@ -8429,22 +8611,28 @@ msgid "can't write user configuration file."
 msgstr "ユーザー設定ファイルを書き出すことができません。"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:482 ../src/generic/datavgen.cpp:1261
+#: ../src/common/datavcmn.cpp:2064 ../src/generic/datavgen.cpp:1384
 msgid "checked"
 msgstr ""
 
-#: ../src/html/chm.cpp:345
+#: ../src/html/chm.cpp:342
 msgid "checksum error"
 msgstr "チェックサムエラー"
 
-#: ../src/common/tarstrm.cpp:820
+#: ../src/common/tarstrm.cpp:814
 msgid "checksum failure reading tar header block"
 msgstr "ヘッダーブロックを読み取り中にチェックサムの不整合が見つかりました"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:226
-#: ../src/richtext/richtextbackgroundpage.cpp:249
-#: ../src/richtext/richtextbackgroundpage.cpp:289
-#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
 #: ../src/richtext/richtextborderspage.cpp:254
 #: ../src/richtext/richtextborderspage.cpp:288
 #: ../src/richtext/richtextborderspage.cpp:322
@@ -8462,105 +8650,128 @@ msgstr "ヘッダーブロックを読み取り中にチェックサムの不整
 #: ../src/richtext/richtextmarginspage.cpp:340
 #: ../src/richtext/richtextmarginspage.cpp:363
 #: ../src/richtext/richtextmarginspage.cpp:388
-#: ../src/richtext/richtextsizepage.cpp:339
-#: ../src/richtext/richtextsizepage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:400
-#: ../src/richtext/richtextsizepage.cpp:427
-#: ../src/richtext/richtextsizepage.cpp:454
-#: ../src/richtext/richtextsizepage.cpp:481
-#: ../src/richtext/richtextsizepage.cpp:555
-#: ../src/richtext/richtextsizepage.cpp:590
-#: ../src/richtext/richtextsizepage.cpp:625
-#: ../src/richtext/richtextsizepage.cpp:660
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
 msgid "cm"
 msgstr ""
 
-#: ../src/html/chm.cpp:347
+#: ../src/html/chm.cpp:344
 msgid "compression error"
 msgstr "圧縮エラー"
 
-#: ../src/common/regex.cpp:236
+#: ../src/common/regex.cpp:233
 msgid "conversion to 8-bit encoding failed"
 msgstr "8ビットエンコーディングへの変換に失敗しました"
 
-#: ../src/common/accelcmn.cpp:187
+#: ../src/common/accelcmn.cpp:186
 msgid "ctrl"
 msgstr "Ctrl"
 
-#: ../src/common/cmdline.cpp:1500
+#: ../src/common/cmdline.cpp:1496
 msgid "date"
 msgstr "日付"
 
-#: ../src/html/chm.cpp:349
+#: ../src/html/chm.cpp:346
 msgid "decompression error"
 msgstr "展開エラー"
 
-#: ../src/richtext/richtextstyles.cpp:780 ../src/common/fmapbase.cpp:820
+#: ../src/common/fmapbase.cpp:816 ../src/richtext/richtextstyles.cpp:777
 msgid "default"
 msgstr "規定"
 
-#: ../src/common/cmdline.cpp:1496
+#: ../src/common/cmdline.cpp:1492
 msgid "double"
 msgstr "double値"
 
-#: ../src/common/debugrpt.cpp:538
+#: ../src/common/debugrpt.cpp:539
 msgid "dump of the process state (binary)"
 msgstr "バイナリーによるプロセス状態のダンプ"
 
-#: ../src/common/datetimefmt.cpp:1969
+#: ../src/common/datetimefmt.cpp:1992
 msgid "eighteenth"
 msgstr "18日"
 
-#: ../src/common/datetimefmt.cpp:1959
+#: ../src/common/datetimefmt.cpp:1982
 msgid "eighth"
 msgstr "8日"
 
-#: ../src/common/datetimefmt.cpp:1962
+#: ../src/common/datetimefmt.cpp:1985
 msgid "eleventh"
 msgstr "11日"
 
-#: ../src/common/fileconf.cpp:1833
+#: ../src/common/fileconf.cpp:1835
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "項目 '%s' が二回以上グループ '%s' に現れています"
 
-#: ../src/html/chm.cpp:343
+#: ../src/html/chm.cpp:340
 msgid "error in data format"
 msgstr "データ様式にエラーがありました"
 
-#: ../src/html/chm.cpp:331
+#: ../src/html/chm.cpp:328
 msgid "error opening file"
 msgstr "ファイルを開く際にエラーが発生しました"
 
-#: ../src/common/zipstrm.cpp:1778
+#: ../src/common/zipstrm.cpp:1836
 msgid "error reading zip central directory"
 msgstr "zipのセントラルディレクトリーを読み取り中にエラーを検出しました"
 
-#: ../src/common/zipstrm.cpp:1870
+#: ../src/common/zipstrm.cpp:1940
 msgid "error reading zip local header"
 msgstr "zipのローカルヘッダーを読み取り中にエラーを検出しました。"
 
-#: ../src/common/zipstrm.cpp:2531
+#: ../src/common/zipstrm.cpp:2615
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "zip項目 '%s' の書き出しエラー: CRCまたは長さが不正です"
 
-#: ../src/common/ffile.cpp:188
+#: ../src/common/zipstrm.cpp:2608
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "zip項目 '%s' の書き出しエラー: CRCまたは長さが不正です"
+
+#: ../src/common/fontcmn.cpp:1205
+#, fuzzy
+msgid "extrabold"
+msgstr "太字"
+
+#: ../src/common/fontcmn.cpp:1223
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1167
+#, fuzzy
+msgid "extralight"
+msgstr "軽量"
+
+#: ../src/msw/webview_ie.cpp:1036
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "'%s' の実行に失敗しました\n"
+
+#: ../src/common/ffile.cpp:187
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "ファイル '%s' のフラッシュができませんでした"
 
+#: ../src/msw/webview_ie.cpp:1045
+#, fuzzy
+msgid "failed to retrieve execution result"
+msgstr "RAS エラーメッセージのテキストを取得できませんでした。"
+
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1030
+#: ../src/generic/datavgen.cpp:1150
 #, fuzzy
 msgid "false"
 msgstr "偽"
 
-#: ../src/common/datetimefmt.cpp:1966
+#: ../src/common/datetimefmt.cpp:1989
 msgid "fifteenth"
 msgstr "15日"
 
-#: ../src/common/datetimefmt.cpp:1956
+#: ../src/common/datetimefmt.cpp:1979
 msgid "fifth"
 msgstr "5日"
 
@@ -8589,131 +8800,150 @@ msgstr "ファイル '%s'  %d行目: 不変キー '%s' への値は無視され�
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "ファイル '%s': 想定外の文字 %c が %d 行目にありました。"
 
-#: ../src/richtext/richtextbuffer.cpp:8738
+#: ../src/richtext/richtextbuffer.cpp:8736
 msgid "files"
 msgstr "ファイル"
 
-#: ../src/common/datetimefmt.cpp:1952
+#: ../src/common/datetimefmt.cpp:1975
 msgid "first"
 msgstr "1日"
 
-#: ../src/html/helpwnd.cpp:1252
+#: ../src/html/helpwnd.cpp:1250
 msgid "font size"
 msgstr "フォントの大きさ"
 
-#: ../src/common/datetimefmt.cpp:1965
+#: ../src/common/datetimefmt.cpp:1988
 msgid "fourteenth"
 msgstr "14日"
 
-#: ../src/common/datetimefmt.cpp:1955
+#: ../src/common/datetimefmt.cpp:1978
 msgid "fourth"
 msgstr "4日"
 
-#: ../src/common/appbase.cpp:783
+#: ../src/common/appbase.cpp:784
 msgid "generate verbose log messages"
 msgstr "冗長なログメッセージを生成します。"
 
-#: ../src/richtext/richtextbuffer.cpp:13138
-#: ../src/richtext/richtextbuffer.cpp:13248
+#: ../src/common/fontcmn.cpp:1215
+msgid "heavy"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:13133
+#: ../src/richtext/richtextbuffer.cpp:13243
 msgid "image"
 msgstr "画像一時ファイル"
 
-#: ../src/common/tarstrm.cpp:796
+#: ../src/common/tarstrm.cpp:790
 msgid "incomplete header block in tar"
 msgstr "不完全なtarヘッダブロックです"
 
-#: ../src/common/xtixml.cpp:489
+#: ../src/common/xtixml.cpp:485
 msgid "incorrect event handler string, missing dot"
 msgstr "点が付いていない不正なイベントハンドラー文字列です"
 
-#: ../src/common/tarstrm.cpp:1381
+#: ../src/common/tarstrm.cpp:1375
 msgid "incorrect size given for tar entry"
 msgstr "tar項目に不正な大きさが与えられています"
 
-#: ../src/common/tarstrm.cpp:993
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:987
 msgid "invalid data in extended tar header"
 msgstr "拡張tarヘッダに不正なデータがあります"
 
-#: ../src/generic/logg.cpp:1030
+#: ../src/generic/logg.cpp:1027
 msgid "invalid message box return value"
 msgstr "メッセージボックスの戻り値は不正なものになります。"
 
-#: ../src/common/zipstrm.cpp:1647
+#: ../src/common/zipstrm.cpp:1688
 msgid "invalid zip file"
 msgstr "不完全なzipファイルです"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:1228
 msgid "italic"
 msgstr "イタリック"
 
-#: ../src/common/fontcmn.cpp:991
+#: ../src/common/webrequest_curl.cpp:374
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "列の記述を初期化できませんでした。"
+
+#: ../src/common/fontcmn.cpp:1172
 msgid "light"
 msgstr "軽量"
 
-#: ../src/common/intl.cpp:303
-#, c-format
-msgid "locale '%s' cannot be set."
-msgstr "ロケールに '%s' を指定できませんでした｡"
+#: ../src/common/fontcmn.cpp:1185
+msgid "medium"
+msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2125
+#: ../src/common/datetimefmt.cpp:2148
 msgid "midnight"
 msgstr "0時"
 
-#: ../src/common/datetimefmt.cpp:1970
+#: ../src/common/datetimefmt.cpp:1993
 msgid "nineteenth"
 msgstr "19日"
 
-#: ../src/common/datetimefmt.cpp:1960
+#: ../src/common/datetimefmt.cpp:1983
 msgid "ninth"
 msgstr "9日"
 
-#: ../src/msw/dde.cpp:1116
+#: ../src/msw/dde.cpp:1180
 msgid "no DDE error."
 msgstr "DDE エラーはありませんでした。"
 
-#: ../src/html/chm.cpp:327
+#: ../src/html/chm.cpp:324
 msgid "no error"
 msgstr "エラーなし"
 
-#: ../src/dfb/fontmgr.cpp:174
+#: ../src/dfb/fontmgr.cpp:171
 #, c-format
 msgid "no fonts found in %s, using builtin font"
 msgstr "%s にフォントが含まれていません。ビルトインフォントを使用します"
 
-#: ../src/html/helpdata.cpp:657
+#: ../src/html/helpdata.cpp:650
 msgid "noname"
 msgstr "名称未設定"
 
-#: ../src/common/datetimefmt.cpp:2124
+#: ../src/common/datetimefmt.cpp:2147
 msgid "noon"
 msgstr "正午"
 
-#: ../src/richtext/richtextstyles.cpp:779
+#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "通常"
 
-#: ../src/common/cmdline.cpp:1492
+#: ../src/common/cmdline.cpp:1488
 msgid "num"
 msgstr "数値"
 
-#: ../src/common/xtixml.cpp:259
+#: ../src/common/accelcmn.cpp:194
+msgid "num "
+msgstr ""
+
+#: ../src/common/xtixml.cpp:255
 msgid "objects cannot have XML Text Nodes"
 msgstr "オブジェクトは XML テキストノードを持つことができません"
 
-#: ../src/html/chm.cpp:339
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
 msgid "out of memory"
 msgstr "メモリ不足"
 
-#: ../src/common/debugrpt.cpp:514
+#: ../src/common/debugrpt.cpp:515
 msgid "process context description"
 msgstr "プロセスコンテキストの記述"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:227
-#: ../src/richtext/richtextbackgroundpage.cpp:250
-#: ../src/richtext/richtextbackgroundpage.cpp:290
-#: ../src/richtext/richtextbackgroundpage.cpp:317
-#: ../src/richtext/richtextfontpage.cpp:177
-#: ../src/richtext/richtextfontpage.cpp:180
 #: ../src/richtext/richtextborderspage.cpp:255
 #: ../src/richtext/richtextborderspage.cpp:289
 #: ../src/richtext/richtextborderspage.cpp:323
@@ -8723,22 +8953,45 @@ msgstr "プロセスコンテキストの記述"
 #: ../src/richtext/richtextborderspage.cpp:491
 #: ../src/richtext/richtextborderspage.cpp:525
 #: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextfontpage.cpp:180
 msgid "pt"
 msgstr ""
 
-#: ../src/richtext/richtextbackgroundpage.cpp:225
-#: ../src/richtext/richtextbackgroundpage.cpp:228
-#: ../src/richtext/richtextbackgroundpage.cpp:229
-#: ../src/richtext/richtextbackgroundpage.cpp:248
-#: ../src/richtext/richtextbackgroundpage.cpp:251
-#: ../src/richtext/richtextbackgroundpage.cpp:252
-#: ../src/richtext/richtextbackgroundpage.cpp:288
-#: ../src/richtext/richtextbackgroundpage.cpp:291
-#: ../src/richtext/richtextbackgroundpage.cpp:292
-#: ../src/richtext/richtextbackgroundpage.cpp:315
-#: ../src/richtext/richtextbackgroundpage.cpp:318
-#: ../src/richtext/richtextbackgroundpage.cpp:319
-#: ../src/richtext/richtextfontpage.cpp:178
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:659
+#: ../src/richtext/richtextsizepage.cpp:662
+#: ../src/richtext/richtextsizepage.cpp:663
 #: ../src/richtext/richtextborderspage.cpp:253
 #: ../src/richtext/richtextborderspage.cpp:256
 #: ../src/richtext/richtextborderspage.cpp:257
@@ -8790,263 +9043,273 @@ msgstr ""
 #: ../src/richtext/richtextmarginspage.cpp:387
 #: ../src/richtext/richtextmarginspage.cpp:389
 #: ../src/richtext/richtextmarginspage.cpp:390
-#: ../src/richtext/richtextsizepage.cpp:338
-#: ../src/richtext/richtextsizepage.cpp:341
-#: ../src/richtext/richtextsizepage.cpp:342
-#: ../src/richtext/richtextsizepage.cpp:372
-#: ../src/richtext/richtextsizepage.cpp:375
-#: ../src/richtext/richtextsizepage.cpp:376
-#: ../src/richtext/richtextsizepage.cpp:399
-#: ../src/richtext/richtextsizepage.cpp:402
-#: ../src/richtext/richtextsizepage.cpp:403
-#: ../src/richtext/richtextsizepage.cpp:426
-#: ../src/richtext/richtextsizepage.cpp:429
-#: ../src/richtext/richtextsizepage.cpp:430
-#: ../src/richtext/richtextsizepage.cpp:453
-#: ../src/richtext/richtextsizepage.cpp:456
-#: ../src/richtext/richtextsizepage.cpp:457
-#: ../src/richtext/richtextsizepage.cpp:480
-#: ../src/richtext/richtextsizepage.cpp:483
-#: ../src/richtext/richtextsizepage.cpp:484
-#: ../src/richtext/richtextsizepage.cpp:554
-#: ../src/richtext/richtextsizepage.cpp:557
-#: ../src/richtext/richtextsizepage.cpp:558
-#: ../src/richtext/richtextsizepage.cpp:589
-#: ../src/richtext/richtextsizepage.cpp:592
-#: ../src/richtext/richtextsizepage.cpp:593
-#: ../src/richtext/richtextsizepage.cpp:624
-#: ../src/richtext/richtextsizepage.cpp:627
-#: ../src/richtext/richtextsizepage.cpp:628
-#: ../src/richtext/richtextsizepage.cpp:659
-#: ../src/richtext/richtextsizepage.cpp:662
-#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextfontpage.cpp:178
 msgid "px"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:193
+#: ../src/common/accelcmn.cpp:192
 #, fuzzy
 msgid "rawctrl"
 msgstr "Ctrl"
 
-#: ../src/html/chm.cpp:333
+#: ../src/html/chm.cpp:330
 msgid "read error"
 msgstr "読み取りエラー"
 
-#: ../src/common/zipstrm.cpp:2085
+#: ../src/common/zipstrm.cpp:2155
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "zipストリームの読み取り中 (項目 %s): CRC 不一致"
 
-#: ../src/common/zipstrm.cpp:2080
+#: ../src/common/zipstrm.cpp:2150
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "zipストリームの読み取り中 (項目 %s): 不正な長さ"
 
-#: ../src/msw/dde.cpp:1159
+#: ../src/msw/dde.cpp:1223
 msgid "reentrancy problem."
 msgstr "同期トランザクションが別の同期トランザクションを開始しようとしました。"
 
-#: ../src/common/datetimefmt.cpp:1953
+#: ../src/common/datetimefmt.cpp:1976
 msgid "second"
 msgstr "2日"
 
-#: ../src/html/chm.cpp:337
+#: ../src/html/chm.cpp:334
 msgid "seek error"
 msgstr "シークエラー"
 
-#: ../src/common/datetimefmt.cpp:1968
+#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#, fuzzy
+msgid "semibold"
+msgstr "太字"
+
+#: ../src/common/datetimefmt.cpp:1991
 msgid "seventeenth"
 msgstr "17日"
 
-#: ../src/common/datetimefmt.cpp:1958
+#: ../src/common/datetimefmt.cpp:1981
 msgid "seventh"
 msgstr "7日"
 
-#: ../src/common/accelcmn.cpp:191
+#: ../src/common/accelcmn.cpp:190
 msgid "shift"
 msgstr "Shift"
 
-#: ../src/common/appbase.cpp:773
+#: ../src/common/appbase.cpp:774
 msgid "show this help message"
 msgstr "このヘルプメッセージを表示します"
 
-#: ../src/common/datetimefmt.cpp:1967
+#: ../src/common/datetimefmt.cpp:1990
 msgid "sixteenth"
 msgstr "16日"
 
-#: ../src/common/datetimefmt.cpp:1957
+#: ../src/common/datetimefmt.cpp:1980
 msgid "sixth"
 msgstr "6日"
 
-#: ../src/common/appcmn.cpp:234
+#: ../src/common/appcmn.cpp:255
 msgid "specify display mode to use (e.g. 640x480-16)"
 msgstr "使用する画面モードを指定ください(例: 640x480-16)"
 
-#: ../src/common/appcmn.cpp:220
+#: ../src/common/appcmn.cpp:241
 msgid "specify the theme to use"
 msgstr "使用するテーマを指定ください"
 
-#: ../src/richtext/richtextbuffer.cpp:9340
+#: ../src/richtext/richtextbuffer.cpp:9337
 msgid "standard/circle"
 msgstr "標準/丸"
 
-#: ../src/richtext/richtextbuffer.cpp:9341
+#: ../src/richtext/richtextbuffer.cpp:9338
 #, fuzzy
 msgid "standard/circle-outline"
 msgstr "標準/丸"
 
-#: ../src/richtext/richtextbuffer.cpp:9343
+#: ../src/richtext/richtextbuffer.cpp:9340
 msgid "standard/diamond"
 msgstr "標準/ひし形"
 
-#: ../src/richtext/richtextbuffer.cpp:9342
+#: ../src/richtext/richtextbuffer.cpp:9339
 msgid "standard/square"
 msgstr "標準/四角"
 
-#: ../src/richtext/richtextbuffer.cpp:9344
+#: ../src/richtext/richtextbuffer.cpp:9341
 msgid "standard/triangle"
 msgstr "標準/三角"
 
-#: ../src/common/zipstrm.cpp:1985
+#: ../src/common/zipstrm.cpp:2055
 msgid "stored file length not in Zip header"
 msgstr "Zipヘッダーにファイルの長さが記されていません"
 
-#: ../src/common/cmdline.cpp:1488
+#: ../src/common/cmdline.cpp:1484
 msgid "str"
 msgstr "文字列"
 
-#: ../src/common/fontcmn.cpp:982
+#: ../src/common/fontcmn.cpp:1145
 #, fuzzy
 msgid "strikethrough"
 msgstr "打ち消し線 (&S)"
 
-#: ../src/common/tarstrm.cpp:1003 ../src/common/tarstrm.cpp:1025
-#: ../src/common/tarstrm.cpp:1507 ../src/common/tarstrm.cpp:1529
+#: ../src/common/tarstrm.cpp:997 ../src/common/tarstrm.cpp:1019
+#: ../src/common/tarstrm.cpp:1501 ../src/common/tarstrm.cpp:1523
 msgid "tar entry not open"
 msgstr "TARの項目を開くことができません"
 
-#: ../src/common/datetimefmt.cpp:1961
+#: ../src/common/datetimefmt.cpp:1984
 msgid "tenth"
 msgstr "10日"
 
-#: ../src/msw/dde.cpp:1123
+#: ../src/msw/dde.cpp:1187
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "トランザクションへの応答が DDE_FBUSY ビットの設定を引き起こしました。"
 
-#: ../src/common/datetimefmt.cpp:1954
+#: ../src/common/fontcmn.cpp:1154
+msgid "thin"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:1977
 msgid "third"
 msgstr "3日"
 
-#: ../src/common/datetimefmt.cpp:1964
+#: ../src/common/datetimefmt.cpp:1987
 msgid "thirteenth"
 msgstr "13日"
 
-#: ../src/common/datetimefmt.cpp:1758
+#: ../src/common/datetimefmt.cpp:1781
 msgid "today"
 msgstr "今日"
 
-#: ../src/common/datetimefmt.cpp:1760
+#: ../src/common/datetimefmt.cpp:1783
 msgid "tomorrow"
 msgstr "明日"
 
-#: ../src/common/fileconf.cpp:1944
+#: ../src/common/fileconf.cpp:1946
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "'%s' の末尾にある / は無視されました"
 
-#: ../src/gtk/aboutdlg.cpp:218
+#: ../src/gtk/aboutdlg.cpp:216
 msgid "translator-credits"
 msgstr "翻訳者-謝辞"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1028
+#: ../src/generic/datavgen.cpp:1148
 msgid "true"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1963
+#: ../src/common/datetimefmt.cpp:1986
 msgid "twelfth"
 msgstr "12日"
 
-#: ../src/common/datetimefmt.cpp:1971
+#: ../src/common/datetimefmt.cpp:1994
 msgid "twentieth"
 msgstr "20日"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:486 ../src/generic/datavgen.cpp:1263
+#: ../src/common/datavcmn.cpp:2068 ../src/generic/datavgen.cpp:1386
 msgid "unchecked"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:802 ../src/common/fontcmn.cpp:978
+#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
 msgid "underlined"
 msgstr "下線"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:490
+#: ../src/common/datavcmn.cpp:2072
 #, fuzzy
 msgid "undetermined"
 msgstr "下線"
 
-#: ../src/common/fileconf.cpp:1979
+#: ../src/common/fileconf.cpp:1981
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "%d文字目に想定外の\"があります '%s'。"
 
-#: ../src/common/tarstrm.cpp:1045
+#: ../src/common/tarstrm.cpp:1039
 msgid "unexpected end of file"
 msgstr "想定外の状況でファイル末尾に達しました"
 
-#: ../src/generic/progdlgg.cpp:370 ../src/common/tarstrm.cpp:371
-#: ../src/common/tarstrm.cpp:394 ../src/common/tarstrm.cpp:425
+#: ../src/common/tarstrm.cpp:366 ../src/common/tarstrm.cpp:389
+#: ../src/common/tarstrm.cpp:420 ../src/generic/progdlgg.cpp:376
 msgid "unknown"
 msgstr "不明"
 
-#: ../src/msw/registry.cpp:150
+#: ../src/msw/registry.cpp:139
 #, fuzzy, c-format
 msgid "unknown (%lu)"
 msgstr "不明"
 
-#: ../src/common/xtixml.cpp:253
+#: ../src/common/xtixml.cpp:249
 #, c-format
 msgid "unknown class %s"
 msgstr "不明なクラス %s"
 
-#: ../src/common/regex.cpp:258 ../src/html/chm.cpp:351
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "圧縮エラー"
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "展開エラー"
+
+#: ../src/common/regex.cpp:255 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "想定外のエラーです"
 
-#: ../src/msw/dialup.cpp:471
+#: ../src/msw/dialup.cpp:465
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "想定外のエラーです (エラーコード 0x%08x)."
 
-#: ../src/common/fmapbase.cpp:834
+#: ../src/common/fmapbase.cpp:830
 #, c-format
 msgid "unknown-%d"
 msgstr "未知-%d"
 
-#: ../src/common/docview.cpp:509
+#: ../src/common/docview.cpp:502
 msgid "unnamed"
 msgstr "名称未指定"
 
-#: ../src/common/docview.cpp:1624
+#: ../src/common/docview.cpp:1618
 #, c-format
 msgid "unnamed%d"
 msgstr "名称未指定%d"
 
-#: ../src/common/zipstrm.cpp:1999 ../src/common/zipstrm.cpp:2319
+#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
 msgid "unsupported Zip compression method"
 msgstr "この Zip 圧縮法には未対応です"
 
-#: ../src/common/translation.cpp:1892
+#: ../src/common/translation.cpp:1942
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "カタログ '%s' を '%s' から利用します。"
 
-#: ../src/html/chm.cpp:335
+#: ../src/html/chm.cpp:332
 msgid "write error"
 msgstr "書き出しエラー"
 
-#: ../src/common/time.cpp:292
+#: ../src/gtk/glcanvas.cpp:187
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/common/time.cpp:285
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay が失敗しました。"
 
@@ -9060,15 +9323,15 @@ msgstr ""
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets はディスプレイを開くことができませんでした。終了します。"
 
-#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:431
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/common/datetimefmt.cpp:1759
+#: ../src/common/datetimefmt.cpp:1782
 msgid "yesterday"
 msgstr "昨日"
 
-#: ../src/common/zstream.cpp:251 ../src/common/zstream.cpp:426
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
 #, c-format
 msgid "zlib error %d"
 msgstr "zlib エラー %d"
@@ -9077,6 +9340,81 @@ msgstr "zlib エラー %d"
 #: ../src/richtext/richtextbulletspage.cpp:288
 msgid "~"
 msgstr "~"
+
+#, fuzzy
+#~ msgid "&Save as"
+#~ msgstr "Save As"
+
+#, fuzzy
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' はアルファベット以外を受け付けません。"
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' は数字でなくてはなりません。"
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' は ASCII 文字以外を受け付けません。"
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' はアルファベット以外を受け付けません。"
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' はアルファベットと数字のみ受け付けます。"
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' は数字以外を受け付けません。"
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "%s クラスのウィンドウを作成できません"
+
+#, fuzzy
+#~ msgid "Could not initalize libnotify."
+#~ msgstr "整列方法を設定できませんでした。"
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "オーバーレイウィンドウを作成できませんでした"
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "オーバーレイウィンドウの内容を初期化できませんでした。"
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "ファイル \"%s\" を Unicode に変換できませんでした。"
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "そのテキストコントロールにテキストを設定できませんでした。"
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr ""
+#~ "不適切な GTK+ コマンドラインオプションです。\"%s --help\" で確認してくださ"
+#~ "い。"
+
+#~ msgid "No unused colour in image."
+#~ msgstr "画像に未使用色がありません。"
+
+#~ msgid "Not available"
+#~ msgstr "利用できません"
+
+#~ msgid "Replace selection"
+#~ msgstr "選択範囲を置換します"
+
+#, fuzzy
+#~ msgid "Save as"
+#~ msgstr "Save As"
+
+#~ msgid "Style Organiser"
+#~ msgstr "スタイルの構成"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "次の標準GTK+オプションも利用できます:\n"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "オーバーレイは初期化する前に Clear できません"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "オーバーレイは二度 Init できません"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "ロケールに '%s' を指定できませんでした｡"
 
 #~ msgid "Adding flavor TEXT failed"
 #~ msgstr "フレーバー TEXT を追加できませんでした"
@@ -9094,9 +9432,6 @@ msgstr "~"
 
 #~ msgid "Column could not be added."
 #~ msgstr "列を追加できませんでした。"
-
-#~ msgid "Column description could not be initialized."
-#~ msgstr "列の記述を初期化できませんでした。"
 
 #~ msgid "Column index not found."
 #~ msgstr "列の索引が見つかりません。"
@@ -9688,9 +10023,6 @@ msgstr "~"
 #~ msgid "Directory '%s' doesn't exist!"
 #~ msgstr "ディレクトリー '%s' は存在しません。"
 
-#~ msgid "File %s does not exist."
-#~ msgstr "ファイル %s は存在しません。"
-
 #~ msgid "Mode %ix%i-%i not available."
 #~ msgstr "モード %ix%i-%i は使えません。"
 
@@ -10009,9 +10341,6 @@ msgstr "~"
 
 #~ msgid "Failed to register OpenGL window class."
 #~ msgstr "OpenGL ウィンドウクラスを登録できませんでした。"
-
-#~ msgid "Fatal error"
-#~ msgstr "重大なエラー"
 
 #~ msgid "Fatal error: "
 #~ msgstr "重大なエラー:"

--- a/locale/ko_KR.po
+++ b/locale/ko_KR.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-21 14:25+0200\n"
+"POT-Creation-Date: 2020-10-18 23:11+0300\n"
 "PO-Revision-Date: 2009-04-23 18:29+0900\n"
 "Last-Translator: 정성기 <dragoneyes.org@gmail.com>\n"
 "Language-Team: Korean <Korean>\n"
@@ -14,7 +14,7 @@ msgstr ""
 "X-Poedit-Country: KOREA, REPUBLIC OF\n"
 "Plural-Forms: nplurals=2; plural=n == 1 ? 0 : 1;\n"
 
-#: ../src/common/debugrpt.cpp:586
+#: ../src/common/debugrpt.cpp:587
 msgid ""
 "\n"
 "Please send this report to the program maintainer, thank you!\n"
@@ -22,8 +22,8 @@ msgstr ""
 "\n"
 "이보고서를 프로그램 개발자에게 보내주세요!\n"
 
-#: ../src/richtext/richtextstyledlg.cpp:210
-#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:206
+#: ../src/richtext/richtextstyledlg.cpp:218
 msgid " "
 msgstr " "
 
@@ -31,70 +31,96 @@ msgstr " "
 msgid "              Thank you and we're sorry for the inconvenience!\n"
 msgstr "              불편을 드려 죄송합니다!\n"
 
-#: ../src/common/prntbase.cpp:573
+#: ../src/common/prntbase.cpp:568
 #, fuzzy, c-format
 msgid " (copy %d of %d)"
 msgstr "페이지 %d/%d"
 
-#: ../src/common/log.cpp:421
+#: ../src/common/log.cpp:440
 #, c-format
 msgid " (error %ld: %s)"
 msgstr " (오류 %ld: %s)"
 
-#: ../src/common/imagtiff.cpp:72
+#: ../src/common/imagtiff.cpp:69
 #, fuzzy, c-format
 msgid " (in module \"%s\")"
 msgstr "tiff 모듈: %s"
 
-#: ../src/osx/core/secretstore.cpp:138
-msgid " (while overwriting an existing item)"
-msgstr ""
-
-#: ../src/common/docview.cpp:1642
+#: ../src/common/docview.cpp:1636
 msgid " - "
 msgstr " - "
 
-#: ../src/richtext/richtextprint.cpp:593 ../src/html/htmprint.cpp:714
+#: ../src/html/htmprint.cpp:712 ../src/richtext/richtextprint.cpp:589
 msgid " Preview"
 msgstr " 미리보기"
 
-#: ../src/common/fontcmn.cpp:824
+#: ../src/common/fontcmn.cpp:973
 msgid " bold"
 msgstr " 굵게"
 
-#: ../src/common/fontcmn.cpp:840
+#: ../src/common/fontcmn.cpp:977
+#, fuzzy
+msgid " extra bold"
+msgstr " 굵게"
+
+#: ../src/common/fontcmn.cpp:985
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:957
+#, fuzzy
+msgid " extra light"
+msgstr " 가늘게"
+
+#: ../src/common/fontcmn.cpp:981
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1001
 msgid " italic"
 msgstr " 기울임"
 
-#: ../src/common/fontcmn.cpp:820
+#: ../src/common/fontcmn.cpp:961
 msgid " light"
 msgstr " 가늘게"
 
-#: ../src/common/fontcmn.cpp:807
+#: ../src/common/fontcmn.cpp:965
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:969
+#, fuzzy
+msgid " semi bold"
+msgstr " 굵게"
+
+#: ../src/common/fontcmn.cpp:940
 msgid " strikethrough"
 msgstr " 취소선"
 
-#: ../src/common/paper.cpp:117
+#: ../src/common/fontcmn.cpp:953
+msgid " thin"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
 msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
 msgstr "#10 봉투, 4 1/8 x 9 1/2 in"
 
-#: ../src/common/paper.cpp:118
+#: ../src/common/paper.cpp:115
 msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
 msgstr "#11 봉투, 4 1/2 x 10 3/8 in"
 
-#: ../src/common/paper.cpp:119
+#: ../src/common/paper.cpp:116
 msgid "#12 Envelope, 4 3/4 x 11 in"
 msgstr "#12 봉투, 4 3/4 x 11 in"
 
-#: ../src/common/paper.cpp:120
+#: ../src/common/paper.cpp:117
 msgid "#14 Envelope, 5 x 11 1/2 in"
 msgstr "#14 봉투, 5 x 11 1/2 in"
 
-#: ../src/common/paper.cpp:116
+#: ../src/common/paper.cpp:113
 msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
 msgstr "#9 봉투, 3 7/8 x 8 7/8 in"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:341
 #: ../src/richtext/richtextsizepage.cpp:340
 #: ../src/richtext/richtextsizepage.cpp:374
 #: ../src/richtext/richtextsizepage.cpp:401
@@ -105,82 +131,83 @@ msgstr "#9 봉투, 3 7/8 x 8 7/8 in"
 #: ../src/richtext/richtextsizepage.cpp:591
 #: ../src/richtext/richtextsizepage.cpp:626
 #: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextbackgroundpage.cpp:341
 #, fuzzy
 msgid "%"
 msgstr "%s"
 
-#: ../src/html/helpwnd.cpp:1031
+#: ../src/html/helpwnd.cpp:1029
 #, fuzzy, c-format
 msgid "%d of %lu"
 msgstr "%i / %i"
 
-#: ../src/html/helpwnd.cpp:1678
+#: ../src/html/helpwnd.cpp:1676
 #, fuzzy, c-format
 msgid "%i of %u"
 msgstr "%i / %i"
 
-#: ../src/generic/filectrlg.cpp:279
+#: ../src/generic/filectrlg.cpp:275
 #, c-format
 msgid "%ld byte"
 msgid_plural "%ld bytes"
 msgstr[0] "%ld 바이트"
 msgstr[1] "%ld 바이트"
 
-#: ../src/html/helpwnd.cpp:1033
+#: ../src/html/helpwnd.cpp:1031
 #, fuzzy, c-format
 msgid "%lu of %lu"
 msgstr "%i / %i"
 
-#: ../src/generic/datavgen.cpp:6028
+#: ../src/generic/datavgen.cpp:6833
 #, fuzzy, c-format
 msgid "%s (%d items)"
 msgstr "%s (또는 %s)"
 
-#: ../src/common/cmdline.cpp:1221
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (또는 %s)"
 
-#: ../src/generic/logg.cpp:224
+#: ../src/generic/logg.cpp:221
 #, c-format
 msgid "%s Error"
 msgstr "오류 : %s"
 
-#: ../src/generic/logg.cpp:236
+#: ../src/generic/logg.cpp:233
 #, c-format
 msgid "%s Information"
 msgstr "정보 : %s"
 
-#: ../src/generic/preferencesg.cpp:113
+#: ../src/generic/preferencesg.cpp:110
 #, fuzzy, c-format
 msgid "%s Preferences"
 msgstr "설정(&P)"
 
-#: ../src/generic/logg.cpp:228
+#: ../src/generic/logg.cpp:225
 #, c-format
 msgid "%s Warning"
 msgstr "경고 : %s"
 
-#: ../src/common/tarstrm.cpp:1319
+#: ../src/common/tarstrm.cpp:1313
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s 발생 '%s' 파일의 tar 헤더 정보가 손상되었습니다"
 
-#: ../src/common/fldlgcmn.cpp:124
+#: ../src/common/fldlgcmn.cpp:121
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s 파일 (%s)|%s"
 
-#: ../src/html/helpwnd.cpp:1716
+#: ../src/html/helpwnd.cpp:1714
 #, fuzzy, c-format
 msgid "%u of %u"
 msgstr "%i / %i"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "&About"
 msgstr "이 프로그램은(&A)"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "&Actual Size"
 msgstr "실제 크기(&A)"
 
@@ -188,28 +215,28 @@ msgstr "실제 크기(&A)"
 msgid "&After a paragraph:"
 msgstr "단락 후(&A):"
 
-#: ../src/richtext/richtextindentspage.cpp:128
 #: ../src/richtext/richtextliststylepage.cpp:319
+#: ../src/richtext/richtextindentspage.cpp:128
 msgid "&Alignment"
 msgstr "정렬(&A)"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "&Apply"
 msgstr "적용(&A)"
 
-#: ../src/richtext/richtextstyledlg.cpp:251
+#: ../src/richtext/richtextstyledlg.cpp:247
 msgid "&Apply Style"
 msgstr "모양새 적용(&A)"
 
-#: ../src/msw/mdi.cpp:179
+#: ../src/msw/mdi.cpp:174
 msgid "&Arrange Icons"
 msgstr "아이콘 표시(&A)"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "&Ascending"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:142
+#: ../src/common/stockitem.cpp:139
 msgid "&Back"
 msgstr "뒤로(&B)"
 
@@ -230,24 +257,24 @@ msgstr "색상(&D):"
 msgid "&Blur distance:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:143
+#: ../src/common/stockitem.cpp:140
 msgid "&Bold"
 msgstr "굵게(&B)"
 
-#: ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141
 msgid "&Bottom"
 msgstr ""
 
+#: ../src/richtext/richtextsizepage.cpp:637
+#: ../src/richtext/richtextsizepage.cpp:644
 #: ../src/richtext/richtextborderspage.cpp:345
 #: ../src/richtext/richtextborderspage.cpp:513
 #: ../src/richtext/richtextmarginspage.cpp:259
 #: ../src/richtext/richtextmarginspage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:637
-#: ../src/richtext/richtextsizepage.cpp:644
 msgid "&Bottom:"
 msgstr ""
 
-#: ../include/wx/richtext/richtextbuffer.h:3866
+#: ../include/wx/richtext/richtextbuffer.h:3861
 #, fuzzy
 msgid "&Box"
 msgstr "굵게(&B)"
@@ -257,39 +284,39 @@ msgstr "굵게(&B)"
 msgid "&Bullet style:"
 msgstr "글머리 모양새(&B)"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "&CD-Rom"
 msgstr ""
 
-#: ../src/generic/wizard.cpp:434 ../src/generic/fontdlgg.cpp:470
-#: ../src/generic/fontdlgg.cpp:489 ../src/osx/carbon/fontdlg.cpp:402
-#: ../src/common/dlgcmn.cpp:279 ../src/common/stockitem.cpp:145
+#: ../src/osx/carbon/fontdlg.cpp:399 ../src/common/stockitem.cpp:142
+#: ../src/generic/wizard.cpp:433 ../src/generic/fontdlgg.cpp:466
+#: ../src/generic/fontdlgg.cpp:485 ../src/osx/cocoa/button.mm:200
 msgid "&Cancel"
 msgstr "취소(&C)"
 
-#: ../src/msw/mdi.cpp:175
+#: ../src/msw/mdi.cpp:170
 msgid "&Cascade"
 msgstr "계단식(&C)"
 
-#: ../include/wx/richtext/richtextbuffer.h:5960
+#: ../include/wx/richtext/richtextbuffer.h:5955
 #, fuzzy
 msgid "&Cell"
 msgstr "취소(&C)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:439
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "&Character code:"
 msgstr "문자 코드(&C):"
 
-#: ../src/common/stockitem.cpp:147
+#: ../src/common/stockitem.cpp:144
 msgid "&Clear"
 msgstr "비우기(&C)"
 
-#: ../src/generic/logg.cpp:516 ../src/common/stockitem.cpp:148
-#: ../src/common/prntbase.cpp:1600 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/stockitem.cpp:145 ../src/common/prntbase.cpp:1625
+#: ../src/univ/themes/win32.cpp:3753 ../src/generic/logg.cpp:513
 msgid "&Close"
 msgstr "닫기(&C)"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 #, fuzzy
 msgid "&Color"
 msgstr "색상(&D):"
@@ -298,21 +325,21 @@ msgstr "색상(&D):"
 msgid "&Colour:"
 msgstr "색상(&D):"
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 #, fuzzy
 msgid "&Convert"
 msgstr "목차"
 
-#: ../src/richtext/richtextctrl.cpp:333 ../src/osx/textctrl_osx.cpp:577
-#: ../src/common/stockitem.cpp:150 ../src/msw/textctrl.cpp:2508
+#: ../src/osx/textctrl_osx.cpp:595 ../src/common/stockitem.cpp:147
+#: ../src/msw/textctrl.cpp:2773 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "복사(&D)"
 
-#: ../src/generic/hyperlinkg.cpp:156
+#: ../src/generic/hyperlinkg.cpp:153
 msgid "&Copy URL"
 msgstr "URL 복사(&D)"
 
-#: ../src/common/headerctrlcmn.cpp:306
+#: ../src/common/headerctrlcmn.cpp:304
 #, fuzzy
 msgid "&Customize..."
 msgstr "사용자 지정 크기"
@@ -321,53 +348,54 @@ msgstr "사용자 지정 크기"
 msgid "&Debug report preview:"
 msgstr "디버그 보고서 미리보기(&D):"
 
-#: ../src/richtext/richtexttabspage.cpp:138
-#: ../src/richtext/richtextctrl.cpp:335 ../src/osx/textctrl_osx.cpp:579
-#: ../src/common/stockitem.cpp:152 ../src/msw/textctrl.cpp:2510
+#: ../src/osx/textctrl_osx.cpp:597 ../src/common/stockitem.cpp:149
+#: ../src/msw/textctrl.cpp:2775 ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtextctrl.cpp:334
 msgid "&Delete"
 msgstr "지우기(&D)"
 
-#: ../src/richtext/richtextstyledlg.cpp:269
+#: ../src/richtext/richtextstyledlg.cpp:265
 msgid "&Delete Style..."
 msgstr "모양새 지우기...(&D)"
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "&Descending"
 msgstr ""
 
-#: ../src/generic/logg.cpp:682
+#: ../src/generic/logg.cpp:679
 msgid "&Details"
 msgstr "자세히(&D)"
 
-#: ../src/common/stockitem.cpp:153
+#: ../src/common/stockitem.cpp:150
 msgid "&Down"
 msgstr "아래로(&D)"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "&Edit"
 msgstr "편집(&E)"
 
-#: ../src/richtext/richtextstyledlg.cpp:263
+#: ../src/richtext/richtextstyledlg.cpp:259
 msgid "&Edit Style..."
 msgstr "편집 모양새...(&E)"
 
-#: ../src/common/stockitem.cpp:155
+#: ../src/common/stockitem.cpp:152
 msgid "&Execute"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/common/stockitem.cpp:154
 msgid "&File"
 msgstr "파일(&F)"
 
-#: ../src/common/stockitem.cpp:158
-msgid "&Find"
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "&Find..."
 msgstr "찾기(&F)"
 
-#: ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:430
 msgid "&Finish"
 msgstr "종료(&F)"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:156
 #, fuzzy
 msgid "&First"
 msgstr "첫 번째"
@@ -376,17 +404,17 @@ msgstr "첫 번째"
 msgid "&Floating mode:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 #, fuzzy
 msgid "&Floppy"
 msgstr "복사(&D)"
 
-#: ../src/common/stockitem.cpp:194
+#: ../src/common/stockitem.cpp:191
 #, fuzzy
 msgid "&Font"
 msgstr "글꼴(&F):"
 
-#: ../src/generic/fontdlgg.cpp:371
+#: ../src/generic/fontdlgg.cpp:367
 msgid "&Font family:"
 msgstr "글꼴 패밀리(&F):"
 
@@ -394,20 +422,20 @@ msgstr "글꼴 패밀리(&F):"
 msgid "&Font for Level..."
 msgstr "사용할 글꼴(&F)..."
 
+#: ../src/richtext/richtextsymboldlg.cpp:397
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:400
 msgid "&Font:"
 msgstr "글꼴(&F):"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "&Forward"
 msgstr "앞으로(&F)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:451
+#: ../src/richtext/richtextsymboldlg.cpp:448
 msgid "&From:"
 msgstr "송신(&F):"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "&Harddisk"
 msgstr ""
 
@@ -417,9 +445,9 @@ msgstr ""
 msgid "&Height:"
 msgstr "두께(&W):"
 
-#: ../src/generic/wizard.cpp:441 ../src/richtext/richtextstyledlg.cpp:303
-#: ../src/richtext/richtextsymboldlg.cpp:479 ../src/osx/menu_osx.cpp:734
-#: ../src/common/stockitem.cpp:163
+#: ../src/common/stockitem.cpp:160 ../src/generic/wizard.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextstyledlg.cpp:299 ../src/osx/cocoa/menu.mm:226
 msgid "&Help"
 msgstr "도움말(&H)"
 
@@ -428,7 +456,7 @@ msgstr "도움말(&H)"
 msgid "&Hide details"
 msgstr "자세히(&D)"
 
-#: ../src/common/stockitem.cpp:164
+#: ../src/common/stockitem.cpp:161
 msgid "&Home"
 msgstr "홈(&H)"
 
@@ -436,56 +464,56 @@ msgstr "홈(&H)"
 msgid "&Horizontal offset:"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:184
 #: ../src/richtext/richtextliststylepage.cpp:372
+#: ../src/richtext/richtextindentspage.cpp:184
 msgid "&Indentation (tenths of a mm)"
 msgstr "들여쓰기(&I)(mm/10)"
 
-#: ../src/richtext/richtextindentspage.cpp:167
 #: ../src/richtext/richtextliststylepage.cpp:356
+#: ../src/richtext/richtextindentspage.cpp:167
 msgid "&Indeterminate"
 msgstr "정의하지않음(&I)"
 
-#: ../src/common/stockitem.cpp:166
+#: ../src/common/stockitem.cpp:163
 msgid "&Index"
 msgstr "색인(&I)"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 #, fuzzy
 msgid "&Info"
 msgstr "실행취소(&U)"
 
-#: ../src/common/stockitem.cpp:168
+#: ../src/common/stockitem.cpp:165
 msgid "&Italic"
 msgstr "기울임(&I)"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "&Jump to"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:153
 #: ../src/richtext/richtextliststylepage.cpp:342
+#: ../src/richtext/richtextindentspage.cpp:153
 msgid "&Justified"
 msgstr "정렬(&J)"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 #, fuzzy
 msgid "&Last"
 msgstr "붙여넣기(&P)"
 
-#: ../src/richtext/richtextindentspage.cpp:139
 #: ../src/richtext/richtextliststylepage.cpp:328
+#: ../src/richtext/richtextindentspage.cpp:139
 msgid "&Left"
 msgstr "왼쪽(&L)"
 
-#: ../src/richtext/richtextindentspage.cpp:195
+#: ../src/richtext/richtextsizepage.cpp:532
+#: ../src/richtext/richtextsizepage.cpp:539
 #: ../src/richtext/richtextborderspage.cpp:243
 #: ../src/richtext/richtextborderspage.cpp:411
 #: ../src/richtext/richtextliststylepage.cpp:381
+#: ../src/richtext/richtextindentspage.cpp:195
 #: ../src/richtext/richtextmarginspage.cpp:186
 #: ../src/richtext/richtextmarginspage.cpp:300
-#: ../src/richtext/richtextsizepage.cpp:532
-#: ../src/richtext/richtextsizepage.cpp:539
 msgid "&Left:"
 msgstr "왼쪽(&L):"
 
@@ -493,11 +521,11 @@ msgstr "왼쪽(&L):"
 msgid "&List level:"
 msgstr "목록 단계(&L):"
 
-#: ../src/generic/logg.cpp:517
+#: ../src/generic/logg.cpp:514
 msgid "&Log"
 msgstr "로그(&L)"
 
-#: ../src/univ/themes/win32.cpp:3748
+#: ../src/univ/themes/win32.cpp:3745
 msgid "&Move"
 msgstr "이동(&M)"
 
@@ -505,21 +533,20 @@ msgstr "이동(&M)"
 msgid "&Move the object to:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 #, fuzzy
 msgid "&Network"
 msgstr "새로 만들기(&N)"
 
-#: ../src/richtext/richtexttabspage.cpp:132 ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173 ../src/richtext/richtexttabspage.cpp:132
 msgid "&New"
 msgstr "새로 만들기(&N)"
 
-#: ../src/aui/tabmdi.cpp:111 ../src/generic/mdig.cpp:100
-#: ../src/msw/mdi.cpp:180
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
 msgid "&Next"
 msgstr "다음(&N)"
 
-#: ../src/generic/wizard.cpp:432 ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:429
 msgid "&Next >"
 msgstr "다음(&N) >"
 
@@ -528,7 +555,7 @@ msgstr "다음(&N) >"
 msgid "&Next Paragraph"
 msgstr "단락 후(&A):"
 
-#: ../src/generic/tipdlg.cpp:240
+#: ../src/generic/tipdlg.cpp:237
 msgid "&Next Tip"
 msgstr "다음 팁(&N)"
 
@@ -536,11 +563,11 @@ msgstr "다음 팁(&N)"
 msgid "&Next style:"
 msgstr "다음 모양새(&N)"
 
-#: ../src/common/stockitem.cpp:177 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:174 ../src/msw/msgdlg.cpp:435
 msgid "&No"
 msgstr "아니오(&N)"
 
-#: ../src/generic/dbgrptg.cpp:356
+#: ../src/generic/dbgrptg.cpp:360
 msgid "&Notes:"
 msgstr "&주의:"
 
@@ -548,12 +575,12 @@ msgstr "&주의:"
 msgid "&Number:"
 msgstr "번호(&N):"
 
-#: ../src/generic/fontdlgg.cpp:475 ../src/generic/fontdlgg.cpp:482
-#: ../src/osx/carbon/fontdlg.cpp:408 ../src/common/stockitem.cpp:178
+#: ../src/osx/carbon/fontdlg.cpp:405 ../src/common/stockitem.cpp:175
+#: ../src/generic/fontdlgg.cpp:471 ../src/generic/fontdlgg.cpp:478
 msgid "&OK"
 msgstr "확인(&O)"
 
-#: ../src/generic/dbgrptg.cpp:342 ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176 ../src/generic/dbgrptg.cpp:342
 msgid "&Open..."
 msgstr "열기...(&O)"
 
@@ -565,16 +592,16 @@ msgstr "들여쓰기 단계(&O)"
 msgid "&Page Break"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:334 ../src/osx/textctrl_osx.cpp:578
-#: ../src/common/stockitem.cpp:180 ../src/msw/textctrl.cpp:2509
+#: ../src/osx/textctrl_osx.cpp:596 ../src/common/stockitem.cpp:177
+#: ../src/msw/textctrl.cpp:2774 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "붙여넣기(&P)"
 
-#: ../include/wx/richtext/richtextbuffer.h:5010
+#: ../include/wx/richtext/richtextbuffer.h:5005
 msgid "&Picture"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:419
 msgid "&Point size:"
 msgstr "크기(&P):"
 
@@ -587,12 +614,11 @@ msgstr "위치(&P)(mm/10):"
 msgid "&Position mode:"
 msgstr "질문"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178
 msgid "&Preferences"
 msgstr "설정(&P)"
 
-#: ../src/aui/tabmdi.cpp:112 ../src/generic/mdig.cpp:101
-#: ../src/msw/mdi.cpp:181
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
 msgid "&Previous"
 msgstr "이전(&P)"
 
@@ -601,80 +627,75 @@ msgstr "이전(&P)"
 msgid "&Previous Paragraph"
 msgstr "이전 페이지"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "&Print..."
 msgstr "인쇄...(&P)"
 
-#: ../src/richtext/richtextctrl.cpp:339 ../src/richtext/richtextctrl.cpp:5514
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtextctrl.cpp:338
+#: ../src/richtext/richtextctrl.cpp:5512
 msgid "&Properties"
 msgstr "특성(&P)"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "&Quit"
 msgstr "종료(&Q)"
 
-#: ../src/richtext/richtextctrl.cpp:330 ../src/osx/textctrl_osx.cpp:574
-#: ../src/common/stockitem.cpp:185 ../src/common/cmdproc.cpp:293
-#: ../src/common/cmdproc.cpp:300 ../src/msw/textctrl.cpp:2505
+#: ../src/osx/textctrl_osx.cpp:592 ../src/common/stockitem.cpp:182
+#: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
+#: ../src/msw/textctrl.cpp:2770 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "다시실행(&R)"
 
-#: ../src/common/cmdproc.cpp:289 ../src/common/cmdproc.cpp:309
+#: ../src/common/cmdproc.cpp:282 ../src/common/cmdproc.cpp:302
 msgid "&Redo "
 msgstr "다시실행(&R)"
 
-#: ../src/richtext/richtextstyledlg.cpp:257
+#: ../src/richtext/richtextstyledlg.cpp:253
 msgid "&Rename Style..."
 msgstr "모양새 이름 바꾸기(&R)..."
 
-#: ../src/generic/fdrepdlg.cpp:179
+#: ../src/generic/fdrepdlg.cpp:176
 msgid "&Replace"
 msgstr "바꾸기(&R)"
 
-#: ../src/richtext/richtextstyledlg.cpp:287
+#: ../src/richtext/richtextstyledlg.cpp:283
 msgid "&Restart numbering"
 msgstr "번호 다시 매기기(&R)"
 
-#: ../src/univ/themes/win32.cpp:3747
+#: ../src/univ/themes/win32.cpp:3744
 msgid "&Restore"
 msgstr "이전 크기로(&R)"
 
-#: ../src/richtext/richtextindentspage.cpp:146
 #: ../src/richtext/richtextliststylepage.cpp:335
+#: ../src/richtext/richtextindentspage.cpp:146
 msgid "&Right"
 msgstr "오른쪽(&R):"
 
-#: ../src/richtext/richtextindentspage.cpp:213
+#: ../src/richtext/richtextsizepage.cpp:602
+#: ../src/richtext/richtextsizepage.cpp:609
 #: ../src/richtext/richtextborderspage.cpp:277
 #: ../src/richtext/richtextborderspage.cpp:445
 #: ../src/richtext/richtextliststylepage.cpp:399
+#: ../src/richtext/richtextindentspage.cpp:213
 #: ../src/richtext/richtextmarginspage.cpp:211
 #: ../src/richtext/richtextmarginspage.cpp:325
-#: ../src/richtext/richtextsizepage.cpp:602
-#: ../src/richtext/richtextsizepage.cpp:609
 msgid "&Right:"
 msgstr "오른쪽(&R):"
 
-#: ../src/common/stockitem.cpp:190
+#: ../src/common/stockitem.cpp:187
 msgid "&Save"
 msgstr "저장(&S)"
-
-#: ../src/common/stockitem.cpp:191
-#, fuzzy
-msgid "&Save as"
-msgstr "다른 이름으로 저장"
 
 #: ../include/wx/richmsgdlg.h:29
 #, fuzzy
 msgid "&See details"
 msgstr "자세히(&D)"
 
-#: ../src/generic/tipdlg.cpp:236
+#: ../src/generic/tipdlg.cpp:233
 msgid "&Show tips at startup"
 msgstr "시작시 팁 보여주기(&S)"
 
-#: ../src/univ/themes/win32.cpp:3750
+#: ../src/univ/themes/win32.cpp:3747
 msgid "&Size"
 msgstr "크기(&S)"
 
@@ -682,36 +703,36 @@ msgstr "크기(&S)"
 msgid "&Size:"
 msgstr "크기(&S)"
 
-#: ../src/generic/progdlgg.cpp:252
+#: ../src/generic/progdlgg.cpp:249
 msgid "&Skip"
 msgstr "건너뛰기(&S)"
 
-#: ../src/richtext/richtextindentspage.cpp:242
 #: ../src/richtext/richtextliststylepage.cpp:417
+#: ../src/richtext/richtextindentspage.cpp:242
 msgid "&Spacing (tenths of a mm)"
 msgstr "간격(&S)(mm/10)"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "&Spell Check"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "&Stop"
 msgstr "중지(&S)"
 
-#: ../src/richtext/richtextfontpage.cpp:275 ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196 ../src/richtext/richtextfontpage.cpp:275
 msgid "&Strikethrough"
 msgstr "취소선(&S)"
 
-#: ../src/generic/fontdlgg.cpp:382 ../src/richtext/richtextstylepage.cpp:106
+#: ../src/generic/fontdlgg.cpp:378 ../src/richtext/richtextstylepage.cpp:106
 msgid "&Style:"
 msgstr "모양새(&S):"
 
-#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:194
 msgid "&Styles:"
 msgstr "모양새(&S):"
 
-#: ../src/richtext/richtextsymboldlg.cpp:413
+#: ../src/richtext/richtextsymboldlg.cpp:410
 msgid "&Subset:"
 msgstr "분류(&S):"
 
@@ -725,27 +746,27 @@ msgstr "심볼(&S):"
 msgid "&Synchronize values"
 msgstr ""
 
-#: ../include/wx/richtext/richtextbuffer.h:6069
+#: ../include/wx/richtext/richtextbuffer.h:6064
 #, fuzzy
 msgid "&Table"
 msgstr "탭"
 
-#: ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197
 #, fuzzy
 msgid "&Top"
 msgstr "복사(&D)"
 
+#: ../src/richtext/richtextsizepage.cpp:567
+#: ../src/richtext/richtextsizepage.cpp:574
 #: ../src/richtext/richtextborderspage.cpp:311
 #: ../src/richtext/richtextborderspage.cpp:479
 #: ../src/richtext/richtextmarginspage.cpp:234
 #: ../src/richtext/richtextmarginspage.cpp:348
-#: ../src/richtext/richtextsizepage.cpp:567
-#: ../src/richtext/richtextsizepage.cpp:574
 #, fuzzy
 msgid "&Top:"
 msgstr "수신:"
 
-#: ../src/generic/fontdlgg.cpp:444 ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199 ../src/generic/fontdlgg.cpp:441
 msgid "&Underline"
 msgstr "밑줄(&U)"
 
@@ -753,21 +774,21 @@ msgstr "밑줄(&U)"
 msgid "&Underlining:"
 msgstr "밑줄(&U):"
 
-#: ../src/richtext/richtextctrl.cpp:329 ../src/osx/textctrl_osx.cpp:573
-#: ../src/common/stockitem.cpp:203 ../src/common/cmdproc.cpp:271
-#: ../src/msw/textctrl.cpp:2504
+#: ../src/osx/textctrl_osx.cpp:591 ../src/common/stockitem.cpp:200
+#: ../src/common/cmdproc.cpp:264 ../src/msw/textctrl.cpp:2769
+#: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "실행취소(&U)"
 
-#: ../src/common/cmdproc.cpp:265
+#: ../src/common/cmdproc.cpp:258
 msgid "&Undo "
 msgstr "실행취소(&U)"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "&Unindent"
 msgstr "내어쓰기"
 
-#: ../src/common/stockitem.cpp:205
+#: ../src/common/stockitem.cpp:202
 msgid "&Up"
 msgstr "위로(&U)"
 
@@ -786,7 +807,7 @@ msgstr "글머리 정렬(&A)"
 msgid "&View..."
 msgstr "열기...(&O)"
 
-#: ../src/generic/fontdlgg.cpp:393
+#: ../src/generic/fontdlgg.cpp:389
 msgid "&Weight:"
 msgstr "두께(&W):"
 
@@ -796,88 +817,58 @@ msgstr "두께(&W):"
 msgid "&Width:"
 msgstr "두께(&W):"
 
-#: ../src/aui/tabmdi.cpp:311 ../src/aui/tabmdi.cpp:327
-#: ../src/aui/tabmdi.cpp:329 ../src/generic/mdig.cpp:294
-#: ../src/generic/mdig.cpp:310 ../src/generic/mdig.cpp:314
-#: ../src/msw/mdi.cpp:78
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
 msgid "&Window"
 msgstr "창(&W)"
 
-#: ../src/common/stockitem.cpp:206 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:203 ../src/msw/msgdlg.cpp:435
 msgid "&Yes"
 msgstr "예(&Y)"
 
-#: ../src/common/valtext.cpp:256
+#: ../src/common/valtext.cpp:197
 #, fuzzy, c-format
-msgid "'%s' contains illegal characters"
+msgid "'%s' contains invalid character(s)"
 msgstr "문자열 '%s' 에는 알파벳 이외의 문자가 입력되었습니다."
 
-#: ../src/common/valtext.cpp:254
-#, fuzzy, c-format
-msgid "'%s' doesn't consist only of valid characters"
-msgstr "문자열 '%s' 에는 알파벳 이외의 문자가 입력되었습니다."
-
-#: ../src/common/config.cpp:519 ../src/msw/regconf.cpp:258
+#: ../src/common/config.cpp:515 ../src/msw/regconf.cpp:255
 #, c-format
 msgid "'%s' has extra '..', ignored."
 msgstr "'%s' 에서  '..' 는 무시합니다."
 
-#: ../src/common/cmdline.cpp:1113 ../src/common/cmdline.cpp:1131
+#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "잘못된 숫자 '%s' 가 '%s' 에 입력 되었습니다."
 
-#: ../src/common/translation.cpp:1100
+#: ../src/common/translation.cpp:1142
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s'은 메시지 카탈로그가 아닙니다."
 
-#: ../src/common/valtext.cpp:165
+#: ../src/common/valtext.cpp:188
 #, fuzzy, c-format
 msgid "'%s' is not one of the valid strings"
 msgstr "'%s'은 메시지 카탈로그가 아닙니다."
 
-#: ../src/common/valtext.cpp:167
+#: ../src/common/valtext.cpp:186
 #, fuzzy, c-format
 msgid "'%s' is one of the invalid strings"
 msgstr "'%s'이(가) 잘못되었습니다"
 
-#: ../src/common/textbuf.cpp:237
+#: ../src/common/textbuf.cpp:233
 #, c-format
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' 는 이진 버퍼 입니다."
-
-#: ../src/common/valtext.cpp:252
-#, c-format
-msgid "'%s' should be numeric."
-msgstr "'%s' 에 숫자 이외의 문자가 입력되었습니다."
-
-#: ../src/common/valtext.cpp:244
-#, c-format
-msgid "'%s' should only contain ASCII characters."
-msgstr "문자열 '%s' 에는 ASCII 이외의 문자가 입력되었습니다."
-
-#: ../src/common/valtext.cpp:246
-#, c-format
-msgid "'%s' should only contain alphabetic characters."
-msgstr "문자열 '%s' 에는 알파벳 이외의 문자가 입력되었습니다."
-
-#: ../src/common/valtext.cpp:248
-#, c-format
-msgid "'%s' should only contain alphabetic or numeric characters."
-msgstr "문자열 '%s' 에는 알파벳 및 숫자 이외의 문자가 입력되었습니다."
-
-#: ../src/common/valtext.cpp:250
-#, fuzzy, c-format
-msgid "'%s' should only contain digits."
-msgstr "문자열 '%s' 에는 ASCII 이외의 문자가 입력되었습니다."
 
 #: ../src/richtext/richtextliststylepage.cpp:229
 #: ../src/richtext/richtextbulletspage.cpp:166
 msgid "(*)"
 msgstr "(*)"
 
-#: ../src/html/helpwnd.cpp:963
+#: ../src/html/helpwnd.cpp:961
 msgid "(Help)"
 msgstr "(도움말)"
 
@@ -886,27 +877,32 @@ msgstr "(도움말)"
 msgid "(None)"
 msgstr "(없음)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:504
+#: ../src/richtext/richtextsymboldlg.cpp:503
 msgid "(Normal text)"
 msgstr "(일반 텍스트)"
 
-#: ../src/html/helpwnd.cpp:419 ../src/html/helpwnd.cpp:1106
-#: ../src/html/helpwnd.cpp:1742
+#: ../src/html/helpwnd.cpp:417 ../src/html/helpwnd.cpp:1104
+#: ../src/html/helpwnd.cpp:1740
 msgid "(bookmarks)"
 msgstr "(책갈피)"
 
+#: ../src/msw/dlmsw.cpp:167
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (오류 %ld: %s)"
+
+#: ../src/richtext/richtextformatdlg.cpp:876
+#: ../src/richtext/richtextliststylepage.cpp:448
+#: ../src/richtext/richtextliststylepage.cpp:460
+#: ../src/richtext/richtextliststylepage.cpp:461
 #: ../src/richtext/richtextindentspage.cpp:274
 #: ../src/richtext/richtextindentspage.cpp:286
 #: ../src/richtext/richtextindentspage.cpp:287
 #: ../src/richtext/richtextindentspage.cpp:311
 #: ../src/richtext/richtextindentspage.cpp:326
-#: ../src/richtext/richtextformatdlg.cpp:884
 #: ../src/richtext/richtextfontpage.cpp:349
 #: ../src/richtext/richtextfontpage.cpp:353
 #: ../src/richtext/richtextfontpage.cpp:357
-#: ../src/richtext/richtextliststylepage.cpp:448
-#: ../src/richtext/richtextliststylepage.cpp:460
-#: ../src/richtext/richtextliststylepage.cpp:461
 msgid "(none)"
 msgstr "(없음)"
 
@@ -925,7 +921,7 @@ msgstr "*)"
 msgid "+"
 msgstr "+"
 
-#: ../src/msw/utils.cpp:1152
+#: ../src/msw/utils.cpp:1143
 msgid ", 64-bit edition"
 msgstr ""
 
@@ -934,171 +930,171 @@ msgstr ""
 msgid "-"
 msgstr "-"
 
-#: ../src/generic/filepickerg.cpp:66
+#: ../src/generic/filepickerg.cpp:63
 msgid "..."
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:276
 #: ../src/richtext/richtextliststylepage.cpp:450
+#: ../src/richtext/richtextindentspage.cpp:276
 #, fuzzy
 msgid "1.1"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:277
 #: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextindentspage.cpp:277
 #, fuzzy
 msgid "1.2"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:278
 #: ../src/richtext/richtextliststylepage.cpp:452
+#: ../src/richtext/richtextindentspage.cpp:278
 #, fuzzy
 msgid "1.3"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:279
 #: ../src/richtext/richtextliststylepage.cpp:453
+#: ../src/richtext/richtextindentspage.cpp:279
 #, fuzzy
 msgid "1.4"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:280
 #: ../src/richtext/richtextliststylepage.cpp:454
+#: ../src/richtext/richtextindentspage.cpp:280
 msgid "1.5"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:281
 #: ../src/richtext/richtextliststylepage.cpp:455
+#: ../src/richtext/richtextindentspage.cpp:281
 #, fuzzy
 msgid "1.6"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:282
 #: ../src/richtext/richtextliststylepage.cpp:456
+#: ../src/richtext/richtextindentspage.cpp:282
 #, fuzzy
 msgid "1.7"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:283
 #: ../src/richtext/richtextliststylepage.cpp:457
+#: ../src/richtext/richtextindentspage.cpp:283
 #, fuzzy
 msgid "1.8"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:284
 #: ../src/richtext/richtextliststylepage.cpp:458
+#: ../src/richtext/richtextindentspage.cpp:284
 #, fuzzy
 msgid "1.9"
 msgstr "1.5"
 
-#: ../src/common/paper.cpp:140
+#: ../src/common/paper.cpp:137
 msgid "10 x 11 in"
 msgstr "10 x 11 in"
 
-#: ../src/common/paper.cpp:113
+#: ../src/common/paper.cpp:110
 msgid "10 x 14 in"
 msgstr "10 x 14 in"
 
-#: ../src/common/paper.cpp:114
+#: ../src/common/paper.cpp:111
 msgid "11 x 17 in"
 msgstr "11 x 17 in"
 
-#: ../src/common/paper.cpp:184
+#: ../src/common/paper.cpp:181
 msgid "12 x 11 in"
 msgstr "12 x 11 in"
 
-#: ../src/common/paper.cpp:141
+#: ../src/common/paper.cpp:138
 msgid "15 x 11 in"
 msgstr "15 x 11 in"
 
-#: ../src/richtext/richtextindentspage.cpp:285
 #: ../src/richtext/richtextliststylepage.cpp:459
+#: ../src/richtext/richtextindentspage.cpp:285
 msgid "2"
 msgstr "2"
 
-#: ../src/common/paper.cpp:132
+#: ../src/common/paper.cpp:129
 msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
 msgstr "6 3/4 봉투, 3 5/8 x 6 1/2 in"
 
-#: ../src/common/paper.cpp:139
+#: ../src/common/paper.cpp:136
 msgid "9 x 11 in"
 msgstr "확대(_I)"
 
-#: ../src/html/htmprint.cpp:431
+#: ../src/html/htmprint.cpp:443
 msgid ": file does not exist!"
 msgstr ": 파일이 존재하지 않습니다!"
 
-#: ../src/common/fontmap.cpp:199
+#: ../src/common/fontmap.cpp:196
 msgid ": unknown charset"
 msgstr ": 알 수 없는 문자셋"
 
-#: ../src/common/fontmap.cpp:413
+#: ../src/common/fontmap.cpp:410
 msgid ": unknown encoding"
 msgstr ": 알 수 없는 문자 인코딩"
 
-#: ../src/generic/wizard.cpp:443
+#: ../src/generic/wizard.cpp:438
 msgid "< &Back"
 msgstr "< &뒤로"
 
-#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:628
-#: ../src/osx/carbon/fontdlg.cpp:648
+#: ../src/osx/carbon/fontdlg.cpp:419 ../src/osx/carbon/fontdlg.cpp:625
+#: ../src/osx/carbon/fontdlg.cpp:645
 msgid "<Any Decorative>"
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:630
-#: ../src/osx/carbon/fontdlg.cpp:650
+#: ../src/osx/carbon/fontdlg.cpp:420 ../src/osx/carbon/fontdlg.cpp:627
+#: ../src/osx/carbon/fontdlg.cpp:647
 msgid "<Any Modern>"
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:626
-#: ../src/osx/carbon/fontdlg.cpp:646
+#: ../src/osx/carbon/fontdlg.cpp:418 ../src/osx/carbon/fontdlg.cpp:623
+#: ../src/osx/carbon/fontdlg.cpp:643
 msgid "<Any Roman>"
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:424 ../src/osx/carbon/fontdlg.cpp:632
-#: ../src/osx/carbon/fontdlg.cpp:652
+#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:629
+#: ../src/osx/carbon/fontdlg.cpp:649
 msgid "<Any Script>"
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:425 ../src/osx/carbon/fontdlg.cpp:637
-#: ../src/osx/carbon/fontdlg.cpp:656
+#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:634
+#: ../src/osx/carbon/fontdlg.cpp:653
 msgid "<Any Swiss>"
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:426 ../src/osx/carbon/fontdlg.cpp:634
-#: ../src/osx/carbon/fontdlg.cpp:654
+#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:631
+#: ../src/osx/carbon/fontdlg.cpp:651
 msgid "<Any Teletype>"
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:420
+#: ../src/osx/carbon/fontdlg.cpp:417
 msgid "<Any>"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
 msgid "<DIR>"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:254 ../src/generic/filectrlg.cpp:277
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
 msgid "<DRIVE>"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:252 ../src/generic/filectrlg.cpp:275
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
 msgid "<LINK>"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1264
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>굵게 기울임 모습.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1270
+#: ../src/html/helpwnd.cpp:1268
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>굵게 기울임 <u>밑줄</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1265
+#: ../src/html/helpwnd.cpp:1263
 msgid "<b>Bold face.</b> "
 msgstr "<b>굵게 모습.</b> "
 
-#: ../src/html/helpwnd.cpp:1264
+#: ../src/html/helpwnd.cpp:1262
 msgid "<i>Italic face.</i> "
 msgstr "<i>기울임 모습.</i> "
 
@@ -1107,16 +1103,16 @@ msgstr "<i>기울임 모습.</i> "
 msgid ">"
 msgstr ">"
 
-#: ../src/generic/dbgrptg.cpp:318
+#: ../src/generic/dbgrptg.cpp:317
 msgid "A debug report has been generated in the directory\n"
 msgstr "디버그 보고서가 다음 디렉토리에 생성되었습니다\n"
 
-#: ../src/common/debugrpt.cpp:573
+#: ../src/common/debugrpt.cpp:574
 msgid "A debug report has been generated. It can be found in"
 msgstr ""
 "디버그 보고서가 생성되었습니다. 다음의 디렉토리에서 확인 하실 수 있습니다."
 
-#: ../src/common/xtixml.cpp:418
+#: ../src/common/xtixml.cpp:414
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "CollectionType 'element' 노드로 구성되어야 합니다."
 
@@ -1127,109 +1123,109 @@ msgstr "CollectionType 'element' 노드로 구성되어야 합니다."
 msgid "A standard bullet name."
 msgstr "표준 글머리 이름."
 
-#: ../src/common/paper.cpp:217
+#: ../src/common/paper.cpp:214
 #, fuzzy
 msgid "A0 sheet, 841 x 1189 mm"
 msgstr "A4 용지, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:218
+#: ../src/common/paper.cpp:215
 #, fuzzy
 msgid "A1 sheet, 594 x 841 mm"
 msgstr "A3 용지, 297 x 420 mm"
 
-#: ../src/common/paper.cpp:159
+#: ../src/common/paper.cpp:156
 msgid "A2 420 x 594 mm"
 msgstr "A2 420 x 594 mm"
 
-#: ../src/common/paper.cpp:156
+#: ../src/common/paper.cpp:153
 msgid "A3 Extra 322 x 445 mm"
 msgstr "A3 Extra 322 x 445 mm"
 
-#: ../src/common/paper.cpp:161
+#: ../src/common/paper.cpp:158
 msgid "A3 Extra Transverse 322 x 445 mm"
 msgstr "A3 Extra Transverse 322 x 445 mm"
 
-#: ../src/common/paper.cpp:170
+#: ../src/common/paper.cpp:167
 msgid "A3 Rotated 420 x 297 mm"
 msgstr "A3 Rotated 420 x 297 mm"
 
-#: ../src/common/paper.cpp:160
+#: ../src/common/paper.cpp:157
 msgid "A3 Transverse 297 x 420 mm"
 msgstr "A3 Transverse 297 x 420 mm"
 
-#: ../src/common/paper.cpp:106
+#: ../src/common/paper.cpp:103
 msgid "A3 sheet, 297 x 420 mm"
 msgstr "A3 용지, 297 x 420 mm"
 
-#: ../src/common/paper.cpp:146
+#: ../src/common/paper.cpp:143
 msgid "A4 Extra 9.27 x 12.69 in"
 msgstr "A4 Extra 9.27 x 12.69 in"
 
-#: ../src/common/paper.cpp:153
+#: ../src/common/paper.cpp:150
 msgid "A4 Plus 210 x 330 mm"
 msgstr "A4 Plus 210 x 330 mm"
 
-#: ../src/common/paper.cpp:171
+#: ../src/common/paper.cpp:168
 msgid "A4 Rotated 297 x 210 mm"
 msgstr "A4 Rotated 297 x 210 mm"
 
-#: ../src/common/paper.cpp:148
+#: ../src/common/paper.cpp:145
 msgid "A4 Transverse 210 x 297 mm"
 msgstr "A4 Transverse 210 x 297 mm"
 
-#: ../src/common/paper.cpp:97
+#: ../src/common/paper.cpp:94
 msgid "A4 sheet, 210 x 297 mm"
 msgstr "A4 용지, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:107
+#: ../src/common/paper.cpp:104
 msgid "A4 small sheet, 210 x 297 mm"
 msgstr "A4 small sheet, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:157
+#: ../src/common/paper.cpp:154
 msgid "A5 Extra 174 x 235 mm"
 msgstr "A5 Extra 174 x 235 mm"
 
-#: ../src/common/paper.cpp:172
+#: ../src/common/paper.cpp:169
 msgid "A5 Rotated 210 x 148 mm"
 msgstr "A5 Rotated 210 x 148 mm"
 
-#: ../src/common/paper.cpp:154
+#: ../src/common/paper.cpp:151
 msgid "A5 Transverse 148 x 210 mm"
 msgstr "A5 Transverse 148 x 210 mm"
 
-#: ../src/common/paper.cpp:108
+#: ../src/common/paper.cpp:105
 msgid "A5 sheet, 148 x 210 mm"
 msgstr "A5 용지, 148 x 210 mm"
 
-#: ../src/common/paper.cpp:164
+#: ../src/common/paper.cpp:161
 msgid "A6 105 x 148 mm"
 msgstr "A6 105 x 148 mm"
 
-#: ../src/common/paper.cpp:177
+#: ../src/common/paper.cpp:174
 msgid "A6 Rotated 148 x 105 mm"
 msgstr "A6 Rotated 148 x 105 mm"
 
-#: ../src/generic/fontdlgg.cpp:83 ../src/richtext/richtextformatdlg.cpp:529
-#: ../src/osx/carbon/fontdlg.cpp:153
+#: ../src/osx/carbon/fontdlg.cpp:150 ../src/generic/fontdlgg.cpp:79
+#: ../src/richtext/richtextformatdlg.cpp:521
 msgid "ABCDEFGabcdefg12345"
 msgstr "ABCDEFGabcdefg12345"
 
-#: ../src/richtext/richtextsymboldlg.cpp:458 ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
 msgid "ASCII"
 msgstr "아스키"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 #, fuzzy
 msgid "About"
 msgstr "이 프로그램은(&A)"
 
-#: ../src/generic/aboutdlgg.cpp:140 ../src/osx/menu_osx.cpp:558
-#: ../src/msw/aboutdlg.cpp:64
+#: ../src/osx/menu_osx.cpp:450 ../src/generic/aboutdlgg.cpp:137
+#: ../src/msw/aboutdlg.cpp:61
 #, c-format
 msgid "About %s"
 msgstr "%s 정보"
 
-#: ../src/osx/menu_osx.cpp:560
+#: ../src/osx/menu_osx.cpp:452
 #, fuzzy
 msgid "About..."
 msgstr "이 프로그램은(&A)"
@@ -1239,39 +1235,39 @@ msgid "Absolute"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:873
+#: ../src/propgrid/advprops.cpp:774
 #, fuzzy
 msgid "ActiveBorder"
 msgstr "Modern"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:874
+#: ../src/propgrid/advprops.cpp:775
 msgid "ActiveCaption"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 #, fuzzy
 msgid "Actual Size"
 msgstr "실제 크기(&A)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:140 ../src/common/accelcmn.cpp:81
+#: ../src/common/stockitem.cpp:137 ../src/common/accelcmn.cpp:78
 msgid "Add"
 msgstr "추가"
 
-#: ../src/richtext/richtextbuffer.cpp:11455
+#: ../src/richtext/richtextbuffer.cpp:11454
 msgid "Add Column"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11392
+#: ../src/richtext/richtextbuffer.cpp:11391
 msgid "Add Row"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:432
+#: ../src/html/helpwnd.cpp:430
 msgid "Add current page to bookmarks"
 msgstr "현재 페이지를 책갈피에 추가 합니다."
 
-#: ../src/generic/colrdlgg.cpp:366
+#: ../src/generic/colrdlgg.cpp:386
 msgid "Add to custom colours"
 msgstr "사용자 색상 추가"
 
@@ -1283,12 +1279,12 @@ msgstr ""
 msgid "AddToPropertyCollection called w/o valid adder"
 msgstr ""
 
-#: ../src/html/helpctrl.cpp:159
+#: ../src/html/helpctrl.cpp:155
 #, c-format
 msgid "Adding book %s"
 msgstr "'%s' 북파일 추가"
 
-#: ../src/common/preferencescmn.cpp:43
+#: ../src/common/preferencescmn.cpp:40
 msgid "Advanced"
 msgstr ""
 
@@ -1296,11 +1292,11 @@ msgstr ""
 msgid "After a paragraph:"
 msgstr "단락 후:"
 
-#: ../src/common/stockitem.cpp:172
+#: ../src/common/stockitem.cpp:169
 msgid "Align Left"
 msgstr "왼쪽 정렬"
 
-#: ../src/common/stockitem.cpp:173
+#: ../src/common/stockitem.cpp:170
 msgid "Align Right"
 msgstr "오른쪽 정렬"
 
@@ -1309,40 +1305,40 @@ msgstr "오른쪽 정렬"
 msgid "Alignment"
 msgstr "정렬(&A)"
 
-#: ../src/generic/prntdlgg.cpp:215
+#: ../src/generic/prntdlgg.cpp:208
 msgid "All"
 msgstr "모두"
 
-#: ../src/generic/filectrlg.cpp:1197 ../src/common/fldlgcmn.cpp:107
+#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1186
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "모든 파일 (%s)|%s"
 
-#: ../include/wx/defs.h:2886
+#: ../include/wx/defs.h:2582
 msgid "All files (*)|*"
 msgstr "모든 파일 (*)|*"
 
-#: ../include/wx/defs.h:2883
+#: ../include/wx/defs.h:2579
 msgid "All files (*.*)|*.*"
 msgstr "모든 파일 (*.*)|*.*"
 
-#: ../src/richtext/richtextstyles.cpp:1061
+#: ../src/richtext/richtextstyles.cpp:1058
 msgid "All styles"
 msgstr "모든 모양새"
 
-#: ../src/propgrid/manager.cpp:1528
+#: ../src/propgrid/manager.cpp:1544
 msgid "Alphabetic Mode"
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:425
+#: ../src/common/xtistrm.cpp:422
 msgid "Already Registered Object passed to SetObjectClassInfo"
 msgstr "이미 등록된 객체입니다(SetObjectClassInfo) "
 
-#: ../src/unix/dialup.cpp:353
+#: ../src/unix/dialup.cpp:352
 msgid "Already dialling ISP."
 msgstr "이미 ISP에 전화 연결중입니다."
 
-#: ../src/common/accelcmn.cpp:331 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/accelcmn.cpp:345 ../src/univ/themes/win32.cpp:3753
 msgid "Alt+"
 msgstr ""
 
@@ -1351,36 +1347,36 @@ msgstr ""
 msgid "An optional corner radius for adding rounded corners."
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:576
+#: ../src/common/debugrpt.cpp:577
 msgid "And includes the following files:\n"
 msgstr "그리고 다음의 파일들을 포함하고 있습니다:\n"
 
-#: ../src/generic/animateg.cpp:162
+#: ../src/generic/animateg.cpp:145
 #, c-format
 msgid "Animation file is not of type %ld."
 msgstr "%ld 타입은 애니매이션 파일이 아닙니다."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:872
+#: ../src/propgrid/advprops.cpp:773
 msgid "AppWorkspace"
 msgstr ""
 
-#: ../src/generic/logg.cpp:1014
+#: ../src/generic/logg.cpp:1011
 #, c-format
 msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
 msgstr "'%s' 파일에 로그를 추가 하시겠습니까 (아니요 시 덮어쓰기 수행)?"
 
-#: ../src/osx/menu_osx.cpp:577 ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:469 ../src/osx/menu_osx.cpp:477
 #, fuzzy
 msgid "Application"
 msgstr "선택"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 #, fuzzy
 msgid "Apply"
 msgstr "적용(&A)"
 
-#: ../src/propgrid/advprops.cpp:1609
+#: ../src/propgrid/advprops.cpp:1515
 msgid "Aqua"
 msgstr ""
 
@@ -1389,31 +1385,31 @@ msgstr ""
 msgid "Arabic"
 msgstr "아랍어"
 
-#: ../src/common/fmapbase.cpp:153
+#: ../src/common/fmapbase.cpp:150
 msgid "Arabic (ISO-8859-6)"
 msgstr "아랍어 (ISO-8859-6)"
 
-#: ../src/msw/ole/automtn.cpp:672
+#: ../src/msw/ole/automtn.cpp:663
 #, fuzzy, c-format
 msgid "Argument %u not found."
 msgstr "Column index를 찾을수 없습니다."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1753
+#: ../src/propgrid/advprops.cpp:1654
 #, fuzzy
 msgid "Arrow"
 msgstr "내일"
 
-#: ../src/generic/aboutdlgg.cpp:184
+#: ../src/generic/aboutdlgg.cpp:181
 msgid "Artists"
 msgstr "Artists"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 #, fuzzy
 msgid "Ascending"
 msgstr "인코딩 %i"
 
-#: ../src/generic/filectrlg.cpp:433
+#: ../src/generic/filectrlg.cpp:429
 msgid "Attributes"
 msgstr "속성"
 
@@ -1423,91 +1419,91 @@ msgstr "속성"
 msgid "Available fonts."
 msgstr "사용가능한 글꼴"
 
-#: ../src/common/paper.cpp:137
+#: ../src/common/paper.cpp:134
 msgid "B4 (ISO) 250 x 353 mm"
 msgstr "B4 (ISO) 250 x 353 mm"
 
-#: ../src/common/paper.cpp:173
+#: ../src/common/paper.cpp:170
 msgid "B4 (JIS) Rotated 364 x 257 mm"
 msgstr "B4 (JIS) Rotated 364 x 257 mm"
 
-#: ../src/common/paper.cpp:127
+#: ../src/common/paper.cpp:124
 msgid "B4 Envelope, 250 x 353 mm"
 msgstr "B4 봉투, 250 x 353 mm"
 
-#: ../src/common/paper.cpp:109
+#: ../src/common/paper.cpp:106
 msgid "B4 sheet, 250 x 354 mm"
 msgstr "B4 용지, 250 x 354 mm"
 
-#: ../src/common/paper.cpp:158
+#: ../src/common/paper.cpp:155
 msgid "B5 (ISO) Extra 201 x 276 mm"
 msgstr "B5 (ISO) Extra 201 x 276 mm"
 
-#: ../src/common/paper.cpp:174
+#: ../src/common/paper.cpp:171
 msgid "B5 (JIS) Rotated 257 x 182 mm"
 msgstr "B5 (JIS) Rotated 257 x 182 mm"
 
-#: ../src/common/paper.cpp:155
+#: ../src/common/paper.cpp:152
 msgid "B5 (JIS) Transverse 182 x 257 mm"
 msgstr "B5 (JIS) Transverse 182 x 257 mm"
 
-#: ../src/common/paper.cpp:128
+#: ../src/common/paper.cpp:125
 msgid "B5 Envelope, 176 x 250 mm"
 msgstr "B5 봉투, 176 x 250 mm"
 
-#: ../src/common/paper.cpp:110
+#: ../src/common/paper.cpp:107
 msgid "B5 sheet, 182 x 257 millimeter"
 msgstr "B5 용지, 182 x 257 millimeter"
 
-#: ../src/common/paper.cpp:182
+#: ../src/common/paper.cpp:179
 msgid "B6 (JIS) 128 x 182 mm"
 msgstr "B6 (JIS) 128 x 182 mm"
 
-#: ../src/common/paper.cpp:183
+#: ../src/common/paper.cpp:180
 msgid "B6 (JIS) Rotated 182 x 128 mm"
 msgstr "B6 (JIS) Rotated 182 x 128 mm"
 
-#: ../src/common/paper.cpp:129
+#: ../src/common/paper.cpp:126
 msgid "B6 Envelope, 176 x 125 mm"
 msgstr "B6 봉투, 176 x 125 mm"
 
-#: ../src/common/imagbmp.cpp:531 ../src/common/imagbmp.cpp:561
-#: ../src/common/imagbmp.cpp:576
+#: ../src/common/imagbmp.cpp:528 ../src/common/imagbmp.cpp:558
+#: ../src/common/imagbmp.cpp:573
 msgid "BMP: Couldn't allocate memory."
 msgstr "BMP: 메모리 할당 실패"
 
-#: ../src/common/imagbmp.cpp:100
+#: ../src/common/imagbmp.cpp:97
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: 잘못된 이미지입니다. 저장할수 없음"
 
-#: ../src/common/imagbmp.cpp:356
+#: ../src/common/imagbmp.cpp:353
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: RGB 색상표(color map)를 사용한 쓰기 실패"
 
-#: ../src/common/imagbmp.cpp:490
+#: ../src/common/imagbmp.cpp:487
 msgid "BMP: Couldn't write data."
 msgstr "BMP: 데이타 쓰기 실패"
 
-#: ../src/common/imagbmp.cpp:246
+#: ../src/common/imagbmp.cpp:243
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: 비트맵 해더를 작성할수 없습니다."
 
-#: ../src/common/imagbmp.cpp:269
+#: ../src/common/imagbmp.cpp:266
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: 비트맵 해더정보를 작성할수 없습니다."
 
-#: ../src/common/imagbmp.cpp:140
+#: ../src/common/imagbmp.cpp:137
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage가 wxPalette를 가지고 있지 않습니다."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:142 ../src/common/accelcmn.cpp:52
+#: ../src/common/stockitem.cpp:139 ../src/common/accelcmn.cpp:49
 #, fuzzy
 msgid "Back"
 msgstr "뒤로(&B)"
 
+#: ../src/richtext/richtextformatdlg.cpp:377
 #: ../src/richtext/richtextbackgroundpage.cpp:148
-#: ../src/richtext/richtextformatdlg.cpp:384
 #, fuzzy
 msgid "Background"
 msgstr "배경 색"
@@ -1517,21 +1513,21 @@ msgstr "배경 색"
 msgid "Background &colour:"
 msgstr "배경 색"
 
-#: ../src/osx/carbon/fontdlg.cpp:220
+#: ../src/osx/carbon/fontdlg.cpp:217
 msgid "Background colour"
 msgstr "배경 색"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:52
+#: ../src/common/accelcmn.cpp:49
 #, fuzzy
 msgid "Backspace"
 msgstr "뒤로(&B)"
 
-#: ../src/common/fmapbase.cpp:160
+#: ../src/common/fmapbase.cpp:157
 msgid "Baltic (ISO-8859-13)"
 msgstr "발트어 (ISO-8859-13)"
 
-#: ../src/common/fmapbase.cpp:151
+#: ../src/common/fmapbase.cpp:148
 msgid "Baltic (old) (ISO-8859-4)"
 msgstr "발트어 (old)(ISO-8859-13)"
 
@@ -1544,25 +1540,25 @@ msgstr "단락 전:"
 msgid "Bitmap"
 msgstr "비트맵"
 
-#: ../src/propgrid/advprops.cpp:1594
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Black"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1755
+#: ../src/propgrid/advprops.cpp:1656
 msgid "Blank"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1603
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Blue"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:345
+#: ../src/generic/colrdlgg.cpp:365
 msgid "Blue:"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:333 ../src/richtext/richtextfontpage.cpp:355
-#: ../src/osx/carbon/fontdlg.cpp:354 ../src/common/stockitem.cpp:143
+#: ../src/osx/carbon/fontdlg.cpp:351 ../src/common/stockitem.cpp:140
+#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:355
 msgid "Bold"
 msgstr "굵게"
 
@@ -1572,35 +1568,39 @@ msgstr "굵게"
 msgid "Border"
 msgstr "Modern"
 
-#: ../src/richtext/richtextformatdlg.cpp:379
+#: ../src/richtext/richtextformatdlg.cpp:372
 #, fuzzy
 msgid "Borders"
 msgstr "Modern"
 
-#: ../src/richtext/richtextsizepage.cpp:288 ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141 ../src/richtext/richtextsizepage.cpp:288
 msgid "Bottom"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:893
+#: ../src/generic/prntdlgg.cpp:886
 msgid "Bottom margin (mm):"
 msgstr "버튼 여백(mm):"
 
-#: ../src/richtext/richtextbuffer.cpp:9383
+#: ../src/richtext/richtextbuffer.cpp:9380
 #, fuzzy
 msgid "Box Properties"
 msgstr "특성(&P)"
 
-#: ../src/richtext/richtextstyles.cpp:1065
+#: ../src/richtext/richtextstyles.cpp:1062
 #, fuzzy
 msgid "Box styles"
 msgstr "모든 모양새"
 
-#: ../src/propgrid/advprops.cpp:1602
+#: ../src/osx/cocoa/menu.mm:292
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1508
 #, fuzzy
 msgid "Brown"
 msgstr "탐색창"
 
-#: ../src/common/filepickercmn.cpp:43 ../src/common/filepickercmn.cpp:44
+#: ../src/common/filepickercmn.cpp:40 ../src/common/filepickercmn.cpp:41
 msgid "Browse"
 msgstr "탐색창"
 
@@ -1613,73 +1613,73 @@ msgstr "글머리 정렬(&A)"
 msgid "Bullet style"
 msgstr "글머리 모양새"
 
-#: ../src/richtext/richtextformatdlg.cpp:359
+#: ../src/richtext/richtextformatdlg.cpp:352
 msgid "Bullets"
 msgstr "글머리"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1756
+#: ../src/propgrid/advprops.cpp:1657
 #, fuzzy
 msgid "Bullseye"
 msgstr "글머리 모양새"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:875
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonFace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:876
+#: ../src/propgrid/advprops.cpp:777
 msgid "ButtonHighlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:877
+#: ../src/propgrid/advprops.cpp:778
 msgid "ButtonShadow"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:878
+#: ../src/propgrid/advprops.cpp:779
 msgid "ButtonText"
 msgstr ""
 
-#: ../src/common/paper.cpp:98
+#: ../src/common/paper.cpp:95
 msgid "C sheet, 17 x 22 in"
 msgstr "C 용지, 17 x 22 in"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "C&lear"
 msgstr "지우기(&L)"
 
-#: ../src/generic/fontdlgg.cpp:406
+#: ../src/generic/fontdlgg.cpp:403
 msgid "C&olour:"
 msgstr "색상(&O):"
 
-#: ../src/common/paper.cpp:123
+#: ../src/common/paper.cpp:120
 msgid "C3 Envelope, 324 x 458 mm"
 msgstr "C3 봉투, 324 x 458 mm"
 
-#: ../src/common/paper.cpp:124
+#: ../src/common/paper.cpp:121
 msgid "C4 Envelope, 229 x 324 mm"
 msgstr "C4 봉투, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:122
+#: ../src/common/paper.cpp:119
 msgid "C5 Envelope, 162 x 229 mm"
 msgstr "C5 봉투, 162 x 229 mm"
 
-#: ../src/common/paper.cpp:125
+#: ../src/common/paper.cpp:122
 msgid "C6 Envelope, 114 x 162 mm"
 msgstr "C6 봉투, 114 x 162 mm"
 
-#: ../src/common/paper.cpp:126
+#: ../src/common/paper.cpp:123
 msgid "C65 Envelope, 114 x 229 mm"
 msgstr "C65 봉투, 114 x 229 mm"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "CD-Rom"
 msgstr ""
 
-#: ../src/html/chm.cpp:815 ../src/html/chm.cpp:874
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:865
 msgid "CHM handler currently supports only local files!"
 msgstr "CHM 헤더는 현재 로컬 파일만을 지원합니다."
 
@@ -1687,191 +1687,195 @@ msgstr "CHM 헤더는 현재 로컬 파일만을 지원합니다."
 msgid "Ca&pitals"
 msgstr "대문자(&P)"
 
-#: ../src/common/cmdproc.cpp:267
+#: ../src/common/cmdproc.cpp:260
 msgid "Can't &Undo "
 msgstr "&실행취소 안됨"
 
-#: ../src/common/image.cpp:2824
+#: ../src/common/image.cpp:2924
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 
-#: ../src/msw/registry.cpp:506
+#: ../src/msw/registry.cpp:495
 #, c-format
 msgid "Can't close registry key '%s'"
 msgstr "레지스터 키 '%s'  닫을 수 없습니다"
 
-#: ../src/msw/registry.cpp:584
+#: ../src/msw/registry.cpp:573
 #, c-format
 msgid "Can't copy values of unsupported type %d."
 msgstr "%d는 지원되지 않는 데이타 타입으로 레지스트 값 복사 할 수 없습니다"
 
-#: ../src/msw/registry.cpp:487
+#: ../src/msw/registry.cpp:476
 #, c-format
 msgid "Can't create registry key '%s'"
 msgstr "레지스터 키 '%s'  생성 할 수 없습니다"
 
-#: ../src/msw/thread.cpp:665
+#: ../src/msw/thread.cpp:657
 msgid "Can't create thread"
 msgstr "쓰레드 생성 할 수 없습니다"
 
-#: ../src/msw/window.cpp:3691
-#, c-format
-msgid "Can't create window of class %s"
-msgstr "클래스 %s 에서 윈도우생성 할 수 없습니다"
-
-#: ../src/msw/registry.cpp:777
+#: ../src/msw/registry.cpp:765
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "레지스터 키 '%s'  삭제 할 수 없습니다"
 
-#: ../src/msw/iniconf.cpp:458
+#: ../src/msw/iniconf.cpp:455
 #, c-format
 msgid "Can't delete the INI file '%s'"
 msgstr "'%s' INI 파일을 삭제할 수 없습니다."
 
-#: ../src/msw/registry.cpp:805
+#: ../src/msw/registry.cpp:793
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "레지스터 값 '%s' 을 지울수 없습니다(레지스터 키 '%s' 에서)"
 
-#: ../src/msw/registry.cpp:1171
+#: ../src/msw/registry.cpp:1159
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "레지스터 키 '%s' 의 하위 키들을 찾을 수 없습니다."
 
-#: ../src/msw/registry.cpp:1132
+#: ../src/msw/registry.cpp:1120
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "레지스터 키값 '%s' 를 찾을 수 없습니다."
 
-#: ../src/msw/registry.cpp:1389
+#: ../src/msw/registry.cpp:1377
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "지원되지 않는 %d 타입의 레지스트 값을 내보낼 수 없습니다."
 
-#: ../src/common/ffile.cpp:254
+#: ../src/common/ffile.cpp:253
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "파일 '%s' 에서 현재 위치를 찾을 수 없습니다."
 
-#: ../src/msw/registry.cpp:418
+#: ../src/msw/registry.cpp:407
 #, c-format
 msgid "Can't get info about registry key '%s'"
 msgstr "레지스터 키 '%s' 의 정보를 가져올 수 없습니다."
 
-#: ../src/common/zstream.cpp:346
+#: ../src/msw/webview_ie.cpp:1024
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "쓰레드 우선 순위를 설정할 수 없습니다."
+
+#: ../src/common/zstream.cpp:343
 msgid "Can't initialize zlib deflate stream."
 msgstr "zlib에서 사용할 압축용 버퍼 할당하지 못했습니다."
 
-#: ../src/common/zstream.cpp:185
+#: ../src/common/zstream.cpp:182
 msgid "Can't initialize zlib inflate stream."
 msgstr "zlib에서 사용할 압축용 버퍼 할당하지 못했습니다."
 
-#: ../src/msw/fswatcher.cpp:476
+#: ../src/msw/fswatcher.cpp:475
 #, c-format
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr ""
 
-#: ../src/msw/registry.cpp:454
+#: ../src/msw/registry.cpp:443
 #, c-format
 msgid "Can't open registry key '%s'"
 msgstr "레지스터 키 '%s' 를 열 수 없습니다."
 
-#: ../src/common/zstream.cpp:252
+#: ../src/common/zstream.cpp:249
 #, c-format
 msgid "Can't read from inflate stream: %s"
 msgstr "압축 해제 실패: %s"
 
-#: ../src/common/zstream.cpp:244
+#: ../src/common/zstream.cpp:241
 msgid "Can't read inflate stream: unexpected EOF in underlying stream."
 msgstr "압축 해제 실패: 압축 데이타가 갑작스럽게 끝났습니다."
 
-#: ../src/msw/registry.cpp:1064
+#: ../src/msw/registry.cpp:1052
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "레지스터 키값 '%s' 를 읽을 수 없습니다."
 
-#: ../src/msw/registry.cpp:878 ../src/msw/registry.cpp:910
-#: ../src/msw/registry.cpp:975
+#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
+#: ../src/msw/registry.cpp:963
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "레지스터 키값 '%s' 를 읽을 수 없습니다."
 
-#: ../src/common/image.cpp:2620
+#: ../src/msw/webview_ie.cpp:1017
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/common/image.cpp:2715
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "이미지를 파일 '%s'에 저장할수 없음: 이미지 핸들러를 찾을 수 없습니다."
 
-#: ../src/generic/logg.cpp:573 ../src/generic/logg.cpp:976
+#: ../src/generic/logg.cpp:570 ../src/generic/logg.cpp:973
 msgid "Can't save log contents to file."
 msgstr "로그를 파일로 저장할 수 없습니다."
 
-#: ../src/msw/thread.cpp:629
+#: ../src/msw/thread.cpp:621
 msgid "Can't set thread priority"
 msgstr "쓰레드 우선 순위를 설정할 수 없습니다."
 
-#: ../src/msw/registry.cpp:896 ../src/msw/registry.cpp:938
-#: ../src/msw/registry.cpp:1081
+#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
+#: ../src/msw/registry.cpp:1069
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "레지스터 키 '%s' 의 값을 설정 할 수 없습니다."
 
-#: ../src/unix/utilsunx.cpp:351
+#: ../src/unix/utilsunx.cpp:353
 #, fuzzy
 msgid "Can't write to child process's stdin"
 msgstr "프로세스 %d 종료할 수 없습니다."
 
-#: ../src/common/zstream.cpp:427
+#: ../src/common/zstream.cpp:424
 #, c-format
 msgid "Can't write to deflate stream: %s"
 msgstr "압축 실패: %s"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:279 ../src/richtext/richtextstyledlg.cpp:300
-#: ../src/common/stockitem.cpp:145 ../src/common/accelcmn.cpp:71
-#: ../src/msw/msgdlg.cpp:454 ../src/msw/progdlg.cpp:673
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:142
+#: ../src/common/accelcmn.cpp:68 ../src/motif/msgdlg.cpp:196
+#: ../src/gtk1/fontdlg.cpp:144 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/progdlg.cpp:940 ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "취소"
 
-#: ../src/common/filefn.cpp:1261
+#: ../src/common/filefn.cpp:1149
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "'%s' 에 해당하는 파일을 찾을 수 없습니다"
 
-#: ../src/msw/dir.cpp:263
+#: ../src/msw/dir.cpp:260
 #, c-format
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "'%s' 폴더에서 파일을 찾을 수 없습니다."
 
-#: ../src/msw/dialup.cpp:523
+#: ../src/msw/dialup.cpp:517
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "동작중인 전화 연결을 찾을수 없습니다: %s"
 
-#: ../src/msw/dialup.cpp:827
+#: ../src/msw/dialup.cpp:821
 msgid "Cannot find the location of address book file"
 msgstr "주소록 파일에서 위치를 찾을 수 없습니다."
 
-#: ../src/msw/ole/automtn.cpp:562
+#: ../src/msw/ole/automtn.cpp:553
 #, fuzzy, c-format
 msgid "Cannot get an active instance of \"%s\""
 msgstr "동작중인 전화 연결을 찾을수 없습니다: %s"
 
-#: ../src/unix/threadpsx.cpp:1035
+#: ../src/unix/threadpsx.cpp:1053
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "스케줄링 정책 %d 에서 우선순위 범위를 얻을 수 없습니다."
 
-#: ../src/unix/utilsunx.cpp:987
+#: ../src/unix/utilsunx.cpp:989
 msgid "Cannot get the hostname"
 msgstr "hostname을 얻을 수 없습니다"
 
-#: ../src/unix/utilsunx.cpp:1023
+#: ../src/unix/utilsunx.cpp:1025
 msgid "Cannot get the official hostname"
 msgstr "공식 hostname을 얻을 수 없습니다"
 
-#: ../src/msw/dialup.cpp:928
+#: ../src/msw/dialup.cpp:922
 msgid "Cannot hang up - no active dialup connection."
 msgstr "접속을 끊을 수 없습니다 - 현재 활성화된 전화 연결이 없습니다."
 
@@ -1879,129 +1883,129 @@ msgstr "접속을 끊을 수 없습니다 - 현재 활성화된 전화 연결이
 msgid "Cannot initialize OLE"
 msgstr "OLE를 초기화할 수 없습니다"
 
-#: ../src/common/socket.cpp:853
+#: ../src/common/socket.cpp:850
 #, fuzzy
 msgid "Cannot initialize sockets"
 msgstr "OLE를 초기화할 수 없습니다"
 
-#: ../src/msw/volume.cpp:619
+#: ../src/msw/volume.cpp:627
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "'%s' 아이콘을 읽어올 수 없습니다."
 
-#: ../src/xrc/xmlres.cpp:360
+#: ../src/xrc/xmlres.cpp:358
 #, fuzzy, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "'%s' 파일에서 리소스를 읽어올 수 없습니다."
 
-#: ../src/xrc/xmlres.cpp:742
+#: ../src/xrc/xmlres.cpp:740
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "'%s' 파일에서 리소스를 읽어올 수 없습니다."
 
-#: ../src/html/htmlfilt.cpp:137
+#: ../src/html/htmlfilt.cpp:134
 #, c-format
 msgid "Cannot open HTML document: %s"
 msgstr "HTML 문서를 열 수 없습니다: %s"
 
-#: ../src/html/helpdata.cpp:667
+#: ../src/html/helpdata.cpp:660
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "HTML 도움말을 열 수 없습니다: %s"
 
-#: ../src/html/helpdata.cpp:299
+#: ../src/html/helpdata.cpp:296
 #, c-format
 msgid "Cannot open contents file: %s"
 msgstr "파일을 열 수 없습니다: %s"
 
-#: ../src/generic/dcpsg.cpp:1667
+#: ../src/generic/dcpsg.cpp:1665
 msgid "Cannot open file for PostScript printing!"
 msgstr "파일을 열수 없습니다. PostScript 파일 인쇄실패"
 
-#: ../src/html/helpdata.cpp:313
+#: ../src/html/helpdata.cpp:310
 #, c-format
 msgid "Cannot open index file: %s"
 msgstr "'%s' 차례 파일을 열 수 없습니다."
 
-#: ../src/xrc/xmlres.cpp:724
+#: ../src/xrc/xmlres.cpp:722
 #, fuzzy, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "'%s' 파일에서 리소스를 읽어올 수 없습니다."
 
-#: ../src/html/helpwnd.cpp:1534
+#: ../src/html/helpwnd.cpp:1532
 msgid "Cannot print empty page."
 msgstr "빈 페이지를 인쇄할 수 없습니다."
 
-#: ../src/msw/volume.cpp:507
+#: ../src/msw/volume.cpp:515
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "'%s' 에서 장치이름을 읽어올 수 없습니다."
 
-#: ../src/msw/thread.cpp:888
+#: ../src/msw/thread.cpp:894
 #, fuzzy, c-format
 msgid "Cannot resume thread %lx"
 msgstr "쓰레드 %x 를 다시시작 할 수 없습니다"
 
-#: ../src/unix/threadpsx.cpp:1016
+#: ../src/unix/threadpsx.cpp:1028
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "스레드 스케줄링 정책을 찾을 수 없습니다."
 
-#: ../src/common/intl.cpp:558
+#: ../src/common/intl.cpp:365
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "\"%s\" 에 대한 언어 로케일을 설정할 수 없습니다."
 
-#: ../src/unix/threadpsx.cpp:831 ../src/msw/thread.cpp:546
+#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
 msgid "Cannot start thread: error writing TLS."
 msgstr "쓰레드 시작 실패: TLS 쓰기 오류."
 
-#: ../src/msw/thread.cpp:872
+#: ../src/msw/thread.cpp:864
 #, fuzzy, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "쓰레드 %x 일시정지 할 수 없습니다"
 
-#: ../src/msw/thread.cpp:794
+#: ../src/msw/thread.cpp:786
 msgid "Cannot wait for thread termination"
 msgstr "쓰레드 종료 실패로 Thread를 강제로 종료합니다"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:75
+#: ../src/common/accelcmn.cpp:72
 #, fuzzy
 msgid "Capital"
 msgstr "대문자(&P)"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:879
+#: ../src/propgrid/advprops.cpp:780
 msgid "CaptionText"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:531
 msgid "Case sensitive"
 msgstr "대/소문자 구분"
 
-#: ../src/propgrid/manager.cpp:1509
+#: ../src/propgrid/manager.cpp:1527
 msgid "Categorized Mode"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9968
+#: ../src/richtext/richtextbuffer.cpp:9965
 #, fuzzy
 msgid "Cell Properties"
 msgstr "특성(&P)"
 
-#: ../src/common/fmapbase.cpp:161
+#: ../src/common/fmapbase.cpp:158
 msgid "Celtic (ISO-8859-14)"
 msgstr "켈트어 (ISO-8859-14)"
 
-#: ../src/richtext/richtextindentspage.cpp:160
 #: ../src/richtext/richtextliststylepage.cpp:349
+#: ../src/richtext/richtextindentspage.cpp:160
 msgid "Cen&tred"
 msgstr "중앙(&T)"
 
-#: ../src/common/stockitem.cpp:170
+#: ../src/common/stockitem.cpp:167
 msgid "Centered"
 msgstr "중앙"
 
-#: ../src/common/fmapbase.cpp:149
+#: ../src/common/fmapbase.cpp:146
 msgid "Central European (ISO-8859-2)"
 msgstr "중앙 유럽어 (ISO-8859-2)"
 
@@ -2010,10 +2014,10 @@ msgstr "중앙 유럽어 (ISO-8859-2)"
 msgid "Centre"
 msgstr "중앙"
 
-#: ../src/richtext/richtextindentspage.cpp:162
-#: ../src/richtext/richtextindentspage.cpp:164
 #: ../src/richtext/richtextliststylepage.cpp:351
 #: ../src/richtext/richtextliststylepage.cpp:353
+#: ../src/richtext/richtextindentspage.cpp:162
+#: ../src/richtext/richtextindentspage.cpp:164
 msgid "Centre text."
 msgstr "텍스트 중앙 정렬."
 
@@ -2027,26 +2031,26 @@ msgstr "중앙(&T)"
 msgid "Ch&oose..."
 msgstr "선택(&o)..."
 
-#: ../src/richtext/richtextbuffer.cpp:4354
+#: ../src/richtext/richtextbuffer.cpp:4351
 msgid "Change List Style"
 msgstr "목록 모양새 바꾸기"
 
-#: ../src/richtext/richtextbuffer.cpp:3709
+#: ../src/richtext/richtextbuffer.cpp:3706
 #, fuzzy
 msgid "Change Object Style"
 msgstr "목록 모양새 바꾸기"
 
-#: ../src/richtext/richtextbuffer.cpp:3982
-#: ../src/richtext/richtextbuffer.cpp:8129
+#: ../src/richtext/richtextbuffer.cpp:3979
+#: ../src/richtext/richtextbuffer.cpp:8125
 #, fuzzy
 msgid "Change Properties"
 msgstr "특성(&P)"
 
-#: ../src/richtext/richtextbuffer.cpp:3526
+#: ../src/richtext/richtextbuffer.cpp:3523
 msgid "Change Style"
 msgstr "모양새 바꾸기"
 
-#: ../src/common/fileconf.cpp:341
+#: ../src/common/fileconf.cpp:335
 #, c-format
 msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
 msgstr ""
@@ -2058,12 +2062,12 @@ msgid "Changing current directory to \"%s\" failed"
 msgstr "디렉토리 \"%s\" 생성을 실패했습니다."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1757
+#: ../src/propgrid/advprops.cpp:1658
 #, fuzzy
 msgid "Character"
 msgstr "문자 코드(&C):"
 
-#: ../src/richtext/richtextstyles.cpp:1063
+#: ../src/richtext/richtextstyles.cpp:1060
 msgid "Character styles"
 msgstr "글꼴 모양새"
 
@@ -2101,20 +2105,20 @@ msgstr "글머리에 괄호추가"
 msgid "Check to indicate right-to-left text layout."
 msgstr "텍스트 색상 변경 하려면 여기를 누르십시오."
 
-#: ../src/osx/carbon/fontdlg.cpp:356 ../src/osx/carbon/fontdlg.cpp:358
+#: ../src/osx/carbon/fontdlg.cpp:353 ../src/osx/carbon/fontdlg.cpp:355
 msgid "Check to make the font bold."
 msgstr "글꼴을 굵게"
 
-#: ../src/osx/carbon/fontdlg.cpp:363 ../src/osx/carbon/fontdlg.cpp:365
+#: ../src/osx/carbon/fontdlg.cpp:360 ../src/osx/carbon/fontdlg.cpp:362
 msgid "Check to make the font italic."
 msgstr "글꼴을 기울임"
 
-#: ../src/osx/carbon/fontdlg.cpp:372 ../src/osx/carbon/fontdlg.cpp:374
+#: ../src/osx/carbon/fontdlg.cpp:369 ../src/osx/carbon/fontdlg.cpp:371
 msgid "Check to make the font underlined."
 msgstr "글꼴에 밑줄을 추가."
 
-#: ../src/richtext/richtextstyledlg.cpp:289
-#: ../src/richtext/richtextstyledlg.cpp:291
+#: ../src/richtext/richtextstyledlg.cpp:285
+#: ../src/richtext/richtextstyledlg.cpp:287
 msgid "Check to restart numbering."
 msgstr "번호 다시 매기기 선택"
 
@@ -2149,55 +2153,55 @@ msgstr "위 첨자로 보기"
 msgid "Check to suppress hyphenation."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:763
+#: ../src/msw/dialup.cpp:757
 msgid "Choose ISP to dial"
 msgstr "ISP에 전화 연결 "
 
-#: ../src/propgrid/props.cpp:1922
+#: ../src/propgrid/props.cpp:1904
 #, fuzzy
 msgid "Choose a directory:"
 msgstr "디렉토리 생성"
 
-#: ../src/propgrid/props.cpp:1975
+#: ../src/propgrid/props.cpp:2199
 #, fuzzy
 msgid "Choose a file"
 msgstr "글꼴 선택"
 
-#: ../src/generic/colrdlgg.cpp:158 ../src/gtk/colordlg.cpp:54
+#: ../src/generic/colrdlgg.cpp:156 ../src/gtk/colordlg.cpp:49
 msgid "Choose colour"
 msgstr "색상 선택"
 
-#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/gtk1/fontdlg.cpp:125 ../src/generic/fontpickerg.cpp:47
+#: ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "글꼴 선택"
 
-#: ../src/common/module.cpp:74
+#: ../src/common/module.cpp:71
 #, c-format
 msgid "Circular dependency involving module \"%s\" detected."
 msgstr "순환 종속성 모듈 \"%s\" 을 발견하였습니다."
 
-#: ../src/aui/tabmdi.cpp:108 ../src/generic/mdig.cpp:97
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
 msgid "Cl&ose"
 msgstr "닫기(&O)"
 
-#: ../src/msw/ole/automtn.cpp:684
+#: ../src/msw/ole/automtn.cpp:675
 #, fuzzy
 msgid "Class not registered."
 msgstr "쓰레드 생성 할 수 없습니다"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:147 ../src/common/accelcmn.cpp:72
+#: ../src/common/stockitem.cpp:144 ../src/common/accelcmn.cpp:69
 #, fuzzy
 msgid "Clear"
 msgstr "비우기(&C)"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "Clear the log contents"
 msgstr "로그 내용 지우기"
 
-#: ../src/richtext/richtextstyledlg.cpp:252
-#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:248
+#: ../src/richtext/richtextstyledlg.cpp:250
 msgid "Click to apply the selected style."
 msgstr "선택한 모양새를 적용하려면 클릭하십시오"
 
@@ -2208,15 +2212,15 @@ msgstr "선택한 모양새를 적용하려면 클릭하십시오"
 msgid "Click to browse for a symbol."
 msgstr "기호 탐색창을 보시려면 여기를 누르십시오."
 
-#: ../src/osx/carbon/fontdlg.cpp:403 ../src/osx/carbon/fontdlg.cpp:405
+#: ../src/osx/carbon/fontdlg.cpp:400 ../src/osx/carbon/fontdlg.cpp:402
 msgid "Click to cancel changes to the font."
 msgstr "글꼴 변경을 취소하려면 여기를 누르십시오."
 
-#: ../src/generic/fontdlgg.cpp:472 ../src/generic/fontdlgg.cpp:491
+#: ../src/generic/fontdlgg.cpp:468 ../src/generic/fontdlgg.cpp:487
 msgid "Click to cancel the font selection."
 msgstr "선택한 글꼴을 취소하려면 여기를 누르십시오."
 
-#: ../src/osx/carbon/fontdlg.cpp:384 ../src/osx/carbon/fontdlg.cpp:386
+#: ../src/osx/carbon/fontdlg.cpp:381 ../src/osx/carbon/fontdlg.cpp:383
 msgid "Click to change the font colour."
 msgstr "글꼴의 색상을 변경 하려면 여기를 누르십시오."
 
@@ -2236,38 +2240,38 @@ msgstr "텍스트 색상 변경 하려면 여기를 누르십시오."
 msgid "Click to choose the font for this level."
 msgstr "현재 단계의 글꼴을 선택 하시려면 클릭하십시오.."
 
-#: ../src/richtext/richtextstyledlg.cpp:279
-#: ../src/richtext/richtextstyledlg.cpp:281
+#: ../src/richtext/richtextstyledlg.cpp:275
+#: ../src/richtext/richtextstyledlg.cpp:277
 msgid "Click to close this window."
 msgstr "현재 창을 닫으려면 여기를 누르십시오."
 
-#: ../src/osx/carbon/fontdlg.cpp:410 ../src/osx/carbon/fontdlg.cpp:412
+#: ../src/osx/carbon/fontdlg.cpp:407 ../src/osx/carbon/fontdlg.cpp:409
 msgid "Click to confirm changes to the font."
 msgstr "글꼴을 변경 적용하려면 여기를 누르십시오."
 
-#: ../src/generic/fontdlgg.cpp:477 ../src/generic/fontdlgg.cpp:479
-#: ../src/generic/fontdlgg.cpp:484 ../src/generic/fontdlgg.cpp:486
+#: ../src/generic/fontdlgg.cpp:473 ../src/generic/fontdlgg.cpp:475
+#: ../src/generic/fontdlgg.cpp:480 ../src/generic/fontdlgg.cpp:482
 msgid "Click to confirm the font selection."
 msgstr "선택한 글꼴을 적용하려면 여기를 누르십시오."
 
-#: ../src/richtext/richtextstyledlg.cpp:244
-#: ../src/richtext/richtextstyledlg.cpp:246
+#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:242
 #, fuzzy
 msgid "Click to create a new box style."
 msgstr "새로운 목록 모양새를 만들려면 여기를 누르십시오."
 
-#: ../src/richtext/richtextstyledlg.cpp:226
-#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:224
 msgid "Click to create a new character style."
 msgstr "새로운 글꼴 모양새를 만들려면 여기를 누르십시오."
 
-#: ../src/richtext/richtextstyledlg.cpp:238
-#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:236
 msgid "Click to create a new list style."
 msgstr "새로운 목록 모양새를 만들려면 여기를 누르십시오."
 
-#: ../src/richtext/richtextstyledlg.cpp:232
-#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:230
 msgid "Click to create a new paragraph style."
 msgstr "새로운 단락 모양새를 만들려면 여기를 누르십시오."
 
@@ -2281,8 +2285,8 @@ msgstr "새로운 탭 위치 만들려면 여기를 누르십시오."
 msgid "Click to delete all tab positions."
 msgstr "모든 탭 위치를 삭제 하시려면 클릭하십시오."
 
-#: ../src/richtext/richtextstyledlg.cpp:270
-#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:268
 msgid "Click to delete the selected style."
 msgstr "선택한 모양새를 지우려면 여기를 누르십시오."
 
@@ -2291,25 +2295,25 @@ msgstr "선택한 모양새를 지우려면 여기를 누르십시오."
 msgid "Click to delete the selected tab position."
 msgstr "선택한 탭 위치를 삭제 하시려면 클릭하십시오."
 
-#: ../src/richtext/richtextstyledlg.cpp:264
-#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:262
 msgid "Click to edit the selected style."
 msgstr "선택한 팔레트를 편집하려면 여기를 누르십시오."
 
-#: ../src/richtext/richtextstyledlg.cpp:258
-#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:256
 msgid "Click to rename the selected style."
 msgstr "선택한 모양새의 이름을 변경하려면 여기를 누르십시오."
 
-#: ../src/generic/dbgrptg.cpp:97 ../src/generic/progdlgg.cpp:759
-#: ../src/richtext/richtextstyledlg.cpp:277
-#: ../src/richtext/richtextsymboldlg.cpp:476 ../src/common/stockitem.cpp:148
-#: ../src/msw/progdlg.cpp:170 ../src/msw/progdlg.cpp:679
-#: ../src/html/helpdlg.cpp:90
+#: ../src/common/stockitem.cpp:145 ../src/generic/dbgrptg.cpp:94
+#: ../src/generic/progdlgg.cpp:781 ../src/msw/progdlg.cpp:211
+#: ../src/msw/progdlg.cpp:946 ../src/html/helpdlg.cpp:87
+#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextstyledlg.cpp:273
 msgid "Close"
 msgstr "닫기"
 
-#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:98
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
 msgid "Close All"
 msgstr "모두 닫기"
 
@@ -2317,66 +2321,66 @@ msgstr "모두 닫기"
 msgid "Close current document"
 msgstr "현재 문서를 닫습니다."
 
-#: ../src/generic/logg.cpp:516
+#: ../src/generic/logg.cpp:513
 msgid "Close this window"
 msgstr "현재 창을 닫습니다."
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6006
+#: ../src/generic/datavgen.cpp:6811
 msgid "Collapse"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 #, fuzzy
 msgid "Color"
 msgstr "색상"
 
-#: ../src/richtext/richtextformatdlg.cpp:776
+#: ../src/richtext/richtextformatdlg.cpp:768
 msgid "Colour"
 msgstr "색상"
 
-#: ../src/msw/colordlg.cpp:158
+#: ../src/msw/colordlg.cpp:227
 #, c-format
 msgid "Colour selection dialog failed with error %0lx."
 msgstr "색상 선택창에서 오류 발생 : %0lx"
 
-#: ../src/osx/carbon/fontdlg.cpp:380
+#: ../src/osx/carbon/fontdlg.cpp:377
 msgid "Colour:"
 msgstr "색상:"
 
-#: ../src/generic/datavgen.cpp:6077
+#: ../src/generic/datavgen.cpp:6882
 #, c-format
 msgid "Column %u"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:114
+#: ../src/common/accelcmn.cpp:112
 msgid "Command"
 msgstr ""
 
-#: ../src/common/init.cpp:196
+#: ../src/common/init.cpp:193
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
 "ignored."
 msgstr "명령행 인자 %d는 유니코드로 변경할수 없어 인자를 무시합니다."
 
-#: ../src/msw/fontdlg.cpp:120
+#: ../src/msw/fontdlg.cpp:170
 #, fuzzy, c-format
 msgid "Common dialog failed with error code %0lx."
 msgstr "색상 선택창에서 오류 발생 : %0lx"
 
-#: ../src/gtk/window.cpp:4649
+#: ../src/gtk/window.cpp:5653
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:1549
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "압축된 HTML 도움말 파일 (*.chm)|*.chm|"
 
-#: ../src/generic/dirctrlg.cpp:444
+#: ../src/generic/dirctrlg.cpp:410
 msgid "Computer"
 msgstr "컴퓨터"
 
@@ -2385,54 +2389,58 @@ msgstr "컴퓨터"
 msgid "Config entry name cannot start with '%c'."
 msgstr "설정파일에 문자열은 '%c' 로 시작할 수 없습니다."
 
-#: ../src/generic/filedlgg.cpp:349 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
 msgid "Confirm"
 msgstr "확인"
 
-#: ../src/html/htmlwin.cpp:566
+#: ../src/html/htmlwin.cpp:569
 msgid "Connecting..."
 msgstr "연결중..."
 
-#: ../src/html/helpwnd.cpp:475
+#: ../src/html/helpwnd.cpp:473
 msgid "Contents"
 msgstr "목차"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:880
+#: ../src/propgrid/advprops.cpp:781
 msgid "ControlDark"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:881
+#: ../src/propgrid/advprops.cpp:782
 msgid "ControlLight"
 msgstr ""
 
-#: ../src/common/strconv.cpp:2262
+#: ../src/common/strconv.cpp:2208
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "문자 인코딩 '%s' 으로의 변환이 실패했습니다."
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 #, fuzzy
 msgid "Convert"
 msgstr "목차"
 
-#: ../src/html/htmlwin.cpp:1079
+#: ../src/html/htmlwin.cpp:1020
 #, c-format
 msgid "Copied to clipboard:\"%s\""
 msgstr "클립보드로 복사:\"%s\""
 
-#: ../src/generic/prntdlgg.cpp:247
+#: ../src/generic/prntdlgg.cpp:240
 msgid "Copies:"
 msgstr "인쇄 매수:"
 
-#: ../src/common/stockitem.cpp:150 ../src/stc/stc_i18n.cpp:18
+#: ../src/common/stockitem.cpp:147 ../src/stc/stc_i18n.cpp:18
 msgid "Copy"
 msgstr "복사"
 
-#: ../src/common/stockitem.cpp:258
+#: ../src/common/stockitem.cpp:255
 msgid "Copy selection"
 msgstr "선택한 부분 복사"
+
+#: ../src/generic/grid.cpp:5945
+msgid "Copying more than one selected block to clipboard is not supported."
+msgstr ""
 
 #: ../src/richtext/richtextborderspage.cpp:566
 #: ../src/richtext/richtextborderspage.cpp:601
@@ -2443,202 +2451,198 @@ msgstr ""
 msgid "Corner &radius:"
 msgstr ""
 
-#: ../src/html/chm.cpp:718
+#: ../src/html/chm.cpp:711
 #, c-format
 msgid "Could not create temporary file '%s'"
 msgstr "임시 파일 '%s' 을 만들수 없습니다."
 
-#: ../src/html/chm.cpp:273
+#: ../src/html/chm.cpp:270
 #, c-format
 msgid "Could not extract %s into %s: %s"
 msgstr "%s 를 %s 에서 추출할 수 없음: %s"
 
-#: ../src/generic/tabg.cpp:1048
+#: ../src/generic/tabg.cpp:1045
 msgid "Could not find tab for id"
 msgstr "tab ID를 찿을 수 없습니다."
 
-#: ../src/gtk/notifmsg.cpp:108
-#, fuzzy
-msgid "Could not initalize libnotify."
-msgstr "정렬 방식을 지정할 수 없습니다."
-
-#: ../src/html/chm.cpp:444
+#: ../src/html/chm.cpp:437
 #, c-format
 msgid "Could not locate file '%s'."
 msgstr "'%s' 파일을 찾을 수 없습니다."
 
-#: ../src/common/filefn.cpp:1403
+#: ../src/msw/graphicsd2d.cpp:604
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/common/filefn.cpp:1291
 #, fuzzy
 msgid "Could not set current working directory"
 msgstr "작업 디렉토리를 가져오는데 실패했습니다."
 
-#: ../src/common/prntbase.cpp:2015
+#: ../src/common/prntbase.cpp:2037
 msgid "Could not start document preview."
 msgstr "문서 미리보기를 시작할 수 없습니다."
 
-#: ../src/generic/printps.cpp:178 ../src/msw/printwin.cpp:210
-#: ../src/gtk/print.cpp:1132
+#: ../src/generic/printps.cpp:159 ../src/msw/printwin.cpp:184
+#: ../src/gtk/print.cpp:1129
 msgid "Could not start printing."
 msgstr "인쇄를 시작할 수 없습니다."
 
-#: ../src/common/wincmn.cpp:2125
+#: ../src/common/wincmn.cpp:2126
 msgid "Could not transfer data to window"
 msgstr "데이타를 창으로 내보낼 수 없습니다."
 
-#: ../src/msw/imaglist.cpp:187 ../src/msw/imaglist.cpp:224
-#: ../src/msw/imaglist.cpp:249 ../src/msw/dragimag.cpp:185
-#: ../src/msw/dragimag.cpp:220
+#: ../src/msw/imaglist.cpp:223 ../src/msw/imaglist.cpp:245
+#: ../src/msw/imaglist.cpp:270 ../src/msw/dragimag.cpp:182
+#: ../src/msw/dragimag.cpp:217
 msgid "Couldn't add an image to the image list."
 msgstr "이미지 목록에 이미지를 추가할 수 없습니다."
 
-#: ../src/osx/glcanvas_osx.cpp:414 ../src/unix/glx11.cpp:558
-#: ../src/msw/glcanvas.cpp:616
+#: ../src/osx/glcanvas_osx.cpp:411 ../src/msw/glcanvas.cpp:631
+#: ../src/unix/glegl.cpp:315 ../src/unix/glx11.cpp:559
 #, fuzzy
 msgid "Couldn't create OpenGL context"
 msgstr "타이머를 생성할 수 없습니다."
 
-#: ../src/msw/timer.cpp:134
+#: ../src/msw/timer.cpp:131
 msgid "Couldn't create a timer"
 msgstr "타이머를 생성할 수 없습니다."
 
-#: ../src/osx/carbon/overlay.cpp:122
-msgid "Couldn't create the overlay window"
-msgstr "오버레이 창을 생성할 수 없습니다."
-
-#: ../src/common/translation.cpp:2024
+#: ../src/common/translation.cpp:2074
 #, fuzzy
 msgid "Couldn't enumerate translations"
 msgstr "스레드를 종료할 수없습니다."
 
-#: ../src/common/dynlib.cpp:120
+#: ../src/common/dynlib.cpp:110
 #, c-format
 msgid "Couldn't find symbol '%s' in a dynamic library"
 msgstr "동적 Library에서 '%s' 기호를 찾을 수 없습니다."
 
-#: ../src/msw/thread.cpp:915
+#: ../src/msw/thread.cpp:921
 msgid "Couldn't get the current thread pointer"
 msgstr "현재 쓰레드 포인터를 얻지 못했습니다."
 
-#: ../src/osx/carbon/overlay.cpp:129
-msgid "Couldn't init the context on the overlay window"
-msgstr "오버레이창의 내용을 초기화 하지 못했습니다."
-
-#: ../src/common/imaggif.cpp:244
+#: ../src/common/imaggif.cpp:241
 #, fuzzy
 msgid "Couldn't initialize GIF hash table."
 msgstr "zlib에서 사용할 압축용 버퍼 할당하지 못했습니다."
 
-#: ../src/common/imagpng.cpp:409
+#: ../src/common/imagpng.cpp:437
 msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
 msgstr "PNG 이미지를 가져오지 못했습니다 - 파일손상 또는 메모리 부족"
 
-#: ../src/unix/sound.cpp:470
+#: ../src/unix/sound.cpp:459
 #, c-format
 msgid "Couldn't load sound data from '%s'."
 msgstr "'%s' 에서 소리 데이타를 읽어올 수 없습니다."
 
-#: ../src/msw/dirdlg.cpp:435
+#: ../src/msw/dirdlg.cpp:287
 #, fuzzy
 msgid "Couldn't obtain folder name"
 msgstr "타이머를 생성할 수 없습니다."
 
-#: ../src/unix/sound_sdl.cpp:229
+#: ../src/unix/sound_sdl.cpp:226
 #, c-format
 msgid "Couldn't open audio: %s"
 msgstr "오디오 열기 실패: %s"
 
-#: ../src/msw/ole/dataobj.cpp:377
+#: ../src/msw/ole/dataobj.cpp:385
 #, c-format
 msgid "Couldn't register clipboard format '%s'."
 msgstr "%s 형식을 클립보드에 등록할 수 없습니다."
 
-#: ../src/msw/listctrl.cpp:869
+#: ../src/msw/listctrl.cpp:933
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "목록보기 에서  아이템 %d 의 정보를 가져올 수 없습니다.  "
 
-#: ../src/common/imagpng.cpp:498 ../src/common/imagpng.cpp:509
-#: ../src/common/imagpng.cpp:519
+#: ../src/common/imagpng.cpp:511 ../src/common/imagpng.cpp:522
+#: ../src/common/imagpng.cpp:532
 msgid "Couldn't save PNG image."
 msgstr "PNG 이미지를 저장할 수 없습니다."
 
-#: ../src/msw/thread.cpp:684
+#: ../src/msw/thread.cpp:676
 msgid "Couldn't terminate thread"
 msgstr "스레드를 종료할 수없습니다."
 
-#: ../src/common/xtistrm.cpp:166
+#: ../src/common/xtistrm.cpp:163
 #, fuzzy, c-format
 msgid "Create Parameter %s not found in declared RTTI Parameters"
 msgstr "생성된 매개 변수 이름을 RTTI 에서 찾을 수 없습니다."
 
-#: ../src/generic/dirdlgg.cpp:288
+#: ../src/generic/dirdlgg.cpp:285
 msgid "Create directory"
 msgstr "디렉토리 생성"
 
-#: ../src/generic/filedlgg.cpp:212 ../src/generic/dirdlgg.cpp:111
+#: ../src/generic/filedlgg.cpp:209 ../src/generic/dirdlgg.cpp:108
 msgid "Create new directory"
 msgstr "새 디렉토리를 생성"
 
-#: ../src/xrc/xmlres.cpp:2460
+#: ../src/common/stockitem.cpp:264
+#, fuzzy
+msgid "Create new document"
+msgstr "새 디렉토리를 생성"
+
+#: ../src/xrc/xmlres.cpp:2515
 #, fuzzy, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "'%s' 의 추출('%s' 에서) 실패 했습니다."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1758
+#: ../src/propgrid/advprops.cpp:1659
 msgid "Cross"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:333
+#: ../src/common/accelcmn.cpp:347
 msgid "Ctrl+"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:332 ../src/osx/textctrl_osx.cpp:576
-#: ../src/common/stockitem.cpp:151 ../src/msw/textctrl.cpp:2507
+#: ../src/osx/textctrl_osx.cpp:594 ../src/common/stockitem.cpp:148
+#: ../src/msw/textctrl.cpp:2772 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "잘라내기(&T)"
 
-#: ../src/generic/filectrlg.cpp:940
+#: ../src/generic/filectrlg.cpp:936
 msgid "Current directory:"
 msgstr "현재 디렉토리:"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:896 ../src/propgrid/advprops.cpp:1574
-#: ../src/propgrid/advprops.cpp:1612
+#: ../src/propgrid/advprops.cpp:797 ../src/propgrid/advprops.cpp:1475
+#: ../src/propgrid/advprops.cpp:1518
 #, fuzzy
 msgid "Custom"
 msgstr "사용자 지정 크기"
 
-#: ../src/gtk/print.cpp:217
+#: ../src/gtk/print.cpp:211
 msgid "Custom size"
 msgstr "사용자 지정 크기"
 
-#: ../src/common/headerctrlcmn.cpp:60
+#: ../src/common/headerctrlcmn.cpp:58
 #, fuzzy
 msgid "Customize Columns"
 msgstr "사용자 지정 크기"
 
-#: ../src/common/stockitem.cpp:151 ../src/stc/stc_i18n.cpp:17
+#: ../src/common/stockitem.cpp:148 ../src/stc/stc_i18n.cpp:17
 msgid "Cut"
 msgstr "잘라내기"
 
-#: ../src/common/stockitem.cpp:259
+#: ../src/common/stockitem.cpp:256
 msgid "Cut selection"
 msgstr "선택한 부분 잘라내기"
 
-#: ../src/common/fmapbase.cpp:152
+#: ../src/common/fmapbase.cpp:149
 msgid "Cyrillic (ISO-8859-5)"
 msgstr "아랍어 (ISO-8859-5)"
 
-#: ../src/common/paper.cpp:99
+#: ../src/common/paper.cpp:96
 msgid "D sheet, 22 x 34 in"
 msgstr "D 용지, 22 x 34 in"
 
-#: ../src/msw/dde.cpp:703
+#: ../src/msw/dde.cpp:698
 msgid "DDE poke request failed"
 msgstr "DDE 로 데이타 전송 실패"
 
-#: ../src/common/imagbmp.cpp:1169
+#: ../src/common/imagbmp.cpp:1181
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr "DIB 헤더: 인코딩이 해상도와 일치 하지 않습니다."
 
@@ -2658,7 +2662,7 @@ msgstr "DIB 헤더: 알수 없는 해상도."
 msgid "DIB Header: Unknown encoding in file."
 msgstr "DIB 헤더 : 알수없는 인코딩."
 
-#: ../src/common/paper.cpp:121
+#: ../src/common/paper.cpp:118
 msgid "DL Envelope, 110 x 220 mm"
 msgstr "DL 봉투, 110 x 220 mm"
 
@@ -2666,55 +2670,55 @@ msgstr "DL 봉투, 110 x 220 mm"
 msgid "Dashed"
 msgstr ""
 
-#: ../src/generic/dbgrptg.cpp:300
+#: ../src/generic/dbgrptg.cpp:301
 #, c-format
 msgid "Debug report \"%s\""
 msgstr "디보그 보고서 \"%s\""
 
-#: ../src/common/debugrpt.cpp:210
+#: ../src/common/debugrpt.cpp:211
 msgid "Debug report couldn't be created."
 msgstr "디보그 보고서가 생성되지 않았습니다."
 
-#: ../src/common/debugrpt.cpp:553
+#: ../src/common/debugrpt.cpp:554
 msgid "Debug report generation has failed."
 msgstr "디버그 보고서의 생성을 실패했습니다."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:84
+#: ../src/common/accelcmn.cpp:81
 msgid "Decimal"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:323
+#: ../src/generic/fontdlgg.cpp:319
 msgid "Decorative"
 msgstr "Decorative"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1752
+#: ../src/propgrid/advprops.cpp:1653
 #, fuzzy
 msgid "Default"
 msgstr "기본값"
 
-#: ../src/common/fmapbase.cpp:796
+#: ../src/common/fmapbase.cpp:792
 msgid "Default encoding"
 msgstr "기본 인코딩"
 
-#: ../src/dfb/fontmgr.cpp:180
+#: ../src/dfb/fontmgr.cpp:177
 msgid "Default font"
 msgstr "기본 글꼴"
 
-#: ../src/generic/prntdlgg.cpp:510
+#: ../src/generic/prntdlgg.cpp:503
 msgid "Default printer"
 msgstr "프린터 기본값"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:51
+#: ../src/common/accelcmn.cpp:48
 #, fuzzy
 msgid "Del"
 msgstr "지우기"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextbuffer.cpp:8221 ../src/common/stockitem.cpp:152
-#: ../src/common/accelcmn.cpp:50 ../src/stc/stc_i18n.cpp:20
+#: ../src/common/stockitem.cpp:149 ../src/common/accelcmn.cpp:47
+#: ../src/richtext/richtextbuffer.cpp:8217 ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "지우기"
 
@@ -2722,81 +2726,81 @@ msgstr "지우기"
 msgid "Delete A&ll"
 msgstr "모두 지우기(&L)"
 
-#: ../src/richtext/richtextbuffer.cpp:11341
+#: ../src/richtext/richtextbuffer.cpp:11340
 #, fuzzy
 msgid "Delete Column"
 msgstr "선택한 부분 지우기"
 
-#: ../src/richtext/richtextbuffer.cpp:11291
+#: ../src/richtext/richtextbuffer.cpp:11290
 #, fuzzy
 msgid "Delete Row"
 msgstr "지우기"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 msgid "Delete Style"
 msgstr "모양새 지우기"
 
-#: ../src/richtext/richtextctrl.cpp:1345 ../src/richtext/richtextctrl.cpp:1584
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
 msgid "Delete Text"
 msgstr "텍스트 삭제"
 
-#: ../src/generic/editlbox.cpp:170
+#: ../src/generic/editlbox.cpp:147
 msgid "Delete item"
 msgstr "아이템 지우기"
 
-#: ../src/common/stockitem.cpp:260
+#: ../src/common/stockitem.cpp:257
 msgid "Delete selection"
 msgstr "선택한 부분 지우기"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 #, c-format
 msgid "Delete style %s?"
 msgstr "'%s' 모양새를 지우시겠습니다까?"
 
-#: ../src/unix/snglinst.cpp:301
+#: ../src/unix/snglinst.cpp:298
 #, c-format
 msgid "Deleted stale lock file '%s'."
 msgstr "오래된 잠금 파일 '%s' 삭제."
 
-#: ../src/common/secretstore.cpp:220
+#: ../src/common/secretstore.cpp:234
 #, fuzzy, c-format
-msgid "Deleting password for \"%s/%s\" failed: %s."
+msgid "Deleting password for \"%s\" failed: %s."
 msgstr "'%s' 의 추출('%s' 에서) 실패 했습니다."
 
-#: ../src/common/module.cpp:124
+#: ../src/common/module.cpp:121
 #, c-format
 msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
 msgstr "\"%s\" 에 종속적인 모듈 \"%s\" 이 존재하지 않습니다."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 #, fuzzy
 msgid "Descending"
 msgstr "기본 인코딩"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:526 ../src/propgrid/advprops.cpp:882
+#: ../src/generic/dirctrlg.cpp:492 ../src/propgrid/advprops.cpp:783
 msgid "Desktop"
 msgstr "바탕 화면"
 
-#: ../src/generic/aboutdlgg.cpp:70
+#: ../src/generic/aboutdlgg.cpp:67
 msgid "Developed by "
 msgstr "개발"
 
-#: ../src/generic/aboutdlgg.cpp:176
+#: ../src/generic/aboutdlgg.cpp:173
 msgid "Developers"
 msgstr "개발자"
 
-#: ../src/msw/dialup.cpp:374
+#: ../src/msw/dialup.cpp:368
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
 msgstr "RAS가 설치되지 않아 전화 연결을 할수 없습니다. RAS 설치해 주십시오. "
 
-#: ../src/generic/tipdlg.cpp:211
+#: ../src/generic/tipdlg.cpp:208
 msgid "Did you know..."
 msgstr "팁 보기"
 
-#: ../src/dfb/wrapdfb.cpp:63
+#: ../src/dfb/wrapdfb.cpp:60
 #, fuzzy, c-format
 msgid "DirectFB error %d occurred."
 msgstr "Direct 가속시 오류 %d 발생."
@@ -2805,29 +2809,29 @@ msgstr "Direct 가속시 오류 %d 발생."
 msgid "Directories"
 msgstr "디렉토리"
 
-#: ../src/common/filefn.cpp:1183
+#: ../src/common/filefn.cpp:1071
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "'%s' 디렉토리를 만들 수 없습니다."
 
-#: ../src/common/filefn.cpp:1197
+#: ../src/common/filefn.cpp:1085
 #, fuzzy, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "'%s' 디렉토리를 만들 수 없습니다."
 
-#: ../src/generic/dirdlgg.cpp:204
+#: ../src/generic/dirdlgg.cpp:201
 msgid "Directory does not exist"
 msgstr "디렉토리가 존재하지 않습니다."
 
-#: ../src/generic/filectrlg.cpp:1399
+#: ../src/generic/filectrlg.cpp:1388
 msgid "Directory doesn't exist."
 msgstr "디렉토리가 존재하지 않습니다."
 
-#: ../src/common/docview.cpp:457
+#: ../src/common/docview.cpp:450
 msgid "Discard changes and reload the last saved version?"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:502
+#: ../src/html/helpwnd.cpp:500
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -2835,46 +2839,46 @@ msgstr ""
 "문자열을 포함하는 모든 색인 항목을 표시합니다. 검색시 대소문자를 구분하지 않"
 "습니다"
 
-#: ../src/html/helpwnd.cpp:679
+#: ../src/html/helpwnd.cpp:677
 msgid "Display options dialog"
 msgstr "보기 설정 창"
 
-#: ../src/html/helpwnd.cpp:322
+#: ../src/html/helpwnd.cpp:320
 msgid "Displays help as you browse the books on the left."
 msgstr "왼쪽에 도움말 탐색창을 표시합니다."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:85
+#: ../src/common/accelcmn.cpp:83
 msgid "Divide"
 msgstr ""
 
-#: ../src/common/docview.cpp:533
+#: ../src/common/docview.cpp:526
 #, fuzzy, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "%s 문서의 바뀐 내용을 저장하시겠습니까?"
 
-#: ../src/common/prntbase.cpp:542
+#: ../src/common/prntbase.cpp:537
 #, fuzzy
 msgid "Document:"
 msgstr "문서화"
 
-#: ../src/generic/aboutdlgg.cpp:73
+#: ../src/generic/aboutdlgg.cpp:70
 msgid "Documentation by "
 msgstr "문서화"
 
-#: ../src/generic/aboutdlgg.cpp:180
+#: ../src/generic/aboutdlgg.cpp:177
 msgid "Documentation writers"
 msgstr "문서 작성자"
 
-#: ../src/common/sizer.cpp:2799
+#: ../src/common/sizer.cpp:2916
 msgid "Don't Save"
 msgstr "저장 하지 않음"
 
-#: ../src/html/htmlwin.cpp:633
+#: ../src/html/htmlwin.cpp:643
 msgid "Done"
 msgstr "완료"
 
-#: ../src/generic/progdlgg.cpp:448 ../src/msw/progdlg.cpp:407
+#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
 msgid "Done."
 msgstr "완료."
 
@@ -2888,44 +2892,44 @@ msgstr "완료"
 msgid "Double"
 msgstr "완료"
 
-#: ../src/common/paper.cpp:176
+#: ../src/common/paper.cpp:173
 msgid "Double Japanese Postcard Rotated 148 x 200 mm"
 msgstr "Double 일본 옆서 Rotated 148 x 200 mm"
 
-#: ../src/common/xtixml.cpp:273
+#: ../src/common/xtixml.cpp:269
 #, c-format
 msgid "Doubly used id : %d"
 msgstr "객체 ID가 이미 정의되어 있습니다: %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:153
-#: ../src/common/accelcmn.cpp:64
+#: ../src/common/stockitem.cpp:150 ../src/common/accelcmn.cpp:61
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Down"
 msgstr "아래로"
 
-#: ../src/richtext/richtextctrl.cpp:865
+#: ../src/richtext/richtextctrl.cpp:864
 msgid "Drag"
 msgstr ""
 
-#: ../src/common/paper.cpp:100
+#: ../src/common/paper.cpp:97
 msgid "E sheet, 34 x 44 in"
 msgstr "E 용지, 34 x 44 in"
 
-#: ../src/unix/fswatcher_inotify.cpp:561
+#: ../src/unix/fswatcher_inotify.cpp:558
 #, fuzzy
 msgid "EOF while reading from inotify descriptor"
 msgstr "파일 디스크립터 %d 에서 데이타를 읽어 올 수 없습니다."
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 #, fuzzy
 msgid "Edit"
 msgstr "편집(&E)"
 
-#: ../src/generic/editlbox.cpp:168
+#: ../src/generic/editlbox.cpp:131
 msgid "Edit item"
 msgstr "아이템 편집"
 
-#: ../include/wx/generic/progdlgg.h:84
+#: ../include/wx/generic/progdlgg.h:85
 msgid "Elapsed time:"
 msgstr "경과 시간:"
 
@@ -2999,63 +3003,63 @@ msgid "Enables the shadow spread."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:66
+#: ../src/common/accelcmn.cpp:63
 msgid "End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:55
+#: ../src/common/accelcmn.cpp:52
 #, fuzzy
 msgid "Enter"
 msgstr "프린터"
 
-#: ../src/richtext/richtextstyledlg.cpp:934
+#: ../src/richtext/richtextstyledlg.cpp:930
 #, fuzzy
 msgid "Enter a box style name"
 msgstr "새 모양새 이름을 입력하십시오"
 
-#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:602
 msgid "Enter a character style name"
 msgstr "글꼴 모양새 이름을 입력하십시오"
 
-#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:816
 msgid "Enter a list style name"
 msgstr "목록 모양새 이름을 입력하십시오"
 
-#: ../src/richtext/richtextstyledlg.cpp:893
+#: ../src/richtext/richtextstyledlg.cpp:889
 msgid "Enter a new style name"
 msgstr "새 모양새 이름을 입력하십시오"
 
-#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:650
 msgid "Enter a paragraph style name"
 msgstr "단락 모양새 이름을 입력하십시오"
 
-#: ../src/generic/dbgrptg.cpp:174
+#: ../src/generic/dbgrptg.cpp:171
 #, c-format
 msgid "Enter command to open file \"%s\":"
 msgstr "\"%s\" 파일의 열기 명령을 입력하십시오:"
 
-#: ../src/generic/helpext.cpp:459
+#: ../src/generic/helpext.cpp:457
 msgid "Entries found"
 msgstr "발견 항목"
 
-#: ../src/common/paper.cpp:142
+#: ../src/common/paper.cpp:139
 msgid "Envelope Invite 220 x 220 mm"
 msgstr "봉투 Invite 220 x 220 mm"
 
-#: ../src/common/config.cpp:469
+#: ../src/common/config.cpp:465
 #, c-format
 msgid ""
 "Environment variables expansion failed: missing '%c' at position %u in '%s'."
 msgstr "환경변수 추가 실패: '%c' 를 찾을 수 없습니다: %u 번째('%s' 에서)"
 
-#: ../src/generic/filedlgg.cpp:357 ../src/generic/dirctrlg.cpp:570
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/dirctrlg.cpp:599
-#: ../src/generic/dirdlgg.cpp:323 ../src/generic/filectrlg.cpp:642
-#: ../src/generic/filectrlg.cpp:756 ../src/generic/filectrlg.cpp:770
-#: ../src/generic/filectrlg.cpp:786 ../src/generic/filectrlg.cpp:1368
-#: ../src/generic/filectrlg.cpp:1399 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/gtk1/fontdlg.cpp:74 ../src/generic/dirctrlg.cpp:536
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/dirctrlg.cpp:565
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1357 ../src/generic/filectrlg.cpp:1388
+#: ../src/generic/filedlgg.cpp:354 ../src/generic/dirdlgg.cpp:320
+#: ../src/gtk/filedlg.cpp:74
 msgid "Error"
 msgstr "오류"
 
@@ -3063,237 +3067,258 @@ msgstr "오류"
 msgid "Error closing epoll descriptor"
 msgstr "Epoll 디스크립터 닫기 실패"
 
-#: ../src/unix/fswatcher_kqueue.cpp:114
+#: ../src/unix/fswatcher_kqueue.cpp:131
 #, fuzzy
 msgid "Error closing kqueue instance"
 msgstr "Epoll 디스크립터 닫기 실패"
 
-#: ../src/common/filefn.cpp:1049
+#: ../src/common/filefn.cpp:938
 #, fuzzy, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "파일 '%s' 를 '%s' 로 복사하는데 실패했습니다."
 
-#: ../src/generic/dirdlgg.cpp:222
+#: ../src/generic/dirdlgg.cpp:219
 msgid "Error creating directory"
 msgstr "디렉토리 생성 오류"
 
-#: ../src/common/imagbmp.cpp:1181
+#: ../src/common/imagbmp.cpp:1193
 msgid "Error in reading image DIB."
 msgstr "DIB 이미지 읽기 오류."
 
-#: ../src/propgrid/propgrid.cpp:6696
+#: ../src/propgrid/propgrid.cpp:6665
 #, c-format
 msgid "Error in resource: %s"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:422
+#: ../src/common/fileconf.cpp:421
 msgid "Error reading config options."
 msgstr "설정 읽기 오류."
+
+#: ../src/msw/webview_ie.cpp:1057 ../src/msw/webview_edge.cpp:850
+#: ../src/gtk/webview_webkit2.cpp:1262 ../src/osx/webview_webkit.mm:383
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
 
 #: ../src/common/fileconf.cpp:1029
 msgid "Error saving user configuration data."
 msgstr "사용자 설정 정보 저장 실패."
 
-#: ../src/gtk/print.cpp:722
+#: ../src/gtk/print.cpp:720
 msgid "Error while printing: "
 msgstr "인쇄하는 도중 오류 발생:"
 
-#: ../src/common/log.cpp:219
+#: ../src/common/log.cpp:237
 msgid "Error: "
 msgstr "오류:"
 
+#: ../src/common/webrequest.cpp:98
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "오류:"
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:69
+#: ../src/common/accelcmn.cpp:66
 msgid "Esc"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:70
+#: ../src/common/accelcmn.cpp:67
 #, fuzzy
 msgid "Escape"
 msgstr "가로 방향"
 
-#: ../src/common/fmapbase.cpp:150
+#: ../src/common/fmapbase.cpp:147
 msgid "Esperanto (ISO-8859-3)"
 msgstr "남유럽어 (ISO-8859-3)"
 
-#: ../include/wx/generic/progdlgg.h:85
+#: ../include/wx/generic/progdlgg.h:86
 msgid "Estimated time:"
 msgstr "예상 시간:"
 
-#: ../src/generic/dbgrptg.cpp:234
+#: ../src/generic/dbgrptg.cpp:231
 #, fuzzy
 msgid "Executable files (*.exe)|*.exe|"
 msgstr "실행 파일 (*.exe)|*.exe|All files (*.*)|*.*||"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:155 ../src/common/accelcmn.cpp:78
+#: ../src/common/stockitem.cpp:152 ../src/common/accelcmn.cpp:75
 msgid "Execute"
 msgstr ""
 
-#: ../src/msw/utilsexc.cpp:876
+#: ../src/msw/utilsexc.cpp:873
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "'%s' 명령 실행 실패"
 
-#: ../src/common/paper.cpp:105
+#: ../src/common/paper.cpp:102
 msgid "Executive, 7 1/4 x 10 1/2 in"
 msgstr "Executive, 7 1/4 x 10 1/2 in"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6009
+#: ../src/generic/datavgen.cpp:6814
 msgid "Expand"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1240
+#: ../src/msw/registry.cpp:1228
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
 msgstr "레지스터 키값 가져오기: 파일 \"%s\" 이미 존재합니다."
 
-#: ../src/common/fmapbase.cpp:195
+#: ../src/common/fmapbase.cpp:192
 msgid "Extended Unix Codepage for Japanese (EUC-JP)"
 msgstr "일본어 (EUC-JP)"
 
-#: ../src/html/chm.cpp:725
+#: ../src/html/chm.cpp:718
 #, c-format
 msgid "Extraction of '%s' into '%s' failed."
 msgstr "'%s' 의 추출('%s' 에서) 실패 했습니다."
 
-#: ../src/common/accelcmn.cpp:249 ../src/common/accelcmn.cpp:344
+#: ../src/common/accelcmn.cpp:259 ../src/common/accelcmn.cpp:358
 msgid "F"
 msgstr ""
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:672
+#: ../src/propgrid/advprops.cpp:582
 #, fuzzy
 msgid "Face Name"
 msgstr "새 이름"
 
-#: ../src/unix/snglinst.cpp:269
+#: ../src/unix/snglinst.cpp:266
 msgid "Failed to access lock file."
 msgstr "파일 접근에 실패했습니다(잠금 파일)."
+
+#: ../src/gtk/font.cpp:572
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "\"%s\" 파일에서 메타 파일을 읽어올 수 없습니다."
 
 #: ../src/unix/epolldispatcher.cpp:116
 #, c-format
 msgid "Failed to add descriptor %d to epoll descriptor %d"
 msgstr "Epoll 디스크립터 %d 에 파일 디스크립터 %d 을 추가하는데 실패했습니다. "
 
-#: ../src/msw/dib.cpp:489
+#: ../src/msw/dib.cpp:535
 #, fuzzy, c-format
 msgid "Failed to allocate %luKb of memory for bitmap data."
 msgstr "비트맵 데이타를  위한 메모리(%luKb) 할당이 실패했습니다."
 
-#: ../src/common/glcmn.cpp:115
+#: ../src/common/glcmn.cpp:112
 msgid "Failed to allocate colour for OpenGL"
 msgstr "OpenGL 색상 할당을 실패 했습니다."
 
-#: ../src/unix/displayx11.cpp:236
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "OpenGL 색상 할당을 실패 했습니다."
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "OpenGL 색상 할당을 실패 했습니다."
+
+#: ../include/wx/unix/private/displayx11.h:89
 msgid "Failed to change video mode"
 msgstr "비디오 모드 변경을 실패했습니다."
 
-#: ../src/common/image.cpp:3277
+#: ../src/common/image.cpp:3396
 #, fuzzy, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "\"%s\" 비트맵 이미지 파을을 저장하는데 실패했습니다."
 
-#: ../src/common/debugrpt.cpp:239
+#: ../src/common/debugrpt.cpp:240
 #, c-format
 msgid "Failed to clean up debug report directory \"%s\""
 msgstr "디버그 보고서 디렉토리 \"%s\" 를 비우는데 실패했습니다."
 
-#: ../src/common/filename.cpp:192
+#: ../src/common/filename.cpp:189
 msgid "Failed to close file handle"
 msgstr "파일 닫기를 실패했습니다."
 
-#: ../src/unix/snglinst.cpp:340
+#: ../src/unix/snglinst.cpp:337
 #, c-format
 msgid "Failed to close lock file '%s'"
 msgstr "'%s' 파일을 지우는 실패했습니다(잠금 파일)."
 
-#: ../src/msw/clipbrd.cpp:112
+#: ../src/msw/clipbrd.cpp:110
 msgid "Failed to close the clipboard."
 msgstr "클립보드를 닫는 데 실패했습니다."
 
-#: ../src/x11/utils.cpp:208
+#: ../src/x11/utils.cpp:170
 #, c-format
 msgid "Failed to close the display \"%s\""
 msgstr "디스플레이 \"%s\" 를 닫는 데 실패했습니다."
 
-#: ../src/msw/dialup.cpp:797
+#: ../src/msw/dialup.cpp:791
 msgid "Failed to connect: missing username/password."
 msgstr "접속 실패: ID 또는 Password가 잘못되었습니다."
 
-#: ../src/msw/dialup.cpp:743
+#: ../src/msw/dialup.cpp:737
 msgid "Failed to connect: no ISP to dial."
 msgstr "접속 실패: 전화 접속을 위한 ISP가 없음"
 
-#: ../src/common/textfile.cpp:203
-#, c-format
-msgid "Failed to convert file \"%s\" to Unicode."
-msgstr "\"%s\" 파을을 유니코드로 변환하는데 실패했습니다."
-
-#: ../src/generic/logg.cpp:956
+#: ../src/generic/logg.cpp:953
 #, fuzzy
 msgid "Failed to copy dialog contents to the clipboard."
 msgstr "클립보드를 여는 데 실패했습니다."
 
-#: ../src/msw/registry.cpp:692
+#: ../src/msw/registry.cpp:681
 #, c-format
 msgid "Failed to copy registry value '%s'"
 msgstr "레지스트 값 '%s' 을 복사하는데 실패했습니다."
 
-#: ../src/msw/registry.cpp:701
+#: ../src/msw/registry.cpp:690
 #, c-format
 msgid "Failed to copy the contents of registry key '%s' to '%s'."
 msgstr "레지스터 키 '%s' 에서 '%s' 로 값 복사가 실패했습니다."
 
-#: ../src/common/filefn.cpp:1015
+#: ../src/common/filefn.cpp:904
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "파일 '%s' 를 '%s' 로 복사하는데 실패했습니다."
 
-#: ../src/msw/registry.cpp:679
+#: ../src/msw/registry.cpp:668
 #, c-format
 msgid "Failed to copy the registry subkey '%s' to '%s'."
 msgstr "레지스터 서브키 '%s' 에서 '%s' 로의 값 복사가 실패 했습니다."
 
-#: ../src/msw/dde.cpp:1070
+#: ../src/msw/dde.cpp:1134
 msgid "Failed to create DDE string"
 msgstr "DDE 문자열 생성을 실패 했습니다."
 
-#: ../src/msw/mdi.cpp:616
+#: ../src/msw/mdi.cpp:621
 msgid "Failed to create MDI parent frame."
 msgstr "MDI의 프레임 생성을 실패 했습니다."
 
-#: ../src/common/filename.cpp:1027
+#: ../src/common/filename.cpp:1024
 msgid "Failed to create a temporary file name"
 msgstr "임시 파일을 생성을 실패했습니다"
 
-#: ../src/msw/utilsexc.cpp:228
+#: ../src/msw/utilsexc.cpp:225
 msgid "Failed to create an anonymous pipe"
 msgstr "익명 파이프 생성을 실패했습니다."
 
-#: ../src/msw/ole/automtn.cpp:522
+#: ../src/msw/ole/automtn.cpp:513
 #, fuzzy, c-format
 msgid "Failed to create an instance of \"%s\""
 msgstr "디렉토리 \"%s\" 생성을 실패했습니다."
 
-#: ../src/msw/dde.cpp:437
+#: ../src/msw/dde.cpp:432
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "'%s' 서버의 '%s' 서비스로의 접속을 실패 했습니다."
 
-#: ../src/msw/cursor.cpp:204
+#: ../src/msw/cursor.cpp:195
 msgid "Failed to create cursor."
 msgstr "마우스 커서 생성을 실패했습니다."
 
-#: ../src/common/debugrpt.cpp:209
+#: ../src/common/debugrpt.cpp:210
 #, c-format
 msgid "Failed to create directory \"%s\""
 msgstr "디렉토리 \"%s\" 생성을 실패했습니다."
 
-#: ../src/generic/dirdlgg.cpp:220
+#: ../src/generic/dirdlgg.cpp:217
 #, c-format
 msgid ""
 "Failed to create directory '%s'\n"
@@ -3306,185 +3331,204 @@ msgstr ""
 msgid "Failed to create epoll descriptor"
 msgstr "Epoll 디스크립터 생성을 실패했습니다."
 
-#: ../src/msw/mimetype.cpp:238
+#: ../src/gtk/font.cpp:562
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "사용자 설정 파일을 갱신하는데 실패했습니다."
+
+#: ../src/msw/mimetype.cpp:235
 #, c-format
 msgid "Failed to create registry entry for '%s' files."
 msgstr "'%s' 타입의 파일실행을 위한 레지스터 키 등록을 실패했습니다."
 
-#: ../src/msw/fdrepdlg.cpp:409
+#: ../src/msw/fdrepdlg.cpp:408
 #, c-format
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr "표준 찾기/바꾸기 창 생성 실패(오류 코드 %d)"
 
-#: ../src/unix/wakeuppipe.cpp:52
+#: ../src/unix/wakeuppipe.cpp:49
 msgid "Failed to create wake up pipe used by event loop."
 msgstr "이벤트 루프에 의한 파이프 Wake-up이 실패 했습니다."
 
-#: ../src/html/winpars.cpp:730
+#: ../src/html/winpars.cpp:727
 #, c-format
 msgid "Failed to display HTML document in %s encoding"
 msgstr "%s 인코딩으로 HTML 문서 보기 실패"
 
-#: ../src/msw/clipbrd.cpp:124
+#: ../src/msw/clipbrd.cpp:122
 msgid "Failed to empty the clipboard."
 msgstr "클립보드를 비우는데 실패했습니다."
 
-#: ../src/unix/displayx11.cpp:212
+#: ../include/wx/unix/private/displayx11.h:65
 msgid "Failed to enumerate video modes"
 msgstr "디스플레이 모드 찾을 수 없습니다."
 
-#: ../src/msw/dde.cpp:722
+#: ../src/msw/dde.cpp:717
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "DDE 서버의 어드바이스 루프로의 연결을 실패 했습니다."
 
-#: ../src/msw/dialup.cpp:629 ../src/msw/dialup.cpp:863
+#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "%s 에 dialup 연결을 실패했습니다."
 
-#: ../src/unix/utilsunx.cpp:611
+#: ../src/unix/utilsunx.cpp:613
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "'%s' 실행을 실패했습니다.\n"
 
-#: ../src/common/debugrpt.cpp:720
+#: ../src/common/debugrpt.cpp:730
 msgid "Failed to execute curl, please install it in PATH."
 msgstr "Curl 을 실행할 수 없습니다. PATH 폴더에 설치해 주세요."
 
-#: ../src/msw/ole/automtn.cpp:505
+#: ../src/msw/ole/automtn.cpp:496
 #, fuzzy, c-format
 msgid "Failed to find CLSID of \"%s\""
 msgstr "'%s' 디스플레이를 여는 데 실패했습니다."
 
-#: ../src/common/regex.cpp:431 ../src/common/regex.cpp:479
+#: ../src/common/regex.cpp:428 ../src/common/regex.cpp:476
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "정규 표현식 %s 에 대한 검색 실패"
 
-#: ../src/msw/dialup.cpp:695
+#: ../src/msw/webview_ie.cpp:978
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:689
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "ISP 이름을 가져오기 실패: %s"
 
-#: ../src/msw/ole/automtn.cpp:574
+#: ../src/msw/ole/automtn.cpp:565
 #, fuzzy, c-format
 msgid "Failed to get OLE automation interface for \"%s\""
 msgstr "디렉토리 \"%s\" 생성을 실패했습니다."
 
-#: ../src/msw/clipbrd.cpp:711
+#: ../src/msw/clipbrd.cpp:731
 msgid "Failed to get data from the clipboard"
 msgstr "클립보드 데이타를 가져오는데 실패했습니다."
 
-#: ../src/common/time.cpp:223
+#: ../src/common/time.cpp:216
 msgid "Failed to get the local system time"
 msgstr "로컬 시스템이 시간을 얻어올 수 없습니다."
 
-#: ../src/common/filefn.cpp:1345
+#: ../src/common/filefn.cpp:1233
 msgid "Failed to get the working directory"
 msgstr "작업 디렉토리를 가져오는데 실패했습니다."
 
-#: ../src/univ/theme.cpp:114
+#: ../src/univ/theme.cpp:111
 msgid "Failed to initialize GUI: no built-in themes found."
 msgstr "GUI 초기화 실패: 테마를 찾을 수 없습니다."
 
-#: ../src/msw/helpchm.cpp:63
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:60
 msgid "Failed to initialize MS HTML Help."
 msgstr "MS HTML 도움말 초기화 실패."
 
-#: ../src/msw/glcanvas.cpp:1381
+#: ../src/msw/glcanvas.cpp:1391
 msgid "Failed to initialize OpenGL"
 msgstr "OpenGL 초기화를 실패했습니다."
 
-#: ../src/msw/dialup.cpp:858
+#: ../src/msw/dialup.cpp:852
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "dialup 연결을 초기화 하는데 실패: %s"
 
-#: ../src/gtk/textctrl.cpp:1128
+#: ../src/gtk/textctrl.cpp:1209
 msgid "Failed to insert text in the control."
 msgstr "컨트롤에 텍스트 삽입 실패."
 
-#: ../src/unix/snglinst.cpp:241
+#: ../src/unix/snglinst.cpp:238
 #, c-format
 msgid "Failed to inspect the lock file '%s'"
 msgstr "'%s' 파일 조사를 실패했습니다(잠금 파일)."
 
-#: ../src/unix/appunix.cpp:182
+#: ../src/unix/appunix.cpp:179
 msgid "Failed to install signal handler"
 msgstr "Signal 등록을 실패했습니다."
 
-#: ../src/unix/threadpsx.cpp:1167
+#: ../src/unix/threadpsx.cpp:1216
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
 msgstr ""
 "쓰레드 종료 실패, 잠재적인 메모리 누수 감지함. 프로그램을 다시 시작하십시오."
 
-#: ../src/msw/utils.cpp:629
+#: ../src/msw/utils.cpp:619
 #, c-format
 msgid "Failed to kill process %d"
 msgstr "프로세스 %d 종료할 수 없습니다."
 
-#: ../src/common/image.cpp:2500
+#: ../src/common/image.cpp:2595
 #, fuzzy, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "%d 이미지('%s' 파일에서)를 읽어올 수 없습니다."
 
-#: ../src/common/image.cpp:2509
+#: ../src/common/image.cpp:2604
 #, fuzzy, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "%d 이미지('%s' 파일에서)를 읽어올 수 없습니다."
 
-#: ../src/common/iconbndl.cpp:225
+#: ../src/common/iconbndl.cpp:224
 #, fuzzy, c-format
 msgid "Failed to load icons from resource '%s'."
 msgstr "%d 이미지('%s' 파일에서)를 읽어올 수 없습니다."
 
-#: ../src/common/iconbndl.cpp:200
+#: ../src/common/iconbndl.cpp:198
 #, fuzzy, c-format
 msgid "Failed to load image %%d from file '%s'."
 msgstr "%d 이미지('%s' 파일에서)를 읽어올 수 없습니다."
 
-#: ../src/common/iconbndl.cpp:208
+#: ../src/common/iconbndl.cpp:206
 #, fuzzy, c-format
 msgid "Failed to load image %d from stream."
 msgstr "%d 이미지('%s' 파일에서)를 읽어올 수 없습니다."
 
-#: ../src/common/image.cpp:2587 ../src/common/image.cpp:2606
+#: ../src/common/image.cpp:2682 ../src/common/image.cpp:2701
 #, fuzzy, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "%d 이미지('%s' 파일에서)를 읽어올 수 없습니다."
 
-#: ../src/msw/enhmeta.cpp:97
+#: ../src/msw/enhmeta.cpp:94
 #, c-format
 msgid "Failed to load metafile from file \"%s\"."
 msgstr "\"%s\" 파일에서 메타 파일을 읽어올 수 없습니다."
 
-#: ../src/msw/volume.cpp:327
+#: ../src/msw/volume.cpp:335
 msgid "Failed to load mpr.dll."
 msgstr "mpr.dll 을 읽어올 수 없습니다."
 
-#: ../src/msw/utils.cpp:953
+#: ../src/msw/utils.cpp:943
 #, fuzzy, c-format
 msgid "Failed to load resource \"%s\"."
 msgstr "\"%s\" 파일에서 메타 파일을 읽어올 수 없습니다."
 
-#: ../src/common/dynlib.cpp:92
+#: ../src/common/dynlib.cpp:86
 #, c-format
 msgid "Failed to load shared library '%s'"
 msgstr "'%s' 공유 Library를 읽어올 수 없습니다."
 
-#: ../src/osx/core/sound.cpp:145
+#: ../src/osx/core/sound.cpp:143
 #, fuzzy, c-format
 msgid "Failed to load sound from \"%s\" (error %d)."
 msgstr "\"%s\" 파일에서 메타 파일을 읽어올 수 없습니다."
 
-#: ../src/msw/utils.cpp:960
+#: ../src/msw/utils.cpp:950
 #, fuzzy, c-format
 msgid "Failed to lock resource \"%s\"."
 msgstr "'%s' 잠금 파일의 잠금 실패 "
 
-#: ../src/unix/snglinst.cpp:198
+#: ../src/unix/snglinst.cpp:195
 #, c-format
 msgid "Failed to lock the lock file '%s'"
 msgstr "'%s' 잠금 파일의 잠금 실패 "
@@ -3494,33 +3538,38 @@ msgstr "'%s' 잠금 파일의 잠금 실패 "
 msgid "Failed to modify descriptor %d in epoll descriptor %d"
 msgstr "Epoll 디스크립터 %d에서  파일 디스크립터 %d의 수정을 실패 했습니다."
 
-#: ../src/common/filename.cpp:2575
+#: ../src/common/filename.cpp:2658
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "%s 번 파일을 수정하는 데 실패"
 
-#: ../src/common/selectdispatcher.cpp:258
+#: ../src/common/selectdispatcher.cpp:255
 msgid "Failed to monitor I/O channels"
 msgstr "모니터의 I/O 채널 선택 실패"
 
-#: ../src/common/filename.cpp:175
+#: ../src/common/filename.cpp:172
 #, c-format
 msgid "Failed to open '%s' for reading"
 msgstr "'%s' 파일을 읽기 모드로 여는 데 실패했습니다."
 
-#: ../src/common/filename.cpp:180
+#: ../src/common/filename.cpp:177
 #, c-format
 msgid "Failed to open '%s' for writing"
 msgstr "'%s' 파일을 쓰기 모드로 여는 데 실패했습니다."
 
-#: ../src/html/chm.cpp:141
+#: ../src/html/chm.cpp:138
 #, c-format
 msgid "Failed to open CHM archive '%s'."
 msgstr "'%s' CHM 파일을 여는 데 실패했습니다."
 
-#: ../src/common/utilscmn.cpp:1126
+#: ../src/common/utilscmn.cpp:1140
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
+msgstr "기본 탐색창에서 URL \"%s\" 여는데 실패했습니다."
+
+#: ../src/common/hyperlnkcmn.cpp:133
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "기본 탐색창에서 URL \"%s\" 여는데 실패했습니다."
 
 #: ../include/wx/msw/private/fswatcher.h:92
@@ -3528,94 +3577,104 @@ msgstr "기본 탐색창에서 URL \"%s\" 여는데 실패했습니다."
 msgid "Failed to open directory \"%s\" for monitoring."
 msgstr "'%s' 파일을 쓰기 모드로 여는 데 실패했습니다."
 
-#: ../src/x11/utils.cpp:227
+#: ../src/x11/utils.cpp:189
 #, c-format
 msgid "Failed to open display \"%s\"."
 msgstr "'%s' 디스플레이를 여는 데 실패했습니다."
 
-#: ../src/common/filename.cpp:1062
+#: ../src/common/filename.cpp:1059
 msgid "Failed to open temporary file."
 msgstr "임시 파일을 여는 데 실패했습니다."
 
-#: ../src/msw/clipbrd.cpp:91
+#: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "클립보드를 여는 데 실패했습니다."
 
-#: ../src/common/translation.cpp:1184
+#: ../src/common/translation.cpp:1226
 #, fuzzy, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "복수형(Plural-Forms) 표현식을 해석할 수 없음: '%s'"
 
-#: ../src/unix/mediactrl.cpp:1214
+#: ../src/unix/mediactrl.cpp:1239
 #, fuzzy, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "'%s' 디스플레이를 여는 데 실패했습니다."
 
-#: ../src/msw/clipbrd.cpp:600
+#: ../src/msw/clipbrd.cpp:610
 msgid "Failed to put data on the clipboard"
 msgstr "클립보드에 데이타 추가 실패"
 
-#: ../src/unix/snglinst.cpp:278
+#: ../src/unix/snglinst.cpp:275
 msgid "Failed to read PID from lock file."
 msgstr "잠금 파일에서  pid를  읽는 데 실패했습니다."
 
-#: ../src/common/fileconf.cpp:433
+#: ../src/common/fileconf.cpp:432
 msgid "Failed to read config options."
 msgstr "설정을 읽어오지 못했습니다."
 
-#: ../src/common/docview.cpp:681
+#: ../src/common/docview.cpp:676
 #, fuzzy, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "\"%s\" 파일에서 메타 파일을 읽어올 수 없습니다."
 
-#: ../src/dfb/evtloop.cpp:98
+#: ../src/dfb/evtloop.cpp:99
 #, fuzzy
 msgid "Failed to read event from DirectFB pipe"
 msgstr "Wake-up 파이프에서 읽는 데 실패했습니다."
 
-#: ../src/unix/wakeuppipe.cpp:120
+#: ../src/unix/wakeuppipe.cpp:117
 msgid "Failed to read from wake-up pipe"
 msgstr "Wake-up 파이프에서 읽는 데 실패했습니다."
 
-#: ../src/unix/utilsunx.cpp:679
+#: ../src/common/textfile.cpp:96
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "\"%s\" 파일에서 메타 파일을 읽어올 수 없습니다."
+
+#: ../src/unix/utilsunx.cpp:681
 msgid "Failed to redirect child process input/output"
 msgstr "자식 프로세스의 입력 또는 출력의 리다이렉트 실패"
 
-#: ../src/msw/utilsexc.cpp:701
+#: ../src/msw/utilsexc.cpp:698
 msgid "Failed to redirect the child process IO"
 msgstr "자식 프로세스의 입출력 리다이렉트 실패"
 
-#: ../src/msw/dde.cpp:288
+#: ../src/msw/dde.cpp:283
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "'%s' DDE 서버 등록 실패"
 
-#: ../src/common/fontmap.cpp:245
+#: ../src/gtk/font.cpp:580
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "사용자 설정 파일을 갱신하는데 실패했습니다."
+
+#: ../src/common/fontmap.cpp:242
 #, c-format
 msgid "Failed to remember the encoding for the charset '%s'."
 msgstr "'%s' 에 대한 서브 인코딩을 알수 없습니다."
 
-#: ../src/common/debugrpt.cpp:227
+#: ../src/common/debugrpt.cpp:228
 #, c-format
 msgid "Failed to remove debug report file \"%s\""
 msgstr "디버그 보고서 파일 \"%s\" 의 삭제를 실패했습니다."
 
-#: ../src/unix/snglinst.cpp:328
+#: ../src/unix/snglinst.cpp:325
 #, c-format
 msgid "Failed to remove lock file '%s'"
 msgstr "'%s' 잠금 파일을 지우는 데 실패했습니다"
 
-#: ../src/unix/snglinst.cpp:288
+#: ../src/unix/snglinst.cpp:285
 #, c-format
 msgid "Failed to remove stale lock file '%s'."
 msgstr "오래된 잠금 파일 '%s' 의 삭제 실패"
 
-#: ../src/msw/registry.cpp:529
+#: ../src/msw/registry.cpp:518
 #, c-format
 msgid "Failed to rename registry value '%s' to '%s'."
 msgstr "'%s' 레지스트 값을 '%s'로 변경 실패"
 
-#: ../src/common/filefn.cpp:1122
+#: ../src/common/filefn.cpp:1011
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -3623,117 +3682,126 @@ msgid ""
 msgstr ""
 "파일이름을  '%s' 에서 '%s' 로 변경 실패, 동일한 파일이름이 이미 존재합니다."
 
-#: ../src/msw/registry.cpp:634
+#: ../src/msw/registry.cpp:623
 #, c-format
 msgid "Failed to rename the registry key '%s' to '%s'."
 msgstr "'%s' 레지스트 키를 '%s'로 변경 실패"
 
-#: ../src/common/filename.cpp:2671
+#: ../src/msw/webview_ie.cpp:995
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/common/filename.cpp:2754
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "'%s' 번 파일검색 실패 "
 
-#: ../src/msw/dialup.cpp:468
+#: ../src/msw/dialup.cpp:462
 msgid "Failed to retrieve text of RAS error message"
 msgstr "RAS 오류 메시지의 텍스트의 검색 실패"
 
-#: ../src/msw/clipbrd.cpp:748
+#: ../src/msw/clipbrd.cpp:768
 msgid "Failed to retrieve the supported clipboard formats"
 msgstr "제공되는 클립보드 포맷을 찾을 수 없습니다."
 
-#: ../src/common/docview.cpp:652
+#: ../src/common/docview.cpp:647
 #, fuzzy, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "\"%s\" 비트맵 이미지 파을을 저장하는데 실패했습니다."
 
-#: ../src/msw/dib.cpp:269
+#: ../src/msw/dib.cpp:312
 #, c-format
 msgid "Failed to save the bitmap image to file \"%s\"."
 msgstr "\"%s\" 비트맵 이미지 파을을 저장하는데 실패했습니다."
 
-#: ../src/msw/dde.cpp:763
+#: ../src/msw/dde.cpp:811
 msgid "Failed to send DDE advise notification"
 msgstr "DDE 어드바이서에서 통지 전송을 실패했습니다"
 
-#: ../src/common/ftp.cpp:402
+#: ../src/common/ftp.cpp:399
 #, c-format
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "FTP 전송모드를 %s 로 변경하지 못했습니다. "
 
-#: ../src/msw/clipbrd.cpp:427
+#: ../src/msw/clipbrd.cpp:443
 msgid "Failed to set clipboard data."
 msgstr "클립보드 데이타 설정을 실패했습니다."
 
-#: ../src/unix/snglinst.cpp:181
+#: ../src/unix/snglinst.cpp:178
 #, c-format
 msgid "Failed to set permissions on lock file '%s'"
 msgstr "잠금 파일 '%s' 의 접근권한 설정을 실패했습니다."
 
-#: ../src/unix/utilsunx.cpp:668
+#: ../src/unix/utilsunx.cpp:670
 #, fuzzy
 msgid "Failed to set process priority"
 msgstr "스레드 우선순위(%d) 설정을 실패했습니다."
 
-#: ../src/common/file.cpp:559
+#: ../src/common/ffile.cpp:355 ../src/common/file.cpp:586
 msgid "Failed to set temporary file permissions"
 msgstr "임시 파일의 접근 권한 설정을 실패 했습니다."
 
-#: ../src/gtk/textctrl.cpp:1072
-msgid "Failed to set text in the text control."
-msgstr "텍스트 Control의 텍스트 입력 실패(인코딩 변환문제)"
-
-#: ../src/unix/threadpsx.cpp:1298
+#: ../src/unix/threadpsx.cpp:1347
 #, fuzzy, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "스레드 우선순위(%d) 설정을 실패했습니다."
 
-#: ../src/unix/threadpsx.cpp:1424
+#: ../src/unix/threadpsx.cpp:1473
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "스레드 우선순위(%d) 설정을 실패했습니다."
 
-#: ../src/unix/utilsunx.cpp:783
+#: ../src/unix/utilsunx.cpp:785
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 
-#: ../src/common/fs_mem.cpp:261
+#: ../src/msw/webview_ie.cpp:987
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:256
 #, c-format
 msgid "Failed to store image '%s' to memory VFS!"
 msgstr "메모리 맵드 파일 '%s' 에 이미지 저장 실패"
 
-#: ../src/dfb/evtloop.cpp:170
+#: ../src/dfb/evtloop.cpp:171
 #, fuzzy
 msgid "Failed to switch DirectFB pipe to non-blocking mode"
 msgstr "비동기 모드에서 파이프를 Wake-up 상태롤 변경하는데 실패"
 
-#: ../src/unix/wakeuppipe.cpp:59
+#: ../src/unix/wakeuppipe.cpp:56
 msgid "Failed to switch wake up pipe to non-blocking mode"
 msgstr "비동기 모드에서 파이프를 Wake-up 상태롤 변경하는데 실패"
 
-#: ../src/unix/threadpsx.cpp:1605
+#: ../src/unix/threadpsx.cpp:1654
 msgid "Failed to terminate a thread."
 msgstr "스레드를 종료를 실패했습니다."
 
-#: ../src/msw/dde.cpp:741
+#: ../src/msw/dde.cpp:736
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "DDE 서버의 어드바이스를 종료할 수 없습니다."
 
-#: ../src/msw/dialup.cpp:938
+#: ../src/msw/dialup.cpp:932
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "전화연결 종료 실패: %s"
 
-#: ../src/common/filename.cpp:2590
+#: ../src/common/filename.cpp:2673
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "'%s' 파일 만들기 실패"
 
-#: ../src/unix/snglinst.cpp:334
+#: ../src/unix/dlunix.cpp:90
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "'%s' 공유 Library를 읽어올 수 없습니다."
+
+#: ../src/unix/snglinst.cpp:331
 #, c-format
 msgid "Failed to unlock lock file '%s'"
 msgstr "'%s' 파일의 잠금 해제 실패"
 
-#: ../src/msw/dde.cpp:309
+#: ../src/msw/dde.cpp:304
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "등록된 '%s' DDE 서버를 제거하는데 실패했습니다. "
@@ -3747,79 +3815,89 @@ msgstr "Epoll 디스크립트 %d 에서 파일 디스크립터 %d를 제거하�
 msgid "Failed to update user configuration file."
 msgstr "사용자 설정 파일을 갱신하는데 실패했습니다."
 
-#: ../src/common/debugrpt.cpp:733
+#: ../src/common/debugrpt.cpp:743
 #, c-format
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "디버그 보고서 전송 실패 (오류 코드 %d)"
 
-#: ../src/unix/snglinst.cpp:168
+#: ../src/unix/snglinst.cpp:165
 #, c-format
 msgid "Failed to write to lock file '%s'"
 msgstr "'%s' 잠금 파일에 쓰기를 실패했습니다."
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:209
+#: ../src/propgrid/propgrid.cpp:190
 #, fuzzy
 msgid "False"
 msgstr "파일"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:694
+#: ../src/propgrid/advprops.cpp:604
 #, fuzzy
 msgid "Family"
 msgstr "글꼴 패밀리(&F):"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/gtk/glcanvas.cpp:176 ../src/gtk/glcanvas.cpp:187
+#, fuzzy
+msgid "Fatal Error"
+msgstr "치명적인 오류"
+
+#: ../src/common/stockitem.cpp:154
 msgid "File"
 msgstr "파일"
 
-#: ../src/common/docview.cpp:669
+#: ../src/common/docview.cpp:664
 #, fuzzy, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "'%s' 파일을 읽기 모드로 여는 데 실패했습니다."
 
-#: ../src/common/docview.cpp:646
+#: ../src/common/docview.cpp:641
 #, fuzzy, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "'%s' 파일을 쓰기 모드로 여는 데 실패했습니다."
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "'%s' 파일이 이미 있습니다.  이 파일을 덮어 쓰시겠습니까?"
 
-#: ../src/common/filefn.cpp:1156
+#: ../src/common/filefn.cpp:1044
 #, fuzzy, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "'%s' 디렉토리를 만들 수 없습니다."
 
-#: ../src/common/filefn.cpp:1139
+#: ../src/common/filefn.cpp:1028
 #, fuzzy, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "'%s' 디렉토리를 만들 수 없습니다."
 
-#: ../src/richtext/richtextctrl.cpp:3081 ../src/common/textcmn.cpp:953
+#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
 msgid "File couldn't be loaded."
 msgstr "파일을 읽어올 수 없습니다."
 
-#: ../src/msw/filedlg.cpp:393
+#: ../src/msw/filedlg.cpp:414
 #, fuzzy, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "색상 선택창에서 오류 발생 : %0lx"
 
-#: ../src/common/docview.cpp:1789
+#: ../src/common/docview.cpp:1783
 msgid "File error"
 msgstr "파일 오류"
 
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/filectrlg.cpp:770
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/filectrlg.cpp:766
 msgid "File name exists already."
 msgstr "파일이 이미 있습니다."
+
+#: ../src/osx/cocoa/filedlg.mm:264
+#, fuzzy
+msgid "File type:"
+msgstr "파일 오류"
 
 #: ../src/motif/filedlg.cpp:220
 msgid "Files"
 msgstr "파일"
 
-#: ../src/common/filefn.cpp:1591
+#: ../src/common/filefn.cpp:1479
 #, c-format
 msgid "Files (%s)"
 msgstr "파일 (%s)"
@@ -3828,16 +3906,30 @@ msgstr "파일 (%s)"
 msgid "Filter"
 msgstr "필터"
 
-#: ../src/common/stockitem.cpp:158 ../src/html/helpwnd.cpp:490
+#: ../src/html/helpwnd.cpp:488
 msgid "Find"
 msgstr "찾기"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:259
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:258
+#, fuzzy
+msgid "Find in document"
+msgstr "HTML 문서를 엽니다"
+
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "Find..."
+msgstr "찾기"
+
+#: ../src/common/stockitem.cpp:156
 #, fuzzy
 msgid "First"
 msgstr "첫 번째"
 
-#: ../src/common/prntbase.cpp:1548
+#: ../src/common/prntbase.cpp:1573
 #, fuzzy
 msgid "First page"
 msgstr "다음 페이지"
@@ -3847,11 +3939,11 @@ msgstr "다음 페이지"
 msgid "Fixed"
 msgstr "고정폭 글꼴:"
 
-#: ../src/html/helpwnd.cpp:1206
+#: ../src/html/helpwnd.cpp:1204
 msgid "Fixed font:"
 msgstr "고정폭 글꼴:"
 
-#: ../src/html/helpwnd.cpp:1269
+#: ../src/html/helpwnd.cpp:1267
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "고정 폭 모습.<br> <b>굵게</b> <i>기울임</i> "
 
@@ -3859,17 +3951,17 @@ msgstr "고정 폭 모습.<br> <b>굵게</b> <i>기울임</i> "
 msgid "Floating"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 #, fuzzy
 msgid "Floppy"
 msgstr "복사"
 
-#: ../src/common/paper.cpp:111
+#: ../src/common/paper.cpp:108
 msgid "Folio, 8 1/2 x 13 in"
 msgstr "Folio, 8 1/2 x 13 in"
 
-#: ../src/richtext/richtextformatdlg.cpp:344 ../src/osx/carbon/fontdlg.cpp:287
-#: ../src/common/stockitem.cpp:194
+#: ../src/osx/carbon/fontdlg.cpp:284 ../src/common/stockitem.cpp:191
+#: ../src/richtext/richtextformatdlg.cpp:337
 msgid "Font"
 msgstr "Font"
 
@@ -3877,7 +3969,24 @@ msgstr "Font"
 msgid "Font &weight:"
 msgstr "글꼴 굵기(&W):"
 
-#: ../src/html/helpwnd.cpp:1207
+#: ../src/osx/fontutil.cpp:89
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
+"\"."
+msgstr ""
+
+#: ../src/msw/font.cpp:1126
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "파일을 읽어올 수 없습니다."
+
+#: ../src/osx/fontutil.cpp:81
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "%s 파일이 없습니다."
+
+#: ../src/html/helpwnd.cpp:1205
 msgid "Font size:"
 msgstr "글꼴 크기:"
 
@@ -3885,76 +3994,76 @@ msgstr "글꼴 크기:"
 msgid "Font st&yle:"
 msgstr "글꼴 모양새(&Y):"
 
-#: ../src/osx/carbon/fontdlg.cpp:329
+#: ../src/osx/carbon/fontdlg.cpp:326
 msgid "Font:"
 msgstr "글꼴:"
 
-#: ../src/dfb/fontmgr.cpp:198
+#: ../src/dfb/fontmgr.cpp:195
 #, c-format
 msgid "Fonts index file %s disappeared while loading fonts."
 msgstr "글꼴을 읽어오는 동안 글꼴 색인파일 %s 이(가) 사라졌습니다."
 
-#: ../src/unix/utilsunx.cpp:645
+#: ../src/unix/utilsunx.cpp:647
 msgid "Fork failed"
 msgstr "포크 실패"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 #, fuzzy
 msgid "Forward"
 msgstr "앞으로(&F)"
 
-#: ../src/common/xtixml.cpp:235
+#: ../src/common/xtixml.cpp:231
 msgid "Forward hrefs are not supported"
 msgstr "포워드 hrefs 지원되지 않습니다"
 
-#: ../src/html/helpwnd.cpp:875
+#: ../src/html/helpwnd.cpp:873
 #, c-format
 msgid "Found %i matches"
 msgstr "%i 개의 항목 검색됨"
 
-#: ../src/generic/prntdlgg.cpp:238
+#: ../src/generic/prntdlgg.cpp:231
 msgid "From:"
 msgstr "송신:"
 
-#: ../src/propgrid/advprops.cpp:1604
+#: ../src/propgrid/advprops.cpp:1510
 msgid "Fuchsia"
 msgstr ""
 
-#: ../src/common/imaggif.cpp:138
+#: ../src/common/imaggif.cpp:135
 msgid "GIF: data stream seems to be truncated."
 msgstr "GIF: 스트림 데이타가 잘렸습니다."
 
-#: ../src/common/imaggif.cpp:128
+#: ../src/common/imaggif.cpp:125
 msgid "GIF: error in GIF image format."
 msgstr "GIF: 이미지 포맷 오류"
 
-#: ../src/common/imaggif.cpp:133
+#: ../src/common/imaggif.cpp:130
 msgid "GIF: not enough memory."
 msgstr "GIF: 메모리가 부족합니다"
 
-#: ../src/gtk/window.cpp:4631
+#: ../src/gtk/window.cpp:5635
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
 msgstr ""
 
-#: ../src/univ/themes/gtk.cpp:525
+#: ../src/univ/themes/gtk.cpp:522
 msgid "GTK+ theme"
 msgstr "Gtk+ 테마"
 
-#: ../src/common/preferencescmn.cpp:40
+#: ../src/common/preferencescmn.cpp:37
 msgid "General"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:258
+#: ../src/common/prntbase.cpp:253
 msgid "Generic PostScript"
 msgstr "일반 PostScript"
 
-#: ../src/common/paper.cpp:135
+#: ../src/common/paper.cpp:132
 msgid "German Legal Fanfold, 8 1/2 x 13 in"
 msgstr "German Legal Fanfold, 8 1/2 x 13 in"
 
-#: ../src/common/paper.cpp:134
+#: ../src/common/paper.cpp:131
 msgid "German Std Fanfold, 8 1/2 x 12 in"
 msgstr "German Std Fanfold, 8 1/2 x 12 in"
 
@@ -3970,48 +4079,48 @@ msgstr ""
 msgid "GetPropertyCollection called w/o valid collection getter"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:658
 msgid "Go back"
 msgstr "뒤로 가기"
 
-#: ../src/html/helpwnd.cpp:661
+#: ../src/html/helpwnd.cpp:659
 msgid "Go forward"
 msgstr "앞으로 가기"
 
-#: ../src/html/helpwnd.cpp:663
+#: ../src/html/helpwnd.cpp:661
 msgid "Go one level up in document hierarchy"
 msgstr "위로 이동"
 
-#: ../src/generic/filedlgg.cpp:208 ../src/generic/dirdlgg.cpp:116
+#: ../src/generic/filedlgg.cpp:205 ../src/generic/dirdlgg.cpp:113
 msgid "Go to home directory"
 msgstr "홈 디렉토리로 가기"
 
-#: ../src/generic/filedlgg.cpp:205
+#: ../src/generic/filedlgg.cpp:202
 msgid "Go to parent directory"
 msgstr "부모 디렉토리로 가기"
 
-#: ../src/generic/aboutdlgg.cpp:76
+#: ../src/generic/aboutdlgg.cpp:73
 msgid "Graphics art by "
 msgstr "그래픽"
 
-#: ../src/propgrid/advprops.cpp:1599
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Gray"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:883
+#: ../src/propgrid/advprops.cpp:784
 msgid "GrayText"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:154
+#: ../src/common/fmapbase.cpp:151
 msgid "Greek (ISO-8859-7)"
 msgstr "그리스어 (ISO-8859-7)"
 
-#: ../src/propgrid/advprops.cpp:1600
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Green"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:342
+#: ../src/generic/colrdlgg.cpp:362
 msgid "Green:"
 msgstr ""
 
@@ -4019,109 +4128,109 @@ msgstr ""
 msgid "Groove"
 msgstr ""
 
-#: ../src/common/zstream.cpp:158 ../src/common/zstream.cpp:318
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
 msgid "Gzip not supported by this version of zlib"
 msgstr "사용중인 zlib 버전에서 Gzip을 지원하지 않습니다."
 
-#: ../src/html/helpwnd.cpp:1549
+#: ../src/html/helpwnd.cpp:1547
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "HTML 도움말 프로젝트 (*.hhp)|*.hhp|"
 
-#: ../src/html/htmlwin.cpp:681
+#: ../src/html/htmlwin.cpp:691
 #, c-format
 msgid "HTML anchor %s does not exist."
 msgstr "HTML anchor %s 가 없습니다."
 
-#: ../src/html/helpwnd.cpp:1547
+#: ../src/html/helpwnd.cpp:1545
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "HTML 파일 (*.html;*.htm)|*.html;*.htm|"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1759
+#: ../src/propgrid/advprops.cpp:1660
 msgid "Hand"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "Harddisk"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:155
+#: ../src/common/fmapbase.cpp:152
 msgid "Hebrew (ISO-8859-8)"
 msgstr "히브리어 (ISO-8859-8)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:280 ../src/osx/button_osx.cpp:39
-#: ../src/common/stockitem.cpp:163 ../src/common/accelcmn.cpp:80
-#: ../src/html/helpdlg.cpp:66 ../src/html/helpfrm.cpp:111
+#: ../include/wx/msgdlg.h:282 ../src/osx/button_osx.cpp:39
+#: ../src/common/stockitem.cpp:160 ../src/common/accelcmn.cpp:77
+#: ../src/html/helpfrm.cpp:108 ../src/html/helpdlg.cpp:63
 msgid "Help"
 msgstr "도움말"
 
-#: ../src/html/helpwnd.cpp:1200
+#: ../src/html/helpwnd.cpp:1198
 msgid "Help Browser Options"
 msgstr "도움말 설정"
 
-#: ../src/generic/helpext.cpp:454 ../src/generic/helpext.cpp:455
+#: ../src/generic/helpext.cpp:452 ../src/generic/helpext.cpp:453
 msgid "Help Index"
 msgstr "도움말 인덱스"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1529
 msgid "Help Printing"
 msgstr "인쇄 도움말"
 
-#: ../src/html/helpwnd.cpp:801
+#: ../src/html/helpwnd.cpp:799
 msgid "Help Topics"
 msgstr "도움말 주제"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1546
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "도움말 문서 (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 
-#: ../src/generic/helpext.cpp:267
+#: ../src/generic/helpext.cpp:265
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "도움말 디렉토리 \"%s\" 가 없습니다."
 
-#: ../src/generic/helpext.cpp:275
+#: ../src/generic/helpext.cpp:273
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "도움말 파일 \"%s\" 이 없습니다."
 
-#: ../src/html/helpctrl.cpp:63
+#: ../src/html/helpctrl.cpp:59
 #, c-format
 msgid "Help: %s"
 msgstr "도움말: %s"
 
-#: ../src/osx/menu_osx.cpp:577
+#: ../src/osx/menu_osx.cpp:469
 #, fuzzy, c-format
 msgid "Hide %s"
 msgstr "도움말: %s"
 
-#: ../src/osx/menu_osx.cpp:579
+#: ../src/osx/menu_osx.cpp:471
 msgid "Hide Others"
 msgstr ""
 
-#: ../src/generic/infobar.cpp:84
+#: ../src/generic/infobar.cpp:81
 msgid "Hide this notification message."
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:884
+#: ../src/propgrid/advprops.cpp:785
 #, fuzzy
 msgid "Highlight"
 msgstr "가늘게"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:885
+#: ../src/propgrid/advprops.cpp:786
 #, fuzzy
 msgid "HighlightText"
 msgstr "텍스트 오른쪽 정렬"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:164 ../src/common/accelcmn.cpp:65
+#: ../src/common/stockitem.cpp:161 ../src/common/accelcmn.cpp:62
 msgid "Home"
 msgstr "홈"
 
-#: ../src/generic/dirctrlg.cpp:524
+#: ../src/generic/dirctrlg.cpp:490
 msgid "Home directory"
 msgstr "홈 디렉토리"
 
@@ -4131,61 +4240,61 @@ msgid "How the object will float relative to the text."
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1760
+#: ../src/propgrid/advprops.cpp:1661
 msgid "I-Beam"
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1196
+#: ../src/common/imagbmp.cpp:1208
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: DIB 마스크에서 읽기 오류가 발생했습니다."
 
-#: ../src/common/imagbmp.cpp:1290 ../src/common/imagbmp.cpp:1390
-#: ../src/common/imagbmp.cpp:1405 ../src/common/imagbmp.cpp:1416
-#: ../src/common/imagbmp.cpp:1430 ../src/common/imagbmp.cpp:1478
-#: ../src/common/imagbmp.cpp:1493 ../src/common/imagbmp.cpp:1507
-#: ../src/common/imagbmp.cpp:1518
+#: ../src/common/imagbmp.cpp:1302 ../src/common/imagbmp.cpp:1402
+#: ../src/common/imagbmp.cpp:1417 ../src/common/imagbmp.cpp:1428
+#: ../src/common/imagbmp.cpp:1442 ../src/common/imagbmp.cpp:1490
+#: ../src/common/imagbmp.cpp:1505 ../src/common/imagbmp.cpp:1519
+#: ../src/common/imagbmp.cpp:1530
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: 이미지 파일 쓰기 오류!"
 
-#: ../src/common/imagbmp.cpp:1255
+#: ../src/common/imagbmp.cpp:1267
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: 아이콘 이미지가 너무큼(길이)"
 
-#: ../src/common/imagbmp.cpp:1263
+#: ../src/common/imagbmp.cpp:1275
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: 아이콘 이미지가 너무큼(너비)"
 
-#: ../src/common/imagbmp.cpp:1603
+#: ../src/common/imagbmp.cpp:1615
 msgid "ICO: Invalid icon index."
 msgstr "ICO: ICON 인덱스가 잘못되었습니다."
 
-#: ../src/common/imagiff.cpp:758
+#: ../src/common/imagiff.cpp:755
 msgid "IFF: data stream seems to be truncated."
 msgstr "IFF: 스트림 데이타가 잘렸습니다."
 
-#: ../src/common/imagiff.cpp:742
+#: ../src/common/imagiff.cpp:739
 msgid "IFF: error in IFF image format."
 msgstr "IFF: IFF 이미지 포맷 오류"
 
-#: ../src/common/imagiff.cpp:745
+#: ../src/common/imagiff.cpp:742
 msgid "IFF: not enough memory."
 msgstr "IFF: 메모리가 부족합니다"
 
-#: ../src/common/imagiff.cpp:748
+#: ../src/common/imagiff.cpp:745
 msgid "IFF: unknown error!!!"
 msgstr "IFF: 알 수 없는 오류가 발생!!!"
 
-#: ../src/common/fmapbase.cpp:197
+#: ../src/common/fmapbase.cpp:194
 msgid "ISO-2022-JP"
 msgstr "일본어 (ISO-2022-JP)"
 
-#: ../src/html/htmprint.cpp:282
+#: ../src/html/htmprint.cpp:294
 msgid ""
 "If possible, try changing the layout parameters to make the printout more "
 "narrow."
 msgstr ""
 
-#: ../src/generic/dbgrptg.cpp:358
+#: ../src/generic/dbgrptg.cpp:362
 msgid ""
 "If you have any additional information pertaining to this bug\n"
 "report, please enter it here and it will be joined to it:"
@@ -4204,46 +4313,50 @@ msgstr ""
 "하지만 프로그램 개선을 방해할 수 있습니다.\n"
 "가능하시면 보고서를 생성해 주십시오.\n"
 
-#: ../src/msw/registry.cpp:1405
+#: ../src/common/zipstrm.cpp:1043
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1393
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "레지스터 값 \"%s\" 을 무시합니다.(레지스터 키 \"%s\" 에서)"
 
-#: ../src/common/xtistrm.cpp:295
+#: ../src/common/xtistrm.cpp:292
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "잘못된 클래스 객체입니다.(wxEvtHandler 상속한 클래스가 아님)"
 
-#: ../src/common/xti.cpp:513
+#: ../src/common/xti.cpp:510
 msgid "Illegal Parameter Count for ConstructObject Method"
 msgstr ""
 
-#: ../src/common/xti.cpp:501
+#: ../src/common/xti.cpp:498
 msgid "Illegal Parameter Count for Create Method"
 msgstr ""
 
-#: ../src/generic/dirctrlg.cpp:570 ../src/generic/filectrlg.cpp:756
+#: ../src/generic/dirctrlg.cpp:536 ../src/generic/filectrlg.cpp:752
 msgid "Illegal directory name."
 msgstr "잘못된 디렉토리 이름입니다."
 
-#: ../src/generic/filectrlg.cpp:1367
+#: ../src/generic/filectrlg.cpp:1356
 msgid "Illegal file specification."
 msgstr "파일 경로가 잘못되었습니다."
 
-#: ../src/common/image.cpp:2269
+#: ../src/common/image.cpp:2363
 msgid "Image and mask have different sizes."
 msgstr "마스크의 사이즈 정보와 실제 이미지 사이즈가 동일하지 않습니다."
 
-#: ../src/common/image.cpp:2746
+#: ../src/common/image.cpp:2841
 #, fuzzy, c-format
 msgid "Image file is not of type %d."
 msgstr "%ld 타입은 이미지 파일이 아닙니다."
 
-#: ../src/common/image.cpp:2877
+#: ../src/common/image.cpp:2995
 #, fuzzy, c-format
 msgid "Image is not of type %s."
 msgstr "%s 타입은 이미지 파일이 아닙니다."
 
-#: ../src/msw/textctrl.cpp:488
+#: ../src/msw/textctrl.cpp:534
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -4251,104 +4364,104 @@ msgstr ""
 "Rich Edit 컨트롤을 생성할 수 없어 Simple Text 컨트롤로 대체 하였습니다. "
 "riched32.dll 을 재설치 하십시오."
 
-#: ../src/unix/utilsunx.cpp:301
+#: ../src/unix/utilsunx.cpp:303
 msgid "Impossible to get child process input"
 msgstr "자식 프로세스의 입력 리다이렉트 실패"
 
-#: ../src/common/filefn.cpp:1028
+#: ../src/common/filefn.cpp:917
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "'%s' 파일의 접근할 수 없습니다."
 
-#: ../src/common/filefn.cpp:1042
+#: ../src/common/filefn.cpp:931
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "파일 '%s' 덮어쓰기 실패"
 
-#: ../src/common/filefn.cpp:1097
+#: ../src/common/filefn.cpp:986
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "'%s' 파일의 접근권한을 변경할 수 없습니다."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:886
+#: ../src/propgrid/advprops.cpp:787
 #, fuzzy
 msgid "InactiveBorder"
 msgstr "Modern"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:887
+#: ../src/propgrid/advprops.cpp:788
 msgid "InactiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:888
+#: ../src/propgrid/advprops.cpp:789
 msgid "InactiveCaptionText"
 msgstr ""
 
-#: ../src/common/gifdecod.cpp:792
+#: ../src/common/gifdecod.cpp:826
 #, c-format
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:635
+#: ../src/msw/ole/automtn.cpp:626
 msgid "Incorrect number of arguments."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:165
+#: ../src/common/stockitem.cpp:162
 msgid "Indent"
 msgstr "들여쓰기"
 
-#: ../src/richtext/richtextformatdlg.cpp:349
+#: ../src/richtext/richtextformatdlg.cpp:342
 msgid "Indents && Spacing"
 msgstr "들여쓰기 && 줄 간격"
 
-#: ../src/common/stockitem.cpp:166 ../src/html/helpwnd.cpp:515
+#: ../src/common/stockitem.cpp:163 ../src/html/helpwnd.cpp:513
 msgid "Index"
 msgstr "차례"
 
-#: ../src/common/fmapbase.cpp:159
+#: ../src/common/fmapbase.cpp:156
 msgid "Indian (ISO-8859-12)"
 msgstr "인도어 (ISO-8859-12)"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "Info"
 msgstr ""
 
-#: ../src/common/init.cpp:287
+#: ../src/common/init.cpp:284
 msgid "Initialization failed in post init, aborting."
 msgstr "등록된 모듈들의 초기화를 실패했습니다."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:54
+#: ../src/common/accelcmn.cpp:51
 #, fuzzy
 msgid "Ins"
 msgstr "넣기"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextsymboldlg.cpp:472 ../src/common/accelcmn.cpp:53
+#: ../src/common/accelcmn.cpp:50 ../src/richtext/richtextsymboldlg.cpp:469
 msgid "Insert"
 msgstr "넣기"
 
-#: ../src/richtext/richtextbuffer.cpp:8067
+#: ../src/richtext/richtextbuffer.cpp:8063
 #, fuzzy
 msgid "Insert Field"
 msgstr "텍스트 넣기"
 
-#: ../src/richtext/richtextbuffer.cpp:7978
-#: ../src/richtext/richtextbuffer.cpp:8936
+#: ../src/richtext/richtextbuffer.cpp:7974
+#: ../src/richtext/richtextbuffer.cpp:8934
 msgid "Insert Image"
 msgstr "그림 넣기"
 
-#: ../src/richtext/richtextbuffer.cpp:8025
+#: ../src/richtext/richtextbuffer.cpp:8021
 #, fuzzy
 msgid "Insert Object"
 msgstr "텍스트 넣기"
 
-#: ../src/richtext/richtextctrl.cpp:1286 ../src/richtext/richtextctrl.cpp:1494
-#: ../src/richtext/richtextbuffer.cpp:7822
-#: ../src/richtext/richtextbuffer.cpp:7852
-#: ../src/richtext/richtextbuffer.cpp:7894
+#: ../src/richtext/richtextbuffer.cpp:7818
+#: ../src/richtext/richtextbuffer.cpp:7848
+#: ../src/richtext/richtextbuffer.cpp:7890
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
 msgid "Insert Text"
 msgstr "텍스트 넣기"
 
@@ -4363,18 +4476,11 @@ msgstr "단락 전 간격"
 msgid "Inset"
 msgstr "넣기"
 
-#: ../src/gtk/app.cpp:425
-#, c-format
-msgid "Invalid GTK+ command line option, use \"%s --help\""
-msgstr ""
-"GTK+의 명령행 옵션이 잘못됨, 자세한 사항은 다음을 입력해 보세요 : \"%s --help"
-"\""
-
-#: ../src/common/imagtiff.cpp:311
+#: ../src/common/imagtiff.cpp:308
 msgid "Invalid TIFF image index."
 msgstr "TIFF 이미지가 잘못되었습니다."
 
-#: ../src/common/appcmn.cpp:273
+#: ../src/common/appcmn.cpp:294
 #, c-format
 msgid "Invalid display mode specification '%s'."
 msgstr "설정된 디스플레이 모드('%s')가 없습니다. "
@@ -4384,259 +4490,263 @@ msgstr "설정된 디스플레이 모드('%s')가 없습니다. "
 msgid "Invalid geometry specification '%s'"
 msgstr "잘못된 Geometry 지정: '%s'"
 
-#: ../src/unix/fswatcher_inotify.cpp:323
+#: ../src/unix/fswatcher_inotify.cpp:320
 #, c-format
 msgid "Invalid inotify event for \"%s\""
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:312
+#: ../src/unix/snglinst.cpp:309
 #, c-format
 msgid "Invalid lock file '%s'."
 msgstr "'%s' 잠금 파일이 없습니다."
 
-#: ../src/common/translation.cpp:1125
+#: ../src/common/translation.cpp:1167
 #, fuzzy
 msgid "Invalid message catalog."
 msgstr "'%s'은 메시지 카탈로그가 아닙니다."
 
-#: ../src/common/xtistrm.cpp:405 ../src/common/xtistrm.cpp:420
+#: ../src/common/xtistrm.cpp:402 ../src/common/xtistrm.cpp:417
 msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
 msgstr ""
 "GetObjectClassInfo(int objectID) 함수의 매개 변수가 NULL 혹은 잘못된 값입니"
 "다."
 
-#: ../src/common/xtistrm.cpp:435
+#: ../src/common/xtistrm.cpp:432
 msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
 msgstr ""
 "HasObjectClassInfo(int objectID) 함수의 매개 변수가 NULL 혹은 잘못된 값입니"
 "다."
 
-#: ../src/common/regex.cpp:310
+#: ../src/common/regex.cpp:307
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "올바르지 않은 정규식 '%s': %s"
 
-#: ../src/common/config.cpp:226
+#: ../src/common/config.cpp:222
 #, c-format
 msgid "Invalid value %ld for a boolean key \"%s\" in config file."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:351
-#: ../src/osx/carbon/fontdlg.cpp:361 ../src/common/stockitem.cpp:168
+#: ../src/osx/carbon/fontdlg.cpp:358 ../src/common/stockitem.cpp:165
+#: ../src/generic/fontdlgg.cpp:325 ../src/richtext/richtextfontpage.cpp:351
 msgid "Italic"
 msgstr "기울임"
 
-#: ../src/common/paper.cpp:130
+#: ../src/common/paper.cpp:127
 msgid "Italy Envelope, 110 x 230 mm"
 msgstr "이탈리아 봉투, 110 x 230 mm"
 
-#: ../src/common/imagjpeg.cpp:270
+#: ../src/common/imagjpeg.cpp:257
 msgid "JPEG: Couldn't load - file is probably corrupted."
 msgstr "JPEG: 파일을 읽을 수 없습니다. 파일이 손상된 것 같습니다."
 
-#: ../src/common/imagjpeg.cpp:449
+#: ../src/common/imagjpeg.cpp:436
 msgid "JPEG: Couldn't save image."
 msgstr "JPEG: 이미지를 저장할수 없습니다."
 
-#: ../src/common/paper.cpp:163
+#: ../src/common/paper.cpp:160
 msgid "Japanese Double Postcard 200 x 148 mm"
 msgstr "일본 Double 봉투 200 x 148 mm"
 
-#: ../src/common/paper.cpp:167
+#: ../src/common/paper.cpp:164
 msgid "Japanese Envelope Chou #3"
 msgstr "일본 봉투 Chou #3"
 
-#: ../src/common/paper.cpp:180
+#: ../src/common/paper.cpp:177
 msgid "Japanese Envelope Chou #3 Rotated"
 msgstr "일본 봉투 Chou #3 Rotated"
 
-#: ../src/common/paper.cpp:168
+#: ../src/common/paper.cpp:165
 msgid "Japanese Envelope Chou #4"
 msgstr "일본 봉투 Chou #4"
 
-#: ../src/common/paper.cpp:181
+#: ../src/common/paper.cpp:178
 msgid "Japanese Envelope Chou #4 Rotated"
 msgstr "일본 봉투 Chou #4 Rotated"
 
-#: ../src/common/paper.cpp:165
+#: ../src/common/paper.cpp:162
 msgid "Japanese Envelope Kaku #2"
 msgstr "일본 봉투 Kaku #2"
 
-#: ../src/common/paper.cpp:178
+#: ../src/common/paper.cpp:175
 msgid "Japanese Envelope Kaku #2 Rotated"
 msgstr "일본 봉투 Kaku #2 Rotated"
 
-#: ../src/common/paper.cpp:166
+#: ../src/common/paper.cpp:163
 msgid "Japanese Envelope Kaku #3"
 msgstr "일본 봉투 Kaku #3"
 
-#: ../src/common/paper.cpp:179
+#: ../src/common/paper.cpp:176
 msgid "Japanese Envelope Kaku #3 Rotated"
 msgstr "일본 봉투 Kaku #3 Rotated"
 
-#: ../src/common/paper.cpp:185
+#: ../src/common/paper.cpp:182
 msgid "Japanese Envelope You #4"
 msgstr "일본 봉투 You #4"
 
-#: ../src/common/paper.cpp:186
+#: ../src/common/paper.cpp:183
 msgid "Japanese Envelope You #4 Rotated"
 msgstr "일본 봉투 You #4 Rotated"
 
-#: ../src/common/paper.cpp:138
+#: ../src/common/paper.cpp:135
 msgid "Japanese Postcard 100 x 148 mm"
 msgstr "일본 옆서 100 x 148 mm"
 
-#: ../src/common/paper.cpp:175
+#: ../src/common/paper.cpp:172
 msgid "Japanese Postcard Rotated 148 x 100 mm"
 msgstr "일본 옆서 Rotated 148 x 100 mm"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "Jump to"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:171
+#: ../src/common/stockitem.cpp:168
 msgid "Justified"
 msgstr "정렬"
 
-#: ../src/richtext/richtextindentspage.cpp:155
-#: ../src/richtext/richtextindentspage.cpp:157
 #: ../src/richtext/richtextliststylepage.cpp:344
 #: ../src/richtext/richtextliststylepage.cpp:346
+#: ../src/richtext/richtextindentspage.cpp:155
+#: ../src/richtext/richtextindentspage.cpp:157
 msgid "Justify text left and right."
 msgstr "오른쪽 및 왼쪽 정렬."
 
-#: ../src/common/fmapbase.cpp:163
+#: ../src/common/fmapbase.cpp:160
 msgid "KOI8-R"
 msgstr "키릴어 (KOI8-R)"
 
-#: ../src/common/fmapbase.cpp:164
+#: ../src/common/fmapbase.cpp:161
 msgid "KOI8-U"
 msgstr "키릴어 (KOI8-U)"
 
-#: ../src/common/accelcmn.cpp:265 ../src/common/accelcmn.cpp:347
+#: ../src/common/accelcmn.cpp:279 ../src/common/accelcmn.cpp:364
 msgid "KP_"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "KP_Add"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "KP_Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "KP_Decimal"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 #, fuzzy
 msgid "KP_Delete"
 msgstr "지우기"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "KP_Divide"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 #, fuzzy
 msgid "KP_Down"
 msgstr "아래로"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "KP_End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 #, fuzzy
 msgid "KP_Enter"
 msgstr "프린터"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "KP_Equal"
 msgstr ""
 
+#: ../src/common/accelcmn.cpp:276 ../src/common/accelcmn.cpp:361
+msgid "KP_F"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 #, fuzzy
 msgid "KP_Home"
 msgstr "홈"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 #, fuzzy
 msgid "KP_Insert"
 msgstr "넣기"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 #, fuzzy
 msgid "KP_Left"
 msgstr "왼쪽"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "KP_Multiply"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:99
+#: ../src/common/accelcmn.cpp:97
 #, fuzzy
 msgid "KP_Next"
 msgstr "다음"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "KP_PageDown"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "KP_PageUp"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:98
+#: ../src/common/accelcmn.cpp:96
 msgid "KP_Prior"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 #, fuzzy
 msgid "KP_Right"
 msgstr "오른쪽"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "KP_Separator"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "KP_Space"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "KP_Subtract"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "KP_Tab"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "KP_Up"
 msgstr ""
 
@@ -4644,114 +4754,129 @@ msgstr ""
 msgid "L&ine spacing:"
 msgstr "줄 간격(&I):"
 
-#: ../src/generic/prntdlgg.cpp:613 ../src/generic/prntdlgg.cpp:868
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "압축 오류"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "압축 풀기 오류"
+
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:861
 msgid "Landscape"
 msgstr "가로 방향"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 #, fuzzy
 msgid "Last"
 msgstr "붙여 넣기"
 
-#: ../src/common/prntbase.cpp:1572
+#: ../src/common/prntbase.cpp:1597
 #, fuzzy
 msgid "Last page"
 msgstr "다음 페이지"
 
-#: ../src/common/log.cpp:305
+#: ../src/common/log.cpp:324
 #, c-format
 msgid "Last repeated message (\"%s\", %u time) wasn't output"
 msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/common/paper.cpp:103
+#: ../src/common/paper.cpp:100
 msgid "Ledger, 17 x 11 in"
 msgstr "Ledger, 17 x 11 in"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6146
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:58 ../src/generic/datavgen.cpp:6951
+#: ../src/richtext/richtextsizepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:252
 #: ../src/richtext/richtextliststylepage.cpp:253
 #: ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
-#: ../src/richtext/richtextsizepage.cpp:249 ../src/common/accelcmn.cpp:61
 msgid "Left"
 msgstr "왼쪽"
 
-#: ../src/richtext/richtextindentspage.cpp:204
 #: ../src/richtext/richtextliststylepage.cpp:390
+#: ../src/richtext/richtextindentspage.cpp:204
 msgid "Left (&first line):"
 msgstr "첫 줄 들여쓰기:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1761
+#: ../src/propgrid/advprops.cpp:1662
 msgid "Left Button"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:880
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Left margin (mm):"
 msgstr "왼쪽 여백(mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:141
-#: ../src/richtext/richtextindentspage.cpp:143
 #: ../src/richtext/richtextliststylepage.cpp:330
 #: ../src/richtext/richtextliststylepage.cpp:332
+#: ../src/richtext/richtextindentspage.cpp:141
+#: ../src/richtext/richtextindentspage.cpp:143
 msgid "Left-align text."
 msgstr "텍스트 왼쪽 정렬."
 
-#: ../src/common/paper.cpp:144
+#: ../src/common/paper.cpp:141
 msgid "Legal Extra 9 1/2 x 15 in"
 msgstr "Legal Extra 9 1/2 x 15 in"
 
-#: ../src/common/paper.cpp:96
+#: ../src/common/paper.cpp:93
 msgid "Legal, 8 1/2 x 14 in"
 msgstr "Legal, 8 1/2 x 14 in"
 
-#: ../src/common/paper.cpp:143
+#: ../src/common/paper.cpp:140
 msgid "Letter Extra 9 1/2 x 12 in"
 msgstr "Letter Extra 9 1/2 x 12 in"
 
-#: ../src/common/paper.cpp:149
+#: ../src/common/paper.cpp:146
 msgid "Letter Extra Transverse 9.275 x 12 in"
 msgstr "Letter Extra Transverse 9.275 x 12 in"
 
-#: ../src/common/paper.cpp:152
+#: ../src/common/paper.cpp:149
 msgid "Letter Plus 8 1/2 x 12.69 in"
 msgstr "Letter Plus 8 1/2 x 12.69 in"
 
-#: ../src/common/paper.cpp:169
+#: ../src/common/paper.cpp:166
 msgid "Letter Rotated 11 x 8 1/2 in"
 msgstr "Letter Rotated 11 x 8 1/2 in"
 
-#: ../src/common/paper.cpp:101
+#: ../src/common/paper.cpp:98
 msgid "Letter Small, 8 1/2 x 11 in"
 msgstr "Letter Small, 8 1/2 x 11 in"
 
-#: ../src/common/paper.cpp:147
+#: ../src/common/paper.cpp:144
 msgid "Letter Transverse 8 1/2 x 11 in"
 msgstr "Letter Transverse 8 1/2 x 11 in"
 
-#: ../src/common/paper.cpp:95
+#: ../src/common/paper.cpp:92
 msgid "Letter, 8 1/2 x 11 in"
 msgstr "Letter, 8 1/2 x 11 in"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "License"
 msgstr "사용권"
 
-#: ../src/generic/fontdlgg.cpp:332
+#: ../src/generic/fontdlgg.cpp:328
 msgid "Light"
 msgstr "가늘게"
 
-#: ../src/propgrid/advprops.cpp:1608
+#: ../src/propgrid/advprops.cpp:1514
 msgid "Lime"
 msgstr ""
 
-#: ../src/generic/helpext.cpp:294
+#: ../src/generic/helpext.cpp:292
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr "%lu 행(맵 파일 \"%s\" 에서) 에 문법이 잘못되었습니다."
@@ -4760,15 +4885,15 @@ msgstr "%lu 행(맵 파일 \"%s\" 에서) 에 문법이 잘못되었습니다."
 msgid "Line spacing:"
 msgstr "줄 간격:"
 
-#: ../src/html/chm.cpp:838
+#: ../src/html/chm.cpp:829
 msgid "Link contained '//', converted to absolute link."
 msgstr "링크에 '//' 가 포함되어 있어, 절대주소로 변환 합니다."
 
-#: ../src/richtext/richtextformatdlg.cpp:364
+#: ../src/richtext/richtextformatdlg.cpp:357
 msgid "List Style"
 msgstr "목록 모양새"
 
-#: ../src/richtext/richtextstyles.cpp:1064
+#: ../src/richtext/richtextstyles.cpp:1061
 msgid "List styles"
 msgstr "목록 모양새"
 
@@ -4782,26 +4907,26 @@ msgstr "목록의 글꼴 크기."
 msgid "Lists the available fonts."
 msgstr "목록에서 사용가능한 글꼴"
 
-#: ../src/common/fldlgcmn.cpp:340
+#: ../src/common/fldlgcmn.cpp:337
 #, c-format
 msgid "Load %s file"
 msgstr "%s 파일 불러오기"
 
-#: ../src/html/htmlwin.cpp:597
+#: ../src/html/htmlwin.cpp:600
 msgid "Loading : "
 msgstr "불러오는 중:"
 
-#: ../src/unix/snglinst.cpp:246
+#: ../src/unix/snglinst.cpp:243
 #, c-format
 msgid "Lock file '%s' has incorrect owner."
 msgstr "'%s' 잠금파일의 소유자가 잘못되었습니다."
 
-#: ../src/unix/snglinst.cpp:251
+#: ../src/unix/snglinst.cpp:248
 #, c-format
 msgid "Lock file '%s' has incorrect permissions."
 msgstr "'%s' 잠금파일의 접근권한이 잘못되었습니다."
 
-#: ../src/generic/logg.cpp:576
+#: ../src/generic/logg.cpp:573
 #, c-format
 msgid "Log saved to the file '%s'."
 msgstr "'%s' 파일에 로그 저장."
@@ -4816,11 +4941,11 @@ msgstr "소문자로 변경"
 msgid "Lower case roman numerals"
 msgstr "로마 숫자를 소문자로 변경"
 
-#: ../src/gtk/mdi.cpp:422 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk1/mdi.cpp:431 ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "MDI 자식"
 
-#: ../src/msw/helpchm.cpp:56
+#: ../src/msw/helpchm.cpp:53
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -4828,194 +4953,194 @@ msgstr ""
 "MS HTML Help SDK가 설치되어 있지 않아 MS HTML Help 함수를 사용할 수 없습니"
 "다. "
 
-#: ../src/univ/themes/win32.cpp:3754
+#: ../src/univ/themes/win32.cpp:3751
 msgid "Ma&ximize"
 msgstr "최대화(&X)"
 
-#: ../src/common/fmapbase.cpp:203
+#: ../src/common/fmapbase.cpp:200
 #, fuzzy
 msgid "MacArabic"
 msgstr "아랍어"
 
-#: ../src/common/fmapbase.cpp:222
+#: ../src/common/fmapbase.cpp:219
 msgid "MacArmenian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:211
+#: ../src/common/fmapbase.cpp:208
 msgid "MacBengali"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:217
+#: ../src/common/fmapbase.cpp:214
 msgid "MacBurmese"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:236
+#: ../src/common/fmapbase.cpp:233
 msgid "MacCeltic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:227
+#: ../src/common/fmapbase.cpp:224
 msgid "MacCentralEurRoman"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:223
+#: ../src/common/fmapbase.cpp:220
 msgid "MacChineseSimp"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:201
+#: ../src/common/fmapbase.cpp:198
 msgid "MacChineseTrad"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:233
+#: ../src/common/fmapbase.cpp:230
 msgid "MacCroatian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:206
+#: ../src/common/fmapbase.cpp:203
 msgid "MacCyrillic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:207
+#: ../src/common/fmapbase.cpp:204
 msgid "MacDevanagari"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:231
+#: ../src/common/fmapbase.cpp:228
 msgid "MacDingbats"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:226
+#: ../src/common/fmapbase.cpp:223
 msgid "MacEthiopic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:229
+#: ../src/common/fmapbase.cpp:226
 #, fuzzy
 msgid "MacExtArabic"
 msgstr "아랍어"
 
-#: ../src/common/fmapbase.cpp:237
+#: ../src/common/fmapbase.cpp:234
 msgid "MacGaelic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:221
+#: ../src/common/fmapbase.cpp:218
 msgid "MacGeorgian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:205
+#: ../src/common/fmapbase.cpp:202
 msgid "MacGreek"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:209
+#: ../src/common/fmapbase.cpp:206
 msgid "MacGujarati"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:208
+#: ../src/common/fmapbase.cpp:205
 msgid "MacGurmukhi"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:204
+#: ../src/common/fmapbase.cpp:201
 msgid "MacHebrew"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:234
+#: ../src/common/fmapbase.cpp:231
 msgid "MacIcelandic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:200
+#: ../src/common/fmapbase.cpp:197
 msgid "MacJapanese"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:214
+#: ../src/common/fmapbase.cpp:211
 msgid "MacKannada"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:238
+#: ../src/common/fmapbase.cpp:235
 msgid "MacKeyboardGlyphs"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:218
+#: ../src/common/fmapbase.cpp:215
 msgid "MacKhmer"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:202
+#: ../src/common/fmapbase.cpp:199
 msgid "MacKorean"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:220
+#: ../src/common/fmapbase.cpp:217
 msgid "MacLaotian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:215
+#: ../src/common/fmapbase.cpp:212
 msgid "MacMalayalam"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:225
+#: ../src/common/fmapbase.cpp:222
 msgid "MacMongolian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:210
+#: ../src/common/fmapbase.cpp:207
 msgid "MacOriya"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:199
+#: ../src/common/fmapbase.cpp:196
 msgid "MacRoman"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:235
+#: ../src/common/fmapbase.cpp:232
 msgid "MacRomanian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:216
+#: ../src/common/fmapbase.cpp:213
 #, fuzzy
 msgid "MacSinhalese"
 msgstr "대소문자가 구분"
 
-#: ../src/common/fmapbase.cpp:230
+#: ../src/common/fmapbase.cpp:227
 #, fuzzy
 msgid "MacSymbol"
 msgstr "기호"
 
-#: ../src/common/fmapbase.cpp:212
+#: ../src/common/fmapbase.cpp:209
 msgid "MacTamil"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:213
+#: ../src/common/fmapbase.cpp:210
 msgid "MacTelugu"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:219
+#: ../src/common/fmapbase.cpp:216
 msgid "MacThai"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:224
+#: ../src/common/fmapbase.cpp:221
 msgid "MacTibetan"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:232
+#: ../src/common/fmapbase.cpp:229
 msgid "MacTurkish"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:228
+#: ../src/common/fmapbase.cpp:225
 msgid "MacVietnamese"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1762
+#: ../src/propgrid/advprops.cpp:1663
 msgid "Magnifier"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:2143
+#: ../src/propgrid/advprops.cpp:2050
 #, fuzzy
 msgid "Make a selection:"
 msgstr "선택한 부분을 붙여 넣기"
 
-#: ../src/richtext/richtextformatdlg.cpp:374
+#: ../src/richtext/richtextformatdlg.cpp:367
 #: ../src/richtext/richtextmarginspage.cpp:171
 msgid "Margins"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1595
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Maroon"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:147
+#: ../src/generic/fdrepdlg.cpp:144
 msgid "Match case"
 msgstr "대소문자가 구분"
 
@@ -5029,41 +5154,41 @@ msgstr "두께(&W):"
 msgid "Max width:"
 msgstr "다음으로 바꾸기:"
 
-#: ../src/unix/mediactrl.cpp:947
+#: ../src/unix/mediactrl.cpp:972
 #, c-format
 msgid "Media playback error: %s"
 msgstr ""
 
-#: ../src/common/fs_mem.cpp:175
+#: ../src/common/fs_mem.cpp:170
 #, c-format
 msgid "Memory VFS already contains file '%s'!"
 msgstr "'%s' 파일이 VFS에 이미 포함되어 있습니다."
 
 #. TRANSLATORS: Name of keyboard key
 #. TRANSLATORS: Keyword of system colour
-#: ../src/common/accelcmn.cpp:73 ../src/propgrid/advprops.cpp:889
+#: ../src/common/accelcmn.cpp:70 ../src/propgrid/advprops.cpp:790
 msgid "Menu"
 msgstr "메뉴"
 
-#: ../src/common/msgout.cpp:124
+#: ../src/common/msgout.cpp:121
 #, fuzzy
 msgid "Message"
 msgstr "알림 : %s"
 
-#: ../src/univ/themes/metal.cpp:168
+#: ../src/univ/themes/metal.cpp:165
 msgid "Metal theme"
 msgstr "메탈 테마"
 
-#: ../src/msw/ole/automtn.cpp:652
+#: ../src/msw/ole/automtn.cpp:643
 msgid "Method or property not found."
 msgstr ""
 
-#: ../src/univ/themes/win32.cpp:3752
+#: ../src/univ/themes/win32.cpp:3749
 msgid "Mi&nimize"
 msgstr "최소화(&N)"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1763
+#: ../src/propgrid/advprops.cpp:1664
 msgid "Middle Button"
 msgstr ""
 
@@ -5076,36 +5201,41 @@ msgstr "글꼴 굵기(&W):"
 msgid "Min width:"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:668
+#: ../src/osx/cocoa/menu.mm:281
+#, fuzzy
+msgid "Minimize"
+msgstr "최소화(&N)"
+
+#: ../src/msw/ole/automtn.cpp:659
 msgid "Missing a required parameter."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:324
+#: ../src/generic/fontdlgg.cpp:320
 msgid "Modern"
 msgstr "Modern"
 
-#: ../src/generic/filectrlg.cpp:427
+#: ../src/generic/filectrlg.cpp:423
 msgid "Modified"
 msgstr "수정됨"
 
-#: ../src/common/module.cpp:133
+#: ../src/common/module.cpp:130
 #, c-format
 msgid "Module \"%s\" initialization failed"
 msgstr "\"%s\" 모듈의 초기화 실패"
 
-#: ../src/common/paper.cpp:131
+#: ../src/common/paper.cpp:128
 msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
 msgstr "Monarch 봉투, 3 7/8 x 7 1/2 in"
 
-#: ../src/msw/fswatcher.cpp:143
+#: ../src/msw/fswatcher.cpp:140
 msgid "Monitoring individual files for changes is not supported currently."
 msgstr ""
 
-#: ../src/generic/editlbox.cpp:172
+#: ../src/generic/editlbox.cpp:160
 msgid "Move down"
 msgstr "아래로 이동"
 
-#: ../src/generic/editlbox.cpp:171
+#: ../src/generic/editlbox.cpp:155
 msgid "Move up"
 msgstr "위로 이동"
 
@@ -5121,99 +5251,104 @@ msgstr "다음 단락의 기본 모양새"
 msgid "Moves the object to the previous paragraph."
 msgstr "이전 HTML 페이지로 이동"
 
-#: ../src/richtext/richtextbuffer.cpp:9966
+#: ../src/richtext/richtextbuffer.cpp:9963
 msgid "Multiple Cell Properties"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:424
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:82
+msgid "Multiply"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:420
 msgid "Name"
 msgstr "이름"
 
-#: ../src/propgrid/advprops.cpp:1596
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Navy"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "Network"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173
 #, fuzzy
 msgid "New"
 msgstr "새로 만들기(&N)"
 
-#: ../src/richtext/richtextstyledlg.cpp:243
+#: ../src/richtext/richtextstyledlg.cpp:239
 #, fuzzy
 msgid "New &Box Style..."
 msgstr "새 목록 모양새(&L)"
 
-#: ../src/richtext/richtextstyledlg.cpp:225
+#: ../src/richtext/richtextstyledlg.cpp:221
 msgid "New &Character Style..."
 msgstr "새 글꼴 모양새(&C)..."
 
-#: ../src/richtext/richtextstyledlg.cpp:237
+#: ../src/richtext/richtextstyledlg.cpp:233
 msgid "New &List Style..."
 msgstr "새 목록 모양새(&L)"
 
-#: ../src/richtext/richtextstyledlg.cpp:231
+#: ../src/richtext/richtextstyledlg.cpp:227
 msgid "New &Paragraph Style..."
 msgstr "새 단락 모양새(&P)"
 
-#: ../src/richtext/richtextstyledlg.cpp:606
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:654
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:820
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:893
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:934
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:602
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:650
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:816
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:889
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:930
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "New Style"
 msgstr "새 모양새"
 
-#: ../src/generic/editlbox.cpp:169
+#: ../src/generic/editlbox.cpp:139
 msgid "New item"
 msgstr "새 아이템"
 
-#: ../src/generic/dirdlgg.cpp:297 ../src/generic/dirdlgg.cpp:307
-#: ../src/generic/filectrlg.cpp:618 ../src/generic/filectrlg.cpp:627
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+#: ../src/generic/dirdlgg.cpp:294 ../src/generic/dirdlgg.cpp:304
 msgid "NewName"
 msgstr "새 이름"
 
-#: ../src/common/prntbase.cpp:1567 ../src/html/helpwnd.cpp:665
+#: ../src/common/prntbase.cpp:1592 ../src/html/helpwnd.cpp:663
 msgid "Next page"
 msgstr "다음 페이지"
 
-#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:177
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:174
 #: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "아니오"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1764
+#: ../src/propgrid/advprops.cpp:1665
 msgid "No Entry"
 msgstr ""
 
-#: ../src/generic/animateg.cpp:150
+#: ../src/generic/animateg.cpp:133
 #, c-format
 msgid "No animation handler for type %ld defined."
 msgstr "%ld 타입에 대한 애니매이션 핸들러가 없습니다."
 
-#: ../src/dfb/bitmap.cpp:642 ../src/dfb/bitmap.cpp:676
+#: ../src/dfb/bitmap.cpp:639 ../src/dfb/bitmap.cpp:673
 #, c-format
 msgid "No bitmap handler for type %d defined."
 msgstr "타입 %d 에대한 비트맵 핸들러가 정의되지 않았습니다."
 
-#: ../src/common/utilscmn.cpp:1077
+#: ../src/common/utilscmn.cpp:1095
 msgid "No default application configured for HTML files."
 msgstr "HTML 기본 브라우저가 없습니다."
 
-#: ../src/generic/helpext.cpp:445
+#: ../src/generic/helpext.cpp:443
 msgid "No entries found."
 msgstr "항목이 없습니다."
 
-#: ../src/common/fontmap.cpp:421
+#: ../src/common/fontmap.cpp:418
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found,\n"
@@ -5225,7 +5360,7 @@ msgstr ""
 "다른 인코딩 '%s' 를 사용할 수 있습니다.\n"
 "이 인코딩을 사용하시겠습니까 (그렇지 않으면 또 다른 하나를 선택하셔야합니다)?"
 
-#: ../src/common/fontmap.cpp:426
+#: ../src/common/fontmap.cpp:423
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found.\n"
@@ -5236,208 +5371,207 @@ msgstr ""
 "이 인코딩에 사용할 글꼴을 선택 하시겠습니까\n"
 "(그렇지 않으면이 인코딩에 텍스트가 제대로 표시되지 않습니다)?"
 
-#: ../src/generic/animateg.cpp:142
+#: ../src/generic/animateg.cpp:125
 msgid "No handler found for animation type."
 msgstr "애니매이션 핸들러가 없습니다."
 
-#: ../src/common/image.cpp:2728
+#: ../src/common/image.cpp:2823
 msgid "No handler found for image type."
 msgstr "이미지 핸들러가 없습니다."
 
-#: ../src/common/image.cpp:2736 ../src/common/image.cpp:2848
-#: ../src/common/image.cpp:2901
+#: ../src/common/image.cpp:2831 ../src/common/image.cpp:2954
+#: ../src/common/image.cpp:3020
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "타입 %d 에대한 이미지 핸들러가 정의되지 않았습니다."
 
-#: ../src/common/image.cpp:2871 ../src/common/image.cpp:2915
+#: ../src/common/image.cpp:2986 ../src/common/image.cpp:3034
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "타입 %s 에대한 이미지 핸들러가 정의되지 않았습니다."
 
-#: ../src/html/helpwnd.cpp:858
+#: ../src/html/helpwnd.cpp:856
 msgid "No matching page found yet"
 msgstr "일치하는 페이지를 찾을 수 없습니다."
 
-#: ../src/unix/sound.cpp:81
+#: ../src/unix/sound.cpp:78
 msgid "No sound"
 msgstr "소리 없음"
 
-#: ../src/common/image.cpp:2277 ../src/common/image.cpp:2318
+#: ../src/common/image.cpp:2371 ../src/common/image.cpp:2412
 msgid "No unused colour in image being masked."
 msgstr "이미지에서 사용되지 않는 색상을 감춥니다."
 
-#: ../src/common/image.cpp:3374
-msgid "No unused colour in image."
-msgstr "이미지에 사용되지 않은 색상"
-
-#: ../src/generic/helpext.cpp:302
+#: ../src/generic/helpext.cpp:300
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "\"%s\" 로 검색된 파일이 없습니다."
 
-#: ../src/richtext/richtextborderspage.cpp:610
 #: ../src/richtext/richtextsizepage.cpp:248
 #: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:610
 #, fuzzy
 msgid "None"
 msgstr "(없음)"
 
-#: ../src/common/fmapbase.cpp:157
+#: ../src/common/fmapbase.cpp:154
 msgid "Nordic (ISO-8859-10)"
 msgstr "노르웨이어 (ISO-8859-10)"
 
-#: ../src/generic/fontdlgg.cpp:328 ../src/generic/fontdlgg.cpp:331
+#: ../src/generic/fontdlgg.cpp:324 ../src/generic/fontdlgg.cpp:327
 msgid "Normal"
 msgstr "보통"
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1261
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "일반 모습<br>그리고 <u>밑줄</u>. "
 
-#: ../src/html/helpwnd.cpp:1205
+#: ../src/html/helpwnd.cpp:1203
 msgid "Normal font:"
 msgstr "보통 글꼴:"
 
-#: ../src/propgrid/props.cpp:1128
+#: ../src/propgrid/props.cpp:1115
 #, fuzzy, c-format
 msgid "Not %s"
 msgstr "%s 정보"
 
-#: ../include/wx/filename.h:573 ../include/wx/filename.h:578
-#, fuzzy
-msgid "Not available"
-msgstr "유용한 팁이 없습니다."
+#: ../src/common/secretstore.cpp:168
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/webrequest.cpp:605
+msgid "Not enough free disk space for download."
+msgstr ""
 
 #: ../src/richtext/richtextfontpage.cpp:358
 msgid "Not underlined"
 msgstr "밑줄 없음"
 
-#: ../src/common/paper.cpp:115
+#: ../src/common/paper.cpp:112
 msgid "Note, 8 1/2 x 11 in"
 msgstr "Note, 8 1/2 x 11 in"
 
-#: ../src/generic/notifmsgg.cpp:132
+#: ../src/generic/notifmsgg.cpp:129
 msgid "Notice"
 msgstr "알림"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "Num *"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "Num +"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "Num ,"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "Num -"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "Num ."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "Num /"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "Num ="
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "Num Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 #, fuzzy
 msgid "Num Delete"
 msgstr "지우기"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 #, fuzzy
 msgid "Num Down"
 msgstr "아래로"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "Num End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "Num Enter"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 #, fuzzy
 msgid "Num Home"
 msgstr "홈"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 #, fuzzy
 msgid "Num Insert"
 msgstr "넣기"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num Lock"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "Num Page Down"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "Num Page Up"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 #, fuzzy
 msgid "Num Right"
 msgstr "오른쪽"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "Num Space"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "Num Tab"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "Num Up"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "Num left"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num_lock"
 msgstr ""
 
@@ -5446,13 +5580,13 @@ msgstr ""
 msgid "Numbered outline"
 msgstr "Numbered  형태"
 
-#: ../include/wx/msgdlg.h:278 ../src/richtext/richtextstyledlg.cpp:297
-#: ../src/common/stockitem.cpp:178 ../src/msw/msgdlg.cpp:454
-#: ../src/msw/msgdlg.cpp:747 ../src/gtk1/fontdlg.cpp:138
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:175
+#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/msgdlg.cpp:741 ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "확인"
 
-#: ../src/msw/ole/automtn.cpp:692
+#: ../src/msw/ole/automtn.cpp:683
 #, c-format
 msgid "OLE Automation error in %s: %s"
 msgstr ""
@@ -5462,15 +5596,15 @@ msgstr ""
 msgid "Object Properties"
 msgstr "특성(&P)"
 
-#: ../src/msw/ole/automtn.cpp:660
+#: ../src/msw/ole/automtn.cpp:651
 msgid "Object implementation does not support named arguments."
 msgstr ""
 
-#: ../src/common/xtixml.cpp:264
+#: ../src/common/xtixml.cpp:260
 msgid "Objects must have an id attribute"
 msgstr "객체는 반드시 속성 ID를 가져야 합니다."
 
-#: ../src/propgrid/advprops.cpp:1601
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Olive"
 msgstr ""
 
@@ -5478,65 +5612,70 @@ msgstr ""
 msgid "Opaci&ty:"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:354
+#: ../src/generic/colrdlgg.cpp:374
 msgid "Opacity:"
 msgstr ""
 
-#: ../src/common/docview.cpp:1773 ../src/common/docview.cpp:1815
+#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
 msgid "Open File"
 msgstr "파일 열기"
 
-#: ../src/html/helpwnd.cpp:671 ../src/html/helpwnd.cpp:1554
+#: ../src/html/helpwnd.cpp:669 ../src/html/helpwnd.cpp:1552
 msgid "Open HTML document"
 msgstr "HTML 문서를 엽니다"
 
-#: ../src/generic/dbgrptg.cpp:163
+#: ../src/common/stockitem.cpp:265
+#, fuzzy
+msgid "Open an existing document"
+msgstr "HTML 문서를 엽니다"
+
+#: ../src/generic/dbgrptg.cpp:160
 #, c-format
 msgid "Open file \"%s\""
 msgstr "\"%s\" 파일 엽니다."
 
-#: ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176
 #, fuzzy
 msgid "Open..."
 msgstr "열기...(&O)"
 
-#: ../src/unix/glx11.cpp:506 ../src/msw/glcanvas.cpp:592
+#: ../src/msw/glcanvas.cpp:607 ../src/unix/glx11.cpp:513
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr ""
 
-#: ../src/generic/dirctrlg.cpp:599 ../src/generic/dirdlgg.cpp:323
-#: ../src/generic/filectrlg.cpp:642 ../src/generic/filectrlg.cpp:786
+#: ../src/generic/dirctrlg.cpp:565 ../src/generic/filectrlg.cpp:638
+#: ../src/generic/filectrlg.cpp:782 ../src/generic/dirdlgg.cpp:320
 msgid "Operation not permitted."
 msgstr "작동이 허가되지 않음"
 
-#: ../src/common/cmdline.cpp:900
+#: ../src/common/cmdline.cpp:896
 #, fuzzy, c-format
 msgid "Option '%s' can't be negated"
 msgstr "'%s' 디렉토리를 만들 수 없습니다."
 
-#: ../src/common/cmdline.cpp:1064
+#: ../src/common/cmdline.cpp:1060
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "옵션에 '%s' 값이 필요합니다."
 
-#: ../src/common/cmdline.cpp:1147
+#: ../src/common/cmdline.cpp:1143
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "옵션 '%s': '%s' 를 날짜로 변환할 수 없습니다."
 
-#: ../src/generic/prntdlgg.cpp:618
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "설정"
 
-#: ../src/propgrid/advprops.cpp:1606
+#: ../src/propgrid/advprops.cpp:1512
 msgid "Orange"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:615 ../src/generic/prntdlgg.cpp:869
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:862
 msgid "Orientation"
 msgstr "방향"
 
-#: ../src/common/windowid.cpp:242
+#: ../src/common/windowid.cpp:237
 msgid "Out of window IDs.  Recommend shutting down application."
 msgstr "원도우 ID가 잘못되었습니다. 응용 프로그램을 종료합니다."
 
@@ -5550,148 +5689,148 @@ msgstr "들여쓰기 단계(&O)"
 msgid "Outset"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:656
+#: ../src/msw/ole/automtn.cpp:647
 msgid "Overflow while coercing argument values."
 msgstr ""
 
-#: ../src/common/imagpcx.cpp:457 ../src/common/imagpcx.cpp:480
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:479
 msgid "PCX: couldn't allocate memory"
 msgstr "PCX: 메모리가 부족합니다"
 
-#: ../src/common/imagpcx.cpp:456
+#: ../src/common/imagpcx.cpp:455
 msgid "PCX: image format unsupported"
 msgstr "PCX: 이미지 포맷을 지원하지 않습니다."
 
-#: ../src/common/imagpcx.cpp:479
+#: ../src/common/imagpcx.cpp:478
 msgid "PCX: invalid image"
 msgstr "PCX: 이미지가 잘못되었습니다."
 
-#: ../src/common/imagpcx.cpp:442
+#: ../src/common/imagpcx.cpp:441
 msgid "PCX: this is not a PCX file."
 msgstr "PCX: PCX 파일이 아닙니다."
 
-#: ../src/common/imagpcx.cpp:459 ../src/common/imagpcx.cpp:481
+#: ../src/common/imagpcx.cpp:458 ../src/common/imagpcx.cpp:480
 msgid "PCX: unknown error !!!"
 msgstr "PCX: 알 수 없는 오류가 발생!!!"
 
-#: ../src/common/imagpcx.cpp:458
+#: ../src/common/imagpcx.cpp:457
 msgid "PCX: version number too low"
 msgstr "PCX: 버전이 너무 낮습니다."
 
-#: ../src/common/imagpnm.cpp:91
+#: ../src/common/imagpnm.cpp:89
 msgid "PNM: Couldn't allocate memory."
 msgstr "PNM: 메모리가 부족합니다."
 
-#: ../src/common/imagpnm.cpp:73
+#: ../src/common/imagpnm.cpp:71
 msgid "PNM: File format is not recognized."
 msgstr "PNM: 파일 포맷을 인식할 수 없습니다."
 
-#: ../src/common/imagpnm.cpp:112 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
 #: ../src/common/imagpnm.cpp:156
 msgid "PNM: File seems truncated."
 msgstr "PNM: 파일이 잘렸습니다."
 
-#: ../src/common/paper.cpp:187
+#: ../src/common/paper.cpp:184
 msgid "PRC 16K 146 x 215 mm"
 msgstr "PRC 16K 146 x 215 mm"
 
-#: ../src/common/paper.cpp:200
+#: ../src/common/paper.cpp:197
 msgid "PRC 16K Rotated"
 msgstr "PRC 16K Rotated"
 
-#: ../src/common/paper.cpp:188
+#: ../src/common/paper.cpp:185
 msgid "PRC 32K 97 x 151 mm"
 msgstr "PRC 32K 97 x 151 mm"
 
-#: ../src/common/paper.cpp:201
+#: ../src/common/paper.cpp:198
 msgid "PRC 32K Rotated"
 msgstr "PRC 32K Rotated"
 
-#: ../src/common/paper.cpp:189
+#: ../src/common/paper.cpp:186
 msgid "PRC 32K(Big) 97 x 151 mm"
 msgstr "PRC 32K(Big) 97 x 151 mm"
 
-#: ../src/common/paper.cpp:202
+#: ../src/common/paper.cpp:199
 msgid "PRC 32K(Big) Rotated"
 msgstr "PRC 32K(Big) Rotated"
 
-#: ../src/common/paper.cpp:190
+#: ../src/common/paper.cpp:187
 msgid "PRC Envelope #1 102 x 165 mm"
 msgstr "PRC 봉투 #1 102 x 165 mm"
 
-#: ../src/common/paper.cpp:203
+#: ../src/common/paper.cpp:200
 msgid "PRC Envelope #1 Rotated 165 x 102 mm"
 msgstr "PRC 봉투 #1 Rotated 165 x 102 mm"
 
-#: ../src/common/paper.cpp:199
+#: ../src/common/paper.cpp:196
 msgid "PRC Envelope #10 324 x 458 mm"
 msgstr "PRC 봉투 #10 324 x 458 mm"
 
-#: ../src/common/paper.cpp:212
+#: ../src/common/paper.cpp:209
 msgid "PRC Envelope #10 Rotated 458 x 324 mm"
 msgstr "PRC 봉투 #10 Rotated 458 x 324 mm"
 
-#: ../src/common/paper.cpp:191
+#: ../src/common/paper.cpp:188
 msgid "PRC Envelope #2 102 x 176 mm"
 msgstr "PRC 봉투 #2 102 x 176 mm"
 
-#: ../src/common/paper.cpp:204
+#: ../src/common/paper.cpp:201
 msgid "PRC Envelope #2 Rotated 176 x 102 mm"
 msgstr "PRC 봉투 #2 Rotated 176 x 102 mm"
 
-#: ../src/common/paper.cpp:192
+#: ../src/common/paper.cpp:189
 msgid "PRC Envelope #3 125 x 176 mm"
 msgstr "PRC 봉투 #3 125 x 176 mm"
 
-#: ../src/common/paper.cpp:205
+#: ../src/common/paper.cpp:202
 msgid "PRC Envelope #3 Rotated 176 x 125 mm"
 msgstr "PRC 봉투 #3 Rotated 176 x 125 mm"
 
-#: ../src/common/paper.cpp:193
+#: ../src/common/paper.cpp:190
 msgid "PRC Envelope #4 110 x 208 mm"
 msgstr "PRC 봉투 #4 110 x 208 mm"
 
-#: ../src/common/paper.cpp:206
+#: ../src/common/paper.cpp:203
 msgid "PRC Envelope #4 Rotated 208 x 110 mm"
 msgstr "PRC 봉투 #4 Rotated 208 x 110 mm"
 
-#: ../src/common/paper.cpp:194
+#: ../src/common/paper.cpp:191
 msgid "PRC Envelope #5 110 x 220 mm"
 msgstr "PRC 봉투 #5 110 x 220 mm"
 
-#: ../src/common/paper.cpp:207
+#: ../src/common/paper.cpp:204
 msgid "PRC Envelope #5 Rotated 220 x 110 mm"
 msgstr "PRC 봉투 #5 Rotated 220 x 110 mm"
 
-#: ../src/common/paper.cpp:195
+#: ../src/common/paper.cpp:192
 msgid "PRC Envelope #6 120 x 230 mm"
 msgstr "PRC 봉투 #6 120 x 230 mm"
 
-#: ../src/common/paper.cpp:208
+#: ../src/common/paper.cpp:205
 msgid "PRC Envelope #6 Rotated 230 x 120 mm"
 msgstr "PRC 봉투 #6 Rotated 230 x 120 mm"
 
-#: ../src/common/paper.cpp:196
+#: ../src/common/paper.cpp:193
 msgid "PRC Envelope #7 160 x 230 mm"
 msgstr "PRC 봉투 #7 160 x 230 mm"
 
-#: ../src/common/paper.cpp:209
+#: ../src/common/paper.cpp:206
 msgid "PRC Envelope #7 Rotated 230 x 160 mm"
 msgstr "PRC 봉투 #7 Rotated 230 x 160 mm"
 
-#: ../src/common/paper.cpp:197
+#: ../src/common/paper.cpp:194
 msgid "PRC Envelope #8 120 x 309 mm"
 msgstr "PRC 봉투 #8 120 x 309 mm"
 
-#: ../src/common/paper.cpp:210
+#: ../src/common/paper.cpp:207
 msgid "PRC Envelope #8 Rotated 309 x 120 mm"
 msgstr "PRC 봉투 #8 Rotated 309 x 120 mm"
 
-#: ../src/common/paper.cpp:198
+#: ../src/common/paper.cpp:195
 msgid "PRC Envelope #9 229 x 324 mm"
 msgstr "PRC 봉투 #9 229 x 324 mm"
 
-#: ../src/common/paper.cpp:211
+#: ../src/common/paper.cpp:208
 msgid "PRC Envelope #9 Rotated 324 x 229 mm"
 msgstr "PRC 봉투 #9 Rotated 324 x 229 mm"
 
@@ -5699,92 +5838,96 @@ msgstr "PRC 봉투 #9 Rotated 324 x 229 mm"
 msgid "Padding"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:2074
+#: ../src/common/prntbase.cpp:2096
 #, c-format
 msgid "Page %d"
 msgstr "페이지 %d"
 
-#: ../src/common/prntbase.cpp:2072
+#: ../src/common/prntbase.cpp:2094
 #, c-format
 msgid "Page %d of %d"
 msgstr "페이지 %d/%d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 #, fuzzy
 msgid "Page Down"
 msgstr "페이지 %d"
 
-#: ../src/gtk/print.cpp:826
+#: ../src/gtk/print.cpp:829
 msgid "Page Setup"
 msgstr "페이지 설정"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 #, fuzzy
 msgid "Page Up"
 msgstr "페이지 %d"
 
-#: ../src/generic/prntdlgg.cpp:828 ../src/common/prntbase.cpp:484
+#: ../src/common/prntbase.cpp:479 ../src/generic/prntdlgg.cpp:821
 msgid "Page setup"
 msgstr "페이지 설정"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 #, fuzzy
 msgid "PageDown"
 msgstr "아래로"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 #, fuzzy
 msgid "PageUp"
 msgstr "페이지"
 
-#: ../src/generic/prntdlgg.cpp:216
+#: ../src/generic/prntdlgg.cpp:209
 msgid "Pages"
 msgstr "페이지"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1765
+#: ../src/propgrid/advprops.cpp:1666
 msgid "Paint Brush"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:602 ../src/generic/prntdlgg.cpp:801
-#: ../src/generic/prntdlgg.cpp:842 ../src/generic/prntdlgg.cpp:855
-#: ../src/generic/prntdlgg.cpp:1052 ../src/generic/prntdlgg.cpp:1057
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:794
+#: ../src/generic/prntdlgg.cpp:835 ../src/generic/prntdlgg.cpp:848
+#: ../src/generic/prntdlgg.cpp:1045 ../src/generic/prntdlgg.cpp:1050
 msgid "Paper size"
 msgstr "용지 크기"
 
-#: ../src/richtext/richtextstyles.cpp:1062
+#: ../src/richtext/richtextstyles.cpp:1059
 msgid "Paragraph styles"
 msgstr "단락 모양새"
 
-#: ../src/common/xtistrm.cpp:465
+#: ../src/common/xtistrm.cpp:462
 msgid "Passing a already registered object to SetObject"
 msgstr "이미 등록된 객체입니다. 무시함"
 
-#: ../src/common/xtistrm.cpp:476
+#: ../src/common/xtistrm.cpp:473
 #, fuzzy
 msgid "Passing an unknown object to GetObject"
 msgstr "알수없는 객체입니다. 무시함"
 
-#: ../src/richtext/richtextctrl.cpp:3513 ../src/common/stockitem.cpp:180
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:177 ../src/richtext/richtextctrl.cpp:3514
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "붙여 넣기"
 
-#: ../src/common/stockitem.cpp:262
+#: ../src/common/stockitem.cpp:260
 msgid "Paste selection"
 msgstr "선택한 부분을 붙여 넣기"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:74
+#: ../src/common/accelcmn.cpp:71
 msgid "Pause"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1766
+#: ../src/propgrid/advprops.cpp:1667
 msgid "Pencil"
 msgstr ""
 
@@ -5793,21 +5936,21 @@ msgstr ""
 msgid "Peri&od"
 msgstr "마침표(&O)"
 
-#: ../src/generic/filectrlg.cpp:430
+#: ../src/generic/filectrlg.cpp:426
 msgid "Permissions"
 msgstr "권한"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:60
+#: ../src/common/accelcmn.cpp:57
 msgid "PgDn"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:59
+#: ../src/common/accelcmn.cpp:56
 msgid "PgUp"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:12868
+#: ../src/richtext/richtextbuffer.cpp:12863
 #, fuzzy
 msgid "Picture Properties"
 msgstr "특성(&P)"
@@ -5820,46 +5963,46 @@ msgstr "파이프 생성 실패"
 msgid "Please choose a valid font."
 msgstr "사용 가능한 글꼴을 선택하십시오."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
 msgid "Please choose an existing file."
 msgstr "파일을 선택하십시오"
 
-#: ../src/html/helpwnd.cpp:800
+#: ../src/html/helpwnd.cpp:798
 msgid "Please choose the page to display:"
 msgstr "표시할 페이지를 선택하시기 바랍니다 :"
 
-#: ../src/msw/dialup.cpp:764
+#: ../src/msw/dialup.cpp:758
 msgid "Please choose which ISP do you want to connect to"
 msgstr "연결할 ISP를 선택하십시오."
 
-#: ../src/common/headerctrlcmn.cpp:59
+#: ../src/common/headerctrlcmn.cpp:57
 msgid "Please select the columns to show and define their order:"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:538
+#: ../src/common/prntbase.cpp:533
 #, fuzzy
 msgid "Please wait while printing..."
 msgstr "인쇄중 입니다.\n"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1767
+#: ../src/propgrid/advprops.cpp:1668
 #, fuzzy
 msgid "Point Left"
 msgstr "크기(&P):"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1768
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgid "Point Right"
 msgstr "오른쪽 정렬"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:662
+#: ../src/propgrid/advprops.cpp:572
 #, fuzzy
 msgid "Point Size"
 msgstr "크기(&P):"
 
-#: ../src/generic/prntdlgg.cpp:612 ../src/generic/prntdlgg.cpp:867
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:860
 msgid "Portrait"
 msgstr "세로 방향"
 
@@ -5868,265 +6011,275 @@ msgstr "세로 방향"
 msgid "Position"
 msgstr "질문"
 
-#: ../src/generic/prntdlgg.cpp:298
+#: ../src/generic/prntdlgg.cpp:291
 msgid "PostScript file"
 msgstr "PostScript 파일"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178 ../src/osx/cocoa/preferences.mm:303
 #, fuzzy
 msgid "Preferences"
 msgstr "설정(&P)"
 
-#: ../src/osx/menu_osx.cpp:568
+#: ../src/osx/menu_osx.cpp:460
 #, fuzzy
 msgid "Preferences..."
 msgstr "설정(&P)"
 
-#: ../src/common/prntbase.cpp:546
+#: ../src/common/prntbase.cpp:541
 msgid "Preparing"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:455 ../src/osx/carbon/fontdlg.cpp:390
-#: ../src/html/helpwnd.cpp:1222
+#: ../src/osx/carbon/fontdlg.cpp:387 ../src/generic/fontdlgg.cpp:452
+#: ../src/html/helpwnd.cpp:1220
 msgid "Preview:"
 msgstr "미리보기:"
 
-#: ../src/common/prntbase.cpp:1553 ../src/html/helpwnd.cpp:664
+#: ../src/common/prntbase.cpp:1578 ../src/html/helpwnd.cpp:662
 msgid "Previous page"
 msgstr "이전 페이지"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/prntdlgg.cpp:143 ../src/generic/prntdlgg.cpp:157
-#: ../src/common/prntbase.cpp:426 ../src/common/prntbase.cpp:1541
-#: ../src/common/accelcmn.cpp:77 ../src/gtk/print.cpp:620
-#: ../src/gtk/print.cpp:638
+#: ../src/common/prntbase.cpp:421 ../src/common/prntbase.cpp:1566
+#: ../src/common/accelcmn.cpp:74 ../src/generic/prntdlgg.cpp:136
+#: ../src/generic/prntdlgg.cpp:150 ../src/gtk/print.cpp:616
+#: ../src/gtk/print.cpp:634
 msgid "Print"
 msgstr "인쇄"
 
-#: ../include/wx/prntbase.h:399 ../src/common/docview.cpp:1268
+#: ../src/common/docview.cpp:1262
 msgid "Print Preview"
 msgstr "인쇄 미리보기"
 
-#: ../src/common/prntbase.cpp:2015 ../src/common/prntbase.cpp:2057
-#: ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2037 ../src/common/prntbase.cpp:2079
+#: ../src/common/prntbase.cpp:2087
 msgid "Print Preview Failure"
 msgstr "인쇄 미리보기 실패"
 
-#: ../src/generic/prntdlgg.cpp:224
+#: ../src/generic/prntdlgg.cpp:217
 msgid "Print Range"
 msgstr "인쇄 범위"
 
-#: ../src/generic/prntdlgg.cpp:449
+#: ../src/generic/prntdlgg.cpp:442
 msgid "Print Setup"
 msgstr "인쇄 설정"
 
-#: ../src/generic/prntdlgg.cpp:621
+#: ../src/generic/prntdlgg.cpp:614
 msgid "Print in colour"
 msgstr "인쇄 색상"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/osx/webview_webkit.mm:260
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "Column 정보를 초기화 할 수 없습니다."
+
+#: ../src/common/stockitem.cpp:179
 #, fuzzy
 msgid "Print previe&w..."
 msgstr "인쇄 미리 보기(&W)"
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1256
 #, fuzzy
 msgid "Print preview creation failed."
 msgstr "파이프 생성 실패"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/common/stockitem.cpp:179
 #, fuzzy
 msgid "Print preview..."
 msgstr "인쇄 미리 보기"
 
-#: ../src/generic/prntdlgg.cpp:630
+#: ../src/generic/prntdlgg.cpp:623
 msgid "Print spooling"
 msgstr "인쇄 스풀러"
 
-#: ../src/html/helpwnd.cpp:675
+#: ../src/html/helpwnd.cpp:673
 msgid "Print this page"
 msgstr "이 페이지를 인쇄"
 
-#: ../src/generic/prntdlgg.cpp:185
+#: ../src/generic/prntdlgg.cpp:178
 msgid "Print to File"
 msgstr "파일로 인쇄"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 #, fuzzy
 msgid "Print..."
 msgstr "인쇄...(&P)"
 
-#: ../src/generic/prntdlgg.cpp:493
+#: ../src/generic/prntdlgg.cpp:486
 msgid "Printer"
 msgstr "프린터"
 
-#: ../src/generic/prntdlgg.cpp:633
+#: ../src/generic/prntdlgg.cpp:626
 msgid "Printer command:"
 msgstr "인쇄 명령:"
 
-#: ../src/generic/prntdlgg.cpp:180
+#: ../src/generic/prntdlgg.cpp:173
 msgid "Printer options"
 msgstr "인쇄 설정"
 
-#: ../src/generic/prntdlgg.cpp:645
+#: ../src/generic/prntdlgg.cpp:638
 msgid "Printer options:"
 msgstr "인쇄 설정:"
 
-#: ../src/generic/prntdlgg.cpp:916
+#: ../src/generic/prntdlgg.cpp:909
 msgid "Printer..."
 msgstr "프린터..."
 
-#: ../src/generic/prntdlgg.cpp:196
+#: ../src/generic/prntdlgg.cpp:189
 msgid "Printer:"
 msgstr "프린터:"
 
-#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:535
-#: ../src/html/htmprint.cpp:277
+#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:530
+#: ../src/html/htmprint.cpp:289
 #, fuzzy
 msgid "Printing"
 msgstr "인쇄중"
 
-#: ../src/common/prntbase.cpp:612
+#: ../src/common/prntbase.cpp:607
 msgid "Printing "
 msgstr "인쇄중"
 
-#: ../src/common/prntbase.cpp:347
+#: ../src/common/prntbase.cpp:342
 msgid "Printing Error"
 msgstr "인쇄 오류"
 
-#: ../src/common/prntbase.cpp:565
+#: ../src/osx/webview_webkit.mm:251
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "사용중인 zlib 버전에서 Gzip을 지원하지 않습니다."
+
+#: ../src/common/prntbase.cpp:560
 #, fuzzy, c-format
 msgid "Printing page %d"
 msgstr "%d쪽 인쇄 중..."
 
-#: ../src/common/prntbase.cpp:570
+#: ../src/common/prntbase.cpp:565
 #, fuzzy, c-format
 msgid "Printing page %d of %d"
 msgstr "%d쪽 인쇄 중..."
 
-#: ../src/generic/printps.cpp:201
+#: ../src/generic/printps.cpp:182
 #, c-format
 msgid "Printing page %d..."
 msgstr "%d쪽 인쇄 중..."
 
-#: ../src/generic/printps.cpp:161
+#: ../src/generic/printps.cpp:142
 msgid "Printing..."
 msgstr "인쇄중..."
 
-#: ../include/wx/richtext/richtextprint.h:109 ../include/wx/prntbase.h:267
-#: ../src/common/docview.cpp:2132
+#: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
+#: ../src/common/docview.cpp:2137
 #, fuzzy
 msgid "Printout"
 msgstr "인쇄"
 
-#: ../src/common/debugrpt.cpp:560
+#: ../src/common/debugrpt.cpp:561
 #, c-format
 msgid ""
 "Processing debug report has failed, leaving the files in \"%s\" directory."
 msgstr "디버그 보고서 생성 작업이 실패습니다(\"%s\" 디렉토리). "
 
-#: ../src/common/prntbase.cpp:545
+#: ../src/common/prntbase.cpp:540
 msgid "Progress:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181
 #, fuzzy
 msgid "Properties"
 msgstr "특성(&P)"
 
-#: ../src/propgrid/manager.cpp:237
+#: ../src/propgrid/manager.cpp:223
 #, fuzzy
 msgid "Property"
 msgstr "특성(&P)"
 
 #. TRANSLATORS: Caption of message box displaying any property error
-#: ../src/propgrid/propgrid.cpp:3185 ../src/propgrid/propgrid.cpp:3318
+#: ../src/propgrid/propgrid.cpp:3162 ../src/propgrid/propgrid.cpp:3299
 #, fuzzy
 msgid "Property Error"
 msgstr "인쇄 오류"
 
-#: ../src/propgrid/advprops.cpp:1597
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Purple"
 msgstr ""
 
-#: ../src/common/paper.cpp:112
+#: ../src/common/paper.cpp:109
 msgid "Quarto, 215 x 275 mm"
 msgstr "Quarto, 215 x 275 mm"
 
-#: ../src/generic/logg.cpp:1016
+#: ../src/generic/logg.cpp:1013
 msgid "Question"
 msgstr "질문"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1769
+#: ../src/propgrid/advprops.cpp:1670
 #, fuzzy
 msgid "Question Arrow"
 msgstr "질문"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 #, fuzzy
 msgid "Quit"
 msgstr "종료(&Q)"
 
-#: ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:477
 #, fuzzy, c-format
 msgid "Quit %s"
 msgstr "종료(&Q)"
 
-#: ../src/common/stockitem.cpp:263
+#: ../src/common/stockitem.cpp:261
 msgid "Quit this program"
 msgstr "이 프로그램을 닫습니다"
 
-#: ../src/common/accelcmn.cpp:338
+#: ../src/common/accelcmn.cpp:352
 msgid "RawCtrl+"
 msgstr ""
 
-#: ../src/common/ffile.cpp:109 ../src/common/ffile.cpp:133
+#: ../src/common/ffile.cpp:107 ../src/common/ffile.cpp:132
 #, c-format
 msgid "Read error on file '%s'"
 msgstr "'%s '파일을 읽는 데 오류가 발생했습니다."
 
-#: ../src/common/secretstore.cpp:199
+#: ../src/common/secretstore.cpp:211
 #, fuzzy, c-format
-msgid "Reading password for \"%s/%s\" failed: %s."
+msgid "Reading password for \"%s\" failed: %s."
 msgstr "'%s' 의 추출('%s' 에서) 실패 했습니다."
 
-#: ../src/common/prntbase.cpp:272
+#: ../src/common/prntbase.cpp:267
 msgid "Ready"
 msgstr "준비"
 
-#: ../src/propgrid/advprops.cpp:1605
+#: ../src/propgrid/advprops.cpp:1511
 #, fuzzy
 msgid "Red"
 msgstr "다시 실행"
 
-#: ../src/generic/colrdlgg.cpp:339
+#: ../src/generic/colrdlgg.cpp:359
 msgid "Red:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:185 ../src/stc/stc_i18n.cpp:16
+#: ../src/common/stockitem.cpp:182 ../src/stc/stc_i18n.cpp:16
 msgid "Redo"
 msgstr "다시 실행"
 
-#: ../src/common/stockitem.cpp:264
+#: ../src/common/stockitem.cpp:262
 msgid "Redo last action"
 msgstr "마지막 동작을 다시 실행합니다"
 
-#: ../src/common/stockitem.cpp:186
+#: ../src/common/stockitem.cpp:183
 msgid "Refresh"
 msgstr "새로고침"
 
-#: ../src/msw/registry.cpp:626
+#: ../src/msw/registry.cpp:615
 #, c-format
 msgid "Registry key '%s' already exists."
 msgstr "'%s' 레지스터 키가 이미 존재합니다."
 
-#: ../src/msw/registry.cpp:595
+#: ../src/msw/registry.cpp:584
 #, c-format
 msgid "Registry key '%s' does not exist, cannot rename it."
 msgstr "레지스트 키 '%s' 가 없어, 이름을 변경할 수 없습니다."
 
-#: ../src/msw/registry.cpp:727
+#: ../src/msw/registry.cpp:716
 #, c-format
 msgid ""
 "Registry key '%s' is needed for normal system operation,\n"
@@ -6137,22 +6290,22 @@ msgstr ""
 "이 키를 지우시면 시스템이 불안전한 상태가 됩니다.:\n"
 "삭제를 취소 합니다."
 
-#: ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:942
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:917
+#: ../src/msw/registry.cpp:905
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1003
+#: ../src/msw/registry.cpp:991
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:521
+#: ../src/msw/registry.cpp:510
 #, c-format
 msgid "Registry value '%s' already exists."
 msgstr "'%s' 레지스터 값이 이미 존재합니다."
@@ -6167,71 +6320,77 @@ msgstr "일반"
 msgid "Relative"
 msgstr "Decorative"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:456
 msgid "Relevant entries:"
 msgstr "관련 항목:"
 
-#: ../include/wx/generic/progdlgg.h:86
+#: ../include/wx/generic/progdlgg.h:87
 msgid "Remaining time:"
 msgstr "남은 시간:"
 
-#: ../src/common/stockitem.cpp:187
+#: ../src/common/stockitem.cpp:184
 msgid "Remove"
 msgstr "지우기"
 
-#: ../src/richtext/richtextctrl.cpp:1562
+#: ../src/richtext/richtextctrl.cpp:1563
 #, fuzzy
 msgid "Remove Bullet"
 msgstr "지우기"
 
-#: ../src/html/helpwnd.cpp:433
+#: ../src/html/helpwnd.cpp:431
 msgid "Remove current page from bookmarks"
 msgstr "현재 페이지의 책갈피를 제거 합니다."
 
-#: ../src/common/rendcmn.cpp:194
+#: ../src/common/rendcmn.cpp:191
 #, c-format
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr "Renderer \"%s\" 버전 %d.%d  는 호환되지 않습니다."
 
-#: ../src/richtext/richtextbuffer.cpp:4527
+#: ../src/richtext/richtextbuffer.cpp:4524
 msgid "Renumber List"
 msgstr "목록 번호 다시 매기기"
 
-#: ../src/common/stockitem.cpp:188
-msgid "Rep&lace"
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Rep&lace..."
 msgstr "바꾸기(&L)"
 
-#: ../src/richtext/richtextctrl.cpp:3673 ../src/common/stockitem.cpp:188
+#: ../src/richtext/richtextctrl.cpp:3674
 msgid "Replace"
 msgstr "바꾸기"
 
-#: ../src/generic/fdrepdlg.cpp:182
+#: ../src/generic/fdrepdlg.cpp:179
 msgid "Replace &all"
 msgstr "모두 바꾸기(&A)"
 
-#: ../src/common/stockitem.cpp:261
-msgid "Replace selection"
-msgstr "현재 선택 바꾸기"
-
-#: ../src/generic/fdrepdlg.cpp:124
+#: ../src/generic/fdrepdlg.cpp:121
 msgid "Replace with:"
 msgstr "다음으로 바꾸기:"
 
-#: ../src/common/valtext.cpp:163
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Replace..."
+msgstr "바꾸기"
+
+#: ../src/common/valtext.cpp:184
 msgid "Required information entry is empty."
 msgstr ""
 
-#: ../src/common/translation.cpp:1975
+#: ../src/common/translation.cpp:2025
 #, fuzzy, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "'%s'은 메시지 카탈로그가 아닙니다."
 
+#: ../src/gtk/webview_webkit.cpp:985
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:56
+#: ../src/common/accelcmn.cpp:53
 msgid "Return"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:189
+#: ../src/common/stockitem.cpp:186
 msgid "Revert to Saved"
 msgstr "저장된 상태로 되돌리기"
 
@@ -6244,42 +6403,42 @@ msgstr "오른쪽"
 msgid "Rig&ht-to-left"
 msgstr ""
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6149
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:59 ../src/generic/datavgen.cpp:6954
+#: ../src/richtext/richtextsizepage.cpp:250
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextbulletspage.cpp:188
-#: ../src/richtext/richtextsizepage.cpp:250 ../src/common/accelcmn.cpp:62
 msgid "Right"
 msgstr "오른쪽"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1754
+#: ../src/propgrid/advprops.cpp:1655
 #, fuzzy
 msgid "Right Arrow"
 msgstr "오른쪽"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1770
+#: ../src/propgrid/advprops.cpp:1671
 msgid "Right Button"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:892
+#: ../src/generic/prntdlgg.cpp:885
 msgid "Right margin (mm):"
 msgstr "오른쪽 여백(mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:148
-#: ../src/richtext/richtextindentspage.cpp:150
 #: ../src/richtext/richtextliststylepage.cpp:337
 #: ../src/richtext/richtextliststylepage.cpp:339
+#: ../src/richtext/richtextindentspage.cpp:148
+#: ../src/richtext/richtextindentspage.cpp:150
 msgid "Right-align text."
 msgstr "텍스트 오른쪽 정렬"
 
-#: ../src/generic/fontdlgg.cpp:322
+#: ../src/generic/fontdlgg.cpp:318
 msgid "Roman"
 msgstr ""
 
-#: ../src/generic/datavgen.cpp:5916
+#: ../src/generic/datavgen.cpp:6721
 #, c-format
 msgid "Row %i"
 msgstr ""
@@ -6289,31 +6448,31 @@ msgstr ""
 msgid "S&tandard bullet name:"
 msgstr "표준 글머리 이름(&T):"
 
-#: ../src/common/accelcmn.cpp:268 ../src/common/accelcmn.cpp:350
+#: ../src/common/accelcmn.cpp:282 ../src/common/accelcmn.cpp:367
 msgid "SPECIAL"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:190 ../src/common/sizer.cpp:2797
+#: ../src/common/stockitem.cpp:187 ../src/common/sizer.cpp:2914
 msgid "Save"
 msgstr "저장"
 
-#: ../src/common/fldlgcmn.cpp:342
+#: ../src/common/fldlgcmn.cpp:339
 #, c-format
 msgid "Save %s file"
 msgstr "%s 파일 저장"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/common/stockitem.cpp:188 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "다른 이름으로 저장(&A)"
 
-#: ../src/common/docview.cpp:366
+#: ../src/common/docview.cpp:359
 msgid "Save As"
 msgstr "다른 이름으로 저장"
 
-#: ../src/common/stockitem.cpp:191
+#: ../src/common/stockitem.cpp:188
 #, fuzzy
-msgid "Save as"
-msgstr "다른 이름으로 저장"
+msgid "Save As..."
+msgstr "다른 이름으로 저장(&A)"
 
 #: ../src/common/stockitem.cpp:267
 msgid "Save current document"
@@ -6323,96 +6482,96 @@ msgstr "현재 문서를 저장합니다."
 msgid "Save current document with a different filename"
 msgstr "현재 문서를 다른 파일 이름으로 저장합니다."
 
-#: ../src/generic/logg.cpp:512
+#: ../src/generic/logg.cpp:509
 msgid "Save log contents to file"
 msgstr "파일에 로그 저장"
 
-#: ../src/common/secretstore.cpp:179
+#: ../src/common/secretstore.cpp:189
 #, fuzzy, c-format
-msgid "Saving password for \"%s/%s\" failed: %s."
+msgid "Saving password for \"%s\" failed: %s."
 msgstr "'%s' 의 추출('%s' 에서) 실패 했습니다."
 
-#: ../src/generic/fontdlgg.cpp:325
+#: ../src/generic/fontdlgg.cpp:321
 msgid "Script"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll Lock"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll_lock"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:890
+#: ../src/propgrid/advprops.cpp:791
 msgid "Scrollbar"
 msgstr ""
 
-#: ../src/generic/srchctlg.cpp:56 ../src/html/helpwnd.cpp:535
-#: ../src/html/helpwnd.cpp:550
+#: ../src/generic/srchctlg.cpp:55 ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:548 ../src/gtk/srchctrl.cpp:182
 msgid "Search"
 msgstr "찾기"
 
-#: ../src/html/helpwnd.cpp:537
+#: ../src/html/helpwnd.cpp:535
 #, fuzzy
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
 msgstr "위에서 입력한 내용을 검색합니다.  "
 
-#: ../src/generic/fdrepdlg.cpp:160
+#: ../src/generic/fdrepdlg.cpp:157
 msgid "Search direction"
 msgstr "찾는 방향"
 
-#: ../src/generic/fdrepdlg.cpp:112
+#: ../src/generic/fdrepdlg.cpp:109
 msgid "Search for:"
 msgstr "찾을 문자열: "
 
-#: ../src/html/helpwnd.cpp:1052
+#: ../src/html/helpwnd.cpp:1050
 msgid "Search in all books"
 msgstr "모든 도움말 에서 찾기"
 
-#: ../src/html/helpwnd.cpp:857
+#: ../src/html/helpwnd.cpp:855
 msgid "Searching..."
 msgstr "찾는 중..."
 
-#: ../src/generic/dirctrlg.cpp:446
+#: ../src/generic/dirctrlg.cpp:412
 msgid "Sections"
 msgstr "섹션"
 
-#: ../src/common/ffile.cpp:238
+#: ../src/common/ffile.cpp:237
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "'%s' 파일에서 찾을 수 없습니다."
 
-#: ../src/common/ffile.cpp:228
+#: ../src/common/ffile.cpp:227
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr "파일 '%s' 에서 찾기 실패(큰 파일형식을 지원하지 않습니다.)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:76
+#: ../src/common/accelcmn.cpp:73
 #, fuzzy
 msgid "Select"
 msgstr "선택"
 
-#: ../src/richtext/richtextctrl.cpp:337 ../src/osx/textctrl_osx.cpp:581
-#: ../src/common/stockitem.cpp:192 ../src/msw/textctrl.cpp:2512
+#: ../src/osx/textctrl_osx.cpp:599 ../src/common/stockitem.cpp:189
+#: ../src/msw/textctrl.cpp:2777 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "모두 선택(&A)"
 
-#: ../src/common/stockitem.cpp:192 ../src/stc/stc_i18n.cpp:21
+#: ../src/common/stockitem.cpp:189 ../src/stc/stc_i18n.cpp:21
 msgid "Select All"
 msgstr "모두 선택"
 
-#: ../src/common/docview.cpp:1895
+#: ../src/common/docview.cpp:1900
 msgid "Select a document template"
 msgstr "문서 템플릿을 선택합니다"
 
-#: ../src/common/docview.cpp:1969
+#: ../src/common/docview.cpp:1974
 msgid "Select a document view"
 msgstr "문서 뷰를 선택합니다"
 
@@ -6441,20 +6600,20 @@ msgid "Selects the list level to edit."
 msgstr "편집할 목록 단계를 선택하시오."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:82
+#: ../src/common/accelcmn.cpp:79
 msgid "Separator"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1083
+#: ../src/common/cmdline.cpp:1079
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "옵션 '%s' 에 구분자가 없습니다."
 
-#: ../src/osx/menu_osx.cpp:572
+#: ../src/osx/menu_osx.cpp:464
 msgid "Services"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11217
+#: ../src/richtext/richtextbuffer.cpp:11216
 #, fuzzy
 msgid "Set Cell Style"
 msgstr "모양새 지우기"
@@ -6463,11 +6622,11 @@ msgstr "모양새 지우기"
 msgid "SetProperty called w/o valid setter"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:188
+#: ../src/generic/prntdlgg.cpp:181
 msgid "Setup..."
 msgstr "설정..."
 
-#: ../src/msw/dialup.cpp:544
+#: ../src/msw/dialup.cpp:538
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr "여러개의 활성화된 전화연결을 찾았습니다. 임의로 하나를 선택합니다."
 
@@ -6484,41 +6643,41 @@ msgstr ""
 msgid "Shadow c&olour:"
 msgstr "색상 선택"
 
-#: ../src/common/accelcmn.cpp:335
+#: ../src/common/accelcmn.cpp:349
 msgid "Shift+"
 msgstr ""
 
-#: ../src/generic/dirdlgg.cpp:147
+#: ../src/generic/dirdlgg.cpp:144
 msgid "Show &hidden directories"
 msgstr "숨김 폴더 표시(&H)"
 
-#: ../src/generic/filectrlg.cpp:983
+#: ../src/generic/filectrlg.cpp:979
 msgid "Show &hidden files"
 msgstr "숨겨진 파일 표시(&H)"
 
-#: ../src/osx/menu_osx.cpp:580
+#: ../src/osx/menu_osx.cpp:472
 #, fuzzy
 msgid "Show All"
 msgstr "모두 표시"
 
-#: ../src/common/stockitem.cpp:257
+#: ../src/common/stockitem.cpp:254
 msgid "Show about dialog"
 msgstr "정보 대화상자 표시"
 
-#: ../src/html/helpwnd.cpp:492
+#: ../src/html/helpwnd.cpp:490
 msgid "Show all"
 msgstr "모두 표시"
 
-#: ../src/html/helpwnd.cpp:503
+#: ../src/html/helpwnd.cpp:501
 msgid "Show all items in index"
 msgstr "색인의 모든 아이템 표시"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:656
 msgid "Show/hide navigation panel"
 msgstr "탐색 도구모음 보이기/감추기"
 
-#: ../src/richtext/richtextsymboldlg.cpp:421
-#: ../src/richtext/richtextsymboldlg.cpp:423
+#: ../src/richtext/richtextsymboldlg.cpp:418
+#: ../src/richtext/richtextsymboldlg.cpp:420
 msgid "Shows a Unicode subset."
 msgstr "Unicode 부분집합 표시"
 
@@ -6534,7 +6693,7 @@ msgstr "글머리 설정 미리보기."
 msgid "Shows a preview of the font settings."
 msgstr "글꼴의 미리 보기를 표시"
 
-#: ../src/osx/carbon/fontdlg.cpp:394 ../src/osx/carbon/fontdlg.cpp:396
+#: ../src/osx/carbon/fontdlg.cpp:391 ../src/osx/carbon/fontdlg.cpp:393
 msgid "Shows a preview of the font."
 msgstr "글꼴 미리보기"
 
@@ -6543,62 +6702,62 @@ msgstr "글꼴 미리보기"
 msgid "Shows a preview of the paragraph settings."
 msgstr "단락 설정 미리 보기"
 
-#: ../src/generic/fontdlgg.cpp:460 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:456 ../src/generic/fontdlgg.cpp:458
 msgid "Shows the font preview."
 msgstr "글꼴 미리보기"
 
-#: ../src/propgrid/advprops.cpp:1607
+#: ../src/propgrid/advprops.cpp:1513
 msgid "Silver"
 msgstr ""
 
-#: ../src/univ/themes/mono.cpp:516
+#: ../src/univ/themes/mono.cpp:513
 msgid "Simple monochrome theme"
 msgstr "Simple monochrome 테마"
 
-#: ../src/richtext/richtextindentspage.cpp:275
 #: ../src/richtext/richtextliststylepage.cpp:449
+#: ../src/richtext/richtextindentspage.cpp:275
 msgid "Single"
 msgstr "일반"
 
-#: ../src/generic/filectrlg.cpp:425 ../src/richtext/richtextformatdlg.cpp:369
-#: ../src/richtext/richtextsizepage.cpp:299
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextsizepage.cpp:299
+#: ../src/richtext/richtextformatdlg.cpp:362
 msgid "Size"
 msgstr "크기"
 
-#: ../src/osx/carbon/fontdlg.cpp:339
+#: ../src/osx/carbon/fontdlg.cpp:336
 msgid "Size:"
 msgstr "크기:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1775
+#: ../src/propgrid/advprops.cpp:1676
 msgid "Sizing"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1772
+#: ../src/propgrid/advprops.cpp:1673
 msgid "Sizing N-S"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1771
+#: ../src/propgrid/advprops.cpp:1672
 msgid "Sizing NE-SW"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1773
+#: ../src/propgrid/advprops.cpp:1674
 msgid "Sizing NW-SE"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1774
+#: ../src/propgrid/advprops.cpp:1675
 msgid "Sizing W-E"
 msgstr ""
 
-#: ../src/msw/progdlg.cpp:801
+#: ../src/msw/progdlg.cpp:1088
 msgid "Skip"
 msgstr "건너뛰기"
 
-#: ../src/generic/fontdlgg.cpp:330
+#: ../src/generic/fontdlgg.cpp:326
 msgid "Slant"
 msgstr "대각선"
 
@@ -6608,7 +6767,7 @@ msgid "Small C&apitals"
 msgstr "대문자(&P)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:79
+#: ../src/common/accelcmn.cpp:76
 msgid "Snapshot"
 msgstr ""
 
@@ -6617,37 +6776,37 @@ msgstr ""
 msgid "Solid"
 msgstr "굵게"
 
-#: ../src/common/docview.cpp:1791
+#: ../src/common/docview.cpp:1785
 msgid "Sorry, could not open this file."
 msgstr "파일을 열 수 없습니다."
 
-#: ../src/common/prntbase.cpp:2057 ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2079 ../src/common/prntbase.cpp:2087
 msgid "Sorry, not enough memory to create a preview."
 msgstr "메모리가 부족하여 미리보기를 할 수 없습니다."
 
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "Sorry, that name is taken. Please choose another."
 msgstr "이미 존재하는 이름입니다. 다른 이름을 선택하십시오."
 
-#: ../src/common/docview.cpp:1814
+#: ../src/common/docview.cpp:1819
 msgid "Sorry, the format for this file is unknown."
 msgstr "알수 없는 파일 형식 입니다."
 
-#: ../src/unix/sound.cpp:492
+#: ../src/unix/sound.cpp:481
 msgid "Sound data are in unsupported format."
 msgstr "소리 데이타가 알 수 없는 형식 입니다."
 
-#: ../src/unix/sound.cpp:477
+#: ../src/unix/sound.cpp:466
 #, c-format
 msgid "Sound file '%s' is in unsupported format."
 msgstr "'\"%s' 사운드 파일은 지원되지 않는 형식입니다."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:67
+#: ../src/common/accelcmn.cpp:64
 #, fuzzy
 msgid "Space"
 msgstr "간격"
@@ -6656,12 +6815,12 @@ msgstr "간격"
 msgid "Spacing"
 msgstr "간격"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "Spell Check"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1776
+#: ../src/propgrid/advprops.cpp:1677
 msgid "Spraycan"
 msgstr ""
 
@@ -6670,7 +6829,7 @@ msgstr ""
 msgid "Standard"
 msgstr "표준"
 
-#: ../src/common/paper.cpp:104
+#: ../src/common/paper.cpp:101
 msgid "Statement, 5 1/2 x 8 1/2 in"
 msgstr "Statement, 5 1/2 x 8 1/2 in"
 
@@ -6680,35 +6839,31 @@ msgstr "Statement, 5 1/2 x 8 1/2 in"
 msgid "Static"
 msgstr "상태:"
 
-#: ../src/generic/prntdlgg.cpp:204
+#: ../src/generic/prntdlgg.cpp:197
 msgid "Status:"
 msgstr "상태:"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 #, fuzzy
 msgid "Stop"
 msgstr "중지(&S)"
 
-#: ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196
 #, fuzzy
 msgid "Strikethrough"
 msgstr "취소선(&S)"
 
-#: ../src/common/colourcmn.cpp:45
+#: ../src/common/colourcmn.cpp:42
 #, c-format
 msgid "String To Colour : Incorrect colour specification : %s"
 msgstr "색상코드를 문자열로 변환 : 색상 지정이 잘못되었습니다 : %s"
 
 #. TRANSLATORS: Label of font style
-#: ../src/richtext/richtextformatdlg.cpp:339 ../src/propgrid/advprops.cpp:680
+#: ../src/propgrid/advprops.cpp:590 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "모양새"
 
-#: ../include/wx/richtext/richtextstyledlg.h:46
-msgid "Style Organiser"
-msgstr "모양새 관리"
-
-#: ../src/osx/carbon/fontdlg.cpp:348
+#: ../src/osx/carbon/fontdlg.cpp:345
 msgid "Style:"
 msgstr "모양새:"
 
@@ -6717,7 +6872,7 @@ msgid "Subscrip&t"
 msgstr "아래 첨자(&T)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:83
+#: ../src/common/accelcmn.cpp:80
 msgid "Subtract"
 msgstr ""
 
@@ -6725,11 +6880,11 @@ msgstr ""
 msgid "Supe&rscript"
 msgstr "위 첨자(&R)"
 
-#: ../src/common/paper.cpp:150
+#: ../src/common/paper.cpp:147
 msgid "SuperA/SuperA/A4 227 x 356 mm"
 msgstr "SuperA/SuperA/A4 227 x 356 mm"
 
-#: ../src/common/paper.cpp:151
+#: ../src/common/paper.cpp:148
 msgid "SuperB/SuperB/A3 305 x 487 mm"
 msgstr "SuperB/SuperB/A3 305 x 487 mm"
 
@@ -6737,7 +6892,7 @@ msgstr "SuperB/SuperB/A3 305 x 487 mm"
 msgid "Suppress hyphe&nation"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:326
+#: ../src/generic/fontdlgg.cpp:322
 msgid "Swiss"
 msgstr ""
 
@@ -6755,75 +6910,75 @@ msgstr "기호 글꼴(&F):"
 msgid "Symbols"
 msgstr "기호"
 
-#: ../src/common/imagtiff.cpp:369 ../src/common/imagtiff.cpp:382
-#: ../src/common/imagtiff.cpp:741
+#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
+#: ../src/common/imagtiff.cpp:738
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: 메모리를 할당할 수 없습니다."
 
-#: ../src/common/imagtiff.cpp:301
+#: ../src/common/imagtiff.cpp:298
 msgid "TIFF: Error loading image."
 msgstr "TIFF: 이미지 읽어오기 오류."
 
-#: ../src/common/imagtiff.cpp:468
+#: ../src/common/imagtiff.cpp:465
 msgid "TIFF: Error reading image."
 msgstr "TIFF: 이미지 읽기 오류."
 
-#: ../src/common/imagtiff.cpp:608
+#: ../src/common/imagtiff.cpp:605
 msgid "TIFF: Error saving image."
 msgstr "TIFF: 이미지 저장 오류."
 
-#: ../src/common/imagtiff.cpp:846
+#: ../src/common/imagtiff.cpp:843
 msgid "TIFF: Error writing image."
 msgstr "TIFF: 이미지 쓰기 오류"
 
-#: ../src/common/imagtiff.cpp:355
+#: ../src/common/imagtiff.cpp:352
 msgid "TIFF: Image size is abnormally big."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:68
+#: ../src/common/accelcmn.cpp:65
 #, fuzzy
 msgid "Tab"
 msgstr "탭"
 
-#: ../src/richtext/richtextbuffer.cpp:11498
+#: ../src/richtext/richtextbuffer.cpp:11497
 #, fuzzy
 msgid "Table Properties"
 msgstr "특성(&P)"
 
-#: ../src/common/paper.cpp:145
+#: ../src/common/paper.cpp:142
 msgid "Tabloid Extra 11.69 x 18 in"
 msgstr "Tabloid Extra 11.69 x 18 in"
 
-#: ../src/common/paper.cpp:102
+#: ../src/common/paper.cpp:99
 msgid "Tabloid, 11 x 17 in"
 msgstr "Tabloid, 11 x 17 in"
 
-#: ../src/richtext/richtextformatdlg.cpp:354
+#: ../src/richtext/richtextformatdlg.cpp:347
 msgid "Tabs"
 msgstr "탭"
 
-#: ../src/propgrid/advprops.cpp:1598
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Teal"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:327
+#: ../src/generic/fontdlgg.cpp:323
 msgid "Teletype"
 msgstr ""
 
-#: ../src/common/docview.cpp:1896
+#: ../src/common/docview.cpp:1901
 msgid "Templates"
 msgstr "템플릿"
 
-#: ../src/common/fmapbase.cpp:158
+#: ../src/common/fmapbase.cpp:155
 msgid "Thai (ISO-8859-11)"
 msgstr "타이어 (ISO-8859-11)"
 
-#: ../src/common/ftp.cpp:619
+#: ../src/common/ftp.cpp:622
 msgid "The FTP server doesn't support passive mode."
 msgstr "FTP 서버가 패시브 모드를 지원하지 않습니다."
 
-#: ../src/common/ftp.cpp:605
+#: ../src/common/ftp.cpp:608
 msgid "The FTP server doesn't support the PORT command."
 msgstr "FTP 서버가 포트 명령을 지원하지 않습니다."
 
@@ -6834,8 +6989,8 @@ msgstr "FTP 서버가 포트 명령을 지원하지 않습니다."
 msgid "The available bullet styles."
 msgstr "사용가능한 글머리 모양새"
 
-#: ../src/richtext/richtextstyledlg.cpp:202
-#: ../src/richtext/richtextstyledlg.cpp:204
+#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:200
 msgid "The available styles."
 msgstr "사용가능한 모양새"
 
@@ -6896,12 +7051,12 @@ msgstr "탭 위치"
 msgid "The bullet character."
 msgstr "글머리 문자"
 
-#: ../src/richtext/richtextsymboldlg.cpp:443
-#: ../src/richtext/richtextsymboldlg.cpp:445
+#: ../src/richtext/richtextsymboldlg.cpp:440
+#: ../src/richtext/richtextsymboldlg.cpp:442
 msgid "The character code."
 msgstr "문자 코드."
 
-#: ../src/common/fontmap.cpp:203
+#: ../src/common/fontmap.cpp:200
 #, c-format
 msgid ""
 "The charset '%s' is unknown. You may select\n"
@@ -6912,7 +7067,7 @@ msgstr ""
 "다름 문자집합을 선택하십시오.\n"
 "변경하지 원치 않으면 [취소] 클릭십시오."
 
-#: ../src/msw/ole/dataobj.cpp:394
+#: ../src/msw/ole/dataobj.cpp:402
 #, c-format
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "%d 포맷이 클립보드에 없습니다."
@@ -6922,7 +7077,7 @@ msgstr "%d 포맷이 클립보드에 없습니다."
 msgid "The default style for the next paragraph."
 msgstr "다음 단락의 기본 모양새"
 
-#: ../src/generic/dirdlgg.cpp:202
+#: ../src/generic/dirdlgg.cpp:199
 #, c-format
 msgid ""
 "The directory '%s' does not exist\n"
@@ -6931,7 +7086,7 @@ msgstr ""
 "디렉토리 '%s' 가 없습니다\n"
 "디렉토리를 생성하시겠습니까?"
 
-#: ../src/html/htmprint.cpp:271
+#: ../src/html/htmprint.cpp:283
 #, c-format
 msgid ""
 "The document \"%s\" doesn't fit on the page horizontally and will be "
@@ -6940,7 +7095,7 @@ msgid ""
 "Would you like to proceed with printing it nevertheless?"
 msgstr ""
 
-#: ../src/common/docview.cpp:1202
+#: ../src/common/docview.cpp:1196
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -6949,36 +7104,36 @@ msgstr ""
 "파일 '%s' 가 없습니다.\n"
 "최근 사용 파일 목록 에서 제거된거 같습니다."
 
-#: ../src/richtext/richtextindentspage.cpp:208
-#: ../src/richtext/richtextindentspage.cpp:210
 #: ../src/richtext/richtextliststylepage.cpp:394
 #: ../src/richtext/richtextliststylepage.cpp:396
+#: ../src/richtext/richtextindentspage.cpp:208
+#: ../src/richtext/richtextindentspage.cpp:210
 msgid "The first line indent."
 msgstr "첫 줄 들여쓰기"
 
-#: ../src/gtk/utilsgtk.cpp:481
-msgid "The following standard GTK+ options are also supported:\n"
-msgstr "다음은 표준 GTK+ 에서 지원하는 옵션입니다:\n"
+#: ../src/generic/dbgrptg.cpp:318
+msgid "The following debug report will be generated\n"
+msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:414 ../src/generic/fontdlgg.cpp:416
+#: ../src/generic/fontdlgg.cpp:411 ../src/generic/fontdlgg.cpp:413
 msgid "The font colour."
 msgstr "글꼴 색상"
 
-#: ../src/generic/fontdlgg.cpp:375 ../src/generic/fontdlgg.cpp:377
+#: ../src/generic/fontdlgg.cpp:371 ../src/generic/fontdlgg.cpp:373
 msgid "The font family."
 msgstr "글꼴 패밀리"
 
-#: ../src/richtext/richtextsymboldlg.cpp:405
-#: ../src/richtext/richtextsymboldlg.cpp:407
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "The font from which to take the symbol."
 msgstr "기호의 글꼴."
 
-#: ../src/generic/fontdlgg.cpp:427 ../src/generic/fontdlgg.cpp:429
-#: ../src/generic/fontdlgg.cpp:434 ../src/generic/fontdlgg.cpp:436
+#: ../src/generic/fontdlgg.cpp:424 ../src/generic/fontdlgg.cpp:426
+#: ../src/generic/fontdlgg.cpp:430 ../src/generic/fontdlgg.cpp:432
 msgid "The font point size."
 msgstr "글꼴 크기"
 
-#: ../src/osx/carbon/fontdlg.cpp:343 ../src/osx/carbon/fontdlg.cpp:345
+#: ../src/osx/carbon/fontdlg.cpp:340 ../src/osx/carbon/fontdlg.cpp:342
 msgid "The font size in points."
 msgstr "포인트로 나타낸 글꼴 크기"
 
@@ -6988,15 +7143,15 @@ msgstr "포인트로 나타낸 글꼴 크기"
 msgid "The font size units, points or pixels."
 msgstr "포인트로 나타낸 글꼴 크기"
 
-#: ../src/generic/fontdlgg.cpp:386 ../src/generic/fontdlgg.cpp:388
+#: ../src/generic/fontdlgg.cpp:382 ../src/generic/fontdlgg.cpp:384
 msgid "The font style."
 msgstr "글꼴 모양새"
 
-#: ../src/generic/fontdlgg.cpp:397 ../src/generic/fontdlgg.cpp:399
+#: ../src/generic/fontdlgg.cpp:393 ../src/generic/fontdlgg.cpp:395
 msgid "The font weight."
 msgstr "글꼴 두께"
 
-#: ../src/common/docview.cpp:1483
+#: ../src/common/docview.cpp:1477
 #, fuzzy, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Column 너비를 정의할수 없습니다."
@@ -7007,10 +7162,10 @@ msgstr "Column 너비를 정의할수 없습니다."
 msgid "The horizontal offset."
 msgstr "수평 타일"
 
-#: ../src/richtext/richtextindentspage.cpp:199
-#: ../src/richtext/richtextindentspage.cpp:201
 #: ../src/richtext/richtextliststylepage.cpp:385
 #: ../src/richtext/richtextliststylepage.cpp:387
+#: ../src/richtext/richtextindentspage.cpp:199
+#: ../src/richtext/richtextindentspage.cpp:201
 msgid "The left indent."
 msgstr "왼쪽 들여쓰기"
 
@@ -7034,10 +7189,10 @@ msgstr "글꼴 크기"
 msgid "The left position."
 msgstr "탭 위치"
 
-#: ../src/richtext/richtextindentspage.cpp:288
-#: ../src/richtext/richtextindentspage.cpp:290
 #: ../src/richtext/richtextliststylepage.cpp:462
 #: ../src/richtext/richtextliststylepage.cpp:464
+#: ../src/richtext/richtextindentspage.cpp:288
+#: ../src/richtext/richtextindentspage.cpp:290
 msgid "The line spacing."
 msgstr "줄 간격"
 
@@ -7046,7 +7201,7 @@ msgstr "줄 간격"
 msgid "The list item number."
 msgstr "목록 번호 매기기."
 
-#: ../src/msw/ole/automtn.cpp:664
+#: ../src/msw/ole/automtn.cpp:655
 msgid "The locale ID is unknown."
 msgstr ""
 
@@ -7091,20 +7246,20 @@ msgstr "글꼴 두께"
 msgid "The outline level."
 msgstr "들여쓰기 단계."
 
-#: ../src/common/log.cpp:277
+#: ../src/common/log.cpp:296
 #, fuzzy, c-format
 msgid "The previous message repeated %u time."
 msgid_plural "The previous message repeated %u times."
 msgstr[0] "이전의 중요한 메세지를 보여줍니다"
 msgstr[1] "이전의 중요한 메세지를 %lu번 보여줍니다"
 
-#: ../src/common/log.cpp:270
+#: ../src/common/log.cpp:289
 #, fuzzy
 msgid "The previous message repeated once."
 msgstr "이전의 중요한 메세지를 보여줍니다"
 
-#: ../src/richtext/richtextsymboldlg.cpp:462
-#: ../src/richtext/richtextsymboldlg.cpp:464
+#: ../src/richtext/richtextsymboldlg.cpp:459
+#: ../src/richtext/richtextsymboldlg.cpp:461
 msgid "The range to show."
 msgstr "범위 보기"
 
@@ -7118,15 +7273,15 @@ msgstr ""
 "면,\n"
 "체크를 해제하여 보고서에서 제외할수 있습니다.\n"
 
-#: ../src/common/cmdline.cpp:1254
+#: ../src/common/cmdline.cpp:1250
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "필수 매개 변수인 '%s' 가 지정되지 않았습니다."
 
-#: ../src/richtext/richtextindentspage.cpp:217
-#: ../src/richtext/richtextindentspage.cpp:219
 #: ../src/richtext/richtextliststylepage.cpp:403
 #: ../src/richtext/richtextliststylepage.cpp:405
+#: ../src/richtext/richtextindentspage.cpp:217
+#: ../src/richtext/richtextindentspage.cpp:219
 msgid "The right indent."
 msgstr "오른쪽 들여쓰기"
 
@@ -7171,16 +7326,16 @@ msgstr ""
 msgid "The shadow spread."
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:267
 #: ../src/richtext/richtextliststylepage.cpp:439
 #: ../src/richtext/richtextliststylepage.cpp:441
+#: ../src/richtext/richtextindentspage.cpp:267
 msgid "The spacing after the paragraph."
 msgstr "단락 후 간격"
 
-#: ../src/richtext/richtextindentspage.cpp:257
-#: ../src/richtext/richtextindentspage.cpp:259
 #: ../src/richtext/richtextliststylepage.cpp:430
 #: ../src/richtext/richtextliststylepage.cpp:432
+#: ../src/richtext/richtextindentspage.cpp:257
+#: ../src/richtext/richtextindentspage.cpp:259
 msgid "The spacing before the paragraph."
 msgstr "단락 전 간격"
 
@@ -7194,12 +7349,12 @@ msgstr "모양새 이름"
 msgid "The style on which this style is based."
 msgstr "기본 모양새."
 
-#: ../src/richtext/richtextstyledlg.cpp:214
-#: ../src/richtext/richtextstyledlg.cpp:216
+#: ../src/richtext/richtextstyledlg.cpp:210
+#: ../src/richtext/richtextstyledlg.cpp:212
 msgid "The style preview."
 msgstr "모양새 미리보기"
 
-#: ../src/msw/ole/automtn.cpp:680
+#: ../src/msw/ole/automtn.cpp:671
 msgid "The system cannot find the file specified."
 msgstr ""
 
@@ -7212,7 +7367,7 @@ msgstr "탭 위치"
 msgid "The tab positions."
 msgstr "탭 위치"
 
-#: ../src/richtext/richtextctrl.cpp:3098
+#: ../src/richtext/richtextctrl.cpp:3099
 msgid "The text couldn't be saved."
 msgstr "텍스트를 저장할 수 없습니다."
 
@@ -7236,7 +7391,7 @@ msgstr "글꼴 크기"
 msgid "The top position."
 msgstr "탭 위치"
 
-#: ../src/common/cmdline.cpp:1232
+#: ../src/common/cmdline.cpp:1228
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "'%s' 옵션에 대한 값을 지정해야합니다."
@@ -7246,7 +7401,7 @@ msgstr "'%s' 옵션에 대한 값을 지정해야합니다."
 msgid "The value of the corner radius."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:433
+#: ../src/msw/dialup.cpp:427
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -7261,124 +7416,132 @@ msgstr ""
 msgid "The vertical offset."
 msgstr "정렬 방식을 지정할 수 없습니다."
 
-#: ../src/richtext/richtextprint.cpp:619 ../src/html/htmprint.cpp:745
+#: ../src/html/htmprint.cpp:749 ../src/richtext/richtextprint.cpp:615
 msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr ""
 "페이지를 설정하는 동안 문제가 발생했습니다. 기본프린터를 설정해 주세요."
 
-#: ../src/html/htmprint.cpp:255
+#: ../src/html/htmprint.cpp:267
 msgid ""
 "This document doesn't fit on the page horizontally and will be truncated "
 "when it is printed."
 msgstr ""
 
-#: ../src/common/image.cpp:2854
+#: ../src/common/image.cpp:2963
 #, fuzzy, c-format
 msgid "This is not a %s."
 msgstr "PCX: PCX 파일이 아닙니다."
 
-#: ../src/common/wincmn.cpp:1653
+#: ../src/common/wincmn.cpp:1654
 msgid "This platform does not support background transparency."
 msgstr ""
 
-#: ../src/gtk/window.cpp:4660
+#: ../src/gtk/window.cpp:5664
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
 
-#: ../src/msw/thread.cpp:1240
+#: ../src/gtk/glcanvas.cpp:176
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/msw/thread.cpp:1246
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
 msgstr "쓰레드 모듈 초기화 실패:TLS 초기화 실패 "
 
-#: ../src/unix/threadpsx.cpp:1794
+#: ../src/unix/threadpsx.cpp:1843
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr "쓰레드 모듈 초기화 실패: 쓰레드 키 생성 실패"
 
-#: ../src/msw/thread.cpp:1228
+#: ../src/msw/thread.cpp:1234
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
 msgstr "쓰레드 모듈 초기화 실패:TLS 인덱스 할당 실패"
 
-#: ../src/unix/threadpsx.cpp:1043
+#: ../src/unix/threadpsx.cpp:1061
 msgid "Thread priority setting is ignored."
 msgstr "쓰레드 우선순위 설정을 무시합니다."
 
-#: ../src/msw/mdi.cpp:176
+#: ../src/msw/mdi.cpp:171
 msgid "Tile &Horizontally"
 msgstr "수평 타일"
 
-#: ../src/msw/mdi.cpp:177
+#: ../src/msw/mdi.cpp:172
 msgid "Tile &Vertically"
 msgstr "수직 타일"
 
-#: ../src/common/ftp.cpp:200
+#: ../src/common/ftp.cpp:197
 msgid "Timeout while waiting for FTP server to connect, try passive mode."
 msgstr "FTP 접속 실패(Time-out), 패시브 모드로 시도해 보시오."
 
-#: ../src/generic/tipdlg.cpp:201
+#: ../src/generic/tipdlg.cpp:198
 msgid "Tip of the Day"
 msgstr "오늘의 팁"
 
-#: ../src/generic/tipdlg.cpp:140
+#: ../src/generic/tipdlg.cpp:137
 msgid "Tips not available, sorry!"
 msgstr "유용한 팁이 없습니다."
 
-#: ../src/generic/prntdlgg.cpp:242
+#: ../src/generic/prntdlgg.cpp:235
 msgid "To:"
 msgstr "수신:"
 
-#: ../src/richtext/richtextbuffer.cpp:8363
+#: ../src/richtext/richtextbuffer.cpp:8361
 msgid "Too many EndStyle calls!"
 msgstr "EndStyle 함수를 너무 많이 호출함"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:891
+#: ../src/propgrid/advprops.cpp:792
 msgid "Tooltip"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:892
+#: ../src/propgrid/advprops.cpp:793
 msgid "TooltipText"
 msgstr ""
 
-#: ../src/richtext/richtextsizepage.cpp:286
-#: ../src/richtext/richtextsizepage.cpp:290 ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197 ../src/richtext/richtextsizepage.cpp:286
+#: ../src/richtext/richtextsizepage.cpp:290
 #, fuzzy
 msgid "Top"
 msgstr "수신:"
 
-#: ../src/generic/prntdlgg.cpp:881
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Top margin (mm):"
 msgstr "상단 여백(mm):"
 
-#: ../src/generic/aboutdlgg.cpp:79
+#: ../src/generic/aboutdlgg.cpp:76
 msgid "Translations by "
 msgstr "번역"
 
-#: ../src/generic/aboutdlgg.cpp:188
+#: ../src/generic/aboutdlgg.cpp:185
 msgid "Translators"
 msgstr "번역자"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:211
+#: ../src/propgrid/propgrid.cpp:192
 msgid "True"
 msgstr ""
 
-#: ../src/common/fs_mem.cpp:227
+#: ../src/common/fs_mem.cpp:222
 #, c-format
 msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
 msgstr "VFS에서 파일 '%s' 를 삭제할 수 없습니다.(로딩되지 않았음)"
 
-#: ../src/common/fmapbase.cpp:156
+#: ../src/common/fmapbase.cpp:153
 msgid "Turkish (ISO-8859-9)"
 msgstr "터키어 (ISO-8859-9)"
 
-#: ../src/generic/filectrlg.cpp:426
+#: ../src/generic/filectrlg.cpp:422
 msgid "Type"
 msgstr "타입"
 
@@ -7392,36 +7555,36 @@ msgstr "글꼴 이름"
 msgid "Type a size in points."
 msgstr "포인트로 나타낸 글꼴 크기"
 
-#: ../src/msw/ole/automtn.cpp:676
+#: ../src/msw/ole/automtn.cpp:667
 #, c-format
 msgid "Type mismatch in argument %u."
 msgstr ""
 
-#: ../src/common/xtixml.cpp:356 ../src/common/xtixml.cpp:509
-#: ../src/common/xtistrm.cpp:318
+#: ../src/common/xtixml.cpp:352 ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315
 msgid "Type must have enum - long conversion"
 msgstr "받드시 ConvertToLong 함수를 가져야 함니다."
 
-#: ../src/propgrid/propgridiface.cpp:401
+#: ../src/propgrid/propgridiface.cpp:385
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
 "\"%s\"."
 msgstr ""
 
-#: ../src/common/paper.cpp:133
+#: ../src/common/paper.cpp:130
 msgid "US Std Fanfold, 14 7/8 x 11 in"
 msgstr "US Std Fanfold, 14 7/8 x 11 in"
 
-#: ../src/common/fmapbase.cpp:196
+#: ../src/common/fmapbase.cpp:193
 msgid "US-ASCII"
 msgstr "영어 (US-ASCII)"
 
-#: ../src/unix/fswatcher_inotify.cpp:109
+#: ../src/unix/fswatcher_inotify.cpp:106
 msgid "Unable to add inotify watch"
 msgstr ""
 
-#: ../src/unix/fswatcher_kqueue.cpp:136
+#: ../src/unix/fswatcher_kqueue.cpp:153
 msgid "Unable to add kqueue watch"
 msgstr ""
 
@@ -7434,7 +7597,7 @@ msgstr ""
 msgid "Unable to close I/O completion port handle"
 msgstr "파일 닫기를 실패했습니다."
 
-#: ../src/unix/fswatcher_inotify.cpp:97
+#: ../src/unix/fswatcher_inotify.cpp:94
 #, fuzzy
 msgid "Unable to close inotify instance"
 msgstr "파일 닫기를 실패했습니다."
@@ -7454,17 +7617,17 @@ msgstr "파일 닫기를 실패했습니다."
 msgid "Unable to create I/O completion port"
 msgstr "Epoll 디스크립터 생성을 실패했습니다."
 
-#: ../src/msw/fswatcher.cpp:84
+#: ../src/msw/fswatcher.cpp:81
 #, fuzzy
 msgid "Unable to create IOCP worker thread"
 msgstr "MDI의 프레임 생성을 실패 했습니다."
 
-#: ../src/unix/fswatcher_inotify.cpp:74
+#: ../src/unix/fswatcher_inotify.cpp:71
 #, fuzzy
 msgid "Unable to create inotify instance"
 msgstr "DDE 문자열 생성을 실패 했습니다."
 
-#: ../src/unix/fswatcher_kqueue.cpp:97
+#: ../src/unix/fswatcher_kqueue.cpp:114
 #, fuzzy
 msgid "Unable to create kqueue instance"
 msgstr "DDE 문자열 생성을 실패 했습니다."
@@ -7473,11 +7636,11 @@ msgstr "DDE 문자열 생성을 실패 했습니다."
 msgid "Unable to dequeue completion packet"
 msgstr ""
 
-#: ../src/unix/fswatcher_kqueue.cpp:185
+#: ../src/unix/fswatcher_kqueue.cpp:202
 msgid "Unable to get events from kqueue"
 msgstr ""
 
-#: ../src/gtk/app.cpp:435
+#: ../src/gtk/app.cpp:431
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "GTK+ 초기화 할 수 없습니다. 디스플레이 설정이 바르게 되어 있습니까?"
 
@@ -7486,12 +7649,12 @@ msgstr "GTK+ 초기화 할 수 없습니다. 디스플레이 설정이 바르게
 msgid "Unable to open path '%s'"
 msgstr "'%s' CHM 파일을 여는 데 실패했습니다."
 
-#: ../src/html/htmlwin.cpp:583
+#: ../src/html/htmlwin.cpp:586
 #, c-format
 msgid "Unable to open requested HTML document: %s"
 msgstr "HTML 문서를 열 수 없습니다: %s"
 
-#: ../src/unix/sound.cpp:368
+#: ../src/unix/sound.cpp:365
 msgid "Unable to play sound asynchronously."
 msgstr "사운드를 비동기로 재생할 수 없습니다."
 
@@ -7499,63 +7662,63 @@ msgstr "사운드를 비동기로 재생할 수 없습니다."
 msgid "Unable to post completion status"
 msgstr ""
 
-#: ../src/unix/fswatcher_inotify.cpp:556
+#: ../src/unix/fswatcher_inotify.cpp:553
 #, fuzzy
 msgid "Unable to read from inotify descriptor"
 msgstr "파일 디스크립터 %d 에서 데이타를 읽어 올 수 없습니다."
 
-#: ../src/unix/fswatcher_inotify.cpp:141
+#: ../src/unix/fswatcher_inotify.cpp:138
 #, fuzzy, c-format
 msgid "Unable to remove inotify watch %i"
 msgstr "DDE 문자열 생성을 실패 했습니다."
 
-#: ../src/unix/fswatcher_kqueue.cpp:153
+#: ../src/unix/fswatcher_kqueue.cpp:170
 msgid "Unable to remove kqueue watch"
 msgstr ""
 
-#: ../src/msw/fswatcher.cpp:168
+#: ../src/msw/fswatcher.cpp:165
 #, fuzzy, c-format
 msgid "Unable to set up watch for '%s'"
 msgstr "'%s' 파일 만들기 실패"
 
-#: ../src/msw/fswatcher.cpp:91
+#: ../src/msw/fswatcher.cpp:88
 msgid "Unable to start IOCP worker thread"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:201
+#: ../src/common/stockitem.cpp:198
 msgid "Undelete"
 msgstr "되살리기"
 
-#: ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199
 #, fuzzy
 msgid "Underline"
 msgstr "밑줄(&U)"
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/richtext/richtextfontpage.cpp:359 ../src/osx/carbon/fontdlg.cpp:370
-#: ../src/propgrid/advprops.cpp:690
+#: ../src/osx/carbon/fontdlg.cpp:367 ../src/propgrid/advprops.cpp:600
+#: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "밑줄"
 
-#: ../src/common/stockitem.cpp:203 ../src/stc/stc_i18n.cpp:15
+#: ../src/common/stockitem.cpp:200 ../src/stc/stc_i18n.cpp:15
 msgid "Undo"
 msgstr "실행 취소"
 
-#: ../src/common/stockitem.cpp:265
+#: ../src/common/stockitem.cpp:263
 msgid "Undo last action"
 msgstr "마지막 동작을 취소합니다"
 
-#: ../src/common/cmdline.cpp:1029
+#: ../src/common/cmdline.cpp:1025
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "'%s' 옵션에서 예기치 않은 문자가 있습니다."
 
-#: ../src/unix/fswatcher_inotify.cpp:274
+#: ../src/unix/fswatcher_inotify.cpp:271
 #, c-format
 msgid "Unexpected event for \"%s\": no matching watch descriptor."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1195
+#: ../src/common/cmdline.cpp:1191
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "'%s' 의 파라메타가 잘못되었습니다."
@@ -7564,50 +7727,50 @@ msgstr "'%s' 의 파라메타가 잘못되었습니다."
 msgid "Unexpectedly new I/O completion port was created"
 msgstr ""
 
-#: ../src/msw/fswatcher.cpp:70
+#: ../src/msw/fswatcher.cpp:67
 #, fuzzy
 msgid "Ungraceful worker thread termination"
 msgstr "쓰레드 종료 실패로 Thread를 강제로 종료합니다"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:460
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:456
+#: ../src/richtext/richtextsymboldlg.cpp:457
+#: ../src/richtext/richtextsymboldlg.cpp:458
 msgid "Unicode"
 msgstr "유니코드"
 
-#: ../src/common/fmapbase.cpp:185 ../src/common/fmapbase.cpp:191
+#: ../src/common/fmapbase.cpp:182 ../src/common/fmapbase.cpp:188
 msgid "Unicode 16 bit (UTF-16)"
 msgstr "유니코드 (UTF-16)"
 
-#: ../src/common/fmapbase.cpp:190
+#: ../src/common/fmapbase.cpp:187
 msgid "Unicode 16 bit Big Endian (UTF-16BE)"
 msgstr "유니코드 (UTF-16BE)"
 
-#: ../src/common/fmapbase.cpp:186
+#: ../src/common/fmapbase.cpp:183
 msgid "Unicode 16 bit Little Endian (UTF-16LE)"
 msgstr "유니코드 (UTF-16LE)"
 
-#: ../src/common/fmapbase.cpp:187 ../src/common/fmapbase.cpp:193
+#: ../src/common/fmapbase.cpp:184 ../src/common/fmapbase.cpp:190
 msgid "Unicode 32 bit (UTF-32)"
 msgstr "유니코드 (UTF-32)"
 
-#: ../src/common/fmapbase.cpp:192
+#: ../src/common/fmapbase.cpp:189
 msgid "Unicode 32 bit Big Endian (UTF-32BE)"
 msgstr "유니코드 (UTF-32BE)"
 
-#: ../src/common/fmapbase.cpp:188
+#: ../src/common/fmapbase.cpp:185
 msgid "Unicode 32 bit Little Endian (UTF-32LE)"
 msgstr "유니코드 (UTF-32LE)"
 
-#: ../src/common/fmapbase.cpp:182
+#: ../src/common/fmapbase.cpp:179
 msgid "Unicode 7 bit (UTF-7)"
 msgstr "유니코드 (UTF-7)"
 
-#: ../src/common/fmapbase.cpp:183
+#: ../src/common/fmapbase.cpp:180
 msgid "Unicode 8 bit (UTF-8)"
 msgstr "유니코드 (UTF-8)"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 #, fuzzy
 msgid "Unindent"
 msgstr "내어쓰기"
@@ -7769,100 +7932,105 @@ msgstr "쓰레드를 종료할 수 없습니다."
 msgid "Units for this value."
 msgstr "쓰레드를 종료할 수 없습니다."
 
-#: ../src/generic/progdlgg.cpp:353 ../src/generic/progdlgg.cpp:622
+#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
 msgid "Unknown"
 msgstr "알수 없음"
 
-#: ../src/msw/dde.cpp:1174
+#: ../src/msw/dde.cpp:1238
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "%08x 의 DDE 오류 메세지를 찾을 수 없습니다."
 
-#: ../src/common/xtistrm.cpp:410
+#: ../src/common/xtistrm.cpp:407
 msgid "Unknown Object passed to GetObjectClassInfo"
 msgstr "GetObjectClassInfo 에서 객체를 찾을 수 없습니다."
 
-#: ../src/common/imagpng.cpp:366
+#: ../src/common/imagpng.cpp:383
 #, fuzzy, c-format
 msgid "Unknown PNG resolution unit %d"
 msgstr "알 수 없는 TIFF 해상도 단위(%d)임, 무시합니다."
 
-#: ../src/common/xtixml.cpp:327
+#: ../src/common/xtixml.cpp:323
 #, c-format
 msgid "Unknown Property %s"
 msgstr "속성 %s 을 찾을 수 없습니다."
 
-#: ../src/common/imagtiff.cpp:529
+#: ../src/common/imagtiff.cpp:526
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "알 수 없는 TIFF 해상도 단위(%d)임, 무시합니다."
 
-#: ../src/unix/dlunix.cpp:160
+#: ../src/propgrid/props.cpp:155
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/unix/dlunix.cpp:118
 msgid "Unknown dynamic library error"
 msgstr "알수 없는 동적 Library 오류"
 
-#: ../src/common/fmapbase.cpp:810
+#: ../src/common/fmapbase.cpp:806
 #, c-format
 msgid "Unknown encoding (%d)"
 msgstr "인코딩 %d 를 찾을수 없습니다."
 
-#: ../src/msw/ole/automtn.cpp:688
+#: ../src/msw/ole/automtn.cpp:679
 #, fuzzy, c-format
 msgid "Unknown error %08x"
 msgstr "%08x 의 DDE 오류 메세지를 찾을 수 없습니다."
 
-#: ../src/msw/ole/automtn.cpp:647
+#: ../src/msw/ole/automtn.cpp:638
 #, fuzzy
 msgid "Unknown exception"
 msgstr "%s 옵션을 찾을 수 없습니다."
 
-#: ../src/common/image.cpp:2839
+#: ../src/common/image.cpp:2942
 #, fuzzy
 msgid "Unknown image data format."
 msgstr "데이터에 잘못된 형식이 있습니다."
 
-#: ../src/common/cmdline.cpp:914
+#: ../src/common/cmdline.cpp:910
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "%s 옵션을 찾을 수 없습니다."
 
-#: ../src/msw/ole/automtn.cpp:631
+#: ../src/msw/ole/automtn.cpp:622
 msgid "Unknown name or named argument."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:929 ../src/common/cmdline.cpp:951
+#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "%s 옵션을 찾을 수 없습니다."
 
-#: ../src/common/mimecmn.cpp:225
+#: ../src/common/mimecmn.cpp:221
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "'%s' MIME 타입에서 '{' 의 짝이 맞지 않습니다."
 
-#: ../src/common/cmdproc.cpp:262 ../src/common/cmdproc.cpp:288
-#: ../src/common/cmdproc.cpp:308
+#: ../src/common/cmdproc.cpp:255 ../src/common/cmdproc.cpp:281
+#: ../src/common/cmdproc.cpp:301
 msgid "Unnamed command"
 msgstr "익명의 명령"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:413
+#: ../src/propgrid/propgrid.cpp:392
 #, fuzzy
 msgid "Unspecified"
 msgstr "정렬"
 
-#: ../src/msw/clipbrd.cpp:311
+#: ../src/msw/clipbrd.cpp:325
 msgid "Unsupported clipboard format."
 msgstr "클립보드를 지원하지 않습니다."
 
-#: ../src/common/appcmn.cpp:256
+#: ../src/common/appcmn.cpp:277
 #, c-format
 msgid "Unsupported theme '%s'."
 msgstr "'%s' 테마는 지원하지 않습니다."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:205
-#: ../src/common/accelcmn.cpp:63
+#: ../src/common/stockitem.cpp:202 ../src/common/accelcmn.cpp:60
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Up"
 msgstr "위로"
 
@@ -7876,7 +8044,7 @@ msgstr "모두 대문자"
 msgid "Upper case roman numerals"
 msgstr "로마 숫자를 대문자로"
 
-#: ../src/common/cmdline.cpp:1326
+#: ../src/common/cmdline.cpp:1322
 #, c-format
 msgid "Usage: %s"
 msgstr "사용법: %s"
@@ -7885,38 +8053,47 @@ msgstr "사용법: %s"
 msgid "Use &shadow"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:169
-#: ../src/richtext/richtextindentspage.cpp:171
 #: ../src/richtext/richtextliststylepage.cpp:358
 #: ../src/richtext/richtextliststylepage.cpp:360
+#: ../src/richtext/richtextindentspage.cpp:169
+#: ../src/richtext/richtextindentspage.cpp:171
 msgid "Use the current alignment setting."
 msgstr "현재 정렬 방식 사용"
 
-#: ../src/common/valtext.cpp:179
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/gtk/font.cpp:552
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/common/valtext.cpp:142
 msgid "Validation conflict"
 msgstr "충돌"
 
-#: ../src/propgrid/manager.cpp:238
+#: ../src/propgrid/manager.cpp:224
 msgid "Value"
 msgstr ""
 
-#: ../src/propgrid/props.cpp:386 ../src/propgrid/props.cpp:500
+#: ../src/propgrid/props.cpp:309
 #, c-format
 msgid "Value must be %s or higher."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:417 ../src/propgrid/props.cpp:531
+#: ../src/propgrid/props.cpp:336
 #, c-format
 msgid "Value must be %s or less."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:393 ../src/propgrid/props.cpp:424
-#: ../src/propgrid/props.cpp:507 ../src/propgrid/props.cpp:538
+#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
 #, fuzzy, c-format
 msgid "Value must be between %s and %s."
 msgstr "%d 와 %d 사의의 페이지 번호를 입력 하십시오."
 
-#: ../src/generic/aboutdlgg.cpp:128
+#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
 #, fuzzy
 msgid "Version "
 msgstr "버전 %s"
@@ -7927,25 +8104,32 @@ msgstr "버전 %s"
 msgid "Vertical alignment."
 msgstr "정렬 방식을 지정할 수 없습니다."
 
-#: ../src/generic/filedlgg.cpp:202
+#: ../src/generic/filedlgg.cpp:199
 msgid "View files as a detailed view"
 msgstr "자세히보기로 파일보기"
 
-#: ../src/generic/filedlgg.cpp:200
+#: ../src/generic/filedlgg.cpp:197
 msgid "View files as a list view"
 msgstr "목록보기로 파일보기"
 
-#: ../src/common/docview.cpp:1970
+#: ../src/common/docview.cpp:1975
 msgid "Views"
 msgstr "보기"
 
+#: ../src/gtk/app.cpp:348
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1777
+#: ../src/propgrid/advprops.cpp:1678
 msgid "Wait"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1779
+#: ../src/propgrid/advprops.cpp:1680
 msgid "Wait Arrow"
 msgstr ""
 
@@ -7954,253 +8138,250 @@ msgstr ""
 msgid "Waiting for IO on epoll descriptor %d failed"
 msgstr "Epoll 디스크립터 %d 의 입출력 대기가 실패했습니다."
 
-#: ../src/common/log.cpp:223
+#: ../src/common/log.cpp:241
 msgid "Warning: "
 msgstr "경고: "
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1778
+#: ../src/propgrid/advprops.cpp:1679
 msgid "Watch"
 msgstr ""
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:685
+#: ../src/propgrid/advprops.cpp:595
 #, fuzzy
 msgid "Weight"
 msgstr "두께(&W):"
 
-#: ../src/common/fmapbase.cpp:148
+#: ../src/common/fmapbase.cpp:145
 msgid "Western European (ISO-8859-1)"
 msgstr "서유럽어 (ISO-8859-1)"
 
-#: ../src/common/fmapbase.cpp:162
+#: ../src/common/fmapbase.cpp:159
 msgid "Western European with Euro (ISO-8859-15)"
 msgstr "서유럽어 (ISO-8859-15)"
 
-#: ../src/generic/fontdlgg.cpp:446 ../src/generic/fontdlgg.cpp:448
+#: ../src/generic/fontdlgg.cpp:443 ../src/generic/fontdlgg.cpp:445
 msgid "Whether the font is underlined."
 msgstr "글꼴 밑줄이 있는지 여부입니다."
 
-#: ../src/propgrid/advprops.cpp:1611
+#: ../src/propgrid/advprops.cpp:1517
 msgid "White"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:144
+#: ../src/generic/fdrepdlg.cpp:141
 msgid "Whole word"
 msgstr "전체 단어 일치"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:532
 msgid "Whole words only"
 msgstr "단어 단위로 검색"
 
-#: ../src/univ/themes/win32.cpp:1102
+#: ../src/univ/themes/win32.cpp:1099
 msgid "Win32 theme"
 msgstr "Win32 테마"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:893
+#: ../src/propgrid/advprops.cpp:794
 #, fuzzy
 msgid "Window"
 msgstr "창(&W)"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:894
+#: ../src/propgrid/advprops.cpp:795
 #, fuzzy
 msgid "WindowFrame"
 msgstr "창(&W)"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:895
+#: ../src/propgrid/advprops.cpp:796
 #, fuzzy
 msgid "WindowText"
 msgstr "창(&W)"
 
-#: ../src/common/fmapbase.cpp:177
+#: ../src/common/fmapbase.cpp:174
 msgid "Windows Arabic (CP 1256)"
 msgstr "Windows 아라비아어 (CP 1256)"
 
-#: ../src/common/fmapbase.cpp:178
+#: ../src/common/fmapbase.cpp:175
 msgid "Windows Baltic (CP 1257)"
 msgstr "Windows 발트어 (CP 1257)"
 
-#: ../src/common/fmapbase.cpp:171
+#: ../src/common/fmapbase.cpp:168
 msgid "Windows Central European (CP 1250)"
 msgstr "Windows 중유럽어 (CP 1250)"
 
-#: ../src/common/fmapbase.cpp:168
+#: ../src/common/fmapbase.cpp:165
 #, fuzzy
 msgid "Windows Chinese Simplified (CP 936) or GB-2312"
 msgstr "Windows 중국어 간체 (CP 936)"
 
-#: ../src/common/fmapbase.cpp:170
+#: ../src/common/fmapbase.cpp:167
 #, fuzzy
 msgid "Windows Chinese Traditional (CP 950) or Big-5"
 msgstr "Windows 중국어 번체 (CP 950)"
 
-#: ../src/common/fmapbase.cpp:172
+#: ../src/common/fmapbase.cpp:169
 msgid "Windows Cyrillic (CP 1251)"
 msgstr "Windows 키릴 자모 (CP 1251)"
 
-#: ../src/common/fmapbase.cpp:174
+#: ../src/common/fmapbase.cpp:171
 msgid "Windows Greek (CP 1253)"
 msgstr "Windows 그리스어 (CP 1253)"
 
-#: ../src/common/fmapbase.cpp:176
+#: ../src/common/fmapbase.cpp:173
 msgid "Windows Hebrew (CP 1255)"
 msgstr "Windows 히브리어 (CP 1255)"
 
-#: ../src/common/fmapbase.cpp:167
+#: ../src/common/fmapbase.cpp:164
 #, fuzzy
 msgid "Windows Japanese (CP 932) or Shift-JIS"
 msgstr "Windows 일본어 (CP 932)"
 
-#: ../src/common/fmapbase.cpp:180
+#: ../src/common/fmapbase.cpp:177
 #, fuzzy
 msgid "Windows Johab (CP 1361)"
 msgstr "Windows 아라비아어 (CP 1256)"
 
-#: ../src/common/fmapbase.cpp:169
+#: ../src/common/fmapbase.cpp:166
 msgid "Windows Korean (CP 949)"
 msgstr "Windows 한국어 (CP 949)"
 
-#: ../src/common/fmapbase.cpp:166
+#: ../src/common/fmapbase.cpp:163
 msgid "Windows Thai (CP 874)"
 msgstr "Windows 태국어 (CP 874)"
 
-#: ../src/common/fmapbase.cpp:175
+#: ../src/common/fmapbase.cpp:172
 msgid "Windows Turkish (CP 1254)"
 msgstr "Windows 터키어 (CP 1254)"
 
-#: ../src/common/fmapbase.cpp:179
+#: ../src/common/fmapbase.cpp:176
 #, fuzzy
 msgid "Windows Vietnamese (CP 1258)"
 msgstr "Windows 그리스어 (CP 1253)"
 
-#: ../src/common/fmapbase.cpp:173
+#: ../src/common/fmapbase.cpp:170
 msgid "Windows Western European (CP 1252)"
 msgstr "Windows 서유럽어 (CP 1252)"
 
-#: ../src/common/fmapbase.cpp:181
+#: ../src/common/fmapbase.cpp:178
 msgid "Windows/DOS OEM (CP 437)"
 msgstr "Windows/DOS OEM - 미국 (CP 437)"
 
-#: ../src/common/fmapbase.cpp:165
+#: ../src/common/fmapbase.cpp:162
 #, fuzzy
 msgid "Windows/DOS OEM Cyrillic (CP 866)"
 msgstr "Windows 키릴 자모 (CP 1251)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:111
+#: ../src/common/accelcmn.cpp:109
 #, fuzzy
 msgid "Windows_Left"
 msgstr "창(&W)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:113
+#: ../src/common/accelcmn.cpp:111
 #, fuzzy
 msgid "Windows_Menu"
 msgstr "창(&W)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:112
+#: ../src/common/accelcmn.cpp:110
 #, fuzzy
 msgid "Windows_Right"
 msgstr "창(&W)"
 
-#: ../src/common/ffile.cpp:150
+#: ../src/common/ffile.cpp:149
 #, c-format
 msgid "Write error on file '%s'"
 msgstr "'%s' 파일 쓰기 오류"
 
-#: ../src/xml/xml.cpp:914
+#: ../src/xml/xml.cpp:925
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "XML 해석 오류: %s  (줄번호 %d)"
 
-#: ../src/common/xpmdecod.cpp:796
+#: ../src/common/xpmdecod.cpp:794
 msgid "XPM: Malformed pixel data!"
 msgstr "XPM: 잘못된 픽셀 데이타"
 
-#: ../src/common/xpmdecod.cpp:705
+#: ../src/common/xpmdecod.cpp:702
 #, c-format
 msgid "XPM: incorrect colour description in line %d"
 msgstr "XPM: %d 행의 색상지정이 잘못되었습니다."
 
-#: ../src/common/xpmdecod.cpp:680
+#: ../src/common/xpmdecod.cpp:677
 msgid "XPM: incorrect header format!"
 msgstr "XPM: 헤더를 찾을 수 없습니다"
 
-#: ../src/common/xpmdecod.cpp:716 ../src/common/xpmdecod.cpp:725
+#: ../src/common/xpmdecod.cpp:714 ../src/common/xpmdecod.cpp:723
 #, c-format
 msgid "XPM: malformed colour definition '%s' at line %d!"
 msgstr "XPM: '%s' 파일의  %d 행의 색상 지정이 잘못되었습니다!"
 
-#: ../src/common/xpmdecod.cpp:755
+#: ../src/common/xpmdecod.cpp:753
 msgid "XPM: no colors left to use for mask!"
 msgstr "XPM: 마스크로 사용할 생상이 정의되어 있지 않습니다."
 
-#: ../src/common/xpmdecod.cpp:782
+#: ../src/common/xpmdecod.cpp:780
 #, c-format
 msgid "XPM: truncated image data at line %d!"
 msgstr "XPM: %d 행에서 이미지가 잘렸습니다!"
 
-#: ../src/propgrid/advprops.cpp:1610
+#: ../src/propgrid/advprops.cpp:1516
 msgid "Yellow"
 msgstr ""
 
-#: ../include/wx/msgdlg.h:276 ../src/common/stockitem.cpp:206
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:203
 #: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "예"
 
-#: ../src/osx/carbon/overlay.cpp:155
-msgid "You cannot Clear an overlay that is not inited"
-msgstr "오버레이 지울수 없습니다. 초기화 되지 않았습니다."
-
-#: ../src/osx/carbon/overlay.cpp:107 ../src/dfb/overlay.cpp:61
-msgid "You cannot Init an overlay twice"
-msgstr "오버레이를 두번 초기화 할 수 없습니다."
-
-#: ../src/generic/dirdlgg.cpp:287
+#: ../src/generic/dirdlgg.cpp:284
 msgid "You cannot add a new directory to this section."
 msgstr "이 섹션에 새 디렉토리를 추가할 수 없습니다."
 
-#: ../src/propgrid/propgrid.cpp:3299
+#: ../src/propgrid/propgrid.cpp:3276
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:209
+#: ../src/osx/cocoa/menu.mm:286
+#, fuzzy
+msgid "Zoom"
+msgstr "확대(&I)"
+
+#: ../src/common/stockitem.cpp:206
 msgid "Zoom &In"
 msgstr "확대(&I)"
 
-#: ../src/common/stockitem.cpp:210
+#: ../src/common/stockitem.cpp:207
 msgid "Zoom &Out"
 msgstr "축소(&O)"
 
-#: ../src/common/stockitem.cpp:209 ../src/common/prntbase.cpp:1594
+#: ../src/common/stockitem.cpp:206 ../src/common/prntbase.cpp:1619
 #, fuzzy
 msgid "Zoom In"
 msgstr "확대(&I)"
 
-#: ../src/common/stockitem.cpp:210 ../src/common/prntbase.cpp:1580
+#: ../src/common/stockitem.cpp:207 ../src/common/prntbase.cpp:1605
 #, fuzzy
 msgid "Zoom Out"
 msgstr "축소(&O)"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to &Fit"
 msgstr "화면에 맞추기"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 #, fuzzy
 msgid "Zoom to Fit"
 msgstr "화면에 맞추기"
 
-#: ../src/msw/dde.cpp:1141
+#: ../src/msw/dde.cpp:1205
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "프로그램이 경쟁 상태에 빠졋습니다."
 
-#: ../src/msw/dde.cpp:1129
+#: ../src/msw/dde.cpp:1193
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -8211,39 +8392,39 @@ msgstr ""
 "혹은 DDEML 함수에 전달된 인스턴스 ID가\n"
 "잘못되엇습니다."
 
-#: ../src/msw/dde.cpp:1147
+#: ../src/msw/dde.cpp:1211
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "클라이언트의 연결시도가 실패했습니다."
 
-#: ../src/msw/dde.cpp:1144
+#: ../src/msw/dde.cpp:1208
 msgid "a memory allocation failed."
 msgstr "메모리가 부족합니다."
 
-#: ../src/msw/dde.cpp:1138
+#: ../src/msw/dde.cpp:1202
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "DDEML 오류: 잘못된 파라미터 전달"
 
-#: ../src/msw/dde.cpp:1120
+#: ../src/msw/dde.cpp:1184
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "어브바이스 트랜잭션에 대한 동기화 요청이 제한 시간을 초과했습니다."
 
-#: ../src/msw/dde.cpp:1126
+#: ../src/msw/dde.cpp:1190
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "데이터 트랜잭션에 대한  동기화 요청이 제한 시간을 초과했습니다."
 
-#: ../src/msw/dde.cpp:1135
+#: ../src/msw/dde.cpp:1199
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "트랜잭션을 실행에 대한 동기화 요청이 시간이 초과되었습니다."
 
-#: ../src/msw/dde.cpp:1153
+#: ../src/msw/dde.cpp:1217
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "포크 트랜잭션에 대한 동기화 요청이 제한 시간을 초과했습니다."
 
-#: ../src/msw/dde.cpp:1168
+#: ../src/msw/dde.cpp:1232
 msgid "a request to end an advise transaction has timed out."
 msgstr "어브바이스 트랜잭션에 대한 종료 요청이 제한 시간을 초과했습니다."
 
-#: ../src/msw/dde.cpp:1162
+#: ../src/msw/dde.cpp:1226
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -8253,15 +8434,15 @@ msgstr ""
 "트랜잭션이 종료되지 전에\n"
 "서버또는 클라이언트가 종료 되었습니다."
 
-#: ../src/msw/dde.cpp:1150
+#: ../src/msw/dde.cpp:1214
 msgid "a transaction failed."
 msgstr "트랜잭션에 실패했습니다."
 
-#: ../src/common/accelcmn.cpp:189
+#: ../src/common/accelcmn.cpp:188
 msgid "alt"
 msgstr "alt"
 
-#: ../src/msw/dde.cpp:1132
+#: ../src/msw/dde.cpp:1196
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -8273,15 +8454,15 @@ msgstr ""
 "혹은 APPCMD_CLIENTONLY에서 초기화된 프로그램이\n"
 "서버 트랜잭션을 시도했습니다."
 
-#: ../src/msw/dde.cpp:1156
+#: ../src/msw/dde.cpp:1220
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "내부 호출을 통한 PostMessage 함수 호출이 실패했습니다."
 
-#: ../src/msw/dde.cpp:1165
+#: ../src/msw/dde.cpp:1229
 msgid "an internal error has occurred in the DDEML."
 msgstr "DDEML: 시스템 오류 발생"
 
-#: ../src/msw/dde.cpp:1171
+#: ../src/msw/dde.cpp:1235
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -8292,56 +8473,56 @@ msgstr ""
 "XTYP_XACT_COMPLETE 콜백함수에서 일단 프로그램으로 돌아옴,\n"
 "콜백을 위한 트랜잭션 ID(큐ID)가 더이상 유효하지 않습니다."
 
-#: ../src/common/zipstrm.cpp:1483
+#: ../src/common/zipstrm.cpp:1522
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "분활 압축으로 되어있습니다."
 
-#: ../src/common/fileconf.cpp:1847
+#: ../src/common/fileconf.cpp:1849
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "변경 불가능한 설정의 변경을 시도했습니다. '%s' 무시합니다."
 
-#: ../src/html/chm.cpp:329
+#: ../src/html/chm.cpp:326
 msgid "bad arguments to library function"
 msgstr "Library 함수의 매개변수가 잘못되었습니다."
 
-#: ../src/html/chm.cpp:341
+#: ../src/html/chm.cpp:338
 msgid "bad signature"
 msgstr "잘못된 서명"
 
-#: ../src/common/zipstrm.cpp:1918
+#: ../src/common/zipstrm.cpp:1988
 msgid "bad zipfile offset to entry"
 msgstr "Zip 파일 헤더가 잘못되었습니다."
 
-#: ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400
 msgid "binary"
 msgstr "이진"
 
-#: ../src/common/fontcmn.cpp:996
+#: ../src/common/fontcmn.cpp:1195
 msgid "bold"
 msgstr "굵게"
 
-#: ../src/msw/utils.cpp:1144
+#: ../src/msw/utils.cpp:1135
 #, c-format
 msgid "build %lu"
 msgstr ""
 
-#: ../src/common/ffile.cpp:75
+#: ../src/common/ffile.cpp:73
 #, c-format
 msgid "can't close file '%s'"
 msgstr "'%s' 파일을 닫을 수 없습니다."
 
-#: ../src/common/file.cpp:245
+#: ../src/common/file.cpp:242
 #, c-format
 msgid "can't close file descriptor %d"
 msgstr "파일 디스크립터 %d 를 닫을 수 없습니다."
 
-#: ../src/common/file.cpp:586
+#: ../src/common/ffile.cpp:382 ../src/common/file.cpp:613
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "'%s' 파일의 바뀐점을 저장할 수 없습니다."
 
-#: ../src/common/file.cpp:178
+#: ../src/common/file.cpp:175
 #, c-format
 msgid "can't create file '%s'"
 msgstr "'%s' 파일을 생성할 수 없습니다."
@@ -8351,50 +8532,50 @@ msgstr "'%s' 파일을 생성할 수 없습니다."
 msgid "can't delete user configuration file '%s'"
 msgstr "사용자 설정파일 '%s' 을 삭제할 수 없습니다."
 
-#: ../src/common/file.cpp:495
+#: ../src/common/file.cpp:522
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr ""
 "파일 디스크립터 %d에서 현재 오프셋의 위치가 파일의 끝인지 알 수 없습니다."
 
-#: ../src/common/zipstrm.cpp:1692
+#: ../src/common/zipstrm.cpp:1747
 msgid "can't find central directory in zip"
 msgstr "Zip 압축 스트립에서 Central-Directory 를 찾을 수 없습니다."
 
-#: ../src/common/file.cpp:465
+#: ../src/common/file.cpp:492
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "파일 디스크립터 %d 에서 파일의 길이를 얻어올 수 없습니다."
 
-#: ../src/msw/utils.cpp:341
+#: ../src/msw/utils.cpp:336
 msgid "can't find user's HOME, using current directory."
 msgstr "홈 디렉토리를 찾을수 없어 현재 디렉토리를 사용합니다."
 
-#: ../src/common/file.cpp:366
+#: ../src/common/file.cpp:407
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "파일 디스크립터 %d 를 비울수 없습니다."
 
-#: ../src/common/file.cpp:422
+#: ../src/common/file.cpp:463
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "파일 디스크립터 %d 의 현재 위치를 얻을 수 없습니다"
 
-#: ../src/common/fontmap.cpp:325
+#: ../src/common/fontmap.cpp:322
 msgid "can't load any font, aborting"
 msgstr "글꼴 가져오기 실패, 작업을 취소합니다."
 
-#: ../src/common/file.cpp:231 ../src/common/ffile.cpp:59
+#: ../src/common/ffile.cpp:57 ../src/common/file.cpp:228
 #, c-format
 msgid "can't open file '%s'"
 msgstr " '%s' 파일을 열 수 없습니다"
 
-#: ../src/common/fileconf.cpp:320
+#: ../src/common/fileconf.cpp:314
 #, c-format
 msgid "can't open global configuration file '%s'."
 msgstr "전역 설정파일 '%s' 을 열수 없습니다."
 
-#: ../src/common/fileconf.cpp:336
+#: ../src/common/fileconf.cpp:330
 #, c-format
 msgid "can't open user configuration file '%s'."
 msgstr "사용자 설정파일 '%s' 을 열수 없습니다."
@@ -8403,40 +8584,40 @@ msgstr "사용자 설정파일 '%s' 을 열수 없습니다."
 msgid "can't open user configuration file."
 msgstr "사용자 설정파일을 열수 없습니다."
 
-#: ../src/common/zipstrm.cpp:579
+#: ../src/common/zipstrm.cpp:572
 msgid "can't re-initialize zlib deflate stream"
 msgstr "zlib 출력 스트림을 재 초기화 할 수 없습니다"
 
-#: ../src/common/zipstrm.cpp:604
+#: ../src/common/zipstrm.cpp:597
 msgid "can't re-initialize zlib inflate stream"
 msgstr "zlib 입력 스트림을 재 초기화 할 수 없습니다"
 
-#: ../src/common/file.cpp:304
+#: ../src/common/file.cpp:345
 #, c-format
 msgid "can't read from file descriptor %d"
 msgstr "파일 디스크립터 %d 에서 데이타를 읽어 올 수 없습니다."
 
-#: ../src/common/file.cpp:581
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:608
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "'%s' 파일을 지울 수 없습니다"
 
-#: ../src/common/file.cpp:598
+#: ../src/common/ffile.cpp:394 ../src/common/file.cpp:625
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "'%s' 임시 파일을 지울 수 없습니다"
 
-#: ../src/common/file.cpp:408
+#: ../src/common/file.cpp:449
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "파일 디스크립터 %d 찾을 수 없습니다."
 
-#: ../src/common/textfile.cpp:273
+#: ../src/common/textfile.cpp:161
 #, c-format
 msgid "can't write buffer '%s' to disk."
 msgstr "문자열 '%s' 를 디스크에 쓸 수 없습니다."
 
-#: ../src/common/file.cpp:323
+#: ../src/common/file.cpp:364
 #, c-format
 msgid "can't write to file descriptor %d"
 msgstr "파일 디스크립터 %d 에서 데이타를 쓸 수 없습니다."
@@ -8446,22 +8627,28 @@ msgid "can't write user configuration file."
 msgstr "사용자 설정을 파일에 쓸 수 없습니다"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:482 ../src/generic/datavgen.cpp:1261
+#: ../src/common/datavcmn.cpp:2064 ../src/generic/datavgen.cpp:1384
 msgid "checked"
 msgstr ""
 
-#: ../src/html/chm.cpp:345
+#: ../src/html/chm.cpp:342
 msgid "checksum error"
 msgstr "체크섬 오류"
 
-#: ../src/common/tarstrm.cpp:820
+#: ../src/common/tarstrm.cpp:814
 msgid "checksum failure reading tar header block"
 msgstr "tar의 Checksum 실패"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:226
-#: ../src/richtext/richtextbackgroundpage.cpp:249
-#: ../src/richtext/richtextbackgroundpage.cpp:289
-#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
 #: ../src/richtext/richtextborderspage.cpp:254
 #: ../src/richtext/richtextborderspage.cpp:288
 #: ../src/richtext/richtextborderspage.cpp:322
@@ -8479,105 +8666,128 @@ msgstr "tar의 Checksum 실패"
 #: ../src/richtext/richtextmarginspage.cpp:340
 #: ../src/richtext/richtextmarginspage.cpp:363
 #: ../src/richtext/richtextmarginspage.cpp:388
-#: ../src/richtext/richtextsizepage.cpp:339
-#: ../src/richtext/richtextsizepage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:400
-#: ../src/richtext/richtextsizepage.cpp:427
-#: ../src/richtext/richtextsizepage.cpp:454
-#: ../src/richtext/richtextsizepage.cpp:481
-#: ../src/richtext/richtextsizepage.cpp:555
-#: ../src/richtext/richtextsizepage.cpp:590
-#: ../src/richtext/richtextsizepage.cpp:625
-#: ../src/richtext/richtextsizepage.cpp:660
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
 msgid "cm"
 msgstr ""
 
-#: ../src/html/chm.cpp:347
+#: ../src/html/chm.cpp:344
 msgid "compression error"
 msgstr "압축 오류"
 
-#: ../src/common/regex.cpp:236
+#: ../src/common/regex.cpp:233
 msgid "conversion to 8-bit encoding failed"
 msgstr "8비트 인코딩 변환 실패"
 
-#: ../src/common/accelcmn.cpp:187
+#: ../src/common/accelcmn.cpp:186
 msgid "ctrl"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1500
+#: ../src/common/cmdline.cpp:1496
 msgid "date"
 msgstr ""
 
-#: ../src/html/chm.cpp:349
+#: ../src/html/chm.cpp:346
 msgid "decompression error"
 msgstr "압축 풀기 오류"
 
-#: ../src/richtext/richtextstyles.cpp:780 ../src/common/fmapbase.cpp:820
+#: ../src/common/fmapbase.cpp:816 ../src/richtext/richtextstyles.cpp:777
 msgid "default"
 msgstr "기본값"
 
-#: ../src/common/cmdline.cpp:1496
+#: ../src/common/cmdline.cpp:1492
 msgid "double"
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:538
+#: ../src/common/debugrpt.cpp:539
 msgid "dump of the process state (binary)"
 msgstr "현재프로세스의 덤프"
 
-#: ../src/common/datetimefmt.cpp:1969
+#: ../src/common/datetimefmt.cpp:1992
 msgid "eighteenth"
 msgstr "열여덟 번째"
 
-#: ../src/common/datetimefmt.cpp:1959
+#: ../src/common/datetimefmt.cpp:1982
 msgid "eighth"
 msgstr "여덟 번째"
 
-#: ../src/common/datetimefmt.cpp:1962
+#: ../src/common/datetimefmt.cpp:1985
 msgid "eleventh"
 msgstr "열한 번째"
 
-#: ../src/common/fileconf.cpp:1833
+#: ../src/common/fileconf.cpp:1835
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "항목 '%s' 가 구룹 '%s' 에 하나이상 있습니다."
 
-#: ../src/html/chm.cpp:343
+#: ../src/html/chm.cpp:340
 msgid "error in data format"
 msgstr "데이터에 잘못된 형식이 있습니다."
 
-#: ../src/html/chm.cpp:331
+#: ../src/html/chm.cpp:328
 msgid "error opening file"
 msgstr "파일 열기 오류"
 
-#: ../src/common/zipstrm.cpp:1778
+#: ../src/common/zipstrm.cpp:1836
 msgid "error reading zip central directory"
 msgstr "CENTRAL_MAGIC 을 읽을 수 없습니다."
 
-#: ../src/common/zipstrm.cpp:1870
+#: ../src/common/zipstrm.cpp:1940
 msgid "error reading zip local header"
 msgstr "Zip 파일 읽기 오류"
 
-#: ../src/common/zipstrm.cpp:2531
+#: ../src/common/zipstrm.cpp:2615
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "Zip 오류('%s'): CRC 오류"
 
-#: ../src/common/ffile.cpp:188
+#: ../src/common/zipstrm.cpp:2608
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "Zip 오류('%s'): CRC 오류"
+
+#: ../src/common/fontcmn.cpp:1205
+#, fuzzy
+msgid "extrabold"
+msgstr "굵게"
+
+#: ../src/common/fontcmn.cpp:1223
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1167
+#, fuzzy
+msgid "extralight"
+msgstr "가늘게"
+
+#: ../src/msw/webview_ie.cpp:1036
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "'%s' 실행을 실패했습니다.\n"
+
+#: ../src/common/ffile.cpp:187
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "파일 '%s'를 비우는데 실패 했습니다."
 
+#: ../src/msw/webview_ie.cpp:1045
+#, fuzzy
+msgid "failed to retrieve execution result"
+msgstr "RAS 오류 메시지의 텍스트의 검색 실패"
+
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1030
+#: ../src/generic/datavgen.cpp:1150
 #, fuzzy
 msgid "false"
 msgstr "파일"
 
-#: ../src/common/datetimefmt.cpp:1966
+#: ../src/common/datetimefmt.cpp:1989
 msgid "fifteenth"
 msgstr "열다섯 번째"
 
-#: ../src/common/datetimefmt.cpp:1956
+#: ../src/common/datetimefmt.cpp:1979
 msgid "fifth"
 msgstr "다섯 번째"
 
@@ -8606,132 +8816,151 @@ msgstr "파일[%s], 행[%d]: 변경 불가능한 키값 '%s'는 무시합니다.
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "'%s' 파일: 잘못입력된 문자 데이터 %c (%d번째 줄)"
 
-#: ../src/richtext/richtextbuffer.cpp:8738
+#: ../src/richtext/richtextbuffer.cpp:8736
 msgid "files"
 msgstr "파일"
 
-#: ../src/common/datetimefmt.cpp:1952
+#: ../src/common/datetimefmt.cpp:1975
 msgid "first"
 msgstr "첫 번째"
 
-#: ../src/html/helpwnd.cpp:1252
+#: ../src/html/helpwnd.cpp:1250
 msgid "font size"
 msgstr "글꼴 크기"
 
-#: ../src/common/datetimefmt.cpp:1965
+#: ../src/common/datetimefmt.cpp:1988
 msgid "fourteenth"
 msgstr "열네 번째"
 
-#: ../src/common/datetimefmt.cpp:1955
+#: ../src/common/datetimefmt.cpp:1978
 msgid "fourth"
 msgstr "네 번째"
 
-#: ../src/common/appbase.cpp:783
+#: ../src/common/appbase.cpp:784
 msgid "generate verbose log messages"
 msgstr "자세한 로그 메시지 생성"
 
-#: ../src/richtext/richtextbuffer.cpp:13138
-#: ../src/richtext/richtextbuffer.cpp:13248
+#: ../src/common/fontcmn.cpp:1215
+msgid "heavy"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:13133
+#: ../src/richtext/richtextbuffer.cpp:13243
 msgid "image"
 msgstr "그림"
 
-#: ../src/common/tarstrm.cpp:796
+#: ../src/common/tarstrm.cpp:790
 msgid "incomplete header block in tar"
 msgstr "tar 헤더가 잘못되었습니다."
 
-#: ../src/common/xtixml.cpp:489
+#: ../src/common/xtixml.cpp:485
 msgid "incorrect event handler string, missing dot"
 msgstr "잘못된 문자열 : '.' 문자가 없음"
 
-#: ../src/common/tarstrm.cpp:1381
+#: ../src/common/tarstrm.cpp:1375
 msgid "incorrect size given for tar entry"
 msgstr "tar 파일의 크기가 잘못되었습니다."
 
-#: ../src/common/tarstrm.cpp:993
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:987
 msgid "invalid data in extended tar header"
 msgstr "tar 확장 헤더가 잘못되었습니다."
 
-#: ../src/generic/logg.cpp:1030
+#: ../src/generic/logg.cpp:1027
 msgid "invalid message box return value"
 msgstr "메세지창의 반환값이 잘못되었습니다."
 
-#: ../src/common/zipstrm.cpp:1647
+#: ../src/common/zipstrm.cpp:1688
 msgid "invalid zip file"
 msgstr "zip 파일이 잘못되었습니다"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:1228
 msgid "italic"
 msgstr "기울임"
 
-#: ../src/common/fontcmn.cpp:991
+#: ../src/common/webrequest_curl.cpp:374
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "Column 정보를 초기화 할 수 없습니다."
+
+#: ../src/common/fontcmn.cpp:1172
 msgid "light"
 msgstr "가늘게"
 
-#: ../src/common/intl.cpp:303
-#, c-format
-msgid "locale '%s' cannot be set."
-msgstr "문자 인코딩을 '%s' 로 설정할 수 없습니다."
+#: ../src/common/fontcmn.cpp:1185
+msgid "medium"
+msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2125
+#: ../src/common/datetimefmt.cpp:2148
 msgid "midnight"
 msgstr "깊은 밤"
 
-#: ../src/common/datetimefmt.cpp:1970
+#: ../src/common/datetimefmt.cpp:1993
 msgid "nineteenth"
 msgstr "열아홉 번째"
 
-#: ../src/common/datetimefmt.cpp:1960
+#: ../src/common/datetimefmt.cpp:1983
 msgid "ninth"
 msgstr "아홉 번째"
 
-#: ../src/msw/dde.cpp:1116
+#: ../src/msw/dde.cpp:1180
 msgid "no DDE error."
 msgstr "DDE 오류 없음."
 
-#: ../src/html/chm.cpp:327
+#: ../src/html/chm.cpp:324
 msgid "no error"
 msgstr "오류 없음"
 
-#: ../src/dfb/fontmgr.cpp:174
+#: ../src/dfb/fontmgr.cpp:171
 #, c-format
 msgid "no fonts found in %s, using builtin font"
 msgstr "%s 에서 글꼴을 찾을 수 없어, 기본 글꼴을 사용합니다."
 
-#: ../src/html/helpdata.cpp:657
+#: ../src/html/helpdata.cpp:650
 msgid "noname"
 msgstr "이름없음"
 
-#: ../src/common/datetimefmt.cpp:2124
+#: ../src/common/datetimefmt.cpp:2147
 msgid "noon"
 msgstr "정오"
 
-#: ../src/richtext/richtextstyles.cpp:779
+#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
 #, fuzzy
 msgid "normal"
 msgstr "보통"
 
-#: ../src/common/cmdline.cpp:1492
+#: ../src/common/cmdline.cpp:1488
 msgid "num"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:259
+#: ../src/common/accelcmn.cpp:194
+msgid "num "
+msgstr ""
+
+#: ../src/common/xtixml.cpp:255
 msgid "objects cannot have XML Text Nodes"
 msgstr "텍스트 자식 노드가 없습니다. "
 
-#: ../src/html/chm.cpp:339
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
 msgid "out of memory"
 msgstr "메모리 부족"
 
-#: ../src/common/debugrpt.cpp:514
+#: ../src/common/debugrpt.cpp:515
 msgid "process context description"
 msgstr "프로세스 상태 설명"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:227
-#: ../src/richtext/richtextbackgroundpage.cpp:250
-#: ../src/richtext/richtextbackgroundpage.cpp:290
-#: ../src/richtext/richtextbackgroundpage.cpp:317
-#: ../src/richtext/richtextfontpage.cpp:177
-#: ../src/richtext/richtextfontpage.cpp:180
 #: ../src/richtext/richtextborderspage.cpp:255
 #: ../src/richtext/richtextborderspage.cpp:289
 #: ../src/richtext/richtextborderspage.cpp:323
@@ -8741,22 +8970,45 @@ msgstr "프로세스 상태 설명"
 #: ../src/richtext/richtextborderspage.cpp:491
 #: ../src/richtext/richtextborderspage.cpp:525
 #: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextfontpage.cpp:180
 msgid "pt"
 msgstr ""
 
-#: ../src/richtext/richtextbackgroundpage.cpp:225
-#: ../src/richtext/richtextbackgroundpage.cpp:228
-#: ../src/richtext/richtextbackgroundpage.cpp:229
-#: ../src/richtext/richtextbackgroundpage.cpp:248
-#: ../src/richtext/richtextbackgroundpage.cpp:251
-#: ../src/richtext/richtextbackgroundpage.cpp:252
-#: ../src/richtext/richtextbackgroundpage.cpp:288
-#: ../src/richtext/richtextbackgroundpage.cpp:291
-#: ../src/richtext/richtextbackgroundpage.cpp:292
-#: ../src/richtext/richtextbackgroundpage.cpp:315
-#: ../src/richtext/richtextbackgroundpage.cpp:318
-#: ../src/richtext/richtextbackgroundpage.cpp:319
-#: ../src/richtext/richtextfontpage.cpp:178
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:659
+#: ../src/richtext/richtextsizepage.cpp:662
+#: ../src/richtext/richtextsizepage.cpp:663
 #: ../src/richtext/richtextborderspage.cpp:253
 #: ../src/richtext/richtextborderspage.cpp:256
 #: ../src/richtext/richtextborderspage.cpp:257
@@ -8808,263 +9060,273 @@ msgstr ""
 #: ../src/richtext/richtextmarginspage.cpp:387
 #: ../src/richtext/richtextmarginspage.cpp:389
 #: ../src/richtext/richtextmarginspage.cpp:390
-#: ../src/richtext/richtextsizepage.cpp:338
-#: ../src/richtext/richtextsizepage.cpp:341
-#: ../src/richtext/richtextsizepage.cpp:342
-#: ../src/richtext/richtextsizepage.cpp:372
-#: ../src/richtext/richtextsizepage.cpp:375
-#: ../src/richtext/richtextsizepage.cpp:376
-#: ../src/richtext/richtextsizepage.cpp:399
-#: ../src/richtext/richtextsizepage.cpp:402
-#: ../src/richtext/richtextsizepage.cpp:403
-#: ../src/richtext/richtextsizepage.cpp:426
-#: ../src/richtext/richtextsizepage.cpp:429
-#: ../src/richtext/richtextsizepage.cpp:430
-#: ../src/richtext/richtextsizepage.cpp:453
-#: ../src/richtext/richtextsizepage.cpp:456
-#: ../src/richtext/richtextsizepage.cpp:457
-#: ../src/richtext/richtextsizepage.cpp:480
-#: ../src/richtext/richtextsizepage.cpp:483
-#: ../src/richtext/richtextsizepage.cpp:484
-#: ../src/richtext/richtextsizepage.cpp:554
-#: ../src/richtext/richtextsizepage.cpp:557
-#: ../src/richtext/richtextsizepage.cpp:558
-#: ../src/richtext/richtextsizepage.cpp:589
-#: ../src/richtext/richtextsizepage.cpp:592
-#: ../src/richtext/richtextsizepage.cpp:593
-#: ../src/richtext/richtextsizepage.cpp:624
-#: ../src/richtext/richtextsizepage.cpp:627
-#: ../src/richtext/richtextsizepage.cpp:628
-#: ../src/richtext/richtextsizepage.cpp:659
-#: ../src/richtext/richtextsizepage.cpp:662
-#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextfontpage.cpp:178
 msgid "px"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:193
+#: ../src/common/accelcmn.cpp:192
 msgid "rawctrl"
 msgstr ""
 
-#: ../src/html/chm.cpp:333
+#: ../src/html/chm.cpp:330
 msgid "read error"
 msgstr "읽기 오류"
 
-#: ../src/common/zipstrm.cpp:2085
+#: ../src/common/zipstrm.cpp:2155
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "ZIP 스트림 일기 (%s): CRC 오류"
 
-#: ../src/common/zipstrm.cpp:2080
+#: ../src/common/zipstrm.cpp:2150
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "ZIP 스트림 일기 (%s): 길이가 잘못됨"
 
-#: ../src/msw/dde.cpp:1159
+#: ../src/msw/dde.cpp:1223
 msgid "reentrancy problem."
 msgstr "재진입 문제 발생."
 
-#: ../src/common/datetimefmt.cpp:1953
+#: ../src/common/datetimefmt.cpp:1976
 msgid "second"
 msgstr "두 번째"
 
-#: ../src/html/chm.cpp:337
+#: ../src/html/chm.cpp:334
 msgid "seek error"
 msgstr "찿기 오류"
 
-#: ../src/common/datetimefmt.cpp:1968
+#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#, fuzzy
+msgid "semibold"
+msgstr "굵게"
+
+#: ../src/common/datetimefmt.cpp:1991
 msgid "seventeenth"
 msgstr "열일곱 번째"
 
-#: ../src/common/datetimefmt.cpp:1958
+#: ../src/common/datetimefmt.cpp:1981
 msgid "seventh"
 msgstr "일곱 번째"
 
-#: ../src/common/accelcmn.cpp:191
+#: ../src/common/accelcmn.cpp:190
 msgid "shift"
 msgstr ""
 
-#: ../src/common/appbase.cpp:773
+#: ../src/common/appbase.cpp:774
 msgid "show this help message"
 msgstr "이 도움말 계속 보기."
 
-#: ../src/common/datetimefmt.cpp:1967
+#: ../src/common/datetimefmt.cpp:1990
 msgid "sixteenth"
 msgstr "열여섯 번째"
 
-#: ../src/common/datetimefmt.cpp:1957
+#: ../src/common/datetimefmt.cpp:1980
 msgid "sixth"
 msgstr "여섯 번째"
 
-#: ../src/common/appcmn.cpp:234
+#: ../src/common/appcmn.cpp:255
 msgid "specify display mode to use (e.g. 640x480-16)"
 msgstr "디스플레이 모드 지정(예:640x480-16)"
 
-#: ../src/common/appcmn.cpp:220
+#: ../src/common/appcmn.cpp:241
 msgid "specify the theme to use"
 msgstr "사용할 테마"
 
-#: ../src/richtext/richtextbuffer.cpp:9340
+#: ../src/richtext/richtextbuffer.cpp:9337
 #, fuzzy
 msgid "standard/circle"
 msgstr "표준"
 
-#: ../src/richtext/richtextbuffer.cpp:9341
+#: ../src/richtext/richtextbuffer.cpp:9338
 msgid "standard/circle-outline"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9343
+#: ../src/richtext/richtextbuffer.cpp:9340
 msgid "standard/diamond"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9342
+#: ../src/richtext/richtextbuffer.cpp:9339
 #, fuzzy
 msgid "standard/square"
 msgstr "표준"
 
-#: ../src/richtext/richtextbuffer.cpp:9344
+#: ../src/richtext/richtextbuffer.cpp:9341
 msgid "standard/triangle"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1985
+#: ../src/common/zipstrm.cpp:2055
 msgid "stored file length not in Zip header"
 msgstr "Zip 헤더에 파일의 길이가 없습니다."
 
-#: ../src/common/cmdline.cpp:1488
+#: ../src/common/cmdline.cpp:1484
 msgid "str"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:982
+#: ../src/common/fontcmn.cpp:1145
 #, fuzzy
 msgid "strikethrough"
 msgstr "취소선(&S)"
 
-#: ../src/common/tarstrm.cpp:1003 ../src/common/tarstrm.cpp:1025
-#: ../src/common/tarstrm.cpp:1507 ../src/common/tarstrm.cpp:1529
+#: ../src/common/tarstrm.cpp:997 ../src/common/tarstrm.cpp:1019
+#: ../src/common/tarstrm.cpp:1501 ../src/common/tarstrm.cpp:1523
 msgid "tar entry not open"
 msgstr "tar 파일 열기 실패"
 
-#: ../src/common/datetimefmt.cpp:1961
+#: ../src/common/datetimefmt.cpp:1984
 msgid "tenth"
 msgstr "열 번째"
 
-#: ../src/msw/dde.cpp:1123
+#: ../src/msw/dde.cpp:1187
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "DDE 오류: DMLERR_BUSY 상태"
 
-#: ../src/common/datetimefmt.cpp:1954
+#: ../src/common/fontcmn.cpp:1154
+msgid "thin"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:1977
 msgid "third"
 msgstr "세 번째"
 
-#: ../src/common/datetimefmt.cpp:1964
+#: ../src/common/datetimefmt.cpp:1987
 msgid "thirteenth"
 msgstr "열세 번째"
 
-#: ../src/common/datetimefmt.cpp:1758
+#: ../src/common/datetimefmt.cpp:1781
 msgid "today"
 msgstr "오늘"
 
-#: ../src/common/datetimefmt.cpp:1760
+#: ../src/common/datetimefmt.cpp:1783
 msgid "tomorrow"
 msgstr "내일"
 
-#: ../src/common/fileconf.cpp:1944
+#: ../src/common/fileconf.cpp:1946
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "'%s' 의 마지막 역슬러쉬는 무시됩니다."
 
-#: ../src/gtk/aboutdlg.cpp:218
+#: ../src/gtk/aboutdlg.cpp:216
 msgid "translator-credits"
 msgstr "번역"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1028
+#: ../src/generic/datavgen.cpp:1148
 msgid "true"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1963
+#: ../src/common/datetimefmt.cpp:1986
 msgid "twelfth"
 msgstr "열두 번째"
 
-#: ../src/common/datetimefmt.cpp:1971
+#: ../src/common/datetimefmt.cpp:1994
 msgid "twentieth"
 msgstr "스무 번째"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:486 ../src/generic/datavgen.cpp:1263
+#: ../src/common/datavcmn.cpp:2068 ../src/generic/datavgen.cpp:1386
 msgid "unchecked"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:802 ../src/common/fontcmn.cpp:978
+#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
 msgid "underlined"
 msgstr "밑줄"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:490
+#: ../src/common/datavcmn.cpp:2072
 #, fuzzy
 msgid "undetermined"
 msgstr "밑줄"
 
-#: ../src/common/fileconf.cpp:1979
+#: ../src/common/fileconf.cpp:1981
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "%d 번째 줄('%s' 파일)에서 \" 문자가 잘못 입려되었습니다."
 
-#: ../src/common/tarstrm.cpp:1045
+#: ../src/common/tarstrm.cpp:1039
 msgid "unexpected end of file"
 msgstr "파일이 갑작스럽게 끝났습니다"
 
-#: ../src/generic/progdlgg.cpp:370 ../src/common/tarstrm.cpp:371
-#: ../src/common/tarstrm.cpp:394 ../src/common/tarstrm.cpp:425
+#: ../src/common/tarstrm.cpp:366 ../src/common/tarstrm.cpp:389
+#: ../src/common/tarstrm.cpp:420 ../src/generic/progdlgg.cpp:376
 msgid "unknown"
 msgstr "알 수 없음"
 
-#: ../src/msw/registry.cpp:150
+#: ../src/msw/registry.cpp:139
 #, fuzzy, c-format
 msgid "unknown (%lu)"
 msgstr "알 수 없음"
 
-#: ../src/common/xtixml.cpp:253
+#: ../src/common/xtixml.cpp:249
 #, c-format
 msgid "unknown class %s"
 msgstr "%s 는 알 수 없는 클래스입니다."
 
-#: ../src/common/regex.cpp:258 ../src/html/chm.cpp:351
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "압축 오류"
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "압축 풀기 오류"
+
+#: ../src/common/regex.cpp:255 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "알 수 없는 오류"
 
-#: ../src/msw/dialup.cpp:471
+#: ../src/msw/dialup.cpp:465
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "알 수 없는 오류 (오류 코드 %08x)."
 
-#: ../src/common/fmapbase.cpp:834
+#: ../src/common/fmapbase.cpp:830
 #, c-format
 msgid "unknown-%d"
 msgstr "알 수 없음-%d"
 
-#: ../src/common/docview.cpp:509
+#: ../src/common/docview.cpp:502
 msgid "unnamed"
 msgstr "이름없음"
 
-#: ../src/common/docview.cpp:1624
+#: ../src/common/docview.cpp:1618
 #, c-format
 msgid "unnamed%d"
 msgstr "이름없음%d"
 
-#: ../src/common/zipstrm.cpp:1999 ../src/common/zipstrm.cpp:2319
+#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
 msgid "unsupported Zip compression method"
 msgstr "Zip 압축을 지원하지 않습니다."
 
-#: ../src/common/translation.cpp:1892
+#: ../src/common/translation.cpp:1942
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "'%s' 카탈로그 사용 ('%s' 파일)"
 
-#: ../src/html/chm.cpp:335
+#: ../src/html/chm.cpp:332
 msgid "write error"
 msgstr "쓰기 오류"
 
-#: ../src/common/time.cpp:292
+#: ../src/gtk/glcanvas.cpp:187
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/common/time.cpp:285
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay 함수 실패"
 
@@ -9077,15 +9339,15 @@ msgstr "wxWidgets: 디스플레이 '%s' 의 열기 실패. 종료합니다."
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets: 디스플레이 열기 실패. 종료합니다."
 
-#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:431
 msgid "xxxx"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1759
+#: ../src/common/datetimefmt.cpp:1782
 msgid "yesterday"
 msgstr "어제"
 
-#: ../src/common/zstream.cpp:251 ../src/common/zstream.cpp:426
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
 #, c-format
 msgid "zlib error %d"
 msgstr "압축모듈(zlib) 오류 %d"
@@ -9094,6 +9356,83 @@ msgstr "압축모듈(zlib) 오류 %d"
 #: ../src/richtext/richtextbulletspage.cpp:288
 msgid "~"
 msgstr "~"
+
+#, fuzzy
+#~ msgid "&Save as"
+#~ msgstr "다른 이름으로 저장"
+
+#, fuzzy
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "문자열 '%s' 에는 알파벳 이외의 문자가 입력되었습니다."
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' 에 숫자 이외의 문자가 입력되었습니다."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "문자열 '%s' 에는 ASCII 이외의 문자가 입력되었습니다."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "문자열 '%s' 에는 알파벳 이외의 문자가 입력되었습니다."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "문자열 '%s' 에는 알파벳 및 숫자 이외의 문자가 입력되었습니다."
+
+#, fuzzy
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "문자열 '%s' 에는 ASCII 이외의 문자가 입력되었습니다."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "클래스 %s 에서 윈도우생성 할 수 없습니다"
+
+#, fuzzy
+#~ msgid "Could not initalize libnotify."
+#~ msgstr "정렬 방식을 지정할 수 없습니다."
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "오버레이 창을 생성할 수 없습니다."
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "오버레이창의 내용을 초기화 하지 못했습니다."
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "\"%s\" 파을을 유니코드로 변환하는데 실패했습니다."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "텍스트 Control의 텍스트 입력 실패(인코딩 변환문제)"
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr ""
+#~ "GTK+의 명령행 옵션이 잘못됨, 자세한 사항은 다음을 입력해 보세요 : \"%s --"
+#~ "help\""
+
+#~ msgid "No unused colour in image."
+#~ msgstr "이미지에 사용되지 않은 색상"
+
+#, fuzzy
+#~ msgid "Not available"
+#~ msgstr "유용한 팁이 없습니다."
+
+#~ msgid "Replace selection"
+#~ msgstr "현재 선택 바꾸기"
+
+#, fuzzy
+#~ msgid "Save as"
+#~ msgstr "다른 이름으로 저장"
+
+#~ msgid "Style Organiser"
+#~ msgstr "모양새 관리"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "다음은 표준 GTK+ 에서 지원하는 옵션입니다:\n"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "오버레이 지울수 없습니다. 초기화 되지 않았습니다."
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "오버레이를 두번 초기화 할 수 없습니다."
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "문자 인코딩을 '%s' 로 설정할 수 없습니다."
 
 #, fuzzy
 #~ msgid "Bitmap renderer cannot render value; value type: "
@@ -9108,9 +9447,6 @@ msgstr "~"
 
 #~ msgid "Column could not be added."
 #~ msgstr "Column을 추가할수 없습니다."
-
-#~ msgid "Column description could not be initialized."
-#~ msgstr "Column 정보를 초기화 할 수 없습니다."
 
 #~ msgid "Column index not found."
 #~ msgstr "Column index를 찾을수 없습니다."
@@ -9486,9 +9822,6 @@ msgstr "~"
 #~ msgid "Directory '%s' doesn't exist!"
 #~ msgstr "'%s' 디렉토리가 존재하지 않습니다."
 
-#~ msgid "File %s does not exist."
-#~ msgstr "%s 파일이 없습니다."
-
 #~ msgid "Mode %ix%i-%i not available."
 #~ msgstr "%ix%i-%i 디스플레이 모드는 사용할수 없습니다."
 
@@ -9607,9 +9940,6 @@ msgstr "~"
 
 #~ msgid "Failed to register OpenGL window class."
 #~ msgstr "OpenGL 등록 실패"
-
-#~ msgid "Fatal error"
-#~ msgstr "치명적인 오류"
 
 #~ msgid "Fatal error: "
 #~ msgstr "치명적인 오류:"

--- a/locale/lt.po
+++ b/locale/lt.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-21 14:25+0200\n"
+"POT-Creation-Date: 2020-10-18 23:11+0300\n"
 "PO-Revision-Date: 2015-07-09 11:22+0200\n"
 "Last-Translator: Andrius <andrius.balsevicius@gmail.com>\n"
 "Language-Team: wxWidgets translators <wx-translators@googlegroups.com>\n"
@@ -12,14 +12,14 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=n != 1;\n"
 
-#: ../src/common/debugrpt.cpp:586
+#: ../src/common/debugrpt.cpp:587
 msgid ""
 "\n"
 "Please send this report to the program maintainer, thank you!\n"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:210
-#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:206
+#: ../src/richtext/richtextstyledlg.cpp:218
 msgid " "
 msgstr " "
 
@@ -27,70 +27,96 @@ msgstr " "
 msgid "              Thank you and we're sorry for the inconvenience!\n"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:573
+#: ../src/common/prntbase.cpp:568
 #, c-format
 msgid " (copy %d of %d)"
 msgstr " kopija %d iš %d"
 
-#: ../src/common/log.cpp:421
+#: ../src/common/log.cpp:440
 #, c-format
 msgid " (error %ld: %s)"
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:72
+#: ../src/common/imagtiff.cpp:69
 #, c-format
 msgid " (in module \"%s\")"
 msgstr ""
 
-#: ../src/osx/core/secretstore.cpp:138
-msgid " (while overwriting an existing item)"
-msgstr ""
-
-#: ../src/common/docview.cpp:1642
+#: ../src/common/docview.cpp:1636
 msgid " - "
 msgstr " - "
 
-#: ../src/richtext/richtextprint.cpp:593 ../src/html/htmprint.cpp:714
+#: ../src/html/htmprint.cpp:712 ../src/richtext/richtextprint.cpp:589
 msgid " Preview"
 msgstr " Peržiūra"
 
-#: ../src/common/fontcmn.cpp:824
+#: ../src/common/fontcmn.cpp:973
 msgid " bold"
 msgstr " pastorintas"
 
-#: ../src/common/fontcmn.cpp:840
+#: ../src/common/fontcmn.cpp:977
+#, fuzzy
+msgid " extra bold"
+msgstr " pastorintas"
+
+#: ../src/common/fontcmn.cpp:985
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:957
+#, fuzzy
+msgid " extra light"
+msgstr " lengvas"
+
+#: ../src/common/fontcmn.cpp:981
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1001
 msgid " italic"
 msgstr " kursyvas"
 
-#: ../src/common/fontcmn.cpp:820
+#: ../src/common/fontcmn.cpp:961
 msgid " light"
 msgstr " lengvas"
 
-#: ../src/common/fontcmn.cpp:807
+#: ../src/common/fontcmn.cpp:965
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:969
+#, fuzzy
+msgid " semi bold"
+msgstr " pastorintas"
+
+#: ../src/common/fontcmn.cpp:940
 msgid " strikethrough"
 msgstr " perbrauktas"
 
-#: ../src/common/paper.cpp:117
+#: ../src/common/fontcmn.cpp:953
+msgid " thin"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
 msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
 msgstr "#10 Vokas, 4 1/8 x 9 1/2 colių"
 
-#: ../src/common/paper.cpp:118
+#: ../src/common/paper.cpp:115
 msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
 msgstr "#11 Vokas, 4 1/2 x 10 3/8 colių"
 
-#: ../src/common/paper.cpp:119
+#: ../src/common/paper.cpp:116
 msgid "#12 Envelope, 4 3/4 x 11 in"
 msgstr "#12 Vokas, 4 3/4 x 11 colių"
 
-#: ../src/common/paper.cpp:120
+#: ../src/common/paper.cpp:117
 msgid "#14 Envelope, 5 x 11 1/2 in"
 msgstr "#14 Vokas, 5 x 11 1/2 colių"
 
-#: ../src/common/paper.cpp:116
+#: ../src/common/paper.cpp:113
 msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
 msgstr "#9 Vokas, 3 7/8 x 8 7/8 colių"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:341
 #: ../src/richtext/richtextsizepage.cpp:340
 #: ../src/richtext/richtextsizepage.cpp:374
 #: ../src/richtext/richtextsizepage.cpp:401
@@ -101,20 +127,21 @@ msgstr "#9 Vokas, 3 7/8 x 8 7/8 colių"
 #: ../src/richtext/richtextsizepage.cpp:591
 #: ../src/richtext/richtextsizepage.cpp:626
 #: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextbackgroundpage.cpp:341
 msgid "%"
 msgstr "%"
 
-#: ../src/html/helpwnd.cpp:1031
+#: ../src/html/helpwnd.cpp:1029
 #, c-format
 msgid "%d of %lu"
 msgstr "%d iš %lu"
 
-#: ../src/html/helpwnd.cpp:1678
+#: ../src/html/helpwnd.cpp:1676
 #, c-format
 msgid "%i of %u"
 msgstr "%i iš %u"
 
-#: ../src/generic/filectrlg.cpp:279
+#: ../src/generic/filectrlg.cpp:275
 #, c-format
 msgid "%ld byte"
 msgid_plural "%ld bytes"
@@ -122,61 +149,61 @@ msgstr[0] "%ld baitų"
 msgstr[1] "%ld baitų"
 msgstr[2] "%ld baitų"
 
-#: ../src/html/helpwnd.cpp:1033
+#: ../src/html/helpwnd.cpp:1031
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu iš %lu"
 
-#: ../src/generic/datavgen.cpp:6028
+#: ../src/generic/datavgen.cpp:6833
 #, fuzzy, c-format
 msgid "%s (%d items)"
 msgstr "%s (iš %s)"
 
-#: ../src/common/cmdline.cpp:1221
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (iš %s)"
 
-#: ../src/generic/logg.cpp:224
+#: ../src/generic/logg.cpp:221
 #, c-format
 msgid "%s Error"
 msgstr ""
 
-#: ../src/generic/logg.cpp:236
+#: ../src/generic/logg.cpp:233
 #, c-format
 msgid "%s Information"
 msgstr ""
 
-#: ../src/generic/preferencesg.cpp:113
+#: ../src/generic/preferencesg.cpp:110
 #, c-format
 msgid "%s Preferences"
 msgstr ""
 
-#: ../src/generic/logg.cpp:228
+#: ../src/generic/logg.cpp:225
 #, c-format
 msgid "%s Warning"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:1319
+#: ../src/common/tarstrm.cpp:1313
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr ""
 
-#: ../src/common/fldlgcmn.cpp:124
+#: ../src/common/fldlgcmn.cpp:121
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1716
+#: ../src/html/helpwnd.cpp:1714
 #, c-format
 msgid "%u of %u"
 msgstr "%u iš %u"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "&About"
 msgstr "&Apie"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "&Actual Size"
 msgstr ""
 
@@ -184,28 +211,28 @@ msgstr ""
 msgid "&After a paragraph:"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:128
 #: ../src/richtext/richtextliststylepage.cpp:319
+#: ../src/richtext/richtextindentspage.cpp:128
 msgid "&Alignment"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "&Apply"
 msgstr "&Pritaikyti"
 
-#: ../src/richtext/richtextstyledlg.cpp:251
+#: ../src/richtext/richtextstyledlg.cpp:247
 msgid "&Apply Style"
 msgstr ""
 
-#: ../src/msw/mdi.cpp:179
+#: ../src/msw/mdi.cpp:174
 msgid "&Arrange Icons"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "&Ascending"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:142
+#: ../src/common/stockitem.cpp:139
 msgid "&Back"
 msgstr "&Atgal"
 
@@ -225,24 +252,24 @@ msgstr ""
 msgid "&Blur distance:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:143
+#: ../src/common/stockitem.cpp:140
 msgid "&Bold"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141
 msgid "&Bottom"
 msgstr "&Apačios"
 
+#: ../src/richtext/richtextsizepage.cpp:637
+#: ../src/richtext/richtextsizepage.cpp:644
 #: ../src/richtext/richtextborderspage.cpp:345
 #: ../src/richtext/richtextborderspage.cpp:513
 #: ../src/richtext/richtextmarginspage.cpp:259
 #: ../src/richtext/richtextmarginspage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:637
-#: ../src/richtext/richtextsizepage.cpp:644
 msgid "&Bottom:"
 msgstr "&Apačios:"
 
-#: ../include/wx/richtext/richtextbuffer.h:3866
+#: ../include/wx/richtext/richtextbuffer.h:3861
 msgid "&Box"
 msgstr "&Dėžutė"
 
@@ -251,38 +278,38 @@ msgstr "&Dėžutė"
 msgid "&Bullet style:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "&CD-Rom"
 msgstr ""
 
-#: ../src/generic/wizard.cpp:434 ../src/generic/fontdlgg.cpp:470
-#: ../src/generic/fontdlgg.cpp:489 ../src/osx/carbon/fontdlg.cpp:402
-#: ../src/common/dlgcmn.cpp:279 ../src/common/stockitem.cpp:145
+#: ../src/osx/carbon/fontdlg.cpp:399 ../src/common/stockitem.cpp:142
+#: ../src/generic/wizard.cpp:433 ../src/generic/fontdlgg.cpp:466
+#: ../src/generic/fontdlgg.cpp:485 ../src/osx/cocoa/button.mm:200
 msgid "&Cancel"
 msgstr "Atša&ukti"
 
-#: ../src/msw/mdi.cpp:175
+#: ../src/msw/mdi.cpp:170
 msgid "&Cascade"
 msgstr ""
 
-#: ../include/wx/richtext/richtextbuffer.h:5960
+#: ../include/wx/richtext/richtextbuffer.h:5955
 msgid "&Cell"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:439
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "&Character code:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:147
+#: ../src/common/stockitem.cpp:144
 msgid "&Clear"
 msgstr ""
 
-#: ../src/generic/logg.cpp:516 ../src/common/stockitem.cpp:148
-#: ../src/common/prntbase.cpp:1600 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/stockitem.cpp:145 ../src/common/prntbase.cpp:1625
+#: ../src/univ/themes/win32.cpp:3753 ../src/generic/logg.cpp:513
 msgid "&Close"
 msgstr "&Užverti"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "&Color"
 msgstr "&Spalva"
 
@@ -290,20 +317,20 @@ msgstr "&Spalva"
 msgid "&Colour:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "&Convert"
 msgstr "&Paversti"
 
-#: ../src/richtext/richtextctrl.cpp:333 ../src/osx/textctrl_osx.cpp:577
-#: ../src/common/stockitem.cpp:150 ../src/msw/textctrl.cpp:2508
+#: ../src/osx/textctrl_osx.cpp:595 ../src/common/stockitem.cpp:147
+#: ../src/msw/textctrl.cpp:2773 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Kopijuoti"
 
-#: ../src/generic/hyperlinkg.cpp:156
+#: ../src/generic/hyperlinkg.cpp:153
 msgid "&Copy URL"
 msgstr ""
 
-#: ../src/common/headerctrlcmn.cpp:306
+#: ../src/common/headerctrlcmn.cpp:304
 msgid "&Customize..."
 msgstr "&Pritaikyti..."
 
@@ -311,53 +338,54 @@ msgstr "&Pritaikyti..."
 msgid "&Debug report preview:"
 msgstr ""
 
-#: ../src/richtext/richtexttabspage.cpp:138
-#: ../src/richtext/richtextctrl.cpp:335 ../src/osx/textctrl_osx.cpp:579
-#: ../src/common/stockitem.cpp:152 ../src/msw/textctrl.cpp:2510
+#: ../src/osx/textctrl_osx.cpp:597 ../src/common/stockitem.cpp:149
+#: ../src/msw/textctrl.cpp:2775 ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtextctrl.cpp:334
 msgid "&Delete"
 msgstr "&Ištrinti"
 
-#: ../src/richtext/richtextstyledlg.cpp:269
+#: ../src/richtext/richtextstyledlg.cpp:265
 msgid "&Delete Style..."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "&Descending"
 msgstr ""
 
-#: ../src/generic/logg.cpp:682
+#: ../src/generic/logg.cpp:679
 msgid "&Details"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:153
+#: ../src/common/stockitem.cpp:150
 msgid "&Down"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "&Edit"
 msgstr "T&aisyti"
 
-#: ../src/richtext/richtextstyledlg.cpp:263
+#: ../src/richtext/richtextstyledlg.cpp:259
 msgid "&Edit Style..."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:155
+#: ../src/common/stockitem.cpp:152
 msgid "&Execute"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/common/stockitem.cpp:154
 msgid "&File"
 msgstr "&Failas"
 
-#: ../src/common/stockitem.cpp:158
-msgid "&Find"
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "&Find..."
 msgstr "&Ieškoti"
 
-#: ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:430
 msgid "&Finish"
 msgstr "&Baigti"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:156
 msgid "&First"
 msgstr "&Pirmas"
 
@@ -365,15 +393,15 @@ msgstr "&Pirmas"
 msgid "&Floating mode:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "&Floppy"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:194
+#: ../src/common/stockitem.cpp:191
 msgid "&Font"
 msgstr "Š&riftas"
 
-#: ../src/generic/fontdlgg.cpp:371
+#: ../src/generic/fontdlgg.cpp:367
 msgid "&Font family:"
 msgstr "Š&riftų šeima:"
 
@@ -381,20 +409,20 @@ msgstr "Š&riftų šeima:"
 msgid "&Font for Level..."
 msgstr "Š&riftas lygiui..."
 
+#: ../src/richtext/richtextsymboldlg.cpp:397
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:400
 msgid "&Font:"
 msgstr "Š&riftas:"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "&Forward"
 msgstr "&Pirmyn"
 
-#: ../src/richtext/richtextsymboldlg.cpp:451
+#: ../src/richtext/richtextsymboldlg.cpp:448
 msgid "&From:"
 msgstr "&Nuo:"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "&Harddisk"
 msgstr "&Kietasis diskas"
 
@@ -403,9 +431,9 @@ msgstr "&Kietasis diskas"
 msgid "&Height:"
 msgstr "&Aukštis:"
 
-#: ../src/generic/wizard.cpp:441 ../src/richtext/richtextstyledlg.cpp:303
-#: ../src/richtext/richtextsymboldlg.cpp:479 ../src/osx/menu_osx.cpp:734
-#: ../src/common/stockitem.cpp:163
+#: ../src/common/stockitem.cpp:160 ../src/generic/wizard.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextstyledlg.cpp:299 ../src/osx/cocoa/menu.mm:226
 msgid "&Help"
 msgstr "&Pagalba"
 
@@ -413,7 +441,7 @@ msgstr "&Pagalba"
 msgid "&Hide details"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:164
+#: ../src/common/stockitem.cpp:161
 msgid "&Home"
 msgstr ""
 
@@ -421,54 +449,54 @@ msgstr ""
 msgid "&Horizontal offset:"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:184
 #: ../src/richtext/richtextliststylepage.cpp:372
+#: ../src/richtext/richtextindentspage.cpp:184
 msgid "&Indentation (tenths of a mm)"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:167
 #: ../src/richtext/richtextliststylepage.cpp:356
+#: ../src/richtext/richtextindentspage.cpp:167
 msgid "&Indeterminate"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:166
+#: ../src/common/stockitem.cpp:163
 msgid "&Index"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "&Info"
 msgstr "&Informacija"
 
-#: ../src/common/stockitem.cpp:168
+#: ../src/common/stockitem.cpp:165
 msgid "&Italic"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "&Jump to"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:153
 #: ../src/richtext/richtextliststylepage.cpp:342
+#: ../src/richtext/richtextindentspage.cpp:153
 msgid "&Justified"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "&Last"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:139
 #: ../src/richtext/richtextliststylepage.cpp:328
+#: ../src/richtext/richtextindentspage.cpp:139
 msgid "&Left"
 msgstr "&Kairės"
 
-#: ../src/richtext/richtextindentspage.cpp:195
+#: ../src/richtext/richtextsizepage.cpp:532
+#: ../src/richtext/richtextsizepage.cpp:539
 #: ../src/richtext/richtextborderspage.cpp:243
 #: ../src/richtext/richtextborderspage.cpp:411
 #: ../src/richtext/richtextliststylepage.cpp:381
+#: ../src/richtext/richtextindentspage.cpp:195
 #: ../src/richtext/richtextmarginspage.cpp:186
 #: ../src/richtext/richtextmarginspage.cpp:300
-#: ../src/richtext/richtextsizepage.cpp:532
-#: ../src/richtext/richtextsizepage.cpp:539
 msgid "&Left:"
 msgstr "&Kairės:"
 
@@ -476,11 +504,11 @@ msgstr "&Kairės:"
 msgid "&List level:"
 msgstr ""
 
-#: ../src/generic/logg.cpp:517
+#: ../src/generic/logg.cpp:514
 msgid "&Log"
 msgstr ""
 
-#: ../src/univ/themes/win32.cpp:3748
+#: ../src/univ/themes/win32.cpp:3745
 msgid "&Move"
 msgstr "&Perkelti"
 
@@ -488,20 +516,19 @@ msgstr "&Perkelti"
 msgid "&Move the object to:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "&Network"
 msgstr ""
 
-#: ../src/richtext/richtexttabspage.cpp:132 ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173 ../src/richtext/richtexttabspage.cpp:132
 msgid "&New"
 msgstr "&Naujas"
 
-#: ../src/aui/tabmdi.cpp:111 ../src/generic/mdig.cpp:100
-#: ../src/msw/mdi.cpp:180
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
 msgid "&Next"
 msgstr "&Kitas"
 
-#: ../src/generic/wizard.cpp:432 ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:429
 msgid "&Next >"
 msgstr "&Toliau >"
 
@@ -509,7 +536,7 @@ msgstr "&Toliau >"
 msgid "&Next Paragraph"
 msgstr "&Kita pastraipa"
 
-#: ../src/generic/tipdlg.cpp:240
+#: ../src/generic/tipdlg.cpp:237
 msgid "&Next Tip"
 msgstr "&Kitas patarimas"
 
@@ -517,11 +544,11 @@ msgstr "&Kitas patarimas"
 msgid "&Next style:"
 msgstr "&Kitas stilius:"
 
-#: ../src/common/stockitem.cpp:177 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:174 ../src/msw/msgdlg.cpp:435
 msgid "&No"
 msgstr "&Ne"
 
-#: ../src/generic/dbgrptg.cpp:356
+#: ../src/generic/dbgrptg.cpp:360
 msgid "&Notes:"
 msgstr ""
 
@@ -529,12 +556,12 @@ msgstr ""
 msgid "&Number:"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:475 ../src/generic/fontdlgg.cpp:482
-#: ../src/osx/carbon/fontdlg.cpp:408 ../src/common/stockitem.cpp:178
+#: ../src/osx/carbon/fontdlg.cpp:405 ../src/common/stockitem.cpp:175
+#: ../src/generic/fontdlgg.cpp:471 ../src/generic/fontdlgg.cpp:478
 msgid "&OK"
 msgstr "&Gerai"
 
-#: ../src/generic/dbgrptg.cpp:342 ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176 ../src/generic/dbgrptg.cpp:342
 msgid "&Open..."
 msgstr "&Atverti..."
 
@@ -546,16 +573,16 @@ msgstr ""
 msgid "&Page Break"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:334 ../src/osx/textctrl_osx.cpp:578
-#: ../src/common/stockitem.cpp:180 ../src/msw/textctrl.cpp:2509
+#: ../src/osx/textctrl_osx.cpp:596 ../src/common/stockitem.cpp:177
+#: ../src/msw/textctrl.cpp:2774 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "Įk&lijuoti"
 
-#: ../include/wx/richtext/richtextbuffer.h:5010
+#: ../include/wx/richtext/richtextbuffer.h:5005
 msgid "&Picture"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:419
 msgid "&Point size:"
 msgstr ""
 
@@ -567,12 +594,11 @@ msgstr ""
 msgid "&Position mode:"
 msgstr "&Padėtis:"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178
 msgid "&Preferences"
 msgstr ""
 
-#: ../src/aui/tabmdi.cpp:112 ../src/generic/mdig.cpp:101
-#: ../src/msw/mdi.cpp:181
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
 msgid "&Previous"
 msgstr "&Ankstesnis"
 
@@ -580,78 +606,74 @@ msgstr "&Ankstesnis"
 msgid "&Previous Paragraph"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "&Print..."
 msgstr "S&pausdinti..."
 
-#: ../src/richtext/richtextctrl.cpp:339 ../src/richtext/richtextctrl.cpp:5514
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtextctrl.cpp:338
+#: ../src/richtext/richtextctrl.cpp:5512
 msgid "&Properties"
 msgstr "&Savybės"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "&Quit"
 msgstr "Iš&eiti"
 
-#: ../src/richtext/richtextctrl.cpp:330 ../src/osx/textctrl_osx.cpp:574
-#: ../src/common/stockitem.cpp:185 ../src/common/cmdproc.cpp:293
-#: ../src/common/cmdproc.cpp:300 ../src/msw/textctrl.cpp:2505
+#: ../src/osx/textctrl_osx.cpp:592 ../src/common/stockitem.cpp:182
+#: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
+#: ../src/msw/textctrl.cpp:2770 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "Paka&rtoti"
 
-#: ../src/common/cmdproc.cpp:289 ../src/common/cmdproc.cpp:309
+#: ../src/common/cmdproc.cpp:282 ../src/common/cmdproc.cpp:302
 msgid "&Redo "
 msgstr "Paka&rtoti "
 
-#: ../src/richtext/richtextstyledlg.cpp:257
+#: ../src/richtext/richtextstyledlg.cpp:253
 msgid "&Rename Style..."
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:179
+#: ../src/generic/fdrepdlg.cpp:176
 msgid "&Replace"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:287
+#: ../src/richtext/richtextstyledlg.cpp:283
 msgid "&Restart numbering"
 msgstr ""
 
-#: ../src/univ/themes/win32.cpp:3747
+#: ../src/univ/themes/win32.cpp:3744
 msgid "&Restore"
 msgstr "&Atstatyti"
 
-#: ../src/richtext/richtextindentspage.cpp:146
 #: ../src/richtext/richtextliststylepage.cpp:335
+#: ../src/richtext/richtextindentspage.cpp:146
 msgid "&Right"
 msgstr "&Dešinės"
 
-#: ../src/richtext/richtextindentspage.cpp:213
+#: ../src/richtext/richtextsizepage.cpp:602
+#: ../src/richtext/richtextsizepage.cpp:609
 #: ../src/richtext/richtextborderspage.cpp:277
 #: ../src/richtext/richtextborderspage.cpp:445
 #: ../src/richtext/richtextliststylepage.cpp:399
+#: ../src/richtext/richtextindentspage.cpp:213
 #: ../src/richtext/richtextmarginspage.cpp:211
 #: ../src/richtext/richtextmarginspage.cpp:325
-#: ../src/richtext/richtextsizepage.cpp:602
-#: ../src/richtext/richtextsizepage.cpp:609
 msgid "&Right:"
 msgstr "&Dešinės:"
 
-#: ../src/common/stockitem.cpp:190
+#: ../src/common/stockitem.cpp:187
 msgid "&Save"
 msgstr "&Išsaugoti"
-
-#: ../src/common/stockitem.cpp:191
-msgid "&Save as"
-msgstr "Iš&saugoti kaip"
 
 #: ../include/wx/richmsgdlg.h:29
 msgid "&See details"
 msgstr ""
 
-#: ../src/generic/tipdlg.cpp:236
+#: ../src/generic/tipdlg.cpp:233
 msgid "&Show tips at startup"
 msgstr ""
 
-#: ../src/univ/themes/win32.cpp:3750
+#: ../src/univ/themes/win32.cpp:3747
 msgid "&Size"
 msgstr "&Dydis"
 
@@ -659,36 +681,36 @@ msgstr "&Dydis"
 msgid "&Size:"
 msgstr "&Dydis:"
 
-#: ../src/generic/progdlgg.cpp:252
+#: ../src/generic/progdlgg.cpp:249
 msgid "&Skip"
 msgstr "Pralei&sti"
 
-#: ../src/richtext/richtextindentspage.cpp:242
 #: ../src/richtext/richtextliststylepage.cpp:417
+#: ../src/richtext/richtextindentspage.cpp:242
 msgid "&Spacing (tenths of a mm)"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "&Spell Check"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "&Stop"
 msgstr ""
 
-#: ../src/richtext/richtextfontpage.cpp:275 ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196 ../src/richtext/richtextfontpage.cpp:275
 msgid "&Strikethrough"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:382 ../src/richtext/richtextstylepage.cpp:106
+#: ../src/generic/fontdlgg.cpp:378 ../src/richtext/richtextstylepage.cpp:106
 msgid "&Style:"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:194
 msgid "&Styles:"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:413
+#: ../src/richtext/richtextsymboldlg.cpp:410
 msgid "&Subset:"
 msgstr ""
 
@@ -702,24 +724,24 @@ msgstr "&Simbolis:"
 msgid "&Synchronize values"
 msgstr ""
 
-#: ../include/wx/richtext/richtextbuffer.h:6069
+#: ../include/wx/richtext/richtextbuffer.h:6064
 msgid "&Table"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197
 msgid "&Top"
 msgstr "&Viršaus"
 
+#: ../src/richtext/richtextsizepage.cpp:567
+#: ../src/richtext/richtextsizepage.cpp:574
 #: ../src/richtext/richtextborderspage.cpp:311
 #: ../src/richtext/richtextborderspage.cpp:479
 #: ../src/richtext/richtextmarginspage.cpp:234
 #: ../src/richtext/richtextmarginspage.cpp:348
-#: ../src/richtext/richtextsizepage.cpp:567
-#: ../src/richtext/richtextsizepage.cpp:574
 msgid "&Top:"
 msgstr "&Viršaus:"
 
-#: ../src/generic/fontdlgg.cpp:444 ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199 ../src/generic/fontdlgg.cpp:441
 msgid "&Underline"
 msgstr ""
 
@@ -727,21 +749,21 @@ msgstr ""
 msgid "&Underlining:"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:329 ../src/osx/textctrl_osx.cpp:573
-#: ../src/common/stockitem.cpp:203 ../src/common/cmdproc.cpp:271
-#: ../src/msw/textctrl.cpp:2504
+#: ../src/osx/textctrl_osx.cpp:591 ../src/common/stockitem.cpp:200
+#: ../src/common/cmdproc.cpp:264 ../src/msw/textctrl.cpp:2769
+#: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "Atša&ukti"
 
-#: ../src/common/cmdproc.cpp:265
+#: ../src/common/cmdproc.cpp:258
 msgid "&Undo "
 msgstr "Atša&ukti "
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "&Unindent"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:205
+#: ../src/common/stockitem.cpp:202
 msgid "&Up"
 msgstr ""
 
@@ -757,7 +779,7 @@ msgstr "&Vertikali lygiuotė:"
 msgid "&View..."
 msgstr "&Rodyti..."
 
-#: ../src/generic/fontdlgg.cpp:393
+#: ../src/generic/fontdlgg.cpp:389
 msgid "&Weight:"
 msgstr ""
 
@@ -766,80 +788,50 @@ msgstr ""
 msgid "&Width:"
 msgstr ""
 
-#: ../src/aui/tabmdi.cpp:311 ../src/aui/tabmdi.cpp:327
-#: ../src/aui/tabmdi.cpp:329 ../src/generic/mdig.cpp:294
-#: ../src/generic/mdig.cpp:310 ../src/generic/mdig.cpp:314
-#: ../src/msw/mdi.cpp:78
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
 msgid "&Window"
 msgstr "&Langas"
 
-#: ../src/common/stockitem.cpp:206 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:203 ../src/msw/msgdlg.cpp:435
 msgid "&Yes"
 msgstr "&Taip"
 
-#: ../src/common/valtext.cpp:256
+#: ../src/common/valtext.cpp:197
 #, c-format
-msgid "'%s' contains illegal characters"
+msgid "'%s' contains invalid character(s)"
 msgstr ""
 
-#: ../src/common/valtext.cpp:254
-#, c-format
-msgid "'%s' doesn't consist only of valid characters"
-msgstr ""
-
-#: ../src/common/config.cpp:519 ../src/msw/regconf.cpp:258
+#: ../src/common/config.cpp:515 ../src/msw/regconf.cpp:255
 #, c-format
 msgid "'%s' has extra '..', ignored."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1113 ../src/common/cmdline.cpp:1131
+#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr ""
 
-#: ../src/common/translation.cpp:1100
+#: ../src/common/translation.cpp:1142
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr ""
 
-#: ../src/common/valtext.cpp:165
+#: ../src/common/valtext.cpp:188
 #, c-format
 msgid "'%s' is not one of the valid strings"
 msgstr ""
 
-#: ../src/common/valtext.cpp:167
+#: ../src/common/valtext.cpp:186
 #, c-format
 msgid "'%s' is one of the invalid strings"
 msgstr ""
 
-#: ../src/common/textbuf.cpp:237
+#: ../src/common/textbuf.cpp:233
 #, c-format
 msgid "'%s' is probably a binary buffer."
-msgstr ""
-
-#: ../src/common/valtext.cpp:252
-#, c-format
-msgid "'%s' should be numeric."
-msgstr ""
-
-#: ../src/common/valtext.cpp:244
-#, c-format
-msgid "'%s' should only contain ASCII characters."
-msgstr ""
-
-#: ../src/common/valtext.cpp:246
-#, c-format
-msgid "'%s' should only contain alphabetic characters."
-msgstr ""
-
-#: ../src/common/valtext.cpp:248
-#, c-format
-msgid "'%s' should only contain alphabetic or numeric characters."
-msgstr ""
-
-#: ../src/common/valtext.cpp:250
-#, c-format
-msgid "'%s' should only contain digits."
 msgstr ""
 
 #: ../src/richtext/richtextliststylepage.cpp:229
@@ -847,7 +839,7 @@ msgstr ""
 msgid "(*)"
 msgstr "*"
 
-#: ../src/html/helpwnd.cpp:963
+#: ../src/html/helpwnd.cpp:961
 msgid "(Help)"
 msgstr "Pagalba"
 
@@ -856,27 +848,32 @@ msgstr "Pagalba"
 msgid "(None)"
 msgstr "Joks"
 
-#: ../src/richtext/richtextsymboldlg.cpp:504
+#: ../src/richtext/richtextsymboldlg.cpp:503
 msgid "(Normal text)"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:419 ../src/html/helpwnd.cpp:1106
-#: ../src/html/helpwnd.cpp:1742
+#: ../src/html/helpwnd.cpp:417 ../src/html/helpwnd.cpp:1104
+#: ../src/html/helpwnd.cpp:1740
 msgid "(bookmarks)"
 msgstr ""
 
+#: ../src/msw/dlmsw.cpp:167
+#, c-format
+msgid "(error %d: %s)"
+msgstr ""
+
+#: ../src/richtext/richtextformatdlg.cpp:876
+#: ../src/richtext/richtextliststylepage.cpp:448
+#: ../src/richtext/richtextliststylepage.cpp:460
+#: ../src/richtext/richtextliststylepage.cpp:461
 #: ../src/richtext/richtextindentspage.cpp:274
 #: ../src/richtext/richtextindentspage.cpp:286
 #: ../src/richtext/richtextindentspage.cpp:287
 #: ../src/richtext/richtextindentspage.cpp:311
 #: ../src/richtext/richtextindentspage.cpp:326
-#: ../src/richtext/richtextformatdlg.cpp:884
 #: ../src/richtext/richtextfontpage.cpp:349
 #: ../src/richtext/richtextfontpage.cpp:353
 #: ../src/richtext/richtextfontpage.cpp:357
-#: ../src/richtext/richtextliststylepage.cpp:448
-#: ../src/richtext/richtextliststylepage.cpp:460
-#: ../src/richtext/richtextliststylepage.cpp:461
 msgid "(none)"
 msgstr "Joks"
 
@@ -895,7 +892,7 @@ msgstr "*)"
 msgid "+"
 msgstr "+"
 
-#: ../src/msw/utils.cpp:1152
+#: ../src/msw/utils.cpp:1143
 msgid ", 64-bit edition"
 msgstr ", 64-bit laida"
 
@@ -904,163 +901,163 @@ msgstr ", 64-bit laida"
 msgid "-"
 msgstr "-"
 
-#: ../src/generic/filepickerg.cpp:66
+#: ../src/generic/filepickerg.cpp:63
 msgid "..."
 msgstr "..."
 
-#: ../src/richtext/richtextindentspage.cpp:276
 #: ../src/richtext/richtextliststylepage.cpp:450
+#: ../src/richtext/richtextindentspage.cpp:276
 msgid "1.1"
 msgstr "1.1"
 
-#: ../src/richtext/richtextindentspage.cpp:277
 #: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextindentspage.cpp:277
 msgid "1.2"
 msgstr "1.2"
 
-#: ../src/richtext/richtextindentspage.cpp:278
 #: ../src/richtext/richtextliststylepage.cpp:452
+#: ../src/richtext/richtextindentspage.cpp:278
 msgid "1.3"
 msgstr "1.3"
 
-#: ../src/richtext/richtextindentspage.cpp:279
 #: ../src/richtext/richtextliststylepage.cpp:453
+#: ../src/richtext/richtextindentspage.cpp:279
 msgid "1.4"
 msgstr "1.4"
 
-#: ../src/richtext/richtextindentspage.cpp:280
 #: ../src/richtext/richtextliststylepage.cpp:454
+#: ../src/richtext/richtextindentspage.cpp:280
 msgid "1.5"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:281
 #: ../src/richtext/richtextliststylepage.cpp:455
+#: ../src/richtext/richtextindentspage.cpp:281
 msgid "1.6"
 msgstr "1.6"
 
-#: ../src/richtext/richtextindentspage.cpp:282
 #: ../src/richtext/richtextliststylepage.cpp:456
+#: ../src/richtext/richtextindentspage.cpp:282
 msgid "1.7"
 msgstr "1.7"
 
-#: ../src/richtext/richtextindentspage.cpp:283
 #: ../src/richtext/richtextliststylepage.cpp:457
+#: ../src/richtext/richtextindentspage.cpp:283
 msgid "1.8"
 msgstr "1.8"
 
-#: ../src/richtext/richtextindentspage.cpp:284
 #: ../src/richtext/richtextliststylepage.cpp:458
+#: ../src/richtext/richtextindentspage.cpp:284
 msgid "1.9"
 msgstr "1.9"
 
-#: ../src/common/paper.cpp:140
+#: ../src/common/paper.cpp:137
 msgid "10 x 11 in"
 msgstr "10 x 11 colių"
 
-#: ../src/common/paper.cpp:113
+#: ../src/common/paper.cpp:110
 msgid "10 x 14 in"
 msgstr "10 x 14 colių"
 
-#: ../src/common/paper.cpp:114
+#: ../src/common/paper.cpp:111
 msgid "11 x 17 in"
 msgstr "11 x 17 colių"
 
-#: ../src/common/paper.cpp:184
+#: ../src/common/paper.cpp:181
 msgid "12 x 11 in"
 msgstr "12 x 11 colių"
 
-#: ../src/common/paper.cpp:141
+#: ../src/common/paper.cpp:138
 msgid "15 x 11 in"
 msgstr "15 x 11 colių"
 
-#: ../src/richtext/richtextindentspage.cpp:285
 #: ../src/richtext/richtextliststylepage.cpp:459
+#: ../src/richtext/richtextindentspage.cpp:285
 msgid "2"
 msgstr "2"
 
-#: ../src/common/paper.cpp:132
+#: ../src/common/paper.cpp:129
 msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
 msgstr "6 3/4 Vokas, 3 5/8 x 6 1/2 colių"
 
-#: ../src/common/paper.cpp:139
+#: ../src/common/paper.cpp:136
 msgid "9 x 11 in"
 msgstr "9 x 11 colių"
 
-#: ../src/html/htmprint.cpp:431
+#: ../src/html/htmprint.cpp:443
 msgid ": file does not exist!"
 msgstr ""
 
-#: ../src/common/fontmap.cpp:199
+#: ../src/common/fontmap.cpp:196
 msgid ": unknown charset"
 msgstr ""
 
-#: ../src/common/fontmap.cpp:413
+#: ../src/common/fontmap.cpp:410
 msgid ": unknown encoding"
 msgstr ""
 
-#: ../src/generic/wizard.cpp:443
+#: ../src/generic/wizard.cpp:438
 msgid "< &Back"
 msgstr "< &Atgal"
 
-#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:628
-#: ../src/osx/carbon/fontdlg.cpp:648
+#: ../src/osx/carbon/fontdlg.cpp:419 ../src/osx/carbon/fontdlg.cpp:625
+#: ../src/osx/carbon/fontdlg.cpp:645
 msgid "<Any Decorative>"
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:630
-#: ../src/osx/carbon/fontdlg.cpp:650
+#: ../src/osx/carbon/fontdlg.cpp:420 ../src/osx/carbon/fontdlg.cpp:627
+#: ../src/osx/carbon/fontdlg.cpp:647
 msgid "<Any Modern>"
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:626
-#: ../src/osx/carbon/fontdlg.cpp:646
+#: ../src/osx/carbon/fontdlg.cpp:418 ../src/osx/carbon/fontdlg.cpp:623
+#: ../src/osx/carbon/fontdlg.cpp:643
 msgid "<Any Roman>"
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:424 ../src/osx/carbon/fontdlg.cpp:632
-#: ../src/osx/carbon/fontdlg.cpp:652
+#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:629
+#: ../src/osx/carbon/fontdlg.cpp:649
 msgid "<Any Script>"
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:425 ../src/osx/carbon/fontdlg.cpp:637
-#: ../src/osx/carbon/fontdlg.cpp:656
+#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:634
+#: ../src/osx/carbon/fontdlg.cpp:653
 msgid "<Any Swiss>"
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:426 ../src/osx/carbon/fontdlg.cpp:634
-#: ../src/osx/carbon/fontdlg.cpp:654
+#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:631
+#: ../src/osx/carbon/fontdlg.cpp:651
 msgid "<Any Teletype>"
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:420
+#: ../src/osx/carbon/fontdlg.cpp:417
 msgid "<Any>"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
 msgid "<DIR>"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:254 ../src/generic/filectrlg.cpp:277
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
 msgid "<DRIVE>"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:252 ../src/generic/filectrlg.cpp:275
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
 msgid "<LINK>"
 msgstr "NUORODA"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1264
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1270
+#: ../src/html/helpwnd.cpp:1268
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1265
+#: ../src/html/helpwnd.cpp:1263
 msgid "<b>Bold face.</b> "
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1264
+#: ../src/html/helpwnd.cpp:1262
 msgid "<i>Italic face.</i> "
 msgstr ""
 
@@ -1069,15 +1066,15 @@ msgstr ""
 msgid ">"
 msgstr ">"
 
-#: ../src/generic/dbgrptg.cpp:318
+#: ../src/generic/dbgrptg.cpp:317
 msgid "A debug report has been generated in the directory\n"
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:573
+#: ../src/common/debugrpt.cpp:574
 msgid "A debug report has been generated. It can be found in"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:418
+#: ../src/common/xtixml.cpp:414
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr ""
 
@@ -1088,106 +1085,106 @@ msgstr ""
 msgid "A standard bullet name."
 msgstr ""
 
-#: ../src/common/paper.cpp:217
+#: ../src/common/paper.cpp:214
 msgid "A0 sheet, 841 x 1189 mm"
 msgstr "A0 lapas, 841 x 1189 mm"
 
-#: ../src/common/paper.cpp:218
+#: ../src/common/paper.cpp:215
 msgid "A1 sheet, 594 x 841 mm"
 msgstr "A1 lapas, 594 x 841 mm"
 
-#: ../src/common/paper.cpp:159
+#: ../src/common/paper.cpp:156
 msgid "A2 420 x 594 mm"
 msgstr "A2 420 x 594 mm"
 
-#: ../src/common/paper.cpp:156
+#: ../src/common/paper.cpp:153
 msgid "A3 Extra 322 x 445 mm"
 msgstr "A3 Ekstra 322 x 445 mm"
 
-#: ../src/common/paper.cpp:161
+#: ../src/common/paper.cpp:158
 msgid "A3 Extra Transverse 322 x 445 mm"
 msgstr "A3 Ekstra Skersinis 322 x 445 mm"
 
-#: ../src/common/paper.cpp:170
+#: ../src/common/paper.cpp:167
 msgid "A3 Rotated 420 x 297 mm"
 msgstr "A3 Pasuktas 420 x 297 mm"
 
-#: ../src/common/paper.cpp:160
+#: ../src/common/paper.cpp:157
 msgid "A3 Transverse 297 x 420 mm"
 msgstr "A3 Skersinis 297 x 420 mm"
 
-#: ../src/common/paper.cpp:106
+#: ../src/common/paper.cpp:103
 msgid "A3 sheet, 297 x 420 mm"
 msgstr "A3 lapas, 297 x 420 mm"
 
-#: ../src/common/paper.cpp:146
+#: ../src/common/paper.cpp:143
 msgid "A4 Extra 9.27 x 12.69 in"
 msgstr "A4 Ekstra 9.27 x 12.69 colių"
 
-#: ../src/common/paper.cpp:153
+#: ../src/common/paper.cpp:150
 msgid "A4 Plus 210 x 330 mm"
 msgstr "A4 Plius 210 x 330 mm"
 
-#: ../src/common/paper.cpp:171
+#: ../src/common/paper.cpp:168
 msgid "A4 Rotated 297 x 210 mm"
 msgstr "A4 Pasuktas 297 x 210 mm"
 
-#: ../src/common/paper.cpp:148
+#: ../src/common/paper.cpp:145
 msgid "A4 Transverse 210 x 297 mm"
 msgstr "A4 Skersinis 210 x 297 mm"
 
-#: ../src/common/paper.cpp:97
+#: ../src/common/paper.cpp:94
 msgid "A4 sheet, 210 x 297 mm"
 msgstr "A4 lapas, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:107
+#: ../src/common/paper.cpp:104
 msgid "A4 small sheet, 210 x 297 mm"
 msgstr "A4 small lapas, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:157
+#: ../src/common/paper.cpp:154
 msgid "A5 Extra 174 x 235 mm"
 msgstr "A5 Ekstra 174 x 235 mm"
 
-#: ../src/common/paper.cpp:172
+#: ../src/common/paper.cpp:169
 msgid "A5 Rotated 210 x 148 mm"
 msgstr "A5 Pasuktas 210 x 148 mm"
 
-#: ../src/common/paper.cpp:154
+#: ../src/common/paper.cpp:151
 msgid "A5 Transverse 148 x 210 mm"
 msgstr "A5 Skersinis 148 x 210 mm"
 
-#: ../src/common/paper.cpp:108
+#: ../src/common/paper.cpp:105
 msgid "A5 sheet, 148 x 210 mm"
 msgstr "A5 lapas, 148 x 210 mm"
 
-#: ../src/common/paper.cpp:164
+#: ../src/common/paper.cpp:161
 msgid "A6 105 x 148 mm"
 msgstr "A6 105 x 148 mm"
 
-#: ../src/common/paper.cpp:177
+#: ../src/common/paper.cpp:174
 msgid "A6 Rotated 148 x 105 mm"
 msgstr "A6 Pasuktas 148 x 105 mm"
 
-#: ../src/generic/fontdlgg.cpp:83 ../src/richtext/richtextformatdlg.cpp:529
-#: ../src/osx/carbon/fontdlg.cpp:153
+#: ../src/osx/carbon/fontdlg.cpp:150 ../src/generic/fontdlgg.cpp:79
+#: ../src/richtext/richtextformatdlg.cpp:521
 msgid "ABCDEFGabcdefg12345"
 msgstr "ABCDEFGabcdefg12345"
 
-#: ../src/richtext/richtextsymboldlg.cpp:458 ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
 msgid "ASCII"
 msgstr "ASCII"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "About"
 msgstr "Apie"
 
-#: ../src/generic/aboutdlgg.cpp:140 ../src/osx/menu_osx.cpp:558
-#: ../src/msw/aboutdlg.cpp:64
+#: ../src/osx/menu_osx.cpp:450 ../src/generic/aboutdlgg.cpp:137
+#: ../src/msw/aboutdlg.cpp:61
 #, c-format
 msgid "About %s"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:560
+#: ../src/osx/menu_osx.cpp:452
 msgid "About..."
 msgstr "Apie..."
 
@@ -1196,37 +1193,37 @@ msgid "Absolute"
 msgstr "Absoliutus"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:873
+#: ../src/propgrid/advprops.cpp:774
 msgid "ActiveBorder"
 msgstr "Rėmelis"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:874
+#: ../src/propgrid/advprops.cpp:775
 msgid "ActiveCaption"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "Actual Size"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:140 ../src/common/accelcmn.cpp:81
+#: ../src/common/stockitem.cpp:137 ../src/common/accelcmn.cpp:78
 msgid "Add"
 msgstr "Pridėti"
 
-#: ../src/richtext/richtextbuffer.cpp:11455
+#: ../src/richtext/richtextbuffer.cpp:11454
 msgid "Add Column"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11392
+#: ../src/richtext/richtextbuffer.cpp:11391
 msgid "Add Row"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:432
+#: ../src/html/helpwnd.cpp:430
 msgid "Add current page to bookmarks"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:366
+#: ../src/generic/colrdlgg.cpp:386
 msgid "Add to custom colours"
 msgstr ""
 
@@ -1238,12 +1235,12 @@ msgstr ""
 msgid "AddToPropertyCollection called w/o valid adder"
 msgstr ""
 
-#: ../src/html/helpctrl.cpp:159
+#: ../src/html/helpctrl.cpp:155
 #, c-format
 msgid "Adding book %s"
 msgstr ""
 
-#: ../src/common/preferencescmn.cpp:43
+#: ../src/common/preferencescmn.cpp:40
 msgid "Advanced"
 msgstr "Išsamiau"
 
@@ -1251,11 +1248,11 @@ msgstr "Išsamiau"
 msgid "After a paragraph:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:172
+#: ../src/common/stockitem.cpp:169
 msgid "Align Left"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:173
+#: ../src/common/stockitem.cpp:170
 msgid "Align Right"
 msgstr ""
 
@@ -1263,40 +1260,40 @@ msgstr ""
 msgid "Alignment"
 msgstr "Lygiuotė"
 
-#: ../src/generic/prntdlgg.cpp:215
+#: ../src/generic/prntdlgg.cpp:208
 msgid "All"
 msgstr "Viskas"
 
-#: ../src/generic/filectrlg.cpp:1197 ../src/common/fldlgcmn.cpp:107
+#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1186
 #, c-format
 msgid "All files (%s)|%s"
 msgstr ""
 
-#: ../include/wx/defs.h:2886
+#: ../include/wx/defs.h:2582
 msgid "All files (*)|*"
 msgstr ""
 
-#: ../include/wx/defs.h:2883
+#: ../include/wx/defs.h:2579
 msgid "All files (*.*)|*.*"
 msgstr ""
 
-#: ../src/richtext/richtextstyles.cpp:1061
+#: ../src/richtext/richtextstyles.cpp:1058
 msgid "All styles"
 msgstr ""
 
-#: ../src/propgrid/manager.cpp:1528
+#: ../src/propgrid/manager.cpp:1544
 msgid "Alphabetic Mode"
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:425
+#: ../src/common/xtistrm.cpp:422
 msgid "Already Registered Object passed to SetObjectClassInfo"
 msgstr ""
 
-#: ../src/unix/dialup.cpp:353
+#: ../src/unix/dialup.cpp:352
 msgid "Already dialling ISP."
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:331 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/accelcmn.cpp:345 ../src/univ/themes/win32.cpp:3753
 msgid "Alt+"
 msgstr "Alt+"
 
@@ -1305,34 +1302,34 @@ msgstr "Alt+"
 msgid "An optional corner radius for adding rounded corners."
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:576
+#: ../src/common/debugrpt.cpp:577
 msgid "And includes the following files:\n"
 msgstr ""
 
-#: ../src/generic/animateg.cpp:162
+#: ../src/generic/animateg.cpp:145
 #, c-format
 msgid "Animation file is not of type %ld."
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:872
+#: ../src/propgrid/advprops.cpp:773
 msgid "AppWorkspace"
 msgstr ""
 
-#: ../src/generic/logg.cpp:1014
+#: ../src/generic/logg.cpp:1011
 #, c-format
 msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:577 ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:469 ../src/osx/menu_osx.cpp:477
 msgid "Application"
 msgstr "Objektų parinktis"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "Apply"
 msgstr "Pritaikyti"
 
-#: ../src/propgrid/advprops.cpp:1609
+#: ../src/propgrid/advprops.cpp:1515
 msgid "Aqua"
 msgstr ""
 
@@ -1341,29 +1338,29 @@ msgstr ""
 msgid "Arabic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:153
+#: ../src/common/fmapbase.cpp:150
 msgid "Arabic (ISO-8859-6)"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:672
+#: ../src/msw/ole/automtn.cpp:663
 #, c-format
 msgid "Argument %u not found."
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1753
+#: ../src/propgrid/advprops.cpp:1654
 msgid "Arrow"
 msgstr "Rodyklė"
 
-#: ../src/generic/aboutdlgg.cpp:184
+#: ../src/generic/aboutdlgg.cpp:181
 msgid "Artists"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "Ascending"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:433
+#: ../src/generic/filectrlg.cpp:429
 msgid "Attributes"
 msgstr "Atributai"
 
@@ -1373,90 +1370,90 @@ msgstr "Atributai"
 msgid "Available fonts."
 msgstr ""
 
-#: ../src/common/paper.cpp:137
+#: ../src/common/paper.cpp:134
 msgid "B4 (ISO) 250 x 353 mm"
 msgstr "B4 (ISO) 250 x 353 mm"
 
-#: ../src/common/paper.cpp:173
+#: ../src/common/paper.cpp:170
 msgid "B4 (JIS) Rotated 364 x 257 mm"
 msgstr "B4 (JIS) Pasuktas 364 x 257 mm"
 
-#: ../src/common/paper.cpp:127
+#: ../src/common/paper.cpp:124
 msgid "B4 Envelope, 250 x 353 mm"
 msgstr "B4 Vokas, 250 x 353 mm"
 
-#: ../src/common/paper.cpp:109
+#: ../src/common/paper.cpp:106
 msgid "B4 sheet, 250 x 354 mm"
 msgstr "B4 lapas, 250 x 354 mm"
 
-#: ../src/common/paper.cpp:158
+#: ../src/common/paper.cpp:155
 msgid "B5 (ISO) Extra 201 x 276 mm"
 msgstr "B5 (ISO) Ekstra 201 x 276 mm"
 
-#: ../src/common/paper.cpp:174
+#: ../src/common/paper.cpp:171
 msgid "B5 (JIS) Rotated 257 x 182 mm"
 msgstr "B5 (JIS) Pasuktas 257 x 182 mm"
 
-#: ../src/common/paper.cpp:155
+#: ../src/common/paper.cpp:152
 msgid "B5 (JIS) Transverse 182 x 257 mm"
 msgstr "B5 (JIS) Skersinis 182 x 257 mm"
 
-#: ../src/common/paper.cpp:128
+#: ../src/common/paper.cpp:125
 msgid "B5 Envelope, 176 x 250 mm"
 msgstr "B5 Vokas, 176 x 250 mm"
 
-#: ../src/common/paper.cpp:110
+#: ../src/common/paper.cpp:107
 msgid "B5 sheet, 182 x 257 millimeter"
 msgstr "B5 lapas, 182 x 257 millimeter"
 
-#: ../src/common/paper.cpp:182
+#: ../src/common/paper.cpp:179
 msgid "B6 (JIS) 128 x 182 mm"
 msgstr "B6 (JIS) 128 x 182 mm"
 
-#: ../src/common/paper.cpp:183
+#: ../src/common/paper.cpp:180
 msgid "B6 (JIS) Rotated 182 x 128 mm"
 msgstr "B6 (JIS) Pasuktas 182 x 128 mm"
 
-#: ../src/common/paper.cpp:129
+#: ../src/common/paper.cpp:126
 msgid "B6 Envelope, 176 x 125 mm"
 msgstr "B6 Vokas, 176 x 125 mm"
 
-#: ../src/common/imagbmp.cpp:531 ../src/common/imagbmp.cpp:561
-#: ../src/common/imagbmp.cpp:576
+#: ../src/common/imagbmp.cpp:528 ../src/common/imagbmp.cpp:558
+#: ../src/common/imagbmp.cpp:573
 msgid "BMP: Couldn't allocate memory."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:100
+#: ../src/common/imagbmp.cpp:97
 msgid "BMP: Couldn't save invalid image."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:356
+#: ../src/common/imagbmp.cpp:353
 msgid "BMP: Couldn't write RGB color map."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:490
+#: ../src/common/imagbmp.cpp:487
 msgid "BMP: Couldn't write data."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:246
+#: ../src/common/imagbmp.cpp:243
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:269
+#: ../src/common/imagbmp.cpp:266
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:140
+#: ../src/common/imagbmp.cpp:137
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:142 ../src/common/accelcmn.cpp:52
+#: ../src/common/stockitem.cpp:139 ../src/common/accelcmn.cpp:49
 msgid "Back"
 msgstr "Galas"
 
+#: ../src/richtext/richtextformatdlg.cpp:377
 #: ../src/richtext/richtextbackgroundpage.cpp:148
-#: ../src/richtext/richtextformatdlg.cpp:384
 msgid "Background"
 msgstr "Fonas"
 
@@ -1464,20 +1461,20 @@ msgstr "Fonas"
 msgid "Background &colour:"
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:220
+#: ../src/osx/carbon/fontdlg.cpp:217
 msgid "Background colour"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:52
+#: ../src/common/accelcmn.cpp:49
 msgid "Backspace"
 msgstr "Galas"
 
-#: ../src/common/fmapbase.cpp:160
+#: ../src/common/fmapbase.cpp:157
 msgid "Baltic (ISO-8859-13)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:151
+#: ../src/common/fmapbase.cpp:148
 msgid "Baltic (old) (ISO-8859-4)"
 msgstr ""
 
@@ -1490,26 +1487,26 @@ msgstr ""
 msgid "Bitmap"
 msgstr "Taškinė grafika"
 
-#: ../src/propgrid/advprops.cpp:1594
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Black"
 msgstr "Juoda"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1755
+#: ../src/propgrid/advprops.cpp:1656
 msgid "Blank"
 msgstr "Tuščia"
 
-#: ../src/propgrid/advprops.cpp:1603
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Blue"
 msgstr "Mėlyna"
 
-#: ../src/generic/colrdlgg.cpp:345
+#: ../src/generic/colrdlgg.cpp:365
 #, fuzzy
 msgid "Blue:"
 msgstr "Mėlyna"
 
-#: ../src/generic/fontdlgg.cpp:333 ../src/richtext/richtextfontpage.cpp:355
-#: ../src/osx/carbon/fontdlg.cpp:354 ../src/common/stockitem.cpp:143
+#: ../src/osx/carbon/fontdlg.cpp:351 ../src/common/stockitem.cpp:140
+#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:355
 msgid "Bold"
 msgstr "Pastorintas"
 
@@ -1518,31 +1515,35 @@ msgstr "Pastorintas"
 msgid "Border"
 msgstr "Rėmelis"
 
-#: ../src/richtext/richtextformatdlg.cpp:379
+#: ../src/richtext/richtextformatdlg.cpp:372
 msgid "Borders"
 msgstr ""
 
-#: ../src/richtext/richtextsizepage.cpp:288 ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141 ../src/richtext/richtextsizepage.cpp:288
 msgid "Bottom"
 msgstr "Apačia"
 
-#: ../src/generic/prntdlgg.cpp:893
+#: ../src/generic/prntdlgg.cpp:886
 msgid "Bottom margin (mm):"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9383
+#: ../src/richtext/richtextbuffer.cpp:9380
 msgid "Box Properties"
 msgstr ""
 
-#: ../src/richtext/richtextstyles.cpp:1065
+#: ../src/richtext/richtextstyles.cpp:1062
 msgid "Box styles"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1602
+#: ../src/osx/cocoa/menu.mm:292
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Brown"
 msgstr "Naršyti"
 
-#: ../src/common/filepickercmn.cpp:43 ../src/common/filepickercmn.cpp:44
+#: ../src/common/filepickercmn.cpp:40 ../src/common/filepickercmn.cpp:41
 msgid "Browse"
 msgstr "Naršyti"
 
@@ -1555,72 +1556,72 @@ msgstr ""
 msgid "Bullet style"
 msgstr ""
 
-#: ../src/richtext/richtextformatdlg.cpp:359
+#: ../src/richtext/richtextformatdlg.cpp:352
 msgid "Bullets"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1756
+#: ../src/propgrid/advprops.cpp:1657
 msgid "Bullseye"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:875
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonFace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:876
+#: ../src/propgrid/advprops.cpp:777
 msgid "ButtonHighlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:877
+#: ../src/propgrid/advprops.cpp:778
 msgid "ButtonShadow"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:878
+#: ../src/propgrid/advprops.cpp:779
 msgid "ButtonText"
 msgstr ""
 
-#: ../src/common/paper.cpp:98
+#: ../src/common/paper.cpp:95
 msgid "C sheet, 17 x 22 in"
 msgstr ""
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "C&lear"
 msgstr "Išva&lyti"
 
-#: ../src/generic/fontdlgg.cpp:406
+#: ../src/generic/fontdlgg.cpp:403
 msgid "C&olour:"
 msgstr ""
 
-#: ../src/common/paper.cpp:123
+#: ../src/common/paper.cpp:120
 msgid "C3 Envelope, 324 x 458 mm"
 msgstr "C3 Vokas, 324 x 458 mm"
 
-#: ../src/common/paper.cpp:124
+#: ../src/common/paper.cpp:121
 msgid "C4 Envelope, 229 x 324 mm"
 msgstr "C4 Vokas, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:122
+#: ../src/common/paper.cpp:119
 msgid "C5 Envelope, 162 x 229 mm"
 msgstr "C5 Vokas, 162 x 229 mm"
 
-#: ../src/common/paper.cpp:125
+#: ../src/common/paper.cpp:122
 msgid "C6 Envelope, 114 x 162 mm"
 msgstr "C6 Vokas, 114 x 162 mm"
 
-#: ../src/common/paper.cpp:126
+#: ../src/common/paper.cpp:123
 msgid "C65 Envelope, 114 x 229 mm"
 msgstr "C65 Vokas, 114 x 229 mm"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "CD-Rom"
 msgstr ""
 
-#: ../src/html/chm.cpp:815 ../src/html/chm.cpp:874
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:865
 msgid "CHM handler currently supports only local files!"
 msgstr ""
 
@@ -1628,190 +1629,193 @@ msgstr ""
 msgid "Ca&pitals"
 msgstr ""
 
-#: ../src/common/cmdproc.cpp:267
+#: ../src/common/cmdproc.cpp:260
 msgid "Can't &Undo "
 msgstr ""
 
-#: ../src/common/image.cpp:2824
+#: ../src/common/image.cpp:2924
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 
-#: ../src/msw/registry.cpp:506
+#: ../src/msw/registry.cpp:495
 #, c-format
 msgid "Can't close registry key '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:584
+#: ../src/msw/registry.cpp:573
 #, c-format
 msgid "Can't copy values of unsupported type %d."
 msgstr ""
 
-#: ../src/msw/registry.cpp:487
+#: ../src/msw/registry.cpp:476
 #, c-format
 msgid "Can't create registry key '%s'"
 msgstr ""
 
-#: ../src/msw/thread.cpp:665
+#: ../src/msw/thread.cpp:657
 msgid "Can't create thread"
 msgstr ""
 
-#: ../src/msw/window.cpp:3691
-#, c-format
-msgid "Can't create window of class %s"
-msgstr ""
-
-#: ../src/msw/registry.cpp:777
+#: ../src/msw/registry.cpp:765
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr ""
 
-#: ../src/msw/iniconf.cpp:458
+#: ../src/msw/iniconf.cpp:455
 #, c-format
 msgid "Can't delete the INI file '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:805
+#: ../src/msw/registry.cpp:793
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1171
+#: ../src/msw/registry.cpp:1159
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1132
+#: ../src/msw/registry.cpp:1120
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1389
+#: ../src/msw/registry.cpp:1377
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr ""
 
-#: ../src/common/ffile.cpp:254
+#: ../src/common/ffile.cpp:253
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:418
+#: ../src/msw/registry.cpp:407
 #, c-format
 msgid "Can't get info about registry key '%s'"
 msgstr ""
 
-#: ../src/common/zstream.cpp:346
+#: ../src/msw/webview_ie.cpp:1024
+msgid "Can't get the JavaScript object"
+msgstr ""
+
+#: ../src/common/zstream.cpp:343
 msgid "Can't initialize zlib deflate stream."
 msgstr ""
 
-#: ../src/common/zstream.cpp:185
+#: ../src/common/zstream.cpp:182
 msgid "Can't initialize zlib inflate stream."
 msgstr ""
 
-#: ../src/msw/fswatcher.cpp:476
+#: ../src/msw/fswatcher.cpp:475
 #, c-format
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr ""
 
-#: ../src/msw/registry.cpp:454
+#: ../src/msw/registry.cpp:443
 #, c-format
 msgid "Can't open registry key '%s'"
 msgstr ""
 
-#: ../src/common/zstream.cpp:252
+#: ../src/common/zstream.cpp:249
 #, c-format
 msgid "Can't read from inflate stream: %s"
 msgstr ""
 
-#: ../src/common/zstream.cpp:244
+#: ../src/common/zstream.cpp:241
 msgid "Can't read inflate stream: unexpected EOF in underlying stream."
 msgstr ""
 
-#: ../src/msw/registry.cpp:1064
+#: ../src/msw/registry.cpp:1052
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:878 ../src/msw/registry.cpp:910
-#: ../src/msw/registry.cpp:975
+#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
+#: ../src/msw/registry.cpp:963
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr ""
 
-#: ../src/common/image.cpp:2620
+#: ../src/msw/webview_ie.cpp:1017
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/common/image.cpp:2715
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr ""
 
-#: ../src/generic/logg.cpp:573 ../src/generic/logg.cpp:976
+#: ../src/generic/logg.cpp:570 ../src/generic/logg.cpp:973
 msgid "Can't save log contents to file."
 msgstr ""
 
-#: ../src/msw/thread.cpp:629
+#: ../src/msw/thread.cpp:621
 msgid "Can't set thread priority"
 msgstr ""
 
-#: ../src/msw/registry.cpp:896 ../src/msw/registry.cpp:938
-#: ../src/msw/registry.cpp:1081
+#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
+#: ../src/msw/registry.cpp:1069
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:351
+#: ../src/unix/utilsunx.cpp:353
 msgid "Can't write to child process's stdin"
 msgstr ""
 
-#: ../src/common/zstream.cpp:427
+#: ../src/common/zstream.cpp:424
 #, c-format
 msgid "Can't write to deflate stream: %s"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:279 ../src/richtext/richtextstyledlg.cpp:300
-#: ../src/common/stockitem.cpp:145 ../src/common/accelcmn.cpp:71
-#: ../src/msw/msgdlg.cpp:454 ../src/msw/progdlg.cpp:673
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:142
+#: ../src/common/accelcmn.cpp:68 ../src/motif/msgdlg.cpp:196
+#: ../src/gtk1/fontdlg.cpp:144 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/progdlg.cpp:940 ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Atsisakyti"
 
-#: ../src/common/filefn.cpp:1261
+#: ../src/common/filefn.cpp:1149
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr ""
 
-#: ../src/msw/dir.cpp:263
+#: ../src/msw/dir.cpp:260
 #, c-format
 msgid "Cannot enumerate files in directory '%s'"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:523
+#: ../src/msw/dialup.cpp:517
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:827
+#: ../src/msw/dialup.cpp:821
 msgid "Cannot find the location of address book file"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:562
+#: ../src/msw/ole/automtn.cpp:553
 #, c-format
 msgid "Cannot get an active instance of \"%s\""
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1035
+#: ../src/unix/threadpsx.cpp:1053
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:987
+#: ../src/unix/utilsunx.cpp:989
 msgid "Cannot get the hostname"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:1023
+#: ../src/unix/utilsunx.cpp:1025
 msgid "Cannot get the official hostname"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:928
+#: ../src/msw/dialup.cpp:922
 msgid "Cannot hang up - no active dialup connection."
 msgstr ""
 
@@ -1819,126 +1823,126 @@ msgstr ""
 msgid "Cannot initialize OLE"
 msgstr ""
 
-#: ../src/common/socket.cpp:853
+#: ../src/common/socket.cpp:850
 msgid "Cannot initialize sockets"
 msgstr ""
 
-#: ../src/msw/volume.cpp:619
+#: ../src/msw/volume.cpp:627
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr ""
 
-#: ../src/xrc/xmlres.cpp:360
+#: ../src/xrc/xmlres.cpp:358
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr ""
 
-#: ../src/xrc/xmlres.cpp:742
+#: ../src/xrc/xmlres.cpp:740
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr ""
 
-#: ../src/html/htmlfilt.cpp:137
+#: ../src/html/htmlfilt.cpp:134
 #, c-format
 msgid "Cannot open HTML document: %s"
 msgstr ""
 
-#: ../src/html/helpdata.cpp:667
+#: ../src/html/helpdata.cpp:660
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr ""
 
-#: ../src/html/helpdata.cpp:299
+#: ../src/html/helpdata.cpp:296
 #, c-format
 msgid "Cannot open contents file: %s"
 msgstr ""
 
-#: ../src/generic/dcpsg.cpp:1667
+#: ../src/generic/dcpsg.cpp:1665
 msgid "Cannot open file for PostScript printing!"
 msgstr ""
 
-#: ../src/html/helpdata.cpp:313
+#: ../src/html/helpdata.cpp:310
 #, c-format
 msgid "Cannot open index file: %s"
 msgstr ""
 
-#: ../src/xrc/xmlres.cpp:724
+#: ../src/xrc/xmlres.cpp:722
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1534
+#: ../src/html/helpwnd.cpp:1532
 msgid "Cannot print empty page."
 msgstr ""
 
-#: ../src/msw/volume.cpp:507
+#: ../src/msw/volume.cpp:515
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr ""
 
-#: ../src/msw/thread.cpp:888
+#: ../src/msw/thread.cpp:894
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1016
+#: ../src/unix/threadpsx.cpp:1028
 msgid "Cannot retrieve thread scheduling policy."
 msgstr ""
 
-#: ../src/common/intl.cpp:558
+#: ../src/common/intl.cpp:365
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:831 ../src/msw/thread.cpp:546
+#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
 msgid "Cannot start thread: error writing TLS."
 msgstr ""
 
-#: ../src/msw/thread.cpp:872
+#: ../src/msw/thread.cpp:864
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr ""
 
-#: ../src/msw/thread.cpp:794
+#: ../src/msw/thread.cpp:786
 msgid "Cannot wait for thread termination"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:75
+#: ../src/common/accelcmn.cpp:72
 msgid "Capital"
 msgstr "Kursyvas"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:879
+#: ../src/propgrid/advprops.cpp:780
 msgid "CaptionText"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:531
 msgid "Case sensitive"
 msgstr ""
 
-#: ../src/propgrid/manager.cpp:1509
+#: ../src/propgrid/manager.cpp:1527
 msgid "Categorized Mode"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9968
+#: ../src/richtext/richtextbuffer.cpp:9965
 msgid "Cell Properties"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:161
+#: ../src/common/fmapbase.cpp:158
 msgid "Celtic (ISO-8859-14)"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:160
 #: ../src/richtext/richtextliststylepage.cpp:349
+#: ../src/richtext/richtextindentspage.cpp:160
 msgid "Cen&tred"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:170
+#: ../src/common/stockitem.cpp:167
 msgid "Centered"
 msgstr "Centruotas"
 
-#: ../src/common/fmapbase.cpp:149
+#: ../src/common/fmapbase.cpp:146
 msgid "Central European (ISO-8859-2)"
 msgstr ""
 
@@ -1947,10 +1951,10 @@ msgstr ""
 msgid "Centre"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:162
-#: ../src/richtext/richtextindentspage.cpp:164
 #: ../src/richtext/richtextliststylepage.cpp:351
 #: ../src/richtext/richtextliststylepage.cpp:353
+#: ../src/richtext/richtextindentspage.cpp:162
+#: ../src/richtext/richtextindentspage.cpp:164
 msgid "Centre text."
 msgstr ""
 
@@ -1963,24 +1967,24 @@ msgstr ""
 msgid "Ch&oose..."
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:4354
+#: ../src/richtext/richtextbuffer.cpp:4351
 msgid "Change List Style"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:3709
+#: ../src/richtext/richtextbuffer.cpp:3706
 msgid "Change Object Style"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:3982
-#: ../src/richtext/richtextbuffer.cpp:8129
+#: ../src/richtext/richtextbuffer.cpp:3979
+#: ../src/richtext/richtextbuffer.cpp:8125
 msgid "Change Properties"
 msgstr "&Savybės"
 
-#: ../src/richtext/richtextbuffer.cpp:3526
+#: ../src/richtext/richtextbuffer.cpp:3523
 msgid "Change Style"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:341
+#: ../src/common/fileconf.cpp:335
 #, c-format
 msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
 msgstr ""
@@ -1991,11 +1995,11 @@ msgid "Changing current directory to \"%s\" failed"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1757
+#: ../src/propgrid/advprops.cpp:1658
 msgid "Character"
 msgstr ""
 
-#: ../src/richtext/richtextstyles.cpp:1063
+#: ../src/richtext/richtextstyles.cpp:1060
 msgid "Character styles"
 msgstr ""
 
@@ -2032,20 +2036,20 @@ msgstr ""
 msgid "Check to indicate right-to-left text layout."
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:356 ../src/osx/carbon/fontdlg.cpp:358
+#: ../src/osx/carbon/fontdlg.cpp:353 ../src/osx/carbon/fontdlg.cpp:355
 msgid "Check to make the font bold."
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:363 ../src/osx/carbon/fontdlg.cpp:365
+#: ../src/osx/carbon/fontdlg.cpp:360 ../src/osx/carbon/fontdlg.cpp:362
 msgid "Check to make the font italic."
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:372 ../src/osx/carbon/fontdlg.cpp:374
+#: ../src/osx/carbon/fontdlg.cpp:369 ../src/osx/carbon/fontdlg.cpp:371
 msgid "Check to make the font underlined."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:289
-#: ../src/richtext/richtextstyledlg.cpp:291
+#: ../src/richtext/richtextstyledlg.cpp:285
+#: ../src/richtext/richtextstyledlg.cpp:287
 msgid "Check to restart numbering."
 msgstr ""
 
@@ -2079,51 +2083,51 @@ msgstr ""
 msgid "Check to suppress hyphenation."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:763
+#: ../src/msw/dialup.cpp:757
 msgid "Choose ISP to dial"
 msgstr ""
 
-#: ../src/propgrid/props.cpp:1922
+#: ../src/propgrid/props.cpp:1904
 msgid "Choose a directory:"
 msgstr ""
 
-#: ../src/propgrid/props.cpp:1975
+#: ../src/propgrid/props.cpp:2199
 msgid "Choose a file"
 msgstr "Parinkti failą"
 
-#: ../src/generic/colrdlgg.cpp:158 ../src/gtk/colordlg.cpp:54
+#: ../src/generic/colrdlgg.cpp:156 ../src/gtk/colordlg.cpp:49
 msgid "Choose colour"
 msgstr ""
 
-#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/gtk1/fontdlg.cpp:125 ../src/generic/fontpickerg.cpp:47
+#: ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr ""
 
-#: ../src/common/module.cpp:74
+#: ../src/common/module.cpp:71
 #, c-format
 msgid "Circular dependency involving module \"%s\" detected."
 msgstr ""
 
-#: ../src/aui/tabmdi.cpp:108 ../src/generic/mdig.cpp:97
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
 msgid "Cl&ose"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:684
+#: ../src/msw/ole/automtn.cpp:675
 msgid "Class not registered."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:147 ../src/common/accelcmn.cpp:72
+#: ../src/common/stockitem.cpp:144 ../src/common/accelcmn.cpp:69
 msgid "Clear"
 msgstr "Išvalyti"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "Clear the log contents"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:252
-#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:248
+#: ../src/richtext/richtextstyledlg.cpp:250
 msgid "Click to apply the selected style."
 msgstr ""
 
@@ -2134,15 +2138,15 @@ msgstr ""
 msgid "Click to browse for a symbol."
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:403 ../src/osx/carbon/fontdlg.cpp:405
+#: ../src/osx/carbon/fontdlg.cpp:400 ../src/osx/carbon/fontdlg.cpp:402
 msgid "Click to cancel changes to the font."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:472 ../src/generic/fontdlgg.cpp:491
+#: ../src/generic/fontdlgg.cpp:468 ../src/generic/fontdlgg.cpp:487
 msgid "Click to cancel the font selection."
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:384 ../src/osx/carbon/fontdlg.cpp:386
+#: ../src/osx/carbon/fontdlg.cpp:381 ../src/osx/carbon/fontdlg.cpp:383
 msgid "Click to change the font colour."
 msgstr ""
 
@@ -2161,37 +2165,37 @@ msgstr ""
 msgid "Click to choose the font for this level."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:279
-#: ../src/richtext/richtextstyledlg.cpp:281
+#: ../src/richtext/richtextstyledlg.cpp:275
+#: ../src/richtext/richtextstyledlg.cpp:277
 msgid "Click to close this window."
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:410 ../src/osx/carbon/fontdlg.cpp:412
+#: ../src/osx/carbon/fontdlg.cpp:407 ../src/osx/carbon/fontdlg.cpp:409
 msgid "Click to confirm changes to the font."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:477 ../src/generic/fontdlgg.cpp:479
-#: ../src/generic/fontdlgg.cpp:484 ../src/generic/fontdlgg.cpp:486
+#: ../src/generic/fontdlgg.cpp:473 ../src/generic/fontdlgg.cpp:475
+#: ../src/generic/fontdlgg.cpp:480 ../src/generic/fontdlgg.cpp:482
 msgid "Click to confirm the font selection."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:244
-#: ../src/richtext/richtextstyledlg.cpp:246
+#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:242
 msgid "Click to create a new box style."
 msgstr "Spustelėkite sukurti naujam dėžutės stiliui."
 
-#: ../src/richtext/richtextstyledlg.cpp:226
-#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:224
 msgid "Click to create a new character style."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:238
-#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:236
 msgid "Click to create a new list style."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:232
-#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:230
 msgid "Click to create a new paragraph style."
 msgstr ""
 
@@ -2205,8 +2209,8 @@ msgstr ""
 msgid "Click to delete all tab positions."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:270
-#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:268
 msgid "Click to delete the selected style."
 msgstr ""
 
@@ -2215,25 +2219,25 @@ msgstr ""
 msgid "Click to delete the selected tab position."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:264
-#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:262
 msgid "Click to edit the selected style."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:258
-#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:256
 msgid "Click to rename the selected style."
 msgstr ""
 
-#: ../src/generic/dbgrptg.cpp:97 ../src/generic/progdlgg.cpp:759
-#: ../src/richtext/richtextstyledlg.cpp:277
-#: ../src/richtext/richtextsymboldlg.cpp:476 ../src/common/stockitem.cpp:148
-#: ../src/msw/progdlg.cpp:170 ../src/msw/progdlg.cpp:679
-#: ../src/html/helpdlg.cpp:90
+#: ../src/common/stockitem.cpp:145 ../src/generic/dbgrptg.cpp:94
+#: ../src/generic/progdlgg.cpp:781 ../src/msw/progdlg.cpp:211
+#: ../src/msw/progdlg.cpp:946 ../src/html/helpdlg.cpp:87
+#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextstyledlg.cpp:273
 msgid "Close"
 msgstr "Užverti"
 
-#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:98
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
 msgid "Close All"
 msgstr "Užverti visus"
 
@@ -2241,55 +2245,55 @@ msgstr "Užverti visus"
 msgid "Close current document"
 msgstr ""
 
-#: ../src/generic/logg.cpp:516
+#: ../src/generic/logg.cpp:513
 msgid "Close this window"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6006
+#: ../src/generic/datavgen.cpp:6811
 msgid "Collapse"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "Color"
 msgstr "Spalva"
 
-#: ../src/richtext/richtextformatdlg.cpp:776
+#: ../src/richtext/richtextformatdlg.cpp:768
 msgid "Colour"
 msgstr ""
 
-#: ../src/msw/colordlg.cpp:158
+#: ../src/msw/colordlg.cpp:227
 #, c-format
 msgid "Colour selection dialog failed with error %0lx."
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:380
+#: ../src/osx/carbon/fontdlg.cpp:377
 msgid "Colour:"
 msgstr ""
 
-#: ../src/generic/datavgen.cpp:6077
+#: ../src/generic/datavgen.cpp:6882
 #, c-format
 msgid "Column %u"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:114
+#: ../src/common/accelcmn.cpp:112
 msgid "Command"
 msgstr "Komanda"
 
-#: ../src/common/init.cpp:196
+#: ../src/common/init.cpp:193
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
 "ignored."
 msgstr ""
 
-#: ../src/msw/fontdlg.cpp:120
+#: ../src/msw/fontdlg.cpp:170
 #, c-format
 msgid "Common dialog failed with error code %0lx."
 msgstr ""
 
-#: ../src/gtk/window.cpp:4649
+#: ../src/gtk/window.cpp:5653
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
@@ -2297,11 +2301,11 @@ msgstr ""
 "Komponavimas nėra įgalintas šioje sistemoje, prašome įgalinti tai Windows "
 "tvarkyklėje."
 
-#: ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:1549
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr ""
 
-#: ../src/generic/dirctrlg.cpp:444
+#: ../src/generic/dirctrlg.cpp:410
 msgid "Computer"
 msgstr ""
 
@@ -2310,53 +2314,57 @@ msgstr ""
 msgid "Config entry name cannot start with '%c'."
 msgstr ""
 
-#: ../src/generic/filedlgg.cpp:349 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
 msgid "Confirm"
 msgstr "Patvirtinti"
 
-#: ../src/html/htmlwin.cpp:566
+#: ../src/html/htmlwin.cpp:569
 msgid "Connecting..."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:475
+#: ../src/html/helpwnd.cpp:473
 msgid "Contents"
 msgstr "Turinys"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:880
+#: ../src/propgrid/advprops.cpp:781
 msgid "ControlDark"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:881
+#: ../src/propgrid/advprops.cpp:782
 msgid "ControlLight"
 msgstr ""
 
-#: ../src/common/strconv.cpp:2262
+#: ../src/common/strconv.cpp:2208
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "Convert"
 msgstr "Konvertuoti"
 
-#: ../src/html/htmlwin.cpp:1079
+#: ../src/html/htmlwin.cpp:1020
 #, c-format
 msgid "Copied to clipboard:\"%s\""
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:247
+#: ../src/generic/prntdlgg.cpp:240
 msgid "Copies:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:150 ../src/stc/stc_i18n.cpp:18
+#: ../src/common/stockitem.cpp:147 ../src/stc/stc_i18n.cpp:18
 msgid "Copy"
 msgstr "Kopijuoti"
 
-#: ../src/common/stockitem.cpp:258
+#: ../src/common/stockitem.cpp:255
 msgid "Copy selection"
 msgstr "Kopijuoti parinktį"
+
+#: ../src/generic/grid.cpp:5945
+msgid "Copying more than one selected block to clipboard is not supported."
+msgstr ""
 
 #: ../src/richtext/richtextborderspage.cpp:566
 #: ../src/richtext/richtextborderspage.cpp:601
@@ -2367,194 +2375,191 @@ msgstr ""
 msgid "Corner &radius:"
 msgstr ""
 
-#: ../src/html/chm.cpp:718
+#: ../src/html/chm.cpp:711
 #, c-format
 msgid "Could not create temporary file '%s'"
 msgstr ""
 
-#: ../src/html/chm.cpp:273
+#: ../src/html/chm.cpp:270
 #, c-format
 msgid "Could not extract %s into %s: %s"
 msgstr ""
 
-#: ../src/generic/tabg.cpp:1048
+#: ../src/generic/tabg.cpp:1045
 msgid "Could not find tab for id"
 msgstr ""
 
-#: ../src/gtk/notifmsg.cpp:108
-msgid "Could not initalize libnotify."
-msgstr ""
-
-#: ../src/html/chm.cpp:444
+#: ../src/html/chm.cpp:437
 #, c-format
 msgid "Could not locate file '%s'."
 msgstr ""
 
-#: ../src/common/filefn.cpp:1403
+#: ../src/msw/graphicsd2d.cpp:604
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/common/filefn.cpp:1291
 msgid "Could not set current working directory"
 msgstr "Nepavyko nustatyti aktyvaus darbo aplanko"
 
-#: ../src/common/prntbase.cpp:2015
+#: ../src/common/prntbase.cpp:2037
 msgid "Could not start document preview."
 msgstr ""
 
-#: ../src/generic/printps.cpp:178 ../src/msw/printwin.cpp:210
-#: ../src/gtk/print.cpp:1132
+#: ../src/generic/printps.cpp:159 ../src/msw/printwin.cpp:184
+#: ../src/gtk/print.cpp:1129
 msgid "Could not start printing."
 msgstr ""
 
-#: ../src/common/wincmn.cpp:2125
+#: ../src/common/wincmn.cpp:2126
 msgid "Could not transfer data to window"
 msgstr ""
 
-#: ../src/msw/imaglist.cpp:187 ../src/msw/imaglist.cpp:224
-#: ../src/msw/imaglist.cpp:249 ../src/msw/dragimag.cpp:185
-#: ../src/msw/dragimag.cpp:220
+#: ../src/msw/imaglist.cpp:223 ../src/msw/imaglist.cpp:245
+#: ../src/msw/imaglist.cpp:270 ../src/msw/dragimag.cpp:182
+#: ../src/msw/dragimag.cpp:217
 msgid "Couldn't add an image to the image list."
 msgstr ""
 
-#: ../src/osx/glcanvas_osx.cpp:414 ../src/unix/glx11.cpp:558
-#: ../src/msw/glcanvas.cpp:616
+#: ../src/osx/glcanvas_osx.cpp:411 ../src/msw/glcanvas.cpp:631
+#: ../src/unix/glegl.cpp:315 ../src/unix/glx11.cpp:559
 msgid "Couldn't create OpenGL context"
 msgstr ""
 
-#: ../src/msw/timer.cpp:134
+#: ../src/msw/timer.cpp:131
 msgid "Couldn't create a timer"
 msgstr ""
 
-#: ../src/osx/carbon/overlay.cpp:122
-msgid "Couldn't create the overlay window"
-msgstr ""
-
-#: ../src/common/translation.cpp:2024
+#: ../src/common/translation.cpp:2074
 msgid "Couldn't enumerate translations"
 msgstr ""
 
-#: ../src/common/dynlib.cpp:120
+#: ../src/common/dynlib.cpp:110
 #, c-format
 msgid "Couldn't find symbol '%s' in a dynamic library"
 msgstr ""
 
-#: ../src/msw/thread.cpp:915
+#: ../src/msw/thread.cpp:921
 msgid "Couldn't get the current thread pointer"
 msgstr ""
 
-#: ../src/osx/carbon/overlay.cpp:129
-msgid "Couldn't init the context on the overlay window"
-msgstr ""
-
-#: ../src/common/imaggif.cpp:244
+#: ../src/common/imaggif.cpp:241
 msgid "Couldn't initialize GIF hash table."
 msgstr ""
 
-#: ../src/common/imagpng.cpp:409
+#: ../src/common/imagpng.cpp:437
 msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
 msgstr ""
 
-#: ../src/unix/sound.cpp:470
+#: ../src/unix/sound.cpp:459
 #, c-format
 msgid "Couldn't load sound data from '%s'."
 msgstr ""
 
-#: ../src/msw/dirdlg.cpp:435
+#: ../src/msw/dirdlg.cpp:287
 msgid "Couldn't obtain folder name"
 msgstr "Nepavyko gauti aplanko pavadinimo"
 
-#: ../src/unix/sound_sdl.cpp:229
+#: ../src/unix/sound_sdl.cpp:226
 #, c-format
 msgid "Couldn't open audio: %s"
 msgstr ""
 
-#: ../src/msw/ole/dataobj.cpp:377
+#: ../src/msw/ole/dataobj.cpp:385
 #, c-format
 msgid "Couldn't register clipboard format '%s'."
 msgstr ""
 
-#: ../src/msw/listctrl.cpp:869
+#: ../src/msw/listctrl.cpp:933
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr ""
 
-#: ../src/common/imagpng.cpp:498 ../src/common/imagpng.cpp:509
-#: ../src/common/imagpng.cpp:519
+#: ../src/common/imagpng.cpp:511 ../src/common/imagpng.cpp:522
+#: ../src/common/imagpng.cpp:532
 msgid "Couldn't save PNG image."
 msgstr ""
 
-#: ../src/msw/thread.cpp:684
+#: ../src/msw/thread.cpp:676
 msgid "Couldn't terminate thread"
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:166
+#: ../src/common/xtistrm.cpp:163
 #, c-format
 msgid "Create Parameter %s not found in declared RTTI Parameters"
 msgstr ""
 
-#: ../src/generic/dirdlgg.cpp:288
+#: ../src/generic/dirdlgg.cpp:285
 msgid "Create directory"
 msgstr ""
 
-#: ../src/generic/filedlgg.cpp:212 ../src/generic/dirdlgg.cpp:111
+#: ../src/generic/filedlgg.cpp:209 ../src/generic/dirdlgg.cpp:108
 msgid "Create new directory"
 msgstr ""
 
-#: ../src/xrc/xmlres.cpp:2460
+#: ../src/common/stockitem.cpp:264
+#, fuzzy
+msgid "Create new document"
+msgstr "Išsaugoti aktyvų dokumentą"
+
+#: ../src/xrc/xmlres.cpp:2515
 #, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1758
+#: ../src/propgrid/advprops.cpp:1659
 msgid "Cross"
 msgstr "Kirsti"
 
-#: ../src/common/accelcmn.cpp:333
+#: ../src/common/accelcmn.cpp:347
 msgid "Ctrl+"
 msgstr "Ctrl+"
 
-#: ../src/richtext/richtextctrl.cpp:332 ../src/osx/textctrl_osx.cpp:576
-#: ../src/common/stockitem.cpp:151 ../src/msw/textctrl.cpp:2507
+#: ../src/osx/textctrl_osx.cpp:594 ../src/common/stockitem.cpp:148
+#: ../src/msw/textctrl.cpp:2772 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "Iškirp&ti"
 
-#: ../src/generic/filectrlg.cpp:940
+#: ../src/generic/filectrlg.cpp:936
 msgid "Current directory:"
 msgstr ""
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:896 ../src/propgrid/advprops.cpp:1574
-#: ../src/propgrid/advprops.cpp:1612
+#: ../src/propgrid/advprops.cpp:797 ../src/propgrid/advprops.cpp:1475
+#: ../src/propgrid/advprops.cpp:1518
 msgid "Custom"
 msgstr "&Pritaikyti"
 
-#: ../src/gtk/print.cpp:217
+#: ../src/gtk/print.cpp:211
 msgid "Custom size"
 msgstr ""
 
-#: ../src/common/headerctrlcmn.cpp:60
+#: ../src/common/headerctrlcmn.cpp:58
 msgid "Customize Columns"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:151 ../src/stc/stc_i18n.cpp:17
+#: ../src/common/stockitem.cpp:148 ../src/stc/stc_i18n.cpp:17
 msgid "Cut"
 msgstr "Iškirpti"
 
-#: ../src/common/stockitem.cpp:259
+#: ../src/common/stockitem.cpp:256
 msgid "Cut selection"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:152
+#: ../src/common/fmapbase.cpp:149
 msgid "Cyrillic (ISO-8859-5)"
 msgstr ""
 
-#: ../src/common/paper.cpp:99
+#: ../src/common/paper.cpp:96
 msgid "D sheet, 22 x 34 in"
 msgstr ""
 
-#: ../src/msw/dde.cpp:703
+#: ../src/msw/dde.cpp:698
 msgid "DDE poke request failed"
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1169
+#: ../src/common/imagbmp.cpp:1181
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr ""
 
@@ -2574,7 +2579,7 @@ msgstr ""
 msgid "DIB Header: Unknown encoding in file."
 msgstr ""
 
-#: ../src/common/paper.cpp:121
+#: ../src/common/paper.cpp:118
 msgid "DL Envelope, 110 x 220 mm"
 msgstr ""
 
@@ -2582,53 +2587,53 @@ msgstr ""
 msgid "Dashed"
 msgstr "Brūkšninis"
 
-#: ../src/generic/dbgrptg.cpp:300
+#: ../src/generic/dbgrptg.cpp:301
 #, c-format
 msgid "Debug report \"%s\""
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:210
+#: ../src/common/debugrpt.cpp:211
 msgid "Debug report couldn't be created."
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:553
+#: ../src/common/debugrpt.cpp:554
 msgid "Debug report generation has failed."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:84
+#: ../src/common/accelcmn.cpp:81
 msgid "Decimal"
 msgstr "Dešimtainis"
 
-#: ../src/generic/fontdlgg.cpp:323
+#: ../src/generic/fontdlgg.cpp:319
 msgid "Decorative"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1752
+#: ../src/propgrid/advprops.cpp:1653
 msgid "Default"
 msgstr "Numatytasis"
 
-#: ../src/common/fmapbase.cpp:796
+#: ../src/common/fmapbase.cpp:792
 msgid "Default encoding"
 msgstr ""
 
-#: ../src/dfb/fontmgr.cpp:180
+#: ../src/dfb/fontmgr.cpp:177
 msgid "Default font"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:510
+#: ../src/generic/prntdlgg.cpp:503
 msgid "Default printer"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:51
+#: ../src/common/accelcmn.cpp:48
 msgid "Del"
 msgstr "Ištrinti"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextbuffer.cpp:8221 ../src/common/stockitem.cpp:152
-#: ../src/common/accelcmn.cpp:50 ../src/stc/stc_i18n.cpp:20
+#: ../src/common/stockitem.cpp:149 ../src/common/accelcmn.cpp:47
+#: ../src/richtext/richtextbuffer.cpp:8217 ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Ištrinti"
 
@@ -2636,78 +2641,78 @@ msgstr "Ištrinti"
 msgid "Delete A&ll"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11341
+#: ../src/richtext/richtextbuffer.cpp:11340
 msgid "Delete Column"
 msgstr "Ištrinti stilių"
 
-#: ../src/richtext/richtextbuffer.cpp:11291
+#: ../src/richtext/richtextbuffer.cpp:11290
 msgid "Delete Row"
 msgstr "Ištrinti"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 msgid "Delete Style"
 msgstr "Ištrinti stilių"
 
-#: ../src/richtext/richtextctrl.cpp:1345 ../src/richtext/richtextctrl.cpp:1584
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
 msgid "Delete Text"
 msgstr ""
 
-#: ../src/generic/editlbox.cpp:170
+#: ../src/generic/editlbox.cpp:147
 msgid "Delete item"
 msgstr "Ištrinti elementą"
 
-#: ../src/common/stockitem.cpp:260
+#: ../src/common/stockitem.cpp:257
 msgid "Delete selection"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 #, c-format
 msgid "Delete style %s?"
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:301
+#: ../src/unix/snglinst.cpp:298
 #, c-format
 msgid "Deleted stale lock file '%s'."
 msgstr ""
 
-#: ../src/common/secretstore.cpp:220
+#: ../src/common/secretstore.cpp:234
 #, c-format
-msgid "Deleting password for \"%s/%s\" failed: %s."
+msgid "Deleting password for \"%s\" failed: %s."
 msgstr ""
 
-#: ../src/common/module.cpp:124
+#: ../src/common/module.cpp:121
 #, c-format
 msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "Descending"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:526 ../src/propgrid/advprops.cpp:882
+#: ../src/generic/dirctrlg.cpp:492 ../src/propgrid/advprops.cpp:783
 msgid "Desktop"
 msgstr "Darbastalis"
 
-#: ../src/generic/aboutdlgg.cpp:70
+#: ../src/generic/aboutdlgg.cpp:67
 msgid "Developed by "
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:176
+#: ../src/generic/aboutdlgg.cpp:173
 msgid "Developers"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:374
+#: ../src/msw/dialup.cpp:368
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
 msgstr ""
 
-#: ../src/generic/tipdlg.cpp:211
+#: ../src/generic/tipdlg.cpp:208
 msgid "Did you know..."
 msgstr "Ar žinote, kad..."
 
-#: ../src/dfb/wrapdfb.cpp:63
+#: ../src/dfb/wrapdfb.cpp:60
 #, c-format
 msgid "DirectFB error %d occurred."
 msgstr "Įvyko DirectFB klaida %d."
@@ -2716,73 +2721,73 @@ msgstr "Įvyko DirectFB klaida %d."
 msgid "Directories"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1183
+#: ../src/common/filefn.cpp:1071
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1197
+#: ../src/common/filefn.cpp:1085
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr ""
 
-#: ../src/generic/dirdlgg.cpp:204
+#: ../src/generic/dirdlgg.cpp:201
 msgid "Directory does not exist"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:1399
+#: ../src/generic/filectrlg.cpp:1388
 msgid "Directory doesn't exist."
 msgstr ""
 
-#: ../src/common/docview.cpp:457
+#: ../src/common/docview.cpp:450
 msgid "Discard changes and reload the last saved version?"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:502
+#: ../src/html/helpwnd.cpp:500
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:679
+#: ../src/html/helpwnd.cpp:677
 msgid "Display options dialog"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:322
+#: ../src/html/helpwnd.cpp:320
 msgid "Displays help as you browse the books on the left."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:85
+#: ../src/common/accelcmn.cpp:83
 msgid "Divide"
 msgstr "Padalinti"
 
-#: ../src/common/docview.cpp:533
+#: ../src/common/docview.cpp:526
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Ar norite išsaugoti %s pakeitimus?"
 
-#: ../src/common/prntbase.cpp:542
+#: ../src/common/prntbase.cpp:537
 msgid "Document:"
 msgstr "Dokumentas:"
 
-#: ../src/generic/aboutdlgg.cpp:73
+#: ../src/generic/aboutdlgg.cpp:70
 msgid "Documentation by "
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:180
+#: ../src/generic/aboutdlgg.cpp:177
 msgid "Documentation writers"
 msgstr ""
 
-#: ../src/common/sizer.cpp:2799
+#: ../src/common/sizer.cpp:2916
 msgid "Don't Save"
 msgstr "Nesaugoti"
 
-#: ../src/html/htmlwin.cpp:633
+#: ../src/html/htmlwin.cpp:643
 msgid "Done"
 msgstr "Baigta"
 
-#: ../src/generic/progdlgg.cpp:448 ../src/msw/progdlg.cpp:407
+#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
 msgid "Done."
 msgstr "Baigta."
 
@@ -2794,42 +2799,42 @@ msgstr "Taškinis"
 msgid "Double"
 msgstr "Dvigubas"
 
-#: ../src/common/paper.cpp:176
+#: ../src/common/paper.cpp:173
 msgid "Double Japanese Postcard Rotated 148 x 200 mm"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:273
+#: ../src/common/xtixml.cpp:269
 #, c-format
 msgid "Doubly used id : %d"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:153
-#: ../src/common/accelcmn.cpp:64
+#: ../src/common/stockitem.cpp:150 ../src/common/accelcmn.cpp:61
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Down"
 msgstr "Žemyn"
 
-#: ../src/richtext/richtextctrl.cpp:865
+#: ../src/richtext/richtextctrl.cpp:864
 msgid "Drag"
 msgstr "Vilkti"
 
-#: ../src/common/paper.cpp:100
+#: ../src/common/paper.cpp:97
 msgid "E sheet, 34 x 44 in"
 msgstr ""
 
-#: ../src/unix/fswatcher_inotify.cpp:561
+#: ../src/unix/fswatcher_inotify.cpp:558
 msgid "EOF while reading from inotify descriptor"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "Edit"
 msgstr "Taisyti"
 
-#: ../src/generic/editlbox.cpp:168
+#: ../src/generic/editlbox.cpp:131
 msgid "Edit item"
 msgstr ""
 
-#: ../include/wx/generic/progdlgg.h:84
+#: ../include/wx/generic/progdlgg.h:85
 msgid "Elapsed time:"
 msgstr ""
 
@@ -2896,61 +2901,61 @@ msgid "Enables the shadow spread."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:66
+#: ../src/common/accelcmn.cpp:63
 msgid "End"
 msgstr "Pabaiga"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:55
+#: ../src/common/accelcmn.cpp:52
 msgid "Enter"
 msgstr "Spausdintuvas"
 
-#: ../src/richtext/richtextstyledlg.cpp:934
+#: ../src/richtext/richtextstyledlg.cpp:930
 msgid "Enter a box style name"
 msgstr "Įveskite dėžutės stiliaus pavadinimą"
 
-#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:602
 msgid "Enter a character style name"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:816
 msgid "Enter a list style name"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:893
+#: ../src/richtext/richtextstyledlg.cpp:889
 msgid "Enter a new style name"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:650
 msgid "Enter a paragraph style name"
 msgstr ""
 
-#: ../src/generic/dbgrptg.cpp:174
+#: ../src/generic/dbgrptg.cpp:171
 #, c-format
 msgid "Enter command to open file \"%s\":"
 msgstr ""
 
-#: ../src/generic/helpext.cpp:459
+#: ../src/generic/helpext.cpp:457
 msgid "Entries found"
 msgstr ""
 
-#: ../src/common/paper.cpp:142
+#: ../src/common/paper.cpp:139
 msgid "Envelope Invite 220 x 220 mm"
 msgstr ""
 
-#: ../src/common/config.cpp:469
+#: ../src/common/config.cpp:465
 #, c-format
 msgid ""
 "Environment variables expansion failed: missing '%c' at position %u in '%s'."
 msgstr ""
 
-#: ../src/generic/filedlgg.cpp:357 ../src/generic/dirctrlg.cpp:570
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/dirctrlg.cpp:599
-#: ../src/generic/dirdlgg.cpp:323 ../src/generic/filectrlg.cpp:642
-#: ../src/generic/filectrlg.cpp:756 ../src/generic/filectrlg.cpp:770
-#: ../src/generic/filectrlg.cpp:786 ../src/generic/filectrlg.cpp:1368
-#: ../src/generic/filectrlg.cpp:1399 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/gtk1/fontdlg.cpp:74 ../src/generic/dirctrlg.cpp:536
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/dirctrlg.cpp:565
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1357 ../src/generic/filectrlg.cpp:1388
+#: ../src/generic/filedlgg.cpp:354 ../src/generic/dirdlgg.cpp:320
+#: ../src/gtk/filedlg.cpp:74
 msgid "Error"
 msgstr "Klaida"
 
@@ -2958,232 +2963,251 @@ msgstr "Klaida"
 msgid "Error closing epoll descriptor"
 msgstr ""
 
-#: ../src/unix/fswatcher_kqueue.cpp:114
+#: ../src/unix/fswatcher_kqueue.cpp:131
 msgid "Error closing kqueue instance"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1049
+#: ../src/common/filefn.cpp:938
 #, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr ""
 
-#: ../src/generic/dirdlgg.cpp:222
+#: ../src/generic/dirdlgg.cpp:219
 msgid "Error creating directory"
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1181
+#: ../src/common/imagbmp.cpp:1193
 msgid "Error in reading image DIB."
 msgstr ""
 
-#: ../src/propgrid/propgrid.cpp:6696
+#: ../src/propgrid/propgrid.cpp:6665
 #, c-format
 msgid "Error in resource: %s"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:422
+#: ../src/common/fileconf.cpp:421
 msgid "Error reading config options."
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1057 ../src/msw/webview_edge.cpp:850
+#: ../src/gtk/webview_webkit2.cpp:1262 ../src/osx/webview_webkit.mm:383
+#, c-format
+msgid "Error running JavaScript: %s"
 msgstr ""
 
 #: ../src/common/fileconf.cpp:1029
 msgid "Error saving user configuration data."
 msgstr ""
 
-#: ../src/gtk/print.cpp:722
+#: ../src/gtk/print.cpp:720
 msgid "Error while printing: "
 msgstr ""
 
-#: ../src/common/log.cpp:219
+#: ../src/common/log.cpp:237
 msgid "Error: "
 msgstr "Klaida: "
 
+#: ../src/common/webrequest.cpp:98
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Klaida: "
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:69
+#: ../src/common/accelcmn.cpp:66
 msgid "Esc"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:70
+#: ../src/common/accelcmn.cpp:67
 msgid "Escape"
 msgstr "Gulsčias"
 
-#: ../src/common/fmapbase.cpp:150
+#: ../src/common/fmapbase.cpp:147
 msgid "Esperanto (ISO-8859-3)"
 msgstr ""
 
-#: ../include/wx/generic/progdlgg.h:85
+#: ../include/wx/generic/progdlgg.h:86
 msgid "Estimated time:"
 msgstr ""
 
-#: ../src/generic/dbgrptg.cpp:234
+#: ../src/generic/dbgrptg.cpp:231
 msgid "Executable files (*.exe)|*.exe|"
 msgstr "Vykdomieji failai (*.exe)|*.exe|"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:155 ../src/common/accelcmn.cpp:78
+#: ../src/common/stockitem.cpp:152 ../src/common/accelcmn.cpp:75
 msgid "Execute"
 msgstr "Vykdyti"
 
-#: ../src/msw/utilsexc.cpp:876
+#: ../src/msw/utilsexc.cpp:873
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr ""
 
-#: ../src/common/paper.cpp:105
+#: ../src/common/paper.cpp:102
 msgid "Executive, 7 1/4 x 10 1/2 in"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6009
+#: ../src/generic/datavgen.cpp:6814
 msgid "Expand"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1240
+#: ../src/msw/registry.cpp:1228
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:195
+#: ../src/common/fmapbase.cpp:192
 msgid "Extended Unix Codepage for Japanese (EUC-JP)"
 msgstr ""
 
-#: ../src/html/chm.cpp:725
+#: ../src/html/chm.cpp:718
 #, c-format
 msgid "Extraction of '%s' into '%s' failed."
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:249 ../src/common/accelcmn.cpp:344
+#: ../src/common/accelcmn.cpp:259 ../src/common/accelcmn.cpp:358
 msgid "F"
 msgstr ""
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:672
+#: ../src/propgrid/advprops.cpp:582
 msgid "Face Name"
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:269
+#: ../src/unix/snglinst.cpp:266
 msgid "Failed to access lock file."
 msgstr ""
+
+#: ../src/gtk/font.cpp:572
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Nepavyko įkelti piktogramos \"%s\" iš resursų."
 
 #: ../src/unix/epolldispatcher.cpp:116
 #, c-format
 msgid "Failed to add descriptor %d to epoll descriptor %d"
 msgstr ""
 
-#: ../src/msw/dib.cpp:489
+#: ../src/msw/dib.cpp:535
 #, c-format
 msgid "Failed to allocate %luKb of memory for bitmap data."
 msgstr ""
 
-#: ../src/common/glcmn.cpp:115
+#: ../src/common/glcmn.cpp:112
 msgid "Failed to allocate colour for OpenGL"
 msgstr ""
 
-#: ../src/unix/displayx11.cpp:236
+#: ../src/common/lzmastream.cpp:231
+msgid "Failed to allocate memory for LZMA compression."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:121
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr ""
+
+#: ../include/wx/unix/private/displayx11.h:89
 msgid "Failed to change video mode"
 msgstr ""
 
-#: ../src/common/image.cpp:3277
+#: ../src/common/image.cpp:3396
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:239
+#: ../src/common/debugrpt.cpp:240
 #, c-format
 msgid "Failed to clean up debug report directory \"%s\""
 msgstr ""
 
-#: ../src/common/filename.cpp:192
+#: ../src/common/filename.cpp:189
 msgid "Failed to close file handle"
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:340
+#: ../src/unix/snglinst.cpp:337
 #, c-format
 msgid "Failed to close lock file '%s'"
 msgstr ""
 
-#: ../src/msw/clipbrd.cpp:112
+#: ../src/msw/clipbrd.cpp:110
 msgid "Failed to close the clipboard."
 msgstr ""
 
-#: ../src/x11/utils.cpp:208
+#: ../src/x11/utils.cpp:170
 #, c-format
 msgid "Failed to close the display \"%s\""
 msgstr ""
 
-#: ../src/msw/dialup.cpp:797
+#: ../src/msw/dialup.cpp:791
 msgid "Failed to connect: missing username/password."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:743
+#: ../src/msw/dialup.cpp:737
 msgid "Failed to connect: no ISP to dial."
 msgstr ""
 
-#: ../src/common/textfile.cpp:203
-#, c-format
-msgid "Failed to convert file \"%s\" to Unicode."
-msgstr ""
-
-#: ../src/generic/logg.cpp:956
+#: ../src/generic/logg.cpp:953
 msgid "Failed to copy dialog contents to the clipboard."
 msgstr ""
 
-#: ../src/msw/registry.cpp:692
+#: ../src/msw/registry.cpp:681
 #, c-format
 msgid "Failed to copy registry value '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:701
+#: ../src/msw/registry.cpp:690
 #, c-format
 msgid "Failed to copy the contents of registry key '%s' to '%s'."
 msgstr ""
 
-#: ../src/common/filefn.cpp:1015
+#: ../src/common/filefn.cpp:904
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:679
+#: ../src/msw/registry.cpp:668
 #, c-format
 msgid "Failed to copy the registry subkey '%s' to '%s'."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1070
+#: ../src/msw/dde.cpp:1134
 msgid "Failed to create DDE string"
 msgstr ""
 
-#: ../src/msw/mdi.cpp:616
+#: ../src/msw/mdi.cpp:621
 msgid "Failed to create MDI parent frame."
 msgstr ""
 
-#: ../src/common/filename.cpp:1027
+#: ../src/common/filename.cpp:1024
 msgid "Failed to create a temporary file name"
 msgstr ""
 
-#: ../src/msw/utilsexc.cpp:228
+#: ../src/msw/utilsexc.cpp:225
 msgid "Failed to create an anonymous pipe"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:522
+#: ../src/msw/ole/automtn.cpp:513
 #, c-format
 msgid "Failed to create an instance of \"%s\""
 msgstr ""
 
-#: ../src/msw/dde.cpp:437
+#: ../src/msw/dde.cpp:432
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr ""
 
-#: ../src/msw/cursor.cpp:204
+#: ../src/msw/cursor.cpp:195
 msgid "Failed to create cursor."
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:209
+#: ../src/common/debugrpt.cpp:210
 #, c-format
 msgid "Failed to create directory \"%s\""
 msgstr ""
 
-#: ../src/generic/dirdlgg.cpp:220
+#: ../src/generic/dirdlgg.cpp:217
 #, c-format
 msgid ""
 "Failed to create directory '%s'\n"
@@ -3194,184 +3218,202 @@ msgstr ""
 msgid "Failed to create epoll descriptor"
 msgstr ""
 
-#: ../src/msw/mimetype.cpp:238
+#: ../src/gtk/font.cpp:562
+msgid "Failed to create font configuration object."
+msgstr ""
+
+#: ../src/msw/mimetype.cpp:235
 #, c-format
 msgid "Failed to create registry entry for '%s' files."
 msgstr ""
 
-#: ../src/msw/fdrepdlg.cpp:409
+#: ../src/msw/fdrepdlg.cpp:408
 #, c-format
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr ""
 
-#: ../src/unix/wakeuppipe.cpp:52
+#: ../src/unix/wakeuppipe.cpp:49
 msgid "Failed to create wake up pipe used by event loop."
 msgstr ""
 
-#: ../src/html/winpars.cpp:730
+#: ../src/html/winpars.cpp:727
 #, c-format
 msgid "Failed to display HTML document in %s encoding"
 msgstr ""
 
-#: ../src/msw/clipbrd.cpp:124
+#: ../src/msw/clipbrd.cpp:122
 msgid "Failed to empty the clipboard."
 msgstr ""
 
-#: ../src/unix/displayx11.cpp:212
+#: ../include/wx/unix/private/displayx11.h:65
 msgid "Failed to enumerate video modes"
 msgstr ""
 
-#: ../src/msw/dde.cpp:722
+#: ../src/msw/dde.cpp:717
 msgid "Failed to establish an advise loop with DDE server"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:629 ../src/msw/dialup.cpp:863
+#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:611
+#: ../src/unix/utilsunx.cpp:613
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:720
+#: ../src/common/debugrpt.cpp:730
 msgid "Failed to execute curl, please install it in PATH."
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:505
+#: ../src/msw/ole/automtn.cpp:496
 #, c-format
 msgid "Failed to find CLSID of \"%s\""
 msgstr ""
 
-#: ../src/common/regex.cpp:431 ../src/common/regex.cpp:479
+#: ../src/common/regex.cpp:428 ../src/common/regex.cpp:476
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:695
+#: ../src/msw/webview_ie.cpp:978
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:689
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:574
+#: ../src/msw/ole/automtn.cpp:565
 #, c-format
 msgid "Failed to get OLE automation interface for \"%s\""
 msgstr ""
 
-#: ../src/msw/clipbrd.cpp:711
+#: ../src/msw/clipbrd.cpp:731
 msgid "Failed to get data from the clipboard"
 msgstr ""
 
-#: ../src/common/time.cpp:223
+#: ../src/common/time.cpp:216
 msgid "Failed to get the local system time"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1345
+#: ../src/common/filefn.cpp:1233
 msgid "Failed to get the working directory"
 msgstr ""
 
-#: ../src/univ/theme.cpp:114
+#: ../src/univ/theme.cpp:111
 msgid "Failed to initialize GUI: no built-in themes found."
 msgstr ""
 
-#: ../src/msw/helpchm.cpp:63
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:60
 msgid "Failed to initialize MS HTML Help."
 msgstr ""
 
-#: ../src/msw/glcanvas.cpp:1381
+#: ../src/msw/glcanvas.cpp:1391
 msgid "Failed to initialize OpenGL"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:858
+#: ../src/msw/dialup.cpp:852
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr ""
 
-#: ../src/gtk/textctrl.cpp:1128
+#: ../src/gtk/textctrl.cpp:1209
 msgid "Failed to insert text in the control."
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:241
+#: ../src/unix/snglinst.cpp:238
 #, c-format
 msgid "Failed to inspect the lock file '%s'"
 msgstr ""
 
-#: ../src/unix/appunix.cpp:182
+#: ../src/unix/appunix.cpp:179
 msgid "Failed to install signal handler"
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1167
+#: ../src/unix/threadpsx.cpp:1216
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
 msgstr ""
 
-#: ../src/msw/utils.cpp:629
+#: ../src/msw/utils.cpp:619
 #, c-format
 msgid "Failed to kill process %d"
 msgstr ""
 
-#: ../src/common/image.cpp:2500
+#: ../src/common/image.cpp:2595
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Nepavyko įkelti taškinės grafikos \"%s\" iš resursų."
 
-#: ../src/common/image.cpp:2509
+#: ../src/common/image.cpp:2604
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Nepavyko įkelti piktogramos \"%s\" iš resursų."
 
-#: ../src/common/iconbndl.cpp:225
+#: ../src/common/iconbndl.cpp:224
 #, fuzzy, c-format
 msgid "Failed to load icons from resource '%s'."
 msgstr "Nepavyko įkelti piktogramos \"%s\" iš resursų."
 
-#: ../src/common/iconbndl.cpp:200
+#: ../src/common/iconbndl.cpp:198
 #, c-format
 msgid "Failed to load image %%d from file '%s'."
 msgstr ""
 
-#: ../src/common/iconbndl.cpp:208
+#: ../src/common/iconbndl.cpp:206
 #, c-format
 msgid "Failed to load image %d from stream."
 msgstr ""
 
-#: ../src/common/image.cpp:2587 ../src/common/image.cpp:2606
+#: ../src/common/image.cpp:2682 ../src/common/image.cpp:2701
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr ""
 
-#: ../src/msw/enhmeta.cpp:97
+#: ../src/msw/enhmeta.cpp:94
 #, c-format
 msgid "Failed to load metafile from file \"%s\"."
 msgstr ""
 
-#: ../src/msw/volume.cpp:327
+#: ../src/msw/volume.cpp:335
 msgid "Failed to load mpr.dll."
 msgstr ""
 
-#: ../src/msw/utils.cpp:953
+#: ../src/msw/utils.cpp:943
 #, c-format
 msgid "Failed to load resource \"%s\"."
 msgstr ""
 
-#: ../src/common/dynlib.cpp:92
+#: ../src/common/dynlib.cpp:86
 #, c-format
 msgid "Failed to load shared library '%s'"
 msgstr ""
 
-#: ../src/osx/core/sound.cpp:145
+#: ../src/osx/core/sound.cpp:143
 #, c-format
 msgid "Failed to load sound from \"%s\" (error %d)."
 msgstr ""
 
-#: ../src/msw/utils.cpp:960
+#: ../src/msw/utils.cpp:950
 #, c-format
 msgid "Failed to lock resource \"%s\"."
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:198
+#: ../src/unix/snglinst.cpp:195
 #, c-format
 msgid "Failed to lock the lock file '%s'"
 msgstr ""
@@ -3381,33 +3423,38 @@ msgstr ""
 msgid "Failed to modify descriptor %d in epoll descriptor %d"
 msgstr ""
 
-#: ../src/common/filename.cpp:2575
+#: ../src/common/filename.cpp:2658
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr ""
 
-#: ../src/common/selectdispatcher.cpp:258
+#: ../src/common/selectdispatcher.cpp:255
 msgid "Failed to monitor I/O channels"
 msgstr ""
 
-#: ../src/common/filename.cpp:175
+#: ../src/common/filename.cpp:172
 #, c-format
 msgid "Failed to open '%s' for reading"
 msgstr ""
 
-#: ../src/common/filename.cpp:180
+#: ../src/common/filename.cpp:177
 #, c-format
 msgid "Failed to open '%s' for writing"
 msgstr ""
 
-#: ../src/html/chm.cpp:141
+#: ../src/html/chm.cpp:138
 #, c-format
 msgid "Failed to open CHM archive '%s'."
 msgstr ""
 
-#: ../src/common/utilscmn.cpp:1126
+#: ../src/common/utilscmn.cpp:1140
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
+msgstr ""
+
+#: ../src/common/hyperlnkcmn.cpp:133
+#, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
 msgstr ""
 
 #: ../include/wx/msw/private/fswatcher.h:92
@@ -3415,208 +3462,225 @@ msgstr ""
 msgid "Failed to open directory \"%s\" for monitoring."
 msgstr ""
 
-#: ../src/x11/utils.cpp:227
+#: ../src/x11/utils.cpp:189
 #, c-format
 msgid "Failed to open display \"%s\"."
 msgstr ""
 
-#: ../src/common/filename.cpp:1062
+#: ../src/common/filename.cpp:1059
 msgid "Failed to open temporary file."
 msgstr ""
 
-#: ../src/msw/clipbrd.cpp:91
+#: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr ""
 
-#: ../src/common/translation.cpp:1184
+#: ../src/common/translation.cpp:1226
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr ""
 
-#: ../src/unix/mediactrl.cpp:1214
+#: ../src/unix/mediactrl.cpp:1239
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Nepavyko paruošti grojimui \"%s\"."
 
-#: ../src/msw/clipbrd.cpp:600
+#: ../src/msw/clipbrd.cpp:610
 msgid "Failed to put data on the clipboard"
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:278
+#: ../src/unix/snglinst.cpp:275
 msgid "Failed to read PID from lock file."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:433
+#: ../src/common/fileconf.cpp:432
 msgid "Failed to read config options."
 msgstr ""
 
-#: ../src/common/docview.cpp:681
+#: ../src/common/docview.cpp:676
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr ""
 
-#: ../src/dfb/evtloop.cpp:98
+#: ../src/dfb/evtloop.cpp:99
 msgid "Failed to read event from DirectFB pipe"
 msgstr ""
 
-#: ../src/unix/wakeuppipe.cpp:120
+#: ../src/unix/wakeuppipe.cpp:117
 msgid "Failed to read from wake-up pipe"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:679
+#: ../src/common/textfile.cpp:96
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Nepavyko paruošti grojimui \"%s\"."
+
+#: ../src/unix/utilsunx.cpp:681
 msgid "Failed to redirect child process input/output"
 msgstr ""
 
-#: ../src/msw/utilsexc.cpp:701
+#: ../src/msw/utilsexc.cpp:698
 msgid "Failed to redirect the child process IO"
 msgstr ""
 
-#: ../src/msw/dde.cpp:288
+#: ../src/msw/dde.cpp:283
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr ""
 
-#: ../src/common/fontmap.cpp:245
+#: ../src/gtk/font.cpp:580
+msgid "Failed to register font configuration using private fonts."
+msgstr ""
+
+#: ../src/common/fontmap.cpp:242
 #, c-format
 msgid "Failed to remember the encoding for the charset '%s'."
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:227
+#: ../src/common/debugrpt.cpp:228
 #, c-format
 msgid "Failed to remove debug report file \"%s\""
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:328
+#: ../src/unix/snglinst.cpp:325
 #, c-format
 msgid "Failed to remove lock file '%s'"
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:288
+#: ../src/unix/snglinst.cpp:285
 #, c-format
 msgid "Failed to remove stale lock file '%s'."
 msgstr ""
 
-#: ../src/msw/registry.cpp:529
+#: ../src/msw/registry.cpp:518
 #, c-format
 msgid "Failed to rename registry value '%s' to '%s'."
 msgstr ""
 
-#: ../src/common/filefn.cpp:1122
+#: ../src/common/filefn.cpp:1011
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
 "exists."
 msgstr ""
 
-#: ../src/msw/registry.cpp:634
+#: ../src/msw/registry.cpp:623
 #, c-format
 msgid "Failed to rename the registry key '%s' to '%s'."
 msgstr ""
 
-#: ../src/common/filename.cpp:2671
+#: ../src/msw/webview_ie.cpp:995
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/common/filename.cpp:2754
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:468
+#: ../src/msw/dialup.cpp:462
 msgid "Failed to retrieve text of RAS error message"
 msgstr ""
 
-#: ../src/msw/clipbrd.cpp:748
+#: ../src/msw/clipbrd.cpp:768
 msgid "Failed to retrieve the supported clipboard formats"
 msgstr ""
 
-#: ../src/common/docview.cpp:652
+#: ../src/common/docview.cpp:647
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr ""
 
-#: ../src/msw/dib.cpp:269
+#: ../src/msw/dib.cpp:312
 #, c-format
 msgid "Failed to save the bitmap image to file \"%s\"."
 msgstr ""
 
-#: ../src/msw/dde.cpp:763
+#: ../src/msw/dde.cpp:811
 msgid "Failed to send DDE advise notification"
 msgstr ""
 
-#: ../src/common/ftp.cpp:402
+#: ../src/common/ftp.cpp:399
 #, c-format
 msgid "Failed to set FTP transfer mode to %s."
 msgstr ""
 
-#: ../src/msw/clipbrd.cpp:427
+#: ../src/msw/clipbrd.cpp:443
 msgid "Failed to set clipboard data."
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:181
+#: ../src/unix/snglinst.cpp:178
 #, c-format
 msgid "Failed to set permissions on lock file '%s'"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:668
+#: ../src/unix/utilsunx.cpp:670
 msgid "Failed to set process priority"
 msgstr ""
 
-#: ../src/common/file.cpp:559
+#: ../src/common/ffile.cpp:355 ../src/common/file.cpp:586
 msgid "Failed to set temporary file permissions"
 msgstr ""
 
-#: ../src/gtk/textctrl.cpp:1072
-msgid "Failed to set text in the text control."
-msgstr ""
-
-#: ../src/unix/threadpsx.cpp:1298
+#: ../src/unix/threadpsx.cpp:1347
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Nepavyko nustatyti gijų sutapimo lygmens į %lu"
 
-#: ../src/unix/threadpsx.cpp:1424
+#: ../src/unix/threadpsx.cpp:1473
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:783
+#: ../src/unix/utilsunx.cpp:785
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 
-#: ../src/common/fs_mem.cpp:261
+#: ../src/msw/webview_ie.cpp:987
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:256
 #, c-format
 msgid "Failed to store image '%s' to memory VFS!"
 msgstr ""
 
-#: ../src/dfb/evtloop.cpp:170
+#: ../src/dfb/evtloop.cpp:171
 msgid "Failed to switch DirectFB pipe to non-blocking mode"
 msgstr ""
 
-#: ../src/unix/wakeuppipe.cpp:59
+#: ../src/unix/wakeuppipe.cpp:56
 msgid "Failed to switch wake up pipe to non-blocking mode"
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1605
+#: ../src/unix/threadpsx.cpp:1654
 msgid "Failed to terminate a thread."
 msgstr ""
 
-#: ../src/msw/dde.cpp:741
+#: ../src/msw/dde.cpp:736
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:938
+#: ../src/msw/dialup.cpp:932
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr ""
 
-#: ../src/common/filename.cpp:2590
+#: ../src/common/filename.cpp:2673
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:334
+#: ../src/unix/dlunix.cpp:90
+msgid "Failed to unload shared library"
+msgstr ""
+
+#: ../src/unix/snglinst.cpp:331
 #, c-format
 msgid "Failed to unlock lock file '%s'"
 msgstr ""
 
-#: ../src/msw/dde.cpp:309
+#: ../src/msw/dde.cpp:304
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr ""
@@ -3630,77 +3694,86 @@ msgstr ""
 msgid "Failed to update user configuration file."
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:733
+#: ../src/common/debugrpt.cpp:743
 #, c-format
 msgid "Failed to upload the debug report (error code %d)."
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:168
+#: ../src/unix/snglinst.cpp:165
 #, c-format
 msgid "Failed to write to lock file '%s'"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:209
+#: ../src/propgrid/propgrid.cpp:190
 msgid "False"
 msgstr "Klaidingas"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:694
+#: ../src/propgrid/advprops.cpp:604
 msgid "Family"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/gtk/glcanvas.cpp:176 ../src/gtk/glcanvas.cpp:187
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Klaida"
+
+#: ../src/common/stockitem.cpp:154
 msgid "File"
 msgstr "Failas"
 
-#: ../src/common/docview.cpp:669
+#: ../src/common/docview.cpp:664
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr ""
 
-#: ../src/common/docview.cpp:646
+#: ../src/common/docview.cpp:641
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr ""
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1156
+#: ../src/common/filefn.cpp:1044
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Failas '%s' negali būti pašalintas"
 
-#: ../src/common/filefn.cpp:1139
+#: ../src/common/filefn.cpp:1028
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Failas '%s' negali būti pervadintas į '%s'"
 
-#: ../src/richtext/richtextctrl.cpp:3081 ../src/common/textcmn.cpp:953
+#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
 msgid "File couldn't be loaded."
 msgstr ""
 
-#: ../src/msw/filedlg.cpp:393
+#: ../src/msw/filedlg.cpp:414
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr ""
 
-#: ../src/common/docview.cpp:1789
+#: ../src/common/docview.cpp:1783
 msgid "File error"
 msgstr ""
 
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/filectrlg.cpp:770
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/filectrlg.cpp:766
 msgid "File name exists already."
 msgstr "Toks failo pavadinimas jau yra."
+
+#: ../src/osx/cocoa/filedlg.mm:264
+msgid "File type:"
+msgstr ""
 
 #: ../src/motif/filedlg.cpp:220
 msgid "Files"
 msgstr "Failai"
 
-#: ../src/common/filefn.cpp:1591
+#: ../src/common/filefn.cpp:1479
 #, c-format
 msgid "Files (%s)"
 msgstr ""
@@ -3709,15 +3782,28 @@ msgstr ""
 msgid "Filter"
 msgstr "FILTER"
 
-#: ../src/common/stockitem.cpp:158 ../src/html/helpwnd.cpp:490
+#: ../src/html/helpwnd.cpp:488
 msgid "Find"
 msgstr "Rasti"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:259
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:258
+msgid "Find in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "Find..."
+msgstr "Rasti"
+
+#: ../src/common/stockitem.cpp:156
 msgid "First"
 msgstr "Pirmas"
 
-#: ../src/common/prntbase.cpp:1548
+#: ../src/common/prntbase.cpp:1573
 msgid "First page"
 msgstr ""
 
@@ -3725,11 +3811,11 @@ msgstr ""
 msgid "Fixed"
 msgstr "Ištaisyta"
 
-#: ../src/html/helpwnd.cpp:1206
+#: ../src/html/helpwnd.cpp:1204
 msgid "Fixed font:"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1269
+#: ../src/html/helpwnd.cpp:1267
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr ""
 
@@ -3737,16 +3823,16 @@ msgstr ""
 msgid "Floating"
 msgstr "Plaukiojantis"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "Floppy"
 msgstr ""
 
-#: ../src/common/paper.cpp:111
+#: ../src/common/paper.cpp:108
 msgid "Folio, 8 1/2 x 13 in"
 msgstr ""
 
-#: ../src/richtext/richtextformatdlg.cpp:344 ../src/osx/carbon/fontdlg.cpp:287
-#: ../src/common/stockitem.cpp:194
+#: ../src/osx/carbon/fontdlg.cpp:284 ../src/common/stockitem.cpp:191
+#: ../src/richtext/richtextformatdlg.cpp:337
 msgid "Font"
 msgstr "Šriftas"
 
@@ -3754,7 +3840,24 @@ msgstr "Šriftas"
 msgid "Font &weight:"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1207
+#: ../src/osx/fontutil.cpp:89
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
+"\"."
+msgstr ""
+
+#: ../src/msw/font.cpp:1126
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Failas '%s' negali būti pašalintas"
+
+#: ../src/osx/fontutil.cpp:81
+#, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1205
 msgid "Font size:"
 msgstr "Šrifto dydis:"
 
@@ -3762,53 +3865,53 @@ msgstr "Šrifto dydis:"
 msgid "Font st&yle:"
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:329
+#: ../src/osx/carbon/fontdlg.cpp:326
 msgid "Font:"
 msgstr "Šriftas:"
 
-#: ../src/dfb/fontmgr.cpp:198
+#: ../src/dfb/fontmgr.cpp:195
 #, c-format
 msgid "Fonts index file %s disappeared while loading fonts."
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:645
+#: ../src/unix/utilsunx.cpp:647
 msgid "Fork failed"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "Forward"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:235
+#: ../src/common/xtixml.cpp:231
 msgid "Forward hrefs are not supported"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:875
+#: ../src/html/helpwnd.cpp:873
 #, c-format
 msgid "Found %i matches"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:238
+#: ../src/generic/prntdlgg.cpp:231
 msgid "From:"
 msgstr "Nuo:"
 
-#: ../src/propgrid/advprops.cpp:1604
+#: ../src/propgrid/advprops.cpp:1510
 msgid "Fuchsia"
 msgstr ""
 
-#: ../src/common/imaggif.cpp:138
+#: ../src/common/imaggif.cpp:135
 msgid "GIF: data stream seems to be truncated."
 msgstr ""
 
-#: ../src/common/imaggif.cpp:128
+#: ../src/common/imaggif.cpp:125
 msgid "GIF: error in GIF image format."
 msgstr ""
 
-#: ../src/common/imaggif.cpp:133
+#: ../src/common/imaggif.cpp:130
 msgid "GIF: not enough memory."
 msgstr ""
 
-#: ../src/gtk/window.cpp:4631
+#: ../src/gtk/window.cpp:5635
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -3816,23 +3919,23 @@ msgstr ""
 "GTK+ įdiegtas šiame kompiuteryje yra per senas, kad palaikytų komponavimą "
 "ekrane, prašome instaliuoti GTK+ 2.12 arba naujesnį."
 
-#: ../src/univ/themes/gtk.cpp:525
+#: ../src/univ/themes/gtk.cpp:522
 msgid "GTK+ theme"
 msgstr ""
 
-#: ../src/common/preferencescmn.cpp:40
+#: ../src/common/preferencescmn.cpp:37
 msgid "General"
 msgstr "Bendra"
 
-#: ../src/common/prntbase.cpp:258
+#: ../src/common/prntbase.cpp:253
 msgid "Generic PostScript"
 msgstr ""
 
-#: ../src/common/paper.cpp:135
+#: ../src/common/paper.cpp:132
 msgid "German Legal Fanfold, 8 1/2 x 13 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:134
+#: ../src/common/paper.cpp:131
 msgid "German Std Fanfold, 8 1/2 x 12 in"
 msgstr ""
 
@@ -3848,48 +3951,48 @@ msgstr ""
 msgid "GetPropertyCollection called w/o valid collection getter"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:658
 msgid "Go back"
 msgstr "Eiti atgal"
 
-#: ../src/html/helpwnd.cpp:661
+#: ../src/html/helpwnd.cpp:659
 msgid "Go forward"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:663
+#: ../src/html/helpwnd.cpp:661
 msgid "Go one level up in document hierarchy"
 msgstr ""
 
-#: ../src/generic/filedlgg.cpp:208 ../src/generic/dirdlgg.cpp:116
+#: ../src/generic/filedlgg.cpp:205 ../src/generic/dirdlgg.cpp:113
 msgid "Go to home directory"
 msgstr ""
 
-#: ../src/generic/filedlgg.cpp:205
+#: ../src/generic/filedlgg.cpp:202
 msgid "Go to parent directory"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:76
+#: ../src/generic/aboutdlgg.cpp:73
 msgid "Graphics art by "
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1599
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Gray"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:883
+#: ../src/propgrid/advprops.cpp:784
 msgid "GrayText"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:154
+#: ../src/common/fmapbase.cpp:151
 msgid "Greek (ISO-8859-7)"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1600
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Green"
 msgstr "Žalia"
 
-#: ../src/generic/colrdlgg.cpp:342
+#: ../src/generic/colrdlgg.cpp:362
 #, fuzzy
 msgid "Green:"
 msgstr "Žalia"
@@ -3898,107 +4001,107 @@ msgstr "Žalia"
 msgid "Groove"
 msgstr ""
 
-#: ../src/common/zstream.cpp:158 ../src/common/zstream.cpp:318
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
 msgid "Gzip not supported by this version of zlib"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1549
+#: ../src/html/helpwnd.cpp:1547
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr ""
 
-#: ../src/html/htmlwin.cpp:681
+#: ../src/html/htmlwin.cpp:691
 #, c-format
 msgid "HTML anchor %s does not exist."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1547
+#: ../src/html/helpwnd.cpp:1545
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1759
+#: ../src/propgrid/advprops.cpp:1660
 msgid "Hand"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "Harddisk"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:155
+#: ../src/common/fmapbase.cpp:152
 msgid "Hebrew (ISO-8859-8)"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:280 ../src/osx/button_osx.cpp:39
-#: ../src/common/stockitem.cpp:163 ../src/common/accelcmn.cpp:80
-#: ../src/html/helpdlg.cpp:66 ../src/html/helpfrm.cpp:111
+#: ../include/wx/msgdlg.h:282 ../src/osx/button_osx.cpp:39
+#: ../src/common/stockitem.cpp:160 ../src/common/accelcmn.cpp:77
+#: ../src/html/helpfrm.cpp:108 ../src/html/helpdlg.cpp:63
 msgid "Help"
 msgstr "Pagalba"
 
-#: ../src/html/helpwnd.cpp:1200
+#: ../src/html/helpwnd.cpp:1198
 msgid "Help Browser Options"
 msgstr ""
 
-#: ../src/generic/helpext.cpp:454 ../src/generic/helpext.cpp:455
+#: ../src/generic/helpext.cpp:452 ../src/generic/helpext.cpp:453
 msgid "Help Index"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1529
 msgid "Help Printing"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:801
+#: ../src/html/helpwnd.cpp:799
 msgid "Help Topics"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1546
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr ""
 
-#: ../src/generic/helpext.cpp:267
+#: ../src/generic/helpext.cpp:265
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:275
+#: ../src/generic/helpext.cpp:273
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr ""
 
-#: ../src/html/helpctrl.cpp:63
+#: ../src/html/helpctrl.cpp:59
 #, c-format
 msgid "Help: %s"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:577
+#: ../src/osx/menu_osx.cpp:469
 #, c-format
 msgid "Hide %s"
 msgstr "Slėpti %s"
 
-#: ../src/osx/menu_osx.cpp:579
+#: ../src/osx/menu_osx.cpp:471
 msgid "Hide Others"
 msgstr ""
 
-#: ../src/generic/infobar.cpp:84
+#: ../src/generic/infobar.cpp:81
 msgid "Hide this notification message."
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:884
+#: ../src/propgrid/advprops.cpp:785
 msgid "Highlight"
 msgstr "&Aukštis"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:885
+#: ../src/propgrid/advprops.cpp:786
 msgid "HighlightText"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:164 ../src/common/accelcmn.cpp:65
+#: ../src/common/stockitem.cpp:161 ../src/common/accelcmn.cpp:62
 msgid "Home"
 msgstr "Pagrindinis"
 
-#: ../src/generic/dirctrlg.cpp:524
+#: ../src/generic/dirctrlg.cpp:490
 msgid "Home directory"
 msgstr ""
 
@@ -4008,61 +4111,61 @@ msgid "How the object will float relative to the text."
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1760
+#: ../src/propgrid/advprops.cpp:1661
 msgid "I-Beam"
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1196
+#: ../src/common/imagbmp.cpp:1208
 msgid "ICO: Error in reading mask DIB."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1290 ../src/common/imagbmp.cpp:1390
-#: ../src/common/imagbmp.cpp:1405 ../src/common/imagbmp.cpp:1416
-#: ../src/common/imagbmp.cpp:1430 ../src/common/imagbmp.cpp:1478
-#: ../src/common/imagbmp.cpp:1493 ../src/common/imagbmp.cpp:1507
-#: ../src/common/imagbmp.cpp:1518
+#: ../src/common/imagbmp.cpp:1302 ../src/common/imagbmp.cpp:1402
+#: ../src/common/imagbmp.cpp:1417 ../src/common/imagbmp.cpp:1428
+#: ../src/common/imagbmp.cpp:1442 ../src/common/imagbmp.cpp:1490
+#: ../src/common/imagbmp.cpp:1505 ../src/common/imagbmp.cpp:1519
+#: ../src/common/imagbmp.cpp:1530
 msgid "ICO: Error writing the image file!"
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1255
+#: ../src/common/imagbmp.cpp:1267
 msgid "ICO: Image too tall for an icon."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1263
+#: ../src/common/imagbmp.cpp:1275
 msgid "ICO: Image too wide for an icon."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1603
+#: ../src/common/imagbmp.cpp:1615
 msgid "ICO: Invalid icon index."
 msgstr ""
 
-#: ../src/common/imagiff.cpp:758
+#: ../src/common/imagiff.cpp:755
 msgid "IFF: data stream seems to be truncated."
 msgstr ""
 
-#: ../src/common/imagiff.cpp:742
+#: ../src/common/imagiff.cpp:739
 msgid "IFF: error in IFF image format."
 msgstr ""
 
-#: ../src/common/imagiff.cpp:745
+#: ../src/common/imagiff.cpp:742
 msgid "IFF: not enough memory."
 msgstr ""
 
-#: ../src/common/imagiff.cpp:748
+#: ../src/common/imagiff.cpp:745
 msgid "IFF: unknown error!!!"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:197
+#: ../src/common/fmapbase.cpp:194
 msgid "ISO-2022-JP"
 msgstr ""
 
-#: ../src/html/htmprint.cpp:282
+#: ../src/html/htmprint.cpp:294
 msgid ""
 "If possible, try changing the layout parameters to make the printout more "
 "narrow."
 msgstr ""
 
-#: ../src/generic/dbgrptg.cpp:358
+#: ../src/generic/dbgrptg.cpp:362
 msgid ""
 "If you have any additional information pertaining to this bug\n"
 "report, please enter it here and it will be joined to it:"
@@ -4076,145 +4179,149 @@ msgid ""
 "at all possible please do continue with the report generation.\n"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1405
+#: ../src/common/zipstrm.cpp:1043
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1393
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:295
+#: ../src/common/xtistrm.cpp:292
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr ""
 
-#: ../src/common/xti.cpp:513
+#: ../src/common/xti.cpp:510
 msgid "Illegal Parameter Count for ConstructObject Method"
 msgstr ""
 
-#: ../src/common/xti.cpp:501
+#: ../src/common/xti.cpp:498
 msgid "Illegal Parameter Count for Create Method"
 msgstr ""
 
-#: ../src/generic/dirctrlg.cpp:570 ../src/generic/filectrlg.cpp:756
+#: ../src/generic/dirctrlg.cpp:536 ../src/generic/filectrlg.cpp:752
 msgid "Illegal directory name."
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:1367
+#: ../src/generic/filectrlg.cpp:1356
 msgid "Illegal file specification."
 msgstr ""
 
-#: ../src/common/image.cpp:2269
+#: ../src/common/image.cpp:2363
 msgid "Image and mask have different sizes."
 msgstr ""
 
-#: ../src/common/image.cpp:2746
+#: ../src/common/image.cpp:2841
 #, c-format
 msgid "Image file is not of type %d."
 msgstr ""
 
-#: ../src/common/image.cpp:2877
+#: ../src/common/image.cpp:2995
 #, c-format
 msgid "Image is not of type %s."
 msgstr ""
 
-#: ../src/msw/textctrl.cpp:488
+#: ../src/msw/textctrl.cpp:534
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:301
+#: ../src/unix/utilsunx.cpp:303
 msgid "Impossible to get child process input"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1028
+#: ../src/common/filefn.cpp:917
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1042
+#: ../src/common/filefn.cpp:931
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1097
+#: ../src/common/filefn.cpp:986
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:886
+#: ../src/propgrid/advprops.cpp:787
 msgid "InactiveBorder"
 msgstr "Rėmelis"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:887
+#: ../src/propgrid/advprops.cpp:788
 msgid "InactiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:888
+#: ../src/propgrid/advprops.cpp:789
 msgid "InactiveCaptionText"
 msgstr ""
 
-#: ../src/common/gifdecod.cpp:792
+#: ../src/common/gifdecod.cpp:826
 #, c-format
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:635
+#: ../src/msw/ole/automtn.cpp:626
 msgid "Incorrect number of arguments."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:165
+#: ../src/common/stockitem.cpp:162
 msgid "Indent"
 msgstr ""
 
-#: ../src/richtext/richtextformatdlg.cpp:349
+#: ../src/richtext/richtextformatdlg.cpp:342
 msgid "Indents && Spacing"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:166 ../src/html/helpwnd.cpp:515
+#: ../src/common/stockitem.cpp:163 ../src/html/helpwnd.cpp:513
 msgid "Index"
 msgstr "Indeksas"
 
-#: ../src/common/fmapbase.cpp:159
+#: ../src/common/fmapbase.cpp:156
 msgid "Indian (ISO-8859-12)"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "Info"
 msgstr ""
 
-#: ../src/common/init.cpp:287
+#: ../src/common/init.cpp:284
 msgid "Initialization failed in post init, aborting."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:54
+#: ../src/common/accelcmn.cpp:51
 msgid "Ins"
 msgstr "Įterpti"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextsymboldlg.cpp:472 ../src/common/accelcmn.cpp:53
+#: ../src/common/accelcmn.cpp:50 ../src/richtext/richtextsymboldlg.cpp:469
 msgid "Insert"
 msgstr "Įterpti"
 
-#: ../src/richtext/richtextbuffer.cpp:8067
+#: ../src/richtext/richtextbuffer.cpp:8063
 msgid "Insert Field"
 msgstr "Įterpti"
 
-#: ../src/richtext/richtextbuffer.cpp:7978
-#: ../src/richtext/richtextbuffer.cpp:8936
+#: ../src/richtext/richtextbuffer.cpp:7974
+#: ../src/richtext/richtextbuffer.cpp:8934
 msgid "Insert Image"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:8025
+#: ../src/richtext/richtextbuffer.cpp:8021
 msgid "Insert Object"
 msgstr "Įterpti objektą"
 
-#: ../src/richtext/richtextctrl.cpp:1286 ../src/richtext/richtextctrl.cpp:1494
-#: ../src/richtext/richtextbuffer.cpp:7822
-#: ../src/richtext/richtextbuffer.cpp:7852
-#: ../src/richtext/richtextbuffer.cpp:7894
+#: ../src/richtext/richtextbuffer.cpp:7818
+#: ../src/richtext/richtextbuffer.cpp:7848
+#: ../src/richtext/richtextbuffer.cpp:7890
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
 msgid "Insert Text"
 msgstr ""
 
@@ -4227,16 +4334,11 @@ msgstr ""
 msgid "Inset"
 msgstr ""
 
-#: ../src/gtk/app.cpp:425
-#, c-format
-msgid "Invalid GTK+ command line option, use \"%s --help\""
-msgstr ""
-
-#: ../src/common/imagtiff.cpp:311
+#: ../src/common/imagtiff.cpp:308
 msgid "Invalid TIFF image index."
 msgstr ""
 
-#: ../src/common/appcmn.cpp:273
+#: ../src/common/appcmn.cpp:294
 #, c-format
 msgid "Invalid display mode specification '%s'."
 msgstr ""
@@ -4246,246 +4348,250 @@ msgstr ""
 msgid "Invalid geometry specification '%s'"
 msgstr ""
 
-#: ../src/unix/fswatcher_inotify.cpp:323
+#: ../src/unix/fswatcher_inotify.cpp:320
 #, c-format
 msgid "Invalid inotify event for \"%s\""
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:312
+#: ../src/unix/snglinst.cpp:309
 #, c-format
 msgid "Invalid lock file '%s'."
 msgstr ""
 
-#: ../src/common/translation.cpp:1125
+#: ../src/common/translation.cpp:1167
 msgid "Invalid message catalog."
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:405 ../src/common/xtistrm.cpp:420
+#: ../src/common/xtistrm.cpp:402 ../src/common/xtistrm.cpp:417
 msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:435
+#: ../src/common/xtistrm.cpp:432
 msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
 msgstr ""
 
-#: ../src/common/regex.cpp:310
+#: ../src/common/regex.cpp:307
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr ""
 
-#: ../src/common/config.cpp:226
+#: ../src/common/config.cpp:222
 #, c-format
 msgid "Invalid value %ld for a boolean key \"%s\" in config file."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:351
-#: ../src/osx/carbon/fontdlg.cpp:361 ../src/common/stockitem.cpp:168
+#: ../src/osx/carbon/fontdlg.cpp:358 ../src/common/stockitem.cpp:165
+#: ../src/generic/fontdlgg.cpp:325 ../src/richtext/richtextfontpage.cpp:351
 msgid "Italic"
 msgstr "Kursyvas"
 
-#: ../src/common/paper.cpp:130
+#: ../src/common/paper.cpp:127
 msgid "Italy Envelope, 110 x 230 mm"
 msgstr ""
 
-#: ../src/common/imagjpeg.cpp:270
+#: ../src/common/imagjpeg.cpp:257
 msgid "JPEG: Couldn't load - file is probably corrupted."
 msgstr ""
 
-#: ../src/common/imagjpeg.cpp:449
+#: ../src/common/imagjpeg.cpp:436
 msgid "JPEG: Couldn't save image."
 msgstr ""
 
-#: ../src/common/paper.cpp:163
+#: ../src/common/paper.cpp:160
 msgid "Japanese Double Postcard 200 x 148 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:167
+#: ../src/common/paper.cpp:164
 msgid "Japanese Envelope Chou #3"
 msgstr ""
 
-#: ../src/common/paper.cpp:180
+#: ../src/common/paper.cpp:177
 msgid "Japanese Envelope Chou #3 Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:168
+#: ../src/common/paper.cpp:165
 msgid "Japanese Envelope Chou #4"
 msgstr ""
 
-#: ../src/common/paper.cpp:181
+#: ../src/common/paper.cpp:178
 msgid "Japanese Envelope Chou #4 Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:165
+#: ../src/common/paper.cpp:162
 msgid "Japanese Envelope Kaku #2"
 msgstr ""
 
-#: ../src/common/paper.cpp:178
+#: ../src/common/paper.cpp:175
 msgid "Japanese Envelope Kaku #2 Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:166
+#: ../src/common/paper.cpp:163
 msgid "Japanese Envelope Kaku #3"
 msgstr ""
 
-#: ../src/common/paper.cpp:179
+#: ../src/common/paper.cpp:176
 msgid "Japanese Envelope Kaku #3 Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:185
+#: ../src/common/paper.cpp:182
 msgid "Japanese Envelope You #4"
 msgstr ""
 
-#: ../src/common/paper.cpp:186
+#: ../src/common/paper.cpp:183
 msgid "Japanese Envelope You #4 Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:138
+#: ../src/common/paper.cpp:135
 msgid "Japanese Postcard 100 x 148 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:175
+#: ../src/common/paper.cpp:172
 msgid "Japanese Postcard Rotated 148 x 100 mm"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "Jump to"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:171
+#: ../src/common/stockitem.cpp:168
 msgid "Justified"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:155
-#: ../src/richtext/richtextindentspage.cpp:157
 #: ../src/richtext/richtextliststylepage.cpp:344
 #: ../src/richtext/richtextliststylepage.cpp:346
+#: ../src/richtext/richtextindentspage.cpp:155
+#: ../src/richtext/richtextindentspage.cpp:157
 msgid "Justify text left and right."
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:163
+#: ../src/common/fmapbase.cpp:160
 msgid "KOI8-R"
 msgstr "KOI8-R"
 
-#: ../src/common/fmapbase.cpp:164
+#: ../src/common/fmapbase.cpp:161
 msgid "KOI8-U"
 msgstr "KOI8-U"
 
-#: ../src/common/accelcmn.cpp:265 ../src/common/accelcmn.cpp:347
+#: ../src/common/accelcmn.cpp:279 ../src/common/accelcmn.cpp:364
 msgid "KP_"
 msgstr "KP_"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "KP_Add"
 msgstr "KP_ADD"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "KP_Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "KP_Decimal"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 msgid "KP_Delete"
 msgstr "Ištrinti"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "KP_Divide"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 msgid "KP_Down"
 msgstr "Žemyn"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "KP_End"
 msgstr "KP_END"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "KP_Enter"
 msgstr "Spausdintuvas"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "KP_Equal"
 msgstr ""
 
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
-msgid "KP_Home"
-msgstr "Pagrindinis"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
-msgid "KP_Insert"
-msgstr "Įterpti"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
-msgid "KP_Left"
-msgstr "Kairė"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
-msgid "KP_Multiply"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:99
-msgid "KP_Next"
-msgstr "Kitas"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
-msgid "KP_PageDown"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
-msgid "KP_PageUp"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:98
-msgid "KP_Prior"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
-msgid "KP_Right"
-msgstr "Dešinė"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
-msgid "KP_Separator"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
-msgid "KP_Space"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
-msgid "KP_Subtract"
+#: ../src/common/accelcmn.cpp:276 ../src/common/accelcmn.cpp:361
+msgid "KP_F"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
 #: ../src/common/accelcmn.cpp:89
+msgid "KP_Home"
+msgstr "Pagrindinis"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:100
+msgid "KP_Insert"
+msgstr "Įterpti"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:90
+msgid "KP_Left"
+msgstr "Kairė"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:103
+msgid "KP_Multiply"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:97
+msgid "KP_Next"
+msgstr "Kitas"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:95
+msgid "KP_PageDown"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:94
+msgid "KP_PageUp"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:96
+msgid "KP_Prior"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:92
+msgid "KP_Right"
+msgstr "Dešinė"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:105
+msgid "KP_Separator"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:86
+msgid "KP_Space"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:106
+msgid "KP_Subtract"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:87
 msgid "KP_Tab"
 msgstr "KP_TAB"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "KP_Up"
 msgstr "KP_UP"
 
@@ -4493,19 +4599,34 @@ msgstr "KP_UP"
 msgid "L&ine spacing:"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:613 ../src/generic/prntdlgg.cpp:868
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "išspaudimo klaida"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "išspaudimo klaida"
+
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:861
 msgid "Landscape"
 msgstr "Gulsčias"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "Last"
 msgstr "Paskutinis"
 
-#: ../src/common/prntbase.cpp:1572
+#: ../src/common/prntbase.cpp:1597
 msgid "Last page"
 msgstr ""
 
-#: ../src/common/log.cpp:305
+#: ../src/common/log.cpp:324
 #, c-format
 msgid "Last repeated message (\"%s\", %u time) wasn't output"
 msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
@@ -4516,93 +4637,93 @@ msgstr[1] ""
 msgstr[2] ""
 "Paskutinis pasikartojantis pranešimas (\"%s\", %u kartų) nebuvo išvestas"
 
-#: ../src/common/paper.cpp:103
+#: ../src/common/paper.cpp:100
 msgid "Ledger, 17 x 11 in"
 msgstr ""
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6146
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:58 ../src/generic/datavgen.cpp:6951
+#: ../src/richtext/richtextsizepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:252
 #: ../src/richtext/richtextliststylepage.cpp:253
 #: ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
-#: ../src/richtext/richtextsizepage.cpp:249 ../src/common/accelcmn.cpp:61
 msgid "Left"
 msgstr "Kairė"
 
-#: ../src/richtext/richtextindentspage.cpp:204
 #: ../src/richtext/richtextliststylepage.cpp:390
+#: ../src/richtext/richtextindentspage.cpp:204
 msgid "Left (&first line):"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1761
+#: ../src/propgrid/advprops.cpp:1662
 msgid "Left Button"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:880
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Left margin (mm):"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:141
-#: ../src/richtext/richtextindentspage.cpp:143
 #: ../src/richtext/richtextliststylepage.cpp:330
 #: ../src/richtext/richtextliststylepage.cpp:332
+#: ../src/richtext/richtextindentspage.cpp:141
+#: ../src/richtext/richtextindentspage.cpp:143
 msgid "Left-align text."
 msgstr ""
 
-#: ../src/common/paper.cpp:144
+#: ../src/common/paper.cpp:141
 msgid "Legal Extra 9 1/2 x 15 in"
 msgstr "Legalus Ekstra 9 1/2 x 15 colių"
 
-#: ../src/common/paper.cpp:96
+#: ../src/common/paper.cpp:93
 msgid "Legal, 8 1/2 x 14 in"
 msgstr "Legalus, 8 1/2 x 14 colių"
 
-#: ../src/common/paper.cpp:143
+#: ../src/common/paper.cpp:140
 msgid "Letter Extra 9 1/2 x 12 in"
 msgstr "Laiškas Ekstra 9 1/2 x 12 colių"
 
-#: ../src/common/paper.cpp:149
+#: ../src/common/paper.cpp:146
 msgid "Letter Extra Transverse 9.275 x 12 in"
 msgstr "Laiškas Ekstra Skerscoliųis 9.275 x 12 colių"
 
-#: ../src/common/paper.cpp:152
+#: ../src/common/paper.cpp:149
 msgid "Letter Plus 8 1/2 x 12.69 in"
 msgstr "Laiškas Plius 8 1/2 x 12.69 colių"
 
-#: ../src/common/paper.cpp:169
+#: ../src/common/paper.cpp:166
 msgid "Letter Rotated 11 x 8 1/2 in"
 msgstr "Laiškas Pasuktas 11 x 8 1/2 colių"
 
-#: ../src/common/paper.cpp:101
+#: ../src/common/paper.cpp:98
 msgid "Letter Small, 8 1/2 x 11 in"
 msgstr "Laiškas Mažas, 8 1/2 x 11 colių"
 
-#: ../src/common/paper.cpp:147
+#: ../src/common/paper.cpp:144
 msgid "Letter Transverse 8 1/2 x 11 in"
 msgstr "Laiškas Skerscoliųis 8 1/2 x 11 colių"
 
-#: ../src/common/paper.cpp:95
+#: ../src/common/paper.cpp:92
 msgid "Letter, 8 1/2 x 11 in"
 msgstr "Laiškas, 8 1/2 x 11 colių"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "License"
 msgstr "Licencija"
 
-#: ../src/generic/fontdlgg.cpp:332
+#: ../src/generic/fontdlgg.cpp:328
 msgid "Light"
 msgstr "Šviesa"
 
-#: ../src/propgrid/advprops.cpp:1608
+#: ../src/propgrid/advprops.cpp:1514
 msgid "Lime"
 msgstr ""
 
-#: ../src/generic/helpext.cpp:294
+#: ../src/generic/helpext.cpp:292
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr ""
@@ -4611,15 +4732,15 @@ msgstr ""
 msgid "Line spacing:"
 msgstr ""
 
-#: ../src/html/chm.cpp:838
+#: ../src/html/chm.cpp:829
 msgid "Link contained '//', converted to absolute link."
 msgstr ""
 
-#: ../src/richtext/richtextformatdlg.cpp:364
+#: ../src/richtext/richtextformatdlg.cpp:357
 msgid "List Style"
 msgstr "Sąrašo stilius"
 
-#: ../src/richtext/richtextstyles.cpp:1064
+#: ../src/richtext/richtextstyles.cpp:1061
 msgid "List styles"
 msgstr ""
 
@@ -4633,26 +4754,26 @@ msgstr ""
 msgid "Lists the available fonts."
 msgstr ""
 
-#: ../src/common/fldlgcmn.cpp:340
+#: ../src/common/fldlgcmn.cpp:337
 #, c-format
 msgid "Load %s file"
 msgstr ""
 
-#: ../src/html/htmlwin.cpp:597
+#: ../src/html/htmlwin.cpp:600
 msgid "Loading : "
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:246
+#: ../src/unix/snglinst.cpp:243
 #, c-format
 msgid "Lock file '%s' has incorrect owner."
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:251
+#: ../src/unix/snglinst.cpp:248
 #, c-format
 msgid "Lock file '%s' has incorrect permissions."
 msgstr ""
 
-#: ../src/generic/logg.cpp:576
+#: ../src/generic/logg.cpp:573
 #, c-format
 msgid "Log saved to the file '%s'."
 msgstr ""
@@ -4667,199 +4788,199 @@ msgstr ""
 msgid "Lower case roman numerals"
 msgstr ""
 
-#: ../src/gtk/mdi.cpp:422 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk1/mdi.cpp:431 ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr ""
 
-#: ../src/msw/helpchm.cpp:56
+#: ../src/msw/helpchm.cpp:53
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
 msgstr ""
 
-#: ../src/univ/themes/win32.cpp:3754
+#: ../src/univ/themes/win32.cpp:3751
 msgid "Ma&ximize"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:203
+#: ../src/common/fmapbase.cpp:200
 msgid "MacArabic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:222
+#: ../src/common/fmapbase.cpp:219
 msgid "MacArmenian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:211
+#: ../src/common/fmapbase.cpp:208
 msgid "MacBengali"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:217
+#: ../src/common/fmapbase.cpp:214
 msgid "MacBurmese"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:236
+#: ../src/common/fmapbase.cpp:233
 msgid "MacCeltic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:227
+#: ../src/common/fmapbase.cpp:224
 msgid "MacCentralEurRoman"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:223
+#: ../src/common/fmapbase.cpp:220
 msgid "MacChineseSimp"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:201
+#: ../src/common/fmapbase.cpp:198
 msgid "MacChineseTrad"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:233
+#: ../src/common/fmapbase.cpp:230
 msgid "MacCroatian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:206
+#: ../src/common/fmapbase.cpp:203
 msgid "MacCyrillic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:207
+#: ../src/common/fmapbase.cpp:204
 msgid "MacDevanagari"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:231
+#: ../src/common/fmapbase.cpp:228
 msgid "MacDingbats"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:226
+#: ../src/common/fmapbase.cpp:223
 msgid "MacEthiopic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:229
+#: ../src/common/fmapbase.cpp:226
 msgid "MacExtArabic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:237
+#: ../src/common/fmapbase.cpp:234
 msgid "MacGaelic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:221
+#: ../src/common/fmapbase.cpp:218
 msgid "MacGeorgian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:205
+#: ../src/common/fmapbase.cpp:202
 msgid "MacGreek"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:209
+#: ../src/common/fmapbase.cpp:206
 msgid "MacGujarati"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:208
+#: ../src/common/fmapbase.cpp:205
 msgid "MacGurmukhi"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:204
+#: ../src/common/fmapbase.cpp:201
 msgid "MacHebrew"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:234
+#: ../src/common/fmapbase.cpp:231
 msgid "MacIcelandic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:200
+#: ../src/common/fmapbase.cpp:197
 msgid "MacJapanese"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:214
+#: ../src/common/fmapbase.cpp:211
 msgid "MacKannada"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:238
+#: ../src/common/fmapbase.cpp:235
 msgid "MacKeyboardGlyphs"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:218
+#: ../src/common/fmapbase.cpp:215
 msgid "MacKhmer"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:202
+#: ../src/common/fmapbase.cpp:199
 msgid "MacKorean"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:220
+#: ../src/common/fmapbase.cpp:217
 msgid "MacLaotian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:215
+#: ../src/common/fmapbase.cpp:212
 msgid "MacMalayalam"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:225
+#: ../src/common/fmapbase.cpp:222
 msgid "MacMongolian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:210
+#: ../src/common/fmapbase.cpp:207
 msgid "MacOriya"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:199
+#: ../src/common/fmapbase.cpp:196
 msgid "MacRoman"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:235
+#: ../src/common/fmapbase.cpp:232
 msgid "MacRomanian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:216
+#: ../src/common/fmapbase.cpp:213
 msgid "MacSinhalese"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:230
+#: ../src/common/fmapbase.cpp:227
 msgid "MacSymbol"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:212
+#: ../src/common/fmapbase.cpp:209
 msgid "MacTamil"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:213
+#: ../src/common/fmapbase.cpp:210
 msgid "MacTelugu"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:219
+#: ../src/common/fmapbase.cpp:216
 msgid "MacThai"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:224
+#: ../src/common/fmapbase.cpp:221
 msgid "MacTibetan"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:232
+#: ../src/common/fmapbase.cpp:229
 msgid "MacTurkish"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:228
+#: ../src/common/fmapbase.cpp:225
 msgid "MacVietnamese"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1762
+#: ../src/propgrid/advprops.cpp:1663
 msgid "Magnifier"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:2143
+#: ../src/propgrid/advprops.cpp:2050
 msgid "Make a selection:"
 msgstr ""
 
-#: ../src/richtext/richtextformatdlg.cpp:374
+#: ../src/richtext/richtextformatdlg.cpp:367
 #: ../src/richtext/richtextmarginspage.cpp:171
 msgid "Margins"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1595
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Maroon"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:147
+#: ../src/generic/fdrepdlg.cpp:144
 msgid "Match case"
 msgstr "Skirti didžiąsias"
 
@@ -4871,40 +4992,40 @@ msgstr "&Aukštis:"
 msgid "Max width:"
 msgstr "Pakeisti kuo:"
 
-#: ../src/unix/mediactrl.cpp:947
+#: ../src/unix/mediactrl.cpp:972
 #, c-format
 msgid "Media playback error: %s"
 msgstr "Medijos grojimo klaida: %s"
 
-#: ../src/common/fs_mem.cpp:175
+#: ../src/common/fs_mem.cpp:170
 #, c-format
 msgid "Memory VFS already contains file '%s'!"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
 #. TRANSLATORS: Keyword of system colour
-#: ../src/common/accelcmn.cpp:73 ../src/propgrid/advprops.cpp:889
+#: ../src/common/accelcmn.cpp:70 ../src/propgrid/advprops.cpp:790
 msgid "Menu"
 msgstr "Meniu"
 
-#: ../src/common/msgout.cpp:124
+#: ../src/common/msgout.cpp:121
 msgid "Message"
 msgstr "Pranešimas"
 
-#: ../src/univ/themes/metal.cpp:168
+#: ../src/univ/themes/metal.cpp:165
 msgid "Metal theme"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:652
+#: ../src/msw/ole/automtn.cpp:643
 msgid "Method or property not found."
 msgstr ""
 
-#: ../src/univ/themes/win32.cpp:3752
+#: ../src/univ/themes/win32.cpp:3749
 msgid "Mi&nimize"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1763
+#: ../src/propgrid/advprops.cpp:1664
 msgid "Middle Button"
 msgstr ""
 
@@ -4916,36 +5037,40 @@ msgstr "&Aukštis:"
 msgid "Min width:"
 msgstr "Min. plotis:"
 
-#: ../src/msw/ole/automtn.cpp:668
+#: ../src/osx/cocoa/menu.mm:281
+msgid "Minimize"
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:659
 msgid "Missing a required parameter."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:324
+#: ../src/generic/fontdlgg.cpp:320
 msgid "Modern"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:427
+#: ../src/generic/filectrlg.cpp:423
 msgid "Modified"
 msgstr "Pakeista"
 
-#: ../src/common/module.cpp:133
+#: ../src/common/module.cpp:130
 #, c-format
 msgid "Module \"%s\" initialization failed"
 msgstr ""
 
-#: ../src/common/paper.cpp:131
+#: ../src/common/paper.cpp:128
 msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
 msgstr ""
 
-#: ../src/msw/fswatcher.cpp:143
+#: ../src/msw/fswatcher.cpp:140
 msgid "Monitoring individual files for changes is not supported currently."
 msgstr ""
 
-#: ../src/generic/editlbox.cpp:172
+#: ../src/generic/editlbox.cpp:160
 msgid "Move down"
 msgstr "Perkelti žemyn"
 
-#: ../src/generic/editlbox.cpp:171
+#: ../src/generic/editlbox.cpp:155
 msgid "Move up"
 msgstr "Perkelti aukštyn"
 
@@ -4959,97 +5084,102 @@ msgstr ""
 msgid "Moves the object to the previous paragraph."
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9966
+#: ../src/richtext/richtextbuffer.cpp:9963
 msgid "Multiple Cell Properties"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:424
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:82
+msgid "Multiply"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:420
 msgid "Name"
 msgstr "Pavadinimas"
 
-#: ../src/propgrid/advprops.cpp:1596
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Navy"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "Network"
 msgstr "Tinklas"
 
-#: ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173
 msgid "New"
 msgstr "Naujas"
 
-#: ../src/richtext/richtextstyledlg.cpp:243
+#: ../src/richtext/richtextstyledlg.cpp:239
 msgid "New &Box Style..."
 msgstr "Naujas &Dėžutės stilius..."
 
-#: ../src/richtext/richtextstyledlg.cpp:225
+#: ../src/richtext/richtextstyledlg.cpp:221
 msgid "New &Character Style..."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:237
+#: ../src/richtext/richtextstyledlg.cpp:233
 msgid "New &List Style..."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:231
+#: ../src/richtext/richtextstyledlg.cpp:227
 msgid "New &Paragraph Style..."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:606
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:654
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:820
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:893
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:934
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:602
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:650
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:816
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:889
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:930
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "New Style"
 msgstr ""
 
-#: ../src/generic/editlbox.cpp:169
+#: ../src/generic/editlbox.cpp:139
 msgid "New item"
 msgstr ""
 
-#: ../src/generic/dirdlgg.cpp:297 ../src/generic/dirdlgg.cpp:307
-#: ../src/generic/filectrlg.cpp:618 ../src/generic/filectrlg.cpp:627
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+#: ../src/generic/dirdlgg.cpp:294 ../src/generic/dirdlgg.cpp:304
 msgid "NewName"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:1567 ../src/html/helpwnd.cpp:665
+#: ../src/common/prntbase.cpp:1592 ../src/html/helpwnd.cpp:663
 msgid "Next page"
 msgstr "Kitas puslapis"
 
-#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:177
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:174
 #: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Ne"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1764
+#: ../src/propgrid/advprops.cpp:1665
 msgid "No Entry"
 msgstr ""
 
-#: ../src/generic/animateg.cpp:150
+#: ../src/generic/animateg.cpp:133
 #, c-format
 msgid "No animation handler for type %ld defined."
 msgstr ""
 
-#: ../src/dfb/bitmap.cpp:642 ../src/dfb/bitmap.cpp:676
+#: ../src/dfb/bitmap.cpp:639 ../src/dfb/bitmap.cpp:673
 #, c-format
 msgid "No bitmap handler for type %d defined."
 msgstr ""
 
-#: ../src/common/utilscmn.cpp:1077
+#: ../src/common/utilscmn.cpp:1095
 msgid "No default application configured for HTML files."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:445
+#: ../src/generic/helpext.cpp:443
 msgid "No entries found."
 msgstr ""
 
-#: ../src/common/fontmap.cpp:421
+#: ../src/common/fontmap.cpp:418
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found,\n"
@@ -5058,7 +5188,7 @@ msgid ""
 "one)?"
 msgstr ""
 
-#: ../src/common/fontmap.cpp:426
+#: ../src/common/fontmap.cpp:423
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found.\n"
@@ -5066,201 +5196,201 @@ msgid ""
 "(otherwise the text in this encoding will not be shown correctly)?"
 msgstr ""
 
-#: ../src/generic/animateg.cpp:142
+#: ../src/generic/animateg.cpp:125
 msgid "No handler found for animation type."
 msgstr ""
 
-#: ../src/common/image.cpp:2728
+#: ../src/common/image.cpp:2823
 msgid "No handler found for image type."
 msgstr ""
 
-#: ../src/common/image.cpp:2736 ../src/common/image.cpp:2848
-#: ../src/common/image.cpp:2901
+#: ../src/common/image.cpp:2831 ../src/common/image.cpp:2954
+#: ../src/common/image.cpp:3020
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr ""
 
-#: ../src/common/image.cpp:2871 ../src/common/image.cpp:2915
+#: ../src/common/image.cpp:2986 ../src/common/image.cpp:3034
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:858
+#: ../src/html/helpwnd.cpp:856
 msgid "No matching page found yet"
 msgstr ""
 
-#: ../src/unix/sound.cpp:81
+#: ../src/unix/sound.cpp:78
 msgid "No sound"
 msgstr ""
 
-#: ../src/common/image.cpp:2277 ../src/common/image.cpp:2318
+#: ../src/common/image.cpp:2371 ../src/common/image.cpp:2412
 msgid "No unused colour in image being masked."
 msgstr ""
 
-#: ../src/common/image.cpp:3374
-msgid "No unused colour in image."
-msgstr ""
-
-#: ../src/generic/helpext.cpp:302
+#: ../src/generic/helpext.cpp:300
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr ""
 
-#: ../src/richtext/richtextborderspage.cpp:610
 #: ../src/richtext/richtextsizepage.cpp:248
 #: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:610
 msgid "None"
 msgstr "Joks"
 
-#: ../src/common/fmapbase.cpp:157
+#: ../src/common/fmapbase.cpp:154
 msgid "Nordic (ISO-8859-10)"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:328 ../src/generic/fontdlgg.cpp:331
+#: ../src/generic/fontdlgg.cpp:324 ../src/generic/fontdlgg.cpp:327
 msgid "Normal"
 msgstr "Normalus"
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1261
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1205
+#: ../src/html/helpwnd.cpp:1203
 msgid "Normal font:"
 msgstr ""
 
-#: ../src/propgrid/props.cpp:1128
+#: ../src/propgrid/props.cpp:1115
 #, c-format
 msgid "Not %s"
 msgstr ""
 
-#: ../include/wx/filename.h:573 ../include/wx/filename.h:578
-msgid "Not available"
+#: ../src/common/secretstore.cpp:168
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/webrequest.cpp:605
+msgid "Not enough free disk space for download."
 msgstr ""
 
 #: ../src/richtext/richtextfontpage.cpp:358
 msgid "Not underlined"
 msgstr ""
 
-#: ../src/common/paper.cpp:115
+#: ../src/common/paper.cpp:112
 msgid "Note, 8 1/2 x 11 in"
 msgstr ""
 
-#: ../src/generic/notifmsgg.cpp:132
+#: ../src/generic/notifmsgg.cpp:129
 msgid "Notice"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "Num *"
 msgstr "Num *"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "Num +"
 msgstr "Num +"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "Num ,"
 msgstr "Num ,"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "Num -"
 msgstr "Num -"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "Num ."
 msgstr "Num ."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "Num /"
 msgstr "Num /"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "Num ="
 msgstr "Num ="
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "Num Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 msgid "Num Delete"
 msgstr "Ištrinti"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 msgid "Num Down"
 msgstr "Žemyn"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "Num End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "Num Enter"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 msgid "Num Home"
 msgstr "Pagrindinis"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 msgid "Num Insert"
 msgstr "Įterpti"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num Lock"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "Num Page Down"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "Num Page Up"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 msgid "Num Right"
 msgstr "Dešinė"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "Num Space"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "Num Tab"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "Num Up"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "Num left"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num_lock"
 msgstr ""
 
@@ -5269,13 +5399,13 @@ msgstr ""
 msgid "Numbered outline"
 msgstr ""
 
-#: ../include/wx/msgdlg.h:278 ../src/richtext/richtextstyledlg.cpp:297
-#: ../src/common/stockitem.cpp:178 ../src/msw/msgdlg.cpp:454
-#: ../src/msw/msgdlg.cpp:747 ../src/gtk1/fontdlg.cpp:138
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:175
+#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/msgdlg.cpp:741 ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "GERAI"
 
-#: ../src/msw/ole/automtn.cpp:692
+#: ../src/msw/ole/automtn.cpp:683
 #, c-format
 msgid "OLE Automation error in %s: %s"
 msgstr ""
@@ -5284,15 +5414,15 @@ msgstr ""
 msgid "Object Properties"
 msgstr "Objektų savybs"
 
-#: ../src/msw/ole/automtn.cpp:660
+#: ../src/msw/ole/automtn.cpp:651
 msgid "Object implementation does not support named arguments."
 msgstr ""
 
-#: ../src/common/xtixml.cpp:264
+#: ../src/common/xtixml.cpp:260
 msgid "Objects must have an id attribute"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1601
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Olive"
 msgstr ""
 
@@ -5300,64 +5430,68 @@ msgstr ""
 msgid "Opaci&ty:"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:354
+#: ../src/generic/colrdlgg.cpp:374
 msgid "Opacity:"
 msgstr ""
 
-#: ../src/common/docview.cpp:1773 ../src/common/docview.cpp:1815
+#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
 msgid "Open File"
 msgstr "Atverti failą"
 
-#: ../src/html/helpwnd.cpp:671 ../src/html/helpwnd.cpp:1554
+#: ../src/html/helpwnd.cpp:669 ../src/html/helpwnd.cpp:1552
 msgid "Open HTML document"
 msgstr ""
 
-#: ../src/generic/dbgrptg.cpp:163
+#: ../src/common/stockitem.cpp:265
+msgid "Open an existing document"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:160
 #, c-format
 msgid "Open file \"%s\""
 msgstr ""
 
-#: ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176
 msgid "Open..."
 msgstr "Atverti..."
 
-#: ../src/unix/glx11.cpp:506 ../src/msw/glcanvas.cpp:592
+#: ../src/msw/glcanvas.cpp:607 ../src/unix/glx11.cpp:513
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr ""
 
-#: ../src/generic/dirctrlg.cpp:599 ../src/generic/dirdlgg.cpp:323
-#: ../src/generic/filectrlg.cpp:642 ../src/generic/filectrlg.cpp:786
+#: ../src/generic/dirctrlg.cpp:565 ../src/generic/filectrlg.cpp:638
+#: ../src/generic/filectrlg.cpp:782 ../src/generic/dirdlgg.cpp:320
 msgid "Operation not permitted."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:900
+#: ../src/common/cmdline.cpp:896
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1064
+#: ../src/common/cmdline.cpp:1060
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1147
+#: ../src/common/cmdline.cpp:1143
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:618
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Nuostatos"
 
-#: ../src/propgrid/advprops.cpp:1606
+#: ../src/propgrid/advprops.cpp:1512
 msgid "Orange"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:615 ../src/generic/prntdlgg.cpp:869
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:862
 msgid "Orientation"
 msgstr "Orientavimas"
 
-#: ../src/common/windowid.cpp:242
+#: ../src/common/windowid.cpp:237
 msgid "Out of window IDs.  Recommend shutting down application."
 msgstr ""
 
@@ -5370,148 +5504,148 @@ msgstr ""
 msgid "Outset"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:656
+#: ../src/msw/ole/automtn.cpp:647
 msgid "Overflow while coercing argument values."
 msgstr ""
 
-#: ../src/common/imagpcx.cpp:457 ../src/common/imagpcx.cpp:480
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:479
 msgid "PCX: couldn't allocate memory"
 msgstr ""
 
-#: ../src/common/imagpcx.cpp:456
+#: ../src/common/imagpcx.cpp:455
 msgid "PCX: image format unsupported"
 msgstr ""
 
-#: ../src/common/imagpcx.cpp:479
+#: ../src/common/imagpcx.cpp:478
 msgid "PCX: invalid image"
 msgstr ""
 
-#: ../src/common/imagpcx.cpp:442
+#: ../src/common/imagpcx.cpp:441
 msgid "PCX: this is not a PCX file."
 msgstr ""
 
-#: ../src/common/imagpcx.cpp:459 ../src/common/imagpcx.cpp:481
+#: ../src/common/imagpcx.cpp:458 ../src/common/imagpcx.cpp:480
 msgid "PCX: unknown error !!!"
 msgstr ""
 
-#: ../src/common/imagpcx.cpp:458
+#: ../src/common/imagpcx.cpp:457
 msgid "PCX: version number too low"
 msgstr ""
 
-#: ../src/common/imagpnm.cpp:91
+#: ../src/common/imagpnm.cpp:89
 msgid "PNM: Couldn't allocate memory."
 msgstr ""
 
-#: ../src/common/imagpnm.cpp:73
+#: ../src/common/imagpnm.cpp:71
 msgid "PNM: File format is not recognized."
 msgstr ""
 
-#: ../src/common/imagpnm.cpp:112 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
 #: ../src/common/imagpnm.cpp:156
 msgid "PNM: File seems truncated."
 msgstr ""
 
-#: ../src/common/paper.cpp:187
+#: ../src/common/paper.cpp:184
 msgid "PRC 16K 146 x 215 mm"
 msgstr "PRC 16K 146 x 215 mm"
 
-#: ../src/common/paper.cpp:200
+#: ../src/common/paper.cpp:197
 msgid "PRC 16K Rotated"
 msgstr "PRC 16K Pasuktas"
 
-#: ../src/common/paper.cpp:188
+#: ../src/common/paper.cpp:185
 msgid "PRC 32K 97 x 151 mm"
 msgstr "PRC 32K 97 x 151 mm"
 
-#: ../src/common/paper.cpp:201
+#: ../src/common/paper.cpp:198
 msgid "PRC 32K Rotated"
 msgstr "PRC 32K Pasuktas"
 
-#: ../src/common/paper.cpp:189
+#: ../src/common/paper.cpp:186
 msgid "PRC 32K(Big) 97 x 151 mm"
 msgstr "PRC 32K(Big) 97 x 151 mm"
 
-#: ../src/common/paper.cpp:202
+#: ../src/common/paper.cpp:199
 msgid "PRC 32K(Big) Rotated"
 msgstr "PRC 32K(Big) Pasuktas"
 
-#: ../src/common/paper.cpp:190
+#: ../src/common/paper.cpp:187
 msgid "PRC Envelope #1 102 x 165 mm"
 msgstr "PRC Vokas #1 102 x 165 mm"
 
-#: ../src/common/paper.cpp:203
+#: ../src/common/paper.cpp:200
 msgid "PRC Envelope #1 Rotated 165 x 102 mm"
 msgstr "PRC Vokas #1 Pasuktas 165 x 102 mm"
 
-#: ../src/common/paper.cpp:199
+#: ../src/common/paper.cpp:196
 msgid "PRC Envelope #10 324 x 458 mm"
 msgstr "PRC Vokas #10 324 x 458 mm"
 
-#: ../src/common/paper.cpp:212
+#: ../src/common/paper.cpp:209
 msgid "PRC Envelope #10 Rotated 458 x 324 mm"
 msgstr "PRC Vokas #10 Pasuktas 458 x 324 mm"
 
-#: ../src/common/paper.cpp:191
+#: ../src/common/paper.cpp:188
 msgid "PRC Envelope #2 102 x 176 mm"
 msgstr "PRC Vokas #2 102 x 176 mm"
 
-#: ../src/common/paper.cpp:204
+#: ../src/common/paper.cpp:201
 msgid "PRC Envelope #2 Rotated 176 x 102 mm"
 msgstr "PRC Vokas #2 Pasuktas 176 x 102 mm"
 
-#: ../src/common/paper.cpp:192
+#: ../src/common/paper.cpp:189
 msgid "PRC Envelope #3 125 x 176 mm"
 msgstr "PRC Vokas #3 125 x 176 mm"
 
-#: ../src/common/paper.cpp:205
+#: ../src/common/paper.cpp:202
 msgid "PRC Envelope #3 Rotated 176 x 125 mm"
 msgstr "PRC Vokas #3 Pasuktas 176 x 125 mm"
 
-#: ../src/common/paper.cpp:193
+#: ../src/common/paper.cpp:190
 msgid "PRC Envelope #4 110 x 208 mm"
 msgstr "PRC Vokas #4 110 x 208 mm"
 
-#: ../src/common/paper.cpp:206
+#: ../src/common/paper.cpp:203
 msgid "PRC Envelope #4 Rotated 208 x 110 mm"
 msgstr "PRC Vokas #4 Pasuktas 208 x 110 mm"
 
-#: ../src/common/paper.cpp:194
+#: ../src/common/paper.cpp:191
 msgid "PRC Envelope #5 110 x 220 mm"
 msgstr "PRC Vokas #5 110 x 220 mm"
 
-#: ../src/common/paper.cpp:207
+#: ../src/common/paper.cpp:204
 msgid "PRC Envelope #5 Rotated 220 x 110 mm"
 msgstr "PRC Vokas #5 Pasuktas 220 x 110 mm"
 
-#: ../src/common/paper.cpp:195
+#: ../src/common/paper.cpp:192
 msgid "PRC Envelope #6 120 x 230 mm"
 msgstr "PRC Vokas #6 120 x 230 mm"
 
-#: ../src/common/paper.cpp:208
+#: ../src/common/paper.cpp:205
 msgid "PRC Envelope #6 Rotated 230 x 120 mm"
 msgstr "PRC Vokas #6 Pasuktas 230 x 120 mm"
 
-#: ../src/common/paper.cpp:196
+#: ../src/common/paper.cpp:193
 msgid "PRC Envelope #7 160 x 230 mm"
 msgstr "PRC Vokas #7 160 x 230 mm"
 
-#: ../src/common/paper.cpp:209
+#: ../src/common/paper.cpp:206
 msgid "PRC Envelope #7 Rotated 230 x 160 mm"
 msgstr "PRC Vokas #7 Pasuktas 230 x 160 mm"
 
-#: ../src/common/paper.cpp:197
+#: ../src/common/paper.cpp:194
 msgid "PRC Envelope #8 120 x 309 mm"
 msgstr "PRC Vokas #8 120 x 309 mm"
 
-#: ../src/common/paper.cpp:210
+#: ../src/common/paper.cpp:207
 msgid "PRC Envelope #8 Rotated 309 x 120 mm"
 msgstr "PRC Vokas #8 Pasuktas 309 x 120 mm"
 
-#: ../src/common/paper.cpp:198
+#: ../src/common/paper.cpp:195
 msgid "PRC Envelope #9 229 x 324 mm"
 msgstr "PRC Vokas #9 229 x 324 mm"
 
-#: ../src/common/paper.cpp:211
+#: ../src/common/paper.cpp:208
 msgid "PRC Envelope #9 Rotated 324 x 229 mm"
 msgstr "PRC Vokas #9 Pasuktas 324 x 229 mm"
 
@@ -5519,87 +5653,91 @@ msgstr "PRC Vokas #9 Pasuktas 324 x 229 mm"
 msgid "Padding"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:2074
+#: ../src/common/prntbase.cpp:2096
 #, c-format
 msgid "Page %d"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:2072
+#: ../src/common/prntbase.cpp:2094
 #, c-format
 msgid "Page %d of %d"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 msgid "Page Down"
 msgstr "Žemyn"
 
-#: ../src/gtk/print.cpp:826
+#: ../src/gtk/print.cpp:829
 msgid "Page Setup"
 msgstr "Puslapio sąranka"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 msgid "Page Up"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:828 ../src/common/prntbase.cpp:484
+#: ../src/common/prntbase.cpp:479 ../src/generic/prntdlgg.cpp:821
 msgid "Page setup"
 msgstr "Puslapio sąranka"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 msgid "PageDown"
 msgstr "Žemyn"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 msgid "PageUp"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:216
+#: ../src/generic/prntdlgg.cpp:209
 msgid "Pages"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1765
+#: ../src/propgrid/advprops.cpp:1666
 msgid "Paint Brush"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:602 ../src/generic/prntdlgg.cpp:801
-#: ../src/generic/prntdlgg.cpp:842 ../src/generic/prntdlgg.cpp:855
-#: ../src/generic/prntdlgg.cpp:1052 ../src/generic/prntdlgg.cpp:1057
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:794
+#: ../src/generic/prntdlgg.cpp:835 ../src/generic/prntdlgg.cpp:848
+#: ../src/generic/prntdlgg.cpp:1045 ../src/generic/prntdlgg.cpp:1050
 msgid "Paper size"
 msgstr "Popieriaus dydis"
 
-#: ../src/richtext/richtextstyles.cpp:1062
+#: ../src/richtext/richtextstyles.cpp:1059
 msgid "Paragraph styles"
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:465
+#: ../src/common/xtistrm.cpp:462
 msgid "Passing a already registered object to SetObject"
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:476
+#: ../src/common/xtistrm.cpp:473
 msgid "Passing an unknown object to GetObject"
 msgstr "Netinkamas objektas perduodamas GetObject"
 
-#: ../src/richtext/richtextctrl.cpp:3513 ../src/common/stockitem.cpp:180
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:177 ../src/richtext/richtextctrl.cpp:3514
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Įklijuoti"
 
-#: ../src/common/stockitem.cpp:262
+#: ../src/common/stockitem.cpp:260
 msgid "Paste selection"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:74
+#: ../src/common/accelcmn.cpp:71
 msgid "Pause"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1766
+#: ../src/propgrid/advprops.cpp:1667
 msgid "Pencil"
 msgstr ""
 
@@ -5608,21 +5746,21 @@ msgstr ""
 msgid "Peri&od"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:430
+#: ../src/generic/filectrlg.cpp:426
 msgid "Permissions"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:60
+#: ../src/common/accelcmn.cpp:57
 msgid "PgDn"
 msgstr "PgDn"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:59
+#: ../src/common/accelcmn.cpp:56
 msgid "PgUp"
 msgstr "PgUp"
 
-#: ../src/richtext/richtextbuffer.cpp:12868
+#: ../src/richtext/richtextbuffer.cpp:12863
 msgid "Picture Properties"
 msgstr ""
 
@@ -5634,42 +5772,42 @@ msgstr ""
 msgid "Please choose a valid font."
 msgstr ""
 
-#: ../src/generic/filedlgg.cpp:357 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
 msgid "Please choose an existing file."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:800
+#: ../src/html/helpwnd.cpp:798
 msgid "Please choose the page to display:"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:764
+#: ../src/msw/dialup.cpp:758
 msgid "Please choose which ISP do you want to connect to"
 msgstr ""
 
-#: ../src/common/headerctrlcmn.cpp:59
+#: ../src/common/headerctrlcmn.cpp:57
 msgid "Please select the columns to show and define their order:"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:538
+#: ../src/common/prntbase.cpp:533
 msgid "Please wait while printing..."
 msgstr "Prašome palaukti kol spausdinama..."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1767
+#: ../src/propgrid/advprops.cpp:1668
 msgid "Point Left"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1768
+#: ../src/propgrid/advprops.cpp:1669
 msgid "Point Right"
 msgstr "&Aukštis"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:662
+#: ../src/propgrid/advprops.cpp:572
 msgid "Point Size"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:612 ../src/generic/prntdlgg.cpp:867
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:860
 msgid "Portrait"
 msgstr "Stačias"
 
@@ -5677,251 +5815,259 @@ msgstr "Stačias"
 msgid "Position"
 msgstr "Padėtis"
 
-#: ../src/generic/prntdlgg.cpp:298
+#: ../src/generic/prntdlgg.cpp:291
 msgid "PostScript file"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178 ../src/osx/cocoa/preferences.mm:303
 msgid "Preferences"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:568
+#: ../src/osx/menu_osx.cpp:460
 msgid "Preferences..."
 msgstr ""
 
-#: ../src/common/prntbase.cpp:546
+#: ../src/common/prntbase.cpp:541
 msgid "Preparing"
 msgstr "Ruošiamasi"
 
-#: ../src/generic/fontdlgg.cpp:455 ../src/osx/carbon/fontdlg.cpp:390
-#: ../src/html/helpwnd.cpp:1222
+#: ../src/osx/carbon/fontdlg.cpp:387 ../src/generic/fontdlgg.cpp:452
+#: ../src/html/helpwnd.cpp:1220
 msgid "Preview:"
 msgstr "Peržiūra:"
 
-#: ../src/common/prntbase.cpp:1553 ../src/html/helpwnd.cpp:664
+#: ../src/common/prntbase.cpp:1578 ../src/html/helpwnd.cpp:662
 msgid "Previous page"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/prntdlgg.cpp:143 ../src/generic/prntdlgg.cpp:157
-#: ../src/common/prntbase.cpp:426 ../src/common/prntbase.cpp:1541
-#: ../src/common/accelcmn.cpp:77 ../src/gtk/print.cpp:620
-#: ../src/gtk/print.cpp:638
+#: ../src/common/prntbase.cpp:421 ../src/common/prntbase.cpp:1566
+#: ../src/common/accelcmn.cpp:74 ../src/generic/prntdlgg.cpp:136
+#: ../src/generic/prntdlgg.cpp:150 ../src/gtk/print.cpp:616
+#: ../src/gtk/print.cpp:634
 msgid "Print"
 msgstr "Spausdinti"
 
-#: ../include/wx/prntbase.h:399 ../src/common/docview.cpp:1268
+#: ../src/common/docview.cpp:1262
 msgid "Print Preview"
 msgstr "Spausdinimo peržiūra"
 
-#: ../src/common/prntbase.cpp:2015 ../src/common/prntbase.cpp:2057
-#: ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2037 ../src/common/prntbase.cpp:2079
+#: ../src/common/prntbase.cpp:2087
 msgid "Print Preview Failure"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:224
+#: ../src/generic/prntdlgg.cpp:217
 msgid "Print Range"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:449
+#: ../src/generic/prntdlgg.cpp:442
 msgid "Print Setup"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:621
+#: ../src/generic/prntdlgg.cpp:614
 msgid "Print in colour"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/osx/webview_webkit.mm:260
+msgid "Print operation could not be initialized"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:179
 msgid "Print previe&w..."
 msgstr "&Spausdinimo peržiūra..."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1256
 msgid "Print preview creation failed."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/common/stockitem.cpp:179
 msgid "Print preview..."
 msgstr "Spausdinimo peržiūra..."
 
-#: ../src/generic/prntdlgg.cpp:630
+#: ../src/generic/prntdlgg.cpp:623
 msgid "Print spooling"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:675
+#: ../src/html/helpwnd.cpp:673
 msgid "Print this page"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:185
+#: ../src/generic/prntdlgg.cpp:178
 msgid "Print to File"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "Print..."
 msgstr "Spausdinti..."
 
-#: ../src/generic/prntdlgg.cpp:493
+#: ../src/generic/prntdlgg.cpp:486
 msgid "Printer"
 msgstr "Spausdintuvas"
 
-#: ../src/generic/prntdlgg.cpp:633
+#: ../src/generic/prntdlgg.cpp:626
 msgid "Printer command:"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:180
+#: ../src/generic/prntdlgg.cpp:173
 msgid "Printer options"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:645
+#: ../src/generic/prntdlgg.cpp:638
 msgid "Printer options:"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:916
+#: ../src/generic/prntdlgg.cpp:909
 msgid "Printer..."
 msgstr "Spausdintuvas..."
 
-#: ../src/generic/prntdlgg.cpp:196
+#: ../src/generic/prntdlgg.cpp:189
 msgid "Printer:"
 msgstr "Spausdintuvas:"
 
-#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:535
-#: ../src/html/htmprint.cpp:277
+#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:530
+#: ../src/html/htmprint.cpp:289
 msgid "Printing"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:612
+#: ../src/common/prntbase.cpp:607
 msgid "Printing "
 msgstr ""
 
-#: ../src/common/prntbase.cpp:347
+#: ../src/common/prntbase.cpp:342
 msgid "Printing Error"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:565
+#: ../src/osx/webview_webkit.mm:251
+msgid "Printing is not supported by the system web control"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:560
 #, c-format
 msgid "Printing page %d"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:570
+#: ../src/common/prntbase.cpp:565
 #, c-format
 msgid "Printing page %d of %d"
 msgstr "Spausdinamas puslapis %d iš %d"
 
-#: ../src/generic/printps.cpp:201
+#: ../src/generic/printps.cpp:182
 #, c-format
 msgid "Printing page %d..."
 msgstr ""
 
-#: ../src/generic/printps.cpp:161
+#: ../src/generic/printps.cpp:142
 msgid "Printing..."
 msgstr ""
 
-#: ../include/wx/richtext/richtextprint.h:109 ../include/wx/prntbase.h:267
-#: ../src/common/docview.cpp:2132
+#: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
+#: ../src/common/docview.cpp:2137
 msgid "Printout"
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:560
+#: ../src/common/debugrpt.cpp:561
 #, c-format
 msgid ""
 "Processing debug report has failed, leaving the files in \"%s\" directory."
 msgstr ""
 
-#: ../src/common/prntbase.cpp:545
+#: ../src/common/prntbase.cpp:540
 msgid "Progress:"
 msgstr "Progresas:"
 
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181
 msgid "Properties"
 msgstr "Savybės"
 
-#: ../src/propgrid/manager.cpp:237
+#: ../src/propgrid/manager.cpp:223
 msgid "Property"
 msgstr "Savybė"
 
 #. TRANSLATORS: Caption of message box displaying any property error
-#: ../src/propgrid/propgrid.cpp:3185 ../src/propgrid/propgrid.cpp:3318
+#: ../src/propgrid/propgrid.cpp:3162 ../src/propgrid/propgrid.cpp:3299
 msgid "Property Error"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1597
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Purple"
 msgstr ""
 
-#: ../src/common/paper.cpp:112
+#: ../src/common/paper.cpp:109
 msgid "Quarto, 215 x 275 mm"
 msgstr ""
 
-#: ../src/generic/logg.cpp:1016
+#: ../src/generic/logg.cpp:1013
 msgid "Question"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1769
+#: ../src/propgrid/advprops.cpp:1670
 msgid "Question Arrow"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "Quit"
 msgstr "Išeiti"
 
-#: ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:477
 #, c-format
 msgid "Quit %s"
 msgstr "Išeiti %s"
 
-#: ../src/common/stockitem.cpp:263
+#: ../src/common/stockitem.cpp:261
 msgid "Quit this program"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:338
+#: ../src/common/accelcmn.cpp:352
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/ffile.cpp:109 ../src/common/ffile.cpp:133
+#: ../src/common/ffile.cpp:107 ../src/common/ffile.cpp:132
 #, c-format
 msgid "Read error on file '%s'"
 msgstr ""
 
-#: ../src/common/secretstore.cpp:199
+#: ../src/common/secretstore.cpp:211
 #, c-format
-msgid "Reading password for \"%s/%s\" failed: %s."
+msgid "Reading password for \"%s\" failed: %s."
 msgstr ""
 
-#: ../src/common/prntbase.cpp:272
+#: ../src/common/prntbase.cpp:267
 msgid "Ready"
 msgstr "Pasiruošęs"
 
-#: ../src/propgrid/advprops.cpp:1605
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Red"
 msgstr "Raudonas"
 
-#: ../src/generic/colrdlgg.cpp:339
+#: ../src/generic/colrdlgg.cpp:359
 msgid "Red:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:185 ../src/stc/stc_i18n.cpp:16
+#: ../src/common/stockitem.cpp:182 ../src/stc/stc_i18n.cpp:16
 msgid "Redo"
 msgstr "Grąžinti atšauktą"
 
-#: ../src/common/stockitem.cpp:264
+#: ../src/common/stockitem.cpp:262
 msgid "Redo last action"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:186
+#: ../src/common/stockitem.cpp:183
 msgid "Refresh"
 msgstr "Atnaujinti"
 
-#: ../src/msw/registry.cpp:626
+#: ../src/msw/registry.cpp:615
 #, c-format
 msgid "Registry key '%s' already exists."
 msgstr ""
 
-#: ../src/msw/registry.cpp:595
+#: ../src/msw/registry.cpp:584
 #, c-format
 msgid "Registry key '%s' does not exist, cannot rename it."
 msgstr ""
 
-#: ../src/msw/registry.cpp:727
+#: ../src/msw/registry.cpp:716
 #, c-format
 msgid ""
 "Registry key '%s' is needed for normal system operation,\n"
@@ -5929,22 +6075,22 @@ msgid ""
 "operation aborted."
 msgstr ""
 
-#: ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:942
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:917
+#: ../src/msw/registry.cpp:905
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1003
+#: ../src/msw/registry.cpp:991
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:521
+#: ../src/msw/registry.cpp:510
 #, c-format
 msgid "Registry value '%s' already exists."
 msgstr ""
@@ -5958,70 +6104,76 @@ msgstr "Įprastas"
 msgid "Relative"
 msgstr "Santykinis"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:456
 msgid "Relevant entries:"
 msgstr ""
 
-#: ../include/wx/generic/progdlgg.h:86
+#: ../include/wx/generic/progdlgg.h:87
 msgid "Remaining time:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:187
+#: ../src/common/stockitem.cpp:184
 msgid "Remove"
 msgstr "Pašalinti"
 
-#: ../src/richtext/richtextctrl.cpp:1562
+#: ../src/richtext/richtextctrl.cpp:1563
 msgid "Remove Bullet"
 msgstr "Pašalinti ženklelį"
 
-#: ../src/html/helpwnd.cpp:433
+#: ../src/html/helpwnd.cpp:431
 msgid "Remove current page from bookmarks"
 msgstr ""
 
-#: ../src/common/rendcmn.cpp:194
+#: ../src/common/rendcmn.cpp:191
 #, c-format
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:4527
+#: ../src/richtext/richtextbuffer.cpp:4524
 msgid "Renumber List"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:188
-msgid "Rep&lace"
-msgstr ""
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Rep&lace..."
+msgstr "Pakeisti"
 
-#: ../src/richtext/richtextctrl.cpp:3673 ../src/common/stockitem.cpp:188
+#: ../src/richtext/richtextctrl.cpp:3674
 msgid "Replace"
 msgstr "Pakeisti"
 
-#: ../src/generic/fdrepdlg.cpp:182
+#: ../src/generic/fdrepdlg.cpp:179
 msgid "Replace &all"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:261
-msgid "Replace selection"
-msgstr ""
-
-#: ../src/generic/fdrepdlg.cpp:124
+#: ../src/generic/fdrepdlg.cpp:121
 msgid "Replace with:"
 msgstr "Pakeisti šiuo:"
 
-#: ../src/common/valtext.cpp:163
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Replace..."
+msgstr "Pakeisti"
+
+#: ../src/common/valtext.cpp:184
 msgid "Required information entry is empty."
 msgstr ""
 
-#: ../src/common/translation.cpp:1975
+#: ../src/common/translation.cpp:2025
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr ""
 
+#: ../src/gtk/webview_webkit.cpp:985
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:56
+#: ../src/common/accelcmn.cpp:53
 msgid "Return"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:189
+#: ../src/common/stockitem.cpp:186
 msgid "Revert to Saved"
 msgstr ""
 
@@ -6033,41 +6185,41 @@ msgstr ""
 msgid "Rig&ht-to-left"
 msgstr ""
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6149
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:59 ../src/generic/datavgen.cpp:6954
+#: ../src/richtext/richtextsizepage.cpp:250
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextbulletspage.cpp:188
-#: ../src/richtext/richtextsizepage.cpp:250 ../src/common/accelcmn.cpp:62
 msgid "Right"
 msgstr "Dešinė"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1754
+#: ../src/propgrid/advprops.cpp:1655
 msgid "Right Arrow"
 msgstr "Dešinė"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1770
+#: ../src/propgrid/advprops.cpp:1671
 msgid "Right Button"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:892
+#: ../src/generic/prntdlgg.cpp:885
 msgid "Right margin (mm):"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:148
-#: ../src/richtext/richtextindentspage.cpp:150
 #: ../src/richtext/richtextliststylepage.cpp:337
 #: ../src/richtext/richtextliststylepage.cpp:339
+#: ../src/richtext/richtextindentspage.cpp:148
+#: ../src/richtext/richtextindentspage.cpp:150
 msgid "Right-align text."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:322
+#: ../src/generic/fontdlgg.cpp:318
 msgid "Roman"
 msgstr ""
 
-#: ../src/generic/datavgen.cpp:5916
+#: ../src/generic/datavgen.cpp:6721
 #, c-format
 msgid "Row %i"
 msgstr ""
@@ -6077,30 +6229,31 @@ msgstr ""
 msgid "S&tandard bullet name:"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:268 ../src/common/accelcmn.cpp:350
+#: ../src/common/accelcmn.cpp:282 ../src/common/accelcmn.cpp:367
 msgid "SPECIAL"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:190 ../src/common/sizer.cpp:2797
+#: ../src/common/stockitem.cpp:187 ../src/common/sizer.cpp:2914
 msgid "Save"
 msgstr "Išsaugoti"
 
-#: ../src/common/fldlgcmn.cpp:342
+#: ../src/common/fldlgcmn.cpp:339
 #, c-format
 msgid "Save %s file"
 msgstr "Išsaugoti %s failą"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/common/stockitem.cpp:188 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Išs&augoti kaip..."
 
-#: ../src/common/docview.cpp:366
+#: ../src/common/docview.cpp:359
 msgid "Save As"
 msgstr "Išsaugoti kaip"
 
-#: ../src/common/stockitem.cpp:191
-msgid "Save as"
-msgstr "Išsaugoti kaip"
+#: ../src/common/stockitem.cpp:188
+#, fuzzy
+msgid "Save As..."
+msgstr "Išs&augoti kaip..."
 
 #: ../src/common/stockitem.cpp:267
 msgid "Save current document"
@@ -6110,94 +6263,94 @@ msgstr "Išsaugoti aktyvų dokumentą"
 msgid "Save current document with a different filename"
 msgstr "Išsaugoti aktyvų dokumentą kitu pavadinimu"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/generic/logg.cpp:509
 msgid "Save log contents to file"
 msgstr "Išsaugoti žurnalo turinį į failą"
 
-#: ../src/common/secretstore.cpp:179
+#: ../src/common/secretstore.cpp:189
 #, c-format
-msgid "Saving password for \"%s/%s\" failed: %s."
+msgid "Saving password for \"%s\" failed: %s."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:325
+#: ../src/generic/fontdlgg.cpp:321
 msgid "Script"
 msgstr "SCRIPT"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll Lock"
 msgstr "Perslinkimo užrakinimas"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll_lock"
 msgstr "Perslinkimo_užrakinimas"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:890
+#: ../src/propgrid/advprops.cpp:791
 msgid "Scrollbar"
 msgstr "Slinkties juosta"
 
-#: ../src/generic/srchctlg.cpp:56 ../src/html/helpwnd.cpp:535
-#: ../src/html/helpwnd.cpp:550
+#: ../src/generic/srchctlg.cpp:55 ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:548 ../src/gtk/srchctrl.cpp:182
 msgid "Search"
 msgstr "Ieškoti"
 
-#: ../src/html/helpwnd.cpp:537
+#: ../src/html/helpwnd.cpp:535
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:160
+#: ../src/generic/fdrepdlg.cpp:157
 msgid "Search direction"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:112
+#: ../src/generic/fdrepdlg.cpp:109
 msgid "Search for:"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1052
+#: ../src/html/helpwnd.cpp:1050
 msgid "Search in all books"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:857
+#: ../src/html/helpwnd.cpp:855
 msgid "Searching..."
 msgstr ""
 
-#: ../src/generic/dirctrlg.cpp:446
+#: ../src/generic/dirctrlg.cpp:412
 msgid "Sections"
 msgstr "Pjūviai"
 
-#: ../src/common/ffile.cpp:238
+#: ../src/common/ffile.cpp:237
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr ""
 
-#: ../src/common/ffile.cpp:228
+#: ../src/common/ffile.cpp:227
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:76
+#: ../src/common/accelcmn.cpp:73
 msgid "Select"
 msgstr "Parinkti"
 
-#: ../src/richtext/richtextctrl.cpp:337 ../src/osx/textctrl_osx.cpp:581
-#: ../src/common/stockitem.cpp:192 ../src/msw/textctrl.cpp:2512
+#: ../src/osx/textctrl_osx.cpp:599 ../src/common/stockitem.cpp:189
+#: ../src/msw/textctrl.cpp:2777 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "P&ažymėti viską"
 
-#: ../src/common/stockitem.cpp:192 ../src/stc/stc_i18n.cpp:21
+#: ../src/common/stockitem.cpp:189 ../src/stc/stc_i18n.cpp:21
 msgid "Select All"
 msgstr "Pažymėti viską"
 
-#: ../src/common/docview.cpp:1895
+#: ../src/common/docview.cpp:1900
 msgid "Select a document template"
 msgstr ""
 
-#: ../src/common/docview.cpp:1969
+#: ../src/common/docview.cpp:1974
 msgid "Select a document view"
 msgstr ""
 
@@ -6226,20 +6379,20 @@ msgid "Selects the list level to edit."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:82
+#: ../src/common/accelcmn.cpp:79
 msgid "Separator"
 msgstr "Skirtukas"
 
-#: ../src/common/cmdline.cpp:1083
+#: ../src/common/cmdline.cpp:1079
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:572
+#: ../src/osx/menu_osx.cpp:464
 msgid "Services"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11217
+#: ../src/richtext/richtextbuffer.cpp:11216
 msgid "Set Cell Style"
 msgstr ""
 
@@ -6247,11 +6400,11 @@ msgstr ""
 msgid "SetProperty called w/o valid setter"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:188
+#: ../src/generic/prntdlgg.cpp:181
 msgid "Setup..."
 msgstr "Sąranka..."
 
-#: ../src/msw/dialup.cpp:544
+#: ../src/msw/dialup.cpp:538
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr ""
 
@@ -6267,40 +6420,40 @@ msgstr ""
 msgid "Shadow c&olour:"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:335
+#: ../src/common/accelcmn.cpp:349
 msgid "Shift+"
 msgstr "Shift+"
 
-#: ../src/generic/dirdlgg.cpp:147
+#: ../src/generic/dirdlgg.cpp:144
 msgid "Show &hidden directories"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:983
+#: ../src/generic/filectrlg.cpp:979
 msgid "Show &hidden files"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:580
+#: ../src/osx/menu_osx.cpp:472
 msgid "Show All"
 msgstr "Rodyti viską"
 
-#: ../src/common/stockitem.cpp:257
+#: ../src/common/stockitem.cpp:254
 msgid "Show about dialog"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:492
+#: ../src/html/helpwnd.cpp:490
 msgid "Show all"
 msgstr "Rodyti viską"
 
-#: ../src/html/helpwnd.cpp:503
+#: ../src/html/helpwnd.cpp:501
 msgid "Show all items in index"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:656
 msgid "Show/hide navigation panel"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:421
-#: ../src/richtext/richtextsymboldlg.cpp:423
+#: ../src/richtext/richtextsymboldlg.cpp:418
+#: ../src/richtext/richtextsymboldlg.cpp:420
 msgid "Shows a Unicode subset."
 msgstr ""
 
@@ -6316,7 +6469,7 @@ msgstr ""
 msgid "Shows a preview of the font settings."
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:394 ../src/osx/carbon/fontdlg.cpp:396
+#: ../src/osx/carbon/fontdlg.cpp:391 ../src/osx/carbon/fontdlg.cpp:393
 msgid "Shows a preview of the font."
 msgstr ""
 
@@ -6325,62 +6478,62 @@ msgstr ""
 msgid "Shows a preview of the paragraph settings."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:460 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:456 ../src/generic/fontdlgg.cpp:458
 msgid "Shows the font preview."
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1607
+#: ../src/propgrid/advprops.cpp:1513
 msgid "Silver"
 msgstr ""
 
-#: ../src/univ/themes/mono.cpp:516
+#: ../src/univ/themes/mono.cpp:513
 msgid "Simple monochrome theme"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:275
 #: ../src/richtext/richtextliststylepage.cpp:449
+#: ../src/richtext/richtextindentspage.cpp:275
 msgid "Single"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:425 ../src/richtext/richtextformatdlg.cpp:369
-#: ../src/richtext/richtextsizepage.cpp:299
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextsizepage.cpp:299
+#: ../src/richtext/richtextformatdlg.cpp:362
 msgid "Size"
 msgstr "Dydis"
 
-#: ../src/osx/carbon/fontdlg.cpp:339
+#: ../src/osx/carbon/fontdlg.cpp:336
 msgid "Size:"
 msgstr "Dydis:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1775
+#: ../src/propgrid/advprops.cpp:1676
 msgid "Sizing"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1772
+#: ../src/propgrid/advprops.cpp:1673
 msgid "Sizing N-S"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1771
+#: ../src/propgrid/advprops.cpp:1672
 msgid "Sizing NE-SW"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1773
+#: ../src/propgrid/advprops.cpp:1674
 msgid "Sizing NW-SE"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1774
+#: ../src/propgrid/advprops.cpp:1675
 msgid "Sizing W-E"
 msgstr ""
 
-#: ../src/msw/progdlg.cpp:801
+#: ../src/msw/progdlg.cpp:1088
 msgid "Skip"
 msgstr "Praleisti"
 
-#: ../src/generic/fontdlgg.cpp:330
+#: ../src/generic/fontdlgg.cpp:326
 msgid "Slant"
 msgstr ""
 
@@ -6389,7 +6542,7 @@ msgid "Small C&apitals"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:79
+#: ../src/common/accelcmn.cpp:76
 msgid "Snapshot"
 msgstr ""
 
@@ -6397,37 +6550,37 @@ msgstr ""
 msgid "Solid"
 msgstr "Kūnas"
 
-#: ../src/common/docview.cpp:1791
+#: ../src/common/docview.cpp:1785
 msgid "Sorry, could not open this file."
 msgstr ""
 
-#: ../src/common/prntbase.cpp:2057 ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2079 ../src/common/prntbase.cpp:2087
 msgid "Sorry, not enough memory to create a preview."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "Sorry, that name is taken. Please choose another."
 msgstr ""
 
-#: ../src/common/docview.cpp:1814
+#: ../src/common/docview.cpp:1819
 msgid "Sorry, the format for this file is unknown."
 msgstr ""
 
-#: ../src/unix/sound.cpp:492
+#: ../src/unix/sound.cpp:481
 msgid "Sound data are in unsupported format."
 msgstr ""
 
-#: ../src/unix/sound.cpp:477
+#: ../src/unix/sound.cpp:466
 #, c-format
 msgid "Sound file '%s' is in unsupported format."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:67
+#: ../src/common/accelcmn.cpp:64
 msgid "Space"
 msgstr "Tarpas"
 
@@ -6435,12 +6588,12 @@ msgstr "Tarpas"
 msgid "Spacing"
 msgstr "Tarpai"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "Spell Check"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1776
+#: ../src/propgrid/advprops.cpp:1677
 msgid "Spraycan"
 msgstr ""
 
@@ -6449,7 +6602,7 @@ msgstr ""
 msgid "Standard"
 msgstr "Standartinis"
 
-#: ../src/common/paper.cpp:104
+#: ../src/common/paper.cpp:101
 msgid "Statement, 5 1/2 x 8 1/2 in"
 msgstr ""
 
@@ -6458,33 +6611,29 @@ msgstr ""
 msgid "Static"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:204
+#: ../src/generic/prntdlgg.cpp:197
 msgid "Status:"
 msgstr "Būsena:"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "Stop"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196
 msgid "Strikethrough"
 msgstr ""
 
-#: ../src/common/colourcmn.cpp:45
+#: ../src/common/colourcmn.cpp:42
 #, c-format
 msgid "String To Colour : Incorrect colour specification : %s"
 msgstr ""
 
 #. TRANSLATORS: Label of font style
-#: ../src/richtext/richtextformatdlg.cpp:339 ../src/propgrid/advprops.cpp:680
+#: ../src/propgrid/advprops.cpp:590 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Stilius"
 
-#: ../include/wx/richtext/richtextstyledlg.h:46
-msgid "Style Organiser"
-msgstr ""
-
-#: ../src/osx/carbon/fontdlg.cpp:348
+#: ../src/osx/carbon/fontdlg.cpp:345
 msgid "Style:"
 msgstr "Stilius:"
 
@@ -6493,7 +6642,7 @@ msgid "Subscrip&t"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:83
+#: ../src/common/accelcmn.cpp:80
 msgid "Subtract"
 msgstr "Atimti"
 
@@ -6501,11 +6650,11 @@ msgstr "Atimti"
 msgid "Supe&rscript"
 msgstr ""
 
-#: ../src/common/paper.cpp:150
+#: ../src/common/paper.cpp:147
 msgid "SuperA/SuperA/A4 227 x 356 mm"
 msgstr "SuperA/SuperA/A4 227 x 356 mm"
 
-#: ../src/common/paper.cpp:151
+#: ../src/common/paper.cpp:148
 msgid "SuperB/SuperB/A3 305 x 487 mm"
 msgstr "SuperB/SuperB/A3 305 x 487 mm"
 
@@ -6513,7 +6662,7 @@ msgstr "SuperB/SuperB/A3 305 x 487 mm"
 msgid "Suppress hyphe&nation"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:326
+#: ../src/generic/fontdlgg.cpp:322
 msgid "Swiss"
 msgstr ""
 
@@ -6531,73 +6680,73 @@ msgstr ""
 msgid "Symbols"
 msgstr "Simbolis"
 
-#: ../src/common/imagtiff.cpp:369 ../src/common/imagtiff.cpp:382
-#: ../src/common/imagtiff.cpp:741
+#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
+#: ../src/common/imagtiff.cpp:738
 msgid "TIFF: Couldn't allocate memory."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:301
+#: ../src/common/imagtiff.cpp:298
 msgid "TIFF: Error loading image."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:468
+#: ../src/common/imagtiff.cpp:465
 msgid "TIFF: Error reading image."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:608
+#: ../src/common/imagtiff.cpp:605
 msgid "TIFF: Error saving image."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:846
+#: ../src/common/imagtiff.cpp:843
 msgid "TIFF: Error writing image."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:355
+#: ../src/common/imagtiff.cpp:352
 msgid "TIFF: Image size is abnormally big."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:68
+#: ../src/common/accelcmn.cpp:65
 msgid "Tab"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11498
+#: ../src/richtext/richtextbuffer.cpp:11497
 msgid "Table Properties"
 msgstr ""
 
-#: ../src/common/paper.cpp:145
+#: ../src/common/paper.cpp:142
 msgid "Tabloid Extra 11.69 x 18 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:102
+#: ../src/common/paper.cpp:99
 msgid "Tabloid, 11 x 17 in"
 msgstr ""
 
-#: ../src/richtext/richtextformatdlg.cpp:354
+#: ../src/richtext/richtextformatdlg.cpp:347
 msgid "Tabs"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1598
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Teal"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:327
+#: ../src/generic/fontdlgg.cpp:323
 msgid "Teletype"
 msgstr ""
 
-#: ../src/common/docview.cpp:1896
+#: ../src/common/docview.cpp:1901
 msgid "Templates"
 msgstr "Šablonai"
 
-#: ../src/common/fmapbase.cpp:158
+#: ../src/common/fmapbase.cpp:155
 msgid "Thai (ISO-8859-11)"
 msgstr ""
 
-#: ../src/common/ftp.cpp:619
+#: ../src/common/ftp.cpp:622
 msgid "The FTP server doesn't support passive mode."
 msgstr ""
 
-#: ../src/common/ftp.cpp:605
+#: ../src/common/ftp.cpp:608
 msgid "The FTP server doesn't support the PORT command."
 msgstr ""
 
@@ -6608,8 +6757,8 @@ msgstr ""
 msgid "The available bullet styles."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:202
-#: ../src/richtext/richtextstyledlg.cpp:204
+#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:200
 msgid "The available styles."
 msgstr ""
 
@@ -6665,12 +6814,12 @@ msgstr "Apatinė pozicija."
 msgid "The bullet character."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:443
-#: ../src/richtext/richtextsymboldlg.cpp:445
+#: ../src/richtext/richtextsymboldlg.cpp:440
+#: ../src/richtext/richtextsymboldlg.cpp:442
 msgid "The character code."
 msgstr ""
 
-#: ../src/common/fontmap.cpp:203
+#: ../src/common/fontmap.cpp:200
 #, c-format
 msgid ""
 "The charset '%s' is unknown. You may select\n"
@@ -6678,7 +6827,7 @@ msgid ""
 "[Cancel] if it cannot be replaced"
 msgstr ""
 
-#: ../src/msw/ole/dataobj.cpp:394
+#: ../src/msw/ole/dataobj.cpp:402
 #, c-format
 msgid "The clipboard format '%d' doesn't exist."
 msgstr ""
@@ -6688,14 +6837,14 @@ msgstr ""
 msgid "The default style for the next paragraph."
 msgstr ""
 
-#: ../src/generic/dirdlgg.cpp:202
+#: ../src/generic/dirdlgg.cpp:199
 #, c-format
 msgid ""
 "The directory '%s' does not exist\n"
 "Create it now?"
 msgstr ""
 
-#: ../src/html/htmprint.cpp:271
+#: ../src/html/htmprint.cpp:283
 #, c-format
 msgid ""
 "The document \"%s\" doesn't fit on the page horizontally and will be "
@@ -6704,43 +6853,43 @@ msgid ""
 "Would you like to proceed with printing it nevertheless?"
 msgstr ""
 
-#: ../src/common/docview.cpp:1202
+#: ../src/common/docview.cpp:1196
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
 "It has been removed from the most recently used files list."
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:208
-#: ../src/richtext/richtextindentspage.cpp:210
 #: ../src/richtext/richtextliststylepage.cpp:394
 #: ../src/richtext/richtextliststylepage.cpp:396
+#: ../src/richtext/richtextindentspage.cpp:208
+#: ../src/richtext/richtextindentspage.cpp:210
 msgid "The first line indent."
 msgstr ""
 
-#: ../src/gtk/utilsgtk.cpp:481
-msgid "The following standard GTK+ options are also supported:\n"
+#: ../src/generic/dbgrptg.cpp:318
+msgid "The following debug report will be generated\n"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:414 ../src/generic/fontdlgg.cpp:416
+#: ../src/generic/fontdlgg.cpp:411 ../src/generic/fontdlgg.cpp:413
 msgid "The font colour."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:375 ../src/generic/fontdlgg.cpp:377
+#: ../src/generic/fontdlgg.cpp:371 ../src/generic/fontdlgg.cpp:373
 msgid "The font family."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:405
-#: ../src/richtext/richtextsymboldlg.cpp:407
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "The font from which to take the symbol."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:427 ../src/generic/fontdlgg.cpp:429
-#: ../src/generic/fontdlgg.cpp:434 ../src/generic/fontdlgg.cpp:436
+#: ../src/generic/fontdlgg.cpp:424 ../src/generic/fontdlgg.cpp:426
+#: ../src/generic/fontdlgg.cpp:430 ../src/generic/fontdlgg.cpp:432
 msgid "The font point size."
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:343 ../src/osx/carbon/fontdlg.cpp:345
+#: ../src/osx/carbon/fontdlg.cpp:340 ../src/osx/carbon/fontdlg.cpp:342
 msgid "The font size in points."
 msgstr ""
 
@@ -6749,15 +6898,15 @@ msgstr ""
 msgid "The font size units, points or pixels."
 msgstr "Šrifto dydžio vienetai, punktai arba taškai."
 
-#: ../src/generic/fontdlgg.cpp:386 ../src/generic/fontdlgg.cpp:388
+#: ../src/generic/fontdlgg.cpp:382 ../src/generic/fontdlgg.cpp:384
 msgid "The font style."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:397 ../src/generic/fontdlgg.cpp:399
+#: ../src/generic/fontdlgg.cpp:393 ../src/generic/fontdlgg.cpp:395
 msgid "The font weight."
 msgstr ""
 
-#: ../src/common/docview.cpp:1483
+#: ../src/common/docview.cpp:1477
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr ""
@@ -6767,10 +6916,10 @@ msgstr ""
 msgid "The horizontal offset."
 msgstr "Išdėstyti &horizontaliai."
 
-#: ../src/richtext/richtextindentspage.cpp:199
-#: ../src/richtext/richtextindentspage.cpp:201
 #: ../src/richtext/richtextliststylepage.cpp:385
 #: ../src/richtext/richtextliststylepage.cpp:387
+#: ../src/richtext/richtextindentspage.cpp:199
+#: ../src/richtext/richtextindentspage.cpp:201
 msgid "The left indent."
 msgstr ""
 
@@ -6791,10 +6940,10 @@ msgstr ""
 msgid "The left position."
 msgstr "Kairė pozicija."
 
-#: ../src/richtext/richtextindentspage.cpp:288
-#: ../src/richtext/richtextindentspage.cpp:290
 #: ../src/richtext/richtextliststylepage.cpp:462
 #: ../src/richtext/richtextliststylepage.cpp:464
+#: ../src/richtext/richtextindentspage.cpp:288
+#: ../src/richtext/richtextindentspage.cpp:290
 msgid "The line spacing."
 msgstr ""
 
@@ -6803,7 +6952,7 @@ msgstr ""
 msgid "The list item number."
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:664
+#: ../src/msw/ole/automtn.cpp:655
 msgid "The locale ID is unknown."
 msgstr ""
 
@@ -6842,7 +6991,7 @@ msgstr ""
 msgid "The outline level."
 msgstr ""
 
-#: ../src/common/log.cpp:277
+#: ../src/common/log.cpp:296
 #, c-format
 msgid "The previous message repeated %u time."
 msgid_plural "The previous message repeated %u times."
@@ -6850,12 +6999,12 @@ msgstr[0] "Ankstesnis pranešimas pakartotas %u kartą."
 msgstr[1] "Ankstesnis pranešimas pakartotas %u kartų."
 msgstr[2] "Ankstesnis pranešimas pakartotas %u kartų."
 
-#: ../src/common/log.cpp:270
+#: ../src/common/log.cpp:289
 msgid "The previous message repeated once."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:462
-#: ../src/richtext/richtextsymboldlg.cpp:464
+#: ../src/richtext/richtextsymboldlg.cpp:459
+#: ../src/richtext/richtextsymboldlg.cpp:461
 msgid "The range to show."
 msgstr ""
 
@@ -6866,15 +7015,15 @@ msgid ""
 "please uncheck them and they will be removed from the report.\n"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1254
+#: ../src/common/cmdline.cpp:1250
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:217
-#: ../src/richtext/richtextindentspage.cpp:219
 #: ../src/richtext/richtextliststylepage.cpp:403
 #: ../src/richtext/richtextliststylepage.cpp:405
+#: ../src/richtext/richtextindentspage.cpp:217
+#: ../src/richtext/richtextindentspage.cpp:219
 msgid "The right indent."
 msgstr ""
 
@@ -6915,16 +7064,16 @@ msgstr ""
 msgid "The shadow spread."
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:267
 #: ../src/richtext/richtextliststylepage.cpp:439
 #: ../src/richtext/richtextliststylepage.cpp:441
+#: ../src/richtext/richtextindentspage.cpp:267
 msgid "The spacing after the paragraph."
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:257
-#: ../src/richtext/richtextindentspage.cpp:259
 #: ../src/richtext/richtextliststylepage.cpp:430
 #: ../src/richtext/richtextliststylepage.cpp:432
+#: ../src/richtext/richtextindentspage.cpp:257
+#: ../src/richtext/richtextindentspage.cpp:259
 msgid "The spacing before the paragraph."
 msgstr ""
 
@@ -6938,12 +7087,12 @@ msgstr ""
 msgid "The style on which this style is based."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:214
-#: ../src/richtext/richtextstyledlg.cpp:216
+#: ../src/richtext/richtextstyledlg.cpp:210
+#: ../src/richtext/richtextstyledlg.cpp:212
 msgid "The style preview."
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:680
+#: ../src/msw/ole/automtn.cpp:671
 msgid "The system cannot find the file specified."
 msgstr ""
 
@@ -6956,7 +7105,7 @@ msgstr ""
 msgid "The tab positions."
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:3098
+#: ../src/richtext/richtextctrl.cpp:3099
 msgid "The text couldn't be saved."
 msgstr ""
 
@@ -6977,7 +7126,7 @@ msgstr ""
 msgid "The top position."
 msgstr "Viršutinė pozicija."
 
-#: ../src/common/cmdline.cpp:1232
+#: ../src/common/cmdline.cpp:1228
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr ""
@@ -6987,7 +7136,7 @@ msgstr ""
 msgid "The value of the corner radius."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:433
+#: ../src/msw/dialup.cpp:427
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -6999,27 +7148,27 @@ msgstr ""
 msgid "The vertical offset."
 msgstr ""
 
-#: ../src/richtext/richtextprint.cpp:619 ../src/html/htmprint.cpp:745
+#: ../src/html/htmprint.cpp:749 ../src/richtext/richtextprint.cpp:615
 msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr ""
 
-#: ../src/html/htmprint.cpp:255
+#: ../src/html/htmprint.cpp:267
 msgid ""
 "This document doesn't fit on the page horizontally and will be truncated "
 "when it is printed."
 msgstr ""
 
-#: ../src/common/image.cpp:2854
+#: ../src/common/image.cpp:2963
 #, c-format
 msgid "This is not a %s."
 msgstr ""
 
-#: ../src/common/wincmn.cpp:1653
+#: ../src/common/wincmn.cpp:1654
 msgid "This platform does not support background transparency."
 msgstr "Platforma nepalaiko permatomo fono."
 
-#: ../src/gtk/window.cpp:4660
+#: ../src/gtk/window.cpp:5664
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
@@ -7027,96 +7176,104 @@ msgstr ""
 "Ši programa buvo sukompiliuota su sena GKT+ versija, prašome sukompiliuoti "
 "ją su GTK+ 2.12 arba naujesne versija."
 
-#: ../src/msw/thread.cpp:1240
+#: ../src/gtk/glcanvas.cpp:176
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/msw/thread.cpp:1246
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1794
+#: ../src/unix/threadpsx.cpp:1843
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 
-#: ../src/msw/thread.cpp:1228
+#: ../src/msw/thread.cpp:1234
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1043
+#: ../src/unix/threadpsx.cpp:1061
 msgid "Thread priority setting is ignored."
 msgstr ""
 
-#: ../src/msw/mdi.cpp:176
+#: ../src/msw/mdi.cpp:171
 msgid "Tile &Horizontally"
 msgstr "Išdėstyti &horizontaliai"
 
-#: ../src/msw/mdi.cpp:177
+#: ../src/msw/mdi.cpp:172
 msgid "Tile &Vertically"
 msgstr "Išdėstyti &vertikaliai"
 
-#: ../src/common/ftp.cpp:200
+#: ../src/common/ftp.cpp:197
 msgid "Timeout while waiting for FTP server to connect, try passive mode."
 msgstr ""
 
-#: ../src/generic/tipdlg.cpp:201
+#: ../src/generic/tipdlg.cpp:198
 msgid "Tip of the Day"
 msgstr "Dienos patarimas"
 
-#: ../src/generic/tipdlg.cpp:140
+#: ../src/generic/tipdlg.cpp:137
 msgid "Tips not available, sorry!"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:242
+#: ../src/generic/prntdlgg.cpp:235
 msgid "To:"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:8363
+#: ../src/richtext/richtextbuffer.cpp:8361
 msgid "Too many EndStyle calls!"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:891
+#: ../src/propgrid/advprops.cpp:792
 msgid "Tooltip"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:892
+#: ../src/propgrid/advprops.cpp:793
 msgid "TooltipText"
 msgstr ""
 
-#: ../src/richtext/richtextsizepage.cpp:286
-#: ../src/richtext/richtextsizepage.cpp:290 ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197 ../src/richtext/richtextsizepage.cpp:286
+#: ../src/richtext/richtextsizepage.cpp:290
 msgid "Top"
 msgstr "Viršus"
 
-#: ../src/generic/prntdlgg.cpp:881
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Top margin (mm):"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:79
+#: ../src/generic/aboutdlgg.cpp:76
 msgid "Translations by "
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:188
+#: ../src/generic/aboutdlgg.cpp:185
 msgid "Translators"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:211
+#: ../src/propgrid/propgrid.cpp:192
 msgid "True"
 msgstr "Teisingas"
 
-#: ../src/common/fs_mem.cpp:227
+#: ../src/common/fs_mem.cpp:222
 #, c-format
 msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:156
+#: ../src/common/fmapbase.cpp:153
 msgid "Turkish (ISO-8859-9)"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:426
+#: ../src/generic/filectrlg.cpp:422
 msgid "Type"
 msgstr "Tipas"
 
@@ -7130,36 +7287,36 @@ msgstr ""
 msgid "Type a size in points."
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:676
+#: ../src/msw/ole/automtn.cpp:667
 #, c-format
 msgid "Type mismatch in argument %u."
 msgstr ""
 
-#: ../src/common/xtixml.cpp:356 ../src/common/xtixml.cpp:509
-#: ../src/common/xtistrm.cpp:318
+#: ../src/common/xtixml.cpp:352 ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315
 msgid "Type must have enum - long conversion"
 msgstr ""
 
-#: ../src/propgrid/propgridiface.cpp:401
+#: ../src/propgrid/propgridiface.cpp:385
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
 "\"%s\"."
 msgstr ""
 
-#: ../src/common/paper.cpp:133
+#: ../src/common/paper.cpp:130
 msgid "US Std Fanfold, 14 7/8 x 11 in"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:196
+#: ../src/common/fmapbase.cpp:193
 msgid "US-ASCII"
 msgstr ""
 
-#: ../src/unix/fswatcher_inotify.cpp:109
+#: ../src/unix/fswatcher_inotify.cpp:106
 msgid "Unable to add inotify watch"
 msgstr ""
 
-#: ../src/unix/fswatcher_kqueue.cpp:136
+#: ../src/unix/fswatcher_kqueue.cpp:153
 msgid "Unable to add kqueue watch"
 msgstr ""
 
@@ -7171,7 +7328,7 @@ msgstr ""
 msgid "Unable to close I/O completion port handle"
 msgstr ""
 
-#: ../src/unix/fswatcher_inotify.cpp:97
+#: ../src/unix/fswatcher_inotify.cpp:94
 msgid "Unable to close inotify instance"
 msgstr ""
 
@@ -7189,15 +7346,15 @@ msgstr ""
 msgid "Unable to create I/O completion port"
 msgstr ""
 
-#: ../src/msw/fswatcher.cpp:84
+#: ../src/msw/fswatcher.cpp:81
 msgid "Unable to create IOCP worker thread"
 msgstr ""
 
-#: ../src/unix/fswatcher_inotify.cpp:74
+#: ../src/unix/fswatcher_inotify.cpp:71
 msgid "Unable to create inotify instance"
 msgstr ""
 
-#: ../src/unix/fswatcher_kqueue.cpp:97
+#: ../src/unix/fswatcher_kqueue.cpp:114
 msgid "Unable to create kqueue instance"
 msgstr ""
 
@@ -7205,11 +7362,11 @@ msgstr ""
 msgid "Unable to dequeue completion packet"
 msgstr ""
 
-#: ../src/unix/fswatcher_kqueue.cpp:185
+#: ../src/unix/fswatcher_kqueue.cpp:202
 msgid "Unable to get events from kqueue"
 msgstr ""
 
-#: ../src/gtk/app.cpp:435
+#: ../src/gtk/app.cpp:431
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr ""
 
@@ -7218,12 +7375,12 @@ msgstr ""
 msgid "Unable to open path '%s'"
 msgstr ""
 
-#: ../src/html/htmlwin.cpp:583
+#: ../src/html/htmlwin.cpp:586
 #, c-format
 msgid "Unable to open requested HTML document: %s"
 msgstr ""
 
-#: ../src/unix/sound.cpp:368
+#: ../src/unix/sound.cpp:365
 msgid "Unable to play sound asynchronously."
 msgstr ""
 
@@ -7231,61 +7388,61 @@ msgstr ""
 msgid "Unable to post completion status"
 msgstr ""
 
-#: ../src/unix/fswatcher_inotify.cpp:556
+#: ../src/unix/fswatcher_inotify.cpp:553
 msgid "Unable to read from inotify descriptor"
 msgstr ""
 
-#: ../src/unix/fswatcher_inotify.cpp:141
+#: ../src/unix/fswatcher_inotify.cpp:138
 #, c-format
 msgid "Unable to remove inotify watch %i"
 msgstr ""
 
-#: ../src/unix/fswatcher_kqueue.cpp:153
+#: ../src/unix/fswatcher_kqueue.cpp:170
 msgid "Unable to remove kqueue watch"
 msgstr ""
 
-#: ../src/msw/fswatcher.cpp:168
+#: ../src/msw/fswatcher.cpp:165
 #, c-format
 msgid "Unable to set up watch for '%s'"
 msgstr ""
 
-#: ../src/msw/fswatcher.cpp:91
+#: ../src/msw/fswatcher.cpp:88
 msgid "Unable to start IOCP worker thread"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:201
+#: ../src/common/stockitem.cpp:198
 msgid "Undelete"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199
 msgid "Underline"
 msgstr "Pabraukti"
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/richtext/richtextfontpage.cpp:359 ../src/osx/carbon/fontdlg.cpp:370
-#: ../src/propgrid/advprops.cpp:690
+#: ../src/osx/carbon/fontdlg.cpp:367 ../src/propgrid/advprops.cpp:600
+#: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:203 ../src/stc/stc_i18n.cpp:15
+#: ../src/common/stockitem.cpp:200 ../src/stc/stc_i18n.cpp:15
 msgid "Undo"
 msgstr "Atšaukti"
 
-#: ../src/common/stockitem.cpp:265
+#: ../src/common/stockitem.cpp:263
 msgid "Undo last action"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1029
+#: ../src/common/cmdline.cpp:1025
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr ""
 
-#: ../src/unix/fswatcher_inotify.cpp:274
+#: ../src/unix/fswatcher_inotify.cpp:271
 #, c-format
 msgid "Unexpected event for \"%s\": no matching watch descriptor."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1195
+#: ../src/common/cmdline.cpp:1191
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr ""
@@ -7294,49 +7451,49 @@ msgstr ""
 msgid "Unexpectedly new I/O completion port was created"
 msgstr ""
 
-#: ../src/msw/fswatcher.cpp:70
+#: ../src/msw/fswatcher.cpp:67
 msgid "Ungraceful worker thread termination"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:460
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:456
+#: ../src/richtext/richtextsymboldlg.cpp:457
+#: ../src/richtext/richtextsymboldlg.cpp:458
 msgid "Unicode"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:185 ../src/common/fmapbase.cpp:191
+#: ../src/common/fmapbase.cpp:182 ../src/common/fmapbase.cpp:188
 msgid "Unicode 16 bit (UTF-16)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:190
+#: ../src/common/fmapbase.cpp:187
 msgid "Unicode 16 bit Big Endian (UTF-16BE)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:186
+#: ../src/common/fmapbase.cpp:183
 msgid "Unicode 16 bit Little Endian (UTF-16LE)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:187 ../src/common/fmapbase.cpp:193
+#: ../src/common/fmapbase.cpp:184 ../src/common/fmapbase.cpp:190
 msgid "Unicode 32 bit (UTF-32)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:192
+#: ../src/common/fmapbase.cpp:189
 msgid "Unicode 32 bit Big Endian (UTF-32BE)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:188
+#: ../src/common/fmapbase.cpp:185
 msgid "Unicode 32 bit Little Endian (UTF-32LE)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:182
+#: ../src/common/fmapbase.cpp:179
 msgid "Unicode 7 bit (UTF-7)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:183
+#: ../src/common/fmapbase.cpp:180
 msgid "Unicode 8 bit (UTF-8)"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "Unindent"
 msgstr ""
 
@@ -7486,97 +7643,102 @@ msgstr "Viršutinės pozicijos vienetai."
 msgid "Units for this value."
 msgstr ""
 
-#: ../src/generic/progdlgg.cpp:353 ../src/generic/progdlgg.cpp:622
+#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
 msgid "Unknown"
 msgstr "Nežinomas"
 
-#: ../src/msw/dde.cpp:1174
+#: ../src/msw/dde.cpp:1238
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:410
+#: ../src/common/xtistrm.cpp:407
 msgid "Unknown Object passed to GetObjectClassInfo"
 msgstr ""
 
-#: ../src/common/imagpng.cpp:366
+#: ../src/common/imagpng.cpp:383
 #, c-format
 msgid "Unknown PNG resolution unit %d"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:327
+#: ../src/common/xtixml.cpp:323
 #, c-format
 msgid "Unknown Property %s"
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:529
+#: ../src/common/imagtiff.cpp:526
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr ""
 
-#: ../src/unix/dlunix.cpp:160
+#: ../src/propgrid/props.cpp:155
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/unix/dlunix.cpp:118
 msgid "Unknown dynamic library error"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:810
+#: ../src/common/fmapbase.cpp:806
 #, c-format
 msgid "Unknown encoding (%d)"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:688
+#: ../src/msw/ole/automtn.cpp:679
 #, c-format
 msgid "Unknown error %08x"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:647
+#: ../src/msw/ole/automtn.cpp:638
 msgid "Unknown exception"
 msgstr ""
 
-#: ../src/common/image.cpp:2839
+#: ../src/common/image.cpp:2942
 msgid "Unknown image data format."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:914
+#: ../src/common/cmdline.cpp:910
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:631
+#: ../src/msw/ole/automtn.cpp:622
 msgid "Unknown name or named argument."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:929 ../src/common/cmdline.cpp:951
+#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
 #, c-format
 msgid "Unknown option '%s'"
 msgstr ""
 
-#: ../src/common/mimecmn.cpp:225
+#: ../src/common/mimecmn.cpp:221
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr ""
 
-#: ../src/common/cmdproc.cpp:262 ../src/common/cmdproc.cpp:288
-#: ../src/common/cmdproc.cpp:308
+#: ../src/common/cmdproc.cpp:255 ../src/common/cmdproc.cpp:281
+#: ../src/common/cmdproc.cpp:301
 msgid "Unnamed command"
 msgstr ""
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:413
+#: ../src/propgrid/propgrid.cpp:392
 msgid "Unspecified"
 msgstr ""
 
-#: ../src/msw/clipbrd.cpp:311
+#: ../src/msw/clipbrd.cpp:325
 msgid "Unsupported clipboard format."
 msgstr ""
 
-#: ../src/common/appcmn.cpp:256
+#: ../src/common/appcmn.cpp:277
 #, c-format
 msgid "Unsupported theme '%s'."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:205
-#: ../src/common/accelcmn.cpp:63
+#: ../src/common/stockitem.cpp:202 ../src/common/accelcmn.cpp:60
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Up"
 msgstr "Aukštyn"
 
@@ -7590,7 +7752,7 @@ msgstr ""
 msgid "Upper case roman numerals"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1326
+#: ../src/common/cmdline.cpp:1322
 #, c-format
 msgid "Usage: %s"
 msgstr ""
@@ -7599,38 +7761,47 @@ msgstr ""
 msgid "Use &shadow"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:169
-#: ../src/richtext/richtextindentspage.cpp:171
 #: ../src/richtext/richtextliststylepage.cpp:358
 #: ../src/richtext/richtextliststylepage.cpp:360
+#: ../src/richtext/richtextindentspage.cpp:169
+#: ../src/richtext/richtextindentspage.cpp:171
 msgid "Use the current alignment setting."
 msgstr ""
 
-#: ../src/common/valtext.cpp:179
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/gtk/font.cpp:552
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/common/valtext.cpp:142
 msgid "Validation conflict"
 msgstr ""
 
-#: ../src/propgrid/manager.cpp:238
+#: ../src/propgrid/manager.cpp:224
 msgid "Value"
 msgstr "Reikšmė"
 
-#: ../src/propgrid/props.cpp:386 ../src/propgrid/props.cpp:500
+#: ../src/propgrid/props.cpp:309
 #, c-format
 msgid "Value must be %s or higher."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:417 ../src/propgrid/props.cpp:531
+#: ../src/propgrid/props.cpp:336
 #, c-format
 msgid "Value must be %s or less."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:393 ../src/propgrid/props.cpp:424
-#: ../src/propgrid/props.cpp:507 ../src/propgrid/props.cpp:538
+#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:128
+#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Versija "
 
@@ -7639,25 +7810,32 @@ msgstr "Versija "
 msgid "Vertical alignment."
 msgstr "Vertikali lygiuotė."
 
-#: ../src/generic/filedlgg.cpp:202
+#: ../src/generic/filedlgg.cpp:199
 msgid "View files as a detailed view"
 msgstr ""
 
-#: ../src/generic/filedlgg.cpp:200
+#: ../src/generic/filedlgg.cpp:197
 msgid "View files as a list view"
 msgstr ""
 
-#: ../src/common/docview.cpp:1970
+#: ../src/common/docview.cpp:1975
 msgid "Views"
 msgstr "Vaizdai"
 
+#: ../src/gtk/app.cpp:348
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1777
+#: ../src/propgrid/advprops.cpp:1678
 msgid "Wait"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1779
+#: ../src/propgrid/advprops.cpp:1680
 msgid "Wait Arrow"
 msgstr ""
 
@@ -7666,237 +7844,234 @@ msgstr ""
 msgid "Waiting for IO on epoll descriptor %d failed"
 msgstr ""
 
-#: ../src/common/log.cpp:223
+#: ../src/common/log.cpp:241
 msgid "Warning: "
 msgstr "Perspėjimas: "
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1778
+#: ../src/propgrid/advprops.cpp:1679
 msgid "Watch"
 msgstr ""
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:685
+#: ../src/propgrid/advprops.cpp:595
 msgid "Weight"
 msgstr "Storis"
 
-#: ../src/common/fmapbase.cpp:148
+#: ../src/common/fmapbase.cpp:145
 msgid "Western European (ISO-8859-1)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:162
+#: ../src/common/fmapbase.cpp:159
 msgid "Western European with Euro (ISO-8859-15)"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:446 ../src/generic/fontdlgg.cpp:448
+#: ../src/generic/fontdlgg.cpp:443 ../src/generic/fontdlgg.cpp:445
 msgid "Whether the font is underlined."
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1611
+#: ../src/propgrid/advprops.cpp:1517
 msgid "White"
 msgstr "Balta"
 
-#: ../src/generic/fdrepdlg.cpp:144
+#: ../src/generic/fdrepdlg.cpp:141
 msgid "Whole word"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:532
 msgid "Whole words only"
 msgstr ""
 
-#: ../src/univ/themes/win32.cpp:1102
+#: ../src/univ/themes/win32.cpp:1099
 msgid "Win32 theme"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:893
+#: ../src/propgrid/advprops.cpp:794
 msgid "Window"
 msgstr "&Langas"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:894
+#: ../src/propgrid/advprops.cpp:795
 msgid "WindowFrame"
 msgstr "&Langas"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:895
+#: ../src/propgrid/advprops.cpp:796
 msgid "WindowText"
 msgstr "&Langas"
 
-#: ../src/common/fmapbase.cpp:177
+#: ../src/common/fmapbase.cpp:174
 msgid "Windows Arabic (CP 1256)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:178
+#: ../src/common/fmapbase.cpp:175
 msgid "Windows Baltic (CP 1257)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:171
+#: ../src/common/fmapbase.cpp:168
 msgid "Windows Central European (CP 1250)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:168
+#: ../src/common/fmapbase.cpp:165
 msgid "Windows Chinese Simplified (CP 936) or GB-2312"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:170
+#: ../src/common/fmapbase.cpp:167
 msgid "Windows Chinese Traditional (CP 950) or Big-5"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:172
+#: ../src/common/fmapbase.cpp:169
 msgid "Windows Cyrillic (CP 1251)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:174
+#: ../src/common/fmapbase.cpp:171
 msgid "Windows Greek (CP 1253)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:176
+#: ../src/common/fmapbase.cpp:173
 msgid "Windows Hebrew (CP 1255)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:167
+#: ../src/common/fmapbase.cpp:164
 msgid "Windows Japanese (CP 932) or Shift-JIS"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:180
+#: ../src/common/fmapbase.cpp:177
 msgid "Windows Johab (CP 1361)"
 msgstr "Windows Johab (CP 1361)"
 
-#: ../src/common/fmapbase.cpp:169
+#: ../src/common/fmapbase.cpp:166
 msgid "Windows Korean (CP 949)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:166
+#: ../src/common/fmapbase.cpp:163
 msgid "Windows Thai (CP 874)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:175
+#: ../src/common/fmapbase.cpp:172
 msgid "Windows Turkish (CP 1254)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:179
+#: ../src/common/fmapbase.cpp:176
 msgid "Windows Vietnamese (CP 1258)"
 msgstr "Windows Vietnamese (CP 1258)"
 
-#: ../src/common/fmapbase.cpp:173
+#: ../src/common/fmapbase.cpp:170
 msgid "Windows Western European (CP 1252)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:181
+#: ../src/common/fmapbase.cpp:178
 msgid "Windows/DOS OEM (CP 437)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:165
+#: ../src/common/fmapbase.cpp:162
 msgid "Windows/DOS OEM Cyrillic (CP 866)"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:111
+#: ../src/common/accelcmn.cpp:109
 msgid "Windows_Left"
 msgstr "&Langas"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:113
+#: ../src/common/accelcmn.cpp:111
 msgid "Windows_Menu"
 msgstr "&Langas"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:112
+#: ../src/common/accelcmn.cpp:110
 msgid "Windows_Right"
 msgstr "&Langas"
 
-#: ../src/common/ffile.cpp:150
+#: ../src/common/ffile.cpp:149
 #, c-format
 msgid "Write error on file '%s'"
 msgstr ""
 
-#: ../src/xml/xml.cpp:914
+#: ../src/xml/xml.cpp:925
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr ""
 
-#: ../src/common/xpmdecod.cpp:796
+#: ../src/common/xpmdecod.cpp:794
 msgid "XPM: Malformed pixel data!"
 msgstr ""
 
-#: ../src/common/xpmdecod.cpp:705
+#: ../src/common/xpmdecod.cpp:702
 #, c-format
 msgid "XPM: incorrect colour description in line %d"
 msgstr ""
 
-#: ../src/common/xpmdecod.cpp:680
+#: ../src/common/xpmdecod.cpp:677
 msgid "XPM: incorrect header format!"
 msgstr ""
 
-#: ../src/common/xpmdecod.cpp:716 ../src/common/xpmdecod.cpp:725
+#: ../src/common/xpmdecod.cpp:714 ../src/common/xpmdecod.cpp:723
 #, c-format
 msgid "XPM: malformed colour definition '%s' at line %d!"
 msgstr ""
 
-#: ../src/common/xpmdecod.cpp:755
+#: ../src/common/xpmdecod.cpp:753
 msgid "XPM: no colors left to use for mask!"
 msgstr ""
 
-#: ../src/common/xpmdecod.cpp:782
+#: ../src/common/xpmdecod.cpp:780
 #, c-format
 msgid "XPM: truncated image data at line %d!"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1610
+#: ../src/propgrid/advprops.cpp:1516
 msgid "Yellow"
 msgstr "Geltona"
 
-#: ../include/wx/msgdlg.h:276 ../src/common/stockitem.cpp:206
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:203
 #: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Taip"
 
-#: ../src/osx/carbon/overlay.cpp:155
-msgid "You cannot Clear an overlay that is not inited"
-msgstr ""
-
-#: ../src/osx/carbon/overlay.cpp:107 ../src/dfb/overlay.cpp:61
-msgid "You cannot Init an overlay twice"
-msgstr ""
-
-#: ../src/generic/dirdlgg.cpp:287
+#: ../src/generic/dirdlgg.cpp:284
 msgid "You cannot add a new directory to this section."
 msgstr ""
 
-#: ../src/propgrid/propgrid.cpp:3299
+#: ../src/propgrid/propgrid.cpp:3276
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:209
+#: ../src/osx/cocoa/menu.mm:286
+#, fuzzy
+msgid "Zoom"
+msgstr "Didinti"
+
+#: ../src/common/stockitem.cpp:206
 msgid "Zoom &In"
 msgstr "&Didinti"
 
-#: ../src/common/stockitem.cpp:210
+#: ../src/common/stockitem.cpp:207
 msgid "Zoom &Out"
 msgstr "&Mažinti"
 
-#: ../src/common/stockitem.cpp:209 ../src/common/prntbase.cpp:1594
+#: ../src/common/stockitem.cpp:206 ../src/common/prntbase.cpp:1619
 msgid "Zoom In"
 msgstr "Didinti"
 
-#: ../src/common/stockitem.cpp:210 ../src/common/prntbase.cpp:1580
+#: ../src/common/stockitem.cpp:207 ../src/common/prntbase.cpp:1605
 msgid "Zoom Out"
 msgstr "Mažinti"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to &Fit"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to Fit"
 msgstr ""
 
-#: ../src/msw/dde.cpp:1141
+#: ../src/msw/dde.cpp:1205
 msgid "a DDEML application has created a prolonged race condition."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1129
+#: ../src/msw/dde.cpp:1193
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -7904,54 +8079,54 @@ msgid ""
 "was passed to a DDEML function."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1147
+#: ../src/msw/dde.cpp:1211
 msgid "a client's attempt to establish a conversation has failed."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1144
+#: ../src/msw/dde.cpp:1208
 msgid "a memory allocation failed."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1138
+#: ../src/msw/dde.cpp:1202
 msgid "a parameter failed to be validated by the DDEML."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1120
+#: ../src/msw/dde.cpp:1184
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1126
+#: ../src/msw/dde.cpp:1190
 msgid "a request for a synchronous data transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1135
+#: ../src/msw/dde.cpp:1199
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1153
+#: ../src/msw/dde.cpp:1217
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1168
+#: ../src/msw/dde.cpp:1232
 msgid "a request to end an advise transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1162
+#: ../src/msw/dde.cpp:1226
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
 "terminated before completing a transaction."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1150
+#: ../src/msw/dde.cpp:1214
 msgid "a transaction failed."
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:189
+#: ../src/common/accelcmn.cpp:188
 msgid "alt"
 msgstr "alt"
 
-#: ../src/msw/dde.cpp:1132
+#: ../src/msw/dde.cpp:1196
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -7959,71 +8134,71 @@ msgid ""
 "attempted to perform server transactions."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1156
+#: ../src/msw/dde.cpp:1220
 msgid "an internal call to the PostMessage function has failed. "
 msgstr ""
 
-#: ../src/msw/dde.cpp:1165
+#: ../src/msw/dde.cpp:1229
 msgid "an internal error has occurred in the DDEML."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1171
+#: ../src/msw/dde.cpp:1235
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
 "the transaction identifier for that callback is no longer valid."
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1483
+#: ../src/common/zipstrm.cpp:1522
 msgid "assuming this is a multi-part zip concatenated"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1847
+#: ../src/common/fileconf.cpp:1849
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr ""
 
-#: ../src/html/chm.cpp:329
+#: ../src/html/chm.cpp:326
 msgid "bad arguments to library function"
 msgstr ""
 
-#: ../src/html/chm.cpp:341
+#: ../src/html/chm.cpp:338
 msgid "bad signature"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1918
+#: ../src/common/zipstrm.cpp:1988
 msgid "bad zipfile offset to entry"
 msgstr ""
 
-#: ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400
 msgid "binary"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:996
+#: ../src/common/fontcmn.cpp:1195
 msgid "bold"
 msgstr "pastorintas"
 
-#: ../src/msw/utils.cpp:1144
+#: ../src/msw/utils.cpp:1135
 #, c-format
 msgid "build %lu"
 msgstr ""
 
-#: ../src/common/ffile.cpp:75
+#: ../src/common/ffile.cpp:73
 #, c-format
 msgid "can't close file '%s'"
 msgstr ""
 
-#: ../src/common/file.cpp:245
+#: ../src/common/file.cpp:242
 #, c-format
 msgid "can't close file descriptor %d"
 msgstr ""
 
-#: ../src/common/file.cpp:586
+#: ../src/common/ffile.cpp:382 ../src/common/file.cpp:613
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr ""
 
-#: ../src/common/file.cpp:178
+#: ../src/common/file.cpp:175
 #, c-format
 msgid "can't create file '%s'"
 msgstr ""
@@ -8033,49 +8208,49 @@ msgstr ""
 msgid "can't delete user configuration file '%s'"
 msgstr ""
 
-#: ../src/common/file.cpp:495
+#: ../src/common/file.cpp:522
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1692
+#: ../src/common/zipstrm.cpp:1747
 msgid "can't find central directory in zip"
 msgstr ""
 
-#: ../src/common/file.cpp:465
+#: ../src/common/file.cpp:492
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr ""
 
-#: ../src/msw/utils.cpp:341
+#: ../src/msw/utils.cpp:336
 msgid "can't find user's HOME, using current directory."
 msgstr ""
 
-#: ../src/common/file.cpp:366
+#: ../src/common/file.cpp:407
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr ""
 
-#: ../src/common/file.cpp:422
+#: ../src/common/file.cpp:463
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr ""
 
-#: ../src/common/fontmap.cpp:325
+#: ../src/common/fontmap.cpp:322
 msgid "can't load any font, aborting"
 msgstr ""
 
-#: ../src/common/file.cpp:231 ../src/common/ffile.cpp:59
+#: ../src/common/ffile.cpp:57 ../src/common/file.cpp:228
 #, c-format
 msgid "can't open file '%s'"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:320
+#: ../src/common/fileconf.cpp:314
 #, c-format
 msgid "can't open global configuration file '%s'."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:336
+#: ../src/common/fileconf.cpp:330
 #, c-format
 msgid "can't open user configuration file '%s'."
 msgstr ""
@@ -8084,40 +8259,40 @@ msgstr ""
 msgid "can't open user configuration file."
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:579
+#: ../src/common/zipstrm.cpp:572
 msgid "can't re-initialize zlib deflate stream"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:604
+#: ../src/common/zipstrm.cpp:597
 msgid "can't re-initialize zlib inflate stream"
 msgstr ""
 
-#: ../src/common/file.cpp:304
+#: ../src/common/file.cpp:345
 #, c-format
 msgid "can't read from file descriptor %d"
 msgstr ""
 
-#: ../src/common/file.cpp:581
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:608
 #, c-format
 msgid "can't remove file '%s'"
 msgstr ""
 
-#: ../src/common/file.cpp:598
+#: ../src/common/ffile.cpp:394 ../src/common/file.cpp:625
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr ""
 
-#: ../src/common/file.cpp:408
+#: ../src/common/file.cpp:449
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr ""
 
-#: ../src/common/textfile.cpp:273
+#: ../src/common/textfile.cpp:161
 #, c-format
 msgid "can't write buffer '%s' to disk."
 msgstr ""
 
-#: ../src/common/file.cpp:323
+#: ../src/common/file.cpp:364
 #, c-format
 msgid "can't write to file descriptor %d"
 msgstr ""
@@ -8127,22 +8302,28 @@ msgid "can't write user configuration file."
 msgstr ""
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:482 ../src/generic/datavgen.cpp:1261
+#: ../src/common/datavcmn.cpp:2064 ../src/generic/datavgen.cpp:1384
 msgid "checked"
 msgstr ""
 
-#: ../src/html/chm.cpp:345
+#: ../src/html/chm.cpp:342
 msgid "checksum error"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:820
+#: ../src/common/tarstrm.cpp:814
 msgid "checksum failure reading tar header block"
 msgstr ""
 
-#: ../src/richtext/richtextbackgroundpage.cpp:226
-#: ../src/richtext/richtextbackgroundpage.cpp:249
-#: ../src/richtext/richtextbackgroundpage.cpp:289
-#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
 #: ../src/richtext/richtextborderspage.cpp:254
 #: ../src/richtext/richtextborderspage.cpp:288
 #: ../src/richtext/richtextborderspage.cpp:322
@@ -8160,105 +8341,126 @@ msgstr ""
 #: ../src/richtext/richtextmarginspage.cpp:340
 #: ../src/richtext/richtextmarginspage.cpp:363
 #: ../src/richtext/richtextmarginspage.cpp:388
-#: ../src/richtext/richtextsizepage.cpp:339
-#: ../src/richtext/richtextsizepage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:400
-#: ../src/richtext/richtextsizepage.cpp:427
-#: ../src/richtext/richtextsizepage.cpp:454
-#: ../src/richtext/richtextsizepage.cpp:481
-#: ../src/richtext/richtextsizepage.cpp:555
-#: ../src/richtext/richtextsizepage.cpp:590
-#: ../src/richtext/richtextsizepage.cpp:625
-#: ../src/richtext/richtextsizepage.cpp:660
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
 msgid "cm"
 msgstr "cm"
 
-#: ../src/html/chm.cpp:347
+#: ../src/html/chm.cpp:344
 msgid "compression error"
 msgstr ""
 
-#: ../src/common/regex.cpp:236
+#: ../src/common/regex.cpp:233
 msgid "conversion to 8-bit encoding failed"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:187
+#: ../src/common/accelcmn.cpp:186
 msgid "ctrl"
 msgstr "ctrl"
 
-#: ../src/common/cmdline.cpp:1500
+#: ../src/common/cmdline.cpp:1496
 msgid "date"
 msgstr "data"
 
-#: ../src/html/chm.cpp:349
+#: ../src/html/chm.cpp:346
 msgid "decompression error"
 msgstr "išspaudimo klaida"
 
-#: ../src/richtext/richtextstyles.cpp:780 ../src/common/fmapbase.cpp:820
+#: ../src/common/fmapbase.cpp:816 ../src/richtext/richtextstyles.cpp:777
 msgid "default"
 msgstr "numatytasis"
 
-#: ../src/common/cmdline.cpp:1496
+#: ../src/common/cmdline.cpp:1492
 msgid "double"
 msgstr "dvigubas"
 
-#: ../src/common/debugrpt.cpp:538
+#: ../src/common/debugrpt.cpp:539
 msgid "dump of the process state (binary)"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1969
+#: ../src/common/datetimefmt.cpp:1992
 msgid "eighteenth"
 msgstr "aštuonioliktas"
 
-#: ../src/common/datetimefmt.cpp:1959
+#: ../src/common/datetimefmt.cpp:1982
 msgid "eighth"
 msgstr "aštuntas"
 
-#: ../src/common/datetimefmt.cpp:1962
+#: ../src/common/datetimefmt.cpp:1985
 msgid "eleventh"
 msgstr "vienuoliktas"
 
-#: ../src/common/fileconf.cpp:1833
+#: ../src/common/fileconf.cpp:1835
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr ""
 
-#: ../src/html/chm.cpp:343
+#: ../src/html/chm.cpp:340
 msgid "error in data format"
 msgstr ""
 
-#: ../src/html/chm.cpp:331
+#: ../src/html/chm.cpp:328
 msgid "error opening file"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1778
+#: ../src/common/zipstrm.cpp:1836
 msgid "error reading zip central directory"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1870
+#: ../src/common/zipstrm.cpp:1940
 msgid "error reading zip local header"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2531
+#: ../src/common/zipstrm.cpp:2615
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr ""
 
-#: ../src/common/ffile.cpp:188
+#: ../src/common/zipstrm.cpp:2608
+#, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1205
+#, fuzzy
+msgid "extrabold"
+msgstr "pastorintas"
+
+#: ../src/common/fontcmn.cpp:1223
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1167
+#, fuzzy
+msgid "extralight"
+msgstr "lengvas"
+
+#: ../src/msw/webview_ie.cpp:1036
+msgid "failed to evaluate"
+msgstr ""
+
+#: ../src/common/ffile.cpp:187
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr ""
 
+#: ../src/msw/webview_ie.cpp:1045
+msgid "failed to retrieve execution result"
+msgstr ""
+
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1030
+#: ../src/generic/datavgen.cpp:1150
 #, fuzzy
 msgid "false"
 msgstr "Klaidingas"
 
-#: ../src/common/datetimefmt.cpp:1966
+#: ../src/common/datetimefmt.cpp:1989
 msgid "fifteenth"
 msgstr "penkioliktas"
 
-#: ../src/common/datetimefmt.cpp:1956
+#: ../src/common/datetimefmt.cpp:1979
 msgid "fifth"
 msgstr "penktas"
 
@@ -8287,131 +8489,149 @@ msgstr ""
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:8738
+#: ../src/richtext/richtextbuffer.cpp:8736
 msgid "files"
 msgstr "failai"
 
-#: ../src/common/datetimefmt.cpp:1952
+#: ../src/common/datetimefmt.cpp:1975
 msgid "first"
 msgstr "pirmas"
 
-#: ../src/html/helpwnd.cpp:1252
+#: ../src/html/helpwnd.cpp:1250
 msgid "font size"
 msgstr "šrifto dydis"
 
-#: ../src/common/datetimefmt.cpp:1965
+#: ../src/common/datetimefmt.cpp:1988
 msgid "fourteenth"
 msgstr "keturioliktas"
 
-#: ../src/common/datetimefmt.cpp:1955
+#: ../src/common/datetimefmt.cpp:1978
 msgid "fourth"
 msgstr ""
 
-#: ../src/common/appbase.cpp:783
+#: ../src/common/appbase.cpp:784
 msgid "generate verbose log messages"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:13138
-#: ../src/richtext/richtextbuffer.cpp:13248
+#: ../src/common/fontcmn.cpp:1215
+msgid "heavy"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:13133
+#: ../src/richtext/richtextbuffer.cpp:13243
 msgid "image"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:796
+#: ../src/common/tarstrm.cpp:790
 msgid "incomplete header block in tar"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:489
+#: ../src/common/xtixml.cpp:485
 msgid "incorrect event handler string, missing dot"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:1381
+#: ../src/common/tarstrm.cpp:1375
 msgid "incorrect size given for tar entry"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:993
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:987
 msgid "invalid data in extended tar header"
 msgstr ""
 
-#: ../src/generic/logg.cpp:1030
+#: ../src/generic/logg.cpp:1027
 msgid "invalid message box return value"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1647
+#: ../src/common/zipstrm.cpp:1688
 msgid "invalid zip file"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:1228
 msgid "italic"
 msgstr "kursyvas"
 
-#: ../src/common/fontcmn.cpp:991
+#: ../src/common/webrequest_curl.cpp:374
+msgid "libcurl could not be initialized"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1172
 msgid "light"
 msgstr "lengvas"
 
-#: ../src/common/intl.cpp:303
-#, c-format
-msgid "locale '%s' cannot be set."
+#: ../src/common/fontcmn.cpp:1185
+msgid "medium"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2125
+#: ../src/common/datetimefmt.cpp:2148
 msgid "midnight"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1970
+#: ../src/common/datetimefmt.cpp:1993
 msgid "nineteenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1960
+#: ../src/common/datetimefmt.cpp:1983
 msgid "ninth"
 msgstr ""
 
-#: ../src/msw/dde.cpp:1116
+#: ../src/msw/dde.cpp:1180
 msgid "no DDE error."
 msgstr ""
 
-#: ../src/html/chm.cpp:327
+#: ../src/html/chm.cpp:324
 msgid "no error"
 msgstr ""
 
-#: ../src/dfb/fontmgr.cpp:174
+#: ../src/dfb/fontmgr.cpp:171
 #, c-format
 msgid "no fonts found in %s, using builtin font"
 msgstr ""
 
-#: ../src/html/helpdata.cpp:657
+#: ../src/html/helpdata.cpp:650
 msgid "noname"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2124
+#: ../src/common/datetimefmt.cpp:2147
 msgid "noon"
 msgstr ""
 
-#: ../src/richtext/richtextstyles.cpp:779
+#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "normalus"
 
-#: ../src/common/cmdline.cpp:1492
+#: ../src/common/cmdline.cpp:1488
 msgid "num"
 msgstr "num"
 
-#: ../src/common/xtixml.cpp:259
+#: ../src/common/accelcmn.cpp:194
+msgid "num "
+msgstr ""
+
+#: ../src/common/xtixml.cpp:255
 msgid "objects cannot have XML Text Nodes"
 msgstr ""
 
-#: ../src/html/chm.cpp:339
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
 msgid "out of memory"
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:514
+#: ../src/common/debugrpt.cpp:515
 msgid "process context description"
 msgstr ""
 
-#: ../src/richtext/richtextbackgroundpage.cpp:227
-#: ../src/richtext/richtextbackgroundpage.cpp:250
-#: ../src/richtext/richtextbackgroundpage.cpp:290
-#: ../src/richtext/richtextbackgroundpage.cpp:317
-#: ../src/richtext/richtextfontpage.cpp:177
-#: ../src/richtext/richtextfontpage.cpp:180
 #: ../src/richtext/richtextborderspage.cpp:255
 #: ../src/richtext/richtextborderspage.cpp:289
 #: ../src/richtext/richtextborderspage.cpp:323
@@ -8421,22 +8641,45 @@ msgstr ""
 #: ../src/richtext/richtextborderspage.cpp:491
 #: ../src/richtext/richtextborderspage.cpp:525
 #: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextfontpage.cpp:180
 msgid "pt"
 msgstr "pt"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:225
-#: ../src/richtext/richtextbackgroundpage.cpp:228
-#: ../src/richtext/richtextbackgroundpage.cpp:229
-#: ../src/richtext/richtextbackgroundpage.cpp:248
-#: ../src/richtext/richtextbackgroundpage.cpp:251
-#: ../src/richtext/richtextbackgroundpage.cpp:252
-#: ../src/richtext/richtextbackgroundpage.cpp:288
-#: ../src/richtext/richtextbackgroundpage.cpp:291
-#: ../src/richtext/richtextbackgroundpage.cpp:292
-#: ../src/richtext/richtextbackgroundpage.cpp:315
-#: ../src/richtext/richtextbackgroundpage.cpp:318
-#: ../src/richtext/richtextbackgroundpage.cpp:319
-#: ../src/richtext/richtextfontpage.cpp:178
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:659
+#: ../src/richtext/richtextsizepage.cpp:662
+#: ../src/richtext/richtextsizepage.cpp:663
 #: ../src/richtext/richtextborderspage.cpp:253
 #: ../src/richtext/richtextborderspage.cpp:256
 #: ../src/richtext/richtextborderspage.cpp:257
@@ -8488,260 +8731,270 @@ msgstr "pt"
 #: ../src/richtext/richtextmarginspage.cpp:387
 #: ../src/richtext/richtextmarginspage.cpp:389
 #: ../src/richtext/richtextmarginspage.cpp:390
-#: ../src/richtext/richtextsizepage.cpp:338
-#: ../src/richtext/richtextsizepage.cpp:341
-#: ../src/richtext/richtextsizepage.cpp:342
-#: ../src/richtext/richtextsizepage.cpp:372
-#: ../src/richtext/richtextsizepage.cpp:375
-#: ../src/richtext/richtextsizepage.cpp:376
-#: ../src/richtext/richtextsizepage.cpp:399
-#: ../src/richtext/richtextsizepage.cpp:402
-#: ../src/richtext/richtextsizepage.cpp:403
-#: ../src/richtext/richtextsizepage.cpp:426
-#: ../src/richtext/richtextsizepage.cpp:429
-#: ../src/richtext/richtextsizepage.cpp:430
-#: ../src/richtext/richtextsizepage.cpp:453
-#: ../src/richtext/richtextsizepage.cpp:456
-#: ../src/richtext/richtextsizepage.cpp:457
-#: ../src/richtext/richtextsizepage.cpp:480
-#: ../src/richtext/richtextsizepage.cpp:483
-#: ../src/richtext/richtextsizepage.cpp:484
-#: ../src/richtext/richtextsizepage.cpp:554
-#: ../src/richtext/richtextsizepage.cpp:557
-#: ../src/richtext/richtextsizepage.cpp:558
-#: ../src/richtext/richtextsizepage.cpp:589
-#: ../src/richtext/richtextsizepage.cpp:592
-#: ../src/richtext/richtextsizepage.cpp:593
-#: ../src/richtext/richtextsizepage.cpp:624
-#: ../src/richtext/richtextsizepage.cpp:627
-#: ../src/richtext/richtextsizepage.cpp:628
-#: ../src/richtext/richtextsizepage.cpp:659
-#: ../src/richtext/richtextsizepage.cpp:662
-#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextfontpage.cpp:178
 msgid "px"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:193
+#: ../src/common/accelcmn.cpp:192
 msgid "rawctrl"
 msgstr "rawctrl"
 
-#: ../src/html/chm.cpp:333
+#: ../src/html/chm.cpp:330
 msgid "read error"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2085
+#: ../src/common/zipstrm.cpp:2155
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2080
+#: ../src/common/zipstrm.cpp:2150
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr ""
 
-#: ../src/msw/dde.cpp:1159
+#: ../src/msw/dde.cpp:1223
 msgid "reentrancy problem."
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1953
+#: ../src/common/datetimefmt.cpp:1976
 msgid "second"
 msgstr "sekundė"
 
-#: ../src/html/chm.cpp:337
+#: ../src/html/chm.cpp:334
 msgid "seek error"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1968
+#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#, fuzzy
+msgid "semibold"
+msgstr "pastorintas"
+
+#: ../src/common/datetimefmt.cpp:1991
 msgid "seventeenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1958
+#: ../src/common/datetimefmt.cpp:1981
 msgid "seventh"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:191
+#: ../src/common/accelcmn.cpp:190
 msgid "shift"
 msgstr "shift"
 
-#: ../src/common/appbase.cpp:773
+#: ../src/common/appbase.cpp:774
 msgid "show this help message"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1967
+#: ../src/common/datetimefmt.cpp:1990
 msgid "sixteenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1957
+#: ../src/common/datetimefmt.cpp:1980
 msgid "sixth"
 msgstr ""
 
-#: ../src/common/appcmn.cpp:234
+#: ../src/common/appcmn.cpp:255
 msgid "specify display mode to use (e.g. 640x480-16)"
 msgstr ""
 
-#: ../src/common/appcmn.cpp:220
+#: ../src/common/appcmn.cpp:241
 msgid "specify the theme to use"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9340
+#: ../src/richtext/richtextbuffer.cpp:9337
 msgid "standard/circle"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9341
+#: ../src/richtext/richtextbuffer.cpp:9338
 msgid "standard/circle-outline"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9343
+#: ../src/richtext/richtextbuffer.cpp:9340
 msgid "standard/diamond"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9342
+#: ../src/richtext/richtextbuffer.cpp:9339
 msgid "standard/square"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9344
+#: ../src/richtext/richtextbuffer.cpp:9341
 msgid "standard/triangle"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1985
+#: ../src/common/zipstrm.cpp:2055
 msgid "stored file length not in Zip header"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1488
+#: ../src/common/cmdline.cpp:1484
 msgid "str"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:982
+#: ../src/common/fontcmn.cpp:1145
 msgid "strikethrough"
 msgstr "perbrauktas"
 
-#: ../src/common/tarstrm.cpp:1003 ../src/common/tarstrm.cpp:1025
-#: ../src/common/tarstrm.cpp:1507 ../src/common/tarstrm.cpp:1529
+#: ../src/common/tarstrm.cpp:997 ../src/common/tarstrm.cpp:1019
+#: ../src/common/tarstrm.cpp:1501 ../src/common/tarstrm.cpp:1523
 msgid "tar entry not open"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1961
+#: ../src/common/datetimefmt.cpp:1984
 msgid "tenth"
 msgstr ""
 
-#: ../src/msw/dde.cpp:1123
+#: ../src/msw/dde.cpp:1187
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1954
+#: ../src/common/fontcmn.cpp:1154
+msgid "thin"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:1977
 msgid "third"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1964
+#: ../src/common/datetimefmt.cpp:1987
 msgid "thirteenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1758
+#: ../src/common/datetimefmt.cpp:1781
 msgid "today"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1760
+#: ../src/common/datetimefmt.cpp:1783
 msgid "tomorrow"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1944
+#: ../src/common/fileconf.cpp:1946
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr ""
 
-#: ../src/gtk/aboutdlg.cpp:218
+#: ../src/gtk/aboutdlg.cpp:216
 msgid "translator-credits"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1028
+#: ../src/generic/datavgen.cpp:1148
 msgid "true"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1963
+#: ../src/common/datetimefmt.cpp:1986
 msgid "twelfth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1971
+#: ../src/common/datetimefmt.cpp:1994
 msgid "twentieth"
 msgstr ""
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:486 ../src/generic/datavgen.cpp:1263
+#: ../src/common/datavcmn.cpp:2068 ../src/generic/datavgen.cpp:1386
 msgid "unchecked"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:802 ../src/common/fontcmn.cpp:978
+#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
 msgid "underlined"
 msgstr "pabrauktas"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:490
+#: ../src/common/datavcmn.cpp:2072
 #, fuzzy
 msgid "undetermined"
 msgstr "pabrauktas"
 
-#: ../src/common/fileconf.cpp:1979
+#: ../src/common/fileconf.cpp:1981
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:1045
+#: ../src/common/tarstrm.cpp:1039
 msgid "unexpected end of file"
 msgstr ""
 
-#: ../src/generic/progdlgg.cpp:370 ../src/common/tarstrm.cpp:371
-#: ../src/common/tarstrm.cpp:394 ../src/common/tarstrm.cpp:425
+#: ../src/common/tarstrm.cpp:366 ../src/common/tarstrm.cpp:389
+#: ../src/common/tarstrm.cpp:420 ../src/generic/progdlgg.cpp:376
 msgid "unknown"
 msgstr "nežinomas"
 
-#: ../src/msw/registry.cpp:150
+#: ../src/msw/registry.cpp:139
 #, fuzzy, c-format
 msgid "unknown (%lu)"
 msgstr "nežinomas"
 
-#: ../src/common/xtixml.cpp:253
+#: ../src/common/xtixml.cpp:249
 #, c-format
 msgid "unknown class %s"
 msgstr ""
 
-#: ../src/common/regex.cpp:258 ../src/html/chm.cpp:351
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "išspaudimo klaida"
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "išspaudimo klaida"
+
+#: ../src/common/regex.cpp:255 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "nežinoma klaida"
 
-#: ../src/msw/dialup.cpp:471
+#: ../src/msw/dialup.cpp:465
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:834
+#: ../src/common/fmapbase.cpp:830
 #, c-format
 msgid "unknown-%d"
 msgstr ""
 
-#: ../src/common/docview.cpp:509
+#: ../src/common/docview.cpp:502
 msgid "unnamed"
 msgstr ""
 
-#: ../src/common/docview.cpp:1624
+#: ../src/common/docview.cpp:1618
 #, c-format
 msgid "unnamed%d"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1999 ../src/common/zipstrm.cpp:2319
+#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
 msgid "unsupported Zip compression method"
 msgstr ""
 
-#: ../src/common/translation.cpp:1892
+#: ../src/common/translation.cpp:1942
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr ""
 
-#: ../src/html/chm.cpp:335
+#: ../src/html/chm.cpp:332
 msgid "write error"
 msgstr ""
 
-#: ../src/common/time.cpp:292
+#: ../src/gtk/glcanvas.cpp:187
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/common/time.cpp:285
 msgid "wxGetTimeOfDay failed."
 msgstr ""
 
@@ -8754,15 +9007,15 @@ msgstr ""
 msgid "wxWidgets could not open display. Exiting."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:431
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/common/datetimefmt.cpp:1759
+#: ../src/common/datetimefmt.cpp:1782
 msgid "yesterday"
 msgstr ""
 
-#: ../src/common/zstream.cpp:251 ../src/common/zstream.cpp:426
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
 #, c-format
 msgid "zlib error %d"
 msgstr ""
@@ -8771,6 +9024,12 @@ msgstr ""
 #: ../src/richtext/richtextbulletspage.cpp:288
 msgid "~"
 msgstr "~"
+
+#~ msgid "&Save as"
+#~ msgstr "Iš&saugoti kaip"
+
+#~ msgid "Save as"
+#~ msgstr "Išsaugoti kaip"
 
 #~ msgid "Next"
 #~ msgstr "Kitas"

--- a/locale/lv.po
+++ b/locale/lv.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-21 14:25+0200\n"
+"POT-Creation-Date: 2020-10-18 23:11+0300\n"
 "PO-Revision-Date: 2013-01-23 13:14+0300\n"
 "Last-Translator: Jānis Eisaks <jancs@dv.lv>\n"
 "Language-Team: wxWidgets translators <wx-translators@wxwidgets.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "X-Poedit-Country: LATVIA\n"
 "X-Poedit-SourceCharset: utf-8\n"
 
-#: ../src/common/debugrpt.cpp:586
+#: ../src/common/debugrpt.cpp:587
 msgid ""
 "\n"
 "Please send this report to the program maintainer, thank you!\n"
@@ -25,8 +25,8 @@ msgstr ""
 "\n"
 "Lūdzu nosūtiet šo ziņojumu programmas uzturētajam, paldies!\n"
 
-#: ../src/richtext/richtextstyledlg.cpp:210
-#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:206
+#: ../src/richtext/richtextstyledlg.cpp:218
 msgid " "
 msgstr " "
 
@@ -34,70 +34,96 @@ msgstr " "
 msgid "              Thank you and we're sorry for the inconvenience!\n"
 msgstr "              Paldies! Atvainojiet par sagādātajām neērtībām!\n"
 
-#: ../src/common/prntbase.cpp:573
+#: ../src/common/prntbase.cpp:568
 #, fuzzy, c-format
 msgid " (copy %d of %d)"
 msgstr "Lapa %d no %d"
 
-#: ../src/common/log.cpp:421
+#: ../src/common/log.cpp:440
 #, c-format
 msgid " (error %ld: %s)"
 msgstr " (kļūda %ld: %s)"
 
-#: ../src/common/imagtiff.cpp:72
+#: ../src/common/imagtiff.cpp:69
 #, c-format
 msgid " (in module \"%s\")"
 msgstr " (modulī \"%s\")"
 
-#: ../src/osx/core/secretstore.cpp:138
-msgid " (while overwriting an existing item)"
-msgstr ""
-
-#: ../src/common/docview.cpp:1642
+#: ../src/common/docview.cpp:1636
 msgid " - "
 msgstr " - "
 
-#: ../src/richtext/richtextprint.cpp:593 ../src/html/htmprint.cpp:714
+#: ../src/html/htmprint.cpp:712 ../src/richtext/richtextprint.cpp:589
 msgid " Preview"
 msgstr " Priekšskatījums"
 
-#: ../src/common/fontcmn.cpp:824
+#: ../src/common/fontcmn.cpp:973
 msgid " bold"
 msgstr "treknraksts"
 
-#: ../src/common/fontcmn.cpp:840
+#: ../src/common/fontcmn.cpp:977
+#, fuzzy
+msgid " extra bold"
+msgstr "treknraksts"
+
+#: ../src/common/fontcmn.cpp:985
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:957
+#, fuzzy
+msgid " extra light"
+msgstr "gaišs"
+
+#: ../src/common/fontcmn.cpp:981
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1001
 msgid " italic"
 msgstr "kursīvs"
 
-#: ../src/common/fontcmn.cpp:820
+#: ../src/common/fontcmn.cpp:961
 msgid " light"
 msgstr "gaišs"
 
-#: ../src/common/fontcmn.cpp:807
+#: ../src/common/fontcmn.cpp:965
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:969
+#, fuzzy
+msgid " semi bold"
+msgstr "treknraksts"
+
+#: ../src/common/fontcmn.cpp:940
 msgid " strikethrough"
 msgstr " caursvītrots"
 
-#: ../src/common/paper.cpp:117
+#: ../src/common/fontcmn.cpp:953
+msgid " thin"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
 msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
 msgstr "Aploksne Nr. 10, 10.5 x 24.1 cm"
 
-#: ../src/common/paper.cpp:118
+#: ../src/common/paper.cpp:115
 msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
 msgstr "Aploksne Nr. 11, 11.4 x 26.4 cm"
 
-#: ../src/common/paper.cpp:119
+#: ../src/common/paper.cpp:116
 msgid "#12 Envelope, 4 3/4 x 11 in"
 msgstr "Aploksne Nr. 12, 12.1 x 27.9 cm"
 
-#: ../src/common/paper.cpp:120
+#: ../src/common/paper.cpp:117
 msgid "#14 Envelope, 5 x 11 1/2 in"
 msgstr "Aploksne Nr. 14, 12.7 x 29.2 cm"
 
-#: ../src/common/paper.cpp:116
+#: ../src/common/paper.cpp:113
 msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
 msgstr "Aploksne Nr. 9, 9.8 x 22.5 cm"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:341
 #: ../src/richtext/richtextsizepage.cpp:340
 #: ../src/richtext/richtextsizepage.cpp:374
 #: ../src/richtext/richtextsizepage.cpp:401
@@ -108,20 +134,21 @@ msgstr "Aploksne Nr. 9, 9.8 x 22.5 cm"
 #: ../src/richtext/richtextsizepage.cpp:591
 #: ../src/richtext/richtextsizepage.cpp:626
 #: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextbackgroundpage.cpp:341
 msgid "%"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1031
+#: ../src/html/helpwnd.cpp:1029
 #, c-format
 msgid "%d of %lu"
 msgstr "%d no %lu"
 
-#: ../src/html/helpwnd.cpp:1678
+#: ../src/html/helpwnd.cpp:1676
 #, fuzzy, c-format
 msgid "%i of %u"
 msgstr "%i no %i"
 
-#: ../src/generic/filectrlg.cpp:279
+#: ../src/generic/filectrlg.cpp:275
 #, c-format
 msgid "%ld byte"
 msgid_plural "%ld bytes"
@@ -129,61 +156,61 @@ msgstr[0] "%ld baits"
 msgstr[1] "%ld baiti"
 msgstr[2] "%ld baiti"
 
-#: ../src/html/helpwnd.cpp:1033
+#: ../src/html/helpwnd.cpp:1031
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu no %lu"
 
-#: ../src/generic/datavgen.cpp:6028
+#: ../src/generic/datavgen.cpp:6833
 #, fuzzy, c-format
 msgid "%s (%d items)"
 msgstr "%s (vai %s)"
 
-#: ../src/common/cmdline.cpp:1221
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (vai %s)"
 
-#: ../src/generic/logg.cpp:224
+#: ../src/generic/logg.cpp:221
 #, c-format
 msgid "%s Error"
 msgstr "%s Kļuda"
 
-#: ../src/generic/logg.cpp:236
+#: ../src/generic/logg.cpp:233
 #, c-format
 msgid "%s Information"
 msgstr "%s Informācija"
 
-#: ../src/generic/preferencesg.cpp:113
+#: ../src/generic/preferencesg.cpp:110
 #, fuzzy, c-format
 msgid "%s Preferences"
 msgstr "Iestatījumi"
 
-#: ../src/generic/logg.cpp:228
+#: ../src/generic/logg.cpp:225
 #, c-format
 msgid "%s Warning"
 msgstr "%s Brīdinājums"
 
-#: ../src/common/tarstrm.cpp:1319
+#: ../src/common/tarstrm.cpp:1313
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr ""
 
-#: ../src/common/fldlgcmn.cpp:124
+#: ../src/common/fldlgcmn.cpp:121
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s failus (%s)|%s"
 
-#: ../src/html/helpwnd.cpp:1716
+#: ../src/html/helpwnd.cpp:1714
 #, fuzzy, c-format
 msgid "%u of %u"
 msgstr "%lu no %lu"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "&About"
 msgstr "&Par"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "&Actual Size"
 msgstr "&Patiesais izmērs"
 
@@ -191,28 +218,28 @@ msgstr "&Patiesais izmērs"
 msgid "&After a paragraph:"
 msgstr "Aiz rindkopas:"
 
-#: ../src/richtext/richtextindentspage.cpp:128
 #: ../src/richtext/richtextliststylepage.cpp:319
+#: ../src/richtext/richtextindentspage.cpp:128
 msgid "&Alignment"
 msgstr "&Novietojums"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "&Apply"
 msgstr "&Pielietot"
 
-#: ../src/richtext/richtextstyledlg.cpp:251
+#: ../src/richtext/richtextstyledlg.cpp:247
 msgid "&Apply Style"
 msgstr "&Pielietot stilu"
 
-#: ../src/msw/mdi.cpp:179
+#: ../src/msw/mdi.cpp:174
 msgid "&Arrange Icons"
 msgstr "S&akārtot Ikonas"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "&Ascending"
 msgstr "&Augoši"
 
-#: ../src/common/stockitem.cpp:142
+#: ../src/common/stockitem.cpp:139
 msgid "&Back"
 msgstr "A&tpakaļ"
 
@@ -232,24 +259,24 @@ msgstr "&Fona krāsa: "
 msgid "&Blur distance:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:143
+#: ../src/common/stockitem.cpp:140
 msgid "&Bold"
 msgstr "&Treknraksts"
 
-#: ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141
 msgid "&Bottom"
 msgstr "A&pakšā"
 
+#: ../src/richtext/richtextsizepage.cpp:637
+#: ../src/richtext/richtextsizepage.cpp:644
 #: ../src/richtext/richtextborderspage.cpp:345
 #: ../src/richtext/richtextborderspage.cpp:513
 #: ../src/richtext/richtextmarginspage.cpp:259
 #: ../src/richtext/richtextmarginspage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:637
-#: ../src/richtext/richtextsizepage.cpp:644
 msgid "&Bottom:"
 msgstr "&Apakša:"
 
-#: ../include/wx/richtext/richtextbuffer.h:3866
+#: ../include/wx/richtext/richtextbuffer.h:3861
 msgid "&Box"
 msgstr "&Rāmis"
 
@@ -258,38 +285,38 @@ msgstr "&Rāmis"
 msgid "&Bullet style:"
 msgstr "Aizzīmj&u stils:"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "&CD-Rom"
 msgstr "&CD-Rom"
 
-#: ../src/generic/wizard.cpp:434 ../src/generic/fontdlgg.cpp:470
-#: ../src/generic/fontdlgg.cpp:489 ../src/osx/carbon/fontdlg.cpp:402
-#: ../src/common/dlgcmn.cpp:279 ../src/common/stockitem.cpp:145
+#: ../src/osx/carbon/fontdlg.cpp:399 ../src/common/stockitem.cpp:142
+#: ../src/generic/wizard.cpp:433 ../src/generic/fontdlgg.cpp:466
+#: ../src/generic/fontdlgg.cpp:485 ../src/osx/cocoa/button.mm:200
 msgid "&Cancel"
 msgstr "At&celt"
 
-#: ../src/msw/mdi.cpp:175
+#: ../src/msw/mdi.cpp:170
 msgid "&Cascade"
 msgstr "&Kaskādēt"
 
-#: ../include/wx/richtext/richtextbuffer.h:5960
+#: ../include/wx/richtext/richtextbuffer.h:5955
 msgid "&Cell"
 msgstr "Šū&na"
 
-#: ../src/richtext/richtextsymboldlg.cpp:439
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "&Character code:"
 msgstr "Rakstzī&mju kods:"
 
-#: ../src/common/stockitem.cpp:147
+#: ../src/common/stockitem.cpp:144
 msgid "&Clear"
 msgstr "&Notīrīt"
 
-#: ../src/generic/logg.cpp:516 ../src/common/stockitem.cpp:148
-#: ../src/common/prntbase.cpp:1600 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/stockitem.cpp:145 ../src/common/prntbase.cpp:1625
+#: ../src/univ/themes/win32.cpp:3753 ../src/generic/logg.cpp:513
 msgid "&Close"
 msgstr "Ai&zvērt"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "&Color"
 msgstr "&Krāsa"
 
@@ -297,20 +324,20 @@ msgstr "&Krāsa"
 msgid "&Colour:"
 msgstr "&Krāsa:"
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "&Convert"
 msgstr "&Pārveidot"
 
-#: ../src/richtext/richtextctrl.cpp:333 ../src/osx/textctrl_osx.cpp:577
-#: ../src/common/stockitem.cpp:150 ../src/msw/textctrl.cpp:2508
+#: ../src/osx/textctrl_osx.cpp:595 ../src/common/stockitem.cpp:147
+#: ../src/msw/textctrl.cpp:2773 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Kopēt"
 
-#: ../src/generic/hyperlinkg.cpp:156
+#: ../src/generic/hyperlinkg.cpp:153
 msgid "&Copy URL"
 msgstr "&Kopēt URL"
 
-#: ../src/common/headerctrlcmn.cpp:306
+#: ../src/common/headerctrlcmn.cpp:304
 msgid "&Customize..."
 msgstr "&Pielāgot..."
 
@@ -318,53 +345,54 @@ msgstr "&Pielāgot..."
 msgid "&Debug report preview:"
 msgstr "A&tkļūdošanas ziņojuma priekšskatījums:"
 
-#: ../src/richtext/richtexttabspage.cpp:138
-#: ../src/richtext/richtextctrl.cpp:335 ../src/osx/textctrl_osx.cpp:579
-#: ../src/common/stockitem.cpp:152 ../src/msw/textctrl.cpp:2510
+#: ../src/osx/textctrl_osx.cpp:597 ../src/common/stockitem.cpp:149
+#: ../src/msw/textctrl.cpp:2775 ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtextctrl.cpp:334
 msgid "&Delete"
 msgstr "&Dzēst"
 
-#: ../src/richtext/richtextstyledlg.cpp:269
+#: ../src/richtext/richtextstyledlg.cpp:265
 msgid "&Delete Style..."
 msgstr "&Dzēst stilu..."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "&Descending"
 msgstr "&Dilstoši"
 
-#: ../src/generic/logg.cpp:682
+#: ../src/generic/logg.cpp:679
 msgid "&Details"
 msgstr "&Detaļas"
 
-#: ../src/common/stockitem.cpp:153
+#: ../src/common/stockitem.cpp:150
 msgid "&Down"
 msgstr "&Lejup"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "&Edit"
 msgstr "&Labot"
 
-#: ../src/richtext/richtextstyledlg.cpp:263
+#: ../src/richtext/richtextstyledlg.cpp:259
 msgid "&Edit Style..."
 msgstr "&Labot stilu..."
 
-#: ../src/common/stockitem.cpp:155
+#: ../src/common/stockitem.cpp:152
 msgid "&Execute"
 msgstr "&Izpildīt"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/common/stockitem.cpp:154
 msgid "&File"
 msgstr "&Fails"
 
-#: ../src/common/stockitem.cpp:158
-msgid "&Find"
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "&Find..."
 msgstr "&Meklēt"
 
-#: ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:430
 msgid "&Finish"
 msgstr "&Pabeigt"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:156
 msgid "&First"
 msgstr "&Pirmais"
 
@@ -372,15 +400,15 @@ msgstr "&Pirmais"
 msgid "&Floating mode:"
 msgstr "&Peldošais režīms:"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "&Floppy"
 msgstr "&Diskete"
 
-#: ../src/common/stockitem.cpp:194
+#: ../src/common/stockitem.cpp:191
 msgid "&Font"
 msgstr "&Fonts"
 
-#: ../src/generic/fontdlgg.cpp:371
+#: ../src/generic/fontdlgg.cpp:367
 msgid "&Font family:"
 msgstr "&Fontu saime:"
 
@@ -388,20 +416,20 @@ msgstr "&Fontu saime:"
 msgid "&Font for Level..."
 msgstr "Līmeņa &fonts..."
 
+#: ../src/richtext/richtextsymboldlg.cpp:397
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:400
 msgid "&Font:"
 msgstr "&Fonts:"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "&Forward"
 msgstr "Uz &priekšu"
 
-#: ../src/richtext/richtextsymboldlg.cpp:451
+#: ../src/richtext/richtextsymboldlg.cpp:448
 msgid "&From:"
 msgstr "&No:"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "&Harddisk"
 msgstr "&Cietais disks"
 
@@ -410,9 +438,9 @@ msgstr "&Cietais disks"
 msgid "&Height:"
 msgstr "&Augstums:"
 
-#: ../src/generic/wizard.cpp:441 ../src/richtext/richtextstyledlg.cpp:303
-#: ../src/richtext/richtextsymboldlg.cpp:479 ../src/osx/menu_osx.cpp:734
-#: ../src/common/stockitem.cpp:163
+#: ../src/common/stockitem.cpp:160 ../src/generic/wizard.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextstyledlg.cpp:299 ../src/osx/cocoa/menu.mm:226
 msgid "&Help"
 msgstr "&Palīdzība"
 
@@ -420,7 +448,7 @@ msgstr "&Palīdzība"
 msgid "&Hide details"
 msgstr "Slēpt &detaļas"
 
-#: ../src/common/stockitem.cpp:164
+#: ../src/common/stockitem.cpp:161
 msgid "&Home"
 msgstr "&Mājas"
 
@@ -429,54 +457,54 @@ msgstr "&Mājas"
 msgid "&Horizontal offset:"
 msgstr "Vertikālā n&obīde"
 
-#: ../src/richtext/richtextindentspage.cpp:184
 #: ../src/richtext/richtextliststylepage.cpp:372
+#: ../src/richtext/richtextindentspage.cpp:184
 msgid "&Indentation (tenths of a mm)"
 msgstr "Atkāpe (mm desm&itdaļās)"
 
-#: ../src/richtext/richtextindentspage.cpp:167
 #: ../src/richtext/richtextliststylepage.cpp:356
+#: ../src/richtext/richtextindentspage.cpp:167
 msgid "&Indeterminate"
 msgstr "&Nenoteikts"
 
-#: ../src/common/stockitem.cpp:166
+#: ../src/common/stockitem.cpp:163
 msgid "&Index"
 msgstr "&Indekss"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "&Info"
 msgstr "Info"
 
-#: ../src/common/stockitem.cpp:168
+#: ../src/common/stockitem.cpp:165
 msgid "&Italic"
 msgstr "&Slīpraksts"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "&Jump to"
 msgstr "Pārle&kt uz"
 
-#: ../src/richtext/richtextindentspage.cpp:153
 #: ../src/richtext/richtextliststylepage.cpp:342
+#: ../src/richtext/richtextindentspage.cpp:153
 msgid "&Justified"
 msgstr "&Izlīdzināts"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "&Last"
 msgstr "&Pēdējais"
 
-#: ../src/richtext/richtextindentspage.cpp:139
 #: ../src/richtext/richtextliststylepage.cpp:328
+#: ../src/richtext/richtextindentspage.cpp:139
 msgid "&Left"
 msgstr "&Kreisajā pusē"
 
-#: ../src/richtext/richtextindentspage.cpp:195
+#: ../src/richtext/richtextsizepage.cpp:532
+#: ../src/richtext/richtextsizepage.cpp:539
 #: ../src/richtext/richtextborderspage.cpp:243
 #: ../src/richtext/richtextborderspage.cpp:411
 #: ../src/richtext/richtextliststylepage.cpp:381
+#: ../src/richtext/richtextindentspage.cpp:195
 #: ../src/richtext/richtextmarginspage.cpp:186
 #: ../src/richtext/richtextmarginspage.cpp:300
-#: ../src/richtext/richtextsizepage.cpp:532
-#: ../src/richtext/richtextsizepage.cpp:539
 msgid "&Left:"
 msgstr "&Pa kreisi:"
 
@@ -484,11 +512,11 @@ msgstr "&Pa kreisi:"
 msgid "&List level:"
 msgstr "Saraksta &līmenis:"
 
-#: ../src/generic/logg.cpp:517
+#: ../src/generic/logg.cpp:514
 msgid "&Log"
 msgstr "Žurnā&ls"
 
-#: ../src/univ/themes/win32.cpp:3748
+#: ../src/univ/themes/win32.cpp:3745
 msgid "&Move"
 msgstr "&Pārvietot"
 
@@ -496,20 +524,19 @@ msgstr "&Pārvietot"
 msgid "&Move the object to:"
 msgstr "&Pārvietot objektu uz:"
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "&Network"
 msgstr "&Tīkls"
 
-#: ../src/richtext/richtexttabspage.cpp:132 ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173 ../src/richtext/richtexttabspage.cpp:132
 msgid "&New"
 msgstr "&Jauns"
 
-#: ../src/aui/tabmdi.cpp:111 ../src/generic/mdig.cpp:100
-#: ../src/msw/mdi.cpp:180
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
 msgid "&Next"
 msgstr "&Nākošais"
 
-#: ../src/generic/wizard.cpp:432 ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:429
 msgid "&Next >"
 msgstr "&Nākošais >"
 
@@ -517,7 +544,7 @@ msgstr "&Nākošais >"
 msgid "&Next Paragraph"
 msgstr "&Nākamā rindkopa"
 
-#: ../src/generic/tipdlg.cpp:240
+#: ../src/generic/tipdlg.cpp:237
 msgid "&Next Tip"
 msgstr "&Nākošais Padoms"
 
@@ -525,11 +552,11 @@ msgstr "&Nākošais Padoms"
 msgid "&Next style:"
 msgstr "&Nākošais stils:"
 
-#: ../src/common/stockitem.cpp:177 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:174 ../src/msw/msgdlg.cpp:435
 msgid "&No"
 msgstr "&Nē"
 
-#: ../src/generic/dbgrptg.cpp:356
+#: ../src/generic/dbgrptg.cpp:360
 msgid "&Notes:"
 msgstr "Piezī&mes:"
 
@@ -537,12 +564,12 @@ msgstr "Piezī&mes:"
 msgid "&Number:"
 msgstr "&Skaitlis:"
 
-#: ../src/generic/fontdlgg.cpp:475 ../src/generic/fontdlgg.cpp:482
-#: ../src/osx/carbon/fontdlg.cpp:408 ../src/common/stockitem.cpp:178
+#: ../src/osx/carbon/fontdlg.cpp:405 ../src/common/stockitem.cpp:175
+#: ../src/generic/fontdlgg.cpp:471 ../src/generic/fontdlgg.cpp:478
 msgid "&OK"
 msgstr "&Labi"
 
-#: ../src/generic/dbgrptg.cpp:342 ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176 ../src/generic/dbgrptg.cpp:342
 msgid "&Open..."
 msgstr "&Atvērt..."
 
@@ -554,16 +581,16 @@ msgstr "&Aprišu līmenis:"
 msgid "&Page Break"
 msgstr "La&pas atdalītājs"
 
-#: ../src/richtext/richtextctrl.cpp:334 ../src/osx/textctrl_osx.cpp:578
-#: ../src/common/stockitem.cpp:180 ../src/msw/textctrl.cpp:2509
+#: ../src/osx/textctrl_osx.cpp:596 ../src/common/stockitem.cpp:177
+#: ../src/msw/textctrl.cpp:2774 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "Ie&līmēt"
 
-#: ../include/wx/richtext/richtextbuffer.h:5010
+#: ../include/wx/richtext/richtextbuffer.h:5005
 msgid "&Picture"
 msgstr "&Attēls"
 
-#: ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:419
 msgid "&Point size:"
 msgstr "&Punkta izmērs:"
 
@@ -576,12 +603,11 @@ msgstr "No&vietojums (mm desmitdaļās)"
 msgid "&Position mode:"
 msgstr "&Peldošais režīms:"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178
 msgid "&Preferences"
 msgstr "&Preferences"
 
-#: ../src/aui/tabmdi.cpp:112 ../src/generic/mdig.cpp:101
-#: ../src/msw/mdi.cpp:181
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
 msgid "&Previous"
 msgstr "Ie&priekšējais"
 
@@ -589,78 +615,74 @@ msgstr "Ie&priekšējais"
 msgid "&Previous Paragraph"
 msgstr "Ie&priekšējā rindkopa"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "&Print..."
 msgstr "&Drukāt..."
 
-#: ../src/richtext/richtextctrl.cpp:339 ../src/richtext/richtextctrl.cpp:5514
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtextctrl.cpp:338
+#: ../src/richtext/richtextctrl.cpp:5512
 msgid "&Properties"
 msgstr "&Rekvizīti"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "&Quit"
 msgstr "I&ziet"
 
-#: ../src/richtext/richtextctrl.cpp:330 ../src/osx/textctrl_osx.cpp:574
-#: ../src/common/stockitem.cpp:185 ../src/common/cmdproc.cpp:293
-#: ../src/common/cmdproc.cpp:300 ../src/msw/textctrl.cpp:2505
+#: ../src/osx/textctrl_osx.cpp:592 ../src/common/stockitem.cpp:182
+#: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
+#: ../src/msw/textctrl.cpp:2770 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "Atat&saukt"
 
-#: ../src/common/cmdproc.cpp:289 ../src/common/cmdproc.cpp:309
+#: ../src/common/cmdproc.cpp:282 ../src/common/cmdproc.cpp:302
 msgid "&Redo "
 msgstr "Atat&saukt "
 
-#: ../src/richtext/richtextstyledlg.cpp:257
+#: ../src/richtext/richtextstyledlg.cpp:253
 msgid "&Rename Style..."
 msgstr "Pā&rdēvēt stilu..."
 
-#: ../src/generic/fdrepdlg.cpp:179
+#: ../src/generic/fdrepdlg.cpp:176
 msgid "&Replace"
 msgstr "Aiz&vietot"
 
-#: ../src/richtext/richtextstyledlg.cpp:287
+#: ../src/richtext/richtextstyledlg.cpp:283
 msgid "&Restart numbering"
 msgstr "Atsākt numu&rēšanu"
 
-#: ../src/univ/themes/win32.cpp:3747
+#: ../src/univ/themes/win32.cpp:3744
 msgid "&Restore"
 msgstr "At&jaunot"
 
-#: ../src/richtext/richtextindentspage.cpp:146
 #: ../src/richtext/richtextliststylepage.cpp:335
+#: ../src/richtext/richtextindentspage.cpp:146
 msgid "&Right"
 msgstr "&Labajā pusē"
 
-#: ../src/richtext/richtextindentspage.cpp:213
+#: ../src/richtext/richtextsizepage.cpp:602
+#: ../src/richtext/richtextsizepage.cpp:609
 #: ../src/richtext/richtextborderspage.cpp:277
 #: ../src/richtext/richtextborderspage.cpp:445
 #: ../src/richtext/richtextliststylepage.cpp:399
+#: ../src/richtext/richtextindentspage.cpp:213
 #: ../src/richtext/richtextmarginspage.cpp:211
 #: ../src/richtext/richtextmarginspage.cpp:325
-#: ../src/richtext/richtextsizepage.cpp:602
-#: ../src/richtext/richtextsizepage.cpp:609
 msgid "&Right:"
 msgstr "&Pa labi:"
 
-#: ../src/common/stockitem.cpp:190
+#: ../src/common/stockitem.cpp:187
 msgid "&Save"
 msgstr "&Saglabāt"
-
-#: ../src/common/stockitem.cpp:191
-msgid "&Save as"
-msgstr "&Saglabāt Kā "
 
 #: ../include/wx/richmsgdlg.h:29
 msgid "&See details"
 msgstr "&Skatīt detaļas"
 
-#: ../src/generic/tipdlg.cpp:236
+#: ../src/generic/tipdlg.cpp:233
 msgid "&Show tips at startup"
 msgstr "Rādīt dienas padomu&s"
 
-#: ../src/univ/themes/win32.cpp:3750
+#: ../src/univ/themes/win32.cpp:3747
 msgid "&Size"
 msgstr "Izmēr&s"
 
@@ -668,36 +690,36 @@ msgstr "Izmēr&s"
 msgid "&Size:"
 msgstr "&Izmērs:"
 
-#: ../src/generic/progdlgg.cpp:252
+#: ../src/generic/progdlgg.cpp:249
 msgid "&Skip"
 msgstr "&Izlaist"
 
-#: ../src/richtext/richtextindentspage.cpp:242
 #: ../src/richtext/richtextliststylepage.cpp:417
+#: ../src/richtext/richtextindentspage.cpp:242
 msgid "&Spacing (tenths of a mm)"
 msgstr "At&starpe (mm desmitdaļās)"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "&Spell Check"
 msgstr "Pareizrak&stība"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "&Stop"
 msgstr "Ap&stādināt"
 
-#: ../src/richtext/richtextfontpage.cpp:275 ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196 ../src/richtext/richtextfontpage.cpp:275
 msgid "&Strikethrough"
 msgstr "Caur&svītrot"
 
-#: ../src/generic/fontdlgg.cpp:382 ../src/richtext/richtextstylepage.cpp:106
+#: ../src/generic/fontdlgg.cpp:378 ../src/richtext/richtextstylepage.cpp:106
 msgid "&Style:"
 msgstr "&Stils:"
 
-#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:194
 msgid "&Styles:"
 msgstr "&Stili:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:413
+#: ../src/richtext/richtextsymboldlg.cpp:410
 msgid "&Subset:"
 msgstr "&Apakškopa:"
 
@@ -711,24 +733,24 @@ msgstr "&Simbols:"
 msgid "&Synchronize values"
 msgstr ""
 
-#: ../include/wx/richtext/richtextbuffer.h:6069
+#: ../include/wx/richtext/richtextbuffer.h:6064
 msgid "&Table"
 msgstr "&Tabula"
 
-#: ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197
 msgid "&Top"
 msgstr "&Augšā"
 
+#: ../src/richtext/richtextsizepage.cpp:567
+#: ../src/richtext/richtextsizepage.cpp:574
 #: ../src/richtext/richtextborderspage.cpp:311
 #: ../src/richtext/richtextborderspage.cpp:479
 #: ../src/richtext/richtextmarginspage.cpp:234
 #: ../src/richtext/richtextmarginspage.cpp:348
-#: ../src/richtext/richtextsizepage.cpp:567
-#: ../src/richtext/richtextsizepage.cpp:574
 msgid "&Top:"
 msgstr "&Augša:"
 
-#: ../src/generic/fontdlgg.cpp:444 ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199 ../src/generic/fontdlgg.cpp:441
 msgid "&Underline"
 msgstr "Pasvītroj&ums"
 
@@ -736,21 +758,21 @@ msgstr "Pasvītroj&ums"
 msgid "&Underlining:"
 msgstr "Pasvītroj&ums:"
 
-#: ../src/richtext/richtextctrl.cpp:329 ../src/osx/textctrl_osx.cpp:573
-#: ../src/common/stockitem.cpp:203 ../src/common/cmdproc.cpp:271
-#: ../src/msw/textctrl.cpp:2504
+#: ../src/osx/textctrl_osx.cpp:591 ../src/common/stockitem.cpp:200
+#: ../src/common/cmdproc.cpp:264 ../src/msw/textctrl.cpp:2769
+#: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "Atsa&ukt"
 
-#: ../src/common/cmdproc.cpp:265
+#: ../src/common/cmdproc.cpp:258
 msgid "&Undo "
 msgstr "Atsa&ukt "
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "&Unindent"
 msgstr "&Samazināt atkāpi"
 
-#: ../src/common/stockitem.cpp:205
+#: ../src/common/stockitem.cpp:202
 msgid "&Up"
 msgstr "A&ugšup"
 
@@ -767,7 +789,7 @@ msgstr "Vertikālā n&obīde"
 msgid "&View..."
 msgstr "&Skatīt..."
 
-#: ../src/generic/fontdlgg.cpp:393
+#: ../src/generic/fontdlgg.cpp:389
 msgid "&Weight:"
 msgstr "&Svars:"
 
@@ -776,88 +798,58 @@ msgstr "&Svars:"
 msgid "&Width:"
 msgstr "&Platums:"
 
-#: ../src/aui/tabmdi.cpp:311 ../src/aui/tabmdi.cpp:327
-#: ../src/aui/tabmdi.cpp:329 ../src/generic/mdig.cpp:294
-#: ../src/generic/mdig.cpp:310 ../src/generic/mdig.cpp:314
-#: ../src/msw/mdi.cpp:78
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
 msgid "&Window"
 msgstr "&Logs"
 
-#: ../src/common/stockitem.cpp:206 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:203 ../src/msw/msgdlg.cpp:435
 msgid "&Yes"
 msgstr "&Jā"
 
-#: ../src/common/valtext.cpp:256
+#: ../src/common/valtext.cpp:197
 #, fuzzy, c-format
-msgid "'%s' contains illegal characters"
+msgid "'%s' contains invalid character(s)"
 msgstr "'%s' drīkst saturēt tikai alfabēta rakstzīmes."
 
-#: ../src/common/valtext.cpp:254
-#, fuzzy, c-format
-msgid "'%s' doesn't consist only of valid characters"
-msgstr "'%s' drīkst saturēt tikai alfabēta rakstzīmes."
-
-#: ../src/common/config.cpp:519 ../src/msw/regconf.cpp:258
+#: ../src/common/config.cpp:515 ../src/msw/regconf.cpp:255
 #, c-format
 msgid "'%s' has extra '..', ignored."
 msgstr "'%s' ir lieks '..', nav ņemts vērā."
 
-#: ../src/common/cmdline.cpp:1113 ../src/common/cmdline.cpp:1131
+#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' ir nekorekta skaitliska vērtība opcijai '%s'."
 
-#: ../src/common/translation.cpp:1100
+#: ../src/common/translation.cpp:1142
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' ir nederīgs ziņojumu katalogs."
 
-#: ../src/common/valtext.cpp:165
+#: ../src/common/valtext.cpp:188
 #, fuzzy, c-format
 msgid "'%s' is not one of the valid strings"
 msgstr "'%s' ir nederīgs ziņojumu katalogs."
 
-#: ../src/common/valtext.cpp:167
+#: ../src/common/valtext.cpp:186
 #, fuzzy, c-format
 msgid "'%s' is one of the invalid strings"
 msgstr "'%s' ir nederīgs"
 
-#: ../src/common/textbuf.cpp:237
+#: ../src/common/textbuf.cpp:233
 #, c-format
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s', iespējams, ir binārais buferis."
-
-#: ../src/common/valtext.cpp:252
-#, c-format
-msgid "'%s' should be numeric."
-msgstr "'%s' ir jābūt skaitliskam."
-
-#: ../src/common/valtext.cpp:244
-#, c-format
-msgid "'%s' should only contain ASCII characters."
-msgstr "'%s' drīkst saturēt tikai ASCII simbolus."
-
-#: ../src/common/valtext.cpp:246
-#, c-format
-msgid "'%s' should only contain alphabetic characters."
-msgstr "'%s' drīkst saturēt tikai alfabēta rakstzīmes."
-
-#: ../src/common/valtext.cpp:248
-#, c-format
-msgid "'%s' should only contain alphabetic or numeric characters."
-msgstr "'%s' drīkst saturēt tikai alfabēta un skaitliskas rakstzīmes."
-
-#: ../src/common/valtext.cpp:250
-#, c-format
-msgid "'%s' should only contain digits."
-msgstr "'%s' drīkst saturēt tikai ciparus."
 
 #: ../src/richtext/richtextliststylepage.cpp:229
 #: ../src/richtext/richtextbulletspage.cpp:166
 msgid "(*)"
 msgstr "(*)"
 
-#: ../src/html/helpwnd.cpp:963
+#: ../src/html/helpwnd.cpp:961
 msgid "(Help)"
 msgstr "(Palīdzība)"
 
@@ -866,27 +858,32 @@ msgstr "(Palīdzība)"
 msgid "(None)"
 msgstr "(Nekas)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:504
+#: ../src/richtext/richtextsymboldlg.cpp:503
 msgid "(Normal text)"
 msgstr "(Parasts teksts)"
 
-#: ../src/html/helpwnd.cpp:419 ../src/html/helpwnd.cpp:1106
-#: ../src/html/helpwnd.cpp:1742
+#: ../src/html/helpwnd.cpp:417 ../src/html/helpwnd.cpp:1104
+#: ../src/html/helpwnd.cpp:1740
 msgid "(bookmarks)"
 msgstr "(grāmatzīme)"
 
+#: ../src/msw/dlmsw.cpp:167
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (kļūda %ld: %s)"
+
+#: ../src/richtext/richtextformatdlg.cpp:876
+#: ../src/richtext/richtextliststylepage.cpp:448
+#: ../src/richtext/richtextliststylepage.cpp:460
+#: ../src/richtext/richtextliststylepage.cpp:461
 #: ../src/richtext/richtextindentspage.cpp:274
 #: ../src/richtext/richtextindentspage.cpp:286
 #: ../src/richtext/richtextindentspage.cpp:287
 #: ../src/richtext/richtextindentspage.cpp:311
 #: ../src/richtext/richtextindentspage.cpp:326
-#: ../src/richtext/richtextformatdlg.cpp:884
 #: ../src/richtext/richtextfontpage.cpp:349
 #: ../src/richtext/richtextfontpage.cpp:353
 #: ../src/richtext/richtextfontpage.cpp:357
-#: ../src/richtext/richtextliststylepage.cpp:448
-#: ../src/richtext/richtextliststylepage.cpp:460
-#: ../src/richtext/richtextliststylepage.cpp:461
 msgid "(none)"
 msgstr "(nekas)"
 
@@ -905,7 +902,7 @@ msgstr "*)"
 msgid "+"
 msgstr "+"
 
-#: ../src/msw/utils.cpp:1152
+#: ../src/msw/utils.cpp:1143
 msgid ", 64-bit edition"
 msgstr ", 64 bitu versija"
 
@@ -914,163 +911,163 @@ msgstr ", 64 bitu versija"
 msgid "-"
 msgstr "-"
 
-#: ../src/generic/filepickerg.cpp:66
+#: ../src/generic/filepickerg.cpp:63
 msgid "..."
 msgstr "..."
 
-#: ../src/richtext/richtextindentspage.cpp:276
 #: ../src/richtext/richtextliststylepage.cpp:450
+#: ../src/richtext/richtextindentspage.cpp:276
 msgid "1.1"
 msgstr "1.1"
 
-#: ../src/richtext/richtextindentspage.cpp:277
 #: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextindentspage.cpp:277
 msgid "1.2"
 msgstr "1.2"
 
-#: ../src/richtext/richtextindentspage.cpp:278
 #: ../src/richtext/richtextliststylepage.cpp:452
+#: ../src/richtext/richtextindentspage.cpp:278
 msgid "1.3"
 msgstr "1.3"
 
-#: ../src/richtext/richtextindentspage.cpp:279
 #: ../src/richtext/richtextliststylepage.cpp:453
+#: ../src/richtext/richtextindentspage.cpp:279
 msgid "1.4"
 msgstr "1.4"
 
-#: ../src/richtext/richtextindentspage.cpp:280
 #: ../src/richtext/richtextliststylepage.cpp:454
+#: ../src/richtext/richtextindentspage.cpp:280
 msgid "1.5"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:281
 #: ../src/richtext/richtextliststylepage.cpp:455
+#: ../src/richtext/richtextindentspage.cpp:281
 msgid "1.6"
 msgstr "1.6"
 
-#: ../src/richtext/richtextindentspage.cpp:282
 #: ../src/richtext/richtextliststylepage.cpp:456
+#: ../src/richtext/richtextindentspage.cpp:282
 msgid "1.7"
 msgstr "1.7"
 
-#: ../src/richtext/richtextindentspage.cpp:283
 #: ../src/richtext/richtextliststylepage.cpp:457
+#: ../src/richtext/richtextindentspage.cpp:283
 msgid "1.8"
 msgstr "1.8"
 
-#: ../src/richtext/richtextindentspage.cpp:284
 #: ../src/richtext/richtextliststylepage.cpp:458
+#: ../src/richtext/richtextindentspage.cpp:284
 msgid "1.9"
 msgstr "1.9"
 
-#: ../src/common/paper.cpp:140
+#: ../src/common/paper.cpp:137
 msgid "10 x 11 in"
 msgstr "10 x 11 in"
 
-#: ../src/common/paper.cpp:113
+#: ../src/common/paper.cpp:110
 msgid "10 x 14 in"
 msgstr "25.4 x 35.6 cm"
 
-#: ../src/common/paper.cpp:114
+#: ../src/common/paper.cpp:111
 msgid "11 x 17 in"
 msgstr "27.9 x 43.2 cm"
 
-#: ../src/common/paper.cpp:184
+#: ../src/common/paper.cpp:181
 msgid "12 x 11 in"
 msgstr "12 x 11 in"
 
-#: ../src/common/paper.cpp:141
+#: ../src/common/paper.cpp:138
 msgid "15 x 11 in"
 msgstr "15 x 11 in"
 
-#: ../src/richtext/richtextindentspage.cpp:285
 #: ../src/richtext/richtextliststylepage.cpp:459
+#: ../src/richtext/richtextindentspage.cpp:285
 msgid "2"
 msgstr "2"
 
-#: ../src/common/paper.cpp:132
+#: ../src/common/paper.cpp:129
 msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
 msgstr "Aplpksne 6 3/4, 9.2 x 16.5 cm"
 
-#: ../src/common/paper.cpp:139
+#: ../src/common/paper.cpp:136
 msgid "9 x 11 in"
 msgstr "9 x 11 in"
 
-#: ../src/html/htmprint.cpp:431
+#: ../src/html/htmprint.cpp:443
 msgid ": file does not exist!"
 msgstr ": fails neeksistē!"
 
-#: ../src/common/fontmap.cpp:199
+#: ../src/common/fontmap.cpp:196
 msgid ": unknown charset"
 msgstr ": nezināma rakstzīmju kopa"
 
-#: ../src/common/fontmap.cpp:413
+#: ../src/common/fontmap.cpp:410
 msgid ": unknown encoding"
 msgstr ": nezināms kodējums"
 
-#: ../src/generic/wizard.cpp:443
+#: ../src/generic/wizard.cpp:438
 msgid "< &Back"
 msgstr "< At&pakaļ"
 
-#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:628
-#: ../src/osx/carbon/fontdlg.cpp:648
+#: ../src/osx/carbon/fontdlg.cpp:419 ../src/osx/carbon/fontdlg.cpp:625
+#: ../src/osx/carbon/fontdlg.cpp:645
 msgid "<Any Decorative>"
 msgstr "<Jebkurš dekoratīvais>"
 
-#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:630
-#: ../src/osx/carbon/fontdlg.cpp:650
+#: ../src/osx/carbon/fontdlg.cpp:420 ../src/osx/carbon/fontdlg.cpp:627
+#: ../src/osx/carbon/fontdlg.cpp:647
 msgid "<Any Modern>"
 msgstr "<Jebkurš modernais>"
 
-#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:626
-#: ../src/osx/carbon/fontdlg.cpp:646
+#: ../src/osx/carbon/fontdlg.cpp:418 ../src/osx/carbon/fontdlg.cpp:623
+#: ../src/osx/carbon/fontdlg.cpp:643
 msgid "<Any Roman>"
 msgstr "<Jebkurš romāņu>"
 
-#: ../src/osx/carbon/fontdlg.cpp:424 ../src/osx/carbon/fontdlg.cpp:632
-#: ../src/osx/carbon/fontdlg.cpp:652
+#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:629
+#: ../src/osx/carbon/fontdlg.cpp:649
 msgid "<Any Script>"
 msgstr "<Jebkurš rokraksta>"
 
-#: ../src/osx/carbon/fontdlg.cpp:425 ../src/osx/carbon/fontdlg.cpp:637
-#: ../src/osx/carbon/fontdlg.cpp:656
+#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:634
+#: ../src/osx/carbon/fontdlg.cpp:653
 msgid "<Any Swiss>"
 msgstr "<Jebkurš Šveices>"
 
-#: ../src/osx/carbon/fontdlg.cpp:426 ../src/osx/carbon/fontdlg.cpp:634
-#: ../src/osx/carbon/fontdlg.cpp:654
+#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:631
+#: ../src/osx/carbon/fontdlg.cpp:651
 msgid "<Any Teletype>"
 msgstr "<Jebkurš teletaipa>"
 
-#: ../src/osx/carbon/fontdlg.cpp:420
+#: ../src/osx/carbon/fontdlg.cpp:417
 msgid "<Any>"
 msgstr "<Jebkurš>"
 
-#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
 msgid "<DIR>"
 msgstr "<DIR>"
 
-#: ../src/generic/filectrlg.cpp:254 ../src/generic/filectrlg.cpp:277
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
 msgid "<DRIVE>"
 msgstr "<DISKS>"
 
-#: ../src/generic/filectrlg.cpp:252 ../src/generic/filectrlg.cpp:275
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
 msgid "<LINK>"
 msgstr "<SAITE>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1264
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Treknraksts kursīvā.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1270
+#: ../src/html/helpwnd.cpp:1268
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>treknraksts kursīvā <u>pasvītrots</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1265
+#: ../src/html/helpwnd.cpp:1263
 msgid "<b>Bold face.</b> "
 msgstr "<b>Treknraksts.</b> "
 
-#: ../src/html/helpwnd.cpp:1264
+#: ../src/html/helpwnd.cpp:1262
 msgid "<i>Italic face.</i> "
 msgstr "<i>Kursīvs.</i>"
 
@@ -1079,15 +1076,15 @@ msgstr "<i>Kursīvs.</i>"
 msgid ">"
 msgstr ">"
 
-#: ../src/generic/dbgrptg.cpp:318
+#: ../src/generic/dbgrptg.cpp:317
 msgid "A debug report has been generated in the directory\n"
 msgstr "Atkļūdošanas atskaite izveidota mapē\n"
 
-#: ../src/common/debugrpt.cpp:573
+#: ../src/common/debugrpt.cpp:574
 msgid "A debug report has been generated. It can be found in"
 msgstr "Atkļūdošanas ziņojums ir izveidots. Tas ir atrodams"
 
-#: ../src/common/xtixml.cpp:418
+#: ../src/common/xtixml.cpp:414
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr ""
 
@@ -1098,106 +1095,106 @@ msgstr ""
 msgid "A standard bullet name."
 msgstr "Standarta aizzīmes nosaukums."
 
-#: ../src/common/paper.cpp:217
+#: ../src/common/paper.cpp:214
 msgid "A0 sheet, 841 x 1189 mm"
 msgstr "A0 loksne, 841 x 1189 mm"
 
-#: ../src/common/paper.cpp:218
+#: ../src/common/paper.cpp:215
 msgid "A1 sheet, 594 x 841 mm"
 msgstr "A1 loksne,  594 x 841 mm"
 
-#: ../src/common/paper.cpp:159
+#: ../src/common/paper.cpp:156
 msgid "A2 420 x 594 mm"
 msgstr "A2 420 x 594 mm"
 
-#: ../src/common/paper.cpp:156
+#: ../src/common/paper.cpp:153
 msgid "A3 Extra 322 x 445 mm"
 msgstr "A3 Extra 322 x 445 mm"
 
-#: ../src/common/paper.cpp:161
+#: ../src/common/paper.cpp:158
 msgid "A3 Extra Transverse 322 x 445 mm"
 msgstr "A3 Extra Transverse 322 x 445 mm"
 
-#: ../src/common/paper.cpp:170
+#: ../src/common/paper.cpp:167
 msgid "A3 Rotated 420 x 297 mm"
 msgstr "A3 Rotated 420 x 297 mm"
 
-#: ../src/common/paper.cpp:160
+#: ../src/common/paper.cpp:157
 msgid "A3 Transverse 297 x 420 mm"
 msgstr "A3 Transverse 297 x 420 mm"
 
-#: ../src/common/paper.cpp:106
+#: ../src/common/paper.cpp:103
 msgid "A3 sheet, 297 x 420 mm"
 msgstr "A3 loksne, 297 x 420 mm"
 
-#: ../src/common/paper.cpp:146
+#: ../src/common/paper.cpp:143
 msgid "A4 Extra 9.27 x 12.69 in"
 msgstr "A4 Extra 9.27 x 12.69 in"
 
-#: ../src/common/paper.cpp:153
+#: ../src/common/paper.cpp:150
 msgid "A4 Plus 210 x 330 mm"
 msgstr "A4 Plus 210 x 330 mm"
 
-#: ../src/common/paper.cpp:171
+#: ../src/common/paper.cpp:168
 msgid "A4 Rotated 297 x 210 mm"
 msgstr "A4 Rotated 297 x 210 mm"
 
-#: ../src/common/paper.cpp:148
+#: ../src/common/paper.cpp:145
 msgid "A4 Transverse 210 x 297 mm"
 msgstr "A4 Transverse 210 x 297 mm"
 
-#: ../src/common/paper.cpp:97
+#: ../src/common/paper.cpp:94
 msgid "A4 sheet, 210 x 297 mm"
 msgstr "A4 loksne, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:107
+#: ../src/common/paper.cpp:104
 msgid "A4 small sheet, 210 x 297 mm"
 msgstr "A4 mazā loksne, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:157
+#: ../src/common/paper.cpp:154
 msgid "A5 Extra 174 x 235 mm"
 msgstr "A5 Extra 174 x 235 mm"
 
-#: ../src/common/paper.cpp:172
+#: ../src/common/paper.cpp:169
 msgid "A5 Rotated 210 x 148 mm"
 msgstr "A5 Rotated 210 x 148 mm"
 
-#: ../src/common/paper.cpp:154
+#: ../src/common/paper.cpp:151
 msgid "A5 Transverse 148 x 210 mm"
 msgstr "A5 Transverse 148 x 210 mm"
 
-#: ../src/common/paper.cpp:108
+#: ../src/common/paper.cpp:105
 msgid "A5 sheet, 148 x 210 mm"
 msgstr "A5 loksne, 148 x 210 mm"
 
-#: ../src/common/paper.cpp:164
+#: ../src/common/paper.cpp:161
 msgid "A6 105 x 148 mm"
 msgstr "A6 105 x 148 mm"
 
-#: ../src/common/paper.cpp:177
+#: ../src/common/paper.cpp:174
 msgid "A6 Rotated 148 x 105 mm"
 msgstr "A6 Rotated 148 x 105 mm"
 
-#: ../src/generic/fontdlgg.cpp:83 ../src/richtext/richtextformatdlg.cpp:529
-#: ../src/osx/carbon/fontdlg.cpp:153
+#: ../src/osx/carbon/fontdlg.cpp:150 ../src/generic/fontdlgg.cpp:79
+#: ../src/richtext/richtextformatdlg.cpp:521
 msgid "ABCDEFGabcdefg12345"
 msgstr "AĀBCČDŠaābcčdš12345"
 
-#: ../src/richtext/richtextsymboldlg.cpp:458 ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
 msgid "ASCII"
 msgstr "ASCII"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "About"
 msgstr "Par"
 
-#: ../src/generic/aboutdlgg.cpp:140 ../src/osx/menu_osx.cpp:558
-#: ../src/msw/aboutdlg.cpp:64
+#: ../src/osx/menu_osx.cpp:450 ../src/generic/aboutdlgg.cpp:137
+#: ../src/msw/aboutdlg.cpp:61
 #, c-format
 msgid "About %s"
 msgstr "Par %s"
 
-#: ../src/osx/menu_osx.cpp:560
+#: ../src/osx/menu_osx.cpp:452
 #, fuzzy
 msgid "About..."
 msgstr "P&ar..."
@@ -1207,38 +1204,38 @@ msgid "Absolute"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:873
+#: ../src/propgrid/advprops.cpp:774
 #, fuzzy
 msgid "ActiveBorder"
 msgstr "Mala"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:874
+#: ../src/propgrid/advprops.cpp:775
 msgid "ActiveCaption"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "Actual Size"
 msgstr "Patiesais Izmērs"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:140 ../src/common/accelcmn.cpp:81
+#: ../src/common/stockitem.cpp:137 ../src/common/accelcmn.cpp:78
 msgid "Add"
 msgstr "Pievienot"
 
-#: ../src/richtext/richtextbuffer.cpp:11455
+#: ../src/richtext/richtextbuffer.cpp:11454
 msgid "Add Column"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11392
+#: ../src/richtext/richtextbuffer.cpp:11391
 msgid "Add Row"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:432
+#: ../src/html/helpwnd.cpp:430
 msgid "Add current page to bookmarks"
 msgstr "Pievienot grāmatzīmēm pašreizējo lapu"
 
-#: ../src/generic/colrdlgg.cpp:366
+#: ../src/generic/colrdlgg.cpp:386
 msgid "Add to custom colours"
 msgstr "Pievienot pielāgotajām krāsām"
 
@@ -1250,12 +1247,12 @@ msgstr ""
 msgid "AddToPropertyCollection called w/o valid adder"
 msgstr ""
 
-#: ../src/html/helpctrl.cpp:159
+#: ../src/html/helpctrl.cpp:155
 #, c-format
 msgid "Adding book %s"
 msgstr "Pievieno grāmatu %s"
 
-#: ../src/common/preferencescmn.cpp:43
+#: ../src/common/preferencescmn.cpp:40
 msgid "Advanced"
 msgstr ""
 
@@ -1263,11 +1260,11 @@ msgstr ""
 msgid "After a paragraph:"
 msgstr "Aiz rindkopas:"
 
-#: ../src/common/stockitem.cpp:172
+#: ../src/common/stockitem.cpp:169
 msgid "Align Left"
 msgstr "Izlīdzināt gar kreiso"
 
-#: ../src/common/stockitem.cpp:173
+#: ../src/common/stockitem.cpp:170
 msgid "Align Right"
 msgstr "Izlīdzināt gar labo"
 
@@ -1275,40 +1272,40 @@ msgstr "Izlīdzināt gar labo"
 msgid "Alignment"
 msgstr "Izlīdzinašana"
 
-#: ../src/generic/prntdlgg.cpp:215
+#: ../src/generic/prntdlgg.cpp:208
 msgid "All"
 msgstr "Visu"
 
-#: ../src/generic/filectrlg.cpp:1197 ../src/common/fldlgcmn.cpp:107
+#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1186
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Visus failus (%s)|%s"
 
-#: ../include/wx/defs.h:2886
+#: ../include/wx/defs.h:2582
 msgid "All files (*)|*"
 msgstr "Visus failus (*)|*"
 
-#: ../include/wx/defs.h:2883
+#: ../include/wx/defs.h:2579
 msgid "All files (*.*)|*.*"
 msgstr "Visus failus (*.*)|*.*"
 
-#: ../src/richtext/richtextstyles.cpp:1061
+#: ../src/richtext/richtextstyles.cpp:1058
 msgid "All styles"
 msgstr "Visi stili"
 
-#: ../src/propgrid/manager.cpp:1528
+#: ../src/propgrid/manager.cpp:1544
 msgid "Alphabetic Mode"
 msgstr "Alfabētiskais režīms"
 
-#: ../src/common/xtistrm.cpp:425
+#: ../src/common/xtistrm.cpp:422
 msgid "Already Registered Object passed to SetObjectClassInfo"
 msgstr ""
 
-#: ../src/unix/dialup.cpp:353
+#: ../src/unix/dialup.cpp:352
 msgid "Already dialling ISP."
 msgstr "ISP jau tiek zvanīts."
 
-#: ../src/common/accelcmn.cpp:331 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/accelcmn.cpp:345 ../src/univ/themes/win32.cpp:3753
 msgid "Alt+"
 msgstr "Alt+"
 
@@ -1317,36 +1314,36 @@ msgstr "Alt+"
 msgid "An optional corner radius for adding rounded corners."
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:576
+#: ../src/common/debugrpt.cpp:577
 msgid "And includes the following files:\n"
 msgstr "Un ietver sekojošus failus:\n"
 
-#: ../src/generic/animateg.cpp:162
+#: ../src/generic/animateg.cpp:145
 #, c-format
 msgid "Animation file is not of type %ld."
 msgstr "Animācijas faila tips nav  %ld."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:872
+#: ../src/propgrid/advprops.cpp:773
 msgid "AppWorkspace"
 msgstr ""
 
-#: ../src/generic/logg.cpp:1014
+#: ../src/generic/logg.cpp:1011
 #, c-format
 msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
 msgstr ""
 "Papildināt failu '%s' ar žurnāla ierakstiem (izvēloties  [Nē] tas tiks "
 "pārrakstīts)?"
 
-#: ../src/osx/menu_osx.cpp:577 ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:469 ../src/osx/menu_osx.cpp:477
 msgid "Application"
 msgstr "Programma"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "Apply"
 msgstr "Pielietot"
 
-#: ../src/propgrid/advprops.cpp:1609
+#: ../src/propgrid/advprops.cpp:1515
 msgid "Aqua"
 msgstr ""
 
@@ -1355,30 +1352,30 @@ msgstr ""
 msgid "Arabic"
 msgstr "Arābu"
 
-#: ../src/common/fmapbase.cpp:153
+#: ../src/common/fmapbase.cpp:150
 msgid "Arabic (ISO-8859-6)"
 msgstr "Arābu (ISO-8859-6)"
 
-#: ../src/msw/ole/automtn.cpp:672
+#: ../src/msw/ole/automtn.cpp:663
 #, c-format
 msgid "Argument %u not found."
 msgstr "Arguments %u nav atrasts."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1753
+#: ../src/propgrid/advprops.cpp:1654
 #, fuzzy
 msgid "Arrow"
 msgstr "rītdiena"
 
-#: ../src/generic/aboutdlgg.cpp:184
+#: ../src/generic/aboutdlgg.cpp:181
 msgid "Artists"
 msgstr "Izpildītāji"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "Ascending"
 msgstr "Augoši"
 
-#: ../src/generic/filectrlg.cpp:433
+#: ../src/generic/filectrlg.cpp:429
 msgid "Attributes"
 msgstr "Atribūti"
 
@@ -1388,90 +1385,90 @@ msgstr "Atribūti"
 msgid "Available fonts."
 msgstr "Pieejamie fonti."
 
-#: ../src/common/paper.cpp:137
+#: ../src/common/paper.cpp:134
 msgid "B4 (ISO) 250 x 353 mm"
 msgstr "B4 (ISO) 250 x 353 mm"
 
-#: ../src/common/paper.cpp:173
+#: ../src/common/paper.cpp:170
 msgid "B4 (JIS) Rotated 364 x 257 mm"
 msgstr "B4 (JIS) Rotated 364 x 257 mm"
 
-#: ../src/common/paper.cpp:127
+#: ../src/common/paper.cpp:124
 msgid "B4 Envelope, 250 x 353 mm"
 msgstr "B4 aploksne, 250 x 353 mm"
 
-#: ../src/common/paper.cpp:109
+#: ../src/common/paper.cpp:106
 msgid "B4 sheet, 250 x 354 mm"
 msgstr "B4 loksne, 250 x 354 mm"
 
-#: ../src/common/paper.cpp:158
+#: ../src/common/paper.cpp:155
 msgid "B5 (ISO) Extra 201 x 276 mm"
 msgstr "B5 (ISO) Extra 201 x 276 mm"
 
-#: ../src/common/paper.cpp:174
+#: ../src/common/paper.cpp:171
 msgid "B5 (JIS) Rotated 257 x 182 mm"
 msgstr "B5 (JIS) Rotated 257 x 182 mm"
 
-#: ../src/common/paper.cpp:155
+#: ../src/common/paper.cpp:152
 msgid "B5 (JIS) Transverse 182 x 257 mm"
 msgstr "B5 (JIS) Transverse 182 x 257 mm"
 
-#: ../src/common/paper.cpp:128
+#: ../src/common/paper.cpp:125
 msgid "B5 Envelope, 176 x 250 mm"
 msgstr "B5 aploksne, 176 x 250 mm"
 
-#: ../src/common/paper.cpp:110
+#: ../src/common/paper.cpp:107
 msgid "B5 sheet, 182 x 257 millimeter"
 msgstr "B5 loksne, 182 x 257 mm"
 
-#: ../src/common/paper.cpp:182
+#: ../src/common/paper.cpp:179
 msgid "B6 (JIS) 128 x 182 mm"
 msgstr "B6 (JIS) 128 x 182 mm"
 
-#: ../src/common/paper.cpp:183
+#: ../src/common/paper.cpp:180
 msgid "B6 (JIS) Rotated 182 x 128 mm"
 msgstr "B6 (JIS) Rotated 182 x 128 mm"
 
-#: ../src/common/paper.cpp:129
+#: ../src/common/paper.cpp:126
 msgid "B6 Envelope, 176 x 125 mm"
 msgstr "B6 aploksne, 176 x 125 mm"
 
-#: ../src/common/imagbmp.cpp:531 ../src/common/imagbmp.cpp:561
-#: ../src/common/imagbmp.cpp:576
+#: ../src/common/imagbmp.cpp:528 ../src/common/imagbmp.cpp:558
+#: ../src/common/imagbmp.cpp:573
 msgid "BMP: Couldn't allocate memory."
 msgstr "BMP: nevar piešķirt atmiņu."
 
-#: ../src/common/imagbmp.cpp:100
+#: ../src/common/imagbmp.cpp:97
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: nevar saglabāt kļūdainu attēlu."
 
-#: ../src/common/imagbmp.cpp:356
+#: ../src/common/imagbmp.cpp:353
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: nav iespējams pierakstīt RGB krāsu karti."
 
-#: ../src/common/imagbmp.cpp:490
+#: ../src/common/imagbmp.cpp:487
 msgid "BMP: Couldn't write data."
 msgstr "BMP: nevar ierakstīt datus."
 
-#: ../src/common/imagbmp.cpp:246
+#: ../src/common/imagbmp.cpp:243
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: nav iespējams pierakstīt faila (Bitmap) galveni."
 
-#: ../src/common/imagbmp.cpp:269
+#: ../src/common/imagbmp.cpp:266
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: nav iespējams pierakstīt faila  (BitmapInfo) galveni."
 
-#: ../src/common/imagbmp.cpp:140
+#: ../src/common/imagbmp.cpp:137
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage nepastās individuāla wxPalette."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:142 ../src/common/accelcmn.cpp:52
+#: ../src/common/stockitem.cpp:139 ../src/common/accelcmn.cpp:49
 msgid "Back"
 msgstr "Atpakaļ"
 
+#: ../src/richtext/richtextformatdlg.cpp:377
 #: ../src/richtext/richtextbackgroundpage.cpp:148
-#: ../src/richtext/richtextformatdlg.cpp:384
 msgid "Background"
 msgstr "Fons"
 
@@ -1479,21 +1476,21 @@ msgstr "Fons"
 msgid "Background &colour:"
 msgstr "&Fona krāsa:"
 
-#: ../src/osx/carbon/fontdlg.cpp:220
+#: ../src/osx/carbon/fontdlg.cpp:217
 msgid "Background colour"
 msgstr "Fona krāsa"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:52
+#: ../src/common/accelcmn.cpp:49
 #, fuzzy
 msgid "Backspace"
 msgstr "Atpakaļ"
 
-#: ../src/common/fmapbase.cpp:160
+#: ../src/common/fmapbase.cpp:157
 msgid "Baltic (ISO-8859-13)"
 msgstr "Baltijas (ISO-8859-13)"
 
-#: ../src/common/fmapbase.cpp:151
+#: ../src/common/fmapbase.cpp:148
 msgid "Baltic (old) (ISO-8859-4)"
 msgstr "Baltijas (vecais) (ISO-8859-4)"
 
@@ -1506,25 +1503,25 @@ msgstr "Pirms rindkopas:"
 msgid "Bitmap"
 msgstr "Bitkarte"
 
-#: ../src/propgrid/advprops.cpp:1594
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Black"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1755
+#: ../src/propgrid/advprops.cpp:1656
 msgid "Blank"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1603
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Blue"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:345
+#: ../src/generic/colrdlgg.cpp:365
 msgid "Blue:"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:333 ../src/richtext/richtextfontpage.cpp:355
-#: ../src/osx/carbon/fontdlg.cpp:354 ../src/common/stockitem.cpp:143
+#: ../src/osx/carbon/fontdlg.cpp:351 ../src/common/stockitem.cpp:140
+#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:355
 msgid "Bold"
 msgstr "Treknraksts"
 
@@ -1533,32 +1530,36 @@ msgstr "Treknraksts"
 msgid "Border"
 msgstr "Mala"
 
-#: ../src/richtext/richtextformatdlg.cpp:379
+#: ../src/richtext/richtextformatdlg.cpp:372
 msgid "Borders"
 msgstr "Malas"
 
-#: ../src/richtext/richtextsizepage.cpp:288 ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141 ../src/richtext/richtextsizepage.cpp:288
 msgid "Bottom"
 msgstr "Apakša"
 
-#: ../src/generic/prntdlgg.cpp:893
+#: ../src/generic/prntdlgg.cpp:886
 msgid "Bottom margin (mm):"
 msgstr "Apakšējā mala (mm):"
 
-#: ../src/richtext/richtextbuffer.cpp:9383
+#: ../src/richtext/richtextbuffer.cpp:9380
 msgid "Box Properties"
 msgstr "Rāmja īpašības"
 
-#: ../src/richtext/richtextstyles.cpp:1065
+#: ../src/richtext/richtextstyles.cpp:1062
 msgid "Box styles"
 msgstr "&Rāmju stili"
 
-#: ../src/propgrid/advprops.cpp:1602
+#: ../src/osx/cocoa/menu.mm:292
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1508
 #, fuzzy
 msgid "Brown"
 msgstr "Pārlūkot"
 
-#: ../src/common/filepickercmn.cpp:43 ../src/common/filepickercmn.cpp:44
+#: ../src/common/filepickercmn.cpp:40 ../src/common/filepickercmn.cpp:41
 msgid "Browse"
 msgstr "Pārlūkot"
 
@@ -1571,73 +1572,73 @@ msgstr "&Aizzīmējumu izlīdzināšana:"
 msgid "Bullet style"
 msgstr "Aizzīmju stils"
 
-#: ../src/richtext/richtextformatdlg.cpp:359
+#: ../src/richtext/richtextformatdlg.cpp:352
 msgid "Bullets"
 msgstr "Aizzīmes"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1756
+#: ../src/propgrid/advprops.cpp:1657
 #, fuzzy
 msgid "Bullseye"
 msgstr "Aizzīmju stils"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:875
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonFace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:876
+#: ../src/propgrid/advprops.cpp:777
 msgid "ButtonHighlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:877
+#: ../src/propgrid/advprops.cpp:778
 msgid "ButtonShadow"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:878
+#: ../src/propgrid/advprops.cpp:779
 msgid "ButtonText"
 msgstr ""
 
-#: ../src/common/paper.cpp:98
+#: ../src/common/paper.cpp:95
 msgid "C sheet, 17 x 22 in"
 msgstr "C loksne, 432 x 559 mm"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "C&lear"
 msgstr "&Tīrīt"
 
-#: ../src/generic/fontdlgg.cpp:406
+#: ../src/generic/fontdlgg.cpp:403
 msgid "C&olour:"
 msgstr "&Krāsa:"
 
-#: ../src/common/paper.cpp:123
+#: ../src/common/paper.cpp:120
 msgid "C3 Envelope, 324 x 458 mm"
 msgstr "C3 aploksne, 324 x 458 mm"
 
-#: ../src/common/paper.cpp:124
+#: ../src/common/paper.cpp:121
 msgid "C4 Envelope, 229 x 324 mm"
 msgstr "C4 aploksne, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:122
+#: ../src/common/paper.cpp:119
 msgid "C5 Envelope, 162 x 229 mm"
 msgstr "C5 aploksne, 162 x 229 mm"
 
-#: ../src/common/paper.cpp:125
+#: ../src/common/paper.cpp:122
 msgid "C6 Envelope, 114 x 162 mm"
 msgstr "C6 aploksne, 114 x 162 mm"
 
-#: ../src/common/paper.cpp:126
+#: ../src/common/paper.cpp:123
 msgid "C65 Envelope, 114 x 229 mm"
 msgstr "C65 aploksne, 114 x 229 mm"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "CD-Rom"
 msgstr "CD-Rom"
 
-#: ../src/html/chm.cpp:815 ../src/html/chm.cpp:874
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:865
 msgid "CHM handler currently supports only local files!"
 msgstr ""
 
@@ -1645,190 +1646,194 @@ msgstr ""
 msgid "Ca&pitals"
 msgstr "Lieli burti"
 
-#: ../src/common/cmdproc.cpp:267
+#: ../src/common/cmdproc.cpp:260
 msgid "Can't &Undo "
 msgstr "Nevar &atcelt"
 
-#: ../src/common/image.cpp:2824
+#: ../src/common/image.cpp:2924
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 
-#: ../src/msw/registry.cpp:506
+#: ../src/msw/registry.cpp:495
 #, c-format
 msgid "Can't close registry key '%s'"
 msgstr "Nav iespējams aizvērt reģistra atslēgu '%s'"
 
-#: ../src/msw/registry.cpp:584
+#: ../src/msw/registry.cpp:573
 #, c-format
 msgid "Can't copy values of unsupported type %d."
 msgstr "Nav iespējams nokopēt neatbalstīta tipa %d vērtības."
 
-#: ../src/msw/registry.cpp:487
+#: ../src/msw/registry.cpp:476
 #, c-format
 msgid "Can't create registry key '%s'"
 msgstr "Nav iespējams izveidot reģistra atslēgu '%s'"
 
-#: ../src/msw/thread.cpp:665
+#: ../src/msw/thread.cpp:657
 msgid "Can't create thread"
 msgstr "Nav iespējams izveidot pavedienu"
 
-#: ../src/msw/window.cpp:3691
-#, c-format
-msgid "Can't create window of class %s"
-msgstr "Nav iespējams izveidot %s klases logu"
-
-#: ../src/msw/registry.cpp:777
+#: ../src/msw/registry.cpp:765
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Nav iespējams izdzēst atslēgu '%s'"
 
-#: ../src/msw/iniconf.cpp:458
+#: ../src/msw/iniconf.cpp:455
 #, c-format
 msgid "Can't delete the INI file '%s'"
 msgstr "Nav iespējams izdzēst INI failu '%s'"
 
-#: ../src/msw/registry.cpp:805
+#: ../src/msw/registry.cpp:793
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Nav iespējams izdzēst vērtību '%s' no atslēgas '%s'"
 
-#: ../src/msw/registry.cpp:1171
+#: ../src/msw/registry.cpp:1159
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Nav iespējams uzskaitīt atslēgas '%s' apakšatslēgas"
 
-#: ../src/msw/registry.cpp:1132
+#: ../src/msw/registry.cpp:1120
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Nav iespējams uzskaitīt atslēgas '%s' vērtības"
 
-#: ../src/msw/registry.cpp:1389
+#: ../src/msw/registry.cpp:1377
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Nav iespējams eksportēt neatbalstīta tipa %d vērtību."
 
-#: ../src/common/ffile.cpp:254
+#: ../src/common/ffile.cpp:253
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Nav iespējams atrast pašreizējo pozīciju failā '%s'"
 
-#: ../src/msw/registry.cpp:418
+#: ../src/msw/registry.cpp:407
 #, c-format
 msgid "Can't get info about registry key '%s'"
 msgstr "Nav iespējams iegūt informāciju par reģistra atslēgu '%s'"
 
-#: ../src/common/zstream.cpp:346
+#: ../src/msw/webview_ie.cpp:1024
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "Nav iespējams uzstādīt pavediena prioritāti"
+
+#: ../src/common/zstream.cpp:343
 msgid "Can't initialize zlib deflate stream."
 msgstr "Nevar inicializēt zlib saspiešanas straumējumu."
 
-#: ../src/common/zstream.cpp:185
+#: ../src/common/zstream.cpp:182
 msgid "Can't initialize zlib inflate stream."
 msgstr "Nevar inicializēt zlib atspiešanas straumējumu."
 
-#: ../src/msw/fswatcher.cpp:476
+#: ../src/msw/fswatcher.cpp:475
 #, c-format
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "Nav iespējams sekot izmaiņām neesoša mapē \"%s\"."
 
-#: ../src/msw/registry.cpp:454
+#: ../src/msw/registry.cpp:443
 #, c-format
 msgid "Can't open registry key '%s'"
 msgstr "Nav iespējams atvērt reģistra atslēgu '%s'"
 
-#: ../src/common/zstream.cpp:252
+#: ../src/common/zstream.cpp:249
 #, c-format
 msgid "Can't read from inflate stream: %s"
 msgstr ""
 
-#: ../src/common/zstream.cpp:244
+#: ../src/common/zstream.cpp:241
 msgid "Can't read inflate stream: unexpected EOF in underlying stream."
 msgstr ""
 
-#: ../src/msw/registry.cpp:1064
+#: ../src/msw/registry.cpp:1052
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr " '%s' vērtība nav nolasāma"
 
-#: ../src/msw/registry.cpp:878 ../src/msw/registry.cpp:910
-#: ../src/msw/registry.cpp:975
+#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
+#: ../src/msw/registry.cpp:963
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Nav iespējams nolasīt atslēgas '%s' vērtību"
 
-#: ../src/common/image.cpp:2620
+#: ../src/msw/webview_ie.cpp:1017
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/common/image.cpp:2715
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "Nav iespējams saglabāt attēlu failā '%s: nezināms paplašinājums."
 
-#: ../src/generic/logg.cpp:573 ../src/generic/logg.cpp:976
+#: ../src/generic/logg.cpp:570 ../src/generic/logg.cpp:973
 msgid "Can't save log contents to file."
 msgstr "Nav iespējams saglabāt žurnāla saturu failā."
 
-#: ../src/msw/thread.cpp:629
+#: ../src/msw/thread.cpp:621
 msgid "Can't set thread priority"
 msgstr "Nav iespējams uzstādīt pavediena prioritāti"
 
-#: ../src/msw/registry.cpp:896 ../src/msw/registry.cpp:938
-#: ../src/msw/registry.cpp:1081
+#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
+#: ../src/msw/registry.cpp:1069
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Nav iespējams iestatīt '%s' vērtību"
 
-#: ../src/unix/utilsunx.cpp:351
+#: ../src/unix/utilsunx.cpp:353
 msgid "Can't write to child process's stdin"
 msgstr ""
 
-#: ../src/common/zstream.cpp:427
+#: ../src/common/zstream.cpp:424
 #, c-format
 msgid "Can't write to deflate stream: %s"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:279 ../src/richtext/richtextstyledlg.cpp:300
-#: ../src/common/stockitem.cpp:145 ../src/common/accelcmn.cpp:71
-#: ../src/msw/msgdlg.cpp:454 ../src/msw/progdlg.cpp:673
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:142
+#: ../src/common/accelcmn.cpp:68 ../src/motif/msgdlg.cpp:196
+#: ../src/gtk1/fontdlg.cpp:144 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/progdlg.cpp:940 ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Atcelt"
 
-#: ../src/common/filefn.cpp:1261
+#: ../src/common/filefn.cpp:1149
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Nav iespējams uzskaitīt failus '%s'"
 
-#: ../src/msw/dir.cpp:263
+#: ../src/msw/dir.cpp:260
 #, c-format
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Nav iespējams uzskaitīt failus mapē '%s'"
 
-#: ../src/msw/dialup.cpp:523
+#: ../src/msw/dialup.cpp:517
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Aktīva iezvanpieeja nav atrodama: %s"
 
-#: ../src/msw/dialup.cpp:827
+#: ../src/msw/dialup.cpp:821
 msgid "Cannot find the location of address book file"
 msgstr "Nav iespējams noteikt adrešu grāmatas faila atrašanās vietu"
 
-#: ../src/msw/ole/automtn.cpp:562
+#: ../src/msw/ole/automtn.cpp:553
 #, c-format
 msgid "Cannot get an active instance of \"%s\""
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1035
+#: ../src/unix/threadpsx.cpp:1053
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:987
+#: ../src/unix/utilsunx.cpp:989
 msgid "Cannot get the hostname"
 msgstr "Nevar atrast resursdatora vārdu"
 
-#: ../src/unix/utilsunx.cpp:1023
+#: ../src/unix/utilsunx.cpp:1025
 msgid "Cannot get the official hostname"
 msgstr "Nevar atrast oficiālo resursdatora vārdu"
 
-#: ../src/msw/dialup.cpp:928
+#: ../src/msw/dialup.cpp:922
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Nav iespējams nolikt klausuli - nav aktīva iezvanpieejas savienojuma"
 
@@ -1836,127 +1841,127 @@ msgstr "Nav iespējams nolikt klausuli - nav aktīva iezvanpieejas savienojuma"
 msgid "Cannot initialize OLE"
 msgstr "Nav iespējams inicializēt OLE"
 
-#: ../src/common/socket.cpp:853
+#: ../src/common/socket.cpp:850
 msgid "Cannot initialize sockets"
 msgstr ""
 
-#: ../src/msw/volume.cpp:619
+#: ../src/msw/volume.cpp:627
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr " Nav iespējams ielādēt ikonu no '%s'."
 
-#: ../src/xrc/xmlres.cpp:360
+#: ../src/xrc/xmlres.cpp:358
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Nav iespējams ielādēt resursus no '%s'."
 
-#: ../src/xrc/xmlres.cpp:742
+#: ../src/xrc/xmlres.cpp:740
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Nav iespējams ielādēt resursus no faila '%s'."
 
-#: ../src/html/htmlfilt.cpp:137
+#: ../src/html/htmlfilt.cpp:134
 #, c-format
 msgid "Cannot open HTML document: %s"
 msgstr "Nav iespējams atvērt HTML dokumentu: %s"
 
-#: ../src/html/helpdata.cpp:667
+#: ../src/html/helpdata.cpp:660
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Nav iespējams atvērt HTML palīdzības grāmatu: %s"
 
-#: ../src/html/helpdata.cpp:299
+#: ../src/html/helpdata.cpp:296
 #, c-format
 msgid "Cannot open contents file: %s"
 msgstr "Nav iespējams atvērt satura failu: %s"
 
-#: ../src/generic/dcpsg.cpp:1667
+#: ../src/generic/dcpsg.cpp:1665
 msgid "Cannot open file for PostScript printing!"
 msgstr "Nav iespējams atvērt failu drukāšanai PostScript!"
 
-#: ../src/html/helpdata.cpp:313
+#: ../src/html/helpdata.cpp:310
 #, c-format
 msgid "Cannot open index file: %s"
 msgstr "Nav iespējams atvērt indeksu failu: %s"
 
-#: ../src/xrc/xmlres.cpp:724
+#: ../src/xrc/xmlres.cpp:722
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Nav iespējams atvērt resursu failu  '%s'."
 
-#: ../src/html/helpwnd.cpp:1534
+#: ../src/html/helpwnd.cpp:1532
 msgid "Cannot print empty page."
 msgstr "Nav iespējams nodrukāt tukšu lapu."
 
-#: ../src/msw/volume.cpp:507
+#: ../src/msw/volume.cpp:515
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Nav iespējams nolasīt tipa nosaukumu no  '%s'!"
 
-#: ../src/msw/thread.cpp:888
+#: ../src/msw/thread.cpp:894
 #, fuzzy, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Nav iespējams atsākt pavedienu %x"
 
-#: ../src/unix/threadpsx.cpp:1016
+#: ../src/unix/threadpsx.cpp:1028
 msgid "Cannot retrieve thread scheduling policy."
 msgstr ""
 
-#: ../src/common/intl.cpp:558
+#: ../src/common/intl.cpp:365
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "Neizdevās uzstādīt valodas \"%s\" lokāli."
 
-#: ../src/unix/threadpsx.cpp:831 ../src/msw/thread.cpp:546
+#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
 msgid "Cannot start thread: error writing TLS."
 msgstr "Nav iespējams palaist pavedienu: kļūda rakstot TLS."
 
-#: ../src/msw/thread.cpp:872
+#: ../src/msw/thread.cpp:864
 #, fuzzy, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Nav iespējams apturēt pavedienu %x"
 
-#: ../src/msw/thread.cpp:794
+#: ../src/msw/thread.cpp:786
 msgid "Cannot wait for thread termination"
 msgstr "Nevar gaidīt uz pavediena apstāšanos"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:75
+#: ../src/common/accelcmn.cpp:72
 #, fuzzy
 msgid "Capital"
 msgstr "Lieli burti"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:879
+#: ../src/propgrid/advprops.cpp:780
 msgid "CaptionText"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:531
 msgid "Case sensitive"
 msgstr "Reģistrjūtīgs"
 
-#: ../src/propgrid/manager.cpp:1509
+#: ../src/propgrid/manager.cpp:1527
 msgid "Categorized Mode"
 msgstr "Šķirotais režīms"
 
-#: ../src/richtext/richtextbuffer.cpp:9968
+#: ../src/richtext/richtextbuffer.cpp:9965
 msgid "Cell Properties"
 msgstr "Tabulas šūnas parametri"
 
-#: ../src/common/fmapbase.cpp:161
+#: ../src/common/fmapbase.cpp:158
 msgid "Celtic (ISO-8859-14)"
 msgstr "Ķeltu (ISO-8859-14)"
 
-#: ../src/richtext/richtextindentspage.cpp:160
 #: ../src/richtext/richtextliststylepage.cpp:349
+#: ../src/richtext/richtextindentspage.cpp:160
 msgid "Cen&tred"
 msgstr "Cen&trēts"
 
-#: ../src/common/stockitem.cpp:170
+#: ../src/common/stockitem.cpp:167
 msgid "Centered"
 msgstr "Centrēts"
 
-#: ../src/common/fmapbase.cpp:149
+#: ../src/common/fmapbase.cpp:146
 msgid "Central European (ISO-8859-2)"
 msgstr "Centrāl Eiropiešu (ISO-8859-2)"
 
@@ -1965,10 +1970,10 @@ msgstr "Centrāl Eiropiešu (ISO-8859-2)"
 msgid "Centre"
 msgstr "Centrēt"
 
-#: ../src/richtext/richtextindentspage.cpp:162
-#: ../src/richtext/richtextindentspage.cpp:164
 #: ../src/richtext/richtextliststylepage.cpp:351
 #: ../src/richtext/richtextliststylepage.cpp:353
+#: ../src/richtext/richtextindentspage.cpp:162
+#: ../src/richtext/richtextindentspage.cpp:164
 msgid "Centre text."
 msgstr "Centrēt tekstu."
 
@@ -1981,24 +1986,24 @@ msgstr "Centrēts"
 msgid "Ch&oose..."
 msgstr "Iz&vēlieties..."
 
-#: ../src/richtext/richtextbuffer.cpp:4354
+#: ../src/richtext/richtextbuffer.cpp:4351
 msgid "Change List Style"
 msgstr "Mainīt saraksta stilu"
 
-#: ../src/richtext/richtextbuffer.cpp:3709
+#: ../src/richtext/richtextbuffer.cpp:3706
 msgid "Change Object Style"
 msgstr "Mainīt objekta stilu"
 
-#: ../src/richtext/richtextbuffer.cpp:3982
-#: ../src/richtext/richtextbuffer.cpp:8129
+#: ../src/richtext/richtextbuffer.cpp:3979
+#: ../src/richtext/richtextbuffer.cpp:8125
 msgid "Change Properties"
 msgstr "Mainīt īpašības"
 
-#: ../src/richtext/richtextbuffer.cpp:3526
+#: ../src/richtext/richtextbuffer.cpp:3523
 msgid "Change Style"
 msgstr "Mainīt stilu"
 
-#: ../src/common/fileconf.cpp:341
+#: ../src/common/fileconf.cpp:335
 #, c-format
 msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
 msgstr ""
@@ -2011,12 +2016,12 @@ msgid "Changing current directory to \"%s\" failed"
 msgstr "Neizdevās izveidot mapi \"%s\""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1757
+#: ../src/propgrid/advprops.cpp:1658
 #, fuzzy
 msgid "Character"
 msgstr "Rakstzī&mju kods:"
 
-#: ../src/richtext/richtextstyles.cpp:1063
+#: ../src/richtext/richtextstyles.cpp:1060
 msgid "Character styles"
 msgstr "Rakstzīmju stili"
 
@@ -2054,20 +2059,20 @@ msgstr "Atzīmējiet, lai iekļautu aizzīmi iekavās."
 msgid "Check to indicate right-to-left text layout."
 msgstr "Nospiediet, lai mainītu teksta krāsu."
 
-#: ../src/osx/carbon/fontdlg.cpp:356 ../src/osx/carbon/fontdlg.cpp:358
+#: ../src/osx/carbon/fontdlg.cpp:353 ../src/osx/carbon/fontdlg.cpp:355
 msgid "Check to make the font bold."
 msgstr "Atzīmējiet, lai iegūtu fontu treknrakstā."
 
-#: ../src/osx/carbon/fontdlg.cpp:363 ../src/osx/carbon/fontdlg.cpp:365
+#: ../src/osx/carbon/fontdlg.cpp:360 ../src/osx/carbon/fontdlg.cpp:362
 msgid "Check to make the font italic."
 msgstr "Atzīmējiet, lai iegūtu fontu kursīvā."
 
-#: ../src/osx/carbon/fontdlg.cpp:372 ../src/osx/carbon/fontdlg.cpp:374
+#: ../src/osx/carbon/fontdlg.cpp:369 ../src/osx/carbon/fontdlg.cpp:371
 msgid "Check to make the font underlined."
 msgstr "Atzīmējiet, lai iegūtu fontu ar pasvītrojumu."
 
-#: ../src/richtext/richtextstyledlg.cpp:289
-#: ../src/richtext/richtextstyledlg.cpp:291
+#: ../src/richtext/richtextstyledlg.cpp:285
+#: ../src/richtext/richtextstyledlg.cpp:287
 msgid "Check to restart numbering."
 msgstr "Atzīmējiet, lai atsāktu numurēšanu."
 
@@ -2102,51 +2107,51 @@ msgstr "Atzīmējiet, lai rādītu tekstu augšrakstā."
 msgid "Check to suppress hyphenation."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:763
+#: ../src/msw/dialup.cpp:757
 msgid "Choose ISP to dial"
 msgstr "Izvēlieties ISP, kuram zvanīt"
 
-#: ../src/propgrid/props.cpp:1922
+#: ../src/propgrid/props.cpp:1904
 msgid "Choose a directory:"
 msgstr "Izvēlieties mapi:"
 
-#: ../src/propgrid/props.cpp:1975
+#: ../src/propgrid/props.cpp:2199
 msgid "Choose a file"
 msgstr "Izvēlieties failu"
 
-#: ../src/generic/colrdlgg.cpp:158 ../src/gtk/colordlg.cpp:54
+#: ../src/generic/colrdlgg.cpp:156 ../src/gtk/colordlg.cpp:49
 msgid "Choose colour"
 msgstr "Izvēlieties krāsu"
 
-#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/gtk1/fontdlg.cpp:125 ../src/generic/fontpickerg.cpp:47
+#: ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Izvēlieties fontu"
 
-#: ../src/common/module.cpp:74
+#: ../src/common/module.cpp:71
 #, c-format
 msgid "Circular dependency involving module \"%s\" detected."
 msgstr ""
 
-#: ../src/aui/tabmdi.cpp:108 ../src/generic/mdig.cpp:97
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
 msgid "Cl&ose"
 msgstr "Aiz&vērt"
 
-#: ../src/msw/ole/automtn.cpp:684
+#: ../src/msw/ole/automtn.cpp:675
 msgid "Class not registered."
 msgstr "Klase nav reģistrēta."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:147 ../src/common/accelcmn.cpp:72
+#: ../src/common/stockitem.cpp:144 ../src/common/accelcmn.cpp:69
 msgid "Clear"
 msgstr "Notīrīt"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "Clear the log contents"
 msgstr "Notīrīt žurnāla saturu"
 
-#: ../src/richtext/richtextstyledlg.cpp:252
-#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:248
+#: ../src/richtext/richtextstyledlg.cpp:250
 msgid "Click to apply the selected style."
 msgstr "Nospiediet, lai pielietotu izvēlēto stilu."
 
@@ -2157,15 +2162,15 @@ msgstr "Nospiediet, lai pielietotu izvēlēto stilu."
 msgid "Click to browse for a symbol."
 msgstr "Nospiediet, lai sameklētu vajadzīgo simbolu."
 
-#: ../src/osx/carbon/fontdlg.cpp:403 ../src/osx/carbon/fontdlg.cpp:405
+#: ../src/osx/carbon/fontdlg.cpp:400 ../src/osx/carbon/fontdlg.cpp:402
 msgid "Click to cancel changes to the font."
 msgstr "Nospiediet, lai atceltu fonta izmaiņas."
 
-#: ../src/generic/fontdlgg.cpp:472 ../src/generic/fontdlgg.cpp:491
+#: ../src/generic/fontdlgg.cpp:468 ../src/generic/fontdlgg.cpp:487
 msgid "Click to cancel the font selection."
 msgstr "Nospiediet, lai atceltu fonta izvēli."
 
-#: ../src/osx/carbon/fontdlg.cpp:384 ../src/osx/carbon/fontdlg.cpp:386
+#: ../src/osx/carbon/fontdlg.cpp:381 ../src/osx/carbon/fontdlg.cpp:383
 msgid "Click to change the font colour."
 msgstr "Nospiediet, lai mainītu fonta krāsu."
 
@@ -2184,37 +2189,37 @@ msgstr "Nospiediet, lai mainītu teksta krāsu."
 msgid "Click to choose the font for this level."
 msgstr "Nospiediet, lai izvēlētos fontu šim līmenim."
 
-#: ../src/richtext/richtextstyledlg.cpp:279
-#: ../src/richtext/richtextstyledlg.cpp:281
+#: ../src/richtext/richtextstyledlg.cpp:275
+#: ../src/richtext/richtextstyledlg.cpp:277
 msgid "Click to close this window."
 msgstr "Nospiediet, lai aizvērtu šo logu"
 
-#: ../src/osx/carbon/fontdlg.cpp:410 ../src/osx/carbon/fontdlg.cpp:412
+#: ../src/osx/carbon/fontdlg.cpp:407 ../src/osx/carbon/fontdlg.cpp:409
 msgid "Click to confirm changes to the font."
 msgstr "Nospiediet, lai apstiprinātu fonta izmaiņas."
 
-#: ../src/generic/fontdlgg.cpp:477 ../src/generic/fontdlgg.cpp:479
-#: ../src/generic/fontdlgg.cpp:484 ../src/generic/fontdlgg.cpp:486
+#: ../src/generic/fontdlgg.cpp:473 ../src/generic/fontdlgg.cpp:475
+#: ../src/generic/fontdlgg.cpp:480 ../src/generic/fontdlgg.cpp:482
 msgid "Click to confirm the font selection."
 msgstr "Nospiediet, lai apstiprinātu fonta izvēli."
 
-#: ../src/richtext/richtextstyledlg.cpp:244
-#: ../src/richtext/richtextstyledlg.cpp:246
+#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:242
 msgid "Click to create a new box style."
 msgstr "Nospiediet, lai izveidotu jaunu rāmja stilu."
 
-#: ../src/richtext/richtextstyledlg.cpp:226
-#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:224
 msgid "Click to create a new character style."
 msgstr "Nospiediet, lai izveidotu jaunu burtu stilu."
 
-#: ../src/richtext/richtextstyledlg.cpp:238
-#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:236
 msgid "Click to create a new list style."
 msgstr "Nospiediet, lai izveidotu jaunu saraksta stilu."
 
-#: ../src/richtext/richtextstyledlg.cpp:232
-#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:230
 msgid "Click to create a new paragraph style."
 msgstr "Nospiediet, lai izveidotu jaunu rindkopas stilu."
 
@@ -2228,8 +2233,8 @@ msgstr "Nospiediet, lai izveidotu jaunu tabulatora pozīciju."
 msgid "Click to delete all tab positions."
 msgstr "Nospiediet, lai dzēstu visas tabulatora pozīcijas."
 
-#: ../src/richtext/richtextstyledlg.cpp:270
-#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:268
 msgid "Click to delete the selected style."
 msgstr "Nospiediet, lai dzēstu izvēlēto stilu."
 
@@ -2238,25 +2243,25 @@ msgstr "Nospiediet, lai dzēstu izvēlēto stilu."
 msgid "Click to delete the selected tab position."
 msgstr "Nospiediet, lai dzēstu izvēlēto tabulatora pozīciju."
 
-#: ../src/richtext/richtextstyledlg.cpp:264
-#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:262
 msgid "Click to edit the selected style."
 msgstr "Nospiediet, lai labotu izvēlēto stilu."
 
-#: ../src/richtext/richtextstyledlg.cpp:258
-#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:256
 msgid "Click to rename the selected style."
 msgstr "Nospiediet, lai pārdēvētu izvēlēto stilu."
 
-#: ../src/generic/dbgrptg.cpp:97 ../src/generic/progdlgg.cpp:759
-#: ../src/richtext/richtextstyledlg.cpp:277
-#: ../src/richtext/richtextsymboldlg.cpp:476 ../src/common/stockitem.cpp:148
-#: ../src/msw/progdlg.cpp:170 ../src/msw/progdlg.cpp:679
-#: ../src/html/helpdlg.cpp:90
+#: ../src/common/stockitem.cpp:145 ../src/generic/dbgrptg.cpp:94
+#: ../src/generic/progdlgg.cpp:781 ../src/msw/progdlg.cpp:211
+#: ../src/msw/progdlg.cpp:946 ../src/html/helpdlg.cpp:87
+#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextstyledlg.cpp:273
 msgid "Close"
 msgstr "Aizvērt"
 
-#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:98
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
 msgid "Close All"
 msgstr "Aizvērt Visus"
 
@@ -2264,43 +2269,43 @@ msgstr "Aizvērt Visus"
 msgid "Close current document"
 msgstr "Aizvērt aktīvo dokumentu"
 
-#: ../src/generic/logg.cpp:516
+#: ../src/generic/logg.cpp:513
 msgid "Close this window"
 msgstr "Aizvērt šo logu"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6006
+#: ../src/generic/datavgen.cpp:6811
 msgid "Collapse"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "Color"
 msgstr "Krāsa"
 
-#: ../src/richtext/richtextformatdlg.cpp:776
+#: ../src/richtext/richtextformatdlg.cpp:768
 msgid "Colour"
 msgstr "Krāsa"
 
-#: ../src/msw/colordlg.cpp:158
+#: ../src/msw/colordlg.cpp:227
 #, c-format
 msgid "Colour selection dialog failed with error %0lx."
 msgstr "Krāsu izvēles dialogs pārtrauca darbību ar kļūdu  %0lx."
 
-#: ../src/osx/carbon/fontdlg.cpp:380
+#: ../src/osx/carbon/fontdlg.cpp:377
 msgid "Colour:"
 msgstr "Krāsa:"
 
-#: ../src/generic/datavgen.cpp:6077
+#: ../src/generic/datavgen.cpp:6882
 #, c-format
 msgid "Column %u"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:114
+#: ../src/common/accelcmn.cpp:112
 msgid "Command"
 msgstr ""
 
-#: ../src/common/init.cpp:196
+#: ../src/common/init.cpp:193
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
@@ -2309,22 +2314,22 @@ msgstr ""
 "Komandrindas parametru %d nav iespējams pārvērst uz Unikodu, tāpēc tas "
 "netiks ņemts vērā."
 
-#: ../src/msw/fontdlg.cpp:120
+#: ../src/msw/fontdlg.cpp:170
 #, c-format
 msgid "Common dialog failed with error code %0lx."
 msgstr ""
 
-#: ../src/gtk/window.cpp:4649
+#: ../src/gtk/window.cpp:5653
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:1549
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Saspiests HTML Help fails (*.chm)|*.chm|"
 
-#: ../src/generic/dirctrlg.cpp:444
+#: ../src/generic/dirctrlg.cpp:410
 msgid "Computer"
 msgstr "Dators"
 
@@ -2333,53 +2338,57 @@ msgstr "Dators"
 msgid "Config entry name cannot start with '%c'."
 msgstr "Konfigurācijas ieraksta nosaukums nevar sākties ar  '%c'."
 
-#: ../src/generic/filedlgg.cpp:349 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
 msgid "Confirm"
 msgstr "Apstiprināt"
 
-#: ../src/html/htmlwin.cpp:566
+#: ../src/html/htmlwin.cpp:569
 msgid "Connecting..."
 msgstr "Savienošanās..."
 
-#: ../src/html/helpwnd.cpp:475
+#: ../src/html/helpwnd.cpp:473
 msgid "Contents"
 msgstr "Saturs"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:880
+#: ../src/propgrid/advprops.cpp:781
 msgid "ControlDark"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:881
+#: ../src/propgrid/advprops.cpp:782
 msgid "ControlLight"
 msgstr ""
 
-#: ../src/common/strconv.cpp:2262
+#: ../src/common/strconv.cpp:2208
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Pārvēršana uz kodējumu '%s' nedarbojas."
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "Convert"
 msgstr "Pārveidot"
 
-#: ../src/html/htmlwin.cpp:1079
+#: ../src/html/htmlwin.cpp:1020
 #, c-format
 msgid "Copied to clipboard:\"%s\""
 msgstr "Nokopēts starpliktuvē:\"%s\""
 
-#: ../src/generic/prntdlgg.cpp:247
+#: ../src/generic/prntdlgg.cpp:240
 msgid "Copies:"
 msgstr "Kopijas:"
 
-#: ../src/common/stockitem.cpp:150 ../src/stc/stc_i18n.cpp:18
+#: ../src/common/stockitem.cpp:147 ../src/stc/stc_i18n.cpp:18
 msgid "Copy"
 msgstr "Kopēt"
 
-#: ../src/common/stockitem.cpp:258
+#: ../src/common/stockitem.cpp:255
 msgid "Copy selection"
 msgstr "Kopēt iezīmēto"
+
+#: ../src/generic/grid.cpp:5945
+msgid "Copying more than one selected block to clipboard is not supported."
+msgstr ""
 
 #: ../src/richtext/richtextborderspage.cpp:566
 #: ../src/richtext/richtextborderspage.cpp:601
@@ -2390,198 +2399,194 @@ msgstr ""
 msgid "Corner &radius:"
 msgstr ""
 
-#: ../src/html/chm.cpp:718
+#: ../src/html/chm.cpp:711
 #, c-format
 msgid "Could not create temporary file '%s'"
 msgstr "Neizdevās izveidot pagaidu failu '%s'"
 
-#: ../src/html/chm.cpp:273
+#: ../src/html/chm.cpp:270
 #, c-format
 msgid "Could not extract %s into %s: %s"
 msgstr ""
 
-#: ../src/generic/tabg.cpp:1048
+#: ../src/generic/tabg.cpp:1045
 msgid "Could not find tab for id"
 msgstr ""
 
-#: ../src/gtk/notifmsg.cpp:108
-#, fuzzy
-msgid "Could not initalize libnotify."
-msgstr "Neizdevās iestatīt izlīdiznājumu."
-
-#: ../src/html/chm.cpp:444
+#: ../src/html/chm.cpp:437
 #, c-format
 msgid "Could not locate file '%s'."
 msgstr "Neizdevās atrast failu '%s'."
 
-#: ../src/common/filefn.cpp:1403
+#: ../src/msw/graphicsd2d.cpp:604
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/common/filefn.cpp:1291
 msgid "Could not set current working directory"
 msgstr "Neizdevās iestatīt pašreizējo darba mapi"
 
-#: ../src/common/prntbase.cpp:2015
+#: ../src/common/prntbase.cpp:2037
 msgid "Could not start document preview."
 msgstr "Neizdevās parādīt dokumenta priekšskatījumu."
 
-#: ../src/generic/printps.cpp:178 ../src/msw/printwin.cpp:210
-#: ../src/gtk/print.cpp:1132
+#: ../src/generic/printps.cpp:159 ../src/msw/printwin.cpp:184
+#: ../src/gtk/print.cpp:1129
 msgid "Could not start printing."
 msgstr "Neizdevās sākt drukāšanu."
 
-#: ../src/common/wincmn.cpp:2125
+#: ../src/common/wincmn.cpp:2126
 msgid "Could not transfer data to window"
 msgstr "Neizdevās pārvietot datus uz logu"
 
-#: ../src/msw/imaglist.cpp:187 ../src/msw/imaglist.cpp:224
-#: ../src/msw/imaglist.cpp:249 ../src/msw/dragimag.cpp:185
-#: ../src/msw/dragimag.cpp:220
+#: ../src/msw/imaglist.cpp:223 ../src/msw/imaglist.cpp:245
+#: ../src/msw/imaglist.cpp:270 ../src/msw/dragimag.cpp:182
+#: ../src/msw/dragimag.cpp:217
 msgid "Couldn't add an image to the image list."
 msgstr "Neizdevās pievienot attēlu sarakstam."
 
-#: ../src/osx/glcanvas_osx.cpp:414 ../src/unix/glx11.cpp:558
-#: ../src/msw/glcanvas.cpp:616
+#: ../src/osx/glcanvas_osx.cpp:411 ../src/msw/glcanvas.cpp:631
+#: ../src/unix/glegl.cpp:315 ../src/unix/glx11.cpp:559
 #, fuzzy
 msgid "Couldn't create OpenGL context"
 msgstr "Neizdevās izveidot hronometru"
 
-#: ../src/msw/timer.cpp:134
+#: ../src/msw/timer.cpp:131
 msgid "Couldn't create a timer"
 msgstr "Neizdevās izveidot hronometru"
 
-#: ../src/osx/carbon/overlay.cpp:122
-msgid "Couldn't create the overlay window"
-msgstr ""
-
-#: ../src/common/translation.cpp:2024
+#: ../src/common/translation.cpp:2074
 msgid "Couldn't enumerate translations"
 msgstr "Neizdevās uzskaitīt tulkojumus"
 
-#: ../src/common/dynlib.cpp:120
+#: ../src/common/dynlib.cpp:110
 #, c-format
 msgid "Couldn't find symbol '%s' in a dynamic library"
 msgstr "Simbols '%s' nav atrodams dinamiskajā bibliotēkā"
 
-#: ../src/msw/thread.cpp:915
+#: ../src/msw/thread.cpp:921
 msgid "Couldn't get the current thread pointer"
 msgstr "Nevar iegūt pašreizējā pavediena rādītāju"
 
-#: ../src/osx/carbon/overlay.cpp:129
-msgid "Couldn't init the context on the overlay window"
-msgstr ""
-
-#: ../src/common/imaggif.cpp:244
+#: ../src/common/imaggif.cpp:241
 msgid "Couldn't initialize GIF hash table."
 msgstr "Neizdevās inicializēt GIF hash tabulu"
 
-#: ../src/common/imagpng.cpp:409
+#: ../src/common/imagpng.cpp:437
 msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
 msgstr "Neizdevās atvērt PNG attēlu - bojāts fails vai nepietiek atmiņas."
 
-#: ../src/unix/sound.cpp:470
+#: ../src/unix/sound.cpp:459
 #, c-format
 msgid "Couldn't load sound data from '%s'."
 msgstr "Neizdevās ielādēt skaņas datus no '%s'."
 
-#: ../src/msw/dirdlg.cpp:435
+#: ../src/msw/dirdlg.cpp:287
 #, fuzzy
 msgid "Couldn't obtain folder name"
 msgstr "Neizdevās izveidot hronometru"
 
-#: ../src/unix/sound_sdl.cpp:229
+#: ../src/unix/sound_sdl.cpp:226
 #, c-format
 msgid "Couldn't open audio: %s"
 msgstr "Neizdevās atvērt audio: %s"
 
-#: ../src/msw/ole/dataobj.cpp:377
+#: ../src/msw/ole/dataobj.cpp:385
 #, c-format
 msgid "Couldn't register clipboard format '%s'."
 msgstr "Neizdevās reģistrēt starpliktuves formātu '%s'."
 
-#: ../src/msw/listctrl.cpp:869
+#: ../src/msw/listctrl.cpp:933
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "Nav iespējams iegūt informāciju par saraksta vadīklas vienumu %d."
 
-#: ../src/common/imagpng.cpp:498 ../src/common/imagpng.cpp:509
-#: ../src/common/imagpng.cpp:519
+#: ../src/common/imagpng.cpp:511 ../src/common/imagpng.cpp:522
+#: ../src/common/imagpng.cpp:532
 msgid "Couldn't save PNG image."
 msgstr "Neizdevās saglabāt PNG attēlu."
 
-#: ../src/msw/thread.cpp:684
+#: ../src/msw/thread.cpp:676
 msgid "Couldn't terminate thread"
 msgstr "Nav iespējams pārtraukt pavedienu"
 
-#: ../src/common/xtistrm.cpp:166
+#: ../src/common/xtistrm.cpp:163
 #, c-format
 msgid "Create Parameter %s not found in declared RTTI Parameters"
 msgstr ""
 
-#: ../src/generic/dirdlgg.cpp:288
+#: ../src/generic/dirdlgg.cpp:285
 msgid "Create directory"
 msgstr "Izveidot mapi"
 
-#: ../src/generic/filedlgg.cpp:212 ../src/generic/dirdlgg.cpp:111
+#: ../src/generic/filedlgg.cpp:209 ../src/generic/dirdlgg.cpp:108
 msgid "Create new directory"
 msgstr "Izveidot Jaunu mapi"
 
-#: ../src/xrc/xmlres.cpp:2460
+#: ../src/common/stockitem.cpp:264
+#, fuzzy
+msgid "Create new document"
+msgstr "Izveidot Jaunu mapi"
+
+#: ../src/xrc/xmlres.cpp:2515
 #, fuzzy, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Neizdevās izveidot hronometru"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1758
+#: ../src/propgrid/advprops.cpp:1659
 msgid "Cross"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:333
+#: ../src/common/accelcmn.cpp:347
 msgid "Ctrl+"
 msgstr "Ctrl+"
 
-#: ../src/richtext/richtextctrl.cpp:332 ../src/osx/textctrl_osx.cpp:576
-#: ../src/common/stockitem.cpp:151 ../src/msw/textctrl.cpp:2507
+#: ../src/osx/textctrl_osx.cpp:594 ../src/common/stockitem.cpp:148
+#: ../src/msw/textctrl.cpp:2772 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "Izgriez&t"
 
-#: ../src/generic/filectrlg.cpp:940
+#: ../src/generic/filectrlg.cpp:936
 msgid "Current directory:"
 msgstr "Aktuālā mape:"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:896 ../src/propgrid/advprops.cpp:1574
-#: ../src/propgrid/advprops.cpp:1612
+#: ../src/propgrid/advprops.cpp:797 ../src/propgrid/advprops.cpp:1475
+#: ../src/propgrid/advprops.cpp:1518
 #, fuzzy
 msgid "Custom"
 msgstr "Pielāgots izmērs"
 
-#: ../src/gtk/print.cpp:217
+#: ../src/gtk/print.cpp:211
 msgid "Custom size"
 msgstr "Pielāgots izmērs"
 
-#: ../src/common/headerctrlcmn.cpp:60
+#: ../src/common/headerctrlcmn.cpp:58
 msgid "Customize Columns"
 msgstr "Pielāgot slejas"
 
-#: ../src/common/stockitem.cpp:151 ../src/stc/stc_i18n.cpp:17
+#: ../src/common/stockitem.cpp:148 ../src/stc/stc_i18n.cpp:17
 msgid "Cut"
 msgstr "Izgriezt"
 
-#: ../src/common/stockitem.cpp:259
+#: ../src/common/stockitem.cpp:256
 msgid "Cut selection"
 msgstr "Izgriezt iezīmēto"
 
-#: ../src/common/fmapbase.cpp:152
+#: ../src/common/fmapbase.cpp:149
 msgid "Cyrillic (ISO-8859-5)"
 msgstr "Kirilisks (ISO-8859-5)"
 
-#: ../src/common/paper.cpp:99
+#: ../src/common/paper.cpp:96
 msgid "D sheet, 22 x 34 in"
 msgstr "D loksne, 559 x 864 mm"
 
-#: ../src/msw/dde.cpp:703
+#: ../src/msw/dde.cpp:698
 msgid "DDE poke request failed"
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1169
+#: ../src/common/imagbmp.cpp:1181
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr "DIB galvene: kodējums neatbilst bitu dziļumam."
 
@@ -2601,7 +2606,7 @@ msgstr "DIB galvene: nezināms bitu dziļums."
 msgid "DIB Header: Unknown encoding in file."
 msgstr "DIB galvene: nezināms faila kodējums."
 
-#: ../src/common/paper.cpp:121
+#: ../src/common/paper.cpp:118
 msgid "DL Envelope, 110 x 220 mm"
 msgstr "Aploksne DL, 110 x 220 mm"
 
@@ -2609,55 +2614,55 @@ msgstr "Aploksne DL, 110 x 220 mm"
 msgid "Dashed"
 msgstr "Svītrots"
 
-#: ../src/generic/dbgrptg.cpp:300
+#: ../src/generic/dbgrptg.cpp:301
 #, c-format
 msgid "Debug report \"%s\""
 msgstr "Atkļūdošanas atskaite \"%s\""
 
-#: ../src/common/debugrpt.cpp:210
+#: ../src/common/debugrpt.cpp:211
 msgid "Debug report couldn't be created."
 msgstr "Nav iespējams izveidot atkļūdošanas atskaiti."
 
-#: ../src/common/debugrpt.cpp:553
+#: ../src/common/debugrpt.cpp:554
 msgid "Debug report generation has failed."
 msgstr "Neizdevās izveidot atkļūdošanas atskaiti."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:84
+#: ../src/common/accelcmn.cpp:81
 msgid "Decimal"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:323
+#: ../src/generic/fontdlgg.cpp:319
 msgid "Decorative"
 msgstr "Dekoratīvs"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1752
+#: ../src/propgrid/advprops.cpp:1653
 #, fuzzy
 msgid "Default"
 msgstr "noklusētais"
 
-#: ../src/common/fmapbase.cpp:796
+#: ../src/common/fmapbase.cpp:792
 msgid "Default encoding"
 msgstr "Noklusētais kodējums"
 
-#: ../src/dfb/fontmgr.cpp:180
+#: ../src/dfb/fontmgr.cpp:177
 msgid "Default font"
 msgstr "Noklusētais fonts"
 
-#: ../src/generic/prntdlgg.cpp:510
+#: ../src/generic/prntdlgg.cpp:503
 msgid "Default printer"
 msgstr "Noklusētais printeris"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:51
+#: ../src/common/accelcmn.cpp:48
 #, fuzzy
 msgid "Del"
 msgstr "Dzēst"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextbuffer.cpp:8221 ../src/common/stockitem.cpp:152
-#: ../src/common/accelcmn.cpp:50 ../src/stc/stc_i18n.cpp:20
+#: ../src/common/stockitem.cpp:149 ../src/common/accelcmn.cpp:47
+#: ../src/richtext/richtextbuffer.cpp:8217 ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Dzēst"
 
@@ -2665,70 +2670,70 @@ msgstr "Dzēst"
 msgid "Delete A&ll"
 msgstr "Dzēst v&isu"
 
-#: ../src/richtext/richtextbuffer.cpp:11341
+#: ../src/richtext/richtextbuffer.cpp:11340
 #, fuzzy
 msgid "Delete Column"
 msgstr "Dzēst iezīmēto"
 
-#: ../src/richtext/richtextbuffer.cpp:11291
+#: ../src/richtext/richtextbuffer.cpp:11290
 #, fuzzy
 msgid "Delete Row"
 msgstr "Dzēst"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 msgid "Delete Style"
 msgstr "Dzēst stilu"
 
-#: ../src/richtext/richtextctrl.cpp:1345 ../src/richtext/richtextctrl.cpp:1584
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
 msgid "Delete Text"
 msgstr "Dzēst tekstu"
 
-#: ../src/generic/editlbox.cpp:170
+#: ../src/generic/editlbox.cpp:147
 msgid "Delete item"
 msgstr "Dzēst objektu"
 
-#: ../src/common/stockitem.cpp:260
+#: ../src/common/stockitem.cpp:257
 msgid "Delete selection"
 msgstr "Dzēst iezīmēto"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 #, c-format
 msgid "Delete style %s?"
 msgstr "Dzēst stilu %s?"
 
-#: ../src/unix/snglinst.cpp:301
+#: ../src/unix/snglinst.cpp:298
 #, c-format
 msgid "Deleted stale lock file '%s'."
 msgstr "Izdzēsts izmantotais slēdzenes fails '%s'."
 
-#: ../src/common/secretstore.cpp:220
+#: ../src/common/secretstore.cpp:234
 #, fuzzy, c-format
-msgid "Deleting password for \"%s/%s\" failed: %s."
+msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Neizdevās izveidot hronometru"
 
-#: ../src/common/module.cpp:124
+#: ../src/common/module.cpp:121
 #, c-format
 msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
 msgstr "Bibliotēka \"%s\", kas nepieciešama moduļa \"%s\" darbībai, nepastāv."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "Descending"
 msgstr "Dilstoši"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:526 ../src/propgrid/advprops.cpp:882
+#: ../src/generic/dirctrlg.cpp:492 ../src/propgrid/advprops.cpp:783
 msgid "Desktop"
 msgstr "Darba virsma"
 
-#: ../src/generic/aboutdlgg.cpp:70
+#: ../src/generic/aboutdlgg.cpp:67
 msgid "Developed by "
 msgstr "Izstrādājis "
 
-#: ../src/generic/aboutdlgg.cpp:176
+#: ../src/generic/aboutdlgg.cpp:173
 msgid "Developers"
 msgstr "Izstrādātāji"
 
-#: ../src/msw/dialup.cpp:374
+#: ../src/msw/dialup.cpp:368
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -2736,11 +2741,11 @@ msgstr ""
 "Iezvanpieejas funkcijas nav pieejamas, jo uz šī datora nav uzstādīts "
 "attālinātās pieejas serviss (RAS). Lūdzu, uzstādiet to."
 
-#: ../src/generic/tipdlg.cpp:211
+#: ../src/generic/tipdlg.cpp:208
 msgid "Did you know..."
 msgstr "Vai jūs zināt..."
 
-#: ../src/dfb/wrapdfb.cpp:63
+#: ../src/dfb/wrapdfb.cpp:60
 #, fuzzy, c-format
 msgid "DirectFB error %d occurred."
 msgstr "Radās DirectFB kļūda %d."
@@ -2749,29 +2754,29 @@ msgstr "Radās DirectFB kļūda %d."
 msgid "Directories"
 msgstr "Mapes"
 
-#: ../src/common/filefn.cpp:1183
+#: ../src/common/filefn.cpp:1071
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Mapi '%s' nevarēja izveidot"
 
-#: ../src/common/filefn.cpp:1197
+#: ../src/common/filefn.cpp:1085
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "Mapi '%s' nav iespējams izdzēst"
 
-#: ../src/generic/dirdlgg.cpp:204
+#: ../src/generic/dirdlgg.cpp:201
 msgid "Directory does not exist"
 msgstr "Mape nepastāv"
 
-#: ../src/generic/filectrlg.cpp:1399
+#: ../src/generic/filectrlg.cpp:1388
 msgid "Directory doesn't exist."
 msgstr "Mape nepastāv."
 
-#: ../src/common/docview.cpp:457
+#: ../src/common/docview.cpp:450
 msgid "Discard changes and reload the last saved version?"
 msgstr "Atmest izmaiņas un atvērt pēdējo saglabāto versiju?"
 
-#: ../src/html/helpwnd.cpp:502
+#: ../src/html/helpwnd.cpp:500
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -2779,46 +2784,46 @@ msgstr ""
 "Parādīt visus indeksa ierakstus, kas satur norādīto apakšvirkni. Meklēšana "
 "nav reģistrjūtīga."
 
-#: ../src/html/helpwnd.cpp:679
+#: ../src/html/helpwnd.cpp:677
 msgid "Display options dialog"
 msgstr "Ekrāna iestatījumu dialogs"
 
-#: ../src/html/helpwnd.cpp:322
+#: ../src/html/helpwnd.cpp:320
 msgid "Displays help as you browse the books on the left."
 msgstr "Parāda palīdzību pārlūkojot grāmatu sarakstu kreisajā pusē."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:85
+#: ../src/common/accelcmn.cpp:83
 msgid "Divide"
 msgstr ""
 
-#: ../src/common/docview.cpp:533
+#: ../src/common/docview.cpp:526
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Vai vēlaties saglabāt izmaiņas %s?"
 
-#: ../src/common/prntbase.cpp:542
+#: ../src/common/prntbase.cpp:537
 #, fuzzy
 msgid "Document:"
 msgstr "Dokumentācijas autori"
 
-#: ../src/generic/aboutdlgg.cpp:73
+#: ../src/generic/aboutdlgg.cpp:70
 msgid "Documentation by "
 msgstr "Dokumentācijas autori"
 
-#: ../src/generic/aboutdlgg.cpp:180
+#: ../src/generic/aboutdlgg.cpp:177
 msgid "Documentation writers"
 msgstr "Dokumentācijas sastādītāji"
 
-#: ../src/common/sizer.cpp:2799
+#: ../src/common/sizer.cpp:2916
 msgid "Don't Save"
 msgstr "Nesaglabāt"
 
-#: ../src/html/htmlwin.cpp:633
+#: ../src/html/htmlwin.cpp:643
 msgid "Done"
 msgstr "Izdarīts"
 
-#: ../src/generic/progdlgg.cpp:448 ../src/msw/progdlg.cpp:407
+#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
 msgid "Done."
 msgstr "Izdarīts."
 
@@ -2830,42 +2835,42 @@ msgstr "Punktēta"
 msgid "Double"
 msgstr "Divkāršs"
 
-#: ../src/common/paper.cpp:176
+#: ../src/common/paper.cpp:173
 msgid "Double Japanese Postcard Rotated 148 x 200 mm"
 msgstr "Dubultā Japāņu pastkarte, pagriezta, 148 x 200 mm"
 
-#: ../src/common/xtixml.cpp:273
+#: ../src/common/xtixml.cpp:269
 #, c-format
 msgid "Doubly used id : %d"
 msgstr "Divreiz izmantots id: %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:153
-#: ../src/common/accelcmn.cpp:64
+#: ../src/common/stockitem.cpp:150 ../src/common/accelcmn.cpp:61
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Down"
 msgstr "Lejup"
 
-#: ../src/richtext/richtextctrl.cpp:865
+#: ../src/richtext/richtextctrl.cpp:864
 msgid "Drag"
 msgstr "Vilkt"
 
-#: ../src/common/paper.cpp:100
+#: ../src/common/paper.cpp:97
 msgid "E sheet, 34 x 44 in"
 msgstr "E loksne, 34 x 44 in"
 
-#: ../src/unix/fswatcher_inotify.cpp:561
+#: ../src/unix/fswatcher_inotify.cpp:558
 msgid "EOF while reading from inotify descriptor"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "Edit"
 msgstr "Labot"
 
-#: ../src/generic/editlbox.cpp:168
+#: ../src/generic/editlbox.cpp:131
 msgid "Edit item"
 msgstr "Rediģēt objektu"
 
-#: ../include/wx/generic/progdlgg.h:84
+#: ../include/wx/generic/progdlgg.h:85
 #, fuzzy
 msgid "Elapsed time:"
 msgstr "Pagājušais laiks:"
@@ -2938,62 +2943,62 @@ msgid "Enables the shadow spread."
 msgstr "Iespējot platuma vērtību"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:66
+#: ../src/common/accelcmn.cpp:63
 msgid "End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:55
+#: ../src/common/accelcmn.cpp:52
 #, fuzzy
 msgid "Enter"
 msgstr "Printeris"
 
-#: ../src/richtext/richtextstyledlg.cpp:934
+#: ../src/richtext/richtextstyledlg.cpp:930
 msgid "Enter a box style name"
 msgstr "Ievadiet rāmja stila nosaukumu"
 
-#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:602
 msgid "Enter a character style name"
 msgstr "Ievadiet rakstzīmju stila nosaukumu"
 
-#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:816
 msgid "Enter a list style name"
 msgstr "Ievadiet saraksta stila nosaukumu"
 
-#: ../src/richtext/richtextstyledlg.cpp:893
+#: ../src/richtext/richtextstyledlg.cpp:889
 msgid "Enter a new style name"
 msgstr "Ievadiet jaunā stila nosaukumu"
 
-#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:650
 msgid "Enter a paragraph style name"
 msgstr "Ievadiet rindkopas stila nosaukumu"
 
-#: ../src/generic/dbgrptg.cpp:174
+#: ../src/generic/dbgrptg.cpp:171
 #, c-format
 msgid "Enter command to open file \"%s\":"
 msgstr "Ievadiet komandu faila \"%s\" atvēršanai:"
 
-#: ../src/generic/helpext.cpp:459
+#: ../src/generic/helpext.cpp:457
 msgid "Entries found"
 msgstr "Ieraksti atrasti"
 
-#: ../src/common/paper.cpp:142
+#: ../src/common/paper.cpp:139
 msgid "Envelope Invite 220 x 220 mm"
 msgstr "Aploksne Invite 220 x 220 mm"
 
-#: ../src/common/config.cpp:469
+#: ../src/common/config.cpp:465
 #, c-format
 msgid ""
 "Environment variables expansion failed: missing '%c' at position %u in '%s'."
 msgstr ""
 
-#: ../src/generic/filedlgg.cpp:357 ../src/generic/dirctrlg.cpp:570
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/dirctrlg.cpp:599
-#: ../src/generic/dirdlgg.cpp:323 ../src/generic/filectrlg.cpp:642
-#: ../src/generic/filectrlg.cpp:756 ../src/generic/filectrlg.cpp:770
-#: ../src/generic/filectrlg.cpp:786 ../src/generic/filectrlg.cpp:1368
-#: ../src/generic/filectrlg.cpp:1399 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/gtk1/fontdlg.cpp:74 ../src/generic/dirctrlg.cpp:536
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/dirctrlg.cpp:565
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1357 ../src/generic/filectrlg.cpp:1388
+#: ../src/generic/filedlgg.cpp:354 ../src/generic/dirdlgg.cpp:320
+#: ../src/gtk/filedlg.cpp:74
 msgid "Error"
 msgstr "Kļūda"
 
@@ -3001,235 +3006,256 @@ msgstr "Kļūda"
 msgid "Error closing epoll descriptor"
 msgstr ""
 
-#: ../src/unix/fswatcher_kqueue.cpp:114
+#: ../src/unix/fswatcher_kqueue.cpp:131
 msgid "Error closing kqueue instance"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1049
+#: ../src/common/filefn.cpp:938
 #, fuzzy, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Neizdevās nokopēt failu '%s' uz '%s'"
 
-#: ../src/generic/dirdlgg.cpp:222
+#: ../src/generic/dirdlgg.cpp:219
 msgid "Error creating directory"
 msgstr "Kļūda izveidojot mapi"
 
-#: ../src/common/imagbmp.cpp:1181
+#: ../src/common/imagbmp.cpp:1193
 msgid "Error in reading image DIB."
 msgstr "Kļūda nolasot attēla DIB"
 
-#: ../src/propgrid/propgrid.cpp:6696
+#: ../src/propgrid/propgrid.cpp:6665
 #, c-format
 msgid "Error in resource: %s"
 msgstr "Kļūda resursā: %s"
 
-#: ../src/common/fileconf.cpp:422
+#: ../src/common/fileconf.cpp:421
 msgid "Error reading config options."
 msgstr "Kļūda lasot konfigurācijas iestatījumus."
+
+#: ../src/msw/webview_ie.cpp:1057 ../src/msw/webview_edge.cpp:850
+#: ../src/gtk/webview_webkit2.cpp:1262 ../src/osx/webview_webkit.mm:383
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
 
 #: ../src/common/fileconf.cpp:1029
 msgid "Error saving user configuration data."
 msgstr "Kļūda saglabājot lietotāja konfigurācijas datus."
 
-#: ../src/gtk/print.cpp:722
+#: ../src/gtk/print.cpp:720
 msgid "Error while printing: "
 msgstr "Kļūda drukājot:"
 
-#: ../src/common/log.cpp:219
+#: ../src/common/log.cpp:237
 msgid "Error: "
 msgstr "Kļūda: "
 
+#: ../src/common/webrequest.cpp:98
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Kļūda: "
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:69
+#: ../src/common/accelcmn.cpp:66
 msgid "Esc"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:70
+#: ../src/common/accelcmn.cpp:67
 #, fuzzy
 msgid "Escape"
 msgstr "Ainava"
 
-#: ../src/common/fmapbase.cpp:150
+#: ../src/common/fmapbase.cpp:147
 msgid "Esperanto (ISO-8859-3)"
 msgstr "Esperanto (ISO-8859-3)"
 
-#: ../include/wx/generic/progdlgg.h:85
+#: ../include/wx/generic/progdlgg.h:86
 #, fuzzy
 msgid "Estimated time:"
 msgstr "Aptuvenais laiks:"
 
-#: ../src/generic/dbgrptg.cpp:234
+#: ../src/generic/dbgrptg.cpp:231
 msgid "Executable files (*.exe)|*.exe|"
 msgstr "Izpildāmie faili (*.exe)|*.exe|"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:155 ../src/common/accelcmn.cpp:78
+#: ../src/common/stockitem.cpp:152 ../src/common/accelcmn.cpp:75
 msgid "Execute"
 msgstr "Izpildīt"
 
-#: ../src/msw/utilsexc.cpp:876
+#: ../src/msw/utilsexc.cpp:873
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Komandas '%s' izpilde neizdevās"
 
-#: ../src/common/paper.cpp:105
+#: ../src/common/paper.cpp:102
 msgid "Executive, 7 1/4 x 10 1/2 in"
 msgstr "Executive, 7 1/4 x 10 1/2 in"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6009
+#: ../src/generic/datavgen.cpp:6814
 msgid "Expand"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1240
+#: ../src/msw/registry.cpp:1228
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
 msgstr ""
 "Reģistra atslēgas eksports: fails \"%s\" jau pastāv un netiks pārrakstīts."
 
-#: ../src/common/fmapbase.cpp:195
+#: ../src/common/fmapbase.cpp:192
 msgid "Extended Unix Codepage for Japanese (EUC-JP)"
 msgstr "Paplašinātā Unix kodu lapa japāņu valodai (EUC-JP)"
 
-#: ../src/html/chm.cpp:725
+#: ../src/html/chm.cpp:718
 #, c-format
 msgid "Extraction of '%s' into '%s' failed."
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:249 ../src/common/accelcmn.cpp:344
+#: ../src/common/accelcmn.cpp:259 ../src/common/accelcmn.cpp:358
 msgid "F"
 msgstr "F"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:672
+#: ../src/propgrid/advprops.cpp:582
 msgid "Face Name"
 msgstr "Fonta nosaukums"
 
-#: ../src/unix/snglinst.cpp:269
+#: ../src/unix/snglinst.cpp:266
 msgid "Failed to access lock file."
 msgstr "Neizdevās piekļūt slēdzenes failam."
+
+#: ../src/gtk/font.cpp:572
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Neizdevās ielasīt dokumentu no faila \"%s\"."
 
 #: ../src/unix/epolldispatcher.cpp:116
 #, c-format
 msgid "Failed to add descriptor %d to epoll descriptor %d"
 msgstr ""
 
-#: ../src/msw/dib.cpp:489
+#: ../src/msw/dib.cpp:535
 #, c-format
 msgid "Failed to allocate %luKb of memory for bitmap data."
 msgstr "Neizdevās piešķirt %luKb atmiņas bitkartes datiem."
 
-#: ../src/common/glcmn.cpp:115
+#: ../src/common/glcmn.cpp:112
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Neizdevās piešķirt krāsu OpenGL"
 
-#: ../src/unix/displayx11.cpp:236
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Neizdevās piešķirt krāsu OpenGL"
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Neizdevās piešķirt krāsu OpenGL"
+
+#: ../include/wx/unix/private/displayx11.h:89
 msgid "Failed to change video mode"
 msgstr "Nevar nomainīt video režīmu"
 
-#: ../src/common/image.cpp:3277
+#: ../src/common/image.cpp:3396
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Neizdevās pārbaudīt attēla \"%s\" faila formātu."
 
-#: ../src/common/debugrpt.cpp:239
+#: ../src/common/debugrpt.cpp:240
 #, c-format
 msgid "Failed to clean up debug report directory \"%s\""
 msgstr "Nav iespējams iztīrīt atkļūdošanas atskaites mapi \"%s\""
 
-#: ../src/common/filename.cpp:192
+#: ../src/common/filename.cpp:189
 msgid "Failed to close file handle"
 msgstr "Neizdevās aizvērt faila turi."
 
-#: ../src/unix/snglinst.cpp:340
+#: ../src/unix/snglinst.cpp:337
 #, c-format
 msgid "Failed to close lock file '%s'"
 msgstr "Neizdevās aizvērt slēdzenes failu '%s'"
 
-#: ../src/msw/clipbrd.cpp:112
+#: ../src/msw/clipbrd.cpp:110
 msgid "Failed to close the clipboard."
 msgstr "Nevar aizvērt starpliktuvi."
 
-#: ../src/x11/utils.cpp:208
+#: ../src/x11/utils.cpp:170
 #, c-format
 msgid "Failed to close the display \"%s\""
 msgstr "Neizdevās aizvērt ekrānu \"%s\""
 
-#: ../src/msw/dialup.cpp:797
+#: ../src/msw/dialup.cpp:791
 msgid "Failed to connect: missing username/password."
 msgstr "Nav iespējams pieslēgties: nav norādīts lietotāja vārds.parole."
 
-#: ../src/msw/dialup.cpp:743
+#: ../src/msw/dialup.cpp:737
 msgid "Failed to connect: no ISP to dial."
 msgstr "Nav iespējams pieslēgties: nav ISP, kam zvanīt."
 
-#: ../src/common/textfile.cpp:203
-#, c-format
-msgid "Failed to convert file \"%s\" to Unicode."
-msgstr "Neizdevās pārvērst failu \"%s\"  uz Unikodu."
-
-#: ../src/generic/logg.cpp:956
+#: ../src/generic/logg.cpp:953
 msgid "Failed to copy dialog contents to the clipboard."
 msgstr "Neizdevās nokopēt dialoga saturu uz starpliktuvi."
 
-#: ../src/msw/registry.cpp:692
+#: ../src/msw/registry.cpp:681
 #, c-format
 msgid "Failed to copy registry value '%s'"
 msgstr "Neizdevās nokopēt reģistra vertību '%s'"
 
-#: ../src/msw/registry.cpp:701
+#: ../src/msw/registry.cpp:690
 #, c-format
 msgid "Failed to copy the contents of registry key '%s' to '%s'."
 msgstr "Nav iespējams nokopēt reģistra atslēgas '%s' saturu uz '%s'."
 
-#: ../src/common/filefn.cpp:1015
+#: ../src/common/filefn.cpp:904
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Neizdevās nokopēt failu '%s' uz '%s'"
 
-#: ../src/msw/registry.cpp:679
+#: ../src/msw/registry.cpp:668
 #, c-format
 msgid "Failed to copy the registry subkey '%s' to '%s'."
 msgstr "Neizdevās nokopēt reģistra apakšatslēgu '%s' uz '%s'."
 
-#: ../src/msw/dde.cpp:1070
+#: ../src/msw/dde.cpp:1134
 msgid "Failed to create DDE string"
 msgstr "Neizdevās izveidot DDE virkni"
 
-#: ../src/msw/mdi.cpp:616
+#: ../src/msw/mdi.cpp:621
 msgid "Failed to create MDI parent frame."
 msgstr ""
 
-#: ../src/common/filename.cpp:1027
+#: ../src/common/filename.cpp:1024
 msgid "Failed to create a temporary file name"
 msgstr "Neizdevās izveidot pagaidu faila nosaukumu"
 
-#: ../src/msw/utilsexc.cpp:228
+#: ../src/msw/utilsexc.cpp:225
 msgid "Failed to create an anonymous pipe"
 msgstr "Neizdevās izveidot anonīmu programmkanālu"
 
-#: ../src/msw/ole/automtn.cpp:522
+#: ../src/msw/ole/automtn.cpp:513
 #, c-format
 msgid "Failed to create an instance of \"%s\""
 msgstr ""
 
-#: ../src/msw/dde.cpp:437
+#: ../src/msw/dde.cpp:432
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "Neizdevās izveidot savienojumu ar serveri '%s'par tematu '%s'"
 
-#: ../src/msw/cursor.cpp:204
+#: ../src/msw/cursor.cpp:195
 msgid "Failed to create cursor."
 msgstr "Neizdevās izveidot kursoru."
 
-#: ../src/common/debugrpt.cpp:209
+#: ../src/common/debugrpt.cpp:210
 #, c-format
 msgid "Failed to create directory \"%s\""
 msgstr "Neizdevās izveidot mapi \"%s\""
 
-#: ../src/generic/dirdlgg.cpp:220
+#: ../src/generic/dirdlgg.cpp:217
 #, c-format
 msgid ""
 "Failed to create directory '%s'\n"
@@ -3242,116 +3268,135 @@ msgstr ""
 msgid "Failed to create epoll descriptor"
 msgstr ""
 
-#: ../src/msw/mimetype.cpp:238
+#: ../src/gtk/font.cpp:562
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "Neizdevās atsvaidzināt lietotāja konfigurācijas failu."
+
+#: ../src/msw/mimetype.cpp:235
 #, c-format
 msgid "Failed to create registry entry for '%s' files."
 msgstr "Neizdevās izveidot reģistra ierakstu '%s' failiem."
 
-#: ../src/msw/fdrepdlg.cpp:409
+#: ../src/msw/fdrepdlg.cpp:408
 #, c-format
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr "Neizdevās atvērt standarta Meklēt/aizvietot dialogu (kļūdas kods %d)"
 
-#: ../src/unix/wakeuppipe.cpp:52
+#: ../src/unix/wakeuppipe.cpp:49
 msgid "Failed to create wake up pipe used by event loop."
 msgstr ""
 
-#: ../src/html/winpars.cpp:730
+#: ../src/html/winpars.cpp:727
 #, c-format
 msgid "Failed to display HTML document in %s encoding"
 msgstr "Neizdevās parādīt  HTML dokumentu %s kodējumā"
 
-#: ../src/msw/clipbrd.cpp:124
+#: ../src/msw/clipbrd.cpp:122
 msgid "Failed to empty the clipboard."
 msgstr "Neizdevās iztīrīt starpliktuvi."
 
-#: ../src/unix/displayx11.cpp:212
+#: ../include/wx/unix/private/displayx11.h:65
 msgid "Failed to enumerate video modes"
 msgstr "Neizdevās uzskaitīt video režīmus"
 
-#: ../src/msw/dde.cpp:722
+#: ../src/msw/dde.cpp:717
 msgid "Failed to establish an advise loop with DDE server"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:629 ../src/msw/dialup.cpp:863
+#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Neizdevās izveidot iezvanpieejas savienojumu: %s"
 
-#: ../src/unix/utilsunx.cpp:611
+#: ../src/unix/utilsunx.cpp:613
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Neizdevās izpildīt '%s'\n"
 
-#: ../src/common/debugrpt.cpp:720
+#: ../src/common/debugrpt.cpp:730
 msgid "Failed to execute curl, please install it in PATH."
 msgstr "Neizdevās izpildīt curl, lūdzu uzstādiet to sistēmas ceļā (PATH)."
 
-#: ../src/msw/ole/automtn.cpp:505
+#: ../src/msw/ole/automtn.cpp:496
 #, c-format
 msgid "Failed to find CLSID of \"%s\""
 msgstr "Neizdevās atrast \"%s\" CLSID"
 
-#: ../src/common/regex.cpp:431 ../src/common/regex.cpp:479
+#: ../src/common/regex.cpp:428 ../src/common/regex.cpp:476
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "Neizdevās atrast atbilstību regulārai izteiksmei: %s"
 
-#: ../src/msw/dialup.cpp:695
+#: ../src/msw/webview_ie.cpp:978
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:689
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Neizdevās iegūt ISP nosaukumus: %s"
 
-#: ../src/msw/ole/automtn.cpp:574
+#: ../src/msw/ole/automtn.cpp:565
 #, c-format
 msgid "Failed to get OLE automation interface for \"%s\""
 msgstr "Neizdevās saņemt \"%s\" OLE automatizācijas saskarni"
 
-#: ../src/msw/clipbrd.cpp:711
+#: ../src/msw/clipbrd.cpp:731
 msgid "Failed to get data from the clipboard"
 msgstr "Neizdevās iegūt datus no starpliktuves."
 
-#: ../src/common/time.cpp:223
+#: ../src/common/time.cpp:216
 msgid "Failed to get the local system time"
 msgstr "Neizdevās nolasīt lokālās sistēmas laiku"
 
-#: ../src/common/filefn.cpp:1345
+#: ../src/common/filefn.cpp:1233
 msgid "Failed to get the working directory"
 msgstr "Neizdevās noteikt darba mapi"
 
-#: ../src/univ/theme.cpp:114
+#: ../src/univ/theme.cpp:111
 msgid "Failed to initialize GUI: no built-in themes found."
 msgstr ""
 "Neizdevās inicializēt grafisko lietotāja saskarni: nav atrasta neviena "
 "iebūvēta tēma."
 
-#: ../src/msw/helpchm.cpp:63
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:60
 msgid "Failed to initialize MS HTML Help."
 msgstr "Neizdevās inicializēt MS HTML Help."
 
-#: ../src/msw/glcanvas.cpp:1381
+#: ../src/msw/glcanvas.cpp:1391
 msgid "Failed to initialize OpenGL"
 msgstr "Neizdevās inicializēt OpenGL"
 
-#: ../src/msw/dialup.cpp:858
+#: ../src/msw/dialup.cpp:852
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Neizdevās izveidot iezvanpieejas savienojumu: %s"
 
-#: ../src/gtk/textctrl.cpp:1128
+#: ../src/gtk/textctrl.cpp:1209
 msgid "Failed to insert text in the control."
 msgstr "Neizdevās ievietot tekstu vadīklā."
 
-#: ../src/unix/snglinst.cpp:241
+#: ../src/unix/snglinst.cpp:238
 #, c-format
 msgid "Failed to inspect the lock file '%s'"
 msgstr "Neizdevās pārbaudīt slēdzenes failu '%s'"
 
-#: ../src/unix/appunix.cpp:182
+#: ../src/unix/appunix.cpp:179
 msgid "Failed to install signal handler"
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1167
+#: ../src/unix/threadpsx.cpp:1216
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -3359,71 +3404,71 @@ msgstr ""
 "Kļūda pievienojoties pavedienam, atrasta iespējama atmiņas noplūde - lūdzu "
 "pārstartējiet programmu"
 
-#: ../src/msw/utils.cpp:629
+#: ../src/msw/utils.cpp:619
 #, c-format
 msgid "Failed to kill process %d"
 msgstr "Neizdevās pārtraukt procesu %d"
 
-#: ../src/common/image.cpp:2500
+#: ../src/common/image.cpp:2595
 #, fuzzy, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Neizdevās ielādēt attēlu %d no straumējuma."
 
-#: ../src/common/image.cpp:2509
+#: ../src/common/image.cpp:2604
 #, fuzzy, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Neizdevās ielādēt attēlu %d no straumējuma."
 
-#: ../src/common/iconbndl.cpp:225
+#: ../src/common/iconbndl.cpp:224
 #, fuzzy, c-format
 msgid "Failed to load icons from resource '%s'."
 msgstr "Neizdevās ielādēt attēlu %d no straumējuma."
 
-#: ../src/common/iconbndl.cpp:200
+#: ../src/common/iconbndl.cpp:198
 #, c-format
 msgid "Failed to load image %%d from file '%s'."
 msgstr "Neizdevās ielādēt attēlu %%d no faila '%s'."
 
-#: ../src/common/iconbndl.cpp:208
+#: ../src/common/iconbndl.cpp:206
 #, c-format
 msgid "Failed to load image %d from stream."
 msgstr "Neizdevās ielādēt attēlu %d no straumējuma."
 
-#: ../src/common/image.cpp:2587 ../src/common/image.cpp:2606
+#: ../src/common/image.cpp:2682 ../src/common/image.cpp:2701
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Neizdevās ielādēt attēlu no faila \"%s\"."
 
-#: ../src/msw/enhmeta.cpp:97
+#: ../src/msw/enhmeta.cpp:94
 #, c-format
 msgid "Failed to load metafile from file \"%s\"."
 msgstr "Neizdevās ielādēt matafailu no faila \"%s\"."
 
-#: ../src/msw/volume.cpp:327
+#: ../src/msw/volume.cpp:335
 msgid "Failed to load mpr.dll."
 msgstr "Nevar ielādēt mpr.dll."
 
-#: ../src/msw/utils.cpp:953
+#: ../src/msw/utils.cpp:943
 #, c-format
 msgid "Failed to load resource \"%s\"."
 msgstr "Neizdevās ielādēt resursu \"%s\"."
 
-#: ../src/common/dynlib.cpp:92
+#: ../src/common/dynlib.cpp:86
 #, c-format
 msgid "Failed to load shared library '%s'"
 msgstr "Nevar ielādēt koplietojamo bibliotēku '%s'"
 
-#: ../src/osx/core/sound.cpp:145
+#: ../src/osx/core/sound.cpp:143
 #, fuzzy, c-format
 msgid "Failed to load sound from \"%s\" (error %d)."
 msgstr "Neizdevās ielādēt resursu \"%s\"."
 
-#: ../src/msw/utils.cpp:960
+#: ../src/msw/utils.cpp:950
 #, c-format
 msgid "Failed to lock resource \"%s\"."
 msgstr "Neizdevās aizslēgt resursu: \"%s\"."
 
-#: ../src/unix/snglinst.cpp:198
+#: ../src/unix/snglinst.cpp:195
 #, c-format
 msgid "Failed to lock the lock file '%s'"
 msgstr "Neizdevās aizslēgt slēdzenes failu '%s'"
@@ -3433,33 +3478,38 @@ msgstr "Neizdevās aizslēgt slēdzenes failu '%s'"
 msgid "Failed to modify descriptor %d in epoll descriptor %d"
 msgstr ""
 
-#: ../src/common/filename.cpp:2575
+#: ../src/common/filename.cpp:2658
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Neizdevās izmainīt faila  '%s' laikus"
 
-#: ../src/common/selectdispatcher.cpp:258
+#: ../src/common/selectdispatcher.cpp:255
 msgid "Failed to monitor I/O channels"
 msgstr ""
 
-#: ../src/common/filename.cpp:175
+#: ../src/common/filename.cpp:172
 #, c-format
 msgid "Failed to open '%s' for reading"
 msgstr "Neizdevās atvērt '%s' lasīšanai"
 
-#: ../src/common/filename.cpp:180
+#: ../src/common/filename.cpp:177
 #, c-format
 msgid "Failed to open '%s' for writing"
 msgstr "Neizdevās atvērt '%s' rakstīšanai"
 
-#: ../src/html/chm.cpp:141
+#: ../src/html/chm.cpp:138
 #, c-format
 msgid "Failed to open CHM archive '%s'."
 msgstr "Neizdevās atvērt CHM arhīvu '%s'."
 
-#: ../src/common/utilscmn.cpp:1126
+#: ../src/common/utilscmn.cpp:1140
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Noklusētajā pārlūkā neizdevās atvērt URL \"%s\"."
+
+#: ../src/common/hyperlnkcmn.cpp:133
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Noklusētajā pārlūkā neizdevās atvērt URL \"%s\"."
 
 #: ../include/wx/msw/private/fswatcher.h:92
@@ -3467,209 +3517,228 @@ msgstr "Noklusētajā pārlūkā neizdevās atvērt URL \"%s\"."
 msgid "Failed to open directory \"%s\" for monitoring."
 msgstr "Mapi \"%s\" atvērt novērošanai neizdevās."
 
-#: ../src/x11/utils.cpp:227
+#: ../src/x11/utils.cpp:189
 #, c-format
 msgid "Failed to open display \"%s\"."
 msgstr "Neizdevās atvērt displeju \"%s\"."
 
-#: ../src/common/filename.cpp:1062
+#: ../src/common/filename.cpp:1059
 msgid "Failed to open temporary file."
 msgstr "Neizdevās uz atvērt pagaidu failu"
 
-#: ../src/msw/clipbrd.cpp:91
+#: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Neizdevās atvērt starpliktuvi."
 
-#: ../src/common/translation.cpp:1184
+#: ../src/common/translation.cpp:1226
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr ""
 
-#: ../src/unix/mediactrl.cpp:1214
+#: ../src/unix/mediactrl.cpp:1239
 #, fuzzy, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Neizdevās atvērt displeju \"%s\"."
 
-#: ../src/msw/clipbrd.cpp:600
+#: ../src/msw/clipbrd.cpp:610
 msgid "Failed to put data on the clipboard"
 msgstr "Neizdevās ievieto datus starpliktuvē"
 
-#: ../src/unix/snglinst.cpp:278
+#: ../src/unix/snglinst.cpp:275
 msgid "Failed to read PID from lock file."
 msgstr "Neizdevās nolasīt PID no slēdzenes faila."
 
-#: ../src/common/fileconf.cpp:433
+#: ../src/common/fileconf.cpp:432
 msgid "Failed to read config options."
 msgstr "Neizdevās nolasīt konfigurācijas datus."
 
-#: ../src/common/docview.cpp:681
+#: ../src/common/docview.cpp:676
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Neizdevās ielasīt dokumentu no faila \"%s\"."
 
-#: ../src/dfb/evtloop.cpp:98
+#: ../src/dfb/evtloop.cpp:99
 msgid "Failed to read event from DirectFB pipe"
 msgstr "Neizdevās nolasīt notikumu no DirectFB programmkanāla."
 
-#: ../src/unix/wakeuppipe.cpp:120
+#: ../src/unix/wakeuppipe.cpp:117
 msgid "Failed to read from wake-up pipe"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:679
+#: ../src/common/textfile.cpp:96
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Neizdevās ielasīt dokumentu no faila \"%s\"."
+
+#: ../src/unix/utilsunx.cpp:681
 msgid "Failed to redirect child process input/output"
 msgstr ""
 
-#: ../src/msw/utilsexc.cpp:701
+#: ../src/msw/utilsexc.cpp:698
 msgid "Failed to redirect the child process IO"
 msgstr ""
 
-#: ../src/msw/dde.cpp:288
+#: ../src/msw/dde.cpp:283
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Neizdevās reģistrēt DDE serveri '%s'"
 
-#: ../src/common/fontmap.cpp:245
+#: ../src/gtk/font.cpp:580
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "Neizdevās atsvaidzināt lietotāja konfigurācijas failu."
+
+#: ../src/common/fontmap.cpp:242
 #, c-format
 msgid "Failed to remember the encoding for the charset '%s'."
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:227
+#: ../src/common/debugrpt.cpp:228
 #, c-format
 msgid "Failed to remove debug report file \"%s\""
 msgstr "Neizdevās izdzēst atkļūdošanas atskaites failu  \"%s\""
 
-#: ../src/unix/snglinst.cpp:328
+#: ../src/unix/snglinst.cpp:325
 #, c-format
 msgid "Failed to remove lock file '%s'"
 msgstr "Neizdevās izdzēst slēdzenes failu '%s'"
 
-#: ../src/unix/snglinst.cpp:288
+#: ../src/unix/snglinst.cpp:285
 #, c-format
 msgid "Failed to remove stale lock file '%s'."
 msgstr "Neizdevās izdzēst izmantoto slēdzenes failu '%s'."
 
-#: ../src/msw/registry.cpp:529
+#: ../src/msw/registry.cpp:518
 #, c-format
 msgid "Failed to rename registry value '%s' to '%s'."
 msgstr "Neizdevās pārdēvēt reģistra vērtību '%s' par '%s'."
 
-#: ../src/common/filefn.cpp:1122
+#: ../src/common/filefn.cpp:1011
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
 "exists."
 msgstr "Neizdevās pārdēvēt failu '%s' par '%s' jo mērķa fails jau pastāv."
 
-#: ../src/msw/registry.cpp:634
+#: ../src/msw/registry.cpp:623
 #, c-format
 msgid "Failed to rename the registry key '%s' to '%s'."
 msgstr "Neizdevās pārdēvēt reģistra atslēgu '%s' par '%s'."
 
-#: ../src/common/filename.cpp:2671
+#: ../src/msw/webview_ie.cpp:995
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/common/filename.cpp:2754
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Neizdevās iegūt faila '%s' laikus"
 
-#: ../src/msw/dialup.cpp:468
+#: ../src/msw/dialup.cpp:462
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Neizdevās saņemt RAS ķļūdas paziņojuma tekstu."
 
-#: ../src/msw/clipbrd.cpp:748
+#: ../src/msw/clipbrd.cpp:768
 msgid "Failed to retrieve the supported clipboard formats"
 msgstr "Neizdevās saņemt atbalstītos starpliktuves formātus."
 
-#: ../src/common/docview.cpp:652
+#: ../src/common/docview.cpp:647
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Neizdevās saglabāt dokumentu failā \"%s\"."
 
-#: ../src/msw/dib.cpp:269
+#: ../src/msw/dib.cpp:312
 #, c-format
 msgid "Failed to save the bitmap image to file \"%s\"."
 msgstr "Neizdevās saglabāt bitkartes attēlu failā \"%s\"."
 
-#: ../src/msw/dde.cpp:763
+#: ../src/msw/dde.cpp:811
 msgid "Failed to send DDE advise notification"
 msgstr ""
 
-#: ../src/common/ftp.cpp:402
+#: ../src/common/ftp.cpp:399
 #, c-format
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Neizdevās uzstādīt FTP datu pārraides režīmu %s."
 
-#: ../src/msw/clipbrd.cpp:427
+#: ../src/msw/clipbrd.cpp:443
 msgid "Failed to set clipboard data."
 msgstr "Neizdevās iestatīt starpliktuves datus."
 
-#: ../src/unix/snglinst.cpp:181
+#: ../src/unix/snglinst.cpp:178
 #, c-format
 msgid "Failed to set permissions on lock file '%s'"
 msgstr "Neizdevās uzstādīt pieejas tiesības slēdzenes failam '%s'"
 
-#: ../src/unix/utilsunx.cpp:668
+#: ../src/unix/utilsunx.cpp:670
 #, fuzzy
 msgid "Failed to set process priority"
 msgstr "Neizdevās uzstādīt pavediena prioritāti %d."
 
-#: ../src/common/file.cpp:559
+#: ../src/common/ffile.cpp:355 ../src/common/file.cpp:586
 msgid "Failed to set temporary file permissions"
 msgstr "Neizdevās uzstādīt pieejas tiesības pagaidu failam"
 
-#: ../src/gtk/textctrl.cpp:1072
-msgid "Failed to set text in the text control."
-msgstr "Neizdevās iestatīt tekstu teksta vadīklā."
-
-#: ../src/unix/threadpsx.cpp:1298
+#: ../src/unix/threadpsx.cpp:1347
 #, fuzzy, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Neizdevās uzstādīt pavediena prioritāti %d."
 
-#: ../src/unix/threadpsx.cpp:1424
+#: ../src/unix/threadpsx.cpp:1473
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Neizdevās uzstādīt pavediena prioritāti %d."
 
-#: ../src/unix/utilsunx.cpp:783
+#: ../src/unix/utilsunx.cpp:785
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 
-#: ../src/common/fs_mem.cpp:261
+#: ../src/msw/webview_ie.cpp:987
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:256
 #, c-format
 msgid "Failed to store image '%s' to memory VFS!"
 msgstr "Neizdevās saglabāt attēlu '%s' atmiņas VFS!"
 
-#: ../src/dfb/evtloop.cpp:170
+#: ../src/dfb/evtloop.cpp:171
 msgid "Failed to switch DirectFB pipe to non-blocking mode"
 msgstr ""
 
-#: ../src/unix/wakeuppipe.cpp:59
+#: ../src/unix/wakeuppipe.cpp:56
 msgid "Failed to switch wake up pipe to non-blocking mode"
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1605
+#: ../src/unix/threadpsx.cpp:1654
 msgid "Failed to terminate a thread."
 msgstr "Neizdevās pārtraukt pavedienu."
 
-#: ../src/msw/dde.cpp:741
+#: ../src/msw/dde.cpp:736
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:938
+#: ../src/msw/dialup.cpp:932
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Neizdevās pārtraukt iezvanpieejas savienojumu: %s"
 
-#: ../src/common/filename.cpp:2590
+#: ../src/common/filename.cpp:2673
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Neizdevās pieskarties (touch) failam '%s'"
 
-#: ../src/unix/snglinst.cpp:334
+#: ../src/unix/dlunix.cpp:90
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "Nevar ielādēt koplietojamo bibliotēku '%s'"
+
+#: ../src/unix/snglinst.cpp:331
 #, c-format
 msgid "Failed to unlock lock file '%s'"
 msgstr "Neizdevās atslēgt slēdzenes failu '%s'"
 
-#: ../src/msw/dde.cpp:309
+#: ../src/msw/dde.cpp:304
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Neizdevās dereģistrēt DDE serveri '%s'"
@@ -3683,77 +3752,87 @@ msgstr ""
 msgid "Failed to update user configuration file."
 msgstr "Neizdevās atsvaidzināt lietotāja konfigurācijas failu."
 
-#: ../src/common/debugrpt.cpp:733
+#: ../src/common/debugrpt.cpp:743
 #, c-format
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Neizdevās augšupielādēt atkļūdošanas atskaiti (kļūda kods %d)."
 
-#: ../src/unix/snglinst.cpp:168
+#: ../src/unix/snglinst.cpp:165
 #, c-format
 msgid "Failed to write to lock file '%s'"
 msgstr "Neizdevās ierakstīt slēdzenes failā '%s'"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:209
+#: ../src/propgrid/propgrid.cpp:190
 msgid "False"
 msgstr "Aplams"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:694
+#: ../src/propgrid/advprops.cpp:604
 msgid "Family"
 msgstr "Saime"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/gtk/glcanvas.cpp:176 ../src/gtk/glcanvas.cpp:187
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Fatāla kļūda"
+
+#: ../src/common/stockitem.cpp:154
 msgid "File"
 msgstr "Fails"
 
-#: ../src/common/docview.cpp:669
+#: ../src/common/docview.cpp:664
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Fails \"%s\" nav atverams lasīšanai."
 
-#: ../src/common/docview.cpp:646
+#: ../src/common/docview.cpp:641
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Fails \"%s\" nav atverams rakstīšanai."
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "Fails '%s' jau eksistē, vai patiešām vēlaties to pārrakstīt?"
 
-#: ../src/common/filefn.cpp:1156
+#: ../src/common/filefn.cpp:1044
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Fails '%s' nav izdzēšams"
 
-#: ../src/common/filefn.cpp:1139
+#: ../src/common/filefn.cpp:1028
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Fails '%s' nav pārdēvējams par '%s'"
 
-#: ../src/richtext/richtextctrl.cpp:3081 ../src/common/textcmn.cpp:953
+#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
 msgid "File couldn't be loaded."
 msgstr "Failu nevar ielādēt."
 
-#: ../src/msw/filedlg.cpp:393
+#: ../src/msw/filedlg.cpp:414
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Faila dialogs pārtrauca dabību ar kļūdu %0lx."
 
-#: ../src/common/docview.cpp:1789
+#: ../src/common/docview.cpp:1783
 msgid "File error"
 msgstr "Faila kļūda"
 
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/filectrlg.cpp:770
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/filectrlg.cpp:766
 msgid "File name exists already."
 msgstr "Faila nosaukumu jau pastāv."
+
+#: ../src/osx/cocoa/filedlg.mm:264
+#, fuzzy
+msgid "File type:"
+msgstr "Teletaips"
 
 #: ../src/motif/filedlg.cpp:220
 msgid "Files"
 msgstr "Faili"
 
-#: ../src/common/filefn.cpp:1591
+#: ../src/common/filefn.cpp:1479
 #, c-format
 msgid "Files (%s)"
 msgstr "Faili (%s)"
@@ -3762,15 +3841,29 @@ msgstr "Faili (%s)"
 msgid "Filter"
 msgstr "Filtrs"
 
-#: ../src/common/stockitem.cpp:158 ../src/html/helpwnd.cpp:490
+#: ../src/html/helpwnd.cpp:488
 msgid "Find"
 msgstr "Meklēt"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:259
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:258
+#, fuzzy
+msgid "Find in document"
+msgstr "Atvērt HTML dokumentu"
+
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "Find..."
+msgstr "Meklēt"
+
+#: ../src/common/stockitem.cpp:156
 msgid "First"
 msgstr "Pirmais"
 
-#: ../src/common/prntbase.cpp:1548
+#: ../src/common/prntbase.cpp:1573
 msgid "First page"
 msgstr "Pirmā lapa"
 
@@ -3779,11 +3872,11 @@ msgstr "Pirmā lapa"
 msgid "Fixed"
 msgstr "Fiksēts fonts:"
 
-#: ../src/html/helpwnd.cpp:1206
+#: ../src/html/helpwnd.cpp:1204
 msgid "Fixed font:"
 msgstr "Fiksēts fonts:"
 
-#: ../src/html/helpwnd.cpp:1269
+#: ../src/html/helpwnd.cpp:1267
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Fiksēta izmēra.<br> <b>treknraksts</b> <i>kursīvs</i> "
 
@@ -3791,16 +3884,16 @@ msgstr "Fiksēta izmēra.<br> <b>treknraksts</b> <i>kursīvs</i> "
 msgid "Floating"
 msgstr "Peldošs"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "Floppy"
 msgstr "Diskete"
 
-#: ../src/common/paper.cpp:111
+#: ../src/common/paper.cpp:108
 msgid "Folio, 8 1/2 x 13 in"
 msgstr "Folio, 8 1/2 x 13 in"
 
-#: ../src/richtext/richtextformatdlg.cpp:344 ../src/osx/carbon/fontdlg.cpp:287
-#: ../src/common/stockitem.cpp:194
+#: ../src/osx/carbon/fontdlg.cpp:284 ../src/common/stockitem.cpp:191
+#: ../src/richtext/richtextformatdlg.cpp:337
 msgid "Font"
 msgstr "Fonts"
 
@@ -3808,7 +3901,24 @@ msgstr "Fonts"
 msgid "Font &weight:"
 msgstr "Fonta &svars:"
 
-#: ../src/html/helpwnd.cpp:1207
+#: ../src/osx/fontutil.cpp:89
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
+"\"."
+msgstr ""
+
+#: ../src/msw/font.cpp:1126
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Failu nevar ielādēt."
+
+#: ../src/osx/fontutil.cpp:81
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "Fails '%s' neeksistē."
+
+#: ../src/html/helpwnd.cpp:1205
 msgid "Font size:"
 msgstr "Fonta izmērs:"
 
@@ -3816,75 +3926,75 @@ msgstr "Fonta izmērs:"
 msgid "Font st&yle:"
 msgstr "Fonta st&ils:"
 
-#: ../src/osx/carbon/fontdlg.cpp:329
+#: ../src/osx/carbon/fontdlg.cpp:326
 msgid "Font:"
 msgstr "Fonts:"
 
-#: ../src/dfb/fontmgr.cpp:198
+#: ../src/dfb/fontmgr.cpp:195
 #, c-format
 msgid "Fonts index file %s disappeared while loading fonts."
 msgstr "Fontu saraksta fails %s ir pazudis fontu ielādes laikā."
 
-#: ../src/unix/utilsunx.cpp:645
+#: ../src/unix/utilsunx.cpp:647
 msgid "Fork failed"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "Forward"
 msgstr "Pārsūtīt"
 
-#: ../src/common/xtixml.cpp:235
+#: ../src/common/xtixml.cpp:231
 msgid "Forward hrefs are not supported"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:875
+#: ../src/html/helpwnd.cpp:873
 #, c-format
 msgid "Found %i matches"
 msgstr "Atrastas %i atbilstības"
 
-#: ../src/generic/prntdlgg.cpp:238
+#: ../src/generic/prntdlgg.cpp:231
 msgid "From:"
 msgstr "Sūtītājs:"
 
-#: ../src/propgrid/advprops.cpp:1604
+#: ../src/propgrid/advprops.cpp:1510
 msgid "Fuchsia"
 msgstr ""
 
-#: ../src/common/imaggif.cpp:138
+#: ../src/common/imaggif.cpp:135
 msgid "GIF: data stream seems to be truncated."
 msgstr "GIF: datu plūsma šķiet aprauta."
 
-#: ../src/common/imaggif.cpp:128
+#: ../src/common/imaggif.cpp:125
 msgid "GIF: error in GIF image format."
 msgstr "GIF: kļūda GIF attēla formātā."
 
-#: ../src/common/imaggif.cpp:133
+#: ../src/common/imaggif.cpp:130
 msgid "GIF: not enough memory."
 msgstr "GIF: nepietiek atmiņas."
 
-#: ../src/gtk/window.cpp:4631
+#: ../src/gtk/window.cpp:5635
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
 msgstr ""
 
-#: ../src/univ/themes/gtk.cpp:525
+#: ../src/univ/themes/gtk.cpp:522
 msgid "GTK+ theme"
 msgstr "GTK+ tēma"
 
-#: ../src/common/preferencescmn.cpp:40
+#: ../src/common/preferencescmn.cpp:37
 msgid "General"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:258
+#: ../src/common/prntbase.cpp:253
 msgid "Generic PostScript"
 msgstr "Klasiskais PostScript"
 
-#: ../src/common/paper.cpp:135
+#: ../src/common/paper.cpp:132
 msgid "German Legal Fanfold, 8 1/2 x 13 in"
 msgstr "German Legal Fanfold, 8 1/2 x 13 in"
 
-#: ../src/common/paper.cpp:134
+#: ../src/common/paper.cpp:131
 msgid "German Std Fanfold, 8 1/2 x 12 in"
 msgstr "German Std Fanfold, 8 1/2 x 12 in"
 
@@ -3900,49 +4010,49 @@ msgstr ""
 msgid "GetPropertyCollection called w/o valid collection getter"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:658
 msgid "Go back"
 msgstr "Iet atpakaļ"
 
-#: ../src/html/helpwnd.cpp:661
+#: ../src/html/helpwnd.cpp:659
 msgid "Go forward"
 msgstr "Iet uz priekšu"
 
-#: ../src/html/helpwnd.cpp:663
+#: ../src/html/helpwnd.cpp:661
 msgid "Go one level up in document hierarchy"
 msgstr "Iet vienu līmeni augstāk dokumenta hierarhijā"
 
-#: ../src/generic/filedlgg.cpp:208 ../src/generic/dirdlgg.cpp:116
+#: ../src/generic/filedlgg.cpp:205 ../src/generic/dirdlgg.cpp:113
 msgid "Go to home directory"
 msgstr "Iet uz mājas direktoriju"
 
-#: ../src/generic/filedlgg.cpp:205
+#: ../src/generic/filedlgg.cpp:202
 msgid "Go to parent directory"
 msgstr "Iet uz vecāka direktoriju"
 
-#: ../src/generic/aboutdlgg.cpp:76
+#: ../src/generic/aboutdlgg.cpp:73
 msgid "Graphics art by "
 msgstr "Grafiskais noformējums -"
 
-#: ../src/propgrid/advprops.cpp:1599
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Gray"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:883
+#: ../src/propgrid/advprops.cpp:784
 msgid "GrayText"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:154
+#: ../src/common/fmapbase.cpp:151
 msgid "Greek (ISO-8859-7)"
 msgstr "Grieķu (ISO-8859-7)"
 
-#: ../src/propgrid/advprops.cpp:1600
+#: ../src/propgrid/advprops.cpp:1506
 #, fuzzy
 msgid "Green"
 msgstr "Grieķu (MacGreek)"
 
-#: ../src/generic/colrdlgg.cpp:342
+#: ../src/generic/colrdlgg.cpp:362
 #, fuzzy
 msgid "Green:"
 msgstr "Grieķu (MacGreek)"
@@ -3951,109 +4061,109 @@ msgstr "Grieķu (MacGreek)"
 msgid "Groove"
 msgstr "Kaifīgie"
 
-#: ../src/common/zstream.cpp:158 ../src/common/zstream.cpp:318
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
 msgid "Gzip not supported by this version of zlib"
 msgstr "Šī zlib versija neuztur gzip"
 
-#: ../src/html/helpwnd.cpp:1549
+#: ../src/html/helpwnd.cpp:1547
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "HTML Help Project (*.hhp)|*.hhp|"
 
-#: ../src/html/htmlwin.cpp:681
+#: ../src/html/htmlwin.cpp:691
 #, c-format
 msgid "HTML anchor %s does not exist."
 msgstr "HTML enkurs %s nepastāv."
 
-#: ../src/html/helpwnd.cpp:1547
+#: ../src/html/helpwnd.cpp:1545
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "HTML faili (*.html;*.htm)|*.html;*.htm|"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1759
+#: ../src/propgrid/advprops.cpp:1660
 msgid "Hand"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "Harddisk"
 msgstr "Cietais disks"
 
-#: ../src/common/fmapbase.cpp:155
+#: ../src/common/fmapbase.cpp:152
 msgid "Hebrew (ISO-8859-8)"
 msgstr "Ebreju (ISO-8859-8)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:280 ../src/osx/button_osx.cpp:39
-#: ../src/common/stockitem.cpp:163 ../src/common/accelcmn.cpp:80
-#: ../src/html/helpdlg.cpp:66 ../src/html/helpfrm.cpp:111
+#: ../include/wx/msgdlg.h:282 ../src/osx/button_osx.cpp:39
+#: ../src/common/stockitem.cpp:160 ../src/common/accelcmn.cpp:77
+#: ../src/html/helpfrm.cpp:108 ../src/html/helpdlg.cpp:63
 msgid "Help"
 msgstr "Palīdzība"
 
-#: ../src/html/helpwnd.cpp:1200
+#: ../src/html/helpwnd.cpp:1198
 msgid "Help Browser Options"
 msgstr "Palīdzības pārlūka iestatījumi"
 
-#: ../src/generic/helpext.cpp:454 ../src/generic/helpext.cpp:455
+#: ../src/generic/helpext.cpp:452 ../src/generic/helpext.cpp:453
 msgid "Help Index"
 msgstr "Palīdzības saturs"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1529
 msgid "Help Printing"
 msgstr "Palīdzība par drukāšanu"
 
-#: ../src/html/helpwnd.cpp:801
+#: ../src/html/helpwnd.cpp:799
 msgid "Help Topics"
 msgstr "Palīdzības temati"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1546
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Palīdzības grāmatas (*.htb)|*.htb|Palīdzības grāmatas (*.zip)|*.zip|"
 
-#: ../src/generic/helpext.cpp:267
+#: ../src/generic/helpext.cpp:265
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "Palīdzības mape \"%s\" nav atrasta."
 
-#: ../src/generic/helpext.cpp:275
+#: ../src/generic/helpext.cpp:273
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "Palīdzības fails \"%s\" nav atrasts."
 
-#: ../src/html/helpctrl.cpp:63
+#: ../src/html/helpctrl.cpp:59
 #, c-format
 msgid "Help: %s"
 msgstr "Palīdzība: %s"
 
-#: ../src/osx/menu_osx.cpp:577
+#: ../src/osx/menu_osx.cpp:469
 #, c-format
 msgid "Hide %s"
 msgstr "Slēpt %s"
 
-#: ../src/osx/menu_osx.cpp:579
+#: ../src/osx/menu_osx.cpp:471
 msgid "Hide Others"
 msgstr "Slēpt citus"
 
-#: ../src/generic/infobar.cpp:84
+#: ../src/generic/infobar.cpp:81
 msgid "Hide this notification message."
 msgstr "Slēpt šo paziņojumu."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:884
+#: ../src/propgrid/advprops.cpp:785
 #, fuzzy
 msgid "Highlight"
 msgstr "viegls"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:885
+#: ../src/propgrid/advprops.cpp:786
 #, fuzzy
 msgid "HighlightText"
 msgstr "Izlīdzināt tekstu pa labi."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:164 ../src/common/accelcmn.cpp:65
+#: ../src/common/stockitem.cpp:161 ../src/common/accelcmn.cpp:62
 msgid "Home"
 msgstr "Home"
 
-#: ../src/generic/dirctrlg.cpp:524
+#: ../src/generic/dirctrlg.cpp:490
 msgid "Home directory"
 msgstr "Mājas mape"
 
@@ -4063,62 +4173,62 @@ msgid "How the object will float relative to the text."
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1760
+#: ../src/propgrid/advprops.cpp:1661
 msgid "I-Beam"
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1196
+#: ../src/common/imagbmp.cpp:1208
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: kļūda lasot DIB masku."
 
-#: ../src/common/imagbmp.cpp:1290 ../src/common/imagbmp.cpp:1390
-#: ../src/common/imagbmp.cpp:1405 ../src/common/imagbmp.cpp:1416
-#: ../src/common/imagbmp.cpp:1430 ../src/common/imagbmp.cpp:1478
-#: ../src/common/imagbmp.cpp:1493 ../src/common/imagbmp.cpp:1507
-#: ../src/common/imagbmp.cpp:1518
+#: ../src/common/imagbmp.cpp:1302 ../src/common/imagbmp.cpp:1402
+#: ../src/common/imagbmp.cpp:1417 ../src/common/imagbmp.cpp:1428
+#: ../src/common/imagbmp.cpp:1442 ../src/common/imagbmp.cpp:1490
+#: ../src/common/imagbmp.cpp:1505 ../src/common/imagbmp.cpp:1519
+#: ../src/common/imagbmp.cpp:1530
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: kļūda rakstot attēla failu!"
 
-#: ../src/common/imagbmp.cpp:1255
+#: ../src/common/imagbmp.cpp:1267
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: attēls ikonai ir pārāk augsts."
 
-#: ../src/common/imagbmp.cpp:1263
+#: ../src/common/imagbmp.cpp:1275
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: attēls ikonai ir pārāk plats."
 
-#: ../src/common/imagbmp.cpp:1603
+#: ../src/common/imagbmp.cpp:1615
 msgid "ICO: Invalid icon index."
 msgstr "ICO: nederīgs ikonas indekss."
 
-#: ../src/common/imagiff.cpp:758
+#: ../src/common/imagiff.cpp:755
 msgid "IFF: data stream seems to be truncated."
 msgstr "IFF: datu plūsma šķiet aprauta."
 
-#: ../src/common/imagiff.cpp:742
+#: ../src/common/imagiff.cpp:739
 msgid "IFF: error in IFF image format."
 msgstr "IFF: kļūda IFF attēla formātā."
 
-#: ../src/common/imagiff.cpp:745
+#: ../src/common/imagiff.cpp:742
 msgid "IFF: not enough memory."
 msgstr "IFF: nepietiek atmiņas."
 
-#: ../src/common/imagiff.cpp:748
+#: ../src/common/imagiff.cpp:745
 msgid "IFF: unknown error!!!"
 msgstr "IFF: nezināma kļūda!!!"
 
-#: ../src/common/fmapbase.cpp:197
+#: ../src/common/fmapbase.cpp:194
 msgid "ISO-2022-JP"
 msgstr "ISO-2022-JP"
 
-#: ../src/html/htmprint.cpp:282
+#: ../src/html/htmprint.cpp:294
 msgid ""
 "If possible, try changing the layout parameters to make the printout more "
 "narrow."
 msgstr ""
 "Ja iespējams, mēģiniet mainīt izkārtojumu, lai padarītu izdruku šaurāku."
 
-#: ../src/generic/dbgrptg.cpp:358
+#: ../src/generic/dbgrptg.cpp:362
 msgid ""
 "If you have any additional information pertaining to this bug\n"
 "report, please enter it here and it will be joined to it:"
@@ -4137,148 +4247,152 @@ msgstr ""
 "taču ņemiet vērā, ka tas kavēs uzlabošanu,tādēļ, ja iespējams,\n"
 "lūdzu, turpiniet kļūdas atskaites veidošanu.\n"
 
-#: ../src/msw/registry.cpp:1405
+#: ../src/common/zipstrm.cpp:1043
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1393
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Ignorēta vērtība \"%s\" atslēgai \"%s\"."
 
-#: ../src/common/xtistrm.cpp:295
+#: ../src/common/xtistrm.cpp:292
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr ""
 
-#: ../src/common/xti.cpp:513
+#: ../src/common/xti.cpp:510
 msgid "Illegal Parameter Count for ConstructObject Method"
 msgstr "Nederīgs parametru skaits metodei ConstructObject"
 
-#: ../src/common/xti.cpp:501
+#: ../src/common/xti.cpp:498
 msgid "Illegal Parameter Count for Create Method"
 msgstr "Nederīgs parametru skaits metodei Create"
 
-#: ../src/generic/dirctrlg.cpp:570 ../src/generic/filectrlg.cpp:756
+#: ../src/generic/dirctrlg.cpp:536 ../src/generic/filectrlg.cpp:752
 msgid "Illegal directory name."
 msgstr "Nederīgs mapes nosaukums."
 
-#: ../src/generic/filectrlg.cpp:1367
+#: ../src/generic/filectrlg.cpp:1356
 msgid "Illegal file specification."
 msgstr "Nederīga faila specifikācija."
 
-#: ../src/common/image.cpp:2269
+#: ../src/common/image.cpp:2363
 msgid "Image and mask have different sizes."
 msgstr "Attēla un maskas izmēri nesakrīt."
 
-#: ../src/common/image.cpp:2746
+#: ../src/common/image.cpp:2841
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "Attēla faila tips nav %d."
 
-#: ../src/common/image.cpp:2877
+#: ../src/common/image.cpp:2995
 #, c-format
 msgid "Image is not of type %s."
 msgstr "Attēla tips nav %s."
 
-#: ../src/msw/textctrl.cpp:488
+#: ../src/msw/textctrl.cpp:534
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:301
+#: ../src/unix/utilsunx.cpp:303
 msgid "Impossible to get child process input"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1028
+#: ../src/common/filefn.cpp:917
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Nav iespējams iegūt pieejas tiesības failam  '%s'"
 
-#: ../src/common/filefn.cpp:1042
+#: ../src/common/filefn.cpp:931
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Nav iespējams pārrakstīt failu '%s'"
 
-#: ../src/common/filefn.cpp:1097
+#: ../src/common/filefn.cpp:986
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Nav iespējams noteikt pieejas tiesības failam '%s'"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:886
+#: ../src/propgrid/advprops.cpp:787
 #, fuzzy
 msgid "InactiveBorder"
 msgstr "Mala"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:887
+#: ../src/propgrid/advprops.cpp:788
 msgid "InactiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:888
+#: ../src/propgrid/advprops.cpp:789
 msgid "InactiveCaptionText"
 msgstr ""
 
-#: ../src/common/gifdecod.cpp:792
+#: ../src/common/gifdecod.cpp:826
 #, c-format
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:635
+#: ../src/msw/ole/automtn.cpp:626
 msgid "Incorrect number of arguments."
 msgstr "Nepareizs argumentu skaits."
 
-#: ../src/common/stockitem.cpp:165
+#: ../src/common/stockitem.cpp:162
 msgid "Indent"
 msgstr "Atkāpe"
 
-#: ../src/richtext/richtextformatdlg.cpp:349
+#: ../src/richtext/richtextformatdlg.cpp:342
 msgid "Indents && Spacing"
 msgstr "Atkāpes un atstarpes"
 
-#: ../src/common/stockitem.cpp:166 ../src/html/helpwnd.cpp:515
+#: ../src/common/stockitem.cpp:163 ../src/html/helpwnd.cpp:513
 msgid "Index"
 msgstr "Indekss"
 
-#: ../src/common/fmapbase.cpp:159
+#: ../src/common/fmapbase.cpp:156
 msgid "Indian (ISO-8859-12)"
 msgstr "Indiešu (ISO-8859-12)"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "Info"
 msgstr "Info"
 
-#: ../src/common/init.cpp:287
+#: ../src/common/init.cpp:284
 msgid "Initialization failed in post init, aborting."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:54
+#: ../src/common/accelcmn.cpp:51
 #, fuzzy
 msgid "Ins"
 msgstr "Iespiests"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextsymboldlg.cpp:472 ../src/common/accelcmn.cpp:53
+#: ../src/common/accelcmn.cpp:50 ../src/richtext/richtextsymboldlg.cpp:469
 msgid "Insert"
 msgstr "Insert"
 
-#: ../src/richtext/richtextbuffer.cpp:8067
+#: ../src/richtext/richtextbuffer.cpp:8063
 #, fuzzy
 msgid "Insert Field"
 msgstr "Ievietot tekstu"
 
-#: ../src/richtext/richtextbuffer.cpp:7978
-#: ../src/richtext/richtextbuffer.cpp:8936
+#: ../src/richtext/richtextbuffer.cpp:7974
+#: ../src/richtext/richtextbuffer.cpp:8934
 msgid "Insert Image"
 msgstr "Ievietot attēlu"
 
-#: ../src/richtext/richtextbuffer.cpp:8025
+#: ../src/richtext/richtextbuffer.cpp:8021
 msgid "Insert Object"
 msgstr "Ievietot objektu"
 
-#: ../src/richtext/richtextctrl.cpp:1286 ../src/richtext/richtextctrl.cpp:1494
-#: ../src/richtext/richtextbuffer.cpp:7822
-#: ../src/richtext/richtextbuffer.cpp:7852
-#: ../src/richtext/richtextbuffer.cpp:7894
+#: ../src/richtext/richtextbuffer.cpp:7818
+#: ../src/richtext/richtextbuffer.cpp:7848
+#: ../src/richtext/richtextbuffer.cpp:7890
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
 msgid "Insert Text"
 msgstr "Ievietot tekstu"
 
@@ -4291,16 +4405,11 @@ msgstr "Ievietot lapas pārtraukumu pirms rindkopas."
 msgid "Inset"
 msgstr "Iespiests"
 
-#: ../src/gtk/app.cpp:425
-#, c-format
-msgid "Invalid GTK+ command line option, use \"%s --help\""
-msgstr "Nederīgs GTK+ komandrindas parametrs, izmantojiet \"%s --help\""
-
-#: ../src/common/imagtiff.cpp:311
+#: ../src/common/imagtiff.cpp:308
 msgid "Invalid TIFF image index."
 msgstr "Nederīgs TIFF attēla indekss."
 
-#: ../src/common/appcmn.cpp:273
+#: ../src/common/appcmn.cpp:294
 #, c-format
 msgid "Invalid display mode specification '%s'."
 msgstr "Nederīga ekrāna režīma specifikācija '%s'."
@@ -4310,257 +4419,261 @@ msgstr "Nederīga ekrāna režīma specifikācija '%s'."
 msgid "Invalid geometry specification '%s'"
 msgstr "Nederīga ģeometrijas specifikācija '%s'."
 
-#: ../src/unix/fswatcher_inotify.cpp:323
+#: ../src/unix/fswatcher_inotify.cpp:320
 #, c-format
 msgid "Invalid inotify event for \"%s\""
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:312
+#: ../src/unix/snglinst.cpp:309
 #, c-format
 msgid "Invalid lock file '%s'."
 msgstr "Nederīgs slēdzenes fails '%s'."
 
-#: ../src/common/translation.cpp:1125
+#: ../src/common/translation.cpp:1167
 msgid "Invalid message catalog."
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:405 ../src/common/xtistrm.cpp:420
+#: ../src/common/xtistrm.cpp:402 ../src/common/xtistrm.cpp:417
 msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
 msgstr "GetObjectClassInfo nodots nederīgs vai tukšs objekta ID"
 
-#: ../src/common/xtistrm.cpp:435
+#: ../src/common/xtistrm.cpp:432
 msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
 msgstr "HasObjectClassInfo nodots nederīgs vai tukšs objekta ID"
 
-#: ../src/common/regex.cpp:310
+#: ../src/common/regex.cpp:307
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Nederīga regulārā izteiksme '%s': %s"
 
-#: ../src/common/config.cpp:226
+#: ../src/common/config.cpp:222
 #, c-format
 msgid "Invalid value %ld for a boolean key \"%s\" in config file."
 msgstr "Konfigurācijas failā nederīga vērtība %ld Bula atslēgai \"%s\"."
 
-#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:351
-#: ../src/osx/carbon/fontdlg.cpp:361 ../src/common/stockitem.cpp:168
+#: ../src/osx/carbon/fontdlg.cpp:358 ../src/common/stockitem.cpp:165
+#: ../src/generic/fontdlgg.cpp:325 ../src/richtext/richtextfontpage.cpp:351
 msgid "Italic"
 msgstr "Kursīvs"
 
-#: ../src/common/paper.cpp:130
+#: ../src/common/paper.cpp:127
 msgid "Italy Envelope, 110 x 230 mm"
 msgstr "Itāļu aploksne, 110 x 230 mm"
 
-#: ../src/common/imagjpeg.cpp:270
+#: ../src/common/imagjpeg.cpp:257
 msgid "JPEG: Couldn't load - file is probably corrupted."
 msgstr "JPEG: nav atverams - iespējams, fails ir bojāts."
 
-#: ../src/common/imagjpeg.cpp:449
+#: ../src/common/imagjpeg.cpp:436
 msgid "JPEG: Couldn't save image."
 msgstr "JPEG: nav iespējams saglabāt attēlu."
 
-#: ../src/common/paper.cpp:163
+#: ../src/common/paper.cpp:160
 msgid "Japanese Double Postcard 200 x 148 mm"
 msgstr "Japāņu dubultā pastkate, 200 x 148 mm"
 
-#: ../src/common/paper.cpp:167
+#: ../src/common/paper.cpp:164
 msgid "Japanese Envelope Chou #3"
 msgstr "Japāņu aploksne Chou #3"
 
-#: ../src/common/paper.cpp:180
+#: ../src/common/paper.cpp:177
 msgid "Japanese Envelope Chou #3 Rotated"
 msgstr "Japāņu aploksne Chou #3 Rotated"
 
-#: ../src/common/paper.cpp:168
+#: ../src/common/paper.cpp:165
 msgid "Japanese Envelope Chou #4"
 msgstr "Japāņu aploksne Chou #4"
 
-#: ../src/common/paper.cpp:181
+#: ../src/common/paper.cpp:178
 msgid "Japanese Envelope Chou #4 Rotated"
 msgstr "Japāņu aploksne Chou #4 Rotated"
 
-#: ../src/common/paper.cpp:165
+#: ../src/common/paper.cpp:162
 msgid "Japanese Envelope Kaku #2"
 msgstr "Japāņu aploksne Kaku #2"
 
-#: ../src/common/paper.cpp:178
+#: ../src/common/paper.cpp:175
 msgid "Japanese Envelope Kaku #2 Rotated"
 msgstr "Japāņu aploksne Kaku #2 Rotated"
 
-#: ../src/common/paper.cpp:166
+#: ../src/common/paper.cpp:163
 msgid "Japanese Envelope Kaku #3"
 msgstr "Japāņu aploksne Kaku #3"
 
-#: ../src/common/paper.cpp:179
+#: ../src/common/paper.cpp:176
 msgid "Japanese Envelope Kaku #3 Rotated"
 msgstr "Japāņu aploksne Kaku #3 Rotated"
 
-#: ../src/common/paper.cpp:185
+#: ../src/common/paper.cpp:182
 msgid "Japanese Envelope You #4"
 msgstr "Japāņu aploksne You #4"
 
-#: ../src/common/paper.cpp:186
+#: ../src/common/paper.cpp:183
 msgid "Japanese Envelope You #4 Rotated"
 msgstr "Japāņu aploksne You #4 Rotated"
 
-#: ../src/common/paper.cpp:138
+#: ../src/common/paper.cpp:135
 msgid "Japanese Postcard 100 x 148 mm"
 msgstr "Japāņu pastkarte 100 x 148 mm"
 
-#: ../src/common/paper.cpp:175
+#: ../src/common/paper.cpp:172
 msgid "Japanese Postcard Rotated 148 x 100 mm"
 msgstr "Japāņu pastkate, pagriezta 148 x 100 mm"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "Jump to"
 msgstr "Pārlekt uz"
 
-#: ../src/common/stockitem.cpp:171
+#: ../src/common/stockitem.cpp:168
 msgid "Justified"
 msgstr "Izlīdzināts"
 
-#: ../src/richtext/richtextindentspage.cpp:155
-#: ../src/richtext/richtextindentspage.cpp:157
 #: ../src/richtext/richtextliststylepage.cpp:344
 #: ../src/richtext/richtextliststylepage.cpp:346
+#: ../src/richtext/richtextindentspage.cpp:155
+#: ../src/richtext/richtextindentspage.cpp:157
 msgid "Justify text left and right."
 msgstr "Izlidzināt tekstu pa kreisi un pa labi."
 
-#: ../src/common/fmapbase.cpp:163
+#: ../src/common/fmapbase.cpp:160
 msgid "KOI8-R"
 msgstr "KOI8-R"
 
-#: ../src/common/fmapbase.cpp:164
+#: ../src/common/fmapbase.cpp:161
 msgid "KOI8-U"
 msgstr "KOI8-U"
 
-#: ../src/common/accelcmn.cpp:265 ../src/common/accelcmn.cpp:347
+#: ../src/common/accelcmn.cpp:279 ../src/common/accelcmn.cpp:364
 msgid "KP_"
 msgstr "KP_"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 #, fuzzy
 msgid "KP_Add"
 msgstr "KP_ADD"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "KP_Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "KP_Decimal"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 #, fuzzy
 msgid "KP_Delete"
 msgstr "Dzēst"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "KP_Divide"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 #, fuzzy
 msgid "KP_Down"
 msgstr "Lejup"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 #, fuzzy
 msgid "KP_End"
 msgstr "KP_END"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 #, fuzzy
 msgid "KP_Enter"
 msgstr "Printeris"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "KP_Equal"
 msgstr ""
 
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
-#, fuzzy
-msgid "KP_Home"
-msgstr "Home"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
-#, fuzzy
-msgid "KP_Insert"
-msgstr "Insert"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
-#, fuzzy
-msgid "KP_Left"
-msgstr "Pa kreisi"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
-msgid "KP_Multiply"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:99
-#, fuzzy
-msgid "KP_Next"
-msgstr "Nākošais"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
-msgid "KP_PageDown"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
-msgid "KP_PageUp"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:98
-msgid "KP_Prior"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
-#, fuzzy
-msgid "KP_Right"
-msgstr "Pa labi"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
-msgid "KP_Separator"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
-msgid "KP_Space"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
-msgid "KP_Subtract"
+#: ../src/common/accelcmn.cpp:276 ../src/common/accelcmn.cpp:361
+msgid "KP_F"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
 #: ../src/common/accelcmn.cpp:89
 #, fuzzy
+msgid "KP_Home"
+msgstr "Home"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:100
+#, fuzzy
+msgid "KP_Insert"
+msgstr "Insert"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:90
+#, fuzzy
+msgid "KP_Left"
+msgstr "Pa kreisi"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:103
+msgid "KP_Multiply"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:97
+#, fuzzy
+msgid "KP_Next"
+msgstr "Nākošais"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:95
+msgid "KP_PageDown"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:94
+msgid "KP_PageUp"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:96
+msgid "KP_Prior"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:92
+#, fuzzy
+msgid "KP_Right"
+msgstr "Pa labi"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:105
+msgid "KP_Separator"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:86
+msgid "KP_Space"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:106
+msgid "KP_Subtract"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:87
+#, fuzzy
 msgid "KP_Tab"
 msgstr "KP_TAB"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 #, fuzzy
 msgid "KP_Up"
 msgstr "KP_UP"
@@ -4569,19 +4682,34 @@ msgstr "KP_UP"
 msgid "L&ine spacing:"
 msgstr "Rindu atstarpe:"
 
-#: ../src/generic/prntdlgg.cpp:613 ../src/generic/prntdlgg.cpp:868
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "saspiešanas kļūda"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "atspiešanas kļūda"
+
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:861
 msgid "Landscape"
 msgstr "Ainava"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "Last"
 msgstr "Pēdējā"
 
-#: ../src/common/prntbase.cpp:1572
+#: ../src/common/prntbase.cpp:1597
 msgid "Last page"
 msgstr "Pēdējā lapa"
 
-#: ../src/common/log.cpp:305
+#: ../src/common/log.cpp:324
 #, fuzzy, c-format
 msgid "Last repeated message (\"%s\", %u time) wasn't output"
 msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
@@ -4589,93 +4717,93 @@ msgstr[0] "Pēdējais atkārtotais paziņojums (\"%s\", %lu reize) netika izvad�
 msgstr[1] "Pēdējie atkārtotie paziņojumi (\"%s\", %lu reizes) netika izvadīti"
 msgstr[2] "Pēdējais atkārtotais paziņojums (\"%s\", %lu reize) netika izvadīts"
 
-#: ../src/common/paper.cpp:103
+#: ../src/common/paper.cpp:100
 msgid "Ledger, 17 x 11 in"
 msgstr "Ledger, 17 x 11 in"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6146
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:58 ../src/generic/datavgen.cpp:6951
+#: ../src/richtext/richtextsizepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:252
 #: ../src/richtext/richtextliststylepage.cpp:253
 #: ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
-#: ../src/richtext/richtextsizepage.cpp:249 ../src/common/accelcmn.cpp:61
 msgid "Left"
 msgstr "Pa kreisi"
 
-#: ../src/richtext/richtextindentspage.cpp:204
 #: ../src/richtext/richtextliststylepage.cpp:390
+#: ../src/richtext/richtextindentspage.cpp:204
 msgid "Left (&first line):"
 msgstr "Kreisā (&pirmā rinda):"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1761
+#: ../src/propgrid/advprops.cpp:1662
 msgid "Left Button"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:880
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Left margin (mm):"
 msgstr "Kreisā apmale (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:141
-#: ../src/richtext/richtextindentspage.cpp:143
 #: ../src/richtext/richtextliststylepage.cpp:330
 #: ../src/richtext/richtextliststylepage.cpp:332
+#: ../src/richtext/richtextindentspage.cpp:141
+#: ../src/richtext/richtextindentspage.cpp:143
 msgid "Left-align text."
 msgstr "Izlīdzināt pa kreisi."
 
-#: ../src/common/paper.cpp:144
+#: ../src/common/paper.cpp:141
 msgid "Legal Extra 9 1/2 x 15 in"
 msgstr "Legal Extra 9 1/2 x 15 in"
 
-#: ../src/common/paper.cpp:96
+#: ../src/common/paper.cpp:93
 msgid "Legal, 8 1/2 x 14 in"
 msgstr "Legal, 8 1/2 x 14 in"
 
-#: ../src/common/paper.cpp:143
+#: ../src/common/paper.cpp:140
 msgid "Letter Extra 9 1/2 x 12 in"
 msgstr "Letter Extra 9 1/2 x 12 in"
 
-#: ../src/common/paper.cpp:149
+#: ../src/common/paper.cpp:146
 msgid "Letter Extra Transverse 9.275 x 12 in"
 msgstr "Letter Extra Transverse 9.275 x 12 in"
 
-#: ../src/common/paper.cpp:152
+#: ../src/common/paper.cpp:149
 msgid "Letter Plus 8 1/2 x 12.69 in"
 msgstr "Letter Plus 8 1/2 x 12.69 in"
 
-#: ../src/common/paper.cpp:169
+#: ../src/common/paper.cpp:166
 msgid "Letter Rotated 11 x 8 1/2 in"
 msgstr "Letter Rotated 11 x 8 1/2 in"
 
-#: ../src/common/paper.cpp:101
+#: ../src/common/paper.cpp:98
 msgid "Letter Small, 8 1/2 x 11 in"
 msgstr "Letter Small, 8 1/2 x 11 in"
 
-#: ../src/common/paper.cpp:147
+#: ../src/common/paper.cpp:144
 msgid "Letter Transverse 8 1/2 x 11 in"
 msgstr "Letter Transverse 8 1/2 x 11 in"
 
-#: ../src/common/paper.cpp:95
+#: ../src/common/paper.cpp:92
 msgid "Letter, 8 1/2 x 11 in"
 msgstr "Letter, 8 1/2 x 11 in"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "License"
 msgstr "Licence"
 
-#: ../src/generic/fontdlgg.cpp:332
+#: ../src/generic/fontdlgg.cpp:328
 msgid "Light"
 msgstr "Gaišs"
 
-#: ../src/propgrid/advprops.cpp:1608
+#: ../src/propgrid/advprops.cpp:1514
 msgid "Lime"
 msgstr ""
 
-#: ../src/generic/helpext.cpp:294
+#: ../src/generic/helpext.cpp:292
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr ""
@@ -4684,15 +4812,15 @@ msgstr ""
 msgid "Line spacing:"
 msgstr "Rindu atstarpe:"
 
-#: ../src/html/chm.cpp:838
+#: ../src/html/chm.cpp:829
 msgid "Link contained '//', converted to absolute link."
 msgstr "Saite saturēja '//', pārvērsta par absolūto saiti.."
 
-#: ../src/richtext/richtextformatdlg.cpp:364
+#: ../src/richtext/richtextformatdlg.cpp:357
 msgid "List Style"
 msgstr "Saraksta stils"
 
-#: ../src/richtext/richtextstyles.cpp:1064
+#: ../src/richtext/richtextstyles.cpp:1061
 msgid "List styles"
 msgstr "Stilu saraksts"
 
@@ -4706,26 +4834,26 @@ msgstr "Parāda fontu izmērus punktos."
 msgid "Lists the available fonts."
 msgstr "Parāda pieejamo fontu sarakstu."
 
-#: ../src/common/fldlgcmn.cpp:340
+#: ../src/common/fldlgcmn.cpp:337
 #, c-format
 msgid "Load %s file"
 msgstr "Ielādēt %s failu"
 
-#: ../src/html/htmlwin.cpp:597
+#: ../src/html/htmlwin.cpp:600
 msgid "Loading : "
 msgstr "Lasa..."
 
-#: ../src/unix/snglinst.cpp:246
+#: ../src/unix/snglinst.cpp:243
 #, c-format
 msgid "Lock file '%s' has incorrect owner."
 msgstr "Slēdzenes failam '%s' ir nepareizs īpašnieks."
 
-#: ../src/unix/snglinst.cpp:251
+#: ../src/unix/snglinst.cpp:248
 #, c-format
 msgid "Lock file '%s' has incorrect permissions."
 msgstr "slēdzenes failam '%s' ir nepareizas pieejas tiesības."
 
-#: ../src/generic/logg.cpp:576
+#: ../src/generic/logg.cpp:573
 #, c-format
 msgid "Log saved to the file '%s'."
 msgstr "Žurnāls saglabāts failā '%s'."
@@ -4740,11 +4868,11 @@ msgstr "Mazie burti"
 msgid "Lower case roman numerals"
 msgstr "Romiešu cipari ar mazajiem burtiem"
 
-#: ../src/gtk/mdi.cpp:422 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk1/mdi.cpp:431 ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr ""
 
-#: ../src/msw/helpchm.cpp:56
+#: ../src/msw/helpchm.cpp:53
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -4752,189 +4880,189 @@ msgstr ""
 "MS HTML Help funkcijas nav pieejamas, jo MS HTML Help bibliotēka nav "
 "uzstādīta uz šīs mašīnas . Lūdzu, uzstādiet to."
 
-#: ../src/univ/themes/win32.cpp:3754
+#: ../src/univ/themes/win32.cpp:3751
 msgid "Ma&ximize"
 msgstr "Ma&ksimizēt"
 
-#: ../src/common/fmapbase.cpp:203
+#: ../src/common/fmapbase.cpp:200
 msgid "MacArabic"
 msgstr "Arābu (MacArabic)"
 
-#: ../src/common/fmapbase.cpp:222
+#: ../src/common/fmapbase.cpp:219
 msgid "MacArmenian"
 msgstr "Armēņu (MacArmenian)"
 
-#: ../src/common/fmapbase.cpp:211
+#: ../src/common/fmapbase.cpp:208
 msgid "MacBengali"
 msgstr "Bengāļu (MacBengali)"
 
-#: ../src/common/fmapbase.cpp:217
+#: ../src/common/fmapbase.cpp:214
 msgid "MacBurmese"
 msgstr "Birmas (MacBurmese)"
 
-#: ../src/common/fmapbase.cpp:236
+#: ../src/common/fmapbase.cpp:233
 msgid "MacCeltic"
 msgstr "Ķeltu (MacCeltic)"
 
-#: ../src/common/fmapbase.cpp:227
+#: ../src/common/fmapbase.cpp:224
 msgid "MacCentralEurRoman"
 msgstr "Centrāleiropas romāņu (MacCentralEurRoman)"
 
-#: ../src/common/fmapbase.cpp:223
+#: ../src/common/fmapbase.cpp:220
 msgid "MacChineseSimp"
 msgstr "Ķīnas vienkāršotais (MacChineseSimp)"
 
-#: ../src/common/fmapbase.cpp:201
+#: ../src/common/fmapbase.cpp:198
 msgid "MacChineseTrad"
 msgstr "Ķīnas tradicionālais (MacChineseTrad)"
 
-#: ../src/common/fmapbase.cpp:233
+#: ../src/common/fmapbase.cpp:230
 msgid "MacCroatian"
 msgstr "Horvātu (MacCroatian)"
 
-#: ../src/common/fmapbase.cpp:206
+#: ../src/common/fmapbase.cpp:203
 msgid "MacCyrillic"
 msgstr "Kirilica (MacCyrillic)"
 
-#: ../src/common/fmapbase.cpp:207
+#: ../src/common/fmapbase.cpp:204
 msgid "MacDevanagari"
 msgstr "Devanagari (MacDevanagari)"
 
-#: ../src/common/fmapbase.cpp:231
+#: ../src/common/fmapbase.cpp:228
 msgid "MacDingbats"
 msgstr "MacDingbats"
 
-#: ../src/common/fmapbase.cpp:226
+#: ../src/common/fmapbase.cpp:223
 msgid "MacEthiopic"
 msgstr "Etiopiešu (MacEthiopic)"
 
-#: ../src/common/fmapbase.cpp:229
+#: ../src/common/fmapbase.cpp:226
 msgid "MacExtArabic"
 msgstr "Arābu papl. (MacExtArabic)"
 
-#: ../src/common/fmapbase.cpp:237
+#: ../src/common/fmapbase.cpp:234
 msgid "MacGaelic"
 msgstr "Īru (MacGaelic)"
 
-#: ../src/common/fmapbase.cpp:221
+#: ../src/common/fmapbase.cpp:218
 msgid "MacGeorgian"
 msgstr "Gruzīņu (MacGeorgian)"
 
-#: ../src/common/fmapbase.cpp:205
+#: ../src/common/fmapbase.cpp:202
 msgid "MacGreek"
 msgstr "Grieķu (MacGreek)"
 
-#: ../src/common/fmapbase.cpp:209
+#: ../src/common/fmapbase.cpp:206
 msgid "MacGujarati"
 msgstr "Gudžaratu (MacGujarati)"
 
-#: ../src/common/fmapbase.cpp:208
+#: ../src/common/fmapbase.cpp:205
 msgid "MacGurmukhi"
 msgstr "Gurmuhi (MacGurmukhi)"
 
-#: ../src/common/fmapbase.cpp:204
+#: ../src/common/fmapbase.cpp:201
 msgid "MacHebrew"
 msgstr "Ebreju (MacHebrew)"
 
-#: ../src/common/fmapbase.cpp:234
+#: ../src/common/fmapbase.cpp:231
 msgid "MacIcelandic"
 msgstr "Islandiešu (MacIcelandic)"
 
-#: ../src/common/fmapbase.cpp:200
+#: ../src/common/fmapbase.cpp:197
 msgid "MacJapanese"
 msgstr "Japāņu (MacJapanese)"
 
-#: ../src/common/fmapbase.cpp:214
+#: ../src/common/fmapbase.cpp:211
 msgid "MacKannada"
 msgstr "MacKannada"
 
-#: ../src/common/fmapbase.cpp:238
+#: ../src/common/fmapbase.cpp:235
 msgid "MacKeyboardGlyphs"
 msgstr "MacKeyboardGlyphs"
 
-#: ../src/common/fmapbase.cpp:218
+#: ../src/common/fmapbase.cpp:215
 msgid "MacKhmer"
 msgstr "Khmeru (MacKhmer)"
 
-#: ../src/common/fmapbase.cpp:202
+#: ../src/common/fmapbase.cpp:199
 msgid "MacKorean"
 msgstr "Korejiešu (MacKorean)"
 
-#: ../src/common/fmapbase.cpp:220
+#: ../src/common/fmapbase.cpp:217
 msgid "MacLaotian"
 msgstr "Laosiešu (MacLaotian)"
 
-#: ../src/common/fmapbase.cpp:215
+#: ../src/common/fmapbase.cpp:212
 msgid "MacMalayalam"
 msgstr "MacMalayalam"
 
-#: ../src/common/fmapbase.cpp:225
+#: ../src/common/fmapbase.cpp:222
 msgid "MacMongolian"
 msgstr "Mongoļu (MacMongolian)"
 
-#: ../src/common/fmapbase.cpp:210
+#: ../src/common/fmapbase.cpp:207
 msgid "MacOriya"
 msgstr "MacOriya"
 
-#: ../src/common/fmapbase.cpp:199
+#: ../src/common/fmapbase.cpp:196
 msgid "MacRoman"
 msgstr "Romāņu (MacRoman)"
 
-#: ../src/common/fmapbase.cpp:235
+#: ../src/common/fmapbase.cpp:232
 msgid "MacRomanian"
 msgstr "Rumāņu (MacRomanian)"
 
-#: ../src/common/fmapbase.cpp:216
+#: ../src/common/fmapbase.cpp:213
 msgid "MacSinhalese"
 msgstr "MacSinhalese"
 
-#: ../src/common/fmapbase.cpp:230
+#: ../src/common/fmapbase.cpp:227
 msgid "MacSymbol"
 msgstr "Simbolu (MacSymbol)"
 
-#: ../src/common/fmapbase.cpp:212
+#: ../src/common/fmapbase.cpp:209
 msgid "MacTamil"
 msgstr "Tamilu (MacTamil)"
 
-#: ../src/common/fmapbase.cpp:213
+#: ../src/common/fmapbase.cpp:210
 msgid "MacTelugu"
 msgstr "Telugu (MacTelugu)"
 
-#: ../src/common/fmapbase.cpp:219
+#: ../src/common/fmapbase.cpp:216
 msgid "MacThai"
 msgstr "Taju (MacThai)"
 
-#: ../src/common/fmapbase.cpp:224
+#: ../src/common/fmapbase.cpp:221
 msgid "MacTibetan"
 msgstr "Tibetiešu (MacTibetan)"
 
-#: ../src/common/fmapbase.cpp:232
+#: ../src/common/fmapbase.cpp:229
 msgid "MacTurkish"
 msgstr "Turku (MacTurkish)"
 
-#: ../src/common/fmapbase.cpp:228
+#: ../src/common/fmapbase.cpp:225
 msgid "MacVietnamese"
 msgstr "Vjetnamiešu (MacVietnamese)"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1762
+#: ../src/propgrid/advprops.cpp:1663
 msgid "Magnifier"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:2143
+#: ../src/propgrid/advprops.cpp:2050
 msgid "Make a selection:"
 msgstr "Veidot izvēli:"
 
-#: ../src/richtext/richtextformatdlg.cpp:374
+#: ../src/richtext/richtextformatdlg.cpp:367
 #: ../src/richtext/richtextmarginspage.cpp:171
 msgid "Margins"
 msgstr "Apmales"
 
-#: ../src/propgrid/advprops.cpp:1595
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Maroon"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:147
+#: ../src/generic/fdrepdlg.cpp:144
 msgid "Match case"
 msgstr "Reģistrjutīgs"
 
@@ -4946,40 +5074,40 @@ msgstr "Maksimālais augstums:"
 msgid "Max width:"
 msgstr "Maksimālais platums:"
 
-#: ../src/unix/mediactrl.cpp:947
+#: ../src/unix/mediactrl.cpp:972
 #, c-format
 msgid "Media playback error: %s"
 msgstr ""
 
-#: ../src/common/fs_mem.cpp:175
+#: ../src/common/fs_mem.cpp:170
 #, c-format
 msgid "Memory VFS already contains file '%s'!"
 msgstr "Atmiņas VFS jau ir fails '%s'!"
 
 #. TRANSLATORS: Name of keyboard key
 #. TRANSLATORS: Keyword of system colour
-#: ../src/common/accelcmn.cpp:73 ../src/propgrid/advprops.cpp:889
+#: ../src/common/accelcmn.cpp:70 ../src/propgrid/advprops.cpp:790
 msgid "Menu"
 msgstr "Izvēlne"
 
-#: ../src/common/msgout.cpp:124
+#: ../src/common/msgout.cpp:121
 msgid "Message"
 msgstr "Vēstule"
 
-#: ../src/univ/themes/metal.cpp:168
+#: ../src/univ/themes/metal.cpp:165
 msgid "Metal theme"
 msgstr "Metāla tēma"
 
-#: ../src/msw/ole/automtn.cpp:652
+#: ../src/msw/ole/automtn.cpp:643
 msgid "Method or property not found."
 msgstr "Metode vai īpašība nav atrasta."
 
-#: ../src/univ/themes/win32.cpp:3752
+#: ../src/univ/themes/win32.cpp:3749
 msgid "Mi&nimize"
 msgstr "Mi&nimizēt"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1763
+#: ../src/propgrid/advprops.cpp:1664
 msgid "Middle Button"
 msgstr ""
 
@@ -4991,36 +5119,41 @@ msgstr "Min. augstums:"
 msgid "Min width:"
 msgstr "Min. platums"
 
-#: ../src/msw/ole/automtn.cpp:668
+#: ../src/osx/cocoa/menu.mm:281
+#, fuzzy
+msgid "Minimize"
+msgstr "Mi&nimizēt"
+
+#: ../src/msw/ole/automtn.cpp:659
 msgid "Missing a required parameter."
 msgstr "Iztrūkst nepieciešamais paramatrs."
 
-#: ../src/generic/fontdlgg.cpp:324
+#: ../src/generic/fontdlgg.cpp:320
 msgid "Modern"
 msgstr "Moderns"
 
-#: ../src/generic/filectrlg.cpp:427
+#: ../src/generic/filectrlg.cpp:423
 msgid "Modified"
 msgstr "Izmainīts"
 
-#: ../src/common/module.cpp:133
+#: ../src/common/module.cpp:130
 #, c-format
 msgid "Module \"%s\" initialization failed"
 msgstr "Neizdevās inicializēt moduli \"%s\""
 
-#: ../src/common/paper.cpp:131
+#: ../src/common/paper.cpp:128
 msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
 msgstr "Monarch aploksne, 3 7/8 x 7 1/2 in"
 
-#: ../src/msw/fswatcher.cpp:143
+#: ../src/msw/fswatcher.cpp:140
 msgid "Monitoring individual files for changes is not supported currently."
 msgstr "Sekošana izmaiņām atsevišķos failos pagaidām netiek uzturēta."
 
-#: ../src/generic/editlbox.cpp:172
+#: ../src/generic/editlbox.cpp:160
 msgid "Move down"
 msgstr "Uz leju"
 
-#: ../src/generic/editlbox.cpp:171
+#: ../src/generic/editlbox.cpp:155
 msgid "Move up"
 msgstr "Uz augšu"
 
@@ -5034,97 +5167,102 @@ msgstr "Pārvieto objektu uz nākošo rindkopu."
 msgid "Moves the object to the previous paragraph."
 msgstr "Pārvieto objektu uz iepriekšējo rindkopu."
 
-#: ../src/richtext/richtextbuffer.cpp:9966
+#: ../src/richtext/richtextbuffer.cpp:9963
 msgid "Multiple Cell Properties"
 msgstr "Vairāku šūnu īpašības"
 
-#: ../src/generic/filectrlg.cpp:424
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:82
+msgid "Multiply"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:420
 msgid "Name"
 msgstr "Nosaukums"
 
-#: ../src/propgrid/advprops.cpp:1596
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Navy"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "Network"
 msgstr "Tīkls"
 
-#: ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173
 msgid "New"
 msgstr "Jauns"
 
-#: ../src/richtext/richtextstyledlg.cpp:243
+#: ../src/richtext/richtextstyledlg.cpp:239
 msgid "New &Box Style..."
 msgstr "Jauns &rāmja stils..."
 
-#: ../src/richtext/richtextstyledlg.cpp:225
+#: ../src/richtext/richtextstyledlg.cpp:221
 msgid "New &Character Style..."
 msgstr "Jauns rakstzīmju stils..."
 
-#: ../src/richtext/richtextstyledlg.cpp:237
+#: ../src/richtext/richtextstyledlg.cpp:233
 msgid "New &List Style..."
 msgstr "Jaunas saraksta stils..."
 
-#: ../src/richtext/richtextstyledlg.cpp:231
+#: ../src/richtext/richtextstyledlg.cpp:227
 msgid "New &Paragraph Style..."
 msgstr "Jauns rindko&pas stils..."
 
-#: ../src/richtext/richtextstyledlg.cpp:606
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:654
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:820
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:893
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:934
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:602
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:650
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:816
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:889
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:930
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "New Style"
 msgstr "Jauns stils"
 
-#: ../src/generic/editlbox.cpp:169
+#: ../src/generic/editlbox.cpp:139
 msgid "New item"
 msgstr "Jauna vienība"
 
-#: ../src/generic/dirdlgg.cpp:297 ../src/generic/dirdlgg.cpp:307
-#: ../src/generic/filectrlg.cpp:618 ../src/generic/filectrlg.cpp:627
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+#: ../src/generic/dirdlgg.cpp:294 ../src/generic/dirdlgg.cpp:304
 msgid "NewName"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:1567 ../src/html/helpwnd.cpp:665
+#: ../src/common/prntbase.cpp:1592 ../src/html/helpwnd.cpp:663
 msgid "Next page"
 msgstr "Nākamā lapa"
 
-#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:177
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:174
 #: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Nē"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1764
+#: ../src/propgrid/advprops.cpp:1665
 msgid "No Entry"
 msgstr ""
 
-#: ../src/generic/animateg.cpp:150
+#: ../src/generic/animateg.cpp:133
 #, c-format
 msgid "No animation handler for type %ld defined."
 msgstr ""
 
-#: ../src/dfb/bitmap.cpp:642 ../src/dfb/bitmap.cpp:676
+#: ../src/dfb/bitmap.cpp:639 ../src/dfb/bitmap.cpp:673
 #, c-format
 msgid "No bitmap handler for type %d defined."
 msgstr ""
 
-#: ../src/common/utilscmn.cpp:1077
+#: ../src/common/utilscmn.cpp:1095
 msgid "No default application configured for HTML files."
 msgstr "Noklusētā aplikācija HTML failu attēlošanai nav iestatīta."
 
-#: ../src/generic/helpext.cpp:445
+#: ../src/generic/helpext.cpp:443
 msgid "No entries found."
 msgstr "Nav atrasts neviens ieraksts."
 
-#: ../src/common/fontmap.cpp:421
+#: ../src/common/fontmap.cpp:418
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found,\n"
@@ -5136,7 +5274,7 @@ msgstr ""
 "taču ir pieejams alternatīvam kodējumam '%s'.\n"
 "Vai vēlaties izmantot šo kodējumu (citādi būs jāizvēlas cits)?"
 
-#: ../src/common/fontmap.cpp:426
+#: ../src/common/fontmap.cpp:423
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found.\n"
@@ -5147,206 +5285,206 @@ msgstr ""
 "Vai vēlaties izvēlēties citu fontu šim kodējumam\n"
 "(citādi teksts šajā kodējumā tiks attēlots nekorekti)?"
 
-#: ../src/generic/animateg.cpp:142
+#: ../src/generic/animateg.cpp:125
 msgid "No handler found for animation type."
 msgstr ""
 
-#: ../src/common/image.cpp:2728
+#: ../src/common/image.cpp:2823
 msgid "No handler found for image type."
 msgstr ""
 
-#: ../src/common/image.cpp:2736 ../src/common/image.cpp:2848
-#: ../src/common/image.cpp:2901
+#: ../src/common/image.cpp:2831 ../src/common/image.cpp:2954
+#: ../src/common/image.cpp:3020
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr ""
 
-#: ../src/common/image.cpp:2871 ../src/common/image.cpp:2915
+#: ../src/common/image.cpp:2986 ../src/common/image.cpp:3034
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:858
+#: ../src/html/helpwnd.cpp:856
 msgid "No matching page found yet"
 msgstr "Pagaidām netika atrasta atbilstoša lapa"
 
-#: ../src/unix/sound.cpp:81
+#: ../src/unix/sound.cpp:78
 msgid "No sound"
 msgstr "Nav skaņas"
 
-#: ../src/common/image.cpp:2277 ../src/common/image.cpp:2318
+#: ../src/common/image.cpp:2371 ../src/common/image.cpp:2412
 msgid "No unused colour in image being masked."
 msgstr ""
 
-#: ../src/common/image.cpp:3374
-msgid "No unused colour in image."
-msgstr "Attēls nesatur neizmantotas krāsas."
-
-#: ../src/generic/helpext.cpp:302
+#: ../src/generic/helpext.cpp:300
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr ""
 
-#: ../src/richtext/richtextborderspage.cpp:610
 #: ../src/richtext/richtextsizepage.cpp:248
 #: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:610
 msgid "None"
 msgstr "Nekas"
 
-#: ../src/common/fmapbase.cpp:157
+#: ../src/common/fmapbase.cpp:154
 msgid "Nordic (ISO-8859-10)"
 msgstr "Ziemeļvalstu (ISO-8859-10)"
 
-#: ../src/generic/fontdlgg.cpp:328 ../src/generic/fontdlgg.cpp:331
+#: ../src/generic/fontdlgg.cpp:324 ../src/generic/fontdlgg.cpp:327
 msgid "Normal"
 msgstr "Normāls"
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1261
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Normāls fonts<br>un  <u>pasvītrots</u>. "
 
-#: ../src/html/helpwnd.cpp:1205
+#: ../src/html/helpwnd.cpp:1203
 msgid "Normal font:"
 msgstr "Normāls fonts:"
 
-#: ../src/propgrid/props.cpp:1128
+#: ../src/propgrid/props.cpp:1115
 #, c-format
 msgid "Not %s"
 msgstr "Nav %s"
 
-#: ../include/wx/filename.h:573 ../include/wx/filename.h:578
-msgid "Not available"
-msgstr "Nav pieejams"
+#: ../src/common/secretstore.cpp:168
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/webrequest.cpp:605
+msgid "Not enough free disk space for download."
+msgstr ""
 
 #: ../src/richtext/richtextfontpage.cpp:358
 msgid "Not underlined"
 msgstr "Nav pasvītrots"
 
-#: ../src/common/paper.cpp:115
+#: ../src/common/paper.cpp:112
 msgid "Note, 8 1/2 x 11 in"
 msgstr "Note, 8 1/2 x 11 in"
 
-#: ../src/generic/notifmsgg.cpp:132
+#: ../src/generic/notifmsgg.cpp:129
 msgid "Notice"
 msgstr "Paziņojums"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "Num *"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "Num +"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "Num ,"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "Num -"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "Num ."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "Num /"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "Num ="
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "Num Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 #, fuzzy
 msgid "Num Delete"
 msgstr "Dzēst"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 #, fuzzy
 msgid "Num Down"
 msgstr "Lejup"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "Num End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "Num Enter"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 #, fuzzy
 msgid "Num Home"
 msgstr "Home"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 #, fuzzy
 msgid "Num Insert"
 msgstr "Insert"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num Lock"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "Num Page Down"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "Num Page Up"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 #, fuzzy
 msgid "Num Right"
 msgstr "Pa labi"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "Num Space"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "Num Tab"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "Num Up"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "Num left"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num_lock"
 msgstr ""
 
@@ -5355,13 +5493,13 @@ msgstr ""
 msgid "Numbered outline"
 msgstr "Numurētas aprises"
 
-#: ../include/wx/msgdlg.h:278 ../src/richtext/richtextstyledlg.cpp:297
-#: ../src/common/stockitem.cpp:178 ../src/msw/msgdlg.cpp:454
-#: ../src/msw/msgdlg.cpp:747 ../src/gtk1/fontdlg.cpp:138
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:175
+#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/msgdlg.cpp:741 ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "Labi"
 
-#: ../src/msw/ole/automtn.cpp:692
+#: ../src/msw/ole/automtn.cpp:683
 #, c-format
 msgid "OLE Automation error in %s: %s"
 msgstr "OLE automatizācijas kļūda %s: %s"
@@ -5370,15 +5508,15 @@ msgstr "OLE automatizācijas kļūda %s: %s"
 msgid "Object Properties"
 msgstr "Objekta īpašības"
 
-#: ../src/msw/ole/automtn.cpp:660
+#: ../src/msw/ole/automtn.cpp:651
 msgid "Object implementation does not support named arguments."
 msgstr ""
 
-#: ../src/common/xtixml.cpp:264
+#: ../src/common/xtixml.cpp:260
 msgid "Objects must have an id attribute"
 msgstr "Objektiem ir jābūt id atribūtiem"
 
-#: ../src/propgrid/advprops.cpp:1601
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Olive"
 msgstr ""
 
@@ -5386,64 +5524,69 @@ msgstr ""
 msgid "Opaci&ty:"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:354
+#: ../src/generic/colrdlgg.cpp:374
 msgid "Opacity:"
 msgstr ""
 
-#: ../src/common/docview.cpp:1773 ../src/common/docview.cpp:1815
+#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
 msgid "Open File"
 msgstr "Atvērt failu"
 
-#: ../src/html/helpwnd.cpp:671 ../src/html/helpwnd.cpp:1554
+#: ../src/html/helpwnd.cpp:669 ../src/html/helpwnd.cpp:1552
 msgid "Open HTML document"
 msgstr "Atvērt HTML dokumentu"
 
-#: ../src/generic/dbgrptg.cpp:163
+#: ../src/common/stockitem.cpp:265
+#, fuzzy
+msgid "Open an existing document"
+msgstr "Atvērt HTML dokumentu"
+
+#: ../src/generic/dbgrptg.cpp:160
 #, c-format
 msgid "Open file \"%s\""
 msgstr "Atvērt failu \"%s\""
 
-#: ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176
 msgid "Open..."
 msgstr "Atvērt..."
 
-#: ../src/unix/glx11.cpp:506 ../src/msw/glcanvas.cpp:592
+#: ../src/msw/glcanvas.cpp:607 ../src/unix/glx11.cpp:513
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr ""
 
-#: ../src/generic/dirctrlg.cpp:599 ../src/generic/dirdlgg.cpp:323
-#: ../src/generic/filectrlg.cpp:642 ../src/generic/filectrlg.cpp:786
+#: ../src/generic/dirctrlg.cpp:565 ../src/generic/filectrlg.cpp:638
+#: ../src/generic/filectrlg.cpp:782 ../src/generic/dirdlgg.cpp:320
 msgid "Operation not permitted."
 msgstr "Darbība nav atļauta."
 
-#: ../src/common/cmdline.cpp:900
+#: ../src/common/cmdline.cpp:896
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1064
+#: ../src/common/cmdline.cpp:1060
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "Iestatījumam '%s' ir nepieciešama vērtība."
 
-#: ../src/common/cmdline.cpp:1147
+#: ../src/common/cmdline.cpp:1143
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Iestatījums '%s': '%s' nav pārvēršams par datumu."
 
-#: ../src/generic/prntdlgg.cpp:618
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Iestatījumi"
 
-#: ../src/propgrid/advprops.cpp:1606
+#: ../src/propgrid/advprops.cpp:1512
 msgid "Orange"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:615 ../src/generic/prntdlgg.cpp:869
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:862
 msgid "Orientation"
 msgstr "Orientācija"
 
-#: ../src/common/windowid.cpp:242
+#: ../src/common/windowid.cpp:237
 msgid "Out of window IDs.  Recommend shutting down application."
 msgstr "Logu ID ir beigušies. Ieteicams aizvērt aplikāciju."
 
@@ -5456,148 +5599,148 @@ msgstr "Aprises"
 msgid "Outset"
 msgstr "Izspiests"
 
-#: ../src/msw/ole/automtn.cpp:656
+#: ../src/msw/ole/automtn.cpp:647
 msgid "Overflow while coercing argument values."
 msgstr ""
 
-#: ../src/common/imagpcx.cpp:457 ../src/common/imagpcx.cpp:480
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:479
 msgid "PCX: couldn't allocate memory"
 msgstr "PCX: nevar piešķirt atmiņu."
 
-#: ../src/common/imagpcx.cpp:456
+#: ../src/common/imagpcx.cpp:455
 msgid "PCX: image format unsupported"
 msgstr "PCX: neatbalstīts attēla formāts"
 
-#: ../src/common/imagpcx.cpp:479
+#: ../src/common/imagpcx.cpp:478
 msgid "PCX: invalid image"
 msgstr "PCX: nederīgs attēls"
 
-#: ../src/common/imagpcx.cpp:442
+#: ../src/common/imagpcx.cpp:441
 msgid "PCX: this is not a PCX file."
 msgstr "PCX: tas nav  PCX fails."
 
-#: ../src/common/imagpcx.cpp:459 ../src/common/imagpcx.cpp:481
+#: ../src/common/imagpcx.cpp:458 ../src/common/imagpcx.cpp:480
 msgid "PCX: unknown error !!!"
 msgstr "PCX: nezināma kļūda!!!"
 
-#: ../src/common/imagpcx.cpp:458
+#: ../src/common/imagpcx.cpp:457
 msgid "PCX: version number too low"
 msgstr "PCX: pārāk zems versijas numurs"
 
-#: ../src/common/imagpnm.cpp:91
+#: ../src/common/imagpnm.cpp:89
 msgid "PNM: Couldn't allocate memory."
 msgstr "PNM: nevar piešķirt atmiņu."
 
-#: ../src/common/imagpnm.cpp:73
+#: ../src/common/imagpnm.cpp:71
 msgid "PNM: File format is not recognized."
 msgstr "PNM: faila formāts nav atpazīts."
 
-#: ../src/common/imagpnm.cpp:112 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
 #: ../src/common/imagpnm.cpp:156
 msgid "PNM: File seems truncated."
 msgstr "PNM: fails šķiet aprauts."
 
-#: ../src/common/paper.cpp:187
+#: ../src/common/paper.cpp:184
 msgid "PRC 16K 146 x 215 mm"
 msgstr "ĶTR 16K 146 x 215 mm"
 
-#: ../src/common/paper.cpp:200
+#: ../src/common/paper.cpp:197
 msgid "PRC 16K Rotated"
 msgstr "ĶTR 16K pagriezta"
 
-#: ../src/common/paper.cpp:188
+#: ../src/common/paper.cpp:185
 msgid "PRC 32K 97 x 151 mm"
 msgstr "ĶTR 32K 97 x 151 mm"
 
-#: ../src/common/paper.cpp:201
+#: ../src/common/paper.cpp:198
 msgid "PRC 32K Rotated"
 msgstr "ĶTR 32K pagriezta"
 
-#: ../src/common/paper.cpp:189
+#: ../src/common/paper.cpp:186
 msgid "PRC 32K(Big) 97 x 151 mm"
 msgstr "ĶTR 32K(Big) 97 x 151 mm"
 
-#: ../src/common/paper.cpp:202
+#: ../src/common/paper.cpp:199
 msgid "PRC 32K(Big) Rotated"
 msgstr "ĶTR 32K(Big) pagriezta"
 
-#: ../src/common/paper.cpp:190
+#: ../src/common/paper.cpp:187
 msgid "PRC Envelope #1 102 x 165 mm"
 msgstr "ĶTR aploksne #1 102 x 165 mm"
 
-#: ../src/common/paper.cpp:203
+#: ../src/common/paper.cpp:200
 msgid "PRC Envelope #1 Rotated 165 x 102 mm"
 msgstr "ĶTR aploksne #1 Rotated 165 x 102 mm"
 
-#: ../src/common/paper.cpp:199
+#: ../src/common/paper.cpp:196
 msgid "PRC Envelope #10 324 x 458 mm"
 msgstr "ĶTR aploksne #10 324 x 458 mm"
 
-#: ../src/common/paper.cpp:212
+#: ../src/common/paper.cpp:209
 msgid "PRC Envelope #10 Rotated 458 x 324 mm"
 msgstr "ĶTR aploksne #10 Rotated 458 x 324 mm"
 
-#: ../src/common/paper.cpp:191
+#: ../src/common/paper.cpp:188
 msgid "PRC Envelope #2 102 x 176 mm"
 msgstr "ĶTR aploksne #2 102 x 176 mm"
 
-#: ../src/common/paper.cpp:204
+#: ../src/common/paper.cpp:201
 msgid "PRC Envelope #2 Rotated 176 x 102 mm"
 msgstr "ĶTR aploksne #2 Rotated 176 x 102 mm"
 
-#: ../src/common/paper.cpp:192
+#: ../src/common/paper.cpp:189
 msgid "PRC Envelope #3 125 x 176 mm"
 msgstr "ĶTR aploksne #3 125 x 176 mm"
 
-#: ../src/common/paper.cpp:205
+#: ../src/common/paper.cpp:202
 msgid "PRC Envelope #3 Rotated 176 x 125 mm"
 msgstr "ĶTR aploksne #3 Rotated 176 x 125 mm"
 
-#: ../src/common/paper.cpp:193
+#: ../src/common/paper.cpp:190
 msgid "PRC Envelope #4 110 x 208 mm"
 msgstr "ĶTR aploksne #4 110 x 208 mm"
 
-#: ../src/common/paper.cpp:206
+#: ../src/common/paper.cpp:203
 msgid "PRC Envelope #4 Rotated 208 x 110 mm"
 msgstr "ĶTR aploksne #4 Rotated 208 x 110 mm"
 
-#: ../src/common/paper.cpp:194
+#: ../src/common/paper.cpp:191
 msgid "PRC Envelope #5 110 x 220 mm"
 msgstr "ĶTR aploksne #5 110 x 220 mm"
 
-#: ../src/common/paper.cpp:207
+#: ../src/common/paper.cpp:204
 msgid "PRC Envelope #5 Rotated 220 x 110 mm"
 msgstr "ĶTR aploksne #5 Rotated 220 x 110 mm"
 
-#: ../src/common/paper.cpp:195
+#: ../src/common/paper.cpp:192
 msgid "PRC Envelope #6 120 x 230 mm"
 msgstr "ĶTR aploksne #6 120 x 230 mm"
 
-#: ../src/common/paper.cpp:208
+#: ../src/common/paper.cpp:205
 msgid "PRC Envelope #6 Rotated 230 x 120 mm"
 msgstr "ĶTR aploksne #6 Rotated 230 x 120 mm"
 
-#: ../src/common/paper.cpp:196
+#: ../src/common/paper.cpp:193
 msgid "PRC Envelope #7 160 x 230 mm"
 msgstr "ĶTR aploksne #7 160 x 230 mm"
 
-#: ../src/common/paper.cpp:209
+#: ../src/common/paper.cpp:206
 msgid "PRC Envelope #7 Rotated 230 x 160 mm"
 msgstr "ĶTR aploksne #7 Rotated 230 x 160 mm"
 
-#: ../src/common/paper.cpp:197
+#: ../src/common/paper.cpp:194
 msgid "PRC Envelope #8 120 x 309 mm"
 msgstr "ĶTR aploksne #8 120 x 309 mm"
 
-#: ../src/common/paper.cpp:210
+#: ../src/common/paper.cpp:207
 msgid "PRC Envelope #8 Rotated 309 x 120 mm"
 msgstr "ĶTR aploksne #8 Rotated 309 x 120 mm"
 
-#: ../src/common/paper.cpp:198
+#: ../src/common/paper.cpp:195
 msgid "PRC Envelope #9 229 x 324 mm"
 msgstr "ĶTR aploksne #9 229 x 324 mm"
 
-#: ../src/common/paper.cpp:211
+#: ../src/common/paper.cpp:208
 msgid "PRC Envelope #9 Rotated 324 x 229 mm"
 msgstr "ĶTR aploksne #9 Rotated 324 x 229 mm"
 
@@ -5605,92 +5748,96 @@ msgstr "ĶTR aploksne #9 Rotated 324 x 229 mm"
 msgid "Padding"
 msgstr "Papildināšana"
 
-#: ../src/common/prntbase.cpp:2074
+#: ../src/common/prntbase.cpp:2096
 #, c-format
 msgid "Page %d"
 msgstr "Lapa %d"
 
-#: ../src/common/prntbase.cpp:2072
+#: ../src/common/prntbase.cpp:2094
 #, c-format
 msgid "Page %d of %d"
 msgstr "Lapa %d no %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 #, fuzzy
 msgid "Page Down"
 msgstr "Lapa %d"
 
-#: ../src/gtk/print.cpp:826
+#: ../src/gtk/print.cpp:829
 msgid "Page Setup"
 msgstr "Lapas iestatījumi"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 #, fuzzy
 msgid "Page Up"
 msgstr "Lapa %d"
 
-#: ../src/generic/prntdlgg.cpp:828 ../src/common/prntbase.cpp:484
+#: ../src/common/prntbase.cpp:479 ../src/generic/prntdlgg.cpp:821
 msgid "Page setup"
 msgstr "Lapas iestatījumi"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 #, fuzzy
 msgid "PageDown"
 msgstr "Lejup"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 #, fuzzy
 msgid "PageUp"
 msgstr "Lapas"
 
-#: ../src/generic/prntdlgg.cpp:216
+#: ../src/generic/prntdlgg.cpp:209
 msgid "Pages"
 msgstr "Lapas"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1765
+#: ../src/propgrid/advprops.cpp:1666
 msgid "Paint Brush"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:602 ../src/generic/prntdlgg.cpp:801
-#: ../src/generic/prntdlgg.cpp:842 ../src/generic/prntdlgg.cpp:855
-#: ../src/generic/prntdlgg.cpp:1052 ../src/generic/prntdlgg.cpp:1057
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:794
+#: ../src/generic/prntdlgg.cpp:835 ../src/generic/prntdlgg.cpp:848
+#: ../src/generic/prntdlgg.cpp:1045 ../src/generic/prntdlgg.cpp:1050
 msgid "Paper size"
 msgstr "Papīra izmērs"
 
-#: ../src/richtext/richtextstyles.cpp:1062
+#: ../src/richtext/richtextstyles.cpp:1059
 msgid "Paragraph styles"
 msgstr "Rindkopu stili"
 
-#: ../src/common/xtistrm.cpp:465
+#: ../src/common/xtistrm.cpp:462
 msgid "Passing a already registered object to SetObject"
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:476
+#: ../src/common/xtistrm.cpp:473
 #, fuzzy
 msgid "Passing an unknown object to GetObject"
 msgstr "GetObjectClassInfo nodots nezināms objekts"
 
-#: ../src/richtext/richtextctrl.cpp:3513 ../src/common/stockitem.cpp:180
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:177 ../src/richtext/richtextctrl.cpp:3514
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Ielīmēt"
 
-#: ../src/common/stockitem.cpp:262
+#: ../src/common/stockitem.cpp:260
 msgid "Paste selection"
 msgstr "Ielīmēt iezīmēto"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:74
+#: ../src/common/accelcmn.cpp:71
 msgid "Pause"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1766
+#: ../src/propgrid/advprops.cpp:1667
 msgid "Pencil"
 msgstr ""
 
@@ -5699,21 +5846,21 @@ msgstr ""
 msgid "Peri&od"
 msgstr "Peri&ods"
 
-#: ../src/generic/filectrlg.cpp:430
+#: ../src/generic/filectrlg.cpp:426
 msgid "Permissions"
 msgstr "Atļaujas"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:60
+#: ../src/common/accelcmn.cpp:57
 msgid "PgDn"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:59
+#: ../src/common/accelcmn.cpp:56
 msgid "PgUp"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:12868
+#: ../src/richtext/richtextbuffer.cpp:12863
 msgid "Picture Properties"
 msgstr "Attēla īpašības"
 
@@ -5725,45 +5872,45 @@ msgstr ""
 msgid "Please choose a valid font."
 msgstr "Lūdzu, izvēlieties derīgu fontu."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
 msgid "Please choose an existing file."
 msgstr "Lūdzu, izvēlieties esošu failu."
 
-#: ../src/html/helpwnd.cpp:800
+#: ../src/html/helpwnd.cpp:798
 msgid "Please choose the page to display:"
 msgstr "Lūdzu, izvēlieties attēlojamo lapu:"
 
-#: ../src/msw/dialup.cpp:764
+#: ../src/msw/dialup.cpp:758
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Lūdzu izvēlieties ISP, kuram vēlaties pieslēgties"
 
-#: ../src/common/headerctrlcmn.cpp:59
+#: ../src/common/headerctrlcmn.cpp:57
 msgid "Please select the columns to show and define their order:"
 msgstr "Lūdzu, izvēlieties attēlojamās slejas un nosakiet to kārtību:"
 
-#: ../src/common/prntbase.cpp:538
+#: ../src/common/prntbase.cpp:533
 #, fuzzy
 msgid "Please wait while printing..."
 msgstr "Lūdzu, gaidiet, notiek drukāšana\n"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1767
+#: ../src/propgrid/advprops.cpp:1668
 #, fuzzy
 msgid "Point Left"
 msgstr "Izmērs punktos"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1768
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgid "Point Right"
 msgstr "Izlīdzināt gar labo"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:662
+#: ../src/propgrid/advprops.cpp:572
 msgid "Point Size"
 msgstr "Izmērs punktos"
 
-#: ../src/generic/prntdlgg.cpp:612 ../src/generic/prntdlgg.cpp:867
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:860
 msgid "Portrait"
 msgstr "Portrets"
 
@@ -5771,256 +5918,266 @@ msgstr "Portrets"
 msgid "Position"
 msgstr "Pozīcija"
 
-#: ../src/generic/prntdlgg.cpp:298
+#: ../src/generic/prntdlgg.cpp:291
 msgid "PostScript file"
 msgstr "PostScript fails"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178 ../src/osx/cocoa/preferences.mm:303
 msgid "Preferences"
 msgstr "Iestatījumi"
 
-#: ../src/osx/menu_osx.cpp:568
+#: ../src/osx/menu_osx.cpp:460
 msgid "Preferences..."
 msgstr "Iestatījumi.."
 
-#: ../src/common/prntbase.cpp:546
+#: ../src/common/prntbase.cpp:541
 msgid "Preparing"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:455 ../src/osx/carbon/fontdlg.cpp:390
-#: ../src/html/helpwnd.cpp:1222
+#: ../src/osx/carbon/fontdlg.cpp:387 ../src/generic/fontdlgg.cpp:452
+#: ../src/html/helpwnd.cpp:1220
 msgid "Preview:"
 msgstr "Priekšskatījums:"
 
-#: ../src/common/prntbase.cpp:1553 ../src/html/helpwnd.cpp:664
+#: ../src/common/prntbase.cpp:1578 ../src/html/helpwnd.cpp:662
 msgid "Previous page"
 msgstr "Iepriekšējā lapa"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/prntdlgg.cpp:143 ../src/generic/prntdlgg.cpp:157
-#: ../src/common/prntbase.cpp:426 ../src/common/prntbase.cpp:1541
-#: ../src/common/accelcmn.cpp:77 ../src/gtk/print.cpp:620
-#: ../src/gtk/print.cpp:638
+#: ../src/common/prntbase.cpp:421 ../src/common/prntbase.cpp:1566
+#: ../src/common/accelcmn.cpp:74 ../src/generic/prntdlgg.cpp:136
+#: ../src/generic/prntdlgg.cpp:150 ../src/gtk/print.cpp:616
+#: ../src/gtk/print.cpp:634
 msgid "Print"
 msgstr "Drukāt"
 
-#: ../include/wx/prntbase.h:399 ../src/common/docview.cpp:1268
+#: ../src/common/docview.cpp:1262
 msgid "Print Preview"
 msgstr "Drukas priekšskatījums"
 
-#: ../src/common/prntbase.cpp:2015 ../src/common/prntbase.cpp:2057
-#: ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2037 ../src/common/prntbase.cpp:2079
+#: ../src/common/prntbase.cpp:2087
 msgid "Print Preview Failure"
 msgstr "Drukas priekšskatījuma kļūda"
 
-#: ../src/generic/prntdlgg.cpp:224
+#: ../src/generic/prntdlgg.cpp:217
 msgid "Print Range"
 msgstr "Drukāt diapazonu"
 
-#: ../src/generic/prntdlgg.cpp:449
+#: ../src/generic/prntdlgg.cpp:442
 msgid "Print Setup"
 msgstr "Drukas iestatījumi"
 
-#: ../src/generic/prntdlgg.cpp:621
+#: ../src/generic/prntdlgg.cpp:614
 msgid "Print in colour"
 msgstr "Drukāt krāsainu"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/osx/webview_webkit.mm:260
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "Nav iespējams inicializēt slejas aprakstu."
+
+#: ../src/common/stockitem.cpp:179
 #, fuzzy
 msgid "Print previe&w..."
 msgstr "Drukas priekš&skatījums"
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1256
 msgid "Print preview creation failed."
 msgstr "Neizdevās izveidot izdrukas priekšskatījumu."
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/common/stockitem.cpp:179
 #, fuzzy
 msgid "Print preview..."
 msgstr "Drukas priekšskatījums"
 
-#: ../src/generic/prntdlgg.cpp:630
+#: ../src/generic/prntdlgg.cpp:623
 msgid "Print spooling"
 msgstr "Drukas spolēšana"
 
-#: ../src/html/helpwnd.cpp:675
+#: ../src/html/helpwnd.cpp:673
 msgid "Print this page"
 msgstr "Drukāt šo lapu"
 
-#: ../src/generic/prntdlgg.cpp:185
+#: ../src/generic/prntdlgg.cpp:178
 msgid "Print to File"
 msgstr "Drukāt failā"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "Print..."
 msgstr "Drukāt..."
 
-#: ../src/generic/prntdlgg.cpp:493
+#: ../src/generic/prntdlgg.cpp:486
 msgid "Printer"
 msgstr "Printeris"
 
-#: ../src/generic/prntdlgg.cpp:633
+#: ../src/generic/prntdlgg.cpp:626
 msgid "Printer command:"
 msgstr "Printera komanda:"
 
-#: ../src/generic/prntdlgg.cpp:180
+#: ../src/generic/prntdlgg.cpp:173
 msgid "Printer options"
 msgstr "Printera iestatījumi"
 
-#: ../src/generic/prntdlgg.cpp:645
+#: ../src/generic/prntdlgg.cpp:638
 msgid "Printer options:"
 msgstr "Printera iestatījumi:"
 
-#: ../src/generic/prntdlgg.cpp:916
+#: ../src/generic/prntdlgg.cpp:909
 msgid "Printer..."
 msgstr "Printeris.."
 
-#: ../src/generic/prntdlgg.cpp:196
+#: ../src/generic/prntdlgg.cpp:189
 msgid "Printer:"
 msgstr "Drukas iekārta:"
 
-#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:535
-#: ../src/html/htmprint.cpp:277
+#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:530
+#: ../src/html/htmprint.cpp:289
 msgid "Printing"
 msgstr "Drukāšana"
 
-#: ../src/common/prntbase.cpp:612
+#: ../src/common/prntbase.cpp:607
 msgid "Printing "
 msgstr "Drukāšana"
 
-#: ../src/common/prntbase.cpp:347
+#: ../src/common/prntbase.cpp:342
 msgid "Printing Error"
 msgstr "Drukāšanas Kļūda"
 
-#: ../src/common/prntbase.cpp:565
+#: ../src/osx/webview_webkit.mm:251
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "Šī zlib versija neuztur gzip"
+
+#: ../src/common/prntbase.cpp:560
 #, fuzzy, c-format
 msgid "Printing page %d"
 msgstr "Drukājas lapa %d..."
 
-#: ../src/common/prntbase.cpp:570
+#: ../src/common/prntbase.cpp:565
 #, fuzzy, c-format
 msgid "Printing page %d of %d"
 msgstr "Drukājas lapa %d..."
 
-#: ../src/generic/printps.cpp:201
+#: ../src/generic/printps.cpp:182
 #, c-format
 msgid "Printing page %d..."
 msgstr "Drukājas lapa %d..."
 
-#: ../src/generic/printps.cpp:161
+#: ../src/generic/printps.cpp:142
 msgid "Printing..."
 msgstr "Drukājas..."
 
-#: ../include/wx/richtext/richtextprint.h:109 ../include/wx/prntbase.h:267
-#: ../src/common/docview.cpp:2132
+#: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
+#: ../src/common/docview.cpp:2137
 msgid "Printout"
 msgstr "Izdruka"
 
-#: ../src/common/debugrpt.cpp:560
+#: ../src/common/debugrpt.cpp:561
 #, c-format
 msgid ""
 "Processing debug report has failed, leaving the files in \"%s\" directory."
 msgstr ""
 "Atkļūdošanas atskaišu apstrāde neizdevās, faili tiek atstāti mapē \"%s\"."
 
-#: ../src/common/prntbase.cpp:545
+#: ../src/common/prntbase.cpp:540
 msgid "Progress:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181
 msgid "Properties"
 msgstr "Īpašības"
 
-#: ../src/propgrid/manager.cpp:237
+#: ../src/propgrid/manager.cpp:223
 msgid "Property"
 msgstr "Īpašība"
 
 #. TRANSLATORS: Caption of message box displaying any property error
-#: ../src/propgrid/propgrid.cpp:3185 ../src/propgrid/propgrid.cpp:3318
+#: ../src/propgrid/propgrid.cpp:3162 ../src/propgrid/propgrid.cpp:3299
 msgid "Property Error"
 msgstr "Īpašības kļūda "
 
-#: ../src/propgrid/advprops.cpp:1597
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Purple"
 msgstr ""
 
-#: ../src/common/paper.cpp:112
+#: ../src/common/paper.cpp:109
 msgid "Quarto, 215 x 275 mm"
 msgstr "Quarto, 215 x 275 mm"
 
-#: ../src/generic/logg.cpp:1016
+#: ../src/generic/logg.cpp:1013
 msgid "Question"
 msgstr "Jautājums"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1769
+#: ../src/propgrid/advprops.cpp:1670
 #, fuzzy
 msgid "Question Arrow"
 msgstr "Jautājums"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "Quit"
 msgstr "Iziet"
 
-#: ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:477
 #, c-format
 msgid "Quit %s"
 msgstr "Iziet no %s"
 
-#: ../src/common/stockitem.cpp:263
+#: ../src/common/stockitem.cpp:261
 msgid "Quit this program"
 msgstr "Iziet no šīs programmas"
 
-#: ../src/common/accelcmn.cpp:338
+#: ../src/common/accelcmn.cpp:352
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/ffile.cpp:109 ../src/common/ffile.cpp:133
+#: ../src/common/ffile.cpp:107 ../src/common/ffile.cpp:132
 #, c-format
 msgid "Read error on file '%s'"
 msgstr "Lasīšanas kļūda failā '%s'"
 
-#: ../src/common/secretstore.cpp:199
+#: ../src/common/secretstore.cpp:211
 #, fuzzy, c-format
-msgid "Reading password for \"%s/%s\" failed: %s."
+msgid "Reading password for \"%s\" failed: %s."
 msgstr "Neizdevās izveidot hronometru"
 
-#: ../src/common/prntbase.cpp:272
+#: ../src/common/prntbase.cpp:267
 msgid "Ready"
 msgstr "Gatavs"
 
-#: ../src/propgrid/advprops.cpp:1605
+#: ../src/propgrid/advprops.cpp:1511
 #, fuzzy
 msgid "Red"
 msgstr "Atkārtot"
 
-#: ../src/generic/colrdlgg.cpp:339
+#: ../src/generic/colrdlgg.cpp:359
 msgid "Red:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:185 ../src/stc/stc_i18n.cpp:16
+#: ../src/common/stockitem.cpp:182 ../src/stc/stc_i18n.cpp:16
 msgid "Redo"
 msgstr "Atkārtot"
 
-#: ../src/common/stockitem.cpp:264
+#: ../src/common/stockitem.cpp:262
 msgid "Redo last action"
 msgstr "Atkārtot pēdējo darbību"
 
-#: ../src/common/stockitem.cpp:186
+#: ../src/common/stockitem.cpp:183
 msgid "Refresh"
 msgstr "Atsvaidzināt skatu"
 
-#: ../src/msw/registry.cpp:626
+#: ../src/msw/registry.cpp:615
 #, c-format
 msgid "Registry key '%s' already exists."
 msgstr "Reģistra atslēga '%s' jau pastāv."
 
-#: ../src/msw/registry.cpp:595
+#: ../src/msw/registry.cpp:584
 #, c-format
 msgid "Registry key '%s' does not exist, cannot rename it."
 msgstr "Reģistra atslēga '%s' nepastāv, nav iespējams pārdēvēt."
 
-#: ../src/msw/registry.cpp:727
+#: ../src/msw/registry.cpp:716
 #, c-format
 msgid ""
 "Registry key '%s' is needed for normal system operation,\n"
@@ -6031,22 +6188,22 @@ msgstr ""
 "tās dzēšana var novest sistēmu nelietojamā stāvoklī:\n"
 "darbība atcelta."
 
-#: ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:942
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:917
+#: ../src/msw/registry.cpp:905
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1003
+#: ../src/msw/registry.cpp:991
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:521
+#: ../src/msw/registry.cpp:510
 #, c-format
 msgid "Registry value '%s' already exists."
 msgstr "Reģistra vērtība '%s' jau pastāv."
@@ -6061,72 +6218,78 @@ msgstr "Regulārs"
 msgid "Relative"
 msgstr "Dekoratīvs"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:456
 msgid "Relevant entries:"
 msgstr "Saistītie ieraksti:"
 
-#: ../include/wx/generic/progdlgg.h:86
+#: ../include/wx/generic/progdlgg.h:87
 #, fuzzy
 msgid "Remaining time:"
 msgstr "Atlikušais laiks:"
 
-#: ../src/common/stockitem.cpp:187
+#: ../src/common/stockitem.cpp:184
 msgid "Remove"
 msgstr "Aizvākt"
 
-#: ../src/richtext/richtextctrl.cpp:1562
+#: ../src/richtext/richtextctrl.cpp:1563
 #, fuzzy
 msgid "Remove Bullet"
 msgstr "Aizvākt"
 
-#: ../src/html/helpwnd.cpp:433
+#: ../src/html/helpwnd.cpp:431
 msgid "Remove current page from bookmarks"
 msgstr "Izņemt pašreizējo lapu no grāmatazīmēm"
 
-#: ../src/common/rendcmn.cpp:194
+#: ../src/common/rendcmn.cpp:191
 #, c-format
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:4527
+#: ../src/richtext/richtextbuffer.cpp:4524
 msgid "Renumber List"
 msgstr "Pārnumurēt sarakstu"
 
-#: ../src/common/stockitem.cpp:188
-msgid "Rep&lace"
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Rep&lace..."
 msgstr "Aiz&vietot"
 
-#: ../src/richtext/richtextctrl.cpp:3673 ../src/common/stockitem.cpp:188
+#: ../src/richtext/richtextctrl.cpp:3674
 msgid "Replace"
 msgstr "Aizvietot"
 
-#: ../src/generic/fdrepdlg.cpp:182
+#: ../src/generic/fdrepdlg.cpp:179
 msgid "Replace &all"
 msgstr "&Aizstāt visus"
 
-#: ../src/common/stockitem.cpp:261
-msgid "Replace selection"
-msgstr "Aizvietot iezīmējumu"
-
-#: ../src/generic/fdrepdlg.cpp:124
+#: ../src/generic/fdrepdlg.cpp:121
 msgid "Replace with:"
 msgstr "Aizstāt ar:"
 
-#: ../src/common/valtext.cpp:163
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Replace..."
+msgstr "Aizvietot"
+
+#: ../src/common/valtext.cpp:184
 msgid "Required information entry is empty."
 msgstr "Nepieciešamais informācijas ieraksts ir tukšs."
 
-#: ../src/common/translation.cpp:1975
+#: ../src/common/translation.cpp:2025
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr ""
 
+#: ../src/gtk/webview_webkit.cpp:985
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:56
+#: ../src/common/accelcmn.cpp:53
 msgid "Return"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:189
+#: ../src/common/stockitem.cpp:186
 msgid "Revert to Saved"
 msgstr "Atgriezties pie saglabātā"
 
@@ -6138,42 +6301,42 @@ msgstr "Kore"
 msgid "Rig&ht-to-left"
 msgstr ""
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6149
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:59 ../src/generic/datavgen.cpp:6954
+#: ../src/richtext/richtextsizepage.cpp:250
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextbulletspage.cpp:188
-#: ../src/richtext/richtextsizepage.cpp:250 ../src/common/accelcmn.cpp:62
 msgid "Right"
 msgstr "Pa labi"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1754
+#: ../src/propgrid/advprops.cpp:1655
 #, fuzzy
 msgid "Right Arrow"
 msgstr "Pa labi"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1770
+#: ../src/propgrid/advprops.cpp:1671
 msgid "Right Button"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:892
+#: ../src/generic/prntdlgg.cpp:885
 msgid "Right margin (mm):"
 msgstr "Labā apmale (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:148
-#: ../src/richtext/richtextindentspage.cpp:150
 #: ../src/richtext/richtextliststylepage.cpp:337
 #: ../src/richtext/richtextliststylepage.cpp:339
+#: ../src/richtext/richtextindentspage.cpp:148
+#: ../src/richtext/richtextindentspage.cpp:150
 msgid "Right-align text."
 msgstr "Izlīdzināt tekstu pa labi."
 
-#: ../src/generic/fontdlgg.cpp:322
+#: ../src/generic/fontdlgg.cpp:318
 msgid "Roman"
 msgstr "Romāņu"
 
-#: ../src/generic/datavgen.cpp:5916
+#: ../src/generic/datavgen.cpp:6721
 #, c-format
 msgid "Row %i"
 msgstr ""
@@ -6183,30 +6346,31 @@ msgstr ""
 msgid "S&tandard bullet name:"
 msgstr "S&tandarta aizzīmes nosaukums:"
 
-#: ../src/common/accelcmn.cpp:268 ../src/common/accelcmn.cpp:350
+#: ../src/common/accelcmn.cpp:282 ../src/common/accelcmn.cpp:367
 msgid "SPECIAL"
 msgstr "Speciāls"
 
-#: ../src/common/stockitem.cpp:190 ../src/common/sizer.cpp:2797
+#: ../src/common/stockitem.cpp:187 ../src/common/sizer.cpp:2914
 msgid "Save"
 msgstr "Saglabāt"
 
-#: ../src/common/fldlgcmn.cpp:342
+#: ../src/common/fldlgcmn.cpp:339
 #, c-format
 msgid "Save %s file"
 msgstr "Saglabāt %s failu "
 
-#: ../src/generic/logg.cpp:512
+#: ../src/common/stockitem.cpp:188 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Saglabāt &kā..."
 
-#: ../src/common/docview.cpp:366
+#: ../src/common/docview.cpp:359
 msgid "Save As"
 msgstr "Saglabāt kā"
 
-#: ../src/common/stockitem.cpp:191
-msgid "Save as"
-msgstr "Saglabāt kā"
+#: ../src/common/stockitem.cpp:188
+#, fuzzy
+msgid "Save As..."
+msgstr "Saglabāt &kā..."
 
 #: ../src/common/stockitem.cpp:267
 msgid "Save current document"
@@ -6216,95 +6380,95 @@ msgstr "Saglabāt aktīvo dokumentu"
 msgid "Save current document with a different filename"
 msgstr "Saglabāt pašreizējo dokumentu ar citu nosaukumu"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/generic/logg.cpp:509
 msgid "Save log contents to file"
 msgstr "Saglabāt žurnāla saturu failā"
 
-#: ../src/common/secretstore.cpp:179
+#: ../src/common/secretstore.cpp:189
 #, fuzzy, c-format
-msgid "Saving password for \"%s/%s\" failed: %s."
+msgid "Saving password for \"%s\" failed: %s."
 msgstr "Neizdevās izveidot hronometru"
 
-#: ../src/generic/fontdlgg.cpp:325
+#: ../src/generic/fontdlgg.cpp:321
 msgid "Script"
 msgstr "Rokraksta"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll Lock"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll_lock"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:890
+#: ../src/propgrid/advprops.cpp:791
 msgid "Scrollbar"
 msgstr ""
 
-#: ../src/generic/srchctlg.cpp:56 ../src/html/helpwnd.cpp:535
-#: ../src/html/helpwnd.cpp:550
+#: ../src/generic/srchctlg.cpp:55 ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:548 ../src/gtk/srchctrl.cpp:182
 msgid "Search"
 msgstr "Meklēt"
 
-#: ../src/html/helpwnd.cpp:537
+#: ../src/html/helpwnd.cpp:535
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
 msgstr "Meklēt palīdzības grāmatas(-u) saturā tekstu, ko ievadījāt augstāk"
 
-#: ../src/generic/fdrepdlg.cpp:160
+#: ../src/generic/fdrepdlg.cpp:157
 msgid "Search direction"
 msgstr "Meklēšanas virziens"
 
-#: ../src/generic/fdrepdlg.cpp:112
+#: ../src/generic/fdrepdlg.cpp:109
 msgid "Search for:"
 msgstr "Meklēt:"
 
-#: ../src/html/helpwnd.cpp:1052
+#: ../src/html/helpwnd.cpp:1050
 msgid "Search in all books"
 msgstr "Meklēt visās grāmatās"
 
-#: ../src/html/helpwnd.cpp:857
+#: ../src/html/helpwnd.cpp:855
 msgid "Searching..."
 msgstr "Meklē..."
 
-#: ../src/generic/dirctrlg.cpp:446
+#: ../src/generic/dirctrlg.cpp:412
 msgid "Sections"
 msgstr "Sadaļas"
 
-#: ../src/common/ffile.cpp:238
+#: ../src/common/ffile.cpp:237
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr ""
 
-#: ../src/common/ffile.cpp:228
+#: ../src/common/ffile.cpp:227
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:76
+#: ../src/common/accelcmn.cpp:73
 #, fuzzy
 msgid "Select"
 msgstr "Iezīmējums"
 
-#: ../src/richtext/richtextctrl.cpp:337 ../src/osx/textctrl_osx.cpp:581
-#: ../src/common/stockitem.cpp:192 ../src/msw/textctrl.cpp:2512
+#: ../src/osx/textctrl_osx.cpp:599 ../src/common/stockitem.cpp:189
+#: ../src/msw/textctrl.cpp:2777 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Izvēlēties &visu"
 
-#: ../src/common/stockitem.cpp:192 ../src/stc/stc_i18n.cpp:21
+#: ../src/common/stockitem.cpp:189 ../src/stc/stc_i18n.cpp:21
 msgid "Select All"
 msgstr "Iezīmēt visu"
 
-#: ../src/common/docview.cpp:1895
+#: ../src/common/docview.cpp:1900
 msgid "Select a document template"
 msgstr "Izvēlieties dokumenta sagatavi"
 
-#: ../src/common/docview.cpp:1969
+#: ../src/common/docview.cpp:1974
 msgid "Select a document view"
 msgstr "Izvēlieties dokumenta skatu"
 
@@ -6333,20 +6497,20 @@ msgid "Selects the list level to edit."
 msgstr "Izvēlas labojamo saraksta līmeni."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:82
+#: ../src/common/accelcmn.cpp:79
 msgid "Separator"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1083
+#: ../src/common/cmdline.cpp:1079
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Aiz iestatījuma '%s' ir jābūt atdalītājam."
 
-#: ../src/osx/menu_osx.cpp:572
+#: ../src/osx/menu_osx.cpp:464
 msgid "Services"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11217
+#: ../src/richtext/richtextbuffer.cpp:11216
 msgid "Set Cell Style"
 msgstr "Iestatīt šūnas stilu"
 
@@ -6354,11 +6518,11 @@ msgstr "Iestatīt šūnas stilu"
 msgid "SetProperty called w/o valid setter"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:188
+#: ../src/generic/prntdlgg.cpp:181
 msgid "Setup..."
 msgstr "Iestatīt..."
 
-#: ../src/msw/dialup.cpp:544
+#: ../src/msw/dialup.cpp:538
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr "Atrastas vairākas aktīvas iezvanpieejas, tiek izvēlēja viena no tām."
 
@@ -6375,40 +6539,40 @@ msgstr ""
 msgid "Shadow c&olour:"
 msgstr "Izvēlieties krāsu"
 
-#: ../src/common/accelcmn.cpp:335
+#: ../src/common/accelcmn.cpp:349
 msgid "Shift+"
 msgstr "Shift+"
 
-#: ../src/generic/dirdlgg.cpp:147
+#: ../src/generic/dirdlgg.cpp:144
 msgid "Show &hidden directories"
 msgstr "Rādīt &slēptās mapes"
 
-#: ../src/generic/filectrlg.cpp:983
+#: ../src/generic/filectrlg.cpp:979
 msgid "Show &hidden files"
 msgstr "Rādīt &slēptos failus"
 
-#: ../src/osx/menu_osx.cpp:580
+#: ../src/osx/menu_osx.cpp:472
 msgid "Show All"
 msgstr "Rādīt visas"
 
-#: ../src/common/stockitem.cpp:257
+#: ../src/common/stockitem.cpp:254
 msgid "Show about dialog"
 msgstr "Rādīt apraksta dialogu"
 
-#: ../src/html/helpwnd.cpp:492
+#: ../src/html/helpwnd.cpp:490
 msgid "Show all"
 msgstr "Rādīt visas"
 
-#: ../src/html/helpwnd.cpp:503
+#: ../src/html/helpwnd.cpp:501
 msgid "Show all items in index"
 msgstr "Rādīt visus saraksta locekļus"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:656
 msgid "Show/hide navigation panel"
 msgstr "Rādīt/slēpt navigācijas paneli"
 
-#: ../src/richtext/richtextsymboldlg.cpp:421
-#: ../src/richtext/richtextsymboldlg.cpp:423
+#: ../src/richtext/richtextsymboldlg.cpp:418
+#: ../src/richtext/richtextsymboldlg.cpp:420
 msgid "Shows a Unicode subset."
 msgstr "Rāda Unicode apakškopu."
 
@@ -6424,7 +6588,7 @@ msgstr "Rāda aizzīmju iestatījumu priekšskatījumu."
 msgid "Shows a preview of the font settings."
 msgstr "Rāda fonta iestatījumu priekšskatījumu."
 
-#: ../src/osx/carbon/fontdlg.cpp:394 ../src/osx/carbon/fontdlg.cpp:396
+#: ../src/osx/carbon/fontdlg.cpp:391 ../src/osx/carbon/fontdlg.cpp:393
 msgid "Shows a preview of the font."
 msgstr "Rāda fonta priekšskatījumu."
 
@@ -6433,62 +6597,62 @@ msgstr "Rāda fonta priekšskatījumu."
 msgid "Shows a preview of the paragraph settings."
 msgstr "Rāda rindkopas iestatījumu priekšskatījumu."
 
-#: ../src/generic/fontdlgg.cpp:460 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:456 ../src/generic/fontdlgg.cpp:458
 msgid "Shows the font preview."
 msgstr "Rāda fonta priekšskatījumu."
 
-#: ../src/propgrid/advprops.cpp:1607
+#: ../src/propgrid/advprops.cpp:1513
 msgid "Silver"
 msgstr ""
 
-#: ../src/univ/themes/mono.cpp:516
+#: ../src/univ/themes/mono.cpp:513
 msgid "Simple monochrome theme"
 msgstr "Vienkrāsaina tēma"
 
-#: ../src/richtext/richtextindentspage.cpp:275
 #: ../src/richtext/richtextliststylepage.cpp:449
+#: ../src/richtext/richtextindentspage.cpp:275
 msgid "Single"
 msgstr "Viena"
 
-#: ../src/generic/filectrlg.cpp:425 ../src/richtext/richtextformatdlg.cpp:369
-#: ../src/richtext/richtextsizepage.cpp:299
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextsizepage.cpp:299
+#: ../src/richtext/richtextformatdlg.cpp:362
 msgid "Size"
 msgstr "Izmērs"
 
-#: ../src/osx/carbon/fontdlg.cpp:339
+#: ../src/osx/carbon/fontdlg.cpp:336
 msgid "Size:"
 msgstr "Izmērs:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1775
+#: ../src/propgrid/advprops.cpp:1676
 msgid "Sizing"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1772
+#: ../src/propgrid/advprops.cpp:1673
 msgid "Sizing N-S"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1771
+#: ../src/propgrid/advprops.cpp:1672
 msgid "Sizing NE-SW"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1773
+#: ../src/propgrid/advprops.cpp:1674
 msgid "Sizing NW-SE"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1774
+#: ../src/propgrid/advprops.cpp:1675
 msgid "Sizing W-E"
 msgstr ""
 
-#: ../src/msw/progdlg.cpp:801
+#: ../src/msw/progdlg.cpp:1088
 msgid "Skip"
 msgstr "Izlaist"
 
-#: ../src/generic/fontdlgg.cpp:330
+#: ../src/generic/fontdlgg.cpp:326
 msgid "Slant"
 msgstr "Slīpums"
 
@@ -6498,7 +6662,7 @@ msgid "Small C&apitals"
 msgstr "Lieli burti"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:79
+#: ../src/common/accelcmn.cpp:76
 msgid "Snapshot"
 msgstr ""
 
@@ -6506,38 +6670,38 @@ msgstr ""
 msgid "Solid"
 msgstr "Vienlaidus"
 
-#: ../src/common/docview.cpp:1791
+#: ../src/common/docview.cpp:1785
 msgid "Sorry, could not open this file."
 msgstr "Diemžēl, šis fails nav atverams."
 
-#: ../src/common/prntbase.cpp:2057 ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2079 ../src/common/prntbase.cpp:2087
 msgid "Sorry, not enough memory to create a preview."
 msgstr ""
 "Diemžēl, nav pietiekami daudz brīvas atmiņas priekšskatījuma izveidošanai."
 
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "Sorry, that name is taken. Please choose another."
 msgstr "Diemžēl, šis vārds jau ir aizņemts. Izvēlieties citu."
 
-#: ../src/common/docview.cpp:1814
+#: ../src/common/docview.cpp:1819
 msgid "Sorry, the format for this file is unknown."
 msgstr "Atvainojiet, šis faila formāts nav zinams."
 
-#: ../src/unix/sound.cpp:492
+#: ../src/unix/sound.cpp:481
 msgid "Sound data are in unsupported format."
 msgstr "Skaņas dati ir neatbalstītā formātā."
 
-#: ../src/unix/sound.cpp:477
+#: ../src/unix/sound.cpp:466
 #, c-format
 msgid "Sound file '%s' is in unsupported format."
 msgstr "Skaņās faila '%s' formāts nav atbalstīts."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:67
+#: ../src/common/accelcmn.cpp:64
 #, fuzzy
 msgid "Space"
 msgstr "Atstarpes"
@@ -6546,12 +6710,12 @@ msgstr "Atstarpes"
 msgid "Spacing"
 msgstr "Atstarpes"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "Spell Check"
 msgstr "Pareizrakstība"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1776
+#: ../src/propgrid/advprops.cpp:1677
 msgid "Spraycan"
 msgstr ""
 
@@ -6560,7 +6724,7 @@ msgstr ""
 msgid "Standard"
 msgstr "Standarta"
 
-#: ../src/common/paper.cpp:104
+#: ../src/common/paper.cpp:101
 msgid "Statement, 5 1/2 x 8 1/2 in"
 msgstr "Statement, 5 1/2 x 8 1/2 in"
 
@@ -6570,33 +6734,29 @@ msgstr "Statement, 5 1/2 x 8 1/2 in"
 msgid "Static"
 msgstr "Statuss:"
 
-#: ../src/generic/prntdlgg.cpp:204
+#: ../src/generic/prntdlgg.cpp:197
 msgid "Status:"
 msgstr "Statuss:"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "Stop"
 msgstr "Apturēt"
 
-#: ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196
 msgid "Strikethrough"
 msgstr "Caursvītrots"
 
-#: ../src/common/colourcmn.cpp:45
+#: ../src/common/colourcmn.cpp:42
 #, c-format
 msgid "String To Colour : Incorrect colour specification : %s"
 msgstr "Virkne par krāsu: nepareiza krāsas specifikācija: %s"
 
 #. TRANSLATORS: Label of font style
-#: ../src/richtext/richtextformatdlg.cpp:339 ../src/propgrid/advprops.cpp:680
+#: ../src/propgrid/advprops.cpp:590 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Stils"
 
-#: ../include/wx/richtext/richtextstyledlg.h:46
-msgid "Style Organiser"
-msgstr "Stilu vadība"
-
-#: ../src/osx/carbon/fontdlg.cpp:348
+#: ../src/osx/carbon/fontdlg.cpp:345
 msgid "Style:"
 msgstr "Stils:"
 
@@ -6605,7 +6765,7 @@ msgid "Subscrip&t"
 msgstr "Apakšraks&ts"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:83
+#: ../src/common/accelcmn.cpp:80
 msgid "Subtract"
 msgstr ""
 
@@ -6613,11 +6773,11 @@ msgstr ""
 msgid "Supe&rscript"
 msgstr "Augš&raksts"
 
-#: ../src/common/paper.cpp:150
+#: ../src/common/paper.cpp:147
 msgid "SuperA/SuperA/A4 227 x 356 mm"
 msgstr "SuperA/SuperA/A4 227 x 356 mm"
 
-#: ../src/common/paper.cpp:151
+#: ../src/common/paper.cpp:148
 msgid "SuperB/SuperB/A3 305 x 487 mm"
 msgstr "SuperB/SuperB/A3 305 x 487 mm"
 
@@ -6625,7 +6785,7 @@ msgstr "SuperB/SuperB/A3 305 x 487 mm"
 msgid "Suppress hyphe&nation"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:326
+#: ../src/generic/fontdlgg.cpp:322
 msgid "Swiss"
 msgstr "Šveices"
 
@@ -6643,74 +6803,74 @@ msgstr "Simbola &fonts:"
 msgid "Symbols"
 msgstr "Simboli"
 
-#: ../src/common/imagtiff.cpp:369 ../src/common/imagtiff.cpp:382
-#: ../src/common/imagtiff.cpp:741
+#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
+#: ../src/common/imagtiff.cpp:738
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: nevar piešķirt atmiņu."
 
-#: ../src/common/imagtiff.cpp:301
+#: ../src/common/imagtiff.cpp:298
 msgid "TIFF: Error loading image."
 msgstr "TIFF: kļūda ielādējot attēlu."
 
-#: ../src/common/imagtiff.cpp:468
+#: ../src/common/imagtiff.cpp:465
 msgid "TIFF: Error reading image."
 msgstr "TIFF: kļūda lasot attēlu."
 
-#: ../src/common/imagtiff.cpp:608
+#: ../src/common/imagtiff.cpp:605
 msgid "TIFF: Error saving image."
 msgstr "TIFF: kļūda saglabājot attēlu."
 
-#: ../src/common/imagtiff.cpp:846
+#: ../src/common/imagtiff.cpp:843
 msgid "TIFF: Error writing image."
 msgstr "TIFF: kļūda pierakstot attēlu."
 
-#: ../src/common/imagtiff.cpp:355
+#: ../src/common/imagtiff.cpp:352
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: attēla izmērs ir nedabīgi liels."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:68
+#: ../src/common/accelcmn.cpp:65
 #, fuzzy
 msgid "Tab"
 msgstr "Tabuācijas"
 
-#: ../src/richtext/richtextbuffer.cpp:11498
+#: ../src/richtext/richtextbuffer.cpp:11497
 msgid "Table Properties"
 msgstr "Tabulas īpašības"
 
-#: ../src/common/paper.cpp:145
+#: ../src/common/paper.cpp:142
 msgid "Tabloid Extra 11.69 x 18 in"
 msgstr "Tabloid Extra 11.69 x 18 in"
 
-#: ../src/common/paper.cpp:102
+#: ../src/common/paper.cpp:99
 msgid "Tabloid, 11 x 17 in"
 msgstr "Tabloid, 11 x 17 in"
 
-#: ../src/richtext/richtextformatdlg.cpp:354
+#: ../src/richtext/richtextformatdlg.cpp:347
 msgid "Tabs"
 msgstr "Tabuācijas"
 
-#: ../src/propgrid/advprops.cpp:1598
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Teal"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:327
+#: ../src/generic/fontdlgg.cpp:323
 msgid "Teletype"
 msgstr "Teletaips"
 
-#: ../src/common/docview.cpp:1896
+#: ../src/common/docview.cpp:1901
 msgid "Templates"
 msgstr "Sagataves"
 
-#: ../src/common/fmapbase.cpp:158
+#: ../src/common/fmapbase.cpp:155
 msgid "Thai (ISO-8859-11)"
 msgstr "Taju (ISO-8859-11/TIS-620)"
 
-#: ../src/common/ftp.cpp:619
+#: ../src/common/ftp.cpp:622
 msgid "The FTP server doesn't support passive mode."
 msgstr "FTP serveris neatbalsta pasīvo režīmu."
 
-#: ../src/common/ftp.cpp:605
+#: ../src/common/ftp.cpp:608
 msgid "The FTP server doesn't support the PORT command."
 msgstr "FTP serveris neatbalsta PORT komandu."
 
@@ -6721,8 +6881,8 @@ msgstr "FTP serveris neatbalsta PORT komandu."
 msgid "The available bullet styles."
 msgstr "Pieejamie aizzīmju stili."
 
-#: ../src/richtext/richtextstyledlg.cpp:202
-#: ../src/richtext/richtextstyledlg.cpp:204
+#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:200
 msgid "The available styles."
 msgstr "Pieejamie stili."
 
@@ -6780,12 +6940,12 @@ msgstr "Tabulatora pozīcija."
 msgid "The bullet character."
 msgstr "Aizzīmes rakstzīme."
 
-#: ../src/richtext/richtextsymboldlg.cpp:443
-#: ../src/richtext/richtextsymboldlg.cpp:445
+#: ../src/richtext/richtextsymboldlg.cpp:440
+#: ../src/richtext/richtextsymboldlg.cpp:442
 msgid "The character code."
 msgstr "Rakstzīmes kods."
 
-#: ../src/common/fontmap.cpp:203
+#: ../src/common/fontmap.cpp:200
 #, c-format
 msgid ""
 "The charset '%s' is unknown. You may select\n"
@@ -6796,7 +6956,7 @@ msgstr ""
 "citu kodējumu, ar ko to aizvietot, vai izvēlēties\n"
 "[Atcelt], ja tas nav aizvietojams."
 
-#: ../src/msw/ole/dataobj.cpp:394
+#: ../src/msw/ole/dataobj.cpp:402
 #, c-format
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "Starpliktuves formāts '%d' nepastāv."
@@ -6806,7 +6966,7 @@ msgstr "Starpliktuves formāts '%d' nepastāv."
 msgid "The default style for the next paragraph."
 msgstr "Nākošās rindkopas noklusētais stils."
 
-#: ../src/generic/dirdlgg.cpp:202
+#: ../src/generic/dirdlgg.cpp:199
 #, c-format
 msgid ""
 "The directory '%s' does not exist\n"
@@ -6815,7 +6975,7 @@ msgstr ""
 "Mape '%s' nepastāv\n"
 "Izveidot tagad?"
 
-#: ../src/html/htmprint.cpp:271
+#: ../src/html/htmprint.cpp:283
 #, c-format
 msgid ""
 "The document \"%s\" doesn't fit on the page horizontally and will be "
@@ -6828,7 +6988,7 @@ msgstr ""
 "\n"
 "Turpināt drukāt neskatoties uz to?"
 
-#: ../src/common/docview.cpp:1202
+#: ../src/common/docview.cpp:1196
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -6837,36 +6997,36 @@ msgstr ""
 "Fails '%s' nepastāv un nav atverams.\n"
 "Tas ir aizvākts no pēdējo izmantoto failu saraksta."
 
-#: ../src/richtext/richtextindentspage.cpp:208
-#: ../src/richtext/richtextindentspage.cpp:210
 #: ../src/richtext/richtextliststylepage.cpp:394
 #: ../src/richtext/richtextliststylepage.cpp:396
+#: ../src/richtext/richtextindentspage.cpp:208
+#: ../src/richtext/richtextindentspage.cpp:210
 msgid "The first line indent."
 msgstr "Pirmā rinda ar atkāpi."
 
-#: ../src/gtk/utilsgtk.cpp:481
-msgid "The following standard GTK+ options are also supported:\n"
-msgstr "Tiek atbalstīti arī sekojoši GTK+ standarta iestatījumi:\n"
+#: ../src/generic/dbgrptg.cpp:318
+msgid "The following debug report will be generated\n"
+msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:414 ../src/generic/fontdlgg.cpp:416
+#: ../src/generic/fontdlgg.cpp:411 ../src/generic/fontdlgg.cpp:413
 msgid "The font colour."
 msgstr "Fonta krāsa."
 
-#: ../src/generic/fontdlgg.cpp:375 ../src/generic/fontdlgg.cpp:377
+#: ../src/generic/fontdlgg.cpp:371 ../src/generic/fontdlgg.cpp:373
 msgid "The font family."
 msgstr "Fontu saime."
 
-#: ../src/richtext/richtextsymboldlg.cpp:405
-#: ../src/richtext/richtextsymboldlg.cpp:407
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "The font from which to take the symbol."
 msgstr "Fonts, no kura ņemt simbolu."
 
-#: ../src/generic/fontdlgg.cpp:427 ../src/generic/fontdlgg.cpp:429
-#: ../src/generic/fontdlgg.cpp:434 ../src/generic/fontdlgg.cpp:436
+#: ../src/generic/fontdlgg.cpp:424 ../src/generic/fontdlgg.cpp:426
+#: ../src/generic/fontdlgg.cpp:430 ../src/generic/fontdlgg.cpp:432
 msgid "The font point size."
 msgstr "Fonta izmērs punktos."
 
-#: ../src/osx/carbon/fontdlg.cpp:343 ../src/osx/carbon/fontdlg.cpp:345
+#: ../src/osx/carbon/fontdlg.cpp:340 ../src/osx/carbon/fontdlg.cpp:342
 msgid "The font size in points."
 msgstr "Fonta izmērs punktos"
 
@@ -6876,15 +7036,15 @@ msgstr "Fonta izmērs punktos"
 msgid "The font size units, points or pixels."
 msgstr "Fonta izmērs punktos"
 
-#: ../src/generic/fontdlgg.cpp:386 ../src/generic/fontdlgg.cpp:388
+#: ../src/generic/fontdlgg.cpp:382 ../src/generic/fontdlgg.cpp:384
 msgid "The font style."
 msgstr "Fonta stils."
 
-#: ../src/generic/fontdlgg.cpp:397 ../src/generic/fontdlgg.cpp:399
+#: ../src/generic/fontdlgg.cpp:393 ../src/generic/fontdlgg.cpp:395
 msgid "The font weight."
 msgstr "Fonta svars."
 
-#: ../src/common/docview.cpp:1483
+#: ../src/common/docview.cpp:1477
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Nav iespējams noteikt faila '%s' formātu."
@@ -6895,10 +7055,10 @@ msgstr "Nav iespējams noteikt faila '%s' formātu."
 msgid "The horizontal offset."
 msgstr "Iespējot vertikālo nobīdi."
 
-#: ../src/richtext/richtextindentspage.cpp:199
-#: ../src/richtext/richtextindentspage.cpp:201
 #: ../src/richtext/richtextliststylepage.cpp:385
 #: ../src/richtext/richtextliststylepage.cpp:387
+#: ../src/richtext/richtextindentspage.cpp:199
+#: ../src/richtext/richtextindentspage.cpp:201
 msgid "The left indent."
 msgstr "Atkāpe no kreisās malas."
 
@@ -6920,10 +7080,10 @@ msgstr "Kreisās malas papildinājuma lielums."
 msgid "The left position."
 msgstr "Tabulatora pozīcija."
 
-#: ../src/richtext/richtextindentspage.cpp:288
-#: ../src/richtext/richtextindentspage.cpp:290
 #: ../src/richtext/richtextliststylepage.cpp:462
 #: ../src/richtext/richtextliststylepage.cpp:464
+#: ../src/richtext/richtextindentspage.cpp:288
+#: ../src/richtext/richtextindentspage.cpp:290
 msgid "The line spacing."
 msgstr "Rindu atstarpe."
 
@@ -6932,7 +7092,7 @@ msgstr "Rindu atstarpe."
 msgid "The list item number."
 msgstr "Saraksta locekļa numurs."
 
-#: ../src/msw/ole/automtn.cpp:664
+#: ../src/msw/ole/automtn.cpp:655
 msgid "The locale ID is unknown."
 msgstr "Lokāles ID nav zināms."
 
@@ -6972,7 +7132,7 @@ msgstr "Objekta platums."
 msgid "The outline level."
 msgstr "Aprises līmenis."
 
-#: ../src/common/log.cpp:277
+#: ../src/common/log.cpp:296
 #, fuzzy, c-format
 msgid "The previous message repeated %u time."
 msgid_plural "The previous message repeated %u times."
@@ -6980,12 +7140,12 @@ msgstr[0] "Iepriekšējais paziņojums atkārtojās %lu reizi."
 msgstr[1] "Iepriekšējais paziņojums atkārtojās %lu reizes."
 msgstr[2] "Iepriekšējais paziņojums atkārtojās %lu reizes."
 
-#: ../src/common/log.cpp:270
+#: ../src/common/log.cpp:289
 msgid "The previous message repeated once."
 msgstr "Iepriekšējais paziņojums atkārtojās vienreiz."
 
-#: ../src/richtext/richtextsymboldlg.cpp:462
-#: ../src/richtext/richtextsymboldlg.cpp:464
+#: ../src/richtext/richtextsymboldlg.cpp:459
+#: ../src/richtext/richtextsymboldlg.cpp:461
 msgid "The range to show."
 msgstr "Rādāmais diapazons."
 
@@ -6999,15 +7159,15 @@ msgstr ""
 "informāciju,\n"
 "lūdzu, atķeksējiet tos un tie tiks aizvākti no atskaites.\n"
 
-#: ../src/common/cmdline.cpp:1254
+#: ../src/common/cmdline.cpp:1250
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "Nav norādīts nepieciešamais parametrs '%s'."
 
-#: ../src/richtext/richtextindentspage.cpp:217
-#: ../src/richtext/richtextindentspage.cpp:219
 #: ../src/richtext/richtextliststylepage.cpp:403
 #: ../src/richtext/richtextliststylepage.cpp:405
+#: ../src/richtext/richtextindentspage.cpp:217
+#: ../src/richtext/richtextindentspage.cpp:219
 msgid "The right indent."
 msgstr "Atkāpe no labās malas."
 
@@ -7050,16 +7210,16 @@ msgstr ""
 msgid "The shadow spread."
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:267
 #: ../src/richtext/richtextliststylepage.cpp:439
 #: ../src/richtext/richtextliststylepage.cpp:441
+#: ../src/richtext/richtextindentspage.cpp:267
 msgid "The spacing after the paragraph."
 msgstr "Atstarpe aiz rindkopas."
 
-#: ../src/richtext/richtextindentspage.cpp:257
-#: ../src/richtext/richtextindentspage.cpp:259
 #: ../src/richtext/richtextliststylepage.cpp:430
 #: ../src/richtext/richtextliststylepage.cpp:432
+#: ../src/richtext/richtextindentspage.cpp:257
+#: ../src/richtext/richtextindentspage.cpp:259
 msgid "The spacing before the paragraph."
 msgstr "Atstarpe pirms rindkopas."
 
@@ -7073,12 +7233,12 @@ msgstr "Stila nosaukums."
 msgid "The style on which this style is based."
 msgstr "Stils, kas ir šī stila pamatā."
 
-#: ../src/richtext/richtextstyledlg.cpp:214
-#: ../src/richtext/richtextstyledlg.cpp:216
+#: ../src/richtext/richtextstyledlg.cpp:210
+#: ../src/richtext/richtextstyledlg.cpp:212
 msgid "The style preview."
 msgstr "Stila priekšskatījums."
 
-#: ../src/msw/ole/automtn.cpp:680
+#: ../src/msw/ole/automtn.cpp:671
 msgid "The system cannot find the file specified."
 msgstr "Sistēma nespēja atrast norādīto failu."
 
@@ -7091,7 +7251,7 @@ msgstr "Tabulatora pozīcija."
 msgid "The tab positions."
 msgstr "Tabulatora pozīcijas."
 
-#: ../src/richtext/richtextctrl.cpp:3098
+#: ../src/richtext/richtextctrl.cpp:3099
 msgid "The text couldn't be saved."
 msgstr "Tekstu nav iespējams saglabāt."
 
@@ -7113,7 +7273,7 @@ msgstr "Augšējā papildinājuma lielums."
 msgid "The top position."
 msgstr "Tabulatora pozīcija."
 
-#: ../src/common/cmdline.cpp:1232
+#: ../src/common/cmdline.cpp:1228
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "Ir jānorāda iestatījuma '%s' vērtība."
@@ -7123,7 +7283,7 @@ msgstr "Ir jānorāda iestatījuma '%s' vērtība."
 msgid "The value of the corner radius."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:433
+#: ../src/msw/dialup.cpp:427
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -7138,12 +7298,12 @@ msgstr ""
 msgid "The vertical offset."
 msgstr "Iespējot vertikālo nobīdi."
 
-#: ../src/richtext/richtextprint.cpp:619 ../src/html/htmprint.cpp:745
+#: ../src/html/htmprint.cpp:749 ../src/richtext/richtextprint.cpp:615
 msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr "Kļūme lapas iestatījumos: iespējams, jānorāda noklusētais printeris."
 
-#: ../src/html/htmprint.cpp:255
+#: ../src/html/htmprint.cpp:267
 msgid ""
 "This document doesn't fit on the page horizontally and will be truncated "
 "when it is printed."
@@ -7151,16 +7311,16 @@ msgstr ""
 "Šis dokuments neietilpst lapā horizontālā virzienā un tādēļ drukājot tiks "
 "aprauts."
 
-#: ../src/common/image.cpp:2854
+#: ../src/common/image.cpp:2963
 #, c-format
 msgid "This is not a %s."
 msgstr "Šis nav %s."
 
-#: ../src/common/wincmn.cpp:1653
+#: ../src/common/wincmn.cpp:1654
 msgid "This platform does not support background transparency."
 msgstr "Šī platforma neuztur fona caurspīdīgumu."
 
-#: ../src/gtk/window.cpp:4660
+#: ../src/gtk/window.cpp:5664
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
@@ -7168,7 +7328,15 @@ msgstr ""
 "Šī programma ir kompilēta ar pārāk vecu GTK+ versiju, lūdzu, pārkompilējiet "
 "ar GTK+ 2.12 vai jaunāku."
 
-#: ../src/msw/thread.cpp:1240
+#: ../src/gtk/glcanvas.cpp:176
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/msw/thread.cpp:1246
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -7176,13 +7344,13 @@ msgstr ""
 "Kļūda inicializējot pavediena moduli: nav iespējams saglabāt vērtību "
 "pavediena lokālajā glabātuvē"
 
-#: ../src/unix/threadpsx.cpp:1794
+#: ../src/unix/threadpsx.cpp:1843
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 "Kļūda inicializējot pavediena moduli: nav iespējams izveidot pavediena "
 "atslēgu"
 
-#: ../src/msw/thread.cpp:1228
+#: ../src/msw/thread.cpp:1234
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -7190,80 +7358,80 @@ msgstr ""
 "Kļūda inicializējot pavediena moduli: nav iespējams piešķirt indeksu "
 "pavediena lokālajā glabātuvē"
 
-#: ../src/unix/threadpsx.cpp:1043
+#: ../src/unix/threadpsx.cpp:1061
 msgid "Thread priority setting is ignored."
 msgstr "Pavediena prioritātes iestatījums nav ņemts vērā."
 
-#: ../src/msw/mdi.cpp:176
+#: ../src/msw/mdi.cpp:171
 msgid "Tile &Horizontally"
 msgstr "Atspulgs pa &horizontāli"
 
-#: ../src/msw/mdi.cpp:177
+#: ../src/msw/mdi.cpp:172
 msgid "Tile &Vertically"
 msgstr "Atspulgs pa &vertikāli"
 
-#: ../src/common/ftp.cpp:200
+#: ../src/common/ftp.cpp:197
 msgid "Timeout while waiting for FTP server to connect, try passive mode."
 msgstr ""
 
-#: ../src/generic/tipdlg.cpp:201
+#: ../src/generic/tipdlg.cpp:198
 msgid "Tip of the Day"
 msgstr "Dienas padoms"
 
-#: ../src/generic/tipdlg.cpp:140
+#: ../src/generic/tipdlg.cpp:137
 msgid "Tips not available, sorry!"
 msgstr "Dienas padomi nav pieejami!"
 
-#: ../src/generic/prntdlgg.cpp:242
+#: ../src/generic/prntdlgg.cpp:235
 msgid "To:"
 msgstr "Saņēmējs:"
 
-#: ../src/richtext/richtextbuffer.cpp:8363
+#: ../src/richtext/richtextbuffer.cpp:8361
 msgid "Too many EndStyle calls!"
 msgstr "Par daudz EndStyle izsaukumu!"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:891
+#: ../src/propgrid/advprops.cpp:792
 msgid "Tooltip"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:892
+#: ../src/propgrid/advprops.cpp:793
 msgid "TooltipText"
 msgstr ""
 
-#: ../src/richtext/richtextsizepage.cpp:286
-#: ../src/richtext/richtextsizepage.cpp:290 ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197 ../src/richtext/richtextsizepage.cpp:286
+#: ../src/richtext/richtextsizepage.cpp:290
 msgid "Top"
 msgstr "Augša"
 
-#: ../src/generic/prntdlgg.cpp:881
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Top margin (mm):"
 msgstr "Augšējā mala (mm):"
 
-#: ../src/generic/aboutdlgg.cpp:79
+#: ../src/generic/aboutdlgg.cpp:76
 msgid "Translations by "
 msgstr "Tulkojumu autori -"
 
-#: ../src/generic/aboutdlgg.cpp:188
+#: ../src/generic/aboutdlgg.cpp:185
 msgid "Translators"
 msgstr "Tulkotāji"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:211
+#: ../src/propgrid/propgrid.cpp:192
 msgid "True"
 msgstr "Patiess"
 
-#: ../src/common/fs_mem.cpp:227
+#: ../src/common/fs_mem.cpp:222
 #, c-format
 msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
 msgstr "Mēģinājums aizvākt failu '%s' no atmiņas VFS, taču tas nav ielādēts!"
 
-#: ../src/common/fmapbase.cpp:156
+#: ../src/common/fmapbase.cpp:153
 msgid "Turkish (ISO-8859-9)"
 msgstr "Turku (ISO-8859-9)"
 
-#: ../src/generic/filectrlg.cpp:426
+#: ../src/generic/filectrlg.cpp:422
 msgid "Type"
 msgstr "Tips"
 
@@ -7277,17 +7445,17 @@ msgstr "Ierakstiet fonta nosaukumu."
 msgid "Type a size in points."
 msgstr "Ierakstiet izmēru punktos."
 
-#: ../src/msw/ole/automtn.cpp:676
+#: ../src/msw/ole/automtn.cpp:667
 #, c-format
 msgid "Type mismatch in argument %u."
 msgstr "Tipu neatbilstība argumentā %u."
 
-#: ../src/common/xtixml.cpp:356 ../src/common/xtixml.cpp:509
-#: ../src/common/xtistrm.cpp:318
+#: ../src/common/xtixml.cpp:352 ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315
 msgid "Type must have enum - long conversion"
 msgstr ""
 
-#: ../src/propgrid/propgridiface.cpp:401
+#: ../src/propgrid/propgridiface.cpp:385
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
@@ -7296,19 +7464,19 @@ msgstr ""
 "Tipu operācijas \"%s\" kļūda: īpašības ar apzīmējumu \"%s\" tips ir \"%s\", "
 "NEVIS \"%s\"."
 
-#: ../src/common/paper.cpp:133
+#: ../src/common/paper.cpp:130
 msgid "US Std Fanfold, 14 7/8 x 11 in"
 msgstr "US Std Fanfold, 14 7/8 x 11 in"
 
-#: ../src/common/fmapbase.cpp:196
+#: ../src/common/fmapbase.cpp:193
 msgid "US-ASCII"
 msgstr "US-ASCII"
 
-#: ../src/unix/fswatcher_inotify.cpp:109
+#: ../src/unix/fswatcher_inotify.cpp:106
 msgid "Unable to add inotify watch"
 msgstr ""
 
-#: ../src/unix/fswatcher_kqueue.cpp:136
+#: ../src/unix/fswatcher_kqueue.cpp:153
 msgid "Unable to add kqueue watch"
 msgstr ""
 
@@ -7320,7 +7488,7 @@ msgstr ""
 msgid "Unable to close I/O completion port handle"
 msgstr ""
 
-#: ../src/unix/fswatcher_inotify.cpp:97
+#: ../src/unix/fswatcher_inotify.cpp:94
 msgid "Unable to close inotify instance"
 msgstr ""
 
@@ -7338,15 +7506,15 @@ msgstr ""
 msgid "Unable to create I/O completion port"
 msgstr ""
 
-#: ../src/msw/fswatcher.cpp:84
+#: ../src/msw/fswatcher.cpp:81
 msgid "Unable to create IOCP worker thread"
 msgstr ""
 
-#: ../src/unix/fswatcher_inotify.cpp:74
+#: ../src/unix/fswatcher_inotify.cpp:71
 msgid "Unable to create inotify instance"
 msgstr ""
 
-#: ../src/unix/fswatcher_kqueue.cpp:97
+#: ../src/unix/fswatcher_kqueue.cpp:114
 msgid "Unable to create kqueue instance"
 msgstr ""
 
@@ -7354,11 +7522,11 @@ msgstr ""
 msgid "Unable to dequeue completion packet"
 msgstr ""
 
-#: ../src/unix/fswatcher_kqueue.cpp:185
+#: ../src/unix/fswatcher_kqueue.cpp:202
 msgid "Unable to get events from kqueue"
 msgstr ""
 
-#: ../src/gtk/app.cpp:435
+#: ../src/gtk/app.cpp:431
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr ""
 "Nav iespējams inicializēt GTK+, vai DISPLAY parametrs ir iestatīts pareizi?"
@@ -7368,12 +7536,12 @@ msgstr ""
 msgid "Unable to open path '%s'"
 msgstr "Neizdevās atvērt ceļu  '%s'"
 
-#: ../src/html/htmlwin.cpp:583
+#: ../src/html/htmlwin.cpp:586
 #, c-format
 msgid "Unable to open requested HTML document: %s"
 msgstr "Nav iespējams atvērt pieprasīto HTML dokumentu: %s"
 
-#: ../src/unix/sound.cpp:368
+#: ../src/unix/sound.cpp:365
 msgid "Unable to play sound asynchronously."
 msgstr "Nav iespējams atskaņot skaņu asinhroni."
 
@@ -7381,61 +7549,61 @@ msgstr "Nav iespējams atskaņot skaņu asinhroni."
 msgid "Unable to post completion status"
 msgstr ""
 
-#: ../src/unix/fswatcher_inotify.cpp:556
+#: ../src/unix/fswatcher_inotify.cpp:553
 msgid "Unable to read from inotify descriptor"
 msgstr ""
 
-#: ../src/unix/fswatcher_inotify.cpp:141
+#: ../src/unix/fswatcher_inotify.cpp:138
 #, fuzzy, c-format
 msgid "Unable to remove inotify watch %i"
 msgstr "Neizdevās atvērt ceļu  '%s'"
 
-#: ../src/unix/fswatcher_kqueue.cpp:153
+#: ../src/unix/fswatcher_kqueue.cpp:170
 msgid "Unable to remove kqueue watch"
 msgstr ""
 
-#: ../src/msw/fswatcher.cpp:168
+#: ../src/msw/fswatcher.cpp:165
 #, c-format
 msgid "Unable to set up watch for '%s'"
 msgstr ""
 
-#: ../src/msw/fswatcher.cpp:91
+#: ../src/msw/fswatcher.cpp:88
 msgid "Unable to start IOCP worker thread"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:201
+#: ../src/common/stockitem.cpp:198
 msgid "Undelete"
 msgstr "Atjaunot"
 
-#: ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199
 msgid "Underline"
 msgstr "Pasvītrot"
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/richtext/richtextfontpage.cpp:359 ../src/osx/carbon/fontdlg.cpp:370
-#: ../src/propgrid/advprops.cpp:690
+#: ../src/osx/carbon/fontdlg.cpp:367 ../src/propgrid/advprops.cpp:600
+#: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Pasvītrots"
 
-#: ../src/common/stockitem.cpp:203 ../src/stc/stc_i18n.cpp:15
+#: ../src/common/stockitem.cpp:200 ../src/stc/stc_i18n.cpp:15
 msgid "Undo"
 msgstr "Atsaukt"
 
-#: ../src/common/stockitem.cpp:265
+#: ../src/common/stockitem.cpp:263
 msgid "Undo last action"
 msgstr "Atsaukt pēdējo darbību"
 
-#: ../src/common/cmdline.cpp:1029
+#: ../src/common/cmdline.cpp:1025
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Negaidīti simboli aiz iestatījuma '%s'."
 
-#: ../src/unix/fswatcher_inotify.cpp:274
+#: ../src/unix/fswatcher_inotify.cpp:271
 #, c-format
 msgid "Unexpected event for \"%s\": no matching watch descriptor."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1195
+#: ../src/common/cmdline.cpp:1191
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Negaidīts parametrs '%s'"
@@ -7444,49 +7612,49 @@ msgstr "Negaidīts parametrs '%s'"
 msgid "Unexpectedly new I/O completion port was created"
 msgstr ""
 
-#: ../src/msw/fswatcher.cpp:70
+#: ../src/msw/fswatcher.cpp:67
 msgid "Ungraceful worker thread termination"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:460
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:456
+#: ../src/richtext/richtextsymboldlg.cpp:457
+#: ../src/richtext/richtextsymboldlg.cpp:458
 msgid "Unicode"
 msgstr "Unikods"
 
-#: ../src/common/fmapbase.cpp:185 ../src/common/fmapbase.cpp:191
+#: ../src/common/fmapbase.cpp:182 ../src/common/fmapbase.cpp:188
 msgid "Unicode 16 bit (UTF-16)"
 msgstr "Unikods 16 bit (UTF-16)"
 
-#: ../src/common/fmapbase.cpp:190
+#: ../src/common/fmapbase.cpp:187
 msgid "Unicode 16 bit Big Endian (UTF-16BE)"
 msgstr "Unikods 16 bit Big Endian (UTF-16BE)"
 
-#: ../src/common/fmapbase.cpp:186
+#: ../src/common/fmapbase.cpp:183
 msgid "Unicode 16 bit Little Endian (UTF-16LE)"
 msgstr "Unikods 16 bit Little Endian (UTF-16LE)"
 
-#: ../src/common/fmapbase.cpp:187 ../src/common/fmapbase.cpp:193
+#: ../src/common/fmapbase.cpp:184 ../src/common/fmapbase.cpp:190
 msgid "Unicode 32 bit (UTF-32)"
 msgstr "Unikods 32 bit (UTF-32)"
 
-#: ../src/common/fmapbase.cpp:192
+#: ../src/common/fmapbase.cpp:189
 msgid "Unicode 32 bit Big Endian (UTF-32BE)"
 msgstr "Unikods 32 bit Big Endian (UTF-32BE)"
 
-#: ../src/common/fmapbase.cpp:188
+#: ../src/common/fmapbase.cpp:185
 msgid "Unicode 32 bit Little Endian (UTF-32LE)"
 msgstr "Unikods 32 bit Little Endian (UTF-32LE)"
 
-#: ../src/common/fmapbase.cpp:182
+#: ../src/common/fmapbase.cpp:179
 msgid "Unicode 7 bit (UTF-7)"
 msgstr "Unikods 7 bit (UTF-7)"
 
-#: ../src/common/fmapbase.cpp:183
+#: ../src/common/fmapbase.cpp:180
 msgid "Unicode 8 bit (UTF-8)"
 msgstr "Unikods 8 bit (UTF-8)"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "Unindent"
 msgstr "Samazināt atkāpi"
 
@@ -7642,97 +7810,102 @@ msgstr "Vienības augšējam papildinājumam."
 msgid "Units for this value."
 msgstr "Vienības kreisajai malai."
 
-#: ../src/generic/progdlgg.cpp:353 ../src/generic/progdlgg.cpp:622
+#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
 msgid "Unknown"
 msgstr "Nezināms"
 
-#: ../src/msw/dde.cpp:1174
+#: ../src/msw/dde.cpp:1238
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Nezināma DDE kļūda %08x"
 
-#: ../src/common/xtistrm.cpp:410
+#: ../src/common/xtistrm.cpp:407
 msgid "Unknown Object passed to GetObjectClassInfo"
 msgstr "GetObjectClassInfo nodots nezināms objekts"
 
-#: ../src/common/imagpng.cpp:366
+#: ../src/common/imagpng.cpp:383
 #, c-format
 msgid "Unknown PNG resolution unit %d"
 msgstr "Nezināma PNG izšķirtspējas vienība %d"
 
-#: ../src/common/xtixml.cpp:327
+#: ../src/common/xtixml.cpp:323
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Nezināma īpašība %s"
 
-#: ../src/common/imagtiff.cpp:529
+#: ../src/common/imagtiff.cpp:526
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "Nav ņemta vērā nezināma TIFF izšķirtspējas vienība %d"
 
-#: ../src/unix/dlunix.cpp:160
+#: ../src/propgrid/props.cpp:155
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/unix/dlunix.cpp:118
 msgid "Unknown dynamic library error"
 msgstr "Nezināma dinamiskās bibliotēkas kļūda"
 
-#: ../src/common/fmapbase.cpp:810
+#: ../src/common/fmapbase.cpp:806
 #, c-format
 msgid "Unknown encoding (%d)"
 msgstr "Nezināms kodējums (%d)"
 
-#: ../src/msw/ole/automtn.cpp:688
+#: ../src/msw/ole/automtn.cpp:679
 #, c-format
 msgid "Unknown error %08x"
 msgstr "Nezināma kļūda %08x"
 
-#: ../src/msw/ole/automtn.cpp:647
+#: ../src/msw/ole/automtn.cpp:638
 msgid "Unknown exception"
 msgstr "Nezināma izņēmuma situācija"
 
-#: ../src/common/image.cpp:2839
+#: ../src/common/image.cpp:2942
 msgid "Unknown image data format."
 msgstr "Nezinām attēla datu formāts."
 
-#: ../src/common/cmdline.cpp:914
+#: ../src/common/cmdline.cpp:910
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Nezināma garā opcija '%s'"
 
-#: ../src/msw/ole/automtn.cpp:631
+#: ../src/msw/ole/automtn.cpp:622
 msgid "Unknown name or named argument."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:929 ../src/common/cmdline.cpp:951
+#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Nezināma opcija '%s'"
 
-#: ../src/common/mimecmn.cpp:225
+#: ../src/common/mimecmn.cpp:221
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "Nenoslēgta '{' MIME tipa %s ierakstā."
 
-#: ../src/common/cmdproc.cpp:262 ../src/common/cmdproc.cpp:288
-#: ../src/common/cmdproc.cpp:308
+#: ../src/common/cmdproc.cpp:255 ../src/common/cmdproc.cpp:281
+#: ../src/common/cmdproc.cpp:301
 msgid "Unnamed command"
 msgstr "Nenosaukta komanda"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:413
+#: ../src/propgrid/propgrid.cpp:392
 msgid "Unspecified"
 msgstr "Nenorādīts"
 
-#: ../src/msw/clipbrd.cpp:311
+#: ../src/msw/clipbrd.cpp:325
 msgid "Unsupported clipboard format."
 msgstr "Neatbalstīts starpliktuves formāts."
 
-#: ../src/common/appcmn.cpp:256
+#: ../src/common/appcmn.cpp:277
 #, c-format
 msgid "Unsupported theme '%s'."
 msgstr "Neatbalstīta tēma '%s'."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:205
-#: ../src/common/accelcmn.cpp:63
+#: ../src/common/stockitem.cpp:202 ../src/common/accelcmn.cpp:60
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Up"
 msgstr "Uz augšu"
 
@@ -7746,7 +7919,7 @@ msgstr "Lieli burti"
 msgid "Upper case roman numerals"
 msgstr "Romiešu cipari ar lielajiem burtiem."
 
-#: ../src/common/cmdline.cpp:1326
+#: ../src/common/cmdline.cpp:1322
 #, c-format
 msgid "Usage: %s"
 msgstr "Lietošana: %s"
@@ -7755,38 +7928,47 @@ msgstr "Lietošana: %s"
 msgid "Use &shadow"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:169
-#: ../src/richtext/richtextindentspage.cpp:171
 #: ../src/richtext/richtextliststylepage.cpp:358
 #: ../src/richtext/richtextliststylepage.cpp:360
+#: ../src/richtext/richtextindentspage.cpp:169
+#: ../src/richtext/richtextindentspage.cpp:171
 msgid "Use the current alignment setting."
 msgstr "Izmantot pašreizējo izlīdzināšanas iestatījumu."
 
-#: ../src/common/valtext.cpp:179
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/gtk/font.cpp:552
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/common/valtext.cpp:142
 msgid "Validation conflict"
 msgstr "Pārbaudes konflikts"
 
-#: ../src/propgrid/manager.cpp:238
+#: ../src/propgrid/manager.cpp:224
 msgid "Value"
 msgstr "Vērtība"
 
-#: ../src/propgrid/props.cpp:386 ../src/propgrid/props.cpp:500
+#: ../src/propgrid/props.cpp:309
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "Vērtībai jābūt vienādai ar %s vai lielākai."
 
-#: ../src/propgrid/props.cpp:417 ../src/propgrid/props.cpp:531
+#: ../src/propgrid/props.cpp:336
 #, c-format
 msgid "Value must be %s or less."
 msgstr "Vērtībai jābūt vienādai ar %s vai mazākai."
 
-#: ../src/propgrid/props.cpp:393 ../src/propgrid/props.cpp:424
-#: ../src/propgrid/props.cpp:507 ../src/propgrid/props.cpp:538
+#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "Leņķim jābūt starp %s un %s."
 
-#: ../src/generic/aboutdlgg.cpp:128
+#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Versija"
 
@@ -7795,25 +7977,32 @@ msgstr "Versija"
 msgid "Vertical alignment."
 msgstr "Vertikālais izlīdzinājums"
 
-#: ../src/generic/filedlgg.cpp:202
+#: ../src/generic/filedlgg.cpp:199
 msgid "View files as a detailed view"
 msgstr "Aplūkot failus detalizētajā skatā"
 
-#: ../src/generic/filedlgg.cpp:200
+#: ../src/generic/filedlgg.cpp:197
 msgid "View files as a list view"
 msgstr "Aplūkot failus saraksta skatā"
 
-#: ../src/common/docview.cpp:1970
+#: ../src/common/docview.cpp:1975
 msgid "Views"
 msgstr "Skati"
 
+#: ../src/gtk/app.cpp:348
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1777
+#: ../src/propgrid/advprops.cpp:1678
 msgid "Wait"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1779
+#: ../src/propgrid/advprops.cpp:1680
 msgid "Wait Arrow"
 msgstr ""
 
@@ -7822,246 +8011,243 @@ msgstr ""
 msgid "Waiting for IO on epoll descriptor %d failed"
 msgstr ""
 
-#: ../src/common/log.cpp:223
+#: ../src/common/log.cpp:241
 msgid "Warning: "
 msgstr "Brīdinājums: "
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1778
+#: ../src/propgrid/advprops.cpp:1679
 msgid "Watch"
 msgstr ""
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:685
+#: ../src/propgrid/advprops.cpp:595
 msgid "Weight"
 msgstr "Svars"
 
-#: ../src/common/fmapbase.cpp:148
+#: ../src/common/fmapbase.cpp:145
 msgid "Western European (ISO-8859-1)"
 msgstr "Rietumeiropas (ISO-8859-1)"
 
-#: ../src/common/fmapbase.cpp:162
+#: ../src/common/fmapbase.cpp:159
 msgid "Western European with Euro (ISO-8859-15)"
 msgstr "Rietumeiropas ar Eiro (ISO-8859-15)"
 
-#: ../src/generic/fontdlgg.cpp:446 ../src/generic/fontdlgg.cpp:448
+#: ../src/generic/fontdlgg.cpp:443 ../src/generic/fontdlgg.cpp:445
 msgid "Whether the font is underlined."
 msgstr "Vai fonts ir pasvītrots."
 
-#: ../src/propgrid/advprops.cpp:1611
+#: ../src/propgrid/advprops.cpp:1517
 msgid "White"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:144
+#: ../src/generic/fdrepdlg.cpp:141
 msgid "Whole word"
 msgstr "Viss vārds"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:532
 msgid "Whole words only"
 msgstr "Tikai veselus vārdus"
 
-#: ../src/univ/themes/win32.cpp:1102
+#: ../src/univ/themes/win32.cpp:1099
 msgid "Win32 theme"
 msgstr "Win32 tēma"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:893
+#: ../src/propgrid/advprops.cpp:794
 #, fuzzy
 msgid "Window"
 msgstr "&Logs"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:894
+#: ../src/propgrid/advprops.cpp:795
 #, fuzzy
 msgid "WindowFrame"
 msgstr "&Logs"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:895
+#: ../src/propgrid/advprops.cpp:796
 #, fuzzy
 msgid "WindowText"
 msgstr "&Logs"
 
-#: ../src/common/fmapbase.cpp:177
+#: ../src/common/fmapbase.cpp:174
 msgid "Windows Arabic (CP 1256)"
 msgstr "Windows Arābu (CP 1256)"
 
-#: ../src/common/fmapbase.cpp:178
+#: ../src/common/fmapbase.cpp:175
 msgid "Windows Baltic (CP 1257)"
 msgstr "Windows Baltijas (CP 1257)"
 
-#: ../src/common/fmapbase.cpp:171
+#: ../src/common/fmapbase.cpp:168
 msgid "Windows Central European (CP 1250)"
 msgstr "Windows Centrāleiropas (CP 1250)"
 
-#: ../src/common/fmapbase.cpp:168
+#: ../src/common/fmapbase.cpp:165
 msgid "Windows Chinese Simplified (CP 936) or GB-2312"
 msgstr "Windows Ķīnas vienkāršotais (CP 936) or GB-2312"
 
-#: ../src/common/fmapbase.cpp:170
+#: ../src/common/fmapbase.cpp:167
 msgid "Windows Chinese Traditional (CP 950) or Big-5"
 msgstr "Windows Ķīnas tradicionālais (CP 950) or Big-5"
 
-#: ../src/common/fmapbase.cpp:172
+#: ../src/common/fmapbase.cpp:169
 msgid "Windows Cyrillic (CP 1251)"
 msgstr "Windows Kirilica (CP 1251)"
 
-#: ../src/common/fmapbase.cpp:174
+#: ../src/common/fmapbase.cpp:171
 msgid "Windows Greek (CP 1253)"
 msgstr "Windows Grieķu (CP 1253)"
 
-#: ../src/common/fmapbase.cpp:176
+#: ../src/common/fmapbase.cpp:173
 msgid "Windows Hebrew (CP 1255)"
 msgstr "Windows Ebreju (CP 1255)"
 
-#: ../src/common/fmapbase.cpp:167
+#: ../src/common/fmapbase.cpp:164
 msgid "Windows Japanese (CP 932) or Shift-JIS"
 msgstr "Windows Japāņu (CP 932) va8i Shift-JIS"
 
-#: ../src/common/fmapbase.cpp:180
+#: ../src/common/fmapbase.cpp:177
 #, fuzzy
 msgid "Windows Johab (CP 1361)"
 msgstr "Windows Arābu (CP 1256)"
 
-#: ../src/common/fmapbase.cpp:169
+#: ../src/common/fmapbase.cpp:166
 msgid "Windows Korean (CP 949)"
 msgstr "Windows Korean (CP 949)"
 
-#: ../src/common/fmapbase.cpp:166
+#: ../src/common/fmapbase.cpp:163
 msgid "Windows Thai (CP 874)"
 msgstr "Windows Taju (CP 874)"
 
-#: ../src/common/fmapbase.cpp:175
+#: ../src/common/fmapbase.cpp:172
 msgid "Windows Turkish (CP 1254)"
 msgstr "Windows Turku (CP 1254)"
 
-#: ../src/common/fmapbase.cpp:179
+#: ../src/common/fmapbase.cpp:176
 #, fuzzy
 msgid "Windows Vietnamese (CP 1258)"
 msgstr "Windows Grieķu (CP 1253)"
 
-#: ../src/common/fmapbase.cpp:173
+#: ../src/common/fmapbase.cpp:170
 msgid "Windows Western European (CP 1252)"
 msgstr "Windows Rietumeiropas (CP 1252)"
 
-#: ../src/common/fmapbase.cpp:181
+#: ../src/common/fmapbase.cpp:178
 msgid "Windows/DOS OEM (CP 437)"
 msgstr "Windows/DOS OEM (CP 437)"
 
-#: ../src/common/fmapbase.cpp:165
+#: ../src/common/fmapbase.cpp:162
 msgid "Windows/DOS OEM Cyrillic (CP 866)"
 msgstr "Windows/DOS OEM Kirilica (CP 866)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:111
+#: ../src/common/accelcmn.cpp:109
 #, fuzzy
 msgid "Windows_Left"
 msgstr "Windows 7"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:113
+#: ../src/common/accelcmn.cpp:111
 #, fuzzy
 msgid "Windows_Menu"
 msgstr "Windows ME"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:112
+#: ../src/common/accelcmn.cpp:110
 #, fuzzy
 msgid "Windows_Right"
 msgstr "Windows Vista"
 
-#: ../src/common/ffile.cpp:150
+#: ../src/common/ffile.cpp:149
 #, c-format
 msgid "Write error on file '%s'"
 msgstr "Rakstīšanas kļūda failā '%s'"
 
-#: ../src/xml/xml.cpp:914
+#: ../src/xml/xml.cpp:925
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr ""
 
-#: ../src/common/xpmdecod.cpp:796
+#: ../src/common/xpmdecod.cpp:794
 msgid "XPM: Malformed pixel data!"
 msgstr "XPM: nepareizi pikseļu dati!"
 
-#: ../src/common/xpmdecod.cpp:705
+#: ../src/common/xpmdecod.cpp:702
 #, c-format
 msgid "XPM: incorrect colour description in line %d"
 msgstr "XPM: nepareizs krāsas apraksts rindā %d"
 
-#: ../src/common/xpmdecod.cpp:680
+#: ../src/common/xpmdecod.cpp:677
 msgid "XPM: incorrect header format!"
 msgstr "XPM: nepareizs galvenes formāts!"
 
-#: ../src/common/xpmdecod.cpp:716 ../src/common/xpmdecod.cpp:725
+#: ../src/common/xpmdecod.cpp:714 ../src/common/xpmdecod.cpp:723
 #, c-format
 msgid "XPM: malformed colour definition '%s' at line %d!"
 msgstr "XPM: kļūdaina krāsa definīcija '%s' rindā %d!"
 
-#: ../src/common/xpmdecod.cpp:755
+#: ../src/common/xpmdecod.cpp:753
 msgid "XPM: no colors left to use for mask!"
 msgstr "XPM: nav atlikusi neviena maskai izmantojam krāsa!"
 
-#: ../src/common/xpmdecod.cpp:782
+#: ../src/common/xpmdecod.cpp:780
 #, c-format
 msgid "XPM: truncated image data at line %d!"
 msgstr "XPM: aprauti attēla dati rindā %d!"
 
-#: ../src/propgrid/advprops.cpp:1610
+#: ../src/propgrid/advprops.cpp:1516
 msgid "Yellow"
 msgstr ""
 
-#: ../include/wx/msgdlg.h:276 ../src/common/stockitem.cpp:206
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:203
 #: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Jā"
 
-#: ../src/osx/carbon/overlay.cpp:155
-msgid "You cannot Clear an overlay that is not inited"
-msgstr ""
-
-#: ../src/osx/carbon/overlay.cpp:107 ../src/dfb/overlay.cpp:61
-msgid "You cannot Init an overlay twice"
-msgstr ""
-
-#: ../src/generic/dirdlgg.cpp:287
+#: ../src/generic/dirdlgg.cpp:284
 msgid "You cannot add a new directory to this section."
 msgstr "Jūs nevarat pievienot jaunu mapi šai sekcijai."
 
-#: ../src/propgrid/propgrid.cpp:3299
+#: ../src/propgrid/propgrid.cpp:3276
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 "Jūs ievadījāt nederīgu vērtību. Nospiediet ESC, lai pārtauktu labošanu."
 
-#: ../src/common/stockitem.cpp:209
+#: ../src/osx/cocoa/menu.mm:286
+#, fuzzy
+msgid "Zoom"
+msgstr "Tuvināt"
+
+#: ../src/common/stockitem.cpp:206
 msgid "Zoom &In"
 msgstr "Pa&lielināt"
 
-#: ../src/common/stockitem.cpp:210
+#: ../src/common/stockitem.cpp:207
 msgid "Zoom &Out"
 msgstr "Sa&mazināt"
 
-#: ../src/common/stockitem.cpp:209 ../src/common/prntbase.cpp:1594
+#: ../src/common/stockitem.cpp:206 ../src/common/prntbase.cpp:1619
 msgid "Zoom In"
 msgstr "Tuvināt"
 
-#: ../src/common/stockitem.cpp:210 ../src/common/prntbase.cpp:1580
+#: ../src/common/stockitem.cpp:207 ../src/common/prntbase.cpp:1605
 msgid "Zoom Out"
 msgstr "Attālināt"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to &Fit"
 msgstr "Ietilpināt attēlu"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to Fit"
 msgstr "Ietilpināt"
 
-#: ../src/msw/dde.cpp:1141
+#: ../src/msw/dde.cpp:1205
 msgid "a DDEML application has created a prolonged race condition."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1129
+#: ../src/msw/dde.cpp:1193
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -8069,54 +8255,54 @@ msgid ""
 "was passed to a DDEML function."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1147
+#: ../src/msw/dde.cpp:1211
 msgid "a client's attempt to establish a conversation has failed."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1144
+#: ../src/msw/dde.cpp:1208
 msgid "a memory allocation failed."
 msgstr "atmiņas izdalīšanas kļūda."
 
-#: ../src/msw/dde.cpp:1138
+#: ../src/msw/dde.cpp:1202
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "DDEML neapstiprināja parametru."
 
-#: ../src/msw/dde.cpp:1120
+#: ../src/msw/dde.cpp:1184
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1126
+#: ../src/msw/dde.cpp:1190
 msgid "a request for a synchronous data transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1135
+#: ../src/msw/dde.cpp:1199
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1153
+#: ../src/msw/dde.cpp:1217
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1168
+#: ../src/msw/dde.cpp:1232
 msgid "a request to end an advise transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1162
+#: ../src/msw/dde.cpp:1226
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
 "terminated before completing a transaction."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1150
+#: ../src/msw/dde.cpp:1214
 msgid "a transaction failed."
 msgstr "transakcija neizdevās."
 
-#: ../src/common/accelcmn.cpp:189
+#: ../src/common/accelcmn.cpp:188
 msgid "alt"
 msgstr "alt"
 
-#: ../src/msw/dde.cpp:1132
+#: ../src/msw/dde.cpp:1196
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -8124,71 +8310,71 @@ msgid ""
 "attempted to perform server transactions."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1156
+#: ../src/msw/dde.cpp:1220
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "iekšējais funkcijas PostMessage izsaukums neizdevās."
 
-#: ../src/msw/dde.cpp:1165
+#: ../src/msw/dde.cpp:1229
 msgid "an internal error has occurred in the DDEML."
 msgstr "DDEML radās iekšēja kļuda."
 
-#: ../src/msw/dde.cpp:1171
+#: ../src/msw/dde.cpp:1235
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
 "the transaction identifier for that callback is no longer valid."
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1483
+#: ../src/common/zipstrm.cpp:1522
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "pieņemot, ka tas ir apvienots vairāku daļu zip"
 
-#: ../src/common/fileconf.cpp:1847
+#: ../src/common/fileconf.cpp:1849
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "mēģinājums mainīt nemainīgu atslēgu '%s' nav ņemts vērā."
 
-#: ../src/html/chm.cpp:329
+#: ../src/html/chm.cpp:326
 msgid "bad arguments to library function"
 msgstr "bibliotēkas funkcijai nederīgi argumenti"
 
-#: ../src/html/chm.cpp:341
+#: ../src/html/chm.cpp:338
 msgid "bad signature"
 msgstr "nederīgs paraksts"
 
-#: ../src/common/zipstrm.cpp:1918
+#: ../src/common/zipstrm.cpp:1988
 msgid "bad zipfile offset to entry"
 msgstr ""
 
-#: ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400
 msgid "binary"
 msgstr "binārs"
 
-#: ../src/common/fontcmn.cpp:996
+#: ../src/common/fontcmn.cpp:1195
 msgid "bold"
 msgstr "treknraksts"
 
-#: ../src/msw/utils.cpp:1144
+#: ../src/msw/utils.cpp:1135
 #, c-format
 msgid "build %lu"
 msgstr "versija %lu"
 
-#: ../src/common/ffile.cpp:75
+#: ../src/common/ffile.cpp:73
 #, c-format
 msgid "can't close file '%s'"
 msgstr "nevar aizvērt failu '%s'"
 
-#: ../src/common/file.cpp:245
+#: ../src/common/file.cpp:242
 #, c-format
 msgid "can't close file descriptor %d"
 msgstr ""
 
-#: ../src/common/file.cpp:586
+#: ../src/common/ffile.cpp:382 ../src/common/file.cpp:613
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "failā '%s' nav iespējams saglabāt izmaiņas"
 
-#: ../src/common/file.cpp:178
+#: ../src/common/file.cpp:175
 #, c-format
 msgid "can't create file '%s'"
 msgstr "nevar izdzēst failu '%s'"
@@ -8198,49 +8384,49 @@ msgstr "nevar izdzēst failu '%s'"
 msgid "can't delete user configuration file '%s'"
 msgstr "nevar izdzēst lietotāja konfigurācijas failu '%s'"
 
-#: ../src/common/file.cpp:495
+#: ../src/common/file.cpp:522
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1692
+#: ../src/common/zipstrm.cpp:1747
 msgid "can't find central directory in zip"
 msgstr "nav iespējams atrast galveno zip mapi"
 
-#: ../src/common/file.cpp:465
+#: ../src/common/file.cpp:492
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr ""
 
-#: ../src/msw/utils.cpp:341
+#: ../src/msw/utils.cpp:336
 msgid "can't find user's HOME, using current directory."
 msgstr "lietotāja mājas mape nav atrodama, izmanto pašreizējo mapi."
 
-#: ../src/common/file.cpp:366
+#: ../src/common/file.cpp:407
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr ""
 
-#: ../src/common/file.cpp:422
+#: ../src/common/file.cpp:463
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr ""
 
-#: ../src/common/fontmap.cpp:325
+#: ../src/common/fontmap.cpp:322
 msgid "can't load any font, aborting"
 msgstr "nav iespējams ielādēt nevienu fontu, pārtrauc darbu"
 
-#: ../src/common/file.cpp:231 ../src/common/ffile.cpp:59
+#: ../src/common/ffile.cpp:57 ../src/common/file.cpp:228
 #, c-format
 msgid "can't open file '%s'"
 msgstr "nevar atvērt failu '%s'"
 
-#: ../src/common/fileconf.cpp:320
+#: ../src/common/fileconf.cpp:314
 #, c-format
 msgid "can't open global configuration file '%s'."
 msgstr "nevar atvērt globālo konfigurācijas failu '%s'."
 
-#: ../src/common/fileconf.cpp:336
+#: ../src/common/fileconf.cpp:330
 #, c-format
 msgid "can't open user configuration file '%s'."
 msgstr "nevar atvērt lietotāja konfigurācijas failu '%s'."
@@ -8249,40 +8435,40 @@ msgstr "nevar atvērt lietotāja konfigurācijas failu '%s'."
 msgid "can't open user configuration file."
 msgstr "nevar atvērt lietotāja konfigurācijas failu."
 
-#: ../src/common/zipstrm.cpp:579
+#: ../src/common/zipstrm.cpp:572
 msgid "can't re-initialize zlib deflate stream"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:604
+#: ../src/common/zipstrm.cpp:597
 msgid "can't re-initialize zlib inflate stream"
 msgstr ""
 
-#: ../src/common/file.cpp:304
+#: ../src/common/file.cpp:345
 #, c-format
 msgid "can't read from file descriptor %d"
 msgstr ""
 
-#: ../src/common/file.cpp:581
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:608
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "nevar nodzēst failu '%s'"
 
-#: ../src/common/file.cpp:598
+#: ../src/common/ffile.cpp:394 ../src/common/file.cpp:625
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "nevar nodzēst pagaidu failu '%s'"
 
-#: ../src/common/file.cpp:408
+#: ../src/common/file.cpp:449
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr ""
 
-#: ../src/common/textfile.cpp:273
+#: ../src/common/textfile.cpp:161
 #, c-format
 msgid "can't write buffer '%s' to disk."
 msgstr "nevar ierakstīt bufera '%s' saturu diskā."
 
-#: ../src/common/file.cpp:323
+#: ../src/common/file.cpp:364
 #, c-format
 msgid "can't write to file descriptor %d"
 msgstr ""
@@ -8292,22 +8478,28 @@ msgid "can't write user configuration file."
 msgstr "nevar pierakstīt lietotāja konfigurācijas failu."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:482 ../src/generic/datavgen.cpp:1261
+#: ../src/common/datavcmn.cpp:2064 ../src/generic/datavgen.cpp:1384
 msgid "checked"
 msgstr ""
 
-#: ../src/html/chm.cpp:345
+#: ../src/html/chm.cpp:342
 msgid "checksum error"
 msgstr "kļūda kontrolsummā"
 
-#: ../src/common/tarstrm.cpp:820
+#: ../src/common/tarstrm.cpp:814
 msgid "checksum failure reading tar header block"
 msgstr ""
 
-#: ../src/richtext/richtextbackgroundpage.cpp:226
-#: ../src/richtext/richtextbackgroundpage.cpp:249
-#: ../src/richtext/richtextbackgroundpage.cpp:289
-#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
 #: ../src/richtext/richtextborderspage.cpp:254
 #: ../src/richtext/richtextborderspage.cpp:288
 #: ../src/richtext/richtextborderspage.cpp:322
@@ -8325,105 +8517,128 @@ msgstr ""
 #: ../src/richtext/richtextmarginspage.cpp:340
 #: ../src/richtext/richtextmarginspage.cpp:363
 #: ../src/richtext/richtextmarginspage.cpp:388
-#: ../src/richtext/richtextsizepage.cpp:339
-#: ../src/richtext/richtextsizepage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:400
-#: ../src/richtext/richtextsizepage.cpp:427
-#: ../src/richtext/richtextsizepage.cpp:454
-#: ../src/richtext/richtextsizepage.cpp:481
-#: ../src/richtext/richtextsizepage.cpp:555
-#: ../src/richtext/richtextsizepage.cpp:590
-#: ../src/richtext/richtextsizepage.cpp:625
-#: ../src/richtext/richtextsizepage.cpp:660
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
 msgid "cm"
 msgstr "cm"
 
-#: ../src/html/chm.cpp:347
+#: ../src/html/chm.cpp:344
 msgid "compression error"
 msgstr "saspiešanas kļūda"
 
-#: ../src/common/regex.cpp:236
+#: ../src/common/regex.cpp:233
 msgid "conversion to 8-bit encoding failed"
 msgstr "neizdevās pārvērst 8 bitu kodējumā"
 
-#: ../src/common/accelcmn.cpp:187
+#: ../src/common/accelcmn.cpp:186
 msgid "ctrl"
 msgstr "ctrl"
 
-#: ../src/common/cmdline.cpp:1500
+#: ../src/common/cmdline.cpp:1496
 msgid "date"
 msgstr "datums"
 
-#: ../src/html/chm.cpp:349
+#: ../src/html/chm.cpp:346
 msgid "decompression error"
 msgstr "atspiešanas kļūda"
 
-#: ../src/richtext/richtextstyles.cpp:780 ../src/common/fmapbase.cpp:820
+#: ../src/common/fmapbase.cpp:816 ../src/richtext/richtextstyles.cpp:777
 msgid "default"
 msgstr "noklusētais"
 
-#: ../src/common/cmdline.cpp:1496
+#: ../src/common/cmdline.cpp:1492
 msgid "double"
 msgstr "dubults"
 
-#: ../src/common/debugrpt.cpp:538
+#: ../src/common/debugrpt.cpp:539
 msgid "dump of the process state (binary)"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1969
+#: ../src/common/datetimefmt.cpp:1992
 msgid "eighteenth"
 msgstr "astoņpadsmitais"
 
-#: ../src/common/datetimefmt.cpp:1959
+#: ../src/common/datetimefmt.cpp:1982
 msgid "eighth"
 msgstr "astotais"
 
-#: ../src/common/datetimefmt.cpp:1962
+#: ../src/common/datetimefmt.cpp:1985
 msgid "eleventh"
 msgstr "vienpadsmitais"
 
-#: ../src/common/fileconf.cpp:1833
+#: ../src/common/fileconf.cpp:1835
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "ieraksts '%s' grupā '%s' parādās vairākkārt"
 
-#: ../src/html/chm.cpp:343
+#: ../src/html/chm.cpp:340
 msgid "error in data format"
 msgstr "kļūda datu formātā"
 
-#: ../src/html/chm.cpp:331
+#: ../src/html/chm.cpp:328
 msgid "error opening file"
 msgstr "kļūda atverot failu"
 
-#: ../src/common/zipstrm.cpp:1778
+#: ../src/common/zipstrm.cpp:1836
 msgid "error reading zip central directory"
 msgstr "kļūda lasot zip galveno mapi"
 
-#: ../src/common/zipstrm.cpp:1870
+#: ../src/common/zipstrm.cpp:1940
 msgid "error reading zip local header"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2531
+#: ../src/common/zipstrm.cpp:2615
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr ""
 
-#: ../src/common/ffile.cpp:188
+#: ../src/common/zipstrm.cpp:2608
+#, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1205
+#, fuzzy
+msgid "extrabold"
+msgstr "treknraksts"
+
+#: ../src/common/fontcmn.cpp:1223
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1167
+#, fuzzy
+msgid "extralight"
+msgstr "viegls"
+
+#: ../src/msw/webview_ie.cpp:1036
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "Neizdevās izpildīt '%s'\n"
+
+#: ../src/common/ffile.cpp:187
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr ""
 
+#: ../src/msw/webview_ie.cpp:1045
+#, fuzzy
+msgid "failed to retrieve execution result"
+msgstr "Neizdevās saņemt RAS ķļūdas paziņojuma tekstu."
+
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1030
+#: ../src/generic/datavgen.cpp:1150
 #, fuzzy
 msgid "false"
 msgstr "Aplams"
 
-#: ../src/common/datetimefmt.cpp:1966
+#: ../src/common/datetimefmt.cpp:1989
 msgid "fifteenth"
 msgstr "piecpadsmitais"
 
-#: ../src/common/datetimefmt.cpp:1956
+#: ../src/common/datetimefmt.cpp:1979
 msgid "fifth"
 msgstr "piektais"
 
@@ -8452,131 +8667,150 @@ msgstr "fails '%s', rinda %d: nemainīgās atslēgas vērtība '%s' nav ņemta v
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "fails '%s': negaidīts simbols %c %d rindā."
 
-#: ../src/richtext/richtextbuffer.cpp:8738
+#: ../src/richtext/richtextbuffer.cpp:8736
 msgid "files"
 msgstr "failus"
 
-#: ../src/common/datetimefmt.cpp:1952
+#: ../src/common/datetimefmt.cpp:1975
 msgid "first"
 msgstr "pirmais"
 
-#: ../src/html/helpwnd.cpp:1252
+#: ../src/html/helpwnd.cpp:1250
 msgid "font size"
 msgstr "fonta izmērs"
 
-#: ../src/common/datetimefmt.cpp:1965
+#: ../src/common/datetimefmt.cpp:1988
 msgid "fourteenth"
 msgstr "četrpadsmitais"
 
-#: ../src/common/datetimefmt.cpp:1955
+#: ../src/common/datetimefmt.cpp:1978
 msgid "fourth"
 msgstr "ceturtais"
 
-#: ../src/common/appbase.cpp:783
+#: ../src/common/appbase.cpp:784
 msgid "generate verbose log messages"
 msgstr "veidot izsmeļošus žurnāla ierakstus"
 
-#: ../src/richtext/richtextbuffer.cpp:13138
-#: ../src/richtext/richtextbuffer.cpp:13248
+#: ../src/common/fontcmn.cpp:1215
+msgid "heavy"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:13133
+#: ../src/richtext/richtextbuffer.cpp:13243
 msgid "image"
 msgstr "attēls"
 
-#: ../src/common/tarstrm.cpp:796
+#: ../src/common/tarstrm.cpp:790
 msgid "incomplete header block in tar"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:489
+#: ../src/common/xtixml.cpp:485
 msgid "incorrect event handler string, missing dot"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:1381
+#: ../src/common/tarstrm.cpp:1375
 msgid "incorrect size given for tar entry"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:993
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:987
 msgid "invalid data in extended tar header"
 msgstr "Nederīgi dati..."
 
-#: ../src/generic/logg.cpp:1030
+#: ../src/generic/logg.cpp:1027
 msgid "invalid message box return value"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1647
+#: ../src/common/zipstrm.cpp:1688
 msgid "invalid zip file"
 msgstr "nederīgs zip fails"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:1228
 msgid "italic"
 msgstr "slīpraksts"
 
-#: ../src/common/fontcmn.cpp:991
+#: ../src/common/webrequest_curl.cpp:374
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "Nav iespējams inicializēt slejas aprakstu."
+
+#: ../src/common/fontcmn.cpp:1172
 msgid "light"
 msgstr "viegls"
 
-#: ../src/common/intl.cpp:303
-#, c-format
-msgid "locale '%s' cannot be set."
-msgstr "lokāli '%s' nav iespējams uzstādīt."
+#: ../src/common/fontcmn.cpp:1185
+msgid "medium"
+msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2125
+#: ../src/common/datetimefmt.cpp:2148
 msgid "midnight"
 msgstr "pusnakts"
 
-#: ../src/common/datetimefmt.cpp:1970
+#: ../src/common/datetimefmt.cpp:1993
 msgid "nineteenth"
 msgstr "deviņpadsmitais"
 
-#: ../src/common/datetimefmt.cpp:1960
+#: ../src/common/datetimefmt.cpp:1983
 msgid "ninth"
 msgstr "devītais"
 
-#: ../src/msw/dde.cpp:1116
+#: ../src/msw/dde.cpp:1180
 msgid "no DDE error."
 msgstr "nav DDE kļūdas."
 
-#: ../src/html/chm.cpp:327
+#: ../src/html/chm.cpp:324
 msgid "no error"
 msgstr "nav kļūdu"
 
-#: ../src/dfb/fontmgr.cpp:174
+#: ../src/dfb/fontmgr.cpp:171
 #, c-format
 msgid "no fonts found in %s, using builtin font"
 msgstr "mapē %s nav atrasts neviens fonts, izmanto iebūvēto fontu"
 
-#: ../src/html/helpdata.cpp:657
+#: ../src/html/helpdata.cpp:650
 msgid "noname"
 msgstr "bezvārda"
 
-#: ../src/common/datetimefmt.cpp:2124
+#: ../src/common/datetimefmt.cpp:2147
 msgid "noon"
 msgstr "dienas vidus"
 
-#: ../src/richtext/richtextstyles.cpp:779
+#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "normāls"
 
-#: ../src/common/cmdline.cpp:1492
+#: ../src/common/cmdline.cpp:1488
 msgid "num"
 msgstr "Num"
 
-#: ../src/common/xtixml.cpp:259
+#: ../src/common/accelcmn.cpp:194
+msgid "num "
+msgstr ""
+
+#: ../src/common/xtixml.cpp:255
 msgid "objects cannot have XML Text Nodes"
 msgstr ""
 
-#: ../src/html/chm.cpp:339
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
 msgid "out of memory"
 msgstr "pietrūkst atmiņas"
 
-#: ../src/common/debugrpt.cpp:514
+#: ../src/common/debugrpt.cpp:515
 msgid "process context description"
 msgstr "procesa konteksta apraksts"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:227
-#: ../src/richtext/richtextbackgroundpage.cpp:250
-#: ../src/richtext/richtextbackgroundpage.cpp:290
-#: ../src/richtext/richtextbackgroundpage.cpp:317
-#: ../src/richtext/richtextfontpage.cpp:177
-#: ../src/richtext/richtextfontpage.cpp:180
 #: ../src/richtext/richtextborderspage.cpp:255
 #: ../src/richtext/richtextborderspage.cpp:289
 #: ../src/richtext/richtextborderspage.cpp:323
@@ -8586,22 +8820,45 @@ msgstr "procesa konteksta apraksts"
 #: ../src/richtext/richtextborderspage.cpp:491
 #: ../src/richtext/richtextborderspage.cpp:525
 #: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextfontpage.cpp:180
 msgid "pt"
 msgstr ""
 
-#: ../src/richtext/richtextbackgroundpage.cpp:225
-#: ../src/richtext/richtextbackgroundpage.cpp:228
-#: ../src/richtext/richtextbackgroundpage.cpp:229
-#: ../src/richtext/richtextbackgroundpage.cpp:248
-#: ../src/richtext/richtextbackgroundpage.cpp:251
-#: ../src/richtext/richtextbackgroundpage.cpp:252
-#: ../src/richtext/richtextbackgroundpage.cpp:288
-#: ../src/richtext/richtextbackgroundpage.cpp:291
-#: ../src/richtext/richtextbackgroundpage.cpp:292
-#: ../src/richtext/richtextbackgroundpage.cpp:315
-#: ../src/richtext/richtextbackgroundpage.cpp:318
-#: ../src/richtext/richtextbackgroundpage.cpp:319
-#: ../src/richtext/richtextfontpage.cpp:178
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:659
+#: ../src/richtext/richtextsizepage.cpp:662
+#: ../src/richtext/richtextsizepage.cpp:663
 #: ../src/richtext/richtextborderspage.cpp:253
 #: ../src/richtext/richtextborderspage.cpp:256
 #: ../src/richtext/richtextborderspage.cpp:257
@@ -8653,260 +8910,270 @@ msgstr ""
 #: ../src/richtext/richtextmarginspage.cpp:387
 #: ../src/richtext/richtextmarginspage.cpp:389
 #: ../src/richtext/richtextmarginspage.cpp:390
-#: ../src/richtext/richtextsizepage.cpp:338
-#: ../src/richtext/richtextsizepage.cpp:341
-#: ../src/richtext/richtextsizepage.cpp:342
-#: ../src/richtext/richtextsizepage.cpp:372
-#: ../src/richtext/richtextsizepage.cpp:375
-#: ../src/richtext/richtextsizepage.cpp:376
-#: ../src/richtext/richtextsizepage.cpp:399
-#: ../src/richtext/richtextsizepage.cpp:402
-#: ../src/richtext/richtextsizepage.cpp:403
-#: ../src/richtext/richtextsizepage.cpp:426
-#: ../src/richtext/richtextsizepage.cpp:429
-#: ../src/richtext/richtextsizepage.cpp:430
-#: ../src/richtext/richtextsizepage.cpp:453
-#: ../src/richtext/richtextsizepage.cpp:456
-#: ../src/richtext/richtextsizepage.cpp:457
-#: ../src/richtext/richtextsizepage.cpp:480
-#: ../src/richtext/richtextsizepage.cpp:483
-#: ../src/richtext/richtextsizepage.cpp:484
-#: ../src/richtext/richtextsizepage.cpp:554
-#: ../src/richtext/richtextsizepage.cpp:557
-#: ../src/richtext/richtextsizepage.cpp:558
-#: ../src/richtext/richtextsizepage.cpp:589
-#: ../src/richtext/richtextsizepage.cpp:592
-#: ../src/richtext/richtextsizepage.cpp:593
-#: ../src/richtext/richtextsizepage.cpp:624
-#: ../src/richtext/richtextsizepage.cpp:627
-#: ../src/richtext/richtextsizepage.cpp:628
-#: ../src/richtext/richtextsizepage.cpp:659
-#: ../src/richtext/richtextsizepage.cpp:662
-#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextfontpage.cpp:178
 msgid "px"
 msgstr " px"
 
-#: ../src/common/accelcmn.cpp:193
+#: ../src/common/accelcmn.cpp:192
 msgid "rawctrl"
 msgstr "rawctrl"
 
-#: ../src/html/chm.cpp:333
+#: ../src/html/chm.cpp:330
 msgid "read error"
 msgstr "lasīšanas kļūda"
 
-#: ../src/common/zipstrm.cpp:2085
+#: ../src/common/zipstrm.cpp:2155
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2080
+#: ../src/common/zipstrm.cpp:2150
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr ""
 
-#: ../src/msw/dde.cpp:1159
+#: ../src/msw/dde.cpp:1223
 msgid "reentrancy problem."
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1953
+#: ../src/common/datetimefmt.cpp:1976
 msgid "second"
 msgstr "otrais"
 
-#: ../src/html/chm.cpp:337
+#: ../src/html/chm.cpp:334
 msgid "seek error"
 msgstr "pozicionēšanas kļūda"
 
-#: ../src/common/datetimefmt.cpp:1968
+#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#, fuzzy
+msgid "semibold"
+msgstr "treknraksts"
+
+#: ../src/common/datetimefmt.cpp:1991
 msgid "seventeenth"
 msgstr "septiņpadsmitais"
 
-#: ../src/common/datetimefmt.cpp:1958
+#: ../src/common/datetimefmt.cpp:1981
 msgid "seventh"
 msgstr "septītais"
 
-#: ../src/common/accelcmn.cpp:191
+#: ../src/common/accelcmn.cpp:190
 msgid "shift"
 msgstr "shift"
 
-#: ../src/common/appbase.cpp:773
+#: ../src/common/appbase.cpp:774
 msgid "show this help message"
 msgstr "parādīt šo palīdzības paziņojumu"
 
-#: ../src/common/datetimefmt.cpp:1967
+#: ../src/common/datetimefmt.cpp:1990
 msgid "sixteenth"
 msgstr "sešpadsmitais"
 
-#: ../src/common/datetimefmt.cpp:1957
+#: ../src/common/datetimefmt.cpp:1980
 msgid "sixth"
 msgstr "sestais"
 
-#: ../src/common/appcmn.cpp:234
+#: ../src/common/appcmn.cpp:255
 msgid "specify display mode to use (e.g. 640x480-16)"
 msgstr "norādiet izmantojamo ekrāna režīmu (piem. 640x480-16)"
 
-#: ../src/common/appcmn.cpp:220
+#: ../src/common/appcmn.cpp:241
 msgid "specify the theme to use"
 msgstr "norādiet izmantojamo tēmu"
 
-#: ../src/richtext/richtextbuffer.cpp:9340
+#: ../src/richtext/richtextbuffer.cpp:9337
 msgid "standard/circle"
 msgstr "standarta/rinķis"
 
-#: ../src/richtext/richtextbuffer.cpp:9341
+#: ../src/richtext/richtextbuffer.cpp:9338
 msgid "standard/circle-outline"
 msgstr "standarta/riņķa aprises"
 
-#: ../src/richtext/richtextbuffer.cpp:9343
+#: ../src/richtext/richtextbuffer.cpp:9340
 msgid "standard/diamond"
 msgstr "standarta/rombs"
 
-#: ../src/richtext/richtextbuffer.cpp:9342
+#: ../src/richtext/richtextbuffer.cpp:9339
 msgid "standard/square"
 msgstr "standarta/kvadrāts"
 
-#: ../src/richtext/richtextbuffer.cpp:9344
+#: ../src/richtext/richtextbuffer.cpp:9341
 msgid "standard/triangle"
 msgstr "standarta/trīsstūris"
 
-#: ../src/common/zipstrm.cpp:1985
+#: ../src/common/zipstrm.cpp:2055
 msgid "stored file length not in Zip header"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1488
+#: ../src/common/cmdline.cpp:1484
 msgid "str"
 msgstr "str"
 
-#: ../src/common/fontcmn.cpp:982
+#: ../src/common/fontcmn.cpp:1145
 msgid "strikethrough"
 msgstr "caursvītrots"
 
-#: ../src/common/tarstrm.cpp:1003 ../src/common/tarstrm.cpp:1025
-#: ../src/common/tarstrm.cpp:1507 ../src/common/tarstrm.cpp:1529
+#: ../src/common/tarstrm.cpp:997 ../src/common/tarstrm.cpp:1019
+#: ../src/common/tarstrm.cpp:1501 ../src/common/tarstrm.cpp:1523
 msgid "tar entry not open"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1961
+#: ../src/common/datetimefmt.cpp:1984
 msgid "tenth"
 msgstr "desmitais"
 
-#: ../src/msw/dde.cpp:1123
+#: ../src/msw/dde.cpp:1187
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1954
+#: ../src/common/fontcmn.cpp:1154
+msgid "thin"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:1977
 msgid "third"
 msgstr "trešā"
 
-#: ../src/common/datetimefmt.cpp:1964
+#: ../src/common/datetimefmt.cpp:1987
 msgid "thirteenth"
 msgstr "trīspadsmitais"
 
-#: ../src/common/datetimefmt.cpp:1758
+#: ../src/common/datetimefmt.cpp:1781
 msgid "today"
 msgstr "šodiena"
 
-#: ../src/common/datetimefmt.cpp:1760
+#: ../src/common/datetimefmt.cpp:1783
 msgid "tomorrow"
 msgstr "rītdiena"
 
-#: ../src/common/fileconf.cpp:1944
+#: ../src/common/fileconf.cpp:1946
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "nav ņemta vērā '%s' noslēdzošā reversā slīpsvītra"
 
-#: ../src/gtk/aboutdlg.cpp:218
+#: ../src/gtk/aboutdlg.cpp:216
 msgid "translator-credits"
 msgstr "atzinība tulkotājiem"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1028
+#: ../src/generic/datavgen.cpp:1148
 msgid "true"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1963
+#: ../src/common/datetimefmt.cpp:1986
 msgid "twelfth"
 msgstr "divpadsmitais"
 
-#: ../src/common/datetimefmt.cpp:1971
+#: ../src/common/datetimefmt.cpp:1994
 msgid "twentieth"
 msgstr "divdesmitais"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:486 ../src/generic/datavgen.cpp:1263
+#: ../src/common/datavcmn.cpp:2068 ../src/generic/datavgen.cpp:1386
 msgid "unchecked"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:802 ../src/common/fontcmn.cpp:978
+#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
 msgid "underlined"
 msgstr "pasvītrots"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:490
+#: ../src/common/datavcmn.cpp:2072
 #, fuzzy
 msgid "undetermined"
 msgstr "pasvītrots"
 
-#: ../src/common/fileconf.cpp:1979
+#: ../src/common/fileconf.cpp:1981
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "negaidīta \"  pozīcijā %d virknē  '%s'."
 
-#: ../src/common/tarstrm.cpp:1045
+#: ../src/common/tarstrm.cpp:1039
 msgid "unexpected end of file"
 msgstr "negaidītas faila beigas"
 
-#: ../src/generic/progdlgg.cpp:370 ../src/common/tarstrm.cpp:371
-#: ../src/common/tarstrm.cpp:394 ../src/common/tarstrm.cpp:425
+#: ../src/common/tarstrm.cpp:366 ../src/common/tarstrm.cpp:389
+#: ../src/common/tarstrm.cpp:420 ../src/generic/progdlgg.cpp:376
 msgid "unknown"
 msgstr "nezināms"
 
-#: ../src/msw/registry.cpp:150
+#: ../src/msw/registry.cpp:139
 #, fuzzy, c-format
 msgid "unknown (%lu)"
 msgstr "nezināms"
 
-#: ../src/common/xtixml.cpp:253
+#: ../src/common/xtixml.cpp:249
 #, c-format
 msgid "unknown class %s"
 msgstr "nezināma klase %s"
 
-#: ../src/common/regex.cpp:258 ../src/html/chm.cpp:351
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "saspiešanas kļūda"
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "atspiešanas kļūda"
+
+#: ../src/common/regex.cpp:255 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "nezināma kļūda"
 
-#: ../src/msw/dialup.cpp:471
+#: ../src/msw/dialup.cpp:465
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "nezināma kļūda (kļūdas kods %08x)."
 
-#: ../src/common/fmapbase.cpp:834
+#: ../src/common/fmapbase.cpp:830
 #, c-format
 msgid "unknown-%d"
 msgstr "nezināms-%d"
 
-#: ../src/common/docview.cpp:509
+#: ../src/common/docview.cpp:502
 msgid "unnamed"
 msgstr "nenosaukts"
 
-#: ../src/common/docview.cpp:1624
+#: ../src/common/docview.cpp:1618
 #, c-format
 msgid "unnamed%d"
 msgstr "nenosaukts%d"
 
-#: ../src/common/zipstrm.cpp:1999 ../src/common/zipstrm.cpp:2319
+#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
 msgid "unsupported Zip compression method"
 msgstr "neatbalstīta Zip kompresijas metode"
 
-#: ../src/common/translation.cpp:1892
+#: ../src/common/translation.cpp:1942
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "izmanto katalogu '%s' no '%s'."
 
-#: ../src/html/chm.cpp:335
+#: ../src/html/chm.cpp:332
 msgid "write error"
 msgstr "rakstīšanas kļūda"
 
-#: ../src/common/time.cpp:292
+#: ../src/gtk/glcanvas.cpp:187
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/common/time.cpp:285
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay beidzās ar kļūdu."
 
@@ -8919,15 +9186,15 @@ msgstr "wxWidgets neizdevās atvērt ekrānu priekš '%s': beidz darbu."
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets neizdevās atvērt ekrānu. Beidz darbu."
 
-#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:431
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/common/datetimefmt.cpp:1759
+#: ../src/common/datetimefmt.cpp:1782
 msgid "yesterday"
 msgstr "varardiena"
 
-#: ../src/common/zstream.cpp:251 ../src/common/zstream.cpp:426
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
 #, c-format
 msgid "zlib error %d"
 msgstr "zlib kļūda  %d"
@@ -8937,6 +9204,65 @@ msgstr "zlib kļūda  %d"
 msgid "~"
 msgstr "~"
 
+#~ msgid "&Save as"
+#~ msgstr "&Saglabāt Kā "
+
+#, fuzzy
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' drīkst saturēt tikai alfabēta rakstzīmes."
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' ir jābūt skaitliskam."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' drīkst saturēt tikai ASCII simbolus."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' drīkst saturēt tikai alfabēta rakstzīmes."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' drīkst saturēt tikai alfabēta un skaitliskas rakstzīmes."
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' drīkst saturēt tikai ciparus."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "Nav iespējams izveidot %s klases logu"
+
+#, fuzzy
+#~ msgid "Could not initalize libnotify."
+#~ msgstr "Neizdevās iestatīt izlīdiznājumu."
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "Neizdevās pārvērst failu \"%s\"  uz Unikodu."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "Neizdevās iestatīt tekstu teksta vadīklā."
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr "Nederīgs GTK+ komandrindas parametrs, izmantojiet \"%s --help\""
+
+#~ msgid "No unused colour in image."
+#~ msgstr "Attēls nesatur neizmantotas krāsas."
+
+#~ msgid "Not available"
+#~ msgstr "Nav pieejams"
+
+#~ msgid "Replace selection"
+#~ msgstr "Aizvietot iezīmējumu"
+
+#~ msgid "Save as"
+#~ msgstr "Saglabāt kā"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Stilu vadība"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "Tiek atbalstīti arī sekojoši GTK+ standarta iestatījumi:\n"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "lokāli '%s' nav iespējams uzstādīt."
+
 #~ msgid ""
 #~ "Cannot create new column's ID. Probably max. number of columns reached."
 #~ msgstr ""
@@ -8945,9 +9271,6 @@ msgstr "~"
 
 #~ msgid "Column could not be added."
 #~ msgstr "Pievienot sleju nav iespējams."
-
-#~ msgid "Column description could not be initialized."
-#~ msgstr "Nav iespējams inicializēt slejas aprakstu."
 
 #~ msgid "Column index not found."
 #~ msgstr "Slejas indekss nav atrasts."
@@ -9607,14 +9930,8 @@ msgstr "~"
 #~ msgid "Failed to register OpenGL window class."
 #~ msgstr "Neizdevās reģistrēt OpenGL loga klasi."
 
-#~ msgid "Fatal error"
-#~ msgstr "Fatāla kļūda"
-
 #~ msgid "Fatal error: "
 #~ msgstr "Fatāla kļūda: "
-
-#~ msgid "File %s does not exist."
-#~ msgstr "Fails '%s' neeksistē."
 
 #~ msgid "Found "
 #~ msgstr "Atrasts"

--- a/locale/ms.po
+++ b/locale/ms.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-21 14:25+0200\n"
+"POT-Creation-Date: 2020-10-18 23:11+0300\n"
 "PO-Revision-Date: 2006-11-06 10:48+0800\n"
 "Last-Translator: Mahrazi Mohd Kamal <mahrazi@gmail.com>\n"
 "Language-Team: ms_MY <ms@li.org>\n"
@@ -18,7 +18,7 @@ msgstr ""
 "X-Poedit-Language: Malay\n"
 "X-Poedit-Country: MALAYSIA\n"
 
-#: ../src/common/debugrpt.cpp:586
+#: ../src/common/debugrpt.cpp:587
 msgid ""
 "\n"
 "Please send this report to the program maintainer, thank you!\n"
@@ -26,8 +26,8 @@ msgstr ""
 "\n"
 "Sila hantar laporan ini kepada penyelenggara program, terima kasih!\n"
 
-#: ../src/richtext/richtextstyledlg.cpp:210
-#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:206
+#: ../src/richtext/richtextstyledlg.cpp:218
 msgid " "
 msgstr " "
 
@@ -35,70 +35,96 @@ msgstr " "
 msgid "              Thank you and we're sorry for the inconvenience!\n"
 msgstr "              Terima kasih dan segala kesulitan amat dikesali!\n"
 
-#: ../src/common/prntbase.cpp:573
+#: ../src/common/prntbase.cpp:568
 #, fuzzy, c-format
 msgid " (copy %d of %d)"
 msgstr "Laman %d of %d"
 
-#: ../src/common/log.cpp:421
+#: ../src/common/log.cpp:440
 #, c-format
 msgid " (error %ld: %s)"
 msgstr " (ralat %ld: %s)"
 
-#: ../src/common/imagtiff.cpp:72
+#: ../src/common/imagtiff.cpp:69
 #, fuzzy, c-format
 msgid " (in module \"%s\")"
 msgstr "modul tiff: %s"
 
-#: ../src/osx/core/secretstore.cpp:138
-msgid " (while overwriting an existing item)"
-msgstr ""
-
-#: ../src/common/docview.cpp:1642
+#: ../src/common/docview.cpp:1636
 msgid " - "
 msgstr " - "
 
-#: ../src/richtext/richtextprint.cpp:593 ../src/html/htmprint.cpp:714
+#: ../src/html/htmprint.cpp:712 ../src/richtext/richtextprint.cpp:589
 msgid " Preview"
 msgstr " Pralihat"
 
-#: ../src/common/fontcmn.cpp:824
+#: ../src/common/fontcmn.cpp:973
 msgid " bold"
 msgstr "tebal"
 
-#: ../src/common/fontcmn.cpp:840
+#: ../src/common/fontcmn.cpp:977
+#, fuzzy
+msgid " extra bold"
+msgstr "tebal"
+
+#: ../src/common/fontcmn.cpp:985
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:957
+#, fuzzy
+msgid " extra light"
+msgstr "cerah"
+
+#: ../src/common/fontcmn.cpp:981
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1001
 msgid " italic"
 msgstr "italik"
 
-#: ../src/common/fontcmn.cpp:820
+#: ../src/common/fontcmn.cpp:961
 msgid " light"
 msgstr "cerah"
 
-#: ../src/common/fontcmn.cpp:807
+#: ../src/common/fontcmn.cpp:965
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:969
+#, fuzzy
+msgid " semi bold"
+msgstr "tebal"
+
+#: ../src/common/fontcmn.cpp:940
 msgid " strikethrough"
 msgstr ""
 
-#: ../src/common/paper.cpp:117
+#: ../src/common/fontcmn.cpp:953
+msgid " thin"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
 msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
 msgstr "Sampul #10, 4 1/8 x 9 1/2 in"
 
-#: ../src/common/paper.cpp:118
+#: ../src/common/paper.cpp:115
 msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
 msgstr "Sampul #11, 4 1/2 x 10 3/8 in"
 
-#: ../src/common/paper.cpp:119
+#: ../src/common/paper.cpp:116
 msgid "#12 Envelope, 4 3/4 x 11 in"
 msgstr "Sampul #12, 4 3/4 x 11 in"
 
-#: ../src/common/paper.cpp:120
+#: ../src/common/paper.cpp:117
 msgid "#14 Envelope, 5 x 11 1/2 in"
 msgstr "Sampul #14, 5 x 11 1/2 in"
 
-#: ../src/common/paper.cpp:116
+#: ../src/common/paper.cpp:113
 msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
 msgstr "Sampul #9, 3 7/8 x 8 7/8 in"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:341
 #: ../src/richtext/richtextsizepage.cpp:340
 #: ../src/richtext/richtextsizepage.cpp:374
 #: ../src/richtext/richtextsizepage.cpp:401
@@ -109,82 +135,83 @@ msgstr "Sampul #9, 3 7/8 x 8 7/8 in"
 #: ../src/richtext/richtextsizepage.cpp:591
 #: ../src/richtext/richtextsizepage.cpp:626
 #: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextbackgroundpage.cpp:341
 #, fuzzy
 msgid "%"
 msgstr "%s B"
 
-#: ../src/html/helpwnd.cpp:1031
+#: ../src/html/helpwnd.cpp:1029
 #, fuzzy, c-format
 msgid "%d of %lu"
 msgstr "%i of %i"
 
-#: ../src/html/helpwnd.cpp:1678
+#: ../src/html/helpwnd.cpp:1676
 #, fuzzy, c-format
 msgid "%i of %u"
 msgstr "%i of %i"
 
-#: ../src/generic/filectrlg.cpp:279
+#: ../src/generic/filectrlg.cpp:275
 #, c-format
 msgid "%ld byte"
 msgid_plural "%ld bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/html/helpwnd.cpp:1033
+#: ../src/html/helpwnd.cpp:1031
 #, fuzzy, c-format
 msgid "%lu of %lu"
 msgstr "%i of %i"
 
-#: ../src/generic/datavgen.cpp:6028
+#: ../src/generic/datavgen.cpp:6833
 #, fuzzy, c-format
 msgid "%s (%d items)"
 msgstr "%s (or %s)"
 
-#: ../src/common/cmdline.cpp:1221
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (or %s)"
 
-#: ../src/generic/logg.cpp:224
+#: ../src/generic/logg.cpp:221
 #, c-format
 msgid "%s Error"
 msgstr "%s Ralat"
 
-#: ../src/generic/logg.cpp:236
+#: ../src/generic/logg.cpp:233
 #, c-format
 msgid "%s Information"
 msgstr "%s Maklumat"
 
-#: ../src/generic/preferencesg.cpp:113
+#: ../src/generic/preferencesg.cpp:110
 #, fuzzy, c-format
 msgid "%s Preferences"
 msgstr "Keutamaan"
 
-#: ../src/generic/logg.cpp:228
+#: ../src/generic/logg.cpp:225
 #, c-format
 msgid "%s Warning"
 msgstr "%s Amaran"
 
-#: ../src/common/tarstrm.cpp:1319
+#: ../src/common/tarstrm.cpp:1313
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s tidak dapat muat kepala tar untuk masukan '%s'"
 
-#: ../src/common/fldlgcmn.cpp:124
+#: ../src/common/fldlgcmn.cpp:121
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "fail %s (%s)|%s"
 
-#: ../src/html/helpwnd.cpp:1716
+#: ../src/html/helpwnd.cpp:1714
 #, fuzzy, c-format
 msgid "%u of %u"
 msgstr "%i of %i"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "&About"
 msgstr "Perih&al"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "&Actual Size"
 msgstr "Saiz Seben&ar"
 
@@ -193,28 +220,28 @@ msgstr "Saiz Seben&ar"
 msgid "&After a paragraph:"
 msgstr "Selepas satu perenggan:"
 
-#: ../src/richtext/richtextindentspage.cpp:128
 #: ../src/richtext/richtextliststylepage.cpp:319
+#: ../src/richtext/richtextindentspage.cpp:128
 msgid "&Alignment"
 msgstr "J&ajaran"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "&Apply"
 msgstr "Ter&ap"
 
-#: ../src/richtext/richtextstyledlg.cpp:251
+#: ../src/richtext/richtextstyledlg.cpp:247
 msgid "&Apply Style"
 msgstr "Ter&ap Gaya"
 
-#: ../src/msw/mdi.cpp:179
+#: ../src/msw/mdi.cpp:174
 msgid "&Arrange Icons"
 msgstr "Susun Ikon"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "&Ascending"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:142
+#: ../src/common/stockitem.cpp:139
 msgid "&Back"
 msgstr "Kem&bali"
 
@@ -236,24 +263,24 @@ msgstr "Warna:"
 msgid "&Blur distance:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:143
+#: ../src/common/stockitem.cpp:140
 msgid "&Bold"
 msgstr "Te&bal"
 
-#: ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141
 msgid "&Bottom"
 msgstr ""
 
+#: ../src/richtext/richtextsizepage.cpp:637
+#: ../src/richtext/richtextsizepage.cpp:644
 #: ../src/richtext/richtextborderspage.cpp:345
 #: ../src/richtext/richtextborderspage.cpp:513
 #: ../src/richtext/richtextmarginspage.cpp:259
 #: ../src/richtext/richtextmarginspage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:637
-#: ../src/richtext/richtextsizepage.cpp:644
 msgid "&Bottom:"
 msgstr ""
 
-#: ../include/wx/richtext/richtextbuffer.h:3866
+#: ../include/wx/richtext/richtextbuffer.h:3861
 #, fuzzy
 msgid "&Box"
 msgstr "Te&bal"
@@ -263,39 +290,39 @@ msgstr "Te&bal"
 msgid "&Bullet style:"
 msgstr "Gaya peluru:"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "&CD-Rom"
 msgstr ""
 
-#: ../src/generic/wizard.cpp:434 ../src/generic/fontdlgg.cpp:470
-#: ../src/generic/fontdlgg.cpp:489 ../src/osx/carbon/fontdlg.cpp:402
-#: ../src/common/dlgcmn.cpp:279 ../src/common/stockitem.cpp:145
+#: ../src/osx/carbon/fontdlg.cpp:399 ../src/common/stockitem.cpp:142
+#: ../src/generic/wizard.cpp:433 ../src/generic/fontdlgg.cpp:466
+#: ../src/generic/fontdlgg.cpp:485 ../src/osx/cocoa/button.mm:200
 msgid "&Cancel"
 msgstr "&Batal"
 
-#: ../src/msw/mdi.cpp:175
+#: ../src/msw/mdi.cpp:170
 msgid "&Cascade"
 msgstr "Bertindih"
 
-#: ../include/wx/richtext/richtextbuffer.h:5960
+#: ../include/wx/richtext/richtextbuffer.h:5955
 #, fuzzy
 msgid "&Cell"
 msgstr "&Batal"
 
-#: ../src/richtext/richtextsymboldlg.cpp:439
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "&Character code:"
 msgstr "Kod aksara:"
 
-#: ../src/common/stockitem.cpp:147
+#: ../src/common/stockitem.cpp:144
 msgid "&Clear"
 msgstr "Kosongkan"
 
-#: ../src/generic/logg.cpp:516 ../src/common/stockitem.cpp:148
-#: ../src/common/prntbase.cpp:1600 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/stockitem.cpp:145 ../src/common/prntbase.cpp:1625
+#: ../src/univ/themes/win32.cpp:3753 ../src/generic/logg.cpp:513
 msgid "&Close"
 msgstr "&Tutup"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 #, fuzzy
 msgid "&Color"
 msgstr "Warna:"
@@ -304,22 +331,22 @@ msgstr "Warna:"
 msgid "&Colour:"
 msgstr "Warna:"
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 #, fuzzy
 msgid "&Convert"
 msgstr "Kandungan"
 
-#: ../src/richtext/richtextctrl.cpp:333 ../src/osx/textctrl_osx.cpp:577
-#: ../src/common/stockitem.cpp:150 ../src/msw/textctrl.cpp:2508
+#: ../src/osx/textctrl_osx.cpp:595 ../src/common/stockitem.cpp:147
+#: ../src/msw/textctrl.cpp:2773 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Salin"
 
-#: ../src/generic/hyperlinkg.cpp:156
+#: ../src/generic/hyperlinkg.cpp:153
 #, fuzzy
 msgid "&Copy URL"
 msgstr "&Salin"
 
-#: ../src/common/headerctrlcmn.cpp:306
+#: ../src/common/headerctrlcmn.cpp:304
 #, fuzzy
 msgid "&Customize..."
 msgstr "Saiz Fon"
@@ -328,53 +355,54 @@ msgstr "Saiz Fon"
 msgid "&Debug report preview:"
 msgstr "Pralihat laporan nyahpijat:"
 
-#: ../src/richtext/richtexttabspage.cpp:138
-#: ../src/richtext/richtextctrl.cpp:335 ../src/osx/textctrl_osx.cpp:579
-#: ../src/common/stockitem.cpp:152 ../src/msw/textctrl.cpp:2510
+#: ../src/osx/textctrl_osx.cpp:597 ../src/common/stockitem.cpp:149
+#: ../src/msw/textctrl.cpp:2775 ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtextctrl.cpp:334
 msgid "&Delete"
 msgstr "Pa&dam"
 
-#: ../src/richtext/richtextstyledlg.cpp:269
+#: ../src/richtext/richtextstyledlg.cpp:265
 msgid "&Delete Style..."
 msgstr "Pa&dam Gaya..."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "&Descending"
 msgstr ""
 
-#: ../src/generic/logg.cpp:682
+#: ../src/generic/logg.cpp:679
 msgid "&Details"
 msgstr "&Terperinci"
 
-#: ../src/common/stockitem.cpp:153
+#: ../src/common/stockitem.cpp:150
 msgid "&Down"
 msgstr "Turun"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "&Edit"
 msgstr "&Edit"
 
-#: ../src/richtext/richtextstyledlg.cpp:263
+#: ../src/richtext/richtextstyledlg.cpp:259
 msgid "&Edit Style..."
 msgstr "&Edit Gaya..."
 
-#: ../src/common/stockitem.cpp:155
+#: ../src/common/stockitem.cpp:152
 msgid "&Execute"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/common/stockitem.cpp:154
 msgid "&File"
 msgstr "&Fail"
 
-#: ../src/common/stockitem.cpp:158
-msgid "&Find"
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "&Find..."
 msgstr "Ca&ri"
 
-#: ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:430
 msgid "&Finish"
 msgstr "&Tamat"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:156
 #, fuzzy
 msgid "&First"
 msgstr "pertama"
@@ -383,17 +411,17 @@ msgstr "pertama"
 msgid "&Floating mode:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 #, fuzzy
 msgid "&Floppy"
 msgstr "&Salin"
 
-#: ../src/common/stockitem.cpp:194
+#: ../src/common/stockitem.cpp:191
 #, fuzzy
 msgid "&Font"
 msgstr "&Fon:"
 
-#: ../src/generic/fontdlgg.cpp:371
+#: ../src/generic/fontdlgg.cpp:367
 msgid "&Font family:"
 msgstr "Keluarga &fon:"
 
@@ -401,20 +429,20 @@ msgstr "Keluarga &fon:"
 msgid "&Font for Level..."
 msgstr "Fon untuk Paras..."
 
+#: ../src/richtext/richtextsymboldlg.cpp:397
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:400
 msgid "&Font:"
 msgstr "&Fon:"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "&Forward"
 msgstr "Maju"
 
-#: ../src/richtext/richtextsymboldlg.cpp:451
+#: ../src/richtext/richtextsymboldlg.cpp:448
 msgid "&From:"
 msgstr "Dari: "
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "&Harddisk"
 msgstr ""
 
@@ -424,9 +452,9 @@ msgstr ""
 msgid "&Height:"
 msgstr "Berat:"
 
-#: ../src/generic/wizard.cpp:441 ../src/richtext/richtextstyledlg.cpp:303
-#: ../src/richtext/richtextsymboldlg.cpp:479 ../src/osx/menu_osx.cpp:734
-#: ../src/common/stockitem.cpp:163
+#: ../src/common/stockitem.cpp:160 ../src/generic/wizard.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextstyledlg.cpp:299 ../src/osx/cocoa/menu.mm:226
 msgid "&Help"
 msgstr "&Bantuan"
 
@@ -435,7 +463,7 @@ msgstr "&Bantuan"
 msgid "&Hide details"
 msgstr "&Terperinci"
 
-#: ../src/common/stockitem.cpp:164
+#: ../src/common/stockitem.cpp:161
 msgid "&Home"
 msgstr "Ruma&h"
 
@@ -443,56 +471,56 @@ msgstr "Ruma&h"
 msgid "&Horizontal offset:"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:184
 #: ../src/richtext/richtextliststylepage.cpp:372
+#: ../src/richtext/richtextindentspage.cpp:184
 msgid "&Indentation (tenths of a mm)"
 msgstr "Penakukan (satu persepuluh mm)"
 
-#: ../src/richtext/richtextindentspage.cpp:167
 #: ../src/richtext/richtextliststylepage.cpp:356
+#: ../src/richtext/richtextindentspage.cpp:167
 msgid "&Indeterminate"
 msgstr "Gagal ditentukan"
 
-#: ../src/common/stockitem.cpp:166
+#: ../src/common/stockitem.cpp:163
 msgid "&Index"
 msgstr "&Indeks"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 #, fuzzy
 msgid "&Info"
 msgstr "&Nyahcara"
 
-#: ../src/common/stockitem.cpp:168
+#: ../src/common/stockitem.cpp:165
 msgid "&Italic"
 msgstr "&Italik"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "&Jump to"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:153
 #: ../src/richtext/richtextliststylepage.cpp:342
+#: ../src/richtext/richtextindentspage.cpp:153
 msgid "&Justified"
 msgstr "Justifi"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 #, fuzzy
 msgid "&Last"
 msgstr "&Tepek"
 
-#: ../src/richtext/richtextindentspage.cpp:139
 #: ../src/richtext/richtextliststylepage.cpp:328
+#: ../src/richtext/richtextindentspage.cpp:139
 msgid "&Left"
 msgstr "&Kiri"
 
-#: ../src/richtext/richtextindentspage.cpp:195
+#: ../src/richtext/richtextsizepage.cpp:532
+#: ../src/richtext/richtextsizepage.cpp:539
 #: ../src/richtext/richtextborderspage.cpp:243
 #: ../src/richtext/richtextborderspage.cpp:411
 #: ../src/richtext/richtextliststylepage.cpp:381
+#: ../src/richtext/richtextindentspage.cpp:195
 #: ../src/richtext/richtextmarginspage.cpp:186
 #: ../src/richtext/richtextmarginspage.cpp:300
-#: ../src/richtext/richtextsizepage.cpp:532
-#: ../src/richtext/richtextsizepage.cpp:539
 msgid "&Left:"
 msgstr "&Kiri:"
 
@@ -500,11 +528,11 @@ msgstr "&Kiri:"
 msgid "&List level:"
 msgstr "Paras senarai:"
 
-#: ../src/generic/logg.cpp:517
+#: ../src/generic/logg.cpp:514
 msgid "&Log"
 msgstr "&Log"
 
-#: ../src/univ/themes/win32.cpp:3748
+#: ../src/univ/themes/win32.cpp:3745
 msgid "&Move"
 msgstr "&Pindah"
 
@@ -512,21 +540,20 @@ msgstr "&Pindah"
 msgid "&Move the object to:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 #, fuzzy
 msgid "&Network"
 msgstr "&Baru"
 
-#: ../src/richtext/richtexttabspage.cpp:132 ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173 ../src/richtext/richtexttabspage.cpp:132
 msgid "&New"
 msgstr "&Baru"
 
-#: ../src/aui/tabmdi.cpp:111 ../src/generic/mdig.cpp:100
-#: ../src/msw/mdi.cpp:180
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
 msgid "&Next"
 msgstr "Seterus&nya"
 
-#: ../src/generic/wizard.cpp:432 ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:429
 msgid "&Next >"
 msgstr "Seterus&nya >"
 
@@ -535,7 +562,7 @@ msgstr "Seterus&nya >"
 msgid "&Next Paragraph"
 msgstr "Selepas satu perenggan:"
 
-#: ../src/generic/tipdlg.cpp:240
+#: ../src/generic/tipdlg.cpp:237
 msgid "&Next Tip"
 msgstr "Kias Seterusnya"
 
@@ -543,11 +570,11 @@ msgstr "Kias Seterusnya"
 msgid "&Next style:"
 msgstr "Gaya berikutnya:"
 
-#: ../src/common/stockitem.cpp:177 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:174 ../src/msw/msgdlg.cpp:435
 msgid "&No"
 msgstr "T&idak"
 
-#: ../src/generic/dbgrptg.cpp:356
+#: ../src/generic/dbgrptg.cpp:360
 msgid "&Notes:"
 msgstr "&Nota:"
 
@@ -555,12 +582,12 @@ msgstr "&Nota:"
 msgid "&Number:"
 msgstr "&Nombor:"
 
-#: ../src/generic/fontdlgg.cpp:475 ../src/generic/fontdlgg.cpp:482
-#: ../src/osx/carbon/fontdlg.cpp:408 ../src/common/stockitem.cpp:178
+#: ../src/osx/carbon/fontdlg.cpp:405 ../src/common/stockitem.cpp:175
+#: ../src/generic/fontdlgg.cpp:471 ../src/generic/fontdlgg.cpp:478
 msgid "&OK"
 msgstr "&OK"
 
-#: ../src/generic/dbgrptg.cpp:342 ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176 ../src/generic/dbgrptg.cpp:342
 msgid "&Open..."
 msgstr "&Buka..."
 
@@ -573,16 +600,16 @@ msgstr "Paras senarai:"
 msgid "&Page Break"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:334 ../src/osx/textctrl_osx.cpp:578
-#: ../src/common/stockitem.cpp:180 ../src/msw/textctrl.cpp:2509
+#: ../src/osx/textctrl_osx.cpp:596 ../src/common/stockitem.cpp:177
+#: ../src/msw/textctrl.cpp:2774 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&Tepek"
 
-#: ../include/wx/richtext/richtextbuffer.h:5010
+#: ../include/wx/richtext/richtextbuffer.h:5005
 msgid "&Picture"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:419
 msgid "&Point size:"
 msgstr "Saiz titik:"
 
@@ -595,12 +622,11 @@ msgstr "&Posisi (satu persepuluh mm):"
 msgid "&Position mode:"
 msgstr "Soalan"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178
 msgid "&Preferences"
 msgstr "Keutamaan"
 
-#: ../src/aui/tabmdi.cpp:112 ../src/generic/mdig.cpp:101
-#: ../src/msw/mdi.cpp:181
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
 msgid "&Previous"
 msgstr "&Sebelum"
 
@@ -609,80 +635,75 @@ msgstr "&Sebelum"
 msgid "&Previous Paragraph"
 msgstr "Laman sebelum:"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "&Print..."
 msgstr "Ce&tak..."
 
-#: ../src/richtext/richtextctrl.cpp:339 ../src/richtext/richtextctrl.cpp:5514
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtextctrl.cpp:338
+#: ../src/richtext/richtextctrl.cpp:5512
 msgid "&Properties"
 msgstr "&Ciri-ciri"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "&Quit"
 msgstr "&Keluar"
 
-#: ../src/richtext/richtextctrl.cpp:330 ../src/osx/textctrl_osx.cpp:574
-#: ../src/common/stockitem.cpp:185 ../src/common/cmdproc.cpp:293
-#: ../src/common/cmdproc.cpp:300 ../src/msw/textctrl.cpp:2505
+#: ../src/osx/textctrl_osx.cpp:592 ../src/common/stockitem.cpp:182
+#: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
+#: ../src/msw/textctrl.cpp:2770 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Ulangcara"
 
-#: ../src/common/cmdproc.cpp:289 ../src/common/cmdproc.cpp:309
+#: ../src/common/cmdproc.cpp:282 ../src/common/cmdproc.cpp:302
 msgid "&Redo "
 msgstr "&Ulangcara "
 
-#: ../src/richtext/richtextstyledlg.cpp:257
+#: ../src/richtext/richtextstyledlg.cpp:253
 msgid "&Rename Style..."
 msgstr "Menamakan Gaya..."
 
-#: ../src/generic/fdrepdlg.cpp:179
+#: ../src/generic/fdrepdlg.cpp:176
 msgid "&Replace"
 msgstr "&Ganti"
 
-#: ../src/richtext/richtextstyledlg.cpp:287
+#: ../src/richtext/richtextstyledlg.cpp:283
 msgid "&Restart numbering"
 msgstr "Ulangmula pernomboran"
 
-#: ../src/univ/themes/win32.cpp:3747
+#: ../src/univ/themes/win32.cpp:3744
 msgid "&Restore"
 msgstr "&Pulih"
 
-#: ../src/richtext/richtextindentspage.cpp:146
 #: ../src/richtext/richtextliststylepage.cpp:335
+#: ../src/richtext/richtextindentspage.cpp:146
 msgid "&Right"
 msgstr "K&anan"
 
-#: ../src/richtext/richtextindentspage.cpp:213
+#: ../src/richtext/richtextsizepage.cpp:602
+#: ../src/richtext/richtextsizepage.cpp:609
 #: ../src/richtext/richtextborderspage.cpp:277
 #: ../src/richtext/richtextborderspage.cpp:445
 #: ../src/richtext/richtextliststylepage.cpp:399
+#: ../src/richtext/richtextindentspage.cpp:213
 #: ../src/richtext/richtextmarginspage.cpp:211
 #: ../src/richtext/richtextmarginspage.cpp:325
-#: ../src/richtext/richtextsizepage.cpp:602
-#: ../src/richtext/richtextsizepage.cpp:609
 msgid "&Right:"
 msgstr "K&anan:"
 
-#: ../src/common/stockitem.cpp:190
+#: ../src/common/stockitem.cpp:187
 msgid "&Save"
 msgstr "&Simpan"
-
-#: ../src/common/stockitem.cpp:191
-#, fuzzy
-msgid "&Save as"
-msgstr "Simpan Sebagai"
 
 #: ../include/wx/richmsgdlg.h:29
 #, fuzzy
 msgid "&See details"
 msgstr "&Terperinci"
 
-#: ../src/generic/tipdlg.cpp:236
+#: ../src/generic/tipdlg.cpp:233
 msgid "&Show tips at startup"
 msgstr "Papar pe&tua pada permulaan"
 
-#: ../src/univ/themes/win32.cpp:3750
+#: ../src/univ/themes/win32.cpp:3747
 msgid "&Size"
 msgstr "&Saiz"
 
@@ -690,37 +711,37 @@ msgstr "&Saiz"
 msgid "&Size:"
 msgstr "Saiz:"
 
-#: ../src/generic/progdlgg.cpp:252
+#: ../src/generic/progdlgg.cpp:249
 #, fuzzy
 msgid "&Skip"
 msgstr "Langkau"
 
-#: ../src/richtext/richtextindentspage.cpp:242
 #: ../src/richtext/richtextliststylepage.cpp:417
+#: ../src/richtext/richtextindentspage.cpp:242
 msgid "&Spacing (tenths of a mm)"
 msgstr "&Ruang (satu persepuluh mm)"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "&Spell Check"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "&Stop"
 msgstr "&Henti"
 
-#: ../src/richtext/richtextfontpage.cpp:275 ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196 ../src/richtext/richtextfontpage.cpp:275
 msgid "&Strikethrough"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:382 ../src/richtext/richtextstylepage.cpp:106
+#: ../src/generic/fontdlgg.cpp:378 ../src/richtext/richtextstylepage.cpp:106
 msgid "&Style:"
 msgstr "Ga&ya:"
 
-#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:194
 msgid "&Styles:"
 msgstr "Gaya:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:413
+#: ../src/richtext/richtextsymboldlg.cpp:410
 msgid "&Subset:"
 msgstr "&Subset:"
 
@@ -734,27 +755,27 @@ msgstr "Simbol:"
 msgid "&Synchronize values"
 msgstr ""
 
-#: ../include/wx/richtext/richtextbuffer.h:6069
+#: ../include/wx/richtext/richtextbuffer.h:6064
 #, fuzzy
 msgid "&Table"
 msgstr "Tab"
 
-#: ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197
 #, fuzzy
 msgid "&Top"
 msgstr "&Salin"
 
+#: ../src/richtext/richtextsizepage.cpp:567
+#: ../src/richtext/richtextsizepage.cpp:574
 #: ../src/richtext/richtextborderspage.cpp:311
 #: ../src/richtext/richtextborderspage.cpp:479
 #: ../src/richtext/richtextmarginspage.cpp:234
 #: ../src/richtext/richtextmarginspage.cpp:348
-#: ../src/richtext/richtextsizepage.cpp:567
-#: ../src/richtext/richtextsizepage.cpp:574
 #, fuzzy
 msgid "&Top:"
 msgstr "Ke:"
 
-#: ../src/generic/fontdlgg.cpp:444 ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199 ../src/generic/fontdlgg.cpp:441
 msgid "&Underline"
 msgstr "Garis bawah"
 
@@ -762,21 +783,21 @@ msgstr "Garis bawah"
 msgid "&Underlining:"
 msgstr "Garis bawah:"
 
-#: ../src/richtext/richtextctrl.cpp:329 ../src/osx/textctrl_osx.cpp:573
-#: ../src/common/stockitem.cpp:203 ../src/common/cmdproc.cpp:271
-#: ../src/msw/textctrl.cpp:2504
+#: ../src/osx/textctrl_osx.cpp:591 ../src/common/stockitem.cpp:200
+#: ../src/common/cmdproc.cpp:264 ../src/msw/textctrl.cpp:2769
+#: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Nyahcara"
 
-#: ../src/common/cmdproc.cpp:265
+#: ../src/common/cmdproc.cpp:258
 msgid "&Undo "
 msgstr "&Nyahcara "
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "&Unindent"
 msgstr "Nyahjarak"
 
-#: ../src/common/stockitem.cpp:205
+#: ../src/common/stockitem.cpp:202
 msgid "&Up"
 msgstr "A&tas"
 
@@ -795,7 +816,7 @@ msgstr "J&ajaran Peluru:"
 msgid "&View..."
 msgstr "&Buka..."
 
-#: ../src/generic/fontdlgg.cpp:393
+#: ../src/generic/fontdlgg.cpp:389
 msgid "&Weight:"
 msgstr "Berat:"
 
@@ -805,88 +826,58 @@ msgstr "Berat:"
 msgid "&Width:"
 msgstr "Berat:"
 
-#: ../src/aui/tabmdi.cpp:311 ../src/aui/tabmdi.cpp:327
-#: ../src/aui/tabmdi.cpp:329 ../src/generic/mdig.cpp:294
-#: ../src/generic/mdig.cpp:310 ../src/generic/mdig.cpp:314
-#: ../src/msw/mdi.cpp:78
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
 msgid "&Window"
 msgstr "&Tetingkap"
 
-#: ../src/common/stockitem.cpp:206 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:203 ../src/msw/msgdlg.cpp:435
 msgid "&Yes"
 msgstr "&Ya"
 
-#: ../src/common/valtext.cpp:256
+#: ../src/common/valtext.cpp:197
 #, fuzzy, c-format
-msgid "'%s' contains illegal characters"
+msgid "'%s' contains invalid character(s)"
 msgstr "'%s' sepatutnya mengandungi aksara abjab sahaja."
 
-#: ../src/common/valtext.cpp:254
-#, fuzzy, c-format
-msgid "'%s' doesn't consist only of valid characters"
-msgstr "'%s' sepatutnya mengandungi aksara abjab sahaja."
-
-#: ../src/common/config.cpp:519 ../src/msw/regconf.cpp:258
+#: ../src/common/config.cpp:515 ../src/msw/regconf.cpp:255
 #, c-format
 msgid "'%s' has extra '..', ignored."
 msgstr "'%s' ada lebihan '..', diabaikan."
 
-#: ../src/common/cmdline.cpp:1113 ../src/common/cmdline.cpp:1131
+#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' bukanlah nilai nombor yang betul untul pilihan '%s'."
 
-#: ../src/common/translation.cpp:1100
+#: ../src/common/translation.cpp:1142
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' bukanlah mesej katalog yang sah."
 
-#: ../src/common/valtext.cpp:165
+#: ../src/common/valtext.cpp:188
 #, fuzzy, c-format
 msgid "'%s' is not one of the valid strings"
 msgstr "'%s' bukanlah mesej katalog yang sah."
 
-#: ../src/common/valtext.cpp:167
+#: ../src/common/valtext.cpp:186
 #, fuzzy, c-format
 msgid "'%s' is one of the invalid strings"
 msgstr "'%s' tidak sah"
 
-#: ../src/common/textbuf.cpp:237
+#: ../src/common/textbuf.cpp:233
 #, c-format
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' kemungkinan adalah penimbal binari."
-
-#: ../src/common/valtext.cpp:252
-#, c-format
-msgid "'%s' should be numeric."
-msgstr "'%s' sepatutnya nombor."
-
-#: ../src/common/valtext.cpp:244
-#, c-format
-msgid "'%s' should only contain ASCII characters."
-msgstr "'%s' sepatutnya mengandungi aksara ASCII sahaja."
-
-#: ../src/common/valtext.cpp:246
-#, c-format
-msgid "'%s' should only contain alphabetic characters."
-msgstr "'%s' sepatutnya mengandungi aksara abjab sahaja."
-
-#: ../src/common/valtext.cpp:248
-#, c-format
-msgid "'%s' should only contain alphabetic or numeric characters."
-msgstr "'%s' hanya patut mengandungi aksara abjab atau nombor."
-
-#: ../src/common/valtext.cpp:250
-#, fuzzy, c-format
-msgid "'%s' should only contain digits."
-msgstr "'%s' sepatutnya mengandungi aksara ASCII sahaja."
 
 #: ../src/richtext/richtextliststylepage.cpp:229
 #: ../src/richtext/richtextbulletspage.cpp:166
 msgid "(*)"
 msgstr "(*)"
 
-#: ../src/html/helpwnd.cpp:963
+#: ../src/html/helpwnd.cpp:961
 msgid "(Help)"
 msgstr "(Bantuan)"
 
@@ -895,27 +886,32 @@ msgstr "(Bantuan)"
 msgid "(None)"
 msgstr "(Tiada)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:504
+#: ../src/richtext/richtextsymboldlg.cpp:503
 msgid "(Normal text)"
 msgstr "(Teks Normal)"
 
-#: ../src/html/helpwnd.cpp:419 ../src/html/helpwnd.cpp:1106
-#: ../src/html/helpwnd.cpp:1742
+#: ../src/html/helpwnd.cpp:417 ../src/html/helpwnd.cpp:1104
+#: ../src/html/helpwnd.cpp:1740
 msgid "(bookmarks)"
 msgstr "(tanda laman)"
 
+#: ../src/msw/dlmsw.cpp:167
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (ralat %ld: %s)"
+
+#: ../src/richtext/richtextformatdlg.cpp:876
+#: ../src/richtext/richtextliststylepage.cpp:448
+#: ../src/richtext/richtextliststylepage.cpp:460
+#: ../src/richtext/richtextliststylepage.cpp:461
 #: ../src/richtext/richtextindentspage.cpp:274
 #: ../src/richtext/richtextindentspage.cpp:286
 #: ../src/richtext/richtextindentspage.cpp:287
 #: ../src/richtext/richtextindentspage.cpp:311
 #: ../src/richtext/richtextindentspage.cpp:326
-#: ../src/richtext/richtextformatdlg.cpp:884
 #: ../src/richtext/richtextfontpage.cpp:349
 #: ../src/richtext/richtextfontpage.cpp:353
 #: ../src/richtext/richtextfontpage.cpp:357
-#: ../src/richtext/richtextliststylepage.cpp:448
-#: ../src/richtext/richtextliststylepage.cpp:460
-#: ../src/richtext/richtextliststylepage.cpp:461
 msgid "(none)"
 msgstr "(tiada)"
 
@@ -934,7 +930,7 @@ msgstr "*)"
 msgid "+"
 msgstr "+"
 
-#: ../src/msw/utils.cpp:1152
+#: ../src/msw/utils.cpp:1143
 msgid ", 64-bit edition"
 msgstr ""
 
@@ -943,172 +939,172 @@ msgstr ""
 msgid "-"
 msgstr "-"
 
-#: ../src/generic/filepickerg.cpp:66
+#: ../src/generic/filepickerg.cpp:63
 #, fuzzy
 msgid "..."
 msgstr ".."
 
-#: ../src/richtext/richtextindentspage.cpp:276
 #: ../src/richtext/richtextliststylepage.cpp:450
+#: ../src/richtext/richtextindentspage.cpp:276
 #, fuzzy
 msgid "1.1"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:277
 #: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextindentspage.cpp:277
 #, fuzzy
 msgid "1.2"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:278
 #: ../src/richtext/richtextliststylepage.cpp:452
+#: ../src/richtext/richtextindentspage.cpp:278
 #, fuzzy
 msgid "1.3"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:279
 #: ../src/richtext/richtextliststylepage.cpp:453
+#: ../src/richtext/richtextindentspage.cpp:279
 #, fuzzy
 msgid "1.4"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:280
 #: ../src/richtext/richtextliststylepage.cpp:454
+#: ../src/richtext/richtextindentspage.cpp:280
 msgid "1.5"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:281
 #: ../src/richtext/richtextliststylepage.cpp:455
+#: ../src/richtext/richtextindentspage.cpp:281
 #, fuzzy
 msgid "1.6"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:282
 #: ../src/richtext/richtextliststylepage.cpp:456
+#: ../src/richtext/richtextindentspage.cpp:282
 #, fuzzy
 msgid "1.7"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:283
 #: ../src/richtext/richtextliststylepage.cpp:457
+#: ../src/richtext/richtextindentspage.cpp:283
 #, fuzzy
 msgid "1.8"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:284
 #: ../src/richtext/richtextliststylepage.cpp:458
+#: ../src/richtext/richtextindentspage.cpp:284
 #, fuzzy
 msgid "1.9"
 msgstr "1.5"
 
-#: ../src/common/paper.cpp:140
+#: ../src/common/paper.cpp:137
 msgid "10 x 11 in"
 msgstr "10 x 11 in"
 
-#: ../src/common/paper.cpp:113
+#: ../src/common/paper.cpp:110
 msgid "10 x 14 in"
 msgstr "10 x 14 in"
 
-#: ../src/common/paper.cpp:114
+#: ../src/common/paper.cpp:111
 msgid "11 x 17 in"
 msgstr "11 x 17 in"
 
-#: ../src/common/paper.cpp:184
+#: ../src/common/paper.cpp:181
 msgid "12 x 11 in"
 msgstr "12 x 11 in"
 
-#: ../src/common/paper.cpp:141
+#: ../src/common/paper.cpp:138
 msgid "15 x 11 in"
 msgstr "15 x 11 in"
 
-#: ../src/richtext/richtextindentspage.cpp:285
 #: ../src/richtext/richtextliststylepage.cpp:459
+#: ../src/richtext/richtextindentspage.cpp:285
 msgid "2"
 msgstr "2"
 
-#: ../src/common/paper.cpp:132
+#: ../src/common/paper.cpp:129
 msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
 msgstr "Sampul 6 3/4, 3 5/8 x 6 1/2 in"
 
-#: ../src/common/paper.cpp:139
+#: ../src/common/paper.cpp:136
 msgid "9 x 11 in"
 msgstr "9 x 11 in"
 
-#: ../src/html/htmprint.cpp:431
+#: ../src/html/htmprint.cpp:443
 msgid ": file does not exist!"
 msgstr ": fail tidak wujud!"
 
-#: ../src/common/fontmap.cpp:199
+#: ../src/common/fontmap.cpp:196
 msgid ": unknown charset"
 msgstr ": set aksara tidak diketahui"
 
-#: ../src/common/fontmap.cpp:413
+#: ../src/common/fontmap.cpp:410
 msgid ": unknown encoding"
 msgstr ":pengenkodan tidak diketahui"
 
-#: ../src/generic/wizard.cpp:443
+#: ../src/generic/wizard.cpp:438
 msgid "< &Back"
 msgstr "< &Undur"
 
-#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:628
-#: ../src/osx/carbon/fontdlg.cpp:648
+#: ../src/osx/carbon/fontdlg.cpp:419 ../src/osx/carbon/fontdlg.cpp:625
+#: ../src/osx/carbon/fontdlg.cpp:645
 msgid "<Any Decorative>"
 msgstr "<Sebarang Dekoratif>"
 
-#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:630
-#: ../src/osx/carbon/fontdlg.cpp:650
+#: ../src/osx/carbon/fontdlg.cpp:420 ../src/osx/carbon/fontdlg.cpp:627
+#: ../src/osx/carbon/fontdlg.cpp:647
 msgid "<Any Modern>"
 msgstr "<Sebarang Moden>"
 
-#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:626
-#: ../src/osx/carbon/fontdlg.cpp:646
+#: ../src/osx/carbon/fontdlg.cpp:418 ../src/osx/carbon/fontdlg.cpp:623
+#: ../src/osx/carbon/fontdlg.cpp:643
 msgid "<Any Roman>"
 msgstr "<Sebarang Roman>"
 
-#: ../src/osx/carbon/fontdlg.cpp:424 ../src/osx/carbon/fontdlg.cpp:632
-#: ../src/osx/carbon/fontdlg.cpp:652
+#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:629
+#: ../src/osx/carbon/fontdlg.cpp:649
 msgid "<Any Script>"
 msgstr "<Sebarang Skrip>"
 
-#: ../src/osx/carbon/fontdlg.cpp:425 ../src/osx/carbon/fontdlg.cpp:637
-#: ../src/osx/carbon/fontdlg.cpp:656
+#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:634
+#: ../src/osx/carbon/fontdlg.cpp:653
 msgid "<Any Swiss>"
 msgstr "<Sebarang Swiss>"
 
-#: ../src/osx/carbon/fontdlg.cpp:426 ../src/osx/carbon/fontdlg.cpp:634
-#: ../src/osx/carbon/fontdlg.cpp:654
+#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:631
+#: ../src/osx/carbon/fontdlg.cpp:651
 msgid "<Any Teletype>"
 msgstr "<Sebarang Teletaip>"
 
-#: ../src/osx/carbon/fontdlg.cpp:420
+#: ../src/osx/carbon/fontdlg.cpp:417
 msgid "<Any>"
 msgstr "<Sebarang>"
 
-#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
 msgid "<DIR>"
 msgstr "<DIR>"
 
-#: ../src/generic/filectrlg.cpp:254 ../src/generic/filectrlg.cpp:277
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
 msgid "<DRIVE>"
 msgstr "<DRIVE>"
 
-#: ../src/generic/filectrlg.cpp:252 ../src/generic/filectrlg.cpp:275
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
 msgid "<LINK>"
 msgstr "<LINK>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1264
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Rupa tebal italik.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1270
+#: ../src/html/helpwnd.cpp:1268
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>tebal italik <u>garis bawah</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1265
+#: ../src/html/helpwnd.cpp:1263
 msgid "<b>Bold face.</b> "
 msgstr "<b>Rupa tebal.</b> "
 
-#: ../src/html/helpwnd.cpp:1264
+#: ../src/html/helpwnd.cpp:1262
 msgid "<i>Italic face.</i> "
 msgstr "<i>Rupa italik.</i> "
 
@@ -1117,16 +1113,16 @@ msgstr "<i>Rupa italik.</i> "
 msgid ">"
 msgstr ">"
 
-#: ../src/generic/dbgrptg.cpp:318
+#: ../src/generic/dbgrptg.cpp:317
 msgid "A debug report has been generated in the directory\n"
 msgstr "Laporan nyahpijat telah dijana dalam direktori\n"
 
-#: ../src/common/debugrpt.cpp:573
+#: ../src/common/debugrpt.cpp:574
 #, fuzzy
 msgid "A debug report has been generated. It can be found in"
 msgstr "Laporan nyahpijat telah dijana dalam direktori\n"
 
-#: ../src/common/xtixml.cpp:418
+#: ../src/common/xtixml.cpp:414
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Pengumpulan bukan kosong mesti terdiri daripada nod 'elemen'"
 
@@ -1137,109 +1133,109 @@ msgstr "Pengumpulan bukan kosong mesti terdiri daripada nod 'elemen'"
 msgid "A standard bullet name."
 msgstr "Nama peluru piawai"
 
-#: ../src/common/paper.cpp:217
+#: ../src/common/paper.cpp:214
 #, fuzzy
 msgid "A0 sheet, 841 x 1189 mm"
 msgstr "Helai A4, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:218
+#: ../src/common/paper.cpp:215
 #, fuzzy
 msgid "A1 sheet, 594 x 841 mm"
 msgstr "Helai A3, 297 x 420 mm"
 
-#: ../src/common/paper.cpp:159
+#: ../src/common/paper.cpp:156
 msgid "A2 420 x 594 mm"
 msgstr "A2 420 x 594 mm"
 
-#: ../src/common/paper.cpp:156
+#: ../src/common/paper.cpp:153
 msgid "A3 Extra 322 x 445 mm"
 msgstr "A3 Extra 322 x 445 mm"
 
-#: ../src/common/paper.cpp:161
+#: ../src/common/paper.cpp:158
 msgid "A3 Extra Transverse 322 x 445 mm"
 msgstr "A3 Ekstra Lintang 322 x 445 mm"
 
-#: ../src/common/paper.cpp:170
+#: ../src/common/paper.cpp:167
 msgid "A3 Rotated 420 x 297 mm"
 msgstr "A3 Diputar 420 x 297 mm"
 
-#: ../src/common/paper.cpp:160
+#: ../src/common/paper.cpp:157
 msgid "A3 Transverse 297 x 420 mm"
 msgstr "A3 Lintang 297 x 420 mm"
 
-#: ../src/common/paper.cpp:106
+#: ../src/common/paper.cpp:103
 msgid "A3 sheet, 297 x 420 mm"
 msgstr "Helai A3, 297 x 420 mm"
 
-#: ../src/common/paper.cpp:146
+#: ../src/common/paper.cpp:143
 msgid "A4 Extra 9.27 x 12.69 in"
 msgstr "A4 Ekstra 9.27 x 12.69 in"
 
-#: ../src/common/paper.cpp:153
+#: ../src/common/paper.cpp:150
 msgid "A4 Plus 210 x 330 mm"
 msgstr "A4 Tambah 210 x 330 mm"
 
-#: ../src/common/paper.cpp:171
+#: ../src/common/paper.cpp:168
 msgid "A4 Rotated 297 x 210 mm"
 msgstr "A4 Diputar 297 x 210 mm"
 
-#: ../src/common/paper.cpp:148
+#: ../src/common/paper.cpp:145
 msgid "A4 Transverse 210 x 297 mm"
 msgstr "A4 Lintang 210 x 297 mm"
 
-#: ../src/common/paper.cpp:97
+#: ../src/common/paper.cpp:94
 msgid "A4 sheet, 210 x 297 mm"
 msgstr "Helai A4, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:107
+#: ../src/common/paper.cpp:104
 msgid "A4 small sheet, 210 x 297 mm"
 msgstr "Helai kecil A4, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:157
+#: ../src/common/paper.cpp:154
 msgid "A5 Extra 174 x 235 mm"
 msgstr "A5 Ekstra 174 x 235 mm"
 
-#: ../src/common/paper.cpp:172
+#: ../src/common/paper.cpp:169
 msgid "A5 Rotated 210 x 148 mm"
 msgstr "A5 Diputar 210 x 148 mm"
 
-#: ../src/common/paper.cpp:154
+#: ../src/common/paper.cpp:151
 msgid "A5 Transverse 148 x 210 mm"
 msgstr "A5 Lintang 148 x 210 mm"
 
-#: ../src/common/paper.cpp:108
+#: ../src/common/paper.cpp:105
 msgid "A5 sheet, 148 x 210 mm"
 msgstr "Helai A5, 148 x 210 mm"
 
-#: ../src/common/paper.cpp:164
+#: ../src/common/paper.cpp:161
 msgid "A6 105 x 148 mm"
 msgstr "A6 105 x 148 mm"
 
-#: ../src/common/paper.cpp:177
+#: ../src/common/paper.cpp:174
 msgid "A6 Rotated 148 x 105 mm"
 msgstr "A6 Diputar 148 x 105 mm"
 
-#: ../src/generic/fontdlgg.cpp:83 ../src/richtext/richtextformatdlg.cpp:529
-#: ../src/osx/carbon/fontdlg.cpp:153
+#: ../src/osx/carbon/fontdlg.cpp:150 ../src/generic/fontdlgg.cpp:79
+#: ../src/richtext/richtextformatdlg.cpp:521
 msgid "ABCDEFGabcdefg12345"
 msgstr "ABCDEFGabcdefg12345"
 
-#: ../src/richtext/richtextsymboldlg.cpp:458 ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
 msgid "ASCII"
 msgstr "ASCII"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 #, fuzzy
 msgid "About"
 msgstr "Perih&al"
 
-#: ../src/generic/aboutdlgg.cpp:140 ../src/osx/menu_osx.cpp:558
-#: ../src/msw/aboutdlg.cpp:64
+#: ../src/osx/menu_osx.cpp:450 ../src/generic/aboutdlgg.cpp:137
+#: ../src/msw/aboutdlg.cpp:61
 #, fuzzy, c-format
 msgid "About %s"
 msgstr "Perihal"
 
-#: ../src/osx/menu_osx.cpp:560
+#: ../src/osx/menu_osx.cpp:452
 #, fuzzy
 msgid "About..."
 msgstr "Perih&al"
@@ -1249,39 +1245,39 @@ msgid "Absolute"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:873
+#: ../src/propgrid/advprops.cpp:774
 #, fuzzy
 msgid "ActiveBorder"
 msgstr "Moden"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:874
+#: ../src/propgrid/advprops.cpp:775
 msgid "ActiveCaption"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 #, fuzzy
 msgid "Actual Size"
 msgstr "Saiz Seben&ar"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:140 ../src/common/accelcmn.cpp:81
+#: ../src/common/stockitem.cpp:137 ../src/common/accelcmn.cpp:78
 msgid "Add"
 msgstr "Tambah"
 
-#: ../src/richtext/richtextbuffer.cpp:11455
+#: ../src/richtext/richtextbuffer.cpp:11454
 msgid "Add Column"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11392
+#: ../src/richtext/richtextbuffer.cpp:11391
 msgid "Add Row"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:432
+#: ../src/html/helpwnd.cpp:430
 msgid "Add current page to bookmarks"
 msgstr "Tambah laman semasa ke tanda laman"
 
-#: ../src/generic/colrdlgg.cpp:366
+#: ../src/generic/colrdlgg.cpp:386
 msgid "Add to custom colours"
 msgstr "Tambah kepada warna adat"
 
@@ -1293,12 +1289,12 @@ msgstr "AddToPropertyCollection dipanggil pada generic accessor"
 msgid "AddToPropertyCollection called w/o valid adder"
 msgstr "AddToPropertyCollection dipanggill tanpa penambah sah"
 
-#: ../src/html/helpctrl.cpp:159
+#: ../src/html/helpctrl.cpp:155
 #, c-format
 msgid "Adding book %s"
 msgstr "Tambah buku %s"
 
-#: ../src/common/preferencescmn.cpp:43
+#: ../src/common/preferencescmn.cpp:40
 msgid "Advanced"
 msgstr ""
 
@@ -1306,11 +1302,11 @@ msgstr ""
 msgid "After a paragraph:"
 msgstr "Selepas satu perenggan:"
 
-#: ../src/common/stockitem.cpp:172
+#: ../src/common/stockitem.cpp:169
 msgid "Align Left"
 msgstr "Jajar Kiri"
 
-#: ../src/common/stockitem.cpp:173
+#: ../src/common/stockitem.cpp:170
 msgid "Align Right"
 msgstr "Jajar Kanan"
 
@@ -1319,40 +1315,40 @@ msgstr "Jajar Kanan"
 msgid "Alignment"
 msgstr "J&ajaran"
 
-#: ../src/generic/prntdlgg.cpp:215
+#: ../src/generic/prntdlgg.cpp:208
 msgid "All"
 msgstr "Semua"
 
-#: ../src/generic/filectrlg.cpp:1197 ../src/common/fldlgcmn.cpp:107
+#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1186
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Semua fail (%s)|%s"
 
-#: ../include/wx/defs.h:2886
+#: ../include/wx/defs.h:2582
 msgid "All files (*)|*"
 msgstr "Semua fail (*)|*"
 
-#: ../include/wx/defs.h:2883
+#: ../include/wx/defs.h:2579
 msgid "All files (*.*)|*.*"
 msgstr "Semua fail (*.*)|*.*"
 
-#: ../src/richtext/richtextstyles.cpp:1061
+#: ../src/richtext/richtextstyles.cpp:1058
 msgid "All styles"
 msgstr "Semua gaya"
 
-#: ../src/propgrid/manager.cpp:1528
+#: ../src/propgrid/manager.cpp:1544
 msgid "Alphabetic Mode"
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:425
+#: ../src/common/xtistrm.cpp:422
 msgid "Already Registered Object passed to SetObjectClassInfo"
 msgstr "Objek Sedia Daftar dilepaskan ke SetObjectClassInfo"
 
-#: ../src/unix/dialup.cpp:353
+#: ../src/unix/dialup.cpp:352
 msgid "Already dialling ISP."
 msgstr "Sudah mendail ISP"
 
-#: ../src/common/accelcmn.cpp:331 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/accelcmn.cpp:345 ../src/univ/themes/win32.cpp:3753
 #, fuzzy
 msgid "Alt+"
 msgstr "Alt-"
@@ -1362,37 +1358,37 @@ msgstr "Alt-"
 msgid "An optional corner radius for adding rounded corners."
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:576
+#: ../src/common/debugrpt.cpp:577
 #, fuzzy
 msgid "And includes the following files:\n"
 msgstr "*** Dan termasuk fail berikut:\n"
 
-#: ../src/generic/animateg.cpp:162
+#: ../src/generic/animateg.cpp:145
 #, c-format
 msgid "Animation file is not of type %ld."
 msgstr "Fail animasi bukan berjenis %ld."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:872
+#: ../src/propgrid/advprops.cpp:773
 msgid "AppWorkspace"
 msgstr ""
 
-#: ../src/generic/logg.cpp:1014
+#: ../src/generic/logg.cpp:1011
 #, c-format
 msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
 msgstr "Tokok fail log '%s' (memilih [Tidak] akan menindihnya)?"
 
-#: ../src/osx/menu_osx.cpp:577 ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:469 ../src/osx/menu_osx.cpp:477
 #, fuzzy
 msgid "Application"
 msgstr "Pemilihan"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 #, fuzzy
 msgid "Apply"
 msgstr "Ter&ap"
 
-#: ../src/propgrid/advprops.cpp:1609
+#: ../src/propgrid/advprops.cpp:1515
 msgid "Aqua"
 msgstr ""
 
@@ -1401,31 +1397,31 @@ msgstr ""
 msgid "Arabic"
 msgstr "Arab"
 
-#: ../src/common/fmapbase.cpp:153
+#: ../src/common/fmapbase.cpp:150
 msgid "Arabic (ISO-8859-6)"
 msgstr "Arabik (ISO-8859-6)"
 
-#: ../src/msw/ole/automtn.cpp:672
+#: ../src/msw/ole/automtn.cpp:663
 #, fuzzy, c-format
 msgid "Argument %u not found."
 msgstr "Fail bantuan \"%s\" tidak ditemui."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1753
+#: ../src/propgrid/advprops.cpp:1654
 #, fuzzy
 msgid "Arrow"
 msgstr "esok"
 
-#: ../src/generic/aboutdlgg.cpp:184
+#: ../src/generic/aboutdlgg.cpp:181
 msgid "Artists"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 #, fuzzy
 msgid "Ascending"
 msgstr "membaca"
 
-#: ../src/generic/filectrlg.cpp:433
+#: ../src/generic/filectrlg.cpp:429
 msgid "Attributes"
 msgstr "Atribut"
 
@@ -1435,91 +1431,91 @@ msgstr "Atribut"
 msgid "Available fonts."
 msgstr "Fon yang ada."
 
-#: ../src/common/paper.cpp:137
+#: ../src/common/paper.cpp:134
 msgid "B4 (ISO) 250 x 353 mm"
 msgstr "B4 (ISO) 250 x 353 mm"
 
-#: ../src/common/paper.cpp:173
+#: ../src/common/paper.cpp:170
 msgid "B4 (JIS) Rotated 364 x 257 mm"
 msgstr "B4 (JIS) Diputar 364 x 257 mm"
 
-#: ../src/common/paper.cpp:127
+#: ../src/common/paper.cpp:124
 msgid "B4 Envelope, 250 x 353 mm"
 msgstr "B4 Envelope, 250 x 353 mm"
 
-#: ../src/common/paper.cpp:109
+#: ../src/common/paper.cpp:106
 msgid "B4 sheet, 250 x 354 mm"
 msgstr "Helai B4, 250 x 354 mm"
 
-#: ../src/common/paper.cpp:158
+#: ../src/common/paper.cpp:155
 msgid "B5 (ISO) Extra 201 x 276 mm"
 msgstr "B5 (ISO) Ekstra 201 x 276 mm"
 
-#: ../src/common/paper.cpp:174
+#: ../src/common/paper.cpp:171
 msgid "B5 (JIS) Rotated 257 x 182 mm"
 msgstr "B5 (JIS) Diputar 257 x 182 mm"
 
-#: ../src/common/paper.cpp:155
+#: ../src/common/paper.cpp:152
 msgid "B5 (JIS) Transverse 182 x 257 mm"
 msgstr "B5 (JIS) Lintang 182 x 257 mm"
 
-#: ../src/common/paper.cpp:128
+#: ../src/common/paper.cpp:125
 msgid "B5 Envelope, 176 x 250 mm"
 msgstr "Sampul B5, 176 x 250 mm"
 
-#: ../src/common/paper.cpp:110
+#: ../src/common/paper.cpp:107
 msgid "B5 sheet, 182 x 257 millimeter"
 msgstr "Helai B5, 182 x 257 mm"
 
-#: ../src/common/paper.cpp:182
+#: ../src/common/paper.cpp:179
 msgid "B6 (JIS) 128 x 182 mm"
 msgstr "B6 (JIS) 128 x 182 mm"
 
-#: ../src/common/paper.cpp:183
+#: ../src/common/paper.cpp:180
 msgid "B6 (JIS) Rotated 182 x 128 mm"
 msgstr "B6 (JIS) Diputar 182 x 128 mm"
 
-#: ../src/common/paper.cpp:129
+#: ../src/common/paper.cpp:126
 msgid "B6 Envelope, 176 x 125 mm"
 msgstr "Sampul B6, 176 x 125 mm"
 
-#: ../src/common/imagbmp.cpp:531 ../src/common/imagbmp.cpp:561
-#: ../src/common/imagbmp.cpp:576
+#: ../src/common/imagbmp.cpp:528 ../src/common/imagbmp.cpp:558
+#: ../src/common/imagbmp.cpp:573
 msgid "BMP: Couldn't allocate memory."
 msgstr "BMP: Gagal sediakan memori."
 
-#: ../src/common/imagbmp.cpp:100
+#: ../src/common/imagbmp.cpp:97
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: Tidak sapat menyimpan imej yang tidak sah."
 
-#: ../src/common/imagbmp.cpp:356
+#: ../src/common/imagbmp.cpp:353
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: Gagal menulis peta warna RGB."
 
-#: ../src/common/imagbmp.cpp:490
+#: ../src/common/imagbmp.cpp:487
 msgid "BMP: Couldn't write data."
 msgstr "BMP: Gagal menulis data."
 
-#: ../src/common/imagbmp.cpp:246
+#: ../src/common/imagbmp.cpp:243
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: Gagal menulis kepala fail (Bitmap)."
 
-#: ../src/common/imagbmp.cpp:269
+#: ../src/common/imagbmp.cpp:266
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: Gagal menulis fail kepala (BitmapInfo)."
 
-#: ../src/common/imagbmp.cpp:140
+#: ../src/common/imagbmp.cpp:137
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage tidak mempunyai wxPalette."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:142 ../src/common/accelcmn.cpp:52
+#: ../src/common/stockitem.cpp:139 ../src/common/accelcmn.cpp:49
 #, fuzzy
 msgid "Back"
 msgstr "Kem&bali"
 
+#: ../src/richtext/richtextformatdlg.cpp:377
 #: ../src/richtext/richtextbackgroundpage.cpp:148
-#: ../src/richtext/richtextformatdlg.cpp:384
 #, fuzzy
 msgid "Background"
 msgstr "Warna latar"
@@ -1529,21 +1525,21 @@ msgstr "Warna latar"
 msgid "Background &colour:"
 msgstr "Warna latar"
 
-#: ../src/osx/carbon/fontdlg.cpp:220
+#: ../src/osx/carbon/fontdlg.cpp:217
 msgid "Background colour"
 msgstr "Warna latar"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:52
+#: ../src/common/accelcmn.cpp:49
 #, fuzzy
 msgid "Backspace"
 msgstr "Kem&bali"
 
-#: ../src/common/fmapbase.cpp:160
+#: ../src/common/fmapbase.cpp:157
 msgid "Baltic (ISO-8859-13)"
 msgstr "Baltik (ISO-8859-13)"
 
-#: ../src/common/fmapbase.cpp:151
+#: ../src/common/fmapbase.cpp:148
 msgid "Baltic (old) (ISO-8859-4)"
 msgstr "Baltik (lama) (ISO-8859-4)"
 
@@ -1556,25 +1552,25 @@ msgstr "Sebelum perenggan:"
 msgid "Bitmap"
 msgstr "Peta bit"
 
-#: ../src/propgrid/advprops.cpp:1594
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Black"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1755
+#: ../src/propgrid/advprops.cpp:1656
 msgid "Blank"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1603
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Blue"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:345
+#: ../src/generic/colrdlgg.cpp:365
 msgid "Blue:"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:333 ../src/richtext/richtextfontpage.cpp:355
-#: ../src/osx/carbon/fontdlg.cpp:354 ../src/common/stockitem.cpp:143
+#: ../src/osx/carbon/fontdlg.cpp:351 ../src/common/stockitem.cpp:140
+#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:355
 msgid "Bold"
 msgstr "Tebal"
 
@@ -1584,34 +1580,38 @@ msgstr "Tebal"
 msgid "Border"
 msgstr "Moden"
 
-#: ../src/richtext/richtextformatdlg.cpp:379
+#: ../src/richtext/richtextformatdlg.cpp:372
 #, fuzzy
 msgid "Borders"
 msgstr "Moden"
 
-#: ../src/richtext/richtextsizepage.cpp:288 ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141 ../src/richtext/richtextsizepage.cpp:288
 msgid "Bottom"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:893
+#: ../src/generic/prntdlgg.cpp:886
 msgid "Bottom margin (mm):"
 msgstr "Jidar bawah (mm):"
 
-#: ../src/richtext/richtextbuffer.cpp:9383
+#: ../src/richtext/richtextbuffer.cpp:9380
 #, fuzzy
 msgid "Box Properties"
 msgstr "&Ciri-ciri"
 
-#: ../src/richtext/richtextstyles.cpp:1065
+#: ../src/richtext/richtextstyles.cpp:1062
 #, fuzzy
 msgid "Box styles"
 msgstr "Semua gaya"
 
-#: ../src/propgrid/advprops.cpp:1602
+#: ../src/osx/cocoa/menu.mm:292
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Brown"
 msgstr ""
 
-#: ../src/common/filepickercmn.cpp:43 ../src/common/filepickercmn.cpp:44
+#: ../src/common/filepickercmn.cpp:40 ../src/common/filepickercmn.cpp:41
 msgid "Browse"
 msgstr ""
 
@@ -1624,73 +1624,73 @@ msgstr "J&ajaran Peluru:"
 msgid "Bullet style"
 msgstr "Gaya peluru"
 
-#: ../src/richtext/richtextformatdlg.cpp:359
+#: ../src/richtext/richtextformatdlg.cpp:352
 msgid "Bullets"
 msgstr "Peluru"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1756
+#: ../src/propgrid/advprops.cpp:1657
 #, fuzzy
 msgid "Bullseye"
 msgstr "Gaya peluru"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:875
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonFace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:876
+#: ../src/propgrid/advprops.cpp:777
 msgid "ButtonHighlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:877
+#: ../src/propgrid/advprops.cpp:778
 msgid "ButtonShadow"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:878
+#: ../src/propgrid/advprops.cpp:779
 msgid "ButtonText"
 msgstr ""
 
-#: ../src/common/paper.cpp:98
+#: ../src/common/paper.cpp:95
 msgid "C sheet, 17 x 22 in"
 msgstr "Helai D, 22 x 34 in"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "C&lear"
 msgstr "Bersi&hkan"
 
-#: ../src/generic/fontdlgg.cpp:406
+#: ../src/generic/fontdlgg.cpp:403
 msgid "C&olour:"
 msgstr "Warna:"
 
-#: ../src/common/paper.cpp:123
+#: ../src/common/paper.cpp:120
 msgid "C3 Envelope, 324 x 458 mm"
 msgstr "Sampul C3, 324 x 458 mm"
 
-#: ../src/common/paper.cpp:124
+#: ../src/common/paper.cpp:121
 msgid "C4 Envelope, 229 x 324 mm"
 msgstr "Sampul C4, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:122
+#: ../src/common/paper.cpp:119
 msgid "C5 Envelope, 162 x 229 mm"
 msgstr "Sampul C5, 162 x 229 mm"
 
-#: ../src/common/paper.cpp:125
+#: ../src/common/paper.cpp:122
 msgid "C6 Envelope, 114 x 162 mm"
 msgstr "Sampul C6, 114 x 162 mm"
 
-#: ../src/common/paper.cpp:126
+#: ../src/common/paper.cpp:123
 msgid "C65 Envelope, 114 x 229 mm"
 msgstr "Sampul C65, 114 x 229 mm"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "CD-Rom"
 msgstr ""
 
-#: ../src/html/chm.cpp:815 ../src/html/chm.cpp:874
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:865
 msgid "CHM handler currently supports only local files!"
 msgstr "Pengemudi CHM kini hanya menyokong fail lokal!"
 
@@ -1698,191 +1698,195 @@ msgstr "Pengemudi CHM kini hanya menyokong fail lokal!"
 msgid "Ca&pitals"
 msgstr ""
 
-#: ../src/common/cmdproc.cpp:267
+#: ../src/common/cmdproc.cpp:260
 msgid "Can't &Undo "
 msgstr "Tidak Nyahcara "
 
-#: ../src/common/image.cpp:2824
+#: ../src/common/image.cpp:2924
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 
-#: ../src/msw/registry.cpp:506
+#: ../src/msw/registry.cpp:495
 #, c-format
 msgid "Can't close registry key '%s'"
 msgstr "Gagal tutup kunci registri '%s'"
 
-#: ../src/msw/registry.cpp:584
+#: ../src/msw/registry.cpp:573
 #, c-format
 msgid "Can't copy values of unsupported type %d."
 msgstr "Gagal salin nilainya tidak menyokong jenis %d."
 
-#: ../src/msw/registry.cpp:487
+#: ../src/msw/registry.cpp:476
 #, c-format
 msgid "Can't create registry key '%s'"
 msgstr "Gagal mencipta kunci registri '%s'"
 
-#: ../src/msw/thread.cpp:665
+#: ../src/msw/thread.cpp:657
 msgid "Can't create thread"
 msgstr "Gagal mencipta benang"
 
-#: ../src/msw/window.cpp:3691
-#, c-format
-msgid "Can't create window of class %s"
-msgstr "Gagal mencipta tetingkap kelas %s"
-
-#: ../src/msw/registry.cpp:777
+#: ../src/msw/registry.cpp:765
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Gagal padam kunci '%s'"
 
-#: ../src/msw/iniconf.cpp:458
+#: ../src/msw/iniconf.cpp:455
 #, c-format
 msgid "Can't delete the INI file '%s'"
 msgstr "Gagal memadam fail INI '%s'"
 
-#: ../src/msw/registry.cpp:805
+#: ../src/msw/registry.cpp:793
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Gagal memadam nilai '%s' daripada kunci '%s'"
 
-#: ../src/msw/registry.cpp:1171
+#: ../src/msw/registry.cpp:1159
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Gagal menghitung subkunci untuk kunci '%s'"
 
-#: ../src/msw/registry.cpp:1132
+#: ../src/msw/registry.cpp:1120
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Gagal menghitung nilai untuk kunci '%s'"
 
-#: ../src/msw/registry.cpp:1389
+#: ../src/msw/registry.cpp:1377
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Gagal eksport nilai yang tidak menyokong jenis %d"
 
-#: ../src/common/ffile.cpp:254
+#: ../src/common/ffile.cpp:253
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Gagal mencari posisi semasa dalam fail '%s'"
 
-#: ../src/msw/registry.cpp:418
+#: ../src/msw/registry.cpp:407
 #, c-format
 msgid "Can't get info about registry key '%s'"
 msgstr "Gagal mendapatkan maklumat perihal kunci registri '%s'"
 
-#: ../src/common/zstream.cpp:346
+#: ../src/msw/webview_ie.cpp:1024
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "Gagal tetapkan keutamaan benang."
+
+#: ../src/common/zstream.cpp:343
 msgid "Can't initialize zlib deflate stream."
 msgstr "Gagal memulakan strim zlib kempis."
 
-#: ../src/common/zstream.cpp:185
+#: ../src/common/zstream.cpp:182
 msgid "Can't initialize zlib inflate stream."
 msgstr "Gagal memulakan strim zlib kembong."
 
-#: ../src/msw/fswatcher.cpp:476
+#: ../src/msw/fswatcher.cpp:475
 #, c-format
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr ""
 
-#: ../src/msw/registry.cpp:454
+#: ../src/msw/registry.cpp:443
 #, c-format
 msgid "Can't open registry key '%s'"
 msgstr "Gagal membuka kunci regisri '%s'"
 
-#: ../src/common/zstream.cpp:252
+#: ../src/common/zstream.cpp:249
 #, c-format
 msgid "Can't read from inflate stream: %s"
 msgstr "Gagal membaca daripada strim kembong: %s"
 
-#: ../src/common/zstream.cpp:244
+#: ../src/common/zstream.cpp:241
 msgid "Can't read inflate stream: unexpected EOF in underlying stream."
 msgstr "Gagal membaca strim kembung: EOF tidak dijangka dalam dasar strim."
 
-#: ../src/msw/registry.cpp:1064
+#: ../src/msw/registry.cpp:1052
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Gagal baca nilai '%s'"
 
-#: ../src/msw/registry.cpp:878 ../src/msw/registry.cpp:910
-#: ../src/msw/registry.cpp:975
+#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
+#: ../src/msw/registry.cpp:963
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Gagal baca nilai kunci '%s'"
 
-#: ../src/common/image.cpp:2620
+#: ../src/msw/webview_ie.cpp:1017
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/common/image.cpp:2715
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "Gagal menyimpan fail imej '%s': sambungan tidak diketahui."
 
-#: ../src/generic/logg.cpp:573 ../src/generic/logg.cpp:976
+#: ../src/generic/logg.cpp:570 ../src/generic/logg.cpp:973
 msgid "Can't save log contents to file."
 msgstr "Gagal menyimpan kandungan log kepada fail."
 
-#: ../src/msw/thread.cpp:629
+#: ../src/msw/thread.cpp:621
 msgid "Can't set thread priority"
 msgstr "Gagal tetapkan keutamaan benang."
 
-#: ../src/msw/registry.cpp:896 ../src/msw/registry.cpp:938
-#: ../src/msw/registry.cpp:1081
+#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
+#: ../src/msw/registry.cpp:1069
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Gagal tetapkan nilai '%s'"
 
-#: ../src/unix/utilsunx.cpp:351
+#: ../src/unix/utilsunx.cpp:353
 #, fuzzy
 msgid "Can't write to child process's stdin"
 msgstr "Gagal membunuh proses %d"
 
-#: ../src/common/zstream.cpp:427
+#: ../src/common/zstream.cpp:424
 #, c-format
 msgid "Can't write to deflate stream: %s"
 msgstr "Gagal menulis kepada strim kempis: %s"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:279 ../src/richtext/richtextstyledlg.cpp:300
-#: ../src/common/stockitem.cpp:145 ../src/common/accelcmn.cpp:71
-#: ../src/msw/msgdlg.cpp:454 ../src/msw/progdlg.cpp:673
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:142
+#: ../src/common/accelcmn.cpp:68 ../src/motif/msgdlg.cpp:196
+#: ../src/gtk1/fontdlg.cpp:144 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/progdlg.cpp:940 ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Batal"
 
-#: ../src/common/filefn.cpp:1261
+#: ../src/common/filefn.cpp:1149
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Gagal menghitung fail '%s'"
 
-#: ../src/msw/dir.cpp:263
+#: ../src/msw/dir.cpp:260
 #, c-format
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Gagal menghitung fail dalam direktori '%s'"
 
-#: ../src/msw/dialup.cpp:523
+#: ../src/msw/dialup.cpp:517
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Gagal menemui sambungan mendial aktif: %s"
 
-#: ../src/msw/dialup.cpp:827
+#: ../src/msw/dialup.cpp:821
 msgid "Cannot find the location of address book file"
 msgstr "Gagal menemui lokasi fail buku alamat"
 
-#: ../src/msw/ole/automtn.cpp:562
+#: ../src/msw/ole/automtn.cpp:553
 #, fuzzy, c-format
 msgid "Cannot get an active instance of \"%s\""
 msgstr "Gagal menemui sambungan mendial aktif: %s"
 
-#: ../src/unix/threadpsx.cpp:1035
+#: ../src/unix/threadpsx.cpp:1053
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "Gagal mendapatkan keutamaan banjaran untuk penjadualan polisi %d."
 
-#: ../src/unix/utilsunx.cpp:987
+#: ../src/unix/utilsunx.cpp:989
 msgid "Cannot get the hostname"
 msgstr "Gagal mendapatkan namahos"
 
-#: ../src/unix/utilsunx.cpp:1023
+#: ../src/unix/utilsunx.cpp:1025
 msgid "Cannot get the official hostname"
 msgstr "Gagal mendapatkan namahos rasmi"
 
-#: ../src/msw/dialup.cpp:928
+#: ../src/msw/dialup.cpp:922
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Gagal menggantung - tiada sambungan mendial aktif."
 
@@ -1890,129 +1894,129 @@ msgstr "Gagal menggantung - tiada sambungan mendial aktif."
 msgid "Cannot initialize OLE"
 msgstr "Gagal mulakan OLE"
 
-#: ../src/common/socket.cpp:853
+#: ../src/common/socket.cpp:850
 #, fuzzy
 msgid "Cannot initialize sockets"
 msgstr "Gagal mulakan OLE"
 
-#: ../src/msw/volume.cpp:619
+#: ../src/msw/volume.cpp:627
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Gagal memuat ikon dari '%s'."
 
-#: ../src/xrc/xmlres.cpp:360
+#: ../src/xrc/xmlres.cpp:358
 #, fuzzy, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Gagal memuat sumber dari fail '%s'."
 
-#: ../src/xrc/xmlres.cpp:742
+#: ../src/xrc/xmlres.cpp:740
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Gagal memuat sumber dari fail '%s'."
 
-#: ../src/html/htmlfilt.cpp:137
+#: ../src/html/htmlfilt.cpp:134
 #, c-format
 msgid "Cannot open HTML document: %s"
 msgstr "Gagal buka dokumen HTML: %s"
 
-#: ../src/html/helpdata.cpp:667
+#: ../src/html/helpdata.cpp:660
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Gagal buka buku bantuan HTML: %s"
 
-#: ../src/html/helpdata.cpp:299
+#: ../src/html/helpdata.cpp:296
 #, c-format
 msgid "Cannot open contents file: %s"
 msgstr "Gagal buka kandungan fial: %s"
 
-#: ../src/generic/dcpsg.cpp:1667
+#: ../src/generic/dcpsg.cpp:1665
 msgid "Cannot open file for PostScript printing!"
 msgstr "Gagal buka fail untuk cetak PostScript!"
 
-#: ../src/html/helpdata.cpp:313
+#: ../src/html/helpdata.cpp:310
 #, c-format
 msgid "Cannot open index file: %s"
 msgstr "Gagal buka fail indeks: %s"
 
-#: ../src/xrc/xmlres.cpp:724
+#: ../src/xrc/xmlres.cpp:722
 #, fuzzy, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Gagal memuat sumber dari fail '%s'."
 
-#: ../src/html/helpwnd.cpp:1534
+#: ../src/html/helpwnd.cpp:1532
 msgid "Cannot print empty page."
 msgstr "Gagal cipta laman kosong."
 
-#: ../src/msw/volume.cpp:507
+#: ../src/msw/volume.cpp:515
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Gagal baca nama jenis dari '%s'!"
 
-#: ../src/msw/thread.cpp:888
+#: ../src/msw/thread.cpp:894
 #, fuzzy, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Gagal menyambung benang %x"
 
-#: ../src/unix/threadpsx.cpp:1016
+#: ../src/unix/threadpsx.cpp:1028
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Gagal mendapatkan benang penjadualan polisi."
 
-#: ../src/common/intl.cpp:558
+#: ../src/common/intl.cpp:365
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:831 ../src/msw/thread.cpp:546
+#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
 msgid "Cannot start thread: error writing TLS."
 msgstr "Gagal memulakan benang: ralat menulis TLS."
 
-#: ../src/msw/thread.cpp:872
+#: ../src/msw/thread.cpp:864
 #, fuzzy, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Gagal menggantung benang %x"
 
-#: ../src/msw/thread.cpp:794
+#: ../src/msw/thread.cpp:786
 msgid "Cannot wait for thread termination"
 msgstr "Tidak dapat menunggu benang ditamatkan"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:75
+#: ../src/common/accelcmn.cpp:72
 #, fuzzy
 msgid "Capital"
 msgstr "italik"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:879
+#: ../src/propgrid/advprops.cpp:780
 msgid "CaptionText"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:531
 msgid "Case sensitive"
 msgstr "Sensitif kes"
 
-#: ../src/propgrid/manager.cpp:1509
+#: ../src/propgrid/manager.cpp:1527
 msgid "Categorized Mode"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9968
+#: ../src/richtext/richtextbuffer.cpp:9965
 #, fuzzy
 msgid "Cell Properties"
 msgstr "&Ciri-ciri"
 
-#: ../src/common/fmapbase.cpp:161
+#: ../src/common/fmapbase.cpp:158
 msgid "Celtic (ISO-8859-14)"
 msgstr "Celtic (ISO-8859-14)"
 
-#: ../src/richtext/richtextindentspage.cpp:160
 #: ../src/richtext/richtextliststylepage.cpp:349
+#: ../src/richtext/richtextindentspage.cpp:160
 msgid "Cen&tred"
 msgstr "Ke&tengah"
 
-#: ../src/common/stockitem.cpp:170
+#: ../src/common/stockitem.cpp:167
 msgid "Centered"
 msgstr "Ketengah"
 
-#: ../src/common/fmapbase.cpp:149
+#: ../src/common/fmapbase.cpp:146
 msgid "Central European (ISO-8859-2)"
 msgstr "Eropah Tengah (ISO-8859-2)"
 
@@ -2021,10 +2025,10 @@ msgstr "Eropah Tengah (ISO-8859-2)"
 msgid "Centre"
 msgstr "Tengah"
 
-#: ../src/richtext/richtextindentspage.cpp:162
-#: ../src/richtext/richtextindentspage.cpp:164
 #: ../src/richtext/richtextliststylepage.cpp:351
 #: ../src/richtext/richtextliststylepage.cpp:353
+#: ../src/richtext/richtextindentspage.cpp:162
+#: ../src/richtext/richtextindentspage.cpp:164
 msgid "Centre text."
 msgstr "Teks Tengah."
 
@@ -2038,26 +2042,26 @@ msgstr "Ke&tengah"
 msgid "Ch&oose..."
 msgstr "Pilih..."
 
-#: ../src/richtext/richtextbuffer.cpp:4354
+#: ../src/richtext/richtextbuffer.cpp:4351
 msgid "Change List Style"
 msgstr "Ubah Gaya Senarai"
 
-#: ../src/richtext/richtextbuffer.cpp:3709
+#: ../src/richtext/richtextbuffer.cpp:3706
 #, fuzzy
 msgid "Change Object Style"
 msgstr "Ubah Gaya Senarai"
 
-#: ../src/richtext/richtextbuffer.cpp:3982
-#: ../src/richtext/richtextbuffer.cpp:8129
+#: ../src/richtext/richtextbuffer.cpp:3979
+#: ../src/richtext/richtextbuffer.cpp:8125
 #, fuzzy
 msgid "Change Properties"
 msgstr "&Ciri-ciri"
 
-#: ../src/richtext/richtextbuffer.cpp:3526
+#: ../src/richtext/richtextbuffer.cpp:3523
 msgid "Change Style"
 msgstr "Ubah Gaya"
 
-#: ../src/common/fileconf.cpp:341
+#: ../src/common/fileconf.cpp:335
 #, c-format
 msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
 msgstr ""
@@ -2068,12 +2072,12 @@ msgid "Changing current directory to \"%s\" failed"
 msgstr "Gagal mencipta direktori \"%s\""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1757
+#: ../src/propgrid/advprops.cpp:1658
 #, fuzzy
 msgid "Character"
 msgstr "Kod aksara:"
 
-#: ../src/richtext/richtextstyles.cpp:1063
+#: ../src/richtext/richtextstyles.cpp:1060
 msgid "Character styles"
 msgstr "Gaya Aksara"
 
@@ -2111,20 +2115,20 @@ msgstr "Tanda untuk menyertakan peluru dalam kurungan."
 msgid "Check to indicate right-to-left text layout."
 msgstr "Klik untuk ubah warna teks."
 
-#: ../src/osx/carbon/fontdlg.cpp:356 ../src/osx/carbon/fontdlg.cpp:358
+#: ../src/osx/carbon/fontdlg.cpp:353 ../src/osx/carbon/fontdlg.cpp:355
 msgid "Check to make the font bold."
 msgstr "Tanda untuk buat fon tebal."
 
-#: ../src/osx/carbon/fontdlg.cpp:363 ../src/osx/carbon/fontdlg.cpp:365
+#: ../src/osx/carbon/fontdlg.cpp:360 ../src/osx/carbon/fontdlg.cpp:362
 msgid "Check to make the font italic."
 msgstr "Tanda untuk buat fon italik."
 
-#: ../src/osx/carbon/fontdlg.cpp:372 ../src/osx/carbon/fontdlg.cpp:374
+#: ../src/osx/carbon/fontdlg.cpp:369 ../src/osx/carbon/fontdlg.cpp:371
 msgid "Check to make the font underlined."
 msgstr "Sama ada fon bergaris-bawah."
 
-#: ../src/richtext/richtextstyledlg.cpp:289
-#: ../src/richtext/richtextstyledlg.cpp:291
+#: ../src/richtext/richtextstyledlg.cpp:285
+#: ../src/richtext/richtextstyledlg.cpp:287
 msgid "Check to restart numbering."
 msgstr "Periksa untuk mulakan semula pernomboran."
 
@@ -2163,55 +2167,55 @@ msgstr "Tanda untuk menyertakan peluru dalam kurungan."
 msgid "Check to suppress hyphenation."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:763
+#: ../src/msw/dialup.cpp:757
 msgid "Choose ISP to dial"
 msgstr "Pilih ISP untuk dail"
 
-#: ../src/propgrid/props.cpp:1922
+#: ../src/propgrid/props.cpp:1904
 #, fuzzy
 msgid "Choose a directory:"
 msgstr "Cipta direktori"
 
-#: ../src/propgrid/props.cpp:1975
+#: ../src/propgrid/props.cpp:2199
 #, fuzzy
 msgid "Choose a file"
 msgstr "Pilih fon"
 
-#: ../src/generic/colrdlgg.cpp:158 ../src/gtk/colordlg.cpp:54
+#: ../src/generic/colrdlgg.cpp:156 ../src/gtk/colordlg.cpp:49
 msgid "Choose colour"
 msgstr "Pilih warna"
 
-#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/gtk1/fontdlg.cpp:125 ../src/generic/fontpickerg.cpp:47
+#: ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Pilih fon"
 
-#: ../src/common/module.cpp:74
+#: ../src/common/module.cpp:71
 #, c-format
 msgid "Circular dependency involving module \"%s\" detected."
 msgstr "Kebergantungan edaran dikesan melibatkan modul \"%s\"."
 
-#: ../src/aui/tabmdi.cpp:108 ../src/generic/mdig.cpp:97
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
 msgid "Cl&ose"
 msgstr "Tutup"
 
-#: ../src/msw/ole/automtn.cpp:684
+#: ../src/msw/ole/automtn.cpp:675
 #, fuzzy
 msgid "Class not registered."
 msgstr "Gagal mencipta benang"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:147 ../src/common/accelcmn.cpp:72
+#: ../src/common/stockitem.cpp:144 ../src/common/accelcmn.cpp:69
 #, fuzzy
 msgid "Clear"
 msgstr "Kosongkan"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "Clear the log contents"
 msgstr "Lapangkan kandungan log"
 
-#: ../src/richtext/richtextstyledlg.cpp:252
-#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:248
+#: ../src/richtext/richtextstyledlg.cpp:250
 msgid "Click to apply the selected style."
 msgstr "Tanda untuk terapkan gaya pilihan."
 
@@ -2222,15 +2226,15 @@ msgstr "Tanda untuk terapkan gaya pilihan."
 msgid "Click to browse for a symbol."
 msgstr "Klik untuk melungsur simbol."
 
-#: ../src/osx/carbon/fontdlg.cpp:403 ../src/osx/carbon/fontdlg.cpp:405
+#: ../src/osx/carbon/fontdlg.cpp:400 ../src/osx/carbon/fontdlg.cpp:402
 msgid "Click to cancel changes to the font."
 msgstr "Klik untuk batal perubahan fon."
 
-#: ../src/generic/fontdlgg.cpp:472 ../src/generic/fontdlgg.cpp:491
+#: ../src/generic/fontdlgg.cpp:468 ../src/generic/fontdlgg.cpp:487
 msgid "Click to cancel the font selection."
 msgstr "Klik untuk batal pemilihan fon."
 
-#: ../src/osx/carbon/fontdlg.cpp:384 ../src/osx/carbon/fontdlg.cpp:386
+#: ../src/osx/carbon/fontdlg.cpp:381 ../src/osx/carbon/fontdlg.cpp:383
 msgid "Click to change the font colour."
 msgstr "Klik untuk ubah warna fon."
 
@@ -2250,38 +2254,38 @@ msgstr "Klik untuk ubah warna teks."
 msgid "Click to choose the font for this level."
 msgstr "Klik untuk pilih fon untuk paras ini."
 
-#: ../src/richtext/richtextstyledlg.cpp:279
-#: ../src/richtext/richtextstyledlg.cpp:281
+#: ../src/richtext/richtextstyledlg.cpp:275
+#: ../src/richtext/richtextstyledlg.cpp:277
 msgid "Click to close this window."
 msgstr "Klik untuk tutup tetingkap ini"
 
-#: ../src/osx/carbon/fontdlg.cpp:410 ../src/osx/carbon/fontdlg.cpp:412
+#: ../src/osx/carbon/fontdlg.cpp:407 ../src/osx/carbon/fontdlg.cpp:409
 msgid "Click to confirm changes to the font."
 msgstr "Klik untuk kepastian perubahan pada fon."
 
-#: ../src/generic/fontdlgg.cpp:477 ../src/generic/fontdlgg.cpp:479
-#: ../src/generic/fontdlgg.cpp:484 ../src/generic/fontdlgg.cpp:486
+#: ../src/generic/fontdlgg.cpp:473 ../src/generic/fontdlgg.cpp:475
+#: ../src/generic/fontdlgg.cpp:480 ../src/generic/fontdlgg.cpp:482
 msgid "Click to confirm the font selection."
 msgstr "Klik untuk pasti pemilihan fon."
 
-#: ../src/richtext/richtextstyledlg.cpp:244
-#: ../src/richtext/richtextstyledlg.cpp:246
+#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:242
 #, fuzzy
 msgid "Click to create a new box style."
 msgstr "Klik untuk cipta senarai baru gaya."
 
-#: ../src/richtext/richtextstyledlg.cpp:226
-#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:224
 msgid "Click to create a new character style."
 msgstr "Klik untuk cipta gaya aksara baru."
 
-#: ../src/richtext/richtextstyledlg.cpp:238
-#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:236
 msgid "Click to create a new list style."
 msgstr "Klik untuk cipta senarai baru gaya."
 
-#: ../src/richtext/richtextstyledlg.cpp:232
-#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:230
 msgid "Click to create a new paragraph style."
 msgstr "Klik untuk cipta gaya perenggan baru."
 
@@ -2295,8 +2299,8 @@ msgstr "Klik untuk cipta posisi baru tab."
 msgid "Click to delete all tab positions."
 msgstr "Klik untuk padam semua posisi teks."
 
-#: ../src/richtext/richtextstyledlg.cpp:270
-#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:268
 msgid "Click to delete the selected style."
 msgstr "Klik untuk padam gaya pilihan."
 
@@ -2305,25 +2309,25 @@ msgstr "Klik untuk padam gaya pilihan."
 msgid "Click to delete the selected tab position."
 msgstr "Klik untuk padam posisi tab pilihan."
 
-#: ../src/richtext/richtextstyledlg.cpp:264
-#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:262
 msgid "Click to edit the selected style."
 msgstr "Klik untuk edit fon terpilih."
 
-#: ../src/richtext/richtextstyledlg.cpp:258
-#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:256
 msgid "Click to rename the selected style."
 msgstr "Klik untuk menamakan fon terpilih."
 
-#: ../src/generic/dbgrptg.cpp:97 ../src/generic/progdlgg.cpp:759
-#: ../src/richtext/richtextstyledlg.cpp:277
-#: ../src/richtext/richtextsymboldlg.cpp:476 ../src/common/stockitem.cpp:148
-#: ../src/msw/progdlg.cpp:170 ../src/msw/progdlg.cpp:679
-#: ../src/html/helpdlg.cpp:90
+#: ../src/common/stockitem.cpp:145 ../src/generic/dbgrptg.cpp:94
+#: ../src/generic/progdlgg.cpp:781 ../src/msw/progdlg.cpp:211
+#: ../src/msw/progdlg.cpp:946 ../src/html/helpdlg.cpp:87
+#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextstyledlg.cpp:273
 msgid "Close"
 msgstr "Tutup"
 
-#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:98
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
 msgid "Close All"
 msgstr "Tutup &Semua"
 
@@ -2331,67 +2335,67 @@ msgstr "Tutup &Semua"
 msgid "Close current document"
 msgstr "Tutup dokumen semasa"
 
-#: ../src/generic/logg.cpp:516
+#: ../src/generic/logg.cpp:513
 msgid "Close this window"
 msgstr "Tutup tetingkap ini"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6006
+#: ../src/generic/datavgen.cpp:6811
 msgid "Collapse"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 #, fuzzy
 msgid "Color"
 msgstr "Warna:"
 
-#: ../src/richtext/richtextformatdlg.cpp:776
+#: ../src/richtext/richtextformatdlg.cpp:768
 #, fuzzy
 msgid "Colour"
 msgstr "Warna:"
 
-#: ../src/msw/colordlg.cpp:158
+#: ../src/msw/colordlg.cpp:227
 #, fuzzy, c-format
 msgid "Colour selection dialog failed with error %0lx."
 msgstr "Perlaksanaan arahan '%s' gagal dengan ralat: %ul"
 
-#: ../src/osx/carbon/fontdlg.cpp:380
+#: ../src/osx/carbon/fontdlg.cpp:377
 msgid "Colour:"
 msgstr "Warna:"
 
-#: ../src/generic/datavgen.cpp:6077
+#: ../src/generic/datavgen.cpp:6882
 #, c-format
 msgid "Column %u"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:114
+#: ../src/common/accelcmn.cpp:112
 msgid "Command"
 msgstr ""
 
-#: ../src/common/init.cpp:196
+#: ../src/common/init.cpp:193
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
 "ignored."
 msgstr ""
 
-#: ../src/msw/fontdlg.cpp:120
+#: ../src/msw/fontdlg.cpp:170
 #, fuzzy, c-format
 msgid "Common dialog failed with error code %0lx."
 msgstr "Perlaksanaan arahan '%s' gagal dengan ralat: %ul"
 
-#: ../src/gtk/window.cpp:4649
+#: ../src/gtk/window.cpp:5653
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:1549
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Fail Bantuan HTML Termampat (*.chm)|*.chm|"
 
-#: ../src/generic/dirctrlg.cpp:444
+#: ../src/generic/dirctrlg.cpp:410
 msgid "Computer"
 msgstr "Komputer"
 
@@ -2400,55 +2404,59 @@ msgstr "Komputer"
 msgid "Config entry name cannot start with '%c'."
 msgstr "Nama masukan konfig tidak boleh dimulakan dengan '%c'."
 
-#: ../src/generic/filedlgg.cpp:349 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
 msgid "Confirm"
 msgstr "Sah"
 
-#: ../src/html/htmlwin.cpp:566
+#: ../src/html/htmlwin.cpp:569
 msgid "Connecting..."
 msgstr "Menghubungkan..."
 
-#: ../src/html/helpwnd.cpp:475
+#: ../src/html/helpwnd.cpp:473
 msgid "Contents"
 msgstr "Kandungan"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:880
+#: ../src/propgrid/advprops.cpp:781
 msgid "ControlDark"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:881
+#: ../src/propgrid/advprops.cpp:782
 msgid "ControlLight"
 msgstr ""
 
-#: ../src/common/strconv.cpp:2262
+#: ../src/common/strconv.cpp:2208
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Penukaran kepada set aksara '%s' tidak berfungsi."
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 #, fuzzy
 msgid "Convert"
 msgstr "Kandungan"
 
-#: ../src/html/htmlwin.cpp:1079
+#: ../src/html/htmlwin.cpp:1020
 #, c-format
 msgid "Copied to clipboard:\"%s\""
 msgstr "Salin ke papan klip:\"%s\""
 
-#: ../src/generic/prntdlgg.cpp:247
+#: ../src/generic/prntdlgg.cpp:240
 msgid "Copies:"
 msgstr "Salinan:"
 
-#: ../src/common/stockitem.cpp:150 ../src/stc/stc_i18n.cpp:18
+#: ../src/common/stockitem.cpp:147 ../src/stc/stc_i18n.cpp:18
 #, fuzzy
 msgid "Copy"
 msgstr "&Salin"
 
-#: ../src/common/stockitem.cpp:258
+#: ../src/common/stockitem.cpp:255
 msgid "Copy selection"
 msgstr "Salin pilihan"
+
+#: ../src/generic/grid.cpp:5945
+msgid "Copying more than one selected block to clipboard is not supported."
+msgstr ""
 
 #: ../src/richtext/richtextborderspage.cpp:566
 #: ../src/richtext/richtextborderspage.cpp:601
@@ -2459,205 +2467,201 @@ msgstr ""
 msgid "Corner &radius:"
 msgstr ""
 
-#: ../src/html/chm.cpp:718
+#: ../src/html/chm.cpp:711
 #, c-format
 msgid "Could not create temporary file '%s'"
 msgstr "Gagal mencipta fail sementara '%s'"
 
-#: ../src/html/chm.cpp:273
+#: ../src/html/chm.cpp:270
 #, c-format
 msgid "Could not extract %s into %s: %s"
 msgstr "Gagal ekstrak %s kepada %s: %s"
 
-#: ../src/generic/tabg.cpp:1048
+#: ../src/generic/tabg.cpp:1045
 msgid "Could not find tab for id"
 msgstr "Gagal menemui tab untuk id"
 
-#: ../src/gtk/notifmsg.cpp:108
-#, fuzzy
-msgid "Could not initalize libnotify."
-msgstr "Gagal mulakan mencetak."
-
-#: ../src/html/chm.cpp:444
+#: ../src/html/chm.cpp:437
 #, c-format
 msgid "Could not locate file '%s'."
 msgstr "Gagal menempatkan fail '%s'."
 
-#: ../src/common/filefn.cpp:1403
+#: ../src/msw/graphicsd2d.cpp:604
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/common/filefn.cpp:1291
 #, fuzzy
 msgid "Could not set current working directory"
 msgstr "Gagal mendapatkan direktori kerja"
 
-#: ../src/common/prntbase.cpp:2015
+#: ../src/common/prntbase.cpp:2037
 msgid "Could not start document preview."
 msgstr "Gagal mulakan pralihat dokumen."
 
-#: ../src/generic/printps.cpp:178 ../src/msw/printwin.cpp:210
-#: ../src/gtk/print.cpp:1132
+#: ../src/generic/printps.cpp:159 ../src/msw/printwin.cpp:184
+#: ../src/gtk/print.cpp:1129
 msgid "Could not start printing."
 msgstr "Gagal mulakan mencetak."
 
-#: ../src/common/wincmn.cpp:2125
+#: ../src/common/wincmn.cpp:2126
 msgid "Could not transfer data to window"
 msgstr "Gagal hantar data ke tetingkap"
 
-#: ../src/msw/imaglist.cpp:187 ../src/msw/imaglist.cpp:224
-#: ../src/msw/imaglist.cpp:249 ../src/msw/dragimag.cpp:185
-#: ../src/msw/dragimag.cpp:220
+#: ../src/msw/imaglist.cpp:223 ../src/msw/imaglist.cpp:245
+#: ../src/msw/imaglist.cpp:270 ../src/msw/dragimag.cpp:182
+#: ../src/msw/dragimag.cpp:217
 msgid "Couldn't add an image to the image list."
 msgstr "Gagal tambah imej kepada senarai imej."
 
-#: ../src/osx/glcanvas_osx.cpp:414 ../src/unix/glx11.cpp:558
-#: ../src/msw/glcanvas.cpp:616
+#: ../src/osx/glcanvas_osx.cpp:411 ../src/msw/glcanvas.cpp:631
+#: ../src/unix/glegl.cpp:315 ../src/unix/glx11.cpp:559
 #, fuzzy
 msgid "Couldn't create OpenGL context"
 msgstr "Gagal cipta pemasa"
 
-#: ../src/msw/timer.cpp:134
+#: ../src/msw/timer.cpp:131
 msgid "Couldn't create a timer"
 msgstr "Gagal cipta pemasa"
 
-#: ../src/osx/carbon/overlay.cpp:122
-msgid "Couldn't create the overlay window"
-msgstr "Gagal mencipta tetingkap lapisan"
-
-#: ../src/common/translation.cpp:2024
+#: ../src/common/translation.cpp:2074
 #, fuzzy
 msgid "Couldn't enumerate translations"
 msgstr "Gagal menamatkan benang"
 
-#: ../src/common/dynlib.cpp:120
+#: ../src/common/dynlib.cpp:110
 #, c-format
 msgid "Couldn't find symbol '%s' in a dynamic library"
 msgstr "Gagal menemui simbol '%s' dalam pustaka dinamik"
 
-#: ../src/msw/thread.cpp:915
+#: ../src/msw/thread.cpp:921
 msgid "Couldn't get the current thread pointer"
 msgstr "Gagal dapatkan penunjuk benang semasa"
 
-#: ../src/osx/carbon/overlay.cpp:129
-msgid "Couldn't init the context on the overlay window"
-msgstr "Gagal memulakan konteks pada tetingkap lapisan"
-
-#: ../src/common/imaggif.cpp:244
+#: ../src/common/imaggif.cpp:241
 #, fuzzy
 msgid "Couldn't initialize GIF hash table."
 msgstr "Gagal memulakan strim zlib kempis."
 
-#: ../src/common/imagpng.cpp:409
+#: ../src/common/imagpng.cpp:437
 msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
 msgstr "Gagal memuat imej PNG - fail telah rosak atau tidak cukup memori."
 
-#: ../src/unix/sound.cpp:470
+#: ../src/unix/sound.cpp:459
 #, c-format
 msgid "Couldn't load sound data from '%s'."
 msgstr "Gagal memuat data bunyi dari '%s'."
 
-#: ../src/msw/dirdlg.cpp:435
+#: ../src/msw/dirdlg.cpp:287
 #, fuzzy
 msgid "Couldn't obtain folder name"
 msgstr "Gagal cipta pemasa"
 
-#: ../src/unix/sound_sdl.cpp:229
+#: ../src/unix/sound_sdl.cpp:226
 #, c-format
 msgid "Couldn't open audio: %s"
 msgstr "Gagal membuka audio: %s"
 
-#: ../src/msw/ole/dataobj.cpp:377
+#: ../src/msw/ole/dataobj.cpp:385
 #, c-format
 msgid "Couldn't register clipboard format '%s'."
 msgstr "Gagal daftar format klipbod '%s'."
 
-#: ../src/msw/listctrl.cpp:869
+#: ../src/msw/listctrl.cpp:933
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "Gagal menyelamatkan maklumat perihal senarai item kawalan %d."
 
-#: ../src/common/imagpng.cpp:498 ../src/common/imagpng.cpp:509
-#: ../src/common/imagpng.cpp:519
+#: ../src/common/imagpng.cpp:511 ../src/common/imagpng.cpp:522
+#: ../src/common/imagpng.cpp:532
 msgid "Couldn't save PNG image."
 msgstr "Gagal simpan imej PNG."
 
-#: ../src/msw/thread.cpp:684
+#: ../src/msw/thread.cpp:676
 msgid "Couldn't terminate thread"
 msgstr "Gagal menamatkan benang"
 
-#: ../src/common/xtistrm.cpp:166
+#: ../src/common/xtistrm.cpp:163
 #, fuzzy, c-format
 msgid "Create Parameter %s not found in declared RTTI Parameters"
 msgstr "Parameter Cipta tidak dijumpai dalam parameter RRTI yang dinyatakan"
 
-#: ../src/generic/dirdlgg.cpp:288
+#: ../src/generic/dirdlgg.cpp:285
 msgid "Create directory"
 msgstr "Cipta direktori"
 
-#: ../src/generic/filedlgg.cpp:212 ../src/generic/dirdlgg.cpp:111
+#: ../src/generic/filedlgg.cpp:209 ../src/generic/dirdlgg.cpp:108
 msgid "Create new directory"
 msgstr "Cipta direktori baru"
 
-#: ../src/xrc/xmlres.cpp:2460
+#: ../src/common/stockitem.cpp:264
+#, fuzzy
+msgid "Create new document"
+msgstr "Cipta direktori baru"
+
+#: ../src/xrc/xmlres.cpp:2515
 #, fuzzy, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Pengekstrakan '%s' kepada '%s' gagal."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1758
+#: ../src/propgrid/advprops.cpp:1659
 msgid "Cross"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:333
+#: ../src/common/accelcmn.cpp:347
 #, fuzzy
 msgid "Ctrl+"
 msgstr "Ctrl-"
 
-#: ../src/richtext/richtextctrl.cpp:332 ../src/osx/textctrl_osx.cpp:576
-#: ../src/common/stockitem.cpp:151 ../src/msw/textctrl.cpp:2507
+#: ../src/osx/textctrl_osx.cpp:594 ../src/common/stockitem.cpp:148
+#: ../src/msw/textctrl.cpp:2772 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "&Potong"
 
-#: ../src/generic/filectrlg.cpp:940
+#: ../src/generic/filectrlg.cpp:936
 msgid "Current directory:"
 msgstr "Direktori semasa:"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:896 ../src/propgrid/advprops.cpp:1574
-#: ../src/propgrid/advprops.cpp:1612
+#: ../src/propgrid/advprops.cpp:797 ../src/propgrid/advprops.cpp:1475
+#: ../src/propgrid/advprops.cpp:1518
 #, fuzzy
 msgid "Custom"
 msgstr "Saiz Fon"
 
-#: ../src/gtk/print.cpp:217
+#: ../src/gtk/print.cpp:211
 #, fuzzy
 msgid "Custom size"
 msgstr "Saiz Fon"
 
-#: ../src/common/headerctrlcmn.cpp:60
+#: ../src/common/headerctrlcmn.cpp:58
 #, fuzzy
 msgid "Customize Columns"
 msgstr "Saiz Fon"
 
-#: ../src/common/stockitem.cpp:151 ../src/stc/stc_i18n.cpp:17
+#: ../src/common/stockitem.cpp:148 ../src/stc/stc_i18n.cpp:17
 #, fuzzy
 msgid "Cut"
 msgstr "&Potong"
 
-#: ../src/common/stockitem.cpp:259
+#: ../src/common/stockitem.cpp:256
 msgid "Cut selection"
 msgstr "Potong pilihan"
 
-#: ../src/common/fmapbase.cpp:152
+#: ../src/common/fmapbase.cpp:149
 msgid "Cyrillic (ISO-8859-5)"
 msgstr "Cyrillic (ISO-8859-5)"
 
-#: ../src/common/paper.cpp:99
+#: ../src/common/paper.cpp:96
 msgid "D sheet, 22 x 34 in"
 msgstr "Helai D, 22 x 34 in"
 
-#: ../src/msw/dde.cpp:703
+#: ../src/msw/dde.cpp:698
 msgid "DDE poke request failed"
 msgstr "Permintaan poke DDE gagal"
 
-#: ../src/common/imagbmp.cpp:1169
+#: ../src/common/imagbmp.cpp:1181
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr "Kepala DIB: pengenkod tidak sepadan kedalaman bit."
 
@@ -2677,7 +2681,7 @@ msgstr "Kepala DIB: kedalaman bit fail tidak diketahui."
 msgid "DIB Header: Unknown encoding in file."
 msgstr "Kepala DIB: mengenkod fail tidak diketahui."
 
-#: ../src/common/paper.cpp:121
+#: ../src/common/paper.cpp:118
 msgid "DL Envelope, 110 x 220 mm"
 msgstr "Sampul DL, 110 x 220 mm"
 
@@ -2685,56 +2689,56 @@ msgstr "Sampul DL, 110 x 220 mm"
 msgid "Dashed"
 msgstr ""
 
-#: ../src/generic/dbgrptg.cpp:300
+#: ../src/generic/dbgrptg.cpp:301
 #, c-format
 msgid "Debug report \"%s\""
 msgstr "Laporan ralat \"%s\""
 
-#: ../src/common/debugrpt.cpp:210
+#: ../src/common/debugrpt.cpp:211
 msgid "Debug report couldn't be created."
 msgstr "Gagal mencipta laporan nyahpijat."
 
-#: ../src/common/debugrpt.cpp:553
+#: ../src/common/debugrpt.cpp:554
 msgid "Debug report generation has failed."
 msgstr "Gagal menjana laporan nyahpijat"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:84
+#: ../src/common/accelcmn.cpp:81
 msgid "Decimal"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:323
+#: ../src/generic/fontdlgg.cpp:319
 msgid "Decorative"
 msgstr "Dekoratif"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1752
+#: ../src/propgrid/advprops.cpp:1653
 #, fuzzy
 msgid "Default"
 msgstr "lalai"
 
-#: ../src/common/fmapbase.cpp:796
+#: ../src/common/fmapbase.cpp:792
 msgid "Default encoding"
 msgstr "Pengenkodan default"
 
-#: ../src/dfb/fontmgr.cpp:180
+#: ../src/dfb/fontmgr.cpp:177
 #, fuzzy
 msgid "Default font"
 msgstr "Pencetak default"
 
-#: ../src/generic/prntdlgg.cpp:510
+#: ../src/generic/prntdlgg.cpp:503
 msgid "Default printer"
 msgstr "Pencetak default"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:51
+#: ../src/common/accelcmn.cpp:48
 #, fuzzy
 msgid "Del"
 msgstr "Padam"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextbuffer.cpp:8221 ../src/common/stockitem.cpp:152
-#: ../src/common/accelcmn.cpp:50 ../src/stc/stc_i18n.cpp:20
+#: ../src/common/stockitem.cpp:149 ../src/common/accelcmn.cpp:47
+#: ../src/richtext/richtextbuffer.cpp:8217 ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Padam"
 
@@ -2742,72 +2746,72 @@ msgstr "Padam"
 msgid "Delete A&ll"
 msgstr "P&adam Semua"
 
-#: ../src/richtext/richtextbuffer.cpp:11341
+#: ../src/richtext/richtextbuffer.cpp:11340
 #, fuzzy
 msgid "Delete Column"
 msgstr "Padam pilihan"
 
-#: ../src/richtext/richtextbuffer.cpp:11291
+#: ../src/richtext/richtextbuffer.cpp:11290
 #, fuzzy
 msgid "Delete Row"
 msgstr "Padam"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 msgid "Delete Style"
 msgstr "Padam Gaya"
 
-#: ../src/richtext/richtextctrl.cpp:1345 ../src/richtext/richtextctrl.cpp:1584
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
 msgid "Delete Text"
 msgstr "Padam Teks"
 
-#: ../src/generic/editlbox.cpp:170
+#: ../src/generic/editlbox.cpp:147
 msgid "Delete item"
 msgstr "Padam item"
 
-#: ../src/common/stockitem.cpp:260
+#: ../src/common/stockitem.cpp:257
 msgid "Delete selection"
 msgstr "Padam pilihan"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 #, c-format
 msgid "Delete style %s?"
 msgstr "Padam gaya %s?"
 
-#: ../src/unix/snglinst.cpp:301
+#: ../src/unix/snglinst.cpp:298
 #, c-format
 msgid "Deleted stale lock file '%s'."
 msgstr "Padam fail kunci basi '%s'."
 
-#: ../src/common/secretstore.cpp:220
+#: ../src/common/secretstore.cpp:234
 #, fuzzy, c-format
-msgid "Deleting password for \"%s/%s\" failed: %s."
+msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Pengekstrakan '%s' kepada '%s' gagal."
 
-#: ../src/common/module.cpp:124
+#: ../src/common/module.cpp:121
 #, c-format
 msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
 msgstr "Kebergantungan modul \"%s\" daripada \"%s\" tidak wujud."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 #, fuzzy
 msgid "Descending"
 msgstr "Pengenkodan default"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:526 ../src/propgrid/advprops.cpp:882
+#: ../src/generic/dirctrlg.cpp:492 ../src/propgrid/advprops.cpp:783
 msgid "Desktop"
 msgstr "Desktop"
 
-#: ../src/generic/aboutdlgg.cpp:70
+#: ../src/generic/aboutdlgg.cpp:67
 msgid "Developed by "
 msgstr "Dibangunkan oleh"
 
-#: ../src/generic/aboutdlgg.cpp:176
+#: ../src/generic/aboutdlgg.cpp:173
 #, fuzzy
 msgid "Developers"
 msgstr "Dibangunkan oleh"
 
-#: ../src/msw/dialup.cpp:374
+#: ../src/msw/dialup.cpp:368
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -2815,11 +2819,11 @@ msgstr ""
 "Fungsi mendial tiada disebabkan servis capaian jauh (RAS) tidak dipasang "
 "pada mesin ini. Sila pasangkan."
 
-#: ../src/generic/tipdlg.cpp:211
+#: ../src/generic/tipdlg.cpp:208
 msgid "Did you know..."
 msgstr "Tahukah anda..."
 
-#: ../src/dfb/wrapdfb.cpp:63
+#: ../src/dfb/wrapdfb.cpp:60
 #, fuzzy, c-format
 msgid "DirectFB error %d occurred."
 msgstr "Ralat DiretFB %d berlaku."
@@ -2828,29 +2832,29 @@ msgstr "Ralat DiretFB %d berlaku."
 msgid "Directories"
 msgstr "Direktori"
 
-#: ../src/common/filefn.cpp:1183
+#: ../src/common/filefn.cpp:1071
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Direktori '%s' gagal dicipta"
 
-#: ../src/common/filefn.cpp:1197
+#: ../src/common/filefn.cpp:1085
 #, fuzzy, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "Direktori '%s' gagal dicipta"
 
-#: ../src/generic/dirdlgg.cpp:204
+#: ../src/generic/dirdlgg.cpp:201
 msgid "Directory does not exist"
 msgstr "Direktori tidak wujud"
 
-#: ../src/generic/filectrlg.cpp:1399
+#: ../src/generic/filectrlg.cpp:1388
 msgid "Directory doesn't exist."
 msgstr "Direktori tidak wujud."
 
-#: ../src/common/docview.cpp:457
+#: ../src/common/docview.cpp:450
 msgid "Discard changes and reload the last saved version?"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:502
+#: ../src/html/helpwnd.cpp:500
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -2858,47 +2862,47 @@ msgstr ""
 "Papar semua indeks item yang subrentetannya diberi. Carian adalah sensitif "
 "kes."
 
-#: ../src/html/helpwnd.cpp:679
+#: ../src/html/helpwnd.cpp:677
 msgid "Display options dialog"
 msgstr "Papar dialog pilihan"
 
-#: ../src/html/helpwnd.cpp:322
+#: ../src/html/helpwnd.cpp:320
 msgid "Displays help as you browse the books on the left."
 msgstr "Papar bantuan sebaik sahaja anda melayari kiri buku."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:85
+#: ../src/common/accelcmn.cpp:83
 msgid "Divide"
 msgstr ""
 
-#: ../src/common/docview.cpp:533
+#: ../src/common/docview.cpp:526
 #, fuzzy, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Adakah anda ingin menyimpan perubahan kepada dokumen \"%s\"?"
 
-#: ../src/common/prntbase.cpp:542
+#: ../src/common/prntbase.cpp:537
 #, fuzzy
 msgid "Document:"
 msgstr "Dokumentasi oleh"
 
-#: ../src/generic/aboutdlgg.cpp:73
+#: ../src/generic/aboutdlgg.cpp:70
 msgid "Documentation by "
 msgstr "Dokumentasi oleh"
 
-#: ../src/generic/aboutdlgg.cpp:180
+#: ../src/generic/aboutdlgg.cpp:177
 #, fuzzy
 msgid "Documentation writers"
 msgstr "Dokumentasi oleh"
 
-#: ../src/common/sizer.cpp:2799
+#: ../src/common/sizer.cpp:2916
 msgid "Don't Save"
 msgstr "Jangan Simpan"
 
-#: ../src/html/htmlwin.cpp:633
+#: ../src/html/htmlwin.cpp:643
 msgid "Done"
 msgstr "&Selesai"
 
-#: ../src/generic/progdlgg.cpp:448 ../src/msw/progdlg.cpp:407
+#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
 msgid "Done."
 msgstr "Selesai."
 
@@ -2912,44 +2916,44 @@ msgstr "&Selesai"
 msgid "Double"
 msgstr "&Selesai"
 
-#: ../src/common/paper.cpp:176
+#: ../src/common/paper.cpp:173
 msgid "Double Japanese Postcard Rotated 148 x 200 mm"
 msgstr "Poskad Jepun Berganda Dua Diputar 148 x 200 mm"
 
-#: ../src/common/xtixml.cpp:273
+#: ../src/common/xtixml.cpp:269
 #, c-format
 msgid "Doubly used id : %d"
 msgstr "Dua ID diguna : %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:153
-#: ../src/common/accelcmn.cpp:64
+#: ../src/common/stockitem.cpp:150 ../src/common/accelcmn.cpp:61
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Down"
 msgstr "Turun"
 
-#: ../src/richtext/richtextctrl.cpp:865
+#: ../src/richtext/richtextctrl.cpp:864
 msgid "Drag"
 msgstr ""
 
-#: ../src/common/paper.cpp:100
+#: ../src/common/paper.cpp:97
 msgid "E sheet, 34 x 44 in"
 msgstr "Helai E, 34 x 44 in"
 
-#: ../src/unix/fswatcher_inotify.cpp:561
+#: ../src/unix/fswatcher_inotify.cpp:558
 #, fuzzy
 msgid "EOF while reading from inotify descriptor"
 msgstr "gagal membaca dari penghurai fail %d"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 #, fuzzy
 msgid "Edit"
 msgstr "&Edit"
 
-#: ../src/generic/editlbox.cpp:168
+#: ../src/generic/editlbox.cpp:131
 msgid "Edit item"
 msgstr "Edit item"
 
-#: ../include/wx/generic/progdlgg.h:84
+#: ../include/wx/generic/progdlgg.h:85
 #, fuzzy
 msgid "Elapsed time:"
 msgstr "Masa berlalu : "
@@ -3024,52 +3028,52 @@ msgid "Enables the shadow spread."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:66
+#: ../src/common/accelcmn.cpp:63
 msgid "End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:55
+#: ../src/common/accelcmn.cpp:52
 #, fuzzy
 msgid "Enter"
 msgstr "Pencetak"
 
-#: ../src/richtext/richtextstyledlg.cpp:934
+#: ../src/richtext/richtextstyledlg.cpp:930
 #, fuzzy
 msgid "Enter a box style name"
 msgstr "Masukkan nama senarai gaya "
 
-#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:602
 msgid "Enter a character style name"
 msgstr "Masukkan nama aksara gaya"
 
-#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:816
 msgid "Enter a list style name"
 msgstr "Masukkan nama senarai gaya "
 
-#: ../src/richtext/richtextstyledlg.cpp:893
+#: ../src/richtext/richtextstyledlg.cpp:889
 #, fuzzy
 msgid "Enter a new style name"
 msgstr "Masukkan nama senarai gaya "
 
-#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:650
 msgid "Enter a paragraph style name"
 msgstr "Masukkan nama perenggan gaya"
 
-#: ../src/generic/dbgrptg.cpp:174
+#: ../src/generic/dbgrptg.cpp:171
 #, c-format
 msgid "Enter command to open file \"%s\":"
 msgstr "Masukkan arahan untuk membuka fail \"%s\":"
 
-#: ../src/generic/helpext.cpp:459
+#: ../src/generic/helpext.cpp:457
 msgid "Entries found"
 msgstr "Masukan ditemui"
 
-#: ../src/common/paper.cpp:142
+#: ../src/common/paper.cpp:139
 msgid "Envelope Invite 220 x 220 mm"
 msgstr "Sampul Jemputan 220 x 220 mm"
 
-#: ../src/common/config.cpp:469
+#: ../src/common/config.cpp:465
 #, c-format
 msgid ""
 "Environment variables expansion failed: missing '%c' at position %u in '%s'."
@@ -3077,13 +3081,13 @@ msgstr ""
 "Perluasan pembolehubah persekitaran gagal: hilang '%c' pada posisi %u dalam "
 "'%s'."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/generic/dirctrlg.cpp:570
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/dirctrlg.cpp:599
-#: ../src/generic/dirdlgg.cpp:323 ../src/generic/filectrlg.cpp:642
-#: ../src/generic/filectrlg.cpp:756 ../src/generic/filectrlg.cpp:770
-#: ../src/generic/filectrlg.cpp:786 ../src/generic/filectrlg.cpp:1368
-#: ../src/generic/filectrlg.cpp:1399 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/gtk1/fontdlg.cpp:74 ../src/generic/dirctrlg.cpp:536
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/dirctrlg.cpp:565
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1357 ../src/generic/filectrlg.cpp:1388
+#: ../src/generic/filedlgg.cpp:354 ../src/generic/dirdlgg.cpp:320
+#: ../src/gtk/filedlg.cpp:74
 msgid "Error"
 msgstr "Ralat"
 
@@ -3092,241 +3096,262 @@ msgstr "Ralat"
 msgid "Error closing epoll descriptor"
 msgstr "Ralat mencipta direktori"
 
-#: ../src/unix/fswatcher_kqueue.cpp:114
+#: ../src/unix/fswatcher_kqueue.cpp:131
 #, fuzzy
 msgid "Error closing kqueue instance"
 msgstr "Ralat mencipta direktori"
 
-#: ../src/common/filefn.cpp:1049
+#: ../src/common/filefn.cpp:938
 #, fuzzy, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Gagal salin fail '%s' ke '%s'."
 
-#: ../src/generic/dirdlgg.cpp:222
+#: ../src/generic/dirdlgg.cpp:219
 msgid "Error creating directory"
 msgstr "Ralat mencipta direktori"
 
-#: ../src/common/imagbmp.cpp:1181
+#: ../src/common/imagbmp.cpp:1193
 msgid "Error in reading image DIB."
 msgstr "Ralat membaca DIB imej."
 
-#: ../src/propgrid/propgrid.cpp:6696
+#: ../src/propgrid/propgrid.cpp:6665
 #, c-format
 msgid "Error in resource: %s"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:422
+#: ../src/common/fileconf.cpp:421
 msgid "Error reading config options."
 msgstr "Ralat membaca pilihan konfig."
+
+#: ../src/msw/webview_ie.cpp:1057 ../src/msw/webview_edge.cpp:850
+#: ../src/gtk/webview_webkit2.cpp:1262 ../src/osx/webview_webkit.mm:383
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
 
 #: ../src/common/fileconf.cpp:1029
 msgid "Error saving user configuration data."
 msgstr "Ralat menulis fail konfigurasi pengguna."
 
-#: ../src/gtk/print.cpp:722
+#: ../src/gtk/print.cpp:720
 #, fuzzy
 msgid "Error while printing: "
 msgstr "Ralat ketika menunggu semafor"
 
-#: ../src/common/log.cpp:219
+#: ../src/common/log.cpp:237
 msgid "Error: "
 msgstr "Ralat: "
 
+#: ../src/common/webrequest.cpp:98
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Ralat: "
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:69
+#: ../src/common/accelcmn.cpp:66
 msgid "Esc"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:70
+#: ../src/common/accelcmn.cpp:67
 #, fuzzy
 msgid "Escape"
 msgstr "Lanskap"
 
-#: ../src/common/fmapbase.cpp:150
+#: ../src/common/fmapbase.cpp:147
 msgid "Esperanto (ISO-8859-3)"
 msgstr "Esperanto (ISO-8859-3)"
 
-#: ../include/wx/generic/progdlgg.h:85
+#: ../include/wx/generic/progdlgg.h:86
 #, fuzzy
 msgid "Estimated time:"
 msgstr "Masa anggaran : "
 
-#: ../src/generic/dbgrptg.cpp:234
+#: ../src/generic/dbgrptg.cpp:231
 #, fuzzy
 msgid "Executable files (*.exe)|*.exe|"
 msgstr "Fail boleh laksana (*.exe)|*.exe|Semua fail (*.*)|*.*||"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:155 ../src/common/accelcmn.cpp:78
+#: ../src/common/stockitem.cpp:152 ../src/common/accelcmn.cpp:75
 msgid "Execute"
 msgstr ""
 
-#: ../src/msw/utilsexc.cpp:876
+#: ../src/msw/utilsexc.cpp:873
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Perlaksanaan arahan '%s' gagal"
 
-#: ../src/common/paper.cpp:105
+#: ../src/common/paper.cpp:102
 msgid "Executive, 7 1/4 x 10 1/2 in"
 msgstr "Eksekutif, 7 1/4 x 10 1/2 in"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6009
+#: ../src/generic/datavgen.cpp:6814
 msgid "Expand"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1240
+#: ../src/msw/registry.cpp:1228
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
 msgstr ""
 "Mengeksport kunci registri: fail \"%s\" sedia wujud dan tidak akan ditindih."
 
-#: ../src/common/fmapbase.cpp:195
+#: ../src/common/fmapbase.cpp:192
 msgid "Extended Unix Codepage for Japanese (EUC-JP)"
 msgstr "Extended Unix Codepage for Japanese (EUC-JP)"
 
-#: ../src/html/chm.cpp:725
+#: ../src/html/chm.cpp:718
 #, c-format
 msgid "Extraction of '%s' into '%s' failed."
 msgstr "Pengekstrakan '%s' kepada '%s' gagal."
 
-#: ../src/common/accelcmn.cpp:249 ../src/common/accelcmn.cpp:344
+#: ../src/common/accelcmn.cpp:259 ../src/common/accelcmn.cpp:358
 msgid "F"
 msgstr "F"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:672
+#: ../src/propgrid/advprops.cpp:582
 #, fuzzy
 msgid "Face Name"
 msgstr "NamaBaru"
 
-#: ../src/unix/snglinst.cpp:269
+#: ../src/unix/snglinst.cpp:266
 msgid "Failed to access lock file."
 msgstr "Gagal mencapai fail kunci."
+
+#: ../src/gtk/font.cpp:572
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Gagal memuat metafail dari fail \"%s\"."
 
 #: ../src/unix/epolldispatcher.cpp:116
 #, fuzzy, c-format
 msgid "Failed to add descriptor %d to epoll descriptor %d"
 msgstr "gagal menulis kepada penghurai %d"
 
-#: ../src/msw/dib.cpp:489
+#: ../src/msw/dib.cpp:535
 #, fuzzy, c-format
 msgid "Failed to allocate %luKb of memory for bitmap data."
 msgstr "Gagal menyediakan %luKb memori untuk data peta bit."
 
-#: ../src/common/glcmn.cpp:115
+#: ../src/common/glcmn.cpp:112
 #, fuzzy
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Gagal mencipta kursor."
 
-#: ../src/unix/displayx11.cpp:236
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Gagal mencipta kursor."
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Gagal mencipta kursor."
+
+#: ../include/wx/unix/private/displayx11.h:89
 msgid "Failed to change video mode"
 msgstr "Klik menukar mod video"
 
-#: ../src/common/image.cpp:3277
+#: ../src/common/image.cpp:3396
 #, fuzzy, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Gagal menyimpan peta bit kepada fail \"%s\"."
 
-#: ../src/common/debugrpt.cpp:239
+#: ../src/common/debugrpt.cpp:240
 #, c-format
 msgid "Failed to clean up debug report directory \"%s\""
 msgstr "Gagal membersihkan direktori laporan nyahpijat \"%s\""
 
-#: ../src/common/filename.cpp:192
+#: ../src/common/filename.cpp:189
 msgid "Failed to close file handle"
 msgstr "Gagal tutup pengemudi fail"
 
-#: ../src/unix/snglinst.cpp:340
+#: ../src/unix/snglinst.cpp:337
 #, c-format
 msgid "Failed to close lock file '%s'"
 msgstr "Gagal menutup fail kunci '%s'"
 
-#: ../src/msw/clipbrd.cpp:112
+#: ../src/msw/clipbrd.cpp:110
 msgid "Failed to close the clipboard."
 msgstr "Gagal menutup klipbod."
 
-#: ../src/x11/utils.cpp:208
+#: ../src/x11/utils.cpp:170
 #, c-format
 msgid "Failed to close the display \"%s\""
 msgstr "Gagal menutup paparan \"%s\""
 
-#: ../src/msw/dialup.cpp:797
+#: ../src/msw/dialup.cpp:791
 msgid "Failed to connect: missing username/password."
 msgstr "Sila menyambung: hilang nama pengguna/kata laluan."
 
-#: ../src/msw/dialup.cpp:743
+#: ../src/msw/dialup.cpp:737
 msgid "Failed to connect: no ISP to dial."
 msgstr "Gagal menyambung: tiada ISP untuk dail."
 
-#: ../src/common/textfile.cpp:203
-#, fuzzy, c-format
-msgid "Failed to convert file \"%s\" to Unicode."
-msgstr "Gagal menukar kadungan failkepada Unikod."
-
-#: ../src/generic/logg.cpp:956
+#: ../src/generic/logg.cpp:953
 #, fuzzy
 msgid "Failed to copy dialog contents to the clipboard."
 msgstr "Gagal membuka klipbod."
 
-#: ../src/msw/registry.cpp:692
+#: ../src/msw/registry.cpp:681
 #, c-format
 msgid "Failed to copy registry value '%s'"
 msgstr "Gagal salin nilai registri '%s'"
 
-#: ../src/msw/registry.cpp:701
+#: ../src/msw/registry.cpp:690
 #, c-format
 msgid "Failed to copy the contents of registry key '%s' to '%s'."
 msgstr "Gagal salin kandunugan kunci registri '%s' ke '%s'."
 
-#: ../src/common/filefn.cpp:1015
+#: ../src/common/filefn.cpp:904
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Gagal salin fail '%s' ke '%s'."
 
-#: ../src/msw/registry.cpp:679
+#: ../src/msw/registry.cpp:668
 #, c-format
 msgid "Failed to copy the registry subkey '%s' to '%s'."
 msgstr "Gagal salin subkunci registri '%s' ke '%s'."
 
-#: ../src/msw/dde.cpp:1070
+#: ../src/msw/dde.cpp:1134
 msgid "Failed to create DDE string"
 msgstr "Gagal cipta rentetan DDE"
 
-#: ../src/msw/mdi.cpp:616
+#: ../src/msw/mdi.cpp:621
 msgid "Failed to create MDI parent frame."
 msgstr "Gagal cipta bingkai MDI induk."
 
-#: ../src/common/filename.cpp:1027
+#: ../src/common/filename.cpp:1024
 msgid "Failed to create a temporary file name"
 msgstr "Gagal mencipta nama fail sementara"
 
-#: ../src/msw/utilsexc.cpp:228
+#: ../src/msw/utilsexc.cpp:225
 msgid "Failed to create an anonymous pipe"
 msgstr "Gagal mencipta saliran tanpanama"
 
-#: ../src/msw/ole/automtn.cpp:522
+#: ../src/msw/ole/automtn.cpp:513
 #, fuzzy, c-format
 msgid "Failed to create an instance of \"%s\""
 msgstr "Gagal mencipta direktori \"%s\""
 
-#: ../src/msw/dde.cpp:437
+#: ../src/msw/dde.cpp:432
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "Gagal cipta smabugan ke pelayan '%s' pada topik '%s'"
 
-#: ../src/msw/cursor.cpp:204
+#: ../src/msw/cursor.cpp:195
 msgid "Failed to create cursor."
 msgstr "Gagal mencipta kursor."
 
-#: ../src/common/debugrpt.cpp:209
+#: ../src/common/debugrpt.cpp:210
 #, c-format
 msgid "Failed to create directory \"%s\""
 msgstr "Gagal mencipta direktori \"%s\""
 
-#: ../src/generic/dirdlgg.cpp:220
+#: ../src/generic/dirdlgg.cpp:217
 #, c-format
 msgid ""
 "Failed to create directory '%s'\n"
@@ -3340,116 +3365,135 @@ msgstr ""
 msgid "Failed to create epoll descriptor"
 msgstr "Gagal mencipta kursor."
 
-#: ../src/msw/mimetype.cpp:238
+#: ../src/gtk/font.cpp:562
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "Gagal naiktaraf fail konfigurasi pengguna."
+
+#: ../src/msw/mimetype.cpp:235
 #, c-format
 msgid "Failed to create registry entry for '%s' files."
 msgstr "Gagal mencipta kunci registri  untuk fail '%s'."
 
-#: ../src/msw/fdrepdlg.cpp:409
+#: ../src/msw/fdrepdlg.cpp:408
 #, c-format
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr "Gagal mencipta dialog cari/ganti piawai (kod ralat %d)"
 
-#: ../src/unix/wakeuppipe.cpp:52
+#: ../src/unix/wakeuppipe.cpp:49
 #, fuzzy
 msgid "Failed to create wake up pipe used by event loop."
 msgstr "Gagal cipta bar status."
 
-#: ../src/html/winpars.cpp:730
+#: ../src/html/winpars.cpp:727
 #, c-format
 msgid "Failed to display HTML document in %s encoding"
 msgstr "Gagal papar dokumen HTML dalam pengkodan %s"
 
-#: ../src/msw/clipbrd.cpp:124
+#: ../src/msw/clipbrd.cpp:122
 msgid "Failed to empty the clipboard."
 msgstr "Gagal melapangkan klipbod."
 
-#: ../src/unix/displayx11.cpp:212
+#: ../include/wx/unix/private/displayx11.h:65
 msgid "Failed to enumerate video modes"
 msgstr "Gagal menghitung mod video"
 
-#: ../src/msw/dde.cpp:722
+#: ../src/msw/dde.cpp:717
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "Gagal dirikan gelung yang dipertimbangkan dengan pelayan DDE"
 
-#: ../src/msw/dialup.cpp:629 ../src/msw/dialup.cpp:863
+#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Gagal mengukuhkan sambuungan mendial: %s"
 
-#: ../src/unix/utilsunx.cpp:611
+#: ../src/unix/utilsunx.cpp:613
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Gagal melaksanakan '%s'\n"
 
-#: ../src/common/debugrpt.cpp:720
+#: ../src/common/debugrpt.cpp:730
 msgid "Failed to execute curl, please install it in PATH."
 msgstr "Gagal melaksanakan curl. sila pasangkannya dalam PATH."
 
-#: ../src/msw/ole/automtn.cpp:505
+#: ../src/msw/ole/automtn.cpp:496
 #, fuzzy, c-format
 msgid "Failed to find CLSID of \"%s\""
 msgstr "Gagal membuka papara \"%s\"."
 
-#: ../src/common/regex.cpp:431 ../src/common/regex.cpp:479
+#: ../src/common/regex.cpp:428 ../src/common/regex.cpp:476
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "Gagal menemui padanan ungkapan nalar: %s"
 
-#: ../src/msw/dialup.cpp:695
+#: ../src/msw/webview_ie.cpp:978
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:689
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Gagal mendapatkan nama ISP: %s"
 
-#: ../src/msw/ole/automtn.cpp:574
+#: ../src/msw/ole/automtn.cpp:565
 #, fuzzy, c-format
 msgid "Failed to get OLE automation interface for \"%s\""
 msgstr "Gagal mencipta direktori \"%s\""
 
-#: ../src/msw/clipbrd.cpp:711
+#: ../src/msw/clipbrd.cpp:731
 msgid "Failed to get data from the clipboard"
 msgstr "Gagal memdapatkan data dari klipbod."
 
-#: ../src/common/time.cpp:223
+#: ../src/common/time.cpp:216
 msgid "Failed to get the local system time"
 msgstr "Gagal mendapatkan masa sistem lokal"
 
-#: ../src/common/filefn.cpp:1345
+#: ../src/common/filefn.cpp:1233
 msgid "Failed to get the working directory"
 msgstr "Gagal mendapatkan direktori kerja"
 
-#: ../src/univ/theme.cpp:114
+#: ../src/univ/theme.cpp:111
 msgid "Failed to initialize GUI: no built-in themes found."
 msgstr "Gagal memulakan GUI: tiada tema bina-dalam ditemui."
 
-#: ../src/msw/helpchm.cpp:63
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:60
 msgid "Failed to initialize MS HTML Help."
 msgstr "Gagal memulakan Bantuan MS HTML."
 
-#: ../src/msw/glcanvas.cpp:1381
+#: ../src/msw/glcanvas.cpp:1391
 msgid "Failed to initialize OpenGL"
 msgstr "Gagal memulakan OpenGL"
 
-#: ../src/msw/dialup.cpp:858
+#: ../src/msw/dialup.cpp:852
 #, fuzzy, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Gagal menamatkan sambungan mendial: %s"
 
-#: ../src/gtk/textctrl.cpp:1128
+#: ../src/gtk/textctrl.cpp:1209
 msgid "Failed to insert text in the control."
 msgstr "Gagal menyelitkan teks dalam kawalan."
 
-#: ../src/unix/snglinst.cpp:241
+#: ../src/unix/snglinst.cpp:238
 #, c-format
 msgid "Failed to inspect the lock file '%s'"
 msgstr "Gagal menyelia fail kunci '%s'"
 
-#: ../src/unix/appunix.cpp:182
+#: ../src/unix/appunix.cpp:179
 #, fuzzy
 msgid "Failed to install signal handler"
 msgstr "Gagal tutup pengemudi fail"
 
-#: ../src/unix/threadpsx.cpp:1167
+#: ../src/unix/threadpsx.cpp:1216
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -3457,71 +3501,71 @@ msgstr ""
 "Gagal mengikat benang, kemungkinan memori bocor dikesan - sila mulakan "
 "program"
 
-#: ../src/msw/utils.cpp:629
+#: ../src/msw/utils.cpp:619
 #, c-format
 msgid "Failed to kill process %d"
 msgstr "Gagal membunuh proses %d"
 
-#: ../src/common/image.cpp:2500
+#: ../src/common/image.cpp:2595
 #, fuzzy, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Gagal memuat imej %d dari fail '%s'."
 
-#: ../src/common/image.cpp:2509
+#: ../src/common/image.cpp:2604
 #, fuzzy, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Gagal memuat imej %d dari fail '%s'."
 
-#: ../src/common/iconbndl.cpp:225
+#: ../src/common/iconbndl.cpp:224
 #, fuzzy, c-format
 msgid "Failed to load icons from resource '%s'."
 msgstr "Gagal memuat imej %d dari fail '%s'."
 
-#: ../src/common/iconbndl.cpp:200
+#: ../src/common/iconbndl.cpp:198
 #, fuzzy, c-format
 msgid "Failed to load image %%d from file '%s'."
 msgstr "Gagal memuat imej %d dari fail '%s'."
 
-#: ../src/common/iconbndl.cpp:208
+#: ../src/common/iconbndl.cpp:206
 #, fuzzy, c-format
 msgid "Failed to load image %d from stream."
 msgstr "Gagal memuat imej %d dari fail '%s'."
 
-#: ../src/common/image.cpp:2587 ../src/common/image.cpp:2606
+#: ../src/common/image.cpp:2682 ../src/common/image.cpp:2701
 #, fuzzy, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Gagal memuat imej %d dari fail '%s'."
 
-#: ../src/msw/enhmeta.cpp:97
+#: ../src/msw/enhmeta.cpp:94
 #, c-format
 msgid "Failed to load metafile from file \"%s\"."
 msgstr "Gagal memuat metafail dari fail \"%s\"."
 
-#: ../src/msw/volume.cpp:327
+#: ../src/msw/volume.cpp:335
 msgid "Failed to load mpr.dll."
 msgstr "Gagal memuat mpr.dll."
 
-#: ../src/msw/utils.cpp:953
+#: ../src/msw/utils.cpp:943
 #, fuzzy, c-format
 msgid "Failed to load resource \"%s\"."
 msgstr "Gagal memuat metafail dari fail \"%s\"."
 
-#: ../src/common/dynlib.cpp:92
+#: ../src/common/dynlib.cpp:86
 #, c-format
 msgid "Failed to load shared library '%s'"
 msgstr "Gagal memuat pustaka kongsi '%s'"
 
-#: ../src/osx/core/sound.cpp:145
+#: ../src/osx/core/sound.cpp:143
 #, fuzzy, c-format
 msgid "Failed to load sound from \"%s\" (error %d)."
 msgstr "Gagal memuat metafail dari fail \"%s\"."
 
-#: ../src/msw/utils.cpp:960
+#: ../src/msw/utils.cpp:950
 #, fuzzy, c-format
 msgid "Failed to lock resource \"%s\"."
 msgstr "Gagal mengunci fail kunci '%s'"
 
-#: ../src/unix/snglinst.cpp:198
+#: ../src/unix/snglinst.cpp:195
 #, c-format
 msgid "Failed to lock the lock file '%s'"
 msgstr "Gagal mengunci fail kunci '%s'"
@@ -3531,33 +3575,38 @@ msgstr "Gagal mengunci fail kunci '%s'"
 msgid "Failed to modify descriptor %d in epoll descriptor %d"
 msgstr ""
 
-#: ../src/common/filename.cpp:2575
+#: ../src/common/filename.cpp:2658
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Gagal mengubahsuai masa fail untuk '%s'"
 
-#: ../src/common/selectdispatcher.cpp:258
+#: ../src/common/selectdispatcher.cpp:255
 msgid "Failed to monitor I/O channels"
 msgstr ""
 
-#: ../src/common/filename.cpp:175
+#: ../src/common/filename.cpp:172
 #, fuzzy, c-format
 msgid "Failed to open '%s' for reading"
 msgstr "Gagal buka '%s' untuk %s"
 
-#: ../src/common/filename.cpp:180
+#: ../src/common/filename.cpp:177
 #, fuzzy, c-format
 msgid "Failed to open '%s' for writing"
 msgstr "Gagal buka '%s' untuk %s"
 
-#: ../src/html/chm.cpp:141
+#: ../src/html/chm.cpp:138
 #, c-format
 msgid "Failed to open CHM archive '%s'."
 msgstr "Gagal membuka arkib sementara '%s'."
 
-#: ../src/common/utilscmn.cpp:1126
+#: ../src/common/utilscmn.cpp:1140
 #, fuzzy, c-format
 msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Gagal buka '%s' untuk %s"
+
+#: ../src/common/hyperlnkcmn.cpp:133
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Gagal buka '%s' untuk %s"
 
 #: ../include/wx/msw/private/fswatcher.h:92
@@ -3565,96 +3614,106 @@ msgstr "Gagal buka '%s' untuk %s"
 msgid "Failed to open directory \"%s\" for monitoring."
 msgstr "Gagal buka '%s' untuk %s"
 
-#: ../src/x11/utils.cpp:227
+#: ../src/x11/utils.cpp:189
 #, c-format
 msgid "Failed to open display \"%s\"."
 msgstr "Gagal membuka papara \"%s\"."
 
-#: ../src/common/filename.cpp:1062
+#: ../src/common/filename.cpp:1059
 msgid "Failed to open temporary file."
 msgstr "Gagal membuka fail sementara."
 
-#: ../src/msw/clipbrd.cpp:91
+#: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Gagal membuka klipbod."
 
-#: ../src/common/translation.cpp:1184
+#: ../src/common/translation.cpp:1226
 #, fuzzy, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Gagal hurai Bentuk-Majmuk:'%s'"
 
-#: ../src/unix/mediactrl.cpp:1214
+#: ../src/unix/mediactrl.cpp:1239
 #, fuzzy, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Gagal membuka papara \"%s\"."
 
-#: ../src/msw/clipbrd.cpp:600
+#: ../src/msw/clipbrd.cpp:610
 msgid "Failed to put data on the clipboard"
 msgstr "Gagal letak data pada klipbod"
 
-#: ../src/unix/snglinst.cpp:278
+#: ../src/unix/snglinst.cpp:275
 msgid "Failed to read PID from lock file."
 msgstr "Gagal membaca PID daripada fail kunci."
 
-#: ../src/common/fileconf.cpp:433
+#: ../src/common/fileconf.cpp:432
 #, fuzzy
 msgid "Failed to read config options."
 msgstr "Ralat membaca pilihan konfig."
 
-#: ../src/common/docview.cpp:681
+#: ../src/common/docview.cpp:676
 #, fuzzy, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Gagal memuat metafail dari fail \"%s\"."
 
-#: ../src/dfb/evtloop.cpp:98
+#: ../src/dfb/evtloop.cpp:99
 #, fuzzy
 msgid "Failed to read event from DirectFB pipe"
 msgstr "Gagal membaca PID daripada fail kunci."
 
-#: ../src/unix/wakeuppipe.cpp:120
+#: ../src/unix/wakeuppipe.cpp:117
 #, fuzzy
 msgid "Failed to read from wake-up pipe"
 msgstr "Gagal membaca PID daripada fail kunci."
 
-#: ../src/unix/utilsunx.cpp:679
+#: ../src/common/textfile.cpp:96
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Gagal memuat metafail dari fail \"%s\"."
+
+#: ../src/unix/utilsunx.cpp:681
 msgid "Failed to redirect child process input/output"
 msgstr "Gagal mengalihkan  input/output proses anak"
 
-#: ../src/msw/utilsexc.cpp:701
+#: ../src/msw/utilsexc.cpp:698
 msgid "Failed to redirect the child process IO"
 msgstr "Gagal mengalihkan IO proses anak"
 
-#: ../src/msw/dde.cpp:288
+#: ../src/msw/dde.cpp:283
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Gagal daftar pelayan DDE '%s'"
 
-#: ../src/common/fontmap.cpp:245
+#: ../src/gtk/font.cpp:580
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "Gagal naiktaraf fail konfigurasi pengguna."
+
+#: ../src/common/fontmap.cpp:242
 #, c-format
 msgid "Failed to remember the encoding for the charset '%s'."
 msgstr "Gagal mengingat pengenkodan untuk set aksara '%s'."
 
-#: ../src/common/debugrpt.cpp:227
+#: ../src/common/debugrpt.cpp:228
 #, c-format
 msgid "Failed to remove debug report file \"%s\""
 msgstr "Gagal buang fail laporan nyahpijat \"%s\""
 
-#: ../src/unix/snglinst.cpp:328
+#: ../src/unix/snglinst.cpp:325
 #, c-format
 msgid "Failed to remove lock file '%s'"
 msgstr "Gagal buang fail kunci '%s'"
 
-#: ../src/unix/snglinst.cpp:288
+#: ../src/unix/snglinst.cpp:285
 #, c-format
 msgid "Failed to remove stale lock file '%s'."
 msgstr "Gagal buang fail laporan basi '%s'."
 
-#: ../src/msw/registry.cpp:529
+#: ../src/msw/registry.cpp:518
 #, c-format
 msgid "Failed to rename registry value '%s' to '%s'."
 msgstr "Gagal menamakan nilai registri '%s' kepada '%s'."
 
-#: ../src/common/filefn.cpp:1122
+#: ../src/common/filefn.cpp:1011
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -3663,116 +3722,125 @@ msgstr ""
 "Gagal menamakan semula fail '%s' kepada '%s' disebabkan fail destinasi telah "
 "wujud."
 
-#: ../src/msw/registry.cpp:634
+#: ../src/msw/registry.cpp:623
 #, c-format
 msgid "Failed to rename the registry key '%s' to '%s'."
 msgstr "Gagal menamakan kunci registri '%s' kepada '%s'."
 
-#: ../src/common/filename.cpp:2671
+#: ../src/msw/webview_ie.cpp:995
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/common/filename.cpp:2754
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Gagal mendapatkan masa fail untuk '%s'"
 
-#: ../src/msw/dialup.cpp:468
+#: ../src/msw/dialup.cpp:462
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Gagal mendapatkan teks mesej ralat RAS"
 
-#: ../src/msw/clipbrd.cpp:748
+#: ../src/msw/clipbrd.cpp:768
 msgid "Failed to retrieve the supported clipboard formats"
 msgstr "Gagal mendapatkan format klipbod disokong"
 
-#: ../src/common/docview.cpp:652
+#: ../src/common/docview.cpp:647
 #, fuzzy, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Gagal menyimpan peta bit kepada fail \"%s\"."
 
-#: ../src/msw/dib.cpp:269
+#: ../src/msw/dib.cpp:312
 #, c-format
 msgid "Failed to save the bitmap image to file \"%s\"."
 msgstr "Gagal menyimpan peta bit kepada fail \"%s\"."
 
-#: ../src/msw/dde.cpp:763
+#: ../src/msw/dde.cpp:811
 msgid "Failed to send DDE advise notification"
 msgstr "Gagal hantar pemberitahuan nasihat DDE"
 
-#: ../src/common/ftp.cpp:402
+#: ../src/common/ftp.cpp:399
 #, c-format
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Gagal menetapkan mod penhantaran FTP kepada %s."
 
-#: ../src/msw/clipbrd.cpp:427
+#: ../src/msw/clipbrd.cpp:443
 msgid "Failed to set clipboard data."
 msgstr "Gagal tetapkan data klipbod."
 
-#: ../src/unix/snglinst.cpp:181
+#: ../src/unix/snglinst.cpp:178
 #, c-format
 msgid "Failed to set permissions on lock file '%s'"
 msgstr "Gagal menetapkan keizinan pada fail kunci '%s'"
 
-#: ../src/unix/utilsunx.cpp:668
+#: ../src/unix/utilsunx.cpp:670
 #, fuzzy
 msgid "Failed to set process priority"
 msgstr "Gagal tetapkan keutamaan benang %d."
 
-#: ../src/common/file.cpp:559
+#: ../src/common/ffile.cpp:355 ../src/common/file.cpp:586
 msgid "Failed to set temporary file permissions"
 msgstr "PGagal tetapkan keizinan fail sementara."
 
-#: ../src/gtk/textctrl.cpp:1072
-msgid "Failed to set text in the text control."
-msgstr "Gagal menetapkan teks dalam kawalan teks."
-
-#: ../src/unix/threadpsx.cpp:1298
+#: ../src/unix/threadpsx.cpp:1347
 #, fuzzy, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Gagal tetapkan keutamaan benang %d."
 
-#: ../src/unix/threadpsx.cpp:1424
+#: ../src/unix/threadpsx.cpp:1473
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Gagal tetapkan keutamaan benang %d."
 
-#: ../src/unix/utilsunx.cpp:783
+#: ../src/unix/utilsunx.cpp:785
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 
-#: ../src/common/fs_mem.cpp:261
+#: ../src/msw/webview_ie.cpp:987
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:256
 #, c-format
 msgid "Failed to store image '%s' to memory VFS!"
 msgstr "Gagal menyimpan imej '%s' kepada VFS memori!"
 
-#: ../src/dfb/evtloop.cpp:170
+#: ../src/dfb/evtloop.cpp:171
 msgid "Failed to switch DirectFB pipe to non-blocking mode"
 msgstr ""
 
-#: ../src/unix/wakeuppipe.cpp:59
+#: ../src/unix/wakeuppipe.cpp:56
 msgid "Failed to switch wake up pipe to non-blocking mode"
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1605
+#: ../src/unix/threadpsx.cpp:1654
 msgid "Failed to terminate a thread."
 msgstr "Gagal menghentikan benang."
 
-#: ../src/msw/dde.cpp:741
+#: ../src/msw/dde.cpp:736
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "Gagal menamatkan gelung yang dipertimbangkan dengan pelayan DDE"
 
-#: ../src/msw/dialup.cpp:938
+#: ../src/msw/dialup.cpp:932
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Gagal menamatkan sambungan mendial: %s"
 
-#: ../src/common/filename.cpp:2590
+#: ../src/common/filename.cpp:2673
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Gagal sentuh fail '%s'"
 
-#: ../src/unix/snglinst.cpp:334
+#: ../src/unix/dlunix.cpp:90
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "Gagal memuat pustaka kongsi '%s'"
+
+#: ../src/unix/snglinst.cpp:331
 #, c-format
 msgid "Failed to unlock lock file '%s'"
 msgstr "Gagal nyahkunci fail kunci '%s'"
 
-#: ../src/msw/dde.cpp:309
+#: ../src/msw/dde.cpp:304
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Gagal nyahdaftar pelayan DDE '%s'"
@@ -3786,79 +3854,89 @@ msgstr "Gagal mendapatkan data dari klipbod."
 msgid "Failed to update user configuration file."
 msgstr "Gagal naiktaraf fail konfigurasi pengguna."
 
-#: ../src/common/debugrpt.cpp:733
+#: ../src/common/debugrpt.cpp:743
 #, c-format
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Gagal muatnaik laporan nyahpijat (kod ralat %d)."
 
-#: ../src/unix/snglinst.cpp:168
+#: ../src/unix/snglinst.cpp:165
 #, c-format
 msgid "Failed to write to lock file '%s'"
 msgstr "Gagal menulis fail kunci '%s'"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:209
+#: ../src/propgrid/propgrid.cpp:190
 #, fuzzy
 msgid "False"
 msgstr "Fail"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:694
+#: ../src/propgrid/advprops.cpp:604
 #, fuzzy
 msgid "Family"
 msgstr "Keluarga &fon:"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/gtk/glcanvas.cpp:176 ../src/gtk/glcanvas.cpp:187
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Ralat maut"
+
+#: ../src/common/stockitem.cpp:154
 msgid "File"
 msgstr "Fail"
 
-#: ../src/common/docview.cpp:669
+#: ../src/common/docview.cpp:664
 #, fuzzy, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Gagal buka '%s' untuk %s"
 
-#: ../src/common/docview.cpp:646
+#: ../src/common/docview.cpp:641
 #, fuzzy, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Gagal buka '%s' untuk %s"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "Fail '%s' sedia wujud, anda pasti untuk menindihnya?"
 
-#: ../src/common/filefn.cpp:1156
+#: ../src/common/filefn.cpp:1044
 #, fuzzy, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Direktori '%s' gagal dicipta"
 
-#: ../src/common/filefn.cpp:1139
+#: ../src/common/filefn.cpp:1028
 #, fuzzy, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Direktori '%s' gagal dicipta"
 
-#: ../src/richtext/richtextctrl.cpp:3081 ../src/common/textcmn.cpp:953
+#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
 msgid "File couldn't be loaded."
 msgstr "Fail gagal dimuatkan."
 
-#: ../src/msw/filedlg.cpp:393
+#: ../src/msw/filedlg.cpp:414
 #, fuzzy, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Perlaksanaan arahan '%s' gagal dengan ralat: %ul"
 
-#: ../src/common/docview.cpp:1789
+#: ../src/common/docview.cpp:1783
 msgid "File error"
 msgstr "Ralat fail"
 
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/filectrlg.cpp:770
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/filectrlg.cpp:766
 msgid "File name exists already."
 msgstr "Nama fail sedia wujud."
+
+#: ../src/osx/cocoa/filedlg.mm:264
+#, fuzzy
+msgid "File type:"
+msgstr "Teletaip"
 
 #: ../src/motif/filedlg.cpp:220
 msgid "Files"
 msgstr "Fail"
 
-#: ../src/common/filefn.cpp:1591
+#: ../src/common/filefn.cpp:1479
 #, c-format
 msgid "Files (%s)"
 msgstr "Fail (%s)"
@@ -3867,16 +3945,30 @@ msgstr "Fail (%s)"
 msgid "Filter"
 msgstr "Tapis"
 
-#: ../src/common/stockitem.cpp:158 ../src/html/helpwnd.cpp:490
+#: ../src/html/helpwnd.cpp:488
 msgid "Find"
 msgstr "Cari"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:259
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:258
+#, fuzzy
+msgid "Find in document"
+msgstr "Buka dokumen HTML"
+
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "Find..."
+msgstr "Cari"
+
+#: ../src/common/stockitem.cpp:156
 #, fuzzy
 msgid "First"
 msgstr "pertama"
 
-#: ../src/common/prntbase.cpp:1548
+#: ../src/common/prntbase.cpp:1573
 #, fuzzy
 msgid "First page"
 msgstr "Laman berikut"
@@ -3886,11 +3978,11 @@ msgstr "Laman berikut"
 msgid "Fixed"
 msgstr "Fon tetap:"
 
-#: ../src/html/helpwnd.cpp:1206
+#: ../src/html/helpwnd.cpp:1204
 msgid "Fixed font:"
 msgstr "Fon tetap:"
 
-#: ../src/html/helpwnd.cpp:1269
+#: ../src/html/helpwnd.cpp:1267
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Rupa saiz tetap.<br><b>gelap</b><i>italik</i> "
 
@@ -3899,17 +3991,17 @@ msgstr "Rupa saiz tetap.<br><b>gelap</b><i>italik</i> "
 msgid "Floating"
 msgstr "Memformat"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 #, fuzzy
 msgid "Floppy"
 msgstr "&Salin"
 
-#: ../src/common/paper.cpp:111
+#: ../src/common/paper.cpp:108
 msgid "Folio, 8 1/2 x 13 in"
 msgstr "Folio, 8 1/2 x 13 in"
 
-#: ../src/richtext/richtextformatdlg.cpp:344 ../src/osx/carbon/fontdlg.cpp:287
-#: ../src/common/stockitem.cpp:194
+#: ../src/osx/carbon/fontdlg.cpp:284 ../src/common/stockitem.cpp:191
+#: ../src/richtext/richtextformatdlg.cpp:337
 msgid "Font"
 msgstr "Fon"
 
@@ -3917,7 +4009,24 @@ msgstr "Fon"
 msgid "Font &weight:"
 msgstr "Berat fon:"
 
-#: ../src/html/helpwnd.cpp:1207
+#: ../src/osx/fontutil.cpp:89
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
+"\"."
+msgstr ""
+
+#: ../src/msw/font.cpp:1126
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Fail gagal dimuatkan."
+
+#: ../src/osx/fontutil.cpp:81
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "Fail %s tidak wujud."
+
+#: ../src/html/helpwnd.cpp:1205
 msgid "Font size:"
 msgstr "Saiz fon:"
 
@@ -3925,76 +4034,76 @@ msgstr "Saiz fon:"
 msgid "Font st&yle:"
 msgstr "Gaya fon:"
 
-#: ../src/osx/carbon/fontdlg.cpp:329
+#: ../src/osx/carbon/fontdlg.cpp:326
 msgid "Font:"
 msgstr "Fon:"
 
-#: ../src/dfb/fontmgr.cpp:198
+#: ../src/dfb/fontmgr.cpp:195
 #, c-format
 msgid "Fonts index file %s disappeared while loading fonts."
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:645
+#: ../src/unix/utilsunx.cpp:647
 msgid "Fork failed"
 msgstr "Cabang gagal"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 #, fuzzy
 msgid "Forward"
 msgstr "Maju"
 
-#: ../src/common/xtixml.cpp:235
+#: ../src/common/xtixml.cpp:231
 msgid "Forward hrefs are not supported"
 msgstr "href yang dimaju tidak disokong"
 
-#: ../src/html/helpwnd.cpp:875
+#: ../src/html/helpwnd.cpp:873
 #, c-format
 msgid "Found %i matches"
 msgstr "%i padanan ditemui"
 
-#: ../src/generic/prntdlgg.cpp:238
+#: ../src/generic/prntdlgg.cpp:231
 msgid "From:"
 msgstr "Dari:"
 
-#: ../src/propgrid/advprops.cpp:1604
+#: ../src/propgrid/advprops.cpp:1510
 msgid "Fuchsia"
 msgstr ""
 
-#: ../src/common/imaggif.cpp:138
+#: ../src/common/imaggif.cpp:135
 msgid "GIF: data stream seems to be truncated."
 msgstr "GIF: strim data dilihat seperti dipotong."
 
-#: ../src/common/imaggif.cpp:128
+#: ../src/common/imaggif.cpp:125
 msgid "GIF: error in GIF image format."
 msgstr "GIF: ralat dalam format imej GIF."
 
-#: ../src/common/imaggif.cpp:133
+#: ../src/common/imaggif.cpp:130
 msgid "GIF: not enough memory."
 msgstr "GIF: memori tidak mencukupi."
 
-#: ../src/gtk/window.cpp:4631
+#: ../src/gtk/window.cpp:5635
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
 msgstr ""
 
-#: ../src/univ/themes/gtk.cpp:525
+#: ../src/univ/themes/gtk.cpp:522
 msgid "GTK+ theme"
 msgstr "Tema GTK+"
 
-#: ../src/common/preferencescmn.cpp:40
+#: ../src/common/preferencescmn.cpp:37
 msgid "General"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:258
+#: ../src/common/prntbase.cpp:253
 msgid "Generic PostScript"
 msgstr "PostScript Umum"
 
-#: ../src/common/paper.cpp:135
+#: ../src/common/paper.cpp:132
 msgid "German Legal Fanfold, 8 1/2 x 13 in"
 msgstr "Fanfold Legal Jerman, 8 1/2 x 13 in"
 
-#: ../src/common/paper.cpp:134
+#: ../src/common/paper.cpp:131
 msgid "German Std Fanfold, 8 1/2 x 12 in"
 msgstr "Fanfold Piawai Jerman, 8 1/2 x 12 in"
 
@@ -4010,48 +4119,48 @@ msgstr "GetPropertyCollection dipanggil pada accessor umum"
 msgid "GetPropertyCollection called w/o valid collection getter"
 msgstr "GetPropertyCollection dipangil tanpa getter koleksi"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:658
 msgid "Go back"
 msgstr "Kem&bali"
 
-#: ../src/html/helpwnd.cpp:661
+#: ../src/html/helpwnd.cpp:659
 msgid "Go forward"
 msgstr "&Maju"
 
-#: ../src/html/helpwnd.cpp:663
+#: ../src/html/helpwnd.cpp:661
 msgid "Go one level up in document hierarchy"
 msgstr "Pergi satu aras ke atas dalam hirarki dokumen"
 
-#: ../src/generic/filedlgg.cpp:208 ../src/generic/dirdlgg.cpp:116
+#: ../src/generic/filedlgg.cpp:205 ../src/generic/dirdlgg.cpp:113
 msgid "Go to home directory"
 msgstr "Pergi ke direktori rumah"
 
-#: ../src/generic/filedlgg.cpp:205
+#: ../src/generic/filedlgg.cpp:202
 msgid "Go to parent directory"
 msgstr "Pergi ke direntori induk"
 
-#: ../src/generic/aboutdlgg.cpp:76
+#: ../src/generic/aboutdlgg.cpp:73
 msgid "Graphics art by "
 msgstr "Seni grafik oleh"
 
-#: ../src/propgrid/advprops.cpp:1599
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Gray"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:883
+#: ../src/propgrid/advprops.cpp:784
 msgid "GrayText"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:154
+#: ../src/common/fmapbase.cpp:151
 msgid "Greek (ISO-8859-7)"
 msgstr "Greek (ISO-8859-7)"
 
-#: ../src/propgrid/advprops.cpp:1600
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Green"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:342
+#: ../src/generic/colrdlgg.cpp:362
 msgid "Green:"
 msgstr ""
 
@@ -4059,109 +4168,109 @@ msgstr ""
 msgid "Groove"
 msgstr ""
 
-#: ../src/common/zstream.cpp:158 ../src/common/zstream.cpp:318
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
 msgid "Gzip not supported by this version of zlib"
 msgstr "Gzip tidak disokong oleh versi zlib ini"
 
-#: ../src/html/helpwnd.cpp:1549
+#: ../src/html/helpwnd.cpp:1547
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "Projek Bantuan HTML (*.hhp)|*.hhp|"
 
-#: ../src/html/htmlwin.cpp:681
+#: ../src/html/htmlwin.cpp:691
 #, c-format
 msgid "HTML anchor %s does not exist."
 msgstr "Sauh HTML %s tidak wujud."
 
-#: ../src/html/helpwnd.cpp:1547
+#: ../src/html/helpwnd.cpp:1545
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "Fail HTML (*.html;*.htm)|*.html;*.htm|"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1759
+#: ../src/propgrid/advprops.cpp:1660
 msgid "Hand"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "Harddisk"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:155
+#: ../src/common/fmapbase.cpp:152
 msgid "Hebrew (ISO-8859-8)"
 msgstr "Hebrew (ISO-8859-8)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:280 ../src/osx/button_osx.cpp:39
-#: ../src/common/stockitem.cpp:163 ../src/common/accelcmn.cpp:80
-#: ../src/html/helpdlg.cpp:66 ../src/html/helpfrm.cpp:111
+#: ../include/wx/msgdlg.h:282 ../src/osx/button_osx.cpp:39
+#: ../src/common/stockitem.cpp:160 ../src/common/accelcmn.cpp:77
+#: ../src/html/helpfrm.cpp:108 ../src/html/helpdlg.cpp:63
 msgid "Help"
 msgstr "Bantuan"
 
-#: ../src/html/helpwnd.cpp:1200
+#: ../src/html/helpwnd.cpp:1198
 msgid "Help Browser Options"
 msgstr "Pilihan Pelungsur Bantuan"
 
-#: ../src/generic/helpext.cpp:454 ../src/generic/helpext.cpp:455
+#: ../src/generic/helpext.cpp:452 ../src/generic/helpext.cpp:453
 msgid "Help Index"
 msgstr "Indeks Bantuan"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1529
 msgid "Help Printing"
 msgstr "Mencetak Bantuan"
 
-#: ../src/html/helpwnd.cpp:801
+#: ../src/html/helpwnd.cpp:799
 msgid "Help Topics"
 msgstr "Topik Bantuan"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1546
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Buku Bantuan (*.htb)|*.htb|Buku Bantuan (*.zip)|*.zip|"
 
-#: ../src/generic/helpext.cpp:267
+#: ../src/generic/helpext.cpp:265
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "Direktori bantuan \"%s\" tidak ditemui."
 
-#: ../src/generic/helpext.cpp:275
+#: ../src/generic/helpext.cpp:273
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "Fail bantuan \"%s\" tidak ditemui."
 
-#: ../src/html/helpctrl.cpp:63
+#: ../src/html/helpctrl.cpp:59
 #, c-format
 msgid "Help: %s"
 msgstr "Bantuan: %s"
 
-#: ../src/osx/menu_osx.cpp:577
+#: ../src/osx/menu_osx.cpp:469
 #, fuzzy, c-format
 msgid "Hide %s"
 msgstr "Bantuan: %s"
 
-#: ../src/osx/menu_osx.cpp:579
+#: ../src/osx/menu_osx.cpp:471
 msgid "Hide Others"
 msgstr ""
 
-#: ../src/generic/infobar.cpp:84
+#: ../src/generic/infobar.cpp:81
 msgid "Hide this notification message."
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:884
+#: ../src/propgrid/advprops.cpp:785
 #, fuzzy
 msgid "Highlight"
 msgstr "ringan"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:885
+#: ../src/propgrid/advprops.cpp:786
 #, fuzzy
 msgid "HighlightText"
 msgstr "Jajar-kanan teks."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:164 ../src/common/accelcmn.cpp:65
+#: ../src/common/stockitem.cpp:161 ../src/common/accelcmn.cpp:62
 msgid "Home"
 msgstr "Rumah"
 
-#: ../src/generic/dirctrlg.cpp:524
+#: ../src/generic/dirctrlg.cpp:490
 msgid "Home directory"
 msgstr "Direktori rumah"
 
@@ -4171,61 +4280,61 @@ msgid "How the object will float relative to the text."
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1760
+#: ../src/propgrid/advprops.cpp:1661
 msgid "I-Beam"
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1196
+#: ../src/common/imagbmp.cpp:1208
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: Ralat baca DIB topeng."
 
-#: ../src/common/imagbmp.cpp:1290 ../src/common/imagbmp.cpp:1390
-#: ../src/common/imagbmp.cpp:1405 ../src/common/imagbmp.cpp:1416
-#: ../src/common/imagbmp.cpp:1430 ../src/common/imagbmp.cpp:1478
-#: ../src/common/imagbmp.cpp:1493 ../src/common/imagbmp.cpp:1507
-#: ../src/common/imagbmp.cpp:1518
+#: ../src/common/imagbmp.cpp:1302 ../src/common/imagbmp.cpp:1402
+#: ../src/common/imagbmp.cpp:1417 ../src/common/imagbmp.cpp:1428
+#: ../src/common/imagbmp.cpp:1442 ../src/common/imagbmp.cpp:1490
+#: ../src/common/imagbmp.cpp:1505 ../src/common/imagbmp.cpp:1519
+#: ../src/common/imagbmp.cpp:1530
 msgid "ICO: Error writing the image file!"
 msgstr "Ralat menulis fail imej!"
 
-#: ../src/common/imagbmp.cpp:1255
+#: ../src/common/imagbmp.cpp:1267
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: Imej terlalu tinggi untuk ikon."
 
-#: ../src/common/imagbmp.cpp:1263
+#: ../src/common/imagbmp.cpp:1275
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: Imej terlalu lebar untuk ikon."
 
-#: ../src/common/imagbmp.cpp:1603
+#: ../src/common/imagbmp.cpp:1615
 msgid "ICO: Invalid icon index."
 msgstr "ICO: Indeks ikon tidak sah."
 
-#: ../src/common/imagiff.cpp:758
+#: ../src/common/imagiff.cpp:755
 msgid "IFF: data stream seems to be truncated."
 msgstr "IFF: strim data dilihat seperti dipotong."
 
-#: ../src/common/imagiff.cpp:742
+#: ../src/common/imagiff.cpp:739
 msgid "IFF: error in IFF image format."
 msgstr "IFF: ralat pada format imej IFF."
 
-#: ../src/common/imagiff.cpp:745
+#: ../src/common/imagiff.cpp:742
 msgid "IFF: not enough memory."
 msgstr "IFF: tidak cukup memori."
 
-#: ../src/common/imagiff.cpp:748
+#: ../src/common/imagiff.cpp:745
 msgid "IFF: unknown error!!!"
 msgstr "IFF: ralat tidak diketahui!!!"
 
-#: ../src/common/fmapbase.cpp:197
+#: ../src/common/fmapbase.cpp:194
 msgid "ISO-2022-JP"
 msgstr ""
 
-#: ../src/html/htmprint.cpp:282
+#: ../src/html/htmprint.cpp:294
 msgid ""
 "If possible, try changing the layout parameters to make the printout more "
 "narrow."
 msgstr ""
 
-#: ../src/generic/dbgrptg.cpp:358
+#: ../src/generic/dbgrptg.cpp:362
 msgid ""
 "If you have any additional information pertaining to this bug\n"
 "report, please enter it here and it will be joined to it:"
@@ -4245,46 +4354,50 @@ msgstr ""
 "tetapi diingatkan bahawa ini akan membelakangi kemajuan program, jika boleh\n"
 "sila teruskan dengan menjana laporan.\n"
 
-#: ../src/msw/registry.cpp:1405
+#: ../src/common/zipstrm.cpp:1043
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1393
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Abaikan nilai \"%s\" kunci \"%s\"."
 
-#: ../src/common/xtistrm.cpp:295
+#: ../src/common/xtistrm.cpp:292
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Kelas Objek tidak sah (Non-wxEvtHandler) sebagai Sumber Kejadian"
 
-#: ../src/common/xti.cpp:513
+#: ../src/common/xti.cpp:510
 msgid "Illegal Parameter Count for ConstructObject Method"
 msgstr "Kiraan Parameter tidak sah untuk Metod ConstructObject"
 
-#: ../src/common/xti.cpp:501
+#: ../src/common/xti.cpp:498
 msgid "Illegal Parameter Count for Create Method"
 msgstr "Kiraan Parameter tidak sah untuk Method Create"
 
-#: ../src/generic/dirctrlg.cpp:570 ../src/generic/filectrlg.cpp:756
+#: ../src/generic/dirctrlg.cpp:536 ../src/generic/filectrlg.cpp:752
 msgid "Illegal directory name."
 msgstr "Nama direktori tidak sah."
 
-#: ../src/generic/filectrlg.cpp:1367
+#: ../src/generic/filectrlg.cpp:1356
 msgid "Illegal file specification."
 msgstr "spesifikasi fail tidak sah."
 
-#: ../src/common/image.cpp:2269
+#: ../src/common/image.cpp:2363
 msgid "Image and mask have different sizes."
 msgstr "Imej san topeng memiliki saiz berbeza."
 
-#: ../src/common/image.cpp:2746
+#: ../src/common/image.cpp:2841
 #, fuzzy, c-format
 msgid "Image file is not of type %d."
 msgstr "Fail imej bukan berjenis %ld."
 
-#: ../src/common/image.cpp:2877
+#: ../src/common/image.cpp:2995
 #, fuzzy, c-format
 msgid "Image is not of type %s."
 msgstr "Fail imej bukan berjenis %s."
 
-#: ../src/msw/textctrl.cpp:488
+#: ../src/msw/textctrl.cpp:534
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -4292,104 +4405,104 @@ msgstr ""
 "Mustahil untuk mencipta kawalan edit rich, sebaliknya gunakan kawalan mudah "
 "teks. Sila pasang semula riched32.dll"
 
-#: ../src/unix/utilsunx.cpp:301
+#: ../src/unix/utilsunx.cpp:303
 msgid "Impossible to get child process input"
 msgstr "Mustahil untuk mendapatkan input proses anak"
 
-#: ../src/common/filefn.cpp:1028
+#: ../src/common/filefn.cpp:917
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Mustahil mendapatkan keizinan untuk fail '%s'"
 
-#: ../src/common/filefn.cpp:1042
+#: ../src/common/filefn.cpp:931
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Mustahil untuk menindih fail '%s'"
 
-#: ../src/common/filefn.cpp:1097
+#: ../src/common/filefn.cpp:986
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Mustahil untuk menetapkan keizinan fail '%s'"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:886
+#: ../src/propgrid/advprops.cpp:787
 #, fuzzy
 msgid "InactiveBorder"
 msgstr "Moden"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:887
+#: ../src/propgrid/advprops.cpp:788
 msgid "InactiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:888
+#: ../src/propgrid/advprops.cpp:789
 msgid "InactiveCaptionText"
 msgstr ""
 
-#: ../src/common/gifdecod.cpp:792
+#: ../src/common/gifdecod.cpp:826
 #, c-format
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:635
+#: ../src/msw/ole/automtn.cpp:626
 msgid "Incorrect number of arguments."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:165
+#: ../src/common/stockitem.cpp:162
 msgid "Indent"
 msgstr "Jarak"
 
-#: ../src/richtext/richtextformatdlg.cpp:349
+#: ../src/richtext/richtextformatdlg.cpp:342
 msgid "Indents && Spacing"
 msgstr "Takuk  && Ruang"
 
-#: ../src/common/stockitem.cpp:166 ../src/html/helpwnd.cpp:515
+#: ../src/common/stockitem.cpp:163 ../src/html/helpwnd.cpp:513
 msgid "Index"
 msgstr "Indeks"
 
-#: ../src/common/fmapbase.cpp:159
+#: ../src/common/fmapbase.cpp:156
 msgid "Indian (ISO-8859-12)"
 msgstr "Indian (ISO-8859-12)"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "Info"
 msgstr ""
 
-#: ../src/common/init.cpp:287
+#: ../src/common/init.cpp:284
 msgid "Initialization failed in post init, aborting."
 msgstr "Permulaan gagal pada mula pos, gugurkan."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:54
+#: ../src/common/accelcmn.cpp:51
 #, fuzzy
 msgid "Ins"
 msgstr "Selit"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextsymboldlg.cpp:472 ../src/common/accelcmn.cpp:53
+#: ../src/common/accelcmn.cpp:50 ../src/richtext/richtextsymboldlg.cpp:469
 msgid "Insert"
 msgstr "Selit"
 
-#: ../src/richtext/richtextbuffer.cpp:8067
+#: ../src/richtext/richtextbuffer.cpp:8063
 #, fuzzy
 msgid "Insert Field"
 msgstr "Selit Teks"
 
-#: ../src/richtext/richtextbuffer.cpp:7978
-#: ../src/richtext/richtextbuffer.cpp:8936
+#: ../src/richtext/richtextbuffer.cpp:7974
+#: ../src/richtext/richtextbuffer.cpp:8934
 msgid "Insert Image"
 msgstr "Selit Imej"
 
-#: ../src/richtext/richtextbuffer.cpp:8025
+#: ../src/richtext/richtextbuffer.cpp:8021
 #, fuzzy
 msgid "Insert Object"
 msgstr "Selit Teks"
 
-#: ../src/richtext/richtextctrl.cpp:1286 ../src/richtext/richtextctrl.cpp:1494
-#: ../src/richtext/richtextbuffer.cpp:7822
-#: ../src/richtext/richtextbuffer.cpp:7852
-#: ../src/richtext/richtextbuffer.cpp:7894
+#: ../src/richtext/richtextbuffer.cpp:7818
+#: ../src/richtext/richtextbuffer.cpp:7848
+#: ../src/richtext/richtextbuffer.cpp:7890
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
 msgid "Insert Text"
 msgstr "Selit Teks"
 
@@ -4404,16 +4517,11 @@ msgstr "Ruangan sebelum perenggan."
 msgid "Inset"
 msgstr "Selit"
 
-#: ../src/gtk/app.cpp:425
-#, c-format
-msgid "Invalid GTK+ command line option, use \"%s --help\""
-msgstr ""
-
-#: ../src/common/imagtiff.cpp:311
+#: ../src/common/imagtiff.cpp:308
 msgid "Invalid TIFF image index."
 msgstr "Indeks imej TIFF tidak sah."
 
-#: ../src/common/appcmn.cpp:273
+#: ../src/common/appcmn.cpp:294
 #, c-format
 msgid "Invalid display mode specification '%s'."
 msgstr "Spesifikasi mod paparan '%s' tidak sah."
@@ -4423,258 +4531,262 @@ msgstr "Spesifikasi mod paparan '%s' tidak sah."
 msgid "Invalid geometry specification '%s'"
 msgstr "Spesifikasi geometri tidak sah '%s'"
 
-#: ../src/unix/fswatcher_inotify.cpp:323
+#: ../src/unix/fswatcher_inotify.cpp:320
 #, c-format
 msgid "Invalid inotify event for \"%s\""
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:312
+#: ../src/unix/snglinst.cpp:309
 #, c-format
 msgid "Invalid lock file '%s'."
 msgstr "Fail kunci '%s' tidak sah."
 
-#: ../src/common/translation.cpp:1125
+#: ../src/common/translation.cpp:1167
 #, fuzzy
 msgid "Invalid message catalog."
 msgstr "'%s' bukanlah mesej katalog yang sah."
 
-#: ../src/common/xtistrm.cpp:405 ../src/common/xtistrm.cpp:420
+#: ../src/common/xtistrm.cpp:402 ../src/common/xtistrm.cpp:417
 msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
 msgstr "Tidak sah atau Null Object ID dilepaskan kepada GetObjectClassInfo"
 
-#: ../src/common/xtistrm.cpp:435
+#: ../src/common/xtistrm.cpp:432
 msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
 msgstr "Tidak sah atau Null Object ID dilepaskan kepada HasObjectClassInfo"
 
-#: ../src/common/regex.cpp:310
+#: ../src/common/regex.cpp:307
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Ungkapan nalar '%s' tidak sah: %s"
 
-#: ../src/common/config.cpp:226
+#: ../src/common/config.cpp:222
 #, c-format
 msgid "Invalid value %ld for a boolean key \"%s\" in config file."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:351
-#: ../src/osx/carbon/fontdlg.cpp:361 ../src/common/stockitem.cpp:168
+#: ../src/osx/carbon/fontdlg.cpp:358 ../src/common/stockitem.cpp:165
+#: ../src/generic/fontdlgg.cpp:325 ../src/richtext/richtextfontpage.cpp:351
 msgid "Italic"
 msgstr "Italik"
 
-#: ../src/common/paper.cpp:130
+#: ../src/common/paper.cpp:127
 msgid "Italy Envelope, 110 x 230 mm"
 msgstr "Sampul Itali, 110 x 230 mm"
 
-#: ../src/common/imagjpeg.cpp:270
+#: ../src/common/imagjpeg.cpp:257
 msgid "JPEG: Couldn't load - file is probably corrupted."
 msgstr "JPEG: Gagal dimuat - kemungkinan fail rosak."
 
-#: ../src/common/imagjpeg.cpp:449
+#: ../src/common/imagjpeg.cpp:436
 msgid "JPEG: Couldn't save image."
 msgstr "JPEG: Gagal simpan imej."
 
-#: ../src/common/paper.cpp:163
+#: ../src/common/paper.cpp:160
 msgid "Japanese Double Postcard 200 x 148 mm"
 msgstr "Poskad Jepun Ganda Dua 200 x 148 mm"
 
-#: ../src/common/paper.cpp:167
+#: ../src/common/paper.cpp:164
 msgid "Japanese Envelope Chou #3"
 msgstr "Sampul Jepun Chou #3"
 
-#: ../src/common/paper.cpp:180
+#: ../src/common/paper.cpp:177
 msgid "Japanese Envelope Chou #3 Rotated"
 msgstr "Sampul Jepun Chou #3 Diputar"
 
-#: ../src/common/paper.cpp:168
+#: ../src/common/paper.cpp:165
 msgid "Japanese Envelope Chou #4"
 msgstr "Sampul Jepun Chou #4"
 
-#: ../src/common/paper.cpp:181
+#: ../src/common/paper.cpp:178
 msgid "Japanese Envelope Chou #4 Rotated"
 msgstr "Sampul Jepun Chou #4 Diputar"
 
-#: ../src/common/paper.cpp:165
+#: ../src/common/paper.cpp:162
 msgid "Japanese Envelope Kaku #2"
 msgstr "Sampul Jepun Kaku #2"
 
-#: ../src/common/paper.cpp:178
+#: ../src/common/paper.cpp:175
 msgid "Japanese Envelope Kaku #2 Rotated"
 msgstr "Sampul Jepun Kaku #2 Diputar"
 
-#: ../src/common/paper.cpp:166
+#: ../src/common/paper.cpp:163
 msgid "Japanese Envelope Kaku #3"
 msgstr "Sampul Jepun Kaku #3"
 
-#: ../src/common/paper.cpp:179
+#: ../src/common/paper.cpp:176
 msgid "Japanese Envelope Kaku #3 Rotated"
 msgstr "Sampul Jepun Kaku #3 Diputar"
 
-#: ../src/common/paper.cpp:185
+#: ../src/common/paper.cpp:182
 msgid "Japanese Envelope You #4"
 msgstr "Sampul Jepun You #4"
 
-#: ../src/common/paper.cpp:186
+#: ../src/common/paper.cpp:183
 msgid "Japanese Envelope You #4 Rotated"
 msgstr "Sampul Jepun You #4 Diputar"
 
-#: ../src/common/paper.cpp:138
+#: ../src/common/paper.cpp:135
 msgid "Japanese Postcard 100 x 148 mm"
 msgstr "Poskad Jepun 100 x 148 mm"
 
-#: ../src/common/paper.cpp:175
+#: ../src/common/paper.cpp:172
 msgid "Japanese Postcard Rotated 148 x 100 mm"
 msgstr "Poskad Jepun Diputar 148 x 100 mm"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "Jump to"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:171
+#: ../src/common/stockitem.cpp:168
 msgid "Justified"
 msgstr "Ditentu"
 
-#: ../src/richtext/richtextindentspage.cpp:155
-#: ../src/richtext/richtextindentspage.cpp:157
 #: ../src/richtext/richtextliststylepage.cpp:344
 #: ../src/richtext/richtextliststylepage.cpp:346
+#: ../src/richtext/richtextindentspage.cpp:155
+#: ../src/richtext/richtextindentspage.cpp:157
 msgid "Justify text left and right."
 msgstr "Benarkan teks kiri dan kanan."
 
-#: ../src/common/fmapbase.cpp:163
+#: ../src/common/fmapbase.cpp:160
 msgid "KOI8-R"
 msgstr "KOI8-R"
 
-#: ../src/common/fmapbase.cpp:164
+#: ../src/common/fmapbase.cpp:161
 msgid "KOI8-U"
 msgstr "KOI8-U"
 
-#: ../src/common/accelcmn.cpp:265 ../src/common/accelcmn.cpp:347
+#: ../src/common/accelcmn.cpp:279 ../src/common/accelcmn.cpp:364
 msgid "KP_"
 msgstr "KP_"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 #, fuzzy
 msgid "KP_Add"
 msgstr "KP_ADD"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "KP_Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "KP_Decimal"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 #, fuzzy
 msgid "KP_Delete"
 msgstr "Padam"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "KP_Divide"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 #, fuzzy
 msgid "KP_Down"
 msgstr "Turun"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 #, fuzzy
 msgid "KP_End"
 msgstr "KP_END"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 #, fuzzy
 msgid "KP_Enter"
 msgstr "Pencetak"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "KP_Equal"
 msgstr ""
 
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
-#, fuzzy
-msgid "KP_Home"
-msgstr "Rumah"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
-#, fuzzy
-msgid "KP_Insert"
-msgstr "Selit"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
-#, fuzzy
-msgid "KP_Left"
-msgstr "Kiri"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
-msgid "KP_Multiply"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:99
-#, fuzzy
-msgid "KP_Next"
-msgstr "Maju"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
-msgid "KP_PageDown"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
-msgid "KP_PageUp"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:98
-msgid "KP_Prior"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
-#, fuzzy
-msgid "KP_Right"
-msgstr "Kanan"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
-msgid "KP_Separator"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
-msgid "KP_Space"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
-msgid "KP_Subtract"
+#: ../src/common/accelcmn.cpp:276 ../src/common/accelcmn.cpp:361
+msgid "KP_F"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
 #: ../src/common/accelcmn.cpp:89
 #, fuzzy
+msgid "KP_Home"
+msgstr "Rumah"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:100
+#, fuzzy
+msgid "KP_Insert"
+msgstr "Selit"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:90
+#, fuzzy
+msgid "KP_Left"
+msgstr "Kiri"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:103
+msgid "KP_Multiply"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:97
+#, fuzzy
+msgid "KP_Next"
+msgstr "Maju"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:95
+msgid "KP_PageDown"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:94
+msgid "KP_PageUp"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:96
+msgid "KP_Prior"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:92
+#, fuzzy
+msgid "KP_Right"
+msgstr "Kanan"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:105
+msgid "KP_Separator"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:86
+msgid "KP_Space"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:106
+msgid "KP_Subtract"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:87
+#, fuzzy
 msgid "KP_Tab"
 msgstr "KP_TAB"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 #, fuzzy
 msgid "KP_Up"
 msgstr "KP_UP"
@@ -4684,114 +4796,129 @@ msgstr "KP_UP"
 msgid "L&ine spacing:"
 msgstr "Ruang baris:"
 
-#: ../src/generic/prntdlgg.cpp:613 ../src/generic/prntdlgg.cpp:868
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "ralat mampatan"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "ralat nyahmampat"
+
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:861
 msgid "Landscape"
 msgstr "Lanskap"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 #, fuzzy
 msgid "Last"
 msgstr "Tampal"
 
-#: ../src/common/prntbase.cpp:1572
+#: ../src/common/prntbase.cpp:1597
 #, fuzzy
 msgid "Last page"
 msgstr "Laman berikut"
 
-#: ../src/common/log.cpp:305
+#: ../src/common/log.cpp:324
 #, c-format
 msgid "Last repeated message (\"%s\", %u time) wasn't output"
 msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/common/paper.cpp:103
+#: ../src/common/paper.cpp:100
 msgid "Ledger, 17 x 11 in"
 msgstr "Ledger, 17 x 11 in"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6146
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:58 ../src/generic/datavgen.cpp:6951
+#: ../src/richtext/richtextsizepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:252
 #: ../src/richtext/richtextliststylepage.cpp:253
 #: ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
-#: ../src/richtext/richtextsizepage.cpp:249 ../src/common/accelcmn.cpp:61
 msgid "Left"
 msgstr "Kiri"
 
-#: ../src/richtext/richtextindentspage.cpp:204
 #: ../src/richtext/richtextliststylepage.cpp:390
+#: ../src/richtext/richtextindentspage.cpp:204
 msgid "Left (&first line):"
 msgstr "Kiri (baris pertama):"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1761
+#: ../src/propgrid/advprops.cpp:1662
 msgid "Left Button"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:880
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Left margin (mm):"
 msgstr "Left margin (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:141
-#: ../src/richtext/richtextindentspage.cpp:143
 #: ../src/richtext/richtextliststylepage.cpp:330
 #: ../src/richtext/richtextliststylepage.cpp:332
+#: ../src/richtext/richtextindentspage.cpp:141
+#: ../src/richtext/richtextindentspage.cpp:143
 msgid "Left-align text."
 msgstr "Teks jajar-kiri."
 
-#: ../src/common/paper.cpp:144
+#: ../src/common/paper.cpp:141
 msgid "Legal Extra 9 1/2 x 15 in"
 msgstr "Legal Ekstra 9 1/2 x 15 in"
 
-#: ../src/common/paper.cpp:96
+#: ../src/common/paper.cpp:93
 msgid "Legal, 8 1/2 x 14 in"
 msgstr "Legal, 8 1/2 x 14 in"
 
-#: ../src/common/paper.cpp:143
+#: ../src/common/paper.cpp:140
 msgid "Letter Extra 9 1/2 x 12 in"
 msgstr "Letter Ekstra 9 1/2 x 12 in"
 
-#: ../src/common/paper.cpp:149
+#: ../src/common/paper.cpp:146
 msgid "Letter Extra Transverse 9.275 x 12 in"
 msgstr "Surat Ekstra Lintang 9.275 x 12 in"
 
-#: ../src/common/paper.cpp:152
+#: ../src/common/paper.cpp:149
 msgid "Letter Plus 8 1/2 x 12.69 in"
 msgstr "Surat Tambah 8 1/2 x 12.69 in"
 
-#: ../src/common/paper.cpp:169
+#: ../src/common/paper.cpp:166
 msgid "Letter Rotated 11 x 8 1/2 in"
 msgstr "Surat Diputar 11 x 8 1/2 in"
 
-#: ../src/common/paper.cpp:101
+#: ../src/common/paper.cpp:98
 msgid "Letter Small, 8 1/2 x 11 in"
 msgstr "Surat Kecil, 8 1/2 x 11 in"
 
-#: ../src/common/paper.cpp:147
+#: ../src/common/paper.cpp:144
 msgid "Letter Transverse 8 1/2 x 11 in"
 msgstr "Surat Lintang 8 1/2 x 11 in"
 
-#: ../src/common/paper.cpp:95
+#: ../src/common/paper.cpp:92
 msgid "Letter, 8 1/2 x 11 in"
 msgstr "Surat, 8 1/2 x 11 in"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "License"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:332
+#: ../src/generic/fontdlgg.cpp:328
 msgid "Light"
 msgstr "Cerah"
 
-#: ../src/propgrid/advprops.cpp:1608
+#: ../src/propgrid/advprops.cpp:1514
 msgid "Lime"
 msgstr ""
 
-#: ../src/generic/helpext.cpp:294
+#: ../src/generic/helpext.cpp:292
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr "Baris %lu fail peta \"%s\" terdapat sintaks tidak sah, dilangkau."
@@ -4800,15 +4927,15 @@ msgstr "Baris %lu fail peta \"%s\" terdapat sintaks tidak sah, dilangkau."
 msgid "Line spacing:"
 msgstr "Ruang baris:"
 
-#: ../src/html/chm.cpp:838
+#: ../src/html/chm.cpp:829
 msgid "Link contained '//', converted to absolute link."
 msgstr "Pautan mengandungi '//', tukar kepada pautan sebenar."
 
-#: ../src/richtext/richtextformatdlg.cpp:364
+#: ../src/richtext/richtextformatdlg.cpp:357
 msgid "List Style"
 msgstr "Gaya Senarai"
 
-#: ../src/richtext/richtextstyles.cpp:1064
+#: ../src/richtext/richtextstyles.cpp:1061
 msgid "List styles"
 msgstr "Gaya senarai"
 
@@ -4822,26 +4949,26 @@ msgstr "Senaraikan saiz fon dalam titik."
 msgid "Lists the available fonts."
 msgstr "Senarai fon yang ada."
 
-#: ../src/common/fldlgcmn.cpp:340
+#: ../src/common/fldlgcmn.cpp:337
 #, c-format
 msgid "Load %s file"
 msgstr "Memuatkan fail %s"
 
-#: ../src/html/htmlwin.cpp:597
+#: ../src/html/htmlwin.cpp:600
 msgid "Loading : "
 msgstr "Memuatkan: "
 
-#: ../src/unix/snglinst.cpp:246
+#: ../src/unix/snglinst.cpp:243
 #, c-format
 msgid "Lock file '%s' has incorrect owner."
 msgstr "Pemilik fail kunci '%s' yang salah."
 
-#: ../src/unix/snglinst.cpp:251
+#: ../src/unix/snglinst.cpp:248
 #, c-format
 msgid "Lock file '%s' has incorrect permissions."
 msgstr "Keizinan fail kunci '%s' yang salah."
 
-#: ../src/generic/logg.cpp:576
+#: ../src/generic/logg.cpp:573
 #, c-format
 msgid "Log saved to the file '%s'."
 msgstr "Log disimpan ke fail '%s'."
@@ -4856,11 +4983,11 @@ msgstr "Aksara Huruf Kecil"
 msgid "Lower case roman numerals"
 msgstr "Angka roman huruf kecil"
 
-#: ../src/gtk/mdi.cpp:422 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk1/mdi.cpp:431 ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "Anak MDI"
 
-#: ../src/msw/helpchm.cpp:56
+#: ../src/msw/helpchm.cpp:53
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -4868,196 +4995,196 @@ msgstr ""
 "Fungsi Bantuan MS HTML tidak wujud kerana pustaka bantuan MS HTML tidak "
 "dipasang pasa mesin ini. SIla pasangkannya."
 
-#: ../src/univ/themes/win32.cpp:3754
+#: ../src/univ/themes/win32.cpp:3751
 msgid "Ma&ximize"
 msgstr "Mak&simum"
 
-#: ../src/common/fmapbase.cpp:203
+#: ../src/common/fmapbase.cpp:200
 #, fuzzy
 msgid "MacArabic"
 msgstr "Arab"
 
-#: ../src/common/fmapbase.cpp:222
+#: ../src/common/fmapbase.cpp:219
 msgid "MacArmenian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:211
+#: ../src/common/fmapbase.cpp:208
 msgid "MacBengali"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:217
+#: ../src/common/fmapbase.cpp:214
 msgid "MacBurmese"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:236
+#: ../src/common/fmapbase.cpp:233
 msgid "MacCeltic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:227
+#: ../src/common/fmapbase.cpp:224
 msgid "MacCentralEurRoman"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:223
+#: ../src/common/fmapbase.cpp:220
 msgid "MacChineseSimp"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:201
+#: ../src/common/fmapbase.cpp:198
 msgid "MacChineseTrad"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:233
+#: ../src/common/fmapbase.cpp:230
 msgid "MacCroatian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:206
+#: ../src/common/fmapbase.cpp:203
 msgid "MacCyrillic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:207
+#: ../src/common/fmapbase.cpp:204
 msgid "MacDevanagari"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:231
+#: ../src/common/fmapbase.cpp:228
 msgid "MacDingbats"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:226
+#: ../src/common/fmapbase.cpp:223
 msgid "MacEthiopic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:229
+#: ../src/common/fmapbase.cpp:226
 #, fuzzy
 msgid "MacExtArabic"
 msgstr "Arab"
 
-#: ../src/common/fmapbase.cpp:237
+#: ../src/common/fmapbase.cpp:234
 msgid "MacGaelic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:221
+#: ../src/common/fmapbase.cpp:218
 msgid "MacGeorgian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:205
+#: ../src/common/fmapbase.cpp:202
 msgid "MacGreek"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:209
+#: ../src/common/fmapbase.cpp:206
 msgid "MacGujarati"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:208
+#: ../src/common/fmapbase.cpp:205
 msgid "MacGurmukhi"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:204
+#: ../src/common/fmapbase.cpp:201
 msgid "MacHebrew"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:234
+#: ../src/common/fmapbase.cpp:231
 msgid "MacIcelandic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:200
+#: ../src/common/fmapbase.cpp:197
 msgid "MacJapanese"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:214
+#: ../src/common/fmapbase.cpp:211
 msgid "MacKannada"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:238
+#: ../src/common/fmapbase.cpp:235
 msgid "MacKeyboardGlyphs"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:218
+#: ../src/common/fmapbase.cpp:215
 msgid "MacKhmer"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:202
+#: ../src/common/fmapbase.cpp:199
 msgid "MacKorean"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:220
+#: ../src/common/fmapbase.cpp:217
 msgid "MacLaotian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:215
+#: ../src/common/fmapbase.cpp:212
 msgid "MacMalayalam"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:225
+#: ../src/common/fmapbase.cpp:222
 msgid "MacMongolian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:210
+#: ../src/common/fmapbase.cpp:207
 msgid "MacOriya"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:199
+#: ../src/common/fmapbase.cpp:196
 #, fuzzy
 msgid "MacRoman"
 msgstr "Roman"
 
-#: ../src/common/fmapbase.cpp:235
+#: ../src/common/fmapbase.cpp:232
 #, fuzzy
 msgid "MacRomanian"
 msgstr "Roman"
 
-#: ../src/common/fmapbase.cpp:216
+#: ../src/common/fmapbase.cpp:213
 #, fuzzy
 msgid "MacSinhalese"
 msgstr "Padan kes"
 
-#: ../src/common/fmapbase.cpp:230
+#: ../src/common/fmapbase.cpp:227
 #, fuzzy
 msgid "MacSymbol"
 msgstr "Simbol"
 
-#: ../src/common/fmapbase.cpp:212
+#: ../src/common/fmapbase.cpp:209
 msgid "MacTamil"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:213
+#: ../src/common/fmapbase.cpp:210
 msgid "MacTelugu"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:219
+#: ../src/common/fmapbase.cpp:216
 msgid "MacThai"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:224
+#: ../src/common/fmapbase.cpp:221
 msgid "MacTibetan"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:232
+#: ../src/common/fmapbase.cpp:229
 msgid "MacTurkish"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:228
+#: ../src/common/fmapbase.cpp:225
 msgid "MacVietnamese"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1762
+#: ../src/propgrid/advprops.cpp:1663
 msgid "Magnifier"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:2143
+#: ../src/propgrid/advprops.cpp:2050
 #, fuzzy
 msgid "Make a selection:"
 msgstr "Tampal pilihan"
 
-#: ../src/richtext/richtextformatdlg.cpp:374
+#: ../src/richtext/richtextformatdlg.cpp:367
 #: ../src/richtext/richtextmarginspage.cpp:171
 msgid "Margins"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1595
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Maroon"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:147
+#: ../src/generic/fdrepdlg.cpp:144
 msgid "Match case"
 msgstr "Padan kes"
 
@@ -5071,41 +5198,41 @@ msgstr "Berat:"
 msgid "Max width:"
 msgstr "Ganti dengan:"
 
-#: ../src/unix/mediactrl.cpp:947
+#: ../src/unix/mediactrl.cpp:972
 #, c-format
 msgid "Media playback error: %s"
 msgstr ""
 
-#: ../src/common/fs_mem.cpp:175
+#: ../src/common/fs_mem.cpp:170
 #, c-format
 msgid "Memory VFS already contains file '%s'!"
 msgstr "Memori VFS sedia mengandungi fail '%s'!"
 
 #. TRANSLATORS: Name of keyboard key
 #. TRANSLATORS: Keyword of system colour
-#: ../src/common/accelcmn.cpp:73 ../src/propgrid/advprops.cpp:889
+#: ../src/common/accelcmn.cpp:70 ../src/propgrid/advprops.cpp:790
 msgid "Menu"
 msgstr "Menu"
 
-#: ../src/common/msgout.cpp:124
+#: ../src/common/msgout.cpp:121
 #, fuzzy
 msgid "Message"
 msgstr "%s mesej"
 
-#: ../src/univ/themes/metal.cpp:168
+#: ../src/univ/themes/metal.cpp:165
 msgid "Metal theme"
 msgstr "Tema Metal"
 
-#: ../src/msw/ole/automtn.cpp:652
+#: ../src/msw/ole/automtn.cpp:643
 msgid "Method or property not found."
 msgstr ""
 
-#: ../src/univ/themes/win32.cpp:3752
+#: ../src/univ/themes/win32.cpp:3749
 msgid "Mi&nimize"
 msgstr "Mi&nimum"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1763
+#: ../src/propgrid/advprops.cpp:1664
 msgid "Middle Button"
 msgstr ""
 
@@ -5118,36 +5245,41 @@ msgstr "Berat fon:"
 msgid "Min width:"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:668
+#: ../src/osx/cocoa/menu.mm:281
+#, fuzzy
+msgid "Minimize"
+msgstr "Mi&nimum"
+
+#: ../src/msw/ole/automtn.cpp:659
 msgid "Missing a required parameter."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:324
+#: ../src/generic/fontdlgg.cpp:320
 msgid "Modern"
 msgstr "Moden"
 
-#: ../src/generic/filectrlg.cpp:427
+#: ../src/generic/filectrlg.cpp:423
 msgid "Modified"
 msgstr "Diubahsuai"
 
-#: ../src/common/module.cpp:133
+#: ../src/common/module.cpp:130
 #, c-format
 msgid "Module \"%s\" initialization failed"
 msgstr "Modul \"%s\" gagal dimulakan"
 
-#: ../src/common/paper.cpp:131
+#: ../src/common/paper.cpp:128
 msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
 msgstr "Monarch Envelope, 3 7/8 x 7 1/2 in"
 
-#: ../src/msw/fswatcher.cpp:143
+#: ../src/msw/fswatcher.cpp:140
 msgid "Monitoring individual files for changes is not supported currently."
 msgstr ""
 
-#: ../src/generic/editlbox.cpp:172
+#: ../src/generic/editlbox.cpp:160
 msgid "Move down"
 msgstr "Pindah bawah"
 
-#: ../src/generic/editlbox.cpp:171
+#: ../src/generic/editlbox.cpp:155
 msgid "Move up"
 msgstr "Pindah atas"
 
@@ -5163,99 +5295,104 @@ msgstr "Gaya lalai untuk perenggan berikut."
 msgid "Moves the object to the previous paragraph."
 msgstr "Undur ke laman HTML terdahulu"
 
-#: ../src/richtext/richtextbuffer.cpp:9966
+#: ../src/richtext/richtextbuffer.cpp:9963
 msgid "Multiple Cell Properties"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:424
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:82
+msgid "Multiply"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:420
 msgid "Name"
 msgstr "Nama"
 
-#: ../src/propgrid/advprops.cpp:1596
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Navy"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "Network"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173
 #, fuzzy
 msgid "New"
 msgstr "&Baru"
 
-#: ../src/richtext/richtextstyledlg.cpp:243
+#: ../src/richtext/richtextstyledlg.cpp:239
 #, fuzzy
 msgid "New &Box Style..."
 msgstr "Senarai Gaya Baru..."
 
-#: ../src/richtext/richtextstyledlg.cpp:225
+#: ../src/richtext/richtextstyledlg.cpp:221
 msgid "New &Character Style..."
 msgstr "Gaya Aksara Baru..."
 
-#: ../src/richtext/richtextstyledlg.cpp:237
+#: ../src/richtext/richtextstyledlg.cpp:233
 msgid "New &List Style..."
 msgstr "Senarai Gaya Baru..."
 
-#: ../src/richtext/richtextstyledlg.cpp:231
+#: ../src/richtext/richtextstyledlg.cpp:227
 msgid "New &Paragraph Style..."
 msgstr "Gaya &Perenggan Baru..."
 
-#: ../src/richtext/richtextstyledlg.cpp:606
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:654
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:820
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:893
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:934
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:602
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:650
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:816
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:889
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:930
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "New Style"
 msgstr "Gaya Baru"
 
-#: ../src/generic/editlbox.cpp:169
+#: ../src/generic/editlbox.cpp:139
 msgid "New item"
 msgstr "Item Baru"
 
-#: ../src/generic/dirdlgg.cpp:297 ../src/generic/dirdlgg.cpp:307
-#: ../src/generic/filectrlg.cpp:618 ../src/generic/filectrlg.cpp:627
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+#: ../src/generic/dirdlgg.cpp:294 ../src/generic/dirdlgg.cpp:304
 msgid "NewName"
 msgstr "NamaBaru"
 
-#: ../src/common/prntbase.cpp:1567 ../src/html/helpwnd.cpp:665
+#: ../src/common/prntbase.cpp:1592 ../src/html/helpwnd.cpp:663
 msgid "Next page"
 msgstr "Laman berikut"
 
-#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:177
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:174
 #: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Tidak"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1764
+#: ../src/propgrid/advprops.cpp:1665
 msgid "No Entry"
 msgstr ""
 
-#: ../src/generic/animateg.cpp:150
+#: ../src/generic/animateg.cpp:133
 #, c-format
 msgid "No animation handler for type %ld defined."
 msgstr "Tiada pengemudi animasi untuk jenis %ld ditetapkan."
 
-#: ../src/dfb/bitmap.cpp:642 ../src/dfb/bitmap.cpp:676
+#: ../src/dfb/bitmap.cpp:639 ../src/dfb/bitmap.cpp:673
 #, fuzzy, c-format
 msgid "No bitmap handler for type %d defined."
 msgstr "Tiada pengemudi imej untuk jenis %d ditetapkan."
 
-#: ../src/common/utilscmn.cpp:1077
+#: ../src/common/utilscmn.cpp:1095
 msgid "No default application configured for HTML files."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:445
+#: ../src/generic/helpext.cpp:443
 msgid "No entries found."
 msgstr "Tiada masukan ditemui."
 
-#: ../src/common/fontmap.cpp:421
+#: ../src/common/fontmap.cpp:418
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found,\n"
@@ -5268,7 +5405,7 @@ msgstr ""
 "Adakah anda ingin menggunakan pengkodan ini (sebaliknya anda perlu memilih "
 "yang lain)?"
 
-#: ../src/common/fontmap.cpp:426
+#: ../src/common/fontmap.cpp:423
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found.\n"
@@ -5279,209 +5416,208 @@ msgstr ""
 "Adakah anda ingin memilih fon utuk digunakan dengan pengkodan ini\n"
 "(sebaliknya teks dalam pengkodan ini tidak akan dapat dilihat dengan betul)?"
 
-#: ../src/generic/animateg.cpp:142
+#: ../src/generic/animateg.cpp:125
 msgid "No handler found for animation type."
 msgstr "Tiada pengemudi ditemui untuk jenis animasi."
 
-#: ../src/common/image.cpp:2728
+#: ../src/common/image.cpp:2823
 msgid "No handler found for image type."
 msgstr "Tiada pengemudi ditemui untuk jenis imej."
 
-#: ../src/common/image.cpp:2736 ../src/common/image.cpp:2848
-#: ../src/common/image.cpp:2901
+#: ../src/common/image.cpp:2831 ../src/common/image.cpp:2954
+#: ../src/common/image.cpp:3020
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "Tiada pengemudi imej untuk jenis %d ditetapkan."
 
-#: ../src/common/image.cpp:2871 ../src/common/image.cpp:2915
+#: ../src/common/image.cpp:2986 ../src/common/image.cpp:3034
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "Tiada pengemudi imej untuk jenis %s ditetapkan."
 
-#: ../src/html/helpwnd.cpp:858
+#: ../src/html/helpwnd.cpp:856
 msgid "No matching page found yet"
 msgstr "Tiada padanan laman ditemui"
 
-#: ../src/unix/sound.cpp:81
+#: ../src/unix/sound.cpp:78
 msgid "No sound"
 msgstr "Tiada bunyi"
 
-#: ../src/common/image.cpp:2277 ../src/common/image.cpp:2318
+#: ../src/common/image.cpp:2371 ../src/common/image.cpp:2412
 msgid "No unused colour in image being masked."
 msgstr "Tiada warna yang tidak digunakan dalam imej ditopengkan."
 
-#: ../src/common/image.cpp:3374
-msgid "No unused colour in image."
-msgstr "Tiada warna yang tidak digunakan dalam imej."
-
-#: ../src/generic/helpext.cpp:302
+#: ../src/generic/helpext.cpp:300
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "Tiada pemetaan sah ditemui dalam fail \"%s\"."
 
-#: ../src/richtext/richtextborderspage.cpp:610
 #: ../src/richtext/richtextsizepage.cpp:248
 #: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:610
 #, fuzzy
 msgid "None"
 msgstr "(Tiada)"
 
-#: ../src/common/fmapbase.cpp:157
+#: ../src/common/fmapbase.cpp:154
 msgid "Nordic (ISO-8859-10)"
 msgstr "Nordic (ISO-8859-10)"
 
-#: ../src/generic/fontdlgg.cpp:328 ../src/generic/fontdlgg.cpp:331
+#: ../src/generic/fontdlgg.cpp:324 ../src/generic/fontdlgg.cpp:327
 msgid "Normal"
 msgstr "Normal"
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1261
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Rupa normal<br>dan <u>garis-bawah</u>. "
 
-#: ../src/html/helpwnd.cpp:1205
+#: ../src/html/helpwnd.cpp:1203
 msgid "Normal font:"
 msgstr "Fon normal:"
 
-#: ../src/propgrid/props.cpp:1128
+#: ../src/propgrid/props.cpp:1115
 #, fuzzy, c-format
 msgid "Not %s"
 msgstr "Perihal"
 
-#: ../include/wx/filename.h:573 ../include/wx/filename.h:578
-#, fuzzy
-msgid "Not available"
-msgstr "Tiada kemudahan XBM wujud!"
+#: ../src/common/secretstore.cpp:168
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/webrequest.cpp:605
+msgid "Not enough free disk space for download."
+msgstr ""
 
 #: ../src/richtext/richtextfontpage.cpp:358
 msgid "Not underlined"
 msgstr "Tidak bergaris bawah"
 
-#: ../src/common/paper.cpp:115
+#: ../src/common/paper.cpp:112
 msgid "Note, 8 1/2 x 11 in"
 msgstr "Nota, 8 1/2 x 11 in"
 
-#: ../src/generic/notifmsgg.cpp:132
+#: ../src/generic/notifmsgg.cpp:129
 #, fuzzy
 msgid "Notice"
 msgstr "&Nota:"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "Num *"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "Num +"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "Num ,"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "Num -"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "Num ."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "Num /"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "Num ="
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "Num Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 #, fuzzy
 msgid "Num Delete"
 msgstr "Padam"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 #, fuzzy
 msgid "Num Down"
 msgstr "Turun"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "Num End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "Num Enter"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 #, fuzzy
 msgid "Num Home"
 msgstr "Rumah"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 #, fuzzy
 msgid "Num Insert"
 msgstr "Selit"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num Lock"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "Num Page Down"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "Num Page Up"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 #, fuzzy
 msgid "Num Right"
 msgstr "Kanan"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "Num Space"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "Num Tab"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "Num Up"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "Num left"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num_lock"
 msgstr ""
 
@@ -5490,13 +5626,13 @@ msgstr ""
 msgid "Numbered outline"
 msgstr "Menomborkan panduan"
 
-#: ../include/wx/msgdlg.h:278 ../src/richtext/richtextstyledlg.cpp:297
-#: ../src/common/stockitem.cpp:178 ../src/msw/msgdlg.cpp:454
-#: ../src/msw/msgdlg.cpp:747 ../src/gtk1/fontdlg.cpp:138
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:175
+#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/msgdlg.cpp:741 ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "OK"
 
-#: ../src/msw/ole/automtn.cpp:692
+#: ../src/msw/ole/automtn.cpp:683
 #, c-format
 msgid "OLE Automation error in %s: %s"
 msgstr ""
@@ -5506,15 +5642,15 @@ msgstr ""
 msgid "Object Properties"
 msgstr "&Ciri-ciri"
 
-#: ../src/msw/ole/automtn.cpp:660
+#: ../src/msw/ole/automtn.cpp:651
 msgid "Object implementation does not support named arguments."
 msgstr ""
 
-#: ../src/common/xtixml.cpp:264
+#: ../src/common/xtixml.cpp:260
 msgid "Objects must have an id attribute"
 msgstr "Objek perlu ada atribut id"
 
-#: ../src/propgrid/advprops.cpp:1601
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Olive"
 msgstr ""
 
@@ -5522,65 +5658,70 @@ msgstr ""
 msgid "Opaci&ty:"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:354
+#: ../src/generic/colrdlgg.cpp:374
 msgid "Opacity:"
 msgstr ""
 
-#: ../src/common/docview.cpp:1773 ../src/common/docview.cpp:1815
+#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
 msgid "Open File"
 msgstr "Buka Fail"
 
-#: ../src/html/helpwnd.cpp:671 ../src/html/helpwnd.cpp:1554
+#: ../src/html/helpwnd.cpp:669 ../src/html/helpwnd.cpp:1552
 msgid "Open HTML document"
 msgstr "Buka dokumen HTML"
 
-#: ../src/generic/dbgrptg.cpp:163
+#: ../src/common/stockitem.cpp:265
+#, fuzzy
+msgid "Open an existing document"
+msgstr "Buka dokumen HTML"
+
+#: ../src/generic/dbgrptg.cpp:160
 #, c-format
 msgid "Open file \"%s\""
 msgstr "Buka fail  \"%s\""
 
-#: ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176
 #, fuzzy
 msgid "Open..."
 msgstr "&Buka..."
 
-#: ../src/unix/glx11.cpp:506 ../src/msw/glcanvas.cpp:592
+#: ../src/msw/glcanvas.cpp:607 ../src/unix/glx11.cpp:513
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr ""
 
-#: ../src/generic/dirctrlg.cpp:599 ../src/generic/dirdlgg.cpp:323
-#: ../src/generic/filectrlg.cpp:642 ../src/generic/filectrlg.cpp:786
+#: ../src/generic/dirctrlg.cpp:565 ../src/generic/filectrlg.cpp:638
+#: ../src/generic/filectrlg.cpp:782 ../src/generic/dirdlgg.cpp:320
 msgid "Operation not permitted."
 msgstr "Operasi tidak diizinkan."
 
-#: ../src/common/cmdline.cpp:900
+#: ../src/common/cmdline.cpp:896
 #, fuzzy, c-format
 msgid "Option '%s' can't be negated"
 msgstr "Direktori '%s' gagal dicipta"
 
-#: ../src/common/cmdline.cpp:1064
+#: ../src/common/cmdline.cpp:1060
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "Pilihan '%s' perlukan nilai."
 
-#: ../src/common/cmdline.cpp:1147
+#: ../src/common/cmdline.cpp:1143
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Pilihan '%s': '%s' gagal ditukar kepada tarikh."
 
-#: ../src/generic/prntdlgg.cpp:618
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Pilihan"
 
-#: ../src/propgrid/advprops.cpp:1606
+#: ../src/propgrid/advprops.cpp:1512
 msgid "Orange"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:615 ../src/generic/prntdlgg.cpp:869
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:862
 msgid "Orientation"
 msgstr "Orientasi"
 
-#: ../src/common/windowid.cpp:242
+#: ../src/common/windowid.cpp:237
 msgid "Out of window IDs.  Recommend shutting down application."
 msgstr ""
 
@@ -5594,148 +5735,148 @@ msgstr "Paras senarai:"
 msgid "Outset"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:656
+#: ../src/msw/ole/automtn.cpp:647
 msgid "Overflow while coercing argument values."
 msgstr ""
 
-#: ../src/common/imagpcx.cpp:457 ../src/common/imagpcx.cpp:480
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:479
 msgid "PCX: couldn't allocate memory"
 msgstr "PCX: gagal menempatkan memori"
 
-#: ../src/common/imagpcx.cpp:456
+#: ../src/common/imagpcx.cpp:455
 msgid "PCX: image format unsupported"
 msgstr "PCX: format imej tidak disokong"
 
-#: ../src/common/imagpcx.cpp:479
+#: ../src/common/imagpcx.cpp:478
 msgid "PCX: invalid image"
 msgstr "PCX: imej tidak sah"
 
-#: ../src/common/imagpcx.cpp:442
+#: ../src/common/imagpcx.cpp:441
 msgid "PCX: this is not a PCX file."
 msgstr "PCX: ini bukahlah fail PCX."
 
-#: ../src/common/imagpcx.cpp:459 ../src/common/imagpcx.cpp:481
+#: ../src/common/imagpcx.cpp:458 ../src/common/imagpcx.cpp:480
 msgid "PCX: unknown error !!!"
 msgstr "PCX: ralat tidak diketahui !!!"
 
-#: ../src/common/imagpcx.cpp:458
+#: ../src/common/imagpcx.cpp:457
 msgid "PCX: version number too low"
 msgstr "PCX: nombor versi terlalu rendah"
 
-#: ../src/common/imagpnm.cpp:91
+#: ../src/common/imagpnm.cpp:89
 msgid "PNM: Couldn't allocate memory."
 msgstr "PNM: Gagal menempatkan memori"
 
-#: ../src/common/imagpnm.cpp:73
+#: ../src/common/imagpnm.cpp:71
 msgid "PNM: File format is not recognized."
 msgstr "PNM: Format fail tidak dikenal."
 
-#: ../src/common/imagpnm.cpp:112 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
 #: ../src/common/imagpnm.cpp:156
 msgid "PNM: File seems truncated."
 msgstr "PNM: Fail seperti dipotong."
 
-#: ../src/common/paper.cpp:187
+#: ../src/common/paper.cpp:184
 msgid "PRC 16K 146 x 215 mm"
 msgstr "PRC 16K 146 x 215 mm"
 
-#: ../src/common/paper.cpp:200
+#: ../src/common/paper.cpp:197
 msgid "PRC 16K Rotated"
 msgstr "PRC 16K Diputar"
 
-#: ../src/common/paper.cpp:188
+#: ../src/common/paper.cpp:185
 msgid "PRC 32K 97 x 151 mm"
 msgstr "PRC 32K 97 x 151 mm"
 
-#: ../src/common/paper.cpp:201
+#: ../src/common/paper.cpp:198
 msgid "PRC 32K Rotated"
 msgstr "PRC 32K Diputar"
 
-#: ../src/common/paper.cpp:189
+#: ../src/common/paper.cpp:186
 msgid "PRC 32K(Big) 97 x 151 mm"
 msgstr "PRC 32K(Besar) 97 x 151 mm"
 
-#: ../src/common/paper.cpp:202
+#: ../src/common/paper.cpp:199
 msgid "PRC 32K(Big) Rotated"
 msgstr "PRC 32K(Besar) Diputar"
 
-#: ../src/common/paper.cpp:190
+#: ../src/common/paper.cpp:187
 msgid "PRC Envelope #1 102 x 165 mm"
 msgstr "Sampul PRC #1 102 x 165 mm"
 
-#: ../src/common/paper.cpp:203
+#: ../src/common/paper.cpp:200
 msgid "PRC Envelope #1 Rotated 165 x 102 mm"
 msgstr "Sampul PRC #1 Diputar 165 x 102 mm"
 
-#: ../src/common/paper.cpp:199
+#: ../src/common/paper.cpp:196
 msgid "PRC Envelope #10 324 x 458 mm"
 msgstr "Sampul PRC #10 324 x 458 mm"
 
-#: ../src/common/paper.cpp:212
+#: ../src/common/paper.cpp:209
 msgid "PRC Envelope #10 Rotated 458 x 324 mm"
 msgstr "PRC Envelope #10 Rotated 458 x 324 mm"
 
-#: ../src/common/paper.cpp:191
+#: ../src/common/paper.cpp:188
 msgid "PRC Envelope #2 102 x 176 mm"
 msgstr "Sampul PRC #2 102 x 176 mm"
 
-#: ../src/common/paper.cpp:204
+#: ../src/common/paper.cpp:201
 msgid "PRC Envelope #2 Rotated 176 x 102 mm"
 msgstr "Sampul PRC #2 Diputar 176 x 102 mm"
 
-#: ../src/common/paper.cpp:192
+#: ../src/common/paper.cpp:189
 msgid "PRC Envelope #3 125 x 176 mm"
 msgstr "Sampul PRC #3 125 x 176 mm"
 
-#: ../src/common/paper.cpp:205
+#: ../src/common/paper.cpp:202
 msgid "PRC Envelope #3 Rotated 176 x 125 mm"
 msgstr "Sampul PRC #3 Diputar 176 x 125 mm"
 
-#: ../src/common/paper.cpp:193
+#: ../src/common/paper.cpp:190
 msgid "PRC Envelope #4 110 x 208 mm"
 msgstr "Sampul PRC #4 110 x 208 mm"
 
-#: ../src/common/paper.cpp:206
+#: ../src/common/paper.cpp:203
 msgid "PRC Envelope #4 Rotated 208 x 110 mm"
 msgstr "Sampul PRC #4 Diputar 208 x 110 mm"
 
-#: ../src/common/paper.cpp:194
+#: ../src/common/paper.cpp:191
 msgid "PRC Envelope #5 110 x 220 mm"
 msgstr "Sampul PRC #5 110 x 220 mm"
 
-#: ../src/common/paper.cpp:207
+#: ../src/common/paper.cpp:204
 msgid "PRC Envelope #5 Rotated 220 x 110 mm"
 msgstr "Sampul PRC #5 Diputar 220 x 110 mm"
 
-#: ../src/common/paper.cpp:195
+#: ../src/common/paper.cpp:192
 msgid "PRC Envelope #6 120 x 230 mm"
 msgstr "Sampul PRC #6 120 x 230 mm"
 
-#: ../src/common/paper.cpp:208
+#: ../src/common/paper.cpp:205
 msgid "PRC Envelope #6 Rotated 230 x 120 mm"
 msgstr "Sampul PRC #6  Diputar 230 x 120 mm"
 
-#: ../src/common/paper.cpp:196
+#: ../src/common/paper.cpp:193
 msgid "PRC Envelope #7 160 x 230 mm"
 msgstr "Sampul PRC #7 160 x 230 mm"
 
-#: ../src/common/paper.cpp:209
+#: ../src/common/paper.cpp:206
 msgid "PRC Envelope #7 Rotated 230 x 160 mm"
 msgstr "Sampul PRC #7 Diputar 230 x 160 mm"
 
-#: ../src/common/paper.cpp:197
+#: ../src/common/paper.cpp:194
 msgid "PRC Envelope #8 120 x 309 mm"
 msgstr "Sampul PRC #8 120 x 309 mm"
 
-#: ../src/common/paper.cpp:210
+#: ../src/common/paper.cpp:207
 msgid "PRC Envelope #8 Rotated 309 x 120 mm"
 msgstr "Sampul PRC #8 Diputar 309 x 120 mm"
 
-#: ../src/common/paper.cpp:198
+#: ../src/common/paper.cpp:195
 msgid "PRC Envelope #9 229 x 324 mm"
 msgstr "Sampul PRC #9 229 x 324 mm"
 
-#: ../src/common/paper.cpp:211
+#: ../src/common/paper.cpp:208
 msgid "PRC Envelope #9 Rotated 324 x 229 mm"
 msgstr "Sampul PRC #9 Diputar 324 x 229 mm"
 
@@ -5744,92 +5885,96 @@ msgstr "Sampul PRC #9 Diputar 324 x 229 mm"
 msgid "Padding"
 msgstr "membaca"
 
-#: ../src/common/prntbase.cpp:2074
+#: ../src/common/prntbase.cpp:2096
 #, c-format
 msgid "Page %d"
 msgstr "Laman %d"
 
-#: ../src/common/prntbase.cpp:2072
+#: ../src/common/prntbase.cpp:2094
 #, c-format
 msgid "Page %d of %d"
 msgstr "Laman %d of %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 #, fuzzy
 msgid "Page Down"
 msgstr "Laman %d"
 
-#: ../src/gtk/print.cpp:826
+#: ../src/gtk/print.cpp:829
 msgid "Page Setup"
 msgstr "Tetapan Halaman"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 #, fuzzy
 msgid "Page Up"
 msgstr "Laman %d"
 
-#: ../src/generic/prntdlgg.cpp:828 ../src/common/prntbase.cpp:484
+#: ../src/common/prntbase.cpp:479 ../src/generic/prntdlgg.cpp:821
 msgid "Page setup"
 msgstr "Tetapan halaman"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 #, fuzzy
 msgid "PageDown"
 msgstr "Turun"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 #, fuzzy
 msgid "PageUp"
 msgstr "Laman"
 
-#: ../src/generic/prntdlgg.cpp:216
+#: ../src/generic/prntdlgg.cpp:209
 msgid "Pages"
 msgstr "Laman"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1765
+#: ../src/propgrid/advprops.cpp:1666
 msgid "Paint Brush"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:602 ../src/generic/prntdlgg.cpp:801
-#: ../src/generic/prntdlgg.cpp:842 ../src/generic/prntdlgg.cpp:855
-#: ../src/generic/prntdlgg.cpp:1052 ../src/generic/prntdlgg.cpp:1057
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:794
+#: ../src/generic/prntdlgg.cpp:835 ../src/generic/prntdlgg.cpp:848
+#: ../src/generic/prntdlgg.cpp:1045 ../src/generic/prntdlgg.cpp:1050
 msgid "Paper size"
 msgstr "Saiz &kertas:"
 
-#: ../src/richtext/richtextstyles.cpp:1062
+#: ../src/richtext/richtextstyles.cpp:1059
 msgid "Paragraph styles"
 msgstr "Gaya perenggan"
 
-#: ../src/common/xtistrm.cpp:465
+#: ../src/common/xtistrm.cpp:462
 msgid "Passing a already registered object to SetObject"
 msgstr "Passing a already registered object to SetObject"
 
-#: ../src/common/xtistrm.cpp:476
+#: ../src/common/xtistrm.cpp:473
 #, fuzzy
 msgid "Passing an unknown object to GetObject"
 msgstr "Melepaskan objek tidak diketahui kepada GetObject"
 
-#: ../src/richtext/richtextctrl.cpp:3513 ../src/common/stockitem.cpp:180
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:177 ../src/richtext/richtextctrl.cpp:3514
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Tampal"
 
-#: ../src/common/stockitem.cpp:262
+#: ../src/common/stockitem.cpp:260
 msgid "Paste selection"
 msgstr "Tampal pilihan"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:74
+#: ../src/common/accelcmn.cpp:71
 msgid "Pause"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1766
+#: ../src/propgrid/advprops.cpp:1667
 msgid "Pencil"
 msgstr ""
 
@@ -5838,21 +5983,21 @@ msgstr ""
 msgid "Peri&od"
 msgstr "N&oktah"
 
-#: ../src/generic/filectrlg.cpp:430
+#: ../src/generic/filectrlg.cpp:426
 msgid "Permissions"
 msgstr "Keizinan"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:60
+#: ../src/common/accelcmn.cpp:57
 msgid "PgDn"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:59
+#: ../src/common/accelcmn.cpp:56
 msgid "PgUp"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:12868
+#: ../src/richtext/richtextbuffer.cpp:12863
 #, fuzzy
 msgid "Picture Properties"
 msgstr "&Ciri-ciri"
@@ -5865,46 +6010,46 @@ msgstr "Gagal mencipta paip"
 msgid "Please choose a valid font."
 msgstr "Sila pilih fon yang sah."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
 msgid "Please choose an existing file."
 msgstr "Sila pilih fail yang sedia ada."
 
-#: ../src/html/helpwnd.cpp:800
+#: ../src/html/helpwnd.cpp:798
 msgid "Please choose the page to display:"
 msgstr "Sila pilih laman yang ingin dipaparkan:"
 
-#: ../src/msw/dialup.cpp:764
+#: ../src/msw/dialup.cpp:758
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Sila pilih ISP yang mana anda ingin sambung kepadanya"
 
-#: ../src/common/headerctrlcmn.cpp:59
+#: ../src/common/headerctrlcmn.cpp:57
 msgid "Please select the columns to show and define their order:"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:538
+#: ../src/common/prntbase.cpp:533
 #, fuzzy
 msgid "Please wait while printing..."
 msgstr "Sila tunggu semasa mencetak\n"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1767
+#: ../src/propgrid/advprops.cpp:1668
 #, fuzzy
 msgid "Point Left"
 msgstr "Saiz titik:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1768
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgid "Point Right"
 msgstr "Jajar Kanan"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:662
+#: ../src/propgrid/advprops.cpp:572
 #, fuzzy
 msgid "Point Size"
 msgstr "Saiz titik:"
 
-#: ../src/generic/prntdlgg.cpp:612 ../src/generic/prntdlgg.cpp:867
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:860
 msgid "Portrait"
 msgstr "Potret"
 
@@ -5913,268 +6058,278 @@ msgstr "Potret"
 msgid "Position"
 msgstr "Soalan"
 
-#: ../src/generic/prntdlgg.cpp:298
+#: ../src/generic/prntdlgg.cpp:291
 msgid "PostScript file"
 msgstr "Fail PostScript"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178 ../src/osx/cocoa/preferences.mm:303
 #, fuzzy
 msgid "Preferences"
 msgstr "Keutamaan"
 
-#: ../src/osx/menu_osx.cpp:568
+#: ../src/osx/menu_osx.cpp:460
 #, fuzzy
 msgid "Preferences..."
 msgstr "Keutamaan"
 
-#: ../src/common/prntbase.cpp:546
+#: ../src/common/prntbase.cpp:541
 msgid "Preparing"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:455 ../src/osx/carbon/fontdlg.cpp:390
-#: ../src/html/helpwnd.cpp:1222
+#: ../src/osx/carbon/fontdlg.cpp:387 ../src/generic/fontdlgg.cpp:452
+#: ../src/html/helpwnd.cpp:1220
 msgid "Preview:"
 msgstr "Pralihat:"
 
-#: ../src/common/prntbase.cpp:1553 ../src/html/helpwnd.cpp:664
+#: ../src/common/prntbase.cpp:1578 ../src/html/helpwnd.cpp:662
 msgid "Previous page"
 msgstr "Laman sebelum:"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/prntdlgg.cpp:143 ../src/generic/prntdlgg.cpp:157
-#: ../src/common/prntbase.cpp:426 ../src/common/prntbase.cpp:1541
-#: ../src/common/accelcmn.cpp:77 ../src/gtk/print.cpp:620
-#: ../src/gtk/print.cpp:638
+#: ../src/common/prntbase.cpp:421 ../src/common/prntbase.cpp:1566
+#: ../src/common/accelcmn.cpp:74 ../src/generic/prntdlgg.cpp:136
+#: ../src/generic/prntdlgg.cpp:150 ../src/gtk/print.cpp:616
+#: ../src/gtk/print.cpp:634
 msgid "Print"
 msgstr "Cetak"
 
-#: ../include/wx/prntbase.h:399 ../src/common/docview.cpp:1268
+#: ../src/common/docview.cpp:1262
 msgid "Print Preview"
 msgstr "Pralihat Cetak"
 
-#: ../src/common/prntbase.cpp:2015 ../src/common/prntbase.cpp:2057
-#: ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2037 ../src/common/prntbase.cpp:2079
+#: ../src/common/prntbase.cpp:2087
 msgid "Print Preview Failure"
 msgstr "Gagal Pralihat Cetakan"
 
-#: ../src/generic/prntdlgg.cpp:224
+#: ../src/generic/prntdlgg.cpp:217
 msgid "Print Range"
 msgstr "Julat Cetak"
 
-#: ../src/generic/prntdlgg.cpp:449
+#: ../src/generic/prntdlgg.cpp:442
 msgid "Print Setup"
 msgstr "Tetapan Cetak"
 
-#: ../src/generic/prntdlgg.cpp:621
+#: ../src/generic/prntdlgg.cpp:614
 msgid "Print in colour"
 msgstr "Cetak warna"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/osx/webview_webkit.mm:260
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "Gagal mulakan paparan."
+
+#: ../src/common/stockitem.cpp:179
 #, fuzzy
 msgid "Print previe&w..."
 msgstr "Pralihat cetak"
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1256
 #, fuzzy
 msgid "Print preview creation failed."
 msgstr "Gagal mencipta paip"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/common/stockitem.cpp:179
 #, fuzzy
 msgid "Print preview..."
 msgstr "Pralihat cetak"
 
-#: ../src/generic/prntdlgg.cpp:630
+#: ../src/generic/prntdlgg.cpp:623
 msgid "Print spooling"
 msgstr "Gelendong cetak"
 
-#: ../src/html/helpwnd.cpp:675
+#: ../src/html/helpwnd.cpp:673
 msgid "Print this page"
 msgstr "Cetak laman ini"
 
-#: ../src/generic/prntdlgg.cpp:185
+#: ../src/generic/prntdlgg.cpp:178
 msgid "Print to File"
 msgstr "Cetak ke Fail"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 #, fuzzy
 msgid "Print..."
 msgstr "Ce&tak..."
 
-#: ../src/generic/prntdlgg.cpp:493
+#: ../src/generic/prntdlgg.cpp:486
 msgid "Printer"
 msgstr "Pencetak"
 
-#: ../src/generic/prntdlgg.cpp:633
+#: ../src/generic/prntdlgg.cpp:626
 msgid "Printer command:"
 msgstr "Arahan pencetak:"
 
-#: ../src/generic/prntdlgg.cpp:180
+#: ../src/generic/prntdlgg.cpp:173
 msgid "Printer options"
 msgstr "Pilihan pencetak"
 
-#: ../src/generic/prntdlgg.cpp:645
+#: ../src/generic/prntdlgg.cpp:638
 msgid "Printer options:"
 msgstr "Pilihan pencetak:"
 
-#: ../src/generic/prntdlgg.cpp:916
+#: ../src/generic/prntdlgg.cpp:909
 msgid "Printer..."
 msgstr "Pencetak..."
 
-#: ../src/generic/prntdlgg.cpp:196
+#: ../src/generic/prntdlgg.cpp:189
 msgid "Printer:"
 msgstr "Pencetak:"
 
-#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:535
-#: ../src/html/htmprint.cpp:277
+#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:530
+#: ../src/html/htmprint.cpp:289
 #, fuzzy
 msgid "Printing"
 msgstr "Mencetak "
 
-#: ../src/common/prntbase.cpp:612
+#: ../src/common/prntbase.cpp:607
 msgid "Printing "
 msgstr "Mencetak "
 
-#: ../src/common/prntbase.cpp:347
+#: ../src/common/prntbase.cpp:342
 msgid "Printing Error"
 msgstr "Ralat mencetak"
 
-#: ../src/common/prntbase.cpp:565
+#: ../src/osx/webview_webkit.mm:251
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "Gzip tidak disokong oleh versi zlib ini"
+
+#: ../src/common/prntbase.cpp:560
 #, fuzzy, c-format
 msgid "Printing page %d"
 msgstr "Mencetak laman %d..."
 
-#: ../src/common/prntbase.cpp:570
+#: ../src/common/prntbase.cpp:565
 #, fuzzy, c-format
 msgid "Printing page %d of %d"
 msgstr "Mencetak laman %d..."
 
-#: ../src/generic/printps.cpp:201
+#: ../src/generic/printps.cpp:182
 #, c-format
 msgid "Printing page %d..."
 msgstr "Mencetak laman %d..."
 
-#: ../src/generic/printps.cpp:161
+#: ../src/generic/printps.cpp:142
 msgid "Printing..."
 msgstr "Mencetak..."
 
-#: ../include/wx/richtext/richtextprint.h:109 ../include/wx/prntbase.h:267
-#: ../src/common/docview.cpp:2132
+#: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
+#: ../src/common/docview.cpp:2137
 #, fuzzy
 msgid "Printout"
 msgstr "Cetak"
 
-#: ../src/common/debugrpt.cpp:560
+#: ../src/common/debugrpt.cpp:561
 #, c-format
 msgid ""
 "Processing debug report has failed, leaving the files in \"%s\" directory."
 msgstr ""
 "Gagal memproses laporan nyahpijat, meninggalkan fail dalam direktori \"%s\"."
 
-#: ../src/common/prntbase.cpp:545
+#: ../src/common/prntbase.cpp:540
 msgid "Progress:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181
 #, fuzzy
 msgid "Properties"
 msgstr "&Ciri-ciri"
 
-#: ../src/propgrid/manager.cpp:237
+#: ../src/propgrid/manager.cpp:223
 #, fuzzy
 msgid "Property"
 msgstr "&Ciri-ciri"
 
 #. TRANSLATORS: Caption of message box displaying any property error
-#: ../src/propgrid/propgrid.cpp:3185 ../src/propgrid/propgrid.cpp:3318
+#: ../src/propgrid/propgrid.cpp:3162 ../src/propgrid/propgrid.cpp:3299
 #, fuzzy
 msgid "Property Error"
 msgstr "Ralat mencetak"
 
-#: ../src/propgrid/advprops.cpp:1597
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Purple"
 msgstr ""
 
-#: ../src/common/paper.cpp:112
+#: ../src/common/paper.cpp:109
 msgid "Quarto, 215 x 275 mm"
 msgstr "Quarto, 215 x 275 mm"
 
-#: ../src/generic/logg.cpp:1016
+#: ../src/generic/logg.cpp:1013
 msgid "Question"
 msgstr "Soalan"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1769
+#: ../src/propgrid/advprops.cpp:1670
 #, fuzzy
 msgid "Question Arrow"
 msgstr "Soalan"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 #, fuzzy
 msgid "Quit"
 msgstr "&Keluar"
 
-#: ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:477
 #, fuzzy, c-format
 msgid "Quit %s"
 msgstr "&Keluar"
 
-#: ../src/common/stockitem.cpp:263
+#: ../src/common/stockitem.cpp:261
 msgid "Quit this program"
 msgstr "Keluar program ini"
 
-#: ../src/common/accelcmn.cpp:338
+#: ../src/common/accelcmn.cpp:352
 #, fuzzy
 msgid "RawCtrl+"
 msgstr "Ctrl-"
 
-#: ../src/common/ffile.cpp:109 ../src/common/ffile.cpp:133
+#: ../src/common/ffile.cpp:107 ../src/common/ffile.cpp:132
 #, c-format
 msgid "Read error on file '%s'"
 msgstr "Ralat baca pada fail '%s'"
 
-#: ../src/common/secretstore.cpp:199
+#: ../src/common/secretstore.cpp:211
 #, fuzzy, c-format
-msgid "Reading password for \"%s/%s\" failed: %s."
+msgid "Reading password for \"%s\" failed: %s."
 msgstr "Pengekstrakan '%s' kepada '%s' gagal."
 
-#: ../src/common/prntbase.cpp:272
+#: ../src/common/prntbase.cpp:267
 msgid "Ready"
 msgstr "Sedia"
 
-#: ../src/propgrid/advprops.cpp:1605
+#: ../src/propgrid/advprops.cpp:1511
 #, fuzzy
 msgid "Red"
 msgstr "&Ulangcara"
 
-#: ../src/generic/colrdlgg.cpp:339
+#: ../src/generic/colrdlgg.cpp:359
 msgid "Red:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:185 ../src/stc/stc_i18n.cpp:16
+#: ../src/common/stockitem.cpp:182 ../src/stc/stc_i18n.cpp:16
 #, fuzzy
 msgid "Redo"
 msgstr "&Ulangcara"
 
-#: ../src/common/stockitem.cpp:264
+#: ../src/common/stockitem.cpp:262
 msgid "Redo last action"
 msgstr "Ulang tindakan akhir"
 
-#: ../src/common/stockitem.cpp:186
+#: ../src/common/stockitem.cpp:183
 msgid "Refresh"
 msgstr "Segarkan"
 
-#: ../src/msw/registry.cpp:626
+#: ../src/msw/registry.cpp:615
 #, c-format
 msgid "Registry key '%s' already exists."
 msgstr "Kunci registri '%s' sedia wujud."
 
-#: ../src/msw/registry.cpp:595
+#: ../src/msw/registry.cpp:584
 #, c-format
 msgid "Registry key '%s' does not exist, cannot rename it."
 msgstr "Kunci registri '%s' tidak wujud, Gagal menamakannya."
 
-#: ../src/msw/registry.cpp:727
+#: ../src/msw/registry.cpp:716
 #, c-format
 msgid ""
 "Registry key '%s' is needed for normal system operation,\n"
@@ -6185,22 +6340,22 @@ msgstr ""
 "memadamnya akan menjadikan sistem anda dalam keadaan tidak berguna:\n"
 "operasi digugurkan."
 
-#: ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:942
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:917
+#: ../src/msw/registry.cpp:905
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1003
+#: ../src/msw/registry.cpp:991
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:521
+#: ../src/msw/registry.cpp:510
 #, c-format
 msgid "Registry value '%s' already exists."
 msgstr "Nilai registri '%s' sedia wujud."
@@ -6215,74 +6370,80 @@ msgstr "Biasa"
 msgid "Relative"
 msgstr "Dekoratif"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:456
 msgid "Relevant entries:"
 msgstr "Masukan berkaitan:"
 
-#: ../include/wx/generic/progdlgg.h:86
+#: ../include/wx/generic/progdlgg.h:87
 #, fuzzy
 msgid "Remaining time:"
 msgstr "Masa yang tinggal :"
 
-#: ../src/common/stockitem.cpp:187
+#: ../src/common/stockitem.cpp:184
 msgid "Remove"
 msgstr "Buang"
 
-#: ../src/richtext/richtextctrl.cpp:1562
+#: ../src/richtext/richtextctrl.cpp:1563
 #, fuzzy
 msgid "Remove Bullet"
 msgstr "Buang"
 
-#: ../src/html/helpwnd.cpp:433
+#: ../src/html/helpwnd.cpp:431
 msgid "Remove current page from bookmarks"
 msgstr "Buang laman semasa dari tanda laman"
 
-#: ../src/common/rendcmn.cpp:194
+#: ../src/common/rendcmn.cpp:191
 #, c-format
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 "Pelaku \"%s\" mempunyai versi %d.%d yang tidak serasi dan tidak akan "
 "dimuatkan."
 
-#: ../src/richtext/richtextbuffer.cpp:4527
+#: ../src/richtext/richtextbuffer.cpp:4524
 msgid "Renumber List"
 msgstr "Menomborkan Semula Senarai"
 
-#: ../src/common/stockitem.cpp:188
-msgid "Rep&lace"
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Rep&lace..."
 msgstr "Ganti"
 
-#: ../src/richtext/richtextctrl.cpp:3673 ../src/common/stockitem.cpp:188
+#: ../src/richtext/richtextctrl.cpp:3674
 msgid "Replace"
 msgstr "Ganti"
 
-#: ../src/generic/fdrepdlg.cpp:182
+#: ../src/generic/fdrepdlg.cpp:179
 msgid "Replace &all"
 msgstr "G&anti Semua"
 
-#: ../src/common/stockitem.cpp:261
-msgid "Replace selection"
-msgstr "Ganti pilihan"
-
-#: ../src/generic/fdrepdlg.cpp:124
+#: ../src/generic/fdrepdlg.cpp:121
 msgid "Replace with:"
 msgstr "Ganti dengan:"
 
-#: ../src/common/valtext.cpp:163
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Replace..."
+msgstr "Ganti"
+
+#: ../src/common/valtext.cpp:184
 msgid "Required information entry is empty."
 msgstr ""
 
-#: ../src/common/translation.cpp:1975
+#: ../src/common/translation.cpp:2025
 #, fuzzy, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "'%s' bukanlah mesej katalog yang sah."
 
+#: ../src/gtk/webview_webkit.cpp:985
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:56
+#: ../src/common/accelcmn.cpp:53
 msgid "Return"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:189
+#: ../src/common/stockitem.cpp:186
 msgid "Revert to Saved"
 msgstr "Kembali untuk Disimpan"
 
@@ -6295,42 +6456,42 @@ msgstr "Kanan"
 msgid "Rig&ht-to-left"
 msgstr ""
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6149
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:59 ../src/generic/datavgen.cpp:6954
+#: ../src/richtext/richtextsizepage.cpp:250
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextbulletspage.cpp:188
-#: ../src/richtext/richtextsizepage.cpp:250 ../src/common/accelcmn.cpp:62
 msgid "Right"
 msgstr "Kanan"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1754
+#: ../src/propgrid/advprops.cpp:1655
 #, fuzzy
 msgid "Right Arrow"
 msgstr "Kanan"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1770
+#: ../src/propgrid/advprops.cpp:1671
 msgid "Right Button"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:892
+#: ../src/generic/prntdlgg.cpp:885
 msgid "Right margin (mm):"
 msgstr "Jidar kanan (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:148
-#: ../src/richtext/richtextindentspage.cpp:150
 #: ../src/richtext/richtextliststylepage.cpp:337
 #: ../src/richtext/richtextliststylepage.cpp:339
+#: ../src/richtext/richtextindentspage.cpp:148
+#: ../src/richtext/richtextindentspage.cpp:150
 msgid "Right-align text."
 msgstr "Jajar-kanan teks."
 
-#: ../src/generic/fontdlgg.cpp:322
+#: ../src/generic/fontdlgg.cpp:318
 msgid "Roman"
 msgstr "Roman"
 
-#: ../src/generic/datavgen.cpp:5916
+#: ../src/generic/datavgen.cpp:6721
 #, c-format
 msgid "Row %i"
 msgstr ""
@@ -6340,31 +6501,31 @@ msgstr ""
 msgid "S&tandard bullet name:"
 msgstr "Nama peluru piawai:"
 
-#: ../src/common/accelcmn.cpp:268 ../src/common/accelcmn.cpp:350
+#: ../src/common/accelcmn.cpp:282 ../src/common/accelcmn.cpp:367
 msgid "SPECIAL"
 msgstr "SPECIAL"
 
-#: ../src/common/stockitem.cpp:190 ../src/common/sizer.cpp:2797
+#: ../src/common/stockitem.cpp:187 ../src/common/sizer.cpp:2914
 msgid "Save"
 msgstr "Simpan"
 
-#: ../src/common/fldlgcmn.cpp:342
+#: ../src/common/fldlgcmn.cpp:339
 #, c-format
 msgid "Save %s file"
 msgstr "Simpan fail %s"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/common/stockitem.cpp:188 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Simp&an Sebagai..."
 
-#: ../src/common/docview.cpp:366
+#: ../src/common/docview.cpp:359
 msgid "Save As"
 msgstr "Simpan Sebagai"
 
-#: ../src/common/stockitem.cpp:191
+#: ../src/common/stockitem.cpp:188
 #, fuzzy
-msgid "Save as"
-msgstr "Simpan Sebagai"
+msgid "Save As..."
+msgstr "Simp&an Sebagai..."
 
 #: ../src/common/stockitem.cpp:267
 msgid "Save current document"
@@ -6374,40 +6535,40 @@ msgstr "Simpan dokumen semasa"
 msgid "Save current document with a different filename"
 msgstr "Simpan dokumen semasa dengan nama fail berbeza"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/generic/logg.cpp:509
 msgid "Save log contents to file"
 msgstr "Simpan kandungan log kepada fail."
 
-#: ../src/common/secretstore.cpp:179
+#: ../src/common/secretstore.cpp:189
 #, fuzzy, c-format
-msgid "Saving password for \"%s/%s\" failed: %s."
+msgid "Saving password for \"%s\" failed: %s."
 msgstr "Pengekstrakan '%s' kepada '%s' gagal."
 
-#: ../src/generic/fontdlgg.cpp:325
+#: ../src/generic/fontdlgg.cpp:321
 msgid "Script"
 msgstr "Skrip"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll Lock"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll_lock"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:890
+#: ../src/propgrid/advprops.cpp:791
 msgid "Scrollbar"
 msgstr ""
 
-#: ../src/generic/srchctlg.cpp:56 ../src/html/helpwnd.cpp:535
-#: ../src/html/helpwnd.cpp:550
+#: ../src/generic/srchctlg.cpp:55 ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:548 ../src/gtk/srchctrl.cpp:182
 msgid "Search"
 msgstr "Cari"
 
-#: ../src/html/helpwnd.cpp:537
+#: ../src/html/helpwnd.cpp:535
 #, fuzzy
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
@@ -6416,57 +6577,57 @@ msgstr ""
 "Mencari kandungan buku bantuan untuk semua kejadian yang anda taip teks "
 "diatasnya"
 
-#: ../src/generic/fdrepdlg.cpp:160
+#: ../src/generic/fdrepdlg.cpp:157
 msgid "Search direction"
 msgstr "Carian hala"
 
-#: ../src/generic/fdrepdlg.cpp:112
+#: ../src/generic/fdrepdlg.cpp:109
 msgid "Search for:"
 msgstr "Cari:"
 
-#: ../src/html/helpwnd.cpp:1052
+#: ../src/html/helpwnd.cpp:1050
 msgid "Search in all books"
 msgstr "Carian dalam semua buku"
 
-#: ../src/html/helpwnd.cpp:857
+#: ../src/html/helpwnd.cpp:855
 msgid "Searching..."
 msgstr "Mencari..."
 
-#: ../src/generic/dirctrlg.cpp:446
+#: ../src/generic/dirctrlg.cpp:412
 msgid "Sections"
 msgstr "Seksyen"
 
-#: ../src/common/ffile.cpp:238
+#: ../src/common/ffile.cpp:237
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Cari ralat pada fail '%s'"
 
-#: ../src/common/ffile.cpp:228
+#: ../src/common/ffile.cpp:227
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr "Mencari ralat pada fail '%s' (fail besar tidak disokong oleh stdio)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:76
+#: ../src/common/accelcmn.cpp:73
 #, fuzzy
 msgid "Select"
 msgstr "Pemilihan"
 
-#: ../src/richtext/richtextctrl.cpp:337 ../src/osx/textctrl_osx.cpp:581
-#: ../src/common/stockitem.cpp:192 ../src/msw/textctrl.cpp:2512
+#: ../src/osx/textctrl_osx.cpp:599 ../src/common/stockitem.cpp:189
+#: ../src/msw/textctrl.cpp:2777 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Pilih &Semua"
 
-#: ../src/common/stockitem.cpp:192 ../src/stc/stc_i18n.cpp:21
+#: ../src/common/stockitem.cpp:189 ../src/stc/stc_i18n.cpp:21
 #, fuzzy
 msgid "Select All"
 msgstr "Pilih &Semua"
 
-#: ../src/common/docview.cpp:1895
+#: ../src/common/docview.cpp:1900
 msgid "Select a document template"
 msgstr "Pilih templat dokumen"
 
-#: ../src/common/docview.cpp:1969
+#: ../src/common/docview.cpp:1974
 msgid "Select a document view"
 msgstr "Pilih lihat dokumen"
 
@@ -6495,20 +6656,20 @@ msgid "Selects the list level to edit."
 msgstr "Pilih paras senarai untuk edit."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:82
+#: ../src/common/accelcmn.cpp:79
 msgid "Separator"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1083
+#: ../src/common/cmdline.cpp:1079
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Pembahagi dijangka selepas pilihan '%s'."
 
-#: ../src/osx/menu_osx.cpp:572
+#: ../src/osx/menu_osx.cpp:464
 msgid "Services"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11217
+#: ../src/richtext/richtextbuffer.cpp:11216
 #, fuzzy
 msgid "Set Cell Style"
 msgstr "Padam Gaya"
@@ -6517,11 +6678,11 @@ msgstr "Padam Gaya"
 msgid "SetProperty called w/o valid setter"
 msgstr "SetProperty dipanggil tanpa setter sah"
 
-#: ../src/generic/prntdlgg.cpp:188
+#: ../src/generic/prntdlgg.cpp:181
 msgid "Setup..."
 msgstr "Tetapan..."
 
-#: ../src/msw/dialup.cpp:544
+#: ../src/msw/dialup.cpp:538
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr "Beberapa sambungan mendial aktif ditemui, pilih satu secara rawak."
 
@@ -6538,42 +6699,42 @@ msgstr ""
 msgid "Shadow c&olour:"
 msgstr "Pilih warna"
 
-#: ../src/common/accelcmn.cpp:335
+#: ../src/common/accelcmn.cpp:349
 #, fuzzy
 msgid "Shift+"
 msgstr "Shift-"
 
-#: ../src/generic/dirdlgg.cpp:147
+#: ../src/generic/dirdlgg.cpp:144
 msgid "Show &hidden directories"
 msgstr "Tunjuk direktori tersembunyi"
 
-#: ../src/generic/filectrlg.cpp:983
+#: ../src/generic/filectrlg.cpp:979
 msgid "Show &hidden files"
 msgstr "Tunjuk fail tersembunyi"
 
-#: ../src/osx/menu_osx.cpp:580
+#: ../src/osx/menu_osx.cpp:472
 #, fuzzy
 msgid "Show All"
 msgstr "Papar Semua"
 
-#: ../src/common/stockitem.cpp:257
+#: ../src/common/stockitem.cpp:254
 msgid "Show about dialog"
 msgstr "Tunjuk dialog perihal"
 
-#: ../src/html/helpwnd.cpp:492
+#: ../src/html/helpwnd.cpp:490
 msgid "Show all"
 msgstr "Papar Semua"
 
-#: ../src/html/helpwnd.cpp:503
+#: ../src/html/helpwnd.cpp:501
 msgid "Show all items in index"
 msgstr "Tunjuk semua item indeks"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:656
 msgid "Show/hide navigation panel"
 msgstr "Tunjuk/sorok panel navigasi"
 
-#: ../src/richtext/richtextsymboldlg.cpp:421
-#: ../src/richtext/richtextsymboldlg.cpp:423
+#: ../src/richtext/richtextsymboldlg.cpp:418
+#: ../src/richtext/richtextsymboldlg.cpp:420
 msgid "Shows a Unicode subset."
 msgstr "Tunjuk subset Unikod."
 
@@ -6589,7 +6750,7 @@ msgstr "Tunjuk pralihat tetapan peluru."
 msgid "Shows a preview of the font settings."
 msgstr "Tunjuk pralihat tetapan fon."
 
-#: ../src/osx/carbon/fontdlg.cpp:394 ../src/osx/carbon/fontdlg.cpp:396
+#: ../src/osx/carbon/fontdlg.cpp:391 ../src/osx/carbon/fontdlg.cpp:393
 msgid "Shows a preview of the font."
 msgstr "Tunjuk pralihat fon."
 
@@ -6598,62 +6759,62 @@ msgstr "Tunjuk pralihat fon."
 msgid "Shows a preview of the paragraph settings."
 msgstr "Tunjuk pralihat tetapan perenggan."
 
-#: ../src/generic/fontdlgg.cpp:460 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:456 ../src/generic/fontdlgg.cpp:458
 msgid "Shows the font preview."
 msgstr "Tunjuk pralihat fon."
 
-#: ../src/propgrid/advprops.cpp:1607
+#: ../src/propgrid/advprops.cpp:1513
 msgid "Silver"
 msgstr ""
 
-#: ../src/univ/themes/mono.cpp:516
+#: ../src/univ/themes/mono.cpp:513
 msgid "Simple monochrome theme"
 msgstr "Tema monokrom mudah"
 
-#: ../src/richtext/richtextindentspage.cpp:275
 #: ../src/richtext/richtextliststylepage.cpp:449
+#: ../src/richtext/richtextindentspage.cpp:275
 msgid "Single"
 msgstr "Tunggal"
 
-#: ../src/generic/filectrlg.cpp:425 ../src/richtext/richtextformatdlg.cpp:369
-#: ../src/richtext/richtextsizepage.cpp:299
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextsizepage.cpp:299
+#: ../src/richtext/richtextformatdlg.cpp:362
 msgid "Size"
 msgstr "Saiz"
 
-#: ../src/osx/carbon/fontdlg.cpp:339
+#: ../src/osx/carbon/fontdlg.cpp:336
 msgid "Size:"
 msgstr "Saiz:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1775
+#: ../src/propgrid/advprops.cpp:1676
 msgid "Sizing"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1772
+#: ../src/propgrid/advprops.cpp:1673
 msgid "Sizing N-S"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1771
+#: ../src/propgrid/advprops.cpp:1672
 msgid "Sizing NE-SW"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1773
+#: ../src/propgrid/advprops.cpp:1674
 msgid "Sizing NW-SE"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1774
+#: ../src/propgrid/advprops.cpp:1675
 msgid "Sizing W-E"
 msgstr ""
 
-#: ../src/msw/progdlg.cpp:801
+#: ../src/msw/progdlg.cpp:1088
 msgid "Skip"
 msgstr "Langkau"
 
-#: ../src/generic/fontdlgg.cpp:330
+#: ../src/generic/fontdlgg.cpp:326
 msgid "Slant"
 msgstr "Condong"
 
@@ -6662,7 +6823,7 @@ msgid "Small C&apitals"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:79
+#: ../src/common/accelcmn.cpp:76
 msgid "Snapshot"
 msgstr ""
 
@@ -6671,37 +6832,37 @@ msgstr ""
 msgid "Solid"
 msgstr "Tebal"
 
-#: ../src/common/docview.cpp:1791
+#: ../src/common/docview.cpp:1785
 msgid "Sorry, could not open this file."
 msgstr "Maaf, Gagal membuka fail."
 
-#: ../src/common/prntbase.cpp:2057 ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2079 ../src/common/prntbase.cpp:2087
 msgid "Sorry, not enough memory to create a preview."
 msgstr "Maaf, tidak cukup memori untuk mencipta pralihat."
 
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "Sorry, that name is taken. Please choose another."
 msgstr "Maaf, nama sudah diambil. Sila pillih lain."
 
-#: ../src/common/docview.cpp:1814
+#: ../src/common/docview.cpp:1819
 msgid "Sorry, the format for this file is unknown."
 msgstr "Maaf, format fail ini tidak diketahui."
 
-#: ../src/unix/sound.cpp:492
+#: ../src/unix/sound.cpp:481
 msgid "Sound data are in unsupported format."
 msgstr "Data bunyi dalam format yang tidak disokong."
 
-#: ../src/unix/sound.cpp:477
+#: ../src/unix/sound.cpp:466
 #, c-format
 msgid "Sound file '%s' is in unsupported format."
 msgstr "Fail bunyi '%s' dalam format yang tidak disokong."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:67
+#: ../src/common/accelcmn.cpp:64
 #, fuzzy
 msgid "Space"
 msgstr "Ruang"
@@ -6710,12 +6871,12 @@ msgstr "Ruang"
 msgid "Spacing"
 msgstr "Ruang"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "Spell Check"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1776
+#: ../src/propgrid/advprops.cpp:1677
 msgid "Spraycan"
 msgstr ""
 
@@ -6724,7 +6885,7 @@ msgstr ""
 msgid "Standard"
 msgstr "Piawai"
 
-#: ../src/common/paper.cpp:104
+#: ../src/common/paper.cpp:101
 msgid "Statement, 5 1/2 x 8 1/2 in"
 msgstr "Kenyataan, 5 1/2 x 8 1/2 in"
 
@@ -6734,34 +6895,30 @@ msgstr "Kenyataan, 5 1/2 x 8 1/2 in"
 msgid "Static"
 msgstr "Status:"
 
-#: ../src/generic/prntdlgg.cpp:204
+#: ../src/generic/prntdlgg.cpp:197
 msgid "Status:"
 msgstr "Status:"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 #, fuzzy
 msgid "Stop"
 msgstr "&Henti"
 
-#: ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196
 msgid "Strikethrough"
 msgstr ""
 
-#: ../src/common/colourcmn.cpp:45
+#: ../src/common/colourcmn.cpp:42
 #, c-format
 msgid "String To Colour : Incorrect colour specification : %s"
 msgstr "Rentetan Kepada Warna : Spesifikasi warna salah : %s"
 
 #. TRANSLATORS: Label of font style
-#: ../src/richtext/richtextformatdlg.cpp:339 ../src/propgrid/advprops.cpp:680
+#: ../src/propgrid/advprops.cpp:590 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Gaya"
 
-#: ../include/wx/richtext/richtextstyledlg.h:46
-msgid "Style Organiser"
-msgstr "Gaya Pengatur"
-
-#: ../src/osx/carbon/fontdlg.cpp:348
+#: ../src/osx/carbon/fontdlg.cpp:345
 msgid "Style:"
 msgstr "Gaya:"
 
@@ -6771,7 +6928,7 @@ msgid "Subscrip&t"
 msgstr "Skrip"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:83
+#: ../src/common/accelcmn.cpp:80
 msgid "Subtract"
 msgstr ""
 
@@ -6780,11 +6937,11 @@ msgstr ""
 msgid "Supe&rscript"
 msgstr "Skrip"
 
-#: ../src/common/paper.cpp:150
+#: ../src/common/paper.cpp:147
 msgid "SuperA/SuperA/A4 227 x 356 mm"
 msgstr "SuperA/SuperA/A4 227 x 356 mm"
 
-#: ../src/common/paper.cpp:151
+#: ../src/common/paper.cpp:148
 msgid "SuperB/SuperB/A3 305 x 487 mm"
 msgstr "SuperB/SuperB/A3 305 x 487 mm"
 
@@ -6792,7 +6949,7 @@ msgstr "SuperB/SuperB/A3 305 x 487 mm"
 msgid "Suppress hyphe&nation"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:326
+#: ../src/generic/fontdlgg.cpp:322
 msgid "Swiss"
 msgstr "Swiss"
 
@@ -6810,75 +6967,75 @@ msgstr "Fon simbol:"
 msgid "Symbols"
 msgstr "Simbol"
 
-#: ../src/common/imagtiff.cpp:369 ../src/common/imagtiff.cpp:382
-#: ../src/common/imagtiff.cpp:741
+#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
+#: ../src/common/imagtiff.cpp:738
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: Gagal menempatkan memori"
 
-#: ../src/common/imagtiff.cpp:301
+#: ../src/common/imagtiff.cpp:298
 msgid "TIFF: Error loading image."
 msgstr "TIFF: Ralat memuat imej."
 
-#: ../src/common/imagtiff.cpp:468
+#: ../src/common/imagtiff.cpp:465
 msgid "TIFF: Error reading image."
 msgstr "TIFF: Ralat membaca imej."
 
-#: ../src/common/imagtiff.cpp:608
+#: ../src/common/imagtiff.cpp:605
 msgid "TIFF: Error saving image."
 msgstr "TIFF: Ralat menyimpan imej."
 
-#: ../src/common/imagtiff.cpp:846
+#: ../src/common/imagtiff.cpp:843
 msgid "TIFF: Error writing image."
 msgstr "TIFF: Ralat menulis imej."
 
-#: ../src/common/imagtiff.cpp:355
+#: ../src/common/imagtiff.cpp:352
 msgid "TIFF: Image size is abnormally big."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:68
+#: ../src/common/accelcmn.cpp:65
 #, fuzzy
 msgid "Tab"
 msgstr "Tab"
 
-#: ../src/richtext/richtextbuffer.cpp:11498
+#: ../src/richtext/richtextbuffer.cpp:11497
 #, fuzzy
 msgid "Table Properties"
 msgstr "&Ciri-ciri"
 
-#: ../src/common/paper.cpp:145
+#: ../src/common/paper.cpp:142
 msgid "Tabloid Extra 11.69 x 18 in"
 msgstr "Tabloid Ekstra 11.69 x 18 in"
 
-#: ../src/common/paper.cpp:102
+#: ../src/common/paper.cpp:99
 msgid "Tabloid, 11 x 17 in"
 msgstr "Tabloid, 11 x 17 in"
 
-#: ../src/richtext/richtextformatdlg.cpp:354
+#: ../src/richtext/richtextformatdlg.cpp:347
 msgid "Tabs"
 msgstr "Tab"
 
-#: ../src/propgrid/advprops.cpp:1598
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Teal"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:327
+#: ../src/generic/fontdlgg.cpp:323
 msgid "Teletype"
 msgstr "Teletaip"
 
-#: ../src/common/docview.cpp:1896
+#: ../src/common/docview.cpp:1901
 msgid "Templates"
 msgstr "Templat"
 
-#: ../src/common/fmapbase.cpp:158
+#: ../src/common/fmapbase.cpp:155
 msgid "Thai (ISO-8859-11)"
 msgstr "Thai (ISO-8859-11)"
 
-#: ../src/common/ftp.cpp:619
+#: ../src/common/ftp.cpp:622
 msgid "The FTP server doesn't support passive mode."
 msgstr "Pelayan FTP tidak menyokong mod pasif."
 
-#: ../src/common/ftp.cpp:605
+#: ../src/common/ftp.cpp:608
 msgid "The FTP server doesn't support the PORT command."
 msgstr "Pelayan FTP tidak menyokong arahan PORT."
 
@@ -6889,8 +7046,8 @@ msgstr "Pelayan FTP tidak menyokong arahan PORT."
 msgid "The available bullet styles."
 msgstr "Gaya peluru yang ada."
 
-#: ../src/richtext/richtextstyledlg.cpp:202
-#: ../src/richtext/richtextstyledlg.cpp:204
+#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:200
 msgid "The available styles."
 msgstr "Gaya yang ada."
 
@@ -6951,12 +7108,12 @@ msgstr "Posisi tab."
 msgid "The bullet character."
 msgstr "Aksara peluru."
 
-#: ../src/richtext/richtextsymboldlg.cpp:443
-#: ../src/richtext/richtextsymboldlg.cpp:445
+#: ../src/richtext/richtextsymboldlg.cpp:440
+#: ../src/richtext/richtextsymboldlg.cpp:442
 msgid "The character code."
 msgstr "Kod aksara."
 
-#: ../src/common/fontmap.cpp:203
+#: ../src/common/fontmap.cpp:200
 #, c-format
 msgid ""
 "The charset '%s' is unknown. You may select\n"
@@ -6967,7 +7124,7 @@ msgstr ""
 "set aksara lain untuk digantikan atau pilih\n"
 "[Batal] jika tidak boleh diganti"
 
-#: ../src/msw/ole/dataobj.cpp:394
+#: ../src/msw/ole/dataobj.cpp:402
 #, c-format
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "Format klipbod '%d' tidak wujud."
@@ -6977,7 +7134,7 @@ msgstr "Format klipbod '%d' tidak wujud."
 msgid "The default style for the next paragraph."
 msgstr "Gaya lalai untuk perenggan berikut."
 
-#: ../src/generic/dirdlgg.cpp:202
+#: ../src/generic/dirdlgg.cpp:199
 #, c-format
 msgid ""
 "The directory '%s' does not exist\n"
@@ -6986,7 +7143,7 @@ msgstr ""
 "Direktori '%s' tidak wujud\n"
 "Cipta sekarang?"
 
-#: ../src/html/htmprint.cpp:271
+#: ../src/html/htmprint.cpp:283
 #, c-format
 msgid ""
 "The document \"%s\" doesn't fit on the page horizontally and will be "
@@ -6995,7 +7152,7 @@ msgid ""
 "Would you like to proceed with printing it nevertheless?"
 msgstr ""
 
-#: ../src/common/docview.cpp:1202
+#: ../src/common/docview.cpp:1196
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -7004,36 +7161,37 @@ msgstr ""
 "Fail '%s' tidak wujud dan Gagal dibuka.\n"
 "Ia telah dibuang dari senarai fail paling baru diguna."
 
-#: ../src/richtext/richtextindentspage.cpp:208
-#: ../src/richtext/richtextindentspage.cpp:210
 #: ../src/richtext/richtextliststylepage.cpp:394
 #: ../src/richtext/richtextliststylepage.cpp:396
+#: ../src/richtext/richtextindentspage.cpp:208
+#: ../src/richtext/richtextindentspage.cpp:210
 msgid "The first line indent."
 msgstr "Takuk baris pertama."
 
-#: ../src/gtk/utilsgtk.cpp:481
-msgid "The following standard GTK+ options are also supported:\n"
-msgstr ""
+#: ../src/generic/dbgrptg.cpp:318
+#, fuzzy
+msgid "The following debug report will be generated\n"
+msgstr "*** Laporan nyahpijat telah dijana\n"
 
-#: ../src/generic/fontdlgg.cpp:414 ../src/generic/fontdlgg.cpp:416
+#: ../src/generic/fontdlgg.cpp:411 ../src/generic/fontdlgg.cpp:413
 msgid "The font colour."
 msgstr "Warna fon."
 
-#: ../src/generic/fontdlgg.cpp:375 ../src/generic/fontdlgg.cpp:377
+#: ../src/generic/fontdlgg.cpp:371 ../src/generic/fontdlgg.cpp:373
 msgid "The font family."
 msgstr "Keluarga Fon"
 
-#: ../src/richtext/richtextsymboldlg.cpp:405
-#: ../src/richtext/richtextsymboldlg.cpp:407
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "The font from which to take the symbol."
 msgstr "Fon yang akan mengambil simbol."
 
-#: ../src/generic/fontdlgg.cpp:427 ../src/generic/fontdlgg.cpp:429
-#: ../src/generic/fontdlgg.cpp:434 ../src/generic/fontdlgg.cpp:436
+#: ../src/generic/fontdlgg.cpp:424 ../src/generic/fontdlgg.cpp:426
+#: ../src/generic/fontdlgg.cpp:430 ../src/generic/fontdlgg.cpp:432
 msgid "The font point size."
 msgstr "Saiz titik fon."
 
-#: ../src/osx/carbon/fontdlg.cpp:343 ../src/osx/carbon/fontdlg.cpp:345
+#: ../src/osx/carbon/fontdlg.cpp:340 ../src/osx/carbon/fontdlg.cpp:342
 msgid "The font size in points."
 msgstr "Saiz fon dalam titik."
 
@@ -7043,15 +7201,15 @@ msgstr "Saiz fon dalam titik."
 msgid "The font size units, points or pixels."
 msgstr "Saiz fon dalam titik."
 
-#: ../src/generic/fontdlgg.cpp:386 ../src/generic/fontdlgg.cpp:388
+#: ../src/generic/fontdlgg.cpp:382 ../src/generic/fontdlgg.cpp:384
 msgid "The font style."
 msgstr "Gaya fon"
 
-#: ../src/generic/fontdlgg.cpp:397 ../src/generic/fontdlgg.cpp:399
+#: ../src/generic/fontdlgg.cpp:393 ../src/generic/fontdlgg.cpp:395
 msgid "The font weight."
 msgstr "Berat fon."
 
-#: ../src/common/docview.cpp:1483
+#: ../src/common/docview.cpp:1477
 #, fuzzy, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Direktori '%s' gagal dicipta"
@@ -7062,10 +7220,10 @@ msgstr "Direktori '%s' gagal dicipta"
 msgid "The horizontal offset."
 msgstr "Jubin Me&lintang"
 
-#: ../src/richtext/richtextindentspage.cpp:199
-#: ../src/richtext/richtextindentspage.cpp:201
 #: ../src/richtext/richtextliststylepage.cpp:385
 #: ../src/richtext/richtextliststylepage.cpp:387
+#: ../src/richtext/richtextindentspage.cpp:199
+#: ../src/richtext/richtextindentspage.cpp:201
 msgid "The left indent."
 msgstr "Takuk kiri."
 
@@ -7089,10 +7247,10 @@ msgstr "Saiz titik fon."
 msgid "The left position."
 msgstr "Posisi tab."
 
-#: ../src/richtext/richtextindentspage.cpp:288
-#: ../src/richtext/richtextindentspage.cpp:290
 #: ../src/richtext/richtextliststylepage.cpp:462
 #: ../src/richtext/richtextliststylepage.cpp:464
+#: ../src/richtext/richtextindentspage.cpp:288
+#: ../src/richtext/richtextindentspage.cpp:290
 msgid "The line spacing."
 msgstr "Ruang baris."
 
@@ -7101,7 +7259,7 @@ msgstr "Ruang baris."
 msgid "The list item number."
 msgstr "Nombor senarai item."
 
-#: ../src/msw/ole/automtn.cpp:664
+#: ../src/msw/ole/automtn.cpp:655
 msgid "The locale ID is unknown."
 msgstr ""
 
@@ -7147,19 +7305,19 @@ msgstr "Berat fon."
 msgid "The outline level."
 msgstr "Pralihat gaya."
 
-#: ../src/common/log.cpp:277
+#: ../src/common/log.cpp:296
 #, c-format
 msgid "The previous message repeated %u time."
 msgid_plural "The previous message repeated %u times."
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/common/log.cpp:270
+#: ../src/common/log.cpp:289
 msgid "The previous message repeated once."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:462
-#: ../src/richtext/richtextsymboldlg.cpp:464
+#: ../src/richtext/richtextsymboldlg.cpp:459
+#: ../src/richtext/richtextsymboldlg.cpp:461
 msgid "The range to show."
 msgstr "Julat untuk ditunjuk."
 
@@ -7173,15 +7331,15 @@ msgstr ""
 "maklumat peribadi,\n"
 "sila buang tandanya dan akan dibuang daripada laporan.\n"
 
-#: ../src/common/cmdline.cpp:1254
+#: ../src/common/cmdline.cpp:1250
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "Parameter yang diperlukan '%s' tidak ditentukan."
 
-#: ../src/richtext/richtextindentspage.cpp:217
-#: ../src/richtext/richtextindentspage.cpp:219
 #: ../src/richtext/richtextliststylepage.cpp:403
 #: ../src/richtext/richtextliststylepage.cpp:405
+#: ../src/richtext/richtextindentspage.cpp:217
+#: ../src/richtext/richtextindentspage.cpp:219
 msgid "The right indent."
 msgstr "Takuk kanan."
 
@@ -7226,16 +7384,16 @@ msgstr ""
 msgid "The shadow spread."
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:267
 #: ../src/richtext/richtextliststylepage.cpp:439
 #: ../src/richtext/richtextliststylepage.cpp:441
+#: ../src/richtext/richtextindentspage.cpp:267
 msgid "The spacing after the paragraph."
 msgstr "Ruangan selepas perenggan."
 
-#: ../src/richtext/richtextindentspage.cpp:257
-#: ../src/richtext/richtextindentspage.cpp:259
 #: ../src/richtext/richtextliststylepage.cpp:430
 #: ../src/richtext/richtextliststylepage.cpp:432
+#: ../src/richtext/richtextindentspage.cpp:257
+#: ../src/richtext/richtextindentspage.cpp:259
 msgid "The spacing before the paragraph."
 msgstr "Ruangan sebelum perenggan."
 
@@ -7249,12 +7407,12 @@ msgstr "Nama gaya."
 msgid "The style on which this style is based."
 msgstr "Gaya yang pada gaya ini diasaskan."
 
-#: ../src/richtext/richtextstyledlg.cpp:214
-#: ../src/richtext/richtextstyledlg.cpp:216
+#: ../src/richtext/richtextstyledlg.cpp:210
+#: ../src/richtext/richtextstyledlg.cpp:212
 msgid "The style preview."
 msgstr "Pralihat gaya."
 
-#: ../src/msw/ole/automtn.cpp:680
+#: ../src/msw/ole/automtn.cpp:671
 msgid "The system cannot find the file specified."
 msgstr ""
 
@@ -7267,7 +7425,7 @@ msgstr "Posisi tab."
 msgid "The tab positions."
 msgstr "Posisi tab."
 
-#: ../src/richtext/richtextctrl.cpp:3098
+#: ../src/richtext/richtextctrl.cpp:3099
 msgid "The text couldn't be saved."
 msgstr "Teks gagal disimpan."
 
@@ -7291,7 +7449,7 @@ msgstr "Saiz titik fon."
 msgid "The top position."
 msgstr "Posisi tab."
 
-#: ../src/common/cmdline.cpp:1232
+#: ../src/common/cmdline.cpp:1228
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "Nilai pilihan '%s' mesti ditentukan."
@@ -7301,7 +7459,7 @@ msgstr "Nilai pilihan '%s' mesti ditentukan."
 msgid "The value of the corner radius."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:433
+#: ../src/msw/dialup.cpp:427
 #, fuzzy, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -7316,46 +7474,54 @@ msgstr ""
 msgid "The vertical offset."
 msgstr "Gagal mulakan mencetak."
 
-#: ../src/richtext/richtextprint.cpp:619 ../src/html/htmprint.cpp:745
+#: ../src/html/htmprint.cpp:749 ../src/richtext/richtextprint.cpp:615
 msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr ""
 "Terdapat masalah semasa pemasangan laman: anda mungkin perlukan memasang "
 "pencetak lalai."
 
-#: ../src/html/htmprint.cpp:255
+#: ../src/html/htmprint.cpp:267
 msgid ""
 "This document doesn't fit on the page horizontally and will be truncated "
 "when it is printed."
 msgstr ""
 
-#: ../src/common/image.cpp:2854
+#: ../src/common/image.cpp:2963
 #, fuzzy, c-format
 msgid "This is not a %s."
 msgstr "PCX: ini bukahlah fail PCX."
 
-#: ../src/common/wincmn.cpp:1653
+#: ../src/common/wincmn.cpp:1654
 msgid "This platform does not support background transparency."
 msgstr ""
 
-#: ../src/gtk/window.cpp:4660
+#: ../src/gtk/window.cpp:5664
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
 
-#: ../src/msw/thread.cpp:1240
+#: ../src/gtk/glcanvas.cpp:176
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/msw/thread.cpp:1246
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
 msgstr ""
 "Gagal memulakan modul benang: Gagal simpan data dalam penyimpan benang lokal"
 
-#: ../src/unix/threadpsx.cpp:1794
+#: ../src/unix/threadpsx.cpp:1843
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr "Modul benang gagal dimulakan: gagal cipta kunci benang"
 
-#: ../src/msw/thread.cpp:1228
+#: ../src/msw/thread.cpp:1234
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -7363,84 +7529,84 @@ msgstr ""
 "Gagal memulakan modul benang: mustahil untuk menyediakan indeks dalam "
 "penyimpan benang lokal"
 
-#: ../src/unix/threadpsx.cpp:1043
+#: ../src/unix/threadpsx.cpp:1061
 msgid "Thread priority setting is ignored."
 msgstr "Tetapan keutamaan benang diabaikan."
 
-#: ../src/msw/mdi.cpp:176
+#: ../src/msw/mdi.cpp:171
 msgid "Tile &Horizontally"
 msgstr "Jubin Me&lintang"
 
-#: ../src/msw/mdi.cpp:177
+#: ../src/msw/mdi.cpp:172
 msgid "Tile &Vertically"
 msgstr "Jubin Me&negak"
 
-#: ../src/common/ftp.cpp:200
+#: ../src/common/ftp.cpp:197
 msgid "Timeout while waiting for FTP server to connect, try passive mode."
 msgstr "Masa tamat ketika menunggu sambuungan pelayan FTP, cuba mod pasif."
 
-#: ../src/generic/tipdlg.cpp:201
+#: ../src/generic/tipdlg.cpp:198
 msgid "Tip of the Day"
 msgstr "Petua Hari Ini"
 
-#: ../src/generic/tipdlg.cpp:140
+#: ../src/generic/tipdlg.cpp:137
 msgid "Tips not available, sorry!"
 msgstr "Kias tidak wujud, maaf!"
 
-#: ../src/generic/prntdlgg.cpp:242
+#: ../src/generic/prntdlgg.cpp:235
 msgid "To:"
 msgstr "Ke:"
 
-#: ../src/richtext/richtextbuffer.cpp:8363
+#: ../src/richtext/richtextbuffer.cpp:8361
 msgid "Too many EndStyle calls!"
 msgstr "Terlalu banyak panggilan EndStyle!"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:891
+#: ../src/propgrid/advprops.cpp:792
 msgid "Tooltip"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:892
+#: ../src/propgrid/advprops.cpp:793
 msgid "TooltipText"
 msgstr ""
 
-#: ../src/richtext/richtextsizepage.cpp:286
-#: ../src/richtext/richtextsizepage.cpp:290 ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197 ../src/richtext/richtextsizepage.cpp:286
+#: ../src/richtext/richtextsizepage.cpp:290
 #, fuzzy
 msgid "Top"
 msgstr "Ke:"
 
-#: ../src/generic/prntdlgg.cpp:881
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Top margin (mm):"
 msgstr "Jidar bawah (mm):"
 
-#: ../src/generic/aboutdlgg.cpp:79
+#: ../src/generic/aboutdlgg.cpp:76
 msgid "Translations by "
 msgstr "Diterjemah oleh"
 
-#: ../src/generic/aboutdlgg.cpp:188
+#: ../src/generic/aboutdlgg.cpp:185
 #, fuzzy
 msgid "Translators"
 msgstr "Diterjemah oleh"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:211
+#: ../src/propgrid/propgrid.cpp:192
 msgid "True"
 msgstr ""
 
-#: ../src/common/fs_mem.cpp:227
+#: ../src/common/fs_mem.cpp:222
 #, c-format
 msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
 msgstr ""
 "Mencuba untuk menyingkirkan fail '%s' daripada memori VFS, tetapi tidak "
 "dimuatkan!"
 
-#: ../src/common/fmapbase.cpp:156
+#: ../src/common/fmapbase.cpp:153
 msgid "Turkish (ISO-8859-9)"
 msgstr "Turkish (ISO-8859-9)"
 
-#: ../src/generic/filectrlg.cpp:426
+#: ../src/generic/filectrlg.cpp:422
 msgid "Type"
 msgstr "Jenis"
 
@@ -7454,36 +7620,36 @@ msgstr "Jenis nama fon."
 msgid "Type a size in points."
 msgstr "Jenis saiz dalam titik."
 
-#: ../src/msw/ole/automtn.cpp:676
+#: ../src/msw/ole/automtn.cpp:667
 #, c-format
 msgid "Type mismatch in argument %u."
 msgstr ""
 
-#: ../src/common/xtixml.cpp:356 ../src/common/xtixml.cpp:509
-#: ../src/common/xtistrm.cpp:318
+#: ../src/common/xtixml.cpp:352 ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315
 msgid "Type must have enum - long conversion"
 msgstr "Jenis mestilah pertukaran hitung - panjang"
 
-#: ../src/propgrid/propgridiface.cpp:401
+#: ../src/propgrid/propgridiface.cpp:385
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
 "\"%s\"."
 msgstr ""
 
-#: ../src/common/paper.cpp:133
+#: ../src/common/paper.cpp:130
 msgid "US Std Fanfold, 14 7/8 x 11 in"
 msgstr "Fanfold Piawai US, 14 7/8 x 11 in"
 
-#: ../src/common/fmapbase.cpp:196
+#: ../src/common/fmapbase.cpp:193
 msgid "US-ASCII"
 msgstr "US-ASCII"
 
-#: ../src/unix/fswatcher_inotify.cpp:109
+#: ../src/unix/fswatcher_inotify.cpp:106
 msgid "Unable to add inotify watch"
 msgstr ""
 
-#: ../src/unix/fswatcher_kqueue.cpp:136
+#: ../src/unix/fswatcher_kqueue.cpp:153
 msgid "Unable to add kqueue watch"
 msgstr ""
 
@@ -7496,7 +7662,7 @@ msgstr ""
 msgid "Unable to close I/O completion port handle"
 msgstr "Gagal tutup pengemudi fail"
 
-#: ../src/unix/fswatcher_inotify.cpp:97
+#: ../src/unix/fswatcher_inotify.cpp:94
 #, fuzzy
 msgid "Unable to close inotify instance"
 msgstr "Gagal tutup pengemudi fail"
@@ -7516,17 +7682,17 @@ msgstr "Gagal tutup pengemudi fail"
 msgid "Unable to create I/O completion port"
 msgstr "Gagal cipta TextEncodingConverter"
 
-#: ../src/msw/fswatcher.cpp:84
+#: ../src/msw/fswatcher.cpp:81
 #, fuzzy
 msgid "Unable to create IOCP worker thread"
 msgstr "Gagal cipta TextEncodingConverter"
 
-#: ../src/unix/fswatcher_inotify.cpp:74
+#: ../src/unix/fswatcher_inotify.cpp:71
 #, fuzzy
 msgid "Unable to create inotify instance"
 msgstr "Gagal cipta TextEncodingConverter"
 
-#: ../src/unix/fswatcher_kqueue.cpp:97
+#: ../src/unix/fswatcher_kqueue.cpp:114
 #, fuzzy
 msgid "Unable to create kqueue instance"
 msgstr "Gagal cipta TextEncodingConverter"
@@ -7535,11 +7701,11 @@ msgstr "Gagal cipta TextEncodingConverter"
 msgid "Unable to dequeue completion packet"
 msgstr ""
 
-#: ../src/unix/fswatcher_kqueue.cpp:185
+#: ../src/unix/fswatcher_kqueue.cpp:202
 msgid "Unable to get events from kqueue"
 msgstr ""
 
-#: ../src/gtk/app.cpp:435
+#: ../src/gtk/app.cpp:431
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr ""
 
@@ -7548,12 +7714,12 @@ msgstr ""
 msgid "Unable to open path '%s'"
 msgstr "Gagal membuka arkib sementara '%s'."
 
-#: ../src/html/htmlwin.cpp:583
+#: ../src/html/htmlwin.cpp:586
 #, c-format
 msgid "Unable to open requested HTML document: %s"
 msgstr "Gagal membuka dokumen HTML yang diminta: %s"
 
-#: ../src/unix/sound.cpp:368
+#: ../src/unix/sound.cpp:365
 msgid "Unable to play sound asynchronously."
 msgstr "Gagal mainkan bunyi secara tak segerak."
 
@@ -7561,64 +7727,64 @@ msgstr "Gagal mainkan bunyi secara tak segerak."
 msgid "Unable to post completion status"
 msgstr ""
 
-#: ../src/unix/fswatcher_inotify.cpp:556
+#: ../src/unix/fswatcher_inotify.cpp:553
 #, fuzzy
 msgid "Unable to read from inotify descriptor"
 msgstr "gagal membaca dari penghurai fail %d"
 
-#: ../src/unix/fswatcher_inotify.cpp:141
+#: ../src/unix/fswatcher_inotify.cpp:138
 #, fuzzy, c-format
 msgid "Unable to remove inotify watch %i"
 msgstr "Gagal cipta TextEncodingConverter"
 
-#: ../src/unix/fswatcher_kqueue.cpp:153
+#: ../src/unix/fswatcher_kqueue.cpp:170
 msgid "Unable to remove kqueue watch"
 msgstr ""
 
-#: ../src/msw/fswatcher.cpp:168
+#: ../src/msw/fswatcher.cpp:165
 #, fuzzy, c-format
 msgid "Unable to set up watch for '%s'"
 msgstr "Gagal sentuh fail '%s'"
 
-#: ../src/msw/fswatcher.cpp:91
+#: ../src/msw/fswatcher.cpp:88
 msgid "Unable to start IOCP worker thread"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:201
+#: ../src/common/stockitem.cpp:198
 msgid "Undelete"
 msgstr "Nyahpadam"
 
-#: ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199
 #, fuzzy
 msgid "Underline"
 msgstr "Garis bawah"
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/richtext/richtextfontpage.cpp:359 ../src/osx/carbon/fontdlg.cpp:370
-#: ../src/propgrid/advprops.cpp:690
+#: ../src/osx/carbon/fontdlg.cpp:367 ../src/propgrid/advprops.cpp:600
+#: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Digaris bawahkan"
 
-#: ../src/common/stockitem.cpp:203 ../src/stc/stc_i18n.cpp:15
+#: ../src/common/stockitem.cpp:200 ../src/stc/stc_i18n.cpp:15
 #, fuzzy
 msgid "Undo"
 msgstr "&Nyahcara"
 
-#: ../src/common/stockitem.cpp:265
+#: ../src/common/stockitem.cpp:263
 msgid "Undo last action"
 msgstr "Batalkan tindakan akhir"
 
-#: ../src/common/cmdline.cpp:1029
+#: ../src/common/cmdline.cpp:1025
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Aksara mengikut pilihan '%s' tidak dijangka."
 
-#: ../src/unix/fswatcher_inotify.cpp:274
+#: ../src/unix/fswatcher_inotify.cpp:271
 #, c-format
 msgid "Unexpected event for \"%s\": no matching watch descriptor."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1195
+#: ../src/common/cmdline.cpp:1191
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Parameter tidak dijangka '%s'"
@@ -7627,50 +7793,50 @@ msgstr "Parameter tidak dijangka '%s'"
 msgid "Unexpectedly new I/O completion port was created"
 msgstr ""
 
-#: ../src/msw/fswatcher.cpp:70
+#: ../src/msw/fswatcher.cpp:67
 #, fuzzy
 msgid "Ungraceful worker thread termination"
 msgstr "Tidak dapat menunggu benang ditamatkan"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:460
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:456
+#: ../src/richtext/richtextsymboldlg.cpp:457
+#: ../src/richtext/richtextsymboldlg.cpp:458
 msgid "Unicode"
 msgstr "Unikod"
 
-#: ../src/common/fmapbase.cpp:185 ../src/common/fmapbase.cpp:191
+#: ../src/common/fmapbase.cpp:182 ../src/common/fmapbase.cpp:188
 msgid "Unicode 16 bit (UTF-16)"
 msgstr "Unikod 16 bit (UTF-16)"
 
-#: ../src/common/fmapbase.cpp:190
+#: ../src/common/fmapbase.cpp:187
 msgid "Unicode 16 bit Big Endian (UTF-16BE)"
 msgstr "Unikod 16 bit Big Endian (UTF-16BE)"
 
-#: ../src/common/fmapbase.cpp:186
+#: ../src/common/fmapbase.cpp:183
 msgid "Unicode 16 bit Little Endian (UTF-16LE)"
 msgstr "Unikod 16 bit Little Endian (UTF-16LE)"
 
-#: ../src/common/fmapbase.cpp:187 ../src/common/fmapbase.cpp:193
+#: ../src/common/fmapbase.cpp:184 ../src/common/fmapbase.cpp:190
 msgid "Unicode 32 bit (UTF-32)"
 msgstr "Unikod 32 bit (UTF-32)"
 
-#: ../src/common/fmapbase.cpp:192
+#: ../src/common/fmapbase.cpp:189
 msgid "Unicode 32 bit Big Endian (UTF-32BE)"
 msgstr "Unikod 32 bit Big Endian (UTF-32BE)"
 
-#: ../src/common/fmapbase.cpp:188
+#: ../src/common/fmapbase.cpp:185
 msgid "Unicode 32 bit Little Endian (UTF-32LE)"
 msgstr "Unikod 32 bit Little Endian (UTF-32LE)"
 
-#: ../src/common/fmapbase.cpp:182
+#: ../src/common/fmapbase.cpp:179
 msgid "Unicode 7 bit (UTF-7)"
 msgstr "Unikod 7 bit (UTF-7)"
 
-#: ../src/common/fmapbase.cpp:183
+#: ../src/common/fmapbase.cpp:180
 msgid "Unicode 8 bit (UTF-8)"
 msgstr "Unikod 8 bit (UTF-8)"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 #, fuzzy
 msgid "Unindent"
 msgstr "Nyahjarak"
@@ -7832,100 +7998,105 @@ msgstr "Gagal menunggu penamatan benang."
 msgid "Units for this value."
 msgstr "Gagal menunggu penamatan benang."
 
-#: ../src/generic/progdlgg.cpp:353 ../src/generic/progdlgg.cpp:622
+#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
 msgid "Unknown"
 msgstr "Tidak Diketahui"
 
-#: ../src/msw/dde.cpp:1174
+#: ../src/msw/dde.cpp:1238
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Ralat DDE %08x tidak diketahui"
 
-#: ../src/common/xtistrm.cpp:410
+#: ../src/common/xtistrm.cpp:407
 msgid "Unknown Object passed to GetObjectClassInfo"
 msgstr "Objek Tidak Diketahui dilepaskan ke SetObjectClassInfo"
 
-#: ../src/common/imagpng.cpp:366
+#: ../src/common/imagpng.cpp:383
 #, fuzzy, c-format
 msgid "Unknown PNG resolution unit %d"
 msgstr "Pilihan '%s' tidak diketahui"
 
-#: ../src/common/xtixml.cpp:327
+#: ../src/common/xtixml.cpp:323
 #, fuzzy, c-format
 msgid "Unknown Property %s"
 msgstr "Milik Tidak Diketahui %s"
 
-#: ../src/common/imagtiff.cpp:529
+#: ../src/common/imagtiff.cpp:526
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr ""
 
-#: ../src/unix/dlunix.cpp:160
+#: ../src/propgrid/props.cpp:155
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/unix/dlunix.cpp:118
 msgid "Unknown dynamic library error"
 msgstr "Ralat pustaka dinamik tidak diketahui"
 
-#: ../src/common/fmapbase.cpp:810
+#: ../src/common/fmapbase.cpp:806
 #, c-format
 msgid "Unknown encoding (%d)"
 msgstr "Pengenkodan (%d) tidak diketahui"
 
-#: ../src/msw/ole/automtn.cpp:688
+#: ../src/msw/ole/automtn.cpp:679
 #, fuzzy, c-format
 msgid "Unknown error %08x"
 msgstr "Ralat DDE %08x tidak diketahui"
 
-#: ../src/msw/ole/automtn.cpp:647
+#: ../src/msw/ole/automtn.cpp:638
 #, fuzzy
 msgid "Unknown exception"
 msgstr "Pilihan '%s' tidak diketahui"
 
-#: ../src/common/image.cpp:2839
+#: ../src/common/image.cpp:2942
 #, fuzzy
 msgid "Unknown image data format."
 msgstr "ralat dalam format data"
 
-#: ../src/common/cmdline.cpp:914
+#: ../src/common/cmdline.cpp:910
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Pilihan panjang '%s' tidak diketahui"
 
-#: ../src/msw/ole/automtn.cpp:631
+#: ../src/msw/ole/automtn.cpp:622
 msgid "Unknown name or named argument."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:929 ../src/common/cmdline.cpp:951
+#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Pilihan '%s' tidak diketahui"
 
-#: ../src/common/mimecmn.cpp:225
+#: ../src/common/mimecmn.cpp:221
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "'{' tidak sepadan dalam masukan mime types %s."
 
-#: ../src/common/cmdproc.cpp:262 ../src/common/cmdproc.cpp:288
-#: ../src/common/cmdproc.cpp:308
+#: ../src/common/cmdproc.cpp:255 ../src/common/cmdproc.cpp:281
+#: ../src/common/cmdproc.cpp:301
 msgid "Unnamed command"
 msgstr "Arahan tidak bernama"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:413
+#: ../src/propgrid/propgrid.cpp:392
 #, fuzzy
 msgid "Unspecified"
 msgstr "Ditentu"
 
-#: ../src/msw/clipbrd.cpp:311
+#: ../src/msw/clipbrd.cpp:325
 msgid "Unsupported clipboard format."
 msgstr "Format klipbod tidak disokong."
 
-#: ../src/common/appcmn.cpp:256
+#: ../src/common/appcmn.cpp:277
 #, c-format
 msgid "Unsupported theme '%s'."
 msgstr "Tema tidak disokong '%s'."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:205
-#: ../src/common/accelcmn.cpp:63
+#: ../src/common/stockitem.cpp:202 ../src/common/accelcmn.cpp:60
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Up"
 msgstr "Naik"
 
@@ -7939,7 +8110,7 @@ msgstr "Huruf besar"
 msgid "Upper case roman numerals"
 msgstr "Nombor roman huruf besar"
 
-#: ../src/common/cmdline.cpp:1326
+#: ../src/common/cmdline.cpp:1322
 #, c-format
 msgid "Usage: %s"
 msgstr "Penggunaan: %s"
@@ -7948,38 +8119,47 @@ msgstr "Penggunaan: %s"
 msgid "Use &shadow"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:169
-#: ../src/richtext/richtextindentspage.cpp:171
 #: ../src/richtext/richtextliststylepage.cpp:358
 #: ../src/richtext/richtextliststylepage.cpp:360
+#: ../src/richtext/richtextindentspage.cpp:169
+#: ../src/richtext/richtextindentspage.cpp:171
 msgid "Use the current alignment setting."
 msgstr "Guna tetapan penjajaran semasa."
 
-#: ../src/common/valtext.cpp:179
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/gtk/font.cpp:552
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/common/valtext.cpp:142
 msgid "Validation conflict"
 msgstr "Konflik pengesahan"
 
-#: ../src/propgrid/manager.cpp:238
+#: ../src/propgrid/manager.cpp:224
 msgid "Value"
 msgstr ""
 
-#: ../src/propgrid/props.cpp:386 ../src/propgrid/props.cpp:500
+#: ../src/propgrid/props.cpp:309
 #, c-format
 msgid "Value must be %s or higher."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:417 ../src/propgrid/props.cpp:531
+#: ../src/propgrid/props.cpp:336
 #, c-format
 msgid "Value must be %s or less."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:393 ../src/propgrid/props.cpp:424
-#: ../src/propgrid/props.cpp:507 ../src/propgrid/props.cpp:538
+#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
 #, fuzzy, c-format
 msgid "Value must be between %s and %s."
 msgstr "Masukkan nombor laman antara %d dan %d:"
 
-#: ../src/generic/aboutdlgg.cpp:128
+#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
 #, fuzzy
 msgid "Version "
 msgstr "Versi"
@@ -7990,25 +8170,32 @@ msgstr "Versi"
 msgid "Vertical alignment."
 msgstr "Gagal mulakan mencetak."
 
-#: ../src/generic/filedlgg.cpp:202
+#: ../src/generic/filedlgg.cpp:199
 msgid "View files as a detailed view"
 msgstr "Lihat fail sebagai lihat perincian"
 
-#: ../src/generic/filedlgg.cpp:200
+#: ../src/generic/filedlgg.cpp:197
 msgid "View files as a list view"
 msgstr "Lihat fail sebagai senarai lihat"
 
-#: ../src/common/docview.cpp:1970
+#: ../src/common/docview.cpp:1975
 msgid "Views"
 msgstr "Pandangan"
 
+#: ../src/gtk/app.cpp:348
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1777
+#: ../src/propgrid/advprops.cpp:1678
 msgid "Wait"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1779
+#: ../src/propgrid/advprops.cpp:1680
 msgid "Wait Arrow"
 msgstr ""
 
@@ -8017,254 +8204,251 @@ msgstr ""
 msgid "Waiting for IO on epoll descriptor %d failed"
 msgstr "Gagal menunggu penamatan subproses"
 
-#: ../src/common/log.cpp:223
+#: ../src/common/log.cpp:241
 msgid "Warning: "
 msgstr "Amaran:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1778
+#: ../src/propgrid/advprops.cpp:1679
 msgid "Watch"
 msgstr ""
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:685
+#: ../src/propgrid/advprops.cpp:595
 #, fuzzy
 msgid "Weight"
 msgstr "Berat:"
 
-#: ../src/common/fmapbase.cpp:148
+#: ../src/common/fmapbase.cpp:145
 msgid "Western European (ISO-8859-1)"
 msgstr "Eropah Barat (ISO-8859-1)"
 
-#: ../src/common/fmapbase.cpp:162
+#: ../src/common/fmapbase.cpp:159
 msgid "Western European with Euro (ISO-8859-15)"
 msgstr "Eropah Barat dengan Euro (ISO-8859-15)"
 
-#: ../src/generic/fontdlgg.cpp:446 ../src/generic/fontdlgg.cpp:448
+#: ../src/generic/fontdlgg.cpp:443 ../src/generic/fontdlgg.cpp:445
 msgid "Whether the font is underlined."
 msgstr "Sama ada fon bergaris-bawah."
 
-#: ../src/propgrid/advprops.cpp:1611
+#: ../src/propgrid/advprops.cpp:1517
 msgid "White"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:144
+#: ../src/generic/fdrepdlg.cpp:141
 msgid "Whole word"
 msgstr "Seluruh perkataan"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:532
 msgid "Whole words only"
 msgstr "Seluruh perkataan sahaja"
 
-#: ../src/univ/themes/win32.cpp:1102
+#: ../src/univ/themes/win32.cpp:1099
 msgid "Win32 theme"
 msgstr "Tema Win32"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:893
+#: ../src/propgrid/advprops.cpp:794
 #, fuzzy
 msgid "Window"
 msgstr "&Tetingkap"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:894
+#: ../src/propgrid/advprops.cpp:795
 #, fuzzy
 msgid "WindowFrame"
 msgstr "&Tetingkap"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:895
+#: ../src/propgrid/advprops.cpp:796
 #, fuzzy
 msgid "WindowText"
 msgstr "&Tetingkap"
 
-#: ../src/common/fmapbase.cpp:177
+#: ../src/common/fmapbase.cpp:174
 msgid "Windows Arabic (CP 1256)"
 msgstr "Windows Arab (CP 1256)"
 
-#: ../src/common/fmapbase.cpp:178
+#: ../src/common/fmapbase.cpp:175
 msgid "Windows Baltic (CP 1257)"
 msgstr "Windows Baltik (CP 1257)"
 
-#: ../src/common/fmapbase.cpp:171
+#: ../src/common/fmapbase.cpp:168
 msgid "Windows Central European (CP 1250)"
 msgstr "Windows Eropah Tengah (CP 1250)"
 
-#: ../src/common/fmapbase.cpp:168
+#: ../src/common/fmapbase.cpp:165
 #, fuzzy
 msgid "Windows Chinese Simplified (CP 936) or GB-2312"
 msgstr "Windows China Dipermudah (CP 936)"
 
-#: ../src/common/fmapbase.cpp:170
+#: ../src/common/fmapbase.cpp:167
 #, fuzzy
 msgid "Windows Chinese Traditional (CP 950) or Big-5"
 msgstr "Windows China Tradisional (CP 950)"
 
-#: ../src/common/fmapbase.cpp:172
+#: ../src/common/fmapbase.cpp:169
 msgid "Windows Cyrillic (CP 1251)"
 msgstr "Windows Cyrillic (CP 1251)"
 
-#: ../src/common/fmapbase.cpp:174
+#: ../src/common/fmapbase.cpp:171
 msgid "Windows Greek (CP 1253)"
 msgstr "Windows Greek (CP 1253)"
 
-#: ../src/common/fmapbase.cpp:176
+#: ../src/common/fmapbase.cpp:173
 msgid "Windows Hebrew (CP 1255)"
 msgstr "Windows Hebrew (CP 1255)"
 
-#: ../src/common/fmapbase.cpp:167
+#: ../src/common/fmapbase.cpp:164
 #, fuzzy
 msgid "Windows Japanese (CP 932) or Shift-JIS"
 msgstr "Windows Japun (CP 932)"
 
-#: ../src/common/fmapbase.cpp:180
+#: ../src/common/fmapbase.cpp:177
 #, fuzzy
 msgid "Windows Johab (CP 1361)"
 msgstr "Windows Arab (CP 1256)"
 
-#: ../src/common/fmapbase.cpp:169
+#: ../src/common/fmapbase.cpp:166
 msgid "Windows Korean (CP 949)"
 msgstr "Windows Korea (CP 949)"
 
-#: ../src/common/fmapbase.cpp:166
+#: ../src/common/fmapbase.cpp:163
 msgid "Windows Thai (CP 874)"
 msgstr "Windows Thai (CP 874)"
 
-#: ../src/common/fmapbase.cpp:175
+#: ../src/common/fmapbase.cpp:172
 msgid "Windows Turkish (CP 1254)"
 msgstr "Windows Turki (CP 1254)"
 
-#: ../src/common/fmapbase.cpp:179
+#: ../src/common/fmapbase.cpp:176
 #, fuzzy
 msgid "Windows Vietnamese (CP 1258)"
 msgstr "Windows Greek (CP 1253)"
 
-#: ../src/common/fmapbase.cpp:173
+#: ../src/common/fmapbase.cpp:170
 msgid "Windows Western European (CP 1252)"
 msgstr "Windows Eropah Barat (CP 1252)"
 
-#: ../src/common/fmapbase.cpp:181
+#: ../src/common/fmapbase.cpp:178
 msgid "Windows/DOS OEM (CP 437)"
 msgstr "Windows/DOS OEM (CP 437)"
 
-#: ../src/common/fmapbase.cpp:165
+#: ../src/common/fmapbase.cpp:162
 #, fuzzy
 msgid "Windows/DOS OEM Cyrillic (CP 866)"
 msgstr "Windows Cyrillic (CP 1251)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:111
+#: ../src/common/accelcmn.cpp:109
 #, fuzzy
 msgid "Windows_Left"
 msgstr "Windows 95"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:113
+#: ../src/common/accelcmn.cpp:111
 #, fuzzy
 msgid "Windows_Menu"
 msgstr "Windows ME"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:112
+#: ../src/common/accelcmn.cpp:110
 #, fuzzy
 msgid "Windows_Right"
 msgstr "Windows 95"
 
-#: ../src/common/ffile.cpp:150
+#: ../src/common/ffile.cpp:149
 #, c-format
 msgid "Write error on file '%s'"
 msgstr "Ralat tulis fail '%s'"
 
-#: ../src/xml/xml.cpp:914
+#: ../src/xml/xml.cpp:925
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "Ralat menghurai XML: '%s' pada baris %d"
 
-#: ../src/common/xpmdecod.cpp:796
+#: ../src/common/xpmdecod.cpp:794
 msgid "XPM: Malformed pixel data!"
 msgstr "XPM: data piksel tidak berfungsi!"
 
-#: ../src/common/xpmdecod.cpp:705
+#: ../src/common/xpmdecod.cpp:702
 #, c-format
 msgid "XPM: incorrect colour description in line %d"
 msgstr "XPM: definisi warna tidak betul pada baris %d"
 
-#: ../src/common/xpmdecod.cpp:680
+#: ../src/common/xpmdecod.cpp:677
 msgid "XPM: incorrect header format!"
 msgstr "XPM: format kepala tidak betul!"
 
-#: ../src/common/xpmdecod.cpp:716 ../src/common/xpmdecod.cpp:725
+#: ../src/common/xpmdecod.cpp:714 ../src/common/xpmdecod.cpp:723
 #, c-format
 msgid "XPM: malformed colour definition '%s' at line %d!"
 msgstr "XPM: definisi warna tidak berfungsi '%s' pada baris %d!"
 
-#: ../src/common/xpmdecod.cpp:755
+#: ../src/common/xpmdecod.cpp:753
 #, fuzzy
 msgid "XPM: no colors left to use for mask!"
 msgstr "XPM: format kepala tidak betul!"
 
-#: ../src/common/xpmdecod.cpp:782
+#: ../src/common/xpmdecod.cpp:780
 #, c-format
 msgid "XPM: truncated image data at line %d!"
 msgstr "XPM: data imej dicantas pada baris %d!"
 
-#: ../src/propgrid/advprops.cpp:1610
+#: ../src/propgrid/advprops.cpp:1516
 msgid "Yellow"
 msgstr ""
 
-#: ../include/wx/msgdlg.h:276 ../src/common/stockitem.cpp:206
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:203
 #: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Ya"
 
-#: ../src/osx/carbon/overlay.cpp:155
-msgid "You cannot Clear an overlay that is not inited"
-msgstr "Anda tidak boleh Kosongkan lapisan yang tidak dimulakan"
-
-#: ../src/osx/carbon/overlay.cpp:107 ../src/dfb/overlay.cpp:61
-msgid "You cannot Init an overlay twice"
-msgstr "Anda tidak boleh Init lapisan dua kali"
-
-#: ../src/generic/dirdlgg.cpp:287
+#: ../src/generic/dirdlgg.cpp:284
 msgid "You cannot add a new directory to this section."
 msgstr "Anda tidak boleh menambah direktori baru pada seksyen ini."
 
-#: ../src/propgrid/propgrid.cpp:3299
+#: ../src/propgrid/propgrid.cpp:3276
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:209
+#: ../src/osx/cocoa/menu.mm:286
+#, fuzzy
+msgid "Zoom"
+msgstr "Zum Masuk"
+
+#: ../src/common/stockitem.cpp:206
 msgid "Zoom &In"
 msgstr "Zum Masuk"
 
-#: ../src/common/stockitem.cpp:210
+#: ../src/common/stockitem.cpp:207
 msgid "Zoom &Out"
 msgstr "Zum Keluar"
 
-#: ../src/common/stockitem.cpp:209 ../src/common/prntbase.cpp:1594
+#: ../src/common/stockitem.cpp:206 ../src/common/prntbase.cpp:1619
 #, fuzzy
 msgid "Zoom In"
 msgstr "Zum Masuk"
 
-#: ../src/common/stockitem.cpp:210 ../src/common/prntbase.cpp:1580
+#: ../src/common/stockitem.cpp:207 ../src/common/prntbase.cpp:1605
 #, fuzzy
 msgid "Zoom Out"
 msgstr "Zum Keluar"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to &Fit"
 msgstr "Zum Muat"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 #, fuzzy
 msgid "Zoom to Fit"
 msgstr "Zum Muat"
 
-#: ../src/msw/dde.cpp:1141
+#: ../src/msw/dde.cpp:1205
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "Aplikasi DDEML telah mencipta keadaan memanjangkan bangsa."
 
-#: ../src/msw/dde.cpp:1129
+#: ../src/msw/dde.cpp:1193
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -8276,39 +8460,39 @@ msgstr ""
 "atau pengenal contoh tidak sah\n"
 "telah dilepaskan kepada fungsi DDEML."
 
-#: ../src/msw/dde.cpp:1147
+#: ../src/msw/dde.cpp:1211
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "klien mencuba untuk mendirikan perbualan tetapi gagal."
 
-#: ../src/msw/dde.cpp:1144
+#: ../src/msw/dde.cpp:1208
 msgid "a memory allocation failed."
 msgstr "memori gagal ditempatkan."
 
-#: ../src/msw/dde.cpp:1138
+#: ../src/msw/dde.cpp:1202
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "parameter gagal disahkan oleh DDEML."
 
-#: ../src/msw/dde.cpp:1120
+#: ../src/msw/dde.cpp:1184
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "permintaan untuk transaksi menyegerakkan nasihat telah tamat tempoh."
 
-#: ../src/msw/dde.cpp:1126
+#: ../src/msw/dde.cpp:1190
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "permintaan untuk transaksi menyegerakkan data telah tamat tempoh."
 
-#: ../src/msw/dde.cpp:1135
+#: ../src/msw/dde.cpp:1199
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "permintaan untuk transaksi menyegerakkan laksana telah tamat tempoh."
 
-#: ../src/msw/dde.cpp:1153
+#: ../src/msw/dde.cpp:1217
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "permintaan untuk transaksi menyegerakkan penebuk telah tamat tempoh."
 
-#: ../src/msw/dde.cpp:1168
+#: ../src/msw/dde.cpp:1232
 msgid "a request to end an advise transaction has timed out."
 msgstr "permintaan untuk menamatkan transaksi nasihat telah tamat tempoh."
 
-#: ../src/msw/dde.cpp:1162
+#: ../src/msw/dde.cpp:1226
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -8318,15 +8502,15 @@ msgstr ""
 "yang telah ditamatkan oleh klien, atau pelayan\n"
 "ditamatkan sebelum menyudahkan transaksi."
 
-#: ../src/msw/dde.cpp:1150
+#: ../src/msw/dde.cpp:1214
 msgid "a transaction failed."
 msgstr "transaksi gagal."
 
-#: ../src/common/accelcmn.cpp:189
+#: ../src/common/accelcmn.cpp:188
 msgid "alt"
 msgstr "alt"
 
-#: ../src/msw/dde.cpp:1132
+#: ../src/msw/dde.cpp:1196
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -8338,15 +8522,15 @@ msgstr ""
 "aplikasi dimulakan sebagai APPCMD_CLIENTONLY telah\n"
 "berusaha melakukan transaksi pelayan."
 
-#: ../src/msw/dde.cpp:1156
+#: ../src/msw/dde.cpp:1220
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "panggilan dalaman kepada fungsi PostMessage gagal."
 
-#: ../src/msw/dde.cpp:1165
+#: ../src/msw/dde.cpp:1229
 msgid "an internal error has occurred in the DDEML."
 msgstr "ralat dalaman telah berlaku dalam DDEML."
 
-#: ../src/msw/dde.cpp:1171
+#: ../src/msw/dde.cpp:1235
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -8356,56 +8540,56 @@ msgstr ""
 "Sekali aplikasi telah dipulangkan kepada panggil-balik XTYP_XACT_COMPLETE,\n"
 "pengenal transaksi untuk panggil-balik tidak lagi sah."
 
-#: ../src/common/zipstrm.cpp:1483
+#: ../src/common/zipstrm.cpp:1522
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "mengandaikan yang ini adalah cantuman banyak-bahagian zip"
 
-#: ../src/common/fileconf.cpp:1847
+#: ../src/common/fileconf.cpp:1849
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "Cubaan mengubah kunci tidak boleh disenyapkan '%s' diabaikan."
 
-#: ../src/html/chm.cpp:329
+#: ../src/html/chm.cpp:326
 msgid "bad arguments to library function"
 msgstr "argumen buruk kepada fungsi pustaka"
 
-#: ../src/html/chm.cpp:341
+#: ../src/html/chm.cpp:338
 msgid "bad signature"
 msgstr "tandatangan rosak"
 
-#: ../src/common/zipstrm.cpp:1918
+#: ../src/common/zipstrm.cpp:1988
 msgid "bad zipfile offset to entry"
 msgstr "offset fail zip kepada masukan rosak"
 
-#: ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400
 msgid "binary"
 msgstr "binari"
 
-#: ../src/common/fontcmn.cpp:996
+#: ../src/common/fontcmn.cpp:1195
 msgid "bold"
 msgstr "bold"
 
-#: ../src/msw/utils.cpp:1144
+#: ../src/msw/utils.cpp:1135
 #, fuzzy, c-format
 msgid "build %lu"
 msgstr "Windows XP (build %lu"
 
-#: ../src/common/ffile.cpp:75
+#: ../src/common/ffile.cpp:73
 #, c-format
 msgid "can't close file '%s'"
 msgstr "gagal menutup dail '%s'"
 
-#: ../src/common/file.cpp:245
+#: ../src/common/file.cpp:242
 #, c-format
 msgid "can't close file descriptor %d"
 msgstr "gagal tutup penghurai fail %d"
 
-#: ../src/common/file.cpp:586
+#: ../src/common/ffile.cpp:382 ../src/common/file.cpp:613
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "Gagal lakukan perubahan kepada fail '%s'"
 
-#: ../src/common/file.cpp:178
+#: ../src/common/file.cpp:175
 #, c-format
 msgid "can't create file '%s'"
 msgstr "gagal mencipta fail '%s'"
@@ -8415,49 +8599,49 @@ msgstr "gagal mencipta fail '%s'"
 msgid "can't delete user configuration file '%s'"
 msgstr "gagal memadam fail konfigurasi pengguna '%s'"
 
-#: ../src/common/file.cpp:495
+#: ../src/common/file.cpp:522
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr "Gagal ditentukan jika EOF dicapai pada penghurai %d"
 
-#: ../src/common/zipstrm.cpp:1692
+#: ../src/common/zipstrm.cpp:1747
 msgid "can't find central directory in zip"
 msgstr "gagal menemui direktori pusat salam zip"
 
-#: ../src/common/file.cpp:465
+#: ../src/common/file.cpp:492
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "gagal menemui panjang fail pada penghurai fail %d"
 
-#: ../src/msw/utils.cpp:341
+#: ../src/msw/utils.cpp:336
 msgid "can't find user's HOME, using current directory."
 msgstr "Gagal mencari RUMAH pengguna, gunakan direktori semasa."
 
-#: ../src/common/file.cpp:366
+#: ../src/common/file.cpp:407
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "gagal mengeluarkan penghurai fail %d"
 
-#: ../src/common/file.cpp:422
+#: ../src/common/file.cpp:463
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "Gagal menemui posisi pada fail penghurai %d"
 
-#: ../src/common/fontmap.cpp:325
+#: ../src/common/fontmap.cpp:322
 msgid "can't load any font, aborting"
 msgstr "gagal memuat sebarang fon, menggugurkan"
 
-#: ../src/common/file.cpp:231 ../src/common/ffile.cpp:59
+#: ../src/common/ffile.cpp:57 ../src/common/file.cpp:228
 #, c-format
 msgid "can't open file '%s'"
 msgstr "gagal membuka fail '%s'"
 
-#: ../src/common/fileconf.cpp:320
+#: ../src/common/fileconf.cpp:314
 #, c-format
 msgid "can't open global configuration file '%s'."
 msgstr "gagal membuka fail konfigurasi global '%s'."
 
-#: ../src/common/fileconf.cpp:336
+#: ../src/common/fileconf.cpp:330
 #, c-format
 msgid "can't open user configuration file '%s'."
 msgstr "gagal membuka fail konfigurasi pengguna '%s'."
@@ -8466,40 +8650,40 @@ msgstr "gagal membuka fail konfigurasi pengguna '%s'."
 msgid "can't open user configuration file."
 msgstr "gagal membuka fail konfigurasi pengguna."
 
-#: ../src/common/zipstrm.cpp:579
+#: ../src/common/zipstrm.cpp:572
 msgid "can't re-initialize zlib deflate stream"
 msgstr "Gagal memulakan semula strim zlib kempis"
 
-#: ../src/common/zipstrm.cpp:604
+#: ../src/common/zipstrm.cpp:597
 msgid "can't re-initialize zlib inflate stream"
 msgstr "Gagal memulakan semula strim zlib kembong"
 
-#: ../src/common/file.cpp:304
+#: ../src/common/file.cpp:345
 #, c-format
 msgid "can't read from file descriptor %d"
 msgstr "gagal membaca dari penghurai fail %d"
 
-#: ../src/common/file.cpp:581
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:608
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "gagal membuang fail '%s'"
 
-#: ../src/common/file.cpp:598
+#: ../src/common/ffile.cpp:394 ../src/common/file.cpp:625
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "gagal membuang fail sementara '%s'"
 
-#: ../src/common/file.cpp:408
+#: ../src/common/file.cpp:449
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "gagal menemui penghurai fail %d"
 
-#: ../src/common/textfile.cpp:273
+#: ../src/common/textfile.cpp:161
 #, c-format
 msgid "can't write buffer '%s' to disk."
 msgstr "gagal menulis penimbal '%s' kepada cakera."
 
-#: ../src/common/file.cpp:323
+#: ../src/common/file.cpp:364
 #, c-format
 msgid "can't write to file descriptor %d"
 msgstr "gagal menulis kepada penghurai %d"
@@ -8509,22 +8693,28 @@ msgid "can't write user configuration file."
 msgstr "gagal menulis fail konfigurasi pengguna."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:482 ../src/generic/datavgen.cpp:1261
+#: ../src/common/datavcmn.cpp:2064 ../src/generic/datavgen.cpp:1384
 msgid "checked"
 msgstr ""
 
-#: ../src/html/chm.cpp:345
+#: ../src/html/chm.cpp:342
 msgid "checksum error"
 msgstr "ralat checksum"
 
-#: ../src/common/tarstrm.cpp:820
+#: ../src/common/tarstrm.cpp:814
 msgid "checksum failure reading tar header block"
 msgstr "uji-jumlah gagal membaca blok kepala tar"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:226
-#: ../src/richtext/richtextbackgroundpage.cpp:249
-#: ../src/richtext/richtextbackgroundpage.cpp:289
-#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
 #: ../src/richtext/richtextborderspage.cpp:254
 #: ../src/richtext/richtextborderspage.cpp:288
 #: ../src/richtext/richtextborderspage.cpp:322
@@ -8542,105 +8732,128 @@ msgstr "uji-jumlah gagal membaca blok kepala tar"
 #: ../src/richtext/richtextmarginspage.cpp:340
 #: ../src/richtext/richtextmarginspage.cpp:363
 #: ../src/richtext/richtextmarginspage.cpp:388
-#: ../src/richtext/richtextsizepage.cpp:339
-#: ../src/richtext/richtextsizepage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:400
-#: ../src/richtext/richtextsizepage.cpp:427
-#: ../src/richtext/richtextsizepage.cpp:454
-#: ../src/richtext/richtextsizepage.cpp:481
-#: ../src/richtext/richtextsizepage.cpp:555
-#: ../src/richtext/richtextsizepage.cpp:590
-#: ../src/richtext/richtextsizepage.cpp:625
-#: ../src/richtext/richtextsizepage.cpp:660
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
 msgid "cm"
 msgstr ""
 
-#: ../src/html/chm.cpp:347
+#: ../src/html/chm.cpp:344
 msgid "compression error"
 msgstr "ralat mampatan"
 
-#: ../src/common/regex.cpp:236
+#: ../src/common/regex.cpp:233
 msgid "conversion to 8-bit encoding failed"
 msgstr "penukaran kepada pengenkod 8-bit gagal"
 
-#: ../src/common/accelcmn.cpp:187
+#: ../src/common/accelcmn.cpp:186
 msgid "ctrl"
 msgstr "ctrl"
 
-#: ../src/common/cmdline.cpp:1500
+#: ../src/common/cmdline.cpp:1496
 msgid "date"
 msgstr "tarikh"
 
-#: ../src/html/chm.cpp:349
+#: ../src/html/chm.cpp:346
 msgid "decompression error"
 msgstr "ralat nyahmampat"
 
-#: ../src/richtext/richtextstyles.cpp:780 ../src/common/fmapbase.cpp:820
+#: ../src/common/fmapbase.cpp:816 ../src/richtext/richtextstyles.cpp:777
 msgid "default"
 msgstr "lalai"
 
-#: ../src/common/cmdline.cpp:1496
+#: ../src/common/cmdline.cpp:1492
 msgid "double"
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:538
+#: ../src/common/debugrpt.cpp:539
 msgid "dump of the process state (binary)"
 msgstr "buang keadaan prosess (binari)"
 
-#: ../src/common/datetimefmt.cpp:1969
+#: ../src/common/datetimefmt.cpp:1992
 msgid "eighteenth"
 msgstr "kelapan belas"
 
-#: ../src/common/datetimefmt.cpp:1959
+#: ../src/common/datetimefmt.cpp:1982
 msgid "eighth"
 msgstr "kelapan"
 
-#: ../src/common/datetimefmt.cpp:1962
+#: ../src/common/datetimefmt.cpp:1985
 msgid "eleventh"
 msgstr "kesebelas"
 
-#: ../src/common/fileconf.cpp:1833
+#: ../src/common/fileconf.cpp:1835
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "masukan '%s' dipaparkan lebih dari sekali dalam kumpulan '%s'"
 
-#: ../src/html/chm.cpp:343
+#: ../src/html/chm.cpp:340
 msgid "error in data format"
 msgstr "ralat dalam format data"
 
-#: ../src/html/chm.cpp:331
+#: ../src/html/chm.cpp:328
 msgid "error opening file"
 msgstr "ralat membuka fail"
 
-#: ../src/common/zipstrm.cpp:1778
+#: ../src/common/zipstrm.cpp:1836
 msgid "error reading zip central directory"
 msgstr "ralat membaca direktori pusat zip"
 
-#: ../src/common/zipstrm.cpp:1870
+#: ../src/common/zipstrm.cpp:1940
 msgid "error reading zip local header"
 msgstr "ralat membaca kepala lokal zip"
 
-#: ../src/common/zipstrm.cpp:2531
+#: ../src/common/zipstrm.cpp:2615
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "gagal menulis masukan zip '%s': crc atau panjang rosak"
 
-#: ../src/common/ffile.cpp:188
+#: ../src/common/zipstrm.cpp:2608
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "gagal menulis masukan zip '%s': crc atau panjang rosak"
+
+#: ../src/common/fontcmn.cpp:1205
+#, fuzzy
+msgid "extrabold"
+msgstr "bold"
+
+#: ../src/common/fontcmn.cpp:1223
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1167
+#, fuzzy
+msgid "extralight"
+msgstr "ringan"
+
+#: ../src/msw/webview_ie.cpp:1036
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "Gagal melaksanakan '%s'\n"
+
+#: ../src/common/ffile.cpp:187
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "gagal menyegarkan fail '%s'"
 
+#: ../src/msw/webview_ie.cpp:1045
+#, fuzzy
+msgid "failed to retrieve execution result"
+msgstr "Gagal mendapatkan teks mesej ralat RAS"
+
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1030
+#: ../src/generic/datavgen.cpp:1150
 #, fuzzy
 msgid "false"
 msgstr "Fail"
 
-#: ../src/common/datetimefmt.cpp:1966
+#: ../src/common/datetimefmt.cpp:1989
 msgid "fifteenth"
 msgstr "kelima belas"
 
-#: ../src/common/datetimefmt.cpp:1956
+#: ../src/common/datetimefmt.cpp:1979
 msgid "fifth"
 msgstr "kelima"
 
@@ -8669,132 +8882,151 @@ msgstr "fail '%s', baris %d: nilai untuk nilai tetap '%s' diabaikan."
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "fail '%s': aksara %c tidak dijangka pada baris %d."
 
-#: ../src/richtext/richtextbuffer.cpp:8738
+#: ../src/richtext/richtextbuffer.cpp:8736
 msgid "files"
 msgstr "fail"
 
-#: ../src/common/datetimefmt.cpp:1952
+#: ../src/common/datetimefmt.cpp:1975
 msgid "first"
 msgstr "pertama"
 
-#: ../src/html/helpwnd.cpp:1252
+#: ../src/html/helpwnd.cpp:1250
 msgid "font size"
 msgstr "Saiz Fon"
 
-#: ../src/common/datetimefmt.cpp:1965
+#: ../src/common/datetimefmt.cpp:1988
 msgid "fourteenth"
 msgstr "keempat belas"
 
-#: ../src/common/datetimefmt.cpp:1955
+#: ../src/common/datetimefmt.cpp:1978
 msgid "fourth"
 msgstr "keempat"
 
-#: ../src/common/appbase.cpp:783
+#: ../src/common/appbase.cpp:784
 msgid "generate verbose log messages"
 msgstr "menjana mesej log meleret"
 
-#: ../src/richtext/richtextbuffer.cpp:13138
-#: ../src/richtext/richtextbuffer.cpp:13248
+#: ../src/common/fontcmn.cpp:1215
+msgid "heavy"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:13133
+#: ../src/richtext/richtextbuffer.cpp:13243
 msgid "image"
 msgstr "imej"
 
-#: ../src/common/tarstrm.cpp:796
+#: ../src/common/tarstrm.cpp:790
 msgid "incomplete header block in tar"
 msgstr "blok kepala tidak lengkap dalam tar"
 
-#: ../src/common/xtixml.cpp:489
+#: ../src/common/xtixml.cpp:485
 msgid "incorrect event handler string, missing dot"
 msgstr "rentetan pengemudi peristiwa salah, hilang titik"
 
-#: ../src/common/tarstrm.cpp:1381
+#: ../src/common/tarstrm.cpp:1375
 msgid "incorrect size given for tar entry"
 msgstr "saiz diberi tidak betul untuk masukan tar"
 
-#: ../src/common/tarstrm.cpp:993
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:987
 msgid "invalid data in extended tar header"
 msgstr "data tidak sah dalam kepala tar diperpanjang"
 
-#: ../src/generic/logg.cpp:1030
+#: ../src/generic/logg.cpp:1027
 msgid "invalid message box return value"
 msgstr "nilai kembali kotak mesej tidak sah"
 
-#: ../src/common/zipstrm.cpp:1647
+#: ../src/common/zipstrm.cpp:1688
 msgid "invalid zip file"
 msgstr "fail zip tidak sah"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:1228
 msgid "italic"
 msgstr "italik"
 
-#: ../src/common/fontcmn.cpp:991
+#: ../src/common/webrequest_curl.cpp:374
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "Fail gagal dimuatkan."
+
+#: ../src/common/fontcmn.cpp:1172
 msgid "light"
 msgstr "ringan"
 
-#: ../src/common/intl.cpp:303
-#, c-format
-msgid "locale '%s' cannot be set."
-msgstr "locale '%s' Gagal ditetapkan."
+#: ../src/common/fontcmn.cpp:1185
+msgid "medium"
+msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2125
+#: ../src/common/datetimefmt.cpp:2148
 msgid "midnight"
 msgstr "tengah malam"
 
-#: ../src/common/datetimefmt.cpp:1970
+#: ../src/common/datetimefmt.cpp:1993
 msgid "nineteenth"
 msgstr "kesembilan belas"
 
-#: ../src/common/datetimefmt.cpp:1960
+#: ../src/common/datetimefmt.cpp:1983
 msgid "ninth"
 msgstr "kesembilan"
 
-#: ../src/msw/dde.cpp:1116
+#: ../src/msw/dde.cpp:1180
 msgid "no DDE error."
 msgstr "tiada ralat DDE."
 
-#: ../src/html/chm.cpp:327
+#: ../src/html/chm.cpp:324
 msgid "no error"
 msgstr "tiada ralat"
 
-#: ../src/dfb/fontmgr.cpp:174
+#: ../src/dfb/fontmgr.cpp:171
 #, c-format
 msgid "no fonts found in %s, using builtin font"
 msgstr ""
 
-#: ../src/html/helpdata.cpp:657
+#: ../src/html/helpdata.cpp:650
 msgid "noname"
 msgstr "tiada nama"
 
-#: ../src/common/datetimefmt.cpp:2124
+#: ../src/common/datetimefmt.cpp:2147
 msgid "noon"
 msgstr "tengahari"
 
-#: ../src/richtext/richtextstyles.cpp:779
+#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
 #, fuzzy
 msgid "normal"
 msgstr "Normal"
 
-#: ../src/common/cmdline.cpp:1492
+#: ../src/common/cmdline.cpp:1488
 msgid "num"
 msgstr "nom"
 
-#: ../src/common/xtixml.cpp:259
+#: ../src/common/accelcmn.cpp:194
+msgid "num "
+msgstr ""
+
+#: ../src/common/xtixml.cpp:255
 msgid "objects cannot have XML Text Nodes"
 msgstr "objek tidak boleh mempunyai Nod Teks XML"
 
-#: ../src/html/chm.cpp:339
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
 msgid "out of memory"
 msgstr "luar lingkungan memori"
 
-#: ../src/common/debugrpt.cpp:514
+#: ../src/common/debugrpt.cpp:515
 msgid "process context description"
 msgstr "huraian proses konteks"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:227
-#: ../src/richtext/richtextbackgroundpage.cpp:250
-#: ../src/richtext/richtextbackgroundpage.cpp:290
-#: ../src/richtext/richtextbackgroundpage.cpp:317
-#: ../src/richtext/richtextfontpage.cpp:177
-#: ../src/richtext/richtextfontpage.cpp:180
 #: ../src/richtext/richtextborderspage.cpp:255
 #: ../src/richtext/richtextborderspage.cpp:289
 #: ../src/richtext/richtextborderspage.cpp:323
@@ -8804,22 +9036,45 @@ msgstr "huraian proses konteks"
 #: ../src/richtext/richtextborderspage.cpp:491
 #: ../src/richtext/richtextborderspage.cpp:525
 #: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextfontpage.cpp:180
 msgid "pt"
 msgstr ""
 
-#: ../src/richtext/richtextbackgroundpage.cpp:225
-#: ../src/richtext/richtextbackgroundpage.cpp:228
-#: ../src/richtext/richtextbackgroundpage.cpp:229
-#: ../src/richtext/richtextbackgroundpage.cpp:248
-#: ../src/richtext/richtextbackgroundpage.cpp:251
-#: ../src/richtext/richtextbackgroundpage.cpp:252
-#: ../src/richtext/richtextbackgroundpage.cpp:288
-#: ../src/richtext/richtextbackgroundpage.cpp:291
-#: ../src/richtext/richtextbackgroundpage.cpp:292
-#: ../src/richtext/richtextbackgroundpage.cpp:315
-#: ../src/richtext/richtextbackgroundpage.cpp:318
-#: ../src/richtext/richtextbackgroundpage.cpp:319
-#: ../src/richtext/richtextfontpage.cpp:178
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:659
+#: ../src/richtext/richtextsizepage.cpp:662
+#: ../src/richtext/richtextsizepage.cpp:663
 #: ../src/richtext/richtextborderspage.cpp:253
 #: ../src/richtext/richtextborderspage.cpp:256
 #: ../src/richtext/richtextborderspage.cpp:257
@@ -8871,263 +9126,273 @@ msgstr ""
 #: ../src/richtext/richtextmarginspage.cpp:387
 #: ../src/richtext/richtextmarginspage.cpp:389
 #: ../src/richtext/richtextmarginspage.cpp:390
-#: ../src/richtext/richtextsizepage.cpp:338
-#: ../src/richtext/richtextsizepage.cpp:341
-#: ../src/richtext/richtextsizepage.cpp:342
-#: ../src/richtext/richtextsizepage.cpp:372
-#: ../src/richtext/richtextsizepage.cpp:375
-#: ../src/richtext/richtextsizepage.cpp:376
-#: ../src/richtext/richtextsizepage.cpp:399
-#: ../src/richtext/richtextsizepage.cpp:402
-#: ../src/richtext/richtextsizepage.cpp:403
-#: ../src/richtext/richtextsizepage.cpp:426
-#: ../src/richtext/richtextsizepage.cpp:429
-#: ../src/richtext/richtextsizepage.cpp:430
-#: ../src/richtext/richtextsizepage.cpp:453
-#: ../src/richtext/richtextsizepage.cpp:456
-#: ../src/richtext/richtextsizepage.cpp:457
-#: ../src/richtext/richtextsizepage.cpp:480
-#: ../src/richtext/richtextsizepage.cpp:483
-#: ../src/richtext/richtextsizepage.cpp:484
-#: ../src/richtext/richtextsizepage.cpp:554
-#: ../src/richtext/richtextsizepage.cpp:557
-#: ../src/richtext/richtextsizepage.cpp:558
-#: ../src/richtext/richtextsizepage.cpp:589
-#: ../src/richtext/richtextsizepage.cpp:592
-#: ../src/richtext/richtextsizepage.cpp:593
-#: ../src/richtext/richtextsizepage.cpp:624
-#: ../src/richtext/richtextsizepage.cpp:627
-#: ../src/richtext/richtextsizepage.cpp:628
-#: ../src/richtext/richtextsizepage.cpp:659
-#: ../src/richtext/richtextsizepage.cpp:662
-#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextfontpage.cpp:178
 msgid "px"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:193
+#: ../src/common/accelcmn.cpp:192
 #, fuzzy
 msgid "rawctrl"
 msgstr "ctrl"
 
-#: ../src/html/chm.cpp:333
+#: ../src/html/chm.cpp:330
 msgid "read error"
 msgstr "ralat baca"
 
-#: ../src/common/zipstrm.cpp:2085
+#: ../src/common/zipstrm.cpp:2155
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "membaca strim zip (masukan %s): crc buruk"
 
-#: ../src/common/zipstrm.cpp:2080
+#: ../src/common/zipstrm.cpp:2150
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "membaca strim zip (masukan %s): panjang buruk"
 
-#: ../src/msw/dde.cpp:1159
+#: ../src/msw/dde.cpp:1223
 msgid "reentrancy problem."
 msgstr "masalah kemassukan"
 
-#: ../src/common/datetimefmt.cpp:1953
+#: ../src/common/datetimefmt.cpp:1976
 msgid "second"
 msgstr "kedua"
 
-#: ../src/html/chm.cpp:337
+#: ../src/html/chm.cpp:334
 msgid "seek error"
 msgstr "ralat mencari"
 
-#: ../src/common/datetimefmt.cpp:1968
+#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#, fuzzy
+msgid "semibold"
+msgstr "bold"
+
+#: ../src/common/datetimefmt.cpp:1991
 msgid "seventeenth"
 msgstr "ketujuh belas"
 
-#: ../src/common/datetimefmt.cpp:1958
+#: ../src/common/datetimefmt.cpp:1981
 msgid "seventh"
 msgstr "ketujuh"
 
-#: ../src/common/accelcmn.cpp:191
+#: ../src/common/accelcmn.cpp:190
 msgid "shift"
 msgstr "shif"
 
-#: ../src/common/appbase.cpp:773
+#: ../src/common/appbase.cpp:774
 msgid "show this help message"
 msgstr "tunjukkan mesej bantuan ini"
 
-#: ../src/common/datetimefmt.cpp:1967
+#: ../src/common/datetimefmt.cpp:1990
 msgid "sixteenth"
 msgstr "keenam belas"
 
-#: ../src/common/datetimefmt.cpp:1957
+#: ../src/common/datetimefmt.cpp:1980
 msgid "sixth"
 msgstr "keenam"
 
-#: ../src/common/appcmn.cpp:234
+#: ../src/common/appcmn.cpp:255
 msgid "specify display mode to use (e.g. 640x480-16)"
 msgstr "tentukan mod paparan untuk diguna (cth. 640x480-16)"
 
-#: ../src/common/appcmn.cpp:220
+#: ../src/common/appcmn.cpp:241
 msgid "specify the theme to use"
 msgstr "pastikan tema untuk diguna"
 
-#: ../src/richtext/richtextbuffer.cpp:9340
+#: ../src/richtext/richtextbuffer.cpp:9337
 #, fuzzy
 msgid "standard/circle"
 msgstr "Piawai"
 
-#: ../src/richtext/richtextbuffer.cpp:9341
+#: ../src/richtext/richtextbuffer.cpp:9338
 msgid "standard/circle-outline"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9343
+#: ../src/richtext/richtextbuffer.cpp:9340
 msgid "standard/diamond"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9342
+#: ../src/richtext/richtextbuffer.cpp:9339
 #, fuzzy
 msgid "standard/square"
 msgstr "Piawai"
 
-#: ../src/richtext/richtextbuffer.cpp:9344
+#: ../src/richtext/richtextbuffer.cpp:9341
 msgid "standard/triangle"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1985
+#: ../src/common/zipstrm.cpp:2055
 msgid "stored file length not in Zip header"
 msgstr "panjang fail disimpan tidak dalam kepala Zip"
 
-#: ../src/common/cmdline.cpp:1488
+#: ../src/common/cmdline.cpp:1484
 msgid "str"
 msgstr "str"
 
-#: ../src/common/fontcmn.cpp:982
+#: ../src/common/fontcmn.cpp:1145
 msgid "strikethrough"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:1003 ../src/common/tarstrm.cpp:1025
-#: ../src/common/tarstrm.cpp:1507 ../src/common/tarstrm.cpp:1529
+#: ../src/common/tarstrm.cpp:997 ../src/common/tarstrm.cpp:1019
+#: ../src/common/tarstrm.cpp:1501 ../src/common/tarstrm.cpp:1523
 msgid "tar entry not open"
 msgstr "masukan tar tidak dibuka"
 
-#: ../src/common/datetimefmt.cpp:1961
+#: ../src/common/datetimefmt.cpp:1984
 msgid "tenth"
 msgstr "kesepuluh"
 
-#: ../src/msw/dde.cpp:1123
+#: ../src/msw/dde.cpp:1187
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "tindak balas kepada transaksi menyebabkan bit DDE_FBUSY ditetapkan."
 
-#: ../src/common/datetimefmt.cpp:1954
+#: ../src/common/fontcmn.cpp:1154
+msgid "thin"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:1977
 msgid "third"
 msgstr "ketiga"
 
-#: ../src/common/datetimefmt.cpp:1964
+#: ../src/common/datetimefmt.cpp:1987
 msgid "thirteenth"
 msgstr "ketiga belas"
 
-#: ../src/common/datetimefmt.cpp:1758
+#: ../src/common/datetimefmt.cpp:1781
 msgid "today"
 msgstr "hari ini"
 
-#: ../src/common/datetimefmt.cpp:1760
+#: ../src/common/datetimefmt.cpp:1783
 msgid "tomorrow"
 msgstr "esok"
 
-#: ../src/common/fileconf.cpp:1944
+#: ../src/common/fileconf.cpp:1946
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr ""
 
-#: ../src/gtk/aboutdlg.cpp:218
+#: ../src/gtk/aboutdlg.cpp:216
 msgid "translator-credits"
 msgstr "Mahrazi Mohd Kamal <mahrazi@gmail.com>, 2006."
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1028
+#: ../src/generic/datavgen.cpp:1148
 msgid "true"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1963
+#: ../src/common/datetimefmt.cpp:1986
 msgid "twelfth"
 msgstr "kedua belas"
 
-#: ../src/common/datetimefmt.cpp:1971
+#: ../src/common/datetimefmt.cpp:1994
 msgid "twentieth"
 msgstr "keduua puluh"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:486 ../src/generic/datavgen.cpp:1263
+#: ../src/common/datavcmn.cpp:2068 ../src/generic/datavgen.cpp:1386
 msgid "unchecked"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:802 ../src/common/fontcmn.cpp:978
+#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
 msgid "underlined"
 msgstr "digaris bawahkan"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:490
+#: ../src/common/datavcmn.cpp:2072
 #, fuzzy
 msgid "undetermined"
 msgstr "digaris bawahkan"
 
-#: ../src/common/fileconf.cpp:1979
+#: ../src/common/fileconf.cpp:1981
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "\" tidak dijangka pada posisi %d dalam '%s'."
 
-#: ../src/common/tarstrm.cpp:1045
+#: ../src/common/tarstrm.cpp:1039
 msgid "unexpected end of file"
 msgstr "akhir fail tidak dijangka"
 
-#: ../src/generic/progdlgg.cpp:370 ../src/common/tarstrm.cpp:371
-#: ../src/common/tarstrm.cpp:394 ../src/common/tarstrm.cpp:425
+#: ../src/common/tarstrm.cpp:366 ../src/common/tarstrm.cpp:389
+#: ../src/common/tarstrm.cpp:420 ../src/generic/progdlgg.cpp:376
 msgid "unknown"
 msgstr "tidak diketahui"
 
-#: ../src/msw/registry.cpp:150
+#: ../src/msw/registry.cpp:139
 #, fuzzy, c-format
 msgid "unknown (%lu)"
 msgstr "tidak diketahui"
 
-#: ../src/common/xtixml.cpp:253
+#: ../src/common/xtixml.cpp:249
 #, c-format
 msgid "unknown class %s"
 msgstr "kelas %s tidak diketahui"
 
-#: ../src/common/regex.cpp:258 ../src/html/chm.cpp:351
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "ralat mampatan"
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "ralat nyahmampat"
+
+#: ../src/common/regex.cpp:255 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "ralat tidak diketahui"
 
-#: ../src/msw/dialup.cpp:471
+#: ../src/msw/dialup.cpp:465
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "ralat tidak diketahui (kod ralat %08x)."
 
-#: ../src/common/fmapbase.cpp:834
+#: ../src/common/fmapbase.cpp:830
 #, c-format
 msgid "unknown-%d"
 msgstr "tidak diketahui-%d"
 
-#: ../src/common/docview.cpp:509
+#: ../src/common/docview.cpp:502
 msgid "unnamed"
 msgstr "tanpanama"
 
-#: ../src/common/docview.cpp:1624
+#: ../src/common/docview.cpp:1618
 #, c-format
 msgid "unnamed%d"
 msgstr "tanpanama%d"
 
-#: ../src/common/zipstrm.cpp:1999 ../src/common/zipstrm.cpp:2319
+#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
 msgid "unsupported Zip compression method"
 msgstr "Mesej mampatan Zip tidak disokong"
 
-#: ../src/common/translation.cpp:1892
+#: ../src/common/translation.cpp:1942
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "guna katalog '%s' dari '%s'."
 
-#: ../src/html/chm.cpp:335
+#: ../src/html/chm.cpp:332
 msgid "write error"
 msgstr "ralat tulis"
 
-#: ../src/common/time.cpp:292
+#: ../src/gtk/glcanvas.cpp:187
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/common/time.cpp:285
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay gagal."
 
@@ -9140,15 +9405,15 @@ msgstr "wxWidgets Gagal membuka paparan '%s': keluar."
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets Gagal membuka paparan. Keluar."
 
-#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:431
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/common/datetimefmt.cpp:1759
+#: ../src/common/datetimefmt.cpp:1782
 msgid "yesterday"
 msgstr "semalam"
 
-#: ../src/common/zstream.cpp:251 ../src/common/zstream.cpp:426
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
 #, c-format
 msgid "zlib error %d"
 msgstr "Ralat zlib %d"
@@ -9159,8 +9424,74 @@ msgid "~"
 msgstr "~"
 
 #, fuzzy
-#~ msgid "Column could not be added."
-#~ msgstr "Fail gagal dimuatkan."
+#~ msgid "&Save as"
+#~ msgstr "Simpan Sebagai"
+
+#, fuzzy
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' sepatutnya mengandungi aksara abjab sahaja."
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' sepatutnya nombor."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' sepatutnya mengandungi aksara ASCII sahaja."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' sepatutnya mengandungi aksara abjab sahaja."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' hanya patut mengandungi aksara abjab atau nombor."
+
+#, fuzzy
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' sepatutnya mengandungi aksara ASCII sahaja."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "Gagal mencipta tetingkap kelas %s"
+
+#, fuzzy
+#~ msgid "Could not initalize libnotify."
+#~ msgstr "Gagal mulakan mencetak."
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "Gagal mencipta tetingkap lapisan"
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "Gagal memulakan konteks pada tetingkap lapisan"
+
+#, fuzzy
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "Gagal menukar kadungan failkepada Unikod."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "Gagal menetapkan teks dalam kawalan teks."
+
+#~ msgid "No unused colour in image."
+#~ msgstr "Tiada warna yang tidak digunakan dalam imej."
+
+#, fuzzy
+#~ msgid "Not available"
+#~ msgstr "Tiada kemudahan XBM wujud!"
+
+#~ msgid "Replace selection"
+#~ msgstr "Ganti pilihan"
+
+#, fuzzy
+#~ msgid "Save as"
+#~ msgstr "Simpan Sebagai"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Gaya Pengatur"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "Anda tidak boleh Kosongkan lapisan yang tidak dimulakan"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "Anda tidak boleh Init lapisan dua kali"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "locale '%s' Gagal ditetapkan."
 
 #, fuzzy
 #~ msgid "Column index not found."
@@ -9386,10 +9717,6 @@ msgstr "~"
 
 #~ msgid "unknown seek origin"
 #~ msgstr "carian asal tidak diketahui"
-
-#, fuzzy
-#~ msgid "wxWidget's control not initialized."
-#~ msgstr "Gagal mulakan paparan."
 
 #~ msgid "ADD"
 #~ msgstr "ADD"
@@ -9647,9 +9974,6 @@ msgstr "~"
 #~ msgid "Directory '%s' doesn't exist!"
 #~ msgstr "Direktori '%s tidak wujud!"
 
-#~ msgid "File %s does not exist."
-#~ msgstr "Fail %s tidak wujud."
-
 #~ msgid "Mode %ix%i-%i not available."
 #~ msgstr "Mode %ix%i-%i tidak wujud."
 
@@ -9740,9 +10064,6 @@ msgstr "~"
 
 #~ msgid "Failed to register OpenGL window class."
 #~ msgstr "Gagal daftarkan kelas tingkap OpenGL."
-
-#~ msgid "Fatal error"
-#~ msgstr "Ralat maut"
 
 #~ msgid "Fatal error: "
 #~ msgstr "Ralat maut: "
@@ -9925,9 +10246,6 @@ msgstr "~"
 
 #~ msgid "&Print"
 #~ msgstr "Cetak"
-
-#~ msgid "*** A debug report has been generated\n"
-#~ msgstr "*** Laporan nyahpijat telah dijana\n"
 
 #~ msgid "*** It can be found in \"%s\"\n"
 #~ msgstr "*** Ia boleh ditemui dalam \"%s\"\n"

--- a/locale/nb.po
+++ b/locale/nb.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-21 14:25+0200\n"
+"POT-Creation-Date: 2020-10-18 23:11+0300\n"
 "PO-Revision-Date: 2015-10-27 22:33+0100\n"
 "Last-Translator: Hans Fredrik Nordhaug <hans@nordhaug.priv.no>\n"
 "Language-Team: Norwegian Bokmål <i18n-nb@lister.ping.uio.no>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 1.7.5\n"
 
-#: ../src/common/debugrpt.cpp:586
+#: ../src/common/debugrpt.cpp:587
 msgid ""
 "\n"
 "Please send this report to the program maintainer, thank you!\n"
@@ -25,8 +25,8 @@ msgstr ""
 "\n"
 "Send denne rapporten til vedlikeholderen av programmet. På forhånd takk.\n"
 
-#: ../src/richtext/richtextstyledlg.cpp:210
-#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:206
+#: ../src/richtext/richtextstyledlg.cpp:218
 msgid " "
 msgstr "  "
 
@@ -34,73 +34,99 @@ msgstr "  "
 msgid "              Thank you and we're sorry for the inconvenience!\n"
 msgstr "              Takk skal du ha og vi beklager bryet!\n"
 
-#: ../src/common/prntbase.cpp:573
+#: ../src/common/prntbase.cpp:568
 #, fuzzy, c-format
 msgid " (copy %d of %d)"
 msgstr "Side %d av %d"
 
-#: ../src/common/log.cpp:421
+#: ../src/common/log.cpp:440
 #, c-format
 msgid " (error %ld: %s)"
 msgstr "(feil %ld: %s)"
 
-#: ../src/common/imagtiff.cpp:72
+#: ../src/common/imagtiff.cpp:69
 #, fuzzy, c-format
 msgid " (in module \"%s\")"
 msgstr "TIFF-modul: %s"
 
-#: ../src/osx/core/secretstore.cpp:138
-msgid " (while overwriting an existing item)"
-msgstr ""
-
-#: ../src/common/docview.cpp:1642
+#: ../src/common/docview.cpp:1636
 msgid " - "
 msgstr " - "
 
-#: ../src/richtext/richtextprint.cpp:593 ../src/html/htmprint.cpp:714
+#: ../src/html/htmprint.cpp:712 ../src/richtext/richtextprint.cpp:589
 msgid " Preview"
 msgstr "Forhåndsvisning"
 
-#: ../src/common/fontcmn.cpp:824
+#: ../src/common/fontcmn.cpp:973
 #, fuzzy
 msgid " bold"
 msgstr "fet"
 
-#: ../src/common/fontcmn.cpp:840
+#: ../src/common/fontcmn.cpp:977
+#, fuzzy
+msgid " extra bold"
+msgstr "fet"
+
+#: ../src/common/fontcmn.cpp:985
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:957
+#, fuzzy
+msgid " extra light"
+msgstr "lett"
+
+#: ../src/common/fontcmn.cpp:981
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1001
 #, fuzzy
 msgid " italic"
 msgstr "kursiv"
 
-#: ../src/common/fontcmn.cpp:820
+#: ../src/common/fontcmn.cpp:961
 #, fuzzy
 msgid " light"
 msgstr "lett"
 
-#: ../src/common/fontcmn.cpp:807
+#: ../src/common/fontcmn.cpp:965
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:969
+#, fuzzy
+msgid " semi bold"
+msgstr "fet"
+
+#: ../src/common/fontcmn.cpp:940
 msgid " strikethrough"
 msgstr "streke over"
 
-#: ../src/common/paper.cpp:117
+#: ../src/common/fontcmn.cpp:953
+msgid " thin"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
 msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
 msgstr "#10 konvolutt, 4 1/8 x 9 1/2 tommer"
 
-#: ../src/common/paper.cpp:118
+#: ../src/common/paper.cpp:115
 msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
 msgstr "#11 konvolutt, 4 1/2 x 10 3/8 tommer"
 
-#: ../src/common/paper.cpp:119
+#: ../src/common/paper.cpp:116
 msgid "#12 Envelope, 4 3/4 x 11 in"
 msgstr "#12 konvolutt, 4 3/3 x 11 tommer"
 
-#: ../src/common/paper.cpp:120
+#: ../src/common/paper.cpp:117
 msgid "#14 Envelope, 5 x 11 1/2 in"
 msgstr "#14 konvolutt, 5 x 11 1/2 tommer"
 
-#: ../src/common/paper.cpp:116
+#: ../src/common/paper.cpp:113
 msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
 msgstr "#9 konvolutt, 3 7/8 x 8 7/8 tommer"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:341
 #: ../src/richtext/richtextsizepage.cpp:340
 #: ../src/richtext/richtextsizepage.cpp:374
 #: ../src/richtext/richtextsizepage.cpp:401
@@ -111,81 +137,82 @@ msgstr "#9 konvolutt, 3 7/8 x 8 7/8 tommer"
 #: ../src/richtext/richtextsizepage.cpp:591
 #: ../src/richtext/richtextsizepage.cpp:626
 #: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextbackgroundpage.cpp:341
 msgid "%"
 msgstr "%"
 
-#: ../src/html/helpwnd.cpp:1031
+#: ../src/html/helpwnd.cpp:1029
 #, fuzzy, c-format
 msgid "%d of %lu"
 msgstr "%i av %i"
 
-#: ../src/html/helpwnd.cpp:1678
+#: ../src/html/helpwnd.cpp:1676
 #, fuzzy, c-format
 msgid "%i of %u"
 msgstr "%i av %i"
 
-#: ../src/generic/filectrlg.cpp:279
+#: ../src/generic/filectrlg.cpp:275
 #, fuzzy, c-format
 msgid "%ld byte"
 msgid_plural "%ld bytes"
 msgstr[0] "%ld byte"
 msgstr[1] "%ld byte"
 
-#: ../src/html/helpwnd.cpp:1033
+#: ../src/html/helpwnd.cpp:1031
 #, fuzzy, c-format
 msgid "%lu of %lu"
 msgstr "%i av %i"
 
-#: ../src/generic/datavgen.cpp:6028
+#: ../src/generic/datavgen.cpp:6833
 #, fuzzy, c-format
 msgid "%s (%d items)"
 msgstr "%s (eller %s)"
 
-#: ../src/common/cmdline.cpp:1221
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (eller %s)"
 
-#: ../src/generic/logg.cpp:224
+#: ../src/generic/logg.cpp:221
 #, c-format
 msgid "%s Error"
 msgstr "%s Feil"
 
-#: ../src/generic/logg.cpp:236
+#: ../src/generic/logg.cpp:233
 #, c-format
 msgid "%s Information"
 msgstr "%s Informasjon"
 
-#: ../src/generic/preferencesg.cpp:113
+#: ../src/generic/preferencesg.cpp:110
 #, fuzzy, c-format
 msgid "%s Preferences"
 msgstr "&Innstillinger"
 
-#: ../src/generic/logg.cpp:228
+#: ../src/generic/logg.cpp:225
 #, c-format
 msgid "%s Warning"
 msgstr "%s Advarsel"
 
-#: ../src/common/tarstrm.cpp:1319
+#: ../src/common/tarstrm.cpp:1313
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s passet ikke med tar- hodet for innslag '%s'"
 
-#: ../src/common/fldlgcmn.cpp:124
+#: ../src/common/fldlgcmn.cpp:121
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s filer (%s)|%s"
 
-#: ../src/html/helpwnd.cpp:1716
+#: ../src/html/helpwnd.cpp:1714
 #, fuzzy, c-format
 msgid "%u of %u"
 msgstr "%i av %i"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "&About"
 msgstr "%Om"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "&Actual Size"
 msgstr "&Faktisk størrelse"
 
@@ -193,30 +220,30 @@ msgstr "&Faktisk størrelse"
 msgid "&After a paragraph:"
 msgstr "&Etter et avsnitt:"
 
-#: ../src/richtext/richtextindentspage.cpp:128
 #: ../src/richtext/richtextliststylepage.cpp:319
+#: ../src/richtext/richtextindentspage.cpp:128
 #, fuzzy
 msgid "&Alignment"
 msgstr "Venstrejustering"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "&Apply"
 msgstr "&Bruk"
 
-#: ../src/richtext/richtextstyledlg.cpp:251
+#: ../src/richtext/richtextstyledlg.cpp:247
 #, fuzzy
 msgid "&Apply Style"
 msgstr "&Bruk"
 
-#: ../src/msw/mdi.cpp:179
+#: ../src/msw/mdi.cpp:174
 msgid "&Arrange Icons"
 msgstr "&Still opp ikoner"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "&Ascending"
 msgstr "&Stigende"
 
-#: ../src/common/stockitem.cpp:142
+#: ../src/common/stockitem.cpp:139
 msgid "&Back"
 msgstr "&Tilbake"
 
@@ -237,24 +264,24 @@ msgstr "&Farge"
 msgid "&Blur distance:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:143
+#: ../src/common/stockitem.cpp:140
 msgid "&Bold"
 msgstr "&Fet"
 
-#: ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141
 msgid "&Bottom"
 msgstr "&Bunn"
 
+#: ../src/richtext/richtextsizepage.cpp:637
+#: ../src/richtext/richtextsizepage.cpp:644
 #: ../src/richtext/richtextborderspage.cpp:345
 #: ../src/richtext/richtextborderspage.cpp:513
 #: ../src/richtext/richtextmarginspage.cpp:259
 #: ../src/richtext/richtextmarginspage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:637
-#: ../src/richtext/richtextsizepage.cpp:644
 msgid "&Bottom:"
 msgstr "&Bunn:"
 
-#: ../include/wx/richtext/richtextbuffer.h:3866
+#: ../include/wx/richtext/richtextbuffer.h:3861
 #, fuzzy
 msgid "&Box"
 msgstr "&Fet"
@@ -264,39 +291,39 @@ msgstr "&Fet"
 msgid "&Bullet style:"
 msgstr "&Punktstil:"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "&CD-Rom"
 msgstr ""
 
-#: ../src/generic/wizard.cpp:434 ../src/generic/fontdlgg.cpp:470
-#: ../src/generic/fontdlgg.cpp:489 ../src/osx/carbon/fontdlg.cpp:402
-#: ../src/common/dlgcmn.cpp:279 ../src/common/stockitem.cpp:145
+#: ../src/osx/carbon/fontdlg.cpp:399 ../src/common/stockitem.cpp:142
+#: ../src/generic/wizard.cpp:433 ../src/generic/fontdlgg.cpp:466
+#: ../src/generic/fontdlgg.cpp:485 ../src/osx/cocoa/button.mm:200
 msgid "&Cancel"
 msgstr "&Avbryt"
 
-#: ../src/msw/mdi.cpp:175
+#: ../src/msw/mdi.cpp:170
 msgid "&Cascade"
 msgstr "&Kaskade"
 
-#: ../include/wx/richtext/richtextbuffer.h:5960
+#: ../include/wx/richtext/richtextbuffer.h:5955
 #, fuzzy
 msgid "&Cell"
 msgstr "&Avbryt"
 
-#: ../src/richtext/richtextsymboldlg.cpp:439
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "&Character code:"
 msgstr "&Tegnkode:"
 
-#: ../src/common/stockitem.cpp:147
+#: ../src/common/stockitem.cpp:144
 msgid "&Clear"
 msgstr "&Fjern"
 
-#: ../src/generic/logg.cpp:516 ../src/common/stockitem.cpp:148
-#: ../src/common/prntbase.cpp:1600 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/stockitem.cpp:145 ../src/common/prntbase.cpp:1625
+#: ../src/univ/themes/win32.cpp:3753 ../src/generic/logg.cpp:513
 msgid "&Close"
 msgstr "&Lukk"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 #, fuzzy
 msgid "&Color"
 msgstr "&Farge"
@@ -306,22 +333,22 @@ msgstr "&Farge"
 msgid "&Colour:"
 msgstr "&Farge"
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 #, fuzzy
 msgid "&Convert"
 msgstr "Innhold"
 
-#: ../src/richtext/richtextctrl.cpp:333 ../src/osx/textctrl_osx.cpp:577
-#: ../src/common/stockitem.cpp:150 ../src/msw/textctrl.cpp:2508
+#: ../src/osx/textctrl_osx.cpp:595 ../src/common/stockitem.cpp:147
+#: ../src/msw/textctrl.cpp:2773 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Kopier"
 
-#: ../src/generic/hyperlinkg.cpp:156
+#: ../src/generic/hyperlinkg.cpp:153
 #, fuzzy
 msgid "&Copy URL"
 msgstr "&Kopier"
 
-#: ../src/common/headerctrlcmn.cpp:306
+#: ../src/common/headerctrlcmn.cpp:304
 #, fuzzy
 msgid "&Customize..."
 msgstr "skriftstørrelse"
@@ -330,55 +357,56 @@ msgstr "skriftstørrelse"
 msgid "&Debug report preview:"
 msgstr "&Forhåndsvisning av feilsøkingsrapport"
 
-#: ../src/richtext/richtexttabspage.cpp:138
-#: ../src/richtext/richtextctrl.cpp:335 ../src/osx/textctrl_osx.cpp:579
-#: ../src/common/stockitem.cpp:152 ../src/msw/textctrl.cpp:2510
+#: ../src/osx/textctrl_osx.cpp:597 ../src/common/stockitem.cpp:149
+#: ../src/msw/textctrl.cpp:2775 ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtextctrl.cpp:334
 msgid "&Delete"
 msgstr "&Slett"
 
-#: ../src/richtext/richtextstyledlg.cpp:269
+#: ../src/richtext/richtextstyledlg.cpp:265
 #, fuzzy
 msgid "&Delete Style..."
 msgstr "Slett element"
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "&Descending"
 msgstr "&Synkende"
 
-#: ../src/generic/logg.cpp:682
+#: ../src/generic/logg.cpp:679
 msgid "&Details"
 msgstr "&detaljer"
 
-#: ../src/common/stockitem.cpp:153
+#: ../src/common/stockitem.cpp:150
 msgid "&Down"
 msgstr "&ned"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "&Edit"
 msgstr "&Rediger"
 
-#: ../src/richtext/richtextstyledlg.cpp:263
+#: ../src/richtext/richtextstyledlg.cpp:259
 #, fuzzy
 msgid "&Edit Style..."
 msgstr "Redigere element"
 
-#: ../src/common/stockitem.cpp:155
+#: ../src/common/stockitem.cpp:152
 msgid "&Execute"
 msgstr "&Utfør"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/common/stockitem.cpp:154
 msgid "&File"
 msgstr "&Fil"
 
-#: ../src/common/stockitem.cpp:158
-msgid "&Find"
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "&Find..."
 msgstr "&Finn"
 
-#: ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:430
 msgid "&Finish"
 msgstr "&Fullfør"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:156
 #, fuzzy
 msgid "&First"
 msgstr "først"
@@ -387,17 +415,17 @@ msgstr "først"
 msgid "&Floating mode:"
 msgstr "&Flytende modus:"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 #, fuzzy
 msgid "&Floppy"
 msgstr "&Kopier"
 
-#: ../src/common/stockitem.cpp:194
+#: ../src/common/stockitem.cpp:191
 #, fuzzy
 msgid "&Font"
 msgstr "&Skriftfamilie:"
 
-#: ../src/generic/fontdlgg.cpp:371
+#: ../src/generic/fontdlgg.cpp:367
 msgid "&Font family:"
 msgstr "&Skriftfamilie:"
 
@@ -405,22 +433,22 @@ msgstr "&Skriftfamilie:"
 msgid "&Font for Level..."
 msgstr "&Font for nivå..."
 
+#: ../src/richtext/richtextsymboldlg.cpp:397
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:400
 #, fuzzy
 msgid "&Font:"
 msgstr "&Skriftfamilie:"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "&Forward"
 msgstr "&Fremover"
 
-#: ../src/richtext/richtextsymboldlg.cpp:451
+#: ../src/richtext/richtextsymboldlg.cpp:448
 #, fuzzy
 msgid "&From:"
 msgstr "Fra:"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "&Harddisk"
 msgstr ""
 
@@ -430,9 +458,9 @@ msgstr ""
 msgid "&Height:"
 msgstr "&Vekt:"
 
-#: ../src/generic/wizard.cpp:441 ../src/richtext/richtextstyledlg.cpp:303
-#: ../src/richtext/richtextsymboldlg.cpp:479 ../src/osx/menu_osx.cpp:734
-#: ../src/common/stockitem.cpp:163
+#: ../src/common/stockitem.cpp:160 ../src/generic/wizard.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextstyledlg.cpp:299 ../src/osx/cocoa/menu.mm:226
 msgid "&Help"
 msgstr "&Hjelp"
 
@@ -441,7 +469,7 @@ msgstr "&Hjelp"
 msgid "&Hide details"
 msgstr "&detaljer"
 
-#: ../src/common/stockitem.cpp:164
+#: ../src/common/stockitem.cpp:161
 msgid "&Home"
 msgstr "&Hjem"
 
@@ -449,58 +477,58 @@ msgstr "&Hjem"
 msgid "&Horizontal offset:"
 msgstr "&Horisontal offset:"
 
-#: ../src/richtext/richtextindentspage.cpp:184
 #: ../src/richtext/richtextliststylepage.cpp:372
+#: ../src/richtext/richtextindentspage.cpp:184
 msgid "&Indentation (tenths of a mm)"
 msgstr "&Innrykk (1/10 mm)"
 
-#: ../src/richtext/richtextindentspage.cpp:167
 #: ../src/richtext/richtextliststylepage.cpp:356
+#: ../src/richtext/richtextindentspage.cpp:167
 #, fuzzy
 msgid "&Indeterminate"
 msgstr "&Strek under"
 
-#: ../src/common/stockitem.cpp:166
+#: ../src/common/stockitem.cpp:163
 msgid "&Index"
 msgstr "&Indeks"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 #, fuzzy
 msgid "&Info"
 msgstr "&Angre"
 
-#: ../src/common/stockitem.cpp:168
+#: ../src/common/stockitem.cpp:165
 msgid "&Italic"
 msgstr "&Kursiv"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "&Jump to"
 msgstr "&Hopp til"
 
-#: ../src/richtext/richtextindentspage.cpp:153
 #: ../src/richtext/richtextliststylepage.cpp:342
+#: ../src/richtext/richtextindentspage.cpp:153
 #, fuzzy
 msgid "&Justified"
 msgstr "Justert"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 #, fuzzy
 msgid "&Last"
 msgstr "&Lim inn"
 
-#: ../src/richtext/richtextindentspage.cpp:139
 #: ../src/richtext/richtextliststylepage.cpp:328
+#: ../src/richtext/richtextindentspage.cpp:139
 msgid "&Left"
 msgstr "&Venstre"
 
-#: ../src/richtext/richtextindentspage.cpp:195
+#: ../src/richtext/richtextsizepage.cpp:532
+#: ../src/richtext/richtextsizepage.cpp:539
 #: ../src/richtext/richtextborderspage.cpp:243
 #: ../src/richtext/richtextborderspage.cpp:411
 #: ../src/richtext/richtextliststylepage.cpp:381
+#: ../src/richtext/richtextindentspage.cpp:195
 #: ../src/richtext/richtextmarginspage.cpp:186
 #: ../src/richtext/richtextmarginspage.cpp:300
-#: ../src/richtext/richtextsizepage.cpp:532
-#: ../src/richtext/richtextsizepage.cpp:539
 msgid "&Left:"
 msgstr "&Venstre:"
 
@@ -508,11 +536,11 @@ msgstr "&Venstre:"
 msgid "&List level:"
 msgstr "&Listenivå:"
 
-#: ../src/generic/logg.cpp:517
+#: ../src/generic/logg.cpp:514
 msgid "&Log"
 msgstr "&Logg"
 
-#: ../src/univ/themes/win32.cpp:3748
+#: ../src/univ/themes/win32.cpp:3745
 msgid "&Move"
 msgstr "&Flytt"
 
@@ -520,21 +548,20 @@ msgstr "&Flytt"
 msgid "&Move the object to:"
 msgstr "&Flytt objekt til:"
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 #, fuzzy
 msgid "&Network"
 msgstr "&Ny"
 
-#: ../src/richtext/richtexttabspage.cpp:132 ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173 ../src/richtext/richtexttabspage.cpp:132
 msgid "&New"
 msgstr "&Ny"
 
-#: ../src/aui/tabmdi.cpp:111 ../src/generic/mdig.cpp:100
-#: ../src/msw/mdi.cpp:180
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
 msgid "&Next"
 msgstr "&Neste"
 
-#: ../src/generic/wizard.cpp:432 ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:429
 msgid "&Next >"
 msgstr "&Neste >"
 
@@ -542,7 +569,7 @@ msgstr "&Neste >"
 msgid "&Next Paragraph"
 msgstr "&Neste avsnitt"
 
-#: ../src/generic/tipdlg.cpp:240
+#: ../src/generic/tipdlg.cpp:237
 msgid "&Next Tip"
 msgstr "&Neste tips"
 
@@ -551,11 +578,11 @@ msgstr "&Neste tips"
 msgid "&Next style:"
 msgstr "&Neste >"
 
-#: ../src/common/stockitem.cpp:177 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:174 ../src/msw/msgdlg.cpp:435
 msgid "&No"
 msgstr "&Nei"
 
-#: ../src/generic/dbgrptg.cpp:356
+#: ../src/generic/dbgrptg.cpp:360
 msgid "&Notes:"
 msgstr "&Notater:"
 
@@ -563,12 +590,12 @@ msgstr "&Notater:"
 msgid "&Number:"
 msgstr "&Tall:"
 
-#: ../src/generic/fontdlgg.cpp:475 ../src/generic/fontdlgg.cpp:482
-#: ../src/osx/carbon/fontdlg.cpp:408 ../src/common/stockitem.cpp:178
+#: ../src/osx/carbon/fontdlg.cpp:405 ../src/common/stockitem.cpp:175
+#: ../src/generic/fontdlgg.cpp:471 ../src/generic/fontdlgg.cpp:478
 msgid "&OK"
 msgstr "&OK"
 
-#: ../src/generic/dbgrptg.cpp:342 ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176 ../src/generic/dbgrptg.cpp:342
 msgid "&Open..."
 msgstr "&Åpne..."
 
@@ -580,16 +607,16 @@ msgstr "&Disposisjonsnivå"
 msgid "&Page Break"
 msgstr "&Ny side"
 
-#: ../src/richtext/richtextctrl.cpp:334 ../src/osx/textctrl_osx.cpp:578
-#: ../src/common/stockitem.cpp:180 ../src/msw/textctrl.cpp:2509
+#: ../src/osx/textctrl_osx.cpp:596 ../src/common/stockitem.cpp:177
+#: ../src/msw/textctrl.cpp:2774 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&Lim inn"
 
-#: ../include/wx/richtext/richtextbuffer.h:5010
+#: ../include/wx/richtext/richtextbuffer.h:5005
 msgid "&Picture"
 msgstr "&Bilde"
 
-#: ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:419
 msgid "&Point size:"
 msgstr "&Punktstørrelse"
 
@@ -602,12 +629,11 @@ msgstr "&Posisjon(1/10 mm)"
 msgid "&Position mode:"
 msgstr "Spørsmål"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178
 msgid "&Preferences"
 msgstr "&Innstillinger"
 
-#: ../src/aui/tabmdi.cpp:112 ../src/generic/mdig.cpp:101
-#: ../src/msw/mdi.cpp:181
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
 msgid "&Previous"
 msgstr "&Forrige"
 
@@ -616,82 +642,77 @@ msgstr "&Forrige"
 msgid "&Previous Paragraph"
 msgstr "Forrige side"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "&Print..."
 msgstr "&Skriv ut..."
 
-#: ../src/richtext/richtextctrl.cpp:339 ../src/richtext/richtextctrl.cpp:5514
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtextctrl.cpp:338
+#: ../src/richtext/richtextctrl.cpp:5512
 msgid "&Properties"
 msgstr "&Egenskaper"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "&Quit"
 msgstr "&Slutt"
 
-#: ../src/richtext/richtextctrl.cpp:330 ../src/osx/textctrl_osx.cpp:574
-#: ../src/common/stockitem.cpp:185 ../src/common/cmdproc.cpp:293
-#: ../src/common/cmdproc.cpp:300 ../src/msw/textctrl.cpp:2505
+#: ../src/osx/textctrl_osx.cpp:592 ../src/common/stockitem.cpp:182
+#: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
+#: ../src/msw/textctrl.cpp:2770 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Gjenta"
 
-#: ../src/common/cmdproc.cpp:289 ../src/common/cmdproc.cpp:309
+#: ../src/common/cmdproc.cpp:282 ../src/common/cmdproc.cpp:302
 msgid "&Redo "
 msgstr "&Gjenta"
 
-#: ../src/richtext/richtextstyledlg.cpp:257
+#: ../src/richtext/richtextstyledlg.cpp:253
 msgid "&Rename Style..."
 msgstr "&Døp om Stil..."
 
-#: ../src/generic/fdrepdlg.cpp:179
+#: ../src/generic/fdrepdlg.cpp:176
 msgid "&Replace"
 msgstr "&Erstatt"
 
-#: ../src/richtext/richtextstyledlg.cpp:287
+#: ../src/richtext/richtextstyledlg.cpp:283
 msgid "&Restart numbering"
 msgstr "&Gjenstart nummerering"
 
-#: ../src/univ/themes/win32.cpp:3747
+#: ../src/univ/themes/win32.cpp:3744
 msgid "&Restore"
 msgstr "&Gjenopprett"
 
-#: ../src/richtext/richtextindentspage.cpp:146
 #: ../src/richtext/richtextliststylepage.cpp:335
+#: ../src/richtext/richtextindentspage.cpp:146
 #, fuzzy
 msgid "&Right"
 msgstr "Lett"
 
-#: ../src/richtext/richtextindentspage.cpp:213
+#: ../src/richtext/richtextsizepage.cpp:602
+#: ../src/richtext/richtextsizepage.cpp:609
 #: ../src/richtext/richtextborderspage.cpp:277
 #: ../src/richtext/richtextborderspage.cpp:445
 #: ../src/richtext/richtextliststylepage.cpp:399
+#: ../src/richtext/richtextindentspage.cpp:213
 #: ../src/richtext/richtextmarginspage.cpp:211
 #: ../src/richtext/richtextmarginspage.cpp:325
-#: ../src/richtext/richtextsizepage.cpp:602
-#: ../src/richtext/richtextsizepage.cpp:609
 #, fuzzy
 msgid "&Right:"
 msgstr "&Vekt:"
 
-#: ../src/common/stockitem.cpp:190
+#: ../src/common/stockitem.cpp:187
 msgid "&Save"
 msgstr "&Lagre"
-
-#: ../src/common/stockitem.cpp:191
-#, fuzzy
-msgid "&Save as"
-msgstr "Lagre Som"
 
 #: ../include/wx/richmsgdlg.h:29
 #, fuzzy
 msgid "&See details"
 msgstr "&detaljer"
 
-#: ../src/generic/tipdlg.cpp:236
+#: ../src/generic/tipdlg.cpp:233
 msgid "&Show tips at startup"
 msgstr "&Vis tips ved oppstart"
 
-#: ../src/univ/themes/win32.cpp:3750
+#: ../src/univ/themes/win32.cpp:3747
 msgid "&Size"
 msgstr "&Størrelse"
 
@@ -700,38 +721,38 @@ msgstr "&Størrelse"
 msgid "&Size:"
 msgstr "&Størrelse"
 
-#: ../src/generic/progdlgg.cpp:252
+#: ../src/generic/progdlgg.cpp:249
 #, fuzzy
 msgid "&Skip"
 msgstr "Hopp over"
 
-#: ../src/richtext/richtextindentspage.cpp:242
 #: ../src/richtext/richtextliststylepage.cpp:417
+#: ../src/richtext/richtextindentspage.cpp:242
 msgid "&Spacing (tenths of a mm)"
 msgstr "&Avstand (1/10 mm)"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "&Spell Check"
 msgstr "&Stavekontroll"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "&Stop"
 msgstr "&Stopp"
 
-#: ../src/richtext/richtextfontpage.cpp:275 ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196 ../src/richtext/richtextfontpage.cpp:275
 msgid "&Strikethrough"
 msgstr "&Streke over"
 
-#: ../src/generic/fontdlgg.cpp:382 ../src/richtext/richtextstylepage.cpp:106
+#: ../src/generic/fontdlgg.cpp:378 ../src/richtext/richtextstylepage.cpp:106
 msgid "&Style:"
 msgstr "&Stil:"
 
-#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:194
 #, fuzzy
 msgid "&Styles:"
 msgstr "&Stil:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:413
+#: ../src/richtext/richtextsymboldlg.cpp:410
 msgid "&Subset:"
 msgstr "&Undergruppe:"
 
@@ -746,26 +767,26 @@ msgstr "&Stil:"
 msgid "&Synchronize values"
 msgstr "&Synkroniser verdier"
 
-#: ../include/wx/richtext/richtextbuffer.h:6069
+#: ../include/wx/richtext/richtextbuffer.h:6064
 msgid "&Table"
 msgstr "&Tabell"
 
-#: ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197
 #, fuzzy
 msgid "&Top"
 msgstr "&Kopier"
 
+#: ../src/richtext/richtextsizepage.cpp:567
+#: ../src/richtext/richtextsizepage.cpp:574
 #: ../src/richtext/richtextborderspage.cpp:311
 #: ../src/richtext/richtextborderspage.cpp:479
 #: ../src/richtext/richtextmarginspage.cpp:234
 #: ../src/richtext/richtextmarginspage.cpp:348
-#: ../src/richtext/richtextsizepage.cpp:567
-#: ../src/richtext/richtextsizepage.cpp:574
 #, fuzzy
 msgid "&Top:"
 msgstr "Til:"
 
-#: ../src/generic/fontdlgg.cpp:444 ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199 ../src/generic/fontdlgg.cpp:441
 msgid "&Underline"
 msgstr "&Strek under"
 
@@ -774,21 +795,21 @@ msgstr "&Strek under"
 msgid "&Underlining:"
 msgstr "&Strek under"
 
-#: ../src/richtext/richtextctrl.cpp:329 ../src/osx/textctrl_osx.cpp:573
-#: ../src/common/stockitem.cpp:203 ../src/common/cmdproc.cpp:271
-#: ../src/msw/textctrl.cpp:2504
+#: ../src/osx/textctrl_osx.cpp:591 ../src/common/stockitem.cpp:200
+#: ../src/common/cmdproc.cpp:264 ../src/msw/textctrl.cpp:2769
+#: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Angre"
 
-#: ../src/common/cmdproc.cpp:265
+#: ../src/common/cmdproc.cpp:258
 msgid "&Undo "
 msgstr "&Angre"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "&Unindent"
 msgstr "&Fjern innrykk"
 
-#: ../src/common/stockitem.cpp:205
+#: ../src/common/stockitem.cpp:202
 msgid "&Up"
 msgstr "&Opp"
 
@@ -807,7 +828,7 @@ msgstr "Venstrejustering"
 msgid "&View..."
 msgstr "&Åpne..."
 
-#: ../src/generic/fontdlgg.cpp:393
+#: ../src/generic/fontdlgg.cpp:389
 msgid "&Weight:"
 msgstr "&Vekt:"
 
@@ -817,88 +838,58 @@ msgstr "&Vekt:"
 msgid "&Width:"
 msgstr "&Vekt:"
 
-#: ../src/aui/tabmdi.cpp:311 ../src/aui/tabmdi.cpp:327
-#: ../src/aui/tabmdi.cpp:329 ../src/generic/mdig.cpp:294
-#: ../src/generic/mdig.cpp:310 ../src/generic/mdig.cpp:314
-#: ../src/msw/mdi.cpp:78
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
 msgid "&Window"
 msgstr "&Vindu"
 
-#: ../src/common/stockitem.cpp:206 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:203 ../src/msw/msgdlg.cpp:435
 msgid "&Yes"
 msgstr "&Ja"
 
-#: ../src/common/valtext.cpp:256
+#: ../src/common/valtext.cpp:197
 #, fuzzy, c-format
-msgid "'%s' contains illegal characters"
+msgid "'%s' contains invalid character(s)"
 msgstr "«%s» må kun inneholde bokstaver."
 
-#: ../src/common/valtext.cpp:254
-#, fuzzy, c-format
-msgid "'%s' doesn't consist only of valid characters"
-msgstr "«%s» må kun inneholde bokstaver."
-
-#: ../src/common/config.cpp:519 ../src/msw/regconf.cpp:258
+#: ../src/common/config.cpp:515 ../src/msw/regconf.cpp:255
 #, c-format
 msgid "'%s' has extra '..', ignored."
 msgstr "«%s» har ekstra «..», ignorert."
 
-#: ../src/common/cmdline.cpp:1113 ../src/common/cmdline.cpp:1131
+#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "«%s» er ikke en gyldig numerisk verdi for valg «%s»."
 
-#: ../src/common/translation.cpp:1100
+#: ../src/common/translation.cpp:1142
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "«%s» er ikke en gyldig meldingskatalog."
 
-#: ../src/common/valtext.cpp:165
+#: ../src/common/valtext.cpp:188
 #, fuzzy, c-format
 msgid "'%s' is not one of the valid strings"
 msgstr "«%s» er ikke en gyldig meldingskatalog."
 
-#: ../src/common/valtext.cpp:167
+#: ../src/common/valtext.cpp:186
 #, fuzzy, c-format
 msgid "'%s' is one of the invalid strings"
 msgstr "«%s» er ugyldig"
 
-#: ../src/common/textbuf.cpp:237
+#: ../src/common/textbuf.cpp:233
 #, c-format
 msgid "'%s' is probably a binary buffer."
 msgstr "«%s» er sannsynligvis en binær buffer."
-
-#: ../src/common/valtext.cpp:252
-#, c-format
-msgid "'%s' should be numeric."
-msgstr "«%s» skal være numerisk."
-
-#: ../src/common/valtext.cpp:244
-#, c-format
-msgid "'%s' should only contain ASCII characters."
-msgstr "«%s» må kun inneholde ASCII-tegn."
-
-#: ../src/common/valtext.cpp:246
-#, c-format
-msgid "'%s' should only contain alphabetic characters."
-msgstr "«%s» må kun inneholde bokstaver."
-
-#: ../src/common/valtext.cpp:248
-#, c-format
-msgid "'%s' should only contain alphabetic or numeric characters."
-msgstr "«%s» må kun inneholde bokstaver eller tall."
-
-#: ../src/common/valtext.cpp:250
-#, fuzzy, c-format
-msgid "'%s' should only contain digits."
-msgstr "«%s» må kun inneholde ASCII-tegn."
 
 #: ../src/richtext/richtextliststylepage.cpp:229
 #: ../src/richtext/richtextbulletspage.cpp:166
 msgid "(*)"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:963
+#: ../src/html/helpwnd.cpp:961
 msgid "(Help)"
 msgstr "(Hjelp)"
 
@@ -907,28 +898,33 @@ msgstr "(Hjelp)"
 msgid "(None)"
 msgstr "(Ingen)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:504
+#: ../src/richtext/richtextsymboldlg.cpp:503
 #, fuzzy
 msgid "(Normal text)"
 msgstr "Normal skrift:"
 
-#: ../src/html/helpwnd.cpp:419 ../src/html/helpwnd.cpp:1106
-#: ../src/html/helpwnd.cpp:1742
+#: ../src/html/helpwnd.cpp:417 ../src/html/helpwnd.cpp:1104
+#: ../src/html/helpwnd.cpp:1740
 msgid "(bookmarks)"
 msgstr "(bokmerker)"
 
+#: ../src/msw/dlmsw.cpp:167
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr "(feil %ld: %s)"
+
+#: ../src/richtext/richtextformatdlg.cpp:876
+#: ../src/richtext/richtextliststylepage.cpp:448
+#: ../src/richtext/richtextliststylepage.cpp:460
+#: ../src/richtext/richtextliststylepage.cpp:461
 #: ../src/richtext/richtextindentspage.cpp:274
 #: ../src/richtext/richtextindentspage.cpp:286
 #: ../src/richtext/richtextindentspage.cpp:287
 #: ../src/richtext/richtextindentspage.cpp:311
 #: ../src/richtext/richtextindentspage.cpp:326
-#: ../src/richtext/richtextformatdlg.cpp:884
 #: ../src/richtext/richtextfontpage.cpp:349
 #: ../src/richtext/richtextfontpage.cpp:353
 #: ../src/richtext/richtextfontpage.cpp:357
-#: ../src/richtext/richtextliststylepage.cpp:448
-#: ../src/richtext/richtextliststylepage.cpp:460
-#: ../src/richtext/richtextliststylepage.cpp:461
 #, fuzzy
 msgid "(none)"
 msgstr "ikke navn"
@@ -948,7 +944,7 @@ msgstr ""
 msgid "+"
 msgstr ""
 
-#: ../src/msw/utils.cpp:1152
+#: ../src/msw/utils.cpp:1143
 msgid ", 64-bit edition"
 msgstr ""
 
@@ -957,174 +953,174 @@ msgstr ""
 msgid "-"
 msgstr ""
 
-#: ../src/generic/filepickerg.cpp:66
+#: ../src/generic/filepickerg.cpp:63
 #, fuzzy
 msgid "..."
 msgstr ".."
 
-#: ../src/richtext/richtextindentspage.cpp:276
 #: ../src/richtext/richtextliststylepage.cpp:450
+#: ../src/richtext/richtextindentspage.cpp:276
 msgid "1.1"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:277
 #: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextindentspage.cpp:277
 msgid "1.2"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:278
 #: ../src/richtext/richtextliststylepage.cpp:452
+#: ../src/richtext/richtextindentspage.cpp:278
 msgid "1.3"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:279
 #: ../src/richtext/richtextliststylepage.cpp:453
+#: ../src/richtext/richtextindentspage.cpp:279
 msgid "1.4"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:280
 #: ../src/richtext/richtextliststylepage.cpp:454
+#: ../src/richtext/richtextindentspage.cpp:280
 msgid "1.5"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:281
 #: ../src/richtext/richtextliststylepage.cpp:455
+#: ../src/richtext/richtextindentspage.cpp:281
 msgid "1.6"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:282
 #: ../src/richtext/richtextliststylepage.cpp:456
+#: ../src/richtext/richtextindentspage.cpp:282
 msgid "1.7"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:283
 #: ../src/richtext/richtextliststylepage.cpp:457
+#: ../src/richtext/richtextindentspage.cpp:283
 msgid "1.8"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:284
 #: ../src/richtext/richtextliststylepage.cpp:458
+#: ../src/richtext/richtextindentspage.cpp:284
 msgid "1.9"
 msgstr ""
 
-#: ../src/common/paper.cpp:140
+#: ../src/common/paper.cpp:137
 #, fuzzy
 msgid "10 x 11 in"
 msgstr "10 x 14 tommer"
 
-#: ../src/common/paper.cpp:113
+#: ../src/common/paper.cpp:110
 msgid "10 x 14 in"
 msgstr "10 x 14 tommer"
 
-#: ../src/common/paper.cpp:114
+#: ../src/common/paper.cpp:111
 msgid "11 x 17 in"
 msgstr "11 x 17 tommer"
 
-#: ../src/common/paper.cpp:184
+#: ../src/common/paper.cpp:181
 #, fuzzy
 msgid "12 x 11 in"
 msgstr "10 x 14 tommer"
 
-#: ../src/common/paper.cpp:141
+#: ../src/common/paper.cpp:138
 #, fuzzy
 msgid "15 x 11 in"
 msgstr "10 x 14 tommer"
 
-#: ../src/richtext/richtextindentspage.cpp:285
 #: ../src/richtext/richtextliststylepage.cpp:459
+#: ../src/richtext/richtextindentspage.cpp:285
 msgid "2"
 msgstr ""
 
-#: ../src/common/paper.cpp:132
+#: ../src/common/paper.cpp:129
 msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
 msgstr "6 3/4 konvolutt, 3 5/8 x 6 1/2 tommer"
 
-#: ../src/common/paper.cpp:139
+#: ../src/common/paper.cpp:136
 #, fuzzy
 msgid "9 x 11 in"
 msgstr "11 x 17 tommer"
 
-#: ../src/html/htmprint.cpp:431
+#: ../src/html/htmprint.cpp:443
 msgid ": file does not exist!"
 msgstr ": filen eksisterer ikke!"
 
-#: ../src/common/fontmap.cpp:199
+#: ../src/common/fontmap.cpp:196
 msgid ": unknown charset"
 msgstr ": ukjent tegnsett"
 
-#: ../src/common/fontmap.cpp:413
+#: ../src/common/fontmap.cpp:410
 msgid ": unknown encoding"
 msgstr ": ukjent koding"
 
-#: ../src/generic/wizard.cpp:443
+#: ../src/generic/wizard.cpp:438
 msgid "< &Back"
 msgstr "< &Tilbake"
 
-#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:628
-#: ../src/osx/carbon/fontdlg.cpp:648
+#: ../src/osx/carbon/fontdlg.cpp:419 ../src/osx/carbon/fontdlg.cpp:625
+#: ../src/osx/carbon/fontdlg.cpp:645
 #, fuzzy
 msgid "<Any Decorative>"
 msgstr "Dekorativ"
 
-#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:630
-#: ../src/osx/carbon/fontdlg.cpp:650
+#: ../src/osx/carbon/fontdlg.cpp:420 ../src/osx/carbon/fontdlg.cpp:627
+#: ../src/osx/carbon/fontdlg.cpp:647
 #, fuzzy
 msgid "<Any Modern>"
 msgstr "Moderne"
 
-#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:626
-#: ../src/osx/carbon/fontdlg.cpp:646
+#: ../src/osx/carbon/fontdlg.cpp:418 ../src/osx/carbon/fontdlg.cpp:623
+#: ../src/osx/carbon/fontdlg.cpp:643
 #, fuzzy
 msgid "<Any Roman>"
 msgstr "Roman"
 
-#: ../src/osx/carbon/fontdlg.cpp:424 ../src/osx/carbon/fontdlg.cpp:632
-#: ../src/osx/carbon/fontdlg.cpp:652
+#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:629
+#: ../src/osx/carbon/fontdlg.cpp:649
 #, fuzzy
 msgid "<Any Script>"
 msgstr "Skript"
 
-#: ../src/osx/carbon/fontdlg.cpp:425 ../src/osx/carbon/fontdlg.cpp:637
-#: ../src/osx/carbon/fontdlg.cpp:656
+#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:634
+#: ../src/osx/carbon/fontdlg.cpp:653
 #, fuzzy
 msgid "<Any Swiss>"
 msgstr "Swiss"
 
-#: ../src/osx/carbon/fontdlg.cpp:426 ../src/osx/carbon/fontdlg.cpp:634
-#: ../src/osx/carbon/fontdlg.cpp:654
+#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:631
+#: ../src/osx/carbon/fontdlg.cpp:651
 #, fuzzy
 msgid "<Any Teletype>"
 msgstr "Teletype"
 
-#: ../src/osx/carbon/fontdlg.cpp:420
+#: ../src/osx/carbon/fontdlg.cpp:417
 msgid "<Any>"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
 msgid "<DIR>"
 msgstr "<MAPPE>"
 
-#: ../src/generic/filectrlg.cpp:254 ../src/generic/filectrlg.cpp:277
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
 msgid "<DRIVE>"
 msgstr "<LAGERENHET>"
 
-#: ../src/generic/filectrlg.cpp:252 ../src/generic/filectrlg.cpp:275
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
 msgid "<LINK>"
 msgstr "<LENKE>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1264
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Fet kursiv skrift.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1270
+#: ../src/html/helpwnd.cpp:1268
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>fet kursiv <u>understreket</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1265
+#: ../src/html/helpwnd.cpp:1263
 msgid "<b>Bold face.</b> "
 msgstr "<b>Fet skrift.</b> "
 
-#: ../src/html/helpwnd.cpp:1264
+#: ../src/html/helpwnd.cpp:1262
 msgid "<i>Italic face.</i> "
 msgstr "<i>Kursiv skrift.</i> "
 
@@ -1134,16 +1130,16 @@ msgstr "<i>Kursiv skrift.</i> "
 msgid ">"
 msgstr ">>"
 
-#: ../src/generic/dbgrptg.cpp:318
+#: ../src/generic/dbgrptg.cpp:317
 msgid "A debug report has been generated in the directory\n"
 msgstr "En feilsøkingsrapport har generert i mappen\n"
 
-#: ../src/common/debugrpt.cpp:573
+#: ../src/common/debugrpt.cpp:574
 #, fuzzy
 msgid "A debug report has been generated. It can be found in"
 msgstr "En feilsøkingsrapport har generert i mappen\n"
 
-#: ../src/common/xtixml.cpp:418
+#: ../src/common/xtixml.cpp:414
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "En ikke-tom mengde må bestå av «element»-noder"
 
@@ -1154,120 +1150,120 @@ msgstr "En ikke-tom mengde må bestå av «element»-noder"
 msgid "A standard bullet name."
 msgstr "Et standard punktnavn."
 
-#: ../src/common/paper.cpp:217
+#: ../src/common/paper.cpp:214
 #, fuzzy
 msgid "A0 sheet, 841 x 1189 mm"
 msgstr "A4-ark, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:218
+#: ../src/common/paper.cpp:215
 #, fuzzy
 msgid "A1 sheet, 594 x 841 mm"
 msgstr "A3-ark, 297 x 420 mm"
 
-#: ../src/common/paper.cpp:159
-msgid "A2 420 x 594 mm"
-msgstr ""
-
 #: ../src/common/paper.cpp:156
-#, fuzzy
-msgid "A3 Extra 322 x 445 mm"
-msgstr "C3-konvolutt, 324 x 458 mm"
-
-#: ../src/common/paper.cpp:161
-#, fuzzy
-msgid "A3 Extra Transverse 322 x 445 mm"
-msgstr "C3-konvolutt, 324 x 458 mm"
-
-#: ../src/common/paper.cpp:170
-#, fuzzy
-msgid "A3 Rotated 420 x 297 mm"
-msgstr "A4-ark, 210 x 297 mm"
-
-#: ../src/common/paper.cpp:160
-#, fuzzy
-msgid "A3 Transverse 297 x 420 mm"
-msgstr "A3-ark, 297 x 420 mm"
-
-#: ../src/common/paper.cpp:106
-msgid "A3 sheet, 297 x 420 mm"
-msgstr "A3-ark, 297 x 420 mm"
-
-#: ../src/common/paper.cpp:146
-msgid "A4 Extra 9.27 x 12.69 in"
+msgid "A2 420 x 594 mm"
 msgstr ""
 
 #: ../src/common/paper.cpp:153
 #, fuzzy
+msgid "A3 Extra 322 x 445 mm"
+msgstr "C3-konvolutt, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:158
+#, fuzzy
+msgid "A3 Extra Transverse 322 x 445 mm"
+msgstr "C3-konvolutt, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:167
+#, fuzzy
+msgid "A3 Rotated 420 x 297 mm"
+msgstr "A4-ark, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:157
+#, fuzzy
+msgid "A3 Transverse 297 x 420 mm"
+msgstr "A3-ark, 297 x 420 mm"
+
+#: ../src/common/paper.cpp:103
+msgid "A3 sheet, 297 x 420 mm"
+msgstr "A3-ark, 297 x 420 mm"
+
+#: ../src/common/paper.cpp:143
+msgid "A4 Extra 9.27 x 12.69 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:150
+#, fuzzy
 msgid "A4 Plus 210 x 330 mm"
 msgstr "A4-ark, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:171
+#: ../src/common/paper.cpp:168
 #, fuzzy
 msgid "A4 Rotated 297 x 210 mm"
 msgstr "A3-ark, 297 x 420 mm"
 
-#: ../src/common/paper.cpp:148
+#: ../src/common/paper.cpp:145
 #, fuzzy
 msgid "A4 Transverse 210 x 297 mm"
 msgstr "A4-ark, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:97
+#: ../src/common/paper.cpp:94
 msgid "A4 sheet, 210 x 297 mm"
 msgstr "A4-ark, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:107
+#: ../src/common/paper.cpp:104
 msgid "A4 small sheet, 210 x 297 mm"
 msgstr "A4-ark (små), 210 x 297 mm "
 
-#: ../src/common/paper.cpp:157
+#: ../src/common/paper.cpp:154
 #, fuzzy
 msgid "A5 Extra 174 x 235 mm"
 msgstr "A5-ark, 148 x 210 mm"
 
-#: ../src/common/paper.cpp:172
+#: ../src/common/paper.cpp:169
 msgid "A5 Rotated 210 x 148 mm"
 msgstr "A5 Rotert 210 x 148 mm"
 
-#: ../src/common/paper.cpp:154
+#: ../src/common/paper.cpp:151
 #, fuzzy
 msgid "A5 Transverse 148 x 210 mm"
 msgstr "A5-ark, 148 x 210 mm"
 
-#: ../src/common/paper.cpp:108
+#: ../src/common/paper.cpp:105
 msgid "A5 sheet, 148 x 210 mm"
 msgstr "A5-ark, 148 x 210 mm"
 
-#: ../src/common/paper.cpp:164
+#: ../src/common/paper.cpp:161
 #, fuzzy
 msgid "A6 105 x 148 mm"
 msgstr "10 x 14 tommer"
 
-#: ../src/common/paper.cpp:177
+#: ../src/common/paper.cpp:174
 #, fuzzy
 msgid "A6 Rotated 148 x 105 mm"
 msgstr "A5-ark, 148 x 210 mm"
 
-#: ../src/generic/fontdlgg.cpp:83 ../src/richtext/richtextformatdlg.cpp:529
-#: ../src/osx/carbon/fontdlg.cpp:153
+#: ../src/osx/carbon/fontdlg.cpp:150 ../src/generic/fontdlgg.cpp:79
+#: ../src/richtext/richtextformatdlg.cpp:521
 msgid "ABCDEFGabcdefg12345"
 msgstr "ABCDEFGabcdefg12345"
 
-#: ../src/richtext/richtextsymboldlg.cpp:458 ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
 msgid "ASCII"
 msgstr "ASCII"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 #, fuzzy
 msgid "About"
 msgstr "%Om"
 
-#: ../src/generic/aboutdlgg.cpp:140 ../src/osx/menu_osx.cpp:558
-#: ../src/msw/aboutdlg.cpp:64
+#: ../src/osx/menu_osx.cpp:450 ../src/generic/aboutdlgg.cpp:137
+#: ../src/msw/aboutdlg.cpp:61
 #, fuzzy, c-format
 msgid "About %s"
 msgstr "%Om"
 
-#: ../src/osx/menu_osx.cpp:560
+#: ../src/osx/menu_osx.cpp:452
 #, fuzzy
 msgid "About..."
 msgstr "%Om"
@@ -1277,39 +1273,39 @@ msgid "Absolute"
 msgstr "Absolutt"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:873
+#: ../src/propgrid/advprops.cpp:774
 #, fuzzy
 msgid "ActiveBorder"
 msgstr "Moderne"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:874
+#: ../src/propgrid/advprops.cpp:775
 msgid "ActiveCaption"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 #, fuzzy
 msgid "Actual Size"
 msgstr "&Faktisk størrelse"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:140 ../src/common/accelcmn.cpp:81
+#: ../src/common/stockitem.cpp:137 ../src/common/accelcmn.cpp:78
 msgid "Add"
 msgstr "Legg till"
 
-#: ../src/richtext/richtextbuffer.cpp:11455
+#: ../src/richtext/richtextbuffer.cpp:11454
 msgid "Add Column"
 msgstr "Legg til Kolonne"
 
-#: ../src/richtext/richtextbuffer.cpp:11392
+#: ../src/richtext/richtextbuffer.cpp:11391
 msgid "Add Row"
 msgstr "Legg til Rad"
 
-#: ../src/html/helpwnd.cpp:432
+#: ../src/html/helpwnd.cpp:430
 msgid "Add current page to bookmarks"
 msgstr "Legg til gjeldende side til bokmerkene"
 
-#: ../src/generic/colrdlgg.cpp:366
+#: ../src/generic/colrdlgg.cpp:386
 msgid "Add to custom colours"
 msgstr "Legg til selvvalgte farge"
 
@@ -1321,12 +1317,12 @@ msgstr "AddToPropertyCollection kalt på generisk aksessor"
 msgid "AddToPropertyCollection called w/o valid adder"
 msgstr "AddToPropertyCollection kalt uten gyldig tillegger"
 
-#: ../src/html/helpctrl.cpp:159
+#: ../src/html/helpctrl.cpp:155
 #, c-format
 msgid "Adding book %s"
 msgstr "Legger til bok %s"
 
-#: ../src/common/preferencescmn.cpp:43
+#: ../src/common/preferencescmn.cpp:40
 msgid "Advanced"
 msgstr "Avansert"
 
@@ -1334,11 +1330,11 @@ msgstr "Avansert"
 msgid "After a paragraph:"
 msgstr "Etter et avsnitt:"
 
-#: ../src/common/stockitem.cpp:172
+#: ../src/common/stockitem.cpp:169
 msgid "Align Left"
 msgstr "Venstrejustering"
 
-#: ../src/common/stockitem.cpp:173
+#: ../src/common/stockitem.cpp:170
 msgid "Align Right"
 msgstr "Høyrejustering"
 
@@ -1347,40 +1343,40 @@ msgstr "Høyrejustering"
 msgid "Alignment"
 msgstr "Venstrejustering"
 
-#: ../src/generic/prntdlgg.cpp:215
+#: ../src/generic/prntdlgg.cpp:208
 msgid "All"
 msgstr "Alle"
 
-#: ../src/generic/filectrlg.cpp:1197 ../src/common/fldlgcmn.cpp:107
+#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1186
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Alle filer (%s)|%s"
 
-#: ../include/wx/defs.h:2886
+#: ../include/wx/defs.h:2582
 msgid "All files (*)|*"
 msgstr "Alle filer (*)|*"
 
-#: ../include/wx/defs.h:2883
+#: ../include/wx/defs.h:2579
 msgid "All files (*.*)|*.*"
 msgstr "Alle filer (*.*)|*.*"
 
-#: ../src/richtext/richtextstyles.cpp:1061
+#: ../src/richtext/richtextstyles.cpp:1058
 msgid "All styles"
 msgstr "Alle stiler"
 
-#: ../src/propgrid/manager.cpp:1528
+#: ../src/propgrid/manager.cpp:1544
 msgid "Alphabetic Mode"
 msgstr "Alfabetisk Modus"
 
-#: ../src/common/xtistrm.cpp:425
+#: ../src/common/xtistrm.cpp:422
 msgid "Already Registered Object passed to SetObjectClassInfo"
 msgstr "Allerede registrert objekt sendt til SetObjectClassInfo"
 
-#: ../src/unix/dialup.cpp:353
+#: ../src/unix/dialup.cpp:352
 msgid "Already dialling ISP."
 msgstr "Ringer allerede ISP."
 
-#: ../src/common/accelcmn.cpp:331 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/accelcmn.cpp:345 ../src/univ/themes/win32.cpp:3753
 msgid "Alt+"
 msgstr ""
 
@@ -1389,37 +1385,37 @@ msgstr ""
 msgid "An optional corner radius for adding rounded corners."
 msgstr "En valgfri radius for avrundede hjørner."
 
-#: ../src/common/debugrpt.cpp:576
+#: ../src/common/debugrpt.cpp:577
 #, fuzzy
 msgid "And includes the following files:\n"
 msgstr "*** Og den inkluderer følgende filer:\n"
 
-#: ../src/generic/animateg.cpp:162
+#: ../src/generic/animateg.cpp:145
 #, fuzzy, c-format
 msgid "Animation file is not of type %ld."
 msgstr "Bildefil er ikke av type %d."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:872
+#: ../src/propgrid/advprops.cpp:773
 msgid "AppWorkspace"
 msgstr ""
 
-#: ../src/generic/logg.cpp:1014
+#: ../src/generic/logg.cpp:1011
 #, c-format
 msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
 msgstr "Tilføy logg til fil «%s» (velger du [Nei] overskrives filen)?"
 
-#: ../src/osx/menu_osx.cpp:577 ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:469 ../src/osx/menu_osx.cpp:477
 #, fuzzy
 msgid "Application"
 msgstr "Seksjoner"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 #, fuzzy
 msgid "Apply"
 msgstr "&Bruk"
 
-#: ../src/propgrid/advprops.cpp:1609
+#: ../src/propgrid/advprops.cpp:1515
 msgid "Aqua"
 msgstr ""
 
@@ -1428,31 +1424,31 @@ msgstr ""
 msgid "Arabic"
 msgstr "Arabisk"
 
-#: ../src/common/fmapbase.cpp:153
+#: ../src/common/fmapbase.cpp:150
 msgid "Arabic (ISO-8859-6)"
 msgstr "Arabisk (ISO-8859-6)"
 
-#: ../src/msw/ole/automtn.cpp:672
+#: ../src/msw/ole/automtn.cpp:663
 #, fuzzy, c-format
 msgid "Argument %u not found."
 msgstr "katalogfil for domene «%s» ikke funnet."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1753
+#: ../src/propgrid/advprops.cpp:1654
 #, fuzzy
 msgid "Arrow"
 msgstr "i morgen"
 
-#: ../src/generic/aboutdlgg.cpp:184
+#: ../src/generic/aboutdlgg.cpp:181
 msgid "Artists"
 msgstr "Artister"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 #, fuzzy
 msgid "Ascending"
 msgstr "leser"
 
-#: ../src/generic/filectrlg.cpp:433
+#: ../src/generic/filectrlg.cpp:429
 msgid "Attributes"
 msgstr "Atributter"
 
@@ -1462,93 +1458,93 @@ msgstr "Atributter"
 msgid "Available fonts."
 msgstr "Tilgjengelige fonter."
 
-#: ../src/common/paper.cpp:137
+#: ../src/common/paper.cpp:134
 #, fuzzy
 msgid "B4 (ISO) 250 x 353 mm"
 msgstr "B4-ark, 250 x 354 mm"
 
-#: ../src/common/paper.cpp:173
+#: ../src/common/paper.cpp:170
 msgid "B4 (JIS) Rotated 364 x 257 mm"
 msgstr "B4 (JIS) Rotert 364 x 257 mm"
 
-#: ../src/common/paper.cpp:127
+#: ../src/common/paper.cpp:124
 msgid "B4 Envelope, 250 x 353 mm"
 msgstr "B4-konvolutt, 2500 x 353 mm"
 
-#: ../src/common/paper.cpp:109
+#: ../src/common/paper.cpp:106
 msgid "B4 sheet, 250 x 354 mm"
 msgstr "B4-ark, 250 x 354 mm"
 
-#: ../src/common/paper.cpp:158
+#: ../src/common/paper.cpp:155
 msgid "B5 (ISO) Extra 201 x 276 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:174
+#: ../src/common/paper.cpp:171
 msgid "B5 (JIS) Rotated 257 x 182 mm"
 msgstr "B5 (JIS) Rotert 257 x 182 mm"
 
-#: ../src/common/paper.cpp:155
+#: ../src/common/paper.cpp:152
 #, fuzzy
 msgid "B5 (JIS) Transverse 182 x 257 mm"
 msgstr "B5-ark, 182 x 257 mm"
 
-#: ../src/common/paper.cpp:128
+#: ../src/common/paper.cpp:125
 msgid "B5 Envelope, 176 x 250 mm"
 msgstr "B5-konvolutt, 176 x 250 mm"
 
-#: ../src/common/paper.cpp:110
+#: ../src/common/paper.cpp:107
 msgid "B5 sheet, 182 x 257 millimeter"
 msgstr "B5-ark, 182 x 257 mm"
 
-#: ../src/common/paper.cpp:182
+#: ../src/common/paper.cpp:179
 msgid "B6 (JIS) 128 x 182 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:183
+#: ../src/common/paper.cpp:180
 msgid "B6 (JIS) Rotated 182 x 128 mm"
 msgstr "B6 (JIS) Rotert 182 x 128 mm"
 
-#: ../src/common/paper.cpp:129
+#: ../src/common/paper.cpp:126
 msgid "B6 Envelope, 176 x 125 mm"
 msgstr "B6-konvolutt, 176 x 125 mm"
 
-#: ../src/common/imagbmp.cpp:531 ../src/common/imagbmp.cpp:561
-#: ../src/common/imagbmp.cpp:576
+#: ../src/common/imagbmp.cpp:528 ../src/common/imagbmp.cpp:558
+#: ../src/common/imagbmp.cpp:573
 msgid "BMP: Couldn't allocate memory."
 msgstr "BMP: Klarte ikke reservere minne."
 
-#: ../src/common/imagbmp.cpp:100
+#: ../src/common/imagbmp.cpp:97
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: Klarte ikke lagre ugyldig bilde."
 
-#: ../src/common/imagbmp.cpp:356
+#: ../src/common/imagbmp.cpp:353
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: Klarte ikke skrive RGB-fargekart."
 
-#: ../src/common/imagbmp.cpp:490
+#: ../src/common/imagbmp.cpp:487
 msgid "BMP: Couldn't write data."
 msgstr "BMP: Klarte ikke skrive data."
 
-#: ../src/common/imagbmp.cpp:246
+#: ../src/common/imagbmp.cpp:243
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: Klarte ikke skrive filhodet (Bitmap)."
 
-#: ../src/common/imagbmp.cpp:269
+#: ../src/common/imagbmp.cpp:266
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: Klarte ikke skrive filehodet (BitmapInfo)."
 
-#: ../src/common/imagbmp.cpp:140
+#: ../src/common/imagbmp.cpp:137
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage har ikke egen wxPalette."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:142 ../src/common/accelcmn.cpp:52
+#: ../src/common/stockitem.cpp:139 ../src/common/accelcmn.cpp:49
 #, fuzzy
 msgid "Back"
 msgstr "&Tilbake"
 
+#: ../src/richtext/richtextformatdlg.cpp:377
 #: ../src/richtext/richtextbackgroundpage.cpp:148
-#: ../src/richtext/richtextformatdlg.cpp:384
 msgid "Background"
 msgstr "Bakgrunn"
 
@@ -1556,21 +1552,21 @@ msgstr "Bakgrunn"
 msgid "Background &colour:"
 msgstr "&Bakgrunnsfarge"
 
-#: ../src/osx/carbon/fontdlg.cpp:220
+#: ../src/osx/carbon/fontdlg.cpp:217
 msgid "Background colour"
 msgstr "Bakgrunnsfarge"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:52
+#: ../src/common/accelcmn.cpp:49
 #, fuzzy
 msgid "Backspace"
 msgstr "&Tilbake"
 
-#: ../src/common/fmapbase.cpp:160
+#: ../src/common/fmapbase.cpp:157
 msgid "Baltic (ISO-8859-13)"
 msgstr "Baltisk (ISO-8859-13)"
 
-#: ../src/common/fmapbase.cpp:151
+#: ../src/common/fmapbase.cpp:148
 msgid "Baltic (old) (ISO-8859-4)"
 msgstr "Baltisk (gammel) (ISO-8859-4)"
 
@@ -1583,26 +1579,26 @@ msgstr "Før et avsnitt:"
 msgid "Bitmap"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1594
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Black"
 msgstr "Svart"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1755
+#: ../src/propgrid/advprops.cpp:1656
 msgid "Blank"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1603
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Blue"
 msgstr "Blå"
 
-#: ../src/generic/colrdlgg.cpp:345
+#: ../src/generic/colrdlgg.cpp:365
 #, fuzzy
 msgid "Blue:"
 msgstr "Blå"
 
-#: ../src/generic/fontdlgg.cpp:333 ../src/richtext/richtextfontpage.cpp:355
-#: ../src/osx/carbon/fontdlg.cpp:354 ../src/common/stockitem.cpp:143
+#: ../src/osx/carbon/fontdlg.cpp:351 ../src/common/stockitem.cpp:140
+#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:355
 msgid "Bold"
 msgstr "Fet"
 
@@ -1612,34 +1608,38 @@ msgstr "Fet"
 msgid "Border"
 msgstr "Moderne"
 
-#: ../src/richtext/richtextformatdlg.cpp:379
+#: ../src/richtext/richtextformatdlg.cpp:372
 #, fuzzy
 msgid "Borders"
 msgstr "Moderne"
 
-#: ../src/richtext/richtextsizepage.cpp:288 ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141 ../src/richtext/richtextsizepage.cpp:288
 msgid "Bottom"
 msgstr "Bunn"
 
-#: ../src/generic/prntdlgg.cpp:893
+#: ../src/generic/prntdlgg.cpp:886
 msgid "Bottom margin (mm):"
 msgstr "Marg nede (mm):"
 
-#: ../src/richtext/richtextbuffer.cpp:9383
+#: ../src/richtext/richtextbuffer.cpp:9380
 #, fuzzy
 msgid "Box Properties"
 msgstr "&Egenskaper"
 
-#: ../src/richtext/richtextstyles.cpp:1065
+#: ../src/richtext/richtextstyles.cpp:1062
 #, fuzzy
 msgid "Box styles"
 msgstr "&Neste >"
 
-#: ../src/propgrid/advprops.cpp:1602
+#: ../src/osx/cocoa/menu.mm:292
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Brown"
 msgstr "Brun"
 
-#: ../src/common/filepickercmn.cpp:43 ../src/common/filepickercmn.cpp:44
+#: ../src/common/filepickercmn.cpp:40 ../src/common/filepickercmn.cpp:41
 msgid "Browse"
 msgstr "Bla gjennom"
 
@@ -1652,72 +1652,72 @@ msgstr "&Punktlisteplassering"
 msgid "Bullet style"
 msgstr "Punktlistestil"
 
-#: ../src/richtext/richtextformatdlg.cpp:359
+#: ../src/richtext/richtextformatdlg.cpp:352
 msgid "Bullets"
 msgstr "Punkter"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1756
+#: ../src/propgrid/advprops.cpp:1657
 msgid "Bullseye"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:875
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonFace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:876
+#: ../src/propgrid/advprops.cpp:777
 msgid "ButtonHighlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:877
+#: ../src/propgrid/advprops.cpp:778
 msgid "ButtonShadow"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:878
+#: ../src/propgrid/advprops.cpp:779
 msgid "ButtonText"
 msgstr ""
 
-#: ../src/common/paper.cpp:98
+#: ../src/common/paper.cpp:95
 msgid "C sheet, 17 x 22 in"
 msgstr "C-ark, 17 x 22 tommer"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "C&lear"
 msgstr "&Nullstill"
 
-#: ../src/generic/fontdlgg.cpp:406
+#: ../src/generic/fontdlgg.cpp:403
 msgid "C&olour:"
 msgstr "&Farge"
 
-#: ../src/common/paper.cpp:123
+#: ../src/common/paper.cpp:120
 msgid "C3 Envelope, 324 x 458 mm"
 msgstr "C3-konvolutt, 324 x 458 mm"
 
-#: ../src/common/paper.cpp:124
+#: ../src/common/paper.cpp:121
 msgid "C4 Envelope, 229 x 324 mm"
 msgstr "C4-konvolutt, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:122
+#: ../src/common/paper.cpp:119
 msgid "C5 Envelope, 162 x 229 mm"
 msgstr "C5-konvolutt, 162 x 229 mm"
 
-#: ../src/common/paper.cpp:125
+#: ../src/common/paper.cpp:122
 msgid "C6 Envelope, 114 x 162 mm"
 msgstr "C6-konvoluttm 114 x 162 mm"
 
-#: ../src/common/paper.cpp:126
+#: ../src/common/paper.cpp:123
 msgid "C65 Envelope, 114 x 229 mm"
 msgstr "C65-konvolutt, 114 x 229 mm"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "CD-Rom"
 msgstr ""
 
-#: ../src/html/chm.cpp:815 ../src/html/chm.cpp:874
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:865
 msgid "CHM handler currently supports only local files!"
 msgstr "CHM-behandleren støtter for øyeblikket bare lokale filer!"
 
@@ -1725,191 +1725,195 @@ msgstr "CHM-behandleren støtter for øyeblikket bare lokale filer!"
 msgid "Ca&pitals"
 msgstr "&Store bokstaver"
 
-#: ../src/common/cmdproc.cpp:267
+#: ../src/common/cmdproc.cpp:260
 msgid "Can't &Undo "
 msgstr "Klarte ikke &angre"
 
-#: ../src/common/image.cpp:2824
+#: ../src/common/image.cpp:2924
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr "Kan ikke automatisk bestemme bildeformatet."
 
-#: ../src/msw/registry.cpp:506
+#: ../src/msw/registry.cpp:495
 #, c-format
 msgid "Can't close registry key '%s'"
 msgstr "Klarte ikke lukke registernøkkel «%s»"
 
-#: ../src/msw/registry.cpp:584
+#: ../src/msw/registry.cpp:573
 #, c-format
 msgid "Can't copy values of unsupported type %d."
 msgstr "Klarte ikke kopiere verdier av ikke-støttet type %d."
 
-#: ../src/msw/registry.cpp:487
+#: ../src/msw/registry.cpp:476
 #, c-format
 msgid "Can't create registry key '%s'"
 msgstr "Klarte ikke opprette registernøkkel «%s»"
 
-#: ../src/msw/thread.cpp:665
+#: ../src/msw/thread.cpp:657
 msgid "Can't create thread"
 msgstr "Klarte ikke opprette tråd"
 
-#: ../src/msw/window.cpp:3691
-#, c-format
-msgid "Can't create window of class %s"
-msgstr "Klarte ikke opprette vindu av klasse %s"
-
-#: ../src/msw/registry.cpp:777
+#: ../src/msw/registry.cpp:765
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Klarte ikke slette nøkkel «%s»"
 
-#: ../src/msw/iniconf.cpp:458
+#: ../src/msw/iniconf.cpp:455
 #, c-format
 msgid "Can't delete the INI file '%s'"
 msgstr "Klarte ikke slette INI-filen «%s»"
 
-#: ../src/msw/registry.cpp:805
+#: ../src/msw/registry.cpp:793
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Klarte ikke slette verdien «%s» fra nøkkelen «%s»"
 
-#: ../src/msw/registry.cpp:1171
+#: ../src/msw/registry.cpp:1159
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Klarte ikke telle opp undernøkler av nøkkel «%s»"
 
-#: ../src/msw/registry.cpp:1132
+#: ../src/msw/registry.cpp:1120
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Klarte ikke telle opp verdier for nøkkel «%s»"
 
-#: ../src/msw/registry.cpp:1389
+#: ../src/msw/registry.cpp:1377
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Klarte ikke eksportere verdi av ikke-støttet type %d."
 
-#: ../src/common/ffile.cpp:254
+#: ../src/common/ffile.cpp:253
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Klarte ikke finne gjeldende posisjon i filen «%s»"
 
-#: ../src/msw/registry.cpp:418
+#: ../src/msw/registry.cpp:407
 #, c-format
 msgid "Can't get info about registry key '%s'"
 msgstr "Klarte ikke finne informasjon om registernøkkel «%s»"
 
-#: ../src/common/zstream.cpp:346
+#: ../src/msw/webview_ie.cpp:1024
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "Klarte ikke sette trådprioritet"
+
+#: ../src/common/zstream.cpp:343
 msgid "Can't initialize zlib deflate stream."
 msgstr "Klarte ikke klargjøre zlib-strøm for nedpakking."
 
-#: ../src/common/zstream.cpp:185
+#: ../src/common/zstream.cpp:182
 msgid "Can't initialize zlib inflate stream."
 msgstr "Klarte ikke klargjøre zlib-strøm for utpakking."
 
-#: ../src/msw/fswatcher.cpp:476
+#: ../src/msw/fswatcher.cpp:475
 #, c-format
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "Kan ikke overvåke ikkeeksisterende katalog \"%s\" for endringer"
 
-#: ../src/msw/registry.cpp:454
+#: ../src/msw/registry.cpp:443
 #, c-format
 msgid "Can't open registry key '%s'"
 msgstr "Kan ikke åpne registernøkkel «%s»"
 
-#: ../src/common/zstream.cpp:252
+#: ../src/common/zstream.cpp:249
 #, c-format
 msgid "Can't read from inflate stream: %s"
 msgstr "Klarte ikke lese fra utpakkingsstrøm: %s"
 
-#: ../src/common/zstream.cpp:244
+#: ../src/common/zstream.cpp:241
 msgid "Can't read inflate stream: unexpected EOF in underlying stream."
 msgstr "Klarte ikke lese utpakkingsstrøm: uventet EOF i underliggende strøm."
 
-#: ../src/msw/registry.cpp:1064
+#: ../src/msw/registry.cpp:1052
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Klarte ikke lese verdien til «%s»"
 
-#: ../src/msw/registry.cpp:878 ../src/msw/registry.cpp:910
-#: ../src/msw/registry.cpp:975
+#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
+#: ../src/msw/registry.cpp:963
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Klarte ikke lese verdien av nøkkel «%s»"
 
-#: ../src/common/image.cpp:2620
+#: ../src/msw/webview_ie.cpp:1017
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/common/image.cpp:2715
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "Klarte ikke lagre bilde til filen «%s»: Ukjent filtype"
 
-#: ../src/generic/logg.cpp:573 ../src/generic/logg.cpp:976
+#: ../src/generic/logg.cpp:570 ../src/generic/logg.cpp:973
 msgid "Can't save log contents to file."
 msgstr "Klarte ikke lagre logginnholdet til fil."
 
-#: ../src/msw/thread.cpp:629
+#: ../src/msw/thread.cpp:621
 msgid "Can't set thread priority"
 msgstr "Klarte ikke sette trådprioritet"
 
-#: ../src/msw/registry.cpp:896 ../src/msw/registry.cpp:938
-#: ../src/msw/registry.cpp:1081
+#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
+#: ../src/msw/registry.cpp:1069
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Klarte ikke sette verdien for «%s»"
 
-#: ../src/unix/utilsunx.cpp:351
+#: ../src/unix/utilsunx.cpp:353
 #, fuzzy
 msgid "Can't write to child process's stdin"
 msgstr "Klarte ikke drepe prosess %d"
 
-#: ../src/common/zstream.cpp:427
+#: ../src/common/zstream.cpp:424
 #, c-format
 msgid "Can't write to deflate stream: %s"
 msgstr "Klarte ikke skrive til nedpakkingsstrøm: %s"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:279 ../src/richtext/richtextstyledlg.cpp:300
-#: ../src/common/stockitem.cpp:145 ../src/common/accelcmn.cpp:71
-#: ../src/msw/msgdlg.cpp:454 ../src/msw/progdlg.cpp:673
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:142
+#: ../src/common/accelcmn.cpp:68 ../src/motif/msgdlg.cpp:196
+#: ../src/gtk1/fontdlg.cpp:144 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/progdlg.cpp:940 ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: ../src/common/filefn.cpp:1261
+#: ../src/common/filefn.cpp:1149
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Klarte ikke telle opp filer «%s»"
 
-#: ../src/msw/dir.cpp:263
+#: ../src/msw/dir.cpp:260
 #, c-format
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Klarte ikke telle opp filer i mappen «%s»"
 
-#: ../src/msw/dialup.cpp:523
+#: ../src/msw/dialup.cpp:517
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Klarte ikke finne aktiv oppringingsforbindelse: %s"
 
-#: ../src/msw/dialup.cpp:827
+#: ../src/msw/dialup.cpp:821
 msgid "Cannot find the location of address book file"
 msgstr "Klarte ikke plasseringen til adressebokfilen"
 
-#: ../src/msw/ole/automtn.cpp:562
+#: ../src/msw/ole/automtn.cpp:553
 #, fuzzy, c-format
 msgid "Cannot get an active instance of \"%s\""
 msgstr "Klarte ikke finne aktiv oppringingsforbindelse: %s"
 
-#: ../src/unix/threadpsx.cpp:1035
+#: ../src/unix/threadpsx.cpp:1053
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "Klarte ikke finne prioritetsområde for planleggingspolitikk %d."
 
-#: ../src/unix/utilsunx.cpp:987
+#: ../src/unix/utilsunx.cpp:989
 msgid "Cannot get the hostname"
 msgstr "Klarte ikke finne tjenernavn"
 
-#: ../src/unix/utilsunx.cpp:1023
+#: ../src/unix/utilsunx.cpp:1025
 msgid "Cannot get the official hostname"
 msgstr "Klarte ikke finne det offisielle tjenernavnet"
 
-#: ../src/msw/dialup.cpp:928
+#: ../src/msw/dialup.cpp:922
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Klarte ikke legge på - ingen aktiv oppringingsforbindelse."
 
@@ -1917,130 +1921,130 @@ msgstr "Klarte ikke legge på - ingen aktiv oppringingsforbindelse."
 msgid "Cannot initialize OLE"
 msgstr "Klarte ikke initialisere OLE"
 
-#: ../src/common/socket.cpp:853
+#: ../src/common/socket.cpp:850
 #, fuzzy
 msgid "Cannot initialize sockets"
 msgstr "Klarte ikke initialisere OLE"
 
-#: ../src/msw/volume.cpp:619
+#: ../src/msw/volume.cpp:627
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Klarte ikke laste ikon fra «%s»."
 
-#: ../src/xrc/xmlres.cpp:360
+#: ../src/xrc/xmlres.cpp:358
 #, fuzzy, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Klarte ikke laste ressurs fra filen «%s»."
 
-#: ../src/xrc/xmlres.cpp:742
+#: ../src/xrc/xmlres.cpp:740
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Klarte ikke laste ressurs fra filen «%s»."
 
-#: ../src/html/htmlfilt.cpp:137
+#: ../src/html/htmlfilt.cpp:134
 #, c-format
 msgid "Cannot open HTML document: %s"
 msgstr "Klarte ikke åpne HTML-dokument: %s"
 
-#: ../src/html/helpdata.cpp:667
+#: ../src/html/helpdata.cpp:660
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Klarte ikke åpne HTML-hjelpebok: %s"
 
-#: ../src/html/helpdata.cpp:299
+#: ../src/html/helpdata.cpp:296
 #, c-format
 msgid "Cannot open contents file: %s"
 msgstr "Klarte ikke åpne innholdsfil: %s"
 
-#: ../src/generic/dcpsg.cpp:1667
+#: ../src/generic/dcpsg.cpp:1665
 msgid "Cannot open file for PostScript printing!"
 msgstr "Klarte ikke åpne fil for PostScript-utskrift!"
 
-#: ../src/html/helpdata.cpp:313
+#: ../src/html/helpdata.cpp:310
 #, c-format
 msgid "Cannot open index file: %s"
 msgstr "Klarte ikke åpne indeksfile: %s"
 
-#: ../src/xrc/xmlres.cpp:724
+#: ../src/xrc/xmlres.cpp:722
 #, fuzzy, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Klarte ikke laste ressurs fra filen «%s»."
 
-#: ../src/html/helpwnd.cpp:1534
+#: ../src/html/helpwnd.cpp:1532
 msgid "Cannot print empty page."
 msgstr "Klarte ikke skrive ut tom side."
 
-#: ../src/msw/volume.cpp:507
+#: ../src/msw/volume.cpp:515
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Klarte ikke lese typenavn fra «%s»!"
 
-#: ../src/msw/thread.cpp:888
+#: ../src/msw/thread.cpp:894
 #, fuzzy, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Klarte ikke gjenoppta tråden %x"
 
-#: ../src/unix/threadpsx.cpp:1016
+#: ../src/unix/threadpsx.cpp:1028
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Klarte ikke hente trådplanleggingspolitikk."
 
-#: ../src/common/intl.cpp:558
+#: ../src/common/intl.cpp:365
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "Kan ikke sette språket til \"%s\"."
 
-#: ../src/unix/threadpsx.cpp:831 ../src/msw/thread.cpp:546
+#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
 msgid "Cannot start thread: error writing TLS."
 msgstr "Klarte ikke starte tråden: feil ved skriving til TLS."
 
-#: ../src/msw/thread.cpp:872
+#: ../src/msw/thread.cpp:864
 #, fuzzy, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Klarte ikke innstille tråden %x"
 
-#: ../src/msw/thread.cpp:794
+#: ../src/msw/thread.cpp:786
 msgid "Cannot wait for thread termination"
 msgstr "Klarte ikke vente på trådens avslutning"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:75
+#: ../src/common/accelcmn.cpp:72
 #, fuzzy
 msgid "Capital"
 msgstr "kursiv"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:879
+#: ../src/propgrid/advprops.cpp:780
 msgid "CaptionText"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:531
 msgid "Case sensitive"
 msgstr "Skill mellom små og store bokstaver"
 
-#: ../src/propgrid/manager.cpp:1509
+#: ../src/propgrid/manager.cpp:1527
 msgid "Categorized Mode"
 msgstr "Kategorisert Modus"
 
-#: ../src/richtext/richtextbuffer.cpp:9968
+#: ../src/richtext/richtextbuffer.cpp:9965
 #, fuzzy
 msgid "Cell Properties"
 msgstr "&Egenskaper"
 
-#: ../src/common/fmapbase.cpp:161
+#: ../src/common/fmapbase.cpp:158
 msgid "Celtic (ISO-8859-14)"
 msgstr "Keltisk (ISO-8859-14)"
 
-#: ../src/richtext/richtextindentspage.cpp:160
 #: ../src/richtext/richtextliststylepage.cpp:349
+#: ../src/richtext/richtextindentspage.cpp:160
 #, fuzzy
 msgid "Cen&tred"
 msgstr "Sentrert"
 
-#: ../src/common/stockitem.cpp:170
+#: ../src/common/stockitem.cpp:167
 msgid "Centered"
 msgstr "Sentrert"
 
-#: ../src/common/fmapbase.cpp:149
+#: ../src/common/fmapbase.cpp:146
 msgid "Central European (ISO-8859-2)"
 msgstr "Sentraleuropeisk (ISO-8859-2)"
 
@@ -2050,10 +2054,10 @@ msgstr "Sentraleuropeisk (ISO-8859-2)"
 msgid "Centre"
 msgstr "Sentrert"
 
-#: ../src/richtext/richtextindentspage.cpp:162
-#: ../src/richtext/richtextindentspage.cpp:164
 #: ../src/richtext/richtextliststylepage.cpp:351
 #: ../src/richtext/richtextliststylepage.cpp:353
+#: ../src/richtext/richtextindentspage.cpp:162
+#: ../src/richtext/richtextindentspage.cpp:164
 msgid "Centre text."
 msgstr "Sentrer tekst. "
 
@@ -2068,25 +2072,25 @@ msgstr "Sentrert"
 msgid "Ch&oose..."
 msgstr "&Gå til"
 
-#: ../src/richtext/richtextbuffer.cpp:4354
+#: ../src/richtext/richtextbuffer.cpp:4351
 msgid "Change List Style"
 msgstr "Endre liststilen"
 
-#: ../src/richtext/richtextbuffer.cpp:3709
+#: ../src/richtext/richtextbuffer.cpp:3706
 msgid "Change Object Style"
 msgstr "Endre objektstilen"
 
-#: ../src/richtext/richtextbuffer.cpp:3982
-#: ../src/richtext/richtextbuffer.cpp:8129
+#: ../src/richtext/richtextbuffer.cpp:3979
+#: ../src/richtext/richtextbuffer.cpp:8125
 #, fuzzy
 msgid "Change Properties"
 msgstr "&Egenskaper"
 
-#: ../src/richtext/richtextbuffer.cpp:3526
+#: ../src/richtext/richtextbuffer.cpp:3523
 msgid "Change Style"
 msgstr "Endre stil"
 
-#: ../src/common/fileconf.cpp:341
+#: ../src/common/fileconf.cpp:335
 #, c-format
 msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
 msgstr ""
@@ -2099,11 +2103,11 @@ msgid "Changing current directory to \"%s\" failed"
 msgstr "Klarte ikke opprette mappe «%s»"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1757
+#: ../src/propgrid/advprops.cpp:1658
 msgid "Character"
 msgstr ""
 
-#: ../src/richtext/richtextstyles.cpp:1063
+#: ../src/richtext/richtextstyles.cpp:1060
 msgid "Character styles"
 msgstr "Bokstavstiler"
 
@@ -2140,21 +2144,21 @@ msgstr "Klikk for å sette punktet i parentes."
 msgid "Check to indicate right-to-left text layout."
 msgstr "Klikk for å indikere høyre-mot-venstre skrift."
 
-#: ../src/osx/carbon/fontdlg.cpp:356 ../src/osx/carbon/fontdlg.cpp:358
+#: ../src/osx/carbon/fontdlg.cpp:353 ../src/osx/carbon/fontdlg.cpp:355
 msgid "Check to make the font bold."
 msgstr "Klikk for lage fet skrift."
 
-#: ../src/osx/carbon/fontdlg.cpp:363 ../src/osx/carbon/fontdlg.cpp:365
+#: ../src/osx/carbon/fontdlg.cpp:360 ../src/osx/carbon/fontdlg.cpp:362
 msgid "Check to make the font italic."
 msgstr "Klikk for å lage kursiv skrift."
 
-#: ../src/osx/carbon/fontdlg.cpp:372 ../src/osx/carbon/fontdlg.cpp:374
+#: ../src/osx/carbon/fontdlg.cpp:369 ../src/osx/carbon/fontdlg.cpp:371
 #, fuzzy
 msgid "Check to make the font underlined."
 msgstr "Om skriften er understreket."
 
-#: ../src/richtext/richtextstyledlg.cpp:289
-#: ../src/richtext/richtextstyledlg.cpp:291
+#: ../src/richtext/richtextstyledlg.cpp:285
+#: ../src/richtext/richtextstyledlg.cpp:287
 msgid "Check to restart numbering."
 msgstr "Klikk for å gjenstarte nummereringen."
 
@@ -2188,55 +2192,55 @@ msgstr "Klikk for å vise tekst i superskript."
 msgid "Check to suppress hyphenation."
 msgstr "Klikk for å unngå gåseøyne."
 
-#: ../src/msw/dialup.cpp:763
+#: ../src/msw/dialup.cpp:757
 msgid "Choose ISP to dial"
 msgstr "Velg ISP for oppringing"
 
-#: ../src/propgrid/props.cpp:1922
+#: ../src/propgrid/props.cpp:1904
 #, fuzzy
 msgid "Choose a directory:"
 msgstr "Opprett mappe"
 
-#: ../src/propgrid/props.cpp:1975
+#: ../src/propgrid/props.cpp:2199
 #, fuzzy
 msgid "Choose a file"
 msgstr "Velg skrift"
 
-#: ../src/generic/colrdlgg.cpp:158 ../src/gtk/colordlg.cpp:54
+#: ../src/generic/colrdlgg.cpp:156 ../src/gtk/colordlg.cpp:49
 msgid "Choose colour"
 msgstr "Velg farge"
 
-#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/gtk1/fontdlg.cpp:125 ../src/generic/fontpickerg.cpp:47
+#: ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Velg skrift"
 
-#: ../src/common/module.cpp:74
+#: ../src/common/module.cpp:71
 #, c-format
 msgid "Circular dependency involving module \"%s\" detected."
 msgstr "Sirkulær avhengighet i modulen \"%s\" er oppdaget."
 
-#: ../src/aui/tabmdi.cpp:108 ../src/generic/mdig.cpp:97
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
 msgid "Cl&ose"
 msgstr "&Lukk"
 
-#: ../src/msw/ole/automtn.cpp:684
+#: ../src/msw/ole/automtn.cpp:675
 #, fuzzy
 msgid "Class not registered."
 msgstr "Klarte ikke opprette tråd"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:147 ../src/common/accelcmn.cpp:72
+#: ../src/common/stockitem.cpp:144 ../src/common/accelcmn.cpp:69
 #, fuzzy
 msgid "Clear"
 msgstr "&Fjern"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "Clear the log contents"
 msgstr "Tøm loggen for innhold"
 
-#: ../src/richtext/richtextstyledlg.cpp:252
-#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:248
+#: ../src/richtext/richtextstyledlg.cpp:250
 msgid "Click to apply the selected style."
 msgstr "Klikk for å bruke valgt stil."
 
@@ -2247,15 +2251,15 @@ msgstr "Klikk for å bruke valgt stil."
 msgid "Click to browse for a symbol."
 msgstr "Klikk for å bla gjennom etter symbol."
 
-#: ../src/osx/carbon/fontdlg.cpp:403 ../src/osx/carbon/fontdlg.cpp:405
+#: ../src/osx/carbon/fontdlg.cpp:400 ../src/osx/carbon/fontdlg.cpp:402
 msgid "Click to cancel changes to the font."
 msgstr "Klikk for å avbryte endringer på fonten."
 
-#: ../src/generic/fontdlgg.cpp:472 ../src/generic/fontdlgg.cpp:491
+#: ../src/generic/fontdlgg.cpp:468 ../src/generic/fontdlgg.cpp:487
 msgid "Click to cancel the font selection."
 msgstr "Klikk for å avbrytevalg av font."
 
-#: ../src/osx/carbon/fontdlg.cpp:384 ../src/osx/carbon/fontdlg.cpp:386
+#: ../src/osx/carbon/fontdlg.cpp:381 ../src/osx/carbon/fontdlg.cpp:383
 msgid "Click to change the font colour."
 msgstr "Klikk for å endre farge på skrift."
 
@@ -2274,40 +2278,40 @@ msgstr "Klikk for å endre tekstfarge."
 msgid "Click to choose the font for this level."
 msgstr "Klikk for å velge for for dette nivået."
 
-#: ../src/richtext/richtextstyledlg.cpp:279
-#: ../src/richtext/richtextstyledlg.cpp:281
+#: ../src/richtext/richtextstyledlg.cpp:275
+#: ../src/richtext/richtextstyledlg.cpp:277
 #, fuzzy
 msgid "Click to close this window."
 msgstr "Lukk dette vinduet"
 
-#: ../src/osx/carbon/fontdlg.cpp:410 ../src/osx/carbon/fontdlg.cpp:412
+#: ../src/osx/carbon/fontdlg.cpp:407 ../src/osx/carbon/fontdlg.cpp:409
 #, fuzzy
 msgid "Click to confirm changes to the font."
 msgstr "Klikk for å bekrefte skriftvalg"
 
-#: ../src/generic/fontdlgg.cpp:477 ../src/generic/fontdlgg.cpp:479
-#: ../src/generic/fontdlgg.cpp:484 ../src/generic/fontdlgg.cpp:486
+#: ../src/generic/fontdlgg.cpp:473 ../src/generic/fontdlgg.cpp:475
+#: ../src/generic/fontdlgg.cpp:480 ../src/generic/fontdlgg.cpp:482
 msgid "Click to confirm the font selection."
 msgstr "Klikk for å bekrefte skriftvalg"
 
-#: ../src/richtext/richtextstyledlg.cpp:244
-#: ../src/richtext/richtextstyledlg.cpp:246
+#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:242
 msgid "Click to create a new box style."
 msgstr "Klikk for å lage en ny boksstil."
 
-#: ../src/richtext/richtextstyledlg.cpp:226
-#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:224
 msgid "Click to create a new character style."
 msgstr "Klikk for å lage en ny bokstavstil."
 
-#: ../src/richtext/richtextstyledlg.cpp:238
-#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:236
 #, fuzzy
 msgid "Click to create a new list style."
 msgstr "Klikk for å avbryte skriftvalg."
 
-#: ../src/richtext/richtextstyledlg.cpp:232
-#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:230
 msgid "Click to create a new paragraph style."
 msgstr "Klikk for å lage en ny stil for avsnitt."
 
@@ -2321,8 +2325,8 @@ msgstr "Klikk for å lage ny tab-posisjon."
 msgid "Click to delete all tab positions."
 msgstr "Klikk for å fjerne alle tab-posisjoner."
 
-#: ../src/richtext/richtextstyledlg.cpp:270
-#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:268
 msgid "Click to delete the selected style."
 msgstr "Klikk for å fjerne valgt stil.."
 
@@ -2331,25 +2335,25 @@ msgstr "Klikk for å fjerne valgt stil.."
 msgid "Click to delete the selected tab position."
 msgstr "Klikk for å fjerne valgt tab-posisjon."
 
-#: ../src/richtext/richtextstyledlg.cpp:264
-#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:262
 msgid "Click to edit the selected style."
 msgstr "Klikk for å endre valgt stil."
 
-#: ../src/richtext/richtextstyledlg.cpp:258
-#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:256
 msgid "Click to rename the selected style."
 msgstr "Klikk for å døpe om valgt stil."
 
-#: ../src/generic/dbgrptg.cpp:97 ../src/generic/progdlgg.cpp:759
-#: ../src/richtext/richtextstyledlg.cpp:277
-#: ../src/richtext/richtextsymboldlg.cpp:476 ../src/common/stockitem.cpp:148
-#: ../src/msw/progdlg.cpp:170 ../src/msw/progdlg.cpp:679
-#: ../src/html/helpdlg.cpp:90
+#: ../src/common/stockitem.cpp:145 ../src/generic/dbgrptg.cpp:94
+#: ../src/generic/progdlgg.cpp:781 ../src/msw/progdlg.cpp:211
+#: ../src/msw/progdlg.cpp:946 ../src/html/helpdlg.cpp:87
+#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextstyledlg.cpp:273
 msgid "Close"
 msgstr "Lukk"
 
-#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:98
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
 msgid "Close All"
 msgstr "Lukk alle"
 
@@ -2357,68 +2361,68 @@ msgstr "Lukk alle"
 msgid "Close current document"
 msgstr "Lukk dette dokumentet"
 
-#: ../src/generic/logg.cpp:516
+#: ../src/generic/logg.cpp:513
 msgid "Close this window"
 msgstr "Lukk dette vinduet"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6006
+#: ../src/generic/datavgen.cpp:6811
 msgid "Collapse"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 #, fuzzy
 msgid "Color"
 msgstr "&Farge"
 
-#: ../src/richtext/richtextformatdlg.cpp:776
+#: ../src/richtext/richtextformatdlg.cpp:768
 #, fuzzy
 msgid "Colour"
 msgstr "&Farge"
 
-#: ../src/msw/colordlg.cpp:158
+#: ../src/msw/colordlg.cpp:227
 #, fuzzy, c-format
 msgid "Colour selection dialog failed with error %0lx."
 msgstr "Utførelse av kommandoen «%s» feilet med feil: %ul"
 
-#: ../src/osx/carbon/fontdlg.cpp:380
+#: ../src/osx/carbon/fontdlg.cpp:377
 #, fuzzy
 msgid "Colour:"
 msgstr "&Farge"
 
-#: ../src/generic/datavgen.cpp:6077
+#: ../src/generic/datavgen.cpp:6882
 #, fuzzy, c-format
 msgid "Column %u"
 msgstr "Legg til Kolonne"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:114
+#: ../src/common/accelcmn.cpp:112
 msgid "Command"
 msgstr ""
 
-#: ../src/common/init.cpp:196
+#: ../src/common/init.cpp:193
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
 "ignored."
 msgstr ""
 
-#: ../src/msw/fontdlg.cpp:120
+#: ../src/msw/fontdlg.cpp:170
 #, fuzzy, c-format
 msgid "Common dialog failed with error code %0lx."
 msgstr "Utførelse av kommandoen «%s» feilet med feil: %ul"
 
-#: ../src/gtk/window.cpp:4649
+#: ../src/gtk/window.cpp:5653
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:1549
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Komprimert HTML-hjelpfil (*.chm)|*.chm|"
 
-#: ../src/generic/dirctrlg.cpp:444
+#: ../src/generic/dirctrlg.cpp:410
 msgid "Computer"
 msgstr "Datamaskin"
 
@@ -2427,56 +2431,60 @@ msgstr "Datamaskin"
 msgid "Config entry name cannot start with '%c'."
 msgstr "Konfigurasjonsoppføring kan ikke starte med «%c»."
 
-#: ../src/generic/filedlgg.cpp:349 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
 msgid "Confirm"
 msgstr "Bekreft"
 
-#: ../src/html/htmlwin.cpp:566
+#: ../src/html/htmlwin.cpp:569
 msgid "Connecting..."
 msgstr "Kobler til..."
 
-#: ../src/html/helpwnd.cpp:475
+#: ../src/html/helpwnd.cpp:473
 msgid "Contents"
 msgstr "Innhold"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:880
+#: ../src/propgrid/advprops.cpp:781
 msgid "ControlDark"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:881
+#: ../src/propgrid/advprops.cpp:782
 msgid "ControlLight"
 msgstr ""
 
-#: ../src/common/strconv.cpp:2262
+#: ../src/common/strconv.cpp:2208
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Klarte ikke konvertere til tegnsett «%s»."
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 #, fuzzy
 msgid "Convert"
 msgstr "Innhold"
 
-#: ../src/html/htmlwin.cpp:1079
+#: ../src/html/htmlwin.cpp:1020
 #, c-format
 msgid "Copied to clipboard:\"%s\""
 msgstr "Kopiert til utklippstavle: «%s»"
 
-#: ../src/generic/prntdlgg.cpp:247
+#: ../src/generic/prntdlgg.cpp:240
 msgid "Copies:"
 msgstr "Kopier;"
 
-#: ../src/common/stockitem.cpp:150 ../src/stc/stc_i18n.cpp:18
+#: ../src/common/stockitem.cpp:147 ../src/stc/stc_i18n.cpp:18
 #, fuzzy
 msgid "Copy"
 msgstr "&Kopier"
 
-#: ../src/common/stockitem.cpp:258
+#: ../src/common/stockitem.cpp:255
 #, fuzzy
 msgid "Copy selection"
 msgstr "Seksjoner"
+
+#: ../src/generic/grid.cpp:5945
+msgid "Copying more than one selected block to clipboard is not supported."
+msgstr ""
 
 #: ../src/richtext/richtextborderspage.cpp:566
 #: ../src/richtext/richtextborderspage.cpp:601
@@ -2487,203 +2495,197 @@ msgstr "Hjørne"
 msgid "Corner &radius:"
 msgstr "Hjørne&radius:"
 
-#: ../src/html/chm.cpp:718
+#: ../src/html/chm.cpp:711
 #, c-format
 msgid "Could not create temporary file '%s'"
 msgstr "Klarte ikke opprette midlertidig fil «%s»"
 
-#: ../src/html/chm.cpp:273
+#: ../src/html/chm.cpp:270
 #, c-format
 msgid "Could not extract %s into %s: %s"
 msgstr "Klarte ikke å trekke ut %s inni %s: %s"
 
-#: ../src/generic/tabg.cpp:1048
+#: ../src/generic/tabg.cpp:1045
 msgid "Could not find tab for id"
 msgstr "Klarte ikke finne tab for id"
 
-#: ../src/gtk/notifmsg.cpp:108
-#, fuzzy
-msgid "Could not initalize libnotify."
-msgstr "Klarte ikke å sette justering."
-
-#: ../src/html/chm.cpp:444
+#: ../src/html/chm.cpp:437
 #, c-format
 msgid "Could not locate file '%s'."
 msgstr "Klarte ikke å finne fil «%s»."
 
-#: ../src/common/filefn.cpp:1403
+#: ../src/msw/graphicsd2d.cpp:604
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/common/filefn.cpp:1291
 #, fuzzy
 msgid "Could not set current working directory"
 msgstr "Klarte ikke finne gjeldende mappe"
 
-#: ../src/common/prntbase.cpp:2015
+#: ../src/common/prntbase.cpp:2037
 msgid "Could not start document preview."
 msgstr "Klarte ikke starte dokumentforhåndsvisning."
 
-#: ../src/generic/printps.cpp:178 ../src/msw/printwin.cpp:210
-#: ../src/gtk/print.cpp:1132
+#: ../src/generic/printps.cpp:159 ../src/msw/printwin.cpp:184
+#: ../src/gtk/print.cpp:1129
 msgid "Could not start printing."
 msgstr "Klarte ikke starte utskrift."
 
-#: ../src/common/wincmn.cpp:2125
+#: ../src/common/wincmn.cpp:2126
 msgid "Could not transfer data to window"
 msgstr "Klarte ikke overføre data til vindu"
 
-#: ../src/msw/imaglist.cpp:187 ../src/msw/imaglist.cpp:224
-#: ../src/msw/imaglist.cpp:249 ../src/msw/dragimag.cpp:185
-#: ../src/msw/dragimag.cpp:220
+#: ../src/msw/imaglist.cpp:223 ../src/msw/imaglist.cpp:245
+#: ../src/msw/imaglist.cpp:270 ../src/msw/dragimag.cpp:182
+#: ../src/msw/dragimag.cpp:217
 msgid "Couldn't add an image to the image list."
 msgstr "Klarte ikke legge til et bilde i bildelisten."
 
-#: ../src/osx/glcanvas_osx.cpp:414 ../src/unix/glx11.cpp:558
-#: ../src/msw/glcanvas.cpp:616
+#: ../src/osx/glcanvas_osx.cpp:411 ../src/msw/glcanvas.cpp:631
+#: ../src/unix/glegl.cpp:315 ../src/unix/glx11.cpp:559
 #, fuzzy
 msgid "Couldn't create OpenGL context"
 msgstr "Klarte ikke opprette en timer"
 
-#: ../src/msw/timer.cpp:134
+#: ../src/msw/timer.cpp:131
 msgid "Couldn't create a timer"
 msgstr "Klarte ikke opprette en timer"
 
-#: ../src/osx/carbon/overlay.cpp:122
-#, fuzzy
-msgid "Couldn't create the overlay window"
-msgstr "Klarte ikke opprette en timer"
-
-#: ../src/common/translation.cpp:2024
+#: ../src/common/translation.cpp:2074
 #, fuzzy
 msgid "Couldn't enumerate translations"
 msgstr "Klarte ikke avslutte tråden."
 
-#: ../src/common/dynlib.cpp:120
+#: ../src/common/dynlib.cpp:110
 #, c-format
 msgid "Couldn't find symbol '%s' in a dynamic library"
 msgstr "Klarte ikke finne symbol «%s» i et dynamisk bibliotek"
 
-#: ../src/msw/thread.cpp:915
+#: ../src/msw/thread.cpp:921
 msgid "Couldn't get the current thread pointer"
 msgstr "Klarte ikke finne gjeldende trådpeker"
 
-#: ../src/osx/carbon/overlay.cpp:129
-#, fuzzy
-msgid "Couldn't init the context on the overlay window"
-msgstr "Klarte ikke finne gjeldende trådpeker"
-
-#: ../src/common/imaggif.cpp:244
+#: ../src/common/imaggif.cpp:241
 #, fuzzy
 msgid "Couldn't initialize GIF hash table."
 msgstr "Klarte ikke klargjøre zlib-strøm for nedpakking."
 
-#: ../src/common/imagpng.cpp:409
+#: ../src/common/imagpng.cpp:437
 msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
 msgstr ""
 "Klarte ikke laste PNG-bilde - filen er ødelagt er det er for lite minne."
 
-#: ../src/unix/sound.cpp:470
+#: ../src/unix/sound.cpp:459
 #, c-format
 msgid "Couldn't load sound data from '%s'."
 msgstr "Klarte ikke laste lyddata fra «%s»."
 
-#: ../src/msw/dirdlg.cpp:435
+#: ../src/msw/dirdlg.cpp:287
 #, fuzzy
 msgid "Couldn't obtain folder name"
 msgstr "Klarte ikke opprette en timer"
 
-#: ../src/unix/sound_sdl.cpp:229
+#: ../src/unix/sound_sdl.cpp:226
 #, c-format
 msgid "Couldn't open audio: %s"
 msgstr "Klarte ikke åpne lyd: %s"
 
-#: ../src/msw/ole/dataobj.cpp:377
+#: ../src/msw/ole/dataobj.cpp:385
 #, c-format
 msgid "Couldn't register clipboard format '%s'."
 msgstr "Klarte ikke registrere utklippstavleformat «%s»."
 
-#: ../src/msw/listctrl.cpp:869
+#: ../src/msw/listctrl.cpp:933
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "Klarte ikke hente informasjon om listekontrolelement %d."
 
-#: ../src/common/imagpng.cpp:498 ../src/common/imagpng.cpp:509
-#: ../src/common/imagpng.cpp:519
+#: ../src/common/imagpng.cpp:511 ../src/common/imagpng.cpp:522
+#: ../src/common/imagpng.cpp:532
 msgid "Couldn't save PNG image."
 msgstr "Klarte ikke lagre PNG-bilde."
 
-#: ../src/msw/thread.cpp:684
+#: ../src/msw/thread.cpp:676
 msgid "Couldn't terminate thread"
 msgstr "Klarte ikke avslutte tråden."
 
-#: ../src/common/xtistrm.cpp:166
+#: ../src/common/xtistrm.cpp:163
 #, fuzzy, c-format
 msgid "Create Parameter %s not found in declared RTTI Parameters"
 msgstr "Create Parameter ble ikke funnet blant deklarerte RTTI parametere"
 
-#: ../src/generic/dirdlgg.cpp:288
+#: ../src/generic/dirdlgg.cpp:285
 msgid "Create directory"
 msgstr "Opprett mappe"
 
-#: ../src/generic/filedlgg.cpp:212 ../src/generic/dirdlgg.cpp:111
+#: ../src/generic/filedlgg.cpp:209 ../src/generic/dirdlgg.cpp:108
 msgid "Create new directory"
 msgstr "Opprett ny mappe"
 
-#: ../src/xrc/xmlres.cpp:2460
+#: ../src/common/stockitem.cpp:264
+#, fuzzy
+msgid "Create new document"
+msgstr "Opprett ny mappe"
+
+#: ../src/xrc/xmlres.cpp:2515
 #, fuzzy, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Utpakking av «%s» inni «%s» feilet."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1758
+#: ../src/propgrid/advprops.cpp:1659
 msgid "Cross"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:333
+#: ../src/common/accelcmn.cpp:347
 msgid "Ctrl+"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:332 ../src/osx/textctrl_osx.cpp:576
-#: ../src/common/stockitem.cpp:151 ../src/msw/textctrl.cpp:2507
+#: ../src/osx/textctrl_osx.cpp:594 ../src/common/stockitem.cpp:148
+#: ../src/msw/textctrl.cpp:2772 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "Klipp u&t"
 
-#: ../src/generic/filectrlg.cpp:940
+#: ../src/generic/filectrlg.cpp:936
 msgid "Current directory:"
 msgstr "Gjeldende mappe:"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:896 ../src/propgrid/advprops.cpp:1574
-#: ../src/propgrid/advprops.cpp:1612
+#: ../src/propgrid/advprops.cpp:797 ../src/propgrid/advprops.cpp:1475
+#: ../src/propgrid/advprops.cpp:1518
 msgid "Custom"
 msgstr ""
 
-#: ../src/gtk/print.cpp:217
+#: ../src/gtk/print.cpp:211
 msgid "Custom size"
 msgstr "Selvvalgt størrelse"
 
-#: ../src/common/headerctrlcmn.cpp:60
+#: ../src/common/headerctrlcmn.cpp:58
 msgid "Customize Columns"
 msgstr "Selvvalgte kolonner"
 
-#: ../src/common/stockitem.cpp:151 ../src/stc/stc_i18n.cpp:17
+#: ../src/common/stockitem.cpp:148 ../src/stc/stc_i18n.cpp:17
 msgid "Cut"
 msgstr "Klipp u&t"
 
-#: ../src/common/stockitem.cpp:259
+#: ../src/common/stockitem.cpp:256
 msgid "Cut selection"
 msgstr "Klipp ut Seksjoner"
 
-#: ../src/common/fmapbase.cpp:152
+#: ../src/common/fmapbase.cpp:149
 msgid "Cyrillic (ISO-8859-5)"
 msgstr "Kyrillisk (ISO-8859-5)"
 
-#: ../src/common/paper.cpp:99
+#: ../src/common/paper.cpp:96
 msgid "D sheet, 22 x 34 in"
 msgstr "D-ark, 22 x 34 tommer"
 
-#: ../src/msw/dde.cpp:703
+#: ../src/msw/dde.cpp:698
 msgid "DDE poke request failed"
 msgstr "DDE-«snuse» forespørsel feilet"
 
-#: ../src/common/imagbmp.cpp:1169
+#: ../src/common/imagbmp.cpp:1181
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr "DIB-hode: Koding stemmer ikke med bitdybde."
 
@@ -2703,7 +2705,7 @@ msgstr "DIB-hode: Ukjent bitdybde i filen."
 msgid "DIB Header: Unknown encoding in file."
 msgstr "DIB-hode: Ukjent koding i filen."
 
-#: ../src/common/paper.cpp:121
+#: ../src/common/paper.cpp:118
 msgid "DL Envelope, 110 x 220 mm"
 msgstr "DL-konvolutt, 11 x 220 mm"
 
@@ -2711,56 +2713,56 @@ msgstr "DL-konvolutt, 11 x 220 mm"
 msgid "Dashed"
 msgstr ""
 
-#: ../src/generic/dbgrptg.cpp:300
+#: ../src/generic/dbgrptg.cpp:301
 #, c-format
 msgid "Debug report \"%s\""
 msgstr "Feilsøkingsrapport «%s»"
 
-#: ../src/common/debugrpt.cpp:210
+#: ../src/common/debugrpt.cpp:211
 msgid "Debug report couldn't be created."
 msgstr "Feilsøkingsrapport kunne ikke opprettes."
 
-#: ../src/common/debugrpt.cpp:553
+#: ../src/common/debugrpt.cpp:554
 msgid "Debug report generation has failed."
 msgstr "Generering av feilsøkingsrapport feilet."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:84
+#: ../src/common/accelcmn.cpp:81
 msgid "Decimal"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:323
+#: ../src/generic/fontdlgg.cpp:319
 msgid "Decorative"
 msgstr "Dekorativ"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1752
+#: ../src/propgrid/advprops.cpp:1653
 #, fuzzy
 msgid "Default"
 msgstr "standard"
 
-#: ../src/common/fmapbase.cpp:796
+#: ../src/common/fmapbase.cpp:792
 msgid "Default encoding"
 msgstr "Standardkoding"
 
-#: ../src/dfb/fontmgr.cpp:180
+#: ../src/dfb/fontmgr.cpp:177
 #, fuzzy
 msgid "Default font"
 msgstr "Standard skriver"
 
-#: ../src/generic/prntdlgg.cpp:510
+#: ../src/generic/prntdlgg.cpp:503
 msgid "Default printer"
 msgstr "Standard skriver"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:51
+#: ../src/common/accelcmn.cpp:48
 #, fuzzy
 msgid "Del"
 msgstr "&Slett"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextbuffer.cpp:8221 ../src/common/stockitem.cpp:152
-#: ../src/common/accelcmn.cpp:50 ../src/stc/stc_i18n.cpp:20
+#: ../src/common/stockitem.cpp:149 ../src/common/accelcmn.cpp:47
+#: ../src/richtext/richtextbuffer.cpp:8217 ../src/stc/stc_i18n.cpp:20
 #, fuzzy
 msgid "Delete"
 msgstr "&Slett"
@@ -2770,74 +2772,74 @@ msgstr "&Slett"
 msgid "Delete A&ll"
 msgstr "Velg &alle"
 
-#: ../src/richtext/richtextbuffer.cpp:11341
+#: ../src/richtext/richtextbuffer.cpp:11340
 #, fuzzy
 msgid "Delete Column"
 msgstr "Seksjoner"
 
-#: ../src/richtext/richtextbuffer.cpp:11291
+#: ../src/richtext/richtextbuffer.cpp:11290
 #, fuzzy
 msgid "Delete Row"
 msgstr "&Slett"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 #, fuzzy
 msgid "Delete Style"
 msgstr "Slett element"
 
-#: ../src/richtext/richtextctrl.cpp:1345 ../src/richtext/richtextctrl.cpp:1584
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
 #, fuzzy
 msgid "Delete Text"
 msgstr "Slett element"
 
-#: ../src/generic/editlbox.cpp:170
+#: ../src/generic/editlbox.cpp:147
 msgid "Delete item"
 msgstr "Slett element"
 
-#: ../src/common/stockitem.cpp:260
+#: ../src/common/stockitem.cpp:257
 #, fuzzy
 msgid "Delete selection"
 msgstr "Seksjoner"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 #, fuzzy, c-format
 msgid "Delete style %s?"
 msgstr "Slett element"
 
-#: ../src/unix/snglinst.cpp:301
+#: ../src/unix/snglinst.cpp:298
 #, c-format
 msgid "Deleted stale lock file '%s'."
 msgstr "Slettet forslitt låsefil «%s»."
 
-#: ../src/common/secretstore.cpp:220
+#: ../src/common/secretstore.cpp:234
 #, fuzzy, c-format
-msgid "Deleting password for \"%s/%s\" failed: %s."
+msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Utpakking av «%s» inni «%s» feilet."
 
-#: ../src/common/module.cpp:124
+#: ../src/common/module.cpp:121
 #, c-format
 msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 #, fuzzy
 msgid "Descending"
 msgstr "Standardkoding"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:526 ../src/propgrid/advprops.cpp:882
+#: ../src/generic/dirctrlg.cpp:492 ../src/propgrid/advprops.cpp:783
 msgid "Desktop"
 msgstr "Skrivebord"
 
-#: ../src/generic/aboutdlgg.cpp:70
+#: ../src/generic/aboutdlgg.cpp:67
 msgid "Developed by "
 msgstr "Utviklet av"
 
-#: ../src/generic/aboutdlgg.cpp:176
+#: ../src/generic/aboutdlgg.cpp:173
 msgid "Developers"
 msgstr "Utviklere"
 
-#: ../src/msw/dialup.cpp:374
+#: ../src/msw/dialup.cpp:368
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -2845,11 +2847,11 @@ msgstr ""
 "Oppringingsfunskjonene er utilgjengelig fordi Remote Access Service (RAS) "
 "ikke er installert på denne maskinene."
 
-#: ../src/generic/tipdlg.cpp:211
+#: ../src/generic/tipdlg.cpp:208
 msgid "Did you know..."
 msgstr "Visste du at..."
 
-#: ../src/dfb/wrapdfb.cpp:63
+#: ../src/dfb/wrapdfb.cpp:60
 #, c-format
 msgid "DirectFB error %d occurred."
 msgstr ""
@@ -2858,29 +2860,29 @@ msgstr ""
 msgid "Directories"
 msgstr "Mapper"
 
-#: ../src/common/filefn.cpp:1183
+#: ../src/common/filefn.cpp:1071
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Mappe «%s» kunne ikke opprettes"
 
-#: ../src/common/filefn.cpp:1197
+#: ../src/common/filefn.cpp:1085
 #, fuzzy, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "Mappe «%s» kunne ikke opprettes"
 
-#: ../src/generic/dirdlgg.cpp:204
+#: ../src/generic/dirdlgg.cpp:201
 msgid "Directory does not exist"
 msgstr "Mappen eksisterer ikke"
 
-#: ../src/generic/filectrlg.cpp:1399
+#: ../src/generic/filectrlg.cpp:1388
 msgid "Directory doesn't exist."
 msgstr "Mappen eksisterer ikke."
 
-#: ../src/common/docview.cpp:457
+#: ../src/common/docview.cpp:450
 msgid "Discard changes and reload the last saved version?"
 msgstr "Forkast endringene og last opp den forrige versjonen?"
 
-#: ../src/html/helpwnd.cpp:502
+#: ../src/html/helpwnd.cpp:500
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -2888,45 +2890,45 @@ msgstr ""
 "Vis alle indekselementer som inneholder den oppgitte delstrengen. Søket er "
 "uavhengig av liten eller stor bokstav."
 
-#: ../src/html/helpwnd.cpp:679
+#: ../src/html/helpwnd.cpp:677
 msgid "Display options dialog"
 msgstr "Vis innstillingsvindu"
 
-#: ../src/html/helpwnd.cpp:322
+#: ../src/html/helpwnd.cpp:320
 msgid "Displays help as you browse the books on the left."
 msgstr "Viser hjelp mens du blar gjennom bøkene til venstre."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:85
+#: ../src/common/accelcmn.cpp:83
 msgid "Divide"
 msgstr ""
 
-#: ../src/common/docview.cpp:533
+#: ../src/common/docview.cpp:526
 #, fuzzy, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Vil du lagre endringer til document «%s»?"
 
-#: ../src/common/prntbase.cpp:542
+#: ../src/common/prntbase.cpp:537
 msgid "Document:"
 msgstr "Dokument:"
 
-#: ../src/generic/aboutdlgg.cpp:73
+#: ../src/generic/aboutdlgg.cpp:70
 msgid "Documentation by "
 msgstr "Dokumentert av"
 
-#: ../src/generic/aboutdlgg.cpp:180
+#: ../src/generic/aboutdlgg.cpp:177
 msgid "Documentation writers"
 msgstr "Dokumentforfattere"
 
-#: ../src/common/sizer.cpp:2799
+#: ../src/common/sizer.cpp:2916
 msgid "Don't Save"
 msgstr "Ikke lagre"
 
-#: ../src/html/htmlwin.cpp:633
+#: ../src/html/htmlwin.cpp:643
 msgid "Done"
 msgstr "Ferdig"
 
-#: ../src/generic/progdlgg.cpp:448 ../src/msw/progdlg.cpp:407
+#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
 msgid "Done."
 msgstr "ferdig."
 
@@ -2939,44 +2941,44 @@ msgstr "Prikket"
 msgid "Double"
 msgstr "Ferdig"
 
-#: ../src/common/paper.cpp:176
+#: ../src/common/paper.cpp:173
 msgid "Double Japanese Postcard Rotated 148 x 200 mm"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:273
+#: ../src/common/xtixml.cpp:269
 #, c-format
 msgid "Doubly used id : %d"
 msgstr "Dobbel bruker-ID: %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:153
-#: ../src/common/accelcmn.cpp:64
+#: ../src/common/stockitem.cpp:150 ../src/common/accelcmn.cpp:61
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Down"
 msgstr "Ned"
 
-#: ../src/richtext/richtextctrl.cpp:865
+#: ../src/richtext/richtextctrl.cpp:864
 msgid "Drag"
 msgstr "Dra"
 
-#: ../src/common/paper.cpp:100
+#: ../src/common/paper.cpp:97
 msgid "E sheet, 34 x 44 in"
 msgstr "E-ark, 34 x 44 tommer"
 
-#: ../src/unix/fswatcher_inotify.cpp:561
+#: ../src/unix/fswatcher_inotify.cpp:558
 #, fuzzy
 msgid "EOF while reading from inotify descriptor"
 msgstr "klarte ikke lese fra fildeskriptor %d"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 #, fuzzy
 msgid "Edit"
 msgstr "Redigere element"
 
-#: ../src/generic/editlbox.cpp:168
+#: ../src/generic/editlbox.cpp:131
 msgid "Edit item"
 msgstr "Redigere element"
 
-#: ../include/wx/generic/progdlgg.h:84
+#: ../include/wx/generic/progdlgg.h:85
 #, fuzzy
 msgid "Elapsed time:"
 msgstr "Forløpt tid :"
@@ -3044,64 +3046,64 @@ msgid "Enables the shadow spread."
 msgstr "Bruk skyggespredning."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:66
+#: ../src/common/accelcmn.cpp:63
 msgid "End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:55
+#: ../src/common/accelcmn.cpp:52
 #, fuzzy
 msgid "Enter"
 msgstr "Skriver"
 
-#: ../src/richtext/richtextstyledlg.cpp:934
+#: ../src/richtext/richtextstyledlg.cpp:930
 msgid "Enter a box style name"
 msgstr "Navn på boksstil"
 
-#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:602
 msgid "Enter a character style name"
 msgstr "Navn på bokstavstil"
 
-#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:816
 msgid "Enter a list style name"
 msgstr "Navn på stilen"
 
-#: ../src/richtext/richtextstyledlg.cpp:893
+#: ../src/richtext/richtextstyledlg.cpp:889
 msgid "Enter a new style name"
 msgstr "Navn på skriftstil"
 
-#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:650
 msgid "Enter a paragraph style name"
 msgstr "Navn på avsnittstil"
 
-#: ../src/generic/dbgrptg.cpp:174
+#: ../src/generic/dbgrptg.cpp:171
 #, c-format
 msgid "Enter command to open file \"%s\":"
 msgstr "Skriv inn kommando for å åpne fil «%s»:"
 
-#: ../src/generic/helpext.cpp:459
+#: ../src/generic/helpext.cpp:457
 msgid "Entries found"
 msgstr "Oppføringer funnet"
 
-#: ../src/common/paper.cpp:142
+#: ../src/common/paper.cpp:139
 #, fuzzy
 msgid "Envelope Invite 220 x 220 mm"
 msgstr "DL-konvolutt, 11 x 220 mm"
 
-#: ../src/common/config.cpp:469
+#: ../src/common/config.cpp:465
 #, c-format
 msgid ""
 "Environment variables expansion failed: missing '%c' at position %u in '%s'."
 msgstr ""
 "Utvidelse av miljøvariabel feilet: manglende «%c» i posisjon %u i «%s»."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/generic/dirctrlg.cpp:570
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/dirctrlg.cpp:599
-#: ../src/generic/dirdlgg.cpp:323 ../src/generic/filectrlg.cpp:642
-#: ../src/generic/filectrlg.cpp:756 ../src/generic/filectrlg.cpp:770
-#: ../src/generic/filectrlg.cpp:786 ../src/generic/filectrlg.cpp:1368
-#: ../src/generic/filectrlg.cpp:1399 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/gtk1/fontdlg.cpp:74 ../src/generic/dirctrlg.cpp:536
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/dirctrlg.cpp:565
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1357 ../src/generic/filectrlg.cpp:1388
+#: ../src/generic/filedlgg.cpp:354 ../src/generic/dirdlgg.cpp:320
+#: ../src/gtk/filedlg.cpp:74
 msgid "Error"
 msgstr "Feil"
 
@@ -3110,91 +3112,102 @@ msgstr "Feil"
 msgid "Error closing epoll descriptor"
 msgstr "Feil ved opprettelse av mappe"
 
-#: ../src/unix/fswatcher_kqueue.cpp:114
+#: ../src/unix/fswatcher_kqueue.cpp:131
 #, fuzzy
 msgid "Error closing kqueue instance"
 msgstr "Feil ved opprettelse av mappe"
 
-#: ../src/common/filefn.cpp:1049
+#: ../src/common/filefn.cpp:938
 #, fuzzy, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Klarte ikke kopiere file «%s» til «%s»."
 
-#: ../src/generic/dirdlgg.cpp:222
+#: ../src/generic/dirdlgg.cpp:219
 msgid "Error creating directory"
 msgstr "Feil ved opprettelse av mappe"
 
-#: ../src/common/imagbmp.cpp:1181
+#: ../src/common/imagbmp.cpp:1193
 #, fuzzy
 msgid "Error in reading image DIB."
 msgstr "Feil ved lesing av bilde DIB."
 
-#: ../src/propgrid/propgrid.cpp:6696
+#: ../src/propgrid/propgrid.cpp:6665
 #, c-format
 msgid "Error in resource: %s"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:422
+#: ../src/common/fileconf.cpp:421
 msgid "Error reading config options."
 msgstr "Feil ved lesing av konfigurasjonsvalg."
+
+#: ../src/msw/webview_ie.cpp:1057 ../src/msw/webview_edge.cpp:850
+#: ../src/gtk/webview_webkit2.cpp:1262 ../src/osx/webview_webkit.mm:383
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
 
 #: ../src/common/fileconf.cpp:1029
 msgid "Error saving user configuration data."
 msgstr "Feil ved lagring av brukerkonfigurasjonsdata."
 
-#: ../src/gtk/print.cpp:722
+#: ../src/gtk/print.cpp:720
 #, fuzzy
 msgid "Error while printing: "
 msgstr "Feil under venting på semafor"
 
-#: ../src/common/log.cpp:219
+#: ../src/common/log.cpp:237
 msgid "Error: "
 msgstr "Feil:"
 
+#: ../src/common/webrequest.cpp:98
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Feil:"
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:69
+#: ../src/common/accelcmn.cpp:66
 msgid "Esc"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:70
+#: ../src/common/accelcmn.cpp:67
 msgid "Escape"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:150
+#: ../src/common/fmapbase.cpp:147
 msgid "Esperanto (ISO-8859-3)"
 msgstr "Esperanto (ISO-8859-3)"
 
-#: ../include/wx/generic/progdlgg.h:85
+#: ../include/wx/generic/progdlgg.h:86
 #, fuzzy
 msgid "Estimated time:"
 msgstr "Anslått tid :"
 
-#: ../src/generic/dbgrptg.cpp:234
+#: ../src/generic/dbgrptg.cpp:231
 #, fuzzy
 msgid "Executable files (*.exe)|*.exe|"
 msgstr "Kjørbare filer (*.exe)|*.exe|Alle filer (*.*)|*.*||"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:155 ../src/common/accelcmn.cpp:78
+#: ../src/common/stockitem.cpp:152 ../src/common/accelcmn.cpp:75
 msgid "Execute"
 msgstr ""
 
-#: ../src/msw/utilsexc.cpp:876
+#: ../src/msw/utilsexc.cpp:873
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Utførelse av kommandoen «%s» feilet"
 
-#: ../src/common/paper.cpp:105
+#: ../src/common/paper.cpp:102
 msgid "Executive, 7 1/4 x 10 1/2 in"
 msgstr "Executive, 7 1/4 x 10 1/2 tommer"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6009
+#: ../src/generic/datavgen.cpp:6814
 msgid "Expand"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1240
+#: ../src/msw/registry.cpp:1228
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
@@ -3202,150 +3215,160 @@ msgstr ""
 "Eksporterer registernøkkel: file «%s» eksisterer allerede og kan ikke "
 "overskrives"
 
-#: ../src/common/fmapbase.cpp:195
+#: ../src/common/fmapbase.cpp:192
 msgid "Extended Unix Codepage for Japanese (EUC-JP)"
 msgstr "Utvidet Unix tegntabell for japansk (EUC-JP)"
 
-#: ../src/html/chm.cpp:725
+#: ../src/html/chm.cpp:718
 #, c-format
 msgid "Extraction of '%s' into '%s' failed."
 msgstr "Utpakking av «%s» inni «%s» feilet."
 
-#: ../src/common/accelcmn.cpp:249 ../src/common/accelcmn.cpp:344
+#: ../src/common/accelcmn.cpp:259 ../src/common/accelcmn.cpp:358
 msgid "F"
 msgstr ""
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:672
+#: ../src/propgrid/advprops.cpp:582
 #, fuzzy
 msgid "Face Name"
 msgstr "NyttNavn"
 
-#: ../src/unix/snglinst.cpp:269
+#: ../src/unix/snglinst.cpp:266
 msgid "Failed to access lock file."
 msgstr "Klarte ikke få fatt i låsefil."
+
+#: ../src/gtk/font.cpp:572
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Klarte ikke laste metafil fra filen «%s»."
 
 #: ../src/unix/epolldispatcher.cpp:116
 #, fuzzy, c-format
 msgid "Failed to add descriptor %d to epoll descriptor %d"
 msgstr "klarte ikke skrive til deskriptor %d"
 
-#: ../src/msw/dib.cpp:489
+#: ../src/msw/dib.cpp:535
 #, fuzzy, c-format
 msgid "Failed to allocate %luKb of memory for bitmap data."
 msgstr "Klarte ikke reservere %lu Kb minne for bitmap data."
 
-#: ../src/common/glcmn.cpp:115
+#: ../src/common/glcmn.cpp:112
 #, fuzzy
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Klarte ikke opprette peker."
 
-#: ../src/unix/displayx11.cpp:236
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Klarte ikke opprette peker."
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Klarte ikke opprette peker."
+
+#: ../include/wx/unix/private/displayx11.h:89
 msgid "Failed to change video mode"
 msgstr "Klarte ikke skifte videomodus"
 
-#: ../src/common/image.cpp:3277
+#: ../src/common/image.cpp:3396
 #, fuzzy, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Klarte ikke lagre bitmap-bilde til filen «%s». "
 
-#: ../src/common/debugrpt.cpp:239
+#: ../src/common/debugrpt.cpp:240
 #, c-format
 msgid "Failed to clean up debug report directory \"%s\""
 msgstr "Klarte ikke rydde opp i feilsøkingsrapportmappe «%s»"
 
-#: ../src/common/filename.cpp:192
+#: ../src/common/filename.cpp:189
 msgid "Failed to close file handle"
 msgstr "Klarte ikke lukke filreferanse"
 
-#: ../src/unix/snglinst.cpp:340
+#: ../src/unix/snglinst.cpp:337
 #, c-format
 msgid "Failed to close lock file '%s'"
 msgstr "Klarte ikke lukke låsefil «%s»"
 
-#: ../src/msw/clipbrd.cpp:112
+#: ../src/msw/clipbrd.cpp:110
 msgid "Failed to close the clipboard."
 msgstr "Klarte ikke lukke utklippstavlen."
 
-#: ../src/x11/utils.cpp:208
+#: ../src/x11/utils.cpp:170
 #, fuzzy, c-format
 msgid "Failed to close the display \"%s\""
 msgstr "Klarte ikke lukke utklippstavlen."
 
-#: ../src/msw/dialup.cpp:797
+#: ../src/msw/dialup.cpp:791
 msgid "Failed to connect: missing username/password."
 msgstr "Klarte ikke opprette forbindelse: manglende brukernavn/passord."
 
-#: ../src/msw/dialup.cpp:743
+#: ../src/msw/dialup.cpp:737
 msgid "Failed to connect: no ISP to dial."
 msgstr "Klarte ikke opprette forbindelse: ingen ISP å ringe til."
 
-#: ../src/common/textfile.cpp:203
-#, fuzzy, c-format
-msgid "Failed to convert file \"%s\" to Unicode."
-msgstr "Klarte ikke lukke filreferanse"
-
-#: ../src/generic/logg.cpp:956
+#: ../src/generic/logg.cpp:953
 #, fuzzy
 msgid "Failed to copy dialog contents to the clipboard."
 msgstr "Klarte ikke åpne utklippstavle."
 
-#: ../src/msw/registry.cpp:692
+#: ../src/msw/registry.cpp:681
 #, c-format
 msgid "Failed to copy registry value '%s'"
 msgstr "Klarte ikke kopiere registerverdir «%s»."
 
-#: ../src/msw/registry.cpp:701
+#: ../src/msw/registry.cpp:690
 #, c-format
 msgid "Failed to copy the contents of registry key '%s' to '%s'."
 msgstr "Klarte ikke kopiere innholdet av registernøkkel «%s» til «%s»."
 
-#: ../src/common/filefn.cpp:1015
+#: ../src/common/filefn.cpp:904
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Klarte ikke kopiere file «%s» til «%s»."
 
-#: ../src/msw/registry.cpp:679
+#: ../src/msw/registry.cpp:668
 #, c-format
 msgid "Failed to copy the registry subkey '%s' to '%s'."
 msgstr "Klarte ikke kopiere registerundernøkkel «%s» til «%s»."
 
-#: ../src/msw/dde.cpp:1070
+#: ../src/msw/dde.cpp:1134
 msgid "Failed to create DDE string"
 msgstr "Klarte ikke opprette DDE-streng"
 
-#: ../src/msw/mdi.cpp:616
+#: ../src/msw/mdi.cpp:621
 msgid "Failed to create MDI parent frame."
 msgstr "Klarte ikke opprette MDI foreldreramme."
 
-#: ../src/common/filename.cpp:1027
+#: ../src/common/filename.cpp:1024
 msgid "Failed to create a temporary file name"
 msgstr "Klarte ikke opprette et midlertidig filnavn"
 
-#: ../src/msw/utilsexc.cpp:228
+#: ../src/msw/utilsexc.cpp:225
 msgid "Failed to create an anonymous pipe"
 msgstr "Klarte ikke opprette et anonym rør"
 
-#: ../src/msw/ole/automtn.cpp:522
+#: ../src/msw/ole/automtn.cpp:513
 #, fuzzy, c-format
 msgid "Failed to create an instance of \"%s\""
 msgstr "Klarte ikke opprette mappe «%s»"
 
-#: ../src/msw/dde.cpp:437
+#: ../src/msw/dde.cpp:432
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "Klarte ikke opprette forbindelse til tjener «%s» med budskap «%s»"
 
-#: ../src/msw/cursor.cpp:204
+#: ../src/msw/cursor.cpp:195
 msgid "Failed to create cursor."
 msgstr "Klarte ikke opprette peker."
 
-#: ../src/common/debugrpt.cpp:209
+#: ../src/common/debugrpt.cpp:210
 #, c-format
 msgid "Failed to create directory \"%s\""
 msgstr "Klarte ikke opprette mappe «%s»"
 
-#: ../src/generic/dirdlgg.cpp:220
+#: ../src/generic/dirdlgg.cpp:217
 #, c-format
 msgid ""
 "Failed to create directory '%s'\n"
@@ -3359,117 +3382,136 @@ msgstr ""
 msgid "Failed to create epoll descriptor"
 msgstr "Klarte ikke opprette peker."
 
-#: ../src/msw/mimetype.cpp:238
+#: ../src/gtk/font.cpp:562
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "Klarte ikke oppdatere bruker konfigurasjonsfil."
+
+#: ../src/msw/mimetype.cpp:235
 #, c-format
 msgid "Failed to create registry entry for '%s' files."
 msgstr "Klarte ikke opprette registeroppføring for «%s»-filer."
 
-#: ../src/msw/fdrepdlg.cpp:409
+#: ../src/msw/fdrepdlg.cpp:408
 #, c-format
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr "Klarte ikke opprette standard finn/erstattvindu (feilkode %d)"
 
-#: ../src/unix/wakeuppipe.cpp:52
+#: ../src/unix/wakeuppipe.cpp:49
 #, fuzzy
 msgid "Failed to create wake up pipe used by event loop."
 msgstr "Klarte ikke opprette statusbar."
 
-#: ../src/html/winpars.cpp:730
+#: ../src/html/winpars.cpp:727
 #, c-format
 msgid "Failed to display HTML document in %s encoding"
 msgstr "Klarte ikke vise HTML-dokument med %s koding"
 
-#: ../src/msw/clipbrd.cpp:124
+#: ../src/msw/clipbrd.cpp:122
 msgid "Failed to empty the clipboard."
 msgstr "Klarte ikke tømme utklippstavlen."
 
-#: ../src/unix/displayx11.cpp:212
+#: ../include/wx/unix/private/displayx11.h:65
 msgid "Failed to enumerate video modes"
 msgstr "Klarte ikke telle opp videomoder"
 
-#: ../src/msw/dde.cpp:722
+#: ../src/msw/dde.cpp:717
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "Klarte ikke opprette en rådgivningsløkke med DDE-tjeneren"
 
-#: ../src/msw/dialup.cpp:629 ../src/msw/dialup.cpp:863
+#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Klarte ikke opprette oppringingsforbindelse: %s"
 
-#: ../src/unix/utilsunx.cpp:611
+#: ../src/unix/utilsunx.cpp:613
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Klarte ikke utføre «%s»\n"
 
-#: ../src/common/debugrpt.cpp:720
+#: ../src/common/debugrpt.cpp:730
 msgid "Failed to execute curl, please install it in PATH."
 msgstr "Klarte ikke kjøre curl, installere den i stien (PATH)."
 
-#: ../src/msw/ole/automtn.cpp:505
+#: ../src/msw/ole/automtn.cpp:496
 #, fuzzy, c-format
 msgid "Failed to find CLSID of \"%s\""
 msgstr "Klarte ikke åpne «%s» for «%s»"
 
-#: ../src/common/regex.cpp:431 ../src/common/regex.cpp:479
+#: ../src/common/regex.cpp:428 ../src/common/regex.cpp:476
 #, fuzzy, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "Fant ingen treff for «%s» i regulært uttrykk: %s"
 
-#: ../src/msw/dialup.cpp:695
+#: ../src/msw/webview_ie.cpp:978
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:689
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Klarte ikke få ISP navn: %s"
 
-#: ../src/msw/ole/automtn.cpp:574
+#: ../src/msw/ole/automtn.cpp:565
 #, fuzzy, c-format
 msgid "Failed to get OLE automation interface for \"%s\""
 msgstr "Klarte ikke opprette mappe «%s»"
 
-#: ../src/msw/clipbrd.cpp:711
+#: ../src/msw/clipbrd.cpp:731
 msgid "Failed to get data from the clipboard"
 msgstr "Klarte ikke hente data fra utklippstavlen."
 
-#: ../src/common/time.cpp:223
+#: ../src/common/time.cpp:216
 msgid "Failed to get the local system time"
 msgstr "Klarte ikke finne lokal systemtid"
 
-#: ../src/common/filefn.cpp:1345
+#: ../src/common/filefn.cpp:1233
 msgid "Failed to get the working directory"
 msgstr "Klarte ikke finne gjeldende mappe"
 
-#: ../src/univ/theme.cpp:114
+#: ../src/univ/theme.cpp:111
 msgid "Failed to initialize GUI: no built-in themes found."
 msgstr "Klarte ikke initialere GUI: ingen innebygde tema funnet."
 
-#: ../src/msw/helpchm.cpp:63
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:60
 msgid "Failed to initialize MS HTML Help."
 msgstr "Klarte ikke initialisere MS HTML hjelp."
 
-#: ../src/msw/glcanvas.cpp:1381
+#: ../src/msw/glcanvas.cpp:1391
 msgid "Failed to initialize OpenGL"
 msgstr "Klarte ikke initialisere OpenGL"
 
-#: ../src/msw/dialup.cpp:858
+#: ../src/msw/dialup.cpp:852
 #, fuzzy, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Klarte ikke avslutte oppringingskoblingen: %s"
 
-#: ../src/gtk/textctrl.cpp:1128
+#: ../src/gtk/textctrl.cpp:1209
 #, fuzzy
 msgid "Failed to insert text in the control."
 msgstr "Klarte ikke finne gjeldende mappe"
 
-#: ../src/unix/snglinst.cpp:241
+#: ../src/unix/snglinst.cpp:238
 #, c-format
 msgid "Failed to inspect the lock file '%s'"
 msgstr "Klarte ikke inspisere låsefilen «%s»"
 
-#: ../src/unix/appunix.cpp:182
+#: ../src/unix/appunix.cpp:179
 #, fuzzy
 msgid "Failed to install signal handler"
 msgstr "Klarte ikke lukke filreferanse"
 
-#: ../src/unix/threadpsx.cpp:1167
+#: ../src/unix/threadpsx.cpp:1216
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -3477,71 +3519,71 @@ msgstr ""
 "Klarte ikke bli med en tråd, potensiell minnelekkasje oppdaget - start "
 "programmet på nytt"
 
-#: ../src/msw/utils.cpp:629
+#: ../src/msw/utils.cpp:619
 #, c-format
 msgid "Failed to kill process %d"
 msgstr "Klarte ikke drepe prosess %d"
 
-#: ../src/common/image.cpp:2500
+#: ../src/common/image.cpp:2595
 #, fuzzy, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Klarte ikke laste bilde %d fra filen «%s»."
 
-#: ../src/common/image.cpp:2509
+#: ../src/common/image.cpp:2604
 #, fuzzy, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Klarte ikke laste bilde %d fra filen «%s»."
 
-#: ../src/common/iconbndl.cpp:225
+#: ../src/common/iconbndl.cpp:224
 #, fuzzy, c-format
 msgid "Failed to load icons from resource '%s'."
 msgstr "Klarte ikke laste bilde %d fra filen «%s»."
 
-#: ../src/common/iconbndl.cpp:200
+#: ../src/common/iconbndl.cpp:198
 #, fuzzy, c-format
 msgid "Failed to load image %%d from file '%s'."
 msgstr "Klarte ikke laste bilde %d fra filen «%s»."
 
-#: ../src/common/iconbndl.cpp:208
+#: ../src/common/iconbndl.cpp:206
 #, fuzzy, c-format
 msgid "Failed to load image %d from stream."
 msgstr "Klarte ikke laste bilde %d fra filen «%s»."
 
-#: ../src/common/image.cpp:2587 ../src/common/image.cpp:2606
+#: ../src/common/image.cpp:2682 ../src/common/image.cpp:2701
 #, fuzzy, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Klarte ikke laste bilde %d fra filen «%s»."
 
-#: ../src/msw/enhmeta.cpp:97
+#: ../src/msw/enhmeta.cpp:94
 #, c-format
 msgid "Failed to load metafile from file \"%s\"."
 msgstr "Klarte ikke laste metafil fra filen «%s»."
 
-#: ../src/msw/volume.cpp:327
+#: ../src/msw/volume.cpp:335
 msgid "Failed to load mpr.dll."
 msgstr "Klarte ikke laste mpr.dll."
 
-#: ../src/msw/utils.cpp:953
+#: ../src/msw/utils.cpp:943
 #, fuzzy, c-format
 msgid "Failed to load resource \"%s\"."
 msgstr "Klarte ikke laste metafil fra filen «%s»."
 
-#: ../src/common/dynlib.cpp:92
+#: ../src/common/dynlib.cpp:86
 #, c-format
 msgid "Failed to load shared library '%s'"
 msgstr "Klarte ikke laste delt bibliotek «%s»"
 
-#: ../src/osx/core/sound.cpp:145
+#: ../src/osx/core/sound.cpp:143
 #, fuzzy, c-format
 msgid "Failed to load sound from \"%s\" (error %d)."
 msgstr "Klarte ikke laste metafil fra filen «%s»."
 
-#: ../src/msw/utils.cpp:960
+#: ../src/msw/utils.cpp:950
 #, fuzzy, c-format
 msgid "Failed to lock resource \"%s\"."
 msgstr "Klarte ikke låse låsefilen «%s»"
 
-#: ../src/unix/snglinst.cpp:198
+#: ../src/unix/snglinst.cpp:195
 #, c-format
 msgid "Failed to lock the lock file '%s'"
 msgstr "Klarte ikke låse låsefilen «%s»"
@@ -3551,33 +3593,38 @@ msgstr "Klarte ikke låse låsefilen «%s»"
 msgid "Failed to modify descriptor %d in epoll descriptor %d"
 msgstr ""
 
-#: ../src/common/filename.cpp:2575
+#: ../src/common/filename.cpp:2658
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Klarte ikke endre filtid for «%s»"
 
-#: ../src/common/selectdispatcher.cpp:258
+#: ../src/common/selectdispatcher.cpp:255
 msgid "Failed to monitor I/O channels"
 msgstr "Klarte ikke å overvåke I/O-kanalene"
 
-#: ../src/common/filename.cpp:175
+#: ../src/common/filename.cpp:172
 #, fuzzy, c-format
 msgid "Failed to open '%s' for reading"
 msgstr "Klarte ikke åpne «%s» for «%s»"
 
-#: ../src/common/filename.cpp:180
+#: ../src/common/filename.cpp:177
 #, fuzzy, c-format
 msgid "Failed to open '%s' for writing"
 msgstr "Klarte ikke åpne «%s» for «%s»"
 
-#: ../src/html/chm.cpp:141
+#: ../src/html/chm.cpp:138
 #, c-format
 msgid "Failed to open CHM archive '%s'."
 msgstr "Klarte ikke åpne CHM arkiv «%s»."
 
-#: ../src/common/utilscmn.cpp:1126
+#: ../src/common/utilscmn.cpp:1140
 #, fuzzy, c-format
 msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Klarte ikke åpne «%s» for «%s»"
+
+#: ../src/common/hyperlnkcmn.cpp:133
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Klarte ikke åpne «%s» for «%s»"
 
 #: ../include/wx/msw/private/fswatcher.h:92
@@ -3585,96 +3632,106 @@ msgstr "Klarte ikke åpne «%s» for «%s»"
 msgid "Failed to open directory \"%s\" for monitoring."
 msgstr "Klarte ikke åpne «%s» for «%s»"
 
-#: ../src/x11/utils.cpp:227
+#: ../src/x11/utils.cpp:189
 #, fuzzy, c-format
 msgid "Failed to open display \"%s\"."
 msgstr "Klarte ikke åpne «%s» for «%s»"
 
-#: ../src/common/filename.cpp:1062
+#: ../src/common/filename.cpp:1059
 msgid "Failed to open temporary file."
 msgstr "Klarte ikke åpne midlertidig fil."
 
-#: ../src/msw/clipbrd.cpp:91
+#: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Klarte ikke åpne utklippstavle."
 
-#: ../src/common/translation.cpp:1184
+#: ../src/common/translation.cpp:1226
 #, fuzzy, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Klarte ikke tolke flertallsformer: «%s»"
 
-#: ../src/unix/mediactrl.cpp:1214
+#: ../src/unix/mediactrl.cpp:1239
 #, fuzzy, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Klarte ikke åpne «%s» for «%s»"
 
-#: ../src/msw/clipbrd.cpp:600
+#: ../src/msw/clipbrd.cpp:610
 msgid "Failed to put data on the clipboard"
 msgstr "Klarte ikke putte data på utklippstavlen."
 
-#: ../src/unix/snglinst.cpp:278
+#: ../src/unix/snglinst.cpp:275
 msgid "Failed to read PID from lock file."
 msgstr "Klarte ikke lses PID fra låsefil."
 
-#: ../src/common/fileconf.cpp:433
+#: ../src/common/fileconf.cpp:432
 #, fuzzy
 msgid "Failed to read config options."
 msgstr "Feil ved lesing av konfigurasjonsvalg."
 
-#: ../src/common/docview.cpp:681
+#: ../src/common/docview.cpp:676
 #, fuzzy, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Klarte ikke laste metafil fra filen «%s»."
 
-#: ../src/dfb/evtloop.cpp:98
+#: ../src/dfb/evtloop.cpp:99
 #, fuzzy
 msgid "Failed to read event from DirectFB pipe"
 msgstr "Klarte ikke lses PID fra låsefil."
 
-#: ../src/unix/wakeuppipe.cpp:120
+#: ../src/unix/wakeuppipe.cpp:117
 #, fuzzy
 msgid "Failed to read from wake-up pipe"
 msgstr "Klarte ikke lses PID fra låsefil."
 
-#: ../src/unix/utilsunx.cpp:679
+#: ../src/common/textfile.cpp:96
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Klarte ikke laste metafil fra filen «%s»."
+
+#: ../src/unix/utilsunx.cpp:681
 msgid "Failed to redirect child process input/output"
 msgstr "Klarte ikke videresende underprosessen inndata/utdata"
 
-#: ../src/msw/utilsexc.cpp:701
+#: ../src/msw/utilsexc.cpp:698
 msgid "Failed to redirect the child process IO"
 msgstr "Klarte ikke videresende underporsess IO"
 
-#: ../src/msw/dde.cpp:288
+#: ../src/msw/dde.cpp:283
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Klarte ikke registrere DDE-tjener «%s»"
 
-#: ../src/common/fontmap.cpp:245
+#: ../src/gtk/font.cpp:580
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "Klarte ikke oppdatere bruker konfigurasjonsfil."
+
+#: ../src/common/fontmap.cpp:242
 #, c-format
 msgid "Failed to remember the encoding for the charset '%s'."
 msgstr "Klarte ikke huske kodingen for tegnsettet «%s»."
 
-#: ../src/common/debugrpt.cpp:227
+#: ../src/common/debugrpt.cpp:228
 #, c-format
 msgid "Failed to remove debug report file \"%s\""
 msgstr "Klarte ikke slette feilsøkingsrapportfil «%s»"
 
-#: ../src/unix/snglinst.cpp:328
+#: ../src/unix/snglinst.cpp:325
 #, c-format
 msgid "Failed to remove lock file '%s'"
 msgstr "Klarte ikke slette låsefil «%s»"
 
-#: ../src/unix/snglinst.cpp:288
+#: ../src/unix/snglinst.cpp:285
 #, c-format
 msgid "Failed to remove stale lock file '%s'."
 msgstr "Klarte ikke slette forslitt låsefil «%s»."
 
-#: ../src/msw/registry.cpp:529
+#: ../src/msw/registry.cpp:518
 #, c-format
 msgid "Failed to rename registry value '%s' to '%s'."
 msgstr "Klarte ikke endre navn på registerverdi «%s» til «%s»."
 
-#: ../src/common/filefn.cpp:1122
+#: ../src/common/filefn.cpp:1011
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -3682,118 +3739,126 @@ msgid ""
 msgstr ""
 "Klarte ikke å døpe om fil '%s' til '%s' fordi navnet allerede er i bruk."
 
-#: ../src/msw/registry.cpp:634
+#: ../src/msw/registry.cpp:623
 #, c-format
 msgid "Failed to rename the registry key '%s' to '%s'."
 msgstr "Klarte ikke endre navn på registernøkkel «%s» til «%s»."
 
-#: ../src/common/filename.cpp:2671
+#: ../src/msw/webview_ie.cpp:995
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/common/filename.cpp:2754
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Klart ikke hente filtid for «%s»"
 
-#: ../src/msw/dialup.cpp:468
+#: ../src/msw/dialup.cpp:462
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Klarte ikke hente tekst fra RAS feilmelding"
 
-#: ../src/msw/clipbrd.cpp:748
+#: ../src/msw/clipbrd.cpp:768
 msgid "Failed to retrieve the supported clipboard formats"
 msgstr "Klarte ikke hente støttede utklippstavleformat"
 
-#: ../src/common/docview.cpp:652
+#: ../src/common/docview.cpp:647
 #, fuzzy, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Klarte ikke lagre bitmap-bilde til filen «%s». "
 
-#: ../src/msw/dib.cpp:269
+#: ../src/msw/dib.cpp:312
 #, c-format
 msgid "Failed to save the bitmap image to file \"%s\"."
 msgstr "Klarte ikke lagre bitmap-bilde til filen «%s». "
 
-#: ../src/msw/dde.cpp:763
+#: ../src/msw/dde.cpp:811
 msgid "Failed to send DDE advise notification"
 msgstr "Klarte ikke send DDE-rådgivningsmelding"
 
-#: ../src/common/ftp.cpp:402
+#: ../src/common/ftp.cpp:399
 #, c-format
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Klarte ikke sette FTP-overføringsmodus til %s."
 
-#: ../src/msw/clipbrd.cpp:427
+#: ../src/msw/clipbrd.cpp:443
 msgid "Failed to set clipboard data."
 msgstr "Klarte ikke sette utklippstavledata."
 
-#: ../src/unix/snglinst.cpp:181
+#: ../src/unix/snglinst.cpp:178
 #, c-format
 msgid "Failed to set permissions on lock file '%s'"
 msgstr "Klarte ikke sette rettigheter på låsefile «%s»"
 
-#: ../src/unix/utilsunx.cpp:668
+#: ../src/unix/utilsunx.cpp:670
 #, fuzzy
 msgid "Failed to set process priority"
 msgstr "Klarte ikke sette trådprioritet %d"
 
-#: ../src/common/file.cpp:559
+#: ../src/common/ffile.cpp:355 ../src/common/file.cpp:586
 msgid "Failed to set temporary file permissions"
 msgstr "Klarte ikke sette rettigheter for midlertidige filer"
 
-#: ../src/gtk/textctrl.cpp:1072
-#, fuzzy
-msgid "Failed to set text in the text control."
-msgstr "Klarte ikke finne gjeldende mappe"
-
-#: ../src/unix/threadpsx.cpp:1298
+#: ../src/unix/threadpsx.cpp:1347
 #, fuzzy, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Klarte ikke sette trådprioritet %d"
 
-#: ../src/unix/threadpsx.cpp:1424
+#: ../src/unix/threadpsx.cpp:1473
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Klarte ikke sette trådprioritet %d"
 
-#: ../src/unix/utilsunx.cpp:783
+#: ../src/unix/utilsunx.cpp:785
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 "Klarte ikke å sette opp ikke-blokkerende 'pipe', programmet kan bli hengende."
 
-#: ../src/common/fs_mem.cpp:261
+#: ../src/msw/webview_ie.cpp:987
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:256
 #, c-format
 msgid "Failed to store image '%s' to memory VFS!"
 msgstr "Klarte ikke lagre bilde «%s» til minne VFS!"
 
-#: ../src/dfb/evtloop.cpp:170
+#: ../src/dfb/evtloop.cpp:171
 msgid "Failed to switch DirectFB pipe to non-blocking mode"
 msgstr ""
 
-#: ../src/unix/wakeuppipe.cpp:59
+#: ../src/unix/wakeuppipe.cpp:56
 msgid "Failed to switch wake up pipe to non-blocking mode"
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1605
+#: ../src/unix/threadpsx.cpp:1654
 msgid "Failed to terminate a thread."
 msgstr "Klarte ikke avslutte en tråd."
 
-#: ../src/msw/dde.cpp:741
+#: ../src/msw/dde.cpp:736
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "Klarte ikke avslutte rådgivningsløkka med DDE-tjeneren"
 
-#: ../src/msw/dialup.cpp:938
+#: ../src/msw/dialup.cpp:932
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Klarte ikke avslutte oppringingskoblingen: %s"
 
-#: ../src/common/filename.cpp:2590
+#: ../src/common/filename.cpp:2673
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Klarte ikke rør filen «%s»"
 
-#: ../src/unix/snglinst.cpp:334
+#: ../src/unix/dlunix.cpp:90
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "Klarte ikke laste delt bibliotek «%s»"
+
+#: ../src/unix/snglinst.cpp:331
 #, c-format
 msgid "Failed to unlock lock file '%s'"
 msgstr "Klarte ikke låse opp låsefilen «%s»"
 
-#: ../src/msw/dde.cpp:309
+#: ../src/msw/dde.cpp:304
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Klarte ikke avregistrere DDE-tjener «%s»"
@@ -3807,78 +3872,88 @@ msgstr "Klarte ikke hente data fra utklippstavlen."
 msgid "Failed to update user configuration file."
 msgstr "Klarte ikke oppdatere bruker konfigurasjonsfil."
 
-#: ../src/common/debugrpt.cpp:733
+#: ../src/common/debugrpt.cpp:743
 #, c-format
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Klarte ikke laste opp feilsøkingsrapporten (feilkode %d)"
 
-#: ../src/unix/snglinst.cpp:168
+#: ../src/unix/snglinst.cpp:165
 #, c-format
 msgid "Failed to write to lock file '%s'"
 msgstr "Klarte ikke skrive til låsefil «%s»"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:209
+#: ../src/propgrid/propgrid.cpp:190
 msgid "False"
 msgstr ""
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:694
+#: ../src/propgrid/advprops.cpp:604
 #, fuzzy
 msgid "Family"
 msgstr "&Skriftfamilie:"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/gtk/glcanvas.cpp:176 ../src/gtk/glcanvas.cpp:187
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Kritisk feil"
+
+#: ../src/common/stockitem.cpp:154
 msgid "File"
 msgstr "Fil"
 
-#: ../src/common/docview.cpp:669
+#: ../src/common/docview.cpp:664
 #, fuzzy, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Klarte ikke åpne «%s» for «%s»"
 
-#: ../src/common/docview.cpp:646
+#: ../src/common/docview.cpp:641
 #, fuzzy, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Klarte ikke åpne «%s» for «%s»"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "Filen «%s» eksisterer allerede. Vil du virkelig overskrive filen?"
 
-#: ../src/common/filefn.cpp:1156
+#: ../src/common/filefn.cpp:1044
 #, fuzzy, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Mappe «%s» kunne ikke opprettes"
 
-#: ../src/common/filefn.cpp:1139
+#: ../src/common/filefn.cpp:1028
 #, fuzzy, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Mappe «%s» kunne ikke opprettes"
 
-#: ../src/richtext/richtextctrl.cpp:3081 ../src/common/textcmn.cpp:953
+#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
 msgid "File couldn't be loaded."
 msgstr "Klarte ikke laste filen."
 
-#: ../src/msw/filedlg.cpp:393
+#: ../src/msw/filedlg.cpp:414
 #, fuzzy, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Utførelse av kommandoen «%s» feilet med feil: %ul"
 
-#: ../src/common/docview.cpp:1789
+#: ../src/common/docview.cpp:1783
 msgid "File error"
 msgstr "Filfeil"
 
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/filectrlg.cpp:770
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/filectrlg.cpp:766
 msgid "File name exists already."
 msgstr "Filnavn eksisterer allerede."
+
+#: ../src/osx/cocoa/filedlg.mm:264
+#, fuzzy
+msgid "File type:"
+msgstr "Teletype"
 
 #: ../src/motif/filedlg.cpp:220
 msgid "Files"
 msgstr "Filer"
 
-#: ../src/common/filefn.cpp:1591
+#: ../src/common/filefn.cpp:1479
 #, c-format
 msgid "Files (%s)"
 msgstr "Filer (%s)"
@@ -3887,16 +3962,30 @@ msgstr "Filer (%s)"
 msgid "Filter"
 msgstr "Filter"
 
-#: ../src/common/stockitem.cpp:158 ../src/html/helpwnd.cpp:490
+#: ../src/html/helpwnd.cpp:488
 msgid "Find"
 msgstr "Finn"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:259
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:258
+#, fuzzy
+msgid "Find in document"
+msgstr "Åpne HTML-dokument"
+
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "Find..."
+msgstr "Finn"
+
+#: ../src/common/stockitem.cpp:156
 #, fuzzy
 msgid "First"
 msgstr "først"
 
-#: ../src/common/prntbase.cpp:1548
+#: ../src/common/prntbase.cpp:1573
 msgid "First page"
 msgstr "Første side"
 
@@ -3905,11 +3994,11 @@ msgstr "Første side"
 msgid "Fixed"
 msgstr "Fast skrift:"
 
-#: ../src/html/helpwnd.cpp:1206
+#: ../src/html/helpwnd.cpp:1204
 msgid "Fixed font:"
 msgstr "Fast skrift:"
 
-#: ../src/html/helpwnd.cpp:1269
+#: ../src/html/helpwnd.cpp:1267
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Fast størrelse skrift.<br> <b>fet</b> <i>kursiv</i>"
 
@@ -3917,16 +4006,16 @@ msgstr "Fast størrelse skrift.<br> <b>fet</b> <i>kursiv</i>"
 msgid "Floating"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "Floppy"
 msgstr ""
 
-#: ../src/common/paper.cpp:111
+#: ../src/common/paper.cpp:108
 msgid "Folio, 8 1/2 x 13 in"
 msgstr "Folio, 8 1/2 x 13 tommer"
 
-#: ../src/richtext/richtextformatdlg.cpp:344 ../src/osx/carbon/fontdlg.cpp:287
-#: ../src/common/stockitem.cpp:194
+#: ../src/osx/carbon/fontdlg.cpp:284 ../src/common/stockitem.cpp:191
+#: ../src/richtext/richtextformatdlg.cpp:337
 msgid "Font"
 msgstr "Skrift"
 
@@ -3935,7 +4024,24 @@ msgstr "Skrift"
 msgid "Font &weight:"
 msgstr "Skriftvekt"
 
-#: ../src/html/helpwnd.cpp:1207
+#: ../src/osx/fontutil.cpp:89
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
+"\"."
+msgstr ""
+
+#: ../src/msw/font.cpp:1126
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Klarte ikke laste filen."
+
+#: ../src/osx/fontutil.cpp:81
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "Filen «%s» eksisterer ikke."
+
+#: ../src/html/helpwnd.cpp:1205
 msgid "Font size:"
 msgstr "Skriftstørrelse:"
 
@@ -3944,77 +4050,77 @@ msgstr "Skriftstørrelse:"
 msgid "Font st&yle:"
 msgstr "Skriftstørrelse:"
 
-#: ../src/osx/carbon/fontdlg.cpp:329
+#: ../src/osx/carbon/fontdlg.cpp:326
 #, fuzzy
 msgid "Font:"
 msgstr "Skriftstørrelse:"
 
-#: ../src/dfb/fontmgr.cpp:198
+#: ../src/dfb/fontmgr.cpp:195
 #, c-format
 msgid "Fonts index file %s disappeared while loading fonts."
 msgstr "Skriftindeksfilen %s forsvant mens skrifttypene ble lastet opp."
 
-#: ../src/unix/utilsunx.cpp:645
+#: ../src/unix/utilsunx.cpp:647
 msgid "Fork failed"
 msgstr "Forgrening feilet"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 #, fuzzy
 msgid "Forward"
 msgstr "&Fremover"
 
-#: ../src/common/xtixml.cpp:235
+#: ../src/common/xtixml.cpp:231
 msgid "Forward hrefs are not supported"
 msgstr "Fremover HREF-er er ikke støttet"
 
-#: ../src/html/helpwnd.cpp:875
+#: ../src/html/helpwnd.cpp:873
 #, c-format
 msgid "Found %i matches"
 msgstr "Fant %i treff"
 
-#: ../src/generic/prntdlgg.cpp:238
+#: ../src/generic/prntdlgg.cpp:231
 msgid "From:"
 msgstr "Fra:"
 
-#: ../src/propgrid/advprops.cpp:1604
+#: ../src/propgrid/advprops.cpp:1510
 msgid "Fuchsia"
 msgstr ""
 
-#: ../src/common/imaggif.cpp:138
+#: ../src/common/imaggif.cpp:135
 msgid "GIF: data stream seems to be truncated."
 msgstr "GIF:Datastrømmen ser ut til å være trunkert."
 
-#: ../src/common/imaggif.cpp:128
+#: ../src/common/imaggif.cpp:125
 msgid "GIF: error in GIF image format."
 msgstr "GIF: Feil i GIF-bildeformat."
 
-#: ../src/common/imaggif.cpp:133
+#: ../src/common/imaggif.cpp:130
 msgid "GIF: not enough memory."
 msgstr "GIF: Ikke nok minne."
 
-#: ../src/gtk/window.cpp:4631
+#: ../src/gtk/window.cpp:5635
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
 msgstr ""
 
-#: ../src/univ/themes/gtk.cpp:525
+#: ../src/univ/themes/gtk.cpp:522
 msgid "GTK+ theme"
 msgstr "GTK+ tema"
 
-#: ../src/common/preferencescmn.cpp:40
+#: ../src/common/preferencescmn.cpp:37
 msgid "General"
 msgstr "Generell"
 
-#: ../src/common/prntbase.cpp:258
+#: ../src/common/prntbase.cpp:253
 msgid "Generic PostScript"
 msgstr "Generisk PostScript"
 
-#: ../src/common/paper.cpp:135
+#: ../src/common/paper.cpp:132
 msgid "German Legal Fanfold, 8 1/2 x 13 in"
 msgstr "Tysk juridisk papir, 8 1/2 x 13 tommer"
 
-#: ../src/common/paper.cpp:134
+#: ../src/common/paper.cpp:131
 msgid "German Std Fanfold, 8 1/2 x 12 in"
 msgstr "Tysk vanlig papir, 8 1/2 x 12 tommer"
 
@@ -4030,48 +4136,48 @@ msgstr "GetPropertyCollection kalt med generisk aksessor"
 msgid "GetPropertyCollection called w/o valid collection getter"
 msgstr "GetPropertyCollection kalt uten gyldig mengdehenter"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:658
 msgid "Go back"
 msgstr "Gå tilbake"
 
-#: ../src/html/helpwnd.cpp:661
+#: ../src/html/helpwnd.cpp:659
 msgid "Go forward"
 msgstr "Gå frem"
 
-#: ../src/html/helpwnd.cpp:663
+#: ../src/html/helpwnd.cpp:661
 msgid "Go one level up in document hierarchy"
 msgstr "Gå et nivå opp i dokumenthierarkiet"
 
-#: ../src/generic/filedlgg.cpp:208 ../src/generic/dirdlgg.cpp:116
+#: ../src/generic/filedlgg.cpp:205 ../src/generic/dirdlgg.cpp:113
 msgid "Go to home directory"
 msgstr "Gå til hjemmemappe"
 
-#: ../src/generic/filedlgg.cpp:205
+#: ../src/generic/filedlgg.cpp:202
 msgid "Go to parent directory"
 msgstr "Gå til foreldremappe"
 
-#: ../src/generic/aboutdlgg.cpp:76
+#: ../src/generic/aboutdlgg.cpp:73
 msgid "Graphics art by "
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1599
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Gray"
 msgstr "Grå"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:883
+#: ../src/propgrid/advprops.cpp:784
 msgid "GrayText"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:154
+#: ../src/common/fmapbase.cpp:151
 msgid "Greek (ISO-8859-7)"
 msgstr "Gresk (ISO-8859-7)"
 
-#: ../src/propgrid/advprops.cpp:1600
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Green"
 msgstr "Grønn"
 
-#: ../src/generic/colrdlgg.cpp:342
+#: ../src/generic/colrdlgg.cpp:362
 #, fuzzy
 msgid "Green:"
 msgstr "Grønn"
@@ -4080,107 +4186,107 @@ msgstr "Grønn"
 msgid "Groove"
 msgstr ""
 
-#: ../src/common/zstream.cpp:158 ../src/common/zstream.cpp:318
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
 msgid "Gzip not supported by this version of zlib"
 msgstr "Gzip er ikke støttet av denne versjonen av zlib"
 
-#: ../src/html/helpwnd.cpp:1549
+#: ../src/html/helpwnd.cpp:1547
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "HTML hjelpprosjekt (*.hhp)|*.hhp|"
 
-#: ../src/html/htmlwin.cpp:681
+#: ../src/html/htmlwin.cpp:691
 #, c-format
 msgid "HTML anchor %s does not exist."
 msgstr "HTML-anker %s finnes ikke."
 
-#: ../src/html/helpwnd.cpp:1547
+#: ../src/html/helpwnd.cpp:1545
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "HTML-filer  (*.html;*.htm)|*.html;*.htm|"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1759
+#: ../src/propgrid/advprops.cpp:1660
 msgid "Hand"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "Harddisk"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:155
+#: ../src/common/fmapbase.cpp:152
 msgid "Hebrew (ISO-8859-8)"
 msgstr "Hebraisk (ISO-8859-8)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:280 ../src/osx/button_osx.cpp:39
-#: ../src/common/stockitem.cpp:163 ../src/common/accelcmn.cpp:80
-#: ../src/html/helpdlg.cpp:66 ../src/html/helpfrm.cpp:111
+#: ../include/wx/msgdlg.h:282 ../src/osx/button_osx.cpp:39
+#: ../src/common/stockitem.cpp:160 ../src/common/accelcmn.cpp:77
+#: ../src/html/helpfrm.cpp:108 ../src/html/helpdlg.cpp:63
 msgid "Help"
 msgstr "Hjelp"
 
-#: ../src/html/helpwnd.cpp:1200
+#: ../src/html/helpwnd.cpp:1198
 msgid "Help Browser Options"
 msgstr "Innstillinger for hjelpleser"
 
-#: ../src/generic/helpext.cpp:454 ../src/generic/helpext.cpp:455
+#: ../src/generic/helpext.cpp:452 ../src/generic/helpext.cpp:453
 msgid "Help Index"
 msgstr "Indeks for hjelp"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1529
 msgid "Help Printing"
 msgstr "Skriv ut hjelp"
 
-#: ../src/html/helpwnd.cpp:801
+#: ../src/html/helpwnd.cpp:799
 msgid "Help Topics"
 msgstr "Emner for hjelp"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1546
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Hjelpebøker (*.htb)|*.htb|Hjelpebøker (*.zip)|*.zip|"
 
-#: ../src/generic/helpext.cpp:267
+#: ../src/generic/helpext.cpp:265
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "Hjelpemappe \"%s\" ble ikke funet."
 
-#: ../src/generic/helpext.cpp:275
+#: ../src/generic/helpext.cpp:273
 #, fuzzy, c-format
 msgid "Help file \"%s\" not found."
 msgstr "katalogfil for domene «%s» ikke funnet."
 
-#: ../src/html/helpctrl.cpp:63
+#: ../src/html/helpctrl.cpp:59
 #, c-format
 msgid "Help: %s"
 msgstr "Hjelp: %s"
 
-#: ../src/osx/menu_osx.cpp:577
+#: ../src/osx/menu_osx.cpp:469
 #, fuzzy, c-format
 msgid "Hide %s"
 msgstr "Hjelp: %s"
 
-#: ../src/osx/menu_osx.cpp:579
+#: ../src/osx/menu_osx.cpp:471
 msgid "Hide Others"
 msgstr "Skjul andre"
 
-#: ../src/generic/infobar.cpp:84
+#: ../src/generic/infobar.cpp:81
 msgid "Hide this notification message."
 msgstr "Skjul denne meldingen."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:884
+#: ../src/propgrid/advprops.cpp:785
 msgid "Highlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:885
+#: ../src/propgrid/advprops.cpp:786
 msgid "HighlightText"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:164 ../src/common/accelcmn.cpp:65
+#: ../src/common/stockitem.cpp:161 ../src/common/accelcmn.cpp:62
 msgid "Home"
 msgstr "Hjem"
 
-#: ../src/generic/dirctrlg.cpp:524
+#: ../src/generic/dirctrlg.cpp:490
 msgid "Home directory"
 msgstr "Hjemmemappe"
 
@@ -4190,61 +4296,61 @@ msgid "How the object will float relative to the text."
 msgstr "Hvordan objektet vil ligge relativt til teksten."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1760
+#: ../src/propgrid/advprops.cpp:1661
 msgid "I-Beam"
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1196
+#: ../src/common/imagbmp.cpp:1208
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: Feil ved maskelesing DIB."
 
-#: ../src/common/imagbmp.cpp:1290 ../src/common/imagbmp.cpp:1390
-#: ../src/common/imagbmp.cpp:1405 ../src/common/imagbmp.cpp:1416
-#: ../src/common/imagbmp.cpp:1430 ../src/common/imagbmp.cpp:1478
-#: ../src/common/imagbmp.cpp:1493 ../src/common/imagbmp.cpp:1507
-#: ../src/common/imagbmp.cpp:1518
+#: ../src/common/imagbmp.cpp:1302 ../src/common/imagbmp.cpp:1402
+#: ../src/common/imagbmp.cpp:1417 ../src/common/imagbmp.cpp:1428
+#: ../src/common/imagbmp.cpp:1442 ../src/common/imagbmp.cpp:1490
+#: ../src/common/imagbmp.cpp:1505 ../src/common/imagbmp.cpp:1519
+#: ../src/common/imagbmp.cpp:1530
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: Feil ved skriving av bildefil!"
 
-#: ../src/common/imagbmp.cpp:1255
+#: ../src/common/imagbmp.cpp:1267
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: Bilde er for høyt for et ikon."
 
-#: ../src/common/imagbmp.cpp:1263
+#: ../src/common/imagbmp.cpp:1275
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: Bilde er for bredt for et ikon."
 
-#: ../src/common/imagbmp.cpp:1603
+#: ../src/common/imagbmp.cpp:1615
 msgid "ICO: Invalid icon index."
 msgstr "ICO: Ugyldig ikonindeks"
 
-#: ../src/common/imagiff.cpp:758
+#: ../src/common/imagiff.cpp:755
 msgid "IFF: data stream seems to be truncated."
 msgstr "IFF: Datastrøm ser ut til å være trunkert."
 
-#: ../src/common/imagiff.cpp:742
+#: ../src/common/imagiff.cpp:739
 msgid "IFF: error in IFF image format."
 msgstr "IFF: Feil i IFF-bildeformat."
 
-#: ../src/common/imagiff.cpp:745
+#: ../src/common/imagiff.cpp:742
 msgid "IFF: not enough memory."
 msgstr "IFF: Ikke nok minne."
 
-#: ../src/common/imagiff.cpp:748
+#: ../src/common/imagiff.cpp:745
 msgid "IFF: unknown error!!!"
 msgstr "IFF: Ukjent feil!"
 
-#: ../src/common/fmapbase.cpp:197
+#: ../src/common/fmapbase.cpp:194
 msgid "ISO-2022-JP"
 msgstr ""
 
-#: ../src/html/htmprint.cpp:282
+#: ../src/html/htmprint.cpp:294
 msgid ""
 "If possible, try changing the layout parameters to make the printout more "
 "narrow."
 msgstr "Om mulig forsøk å endre parametrene for å gjøre utskriften smalere."
 
-#: ../src/generic/dbgrptg.cpp:358
+#: ../src/generic/dbgrptg.cpp:362
 msgid ""
 "If you have any additional information pertaining to this bug\n"
 "report, please enter it here and it will be joined to it:"
@@ -4263,46 +4369,50 @@ msgstr ""
 "Vær klar over at det kan hindre forbedring av programmet så\n"
 "det er best hvis du fortsetter genereringen av rapporten.\n"
 
-#: ../src/msw/registry.cpp:1405
+#: ../src/common/zipstrm.cpp:1043
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1393
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Ignorerer verdi «%s» for nøkkel «%s»"
 
-#: ../src/common/xtistrm.cpp:295
+#: ../src/common/xtistrm.cpp:292
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Ulovlig objektklasse (Ikke-wxEvtHandler) som hendelseskilde"
 
-#: ../src/common/xti.cpp:513
+#: ../src/common/xti.cpp:510
 msgid "Illegal Parameter Count for ConstructObject Method"
 msgstr "Ugyldig antall parametre for ConstructObject-metode"
 
-#: ../src/common/xti.cpp:501
+#: ../src/common/xti.cpp:498
 msgid "Illegal Parameter Count for Create Method"
 msgstr "Ugyldig antall parametre for Create-metode"
 
-#: ../src/generic/dirctrlg.cpp:570 ../src/generic/filectrlg.cpp:756
+#: ../src/generic/dirctrlg.cpp:536 ../src/generic/filectrlg.cpp:752
 msgid "Illegal directory name."
 msgstr "Ugyldig mappenavn."
 
-#: ../src/generic/filectrlg.cpp:1367
+#: ../src/generic/filectrlg.cpp:1356
 msgid "Illegal file specification."
 msgstr "Ugyldig filspesifikasjon."
 
-#: ../src/common/image.cpp:2269
+#: ../src/common/image.cpp:2363
 msgid "Image and mask have different sizes."
 msgstr "Bilde og maske har forskjellig størrelse."
 
-#: ../src/common/image.cpp:2746
+#: ../src/common/image.cpp:2841
 #, fuzzy, c-format
 msgid "Image file is not of type %d."
 msgstr "Bildefil er ikke av type %d."
 
-#: ../src/common/image.cpp:2877
+#: ../src/common/image.cpp:2995
 #, fuzzy, c-format
 msgid "Image is not of type %s."
 msgstr "Bildefil er ikke av type %d."
 
-#: ../src/msw/textctrl.cpp:488
+#: ../src/msw/textctrl.cpp:534
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -4310,104 +4420,104 @@ msgstr ""
 "Klarte ikke opprette rik redigeringskontroll, bruker enkel tekstkontroll i "
 "steden. Gjeninstaller riched32.dll."
 
-#: ../src/unix/utilsunx.cpp:301
+#: ../src/unix/utilsunx.cpp:303
 msgid "Impossible to get child process input"
 msgstr "Klarte ikke få tak i inndata for underprosess"
 
-#: ../src/common/filefn.cpp:1028
+#: ../src/common/filefn.cpp:917
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Klarte ikke få tak i rettigheter for filen «%s»"
 
-#: ../src/common/filefn.cpp:1042
+#: ../src/common/filefn.cpp:931
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Klarte ikke overskrive filen «%s»"
 
-#: ../src/common/filefn.cpp:1097
+#: ../src/common/filefn.cpp:986
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Klarte ikke sette rettigheter for filen «%s»"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:886
+#: ../src/propgrid/advprops.cpp:787
 #, fuzzy
 msgid "InactiveBorder"
 msgstr "Moderne"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:887
+#: ../src/propgrid/advprops.cpp:788
 msgid "InactiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:888
+#: ../src/propgrid/advprops.cpp:789
 msgid "InactiveCaptionText"
 msgstr ""
 
-#: ../src/common/gifdecod.cpp:792
+#: ../src/common/gifdecod.cpp:826
 #, c-format
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:635
+#: ../src/msw/ole/automtn.cpp:626
 msgid "Incorrect number of arguments."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:165
+#: ../src/common/stockitem.cpp:162
 msgid "Indent"
 msgstr "Innrykk"
 
-#: ../src/richtext/richtextformatdlg.cpp:349
+#: ../src/richtext/richtextformatdlg.cpp:342
 msgid "Indents && Spacing"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:166 ../src/html/helpwnd.cpp:515
+#: ../src/common/stockitem.cpp:163 ../src/html/helpwnd.cpp:513
 msgid "Index"
 msgstr "Indeks"
 
-#: ../src/common/fmapbase.cpp:159
+#: ../src/common/fmapbase.cpp:156
 msgid "Indian (ISO-8859-12)"
 msgstr "Indisk (ISO-8859-12)"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "Info"
 msgstr ""
 
-#: ../src/common/init.cpp:287
+#: ../src/common/init.cpp:284
 msgid "Initialization failed in post init, aborting."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:54
+#: ../src/common/accelcmn.cpp:51
 #, fuzzy
 msgid "Ins"
 msgstr "Innrykk"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextsymboldlg.cpp:472 ../src/common/accelcmn.cpp:53
+#: ../src/common/accelcmn.cpp:50 ../src/richtext/richtextsymboldlg.cpp:469
 #, fuzzy
 msgid "Insert"
 msgstr "Innrykk"
 
-#: ../src/richtext/richtextbuffer.cpp:8067
+#: ../src/richtext/richtextbuffer.cpp:8063
 #, fuzzy
 msgid "Insert Field"
 msgstr "Innrykk"
 
-#: ../src/richtext/richtextbuffer.cpp:7978
-#: ../src/richtext/richtextbuffer.cpp:8936
+#: ../src/richtext/richtextbuffer.cpp:7974
+#: ../src/richtext/richtextbuffer.cpp:8934
 msgid "Insert Image"
 msgstr "Sett inn Bilde"
 
-#: ../src/richtext/richtextbuffer.cpp:8025
+#: ../src/richtext/richtextbuffer.cpp:8021
 msgid "Insert Object"
 msgstr "Sett inn Objekt"
 
-#: ../src/richtext/richtextctrl.cpp:1286 ../src/richtext/richtextctrl.cpp:1494
-#: ../src/richtext/richtextbuffer.cpp:7822
-#: ../src/richtext/richtextbuffer.cpp:7852
-#: ../src/richtext/richtextbuffer.cpp:7894
+#: ../src/richtext/richtextbuffer.cpp:7818
+#: ../src/richtext/richtextbuffer.cpp:7848
+#: ../src/richtext/richtextbuffer.cpp:7890
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
 msgid "Insert Text"
 msgstr "Sett inn Tekst"
 
@@ -4421,16 +4531,11 @@ msgstr "Sett inn sideskift før neste avsnitt."
 msgid "Inset"
 msgstr "Innrykk"
 
-#: ../src/gtk/app.cpp:425
-#, c-format
-msgid "Invalid GTK+ command line option, use \"%s --help\""
-msgstr ""
-
-#: ../src/common/imagtiff.cpp:311
+#: ../src/common/imagtiff.cpp:308
 msgid "Invalid TIFF image index."
 msgstr "Ugyldig TIFF bildeindeks."
 
-#: ../src/common/appcmn.cpp:273
+#: ../src/common/appcmn.cpp:294
 #, c-format
 msgid "Invalid display mode specification '%s'."
 msgstr "Ugyldig spesifikasjon «%s» for skjermmodus."
@@ -4440,254 +4545,258 @@ msgstr "Ugyldig spesifikasjon «%s» for skjermmodus."
 msgid "Invalid geometry specification '%s'"
 msgstr "Ugyldig geometrispesifikasjon «%s»."
 
-#: ../src/unix/fswatcher_inotify.cpp:323
+#: ../src/unix/fswatcher_inotify.cpp:320
 #, c-format
 msgid "Invalid inotify event for \"%s\""
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:312
+#: ../src/unix/snglinst.cpp:309
 #, c-format
 msgid "Invalid lock file '%s'."
 msgstr "Ugyldig låsefil «%s»."
 
-#: ../src/common/translation.cpp:1125
+#: ../src/common/translation.cpp:1167
 #, fuzzy
 msgid "Invalid message catalog."
 msgstr "«%s» er ikke en gyldig meldingskatalog."
 
-#: ../src/common/xtistrm.cpp:405 ../src/common/xtistrm.cpp:420
+#: ../src/common/xtistrm.cpp:402 ../src/common/xtistrm.cpp:417
 msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
 msgstr "Ugyldig eller nullobjekt-ID sendt til GetObjectClassInfo"
 
-#: ../src/common/xtistrm.cpp:435
+#: ../src/common/xtistrm.cpp:432
 msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
 msgstr "Ugyldig eller nullobjekt-ID sendt til HasObjectClassInfo"
 
-#: ../src/common/regex.cpp:310
+#: ../src/common/regex.cpp:307
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Ugyldig regulært uttrykk «%s»: %s"
 
-#: ../src/common/config.cpp:226
+#: ../src/common/config.cpp:222
 #, c-format
 msgid "Invalid value %ld for a boolean key \"%s\" in config file."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:351
-#: ../src/osx/carbon/fontdlg.cpp:361 ../src/common/stockitem.cpp:168
+#: ../src/osx/carbon/fontdlg.cpp:358 ../src/common/stockitem.cpp:165
+#: ../src/generic/fontdlgg.cpp:325 ../src/richtext/richtextfontpage.cpp:351
 msgid "Italic"
 msgstr "Kursiv"
 
-#: ../src/common/paper.cpp:130
+#: ../src/common/paper.cpp:127
 msgid "Italy Envelope, 110 x 230 mm"
 msgstr "Italia-konvolutt, 110 x 230 mm"
 
-#: ../src/common/imagjpeg.cpp:270
+#: ../src/common/imagjpeg.cpp:257
 msgid "JPEG: Couldn't load - file is probably corrupted."
 msgstr "JPEG: Klarte ikke laste filen - sannsynligvis ødelagt."
 
-#: ../src/common/imagjpeg.cpp:449
+#: ../src/common/imagjpeg.cpp:436
 msgid "JPEG: Couldn't save image."
 msgstr "JPEG: Klarte ikke lagre bilde."
 
-#: ../src/common/paper.cpp:163
+#: ../src/common/paper.cpp:160
 msgid "Japanese Double Postcard 200 x 148 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:167
+#: ../src/common/paper.cpp:164
 msgid "Japanese Envelope Chou #3"
 msgstr ""
 
-#: ../src/common/paper.cpp:180
+#: ../src/common/paper.cpp:177
 msgid "Japanese Envelope Chou #3 Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:168
+#: ../src/common/paper.cpp:165
 msgid "Japanese Envelope Chou #4"
 msgstr ""
 
-#: ../src/common/paper.cpp:181
+#: ../src/common/paper.cpp:178
 msgid "Japanese Envelope Chou #4 Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:165
+#: ../src/common/paper.cpp:162
 msgid "Japanese Envelope Kaku #2"
 msgstr ""
 
-#: ../src/common/paper.cpp:178
+#: ../src/common/paper.cpp:175
 msgid "Japanese Envelope Kaku #2 Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:166
+#: ../src/common/paper.cpp:163
 msgid "Japanese Envelope Kaku #3"
 msgstr ""
 
-#: ../src/common/paper.cpp:179
+#: ../src/common/paper.cpp:176
 msgid "Japanese Envelope Kaku #3 Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:185
+#: ../src/common/paper.cpp:182
 msgid "Japanese Envelope You #4"
 msgstr ""
 
-#: ../src/common/paper.cpp:186
+#: ../src/common/paper.cpp:183
 msgid "Japanese Envelope You #4 Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:138
+#: ../src/common/paper.cpp:135
 msgid "Japanese Postcard 100 x 148 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:175
+#: ../src/common/paper.cpp:172
 msgid "Japanese Postcard Rotated 148 x 100 mm"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "Jump to"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:171
+#: ../src/common/stockitem.cpp:168
 msgid "Justified"
 msgstr "Justert"
 
-#: ../src/richtext/richtextindentspage.cpp:155
-#: ../src/richtext/richtextindentspage.cpp:157
 #: ../src/richtext/richtextliststylepage.cpp:344
 #: ../src/richtext/richtextliststylepage.cpp:346
+#: ../src/richtext/richtextindentspage.cpp:155
+#: ../src/richtext/richtextindentspage.cpp:157
 msgid "Justify text left and right."
 msgstr "Juster teksten venstre og høyre."
 
-#: ../src/common/fmapbase.cpp:163
+#: ../src/common/fmapbase.cpp:160
 msgid "KOI8-R"
 msgstr "KOI8-R"
 
-#: ../src/common/fmapbase.cpp:164
+#: ../src/common/fmapbase.cpp:161
 msgid "KOI8-U"
 msgstr "KOI8-U"
 
-#: ../src/common/accelcmn.cpp:265 ../src/common/accelcmn.cpp:347
+#: ../src/common/accelcmn.cpp:279 ../src/common/accelcmn.cpp:364
 msgid "KP_"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "KP_Add"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "KP_Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "KP_Decimal"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 #, fuzzy
 msgid "KP_Delete"
 msgstr "&Slett"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "KP_Divide"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 #, fuzzy
 msgid "KP_Down"
 msgstr "Ned"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "KP_End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 #, fuzzy
 msgid "KP_Enter"
 msgstr "Skriver"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "KP_Equal"
 msgstr ""
 
+#: ../src/common/accelcmn.cpp:276 ../src/common/accelcmn.cpp:361
+msgid "KP_F"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 #, fuzzy
 msgid "KP_Home"
 msgstr "Hjem"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 #, fuzzy
 msgid "KP_Insert"
 msgstr "Innrykk"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "KP_Left"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "KP_Multiply"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:99
+#: ../src/common/accelcmn.cpp:97
 #, fuzzy
 msgid "KP_Next"
 msgstr "Neste"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "KP_PageDown"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "KP_PageUp"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:98
+#: ../src/common/accelcmn.cpp:96
 msgid "KP_Prior"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 #, fuzzy
 msgid "KP_Right"
 msgstr "Lett"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "KP_Separator"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "KP_Space"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "KP_Subtract"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "KP_Tab"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "KP_Up"
 msgstr ""
 
@@ -4695,117 +4804,132 @@ msgstr ""
 msgid "L&ine spacing:"
 msgstr "L&injeavstand:"
 
-#: ../src/generic/prntdlgg.cpp:613 ../src/generic/prntdlgg.cpp:868
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "kompresjonsfeil"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "feil ved utpakking"
+
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:861
 msgid "Landscape"
 msgstr "Liggende"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "Last"
 msgstr "Siste"
 
-#: ../src/common/prntbase.cpp:1572
+#: ../src/common/prntbase.cpp:1597
 msgid "Last page"
 msgstr "Siste side"
 
-#: ../src/common/log.cpp:305
+#: ../src/common/log.cpp:324
 #, c-format
 msgid "Last repeated message (\"%s\", %u time) wasn't output"
 msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/common/paper.cpp:103
+#: ../src/common/paper.cpp:100
 msgid "Ledger, 17 x 11 in"
 msgstr "Ledger, 17 x 11 in"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6146
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:58 ../src/generic/datavgen.cpp:6951
+#: ../src/richtext/richtextsizepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:252
 #: ../src/richtext/richtextliststylepage.cpp:253
 #: ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
-#: ../src/richtext/richtextsizepage.cpp:249 ../src/common/accelcmn.cpp:61
 msgid "Left"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:204
 #: ../src/richtext/richtextliststylepage.cpp:390
+#: ../src/richtext/richtextindentspage.cpp:204
 msgid "Left (&first line):"
 msgstr "Venstre (&første linje)"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1761
+#: ../src/propgrid/advprops.cpp:1662
 msgid "Left Button"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:880
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Left margin (mm):"
 msgstr "Venstremarg (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:141
-#: ../src/richtext/richtextindentspage.cpp:143
 #: ../src/richtext/richtextliststylepage.cpp:330
 #: ../src/richtext/richtextliststylepage.cpp:332
+#: ../src/richtext/richtextindentspage.cpp:141
+#: ../src/richtext/richtextindentspage.cpp:143
 msgid "Left-align text."
 msgstr ""
 
-#: ../src/common/paper.cpp:144
+#: ../src/common/paper.cpp:141
 #, fuzzy
 msgid "Legal Extra 9 1/2 x 15 in"
 msgstr "Legal, 8 1/2 x 14 in"
 
-#: ../src/common/paper.cpp:96
+#: ../src/common/paper.cpp:93
 msgid "Legal, 8 1/2 x 14 in"
 msgstr "Legal, 8 1/2 x 14 in"
 
-#: ../src/common/paper.cpp:143
+#: ../src/common/paper.cpp:140
 #, fuzzy
 msgid "Letter Extra 9 1/2 x 12 in"
 msgstr "Letter, 8 1/2 x 11 tommer"
 
-#: ../src/common/paper.cpp:149
+#: ../src/common/paper.cpp:146
 msgid "Letter Extra Transverse 9.275 x 12 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:152
+#: ../src/common/paper.cpp:149
 #, fuzzy
 msgid "Letter Plus 8 1/2 x 12.69 in"
 msgstr "Letter, 8 1/2 x 11 tommer"
 
-#: ../src/common/paper.cpp:169
+#: ../src/common/paper.cpp:166
 #, fuzzy
 msgid "Letter Rotated 11 x 8 1/2 in"
 msgstr "Letter, 8 1/2 x 11 tommer"
 
-#: ../src/common/paper.cpp:101
+#: ../src/common/paper.cpp:98
 msgid "Letter Small, 8 1/2 x 11 in"
 msgstr "Letter (lite), 8 1/2 x 11 tommer"
 
-#: ../src/common/paper.cpp:147
+#: ../src/common/paper.cpp:144
 #, fuzzy
 msgid "Letter Transverse 8 1/2 x 11 in"
 msgstr "Letter, 8 1/2 x 11 tommer"
 
-#: ../src/common/paper.cpp:95
+#: ../src/common/paper.cpp:92
 msgid "Letter, 8 1/2 x 11 in"
 msgstr "Letter, 8 1/2 x 11 tommer"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "License"
 msgstr "Lisens"
 
-#: ../src/generic/fontdlgg.cpp:332
+#: ../src/generic/fontdlgg.cpp:328
 msgid "Light"
 msgstr "Lett"
 
-#: ../src/propgrid/advprops.cpp:1608
+#: ../src/propgrid/advprops.cpp:1514
 msgid "Lime"
 msgstr ""
 
-#: ../src/generic/helpext.cpp:294
+#: ../src/generic/helpext.cpp:292
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr ""
@@ -4814,15 +4938,15 @@ msgstr ""
 msgid "Line spacing:"
 msgstr "Linjeavstand:"
 
-#: ../src/html/chm.cpp:838
+#: ../src/html/chm.cpp:829
 msgid "Link contained '//', converted to absolute link."
 msgstr "Lenke inneholdt «//», konvertert til absolutt lenke."
 
-#: ../src/richtext/richtextformatdlg.cpp:364
+#: ../src/richtext/richtextformatdlg.cpp:357
 msgid "List Style"
 msgstr "Listestil"
 
-#: ../src/richtext/richtextstyles.cpp:1064
+#: ../src/richtext/richtextstyles.cpp:1061
 msgid "List styles"
 msgstr "List opp stiler"
 
@@ -4837,26 +4961,26 @@ msgstr "Lister opp fonter i punkter."
 msgid "Lists the available fonts."
 msgstr "Tips er ikke tilgjengelig, beklager!"
 
-#: ../src/common/fldlgcmn.cpp:340
+#: ../src/common/fldlgcmn.cpp:337
 #, c-format
 msgid "Load %s file"
 msgstr "Laster %s fil"
 
-#: ../src/html/htmlwin.cpp:597
+#: ../src/html/htmlwin.cpp:600
 msgid "Loading : "
 msgstr "Laster:"
 
-#: ../src/unix/snglinst.cpp:246
+#: ../src/unix/snglinst.cpp:243
 #, c-format
 msgid "Lock file '%s' has incorrect owner."
 msgstr "Låsefil «%s» har feil eier."
 
-#: ../src/unix/snglinst.cpp:251
+#: ../src/unix/snglinst.cpp:248
 #, c-format
 msgid "Lock file '%s' has incorrect permissions."
 msgstr "Låsefeil «%s» har feil rettigheter."
 
-#: ../src/generic/logg.cpp:576
+#: ../src/generic/logg.cpp:573
 #, c-format
 msgid "Log saved to the file '%s'."
 msgstr "Logg lagret til filen «%s»."
@@ -4871,11 +4995,11 @@ msgstr "Små bokstaver"
 msgid "Lower case roman numerals"
 msgstr "Romerske tall med små bokstaver"
 
-#: ../src/gtk/mdi.cpp:422 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk1/mdi.cpp:431 ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "MDI-barn"
 
-#: ../src/msw/helpchm.cpp:56
+#: ../src/msw/helpchm.cpp:53
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -4883,193 +5007,193 @@ msgstr ""
 "MS HTML hjelpefunksjoner er utilgjengelig fordi MS HTML hjelpebiblioteket "
 "ikke er installert på denne maskinen."
 
-#: ../src/univ/themes/win32.cpp:3754
+#: ../src/univ/themes/win32.cpp:3751
 msgid "Ma&ximize"
 msgstr "Ma&ksimer"
 
-#: ../src/common/fmapbase.cpp:203
+#: ../src/common/fmapbase.cpp:200
 msgid "MacArabic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:222
+#: ../src/common/fmapbase.cpp:219
 msgid "MacArmenian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:211
+#: ../src/common/fmapbase.cpp:208
 msgid "MacBengali"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:217
+#: ../src/common/fmapbase.cpp:214
 msgid "MacBurmese"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:236
+#: ../src/common/fmapbase.cpp:233
 msgid "MacCeltic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:227
+#: ../src/common/fmapbase.cpp:224
 msgid "MacCentralEurRoman"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:223
+#: ../src/common/fmapbase.cpp:220
 msgid "MacChineseSimp"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:201
+#: ../src/common/fmapbase.cpp:198
 msgid "MacChineseTrad"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:233
+#: ../src/common/fmapbase.cpp:230
 msgid "MacCroatian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:206
+#: ../src/common/fmapbase.cpp:203
 msgid "MacCyrillic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:207
+#: ../src/common/fmapbase.cpp:204
 msgid "MacDevanagari"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:231
+#: ../src/common/fmapbase.cpp:228
 msgid "MacDingbats"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:226
+#: ../src/common/fmapbase.cpp:223
 msgid "MacEthiopic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:229
+#: ../src/common/fmapbase.cpp:226
 msgid "MacExtArabic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:237
+#: ../src/common/fmapbase.cpp:234
 msgid "MacGaelic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:221
+#: ../src/common/fmapbase.cpp:218
 msgid "MacGeorgian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:205
+#: ../src/common/fmapbase.cpp:202
 msgid "MacGreek"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:209
+#: ../src/common/fmapbase.cpp:206
 msgid "MacGujarati"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:208
+#: ../src/common/fmapbase.cpp:205
 msgid "MacGurmukhi"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:204
+#: ../src/common/fmapbase.cpp:201
 msgid "MacHebrew"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:234
+#: ../src/common/fmapbase.cpp:231
 msgid "MacIcelandic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:200
+#: ../src/common/fmapbase.cpp:197
 msgid "MacJapanese"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:214
+#: ../src/common/fmapbase.cpp:211
 msgid "MacKannada"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:238
+#: ../src/common/fmapbase.cpp:235
 msgid "MacKeyboardGlyphs"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:218
+#: ../src/common/fmapbase.cpp:215
 msgid "MacKhmer"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:202
+#: ../src/common/fmapbase.cpp:199
 msgid "MacKorean"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:220
+#: ../src/common/fmapbase.cpp:217
 msgid "MacLaotian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:215
+#: ../src/common/fmapbase.cpp:212
 msgid "MacMalayalam"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:225
+#: ../src/common/fmapbase.cpp:222
 msgid "MacMongolian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:210
+#: ../src/common/fmapbase.cpp:207
 msgid "MacOriya"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:199
+#: ../src/common/fmapbase.cpp:196
 #, fuzzy
 msgid "MacRoman"
 msgstr "Roman"
 
-#: ../src/common/fmapbase.cpp:235
+#: ../src/common/fmapbase.cpp:232
 #, fuzzy
 msgid "MacRomanian"
 msgstr "Roman"
 
-#: ../src/common/fmapbase.cpp:216
+#: ../src/common/fmapbase.cpp:213
 #, fuzzy
 msgid "MacSinhalese"
 msgstr "Skill mellom store og små bokstaver"
 
-#: ../src/common/fmapbase.cpp:230
+#: ../src/common/fmapbase.cpp:227
 #, fuzzy
 msgid "MacSymbol"
 msgstr "&Stil:"
 
-#: ../src/common/fmapbase.cpp:212
+#: ../src/common/fmapbase.cpp:209
 msgid "MacTamil"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:213
+#: ../src/common/fmapbase.cpp:210
 msgid "MacTelugu"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:219
+#: ../src/common/fmapbase.cpp:216
 msgid "MacThai"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:224
+#: ../src/common/fmapbase.cpp:221
 msgid "MacTibetan"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:232
+#: ../src/common/fmapbase.cpp:229
 msgid "MacTurkish"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:228
+#: ../src/common/fmapbase.cpp:225
 msgid "MacVietnamese"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1762
+#: ../src/propgrid/advprops.cpp:1663
 msgid "Magnifier"
 msgstr "Forstørrelsesglass"
 
-#: ../src/propgrid/advprops.cpp:2143
+#: ../src/propgrid/advprops.cpp:2050
 msgid "Make a selection:"
 msgstr "SeksjonerGjør et valg:"
 
-#: ../src/richtext/richtextformatdlg.cpp:374
+#: ../src/richtext/richtextformatdlg.cpp:367
 #: ../src/richtext/richtextmarginspage.cpp:171
 msgid "Margins"
 msgstr "Marger"
 
-#: ../src/propgrid/advprops.cpp:1595
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Maroon"
 msgstr "Rødbrun"
 
-#: ../src/generic/fdrepdlg.cpp:147
+#: ../src/generic/fdrepdlg.cpp:144
 msgid "Match case"
 msgstr "Skill mellom store og små bokstaver"
 
@@ -5081,40 +5205,40 @@ msgstr "Maks høyde:"
 msgid "Max width:"
 msgstr "Maks bredde:"
 
-#: ../src/unix/mediactrl.cpp:947
+#: ../src/unix/mediactrl.cpp:972
 #, c-format
 msgid "Media playback error: %s"
 msgstr "Avspillingsfeil: %s"
 
-#: ../src/common/fs_mem.cpp:175
+#: ../src/common/fs_mem.cpp:170
 #, c-format
 msgid "Memory VFS already contains file '%s'!"
 msgstr "Minne VFS inneholder allerede filen «%s»!"
 
 #. TRANSLATORS: Name of keyboard key
 #. TRANSLATORS: Keyword of system colour
-#: ../src/common/accelcmn.cpp:73 ../src/propgrid/advprops.cpp:889
+#: ../src/common/accelcmn.cpp:70 ../src/propgrid/advprops.cpp:790
 msgid "Menu"
 msgstr "Meny"
 
-#: ../src/common/msgout.cpp:124
+#: ../src/common/msgout.cpp:121
 msgid "Message"
 msgstr "Melding"
 
-#: ../src/univ/themes/metal.cpp:168
+#: ../src/univ/themes/metal.cpp:165
 msgid "Metal theme"
 msgstr "Metaltema"
 
-#: ../src/msw/ole/automtn.cpp:652
+#: ../src/msw/ole/automtn.cpp:643
 msgid "Method or property not found."
 msgstr ""
 
-#: ../src/univ/themes/win32.cpp:3752
+#: ../src/univ/themes/win32.cpp:3749
 msgid "Mi&nimize"
 msgstr "Mi&nimer"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1763
+#: ../src/propgrid/advprops.cpp:1664
 msgid "Middle Button"
 msgstr ""
 
@@ -5126,36 +5250,41 @@ msgstr "Min høyde:"
 msgid "Min width:"
 msgstr "Min bredde:"
 
-#: ../src/msw/ole/automtn.cpp:668
+#: ../src/osx/cocoa/menu.mm:281
+#, fuzzy
+msgid "Minimize"
+msgstr "Mi&nimer"
+
+#: ../src/msw/ole/automtn.cpp:659
 msgid "Missing a required parameter."
 msgstr "En påkrevd parameter mangler."
 
-#: ../src/generic/fontdlgg.cpp:324
+#: ../src/generic/fontdlgg.cpp:320
 msgid "Modern"
 msgstr "Moderne"
 
-#: ../src/generic/filectrlg.cpp:427
+#: ../src/generic/filectrlg.cpp:423
 msgid "Modified"
 msgstr "Modifisert"
 
-#: ../src/common/module.cpp:133
+#: ../src/common/module.cpp:130
 #, c-format
 msgid "Module \"%s\" initialization failed"
 msgstr ""
 
-#: ../src/common/paper.cpp:131
+#: ../src/common/paper.cpp:128
 msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
 msgstr "Monark-konvolutt, 3 7/8 x 7 1/2 tommer"
 
-#: ../src/msw/fswatcher.cpp:143
+#: ../src/msw/fswatcher.cpp:140
 msgid "Monitoring individual files for changes is not supported currently."
 msgstr "Overvåking av endringer av individuelle filer er ikke støttet. "
 
-#: ../src/generic/editlbox.cpp:172
+#: ../src/generic/editlbox.cpp:160
 msgid "Move down"
 msgstr "Flytt ned"
 
-#: ../src/generic/editlbox.cpp:171
+#: ../src/generic/editlbox.cpp:155
 msgid "Move up"
 msgstr "Flytt opp"
 
@@ -5169,99 +5298,104 @@ msgstr "Flytter objektet til neste avsnitt."
 msgid "Moves the object to the previous paragraph."
 msgstr "Flytter objektet til forige avsnitt."
 
-#: ../src/richtext/richtextbuffer.cpp:9966
+#: ../src/richtext/richtextbuffer.cpp:9963
 msgid "Multiple Cell Properties"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:424
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:82
+msgid "Multiply"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:420
 msgid "Name"
 msgstr "Navn"
 
-#: ../src/propgrid/advprops.cpp:1596
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Navy"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "Network"
 msgstr "Nettverk"
 
-#: ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173
 #, fuzzy
 msgid "New"
 msgstr "&Ny"
 
-#: ../src/richtext/richtextstyledlg.cpp:243
+#: ../src/richtext/richtextstyledlg.cpp:239
 #, fuzzy
 msgid "New &Box Style..."
 msgstr "Nytt element"
 
-#: ../src/richtext/richtextstyledlg.cpp:225
+#: ../src/richtext/richtextstyledlg.cpp:221
 msgid "New &Character Style..."
 msgstr "Ny &bokstavstil..."
 
-#: ../src/richtext/richtextstyledlg.cpp:237
+#: ../src/richtext/richtextstyledlg.cpp:233
 msgid "New &List Style..."
 msgstr "Ny &liststil..."
 
-#: ../src/richtext/richtextstyledlg.cpp:231
+#: ../src/richtext/richtextstyledlg.cpp:227
 msgid "New &Paragraph Style..."
 msgstr "Ny &avsnittstil..."
 
-#: ../src/richtext/richtextstyledlg.cpp:606
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:654
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:820
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:893
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:934
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:602
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:650
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:816
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:889
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:930
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "New Style"
 msgstr "Nytt elementNy stil"
 
-#: ../src/generic/editlbox.cpp:169
+#: ../src/generic/editlbox.cpp:139
 msgid "New item"
 msgstr "Nytt element"
 
-#: ../src/generic/dirdlgg.cpp:297 ../src/generic/dirdlgg.cpp:307
-#: ../src/generic/filectrlg.cpp:618 ../src/generic/filectrlg.cpp:627
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+#: ../src/generic/dirdlgg.cpp:294 ../src/generic/dirdlgg.cpp:304
 msgid "NewName"
 msgstr "NyttNavn"
 
-#: ../src/common/prntbase.cpp:1567 ../src/html/helpwnd.cpp:665
+#: ../src/common/prntbase.cpp:1592 ../src/html/helpwnd.cpp:663
 msgid "Next page"
 msgstr "Neste side"
 
-#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:177
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:174
 #: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Nei"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1764
+#: ../src/propgrid/advprops.cpp:1665
 msgid "No Entry"
 msgstr ""
 
-#: ../src/generic/animateg.cpp:150
+#: ../src/generic/animateg.cpp:133
 #, fuzzy, c-format
 msgid "No animation handler for type %ld defined."
 msgstr "Ingen bildebehandler for type %d definert."
 
-#: ../src/dfb/bitmap.cpp:642 ../src/dfb/bitmap.cpp:676
+#: ../src/dfb/bitmap.cpp:639 ../src/dfb/bitmap.cpp:673
 #, fuzzy, c-format
 msgid "No bitmap handler for type %d defined."
 msgstr "Ingen bildebehandler for type %d definert."
 
-#: ../src/common/utilscmn.cpp:1077
+#: ../src/common/utilscmn.cpp:1095
 msgid "No default application configured for HTML files."
 msgstr "Ingen applikasjon satt opp for HTML-filer."
 
-#: ../src/generic/helpext.cpp:445
+#: ../src/generic/helpext.cpp:443
 msgid "No entries found."
 msgstr "Ingen oppføringer funnet."
 
-#: ../src/common/fontmap.cpp:421
+#: ../src/common/fontmap.cpp:418
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found,\n"
@@ -5273,7 +5407,7 @@ msgstr ""
 "men en alternativ koding «%s» er tilgjengelig.\n"
 "Vil du bruke denne koding (hvis ikke må du velge en annen)?"
 
-#: ../src/common/fontmap.cpp:426
+#: ../src/common/fontmap.cpp:423
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found.\n"
@@ -5284,211 +5418,210 @@ msgstr ""
 "Vil du velge en annen skrift for denne kodingen\n"
 "(hvis ikke vil teksten i denne kodingen bli vist feil)?"
 
-#: ../src/generic/animateg.cpp:142
+#: ../src/generic/animateg.cpp:125
 #, fuzzy
 msgid "No handler found for animation type."
 msgstr "Ingen behandler funnet for bildetype."
 
-#: ../src/common/image.cpp:2728
+#: ../src/common/image.cpp:2823
 msgid "No handler found for image type."
 msgstr "Ingen behandler funnet for bildetype."
 
-#: ../src/common/image.cpp:2736 ../src/common/image.cpp:2848
-#: ../src/common/image.cpp:2901
+#: ../src/common/image.cpp:2831 ../src/common/image.cpp:2954
+#: ../src/common/image.cpp:3020
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "Ingen bildebehandler for type %d definert."
 
-#: ../src/common/image.cpp:2871 ../src/common/image.cpp:2915
+#: ../src/common/image.cpp:2986 ../src/common/image.cpp:3034
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "Ingen bildebehandler for type %s definert."
 
-#: ../src/html/helpwnd.cpp:858
+#: ../src/html/helpwnd.cpp:856
 msgid "No matching page found yet"
 msgstr "Ingen sider med treff funnet enda"
 
-#: ../src/unix/sound.cpp:81
+#: ../src/unix/sound.cpp:78
 msgid "No sound"
 msgstr "Ingen lyd"
 
-#: ../src/common/image.cpp:2277 ../src/common/image.cpp:2318
+#: ../src/common/image.cpp:2371 ../src/common/image.cpp:2412
 msgid "No unused colour in image being masked."
 msgstr "Ingen ubrukte farger i bilde blir masket."
 
-#: ../src/common/image.cpp:3374
-msgid "No unused colour in image."
-msgstr "Ingen ubrukte farger i bildet."
-
-#: ../src/generic/helpext.cpp:302
+#: ../src/generic/helpext.cpp:300
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr ""
 
-#: ../src/richtext/richtextborderspage.cpp:610
 #: ../src/richtext/richtextsizepage.cpp:248
 #: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:610
 #, fuzzy
 msgid "None"
 msgstr "Ferdig"
 
-#: ../src/common/fmapbase.cpp:157
+#: ../src/common/fmapbase.cpp:154
 msgid "Nordic (ISO-8859-10)"
 msgstr "Nordisk (ISO-8859-10)"
 
-#: ../src/generic/fontdlgg.cpp:328 ../src/generic/fontdlgg.cpp:331
+#: ../src/generic/fontdlgg.cpp:324 ../src/generic/fontdlgg.cpp:327
 msgid "Normal"
 msgstr "Normal"
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1261
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Normal skrift<br>og <u>understreket</u>."
 
-#: ../src/html/helpwnd.cpp:1205
+#: ../src/html/helpwnd.cpp:1203
 msgid "Normal font:"
 msgstr "Normal skrift:"
 
-#: ../src/propgrid/props.cpp:1128
+#: ../src/propgrid/props.cpp:1115
 #, fuzzy, c-format
 msgid "Not %s"
 msgstr "%Om"
 
-#: ../include/wx/filename.h:573 ../include/wx/filename.h:578
-#, fuzzy
-msgid "Not available"
-msgstr "Ingen XBM-fasilitet tilgjengelig!"
+#: ../src/common/secretstore.cpp:168
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/webrequest.cpp:605
+msgid "Not enough free disk space for download."
+msgstr ""
 
 #: ../src/richtext/richtextfontpage.cpp:358
 #, fuzzy
 msgid "Not underlined"
 msgstr "understreket"
 
-#: ../src/common/paper.cpp:115
+#: ../src/common/paper.cpp:112
 msgid "Note, 8 1/2 x 11 in"
 msgstr "Notat, 8 1/2 x 11 tommer"
 
-#: ../src/generic/notifmsgg.cpp:132
+#: ../src/generic/notifmsgg.cpp:129
 #, fuzzy
 msgid "Notice"
 msgstr "&Notater:"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "Num *"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "Num +"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "Num ,"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "Num -"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "Num ."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "Num /"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "Num ="
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "Num Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 #, fuzzy
 msgid "Num Delete"
 msgstr "&Slett"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 #, fuzzy
 msgid "Num Down"
 msgstr "Ned"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "Num End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "Num Enter"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 #, fuzzy
 msgid "Num Home"
 msgstr "Hjem"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 #, fuzzy
 msgid "Num Insert"
 msgstr "Innrykk"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num Lock"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "Num Page Down"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "Num Page Up"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 #, fuzzy
 msgid "Num Right"
 msgstr "Lett"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "Num Space"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "Num Tab"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "Num Up"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "Num left"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num_lock"
 msgstr ""
 
@@ -5497,13 +5630,13 @@ msgstr ""
 msgid "Numbered outline"
 msgstr "Nummerert disposisjon"
 
-#: ../include/wx/msgdlg.h:278 ../src/richtext/richtextstyledlg.cpp:297
-#: ../src/common/stockitem.cpp:178 ../src/msw/msgdlg.cpp:454
-#: ../src/msw/msgdlg.cpp:747 ../src/gtk1/fontdlg.cpp:138
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:175
+#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/msgdlg.cpp:741 ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "OK"
 
-#: ../src/msw/ole/automtn.cpp:692
+#: ../src/msw/ole/automtn.cpp:683
 #, c-format
 msgid "OLE Automation error in %s: %s"
 msgstr ""
@@ -5513,15 +5646,15 @@ msgstr ""
 msgid "Object Properties"
 msgstr "&Egenskaper"
 
-#: ../src/msw/ole/automtn.cpp:660
+#: ../src/msw/ole/automtn.cpp:651
 msgid "Object implementation does not support named arguments."
 msgstr ""
 
-#: ../src/common/xtixml.cpp:264
+#: ../src/common/xtixml.cpp:260
 msgid "Objects must have an id attribute"
 msgstr "Objekter må ha en ID attributt"
 
-#: ../src/propgrid/advprops.cpp:1601
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Olive"
 msgstr "Oliven"
 
@@ -5529,66 +5662,71 @@ msgstr "Oliven"
 msgid "Opaci&ty:"
 msgstr "Dekkevne:"
 
-#: ../src/generic/colrdlgg.cpp:354
+#: ../src/generic/colrdlgg.cpp:374
 #, fuzzy
 msgid "Opacity:"
 msgstr "Dekkevne:"
 
-#: ../src/common/docview.cpp:1773 ../src/common/docview.cpp:1815
+#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
 msgid "Open File"
 msgstr "Åpne Fil"
 
-#: ../src/html/helpwnd.cpp:671 ../src/html/helpwnd.cpp:1554
+#: ../src/html/helpwnd.cpp:669 ../src/html/helpwnd.cpp:1552
 msgid "Open HTML document"
 msgstr "Åpne HTML-dokument"
 
-#: ../src/generic/dbgrptg.cpp:163
+#: ../src/common/stockitem.cpp:265
+#, fuzzy
+msgid "Open an existing document"
+msgstr "Åpne HTML-dokument"
+
+#: ../src/generic/dbgrptg.cpp:160
 #, c-format
 msgid "Open file \"%s\""
 msgstr "Åpne fil «%s»"
 
-#: ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176
 #, fuzzy
 msgid "Open..."
 msgstr "&Åpne..."
 
-#: ../src/unix/glx11.cpp:506 ../src/msw/glcanvas.cpp:592
+#: ../src/msw/glcanvas.cpp:607 ../src/unix/glx11.cpp:513
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr ""
 
-#: ../src/generic/dirctrlg.cpp:599 ../src/generic/dirdlgg.cpp:323
-#: ../src/generic/filectrlg.cpp:642 ../src/generic/filectrlg.cpp:786
+#: ../src/generic/dirctrlg.cpp:565 ../src/generic/filectrlg.cpp:638
+#: ../src/generic/filectrlg.cpp:782 ../src/generic/dirdlgg.cpp:320
 msgid "Operation not permitted."
 msgstr "Operasjon ikke tillatt."
 
-#: ../src/common/cmdline.cpp:900
+#: ../src/common/cmdline.cpp:896
 #, fuzzy, c-format
 msgid "Option '%s' can't be negated"
 msgstr "Mappe «%s» kunne ikke opprettes"
 
-#: ../src/common/cmdline.cpp:1064
+#: ../src/common/cmdline.cpp:1060
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "Opsjon «%s» må ha en verdi."
 
-#: ../src/common/cmdline.cpp:1147
+#: ../src/common/cmdline.cpp:1143
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Opsjon «%s»: «%s» kan ikke konverteres til en dato."
 
-#: ../src/generic/prntdlgg.cpp:618
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Opsjoner"
 
-#: ../src/propgrid/advprops.cpp:1606
+#: ../src/propgrid/advprops.cpp:1512
 msgid "Orange"
 msgstr "Oransje"
 
-#: ../src/generic/prntdlgg.cpp:615 ../src/generic/prntdlgg.cpp:869
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:862
 msgid "Orientation"
 msgstr "Orientering"
 
-#: ../src/common/windowid.cpp:242
+#: ../src/common/windowid.cpp:237
 msgid "Out of window IDs.  Recommend shutting down application."
 msgstr ""
 
@@ -5601,167 +5739,167 @@ msgstr "Disposisjon"
 msgid "Outset"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:656
+#: ../src/msw/ole/automtn.cpp:647
 msgid "Overflow while coercing argument values."
 msgstr ""
 
-#: ../src/common/imagpcx.cpp:457 ../src/common/imagpcx.cpp:480
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:479
 msgid "PCX: couldn't allocate memory"
 msgstr "PCX: Klarte ikke reservere minne"
 
-#: ../src/common/imagpcx.cpp:456
+#: ../src/common/imagpcx.cpp:455
 msgid "PCX: image format unsupported"
 msgstr "PCX: Bildeformat ikke støttet"
 
-#: ../src/common/imagpcx.cpp:479
+#: ../src/common/imagpcx.cpp:478
 msgid "PCX: invalid image"
 msgstr "PCX: Ugyldig bilde"
 
-#: ../src/common/imagpcx.cpp:442
+#: ../src/common/imagpcx.cpp:441
 msgid "PCX: this is not a PCX file."
 msgstr "PCX: Dette er ikke en PCX-fil"
 
-#: ../src/common/imagpcx.cpp:459 ../src/common/imagpcx.cpp:481
+#: ../src/common/imagpcx.cpp:458 ../src/common/imagpcx.cpp:480
 msgid "PCX: unknown error !!!"
 msgstr "PCX: Ukjent feil!"
 
-#: ../src/common/imagpcx.cpp:458
+#: ../src/common/imagpcx.cpp:457
 msgid "PCX: version number too low"
 msgstr "PCX: Versjonsnummer er for lavt"
 
-#: ../src/common/imagpnm.cpp:91
+#: ../src/common/imagpnm.cpp:89
 msgid "PNM: Couldn't allocate memory."
 msgstr "PNM: Klarte ikke reservere minne."
 
-#: ../src/common/imagpnm.cpp:73
+#: ../src/common/imagpnm.cpp:71
 msgid "PNM: File format is not recognized."
 msgstr "PNM: Filformat ikke gjenkjent"
 
-#: ../src/common/imagpnm.cpp:112 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
 #: ../src/common/imagpnm.cpp:156
 msgid "PNM: File seems truncated."
 msgstr "PNM: Filen ser ut til å være trunkert."
 
-#: ../src/common/paper.cpp:187
+#: ../src/common/paper.cpp:184
 msgid "PRC 16K 146 x 215 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:200
+#: ../src/common/paper.cpp:197
 msgid "PRC 16K Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:188
+#: ../src/common/paper.cpp:185
 msgid "PRC 32K 97 x 151 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:201
+#: ../src/common/paper.cpp:198
 msgid "PRC 32K Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:189
+#: ../src/common/paper.cpp:186
 msgid "PRC 32K(Big) 97 x 151 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:202
+#: ../src/common/paper.cpp:199
 msgid "PRC 32K(Big) Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:190
+#: ../src/common/paper.cpp:187
 #, fuzzy
 msgid "PRC Envelope #1 102 x 165 mm"
 msgstr "C6-konvoluttm 114 x 162 mm"
 
-#: ../src/common/paper.cpp:203
+#: ../src/common/paper.cpp:200
 #, fuzzy
 msgid "PRC Envelope #1 Rotated 165 x 102 mm"
 msgstr "C6-konvoluttm 114 x 162 mm"
 
-#: ../src/common/paper.cpp:199
+#: ../src/common/paper.cpp:196
 #, fuzzy
 msgid "PRC Envelope #10 324 x 458 mm"
 msgstr "C3-konvolutt, 324 x 458 mm"
 
-#: ../src/common/paper.cpp:212
+#: ../src/common/paper.cpp:209
 #, fuzzy
 msgid "PRC Envelope #10 Rotated 458 x 324 mm"
 msgstr "C4-konvolutt, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:191
+#: ../src/common/paper.cpp:188
 #, fuzzy
 msgid "PRC Envelope #2 102 x 176 mm"
 msgstr "C6-konvoluttm 114 x 162 mm"
 
-#: ../src/common/paper.cpp:204
+#: ../src/common/paper.cpp:201
 #, fuzzy
 msgid "PRC Envelope #2 Rotated 176 x 102 mm"
 msgstr "B6-konvolutt, 176 x 125 mm"
 
-#: ../src/common/paper.cpp:192
+#: ../src/common/paper.cpp:189
 #, fuzzy
 msgid "PRC Envelope #3 125 x 176 mm"
 msgstr "C6-konvoluttm 114 x 162 mm"
 
-#: ../src/common/paper.cpp:205
+#: ../src/common/paper.cpp:202
 #, fuzzy
 msgid "PRC Envelope #3 Rotated 176 x 125 mm"
 msgstr "B6-konvolutt, 176 x 125 mm"
 
-#: ../src/common/paper.cpp:193
+#: ../src/common/paper.cpp:190
 #, fuzzy
 msgid "PRC Envelope #4 110 x 208 mm"
 msgstr "DL-konvolutt, 11 x 220 mm"
 
-#: ../src/common/paper.cpp:206
+#: ../src/common/paper.cpp:203
 #, fuzzy
 msgid "PRC Envelope #4 Rotated 208 x 110 mm"
 msgstr "C6-konvoluttm 114 x 162 mm"
 
-#: ../src/common/paper.cpp:194
+#: ../src/common/paper.cpp:191
 #, fuzzy
 msgid "PRC Envelope #5 110 x 220 mm"
 msgstr "DL-konvolutt, 11 x 220 mm"
 
-#: ../src/common/paper.cpp:207
+#: ../src/common/paper.cpp:204
 #, fuzzy
 msgid "PRC Envelope #5 Rotated 220 x 110 mm"
 msgstr "C4-konvolutt, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:195
+#: ../src/common/paper.cpp:192
 #, fuzzy
 msgid "PRC Envelope #6 120 x 230 mm"
 msgstr "C5-konvolutt, 162 x 229 mm"
 
-#: ../src/common/paper.cpp:208
+#: ../src/common/paper.cpp:205
 #, fuzzy
 msgid "PRC Envelope #6 Rotated 230 x 120 mm"
 msgstr "C5-konvolutt, 162 x 229 mm"
 
-#: ../src/common/paper.cpp:196
+#: ../src/common/paper.cpp:193
 #, fuzzy
 msgid "PRC Envelope #7 160 x 230 mm"
 msgstr "B5-konvolutt, 176 x 250 mm"
 
-#: ../src/common/paper.cpp:209
+#: ../src/common/paper.cpp:206
 #, fuzzy
 msgid "PRC Envelope #7 Rotated 230 x 160 mm"
 msgstr "C6-konvoluttm 114 x 162 mm"
 
-#: ../src/common/paper.cpp:197
+#: ../src/common/paper.cpp:194
 #, fuzzy
 msgid "PRC Envelope #8 120 x 309 mm"
 msgstr "C5-konvolutt, 162 x 229 mm"
 
-#: ../src/common/paper.cpp:210
+#: ../src/common/paper.cpp:207
 #, fuzzy
 msgid "PRC Envelope #8 Rotated 309 x 120 mm"
 msgstr "C4-konvolutt, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:198
+#: ../src/common/paper.cpp:195
 #, fuzzy
 msgid "PRC Envelope #9 229 x 324 mm"
 msgstr "C4-konvolutt, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:211
+#: ../src/common/paper.cpp:208
 #, fuzzy
 msgid "PRC Envelope #9 Rotated 324 x 229 mm"
 msgstr "C5-konvolutt, 162 x 229 mm"
@@ -5771,94 +5909,98 @@ msgstr "C5-konvolutt, 162 x 229 mm"
 msgid "Padding"
 msgstr "leser"
 
-#: ../src/common/prntbase.cpp:2074
+#: ../src/common/prntbase.cpp:2096
 #, c-format
 msgid "Page %d"
 msgstr "Side %d"
 
-#: ../src/common/prntbase.cpp:2072
+#: ../src/common/prntbase.cpp:2094
 #, c-format
 msgid "Page %d of %d"
 msgstr "Side %d av %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 #, fuzzy
 msgid "Page Down"
 msgstr "Side %d"
 
-#: ../src/gtk/print.cpp:826
+#: ../src/gtk/print.cpp:829
 msgid "Page Setup"
 msgstr "Sideoppsett"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 #, fuzzy
 msgid "Page Up"
 msgstr "Side %d"
 
-#: ../src/generic/prntdlgg.cpp:828 ../src/common/prntbase.cpp:484
+#: ../src/common/prntbase.cpp:479 ../src/generic/prntdlgg.cpp:821
 msgid "Page setup"
 msgstr "Sideoppsett"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 #, fuzzy
 msgid "PageDown"
 msgstr "Ned"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 #, fuzzy
 msgid "PageUp"
 msgstr "Sider"
 
-#: ../src/generic/prntdlgg.cpp:216
+#: ../src/generic/prntdlgg.cpp:209
 msgid "Pages"
 msgstr "Sider"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1765
+#: ../src/propgrid/advprops.cpp:1666
 msgid "Paint Brush"
 msgstr "Malepensel"
 
-#: ../src/generic/prntdlgg.cpp:602 ../src/generic/prntdlgg.cpp:801
-#: ../src/generic/prntdlgg.cpp:842 ../src/generic/prntdlgg.cpp:855
-#: ../src/generic/prntdlgg.cpp:1052 ../src/generic/prntdlgg.cpp:1057
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:794
+#: ../src/generic/prntdlgg.cpp:835 ../src/generic/prntdlgg.cpp:848
+#: ../src/generic/prntdlgg.cpp:1045 ../src/generic/prntdlgg.cpp:1050
 msgid "Paper size"
 msgstr "Papirstørrelse"
 
-#: ../src/richtext/richtextstyles.cpp:1062
+#: ../src/richtext/richtextstyles.cpp:1059
 msgid "Paragraph styles"
 msgstr "Avsnittstil"
 
-#: ../src/common/xtistrm.cpp:465
+#: ../src/common/xtistrm.cpp:462
 msgid "Passing a already registered object to SetObject"
 msgstr "Allerede registrert objekt sendt til SetObject"
 
-#: ../src/common/xtistrm.cpp:476
+#: ../src/common/xtistrm.cpp:473
 #, fuzzy
 msgid "Passing an unknown object to GetObject"
 msgstr "Ukjent objekt sendt til GetObject"
 
-#: ../src/richtext/richtextctrl.cpp:3513 ../src/common/stockitem.cpp:180
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:177 ../src/richtext/richtextctrl.cpp:3514
 #: ../src/stc/stc_i18n.cpp:19
 #, fuzzy
 msgid "Paste"
 msgstr "&Lim inn"
 
-#: ../src/common/stockitem.cpp:262
+#: ../src/common/stockitem.cpp:260
 #, fuzzy
 msgid "Paste selection"
 msgstr "Seksjoner"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:74
+#: ../src/common/accelcmn.cpp:71
 msgid "Pause"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1766
+#: ../src/propgrid/advprops.cpp:1667
 msgid "Pencil"
 msgstr "Blyant"
 
@@ -5867,21 +6009,21 @@ msgstr "Blyant"
 msgid "Peri&od"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:430
+#: ../src/generic/filectrlg.cpp:426
 msgid "Permissions"
 msgstr "Rettigheter"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:60
+#: ../src/common/accelcmn.cpp:57
 msgid "PgDn"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:59
+#: ../src/common/accelcmn.cpp:56
 msgid "PgUp"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:12868
+#: ../src/richtext/richtextbuffer.cpp:12863
 #, fuzzy
 msgid "Picture Properties"
 msgstr "&Egenskaper"
@@ -5894,46 +6036,46 @@ msgstr "Røropprettelse feilet"
 msgid "Please choose a valid font."
 msgstr "Velg en gyldig skrift."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
 msgid "Please choose an existing file."
 msgstr "Velg en eksisterende fil."
 
-#: ../src/html/helpwnd.cpp:800
+#: ../src/html/helpwnd.cpp:798
 msgid "Please choose the page to display:"
 msgstr "Velg siden som skal vises:"
 
-#: ../src/msw/dialup.cpp:764
+#: ../src/msw/dialup.cpp:758
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Velg hvilken ISP du vil koble til"
 
-#: ../src/common/headerctrlcmn.cpp:59
+#: ../src/common/headerctrlcmn.cpp:57
 msgid "Please select the columns to show and define their order:"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:538
+#: ../src/common/prntbase.cpp:533
 #, fuzzy
 msgid "Please wait while printing..."
 msgstr "Vent mens utskriften pågår\n"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1767
+#: ../src/propgrid/advprops.cpp:1668
 #, fuzzy
 msgid "Point Left"
 msgstr "&Punktstørrelse"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1768
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgid "Point Right"
 msgstr "Høyrejustering"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:662
+#: ../src/propgrid/advprops.cpp:572
 #, fuzzy
 msgid "Point Size"
 msgstr "&Punktstørrelse"
 
-#: ../src/generic/prntdlgg.cpp:612 ../src/generic/prntdlgg.cpp:867
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:860
 msgid "Portrait"
 msgstr "Portrett"
 
@@ -5941,269 +6083,279 @@ msgstr "Portrett"
 msgid "Position"
 msgstr "Posisjon"
 
-#: ../src/generic/prntdlgg.cpp:298
+#: ../src/generic/prntdlgg.cpp:291
 msgid "PostScript file"
 msgstr "PostScript-fil"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178 ../src/osx/cocoa/preferences.mm:303
 #, fuzzy
 msgid "Preferences"
 msgstr "&Innstillinger"
 
-#: ../src/osx/menu_osx.cpp:568
+#: ../src/osx/menu_osx.cpp:460
 #, fuzzy
 msgid "Preferences..."
 msgstr "&Innstillinger"
 
-#: ../src/common/prntbase.cpp:546
+#: ../src/common/prntbase.cpp:541
 msgid "Preparing"
 msgstr "Forbereder"
 
-#: ../src/generic/fontdlgg.cpp:455 ../src/osx/carbon/fontdlg.cpp:390
-#: ../src/html/helpwnd.cpp:1222
+#: ../src/osx/carbon/fontdlg.cpp:387 ../src/generic/fontdlgg.cpp:452
+#: ../src/html/helpwnd.cpp:1220
 msgid "Preview:"
 msgstr "Forhåndsvisning:"
 
-#: ../src/common/prntbase.cpp:1553 ../src/html/helpwnd.cpp:664
+#: ../src/common/prntbase.cpp:1578 ../src/html/helpwnd.cpp:662
 msgid "Previous page"
 msgstr "Forrige side"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/prntdlgg.cpp:143 ../src/generic/prntdlgg.cpp:157
-#: ../src/common/prntbase.cpp:426 ../src/common/prntbase.cpp:1541
-#: ../src/common/accelcmn.cpp:77 ../src/gtk/print.cpp:620
-#: ../src/gtk/print.cpp:638
+#: ../src/common/prntbase.cpp:421 ../src/common/prntbase.cpp:1566
+#: ../src/common/accelcmn.cpp:74 ../src/generic/prntdlgg.cpp:136
+#: ../src/generic/prntdlgg.cpp:150 ../src/gtk/print.cpp:616
+#: ../src/gtk/print.cpp:634
 msgid "Print"
 msgstr "Utskrift"
 
-#: ../include/wx/prntbase.h:399 ../src/common/docview.cpp:1268
+#: ../src/common/docview.cpp:1262
 msgid "Print Preview"
 msgstr "Forhåndsvisning av utskrift"
 
-#: ../src/common/prntbase.cpp:2015 ../src/common/prntbase.cpp:2057
-#: ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2037 ../src/common/prntbase.cpp:2079
+#: ../src/common/prntbase.cpp:2087
 msgid "Print Preview Failure"
 msgstr "Feil ved forhåndsvisning av utskrift"
 
-#: ../src/generic/prntdlgg.cpp:224
+#: ../src/generic/prntdlgg.cpp:217
 msgid "Print Range"
 msgstr "Utskriftsområde"
 
-#: ../src/generic/prntdlgg.cpp:449
+#: ../src/generic/prntdlgg.cpp:442
 msgid "Print Setup"
 msgstr "Oppsett av utskrift"
 
-#: ../src/generic/prntdlgg.cpp:621
+#: ../src/generic/prntdlgg.cpp:614
 msgid "Print in colour"
 msgstr "Utskrift med farger"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/osx/webview_webkit.mm:260
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "Kolonnebeskrivele kunne ikke initialiseres."
+
+#: ../src/common/stockitem.cpp:179
 #, fuzzy
 msgid "Print previe&w..."
 msgstr "&Forhåndsvisning av utskrift"
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1256
 #, fuzzy
 msgid "Print preview creation failed."
 msgstr "Røropprettelse feilet"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/common/stockitem.cpp:179
 #, fuzzy
 msgid "Print preview..."
 msgstr "&Forhåndsvisning av utskrift"
 
-#: ../src/generic/prntdlgg.cpp:630
+#: ../src/generic/prntdlgg.cpp:623
 msgid "Print spooling"
 msgstr "Utskriftskø"
 
-#: ../src/html/helpwnd.cpp:675
+#: ../src/html/helpwnd.cpp:673
 msgid "Print this page"
 msgstr "Skriv ut denne siden"
 
-#: ../src/generic/prntdlgg.cpp:185
+#: ../src/generic/prntdlgg.cpp:178
 msgid "Print to File"
 msgstr "Skriv til fil"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 #, fuzzy
 msgid "Print..."
 msgstr "&Skriv ut..."
 
-#: ../src/generic/prntdlgg.cpp:493
+#: ../src/generic/prntdlgg.cpp:486
 msgid "Printer"
 msgstr "Skriver"
 
-#: ../src/generic/prntdlgg.cpp:633
+#: ../src/generic/prntdlgg.cpp:626
 msgid "Printer command:"
 msgstr "Skriverkommando:"
 
-#: ../src/generic/prntdlgg.cpp:180
+#: ../src/generic/prntdlgg.cpp:173
 msgid "Printer options"
 msgstr "Skriveropsjoner"
 
-#: ../src/generic/prntdlgg.cpp:645
+#: ../src/generic/prntdlgg.cpp:638
 msgid "Printer options:"
 msgstr "Skriveropsjoner:"
 
-#: ../src/generic/prntdlgg.cpp:916
+#: ../src/generic/prntdlgg.cpp:909
 msgid "Printer..."
 msgstr "Skriver..."
 
-#: ../src/generic/prntdlgg.cpp:196
+#: ../src/generic/prntdlgg.cpp:189
 msgid "Printer:"
 msgstr "Skriver:"
 
-#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:535
-#: ../src/html/htmprint.cpp:277
+#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:530
+#: ../src/html/htmprint.cpp:289
 #, fuzzy
 msgid "Printing"
 msgstr "Skriver ut"
 
-#: ../src/common/prntbase.cpp:612
+#: ../src/common/prntbase.cpp:607
 msgid "Printing "
 msgstr "Skriver ut"
 
-#: ../src/common/prntbase.cpp:347
+#: ../src/common/prntbase.cpp:342
 msgid "Printing Error"
 msgstr "Feil ved utskrift"
 
-#: ../src/common/prntbase.cpp:565
+#: ../src/osx/webview_webkit.mm:251
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "Gzip er ikke støttet av denne versjonen av zlib"
+
+#: ../src/common/prntbase.cpp:560
 #, fuzzy, c-format
 msgid "Printing page %d"
 msgstr "Skriver ut side %d..."
 
-#: ../src/common/prntbase.cpp:570
+#: ../src/common/prntbase.cpp:565
 #, fuzzy, c-format
 msgid "Printing page %d of %d"
 msgstr "Skriver ut side %d..."
 
-#: ../src/generic/printps.cpp:201
+#: ../src/generic/printps.cpp:182
 #, c-format
 msgid "Printing page %d..."
 msgstr "Skriver ut side %d..."
 
-#: ../src/generic/printps.cpp:161
+#: ../src/generic/printps.cpp:142
 msgid "Printing..."
 msgstr "Skriver ut..."
 
-#: ../include/wx/richtext/richtextprint.h:109 ../include/wx/prntbase.h:267
-#: ../src/common/docview.cpp:2132
+#: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
+#: ../src/common/docview.cpp:2137
 #, fuzzy
 msgid "Printout"
 msgstr "Utskrift"
 
-#: ../src/common/debugrpt.cpp:560
+#: ../src/common/debugrpt.cpp:561
 #, c-format
 msgid ""
 "Processing debug report has failed, leaving the files in \"%s\" directory."
 msgstr ""
 "Behandling av feilsøkingsrapporten feilet, etterlater filene i mappen «%s»."
 
-#: ../src/common/prntbase.cpp:545
+#: ../src/common/prntbase.cpp:540
 msgid "Progress:"
 msgstr "Framdrift:"
 
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181
 #, fuzzy
 msgid "Properties"
 msgstr "&Egenskaper"
 
-#: ../src/propgrid/manager.cpp:237
+#: ../src/propgrid/manager.cpp:223
 #, fuzzy
 msgid "Property"
 msgstr "&Egenskaper"
 
 #. TRANSLATORS: Caption of message box displaying any property error
-#: ../src/propgrid/propgrid.cpp:3185 ../src/propgrid/propgrid.cpp:3318
+#: ../src/propgrid/propgrid.cpp:3162 ../src/propgrid/propgrid.cpp:3299
 #, fuzzy
 msgid "Property Error"
 msgstr "Feil ved utskrift"
 
-#: ../src/propgrid/advprops.cpp:1597
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Purple"
 msgstr "Purpur"
 
-#: ../src/common/paper.cpp:112
+#: ../src/common/paper.cpp:109
 msgid "Quarto, 215 x 275 mm"
 msgstr "Quarto, 215 x 275 mm"
 
-#: ../src/generic/logg.cpp:1016
+#: ../src/generic/logg.cpp:1013
 msgid "Question"
 msgstr "Spørsmål"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1769
+#: ../src/propgrid/advprops.cpp:1670
 #, fuzzy
 msgid "Question Arrow"
 msgstr "Spørsmål"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 #, fuzzy
 msgid "Quit"
 msgstr "&Slutt"
 
-#: ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:477
 #, fuzzy, c-format
 msgid "Quit %s"
 msgstr "&Slutt"
 
-#: ../src/common/stockitem.cpp:263
+#: ../src/common/stockitem.cpp:261
 #, fuzzy
 msgid "Quit this program"
 msgstr "Skriv ut denne siden"
 
-#: ../src/common/accelcmn.cpp:338
+#: ../src/common/accelcmn.cpp:352
 #, fuzzy
 msgid "RawCtrl+"
 msgstr "ctrl"
 
-#: ../src/common/ffile.cpp:109 ../src/common/ffile.cpp:133
+#: ../src/common/ffile.cpp:107 ../src/common/ffile.cpp:132
 #, c-format
 msgid "Read error on file '%s'"
 msgstr "Lesefeil i fil «%s»"
 
-#: ../src/common/secretstore.cpp:199
+#: ../src/common/secretstore.cpp:211
 #, fuzzy, c-format
-msgid "Reading password for \"%s/%s\" failed: %s."
+msgid "Reading password for \"%s\" failed: %s."
 msgstr "Utpakking av «%s» inni «%s» feilet."
 
-#: ../src/common/prntbase.cpp:272
+#: ../src/common/prntbase.cpp:267
 msgid "Ready"
 msgstr "Klar"
 
-#: ../src/propgrid/advprops.cpp:1605
+#: ../src/propgrid/advprops.cpp:1511
 #, fuzzy
 msgid "Red"
 msgstr "&Gjenta"
 
-#: ../src/generic/colrdlgg.cpp:339
+#: ../src/generic/colrdlgg.cpp:359
 msgid "Red:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:185 ../src/stc/stc_i18n.cpp:16
+#: ../src/common/stockitem.cpp:182 ../src/stc/stc_i18n.cpp:16
 #, fuzzy
 msgid "Redo"
 msgstr "&Gjenta"
 
-#: ../src/common/stockitem.cpp:264
+#: ../src/common/stockitem.cpp:262
 msgid "Redo last action"
 msgstr "Gjenta forrige"
 
-#: ../src/common/stockitem.cpp:186
+#: ../src/common/stockitem.cpp:183
 msgid "Refresh"
 msgstr "Oppdater"
 
-#: ../src/msw/registry.cpp:626
+#: ../src/msw/registry.cpp:615
 #, c-format
 msgid "Registry key '%s' already exists."
 msgstr "Registernøkkel «%s» eksisterer allerede."
 
-#: ../src/msw/registry.cpp:595
+#: ../src/msw/registry.cpp:584
 #, c-format
 msgid "Registry key '%s' does not exist, cannot rename it."
 msgstr "Registernøkkel «%s» eksisterer ikke, kan ikke endre navn."
 
-#: ../src/msw/registry.cpp:727
+#: ../src/msw/registry.cpp:716
 #, c-format
 msgid ""
 "Registry key '%s' is needed for normal system operation,\n"
@@ -6214,22 +6366,22 @@ msgstr ""
 "sletting vil etterlate system i en ubrukbar tilstand:\n"
 "operasjon avbrutt."
 
-#: ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:942
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:917
+#: ../src/msw/registry.cpp:905
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1003
+#: ../src/msw/registry.cpp:991
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:521
+#: ../src/msw/registry.cpp:510
 #, c-format
 msgid "Registry value '%s' already exists."
 msgstr "Registerverdi «%s» eksisterer allerede."
@@ -6244,74 +6396,79 @@ msgstr "Vanlig"
 msgid "Relative"
 msgstr "Dekorativ"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:456
 msgid "Relevant entries:"
 msgstr "Relevante oppføringer:"
 
-#: ../include/wx/generic/progdlgg.h:86
+#: ../include/wx/generic/progdlgg.h:87
 #, fuzzy
 msgid "Remaining time:"
 msgstr "Gjenstående tid :"
 
-#: ../src/common/stockitem.cpp:187
+#: ../src/common/stockitem.cpp:184
 msgid "Remove"
 msgstr "Slett"
 
-#: ../src/richtext/richtextctrl.cpp:1562
+#: ../src/richtext/richtextctrl.cpp:1563
 #, fuzzy
 msgid "Remove Bullet"
 msgstr "Slett"
 
-#: ../src/html/helpwnd.cpp:433
+#: ../src/html/helpwnd.cpp:431
 msgid "Remove current page from bookmarks"
 msgstr "Slett gjeldende side fra bokmerker"
 
-#: ../src/common/rendcmn.cpp:194
+#: ../src/common/rendcmn.cpp:191
 #, c-format
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr "Utfører «%s» har ikke-kompatibel versjon %d.%d og ble ikke lastet."
 
-#: ../src/richtext/richtextbuffer.cpp:4527
+#: ../src/richtext/richtextbuffer.cpp:4524
 msgid "Renumber List"
 msgstr "Renummerer liste"
 
-#: ../src/common/stockitem.cpp:188
-msgid "Rep&lace"
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Rep&lace..."
 msgstr "Er&statt"
 
-#: ../src/richtext/richtextctrl.cpp:3673 ../src/common/stockitem.cpp:188
+#: ../src/richtext/richtextctrl.cpp:3674
 #, fuzzy
 msgid "Replace"
 msgstr "&Erstatt"
 
-#: ../src/generic/fdrepdlg.cpp:182
+#: ../src/generic/fdrepdlg.cpp:179
 msgid "Replace &all"
 msgstr "Erstatt &alle"
 
-#: ../src/common/stockitem.cpp:261
-#, fuzzy
-msgid "Replace selection"
-msgstr "Erstatt &alle"
-
-#: ../src/generic/fdrepdlg.cpp:124
+#: ../src/generic/fdrepdlg.cpp:121
 msgid "Replace with:"
 msgstr "Erstatt med:"
 
-#: ../src/common/valtext.cpp:163
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Replace..."
+msgstr "&Erstatt"
+
+#: ../src/common/valtext.cpp:184
 msgid "Required information entry is empty."
 msgstr ""
 
-#: ../src/common/translation.cpp:1975
+#: ../src/common/translation.cpp:2025
 #, fuzzy, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "«%s» er ikke en gyldig meldingskatalog."
 
+#: ../src/gtk/webview_webkit.cpp:985
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:56
+#: ../src/common/accelcmn.cpp:53
 msgid "Return"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:189
+#: ../src/common/stockitem.cpp:186
 msgid "Revert to Saved"
 msgstr "Gå tilbake til lagret versjon"
 
@@ -6324,41 +6481,41 @@ msgstr "Lett"
 msgid "Rig&ht-to-left"
 msgstr "Høyre-til-venstre"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6149
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:59 ../src/generic/datavgen.cpp:6954
+#: ../src/richtext/richtextsizepage.cpp:250
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextbulletspage.cpp:188
-#: ../src/richtext/richtextsizepage.cpp:250 ../src/common/accelcmn.cpp:62
 msgid "Right"
 msgstr "Høyre"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1754
+#: ../src/propgrid/advprops.cpp:1655
 msgid "Right Arrow"
 msgstr "Høyrepil"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1770
+#: ../src/propgrid/advprops.cpp:1671
 msgid "Right Button"
 msgstr "Høyreknapp"
 
-#: ../src/generic/prntdlgg.cpp:892
+#: ../src/generic/prntdlgg.cpp:885
 msgid "Right margin (mm):"
 msgstr "Høyremarg (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:148
-#: ../src/richtext/richtextindentspage.cpp:150
 #: ../src/richtext/richtextliststylepage.cpp:337
 #: ../src/richtext/richtextliststylepage.cpp:339
+#: ../src/richtext/richtextindentspage.cpp:148
+#: ../src/richtext/richtextindentspage.cpp:150
 msgid "Right-align text."
 msgstr "Høyrejuster tekst."
 
-#: ../src/generic/fontdlgg.cpp:322
+#: ../src/generic/fontdlgg.cpp:318
 msgid "Roman"
 msgstr "Roman"
 
-#: ../src/generic/datavgen.cpp:5916
+#: ../src/generic/datavgen.cpp:6721
 #, c-format
 msgid "Row %i"
 msgstr ""
@@ -6368,31 +6525,31 @@ msgstr ""
 msgid "S&tandard bullet name:"
 msgstr "S&tandard punktnavn:"
 
-#: ../src/common/accelcmn.cpp:268 ../src/common/accelcmn.cpp:350
+#: ../src/common/accelcmn.cpp:282 ../src/common/accelcmn.cpp:367
 msgid "SPECIAL"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:190 ../src/common/sizer.cpp:2797
+#: ../src/common/stockitem.cpp:187 ../src/common/sizer.cpp:2914
 msgid "Save"
 msgstr "&Lagre"
 
-#: ../src/common/fldlgcmn.cpp:342
+#: ../src/common/fldlgcmn.cpp:339
 #, c-format
 msgid "Save %s file"
 msgstr "Lagre %s fil"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/common/stockitem.cpp:188 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Lagre &som..."
 
-#: ../src/common/docview.cpp:366
+#: ../src/common/docview.cpp:359
 msgid "Save As"
 msgstr "Lagre Som"
 
-#: ../src/common/stockitem.cpp:191
+#: ../src/common/stockitem.cpp:188
 #, fuzzy
-msgid "Save as"
-msgstr "Lagre Som"
+msgid "Save As..."
+msgstr "Lagre &som..."
 
 #: ../src/common/stockitem.cpp:267
 #, fuzzy
@@ -6403,96 +6560,96 @@ msgstr "Velg en dokumentvisning"
 msgid "Save current document with a different filename"
 msgstr "Lagre dette dokumentet med et annet filnavn"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/generic/logg.cpp:509
 msgid "Save log contents to file"
 msgstr "Lagre logginnhold til fil"
 
-#: ../src/common/secretstore.cpp:179
+#: ../src/common/secretstore.cpp:189
 #, fuzzy, c-format
-msgid "Saving password for \"%s/%s\" failed: %s."
+msgid "Saving password for \"%s\" failed: %s."
 msgstr "Utpakking av «%s» inni «%s» feilet."
 
-#: ../src/generic/fontdlgg.cpp:325
+#: ../src/generic/fontdlgg.cpp:321
 msgid "Script"
 msgstr "Skript"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll Lock"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll_lock"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:890
+#: ../src/propgrid/advprops.cpp:791
 msgid "Scrollbar"
 msgstr ""
 
-#: ../src/generic/srchctlg.cpp:56 ../src/html/helpwnd.cpp:535
-#: ../src/html/helpwnd.cpp:550
+#: ../src/generic/srchctlg.cpp:55 ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:548 ../src/gtk/srchctrl.cpp:182
 msgid "Search"
 msgstr "Søk"
 
-#: ../src/html/helpwnd.cpp:537
+#: ../src/html/helpwnd.cpp:535
 #, fuzzy
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
 msgstr "Søk innholdet av alle hjelpebøker etter teksten du skrev ovenfor"
 
-#: ../src/generic/fdrepdlg.cpp:160
+#: ../src/generic/fdrepdlg.cpp:157
 msgid "Search direction"
 msgstr "Søkeretning"
 
-#: ../src/generic/fdrepdlg.cpp:112
+#: ../src/generic/fdrepdlg.cpp:109
 msgid "Search for:"
 msgstr "Søk etter:"
 
-#: ../src/html/helpwnd.cpp:1052
+#: ../src/html/helpwnd.cpp:1050
 msgid "Search in all books"
 msgstr "Søk i alle bøker"
 
-#: ../src/html/helpwnd.cpp:857
+#: ../src/html/helpwnd.cpp:855
 msgid "Searching..."
 msgstr "Søker..."
 
-#: ../src/generic/dirctrlg.cpp:446
+#: ../src/generic/dirctrlg.cpp:412
 msgid "Sections"
 msgstr "Seksjoner"
 
-#: ../src/common/ffile.cpp:238
+#: ../src/common/ffile.cpp:237
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Søkefeil i filen «%s»"
 
-#: ../src/common/ffile.cpp:228
+#: ../src/common/ffile.cpp:227
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr "Søker etter feil i fil «%s» (store filer ikke støttet av stdio)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:76
+#: ../src/common/accelcmn.cpp:73
 msgid "Select"
 msgstr "Velg"
 
-#: ../src/richtext/richtextctrl.cpp:337 ../src/osx/textctrl_osx.cpp:581
-#: ../src/common/stockitem.cpp:192 ../src/msw/textctrl.cpp:2512
+#: ../src/osx/textctrl_osx.cpp:599 ../src/common/stockitem.cpp:189
+#: ../src/msw/textctrl.cpp:2777 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Velg &alle"
 
-#: ../src/common/stockitem.cpp:192 ../src/stc/stc_i18n.cpp:21
+#: ../src/common/stockitem.cpp:189 ../src/stc/stc_i18n.cpp:21
 #, fuzzy
 msgid "Select All"
 msgstr "Velg &alle"
 
-#: ../src/common/docview.cpp:1895
+#: ../src/common/docview.cpp:1900
 msgid "Select a document template"
 msgstr "Velg en dokumentmal"
 
-#: ../src/common/docview.cpp:1969
+#: ../src/common/docview.cpp:1974
 msgid "Select a document view"
 msgstr "Velg en dokumentvisning"
 
@@ -6521,20 +6678,20 @@ msgid "Selects the list level to edit."
 msgstr "Velger listenivå som skal endres."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:82
+#: ../src/common/accelcmn.cpp:79
 msgid "Separator"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1083
+#: ../src/common/cmdline.cpp:1079
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Seperator forventet etter opsjonen «%s»."
 
-#: ../src/osx/menu_osx.cpp:572
+#: ../src/osx/menu_osx.cpp:464
 msgid "Services"
 msgstr "Tjenester"
 
-#: ../src/richtext/richtextbuffer.cpp:11217
+#: ../src/richtext/richtextbuffer.cpp:11216
 msgid "Set Cell Style"
 msgstr "Sett cellestil"
 
@@ -6542,11 +6699,11 @@ msgstr "Sett cellestil"
 msgid "SetProperty called w/o valid setter"
 msgstr "SetProperty kalt uten gyldig setter"
 
-#: ../src/generic/prntdlgg.cpp:188
+#: ../src/generic/prntdlgg.cpp:181
 msgid "Setup..."
 msgstr "Sett opp..."
 
-#: ../src/msw/dialup.cpp:544
+#: ../src/msw/dialup.cpp:538
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr "Flere aktive oppringingsforbindelser funnet, velger en tilfeldig."
 
@@ -6562,43 +6719,43 @@ msgstr "Skygge"
 msgid "Shadow c&olour:"
 msgstr "Velg skyggefarge"
 
-#: ../src/common/accelcmn.cpp:335
+#: ../src/common/accelcmn.cpp:349
 msgid "Shift+"
 msgstr ""
 
-#: ../src/generic/dirdlgg.cpp:147
+#: ../src/generic/dirdlgg.cpp:144
 #, fuzzy
 msgid "Show &hidden directories"
 msgstr "Vis skjulte mapper"
 
-#: ../src/generic/filectrlg.cpp:983
+#: ../src/generic/filectrlg.cpp:979
 #, fuzzy
 msgid "Show &hidden files"
 msgstr "Vis skjulte filer"
 
-#: ../src/osx/menu_osx.cpp:580
+#: ../src/osx/menu_osx.cpp:472
 #, fuzzy
 msgid "Show All"
 msgstr "Vis alle"
 
-#: ../src/common/stockitem.cpp:257
+#: ../src/common/stockitem.cpp:254
 msgid "Show about dialog"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:492
+#: ../src/html/helpwnd.cpp:490
 msgid "Show all"
 msgstr "Vis alle"
 
-#: ../src/html/helpwnd.cpp:503
+#: ../src/html/helpwnd.cpp:501
 msgid "Show all items in index"
 msgstr "Vis alle elementer i indeksen"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:656
 msgid "Show/hide navigation panel"
 msgstr "Vis/skjul navigasjonspanel"
 
-#: ../src/richtext/richtextsymboldlg.cpp:421
-#: ../src/richtext/richtextsymboldlg.cpp:423
+#: ../src/richtext/richtextsymboldlg.cpp:418
+#: ../src/richtext/richtextsymboldlg.cpp:420
 msgid "Shows a Unicode subset."
 msgstr "Viser en undergruppe av Unicode."
 
@@ -6614,7 +6771,7 @@ msgstr "Forhåndsvisning av punktinnstillingene."
 msgid "Shows a preview of the font settings."
 msgstr "Forhåndsvisning av  skriftinnstillingene."
 
-#: ../src/osx/carbon/fontdlg.cpp:394 ../src/osx/carbon/fontdlg.cpp:396
+#: ../src/osx/carbon/fontdlg.cpp:391 ../src/osx/carbon/fontdlg.cpp:393
 msgid "Shows a preview of the font."
 msgstr "Forhåndsvisning av skrifttypen."
 
@@ -6623,63 +6780,63 @@ msgstr "Forhåndsvisning av skrifttypen."
 msgid "Shows a preview of the paragraph settings."
 msgstr "Forhåndsvisning av avsnittinnstillingene."
 
-#: ../src/generic/fontdlgg.cpp:460 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:456 ../src/generic/fontdlgg.cpp:458
 msgid "Shows the font preview."
 msgstr "Viser skriftforhåndsvisning."
 
-#: ../src/propgrid/advprops.cpp:1607
+#: ../src/propgrid/advprops.cpp:1513
 msgid "Silver"
 msgstr "Sølv"
 
-#: ../src/univ/themes/mono.cpp:516
+#: ../src/univ/themes/mono.cpp:513
 msgid "Simple monochrome theme"
 msgstr "Enkelt monokromt tema"
 
-#: ../src/richtext/richtextindentspage.cpp:275
 #: ../src/richtext/richtextliststylepage.cpp:449
+#: ../src/richtext/richtextindentspage.cpp:275
 msgid "Single"
 msgstr "Enkel"
 
-#: ../src/generic/filectrlg.cpp:425 ../src/richtext/richtextformatdlg.cpp:369
-#: ../src/richtext/richtextsizepage.cpp:299
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextsizepage.cpp:299
+#: ../src/richtext/richtextformatdlg.cpp:362
 msgid "Size"
 msgstr "Størrelse"
 
-#: ../src/osx/carbon/fontdlg.cpp:339
+#: ../src/osx/carbon/fontdlg.cpp:336
 #, fuzzy
 msgid "Size:"
 msgstr "Størrelse"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1775
+#: ../src/propgrid/advprops.cpp:1676
 msgid "Sizing"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1772
+#: ../src/propgrid/advprops.cpp:1673
 msgid "Sizing N-S"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1771
+#: ../src/propgrid/advprops.cpp:1672
 msgid "Sizing NE-SW"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1773
+#: ../src/propgrid/advprops.cpp:1674
 msgid "Sizing NW-SE"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1774
+#: ../src/propgrid/advprops.cpp:1675
 msgid "Sizing W-E"
 msgstr ""
 
-#: ../src/msw/progdlg.cpp:801
+#: ../src/msw/progdlg.cpp:1088
 msgid "Skip"
 msgstr "Hopp over"
 
-#: ../src/generic/fontdlgg.cpp:330
+#: ../src/generic/fontdlgg.cpp:326
 msgid "Slant"
 msgstr "Skrå"
 
@@ -6688,7 +6845,7 @@ msgid "Small C&apitals"
 msgstr "Små bokstaver"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:79
+#: ../src/common/accelcmn.cpp:76
 msgid "Snapshot"
 msgstr ""
 
@@ -6697,37 +6854,37 @@ msgstr ""
 msgid "Solid"
 msgstr "Fet"
 
-#: ../src/common/docview.cpp:1791
+#: ../src/common/docview.cpp:1785
 msgid "Sorry, could not open this file."
 msgstr "Klarte ikke åpne denne filen."
 
-#: ../src/common/prntbase.cpp:2057 ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2079 ../src/common/prntbase.cpp:2087
 msgid "Sorry, not enough memory to create a preview."
 msgstr "Ikke nok minne til å lage en forhåndsvisning."
 
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "Sorry, that name is taken. Please choose another."
 msgstr "Beklager, det navnet er opptatt. Velg et annet."
 
-#: ../src/common/docview.cpp:1814
+#: ../src/common/docview.cpp:1819
 msgid "Sorry, the format for this file is unknown."
 msgstr "Formatet for denne filen er ukjent."
 
-#: ../src/unix/sound.cpp:492
+#: ../src/unix/sound.cpp:481
 msgid "Sound data are in unsupported format."
 msgstr "Format for lyddata er ikke støttet."
 
-#: ../src/unix/sound.cpp:477
+#: ../src/unix/sound.cpp:466
 #, c-format
 msgid "Sound file '%s' is in unsupported format."
 msgstr "Formatet på lydfilen «%s» er ikke støttet."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:67
+#: ../src/common/accelcmn.cpp:64
 #, fuzzy
 msgid "Space"
 msgstr "Søker..."
@@ -6737,12 +6894,12 @@ msgstr "Søker..."
 msgid "Spacing"
 msgstr "Søker..."
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "Spell Check"
 msgstr "Stavekontroll"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1776
+#: ../src/propgrid/advprops.cpp:1677
 msgid "Spraycan"
 msgstr "Sprayboks"
 
@@ -6751,7 +6908,7 @@ msgstr "Sprayboks"
 msgid "Standard"
 msgstr ""
 
-#: ../src/common/paper.cpp:104
+#: ../src/common/paper.cpp:101
 msgid "Statement, 5 1/2 x 8 1/2 in"
 msgstr "Statement, 5 1/2 x 8 1/2 tommer"
 
@@ -6761,35 +6918,31 @@ msgstr "Statement, 5 1/2 x 8 1/2 tommer"
 msgid "Static"
 msgstr "Status: "
 
-#: ../src/generic/prntdlgg.cpp:204
+#: ../src/generic/prntdlgg.cpp:197
 msgid "Status:"
 msgstr "Status: "
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 #, fuzzy
 msgid "Stop"
 msgstr "&Stopp"
 
-#: ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196
 msgid "Strikethrough"
 msgstr "Overstreke"
 
-#: ../src/common/colourcmn.cpp:45
+#: ../src/common/colourcmn.cpp:42
 #, c-format
 msgid "String To Colour : Incorrect colour specification : %s"
 msgstr "Tekst til farge : Ugyldig fargespesifikasjon : %s"
 
 #. TRANSLATORS: Label of font style
-#: ../src/richtext/richtextformatdlg.cpp:339 ../src/propgrid/advprops.cpp:680
+#: ../src/propgrid/advprops.cpp:590 ../src/richtext/richtextformatdlg.cpp:332
 #, fuzzy
 msgid "Style"
 msgstr "&Stil:"
 
-#: ../include/wx/richtext/richtextstyledlg.h:46
-msgid "Style Organiser"
-msgstr "Stilorganiserer"
-
-#: ../src/osx/carbon/fontdlg.cpp:348
+#: ../src/osx/carbon/fontdlg.cpp:345
 #, fuzzy
 msgid "Style:"
 msgstr "&Stil:"
@@ -6800,7 +6953,7 @@ msgid "Subscrip&t"
 msgstr "Skript"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:83
+#: ../src/common/accelcmn.cpp:80
 msgid "Subtract"
 msgstr "Trekk fra"
 
@@ -6809,11 +6962,11 @@ msgstr "Trekk fra"
 msgid "Supe&rscript"
 msgstr "Skript"
 
-#: ../src/common/paper.cpp:150
+#: ../src/common/paper.cpp:147
 msgid "SuperA/SuperA/A4 227 x 356 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:151
+#: ../src/common/paper.cpp:148
 msgid "SuperB/SuperB/A3 305 x 487 mm"
 msgstr ""
 
@@ -6821,7 +6974,7 @@ msgstr ""
 msgid "Suppress hyphe&nation"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:326
+#: ../src/generic/fontdlgg.cpp:322
 msgid "Swiss"
 msgstr "Swiss"
 
@@ -6839,75 +6992,75 @@ msgstr ""
 msgid "Symbols"
 msgstr "Symboler"
 
-#: ../src/common/imagtiff.cpp:369 ../src/common/imagtiff.cpp:382
-#: ../src/common/imagtiff.cpp:741
+#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
+#: ../src/common/imagtiff.cpp:738
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: Klarte ikke reservere minne."
 
-#: ../src/common/imagtiff.cpp:301
+#: ../src/common/imagtiff.cpp:298
 msgid "TIFF: Error loading image."
 msgstr "TIFF: Feil ved bildelasting."
 
-#: ../src/common/imagtiff.cpp:468
+#: ../src/common/imagtiff.cpp:465
 msgid "TIFF: Error reading image."
 msgstr "TIFF: Feil ved bildelesing."
 
-#: ../src/common/imagtiff.cpp:608
+#: ../src/common/imagtiff.cpp:605
 msgid "TIFF: Error saving image."
 msgstr "TIFF: Feil ved lagring av bilde."
 
-#: ../src/common/imagtiff.cpp:846
+#: ../src/common/imagtiff.cpp:843
 msgid "TIFF: Error writing image."
 msgstr "TIFF: Feil ved skriving av bilde."
 
-#: ../src/common/imagtiff.cpp:355
+#: ../src/common/imagtiff.cpp:352
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: Bildet er unormalt stort."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:68
+#: ../src/common/accelcmn.cpp:65
 msgid "Tab"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11498
+#: ../src/richtext/richtextbuffer.cpp:11497
 #, fuzzy
 msgid "Table Properties"
 msgstr "&Egenskaper"
 
-#: ../src/common/paper.cpp:145
+#: ../src/common/paper.cpp:142
 #, fuzzy
 msgid "Tabloid Extra 11.69 x 18 in"
 msgstr "Tabloid, 11 x 17 tommer"
 
-#: ../src/common/paper.cpp:102
+#: ../src/common/paper.cpp:99
 msgid "Tabloid, 11 x 17 in"
 msgstr "Tabloid, 11 x 17 tommer"
 
-#: ../src/richtext/richtextformatdlg.cpp:354
+#: ../src/richtext/richtextformatdlg.cpp:347
 msgid "Tabs"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1598
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Teal"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:327
+#: ../src/generic/fontdlgg.cpp:323
 msgid "Teletype"
 msgstr "Teletype"
 
-#: ../src/common/docview.cpp:1896
+#: ../src/common/docview.cpp:1901
 msgid "Templates"
 msgstr "Maler"
 
-#: ../src/common/fmapbase.cpp:158
+#: ../src/common/fmapbase.cpp:155
 msgid "Thai (ISO-8859-11)"
 msgstr "Thai (ISO-8859-11)"
 
-#: ../src/common/ftp.cpp:619
+#: ../src/common/ftp.cpp:622
 msgid "The FTP server doesn't support passive mode."
 msgstr "FTP-tjeneren støtter ikke passiv modus."
 
-#: ../src/common/ftp.cpp:605
+#: ../src/common/ftp.cpp:608
 msgid "The FTP server doesn't support the PORT command."
 msgstr "FTP-tjeneren støtter ikke PORT-kommandoen."
 
@@ -6918,8 +7071,8 @@ msgstr "FTP-tjeneren støtter ikke PORT-kommandoen."
 msgid "The available bullet styles."
 msgstr "De tilgjengelige punktstilene."
 
-#: ../src/richtext/richtextstyledlg.cpp:202
-#: ../src/richtext/richtextstyledlg.cpp:204
+#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:200
 #, fuzzy
 msgid "The available styles."
 msgstr "Skriftstil"
@@ -6981,12 +7134,12 @@ msgstr "Skriftpunktstørrelse"
 msgid "The bullet character."
 msgstr "Punktbokstaven."
 
-#: ../src/richtext/richtextsymboldlg.cpp:443
-#: ../src/richtext/richtextsymboldlg.cpp:445
+#: ../src/richtext/richtextsymboldlg.cpp:440
+#: ../src/richtext/richtextsymboldlg.cpp:442
 msgid "The character code."
 msgstr "Tegnkoden."
 
-#: ../src/common/fontmap.cpp:203
+#: ../src/common/fontmap.cpp:200
 #, c-format
 msgid ""
 "The charset '%s' is unknown. You may select\n"
@@ -6996,7 +7149,7 @@ msgstr ""
 "Tegnsettet «%s» er ukjent. Velg et annet tegnsett\n"
 "eller velg [Avbryt] hvis det ikke kan byttes ut."
 
-#: ../src/msw/ole/dataobj.cpp:394
+#: ../src/msw/ole/dataobj.cpp:402
 #, c-format
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "Utklippstavleformatet «%d» finnes ikke."
@@ -7006,7 +7159,7 @@ msgstr "Utklippstavleformatet «%d» finnes ikke."
 msgid "The default style for the next paragraph."
 msgstr "Standard stil for neste avsnitt."
 
-#: ../src/generic/dirdlgg.cpp:202
+#: ../src/generic/dirdlgg.cpp:199
 #, c-format
 msgid ""
 "The directory '%s' does not exist\n"
@@ -7015,7 +7168,7 @@ msgstr ""
 "Mappen «%s» finnes ikke.\n"
 "Opprett den nå?"
 
-#: ../src/html/htmprint.cpp:271
+#: ../src/html/htmprint.cpp:283
 #, c-format
 msgid ""
 "The document \"%s\" doesn't fit on the page horizontally and will be "
@@ -7028,7 +7181,7 @@ msgstr ""
 "\n"
 "Vil du fortsette likevel?"
 
-#: ../src/common/docview.cpp:1202
+#: ../src/common/docview.cpp:1196
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -7037,37 +7190,38 @@ msgstr ""
 "Filen «%s» eksisterer ikke og kunne ikke åpnes.\n"
 "Den er fjernet fra listen over nylig brukte filer."
 
-#: ../src/richtext/richtextindentspage.cpp:208
-#: ../src/richtext/richtextindentspage.cpp:210
 #: ../src/richtext/richtextliststylepage.cpp:394
 #: ../src/richtext/richtextliststylepage.cpp:396
+#: ../src/richtext/richtextindentspage.cpp:208
+#: ../src/richtext/richtextindentspage.cpp:210
 #, fuzzy
 msgid "The first line indent."
 msgstr "Skriftpunktstørrelse"
 
-#: ../src/gtk/utilsgtk.cpp:481
-msgid "The following standard GTK+ options are also supported:\n"
-msgstr ""
+#: ../src/generic/dbgrptg.cpp:318
+#, fuzzy
+msgid "The following debug report will be generated\n"
+msgstr "*** En feilsøkingsrapport har blitt generert\n"
 
-#: ../src/generic/fontdlgg.cpp:414 ../src/generic/fontdlgg.cpp:416
+#: ../src/generic/fontdlgg.cpp:411 ../src/generic/fontdlgg.cpp:413
 msgid "The font colour."
 msgstr "Skriftfarge"
 
-#: ../src/generic/fontdlgg.cpp:375 ../src/generic/fontdlgg.cpp:377
+#: ../src/generic/fontdlgg.cpp:371 ../src/generic/fontdlgg.cpp:373
 msgid "The font family."
 msgstr "Skriftfamilie"
 
-#: ../src/richtext/richtextsymboldlg.cpp:405
-#: ../src/richtext/richtextsymboldlg.cpp:407
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "The font from which to take the symbol."
 msgstr "Fonten som symbolet hentes fra."
 
-#: ../src/generic/fontdlgg.cpp:427 ../src/generic/fontdlgg.cpp:429
-#: ../src/generic/fontdlgg.cpp:434 ../src/generic/fontdlgg.cpp:436
+#: ../src/generic/fontdlgg.cpp:424 ../src/generic/fontdlgg.cpp:426
+#: ../src/generic/fontdlgg.cpp:430 ../src/generic/fontdlgg.cpp:432
 msgid "The font point size."
 msgstr "Skriftpunktstørrelse"
 
-#: ../src/osx/carbon/fontdlg.cpp:343 ../src/osx/carbon/fontdlg.cpp:345
+#: ../src/osx/carbon/fontdlg.cpp:340 ../src/osx/carbon/fontdlg.cpp:342
 #, fuzzy
 msgid "The font size in points."
 msgstr "Skriftpunktstørrelse"
@@ -7078,15 +7232,15 @@ msgstr "Skriftpunktstørrelse"
 msgid "The font size units, points or pixels."
 msgstr "Skriftpunktstørrelse"
 
-#: ../src/generic/fontdlgg.cpp:386 ../src/generic/fontdlgg.cpp:388
+#: ../src/generic/fontdlgg.cpp:382 ../src/generic/fontdlgg.cpp:384
 msgid "The font style."
 msgstr "Skriftstil"
 
-#: ../src/generic/fontdlgg.cpp:397 ../src/generic/fontdlgg.cpp:399
+#: ../src/generic/fontdlgg.cpp:393 ../src/generic/fontdlgg.cpp:395
 msgid "The font weight."
 msgstr "Skriftvekt"
 
-#: ../src/common/docview.cpp:1483
+#: ../src/common/docview.cpp:1477
 #, fuzzy, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Mappe «%s» kunne ikke opprettes"
@@ -7097,10 +7251,10 @@ msgstr "Mappe «%s» kunne ikke opprettes"
 msgid "The horizontal offset."
 msgstr "Tile &horisontalt"
 
-#: ../src/richtext/richtextindentspage.cpp:199
-#: ../src/richtext/richtextindentspage.cpp:201
 #: ../src/richtext/richtextliststylepage.cpp:385
 #: ../src/richtext/richtextliststylepage.cpp:387
+#: ../src/richtext/richtextindentspage.cpp:199
+#: ../src/richtext/richtextindentspage.cpp:201
 msgid "The left indent."
 msgstr "INnrykk fra venstre."
 
@@ -7121,10 +7275,10 @@ msgstr "Polstring til venstre. "
 msgid "The left position."
 msgstr "Venstre posisjon."
 
-#: ../src/richtext/richtextindentspage.cpp:288
-#: ../src/richtext/richtextindentspage.cpp:290
 #: ../src/richtext/richtextliststylepage.cpp:462
 #: ../src/richtext/richtextliststylepage.cpp:464
+#: ../src/richtext/richtextindentspage.cpp:288
+#: ../src/richtext/richtextindentspage.cpp:290
 msgid "The line spacing."
 msgstr "Linjeavstanden."
 
@@ -7133,7 +7287,7 @@ msgstr "Linjeavstanden."
 msgid "The list item number."
 msgstr "Nummer på listeinnslaget."
 
-#: ../src/msw/ole/automtn.cpp:664
+#: ../src/msw/ole/automtn.cpp:655
 msgid "The locale ID is unknown."
 msgstr "ID på din locale er ukjent."
 
@@ -7173,19 +7327,19 @@ msgstr "Bredde på objekt."
 msgid "The outline level."
 msgstr "Viser skriftforhåndsvisning."
 
-#: ../src/common/log.cpp:277
+#: ../src/common/log.cpp:296
 #, c-format
 msgid "The previous message repeated %u time."
 msgid_plural "The previous message repeated %u times."
 msgstr[0] "Den forrige meldingen repetert %u gang."
 msgstr[1] "Den forrige meldingen repetert %u ganger."
 
-#: ../src/common/log.cpp:270
+#: ../src/common/log.cpp:289
 msgid "The previous message repeated once."
 msgstr "Den forrige meldingen repetert en gang."
 
-#: ../src/richtext/richtextsymboldlg.cpp:462
-#: ../src/richtext/richtextsymboldlg.cpp:464
+#: ../src/richtext/richtextsymboldlg.cpp:459
+#: ../src/richtext/richtextsymboldlg.cpp:461
 msgid "The range to show."
 msgstr "Område som skal vises."
 
@@ -7200,15 +7354,15 @@ msgstr ""
 "så fjerner du bare markeringen foran dem og de vil bli fjernet fra "
 "rapporten.\n"
 
-#: ../src/common/cmdline.cpp:1254
+#: ../src/common/cmdline.cpp:1250
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "Den nødvendige parameteren «%s» var ikke oppgitt."
 
-#: ../src/richtext/richtextindentspage.cpp:217
-#: ../src/richtext/richtextindentspage.cpp:219
 #: ../src/richtext/richtextliststylepage.cpp:403
 #: ../src/richtext/richtextliststylepage.cpp:405
+#: ../src/richtext/richtextindentspage.cpp:217
+#: ../src/richtext/richtextindentspage.cpp:219
 msgid "The right indent."
 msgstr "Innrykk fra høyre."
 
@@ -7249,16 +7403,16 @@ msgstr "Dekkevnen til skyggen."
 msgid "The shadow spread."
 msgstr "Spredning på skyggen."
 
-#: ../src/richtext/richtextindentspage.cpp:267
 #: ../src/richtext/richtextliststylepage.cpp:439
 #: ../src/richtext/richtextliststylepage.cpp:441
+#: ../src/richtext/richtextindentspage.cpp:267
 msgid "The spacing after the paragraph."
 msgstr "Avstand etter avsnittet."
 
-#: ../src/richtext/richtextindentspage.cpp:257
-#: ../src/richtext/richtextindentspage.cpp:259
 #: ../src/richtext/richtextliststylepage.cpp:430
 #: ../src/richtext/richtextliststylepage.cpp:432
+#: ../src/richtext/richtextindentspage.cpp:257
+#: ../src/richtext/richtextindentspage.cpp:259
 msgid "The spacing before the paragraph."
 msgstr "Avstand før avsnittet."
 
@@ -7272,13 +7426,13 @@ msgstr "Stilnavn."
 msgid "The style on which this style is based."
 msgstr "Stilen som denne stilen baseres på."
 
-#: ../src/richtext/richtextstyledlg.cpp:214
-#: ../src/richtext/richtextstyledlg.cpp:216
+#: ../src/richtext/richtextstyledlg.cpp:210
+#: ../src/richtext/richtextstyledlg.cpp:212
 #, fuzzy
 msgid "The style preview."
 msgstr "Viser skriftforhåndsvisning."
 
-#: ../src/msw/ole/automtn.cpp:680
+#: ../src/msw/ole/automtn.cpp:671
 msgid "The system cannot find the file specified."
 msgstr "Systemet kan ikke finne den spesifiserte filen."
 
@@ -7291,7 +7445,7 @@ msgstr "Tab-posisjonen."
 msgid "The tab positions."
 msgstr "Tab-posisjonene."
 
-#: ../src/richtext/richtextctrl.cpp:3098
+#: ../src/richtext/richtextctrl.cpp:3099
 msgid "The text couldn't be saved."
 msgstr "Klarte ikke lagre teksten."
 
@@ -7312,7 +7466,7 @@ msgstr "Polstring på toppen."
 msgid "The top position."
 msgstr "Plassering av topp"
 
-#: ../src/common/cmdline.cpp:1232
+#: ../src/common/cmdline.cpp:1228
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "Verdien for opsjonen «%s» må oppgies."
@@ -7322,7 +7476,7 @@ msgstr "Verdien for opsjonen «%s» må oppgies."
 msgid "The value of the corner radius."
 msgstr "Størrelsen på hjørneradius."
 
-#: ../src/msw/dialup.cpp:433
+#: ../src/msw/dialup.cpp:427
 #, fuzzy, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -7337,14 +7491,14 @@ msgstr ""
 msgid "The vertical offset."
 msgstr "Klarte ikke starte utskrift."
 
-#: ../src/richtext/richtextprint.cpp:619 ../src/html/htmprint.cpp:745
+#: ../src/html/htmprint.cpp:749 ../src/richtext/richtextprint.cpp:615
 msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr ""
 "Det oppstod et problem med sideoppsettet - kanskje du må installere en "
 "skriver."
 
-#: ../src/html/htmprint.cpp:255
+#: ../src/html/htmprint.cpp:267
 msgid ""
 "This document doesn't fit on the page horizontally and will be truncated "
 "when it is printed."
@@ -7352,22 +7506,30 @@ msgstr ""
 "Dette dokumentet passer ikke horisontalt på siden og vil bli kuttet når det "
 "skrives ut."
 
-#: ../src/common/image.cpp:2854
+#: ../src/common/image.cpp:2963
 #, fuzzy, c-format
 msgid "This is not a %s."
 msgstr "PCX: Dette er ikke en PCX-fil"
 
-#: ../src/common/wincmn.cpp:1653
+#: ../src/common/wincmn.cpp:1654
 msgid "This platform does not support background transparency."
 msgstr "Denne plattformen støtter ikke transparente bakgrunner."
 
-#: ../src/gtk/window.cpp:4660
+#: ../src/gtk/window.cpp:5664
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
 
-#: ../src/msw/thread.cpp:1240
+#: ../src/gtk/glcanvas.cpp:176
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/msw/thread.cpp:1246
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -7375,11 +7537,11 @@ msgstr ""
 "Initialisering av trådmodul feilet: klarte ikke lagre verdien i det lokale "
 "trådlageret"
 
-#: ../src/unix/threadpsx.cpp:1794
+#: ../src/unix/threadpsx.cpp:1843
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr "Initialisering av trådmodul feilet: klarte ikke opprette trådnøkkel"
 
-#: ../src/msw/thread.cpp:1228
+#: ../src/msw/thread.cpp:1234
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -7387,80 +7549,80 @@ msgstr ""
 "Initialisering av trådmodul feilet: umulig å reservere indeks i det lokale "
 "trådlager"
 
-#: ../src/unix/threadpsx.cpp:1043
+#: ../src/unix/threadpsx.cpp:1061
 msgid "Thread priority setting is ignored."
 msgstr "Trådprioritetinnstilling ignorert."
 
-#: ../src/msw/mdi.cpp:176
+#: ../src/msw/mdi.cpp:171
 msgid "Tile &Horizontally"
 msgstr "Tile &horisontalt"
 
-#: ../src/msw/mdi.cpp:177
+#: ../src/msw/mdi.cpp:172
 msgid "Tile &Vertically"
 msgstr "Tile &vertikalt"
 
-#: ../src/common/ftp.cpp:200
+#: ../src/common/ftp.cpp:197
 msgid "Timeout while waiting for FTP server to connect, try passive mode."
 msgstr "Tidsavbrudd under venting på FTP-tilkobling, prøv passiv modus."
 
-#: ../src/generic/tipdlg.cpp:201
+#: ../src/generic/tipdlg.cpp:198
 msgid "Tip of the Day"
 msgstr "Dagens tips"
 
-#: ../src/generic/tipdlg.cpp:140
+#: ../src/generic/tipdlg.cpp:137
 msgid "Tips not available, sorry!"
 msgstr "Tips er ikke tilgjengelig, beklager!"
 
-#: ../src/generic/prntdlgg.cpp:242
+#: ../src/generic/prntdlgg.cpp:235
 msgid "To:"
 msgstr "Til:"
 
-#: ../src/richtext/richtextbuffer.cpp:8363
+#: ../src/richtext/richtextbuffer.cpp:8361
 msgid "Too many EndStyle calls!"
 msgstr "For mange kall til EndStyle!"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:891
+#: ../src/propgrid/advprops.cpp:792
 msgid "Tooltip"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:892
+#: ../src/propgrid/advprops.cpp:793
 msgid "TooltipText"
 msgstr ""
 
-#: ../src/richtext/richtextsizepage.cpp:286
-#: ../src/richtext/richtextsizepage.cpp:290 ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197 ../src/richtext/richtextsizepage.cpp:286
+#: ../src/richtext/richtextsizepage.cpp:290
 msgid "Top"
 msgstr "Topp"
 
-#: ../src/generic/prntdlgg.cpp:881
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Top margin (mm):"
 msgstr "Toppmarg (mm):"
 
-#: ../src/generic/aboutdlgg.cpp:79
+#: ../src/generic/aboutdlgg.cpp:76
 msgid "Translations by "
 msgstr "Oversatt av"
 
-#: ../src/generic/aboutdlgg.cpp:188
+#: ../src/generic/aboutdlgg.cpp:185
 msgid "Translators"
 msgstr "Oversettere"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:211
+#: ../src/propgrid/propgrid.cpp:192
 msgid "True"
 msgstr ""
 
-#: ../src/common/fs_mem.cpp:227
+#: ../src/common/fs_mem.cpp:222
 #, c-format
 msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
 msgstr "Prøvde å fjerne filen «%s» fra VFS minne, men den er ikke lastet!"
 
-#: ../src/common/fmapbase.cpp:156
+#: ../src/common/fmapbase.cpp:153
 msgid "Turkish (ISO-8859-9)"
 msgstr "Tyrkisk (ISO-8859-9)"
 
-#: ../src/generic/filectrlg.cpp:426
+#: ../src/generic/filectrlg.cpp:422
 msgid "Type"
 msgstr "Type"
 
@@ -7475,37 +7637,37 @@ msgstr "Skriftfamilie"
 msgid "Type a size in points."
 msgstr "Oppgi en størrelse i 'points'"
 
-#: ../src/msw/ole/automtn.cpp:676
+#: ../src/msw/ole/automtn.cpp:667
 #, c-format
 msgid "Type mismatch in argument %u."
 msgstr ""
 
-#: ../src/common/xtixml.cpp:356 ../src/common/xtixml.cpp:509
-#: ../src/common/xtistrm.cpp:318
+#: ../src/common/xtixml.cpp:352 ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315
 msgid "Type must have enum - long conversion"
 msgstr "Type må ha enum - long conversion"
 
-#: ../src/propgrid/propgridiface.cpp:401
+#: ../src/propgrid/propgridiface.cpp:385
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
 "\"%s\"."
 msgstr ""
 
-#: ../src/common/paper.cpp:133
+#: ../src/common/paper.cpp:130
 msgid "US Std Fanfold, 14 7/8 x 11 in"
 msgstr "Amerikansk standard papir, 14 7/8 x 11 tommer"
 
-#: ../src/common/fmapbase.cpp:196
+#: ../src/common/fmapbase.cpp:193
 #, fuzzy
 msgid "US-ASCII"
 msgstr "ASCII"
 
-#: ../src/unix/fswatcher_inotify.cpp:109
+#: ../src/unix/fswatcher_inotify.cpp:106
 msgid "Unable to add inotify watch"
 msgstr ""
 
-#: ../src/unix/fswatcher_kqueue.cpp:136
+#: ../src/unix/fswatcher_kqueue.cpp:153
 msgid "Unable to add kqueue watch"
 msgstr ""
 
@@ -7518,7 +7680,7 @@ msgstr ""
 msgid "Unable to close I/O completion port handle"
 msgstr "Klarte ikke lukke filreferanse"
 
-#: ../src/unix/fswatcher_inotify.cpp:97
+#: ../src/unix/fswatcher_inotify.cpp:94
 #, fuzzy
 msgid "Unable to close inotify instance"
 msgstr "Klarte ikke lukke filreferanse"
@@ -7538,17 +7700,17 @@ msgstr "Klarte ikke lukke filreferanse"
 msgid "Unable to create I/O completion port"
 msgstr "Klarte ikke opprette peker."
 
-#: ../src/msw/fswatcher.cpp:84
+#: ../src/msw/fswatcher.cpp:81
 #, fuzzy
 msgid "Unable to create IOCP worker thread"
 msgstr "Klarte ikke opprette MDI foreldreramme."
 
-#: ../src/unix/fswatcher_inotify.cpp:74
+#: ../src/unix/fswatcher_inotify.cpp:71
 #, fuzzy
 msgid "Unable to create inotify instance"
 msgstr "Klarte ikke opprette DDE-streng"
 
-#: ../src/unix/fswatcher_kqueue.cpp:97
+#: ../src/unix/fswatcher_kqueue.cpp:114
 #, fuzzy
 msgid "Unable to create kqueue instance"
 msgstr "Klarte ikke opprette DDE-streng"
@@ -7557,11 +7719,11 @@ msgstr "Klarte ikke opprette DDE-streng"
 msgid "Unable to dequeue completion packet"
 msgstr ""
 
-#: ../src/unix/fswatcher_kqueue.cpp:185
+#: ../src/unix/fswatcher_kqueue.cpp:202
 msgid "Unable to get events from kqueue"
 msgstr ""
 
-#: ../src/gtk/app.cpp:435
+#: ../src/gtk/app.cpp:431
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr ""
 
@@ -7570,12 +7732,12 @@ msgstr ""
 msgid "Unable to open path '%s'"
 msgstr "Klarte ikke åpne CHM arkiv «%s»."
 
-#: ../src/html/htmlwin.cpp:583
+#: ../src/html/htmlwin.cpp:586
 #, c-format
 msgid "Unable to open requested HTML document: %s"
 msgstr "Klarte ikke åpne forespurt HTML-dokument: %s"
 
-#: ../src/unix/sound.cpp:368
+#: ../src/unix/sound.cpp:365
 msgid "Unable to play sound asynchronously."
 msgstr "Klarte ikke spille lyd asynkront."
 
@@ -7583,65 +7745,65 @@ msgstr "Klarte ikke spille lyd asynkront."
 msgid "Unable to post completion status"
 msgstr ""
 
-#: ../src/unix/fswatcher_inotify.cpp:556
+#: ../src/unix/fswatcher_inotify.cpp:553
 #, fuzzy
 msgid "Unable to read from inotify descriptor"
 msgstr "klarte ikke lese fra fildeskriptor %d"
 
-#: ../src/unix/fswatcher_inotify.cpp:141
+#: ../src/unix/fswatcher_inotify.cpp:138
 #, fuzzy, c-format
 msgid "Unable to remove inotify watch %i"
 msgstr "Klarte ikke opprette DDE-streng"
 
-#: ../src/unix/fswatcher_kqueue.cpp:153
+#: ../src/unix/fswatcher_kqueue.cpp:170
 msgid "Unable to remove kqueue watch"
 msgstr ""
 
-#: ../src/msw/fswatcher.cpp:168
+#: ../src/msw/fswatcher.cpp:165
 #, fuzzy, c-format
 msgid "Unable to set up watch for '%s'"
 msgstr "Klarte ikke rør filen «%s»"
 
-#: ../src/msw/fswatcher.cpp:91
+#: ../src/msw/fswatcher.cpp:88
 msgid "Unable to start IOCP worker thread"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:201
+#: ../src/common/stockitem.cpp:198
 msgid "Undelete"
 msgstr "Angre sletting"
 
-#: ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199
 #, fuzzy
 msgid "Underline"
 msgstr "&Strek under"
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/richtext/richtextfontpage.cpp:359 ../src/osx/carbon/fontdlg.cpp:370
-#: ../src/propgrid/advprops.cpp:690
+#: ../src/osx/carbon/fontdlg.cpp:367 ../src/propgrid/advprops.cpp:600
+#: ../src/richtext/richtextfontpage.cpp:359
 #, fuzzy
 msgid "Underlined"
 msgstr "&Strek under"
 
-#: ../src/common/stockitem.cpp:203 ../src/stc/stc_i18n.cpp:15
+#: ../src/common/stockitem.cpp:200 ../src/stc/stc_i18n.cpp:15
 #, fuzzy
 msgid "Undo"
 msgstr "&Angre"
 
-#: ../src/common/stockitem.cpp:265
+#: ../src/common/stockitem.cpp:263
 msgid "Undo last action"
 msgstr "Angre siste handlin"
 
-#: ../src/common/cmdline.cpp:1029
+#: ../src/common/cmdline.cpp:1025
 #, fuzzy, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Uventet parameter «%s»"
 
-#: ../src/unix/fswatcher_inotify.cpp:274
+#: ../src/unix/fswatcher_inotify.cpp:271
 #, c-format
 msgid "Unexpected event for \"%s\": no matching watch descriptor."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1195
+#: ../src/common/cmdline.cpp:1191
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Uventet parameter «%s»"
@@ -7650,51 +7812,51 @@ msgstr "Uventet parameter «%s»"
 msgid "Unexpectedly new I/O completion port was created"
 msgstr ""
 
-#: ../src/msw/fswatcher.cpp:70
+#: ../src/msw/fswatcher.cpp:67
 #, fuzzy
 msgid "Ungraceful worker thread termination"
 msgstr "Klarte ikke vente på trådens avslutning"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:460
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:456
+#: ../src/richtext/richtextsymboldlg.cpp:457
+#: ../src/richtext/richtextsymboldlg.cpp:458
 #, fuzzy
 msgid "Unicode"
 msgstr "&Fjern innrykk"
 
-#: ../src/common/fmapbase.cpp:185 ../src/common/fmapbase.cpp:191
+#: ../src/common/fmapbase.cpp:182 ../src/common/fmapbase.cpp:188
 msgid "Unicode 16 bit (UTF-16)"
 msgstr "Unicode 16 bit (UTF-16)"
 
-#: ../src/common/fmapbase.cpp:190
+#: ../src/common/fmapbase.cpp:187
 msgid "Unicode 16 bit Big Endian (UTF-16BE)"
 msgstr "Unicode 16 bit Big Endian (UTF-16BE)"
 
-#: ../src/common/fmapbase.cpp:186
+#: ../src/common/fmapbase.cpp:183
 msgid "Unicode 16 bit Little Endian (UTF-16LE)"
 msgstr "Unicode 16 bit Little Endian (UTF-16LE)"
 
-#: ../src/common/fmapbase.cpp:187 ../src/common/fmapbase.cpp:193
+#: ../src/common/fmapbase.cpp:184 ../src/common/fmapbase.cpp:190
 msgid "Unicode 32 bit (UTF-32)"
 msgstr "Unicode 32 bit (UTF-32)"
 
-#: ../src/common/fmapbase.cpp:192
+#: ../src/common/fmapbase.cpp:189
 msgid "Unicode 32 bit Big Endian (UTF-32BE)"
 msgstr "Unicode 32 bit Big Endian (UTF-32BE)"
 
-#: ../src/common/fmapbase.cpp:188
+#: ../src/common/fmapbase.cpp:185
 msgid "Unicode 32 bit Little Endian (UTF-32LE)"
 msgstr "Unicode 32 bit Little Endian (UTF-32LE)"
 
-#: ../src/common/fmapbase.cpp:182
+#: ../src/common/fmapbase.cpp:179
 msgid "Unicode 7 bit (UTF-7)"
 msgstr "Unicode 7 bit (UTF-7)"
 
-#: ../src/common/fmapbase.cpp:183
+#: ../src/common/fmapbase.cpp:180
 msgid "Unicode 8 bit (UTF-8)"
 msgstr "Unicode 8 bit (UTF-8)"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 #, fuzzy
 msgid "Unindent"
 msgstr "&Fjern innrykk"
@@ -7847,99 +8009,104 @@ msgstr "Kan ikke vente på trådens avslutning."
 msgid "Units for this value."
 msgstr "Kan ikke vente på trådens avslutning."
 
-#: ../src/generic/progdlgg.cpp:353 ../src/generic/progdlgg.cpp:622
+#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
 #, fuzzy
 msgid "Unknown"
 msgstr "ukjent"
 
-#: ../src/msw/dde.cpp:1174
+#: ../src/msw/dde.cpp:1238
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Ukjent DDE-feil %08x"
 
-#: ../src/common/xtistrm.cpp:410
+#: ../src/common/xtistrm.cpp:407
 msgid "Unknown Object passed to GetObjectClassInfo"
 msgstr "Ukjent objekt sendt til GetObjectClassInfo"
 
-#: ../src/common/imagpng.cpp:366
+#: ../src/common/imagpng.cpp:383
 #, fuzzy, c-format
 msgid "Unknown PNG resolution unit %d"
 msgstr "Ukjent opsjon «%s»"
 
-#: ../src/common/xtixml.cpp:327
+#: ../src/common/xtixml.cpp:323
 #, fuzzy, c-format
 msgid "Unknown Property %s"
 msgstr "Ukjent egenskap %s"
 
-#: ../src/common/imagtiff.cpp:529
+#: ../src/common/imagtiff.cpp:526
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "Ukjent enhet %d for oppløsning i TIFF ble ignorert"
 
-#: ../src/unix/dlunix.cpp:160
+#: ../src/propgrid/props.cpp:155
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/unix/dlunix.cpp:118
 msgid "Unknown dynamic library error"
 msgstr "Ukjent feil i dynamisk bibliotek"
 
-#: ../src/common/fmapbase.cpp:810
+#: ../src/common/fmapbase.cpp:806
 #, c-format
 msgid "Unknown encoding (%d)"
 msgstr "Ukjent koding (%d)"
 
-#: ../src/msw/ole/automtn.cpp:688
+#: ../src/msw/ole/automtn.cpp:679
 #, fuzzy, c-format
 msgid "Unknown error %08x"
 msgstr "Ukjent DDE-feil %08x"
 
-#: ../src/msw/ole/automtn.cpp:647
+#: ../src/msw/ole/automtn.cpp:638
 #, fuzzy
 msgid "Unknown exception"
 msgstr "Ukjent opsjon «%s»"
 
-#: ../src/common/image.cpp:2839
+#: ../src/common/image.cpp:2942
 msgid "Unknown image data format."
 msgstr "Ukjent bildeformat"
 
-#: ../src/common/cmdline.cpp:914
+#: ../src/common/cmdline.cpp:910
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Ukjent lang opsjon «%s»"
 
-#: ../src/msw/ole/automtn.cpp:631
+#: ../src/msw/ole/automtn.cpp:622
 msgid "Unknown name or named argument."
 msgstr "Ukjent navn eller argument."
 
-#: ../src/common/cmdline.cpp:929 ../src/common/cmdline.cpp:951
+#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Ukjent opsjon «%s»"
 
-#: ../src/common/mimecmn.cpp:225
+#: ../src/common/mimecmn.cpp:221
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "Ubalansert «{» i en oppføring for mime-type %s."
 
-#: ../src/common/cmdproc.cpp:262 ../src/common/cmdproc.cpp:288
-#: ../src/common/cmdproc.cpp:308
+#: ../src/common/cmdproc.cpp:255 ../src/common/cmdproc.cpp:281
+#: ../src/common/cmdproc.cpp:301
 msgid "Unnamed command"
 msgstr "Ikke-navngitt kommando"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:413
+#: ../src/propgrid/propgrid.cpp:392
 msgid "Unspecified"
 msgstr "Uspesifisert"
 
-#: ../src/msw/clipbrd.cpp:311
+#: ../src/msw/clipbrd.cpp:325
 msgid "Unsupported clipboard format."
 msgstr "Ikke-støttet utklippstavleformat."
 
-#: ../src/common/appcmn.cpp:256
+#: ../src/common/appcmn.cpp:277
 #, c-format
 msgid "Unsupported theme '%s'."
 msgstr "Ikke-støttet tema «%s»."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:205
-#: ../src/common/accelcmn.cpp:63
+#: ../src/common/stockitem.cpp:202 ../src/common/accelcmn.cpp:60
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Up"
 msgstr "Opp"
 
@@ -7953,7 +8120,7 @@ msgstr "Store bokstaver"
 msgid "Upper case roman numerals"
 msgstr "Romerske tall i store bokstaver"
 
-#: ../src/common/cmdline.cpp:1326
+#: ../src/common/cmdline.cpp:1322
 #, c-format
 msgid "Usage: %s"
 msgstr "Bruk: %s"
@@ -7962,38 +8129,47 @@ msgstr "Bruk: %s"
 msgid "Use &shadow"
 msgstr "Bruk &skygge"
 
-#: ../src/richtext/richtextindentspage.cpp:169
-#: ../src/richtext/richtextindentspage.cpp:171
 #: ../src/richtext/richtextliststylepage.cpp:358
 #: ../src/richtext/richtextliststylepage.cpp:360
+#: ../src/richtext/richtextindentspage.cpp:169
+#: ../src/richtext/richtextindentspage.cpp:171
 msgid "Use the current alignment setting."
 msgstr "Bruk gjeldende justering."
 
-#: ../src/common/valtext.cpp:179
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/gtk/font.cpp:552
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/common/valtext.cpp:142
 msgid "Validation conflict"
 msgstr "Valideringskonflikt"
 
-#: ../src/propgrid/manager.cpp:238
+#: ../src/propgrid/manager.cpp:224
 msgid "Value"
 msgstr "Verdi"
 
-#: ../src/propgrid/props.cpp:386 ../src/propgrid/props.cpp:500
+#: ../src/propgrid/props.cpp:309
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "Verdien må være %s eller høyere."
 
-#: ../src/propgrid/props.cpp:417 ../src/propgrid/props.cpp:531
+#: ../src/propgrid/props.cpp:336
 #, c-format
 msgid "Value must be %s or less."
 msgstr "Verdien må være %s eller mindre."
 
-#: ../src/propgrid/props.cpp:393 ../src/propgrid/props.cpp:424
-#: ../src/propgrid/props.cpp:507 ../src/propgrid/props.cpp:538
+#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
 #, fuzzy, c-format
 msgid "Value must be between %s and %s."
 msgstr "Oppgi et sidetall mellom %d og %d:"
 
-#: ../src/generic/aboutdlgg.cpp:128
+#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
 #, fuzzy
 msgid "Version "
 msgstr "Rettigheter"
@@ -8004,25 +8180,32 @@ msgstr "Rettigheter"
 msgid "Vertical alignment."
 msgstr "Klarte ikke starte utskrift."
 
-#: ../src/generic/filedlgg.cpp:202
+#: ../src/generic/filedlgg.cpp:199
 msgid "View files as a detailed view"
 msgstr "Vis filer i detaljert visning"
 
-#: ../src/generic/filedlgg.cpp:200
+#: ../src/generic/filedlgg.cpp:197
 msgid "View files as a list view"
 msgstr "Vis filer i liste-visning"
 
-#: ../src/common/docview.cpp:1970
+#: ../src/common/docview.cpp:1975
 msgid "Views"
 msgstr "Visninger"
 
+#: ../src/gtk/app.cpp:348
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1777
+#: ../src/propgrid/advprops.cpp:1678
 msgid "Wait"
 msgstr "Vent"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1779
+#: ../src/propgrid/advprops.cpp:1680
 msgid "Wait Arrow"
 msgstr ""
 
@@ -8031,247 +8214,244 @@ msgstr ""
 msgid "Waiting for IO on epoll descriptor %d failed"
 msgstr "Venting på avslutning av underprosess feilet"
 
-#: ../src/common/log.cpp:223
+#: ../src/common/log.cpp:241
 msgid "Warning: "
 msgstr "Advarsel:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1778
+#: ../src/propgrid/advprops.cpp:1679
 msgid "Watch"
 msgstr ""
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:685
+#: ../src/propgrid/advprops.cpp:595
 #, fuzzy
 msgid "Weight"
 msgstr "&Vekt:"
 
-#: ../src/common/fmapbase.cpp:148
+#: ../src/common/fmapbase.cpp:145
 msgid "Western European (ISO-8859-1)"
 msgstr "Vesteuropeisk (ISO-8859-1)"
 
-#: ../src/common/fmapbase.cpp:162
+#: ../src/common/fmapbase.cpp:159
 msgid "Western European with Euro (ISO-8859-15)"
 msgstr "Vesteuropeisk med euro (ISO-8859-15)"
 
-#: ../src/generic/fontdlgg.cpp:446 ../src/generic/fontdlgg.cpp:448
+#: ../src/generic/fontdlgg.cpp:443 ../src/generic/fontdlgg.cpp:445
 msgid "Whether the font is underlined."
 msgstr "Om skriften er understreket."
 
-#: ../src/propgrid/advprops.cpp:1611
+#: ../src/propgrid/advprops.cpp:1517
 msgid "White"
 msgstr "Hvit"
 
-#: ../src/generic/fdrepdlg.cpp:144
+#: ../src/generic/fdrepdlg.cpp:141
 msgid "Whole word"
 msgstr "Hele ord"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:532
 msgid "Whole words only"
 msgstr "Bare hele ord"
 
-#: ../src/univ/themes/win32.cpp:1102
+#: ../src/univ/themes/win32.cpp:1099
 msgid "Win32 theme"
 msgstr "Win32-tema"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:893
+#: ../src/propgrid/advprops.cpp:794
 #, fuzzy
 msgid "Window"
 msgstr "&Vindu"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:894
+#: ../src/propgrid/advprops.cpp:795
 #, fuzzy
 msgid "WindowFrame"
 msgstr "&Vindu"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:895
+#: ../src/propgrid/advprops.cpp:796
 #, fuzzy
 msgid "WindowText"
 msgstr "&Vindu"
 
-#: ../src/common/fmapbase.cpp:177
+#: ../src/common/fmapbase.cpp:174
 msgid "Windows Arabic (CP 1256)"
 msgstr "Windows arabisk (CP 1256)"
 
-#: ../src/common/fmapbase.cpp:178
+#: ../src/common/fmapbase.cpp:175
 msgid "Windows Baltic (CP 1257)"
 msgstr "Windows baltisk (CP 1257)"
 
-#: ../src/common/fmapbase.cpp:171
+#: ../src/common/fmapbase.cpp:168
 msgid "Windows Central European (CP 1250)"
 msgstr "Windows sentraleuropeisk (CP 1250)"
 
-#: ../src/common/fmapbase.cpp:168
+#: ../src/common/fmapbase.cpp:165
 #, fuzzy
 msgid "Windows Chinese Simplified (CP 936) or GB-2312"
 msgstr "Windows kinesisk med enkle tegn (CP 936)"
 
-#: ../src/common/fmapbase.cpp:170
+#: ../src/common/fmapbase.cpp:167
 #, fuzzy
 msgid "Windows Chinese Traditional (CP 950) or Big-5"
 msgstr "Windows kinesisk (CP 950)"
 
-#: ../src/common/fmapbase.cpp:172
+#: ../src/common/fmapbase.cpp:169
 msgid "Windows Cyrillic (CP 1251)"
 msgstr "Windows kyrillisk (CP 1251)"
 
-#: ../src/common/fmapbase.cpp:174
+#: ../src/common/fmapbase.cpp:171
 msgid "Windows Greek (CP 1253)"
 msgstr "Windows gresk (CP 1253)"
 
-#: ../src/common/fmapbase.cpp:176
+#: ../src/common/fmapbase.cpp:173
 msgid "Windows Hebrew (CP 1255)"
 msgstr "Windows hebraisk (CP 1255)"
 
-#: ../src/common/fmapbase.cpp:167
+#: ../src/common/fmapbase.cpp:164
 #, fuzzy
 msgid "Windows Japanese (CP 932) or Shift-JIS"
 msgstr "Windows japansk (CP 932)"
 
-#: ../src/common/fmapbase.cpp:180
+#: ../src/common/fmapbase.cpp:177
 msgid "Windows Johab (CP 1361)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:169
+#: ../src/common/fmapbase.cpp:166
 msgid "Windows Korean (CP 949)"
 msgstr "Windows koreansk (CP 949)"
 
-#: ../src/common/fmapbase.cpp:166
+#: ../src/common/fmapbase.cpp:163
 msgid "Windows Thai (CP 874)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:175
+#: ../src/common/fmapbase.cpp:172
 msgid "Windows Turkish (CP 1254)"
 msgstr "Windows tyrkisk (CP 1254)"
 
-#: ../src/common/fmapbase.cpp:179
+#: ../src/common/fmapbase.cpp:176
 msgid "Windows Vietnamese (CP 1258)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:173
+#: ../src/common/fmapbase.cpp:170
 msgid "Windows Western European (CP 1252)"
 msgstr "Windows vesteuropeisk (CP 1252)"
 
-#: ../src/common/fmapbase.cpp:181
+#: ../src/common/fmapbase.cpp:178
 msgid "Windows/DOS OEM (CP 437)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:165
+#: ../src/common/fmapbase.cpp:162
 msgid "Windows/DOS OEM Cyrillic (CP 866)"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:111
+#: ../src/common/accelcmn.cpp:109
 msgid "Windows_Left"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:113
+#: ../src/common/accelcmn.cpp:111
 msgid "Windows_Menu"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:112
+#: ../src/common/accelcmn.cpp:110
 msgid "Windows_Right"
 msgstr ""
 
-#: ../src/common/ffile.cpp:150
+#: ../src/common/ffile.cpp:149
 #, c-format
 msgid "Write error on file '%s'"
 msgstr "Skrivefeil på fil «%s»"
 
-#: ../src/xml/xml.cpp:914
+#: ../src/xml/xml.cpp:925
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "XML tolkefeil: «%s» på linje %d"
 
-#: ../src/common/xpmdecod.cpp:796
+#: ../src/common/xpmdecod.cpp:794
 msgid "XPM: Malformed pixel data!"
 msgstr "XPM: Ugyldig pikseldata"
 
-#: ../src/common/xpmdecod.cpp:705
+#: ../src/common/xpmdecod.cpp:702
 #, fuzzy, c-format
 msgid "XPM: incorrect colour description in line %d"
 msgstr "XPM: Ugyldig fargedefinisjon «%s»!"
 
-#: ../src/common/xpmdecod.cpp:680
+#: ../src/common/xpmdecod.cpp:677
 msgid "XPM: incorrect header format!"
 msgstr "XPM: ugylig hodeformat!"
 
-#: ../src/common/xpmdecod.cpp:716 ../src/common/xpmdecod.cpp:725
+#: ../src/common/xpmdecod.cpp:714 ../src/common/xpmdecod.cpp:723
 #, fuzzy, c-format
 msgid "XPM: malformed colour definition '%s' at line %d!"
 msgstr "XPM: Ugyldig fargedefinisjon «%s»!"
 
-#: ../src/common/xpmdecod.cpp:755
+#: ../src/common/xpmdecod.cpp:753
 msgid "XPM: no colors left to use for mask!"
 msgstr "XPM: ingen farger igjen å bruke for masken!"
 
-#: ../src/common/xpmdecod.cpp:782
+#: ../src/common/xpmdecod.cpp:780
 #, c-format
 msgid "XPM: truncated image data at line %d!"
 msgstr "XPM: trunkerte bildedata på linje %d!"
 
-#: ../src/propgrid/advprops.cpp:1610
+#: ../src/propgrid/advprops.cpp:1516
 msgid "Yellow"
 msgstr "Gul"
 
-#: ../include/wx/msgdlg.h:276 ../src/common/stockitem.cpp:206
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:203
 #: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Ja"
 
-#: ../src/osx/carbon/overlay.cpp:155
-msgid "You cannot Clear an overlay that is not inited"
-msgstr ""
-
-#: ../src/osx/carbon/overlay.cpp:107 ../src/dfb/overlay.cpp:61
-msgid "You cannot Init an overlay twice"
-msgstr ""
-
-#: ../src/generic/dirdlgg.cpp:287
+#: ../src/generic/dirdlgg.cpp:284
 msgid "You cannot add a new directory to this section."
 msgstr "Du kan ikke legge til en ny mappe i denne seksjonen."
 
-#: ../src/propgrid/propgrid.cpp:3299
+#: ../src/propgrid/propgrid.cpp:3276
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr "Du har lagt inn en ugyldig verdi. Trykk ESC for å avbryte redigering."
 
-#: ../src/common/stockitem.cpp:209
+#: ../src/osx/cocoa/menu.mm:286
+#, fuzzy
+msgid "Zoom"
+msgstr "Vis &større"
+
+#: ../src/common/stockitem.cpp:206
 msgid "Zoom &In"
 msgstr "Vis &større"
 
-#: ../src/common/stockitem.cpp:210
+#: ../src/common/stockitem.cpp:207
 msgid "Zoom &Out"
 msgstr "Vis &mindre"
 
-#: ../src/common/stockitem.cpp:209 ../src/common/prntbase.cpp:1594
+#: ../src/common/stockitem.cpp:206 ../src/common/prntbase.cpp:1619
 #, fuzzy
 msgid "Zoom In"
 msgstr "Vis &større"
 
-#: ../src/common/stockitem.cpp:210 ../src/common/prntbase.cpp:1580
+#: ../src/common/stockitem.cpp:207 ../src/common/prntbase.cpp:1605
 #, fuzzy
 msgid "Zoom Out"
 msgstr "Vis &mindre"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to &Fit"
 msgstr "Tilpass til skjerm"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 #, fuzzy
 msgid "Zoom to Fit"
 msgstr "Tilpass til skjerm"
 
-#: ../src/msw/dde.cpp:1141
+#: ../src/msw/dde.cpp:1205
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "et DDEML-program har skapt en prolongert kappløpsbetingelse."
 
-#: ../src/msw/dde.cpp:1129
+#: ../src/msw/dde.cpp:1193
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -8282,40 +8462,40 @@ msgstr ""
 "eller en ugyldig instanseindentifikator\n"
 "ble sendt til en DDEML-funksjon."
 
-#: ../src/msw/dde.cpp:1147
+#: ../src/msw/dde.cpp:1211
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "en klients forsøk på å etablere en konversasjon feilet."
 
-#: ../src/msw/dde.cpp:1144
+#: ../src/msw/dde.cpp:1208
 msgid "a memory allocation failed."
 msgstr "en minnereservasjon feilet."
 
-#: ../src/msw/dde.cpp:1138
+#: ../src/msw/dde.cpp:1202
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "en parameter ble ikke validert av DDEML-en."
 
-#: ../src/msw/dde.cpp:1120
+#: ../src/msw/dde.cpp:1184
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "tidsavbrudd i en forespørsel etter synkron rådtransaksjon"
 
-#: ../src/msw/dde.cpp:1126
+#: ../src/msw/dde.cpp:1190
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "tidsavbrudd i en forespørsel etter synkron datatransaksjon"
 
-#: ../src/msw/dde.cpp:1135
+#: ../src/msw/dde.cpp:1199
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "en forespørsel om en synkron utførselstransaksjon har gått ut på tid."
 
-#: ../src/msw/dde.cpp:1153
+#: ../src/msw/dde.cpp:1217
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "en forespørsel om en asynkron «snuse»-transaksjon har gått ut på tid."
 
-#: ../src/msw/dde.cpp:1168
+#: ../src/msw/dde.cpp:1232
 msgid "a request to end an advise transaction has timed out."
 msgstr ""
 "en forespørsel om å avslutte en rådgivningstransaksjon har gått ut på tid."
 
-#: ../src/msw/dde.cpp:1162
+#: ../src/msw/dde.cpp:1226
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -8325,15 +8505,15 @@ msgstr ""
 "som ble avsluttet av klienten, eller tjeneren ble\n"
 "slått av før transaksjonen ble fullført."
 
-#: ../src/msw/dde.cpp:1150
+#: ../src/msw/dde.cpp:1214
 msgid "a transaction failed."
 msgstr "en transaksjon feilet."
 
-#: ../src/common/accelcmn.cpp:189
+#: ../src/common/accelcmn.cpp:188
 msgid "alt"
 msgstr "alt"
 
-#: ../src/msw/dde.cpp:1132
+#: ../src/msw/dde.cpp:1196
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -8345,15 +8525,15 @@ msgstr ""
 "eller et program initialisert som APPCMD_CLIENTONLY har\n"
 "prøvd å utføre tjenertransaksjoner."
 
-#: ../src/msw/dde.cpp:1156
+#: ../src/msw/dde.cpp:1220
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "Et internt kall til PostMessage-funksjonen feilet."
 
-#: ../src/msw/dde.cpp:1165
+#: ../src/msw/dde.cpp:1229
 msgid "an internal error has occurred in the DDEML."
 msgstr "En intern feil har oppstått i DDEML-en."
 
-#: ../src/msw/dde.cpp:1171
+#: ../src/msw/dde.cpp:1235
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -8364,56 +8544,56 @@ msgstr ""
 "så vil ikke transaksjonsidentifikatoren for det tilbakekallet lenger være "
 "gyldig."
 
-#: ../src/common/zipstrm.cpp:1483
+#: ../src/common/zipstrm.cpp:1522
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "antar dette er en mangedelt zip-fil slått sammen"
 
-#: ../src/common/fileconf.cpp:1847
+#: ../src/common/fileconf.cpp:1849
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "forsøk på å endre uforanderlig nøkkel «%s» ignorert."
 
-#: ../src/html/chm.cpp:329
+#: ../src/html/chm.cpp:326
 msgid "bad arguments to library function"
 msgstr "ugyldig argument til biblioteksfunksjon"
 
-#: ../src/html/chm.cpp:341
+#: ../src/html/chm.cpp:338
 msgid "bad signature"
 msgstr "ugyldig signatur"
 
-#: ../src/common/zipstrm.cpp:1918
+#: ../src/common/zipstrm.cpp:1988
 msgid "bad zipfile offset to entry"
 msgstr "ugylidg zipfil forskyvning til oppføring"
 
-#: ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400
 msgid "binary"
 msgstr "binært"
 
-#: ../src/common/fontcmn.cpp:996
+#: ../src/common/fontcmn.cpp:1195
 msgid "bold"
 msgstr "fet"
 
-#: ../src/msw/utils.cpp:1144
+#: ../src/msw/utils.cpp:1135
 #, fuzzy, c-format
 msgid "build %lu"
 msgstr "Windows XP (build %lu"
 
-#: ../src/common/ffile.cpp:75
+#: ../src/common/ffile.cpp:73
 #, c-format
 msgid "can't close file '%s'"
 msgstr "klarte ikke lukke fil «%s»"
 
-#: ../src/common/file.cpp:245
+#: ../src/common/file.cpp:242
 #, c-format
 msgid "can't close file descriptor %d"
 msgstr "klarte ikke lukke fildeskriptor %d"
 
-#: ../src/common/file.cpp:586
+#: ../src/common/ffile.cpp:382 ../src/common/file.cpp:613
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "klarte ikke utføre endringene på filen «%s»"
 
-#: ../src/common/file.cpp:178
+#: ../src/common/file.cpp:175
 #, c-format
 msgid "can't create file '%s'"
 msgstr "klarte ikke opprette fil «%s»"
@@ -8423,49 +8603,49 @@ msgstr "klarte ikke opprette fil «%s»"
 msgid "can't delete user configuration file '%s'"
 msgstr "klarte ikke slette file «%s» for brukerkonfigurasjon"
 
-#: ../src/common/file.cpp:495
+#: ../src/common/file.cpp:522
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr "klarte ikke avgjøre om slutten på filen er nådd for deskriptor %d "
 
-#: ../src/common/zipstrm.cpp:1692
+#: ../src/common/zipstrm.cpp:1747
 msgid "can't find central directory in zip"
 msgstr "Klarte ikke finne zip-sentralmappe"
 
-#: ../src/common/file.cpp:465
+#: ../src/common/file.cpp:492
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "klarte ikke finne lengde av filen med deskriptor %d"
 
-#: ../src/msw/utils.cpp:341
+#: ../src/msw/utils.cpp:336
 msgid "can't find user's HOME, using current directory."
 msgstr "klarte ikke finne brukerens HOME, bruker gjeldende katalog."
 
-#: ../src/common/file.cpp:366
+#: ../src/common/file.cpp:407
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "klarte ikke tømme fildeskriptor %d"
 
-#: ../src/common/file.cpp:422
+#: ../src/common/file.cpp:463
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "klarte ikke finne søkeposisjon på fildeskriptor %d"
 
-#: ../src/common/fontmap.cpp:325
+#: ../src/common/fontmap.cpp:322
 msgid "can't load any font, aborting"
 msgstr "klarte ikke laste noe skrifter, avbryter"
 
-#: ../src/common/file.cpp:231 ../src/common/ffile.cpp:59
+#: ../src/common/ffile.cpp:57 ../src/common/file.cpp:228
 #, c-format
 msgid "can't open file '%s'"
 msgstr "klarte ikke åpne fil «%s»"
 
-#: ../src/common/fileconf.cpp:320
+#: ../src/common/fileconf.cpp:314
 #, c-format
 msgid "can't open global configuration file '%s'."
 msgstr "klarte ikke åpne global konfigurasjonsfil «%s»."
 
-#: ../src/common/fileconf.cpp:336
+#: ../src/common/fileconf.cpp:330
 #, c-format
 msgid "can't open user configuration file '%s'."
 msgstr "klarte ikke åpne bruker konfigurasjonsfil «%s»."
@@ -8474,40 +8654,40 @@ msgstr "klarte ikke åpne bruker konfigurasjonsfil «%s»."
 msgid "can't open user configuration file."
 msgstr "klarte ikke åpne bruker konfigurasjonsfil."
 
-#: ../src/common/zipstrm.cpp:579
+#: ../src/common/zipstrm.cpp:572
 msgid "can't re-initialize zlib deflate stream"
 msgstr "Klarte ikke klargjøre zlib-strøm for nedpakking."
 
-#: ../src/common/zipstrm.cpp:604
+#: ../src/common/zipstrm.cpp:597
 msgid "can't re-initialize zlib inflate stream"
 msgstr "Klarte ikke klargjøre zlib-strøm for utpakking."
 
-#: ../src/common/file.cpp:304
+#: ../src/common/file.cpp:345
 #, c-format
 msgid "can't read from file descriptor %d"
 msgstr "klarte ikke lese fra fildeskriptor %d"
 
-#: ../src/common/file.cpp:581
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:608
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "klarte ikke slette fil «%s»"
 
-#: ../src/common/file.cpp:598
+#: ../src/common/ffile.cpp:394 ../src/common/file.cpp:625
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "klarte ikke slette midlertidig fil «%s»"
 
-#: ../src/common/file.cpp:408
+#: ../src/common/file.cpp:449
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "klarte ikke søke på fildeskriptor %d"
 
-#: ../src/common/textfile.cpp:273
+#: ../src/common/textfile.cpp:161
 #, c-format
 msgid "can't write buffer '%s' to disk."
 msgstr "klarte ikke skriver buffer «%s» til disk."
 
-#: ../src/common/file.cpp:323
+#: ../src/common/file.cpp:364
 #, c-format
 msgid "can't write to file descriptor %d"
 msgstr "klarte ikke skrive til deskriptor %d"
@@ -8517,22 +8697,28 @@ msgid "can't write user configuration file."
 msgstr "klarte ikke skrive til bruker konfigurasjonsfil."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:482 ../src/generic/datavgen.cpp:1261
+#: ../src/common/datavcmn.cpp:2064 ../src/generic/datavgen.cpp:1384
 msgid "checked"
 msgstr ""
 
-#: ../src/html/chm.cpp:345
+#: ../src/html/chm.cpp:342
 msgid "checksum error"
 msgstr "kontrollsumfeil"
 
-#: ../src/common/tarstrm.cpp:820
+#: ../src/common/tarstrm.cpp:814
 msgid "checksum failure reading tar header block"
 msgstr "kontrollsumfeil ved lesing av hodeblokk fra tar"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:226
-#: ../src/richtext/richtextbackgroundpage.cpp:249
-#: ../src/richtext/richtextbackgroundpage.cpp:289
-#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
 #: ../src/richtext/richtextborderspage.cpp:254
 #: ../src/richtext/richtextborderspage.cpp:288
 #: ../src/richtext/richtextborderspage.cpp:322
@@ -8550,104 +8736,127 @@ msgstr "kontrollsumfeil ved lesing av hodeblokk fra tar"
 #: ../src/richtext/richtextmarginspage.cpp:340
 #: ../src/richtext/richtextmarginspage.cpp:363
 #: ../src/richtext/richtextmarginspage.cpp:388
-#: ../src/richtext/richtextsizepage.cpp:339
-#: ../src/richtext/richtextsizepage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:400
-#: ../src/richtext/richtextsizepage.cpp:427
-#: ../src/richtext/richtextsizepage.cpp:454
-#: ../src/richtext/richtextsizepage.cpp:481
-#: ../src/richtext/richtextsizepage.cpp:555
-#: ../src/richtext/richtextsizepage.cpp:590
-#: ../src/richtext/richtextsizepage.cpp:625
-#: ../src/richtext/richtextsizepage.cpp:660
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
 msgid "cm"
 msgstr ""
 
-#: ../src/html/chm.cpp:347
+#: ../src/html/chm.cpp:344
 msgid "compression error"
 msgstr "kompresjonsfeil"
 
-#: ../src/common/regex.cpp:236
+#: ../src/common/regex.cpp:233
 msgid "conversion to 8-bit encoding failed"
 msgstr "konvertering til 8-bit koding feilet"
 
-#: ../src/common/accelcmn.cpp:187
+#: ../src/common/accelcmn.cpp:186
 msgid "ctrl"
 msgstr "ctrl"
 
-#: ../src/common/cmdline.cpp:1500
+#: ../src/common/cmdline.cpp:1496
 msgid "date"
 msgstr "dato"
 
-#: ../src/html/chm.cpp:349
+#: ../src/html/chm.cpp:346
 msgid "decompression error"
 msgstr "feil ved utpakking"
 
-#: ../src/richtext/richtextstyles.cpp:780 ../src/common/fmapbase.cpp:820
+#: ../src/common/fmapbase.cpp:816 ../src/richtext/richtextstyles.cpp:777
 msgid "default"
 msgstr "standard"
 
-#: ../src/common/cmdline.cpp:1496
+#: ../src/common/cmdline.cpp:1492
 msgid "double"
 msgstr "dobbel"
 
-#: ../src/common/debugrpt.cpp:538
+#: ../src/common/debugrpt.cpp:539
 msgid "dump of the process state (binary)"
 msgstr "dump av prosesstilstanden (binært)"
 
-#: ../src/common/datetimefmt.cpp:1969
+#: ../src/common/datetimefmt.cpp:1992
 msgid "eighteenth"
 msgstr "attende"
 
-#: ../src/common/datetimefmt.cpp:1959
+#: ../src/common/datetimefmt.cpp:1982
 msgid "eighth"
 msgstr "åttende"
 
-#: ../src/common/datetimefmt.cpp:1962
+#: ../src/common/datetimefmt.cpp:1985
 msgid "eleventh"
 msgstr "ellevte"
 
-#: ../src/common/fileconf.cpp:1833
+#: ../src/common/fileconf.cpp:1835
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "oppføring «%s» forekommer mer enn en gang i gruppen «%s»"
 
-#: ../src/html/chm.cpp:343
+#: ../src/html/chm.cpp:340
 msgid "error in data format"
 msgstr "feil i dataformat"
 
-#: ../src/html/chm.cpp:331
+#: ../src/html/chm.cpp:328
 msgid "error opening file"
 msgstr "feil ved åpning av fil"
 
-#: ../src/common/zipstrm.cpp:1778
+#: ../src/common/zipstrm.cpp:1836
 msgid "error reading zip central directory"
 msgstr "Feil ved lesing av zip-sentralmappe"
 
-#: ../src/common/zipstrm.cpp:1870
+#: ../src/common/zipstrm.cpp:1940
 msgid "error reading zip local header"
 msgstr "feil ved lesing av lokalt zip-hode "
 
-#: ../src/common/zipstrm.cpp:2531
+#: ../src/common/zipstrm.cpp:2615
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "feil ved skriving av zip-oppføring «%s»: feil crc eller lengde"
 
-#: ../src/common/ffile.cpp:188
+#: ../src/common/zipstrm.cpp:2608
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "feil ved skriving av zip-oppføring «%s»: feil crc eller lengde"
+
+#: ../src/common/fontcmn.cpp:1205
+#, fuzzy
+msgid "extrabold"
+msgstr "fet"
+
+#: ../src/common/fontcmn.cpp:1223
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1167
+#, fuzzy
+msgid "extralight"
+msgstr "lett"
+
+#: ../src/msw/webview_ie.cpp:1036
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "Klarte ikke utføre «%s»\n"
+
+#: ../src/common/ffile.cpp:187
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "klarte ikke tømme filen «%s»"
 
+#: ../src/msw/webview_ie.cpp:1045
+#, fuzzy
+msgid "failed to retrieve execution result"
+msgstr "Klarte ikke hente tekst fra RAS feilmelding"
+
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1030
+#: ../src/generic/datavgen.cpp:1150
 msgid "false"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1966
+#: ../src/common/datetimefmt.cpp:1989
 msgid "fifteenth"
 msgstr "femtende"
 
-#: ../src/common/datetimefmt.cpp:1956
+#: ../src/common/datetimefmt.cpp:1979
 msgid "fifth"
 msgstr "femte"
 
@@ -8676,132 +8885,151 @@ msgstr "file «%s», linje %d: verdi for uforanderlig nøkkel «%s» ignorert."
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "fil «%s»: uventet tegn %c på linje %d."
 
-#: ../src/richtext/richtextbuffer.cpp:8738
+#: ../src/richtext/richtextbuffer.cpp:8736
 msgid "files"
 msgstr "Filer"
 
-#: ../src/common/datetimefmt.cpp:1952
+#: ../src/common/datetimefmt.cpp:1975
 msgid "first"
 msgstr "først"
 
-#: ../src/html/helpwnd.cpp:1252
+#: ../src/html/helpwnd.cpp:1250
 msgid "font size"
 msgstr "skriftstørrelse"
 
-#: ../src/common/datetimefmt.cpp:1965
+#: ../src/common/datetimefmt.cpp:1988
 msgid "fourteenth"
 msgstr "fjortende"
 
-#: ../src/common/datetimefmt.cpp:1955
+#: ../src/common/datetimefmt.cpp:1978
 msgid "fourth"
 msgstr "fjedre"
 
-#: ../src/common/appbase.cpp:783
+#: ../src/common/appbase.cpp:784
 msgid "generate verbose log messages"
 msgstr "generer ordrike loggmeldinger"
 
-#: ../src/richtext/richtextbuffer.cpp:13138
-#: ../src/richtext/richtextbuffer.cpp:13248
+#: ../src/common/fontcmn.cpp:1215
+msgid "heavy"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:13133
+#: ../src/richtext/richtextbuffer.cpp:13243
 msgid "image"
 msgstr "bilde"
 
-#: ../src/common/tarstrm.cpp:796
+#: ../src/common/tarstrm.cpp:790
 msgid "incomplete header block in tar"
 msgstr "ukomplett hodeblokk i tar"
 
-#: ../src/common/xtixml.cpp:489
+#: ../src/common/xtixml.cpp:485
 msgid "incorrect event handler string, missing dot"
 msgstr "ugyldig hendelsebehandlerstreng, mangler punktum"
 
-#: ../src/common/tarstrm.cpp:1381
+#: ../src/common/tarstrm.cpp:1375
 msgid "incorrect size given for tar entry"
 msgstr "ugyldig størrelse for tar-innslag"
 
-#: ../src/common/tarstrm.cpp:993
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:987
 msgid "invalid data in extended tar header"
 msgstr "ugyldig data i utvidet tar-hode"
 
-#: ../src/generic/logg.cpp:1030
+#: ../src/generic/logg.cpp:1027
 msgid "invalid message box return value"
 msgstr "ugyldig meldingsboks returverdi"
 
-#: ../src/common/zipstrm.cpp:1647
+#: ../src/common/zipstrm.cpp:1688
 msgid "invalid zip file"
 msgstr "ugyldig zipfil"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:1228
 msgid "italic"
 msgstr "kursiv"
 
-#: ../src/common/fontcmn.cpp:991
+#: ../src/common/webrequest_curl.cpp:374
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "Kolonnebeskrivele kunne ikke initialiseres."
+
+#: ../src/common/fontcmn.cpp:1172
 msgid "light"
 msgstr "lett"
 
-#: ../src/common/intl.cpp:303
-#, c-format
-msgid "locale '%s' cannot be set."
-msgstr "klarte ikke sette lokale «%s»."
+#: ../src/common/fontcmn.cpp:1185
+msgid "medium"
+msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2125
+#: ../src/common/datetimefmt.cpp:2148
 msgid "midnight"
 msgstr "midnatt"
 
-#: ../src/common/datetimefmt.cpp:1970
+#: ../src/common/datetimefmt.cpp:1993
 msgid "nineteenth"
 msgstr "nittende"
 
-#: ../src/common/datetimefmt.cpp:1960
+#: ../src/common/datetimefmt.cpp:1983
 msgid "ninth"
 msgstr "niende"
 
-#: ../src/msw/dde.cpp:1116
+#: ../src/msw/dde.cpp:1180
 msgid "no DDE error."
 msgstr "ingen DDE-feil"
 
-#: ../src/html/chm.cpp:327
+#: ../src/html/chm.cpp:324
 msgid "no error"
 msgstr "ingen feil"
 
-#: ../src/dfb/fontmgr.cpp:174
+#: ../src/dfb/fontmgr.cpp:171
 #, c-format
 msgid "no fonts found in %s, using builtin font"
 msgstr "ingen fonter funnet i %s, bruker innebygd font"
 
-#: ../src/html/helpdata.cpp:657
+#: ../src/html/helpdata.cpp:650
 msgid "noname"
 msgstr "ikke navn"
 
-#: ../src/common/datetimefmt.cpp:2124
+#: ../src/common/datetimefmt.cpp:2147
 msgid "noon"
 msgstr "middag"
 
-#: ../src/richtext/richtextstyles.cpp:779
+#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
 #, fuzzy
 msgid "normal"
 msgstr "Normal"
 
-#: ../src/common/cmdline.cpp:1492
+#: ../src/common/cmdline.cpp:1488
 msgid "num"
 msgstr "nummer"
 
-#: ../src/common/xtixml.cpp:259
+#: ../src/common/accelcmn.cpp:194
+msgid "num "
+msgstr ""
+
+#: ../src/common/xtixml.cpp:255
 msgid "objects cannot have XML Text Nodes"
 msgstr "objekter kan ikke ha XML-tekstnoder"
 
-#: ../src/html/chm.cpp:339
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
 msgid "out of memory"
 msgstr "tom for minne"
 
-#: ../src/common/debugrpt.cpp:514
+#: ../src/common/debugrpt.cpp:515
 msgid "process context description"
 msgstr "beskrivelse av prosesskonteksten"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:227
-#: ../src/richtext/richtextbackgroundpage.cpp:250
-#: ../src/richtext/richtextbackgroundpage.cpp:290
-#: ../src/richtext/richtextbackgroundpage.cpp:317
-#: ../src/richtext/richtextfontpage.cpp:177
-#: ../src/richtext/richtextfontpage.cpp:180
 #: ../src/richtext/richtextborderspage.cpp:255
 #: ../src/richtext/richtextborderspage.cpp:289
 #: ../src/richtext/richtextborderspage.cpp:323
@@ -8811,22 +9039,45 @@ msgstr "beskrivelse av prosesskonteksten"
 #: ../src/richtext/richtextborderspage.cpp:491
 #: ../src/richtext/richtextborderspage.cpp:525
 #: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextfontpage.cpp:180
 msgid "pt"
 msgstr ""
 
-#: ../src/richtext/richtextbackgroundpage.cpp:225
-#: ../src/richtext/richtextbackgroundpage.cpp:228
-#: ../src/richtext/richtextbackgroundpage.cpp:229
-#: ../src/richtext/richtextbackgroundpage.cpp:248
-#: ../src/richtext/richtextbackgroundpage.cpp:251
-#: ../src/richtext/richtextbackgroundpage.cpp:252
-#: ../src/richtext/richtextbackgroundpage.cpp:288
-#: ../src/richtext/richtextbackgroundpage.cpp:291
-#: ../src/richtext/richtextbackgroundpage.cpp:292
-#: ../src/richtext/richtextbackgroundpage.cpp:315
-#: ../src/richtext/richtextbackgroundpage.cpp:318
-#: ../src/richtext/richtextbackgroundpage.cpp:319
-#: ../src/richtext/richtextfontpage.cpp:178
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:659
+#: ../src/richtext/richtextsizepage.cpp:662
+#: ../src/richtext/richtextsizepage.cpp:663
 #: ../src/richtext/richtextborderspage.cpp:253
 #: ../src/richtext/richtextborderspage.cpp:256
 #: ../src/richtext/richtextborderspage.cpp:257
@@ -8878,262 +9129,272 @@ msgstr ""
 #: ../src/richtext/richtextmarginspage.cpp:387
 #: ../src/richtext/richtextmarginspage.cpp:389
 #: ../src/richtext/richtextmarginspage.cpp:390
-#: ../src/richtext/richtextsizepage.cpp:338
-#: ../src/richtext/richtextsizepage.cpp:341
-#: ../src/richtext/richtextsizepage.cpp:342
-#: ../src/richtext/richtextsizepage.cpp:372
-#: ../src/richtext/richtextsizepage.cpp:375
-#: ../src/richtext/richtextsizepage.cpp:376
-#: ../src/richtext/richtextsizepage.cpp:399
-#: ../src/richtext/richtextsizepage.cpp:402
-#: ../src/richtext/richtextsizepage.cpp:403
-#: ../src/richtext/richtextsizepage.cpp:426
-#: ../src/richtext/richtextsizepage.cpp:429
-#: ../src/richtext/richtextsizepage.cpp:430
-#: ../src/richtext/richtextsizepage.cpp:453
-#: ../src/richtext/richtextsizepage.cpp:456
-#: ../src/richtext/richtextsizepage.cpp:457
-#: ../src/richtext/richtextsizepage.cpp:480
-#: ../src/richtext/richtextsizepage.cpp:483
-#: ../src/richtext/richtextsizepage.cpp:484
-#: ../src/richtext/richtextsizepage.cpp:554
-#: ../src/richtext/richtextsizepage.cpp:557
-#: ../src/richtext/richtextsizepage.cpp:558
-#: ../src/richtext/richtextsizepage.cpp:589
-#: ../src/richtext/richtextsizepage.cpp:592
-#: ../src/richtext/richtextsizepage.cpp:593
-#: ../src/richtext/richtextsizepage.cpp:624
-#: ../src/richtext/richtextsizepage.cpp:627
-#: ../src/richtext/richtextsizepage.cpp:628
-#: ../src/richtext/richtextsizepage.cpp:659
-#: ../src/richtext/richtextsizepage.cpp:662
-#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextfontpage.cpp:178
 msgid "px"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:193
+#: ../src/common/accelcmn.cpp:192
 #, fuzzy
 msgid "rawctrl"
 msgstr "ctrl"
 
-#: ../src/html/chm.cpp:333
+#: ../src/html/chm.cpp:330
 msgid "read error"
 msgstr "lesefeil"
 
-#: ../src/common/zipstrm.cpp:2085
+#: ../src/common/zipstrm.cpp:2155
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "leser zip-strøm (oppføring %s): feil crc"
 
-#: ../src/common/zipstrm.cpp:2080
+#: ../src/common/zipstrm.cpp:2150
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "leser zip-strøm (oppføring %s): feil lengde"
 
-#: ../src/msw/dde.cpp:1159
+#: ../src/msw/dde.cpp:1223
 msgid "reentrancy problem."
 msgstr "gjeninngangsproblem."
 
-#: ../src/common/datetimefmt.cpp:1953
+#: ../src/common/datetimefmt.cpp:1976
 msgid "second"
 msgstr "andre"
 
-#: ../src/html/chm.cpp:337
+#: ../src/html/chm.cpp:334
 msgid "seek error"
 msgstr "søkefeil"
 
-#: ../src/common/datetimefmt.cpp:1968
+#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#, fuzzy
+msgid "semibold"
+msgstr "fet"
+
+#: ../src/common/datetimefmt.cpp:1991
 msgid "seventeenth"
 msgstr "syttende"
 
-#: ../src/common/datetimefmt.cpp:1958
+#: ../src/common/datetimefmt.cpp:1981
 msgid "seventh"
 msgstr "sjuende"
 
-#: ../src/common/accelcmn.cpp:191
+#: ../src/common/accelcmn.cpp:190
 msgid "shift"
 msgstr "shift"
 
-#: ../src/common/appbase.cpp:773
+#: ../src/common/appbase.cpp:774
 msgid "show this help message"
 msgstr "vis denne hjelpmeldingen"
 
-#: ../src/common/datetimefmt.cpp:1967
+#: ../src/common/datetimefmt.cpp:1990
 msgid "sixteenth"
 msgstr "sekstende"
 
-#: ../src/common/datetimefmt.cpp:1957
+#: ../src/common/datetimefmt.cpp:1980
 msgid "sixth"
 msgstr "sjette"
 
-#: ../src/common/appcmn.cpp:234
+#: ../src/common/appcmn.cpp:255
 msgid "specify display mode to use (e.g. 640x480-16)"
 msgstr "oppgi skjermmodus som skal brukes (f.eks. 640x480-16)"
 
-#: ../src/common/appcmn.cpp:220
+#: ../src/common/appcmn.cpp:241
 msgid "specify the theme to use"
 msgstr "oppgi temaet som skal bruker"
 
-#: ../src/richtext/richtextbuffer.cpp:9340
+#: ../src/richtext/richtextbuffer.cpp:9337
 msgid "standard/circle"
 msgstr "standard/sirkel"
 
-#: ../src/richtext/richtextbuffer.cpp:9341
+#: ../src/richtext/richtextbuffer.cpp:9338
 msgid "standard/circle-outline"
 msgstr "standard/sirkel-omriss"
 
-#: ../src/richtext/richtextbuffer.cpp:9343
+#: ../src/richtext/richtextbuffer.cpp:9340
 msgid "standard/diamond"
 msgstr "standard/diamant"
 
-#: ../src/richtext/richtextbuffer.cpp:9342
+#: ../src/richtext/richtextbuffer.cpp:9339
 msgid "standard/square"
 msgstr "standard/firkant"
 
-#: ../src/richtext/richtextbuffer.cpp:9344
+#: ../src/richtext/richtextbuffer.cpp:9341
 msgid "standard/triangle"
 msgstr "standard/triangel"
 
-#: ../src/common/zipstrm.cpp:1985
+#: ../src/common/zipstrm.cpp:2055
 msgid "stored file length not in Zip header"
 msgstr "lagret fillengde ikke funnet i Zip-hode"
 
-#: ../src/common/cmdline.cpp:1488
+#: ../src/common/cmdline.cpp:1484
 msgid "str"
 msgstr "str"
 
-#: ../src/common/fontcmn.cpp:982
+#: ../src/common/fontcmn.cpp:1145
 msgid "strikethrough"
 msgstr "overstrek"
 
-#: ../src/common/tarstrm.cpp:1003 ../src/common/tarstrm.cpp:1025
-#: ../src/common/tarstrm.cpp:1507 ../src/common/tarstrm.cpp:1529
+#: ../src/common/tarstrm.cpp:997 ../src/common/tarstrm.cpp:1019
+#: ../src/common/tarstrm.cpp:1501 ../src/common/tarstrm.cpp:1523
 msgid "tar entry not open"
 msgstr "tar-innslag er ikke åpent"
 
-#: ../src/common/datetimefmt.cpp:1961
+#: ../src/common/datetimefmt.cpp:1984
 msgid "tenth"
 msgstr "tiende"
 
-#: ../src/msw/dde.cpp:1123
+#: ../src/msw/dde.cpp:1187
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "svaret på transaksjonen gjorde at DDE_FBUSY-biten ble satt."
 
-#: ../src/common/datetimefmt.cpp:1954
+#: ../src/common/fontcmn.cpp:1154
+msgid "thin"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:1977
 msgid "third"
 msgstr "tredje"
 
-#: ../src/common/datetimefmt.cpp:1964
+#: ../src/common/datetimefmt.cpp:1987
 msgid "thirteenth"
 msgstr "trettende"
 
-#: ../src/common/datetimefmt.cpp:1758
+#: ../src/common/datetimefmt.cpp:1781
 msgid "today"
 msgstr "i dag"
 
-#: ../src/common/datetimefmt.cpp:1760
+#: ../src/common/datetimefmt.cpp:1783
 msgid "tomorrow"
 msgstr "i morgen"
 
-#: ../src/common/fileconf.cpp:1944
+#: ../src/common/fileconf.cpp:1946
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr ""
 
-#: ../src/gtk/aboutdlg.cpp:218
+#: ../src/gtk/aboutdlg.cpp:216
 msgid "translator-credits"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1028
+#: ../src/generic/datavgen.cpp:1148
 msgid "true"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1963
+#: ../src/common/datetimefmt.cpp:1986
 msgid "twelfth"
 msgstr "tolvte"
 
-#: ../src/common/datetimefmt.cpp:1971
+#: ../src/common/datetimefmt.cpp:1994
 msgid "twentieth"
 msgstr "tjuende"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:486 ../src/generic/datavgen.cpp:1263
+#: ../src/common/datavcmn.cpp:2068 ../src/generic/datavgen.cpp:1386
 msgid "unchecked"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:802 ../src/common/fontcmn.cpp:978
+#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
 msgid "underlined"
 msgstr "understreket"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:490
+#: ../src/common/datavcmn.cpp:2072
 #, fuzzy
 msgid "undetermined"
 msgstr "understreket"
 
-#: ../src/common/fileconf.cpp:1979
+#: ../src/common/fileconf.cpp:1981
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "uventet \" i posisjon %d i «%s»."
 
-#: ../src/common/tarstrm.cpp:1045
+#: ../src/common/tarstrm.cpp:1039
 #, fuzzy
 msgid "unexpected end of file"
 msgstr "Uventet slutt på filen under tolking av ressurs."
 
-#: ../src/generic/progdlgg.cpp:370 ../src/common/tarstrm.cpp:371
-#: ../src/common/tarstrm.cpp:394 ../src/common/tarstrm.cpp:425
+#: ../src/common/tarstrm.cpp:366 ../src/common/tarstrm.cpp:389
+#: ../src/common/tarstrm.cpp:420 ../src/generic/progdlgg.cpp:376
 msgid "unknown"
 msgstr "ukjent"
 
-#: ../src/msw/registry.cpp:150
+#: ../src/msw/registry.cpp:139
 #, fuzzy, c-format
 msgid "unknown (%lu)"
 msgstr "ukjent"
 
-#: ../src/common/xtixml.cpp:253
+#: ../src/common/xtixml.cpp:249
 #, c-format
 msgid "unknown class %s"
 msgstr "ukjent klasse %s"
 
-#: ../src/common/regex.cpp:258 ../src/html/chm.cpp:351
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "kompresjonsfeil"
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "feil ved utpakking"
+
+#: ../src/common/regex.cpp:255 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "ukjent feil "
 
-#: ../src/msw/dialup.cpp:471
+#: ../src/msw/dialup.cpp:465
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "ukjent feil (feilkode %08x)."
 
-#: ../src/common/fmapbase.cpp:834
+#: ../src/common/fmapbase.cpp:830
 #, c-format
 msgid "unknown-%d"
 msgstr "ukjent-%d"
 
-#: ../src/common/docview.cpp:509
+#: ../src/common/docview.cpp:502
 msgid "unnamed"
 msgstr "uten navn"
 
-#: ../src/common/docview.cpp:1624
+#: ../src/common/docview.cpp:1618
 #, c-format
 msgid "unnamed%d"
 msgstr "uten navn %d"
 
-#: ../src/common/zipstrm.cpp:1999 ../src/common/zipstrm.cpp:2319
+#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
 msgid "unsupported Zip compression method"
 msgstr "ikke-støttet Zip-komprimeringsmetode"
 
-#: ../src/common/translation.cpp:1892
+#: ../src/common/translation.cpp:1942
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "bruker katalog «%s» fra «%s»."
 
-#: ../src/html/chm.cpp:335
+#: ../src/html/chm.cpp:332
 msgid "write error"
 msgstr "skrivefeil"
 
-#: ../src/common/time.cpp:292
+#: ../src/gtk/glcanvas.cpp:187
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/common/time.cpp:285
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay feilet."
 
@@ -9146,15 +9407,15 @@ msgstr "wxWidgets klarte ikke åpne skjerm for '%s': avslutter."
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets klarte ikke åpne skjerm. Avslutter."
 
-#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:431
 msgid "xxxx"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1759
+#: ../src/common/datetimefmt.cpp:1782
 msgid "yesterday"
 msgstr "i går"
 
-#: ../src/common/zstream.cpp:251 ../src/common/zstream.cpp:426
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
 #, c-format
 msgid "zlib error %d"
 msgstr "zlib-feil %d"
@@ -9163,6 +9424,74 @@ msgstr "zlib-feil %d"
 #: ../src/richtext/richtextbulletspage.cpp:288
 msgid "~"
 msgstr ""
+
+#, fuzzy
+#~ msgid "&Save as"
+#~ msgstr "Lagre Som"
+
+#, fuzzy
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "«%s» må kun inneholde bokstaver."
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "«%s» skal være numerisk."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "«%s» må kun inneholde ASCII-tegn."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "«%s» må kun inneholde bokstaver."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "«%s» må kun inneholde bokstaver eller tall."
+
+#, fuzzy
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "«%s» må kun inneholde ASCII-tegn."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "Klarte ikke opprette vindu av klasse %s"
+
+#, fuzzy
+#~ msgid "Could not initalize libnotify."
+#~ msgstr "Klarte ikke å sette justering."
+
+#, fuzzy
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "Klarte ikke opprette en timer"
+
+#, fuzzy
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "Klarte ikke finne gjeldende trådpeker"
+
+#, fuzzy
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "Klarte ikke lukke filreferanse"
+
+#, fuzzy
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "Klarte ikke finne gjeldende mappe"
+
+#~ msgid "No unused colour in image."
+#~ msgstr "Ingen ubrukte farger i bildet."
+
+#, fuzzy
+#~ msgid "Not available"
+#~ msgstr "Ingen XBM-fasilitet tilgjengelig!"
+
+#, fuzzy
+#~ msgid "Replace selection"
+#~ msgstr "Erstatt &alle"
+
+#, fuzzy
+#~ msgid "Save as"
+#~ msgstr "Lagre Som"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Stilorganiserer"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "klarte ikke sette lokale «%s»."
 
 #~ msgid ""
 #~ "Cannot create new column's ID. Probably max. number of columns reached."
@@ -9173,9 +9502,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Column could not be added."
 #~ msgstr "Klarte ikke laste filen."
-
-#~ msgid "Column description could not be initialized."
-#~ msgstr "Kolonnebeskrivele kunne ikke initialiseres."
 
 #, fuzzy
 #~ msgid "Column index not found."
@@ -9418,9 +9744,6 @@ msgstr ""
 #~ msgid "Directory '%s' doesn't exist!"
 #~ msgstr "Mappen «%s» eksisterer ikke!"
 
-#~ msgid "File %s does not exist."
-#~ msgstr "Filen «%s» eksisterer ikke."
-
 #~ msgid "Mode %ix%i-%i not available."
 #~ msgstr "Modus %ix%i-%i ikke tilgjengelig."
 
@@ -9496,9 +9819,6 @@ msgstr ""
 
 #~ msgid "Failed to register OpenGL window class."
 #~ msgstr "Klarte ikke registrere OpenGL vindusklasse."
-
-#~ msgid "Fatal error"
-#~ msgstr "Kritisk feil"
 
 #~ msgid "Fatal error: "
 #~ msgstr "Kritisk feil:"
@@ -9656,9 +9976,6 @@ msgstr ""
 
 #~ msgid "&Print"
 #~ msgstr "&Skriv ut"
-
-#~ msgid "*** A debug report has been generated\n"
-#~ msgstr "*** En feilsøkingsrapport har blitt generert\n"
 
 #~ msgid "*** It can be found in \"%s\"\n"
 #~ msgstr "*** Den kan bli funnet i «%s»\n"

--- a/locale/ne.po
+++ b/locale/ne.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-21 14:25+0200\n"
+"POT-Creation-Date: 2020-10-18 23:11+0300\n"
 "PO-Revision-Date: 2015-05-09 20:03+0545\n"
 "Last-Translator: drishtibachak@gmail.com\n"
 "Language-Team: Him Prasad Gautam <himjee@yahoo.com>\n"
@@ -15,7 +15,7 @@ msgstr ""
 "X-Generator: Poedit 1.7.5\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ../src/common/debugrpt.cpp:586
+#: ../src/common/debugrpt.cpp:587
 msgid ""
 "\n"
 "Please send this report to the program maintainer, thank you!\n"
@@ -23,8 +23,8 @@ msgstr ""
 "\n"
 " कृपया यो प्रतिवेदन कार्यक्रम सम्भार कर्ता लाई पेश गर्नु होला । धन्यवाद!\n"
 
-#: ../src/richtext/richtextstyledlg.cpp:210
-#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:206
+#: ../src/richtext/richtextstyledlg.cpp:218
 msgid " "
 msgstr " "
 
@@ -32,71 +32,97 @@ msgstr " "
 msgid "              Thank you and we're sorry for the inconvenience!\n"
 msgstr "धन्यवाद र असुविधाका लागि क्षमा प्रार्थी छौं ।!\n"
 
-#: ../src/common/prntbase.cpp:573
+#: ../src/common/prntbase.cpp:568
 #, c-format
 msgid " (copy %d of %d)"
 msgstr "%d बट्टा %d को नक्कल"
 
-#: ../src/common/log.cpp:421
+#: ../src/common/log.cpp:440
 #, c-format
 msgid " (error %ld: %s)"
 msgstr " (गल्ती %ld: %s)"
 
-#: ../src/common/imagtiff.cpp:72
+#: ../src/common/imagtiff.cpp:69
 #, c-format
 msgid " (in module \"%s\")"
 msgstr "(Module \"%s\"मा)"
 
-#: ../src/osx/core/secretstore.cpp:138
-msgid " (while overwriting an existing item)"
-msgstr ""
-
-#: ../src/common/docview.cpp:1642
+#: ../src/common/docview.cpp:1636
 msgid " - "
 msgstr " - "
 
-#: ../src/richtext/richtextprint.cpp:593 ../src/html/htmprint.cpp:714
+#: ../src/html/htmprint.cpp:712 ../src/richtext/richtextprint.cpp:589
 msgid " Preview"
 msgstr "चेहरा"
 
-#: ../src/common/fontcmn.cpp:824
+#: ../src/common/fontcmn.cpp:973
 msgid " bold"
 msgstr "मोटो"
 
-#: ../src/common/fontcmn.cpp:840
+#: ../src/common/fontcmn.cpp:977
+#, fuzzy
+msgid " extra bold"
+msgstr "मोटो"
+
+#: ../src/common/fontcmn.cpp:985
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:957
+#, fuzzy
+msgid " extra light"
+msgstr "हलुको"
+
+#: ../src/common/fontcmn.cpp:981
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1001
 msgid " italic"
 msgstr "डल्केको"
 
-#: ../src/common/fontcmn.cpp:820
+#: ../src/common/fontcmn.cpp:961
 msgid " light"
 msgstr "हलुको"
 
-#: ../src/common/fontcmn.cpp:807
+#: ../src/common/fontcmn.cpp:965
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:969
+#, fuzzy
+msgid " semi bold"
+msgstr "मोटो"
+
+#: ../src/common/fontcmn.cpp:940
 #, fuzzy
 msgid " strikethrough"
 msgstr "strikethrough"
 
-#: ../src/common/paper.cpp:117
+#: ../src/common/fontcmn.cpp:953
+msgid " thin"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
 msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
 msgstr "#10 खाम, 4 1/8 x 9 1/2 इन्च"
 
-#: ../src/common/paper.cpp:118
+#: ../src/common/paper.cpp:115
 msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
 msgstr "#11 खाम, 4 1/2 x 10 3/8 इन्च"
 
-#: ../src/common/paper.cpp:119
+#: ../src/common/paper.cpp:116
 msgid "#12 Envelope, 4 3/4 x 11 in"
 msgstr "#12 खाम, 4 3/4 x 11 इन्च"
 
-#: ../src/common/paper.cpp:120
+#: ../src/common/paper.cpp:117
 msgid "#14 Envelope, 5 x 11 1/2 in"
 msgstr "#14 खाम, 5 x 11 1/2 इन्च"
 
-#: ../src/common/paper.cpp:116
+#: ../src/common/paper.cpp:113
 msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
 msgstr "#9 खाम, 3 7/8 x 8 7/8 इन्च"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:341
 #: ../src/richtext/richtextsizepage.cpp:340
 #: ../src/richtext/richtextsizepage.cpp:374
 #: ../src/richtext/richtextsizepage.cpp:401
@@ -107,81 +133,82 @@ msgstr "#9 खाम, 3 7/8 x 8 7/8 इन्च"
 #: ../src/richtext/richtextsizepage.cpp:591
 #: ../src/richtext/richtextsizepage.cpp:626
 #: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextbackgroundpage.cpp:341
 msgid "%"
 msgstr "%"
 
-#: ../src/html/helpwnd.cpp:1031
+#: ../src/html/helpwnd.cpp:1029
 #, c-format
 msgid "%d of %lu"
 msgstr "%d को %lu"
 
-#: ../src/html/helpwnd.cpp:1678
+#: ../src/html/helpwnd.cpp:1676
 #, c-format
 msgid "%i of %u"
 msgstr "%i - %u को"
 
-#: ../src/generic/filectrlg.cpp:279
+#: ../src/generic/filectrlg.cpp:275
 #, c-format
 msgid "%ld byte"
 msgid_plural "%ld bytes"
 msgstr[0] "%ld बाइट"
 msgstr[1] "%ld बाइटहरू"
 
-#: ../src/html/helpwnd.cpp:1033
+#: ../src/html/helpwnd.cpp:1031
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu को %lu"
 
-#: ../src/generic/datavgen.cpp:6028
+#: ../src/generic/datavgen.cpp:6833
 #, fuzzy, c-format
 msgid "%s (%d items)"
 msgstr "%s (अथवा %s)"
 
-#: ../src/common/cmdline.cpp:1221
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (अथवा %s)"
 
-#: ../src/generic/logg.cpp:224
+#: ../src/generic/logg.cpp:221
 #, c-format
 msgid "%s Error"
 msgstr "%s गल्ती"
 
-#: ../src/generic/logg.cpp:236
+#: ../src/generic/logg.cpp:233
 #, c-format
 msgid "%s Information"
 msgstr "%s सूचना"
 
-#: ../src/generic/preferencesg.cpp:113
+#: ../src/generic/preferencesg.cpp:110
 #, c-format
 msgid "%s Preferences"
 msgstr " %s प्राथमिकताहरू "
 
-#: ../src/generic/logg.cpp:228
+#: ../src/generic/logg.cpp:225
 #, c-format
 msgid "%s Warning"
 msgstr "%s चेतावनी"
 
-#: ../src/common/tarstrm.cpp:1319
+#: ../src/common/tarstrm.cpp:1313
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s tar header '%s' प्रविष्टिको लागि मिलेन ।"
 
-#: ../src/common/fldlgcmn.cpp:124
+#: ../src/common/fldlgcmn.cpp:121
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s फाइल (%s)|%s"
 
-#: ../src/html/helpwnd.cpp:1716
+#: ../src/html/helpwnd.cpp:1714
 #, c-format
 msgid "%u of %u"
 msgstr "%u को %u"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "&About"
 msgstr "&बारेमा"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "&Actual Size"
 msgstr "&वास्तविक आकार"
 
@@ -189,28 +216,28 @@ msgstr "&वास्तविक आकार"
 msgid "&After a paragraph:"
 msgstr "&अनुच्छेद पछि"
 
-#: ../src/richtext/richtextindentspage.cpp:128
 #: ../src/richtext/richtextliststylepage.cpp:319
+#: ../src/richtext/richtextindentspage.cpp:128
 msgid "&Alignment"
 msgstr "&पङ्क्तिणवद्धता"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "&Apply"
 msgstr "&लागू गर"
 
-#: ../src/richtext/richtextstyledlg.cpp:251
+#: ../src/richtext/richtextstyledlg.cpp:247
 msgid "&Apply Style"
 msgstr "&शैली लागू गर"
 
-#: ../src/msw/mdi.cpp:179
+#: ../src/msw/mdi.cpp:174
 msgid "&Arrange Icons"
 msgstr "&प्रतिमा मिलाउ"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "&Ascending"
 msgstr "&बढ्दो वर्णानुक्रमिक"
 
-#: ../src/common/stockitem.cpp:142
+#: ../src/common/stockitem.cpp:139
 msgid "&Back"
 msgstr "&पछाडि"
 
@@ -230,24 +257,24 @@ msgstr "&पृष्ठभूमि रङ्ग:"
 msgid "&Blur distance:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:143
+#: ../src/common/stockitem.cpp:140
 msgid "&Bold"
 msgstr "&मोटो"
 
-#: ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141
 msgid "&Bottom"
 msgstr "&पुछार"
 
+#: ../src/richtext/richtextsizepage.cpp:637
+#: ../src/richtext/richtextsizepage.cpp:644
 #: ../src/richtext/richtextborderspage.cpp:345
 #: ../src/richtext/richtextborderspage.cpp:513
 #: ../src/richtext/richtextmarginspage.cpp:259
 #: ../src/richtext/richtextmarginspage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:637
-#: ../src/richtext/richtextsizepage.cpp:644
 msgid "&Bottom:"
 msgstr "&पुछार:"
 
-#: ../include/wx/richtext/richtextbuffer.h:3866
+#: ../include/wx/richtext/richtextbuffer.h:3861
 msgid "&Box"
 msgstr "&बाकस"
 
@@ -256,38 +283,38 @@ msgstr "&बाकस"
 msgid "&Bullet style:"
 msgstr "&गोलिछिन्हको शैली:"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "&CD-Rom"
 msgstr "&CD-Rom"
 
-#: ../src/generic/wizard.cpp:434 ../src/generic/fontdlgg.cpp:470
-#: ../src/generic/fontdlgg.cpp:489 ../src/osx/carbon/fontdlg.cpp:402
-#: ../src/common/dlgcmn.cpp:279 ../src/common/stockitem.cpp:145
+#: ../src/osx/carbon/fontdlg.cpp:399 ../src/common/stockitem.cpp:142
+#: ../src/generic/wizard.cpp:433 ../src/generic/fontdlgg.cpp:466
+#: ../src/generic/fontdlgg.cpp:485 ../src/osx/cocoa/button.mm:200
 msgid "&Cancel"
 msgstr "&रद्द"
 
-#: ../src/msw/mdi.cpp:175
+#: ../src/msw/mdi.cpp:170
 msgid "&Cascade"
 msgstr "&Cascade"
 
-#: ../include/wx/richtext/richtextbuffer.h:5960
+#: ../include/wx/richtext/richtextbuffer.h:5955
 msgid "&Cell"
 msgstr "&कोशिका"
 
-#: ../src/richtext/richtextsymboldlg.cpp:439
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "&Character code:"
 msgstr "&वर्ण संहिता"
 
-#: ../src/common/stockitem.cpp:147
+#: ../src/common/stockitem.cpp:144
 msgid "&Clear"
 msgstr "&सफा गर"
 
-#: ../src/generic/logg.cpp:516 ../src/common/stockitem.cpp:148
-#: ../src/common/prntbase.cpp:1600 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/stockitem.cpp:145 ../src/common/prntbase.cpp:1625
+#: ../src/univ/themes/win32.cpp:3753 ../src/generic/logg.cpp:513
 msgid "&Close"
 msgstr "&बन्द गर"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "&Color"
 msgstr "&रङ्ग"
 
@@ -295,20 +322,20 @@ msgstr "&रङ्ग"
 msgid "&Colour:"
 msgstr "&रङ्ग:"
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "&Convert"
 msgstr "&रूपान्तरण गर"
 
-#: ../src/richtext/richtextctrl.cpp:333 ../src/osx/textctrl_osx.cpp:577
-#: ../src/common/stockitem.cpp:150 ../src/msw/textctrl.cpp:2508
+#: ../src/osx/textctrl_osx.cpp:595 ../src/common/stockitem.cpp:147
+#: ../src/msw/textctrl.cpp:2773 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&नक्कल उतार"
 
-#: ../src/generic/hyperlinkg.cpp:156
+#: ../src/generic/hyperlinkg.cpp:153
 msgid "&Copy URL"
 msgstr "Url को &नक्कल उतार "
 
-#: ../src/common/headerctrlcmn.cpp:306
+#: ../src/common/headerctrlcmn.cpp:304
 msgid "&Customize..."
 msgstr "&आफू अनुकूल बनाउ.."
 
@@ -316,53 +343,54 @@ msgstr "&आफू अनुकूल बनाउ.."
 msgid "&Debug report preview:"
 msgstr "प्रतिवेदन चेहराको &खानतलासी :"
 
-#: ../src/richtext/richtexttabspage.cpp:138
-#: ../src/richtext/richtextctrl.cpp:335 ../src/osx/textctrl_osx.cpp:579
-#: ../src/common/stockitem.cpp:152 ../src/msw/textctrl.cpp:2510
+#: ../src/osx/textctrl_osx.cpp:597 ../src/common/stockitem.cpp:149
+#: ../src/msw/textctrl.cpp:2775 ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtextctrl.cpp:334
 msgid "&Delete"
 msgstr "&मेटाइ देउ"
 
-#: ../src/richtext/richtextstyledlg.cpp:269
+#: ../src/richtext/richtextstyledlg.cpp:265
 msgid "&Delete Style..."
 msgstr "शैली &मेटाइ देउ ."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "&Descending"
 msgstr "&घट्दो क्रममा वर्णानुक्रमिक"
 
-#: ../src/generic/logg.cpp:682
+#: ../src/generic/logg.cpp:679
 msgid "&Details"
 msgstr "विस्तृत"
 
-#: ../src/common/stockitem.cpp:153
+#: ../src/common/stockitem.cpp:150
 msgid "&Down"
 msgstr "&तल"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "&Edit"
 msgstr "&सम्पादन"
 
-#: ../src/richtext/richtextstyledlg.cpp:263
+#: ../src/richtext/richtextstyledlg.cpp:259
 msgid "&Edit Style..."
 msgstr "शैलीको &सम्पादन .."
 
-#: ../src/common/stockitem.cpp:155
+#: ../src/common/stockitem.cpp:152
 msgid "&Execute"
 msgstr "&कार्यान्वयन गर"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/common/stockitem.cpp:154
 msgid "&File"
 msgstr "&फाइल"
 
-#: ../src/common/stockitem.cpp:158
-msgid "&Find"
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "&Find..."
 msgstr "&फेला पार"
 
-#: ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:430
 msgid "&Finish"
 msgstr "&समाप्त"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:156
 msgid "&First"
 msgstr "&पहिलो"
 
@@ -370,15 +398,15 @@ msgstr "&पहिलो"
 msgid "&Floating mode:"
 msgstr "&तैरि रहेको मुद्रा:"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "&Floppy"
 msgstr "&फ्लपी"
 
-#: ../src/common/stockitem.cpp:194
+#: ../src/common/stockitem.cpp:191
 msgid "&Font"
 msgstr "&वरणाकृति"
 
-#: ../src/generic/fontdlgg.cpp:371
+#: ../src/generic/fontdlgg.cpp:367
 msgid "&Font family:"
 msgstr "&वरणाकृति परिवार:"
 
@@ -386,20 +414,20 @@ msgstr "&वरणाकृति परिवार:"
 msgid "&Font for Level..."
 msgstr "&वरणाकृति for तह.."
 
+#: ../src/richtext/richtextsymboldlg.cpp:397
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:400
 msgid "&Font:"
 msgstr "&वरणाकृति:"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "&Forward"
 msgstr "&प्रेषित गर"
 
-#: ../src/richtext/richtextsymboldlg.cpp:451
+#: ../src/richtext/richtextsymboldlg.cpp:448
 msgid "&From:"
 msgstr "&बाट:"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "&Harddisk"
 msgstr "&Harddisk"
 
@@ -408,9 +436,9 @@ msgstr "&Harddisk"
 msgid "&Height:"
 msgstr "&उचाइ:"
 
-#: ../src/generic/wizard.cpp:441 ../src/richtext/richtextstyledlg.cpp:303
-#: ../src/richtext/richtextsymboldlg.cpp:479 ../src/osx/menu_osx.cpp:734
-#: ../src/common/stockitem.cpp:163
+#: ../src/common/stockitem.cpp:160 ../src/generic/wizard.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextstyledlg.cpp:299 ../src/osx/cocoa/menu.mm:226
 msgid "&Help"
 msgstr "&सहयोग"
 
@@ -418,7 +446,7 @@ msgstr "&सहयोग"
 msgid "&Hide details"
 msgstr "विस्तृत &लुकाउ "
 
-#: ../src/common/stockitem.cpp:164
+#: ../src/common/stockitem.cpp:161
 msgid "&Home"
 msgstr "&गृह"
 
@@ -426,54 +454,54 @@ msgstr "&गृह"
 msgid "&Horizontal offset:"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:184
 #: ../src/richtext/richtextliststylepage.cpp:372
+#: ../src/richtext/richtextindentspage.cpp:184
 msgid "&Indentation (tenths of a mm)"
 msgstr "&Indentation (मिलि मिटरको दसौँ भाग)"
 
-#: ../src/richtext/richtextindentspage.cpp:167
 #: ../src/richtext/richtextliststylepage.cpp:356
+#: ../src/richtext/richtextindentspage.cpp:167
 msgid "&Indeterminate"
 msgstr "&निकाल्न नसकिने"
 
-#: ../src/common/stockitem.cpp:166
+#: ../src/common/stockitem.cpp:163
 msgid "&Index"
 msgstr "&अनुक्रमणिका"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "&Info"
 msgstr "&जानकारी"
 
-#: ../src/common/stockitem.cpp:168
+#: ../src/common/stockitem.cpp:165
 msgid "&Italic"
 msgstr "&डल्केको"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "&Jump to"
 msgstr "मा &फड्को मार "
 
-#: ../src/richtext/richtextindentspage.cpp:153
 #: ../src/richtext/richtextliststylepage.cpp:342
+#: ../src/richtext/richtextindentspage.cpp:153
 msgid "&Justified"
 msgstr "&छेउ मिलेको"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "&Last"
 msgstr "&अन्तिम"
 
-#: ../src/richtext/richtextindentspage.cpp:139
 #: ../src/richtext/richtextliststylepage.cpp:328
+#: ../src/richtext/richtextindentspage.cpp:139
 msgid "&Left"
 msgstr "&देब्रे"
 
-#: ../src/richtext/richtextindentspage.cpp:195
+#: ../src/richtext/richtextsizepage.cpp:532
+#: ../src/richtext/richtextsizepage.cpp:539
 #: ../src/richtext/richtextborderspage.cpp:243
 #: ../src/richtext/richtextborderspage.cpp:411
 #: ../src/richtext/richtextliststylepage.cpp:381
+#: ../src/richtext/richtextindentspage.cpp:195
 #: ../src/richtext/richtextmarginspage.cpp:186
 #: ../src/richtext/richtextmarginspage.cpp:300
-#: ../src/richtext/richtextsizepage.cpp:532
-#: ../src/richtext/richtextsizepage.cpp:539
 msgid "&Left:"
 msgstr "&देब्रे:"
 
@@ -481,11 +509,11 @@ msgstr "&देब्रे:"
 msgid "&List level:"
 msgstr "&सूचि तह:"
 
-#: ../src/generic/logg.cpp:517
+#: ../src/generic/logg.cpp:514
 msgid "&Log"
 msgstr "&पुस्तिका"
 
-#: ../src/univ/themes/win32.cpp:3748
+#: ../src/univ/themes/win32.cpp:3745
 msgid "&Move"
 msgstr "&जाउ"
 
@@ -493,20 +521,19 @@ msgstr "&जाउ"
 msgid "&Move the object to:"
 msgstr "&वस्तुमा जाउ"
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "&Network"
 msgstr "&सञ्जाल "
 
-#: ../src/richtext/richtexttabspage.cpp:132 ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173 ../src/richtext/richtexttabspage.cpp:132
 msgid "&New"
 msgstr "&नया"
 
-#: ../src/aui/tabmdi.cpp:111 ../src/generic/mdig.cpp:100
-#: ../src/msw/mdi.cpp:180
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
 msgid "&Next"
 msgstr "&अघिल्लो"
 
-#: ../src/generic/wizard.cpp:432 ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:429
 msgid "&Next >"
 msgstr "&अघिल्लो >"
 
@@ -514,7 +541,7 @@ msgstr "&अघिल्लो >"
 msgid "&Next Paragraph"
 msgstr "&अघिल्लो अनुच्छेद"
 
-#: ../src/generic/tipdlg.cpp:240
+#: ../src/generic/tipdlg.cpp:237
 msgid "&Next Tip"
 msgstr "&अघिल्लो टिपोट"
 
@@ -522,11 +549,11 @@ msgstr "&अघिल्लो टिपोट"
 msgid "&Next style:"
 msgstr "&अघिल्लो शैली:"
 
-#: ../src/common/stockitem.cpp:177 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:174 ../src/msw/msgdlg.cpp:435
 msgid "&No"
 msgstr "&होइन"
 
-#: ../src/generic/dbgrptg.cpp:356
+#: ../src/generic/dbgrptg.cpp:360
 msgid "&Notes:"
 msgstr "&टिप्पणीहरू:"
 
@@ -534,12 +561,12 @@ msgstr "&टिप्पणीहरू:"
 msgid "&Number:"
 msgstr "&सङ्ख्या:"
 
-#: ../src/generic/fontdlgg.cpp:475 ../src/generic/fontdlgg.cpp:482
-#: ../src/osx/carbon/fontdlg.cpp:408 ../src/common/stockitem.cpp:178
+#: ../src/osx/carbon/fontdlg.cpp:405 ../src/common/stockitem.cpp:175
+#: ../src/generic/fontdlgg.cpp:471 ../src/generic/fontdlgg.cpp:478
 msgid "&OK"
 msgstr "&ठीक"
 
-#: ../src/generic/dbgrptg.cpp:342 ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176 ../src/generic/dbgrptg.cpp:342
 msgid "&Open..."
 msgstr "&खोली देउ"
 
@@ -551,16 +578,16 @@ msgstr "&बाह्य रेखा तह:"
 msgid "&Page Break"
 msgstr "&पृष्ट विच्छेद"
 
-#: ../src/richtext/richtextctrl.cpp:334 ../src/osx/textctrl_osx.cpp:578
-#: ../src/common/stockitem.cpp:180 ../src/msw/textctrl.cpp:2509
+#: ../src/osx/textctrl_osx.cpp:596 ../src/common/stockitem.cpp:177
+#: ../src/msw/textctrl.cpp:2774 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&टाँसि देउ"
 
-#: ../include/wx/richtext/richtextbuffer.h:5010
+#: ../include/wx/richtext/richtextbuffer.h:5005
 msgid "&Picture"
 msgstr "&चीत्र"
 
-#: ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:419
 msgid "&Point size:"
 msgstr "&थोप्लोको आकार:"
 
@@ -572,12 +599,11 @@ msgstr "&स्थान (मिलि मिटरको दसौँ भाग
 msgid "&Position mode:"
 msgstr "&अवस्था मुद्रा:"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178
 msgid "&Preferences"
 msgstr "&प्राथमिकताहरू"
 
-#: ../src/aui/tabmdi.cpp:112 ../src/generic/mdig.cpp:101
-#: ../src/msw/mdi.cpp:181
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
 msgid "&Previous"
 msgstr "&पछिल्लो"
 
@@ -585,78 +611,74 @@ msgstr "&पछिल्लो"
 msgid "&Previous Paragraph"
 msgstr "&पछिल्लो अनुच्छेद"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "&Print..."
 msgstr "&छापी देउ.."
 
-#: ../src/richtext/richtextctrl.cpp:339 ../src/richtext/richtextctrl.cpp:5514
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtextctrl.cpp:338
+#: ../src/richtext/richtextctrl.cpp:5512
 msgid "&Properties"
 msgstr "&गुणहरू"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "&Quit"
 msgstr "&त्यागि देउ"
 
-#: ../src/richtext/richtextctrl.cpp:330 ../src/osx/textctrl_osx.cpp:574
-#: ../src/common/stockitem.cpp:185 ../src/common/cmdproc.cpp:293
-#: ../src/common/cmdproc.cpp:300 ../src/msw/textctrl.cpp:2505
+#: ../src/osx/textctrl_osx.cpp:592 ../src/common/stockitem.cpp:182
+#: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
+#: ../src/msw/textctrl.cpp:2770 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&फेरि गर"
 
-#: ../src/common/cmdproc.cpp:289 ../src/common/cmdproc.cpp:309
+#: ../src/common/cmdproc.cpp:282 ../src/common/cmdproc.cpp:302
 msgid "&Redo "
 msgstr "&फेरि गर "
 
-#: ../src/richtext/richtextstyledlg.cpp:257
+#: ../src/richtext/richtextstyledlg.cpp:253
 msgid "&Rename Style..."
 msgstr " शैली को&नाम फेर.."
 
-#: ../src/generic/fdrepdlg.cpp:179
+#: ../src/generic/fdrepdlg.cpp:176
 msgid "&Replace"
 msgstr "&प्रतिस्थापन"
 
-#: ../src/richtext/richtextstyledlg.cpp:287
+#: ../src/richtext/richtextstyledlg.cpp:283
 msgid "&Restart numbering"
 msgstr "&फेरि सङ्ख्या राख्न सुरु गर "
 
-#: ../src/univ/themes/win32.cpp:3747
+#: ../src/univ/themes/win32.cpp:3744
 msgid "&Restore"
 msgstr "&फेरि स्थापित गर"
 
-#: ../src/richtext/richtextindentspage.cpp:146
 #: ../src/richtext/richtextliststylepage.cpp:335
+#: ../src/richtext/richtextindentspage.cpp:146
 msgid "&Right"
 msgstr "&दाहिने"
 
-#: ../src/richtext/richtextindentspage.cpp:213
+#: ../src/richtext/richtextsizepage.cpp:602
+#: ../src/richtext/richtextsizepage.cpp:609
 #: ../src/richtext/richtextborderspage.cpp:277
 #: ../src/richtext/richtextborderspage.cpp:445
 #: ../src/richtext/richtextliststylepage.cpp:399
+#: ../src/richtext/richtextindentspage.cpp:213
 #: ../src/richtext/richtextmarginspage.cpp:211
 #: ../src/richtext/richtextmarginspage.cpp:325
-#: ../src/richtext/richtextsizepage.cpp:602
-#: ../src/richtext/richtextsizepage.cpp:609
 msgid "&Right:"
 msgstr "&दाहिने:"
 
-#: ../src/common/stockitem.cpp:190
+#: ../src/common/stockitem.cpp:187
 msgid "&Save"
 msgstr "&बचत गर"
-
-#: ../src/common/stockitem.cpp:191
-msgid "&Save as"
-msgstr "&यसरी बचत गर"
 
 #: ../include/wx/richmsgdlg.h:29
 msgid "&See details"
 msgstr "&विस्तृत अवलोकन"
 
-#: ../src/generic/tipdlg.cpp:236
+#: ../src/generic/tipdlg.cpp:233
 msgid "&Show tips at startup"
 msgstr "&सुरु हुँदा टिपोट देखाउ"
 
-#: ../src/univ/themes/win32.cpp:3750
+#: ../src/univ/themes/win32.cpp:3747
 msgid "&Size"
 msgstr "&आकार"
 
@@ -664,36 +686,36 @@ msgstr "&आकार"
 msgid "&Size:"
 msgstr "&आकार:"
 
-#: ../src/generic/progdlgg.cpp:252
+#: ../src/generic/progdlgg.cpp:249
 msgid "&Skip"
 msgstr "&उफ्र"
 
-#: ../src/richtext/richtextindentspage.cpp:242
 #: ../src/richtext/richtextliststylepage.cpp:417
+#: ../src/richtext/richtextindentspage.cpp:242
 msgid "&Spacing (tenths of a mm)"
 msgstr "&फरक (मिलि मिटरको दसौँ भाग)"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "&Spell Check"
 msgstr "&हिज्जे जाँच"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "&Stop"
 msgstr "&रोकि देउ"
 
-#: ../src/richtext/richtextfontpage.cpp:275 ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196 ../src/richtext/richtextfontpage.cpp:275
 msgid "&Strikethrough"
 msgstr "&Strikethrough"
 
-#: ../src/generic/fontdlgg.cpp:382 ../src/richtext/richtextstylepage.cpp:106
+#: ../src/generic/fontdlgg.cpp:378 ../src/richtext/richtextstylepage.cpp:106
 msgid "&Style:"
 msgstr "&शैली:"
 
-#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:194
 msgid "&Styles:"
 msgstr "&शैलीहरू:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:413
+#: ../src/richtext/richtextsymboldlg.cpp:410
 msgid "&Subset:"
 msgstr "&उप समूह"
 
@@ -707,24 +729,24 @@ msgstr "&चिन्ह:"
 msgid "&Synchronize values"
 msgstr "&संयोजित मानहरू"
 
-#: ../include/wx/richtext/richtextbuffer.h:6069
+#: ../include/wx/richtext/richtextbuffer.h:6064
 msgid "&Table"
 msgstr "&तालिका"
 
-#: ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197
 msgid "&Top"
 msgstr "&सिरान"
 
+#: ../src/richtext/richtextsizepage.cpp:567
+#: ../src/richtext/richtextsizepage.cpp:574
 #: ../src/richtext/richtextborderspage.cpp:311
 #: ../src/richtext/richtextborderspage.cpp:479
 #: ../src/richtext/richtextmarginspage.cpp:234
 #: ../src/richtext/richtextmarginspage.cpp:348
-#: ../src/richtext/richtextsizepage.cpp:567
-#: ../src/richtext/richtextsizepage.cpp:574
 msgid "&Top:"
 msgstr "&सिरान:"
 
-#: ../src/generic/fontdlgg.cpp:444 ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199 ../src/generic/fontdlgg.cpp:441
 msgid "&Underline"
 msgstr "&अधोरेखाङ्कन"
 
@@ -732,21 +754,21 @@ msgstr "&अधोरेखाङ्कन"
 msgid "&Underlining:"
 msgstr "&अदोरेखाङ्करण:"
 
-#: ../src/richtext/richtextctrl.cpp:329 ../src/osx/textctrl_osx.cpp:573
-#: ../src/common/stockitem.cpp:203 ../src/common/cmdproc.cpp:271
-#: ../src/msw/textctrl.cpp:2504
+#: ../src/osx/textctrl_osx.cpp:591 ../src/common/stockitem.cpp:200
+#: ../src/common/cmdproc.cpp:264 ../src/msw/textctrl.cpp:2769
+#: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&उल्टाउ"
 
-#: ../src/common/cmdproc.cpp:265
+#: ../src/common/cmdproc.cpp:258
 msgid "&Undo "
 msgstr "&उल्टाउ "
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "&Unindent"
 msgstr "&Unindent"
 
-#: ../src/common/stockitem.cpp:205
+#: ../src/common/stockitem.cpp:202
 msgid "&Up"
 msgstr "&माथि"
 
@@ -763,7 +785,7 @@ msgstr "&ठाडो पङ्‌क्तिबद्धता:"
 msgid "&View..."
 msgstr "&दृश्य.."
 
-#: ../src/generic/fontdlgg.cpp:393
+#: ../src/generic/fontdlgg.cpp:389
 msgid "&Weight:"
 msgstr "&भार:"
 
@@ -772,88 +794,58 @@ msgstr "&भार:"
 msgid "&Width:"
 msgstr "&छोडाइ:"
 
-#: ../src/aui/tabmdi.cpp:311 ../src/aui/tabmdi.cpp:327
-#: ../src/aui/tabmdi.cpp:329 ../src/generic/mdig.cpp:294
-#: ../src/generic/mdig.cpp:310 ../src/generic/mdig.cpp:314
-#: ../src/msw/mdi.cpp:78
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
 msgid "&Window"
 msgstr "&विन्डो"
 
-#: ../src/common/stockitem.cpp:206 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:203 ../src/msw/msgdlg.cpp:435
 msgid "&Yes"
 msgstr "&हो"
 
-#: ../src/common/valtext.cpp:256
-#, c-format
-msgid "'%s' contains illegal characters"
+#: ../src/common/valtext.cpp:197
+#, fuzzy, c-format
+msgid "'%s' contains invalid character(s)"
 msgstr "'%s' मा अवैध वर्णहरू छन् ।"
 
-#: ../src/common/valtext.cpp:254
-#, c-format
-msgid "'%s' doesn't consist only of valid characters"
-msgstr "'%s' मा केवल वैध मानहरू मात्रै छैनन् ।"
-
-#: ../src/common/config.cpp:519 ../src/msw/regconf.cpp:258
+#: ../src/common/config.cpp:515 ../src/msw/regconf.cpp:255
 #, c-format
 msgid "'%s' has extra '..', ignored."
 msgstr "'%s' मा अतिरिक्त '..' रहेछ, बेवास्ता गर्नु होस् ।"
 
-#: ../src/common/cmdline.cpp:1113 ../src/common/cmdline.cpp:1131
+#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' सहि सङ्ख्यात्मक मान विकल्प '%s' को लागि हदैन"
 
-#: ../src/common/translation.cpp:1100
+#: ../src/common/translation.cpp:1142
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' सहि सन्देश सूची होइन"
 
-#: ../src/common/valtext.cpp:165
+#: ../src/common/valtext.cpp:188
 #, c-format
 msgid "'%s' is not one of the valid strings"
 msgstr "'%s' कुनै वैध पदावली होइन ।"
 
-#: ../src/common/valtext.cpp:167
+#: ../src/common/valtext.cpp:186
 #, c-format
 msgid "'%s' is one of the invalid strings"
 msgstr "अवैध पदावलीहरू मद्धे '%s'  एउटा हो ।"
 
-#: ../src/common/textbuf.cpp:237
+#: ../src/common/textbuf.cpp:233
 #, c-format
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' सम्भवता binary buffer हो ।"
-
-#: ../src/common/valtext.cpp:252
-#, c-format
-msgid "'%s' should be numeric."
-msgstr "'%s' सङ्ख्यात्मक हुनै पर्छ ।"
-
-#: ../src/common/valtext.cpp:244
-#, c-format
-msgid "'%s' should only contain ASCII characters."
-msgstr "'%s' मा ASCII वर्णहरू मात्रै हुन सक्छ ।"
-
-#: ../src/common/valtext.cpp:246
-#, c-format
-msgid "'%s' should only contain alphabetic characters."
-msgstr "'%s' मा वर्णहरू मात्रै हु सक्छ ।"
-
-#: ../src/common/valtext.cpp:248
-#, c-format
-msgid "'%s' should only contain alphabetic or numeric characters."
-msgstr "'%s' मा पाठिय अथवा सङ्ख्यात्मक वर्णहरू मात्रै हुन सक्छ ।"
-
-#: ../src/common/valtext.cpp:250
-#, c-format
-msgid "'%s' should only contain digits."
-msgstr "'%s' मा सङ्ख्या मात्रै हुन सक्छ ।"
 
 #: ../src/richtext/richtextliststylepage.cpp:229
 #: ../src/richtext/richtextbulletspage.cpp:166
 msgid "(*)"
 msgstr "(*)"
 
-#: ../src/html/helpwnd.cpp:963
+#: ../src/html/helpwnd.cpp:961
 msgid "(Help)"
 msgstr "(सहयोग)"
 
@@ -862,27 +854,32 @@ msgstr "(सहयोग)"
 msgid "(None)"
 msgstr "(कुनै पनि होइन)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:504
+#: ../src/richtext/richtextsymboldlg.cpp:503
 msgid "(Normal text)"
 msgstr "(सामान्य पाठ)"
 
-#: ../src/html/helpwnd.cpp:419 ../src/html/helpwnd.cpp:1106
-#: ../src/html/helpwnd.cpp:1742
+#: ../src/html/helpwnd.cpp:417 ../src/html/helpwnd.cpp:1104
+#: ../src/html/helpwnd.cpp:1740
 msgid "(bookmarks)"
 msgstr "(बुकमार्क)"
 
+#: ../src/msw/dlmsw.cpp:167
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (गल्ती %ld: %s)"
+
+#: ../src/richtext/richtextformatdlg.cpp:876
+#: ../src/richtext/richtextliststylepage.cpp:448
+#: ../src/richtext/richtextliststylepage.cpp:460
+#: ../src/richtext/richtextliststylepage.cpp:461
 #: ../src/richtext/richtextindentspage.cpp:274
 #: ../src/richtext/richtextindentspage.cpp:286
 #: ../src/richtext/richtextindentspage.cpp:287
 #: ../src/richtext/richtextindentspage.cpp:311
 #: ../src/richtext/richtextindentspage.cpp:326
-#: ../src/richtext/richtextformatdlg.cpp:884
 #: ../src/richtext/richtextfontpage.cpp:349
 #: ../src/richtext/richtextfontpage.cpp:353
 #: ../src/richtext/richtextfontpage.cpp:357
-#: ../src/richtext/richtextliststylepage.cpp:448
-#: ../src/richtext/richtextliststylepage.cpp:460
-#: ../src/richtext/richtextliststylepage.cpp:461
 msgid "(none)"
 msgstr "(कुनै पनि होइन)"
 
@@ -901,7 +898,7 @@ msgstr "*)"
 msgid "+"
 msgstr "+"
 
-#: ../src/msw/utils.cpp:1152
+#: ../src/msw/utils.cpp:1143
 msgid ", 64-bit edition"
 msgstr ", 64-bit संस्करण"
 
@@ -910,163 +907,163 @@ msgstr ", 64-bit संस्करण"
 msgid "-"
 msgstr "-"
 
-#: ../src/generic/filepickerg.cpp:66
+#: ../src/generic/filepickerg.cpp:63
 msgid "..."
 msgstr ".."
 
-#: ../src/richtext/richtextindentspage.cpp:276
 #: ../src/richtext/richtextliststylepage.cpp:450
+#: ../src/richtext/richtextindentspage.cpp:276
 msgid "1.1"
 msgstr "1.1"
 
-#: ../src/richtext/richtextindentspage.cpp:277
 #: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextindentspage.cpp:277
 msgid "1.2"
 msgstr "1.2"
 
-#: ../src/richtext/richtextindentspage.cpp:278
 #: ../src/richtext/richtextliststylepage.cpp:452
+#: ../src/richtext/richtextindentspage.cpp:278
 msgid "1.3"
 msgstr "1.3"
 
-#: ../src/richtext/richtextindentspage.cpp:279
 #: ../src/richtext/richtextliststylepage.cpp:453
+#: ../src/richtext/richtextindentspage.cpp:279
 msgid "1.4"
 msgstr "1.4"
 
-#: ../src/richtext/richtextindentspage.cpp:280
 #: ../src/richtext/richtextliststylepage.cpp:454
+#: ../src/richtext/richtextindentspage.cpp:280
 msgid "1.5"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:281
 #: ../src/richtext/richtextliststylepage.cpp:455
+#: ../src/richtext/richtextindentspage.cpp:281
 msgid "1.6"
 msgstr "1.6"
 
-#: ../src/richtext/richtextindentspage.cpp:282
 #: ../src/richtext/richtextliststylepage.cpp:456
+#: ../src/richtext/richtextindentspage.cpp:282
 msgid "1.7"
 msgstr "1.7"
 
-#: ../src/richtext/richtextindentspage.cpp:283
 #: ../src/richtext/richtextliststylepage.cpp:457
+#: ../src/richtext/richtextindentspage.cpp:283
 msgid "1.8"
 msgstr "1.8"
 
-#: ../src/richtext/richtextindentspage.cpp:284
 #: ../src/richtext/richtextliststylepage.cpp:458
+#: ../src/richtext/richtextindentspage.cpp:284
 msgid "1.9"
 msgstr "1.9"
 
-#: ../src/common/paper.cpp:140
+#: ../src/common/paper.cpp:137
 msgid "10 x 11 in"
 msgstr "10 x 11इन्च"
 
-#: ../src/common/paper.cpp:113
+#: ../src/common/paper.cpp:110
 msgid "10 x 14 in"
 msgstr "10 x 14इन्च"
 
-#: ../src/common/paper.cpp:114
+#: ../src/common/paper.cpp:111
 msgid "11 x 17 in"
 msgstr "11 x 17इन्च"
 
-#: ../src/common/paper.cpp:184
+#: ../src/common/paper.cpp:181
 msgid "12 x 11 in"
 msgstr "12 x 11इन्च"
 
-#: ../src/common/paper.cpp:141
+#: ../src/common/paper.cpp:138
 msgid "15 x 11 in"
 msgstr "15 x 11इन्च"
 
-#: ../src/richtext/richtextindentspage.cpp:285
 #: ../src/richtext/richtextliststylepage.cpp:459
+#: ../src/richtext/richtextindentspage.cpp:285
 msgid "2"
 msgstr "2"
 
-#: ../src/common/paper.cpp:132
+#: ../src/common/paper.cpp:129
 msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
 msgstr "6 3/4 खाम, 3 5/8 x 6 1/2 इन्च"
 
-#: ../src/common/paper.cpp:139
+#: ../src/common/paper.cpp:136
 msgid "9 x 11 in"
 msgstr "9 x 11इन्च"
 
-#: ../src/html/htmprint.cpp:431
+#: ../src/html/htmprint.cpp:443
 msgid ": file does not exist!"
 msgstr ": फाइल छैन ।"
 
-#: ../src/common/fontmap.cpp:199
+#: ../src/common/fontmap.cpp:196
 msgid ": unknown charset"
 msgstr ": अज्ञात पाठ समूह"
 
-#: ../src/common/fontmap.cpp:413
+#: ../src/common/fontmap.cpp:410
 msgid ": unknown encoding"
 msgstr ": अज्ञात अनुसंहिता"
 
-#: ../src/generic/wizard.cpp:443
+#: ../src/generic/wizard.cpp:438
 msgid "< &Back"
 msgstr "< &पछाडि"
 
-#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:628
-#: ../src/osx/carbon/fontdlg.cpp:648
+#: ../src/osx/carbon/fontdlg.cpp:419 ../src/osx/carbon/fontdlg.cpp:625
+#: ../src/osx/carbon/fontdlg.cpp:645
 msgid "<Any Decorative>"
 msgstr "<कुनै सजावट>"
 
-#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:630
-#: ../src/osx/carbon/fontdlg.cpp:650
+#: ../src/osx/carbon/fontdlg.cpp:420 ../src/osx/carbon/fontdlg.cpp:627
+#: ../src/osx/carbon/fontdlg.cpp:647
 msgid "<Any Modern>"
 msgstr "<कुनै मोडेम >"
 
-#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:626
-#: ../src/osx/carbon/fontdlg.cpp:646
+#: ../src/osx/carbon/fontdlg.cpp:418 ../src/osx/carbon/fontdlg.cpp:623
+#: ../src/osx/carbon/fontdlg.cpp:643
 msgid "<Any Roman>"
 msgstr "<कुनै रोमन>"
 
-#: ../src/osx/carbon/fontdlg.cpp:424 ../src/osx/carbon/fontdlg.cpp:632
-#: ../src/osx/carbon/fontdlg.cpp:652
+#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:629
+#: ../src/osx/carbon/fontdlg.cpp:649
 msgid "<Any Script>"
 msgstr "<कुनै Script>"
 
-#: ../src/osx/carbon/fontdlg.cpp:425 ../src/osx/carbon/fontdlg.cpp:637
-#: ../src/osx/carbon/fontdlg.cpp:656
+#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:634
+#: ../src/osx/carbon/fontdlg.cpp:653
 msgid "<Any Swiss>"
 msgstr "<कुनै Swiss>"
 
-#: ../src/osx/carbon/fontdlg.cpp:426 ../src/osx/carbon/fontdlg.cpp:634
-#: ../src/osx/carbon/fontdlg.cpp:654
+#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:631
+#: ../src/osx/carbon/fontdlg.cpp:651
 msgid "<Any Teletype>"
 msgstr "<कुनै Teletype>"
 
-#: ../src/osx/carbon/fontdlg.cpp:420
+#: ../src/osx/carbon/fontdlg.cpp:417
 msgid "<Any>"
 msgstr "<कुनै>"
 
-#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
 msgid "<DIR>"
 msgstr "<DIR>"
 
-#: ../src/generic/filectrlg.cpp:254 ../src/generic/filectrlg.cpp:277
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
 msgid "<DRIVE>"
 msgstr "<DRIVE>"
 
-#: ../src/generic/filectrlg.cpp:252 ../src/generic/filectrlg.cpp:275
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
 msgid "<LINK>"
 msgstr "<LINK>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1264
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>मोटो डल्केको </i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1270
+#: ../src/html/helpwnd.cpp:1268
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i> मोटो डल्केको <u> अधोरेखाङ्कित </u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1265
+#: ../src/html/helpwnd.cpp:1263
 msgid "<b>Bold face.</b> "
 msgstr "<b>मोटो .</b> "
 
-#: ../src/html/helpwnd.cpp:1264
+#: ../src/html/helpwnd.cpp:1262
 msgid "<i>Italic face.</i> "
 msgstr "<i>डल्केको .</i> "
 
@@ -1075,15 +1072,15 @@ msgstr "<i>डल्केको .</i> "
 msgid ">"
 msgstr ">"
 
-#: ../src/generic/dbgrptg.cpp:318
+#: ../src/generic/dbgrptg.cpp:317
 msgid "A debug report has been generated in the directory\n"
 msgstr "खानतलासी प्रतिवेदन गर्रामा सिर्जना गरियो । \n"
 
-#: ../src/common/debugrpt.cpp:573
+#: ../src/common/debugrpt.cpp:574
 msgid "A debug report has been generated. It can be found in"
 msgstr "खानतलासी प्रतिवेदन सिर्जना गरियो । यो राखेको स्थान"
 
-#: ../src/common/xtixml.cpp:418
+#: ../src/common/xtixml.cpp:414
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "खालि नभएको सङ्ग्रहमा 'Element' टिप्पणी हुनै पर्दछ ।"
 
@@ -1094,106 +1091,106 @@ msgstr "खालि नभएको सङ्ग्रहमा 'Element' ट�
 msgid "A standard bullet name."
 msgstr "स्तरीय थोप्लोको नाम"
 
-#: ../src/common/paper.cpp:217
+#: ../src/common/paper.cpp:214
 msgid "A0 sheet, 841 x 1189 mm"
 msgstr "A0 शीट, 841 x 1189 मिमी"
 
-#: ../src/common/paper.cpp:218
+#: ../src/common/paper.cpp:215
 msgid "A1 sheet, 594 x 841 mm"
 msgstr "A1 शीट, 594 x 841 मिमी"
 
-#: ../src/common/paper.cpp:159
+#: ../src/common/paper.cpp:156
 msgid "A2 420 x 594 mm"
 msgstr "A2 420 x 594 मिमी"
 
-#: ../src/common/paper.cpp:156
+#: ../src/common/paper.cpp:153
 msgid "A3 Extra 322 x 445 mm"
 msgstr "A3 Extra 322 x 445 मिमी"
 
-#: ../src/common/paper.cpp:161
+#: ../src/common/paper.cpp:158
 msgid "A3 Extra Transverse 322 x 445 mm"
 msgstr "A3 Extra Transverse 322 x 445 मिमी"
 
-#: ../src/common/paper.cpp:170
+#: ../src/common/paper.cpp:167
 msgid "A3 Rotated 420 x 297 mm"
 msgstr "A3 rotated 420 x 297 मिमी"
 
-#: ../src/common/paper.cpp:160
+#: ../src/common/paper.cpp:157
 msgid "A3 Transverse 297 x 420 mm"
 msgstr "A3 Transverse 297 x 420 मिमी"
 
-#: ../src/common/paper.cpp:106
+#: ../src/common/paper.cpp:103
 msgid "A3 sheet, 297 x 420 mm"
 msgstr "A3 शीट, 297 x 420 मिमी"
 
-#: ../src/common/paper.cpp:146
+#: ../src/common/paper.cpp:143
 msgid "A4 Extra 9.27 x 12.69 in"
 msgstr "A4 Extra 9.27 x 12.69इन्च"
 
-#: ../src/common/paper.cpp:153
+#: ../src/common/paper.cpp:150
 msgid "A4 Plus 210 x 330 mm"
 msgstr "A4 Plus 210 x 330 मिमी"
 
-#: ../src/common/paper.cpp:171
+#: ../src/common/paper.cpp:168
 msgid "A4 Rotated 297 x 210 mm"
 msgstr "A4 rotated 297 x 210 मिमी"
 
-#: ../src/common/paper.cpp:148
+#: ../src/common/paper.cpp:145
 msgid "A4 Transverse 210 x 297 mm"
 msgstr "A4 Transverse 210 x 297 मिमी"
 
-#: ../src/common/paper.cpp:97
+#: ../src/common/paper.cpp:94
 msgid "A4 sheet, 210 x 297 mm"
 msgstr "A4 शीट, 210 x 297 मिमी"
 
-#: ../src/common/paper.cpp:107
+#: ../src/common/paper.cpp:104
 msgid "A4 small sheet, 210 x 297 mm"
 msgstr "A4 small शीट, 210 x 297 मिमी"
 
-#: ../src/common/paper.cpp:157
+#: ../src/common/paper.cpp:154
 msgid "A5 Extra 174 x 235 mm"
 msgstr "A5 Extra 174 x 235 मिमी"
 
-#: ../src/common/paper.cpp:172
+#: ../src/common/paper.cpp:169
 msgid "A5 Rotated 210 x 148 mm"
 msgstr "A5 Rotated 210 x 148 मिमी"
 
-#: ../src/common/paper.cpp:154
+#: ../src/common/paper.cpp:151
 msgid "A5 Transverse 148 x 210 mm"
 msgstr "A5 Transverse 148 x 210 मिमी"
 
-#: ../src/common/paper.cpp:108
+#: ../src/common/paper.cpp:105
 msgid "A5 sheet, 148 x 210 mm"
 msgstr "A5 शीट, 148 x 210 मिमी"
 
-#: ../src/common/paper.cpp:164
+#: ../src/common/paper.cpp:161
 msgid "A6 105 x 148 mm"
 msgstr "A6 105 x 148 मिमी"
 
-#: ../src/common/paper.cpp:177
+#: ../src/common/paper.cpp:174
 msgid "A6 Rotated 148 x 105 mm"
 msgstr "A6 Rotated 148 x 105 मिमी"
 
-#: ../src/generic/fontdlgg.cpp:83 ../src/richtext/richtextformatdlg.cpp:529
-#: ../src/osx/carbon/fontdlg.cpp:153
+#: ../src/osx/carbon/fontdlg.cpp:150 ../src/generic/fontdlgg.cpp:79
+#: ../src/richtext/richtextformatdlg.cpp:521
 msgid "ABCDEFGabcdefg12345"
 msgstr "ABCDEFGabcdefg12345"
 
-#: ../src/richtext/richtextsymboldlg.cpp:458 ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
 msgid "ASCII"
 msgstr "ASCII"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "About"
 msgstr "बारेमा"
 
-#: ../src/generic/aboutdlgg.cpp:140 ../src/osx/menu_osx.cpp:558
-#: ../src/msw/aboutdlg.cpp:64
+#: ../src/osx/menu_osx.cpp:450 ../src/generic/aboutdlgg.cpp:137
+#: ../src/msw/aboutdlg.cpp:61
 #, c-format
 msgid "About %s"
 msgstr "%s को बारेमा"
 
-#: ../src/osx/menu_osx.cpp:560
+#: ../src/osx/menu_osx.cpp:452
 msgid "About..."
 msgstr "बारेमा"
 
@@ -1202,37 +1199,37 @@ msgid "Absolute"
 msgstr "निरपेक्ष"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:873
+#: ../src/propgrid/advprops.cpp:774
 msgid "ActiveBorder"
 msgstr "सक्रिय सिमाना"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:874
+#: ../src/propgrid/advprops.cpp:775
 msgid "ActiveCaption"
 msgstr "सक्रिय शिर्षक"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "Actual Size"
 msgstr "वास्तविक आकार"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:140 ../src/common/accelcmn.cpp:81
+#: ../src/common/stockitem.cpp:137 ../src/common/accelcmn.cpp:78
 msgid "Add"
 msgstr "थप"
 
-#: ../src/richtext/richtextbuffer.cpp:11455
+#: ../src/richtext/richtextbuffer.cpp:11454
 msgid "Add Column"
 msgstr "महल थप"
 
-#: ../src/richtext/richtextbuffer.cpp:11392
+#: ../src/richtext/richtextbuffer.cpp:11391
 msgid "Add Row"
 msgstr "हरफ थप"
 
-#: ../src/html/helpwnd.cpp:432
+#: ../src/html/helpwnd.cpp:430
 msgid "Add current page to bookmarks"
 msgstr "चालू पृष्टलाई बुकमार्कमा थप गर"
 
-#: ../src/generic/colrdlgg.cpp:366
+#: ../src/generic/colrdlgg.cpp:386
 msgid "Add to custom colours"
 msgstr "प्रचलित रङ्गहरूमा थप गर"
 
@@ -1244,12 +1241,12 @@ msgstr "generic accessor भनिने गुणहरूको सङ्ग�
 msgid "AddToPropertyCollection called w/o valid adder"
 msgstr "w/o valid adder भनिने गुणहरूको सङ्ग्रहमा थप गर ।"
 
-#: ../src/html/helpctrl.cpp:159
+#: ../src/html/helpctrl.cpp:155
 #, c-format
 msgid "Adding book %s"
 msgstr "किताब %s थिदै"
 
-#: ../src/common/preferencescmn.cpp:43
+#: ../src/common/preferencescmn.cpp:40
 msgid "Advanced"
 msgstr "समृद्ध"
 
@@ -1257,11 +1254,11 @@ msgstr "समृद्ध"
 msgid "After a paragraph:"
 msgstr " अनुच्छेद पछि:"
 
-#: ../src/common/stockitem.cpp:172
+#: ../src/common/stockitem.cpp:169
 msgid "Align Left"
 msgstr " देब्रे पङ्क्ति"
 
-#: ../src/common/stockitem.cpp:173
+#: ../src/common/stockitem.cpp:170
 msgid "Align Right"
 msgstr "दाहिने पङ्ति"
 
@@ -1269,40 +1266,40 @@ msgstr "दाहिने पङ्ति"
 msgid "Alignment"
 msgstr "पङ्‌क्तिबद्धता"
 
-#: ../src/generic/prntdlgg.cpp:215
+#: ../src/generic/prntdlgg.cpp:208
 msgid "All"
 msgstr "सबै"
 
-#: ../src/generic/filectrlg.cpp:1197 ../src/common/fldlgcmn.cpp:107
+#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1186
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "सबै फाइलहरू (%s)|%s"
 
-#: ../include/wx/defs.h:2886
+#: ../include/wx/defs.h:2582
 msgid "All files (*)|*"
 msgstr "सबै फाइलहरू(*)|*"
 
-#: ../include/wx/defs.h:2883
+#: ../include/wx/defs.h:2579
 msgid "All files (*.*)|*.*"
 msgstr "सबै फाइलहरू(*.*)|*.*"
 
-#: ../src/richtext/richtextstyles.cpp:1061
+#: ../src/richtext/richtextstyles.cpp:1058
 msgid "All styles"
 msgstr "सबै शैलीहरू"
 
-#: ../src/propgrid/manager.cpp:1528
+#: ../src/propgrid/manager.cpp:1544
 msgid "Alphabetic Mode"
 msgstr "वर्णीय मुद्रा"
 
-#: ../src/common/xtistrm.cpp:425
+#: ../src/common/xtistrm.cpp:422
 msgid "Already Registered Object passed to SetObjectClassInfo"
 msgstr "पहिले नै दर्ता भएको वस्तु SetObjectClass Info मा पठाइयो ।"
 
-#: ../src/unix/dialup.cpp:353
+#: ../src/unix/dialup.cpp:352
 msgid "Already dialling ISP."
 msgstr "पहिले देखी नै ISP डायल गर्दै छु ।"
 
-#: ../src/common/accelcmn.cpp:331 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/accelcmn.cpp:345 ../src/univ/themes/win32.cpp:3753
 msgid "Alt+"
 msgstr "Alt+"
 
@@ -1311,34 +1308,34 @@ msgstr "Alt+"
 msgid "An optional corner radius for adding rounded corners."
 msgstr "गोलो कोण थप्ने वैकल्पित कोणिय अर्ध व्यास ।"
 
-#: ../src/common/debugrpt.cpp:576
+#: ../src/common/debugrpt.cpp:577
 msgid "And includes the following files:\n"
 msgstr "एवम् निमन लिखित फाइलहरू समावेश गर्छ:\n"
 
-#: ../src/generic/animateg.cpp:162
+#: ../src/generic/animateg.cpp:145
 #, c-format
 msgid "Animation file is not of type %ld."
 msgstr "चलायमान फाइल %ld प्रकृतिको होइन ।"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:872
+#: ../src/propgrid/advprops.cpp:773
 msgid "AppWorkspace"
 msgstr "एपकार्यस्थल"
 
-#: ../src/generic/logg.cpp:1014
+#: ../src/generic/logg.cpp:1011
 #, c-format
 msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
 msgstr "फाइल '%s' मा लग पुस्तिका थपेर लेख ।([NO] छानेमा यसै माथि लेख्ने छ ।"
 
-#: ../src/osx/menu_osx.cpp:577 ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:469 ../src/osx/menu_osx.cpp:477
 msgid "Application"
 msgstr "अनुप्रयोग"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "Apply"
 msgstr "लागू गर"
 
-#: ../src/propgrid/advprops.cpp:1609
+#: ../src/propgrid/advprops.cpp:1515
 msgid "Aqua"
 msgstr "पानी रङ्ग"
 
@@ -1347,29 +1344,29 @@ msgstr "पानी रङ्ग"
 msgid "Arabic"
 msgstr "अरबी"
 
-#: ../src/common/fmapbase.cpp:153
+#: ../src/common/fmapbase.cpp:150
 msgid "Arabic (ISO-8859-6)"
 msgstr "अरबी (ISO-8859-6)"
 
-#: ../src/msw/ole/automtn.cpp:672
+#: ../src/msw/ole/automtn.cpp:663
 #, c-format
 msgid "Argument %u not found."
 msgstr "तर्क %u भेटिएन ।"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1753
+#: ../src/propgrid/advprops.cpp:1654
 msgid "Arrow"
 msgstr "वाण"
 
-#: ../src/generic/aboutdlgg.cpp:184
+#: ../src/generic/aboutdlgg.cpp:181
 msgid "Artists"
 msgstr "कलाकारहरू"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "Ascending"
 msgstr "बढ्दो वर्णानुक्रमिक"
 
-#: ../src/generic/filectrlg.cpp:433
+#: ../src/generic/filectrlg.cpp:429
 msgid "Attributes"
 msgstr "Attributes"
 
@@ -1379,90 +1376,90 @@ msgstr "Attributes"
 msgid "Available fonts."
 msgstr "उपलब्ध वरणाकृतिहरू"
 
-#: ../src/common/paper.cpp:137
+#: ../src/common/paper.cpp:134
 msgid "B4 (ISO) 250 x 353 mm"
 msgstr "B4 (ISO) 250 x 353 मिमी"
 
-#: ../src/common/paper.cpp:173
+#: ../src/common/paper.cpp:170
 msgid "B4 (JIS) Rotated 364 x 257 mm"
 msgstr "B4 (JIS) घुसाइयो 364 x 257 मिमी"
 
-#: ../src/common/paper.cpp:127
+#: ../src/common/paper.cpp:124
 msgid "B4 Envelope, 250 x 353 mm"
 msgstr "B4 खाम, 250 x 353 मिमी"
 
-#: ../src/common/paper.cpp:109
+#: ../src/common/paper.cpp:106
 msgid "B4 sheet, 250 x 354 mm"
 msgstr "B4 शीट, 250 x 354 मिमी"
 
-#: ../src/common/paper.cpp:158
+#: ../src/common/paper.cpp:155
 msgid "B5 (ISO) Extra 201 x 276 mm"
 msgstr "B5 (ISO) Extra 201 x 276 मिमी"
 
-#: ../src/common/paper.cpp:174
+#: ../src/common/paper.cpp:171
 msgid "B5 (JIS) Rotated 257 x 182 mm"
 msgstr "B5 (JIS) Rounded 257 x 182 मिमी"
 
-#: ../src/common/paper.cpp:155
+#: ../src/common/paper.cpp:152
 msgid "B5 (JIS) Transverse 182 x 257 mm"
 msgstr "B5 (JIS) Transverse 182 x 257 मिमी"
 
-#: ../src/common/paper.cpp:128
+#: ../src/common/paper.cpp:125
 msgid "B5 Envelope, 176 x 250 mm"
 msgstr "B5 खाम, 176 x 250 मिमी"
 
-#: ../src/common/paper.cpp:110
+#: ../src/common/paper.cpp:107
 msgid "B5 sheet, 182 x 257 millimeter"
 msgstr "B5 शीट, 182 x 257 millimeter"
 
-#: ../src/common/paper.cpp:182
+#: ../src/common/paper.cpp:179
 msgid "B6 (JIS) 128 x 182 mm"
 msgstr "B6 (JIS) 128 x 182 मिमी"
 
-#: ../src/common/paper.cpp:183
+#: ../src/common/paper.cpp:180
 msgid "B6 (JIS) Rotated 182 x 128 mm"
 msgstr "B6 (JIS) Rounded 182 x 128 मिमी"
 
-#: ../src/common/paper.cpp:129
+#: ../src/common/paper.cpp:126
 msgid "B6 Envelope, 176 x 125 mm"
 msgstr "B6 खाम, 176 x 125 मिमी"
 
-#: ../src/common/imagbmp.cpp:531 ../src/common/imagbmp.cpp:561
-#: ../src/common/imagbmp.cpp:576
+#: ../src/common/imagbmp.cpp:528 ../src/common/imagbmp.cpp:558
+#: ../src/common/imagbmp.cpp:573
 msgid "BMP: Couldn't allocate memory."
 msgstr "BMP: भण्डार उपलब्ध गराउन सकेन ।"
 
-#: ../src/common/imagbmp.cpp:100
+#: ../src/common/imagbmp.cpp:97
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: चित्र गल्ती भएकोले बचत भएन ।"
 
-#: ../src/common/imagbmp.cpp:356
+#: ../src/common/imagbmp.cpp:353
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: RGB रङ्गिन नक्सा लेख्न सकेन"
 
-#: ../src/common/imagbmp.cpp:490
+#: ../src/common/imagbmp.cpp:487
 msgid "BMP: Couldn't write data."
 msgstr "BMP: तथ्याङ्क लेख्न सकिएन ।"
 
-#: ../src/common/imagbmp.cpp:246
+#: ../src/common/imagbmp.cpp:243
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: फाइल (Bitmap) को शीर्षक लेख्न सकिएन ।"
 
-#: ../src/common/imagbmp.cpp:269
+#: ../src/common/imagbmp.cpp:266
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: फाइल (Bitmap जानकारी) शीर्षक लेख्न सकिएन ।"
 
-#: ../src/common/imagbmp.cpp:140
+#: ../src/common/imagbmp.cpp:137
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage को आफ्नै wxPalette छैन ।"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:142 ../src/common/accelcmn.cpp:52
+#: ../src/common/stockitem.cpp:139 ../src/common/accelcmn.cpp:49
 msgid "Back"
 msgstr "पछाडी"
 
+#: ../src/richtext/richtextformatdlg.cpp:377
 #: ../src/richtext/richtextbackgroundpage.cpp:148
-#: ../src/richtext/richtextformatdlg.cpp:384
 msgid "Background"
 msgstr "पृष्ठभूमि"
 
@@ -1470,20 +1467,20 @@ msgstr "पृष्ठभूमि"
 msgid "Background &colour:"
 msgstr "पृष्ठभूमि &रङ्ग:"
 
-#: ../src/osx/carbon/fontdlg.cpp:220
+#: ../src/osx/carbon/fontdlg.cpp:217
 msgid "Background colour"
 msgstr "पृष्ठभूमिको रङ्ग"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:52
+#: ../src/common/accelcmn.cpp:49
 msgid "Backspace"
 msgstr "backspace"
 
-#: ../src/common/fmapbase.cpp:160
+#: ../src/common/fmapbase.cpp:157
 msgid "Baltic (ISO-8859-13)"
 msgstr "Baltic (ISO-8859-13)"
 
-#: ../src/common/fmapbase.cpp:151
+#: ../src/common/fmapbase.cpp:148
 msgid "Baltic (old) (ISO-8859-4)"
 msgstr "Baltic (old) (ISO-8859-4)"
 
@@ -1496,26 +1493,26 @@ msgstr " अनुच्छेद अगाडि:"
 msgid "Bitmap"
 msgstr "Bitmap"
 
-#: ../src/propgrid/advprops.cpp:1594
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Black"
 msgstr "कालो"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1755
+#: ../src/propgrid/advprops.cpp:1656
 msgid "Blank"
 msgstr "रित्तो"
 
-#: ../src/propgrid/advprops.cpp:1603
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Blue"
 msgstr "नीलो"
 
-#: ../src/generic/colrdlgg.cpp:345
+#: ../src/generic/colrdlgg.cpp:365
 #, fuzzy
 msgid "Blue:"
 msgstr "नीलो"
 
-#: ../src/generic/fontdlgg.cpp:333 ../src/richtext/richtextfontpage.cpp:355
-#: ../src/osx/carbon/fontdlg.cpp:354 ../src/common/stockitem.cpp:143
+#: ../src/osx/carbon/fontdlg.cpp:351 ../src/common/stockitem.cpp:140
+#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:355
 msgid "Bold"
 msgstr "मोटो"
 
@@ -1524,31 +1521,35 @@ msgstr "मोटो"
 msgid "Border"
 msgstr "सिमाना"
 
-#: ../src/richtext/richtextformatdlg.cpp:379
+#: ../src/richtext/richtextformatdlg.cpp:372
 msgid "Borders"
 msgstr "सिमानाहरू"
 
-#: ../src/richtext/richtextsizepage.cpp:288 ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141 ../src/richtext/richtextsizepage.cpp:288
 msgid "Bottom"
 msgstr "पुछार"
 
-#: ../src/generic/prntdlgg.cpp:893
+#: ../src/generic/prntdlgg.cpp:886
 msgid "Bottom margin (mm):"
 msgstr "तलको सिमान्त (मिमि):"
 
-#: ../src/richtext/richtextbuffer.cpp:9383
+#: ../src/richtext/richtextbuffer.cpp:9380
 msgid "Box Properties"
 msgstr "बाकसका गुणहरू"
 
-#: ../src/richtext/richtextstyles.cpp:1065
+#: ../src/richtext/richtextstyles.cpp:1062
 msgid "Box styles"
 msgstr "बाकसका शैलीहरू"
 
-#: ../src/propgrid/advprops.cpp:1602
+#: ../src/osx/cocoa/menu.mm:292
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Brown"
 msgstr "खैरो"
 
-#: ../src/common/filepickercmn.cpp:43 ../src/common/filepickercmn.cpp:44
+#: ../src/common/filepickercmn.cpp:40 ../src/common/filepickercmn.cpp:41
 msgid "Browse"
 msgstr "खोतल्ने"
 
@@ -1561,72 +1562,72 @@ msgstr "थोप्लो &पङ्क्तिsवद्धता:"
 msgid "Bullet style"
 msgstr "थोप्ले शैली"
 
-#: ../src/richtext/richtextformatdlg.cpp:359
+#: ../src/richtext/richtextformatdlg.cpp:352
 msgid "Bullets"
 msgstr "थोप्लोहरू"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1756
+#: ../src/propgrid/advprops.cpp:1657
 msgid "Bullseye"
 msgstr "Bullseye"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:875
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonFace"
 msgstr "टाँकचेहरा"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:876
+#: ../src/propgrid/advprops.cpp:777
 msgid "ButtonHighlight"
 msgstr "उज्यालोटाक"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:877
+#: ../src/propgrid/advprops.cpp:778
 msgid "ButtonShadow"
 msgstr "विम्वटाँक"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:878
+#: ../src/propgrid/advprops.cpp:779
 msgid "ButtonText"
 msgstr "टाँकपाठ"
 
-#: ../src/common/paper.cpp:98
+#: ../src/common/paper.cpp:95
 msgid "C sheet, 17 x 22 in"
 msgstr "C शीट, 17 x 22 इन्च"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "C&lear"
 msgstr "&मेटाउ"
 
-#: ../src/generic/fontdlgg.cpp:406
+#: ../src/generic/fontdlgg.cpp:403
 msgid "C&olour:"
 msgstr " &रङ्ग:"
 
-#: ../src/common/paper.cpp:123
+#: ../src/common/paper.cpp:120
 msgid "C3 Envelope, 324 x 458 mm"
 msgstr "C3 खाम, 324 x 458 मिमी"
 
-#: ../src/common/paper.cpp:124
+#: ../src/common/paper.cpp:121
 msgid "C4 Envelope, 229 x 324 mm"
 msgstr "C4 खाम, 229 x 324 मिमी"
 
-#: ../src/common/paper.cpp:122
+#: ../src/common/paper.cpp:119
 msgid "C5 Envelope, 162 x 229 mm"
 msgstr "C5 खाम, 162 x 229 मिमी"
 
-#: ../src/common/paper.cpp:125
+#: ../src/common/paper.cpp:122
 msgid "C6 Envelope, 114 x 162 mm"
 msgstr "C6 खाम, 114 x 162 मिमी"
 
-#: ../src/common/paper.cpp:126
+#: ../src/common/paper.cpp:123
 msgid "C65 Envelope, 114 x 229 mm"
 msgstr "C65 खाम, 114 x 229 मिमी"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "CD-Rom"
 msgstr "CD-Rom"
 
-#: ../src/html/chm.cpp:815 ../src/html/chm.cpp:874
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:865
 msgid "CHM handler currently supports only local files!"
 msgstr "CHM handler ले हाल स्थानीय फाइललाई मात्र समर्थन गर्छ ।"
 
@@ -1634,190 +1635,194 @@ msgstr "CHM handler ले हाल स्थानीय फाइललाई
 msgid "Ca&pitals"
 msgstr "Ca&pitals"
 
-#: ../src/common/cmdproc.cpp:267
+#: ../src/common/cmdproc.cpp:260
 msgid "Can't &Undo "
 msgstr "&उल्टाउन सकिँदैन । "
 
-#: ../src/common/image.cpp:2824
+#: ../src/common/image.cpp:2924
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr "खोज्न नसकिने Input चित्रको बनोट आफै पता लगाउन सकिँदैन ।"
 
-#: ../src/msw/registry.cpp:506
+#: ../src/msw/registry.cpp:495
 #, c-format
 msgid "Can't close registry key '%s'"
 msgstr "registry key '%s' लाइ बन्द गर्न सकिँदैन ।"
 
-#: ../src/msw/registry.cpp:584
+#: ../src/msw/registry.cpp:573
 #, c-format
 msgid "Can't copy values of unsupported type %d."
 msgstr "असमर्थित किसिमको %d मान उतार्न सकिँदैन । "
 
-#: ../src/msw/registry.cpp:487
+#: ../src/msw/registry.cpp:476
 #, c-format
 msgid "Can't create registry key '%s'"
 msgstr "registry कुञ्जी '%s' सिर्जना गर्न सकिँदैन ।"
 
-#: ../src/msw/thread.cpp:665
+#: ../src/msw/thread.cpp:657
 msgid "Can't create thread"
 msgstr "thread सिर्जना गर्न सकिँदैन ।"
 
-#: ../src/msw/window.cpp:3691
-#, c-format
-msgid "Can't create window of class %s"
-msgstr "विन्डो class %s सिर्जना गर्न सकिँदैन ।"
-
-#: ../src/msw/registry.cpp:777
+#: ../src/msw/registry.cpp:765
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "'%s' कुञ्जीलाई मेटाउन सकिँदैन ।"
 
-#: ../src/msw/iniconf.cpp:458
+#: ../src/msw/iniconf.cpp:455
 #, c-format
 msgid "Can't delete the INI file '%s'"
 msgstr "INI फाइल '%s' लाई मेटाउन सकिँदैन ।"
 
-#: ../src/msw/registry.cpp:805
+#: ../src/msw/registry.cpp:793
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "मान '%s' लाई कुञ्जी '%s' बाट मेटाउन सकिँदैन ।"
 
-#: ../src/msw/registry.cpp:1171
+#: ../src/msw/registry.cpp:1159
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "%s' कुञ्जीको उप कुञ्जी लेखाजोखा गर्न सकिँदैन ।"
 
-#: ../src/msw/registry.cpp:1132
+#: ../src/msw/registry.cpp:1120
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "%s' कुञ्जीको मान लेखाजोखा गर्न सकिँदैन ।"
 
-#: ../src/msw/registry.cpp:1389
+#: ../src/msw/registry.cpp:1377
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "%d किसिमको असमर्थित मान निर्यात गर्न सकिँदैन ।"
 
-#: ../src/common/ffile.cpp:254
+#: ../src/common/ffile.cpp:253
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "फाइल '%s' मा चालू स्थान पता लगाउन सकिँदैन ।"
 
-#: ../src/msw/registry.cpp:418
+#: ../src/msw/registry.cpp:407
 #, c-format
 msgid "Can't get info about registry key '%s'"
 msgstr "registry कुञ्जी '%s' को बारेमा जानकारी पाउन सकिँदैन ।"
 
-#: ../src/common/zstream.cpp:346
+#: ../src/msw/webview_ie.cpp:1024
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "thread प्राथमिकता सेट गर्न सकिँदैन ।"
+
+#: ../src/common/zstream.cpp:343
 msgid "Can't initialize zlib deflate stream."
 msgstr "zlib deflate stream लाइ सुरु गर् सकिँदैन ।"
 
-#: ../src/common/zstream.cpp:185
+#: ../src/common/zstream.cpp:182
 msgid "Can't initialize zlib inflate stream."
 msgstr "zlib inflate stream लाइ सुर गर्न सकिँदैन ।"
 
-#: ../src/msw/fswatcher.cpp:476
+#: ../src/msw/fswatcher.cpp:475
 #, c-format
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "परिवर्तनको लागी भनेर हुँदै नभएको घर्रा \"%s\" लाइ अनुगमन गर्न सकिँदैन ।"
 
-#: ../src/msw/registry.cpp:454
+#: ../src/msw/registry.cpp:443
 #, c-format
 msgid "Can't open registry key '%s'"
 msgstr "registry कुञ्जी '%s लाइ खोल्न सकिँदैन ।'"
 
-#: ../src/common/zstream.cpp:252
+#: ../src/common/zstream.cpp:249
 #, c-format
 msgid "Can't read from inflate stream: %s"
 msgstr "inflate stream: %s बाट पढ्न सकिँदैन ।"
 
-#: ../src/common/zstream.cpp:244
+#: ../src/common/zstream.cpp:241
 msgid "Can't read inflate stream: unexpected EOF in underlying stream."
 msgstr "inflate stream पढ्न सकिँदैन: अनपेक्षित रूपले फाइलको अन्तिममा पुगियो ।"
 
-#: ../src/msw/registry.cpp:1064
+#: ../src/msw/registry.cpp:1052
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "'%s' को मान पड्न सकिँदैन ।"
 
-#: ../src/msw/registry.cpp:878 ../src/msw/registry.cpp:910
-#: ../src/msw/registry.cpp:975
+#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
+#: ../src/msw/registry.cpp:963
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "कुञ्जी '%s' को मान पढ्न सकिँदैन ।"
 
-#: ../src/common/image.cpp:2620
+#: ../src/msw/webview_ie.cpp:1017
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/common/image.cpp:2715
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "अज्ञात Extension भएको फाइल '%s' मा चित्र बचत गर्न सकिँदैन ।"
 
-#: ../src/generic/logg.cpp:573 ../src/generic/logg.cpp:976
+#: ../src/generic/logg.cpp:570 ../src/generic/logg.cpp:973
 msgid "Can't save log contents to file."
 msgstr "लग पुस्तिकाका सामाग्रीहरूलाई बचत गर्न सकिँदैन ।"
 
-#: ../src/msw/thread.cpp:629
+#: ../src/msw/thread.cpp:621
 msgid "Can't set thread priority"
 msgstr "thread प्राथमिकता सेट गर्न सकिँदैन ।"
 
-#: ../src/msw/registry.cpp:896 ../src/msw/registry.cpp:938
-#: ../src/msw/registry.cpp:1081
+#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
+#: ../src/msw/registry.cpp:1069
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "'%s' को मान सेट गर्न सकिँदैन ।"
 
-#: ../src/unix/utilsunx.cpp:351
+#: ../src/unix/utilsunx.cpp:353
 msgid "Can't write to child process's stdin"
 msgstr "सीसु प्रक्रिया s stdin मा लेख्न सकिँदैन ।"
 
-#: ../src/common/zstream.cpp:427
+#: ../src/common/zstream.cpp:424
 #, c-format
 msgid "Can't write to deflate stream: %s"
 msgstr "deflate stream: %s मा लेख्न सकिँदैन"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:279 ../src/richtext/richtextstyledlg.cpp:300
-#: ../src/common/stockitem.cpp:145 ../src/common/accelcmn.cpp:71
-#: ../src/msw/msgdlg.cpp:454 ../src/msw/progdlg.cpp:673
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:142
+#: ../src/common/accelcmn.cpp:68 ../src/motif/msgdlg.cpp:196
+#: ../src/gtk1/fontdlg.cpp:144 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/progdlg.cpp:940 ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "रद्द गर"
 
-#: ../src/common/filefn.cpp:1261
+#: ../src/common/filefn.cpp:1149
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "गल्ती '%s' गणना गर्न सकिँदैन ।"
 
-#: ../src/msw/dir.cpp:263
+#: ../src/msw/dir.cpp:260
 #, c-format
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "'%s' घर्रामा भएको गल्ती गणना गर्न सकिँदैन ।"
 
-#: ../src/msw/dialup.cpp:523
+#: ../src/msw/dialup.cpp:517
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "सक्रिय डायलअप जडान फेला पार्न सकिँदैन ।: %s"
 
-#: ../src/msw/dialup.cpp:827
+#: ../src/msw/dialup.cpp:821
 msgid "Cannot find the location of address book file"
 msgstr "ठेगाना किताब फाइलको स्थान फेला पार्न सकिँदैन ।"
 
-#: ../src/msw/ole/automtn.cpp:562
+#: ../src/msw/ole/automtn.cpp:553
 #, c-format
 msgid "Cannot get an active instance of \"%s\""
 msgstr "सक्रिय instance \"%s\" लाइ फेला पार्न सकिँदैन ।"
 
-#: ../src/unix/threadpsx.cpp:1035
+#: ../src/unix/threadpsx.cpp:1053
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "प्राथमिकता तह for कार्यसूची नीति %d पाउन सकिँदैन ।"
 
-#: ../src/unix/utilsunx.cpp:987
+#: ../src/unix/utilsunx.cpp:989
 msgid "Cannot get the hostname"
 msgstr "सत्कार कर्ताको नाम पाउन सकिँदैन ।"
 
-#: ../src/unix/utilsunx.cpp:1023
+#: ../src/unix/utilsunx.cpp:1025
 msgid "Cannot get the official hostname"
 msgstr "अतिरिक्त सत्कार कर्ताको नाम पाउन सकिँदैन ।"
 
-#: ../src/msw/dialup.cpp:928
+#: ../src/msw/dialup.cpp:922
 msgid "Cannot hang up - no active dialup connection."
 msgstr "सक्रिय डायल जडान पाउन सकिँदैन ।"
 
@@ -1825,126 +1830,126 @@ msgstr "सक्रिय डायल जडान पाउन सकिँ�
 msgid "Cannot initialize OLE"
 msgstr "OLE लाइ सुरु गर्न सकिँदैन ।"
 
-#: ../src/common/socket.cpp:853
+#: ../src/common/socket.cpp:850
 msgid "Cannot initialize sockets"
 msgstr "sockets लाइ सुरु गर्न सकिँदैन ।"
 
-#: ../src/msw/volume.cpp:619
+#: ../src/msw/volume.cpp:627
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "'%s' बाट प्रतिमा वहन गर्न सकिँदैन ।"
 
-#: ../src/xrc/xmlres.cpp:360
+#: ../src/xrc/xmlres.cpp:358
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "'%s' बाट श्रोत वहन गर्न सकिँदैन ।"
 
-#: ../src/xrc/xmlres.cpp:742
+#: ../src/xrc/xmlres.cpp:740
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "फाइल '%s' बाट श्रोत वहन गर्न सकिँदैन ।"
 
-#: ../src/html/htmlfilt.cpp:137
+#: ../src/html/htmlfilt.cpp:134
 #, c-format
 msgid "Cannot open HTML document: %s"
 msgstr "HTML कागजात: %s खोल्न सकिँदैन ।"
 
-#: ../src/html/helpdata.cpp:667
+#: ../src/html/helpdata.cpp:660
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "HTML सहयोग किताब: %s लाइ खोल्न सकिँदैन ।"
 
-#: ../src/html/helpdata.cpp:299
+#: ../src/html/helpdata.cpp:296
 #, c-format
 msgid "Cannot open contents file: %s"
 msgstr "विषय सुची फाइल: %s लाइ खोल्न सकिँदैन"
 
-#: ../src/generic/dcpsg.cpp:1667
+#: ../src/generic/dcpsg.cpp:1665
 msgid "Cannot open file for PostScript printing!"
 msgstr "PostScript प्रिन्टिङ गर्न फाइल खोल्न सकिँदैन ।"
 
-#: ../src/html/helpdata.cpp:313
+#: ../src/html/helpdata.cpp:310
 #, c-format
 msgid "Cannot open index file: %s"
 msgstr "अनुक्रमणिका फाइल: %s खोल्न सकिँदैन ।"
 
-#: ../src/xrc/xmlres.cpp:724
+#: ../src/xrc/xmlres.cpp:722
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "श्रोत फाइल '%s' खोल्न सकिँदैन ।"
 
-#: ../src/html/helpwnd.cpp:1534
+#: ../src/html/helpwnd.cpp:1532
 msgid "Cannot print empty page."
 msgstr "खाली पृष्ट छाप्न सकिँदैन ।"
 
-#: ../src/msw/volume.cpp:507
+#: ../src/msw/volume.cpp:515
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "'%s' बाट typename पढ्न सकिँदैन ।"
 
-#: ../src/msw/thread.cpp:888
+#: ../src/msw/thread.cpp:894
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "%lx धागो सुभारम्भ गर्न सकिएन।"
 
-#: ../src/unix/threadpsx.cpp:1016
+#: ../src/unix/threadpsx.cpp:1028
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "thread कार्य सुची नीति प्राप्त गर्न सकिँदैन ।"
 
-#: ../src/common/intl.cpp:558
+#: ../src/common/intl.cpp:365
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "भाषा \"%s\" लाइ स्थानीयतामा सेट गर्न सकिँदैन ।"
 
-#: ../src/unix/threadpsx.cpp:831 ../src/msw/thread.cpp:546
+#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
 msgid "Cannot start thread: error writing TLS."
 msgstr "thread सुरु गर्न सकिँदैन: TLS लेखाइमा गल्ती भयो ।"
 
-#: ../src/msw/thread.cpp:872
+#: ../src/msw/thread.cpp:864
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "%lx धागो निलम्बन गर्न सकिएन ।"
 
-#: ../src/msw/thread.cpp:794
+#: ../src/msw/thread.cpp:786
 msgid "Cannot wait for thread termination"
 msgstr "thread को समाप्ति पर्खन सकिँदैन ।"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:75
+#: ../src/common/accelcmn.cpp:72
 msgid "Capital"
 msgstr "ठूलोवर्ण"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:879
+#: ../src/propgrid/advprops.cpp:780
 msgid "CaptionText"
 msgstr "शिर्षकपाठ"
 
-#: ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:531
 msgid "Case sensitive"
 msgstr "Case सम्बेदनसिल "
 
-#: ../src/propgrid/manager.cpp:1509
+#: ../src/propgrid/manager.cpp:1527
 msgid "Categorized Mode"
 msgstr "निर्दिष्ट मुद्रा"
 
-#: ../src/richtext/richtextbuffer.cpp:9968
+#: ../src/richtext/richtextbuffer.cpp:9965
 msgid "Cell Properties"
 msgstr "कोशिका गुणहरू"
 
-#: ../src/common/fmapbase.cpp:161
+#: ../src/common/fmapbase.cpp:158
 msgid "Celtic (ISO-8859-14)"
 msgstr "Celtic (ISO-8859-14)"
 
-#: ../src/richtext/richtextindentspage.cpp:160
 #: ../src/richtext/richtextliststylepage.cpp:349
+#: ../src/richtext/richtextindentspage.cpp:160
 msgid "Cen&tred"
 msgstr "&केन्द्रित"
 
-#: ../src/common/stockitem.cpp:170
+#: ../src/common/stockitem.cpp:167
 msgid "Centered"
 msgstr "केन्द्र"
 
-#: ../src/common/fmapbase.cpp:149
+#: ../src/common/fmapbase.cpp:146
 msgid "Central European (ISO-8859-2)"
 msgstr "केन्द्रीय युरोपेली (ISO-8859-2)"
 
@@ -1953,10 +1958,10 @@ msgstr "केन्द्रीय युरोपेली (ISO-8859-2)"
 msgid "Centre"
 msgstr "केन्द्र"
 
-#: ../src/richtext/richtextindentspage.cpp:162
-#: ../src/richtext/richtextindentspage.cpp:164
 #: ../src/richtext/richtextliststylepage.cpp:351
 #: ../src/richtext/richtextliststylepage.cpp:353
+#: ../src/richtext/richtextindentspage.cpp:162
+#: ../src/richtext/richtextindentspage.cpp:164
 msgid "Centre text."
 msgstr "बीचको पाठ"
 
@@ -1969,24 +1974,24 @@ msgstr "केन्द्रित"
 msgid "Ch&oose..."
 msgstr "&रोजाई.."
 
-#: ../src/richtext/richtextbuffer.cpp:4354
+#: ../src/richtext/richtextbuffer.cpp:4351
 msgid "Change List Style"
 msgstr "सूचिको शैली परिवर्तन "
 
-#: ../src/richtext/richtextbuffer.cpp:3709
+#: ../src/richtext/richtextbuffer.cpp:3706
 msgid "Change Object Style"
 msgstr "वस्तुको शैली परिवर्तन"
 
-#: ../src/richtext/richtextbuffer.cpp:3982
-#: ../src/richtext/richtextbuffer.cpp:8129
+#: ../src/richtext/richtextbuffer.cpp:3979
+#: ../src/richtext/richtextbuffer.cpp:8125
 msgid "Change Properties"
 msgstr "गुणहरूको परिवर्तन "
 
-#: ../src/richtext/richtextbuffer.cpp:3526
+#: ../src/richtext/richtextbuffer.cpp:3523
 msgid "Change Style"
 msgstr "शैलीको परिवर्तन"
 
-#: ../src/common/fileconf.cpp:341
+#: ../src/common/fileconf.cpp:335
 #, c-format
 msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
 msgstr ""
@@ -1998,11 +2003,11 @@ msgid "Changing current directory to \"%s\" failed"
 msgstr "घर्रा \"%s\" सिर्जना गर्न सकिएन ।"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1757
+#: ../src/propgrid/advprops.cpp:1658
 msgid "Character"
 msgstr "वर्ण"
 
-#: ../src/richtext/richtextstyles.cpp:1063
+#: ../src/richtext/richtextstyles.cpp:1060
 msgid "Character styles"
 msgstr "वर्ण शैलीहरू"
 
@@ -2039,20 +2044,20 @@ msgstr "गोलीलाई कोष्ठ भित्र राख्ने
 msgid "Check to indicate right-to-left text layout."
 msgstr "दाँया देखि वाँया पाठ रुपरेखा जनाउन  टिक लगाउ"
 
-#: ../src/osx/carbon/fontdlg.cpp:356 ../src/osx/carbon/fontdlg.cpp:358
+#: ../src/osx/carbon/fontdlg.cpp:353 ../src/osx/carbon/fontdlg.cpp:355
 msgid "Check to make the font bold."
 msgstr "वरणाकृति मोटो बनाउने हो भने टिक लगाउ"
 
-#: ../src/osx/carbon/fontdlg.cpp:363 ../src/osx/carbon/fontdlg.cpp:365
+#: ../src/osx/carbon/fontdlg.cpp:360 ../src/osx/carbon/fontdlg.cpp:362
 msgid "Check to make the font italic."
 msgstr "वरणाकृति डल्केको बनाउने हो भने टिक लगाउ"
 
-#: ../src/osx/carbon/fontdlg.cpp:372 ../src/osx/carbon/fontdlg.cpp:374
+#: ../src/osx/carbon/fontdlg.cpp:369 ../src/osx/carbon/fontdlg.cpp:371
 msgid "Check to make the font underlined."
 msgstr "वरणाकृति अधोरेखाङ्कित बनाउने हो भने टिक लगाउ"
 
-#: ../src/richtext/richtextstyledlg.cpp:289
-#: ../src/richtext/richtextstyledlg.cpp:291
+#: ../src/richtext/richtextstyledlg.cpp:285
+#: ../src/richtext/richtextstyledlg.cpp:287
 msgid "Check to restart numbering."
 msgstr "फेरि सङ्ख्या सुरु गर्ने हो भने टिक लगाउ"
 
@@ -2086,51 +2091,51 @@ msgstr "टाउकोमा पाठ देखाउने हो भने �
 msgid "Check to suppress hyphenation."
 msgstr "हाइफरनेसन दबाउन टिक लगाउनु होला ।."
 
-#: ../src/msw/dialup.cpp:763
+#: ../src/msw/dialup.cpp:757
 msgid "Choose ISP to dial"
 msgstr "डायल गर्न ISP छान्नु होस्"
 
-#: ../src/propgrid/props.cpp:1922
+#: ../src/propgrid/props.cpp:1904
 msgid "Choose a directory:"
 msgstr "एउटा घर्रा छान्नु होस्:"
 
-#: ../src/propgrid/props.cpp:1975
+#: ../src/propgrid/props.cpp:2199
 msgid "Choose a file"
 msgstr "एउटा फाइल छान्नु होस्"
 
-#: ../src/generic/colrdlgg.cpp:158 ../src/gtk/colordlg.cpp:54
+#: ../src/generic/colrdlgg.cpp:156 ../src/gtk/colordlg.cpp:49
 msgid "Choose colour"
 msgstr "रङ्ग छान्नु होस्"
 
-#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/gtk1/fontdlg.cpp:125 ../src/generic/fontpickerg.cpp:47
+#: ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "वरणाकृति छान्नु होस्"
 
-#: ../src/common/module.cpp:74
+#: ../src/common/module.cpp:71
 #, c-format
 msgid "Circular dependency involving module \"%s\" detected."
 msgstr "चक्री य module \"%s\" पाइयो"
 
-#: ../src/aui/tabmdi.cpp:108 ../src/generic/mdig.cpp:97
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
 msgid "Cl&ose"
 msgstr "&बन्द गर"
 
-#: ../src/msw/ole/automtn.cpp:684
+#: ../src/msw/ole/automtn.cpp:675
 msgid "Class not registered."
 msgstr "Class दर्ता छैन"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:147 ../src/common/accelcmn.cpp:72
+#: ../src/common/stockitem.cpp:144 ../src/common/accelcmn.cpp:69
 msgid "Clear"
 msgstr "मेटाउ"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "Clear the log contents"
 msgstr "लग पुस्तिका का सामाग्रीहरू मेटाउ "
 
-#: ../src/richtext/richtextstyledlg.cpp:252
-#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:248
+#: ../src/richtext/richtextstyledlg.cpp:250
 msgid "Click to apply the selected style."
 msgstr "चयन गरिएको शैली लागू गर्न किटिक्क पार्नु होस्"
 
@@ -2141,15 +2146,15 @@ msgstr "चयन गरिएको शैली लागू गर्न क�
 msgid "Click to browse for a symbol."
 msgstr "चिन्ह खोतल्न किटिक्क पार्नु होस"
 
-#: ../src/osx/carbon/fontdlg.cpp:403 ../src/osx/carbon/fontdlg.cpp:405
+#: ../src/osx/carbon/fontdlg.cpp:400 ../src/osx/carbon/fontdlg.cpp:402
 msgid "Click to cancel changes to the font."
 msgstr "वरणाकृति परिवर्तन रद्द गर्न किटिक्क पार्नु होस्"
 
-#: ../src/generic/fontdlgg.cpp:472 ../src/generic/fontdlgg.cpp:491
+#: ../src/generic/fontdlgg.cpp:468 ../src/generic/fontdlgg.cpp:487
 msgid "Click to cancel the font selection."
 msgstr "वरणाकृतिको चयन रद्द गर्न किटिक्क पार्नु होस्"
 
-#: ../src/osx/carbon/fontdlg.cpp:384 ../src/osx/carbon/fontdlg.cpp:386
+#: ../src/osx/carbon/fontdlg.cpp:381 ../src/osx/carbon/fontdlg.cpp:383
 msgid "Click to change the font colour."
 msgstr "वरणाकृतिको रङ्ग फेर्न किटिक्क पार्नु होस्"
 
@@ -2168,37 +2173,37 @@ msgstr "पाठको रङ्ग फेर्न किटिक्क प�
 msgid "Click to choose the font for this level."
 msgstr "यो तहमा वरणाकृति छान्न किटिक्क पार्नु होस्"
 
-#: ../src/richtext/richtextstyledlg.cpp:279
-#: ../src/richtext/richtextstyledlg.cpp:281
+#: ../src/richtext/richtextstyledlg.cpp:275
+#: ../src/richtext/richtextstyledlg.cpp:277
 msgid "Click to close this window."
 msgstr "यो विन्डो बन्द गर्न किटिक्क पार्नु होस्"
 
-#: ../src/osx/carbon/fontdlg.cpp:410 ../src/osx/carbon/fontdlg.cpp:412
+#: ../src/osx/carbon/fontdlg.cpp:407 ../src/osx/carbon/fontdlg.cpp:409
 msgid "Click to confirm changes to the font."
 msgstr "वरणाकृति परिवर्तन यकिन गर्न किटिक्क पार्नु होस्"
 
-#: ../src/generic/fontdlgg.cpp:477 ../src/generic/fontdlgg.cpp:479
-#: ../src/generic/fontdlgg.cpp:484 ../src/generic/fontdlgg.cpp:486
+#: ../src/generic/fontdlgg.cpp:473 ../src/generic/fontdlgg.cpp:475
+#: ../src/generic/fontdlgg.cpp:480 ../src/generic/fontdlgg.cpp:482
 msgid "Click to confirm the font selection."
 msgstr "वरणाकृतिको चयन यकिन गर्न किटिक्क पार्नु होस्"
 
-#: ../src/richtext/richtextstyledlg.cpp:244
-#: ../src/richtext/richtextstyledlg.cpp:246
+#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:242
 msgid "Click to create a new box style."
 msgstr "नया बाकस शैली सिर्जना गर्न किटिक्क पार्नु होस्"
 
-#: ../src/richtext/richtextstyledlg.cpp:226
-#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:224
 msgid "Click to create a new character style."
 msgstr "नया वर्ण शैली सिर्जना गर्न किटिक्क पार्नु होस्"
 
-#: ../src/richtext/richtextstyledlg.cpp:238
-#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:236
 msgid "Click to create a new list style."
 msgstr "Click to create a नया सूचि शैली सिर्जना गर्न किटिक्क पार्नु होस्"
 
-#: ../src/richtext/richtextstyledlg.cpp:232
-#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:230
 msgid "Click to create a new paragraph style."
 msgstr "नया अनुच्छेद शैली सिर्जना गर्न किटिक्क पार्नु होस्"
 
@@ -2212,8 +2217,8 @@ msgstr "नया tab स्थान सिर्जना गर्न कि�
 msgid "Click to delete all tab positions."
 msgstr "सबै tab स्थानहरू मेटाउन किटिक्क पार्नु होस्"
 
-#: ../src/richtext/richtextstyledlg.cpp:270
-#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:268
 msgid "Click to delete the selected style."
 msgstr "चयन गरेको शैली मेटाउन किटिक्क पार्नु होस्"
 
@@ -2222,25 +2227,25 @@ msgstr "चयन गरेको शैली मेटाउन किटि�
 msgid "Click to delete the selected tab position."
 msgstr "चयन गरेको tab स्थान मेटाउन किटिक्क पार्नु होस्"
 
-#: ../src/richtext/richtextstyledlg.cpp:264
-#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:262
 msgid "Click to edit the selected style."
 msgstr "चयन गरेको शैली सम्पादन गर्न किटिक्क पार्नु होस्"
 
-#: ../src/richtext/richtextstyledlg.cpp:258
-#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:256
 msgid "Click to rename the selected style."
 msgstr "चयन गरेको शैलीको नाम फेर्न किटिक्क पार्नु होस्"
 
-#: ../src/generic/dbgrptg.cpp:97 ../src/generic/progdlgg.cpp:759
-#: ../src/richtext/richtextstyledlg.cpp:277
-#: ../src/richtext/richtextsymboldlg.cpp:476 ../src/common/stockitem.cpp:148
-#: ../src/msw/progdlg.cpp:170 ../src/msw/progdlg.cpp:679
-#: ../src/html/helpdlg.cpp:90
+#: ../src/common/stockitem.cpp:145 ../src/generic/dbgrptg.cpp:94
+#: ../src/generic/progdlgg.cpp:781 ../src/msw/progdlg.cpp:211
+#: ../src/msw/progdlg.cpp:946 ../src/html/helpdlg.cpp:87
+#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextstyledlg.cpp:273
 msgid "Close"
 msgstr "बन्द गर"
 
-#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:98
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
 msgid "Close All"
 msgstr "सबै बन्द गर "
 
@@ -2248,55 +2253,55 @@ msgstr "सबै बन्द गर "
 msgid "Close current document"
 msgstr "चालू कागजात बन्द गर "
 
-#: ../src/generic/logg.cpp:516
+#: ../src/generic/logg.cpp:513
 msgid "Close this window"
 msgstr "यो विन्डो बन्द गर "
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6006
+#: ../src/generic/datavgen.cpp:6811
 msgid "Collapse"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "Color"
 msgstr "रङ्ग"
 
-#: ../src/richtext/richtextformatdlg.cpp:776
+#: ../src/richtext/richtextformatdlg.cpp:768
 msgid "Colour"
 msgstr "रङ्ग"
 
-#: ../src/msw/colordlg.cpp:158
+#: ../src/msw/colordlg.cpp:227
 #, c-format
 msgid "Colour selection dialog failed with error %0lx."
 msgstr "रङ्ग चयन पातो %0lx गल्तीले गर्दा असफल भयो ।"
 
-#: ../src/osx/carbon/fontdlg.cpp:380
+#: ../src/osx/carbon/fontdlg.cpp:377
 msgid "Colour:"
 msgstr "रङ्ग:"
 
-#: ../src/generic/datavgen.cpp:6077
+#: ../src/generic/datavgen.cpp:6882
 #, fuzzy, c-format
 msgid "Column %u"
 msgstr "महल थप"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:114
+#: ../src/common/accelcmn.cpp:112
 msgid "Command"
 msgstr "आदेश"
 
-#: ../src/common/init.cpp:196
+#: ../src/common/init.cpp:193
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
 "ignored."
 msgstr "आदेश लाइन argument %d लाई युनिकोडमा फेर्न नसकि एकोले बेवास्ता गरियो ।"
 
-#: ../src/msw/fontdlg.cpp:120
+#: ../src/msw/fontdlg.cpp:170
 #, c-format
 msgid "Common dialog failed with error code %0lx."
 msgstr "गल्ती कोड %0lx ले गर्दा साझा पातो असफल भयो ।"
 
-#: ../src/gtk/window.cpp:4649
+#: ../src/gtk/window.cpp:5653
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
@@ -2304,11 +2309,11 @@ msgstr ""
 "यो प्रणालीले क्षतिपूर्ति लाइ समर्थन गर्दैन । कृपया तपाइको विन्डो व्यवस्थापकमा यसलाई सक्षम "
 "बनाउनु होस् "
 
-#: ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:1549
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "खाँदिएको HTML सहयोग फाइल (*.chm)|*.chm|"
 
-#: ../src/generic/dirctrlg.cpp:444
+#: ../src/generic/dirctrlg.cpp:410
 msgid "Computer"
 msgstr "कम्प्युटर"
 
@@ -2317,53 +2322,57 @@ msgstr "कम्प्युटर"
 msgid "Config entry name cannot start with '%c'."
 msgstr "Config प्रविष्टि नाम '%c' सित सुरु हुँदैन"
 
-#: ../src/generic/filedlgg.cpp:349 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
 msgid "Confirm"
 msgstr "यकिन गर्नु होस्"
 
-#: ../src/html/htmlwin.cpp:566
+#: ../src/html/htmlwin.cpp:569
 msgid "Connecting..."
 msgstr "जोड्दै छु"
 
-#: ../src/html/helpwnd.cpp:475
+#: ../src/html/helpwnd.cpp:473
 msgid "Contents"
 msgstr "सामाग्रीहरू"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:880
+#: ../src/propgrid/advprops.cpp:781
 msgid "ControlDark"
 msgstr "अध्यारोनियन्त्रण"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:881
+#: ../src/propgrid/advprops.cpp:782
 msgid "ControlLight"
 msgstr "उज्यालोनियन्त्रण"
 
-#: ../src/common/strconv.cpp:2262
+#: ../src/common/strconv.cpp:2208
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "वर्ण समूह '%s' मा परिवर्तन हुन सक्दैन"
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "Convert"
 msgstr "बदलि देउ"
 
-#: ../src/html/htmlwin.cpp:1079
+#: ../src/html/htmlwin.cpp:1020
 #, c-format
 msgid "Copied to clipboard:\"%s\""
 msgstr "क्लिप पाटीमा उतारियो:\"%s\""
 
-#: ../src/generic/prntdlgg.cpp:247
+#: ../src/generic/prntdlgg.cpp:240
 msgid "Copies:"
 msgstr "प्रतिहरू:"
 
-#: ../src/common/stockitem.cpp:150 ../src/stc/stc_i18n.cpp:18
+#: ../src/common/stockitem.cpp:147 ../src/stc/stc_i18n.cpp:18
 msgid "Copy"
 msgstr "नक्कल उतार"
 
-#: ../src/common/stockitem.cpp:258
+#: ../src/common/stockitem.cpp:255
 msgid "Copy selection"
 msgstr "चयनको नक्कल उतार "
+
+#: ../src/generic/grid.cpp:5945
+msgid "Copying more than one selected block to clipboard is not supported."
+msgstr ""
 
 #: ../src/richtext/richtextborderspage.cpp:566
 #: ../src/richtext/richtextborderspage.cpp:601
@@ -2374,196 +2383,192 @@ msgstr "कोण"
 msgid "Corner &radius:"
 msgstr "कोण र अर्धव्यास:"
 
-#: ../src/html/chm.cpp:718
+#: ../src/html/chm.cpp:711
 #, c-format
 msgid "Could not create temporary file '%s'"
 msgstr "अस्ताइ फाइल '%s' सिर्जना गर्न सकिएन "
 
-#: ../src/html/chm.cpp:273
+#: ../src/html/chm.cpp:270
 #, c-format
 msgid "Could not extract %s into %s: %s"
 msgstr "%s लाई %s मा तान्न सकिएन: %s"
 
-#: ../src/generic/tabg.cpp:1048
+#: ../src/generic/tabg.cpp:1045
 msgid "Could not find tab for id"
 msgstr "ID का लागि tab फेला परेन"
 
-#: ../src/gtk/notifmsg.cpp:108
-#, fuzzy
-msgid "Could not initalize libnotify."
-msgstr "पङ्क्ति बद्धता तय गर्न सकिएन"
-
-#: ../src/html/chm.cpp:444
+#: ../src/html/chm.cpp:437
 #, c-format
 msgid "Could not locate file '%s'."
 msgstr "फाइल '%s' पत्तो लागेन"
 
-#: ../src/common/filefn.cpp:1403
+#: ../src/msw/graphicsd2d.cpp:604
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/common/filefn.cpp:1291
 msgid "Could not set current working directory"
 msgstr "चालू अवस्थामा रहेको घर्रा तय गर्न सकिएन"
 
-#: ../src/common/prntbase.cpp:2015
+#: ../src/common/prntbase.cpp:2037
 msgid "Could not start document preview."
 msgstr "कागजातको चेहरा सुरु गर्न सकिएन"
 
-#: ../src/generic/printps.cpp:178 ../src/msw/printwin.cpp:210
-#: ../src/gtk/print.cpp:1132
+#: ../src/generic/printps.cpp:159 ../src/msw/printwin.cpp:184
+#: ../src/gtk/print.cpp:1129
 msgid "Could not start printing."
 msgstr "प्रिन्टिङ सुरु गर्न सकिएन"
 
-#: ../src/common/wincmn.cpp:2125
+#: ../src/common/wincmn.cpp:2126
 msgid "Could not transfer data to window"
 msgstr "विन्डोमा तथ्याङ्क सार्न सकिएन"
 
-#: ../src/msw/imaglist.cpp:187 ../src/msw/imaglist.cpp:224
-#: ../src/msw/imaglist.cpp:249 ../src/msw/dragimag.cpp:185
-#: ../src/msw/dragimag.cpp:220
+#: ../src/msw/imaglist.cpp:223 ../src/msw/imaglist.cpp:245
+#: ../src/msw/imaglist.cpp:270 ../src/msw/dragimag.cpp:182
+#: ../src/msw/dragimag.cpp:217
 msgid "Couldn't add an image to the image list."
 msgstr "तस्विर सुचीमा तस्विर थप्न सकिएन"
 
-#: ../src/osx/glcanvas_osx.cpp:414 ../src/unix/glx11.cpp:558
-#: ../src/msw/glcanvas.cpp:616
+#: ../src/osx/glcanvas_osx.cpp:411 ../src/msw/glcanvas.cpp:631
+#: ../src/unix/glegl.cpp:315 ../src/unix/glx11.cpp:559
 #, fuzzy
 msgid "Couldn't create OpenGL context"
 msgstr "टाइम र सिर्जना गर्न सकिएन"
 
-#: ../src/msw/timer.cpp:134
+#: ../src/msw/timer.cpp:131
 msgid "Couldn't create a timer"
 msgstr "टाइम र सिर्जना गर्न सकिएन"
 
-#: ../src/osx/carbon/overlay.cpp:122
-msgid "Couldn't create the overlay window"
-msgstr "खप्टिएको विन्डो सिर्जना गर्न सकिएन"
-
-#: ../src/common/translation.cpp:2024
+#: ../src/common/translation.cpp:2074
 msgid "Couldn't enumerate translations"
 msgstr "अनुवाद को लेखाजोखा गर्न सकिएन"
 
-#: ../src/common/dynlib.cpp:120
+#: ../src/common/dynlib.cpp:110
 #, c-format
 msgid "Couldn't find symbol '%s' in a dynamic library"
 msgstr "चिन्ह '%s' गतिसित पुस्तकालयमा पाउन सकिएन"
 
-#: ../src/msw/thread.cpp:915
+#: ../src/msw/thread.cpp:921
 msgid "Couldn't get the current thread pointer"
 msgstr "चालू thread Adder पाउन सकिएन"
 
-#: ../src/osx/carbon/overlay.cpp:129
-msgid "Couldn't init the context on the overlay window"
-msgstr "खप्टिएको विन्डोका सामाग्री पाउन सकिएन"
-
-#: ../src/common/imaggif.cpp:244
+#: ../src/common/imaggif.cpp:241
 msgid "Couldn't initialize GIF hash table."
 msgstr "GIF hash तालिका सुरु गर्न सकिएन"
 
-#: ../src/common/imagpng.cpp:409
+#: ../src/common/imagpng.cpp:437
 msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
 msgstr "PNG तस्विर- फाइल बिग्रिएको छ अथवा चाहिने जति भण्डार छैन"
 
-#: ../src/unix/sound.cpp:470
+#: ../src/unix/sound.cpp:459
 #, c-format
 msgid "Couldn't load sound data from '%s'."
 msgstr "आवाज '%s' को तथ्याङ्क वहन गर्न सकिएन"
 
-#: ../src/msw/dirdlg.cpp:435
+#: ../src/msw/dirdlg.cpp:287
 msgid "Couldn't obtain folder name"
 msgstr "थैलीको नाम पाउनसकिएन"
 
-#: ../src/unix/sound_sdl.cpp:229
+#: ../src/unix/sound_sdl.cpp:226
 #, c-format
 msgid "Couldn't open audio: %s"
 msgstr "श्रव्य हटाउन सकिएन: %s"
 
-#: ../src/msw/ole/dataobj.cpp:377
+#: ../src/msw/ole/dataobj.cpp:385
 #, c-format
 msgid "Couldn't register clipboard format '%s'."
 msgstr "क्लिप पाटीको स्वरूप '%s' दर्ता गर्न सकिएन"
 
-#: ../src/msw/listctrl.cpp:869
+#: ../src/msw/listctrl.cpp:933
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "सूचि नियन्त्रण सामाग्री %d को बारेमा सूचना पाउन सकिएन "
 
-#: ../src/common/imagpng.cpp:498 ../src/common/imagpng.cpp:509
-#: ../src/common/imagpng.cpp:519
+#: ../src/common/imagpng.cpp:511 ../src/common/imagpng.cpp:522
+#: ../src/common/imagpng.cpp:532
 msgid "Couldn't save PNG image."
 msgstr "PNG तस्विर बचत गर्न सकिएन"
 
-#: ../src/msw/thread.cpp:684
+#: ../src/msw/thread.cpp:676
 msgid "Couldn't terminate thread"
 msgstr "thread बन्द गर्न सकिएन"
 
-#: ../src/common/xtistrm.cpp:166
+#: ../src/common/xtistrm.cpp:163
 #, c-format
 msgid "Create Parameter %s not found in declared RTTI Parameters"
 msgstr "%s मापकहरूको सिर्जना घोषित RTTI मापकमा पाइ एन "
 
-#: ../src/generic/dirdlgg.cpp:288
+#: ../src/generic/dirdlgg.cpp:285
 msgid "Create directory"
 msgstr "घर्राको सिर्जना गर्नु होस्"
 
-#: ../src/generic/filedlgg.cpp:212 ../src/generic/dirdlgg.cpp:111
+#: ../src/generic/filedlgg.cpp:209 ../src/generic/dirdlgg.cpp:108
 msgid "Create new directory"
 msgstr "नया घर्राको सिर्जना गर्नु होस्"
 
-#: ../src/xrc/xmlres.cpp:2460
+#: ../src/common/stockitem.cpp:264
+#, fuzzy
+msgid "Create new document"
+msgstr "नया घर्राको सिर्जना गर्नु होस्"
+
+#: ../src/xrc/xmlres.cpp:2515
 #, fuzzy, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "'%s' लाई '%s' मा खिच्ने काम असफल भयो ।"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1758
+#: ../src/propgrid/advprops.cpp:1659
 msgid "Cross"
 msgstr "क्रस"
 
-#: ../src/common/accelcmn.cpp:333
+#: ../src/common/accelcmn.cpp:347
 msgid "Ctrl+"
 msgstr "Ctrl+"
 
-#: ../src/richtext/richtextctrl.cpp:332 ../src/osx/textctrl_osx.cpp:576
-#: ../src/common/stockitem.cpp:151 ../src/msw/textctrl.cpp:2507
+#: ../src/osx/textctrl_osx.cpp:594 ../src/common/stockitem.cpp:148
+#: ../src/msw/textctrl.cpp:2772 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "&काट्नु होस्"
 
-#: ../src/generic/filectrlg.cpp:940
+#: ../src/generic/filectrlg.cpp:936
 msgid "Current directory:"
 msgstr "चालू घर्रा:"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:896 ../src/propgrid/advprops.cpp:1574
-#: ../src/propgrid/advprops.cpp:1612
+#: ../src/propgrid/advprops.cpp:797 ../src/propgrid/advprops.cpp:1475
+#: ../src/propgrid/advprops.cpp:1518
 msgid "Custom"
 msgstr "प्रचलित"
 
-#: ../src/gtk/print.cpp:217
+#: ../src/gtk/print.cpp:211
 msgid "Custom size"
 msgstr "चल्तीको आकार"
 
-#: ../src/common/headerctrlcmn.cpp:60
+#: ../src/common/headerctrlcmn.cpp:58
 msgid "Customize Columns"
 msgstr "आफ्नो अनुकूलको महल बनाउ "
 
-#: ../src/common/stockitem.cpp:151 ../src/stc/stc_i18n.cpp:17
+#: ../src/common/stockitem.cpp:148 ../src/stc/stc_i18n.cpp:17
 msgid "Cut"
 msgstr "काट"
 
-#: ../src/common/stockitem.cpp:259
+#: ../src/common/stockitem.cpp:256
 msgid "Cut selection"
 msgstr "चयन काट"
 
-#: ../src/common/fmapbase.cpp:152
+#: ../src/common/fmapbase.cpp:149
 msgid "Cyrillic (ISO-8859-5)"
 msgstr "Cyrillic (ISO-8859-5)"
 
-#: ../src/common/paper.cpp:99
+#: ../src/common/paper.cpp:96
 msgid "D sheet, 22 x 34 in"
 msgstr "D शीट, 22 x 34इन्च"
 
-#: ../src/msw/dde.cpp:703
+#: ../src/msw/dde.cpp:698
 msgid "DDE poke request failed"
 msgstr "DDE poke अनुरोध असफल भयो"
 
-#: ../src/common/imagbmp.cpp:1169
+#: ../src/common/imagbmp.cpp:1181
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr "DIB शीर्षक: अनुसंहिता bitdepth सित मिल्दैन "
 
@@ -2583,7 +2588,7 @@ msgstr "DIB शीर्षक: फाइलमा अज्ञात bitdepth "
 msgid "DIB Header: Unknown encoding in file."
 msgstr "DIB शीर्षक: फाइलमा अज्ञात अनुसंहिता"
 
-#: ../src/common/paper.cpp:121
+#: ../src/common/paper.cpp:118
 msgid "DL Envelope, 110 x 220 mm"
 msgstr "DL खाम, 110 x 220 मिमी"
 
@@ -2591,53 +2596,53 @@ msgstr "DL खाम, 110 x 220 मिमी"
 msgid "Dashed"
 msgstr "Dashed"
 
-#: ../src/generic/dbgrptg.cpp:300
+#: ../src/generic/dbgrptg.cpp:301
 #, c-format
 msgid "Debug report \"%s\""
 msgstr "खान तलासी प्रतिवेदन \"%s\" "
 
-#: ../src/common/debugrpt.cpp:210
+#: ../src/common/debugrpt.cpp:211
 msgid "Debug report couldn't be created."
 msgstr "खानतलासी प्रतिवेदन सिर्जना गर्न सकिएन"
 
-#: ../src/common/debugrpt.cpp:553
+#: ../src/common/debugrpt.cpp:554
 msgid "Debug report generation has failed."
 msgstr "खानतलासी प्रतिवेदन तयारी असफल भयो ।"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:84
+#: ../src/common/accelcmn.cpp:81
 msgid "Decimal"
 msgstr "दशमलव"
 
-#: ../src/generic/fontdlgg.cpp:323
+#: ../src/generic/fontdlgg.cpp:319
 msgid "Decorative"
 msgstr "श्रृङ्गार युक्त"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1752
+#: ../src/propgrid/advprops.cpp:1653
 msgid "Default"
 msgstr "निर्धारित"
 
-#: ../src/common/fmapbase.cpp:796
+#: ../src/common/fmapbase.cpp:792
 msgid "Default encoding"
 msgstr "निर्धारित अनुसंहिता"
 
-#: ../src/dfb/fontmgr.cpp:180
+#: ../src/dfb/fontmgr.cpp:177
 msgid "Default font"
 msgstr "निर्धारित वरणाकृति"
 
-#: ../src/generic/prntdlgg.cpp:510
+#: ../src/generic/prntdlgg.cpp:503
 msgid "Default printer"
 msgstr "निर्धारित प्रिन्टर"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:51
+#: ../src/common/accelcmn.cpp:48
 msgid "Del"
 msgstr "DEL"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextbuffer.cpp:8221 ../src/common/stockitem.cpp:152
-#: ../src/common/accelcmn.cpp:50 ../src/stc/stc_i18n.cpp:20
+#: ../src/common/stockitem.cpp:149 ../src/common/accelcmn.cpp:47
+#: ../src/richtext/richtextbuffer.cpp:8217 ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "मेटाइ देउ"
 
@@ -2645,68 +2650,68 @@ msgstr "मेटाइ देउ"
 msgid "Delete A&ll"
 msgstr "&सबै मेटाइ देउ "
 
-#: ../src/richtext/richtextbuffer.cpp:11341
+#: ../src/richtext/richtextbuffer.cpp:11340
 msgid "Delete Column"
 msgstr "महल हटाउ"
 
-#: ../src/richtext/richtextbuffer.cpp:11291
+#: ../src/richtext/richtextbuffer.cpp:11290
 msgid "Delete Row"
 msgstr "हरफ हटाउ"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 msgid "Delete Style"
 msgstr "शैली मेटाइ देउ "
 
-#: ../src/richtext/richtextctrl.cpp:1345 ../src/richtext/richtextctrl.cpp:1584
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
 msgid "Delete Text"
 msgstr "पाठ मेटाइ देउ "
 
-#: ../src/generic/editlbox.cpp:170
+#: ../src/generic/editlbox.cpp:147
 msgid "Delete item"
 msgstr "सामाग्री मेटाइ देउ "
 
-#: ../src/common/stockitem.cpp:260
+#: ../src/common/stockitem.cpp:257
 msgid "Delete selection"
 msgstr "चयन मेटाइ देउ "
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 #, c-format
 msgid "Delete style %s?"
 msgstr "शैली %s मेटाउने हो?"
 
-#: ../src/unix/snglinst.cpp:301
+#: ../src/unix/snglinst.cpp:298
 #, c-format
 msgid "Deleted stale lock file '%s'."
 msgstr "बासी चाबी फाइल '%s'. हटाइयो ।"
 
-#: ../src/common/secretstore.cpp:220
+#: ../src/common/secretstore.cpp:234
 #, fuzzy, c-format
-msgid "Deleting password for \"%s/%s\" failed: %s."
+msgid "Deleting password for \"%s\" failed: %s."
 msgstr "'%s' लाई '%s' मा खिच्ने काम असफल भयो ।"
 
-#: ../src/common/module.cpp:124
+#: ../src/common/module.cpp:121
 #, c-format
 msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
 msgstr "आश्रय \"%s\" मोड्युल \"%s\" मा छदै छैन"
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "Descending"
 msgstr "घट्दो क्रममा वर्णानुक्रमिक"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:526 ../src/propgrid/advprops.cpp:882
+#: ../src/generic/dirctrlg.cpp:492 ../src/propgrid/advprops.cpp:783
 msgid "Desktop"
 msgstr "डेस्कटप"
 
-#: ../src/generic/aboutdlgg.cpp:70
+#: ../src/generic/aboutdlgg.cpp:67
 msgid "Developed by "
 msgstr "विकास कर्ता"
 
-#: ../src/generic/aboutdlgg.cpp:176
+#: ../src/generic/aboutdlgg.cpp:173
 msgid "Developers"
 msgstr "विकास कर्मी"
 
-#: ../src/msw/dialup.cpp:374
+#: ../src/msw/dialup.cpp:368
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -2714,11 +2719,11 @@ msgstr ""
 "यो कम्प्युटरमा दूर पहुँच सेवा (RAS) स्थापना नघरैकोले डायल सेवा उपलब्ध हुन सकेन । कृपया "
 "यसलाई स्थापना गर्नु होला ।"
 
-#: ../src/generic/tipdlg.cpp:211
+#: ../src/generic/tipdlg.cpp:208
 msgid "Did you know..."
 msgstr "के तपाइलाई थाहा छ?"
 
-#: ../src/dfb/wrapdfb.cpp:63
+#: ../src/dfb/wrapdfb.cpp:60
 #, c-format
 msgid "DirectFB error %d occurred."
 msgstr "DirectFB %d गल्ती हुन पुग्यो ।"
@@ -2727,29 +2732,29 @@ msgstr "DirectFB %d गल्ती हुन पुग्यो ।"
 msgid "Directories"
 msgstr "घर्रा"
 
-#: ../src/common/filefn.cpp:1183
+#: ../src/common/filefn.cpp:1071
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "'%s' घर्रा सिर्जना गर्न सकिएन ।"
 
-#: ../src/common/filefn.cpp:1197
+#: ../src/common/filefn.cpp:1085
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "'%s' घर्रा मेटाउन सकिएन ।"
 
-#: ../src/generic/dirdlgg.cpp:204
+#: ../src/generic/dirdlgg.cpp:201
 msgid "Directory does not exist"
 msgstr "घर्रा छदै छैन"
 
-#: ../src/generic/filectrlg.cpp:1399
+#: ../src/generic/filectrlg.cpp:1388
 msgid "Directory doesn't exist."
 msgstr "घर्रा छदै छैन"
 
-#: ../src/common/docview.cpp:457
+#: ../src/common/docview.cpp:450
 msgid "Discard changes and reload the last saved version?"
 msgstr "के परिवर्तन लाई त्यागेर अन्तिम बचत संस्करणलाई वहन गर्ने हो?"
 
-#: ../src/html/helpwnd.cpp:502
+#: ../src/html/helpwnd.cpp:500
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -2757,45 +2762,45 @@ msgstr ""
 "प्रदान गरिएको शब्द भएका सबै अनुसूची लाई देखाउ । खोज तलासले ठूलो वा सानो वर्णको वास्ता "
 "गर्दैन । "
 
-#: ../src/html/helpwnd.cpp:679
+#: ../src/html/helpwnd.cpp:677
 msgid "Display options dialog"
 msgstr "विकल्प पातो देखाउ"
 
-#: ../src/html/helpwnd.cpp:322
+#: ../src/html/helpwnd.cpp:320
 msgid "Displays help as you browse the books on the left."
 msgstr "किताब पल्टाउँदा देब्रे पट्टि सहयोग देखाउँछ "
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:85
+#: ../src/common/accelcmn.cpp:83
 msgid "Divide"
 msgstr "विभाजन"
 
-#: ../src/common/docview.cpp:533
+#: ../src/common/docview.cpp:526
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "के तपाइ %s मा परिवर्तन लाई बचत गर्न चाहनु हुन्छ?"
 
-#: ../src/common/prntbase.cpp:542
+#: ../src/common/prntbase.cpp:537
 msgid "Document:"
 msgstr "कागजात"
 
-#: ../src/generic/aboutdlgg.cpp:73
+#: ../src/generic/aboutdlgg.cpp:70
 msgid "Documentation by "
 msgstr "अभिलेखन कर्ता"
 
-#: ../src/generic/aboutdlgg.cpp:180
+#: ../src/generic/aboutdlgg.cpp:177
 msgid "Documentation writers"
 msgstr "कागजातहरूका लेखकहरू"
 
-#: ../src/common/sizer.cpp:2799
+#: ../src/common/sizer.cpp:2916
 msgid "Don't Save"
 msgstr "बचत नगर"
 
-#: ../src/html/htmlwin.cpp:633
+#: ../src/html/htmlwin.cpp:643
 msgid "Done"
 msgstr "सकियो"
 
-#: ../src/generic/progdlgg.cpp:448 ../src/msw/progdlg.cpp:407
+#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
 msgid "Done."
 msgstr "सकियो"
 
@@ -2807,42 +2812,42 @@ msgstr "थोप्लो थोप्लो"
 msgid "Double"
 msgstr "दुई वटा"
 
-#: ../src/common/paper.cpp:176
+#: ../src/common/paper.cpp:173
 msgid "Double Japanese Postcard Rotated 148 x 200 mm"
 msgstr "दोबर जापानी गोलो पोस्टकार्ड 148 x 200 मिमी"
 
-#: ../src/common/xtixml.cpp:273
+#: ../src/common/xtixml.cpp:269
 #, c-format
 msgid "Doubly used id : %d"
 msgstr "दोहोरिएर प्रयोग भएको id : %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:153
-#: ../src/common/accelcmn.cpp:64
+#: ../src/common/stockitem.cpp:150 ../src/common/accelcmn.cpp:61
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Down"
 msgstr "तल"
 
-#: ../src/richtext/richtextctrl.cpp:865
+#: ../src/richtext/richtextctrl.cpp:864
 msgid "Drag"
 msgstr "घिसार्नू"
 
-#: ../src/common/paper.cpp:100
+#: ../src/common/paper.cpp:97
 msgid "E sheet, 34 x 44 in"
 msgstr "E शीट, 34 x 44इन्च"
 
-#: ../src/unix/fswatcher_inotify.cpp:561
+#: ../src/unix/fswatcher_inotify.cpp:558
 msgid "EOF while reading from inotify descriptor"
 msgstr "inotify ब्याख्याकारबाट पढ्दा फाइलको अन्तमा पुगियो । "
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "Edit"
 msgstr "सम्पादन"
 
-#: ../src/generic/editlbox.cpp:168
+#: ../src/generic/editlbox.cpp:131
 msgid "Edit item"
 msgstr "सम्पादन सामाग्री"
 
-#: ../include/wx/generic/progdlgg.h:84
+#: ../include/wx/generic/progdlgg.h:85
 msgid "Elapsed time:"
 msgstr "गुज्रिएको समय:"
 
@@ -2914,61 +2919,61 @@ msgid "Enables the shadow spread."
 msgstr "छोडाइ मान लाई योग्य बनाउ"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:66
+#: ../src/common/accelcmn.cpp:63
 msgid "End"
 msgstr "अन्त"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:55
+#: ../src/common/accelcmn.cpp:52
 msgid "Enter"
 msgstr "enter"
 
-#: ../src/richtext/richtextstyledlg.cpp:934
+#: ../src/richtext/richtextstyledlg.cpp:930
 msgid "Enter a box style name"
 msgstr "बाकस शैलीको नाम लेख"
 
-#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:602
 msgid "Enter a character style name"
 msgstr "वर्ण शैलीको नाम लेख"
 
-#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:816
 msgid "Enter a list style name"
 msgstr "सूचि शैलीको नाम लेख"
 
-#: ../src/richtext/richtextstyledlg.cpp:893
+#: ../src/richtext/richtextstyledlg.cpp:889
 msgid "Enter a new style name"
 msgstr "नया शैलीको नाम लेख"
 
-#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:650
 msgid "Enter a paragraph style name"
 msgstr "अनुच्छेद शैलीको नाम लेख"
 
-#: ../src/generic/dbgrptg.cpp:174
+#: ../src/generic/dbgrptg.cpp:171
 #, c-format
 msgid "Enter command to open file \"%s\":"
 msgstr "फाइल \"%s\" पल्टाउन आदेश लेख:"
 
-#: ../src/generic/helpext.cpp:459
+#: ../src/generic/helpext.cpp:457
 msgid "Entries found"
 msgstr "प्रविष्टि पाइयो"
 
-#: ../src/common/paper.cpp:142
+#: ../src/common/paper.cpp:139
 msgid "Envelope Invite 220 x 220 mm"
 msgstr "खाम Invite 220 x 220 मिमी"
 
-#: ../src/common/config.cpp:469
+#: ../src/common/config.cpp:465
 #, c-format
 msgid ""
 "Environment variables expansion failed: missing '%c' at position %u in '%s'."
 msgstr "वातावरणीय चल विस्तार असफल भयो: '%c' स्थान %u मा ('%s' को) हराएको छ ।"
 
-#: ../src/generic/filedlgg.cpp:357 ../src/generic/dirctrlg.cpp:570
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/dirctrlg.cpp:599
-#: ../src/generic/dirdlgg.cpp:323 ../src/generic/filectrlg.cpp:642
-#: ../src/generic/filectrlg.cpp:756 ../src/generic/filectrlg.cpp:770
-#: ../src/generic/filectrlg.cpp:786 ../src/generic/filectrlg.cpp:1368
-#: ../src/generic/filectrlg.cpp:1399 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/gtk1/fontdlg.cpp:74 ../src/generic/dirctrlg.cpp:536
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/dirctrlg.cpp:565
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1357 ../src/generic/filectrlg.cpp:1388
+#: ../src/generic/filedlgg.cpp:354 ../src/generic/dirdlgg.cpp:320
+#: ../src/gtk/filedlg.cpp:74
 msgid "Error"
 msgstr "गल्ती"
 
@@ -2976,232 +2981,253 @@ msgstr "गल्ती"
 msgid "Error closing epoll descriptor"
 msgstr "गल्ती भएकोले epoll ब्याख्याकार बन्द हुँदै छ ।"
 
-#: ../src/unix/fswatcher_kqueue.cpp:114
+#: ../src/unix/fswatcher_kqueue.cpp:131
 msgid "Error closing kqueue instance"
 msgstr "गल्ती भएकोले kqueue instance बन्द हुँदैछ ।"
 
-#: ../src/common/filefn.cpp:1049
+#: ../src/common/filefn.cpp:938
 #, fuzzy, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "फाइल '%s' को नक्कल '%s' मा उतार्न सकिएन ।"
 
-#: ../src/generic/dirdlgg.cpp:222
+#: ../src/generic/dirdlgg.cpp:219
 msgid "Error creating directory"
 msgstr "घर्रा सिर्जनामा गल्ती "
 
-#: ../src/common/imagbmp.cpp:1181
+#: ../src/common/imagbmp.cpp:1193
 msgid "Error in reading image DIB."
 msgstr "तस्विरको डिपो ट पढ्न गल्ती भयो ।"
 
-#: ../src/propgrid/propgrid.cpp:6696
+#: ../src/propgrid/propgrid.cpp:6665
 #, c-format
 msgid "Error in resource: %s"
 msgstr "श्रोतमा गल्ती: : %s"
 
-#: ../src/common/fileconf.cpp:422
+#: ../src/common/fileconf.cpp:421
 msgid "Error reading config options."
 msgstr "config विकल्प पढ्न गल्ती भयो ।"
+
+#: ../src/msw/webview_ie.cpp:1057 ../src/msw/webview_edge.cpp:850
+#: ../src/gtk/webview_webkit2.cpp:1262 ../src/osx/webview_webkit.mm:383
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
 
 #: ../src/common/fileconf.cpp:1029
 msgid "Error saving user configuration data."
 msgstr "उपभोक्ताको अभियोजन तथ्याङ्क बचतमा गल्ती भयो ।"
 
-#: ../src/gtk/print.cpp:722
+#: ../src/gtk/print.cpp:720
 msgid "Error while printing: "
 msgstr "प्रिन्टिङ गर्दा गल्ती भयो : "
 
-#: ../src/common/log.cpp:219
+#: ../src/common/log.cpp:237
 msgid "Error: "
 msgstr "गल्ती: "
 
+#: ../src/common/webrequest.cpp:98
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "गल्ती: "
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:69
+#: ../src/common/accelcmn.cpp:66
 msgid "Esc"
 msgstr "ESC"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:70
+#: ../src/common/accelcmn.cpp:67
 msgid "Escape"
 msgstr "escape"
 
-#: ../src/common/fmapbase.cpp:150
+#: ../src/common/fmapbase.cpp:147
 msgid "Esperanto (ISO-8859-3)"
 msgstr "Esperanto (ISO-8859-3)"
 
-#: ../include/wx/generic/progdlgg.h:85
+#: ../include/wx/generic/progdlgg.h:86
 msgid "Estimated time:"
 msgstr "अनुमानित समय:"
 
-#: ../src/generic/dbgrptg.cpp:234
+#: ../src/generic/dbgrptg.cpp:231
 msgid "Executable files (*.exe)|*.exe|"
 msgstr "Executable फाइलहरू(*.exe)|*.exe|"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:155 ../src/common/accelcmn.cpp:78
+#: ../src/common/stockitem.cpp:152 ../src/common/accelcmn.cpp:75
 msgid "Execute"
 msgstr "कार्यान्वयन गर"
 
-#: ../src/msw/utilsexc.cpp:876
+#: ../src/msw/utilsexc.cpp:873
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "आदेश '%s' को कार्यान्वयन असफल भयो ।"
 
-#: ../src/common/paper.cpp:105
+#: ../src/common/paper.cpp:102
 msgid "Executive, 7 1/4 x 10 1/2 in"
 msgstr "Executive, 7 1/4 x 10 1/2इन्च"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6009
+#: ../src/generic/datavgen.cpp:6814
 msgid "Expand"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1240
+#: ../src/msw/registry.cpp:1228
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
 msgstr "registry कुञ्जी निर्यात हुँदैछ: फाइल\"%s\" छदै च त्यसैले फेरी लेखिने काम हुँदैन ।"
 
-#: ../src/common/fmapbase.cpp:195
+#: ../src/common/fmapbase.cpp:192
 msgid "Extended Unix Codepage for Japanese (EUC-JP)"
 msgstr "Extended Unix Codepage for Japanese (EUC-JP)"
 
-#: ../src/html/chm.cpp:725
+#: ../src/html/chm.cpp:718
 #, c-format
 msgid "Extraction of '%s' into '%s' failed."
 msgstr "'%s' लाई '%s' मा खिच्ने काम असफल भयो ।"
 
-#: ../src/common/accelcmn.cpp:249 ../src/common/accelcmn.cpp:344
+#: ../src/common/accelcmn.cpp:259 ../src/common/accelcmn.cpp:358
 msgid "F"
 msgstr "F"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:672
+#: ../src/propgrid/advprops.cpp:582
 msgid "Face Name"
 msgstr "अनुहारको नाम"
 
-#: ../src/unix/snglinst.cpp:269
+#: ../src/unix/snglinst.cpp:266
 msgid "Failed to access lock file."
 msgstr "चाबी फाइल हेर्न सकिएन ।"
+
+#: ../src/gtk/font.cpp:572
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "फाइल \"%s\". बाट कागजात पढ्न सकिएन ।"
 
 #: ../src/unix/epolldispatcher.cpp:116
 #, c-format
 msgid "Failed to add descriptor %d to epoll descriptor %d"
 msgstr "ब्याख्याकार %d लाई epoll ब्याख्याकार %d मा थप्न सकिएन ।"
 
-#: ../src/msw/dib.cpp:489
+#: ../src/msw/dib.cpp:535
 #, c-format
 msgid "Failed to allocate %luKb of memory for bitmap data."
 msgstr "bitmap तथ्याङ्कको लागि %luKb को भण्डार उपलब्ध गराउन सकिएन ।"
 
-#: ../src/common/glcmn.cpp:115
+#: ../src/common/glcmn.cpp:112
 msgid "Failed to allocate colour for OpenGL"
 msgstr "OpenGL को लागि रङ्ग उपलब्ध गराउन सकिएन ।"
 
-#: ../src/unix/displayx11.cpp:236
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "OpenGL को लागि रङ्ग उपलब्ध गराउन सकिएन ।"
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "OpenGL को लागि रङ्ग उपलब्ध गराउन सकिएन ।"
+
+#: ../include/wx/unix/private/displayx11.h:89
 msgid "Failed to change video mode"
 msgstr "श्रव्य दृश्य मुद्रामा बदल्न सकिएन"
 
-#: ../src/common/image.cpp:3277
+#: ../src/common/image.cpp:3396
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "तस्विर फाइल \"%s\" को स्वरूप जाँच्न सकिएन ।"
 
-#: ../src/common/debugrpt.cpp:239
+#: ../src/common/debugrpt.cpp:240
 #, c-format
 msgid "Failed to clean up debug report directory \"%s\""
 msgstr "खानतलासी प्रतिवेदन घर्रा \"%s\" सफा गर्न सकिएन ।"
 
-#: ../src/common/filename.cpp:192
+#: ../src/common/filename.cpp:189
 msgid "Failed to close file handle"
 msgstr "फाइल को हातो बन्द गर्न सकिएन ।"
 
-#: ../src/unix/snglinst.cpp:340
+#: ../src/unix/snglinst.cpp:337
 #, c-format
 msgid "Failed to close lock file '%s'"
 msgstr "चाबी फाइल '%s' बन्द गर्न सकिएन ।"
 
-#: ../src/msw/clipbrd.cpp:112
+#: ../src/msw/clipbrd.cpp:110
 msgid "Failed to close the clipboard."
 msgstr "क्लिप पाटी बन्द गर्न सकिएन ।"
 
-#: ../src/x11/utils.cpp:208
+#: ../src/x11/utils.cpp:170
 #, c-format
 msgid "Failed to close the display \"%s\""
 msgstr "दृश्य \"%s\" बन्द गर्न सकिएन ।"
 
-#: ../src/msw/dialup.cpp:797
+#: ../src/msw/dialup.cpp:791
 msgid "Failed to connect: missing username/password."
 msgstr "जोड्न सकिएन: ग्राहकको नाम/पाल्सीशब्द छैन ।"
 
-#: ../src/msw/dialup.cpp:743
+#: ../src/msw/dialup.cpp:737
 msgid "Failed to connect: no ISP to dial."
 msgstr "जोड्न सकिएन: डायल गर्न ISP छैन"
 
-#: ../src/common/textfile.cpp:203
-#, c-format
-msgid "Failed to convert file \"%s\" to Unicode."
-msgstr "फाइल \"%s\" लाई युनिकोडमा परिवर्तन गर्न सकिएन ।"
-
-#: ../src/generic/logg.cpp:956
+#: ../src/generic/logg.cpp:953
 msgid "Failed to copy dialog contents to the clipboard."
 msgstr "पर्दामा भएका सामाग्रीहरू लाई क्लिप पाटीमा उतार्न सकिएन ।"
 
-#: ../src/msw/registry.cpp:692
+#: ../src/msw/registry.cpp:681
 #, c-format
 msgid "Failed to copy registry value '%s'"
 msgstr "registry मान '%s' को नक्कल उतार्न सकिएन ।"
 
-#: ../src/msw/registry.cpp:701
+#: ../src/msw/registry.cpp:690
 #, c-format
 msgid "Failed to copy the contents of registry key '%s' to '%s'."
 msgstr "registry कुञ्जीको सामाग्री '%s' को नक्कल '%s' मा उतार्न सकिएन ।"
 
-#: ../src/common/filefn.cpp:1015
+#: ../src/common/filefn.cpp:904
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "फाइल '%s' को नक्कल '%s' मा उतार्न सकिएन ।"
 
-#: ../src/msw/registry.cpp:679
+#: ../src/msw/registry.cpp:668
 #, c-format
 msgid "Failed to copy the registry subkey '%s' to '%s'."
 msgstr "registry उप-कुञ्जी '%s' को नक्कल '%s' मा उतार्न सकिएन ।"
 
-#: ../src/msw/dde.cpp:1070
+#: ../src/msw/dde.cpp:1134
 msgid "Failed to create DDE string"
 msgstr "DDE string को सिर्जना गर्न सकिएन ।"
 
-#: ../src/msw/mdi.cpp:616
+#: ../src/msw/mdi.cpp:621
 msgid "Failed to create MDI parent frame."
 msgstr "MDI parent frame को सिर्जना गर्न सकिएन ।"
 
-#: ../src/common/filename.cpp:1027
+#: ../src/common/filename.cpp:1024
 msgid "Failed to create a temporary file name"
 msgstr "अस्ताई फाइलको नाम सिर्जना गर्न सकिएन ।"
 
-#: ../src/msw/utilsexc.cpp:228
+#: ../src/msw/utilsexc.cpp:225
 msgid "Failed to create an anonymous pipe"
 msgstr "anonymous pipe को सिर्जना गर्न सकिएन ।"
 
-#: ../src/msw/ole/automtn.cpp:522
+#: ../src/msw/ole/automtn.cpp:513
 #, c-format
 msgid "Failed to create an instance of \"%s\""
 msgstr "instance \"%s\" को सिर्जना गर्न सकिएन ।"
 
-#: ../src/msw/dde.cpp:437
+#: ../src/msw/dde.cpp:432
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "सर्बर '%s' मा शीर्षक '%s' सित सम्बन्ध गाँस्न सकिएन ।"
 
-#: ../src/msw/cursor.cpp:204
+#: ../src/msw/cursor.cpp:195
 msgid "Failed to create cursor."
 msgstr "कर्सर सिर्जना गर्न सकिएन ।"
 
-#: ../src/common/debugrpt.cpp:209
+#: ../src/common/debugrpt.cpp:210
 #, c-format
 msgid "Failed to create directory \"%s\""
 msgstr "घर्रा \"%s\" सिर्जना गर्न सकिएन ।"
 
-#: ../src/generic/dirdlgg.cpp:220
+#: ../src/generic/dirdlgg.cpp:217
 #, c-format
 msgid ""
 "Failed to create directory '%s'\n"
@@ -3214,184 +3240,203 @@ msgstr ""
 msgid "Failed to create epoll descriptor"
 msgstr "epoll ब्याख्याकार को सिर्जना गर्न सकिएन ।"
 
-#: ../src/msw/mimetype.cpp:238
+#: ../src/gtk/font.cpp:562
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "उपभोक्ता अभियोजन फाइल अद्यावधि करण गर्न सकिएन ।"
+
+#: ../src/msw/mimetype.cpp:235
 #, c-format
 msgid "Failed to create registry entry for '%s' files."
 msgstr "फाइलहरू '%s' का लागि registry प्रविष्टि सिर्जना गर्न सकिएन ।"
 
-#: ../src/msw/fdrepdlg.cpp:409
+#: ../src/msw/fdrepdlg.cpp:408
 #, c-format
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr "स्तरीय फेला पार्ने/प्रतिस्थापित गर्ने पातो (गल्ती संहिता %d) सिर्जना गर्न सकिएन ।"
 
-#: ../src/unix/wakeuppipe.cpp:52
+#: ../src/unix/wakeuppipe.cpp:49
 msgid "Failed to create wake up pipe used by event loop."
 msgstr "event loop ले प्रयोग गर्ने Wake Up Pipe सिर्जना गर्न सकिएन ।"
 
-#: ../src/html/winpars.cpp:730
+#: ../src/html/winpars.cpp:727
 #, c-format
 msgid "Failed to display HTML document in %s encoding"
 msgstr "%s अनुसंहितामा html कागजात सिर्जना गर्न सकिएन ।"
 
-#: ../src/msw/clipbrd.cpp:124
+#: ../src/msw/clipbrd.cpp:122
 msgid "Failed to empty the clipboard."
 msgstr "क्लिप पाटी रित्याउन सकिएन ।"
 
-#: ../src/unix/displayx11.cpp:212
+#: ../include/wx/unix/private/displayx11.h:65
 msgid "Failed to enumerate video modes"
 msgstr "श्रव्य दृश्य मुद्रा गणना गर्न सकिएन ।"
 
-#: ../src/msw/dde.cpp:722
+#: ../src/msw/dde.cpp:717
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "DDE सर्भर सित advise loop सम्बन्ध राख्न सकिएन ।"
 
-#: ../src/msw/dialup.cpp:629 ../src/msw/dialup.cpp:863
+#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "डायलअप जडान %s स्थापित गर्न सकिएन ।"
 
-#: ../src/unix/utilsunx.cpp:611
+#: ../src/unix/utilsunx.cpp:613
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "'%s' कार्यान्वयन गर्न सकिएन ।\n"
 
-#: ../src/common/debugrpt.cpp:720
+#: ../src/common/debugrpt.cpp:730
 msgid "Failed to execute curl, please install it in PATH."
 msgstr "curl कार्यान्वयन गर्न सकिएन, कृपया यसलाई PATH मा स्थापन गर्नु होस् ।"
 
-#: ../src/msw/ole/automtn.cpp:505
+#: ../src/msw/ole/automtn.cpp:496
 #, c-format
 msgid "Failed to find CLSID of \"%s\""
 msgstr "\"%s\" को CLSID फेला पार्न सकिएन ।"
 
-#: ../src/common/regex.cpp:431 ../src/common/regex.cpp:479
+#: ../src/common/regex.cpp:428 ../src/common/regex.cpp:476
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "नियमित अभिव्यक्ति%s सित मिल्ने शब्द पाइ एन ।"
 
-#: ../src/msw/dialup.cpp:695
+#: ../src/msw/webview_ie.cpp:978
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:689
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "ISP नामहरू %s पाउन सकिएन ।"
 
-#: ../src/msw/ole/automtn.cpp:574
+#: ../src/msw/ole/automtn.cpp:565
 #, c-format
 msgid "Failed to get OLE automation interface for \"%s\""
 msgstr "\"%s\" का लागि पुराना स्वचालित interface पाउन सकिएन ।"
 
-#: ../src/msw/clipbrd.cpp:711
+#: ../src/msw/clipbrd.cpp:731
 msgid "Failed to get data from the clipboard"
 msgstr "क्लिप पाटीबाट केही पनि पाउन सकिएन ।"
 
-#: ../src/common/time.cpp:223
+#: ../src/common/time.cpp:216
 msgid "Failed to get the local system time"
 msgstr "कम्प्युटर प्रणालीमा स्थानीय समय भेटिएन ।"
 
-#: ../src/common/filefn.cpp:1345
+#: ../src/common/filefn.cpp:1233
 msgid "Failed to get the working directory"
 msgstr "कार्य गर्दै गरेको घर्रा पाउन सकिएन ।"
 
-#: ../src/univ/theme.cpp:114
+#: ../src/univ/theme.cpp:111
 msgid "Failed to initialize GUI: no built-in themes found."
 msgstr "GUI सुरुवात गर्न सकिएन: बनी बनाउ themes पाइ एन ।"
 
-#: ../src/msw/helpchm.cpp:63
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:60
 msgid "Failed to initialize MS HTML Help."
 msgstr "MS HTML सहयोग सुरु गर्न सकिएन ।"
 
-#: ../src/msw/glcanvas.cpp:1381
+#: ../src/msw/glcanvas.cpp:1391
 msgid "Failed to initialize OpenGL"
 msgstr "OpenGL सुरु गर्न सकिएन ।"
 
-#: ../src/msw/dialup.cpp:858
+#: ../src/msw/dialup.cpp:852
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "%s डायलअप जडान गराउन सकिएन ।"
 
-#: ../src/gtk/textctrl.cpp:1128
+#: ../src/gtk/textctrl.cpp:1209
 msgid "Failed to insert text in the control."
 msgstr "नियन्त्रणमा पाठ लेख्न सकिएन ।"
 
-#: ../src/unix/snglinst.cpp:241
+#: ../src/unix/snglinst.cpp:238
 #, c-format
 msgid "Failed to inspect the lock file '%s'"
 msgstr "'%s' चाबी फाइल जाँच्न सकिएन ।"
 
-#: ../src/unix/appunix.cpp:182
+#: ../src/unix/appunix.cpp:179
 msgid "Failed to install signal handler"
 msgstr "सङ्केत चालक स्थापित गर्न सकिएन ।"
 
-#: ../src/unix/threadpsx.cpp:1167
+#: ../src/unix/threadpsx.cpp:1216
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
 msgstr "Thread जोड्न सकिएन, भण्डार चुहावट प्रबल छ- कृपया कार्यक्रम फेरी सुरु गर्नु होला"
 
-#: ../src/msw/utils.cpp:629
+#: ../src/msw/utils.cpp:619
 #, c-format
 msgid "Failed to kill process %d"
 msgstr "प्रक्रिया %d लाई मार्न सकिएन ।"
 
-#: ../src/common/image.cpp:2500
+#: ../src/common/image.cpp:2595
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "श्रोतबाट %s BitMap वहन गर्न सकिएन "
 
-#: ../src/common/image.cpp:2509
+#: ../src/common/image.cpp:2604
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "श्रोतबाट %s प्रतिमा वहन गर्न सकिएन "
 
-#: ../src/common/iconbndl.cpp:225
+#: ../src/common/iconbndl.cpp:224
 #, fuzzy, c-format
 msgid "Failed to load icons from resource '%s'."
 msgstr "श्रोतबाट %s प्रतिमा वहन गर्न सकिएन "
 
-#: ../src/common/iconbndl.cpp:200
+#: ../src/common/iconbndl.cpp:198
 #, c-format
 msgid "Failed to load image %%d from file '%s'."
 msgstr "तस्विर %%d फाइल'%s' बाट वहन गर्न सकिएन "
 
-#: ../src/common/iconbndl.cpp:208
+#: ../src/common/iconbndl.cpp:206
 #, c-format
 msgid "Failed to load image %d from stream."
 msgstr "stream बाट %d तस्विर वहन गर्न सकिएन "
 
-#: ../src/common/image.cpp:2587 ../src/common/image.cpp:2606
+#: ../src/common/image.cpp:2682 ../src/common/image.cpp:2701
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "फाइल \"%s\" बाट तस्विर वहन गर्न सकिएन "
 
-#: ../src/msw/enhmeta.cpp:97
+#: ../src/msw/enhmeta.cpp:94
 #, c-format
 msgid "Failed to load metafile from file \"%s\"."
 msgstr "फाइल \"%s\" बाट metafile तस्विर वहन गर्न सकिएन "
 
-#: ../src/msw/volume.cpp:327
+#: ../src/msw/volume.cpp:335
 msgid "Failed to load mpr.dll."
 msgstr "mpr.dll वहन गर्न सकिएन "
 
-#: ../src/msw/utils.cpp:953
+#: ../src/msw/utils.cpp:943
 #, c-format
 msgid "Failed to load resource \"%s\"."
 msgstr "श्रोत \"%s\" वहन गर्न सकिएन "
 
-#: ../src/common/dynlib.cpp:92
+#: ../src/common/dynlib.cpp:86
 #, c-format
 msgid "Failed to load shared library '%s'"
 msgstr "साझा पुस्तकालय '%s' वहन गर्न सकिएन "
 
-#: ../src/osx/core/sound.cpp:145
+#: ../src/osx/core/sound.cpp:143
 #, c-format
 msgid "Failed to load sound from \"%s\" (error %d)."
 msgstr "\"%s\" (त्रुटि %d). बाट ध्वनिलाई  बहन गर्न सकिएन "
 
-#: ../src/msw/utils.cpp:960
+#: ../src/msw/utils.cpp:950
 #, c-format
 msgid "Failed to lock resource \"%s\"."
 msgstr "श्रोत \"%s\" लाई चाबी लगाउन सकिएन ।"
 
-#: ../src/unix/snglinst.cpp:198
+#: ../src/unix/snglinst.cpp:195
 #, c-format
 msgid "Failed to lock the lock file '%s'"
 msgstr "चाबी फाइल '%s' मा चाबी लगाउन सकिएन ।"
@@ -3401,33 +3446,38 @@ msgstr "चाबी फाइल '%s' मा चाबी लगाउन स�
 msgid "Failed to modify descriptor %d in epoll descriptor %d"
 msgstr "ब्याख्याकार %d (epoll ब्याख्याकार %d मा ) फेर बदल गर्न सकिएन ।"
 
-#: ../src/common/filename.cpp:2575
+#: ../src/common/filename.cpp:2658
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "'%s' फाइलको समय फेर बदल गर्न सकिएन ।"
 
-#: ../src/common/selectdispatcher.cpp:258
+#: ../src/common/selectdispatcher.cpp:255
 msgid "Failed to monitor I/O channels"
 msgstr "लगानी/प्रतिफल मार्ग अनुगमन गर्न सकिएन ।"
 
-#: ../src/common/filename.cpp:175
+#: ../src/common/filename.cpp:172
 #, c-format
 msgid "Failed to open '%s' for reading"
 msgstr "पढ्नका लागि '%s' लाई खोल्न सकिएन ।"
 
-#: ../src/common/filename.cpp:180
+#: ../src/common/filename.cpp:177
 #, c-format
 msgid "Failed to open '%s' for writing"
 msgstr "लेख्नका लागि '%s' खोल्न सकिएन ।"
 
-#: ../src/html/chm.cpp:141
+#: ../src/html/chm.cpp:138
 #, c-format
 msgid "Failed to open CHM archive '%s'."
 msgstr "सङ्ग्रह '%s' खोल्न सकिएन ।"
 
-#: ../src/common/utilscmn.cpp:1126
+#: ../src/common/utilscmn.cpp:1140
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
+msgstr "निर्धारित Browser मा \"%s\" खोल्न सकिएन ।"
+
+#: ../src/common/hyperlnkcmn.cpp:133
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "निर्धारित Browser मा \"%s\" खोल्न सकिएन ।"
 
 #: ../include/wx/msw/private/fswatcher.h:92
@@ -3435,208 +3485,227 @@ msgstr "निर्धारित Browser मा \"%s\" खोल्न सक
 msgid "Failed to open directory \"%s\" for monitoring."
 msgstr "अनुगमनका लागि घर्रा \"%s\" खोल्न सकिएन ।"
 
-#: ../src/x11/utils.cpp:227
+#: ../src/x11/utils.cpp:189
 #, c-format
 msgid "Failed to open display \"%s\"."
 msgstr "दृश्य \"%s\" खोल्न सकिएन ।"
 
-#: ../src/common/filename.cpp:1062
+#: ../src/common/filename.cpp:1059
 msgid "Failed to open temporary file."
 msgstr "अस्ताई फाइल खोल्न सकिएन ।"
 
-#: ../src/msw/clipbrd.cpp:91
+#: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "क्लिप पाटी खोल्न सकिएन ।"
 
-#: ../src/common/translation.cpp:1184
+#: ../src/common/translation.cpp:1226
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "बहुवचन स्वरूप '%s' पठाउन सकिएन ।"
 
-#: ../src/unix/mediactrl.cpp:1214
+#: ../src/unix/mediactrl.cpp:1239
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "\"%s\" लाई बजाउने तयारी असफल भयो ।"
 
-#: ../src/msw/clipbrd.cpp:600
+#: ../src/msw/clipbrd.cpp:610
 msgid "Failed to put data on the clipboard"
 msgstr "क्लिप पाटीमा तथ्याङ्क राख्न सकिएन ।"
 
-#: ../src/unix/snglinst.cpp:278
+#: ../src/unix/snglinst.cpp:275
 msgid "Failed to read PID from lock file."
 msgstr "चाबी फाइलबाट PID पढ्न सकिएन ।"
 
-#: ../src/common/fileconf.cpp:433
+#: ../src/common/fileconf.cpp:432
 msgid "Failed to read config options."
 msgstr "अभियोजन विकल्प पढ्न सकिएन ।"
 
-#: ../src/common/docview.cpp:681
+#: ../src/common/docview.cpp:676
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "फाइल \"%s\". बाट कागजात पढ्न सकिएन ।"
 
-#: ../src/dfb/evtloop.cpp:98
+#: ../src/dfb/evtloop.cpp:99
 msgid "Failed to read event from DirectFB pipe"
 msgstr "DirectFB pipe बाट घटना पढ्न सकिएन ।"
 
-#: ../src/unix/wakeuppipe.cpp:120
+#: ../src/unix/wakeuppipe.cpp:117
 msgid "Failed to read from wake-up pipe"
 msgstr "Wake-Up pipe बाट पढ्न सकिएन ।"
 
-#: ../src/unix/utilsunx.cpp:679
+#: ../src/common/textfile.cpp:96
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "फाइल \"%s\". बाट कागजात पढ्न सकिएन ।"
+
+#: ../src/unix/utilsunx.cpp:681
 msgid "Failed to redirect child process input/output"
 msgstr "बाल प्रक्रिया लगानी/प्रतिफल फेरि पठाउन सकिएन ।"
 
-#: ../src/msw/utilsexc.cpp:701
+#: ../src/msw/utilsexc.cpp:698
 msgid "Failed to redirect the child process IO"
 msgstr "बाल प्रक्रिया लगानी/प्रतिफल फेरि पठाउन सकिएन ।"
 
-#: ../src/msw/dde.cpp:288
+#: ../src/msw/dde.cpp:283
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "DDE सर्भर '%s' दर्ता गर्न सकिएन ।"
 
-#: ../src/common/fontmap.cpp:245
+#: ../src/gtk/font.cpp:580
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "उपभोक्ता अभियोजन फाइल अद्यावधि करण गर्न सकिएन ।"
+
+#: ../src/common/fontmap.cpp:242
 #, c-format
 msgid "Failed to remember the encoding for the charset '%s'."
 msgstr "वर्णसेट '%s' को अनुसंहिता सम्झन सकिएन ।"
 
-#: ../src/common/debugrpt.cpp:227
+#: ../src/common/debugrpt.cpp:228
 #, c-format
 msgid "Failed to remove debug report file \"%s\""
 msgstr "खानतलासी प्रतिवेदन फाइल \"%s\" हटाउन सकिएन ।"
 
-#: ../src/unix/snglinst.cpp:328
+#: ../src/unix/snglinst.cpp:325
 #, c-format
 msgid "Failed to remove lock file '%s'"
 msgstr "चाबी फाइल '%s' हटाउन सकिएन ।"
 
-#: ../src/unix/snglinst.cpp:288
+#: ../src/unix/snglinst.cpp:285
 #, c-format
 msgid "Failed to remove stale lock file '%s'."
 msgstr "बासी चाबी फाइल '%s'. हटाउन सकिएन ।"
 
-#: ../src/msw/registry.cpp:529
+#: ../src/msw/registry.cpp:518
 #, c-format
 msgid "Failed to rename registry value '%s' to '%s'."
 msgstr "registry मान '%s' लाई '%s' मा नामा करण गर्न सकिएन ।"
 
-#: ../src/common/filefn.cpp:1122
+#: ../src/common/filefn.cpp:1011
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
 "exists."
 msgstr "यही नामको अर्को फाइल भएकोले '%s' फाइलको नाम '%s' मा फेर्न सकिएन ।"
 
-#: ../src/msw/registry.cpp:634
+#: ../src/msw/registry.cpp:623
 #, c-format
 msgid "Failed to rename the registry key '%s' to '%s'."
 msgstr "registry कुञ्जी '%s' लाई '%s' मा नामा करण गर्न सकिएन ।"
 
-#: ../src/common/filename.cpp:2671
+#: ../src/msw/webview_ie.cpp:995
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/common/filename.cpp:2754
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "फाइल '%s' को समय लिन सकिएन ।"
 
-#: ../src/msw/dialup.cpp:468
+#: ../src/msw/dialup.cpp:462
 msgid "Failed to retrieve text of RAS error message"
 msgstr "RAS गल्ती सन् देसको पाठहरू लिन सकिएन ।"
 
-#: ../src/msw/clipbrd.cpp:748
+#: ../src/msw/clipbrd.cpp:768
 msgid "Failed to retrieve the supported clipboard formats"
 msgstr "समर्थन गर्ने क्लिप पाटीको स्वरूप लिन सकिएन ।"
 
-#: ../src/common/docview.cpp:652
+#: ../src/common/docview.cpp:647
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "फाइल \"%s\" मा कागजातहरू बचत गर्न सकिएन ।"
 
-#: ../src/msw/dib.cpp:269
+#: ../src/msw/dib.cpp:312
 #, c-format
 msgid "Failed to save the bitmap image to file \"%s\"."
 msgstr "फाइल \"%s\" मा bitmap तस्विर बचत गर्न सकिएन ।"
 
-#: ../src/msw/dde.cpp:763
+#: ../src/msw/dde.cpp:811
 msgid "Failed to send DDE advise notification"
 msgstr "DDE सूचना सल्लाह पठाउन सकिएन ।"
 
-#: ../src/common/ftp.cpp:402
+#: ../src/common/ftp.cpp:399
 #, c-format
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "FTP सरुवा मुद्रालाई %s मा तय गर्न सकिएन ।"
 
-#: ../src/msw/clipbrd.cpp:427
+#: ../src/msw/clipbrd.cpp:443
 msgid "Failed to set clipboard data."
 msgstr "क्लिप पाटीमा तथ्याङ्क तय गर्न सकिएन ।"
 
-#: ../src/unix/snglinst.cpp:181
+#: ../src/unix/snglinst.cpp:178
 #, c-format
 msgid "Failed to set permissions on lock file '%s'"
 msgstr "चाबी फाइलमा '%s' अनुमति राख्न सकिएन ।"
 
-#: ../src/unix/utilsunx.cpp:668
+#: ../src/unix/utilsunx.cpp:670
 msgid "Failed to set process priority"
 msgstr "प्रक्रिया प्राथमिकता क्रम तोक्न सकिएन ।"
 
-#: ../src/common/file.cpp:559
+#: ../src/common/ffile.cpp:355 ../src/common/file.cpp:586
 msgid "Failed to set temporary file permissions"
 msgstr "अस्ताई फाइल अनुमित राख्न सकिएन ।"
 
-#: ../src/gtk/textctrl.cpp:1072
-msgid "Failed to set text in the text control."
-msgstr "पाठ नियन्त्रक मा पाठ राख्न सकिएन ।"
-
-#: ../src/unix/threadpsx.cpp:1298
+#: ../src/unix/threadpsx.cpp:1347
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "thread स्वीकृति तहलाई %lu मा तय गर्न सकिएन ।"
 
-#: ../src/unix/threadpsx.cpp:1424
+#: ../src/unix/threadpsx.cpp:1473
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "thread प्राथमिकता %d कायम गर्न सकिएन ।"
 
-#: ../src/unix/utilsunx.cpp:783
+#: ../src/unix/utilsunx.cpp:785
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr "न टालिएको पाइप जडान गर्न सकिएन, कार्यक्रम निष्क्रिय हुन सक्छ ।"
 
-#: ../src/common/fs_mem.cpp:261
+#: ../src/msw/webview_ie.cpp:987
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:256
 #, c-format
 msgid "Failed to store image '%s' to memory VFS!"
 msgstr "तस्विर '%s' लाई VFS भण्डारमा सञ्चय गर्न सकिएन ।!"
 
-#: ../src/dfb/evtloop.cpp:170
+#: ../src/dfb/evtloop.cpp:171
 msgid "Failed to switch DirectFB pipe to non-blocking mode"
 msgstr "DirectFB pipe लाई न टालिएको मुद्रामा लान सकिएन ।"
 
-#: ../src/unix/wakeuppipe.cpp:59
+#: ../src/unix/wakeuppipe.cpp:56
 msgid "Failed to switch wake up pipe to non-blocking mode"
 msgstr "wake Up pipe लाई न टालिएको मुद्रामा लान सकिएन ।"
 
-#: ../src/unix/threadpsx.cpp:1605
+#: ../src/unix/threadpsx.cpp:1654
 msgid "Failed to terminate a thread."
 msgstr "thread लाई बन्द गर्न सकिएन ।"
 
-#: ../src/msw/dde.cpp:741
+#: ../src/msw/dde.cpp:736
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "advise loop with DDE server बन्द गर्न सकिएन ।"
 
-#: ../src/msw/dialup.cpp:938
+#: ../src/msw/dialup.cpp:932
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "डायलअप जडान %s बन्द गर्न सकिएन ।"
 
-#: ../src/common/filename.cpp:2590
+#: ../src/common/filename.cpp:2673
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "फाइल '%s' लाइ छु सकिएन ।"
 
-#: ../src/unix/snglinst.cpp:334
+#: ../src/unix/dlunix.cpp:90
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "साझा पुस्तकालय '%s' वहन गर्न सकिएन "
+
+#: ../src/unix/snglinst.cpp:331
 #, c-format
 msgid "Failed to unlock lock file '%s'"
 msgstr "चाबी लागेको फाइल '%s' को चाबी खोल्न सकिएन ।"
 
-#: ../src/msw/dde.cpp:309
+#: ../src/msw/dde.cpp:304
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "DDE सर्भर '%s' को दर्ता खारेज गर्न सकिएन ।"
@@ -3650,78 +3719,88 @@ msgstr "ब्याख्याकार %d को दर्ता epoll ब्
 msgid "Failed to update user configuration file."
 msgstr "उपभोक्ता अभियोजन फाइल अद्यावधि करण गर्न सकिएन ।"
 
-#: ../src/common/debugrpt.cpp:733
+#: ../src/common/debugrpt.cpp:743
 #, c-format
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "खानतलासी प्रतिवेदन (गल्ती कोड %d) अपलोड गर्न सकिएन ।"
 
-#: ../src/unix/snglinst.cpp:168
+#: ../src/unix/snglinst.cpp:165
 #, c-format
 msgid "Failed to write to lock file '%s'"
 msgstr "चाबी फाइल '%s' मा लेख्न सकिएन ।"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:209
+#: ../src/propgrid/propgrid.cpp:190
 msgid "False"
 msgstr "असत्य"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:694
+#: ../src/propgrid/advprops.cpp:604
 msgid "Family"
 msgstr "परिवार"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/gtk/glcanvas.cpp:176 ../src/gtk/glcanvas.cpp:187
+#, fuzzy
+msgid "Fatal Error"
+msgstr "फाइलको गल्ती"
+
+#: ../src/common/stockitem.cpp:154
 msgid "File"
 msgstr "फाइल"
 
-#: ../src/common/docview.cpp:669
+#: ../src/common/docview.cpp:664
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "फाइल \"%s\" पढ्नको लागि खोल्न सकिएन ।"
 
-#: ../src/common/docview.cpp:646
+#: ../src/common/docview.cpp:641
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "फाइल \"%s\" लेख्नका लागि खोल्न सकिएन ।"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr ""
 "फाइल '%s' पहिले देखि नै छ, के तपाइ वास्तवमा नै यसलाई मेटाएर नया राख्न चाहनु हुन्छ?"
 
-#: ../src/common/filefn.cpp:1156
+#: ../src/common/filefn.cpp:1044
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "फाइल '%s' लाई हटाउन सकिएन ।"
 
-#: ../src/common/filefn.cpp:1139
+#: ../src/common/filefn.cpp:1028
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "फाइल '%s' को नामा करण '%s' राख्न सकिएन ।"
 
-#: ../src/richtext/richtextctrl.cpp:3081 ../src/common/textcmn.cpp:953
+#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
 msgid "File couldn't be loaded."
 msgstr "फाइल वहन गर्न सकिएन ।"
 
-#: ../src/msw/filedlg.cpp:393
+#: ../src/msw/filedlg.cpp:414
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "फाइल पाटी गल्ती कोड %0lx ले असफल भयो ।"
 
-#: ../src/common/docview.cpp:1789
+#: ../src/common/docview.cpp:1783
 msgid "File error"
 msgstr "फाइलको गल्ती"
 
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/filectrlg.cpp:770
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/filectrlg.cpp:766
 msgid "File name exists already."
 msgstr "फाइल को नाम पहिले देखि नै छ ।"
+
+#: ../src/osx/cocoa/filedlg.mm:264
+#, fuzzy
+msgid "File type:"
+msgstr "Teletype"
 
 #: ../src/motif/filedlg.cpp:220
 msgid "Files"
 msgstr "फाइलहरू"
 
-#: ../src/common/filefn.cpp:1591
+#: ../src/common/filefn.cpp:1479
 #, c-format
 msgid "Files (%s)"
 msgstr "फाइलहरू (%s)"
@@ -3730,15 +3809,29 @@ msgstr "फाइलहरू (%s)"
 msgid "Filter"
 msgstr "फिल्टर"
 
-#: ../src/common/stockitem.cpp:158 ../src/html/helpwnd.cpp:490
+#: ../src/html/helpwnd.cpp:488
 msgid "Find"
 msgstr "फेला पार"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:259
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:258
+#, fuzzy
+msgid "Find in document"
+msgstr "HTML कागजात पल्टाउ "
+
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "Find..."
+msgstr "फेला पार"
+
+#: ../src/common/stockitem.cpp:156
 msgid "First"
 msgstr "प्रथम"
 
-#: ../src/common/prntbase.cpp:1548
+#: ../src/common/prntbase.cpp:1573
 msgid "First page"
 msgstr "प्रथम पृष्ट"
 
@@ -3746,11 +3839,11 @@ msgstr "प्रथम पृष्ट"
 msgid "Fixed"
 msgstr "निश्चित "
 
-#: ../src/html/helpwnd.cpp:1206
+#: ../src/html/helpwnd.cpp:1204
 msgid "Fixed font:"
 msgstr "निश्चित वरणाकृति:"
 
-#: ../src/html/helpwnd.cpp:1269
+#: ../src/html/helpwnd.cpp:1267
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "निश्चित आकार face.<br> <b>मोटो</b> <i>डल्केको</i> "
 
@@ -3758,16 +3851,16 @@ msgstr "निश्चित आकार face.<br> <b>मोटो</b> <i>ड�
 msgid "Floating"
 msgstr "तैरि रहेको"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "Floppy"
 msgstr "फ्लपी"
 
-#: ../src/common/paper.cpp:111
+#: ../src/common/paper.cpp:108
 msgid "Folio, 8 1/2 x 13 in"
 msgstr "Folio, 8 1/2 x 13इन्च"
 
-#: ../src/richtext/richtextformatdlg.cpp:344 ../src/osx/carbon/fontdlg.cpp:287
-#: ../src/common/stockitem.cpp:194
+#: ../src/osx/carbon/fontdlg.cpp:284 ../src/common/stockitem.cpp:191
+#: ../src/richtext/richtextformatdlg.cpp:337
 msgid "Font"
 msgstr "वरणाकृति"
 
@@ -3775,7 +3868,24 @@ msgstr "वरणाकृति"
 msgid "Font &weight:"
 msgstr "वरणाकृति &भार:"
 
-#: ../src/html/helpwnd.cpp:1207
+#: ../src/osx/fontutil.cpp:89
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
+"\"."
+msgstr ""
+
+#: ../src/msw/font.cpp:1126
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "फाइल वहन गर्न सकिएन ।"
+
+#: ../src/osx/fontutil.cpp:81
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr ": फाइल छैन ।"
+
+#: ../src/html/helpwnd.cpp:1205
 msgid "Font size:"
 msgstr "वरणाकृतिको आकार:"
 
@@ -3783,53 +3893,53 @@ msgstr "वरणाकृतिको आकार:"
 msgid "Font st&yle:"
 msgstr "वरणाकृतिको &शैली:"
 
-#: ../src/osx/carbon/fontdlg.cpp:329
+#: ../src/osx/carbon/fontdlg.cpp:326
 msgid "Font:"
 msgstr "वरणाकृति:"
 
-#: ../src/dfb/fontmgr.cpp:198
+#: ../src/dfb/fontmgr.cpp:195
 #, c-format
 msgid "Fonts index file %s disappeared while loading fonts."
 msgstr "वरणाकृति अनुक्रमणिका फाइल %s वरणाकृति वहन गर्ने क्रममा हरायो ।"
 
-#: ../src/unix/utilsunx.cpp:645
+#: ../src/unix/utilsunx.cpp:647
 msgid "Fork failed"
 msgstr "Fork असफल भयो ।"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "Forward"
 msgstr "प्रेषित गर"
 
-#: ../src/common/xtixml.cpp:235
+#: ../src/common/xtixml.cpp:231
 msgid "Forward hrefs are not supported"
 msgstr "hrefs प्रेषण समर्थन गर्न सकिँदैन ।"
 
-#: ../src/html/helpwnd.cpp:875
+#: ../src/html/helpwnd.cpp:873
 #, c-format
 msgid "Found %i matches"
 msgstr "%i मिल्दो झुल्दो पाइयो ।"
 
-#: ../src/generic/prntdlgg.cpp:238
+#: ../src/generic/prntdlgg.cpp:231
 msgid "From:"
 msgstr "बाट:"
 
-#: ../src/propgrid/advprops.cpp:1604
+#: ../src/propgrid/advprops.cpp:1510
 msgid "Fuchsia"
 msgstr "अबिरे"
 
-#: ../src/common/imaggif.cpp:138
+#: ../src/common/imaggif.cpp:135
 msgid "GIF: data stream seems to be truncated."
 msgstr "GIF: तथ्याङ्क काटकुट गरेको जस्तो छ ।"
 
-#: ../src/common/imaggif.cpp:128
+#: ../src/common/imaggif.cpp:125
 msgid "GIF: error in GIF image format."
 msgstr "GIF: GIF तस्विरको स्वरूप मिलेन"
 
-#: ../src/common/imaggif.cpp:133
+#: ../src/common/imaggif.cpp:130
 msgid "GIF: not enough memory."
 msgstr "GIF: यथेष्ट भण्डार छैन"
 
-#: ../src/gtk/window.cpp:4631
+#: ../src/gtk/window.cpp:5635
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -3837,23 +3947,23 @@ msgstr ""
 "यो कम्प्युटरमा स्थापित GTK+ धेरै पुरानो रहेछ पर्दाको पूर्तिको लागि GTK+ 2.12 अथवा यो "
 "भन्दा नयाँ संस्करण स्थापित गर्नु होला ।"
 
-#: ../src/univ/themes/gtk.cpp:525
+#: ../src/univ/themes/gtk.cpp:522
 msgid "GTK+ theme"
 msgstr "GTK+ theme"
 
-#: ../src/common/preferencescmn.cpp:40
+#: ../src/common/preferencescmn.cpp:37
 msgid "General"
 msgstr "&सामान्य"
 
-#: ../src/common/prntbase.cpp:258
+#: ../src/common/prntbase.cpp:253
 msgid "Generic PostScript"
 msgstr "Generic PostScript"
 
-#: ../src/common/paper.cpp:135
+#: ../src/common/paper.cpp:132
 msgid "German Legal Fanfold, 8 1/2 x 13 in"
 msgstr "जर्मनी Legal Fanfold, 8 1/2 x 13इन्च"
 
-#: ../src/common/paper.cpp:134
+#: ../src/common/paper.cpp:131
 msgid "German Std Fanfold, 8 1/2 x 12 in"
 msgstr "जर्मनी Std Fanfold, 8 1/2 x 12इन्च"
 
@@ -3869,48 +3979,48 @@ msgstr "GetPropertyCollection called on a generic accessor"
 msgid "GetPropertyCollection called w/o valid collection getter"
 msgstr "GetPropertyCollection called w/o valid collection getter"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:658
 msgid "Go back"
 msgstr "फर्केर जाउ"
 
-#: ../src/html/helpwnd.cpp:661
+#: ../src/html/helpwnd.cpp:659
 msgid "Go forward"
 msgstr "अगाडी जाउ"
 
-#: ../src/html/helpwnd.cpp:663
+#: ../src/html/helpwnd.cpp:661
 msgid "Go one level up in document hierarchy"
 msgstr "कागजातको मर्यादामा एक तह माथि जाउ"
 
-#: ../src/generic/filedlgg.cpp:208 ../src/generic/dirdlgg.cpp:116
+#: ../src/generic/filedlgg.cpp:205 ../src/generic/dirdlgg.cpp:113
 msgid "Go to home directory"
 msgstr "गृह गर्रामा जाउ "
 
-#: ../src/generic/filedlgg.cpp:205
+#: ../src/generic/filedlgg.cpp:202
 msgid "Go to parent directory"
 msgstr "उपल्लो गर्रामा जाउ"
 
-#: ../src/generic/aboutdlgg.cpp:76
+#: ../src/generic/aboutdlgg.cpp:73
 msgid "Graphics art by "
 msgstr "चित्रकाव्यकन कलाकार"
 
-#: ../src/propgrid/advprops.cpp:1599
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Gray"
 msgstr "खैरो"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:883
+#: ../src/propgrid/advprops.cpp:784
 msgid "GrayText"
 msgstr "खैरोपाठ"
 
-#: ../src/common/fmapbase.cpp:154
+#: ../src/common/fmapbase.cpp:151
 msgid "Greek (ISO-8859-7)"
 msgstr "Greek (ISO-8859-7)"
 
-#: ../src/propgrid/advprops.cpp:1600
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Green"
 msgstr "हरियो"
 
-#: ../src/generic/colrdlgg.cpp:342
+#: ../src/generic/colrdlgg.cpp:362
 #, fuzzy
 msgid "Green:"
 msgstr "हरियो"
@@ -3919,107 +4029,107 @@ msgstr "हरियो"
 msgid "Groove"
 msgstr "दाँती"
 
-#: ../src/common/zstream.cpp:158 ../src/common/zstream.cpp:318
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
 msgid "Gzip not supported by this version of zlib"
 msgstr "यो zlib को संस्करणले Gzip समर्थन गर्दैन ।"
 
-#: ../src/html/helpwnd.cpp:1549
+#: ../src/html/helpwnd.cpp:1547
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "HTML सहयोग योजना (*.hhp)|*.hhp|"
 
-#: ../src/html/htmlwin.cpp:681
+#: ../src/html/htmlwin.cpp:691
 #, c-format
 msgid "HTML anchor %s does not exist."
 msgstr "HTML anchor %s छदै छैन ।"
 
-#: ../src/html/helpwnd.cpp:1547
+#: ../src/html/helpwnd.cpp:1545
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "HTML फाइलहरू (*.html;*.htm)|*.html;*.htm|"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1759
+#: ../src/propgrid/advprops.cpp:1660
 msgid "Hand"
 msgstr "हात"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "Harddisk"
 msgstr "Harddisk"
 
-#: ../src/common/fmapbase.cpp:155
+#: ../src/common/fmapbase.cpp:152
 msgid "Hebrew (ISO-8859-8)"
 msgstr "हिब्रु (ISO-8859-8)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:280 ../src/osx/button_osx.cpp:39
-#: ../src/common/stockitem.cpp:163 ../src/common/accelcmn.cpp:80
-#: ../src/html/helpdlg.cpp:66 ../src/html/helpfrm.cpp:111
+#: ../include/wx/msgdlg.h:282 ../src/osx/button_osx.cpp:39
+#: ../src/common/stockitem.cpp:160 ../src/common/accelcmn.cpp:77
+#: ../src/html/helpfrm.cpp:108 ../src/html/helpdlg.cpp:63
 msgid "Help"
 msgstr "सहयोग"
 
-#: ../src/html/helpwnd.cpp:1200
+#: ../src/html/helpwnd.cpp:1198
 msgid "Help Browser Options"
 msgstr "सहयोगी Browser विकल्पहरू"
 
-#: ../src/generic/helpext.cpp:454 ../src/generic/helpext.cpp:455
+#: ../src/generic/helpext.cpp:452 ../src/generic/helpext.cpp:453
 msgid "Help Index"
 msgstr "सहयोग अनुक्रमणिका"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1529
 msgid "Help Printing"
 msgstr "सहयोग छापिँदै "
 
-#: ../src/html/helpwnd.cpp:801
+#: ../src/html/helpwnd.cpp:799
 msgid "Help Topics"
 msgstr "सहयोग शीर्षक"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1546
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "सहयोग किताबहरू (*.htb)|*.htb|सहयोग किताबहरू (*.zip)|*.zip|"
 
-#: ../src/generic/helpext.cpp:267
+#: ../src/generic/helpext.cpp:265
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "सहयोग घर्रा \"%s\" पाइ एन ।"
 
-#: ../src/generic/helpext.cpp:275
+#: ../src/generic/helpext.cpp:273
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "सहयोग फाइल \"%s\" पाइ एन ।"
 
-#: ../src/html/helpctrl.cpp:63
+#: ../src/html/helpctrl.cpp:59
 #, c-format
 msgid "Help: %s"
 msgstr "सहयोग: %s"
 
-#: ../src/osx/menu_osx.cpp:577
+#: ../src/osx/menu_osx.cpp:469
 #, c-format
 msgid "Hide %s"
 msgstr "%s लुकाउ "
 
-#: ../src/osx/menu_osx.cpp:579
+#: ../src/osx/menu_osx.cpp:471
 msgid "Hide Others"
 msgstr "अरूलाई पनि लुकाउ "
 
-#: ../src/generic/infobar.cpp:84
+#: ../src/generic/infobar.cpp:81
 msgid "Hide this notification message."
 msgstr "सूचना सन्देश लुकाउ "
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:884
+#: ../src/propgrid/advprops.cpp:785
 msgid "Highlight"
 msgstr "प्रकासीकरण"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:885
+#: ../src/propgrid/advprops.cpp:786
 msgid "HighlightText"
 msgstr "प्रकासयुक्त पाठ"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:164 ../src/common/accelcmn.cpp:65
+#: ../src/common/stockitem.cpp:161 ../src/common/accelcmn.cpp:62
 msgid "Home"
 msgstr "गृह"
 
-#: ../src/generic/dirctrlg.cpp:524
+#: ../src/generic/dirctrlg.cpp:490
 msgid "Home directory"
 msgstr "गृह घर्रा"
 
@@ -4029,61 +4139,61 @@ msgid "How the object will float relative to the text."
 msgstr "पाठको सापेक्षतामा कसरी वस्तु वहन गर्ला?"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1760
+#: ../src/propgrid/advprops.cpp:1661
 msgid "I-Beam"
 msgstr "i-बलो"
 
-#: ../src/common/imagbmp.cpp:1196
+#: ../src/common/imagbmp.cpp:1208
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: मखुन्डो खण्ड पढाइमा गल्ती "
 
-#: ../src/common/imagbmp.cpp:1290 ../src/common/imagbmp.cpp:1390
-#: ../src/common/imagbmp.cpp:1405 ../src/common/imagbmp.cpp:1416
-#: ../src/common/imagbmp.cpp:1430 ../src/common/imagbmp.cpp:1478
-#: ../src/common/imagbmp.cpp:1493 ../src/common/imagbmp.cpp:1507
-#: ../src/common/imagbmp.cpp:1518
+#: ../src/common/imagbmp.cpp:1302 ../src/common/imagbmp.cpp:1402
+#: ../src/common/imagbmp.cpp:1417 ../src/common/imagbmp.cpp:1428
+#: ../src/common/imagbmp.cpp:1442 ../src/common/imagbmp.cpp:1490
+#: ../src/common/imagbmp.cpp:1505 ../src/common/imagbmp.cpp:1519
+#: ../src/common/imagbmp.cpp:1530
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: तस्विर फाइल लेखाइमा गल्ती !"
 
-#: ../src/common/imagbmp.cpp:1255
+#: ../src/common/imagbmp.cpp:1267
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: प्रतिमाको लागि तस्विर धेरै अग्लो भयो"
 
-#: ../src/common/imagbmp.cpp:1263
+#: ../src/common/imagbmp.cpp:1275
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: प्रतिमाको लागि तस्विर धेरै चौडा भयो"
 
-#: ../src/common/imagbmp.cpp:1603
+#: ../src/common/imagbmp.cpp:1615
 msgid "ICO: Invalid icon index."
 msgstr "ICO: प्रतिमा अनुक्रमणिका मिलेन"
 
-#: ../src/common/imagiff.cpp:758
+#: ../src/common/imagiff.cpp:755
 msgid "IFF: data stream seems to be truncated."
 msgstr "IFF: तथ्याङ्क काटकुट भए जस्तो छ ।"
 
-#: ../src/common/imagiff.cpp:742
+#: ../src/common/imagiff.cpp:739
 msgid "IFF: error in IFF image format."
 msgstr "IFF: IFF तस्विर स्वरूपमा गल्ती"
 
-#: ../src/common/imagiff.cpp:745
+#: ../src/common/imagiff.cpp:742
 msgid "IFF: not enough memory."
 msgstr "IFF: यथेष्ट भण्डार छैन "
 
-#: ../src/common/imagiff.cpp:748
+#: ../src/common/imagiff.cpp:745
 msgid "IFF: unknown error!!!"
 msgstr "IFF: अज्ञात गल्ती!!!"
 
-#: ../src/common/fmapbase.cpp:197
+#: ../src/common/fmapbase.cpp:194
 msgid "ISO-2022-JP"
 msgstr "ISO-2022-JP"
 
-#: ../src/html/htmprint.cpp:282
+#: ../src/html/htmprint.cpp:294
 msgid ""
 "If possible, try changing the layout parameters to make the printout more "
 "narrow."
 msgstr "छाप्ने सामाग्री लाइ खाँद्न सम्भव छ भने रूपरेखा लाइ बदल्न कशिस गर्नु होला ।"
 
-#: ../src/generic/dbgrptg.cpp:358
+#: ../src/generic/dbgrptg.cpp:362
 msgid ""
 "If you have any additional information pertaining to this bug\n"
 "report, please enter it here and it will be joined to it:"
@@ -4103,46 +4213,50 @@ msgstr ""
 "तर ख्याल राख्नु होस्, यसले कार्यक्रमको स्तरलाई प्रभावित पनि पार्न सक्छ । \n"
 "सम्भव भएसम्म प्रतिवेदन उत्पादन गर्नु उचित हुन्छ ।\n"
 
-#: ../src/msw/registry.cpp:1405
+#: ../src/common/zipstrm.cpp:1043
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1393
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "मान \"%s\" लाई (कुञ्जी \"%s\" ko ) बेवास्ता गरिदै छ ।"
 
-#: ../src/common/xtistrm.cpp:295
+#: ../src/common/xtistrm.cpp:292
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "घटना श्रोतको रूपमा अवैध वस्तु वर्ग (Non-wxEvtHandler) "
 
-#: ../src/common/xti.cpp:513
+#: ../src/common/xti.cpp:510
 msgid "Illegal Parameter Count for ConstructObject Method"
 msgstr "ConstructObject विधिको लागि अवैध Parameter को गणना"
 
-#: ../src/common/xti.cpp:501
+#: ../src/common/xti.cpp:498
 msgid "Illegal Parameter Count for Create Method"
 msgstr "सिर्जना विधिको लागि अवैध Parameter को गणना"
 
-#: ../src/generic/dirctrlg.cpp:570 ../src/generic/filectrlg.cpp:756
+#: ../src/generic/dirctrlg.cpp:536 ../src/generic/filectrlg.cpp:752
 msgid "Illegal directory name."
 msgstr "अवैध घर्राको नाम"
 
-#: ../src/generic/filectrlg.cpp:1367
+#: ../src/generic/filectrlg.cpp:1356
 msgid "Illegal file specification."
 msgstr "अवैध फाइल मानकहरू"
 
-#: ../src/common/image.cpp:2269
+#: ../src/common/image.cpp:2363
 msgid "Image and mask have different sizes."
 msgstr "तस्विर र मखुन्डो फरक फरक आकारका छन् ।"
 
-#: ../src/common/image.cpp:2746
+#: ../src/common/image.cpp:2841
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "तस्विर फाइल %d किसिमको छैन ।"
 
-#: ../src/common/image.cpp:2877
+#: ../src/common/image.cpp:2995
 #, c-format
 msgid "Image is not of type %s."
 msgstr "तस्विर %s किसिमको छैन ।"
 
-#: ../src/msw/textctrl.cpp:488
+#: ../src/msw/textctrl.cpp:534
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -4150,100 +4264,100 @@ msgstr ""
 "सामान्य पाठ नियन्त्रकको प्रयोग गरी rich edit control सिर्जना गर्न सम्भव छैन, कृपया "
 "riched32.dll लाई फेरी स्थापित गर्नु होला ।"
 
-#: ../src/unix/utilsunx.cpp:301
+#: ../src/unix/utilsunx.cpp:303
 msgid "Impossible to get child process input"
 msgstr "शिशु प्रक्रिया लगानी प्राप्त गर्न सम्भव छैन ।"
 
-#: ../src/common/filefn.cpp:1028
+#: ../src/common/filefn.cpp:917
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "फाइल '%s' को स्वीकृति पाउन सम्भव छैन ।"
 
-#: ../src/common/filefn.cpp:1042
+#: ../src/common/filefn.cpp:931
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "फाइल '%s' मेटाएर अर्को फाइल बनाउन सम्भव छैन ।"
 
-#: ../src/common/filefn.cpp:1097
+#: ../src/common/filefn.cpp:986
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "फाइल '%s' को स्वीकृति तय गर्न सम्भव छैन ।"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:886
+#: ../src/propgrid/advprops.cpp:787
 msgid "InactiveBorder"
 msgstr "निस्क्रिय सिमाना"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:887
+#: ../src/propgrid/advprops.cpp:788
 msgid "InactiveCaption"
 msgstr "निस्क्रियशिर्षक"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:888
+#: ../src/propgrid/advprops.cpp:789
 msgid "InactiveCaptionText"
 msgstr "निस्क्रियशिर्षकपाठ"
 
-#: ../src/common/gifdecod.cpp:792
+#: ../src/common/gifdecod.cpp:826
 #, c-format
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "अशुद्ध GIF फ्रेम आकार (%u, %d) (फ्रेम #%u का लागि ) "
 
-#: ../src/msw/ole/automtn.cpp:635
+#: ../src/msw/ole/automtn.cpp:626
 msgid "Incorrect number of arguments."
 msgstr "अशुद्ध arguments सङ्ख्या "
 
-#: ../src/common/stockitem.cpp:165
+#: ../src/common/stockitem.cpp:162
 msgid "Indent"
 msgstr "Indent"
 
-#: ../src/richtext/richtextformatdlg.cpp:349
+#: ../src/richtext/richtextformatdlg.cpp:342
 msgid "Indents && Spacing"
 msgstr "Indents र खालि स्थान"
 
-#: ../src/common/stockitem.cpp:166 ../src/html/helpwnd.cpp:515
+#: ../src/common/stockitem.cpp:163 ../src/html/helpwnd.cpp:513
 msgid "Index"
 msgstr "अनुक्रमणिका"
 
-#: ../src/common/fmapbase.cpp:159
+#: ../src/common/fmapbase.cpp:156
 msgid "Indian (ISO-8859-12)"
 msgstr "भारतीय (ISO-8859-12)"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "Info"
 msgstr "जानकारी"
 
-#: ../src/common/init.cpp:287
+#: ../src/common/init.cpp:284
 msgid "Initialization failed in post init, aborting."
 msgstr "post init मा सुरुवात असफल भयो, त्यसैले तुहिधै छ"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:54
+#: ../src/common/accelcmn.cpp:51
 msgid "Ins"
 msgstr "INS"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextsymboldlg.cpp:472 ../src/common/accelcmn.cpp:53
+#: ../src/common/accelcmn.cpp:50 ../src/richtext/richtextsymboldlg.cpp:469
 msgid "Insert"
 msgstr "घुसाउ"
 
-#: ../src/richtext/richtextbuffer.cpp:8067
+#: ../src/richtext/richtextbuffer.cpp:8063
 msgid "Insert Field"
 msgstr "क्षेत्र घुसाउ"
 
-#: ../src/richtext/richtextbuffer.cpp:7978
-#: ../src/richtext/richtextbuffer.cpp:8936
+#: ../src/richtext/richtextbuffer.cpp:7974
+#: ../src/richtext/richtextbuffer.cpp:8934
 msgid "Insert Image"
 msgstr "तस्विर घुसाउ"
 
-#: ../src/richtext/richtextbuffer.cpp:8025
+#: ../src/richtext/richtextbuffer.cpp:8021
 msgid "Insert Object"
 msgstr "वस्तु घुसाउ"
 
-#: ../src/richtext/richtextctrl.cpp:1286 ../src/richtext/richtextctrl.cpp:1494
-#: ../src/richtext/richtextbuffer.cpp:7822
-#: ../src/richtext/richtextbuffer.cpp:7852
-#: ../src/richtext/richtextbuffer.cpp:7894
+#: ../src/richtext/richtextbuffer.cpp:7818
+#: ../src/richtext/richtextbuffer.cpp:7848
+#: ../src/richtext/richtextbuffer.cpp:7890
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
 msgid "Insert Text"
 msgstr "पाठ घुसाउ"
 
@@ -4256,16 +4370,11 @@ msgstr "अनुच्छेद अगाडि पृष्ट विच्छ
 msgid "Inset"
 msgstr "चित्र भित्रको चित्र"
 
-#: ../src/gtk/app.cpp:425
-#, c-format
-msgid "Invalid GTK+ command line option, use \"%s --help\""
-msgstr "नमिल्दो GTK+ आदेश लाइन विकल्प, \"%s --सहयोग\" को प्रयोग गर्नु होस् ।"
-
-#: ../src/common/imagtiff.cpp:311
+#: ../src/common/imagtiff.cpp:308
 msgid "Invalid TIFF image index."
 msgstr "नमिल्दो TIFF तस्विर अनुक्रमणिका"
 
-#: ../src/common/appcmn.cpp:273
+#: ../src/common/appcmn.cpp:294
 #, c-format
 msgid "Invalid display mode specification '%s'."
 msgstr "नमिल्दो दृश्य मुद्रा मानक '%s'"
@@ -4275,246 +4384,250 @@ msgstr "नमिल्दो दृश्य मुद्रा मानक '%
 msgid "Invalid geometry specification '%s'"
 msgstr "नमिल्दो ज्यामिति मानक '%s'"
 
-#: ../src/unix/fswatcher_inotify.cpp:323
+#: ../src/unix/fswatcher_inotify.cpp:320
 #, c-format
 msgid "Invalid inotify event for \"%s\""
 msgstr "\"%s\" का लागि  सूचीत अवैध  घटना ।"
 
-#: ../src/unix/snglinst.cpp:312
+#: ../src/unix/snglinst.cpp:309
 #, c-format
 msgid "Invalid lock file '%s'."
 msgstr "नमिल्दो चाबी फाइल '%s'"
 
-#: ../src/common/translation.cpp:1125
+#: ../src/common/translation.cpp:1167
 msgid "Invalid message catalog."
 msgstr "नमिल्दो सन्देश सूची"
 
-#: ../src/common/xtistrm.cpp:405 ../src/common/xtistrm.cpp:420
+#: ../src/common/xtistrm.cpp:402 ../src/common/xtistrm.cpp:417
 msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
 msgstr "नमिल्दो अथवा शून्य वस्तु ID GetObjectClassInfo मा पठाइयो ।"
 
-#: ../src/common/xtistrm.cpp:435
+#: ../src/common/xtistrm.cpp:432
 msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
 msgstr "नमिल्दो अथवा शून्य वस्तु ID HasObjectClassInfo मा पठाइयो ।"
 
-#: ../src/common/regex.cpp:310
+#: ../src/common/regex.cpp:307
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "नमिल्दो नियमित अभिव्यक्ति %s': %s"
 
-#: ../src/common/config.cpp:226
+#: ../src/common/config.cpp:222
 #, c-format
 msgid "Invalid value %ld for a boolean key \"%s\" in config file."
 msgstr "मान %ld नमिल्दो छ (अभियोजन फाइलमा boolean कुञ्जी \"%s\" का लागि ) "
 
-#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:351
-#: ../src/osx/carbon/fontdlg.cpp:361 ../src/common/stockitem.cpp:168
+#: ../src/osx/carbon/fontdlg.cpp:358 ../src/common/stockitem.cpp:165
+#: ../src/generic/fontdlgg.cpp:325 ../src/richtext/richtextfontpage.cpp:351
 msgid "Italic"
 msgstr "डल्केको"
 
-#: ../src/common/paper.cpp:130
+#: ../src/common/paper.cpp:127
 msgid "Italy Envelope, 110 x 230 mm"
 msgstr "Italy खाम, 110 x 230 मिमी"
 
-#: ../src/common/imagjpeg.cpp:270
+#: ../src/common/imagjpeg.cpp:257
 msgid "JPEG: Couldn't load - file is probably corrupted."
 msgstr "JPEG: वहन गर्न सकिएन- सम्भवतः फाइल बिग्रिएको छ ।"
 
-#: ../src/common/imagjpeg.cpp:449
+#: ../src/common/imagjpeg.cpp:436
 msgid "JPEG: Couldn't save image."
 msgstr "JPEG: तस्विर बचत गर्न सकिएन ।"
 
-#: ../src/common/paper.cpp:163
+#: ../src/common/paper.cpp:160
 msgid "Japanese Double Postcard 200 x 148 mm"
 msgstr "जापानी दोबर पोस्टकार्ड 200 x 148 मिमी"
 
-#: ../src/common/paper.cpp:167
+#: ../src/common/paper.cpp:164
 msgid "Japanese Envelope Chou #3"
 msgstr "जापानी खाम Chou #3"
 
-#: ../src/common/paper.cpp:180
+#: ../src/common/paper.cpp:177
 msgid "Japanese Envelope Chou #3 Rotated"
 msgstr "जापानी खाम Chou #3 Rounded"
 
-#: ../src/common/paper.cpp:168
+#: ../src/common/paper.cpp:165
 msgid "Japanese Envelope Chou #4"
 msgstr "जापानी खाम Chou #4"
 
-#: ../src/common/paper.cpp:181
+#: ../src/common/paper.cpp:178
 msgid "Japanese Envelope Chou #4 Rotated"
 msgstr "जापानी खाम Chou #4 Rounded"
 
-#: ../src/common/paper.cpp:165
+#: ../src/common/paper.cpp:162
 msgid "Japanese Envelope Kaku #2"
 msgstr "जापानी खाम Kaku #2"
 
-#: ../src/common/paper.cpp:178
+#: ../src/common/paper.cpp:175
 msgid "Japanese Envelope Kaku #2 Rotated"
 msgstr "जापानी खाम Kaku #2 Rounded"
 
-#: ../src/common/paper.cpp:166
+#: ../src/common/paper.cpp:163
 msgid "Japanese Envelope Kaku #3"
 msgstr "जापानी खाम Kaku #3"
 
-#: ../src/common/paper.cpp:179
+#: ../src/common/paper.cpp:176
 msgid "Japanese Envelope Kaku #3 Rotated"
 msgstr "जापानी खाम Kaku #3 Rounded"
 
-#: ../src/common/paper.cpp:185
+#: ../src/common/paper.cpp:182
 msgid "Japanese Envelope You #4"
 msgstr "जापानी खाम You #4"
 
-#: ../src/common/paper.cpp:186
+#: ../src/common/paper.cpp:183
 msgid "Japanese Envelope You #4 Rotated"
 msgstr "जापानी खाम You #4 Rounded"
 
-#: ../src/common/paper.cpp:138
+#: ../src/common/paper.cpp:135
 msgid "Japanese Postcard 100 x 148 mm"
 msgstr "जापानी पोस्टकार्ड Postcard 100 x 148 मिमी"
 
-#: ../src/common/paper.cpp:175
+#: ../src/common/paper.cpp:172
 msgid "Japanese Postcard Rotated 148 x 100 mm"
 msgstr "जापानी पोस्टकार्ड Rounded 148 x 100 मिमी"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "Jump to"
 msgstr "फड्को मार "
 
-#: ../src/common/stockitem.cpp:171
+#: ../src/common/stockitem.cpp:168
 msgid "Justified"
 msgstr "धुबै सिमाना"
 
-#: ../src/richtext/richtextindentspage.cpp:155
-#: ../src/richtext/richtextindentspage.cpp:157
 #: ../src/richtext/richtextliststylepage.cpp:344
 #: ../src/richtext/richtextliststylepage.cpp:346
+#: ../src/richtext/richtextindentspage.cpp:155
+#: ../src/richtext/richtextindentspage.cpp:157
 msgid "Justify text left and right."
 msgstr "पाठलाई देब्रे र दाहिने किनारमा मिलाउ ।"
 
-#: ../src/common/fmapbase.cpp:163
+#: ../src/common/fmapbase.cpp:160
 msgid "KOI8-R"
 msgstr "KOI8-R"
 
-#: ../src/common/fmapbase.cpp:164
+#: ../src/common/fmapbase.cpp:161
 msgid "KOI8-U"
 msgstr "KOI8-U"
 
-#: ../src/common/accelcmn.cpp:265 ../src/common/accelcmn.cpp:347
+#: ../src/common/accelcmn.cpp:279 ../src/common/accelcmn.cpp:364
 msgid "KP_"
 msgstr "KP_"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "KP_Add"
 msgstr "KP_थप"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "KP_Begin"
 msgstr "KP_सुरु"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "KP_Decimal"
 msgstr "KP_दशमलव"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 msgid "KP_Delete"
 msgstr "KP_मेटाइ देउ"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "KP_Divide"
 msgstr "KP_भाग गर"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 msgid "KP_Down"
 msgstr "KP_तल"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "KP_End"
 msgstr "KP_अन्त्य"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "KP_Enter"
 msgstr "KP_ENTER"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "KP_Equal"
 msgstr "KP_बराबर"
 
+#: ../src/common/accelcmn.cpp:276 ../src/common/accelcmn.cpp:361
+msgid "KP_F"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 msgid "KP_Home"
 msgstr "KP_गृह"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 msgid "KP_Insert"
 msgstr "KP_INSERT"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "KP_Left"
 msgstr "KP_देब्रे"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "KP_Multiply"
 msgstr "KP_गुणन"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:99
+#: ../src/common/accelcmn.cpp:97
 msgid "KP_Next"
 msgstr "KP_अघिल्लो"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "KP_PageDown"
 msgstr "KP_तल्लो पृष्ट"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "KP_PageUp"
 msgstr "KP_माथिल्लो पृष्ट"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:98
+#: ../src/common/accelcmn.cpp:96
 msgid "KP_Prior"
 msgstr "KP_अघिल्लो"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 msgid "KP_Right"
 msgstr "KP_दाहिने"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "KP_Separator"
 msgstr "KP_विभाजक"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "KP_Space"
 msgstr "KP_SPACE"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "KP_Subtract"
 msgstr "KP_घटाउ"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "KP_Tab"
 msgstr "KP_TAB"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "KP_Up"
 msgstr "KP_माथि"
 
@@ -4522,112 +4635,127 @@ msgstr "KP_माथि"
 msgid "L&ine spacing:"
 msgstr "&रेखा को फरक:"
 
-#: ../src/generic/prntdlgg.cpp:613 ../src/generic/prntdlgg.cpp:868
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "दबाब गल्ती"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "दबाब विहीनता गल्ती"
+
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:861
 msgid "Landscape"
 msgstr "तेर्सो"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "Last"
 msgstr "अन्तिम"
 
-#: ../src/common/prntbase.cpp:1572
+#: ../src/common/prntbase.cpp:1597
 msgid "Last page"
 msgstr "अन्तिम पृष्ट"
 
-#: ../src/common/log.cpp:305
+#: ../src/common/log.cpp:324
 #, fuzzy, c-format
 msgid "Last repeated message (\"%s\", %u time) wasn't output"
 msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
 msgstr[0] "दोहोरिएको अन्तिम सन्देश (\"%s\", %lu पटक) प्रतिफल थिएन"
 msgstr[1] "दोहोरिएको अन्तिम सन्देश (\"%s\", %lu पटकमात्र) प्रतिफल थिएन"
 
-#: ../src/common/paper.cpp:103
+#: ../src/common/paper.cpp:100
 msgid "Ledger, 17 x 11 in"
 msgstr "लेजर , 17 x 11इन्च"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6146
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:58 ../src/generic/datavgen.cpp:6951
+#: ../src/richtext/richtextsizepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:252
 #: ../src/richtext/richtextliststylepage.cpp:253
 #: ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
-#: ../src/richtext/richtextsizepage.cpp:249 ../src/common/accelcmn.cpp:61
 msgid "Left"
 msgstr "देब्रे"
 
-#: ../src/richtext/richtextindentspage.cpp:204
 #: ../src/richtext/richtextliststylepage.cpp:390
+#: ../src/richtext/richtextindentspage.cpp:204
 msgid "Left (&first line):"
 msgstr "देब्रे (&प्रथम line):"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1761
+#: ../src/propgrid/advprops.cpp:1662
 msgid "Left Button"
 msgstr "वाञाँ टाँक"
 
-#: ../src/generic/prntdlgg.cpp:880
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Left margin (mm):"
 msgstr "देब्रे सिमान्त(मिमी):"
 
-#: ../src/richtext/richtextindentspage.cpp:141
-#: ../src/richtext/richtextindentspage.cpp:143
 #: ../src/richtext/richtextliststylepage.cpp:330
 #: ../src/richtext/richtextliststylepage.cpp:332
+#: ../src/richtext/richtextindentspage.cpp:141
+#: ../src/richtext/richtextindentspage.cpp:143
 msgid "Left-align text."
 msgstr "देब्रे-पङ्क्ति पाठ"
 
-#: ../src/common/paper.cpp:144
+#: ../src/common/paper.cpp:141
 msgid "Legal Extra 9 1/2 x 15 in"
 msgstr "Legal Extra 9 1/2 x 15इन्च"
 
-#: ../src/common/paper.cpp:96
+#: ../src/common/paper.cpp:93
 msgid "Legal, 8 1/2 x 14 in"
 msgstr "Legal, 8 1/2 x 14इन्च"
 
-#: ../src/common/paper.cpp:143
+#: ../src/common/paper.cpp:140
 msgid "Letter Extra 9 1/2 x 12 in"
 msgstr "Letter Extra 9 1/2 x 12इन्च"
 
-#: ../src/common/paper.cpp:149
+#: ../src/common/paper.cpp:146
 msgid "Letter Extra Transverse 9.275 x 12 in"
 msgstr "Letter Extra Transverse 9.275 x 12इन्च"
 
-#: ../src/common/paper.cpp:152
+#: ../src/common/paper.cpp:149
 msgid "Letter Plus 8 1/2 x 12.69 in"
 msgstr "Letter Plus 8 1/2 x 12.69इन्च"
 
-#: ../src/common/paper.cpp:169
+#: ../src/common/paper.cpp:166
 msgid "Letter Rotated 11 x 8 1/2 in"
 msgstr "Letter Rounded 11 x 8 1/2इन्च"
 
-#: ../src/common/paper.cpp:101
+#: ../src/common/paper.cpp:98
 msgid "Letter Small, 8 1/2 x 11 in"
 msgstr "Letter Small, 8 1/2 x 11इन्च"
 
-#: ../src/common/paper.cpp:147
+#: ../src/common/paper.cpp:144
 msgid "Letter Transverse 8 1/2 x 11 in"
 msgstr "Letter Transverse 8 1/2 x 11इन्च"
 
-#: ../src/common/paper.cpp:95
+#: ../src/common/paper.cpp:92
 msgid "Letter, 8 1/2 x 11 in"
 msgstr "Letter, 8 1/2 x 11इन्च"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "License"
 msgstr "इजाजत"
 
-#: ../src/generic/fontdlgg.cpp:332
+#: ../src/generic/fontdlgg.cpp:328
 msgid "Light"
 msgstr "हलुको"
 
-#: ../src/propgrid/advprops.cpp:1608
+#: ../src/propgrid/advprops.cpp:1514
 msgid "Lime"
 msgstr "कागती"
 
-#: ../src/generic/helpext.cpp:294
+#: ../src/generic/helpext.cpp:292
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr "लाइन %lu मा (नक्सा फाइल \"%s\" ) नमिल्दो लेखाइ छ, फड्को मारेर जाउ"
@@ -4636,15 +4764,15 @@ msgstr "लाइन %lu मा (नक्सा फाइल \"%s\" ) नमि
 msgid "Line spacing:"
 msgstr "लाइनको फरक:"
 
-#: ../src/html/chm.cpp:838
+#: ../src/html/chm.cpp:829
 msgid "Link contained '//', converted to absolute link."
 msgstr "लिङ्क मा '//' छ, पुर्ण लिङ्कमा बदलियो ।"
 
-#: ../src/richtext/richtextformatdlg.cpp:364
+#: ../src/richtext/richtextformatdlg.cpp:357
 msgid "List Style"
 msgstr "शैलीको सुची"
 
-#: ../src/richtext/richtextstyles.cpp:1064
+#: ../src/richtext/richtextstyles.cpp:1061
 msgid "List styles"
 msgstr "शैलीहरूको सुची"
 
@@ -4658,26 +4786,26 @@ msgstr "वरणाकृतिका आकारहरूको सुची 
 msgid "Lists the available fonts."
 msgstr "उपलब्ध वरणाकृतिहरूको सुची"
 
-#: ../src/common/fldlgcmn.cpp:340
+#: ../src/common/fldlgcmn.cpp:337
 #, c-format
 msgid "Load %s file"
 msgstr "%s फाइल वहन गर "
 
-#: ../src/html/htmlwin.cpp:597
+#: ../src/html/htmlwin.cpp:600
 msgid "Loading : "
 msgstr "वहन गरिदैं : "
 
-#: ../src/unix/snglinst.cpp:246
+#: ../src/unix/snglinst.cpp:243
 #, c-format
 msgid "Lock file '%s' has incorrect owner."
 msgstr "चाबी फाइल '%s' को नमिल्दो owner छ ।"
 
-#: ../src/unix/snglinst.cpp:251
+#: ../src/unix/snglinst.cpp:248
 #, c-format
 msgid "Lock file '%s' has incorrect permissions."
 msgstr "चाबी फाइल '%s' को अनुमति अवैध छ ।"
 
-#: ../src/generic/logg.cpp:576
+#: ../src/generic/logg.cpp:573
 #, c-format
 msgid "Log saved to the file '%s'."
 msgstr "लग फाइल '%s' मा बचत भयो ।"
@@ -4692,11 +4820,11 @@ msgstr "सानो वर्णहरू"
 msgid "Lower case roman numerals"
 msgstr "सानो वर्ण रोमन सङ्ख्या"
 
-#: ../src/gtk/mdi.cpp:422 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk1/mdi.cpp:431 ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "MDI शिशु"
 
-#: ../src/msw/helpchm.cpp:56
+#: ../src/msw/helpchm.cpp:53
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -4704,189 +4832,189 @@ msgstr ""
 "यो कम्प्युटरमा MS HTML सहयोग पुस्तकालय स्थापित नभएकोले MS HTML सहयोग उपलब्ध भएन । "
 "कृपया यसलाई स्थापना गर्नु होला ।"
 
-#: ../src/univ/themes/win32.cpp:3754
+#: ../src/univ/themes/win32.cpp:3751
 msgid "Ma&ximize"
 msgstr "&ठूलो बनाउ"
 
-#: ../src/common/fmapbase.cpp:203
+#: ../src/common/fmapbase.cpp:200
 msgid "MacArabic"
 msgstr "MacArabic"
 
-#: ../src/common/fmapbase.cpp:222
+#: ../src/common/fmapbase.cpp:219
 msgid "MacArmenian"
 msgstr "MacArmenian"
 
-#: ../src/common/fmapbase.cpp:211
+#: ../src/common/fmapbase.cpp:208
 msgid "MacBengali"
 msgstr "MacBengali"
 
-#: ../src/common/fmapbase.cpp:217
+#: ../src/common/fmapbase.cpp:214
 msgid "MacBurmese"
 msgstr "MacBurmese"
 
-#: ../src/common/fmapbase.cpp:236
+#: ../src/common/fmapbase.cpp:233
 msgid "MacCeltic"
 msgstr "MacCeltic"
 
-#: ../src/common/fmapbase.cpp:227
+#: ../src/common/fmapbase.cpp:224
 msgid "MacCentralEurRoman"
 msgstr "MacCentralEurRoman"
 
-#: ../src/common/fmapbase.cpp:223
+#: ../src/common/fmapbase.cpp:220
 msgid "MacChineseSimp"
 msgstr "MacChineseSimp"
 
-#: ../src/common/fmapbase.cpp:201
+#: ../src/common/fmapbase.cpp:198
 msgid "MacChineseTrad"
 msgstr "MacChineseTrad"
 
-#: ../src/common/fmapbase.cpp:233
+#: ../src/common/fmapbase.cpp:230
 msgid "MacCroatian"
 msgstr "MacCroatian"
 
-#: ../src/common/fmapbase.cpp:206
+#: ../src/common/fmapbase.cpp:203
 msgid "MacCyrillic"
 msgstr "MacCyrillic"
 
-#: ../src/common/fmapbase.cpp:207
+#: ../src/common/fmapbase.cpp:204
 msgid "MacDevanagari"
 msgstr "MacDevanagari"
 
-#: ../src/common/fmapbase.cpp:231
+#: ../src/common/fmapbase.cpp:228
 msgid "MacDingbats"
 msgstr "MacDingbats"
 
-#: ../src/common/fmapbase.cpp:226
+#: ../src/common/fmapbase.cpp:223
 msgid "MacEthiopic"
 msgstr "MacEthiopic"
 
-#: ../src/common/fmapbase.cpp:229
+#: ../src/common/fmapbase.cpp:226
 msgid "MacExtArabic"
 msgstr "MacExtArabic"
 
-#: ../src/common/fmapbase.cpp:237
+#: ../src/common/fmapbase.cpp:234
 msgid "MacGaelic"
 msgstr "MacGaelic"
 
-#: ../src/common/fmapbase.cpp:221
+#: ../src/common/fmapbase.cpp:218
 msgid "MacGeorgian"
 msgstr "MacGeorgian"
 
-#: ../src/common/fmapbase.cpp:205
+#: ../src/common/fmapbase.cpp:202
 msgid "MacGreek"
 msgstr "MacGreek"
 
-#: ../src/common/fmapbase.cpp:209
+#: ../src/common/fmapbase.cpp:206
 msgid "MacGujarati"
 msgstr "MacGujarati"
 
-#: ../src/common/fmapbase.cpp:208
+#: ../src/common/fmapbase.cpp:205
 msgid "MacGurmukhi"
 msgstr "MacGurmukhi"
 
-#: ../src/common/fmapbase.cpp:204
+#: ../src/common/fmapbase.cpp:201
 msgid "MacHebrew"
 msgstr "MacHebrew"
 
-#: ../src/common/fmapbase.cpp:234
+#: ../src/common/fmapbase.cpp:231
 msgid "MacIcelandic"
 msgstr "MacIcelandic"
 
-#: ../src/common/fmapbase.cpp:200
+#: ../src/common/fmapbase.cpp:197
 msgid "MacJapanese"
 msgstr "MacJapanese"
 
-#: ../src/common/fmapbase.cpp:214
+#: ../src/common/fmapbase.cpp:211
 msgid "MacKannada"
 msgstr "MacKannada"
 
-#: ../src/common/fmapbase.cpp:238
+#: ../src/common/fmapbase.cpp:235
 msgid "MacKeyboardGlyphs"
 msgstr "MacKeyboardGlyphs"
 
-#: ../src/common/fmapbase.cpp:218
+#: ../src/common/fmapbase.cpp:215
 msgid "MacKhmer"
 msgstr "MacKhmer"
 
-#: ../src/common/fmapbase.cpp:202
+#: ../src/common/fmapbase.cpp:199
 msgid "MacKorean"
 msgstr "MacKorean"
 
-#: ../src/common/fmapbase.cpp:220
+#: ../src/common/fmapbase.cpp:217
 msgid "MacLaotian"
 msgstr "MacLaotian"
 
-#: ../src/common/fmapbase.cpp:215
+#: ../src/common/fmapbase.cpp:212
 msgid "MacMalayalam"
 msgstr "MacMalayalam"
 
-#: ../src/common/fmapbase.cpp:225
+#: ../src/common/fmapbase.cpp:222
 msgid "MacMongolian"
 msgstr "MacMongolian"
 
-#: ../src/common/fmapbase.cpp:210
+#: ../src/common/fmapbase.cpp:207
 msgid "MacOriya"
 msgstr "MacOriya"
 
-#: ../src/common/fmapbase.cpp:199
+#: ../src/common/fmapbase.cpp:196
 msgid "MacRoman"
 msgstr "MacRoman"
 
-#: ../src/common/fmapbase.cpp:235
+#: ../src/common/fmapbase.cpp:232
 msgid "MacRomanian"
 msgstr "MacRomanian"
 
-#: ../src/common/fmapbase.cpp:216
+#: ../src/common/fmapbase.cpp:213
 msgid "MacSinhalese"
 msgstr "MacSinhalese"
 
-#: ../src/common/fmapbase.cpp:230
+#: ../src/common/fmapbase.cpp:227
 msgid "MacSymbol"
 msgstr "MacSymbol"
 
-#: ../src/common/fmapbase.cpp:212
+#: ../src/common/fmapbase.cpp:209
 msgid "MacTamil"
 msgstr "MacTamil"
 
-#: ../src/common/fmapbase.cpp:213
+#: ../src/common/fmapbase.cpp:210
 msgid "MacTelugu"
 msgstr "MacTelugu"
 
-#: ../src/common/fmapbase.cpp:219
+#: ../src/common/fmapbase.cpp:216
 msgid "MacThai"
 msgstr "MacThai"
 
-#: ../src/common/fmapbase.cpp:224
+#: ../src/common/fmapbase.cpp:221
 msgid "MacTibetan"
 msgstr "MacTibetan"
 
-#: ../src/common/fmapbase.cpp:232
+#: ../src/common/fmapbase.cpp:229
 msgid "MacTurkish"
 msgstr "MacTurkish"
 
-#: ../src/common/fmapbase.cpp:228
+#: ../src/common/fmapbase.cpp:225
 msgid "MacVietnamese"
 msgstr "MacVietnamese"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1762
+#: ../src/propgrid/advprops.cpp:1663
 msgid "Magnifier"
 msgstr "अभिबर्धक"
 
-#: ../src/propgrid/advprops.cpp:2143
+#: ../src/propgrid/advprops.cpp:2050
 msgid "Make a selection:"
 msgstr "चयन गर"
 
-#: ../src/richtext/richtextformatdlg.cpp:374
+#: ../src/richtext/richtextformatdlg.cpp:367
 #: ../src/richtext/richtextmarginspage.cpp:171
 msgid "Margins"
 msgstr "सिमान्त"
 
-#: ../src/propgrid/advprops.cpp:1595
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Maroon"
 msgstr "गम्भिर"
 
-#: ../src/generic/fdrepdlg.cpp:147
+#: ../src/generic/fdrepdlg.cpp:144
 msgid "Match case"
 msgstr "वर्ण मिलान"
 
@@ -4898,40 +5026,40 @@ msgstr "अधिकतम उचाइ:"
 msgid "Max width:"
 msgstr "अधिकतम छोडाइ:"
 
-#: ../src/unix/mediactrl.cpp:947
+#: ../src/unix/mediactrl.cpp:972
 #, c-format
 msgid "Media playback error: %s"
 msgstr "श्रव्य सामाग्री पृष्ठध्वनी त्रुटी: %s"
 
-#: ../src/common/fs_mem.cpp:175
+#: ../src/common/fs_mem.cpp:170
 #, c-format
 msgid "Memory VFS already contains file '%s'!"
 msgstr "भण्डार VFS मा पहिले नै फाइल '%s' राखिएको छ!"
 
 #. TRANSLATORS: Name of keyboard key
 #. TRANSLATORS: Keyword of system colour
-#: ../src/common/accelcmn.cpp:73 ../src/propgrid/advprops.cpp:889
+#: ../src/common/accelcmn.cpp:70 ../src/propgrid/advprops.cpp:790
 msgid "Menu"
 msgstr "मेनु"
 
-#: ../src/common/msgout.cpp:124
+#: ../src/common/msgout.cpp:121
 msgid "Message"
 msgstr "सन्देश"
 
-#: ../src/univ/themes/metal.cpp:168
+#: ../src/univ/themes/metal.cpp:165
 msgid "Metal theme"
 msgstr "धातु theme"
 
-#: ../src/msw/ole/automtn.cpp:652
+#: ../src/msw/ole/automtn.cpp:643
 msgid "Method or property not found."
 msgstr "विधि अथवा गुण पाइ एन ।"
 
-#: ../src/univ/themes/win32.cpp:3752
+#: ../src/univ/themes/win32.cpp:3749
 msgid "Mi&nimize"
 msgstr "&सूक्ष्म बनाउ"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1763
+#: ../src/propgrid/advprops.cpp:1664
 msgid "Middle Button"
 msgstr "मध्य टाँक"
 
@@ -4943,36 +5071,41 @@ msgstr "न्यून उचाइ:"
 msgid "Min width:"
 msgstr "न्यून छोडाइ:"
 
-#: ../src/msw/ole/automtn.cpp:668
+#: ../src/osx/cocoa/menu.mm:281
+#, fuzzy
+msgid "Minimize"
+msgstr "&सूक्ष्म बनाउ"
+
+#: ../src/msw/ole/automtn.cpp:659
 msgid "Missing a required parameter."
 msgstr "आवश्यक parameter छुडेको छ"
 
-#: ../src/generic/fontdlgg.cpp:324
+#: ../src/generic/fontdlgg.cpp:320
 msgid "Modern"
 msgstr "आधुनिक"
 
-#: ../src/generic/filectrlg.cpp:427
+#: ../src/generic/filectrlg.cpp:423
 msgid "Modified"
 msgstr "परिवर्तित"
 
-#: ../src/common/module.cpp:133
+#: ../src/common/module.cpp:130
 #, c-format
 msgid "Module \"%s\" initialization failed"
 msgstr "Module \"%s\" को सुरुवात असफल भयो ।failed"
 
-#: ../src/common/paper.cpp:131
+#: ../src/common/paper.cpp:128
 msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
 msgstr "आधुनिक खाम, 3 7/8 x 7 1/2इन्च"
 
-#: ../src/msw/fswatcher.cpp:143
+#: ../src/msw/fswatcher.cpp:140
 msgid "Monitoring individual files for changes is not supported currently."
 msgstr "हाल व्यक्तिगत फाइलको परिवर्तन अनुगमनलाई समर्थन गर्दैन ।"
 
-#: ../src/generic/editlbox.cpp:172
+#: ../src/generic/editlbox.cpp:160
 msgid "Move down"
 msgstr "तल जाउ "
 
-#: ../src/generic/editlbox.cpp:171
+#: ../src/generic/editlbox.cpp:155
 msgid "Move up"
 msgstr "माथि जाउ "
 
@@ -4986,97 +5119,103 @@ msgstr "अघिल्लो अनुच्छेदमा वस्तुल�
 msgid "Moves the object to the previous paragraph."
 msgstr "पछिल्लो अनुच्छेदमा वस्तुलाई लैजान्छ । "
 
-#: ../src/richtext/richtextbuffer.cpp:9966
+#: ../src/richtext/richtextbuffer.cpp:9963
 msgid "Multiple Cell Properties"
 msgstr "बहु कोशिका गुणहरू"
 
-#: ../src/generic/filectrlg.cpp:424
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:82
+#, fuzzy
+msgid "Multiply"
+msgstr "KP_गुणन"
+
+#: ../src/generic/filectrlg.cpp:420
 msgid "Name"
 msgstr "नाम"
 
-#: ../src/propgrid/advprops.cpp:1596
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Navy"
 msgstr "समुन्द्री नीलो"
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "Network"
 msgstr "सञ्जाल"
 
-#: ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173
 msgid "New"
 msgstr "नया"
 
-#: ../src/richtext/richtextstyledlg.cpp:243
+#: ../src/richtext/richtextstyledlg.cpp:239
 msgid "New &Box Style..."
 msgstr "नया &बाकस शैली.."
 
-#: ../src/richtext/richtextstyledlg.cpp:225
+#: ../src/richtext/richtextstyledlg.cpp:221
 msgid "New &Character Style..."
 msgstr "नया &वर्ण शैली.."
 
-#: ../src/richtext/richtextstyledlg.cpp:237
+#: ../src/richtext/richtextstyledlg.cpp:233
 msgid "New &List Style..."
 msgstr "नया &सूचि शैली.."
 
-#: ../src/richtext/richtextstyledlg.cpp:231
+#: ../src/richtext/richtextstyledlg.cpp:227
 msgid "New &Paragraph Style..."
 msgstr "नया &अनुच्छेद शैली.."
 
-#: ../src/richtext/richtextstyledlg.cpp:606
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:654
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:820
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:893
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:934
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:602
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:650
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:816
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:889
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:930
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "New Style"
 msgstr "नया शैली"
 
-#: ../src/generic/editlbox.cpp:169
+#: ../src/generic/editlbox.cpp:139
 msgid "New item"
 msgstr "नया सामाग्री"
 
-#: ../src/generic/dirdlgg.cpp:297 ../src/generic/dirdlgg.cpp:307
-#: ../src/generic/filectrlg.cpp:618 ../src/generic/filectrlg.cpp:627
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+#: ../src/generic/dirdlgg.cpp:294 ../src/generic/dirdlgg.cpp:304
 msgid "NewName"
 msgstr "नया नाम"
 
-#: ../src/common/prntbase.cpp:1567 ../src/html/helpwnd.cpp:665
+#: ../src/common/prntbase.cpp:1592 ../src/html/helpwnd.cpp:663
 msgid "Next page"
 msgstr "अघिल्लो पृष्ट"
 
-#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:177
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:174
 #: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "होइन"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1764
+#: ../src/propgrid/advprops.cpp:1665
 msgid "No Entry"
 msgstr "प्रविष्टि हिन "
 
-#: ../src/generic/animateg.cpp:150
+#: ../src/generic/animateg.cpp:133
 #, c-format
 msgid "No animation handler for type %ld defined."
 msgstr "चलायमान सञ्चालक %ld जस्ताका लागि परिभाषित गरिएको छैन ।"
 
-#: ../src/dfb/bitmap.cpp:642 ../src/dfb/bitmap.cpp:676
+#: ../src/dfb/bitmap.cpp:639 ../src/dfb/bitmap.cpp:673
 #, c-format
 msgid "No bitmap handler for type %d defined."
 msgstr "%d किसिमको लागि कुनै पनि bitmap सञ्चालक परिभाषित गरिएको छैन।"
 
-#: ../src/common/utilscmn.cpp:1077
+#: ../src/common/utilscmn.cpp:1095
 msgid "No default application configured for HTML files."
 msgstr "HTML फाइलहरूका लागि निर्धारित अनुप्रयोग अनियोजित छैन ।"
 
-#: ../src/generic/helpext.cpp:445
+#: ../src/generic/helpext.cpp:443
 msgid "No entries found."
 msgstr "कुनै प्रविष्टि पाइ एन"
 
-#: ../src/common/fontmap.cpp:421
+#: ../src/common/fontmap.cpp:418
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found,\n"
@@ -5088,7 +5227,7 @@ msgstr ""
 "तर वैकल्पिक अनुसंहिता '%s' भने उपलब्ध छ । \n"
 "के तपाइ यो अनुसंहिता लाई प्रयोग गर्न चाहनु हुन्छ (अन्यथा तपाइले अर्कै छान्नु पर्छ)?"
 
-#: ../src/common/fontmap.cpp:426
+#: ../src/common/fontmap.cpp:423
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found.\n"
@@ -5099,201 +5238,201 @@ msgstr ""
 "के तपाई यो अनुसंहितामा धेखाउनका लागि कुनै वर्णाकृति चयन गर्नु हुन्छ? \n"
 "(अन्यथा यो अनुसंहितामा कुनै पनि पाठ शुद्ध रूपमा देखाउन सकिदैन)?"
 
-#: ../src/generic/animateg.cpp:142
+#: ../src/generic/animateg.cpp:125
 msgid "No handler found for animation type."
 msgstr "चलायमान किसिमको लागि कुनै चालक पाइ एन ।"
 
-#: ../src/common/image.cpp:2728
+#: ../src/common/image.cpp:2823
 msgid "No handler found for image type."
 msgstr "तस्विर किसिमको लागि कुनै चालक पाइ एन ।"
 
-#: ../src/common/image.cpp:2736 ../src/common/image.cpp:2848
-#: ../src/common/image.cpp:2901
+#: ../src/common/image.cpp:2831 ../src/common/image.cpp:2954
+#: ../src/common/image.cpp:3020
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "तोकिएको %d किसिमका लागि तस्विर चालक छैन ।"
 
-#: ../src/common/image.cpp:2871 ../src/common/image.cpp:2915
+#: ../src/common/image.cpp:2986 ../src/common/image.cpp:3034
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "तोकिएको %s किसिमका लागि तस्विर चालक छैन ।"
 
-#: ../src/html/helpwnd.cpp:858
+#: ../src/html/helpwnd.cpp:856
 msgid "No matching page found yet"
 msgstr "मिल्दो पृष्ट अझसम्म पाइ एन ।"
 
-#: ../src/unix/sound.cpp:81
+#: ../src/unix/sound.cpp:78
 msgid "No sound"
 msgstr "आवाज छैन "
 
-#: ../src/common/image.cpp:2277 ../src/common/image.cpp:2318
+#: ../src/common/image.cpp:2371 ../src/common/image.cpp:2412
 msgid "No unused colour in image being masked."
 msgstr "तस्विरमा प्रयोग नगरिएको रङ्ग मकुन्डोमा चलाएन ।"
 
-#: ../src/common/image.cpp:3374
-msgid "No unused colour in image."
-msgstr "तस्विरमा प्रयोग नगरेको रङ्ग छैन ।"
-
-#: ../src/generic/helpext.cpp:302
+#: ../src/generic/helpext.cpp:300
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "फाइल \"%s\" मा वैध रङ्गिन नक्सा पाइ एन ।"
 
-#: ../src/richtext/richtextborderspage.cpp:610
 #: ../src/richtext/richtextsizepage.cpp:248
 #: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:610
 msgid "None"
 msgstr "कुनै पनि होइन"
 
-#: ../src/common/fmapbase.cpp:157
+#: ../src/common/fmapbase.cpp:154
 msgid "Nordic (ISO-8859-10)"
 msgstr "Nordic (ISO-8859-10)"
 
-#: ../src/generic/fontdlgg.cpp:328 ../src/generic/fontdlgg.cpp:331
+#: ../src/generic/fontdlgg.cpp:324 ../src/generic/fontdlgg.cpp:327
 msgid "Normal"
 msgstr "साधारण"
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1261
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "साधारण अनुहार<br>and <u> अधोरेखाङ्कित </u>. "
 
-#: ../src/html/helpwnd.cpp:1205
+#: ../src/html/helpwnd.cpp:1203
 msgid "Normal font:"
 msgstr "साधारण वरणाकृति:"
 
-#: ../src/propgrid/props.cpp:1128
+#: ../src/propgrid/props.cpp:1115
 #, c-format
 msgid "Not %s"
 msgstr "%s होइन"
 
-#: ../include/wx/filename.h:573 ../include/wx/filename.h:578
-msgid "Not available"
-msgstr "उपलब्ध छैन"
+#: ../src/common/secretstore.cpp:168
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/webrequest.cpp:605
+msgid "Not enough free disk space for download."
+msgstr ""
 
 #: ../src/richtext/richtextfontpage.cpp:358
 msgid "Not underlined"
 msgstr "अधोरेखाङ्कित होइन"
 
-#: ../src/common/paper.cpp:115
+#: ../src/common/paper.cpp:112
 msgid "Note, 8 1/2 x 11 in"
 msgstr "टिप्पणी, 8 1/2 x 11इन्च"
 
-#: ../src/generic/notifmsgg.cpp:132
+#: ../src/generic/notifmsgg.cpp:129
 msgid "Notice"
 msgstr "सूचना"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "Num *"
 msgstr "Num *"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "Num +"
 msgstr "Num +"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "Num ,"
 msgstr "Num ,"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "Num -"
 msgstr "Num -"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "Num ."
 msgstr "Num ."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "Num /"
 msgstr "Num /"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "Num ="
 msgstr "Num ="
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "Num Begin"
 msgstr "Num Begin"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 msgid "Num Delete"
 msgstr "Num Delete"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 msgid "Num Down"
 msgstr "Num Down"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "Num End"
 msgstr "Num End"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "Num Enter"
 msgstr "Num Enter"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 msgid "Num Home"
 msgstr "Num Home"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 msgid "Num Insert"
 msgstr "Num Insert"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num Lock"
 msgstr "num lock"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "Num Page Down"
 msgstr "Num Page Down"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "Num Page Up"
 msgstr "Num Page Up"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 msgid "Num Right"
 msgstr "Num Right"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "Num Space"
 msgstr "Num Space"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "Num Tab"
 msgstr "Num Tab"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "Num Up"
 msgstr "Num Up"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "Num left"
 msgstr "Num left"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num_lock"
 msgstr "num lock"
 
@@ -5302,13 +5441,13 @@ msgstr "num lock"
 msgid "Numbered outline"
 msgstr "सङ्ख्यात्मक बाह्यरेखा"
 
-#: ../include/wx/msgdlg.h:278 ../src/richtext/richtextstyledlg.cpp:297
-#: ../src/common/stockitem.cpp:178 ../src/msw/msgdlg.cpp:454
-#: ../src/msw/msgdlg.cpp:747 ../src/gtk1/fontdlg.cpp:138
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:175
+#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/msgdlg.cpp:741 ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "ठीक"
 
-#: ../src/msw/ole/automtn.cpp:692
+#: ../src/msw/ole/automtn.cpp:683
 #, c-format
 msgid "OLE Automation error in %s: %s"
 msgstr "%s मा OLE स्वचालित गल्ती : %s "
@@ -5317,15 +5456,15 @@ msgstr "%s मा OLE स्वचालित गल्ती : %s "
 msgid "Object Properties"
 msgstr "वस्तु गुणहरू"
 
-#: ../src/msw/ole/automtn.cpp:660
+#: ../src/msw/ole/automtn.cpp:651
 msgid "Object implementation does not support named arguments."
 msgstr "वस्तु कार्यान्वयनले नामाङ्कित तर्कलाई समर्थन गर्दैन ।"
 
-#: ../src/common/xtixml.cpp:264
+#: ../src/common/xtixml.cpp:260
 msgid "Objects must have an id attribute"
 msgstr "वस्तुको id attribute हुनै पर्दछ "
 
-#: ../src/propgrid/advprops.cpp:1601
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Olive"
 msgstr "जैतुन"
 
@@ -5333,65 +5472,70 @@ msgstr "जैतुन"
 msgid "Opaci&ty:"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:354
+#: ../src/generic/colrdlgg.cpp:374
 msgid "Opacity:"
 msgstr ""
 
-#: ../src/common/docview.cpp:1773 ../src/common/docview.cpp:1815
+#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
 msgid "Open File"
 msgstr "फाइल पल्टाउ "
 
-#: ../src/html/helpwnd.cpp:671 ../src/html/helpwnd.cpp:1554
+#: ../src/html/helpwnd.cpp:669 ../src/html/helpwnd.cpp:1552
 msgid "Open HTML document"
 msgstr "HTML कागजात पल्टाउ "
 
-#: ../src/generic/dbgrptg.cpp:163
+#: ../src/common/stockitem.cpp:265
+#, fuzzy
+msgid "Open an existing document"
+msgstr "HTML कागजात पल्टाउ "
+
+#: ../src/generic/dbgrptg.cpp:160
 #, c-format
 msgid "Open file \"%s\""
 msgstr "फाइल \"%s\" पल्टाउ "
 
-#: ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176
 msgid "Open..."
 msgstr "पल्टाउ.."
 
-#: ../src/unix/glx11.cpp:506 ../src/msw/glcanvas.cpp:592
+#: ../src/msw/glcanvas.cpp:607 ../src/unix/glx11.cpp:513
 #, fuzzy
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr "भित्रि OpenGL पार्श्वचित्रलाई OpenGL driver ले समर्थन गर्दैन."
 
-#: ../src/generic/dirctrlg.cpp:599 ../src/generic/dirdlgg.cpp:323
-#: ../src/generic/filectrlg.cpp:642 ../src/generic/filectrlg.cpp:786
+#: ../src/generic/dirctrlg.cpp:565 ../src/generic/filectrlg.cpp:638
+#: ../src/generic/filectrlg.cpp:782 ../src/generic/dirdlgg.cpp:320
 msgid "Operation not permitted."
 msgstr "सञ्चालनको अनुमति छैन ।"
 
-#: ../src/common/cmdline.cpp:900
+#: ../src/common/cmdline.cpp:896
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "विकल्प '%s' नकारात्मक हुन सक्दैन ।"
 
-#: ../src/common/cmdline.cpp:1064
+#: ../src/common/cmdline.cpp:1060
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "विकल्प '%s' को एउटा मान हुनै पर्दछ"
 
-#: ../src/common/cmdline.cpp:1147
+#: ../src/common/cmdline.cpp:1143
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "विकल्प '%s': '%s' मितिमा बदल्न सकिँदैन ।"
 
-#: ../src/generic/prntdlgg.cpp:618
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "विकल्पहरू"
 
-#: ../src/propgrid/advprops.cpp:1606
+#: ../src/propgrid/advprops.cpp:1512
 msgid "Orange"
 msgstr "सुन्तला"
 
-#: ../src/generic/prntdlgg.cpp:615 ../src/generic/prntdlgg.cpp:869
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:862
 msgid "Orientation"
 msgstr "झुकाव"
 
-#: ../src/common/windowid.cpp:242
+#: ../src/common/windowid.cpp:237
 msgid "Out of window IDs.  Recommend shutting down application."
 msgstr "विन्डोज IDs भन्दा बाहिर । अनुप्रयोग बन्द गर्न सुझावित ।"
 
@@ -5404,148 +5548,148 @@ msgstr "बाह्यरेखा"
 msgid "Outset"
 msgstr "बाहिरी चित्र"
 
-#: ../src/msw/ole/automtn.cpp:656
+#: ../src/msw/ole/automtn.cpp:647
 msgid "Overflow while coercing argument values."
 msgstr "Overflow while coercing argument values"
 
-#: ../src/common/imagpcx.cpp:457 ../src/common/imagpcx.cpp:480
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:479
 msgid "PCX: couldn't allocate memory"
 msgstr "PCX: भण्डार छुट्याउन सकेन ।"
 
-#: ../src/common/imagpcx.cpp:456
+#: ../src/common/imagpcx.cpp:455
 msgid "PCX: image format unsupported"
 msgstr "PCX: तस्विर स्वरूप समर्थित छैन ।"
 
-#: ../src/common/imagpcx.cpp:479
+#: ../src/common/imagpcx.cpp:478
 msgid "PCX: invalid image"
 msgstr "PCX: नमिल्दो तस्विर "
 
-#: ../src/common/imagpcx.cpp:442
+#: ../src/common/imagpcx.cpp:441
 msgid "PCX: this is not a PCX file."
 msgstr "PCX: यो PCX फाइल होइन ।"
 
-#: ../src/common/imagpcx.cpp:459 ../src/common/imagpcx.cpp:481
+#: ../src/common/imagpcx.cpp:458 ../src/common/imagpcx.cpp:480
 msgid "PCX: unknown error !!!"
 msgstr "PCX: अज्ञात गल्ती !!!"
 
-#: ../src/common/imagpcx.cpp:458
+#: ../src/common/imagpcx.cpp:457
 msgid "PCX: version number too low"
 msgstr "PCX: संस्करण सङ्ख्या धेरै सानो भयो ।"
 
-#: ../src/common/imagpnm.cpp:91
+#: ../src/common/imagpnm.cpp:89
 msgid "PNM: Couldn't allocate memory."
 msgstr "PNM: भण्डार छुट्याउन सकिएन ।"
 
-#: ../src/common/imagpnm.cpp:73
+#: ../src/common/imagpnm.cpp:71
 msgid "PNM: File format is not recognized."
 msgstr "PNM: फाइलको स्वरूप पहिचान गर्न सकिएन ।"
 
-#: ../src/common/imagpnm.cpp:112 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
 #: ../src/common/imagpnm.cpp:156
 msgid "PNM: File seems truncated."
 msgstr "PNM: फाइल काटकुट भए जस्तो छ ।"
 
-#: ../src/common/paper.cpp:187
+#: ../src/common/paper.cpp:184
 msgid "PRC 16K 146 x 215 mm"
 msgstr "PRC 16K 146 x 215 मिमी"
 
-#: ../src/common/paper.cpp:200
+#: ../src/common/paper.cpp:197
 msgid "PRC 16K Rotated"
 msgstr "PRC 16K Rounded"
 
-#: ../src/common/paper.cpp:188
+#: ../src/common/paper.cpp:185
 msgid "PRC 32K 97 x 151 mm"
 msgstr "PRC 32K 97 x 151 मिमी"
 
-#: ../src/common/paper.cpp:201
+#: ../src/common/paper.cpp:198
 msgid "PRC 32K Rotated"
 msgstr "PRC 32K Rounded"
 
-#: ../src/common/paper.cpp:189
+#: ../src/common/paper.cpp:186
 msgid "PRC 32K(Big) 97 x 151 mm"
 msgstr "PRC 32K(Big) 97 x 151 मिमी"
 
-#: ../src/common/paper.cpp:202
+#: ../src/common/paper.cpp:199
 msgid "PRC 32K(Big) Rotated"
 msgstr "PRC 32K(Big) Rounded"
 
-#: ../src/common/paper.cpp:190
+#: ../src/common/paper.cpp:187
 msgid "PRC Envelope #1 102 x 165 mm"
 msgstr "PRC खाम #1 102 x 165 मिमी"
 
-#: ../src/common/paper.cpp:203
+#: ../src/common/paper.cpp:200
 msgid "PRC Envelope #1 Rotated 165 x 102 mm"
 msgstr "PRC खाम #1 Rounded 165 x 102 मिमी"
 
-#: ../src/common/paper.cpp:199
+#: ../src/common/paper.cpp:196
 msgid "PRC Envelope #10 324 x 458 mm"
 msgstr "PRC खाम #10 324 x 458 मिमी"
 
-#: ../src/common/paper.cpp:212
+#: ../src/common/paper.cpp:209
 msgid "PRC Envelope #10 Rotated 458 x 324 mm"
 msgstr "PRC खाम #10 Rounded 458 x 324 मिमी"
 
-#: ../src/common/paper.cpp:191
+#: ../src/common/paper.cpp:188
 msgid "PRC Envelope #2 102 x 176 mm"
 msgstr "PRC खाम #2 102 x 176 मिमी"
 
-#: ../src/common/paper.cpp:204
+#: ../src/common/paper.cpp:201
 msgid "PRC Envelope #2 Rotated 176 x 102 mm"
 msgstr "PRC खाम #2 Rounded 176 x 102 मिमी"
 
-#: ../src/common/paper.cpp:192
+#: ../src/common/paper.cpp:189
 msgid "PRC Envelope #3 125 x 176 mm"
 msgstr "PRC खाम #3 125 x 176 मिमी"
 
-#: ../src/common/paper.cpp:205
+#: ../src/common/paper.cpp:202
 msgid "PRC Envelope #3 Rotated 176 x 125 mm"
 msgstr "PRC खाम #3 Rounded 176 x 125 मिमी"
 
-#: ../src/common/paper.cpp:193
+#: ../src/common/paper.cpp:190
 msgid "PRC Envelope #4 110 x 208 mm"
 msgstr "PRC खाम #4 110 x 208 मिमी"
 
-#: ../src/common/paper.cpp:206
+#: ../src/common/paper.cpp:203
 msgid "PRC Envelope #4 Rotated 208 x 110 mm"
 msgstr "PRC खाम #4 Rounded 208 x 110 मिमी"
 
-#: ../src/common/paper.cpp:194
+#: ../src/common/paper.cpp:191
 msgid "PRC Envelope #5 110 x 220 mm"
 msgstr "PRC खाम #5 110 x 220 मिमी"
 
-#: ../src/common/paper.cpp:207
+#: ../src/common/paper.cpp:204
 msgid "PRC Envelope #5 Rotated 220 x 110 mm"
 msgstr "PRC खाम #5 Rounded 220 x 110 मिमी"
 
-#: ../src/common/paper.cpp:195
+#: ../src/common/paper.cpp:192
 msgid "PRC Envelope #6 120 x 230 mm"
 msgstr "PRC खाम #6 120 x 230 मिमी"
 
-#: ../src/common/paper.cpp:208
+#: ../src/common/paper.cpp:205
 msgid "PRC Envelope #6 Rotated 230 x 120 mm"
 msgstr "PRC खाम #6 Rounded 230 x 120 मिमी"
 
-#: ../src/common/paper.cpp:196
+#: ../src/common/paper.cpp:193
 msgid "PRC Envelope #7 160 x 230 mm"
 msgstr "PRC खाम #7 160 x 230 मिमी"
 
-#: ../src/common/paper.cpp:209
+#: ../src/common/paper.cpp:206
 msgid "PRC Envelope #7 Rotated 230 x 160 mm"
 msgstr "PRC खाम #7 Rounded 230 x 160 मिमी"
 
-#: ../src/common/paper.cpp:197
+#: ../src/common/paper.cpp:194
 msgid "PRC Envelope #8 120 x 309 mm"
 msgstr "PRC खाम #8 120 x 309 मिमी"
 
-#: ../src/common/paper.cpp:210
+#: ../src/common/paper.cpp:207
 msgid "PRC Envelope #8 Rotated 309 x 120 mm"
 msgstr "PRC खाम #8 Rounded 309 x 120 मिमी"
 
-#: ../src/common/paper.cpp:198
+#: ../src/common/paper.cpp:195
 msgid "PRC Envelope #9 229 x 324 mm"
 msgstr "PRC खाम #9 229 x 324 मिमी"
 
-#: ../src/common/paper.cpp:211
+#: ../src/common/paper.cpp:208
 msgid "PRC Envelope #9 Rotated 324 x 229 mm"
 msgstr "PRC खाम #9 Rounded 324 x 229 मिमी"
 
@@ -5553,87 +5697,91 @@ msgstr "PRC खाम #9 Rounded 324 x 229 मिमी"
 msgid "Padding"
 msgstr "ख्रेस्रा"
 
-#: ../src/common/prntbase.cpp:2074
+#: ../src/common/prntbase.cpp:2096
 #, c-format
 msgid "Page %d"
 msgstr "पृष्ट %d"
 
-#: ../src/common/prntbase.cpp:2072
+#: ../src/common/prntbase.cpp:2094
 #, c-format
 msgid "Page %d of %d"
 msgstr "पृष्ट %d बट्टा %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 msgid "Page Down"
 msgstr "तल्लो पृष्ट"
 
-#: ../src/gtk/print.cpp:826
+#: ../src/gtk/print.cpp:829
 msgid "Page Setup"
 msgstr "पृष्ट मिलाउ"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 msgid "Page Up"
 msgstr "माथिल्लो पृष्ट"
 
-#: ../src/generic/prntdlgg.cpp:828 ../src/common/prntbase.cpp:484
+#: ../src/common/prntbase.cpp:479 ../src/generic/prntdlgg.cpp:821
 msgid "Page setup"
 msgstr "पृष्ट मिलाउ"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 msgid "PageDown"
 msgstr "PAGEDOWN"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 msgid "PageUp"
 msgstr "PAGEUp"
 
-#: ../src/generic/prntdlgg.cpp:216
+#: ../src/generic/prntdlgg.cpp:209
 msgid "Pages"
 msgstr "पानाहरू "
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1765
+#: ../src/propgrid/advprops.cpp:1666
 msgid "Paint Brush"
 msgstr "पोत्ने बुरुस"
 
-#: ../src/generic/prntdlgg.cpp:602 ../src/generic/prntdlgg.cpp:801
-#: ../src/generic/prntdlgg.cpp:842 ../src/generic/prntdlgg.cpp:855
-#: ../src/generic/prntdlgg.cpp:1052 ../src/generic/prntdlgg.cpp:1057
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:794
+#: ../src/generic/prntdlgg.cpp:835 ../src/generic/prntdlgg.cpp:848
+#: ../src/generic/prntdlgg.cpp:1045 ../src/generic/prntdlgg.cpp:1050
 msgid "Paper size"
 msgstr "कागजको आकार"
 
-#: ../src/richtext/richtextstyles.cpp:1062
+#: ../src/richtext/richtextstyles.cpp:1059
 msgid "Paragraph styles"
 msgstr "अनुच्छेद शैलीहरू "
 
-#: ../src/common/xtistrm.cpp:465
+#: ../src/common/xtistrm.cpp:462
 msgid "Passing a already registered object to SetObject"
 msgstr "पहिले नै दर्ता भएको वस्तु SetObject मा पठाउँदै ।"
 
-#: ../src/common/xtistrm.cpp:476
+#: ../src/common/xtistrm.cpp:473
 msgid "Passing an unknown object to GetObject"
 msgstr "अज्ञात वस्तुलाई GetObject मा पठाइँदै छ "
 
-#: ../src/richtext/richtextctrl.cpp:3513 ../src/common/stockitem.cpp:180
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:177 ../src/richtext/richtextctrl.cpp:3514
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "टाँसि देउ"
 
-#: ../src/common/stockitem.cpp:262
+#: ../src/common/stockitem.cpp:260
 msgid "Paste selection"
 msgstr "चयन टाँसि देउ "
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:74
+#: ../src/common/accelcmn.cpp:71
 msgid "Pause"
 msgstr "विश्राम"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1766
+#: ../src/propgrid/advprops.cpp:1667
 msgid "Pencil"
 msgstr "पेन्सिल"
 
@@ -5642,21 +5790,21 @@ msgstr "पेन्सिल"
 msgid "Peri&od"
 msgstr "&थोप्लो"
 
-#: ../src/generic/filectrlg.cpp:430
+#: ../src/generic/filectrlg.cpp:426
 msgid "Permissions"
 msgstr "अनुमति"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:60
+#: ../src/common/accelcmn.cpp:57
 msgid "PgDn"
 msgstr "PGDN"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:59
+#: ../src/common/accelcmn.cpp:56
 msgid "PgUp"
 msgstr "PGUP"
 
-#: ../src/richtext/richtextbuffer.cpp:12868
+#: ../src/richtext/richtextbuffer.cpp:12863
 msgid "Picture Properties"
 msgstr "तस्विरका गुणहरू"
 
@@ -5668,42 +5816,42 @@ msgstr "Pipe सिर्जना असफल भयो ।"
 msgid "Please choose a valid font."
 msgstr "कृपया वैध वरणाकृति छान्नु होस् ।"
 
-#: ../src/generic/filedlgg.cpp:357 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
 msgid "Please choose an existing file."
 msgstr "भण्डारमा भएको फाइल छान्नु होस् ।"
 
-#: ../src/html/helpwnd.cpp:800
+#: ../src/html/helpwnd.cpp:798
 msgid "Please choose the page to display:"
 msgstr "कृपया देखाइने पृष्ट छान्नु होस् ।"
 
-#: ../src/msw/dialup.cpp:764
+#: ../src/msw/dialup.cpp:758
 msgid "Please choose which ISP do you want to connect to"
 msgstr "कृपया जुन ISP मा जोड्ने हो उही छान्नु होस् "
 
-#: ../src/common/headerctrlcmn.cpp:59
+#: ../src/common/headerctrlcmn.cpp:57
 msgid "Please select the columns to show and define their order:"
 msgstr "कृपया देखाउने महलहरू चयन गरेर तिनिहरूको क्रम उल्लेख गर्नु होस्:"
 
-#: ../src/common/prntbase.cpp:538
+#: ../src/common/prntbase.cpp:533
 msgid "Please wait while printing..."
 msgstr "कृपया पर्खनु होस् है छाप्ने काम हुँदैछ ।"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1767
+#: ../src/propgrid/advprops.cpp:1668
 msgid "Point Left"
 msgstr "थोप्लो वायाँ"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1768
+#: ../src/propgrid/advprops.cpp:1669
 msgid "Point Right"
 msgstr "थोप्लो दाया"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:662
+#: ../src/propgrid/advprops.cpp:572
 msgid "Point Size"
 msgstr "थोप्लोको आकार"
 
-#: ../src/generic/prntdlgg.cpp:612 ../src/generic/prntdlgg.cpp:867
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:860
 msgid "Portrait"
 msgstr "ठाडो"
 
@@ -5711,251 +5859,261 @@ msgstr "ठाडो"
 msgid "Position"
 msgstr "स्थान"
 
-#: ../src/generic/prntdlgg.cpp:298
+#: ../src/generic/prntdlgg.cpp:291
 msgid "PostScript file"
 msgstr "PostScript फाइल"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178 ../src/osx/cocoa/preferences.mm:303
 msgid "Preferences"
 msgstr "प्राथमिकताहरू"
 
-#: ../src/osx/menu_osx.cpp:568
+#: ../src/osx/menu_osx.cpp:460
 msgid "Preferences..."
 msgstr "प्राथमिकताहरू.."
 
-#: ../src/common/prntbase.cpp:546
+#: ../src/common/prntbase.cpp:541
 msgid "Preparing"
 msgstr "तयारी हुदैछ ।"
 
-#: ../src/generic/fontdlgg.cpp:455 ../src/osx/carbon/fontdlg.cpp:390
-#: ../src/html/helpwnd.cpp:1222
+#: ../src/osx/carbon/fontdlg.cpp:387 ../src/generic/fontdlgg.cpp:452
+#: ../src/html/helpwnd.cpp:1220
 msgid "Preview:"
 msgstr "चेहरा:"
 
-#: ../src/common/prntbase.cpp:1553 ../src/html/helpwnd.cpp:664
+#: ../src/common/prntbase.cpp:1578 ../src/html/helpwnd.cpp:662
 msgid "Previous page"
 msgstr "पछिल्लो पृष्ट"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/prntdlgg.cpp:143 ../src/generic/prntdlgg.cpp:157
-#: ../src/common/prntbase.cpp:426 ../src/common/prntbase.cpp:1541
-#: ../src/common/accelcmn.cpp:77 ../src/gtk/print.cpp:620
-#: ../src/gtk/print.cpp:638
+#: ../src/common/prntbase.cpp:421 ../src/common/prntbase.cpp:1566
+#: ../src/common/accelcmn.cpp:74 ../src/generic/prntdlgg.cpp:136
+#: ../src/generic/prntdlgg.cpp:150 ../src/gtk/print.cpp:616
+#: ../src/gtk/print.cpp:634
 msgid "Print"
 msgstr "छाप्ने काम गर"
 
-#: ../include/wx/prntbase.h:399 ../src/common/docview.cpp:1268
+#: ../src/common/docview.cpp:1262
 msgid "Print Preview"
 msgstr "छापिने चेहरा"
 
-#: ../src/common/prntbase.cpp:2015 ../src/common/prntbase.cpp:2057
-#: ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2037 ../src/common/prntbase.cpp:2079
+#: ../src/common/prntbase.cpp:2087
 msgid "Print Preview Failure"
 msgstr "छापिने चेहरा देखाउन सकिएन"
 
-#: ../src/generic/prntdlgg.cpp:224
+#: ../src/generic/prntdlgg.cpp:217
 msgid "Print Range"
 msgstr "कति छाप्ने हो"
 
-#: ../src/generic/prntdlgg.cpp:449
+#: ../src/generic/prntdlgg.cpp:442
 msgid "Print Setup"
 msgstr "छाप्ने रूप"
 
-#: ../src/generic/prntdlgg.cpp:621
+#: ../src/generic/prntdlgg.cpp:614
 msgid "Print in colour"
 msgstr "रङ्गिन छाप्ने काम"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/osx/webview_webkit.mm:260
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "महलको बयान सुरु भएन"
+
+#: ../src/common/stockitem.cpp:179
 msgid "Print previe&w..."
 msgstr "&छापिने चेहरा"
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1256
 msgid "Print preview creation failed."
 msgstr "छापिने चेहराको सिर्जना असफल भयो ।"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/common/stockitem.cpp:179
 msgid "Print preview..."
 msgstr "छापिने चेहरा"
 
-#: ../src/generic/prntdlgg.cpp:630
+#: ../src/generic/prntdlgg.cpp:623
 msgid "Print spooling"
 msgstr "छापिने काम बिग्रयो ।"
 
-#: ../src/html/helpwnd.cpp:675
+#: ../src/html/helpwnd.cpp:673
 msgid "Print this page"
 msgstr "यो पृष्ट छापी देउ"
 
-#: ../src/generic/prntdlgg.cpp:185
+#: ../src/generic/prntdlgg.cpp:178
 msgid "Print to File"
 msgstr "फाइलमा लेख ।"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "Print..."
 msgstr "छापी देउ.."
 
-#: ../src/generic/prntdlgg.cpp:493
+#: ../src/generic/prntdlgg.cpp:486
 msgid "Printer"
 msgstr "प्रिन्टर"
 
-#: ../src/generic/prntdlgg.cpp:633
+#: ../src/generic/prntdlgg.cpp:626
 msgid "Printer command:"
 msgstr "प्रिन्टर आदेश:"
 
-#: ../src/generic/prntdlgg.cpp:180
+#: ../src/generic/prntdlgg.cpp:173
 msgid "Printer options"
 msgstr "प्रिन्टर विकल्पहरू"
 
-#: ../src/generic/prntdlgg.cpp:645
+#: ../src/generic/prntdlgg.cpp:638
 msgid "Printer options:"
 msgstr "प्रिन्टर विकल्पहरू:"
 
-#: ../src/generic/prntdlgg.cpp:916
+#: ../src/generic/prntdlgg.cpp:909
 msgid "Printer..."
 msgstr "प्रिन्टर.."
 
-#: ../src/generic/prntdlgg.cpp:196
+#: ../src/generic/prntdlgg.cpp:189
 msgid "Printer:"
 msgstr "प्रिन्टर:"
 
-#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:535
-#: ../src/html/htmprint.cpp:277
+#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:530
+#: ../src/html/htmprint.cpp:289
 msgid "Printing"
 msgstr "छाप्ने काम हुँदैछ ।"
 
-#: ../src/common/prntbase.cpp:612
+#: ../src/common/prntbase.cpp:607
 msgid "Printing "
 msgstr "छाप्ने काम हुँदैछ ।"
 
-#: ../src/common/prntbase.cpp:347
+#: ../src/common/prntbase.cpp:342
 msgid "Printing Error"
 msgstr "छपाइमा गल्ती"
 
-#: ../src/common/prntbase.cpp:565
+#: ../src/osx/webview_webkit.mm:251
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "यो zlib को संस्करणले Gzip समर्थन गर्दैन ।"
+
+#: ../src/common/prntbase.cpp:560
 #, fuzzy, c-format
 msgid "Printing page %d"
 msgstr "पृष्ट %d.. छापिँदै छ ।"
 
-#: ../src/common/prntbase.cpp:570
+#: ../src/common/prntbase.cpp:565
 #, c-format
 msgid "Printing page %d of %d"
 msgstr "पृष्ट %d बट्टा %d छापिँदै छ ।"
 
-#: ../src/generic/printps.cpp:201
+#: ../src/generic/printps.cpp:182
 #, c-format
 msgid "Printing page %d..."
 msgstr "पृष्ट %d.. छापिँदै छ ।"
 
-#: ../src/generic/printps.cpp:161
+#: ../src/generic/printps.cpp:142
 msgid "Printing..."
 msgstr "छाप्ने काम दुदै च.."
 
-#: ../include/wx/richtext/richtextprint.h:109 ../include/wx/prntbase.h:267
-#: ../src/common/docview.cpp:2132
+#: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
+#: ../src/common/docview.cpp:2137
 msgid "Printout"
 msgstr "छापिएका पानाहरू"
 
-#: ../src/common/debugrpt.cpp:560
+#: ../src/common/debugrpt.cpp:561
 #, c-format
 msgid ""
 "Processing debug report has failed, leaving the files in \"%s\" directory."
 msgstr "\"%s\" घर्रामा फाइल राख्दै खान तलासी प्रतिवेदनको प्रशोधन असफल भयो ।"
 
-#: ../src/common/prntbase.cpp:545
+#: ../src/common/prntbase.cpp:540
 msgid "Progress:"
 msgstr "प्रगति"
 
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181
 msgid "Properties"
 msgstr "गुणहरू"
 
-#: ../src/propgrid/manager.cpp:237
+#: ../src/propgrid/manager.cpp:223
 msgid "Property"
 msgstr "गुण"
 
 #. TRANSLATORS: Caption of message box displaying any property error
-#: ../src/propgrid/propgrid.cpp:3185 ../src/propgrid/propgrid.cpp:3318
+#: ../src/propgrid/propgrid.cpp:3162 ../src/propgrid/propgrid.cpp:3299
 msgid "Property Error"
 msgstr "गुणको गल्ती"
 
-#: ../src/propgrid/advprops.cpp:1597
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Purple"
 msgstr "बैजनी"
 
-#: ../src/common/paper.cpp:112
+#: ../src/common/paper.cpp:109
 msgid "Quarto, 215 x 275 mm"
 msgstr "Quarto, 215 x 275 मिमी"
 
-#: ../src/generic/logg.cpp:1016
+#: ../src/generic/logg.cpp:1013
 msgid "Question"
 msgstr "प्रश्न"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1769
+#: ../src/propgrid/advprops.cpp:1670
 msgid "Question Arrow"
 msgstr "जिज्ञासा वाण"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "Quit"
 msgstr "त्यागि देउ"
 
-#: ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:477
 #, c-format
 msgid "Quit %s"
 msgstr "%s लाई त्यागि देउ "
 
-#: ../src/common/stockitem.cpp:263
+#: ../src/common/stockitem.cpp:261
 msgid "Quit this program"
 msgstr "यो कार्यक्रमलाई त्यागि देउ "
 
-#: ../src/common/accelcmn.cpp:338
+#: ../src/common/accelcmn.cpp:352
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/ffile.cpp:109 ../src/common/ffile.cpp:133
+#: ../src/common/ffile.cpp:107 ../src/common/ffile.cpp:132
 #, c-format
 msgid "Read error on file '%s'"
 msgstr "फाइल '%s' मा पढ्न गल्ती भयो ।"
 
-#: ../src/common/secretstore.cpp:199
+#: ../src/common/secretstore.cpp:211
 #, fuzzy, c-format
-msgid "Reading password for \"%s/%s\" failed: %s."
+msgid "Reading password for \"%s\" failed: %s."
 msgstr "'%s' लाई '%s' मा खिच्ने काम असफल भयो ।"
 
-#: ../src/common/prntbase.cpp:272
+#: ../src/common/prntbase.cpp:267
 msgid "Ready"
 msgstr "तयार"
 
-#: ../src/propgrid/advprops.cpp:1605
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Red"
 msgstr "रातो"
 
-#: ../src/generic/colrdlgg.cpp:339
+#: ../src/generic/colrdlgg.cpp:359
 msgid "Red:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:185 ../src/stc/stc_i18n.cpp:16
+#: ../src/common/stockitem.cpp:182 ../src/stc/stc_i18n.cpp:16
 msgid "Redo"
 msgstr "फेरि गर"
 
-#: ../src/common/stockitem.cpp:264
+#: ../src/common/stockitem.cpp:262
 msgid "Redo last action"
 msgstr "अन्तिम कार्य फेरि गर "
 
-#: ../src/common/stockitem.cpp:186
+#: ../src/common/stockitem.cpp:183
 msgid "Refresh"
 msgstr "ताजकी य"
 
-#: ../src/msw/registry.cpp:626
+#: ../src/msw/registry.cpp:615
 #, c-format
 msgid "Registry key '%s' already exists."
 msgstr "Registry कुञ्जी '%s' पहिले देखि नै छ ।"
 
-#: ../src/msw/registry.cpp:595
+#: ../src/msw/registry.cpp:584
 #, c-format
 msgid "Registry key '%s' does not exist, cannot rename it."
 msgstr "Registry कुञ्जी '%s' नभएकोले नाम फेर्न सकिँदैन ।"
 
-#: ../src/msw/registry.cpp:727
+#: ../src/msw/registry.cpp:716
 #, c-format
 msgid ""
 "Registry key '%s' is needed for normal system operation,\n"
@@ -5965,22 +6123,22 @@ msgstr ""
 "सामान्य रूपमा यस प्रणालीलेकाम गर्नका लागि Registry कुञ्जी '%s' चाहिन्छ ।\n"
 "यसलाई मेट्नु भयो भने यो प्रणाली निकम्मा हुने छ ।सञ्चालन त तुहियो!"
 
-#: ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:942
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:917
+#: ../src/msw/registry.cpp:905
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1003
+#: ../src/msw/registry.cpp:991
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:521
+#: ../src/msw/registry.cpp:510
 #, c-format
 msgid "Registry value '%s' already exists."
 msgstr "Registry मान '%s' पहिले देखि नै छ ।"
@@ -5994,70 +6152,76 @@ msgstr "नियमित"
 msgid "Relative"
 msgstr "सापेक्षित"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:456
 msgid "Relevant entries:"
 msgstr "सन्दर्भित प्रविष्टि:"
 
-#: ../include/wx/generic/progdlgg.h:86
+#: ../include/wx/generic/progdlgg.h:87
 msgid "Remaining time:"
 msgstr "बांकि समय:"
 
-#: ../src/common/stockitem.cpp:187
+#: ../src/common/stockitem.cpp:184
 msgid "Remove"
 msgstr "हटाउ"
 
-#: ../src/richtext/richtextctrl.cpp:1562
+#: ../src/richtext/richtextctrl.cpp:1563
 msgid "Remove Bullet"
 msgstr "गोली चिन्ह हटाउ"
 
-#: ../src/html/helpwnd.cpp:433
+#: ../src/html/helpwnd.cpp:431
 msgid "Remove current page from bookmarks"
 msgstr "पृष्ट लाई बुकमार्कबाट हटाउ"
 
-#: ../src/common/rendcmn.cpp:194
+#: ../src/common/rendcmn.cpp:191
 #, c-format
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr "Renderer \"%s\" सित मिलान गर्न नसकिने संस्करण %d.%d भएकोले वहन गर्न सकिएन ।"
 
-#: ../src/richtext/richtextbuffer.cpp:4527
+#: ../src/richtext/richtextbuffer.cpp:4524
 msgid "Renumber List"
 msgstr "फेरि सङ्ख्या राख"
 
-#: ../src/common/stockitem.cpp:188
-msgid "Rep&lace"
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Rep&lace..."
 msgstr "&बदलि देउ"
 
-#: ../src/richtext/richtextctrl.cpp:3673 ../src/common/stockitem.cpp:188
+#: ../src/richtext/richtextctrl.cpp:3674
 msgid "Replace"
 msgstr "प्रतिस्थापन गर"
 
-#: ../src/generic/fdrepdlg.cpp:182
+#: ../src/generic/fdrepdlg.cpp:179
 msgid "Replace &all"
 msgstr "&सबैको प्रतिस्थापन "
 
-#: ../src/common/stockitem.cpp:261
-msgid "Replace selection"
-msgstr "चयनको प्रतिस्थापन"
-
-#: ../src/generic/fdrepdlg.cpp:124
+#: ../src/generic/fdrepdlg.cpp:121
 msgid "Replace with:"
 msgstr "यसमा बदलि देउ :"
 
-#: ../src/common/valtext.cpp:163
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Replace..."
+msgstr "प्रतिस्थापन गर"
+
+#: ../src/common/valtext.cpp:184
 msgid "Required information entry is empty."
 msgstr "चाहिएको सूचना प्रविष्टि खालि छ ।"
 
-#: ../src/common/translation.cpp:1975
+#: ../src/common/translation.cpp:2025
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "श्रोत '%s' वैध सन्देश सूचि होइन ।"
 
+#: ../src/gtk/webview_webkit.cpp:985
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:56
+#: ../src/common/accelcmn.cpp:53
 msgid "Return"
 msgstr "return"
 
-#: ../src/common/stockitem.cpp:189
+#: ../src/common/stockitem.cpp:186
 msgid "Revert to Saved"
 msgstr "बचत उल्टियो "
 
@@ -6069,41 +6233,41 @@ msgstr "धुरी"
 msgid "Rig&ht-to-left"
 msgstr "&दायाँ -देखि वायाँ"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6149
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:59 ../src/generic/datavgen.cpp:6954
+#: ../src/richtext/richtextsizepage.cpp:250
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextbulletspage.cpp:188
-#: ../src/richtext/richtextsizepage.cpp:250 ../src/common/accelcmn.cpp:62
 msgid "Right"
 msgstr "दाहिने"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1754
+#: ../src/propgrid/advprops.cpp:1655
 msgid "Right Arrow"
 msgstr "दायाँ वाण"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1770
+#: ../src/propgrid/advprops.cpp:1671
 msgid "Right Button"
 msgstr "दायाँ टाँक"
 
-#: ../src/generic/prntdlgg.cpp:892
+#: ../src/generic/prntdlgg.cpp:885
 msgid "Right margin (mm):"
 msgstr "दाहिने सिमान्त (मिमि):"
 
-#: ../src/richtext/richtextindentspage.cpp:148
-#: ../src/richtext/richtextindentspage.cpp:150
 #: ../src/richtext/richtextliststylepage.cpp:337
 #: ../src/richtext/richtextliststylepage.cpp:339
+#: ../src/richtext/richtextindentspage.cpp:148
+#: ../src/richtext/richtextindentspage.cpp:150
 msgid "Right-align text."
 msgstr "दाहिने-पङ्क्तिबद्ध पाठ"
 
-#: ../src/generic/fontdlgg.cpp:322
+#: ../src/generic/fontdlgg.cpp:318
 msgid "Roman"
 msgstr "रोमन"
 
-#: ../src/generic/datavgen.cpp:5916
+#: ../src/generic/datavgen.cpp:6721
 #, c-format
 msgid "Row %i"
 msgstr ""
@@ -6113,30 +6277,31 @@ msgstr ""
 msgid "S&tandard bullet name:"
 msgstr "&स्तरीय गोलीको नाम:"
 
-#: ../src/common/accelcmn.cpp:268 ../src/common/accelcmn.cpp:350
+#: ../src/common/accelcmn.cpp:282 ../src/common/accelcmn.cpp:367
 msgid "SPECIAL"
 msgstr "विशेष"
 
-#: ../src/common/stockitem.cpp:190 ../src/common/sizer.cpp:2797
+#: ../src/common/stockitem.cpp:187 ../src/common/sizer.cpp:2914
 msgid "Save"
 msgstr "बचत गर"
 
-#: ../src/common/fldlgcmn.cpp:342
+#: ../src/common/fldlgcmn.cpp:339
 #, c-format
 msgid "Save %s file"
 msgstr "%s फाइललाई बचत गर "
 
-#: ../src/generic/logg.cpp:512
+#: ../src/common/stockitem.cpp:188 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "&यसरी बचत गर"
 
-#: ../src/common/docview.cpp:366
+#: ../src/common/docview.cpp:359
 msgid "Save As"
 msgstr "यसरी बचत गर "
 
-#: ../src/common/stockitem.cpp:191
-msgid "Save as"
-msgstr "यसरी बचत गर "
+#: ../src/common/stockitem.cpp:188
+#, fuzzy
+msgid "Save As..."
+msgstr "&यसरी बचत गर"
 
 #: ../src/common/stockitem.cpp:267
 msgid "Save current document"
@@ -6146,94 +6311,94 @@ msgstr "चालू कागजातलाई बचत गर "
 msgid "Save current document with a different filename"
 msgstr "चालू कागजातलाई अर्कै फाइल नाम दिएर बचत गर "
 
-#: ../src/generic/logg.cpp:512
+#: ../src/generic/logg.cpp:509
 msgid "Save log contents to file"
 msgstr "लग पुस्तिकाको सामाग्रीलाई फाइलमा बचत गर"
 
-#: ../src/common/secretstore.cpp:179
+#: ../src/common/secretstore.cpp:189
 #, fuzzy, c-format
-msgid "Saving password for \"%s/%s\" failed: %s."
+msgid "Saving password for \"%s\" failed: %s."
 msgstr "'%s' लाई '%s' मा खिच्ने काम असफल भयो ।"
 
-#: ../src/generic/fontdlgg.cpp:325
+#: ../src/generic/fontdlgg.cpp:321
 msgid "Script"
 msgstr "Script"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll Lock"
 msgstr "सार्ने चाबी"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll_lock"
 msgstr "सार्ने चाबी"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:890
+#: ../src/propgrid/advprops.cpp:791
 msgid "Scrollbar"
 msgstr "घिसार्नेपट्टी"
 
-#: ../src/generic/srchctlg.cpp:56 ../src/html/helpwnd.cpp:535
-#: ../src/html/helpwnd.cpp:550
+#: ../src/generic/srchctlg.cpp:55 ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:548 ../src/gtk/srchctrl.cpp:182
 msgid "Search"
 msgstr "खोजतलास"
 
-#: ../src/html/helpwnd.cpp:537
+#: ../src/html/helpwnd.cpp:535
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
 msgstr "सहयोग किताब (s) का सबै सामाग्रीमा यस अघि टङ्कण गरेको पाठहरू लाई खोज ।"
 
-#: ../src/generic/fdrepdlg.cpp:160
+#: ../src/generic/fdrepdlg.cpp:157
 msgid "Search direction"
 msgstr "खोजी दिशा"
 
-#: ../src/generic/fdrepdlg.cpp:112
+#: ../src/generic/fdrepdlg.cpp:109
 msgid "Search for:"
 msgstr "यसलाई खोज्ने:"
 
-#: ../src/html/helpwnd.cpp:1052
+#: ../src/html/helpwnd.cpp:1050
 msgid "Search in all books"
 msgstr "सबै किताबहरूमा खोज ।"
 
-#: ../src/html/helpwnd.cpp:857
+#: ../src/html/helpwnd.cpp:855
 msgid "Searching..."
 msgstr "खोजतलास हुँदैछ "
 
-#: ../src/generic/dirctrlg.cpp:446
+#: ../src/generic/dirctrlg.cpp:412
 msgid "Sections"
 msgstr "खण्ड"
 
-#: ../src/common/ffile.cpp:238
+#: ../src/common/ffile.cpp:237
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "फाइल '%s' मा खोजीको गल्ती ।"
 
-#: ../src/common/ffile.cpp:228
+#: ../src/common/ffile.cpp:227
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr "फाइल '%s' (stdio ले ठूलो फाइललाई समर्थन गर्दै न ) मा खोजिको गल्ती । "
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:76
+#: ../src/common/accelcmn.cpp:73
 msgid "Select"
 msgstr "चयन गर्नु"
 
-#: ../src/richtext/richtextctrl.cpp:337 ../src/osx/textctrl_osx.cpp:581
-#: ../src/common/stockitem.cpp:192 ../src/msw/textctrl.cpp:2512
+#: ../src/osx/textctrl_osx.cpp:599 ../src/common/stockitem.cpp:189
+#: ../src/msw/textctrl.cpp:2777 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "&सबैलाई चयन गर"
 
-#: ../src/common/stockitem.cpp:192 ../src/stc/stc_i18n.cpp:21
+#: ../src/common/stockitem.cpp:189 ../src/stc/stc_i18n.cpp:21
 msgid "Select All"
 msgstr "सबै चयन गर"
 
-#: ../src/common/docview.cpp:1895
+#: ../src/common/docview.cpp:1900
 msgid "Select a document template"
 msgstr "एउटा कागजात  लेखोट चयन गर ।"
 
-#: ../src/common/docview.cpp:1969
+#: ../src/common/docview.cpp:1974
 msgid "Select a document view"
 msgstr "एउटा कागजातको दृश्य चयन गर"
 
@@ -6262,20 +6427,20 @@ msgid "Selects the list level to edit."
 msgstr "सम्पादनका लागि सूचि तह चयन गर्छ ।"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:82
+#: ../src/common/accelcmn.cpp:79
 msgid "Separator"
 msgstr "विभाजक"
 
-#: ../src/common/cmdline.cpp:1083
+#: ../src/common/cmdline.cpp:1079
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "विकल्प '%s' पछि विभाजक अपेक्षा गरिन्छ ।"
 
-#: ../src/osx/menu_osx.cpp:572
+#: ../src/osx/menu_osx.cpp:464
 msgid "Services"
 msgstr "सेवा"
 
-#: ../src/richtext/richtextbuffer.cpp:11217
+#: ../src/richtext/richtextbuffer.cpp:11216
 msgid "Set Cell Style"
 msgstr "कोशिका शैली तय गर्नु होस् ।"
 
@@ -6283,11 +6448,11 @@ msgstr "कोशिका शैली तय गर्नु होस् ।"
 msgid "SetProperty called w/o valid setter"
 msgstr "SetProperty called w/o valid setter"
 
-#: ../src/generic/prntdlgg.cpp:188
+#: ../src/generic/prntdlgg.cpp:181
 msgid "Setup..."
 msgstr "स्थापक"
 
-#: ../src/msw/dialup.cpp:544
+#: ../src/msw/dialup.cpp:538
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr "धेरै वटा सक्रिय डायल अप जडान भएको पाइयो । कुनै एउटालाई चयन गरिदैं छ ।"
 
@@ -6305,40 +6470,40 @@ msgstr "विम्वटाँक"
 msgid "Shadow c&olour:"
 msgstr "रङ्ग छान्नु होस्"
 
-#: ../src/common/accelcmn.cpp:335
+#: ../src/common/accelcmn.cpp:349
 msgid "Shift+"
 msgstr "Shift+"
 
-#: ../src/generic/dirdlgg.cpp:147
+#: ../src/generic/dirdlgg.cpp:144
 msgid "Show &hidden directories"
 msgstr "&लुकाएका घर्राहरू देखाउ "
 
-#: ../src/generic/filectrlg.cpp:983
+#: ../src/generic/filectrlg.cpp:979
 msgid "Show &hidden files"
 msgstr "&लुकाएका फाइलहरू देखाउ "
 
-#: ../src/osx/menu_osx.cpp:580
+#: ../src/osx/menu_osx.cpp:472
 msgid "Show All"
 msgstr "सबै देखाउ "
 
-#: ../src/common/stockitem.cpp:257
+#: ../src/common/stockitem.cpp:254
 msgid "Show about dialog"
 msgstr "पातोको बारेमा देखाउ "
 
-#: ../src/html/helpwnd.cpp:492
+#: ../src/html/helpwnd.cpp:490
 msgid "Show all"
 msgstr " सबै देखाउ "
 
-#: ../src/html/helpwnd.cpp:503
+#: ../src/html/helpwnd.cpp:501
 msgid "Show all items in index"
 msgstr "सबै सामाग्रीलाई अनुक्रमणिकामा देखाउ "
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:656
 msgid "Show/hide navigation panel"
 msgstr "आवागमन कक्ष देखाउ/लुकाउ "
 
-#: ../src/richtext/richtextsymboldlg.cpp:421
-#: ../src/richtext/richtextsymboldlg.cpp:423
+#: ../src/richtext/richtextsymboldlg.cpp:418
+#: ../src/richtext/richtextsymboldlg.cpp:420
 msgid "Shows a Unicode subset."
 msgstr "युनिकोड subset देखाउ छ ।"
 
@@ -6354,7 +6519,7 @@ msgstr "गोलि चिन्ह अनुकूलताको चेहर
 msgid "Shows a preview of the font settings."
 msgstr "वरणाकृति अनुकूलताको चेहरा देखाउ छ ।"
 
-#: ../src/osx/carbon/fontdlg.cpp:394 ../src/osx/carbon/fontdlg.cpp:396
+#: ../src/osx/carbon/fontdlg.cpp:391 ../src/osx/carbon/fontdlg.cpp:393
 msgid "Shows a preview of the font."
 msgstr "वरणाकृतिको चेहरा देखाउ छ ।"
 
@@ -6363,62 +6528,62 @@ msgstr "वरणाकृतिको चेहरा देखाउ छ ।"
 msgid "Shows a preview of the paragraph settings."
 msgstr "अनुच्छेद अनुकूलताको चेहरा देखाउ छ ।"
 
-#: ../src/generic/fontdlgg.cpp:460 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:456 ../src/generic/fontdlgg.cpp:458
 msgid "Shows the font preview."
 msgstr "वरणाकृति चेहरा देखाउ छ ।"
 
-#: ../src/propgrid/advprops.cpp:1607
+#: ../src/propgrid/advprops.cpp:1513
 msgid "Silver"
 msgstr "चाँदी"
 
-#: ../src/univ/themes/mono.cpp:516
+#: ../src/univ/themes/mono.cpp:513
 msgid "Simple monochrome theme"
 msgstr "साधारण एकल रङ्गिन theme"
 
-#: ../src/richtext/richtextindentspage.cpp:275
 #: ../src/richtext/richtextliststylepage.cpp:449
+#: ../src/richtext/richtextindentspage.cpp:275
 msgid "Single"
 msgstr "एउटा"
 
-#: ../src/generic/filectrlg.cpp:425 ../src/richtext/richtextformatdlg.cpp:369
-#: ../src/richtext/richtextsizepage.cpp:299
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextsizepage.cpp:299
+#: ../src/richtext/richtextformatdlg.cpp:362
 msgid "Size"
 msgstr "आकार"
 
-#: ../src/osx/carbon/fontdlg.cpp:339
+#: ../src/osx/carbon/fontdlg.cpp:336
 msgid "Size:"
 msgstr "आकार:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1775
+#: ../src/propgrid/advprops.cpp:1676
 msgid "Sizing"
 msgstr "आकारकरण"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1772
+#: ../src/propgrid/advprops.cpp:1673
 msgid "Sizing N-S"
 msgstr "उ-द तर्फ आकारकरण"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1771
+#: ../src/propgrid/advprops.cpp:1672
 msgid "Sizing NE-SW"
 msgstr "पूउ-पद तर्फ आकारकरण"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1773
+#: ../src/propgrid/advprops.cpp:1674
 msgid "Sizing NW-SE"
 msgstr "उप-दपू तर्फ आकारकरण"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1774
+#: ../src/propgrid/advprops.cpp:1675
 msgid "Sizing W-E"
 msgstr "पूप तर्फ आकारकरण"
 
-#: ../src/msw/progdlg.cpp:801
+#: ../src/msw/progdlg.cpp:1088
 msgid "Skip"
 msgstr "उफ्र"
 
-#: ../src/generic/fontdlgg.cpp:330
+#: ../src/generic/fontdlgg.cpp:326
 msgid "Slant"
 msgstr "छड्के"
 
@@ -6427,7 +6592,7 @@ msgid "Small C&apitals"
 msgstr "सानो &ठूलो वर्ण"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:79
+#: ../src/common/accelcmn.cpp:76
 msgid "Snapshot"
 msgstr "परिक्षण प्रति"
 
@@ -6435,37 +6600,37 @@ msgstr "परिक्षण प्रति"
 msgid "Solid"
 msgstr "ठोस"
 
-#: ../src/common/docview.cpp:1791
+#: ../src/common/docview.cpp:1785
 msgid "Sorry, could not open this file."
 msgstr "माफ गर्नु होस्, यो फाइल खोल्न सकिएन ।"
 
-#: ../src/common/prntbase.cpp:2057 ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2079 ../src/common/prntbase.cpp:2087
 msgid "Sorry, not enough memory to create a preview."
 msgstr "माफ गर्नु होस्, चेहरा सिर्जना गर्न यथेष्ट भण्डार छैन ।"
 
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "Sorry, that name is taken. Please choose another."
 msgstr "माफ गर्नु होस्, त्यो नाम लिइ सकियो । कृपया अर्को छान्नु होस् ।"
 
-#: ../src/common/docview.cpp:1814
+#: ../src/common/docview.cpp:1819
 msgid "Sorry, the format for this file is unknown."
 msgstr "माफ गर्नु होस्, यो फाइलको बनोट थाहा भएन ।"
 
-#: ../src/unix/sound.cpp:492
+#: ../src/unix/sound.cpp:481
 msgid "Sound data are in unsupported format."
 msgstr "ध्वनि तथ्याङ्क असमर्थित बनोटमा छन् ।"
 
-#: ../src/unix/sound.cpp:477
+#: ../src/unix/sound.cpp:466
 #, c-format
 msgid "Sound file '%s' is in unsupported format."
 msgstr "ध्वनि फाइल '%s' असमर्थित बनोटमा छ ।"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:67
+#: ../src/common/accelcmn.cpp:64
 msgid "Space"
 msgstr "space"
 
@@ -6473,12 +6638,12 @@ msgstr "space"
 msgid "Spacing"
 msgstr "Spacing"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "Spell Check"
 msgstr "हिज्जे जाँच"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1776
+#: ../src/propgrid/advprops.cpp:1677
 msgid "Spraycan"
 msgstr "Spraycan"
 
@@ -6487,7 +6652,7 @@ msgstr "Spraycan"
 msgid "Standard"
 msgstr "स्तरीय"
 
-#: ../src/common/paper.cpp:104
+#: ../src/common/paper.cpp:101
 msgid "Statement, 5 1/2 x 8 1/2 in"
 msgstr "बयान, 5 1/2 x 8 1/2इन्च"
 
@@ -6496,33 +6661,29 @@ msgstr "बयान, 5 1/2 x 8 1/2इन्च"
 msgid "Static"
 msgstr "स्थिर"
 
-#: ../src/generic/prntdlgg.cpp:204
+#: ../src/generic/prntdlgg.cpp:197
 msgid "Status:"
 msgstr "स्थिति:"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "Stop"
 msgstr "रोकि देउ"
 
-#: ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196
 msgid "Strikethrough"
 msgstr "Strikethrough"
 
-#: ../src/common/colourcmn.cpp:45
+#: ../src/common/colourcmn.cpp:42
 #, c-format
 msgid "String To Colour : Incorrect colour specification : %s"
 msgstr "String को रङ्ग : गलत रङ्ग specification : %s"
 
 #. TRANSLATORS: Label of font style
-#: ../src/richtext/richtextformatdlg.cpp:339 ../src/propgrid/advprops.cpp:680
+#: ../src/propgrid/advprops.cpp:590 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "शैली"
 
-#: ../include/wx/richtext/richtextstyledlg.h:46
-msgid "Style Organiser"
-msgstr "शैली व्यवस्थापक"
-
-#: ../src/osx/carbon/fontdlg.cpp:348
+#: ../src/osx/carbon/fontdlg.cpp:345
 msgid "Style:"
 msgstr "शैली:"
 
@@ -6531,7 +6692,7 @@ msgid "Subscrip&t"
 msgstr "&पैतालोमा"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:83
+#: ../src/common/accelcmn.cpp:80
 msgid "Subtract"
 msgstr "घटाउ"
 
@@ -6539,11 +6700,11 @@ msgstr "घटाउ"
 msgid "Supe&rscript"
 msgstr "&टाउकोमा"
 
-#: ../src/common/paper.cpp:150
+#: ../src/common/paper.cpp:147
 msgid "SuperA/SuperA/A4 227 x 356 mm"
 msgstr "SuperA/SuperA/A4 227 x 356 mm"
 
-#: ../src/common/paper.cpp:151
+#: ../src/common/paper.cpp:148
 msgid "SuperB/SuperB/A3 305 x 487 mm"
 msgstr "SuperB/SuperB/A3 305 x 487 mm"
 
@@ -6551,7 +6712,7 @@ msgstr "SuperB/SuperB/A3 305 x 487 mm"
 msgid "Suppress hyphe&nation"
 msgstr "हाइपरनेशनलाई &दबाउ"
 
-#: ../src/generic/fontdlgg.cpp:326
+#: ../src/generic/fontdlgg.cpp:322
 msgid "Swiss"
 msgstr "Swiss"
 
@@ -6569,73 +6730,73 @@ msgstr "चिन्ह &वरणाकृति:"
 msgid "Symbols"
 msgstr "चिन्ह"
 
-#: ../src/common/imagtiff.cpp:369 ../src/common/imagtiff.cpp:382
-#: ../src/common/imagtiff.cpp:741
+#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
+#: ../src/common/imagtiff.cpp:738
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: भण्डार उपलब्ध गराउन सकिएन ।"
 
-#: ../src/common/imagtiff.cpp:301
+#: ../src/common/imagtiff.cpp:298
 msgid "TIFF: Error loading image."
 msgstr "TIFF: तस्विर वहनमा गल्ती"
 
-#: ../src/common/imagtiff.cpp:468
+#: ../src/common/imagtiff.cpp:465
 msgid "TIFF: Error reading image."
 msgstr "TIFF: तस्विर पढ्नमा गल्ती "
 
-#: ../src/common/imagtiff.cpp:608
+#: ../src/common/imagtiff.cpp:605
 msgid "TIFF: Error saving image."
 msgstr "TIFF: तस्विर बचतमा गल्ती "
 
-#: ../src/common/imagtiff.cpp:846
+#: ../src/common/imagtiff.cpp:843
 msgid "TIFF: Error writing image."
 msgstr "TIFF: तस्विर लेखाइमा गल्ती "
 
-#: ../src/common/imagtiff.cpp:355
+#: ../src/common/imagtiff.cpp:352
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: तस्विरको आकार असाधारण ठूलो छ ।"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:68
+#: ../src/common/accelcmn.cpp:65
 msgid "Tab"
 msgstr "ट्याब"
 
-#: ../src/richtext/richtextbuffer.cpp:11498
+#: ../src/richtext/richtextbuffer.cpp:11497
 msgid "Table Properties"
 msgstr "तालिका गुणहरू"
 
-#: ../src/common/paper.cpp:145
+#: ../src/common/paper.cpp:142
 msgid "Tabloid Extra 11.69 x 18 in"
 msgstr "Tabloid Extra 11.69 x 18इन्च"
 
-#: ../src/common/paper.cpp:102
+#: ../src/common/paper.cpp:99
 msgid "Tabloid, 11 x 17 in"
 msgstr "Tabloid, 11 x 17इन्च"
 
-#: ../src/richtext/richtextformatdlg.cpp:354
+#: ../src/richtext/richtextformatdlg.cpp:347
 msgid "Tabs"
 msgstr "Tabs"
 
-#: ../src/propgrid/advprops.cpp:1598
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Teal"
 msgstr "गाढा नीलो"
 
-#: ../src/generic/fontdlgg.cpp:327
+#: ../src/generic/fontdlgg.cpp:323
 msgid "Teletype"
 msgstr "Teletype"
 
-#: ../src/common/docview.cpp:1896
+#: ../src/common/docview.cpp:1901
 msgid "Templates"
 msgstr "लेखोट"
 
-#: ../src/common/fmapbase.cpp:158
+#: ../src/common/fmapbase.cpp:155
 msgid "Thai (ISO-8859-11)"
 msgstr "Thai (ISO-8859-11)"
 
-#: ../src/common/ftp.cpp:619
+#: ../src/common/ftp.cpp:622
 msgid "The FTP server doesn't support passive mode."
 msgstr "FTP सर्बरले निष्क्रिय मुद्रा समर्थन गर्दैन ।"
 
-#: ../src/common/ftp.cpp:605
+#: ../src/common/ftp.cpp:608
 msgid "The FTP server doesn't support the PORT command."
 msgstr "FTP सर्बरले पोर्ट आदेश समर्थन गर्दैन ।"
 
@@ -6646,8 +6807,8 @@ msgstr "FTP सर्बरले पोर्ट आदेश समर्थ�
 msgid "The available bullet styles."
 msgstr "उपलब्ध गोलि चिन्हका शैलीहरू "
 
-#: ../src/richtext/richtextstyledlg.cpp:202
-#: ../src/richtext/richtextstyledlg.cpp:204
+#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:200
 msgid "The available styles."
 msgstr "उपलब्ध शैलीहरू"
 
@@ -6703,12 +6864,12 @@ msgstr "पुछार स्थान "
 msgid "The bullet character."
 msgstr "गोलि चिन्हको वर्ण"
 
-#: ../src/richtext/richtextsymboldlg.cpp:443
-#: ../src/richtext/richtextsymboldlg.cpp:445
+#: ../src/richtext/richtextsymboldlg.cpp:440
+#: ../src/richtext/richtextsymboldlg.cpp:442
 msgid "The character code."
 msgstr "वर्ण कोड "
 
-#: ../src/common/fontmap.cpp:203
+#: ../src/common/fontmap.cpp:200
 #, c-format
 msgid ""
 "The charset '%s' is unknown. You may select\n"
@@ -6719,7 +6880,7 @@ msgstr ""
 " तपाइले यसको सट्टामा अर्को वर्णसेट छान्न सक्नु हुन्छ।\n"
 " अथवा अर्को साट्न सकिदैन भने [Cancel] गर्नु होस् । "
 
-#: ../src/msw/ole/dataobj.cpp:394
+#: ../src/msw/ole/dataobj.cpp:402
 #, c-format
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "क्लिप पाटी बनोट '%d' अस्तित्वमा छैन ।"
@@ -6729,7 +6890,7 @@ msgstr "क्लिप पाटी बनोट '%d' अस्तित्व�
 msgid "The default style for the next paragraph."
 msgstr "अघिल्लो अनुच्छेदका लागि निर्धारित शैली "
 
-#: ../src/generic/dirdlgg.cpp:202
+#: ../src/generic/dirdlgg.cpp:199
 #, c-format
 msgid ""
 "The directory '%s' does not exist\n"
@@ -6738,7 +6899,7 @@ msgstr ""
 "घर्रा '%s' भेट्टिएन ।\n"
 "नयाँ सिर्जना गर्ने हो?"
 
-#: ../src/html/htmprint.cpp:271
+#: ../src/html/htmprint.cpp:283
 #, c-format
 msgid ""
 "The document \"%s\" doesn't fit on the page horizontally and will be "
@@ -6751,7 +6912,7 @@ msgstr ""
 "\n"
 "के तपाई जस्तो सुकै भए पनि छाप्न चाहनु हुन्छ?"
 
-#: ../src/common/docview.cpp:1202
+#: ../src/common/docview.cpp:1196
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -6760,36 +6921,36 @@ msgstr ""
 "फाइल '%s' नभेटिएकोले खोल्न सकिएन ।\n"
 "यसलाई हालै प्रयोग गरेका फाइलहरूको सूचीबाट हटाइयो ।"
 
-#: ../src/richtext/richtextindentspage.cpp:208
-#: ../src/richtext/richtextindentspage.cpp:210
 #: ../src/richtext/richtextliststylepage.cpp:394
 #: ../src/richtext/richtextliststylepage.cpp:396
+#: ../src/richtext/richtextindentspage.cpp:208
+#: ../src/richtext/richtextindentspage.cpp:210
 msgid "The first line indent."
 msgstr "पहिलो लाइनको indent"
 
-#: ../src/gtk/utilsgtk.cpp:481
-msgid "The following standard GTK+ options are also supported:\n"
-msgstr "तलको स्तरीय GTK+ विकल्प पनि समर्थन गरिन्छ:\n"
+#: ../src/generic/dbgrptg.cpp:318
+msgid "The following debug report will be generated\n"
+msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:414 ../src/generic/fontdlgg.cpp:416
+#: ../src/generic/fontdlgg.cpp:411 ../src/generic/fontdlgg.cpp:413
 msgid "The font colour."
 msgstr "वरणाकृतिको रङ्ग"
 
-#: ../src/generic/fontdlgg.cpp:375 ../src/generic/fontdlgg.cpp:377
+#: ../src/generic/fontdlgg.cpp:371 ../src/generic/fontdlgg.cpp:373
 msgid "The font family."
 msgstr "वरणाकृतिको परिवार"
 
-#: ../src/richtext/richtextsymboldlg.cpp:405
-#: ../src/richtext/richtextsymboldlg.cpp:407
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "The font from which to take the symbol."
 msgstr "त्यो वरणाकृति जसबाट चिन्ह लिइन्छ ।"
 
-#: ../src/generic/fontdlgg.cpp:427 ../src/generic/fontdlgg.cpp:429
-#: ../src/generic/fontdlgg.cpp:434 ../src/generic/fontdlgg.cpp:436
+#: ../src/generic/fontdlgg.cpp:424 ../src/generic/fontdlgg.cpp:426
+#: ../src/generic/fontdlgg.cpp:430 ../src/generic/fontdlgg.cpp:432
 msgid "The font point size."
 msgstr "वरणाकृतिको आकार (थोप्लोमा)"
 
-#: ../src/osx/carbon/fontdlg.cpp:343 ../src/osx/carbon/fontdlg.cpp:345
+#: ../src/osx/carbon/fontdlg.cpp:340 ../src/osx/carbon/fontdlg.cpp:342
 msgid "The font size in points."
 msgstr "वरणाकृतिको आकार (थोप्लोमा).वरणाकृतिको आकार in थोप्लोs"
 
@@ -6798,15 +6959,15 @@ msgstr "वरणाकृतिको आकार (थोप्लोमा).�
 msgid "The font size units, points or pixels."
 msgstr "वरणाकृति आकारको एकाई, विन्दु अथवा पिक्सेल"
 
-#: ../src/generic/fontdlgg.cpp:386 ../src/generic/fontdlgg.cpp:388
+#: ../src/generic/fontdlgg.cpp:382 ../src/generic/fontdlgg.cpp:384
 msgid "The font style."
 msgstr "वरणाकृतिको शैली"
 
-#: ../src/generic/fontdlgg.cpp:397 ../src/generic/fontdlgg.cpp:399
+#: ../src/generic/fontdlgg.cpp:393 ../src/generic/fontdlgg.cpp:395
 msgid "The font weight."
 msgstr "वरणाकृतिको भार"
 
-#: ../src/common/docview.cpp:1483
+#: ../src/common/docview.cpp:1477
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "फाइल '%s' को बनोट पता लगाउन सकिएन ।"
@@ -6817,10 +6978,10 @@ msgstr "फाइल '%s' को बनोट पता लगाउन सक�
 msgid "The horizontal offset."
 msgstr "&तेर्सो पारेर राख"
 
-#: ../src/richtext/richtextindentspage.cpp:199
-#: ../src/richtext/richtextindentspage.cpp:201
 #: ../src/richtext/richtextliststylepage.cpp:385
 #: ../src/richtext/richtextliststylepage.cpp:387
+#: ../src/richtext/richtextindentspage.cpp:199
+#: ../src/richtext/richtextindentspage.cpp:201
 msgid "The left indent."
 msgstr "देब्रे indent"
 
@@ -6841,10 +7002,10 @@ msgstr "देब्रे ख्रेस्रा को आकार"
 msgid "The left position."
 msgstr "देब्रे स्थान "
 
-#: ../src/richtext/richtextindentspage.cpp:288
-#: ../src/richtext/richtextindentspage.cpp:290
 #: ../src/richtext/richtextliststylepage.cpp:462
 #: ../src/richtext/richtextliststylepage.cpp:464
+#: ../src/richtext/richtextindentspage.cpp:288
+#: ../src/richtext/richtextindentspage.cpp:290
 msgid "The line spacing."
 msgstr "हरफको अन्तर"
 
@@ -6853,7 +7014,7 @@ msgstr "हरफको अन्तर"
 msgid "The list item number."
 msgstr "सूचि सामाग्रीको सङ्ख्या"
 
-#: ../src/msw/ole/automtn.cpp:664
+#: ../src/msw/ole/automtn.cpp:655
 msgid "The locale ID is unknown."
 msgstr "स्थानीय ID थाहा भएन"
 
@@ -6892,19 +7053,19 @@ msgstr "वस्तुको छोडाइ"
 msgid "The outline level."
 msgstr "बाहिरी तह"
 
-#: ../src/common/log.cpp:277
+#: ../src/common/log.cpp:296
 #, fuzzy, c-format
 msgid "The previous message repeated %u time."
 msgid_plural "The previous message repeated %u times."
 msgstr[0] "अघिल्लो सन्देश %lu पटक दोहोरियो ।"
 msgstr[1] "अघिल्लो सन्देश %lu पटक दोहोरियो ।"
 
-#: ../src/common/log.cpp:270
+#: ../src/common/log.cpp:289
 msgid "The previous message repeated once."
 msgstr " पछिल्लो सन्देश एक पटक दोहोरियो ।"
 
-#: ../src/richtext/richtextsymboldlg.cpp:462
-#: ../src/richtext/richtextsymboldlg.cpp:464
+#: ../src/richtext/richtextsymboldlg.cpp:459
+#: ../src/richtext/richtextsymboldlg.cpp:461
 msgid "The range to show."
 msgstr "देखाउने तह"
 
@@ -6917,15 +7078,15 @@ msgstr ""
 "निम्न लिखित फाइलहरू प्रतिवेदनमा समाबेस छन् ।. यदि यी फाइलहरुमा निजी सूचना छ भने\n"
 "कृपया टिक नगर्नु होला । यसो गरेमा यीनिहरूलाई प्रतिवेदनबाट हटाइने छ । \n"
 
-#: ../src/common/cmdline.cpp:1254
+#: ../src/common/cmdline.cpp:1250
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "आवश्यक parameter '%s' तोकिएको थिएन ।"
 
-#: ../src/richtext/richtextindentspage.cpp:217
-#: ../src/richtext/richtextindentspage.cpp:219
 #: ../src/richtext/richtextliststylepage.cpp:403
 #: ../src/richtext/richtextliststylepage.cpp:405
+#: ../src/richtext/richtextindentspage.cpp:217
+#: ../src/richtext/richtextindentspage.cpp:219
 msgid "The right indent."
 msgstr "दाहिने indent"
 
@@ -6967,16 +7128,16 @@ msgstr ""
 msgid "The shadow spread."
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:267
 #: ../src/richtext/richtextliststylepage.cpp:439
 #: ../src/richtext/richtextliststylepage.cpp:441
+#: ../src/richtext/richtextindentspage.cpp:267
 msgid "The spacing after the paragraph."
 msgstr "अनुच्छेद पछिको परक"
 
-#: ../src/richtext/richtextindentspage.cpp:257
-#: ../src/richtext/richtextindentspage.cpp:259
 #: ../src/richtext/richtextliststylepage.cpp:430
 #: ../src/richtext/richtextliststylepage.cpp:432
+#: ../src/richtext/richtextindentspage.cpp:257
+#: ../src/richtext/richtextindentspage.cpp:259
 msgid "The spacing before the paragraph."
 msgstr "अनुच्छेद अघिको परक "
 
@@ -6990,12 +7151,12 @@ msgstr "शैलीको name"
 msgid "The style on which this style is based."
 msgstr "त्यो शैली जसमा यो शैली आधारित छ ।"
 
-#: ../src/richtext/richtextstyledlg.cpp:214
-#: ../src/richtext/richtextstyledlg.cpp:216
+#: ../src/richtext/richtextstyledlg.cpp:210
+#: ../src/richtext/richtextstyledlg.cpp:212
 msgid "The style preview."
 msgstr "शैलीको चेहरा"
 
-#: ../src/msw/ole/automtn.cpp:680
+#: ../src/msw/ole/automtn.cpp:671
 msgid "The system cannot find the file specified."
 msgstr "यो प्रणालीले तोकिएको फाइल फेला पार्न सक्दैन ।"
 
@@ -7008,7 +7169,7 @@ msgstr "tab को स्थान "
 msgid "The tab positions."
 msgstr "tab का स्थानहरू"
 
-#: ../src/richtext/richtextctrl.cpp:3098
+#: ../src/richtext/richtextctrl.cpp:3099
 msgid "The text couldn't be saved."
 msgstr "पाठलाई बचत गर्न सकेन"
 
@@ -7029,7 +7190,7 @@ msgstr "सिरान ख्रेस्रा को आकार"
 msgid "The top position."
 msgstr "सिरान स्थान "
 
-#: ../src/common/cmdline.cpp:1232
+#: ../src/common/cmdline.cpp:1228
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "विकल्प '%s' को मान तोक्न पर्छ ।"
@@ -7039,7 +7200,7 @@ msgstr "विकल्प '%s' को मान तोक्न पर्छ �
 msgid "The value of the corner radius."
 msgstr "कोणीय अर्धव्यासको मान "
 
-#: ../src/msw/dialup.cpp:433
+#: ../src/msw/dialup.cpp:427
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -7054,27 +7215,27 @@ msgstr ""
 msgid "The vertical offset."
 msgstr "ठाडो पङ्क्ति बद्धता लाई योग्य बनाउ"
 
-#: ../src/richtext/richtextprint.cpp:619 ../src/html/htmprint.cpp:745
+#: ../src/html/htmprint.cpp:749 ../src/richtext/richtextprint.cpp:615
 msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr "पृष्ट मिलाउँदा समस्या आयो: तपाइले निर्धारित प्रिन्टर नै रोज्नु राम्रो होला ।"
 
-#: ../src/html/htmprint.cpp:255
+#: ../src/html/htmprint.cpp:267
 msgid ""
 "This document doesn't fit on the page horizontally and will be truncated "
 "when it is printed."
 msgstr "यो कागजातका सबै सामाग्री पृष्टको तेर्सो तर्फ आँटेन, Print गर्दा केही काटिने छ ।"
 
-#: ../src/common/image.cpp:2854
+#: ../src/common/image.cpp:2963
 #, c-format
 msgid "This is not a %s."
 msgstr "यो %s होइन ।"
 
-#: ../src/common/wincmn.cpp:1653
+#: ../src/common/wincmn.cpp:1654
 msgid "This platform does not support background transparency."
 msgstr "यो platform ले पृष्ठभूमि पारदर्शितालाई समर्थन गर्दैन ।"
 
-#: ../src/gtk/window.cpp:4660
+#: ../src/gtk/window.cpp:5664
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
@@ -7082,96 +7243,104 @@ msgstr ""
 "यो कार्यक्रम निकै पुरानो GTK+ संस्करणमा प्रशोधन गरियो । कृपया GTK+ 2.12 अथवा यो भन्दा "
 "नया संस्करण राख्नु होला ।"
 
-#: ../src/msw/thread.cpp:1240
+#: ../src/gtk/glcanvas.cpp:176
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/msw/thread.cpp:1246
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
 msgstr "Thread module सुरु हुन सकेन: स्थानीय Thread भण्डारमा कुनै मान राख्न सकिँदैन ।"
 
-#: ../src/unix/threadpsx.cpp:1794
+#: ../src/unix/threadpsx.cpp:1843
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr "Thread module को सुरुवात असफल भयो : thread कुञ्जी सिर्जना गर्न असफल भयो ।"
 
-#: ../src/msw/thread.cpp:1228
+#: ../src/msw/thread.cpp:1234
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
 msgstr "Thread module सुरु हुन सकेन: स्थानीय thread भण्डारमा सुची राख्न सम्भव छैन ।"
 
-#: ../src/unix/threadpsx.cpp:1043
+#: ../src/unix/threadpsx.cpp:1061
 msgid "Thread priority setting is ignored."
 msgstr "Thread प्राथमिकता कायम लाइ बेवास्ता गरियो"
 
-#: ../src/msw/mdi.cpp:176
+#: ../src/msw/mdi.cpp:171
 msgid "Tile &Horizontally"
 msgstr "&तेर्सो पारेर राख"
 
-#: ../src/msw/mdi.cpp:177
+#: ../src/msw/mdi.cpp:172
 msgid "Tile &Vertically"
 msgstr "&ठाडो पारेर राख"
 
-#: ../src/common/ftp.cpp:200
+#: ../src/common/ftp.cpp:197
 msgid "Timeout while waiting for FTP server to connect, try passive mode."
 msgstr "FTP सर्बरको जडानलाई पर्ख दा समय सकियो, पास मुद्रा कोसिस गर्नु होस् ।"
 
-#: ../src/generic/tipdlg.cpp:201
+#: ../src/generic/tipdlg.cpp:198
 msgid "Tip of the Day"
 msgstr "आजको विशेष कुरा"
 
-#: ../src/generic/tipdlg.cpp:140
+#: ../src/generic/tipdlg.cpp:137
 msgid "Tips not available, sorry!"
 msgstr "कुनै तौर तरिका उपलब्ध छैन ।!"
 
-#: ../src/generic/prntdlgg.cpp:242
+#: ../src/generic/prntdlgg.cpp:235
 msgid "To:"
 msgstr "लाई:"
 
-#: ../src/richtext/richtextbuffer.cpp:8363
+#: ../src/richtext/richtextbuffer.cpp:8361
 msgid "Too many EndStyle calls!"
 msgstr "धेरै अन्त शैली बोलावट!"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:891
+#: ../src/propgrid/advprops.cpp:792
 msgid "Tooltip"
 msgstr "औजारपट्टी"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:892
+#: ../src/propgrid/advprops.cpp:793
 msgid "TooltipText"
 msgstr "औजारपट्टीपाठ"
 
-#: ../src/richtext/richtextsizepage.cpp:286
-#: ../src/richtext/richtextsizepage.cpp:290 ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197 ../src/richtext/richtextsizepage.cpp:286
+#: ../src/richtext/richtextsizepage.cpp:290
 msgid "Top"
 msgstr "सिरान"
 
-#: ../src/generic/prntdlgg.cpp:881
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Top margin (mm):"
 msgstr "सिरान किनार (मिमि):"
 
-#: ../src/generic/aboutdlgg.cpp:79
+#: ../src/generic/aboutdlgg.cpp:76
 msgid "Translations by "
 msgstr "अनुवादन कर्ता "
 
-#: ../src/generic/aboutdlgg.cpp:188
+#: ../src/generic/aboutdlgg.cpp:185
 msgid "Translators"
 msgstr "अनुवादकहरू"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:211
+#: ../src/propgrid/propgrid.cpp:192
 msgid "True"
 msgstr "True"
 
-#: ../src/common/fs_mem.cpp:227
+#: ../src/common/fs_mem.cpp:222
 #, c-format
 msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
 msgstr "फाइल '%s' लाई VFS भण्डारबाट हटाउन कोसिस हुँदैछ, तर यो वहन भएकै छैन!"
 
-#: ../src/common/fmapbase.cpp:156
+#: ../src/common/fmapbase.cpp:153
 msgid "Turkish (ISO-8859-9)"
 msgstr "Turkish (ISO-8859-9)"
 
-#: ../src/generic/filectrlg.cpp:426
+#: ../src/generic/filectrlg.cpp:422
 msgid "Type"
 msgstr "टङ्कण"
 
@@ -7185,17 +7354,17 @@ msgstr "वरणाकृतिको नाम टङ्कण गर"
 msgid "Type a size in points."
 msgstr "थोप्लोमा आकारलाई टङ्कण गर"
 
-#: ../src/msw/ole/automtn.cpp:676
+#: ../src/msw/ole/automtn.cpp:667
 #, c-format
 msgid "Type mismatch in argument %u."
 msgstr "Type mismatch in argument %u"
 
-#: ../src/common/xtixml.cpp:356 ../src/common/xtixml.cpp:509
-#: ../src/common/xtistrm.cpp:318
+#: ../src/common/xtixml.cpp:352 ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315
 msgid "Type must have enum - long conversion"
 msgstr "Type must have enum - long conversion"
 
-#: ../src/propgrid/propgridiface.cpp:401
+#: ../src/propgrid/propgridiface.cpp:385
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
@@ -7204,19 +7373,19 @@ msgstr ""
 "टङ्कण सञ्चालन \"%s\" असफल भयो: सम् पति तह \"%s\" \"%s\" खालको छ, \"%s\" किसिमको "
 "होइन"
 
-#: ../src/common/paper.cpp:133
+#: ../src/common/paper.cpp:130
 msgid "US Std Fanfold, 14 7/8 x 11 in"
 msgstr "US Std Fanfold, 14 7/8 x 11इन्च"
 
-#: ../src/common/fmapbase.cpp:196
+#: ../src/common/fmapbase.cpp:193
 msgid "US-ASCII"
 msgstr "US-ASCII"
 
-#: ../src/unix/fswatcher_inotify.cpp:109
+#: ../src/unix/fswatcher_inotify.cpp:106
 msgid "Unable to add inotify watch"
 msgstr "inotify घडी थप्न सकिएन ।"
 
-#: ../src/unix/fswatcher_kqueue.cpp:136
+#: ../src/unix/fswatcher_kqueue.cpp:153
 msgid "Unable to add kqueue watch"
 msgstr "kqueue घडी थप्न सकिएन ।"
 
@@ -7228,7 +7397,7 @@ msgstr "हातोलाई I/O completion port सित समाविष�
 msgid "Unable to close I/O completion port handle"
 msgstr "I/O completion port हातोलाई बन्द गर्न सकिएन ।"
 
-#: ../src/unix/fswatcher_inotify.cpp:97
+#: ../src/unix/fswatcher_inotify.cpp:94
 msgid "Unable to close inotify instance"
 msgstr "inotify instance लाइ बन्द गर्न सकिएन ।"
 
@@ -7246,15 +7415,15 @@ msgstr "हातो '%s' लाई बन्द गर्न सकिएन �
 msgid "Unable to create I/O completion port"
 msgstr "I/O completion port लाई सिर्जना गर्न सकिएन ।"
 
-#: ../src/msw/fswatcher.cpp:84
+#: ../src/msw/fswatcher.cpp:81
 msgid "Unable to create IOCP worker thread"
 msgstr "IOCP worker सिर्जना गर्न सकिएन ।"
 
-#: ../src/unix/fswatcher_inotify.cpp:74
+#: ../src/unix/fswatcher_inotify.cpp:71
 msgid "Unable to create inotify instance"
 msgstr "inotify instance लाई सिर्जना गर्न सकिएन ।Unable to create "
 
-#: ../src/unix/fswatcher_kqueue.cpp:97
+#: ../src/unix/fswatcher_kqueue.cpp:114
 msgid "Unable to create kqueue instance"
 msgstr "kqueue instance लाई सिर्जना गर्न सकिएन ।"
 
@@ -7262,11 +7431,11 @@ msgstr "kqueue instance लाई सिर्जना गर्न सकि�
 msgid "Unable to dequeue completion packet"
 msgstr "completion packet लाई छरपस्ट गर्न सकिएन ।"
 
-#: ../src/unix/fswatcher_kqueue.cpp:185
+#: ../src/unix/fswatcher_kqueue.cpp:202
 msgid "Unable to get events from kqueue"
 msgstr "kqueue बाट घटना पाउन सकिएन ।"
 
-#: ../src/gtk/app.cpp:435
+#: ../src/gtk/app.cpp:431
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "GTK+ लाई सुरुवात गर्न सकिएन, के दृश्यक त राम्ररी मिलाएको छ ?"
 
@@ -7275,12 +7444,12 @@ msgstr "GTK+ लाई सुरुवात गर्न सकिएन, क�
 msgid "Unable to open path '%s'"
 msgstr "path '%s' खोल्न सकिएन ।"
 
-#: ../src/html/htmlwin.cpp:583
+#: ../src/html/htmlwin.cpp:586
 #, c-format
 msgid "Unable to open requested HTML document: %s"
 msgstr "अनुरोध गरिएको HTML कागजात: %s लाई खोल्न सकिएन ।"
 
-#: ../src/unix/sound.cpp:368
+#: ../src/unix/sound.cpp:365
 msgid "Unable to play sound asynchronously."
 msgstr "ध्वनिलाई सिलसिला मिलाएर बजाउन सकिएन ।"
 
@@ -7288,61 +7457,61 @@ msgstr "ध्वनिलाई सिलसिला मिलाएर बज
 msgid "Unable to post completion status"
 msgstr "समाप्तिको स्थिति पठाउन सकिएन ।"
 
-#: ../src/unix/fswatcher_inotify.cpp:556
+#: ../src/unix/fswatcher_inotify.cpp:553
 msgid "Unable to read from inotify descriptor"
 msgstr "inotify descriptor बाट पढ्न सकिएन ।"
 
-#: ../src/unix/fswatcher_inotify.cpp:141
+#: ../src/unix/fswatcher_inotify.cpp:138
 #, fuzzy, c-format
 msgid "Unable to remove inotify watch %i"
 msgstr "inotify घडी हटाउन सकिएन ।"
 
-#: ../src/unix/fswatcher_kqueue.cpp:153
+#: ../src/unix/fswatcher_kqueue.cpp:170
 msgid "Unable to remove kqueue watch"
 msgstr "kqueue घडीलाई हटाउन सकिएन ।"
 
-#: ../src/msw/fswatcher.cpp:168
+#: ../src/msw/fswatcher.cpp:165
 #, c-format
 msgid "Unable to set up watch for '%s'"
 msgstr "घडी '%s' लाई कायम गर्न सकिएन ।"
 
-#: ../src/msw/fswatcher.cpp:91
+#: ../src/msw/fswatcher.cpp:88
 msgid "Unable to start IOCP worker thread"
 msgstr "IOCP worker thread लाई सुरुवात गर्न सकिएन ।"
 
-#: ../src/common/stockitem.cpp:201
+#: ../src/common/stockitem.cpp:198
 msgid "Undelete"
 msgstr "नमेटाउ"
 
-#: ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199
 msgid "Underline"
 msgstr "अधोरेखाङ्कन"
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/richtext/richtextfontpage.cpp:359 ../src/osx/carbon/fontdlg.cpp:370
-#: ../src/propgrid/advprops.cpp:690
+#: ../src/osx/carbon/fontdlg.cpp:367 ../src/propgrid/advprops.cpp:600
+#: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "अधोरेखाङ्कित"
 
-#: ../src/common/stockitem.cpp:203 ../src/stc/stc_i18n.cpp:15
+#: ../src/common/stockitem.cpp:200 ../src/stc/stc_i18n.cpp:15
 msgid "Undo"
 msgstr "उल्टाउ"
 
-#: ../src/common/stockitem.cpp:265
+#: ../src/common/stockitem.cpp:263
 msgid "Undo last action"
 msgstr "अन्तिमको काम उल्टाउ "
 
-#: ../src/common/cmdline.cpp:1029
+#: ../src/common/cmdline.cpp:1025
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "विकल्पहरू '%s' मा नसोचेका वर्णहरू "
 
-#: ../src/unix/fswatcher_inotify.cpp:274
+#: ../src/unix/fswatcher_inotify.cpp:271
 #, c-format
 msgid "Unexpected event for \"%s\": no matching watch descriptor."
 msgstr "अनुमान नगरेको घटना \"%s\": कुनै मिल्दो घडि व्याख्याकार छैन ।"
 
-#: ../src/common/cmdline.cpp:1195
+#: ../src/common/cmdline.cpp:1191
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "नसोचेका parameter '%s'"
@@ -7351,49 +7520,49 @@ msgstr "नसोचेका parameter '%s'"
 msgid "Unexpectedly new I/O completion port was created"
 msgstr "अचानक नया I/O completion port को सिर्जना भयो"
 
-#: ../src/msw/fswatcher.cpp:70
+#: ../src/msw/fswatcher.cpp:67
 msgid "Ungraceful worker thread termination"
 msgstr "Ungraceful worker thread termination"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:460
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:456
+#: ../src/richtext/richtextsymboldlg.cpp:457
+#: ../src/richtext/richtextsymboldlg.cpp:458
 msgid "Unicode"
 msgstr "युनिकोड"
 
-#: ../src/common/fmapbase.cpp:185 ../src/common/fmapbase.cpp:191
+#: ../src/common/fmapbase.cpp:182 ../src/common/fmapbase.cpp:188
 msgid "Unicode 16 bit (UTF-16)"
 msgstr "16 bit युनिकोड (UTF-16)"
 
-#: ../src/common/fmapbase.cpp:190
+#: ../src/common/fmapbase.cpp:187
 msgid "Unicode 16 bit Big Endian (UTF-16BE)"
 msgstr "बृहत् भारतीय 16 bit युनिकोड (UTF-16BE)"
 
-#: ../src/common/fmapbase.cpp:186
+#: ../src/common/fmapbase.cpp:183
 msgid "Unicode 16 bit Little Endian (UTF-16LE)"
 msgstr "सानो भारतीय 16 bit युनिकोड (UTF-16LE)"
 
-#: ../src/common/fmapbase.cpp:187 ../src/common/fmapbase.cpp:193
+#: ../src/common/fmapbase.cpp:184 ../src/common/fmapbase.cpp:190
 msgid "Unicode 32 bit (UTF-32)"
 msgstr "युनिकोड 32 bit (UTF-32)"
 
-#: ../src/common/fmapbase.cpp:192
+#: ../src/common/fmapbase.cpp:189
 msgid "Unicode 32 bit Big Endian (UTF-32BE)"
 msgstr "युनिकोड 32 bit बृहत् भारतीय (UTF-32BE)"
 
-#: ../src/common/fmapbase.cpp:188
+#: ../src/common/fmapbase.cpp:185
 msgid "Unicode 32 bit Little Endian (UTF-32LE)"
 msgstr "युनिकोड 32 bit सानो भारतीय(UTF-32LE)"
 
-#: ../src/common/fmapbase.cpp:182
+#: ../src/common/fmapbase.cpp:179
 msgid "Unicode 7 bit (UTF-7)"
 msgstr "युनिकोड 7 bit (UTF-7)"
 
-#: ../src/common/fmapbase.cpp:183
+#: ../src/common/fmapbase.cpp:180
 msgid "Unicode 8 bit (UTF-8)"
 msgstr "युनिकोड 8 bit (UTF-8)"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "Unindent"
 msgstr "Unindent"
 
@@ -7544,97 +7713,102 @@ msgstr "सिरान स्थानकोएकाइ"
 msgid "Units for this value."
 msgstr "देब्रे सिमान्तको एकाइ"
 
-#: ../src/generic/progdlgg.cpp:353 ../src/generic/progdlgg.cpp:622
+#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
 msgid "Unknown"
 msgstr "अज्ञात"
 
-#: ../src/msw/dde.cpp:1174
+#: ../src/msw/dde.cpp:1238
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "अज्ञात DDE गल्ती %08x"
 
-#: ../src/common/xtistrm.cpp:410
+#: ../src/common/xtistrm.cpp:407
 msgid "Unknown Object passed to GetObjectClassInfo"
 msgstr "अज्ञात वस्तु GetObjectClassInfo मा पठाइयो"
 
-#: ../src/common/imagpng.cpp:366
+#: ../src/common/imagpng.cpp:383
 #, c-format
 msgid "Unknown PNG resolution unit %d"
 msgstr "अज्ञात PNG resolution एकाइ %d"
 
-#: ../src/common/xtixml.cpp:327
+#: ../src/common/xtixml.cpp:323
 #, c-format
 msgid "Unknown Property %s"
 msgstr "अज्ञात गुण %s"
 
-#: ../src/common/imagtiff.cpp:529
+#: ../src/common/imagtiff.cpp:526
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "अज्ञात TIFF resolution एकाइ %d लाई बेवास्ता गरियो "
 
-#: ../src/unix/dlunix.cpp:160
+#: ../src/propgrid/props.cpp:155
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/unix/dlunix.cpp:118
 msgid "Unknown dynamic library error"
 msgstr "अज्ञात गतिसित पुस्तकालय गल्ती"
 
-#: ../src/common/fmapbase.cpp:810
+#: ../src/common/fmapbase.cpp:806
 #, c-format
 msgid "Unknown encoding (%d)"
 msgstr "अज्ञात अनुसंहिता (%d)"
 
-#: ../src/msw/ole/automtn.cpp:688
+#: ../src/msw/ole/automtn.cpp:679
 #, c-format
 msgid "Unknown error %08x"
 msgstr "अज्ञात गल्ती %08x"
 
-#: ../src/msw/ole/automtn.cpp:647
+#: ../src/msw/ole/automtn.cpp:638
 msgid "Unknown exception"
 msgstr "अज्ञात नमिल्दो अवस्था"
 
-#: ../src/common/image.cpp:2839
+#: ../src/common/image.cpp:2942
 msgid "Unknown image data format."
 msgstr "अज्ञात तस्विर तथ्याङ्क बनोट"
 
-#: ../src/common/cmdline.cpp:914
+#: ../src/common/cmdline.cpp:910
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "अज्ञात लामो विकल्प '%s'"
 
-#: ../src/msw/ole/automtn.cpp:631
+#: ../src/msw/ole/automtn.cpp:622
 msgid "Unknown name or named argument."
 msgstr "अज्ञात नाम अथवा नामाङ्कित तर्क"
 
-#: ../src/common/cmdline.cpp:929 ../src/common/cmdline.cpp:951
+#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "अज्ञात विकल्प '%s'"
 
-#: ../src/common/mimecmn.cpp:225
+#: ../src/common/mimecmn.cpp:221
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "Mime किसिम %s को entry मा '{' मल्दैन ।"
 
-#: ../src/common/cmdproc.cpp:262 ../src/common/cmdproc.cpp:288
-#: ../src/common/cmdproc.cpp:308
+#: ../src/common/cmdproc.cpp:255 ../src/common/cmdproc.cpp:281
+#: ../src/common/cmdproc.cpp:301
 msgid "Unnamed command"
 msgstr "बैनामै आदेश"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:413
+#: ../src/propgrid/propgrid.cpp:392
 msgid "Unspecified"
 msgstr "नतोकिएको"
 
-#: ../src/msw/clipbrd.cpp:311
+#: ../src/msw/clipbrd.cpp:325
 msgid "Unsupported clipboard format."
 msgstr "असमर्थित क्लिप पाटी बनोट"
 
-#: ../src/common/appcmn.cpp:256
+#: ../src/common/appcmn.cpp:277
 #, c-format
 msgid "Unsupported theme '%s'."
 msgstr "असमर्थित theme '%s'"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:205
-#: ../src/common/accelcmn.cpp:63
+#: ../src/common/stockitem.cpp:202 ../src/common/accelcmn.cpp:60
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Up"
 msgstr "माथि"
 
@@ -7648,7 +7822,7 @@ msgstr "ठूलो खालको पाठ"
 msgid "Upper case roman numerals"
 msgstr "ठूलो खालको रोमन सङ्ख्या"
 
-#: ../src/common/cmdline.cpp:1326
+#: ../src/common/cmdline.cpp:1322
 #, c-format
 msgid "Usage: %s"
 msgstr "प्रयोग: %s"
@@ -7657,38 +7831,47 @@ msgstr "प्रयोग: %s"
 msgid "Use &shadow"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:169
-#: ../src/richtext/richtextindentspage.cpp:171
 #: ../src/richtext/richtextliststylepage.cpp:358
 #: ../src/richtext/richtextliststylepage.cpp:360
+#: ../src/richtext/richtextindentspage.cpp:169
+#: ../src/richtext/richtextindentspage.cpp:171
 msgid "Use the current alignment setting."
 msgstr "चालू पङ्क्ति बद्ध अनुकूलताको प्रयोग गर"
 
-#: ../src/common/valtext.cpp:179
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/gtk/font.cpp:552
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/common/valtext.cpp:142
 msgid "Validation conflict"
 msgstr "वैधता को विवाद"
 
-#: ../src/propgrid/manager.cpp:238
+#: ../src/propgrid/manager.cpp:224
 msgid "Value"
 msgstr "मान"
 
-#: ../src/propgrid/props.cpp:386 ../src/propgrid/props.cpp:500
+#: ../src/propgrid/props.cpp:309
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "मान %s अथवा यो भन्दा बढि हुनै पर्दछ ।"
 
-#: ../src/propgrid/props.cpp:417 ../src/propgrid/props.cpp:531
+#: ../src/propgrid/props.cpp:336
 #, c-format
 msgid "Value must be %s or less."
 msgstr "मान %s अथवा यो भन्दा घटि हुनै पर्दछ ।"
 
-#: ../src/propgrid/props.cpp:393 ../src/propgrid/props.cpp:424
-#: ../src/propgrid/props.cpp:507 ../src/propgrid/props.cpp:538
+#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "मान %s र %s को बीचमा हुनै पर्दछ ।"
 
-#: ../src/generic/aboutdlgg.cpp:128
+#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "संस्करण"
 
@@ -7697,25 +7880,32 @@ msgstr "संस्करण"
 msgid "Vertical alignment."
 msgstr "ठाडो पङ्‌क्तिबद्धता"
 
-#: ../src/generic/filedlgg.cpp:202
+#: ../src/generic/filedlgg.cpp:199
 msgid "View files as a detailed view"
 msgstr "विस्तृत दृश्यको रूपमा फाइल हेर्नु होस् "
 
-#: ../src/generic/filedlgg.cpp:200
+#: ../src/generic/filedlgg.cpp:197
 msgid "View files as a list view"
 msgstr "सूचि दृश्यको रूपमा फाइल हेर्नु होस् "
 
-#: ../src/common/docview.cpp:1970
+#: ../src/common/docview.cpp:1975
 msgid "Views"
 msgstr "दृश्यहरू"
 
+#: ../src/gtk/app.cpp:348
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1777
+#: ../src/propgrid/advprops.cpp:1678
 msgid "Wait"
 msgstr "प्रतिक्षा"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1779
+#: ../src/propgrid/advprops.cpp:1680
 msgid "Wait Arrow"
 msgstr "प्रतिक्षा वाण"
 
@@ -7724,237 +7914,234 @@ msgstr "प्रतिक्षा वाण"
 msgid "Waiting for IO on epoll descriptor %d failed"
 msgstr " epoll ब्याख्याकार %d मा IO को पर्खाइ असफल भयो ।"
 
-#: ../src/common/log.cpp:223
+#: ../src/common/log.cpp:241
 msgid "Warning: "
 msgstr "चेतावनी: "
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1778
+#: ../src/propgrid/advprops.cpp:1679
 msgid "Watch"
 msgstr "घडी"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:685
+#: ../src/propgrid/advprops.cpp:595
 msgid "Weight"
 msgstr "भार"
 
-#: ../src/common/fmapbase.cpp:148
+#: ../src/common/fmapbase.cpp:145
 msgid "Western European (ISO-8859-1)"
 msgstr "पश्चिमा युरोपेली (ISO-8859-1)"
 
-#: ../src/common/fmapbase.cpp:162
+#: ../src/common/fmapbase.cpp:159
 msgid "Western European with Euro (ISO-8859-15)"
 msgstr "पश्चिमा युरोपेली with Euro (ISO-8859-15)"
 
-#: ../src/generic/fontdlgg.cpp:446 ../src/generic/fontdlgg.cpp:448
+#: ../src/generic/fontdlgg.cpp:443 ../src/generic/fontdlgg.cpp:445
 msgid "Whether the font is underlined."
 msgstr "वरणाकृति अधोरेखाङ्कित छ वा चैन ।"
 
-#: ../src/propgrid/advprops.cpp:1611
+#: ../src/propgrid/advprops.cpp:1517
 msgid "White"
 msgstr "सेतो"
 
-#: ../src/generic/fdrepdlg.cpp:144
+#: ../src/generic/fdrepdlg.cpp:141
 msgid "Whole word"
 msgstr "पुरै शब्द"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:532
 msgid "Whole words only"
 msgstr "पुरै शब्दहरू मात्र"
 
-#: ../src/univ/themes/win32.cpp:1102
+#: ../src/univ/themes/win32.cpp:1099
 msgid "Win32 theme"
 msgstr "Win32 theme"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:893
+#: ../src/propgrid/advprops.cpp:794
 msgid "Window"
 msgstr "सन्झ्याल"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:894
+#: ../src/propgrid/advprops.cpp:795
 msgid "WindowFrame"
 msgstr "विन्डोफ्रेम"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:895
+#: ../src/propgrid/advprops.cpp:796
 msgid "WindowText"
 msgstr "विन्डोपाठ"
 
-#: ../src/common/fmapbase.cpp:177
+#: ../src/common/fmapbase.cpp:174
 msgid "Windows Arabic (CP 1256)"
 msgstr "अरबी विन्डोज (CP 1256)"
 
-#: ../src/common/fmapbase.cpp:178
+#: ../src/common/fmapbase.cpp:175
 msgid "Windows Baltic (CP 1257)"
 msgstr "बाल्टीकन विन्डोज (CP 1257)"
 
-#: ../src/common/fmapbase.cpp:171
+#: ../src/common/fmapbase.cpp:168
 msgid "Windows Central European (CP 1250)"
 msgstr "केन्द्रीय युरोपेली विन्डोज (CP 1250)"
 
-#: ../src/common/fmapbase.cpp:168
+#: ../src/common/fmapbase.cpp:165
 msgid "Windows Chinese Simplified (CP 936) or GB-2312"
 msgstr "सरलीकृत चिनियाँ विन्डोज (CP 936) अथवा GB-2312"
 
-#: ../src/common/fmapbase.cpp:170
+#: ../src/common/fmapbase.cpp:167
 msgid "Windows Chinese Traditional (CP 950) or Big-5"
 msgstr "परम्परागत चिनियाँ विन्डोज (CP 950) अथवा Big-5"
 
-#: ../src/common/fmapbase.cpp:172
+#: ../src/common/fmapbase.cpp:169
 msgid "Windows Cyrillic (CP 1251)"
 msgstr "सेरिलिक विन्डोज (CP 1251)"
 
-#: ../src/common/fmapbase.cpp:174
+#: ../src/common/fmapbase.cpp:171
 msgid "Windows Greek (CP 1253)"
 msgstr "ग्रीक विन्डोज (CP 1253)"
 
-#: ../src/common/fmapbase.cpp:176
+#: ../src/common/fmapbase.cpp:173
 msgid "Windows Hebrew (CP 1255)"
 msgstr "हिब्रु विन्डोज (CP 1255)"
 
-#: ../src/common/fmapbase.cpp:167
+#: ../src/common/fmapbase.cpp:164
 msgid "Windows Japanese (CP 932) or Shift-JIS"
 msgstr "जापानी विन्डोज (CP 932) अथवा Shift-JIS"
 
-#: ../src/common/fmapbase.cpp:180
+#: ../src/common/fmapbase.cpp:177
 msgid "Windows Johab (CP 1361)"
 msgstr "जोहब विन्डोज (CP 1361)"
 
-#: ../src/common/fmapbase.cpp:169
+#: ../src/common/fmapbase.cpp:166
 msgid "Windows Korean (CP 949)"
 msgstr "कोरिया ली विन्डोज (CP 949)"
 
-#: ../src/common/fmapbase.cpp:166
+#: ../src/common/fmapbase.cpp:163
 msgid "Windows Thai (CP 874)"
 msgstr "थाइ विन्डोज (CP 874)"
 
-#: ../src/common/fmapbase.cpp:175
+#: ../src/common/fmapbase.cpp:172
 msgid "Windows Turkish (CP 1254)"
 msgstr "तुर्कि विन्डोज (CP 1254)"
 
-#: ../src/common/fmapbase.cpp:179
+#: ../src/common/fmapbase.cpp:176
 msgid "Windows Vietnamese (CP 1258)"
 msgstr "भियतनामी विन्डोज (CP 1253)"
 
-#: ../src/common/fmapbase.cpp:173
+#: ../src/common/fmapbase.cpp:170
 msgid "Windows Western European (CP 1252)"
 msgstr "पश्चिमा युरोपेली विन्डोज (CP 1252)"
 
-#: ../src/common/fmapbase.cpp:181
+#: ../src/common/fmapbase.cpp:178
 msgid "Windows/DOS OEM (CP 437)"
 msgstr "विन्डोज /DOS OEM (CP 437)"
 
-#: ../src/common/fmapbase.cpp:165
+#: ../src/common/fmapbase.cpp:162
 msgid "Windows/DOS OEM Cyrillic (CP 866)"
 msgstr "विन्डोज /DOS OEM सेरिलिक (CP 866)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:111
+#: ../src/common/accelcmn.cpp:109
 msgid "Windows_Left"
 msgstr "विन्डोज_देब्रे"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:113
+#: ../src/common/accelcmn.cpp:111
 msgid "Windows_Menu"
 msgstr "विन्डोज_मेनु"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:112
+#: ../src/common/accelcmn.cpp:110
 msgid "Windows_Right"
 msgstr "विन्डोज_दाहिने"
 
-#: ../src/common/ffile.cpp:150
+#: ../src/common/ffile.cpp:149
 #, c-format
 msgid "Write error on file '%s'"
 msgstr "फाइल '%s' को लेखाइमा गल्ती"
 
-#: ../src/xml/xml.cpp:914
+#: ../src/xml/xml.cpp:925
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "XML पठाउन मा गल्ती: '%s' (%d लाइनमा)"
 
-#: ../src/common/xpmdecod.cpp:796
+#: ../src/common/xpmdecod.cpp:794
 msgid "XPM: Malformed pixel data!"
 msgstr "XPM: नमिल्दो pixel तथ्याङ्क !"
 
-#: ../src/common/xpmdecod.cpp:705
+#: ../src/common/xpmdecod.cpp:702
 #, c-format
 msgid "XPM: incorrect colour description in line %d"
 msgstr "XPM: लाइन %d मा अशुद्ध रङ्गको विवरण"
 
-#: ../src/common/xpmdecod.cpp:680
+#: ../src/common/xpmdecod.cpp:677
 msgid "XPM: incorrect header format!"
 msgstr "XPM: शीर्ष बनोटमा अशुद्धता!"
 
-#: ../src/common/xpmdecod.cpp:716 ../src/common/xpmdecod.cpp:725
+#: ../src/common/xpmdecod.cpp:714 ../src/common/xpmdecod.cpp:723
 #, c-format
 msgid "XPM: malformed colour definition '%s' at line %d!"
 msgstr "XPM: नमिल्दो रङ्गको परिभाषा '%s' ! (लाइन %d मा ) "
 
-#: ../src/common/xpmdecod.cpp:755
+#: ../src/common/xpmdecod.cpp:753
 msgid "XPM: no colors left to use for mask!"
 msgstr "XPM: मखुन्डोको लागि कुनै रङ्ग छैन ।"
 
-#: ../src/common/xpmdecod.cpp:782
+#: ../src/common/xpmdecod.cpp:780
 #, c-format
 msgid "XPM: truncated image data at line %d!"
 msgstr "XPM: %d लाइनमा काटिएको तस्विर तथ्याङ्क !"
 
-#: ../src/propgrid/advprops.cpp:1610
+#: ../src/propgrid/advprops.cpp:1516
 msgid "Yellow"
 msgstr "पहेँलो"
 
-#: ../include/wx/msgdlg.h:276 ../src/common/stockitem.cpp:206
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:203
 #: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "हो"
 
-#: ../src/osx/carbon/overlay.cpp:155
-msgid "You cannot Clear an overlay that is not inited"
-msgstr "पोतिएको होइन भने तपाइले खप्टिएको स्थानमा सफा गर्न सक्नु हुन्न ।"
-
-#: ../src/osx/carbon/overlay.cpp:107 ../src/dfb/overlay.cpp:61
-msgid "You cannot Init an overlay twice"
-msgstr "तपाइले खप्टिएको स्थानमा दुई पटक पोत्न सक्नु हुन्न ।"
-
-#: ../src/generic/dirdlgg.cpp:287
+#: ../src/generic/dirdlgg.cpp:284
 msgid "You cannot add a new directory to this section."
 msgstr "तपाइले यो खण्डमा नया घर्रा थप्न सक्नु हुन्न ।"
 
-#: ../src/propgrid/propgrid.cpp:3299
+#: ../src/propgrid/propgrid.cpp:3276
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr "तपाइले गल्ती मान राख्नु भयो । सम्पादनलाई रद्द गर्न ESC दबाउनु होस् ।"
 
-#: ../src/common/stockitem.cpp:209
+#: ../src/osx/cocoa/menu.mm:286
+#, fuzzy
+msgid "Zoom"
+msgstr "ठूलो पार"
+
+#: ../src/common/stockitem.cpp:206
 msgid "Zoom &In"
 msgstr "&ठूलो पार्ने"
 
-#: ../src/common/stockitem.cpp:210
+#: ../src/common/stockitem.cpp:207
 msgid "Zoom &Out"
 msgstr "&सानो पार्ने"
 
-#: ../src/common/stockitem.cpp:209 ../src/common/prntbase.cpp:1594
+#: ../src/common/stockitem.cpp:206 ../src/common/prntbase.cpp:1619
 msgid "Zoom In"
 msgstr "ठूलो पार"
 
-#: ../src/common/stockitem.cpp:210 ../src/common/prntbase.cpp:1580
+#: ../src/common/stockitem.cpp:207 ../src/common/prntbase.cpp:1605
 msgid "Zoom Out"
 msgstr "सानो पार"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to &Fit"
 msgstr "&मिल्दो आकारमा ल्याउ"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to Fit"
 msgstr "मिल्दो आकारमा ल्याउ"
 
-#: ../src/msw/dde.cpp:1141
+#: ../src/msw/dde.cpp:1205
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "DDEML अनुप्रयोगले लम्बिएको दौडको सिर्जना गरेको छ ।"
 
-#: ../src/msw/dde.cpp:1129
+#: ../src/msw/dde.cpp:1193
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -7966,39 +8153,39 @@ msgstr ""
 "अथवा \n"
 "अवैध परिचायक लाई DDEML function मा पटाइयो ।"
 
-#: ../src/msw/dde.cpp:1147
+#: ../src/msw/dde.cpp:1211
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "वार्तालापको लागि ग्राहकको जडान प्रयास असफल भयो ।"
 
-#: ../src/msw/dde.cpp:1144
+#: ../src/msw/dde.cpp:1208
 msgid "a memory allocation failed."
 msgstr "भण्डार उपलब्ध गराउने प्रयास असफल भयो ।"
 
-#: ../src/msw/dde.cpp:1138
+#: ../src/msw/dde.cpp:1202
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "एउटा parameter DDEML वाट वैधता पाउन असफल भयो ।"
 
-#: ../src/msw/dde.cpp:1120
+#: ../src/msw/dde.cpp:1184
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "व्यवस्थित सल्लाह कारोबारका लागि अनुरोध समय सकियो ।"
 
-#: ../src/msw/dde.cpp:1126
+#: ../src/msw/dde.cpp:1190
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "व्यवस्थित तथ्याङ्क कारोबारका लागि अनुरोध समय सकियो ।"
 
-#: ../src/msw/dde.cpp:1135
+#: ../src/msw/dde.cpp:1199
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "व्यवस्थित कार्यकारी कारोबारका लागि अनुरोध समय सकियो ।"
 
-#: ../src/msw/dde.cpp:1153
+#: ../src/msw/dde.cpp:1217
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "व्यवस्थित poke कारोबारका लागि अनुरोध समय सकियो ।"
 
-#: ../src/msw/dde.cpp:1168
+#: ../src/msw/dde.cpp:1232
 msgid "a request to end an advise transaction has timed out."
 msgstr "व्यवस्थित सल्लाह कारोबार समाप्तिको लागि अनुरोध समय सकियो ।"
 
-#: ../src/msw/dde.cpp:1162
+#: ../src/msw/dde.cpp:1226
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -8008,15 +8195,15 @@ msgstr ""
 " अथवा \n"
 "सर्बरले नै कारोबार समाप्त हुनु अगावै काटि दियो ।"
 
-#: ../src/msw/dde.cpp:1150
+#: ../src/msw/dde.cpp:1214
 msgid "a transaction failed."
 msgstr "कारोबार असफल भयो ।"
 
-#: ../src/common/accelcmn.cpp:189
+#: ../src/common/accelcmn.cpp:188
 msgid "alt"
 msgstr "Alt"
 
-#: ../src/msw/dde.cpp:1132
+#: ../src/msw/dde.cpp:1196
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -8027,17 +8214,17 @@ msgstr ""
 "अथवा \n"
 " अनुप्रयोगले APPCMD_CLIENTONLY को रूपमा सर्बर कारोबार को प्रयास आरम्भ गरायो।"
 
-#: ../src/msw/dde.cpp:1156
+#: ../src/msw/dde.cpp:1220
 msgid "an internal call to the PostMessage function has failed. "
 msgstr ""
 "PostMessage function को आन्तरिक बोलावट असफल भयो । an internal call to the has "
 "failed. "
 
-#: ../src/msw/dde.cpp:1165
+#: ../src/msw/dde.cpp:1229
 msgid "an internal error has occurred in the DDEML."
 msgstr "आन्तरिक रूपमा DDEML मा गल्ती भयो ।"
 
-#: ../src/msw/dde.cpp:1171
+#: ../src/msw/dde.cpp:1235
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -8048,56 +8235,56 @@ msgstr ""
 " फिर्ता पठाइ सके पछि, \n"
 " कारोबार परिचायक लाई फिर्ता बोलाउने कार्य मान्य हुने छैन । "
 
-#: ../src/common/zipstrm.cpp:1483
+#: ../src/common/zipstrm.cpp:1522
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "यो बहू-टुक्रा जोडजाड गरेर बनाइएको zip मानियो । "
 
-#: ../src/common/fileconf.cpp:1847
+#: ../src/common/fileconf.cpp:1849
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "परिवर्तित नहुने कुञ्जी '%s' को परिवर्तन प्रयासलाई बेवास्ता गरियो ।"
 
-#: ../src/html/chm.cpp:329
+#: ../src/html/chm.cpp:326
 msgid "bad arguments to library function"
 msgstr "पुस्तकालय function का लागि नमिल्ने तर्क "
 
-#: ../src/html/chm.cpp:341
+#: ../src/html/chm.cpp:338
 msgid "bad signature"
 msgstr "गलत हस्ताक्षर"
 
-#: ../src/common/zipstrm.cpp:1918
+#: ../src/common/zipstrm.cpp:1988
 msgid "bad zipfile offset to entry"
 msgstr "प्रविष्टिका लागि गलत zip फाइलको हातो"
 
-#: ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400
 msgid "binary"
 msgstr "binary"
 
-#: ../src/common/fontcmn.cpp:996
+#: ../src/common/fontcmn.cpp:1195
 msgid "bold"
 msgstr "मोटो"
 
-#: ../src/msw/utils.cpp:1144
+#: ../src/msw/utils.cpp:1135
 #, c-format
 msgid "build %lu"
 msgstr "निर्माण %lu"
 
-#: ../src/common/ffile.cpp:75
+#: ../src/common/ffile.cpp:73
 #, c-format
 msgid "can't close file '%s'"
 msgstr "फाइल '%s' बन्द गर्न सकिँदैन ।"
 
-#: ../src/common/file.cpp:245
+#: ../src/common/file.cpp:242
 #, c-format
 msgid "can't close file descriptor %d"
 msgstr "फाइल ब्याख्याकार %d बन्द गर्न सकिँदैन ।"
 
-#: ../src/common/file.cpp:586
+#: ../src/common/ffile.cpp:382 ../src/common/file.cpp:613
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "फाइल '%s' लाई वाचा गर्न सकिँदैन ।"
 
-#: ../src/common/file.cpp:178
+#: ../src/common/file.cpp:175
 #, c-format
 msgid "can't create file '%s'"
 msgstr "फाइल '%s' सिर्जना गर्न सकिँदैन ।"
@@ -8107,49 +8294,49 @@ msgstr "फाइल '%s' सिर्जना गर्न सकिँदै�
 msgid "can't delete user configuration file '%s'"
 msgstr "उपभोक्ताको अभियोजन फाइल '%s' मेटाउन सकिँदैन ।"
 
-#: ../src/common/file.cpp:495
+#: ../src/common/file.cpp:522
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr "यदि फाइलको अन्त ब्याख्याकार %d मा पुगेको छ भने यसलाई पता लगाउन सकिँदैन ।"
 
-#: ../src/common/zipstrm.cpp:1692
+#: ../src/common/zipstrm.cpp:1747
 msgid "can't find central directory in zip"
 msgstr "zip मा केन्द्रीय घर्रा फेला पार्न सकिँदैन ।"
 
-#: ../src/common/file.cpp:465
+#: ../src/common/file.cpp:492
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "फाइल ब्याख्याकार %d मा फाइल को लम्बाइ फेला पार्न सकिँदैन ।"
 
-#: ../src/msw/utils.cpp:341
+#: ../src/msw/utils.cpp:336
 msgid "can't find user's HOME, using current directory."
 msgstr "चालू घर्राको प्रयोग गरेर उपभोक्ताको गृह फेला पार्न सकिँदैन ।"
 
-#: ../src/common/file.cpp:366
+#: ../src/common/file.cpp:407
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "फाइल ब्याख्याकार %d लाई माझ्न सकिँदैन ।"
 
-#: ../src/common/file.cpp:422
+#: ../src/common/file.cpp:463
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "फाइल ब्याख्याकार %d मा खोजी को स्थान पाउन सकिँदैन ।"
 
-#: ../src/common/fontmap.cpp:325
+#: ../src/common/fontmap.cpp:322
 msgid "can't load any font, aborting"
 msgstr "कुनै पनि वरणाकृतिलाई वहन गर्न सकिँदैन, परित्याग गरिदैं छ"
 
-#: ../src/common/file.cpp:231 ../src/common/ffile.cpp:59
+#: ../src/common/ffile.cpp:57 ../src/common/file.cpp:228
 #, c-format
 msgid "can't open file '%s'"
 msgstr "फाइल '%s' लाई पल्टाउन सकिँदैन ।"
 
-#: ../src/common/fileconf.cpp:320
+#: ../src/common/fileconf.cpp:314
 #, c-format
 msgid "can't open global configuration file '%s'."
 msgstr "साझा अभियोजन फाइल '%s' लाई खोल्न सकिएन ।"
 
-#: ../src/common/fileconf.cpp:336
+#: ../src/common/fileconf.cpp:330
 #, c-format
 msgid "can't open user configuration file '%s'."
 msgstr "उपभोक्ताको अभियोजन फाइल '%s' लाई खोल्न सकिएन ।"
@@ -8158,40 +8345,40 @@ msgstr "उपभोक्ताको अभियोजन फाइल '%s' �
 msgid "can't open user configuration file."
 msgstr "उपभोक्ताको अभियोजन फाइललाई खोल्न सकिएन ।"
 
-#: ../src/common/zipstrm.cpp:579
+#: ../src/common/zipstrm.cpp:572
 msgid "can't re-initialize zlib deflate stream"
 msgstr "zlib deflate stream लाई पुनः सुरुवात गर्न सकिँदैन ।"
 
-#: ../src/common/zipstrm.cpp:604
+#: ../src/common/zipstrm.cpp:597
 msgid "can't re-initialize zlib inflate stream"
 msgstr "zlib inflate stream लाई पुनः सुरुवात गर्न सकिँदैन ।"
 
-#: ../src/common/file.cpp:304
+#: ../src/common/file.cpp:345
 #, c-format
 msgid "can't read from file descriptor %d"
 msgstr "फाइल ब्याख्याकार %d बाट पढ्न सकिँदैन ।"
 
-#: ../src/common/file.cpp:581
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:608
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "फाइल '%s' लाइ हटाउन सकिँदैन ।"
 
-#: ../src/common/file.cpp:598
+#: ../src/common/ffile.cpp:394 ../src/common/file.cpp:625
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "अस्ताइ फाइल '%s' लाई हटाउन सकिँदैन ।"
 
-#: ../src/common/file.cpp:408
+#: ../src/common/file.cpp:449
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "फाइल ब्याख्याकार %d मा खोज्न सकिँदैन ।"
 
-#: ../src/common/textfile.cpp:273
+#: ../src/common/textfile.cpp:161
 #, c-format
 msgid "can't write buffer '%s' to disk."
 msgstr "buffer '%s' लाई disk मा लेख्न सकिँदैन ।"
 
-#: ../src/common/file.cpp:323
+#: ../src/common/file.cpp:364
 #, c-format
 msgid "can't write to file descriptor %d"
 msgstr "फाइल ब्याख्याकार %d लाई लेख्न सकिँदैन ।"
@@ -8201,22 +8388,28 @@ msgid "can't write user configuration file."
 msgstr "उपभोक्ताको अभियोजन फाइल लेख्न सकिँदैन "
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:482 ../src/generic/datavgen.cpp:1261
+#: ../src/common/datavcmn.cpp:2064 ../src/generic/datavgen.cpp:1384
 msgid "checked"
 msgstr ""
 
-#: ../src/html/chm.cpp:345
+#: ../src/html/chm.cpp:342
 msgid "checksum error"
 msgstr "गल्ती जाँच सूचि"
 
-#: ../src/common/tarstrm.cpp:820
+#: ../src/common/tarstrm.cpp:814
 msgid "checksum failure reading tar header block"
 msgstr "tar header हिस्सा असफलता जाँच सुची "
 
-#: ../src/richtext/richtextbackgroundpage.cpp:226
-#: ../src/richtext/richtextbackgroundpage.cpp:249
-#: ../src/richtext/richtextbackgroundpage.cpp:289
-#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
 #: ../src/richtext/richtextborderspage.cpp:254
 #: ../src/richtext/richtextborderspage.cpp:288
 #: ../src/richtext/richtextborderspage.cpp:322
@@ -8234,105 +8427,128 @@ msgstr "tar header हिस्सा असफलता जाँच सुच�
 #: ../src/richtext/richtextmarginspage.cpp:340
 #: ../src/richtext/richtextmarginspage.cpp:363
 #: ../src/richtext/richtextmarginspage.cpp:388
-#: ../src/richtext/richtextsizepage.cpp:339
-#: ../src/richtext/richtextsizepage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:400
-#: ../src/richtext/richtextsizepage.cpp:427
-#: ../src/richtext/richtextsizepage.cpp:454
-#: ../src/richtext/richtextsizepage.cpp:481
-#: ../src/richtext/richtextsizepage.cpp:555
-#: ../src/richtext/richtextsizepage.cpp:590
-#: ../src/richtext/richtextsizepage.cpp:625
-#: ../src/richtext/richtextsizepage.cpp:660
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
 msgid "cm"
 msgstr "सेमी"
 
-#: ../src/html/chm.cpp:347
+#: ../src/html/chm.cpp:344
 msgid "compression error"
 msgstr "दबाब गल्ती"
 
-#: ../src/common/regex.cpp:236
+#: ../src/common/regex.cpp:233
 msgid "conversion to 8-bit encoding failed"
 msgstr "8-bit अनुसंहिता मा रूपान्तरण असफल भयो ।"
 
-#: ../src/common/accelcmn.cpp:187
+#: ../src/common/accelcmn.cpp:186
 msgid "ctrl"
 msgstr "नियन्त्रण"
 
-#: ../src/common/cmdline.cpp:1500
+#: ../src/common/cmdline.cpp:1496
 msgid "date"
 msgstr "मिति"
 
-#: ../src/html/chm.cpp:349
+#: ../src/html/chm.cpp:346
 msgid "decompression error"
 msgstr "दबाब विहीनता गल्ती"
 
-#: ../src/richtext/richtextstyles.cpp:780 ../src/common/fmapbase.cpp:820
+#: ../src/common/fmapbase.cpp:816 ../src/richtext/richtextstyles.cpp:777
 msgid "default"
 msgstr "निर्धारित"
 
-#: ../src/common/cmdline.cpp:1496
+#: ../src/common/cmdline.cpp:1492
 msgid "double"
 msgstr "दोबर"
 
-#: ../src/common/debugrpt.cpp:538
+#: ../src/common/debugrpt.cpp:539
 msgid "dump of the process state (binary)"
 msgstr "प्रक्रिया अवस्था थुप्रियो (binary)"
 
-#: ../src/common/datetimefmt.cpp:1969
+#: ../src/common/datetimefmt.cpp:1992
 msgid "eighteenth"
 msgstr "अठारौं"
 
-#: ../src/common/datetimefmt.cpp:1959
+#: ../src/common/datetimefmt.cpp:1982
 msgid "eighth"
 msgstr "आठौं"
 
-#: ../src/common/datetimefmt.cpp:1962
+#: ../src/common/datetimefmt.cpp:1985
 msgid "eleventh"
 msgstr "एघारौं"
 
-#: ../src/common/fileconf.cpp:1833
+#: ../src/common/fileconf.cpp:1835
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "प्रविष्टि '%s' समूह '%s' मा एक पल्ट भन्दा बढि देखिन्छ "
 
-#: ../src/html/chm.cpp:343
+#: ../src/html/chm.cpp:340
 msgid "error in data format"
 msgstr "तथ्याङ्क बनोटमा गल्ती "
 
-#: ../src/html/chm.cpp:331
+#: ../src/html/chm.cpp:328
 msgid "error opening file"
 msgstr "फाइल खोल्दा गल्ती"
 
-#: ../src/common/zipstrm.cpp:1778
+#: ../src/common/zipstrm.cpp:1836
 msgid "error reading zip central directory"
 msgstr "केन्द्रीय घर्रा पढ्दा गल्ती "
 
-#: ../src/common/zipstrm.cpp:1870
+#: ../src/common/zipstrm.cpp:1940
 msgid "error reading zip local header"
 msgstr "स्थानीय header पढ्दा गल्ती "
 
-#: ../src/common/zipstrm.cpp:2531
+#: ../src/common/zipstrm.cpp:2615
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "zip प्रविष्टि '%s' लेखाइमा गल्ती: गलत crc अथवा लम्बाइ"
 
-#: ../src/common/ffile.cpp:188
+#: ../src/common/zipstrm.cpp:2608
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "zip प्रविष्टि '%s' लेखाइमा गल्ती: गलत crc अथवा लम्बाइ"
+
+#: ../src/common/fontcmn.cpp:1205
+#, fuzzy
+msgid "extrabold"
+msgstr "मोटो"
+
+#: ../src/common/fontcmn.cpp:1223
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1167
+#, fuzzy
+msgid "extralight"
+msgstr "हलुको"
+
+#: ../src/msw/webview_ie.cpp:1036
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "'%s' कार्यान्वयन गर्न सकिएन ।\n"
+
+#: ../src/common/ffile.cpp:187
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "फाइल '%s' लाइ चिल्लो पार्न असफल भयो ।"
 
+#: ../src/msw/webview_ie.cpp:1045
+#, fuzzy
+msgid "failed to retrieve execution result"
+msgstr "RAS गल्ती सन् देसको पाठहरू लिन सकिएन ।"
+
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1030
+#: ../src/generic/datavgen.cpp:1150
 #, fuzzy
 msgid "false"
 msgstr "असत्य"
 
-#: ../src/common/datetimefmt.cpp:1966
+#: ../src/common/datetimefmt.cpp:1989
 msgid "fifteenth"
 msgstr "पन्ध्रौं"
 
-#: ../src/common/datetimefmt.cpp:1956
+#: ../src/common/datetimefmt.cpp:1979
 msgid "fifth"
 msgstr "पाछौं"
 
@@ -8361,131 +8577,150 @@ msgstr "फाइल '%s', लाइन %d: अपरिवर्तित क�
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "फाइल '%s': वर्ण %c (%d लाइनमा ) अनपेक्षित छ ।"
 
-#: ../src/richtext/richtextbuffer.cpp:8738
+#: ../src/richtext/richtextbuffer.cpp:8736
 msgid "files"
 msgstr "फाइलहरू"
 
-#: ../src/common/datetimefmt.cpp:1952
+#: ../src/common/datetimefmt.cpp:1975
 msgid "first"
 msgstr "प्रथम"
 
-#: ../src/html/helpwnd.cpp:1252
+#: ../src/html/helpwnd.cpp:1250
 msgid "font size"
 msgstr "वरणाकृतिको आकार"
 
-#: ../src/common/datetimefmt.cpp:1965
+#: ../src/common/datetimefmt.cpp:1988
 msgid "fourteenth"
 msgstr "चौधौं "
 
-#: ../src/common/datetimefmt.cpp:1955
+#: ../src/common/datetimefmt.cpp:1978
 msgid "fourth"
 msgstr "चौथो"
 
-#: ../src/common/appbase.cpp:783
+#: ../src/common/appbase.cpp:784
 msgid "generate verbose log messages"
 msgstr "लामो सन्देशहरू उत्पादन गर्छ ।"
 
-#: ../src/richtext/richtextbuffer.cpp:13138
-#: ../src/richtext/richtextbuffer.cpp:13248
+#: ../src/common/fontcmn.cpp:1215
+msgid "heavy"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:13133
+#: ../src/richtext/richtextbuffer.cpp:13243
 msgid "image"
 msgstr "तस्विर"
 
-#: ../src/common/tarstrm.cpp:796
+#: ../src/common/tarstrm.cpp:790
 msgid "incomplete header block in tar"
 msgstr "tar मा अपूरो header हिस्सा"
 
-#: ../src/common/xtixml.cpp:489
+#: ../src/common/xtixml.cpp:485
 msgid "incorrect event handler string, missing dot"
 msgstr "अशुद्ध घटना सञ्चालक , थोप्लो छुटेको छ ।"
 
-#: ../src/common/tarstrm.cpp:1381
+#: ../src/common/tarstrm.cpp:1375
 msgid "incorrect size given for tar entry"
 msgstr "tar प्रविष्टिका लागि दिइएको आकार असुद्धी छ ।"
 
-#: ../src/common/tarstrm.cpp:993
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:987
 msgid "invalid data in extended tar header"
 msgstr "विस्तारित tar header मा अवैध तथ्याङ्क छ ।"
 
-#: ../src/generic/logg.cpp:1030
+#: ../src/generic/logg.cpp:1027
 msgid "invalid message box return value"
 msgstr "सन्देश बाकसको मान अवैध छ । "
 
-#: ../src/common/zipstrm.cpp:1647
+#: ../src/common/zipstrm.cpp:1688
 msgid "invalid zip file"
 msgstr "अवैध zip फाइल"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:1228
 msgid "italic"
 msgstr "डल्केको"
 
-#: ../src/common/fontcmn.cpp:991
+#: ../src/common/webrequest_curl.cpp:374
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "महलको बयान सुरु भएन"
+
+#: ../src/common/fontcmn.cpp:1172
 msgid "light"
 msgstr "हलुको"
 
-#: ../src/common/intl.cpp:303
-#, c-format
-msgid "locale '%s' cannot be set."
-msgstr "स्थानीयता '%s' कायम गर्न सकिँदैन ।"
+#: ../src/common/fontcmn.cpp:1185
+msgid "medium"
+msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2125
+#: ../src/common/datetimefmt.cpp:2148
 msgid "midnight"
 msgstr "मध्य रात"
 
-#: ../src/common/datetimefmt.cpp:1970
+#: ../src/common/datetimefmt.cpp:1993
 msgid "nineteenth"
 msgstr "उन्नाइसौं"
 
-#: ../src/common/datetimefmt.cpp:1960
+#: ../src/common/datetimefmt.cpp:1983
 msgid "ninth"
 msgstr "नवौं"
 
-#: ../src/msw/dde.cpp:1116
+#: ../src/msw/dde.cpp:1180
 msgid "no DDE error."
 msgstr "DDE गल्ती छैन"
 
-#: ../src/html/chm.cpp:327
+#: ../src/html/chm.cpp:324
 msgid "no error"
 msgstr "गल्ती छैन"
 
-#: ../src/dfb/fontmgr.cpp:174
+#: ../src/dfb/fontmgr.cpp:171
 #, c-format
 msgid "no fonts found in %s, using builtin font"
 msgstr "%s मा वरणाकृतिहरू छैनन्, बनि बनाउ वरणाकृति को प्रयोग गरिदैं छ"
 
-#: ../src/html/helpdata.cpp:657
+#: ../src/html/helpdata.cpp:650
 msgid "noname"
 msgstr "बैनामै "
 
-#: ../src/common/datetimefmt.cpp:2124
+#: ../src/common/datetimefmt.cpp:2147
 msgid "noon"
 msgstr "मध्यान्न"
 
-#: ../src/richtext/richtextstyles.cpp:779
+#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "सामान्य"
 
-#: ../src/common/cmdline.cpp:1492
+#: ../src/common/cmdline.cpp:1488
 msgid "num"
 msgstr "num"
 
-#: ../src/common/xtixml.cpp:259
+#: ../src/common/accelcmn.cpp:194
+msgid "num "
+msgstr ""
+
+#: ../src/common/xtixml.cpp:255
 msgid "objects cannot have XML Text Nodes"
 msgstr "वस्तु को XML पाठ टिप्पणी हुन सक्दैन ।"
 
-#: ../src/html/chm.cpp:339
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
 msgid "out of memory"
 msgstr "भण्डार क्षमता भन्दा बाहिर"
 
-#: ../src/common/debugrpt.cpp:514
+#: ../src/common/debugrpt.cpp:515
 msgid "process context description"
 msgstr "प्रक्रिया सन्दर्भको बयान"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:227
-#: ../src/richtext/richtextbackgroundpage.cpp:250
-#: ../src/richtext/richtextbackgroundpage.cpp:290
-#: ../src/richtext/richtextbackgroundpage.cpp:317
-#: ../src/richtext/richtextfontpage.cpp:177
-#: ../src/richtext/richtextfontpage.cpp:180
 #: ../src/richtext/richtextborderspage.cpp:255
 #: ../src/richtext/richtextborderspage.cpp:289
 #: ../src/richtext/richtextborderspage.cpp:323
@@ -8495,22 +8730,45 @@ msgstr "प्रक्रिया सन्दर्भको बयान"
 #: ../src/richtext/richtextborderspage.cpp:491
 #: ../src/richtext/richtextborderspage.cpp:525
 #: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextfontpage.cpp:180
 msgid "pt"
 msgstr "pt"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:225
-#: ../src/richtext/richtextbackgroundpage.cpp:228
-#: ../src/richtext/richtextbackgroundpage.cpp:229
-#: ../src/richtext/richtextbackgroundpage.cpp:248
-#: ../src/richtext/richtextbackgroundpage.cpp:251
-#: ../src/richtext/richtextbackgroundpage.cpp:252
-#: ../src/richtext/richtextbackgroundpage.cpp:288
-#: ../src/richtext/richtextbackgroundpage.cpp:291
-#: ../src/richtext/richtextbackgroundpage.cpp:292
-#: ../src/richtext/richtextbackgroundpage.cpp:315
-#: ../src/richtext/richtextbackgroundpage.cpp:318
-#: ../src/richtext/richtextbackgroundpage.cpp:319
-#: ../src/richtext/richtextfontpage.cpp:178
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:659
+#: ../src/richtext/richtextsizepage.cpp:662
+#: ../src/richtext/richtextsizepage.cpp:663
 #: ../src/richtext/richtextborderspage.cpp:253
 #: ../src/richtext/richtextborderspage.cpp:256
 #: ../src/richtext/richtextborderspage.cpp:257
@@ -8562,260 +8820,270 @@ msgstr "pt"
 #: ../src/richtext/richtextmarginspage.cpp:387
 #: ../src/richtext/richtextmarginspage.cpp:389
 #: ../src/richtext/richtextmarginspage.cpp:390
-#: ../src/richtext/richtextsizepage.cpp:338
-#: ../src/richtext/richtextsizepage.cpp:341
-#: ../src/richtext/richtextsizepage.cpp:342
-#: ../src/richtext/richtextsizepage.cpp:372
-#: ../src/richtext/richtextsizepage.cpp:375
-#: ../src/richtext/richtextsizepage.cpp:376
-#: ../src/richtext/richtextsizepage.cpp:399
-#: ../src/richtext/richtextsizepage.cpp:402
-#: ../src/richtext/richtextsizepage.cpp:403
-#: ../src/richtext/richtextsizepage.cpp:426
-#: ../src/richtext/richtextsizepage.cpp:429
-#: ../src/richtext/richtextsizepage.cpp:430
-#: ../src/richtext/richtextsizepage.cpp:453
-#: ../src/richtext/richtextsizepage.cpp:456
-#: ../src/richtext/richtextsizepage.cpp:457
-#: ../src/richtext/richtextsizepage.cpp:480
-#: ../src/richtext/richtextsizepage.cpp:483
-#: ../src/richtext/richtextsizepage.cpp:484
-#: ../src/richtext/richtextsizepage.cpp:554
-#: ../src/richtext/richtextsizepage.cpp:557
-#: ../src/richtext/richtextsizepage.cpp:558
-#: ../src/richtext/richtextsizepage.cpp:589
-#: ../src/richtext/richtextsizepage.cpp:592
-#: ../src/richtext/richtextsizepage.cpp:593
-#: ../src/richtext/richtextsizepage.cpp:624
-#: ../src/richtext/richtextsizepage.cpp:627
-#: ../src/richtext/richtextsizepage.cpp:628
-#: ../src/richtext/richtextsizepage.cpp:659
-#: ../src/richtext/richtextsizepage.cpp:662
-#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextfontpage.cpp:178
 msgid "px"
 msgstr "px"
 
-#: ../src/common/accelcmn.cpp:193
+#: ../src/common/accelcmn.cpp:192
 msgid "rawctrl"
 msgstr "rawctrl"
 
-#: ../src/html/chm.cpp:333
+#: ../src/html/chm.cpp:330
 msgid "read error"
 msgstr "पढ्नमा गल्ती"
 
-#: ../src/common/zipstrm.cpp:2085
+#: ../src/common/zipstrm.cpp:2155
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "zip stream (प्रविष्टि %s) पढिँदै: गलत crc"
 
-#: ../src/common/zipstrm.cpp:2080
+#: ../src/common/zipstrm.cpp:2150
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "zip stream (प्रविष्टि %s) पढिँदै: गलत लम्बाइ"
 
-#: ../src/msw/dde.cpp:1159
+#: ../src/msw/dde.cpp:1223
 msgid "reentrancy problem."
 msgstr "पुनः प्रविष्टिको समस्या"
 
-#: ../src/common/datetimefmt.cpp:1953
+#: ../src/common/datetimefmt.cpp:1976
 msgid "second"
 msgstr "दोस्रो"
 
-#: ../src/html/chm.cpp:337
+#: ../src/html/chm.cpp:334
 msgid "seek error"
 msgstr "खोजीको गल्ती "
 
-#: ../src/common/datetimefmt.cpp:1968
+#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#, fuzzy
+msgid "semibold"
+msgstr "मोटो"
+
+#: ../src/common/datetimefmt.cpp:1991
 msgid "seventeenth"
 msgstr "सत्रौं"
 
-#: ../src/common/datetimefmt.cpp:1958
+#: ../src/common/datetimefmt.cpp:1981
 msgid "seventh"
 msgstr "सातौं"
 
-#: ../src/common/accelcmn.cpp:191
+#: ../src/common/accelcmn.cpp:190
 msgid "shift"
 msgstr "shift"
 
-#: ../src/common/appbase.cpp:773
+#: ../src/common/appbase.cpp:774
 msgid "show this help message"
 msgstr "यो सहयोग सन्देश देखाउ "
 
-#: ../src/common/datetimefmt.cpp:1967
+#: ../src/common/datetimefmt.cpp:1990
 msgid "sixteenth"
 msgstr "सोह्रौं"
 
-#: ../src/common/datetimefmt.cpp:1957
+#: ../src/common/datetimefmt.cpp:1980
 msgid "sixth"
 msgstr "छैठौँ"
 
-#: ../src/common/appcmn.cpp:234
+#: ../src/common/appcmn.cpp:255
 msgid "specify display mode to use (e.g. 640x480-16)"
 msgstr "प्रयोगका लागि दृश्यक मुद्रा तोक्नु होला (e.g. 640x480-16)"
 
-#: ../src/common/appcmn.cpp:220
+#: ../src/common/appcmn.cpp:241
 msgid "specify the theme to use"
 msgstr "प्रयोगका लागि theme तोक्नु होला ।"
 
-#: ../src/richtext/richtextbuffer.cpp:9340
+#: ../src/richtext/richtextbuffer.cpp:9337
 msgid "standard/circle"
 msgstr "स्तरीय/वृत"
 
-#: ../src/richtext/richtextbuffer.cpp:9341
+#: ../src/richtext/richtextbuffer.cpp:9338
 msgid "standard/circle-outline"
 msgstr "स्तरीय/वृत-बाह्यरेखा"
 
-#: ../src/richtext/richtextbuffer.cpp:9343
+#: ../src/richtext/richtextbuffer.cpp:9340
 msgid "standard/diamond"
 msgstr "हिरा/हिरा"
 
-#: ../src/richtext/richtextbuffer.cpp:9342
+#: ../src/richtext/richtextbuffer.cpp:9339
 msgid "standard/square"
 msgstr "वर्ग/वर्ग"
 
-#: ../src/richtext/richtextbuffer.cpp:9344
+#: ../src/richtext/richtextbuffer.cpp:9341
 msgid "standard/triangle"
 msgstr "स्तरीय/त्रिभुज"
 
-#: ../src/common/zipstrm.cpp:1985
+#: ../src/common/zipstrm.cpp:2055
 msgid "stored file length not in Zip header"
 msgstr "फाइलको लम्बाइ Zip header भन्दा अन्तै भण्डार गर"
 
-#: ../src/common/cmdline.cpp:1488
+#: ../src/common/cmdline.cpp:1484
 msgid "str"
 msgstr "str"
 
-#: ../src/common/fontcmn.cpp:982
+#: ../src/common/fontcmn.cpp:1145
 msgid "strikethrough"
 msgstr "strikethrough"
 
-#: ../src/common/tarstrm.cpp:1003 ../src/common/tarstrm.cpp:1025
-#: ../src/common/tarstrm.cpp:1507 ../src/common/tarstrm.cpp:1529
+#: ../src/common/tarstrm.cpp:997 ../src/common/tarstrm.cpp:1019
+#: ../src/common/tarstrm.cpp:1501 ../src/common/tarstrm.cpp:1523
 msgid "tar entry not open"
 msgstr "tar प्रविष्टि नपल्टाउ"
 
-#: ../src/common/datetimefmt.cpp:1961
+#: ../src/common/datetimefmt.cpp:1984
 msgid "tenth"
 msgstr "दसौं"
 
-#: ../src/msw/dde.cpp:1123
+#: ../src/msw/dde.cpp:1187
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "कारोबारको प्रतिक्रियाले DDE_FBUSY bit लाइ तय गर्नु पर्ने बनायो ।"
 
-#: ../src/common/datetimefmt.cpp:1954
+#: ../src/common/fontcmn.cpp:1154
+msgid "thin"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:1977
 msgid "third"
 msgstr "तेस्रो"
 
-#: ../src/common/datetimefmt.cpp:1964
+#: ../src/common/datetimefmt.cpp:1987
 msgid "thirteenth"
 msgstr "तेह्रौं"
 
-#: ../src/common/datetimefmt.cpp:1758
+#: ../src/common/datetimefmt.cpp:1781
 msgid "today"
 msgstr "आज"
 
-#: ../src/common/datetimefmt.cpp:1760
+#: ../src/common/datetimefmt.cpp:1783
 msgid "tomorrow"
 msgstr "भोलि"
 
-#: ../src/common/fileconf.cpp:1944
+#: ../src/common/fileconf.cpp:1946
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "'%s' मा पछाडिको backslash बेवास्ता गरियो ।"
 
-#: ../src/gtk/aboutdlg.cpp:218
+#: ../src/gtk/aboutdlg.cpp:216
 msgid "translator-credits"
 msgstr "अणुवादकन-श्रेय"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1028
+#: ../src/generic/datavgen.cpp:1148
 msgid "true"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1963
+#: ../src/common/datetimefmt.cpp:1986
 msgid "twelfth"
 msgstr "बाह्रौं"
 
-#: ../src/common/datetimefmt.cpp:1971
+#: ../src/common/datetimefmt.cpp:1994
 msgid "twentieth"
 msgstr "बीसौं"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:486 ../src/generic/datavgen.cpp:1263
+#: ../src/common/datavcmn.cpp:2068 ../src/generic/datavgen.cpp:1386
 msgid "unchecked"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:802 ../src/common/fontcmn.cpp:978
+#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
 msgid "underlined"
 msgstr "अधोरेखाङ्कित"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:490
+#: ../src/common/datavcmn.cpp:2072
 #, fuzzy
 msgid "undetermined"
 msgstr "अधोरेखाङ्कित"
 
-#: ../src/common/fileconf.cpp:1979
+#: ../src/common/fileconf.cpp:1981
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "\" अनपेक्षित छ, (स्थान %d '; %s' को ) ।"
 
-#: ../src/common/tarstrm.cpp:1045
+#: ../src/common/tarstrm.cpp:1039
 msgid "unexpected end of file"
 msgstr "फाइलको अनपेक्षित अन्त"
 
-#: ../src/generic/progdlgg.cpp:370 ../src/common/tarstrm.cpp:371
-#: ../src/common/tarstrm.cpp:394 ../src/common/tarstrm.cpp:425
+#: ../src/common/tarstrm.cpp:366 ../src/common/tarstrm.cpp:389
+#: ../src/common/tarstrm.cpp:420 ../src/generic/progdlgg.cpp:376
 msgid "unknown"
 msgstr "अज्ञात"
 
-#: ../src/msw/registry.cpp:150
+#: ../src/msw/registry.cpp:139
 #, fuzzy, c-format
 msgid "unknown (%lu)"
 msgstr "अज्ञात"
 
-#: ../src/common/xtixml.cpp:253
+#: ../src/common/xtixml.cpp:249
 #, c-format
 msgid "unknown class %s"
 msgstr "अज्ञात class %s"
 
-#: ../src/common/regex.cpp:258 ../src/html/chm.cpp:351
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "दबाब गल्ती"
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "दबाब विहीनता गल्ती"
+
+#: ../src/common/regex.cpp:255 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "अज्ञात गल्ती"
 
-#: ../src/msw/dialup.cpp:471
+#: ../src/msw/dialup.cpp:465
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "अज्ञात गल्ती (गल्ती कोड %08x)"
 
-#: ../src/common/fmapbase.cpp:834
+#: ../src/common/fmapbase.cpp:830
 #, c-format
 msgid "unknown-%d"
 msgstr "अज्ञात -%d"
 
-#: ../src/common/docview.cpp:509
+#: ../src/common/docview.cpp:502
 msgid "unnamed"
 msgstr "नाम नपाएको"
 
-#: ../src/common/docview.cpp:1624
+#: ../src/common/docview.cpp:1618
 #, c-format
 msgid "unnamed%d"
 msgstr "नाम नभएको %d"
 
-#: ../src/common/zipstrm.cpp:1999 ../src/common/zipstrm.cpp:2319
+#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
 msgid "unsupported Zip compression method"
 msgstr "असमर्थित Zip दबाब विधि "
 
-#: ../src/common/translation.cpp:1892
+#: ../src/common/translation.cpp:1942
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "'%s' सूचि प्रयोग हुदैछ (%s' वाट ) ।"
 
-#: ../src/html/chm.cpp:335
+#: ../src/html/chm.cpp:332
 msgid "write error"
 msgstr "लेखाइमा गल्ती"
 
-#: ../src/common/time.cpp:292
+#: ../src/gtk/glcanvas.cpp:187
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/common/time.cpp:285
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay असफल भयो ।"
 
@@ -8828,15 +9096,15 @@ msgstr "wxWidgets ले दृश्यक '%s' लाइ खोल्न स�
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets ले दृश्यक खोल्न सकेन: बहिर्गमन गरिदैं छ ।"
 
-#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:431
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/common/datetimefmt.cpp:1759
+#: ../src/common/datetimefmt.cpp:1782
 msgid "yesterday"
 msgstr "हिजो"
 
-#: ../src/common/zstream.cpp:251 ../src/common/zstream.cpp:426
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
 #, c-format
 msgid "zlib error %d"
 msgstr "zlib गल्ती %d"
@@ -8845,6 +9113,76 @@ msgstr "zlib गल्ती %d"
 #: ../src/richtext/richtextbulletspage.cpp:288
 msgid "~"
 msgstr "~"
+
+#~ msgid "&Save as"
+#~ msgstr "&यसरी बचत गर"
+
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' मा केवल वैध मानहरू मात्रै छैनन् ।"
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' सङ्ख्यात्मक हुनै पर्छ ।"
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' मा ASCII वर्णहरू मात्रै हुन सक्छ ।"
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' मा वर्णहरू मात्रै हु सक्छ ।"
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' मा पाठिय अथवा सङ्ख्यात्मक वर्णहरू मात्रै हुन सक्छ ।"
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' मा सङ्ख्या मात्रै हुन सक्छ ।"
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "विन्डो class %s सिर्जना गर्न सकिँदैन ।"
+
+#, fuzzy
+#~ msgid "Could not initalize libnotify."
+#~ msgstr "पङ्क्ति बद्धता तय गर्न सकिएन"
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "खप्टिएको विन्डो सिर्जना गर्न सकिएन"
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "खप्टिएको विन्डोका सामाग्री पाउन सकिएन"
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "फाइल \"%s\" लाई युनिकोडमा परिवर्तन गर्न सकिएन ।"
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "पाठ नियन्त्रक मा पाठ राख्न सकिएन ।"
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr "नमिल्दो GTK+ आदेश लाइन विकल्प, \"%s --सहयोग\" को प्रयोग गर्नु होस् ।"
+
+#~ msgid "No unused colour in image."
+#~ msgstr "तस्विरमा प्रयोग नगरेको रङ्ग छैन ।"
+
+#~ msgid "Not available"
+#~ msgstr "उपलब्ध छैन"
+
+#~ msgid "Replace selection"
+#~ msgstr "चयनको प्रतिस्थापन"
+
+#~ msgid "Save as"
+#~ msgstr "यसरी बचत गर "
+
+#~ msgid "Style Organiser"
+#~ msgstr "शैली व्यवस्थापक"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "तलको स्तरीय GTK+ विकल्प पनि समर्थन गरिन्छ:\n"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "पोतिएको होइन भने तपाइले खप्टिएको स्थानमा सफा गर्न सक्नु हुन्न ।"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "तपाइले खप्टिएको स्थानमा दुई पटक पोत्न सक्नु हुन्न ।"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "स्थानीयता '%s' कायम गर्न सकिँदैन ।"
 
 #~ msgid "Adding flavor TEXT failed"
 #~ msgstr "flavor TEXT थप्न सकिएन"
@@ -8862,9 +9200,6 @@ msgstr "~"
 
 #~ msgid "Column could not be added."
 #~ msgstr "महल थप्न सकिएन"
-
-#~ msgid "Column description could not be initialized."
-#~ msgstr "महलको बयान सुरु भएन"
 
 #~ msgid "Column index not found."
 #~ msgstr "महलको अनुक्रमणिका भेटिएन"

--- a/locale/nl.po
+++ b/locale/nl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-21 14:25+0200\n"
+"POT-Creation-Date: 2020-10-18 23:11+0300\n"
 "PO-Revision-Date: 2020-10-15 15:50+0200\n"
 "Last-Translator: gvmelle <translations@gvmelle.com>\n"
 "Language-Team: Dutch (http://www.transifex.com/projects/p/"
@@ -20,7 +20,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.4.1\n"
 
-#: ../src/common/debugrpt.cpp:586
+#: ../src/common/debugrpt.cpp:587
 msgid ""
 "\n"
 "Please send this report to the program maintainer, thank you!\n"
@@ -28,8 +28,8 @@ msgstr ""
 "\n"
 "Zend dit rapport naar de programmabeheerder, bedankt!\n"
 
-#: ../src/richtext/richtextstyledlg.cpp:210
-#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:206
+#: ../src/richtext/richtextstyledlg.cpp:218
 msgid " "
 msgstr " "
 
@@ -37,70 +37,96 @@ msgstr " "
 msgid "              Thank you and we're sorry for the inconvenience!\n"
 msgstr "              Dank u en onze excuses voor het ongemak!\n"
 
-#: ../src/common/prntbase.cpp:573
+#: ../src/common/prntbase.cpp:568
 #, c-format
 msgid " (copy %d of %d)"
 msgstr " (%d van %d kopiëren)"
 
-#: ../src/common/log.cpp:421
+#: ../src/common/log.cpp:440
 #, c-format
 msgid " (error %ld: %s)"
 msgstr " (fout %ld: %s)"
 
-#: ../src/common/imagtiff.cpp:72
+#: ../src/common/imagtiff.cpp:69
 #, c-format
 msgid " (in module \"%s\")"
 msgstr " (in module \"%s\")"
 
-#: ../src/osx/core/secretstore.cpp:138
-msgid " (while overwriting an existing item)"
-msgstr ""
-
-#: ../src/common/docview.cpp:1642
+#: ../src/common/docview.cpp:1636
 msgid " - "
 msgstr " - "
 
-#: ../src/richtext/richtextprint.cpp:593 ../src/html/htmprint.cpp:714
+#: ../src/html/htmprint.cpp:712 ../src/richtext/richtextprint.cpp:589
 msgid " Preview"
 msgstr " Voorbeeld"
 
-#: ../src/common/fontcmn.cpp:824
+#: ../src/common/fontcmn.cpp:973
 msgid " bold"
 msgstr " vet"
 
-#: ../src/common/fontcmn.cpp:840
+#: ../src/common/fontcmn.cpp:977
+#, fuzzy
+msgid " extra bold"
+msgstr " vet"
+
+#: ../src/common/fontcmn.cpp:985
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:957
+#, fuzzy
+msgid " extra light"
+msgstr " licht"
+
+#: ../src/common/fontcmn.cpp:981
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1001
 msgid " italic"
 msgstr " cursief"
 
-#: ../src/common/fontcmn.cpp:820
+#: ../src/common/fontcmn.cpp:961
 msgid " light"
 msgstr " licht"
 
-#: ../src/common/fontcmn.cpp:807
+#: ../src/common/fontcmn.cpp:965
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:969
+#, fuzzy
+msgid " semi bold"
+msgstr " vet"
+
+#: ../src/common/fontcmn.cpp:940
 msgid " strikethrough"
 msgstr " doorhalen"
 
-#: ../src/common/paper.cpp:117
+#: ../src/common/fontcmn.cpp:953
+msgid " thin"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
 msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
 msgstr "Envelop nr.10, 4 1/8 x 9 1/2 inch"
 
-#: ../src/common/paper.cpp:118
+#: ../src/common/paper.cpp:115
 msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
 msgstr "Envelop nr.11, 4 1/2 x 10 3/8 inch"
 
-#: ../src/common/paper.cpp:119
+#: ../src/common/paper.cpp:116
 msgid "#12 Envelope, 4 3/4 x 11 in"
 msgstr "Envelop nr.12, 4 3/4 x 11 inch"
 
-#: ../src/common/paper.cpp:120
+#: ../src/common/paper.cpp:117
 msgid "#14 Envelope, 5 x 11 1/2 in"
 msgstr "Envelop nr.14, 5 x 11 1/2 inch"
 
-#: ../src/common/paper.cpp:116
+#: ../src/common/paper.cpp:113
 msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
 msgstr "Envelop nr.9, 3 7/8 x 8 7/8 inch"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:341
 #: ../src/richtext/richtextsizepage.cpp:340
 #: ../src/richtext/richtextsizepage.cpp:374
 #: ../src/richtext/richtextsizepage.cpp:401
@@ -111,81 +137,82 @@ msgstr "Envelop nr.9, 3 7/8 x 8 7/8 inch"
 #: ../src/richtext/richtextsizepage.cpp:591
 #: ../src/richtext/richtextsizepage.cpp:626
 #: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextbackgroundpage.cpp:341
 msgid "%"
 msgstr "%"
 
-#: ../src/html/helpwnd.cpp:1031
+#: ../src/html/helpwnd.cpp:1029
 #, c-format
 msgid "%d of %lu"
 msgstr "%d of %lu"
 
-#: ../src/html/helpwnd.cpp:1678
+#: ../src/html/helpwnd.cpp:1676
 #, c-format
 msgid "%i of %u"
 msgstr "%i van %u"
 
-#: ../src/generic/filectrlg.cpp:279
+#: ../src/generic/filectrlg.cpp:275
 #, c-format
 msgid "%ld byte"
 msgid_plural "%ld bytes"
 msgstr[0] "%ld byte"
 msgstr[1] "%ld bytes"
 
-#: ../src/html/helpwnd.cpp:1033
+#: ../src/html/helpwnd.cpp:1031
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu van %lu"
 
-#: ../src/generic/datavgen.cpp:6028
+#: ../src/generic/datavgen.cpp:6833
 #, c-format
 msgid "%s (%d items)"
 msgstr "%s ( %d elementen)"
 
-#: ../src/common/cmdline.cpp:1221
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (of %s)"
 
-#: ../src/generic/logg.cpp:224
+#: ../src/generic/logg.cpp:221
 #, c-format
 msgid "%s Error"
 msgstr "%s Fout"
 
-#: ../src/generic/logg.cpp:236
+#: ../src/generic/logg.cpp:233
 #, c-format
 msgid "%s Information"
 msgstr "%s Informatie"
 
-#: ../src/generic/preferencesg.cpp:113
+#: ../src/generic/preferencesg.cpp:110
 #, c-format
 msgid "%s Preferences"
 msgstr "%s voorkeuren"
 
-#: ../src/generic/logg.cpp:228
+#: ../src/generic/logg.cpp:225
 #, c-format
 msgid "%s Warning"
 msgstr "%s Waarschuwing"
 
-#: ../src/common/tarstrm.cpp:1319
+#: ../src/common/tarstrm.cpp:1313
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s paste niet bij de tar-header voor regel '%s'"
 
-#: ../src/common/fldlgcmn.cpp:124
+#: ../src/common/fldlgcmn.cpp:121
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s bestanden (%s)|%s"
 
-#: ../src/html/helpwnd.cpp:1716
+#: ../src/html/helpwnd.cpp:1714
 #, c-format
 msgid "%u of %u"
 msgstr "%u van %u"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "&About"
 msgstr "&Over"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "&Actual Size"
 msgstr "&Werkelijke grootte"
 
@@ -193,28 +220,28 @@ msgstr "&Werkelijke grootte"
 msgid "&After a paragraph:"
 msgstr "&Na een paragraaf:"
 
-#: ../src/richtext/richtextindentspage.cpp:128
 #: ../src/richtext/richtextliststylepage.cpp:319
+#: ../src/richtext/richtextindentspage.cpp:128
 msgid "&Alignment"
 msgstr "&Uitlijning"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "&Apply"
 msgstr "Toe&passen"
 
-#: ../src/richtext/richtextstyledlg.cpp:251
+#: ../src/richtext/richtextstyledlg.cpp:247
 msgid "&Apply Style"
 msgstr "Stijl toe&passen"
 
-#: ../src/msw/mdi.cpp:179
+#: ../src/msw/mdi.cpp:174
 msgid "&Arrange Icons"
 msgstr "&Pictogrammen Schikken"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "&Ascending"
 msgstr "&Oplopend"
 
-#: ../src/common/stockitem.cpp:142
+#: ../src/common/stockitem.cpp:139
 msgid "&Back"
 msgstr "&Terug"
 
@@ -234,24 +261,24 @@ msgstr "&Bg kleur:"
 msgid "&Blur distance:"
 msgstr "&Vervagingsafstand:"
 
-#: ../src/common/stockitem.cpp:143
+#: ../src/common/stockitem.cpp:140
 msgid "&Bold"
 msgstr "&Vet"
 
-#: ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141
 msgid "&Bottom"
 msgstr "&Bodem"
 
+#: ../src/richtext/richtextsizepage.cpp:637
+#: ../src/richtext/richtextsizepage.cpp:644
 #: ../src/richtext/richtextborderspage.cpp:345
 #: ../src/richtext/richtextborderspage.cpp:513
 #: ../src/richtext/richtextmarginspage.cpp:259
 #: ../src/richtext/richtextmarginspage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:637
-#: ../src/richtext/richtextsizepage.cpp:644
 msgid "&Bottom:"
 msgstr "&Bodem:"
 
-#: ../include/wx/richtext/richtextbuffer.h:3866
+#: ../include/wx/richtext/richtextbuffer.h:3861
 msgid "&Box"
 msgstr "&Vak"
 
@@ -260,38 +287,38 @@ msgstr "&Vak"
 msgid "&Bullet style:"
 msgstr "&Opsommingstijl:"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "&CD-Rom"
 msgstr "&CD-rom"
 
-#: ../src/generic/wizard.cpp:434 ../src/generic/fontdlgg.cpp:470
-#: ../src/generic/fontdlgg.cpp:489 ../src/osx/carbon/fontdlg.cpp:402
-#: ../src/common/dlgcmn.cpp:279 ../src/common/stockitem.cpp:145
+#: ../src/osx/carbon/fontdlg.cpp:399 ../src/common/stockitem.cpp:142
+#: ../src/generic/wizard.cpp:433 ../src/generic/fontdlgg.cpp:466
+#: ../src/generic/fontdlgg.cpp:485 ../src/osx/cocoa/button.mm:200
 msgid "&Cancel"
 msgstr "&Annuleren"
 
-#: ../src/msw/mdi.cpp:175
+#: ../src/msw/mdi.cpp:170
 msgid "&Cascade"
 msgstr "&Trapsgewijs"
 
-#: ../include/wx/richtext/richtextbuffer.h:5960
+#: ../include/wx/richtext/richtextbuffer.h:5955
 msgid "&Cell"
 msgstr "&Cel"
 
-#: ../src/richtext/richtextsymboldlg.cpp:439
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "&Character code:"
 msgstr "&Lettertekencode:"
 
-#: ../src/common/stockitem.cpp:147
+#: ../src/common/stockitem.cpp:144
 msgid "&Clear"
 msgstr "&Wissen"
 
-#: ../src/generic/logg.cpp:516 ../src/common/stockitem.cpp:148
-#: ../src/common/prntbase.cpp:1600 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/stockitem.cpp:145 ../src/common/prntbase.cpp:1625
+#: ../src/univ/themes/win32.cpp:3753 ../src/generic/logg.cpp:513
 msgid "&Close"
 msgstr "&Sluiten"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "&Color"
 msgstr "&Kleur"
 
@@ -299,20 +326,20 @@ msgstr "&Kleur"
 msgid "&Colour:"
 msgstr "&Kleur:"
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "&Convert"
 msgstr "&Converteren"
 
-#: ../src/richtext/richtextctrl.cpp:333 ../src/osx/textctrl_osx.cpp:577
-#: ../src/common/stockitem.cpp:150 ../src/msw/textctrl.cpp:2508
+#: ../src/osx/textctrl_osx.cpp:595 ../src/common/stockitem.cpp:147
+#: ../src/msw/textctrl.cpp:2773 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Kopiëren"
 
-#: ../src/generic/hyperlinkg.cpp:156
+#: ../src/generic/hyperlinkg.cpp:153
 msgid "&Copy URL"
 msgstr "URL &kopiëren"
 
-#: ../src/common/headerctrlcmn.cpp:306
+#: ../src/common/headerctrlcmn.cpp:304
 msgid "&Customize..."
 msgstr "&Aanpassen..."
 
@@ -320,53 +347,54 @@ msgstr "&Aanpassen..."
 msgid "&Debug report preview:"
 msgstr "Voorbeeld &foutopsporingsrapport:"
 
-#: ../src/richtext/richtexttabspage.cpp:138
-#: ../src/richtext/richtextctrl.cpp:335 ../src/osx/textctrl_osx.cpp:579
-#: ../src/common/stockitem.cpp:152 ../src/msw/textctrl.cpp:2510
+#: ../src/osx/textctrl_osx.cpp:597 ../src/common/stockitem.cpp:149
+#: ../src/msw/textctrl.cpp:2775 ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtextctrl.cpp:334
 msgid "&Delete"
 msgstr "&Verwijderen"
 
-#: ../src/richtext/richtextstyledlg.cpp:269
+#: ../src/richtext/richtextstyledlg.cpp:265
 msgid "&Delete Style..."
 msgstr "Stijl &verwijderen..."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "&Descending"
 msgstr "&Aflopend"
 
-#: ../src/generic/logg.cpp:682
+#: ../src/generic/logg.cpp:679
 msgid "&Details"
 msgstr "&Details"
 
-#: ../src/common/stockitem.cpp:153
+#: ../src/common/stockitem.cpp:150
 msgid "&Down"
 msgstr "O&mlaag"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "&Edit"
 msgstr "Be&werken"
 
-#: ../src/richtext/richtextstyledlg.cpp:263
+#: ../src/richtext/richtextstyledlg.cpp:259
 msgid "&Edit Style..."
 msgstr "S&tijl bewerken..."
 
-#: ../src/common/stockitem.cpp:155
+#: ../src/common/stockitem.cpp:152
 msgid "&Execute"
 msgstr "&Uitvoeren"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/common/stockitem.cpp:154
 msgid "&File"
 msgstr "&Bestand"
 
-#: ../src/common/stockitem.cpp:158
-msgid "&Find"
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "&Find..."
 msgstr "&Zoeken"
 
-#: ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:430
 msgid "&Finish"
 msgstr "&Voltooien"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:156
 msgid "&First"
 msgstr "&Eerste"
 
@@ -374,15 +402,15 @@ msgstr "&Eerste"
 msgid "&Floating mode:"
 msgstr "&Zwevende modus:"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "&Floppy"
 msgstr "&Diskette"
 
-#: ../src/common/stockitem.cpp:194
+#: ../src/common/stockitem.cpp:191
 msgid "&Font"
 msgstr "&Lettertype"
 
-#: ../src/generic/fontdlgg.cpp:371
+#: ../src/generic/fontdlgg.cpp:367
 msgid "&Font family:"
 msgstr "&Lettertypefamilie:"
 
@@ -390,20 +418,20 @@ msgstr "&Lettertypefamilie:"
 msgid "&Font for Level..."
 msgstr "&Lettertype voor niveau..."
 
+#: ../src/richtext/richtextsymboldlg.cpp:397
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:400
 msgid "&Font:"
 msgstr "&Lettertype:"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "&Forward"
 msgstr "&Verder"
 
-#: ../src/richtext/richtextsymboldlg.cpp:451
+#: ../src/richtext/richtextsymboldlg.cpp:448
 msgid "&From:"
 msgstr "&Van:"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "&Harddisk"
 msgstr "&Hardeschijf"
 
@@ -412,9 +440,9 @@ msgstr "&Hardeschijf"
 msgid "&Height:"
 msgstr "&Hoogte:"
 
-#: ../src/generic/wizard.cpp:441 ../src/richtext/richtextstyledlg.cpp:303
-#: ../src/richtext/richtextsymboldlg.cpp:479 ../src/osx/menu_osx.cpp:734
-#: ../src/common/stockitem.cpp:163
+#: ../src/common/stockitem.cpp:160 ../src/generic/wizard.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextstyledlg.cpp:299 ../src/osx/cocoa/menu.mm:226
 msgid "&Help"
 msgstr "&Help"
 
@@ -422,7 +450,7 @@ msgstr "&Help"
 msgid "&Hide details"
 msgstr "&Verbergen details"
 
-#: ../src/common/stockitem.cpp:164
+#: ../src/common/stockitem.cpp:161
 msgid "&Home"
 msgstr "S&tart"
 
@@ -430,54 +458,54 @@ msgstr "S&tart"
 msgid "&Horizontal offset:"
 msgstr "&Horizontale verschuiving:"
 
-#: ../src/richtext/richtextindentspage.cpp:184
 #: ../src/richtext/richtextliststylepage.cpp:372
+#: ../src/richtext/richtextindentspage.cpp:184
 msgid "&Indentation (tenths of a mm)"
 msgstr "I&nspringing (tienden van een mm)"
 
-#: ../src/richtext/richtextindentspage.cpp:167
 #: ../src/richtext/richtextliststylepage.cpp:356
+#: ../src/richtext/richtextindentspage.cpp:167
 msgid "&Indeterminate"
 msgstr "&Onduidelijk"
 
-#: ../src/common/stockitem.cpp:166
+#: ../src/common/stockitem.cpp:163
 msgid "&Index"
 msgstr "&Index"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "&Info"
 msgstr "&Info"
 
-#: ../src/common/stockitem.cpp:168
+#: ../src/common/stockitem.cpp:165
 msgid "&Italic"
 msgstr "C&ursief"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "&Jump to"
 msgstr "&Spring naar"
 
-#: ../src/richtext/richtextindentspage.cpp:153
 #: ../src/richtext/richtextliststylepage.cpp:342
+#: ../src/richtext/richtextindentspage.cpp:153
 msgid "&Justified"
 msgstr "Uit&gevuld"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "&Last"
 msgstr "&Laatste"
 
-#: ../src/richtext/richtextindentspage.cpp:139
 #: ../src/richtext/richtextliststylepage.cpp:328
+#: ../src/richtext/richtextindentspage.cpp:139
 msgid "&Left"
 msgstr "&Links"
 
-#: ../src/richtext/richtextindentspage.cpp:195
+#: ../src/richtext/richtextsizepage.cpp:532
+#: ../src/richtext/richtextsizepage.cpp:539
 #: ../src/richtext/richtextborderspage.cpp:243
 #: ../src/richtext/richtextborderspage.cpp:411
 #: ../src/richtext/richtextliststylepage.cpp:381
+#: ../src/richtext/richtextindentspage.cpp:195
 #: ../src/richtext/richtextmarginspage.cpp:186
 #: ../src/richtext/richtextmarginspage.cpp:300
-#: ../src/richtext/richtextsizepage.cpp:532
-#: ../src/richtext/richtextsizepage.cpp:539
 msgid "&Left:"
 msgstr "&Links:"
 
@@ -485,11 +513,11 @@ msgstr "&Links:"
 msgid "&List level:"
 msgstr "&Lijstniveau:"
 
-#: ../src/generic/logg.cpp:517
+#: ../src/generic/logg.cpp:514
 msgid "&Log"
 msgstr "&Log"
 
-#: ../src/univ/themes/win32.cpp:3748
+#: ../src/univ/themes/win32.cpp:3745
 msgid "&Move"
 msgstr "&Verplaatsen"
 
@@ -497,19 +525,19 @@ msgstr "&Verplaatsen"
 msgid "&Move the object to:"
 msgstr "&Verplaats object naar:"
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "&Network"
 msgstr "&Netwerk"
 
-#: ../src/richtext/richtexttabspage.cpp:132 ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173 ../src/richtext/richtexttabspage.cpp:132
 msgid "&New"
 msgstr "&Nieuw"
 
-#: ../src/aui/tabmdi.cpp:111 ../src/generic/mdig.cpp:100 ../src/msw/mdi.cpp:180
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
 msgid "&Next"
 msgstr "&Volgende"
 
-#: ../src/generic/wizard.cpp:432 ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:429
 msgid "&Next >"
 msgstr "&Volgende >"
 
@@ -517,7 +545,7 @@ msgstr "&Volgende >"
 msgid "&Next Paragraph"
 msgstr "&Volgende paragraaf"
 
-#: ../src/generic/tipdlg.cpp:240
+#: ../src/generic/tipdlg.cpp:237
 msgid "&Next Tip"
 msgstr "&Volgende tip"
 
@@ -525,11 +553,11 @@ msgstr "&Volgende tip"
 msgid "&Next style:"
 msgstr "Volge&nde stijl:"
 
-#: ../src/common/stockitem.cpp:177 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:174 ../src/msw/msgdlg.cpp:435
 msgid "&No"
 msgstr "&Nee"
 
-#: ../src/generic/dbgrptg.cpp:356
+#: ../src/generic/dbgrptg.cpp:360
 msgid "&Notes:"
 msgstr "&Notities:"
 
@@ -537,12 +565,12 @@ msgstr "&Notities:"
 msgid "&Number:"
 msgstr "&Nummer:"
 
-#: ../src/generic/fontdlgg.cpp:475 ../src/generic/fontdlgg.cpp:482
-#: ../src/osx/carbon/fontdlg.cpp:408 ../src/common/stockitem.cpp:178
+#: ../src/osx/carbon/fontdlg.cpp:405 ../src/common/stockitem.cpp:175
+#: ../src/generic/fontdlgg.cpp:471 ../src/generic/fontdlgg.cpp:478
 msgid "&OK"
 msgstr "&OK"
 
-#: ../src/generic/dbgrptg.cpp:342 ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176 ../src/generic/dbgrptg.cpp:342
 msgid "&Open..."
 msgstr "&Openen..."
 
@@ -554,16 +582,16 @@ msgstr "&Outline niveau:"
 msgid "&Page Break"
 msgstr "&Pagina-einde"
 
-#: ../src/richtext/richtextctrl.cpp:334 ../src/osx/textctrl_osx.cpp:578
-#: ../src/common/stockitem.cpp:180 ../src/msw/textctrl.cpp:2509
+#: ../src/osx/textctrl_osx.cpp:596 ../src/common/stockitem.cpp:177
+#: ../src/msw/textctrl.cpp:2774 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&Plakken"
 
-#: ../include/wx/richtext/richtextbuffer.h:5010
+#: ../include/wx/richtext/richtextbuffer.h:5005
 msgid "&Picture"
 msgstr "&Afbeelding"
 
-#: ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:419
 msgid "&Point size:"
 msgstr "&Puntgrootte:"
 
@@ -575,11 +603,11 @@ msgstr "&Positie (tienden van een mm):"
 msgid "&Position mode:"
 msgstr "&Positiemodus:"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178
 msgid "&Preferences"
 msgstr "&Voorkeuren"
 
-#: ../src/aui/tabmdi.cpp:112 ../src/generic/mdig.cpp:101 ../src/msw/mdi.cpp:181
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
 msgid "&Previous"
 msgstr "&Vorig"
 
@@ -587,78 +615,74 @@ msgstr "&Vorig"
 msgid "&Previous Paragraph"
 msgstr "&Vorige paragraaf"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "&Print..."
 msgstr "Af&drukken..."
 
-#: ../src/richtext/richtextctrl.cpp:339 ../src/richtext/richtextctrl.cpp:5514
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtextctrl.cpp:338
+#: ../src/richtext/richtextctrl.cpp:5512
 msgid "&Properties"
 msgstr "Eigenscha&ppen"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "&Quit"
 msgstr "A&fsluiten"
 
-#: ../src/richtext/richtextctrl.cpp:330 ../src/osx/textctrl_osx.cpp:574
-#: ../src/common/stockitem.cpp:185 ../src/common/cmdproc.cpp:293
-#: ../src/common/cmdproc.cpp:300 ../src/msw/textctrl.cpp:2505
+#: ../src/osx/textctrl_osx.cpp:592 ../src/common/stockitem.cpp:182
+#: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
+#: ../src/msw/textctrl.cpp:2770 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "Opnie&uw"
 
-#: ../src/common/cmdproc.cpp:289 ../src/common/cmdproc.cpp:309
+#: ../src/common/cmdproc.cpp:282 ../src/common/cmdproc.cpp:302
 msgid "&Redo "
 msgstr "Opnie&uw "
 
-#: ../src/richtext/richtextstyledlg.cpp:257
+#: ../src/richtext/richtextstyledlg.cpp:253
 msgid "&Rename Style..."
 msgstr "Stijl he&rnoemen…"
 
-#: ../src/generic/fdrepdlg.cpp:179
+#: ../src/generic/fdrepdlg.cpp:176
 msgid "&Replace"
 msgstr "&Vervangen"
 
-#: ../src/richtext/richtextstyledlg.cpp:287
+#: ../src/richtext/richtextstyledlg.cpp:283
 msgid "&Restart numbering"
 msgstr "Nummering he&rstarten"
 
-#: ../src/univ/themes/win32.cpp:3747
+#: ../src/univ/themes/win32.cpp:3744
 msgid "&Restore"
 msgstr "&Herstellen"
 
-#: ../src/richtext/richtextindentspage.cpp:146
 #: ../src/richtext/richtextliststylepage.cpp:335
+#: ../src/richtext/richtextindentspage.cpp:146
 msgid "&Right"
 msgstr "&Rechts"
 
-#: ../src/richtext/richtextindentspage.cpp:213
+#: ../src/richtext/richtextsizepage.cpp:602
+#: ../src/richtext/richtextsizepage.cpp:609
 #: ../src/richtext/richtextborderspage.cpp:277
 #: ../src/richtext/richtextborderspage.cpp:445
 #: ../src/richtext/richtextliststylepage.cpp:399
+#: ../src/richtext/richtextindentspage.cpp:213
 #: ../src/richtext/richtextmarginspage.cpp:211
 #: ../src/richtext/richtextmarginspage.cpp:325
-#: ../src/richtext/richtextsizepage.cpp:602
-#: ../src/richtext/richtextsizepage.cpp:609
 msgid "&Right:"
 msgstr "&Rechts:"
 
-#: ../src/common/stockitem.cpp:190
+#: ../src/common/stockitem.cpp:187
 msgid "&Save"
 msgstr "Op&slaan"
-
-#: ../src/common/stockitem.cpp:191
-msgid "&Save as"
-msgstr "&Opslaan Als"
 
 #: ../include/wx/richmsgdlg.h:29
 msgid "&See details"
 msgstr "&Zie details"
 
-#: ../src/generic/tipdlg.cpp:236
+#: ../src/generic/tipdlg.cpp:233
 msgid "&Show tips at startup"
 msgstr "&Toon tips bij opstarten"
 
-#: ../src/univ/themes/win32.cpp:3750
+#: ../src/univ/themes/win32.cpp:3747
 msgid "&Size"
 msgstr "&Grootte"
 
@@ -666,36 +690,36 @@ msgstr "&Grootte"
 msgid "&Size:"
 msgstr "&Grootte:"
 
-#: ../src/generic/progdlgg.cpp:252
+#: ../src/generic/progdlgg.cpp:249
 msgid "&Skip"
 msgstr "Over&slaan"
 
-#: ../src/richtext/richtextindentspage.cpp:242
 #: ../src/richtext/richtextliststylepage.cpp:417
+#: ../src/richtext/richtextindentspage.cpp:242
 msgid "&Spacing (tenths of a mm)"
 msgstr "&Tussenruimte (tienden van een mm)"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "&Spell Check"
 msgstr "&Spellingscontrole"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "&Stop"
 msgstr "&Stoppen"
 
-#: ../src/richtext/richtextfontpage.cpp:275 ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196 ../src/richtext/richtextfontpage.cpp:275
 msgid "&Strikethrough"
 msgstr "&Doorhalen"
 
-#: ../src/generic/fontdlgg.cpp:382 ../src/richtext/richtextstylepage.cpp:106
+#: ../src/generic/fontdlgg.cpp:378 ../src/richtext/richtextstylepage.cpp:106
 msgid "&Style:"
 msgstr "&Stijl:"
 
-#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:194
 msgid "&Styles:"
 msgstr "&Stijlen:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:413
+#: ../src/richtext/richtextsymboldlg.cpp:410
 msgid "&Subset:"
 msgstr "&Subset:"
 
@@ -709,24 +733,24 @@ msgstr "&Symbool:"
 msgid "&Synchronize values"
 msgstr "Waarden &synchroniseren"
 
-#: ../include/wx/richtext/richtextbuffer.h:6069
+#: ../include/wx/richtext/richtextbuffer.h:6064
 msgid "&Table"
 msgstr "&Tabel"
 
-#: ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197
 msgid "&Top"
 msgstr "&Top"
 
+#: ../src/richtext/richtextsizepage.cpp:567
+#: ../src/richtext/richtextsizepage.cpp:574
 #: ../src/richtext/richtextborderspage.cpp:311
 #: ../src/richtext/richtextborderspage.cpp:479
 #: ../src/richtext/richtextmarginspage.cpp:234
 #: ../src/richtext/richtextmarginspage.cpp:348
-#: ../src/richtext/richtextsizepage.cpp:567
-#: ../src/richtext/richtextsizepage.cpp:574
 msgid "&Top:"
 msgstr "&Top:"
 
-#: ../src/generic/fontdlgg.cpp:444 ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199 ../src/generic/fontdlgg.cpp:441
 msgid "&Underline"
 msgstr "Onderstre&pen"
 
@@ -734,21 +758,21 @@ msgstr "Onderstre&pen"
 msgid "&Underlining:"
 msgstr "Onderstre&ping:"
 
-#: ../src/richtext/richtextctrl.cpp:329 ../src/osx/textctrl_osx.cpp:573
-#: ../src/common/stockitem.cpp:203 ../src/common/cmdproc.cpp:271
-#: ../src/msw/textctrl.cpp:2504
+#: ../src/osx/textctrl_osx.cpp:591 ../src/common/stockitem.cpp:200
+#: ../src/common/cmdproc.cpp:264 ../src/msw/textctrl.cpp:2769
+#: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Ongedaan maken"
 
-#: ../src/common/cmdproc.cpp:265
+#: ../src/common/cmdproc.cpp:258
 msgid "&Undo "
 msgstr "Maak &ongedaan: "
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "&Unindent"
 msgstr "&Niet Inspringen"
 
-#: ../src/common/stockitem.cpp:205
+#: ../src/common/stockitem.cpp:202
 msgid "&Up"
 msgstr "&Omhoog"
 
@@ -764,7 +788,7 @@ msgstr "&Verticale verschuiving:"
 msgid "&View..."
 msgstr "&Beeld..."
 
-#: ../src/generic/fontdlgg.cpp:393
+#: ../src/generic/fontdlgg.cpp:389
 msgid "&Weight:"
 msgstr "Ge&wicht:"
 
@@ -773,88 +797,58 @@ msgstr "Ge&wicht:"
 msgid "&Width:"
 msgstr "&Breedte:"
 
-#: ../src/aui/tabmdi.cpp:311 ../src/aui/tabmdi.cpp:327
-#: ../src/aui/tabmdi.cpp:329 ../src/generic/mdig.cpp:294
-#: ../src/generic/mdig.cpp:310 ../src/generic/mdig.cpp:314
-#: ../src/msw/mdi.cpp:78
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
 msgid "&Window"
 msgstr "&Venster"
 
-#: ../src/common/stockitem.cpp:206 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:203 ../src/msw/msgdlg.cpp:435
 msgid "&Yes"
 msgstr "&Ja"
 
-#: ../src/common/valtext.cpp:256
-#, c-format
-msgid "'%s' contains illegal characters"
+#: ../src/common/valtext.cpp:197
+#, fuzzy, c-format
+msgid "'%s' contains invalid character(s)"
 msgstr "'%s' bevat ongeldige tekens"
 
-#: ../src/common/valtext.cpp:254
-#, c-format
-msgid "'%s' doesn't consist only of valid characters"
-msgstr "'%s' bestaat niet alleen uit geldige tekens"
-
-#: ../src/common/config.cpp:519 ../src/msw/regconf.cpp:258
+#: ../src/common/config.cpp:515 ../src/msw/regconf.cpp:255
 #, c-format
 msgid "'%s' has extra '..', ignored."
 msgstr "'%s' heeft extra '..', genegeerd."
 
-#: ../src/common/cmdline.cpp:1113 ../src/common/cmdline.cpp:1131
+#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' is geen geldige numerieke waarde voor optie '%s'."
 
-#: ../src/common/translation.cpp:1100
+#: ../src/common/translation.cpp:1142
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' is geen geldige berichtcatalogus."
 
-#: ../src/common/valtext.cpp:165
+#: ../src/common/valtext.cpp:188
 #, c-format
 msgid "'%s' is not one of the valid strings"
 msgstr "'%s' is niet een van de geldige strings"
 
-#: ../src/common/valtext.cpp:167
+#: ../src/common/valtext.cpp:186
 #, c-format
 msgid "'%s' is one of the invalid strings"
 msgstr "'%s' is een van de ongeldige strings"
 
-#: ../src/common/textbuf.cpp:237
+#: ../src/common/textbuf.cpp:233
 #, c-format
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' is waarschijnlijk een binaire buffer."
-
-#: ../src/common/valtext.cpp:252
-#, c-format
-msgid "'%s' should be numeric."
-msgstr "'%s' moet numeriek zijn."
-
-#: ../src/common/valtext.cpp:244
-#, c-format
-msgid "'%s' should only contain ASCII characters."
-msgstr "'%s' mag alleen ASCII-tekens bevatten."
-
-#: ../src/common/valtext.cpp:246
-#, c-format
-msgid "'%s' should only contain alphabetic characters."
-msgstr "'%s' mag alleen letters bevatten."
-
-#: ../src/common/valtext.cpp:248
-#, c-format
-msgid "'%s' should only contain alphabetic or numeric characters."
-msgstr "'%s' mag alleen alfa-numerieke tekens bevatten."
-
-#: ../src/common/valtext.cpp:250
-#, c-format
-msgid "'%s' should only contain digits."
-msgstr "'%s' mag alleen cijfers bevatten."
 
 #: ../src/richtext/richtextliststylepage.cpp:229
 #: ../src/richtext/richtextbulletspage.cpp:166
 msgid "(*)"
 msgstr "(*)"
 
-#: ../src/html/helpwnd.cpp:963
+#: ../src/html/helpwnd.cpp:961
 msgid "(Help)"
 msgstr "(Help)"
 
@@ -863,27 +857,32 @@ msgstr "(Help)"
 msgid "(None)"
 msgstr "(Geen)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:504
+#: ../src/richtext/richtextsymboldlg.cpp:503
 msgid "(Normal text)"
 msgstr "(Normale tekst)"
 
-#: ../src/html/helpwnd.cpp:419 ../src/html/helpwnd.cpp:1106
-#: ../src/html/helpwnd.cpp:1742
+#: ../src/html/helpwnd.cpp:417 ../src/html/helpwnd.cpp:1104
+#: ../src/html/helpwnd.cpp:1740
 msgid "(bookmarks)"
 msgstr "(favorieten)"
 
+#: ../src/msw/dlmsw.cpp:167
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (fout %ld: %s)"
+
+#: ../src/richtext/richtextformatdlg.cpp:876
+#: ../src/richtext/richtextliststylepage.cpp:448
+#: ../src/richtext/richtextliststylepage.cpp:460
+#: ../src/richtext/richtextliststylepage.cpp:461
 #: ../src/richtext/richtextindentspage.cpp:274
 #: ../src/richtext/richtextindentspage.cpp:286
 #: ../src/richtext/richtextindentspage.cpp:287
 #: ../src/richtext/richtextindentspage.cpp:311
 #: ../src/richtext/richtextindentspage.cpp:326
-#: ../src/richtext/richtextformatdlg.cpp:884
 #: ../src/richtext/richtextfontpage.cpp:349
 #: ../src/richtext/richtextfontpage.cpp:353
 #: ../src/richtext/richtextfontpage.cpp:357
-#: ../src/richtext/richtextliststylepage.cpp:448
-#: ../src/richtext/richtextliststylepage.cpp:460
-#: ../src/richtext/richtextliststylepage.cpp:461
 msgid "(none)"
 msgstr "(geen)"
 
@@ -902,7 +901,7 @@ msgstr "*)"
 msgid "+"
 msgstr "+"
 
-#: ../src/msw/utils.cpp:1152
+#: ../src/msw/utils.cpp:1143
 msgid ", 64-bit edition"
 msgstr ", 64-bit editie"
 
@@ -911,163 +910,163 @@ msgstr ", 64-bit editie"
 msgid "-"
 msgstr "-"
 
-#: ../src/generic/filepickerg.cpp:66
+#: ../src/generic/filepickerg.cpp:63
 msgid "..."
 msgstr "..."
 
-#: ../src/richtext/richtextindentspage.cpp:276
 #: ../src/richtext/richtextliststylepage.cpp:450
+#: ../src/richtext/richtextindentspage.cpp:276
 msgid "1.1"
 msgstr "1.1"
 
-#: ../src/richtext/richtextindentspage.cpp:277
 #: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextindentspage.cpp:277
 msgid "1.2"
 msgstr "1.2"
 
-#: ../src/richtext/richtextindentspage.cpp:278
 #: ../src/richtext/richtextliststylepage.cpp:452
+#: ../src/richtext/richtextindentspage.cpp:278
 msgid "1.3"
 msgstr "1.3"
 
-#: ../src/richtext/richtextindentspage.cpp:279
 #: ../src/richtext/richtextliststylepage.cpp:453
+#: ../src/richtext/richtextindentspage.cpp:279
 msgid "1.4"
 msgstr "1.4"
 
-#: ../src/richtext/richtextindentspage.cpp:280
 #: ../src/richtext/richtextliststylepage.cpp:454
+#: ../src/richtext/richtextindentspage.cpp:280
 msgid "1.5"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:281
 #: ../src/richtext/richtextliststylepage.cpp:455
+#: ../src/richtext/richtextindentspage.cpp:281
 msgid "1.6"
 msgstr "1.6"
 
-#: ../src/richtext/richtextindentspage.cpp:282
 #: ../src/richtext/richtextliststylepage.cpp:456
+#: ../src/richtext/richtextindentspage.cpp:282
 msgid "1.7"
 msgstr "1.7"
 
-#: ../src/richtext/richtextindentspage.cpp:283
 #: ../src/richtext/richtextliststylepage.cpp:457
+#: ../src/richtext/richtextindentspage.cpp:283
 msgid "1.8"
 msgstr "1.8"
 
-#: ../src/richtext/richtextindentspage.cpp:284
 #: ../src/richtext/richtextliststylepage.cpp:458
+#: ../src/richtext/richtextindentspage.cpp:284
 msgid "1.9"
 msgstr "1.9"
 
-#: ../src/common/paper.cpp:140
+#: ../src/common/paper.cpp:137
 msgid "10 x 11 in"
 msgstr "10 x 11 inch"
 
-#: ../src/common/paper.cpp:113
+#: ../src/common/paper.cpp:110
 msgid "10 x 14 in"
 msgstr "10 x 14 inch"
 
-#: ../src/common/paper.cpp:114
+#: ../src/common/paper.cpp:111
 msgid "11 x 17 in"
 msgstr "11 x 17 inch"
 
-#: ../src/common/paper.cpp:184
+#: ../src/common/paper.cpp:181
 msgid "12 x 11 in"
 msgstr "12 x 11 inch"
 
-#: ../src/common/paper.cpp:141
+#: ../src/common/paper.cpp:138
 msgid "15 x 11 in"
 msgstr "15 x 11 inch"
 
-#: ../src/richtext/richtextindentspage.cpp:285
 #: ../src/richtext/richtextliststylepage.cpp:459
+#: ../src/richtext/richtextindentspage.cpp:285
 msgid "2"
 msgstr "2"
 
-#: ../src/common/paper.cpp:132
+#: ../src/common/paper.cpp:129
 msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
 msgstr "6 3/4 envelop, 3 5/8 x 6 1/2 inch"
 
-#: ../src/common/paper.cpp:139
+#: ../src/common/paper.cpp:136
 msgid "9 x 11 in"
 msgstr "9 x 11 inch"
 
-#: ../src/html/htmprint.cpp:431
+#: ../src/html/htmprint.cpp:443
 msgid ": file does not exist!"
 msgstr ": bestand bestaat niet!"
 
-#: ../src/common/fontmap.cpp:199
+#: ../src/common/fontmap.cpp:196
 msgid ": unknown charset"
 msgstr ": onbekende tekenset"
 
-#: ../src/common/fontmap.cpp:413
+#: ../src/common/fontmap.cpp:410
 msgid ": unknown encoding"
 msgstr ": onbekende codering"
 
-#: ../src/generic/wizard.cpp:443
+#: ../src/generic/wizard.cpp:438
 msgid "< &Back"
 msgstr "< &Terug"
 
-#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:628
-#: ../src/osx/carbon/fontdlg.cpp:648
+#: ../src/osx/carbon/fontdlg.cpp:419 ../src/osx/carbon/fontdlg.cpp:625
+#: ../src/osx/carbon/fontdlg.cpp:645
 msgid "<Any Decorative>"
 msgstr "<Elke Decoratief>"
 
-#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:630
-#: ../src/osx/carbon/fontdlg.cpp:650
+#: ../src/osx/carbon/fontdlg.cpp:420 ../src/osx/carbon/fontdlg.cpp:627
+#: ../src/osx/carbon/fontdlg.cpp:647
 msgid "<Any Modern>"
 msgstr "<Elke Modern>"
 
-#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:626
-#: ../src/osx/carbon/fontdlg.cpp:646
+#: ../src/osx/carbon/fontdlg.cpp:418 ../src/osx/carbon/fontdlg.cpp:623
+#: ../src/osx/carbon/fontdlg.cpp:643
 msgid "<Any Roman>"
 msgstr "<Elke Romaans>"
 
-#: ../src/osx/carbon/fontdlg.cpp:424 ../src/osx/carbon/fontdlg.cpp:632
-#: ../src/osx/carbon/fontdlg.cpp:652
+#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:629
+#: ../src/osx/carbon/fontdlg.cpp:649
 msgid "<Any Script>"
 msgstr "<Elke Script>"
 
-#: ../src/osx/carbon/fontdlg.cpp:425 ../src/osx/carbon/fontdlg.cpp:637
-#: ../src/osx/carbon/fontdlg.cpp:656
+#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:634
+#: ../src/osx/carbon/fontdlg.cpp:653
 msgid "<Any Swiss>"
 msgstr "<Elke Helvetica>"
 
-#: ../src/osx/carbon/fontdlg.cpp:426 ../src/osx/carbon/fontdlg.cpp:634
-#: ../src/osx/carbon/fontdlg.cpp:654
+#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:631
+#: ../src/osx/carbon/fontdlg.cpp:651
 msgid "<Any Teletype>"
 msgstr "<Elke Teletype>"
 
-#: ../src/osx/carbon/fontdlg.cpp:420
+#: ../src/osx/carbon/fontdlg.cpp:417
 msgid "<Any>"
 msgstr "<Elke>"
 
-#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
 msgid "<DIR>"
 msgstr "<DIR>"
 
-#: ../src/generic/filectrlg.cpp:254 ../src/generic/filectrlg.cpp:277
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
 msgid "<DRIVE>"
 msgstr "<STATION>"
 
-#: ../src/generic/filectrlg.cpp:252 ../src/generic/filectrlg.cpp:275
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
 msgid "<LINK>"
 msgstr "<LINK>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1264
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Vet cursief lettertype.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1270
+#: ../src/html/helpwnd.cpp:1268
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>vet cursief <u>onderstreept</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1265
+#: ../src/html/helpwnd.cpp:1263
 msgid "<b>Bold face.</b> "
 msgstr "<b>Vet lettertype.</b> "
 
-#: ../src/html/helpwnd.cpp:1264
+#: ../src/html/helpwnd.cpp:1262
 msgid "<i>Italic face.</i> "
 msgstr "<i>Cursief lettertype.</i> "
 
@@ -1076,15 +1075,15 @@ msgstr "<i>Cursief lettertype.</i> "
 msgid ">"
 msgstr ">"
 
-#: ../src/generic/dbgrptg.cpp:318
+#: ../src/generic/dbgrptg.cpp:317
 msgid "A debug report has been generated in the directory\n"
 msgstr "Een foutopsporingsrapport is aangemaakt in de map\n"
 
-#: ../src/common/debugrpt.cpp:573
+#: ../src/common/debugrpt.cpp:574
 msgid "A debug report has been generated. It can be found in"
 msgstr "Er is een foutopsporingsrapport gemaakt. Het kan gevonden worden in"
 
-#: ../src/common/xtixml.cpp:418
+#: ../src/common/xtixml.cpp:414
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Een niet lege verzameling moet bestaan uit 'element'-knopen"
 
@@ -1095,106 +1094,106 @@ msgstr "Een niet lege verzameling moet bestaan uit 'element'-knopen"
 msgid "A standard bullet name."
 msgstr "Een standaard opsommingstekennaam."
 
-#: ../src/common/paper.cpp:217
+#: ../src/common/paper.cpp:214
 msgid "A0 sheet, 841 x 1189 mm"
 msgstr "A0, 841 x 1189 mm"
 
-#: ../src/common/paper.cpp:218
+#: ../src/common/paper.cpp:215
 msgid "A1 sheet, 594 x 841 mm"
 msgstr "A1, 594 x 841 mm"
 
-#: ../src/common/paper.cpp:159
+#: ../src/common/paper.cpp:156
 msgid "A2 420 x 594 mm"
 msgstr "A2 420 x 594 mm"
 
-#: ../src/common/paper.cpp:156
+#: ../src/common/paper.cpp:153
 msgid "A3 Extra 322 x 445 mm"
 msgstr "A3 Extra 322 x 445 mm"
 
-#: ../src/common/paper.cpp:161
+#: ../src/common/paper.cpp:158
 msgid "A3 Extra Transverse 322 x 445 mm"
 msgstr "A3 Extra Transverse 322 x 445 mm"
 
-#: ../src/common/paper.cpp:170
+#: ../src/common/paper.cpp:167
 msgid "A3 Rotated 420 x 297 mm"
 msgstr "A3 gedraaid 420 x 297 mm"
 
-#: ../src/common/paper.cpp:160
+#: ../src/common/paper.cpp:157
 msgid "A3 Transverse 297 x 420 mm"
 msgstr "A3 Transverse 297 x 420 mm"
 
-#: ../src/common/paper.cpp:106
+#: ../src/common/paper.cpp:103
 msgid "A3 sheet, 297 x 420 mm"
 msgstr "A3, 297 x 420 mm"
 
-#: ../src/common/paper.cpp:146
+#: ../src/common/paper.cpp:143
 msgid "A4 Extra 9.27 x 12.69 in"
 msgstr "A4 Extra 9.27 x 12.69 inch"
 
-#: ../src/common/paper.cpp:153
+#: ../src/common/paper.cpp:150
 msgid "A4 Plus 210 x 330 mm"
 msgstr "A4 Plus 210 x 330 mm"
 
-#: ../src/common/paper.cpp:171
+#: ../src/common/paper.cpp:168
 msgid "A4 Rotated 297 x 210 mm"
 msgstr "A4 gedraaid 297 x 210 mm"
 
-#: ../src/common/paper.cpp:148
+#: ../src/common/paper.cpp:145
 msgid "A4 Transverse 210 x 297 mm"
 msgstr "A4 Transverse 210 x 297 mm"
 
-#: ../src/common/paper.cpp:97
+#: ../src/common/paper.cpp:94
 msgid "A4 sheet, 210 x 297 mm"
 msgstr "A4, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:107
+#: ../src/common/paper.cpp:104
 msgid "A4 small sheet, 210 x 297 mm"
 msgstr "A4 klein, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:157
+#: ../src/common/paper.cpp:154
 msgid "A5 Extra 174 x 235 mm"
 msgstr "A5 Extra 174 x 235 mm"
 
-#: ../src/common/paper.cpp:172
+#: ../src/common/paper.cpp:169
 msgid "A5 Rotated 210 x 148 mm"
 msgstr "A5 gedraaid 210 x 148 mm"
 
-#: ../src/common/paper.cpp:154
+#: ../src/common/paper.cpp:151
 msgid "A5 Transverse 148 x 210 mm"
 msgstr "A5 Transverse 148 x 210 mm"
 
-#: ../src/common/paper.cpp:108
+#: ../src/common/paper.cpp:105
 msgid "A5 sheet, 148 x 210 mm"
 msgstr "A5, 148 x 210 mm"
 
-#: ../src/common/paper.cpp:164
+#: ../src/common/paper.cpp:161
 msgid "A6 105 x 148 mm"
 msgstr "A6 105 x 148 mm"
 
-#: ../src/common/paper.cpp:177
+#: ../src/common/paper.cpp:174
 msgid "A6 Rotated 148 x 105 mm"
 msgstr "A6 gedraaid 148 x 105 mm"
 
-#: ../src/generic/fontdlgg.cpp:83 ../src/richtext/richtextformatdlg.cpp:529
-#: ../src/osx/carbon/fontdlg.cpp:153
+#: ../src/osx/carbon/fontdlg.cpp:150 ../src/generic/fontdlgg.cpp:79
+#: ../src/richtext/richtextformatdlg.cpp:521
 msgid "ABCDEFGabcdefg12345"
 msgstr "ABCDEFGabcdefg12345"
 
-#: ../src/richtext/richtextsymboldlg.cpp:458 ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
 msgid "ASCII"
 msgstr "ASCII"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "About"
 msgstr "Over"
 
-#: ../src/generic/aboutdlgg.cpp:140 ../src/osx/menu_osx.cpp:558
-#: ../src/msw/aboutdlg.cpp:64
+#: ../src/osx/menu_osx.cpp:450 ../src/generic/aboutdlgg.cpp:137
+#: ../src/msw/aboutdlg.cpp:61
 #, c-format
 msgid "About %s"
 msgstr "Over %s"
 
-#: ../src/osx/menu_osx.cpp:560
+#: ../src/osx/menu_osx.cpp:452
 msgid "About..."
 msgstr "Over..."
 
@@ -1203,37 +1202,37 @@ msgid "Absolute"
 msgstr "Absoluut"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:873
+#: ../src/propgrid/advprops.cpp:774
 msgid "ActiveBorder"
 msgstr "ActiveBorder"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:874
+#: ../src/propgrid/advprops.cpp:775
 msgid "ActiveCaption"
 msgstr "ActiveCaption"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "Actual Size"
 msgstr "Werkelijke grootte"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:140 ../src/common/accelcmn.cpp:81
+#: ../src/common/stockitem.cpp:137 ../src/common/accelcmn.cpp:78
 msgid "Add"
 msgstr "Toevoegen"
 
-#: ../src/richtext/richtextbuffer.cpp:11455
+#: ../src/richtext/richtextbuffer.cpp:11454
 msgid "Add Column"
 msgstr "Kolom toevoegen"
 
-#: ../src/richtext/richtextbuffer.cpp:11392
+#: ../src/richtext/richtextbuffer.cpp:11391
 msgid "Add Row"
 msgstr "Rij toevoegen"
 
-#: ../src/html/helpwnd.cpp:432
+#: ../src/html/helpwnd.cpp:430
 msgid "Add current page to bookmarks"
 msgstr "Voeg huidige pagina toe aan favorieten"
 
-#: ../src/generic/colrdlgg.cpp:366
+#: ../src/generic/colrdlgg.cpp:386
 msgid "Add to custom colours"
 msgstr "Voeg toe aan aangepaste kleuren"
 
@@ -1245,12 +1244,12 @@ msgstr "AddToPropertyCollection riep een generieke 'accessor' aan"
 msgid "AddToPropertyCollection called w/o valid adder"
 msgstr "AddToPropertyCollection deed een aanroep zonder geldige 'adder'"
 
-#: ../src/html/helpctrl.cpp:159
+#: ../src/html/helpctrl.cpp:155
 #, c-format
 msgid "Adding book %s"
 msgstr "Bezig met toevoegen van boek %s"
 
-#: ../src/common/preferencescmn.cpp:43
+#: ../src/common/preferencescmn.cpp:40
 msgid "Advanced"
 msgstr "Geavanceerd"
 
@@ -1258,11 +1257,11 @@ msgstr "Geavanceerd"
 msgid "After a paragraph:"
 msgstr "Na een alinea:"
 
-#: ../src/common/stockitem.cpp:172
+#: ../src/common/stockitem.cpp:169
 msgid "Align Left"
 msgstr "Links uitlijnen"
 
-#: ../src/common/stockitem.cpp:173
+#: ../src/common/stockitem.cpp:170
 msgid "Align Right"
 msgstr "Rechts uitlijnen"
 
@@ -1270,40 +1269,40 @@ msgstr "Rechts uitlijnen"
 msgid "Alignment"
 msgstr "Uitlijning"
 
-#: ../src/generic/prntdlgg.cpp:215
+#: ../src/generic/prntdlgg.cpp:208
 msgid "All"
 msgstr "Alles"
 
-#: ../src/generic/filectrlg.cpp:1197 ../src/common/fldlgcmn.cpp:107
+#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1186
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Alle bestanden (%s)|%s"
 
-#: ../include/wx/defs.h:2886
+#: ../include/wx/defs.h:2582
 msgid "All files (*)|*"
 msgstr "Alle bestanden (*)|*"
 
-#: ../include/wx/defs.h:2883
+#: ../include/wx/defs.h:2579
 msgid "All files (*.*)|*.*"
 msgstr "Alle bestanden (*.*)|*.*"
 
-#: ../src/richtext/richtextstyles.cpp:1061
+#: ../src/richtext/richtextstyles.cpp:1058
 msgid "All styles"
 msgstr "Alle stijlen"
 
-#: ../src/propgrid/manager.cpp:1528
+#: ../src/propgrid/manager.cpp:1544
 msgid "Alphabetic Mode"
 msgstr "Alfabetische modus"
 
-#: ../src/common/xtistrm.cpp:425
+#: ../src/common/xtistrm.cpp:422
 msgid "Already Registered Object passed to SetObjectClassInfo"
 msgstr "Al geregistreerd object doorgegeven aan SetObjectClassInfo"
 
-#: ../src/unix/dialup.cpp:353
+#: ../src/unix/dialup.cpp:352
 msgid "Already dialling ISP."
 msgstr "Al bezig internetaanbieder te bellen."
 
-#: ../src/common/accelcmn.cpp:331 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/accelcmn.cpp:345 ../src/univ/themes/win32.cpp:3753
 msgid "Alt+"
 msgstr "Alt+"
 
@@ -1312,34 +1311,34 @@ msgstr "Alt+"
 msgid "An optional corner radius for adding rounded corners."
 msgstr "Een optionele hoek-straal om afgeronde hoeken toe te voegen."
 
-#: ../src/common/debugrpt.cpp:576
+#: ../src/common/debugrpt.cpp:577
 msgid "And includes the following files:\n"
 msgstr "En omvat de volgende bestanden:\n"
 
-#: ../src/generic/animateg.cpp:162
+#: ../src/generic/animateg.cpp:145
 #, c-format
 msgid "Animation file is not of type %ld."
 msgstr "Animatiebestand is niet van type %ld."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:872
+#: ../src/propgrid/advprops.cpp:773
 msgid "AppWorkspace"
 msgstr "AppWorkspace"
 
-#: ../src/generic/logg.cpp:1014
+#: ../src/generic/logg.cpp:1011
 #, c-format
 msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
 msgstr "Voeg log toe aan bestand '%s' (kies [Nee] om te overschrijven)?"
 
-#: ../src/osx/menu_osx.cpp:577 ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:469 ../src/osx/menu_osx.cpp:477
 msgid "Application"
 msgstr "Applicatie"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "Apply"
 msgstr "Toepassen"
 
-#: ../src/propgrid/advprops.cpp:1609
+#: ../src/propgrid/advprops.cpp:1515
 msgid "Aqua"
 msgstr "Agua"
 
@@ -1348,29 +1347,29 @@ msgstr "Agua"
 msgid "Arabic"
 msgstr "Arabisch"
 
-#: ../src/common/fmapbase.cpp:153
+#: ../src/common/fmapbase.cpp:150
 msgid "Arabic (ISO-8859-6)"
 msgstr "Arabisch (ISO-8859-6)"
 
-#: ../src/msw/ole/automtn.cpp:672
+#: ../src/msw/ole/automtn.cpp:663
 #, c-format
 msgid "Argument %u not found."
 msgstr "Argument %u niet gevonden."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1753
+#: ../src/propgrid/advprops.cpp:1654
 msgid "Arrow"
 msgstr "Pijl"
 
-#: ../src/generic/aboutdlgg.cpp:184
+#: ../src/generic/aboutdlgg.cpp:181
 msgid "Artists"
 msgstr "Kunstenaars"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "Ascending"
 msgstr "Oplopend"
 
-#: ../src/generic/filectrlg.cpp:433
+#: ../src/generic/filectrlg.cpp:429
 msgid "Attributes"
 msgstr "Attributen"
 
@@ -1380,90 +1379,90 @@ msgstr "Attributen"
 msgid "Available fonts."
 msgstr "Beschikbare lettertypen."
 
-#: ../src/common/paper.cpp:137
+#: ../src/common/paper.cpp:134
 msgid "B4 (ISO) 250 x 353 mm"
 msgstr "B4 (ISO) 250 x 353 mm"
 
-#: ../src/common/paper.cpp:173
+#: ../src/common/paper.cpp:170
 msgid "B4 (JIS) Rotated 364 x 257 mm"
 msgstr "B4 (JIS) gedraaid 364 x 257 mm"
 
-#: ../src/common/paper.cpp:127
+#: ../src/common/paper.cpp:124
 msgid "B4 Envelope, 250 x 353 mm"
 msgstr "Envelop B4, 250 x 353 mm"
 
-#: ../src/common/paper.cpp:109
+#: ../src/common/paper.cpp:106
 msgid "B4 sheet, 250 x 354 mm"
 msgstr "B4, 250 x 354 mm"
 
-#: ../src/common/paper.cpp:158
+#: ../src/common/paper.cpp:155
 msgid "B5 (ISO) Extra 201 x 276 mm"
 msgstr "B5 (ISO) Extra 201 x 276 mm"
 
-#: ../src/common/paper.cpp:174
+#: ../src/common/paper.cpp:171
 msgid "B5 (JIS) Rotated 257 x 182 mm"
 msgstr "B5 (JIS) gedraaid 257 x 182 mm"
 
-#: ../src/common/paper.cpp:155
+#: ../src/common/paper.cpp:152
 msgid "B5 (JIS) Transverse 182 x 257 mm"
 msgstr "B5 (JIS) Transverse 182 x 257 mm"
 
-#: ../src/common/paper.cpp:128
+#: ../src/common/paper.cpp:125
 msgid "B5 Envelope, 176 x 250 mm"
 msgstr "Envelop B5, 176 x 250 mm"
 
-#: ../src/common/paper.cpp:110
+#: ../src/common/paper.cpp:107
 msgid "B5 sheet, 182 x 257 millimeter"
 msgstr "B5, 182, 257 mm"
 
-#: ../src/common/paper.cpp:182
+#: ../src/common/paper.cpp:179
 msgid "B6 (JIS) 128 x 182 mm"
 msgstr "B6 (JIS) 128 x 182 mm"
 
-#: ../src/common/paper.cpp:183
+#: ../src/common/paper.cpp:180
 msgid "B6 (JIS) Rotated 182 x 128 mm"
 msgstr "B6 (JIS) gedraaid 182 x 128 mm"
 
-#: ../src/common/paper.cpp:129
+#: ../src/common/paper.cpp:126
 msgid "B6 Envelope, 176 x 125 mm"
 msgstr "Envelop B6, 176 x 125 mm"
 
-#: ../src/common/imagbmp.cpp:531 ../src/common/imagbmp.cpp:561
-#: ../src/common/imagbmp.cpp:576
+#: ../src/common/imagbmp.cpp:528 ../src/common/imagbmp.cpp:558
+#: ../src/common/imagbmp.cpp:573
 msgid "BMP: Couldn't allocate memory."
 msgstr "BMP: kon geen geheugen reserveren."
 
-#: ../src/common/imagbmp.cpp:100
+#: ../src/common/imagbmp.cpp:97
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: kon ongeldige afbeelding niet opslaan."
 
-#: ../src/common/imagbmp.cpp:356
+#: ../src/common/imagbmp.cpp:353
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: Kon RGB kleur map niet schrijven."
 
-#: ../src/common/imagbmp.cpp:490
+#: ../src/common/imagbmp.cpp:487
 msgid "BMP: Couldn't write data."
 msgstr "BMP: kon gegevens niet wegschrijven."
 
-#: ../src/common/imagbmp.cpp:246
+#: ../src/common/imagbmp.cpp:243
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: Kon koptekst van bestand (Bitmap) niet schrijven."
 
-#: ../src/common/imagbmp.cpp:269
+#: ../src/common/imagbmp.cpp:266
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: kon de bestandsheader niet schrijven."
 
-#: ../src/common/imagbmp.cpp:140
+#: ../src/common/imagbmp.cpp:137
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage heeft geen eigen wxPalette."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:142 ../src/common/accelcmn.cpp:52
+#: ../src/common/stockitem.cpp:139 ../src/common/accelcmn.cpp:49
 msgid "Back"
 msgstr "Terug"
 
+#: ../src/richtext/richtextformatdlg.cpp:377
 #: ../src/richtext/richtextbackgroundpage.cpp:148
-#: ../src/richtext/richtextformatdlg.cpp:384
 msgid "Background"
 msgstr "Achtergrond"
 
@@ -1471,20 +1470,20 @@ msgstr "Achtergrond"
 msgid "Background &colour:"
 msgstr "Achtergrond&kleur:"
 
-#: ../src/osx/carbon/fontdlg.cpp:220
+#: ../src/osx/carbon/fontdlg.cpp:217
 msgid "Background colour"
 msgstr "Achtergrondkleur"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:52
+#: ../src/common/accelcmn.cpp:49
 msgid "Backspace"
 msgstr "Backspace"
 
-#: ../src/common/fmapbase.cpp:160
+#: ../src/common/fmapbase.cpp:157
 msgid "Baltic (ISO-8859-13)"
 msgstr "Baltisch (ISO-8859-13)"
 
-#: ../src/common/fmapbase.cpp:151
+#: ../src/common/fmapbase.cpp:148
 msgid "Baltic (old) (ISO-8859-4)"
 msgstr "Baltisch (oud) (ISO-8859-4)"
 
@@ -1497,25 +1496,25 @@ msgstr "Vóór een alinea:"
 msgid "Bitmap"
 msgstr "Bitmap"
 
-#: ../src/propgrid/advprops.cpp:1594
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Black"
 msgstr "Zwart"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1755
+#: ../src/propgrid/advprops.cpp:1656
 msgid "Blank"
 msgstr "Blanco"
 
-#: ../src/propgrid/advprops.cpp:1603
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Blue"
 msgstr "Blauw"
 
-#: ../src/generic/colrdlgg.cpp:345
+#: ../src/generic/colrdlgg.cpp:365
 msgid "Blue:"
 msgstr "Blauw:"
 
-#: ../src/generic/fontdlgg.cpp:333 ../src/richtext/richtextfontpage.cpp:355
-#: ../src/osx/carbon/fontdlg.cpp:354 ../src/common/stockitem.cpp:143
+#: ../src/osx/carbon/fontdlg.cpp:351 ../src/common/stockitem.cpp:140
+#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:355
 msgid "Bold"
 msgstr "Vet"
 
@@ -1524,31 +1523,35 @@ msgstr "Vet"
 msgid "Border"
 msgstr "Rand"
 
-#: ../src/richtext/richtextformatdlg.cpp:379
+#: ../src/richtext/richtextformatdlg.cpp:372
 msgid "Borders"
 msgstr "Randen"
 
-#: ../src/richtext/richtextsizepage.cpp:288 ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141 ../src/richtext/richtextsizepage.cpp:288
 msgid "Bottom"
 msgstr "Bodem"
 
-#: ../src/generic/prntdlgg.cpp:893
+#: ../src/generic/prntdlgg.cpp:886
 msgid "Bottom margin (mm):"
 msgstr "Ondermarge (mm):"
 
-#: ../src/richtext/richtextbuffer.cpp:9383
+#: ../src/richtext/richtextbuffer.cpp:9380
 msgid "Box Properties"
 msgstr "Vak Eigenschappen"
 
-#: ../src/richtext/richtextstyles.cpp:1065
+#: ../src/richtext/richtextstyles.cpp:1062
 msgid "Box styles"
 msgstr "Vak stijlen"
 
-#: ../src/propgrid/advprops.cpp:1602
+#: ../src/osx/cocoa/menu.mm:292
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Brown"
 msgstr "Bruin"
 
-#: ../src/common/filepickercmn.cpp:43 ../src/common/filepickercmn.cpp:44
+#: ../src/common/filepickercmn.cpp:40 ../src/common/filepickercmn.cpp:41
 msgid "Browse"
 msgstr "Bladeren"
 
@@ -1561,72 +1564,72 @@ msgstr "Opsommings&teken-uitlijning:"
 msgid "Bullet style"
 msgstr "Opsommingsteken-stijl"
 
-#: ../src/richtext/richtextformatdlg.cpp:359
+#: ../src/richtext/richtextformatdlg.cpp:352
 msgid "Bullets"
 msgstr "Opsommingtekens"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1756
+#: ../src/propgrid/advprops.cpp:1657
 msgid "Bullseye"
 msgstr "Roos"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:875
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonFace"
 msgstr "ButtonFace"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:876
+#: ../src/propgrid/advprops.cpp:777
 msgid "ButtonHighlight"
 msgstr "ButtonHighlight"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:877
+#: ../src/propgrid/advprops.cpp:778
 msgid "ButtonShadow"
 msgstr "ButtonShadow"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:878
+#: ../src/propgrid/advprops.cpp:779
 msgid "ButtonText"
 msgstr "ButtonText"
 
-#: ../src/common/paper.cpp:98
+#: ../src/common/paper.cpp:95
 msgid "C sheet, 17 x 22 in"
 msgstr "C, 17 x 22 inch"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "C&lear"
 msgstr "&Wissen"
 
-#: ../src/generic/fontdlgg.cpp:406
+#: ../src/generic/fontdlgg.cpp:403
 msgid "C&olour:"
 msgstr "&Kleur:"
 
-#: ../src/common/paper.cpp:123
+#: ../src/common/paper.cpp:120
 msgid "C3 Envelope, 324 x 458 mm"
 msgstr "Envelop C3, 324 x 458 mm"
 
-#: ../src/common/paper.cpp:124
+#: ../src/common/paper.cpp:121
 msgid "C4 Envelope, 229 x 324 mm"
 msgstr "Envelop C4, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:122
+#: ../src/common/paper.cpp:119
 msgid "C5 Envelope, 162 x 229 mm"
 msgstr "Envelop C5, 162 x 229 mm"
 
-#: ../src/common/paper.cpp:125
+#: ../src/common/paper.cpp:122
 msgid "C6 Envelope, 114 x 162 mm"
 msgstr "Envelop C6, 114 x 162 mm"
 
-#: ../src/common/paper.cpp:126
+#: ../src/common/paper.cpp:123
 msgid "C65 Envelope, 114 x 229 mm"
 msgstr "Envelop C65, 114 x 229 mm"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "CD-Rom"
 msgstr "CD-Rom"
 
-#: ../src/html/chm.cpp:815 ../src/html/chm.cpp:874
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:865
 msgid "CHM handler currently supports only local files!"
 msgstr "CHM-afhandeling ondersteunt momenteel alleen lokale bestanden!"
 
@@ -1634,193 +1637,197 @@ msgstr "CHM-afhandeling ondersteunt momenteel alleen lokale bestanden!"
 msgid "Ca&pitals"
 msgstr "&Hoofdletters"
 
-#: ../src/common/cmdproc.cpp:267
+#: ../src/common/cmdproc.cpp:260
 msgid "Can't &Undo "
 msgstr "Kan niet &ongedaan maken: "
 
-#: ../src/common/image.cpp:2824
+#: ../src/common/image.cpp:2924
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 "Kan niet automatisch het afbeeldingsformaat bepalen voor niet vindbare input."
 
-#: ../src/msw/registry.cpp:506
+#: ../src/msw/registry.cpp:495
 #, c-format
 msgid "Can't close registry key '%s'"
 msgstr "Kan registersleutel '%s' niet sluiten"
 
-#: ../src/msw/registry.cpp:584
+#: ../src/msw/registry.cpp:573
 #, c-format
 msgid "Can't copy values of unsupported type %d."
 msgstr "Kan geen waarden van niet-ondersteund type %d kopiëren."
 
-#: ../src/msw/registry.cpp:487
+#: ../src/msw/registry.cpp:476
 #, c-format
 msgid "Can't create registry key '%s'"
 msgstr "Kan registersleutel '%s' niet maken"
 
-#: ../src/msw/thread.cpp:665
+#: ../src/msw/thread.cpp:657
 msgid "Can't create thread"
 msgstr "Kan thread niet maken"
 
-#: ../src/msw/window.cpp:3691
-#, c-format
-msgid "Can't create window of class %s"
-msgstr "Kan venster van klasse '%s' niet maken"
-
-#: ../src/msw/registry.cpp:777
+#: ../src/msw/registry.cpp:765
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Kan sleutel '%s' niet verwijderen"
 
-#: ../src/msw/iniconf.cpp:458
+#: ../src/msw/iniconf.cpp:455
 #, c-format
 msgid "Can't delete the INI file '%s'"
 msgstr "Kan INI-bestand '%s' niet verwijderen"
 
-#: ../src/msw/registry.cpp:805
+#: ../src/msw/registry.cpp:793
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Kan waarde '%s' niet verwijderen uit sleutel '%s'"
 
-#: ../src/msw/registry.cpp:1171
+#: ../src/msw/registry.cpp:1159
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Kan subsleutels van sleutel '%s' niet opsommen"
 
-#: ../src/msw/registry.cpp:1132
+#: ../src/msw/registry.cpp:1120
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Kan waarden van sleutel '%s' niet opsommen"
 
-#: ../src/msw/registry.cpp:1389
+#: ../src/msw/registry.cpp:1377
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Kan geen waarde van niet-ondersteund type %d exporteren."
 
-#: ../src/common/ffile.cpp:254
+#: ../src/common/ffile.cpp:253
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Kan huidige positie in bestand '%s' niet vinden"
 
-#: ../src/msw/registry.cpp:418
+#: ../src/msw/registry.cpp:407
 #, c-format
 msgid "Can't get info about registry key '%s'"
 msgstr "Kan geen informatie krijgen over registersleutel '%s'"
 
-#: ../src/common/zstream.cpp:346
+#: ../src/msw/webview_ie.cpp:1024
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "Kan thread-prioriteit niet instellen"
+
+#: ../src/common/zstream.cpp:343
 msgid "Can't initialize zlib deflate stream."
 msgstr "Kan zlib deflate stream niet initialiseren."
 
-#: ../src/common/zstream.cpp:185
+#: ../src/common/zstream.cpp:182
 msgid "Can't initialize zlib inflate stream."
 msgstr "Kan zlib inflate stream niet initialiseren."
 
-#: ../src/msw/fswatcher.cpp:476
+#: ../src/msw/fswatcher.cpp:475
 #, c-format
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "Kan niet bestaande map \"%s\" niet controleren op veranderingen."
 
-#: ../src/msw/registry.cpp:454
+#: ../src/msw/registry.cpp:443
 #, c-format
 msgid "Can't open registry key '%s'"
 msgstr "Kan registersleutel '%s' niet openen"
 
-#: ../src/common/zstream.cpp:252
+#: ../src/common/zstream.cpp:249
 #, c-format
 msgid "Can't read from inflate stream: %s"
 msgstr "Kan niet lezen van opblazen stroom: %s"
 
-#: ../src/common/zstream.cpp:244
+#: ../src/common/zstream.cpp:241
 msgid "Can't read inflate stream: unexpected EOF in underlying stream."
 msgstr ""
 "Kan stream niet uitpakken: onverwacht einde-van-bestand in onderliggende "
 "stream."
 
-#: ../src/msw/registry.cpp:1064
+#: ../src/msw/registry.cpp:1052
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Kan waarde van '%s' niet lezen"
 
-#: ../src/msw/registry.cpp:878 ../src/msw/registry.cpp:910
-#: ../src/msw/registry.cpp:975
+#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
+#: ../src/msw/registry.cpp:963
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Kan waarde van sleutel '%s' niet lezen"
 
-#: ../src/common/image.cpp:2620
+#: ../src/msw/webview_ie.cpp:1017
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/common/image.cpp:2715
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "Kan afbeelding niet opslaan naar bestand '%s': Onbekende extensie."
 
-#: ../src/generic/logg.cpp:573 ../src/generic/logg.cpp:976
+#: ../src/generic/logg.cpp:570 ../src/generic/logg.cpp:973
 msgid "Can't save log contents to file."
 msgstr "Kan log inhoud niet in bestand opslaan."
 
-#: ../src/msw/thread.cpp:629
+#: ../src/msw/thread.cpp:621
 msgid "Can't set thread priority"
 msgstr "Kan thread-prioriteit niet instellen"
 
-#: ../src/msw/registry.cpp:896 ../src/msw/registry.cpp:938
-#: ../src/msw/registry.cpp:1081
+#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
+#: ../src/msw/registry.cpp:1069
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Kan waarde van '%s' niet instellen"
 
-#: ../src/unix/utilsunx.cpp:351
+#: ../src/unix/utilsunx.cpp:353
 msgid "Can't write to child process's stdin"
 msgstr "Kan niet schrijven naar child proces's stdin"
 
-#: ../src/common/zstream.cpp:427
+#: ../src/common/zstream.cpp:424
 #, c-format
 msgid "Can't write to deflate stream: %s"
 msgstr "Kan niet schrijven naar deflate stream: %s"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:279 ../src/richtext/richtextstyledlg.cpp:300
-#: ../src/common/stockitem.cpp:145 ../src/common/accelcmn.cpp:71
-#: ../src/msw/msgdlg.cpp:454 ../src/msw/progdlg.cpp:673
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:142
+#: ../src/common/accelcmn.cpp:68 ../src/motif/msgdlg.cpp:196
+#: ../src/gtk1/fontdlg.cpp:144 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/progdlg.cpp:940 ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Annuleer"
 
-#: ../src/common/filefn.cpp:1261
+#: ../src/common/filefn.cpp:1149
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Kan bestanden in map '%s' niet opsommen"
 
-#: ../src/msw/dir.cpp:263
+#: ../src/msw/dir.cpp:260
 #, c-format
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Kan bestanden in map '%s' niet opsommen"
 
-#: ../src/msw/dialup.cpp:523
+#: ../src/msw/dialup.cpp:517
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Kan geen actieve inbelverbinding vinden: %s"
 
-#: ../src/msw/dialup.cpp:827
+#: ../src/msw/dialup.cpp:821
 msgid "Cannot find the location of address book file"
 msgstr "Kan locatie van adresboek niet vinden"
 
-#: ../src/msw/ole/automtn.cpp:562
+#: ../src/msw/ole/automtn.cpp:553
 #, c-format
 msgid "Cannot get an active instance of \"%s\""
 msgstr "Kan geen actief exemplaarset verkrijgen van \"%s\""
 
-#: ../src/unix/threadpsx.cpp:1035
+#: ../src/unix/threadpsx.cpp:1053
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "Kan prioriteitbereik niet verkrijgen voor planningstrategie %d."
 
-#: ../src/unix/utilsunx.cpp:987
+#: ../src/unix/utilsunx.cpp:989
 msgid "Cannot get the hostname"
 msgstr "Kan hostnaam niet verkrijgen"
 
-#: ../src/unix/utilsunx.cpp:1023
+#: ../src/unix/utilsunx.cpp:1025
 msgid "Cannot get the official hostname"
 msgstr "Kan officiële hostnaam niet verkrijgen"
 
-#: ../src/msw/dialup.cpp:928
+#: ../src/msw/dialup.cpp:922
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Kan niet ophangen - geen actieve inbelverbinding."
 
@@ -1828,126 +1835,126 @@ msgstr "Kan niet ophangen - geen actieve inbelverbinding."
 msgid "Cannot initialize OLE"
 msgstr "Kan OLE niet initialiseren"
 
-#: ../src/common/socket.cpp:853
+#: ../src/common/socket.cpp:850
 msgid "Cannot initialize sockets"
 msgstr "Kan sockets niet initiëren"
 
-#: ../src/msw/volume.cpp:619
+#: ../src/msw/volume.cpp:627
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Kan pictogram niet laden van '%s'."
 
-#: ../src/xrc/xmlres.cpp:360
+#: ../src/xrc/xmlres.cpp:358
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Kan bronnen niet laden uit '%s'."
 
-#: ../src/xrc/xmlres.cpp:742
+#: ../src/xrc/xmlres.cpp:740
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Kan bronnen niet laden uit bestand '%s'."
 
-#: ../src/html/htmlfilt.cpp:137
+#: ../src/html/htmlfilt.cpp:134
 #, c-format
 msgid "Cannot open HTML document: %s"
 msgstr "Kan HTML-document '%s' niet openen"
 
-#: ../src/html/helpdata.cpp:667
+#: ../src/html/helpdata.cpp:660
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Kan HTML-helpbestand '%s' niet openen"
 
-#: ../src/html/helpdata.cpp:299
+#: ../src/html/helpdata.cpp:296
 #, c-format
 msgid "Cannot open contents file: %s"
 msgstr "Kon inhoudsopgave-bestand niet openen: %s"
 
-#: ../src/generic/dcpsg.cpp:1667
+#: ../src/generic/dcpsg.cpp:1665
 msgid "Cannot open file for PostScript printing!"
 msgstr "Kan bestand voor PostScript-afdrukken niet openen!"
 
-#: ../src/html/helpdata.cpp:313
+#: ../src/html/helpdata.cpp:310
 #, c-format
 msgid "Cannot open index file: %s"
 msgstr "Kan index-bestand niet openen: %s"
 
-#: ../src/xrc/xmlres.cpp:724
+#: ../src/xrc/xmlres.cpp:722
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Kan bronbestand '%s' niet openen."
 
-#: ../src/html/helpwnd.cpp:1534
+#: ../src/html/helpwnd.cpp:1532
 msgid "Cannot print empty page."
 msgstr "Kan geen lege pagina afdrukken."
 
-#: ../src/msw/volume.cpp:507
+#: ../src/msw/volume.cpp:515
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Kan typenaam van '%s' niet lezen!"
 
-#: ../src/msw/thread.cpp:888
+#: ../src/msw/thread.cpp:894
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Kan thread %lx niet voortzetten"
 
-#: ../src/unix/threadpsx.cpp:1016
+#: ../src/unix/threadpsx.cpp:1028
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Kan thread-planningstrategie niet verkrijgen."
 
-#: ../src/common/intl.cpp:558
+#: ../src/common/intl.cpp:365
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "Kan de lokale niet naar Taal \"%s\" omzetten."
 
-#: ../src/unix/threadpsx.cpp:831 ../src/msw/thread.cpp:546
+#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
 msgid "Cannot start thread: error writing TLS."
 msgstr "Kan thread niet starten: fout bij schrijven TLS."
 
-#: ../src/msw/thread.cpp:872
+#: ../src/msw/thread.cpp:864
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Kan thread %lx niet tijdelijk buiten dienst stellen"
 
-#: ../src/msw/thread.cpp:794
+#: ../src/msw/thread.cpp:786
 msgid "Cannot wait for thread termination"
 msgstr "Kan niet wachten op thread-beëindiging"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:75
+#: ../src/common/accelcmn.cpp:72
 msgid "Capital"
 msgstr "Hoofdletter"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:879
+#: ../src/propgrid/advprops.cpp:780
 msgid "CaptionText"
 msgstr "CaptionText"
 
-#: ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:531
 msgid "Case sensitive"
 msgstr "Hoofdlettergevoelig"
 
-#: ../src/propgrid/manager.cpp:1509
+#: ../src/propgrid/manager.cpp:1527
 msgid "Categorized Mode"
 msgstr "Gecatogoriseerde modus"
 
-#: ../src/richtext/richtextbuffer.cpp:9968
+#: ../src/richtext/richtextbuffer.cpp:9965
 msgid "Cell Properties"
 msgstr "Cel Eigenschappen"
 
-#: ../src/common/fmapbase.cpp:161
+#: ../src/common/fmapbase.cpp:158
 msgid "Celtic (ISO-8859-14)"
 msgstr "Celtic (ISO-8859-14)"
 
-#: ../src/richtext/richtextindentspage.cpp:160
 #: ../src/richtext/richtextliststylepage.cpp:349
+#: ../src/richtext/richtextindentspage.cpp:160
 msgid "Cen&tred"
 msgstr "Gecen&treerd"
 
-#: ../src/common/stockitem.cpp:170
+#: ../src/common/stockitem.cpp:167
 msgid "Centered"
 msgstr "Gecentreerd"
 
-#: ../src/common/fmapbase.cpp:149
+#: ../src/common/fmapbase.cpp:146
 msgid "Central European (ISO-8859-2)"
 msgstr "Centraal-Europees (ISO-8859-2)"
 
@@ -1956,10 +1963,10 @@ msgstr "Centraal-Europees (ISO-8859-2)"
 msgid "Centre"
 msgstr "Centrum"
 
-#: ../src/richtext/richtextindentspage.cpp:162
-#: ../src/richtext/richtextindentspage.cpp:164
 #: ../src/richtext/richtextliststylepage.cpp:351
 #: ../src/richtext/richtextliststylepage.cpp:353
+#: ../src/richtext/richtextindentspage.cpp:162
+#: ../src/richtext/richtextindentspage.cpp:164
 msgid "Centre text."
 msgstr "Tekst Centreren."
 
@@ -1972,24 +1979,24 @@ msgstr "Gecentreerd"
 msgid "Ch&oose..."
 msgstr "K&iezen..."
 
-#: ../src/richtext/richtextbuffer.cpp:4354
+#: ../src/richtext/richtextbuffer.cpp:4351
 msgid "Change List Style"
 msgstr "Verander lijst Stijl"
 
-#: ../src/richtext/richtextbuffer.cpp:3709
+#: ../src/richtext/richtextbuffer.cpp:3706
 msgid "Change Object Style"
 msgstr "Verander lijst Stijl"
 
-#: ../src/richtext/richtextbuffer.cpp:3982
-#: ../src/richtext/richtextbuffer.cpp:8129
+#: ../src/richtext/richtextbuffer.cpp:3979
+#: ../src/richtext/richtextbuffer.cpp:8125
 msgid "Change Properties"
 msgstr "Wijzig Eigenschappen"
 
-#: ../src/richtext/richtextbuffer.cpp:3526
+#: ../src/richtext/richtextbuffer.cpp:3523
 msgid "Change Style"
 msgstr "Verander Stijl"
 
-#: ../src/common/fileconf.cpp:341
+#: ../src/common/fileconf.cpp:335
 #, c-format
 msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
 msgstr ""
@@ -2002,11 +2009,11 @@ msgid "Changing current directory to \"%s\" failed"
 msgstr "Het veranderen van de huidige directory naar \"%s\" is mislukt"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1757
+#: ../src/propgrid/advprops.cpp:1658
 msgid "Character"
 msgstr "Letterteken"
 
-#: ../src/richtext/richtextstyles.cpp:1063
+#: ../src/richtext/richtextstyles.cpp:1060
 msgid "Character styles"
 msgstr "Letterteken Stijlen"
 
@@ -2043,20 +2050,20 @@ msgstr "Klik om het opsommingsteken tussen haakjes te zetten."
 msgid "Check to indicate right-to-left text layout."
 msgstr "Aanvinken om rechts-naar-links tekst lay-out aan te geven."
 
-#: ../src/osx/carbon/fontdlg.cpp:356 ../src/osx/carbon/fontdlg.cpp:358
+#: ../src/osx/carbon/fontdlg.cpp:353 ../src/osx/carbon/fontdlg.cpp:355
 msgid "Check to make the font bold."
 msgstr "Aanvinken voor Vet Lettertype."
 
-#: ../src/osx/carbon/fontdlg.cpp:363 ../src/osx/carbon/fontdlg.cpp:365
+#: ../src/osx/carbon/fontdlg.cpp:360 ../src/osx/carbon/fontdlg.cpp:362
 msgid "Check to make the font italic."
 msgstr "Aanvinken voor Cursief Lettertype."
 
-#: ../src/osx/carbon/fontdlg.cpp:372 ../src/osx/carbon/fontdlg.cpp:374
+#: ../src/osx/carbon/fontdlg.cpp:369 ../src/osx/carbon/fontdlg.cpp:371
 msgid "Check to make the font underlined."
 msgstr "Aanvinken voor Onderstreept Lettertype."
 
-#: ../src/richtext/richtextstyledlg.cpp:289
-#: ../src/richtext/richtextstyledlg.cpp:291
+#: ../src/richtext/richtextstyledlg.cpp:285
+#: ../src/richtext/richtextstyledlg.cpp:287
 msgid "Check to restart numbering."
 msgstr "Aanvinken voor herstart nummering."
 
@@ -2090,52 +2097,52 @@ msgstr "Aanvinken voor tekst in bovenschrift."
 msgid "Check to suppress hyphenation."
 msgstr "Aanvinken om woordafbreking te onderdrukken."
 
-#: ../src/msw/dialup.cpp:763
+#: ../src/msw/dialup.cpp:757
 msgid "Choose ISP to dial"
 msgstr "Kies internetaanbieder om te bellen"
 
-#: ../src/propgrid/props.cpp:1922
+#: ../src/propgrid/props.cpp:1904
 msgid "Choose a directory:"
 msgstr "Kies een map:"
 
-#: ../src/propgrid/props.cpp:1975
+#: ../src/propgrid/props.cpp:2199
 msgid "Choose a file"
 msgstr "Kies een bestand"
 
-#: ../src/generic/colrdlgg.cpp:158 ../src/gtk/colordlg.cpp:54
+#: ../src/generic/colrdlgg.cpp:156 ../src/gtk/colordlg.cpp:49
 msgid "Choose colour"
 msgstr "Kies Kleur"
 
-#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/gtk1/fontdlg.cpp:125 ../src/generic/fontpickerg.cpp:47
+#: ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Kies lettertype"
 
-#: ../src/common/module.cpp:74
+#: ../src/common/module.cpp:71
 #, c-format
 msgid "Circular dependency involving module \"%s\" detected."
 msgstr ""
 "Circulaire afhankelijkheid met betrekking tot module ‘%s’ gedetecteerd."
 
-#: ../src/aui/tabmdi.cpp:108 ../src/generic/mdig.cpp:97
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
 msgid "Cl&ose"
 msgstr "Sl&uiten"
 
-#: ../src/msw/ole/automtn.cpp:684
+#: ../src/msw/ole/automtn.cpp:675
 msgid "Class not registered."
 msgstr "Klasse niet geregistreerd."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:147 ../src/common/accelcmn.cpp:72
+#: ../src/common/stockitem.cpp:144 ../src/common/accelcmn.cpp:69
 msgid "Clear"
 msgstr "Wissen"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "Clear the log contents"
 msgstr "Wis de inhoud van het logbestand"
 
-#: ../src/richtext/richtextstyledlg.cpp:252
-#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:248
+#: ../src/richtext/richtextstyledlg.cpp:250
 msgid "Click to apply the selected style."
 msgstr "Klik voor toepassen geselecteerde stijl."
 
@@ -2146,15 +2153,15 @@ msgstr "Klik voor toepassen geselecteerde stijl."
 msgid "Click to browse for a symbol."
 msgstr "Klik voor zoeken naar symbool."
 
-#: ../src/osx/carbon/fontdlg.cpp:403 ../src/osx/carbon/fontdlg.cpp:405
+#: ../src/osx/carbon/fontdlg.cpp:400 ../src/osx/carbon/fontdlg.cpp:402
 msgid "Click to cancel changes to the font."
 msgstr "Klik om lettertype veranderingen te annuleren."
 
-#: ../src/generic/fontdlgg.cpp:472 ../src/generic/fontdlgg.cpp:491
+#: ../src/generic/fontdlgg.cpp:468 ../src/generic/fontdlgg.cpp:487
 msgid "Click to cancel the font selection."
 msgstr "Klik voor het annuleren van lettertypekeuze."
 
-#: ../src/osx/carbon/fontdlg.cpp:384 ../src/osx/carbon/fontdlg.cpp:386
+#: ../src/osx/carbon/fontdlg.cpp:381 ../src/osx/carbon/fontdlg.cpp:383
 msgid "Click to change the font colour."
 msgstr "Klik voor het veranderen van lettertypekleur."
 
@@ -2173,37 +2180,37 @@ msgstr "Klik voor het veranderen van tekstkleur."
 msgid "Click to choose the font for this level."
 msgstr "Klik voor het kiezen van het lettertype voor dit niveau."
 
-#: ../src/richtext/richtextstyledlg.cpp:279
-#: ../src/richtext/richtextstyledlg.cpp:281
+#: ../src/richtext/richtextstyledlg.cpp:275
+#: ../src/richtext/richtextstyledlg.cpp:277
 msgid "Click to close this window."
 msgstr "Klik om dit venster te sluiten."
 
-#: ../src/osx/carbon/fontdlg.cpp:410 ../src/osx/carbon/fontdlg.cpp:412
+#: ../src/osx/carbon/fontdlg.cpp:407 ../src/osx/carbon/fontdlg.cpp:409
 msgid "Click to confirm changes to the font."
 msgstr "Klik voor bevestiging van lettertypeveranderingen."
 
-#: ../src/generic/fontdlgg.cpp:477 ../src/generic/fontdlgg.cpp:479
-#: ../src/generic/fontdlgg.cpp:484 ../src/generic/fontdlgg.cpp:486
+#: ../src/generic/fontdlgg.cpp:473 ../src/generic/fontdlgg.cpp:475
+#: ../src/generic/fontdlgg.cpp:480 ../src/generic/fontdlgg.cpp:482
 msgid "Click to confirm the font selection."
 msgstr "Klik voor bevestiging van lettertypeselectie."
 
-#: ../src/richtext/richtextstyledlg.cpp:244
-#: ../src/richtext/richtextstyledlg.cpp:246
+#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:242
 msgid "Click to create a new box style."
 msgstr "Klik voor het maken van een nieuwe vak stijl."
 
-#: ../src/richtext/richtextstyledlg.cpp:226
-#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:224
 msgid "Click to create a new character style."
 msgstr "Klik voor het maken van een nieuwe letterteken stijl."
 
-#: ../src/richtext/richtextstyledlg.cpp:238
-#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:236
 msgid "Click to create a new list style."
 msgstr "Klik voor het maken van een nieuwe lijst stijl."
 
-#: ../src/richtext/richtextstyledlg.cpp:232
-#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:230
 msgid "Click to create a new paragraph style."
 msgstr "Klik voor het maken van een nieuwe paragraaf stijl."
 
@@ -2217,8 +2224,8 @@ msgstr "Klik voor het maken van een nieuwe tab positie."
 msgid "Click to delete all tab positions."
 msgstr "Klik om alle tabposities te verwijderen."
 
-#: ../src/richtext/richtextstyledlg.cpp:270
-#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:268
 msgid "Click to delete the selected style."
 msgstr "Klik voor het verwijderen van geselecteerde stijl."
 
@@ -2227,25 +2234,25 @@ msgstr "Klik voor het verwijderen van geselecteerde stijl."
 msgid "Click to delete the selected tab position."
 msgstr "Klik voor het verwijderen van geselecteerd tab positie."
 
-#: ../src/richtext/richtextstyledlg.cpp:264
-#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:262
 msgid "Click to edit the selected style."
 msgstr "Klik voor het bewerken van geselecteerde stijl."
 
-#: ../src/richtext/richtextstyledlg.cpp:258
-#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:256
 msgid "Click to rename the selected style."
 msgstr "Klik voor het hernoemen van geselecteerde stijl."
 
-#: ../src/generic/dbgrptg.cpp:97 ../src/generic/progdlgg.cpp:759
-#: ../src/richtext/richtextstyledlg.cpp:277
-#: ../src/richtext/richtextsymboldlg.cpp:476 ../src/common/stockitem.cpp:148
-#: ../src/msw/progdlg.cpp:170 ../src/msw/progdlg.cpp:679
-#: ../src/html/helpdlg.cpp:90
+#: ../src/common/stockitem.cpp:145 ../src/generic/dbgrptg.cpp:94
+#: ../src/generic/progdlgg.cpp:781 ../src/msw/progdlg.cpp:211
+#: ../src/msw/progdlg.cpp:946 ../src/html/helpdlg.cpp:87
+#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextstyledlg.cpp:273
 msgid "Close"
 msgstr "Sluiten"
 
-#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:98
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
 msgid "Close All"
 msgstr "Alles Sluiten"
 
@@ -2253,43 +2260,43 @@ msgstr "Alles Sluiten"
 msgid "Close current document"
 msgstr "Huidig document sluiten"
 
-#: ../src/generic/logg.cpp:516
+#: ../src/generic/logg.cpp:513
 msgid "Close this window"
 msgstr "Sluit dit venster"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6006
+#: ../src/generic/datavgen.cpp:6811
 msgid "Collapse"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "Color"
 msgstr "Kleur"
 
-#: ../src/richtext/richtextformatdlg.cpp:776
+#: ../src/richtext/richtextformatdlg.cpp:768
 msgid "Colour"
 msgstr "Kleur"
 
-#: ../src/msw/colordlg.cpp:158
+#: ../src/msw/colordlg.cpp:227
 #, c-format
 msgid "Colour selection dialog failed with error %0lx."
 msgstr "Kleurenselectie dialoog mislukt met fout %0lx."
 
-#: ../src/osx/carbon/fontdlg.cpp:380
+#: ../src/osx/carbon/fontdlg.cpp:377
 msgid "Colour:"
 msgstr "Kleur:"
 
-#: ../src/generic/datavgen.cpp:6077
+#: ../src/generic/datavgen.cpp:6882
 #, c-format
 msgid "Column %u"
 msgstr "Kolom %u"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:114
+#: ../src/common/accelcmn.cpp:112
 msgid "Command"
 msgstr "Commando"
 
-#: ../src/common/init.cpp:196
+#: ../src/common/init.cpp:193
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
@@ -2298,12 +2305,12 @@ msgstr ""
 "Commandoregel argument %d kon niet omgezet worden naar Unicode en zal worden "
 "genegeerd."
 
-#: ../src/msw/fontdlg.cpp:120
+#: ../src/msw/fontdlg.cpp:170
 #, c-format
 msgid "Common dialog failed with error code %0lx."
 msgstr "Common dialoog mislukt met fout %0lx."
 
-#: ../src/gtk/window.cpp:4649
+#: ../src/gtk/window.cpp:5653
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
@@ -2311,11 +2318,11 @@ msgstr ""
 "Samenstellen niet ondersteund door dit systeem. U kunt dit inschakelen in uw "
 "Vensterbeheer."
 
-#: ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:1549
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Gecomprimeerd HTML-hulpbestand (*.chm)|*.chm|"
 
-#: ../src/generic/dirctrlg.cpp:444
+#: ../src/generic/dirctrlg.cpp:410
 msgid "Computer"
 msgstr "Computer"
 
@@ -2324,53 +2331,57 @@ msgstr "Computer"
 msgid "Config entry name cannot start with '%c'."
 msgstr "Naam van configuratie-ingang kan niet beginnen met '%c'."
 
-#: ../src/generic/filedlgg.cpp:349 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
 msgid "Confirm"
 msgstr "Bevestig"
 
-#: ../src/html/htmlwin.cpp:566
+#: ../src/html/htmlwin.cpp:569
 msgid "Connecting..."
 msgstr "Bezig te verbinden..."
 
-#: ../src/html/helpwnd.cpp:475
+#: ../src/html/helpwnd.cpp:473
 msgid "Contents"
 msgstr "Inhoud"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:880
+#: ../src/propgrid/advprops.cpp:781
 msgid "ControlDark"
 msgstr "ControlDark"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:881
+#: ../src/propgrid/advprops.cpp:782
 msgid "ControlLight"
 msgstr "ControlLight"
 
-#: ../src/common/strconv.cpp:2262
+#: ../src/common/strconv.cpp:2208
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Conversie naar karakterset '%s' werkt niet."
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "Convert"
 msgstr "Converteren"
 
-#: ../src/html/htmlwin.cpp:1079
+#: ../src/html/htmlwin.cpp:1020
 #, c-format
 msgid "Copied to clipboard:\"%s\""
 msgstr "Gekopieerd naar klembord:\"%s\""
 
-#: ../src/generic/prntdlgg.cpp:247
+#: ../src/generic/prntdlgg.cpp:240
 msgid "Copies:"
 msgstr "Kopieën:"
 
-#: ../src/common/stockitem.cpp:150 ../src/stc/stc_i18n.cpp:18
+#: ../src/common/stockitem.cpp:147 ../src/stc/stc_i18n.cpp:18
 msgid "Copy"
 msgstr "Kopi&#235;ren"
 
-#: ../src/common/stockitem.cpp:258
+#: ../src/common/stockitem.cpp:255
 msgid "Copy selection"
 msgstr "Selectie kopiëren"
+
+#: ../src/generic/grid.cpp:5945
+msgid "Copying more than one selected block to clipboard is not supported."
+msgstr ""
 
 #: ../src/richtext/richtextborderspage.cpp:566
 #: ../src/richtext/richtextborderspage.cpp:601
@@ -2381,195 +2392,192 @@ msgstr "Hoek"
 msgid "Corner &radius:"
 msgstr "Hoek-st&raal:"
 
-#: ../src/html/chm.cpp:718
+#: ../src/html/chm.cpp:711
 #, c-format
 msgid "Could not create temporary file '%s'"
 msgstr "Kon tijdelijk bestand '%s' niet aanmaken"
 
-#: ../src/html/chm.cpp:273
+#: ../src/html/chm.cpp:270
 #, c-format
 msgid "Could not extract %s into %s: %s"
 msgstr "Kon %s niet extraheren in %s: %s"
 
-#: ../src/generic/tabg.cpp:1048
+#: ../src/generic/tabg.cpp:1045
 msgid "Could not find tab for id"
 msgstr "Kon tabblad niet vinden voor id"
 
-#: ../src/gtk/notifmsg.cpp:108
-msgid "Could not initalize libnotify."
-msgstr "Kon niet initalize libnotify."
-
-#: ../src/html/chm.cpp:444
+#: ../src/html/chm.cpp:437
 #, c-format
 msgid "Could not locate file '%s'."
 msgstr "Kon niet vinden bestand '%s'."
 
-#: ../src/common/filefn.cpp:1403
+#: ../src/msw/graphicsd2d.cpp:604
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/common/filefn.cpp:1291
 msgid "Could not set current working directory"
 msgstr "Instellen van huidige werk map mislukt"
 
-#: ../src/common/prntbase.cpp:2015
+#: ../src/common/prntbase.cpp:2037
 msgid "Could not start document preview."
 msgstr "Kon afdrukvoorbeeld niet starten."
 
-#: ../src/generic/printps.cpp:178 ../src/msw/printwin.cpp:210
-#: ../src/gtk/print.cpp:1132
+#: ../src/generic/printps.cpp:159 ../src/msw/printwin.cpp:184
+#: ../src/gtk/print.cpp:1129
 msgid "Could not start printing."
 msgstr "Kon printen niet starten."
 
-#: ../src/common/wincmn.cpp:2125
+#: ../src/common/wincmn.cpp:2126
 msgid "Could not transfer data to window"
 msgstr "Kon gegevens niet naar venster overdragen"
 
-#: ../src/msw/imaglist.cpp:187 ../src/msw/imaglist.cpp:224
-#: ../src/msw/imaglist.cpp:249 ../src/msw/dragimag.cpp:185
-#: ../src/msw/dragimag.cpp:220
+#: ../src/msw/imaglist.cpp:223 ../src/msw/imaglist.cpp:245
+#: ../src/msw/imaglist.cpp:270 ../src/msw/dragimag.cpp:182
+#: ../src/msw/dragimag.cpp:217
 msgid "Couldn't add an image to the image list."
 msgstr "Kon geen afbeelding aan de lijst toevoegen."
 
-#: ../src/osx/glcanvas_osx.cpp:414 ../src/unix/glx11.cpp:558
-#: ../src/msw/glcanvas.cpp:616
+#: ../src/osx/glcanvas_osx.cpp:411 ../src/msw/glcanvas.cpp:631
+#: ../src/unix/glegl.cpp:315 ../src/unix/glx11.cpp:559
 msgid "Couldn't create OpenGL context"
 msgstr "Kan geen OpenGL-context maken"
 
-#: ../src/msw/timer.cpp:134
+#: ../src/msw/timer.cpp:131
 msgid "Couldn't create a timer"
 msgstr "Kon geen timer creëren"
 
-#: ../src/osx/carbon/overlay.cpp:122
-msgid "Couldn't create the overlay window"
-msgstr "Kon geen overlay venster aanmaken"
-
-#: ../src/common/translation.cpp:2024
+#: ../src/common/translation.cpp:2074
 msgid "Couldn't enumerate translations"
 msgstr "Kon vertalingen niet opsommen"
 
-#: ../src/common/dynlib.cpp:120
+#: ../src/common/dynlib.cpp:110
 #, c-format
 msgid "Couldn't find symbol '%s' in a dynamic library"
 msgstr "Kon symbool %s niet vinden in een dynamische bibliotheek"
 
-#: ../src/msw/thread.cpp:915
+#: ../src/msw/thread.cpp:921
 msgid "Couldn't get the current thread pointer"
 msgstr "Kon pointer naar huidige thread niet verkrijgen"
 
-#: ../src/osx/carbon/overlay.cpp:129
-msgid "Couldn't init the context on the overlay window"
-msgstr "Kon de context in het overlay venster niet initiëren"
-
-#: ../src/common/imaggif.cpp:244
+#: ../src/common/imaggif.cpp:241
 msgid "Couldn't initialize GIF hash table."
 msgstr "Kon GIF hash-tabel niet initiëren."
 
-#: ../src/common/imagpng.cpp:409
+#: ../src/common/imagpng.cpp:437
 msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
 msgstr ""
 "Kon PNG-afbeelding niet laden: bestand is corrupt of onvoldoende geheugen."
 
-#: ../src/unix/sound.cpp:470
+#: ../src/unix/sound.cpp:459
 #, c-format
 msgid "Couldn't load sound data from '%s'."
 msgstr "Kon geen geluidsgegevens laden van '%s'."
 
-#: ../src/msw/dirdlg.cpp:435
+#: ../src/msw/dirdlg.cpp:287
 msgid "Couldn't obtain folder name"
 msgstr "Kon de mapnaam niet verkrijgen"
 
-#: ../src/unix/sound_sdl.cpp:229
+#: ../src/unix/sound_sdl.cpp:226
 #, c-format
 msgid "Couldn't open audio: %s"
 msgstr "Kon audio: %s niet openen"
 
-#: ../src/msw/ole/dataobj.cpp:377
+#: ../src/msw/ole/dataobj.cpp:385
 #, c-format
 msgid "Couldn't register clipboard format '%s'."
 msgstr "Kon klembord-formaat '%s' niet registreren."
 
-#: ../src/msw/listctrl.cpp:869
+#: ../src/msw/listctrl.cpp:933
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "Kon geen informatie verkrijgen over lijst-control element %d."
 
-#: ../src/common/imagpng.cpp:498 ../src/common/imagpng.cpp:509
-#: ../src/common/imagpng.cpp:519
+#: ../src/common/imagpng.cpp:511 ../src/common/imagpng.cpp:522
+#: ../src/common/imagpng.cpp:532
 msgid "Couldn't save PNG image."
 msgstr "Kon PNG afbeelding niet opslaan."
 
-#: ../src/msw/thread.cpp:684
+#: ../src/msw/thread.cpp:676
 msgid "Couldn't terminate thread"
 msgstr "Kon thread niet beëindigen"
 
-#: ../src/common/xtistrm.cpp:166
+#: ../src/common/xtistrm.cpp:163
 #, c-format
 msgid "Create Parameter %s not found in declared RTTI Parameters"
 msgstr "Create Parameter %s niet gevonden in gedeclareerde RTTI Parameters"
 
-#: ../src/generic/dirdlgg.cpp:288
+#: ../src/generic/dirdlgg.cpp:285
 msgid "Create directory"
 msgstr "Maak map"
 
-#: ../src/generic/filedlgg.cpp:212 ../src/generic/dirdlgg.cpp:111
+#: ../src/generic/filedlgg.cpp:209 ../src/generic/dirdlgg.cpp:108
 msgid "Create new directory"
 msgstr "Maak nieuwe map"
 
-#: ../src/xrc/xmlres.cpp:2460
+#: ../src/common/stockitem.cpp:264
+#, fuzzy
+msgid "Create new document"
+msgstr "Maak nieuwe map"
+
+#: ../src/xrc/xmlres.cpp:2515
 #, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Aanmaken van '%s' in '%s' mislukte."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1758
+#: ../src/propgrid/advprops.cpp:1659
 msgid "Cross"
 msgstr "Kruis"
 
-#: ../src/common/accelcmn.cpp:333
+#: ../src/common/accelcmn.cpp:347
 msgid "Ctrl+"
 msgstr "Ctrl+"
 
-#: ../src/richtext/richtextctrl.cpp:332 ../src/osx/textctrl_osx.cpp:576
-#: ../src/common/stockitem.cpp:151 ../src/msw/textctrl.cpp:2507
+#: ../src/osx/textctrl_osx.cpp:594 ../src/common/stockitem.cpp:148
+#: ../src/msw/textctrl.cpp:2772 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "Kni&ppen"
 
-#: ../src/generic/filectrlg.cpp:940
+#: ../src/generic/filectrlg.cpp:936
 msgid "Current directory:"
 msgstr "Huidige map:"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:896 ../src/propgrid/advprops.cpp:1574
-#: ../src/propgrid/advprops.cpp:1612
+#: ../src/propgrid/advprops.cpp:797 ../src/propgrid/advprops.cpp:1475
+#: ../src/propgrid/advprops.cpp:1518
 msgid "Custom"
 msgstr "Aangepast"
 
-#: ../src/gtk/print.cpp:217
+#: ../src/gtk/print.cpp:211
 msgid "Custom size"
 msgstr "Aangepaste grootte"
 
-#: ../src/common/headerctrlcmn.cpp:60
+#: ../src/common/headerctrlcmn.cpp:58
 msgid "Customize Columns"
 msgstr "Kolommen aanpassen"
 
-#: ../src/common/stockitem.cpp:151 ../src/stc/stc_i18n.cpp:17
+#: ../src/common/stockitem.cpp:148 ../src/stc/stc_i18n.cpp:17
 msgid "Cut"
 msgstr "Knippen"
 
-#: ../src/common/stockitem.cpp:259
+#: ../src/common/stockitem.cpp:256
 msgid "Cut selection"
 msgstr "Selectie knippen"
 
-#: ../src/common/fmapbase.cpp:152
+#: ../src/common/fmapbase.cpp:149
 msgid "Cyrillic (ISO-8859-5)"
 msgstr "Cyrillic (ISO-8859-5)"
 
-#: ../src/common/paper.cpp:99
+#: ../src/common/paper.cpp:96
 msgid "D sheet, 22 x 34 in"
 msgstr "D, 22 x34 inch"
 
-#: ../src/msw/dde.cpp:703
+#: ../src/msw/dde.cpp:698
 msgid "DDE poke request failed"
 msgstr "DDE poke verzoek mislukt"
 
-#: ../src/common/imagbmp.cpp:1169
+#: ../src/common/imagbmp.cpp:1181
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr "DIB Header: Codering komt niet overeen met bit-diepte."
 
@@ -2589,7 +2597,7 @@ msgstr "DIB Header: Onbekende bitdiepte in bestand."
 msgid "DIB Header: Unknown encoding in file."
 msgstr "DIB Header: Onbekende codering in bestand."
 
-#: ../src/common/paper.cpp:121
+#: ../src/common/paper.cpp:118
 msgid "DL Envelope, 110 x 220 mm"
 msgstr "Envelop DL, 110 x 220 mm"
 
@@ -2597,53 +2605,53 @@ msgstr "Envelop DL, 110 x 220 mm"
 msgid "Dashed"
 msgstr "Gestreept"
 
-#: ../src/generic/dbgrptg.cpp:300
+#: ../src/generic/dbgrptg.cpp:301
 #, c-format
 msgid "Debug report \"%s\""
 msgstr "Futopsporingsrapport \"%s\""
 
-#: ../src/common/debugrpt.cpp:210
+#: ../src/common/debugrpt.cpp:211
 msgid "Debug report couldn't be created."
 msgstr "Foutopsporingsrapport kon niet worden gemaakt."
 
-#: ../src/common/debugrpt.cpp:553
+#: ../src/common/debugrpt.cpp:554
 msgid "Debug report generation has failed."
 msgstr "Genereren van foutopsporingsrapport mislukt."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:84
+#: ../src/common/accelcmn.cpp:81
 msgid "Decimal"
 msgstr "Decimaal"
 
-#: ../src/generic/fontdlgg.cpp:323
+#: ../src/generic/fontdlgg.cpp:319
 msgid "Decorative"
 msgstr "Decoratief"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1752
+#: ../src/propgrid/advprops.cpp:1653
 msgid "Default"
 msgstr "Standaard"
 
-#: ../src/common/fmapbase.cpp:796
+#: ../src/common/fmapbase.cpp:792
 msgid "Default encoding"
 msgstr "Standaardcodering"
 
-#: ../src/dfb/fontmgr.cpp:180
+#: ../src/dfb/fontmgr.cpp:177
 msgid "Default font"
 msgstr "Standaard lettertype"
 
-#: ../src/generic/prntdlgg.cpp:510
+#: ../src/generic/prntdlgg.cpp:503
 msgid "Default printer"
 msgstr "Standaardprinter"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:51
+#: ../src/common/accelcmn.cpp:48
 msgid "Del"
 msgstr "Del"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextbuffer.cpp:8221 ../src/common/stockitem.cpp:152
-#: ../src/common/accelcmn.cpp:50 ../src/stc/stc_i18n.cpp:20
+#: ../src/common/stockitem.cpp:149 ../src/common/accelcmn.cpp:47
+#: ../src/richtext/richtextbuffer.cpp:8217 ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Verwijderen"
 
@@ -2651,68 +2659,68 @@ msgstr "Verwijderen"
 msgid "Delete A&ll"
 msgstr "A&lles verwijderen"
 
-#: ../src/richtext/richtextbuffer.cpp:11341
+#: ../src/richtext/richtextbuffer.cpp:11340
 msgid "Delete Column"
 msgstr "Kolom verwijderen"
 
-#: ../src/richtext/richtextbuffer.cpp:11291
+#: ../src/richtext/richtextbuffer.cpp:11290
 msgid "Delete Row"
 msgstr "Rij verwijderen"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 msgid "Delete Style"
 msgstr "Stijl verwijderen"
 
-#: ../src/richtext/richtextctrl.cpp:1345 ../src/richtext/richtextctrl.cpp:1584
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
 msgid "Delete Text"
 msgstr "Tekst verwijderen"
 
-#: ../src/generic/editlbox.cpp:170
+#: ../src/generic/editlbox.cpp:147
 msgid "Delete item"
 msgstr "Element verwijderen"
 
-#: ../src/common/stockitem.cpp:260
+#: ../src/common/stockitem.cpp:257
 msgid "Delete selection"
 msgstr "Selectie verwijderen"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 #, c-format
 msgid "Delete style %s?"
 msgstr "Stijl %s verwijderen?"
 
-#: ../src/unix/snglinst.cpp:301
+#: ../src/unix/snglinst.cpp:298
 #, c-format
 msgid "Deleted stale lock file '%s'."
 msgstr "Verouderd vergrendeld bestand '%s' verwijderd."
 
-#: ../src/common/secretstore.cpp:220
-#, c-format
-msgid "Deleting password for \"%s/%s\" failed: %s."
+#: ../src/common/secretstore.cpp:234
+#, fuzzy, c-format
+msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Het verwijderen van het wachtwoord voor \"%s/%s\" is mislukt: %s."
 
-#: ../src/common/module.cpp:124
+#: ../src/common/module.cpp:121
 #, c-format
 msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
 msgstr "Afhankelijkheid \"%s\" van module \"%s\" bestaat niet."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "Descending"
 msgstr "Aflopend"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:526 ../src/propgrid/advprops.cpp:882
+#: ../src/generic/dirctrlg.cpp:492 ../src/propgrid/advprops.cpp:783
 msgid "Desktop"
 msgstr "Bureaublad"
 
-#: ../src/generic/aboutdlgg.cpp:70
+#: ../src/generic/aboutdlgg.cpp:67
 msgid "Developed by "
 msgstr "Ontwikkeld door "
 
-#: ../src/generic/aboutdlgg.cpp:176
+#: ../src/generic/aboutdlgg.cpp:173
 msgid "Developers"
 msgstr "Ontwikkelaars"
 
-#: ../src/msw/dialup.cpp:374
+#: ../src/msw/dialup.cpp:368
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -2720,11 +2728,11 @@ msgstr ""
 "Inbelfuncties zijn niet beschikbaar omdat de inbelverbindingsoftware (RAS) "
 "niet op deze machine is geïnstalleerd. Installeer het a.u.b."
 
-#: ../src/generic/tipdlg.cpp:211
+#: ../src/generic/tipdlg.cpp:208
 msgid "Did you know..."
 msgstr "Wist u dat..."
 
-#: ../src/dfb/wrapdfb.cpp:63
+#: ../src/dfb/wrapdfb.cpp:60
 #, c-format
 msgid "DirectFB error %d occurred."
 msgstr "DirectFB fout %d opgetreden."
@@ -2733,29 +2741,29 @@ msgstr "DirectFB fout %d opgetreden."
 msgid "Directories"
 msgstr "Mappen"
 
-#: ../src/common/filefn.cpp:1183
+#: ../src/common/filefn.cpp:1071
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Map '%s' kon niet worden gemaakt"
 
-#: ../src/common/filefn.cpp:1197
+#: ../src/common/filefn.cpp:1085
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "Map '%s' kon niet worden verwijderd"
 
-#: ../src/generic/dirdlgg.cpp:204
+#: ../src/generic/dirdlgg.cpp:201
 msgid "Directory does not exist"
 msgstr "Map bestaat niet"
 
-#: ../src/generic/filectrlg.cpp:1399
+#: ../src/generic/filectrlg.cpp:1388
 msgid "Directory doesn't exist."
 msgstr "Map bestaat niet."
 
-#: ../src/common/docview.cpp:457
+#: ../src/common/docview.cpp:450
 msgid "Discard changes and reload the last saved version?"
 msgstr "Wijzigingen negeren en laatst opgeslagen versie herladen?"
 
-#: ../src/html/helpwnd.cpp:502
+#: ../src/html/helpwnd.cpp:500
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -2763,45 +2771,45 @@ msgstr ""
 "Toon alle index elementen die de gegeven subtekenreeks bevatten. Niet "
 "hoofdlettergevoelig."
 
-#: ../src/html/helpwnd.cpp:679
+#: ../src/html/helpwnd.cpp:677
 msgid "Display options dialog"
 msgstr "Toon optie-dialoog"
 
-#: ../src/html/helpwnd.cpp:322
+#: ../src/html/helpwnd.cpp:320
 msgid "Displays help as you browse the books on the left."
 msgstr "Toont hulptekst terwijl u de boeken aan de linkerzijde doorbladert."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:85
+#: ../src/common/accelcmn.cpp:83
 msgid "Divide"
 msgstr "Scheiding"
 
-#: ../src/common/docview.cpp:533
+#: ../src/common/docview.cpp:526
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Wilt u de veranderingen aan %s opslaan?"
 
-#: ../src/common/prntbase.cpp:542
+#: ../src/common/prntbase.cpp:537
 msgid "Document:"
 msgstr "Document:"
 
-#: ../src/generic/aboutdlgg.cpp:73
+#: ../src/generic/aboutdlgg.cpp:70
 msgid "Documentation by "
 msgstr "Documentatie door "
 
-#: ../src/generic/aboutdlgg.cpp:180
+#: ../src/generic/aboutdlgg.cpp:177
 msgid "Documentation writers"
 msgstr "Documentatie schrijvers"
 
-#: ../src/common/sizer.cpp:2799
+#: ../src/common/sizer.cpp:2916
 msgid "Don't Save"
 msgstr "Niet Opslaan"
 
-#: ../src/html/htmlwin.cpp:633
+#: ../src/html/htmlwin.cpp:643
 msgid "Done"
 msgstr "Klaar"
 
-#: ../src/generic/progdlgg.cpp:448 ../src/msw/progdlg.cpp:407
+#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
 msgid "Done."
 msgstr "Klaar."
 
@@ -2813,42 +2821,42 @@ msgstr "Gestippeld"
 msgid "Double"
 msgstr "Dubbel"
 
-#: ../src/common/paper.cpp:176
+#: ../src/common/paper.cpp:173
 msgid "Double Japanese Postcard Rotated 148 x 200 mm"
 msgstr "Dubbele Japanse briefkaart gedraaid 148 x 200 mm"
 
-#: ../src/common/xtixml.cpp:273
+#: ../src/common/xtixml.cpp:269
 #, c-format
 msgid "Doubly used id : %d"
 msgstr "Dubbel gebruikt ID: %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:153
-#: ../src/common/accelcmn.cpp:64
+#: ../src/common/stockitem.cpp:150 ../src/common/accelcmn.cpp:61
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Down"
 msgstr "Omlaag"
 
-#: ../src/richtext/richtextctrl.cpp:865
+#: ../src/richtext/richtextctrl.cpp:864
 msgid "Drag"
 msgstr "Slepen"
 
-#: ../src/common/paper.cpp:100
+#: ../src/common/paper.cpp:97
 msgid "E sheet, 34 x 44 in"
 msgstr "E, 34 x 44 inch"
 
-#: ../src/unix/fswatcher_inotify.cpp:561
+#: ../src/unix/fswatcher_inotify.cpp:558
 msgid "EOF while reading from inotify descriptor"
 msgstr "EOF tijdens lezen van inotify descriptor"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "Edit"
 msgstr "Bewerken"
 
-#: ../src/generic/editlbox.cpp:168
+#: ../src/generic/editlbox.cpp:131
 msgid "Edit item"
 msgstr "Element bewerken"
 
-#: ../include/wx/generic/progdlgg.h:84
+#: ../include/wx/generic/progdlgg.h:85
 msgid "Elapsed time:"
 msgstr "Verstreken tijd:"
 
@@ -2915,49 +2923,49 @@ msgid "Enables the shadow spread."
 msgstr "Schakelt de schaduwbreedte in."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:66
+#: ../src/common/accelcmn.cpp:63
 msgid "End"
 msgstr "End"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:55
+#: ../src/common/accelcmn.cpp:52
 msgid "Enter"
 msgstr "Enter"
 
-#: ../src/richtext/richtextstyledlg.cpp:934
+#: ../src/richtext/richtextstyledlg.cpp:930
 msgid "Enter a box style name"
 msgstr "Vul een vak stijlnaam in"
 
-#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:602
 msgid "Enter a character style name"
 msgstr "Vul een lettertekenstijlnaam in"
 
-#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:816
 msgid "Enter a list style name"
 msgstr "Vul een lijststijl in"
 
-#: ../src/richtext/richtextstyledlg.cpp:893
+#: ../src/richtext/richtextstyledlg.cpp:889
 msgid "Enter a new style name"
 msgstr "Vul een nieuwe stijlnaam in"
 
-#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:650
 msgid "Enter a paragraph style name"
 msgstr "Vul een paragraafstijl in"
 
-#: ../src/generic/dbgrptg.cpp:174
+#: ../src/generic/dbgrptg.cpp:171
 #, c-format
 msgid "Enter command to open file \"%s\":"
 msgstr "Opdracht invoeren voor openen van bestand  \"%s\":"
 
-#: ../src/generic/helpext.cpp:459
+#: ../src/generic/helpext.cpp:457
 msgid "Entries found"
 msgstr "Ingangen gevonden"
 
-#: ../src/common/paper.cpp:142
+#: ../src/common/paper.cpp:139
 msgid "Envelope Invite 220 x 220 mm"
 msgstr "Envelop Invite 220 x 220 mm"
 
-#: ../src/common/config.cpp:469
+#: ../src/common/config.cpp:465
 #, c-format
 msgid ""
 "Environment variables expansion failed: missing '%c' at position %u in '%s'."
@@ -2965,13 +2973,13 @@ msgstr ""
 "Uitbreiding van omgevingsvariabelen mislukt: ontbrekende '%c' op positie %u "
 "in '%s'."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/generic/dirctrlg.cpp:570
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/dirctrlg.cpp:599
-#: ../src/generic/dirdlgg.cpp:323 ../src/generic/filectrlg.cpp:642
-#: ../src/generic/filectrlg.cpp:756 ../src/generic/filectrlg.cpp:770
-#: ../src/generic/filectrlg.cpp:786 ../src/generic/filectrlg.cpp:1368
-#: ../src/generic/filectrlg.cpp:1399 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/gtk1/fontdlg.cpp:74 ../src/generic/dirctrlg.cpp:536
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/dirctrlg.cpp:565
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1357 ../src/generic/filectrlg.cpp:1388
+#: ../src/generic/filedlgg.cpp:354 ../src/generic/dirdlgg.cpp:320
+#: ../src/gtk/filedlg.cpp:74
 msgid "Error"
 msgstr "Fout"
 
@@ -2979,86 +2987,97 @@ msgstr "Fout"
 msgid "Error closing epoll descriptor"
 msgstr "Fout bij sluiten van epoll descriptor"
 
-#: ../src/unix/fswatcher_kqueue.cpp:114
+#: ../src/unix/fswatcher_kqueue.cpp:131
 msgid "Error closing kqueue instance"
 msgstr "Fout bij sluiten van kqueue exemplaarset"
 
-#: ../src/common/filefn.cpp:1049
+#: ../src/common/filefn.cpp:938
 #, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Fout bij het kopiëren van het bestand '%s' naar '%s'."
 
-#: ../src/generic/dirdlgg.cpp:222
+#: ../src/generic/dirdlgg.cpp:219
 msgid "Error creating directory"
 msgstr "Fout bij het maken van map"
 
-#: ../src/common/imagbmp.cpp:1181
+#: ../src/common/imagbmp.cpp:1193
 msgid "Error in reading image DIB."
 msgstr "Fout bij lezen afbeelding DIB."
 
-#: ../src/propgrid/propgrid.cpp:6696
+#: ../src/propgrid/propgrid.cpp:6665
 #, c-format
 msgid "Error in resource: %s"
 msgstr "Fout in bron: %s"
 
-#: ../src/common/fileconf.cpp:422
+#: ../src/common/fileconf.cpp:421
 msgid "Error reading config options."
 msgstr "Fout bij lezen van configuratie opties."
+
+#: ../src/msw/webview_ie.cpp:1057 ../src/msw/webview_edge.cpp:850
+#: ../src/gtk/webview_webkit2.cpp:1262 ../src/osx/webview_webkit.mm:383
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
 
 #: ../src/common/fileconf.cpp:1029
 msgid "Error saving user configuration data."
 msgstr "Fout van bij het opslaan van de instellingsgegevens."
 
-#: ../src/gtk/print.cpp:722
+#: ../src/gtk/print.cpp:720
 msgid "Error while printing: "
 msgstr "Fout bij het printen: "
 
-#: ../src/common/log.cpp:219
+#: ../src/common/log.cpp:237
 msgid "Error: "
 msgstr "Fout: "
 
+#: ../src/common/webrequest.cpp:98
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Fout: "
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:69
+#: ../src/common/accelcmn.cpp:66
 msgid "Esc"
 msgstr "Esc"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:70
+#: ../src/common/accelcmn.cpp:67
 msgid "Escape"
 msgstr "Escape"
 
-#: ../src/common/fmapbase.cpp:150
+#: ../src/common/fmapbase.cpp:147
 msgid "Esperanto (ISO-8859-3)"
 msgstr "Esperanto (ISO-8859-3)"
 
-#: ../include/wx/generic/progdlgg.h:85
+#: ../include/wx/generic/progdlgg.h:86
 msgid "Estimated time:"
 msgstr "Geschatte tijd:"
 
-#: ../src/generic/dbgrptg.cpp:234
+#: ../src/generic/dbgrptg.cpp:231
 msgid "Executable files (*.exe)|*.exe|"
 msgstr "Uitvoerbare bestanden (*.exe)|*.exe|"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:155 ../src/common/accelcmn.cpp:78
+#: ../src/common/stockitem.cpp:152 ../src/common/accelcmn.cpp:75
 msgid "Execute"
 msgstr "Uitvoeren"
 
-#: ../src/msw/utilsexc.cpp:876
+#: ../src/msw/utilsexc.cpp:873
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Uitvoering van opdracht '%s' mislukt"
 
-#: ../src/common/paper.cpp:105
+#: ../src/common/paper.cpp:102
 msgid "Executive, 7 1/4 x 10 1/2 in"
 msgstr "USA Executive, 7 1/4 x 10 1/2 inch"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6009
+#: ../src/generic/datavgen.cpp:6814
 msgid "Expand"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1240
+#: ../src/msw/registry.cpp:1228
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
@@ -3066,147 +3085,157 @@ msgstr ""
 "Exporteren registersleutel: bestand \"%s\" bestaat al en wordt niet "
 "overschreven."
 
-#: ../src/common/fmapbase.cpp:195
+#: ../src/common/fmapbase.cpp:192
 msgid "Extended Unix Codepage for Japanese (EUC-JP)"
 msgstr "Extended Unix Codepage voor Japans (EUC-JP)"
 
-#: ../src/html/chm.cpp:725
+#: ../src/html/chm.cpp:718
 #, c-format
 msgid "Extraction of '%s' into '%s' failed."
 msgstr "Extractie van '%s' in '%s' mislukt."
 
-#: ../src/common/accelcmn.cpp:249 ../src/common/accelcmn.cpp:344
+#: ../src/common/accelcmn.cpp:259 ../src/common/accelcmn.cpp:358
 msgid "F"
 msgstr "F"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:672
+#: ../src/propgrid/advprops.cpp:582
 msgid "Face Name"
 msgstr "Letterbeeld Naam"
 
-#: ../src/unix/snglinst.cpp:269
+#: ../src/unix/snglinst.cpp:266
 msgid "Failed to access lock file."
 msgstr "Toegang naar beveiligd bestand mislukt."
+
+#: ../src/gtk/font.cpp:572
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Lezen van document van het bestand \"%s\" mislukt."
 
 #: ../src/unix/epolldispatcher.cpp:116
 #, c-format
 msgid "Failed to add descriptor %d to epoll descriptor %d"
 msgstr "Kon geen descriptor %d toevoegen aan epoll descriptor %d"
 
-#: ../src/msw/dib.cpp:489
+#: ../src/msw/dib.cpp:535
 #, c-format
 msgid "Failed to allocate %luKb of memory for bitmap data."
 msgstr "Allokeren van %luKb geheugen voor bitmap-data is mislukt."
 
-#: ../src/common/glcmn.cpp:115
+#: ../src/common/glcmn.cpp:112
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Kon geen kleur allokeren voor OpenGL"
 
-#: ../src/unix/displayx11.cpp:236
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Kon geen kleur allokeren voor OpenGL"
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Kon geen kleur allokeren voor OpenGL"
+
+#: ../include/wx/unix/private/displayx11.h:89
 msgid "Failed to change video mode"
 msgstr "Kon video modus niet veranderen"
 
-#: ../src/common/image.cpp:3277
+#: ../src/common/image.cpp:3396
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Controleren van formaat afbeeldingsbestand \"%s\" mislukt."
 
-#: ../src/common/debugrpt.cpp:239
+#: ../src/common/debugrpt.cpp:240
 #, c-format
 msgid "Failed to clean up debug report directory \"%s\""
 msgstr "Opschonen van de foutopsporingsrapportage map  \"%s\" is mislukt"
 
-#: ../src/common/filename.cpp:192
+#: ../src/common/filename.cpp:189
 msgid "Failed to close file handle"
 msgstr "Sluiten van bestandshandle mislukt"
 
-#: ../src/unix/snglinst.cpp:340
+#: ../src/unix/snglinst.cpp:337
 #, c-format
 msgid "Failed to close lock file '%s'"
 msgstr "Sluiten van vergrendeld bestand '%s' mislukt"
 
-#: ../src/msw/clipbrd.cpp:112
+#: ../src/msw/clipbrd.cpp:110
 msgid "Failed to close the clipboard."
 msgstr "Sluiten van klembord mislukt."
 
-#: ../src/x11/utils.cpp:208
+#: ../src/x11/utils.cpp:170
 #, c-format
 msgid "Failed to close the display \"%s\""
 msgstr "Kon de display \"%s\" niet sluiten"
 
-#: ../src/msw/dialup.cpp:797
+#: ../src/msw/dialup.cpp:791
 msgid "Failed to connect: missing username/password."
 msgstr "Verbinding mislukt: gebruikersnaam/wachtwoord ontbreekt."
 
-#: ../src/msw/dialup.cpp:743
+#: ../src/msw/dialup.cpp:737
 msgid "Failed to connect: no ISP to dial."
 msgstr "Verbinding mislukt: geen internetaanbieder om te bellen."
 
-#: ../src/common/textfile.cpp:203
-#, c-format
-msgid "Failed to convert file \"%s\" to Unicode."
-msgstr "Conversie bestand \"%s\" naar Unicode mislukt."
-
-#: ../src/generic/logg.cpp:956
+#: ../src/generic/logg.cpp:953
 msgid "Failed to copy dialog contents to the clipboard."
 msgstr "Kopiëren inhoud dialoogvenster naar klembord mislukt."
 
-#: ../src/msw/registry.cpp:692
+#: ../src/msw/registry.cpp:681
 #, c-format
 msgid "Failed to copy registry value '%s'"
 msgstr "Kopiëren van registerwaarde '%s' mislukt"
 
-#: ../src/msw/registry.cpp:701
+#: ../src/msw/registry.cpp:690
 #, c-format
 msgid "Failed to copy the contents of registry key '%s' to '%s'."
 msgstr "Kopiëren van registersleutel '%s' naar '%s' mislukt."
 
-#: ../src/common/filefn.cpp:1015
+#: ../src/common/filefn.cpp:904
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Kopiëren van bestand '%s' naar '%s' mislukt"
 
-#: ../src/msw/registry.cpp:679
+#: ../src/msw/registry.cpp:668
 #, c-format
 msgid "Failed to copy the registry subkey '%s' to '%s'."
 msgstr "Kopiëren van registersubsleutel '%s' naar '%s' mislukt."
 
-#: ../src/msw/dde.cpp:1070
+#: ../src/msw/dde.cpp:1134
 msgid "Failed to create DDE string"
 msgstr "Maken van DDE-string mislukt"
 
-#: ../src/msw/mdi.cpp:616
+#: ../src/msw/mdi.cpp:621
 msgid "Failed to create MDI parent frame."
 msgstr "Maken van MDI-hoofdvenster mislukt."
 
-#: ../src/common/filename.cpp:1027
+#: ../src/common/filename.cpp:1024
 msgid "Failed to create a temporary file name"
 msgstr "Maken van een tijdelijke bestandsnaam mislukt"
 
-#: ../src/msw/utilsexc.cpp:228
+#: ../src/msw/utilsexc.cpp:225
 msgid "Failed to create an anonymous pipe"
 msgstr "Maken van een anonieme pipe mislukt"
 
-#: ../src/msw/ole/automtn.cpp:522
+#: ../src/msw/ole/automtn.cpp:513
 #, c-format
 msgid "Failed to create an instance of \"%s\""
 msgstr "Aanmaken exemplaarset van \"%s\" mislukt"
 
-#: ../src/msw/dde.cpp:437
+#: ../src/msw/dde.cpp:432
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "Maken van verbinding met server '%s' voor onderwerp '%s' mislukt"
 
-#: ../src/msw/cursor.cpp:204
+#: ../src/msw/cursor.cpp:195
 msgid "Failed to create cursor."
 msgstr "Cursor aanmaken mislukt."
 
-#: ../src/common/debugrpt.cpp:209
+#: ../src/common/debugrpt.cpp:210
 #, c-format
 msgid "Failed to create directory \"%s\""
 msgstr "Aanmaken map \"%s\" mislukt"
 
-#: ../src/generic/dirdlgg.cpp:220
+#: ../src/generic/dirdlgg.cpp:217
 #, c-format
 msgid ""
 "Failed to create directory '%s'\n"
@@ -3219,114 +3248,133 @@ msgstr ""
 msgid "Failed to create epoll descriptor"
 msgstr "Aanmaken epoll descriptor mislukt"
 
-#: ../src/msw/mimetype.cpp:238
+#: ../src/gtk/font.cpp:562
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "Updaten van gebruikersconfiguratie bestand is mislukt."
+
+#: ../src/msw/mimetype.cpp:235
 #, c-format
 msgid "Failed to create registry entry for '%s' files."
 msgstr "Maken van registersleutel '%s' mislukt."
 
-#: ../src/msw/fdrepdlg.cpp:409
+#: ../src/msw/fdrepdlg.cpp:408
 #, c-format
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr "Maken van het standaard zoek/vervang dialoog mislukt (foutcode %d)"
 
-#: ../src/unix/wakeuppipe.cpp:52
+#: ../src/unix/wakeuppipe.cpp:49
 msgid "Failed to create wake up pipe used by event loop."
 msgstr "Aanmaken wake-up pipe gebruikt door gebeurtenis-lus mislukt."
 
-#: ../src/html/winpars.cpp:730
+#: ../src/html/winpars.cpp:727
 #, c-format
 msgid "Failed to display HTML document in %s encoding"
 msgstr "Weergeven van HTML-document in %s-codering mislukt"
 
-#: ../src/msw/clipbrd.cpp:124
+#: ../src/msw/clipbrd.cpp:122
 msgid "Failed to empty the clipboard."
 msgstr "Legen van klembord mislukt."
 
-#: ../src/unix/displayx11.cpp:212
+#: ../include/wx/unix/private/displayx11.h:65
 msgid "Failed to enumerate video modes"
 msgstr "Enumereren van video modes mislukt"
 
-#: ../src/msw/dde.cpp:722
+#: ../src/msw/dde.cpp:717
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "Opzetten van advies-lus met de DDE-server mislukt"
 
-#: ../src/msw/dialup.cpp:629 ../src/msw/dialup.cpp:863
+#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Maken van inbelverbinding mislukt: %s"
 
-#: ../src/unix/utilsunx.cpp:611
+#: ../src/unix/utilsunx.cpp:613
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Uitvoeren van '%s' mislukt\n"
 
-#: ../src/common/debugrpt.cpp:720
+#: ../src/common/debugrpt.cpp:730
 msgid "Failed to execute curl, please install it in PATH."
 msgstr "Uitvoeren van curl mislukt, installeer het alstublieft in PATH."
 
-#: ../src/msw/ole/automtn.cpp:505
+#: ../src/msw/ole/automtn.cpp:496
 #, c-format
 msgid "Failed to find CLSID of \"%s\""
 msgstr "Vinden van CLSID \"%s\" mislukt."
 
-#: ../src/common/regex.cpp:431 ../src/common/regex.cpp:479
+#: ../src/common/regex.cpp:428 ../src/common/regex.cpp:476
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "Vinden van overeenkomst voor reguliere expressie '%s' mislukt"
 
-#: ../src/msw/dialup.cpp:695
+#: ../src/msw/webview_ie.cpp:978
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:689
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Verkrijgen van namen van internetaanbieders mislukt: %s"
 
-#: ../src/msw/ole/automtn.cpp:574
+#: ../src/msw/ole/automtn.cpp:565
 #, c-format
 msgid "Failed to get OLE automation interface for \"%s\""
 msgstr "Verkrijgen van OLE automation interface voor \"%s\" mislukt"
 
-#: ../src/msw/clipbrd.cpp:711
+#: ../src/msw/clipbrd.cpp:731
 msgid "Failed to get data from the clipboard"
 msgstr "Gegevens van klembord ophalen mislukt"
 
-#: ../src/common/time.cpp:223
+#: ../src/common/time.cpp:216
 msgid "Failed to get the local system time"
 msgstr "Verkrijgen van lokale systeemtijd mislukt"
 
-#: ../src/common/filefn.cpp:1345
+#: ../src/common/filefn.cpp:1233
 msgid "Failed to get the working directory"
 msgstr "Verkrijgen van de werk map mislukt"
 
-#: ../src/univ/theme.cpp:114
+#: ../src/univ/theme.cpp:111
 msgid "Failed to initialize GUI: no built-in themes found."
 msgstr "Initialiseren van GUI mislukt: Geen ingebouwd thema gevonden."
 
-#: ../src/msw/helpchm.cpp:63
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:60
 msgid "Failed to initialize MS HTML Help."
 msgstr "Initialiseren van MS HTML Help mislukt."
 
-#: ../src/msw/glcanvas.cpp:1381
+#: ../src/msw/glcanvas.cpp:1391
 msgid "Failed to initialize OpenGL"
 msgstr "Initialiseren van OpenGL mislukt"
 
-#: ../src/msw/dialup.cpp:858
+#: ../src/msw/dialup.cpp:852
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Maken van inbelverbinding mislukt: %s"
 
-#: ../src/gtk/textctrl.cpp:1128
+#: ../src/gtk/textctrl.cpp:1209
 msgid "Failed to insert text in the control."
 msgstr "Kan geen tekst aanbrengen in de control."
 
-#: ../src/unix/snglinst.cpp:241
+#: ../src/unix/snglinst.cpp:238
 #, c-format
 msgid "Failed to inspect the lock file '%s'"
 msgstr "Inspecteren van grendelbestand '%s' mislukt"
 
-#: ../src/unix/appunix.cpp:182
+#: ../src/unix/appunix.cpp:179
 msgid "Failed to install signal handler"
 msgstr "Installeren van signaal handler mislukt"
 
-#: ../src/unix/threadpsx.cpp:1167
+#: ../src/unix/threadpsx.cpp:1216
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -3334,71 +3382,71 @@ msgstr ""
 "Aansluiten bij een draadje mislukt, mogelijk geheugenlek aangetroffen - "
 "herstart het programma a.u.b"
 
-#: ../src/msw/utils.cpp:629
+#: ../src/msw/utils.cpp:619
 #, c-format
 msgid "Failed to kill process %d"
 msgstr "Abrupt afsluiten van proces %d mislukt"
 
-#: ../src/common/image.cpp:2500
+#: ../src/common/image.cpp:2595
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Laden van bitmap \"%s\" van bronnen mislukt."
 
-#: ../src/common/image.cpp:2509
+#: ../src/common/image.cpp:2604
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Laden van icoon \"%s\" van bronnen mislukt."
 
-#: ../src/common/iconbndl.cpp:225
+#: ../src/common/iconbndl.cpp:224
 #, c-format
 msgid "Failed to load icons from resource '%s'."
 msgstr "Kan geen pictogrammen laden van resource '%s'."
 
-#: ../src/common/iconbndl.cpp:200
+#: ../src/common/iconbndl.cpp:198
 #, c-format
 msgid "Failed to load image %%d from file '%s'."
 msgstr "Laden van afbeelding %%d van bestand '%s' mislukt."
 
-#: ../src/common/iconbndl.cpp:208
+#: ../src/common/iconbndl.cpp:206
 #, c-format
 msgid "Failed to load image %d from stream."
 msgstr "Laden van afbeelding %d van stream mislukt."
 
-#: ../src/common/image.cpp:2587 ../src/common/image.cpp:2606
+#: ../src/common/image.cpp:2682 ../src/common/image.cpp:2701
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Laden van afbeelding van bestand \"'%s\" mislukt."
 
-#: ../src/msw/enhmeta.cpp:97
+#: ../src/msw/enhmeta.cpp:94
 #, c-format
 msgid "Failed to load metafile from file \"%s\"."
 msgstr "Laden van metabestand uit bestand \"%s\" mislukt."
 
-#: ../src/msw/volume.cpp:327
+#: ../src/msw/volume.cpp:335
 msgid "Failed to load mpr.dll."
 msgstr "Laden van mpr.dll mislukt."
 
-#: ../src/msw/utils.cpp:953
+#: ../src/msw/utils.cpp:943
 #, c-format
 msgid "Failed to load resource \"%s\"."
 msgstr "Laden van bronbestand \"%s\" mislukt."
 
-#: ../src/common/dynlib.cpp:92
+#: ../src/common/dynlib.cpp:86
 #, c-format
 msgid "Failed to load shared library '%s'"
 msgstr "Laden van gedeelde bibliotheek '%s' mislukt"
 
-#: ../src/osx/core/sound.cpp:145
+#: ../src/osx/core/sound.cpp:143
 #, c-format
 msgid "Failed to load sound from \"%s\" (error %d)."
 msgstr "Laden van geluid \"%s\" mislukt (fout %d)."
 
-#: ../src/msw/utils.cpp:960
+#: ../src/msw/utils.cpp:950
 #, c-format
 msgid "Failed to lock resource \"%s\"."
 msgstr "Vergrendelen van bronbestand \"%s\" mislukt."
 
-#: ../src/unix/snglinst.cpp:198
+#: ../src/unix/snglinst.cpp:195
 #, c-format
 msgid "Failed to lock the lock file '%s'"
 msgstr "Vergrendelen van het vergrendelde bestand '%s' mislukt"
@@ -3408,33 +3456,38 @@ msgstr "Vergrendelen van het vergrendelde bestand '%s' mislukt"
 msgid "Failed to modify descriptor %d in epoll descriptor %d"
 msgstr "Modificeren van descriptor %d in epoll descriptor %d mislukt"
 
-#: ../src/common/filename.cpp:2575
+#: ../src/common/filename.cpp:2658
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Veranderen van bestandstijden van '%s' mislukt"
 
-#: ../src/common/selectdispatcher.cpp:258
+#: ../src/common/selectdispatcher.cpp:255
 msgid "Failed to monitor I/O channels"
 msgstr "Toezicht houden op I/O kanalen mislukt"
 
-#: ../src/common/filename.cpp:175
+#: ../src/common/filename.cpp:172
 #, c-format
 msgid "Failed to open '%s' for reading"
 msgstr "Openen van '%s'  voor lezen mislukt"
 
-#: ../src/common/filename.cpp:180
+#: ../src/common/filename.cpp:177
 #, c-format
 msgid "Failed to open '%s' for writing"
 msgstr "Openen van '%s'  voor schrijven mislukt"
 
-#: ../src/html/chm.cpp:141
+#: ../src/html/chm.cpp:138
 #, c-format
 msgid "Failed to open CHM archive '%s'."
 msgstr "Openen van CHM archief  '%s' mislukt."
 
-#: ../src/common/utilscmn.cpp:1126
+#: ../src/common/utilscmn.cpp:1140
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Openen van URL \"%s\" in standaard browser mislukt."
+
+#: ../src/common/hyperlnkcmn.cpp:133
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Openen van URL \"%s\" in standaard browser mislukt."
 
 #: ../include/wx/msw/private/fswatcher.h:92
@@ -3442,93 +3495,103 @@ msgstr "Openen van URL \"%s\" in standaard browser mislukt."
 msgid "Failed to open directory \"%s\" for monitoring."
 msgstr "Openen van map \"%s\"  voor controleren mislukt."
 
-#: ../src/x11/utils.cpp:227
+#: ../src/x11/utils.cpp:189
 #, c-format
 msgid "Failed to open display \"%s\"."
 msgstr "Openen van display \"%s\" mislukt."
 
-#: ../src/common/filename.cpp:1062
+#: ../src/common/filename.cpp:1059
 msgid "Failed to open temporary file."
 msgstr "Openen van tijdelijk bestand mislukt."
 
-#: ../src/msw/clipbrd.cpp:91
+#: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Openen van klembord mislukt."
 
-#: ../src/common/translation.cpp:1184
+#: ../src/common/translation.cpp:1226
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Kan Plural-Forms:'%s' niet parseren"
 
-#: ../src/unix/mediactrl.cpp:1214
+#: ../src/unix/mediactrl.cpp:1239
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Voorbereiden om \"%s\" af te spelen mislukt."
 
-#: ../src/msw/clipbrd.cpp:600
+#: ../src/msw/clipbrd.cpp:610
 msgid "Failed to put data on the clipboard"
 msgstr "Bewaren van gegevens op klembord mislukt"
 
-#: ../src/unix/snglinst.cpp:278
+#: ../src/unix/snglinst.cpp:275
 msgid "Failed to read PID from lock file."
 msgstr "Lezen van PID van vergrendeld bestand mislukt."
 
-#: ../src/common/fileconf.cpp:433
+#: ../src/common/fileconf.cpp:432
 msgid "Failed to read config options."
 msgstr "Lezen van config opties mislukt."
 
-#: ../src/common/docview.cpp:681
+#: ../src/common/docview.cpp:676
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Lezen van document van het bestand \"%s\" mislukt."
 
-#: ../src/dfb/evtloop.cpp:98
+#: ../src/dfb/evtloop.cpp:99
 msgid "Failed to read event from DirectFB pipe"
 msgstr "Lezen van gebeurtenis uit DirectFB pipe mislukt"
 
-#: ../src/unix/wakeuppipe.cpp:120
+#: ../src/unix/wakeuppipe.cpp:117
 msgid "Failed to read from wake-up pipe"
 msgstr "Lezen van wake-up pipe mislukt"
 
-#: ../src/unix/utilsunx.cpp:679
+#: ../src/common/textfile.cpp:96
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Lezen van document van het bestand \"%s\" mislukt."
+
+#: ../src/unix/utilsunx.cpp:681
 msgid "Failed to redirect child process input/output"
 msgstr "Omleiden van I/O van child proces mislukt"
 
-#: ../src/msw/utilsexc.cpp:701
+#: ../src/msw/utilsexc.cpp:698
 msgid "Failed to redirect the child process IO"
 msgstr "Omleiden van I/O van child proces mislukt"
 
-#: ../src/msw/dde.cpp:288
+#: ../src/msw/dde.cpp:283
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Registratie van DDE-server '%s' mislukt"
 
-#: ../src/common/fontmap.cpp:245
+#: ../src/gtk/font.cpp:580
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "Updaten van gebruikersconfiguratie bestand is mislukt."
+
+#: ../src/common/fontmap.cpp:242
 #, c-format
 msgid "Failed to remember the encoding for the charset '%s'."
 msgstr "Onthouden van codering voor tekenset '%s' mislukt."
 
-#: ../src/common/debugrpt.cpp:227
+#: ../src/common/debugrpt.cpp:228
 #, c-format
 msgid "Failed to remove debug report file \"%s\""
 msgstr "Verwijderen van foutopsporingsrapport bestand \"%s\" is mislukt."
 
-#: ../src/unix/snglinst.cpp:328
+#: ../src/unix/snglinst.cpp:325
 #, c-format
 msgid "Failed to remove lock file '%s'"
 msgstr "Verwijderen van vergrendeld bestand '%s' mislukt"
 
-#: ../src/unix/snglinst.cpp:288
+#: ../src/unix/snglinst.cpp:285
 #, c-format
 msgid "Failed to remove stale lock file '%s'."
 msgstr "Verwijderen van verouderd vergrendeld bestand '%s' mislukt."
 
-#: ../src/msw/registry.cpp:529
+#: ../src/msw/registry.cpp:518
 #, c-format
 msgid "Failed to rename registry value '%s' to '%s'."
 msgstr "Kan de naam van de registerwaarde '%s' niet wijzigen in '%s'."
 
-#: ../src/common/filefn.cpp:1122
+#: ../src/common/filefn.cpp:1011
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -3537,115 +3600,124 @@ msgstr ""
 "Hernoemen van het bestand ‘%s’ naar ‘%s’ mislukt omdat het doelbestand al "
 "bestaat."
 
-#: ../src/msw/registry.cpp:634
+#: ../src/msw/registry.cpp:623
 #, c-format
 msgid "Failed to rename the registry key '%s' to '%s'."
 msgstr "Kan de naam van de registersleutel '%s' niet wijzigen in '%s'."
 
-#: ../src/common/filename.cpp:2671
+#: ../src/msw/webview_ie.cpp:995
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/common/filename.cpp:2754
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Verkrijgen van bestandstijden voor '%s' mislukt"
 
-#: ../src/msw/dialup.cpp:468
+#: ../src/msw/dialup.cpp:462
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Verkrijgen van tekst van inbel-foutmelding mislukt"
 
-#: ../src/msw/clipbrd.cpp:748
+#: ../src/msw/clipbrd.cpp:768
 msgid "Failed to retrieve the supported clipboard formats"
 msgstr "Verkrijgen van ondersteunde klembord-formaten mislukt"
 
-#: ../src/common/docview.cpp:652
+#: ../src/common/docview.cpp:647
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Opslaan van document naar het bestand \"%s\" mislukt."
 
-#: ../src/msw/dib.cpp:269
+#: ../src/msw/dib.cpp:312
 #, c-format
 msgid "Failed to save the bitmap image to file \"%s\"."
 msgstr "Opslaan van bitmap afbeelding naar bestand \"%s\" mislukt."
 
-#: ../src/msw/dde.cpp:763
+#: ../src/msw/dde.cpp:811
 msgid "Failed to send DDE advise notification"
 msgstr "Versturen van DDE-adviesnotificatie mislukt"
 
-#: ../src/common/ftp.cpp:402
+#: ../src/common/ftp.cpp:399
 #, c-format
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Instellen van FTP transfer mode naar %s mislukt."
 
-#: ../src/msw/clipbrd.cpp:427
+#: ../src/msw/clipbrd.cpp:443
 msgid "Failed to set clipboard data."
 msgstr "Instellen van klembordgegevens mislukt."
 
-#: ../src/unix/snglinst.cpp:181
+#: ../src/unix/snglinst.cpp:178
 #, c-format
 msgid "Failed to set permissions on lock file '%s'"
 msgstr "Instellen van permissies op grendelbestand '%s' mislukt"
 
-#: ../src/unix/utilsunx.cpp:668
+#: ../src/unix/utilsunx.cpp:670
 msgid "Failed to set process priority"
 msgstr "Instellen van prioriteit van proces mislukt"
 
-#: ../src/common/file.cpp:559
+#: ../src/common/ffile.cpp:355 ../src/common/file.cpp:586
 msgid "Failed to set temporary file permissions"
 msgstr "Instellen van machtigingen van tijdelijk bestand mislukt"
 
-#: ../src/gtk/textctrl.cpp:1072
-msgid "Failed to set text in the text control."
-msgstr "Kan geen tekst aanbrengen in tekst-control."
-
-#: ../src/unix/threadpsx.cpp:1298
+#: ../src/unix/threadpsx.cpp:1347
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Instellen van concurrency-niveau van thread op %lu mislukt"
 
-#: ../src/unix/threadpsx.cpp:1424
+#: ../src/unix/threadpsx.cpp:1473
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Instellen van prioriteit van thread %d mislukt."
 
-#: ../src/unix/utilsunx.cpp:783
+#: ../src/unix/utilsunx.cpp:785
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr "Niet-blokkerende pipe instellen mislukt. Het programma kan hangen."
 
-#: ../src/common/fs_mem.cpp:261
+#: ../src/msw/webview_ie.cpp:987
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:256
 #, c-format
 msgid "Failed to store image '%s' to memory VFS!"
 msgstr "Opslaan van afbeelding '%s' in geheugen VFS mislukt!"
 
-#: ../src/dfb/evtloop.cpp:170
+#: ../src/dfb/evtloop.cpp:171
 msgid "Failed to switch DirectFB pipe to non-blocking mode"
 msgstr "Kan directfb-pijp niet overschakelen naar niet-blokkerende modus"
 
-#: ../src/unix/wakeuppipe.cpp:59
+#: ../src/unix/wakeuppipe.cpp:56
 msgid "Failed to switch wake up pipe to non-blocking mode"
 msgstr "Kan de wake-up-pipe niet overschakelen naar de niet-blokkerende modus"
 
-#: ../src/unix/threadpsx.cpp:1605
+#: ../src/unix/threadpsx.cpp:1654
 msgid "Failed to terminate a thread."
 msgstr "Beëindigen van thread mislukt."
 
-#: ../src/msw/dde.cpp:741
+#: ../src/msw/dde.cpp:736
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "Beëindigen van advies-lus met de DDE-server mislukt"
 
-#: ../src/msw/dialup.cpp:938
+#: ../src/msw/dialup.cpp:932
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Ophangen van inbelverbinding mislukt: %s"
 
-#: ../src/common/filename.cpp:2590
+#: ../src/common/filename.cpp:2673
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Touchen van bestand '%s' mislukt"
 
-#: ../src/unix/snglinst.cpp:334
+#: ../src/unix/dlunix.cpp:90
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "Laden van gedeelde bibliotheek '%s' mislukt"
+
+#: ../src/unix/snglinst.cpp:331
 #, c-format
 msgid "Failed to unlock lock file '%s'"
 msgstr "Ontgrendelen van het vergrendelde bestand '%s' mislukt"
 
-#: ../src/msw/dde.cpp:309
+#: ../src/msw/dde.cpp:304
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Deregistreren van DDE-server %s mislukt"
@@ -3660,77 +3732,87 @@ msgstr ""
 msgid "Failed to update user configuration file."
 msgstr "Updaten van gebruikersconfiguratie bestand is mislukt."
 
-#: ../src/common/debugrpt.cpp:733
+#: ../src/common/debugrpt.cpp:743
 #, c-format
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Uploaden van het foutopsporingsrapport is mislukt (foutcode %d)."
 
-#: ../src/unix/snglinst.cpp:168
+#: ../src/unix/snglinst.cpp:165
 #, c-format
 msgid "Failed to write to lock file '%s'"
 msgstr "Schrijven naar vergrendeld bestand '%s' mislukt"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:209
+#: ../src/propgrid/propgrid.cpp:190
 msgid "False"
 msgstr "Onwaar"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:694
+#: ../src/propgrid/advprops.cpp:604
 msgid "Family"
 msgstr "Familie"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/gtk/glcanvas.cpp:176 ../src/gtk/glcanvas.cpp:187
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Bestandsfout"
+
+#: ../src/common/stockitem.cpp:154
 msgid "File"
 msgstr "Bestand"
 
-#: ../src/common/docview.cpp:669
+#: ../src/common/docview.cpp:664
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Openen van bestand \"%s\"  voor lezen mislukt."
 
-#: ../src/common/docview.cpp:646
+#: ../src/common/docview.cpp:641
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Openen van bestand \"%s\" voor schrijven mislukt."
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "Bestand '%s' bestaat al, overschrijven?"
 
-#: ../src/common/filefn.cpp:1156
+#: ../src/common/filefn.cpp:1044
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Bestand '%s' kon niet worden verwijderd"
 
-#: ../src/common/filefn.cpp:1139
+#: ../src/common/filefn.cpp:1028
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Bestand '%s' kon niet worden hernoemd naar '%s'"
 
-#: ../src/richtext/richtextctrl.cpp:3081 ../src/common/textcmn.cpp:953
+#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
 msgid "File couldn't be loaded."
 msgstr "Bestand kon niet worden geladen."
 
-#: ../src/msw/filedlg.cpp:393
+#: ../src/msw/filedlg.cpp:414
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Bestandsdialoog mislukt met foutcode %0lx."
 
-#: ../src/common/docview.cpp:1789
+#: ../src/common/docview.cpp:1783
 msgid "File error"
 msgstr "Bestandsfout"
 
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/filectrlg.cpp:770
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/filectrlg.cpp:766
 msgid "File name exists already."
 msgstr "Bestandsnaam bestaat al."
+
+#: ../src/osx/cocoa/filedlg.mm:264
+#, fuzzy
+msgid "File type:"
+msgstr "Niet proportioneel (Teletype)"
 
 #: ../src/motif/filedlg.cpp:220
 msgid "Files"
 msgstr "Bestanden"
 
-#: ../src/common/filefn.cpp:1591
+#: ../src/common/filefn.cpp:1479
 #, c-format
 msgid "Files (%s)"
 msgstr "Bestanden (%s)"
@@ -3739,15 +3821,29 @@ msgstr "Bestanden (%s)"
 msgid "Filter"
 msgstr "Filter"
 
-#: ../src/common/stockitem.cpp:158 ../src/html/helpwnd.cpp:490
+#: ../src/html/helpwnd.cpp:488
 msgid "Find"
 msgstr "Zoeken"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:259
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:258
+#, fuzzy
+msgid "Find in document"
+msgstr "HTML-document openen"
+
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "Find..."
+msgstr "Zoeken"
+
+#: ../src/common/stockitem.cpp:156
 msgid "First"
 msgstr "Eerste"
 
-#: ../src/common/prntbase.cpp:1548
+#: ../src/common/prntbase.cpp:1573
 msgid "First page"
 msgstr "Eerste pagina"
 
@@ -3755,11 +3851,11 @@ msgstr "Eerste pagina"
 msgid "Fixed"
 msgstr "Vast"
 
-#: ../src/html/helpwnd.cpp:1206
+#: ../src/html/helpwnd.cpp:1204
 msgid "Fixed font:"
 msgstr "Niet proportioneel lettertype:"
 
-#: ../src/html/helpwnd.cpp:1269
+#: ../src/html/helpwnd.cpp:1267
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Lettertype met vaste breedte.<br> <b>vet</b> <i>cursief</i> "
 
@@ -3767,16 +3863,16 @@ msgstr "Lettertype met vaste breedte.<br> <b>vet</b> <i>cursief</i> "
 msgid "Floating"
 msgstr "Zwevend"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "Floppy"
 msgstr "Diskette"
 
-#: ../src/common/paper.cpp:111
+#: ../src/common/paper.cpp:108
 msgid "Folio, 8 1/2 x 13 in"
 msgstr "Folio, 8 1/2 x 13 inch"
 
-#: ../src/richtext/richtextformatdlg.cpp:344 ../src/osx/carbon/fontdlg.cpp:287
-#: ../src/common/stockitem.cpp:194
+#: ../src/osx/carbon/fontdlg.cpp:284 ../src/common/stockitem.cpp:191
+#: ../src/richtext/richtextformatdlg.cpp:337
 msgid "Font"
 msgstr "Lettertype"
 
@@ -3784,7 +3880,24 @@ msgstr "Lettertype"
 msgid "Font &weight:"
 msgstr "Lettertype z&waarte:"
 
-#: ../src/html/helpwnd.cpp:1207
+#: ../src/osx/fontutil.cpp:89
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
+"\"."
+msgstr ""
+
+#: ../src/msw/font.cpp:1126
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Bestand kon niet worden geladen."
+
+#: ../src/osx/fontutil.cpp:81
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr ": bestand bestaat niet!"
+
+#: ../src/html/helpwnd.cpp:1205
 msgid "Font size:"
 msgstr "Lettertype-grootte:"
 
@@ -3792,54 +3905,54 @@ msgstr "Lettertype-grootte:"
 msgid "Font st&yle:"
 msgstr "Lettertype st&ijl:"
 
-#: ../src/osx/carbon/fontdlg.cpp:329
+#: ../src/osx/carbon/fontdlg.cpp:326
 msgid "Font:"
 msgstr "Lettertype:"
 
-#: ../src/dfb/fontmgr.cpp:198
+#: ../src/dfb/fontmgr.cpp:195
 #, c-format
 msgid "Fonts index file %s disappeared while loading fonts."
 msgstr ""
 "Lettertype index bestand %s verdwenen tijdens het laden van lettertypes."
 
-#: ../src/unix/utilsunx.cpp:645
+#: ../src/unix/utilsunx.cpp:647
 msgid "Fork failed"
 msgstr "Vork mislukt"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "Forward"
 msgstr "Verder"
 
-#: ../src/common/xtixml.cpp:235
+#: ../src/common/xtixml.cpp:231
 msgid "Forward hrefs are not supported"
 msgstr "Doorsturen van hrefs wordt niet ondersteund"
 
-#: ../src/html/helpwnd.cpp:875
+#: ../src/html/helpwnd.cpp:873
 #, c-format
 msgid "Found %i matches"
 msgstr "%i Overeenkomsten gevonden"
 
-#: ../src/generic/prntdlgg.cpp:238
+#: ../src/generic/prntdlgg.cpp:231
 msgid "From:"
 msgstr "Van:"
 
-#: ../src/propgrid/advprops.cpp:1604
+#: ../src/propgrid/advprops.cpp:1510
 msgid "Fuchsia"
 msgstr "Fuchsiapaars"
 
-#: ../src/common/imaggif.cpp:138
+#: ../src/common/imaggif.cpp:135
 msgid "GIF: data stream seems to be truncated."
 msgstr "GIF: gegevensstroom lijkt afgekapt."
 
-#: ../src/common/imaggif.cpp:128
+#: ../src/common/imaggif.cpp:125
 msgid "GIF: error in GIF image format."
 msgstr "GIF: fout in GIF-bestandsformaat."
 
-#: ../src/common/imaggif.cpp:133
+#: ../src/common/imaggif.cpp:130
 msgid "GIF: not enough memory."
 msgstr "GIF: onvoldoende geheugen."
 
-#: ../src/gtk/window.cpp:4631
+#: ../src/gtk/window.cpp:5635
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -3847,23 +3960,23 @@ msgstr ""
 "GTK+ geïnstalleerd op deze machine is te oud om schermsamenstellingen te "
 "ondersteunen. Installeer GTK+ 2.12 of nieuwer."
 
-#: ../src/univ/themes/gtk.cpp:525
+#: ../src/univ/themes/gtk.cpp:522
 msgid "GTK+ theme"
 msgstr "GTK+ thema"
 
-#: ../src/common/preferencescmn.cpp:40
+#: ../src/common/preferencescmn.cpp:37
 msgid "General"
 msgstr "Algemeen"
 
-#: ../src/common/prntbase.cpp:258
+#: ../src/common/prntbase.cpp:253
 msgid "Generic PostScript"
 msgstr "Generiek Postscript"
 
-#: ../src/common/paper.cpp:135
+#: ../src/common/paper.cpp:132
 msgid "German Legal Fanfold, 8 1/2 x 13 in"
 msgstr "Duitse Legal Fanfold, 8 1/2 x 13 inch"
 
-#: ../src/common/paper.cpp:134
+#: ../src/common/paper.cpp:131
 msgid "German Std Fanfold, 8 1/2 x 12 in"
 msgstr "Duitse Std Fanfold, 8 1/2 x 12 inch"
 
@@ -3879,48 +3992,48 @@ msgstr "GetPropertyCollection aangeroepen op een generieke “accessor”"
 msgid "GetPropertyCollection called w/o valid collection getter"
 msgstr "GetPropertyCollection aangeroepen zonder geldige “collection getter”"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:658
 msgid "Go back"
 msgstr "Ga terug"
 
-#: ../src/html/helpwnd.cpp:661
+#: ../src/html/helpwnd.cpp:659
 msgid "Go forward"
 msgstr "Ga vooruit"
 
-#: ../src/html/helpwnd.cpp:663
+#: ../src/html/helpwnd.cpp:661
 msgid "Go one level up in document hierarchy"
 msgstr "Ga niveau hoger in document-hiërarchie"
 
-#: ../src/generic/filedlgg.cpp:208 ../src/generic/dirdlgg.cpp:116
+#: ../src/generic/filedlgg.cpp:205 ../src/generic/dirdlgg.cpp:113
 msgid "Go to home directory"
 msgstr "Ga naar startmap"
 
-#: ../src/generic/filedlgg.cpp:205
+#: ../src/generic/filedlgg.cpp:202
 msgid "Go to parent directory"
 msgstr "Ga naar bovenliggende map"
 
-#: ../src/generic/aboutdlgg.cpp:76
+#: ../src/generic/aboutdlgg.cpp:73
 msgid "Graphics art by "
 msgstr "Grafische kunst door "
 
-#: ../src/propgrid/advprops.cpp:1599
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Gray"
 msgstr "Grijs"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:883
+#: ../src/propgrid/advprops.cpp:784
 msgid "GrayText"
 msgstr "GrayText"
 
-#: ../src/common/fmapbase.cpp:154
+#: ../src/common/fmapbase.cpp:151
 msgid "Greek (ISO-8859-7)"
 msgstr "Grieks (ISO-8859-7)"
 
-#: ../src/propgrid/advprops.cpp:1600
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Green"
 msgstr "Groen"
 
-#: ../src/generic/colrdlgg.cpp:342
+#: ../src/generic/colrdlgg.cpp:362
 msgid "Green:"
 msgstr "Groen:"
 
@@ -3928,107 +4041,107 @@ msgstr "Groen:"
 msgid "Groove"
 msgstr "Groef"
 
-#: ../src/common/zstream.cpp:158 ../src/common/zstream.cpp:318
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
 msgid "Gzip not supported by this version of zlib"
 msgstr "Gzip niet ondersteund door deze versie van zlib"
 
-#: ../src/html/helpwnd.cpp:1549
+#: ../src/html/helpwnd.cpp:1547
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "HTML Help Project (*.hhp)|*.hhp|"
 
-#: ../src/html/htmlwin.cpp:681
+#: ../src/html/htmlwin.cpp:691
 #, c-format
 msgid "HTML anchor %s does not exist."
 msgstr "HTML-anchor %s bestaat niet."
 
-#: ../src/html/helpwnd.cpp:1547
+#: ../src/html/helpwnd.cpp:1545
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "HTML bestanden (*.html;*.htm)|*.html;*.htm|"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1759
+#: ../src/propgrid/advprops.cpp:1660
 msgid "Hand"
 msgstr "Hand"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "Harddisk"
 msgstr "Hardeschijf"
 
-#: ../src/common/fmapbase.cpp:155
+#: ../src/common/fmapbase.cpp:152
 msgid "Hebrew (ISO-8859-8)"
 msgstr "Hebreeuws (ISO-8859-8)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:280 ../src/osx/button_osx.cpp:39
-#: ../src/common/stockitem.cpp:163 ../src/common/accelcmn.cpp:80
-#: ../src/html/helpdlg.cpp:66 ../src/html/helpfrm.cpp:111
+#: ../include/wx/msgdlg.h:282 ../src/osx/button_osx.cpp:39
+#: ../src/common/stockitem.cpp:160 ../src/common/accelcmn.cpp:77
+#: ../src/html/helpfrm.cpp:108 ../src/html/helpdlg.cpp:63
 msgid "Help"
 msgstr "Help"
 
-#: ../src/html/helpwnd.cpp:1200
+#: ../src/html/helpwnd.cpp:1198
 msgid "Help Browser Options"
 msgstr "Help Browser Instellingen"
 
-#: ../src/generic/helpext.cpp:454 ../src/generic/helpext.cpp:455
+#: ../src/generic/helpext.cpp:452 ../src/generic/helpext.cpp:453
 msgid "Help Index"
 msgstr "Help Index"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1529
 msgid "Help Printing"
 msgstr "Help Afdrukken"
 
-#: ../src/html/helpwnd.cpp:801
+#: ../src/html/helpwnd.cpp:799
 msgid "Help Topics"
 msgstr "Hulp-onderwerpen"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1546
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Helpboeken (*.htb)|*.htb|Helpboeken (*.zip)|*.zip|"
 
-#: ../src/generic/helpext.cpp:267
+#: ../src/generic/helpext.cpp:265
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "Helpmap \"%s\" niet gevonden."
 
-#: ../src/generic/helpext.cpp:275
+#: ../src/generic/helpext.cpp:273
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "Helpbestand \"%s\" niet gevonden."
 
-#: ../src/html/helpctrl.cpp:63
+#: ../src/html/helpctrl.cpp:59
 #, c-format
 msgid "Help: %s"
 msgstr "Help: %s"
 
-#: ../src/osx/menu_osx.cpp:577
+#: ../src/osx/menu_osx.cpp:469
 #, c-format
 msgid "Hide %s"
 msgstr "Verberg %s"
 
-#: ../src/osx/menu_osx.cpp:579
+#: ../src/osx/menu_osx.cpp:471
 msgid "Hide Others"
 msgstr "Verberg anderen"
 
-#: ../src/generic/infobar.cpp:84
+#: ../src/generic/infobar.cpp:81
 msgid "Hide this notification message."
 msgstr "Verberg dit notificatiebericht."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:884
+#: ../src/propgrid/advprops.cpp:785
 msgid "Highlight"
 msgstr "Markeer"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:885
+#: ../src/propgrid/advprops.cpp:786
 msgid "HighlightText"
 msgstr "Gemarkeerde tekst"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:164 ../src/common/accelcmn.cpp:65
+#: ../src/common/stockitem.cpp:161 ../src/common/accelcmn.cpp:62
 msgid "Home"
 msgstr "Thuis"
 
-#: ../src/generic/dirctrlg.cpp:524
+#: ../src/generic/dirctrlg.cpp:490
 msgid "Home directory"
 msgstr "Thuismap"
 
@@ -4038,55 +4151,55 @@ msgid "How the object will float relative to the text."
 msgstr "Hoe het object zweeft relatief t.o.v. de tekst."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1760
+#: ../src/propgrid/advprops.cpp:1661
 msgid "I-Beam"
 msgstr "I-Beam"
 
-#: ../src/common/imagbmp.cpp:1196
+#: ../src/common/imagbmp.cpp:1208
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: Fout bij lezen masker DIB."
 
-#: ../src/common/imagbmp.cpp:1290 ../src/common/imagbmp.cpp:1390
-#: ../src/common/imagbmp.cpp:1405 ../src/common/imagbmp.cpp:1416
-#: ../src/common/imagbmp.cpp:1430 ../src/common/imagbmp.cpp:1478
-#: ../src/common/imagbmp.cpp:1493 ../src/common/imagbmp.cpp:1507
-#: ../src/common/imagbmp.cpp:1518
+#: ../src/common/imagbmp.cpp:1302 ../src/common/imagbmp.cpp:1402
+#: ../src/common/imagbmp.cpp:1417 ../src/common/imagbmp.cpp:1428
+#: ../src/common/imagbmp.cpp:1442 ../src/common/imagbmp.cpp:1490
+#: ../src/common/imagbmp.cpp:1505 ../src/common/imagbmp.cpp:1519
+#: ../src/common/imagbmp.cpp:1530
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: Fout bij het wegschrijven van de afbeelding!"
 
-#: ../src/common/imagbmp.cpp:1255
+#: ../src/common/imagbmp.cpp:1267
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: Afbeelding is te hoog voor een pictogram."
 
-#: ../src/common/imagbmp.cpp:1263
+#: ../src/common/imagbmp.cpp:1275
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: Afbeelding is te breed voor een pictogram."
 
-#: ../src/common/imagbmp.cpp:1603
+#: ../src/common/imagbmp.cpp:1615
 msgid "ICO: Invalid icon index."
 msgstr "ICO: Ongeldige pictogram index."
 
-#: ../src/common/imagiff.cpp:758
+#: ../src/common/imagiff.cpp:755
 msgid "IFF: data stream seems to be truncated."
 msgstr "IFFF: gegevensstroom lijkt afgekapt."
 
-#: ../src/common/imagiff.cpp:742
+#: ../src/common/imagiff.cpp:739
 msgid "IFF: error in IFF image format."
 msgstr "IFF: fout in IFF bestandsformaat."
 
-#: ../src/common/imagiff.cpp:745
+#: ../src/common/imagiff.cpp:742
 msgid "IFF: not enough memory."
 msgstr "IFF: onvoldoende geheugen."
 
-#: ../src/common/imagiff.cpp:748
+#: ../src/common/imagiff.cpp:745
 msgid "IFF: unknown error!!!"
 msgstr "IFF: onbekende fout!!!"
 
-#: ../src/common/fmapbase.cpp:197
+#: ../src/common/fmapbase.cpp:194
 msgid "ISO-2022-JP"
 msgstr "ISO-2022-JP"
 
-#: ../src/html/htmprint.cpp:282
+#: ../src/html/htmprint.cpp:294
 msgid ""
 "If possible, try changing the layout parameters to make the printout more "
 "narrow."
@@ -4094,7 +4207,7 @@ msgstr ""
 "Indien mogelijk, probeer de opmaakparameters te veranderen om de afdruk "
 "smaller te maken."
 
-#: ../src/generic/dbgrptg.cpp:358
+#: ../src/generic/dbgrptg.cpp:362
 msgid ""
 "If you have any additional information pertaining to this bug\n"
 "report, please enter it here and it will be joined to it:"
@@ -4115,46 +4228,50 @@ msgstr ""
 "verhinderen, dus als\n"
 "het enigszins mogelijk is, ga dan door met het genereren van het rapport.\n"
 
-#: ../src/msw/registry.cpp:1405
+#: ../src/common/zipstrm.cpp:1043
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1393
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Negeren van waarde \"%s\" van de sleutel \"%s\"."
 
-#: ../src/common/xtistrm.cpp:295
+#: ../src/common/xtistrm.cpp:292
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Illegale Object Class (Non-wxEvtHandler) als Event Source"
 
-#: ../src/common/xti.cpp:513
+#: ../src/common/xti.cpp:510
 msgid "Illegal Parameter Count for ConstructObject Method"
 msgstr "Ilegale aantal Parameters voor ConstructObject Methode"
 
-#: ../src/common/xti.cpp:501
+#: ../src/common/xti.cpp:498
 msgid "Illegal Parameter Count for Create Method"
 msgstr "Ilegale aantal Parameters voor Create Methode"
 
-#: ../src/generic/dirctrlg.cpp:570 ../src/generic/filectrlg.cpp:756
+#: ../src/generic/dirctrlg.cpp:536 ../src/generic/filectrlg.cpp:752
 msgid "Illegal directory name."
 msgstr "Ongeldige mapnaam."
 
-#: ../src/generic/filectrlg.cpp:1367
+#: ../src/generic/filectrlg.cpp:1356
 msgid "Illegal file specification."
 msgstr "Ongeldige bestandsspecificatie."
 
-#: ../src/common/image.cpp:2269
+#: ../src/common/image.cpp:2363
 msgid "Image and mask have different sizes."
 msgstr "Afbeelding en masker hebben verschillende afmetingen."
 
-#: ../src/common/image.cpp:2746
+#: ../src/common/image.cpp:2841
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "Afbeeldingsbestand is niet van type %d."
 
-#: ../src/common/image.cpp:2877
+#: ../src/common/image.cpp:2995
 #, c-format
 msgid "Image is not of type %s."
 msgstr "Afbeelding is niet van type %s."
 
-#: ../src/msw/textctrl.cpp:488
+#: ../src/msw/textctrl.cpp:534
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -4162,100 +4279,100 @@ msgstr ""
 "Niet mogelijk om Rich Edit control te maken, gewone tekst wordt gebruikt. "
 "Installeer riched32.dll a.u.b. opnieuw"
 
-#: ../src/unix/utilsunx.cpp:301
+#: ../src/unix/utilsunx.cpp:303
 msgid "Impossible to get child process input"
 msgstr "Onmogelijk om child proces input te verkrijgen"
 
-#: ../src/common/filefn.cpp:1028
+#: ../src/common/filefn.cpp:917
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Onmogelijk om machtigingen voor bestand '%s' te krijgen"
 
-#: ../src/common/filefn.cpp:1042
+#: ../src/common/filefn.cpp:931
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Overschrijven van bestand '%s' mislukt"
 
-#: ../src/common/filefn.cpp:1097
+#: ../src/common/filefn.cpp:986
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Onmogelijk om machtigingen voor het bestand '%s' in te stellen"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:886
+#: ../src/propgrid/advprops.cpp:787
 msgid "InactiveBorder"
 msgstr "InactiveBorder"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:887
+#: ../src/propgrid/advprops.cpp:788
 msgid "InactiveCaption"
 msgstr "InactiveCaption"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:888
+#: ../src/propgrid/advprops.cpp:789
 msgid "InactiveCaptionText"
 msgstr "InactiveCaptionText"
 
-#: ../src/common/gifdecod.cpp:792
+#: ../src/common/gifdecod.cpp:826
 #, c-format
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "Onjuiste GIF frame grootte (%u, %d) voor het frame #%u"
 
-#: ../src/msw/ole/automtn.cpp:635
+#: ../src/msw/ole/automtn.cpp:626
 msgid "Incorrect number of arguments."
 msgstr "Onjuist aantal argumenten."
 
-#: ../src/common/stockitem.cpp:165
+#: ../src/common/stockitem.cpp:162
 msgid "Indent"
 msgstr "Inspringen"
 
-#: ../src/richtext/richtextformatdlg.cpp:349
+#: ../src/richtext/richtextformatdlg.cpp:342
 msgid "Indents && Spacing"
 msgstr "Inspringingen && Tussenruimtes"
 
-#: ../src/common/stockitem.cpp:166 ../src/html/helpwnd.cpp:515
+#: ../src/common/stockitem.cpp:163 ../src/html/helpwnd.cpp:513
 msgid "Index"
 msgstr "Index"
 
-#: ../src/common/fmapbase.cpp:159
+#: ../src/common/fmapbase.cpp:156
 msgid "Indian (ISO-8859-12)"
 msgstr "Indisch (ISO-8859-12)"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "Info"
 msgstr "Info"
 
-#: ../src/common/init.cpp:287
+#: ../src/common/init.cpp:284
 msgid "Initialization failed in post init, aborting."
 msgstr "Initialisatie mislukt in post init: voortijdig beëindigd.."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:54
+#: ../src/common/accelcmn.cpp:51
 msgid "Ins"
 msgstr "Ins"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextsymboldlg.cpp:472 ../src/common/accelcmn.cpp:53
+#: ../src/common/accelcmn.cpp:50 ../src/richtext/richtextsymboldlg.cpp:469
 msgid "Insert"
 msgstr "Invoegen"
 
-#: ../src/richtext/richtextbuffer.cpp:8067
+#: ../src/richtext/richtextbuffer.cpp:8063
 msgid "Insert Field"
 msgstr "Veld invoegen"
 
-#: ../src/richtext/richtextbuffer.cpp:7978
-#: ../src/richtext/richtextbuffer.cpp:8936
+#: ../src/richtext/richtextbuffer.cpp:7974
+#: ../src/richtext/richtextbuffer.cpp:8934
 msgid "Insert Image"
 msgstr "Afbeelding Invoegen"
 
-#: ../src/richtext/richtextbuffer.cpp:8025
+#: ../src/richtext/richtextbuffer.cpp:8021
 msgid "Insert Object"
 msgstr "Object invoegen"
 
-#: ../src/richtext/richtextctrl.cpp:1286 ../src/richtext/richtextctrl.cpp:1494
-#: ../src/richtext/richtextbuffer.cpp:7822
-#: ../src/richtext/richtextbuffer.cpp:7852
-#: ../src/richtext/richtextbuffer.cpp:7894
+#: ../src/richtext/richtextbuffer.cpp:7818
+#: ../src/richtext/richtextbuffer.cpp:7848
+#: ../src/richtext/richtextbuffer.cpp:7890
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
 msgid "Insert Text"
 msgstr "Tekst invoegen"
 
@@ -4268,16 +4385,11 @@ msgstr "Een pagina-einde invoegen voor de paragraaf."
 msgid "Inset"
 msgstr "Invoeging"
 
-#: ../src/gtk/app.cpp:425
-#, c-format
-msgid "Invalid GTK+ command line option, use \"%s --help\""
-msgstr "Ongeldig GTK+ commandoregel  optie, gebruik \"%s --help\""
-
-#: ../src/common/imagtiff.cpp:311
+#: ../src/common/imagtiff.cpp:308
 msgid "Invalid TIFF image index."
 msgstr "Ongeldige TIFF-afbeeldingsindex."
 
-#: ../src/common/appcmn.cpp:273
+#: ../src/common/appcmn.cpp:294
 #, c-format
 msgid "Invalid display mode specification '%s'."
 msgstr "Ongeldige beeldscherm mode specificatie. '%s'."
@@ -4287,247 +4399,251 @@ msgstr "Ongeldige beeldscherm mode specificatie. '%s'."
 msgid "Invalid geometry specification '%s'"
 msgstr "Ongeldige geometrie specificatie '%s'"
 
-#: ../src/unix/fswatcher_inotify.cpp:323
+#: ../src/unix/fswatcher_inotify.cpp:320
 #, c-format
 msgid "Invalid inotify event for \"%s\""
 msgstr "Ongeldige inotify-gebeurtenis voor \"%s\""
 
-#: ../src/unix/snglinst.cpp:312
+#: ../src/unix/snglinst.cpp:309
 #, c-format
 msgid "Invalid lock file '%s'."
 msgstr "Ongeldig vergrendeld bestand '%s'."
 
-#: ../src/common/translation.cpp:1125
+#: ../src/common/translation.cpp:1167
 msgid "Invalid message catalog."
 msgstr "Ongeldige berichtencatalogus."
 
-#: ../src/common/xtistrm.cpp:405 ../src/common/xtistrm.cpp:420
+#: ../src/common/xtistrm.cpp:402 ../src/common/xtistrm.cpp:417
 msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
 msgstr "Ongeldig of Null Object ID doorgegeven naar GetObjectClassInfo"
 
-#: ../src/common/xtistrm.cpp:435
+#: ../src/common/xtistrm.cpp:432
 msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
 msgstr "Ongeldig of Null Object ID doorgegeven naar HasObjectClassInfo"
 
-#: ../src/common/regex.cpp:310
+#: ../src/common/regex.cpp:307
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Ongeldige reguliere expressie '%s': %s"
 
-#: ../src/common/config.cpp:226
+#: ../src/common/config.cpp:222
 #, c-format
 msgid "Invalid value %ld for a boolean key \"%s\" in config file."
 msgstr ""
 "Ongeldige waarde %ld voor een boolean sleutel \"%s\" in config bestand."
 
-#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:351
-#: ../src/osx/carbon/fontdlg.cpp:361 ../src/common/stockitem.cpp:168
+#: ../src/osx/carbon/fontdlg.cpp:358 ../src/common/stockitem.cpp:165
+#: ../src/generic/fontdlgg.cpp:325 ../src/richtext/richtextfontpage.cpp:351
 msgid "Italic"
 msgstr "Cursief"
 
-#: ../src/common/paper.cpp:130
+#: ../src/common/paper.cpp:127
 msgid "Italy Envelope, 110 x 230 mm"
 msgstr "Envelop 'Italy', 110 x 230 mm"
 
-#: ../src/common/imagjpeg.cpp:270
+#: ../src/common/imagjpeg.cpp:257
 msgid "JPEG: Couldn't load - file is probably corrupted."
 msgstr "JPEG: kon niet laden - bestand is waarschijnlijk corrupt."
 
-#: ../src/common/imagjpeg.cpp:449
+#: ../src/common/imagjpeg.cpp:436
 msgid "JPEG: Couldn't save image."
 msgstr "JPEG: kon afbeelding niet opslaan."
 
-#: ../src/common/paper.cpp:163
+#: ../src/common/paper.cpp:160
 msgid "Japanese Double Postcard 200 x 148 mm"
 msgstr "Japanse Dubbele Briefkaart 200 x 148 mm"
 
-#: ../src/common/paper.cpp:167
+#: ../src/common/paper.cpp:164
 msgid "Japanese Envelope Chou #3"
 msgstr "Japanse Envelop Chou #3"
 
-#: ../src/common/paper.cpp:180
+#: ../src/common/paper.cpp:177
 msgid "Japanese Envelope Chou #3 Rotated"
 msgstr "Japanse Envelop Chou #3 gedraaid"
 
-#: ../src/common/paper.cpp:168
+#: ../src/common/paper.cpp:165
 msgid "Japanese Envelope Chou #4"
 msgstr "Japanse Envelop Chou #4"
 
-#: ../src/common/paper.cpp:181
+#: ../src/common/paper.cpp:178
 msgid "Japanese Envelope Chou #4 Rotated"
 msgstr "Japanse Envelop Chou #4 Gedraaid"
 
-#: ../src/common/paper.cpp:165
+#: ../src/common/paper.cpp:162
 msgid "Japanese Envelope Kaku #2"
 msgstr "Japanse Envelop Kaku #2"
 
-#: ../src/common/paper.cpp:178
+#: ../src/common/paper.cpp:175
 msgid "Japanese Envelope Kaku #2 Rotated"
 msgstr "Japanse Envelop Kaku #2 Gedraaid"
 
-#: ../src/common/paper.cpp:166
+#: ../src/common/paper.cpp:163
 msgid "Japanese Envelope Kaku #3"
 msgstr "Japanse Envelop Kaku #3"
 
-#: ../src/common/paper.cpp:179
+#: ../src/common/paper.cpp:176
 msgid "Japanese Envelope Kaku #3 Rotated"
 msgstr "Japanse Envelop Kaku #3 Gedraaid"
 
-#: ../src/common/paper.cpp:185
+#: ../src/common/paper.cpp:182
 msgid "Japanese Envelope You #4"
 msgstr "Japanse Envelop You #4"
 
-#: ../src/common/paper.cpp:186
+#: ../src/common/paper.cpp:183
 msgid "Japanese Envelope You #4 Rotated"
 msgstr "Japanse Envelop You #4 Gedraaid"
 
-#: ../src/common/paper.cpp:138
+#: ../src/common/paper.cpp:135
 msgid "Japanese Postcard 100 x 148 mm"
 msgstr "Japanse Briefkaart 100 x 148 mm"
 
-#: ../src/common/paper.cpp:175
+#: ../src/common/paper.cpp:172
 msgid "Japanese Postcard Rotated 148 x 100 mm"
 msgstr "Japanse Breifkaart Gedraaid 148 x 100 mm"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "Jump to"
 msgstr "Spring naar"
 
-#: ../src/common/stockitem.cpp:171
+#: ../src/common/stockitem.cpp:168
 msgid "Justified"
 msgstr "Uitgevuld"
 
-#: ../src/richtext/richtextindentspage.cpp:155
-#: ../src/richtext/richtextindentspage.cpp:157
 #: ../src/richtext/richtextliststylepage.cpp:344
 #: ../src/richtext/richtextliststylepage.cpp:346
+#: ../src/richtext/richtextindentspage.cpp:155
+#: ../src/richtext/richtextindentspage.cpp:157
 msgid "Justify text left and right."
 msgstr "Tekst Links en rechts uitlijnen."
 
-#: ../src/common/fmapbase.cpp:163
+#: ../src/common/fmapbase.cpp:160
 msgid "KOI8-R"
 msgstr "KOI8-R"
 
-#: ../src/common/fmapbase.cpp:164
+#: ../src/common/fmapbase.cpp:161
 msgid "KOI8-U"
 msgstr "KOI8-U"
 
-#: ../src/common/accelcmn.cpp:265 ../src/common/accelcmn.cpp:347
+#: ../src/common/accelcmn.cpp:279 ../src/common/accelcmn.cpp:364
 msgid "KP_"
 msgstr "KP_"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "KP_Add"
 msgstr "KP_Add"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "KP_Begin"
 msgstr "KP_Begin"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "KP_Decimal"
 msgstr "KP_Decimal"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 msgid "KP_Delete"
 msgstr "KP_Delete"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "KP_Divide"
 msgstr "KP_Divide"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 msgid "KP_Down"
 msgstr "KP_Down"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "KP_End"
 msgstr "KP_End"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "KP_Enter"
 msgstr "KP_Enter"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "KP_Equal"
 msgstr "KP_Equal"
 
+#: ../src/common/accelcmn.cpp:276 ../src/common/accelcmn.cpp:361
+msgid "KP_F"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 msgid "KP_Home"
 msgstr "KP_Home"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 msgid "KP_Insert"
 msgstr "KP_Insert"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "KP_Left"
 msgstr "KP_Left"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "KP_Multiply"
 msgstr "KP_Multiply"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:99
+#: ../src/common/accelcmn.cpp:97
 msgid "KP_Next"
 msgstr "KP_Next"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "KP_PageDown"
 msgstr "KP_PageDown"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "KP_PageUp"
 msgstr "KP_PageUp"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:98
+#: ../src/common/accelcmn.cpp:96
 msgid "KP_Prior"
 msgstr "KP_Prior"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 msgid "KP_Right"
 msgstr "KP_Right"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "KP_Separator"
 msgstr "KP_Separator"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "KP_Space"
 msgstr "KP_Space"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "KP_Subtract"
 msgstr "KP_Subtract"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "KP_Tab"
 msgstr "KP_Tab"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "KP_Up"
 msgstr "KP_Up"
 
@@ -4535,112 +4651,127 @@ msgstr "KP_Up"
 msgid "L&ine spacing:"
 msgstr "R&egel tussenruimte:"
 
-#: ../src/generic/prntdlgg.cpp:613 ../src/generic/prntdlgg.cpp:868
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "compressie fout"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "decompressie fout"
+
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:861
 msgid "Landscape"
 msgstr "Liggend"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "Last"
 msgstr "Laatste"
 
-#: ../src/common/prntbase.cpp:1572
+#: ../src/common/prntbase.cpp:1597
 msgid "Last page"
 msgstr "Laatste pagina"
 
-#: ../src/common/log.cpp:305
+#: ../src/common/log.cpp:324
 #, c-format
 msgid "Last repeated message (\"%s\", %u time) wasn't output"
 msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
 msgstr[0] "Laatst herhaald bericht (\"%s\", %u keer) is niet uitgevoerd"
 msgstr[1] "Laatst herhaald berichten (\"%s\", %u keer) zijn niet uitgevoerd"
 
-#: ../src/common/paper.cpp:103
+#: ../src/common/paper.cpp:100
 msgid "Ledger, 17 x 11 in"
 msgstr "USA Ledger, 17 x 11 inch"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6146
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:58 ../src/generic/datavgen.cpp:6951
+#: ../src/richtext/richtextsizepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:252
 #: ../src/richtext/richtextliststylepage.cpp:253
 #: ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
-#: ../src/richtext/richtextsizepage.cpp:249 ../src/common/accelcmn.cpp:61
 msgid "Left"
 msgstr "Links"
 
-#: ../src/richtext/richtextindentspage.cpp:204
 #: ../src/richtext/richtextliststylepage.cpp:390
+#: ../src/richtext/richtextindentspage.cpp:204
 msgid "Left (&first line):"
 msgstr "Links (&eerste regel):"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1761
+#: ../src/propgrid/advprops.cpp:1662
 msgid "Left Button"
 msgstr "Linker knop"
 
-#: ../src/generic/prntdlgg.cpp:880
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Left margin (mm):"
 msgstr "Linkermarge (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:141
-#: ../src/richtext/richtextindentspage.cpp:143
 #: ../src/richtext/richtextliststylepage.cpp:330
 #: ../src/richtext/richtextliststylepage.cpp:332
+#: ../src/richtext/richtextindentspage.cpp:141
+#: ../src/richtext/richtextindentspage.cpp:143
 msgid "Left-align text."
 msgstr "Links uitgelijnde tekst."
 
-#: ../src/common/paper.cpp:144
+#: ../src/common/paper.cpp:141
 msgid "Legal Extra 9 1/2 x 15 in"
 msgstr "Legal Extra 9 1/2 x 15 in"
 
-#: ../src/common/paper.cpp:96
+#: ../src/common/paper.cpp:93
 msgid "Legal, 8 1/2 x 14 in"
 msgstr "USA Legal, 8 1/2 x 14 inch"
 
-#: ../src/common/paper.cpp:143
+#: ../src/common/paper.cpp:140
 msgid "Letter Extra 9 1/2 x 12 in"
 msgstr "Letter Extra 9 1/2 x 12 in"
 
-#: ../src/common/paper.cpp:149
+#: ../src/common/paper.cpp:146
 msgid "Letter Extra Transverse 9.275 x 12 in"
 msgstr "Letter Extra Transverse 9.275 x 12 in"
 
-#: ../src/common/paper.cpp:152
+#: ../src/common/paper.cpp:149
 msgid "Letter Plus 8 1/2 x 12.69 in"
 msgstr "Letter Plus 8 1/2 x 12.69 in"
 
-#: ../src/common/paper.cpp:169
+#: ../src/common/paper.cpp:166
 msgid "Letter Rotated 11 x 8 1/2 in"
 msgstr "Letter Gedraaid 11 x 8 1/2 in"
 
-#: ../src/common/paper.cpp:101
+#: ../src/common/paper.cpp:98
 msgid "Letter Small, 8 1/2 x 11 in"
 msgstr "Letter Klein, 8 1/2 x 11 inch"
 
-#: ../src/common/paper.cpp:147
+#: ../src/common/paper.cpp:144
 msgid "Letter Transverse 8 1/2 x 11 in"
 msgstr "Letter Transverse 8 1/2 x 11 in"
 
-#: ../src/common/paper.cpp:95
+#: ../src/common/paper.cpp:92
 msgid "Letter, 8 1/2 x 11 in"
 msgstr "Letter, 8 1/2 x 11 inch"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "License"
 msgstr "Licentie"
 
-#: ../src/generic/fontdlgg.cpp:332
+#: ../src/generic/fontdlgg.cpp:328
 msgid "Light"
 msgstr "Licht"
 
-#: ../src/propgrid/advprops.cpp:1608
+#: ../src/propgrid/advprops.cpp:1514
 msgid "Lime"
 msgstr "Citroengeel"
 
-#: ../src/generic/helpext.cpp:294
+#: ../src/generic/helpext.cpp:292
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr ""
@@ -4650,15 +4781,15 @@ msgstr ""
 msgid "Line spacing:"
 msgstr "Regel tussenruimte:"
 
-#: ../src/html/chm.cpp:838
+#: ../src/html/chm.cpp:829
 msgid "Link contained '//', converted to absolute link."
 msgstr "Koppeling bevatte '//': omgezet naar absolute koppeling."
 
-#: ../src/richtext/richtextformatdlg.cpp:364
+#: ../src/richtext/richtextformatdlg.cpp:357
 msgid "List Style"
 msgstr "Lijst Stijl"
 
-#: ../src/richtext/richtextstyles.cpp:1064
+#: ../src/richtext/richtextstyles.cpp:1061
 msgid "List styles"
 msgstr "Lijst stijlen"
 
@@ -4672,26 +4803,26 @@ msgstr "Maakt overzicht van lettertypegroottes in punten."
 msgid "Lists the available fonts."
 msgstr "Geef overzicht beschikbare lettertypes."
 
-#: ../src/common/fldlgcmn.cpp:340
+#: ../src/common/fldlgcmn.cpp:337
 #, c-format
 msgid "Load %s file"
 msgstr "Laad %s-bestand"
 
-#: ../src/html/htmlwin.cpp:597
+#: ../src/html/htmlwin.cpp:600
 msgid "Loading : "
 msgstr "Bezig met laden: "
 
-#: ../src/unix/snglinst.cpp:246
+#: ../src/unix/snglinst.cpp:243
 #, c-format
 msgid "Lock file '%s' has incorrect owner."
 msgstr "Lock-bestand '%s' heeft onjuiste eigenaar."
 
-#: ../src/unix/snglinst.cpp:251
+#: ../src/unix/snglinst.cpp:248
 #, c-format
 msgid "Lock file '%s' has incorrect permissions."
 msgstr "Vergrendelingsbestand '%s' heeft onjuiste machtigingen."
 
-#: ../src/generic/logg.cpp:576
+#: ../src/generic/logg.cpp:573
 #, c-format
 msgid "Log saved to the file '%s'."
 msgstr "Log opgeslagen in bestand '%s'."
@@ -4706,11 +4837,11 @@ msgstr "Kleineletters"
 msgid "Lower case roman numerals"
 msgstr "Kleineletters Romeinse telwoorden"
 
-#: ../src/gtk/mdi.cpp:422 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk1/mdi.cpp:431 ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "MDI subvenster"
 
-#: ../src/msw/helpchm.cpp:56
+#: ../src/msw/helpchm.cpp:53
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -4718,189 +4849,189 @@ msgstr ""
 "MS HTML Help functies zijn niet beschikbaar omdat de MS HTML Help "
 "bibliotheek niet op deze machine is geïnstalleerd. Installeer het a.u.b."
 
-#: ../src/univ/themes/win32.cpp:3754
+#: ../src/univ/themes/win32.cpp:3751
 msgid "Ma&ximize"
 msgstr "Maximaliseren"
 
-#: ../src/common/fmapbase.cpp:203
+#: ../src/common/fmapbase.cpp:200
 msgid "MacArabic"
 msgstr "MacArabic"
 
-#: ../src/common/fmapbase.cpp:222
+#: ../src/common/fmapbase.cpp:219
 msgid "MacArmenian"
 msgstr "MacArmenian"
 
-#: ../src/common/fmapbase.cpp:211
+#: ../src/common/fmapbase.cpp:208
 msgid "MacBengali"
 msgstr "MacBengali"
 
-#: ../src/common/fmapbase.cpp:217
+#: ../src/common/fmapbase.cpp:214
 msgid "MacBurmese"
 msgstr "MacBurmese"
 
-#: ../src/common/fmapbase.cpp:236
+#: ../src/common/fmapbase.cpp:233
 msgid "MacCeltic"
 msgstr "MacCeltic"
 
-#: ../src/common/fmapbase.cpp:227
+#: ../src/common/fmapbase.cpp:224
 msgid "MacCentralEurRoman"
 msgstr "MacCentralEurRoman"
 
-#: ../src/common/fmapbase.cpp:223
+#: ../src/common/fmapbase.cpp:220
 msgid "MacChineseSimp"
 msgstr "MacChineseSimp"
 
-#: ../src/common/fmapbase.cpp:201
+#: ../src/common/fmapbase.cpp:198
 msgid "MacChineseTrad"
 msgstr "MacChineseTrad"
 
-#: ../src/common/fmapbase.cpp:233
+#: ../src/common/fmapbase.cpp:230
 msgid "MacCroatian"
 msgstr "MacCroatian"
 
-#: ../src/common/fmapbase.cpp:206
+#: ../src/common/fmapbase.cpp:203
 msgid "MacCyrillic"
 msgstr "MacCyrillic"
 
-#: ../src/common/fmapbase.cpp:207
+#: ../src/common/fmapbase.cpp:204
 msgid "MacDevanagari"
 msgstr "MacDevanagari"
 
-#: ../src/common/fmapbase.cpp:231
+#: ../src/common/fmapbase.cpp:228
 msgid "MacDingbats"
 msgstr "MacDingbats"
 
-#: ../src/common/fmapbase.cpp:226
+#: ../src/common/fmapbase.cpp:223
 msgid "MacEthiopic"
 msgstr "MacEthiopic"
 
-#: ../src/common/fmapbase.cpp:229
+#: ../src/common/fmapbase.cpp:226
 msgid "MacExtArabic"
 msgstr "MacExtArabic"
 
-#: ../src/common/fmapbase.cpp:237
+#: ../src/common/fmapbase.cpp:234
 msgid "MacGaelic"
 msgstr "MacGaelic"
 
-#: ../src/common/fmapbase.cpp:221
+#: ../src/common/fmapbase.cpp:218
 msgid "MacGeorgian"
 msgstr "MacGeorgian"
 
-#: ../src/common/fmapbase.cpp:205
+#: ../src/common/fmapbase.cpp:202
 msgid "MacGreek"
 msgstr "MacGreek"
 
-#: ../src/common/fmapbase.cpp:209
+#: ../src/common/fmapbase.cpp:206
 msgid "MacGujarati"
 msgstr "MacGujarati"
 
-#: ../src/common/fmapbase.cpp:208
+#: ../src/common/fmapbase.cpp:205
 msgid "MacGurmukhi"
 msgstr "MacGurmukhi"
 
-#: ../src/common/fmapbase.cpp:204
+#: ../src/common/fmapbase.cpp:201
 msgid "MacHebrew"
 msgstr "MacHebrew"
 
-#: ../src/common/fmapbase.cpp:234
+#: ../src/common/fmapbase.cpp:231
 msgid "MacIcelandic"
 msgstr "MacIcelandic"
 
-#: ../src/common/fmapbase.cpp:200
+#: ../src/common/fmapbase.cpp:197
 msgid "MacJapanese"
 msgstr "MacJapanese"
 
-#: ../src/common/fmapbase.cpp:214
+#: ../src/common/fmapbase.cpp:211
 msgid "MacKannada"
 msgstr "MacKannada"
 
-#: ../src/common/fmapbase.cpp:238
+#: ../src/common/fmapbase.cpp:235
 msgid "MacKeyboardGlyphs"
 msgstr "MacKeyboardGlyphs"
 
-#: ../src/common/fmapbase.cpp:218
+#: ../src/common/fmapbase.cpp:215
 msgid "MacKhmer"
 msgstr "MacKhmer"
 
-#: ../src/common/fmapbase.cpp:202
+#: ../src/common/fmapbase.cpp:199
 msgid "MacKorean"
 msgstr "MacKorean"
 
-#: ../src/common/fmapbase.cpp:220
+#: ../src/common/fmapbase.cpp:217
 msgid "MacLaotian"
 msgstr "MacLaotian"
 
-#: ../src/common/fmapbase.cpp:215
+#: ../src/common/fmapbase.cpp:212
 msgid "MacMalayalam"
 msgstr "MacMalayalam"
 
-#: ../src/common/fmapbase.cpp:225
+#: ../src/common/fmapbase.cpp:222
 msgid "MacMongolian"
 msgstr "MacMongolian"
 
-#: ../src/common/fmapbase.cpp:210
+#: ../src/common/fmapbase.cpp:207
 msgid "MacOriya"
 msgstr "MacOriya"
 
-#: ../src/common/fmapbase.cpp:199
+#: ../src/common/fmapbase.cpp:196
 msgid "MacRoman"
 msgstr "MacRoman"
 
-#: ../src/common/fmapbase.cpp:235
+#: ../src/common/fmapbase.cpp:232
 msgid "MacRomanian"
 msgstr "MacRomanian"
 
-#: ../src/common/fmapbase.cpp:216
+#: ../src/common/fmapbase.cpp:213
 msgid "MacSinhalese"
 msgstr "MacSinhalese"
 
-#: ../src/common/fmapbase.cpp:230
+#: ../src/common/fmapbase.cpp:227
 msgid "MacSymbol"
 msgstr "MacSymbol"
 
-#: ../src/common/fmapbase.cpp:212
+#: ../src/common/fmapbase.cpp:209
 msgid "MacTamil"
 msgstr "MacTamil"
 
-#: ../src/common/fmapbase.cpp:213
+#: ../src/common/fmapbase.cpp:210
 msgid "MacTelugu"
 msgstr "MacTelugu"
 
-#: ../src/common/fmapbase.cpp:219
+#: ../src/common/fmapbase.cpp:216
 msgid "MacThai"
 msgstr "MacThai"
 
-#: ../src/common/fmapbase.cpp:224
+#: ../src/common/fmapbase.cpp:221
 msgid "MacTibetan"
 msgstr "MacTibetan"
 
-#: ../src/common/fmapbase.cpp:232
+#: ../src/common/fmapbase.cpp:229
 msgid "MacTurkish"
 msgstr "MacTurkish"
 
-#: ../src/common/fmapbase.cpp:228
+#: ../src/common/fmapbase.cpp:225
 msgid "MacVietnamese"
 msgstr "MacVietnamese"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1762
+#: ../src/propgrid/advprops.cpp:1663
 msgid "Magnifier"
 msgstr "Vergrootglas"
 
-#: ../src/propgrid/advprops.cpp:2143
+#: ../src/propgrid/advprops.cpp:2050
 msgid "Make a selection:"
 msgstr "Maak een selectie:"
 
-#: ../src/richtext/richtextformatdlg.cpp:374
+#: ../src/richtext/richtextformatdlg.cpp:367
 #: ../src/richtext/richtextmarginspage.cpp:171
 msgid "Margins"
 msgstr "Marges"
 
-#: ../src/propgrid/advprops.cpp:1595
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Maroon"
 msgstr "Kastanjebruin"
 
-#: ../src/generic/fdrepdlg.cpp:147
+#: ../src/generic/fdrepdlg.cpp:144
 msgid "Match case"
 msgstr "Hoofdlettergevoelig"
 
@@ -4912,40 +5043,40 @@ msgstr "Maximale hoogte:"
 msgid "Max width:"
 msgstr "Maximale breedte:"
 
-#: ../src/unix/mediactrl.cpp:947
+#: ../src/unix/mediactrl.cpp:972
 #, c-format
 msgid "Media playback error: %s"
 msgstr "Media-afspeelfout: %s"
 
-#: ../src/common/fs_mem.cpp:175
+#: ../src/common/fs_mem.cpp:170
 #, c-format
 msgid "Memory VFS already contains file '%s'!"
 msgstr "Geheugen VFS bevat al bestand '%s'!"
 
 #. TRANSLATORS: Name of keyboard key
 #. TRANSLATORS: Keyword of system colour
-#: ../src/common/accelcmn.cpp:73 ../src/propgrid/advprops.cpp:889
+#: ../src/common/accelcmn.cpp:70 ../src/propgrid/advprops.cpp:790
 msgid "Menu"
 msgstr "Menu"
 
-#: ../src/common/msgout.cpp:124
+#: ../src/common/msgout.cpp:121
 msgid "Message"
 msgstr "Bericht"
 
-#: ../src/univ/themes/metal.cpp:168
+#: ../src/univ/themes/metal.cpp:165
 msgid "Metal theme"
 msgstr "Metaal thema"
 
-#: ../src/msw/ole/automtn.cpp:652
+#: ../src/msw/ole/automtn.cpp:643
 msgid "Method or property not found."
 msgstr "Methode of eigenschap niet gevonden."
 
-#: ../src/univ/themes/win32.cpp:3752
+#: ../src/univ/themes/win32.cpp:3749
 msgid "Mi&nimize"
 msgstr "Minimaliseren"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1763
+#: ../src/propgrid/advprops.cpp:1664
 msgid "Middle Button"
 msgstr "Middelste knop"
 
@@ -4957,38 +5088,43 @@ msgstr "Minimale hoogte:"
 msgid "Min width:"
 msgstr "Minimale breedte:"
 
-#: ../src/msw/ole/automtn.cpp:668
+#: ../src/osx/cocoa/menu.mm:281
+#, fuzzy
+msgid "Minimize"
+msgstr "Minimaliseren"
+
+#: ../src/msw/ole/automtn.cpp:659
 msgid "Missing a required parameter."
 msgstr "Er ontbreekt een vereiste parameter."
 
-#: ../src/generic/fontdlgg.cpp:324
+#: ../src/generic/fontdlgg.cpp:320
 msgid "Modern"
 msgstr "Modern"
 
-#: ../src/generic/filectrlg.cpp:427
+#: ../src/generic/filectrlg.cpp:423
 msgid "Modified"
 msgstr "Gewijzigd"
 
-#: ../src/common/module.cpp:133
+#: ../src/common/module.cpp:130
 #, c-format
 msgid "Module \"%s\" initialization failed"
 msgstr "Initialisatie Module \"%s\" mislukt"
 
-#: ../src/common/paper.cpp:131
+#: ../src/common/paper.cpp:128
 msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
 msgstr "Envelop 'Monarch', 3 7/8 x 7 1/2 inch"
 
-#: ../src/msw/fswatcher.cpp:143
+#: ../src/msw/fswatcher.cpp:140
 msgid "Monitoring individual files for changes is not supported currently."
 msgstr ""
 "Controleren van individuele bestanden op veranderingen wordt nog niet "
 "ondersteund."
 
-#: ../src/generic/editlbox.cpp:172
+#: ../src/generic/editlbox.cpp:160
 msgid "Move down"
 msgstr "Verplaats omlaag"
 
-#: ../src/generic/editlbox.cpp:171
+#: ../src/generic/editlbox.cpp:155
 msgid "Move up"
 msgstr "Verplaats naar boven"
 
@@ -5002,97 +5138,103 @@ msgstr "Verplaatst het object naar de volgende paragraaf."
 msgid "Moves the object to the previous paragraph."
 msgstr "Verplaatst het object naar de vorige paragraaf."
 
-#: ../src/richtext/richtextbuffer.cpp:9966
+#: ../src/richtext/richtextbuffer.cpp:9963
 msgid "Multiple Cell Properties"
 msgstr "Mutiple Cel eigenschappen"
 
-#: ../src/generic/filectrlg.cpp:424
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:82
+#, fuzzy
+msgid "Multiply"
+msgstr "KP_Multiply"
+
+#: ../src/generic/filectrlg.cpp:420
 msgid "Name"
 msgstr "Naam"
 
-#: ../src/propgrid/advprops.cpp:1596
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Navy"
 msgstr "Marineblauw"
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "Network"
 msgstr "Netwerk"
 
-#: ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173
 msgid "New"
 msgstr "Nieuw"
 
-#: ../src/richtext/richtextstyledlg.cpp:243
+#: ../src/richtext/richtextstyledlg.cpp:239
 msgid "New &Box Style..."
 msgstr "Nieuwe &Vak Stijl..."
 
-#: ../src/richtext/richtextstyledlg.cpp:225
+#: ../src/richtext/richtextstyledlg.cpp:221
 msgid "New &Character Style..."
 msgstr "Nieuw &Letterteken Stijl..."
 
-#: ../src/richtext/richtextstyledlg.cpp:237
+#: ../src/richtext/richtextstyledlg.cpp:233
 msgid "New &List Style..."
 msgstr "Nieuwe &Lijst Stijl..."
 
-#: ../src/richtext/richtextstyledlg.cpp:231
+#: ../src/richtext/richtextstyledlg.cpp:227
 msgid "New &Paragraph Style..."
 msgstr "Nieuwe &Paragraaf Stijl..."
 
-#: ../src/richtext/richtextstyledlg.cpp:606
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:654
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:820
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:893
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:934
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:602
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:650
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:816
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:889
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:930
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "New Style"
 msgstr "Nieuw Stijl"
 
-#: ../src/generic/editlbox.cpp:169
+#: ../src/generic/editlbox.cpp:139
 msgid "New item"
 msgstr "Nieuw element"
 
-#: ../src/generic/dirdlgg.cpp:297 ../src/generic/dirdlgg.cpp:307
-#: ../src/generic/filectrlg.cpp:618 ../src/generic/filectrlg.cpp:627
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+#: ../src/generic/dirdlgg.cpp:294 ../src/generic/dirdlgg.cpp:304
 msgid "NewName"
 msgstr "Nieuwe map"
 
-#: ../src/common/prntbase.cpp:1567 ../src/html/helpwnd.cpp:665
+#: ../src/common/prntbase.cpp:1592 ../src/html/helpwnd.cpp:663
 msgid "Next page"
 msgstr "Volgende pagina"
 
-#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:177
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:174
 #: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Nee"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1764
+#: ../src/propgrid/advprops.cpp:1665
 msgid "No Entry"
 msgstr "Geen toegang"
 
-#: ../src/generic/animateg.cpp:150
+#: ../src/generic/animateg.cpp:133
 #, c-format
 msgid "No animation handler for type %ld defined."
 msgstr "Geen animatie handler voor type %ld gedefinieerd."
 
-#: ../src/dfb/bitmap.cpp:642 ../src/dfb/bitmap.cpp:676
+#: ../src/dfb/bitmap.cpp:639 ../src/dfb/bitmap.cpp:673
 #, c-format
 msgid "No bitmap handler for type %d defined."
 msgstr "Geen bitmap handler voor type %d gedefinieerd."
 
-#: ../src/common/utilscmn.cpp:1077
+#: ../src/common/utilscmn.cpp:1095
 msgid "No default application configured for HTML files."
 msgstr "Er is geen standaard toepassing geconfigureerd voor HTML bestanden."
 
-#: ../src/generic/helpext.cpp:445
+#: ../src/generic/helpext.cpp:443
 msgid "No entries found."
 msgstr "Geen ingangen gevonden."
 
-#: ../src/common/fontmap.cpp:421
+#: ../src/common/fontmap.cpp:418
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found,\n"
@@ -5105,7 +5247,7 @@ msgstr ""
 "maar een alternatieve versleuteling '%s' is beschikbaar.\n"
 "Wilt u deze versleuteling gebruiken (Anders moet u een andere kiezen)?"
 
-#: ../src/common/fontmap.cpp:426
+#: ../src/common/fontmap.cpp:423
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found.\n"
@@ -5116,201 +5258,201 @@ msgstr ""
 "Wilt u een lettertype selecteren voor deze versleuteling \n"
 "(anders zal de tekst in deze versleuteling niet correct weergegeven worden)?"
 
-#: ../src/generic/animateg.cpp:142
+#: ../src/generic/animateg.cpp:125
 msgid "No handler found for animation type."
 msgstr "Geen handler gevonden voor animatietype."
 
-#: ../src/common/image.cpp:2728
+#: ../src/common/image.cpp:2823
 msgid "No handler found for image type."
 msgstr "Geen handler gevonden voor afbeeldingstype."
 
-#: ../src/common/image.cpp:2736 ../src/common/image.cpp:2848
-#: ../src/common/image.cpp:2901
+#: ../src/common/image.cpp:2831 ../src/common/image.cpp:2954
+#: ../src/common/image.cpp:3020
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "Geen afbeeldingshandler voor het type %d gedefinieerd."
 
-#: ../src/common/image.cpp:2871 ../src/common/image.cpp:2915
+#: ../src/common/image.cpp:2986 ../src/common/image.cpp:3034
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "Geen afbeeldingshandler voor het type %s gedefinieerd."
 
-#: ../src/html/helpwnd.cpp:858
+#: ../src/html/helpwnd.cpp:856
 msgid "No matching page found yet"
 msgstr "Nog geen overeenkomende pagina gevonden"
 
-#: ../src/unix/sound.cpp:81
+#: ../src/unix/sound.cpp:78
 msgid "No sound"
 msgstr "Geen geluid"
 
-#: ../src/common/image.cpp:2277 ../src/common/image.cpp:2318
+#: ../src/common/image.cpp:2371 ../src/common/image.cpp:2412
 msgid "No unused colour in image being masked."
 msgstr "Geen ongebruikte kleur in afbeelding gemaskeerd."
 
-#: ../src/common/image.cpp:3374
-msgid "No unused colour in image."
-msgstr "Geen ongebruikte kleuren in afbeelding."
-
-#: ../src/generic/helpext.cpp:302
+#: ../src/generic/helpext.cpp:300
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "Geen geldige mappingen gevonden in het bestand \"%s\"."
 
-#: ../src/richtext/richtextborderspage.cpp:610
 #: ../src/richtext/richtextsizepage.cpp:248
 #: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:610
 msgid "None"
 msgstr "Geen"
 
-#: ../src/common/fmapbase.cpp:157
+#: ../src/common/fmapbase.cpp:154
 msgid "Nordic (ISO-8859-10)"
 msgstr "Noors (ISO-8859-10)"
 
-#: ../src/generic/fontdlgg.cpp:328 ../src/generic/fontdlgg.cpp:331
+#: ../src/generic/fontdlgg.cpp:324 ../src/generic/fontdlgg.cpp:327
 msgid "Normal"
 msgstr "Normaal"
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1261
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Normale letter<br>en <u>onderstreept</u>. "
 
-#: ../src/html/helpwnd.cpp:1205
+#: ../src/html/helpwnd.cpp:1203
 msgid "Normal font:"
 msgstr "Normaal lettertype:"
 
-#: ../src/propgrid/props.cpp:1128
+#: ../src/propgrid/props.cpp:1115
 #, c-format
 msgid "Not %s"
 msgstr "Niet %s"
 
-#: ../include/wx/filename.h:573 ../include/wx/filename.h:578
-msgid "Not available"
-msgstr "Niet beschikbaar"
+#: ../src/common/secretstore.cpp:168
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/webrequest.cpp:605
+msgid "Not enough free disk space for download."
+msgstr ""
 
 #: ../src/richtext/richtextfontpage.cpp:358
 msgid "Not underlined"
 msgstr "Niet onderstreept"
 
-#: ../src/common/paper.cpp:115
+#: ../src/common/paper.cpp:112
 msgid "Note, 8 1/2 x 11 in"
 msgstr "Notitie, 8 1/2 x 11 inch"
 
-#: ../src/generic/notifmsgg.cpp:132
+#: ../src/generic/notifmsgg.cpp:129
 msgid "Notice"
 msgstr "Notitie"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "Num *"
 msgstr "Num *"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "Num +"
 msgstr "Num +"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "Num ,"
 msgstr "Num ,"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "Num -"
 msgstr "Num -"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "Num ."
 msgstr "Num ."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "Num /"
 msgstr "Num /"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "Num ="
 msgstr "Num ="
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "Num Begin"
 msgstr "Num Begin"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 msgid "Num Delete"
 msgstr "Num Delete"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 msgid "Num Down"
 msgstr "Num Down"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "Num End"
 msgstr "Num End"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "Num Enter"
 msgstr "Num Enter"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 msgid "Num Home"
 msgstr "Num Home"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 msgid "Num Insert"
 msgstr "Num Insert"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num Lock"
 msgstr "Num Lock"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "Num Page Down"
 msgstr "Num Page Down"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "Num Page Up"
 msgstr "Num Page Up"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 msgid "Num Right"
 msgstr "Num Right"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "Num Space"
 msgstr "Num Space"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "Num Tab"
 msgstr "Num Tab"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "Num Up"
 msgstr "Num Up"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "Num left"
 msgstr "Num left"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num_lock"
 msgstr "Num_lock"
 
@@ -5319,13 +5461,13 @@ msgstr "Num_lock"
 msgid "Numbered outline"
 msgstr "Genummerde outline"
 
-#: ../include/wx/msgdlg.h:278 ../src/richtext/richtextstyledlg.cpp:297
-#: ../src/common/stockitem.cpp:178 ../src/msw/msgdlg.cpp:454
-#: ../src/msw/msgdlg.cpp:747 ../src/gtk1/fontdlg.cpp:138
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:175
+#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/msgdlg.cpp:741 ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "OK"
 
-#: ../src/msw/ole/automtn.cpp:692
+#: ../src/msw/ole/automtn.cpp:683
 #, c-format
 msgid "OLE Automation error in %s: %s"
 msgstr "OLE Automatiseringsfout in %s: %s"
@@ -5334,15 +5476,15 @@ msgstr "OLE Automatiseringsfout in %s: %s"
 msgid "Object Properties"
 msgstr "Object eigenschappen"
 
-#: ../src/msw/ole/automtn.cpp:660
+#: ../src/msw/ole/automtn.cpp:651
 msgid "Object implementation does not support named arguments."
 msgstr "Object implementatie ondersteunt geen benoemde argumenten."
 
-#: ../src/common/xtixml.cpp:264
+#: ../src/common/xtixml.cpp:260
 msgid "Objects must have an id attribute"
 msgstr "Objecten moeten een id attribuut hebben"
 
-#: ../src/propgrid/advprops.cpp:1601
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Olive"
 msgstr "Olijfgroen"
 
@@ -5350,64 +5492,69 @@ msgstr "Olijfgroen"
 msgid "Opaci&ty:"
 msgstr "Ondoorzich&tigheid:"
 
-#: ../src/generic/colrdlgg.cpp:354
+#: ../src/generic/colrdlgg.cpp:374
 msgid "Opacity:"
 msgstr "Ondoorzichtigheid:"
 
-#: ../src/common/docview.cpp:1773 ../src/common/docview.cpp:1815
+#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
 msgid "Open File"
 msgstr "Open Bestand"
 
-#: ../src/html/helpwnd.cpp:671 ../src/html/helpwnd.cpp:1554
+#: ../src/html/helpwnd.cpp:669 ../src/html/helpwnd.cpp:1552
 msgid "Open HTML document"
 msgstr "HTML-document openen"
 
-#: ../src/generic/dbgrptg.cpp:163
+#: ../src/common/stockitem.cpp:265
+#, fuzzy
+msgid "Open an existing document"
+msgstr "HTML-document openen"
+
+#: ../src/generic/dbgrptg.cpp:160
 #, c-format
 msgid "Open file \"%s\""
 msgstr "Open bestand \"%s\""
 
-#: ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176
 msgid "Open..."
 msgstr "Openen..."
 
-#: ../src/unix/glx11.cpp:506 ../src/msw/glcanvas.cpp:592
+#: ../src/msw/glcanvas.cpp:607 ../src/unix/glx11.cpp:513
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr "OpenGL 3.0 of hoger wordt niet ondersteund door de OpenGL driver."
 
-#: ../src/generic/dirctrlg.cpp:599 ../src/generic/dirdlgg.cpp:323
-#: ../src/generic/filectrlg.cpp:642 ../src/generic/filectrlg.cpp:786
+#: ../src/generic/dirctrlg.cpp:565 ../src/generic/filectrlg.cpp:638
+#: ../src/generic/filectrlg.cpp:782 ../src/generic/dirdlgg.cpp:320
 msgid "Operation not permitted."
 msgstr "Bewerking niet toegestaan."
 
-#: ../src/common/cmdline.cpp:900
+#: ../src/common/cmdline.cpp:896
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "Optie '%s' kon niet worden genegeerd"
 
-#: ../src/common/cmdline.cpp:1064
+#: ../src/common/cmdline.cpp:1060
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "Optie '%s' vereist een waarde."
 
-#: ../src/common/cmdline.cpp:1147
+#: ../src/common/cmdline.cpp:1143
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Optie '%s': '%s' kan niet naar een datum worden geconverteerd."
 
-#: ../src/generic/prntdlgg.cpp:618
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Instellingen"
 
-#: ../src/propgrid/advprops.cpp:1606
+#: ../src/propgrid/advprops.cpp:1512
 msgid "Orange"
 msgstr "Oranje"
 
-#: ../src/generic/prntdlgg.cpp:615 ../src/generic/prntdlgg.cpp:869
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:862
 msgid "Orientation"
 msgstr "Oriëntatie"
 
-#: ../src/common/windowid.cpp:242
+#: ../src/common/windowid.cpp:237
 msgid "Out of window IDs.  Recommend shutting down application."
 msgstr "Geen Venster ID's meer. Aanbevolen de toepassing af te sluiten."
 
@@ -5420,148 +5567,148 @@ msgstr "Outline"
 msgid "Outset"
 msgstr "Aanvang"
 
-#: ../src/msw/ole/automtn.cpp:656
+#: ../src/msw/ole/automtn.cpp:647
 msgid "Overflow while coercing argument values."
 msgstr "Overloop tijdens afdwingen argument waarden."
 
-#: ../src/common/imagpcx.cpp:457 ../src/common/imagpcx.cpp:480
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:479
 msgid "PCX: couldn't allocate memory"
 msgstr "PCX: kon geen geheugen reserveren"
 
-#: ../src/common/imagpcx.cpp:456
+#: ../src/common/imagpcx.cpp:455
 msgid "PCX: image format unsupported"
 msgstr "PCX: bestandsformaat niet ondersteund"
 
-#: ../src/common/imagpcx.cpp:479
+#: ../src/common/imagpcx.cpp:478
 msgid "PCX: invalid image"
 msgstr "PCX: ongeldige afbeelding"
 
-#: ../src/common/imagpcx.cpp:442
+#: ../src/common/imagpcx.cpp:441
 msgid "PCX: this is not a PCX file."
 msgstr "PCX: dit is geen PCX-bestand."
 
-#: ../src/common/imagpcx.cpp:459 ../src/common/imagpcx.cpp:481
+#: ../src/common/imagpcx.cpp:458 ../src/common/imagpcx.cpp:480
 msgid "PCX: unknown error !!!"
 msgstr "PCX: onbekende fout!"
 
-#: ../src/common/imagpcx.cpp:458
+#: ../src/common/imagpcx.cpp:457
 msgid "PCX: version number too low"
 msgstr "PCX: versienummer te laag"
 
-#: ../src/common/imagpnm.cpp:91
+#: ../src/common/imagpnm.cpp:89
 msgid "PNM: Couldn't allocate memory."
 msgstr "PNM: kon geen geheugen reserveren."
 
-#: ../src/common/imagpnm.cpp:73
+#: ../src/common/imagpnm.cpp:71
 msgid "PNM: File format is not recognized."
 msgstr "PNM: Bestandsindeling wordt niet herkend."
 
-#: ../src/common/imagpnm.cpp:112 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
 #: ../src/common/imagpnm.cpp:156
 msgid "PNM: File seems truncated."
 msgstr "PNM: bestand lijkt afgekapt."
 
-#: ../src/common/paper.cpp:187
+#: ../src/common/paper.cpp:184
 msgid "PRC 16K 146 x 215 mm"
 msgstr "PRC 16K 146 x 215 mm"
 
-#: ../src/common/paper.cpp:200
+#: ../src/common/paper.cpp:197
 msgid "PRC 16K Rotated"
 msgstr "PRC 16K Gedraaid"
 
-#: ../src/common/paper.cpp:188
+#: ../src/common/paper.cpp:185
 msgid "PRC 32K 97 x 151 mm"
 msgstr "PRC 32K 97 x 151 mm"
 
-#: ../src/common/paper.cpp:201
+#: ../src/common/paper.cpp:198
 msgid "PRC 32K Rotated"
 msgstr "PRC 32K Gedraaid"
 
-#: ../src/common/paper.cpp:189
+#: ../src/common/paper.cpp:186
 msgid "PRC 32K(Big) 97 x 151 mm"
 msgstr "PRC 32K(Big) 97 x 151 mm"
 
-#: ../src/common/paper.cpp:202
+#: ../src/common/paper.cpp:199
 msgid "PRC 32K(Big) Rotated"
 msgstr "PRC 32K(Groot) Gedraaid"
 
-#: ../src/common/paper.cpp:190
+#: ../src/common/paper.cpp:187
 msgid "PRC Envelope #1 102 x 165 mm"
 msgstr "PRC Envelop #1 102 x 165 mm"
 
-#: ../src/common/paper.cpp:203
+#: ../src/common/paper.cpp:200
 msgid "PRC Envelope #1 Rotated 165 x 102 mm"
 msgstr "PRC Envelop #1 Gedraaid 165 x 102 mm"
 
-#: ../src/common/paper.cpp:199
+#: ../src/common/paper.cpp:196
 msgid "PRC Envelope #10 324 x 458 mm"
 msgstr "PRC Envelop #10 324 x 458 mm"
 
-#: ../src/common/paper.cpp:212
+#: ../src/common/paper.cpp:209
 msgid "PRC Envelope #10 Rotated 458 x 324 mm"
 msgstr "PRC Envelop #10 Gedraaid 458 x 324 mm"
 
-#: ../src/common/paper.cpp:191
+#: ../src/common/paper.cpp:188
 msgid "PRC Envelope #2 102 x 176 mm"
 msgstr "PRC Envelop #2 102 x 176 mm"
 
-#: ../src/common/paper.cpp:204
+#: ../src/common/paper.cpp:201
 msgid "PRC Envelope #2 Rotated 176 x 102 mm"
 msgstr "PRC Envelop #2 Gedraaid 176 x 102 mm"
 
-#: ../src/common/paper.cpp:192
+#: ../src/common/paper.cpp:189
 msgid "PRC Envelope #3 125 x 176 mm"
 msgstr "PRC Envelop #3 125 x 176 mm"
 
-#: ../src/common/paper.cpp:205
+#: ../src/common/paper.cpp:202
 msgid "PRC Envelope #3 Rotated 176 x 125 mm"
 msgstr "PRC Envelop #3 Gedraaid 176 x 125 mm"
 
-#: ../src/common/paper.cpp:193
+#: ../src/common/paper.cpp:190
 msgid "PRC Envelope #4 110 x 208 mm"
 msgstr "PRC Envelop #4 110 x 208 mm"
 
-#: ../src/common/paper.cpp:206
+#: ../src/common/paper.cpp:203
 msgid "PRC Envelope #4 Rotated 208 x 110 mm"
 msgstr "PRC Envelop #4 Gedraaid 208 x 110 mm"
 
-#: ../src/common/paper.cpp:194
+#: ../src/common/paper.cpp:191
 msgid "PRC Envelope #5 110 x 220 mm"
 msgstr "PRC Envelop #5 110 x 220 mm"
 
-#: ../src/common/paper.cpp:207
+#: ../src/common/paper.cpp:204
 msgid "PRC Envelope #5 Rotated 220 x 110 mm"
 msgstr "PRC Envelop #5 Gedraaid 220 x 110 mm"
 
-#: ../src/common/paper.cpp:195
+#: ../src/common/paper.cpp:192
 msgid "PRC Envelope #6 120 x 230 mm"
 msgstr "PRC Envelop #6 120 x 230 mm"
 
-#: ../src/common/paper.cpp:208
+#: ../src/common/paper.cpp:205
 msgid "PRC Envelope #6 Rotated 230 x 120 mm"
 msgstr "Envelop C5, 162 x 229 mm"
 
-#: ../src/common/paper.cpp:196
+#: ../src/common/paper.cpp:193
 msgid "PRC Envelope #7 160 x 230 mm"
 msgstr "PRC Envelop #7 160 x 230 mm"
 
-#: ../src/common/paper.cpp:209
+#: ../src/common/paper.cpp:206
 msgid "PRC Envelope #7 Rotated 230 x 160 mm"
 msgstr "PRC Envelop #7 Gedraaid 230 x 160 mm"
 
-#: ../src/common/paper.cpp:197
+#: ../src/common/paper.cpp:194
 msgid "PRC Envelope #8 120 x 309 mm"
 msgstr "PRC Envelop #8 120 x 309 mm"
 
-#: ../src/common/paper.cpp:210
+#: ../src/common/paper.cpp:207
 msgid "PRC Envelope #8 Rotated 309 x 120 mm"
 msgstr "PRC Envelop #8 Gedraaid 309 x 120 mm"
 
-#: ../src/common/paper.cpp:198
+#: ../src/common/paper.cpp:195
 msgid "PRC Envelope #9 229 x 324 mm"
 msgstr "PRC Envelop #9 229 x 324 mm"
 
-#: ../src/common/paper.cpp:211
+#: ../src/common/paper.cpp:208
 msgid "PRC Envelope #9 Rotated 324 x 229 mm"
 msgstr "PRC Envelop #9 Gedraaid 324 x 229 mm"
 
@@ -5569,87 +5716,91 @@ msgstr "PRC Envelop #9 Gedraaid 324 x 229 mm"
 msgid "Padding"
 msgstr "Uitvulling"
 
-#: ../src/common/prntbase.cpp:2074
+#: ../src/common/prntbase.cpp:2096
 #, c-format
 msgid "Page %d"
 msgstr "Pagina %d"
 
-#: ../src/common/prntbase.cpp:2072
+#: ../src/common/prntbase.cpp:2094
 #, c-format
 msgid "Page %d of %d"
 msgstr "Pagina %d van %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 msgid "Page Down"
 msgstr "Page Down"
 
-#: ../src/gtk/print.cpp:826
+#: ../src/gtk/print.cpp:829
 msgid "Page Setup"
 msgstr "Pagina-instellingen"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 msgid "Page Up"
 msgstr "Page Up"
 
-#: ../src/generic/prntdlgg.cpp:828 ../src/common/prntbase.cpp:484
+#: ../src/common/prntbase.cpp:479 ../src/generic/prntdlgg.cpp:821
 msgid "Page setup"
 msgstr "Pagina instellingen"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 msgid "PageDown"
 msgstr "PageDown"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 msgid "PageUp"
 msgstr "PageUp"
 
-#: ../src/generic/prntdlgg.cpp:216
+#: ../src/generic/prntdlgg.cpp:209
 msgid "Pages"
 msgstr "Pagina's"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1765
+#: ../src/propgrid/advprops.cpp:1666
 msgid "Paint Brush"
 msgstr "Penseel"
 
-#: ../src/generic/prntdlgg.cpp:602 ../src/generic/prntdlgg.cpp:801
-#: ../src/generic/prntdlgg.cpp:842 ../src/generic/prntdlgg.cpp:855
-#: ../src/generic/prntdlgg.cpp:1052 ../src/generic/prntdlgg.cpp:1057
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:794
+#: ../src/generic/prntdlgg.cpp:835 ../src/generic/prntdlgg.cpp:848
+#: ../src/generic/prntdlgg.cpp:1045 ../src/generic/prntdlgg.cpp:1050
 msgid "Paper size"
 msgstr "Papierformaat"
 
-#: ../src/richtext/richtextstyles.cpp:1062
+#: ../src/richtext/richtextstyles.cpp:1059
 msgid "Paragraph styles"
 msgstr "Paragraaf stijlen"
 
-#: ../src/common/xtistrm.cpp:465
+#: ../src/common/xtistrm.cpp:462
 msgid "Passing a already registered object to SetObject"
 msgstr "Al geregistreerd object doorgegeven aan SetObject"
 
-#: ../src/common/xtistrm.cpp:476
+#: ../src/common/xtistrm.cpp:473
 msgid "Passing an unknown object to GetObject"
 msgstr "Doorgave van een onbekend object naar GetObject"
 
-#: ../src/richtext/richtextctrl.cpp:3513 ../src/common/stockitem.cpp:180
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:177 ../src/richtext/richtextctrl.cpp:3514
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Plakken"
 
-#: ../src/common/stockitem.cpp:262
+#: ../src/common/stockitem.cpp:260
 msgid "Paste selection"
 msgstr "Selectie plakken"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:74
+#: ../src/common/accelcmn.cpp:71
 msgid "Pause"
 msgstr "Pause"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1766
+#: ../src/propgrid/advprops.cpp:1667
 msgid "Pencil"
 msgstr "Potlood"
 
@@ -5658,21 +5809,21 @@ msgstr "Potlood"
 msgid "Peri&od"
 msgstr "Peri&ode"
 
-#: ../src/generic/filectrlg.cpp:430
+#: ../src/generic/filectrlg.cpp:426
 msgid "Permissions"
 msgstr "Machtigingen"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:60
+#: ../src/common/accelcmn.cpp:57
 msgid "PgDn"
 msgstr "PgDn"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:59
+#: ../src/common/accelcmn.cpp:56
 msgid "PgUp"
 msgstr "PgUp"
 
-#: ../src/richtext/richtextbuffer.cpp:12868
+#: ../src/richtext/richtextbuffer.cpp:12863
 msgid "Picture Properties"
 msgstr "Afbeelding Eigenschappen"
 
@@ -5684,42 +5835,42 @@ msgstr "Maken van pipe mislukt"
 msgid "Please choose a valid font."
 msgstr "Kies a.u.b. een geldig lettertype."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
 msgid "Please choose an existing file."
 msgstr "Kies a.u.b. een bestaand bestand."
 
-#: ../src/html/helpwnd.cpp:800
+#: ../src/html/helpwnd.cpp:798
 msgid "Please choose the page to display:"
 msgstr "Selecteer een pagina om te tonen:"
 
-#: ../src/msw/dialup.cpp:764
+#: ../src/msw/dialup.cpp:758
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Kies a.u.b. een internetaanbieder waarmee u verbinding wilt maken"
 
-#: ../src/common/headerctrlcmn.cpp:59
+#: ../src/common/headerctrlcmn.cpp:57
 msgid "Please select the columns to show and define their order:"
 msgstr "Selecteer de kolommen voor weergeven en definiëren van hun volgorde:"
 
-#: ../src/common/prntbase.cpp:538
+#: ../src/common/prntbase.cpp:533
 msgid "Please wait while printing..."
 msgstr "Een ogenblik geduld. Bezig met printen..."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1767
+#: ../src/propgrid/advprops.cpp:1668
 msgid "Point Left"
 msgstr "Wijs links"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1768
+#: ../src/propgrid/advprops.cpp:1669
 msgid "Point Right"
 msgstr "Wijs rechts"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:662
+#: ../src/propgrid/advprops.cpp:572
 msgid "Point Size"
 msgstr "Puntgrootte"
 
-#: ../src/generic/prntdlgg.cpp:612 ../src/generic/prntdlgg.cpp:867
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:860
 msgid "Portrait"
 msgstr "Staand"
 
@@ -5727,150 +5878,160 @@ msgstr "Staand"
 msgid "Position"
 msgstr "Positie"
 
-#: ../src/generic/prntdlgg.cpp:298
+#: ../src/generic/prntdlgg.cpp:291
 msgid "PostScript file"
 msgstr "PostScript-bestand"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178 ../src/osx/cocoa/preferences.mm:303
 msgid "Preferences"
 msgstr "Voorkeuren"
 
-#: ../src/osx/menu_osx.cpp:568
+#: ../src/osx/menu_osx.cpp:460
 msgid "Preferences..."
 msgstr "Voorkeuren..."
 
-#: ../src/common/prntbase.cpp:546
+#: ../src/common/prntbase.cpp:541
 msgid "Preparing"
 msgstr "Voorbereiden"
 
-#: ../src/generic/fontdlgg.cpp:455 ../src/osx/carbon/fontdlg.cpp:390
-#: ../src/html/helpwnd.cpp:1222
+#: ../src/osx/carbon/fontdlg.cpp:387 ../src/generic/fontdlgg.cpp:452
+#: ../src/html/helpwnd.cpp:1220
 msgid "Preview:"
 msgstr "Afdrukvoorbeeld:"
 
-#: ../src/common/prntbase.cpp:1553 ../src/html/helpwnd.cpp:664
+#: ../src/common/prntbase.cpp:1578 ../src/html/helpwnd.cpp:662
 msgid "Previous page"
 msgstr "Vorige pagina"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/prntdlgg.cpp:143 ../src/generic/prntdlgg.cpp:157
-#: ../src/common/prntbase.cpp:426 ../src/common/prntbase.cpp:1541
-#: ../src/common/accelcmn.cpp:77 ../src/gtk/print.cpp:620
-#: ../src/gtk/print.cpp:638
+#: ../src/common/prntbase.cpp:421 ../src/common/prntbase.cpp:1566
+#: ../src/common/accelcmn.cpp:74 ../src/generic/prntdlgg.cpp:136
+#: ../src/generic/prntdlgg.cpp:150 ../src/gtk/print.cpp:616
+#: ../src/gtk/print.cpp:634
 msgid "Print"
 msgstr "Afdrukken"
 
-#: ../include/wx/prntbase.h:399 ../src/common/docview.cpp:1268
+#: ../src/common/docview.cpp:1262
 msgid "Print Preview"
 msgstr "Afdrukvoorbeeld"
 
-#: ../src/common/prntbase.cpp:2015 ../src/common/prntbase.cpp:2057
-#: ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2037 ../src/common/prntbase.cpp:2079
+#: ../src/common/prntbase.cpp:2087
 msgid "Print Preview Failure"
 msgstr "Afdrukvoorbeeld mislukt"
 
-#: ../src/generic/prntdlgg.cpp:224
+#: ../src/generic/prntdlgg.cpp:217
 msgid "Print Range"
 msgstr "Afdrukbereik"
 
-#: ../src/generic/prntdlgg.cpp:449
+#: ../src/generic/prntdlgg.cpp:442
 msgid "Print Setup"
 msgstr "Afdrukinstellingen"
 
-#: ../src/generic/prntdlgg.cpp:621
+#: ../src/generic/prntdlgg.cpp:614
 msgid "Print in colour"
 msgstr "In kleur afdrukken"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/osx/webview_webkit.mm:260
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "Kolombeschrijving kon niet worden geïnitialiseerd."
+
+#: ../src/common/stockitem.cpp:179
 msgid "Print previe&w..."
 msgstr "&Afdrukvoorbeeld..."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1256
 msgid "Print preview creation failed."
 msgstr "Maken afdrukvoorbeeld mislukt."
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/common/stockitem.cpp:179
 msgid "Print preview..."
 msgstr "Afdrukvoorbeeld..."
 
-#: ../src/generic/prntdlgg.cpp:630
+#: ../src/generic/prntdlgg.cpp:623
 msgid "Print spooling"
 msgstr "Afdruk-spoolen"
 
-#: ../src/html/helpwnd.cpp:675
+#: ../src/html/helpwnd.cpp:673
 msgid "Print this page"
 msgstr "Deze pagina afdrukken"
 
-#: ../src/generic/prntdlgg.cpp:185
+#: ../src/generic/prntdlgg.cpp:178
 msgid "Print to File"
 msgstr "Naar bestand afdrukken"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "Print..."
 msgstr "Afdrukken..."
 
-#: ../src/generic/prntdlgg.cpp:493
+#: ../src/generic/prntdlgg.cpp:486
 msgid "Printer"
 msgstr "Printer"
 
-#: ../src/generic/prntdlgg.cpp:633
+#: ../src/generic/prntdlgg.cpp:626
 msgid "Printer command:"
 msgstr "Printercommando:"
 
-#: ../src/generic/prntdlgg.cpp:180
+#: ../src/generic/prntdlgg.cpp:173
 msgid "Printer options"
 msgstr "Printer-opties"
 
-#: ../src/generic/prntdlgg.cpp:645
+#: ../src/generic/prntdlgg.cpp:638
 msgid "Printer options:"
 msgstr "Printer-opties:"
 
-#: ../src/generic/prntdlgg.cpp:916
+#: ../src/generic/prntdlgg.cpp:909
 msgid "Printer..."
 msgstr "Printer..."
 
-#: ../src/generic/prntdlgg.cpp:196
+#: ../src/generic/prntdlgg.cpp:189
 msgid "Printer:"
 msgstr "Printer:"
 
-#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:535
-#: ../src/html/htmprint.cpp:277
+#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:530
+#: ../src/html/htmprint.cpp:289
 msgid "Printing"
 msgstr "Bezig met afdrukken"
 
-#: ../src/common/prntbase.cpp:612
+#: ../src/common/prntbase.cpp:607
 msgid "Printing "
 msgstr "Bezig met afdrukken "
 
-#: ../src/common/prntbase.cpp:347
+#: ../src/common/prntbase.cpp:342
 msgid "Printing Error"
 msgstr "Afdrukfout"
 
-#: ../src/common/prntbase.cpp:565
+#: ../src/osx/webview_webkit.mm:251
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "Gzip niet ondersteund door deze versie van zlib"
+
+#: ../src/common/prntbase.cpp:560
 #, c-format
 msgid "Printing page %d"
 msgstr "Bezig met afdrukken van pagina %d"
 
-#: ../src/common/prntbase.cpp:570
+#: ../src/common/prntbase.cpp:565
 #, c-format
 msgid "Printing page %d of %d"
 msgstr "Bezig met afdrukken van pagina %d van %d"
 
-#: ../src/generic/printps.cpp:201
+#: ../src/generic/printps.cpp:182
 #, c-format
 msgid "Printing page %d..."
 msgstr "Bezig met afdrukken van pagina %d..."
 
-#: ../src/generic/printps.cpp:161
+#: ../src/generic/printps.cpp:142
 msgid "Printing..."
 msgstr "Bezig met afdrukken..."
 
-#: ../include/wx/richtext/richtextprint.h:109 ../include/wx/prntbase.h:267
-#: ../src/common/docview.cpp:2132
+#: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
+#: ../src/common/docview.cpp:2137
 msgid "Printout"
 msgstr "Afdruk"
 
-#: ../src/common/debugrpt.cpp:560
+#: ../src/common/debugrpt.cpp:561
 #, c-format
 msgid ""
 "Processing debug report has failed, leaving the files in \"%s\" directory."
@@ -5878,102 +6039,102 @@ msgstr ""
 "Verwerking van foutopsporingsrapport mislukt. Bestanden zijn achtergelaten "
 "in de \"%s\" map."
 
-#: ../src/common/prntbase.cpp:545
+#: ../src/common/prntbase.cpp:540
 msgid "Progress:"
 msgstr "Voortgang:"
 
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181
 msgid "Properties"
 msgstr "Eigenschappen"
 
-#: ../src/propgrid/manager.cpp:237
+#: ../src/propgrid/manager.cpp:223
 msgid "Property"
 msgstr "Eigenschap"
 
 #. TRANSLATORS: Caption of message box displaying any property error
-#: ../src/propgrid/propgrid.cpp:3185 ../src/propgrid/propgrid.cpp:3318
+#: ../src/propgrid/propgrid.cpp:3162 ../src/propgrid/propgrid.cpp:3299
 msgid "Property Error"
 msgstr "Eigenschapsfout"
 
-#: ../src/propgrid/advprops.cpp:1597
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Purple"
 msgstr "Paars"
 
-#: ../src/common/paper.cpp:112
+#: ../src/common/paper.cpp:109
 msgid "Quarto, 215 x 275 mm"
 msgstr "Kwarto, 215 x 275 mm"
 
-#: ../src/generic/logg.cpp:1016
+#: ../src/generic/logg.cpp:1013
 msgid "Question"
 msgstr "Vraag"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1769
+#: ../src/propgrid/advprops.cpp:1670
 msgid "Question Arrow"
 msgstr "Vraagteken pijl"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "Quit"
 msgstr "Afsluiten"
 
-#: ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:477
 #, c-format
 msgid "Quit %s"
 msgstr "Stop %s"
 
-#: ../src/common/stockitem.cpp:263
+#: ../src/common/stockitem.cpp:261
 msgid "Quit this program"
 msgstr "Dit programma afsluiten"
 
-#: ../src/common/accelcmn.cpp:338
+#: ../src/common/accelcmn.cpp:352
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/ffile.cpp:109 ../src/common/ffile.cpp:133
+#: ../src/common/ffile.cpp:107 ../src/common/ffile.cpp:132
 #, c-format
 msgid "Read error on file '%s'"
 msgstr "Leesfout bij bestand '%s'"
 
-#: ../src/common/secretstore.cpp:199
-#, c-format
-msgid "Reading password for \"%s/%s\" failed: %s."
+#: ../src/common/secretstore.cpp:211
+#, fuzzy, c-format
+msgid "Reading password for \"%s\" failed: %s."
 msgstr "Het lezen van wachtwoord voor \"%s/%s\" is mislukt: %s."
 
-#: ../src/common/prntbase.cpp:272
+#: ../src/common/prntbase.cpp:267
 msgid "Ready"
 msgstr "Gereed"
 
-#: ../src/propgrid/advprops.cpp:1605
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Red"
 msgstr "Rood"
 
-#: ../src/generic/colrdlgg.cpp:339
+#: ../src/generic/colrdlgg.cpp:359
 msgid "Red:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:185 ../src/stc/stc_i18n.cpp:16
+#: ../src/common/stockitem.cpp:182 ../src/stc/stc_i18n.cpp:16
 msgid "Redo"
 msgstr "Opnieuw"
 
-#: ../src/common/stockitem.cpp:264
+#: ../src/common/stockitem.cpp:262
 msgid "Redo last action"
 msgstr "Herhaal laatste actie"
 
-#: ../src/common/stockitem.cpp:186
+#: ../src/common/stockitem.cpp:183
 msgid "Refresh"
 msgstr "Verversen"
 
-#: ../src/msw/registry.cpp:626
+#: ../src/msw/registry.cpp:615
 #, c-format
 msgid "Registry key '%s' already exists."
 msgstr "Registersleutel '%s' bestaat al."
 
-#: ../src/msw/registry.cpp:595
+#: ../src/msw/registry.cpp:584
 #, c-format
 msgid "Registry key '%s' does not exist, cannot rename it."
 msgstr "Registersleutel '%s' bestaat niet, kan niet hernoemen."
 
-#: ../src/msw/registry.cpp:727
+#: ../src/msw/registry.cpp:716
 #, c-format
 msgid ""
 "Registry key '%s' is needed for normal system operation,\n"
@@ -5984,22 +6145,22 @@ msgstr ""
 "wissen maakt uw systeem onbruikbaar:\n"
 "bewerking afgebroken."
 
-#: ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:942
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:917
+#: ../src/msw/registry.cpp:905
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1003
+#: ../src/msw/registry.cpp:991
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:521
+#: ../src/msw/registry.cpp:510
 #, c-format
 msgid "Registry value '%s' already exists."
 msgstr "Registerwaarde '%s' bestaat al."
@@ -6013,71 +6174,77 @@ msgstr "Normaal"
 msgid "Relative"
 msgstr "Relatief"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:456
 msgid "Relevant entries:"
 msgstr "Relevante ingangen:"
 
-#: ../include/wx/generic/progdlgg.h:86
+#: ../include/wx/generic/progdlgg.h:87
 msgid "Remaining time:"
 msgstr "Resterende tijd:"
 
-#: ../src/common/stockitem.cpp:187
+#: ../src/common/stockitem.cpp:184
 msgid "Remove"
 msgstr "Weghalen"
 
-#: ../src/richtext/richtextctrl.cpp:1562
+#: ../src/richtext/richtextctrl.cpp:1563
 msgid "Remove Bullet"
 msgstr "Bolletje weghalen"
 
-#: ../src/html/helpwnd.cpp:433
+#: ../src/html/helpwnd.cpp:431
 msgid "Remove current page from bookmarks"
 msgstr "Verwijder huidige pagina uit favorieten"
 
-#: ../src/common/rendcmn.cpp:194
+#: ../src/common/rendcmn.cpp:191
 #, c-format
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 "Renderer \"%s\" heeft incompatibele versie %d.%d en kan niet worden geladen."
 
-#: ../src/richtext/richtextbuffer.cpp:4527
+#: ../src/richtext/richtextbuffer.cpp:4524
 msgid "Renumber List"
 msgstr "Hernummer lijst"
 
-#: ../src/common/stockitem.cpp:188
-msgid "Rep&lace"
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Rep&lace..."
 msgstr "&Vervangen"
 
-#: ../src/richtext/richtextctrl.cpp:3673 ../src/common/stockitem.cpp:188
+#: ../src/richtext/richtextctrl.cpp:3674
 msgid "Replace"
 msgstr "Vervangen"
 
-#: ../src/generic/fdrepdlg.cpp:182
+#: ../src/generic/fdrepdlg.cpp:179
 msgid "Replace &all"
 msgstr "Allemaal vervangen"
 
-#: ../src/common/stockitem.cpp:261
-msgid "Replace selection"
-msgstr "Selectie vervangen"
-
-#: ../src/generic/fdrepdlg.cpp:124
+#: ../src/generic/fdrepdlg.cpp:121
 msgid "Replace with:"
 msgstr "Vervangen met:"
 
-#: ../src/common/valtext.cpp:163
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Replace..."
+msgstr "Vervangen"
+
+#: ../src/common/valtext.cpp:184
 msgid "Required information entry is empty."
 msgstr "Vereiste informatieregel is leeg."
 
-#: ../src/common/translation.cpp:1975
+#: ../src/common/translation.cpp:2025
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "Bronbestand '%s' is geen geldige berichtencatalogus."
 
+#: ../src/gtk/webview_webkit.cpp:985
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:56
+#: ../src/common/accelcmn.cpp:53
 msgid "Return"
 msgstr "Terugtoets"
 
-#: ../src/common/stockitem.cpp:189
+#: ../src/common/stockitem.cpp:186
 msgid "Revert to Saved"
 msgstr "Terug naar Opgeslagen"
 
@@ -6089,41 +6256,41 @@ msgstr "Rug"
 msgid "Rig&ht-to-left"
 msgstr "Rech&ts-naar-links"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6149
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:59 ../src/generic/datavgen.cpp:6954
+#: ../src/richtext/richtextsizepage.cpp:250
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextbulletspage.cpp:188
-#: ../src/richtext/richtextsizepage.cpp:250 ../src/common/accelcmn.cpp:62
 msgid "Right"
 msgstr "Rechts"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1754
+#: ../src/propgrid/advprops.cpp:1655
 msgid "Right Arrow"
 msgstr "Right Arrow"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1770
+#: ../src/propgrid/advprops.cpp:1671
 msgid "Right Button"
 msgstr "Rechter knop"
 
-#: ../src/generic/prntdlgg.cpp:892
+#: ../src/generic/prntdlgg.cpp:885
 msgid "Right margin (mm):"
 msgstr "Rechtermarge (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:148
-#: ../src/richtext/richtextindentspage.cpp:150
 #: ../src/richtext/richtextliststylepage.cpp:337
 #: ../src/richtext/richtextliststylepage.cpp:339
+#: ../src/richtext/richtextindentspage.cpp:148
+#: ../src/richtext/richtextindentspage.cpp:150
 msgid "Right-align text."
 msgstr "Rechtsuitgelijnde tekst."
 
-#: ../src/generic/fontdlgg.cpp:322
+#: ../src/generic/fontdlgg.cpp:318
 msgid "Roman"
 msgstr "Romein"
 
-#: ../src/generic/datavgen.cpp:5916
+#: ../src/generic/datavgen.cpp:6721
 #, c-format
 msgid "Row %i"
 msgstr ""
@@ -6133,30 +6300,31 @@ msgstr ""
 msgid "S&tandard bullet name:"
 msgstr "S&tandaard naam opsommingsteken:"
 
-#: ../src/common/accelcmn.cpp:268 ../src/common/accelcmn.cpp:350
+#: ../src/common/accelcmn.cpp:282 ../src/common/accelcmn.cpp:367
 msgid "SPECIAL"
 msgstr "SPECIAAL"
 
-#: ../src/common/stockitem.cpp:190 ../src/common/sizer.cpp:2797
+#: ../src/common/stockitem.cpp:187 ../src/common/sizer.cpp:2914
 msgid "Save"
 msgstr "Bewaren"
 
-#: ../src/common/fldlgcmn.cpp:342
+#: ../src/common/fldlgcmn.cpp:339
 #, c-format
 msgid "Save %s file"
 msgstr "Sla %s-bestand op"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/common/stockitem.cpp:188 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Opslaan &Als..."
 
-#: ../src/common/docview.cpp:366
+#: ../src/common/docview.cpp:359
 msgid "Save As"
 msgstr "Opslaan Als"
 
-#: ../src/common/stockitem.cpp:191
-msgid "Save as"
-msgstr "Opslaan Als"
+#: ../src/common/stockitem.cpp:188
+#, fuzzy
+msgid "Save As..."
+msgstr "Opslaan &Als..."
 
 #: ../src/common/stockitem.cpp:267
 msgid "Save current document"
@@ -6166,40 +6334,40 @@ msgstr "Huidig document opslaan"
 msgid "Save current document with a different filename"
 msgstr "Het huidige bestand onder een nieuwe naam opslaan"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/generic/logg.cpp:509
 msgid "Save log contents to file"
 msgstr "Sla log-gegevens op in bestand"
 
-#: ../src/common/secretstore.cpp:179
-#, c-format
-msgid "Saving password for \"%s/%s\" failed: %s."
+#: ../src/common/secretstore.cpp:189
+#, fuzzy, c-format
+msgid "Saving password for \"%s\" failed: %s."
 msgstr "Het opslaan van wachtwoord voor \"%s/%s\" is mislukt: %s."
 
-#: ../src/generic/fontdlgg.cpp:325
+#: ../src/generic/fontdlgg.cpp:321
 msgid "Script"
 msgstr "Script"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll Lock"
 msgstr "Scroll Lock"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll_lock"
 msgstr "Scroll_lock"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:890
+#: ../src/propgrid/advprops.cpp:791
 msgid "Scrollbar"
 msgstr "Scrollbar"
 
-#: ../src/generic/srchctlg.cpp:56 ../src/html/helpwnd.cpp:535
-#: ../src/html/helpwnd.cpp:550
+#: ../src/generic/srchctlg.cpp:55 ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:548 ../src/gtk/srchctrl.cpp:182
 msgid "Search"
 msgstr "Zoeken"
 
-#: ../src/html/helpwnd.cpp:537
+#: ../src/html/helpwnd.cpp:535
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
@@ -6207,32 +6375,32 @@ msgstr ""
 "Zoek in inhoudsopgave van helpbestand(en) naar alle plaatsen waar de tekst "
 "die u boven heeft getypt voorkomt"
 
-#: ../src/generic/fdrepdlg.cpp:160
+#: ../src/generic/fdrepdlg.cpp:157
 msgid "Search direction"
 msgstr "Zoek richting"
 
-#: ../src/generic/fdrepdlg.cpp:112
+#: ../src/generic/fdrepdlg.cpp:109
 msgid "Search for:"
 msgstr "Zoeken naar:"
 
-#: ../src/html/helpwnd.cpp:1052
+#: ../src/html/helpwnd.cpp:1050
 msgid "Search in all books"
 msgstr "Zoek in alle boeken"
 
-#: ../src/html/helpwnd.cpp:857
+#: ../src/html/helpwnd.cpp:855
 msgid "Searching..."
 msgstr "Bezig met zoeken..."
 
-#: ../src/generic/dirctrlg.cpp:446
+#: ../src/generic/dirctrlg.cpp:412
 msgid "Sections"
 msgstr "Secties"
 
-#: ../src/common/ffile.cpp:238
+#: ../src/common/ffile.cpp:237
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Zoekfout bij bestand '%s'"
 
-#: ../src/common/ffile.cpp:228
+#: ../src/common/ffile.cpp:227
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
@@ -6240,24 +6408,24 @@ msgstr ""
 "stdio)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:76
+#: ../src/common/accelcmn.cpp:73
 msgid "Select"
 msgstr "Selecteer"
 
-#: ../src/richtext/richtextctrl.cpp:337 ../src/osx/textctrl_osx.cpp:581
-#: ../src/common/stockitem.cpp:192 ../src/msw/textctrl.cpp:2512
+#: ../src/osx/textctrl_osx.cpp:599 ../src/common/stockitem.cpp:189
+#: ../src/msw/textctrl.cpp:2777 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Selecteer alles"
 
-#: ../src/common/stockitem.cpp:192 ../src/stc/stc_i18n.cpp:21
+#: ../src/common/stockitem.cpp:189 ../src/stc/stc_i18n.cpp:21
 msgid "Select All"
 msgstr "Selecteer alles"
 
-#: ../src/common/docview.cpp:1895
+#: ../src/common/docview.cpp:1900
 msgid "Select a document template"
 msgstr "Selecteer een documentsjabloon"
 
-#: ../src/common/docview.cpp:1969
+#: ../src/common/docview.cpp:1974
 msgid "Select a document view"
 msgstr "Selecteer een documentweergave"
 
@@ -6286,20 +6454,20 @@ msgid "Selects the list level to edit."
 msgstr "Selecteert het lijstniveau voor bewerking."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:82
+#: ../src/common/accelcmn.cpp:79
 msgid "Separator"
 msgstr "Scheidingsteken"
 
-#: ../src/common/cmdline.cpp:1083
+#: ../src/common/cmdline.cpp:1079
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Scheidingsteken verwacht na de optie '%s'."
 
-#: ../src/osx/menu_osx.cpp:572
+#: ../src/osx/menu_osx.cpp:464
 msgid "Services"
 msgstr "Diensten"
 
-#: ../src/richtext/richtextbuffer.cpp:11217
+#: ../src/richtext/richtextbuffer.cpp:11216
 msgid "Set Cell Style"
 msgstr "Cel stijl instellen"
 
@@ -6307,11 +6475,11 @@ msgstr "Cel stijl instellen"
 msgid "SetProperty called w/o valid setter"
 msgstr "SetProperty aangeroepen zonder geldige \"setter\""
 
-#: ../src/generic/prntdlgg.cpp:188
+#: ../src/generic/prntdlgg.cpp:181
 msgid "Setup..."
 msgstr "Instellingen..."
 
-#: ../src/msw/dialup.cpp:544
+#: ../src/msw/dialup.cpp:538
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr ""
 "Meerdere actieve inbelverbindingen gevonden, willekeurige keuze gemaakt."
@@ -6328,40 +6496,40 @@ msgstr "Schaduw"
 msgid "Shadow c&olour:"
 msgstr "Schad&uwkleur:"
 
-#: ../src/common/accelcmn.cpp:335
+#: ../src/common/accelcmn.cpp:349
 msgid "Shift+"
 msgstr "Shift+"
 
-#: ../src/generic/dirdlgg.cpp:147
+#: ../src/generic/dirdlgg.cpp:144
 msgid "Show &hidden directories"
 msgstr "Toon &verborgen mappen"
 
-#: ../src/generic/filectrlg.cpp:983
+#: ../src/generic/filectrlg.cpp:979
 msgid "Show &hidden files"
 msgstr "Toon &Verborgen bestanden"
 
-#: ../src/osx/menu_osx.cpp:580
+#: ../src/osx/menu_osx.cpp:472
 msgid "Show All"
 msgstr "Toon alles"
 
-#: ../src/common/stockitem.cpp:257
+#: ../src/common/stockitem.cpp:254
 msgid "Show about dialog"
 msgstr "Toon 'Over' dialoogvenster"
 
-#: ../src/html/helpwnd.cpp:492
+#: ../src/html/helpwnd.cpp:490
 msgid "Show all"
 msgstr "Toon alles"
 
-#: ../src/html/helpwnd.cpp:503
+#: ../src/html/helpwnd.cpp:501
 msgid "Show all items in index"
 msgstr "Toon alle elementen in de index"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:656
 msgid "Show/hide navigation panel"
 msgstr "Toon/verberg navigatie-paneel"
 
-#: ../src/richtext/richtextsymboldlg.cpp:421
-#: ../src/richtext/richtextsymboldlg.cpp:423
+#: ../src/richtext/richtextsymboldlg.cpp:418
+#: ../src/richtext/richtextsymboldlg.cpp:420
 msgid "Shows a Unicode subset."
 msgstr "Toont een Unicode subset."
 
@@ -6377,7 +6545,7 @@ msgstr "Toont een voorbeeld van de opsommingtekens instellingen."
 msgid "Shows a preview of the font settings."
 msgstr "Toon een voorbeeld van de lettertype instellingen."
 
-#: ../src/osx/carbon/fontdlg.cpp:394 ../src/osx/carbon/fontdlg.cpp:396
+#: ../src/osx/carbon/fontdlg.cpp:391 ../src/osx/carbon/fontdlg.cpp:393
 msgid "Shows a preview of the font."
 msgstr "Toont een voorbeeld van het lettertype."
 
@@ -6386,62 +6554,62 @@ msgstr "Toont een voorbeeld van het lettertype."
 msgid "Shows a preview of the paragraph settings."
 msgstr "Toont een voorbeeld van de paragraaf instellingen."
 
-#: ../src/generic/fontdlgg.cpp:460 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:456 ../src/generic/fontdlgg.cpp:458
 msgid "Shows the font preview."
 msgstr "Toont het lettertype voorbeeld."
 
-#: ../src/propgrid/advprops.cpp:1607
+#: ../src/propgrid/advprops.cpp:1513
 msgid "Silver"
 msgstr "Zilver"
 
-#: ../src/univ/themes/mono.cpp:516
+#: ../src/univ/themes/mono.cpp:513
 msgid "Simple monochrome theme"
 msgstr "Eenvoudig monochroom thema"
 
-#: ../src/richtext/richtextindentspage.cpp:275
 #: ../src/richtext/richtextliststylepage.cpp:449
+#: ../src/richtext/richtextindentspage.cpp:275
 msgid "Single"
 msgstr "Enkel"
 
-#: ../src/generic/filectrlg.cpp:425 ../src/richtext/richtextformatdlg.cpp:369
-#: ../src/richtext/richtextsizepage.cpp:299
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextsizepage.cpp:299
+#: ../src/richtext/richtextformatdlg.cpp:362
 msgid "Size"
 msgstr "Formaat"
 
-#: ../src/osx/carbon/fontdlg.cpp:339
+#: ../src/osx/carbon/fontdlg.cpp:336
 msgid "Size:"
 msgstr "Grootte:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1775
+#: ../src/propgrid/advprops.cpp:1676
 msgid "Sizing"
 msgstr "Dimensionering"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1772
+#: ../src/propgrid/advprops.cpp:1673
 msgid "Sizing N-S"
 msgstr "Dimensionering N-Z"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1771
+#: ../src/propgrid/advprops.cpp:1672
 msgid "Sizing NE-SW"
 msgstr "Dimensionering NO-ZW"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1773
+#: ../src/propgrid/advprops.cpp:1674
 msgid "Sizing NW-SE"
 msgstr "Dimensionering NW-ZO"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1774
+#: ../src/propgrid/advprops.cpp:1675
 msgid "Sizing W-E"
 msgstr "Dimensionering W-O"
 
-#: ../src/msw/progdlg.cpp:801
+#: ../src/msw/progdlg.cpp:1088
 msgid "Skip"
 msgstr "Overslaan"
 
-#: ../src/generic/fontdlgg.cpp:330
+#: ../src/generic/fontdlgg.cpp:326
 msgid "Slant"
 msgstr "Schuin"
 
@@ -6450,7 +6618,7 @@ msgid "Small C&apitals"
 msgstr "Klein kapitaal"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:79
+#: ../src/common/accelcmn.cpp:76
 msgid "Snapshot"
 msgstr "Momentopname"
 
@@ -6458,37 +6626,37 @@ msgstr "Momentopname"
 msgid "Solid"
 msgstr "Solide"
 
-#: ../src/common/docview.cpp:1791
+#: ../src/common/docview.cpp:1785
 msgid "Sorry, could not open this file."
 msgstr "Sorry, kon dit bestand niet openen."
 
-#: ../src/common/prntbase.cpp:2057 ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2079 ../src/common/prntbase.cpp:2087
 msgid "Sorry, not enough memory to create a preview."
 msgstr "Sorry, onvoldoende geheugen voor afdrukweergave."
 
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "Sorry, that name is taken. Please choose another."
 msgstr "Helaas, die naam bestaat al. Kies een andere."
 
-#: ../src/common/docview.cpp:1814
+#: ../src/common/docview.cpp:1819
 msgid "Sorry, the format for this file is unknown."
 msgstr "Helaas, het formaat van dit bestand is onbekend."
 
-#: ../src/unix/sound.cpp:492
+#: ../src/unix/sound.cpp:481
 msgid "Sound data are in unsupported format."
 msgstr "De geluidsdata zijn in een niet ondersteund formaat."
 
-#: ../src/unix/sound.cpp:477
+#: ../src/unix/sound.cpp:466
 #, c-format
 msgid "Sound file '%s' is in unsupported format."
 msgstr "Geluidsbestand '%s' heeft een niet ondersteund formaat."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:67
+#: ../src/common/accelcmn.cpp:64
 msgid "Space"
 msgstr "Spatie"
 
@@ -6496,12 +6664,12 @@ msgstr "Spatie"
 msgid "Spacing"
 msgstr "Tussenruimtebepaling"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "Spell Check"
 msgstr "Spellingscontrole"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1776
+#: ../src/propgrid/advprops.cpp:1677
 msgid "Spraycan"
 msgstr "Spuitbus"
 
@@ -6510,7 +6678,7 @@ msgstr "Spuitbus"
 msgid "Standard"
 msgstr "Standaard"
 
-#: ../src/common/paper.cpp:104
+#: ../src/common/paper.cpp:101
 msgid "Statement, 5 1/2 x 8 1/2 in"
 msgstr "USA Statement, 5 1/2 x 8 1/2 inch"
 
@@ -6519,33 +6687,29 @@ msgstr "USA Statement, 5 1/2 x 8 1/2 inch"
 msgid "Static"
 msgstr "Statisch"
 
-#: ../src/generic/prntdlgg.cpp:204
+#: ../src/generic/prntdlgg.cpp:197
 msgid "Status:"
 msgstr "Status:"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "Stop"
 msgstr "Stoppen"
 
-#: ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196
 msgid "Strikethrough"
 msgstr "Doorhalen"
 
-#: ../src/common/colourcmn.cpp:45
+#: ../src/common/colourcmn.cpp:42
 #, c-format
 msgid "String To Colour : Incorrect colour specification : %s"
 msgstr "Tekenreeks Naar Kleur : Incorrecte kleur specificatie: %s"
 
 #. TRANSLATORS: Label of font style
-#: ../src/richtext/richtextformatdlg.cpp:339 ../src/propgrid/advprops.cpp:680
+#: ../src/propgrid/advprops.cpp:590 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Stijl"
 
-#: ../include/wx/richtext/richtextstyledlg.h:46
-msgid "Style Organiser"
-msgstr "Stijl Organiseren"
-
-#: ../src/osx/carbon/fontdlg.cpp:348
+#: ../src/osx/carbon/fontdlg.cpp:345
 msgid "Style:"
 msgstr "Stijl:"
 
@@ -6554,7 +6718,7 @@ msgid "Subscrip&t"
 msgstr "Onderschrif&t"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:83
+#: ../src/common/accelcmn.cpp:80
 msgid "Subtract"
 msgstr "Aftrekken"
 
@@ -6562,11 +6726,11 @@ msgstr "Aftrekken"
 msgid "Supe&rscript"
 msgstr "Bovensch&rift"
 
-#: ../src/common/paper.cpp:150
+#: ../src/common/paper.cpp:147
 msgid "SuperA/SuperA/A4 227 x 356 mm"
 msgstr "SuperA/SuperA/A4 227 x 356 mm"
 
-#: ../src/common/paper.cpp:151
+#: ../src/common/paper.cpp:148
 msgid "SuperB/SuperB/A3 305 x 487 mm"
 msgstr "SuperB/SuperB/A3 305 x 487 mm"
 
@@ -6574,7 +6738,7 @@ msgstr "SuperB/SuperB/A3 305 x 487 mm"
 msgid "Suppress hyphe&nation"
 msgstr "Woordafbreking onderdrukken"
 
-#: ../src/generic/fontdlgg.cpp:326
+#: ../src/generic/fontdlgg.cpp:322
 msgid "Swiss"
 msgstr "Schreefloos"
 
@@ -6592,73 +6756,73 @@ msgstr "Symbool &-lettertype:"
 msgid "Symbols"
 msgstr "Symbolen"
 
-#: ../src/common/imagtiff.cpp:369 ../src/common/imagtiff.cpp:382
-#: ../src/common/imagtiff.cpp:741
+#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
+#: ../src/common/imagtiff.cpp:738
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: kon geen geheugen reserveren."
 
-#: ../src/common/imagtiff.cpp:301
+#: ../src/common/imagtiff.cpp:298
 msgid "TIFF: Error loading image."
 msgstr "TIFF: fout bij laden van afbeelding."
 
-#: ../src/common/imagtiff.cpp:468
+#: ../src/common/imagtiff.cpp:465
 msgid "TIFF: Error reading image."
 msgstr "TIFF: fout bij lezen van afbeelding."
 
-#: ../src/common/imagtiff.cpp:608
+#: ../src/common/imagtiff.cpp:605
 msgid "TIFF: Error saving image."
 msgstr "TIFF: fout bij opslaan van afbeelding."
 
-#: ../src/common/imagtiff.cpp:846
+#: ../src/common/imagtiff.cpp:843
 msgid "TIFF: Error writing image."
 msgstr "TIFF: fout bij schrijven van afbeelding."
 
-#: ../src/common/imagtiff.cpp:355
+#: ../src/common/imagtiff.cpp:352
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: Afbeeldingsgrootte is abnormaal groot."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:68
+#: ../src/common/accelcmn.cpp:65
 msgid "Tab"
 msgstr "Tab"
 
-#: ../src/richtext/richtextbuffer.cpp:11498
+#: ../src/richtext/richtextbuffer.cpp:11497
 msgid "Table Properties"
 msgstr "Tabel eigenschappen"
 
-#: ../src/common/paper.cpp:145
+#: ../src/common/paper.cpp:142
 msgid "Tabloid Extra 11.69 x 18 in"
 msgstr "Tabloid Extra 11.69 x 18 in"
 
-#: ../src/common/paper.cpp:102
+#: ../src/common/paper.cpp:99
 msgid "Tabloid, 11 x 17 in"
 msgstr "USA Tabloid, 11 x 17 inch"
 
-#: ../src/richtext/richtextformatdlg.cpp:354
+#: ../src/richtext/richtextformatdlg.cpp:347
 msgid "Tabs"
 msgstr "Tabs"
 
-#: ../src/propgrid/advprops.cpp:1598
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Teal"
 msgstr "Blauwgroen"
 
-#: ../src/generic/fontdlgg.cpp:327
+#: ../src/generic/fontdlgg.cpp:323
 msgid "Teletype"
 msgstr "Niet proportioneel (Teletype)"
 
-#: ../src/common/docview.cpp:1896
+#: ../src/common/docview.cpp:1901
 msgid "Templates"
 msgstr "Sjablonen"
 
-#: ../src/common/fmapbase.cpp:158
+#: ../src/common/fmapbase.cpp:155
 msgid "Thai (ISO-8859-11)"
 msgstr "Thais (ISO-8859-11)"
 
-#: ../src/common/ftp.cpp:619
+#: ../src/common/ftp.cpp:622
 msgid "The FTP server doesn't support passive mode."
 msgstr "De FTP server ondersteunt niet passieve mode."
 
-#: ../src/common/ftp.cpp:605
+#: ../src/common/ftp.cpp:608
 msgid "The FTP server doesn't support the PORT command."
 msgstr "De FTP server ondersteunt het PORT commando niet."
 
@@ -6669,8 +6833,8 @@ msgstr "De FTP server ondersteunt het PORT commando niet."
 msgid "The available bullet styles."
 msgstr "De beschikbare opsommingsteken stijlen."
 
-#: ../src/richtext/richtextstyledlg.cpp:202
-#: ../src/richtext/richtextstyledlg.cpp:204
+#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:200
 msgid "The available styles."
 msgstr "De beschikbare Stijlen."
 
@@ -6726,12 +6890,12 @@ msgstr "De onderpositie."
 msgid "The bullet character."
 msgstr "Het opsommingsteken letterteken."
 
-#: ../src/richtext/richtextsymboldlg.cpp:443
-#: ../src/richtext/richtextsymboldlg.cpp:445
+#: ../src/richtext/richtextsymboldlg.cpp:440
+#: ../src/richtext/richtextsymboldlg.cpp:442
 msgid "The character code."
 msgstr "De Letterteken code."
 
-#: ../src/common/fontmap.cpp:203
+#: ../src/common/fontmap.cpp:200
 #, c-format
 msgid ""
 "The charset '%s' is unknown. You may select\n"
@@ -6742,7 +6906,7 @@ msgstr ""
 "tekenset kiezen om te vervangen of kies [Annuleer]\n"
 "als het niet vervangen kan worden"
 
-#: ../src/msw/ole/dataobj.cpp:394
+#: ../src/msw/ole/dataobj.cpp:402
 #, c-format
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "Het klembord-formaat '%d' bestaat niet."
@@ -6752,7 +6916,7 @@ msgstr "Het klembord-formaat '%d' bestaat niet."
 msgid "The default style for the next paragraph."
 msgstr "De standaard stijl voor de volgende paragraaf."
 
-#: ../src/generic/dirdlgg.cpp:202
+#: ../src/generic/dirdlgg.cpp:199
 #, c-format
 msgid ""
 "The directory '%s' does not exist\n"
@@ -6761,7 +6925,7 @@ msgstr ""
 "De map '%s' bestaat niet\n"
 "Nu maken?"
 
-#: ../src/html/htmprint.cpp:271
+#: ../src/html/htmprint.cpp:283
 #, c-format
 msgid ""
 "The document \"%s\" doesn't fit on the page horizontally and will be "
@@ -6774,7 +6938,7 @@ msgstr ""
 "\n"
 "Wilt u ondanks dat toch doorgaan met afdrukken?"
 
-#: ../src/common/docview.cpp:1202
+#: ../src/common/docview.cpp:1196
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -6783,36 +6947,36 @@ msgstr ""
 "Het bestand '%s' bestaat niet en kon niet geopend worden.\n"
 "Het is verwijderd van de lijst 'recente bestanden'."
 
-#: ../src/richtext/richtextindentspage.cpp:208
-#: ../src/richtext/richtextindentspage.cpp:210
 #: ../src/richtext/richtextliststylepage.cpp:394
 #: ../src/richtext/richtextliststylepage.cpp:396
+#: ../src/richtext/richtextindentspage.cpp:208
+#: ../src/richtext/richtextindentspage.cpp:210
 msgid "The first line indent."
 msgstr "De eerste regel inspringing."
 
-#: ../src/gtk/utilsgtk.cpp:481
-msgid "The following standard GTK+ options are also supported:\n"
-msgstr "De volgende standaard GTK+ opties worden ook ondersteund:\n"
+#: ../src/generic/dbgrptg.cpp:318
+msgid "The following debug report will be generated\n"
+msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:414 ../src/generic/fontdlgg.cpp:416
+#: ../src/generic/fontdlgg.cpp:411 ../src/generic/fontdlgg.cpp:413
 msgid "The font colour."
 msgstr "De lettertypekleur."
 
-#: ../src/generic/fontdlgg.cpp:375 ../src/generic/fontdlgg.cpp:377
+#: ../src/generic/fontdlgg.cpp:371 ../src/generic/fontdlgg.cpp:373
 msgid "The font family."
 msgstr "De lettertypefamilie."
 
-#: ../src/richtext/richtextsymboldlg.cpp:405
-#: ../src/richtext/richtextsymboldlg.cpp:407
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "The font from which to take the symbol."
 msgstr "Het lettertype waar het symbool van wordt genomen."
 
-#: ../src/generic/fontdlgg.cpp:427 ../src/generic/fontdlgg.cpp:429
-#: ../src/generic/fontdlgg.cpp:434 ../src/generic/fontdlgg.cpp:436
+#: ../src/generic/fontdlgg.cpp:424 ../src/generic/fontdlgg.cpp:426
+#: ../src/generic/fontdlgg.cpp:430 ../src/generic/fontdlgg.cpp:432
 msgid "The font point size."
 msgstr "De lettertype puntgrootte."
 
-#: ../src/osx/carbon/fontdlg.cpp:343 ../src/osx/carbon/fontdlg.cpp:345
+#: ../src/osx/carbon/fontdlg.cpp:340 ../src/osx/carbon/fontdlg.cpp:342
 msgid "The font size in points."
 msgstr "De lettertypegrootte in punten."
 
@@ -6821,15 +6985,15 @@ msgstr "De lettertypegrootte in punten."
 msgid "The font size units, points or pixels."
 msgstr "De lettertypegrootte in units, punten of pixels."
 
-#: ../src/generic/fontdlgg.cpp:386 ../src/generic/fontdlgg.cpp:388
+#: ../src/generic/fontdlgg.cpp:382 ../src/generic/fontdlgg.cpp:384
 msgid "The font style."
 msgstr "De lettertypestijl."
 
-#: ../src/generic/fontdlgg.cpp:397 ../src/generic/fontdlgg.cpp:399
+#: ../src/generic/fontdlgg.cpp:393 ../src/generic/fontdlgg.cpp:395
 msgid "The font weight."
 msgstr "De lettertypegewicht."
 
-#: ../src/common/docview.cpp:1483
+#: ../src/common/docview.cpp:1477
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Het formaat van bestand '%s' kan niet worden bepaald."
@@ -6839,10 +7003,10 @@ msgstr "Het formaat van bestand '%s' kan niet worden bepaald."
 msgid "The horizontal offset."
 msgstr "De horizontale verschuiving."
 
-#: ../src/richtext/richtextindentspage.cpp:199
-#: ../src/richtext/richtextindentspage.cpp:201
 #: ../src/richtext/richtextliststylepage.cpp:385
 #: ../src/richtext/richtextliststylepage.cpp:387
+#: ../src/richtext/richtextindentspage.cpp:199
+#: ../src/richtext/richtextindentspage.cpp:201
 msgid "The left indent."
 msgstr "De Linkse inspringing."
 
@@ -6863,10 +7027,10 @@ msgstr "De grootte van de linker uitvulruimte."
 msgid "The left position."
 msgstr "De linkerpositie."
 
-#: ../src/richtext/richtextindentspage.cpp:288
-#: ../src/richtext/richtextindentspage.cpp:290
 #: ../src/richtext/richtextliststylepage.cpp:462
 #: ../src/richtext/richtextliststylepage.cpp:464
+#: ../src/richtext/richtextindentspage.cpp:288
+#: ../src/richtext/richtextindentspage.cpp:290
 msgid "The line spacing."
 msgstr "De regeltussenruimte."
 
@@ -6875,7 +7039,7 @@ msgstr "De regeltussenruimte."
 msgid "The list item number."
 msgstr "Het nummer van de elementenlijst."
 
-#: ../src/msw/ole/automtn.cpp:664
+#: ../src/msw/ole/automtn.cpp:655
 msgid "The locale ID is unknown."
 msgstr "De lokale ID is onbekend."
 
@@ -6914,19 +7078,19 @@ msgstr "De breedte van het object."
 msgid "The outline level."
 msgstr "Het Outline niveau."
 
-#: ../src/common/log.cpp:277
+#: ../src/common/log.cpp:296
 #, c-format
 msgid "The previous message repeated %u time."
 msgid_plural "The previous message repeated %u times."
 msgstr[0] "Het vorige bericht  is %u keer herhaald."
 msgstr[1] "Het vorige berichten zijn  %u keer herhaald."
 
-#: ../src/common/log.cpp:270
+#: ../src/common/log.cpp:289
 msgid "The previous message repeated once."
 msgstr "Het vorige bericht eenmaal herhaald."
 
-#: ../src/richtext/richtextsymboldlg.cpp:462
-#: ../src/richtext/richtextsymboldlg.cpp:464
+#: ../src/richtext/richtextsymboldlg.cpp:459
+#: ../src/richtext/richtextsymboldlg.cpp:461
 msgid "The range to show."
 msgstr "De te tonen range."
 
@@ -6940,15 +7104,15 @@ msgstr ""
 "bestanden persoonlijke informatie bevat,\n"
 "haal dan het vinkje weg en ze zullen verwijderd worden uit het rapport.\n"
 
-#: ../src/common/cmdline.cpp:1254
+#: ../src/common/cmdline.cpp:1250
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "De benodigde parameter '%s' was niet gespecificeerd."
 
-#: ../src/richtext/richtextindentspage.cpp:217
-#: ../src/richtext/richtextindentspage.cpp:219
 #: ../src/richtext/richtextliststylepage.cpp:403
 #: ../src/richtext/richtextliststylepage.cpp:405
+#: ../src/richtext/richtextindentspage.cpp:217
+#: ../src/richtext/richtextindentspage.cpp:219
 msgid "The right indent."
 msgstr "De rechts inspringing."
 
@@ -6989,16 +7153,16 @@ msgstr "De schaduwondoorzichtigheid."
 msgid "The shadow spread."
 msgstr "De schaduwspreiding."
 
-#: ../src/richtext/richtextindentspage.cpp:267
 #: ../src/richtext/richtextliststylepage.cpp:439
 #: ../src/richtext/richtextliststylepage.cpp:441
+#: ../src/richtext/richtextindentspage.cpp:267
 msgid "The spacing after the paragraph."
 msgstr "De ruimte na de paragraaf."
 
-#: ../src/richtext/richtextindentspage.cpp:257
-#: ../src/richtext/richtextindentspage.cpp:259
 #: ../src/richtext/richtextliststylepage.cpp:430
 #: ../src/richtext/richtextliststylepage.cpp:432
+#: ../src/richtext/richtextindentspage.cpp:257
+#: ../src/richtext/richtextindentspage.cpp:259
 msgid "The spacing before the paragraph."
 msgstr "De tussenruimte voor de paragraaf."
 
@@ -7012,12 +7176,12 @@ msgstr "De stijl naam."
 msgid "The style on which this style is based."
 msgstr "De stijl waarop deze stijl is gebaseerd."
 
-#: ../src/richtext/richtextstyledlg.cpp:214
-#: ../src/richtext/richtextstyledlg.cpp:216
+#: ../src/richtext/richtextstyledlg.cpp:210
+#: ../src/richtext/richtextstyledlg.cpp:212
 msgid "The style preview."
 msgstr "Afdrukvoorbeeld van de stijl."
 
-#: ../src/msw/ole/automtn.cpp:680
+#: ../src/msw/ole/automtn.cpp:671
 msgid "The system cannot find the file specified."
 msgstr "Het systeem kan het opgegeven bestand niet vinden."
 
@@ -7030,7 +7194,7 @@ msgstr "De tab positie."
 msgid "The tab positions."
 msgstr "De tab posities."
 
-#: ../src/richtext/richtextctrl.cpp:3098
+#: ../src/richtext/richtextctrl.cpp:3099
 msgid "The text couldn't be saved."
 msgstr "De tekst kon niet worden opgeslagen."
 
@@ -7051,7 +7215,7 @@ msgstr "De grootte van de bovenuitvulruimte."
 msgid "The top position."
 msgstr "De bovenpositie."
 
-#: ../src/common/cmdline.cpp:1232
+#: ../src/common/cmdline.cpp:1228
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "De waarde voor de optie '%s' moet worden opgegeven."
@@ -7061,7 +7225,7 @@ msgstr "De waarde voor de optie '%s' moet worden opgegeven."
 msgid "The value of the corner radius."
 msgstr "Waarde van de hoek-straal."
 
-#: ../src/msw/dialup.cpp:433
+#: ../src/msw/dialup.cpp:427
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -7076,14 +7240,14 @@ msgstr ""
 msgid "The vertical offset."
 msgstr "De verticale verschuiving."
 
-#: ../src/richtext/richtextprint.cpp:619 ../src/html/htmprint.cpp:745
+#: ../src/html/htmprint.cpp:749 ../src/richtext/richtextprint.cpp:615
 msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr ""
 "Er was een probleem tijdens pagina-instellingen: u moet mogelijk een "
 "standaard printer instellen."
 
-#: ../src/html/htmprint.cpp:255
+#: ../src/html/htmprint.cpp:267
 msgid ""
 "This document doesn't fit on the page horizontally and will be truncated "
 "when it is printed."
@@ -7091,16 +7255,16 @@ msgstr ""
 "Dit document pas horizontaal niet op de pagina en zal worden afgekapt als "
 "het wordt afgedrukt."
 
-#: ../src/common/image.cpp:2854
+#: ../src/common/image.cpp:2963
 #, c-format
 msgid "This is not a %s."
 msgstr "Dit is niet een %s."
 
-#: ../src/common/wincmn.cpp:1653
+#: ../src/common/wincmn.cpp:1654
 msgid "This platform does not support background transparency."
 msgstr "Dit platform ondersteunt  geen transparante achtergrond."
 
-#: ../src/gtk/window.cpp:4660
+#: ../src/gtk/window.cpp:5664
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
@@ -7108,7 +7272,15 @@ msgstr ""
 "Dit programma is gecompileerd met een te oude versie van GTK+. Herbouw het "
 "met GTK+ 2.12 of nieuwer."
 
-#: ../src/msw/thread.cpp:1240
+#: ../src/gtk/glcanvas.cpp:176
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/msw/thread.cpp:1246
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -7116,11 +7288,11 @@ msgstr ""
 "Threadmodule-initialisatie mislukt: kan geen waarde opslaan in lokale thread-"
 "geheugenruimte"
 
-#: ../src/unix/threadpsx.cpp:1794
+#: ../src/unix/threadpsx.cpp:1843
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr "Threadmodule-initialisatie mislukt: maken van thread-sleutel mislukt"
 
-#: ../src/msw/thread.cpp:1228
+#: ../src/msw/thread.cpp:1234
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -7128,84 +7300,84 @@ msgstr ""
 "Threadmodule-initialisatie mislukt: niet mogelijk een index te reserveren in "
 "lokale thread-geheugenruimte"
 
-#: ../src/unix/threadpsx.cpp:1043
+#: ../src/unix/threadpsx.cpp:1061
 msgid "Thread priority setting is ignored."
 msgstr "Thread-prioriteitsinstelling is genegeerd."
 
-#: ../src/msw/mdi.cpp:176
+#: ../src/msw/mdi.cpp:171
 msgid "Tile &Horizontally"
 msgstr "Onder elkaar"
 
-#: ../src/msw/mdi.cpp:177
+#: ../src/msw/mdi.cpp:172
 msgid "Tile &Vertically"
 msgstr "Naast elkaar"
 
-#: ../src/common/ftp.cpp:200
+#: ../src/common/ftp.cpp:197
 msgid "Timeout while waiting for FTP server to connect, try passive mode."
 msgstr ""
 "Time-out tijdens het wachten op FTP server verbinding: probeer de passieve "
 "modus."
 
-#: ../src/generic/tipdlg.cpp:201
+#: ../src/generic/tipdlg.cpp:198
 msgid "Tip of the Day"
 msgstr "Tip van de dag"
 
-#: ../src/generic/tipdlg.cpp:140
+#: ../src/generic/tipdlg.cpp:137
 msgid "Tips not available, sorry!"
 msgstr "Geen tips beschikbaar, sorry!"
 
-#: ../src/generic/prntdlgg.cpp:242
+#: ../src/generic/prntdlgg.cpp:235
 msgid "To:"
 msgstr "Aan:"
 
-#: ../src/richtext/richtextbuffer.cpp:8363
+#: ../src/richtext/richtextbuffer.cpp:8361
 msgid "Too many EndStyle calls!"
 msgstr "Te veel EindStijl aanroepen!"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:891
+#: ../src/propgrid/advprops.cpp:792
 msgid "Tooltip"
 msgstr "Tooltip"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:892
+#: ../src/propgrid/advprops.cpp:793
 msgid "TooltipText"
 msgstr "TooltipText"
 
-#: ../src/richtext/richtextsizepage.cpp:286
-#: ../src/richtext/richtextsizepage.cpp:290 ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197 ../src/richtext/richtextsizepage.cpp:286
+#: ../src/richtext/richtextsizepage.cpp:290
 msgid "Top"
 msgstr "Top"
 
-#: ../src/generic/prntdlgg.cpp:881
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Top margin (mm):"
 msgstr "Bovenmarge (mm):"
 
-#: ../src/generic/aboutdlgg.cpp:79
+#: ../src/generic/aboutdlgg.cpp:76
 msgid "Translations by "
 msgstr "Vertalingen door "
 
-#: ../src/generic/aboutdlgg.cpp:188
+#: ../src/generic/aboutdlgg.cpp:185
 msgid "Translators"
 msgstr "Vertalers"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:211
+#: ../src/propgrid/propgrid.cpp:192
 msgid "True"
 msgstr "Waar"
 
-#: ../src/common/fs_mem.cpp:227
+#: ../src/common/fs_mem.cpp:222
 #, c-format
 msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
 msgstr ""
 "Bezig met poging om bestand '%s' uit geheugen VFS te verwijderen, maar het "
 "is niet geladen!"
 
-#: ../src/common/fmapbase.cpp:156
+#: ../src/common/fmapbase.cpp:153
 msgid "Turkish (ISO-8859-9)"
 msgstr "Turks (ISO-8859-9)"
 
-#: ../src/generic/filectrlg.cpp:426
+#: ../src/generic/filectrlg.cpp:422
 msgid "Type"
 msgstr "Type"
 
@@ -7219,17 +7391,17 @@ msgstr "Typ een lettertype naam."
 msgid "Type a size in points."
 msgstr "Typ een grootte in punten."
 
-#: ../src/msw/ole/automtn.cpp:676
+#: ../src/msw/ole/automtn.cpp:667
 #, c-format
 msgid "Type mismatch in argument %u."
 msgstr "Type komt niet overeen in argument %u."
 
-#: ../src/common/xtixml.cpp:356 ../src/common/xtixml.cpp:509
-#: ../src/common/xtistrm.cpp:318
+#: ../src/common/xtixml.cpp:352 ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315
 msgid "Type must have enum - long conversion"
 msgstr "Type moet enum hebben - lange conversie"
 
-#: ../src/propgrid/propgridiface.cpp:401
+#: ../src/propgrid/propgridiface.cpp:385
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
@@ -7238,19 +7410,19 @@ msgstr ""
 "Type handeling \"%s\" mislukt: Eigenschap met label \"%s\" is van type \"%s"
 "\", NIET \"%s\"."
 
-#: ../src/common/paper.cpp:133
+#: ../src/common/paper.cpp:130
 msgid "US Std Fanfold, 14 7/8 x 11 in"
 msgstr "USA Std Fanfold, 14 7/8 x 11 inch"
 
-#: ../src/common/fmapbase.cpp:196
+#: ../src/common/fmapbase.cpp:193
 msgid "US-ASCII"
 msgstr "US-ASCII"
 
-#: ../src/unix/fswatcher_inotify.cpp:109
+#: ../src/unix/fswatcher_inotify.cpp:106
 msgid "Unable to add inotify watch"
 msgstr "Kan geen inotify controle toevoegen"
 
-#: ../src/unix/fswatcher_kqueue.cpp:136
+#: ../src/unix/fswatcher_kqueue.cpp:153
 msgid "Unable to add kqueue watch"
 msgstr "Kan geen kqueue controle toevoegen"
 
@@ -7262,7 +7434,7 @@ msgstr "Kan handle niet associëren met I/O voltooiingspoort"
 msgid "Unable to close I/O completion port handle"
 msgstr "Sluiten van I/O voltooiingspoort ingang niet mogelijk"
 
-#: ../src/unix/fswatcher_inotify.cpp:97
+#: ../src/unix/fswatcher_inotify.cpp:94
 msgid "Unable to close inotify instance"
 msgstr "Sluiten van inotify exemplaarset niet mogelijk"
 
@@ -7280,15 +7452,15 @@ msgstr "Sluiten van de ingang voor '%s' niet mogelijk."
 msgid "Unable to create I/O completion port"
 msgstr "Niet mogelijk een I/O voltooiingspoort aan te maken"
 
-#: ../src/msw/fswatcher.cpp:84
+#: ../src/msw/fswatcher.cpp:81
 msgid "Unable to create IOCP worker thread"
 msgstr "Niet mogelijk een IOCP WorklerThread aan te maken"
 
-#: ../src/unix/fswatcher_inotify.cpp:74
+#: ../src/unix/fswatcher_inotify.cpp:71
 msgid "Unable to create inotify instance"
 msgstr "Niet mogelijk een inotify exemplaarset aan te maken"
 
-#: ../src/unix/fswatcher_kqueue.cpp:97
+#: ../src/unix/fswatcher_kqueue.cpp:114
 msgid "Unable to create kqueue instance"
 msgstr "Niet mogelijk een kqueue exemplaarset aan te maken"
 
@@ -7296,11 +7468,11 @@ msgstr "Niet mogelijk een kqueue exemplaarset aan te maken"
 msgid "Unable to dequeue completion packet"
 msgstr "Kan voltooiingspakket niet uit de wachtrij halen"
 
-#: ../src/unix/fswatcher_kqueue.cpp:185
+#: ../src/unix/fswatcher_kqueue.cpp:202
 msgid "Unable to get events from kqueue"
 msgstr "Kan gebeurtenissen niet uit kqueue halen"
 
-#: ../src/gtk/app.cpp:435
+#: ../src/gtk/app.cpp:431
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "Niet in staat GTK+ te initialiseren. Is DISPLAY juist ingesteld?"
 
@@ -7309,12 +7481,12 @@ msgstr "Niet in staat GTK+ te initialiseren. Is DISPLAY juist ingesteld?"
 msgid "Unable to open path '%s'"
 msgstr "Niet mogelijk pad '%s' te openen"
 
-#: ../src/html/htmlwin.cpp:583
+#: ../src/html/htmlwin.cpp:586
 #, c-format
 msgid "Unable to open requested HTML document: %s"
 msgstr "Kan gevraagd HTML-document niet openen: %s"
 
-#: ../src/unix/sound.cpp:368
+#: ../src/unix/sound.cpp:365
 msgid "Unable to play sound asynchronously."
 msgstr "Niet in staat geluid asynchroon af te spelen."
 
@@ -7322,62 +7494,62 @@ msgstr "Niet in staat geluid asynchroon af te spelen."
 msgid "Unable to post completion status"
 msgstr "Kan voltooiingstatus niet plaatsen"
 
-#: ../src/unix/fswatcher_inotify.cpp:556
+#: ../src/unix/fswatcher_inotify.cpp:553
 msgid "Unable to read from inotify descriptor"
 msgstr "Kan niet lezen van inotify descriptor"
 
-#: ../src/unix/fswatcher_inotify.cpp:141
+#: ../src/unix/fswatcher_inotify.cpp:138
 #, c-format
 msgid "Unable to remove inotify watch %i"
 msgstr "Kan inotify horloge %i niet verwijderen"
 
-#: ../src/unix/fswatcher_kqueue.cpp:153
+#: ../src/unix/fswatcher_kqueue.cpp:170
 msgid "Unable to remove kqueue watch"
 msgstr "Kan kqueue controle niet verwijderen"
 
-#: ../src/msw/fswatcher.cpp:168
+#: ../src/msw/fswatcher.cpp:165
 #, c-format
 msgid "Unable to set up watch for '%s'"
 msgstr "Kan controle op '%s' niet instellen"
 
-#: ../src/msw/fswatcher.cpp:91
+#: ../src/msw/fswatcher.cpp:88
 msgid "Unable to start IOCP worker thread"
 msgstr "Kan IOCP WorkerThread niet opstarten"
 
-#: ../src/common/stockitem.cpp:201
+#: ../src/common/stockitem.cpp:198
 msgid "Undelete"
 msgstr "Terugzetten"
 
-#: ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199
 msgid "Underline"
 msgstr "Onderstrepen"
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/richtext/richtextfontpage.cpp:359 ../src/osx/carbon/fontdlg.cpp:370
-#: ../src/propgrid/advprops.cpp:690
+#: ../src/osx/carbon/fontdlg.cpp:367 ../src/propgrid/advprops.cpp:600
+#: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Onderstreept"
 
-#: ../src/common/stockitem.cpp:203 ../src/stc/stc_i18n.cpp:15
+#: ../src/common/stockitem.cpp:200 ../src/stc/stc_i18n.cpp:15
 msgid "Undo"
 msgstr "Ongedaan maken"
 
-#: ../src/common/stockitem.cpp:265
+#: ../src/common/stockitem.cpp:263
 msgid "Undo last action"
 msgstr "Laatste actie ongedaan maken"
 
-#: ../src/common/cmdline.cpp:1029
+#: ../src/common/cmdline.cpp:1025
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Onverwachte lettertekens na de optie '%s'."
 
-#: ../src/unix/fswatcher_inotify.cpp:274
+#: ../src/unix/fswatcher_inotify.cpp:271
 #, c-format
 msgid "Unexpected event for \"%s\": no matching watch descriptor."
 msgstr ""
 "Onverwachte gebeurtenis voor \"%s\": geen overeenkomende watch descriptor."
 
-#: ../src/common/cmdline.cpp:1195
+#: ../src/common/cmdline.cpp:1191
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Onverwachte parameter '%s'"
@@ -7386,49 +7558,49 @@ msgstr "Onverwachte parameter '%s'"
 msgid "Unexpectedly new I/O completion port was created"
 msgstr "Er is onverwacht een nieuwe I/O voltooiingspoort aangemaakt"
 
-#: ../src/msw/fswatcher.cpp:70
+#: ../src/msw/fswatcher.cpp:67
 msgid "Ungraceful worker thread termination"
 msgstr "Onbevallige WorkerThread beëindiging"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:460
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:456
+#: ../src/richtext/richtextsymboldlg.cpp:457
+#: ../src/richtext/richtextsymboldlg.cpp:458
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../src/common/fmapbase.cpp:185 ../src/common/fmapbase.cpp:191
+#: ../src/common/fmapbase.cpp:182 ../src/common/fmapbase.cpp:188
 msgid "Unicode 16 bit (UTF-16)"
 msgstr "Unicode 16 bit (UTF-16)"
 
-#: ../src/common/fmapbase.cpp:190
+#: ../src/common/fmapbase.cpp:187
 msgid "Unicode 16 bit Big Endian (UTF-16BE)"
 msgstr "Unicode 16 bit Big Endian (UTF-16BE)"
 
-#: ../src/common/fmapbase.cpp:186
+#: ../src/common/fmapbase.cpp:183
 msgid "Unicode 16 bit Little Endian (UTF-16LE)"
 msgstr "Unicode 16 bit Little Endian (UTF-16LE)"
 
-#: ../src/common/fmapbase.cpp:187 ../src/common/fmapbase.cpp:193
+#: ../src/common/fmapbase.cpp:184 ../src/common/fmapbase.cpp:190
 msgid "Unicode 32 bit (UTF-32)"
 msgstr "Unicode 32 bit (UTF-32)"
 
-#: ../src/common/fmapbase.cpp:192
+#: ../src/common/fmapbase.cpp:189
 msgid "Unicode 32 bit Big Endian (UTF-32BE)"
 msgstr "Unicode 32 bit Big Endian (UTF-32BE)"
 
-#: ../src/common/fmapbase.cpp:188
+#: ../src/common/fmapbase.cpp:185
 msgid "Unicode 32 bit Little Endian (UTF-32LE)"
 msgstr "Unicode 32 bit Little Endian (UTF-32LE)"
 
-#: ../src/common/fmapbase.cpp:182
+#: ../src/common/fmapbase.cpp:179
 msgid "Unicode 7 bit (UTF-7)"
 msgstr "Unicode 7 bit (UTF-7)"
 
-#: ../src/common/fmapbase.cpp:183
+#: ../src/common/fmapbase.cpp:180
 msgid "Unicode 8 bit (UTF-8)"
 msgstr "Unicode 8 bit (UTF-8)"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "Unindent"
 msgstr "Inspringing opheffen"
 
@@ -7578,97 +7750,102 @@ msgstr "Eenheden voor de bovenpositie."
 msgid "Units for this value."
 msgstr "Eenheden voor deze waarde."
 
-#: ../src/generic/progdlgg.cpp:353 ../src/generic/progdlgg.cpp:622
+#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
 msgid "Unknown"
 msgstr "Unknown"
 
-#: ../src/msw/dde.cpp:1174
+#: ../src/msw/dde.cpp:1238
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Onbekende DDE-fout %08x"
 
-#: ../src/common/xtistrm.cpp:410
+#: ../src/common/xtistrm.cpp:407
 msgid "Unknown Object passed to GetObjectClassInfo"
 msgstr "Onbekend  Object doorgegeven aan GetObjectClassInfo"
 
-#: ../src/common/imagpng.cpp:366
+#: ../src/common/imagpng.cpp:383
 #, c-format
 msgid "Unknown PNG resolution unit %d"
 msgstr "Onbekende PNG resolutie eenheid %d"
 
-#: ../src/common/xtixml.cpp:327
+#: ../src/common/xtixml.cpp:323
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Onbekende Eigenschap %s"
 
-#: ../src/common/imagtiff.cpp:529
+#: ../src/common/imagtiff.cpp:526
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "Onbekende TIFF resolutie eenheid%d genegeerd"
 
-#: ../src/unix/dlunix.cpp:160
+#: ../src/propgrid/props.cpp:155
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/unix/dlunix.cpp:118
 msgid "Unknown dynamic library error"
 msgstr "Onbekende dynamische bibliotheek fout"
 
-#: ../src/common/fmapbase.cpp:810
+#: ../src/common/fmapbase.cpp:806
 #, c-format
 msgid "Unknown encoding (%d)"
 msgstr "Onbekende codering (%d)"
 
-#: ../src/msw/ole/automtn.cpp:688
+#: ../src/msw/ole/automtn.cpp:679
 #, c-format
 msgid "Unknown error %08x"
 msgstr "Onbekende fout %08x"
 
-#: ../src/msw/ole/automtn.cpp:647
+#: ../src/msw/ole/automtn.cpp:638
 msgid "Unknown exception"
 msgstr "Onbekende uitzondering"
 
-#: ../src/common/image.cpp:2839
+#: ../src/common/image.cpp:2942
 msgid "Unknown image data format."
 msgstr "Onbekende afbeelding gegevensformaat."
 
-#: ../src/common/cmdline.cpp:914
+#: ../src/common/cmdline.cpp:910
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Onbekende lange optie '%s'"
 
-#: ../src/msw/ole/automtn.cpp:631
+#: ../src/msw/ole/automtn.cpp:622
 msgid "Unknown name or named argument."
 msgstr "Onbekende naam of benoemd argument."
 
-#: ../src/common/cmdline.cpp:929 ../src/common/cmdline.cpp:951
+#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Onbekende optie '%s'"
 
-#: ../src/common/mimecmn.cpp:225
+#: ../src/common/mimecmn.cpp:221
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "Niet afgesloten '{' in ingang voor mime-type %s."
 
-#: ../src/common/cmdproc.cpp:262 ../src/common/cmdproc.cpp:288
-#: ../src/common/cmdproc.cpp:308
+#: ../src/common/cmdproc.cpp:255 ../src/common/cmdproc.cpp:281
+#: ../src/common/cmdproc.cpp:301
 msgid "Unnamed command"
 msgstr "Naamloze opdracht"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:413
+#: ../src/propgrid/propgrid.cpp:392
 msgid "Unspecified"
 msgstr "Ongespecifieerd"
 
-#: ../src/msw/clipbrd.cpp:311
+#: ../src/msw/clipbrd.cpp:325
 msgid "Unsupported clipboard format."
 msgstr "Niet ondersteund klembord-formaat."
 
-#: ../src/common/appcmn.cpp:256
+#: ../src/common/appcmn.cpp:277
 #, c-format
 msgid "Unsupported theme '%s'."
 msgstr "Niet ondersteund thema '%s'."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:205
-#: ../src/common/accelcmn.cpp:63
+#: ../src/common/stockitem.cpp:202 ../src/common/accelcmn.cpp:60
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Up"
 msgstr "Omhoog"
 
@@ -7682,7 +7859,7 @@ msgstr "Hoofdletters"
 msgid "Upper case roman numerals"
 msgstr "Kapitale Romeinse cijfers"
 
-#: ../src/common/cmdline.cpp:1326
+#: ../src/common/cmdline.cpp:1322
 #, c-format
 msgid "Usage: %s"
 msgstr "Gebruik: %s"
@@ -7691,38 +7868,47 @@ msgstr "Gebruik: %s"
 msgid "Use &shadow"
 msgstr "Gebruik &schaduw"
 
-#: ../src/richtext/richtextindentspage.cpp:169
-#: ../src/richtext/richtextindentspage.cpp:171
 #: ../src/richtext/richtextliststylepage.cpp:358
 #: ../src/richtext/richtextliststylepage.cpp:360
+#: ../src/richtext/richtextindentspage.cpp:169
+#: ../src/richtext/richtextindentspage.cpp:171
 msgid "Use the current alignment setting."
 msgstr "Gebruik de actuele uitlijningsinstelling."
 
-#: ../src/common/valtext.cpp:179
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/gtk/font.cpp:552
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/common/valtext.cpp:142
 msgid "Validation conflict"
 msgstr "Validatie-conflict"
 
-#: ../src/propgrid/manager.cpp:238
+#: ../src/propgrid/manager.cpp:224
 msgid "Value"
 msgstr "Waarde"
 
-#: ../src/propgrid/props.cpp:386 ../src/propgrid/props.cpp:500
+#: ../src/propgrid/props.cpp:309
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "Waarde moet %s zijn of meer."
 
-#: ../src/propgrid/props.cpp:417 ../src/propgrid/props.cpp:531
+#: ../src/propgrid/props.cpp:336
 #, c-format
 msgid "Value must be %s or less."
 msgstr "Waarde moet %s zijn of minder."
 
-#: ../src/propgrid/props.cpp:393 ../src/propgrid/props.cpp:424
-#: ../src/propgrid/props.cpp:507 ../src/propgrid/props.cpp:538
+#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "Waarde moet tussen %s en %s liggen."
 
-#: ../src/generic/aboutdlgg.cpp:128
+#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Versie "
 
@@ -7731,25 +7917,32 @@ msgstr "Versie "
 msgid "Vertical alignment."
 msgstr "Vertikale uitlijning."
 
-#: ../src/generic/filedlgg.cpp:202
+#: ../src/generic/filedlgg.cpp:199
 msgid "View files as a detailed view"
 msgstr "Toon bestanden in detail-weergave"
 
-#: ../src/generic/filedlgg.cpp:200
+#: ../src/generic/filedlgg.cpp:197
 msgid "View files as a list view"
 msgstr "Toon bestanden in lijst-weergave"
 
-#: ../src/common/docview.cpp:1970
+#: ../src/common/docview.cpp:1975
 msgid "Views"
 msgstr "Weergaven"
 
+#: ../src/gtk/app.cpp:348
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1777
+#: ../src/propgrid/advprops.cpp:1678
 msgid "Wait"
 msgstr "Wacht"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1779
+#: ../src/propgrid/advprops.cpp:1680
 msgid "Wait Arrow"
 msgstr "Wacht pijl"
 
@@ -7758,241 +7951,238 @@ msgstr "Wacht pijl"
 msgid "Waiting for IO on epoll descriptor %d failed"
 msgstr "Het wachten op IO voor epoll beschrijver %d mislukte"
 
-#: ../src/common/log.cpp:223
+#: ../src/common/log.cpp:241
 msgid "Warning: "
 msgstr "Waarschuwing: "
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1778
+#: ../src/propgrid/advprops.cpp:1679
 msgid "Watch"
 msgstr "Bekijk"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:685
+#: ../src/propgrid/advprops.cpp:595
 msgid "Weight"
 msgstr "Gewicht"
 
-#: ../src/common/fmapbase.cpp:148
+#: ../src/common/fmapbase.cpp:145
 msgid "Western European (ISO-8859-1)"
 msgstr "West-Europees (ISO-8859-1)"
 
-#: ../src/common/fmapbase.cpp:162
+#: ../src/common/fmapbase.cpp:159
 msgid "Western European with Euro (ISO-8859-15)"
 msgstr "West-Europees met Euro teken (ISO-8859-15)"
 
-#: ../src/generic/fontdlgg.cpp:446 ../src/generic/fontdlgg.cpp:448
+#: ../src/generic/fontdlgg.cpp:443 ../src/generic/fontdlgg.cpp:445
 msgid "Whether the font is underlined."
 msgstr "Of het lettertype is onderstreept."
 
-#: ../src/propgrid/advprops.cpp:1611
+#: ../src/propgrid/advprops.cpp:1517
 msgid "White"
 msgstr "Wit"
 
-#: ../src/generic/fdrepdlg.cpp:144
+#: ../src/generic/fdrepdlg.cpp:141
 msgid "Whole word"
 msgstr "Alleen hele woorden"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:532
 msgid "Whole words only"
 msgstr "Alleen hele woorden"
 
-#: ../src/univ/themes/win32.cpp:1102
+#: ../src/univ/themes/win32.cpp:1099
 msgid "Win32 theme"
 msgstr "Win32 thema"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:893
+#: ../src/propgrid/advprops.cpp:794
 msgid "Window"
 msgstr "Venster"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:894
+#: ../src/propgrid/advprops.cpp:795
 msgid "WindowFrame"
 msgstr "WindowFrame"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:895
+#: ../src/propgrid/advprops.cpp:796
 msgid "WindowText"
 msgstr "WindowText"
 
-#: ../src/common/fmapbase.cpp:177
+#: ../src/common/fmapbase.cpp:174
 msgid "Windows Arabic (CP 1256)"
 msgstr "Windows Arabisch (CP 1256)"
 
-#: ../src/common/fmapbase.cpp:178
+#: ../src/common/fmapbase.cpp:175
 msgid "Windows Baltic (CP 1257)"
 msgstr "Windows Baltisch (CP 1257)"
 
-#: ../src/common/fmapbase.cpp:171
+#: ../src/common/fmapbase.cpp:168
 msgid "Windows Central European (CP 1250)"
 msgstr "Windows Centraal Europees (CP 1250)"
 
-#: ../src/common/fmapbase.cpp:168
+#: ../src/common/fmapbase.cpp:165
 msgid "Windows Chinese Simplified (CP 936) or GB-2312"
 msgstr "Windows Chinees Gesimplificeerd (CP 936) of GB-2312"
 
-#: ../src/common/fmapbase.cpp:170
+#: ../src/common/fmapbase.cpp:167
 msgid "Windows Chinese Traditional (CP 950) or Big-5"
 msgstr "Windows Traditioneel Chinees (CP 950) of Big-5"
 
-#: ../src/common/fmapbase.cpp:172
+#: ../src/common/fmapbase.cpp:169
 msgid "Windows Cyrillic (CP 1251)"
 msgstr "Windows Cyrillisch (CP 1251)"
 
-#: ../src/common/fmapbase.cpp:174
+#: ../src/common/fmapbase.cpp:171
 msgid "Windows Greek (CP 1253)"
 msgstr "Windows Grieks (CP 1253)"
 
-#: ../src/common/fmapbase.cpp:176
+#: ../src/common/fmapbase.cpp:173
 msgid "Windows Hebrew (CP 1255)"
 msgstr "Windows Hebreeuws (CP 1255)"
 
-#: ../src/common/fmapbase.cpp:167
+#: ../src/common/fmapbase.cpp:164
 msgid "Windows Japanese (CP 932) or Shift-JIS"
 msgstr "Windows Japans (CP 932) of Shift-JIS"
 
-#: ../src/common/fmapbase.cpp:180
+#: ../src/common/fmapbase.cpp:177
 msgid "Windows Johab (CP 1361)"
 msgstr "Windows Johab (CP 1361)"
 
-#: ../src/common/fmapbase.cpp:169
+#: ../src/common/fmapbase.cpp:166
 msgid "Windows Korean (CP 949)"
 msgstr "Windows Koreaans (CP 949)"
 
-#: ../src/common/fmapbase.cpp:166
+#: ../src/common/fmapbase.cpp:163
 msgid "Windows Thai (CP 874)"
 msgstr "Windows Thai (CP 874)"
 
-#: ../src/common/fmapbase.cpp:175
+#: ../src/common/fmapbase.cpp:172
 msgid "Windows Turkish (CP 1254)"
 msgstr "Windows Turks (CP 1254)"
 
-#: ../src/common/fmapbase.cpp:179
+#: ../src/common/fmapbase.cpp:176
 msgid "Windows Vietnamese (CP 1258)"
 msgstr "Windows Vietnamees (CP 1258)"
 
-#: ../src/common/fmapbase.cpp:173
+#: ../src/common/fmapbase.cpp:170
 msgid "Windows Western European (CP 1252)"
 msgstr "Windows West Europees (CP 1252)"
 
-#: ../src/common/fmapbase.cpp:181
+#: ../src/common/fmapbase.cpp:178
 msgid "Windows/DOS OEM (CP 437)"
 msgstr "Windows/DOS OEM (CP 437)"
 
-#: ../src/common/fmapbase.cpp:165
+#: ../src/common/fmapbase.cpp:162
 msgid "Windows/DOS OEM Cyrillic (CP 866)"
 msgstr "Windows/DOS OEM Cyrillic (CP 866)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:111
+#: ../src/common/accelcmn.cpp:109
 msgid "Windows_Left"
 msgstr "Windows_Left"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:113
+#: ../src/common/accelcmn.cpp:111
 msgid "Windows_Menu"
 msgstr "Windows_Menu"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:112
+#: ../src/common/accelcmn.cpp:110
 msgid "Windows_Right"
 msgstr "Windows_Right"
 
-#: ../src/common/ffile.cpp:150
+#: ../src/common/ffile.cpp:149
 #, c-format
 msgid "Write error on file '%s'"
 msgstr "Schrijffout bij bestand '%s'"
 
-#: ../src/xml/xml.cpp:914
+#: ../src/xml/xml.cpp:925
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "XML ontleed fout: '%s' in lijn %d"
 
-#: ../src/common/xpmdecod.cpp:796
+#: ../src/common/xpmdecod.cpp:794
 msgid "XPM: Malformed pixel data!"
 msgstr "XPM: Misvormde pixel gegevens!"
 
-#: ../src/common/xpmdecod.cpp:705
+#: ../src/common/xpmdecod.cpp:702
 #, c-format
 msgid "XPM: incorrect colour description in line %d"
 msgstr "XPM: incorrecte kleurbeschrijving in regel %d"
 
-#: ../src/common/xpmdecod.cpp:680
+#: ../src/common/xpmdecod.cpp:677
 msgid "XPM: incorrect header format!"
 msgstr "XPM: incorrecte header formaat!"
 
-#: ../src/common/xpmdecod.cpp:716 ../src/common/xpmdecod.cpp:725
+#: ../src/common/xpmdecod.cpp:714 ../src/common/xpmdecod.cpp:723
 #, c-format
 msgid "XPM: malformed colour definition '%s' at line %d!"
 msgstr "XPM: misvormde kleur definitie '%s' op regel %d!"
 
-#: ../src/common/xpmdecod.cpp:755
+#: ../src/common/xpmdecod.cpp:753
 msgid "XPM: no colors left to use for mask!"
 msgstr "XPM: geen kleuren over voor maskering!"
 
-#: ../src/common/xpmdecod.cpp:782
+#: ../src/common/xpmdecod.cpp:780
 #, c-format
 msgid "XPM: truncated image data at line %d!"
 msgstr "XPM: afgeknotte afbeeldingsgegevens op regel %d!"
 
-#: ../src/propgrid/advprops.cpp:1610
+#: ../src/propgrid/advprops.cpp:1516
 msgid "Yellow"
 msgstr "Geel"
 
-#: ../include/wx/msgdlg.h:276 ../src/common/stockitem.cpp:206
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:203
 #: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Ja"
 
-#: ../src/osx/carbon/overlay.cpp:155
-msgid "You cannot Clear an overlay that is not inited"
-msgstr "U kunt geen overlay wissen die niet is geïnitieerd"
-
-#: ../src/osx/carbon/overlay.cpp:107 ../src/dfb/overlay.cpp:61
-msgid "You cannot Init an overlay twice"
-msgstr "U kunt niet een overlay twee keer initiëren"
-
-#: ../src/generic/dirdlgg.cpp:287
+#: ../src/generic/dirdlgg.cpp:284
 msgid "You cannot add a new directory to this section."
 msgstr "U kunt geen nieuwe map aan deze sectie toevoegen."
 
-#: ../src/propgrid/propgrid.cpp:3299
+#: ../src/propgrid/propgrid.cpp:3276
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 "U heeft een ongeldige waarde ingevoerd. Druk op Esc om de bewerking te "
 "annuleren."
 
-#: ../src/common/stockitem.cpp:209
+#: ../src/osx/cocoa/menu.mm:286
+#, fuzzy
+msgid "Zoom"
+msgstr "Inzoomen"
+
+#: ../src/common/stockitem.cpp:206
 msgid "Zoom &In"
 msgstr "In&zoomen"
 
-#: ../src/common/stockitem.cpp:210
+#: ../src/common/stockitem.cpp:207
 msgid "Zoom &Out"
 msgstr "&Uitzoomen"
 
-#: ../src/common/stockitem.cpp:209 ../src/common/prntbase.cpp:1594
+#: ../src/common/stockitem.cpp:206 ../src/common/prntbase.cpp:1619
 msgid "Zoom In"
 msgstr "Inzoomen"
 
-#: ../src/common/stockitem.cpp:210 ../src/common/prntbase.cpp:1580
+#: ../src/common/stockitem.cpp:207 ../src/common/prntbase.cpp:1605
 msgid "Zoom Out"
 msgstr "Uitzoomen"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to &Fit"
 msgstr "Inzoomen tot &Passend"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to Fit"
 msgstr "Inzoomen tot Passend"
 
-#: ../src/msw/dde.cpp:1141
+#: ../src/msw/dde.cpp:1205
 msgid "a DDEML application has created a prolonged race condition."
 msgstr ""
 "een DDEML-applicatie heeft door een 'race'-conditie geheugengebrek "
 "veroorzaakt."
 
-#: ../src/msw/dde.cpp:1129
+#: ../src/msw/dde.cpp:1193
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -8003,45 +8193,45 @@ msgstr ""
 "te roepen\n"
 "of een ongeldige applicatie-pid was doorgegeven aan een DDEML-functie."
 
-#: ../src/msw/dde.cpp:1147
+#: ../src/msw/dde.cpp:1211
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "een poging van een cliënt om een conversatie op te zetten is mislukt."
 
-#: ../src/msw/dde.cpp:1144
+#: ../src/msw/dde.cpp:1208
 msgid "a memory allocation failed."
 msgstr "een geheugenreservering is mislukt."
 
-#: ../src/msw/dde.cpp:1138
+#: ../src/msw/dde.cpp:1202
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "een parameter kon niet door de DDEML gevalideerd worden."
 
-#: ../src/msw/dde.cpp:1120
+#: ../src/msw/dde.cpp:1184
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr ""
 "aanvraag voor synchrone adviestransactie heeft een time-out veroorzaakt."
 
-#: ../src/msw/dde.cpp:1126
+#: ../src/msw/dde.cpp:1190
 msgid "a request for a synchronous data transaction has timed out."
 msgstr ""
 "aanvraag voor synchrone gegevenstransactie heeft een time-out veroorzaakt."
 
-#: ../src/msw/dde.cpp:1135
+#: ../src/msw/dde.cpp:1199
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr ""
 "aanvraag voor synchrone uitvoeringstransactie heeft een time-out veroorzaakt."
 
-#: ../src/msw/dde.cpp:1153
+#: ../src/msw/dde.cpp:1217
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr ""
 "aanvraag voor synchrone 'poke' transactie heeft een time-out veroorzaakt."
 
-#: ../src/msw/dde.cpp:1168
+#: ../src/msw/dde.cpp:1232
 msgid "a request to end an advise transaction has timed out."
 msgstr ""
 "aanvraag voor beëindigen  van adviestransactie heeft een time-out "
 "veroorzaakt."
 
-#: ../src/msw/dde.cpp:1162
+#: ../src/msw/dde.cpp:1226
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -8051,15 +8241,15 @@ msgstr ""
 "die door de cliënt was beëindigd of de server heeft afgebroken\n"
 "voordat de transactie was afgerond."
 
-#: ../src/msw/dde.cpp:1150
+#: ../src/msw/dde.cpp:1214
 msgid "a transaction failed."
 msgstr "een transactie is mislukt."
 
-#: ../src/common/accelcmn.cpp:189
+#: ../src/common/accelcmn.cpp:188
 msgid "alt"
 msgstr "alt"
 
-#: ../src/msw/dde.cpp:1132
+#: ../src/msw/dde.cpp:1196
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -8071,15 +8261,15 @@ msgstr ""
 "is\n"
 "gestart heeft geprobeerd een server-transactie uit te voeren."
 
-#: ../src/msw/dde.cpp:1156
+#: ../src/msw/dde.cpp:1220
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "een interne oproep van de PostMessage-functie is mislukt "
 
-#: ../src/msw/dde.cpp:1165
+#: ../src/msw/dde.cpp:1229
 msgid "an internal error has occurred in the DDEML."
 msgstr "een interne fout is opgetreden in de DDEML."
 
-#: ../src/msw/dde.cpp:1171
+#: ../src/msw/dde.cpp:1235
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -8089,56 +8279,56 @@ msgstr ""
 "Als de applicatie verdergaat na een XTYP_XACT_COMPLETE-callback dan is\n"
 "de transactie-id voor die callback niet meer geldig."
 
-#: ../src/common/zipstrm.cpp:1483
+#: ../src/common/zipstrm.cpp:1522
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "aangenomen dat dit een multi-part zip concatenatie is"
 
-#: ../src/common/fileconf.cpp:1847
+#: ../src/common/fileconf.cpp:1849
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "poging tot wijzigen van onveranderbare sleutel '%s' genegeerd."
 
-#: ../src/html/chm.cpp:329
+#: ../src/html/chm.cpp:326
 msgid "bad arguments to library function"
 msgstr "foute argumenten voor bibliotheek functie"
 
-#: ../src/html/chm.cpp:341
+#: ../src/html/chm.cpp:338
 msgid "bad signature"
 msgstr "slechte handtekening"
 
-#: ../src/common/zipstrm.cpp:1918
+#: ../src/common/zipstrm.cpp:1988
 msgid "bad zipfile offset to entry"
 msgstr "slechte zipfile offset naar binnenkomst"
 
-#: ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400
 msgid "binary"
 msgstr "binair"
 
-#: ../src/common/fontcmn.cpp:996
+#: ../src/common/fontcmn.cpp:1195
 msgid "bold"
 msgstr "vet"
 
-#: ../src/msw/utils.cpp:1144
+#: ../src/msw/utils.cpp:1135
 #, c-format
 msgid "build %lu"
 msgstr "build %lu"
 
-#: ../src/common/ffile.cpp:75
+#: ../src/common/ffile.cpp:73
 #, c-format
 msgid "can't close file '%s'"
 msgstr "kan bestand '%s' niet sluiten"
 
-#: ../src/common/file.cpp:245
+#: ../src/common/file.cpp:242
 #, c-format
 msgid "can't close file descriptor %d"
 msgstr "kan bestandsbeschrijving %d niet sluiten"
 
-#: ../src/common/file.cpp:586
+#: ../src/common/ffile.cpp:382 ../src/common/file.cpp:613
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "kan verandering niet doorvoeren in bestand '%s'"
 
-#: ../src/common/file.cpp:178
+#: ../src/common/file.cpp:175
 #, c-format
 msgid "can't create file '%s'"
 msgstr "kan bestand '%s' niet maken"
@@ -8148,50 +8338,50 @@ msgstr "kan bestand '%s' niet maken"
 msgid "can't delete user configuration file '%s'"
 msgstr "kan bestand met gebruikersinstellingen '%s' niet wissen"
 
-#: ../src/common/file.cpp:495
+#: ../src/common/file.cpp:522
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr ""
 "kan niet bepalen of bestandseinde is bereikt bij bestandsbeschrijving %d"
 
-#: ../src/common/zipstrm.cpp:1692
+#: ../src/common/zipstrm.cpp:1747
 msgid "can't find central directory in zip"
 msgstr "kan centrale map in zipbestand niet vinden"
 
-#: ../src/common/file.cpp:465
+#: ../src/common/file.cpp:492
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "kan bestandslengte niet vinden bij bestandsbeschrijving %d"
 
-#: ../src/msw/utils.cpp:341
+#: ../src/msw/utils.cpp:336
 msgid "can't find user's HOME, using current directory."
 msgstr "kan gebruikers startlocatie niet vinden, gebruik huidige map."
 
-#: ../src/common/file.cpp:366
+#: ../src/common/file.cpp:407
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "kan bestandsbeschrijving %d niet legen"
 
-#: ../src/common/file.cpp:422
+#: ../src/common/file.cpp:463
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "kan zoekpositie niet verkrijgen bij bestandsbeschrijving %d"
 
-#: ../src/common/fontmap.cpp:325
+#: ../src/common/fontmap.cpp:322
 msgid "can't load any font, aborting"
 msgstr "kan geen lettertype laden, wordt afgebroken"
 
-#: ../src/common/file.cpp:231 ../src/common/ffile.cpp:59
+#: ../src/common/ffile.cpp:57 ../src/common/file.cpp:228
 #, c-format
 msgid "can't open file '%s'"
 msgstr "kan bestand '%s' niet openen"
 
-#: ../src/common/fileconf.cpp:320
+#: ../src/common/fileconf.cpp:314
 #, c-format
 msgid "can't open global configuration file '%s'."
 msgstr "kan globaal configuratiebestand '%s' niet openen."
 
-#: ../src/common/fileconf.cpp:336
+#: ../src/common/fileconf.cpp:330
 #, c-format
 msgid "can't open user configuration file '%s'."
 msgstr "kan gebruikers-configuratiebestand '%s' niet openen."
@@ -8200,40 +8390,40 @@ msgstr "kan gebruikers-configuratiebestand '%s' niet openen."
 msgid "can't open user configuration file."
 msgstr "kan gebruikers-configuratiebestand niet openen."
 
-#: ../src/common/zipstrm.cpp:579
+#: ../src/common/zipstrm.cpp:572
 msgid "can't re-initialize zlib deflate stream"
 msgstr "kan zlib deflate stream niet opnieuw starten"
 
-#: ../src/common/zipstrm.cpp:604
+#: ../src/common/zipstrm.cpp:597
 msgid "can't re-initialize zlib inflate stream"
 msgstr "kan zlib inflate stream niet opnieuw starten"
 
-#: ../src/common/file.cpp:304
+#: ../src/common/file.cpp:345
 #, c-format
 msgid "can't read from file descriptor %d"
 msgstr "kan niet lezen van bestandsbeschrijving %d"
 
-#: ../src/common/file.cpp:581
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:608
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "kan bestand '%s' niet verwijderen"
 
-#: ../src/common/file.cpp:598
+#: ../src/common/ffile.cpp:394 ../src/common/file.cpp:625
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "kan tijdelijk bestand '%s' niet verwijderen"
 
-#: ../src/common/file.cpp:408
+#: ../src/common/file.cpp:449
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "kan niet zoeken bij bestandsbeschrijving %d"
 
-#: ../src/common/textfile.cpp:273
+#: ../src/common/textfile.cpp:161
 #, c-format
 msgid "can't write buffer '%s' to disk."
 msgstr "kan buffer '%s' niet naar schijf schrijven."
 
-#: ../src/common/file.cpp:323
+#: ../src/common/file.cpp:364
 #, c-format
 msgid "can't write to file descriptor %d"
 msgstr "kan niet schrijven naar bestandsbeschrijving %d"
@@ -8243,22 +8433,28 @@ msgid "can't write user configuration file."
 msgstr "kan gebruikers-configuratiebestand niet schrijven."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:482 ../src/generic/datavgen.cpp:1261
+#: ../src/common/datavcmn.cpp:2064 ../src/generic/datavgen.cpp:1384
 msgid "checked"
 msgstr ""
 
-#: ../src/html/chm.cpp:345
+#: ../src/html/chm.cpp:342
 msgid "checksum error"
 msgstr "checksum fout"
 
-#: ../src/common/tarstrm.cpp:820
+#: ../src/common/tarstrm.cpp:814
 msgid "checksum failure reading tar header block"
 msgstr "checksum mislukt tijdens lezen tar header blok"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:226
-#: ../src/richtext/richtextbackgroundpage.cpp:249
-#: ../src/richtext/richtextbackgroundpage.cpp:289
-#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
 #: ../src/richtext/richtextborderspage.cpp:254
 #: ../src/richtext/richtextborderspage.cpp:288
 #: ../src/richtext/richtextborderspage.cpp:322
@@ -8276,104 +8472,127 @@ msgstr "checksum mislukt tijdens lezen tar header blok"
 #: ../src/richtext/richtextmarginspage.cpp:340
 #: ../src/richtext/richtextmarginspage.cpp:363
 #: ../src/richtext/richtextmarginspage.cpp:388
-#: ../src/richtext/richtextsizepage.cpp:339
-#: ../src/richtext/richtextsizepage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:400
-#: ../src/richtext/richtextsizepage.cpp:427
-#: ../src/richtext/richtextsizepage.cpp:454
-#: ../src/richtext/richtextsizepage.cpp:481
-#: ../src/richtext/richtextsizepage.cpp:555
-#: ../src/richtext/richtextsizepage.cpp:590
-#: ../src/richtext/richtextsizepage.cpp:625
-#: ../src/richtext/richtextsizepage.cpp:660
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
 msgid "cm"
 msgstr "cm"
 
-#: ../src/html/chm.cpp:347
+#: ../src/html/chm.cpp:344
 msgid "compression error"
 msgstr "compressie fout"
 
-#: ../src/common/regex.cpp:236
+#: ../src/common/regex.cpp:233
 msgid "conversion to 8-bit encoding failed"
 msgstr "conversie naar 8-bit versleuteling mislukt"
 
-#: ../src/common/accelcmn.cpp:187
+#: ../src/common/accelcmn.cpp:186
 msgid "ctrl"
 msgstr "ctrl"
 
-#: ../src/common/cmdline.cpp:1500
+#: ../src/common/cmdline.cpp:1496
 msgid "date"
 msgstr "datum"
 
-#: ../src/html/chm.cpp:349
+#: ../src/html/chm.cpp:346
 msgid "decompression error"
 msgstr "decompressie fout"
 
-#: ../src/richtext/richtextstyles.cpp:780 ../src/common/fmapbase.cpp:820
+#: ../src/common/fmapbase.cpp:816 ../src/richtext/richtextstyles.cpp:777
 msgid "default"
 msgstr "standaard"
 
-#: ../src/common/cmdline.cpp:1496
+#: ../src/common/cmdline.cpp:1492
 msgid "double"
 msgstr "dubbel"
 
-#: ../src/common/debugrpt.cpp:538
+#: ../src/common/debugrpt.cpp:539
 msgid "dump of the process state (binary)"
 msgstr "dump van de proces status (binair)"
 
-#: ../src/common/datetimefmt.cpp:1969
+#: ../src/common/datetimefmt.cpp:1992
 msgid "eighteenth"
 msgstr "achttiende"
 
-#: ../src/common/datetimefmt.cpp:1959
+#: ../src/common/datetimefmt.cpp:1982
 msgid "eighth"
 msgstr "achtste"
 
-#: ../src/common/datetimefmt.cpp:1962
+#: ../src/common/datetimefmt.cpp:1985
 msgid "eleventh"
 msgstr "elfde"
 
-#: ../src/common/fileconf.cpp:1833
+#: ../src/common/fileconf.cpp:1835
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "ingang '%s' komt meer dan één keer voor in groep '%s'"
 
-#: ../src/html/chm.cpp:343
+#: ../src/html/chm.cpp:340
 msgid "error in data format"
 msgstr "fout in gegevens formaat"
 
-#: ../src/html/chm.cpp:331
+#: ../src/html/chm.cpp:328
 msgid "error opening file"
 msgstr "fout bij openen bestand"
 
-#: ../src/common/zipstrm.cpp:1778
+#: ../src/common/zipstrm.cpp:1836
 msgid "error reading zip central directory"
 msgstr "fout bij het lezen van zip centrale map"
 
-#: ../src/common/zipstrm.cpp:1870
+#: ../src/common/zipstrm.cpp:1940
 msgid "error reading zip local header"
 msgstr "fout lezen zip lokale header"
 
-#: ../src/common/zipstrm.cpp:2531
+#: ../src/common/zipstrm.cpp:2615
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "fout schrijven zip invoer '%s': foute crc of lengte"
 
-#: ../src/common/ffile.cpp:188
+#: ../src/common/zipstrm.cpp:2608
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "fout schrijven zip invoer '%s': foute crc of lengte"
+
+#: ../src/common/fontcmn.cpp:1205
+#, fuzzy
+msgid "extrabold"
+msgstr "vet"
+
+#: ../src/common/fontcmn.cpp:1223
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1167
+#, fuzzy
+msgid "extralight"
+msgstr "licht"
+
+#: ../src/msw/webview_ie.cpp:1036
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "Uitvoeren van '%s' mislukt\n"
+
+#: ../src/common/ffile.cpp:187
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "legen van bestand '%s' mislukt"
 
+#: ../src/msw/webview_ie.cpp:1045
+#, fuzzy
+msgid "failed to retrieve execution result"
+msgstr "Verkrijgen van tekst van inbel-foutmelding mislukt"
+
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1030
+#: ../src/generic/datavgen.cpp:1150
 msgid "false"
 msgstr "onwaar"
 
-#: ../src/common/datetimefmt.cpp:1966
+#: ../src/common/datetimefmt.cpp:1989
 msgid "fifteenth"
 msgstr "vijftiende"
 
-#: ../src/common/datetimefmt.cpp:1956
+#: ../src/common/datetimefmt.cpp:1979
 msgid "fifth"
 msgstr "vijfde"
 
@@ -8404,131 +8623,150 @@ msgstr ""
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "bestand '%s': onverwacht teken %c bij regel %zu."
 
-#: ../src/richtext/richtextbuffer.cpp:8738
+#: ../src/richtext/richtextbuffer.cpp:8736
 msgid "files"
 msgstr "bestanden"
 
-#: ../src/common/datetimefmt.cpp:1952
+#: ../src/common/datetimefmt.cpp:1975
 msgid "first"
 msgstr "eerste"
 
-#: ../src/html/helpwnd.cpp:1252
+#: ../src/html/helpwnd.cpp:1250
 msgid "font size"
 msgstr "lettertype grootte"
 
-#: ../src/common/datetimefmt.cpp:1965
+#: ../src/common/datetimefmt.cpp:1988
 msgid "fourteenth"
 msgstr "veertiende"
 
-#: ../src/common/datetimefmt.cpp:1955
+#: ../src/common/datetimefmt.cpp:1978
 msgid "fourth"
 msgstr "vierde"
 
-#: ../src/common/appbase.cpp:783
+#: ../src/common/appbase.cpp:784
 msgid "generate verbose log messages"
 msgstr "genereer uitgebreide log meldingen"
 
-#: ../src/richtext/richtextbuffer.cpp:13138
-#: ../src/richtext/richtextbuffer.cpp:13248
+#: ../src/common/fontcmn.cpp:1215
+msgid "heavy"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:13133
+#: ../src/richtext/richtextbuffer.cpp:13243
 msgid "image"
 msgstr "afbeelding"
 
-#: ../src/common/tarstrm.cpp:796
+#: ../src/common/tarstrm.cpp:790
 msgid "incomplete header block in tar"
 msgstr "onvolledige header blok in tar"
 
-#: ../src/common/xtixml.cpp:489
+#: ../src/common/xtixml.cpp:485
 msgid "incorrect event handler string, missing dot"
 msgstr "onjuiste gebeurtenishandlerreeks, ontbrekende stip"
 
-#: ../src/common/tarstrm.cpp:1381
+#: ../src/common/tarstrm.cpp:1375
 msgid "incorrect size given for tar entry"
 msgstr "onjuiste grootte aangegeven voor tar invoer"
 
-#: ../src/common/tarstrm.cpp:993
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:987
 msgid "invalid data in extended tar header"
 msgstr "ongeldige data in extended tar header"
 
-#: ../src/generic/logg.cpp:1030
+#: ../src/generic/logg.cpp:1027
 msgid "invalid message box return value"
 msgstr "ongeldige return-waarde van berichtvenster"
 
-#: ../src/common/zipstrm.cpp:1647
+#: ../src/common/zipstrm.cpp:1688
 msgid "invalid zip file"
 msgstr "ongeldig zip-bestand"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:1228
 msgid "italic"
 msgstr "cursief"
 
-#: ../src/common/fontcmn.cpp:991
+#: ../src/common/webrequest_curl.cpp:374
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "Kolombeschrijving kon niet worden geïnitialiseerd."
+
+#: ../src/common/fontcmn.cpp:1172
 msgid "light"
 msgstr "licht"
 
-#: ../src/common/intl.cpp:303
-#, c-format
-msgid "locale '%s' cannot be set."
-msgstr "landinstelling '%s' kan niet worden ingesteld."
+#: ../src/common/fontcmn.cpp:1185
+msgid "medium"
+msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2125
+#: ../src/common/datetimefmt.cpp:2148
 msgid "midnight"
 msgstr "middernacht"
 
-#: ../src/common/datetimefmt.cpp:1970
+#: ../src/common/datetimefmt.cpp:1993
 msgid "nineteenth"
 msgstr "negentiende"
 
-#: ../src/common/datetimefmt.cpp:1960
+#: ../src/common/datetimefmt.cpp:1983
 msgid "ninth"
 msgstr "negende"
 
-#: ../src/msw/dde.cpp:1116
+#: ../src/msw/dde.cpp:1180
 msgid "no DDE error."
 msgstr "geen DDE-fout."
 
-#: ../src/html/chm.cpp:327
+#: ../src/html/chm.cpp:324
 msgid "no error"
 msgstr "geen fout"
 
-#: ../src/dfb/fontmgr.cpp:174
+#: ../src/dfb/fontmgr.cpp:171
 #, c-format
 msgid "no fonts found in %s, using builtin font"
 msgstr "geen lettertypes gevonden in %s. Gebruik ingebouwde lettertype"
 
-#: ../src/html/helpdata.cpp:657
+#: ../src/html/helpdata.cpp:650
 msgid "noname"
 msgstr "naamloos"
 
-#: ../src/common/datetimefmt.cpp:2124
+#: ../src/common/datetimefmt.cpp:2147
 msgid "noon"
 msgstr "middag"
 
-#: ../src/richtext/richtextstyles.cpp:779
+#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "normaal"
 
-#: ../src/common/cmdline.cpp:1492
+#: ../src/common/cmdline.cpp:1488
 msgid "num"
 msgstr "num"
 
-#: ../src/common/xtixml.cpp:259
+#: ../src/common/accelcmn.cpp:194
+msgid "num "
+msgstr ""
+
+#: ../src/common/xtixml.cpp:255
 msgid "objects cannot have XML Text Nodes"
 msgstr "objecten kunnen geen XML teskt Nodes hebben"
 
-#: ../src/html/chm.cpp:339
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
 msgid "out of memory"
 msgstr "geheugen uitgeput"
 
-#: ../src/common/debugrpt.cpp:514
+#: ../src/common/debugrpt.cpp:515
 msgid "process context description"
 msgstr "procesinhoud beschrijving"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:227
-#: ../src/richtext/richtextbackgroundpage.cpp:250
-#: ../src/richtext/richtextbackgroundpage.cpp:290
-#: ../src/richtext/richtextbackgroundpage.cpp:317
-#: ../src/richtext/richtextfontpage.cpp:177
-#: ../src/richtext/richtextfontpage.cpp:180
 #: ../src/richtext/richtextborderspage.cpp:255
 #: ../src/richtext/richtextborderspage.cpp:289
 #: ../src/richtext/richtextborderspage.cpp:323
@@ -8538,22 +8776,45 @@ msgstr "procesinhoud beschrijving"
 #: ../src/richtext/richtextborderspage.cpp:491
 #: ../src/richtext/richtextborderspage.cpp:525
 #: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextfontpage.cpp:180
 msgid "pt"
 msgstr "pt"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:225
-#: ../src/richtext/richtextbackgroundpage.cpp:228
-#: ../src/richtext/richtextbackgroundpage.cpp:229
-#: ../src/richtext/richtextbackgroundpage.cpp:248
-#: ../src/richtext/richtextbackgroundpage.cpp:251
-#: ../src/richtext/richtextbackgroundpage.cpp:252
-#: ../src/richtext/richtextbackgroundpage.cpp:288
-#: ../src/richtext/richtextbackgroundpage.cpp:291
-#: ../src/richtext/richtextbackgroundpage.cpp:292
-#: ../src/richtext/richtextbackgroundpage.cpp:315
-#: ../src/richtext/richtextbackgroundpage.cpp:318
-#: ../src/richtext/richtextbackgroundpage.cpp:319
-#: ../src/richtext/richtextfontpage.cpp:178
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:659
+#: ../src/richtext/richtextsizepage.cpp:662
+#: ../src/richtext/richtextsizepage.cpp:663
 #: ../src/richtext/richtextborderspage.cpp:253
 #: ../src/richtext/richtextborderspage.cpp:256
 #: ../src/richtext/richtextborderspage.cpp:257
@@ -8605,259 +8866,269 @@ msgstr "pt"
 #: ../src/richtext/richtextmarginspage.cpp:387
 #: ../src/richtext/richtextmarginspage.cpp:389
 #: ../src/richtext/richtextmarginspage.cpp:390
-#: ../src/richtext/richtextsizepage.cpp:338
-#: ../src/richtext/richtextsizepage.cpp:341
-#: ../src/richtext/richtextsizepage.cpp:342
-#: ../src/richtext/richtextsizepage.cpp:372
-#: ../src/richtext/richtextsizepage.cpp:375
-#: ../src/richtext/richtextsizepage.cpp:376
-#: ../src/richtext/richtextsizepage.cpp:399
-#: ../src/richtext/richtextsizepage.cpp:402
-#: ../src/richtext/richtextsizepage.cpp:403
-#: ../src/richtext/richtextsizepage.cpp:426
-#: ../src/richtext/richtextsizepage.cpp:429
-#: ../src/richtext/richtextsizepage.cpp:430
-#: ../src/richtext/richtextsizepage.cpp:453
-#: ../src/richtext/richtextsizepage.cpp:456
-#: ../src/richtext/richtextsizepage.cpp:457
-#: ../src/richtext/richtextsizepage.cpp:480
-#: ../src/richtext/richtextsizepage.cpp:483
-#: ../src/richtext/richtextsizepage.cpp:484
-#: ../src/richtext/richtextsizepage.cpp:554
-#: ../src/richtext/richtextsizepage.cpp:557
-#: ../src/richtext/richtextsizepage.cpp:558
-#: ../src/richtext/richtextsizepage.cpp:589
-#: ../src/richtext/richtextsizepage.cpp:592
-#: ../src/richtext/richtextsizepage.cpp:593
-#: ../src/richtext/richtextsizepage.cpp:624
-#: ../src/richtext/richtextsizepage.cpp:627
-#: ../src/richtext/richtextsizepage.cpp:628
-#: ../src/richtext/richtextsizepage.cpp:659
-#: ../src/richtext/richtextsizepage.cpp:662
-#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextfontpage.cpp:178
 msgid "px"
 msgstr "px"
 
-#: ../src/common/accelcmn.cpp:193
+#: ../src/common/accelcmn.cpp:192
 msgid "rawctrl"
 msgstr "rawctrl"
 
-#: ../src/html/chm.cpp:333
+#: ../src/html/chm.cpp:330
 msgid "read error"
 msgstr "fout bij lezen"
 
-#: ../src/common/zipstrm.cpp:2085
+#: ../src/common/zipstrm.cpp:2155
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "inlezen van zip stream (regel %s): foute crc"
 
-#: ../src/common/zipstrm.cpp:2080
+#: ../src/common/zipstrm.cpp:2150
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "inlezen van zip stream (regel %s): foute lengte"
 
-#: ../src/msw/dde.cpp:1159
+#: ../src/msw/dde.cpp:1223
 msgid "reentrancy problem."
 msgstr "probleem met 'reentrancy'."
 
-#: ../src/common/datetimefmt.cpp:1953
+#: ../src/common/datetimefmt.cpp:1976
 msgid "second"
 msgstr "tweede"
 
-#: ../src/html/chm.cpp:337
+#: ../src/html/chm.cpp:334
 msgid "seek error"
 msgstr "zoekfout"
 
-#: ../src/common/datetimefmt.cpp:1968
+#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#, fuzzy
+msgid "semibold"
+msgstr "vet"
+
+#: ../src/common/datetimefmt.cpp:1991
 msgid "seventeenth"
 msgstr "zeventiende"
 
-#: ../src/common/datetimefmt.cpp:1958
+#: ../src/common/datetimefmt.cpp:1981
 msgid "seventh"
 msgstr "zevende"
 
-#: ../src/common/accelcmn.cpp:191
+#: ../src/common/accelcmn.cpp:190
 msgid "shift"
 msgstr "shift"
 
-#: ../src/common/appbase.cpp:773
+#: ../src/common/appbase.cpp:774
 msgid "show this help message"
 msgstr "dit helpbericht weergeven"
 
-#: ../src/common/datetimefmt.cpp:1967
+#: ../src/common/datetimefmt.cpp:1990
 msgid "sixteenth"
 msgstr "zestiende"
 
-#: ../src/common/datetimefmt.cpp:1957
+#: ../src/common/datetimefmt.cpp:1980
 msgid "sixth"
 msgstr "zesde"
 
-#: ../src/common/appcmn.cpp:234
+#: ../src/common/appcmn.cpp:255
 msgid "specify display mode to use (e.g. 640x480-16)"
 msgstr "kies de te gebruiken beeldscherm mode (B.V. 640x480-16)"
 
-#: ../src/common/appcmn.cpp:220
+#: ../src/common/appcmn.cpp:241
 msgid "specify the theme to use"
 msgstr "kies het te gebruiken thema"
 
-#: ../src/richtext/richtextbuffer.cpp:9340
+#: ../src/richtext/richtextbuffer.cpp:9337
 msgid "standard/circle"
 msgstr "standaard/circel"
 
-#: ../src/richtext/richtextbuffer.cpp:9341
+#: ../src/richtext/richtextbuffer.cpp:9338
 msgid "standard/circle-outline"
 msgstr "standaard/circel-buitenrand"
 
-#: ../src/richtext/richtextbuffer.cpp:9343
+#: ../src/richtext/richtextbuffer.cpp:9340
 msgid "standard/diamond"
 msgstr "standaard/diamant"
 
-#: ../src/richtext/richtextbuffer.cpp:9342
+#: ../src/richtext/richtextbuffer.cpp:9339
 msgid "standard/square"
 msgstr "standaard/vierkant"
 
-#: ../src/richtext/richtextbuffer.cpp:9344
+#: ../src/richtext/richtextbuffer.cpp:9341
 msgid "standard/triangle"
 msgstr "standaard/driehoek"
 
-#: ../src/common/zipstrm.cpp:1985
+#: ../src/common/zipstrm.cpp:2055
 msgid "stored file length not in Zip header"
 msgstr "opgeslagen bestandslengte niet in Zip header"
 
-#: ../src/common/cmdline.cpp:1488
+#: ../src/common/cmdline.cpp:1484
 msgid "str"
 msgstr "str"
 
-#: ../src/common/fontcmn.cpp:982
+#: ../src/common/fontcmn.cpp:1145
 msgid "strikethrough"
 msgstr "doorhalen"
 
-#: ../src/common/tarstrm.cpp:1003 ../src/common/tarstrm.cpp:1025
-#: ../src/common/tarstrm.cpp:1507 ../src/common/tarstrm.cpp:1529
+#: ../src/common/tarstrm.cpp:997 ../src/common/tarstrm.cpp:1019
+#: ../src/common/tarstrm.cpp:1501 ../src/common/tarstrm.cpp:1523
 msgid "tar entry not open"
 msgstr "tar ingang niet open"
 
-#: ../src/common/datetimefmt.cpp:1961
+#: ../src/common/datetimefmt.cpp:1984
 msgid "tenth"
 msgstr "tiende"
 
-#: ../src/msw/dde.cpp:1123
+#: ../src/msw/dde.cpp:1187
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "het antwoord op de transactie heeft de DDE_FBUSY-bit op 1 gezet."
 
-#: ../src/common/datetimefmt.cpp:1954
+#: ../src/common/fontcmn.cpp:1154
+msgid "thin"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:1977
 msgid "third"
 msgstr "derde"
 
-#: ../src/common/datetimefmt.cpp:1964
+#: ../src/common/datetimefmt.cpp:1987
 msgid "thirteenth"
 msgstr "dertiende"
 
-#: ../src/common/datetimefmt.cpp:1758
+#: ../src/common/datetimefmt.cpp:1781
 msgid "today"
 msgstr "vandaag"
 
-#: ../src/common/datetimefmt.cpp:1760
+#: ../src/common/datetimefmt.cpp:1783
 msgid "tomorrow"
 msgstr "morgen"
 
-#: ../src/common/fileconf.cpp:1944
+#: ../src/common/fileconf.cpp:1946
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "trailing backslash genegeerd in '%s'"
 
-#: ../src/gtk/aboutdlg.cpp:218
+#: ../src/gtk/aboutdlg.cpp:216
 msgid "translator-credits"
 msgstr "vertaling credits"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1028
+#: ../src/generic/datavgen.cpp:1148
 msgid "true"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1963
+#: ../src/common/datetimefmt.cpp:1986
 msgid "twelfth"
 msgstr "twaalfde"
 
-#: ../src/common/datetimefmt.cpp:1971
+#: ../src/common/datetimefmt.cpp:1994
 msgid "twentieth"
 msgstr "twintigste"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:486 ../src/generic/datavgen.cpp:1263
+#: ../src/common/datavcmn.cpp:2068 ../src/generic/datavgen.cpp:1386
 msgid "unchecked"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:802 ../src/common/fontcmn.cpp:978
+#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
 msgid "underlined"
 msgstr "onderstreept"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:490
+#: ../src/common/datavcmn.cpp:2072
 msgid "undetermined"
 msgstr "onbepaald"
 
-#: ../src/common/fileconf.cpp:1979
+#: ../src/common/fileconf.cpp:1981
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "onverwachte \" op positie %d in '%s'."
 
-#: ../src/common/tarstrm.cpp:1045
+#: ../src/common/tarstrm.cpp:1039
 msgid "unexpected end of file"
 msgstr "onverwacht einde van bestand"
 
-#: ../src/generic/progdlgg.cpp:370 ../src/common/tarstrm.cpp:371
-#: ../src/common/tarstrm.cpp:394 ../src/common/tarstrm.cpp:425
+#: ../src/common/tarstrm.cpp:366 ../src/common/tarstrm.cpp:389
+#: ../src/common/tarstrm.cpp:420 ../src/generic/progdlgg.cpp:376
 msgid "unknown"
 msgstr "onbekend"
 
-#: ../src/msw/registry.cpp:150
+#: ../src/msw/registry.cpp:139
 #, c-format
 msgid "unknown (%lu)"
 msgstr "onbekend (%lu)"
 
-#: ../src/common/xtixml.cpp:253
+#: ../src/common/xtixml.cpp:249
 #, c-format
 msgid "unknown class %s"
 msgstr "onbekende klasse %s"
 
-#: ../src/common/regex.cpp:258 ../src/html/chm.cpp:351
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "compressie fout"
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "decompressie fout"
+
+#: ../src/common/regex.cpp:255 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "onbekende fout"
 
-#: ../src/msw/dialup.cpp:471
+#: ../src/msw/dialup.cpp:465
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "onbekende fout (foutnummer %08x)."
 
-#: ../src/common/fmapbase.cpp:834
+#: ../src/common/fmapbase.cpp:830
 #, c-format
 msgid "unknown-%d"
 msgstr "onbekend-%d"
 
-#: ../src/common/docview.cpp:509
+#: ../src/common/docview.cpp:502
 msgid "unnamed"
 msgstr "naamloos"
 
-#: ../src/common/docview.cpp:1624
+#: ../src/common/docview.cpp:1618
 #, c-format
 msgid "unnamed%d"
 msgstr "naamloos%d"
 
-#: ../src/common/zipstrm.cpp:1999 ../src/common/zipstrm.cpp:2319
+#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
 msgid "unsupported Zip compression method"
 msgstr "niet ondersteunde Zip-compressiemethode"
 
-#: ../src/common/translation.cpp:1892
+#: ../src/common/translation.cpp:1942
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "catalogus '%s' van '%s' wordt gebruikt."
 
-#: ../src/html/chm.cpp:335
+#: ../src/html/chm.cpp:332
 msgid "write error"
 msgstr "fout bij schrijven"
 
-#: ../src/common/time.cpp:292
+#: ../src/gtk/glcanvas.cpp:187
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/common/time.cpp:285
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay mislukt."
 
@@ -8870,15 +9141,15 @@ msgstr "wxWidgets kon beeldscherm niet openen voor '%s': afbreken."
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets kon beeldscherm niet openen. Afbreken."
 
-#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:431
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/common/datetimefmt.cpp:1759
+#: ../src/common/datetimefmt.cpp:1782
 msgid "yesterday"
 msgstr "gisteren"
 
-#: ../src/common/zstream.cpp:251 ../src/common/zstream.cpp:426
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
 #, c-format
 msgid "zlib error %d"
 msgstr "zlib-fout %d"
@@ -8887,6 +9158,75 @@ msgstr "zlib-fout %d"
 #: ../src/richtext/richtextbulletspage.cpp:288
 msgid "~"
 msgstr "~"
+
+#~ msgid "&Save as"
+#~ msgstr "&Opslaan Als"
+
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' bestaat niet alleen uit geldige tekens"
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' moet numeriek zijn."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' mag alleen ASCII-tekens bevatten."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' mag alleen letters bevatten."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' mag alleen alfa-numerieke tekens bevatten."
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' mag alleen cijfers bevatten."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "Kan venster van klasse '%s' niet maken"
+
+#~ msgid "Could not initalize libnotify."
+#~ msgstr "Kon niet initalize libnotify."
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "Kon geen overlay venster aanmaken"
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "Kon de context in het overlay venster niet initiëren"
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "Conversie bestand \"%s\" naar Unicode mislukt."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "Kan geen tekst aanbrengen in tekst-control."
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr "Ongeldig GTK+ commandoregel  optie, gebruik \"%s --help\""
+
+#~ msgid "No unused colour in image."
+#~ msgstr "Geen ongebruikte kleuren in afbeelding."
+
+#~ msgid "Not available"
+#~ msgstr "Niet beschikbaar"
+
+#~ msgid "Replace selection"
+#~ msgstr "Selectie vervangen"
+
+#~ msgid "Save as"
+#~ msgstr "Opslaan Als"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Stijl Organiseren"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "De volgende standaard GTK+ opties worden ook ondersteund:\n"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "U kunt geen overlay wissen die niet is geïnitieerd"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "U kunt niet een overlay twee keer initiëren"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "landinstelling '%s' kan niet worden ingesteld."
 
 #~ msgid "Adding flavor TEXT failed"
 #~ msgstr "Toevoegen flavor TEXT mislukt"
@@ -8905,9 +9245,6 @@ msgstr "~"
 
 #~ msgid "Column could not be added."
 #~ msgstr "Kolom kon niet toegevoegd worden."
-
-#~ msgid "Column description could not be initialized."
-#~ msgstr "Kolombeschrijving kon niet worden geïnitialiseerd."
 
 #~ msgid "Column index not found."
 #~ msgstr "Kolomindex niet gevonden."

--- a/locale/pl.po
+++ b/locale/pl.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-21 14:25+0200\n"
+"POT-Creation-Date: 2020-10-18 23:11+0300\n"
 "PO-Revision-Date: 2014-06-04 16:19+1200\n"
 "Last-Translator: Mariusz Drozdowski <schemedit@wp.pl>\n"
 "Language-Team: wxWidgets translators <wx-translators@wxwidgets.org>\n"
@@ -14,7 +14,7 @@ msgstr ""
 "|| n%100>=20) ? 1 : 2;\n"
 "X-Generator: Poedit 1.6.5\n"
 
-#: ../src/common/debugrpt.cpp:586
+#: ../src/common/debugrpt.cpp:587
 msgid ""
 "\n"
 "Please send this report to the program maintainer, thank you!\n"
@@ -22,8 +22,8 @@ msgstr ""
 "\n"
 "Proszę przesłać ten raport do autora programu, dziękuję!\n"
 
-#: ../src/richtext/richtextstyledlg.cpp:210
-#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:206
+#: ../src/richtext/richtextstyledlg.cpp:218
 msgid " "
 msgstr " "
 
@@ -31,70 +31,96 @@ msgstr " "
 msgid "              Thank you and we're sorry for the inconvenience!\n"
 msgstr "              Dziękujemy i przepraszamy za niedogodności!\n"
 
-#: ../src/common/prntbase.cpp:573
+#: ../src/common/prntbase.cpp:568
 #, c-format
 msgid " (copy %d of %d)"
 msgstr " (kopia %d z %d)"
 
-#: ../src/common/log.cpp:421
+#: ../src/common/log.cpp:440
 #, c-format
 msgid " (error %ld: %s)"
 msgstr " (błąd %ld: %s)"
 
-#: ../src/common/imagtiff.cpp:72
+#: ../src/common/imagtiff.cpp:69
 #, c-format
 msgid " (in module \"%s\")"
 msgstr " (w module \"%s\")"
 
-#: ../src/osx/core/secretstore.cpp:138
-msgid " (while overwriting an existing item)"
-msgstr ""
-
-#: ../src/common/docview.cpp:1642
+#: ../src/common/docview.cpp:1636
 msgid " - "
 msgstr " - "
 
-#: ../src/richtext/richtextprint.cpp:593 ../src/html/htmprint.cpp:714
+#: ../src/html/htmprint.cpp:712 ../src/richtext/richtextprint.cpp:589
 msgid " Preview"
 msgstr " Podgląd"
 
-#: ../src/common/fontcmn.cpp:824
+#: ../src/common/fontcmn.cpp:973
 msgid " bold"
 msgstr "pogrubiony"
 
-#: ../src/common/fontcmn.cpp:840
+#: ../src/common/fontcmn.cpp:977
+#, fuzzy
+msgid " extra bold"
+msgstr "pogrubiony"
+
+#: ../src/common/fontcmn.cpp:985
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:957
+#, fuzzy
+msgid " extra light"
+msgstr "lekki"
+
+#: ../src/common/fontcmn.cpp:981
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1001
 msgid " italic"
 msgstr "kursywa"
 
-#: ../src/common/fontcmn.cpp:820
+#: ../src/common/fontcmn.cpp:961
 msgid " light"
 msgstr "lekki"
 
-#: ../src/common/fontcmn.cpp:807
+#: ../src/common/fontcmn.cpp:965
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:969
+#, fuzzy
+msgid " semi bold"
+msgstr "pogrubiony"
+
+#: ../src/common/fontcmn.cpp:940
 msgid " strikethrough"
 msgstr " przekreślenie"
 
-#: ../src/common/paper.cpp:117
+#: ../src/common/fontcmn.cpp:953
+msgid " thin"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
 msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
 msgstr "Koperta #10, 4 1/8 x 9 1/2 cali"
 
-#: ../src/common/paper.cpp:118
+#: ../src/common/paper.cpp:115
 msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
 msgstr "Koperta #11, 4 1/2 x 10 3/8 cali"
 
-#: ../src/common/paper.cpp:119
+#: ../src/common/paper.cpp:116
 msgid "#12 Envelope, 4 3/4 x 11 in"
 msgstr "Koperta #12, 4 3/4 x 11 cali"
 
-#: ../src/common/paper.cpp:120
+#: ../src/common/paper.cpp:117
 msgid "#14 Envelope, 5 x 11 1/2 in"
 msgstr "Koperta #14, 5 x 11 1/2 cali"
 
-#: ../src/common/paper.cpp:116
+#: ../src/common/paper.cpp:113
 msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
 msgstr "Koperta #9, 3 7/8 x 8 7/8 cali"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:341
 #: ../src/richtext/richtextsizepage.cpp:340
 #: ../src/richtext/richtextsizepage.cpp:374
 #: ../src/richtext/richtextsizepage.cpp:401
@@ -105,21 +131,22 @@ msgstr "Koperta #9, 3 7/8 x 8 7/8 cali"
 #: ../src/richtext/richtextsizepage.cpp:591
 #: ../src/richtext/richtextsizepage.cpp:626
 #: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextbackgroundpage.cpp:341
 #, fuzzy
 msgid "%"
 msgstr "%s"
 
-#: ../src/html/helpwnd.cpp:1031
+#: ../src/html/helpwnd.cpp:1029
 #, c-format
 msgid "%d of %lu"
 msgstr "%d z %lu"
 
-#: ../src/html/helpwnd.cpp:1678
+#: ../src/html/helpwnd.cpp:1676
 #, fuzzy, c-format
 msgid "%i of %u"
 msgstr "%i z %i"
 
-#: ../src/generic/filectrlg.cpp:279
+#: ../src/generic/filectrlg.cpp:275
 #, c-format
 msgid "%ld byte"
 msgid_plural "%ld bytes"
@@ -127,61 +154,61 @@ msgstr[0] "%ld bajt"
 msgstr[1] "%ld bajty"
 msgstr[2] "%ld bajtów"
 
-#: ../src/html/helpwnd.cpp:1033
+#: ../src/html/helpwnd.cpp:1031
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu z %lu"
 
-#: ../src/generic/datavgen.cpp:6028
+#: ../src/generic/datavgen.cpp:6833
 #, fuzzy, c-format
 msgid "%s (%d items)"
 msgstr "%s (lub %s)"
 
-#: ../src/common/cmdline.cpp:1221
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (lub %s)"
 
-#: ../src/generic/logg.cpp:224
+#: ../src/generic/logg.cpp:221
 #, c-format
 msgid "%s Error"
 msgstr "%s Błąd"
 
-#: ../src/generic/logg.cpp:236
+#: ../src/generic/logg.cpp:233
 #, c-format
 msgid "%s Information"
 msgstr "%s Informacja"
 
-#: ../src/generic/preferencesg.cpp:113
+#: ../src/generic/preferencesg.cpp:110
 #, c-format
 msgid "%s Preferences"
 msgstr "Preferencje %s"
 
-#: ../src/generic/logg.cpp:228
+#: ../src/generic/logg.cpp:225
 #, c-format
 msgid "%s Warning"
 msgstr "%s Ostrzeżenie"
 
-#: ../src/common/tarstrm.cpp:1319
+#: ../src/common/tarstrm.cpp:1313
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s nie pasuje nagłówek tar do wpisu '%s'"
 
-#: ../src/common/fldlgcmn.cpp:124
+#: ../src/common/fldlgcmn.cpp:121
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s pliki (%s)|%s"
 
-#: ../src/html/helpwnd.cpp:1716
+#: ../src/html/helpwnd.cpp:1714
 #, fuzzy, c-format
 msgid "%u of %u"
 msgstr "%lu z %lu"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "&About"
 msgstr "Inform&acje"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "&Actual Size"
 msgstr "&Bieżący rozmiar"
 
@@ -189,28 +216,28 @@ msgstr "&Bieżący rozmiar"
 msgid "&After a paragraph:"
 msgstr "&Po paragrafie:"
 
-#: ../src/richtext/richtextindentspage.cpp:128
 #: ../src/richtext/richtextliststylepage.cpp:319
+#: ../src/richtext/richtextindentspage.cpp:128
 msgid "&Alignment"
 msgstr "&Wyrównanie"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "&Apply"
 msgstr "Z&astosuj"
 
-#: ../src/richtext/richtextstyledlg.cpp:251
+#: ../src/richtext/richtextstyledlg.cpp:247
 msgid "&Apply Style"
 msgstr "Z&astosuj styl"
 
-#: ../src/msw/mdi.cpp:179
+#: ../src/msw/mdi.cpp:174
 msgid "&Arrange Icons"
 msgstr "&Rozmieść ikony"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "&Ascending"
 msgstr "&Rosnąco"
 
-#: ../src/common/stockitem.cpp:142
+#: ../src/common/stockitem.cpp:139
 msgid "&Back"
 msgstr "&Wstecz"
 
@@ -230,24 +257,24 @@ msgstr "Kolor &tła:"
 msgid "&Blur distance:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:143
+#: ../src/common/stockitem.cpp:140
 msgid "&Bold"
 msgstr "Pogru&biony"
 
-#: ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141
 msgid "&Bottom"
 msgstr "&Dolny"
 
+#: ../src/richtext/richtextsizepage.cpp:637
+#: ../src/richtext/richtextsizepage.cpp:644
 #: ../src/richtext/richtextborderspage.cpp:345
 #: ../src/richtext/richtextborderspage.cpp:513
 #: ../src/richtext/richtextmarginspage.cpp:259
 #: ../src/richtext/richtextmarginspage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:637
-#: ../src/richtext/richtextsizepage.cpp:644
 msgid "&Bottom:"
 msgstr "&Dolny:"
 
-#: ../include/wx/richtext/richtextbuffer.h:3866
+#: ../include/wx/richtext/richtextbuffer.h:3861
 msgid "&Box"
 msgstr "&Blok"
 
@@ -256,38 +283,38 @@ msgstr "&Blok"
 msgid "&Bullet style:"
 msgstr "&Styl wypunktowania:"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "&CD-Rom"
 msgstr "&CD-Rom"
 
-#: ../src/generic/wizard.cpp:434 ../src/generic/fontdlgg.cpp:470
-#: ../src/generic/fontdlgg.cpp:489 ../src/osx/carbon/fontdlg.cpp:402
-#: ../src/common/dlgcmn.cpp:279 ../src/common/stockitem.cpp:145
+#: ../src/osx/carbon/fontdlg.cpp:399 ../src/common/stockitem.cpp:142
+#: ../src/generic/wizard.cpp:433 ../src/generic/fontdlgg.cpp:466
+#: ../src/generic/fontdlgg.cpp:485 ../src/osx/cocoa/button.mm:200
 msgid "&Cancel"
 msgstr "&Anuluj"
 
-#: ../src/msw/mdi.cpp:175
+#: ../src/msw/mdi.cpp:170
 msgid "&Cascade"
 msgstr "&Kaskada"
 
-#: ../include/wx/richtext/richtextbuffer.h:5960
+#: ../include/wx/richtext/richtextbuffer.h:5955
 msgid "&Cell"
 msgstr "&Komórka"
 
-#: ../src/richtext/richtextsymboldlg.cpp:439
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "&Character code:"
 msgstr "&Kod znaku:"
 
-#: ../src/common/stockitem.cpp:147
+#: ../src/common/stockitem.cpp:144
 msgid "&Clear"
 msgstr "Wy&czyść"
 
-#: ../src/generic/logg.cpp:516 ../src/common/stockitem.cpp:148
-#: ../src/common/prntbase.cpp:1600 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/stockitem.cpp:145 ../src/common/prntbase.cpp:1625
+#: ../src/univ/themes/win32.cpp:3753 ../src/generic/logg.cpp:513
 msgid "&Close"
 msgstr "Zam&knij"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "&Color"
 msgstr "K&olor"
 
@@ -295,20 +322,20 @@ msgstr "K&olor"
 msgid "&Colour:"
 msgstr "K&olor:"
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "&Convert"
 msgstr "&Konwertuj"
 
-#: ../src/richtext/richtextctrl.cpp:333 ../src/osx/textctrl_osx.cpp:577
-#: ../src/common/stockitem.cpp:150 ../src/msw/textctrl.cpp:2508
+#: ../src/osx/textctrl_osx.cpp:595 ../src/common/stockitem.cpp:147
+#: ../src/msw/textctrl.cpp:2773 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Kopiuj"
 
-#: ../src/generic/hyperlinkg.cpp:156
+#: ../src/generic/hyperlinkg.cpp:153
 msgid "&Copy URL"
 msgstr "&Kopiuj URL"
 
-#: ../src/common/headerctrlcmn.cpp:306
+#: ../src/common/headerctrlcmn.cpp:304
 msgid "&Customize..."
 msgstr "&Dostosuj..."
 
@@ -316,53 +343,54 @@ msgstr "&Dostosuj..."
 msgid "&Debug report preview:"
 msgstr "Po&dgląd raportu błędów:"
 
-#: ../src/richtext/richtexttabspage.cpp:138
-#: ../src/richtext/richtextctrl.cpp:335 ../src/osx/textctrl_osx.cpp:579
-#: ../src/common/stockitem.cpp:152 ../src/msw/textctrl.cpp:2510
+#: ../src/osx/textctrl_osx.cpp:597 ../src/common/stockitem.cpp:149
+#: ../src/msw/textctrl.cpp:2775 ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtextctrl.cpp:334
 msgid "&Delete"
 msgstr "&Usuń"
 
-#: ../src/richtext/richtextstyledlg.cpp:269
+#: ../src/richtext/richtextstyledlg.cpp:265
 msgid "&Delete Style..."
 msgstr "&Usuń styl..."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "&Descending"
 msgstr "&Malejąco"
 
-#: ../src/generic/logg.cpp:682
+#: ../src/generic/logg.cpp:679
 msgid "&Details"
 msgstr "&Szczegóły"
 
-#: ../src/common/stockitem.cpp:153
+#: ../src/common/stockitem.cpp:150
 msgid "&Down"
 msgstr "W &dół"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "&Edit"
 msgstr "&Edytuj"
 
-#: ../src/richtext/richtextstyledlg.cpp:263
+#: ../src/richtext/richtextstyledlg.cpp:259
 msgid "&Edit Style..."
 msgstr "&Edytuj styl..."
 
-#: ../src/common/stockitem.cpp:155
+#: ../src/common/stockitem.cpp:152
 msgid "&Execute"
 msgstr "&Uruchom"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/common/stockitem.cpp:154
 msgid "&File"
 msgstr "&Plik"
 
-#: ../src/common/stockitem.cpp:158
-msgid "&Find"
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "&Find..."
 msgstr "&Znajdź"
 
-#: ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:430
 msgid "&Finish"
 msgstr "Za&kończ"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:156
 msgid "&First"
 msgstr "Pierwszy"
 
@@ -370,15 +398,15 @@ msgstr "Pierwszy"
 msgid "&Floating mode:"
 msgstr "Tryb &ruchomy:"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "&Floppy"
 msgstr "&Dyskietka"
 
-#: ../src/common/stockitem.cpp:194
+#: ../src/common/stockitem.cpp:191
 msgid "&Font"
 msgstr "&Czcionka"
 
-#: ../src/generic/fontdlgg.cpp:371
+#: ../src/generic/fontdlgg.cpp:367
 msgid "&Font family:"
 msgstr "&Rozmiar czcionki:"
 
@@ -386,20 +414,20 @@ msgstr "&Rozmiar czcionki:"
 msgid "&Font for Level..."
 msgstr "&Czcionka dla poziomu..."
 
+#: ../src/richtext/richtextsymboldlg.cpp:397
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:400
 msgid "&Font:"
 msgstr "&Czcionka:"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "&Forward"
 msgstr "&Dalej"
 
-#: ../src/richtext/richtextsymboldlg.cpp:451
+#: ../src/richtext/richtextsymboldlg.cpp:448
 msgid "&From:"
 msgstr "&Od:"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "&Harddisk"
 msgstr "&Dysk twardy"
 
@@ -408,9 +436,9 @@ msgstr "&Dysk twardy"
 msgid "&Height:"
 msgstr "&Wysokość:"
 
-#: ../src/generic/wizard.cpp:441 ../src/richtext/richtextstyledlg.cpp:303
-#: ../src/richtext/richtextsymboldlg.cpp:479 ../src/osx/menu_osx.cpp:734
-#: ../src/common/stockitem.cpp:163
+#: ../src/common/stockitem.cpp:160 ../src/generic/wizard.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextstyledlg.cpp:299 ../src/osx/cocoa/menu.mm:226
 msgid "&Help"
 msgstr "&Pomoc"
 
@@ -418,7 +446,7 @@ msgstr "&Pomoc"
 msgid "&Hide details"
 msgstr "&Ukryj szczegóły"
 
-#: ../src/common/stockitem.cpp:164
+#: ../src/common/stockitem.cpp:161
 msgid "&Home"
 msgstr "&Początek"
 
@@ -426,54 +454,54 @@ msgstr "&Początek"
 msgid "&Horizontal offset:"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:184
 #: ../src/richtext/richtextliststylepage.cpp:372
+#: ../src/richtext/richtextindentspage.cpp:184
 msgid "&Indentation (tenths of a mm)"
 msgstr "&Wcięcia (w dziesiątych częściach mm)"
 
-#: ../src/richtext/richtextindentspage.cpp:167
 #: ../src/richtext/richtextliststylepage.cpp:356
+#: ../src/richtext/richtextindentspage.cpp:167
 msgid "&Indeterminate"
 msgstr "&Nieokreślony"
 
-#: ../src/common/stockitem.cpp:166
+#: ../src/common/stockitem.cpp:163
 msgid "&Index"
 msgstr "&Indeks"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "&Info"
 msgstr "&Info"
 
-#: ../src/common/stockitem.cpp:168
+#: ../src/common/stockitem.cpp:165
 msgid "&Italic"
 msgstr "&Kursywa"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "&Jump to"
 msgstr "&Skocz do"
 
-#: ../src/richtext/richtextindentspage.cpp:153
 #: ../src/richtext/richtextliststylepage.cpp:342
+#: ../src/richtext/richtextindentspage.cpp:153
 msgid "&Justified"
 msgstr "&Wyrównanie obustronne"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "&Last"
 msgstr "&Ostatni"
 
-#: ../src/richtext/richtextindentspage.cpp:139
 #: ../src/richtext/richtextliststylepage.cpp:328
+#: ../src/richtext/richtextindentspage.cpp:139
 msgid "&Left"
 msgstr "&Lewy"
 
-#: ../src/richtext/richtextindentspage.cpp:195
+#: ../src/richtext/richtextsizepage.cpp:532
+#: ../src/richtext/richtextsizepage.cpp:539
 #: ../src/richtext/richtextborderspage.cpp:243
 #: ../src/richtext/richtextborderspage.cpp:411
 #: ../src/richtext/richtextliststylepage.cpp:381
+#: ../src/richtext/richtextindentspage.cpp:195
 #: ../src/richtext/richtextmarginspage.cpp:186
 #: ../src/richtext/richtextmarginspage.cpp:300
-#: ../src/richtext/richtextsizepage.cpp:532
-#: ../src/richtext/richtextsizepage.cpp:539
 msgid "&Left:"
 msgstr "&Lewy:"
 
@@ -481,11 +509,11 @@ msgstr "&Lewy:"
 msgid "&List level:"
 msgstr "Poziom &listy:"
 
-#: ../src/generic/logg.cpp:517
+#: ../src/generic/logg.cpp:514
 msgid "&Log"
 msgstr "&Dziennik"
 
-#: ../src/univ/themes/win32.cpp:3748
+#: ../src/univ/themes/win32.cpp:3745
 msgid "&Move"
 msgstr "Prz&enieś"
 
@@ -493,20 +521,19 @@ msgstr "Prz&enieś"
 msgid "&Move the object to:"
 msgstr "&Przenieś obiekt do:"
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "&Network"
 msgstr "&Sieć"
 
-#: ../src/richtext/richtexttabspage.cpp:132 ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173 ../src/richtext/richtexttabspage.cpp:132
 msgid "&New"
 msgstr "&Nowy"
 
-#: ../src/aui/tabmdi.cpp:111 ../src/generic/mdig.cpp:100
-#: ../src/msw/mdi.cpp:180
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
 msgid "&Next"
 msgstr "&Następne"
 
-#: ../src/generic/wizard.cpp:432 ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:429
 msgid "&Next >"
 msgstr "&Dalej >"
 
@@ -514,7 +541,7 @@ msgstr "&Dalej >"
 msgid "&Next Paragraph"
 msgstr "&Następny akapit"
 
-#: ../src/generic/tipdlg.cpp:240
+#: ../src/generic/tipdlg.cpp:237
 msgid "&Next Tip"
 msgstr "&Następna porada"
 
@@ -522,11 +549,11 @@ msgstr "&Następna porada"
 msgid "&Next style:"
 msgstr "&Następny styl:"
 
-#: ../src/common/stockitem.cpp:177 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:174 ../src/msw/msgdlg.cpp:435
 msgid "&No"
 msgstr "&Nie"
 
-#: ../src/generic/dbgrptg.cpp:356
+#: ../src/generic/dbgrptg.cpp:360
 msgid "&Notes:"
 msgstr "&Uwagi:"
 
@@ -534,12 +561,12 @@ msgstr "&Uwagi:"
 msgid "&Number:"
 msgstr "&Numer:"
 
-#: ../src/generic/fontdlgg.cpp:475 ../src/generic/fontdlgg.cpp:482
-#: ../src/osx/carbon/fontdlg.cpp:408 ../src/common/stockitem.cpp:178
+#: ../src/osx/carbon/fontdlg.cpp:405 ../src/common/stockitem.cpp:175
+#: ../src/generic/fontdlgg.cpp:471 ../src/generic/fontdlgg.cpp:478
 msgid "&OK"
 msgstr "&OK"
 
-#: ../src/generic/dbgrptg.cpp:342 ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176 ../src/generic/dbgrptg.cpp:342
 msgid "&Open..."
 msgstr "&Otwórz..."
 
@@ -551,16 +578,16 @@ msgstr "Poziom &kontur:"
 msgid "&Page Break"
 msgstr "&Podział strony"
 
-#: ../src/richtext/richtextctrl.cpp:334 ../src/osx/textctrl_osx.cpp:578
-#: ../src/common/stockitem.cpp:180 ../src/msw/textctrl.cpp:2509
+#: ../src/osx/textctrl_osx.cpp:596 ../src/common/stockitem.cpp:177
+#: ../src/msw/textctrl.cpp:2774 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "Wkl&ej"
 
-#: ../include/wx/richtext/richtextbuffer.h:5010
+#: ../include/wx/richtext/richtextbuffer.h:5005
 msgid "&Picture"
 msgstr "&Obraz"
 
-#: ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:419
 msgid "&Point size:"
 msgstr "&Rozmiar punktu:"
 
@@ -572,12 +599,11 @@ msgstr "&Pozycja (w dziesiątych częściach mm):"
 msgid "&Position mode:"
 msgstr "&Tryb pozycji:"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178
 msgid "&Preferences"
 msgstr "&Preferencje"
 
-#: ../src/aui/tabmdi.cpp:112 ../src/generic/mdig.cpp:101
-#: ../src/msw/mdi.cpp:181
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
 msgid "&Previous"
 msgstr "&Poprzednie"
 
@@ -585,78 +611,74 @@ msgstr "&Poprzednie"
 msgid "&Previous Paragraph"
 msgstr "&Poprzedni akapit"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "&Print..."
 msgstr "&Drukuj..."
 
-#: ../src/richtext/richtextctrl.cpp:339 ../src/richtext/richtextctrl.cpp:5514
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtextctrl.cpp:338
+#: ../src/richtext/richtextctrl.cpp:5512
 msgid "&Properties"
 msgstr "&Właściwości"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "&Quit"
 msgstr "&Wyjście"
 
-#: ../src/richtext/richtextctrl.cpp:330 ../src/osx/textctrl_osx.cpp:574
-#: ../src/common/stockitem.cpp:185 ../src/common/cmdproc.cpp:293
-#: ../src/common/cmdproc.cpp:300 ../src/msw/textctrl.cpp:2505
+#: ../src/osx/textctrl_osx.cpp:592 ../src/common/stockitem.cpp:182
+#: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
+#: ../src/msw/textctrl.cpp:2770 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Ponów"
 
-#: ../src/common/cmdproc.cpp:289 ../src/common/cmdproc.cpp:309
+#: ../src/common/cmdproc.cpp:282 ../src/common/cmdproc.cpp:302
 msgid "&Redo "
 msgstr "&Ponów "
 
-#: ../src/richtext/richtextstyledlg.cpp:257
+#: ../src/richtext/richtextstyledlg.cpp:253
 msgid "&Rename Style..."
 msgstr "&Zmień nazwę stylu..."
 
-#: ../src/generic/fdrepdlg.cpp:179
+#: ../src/generic/fdrepdlg.cpp:176
 msgid "&Replace"
 msgstr "&Zastąp"
 
-#: ../src/richtext/richtextstyledlg.cpp:287
+#: ../src/richtext/richtextstyledlg.cpp:283
 msgid "&Restart numbering"
 msgstr "&Ponowienie numeracji"
 
-#: ../src/univ/themes/win32.cpp:3747
+#: ../src/univ/themes/win32.cpp:3744
 msgid "&Restore"
 msgstr "&Przywróć"
 
-#: ../src/richtext/richtextindentspage.cpp:146
 #: ../src/richtext/richtextliststylepage.cpp:335
+#: ../src/richtext/richtextindentspage.cpp:146
 msgid "&Right"
 msgstr "&Prawy"
 
-#: ../src/richtext/richtextindentspage.cpp:213
+#: ../src/richtext/richtextsizepage.cpp:602
+#: ../src/richtext/richtextsizepage.cpp:609
 #: ../src/richtext/richtextborderspage.cpp:277
 #: ../src/richtext/richtextborderspage.cpp:445
 #: ../src/richtext/richtextliststylepage.cpp:399
+#: ../src/richtext/richtextindentspage.cpp:213
 #: ../src/richtext/richtextmarginspage.cpp:211
 #: ../src/richtext/richtextmarginspage.cpp:325
-#: ../src/richtext/richtextsizepage.cpp:602
-#: ../src/richtext/richtextsizepage.cpp:609
 msgid "&Right:"
 msgstr "&Prawy:"
 
-#: ../src/common/stockitem.cpp:190
+#: ../src/common/stockitem.cpp:187
 msgid "&Save"
 msgstr "Zapi&sz"
-
-#: ../src/common/stockitem.cpp:191
-msgid "&Save as"
-msgstr "Zapisz &Jako"
 
 #: ../include/wx/richmsgdlg.h:29
 msgid "&See details"
 msgstr "&Zobacz szczegóły"
 
-#: ../src/generic/tipdlg.cpp:236
+#: ../src/generic/tipdlg.cpp:233
 msgid "&Show tips at startup"
 msgstr "&Pokazuj porady przy uruchamianiu"
 
-#: ../src/univ/themes/win32.cpp:3750
+#: ../src/univ/themes/win32.cpp:3747
 msgid "&Size"
 msgstr "&Rozmiar"
 
@@ -664,36 +686,36 @@ msgstr "&Rozmiar"
 msgid "&Size:"
 msgstr "&Rozmiar:"
 
-#: ../src/generic/progdlgg.cpp:252
+#: ../src/generic/progdlgg.cpp:249
 msgid "&Skip"
 msgstr "&Pomiń"
 
-#: ../src/richtext/richtextindentspage.cpp:242
 #: ../src/richtext/richtextliststylepage.cpp:417
+#: ../src/richtext/richtextindentspage.cpp:242
 msgid "&Spacing (tenths of a mm)"
 msgstr "&Odstępy (w dziesiątych częściach mm)"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "&Spell Check"
 msgstr "&Sprawdzanie pisowni"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "&Stop"
 msgstr "&Stop"
 
-#: ../src/richtext/richtextfontpage.cpp:275 ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196 ../src/richtext/richtextfontpage.cpp:275
 msgid "&Strikethrough"
 msgstr "&Przekreślenie"
 
-#: ../src/generic/fontdlgg.cpp:382 ../src/richtext/richtextstylepage.cpp:106
+#: ../src/generic/fontdlgg.cpp:378 ../src/richtext/richtextstylepage.cpp:106
 msgid "&Style:"
 msgstr "&Styl:"
 
-#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:194
 msgid "&Styles:"
 msgstr "&Style:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:413
+#: ../src/richtext/richtextsymboldlg.cpp:410
 msgid "&Subset:"
 msgstr "&Podzbiór:"
 
@@ -707,24 +729,24 @@ msgstr "&Symbol:"
 msgid "&Synchronize values"
 msgstr ""
 
-#: ../include/wx/richtext/richtextbuffer.h:6069
+#: ../include/wx/richtext/richtextbuffer.h:6064
 msgid "&Table"
 msgstr "&Tabela"
 
-#: ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197
 msgid "&Top"
 msgstr "&Góra"
 
+#: ../src/richtext/richtextsizepage.cpp:567
+#: ../src/richtext/richtextsizepage.cpp:574
 #: ../src/richtext/richtextborderspage.cpp:311
 #: ../src/richtext/richtextborderspage.cpp:479
 #: ../src/richtext/richtextmarginspage.cpp:234
 #: ../src/richtext/richtextmarginspage.cpp:348
-#: ../src/richtext/richtextsizepage.cpp:567
-#: ../src/richtext/richtextsizepage.cpp:574
 msgid "&Top:"
 msgstr "&Góra:"
 
-#: ../src/generic/fontdlgg.cpp:444 ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199 ../src/generic/fontdlgg.cpp:441
 msgid "&Underline"
 msgstr "&Podkreślony"
 
@@ -732,21 +754,21 @@ msgstr "&Podkreślony"
 msgid "&Underlining:"
 msgstr "&Podkreślenie:"
 
-#: ../src/richtext/richtextctrl.cpp:329 ../src/osx/textctrl_osx.cpp:573
-#: ../src/common/stockitem.cpp:203 ../src/common/cmdproc.cpp:271
-#: ../src/msw/textctrl.cpp:2504
+#: ../src/osx/textctrl_osx.cpp:591 ../src/common/stockitem.cpp:200
+#: ../src/common/cmdproc.cpp:264 ../src/msw/textctrl.cpp:2769
+#: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Cofnij"
 
-#: ../src/common/cmdproc.cpp:265
+#: ../src/common/cmdproc.cpp:258
 msgid "&Undo "
 msgstr "&Cofnij "
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "&Unindent"
 msgstr "&Cofnij wcięcie"
 
-#: ../src/common/stockitem.cpp:205
+#: ../src/common/stockitem.cpp:202
 msgid "&Up"
 msgstr "&W górę"
 
@@ -763,7 +785,7 @@ msgstr "&Wyrównanie pionowe:"
 msgid "&View..."
 msgstr "&Widok..."
 
-#: ../src/generic/fontdlgg.cpp:393
+#: ../src/generic/fontdlgg.cpp:389
 msgid "&Weight:"
 msgstr "&Waga"
 
@@ -772,88 +794,58 @@ msgstr "&Waga"
 msgid "&Width:"
 msgstr "&Szerokość:"
 
-#: ../src/aui/tabmdi.cpp:311 ../src/aui/tabmdi.cpp:327
-#: ../src/aui/tabmdi.cpp:329 ../src/generic/mdig.cpp:294
-#: ../src/generic/mdig.cpp:310 ../src/generic/mdig.cpp:314
-#: ../src/msw/mdi.cpp:78
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
 msgid "&Window"
 msgstr "&Okno"
 
-#: ../src/common/stockitem.cpp:206 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:203 ../src/msw/msgdlg.cpp:435
 msgid "&Yes"
 msgstr "&Tak"
 
-#: ../src/common/valtext.cpp:256
+#: ../src/common/valtext.cpp:197
 #, fuzzy, c-format
-msgid "'%s' contains illegal characters"
+msgid "'%s' contains invalid character(s)"
 msgstr "'%s' powinien zawierać tylko wartości znakowe."
 
-#: ../src/common/valtext.cpp:254
-#, fuzzy, c-format
-msgid "'%s' doesn't consist only of valid characters"
-msgstr "'%s' powinien zawierać tylko wartości znakowe."
-
-#: ../src/common/config.cpp:519 ../src/msw/regconf.cpp:258
+#: ../src/common/config.cpp:515 ../src/msw/regconf.cpp:255
 #, c-format
 msgid "'%s' has extra '..', ignored."
 msgstr "'%s' ma nadmiarowe '..', zignorowane."
 
-#: ../src/common/cmdline.cpp:1113 ../src/common/cmdline.cpp:1131
+#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' nie jest poprawną wartością numeryczną opcji '%s'."
 
-#: ../src/common/translation.cpp:1100
+#: ../src/common/translation.cpp:1142
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' nie jest prawidłowym katalogiem komunikatów."
 
-#: ../src/common/valtext.cpp:165
+#: ../src/common/valtext.cpp:188
 #, fuzzy, c-format
 msgid "'%s' is not one of the valid strings"
 msgstr "'%s' nie jest prawidłowym katalogiem komunikatów."
 
-#: ../src/common/valtext.cpp:167
+#: ../src/common/valtext.cpp:186
 #, fuzzy, c-format
 msgid "'%s' is one of the invalid strings"
 msgstr "'%s' jest nieprawidłowy"
 
-#: ../src/common/textbuf.cpp:237
+#: ../src/common/textbuf.cpp:233
 #, c-format
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' jest prawdopodobnie buforem binarnym."
-
-#: ../src/common/valtext.cpp:252
-#, c-format
-msgid "'%s' should be numeric."
-msgstr "'%s' powinno być numeryczne."
-
-#: ../src/common/valtext.cpp:244
-#, c-format
-msgid "'%s' should only contain ASCII characters."
-msgstr "'%s' powinien zawierać tylko znaki ASCII."
-
-#: ../src/common/valtext.cpp:246
-#, c-format
-msgid "'%s' should only contain alphabetic characters."
-msgstr "'%s' powinien zawierać tylko wartości znakowe."
-
-#: ../src/common/valtext.cpp:248
-#, c-format
-msgid "'%s' should only contain alphabetic or numeric characters."
-msgstr "'%s' powinien zawierać tylko wartości znakowe lub numeryczne."
-
-#: ../src/common/valtext.cpp:250
-#, c-format
-msgid "'%s' should only contain digits."
-msgstr "'%s' powinien zawierać tylko cyfry."
 
 #: ../src/richtext/richtextliststylepage.cpp:229
 #: ../src/richtext/richtextbulletspage.cpp:166
 msgid "(*)"
 msgstr "(*)"
 
-#: ../src/html/helpwnd.cpp:963
+#: ../src/html/helpwnd.cpp:961
 msgid "(Help)"
 msgstr "(Pomoc)"
 
@@ -862,27 +854,32 @@ msgstr "(Pomoc)"
 msgid "(None)"
 msgstr "(Brak)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:504
+#: ../src/richtext/richtextsymboldlg.cpp:503
 msgid "(Normal text)"
 msgstr "(Normalny tekst)"
 
-#: ../src/html/helpwnd.cpp:419 ../src/html/helpwnd.cpp:1106
-#: ../src/html/helpwnd.cpp:1742
+#: ../src/html/helpwnd.cpp:417 ../src/html/helpwnd.cpp:1104
+#: ../src/html/helpwnd.cpp:1740
 msgid "(bookmarks)"
 msgstr "(zakładki)"
 
+#: ../src/msw/dlmsw.cpp:167
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (błąd %ld: %s)"
+
+#: ../src/richtext/richtextformatdlg.cpp:876
+#: ../src/richtext/richtextliststylepage.cpp:448
+#: ../src/richtext/richtextliststylepage.cpp:460
+#: ../src/richtext/richtextliststylepage.cpp:461
 #: ../src/richtext/richtextindentspage.cpp:274
 #: ../src/richtext/richtextindentspage.cpp:286
 #: ../src/richtext/richtextindentspage.cpp:287
 #: ../src/richtext/richtextindentspage.cpp:311
 #: ../src/richtext/richtextindentspage.cpp:326
-#: ../src/richtext/richtextformatdlg.cpp:884
 #: ../src/richtext/richtextfontpage.cpp:349
 #: ../src/richtext/richtextfontpage.cpp:353
 #: ../src/richtext/richtextfontpage.cpp:357
-#: ../src/richtext/richtextliststylepage.cpp:448
-#: ../src/richtext/richtextliststylepage.cpp:460
-#: ../src/richtext/richtextliststylepage.cpp:461
 msgid "(none)"
 msgstr "(beznazwy)"
 
@@ -901,7 +898,7 @@ msgstr "*)"
 msgid "+"
 msgstr "+"
 
-#: ../src/msw/utils.cpp:1152
+#: ../src/msw/utils.cpp:1143
 msgid ", 64-bit edition"
 msgstr ", wydanie 64-bitowe"
 
@@ -910,163 +907,163 @@ msgstr ", wydanie 64-bitowe"
 msgid "-"
 msgstr "-"
 
-#: ../src/generic/filepickerg.cpp:66
+#: ../src/generic/filepickerg.cpp:63
 msgid "..."
 msgstr "..."
 
-#: ../src/richtext/richtextindentspage.cpp:276
 #: ../src/richtext/richtextliststylepage.cpp:450
+#: ../src/richtext/richtextindentspage.cpp:276
 msgid "1.1"
 msgstr "1.1"
 
-#: ../src/richtext/richtextindentspage.cpp:277
 #: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextindentspage.cpp:277
 msgid "1.2"
 msgstr "1.2"
 
-#: ../src/richtext/richtextindentspage.cpp:278
 #: ../src/richtext/richtextliststylepage.cpp:452
+#: ../src/richtext/richtextindentspage.cpp:278
 msgid "1.3"
 msgstr "1.3"
 
-#: ../src/richtext/richtextindentspage.cpp:279
 #: ../src/richtext/richtextliststylepage.cpp:453
+#: ../src/richtext/richtextindentspage.cpp:279
 msgid "1.4"
 msgstr "1.4"
 
-#: ../src/richtext/richtextindentspage.cpp:280
 #: ../src/richtext/richtextliststylepage.cpp:454
+#: ../src/richtext/richtextindentspage.cpp:280
 msgid "1.5"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:281
 #: ../src/richtext/richtextliststylepage.cpp:455
+#: ../src/richtext/richtextindentspage.cpp:281
 msgid "1.6"
 msgstr "1.6"
 
-#: ../src/richtext/richtextindentspage.cpp:282
 #: ../src/richtext/richtextliststylepage.cpp:456
+#: ../src/richtext/richtextindentspage.cpp:282
 msgid "1.7"
 msgstr "1.7"
 
-#: ../src/richtext/richtextindentspage.cpp:283
 #: ../src/richtext/richtextliststylepage.cpp:457
+#: ../src/richtext/richtextindentspage.cpp:283
 msgid "1.8"
 msgstr "1.8"
 
-#: ../src/richtext/richtextindentspage.cpp:284
 #: ../src/richtext/richtextliststylepage.cpp:458
+#: ../src/richtext/richtextindentspage.cpp:284
 msgid "1.9"
 msgstr "1.9"
 
-#: ../src/common/paper.cpp:140
+#: ../src/common/paper.cpp:137
 msgid "10 x 11 in"
 msgstr "10 x 11 cali"
 
-#: ../src/common/paper.cpp:113
+#: ../src/common/paper.cpp:110
 msgid "10 x 14 in"
 msgstr "10 x 14 cali"
 
-#: ../src/common/paper.cpp:114
+#: ../src/common/paper.cpp:111
 msgid "11 x 17 in"
 msgstr "11 x 17 cali"
 
-#: ../src/common/paper.cpp:184
+#: ../src/common/paper.cpp:181
 msgid "12 x 11 in"
 msgstr "12 x 11 cali"
 
-#: ../src/common/paper.cpp:141
+#: ../src/common/paper.cpp:138
 msgid "15 x 11 in"
 msgstr "15 x 11 cali"
 
-#: ../src/richtext/richtextindentspage.cpp:285
 #: ../src/richtext/richtextliststylepage.cpp:459
+#: ../src/richtext/richtextindentspage.cpp:285
 msgid "2"
 msgstr "2"
 
-#: ../src/common/paper.cpp:132
+#: ../src/common/paper.cpp:129
 msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
 msgstr "Koperta 6 3/4, 3 5/8 x 6 1/2 cali"
 
-#: ../src/common/paper.cpp:139
+#: ../src/common/paper.cpp:136
 msgid "9 x 11 in"
 msgstr "9 x 11 cali"
 
-#: ../src/html/htmprint.cpp:431
+#: ../src/html/htmprint.cpp:443
 msgid ": file does not exist!"
 msgstr ": plik nie istnieje!"
 
-#: ../src/common/fontmap.cpp:199
+#: ../src/common/fontmap.cpp:196
 msgid ": unknown charset"
 msgstr ": nieznany zestaw znaków"
 
-#: ../src/common/fontmap.cpp:413
+#: ../src/common/fontmap.cpp:410
 msgid ": unknown encoding"
 msgstr ": nieznane kodowanie"
 
-#: ../src/generic/wizard.cpp:443
+#: ../src/generic/wizard.cpp:438
 msgid "< &Back"
 msgstr "< &Wstecz"
 
-#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:628
-#: ../src/osx/carbon/fontdlg.cpp:648
+#: ../src/osx/carbon/fontdlg.cpp:419 ../src/osx/carbon/fontdlg.cpp:625
+#: ../src/osx/carbon/fontdlg.cpp:645
 msgid "<Any Decorative>"
 msgstr "<dowolny ozdobny>"
 
-#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:630
-#: ../src/osx/carbon/fontdlg.cpp:650
+#: ../src/osx/carbon/fontdlg.cpp:420 ../src/osx/carbon/fontdlg.cpp:627
+#: ../src/osx/carbon/fontdlg.cpp:647
 msgid "<Any Modern>"
 msgstr "<dowolny współczesny>"
 
-#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:626
-#: ../src/osx/carbon/fontdlg.cpp:646
+#: ../src/osx/carbon/fontdlg.cpp:418 ../src/osx/carbon/fontdlg.cpp:623
+#: ../src/osx/carbon/fontdlg.cpp:643
 msgid "<Any Roman>"
 msgstr "<dowolny rzymski>"
 
-#: ../src/osx/carbon/fontdlg.cpp:424 ../src/osx/carbon/fontdlg.cpp:632
-#: ../src/osx/carbon/fontdlg.cpp:652
+#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:629
+#: ../src/osx/carbon/fontdlg.cpp:649
 msgid "<Any Script>"
 msgstr "<dowolny Skrypt>"
 
-#: ../src/osx/carbon/fontdlg.cpp:425 ../src/osx/carbon/fontdlg.cpp:637
-#: ../src/osx/carbon/fontdlg.cpp:656
+#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:634
+#: ../src/osx/carbon/fontdlg.cpp:653
 msgid "<Any Swiss>"
 msgstr "<dowolny szwajcarski>"
 
-#: ../src/osx/carbon/fontdlg.cpp:426 ../src/osx/carbon/fontdlg.cpp:634
-#: ../src/osx/carbon/fontdlg.cpp:654
+#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:631
+#: ../src/osx/carbon/fontdlg.cpp:651
 msgid "<Any Teletype>"
 msgstr "<dowolny Teletype>"
 
-#: ../src/osx/carbon/fontdlg.cpp:420
+#: ../src/osx/carbon/fontdlg.cpp:417
 msgid "<Any>"
 msgstr "<dowolny>"
 
-#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
 msgid "<DIR>"
 msgstr "<KATALOG>"
 
-#: ../src/generic/filectrlg.cpp:254 ../src/generic/filectrlg.cpp:277
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
 msgid "<DRIVE>"
 msgstr "<NAPĘD>"
 
-#: ../src/generic/filectrlg.cpp:252 ../src/generic/filectrlg.cpp:275
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
 msgid "<LINK>"
 msgstr "<ŁĄCZE>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1264
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Pogrubiona kursywa.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1270
+#: ../src/html/helpwnd.cpp:1268
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>pogrubiona kursywa <u>z podkreśleniem</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1265
+#: ../src/html/helpwnd.cpp:1263
 msgid "<b>Bold face.</b> "
 msgstr "<b>Pogrubienie.</b> "
 
-#: ../src/html/helpwnd.cpp:1264
+#: ../src/html/helpwnd.cpp:1262
 msgid "<i>Italic face.</i> "
 msgstr "<i>Kursywa.</i> "
 
@@ -1075,15 +1072,15 @@ msgstr "<i>Kursywa.</i> "
 msgid ">"
 msgstr ">"
 
-#: ../src/generic/dbgrptg.cpp:318
+#: ../src/generic/dbgrptg.cpp:317
 msgid "A debug report has been generated in the directory\n"
 msgstr "Raport błędów został wygenerowany w katalogu\n"
 
-#: ../src/common/debugrpt.cpp:573
+#: ../src/common/debugrpt.cpp:574
 msgid "A debug report has been generated. It can be found in"
 msgstr "Raport błędów został wygenerowany. Znajduje się w"
 
-#: ../src/common/xtixml.cpp:418
+#: ../src/common/xtixml.cpp:414
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Nie pusta kolekcja musi składać się z węzłów typu 'element'"
 
@@ -1094,106 +1091,106 @@ msgstr "Nie pusta kolekcja musi składać się z węzłów typu 'element'"
 msgid "A standard bullet name."
 msgstr "Standardowa nazwa wypunktowania."
 
-#: ../src/common/paper.cpp:217
+#: ../src/common/paper.cpp:214
 msgid "A0 sheet, 841 x 1189 mm"
 msgstr "Arkusz A0, 841 x 1189 mm"
 
-#: ../src/common/paper.cpp:218
+#: ../src/common/paper.cpp:215
 msgid "A1 sheet, 594 x 841 mm"
 msgstr "Arkusz A1, 594 x 841 mm"
 
-#: ../src/common/paper.cpp:159
+#: ../src/common/paper.cpp:156
 msgid "A2 420 x 594 mm"
 msgstr "A2 420 x 594 mm"
 
-#: ../src/common/paper.cpp:156
+#: ../src/common/paper.cpp:153
 msgid "A3 Extra 322 x 445 mm"
 msgstr "A3 Extra 322 x 445 mm"
 
-#: ../src/common/paper.cpp:161
+#: ../src/common/paper.cpp:158
 msgid "A3 Extra Transverse 322 x 445 mm"
 msgstr "A3 Extra Poprzecznie 322 x 445 mm"
 
-#: ../src/common/paper.cpp:170
+#: ../src/common/paper.cpp:167
 msgid "A3 Rotated 420 x 297 mm"
 msgstr "A3 Obrócone 420 x 297 mm"
 
-#: ../src/common/paper.cpp:160
+#: ../src/common/paper.cpp:157
 msgid "A3 Transverse 297 x 420 mm"
 msgstr "A3 Poprzecznie 297 x 420 mm"
 
-#: ../src/common/paper.cpp:106
+#: ../src/common/paper.cpp:103
 msgid "A3 sheet, 297 x 420 mm"
 msgstr "Arkusz A3, 297 x 420 mm"
 
-#: ../src/common/paper.cpp:146
+#: ../src/common/paper.cpp:143
 msgid "A4 Extra 9.27 x 12.69 in"
 msgstr "A4 Extra 9.27 x 12.69 cali"
 
-#: ../src/common/paper.cpp:153
+#: ../src/common/paper.cpp:150
 msgid "A4 Plus 210 x 330 mm"
 msgstr "A4 Plus 210 x 330 mm"
 
-#: ../src/common/paper.cpp:171
+#: ../src/common/paper.cpp:168
 msgid "A4 Rotated 297 x 210 mm"
 msgstr "A4 Obrócone 297 x 210 mm"
 
-#: ../src/common/paper.cpp:148
+#: ../src/common/paper.cpp:145
 msgid "A4 Transverse 210 x 297 mm"
 msgstr "A4 Poprzecznie 210 x 297 mm"
 
-#: ../src/common/paper.cpp:97
+#: ../src/common/paper.cpp:94
 msgid "A4 sheet, 210 x 297 mm"
 msgstr "Arkusz A4, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:107
+#: ../src/common/paper.cpp:104
 msgid "A4 small sheet, 210 x 297 mm"
 msgstr "Mały arkusz A4, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:157
+#: ../src/common/paper.cpp:154
 msgid "A5 Extra 174 x 235 mm"
 msgstr "A5 Extra 174 x 235 mm"
 
-#: ../src/common/paper.cpp:172
+#: ../src/common/paper.cpp:169
 msgid "A5 Rotated 210 x 148 mm"
 msgstr "A5 Obrócone 210 x 148 mm"
 
-#: ../src/common/paper.cpp:154
+#: ../src/common/paper.cpp:151
 msgid "A5 Transverse 148 x 210 mm"
 msgstr "A5 Poprzecznie 148 x 210 mm"
 
-#: ../src/common/paper.cpp:108
+#: ../src/common/paper.cpp:105
 msgid "A5 sheet, 148 x 210 mm"
 msgstr "Arkusz A5, 148 x 210 mm"
 
-#: ../src/common/paper.cpp:164
+#: ../src/common/paper.cpp:161
 msgid "A6 105 x 148 mm"
 msgstr "A6 105 x 148 mm"
 
-#: ../src/common/paper.cpp:177
+#: ../src/common/paper.cpp:174
 msgid "A6 Rotated 148 x 105 mm"
 msgstr "A6 Obrócone 148 x 105 mm"
 
-#: ../src/generic/fontdlgg.cpp:83 ../src/richtext/richtextformatdlg.cpp:529
-#: ../src/osx/carbon/fontdlg.cpp:153
+#: ../src/osx/carbon/fontdlg.cpp:150 ../src/generic/fontdlgg.cpp:79
+#: ../src/richtext/richtextformatdlg.cpp:521
 msgid "ABCDEFGabcdefg12345"
 msgstr "ABCDEFGabcdefg12345"
 
-#: ../src/richtext/richtextsymboldlg.cpp:458 ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
 msgid "ASCII"
 msgstr "ASCII"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "About"
 msgstr "Inform&acje"
 
-#: ../src/generic/aboutdlgg.cpp:140 ../src/osx/menu_osx.cpp:558
-#: ../src/msw/aboutdlg.cpp:64
+#: ../src/osx/menu_osx.cpp:450 ../src/generic/aboutdlgg.cpp:137
+#: ../src/msw/aboutdlg.cpp:61
 #, c-format
 msgid "About %s"
 msgstr "O %s"
 
-#: ../src/osx/menu_osx.cpp:560
+#: ../src/osx/menu_osx.cpp:452
 #, fuzzy
 msgid "About..."
 msgstr "Inform&acje"
@@ -1203,40 +1200,40 @@ msgid "Absolute"
 msgstr "Absolutne"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:873
+#: ../src/propgrid/advprops.cpp:774
 #, fuzzy
 msgid "ActiveBorder"
 msgstr "Obramowanie"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:874
+#: ../src/propgrid/advprops.cpp:775
 msgid "ActiveCaption"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "Actual Size"
 msgstr "Bieżący rozmiar"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:140 ../src/common/accelcmn.cpp:81
+#: ../src/common/stockitem.cpp:137 ../src/common/accelcmn.cpp:78
 msgid "Add"
 msgstr "Dodaj"
 
-#: ../src/richtext/richtextbuffer.cpp:11455
+#: ../src/richtext/richtextbuffer.cpp:11454
 #, fuzzy
 msgid "Add Column"
 msgstr "Dodaj kolumnę"
 
-#: ../src/richtext/richtextbuffer.cpp:11392
+#: ../src/richtext/richtextbuffer.cpp:11391
 #, fuzzy
 msgid "Add Row"
 msgstr "Dodaj wiersz"
 
-#: ../src/html/helpwnd.cpp:432
+#: ../src/html/helpwnd.cpp:430
 msgid "Add current page to bookmarks"
 msgstr "Dodaj bieżącą stronę do listy zakładek"
 
-#: ../src/generic/colrdlgg.cpp:366
+#: ../src/generic/colrdlgg.cpp:386
 msgid "Add to custom colours"
 msgstr "Dodaj do kolorów niestandardowych"
 
@@ -1249,12 +1246,12 @@ msgid "AddToPropertyCollection called w/o valid adder"
 msgstr ""
 "Funkcja GetPropertyCollection wywołana bez poprawnego modułu pobierającego"
 
-#: ../src/html/helpctrl.cpp:159
+#: ../src/html/helpctrl.cpp:155
 #, c-format
 msgid "Adding book %s"
 msgstr "Dodawanie książki %s"
 
-#: ../src/common/preferencescmn.cpp:43
+#: ../src/common/preferencescmn.cpp:40
 msgid "Advanced"
 msgstr "Zaawansowane"
 
@@ -1262,11 +1259,11 @@ msgstr "Zaawansowane"
 msgid "After a paragraph:"
 msgstr "Za paragrafem:"
 
-#: ../src/common/stockitem.cpp:172
+#: ../src/common/stockitem.cpp:169
 msgid "Align Left"
 msgstr "Wyrównanie do lewej"
 
-#: ../src/common/stockitem.cpp:173
+#: ../src/common/stockitem.cpp:170
 msgid "Align Right"
 msgstr "Wyrównanie do prawej"
 
@@ -1274,41 +1271,41 @@ msgstr "Wyrównanie do prawej"
 msgid "Alignment"
 msgstr "Wyrównanie"
 
-#: ../src/generic/prntdlgg.cpp:215
+#: ../src/generic/prntdlgg.cpp:208
 msgid "All"
 msgstr "Wszystko"
 
-#: ../src/generic/filectrlg.cpp:1197 ../src/common/fldlgcmn.cpp:107
+#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1186
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Wszystkie pliki (%s)|%s"
 
-#: ../include/wx/defs.h:2886
+#: ../include/wx/defs.h:2582
 msgid "All files (*)|*"
 msgstr "Wszystkie pliki (*)|*"
 
-#: ../include/wx/defs.h:2883
+#: ../include/wx/defs.h:2579
 msgid "All files (*.*)|*.*"
 msgstr "Wszystkie pliki (*.*)|*.*"
 
-#: ../src/richtext/richtextstyles.cpp:1061
+#: ../src/richtext/richtextstyles.cpp:1058
 msgid "All styles"
 msgstr "Wszystkie style"
 
-#: ../src/propgrid/manager.cpp:1528
+#: ../src/propgrid/manager.cpp:1544
 msgid "Alphabetic Mode"
 msgstr "Tryb Alfabetyczny"
 
-#: ../src/common/xtistrm.cpp:425
+#: ../src/common/xtistrm.cpp:422
 msgid "Already Registered Object passed to SetObjectClassInfo"
 msgstr ""
 "Zarejestrowany wcześniej obiekt przekazany do funkcji SetObjectClassInfo"
 
-#: ../src/unix/dialup.cpp:353
+#: ../src/unix/dialup.cpp:352
 msgid "Already dialling ISP."
 msgstr "Już łączy z ISP."
 
-#: ../src/common/accelcmn.cpp:331 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/accelcmn.cpp:345 ../src/univ/themes/win32.cpp:3753
 msgid "Alt+"
 msgstr "Alt+"
 
@@ -1317,34 +1314,34 @@ msgstr "Alt+"
 msgid "An optional corner radius for adding rounded corners."
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:576
+#: ../src/common/debugrpt.cpp:577
 msgid "And includes the following files:\n"
 msgstr "I zawiera następujące pliki:\n"
 
-#: ../src/generic/animateg.cpp:162
+#: ../src/generic/animateg.cpp:145
 #, c-format
 msgid "Animation file is not of type %ld."
 msgstr "Plik animacyjny nie jest typu %ld."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:872
+#: ../src/propgrid/advprops.cpp:773
 msgid "AppWorkspace"
 msgstr ""
 
-#: ../src/generic/logg.cpp:1014
+#: ../src/generic/logg.cpp:1011
 #, c-format
 msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
 msgstr "Dołączyć dziennik do pliku '%s' (wybierając [Nie] zastąpisz go)?"
 
-#: ../src/osx/menu_osx.cpp:577 ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:469 ../src/osx/menu_osx.cpp:477
 msgid "Application"
 msgstr "Aplikacja"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "Apply"
 msgstr "Zastosuj"
 
-#: ../src/propgrid/advprops.cpp:1609
+#: ../src/propgrid/advprops.cpp:1515
 msgid "Aqua"
 msgstr ""
 
@@ -1353,32 +1350,32 @@ msgstr ""
 msgid "Arabic"
 msgstr "Arabski"
 
-#: ../src/common/fmapbase.cpp:153
+#: ../src/common/fmapbase.cpp:150
 msgid "Arabic (ISO-8859-6)"
 msgstr "Arabski (ISO-8859-6)"
 
 # catalog file --> ?
 # domain --> ?
-#: ../src/msw/ole/automtn.cpp:672
+#: ../src/msw/ole/automtn.cpp:663
 #, c-format
 msgid "Argument %u not found."
 msgstr "Nie znaleziono argumentu %u."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1753
+#: ../src/propgrid/advprops.cpp:1654
 #, fuzzy
 msgid "Arrow"
 msgstr "jutro"
 
-#: ../src/generic/aboutdlgg.cpp:184
+#: ../src/generic/aboutdlgg.cpp:181
 msgid "Artists"
 msgstr "Artyści"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "Ascending"
 msgstr "Rosnąco"
 
-#: ../src/generic/filectrlg.cpp:433
+#: ../src/generic/filectrlg.cpp:429
 msgid "Attributes"
 msgstr "Właściwości"
 
@@ -1388,90 +1385,90 @@ msgstr "Właściwości"
 msgid "Available fonts."
 msgstr "Dostępne czcionki."
 
-#: ../src/common/paper.cpp:137
+#: ../src/common/paper.cpp:134
 msgid "B4 (ISO) 250 x 353 mm"
 msgstr "B4 (ISO) 250 x 353 mm"
 
-#: ../src/common/paper.cpp:173
+#: ../src/common/paper.cpp:170
 msgid "B4 (JIS) Rotated 364 x 257 mm"
 msgstr "B4 (JIS) Obrócone 364 x 257 mm"
 
-#: ../src/common/paper.cpp:127
+#: ../src/common/paper.cpp:124
 msgid "B4 Envelope, 250 x 353 mm"
 msgstr "Koperta B4, 250 x 353 mm"
 
-#: ../src/common/paper.cpp:109
+#: ../src/common/paper.cpp:106
 msgid "B4 sheet, 250 x 354 mm"
 msgstr "Arkusz B4, 250 x 354 mm"
 
-#: ../src/common/paper.cpp:158
+#: ../src/common/paper.cpp:155
 msgid "B5 (ISO) Extra 201 x 276 mm"
 msgstr "B5 (ISO) Extra 201 x 276 mm"
 
-#: ../src/common/paper.cpp:174
+#: ../src/common/paper.cpp:171
 msgid "B5 (JIS) Rotated 257 x 182 mm"
 msgstr "B5 (JIS) Obrócone 257 x 182 mm"
 
-#: ../src/common/paper.cpp:155
+#: ../src/common/paper.cpp:152
 msgid "B5 (JIS) Transverse 182 x 257 mm"
 msgstr "B5 (JIS) Poprzecznie 182 x 257 mm"
 
-#: ../src/common/paper.cpp:128
+#: ../src/common/paper.cpp:125
 msgid "B5 Envelope, 176 x 250 mm"
 msgstr "Koperta B5, 176 x 250 mm"
 
-#: ../src/common/paper.cpp:110
+#: ../src/common/paper.cpp:107
 msgid "B5 sheet, 182 x 257 millimeter"
 msgstr "Arkusz B5, 182 x 257 mm"
 
-#: ../src/common/paper.cpp:182
+#: ../src/common/paper.cpp:179
 msgid "B6 (JIS) 128 x 182 mm"
 msgstr "B6 (JIS) 128 x 182 mm"
 
-#: ../src/common/paper.cpp:183
+#: ../src/common/paper.cpp:180
 msgid "B6 (JIS) Rotated 182 x 128 mm"
 msgstr "B6 (JIS) Obrócone 182 x 128 mm"
 
-#: ../src/common/paper.cpp:129
+#: ../src/common/paper.cpp:126
 msgid "B6 Envelope, 176 x 125 mm"
 msgstr "Koperta B6, 176 x 125 mm"
 
-#: ../src/common/imagbmp.cpp:531 ../src/common/imagbmp.cpp:561
-#: ../src/common/imagbmp.cpp:576
+#: ../src/common/imagbmp.cpp:528 ../src/common/imagbmp.cpp:558
+#: ../src/common/imagbmp.cpp:573
 msgid "BMP: Couldn't allocate memory."
 msgstr "BMP: Nie można przydzielić pamięci."
 
-#: ../src/common/imagbmp.cpp:100
+#: ../src/common/imagbmp.cpp:97
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: Nie można zapisać nieprawidłowego obrazu.."
 
-#: ../src/common/imagbmp.cpp:356
+#: ../src/common/imagbmp.cpp:353
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: Nie można zapisać mapy kolorów RGB."
 
-#: ../src/common/imagbmp.cpp:490
+#: ../src/common/imagbmp.cpp:487
 msgid "BMP: Couldn't write data."
 msgstr "BMP: Nie można zapisać danych."
 
-#: ../src/common/imagbmp.cpp:246
+#: ../src/common/imagbmp.cpp:243
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: Nie można zapisać nagłówka pliku (Bitmap)."
 
-#: ../src/common/imagbmp.cpp:269
+#: ../src/common/imagbmp.cpp:266
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: Nie można zapisać nagłówka pliku (BitmapInfo)."
 
-#: ../src/common/imagbmp.cpp:140
+#: ../src/common/imagbmp.cpp:137
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage nie ma własnej wxPalette."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:142 ../src/common/accelcmn.cpp:52
+#: ../src/common/stockitem.cpp:139 ../src/common/accelcmn.cpp:49
 msgid "Back"
 msgstr "Wstecz"
 
+#: ../src/richtext/richtextformatdlg.cpp:377
 #: ../src/richtext/richtextbackgroundpage.cpp:148
-#: ../src/richtext/richtextformatdlg.cpp:384
 msgid "Background"
 msgstr "Tło"
 
@@ -1479,21 +1476,21 @@ msgstr "Tło"
 msgid "Background &colour:"
 msgstr "Kolor &tła"
 
-#: ../src/osx/carbon/fontdlg.cpp:220
+#: ../src/osx/carbon/fontdlg.cpp:217
 msgid "Background colour"
 msgstr "Kolor tła"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:52
+#: ../src/common/accelcmn.cpp:49
 #, fuzzy
 msgid "Backspace"
 msgstr "Wstecz"
 
-#: ../src/common/fmapbase.cpp:160
+#: ../src/common/fmapbase.cpp:157
 msgid "Baltic (ISO-8859-13)"
 msgstr "Bałtycki (ISO-8859-13)"
 
-#: ../src/common/fmapbase.cpp:151
+#: ../src/common/fmapbase.cpp:148
 msgid "Baltic (old) (ISO-8859-4)"
 msgstr "Bałtycki (stary) (ISO-8859-4)"
 
@@ -1506,25 +1503,25 @@ msgstr "Przed paragrafem:"
 msgid "Bitmap"
 msgstr "Bitmap"
 
-#: ../src/propgrid/advprops.cpp:1594
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Black"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1755
+#: ../src/propgrid/advprops.cpp:1656
 msgid "Blank"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1603
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Blue"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:345
+#: ../src/generic/colrdlgg.cpp:365
 msgid "Blue:"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:333 ../src/richtext/richtextfontpage.cpp:355
-#: ../src/osx/carbon/fontdlg.cpp:354 ../src/common/stockitem.cpp:143
+#: ../src/osx/carbon/fontdlg.cpp:351 ../src/common/stockitem.cpp:140
+#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:355
 msgid "Bold"
 msgstr "Pogrubiony"
 
@@ -1533,32 +1530,36 @@ msgstr "Pogrubiony"
 msgid "Border"
 msgstr "Obramowanie"
 
-#: ../src/richtext/richtextformatdlg.cpp:379
+#: ../src/richtext/richtextformatdlg.cpp:372
 msgid "Borders"
 msgstr "Ramki"
 
-#: ../src/richtext/richtextsizepage.cpp:288 ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141 ../src/richtext/richtextsizepage.cpp:288
 msgid "Bottom"
 msgstr "Dolny"
 
-#: ../src/generic/prntdlgg.cpp:893
+#: ../src/generic/prntdlgg.cpp:886
 msgid "Bottom margin (mm):"
 msgstr "Dolny margines (mm):"
 
-#: ../src/richtext/richtextbuffer.cpp:9383
+#: ../src/richtext/richtextbuffer.cpp:9380
 msgid "Box Properties"
 msgstr "&Właściwości bloku"
 
-#: ../src/richtext/richtextstyles.cpp:1065
+#: ../src/richtext/richtextstyles.cpp:1062
 msgid "Box styles"
 msgstr "Style bloku"
 
-#: ../src/propgrid/advprops.cpp:1602
+#: ../src/osx/cocoa/menu.mm:292
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1508
 #, fuzzy
 msgid "Brown"
 msgstr "Przeglądaj"
 
-#: ../src/common/filepickercmn.cpp:43 ../src/common/filepickercmn.cpp:44
+#: ../src/common/filepickercmn.cpp:40 ../src/common/filepickercmn.cpp:41
 msgid "Browse"
 msgstr "Przeglądaj"
 
@@ -1571,73 +1572,73 @@ msgstr "&Wyrównanie wypunktowania:"
 msgid "Bullet style"
 msgstr "Styl wypunktowania"
 
-#: ../src/richtext/richtextformatdlg.cpp:359
+#: ../src/richtext/richtextformatdlg.cpp:352
 msgid "Bullets"
 msgstr "Wypunktowania"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1756
+#: ../src/propgrid/advprops.cpp:1657
 #, fuzzy
 msgid "Bullseye"
 msgstr "Styl wypunktowania"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:875
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonFace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:876
+#: ../src/propgrid/advprops.cpp:777
 msgid "ButtonHighlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:877
+#: ../src/propgrid/advprops.cpp:778
 msgid "ButtonShadow"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:878
+#: ../src/propgrid/advprops.cpp:779
 msgid "ButtonText"
 msgstr ""
 
-#: ../src/common/paper.cpp:98
+#: ../src/common/paper.cpp:95
 msgid "C sheet, 17 x 22 in"
 msgstr "Arkusz C, 17 x 22 cali"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "C&lear"
 msgstr "&Wyczyść"
 
-#: ../src/generic/fontdlgg.cpp:406
+#: ../src/generic/fontdlgg.cpp:403
 msgid "C&olour:"
 msgstr "K&olor:"
 
-#: ../src/common/paper.cpp:123
+#: ../src/common/paper.cpp:120
 msgid "C3 Envelope, 324 x 458 mm"
 msgstr "Koperta C3, 324 x 458 mm"
 
-#: ../src/common/paper.cpp:124
+#: ../src/common/paper.cpp:121
 msgid "C4 Envelope, 229 x 324 mm"
 msgstr "Koperta C4, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:122
+#: ../src/common/paper.cpp:119
 msgid "C5 Envelope, 162 x 229 mm"
 msgstr "Koperta C5, 162 x 229 mm"
 
-#: ../src/common/paper.cpp:125
+#: ../src/common/paper.cpp:122
 msgid "C6 Envelope, 114 x 162 mm"
 msgstr "Koperta C6, 114 x 162 mm"
 
-#: ../src/common/paper.cpp:126
+#: ../src/common/paper.cpp:123
 msgid "C65 Envelope, 114 x 229 mm"
 msgstr "Koperta C65, 114 x 229 mm"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "CD-Rom"
 msgstr "CD-Rom"
 
-#: ../src/html/chm.cpp:815 ../src/html/chm.cpp:874
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:865
 msgid "CHM handler currently supports only local files!"
 msgstr "Obsługa CHM obecnie wspiera tylko pliki lokalne!"
 
@@ -1645,196 +1646,201 @@ msgstr "Obsługa CHM obecnie wspiera tylko pliki lokalne!"
 msgid "Ca&pitals"
 msgstr "&Duże litery"
 
-#: ../src/common/cmdproc.cpp:267
+#: ../src/common/cmdproc.cpp:260
 msgid "Can't &Undo "
 msgstr "Nie można &cofnąć "
 
-#: ../src/common/image.cpp:2824
+#: ../src/common/image.cpp:2924
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 "Nie można automatycznie określić formatu obrazu dla nieprzeszukiwalnego "
 "wejścia."
 
-#: ../src/msw/registry.cpp:506
+#: ../src/msw/registry.cpp:495
 #, c-format
 msgid "Can't close registry key '%s'"
 msgstr "Nie można zamknąć klucza rejestru '%s'"
 
-#: ../src/msw/registry.cpp:584
+#: ../src/msw/registry.cpp:573
 #, c-format
 msgid "Can't copy values of unsupported type %d."
 msgstr "Nie można kopiować wartości nieobsługiwanego typu %d."
 
-#: ../src/msw/registry.cpp:487
+#: ../src/msw/registry.cpp:476
 #, c-format
 msgid "Can't create registry key '%s'"
 msgstr "Nie można utworzyć klucza rejestru '%s'"
 
-#: ../src/msw/thread.cpp:665
+#: ../src/msw/thread.cpp:657
 msgid "Can't create thread"
 msgstr "Nie można utworzyć wątku"
 
-#: ../src/msw/window.cpp:3691
-#, c-format
-msgid "Can't create window of class %s"
-msgstr "Nie można utworzyć okna klasy '%s'"
-
-#: ../src/msw/registry.cpp:777
+#: ../src/msw/registry.cpp:765
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Nie można usunąć klucza '%s'"
 
-#: ../src/msw/iniconf.cpp:458
+#: ../src/msw/iniconf.cpp:455
 #, c-format
 msgid "Can't delete the INI file '%s'"
 msgstr "Nie można usunąć pliku INI '%s'"
 
-#: ../src/msw/registry.cpp:805
+#: ../src/msw/registry.cpp:793
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Nie można usunąć wartości '%s' z klucza '%s'"
 
-#: ../src/msw/registry.cpp:1171
+#: ../src/msw/registry.cpp:1159
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Nie można wyliczyć podkluczy klucza '%s'"
 
-#: ../src/msw/registry.cpp:1132
+#: ../src/msw/registry.cpp:1120
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Nie można wyliczyć wartości klucza '%s'"
 
-#: ../src/msw/registry.cpp:1389
+#: ../src/msw/registry.cpp:1377
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Nie można wyeksportować wartości nieobsługiwanego typu %d."
 
-#: ../src/common/ffile.cpp:254
+#: ../src/common/ffile.cpp:253
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Nie można znaleźć bieżącej pozycji w pliku '%s'"
 
-#: ../src/msw/registry.cpp:418
+#: ../src/msw/registry.cpp:407
 #, c-format
 msgid "Can't get info about registry key '%s'"
 msgstr "Nie można uzyskać informacji o kluczu rejestru '%s'"
 
-#: ../src/common/zstream.cpp:346
+# ustalić?
+#: ../src/msw/webview_ie.cpp:1024
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "Nie można zmienić priorytetu wątku"
+
+#: ../src/common/zstream.cpp:343
 msgid "Can't initialize zlib deflate stream."
 msgstr "Nie można zainicjować strumienia kompresji biblioteki zlib."
 
-#: ../src/common/zstream.cpp:185
+#: ../src/common/zstream.cpp:182
 msgid "Can't initialize zlib inflate stream."
 msgstr "Nie można zainicjować strumienia dekompresji biblioteki zlib."
 
-#: ../src/msw/fswatcher.cpp:476
+#: ../src/msw/fswatcher.cpp:475
 #, c-format
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "Nie można monitorować zmian w nieistniejącym folderze \"%s\"."
 
-#: ../src/msw/registry.cpp:454
+#: ../src/msw/registry.cpp:443
 #, c-format
 msgid "Can't open registry key '%s'"
 msgstr "Nie można otworzyć klucza rejestru '%s'"
 
-#: ../src/common/zstream.cpp:252
+#: ../src/common/zstream.cpp:249
 #, c-format
 msgid "Can't read from inflate stream: %s"
 msgstr "Nie można czytać z dekompresowanego strumienia: %s"
 
-#: ../src/common/zstream.cpp:244
+#: ../src/common/zstream.cpp:241
 msgid "Can't read inflate stream: unexpected EOF in underlying stream."
 msgstr ""
 "Nie można odczytać dekompresowanego strumienia: nieoczekiwany koniec w "
 "strumieniu."
 
-#: ../src/msw/registry.cpp:1064
+#: ../src/msw/registry.cpp:1052
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Nie można odczytać wartości '%s'"
 
-#: ../src/msw/registry.cpp:878 ../src/msw/registry.cpp:910
-#: ../src/msw/registry.cpp:975
+#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
+#: ../src/msw/registry.cpp:963
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Nie można odczytać wartości klucza '%s'"
 
-#: ../src/common/image.cpp:2620
+#: ../src/msw/webview_ie.cpp:1017
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/common/image.cpp:2715
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "Nie można zapisać obrazu do pliku '%s': nieznane rozszerzenie."
 
-#: ../src/generic/logg.cpp:573 ../src/generic/logg.cpp:976
+#: ../src/generic/logg.cpp:570 ../src/generic/logg.cpp:973
 msgid "Can't save log contents to file."
 msgstr "Nie można zapisać zawartości dziennika w pliku."
 
 # ustalić?
-#: ../src/msw/thread.cpp:629
+#: ../src/msw/thread.cpp:621
 msgid "Can't set thread priority"
 msgstr "Nie można zmienić priorytetu wątku"
 
-#: ../src/msw/registry.cpp:896 ../src/msw/registry.cpp:938
-#: ../src/msw/registry.cpp:1081
+#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
+#: ../src/msw/registry.cpp:1069
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Nie można nadać wartości '%s'"
 
-#: ../src/unix/utilsunx.cpp:351
+#: ../src/unix/utilsunx.cpp:353
 msgid "Can't write to child process's stdin"
 msgstr ""
 "Błąd zapisu do standardowego strumienia wejściowego (stdin) procesu potomnego"
 
-#: ../src/common/zstream.cpp:427
+#: ../src/common/zstream.cpp:424
 #, c-format
 msgid "Can't write to deflate stream: %s"
 msgstr "Nie można zapisywać do kompresowanego strumienia: %s"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:279 ../src/richtext/richtextstyledlg.cpp:300
-#: ../src/common/stockitem.cpp:145 ../src/common/accelcmn.cpp:71
-#: ../src/msw/msgdlg.cpp:454 ../src/msw/progdlg.cpp:673
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:142
+#: ../src/common/accelcmn.cpp:68 ../src/motif/msgdlg.cpp:196
+#: ../src/gtk1/fontdlg.cpp:144 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/progdlg.cpp:940 ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Zrezygnuj"
 
-#: ../src/common/filefn.cpp:1261
+#: ../src/common/filefn.cpp:1149
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Nie można wyliczyć plików '%s'"
 
-#: ../src/msw/dir.cpp:263
+#: ../src/msw/dir.cpp:260
 #, c-format
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Nie można wyliczyć plików w katalogu '%s'"
 
-#: ../src/msw/dialup.cpp:523
+#: ../src/msw/dialup.cpp:517
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Nie można znaleźć aktywnego połączenia dialup: %s"
 
-#: ../src/msw/dialup.cpp:827
+#: ../src/msw/dialup.cpp:821
 msgid "Cannot find the location of address book file"
 msgstr "Nie można znaleźć lokalizacji pliku książki adresowej"
 
-#: ../src/msw/ole/automtn.cpp:562
+#: ../src/msw/ole/automtn.cpp:553
 #, c-format
 msgid "Cannot get an active instance of \"%s\""
 msgstr "NIe można znaleźć aktywnej instancji \"%s\""
 
-#: ../src/unix/threadpsx.cpp:1035
+#: ../src/unix/threadpsx.cpp:1053
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "Nie można uzyskać zakresu priorytetów strategii harmogramowania %d."
 
-#: ../src/unix/utilsunx.cpp:987
+#: ../src/unix/utilsunx.cpp:989
 msgid "Cannot get the hostname"
 msgstr "Nie można pobrać nazwy serwera"
 
-#: ../src/unix/utilsunx.cpp:1023
+#: ../src/unix/utilsunx.cpp:1025
 msgid "Cannot get the official hostname"
 msgstr "Nie można pobrać oficjalnej nazwy serwera"
 
-#: ../src/msw/dialup.cpp:928
+#: ../src/msw/dialup.cpp:922
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Nie można rozłączyć - brak aktywnego połączenia dialup."
 
@@ -1842,127 +1848,127 @@ msgstr "Nie można rozłączyć - brak aktywnego połączenia dialup."
 msgid "Cannot initialize OLE"
 msgstr "Nie można zainicjować OLE"
 
-#: ../src/common/socket.cpp:853
+#: ../src/common/socket.cpp:850
 msgid "Cannot initialize sockets"
 msgstr "Nie można zainicjować gniazd"
 
-#: ../src/msw/volume.cpp:619
+#: ../src/msw/volume.cpp:627
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Nie można wczytać ikony z '%s'."
 
-#: ../src/xrc/xmlres.cpp:360
+#: ../src/xrc/xmlres.cpp:358
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Nie można wczytać zasobów z pliku '%s'."
 
-#: ../src/xrc/xmlres.cpp:742
+#: ../src/xrc/xmlres.cpp:740
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Nie można wczytać zasobów z pliku '%s'."
 
-#: ../src/html/htmlfilt.cpp:137
+#: ../src/html/htmlfilt.cpp:134
 #, c-format
 msgid "Cannot open HTML document: %s"
 msgstr "Nie można otworzyć dokumentu HTML: %s"
 
-#: ../src/html/helpdata.cpp:667
+#: ../src/html/helpdata.cpp:660
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Nie można otworzyć książki pomocy HTML: %s"
 
-#: ../src/html/helpdata.cpp:299
+#: ../src/html/helpdata.cpp:296
 #, c-format
 msgid "Cannot open contents file: %s"
 msgstr "Nie można otworzyć pliku spisu treści: %s"
 
-#: ../src/generic/dcpsg.cpp:1667
+#: ../src/generic/dcpsg.cpp:1665
 msgid "Cannot open file for PostScript printing!"
 msgstr "Nie można otworzyć pliku dla drukowania postscriptowego!"
 
-#: ../src/html/helpdata.cpp:313
+#: ../src/html/helpdata.cpp:310
 #, c-format
 msgid "Cannot open index file: %s"
 msgstr "Nie można otworzyć pliku indeksowego: %s"
 
-#: ../src/xrc/xmlres.cpp:724
+#: ../src/xrc/xmlres.cpp:722
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Nie można wczytać zasobów z pliku '%s'."
 
-#: ../src/html/helpwnd.cpp:1534
+#: ../src/html/helpwnd.cpp:1532
 msgid "Cannot print empty page."
 msgstr "Nie można wydrukować pustej strony."
 
-#: ../src/msw/volume.cpp:507
+#: ../src/msw/volume.cpp:515
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Nie można odczytać nazwy typu z  '%s'!"
 
-#: ../src/msw/thread.cpp:888
+#: ../src/msw/thread.cpp:894
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Nie można wznowić wątku %lx"
 
-#: ../src/unix/threadpsx.cpp:1016
+#: ../src/unix/threadpsx.cpp:1028
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Nie można uzyskać strategii harmonogramowania wątków."
 
-#: ../src/common/intl.cpp:558
+#: ../src/common/intl.cpp:365
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "Nie można ustawić lokalizacji na język \"%s\"."
 
-#: ../src/unix/threadpsx.cpp:831 ../src/msw/thread.cpp:546
+#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
 msgid "Cannot start thread: error writing TLS."
 msgstr "Nie można wystartować wątku: błąd zapisu TLS."
 
-#: ../src/msw/thread.cpp:872
+#: ../src/msw/thread.cpp:864
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Nie można zawiesić wątku %lx"
 
-#: ../src/msw/thread.cpp:794
+#: ../src/msw/thread.cpp:786
 msgid "Cannot wait for thread termination"
 msgstr "Nie można czekać na zakończenie wątku"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:75
+#: ../src/common/accelcmn.cpp:72
 #, fuzzy
 msgid "Capital"
 msgstr "&Duże litery"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:879
+#: ../src/propgrid/advprops.cpp:780
 msgid "CaptionText"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:531
 msgid "Case sensitive"
 msgstr "Uwzględniaj wielkość liter"
 
-#: ../src/propgrid/manager.cpp:1509
+#: ../src/propgrid/manager.cpp:1527
 msgid "Categorized Mode"
 msgstr "Tryb skategoryzowany"
 
-#: ../src/richtext/richtextbuffer.cpp:9968
+#: ../src/richtext/richtextbuffer.cpp:9965
 msgid "Cell Properties"
 msgstr "&Właściwości komórki"
 
-#: ../src/common/fmapbase.cpp:161
+#: ../src/common/fmapbase.cpp:158
 msgid "Celtic (ISO-8859-14)"
 msgstr "Celtycki (ISO-8859-14)"
 
-#: ../src/richtext/richtextindentspage.cpp:160
 #: ../src/richtext/richtextliststylepage.cpp:349
+#: ../src/richtext/richtextindentspage.cpp:160
 msgid "Cen&tred"
 msgstr "wyś&rodkowany"
 
-#: ../src/common/stockitem.cpp:170
+#: ../src/common/stockitem.cpp:167
 msgid "Centered"
 msgstr "Wyrównanie do środka"
 
-#: ../src/common/fmapbase.cpp:149
+#: ../src/common/fmapbase.cpp:146
 msgid "Central European (ISO-8859-2)"
 msgstr "Środkowoeuropejski (ISO-8859-2)"
 
@@ -1971,10 +1977,10 @@ msgstr "Środkowoeuropejski (ISO-8859-2)"
 msgid "Centre"
 msgstr "Wyrównanie do środka"
 
-#: ../src/richtext/richtextindentspage.cpp:162
-#: ../src/richtext/richtextindentspage.cpp:164
 #: ../src/richtext/richtextliststylepage.cpp:351
 #: ../src/richtext/richtextliststylepage.cpp:353
+#: ../src/richtext/richtextindentspage.cpp:162
+#: ../src/richtext/richtextindentspage.cpp:164
 msgid "Centre text."
 msgstr "Wyśrodkowanie tekstu."
 
@@ -1987,24 +1993,24 @@ msgstr "wyśrodkowany"
 msgid "Ch&oose..."
 msgstr "&Wybierz..."
 
-#: ../src/richtext/richtextbuffer.cpp:4354
+#: ../src/richtext/richtextbuffer.cpp:4351
 msgid "Change List Style"
 msgstr "Zmień styl listy"
 
-#: ../src/richtext/richtextbuffer.cpp:3709
+#: ../src/richtext/richtextbuffer.cpp:3706
 msgid "Change Object Style"
 msgstr "Zmień styl obiektu"
 
-#: ../src/richtext/richtextbuffer.cpp:3982
-#: ../src/richtext/richtextbuffer.cpp:8129
+#: ../src/richtext/richtextbuffer.cpp:3979
+#: ../src/richtext/richtextbuffer.cpp:8125
 msgid "Change Properties"
 msgstr "Zmień właściwości"
 
-#: ../src/richtext/richtextbuffer.cpp:3526
+#: ../src/richtext/richtextbuffer.cpp:3523
 msgid "Change Style"
 msgstr "Zmień styl"
 
-#: ../src/common/fileconf.cpp:341
+#: ../src/common/fileconf.cpp:335
 #, c-format
 msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
 msgstr ""
@@ -2016,12 +2022,12 @@ msgid "Changing current directory to \"%s\" failed"
 msgstr "Nie udało się utworzenie katalogu \"%s\""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1757
+#: ../src/propgrid/advprops.cpp:1658
 #, fuzzy
 msgid "Character"
 msgstr "&Kod znaku:"
 
-#: ../src/richtext/richtextstyles.cpp:1063
+#: ../src/richtext/richtextstyles.cpp:1060
 msgid "Character styles"
 msgstr "Style znaku"
 
@@ -2059,20 +2065,20 @@ msgstr "Zaznacz aby dołączyć wypunktowanie w nawiasach."
 msgid "Check to indicate right-to-left text layout."
 msgstr "Kliknij, aby zmienić kolor tekstu."
 
-#: ../src/osx/carbon/fontdlg.cpp:356 ../src/osx/carbon/fontdlg.cpp:358
+#: ../src/osx/carbon/fontdlg.cpp:353 ../src/osx/carbon/fontdlg.cpp:355
 msgid "Check to make the font bold."
 msgstr "Zaznacz aby pogrubić czcionkę."
 
-#: ../src/osx/carbon/fontdlg.cpp:363 ../src/osx/carbon/fontdlg.cpp:365
+#: ../src/osx/carbon/fontdlg.cpp:360 ../src/osx/carbon/fontdlg.cpp:362
 msgid "Check to make the font italic."
 msgstr "Zaznacz aby uzyskać kursywę czcionki."
 
-#: ../src/osx/carbon/fontdlg.cpp:372 ../src/osx/carbon/fontdlg.cpp:374
+#: ../src/osx/carbon/fontdlg.cpp:369 ../src/osx/carbon/fontdlg.cpp:371
 msgid "Check to make the font underlined."
 msgstr "Zaznacz aby podkreślić czcionkę."
 
-#: ../src/richtext/richtextstyledlg.cpp:289
-#: ../src/richtext/richtextstyledlg.cpp:291
+#: ../src/richtext/richtextstyledlg.cpp:285
+#: ../src/richtext/richtextstyledlg.cpp:287
 msgid "Check to restart numbering."
 msgstr "Zaznacz aby ponownie uruchomić numerację."
 
@@ -2106,51 +2112,51 @@ msgstr "Zaznacz aby wyświetlić tekst w indeksie górnym."
 msgid "Check to suppress hyphenation."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:763
+#: ../src/msw/dialup.cpp:757
 msgid "Choose ISP to dial"
 msgstr "Wybierz ISP do połączenia"
 
-#: ../src/propgrid/props.cpp:1922
+#: ../src/propgrid/props.cpp:1904
 msgid "Choose a directory:"
 msgstr "Wybierz katalog"
 
-#: ../src/propgrid/props.cpp:1975
+#: ../src/propgrid/props.cpp:2199
 msgid "Choose a file"
 msgstr "Wybierz plik"
 
-#: ../src/generic/colrdlgg.cpp:158 ../src/gtk/colordlg.cpp:54
+#: ../src/generic/colrdlgg.cpp:156 ../src/gtk/colordlg.cpp:49
 msgid "Choose colour"
 msgstr "Wybierz kolor"
 
-#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/gtk1/fontdlg.cpp:125 ../src/generic/fontpickerg.cpp:47
+#: ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Wybierz czcionkę"
 
-#: ../src/common/module.cpp:74
+#: ../src/common/module.cpp:71
 #, c-format
 msgid "Circular dependency involving module \"%s\" detected."
 msgstr "Wykryto kołową zależność w związku z modułem \"%s\""
 
-#: ../src/aui/tabmdi.cpp:108 ../src/generic/mdig.cpp:97
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
 msgid "Cl&ose"
 msgstr "Zam&knij"
 
-#: ../src/msw/ole/automtn.cpp:684
+#: ../src/msw/ole/automtn.cpp:675
 msgid "Class not registered."
 msgstr "Klasa niezarejestrowana."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:147 ../src/common/accelcmn.cpp:72
+#: ../src/common/stockitem.cpp:144 ../src/common/accelcmn.cpp:69
 msgid "Clear"
 msgstr "Wyczyść"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "Clear the log contents"
 msgstr "Wyczyść zawartość dziennika"
 
-#: ../src/richtext/richtextstyledlg.cpp:252
-#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:248
+#: ../src/richtext/richtextstyledlg.cpp:250
 msgid "Click to apply the selected style."
 msgstr "Kliknij, aby zastosować wybrany styl."
 
@@ -2161,15 +2167,15 @@ msgstr "Kliknij, aby zastosować wybrany styl."
 msgid "Click to browse for a symbol."
 msgstr "Kliknij, aby wyszukać symbol."
 
-#: ../src/osx/carbon/fontdlg.cpp:403 ../src/osx/carbon/fontdlg.cpp:405
+#: ../src/osx/carbon/fontdlg.cpp:400 ../src/osx/carbon/fontdlg.cpp:402
 msgid "Click to cancel changes to the font."
 msgstr "Kliknij, aby anulować zmiany czcionki."
 
-#: ../src/generic/fontdlgg.cpp:472 ../src/generic/fontdlgg.cpp:491
+#: ../src/generic/fontdlgg.cpp:468 ../src/generic/fontdlgg.cpp:487
 msgid "Click to cancel the font selection."
 msgstr "Anulowanie wyboru czcionki"
 
-#: ../src/osx/carbon/fontdlg.cpp:384 ../src/osx/carbon/fontdlg.cpp:386
+#: ../src/osx/carbon/fontdlg.cpp:381 ../src/osx/carbon/fontdlg.cpp:383
 msgid "Click to change the font colour."
 msgstr "Kliknij, aby zmienić kolor czcionki."
 
@@ -2188,37 +2194,37 @@ msgstr "Kliknij, aby zmienić kolor tekstu."
 msgid "Click to choose the font for this level."
 msgstr "Kliknij, aby wybrać czcionkę dla tego poziomu."
 
-#: ../src/richtext/richtextstyledlg.cpp:279
-#: ../src/richtext/richtextstyledlg.cpp:281
+#: ../src/richtext/richtextstyledlg.cpp:275
+#: ../src/richtext/richtextstyledlg.cpp:277
 msgid "Click to close this window."
 msgstr "Kliknij, aby zamknąć to okno."
 
-#: ../src/osx/carbon/fontdlg.cpp:410 ../src/osx/carbon/fontdlg.cpp:412
+#: ../src/osx/carbon/fontdlg.cpp:407 ../src/osx/carbon/fontdlg.cpp:409
 msgid "Click to confirm changes to the font."
 msgstr "Kliknij, aby potwierdzić zmiany czcionki."
 
-#: ../src/generic/fontdlgg.cpp:477 ../src/generic/fontdlgg.cpp:479
-#: ../src/generic/fontdlgg.cpp:484 ../src/generic/fontdlgg.cpp:486
+#: ../src/generic/fontdlgg.cpp:473 ../src/generic/fontdlgg.cpp:475
+#: ../src/generic/fontdlgg.cpp:480 ../src/generic/fontdlgg.cpp:482
 msgid "Click to confirm the font selection."
 msgstr "Potwierdzenie wyboru czcionki"
 
-#: ../src/richtext/richtextstyledlg.cpp:244
-#: ../src/richtext/richtextstyledlg.cpp:246
+#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:242
 msgid "Click to create a new box style."
 msgstr "Kliknij, aby utworzyć nowy styl bloku."
 
-#: ../src/richtext/richtextstyledlg.cpp:226
-#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:224
 msgid "Click to create a new character style."
 msgstr "Kliknij, aby utworzyć nowy styl znaków."
 
-#: ../src/richtext/richtextstyledlg.cpp:238
-#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:236
 msgid "Click to create a new list style."
 msgstr "Kliknij, aby utworzyć nowy styl listy."
 
-#: ../src/richtext/richtextstyledlg.cpp:232
-#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:230
 msgid "Click to create a new paragraph style."
 msgstr "Kliknij, aby utworzyć nowy styl paragrafu."
 
@@ -2232,8 +2238,8 @@ msgstr "Kliknij, aby utworzyć nową pozycję karty."
 msgid "Click to delete all tab positions."
 msgstr "Kliknij, aby usunąć wszystkie pozycje kart."
 
-#: ../src/richtext/richtextstyledlg.cpp:270
-#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:268
 msgid "Click to delete the selected style."
 msgstr "Kliknij, aby usunąć wybrany styl."
 
@@ -2242,25 +2248,25 @@ msgstr "Kliknij, aby usunąć wybrany styl."
 msgid "Click to delete the selected tab position."
 msgstr "Kliknij, aby usunąć wybraną pozycję karty."
 
-#: ../src/richtext/richtextstyledlg.cpp:264
-#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:262
 msgid "Click to edit the selected style."
 msgstr "Kliknij, aby edytować wybrany styl."
 
-#: ../src/richtext/richtextstyledlg.cpp:258
-#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:256
 msgid "Click to rename the selected style."
 msgstr "Kliknij, aby zmienić nazwę wybranego stylu."
 
-#: ../src/generic/dbgrptg.cpp:97 ../src/generic/progdlgg.cpp:759
-#: ../src/richtext/richtextstyledlg.cpp:277
-#: ../src/richtext/richtextsymboldlg.cpp:476 ../src/common/stockitem.cpp:148
-#: ../src/msw/progdlg.cpp:170 ../src/msw/progdlg.cpp:679
-#: ../src/html/helpdlg.cpp:90
+#: ../src/common/stockitem.cpp:145 ../src/generic/dbgrptg.cpp:94
+#: ../src/generic/progdlgg.cpp:781 ../src/msw/progdlg.cpp:211
+#: ../src/msw/progdlg.cpp:946 ../src/html/helpdlg.cpp:87
+#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextstyledlg.cpp:273
 msgid "Close"
 msgstr "Zamknij"
 
-#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:98
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
 msgid "Close All"
 msgstr "Zamknij wszystko"
 
@@ -2268,43 +2274,43 @@ msgstr "Zamknij wszystko"
 msgid "Close current document"
 msgstr "Zamknij bieżący dokument"
 
-#: ../src/generic/logg.cpp:516
+#: ../src/generic/logg.cpp:513
 msgid "Close this window"
 msgstr "Zamknij to okno"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6006
+#: ../src/generic/datavgen.cpp:6811
 msgid "Collapse"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "Color"
 msgstr "Kolor"
 
-#: ../src/richtext/richtextformatdlg.cpp:776
+#: ../src/richtext/richtextformatdlg.cpp:768
 msgid "Colour"
 msgstr "Kolor"
 
-#: ../src/msw/colordlg.cpp:158
+#: ../src/msw/colordlg.cpp:227
 #, c-format
 msgid "Colour selection dialog failed with error %0lx."
 msgstr "Okno wyboru koloru nie powiodło się z błędem %0lx."
 
-#: ../src/osx/carbon/fontdlg.cpp:380
+#: ../src/osx/carbon/fontdlg.cpp:377
 msgid "Colour:"
 msgstr "Kolor:"
 
-#: ../src/generic/datavgen.cpp:6077
+#: ../src/generic/datavgen.cpp:6882
 #, fuzzy, c-format
 msgid "Column %u"
 msgstr "Dodaj kolumnę"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:114
+#: ../src/common/accelcmn.cpp:112
 msgid "Command"
 msgstr ""
 
-#: ../src/common/init.cpp:196
+#: ../src/common/init.cpp:193
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
@@ -2313,23 +2319,23 @@ msgstr ""
 "Argument wiersza polecenia %d nie może zostać zamieniony na Unicode i "
 "zostanie zignorowany."
 
-#: ../src/msw/fontdlg.cpp:120
+#: ../src/msw/fontdlg.cpp:170
 #, c-format
 msgid "Common dialog failed with error code %0lx."
 msgstr "Dialog zawiódł, kod błędu: %0lx"
 
-#: ../src/gtk/window.cpp:4649
+#: ../src/gtk/window.cpp:5653
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
 msgstr ""
 "Kompozycje nie są wspierane w tym systemie, proszę je włączyć w managerze."
 
-#: ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:1549
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Skompresowane pliki pomocy HTML Help (*.chm)|*.chm|"
 
-#: ../src/generic/dirctrlg.cpp:444
+#: ../src/generic/dirctrlg.cpp:410
 msgid "Computer"
 msgstr "Komputer"
 
@@ -2338,53 +2344,57 @@ msgstr "Komputer"
 msgid "Config entry name cannot start with '%c'."
 msgstr "Nazwa pozycji konfiguracji nie może zaczynać się od '%c'."
 
-#: ../src/generic/filedlgg.cpp:349 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
 msgid "Confirm"
 msgstr "Potwierdź"
 
-#: ../src/html/htmlwin.cpp:566
+#: ../src/html/htmlwin.cpp:569
 msgid "Connecting..."
 msgstr "Łączenie..."
 
-#: ../src/html/helpwnd.cpp:475
+#: ../src/html/helpwnd.cpp:473
 msgid "Contents"
 msgstr "Zawartość"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:880
+#: ../src/propgrid/advprops.cpp:781
 msgid "ControlDark"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:881
+#: ../src/propgrid/advprops.cpp:782
 msgid "ControlLight"
 msgstr ""
 
-#: ../src/common/strconv.cpp:2262
+#: ../src/common/strconv.cpp:2208
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Nie działa konwersja do zestawu znaków '%s'."
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "Convert"
 msgstr "KonwertujZawartość"
 
-#: ../src/html/htmlwin.cpp:1079
+#: ../src/html/htmlwin.cpp:1020
 #, c-format
 msgid "Copied to clipboard:\"%s\""
 msgstr "Skopiowano do schowka:\"%s\""
 
-#: ../src/generic/prntdlgg.cpp:247
+#: ../src/generic/prntdlgg.cpp:240
 msgid "Copies:"
 msgstr "Kopie:"
 
-#: ../src/common/stockitem.cpp:150 ../src/stc/stc_i18n.cpp:18
+#: ../src/common/stockitem.cpp:147 ../src/stc/stc_i18n.cpp:18
 msgid "Copy"
 msgstr "Kopiuj"
 
-#: ../src/common/stockitem.cpp:258
+#: ../src/common/stockitem.cpp:255
 msgid "Copy selection"
 msgstr "Kopiuj wybór"
+
+#: ../src/generic/grid.cpp:5945
+msgid "Copying more than one selected block to clipboard is not supported."
+msgstr ""
 
 #: ../src/richtext/richtextborderspage.cpp:566
 #: ../src/richtext/richtextborderspage.cpp:601
@@ -2395,200 +2405,196 @@ msgstr ""
 msgid "Corner &radius:"
 msgstr ""
 
-#: ../src/html/chm.cpp:718
+#: ../src/html/chm.cpp:711
 #, c-format
 msgid "Could not create temporary file '%s'"
 msgstr "Nie można utworzyć tymczasowego pliku '%s'"
 
-#: ../src/html/chm.cpp:273
+#: ../src/html/chm.cpp:270
 #, c-format
 msgid "Could not extract %s into %s: %s"
 msgstr "Nie można wydzielić %s do %s: %s"
 
-#: ../src/generic/tabg.cpp:1048
+#: ../src/generic/tabg.cpp:1045
 msgid "Could not find tab for id"
 msgstr "Nie można znaleźć (tab) dla (id)"
 
-#: ../src/gtk/notifmsg.cpp:108
-#, fuzzy
-msgid "Could not initalize libnotify."
-msgstr "Nie można ustawić wyrównania."
-
-#: ../src/html/chm.cpp:444
+#: ../src/html/chm.cpp:437
 #, c-format
 msgid "Could not locate file '%s'."
 msgstr "Nie odnaleziono pliku '%s'."
 
-#: ../src/common/filefn.cpp:1403
+#: ../src/msw/graphicsd2d.cpp:604
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/common/filefn.cpp:1291
 msgid "Could not set current working directory"
 msgstr "Nie udało się ustawić katalogu roboczego"
 
-#: ../src/common/prntbase.cpp:2015
+#: ../src/common/prntbase.cpp:2037
 msgid "Could not start document preview."
 msgstr "Nie można wystartować podglądu dokumentu."
 
-#: ../src/generic/printps.cpp:178 ../src/msw/printwin.cpp:210
-#: ../src/gtk/print.cpp:1132
+#: ../src/generic/printps.cpp:159 ../src/msw/printwin.cpp:184
+#: ../src/gtk/print.cpp:1129
 msgid "Could not start printing."
 msgstr "Nie można rozpocząć drukowania."
 
 # przenieść?
-#: ../src/common/wincmn.cpp:2125
+#: ../src/common/wincmn.cpp:2126
 msgid "Could not transfer data to window"
 msgstr "Nie można przenieść danych do okna"
 
-#: ../src/msw/imaglist.cpp:187 ../src/msw/imaglist.cpp:224
-#: ../src/msw/imaglist.cpp:249 ../src/msw/dragimag.cpp:185
-#: ../src/msw/dragimag.cpp:220
+#: ../src/msw/imaglist.cpp:223 ../src/msw/imaglist.cpp:245
+#: ../src/msw/imaglist.cpp:270 ../src/msw/dragimag.cpp:182
+#: ../src/msw/dragimag.cpp:217
 msgid "Couldn't add an image to the image list."
 msgstr "Nie można dodać obrazu do listy obrazów."
 
-#: ../src/osx/glcanvas_osx.cpp:414 ../src/unix/glx11.cpp:558
-#: ../src/msw/glcanvas.cpp:616
+#: ../src/osx/glcanvas_osx.cpp:411 ../src/msw/glcanvas.cpp:631
+#: ../src/unix/glegl.cpp:315 ../src/unix/glx11.cpp:559
 #, fuzzy
 msgid "Couldn't create OpenGL context"
 msgstr "Nie można utworzyć stopera"
 
-#: ../src/msw/timer.cpp:134
+#: ../src/msw/timer.cpp:131
 msgid "Couldn't create a timer"
 msgstr "Nie można utworzyć stopera"
 
-#: ../src/osx/carbon/overlay.cpp:122
-msgid "Couldn't create the overlay window"
-msgstr "Nie można utworzyć okna nakładki"
-
-#: ../src/common/translation.cpp:2024
+#: ../src/common/translation.cpp:2074
 msgid "Couldn't enumerate translations"
 msgstr "Nie można policzyć tłumaczeń"
 
 # dynamicznej? nieładne, a chyba zbędne
-#: ../src/common/dynlib.cpp:120
+#: ../src/common/dynlib.cpp:110
 #, c-format
 msgid "Couldn't find symbol '%s' in a dynamic library"
 msgstr "Nie można znaleźć symbolu '%s' w bibliotece"
 
-#: ../src/msw/thread.cpp:915
+#: ../src/msw/thread.cpp:921
 msgid "Couldn't get the current thread pointer"
 msgstr "Nie można pobrać wskaźnika aktualnego wątku"
 
-#: ../src/osx/carbon/overlay.cpp:129
-msgid "Couldn't init the context on the overlay window"
-msgstr "Nie można zainicjować kontekstu w oknie nakładki"
-
-#: ../src/common/imaggif.cpp:244
+#: ../src/common/imaggif.cpp:241
 msgid "Couldn't initialize GIF hash table."
 msgstr "Błąd podczas inicjalizacji tablicy haszującej GIF."
 
-#: ../src/common/imagpng.cpp:409
+#: ../src/common/imagpng.cpp:437
 msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
 msgstr ""
 "Nie można wczytać obrazu PNG - plik jest uszkodzony lub zabrakło pamięci."
 
-#: ../src/unix/sound.cpp:470
+#: ../src/unix/sound.cpp:459
 #, c-format
 msgid "Couldn't load sound data from '%s'."
 msgstr "Nie można wczytać danych dźwiękowych '%s'."
 
-#: ../src/msw/dirdlg.cpp:435
+#: ../src/msw/dirdlg.cpp:287
 msgid "Couldn't obtain folder name"
 msgstr "Nie można pobrać nazwy folderu"
 
-#: ../src/unix/sound_sdl.cpp:229
+#: ../src/unix/sound_sdl.cpp:226
 #, c-format
 msgid "Couldn't open audio: %s"
 msgstr "Nie można otworzyć dźwięku: %s"
 
-#: ../src/msw/ole/dataobj.cpp:377
+#: ../src/msw/ole/dataobj.cpp:385
 #, c-format
 msgid "Couldn't register clipboard format '%s'."
 msgstr "Nie można zarejestrować formatu schowka '%s'."
 
-#: ../src/msw/listctrl.cpp:869
+#: ../src/msw/listctrl.cpp:933
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "Nie można pobrać informacji o elemencie listy kontroli %d."
 
-#: ../src/common/imagpng.cpp:498 ../src/common/imagpng.cpp:509
-#: ../src/common/imagpng.cpp:519
+#: ../src/common/imagpng.cpp:511 ../src/common/imagpng.cpp:522
+#: ../src/common/imagpng.cpp:532
 msgid "Couldn't save PNG image."
 msgstr "Nie można zapisać obrazu PNG."
 
-#: ../src/msw/thread.cpp:684
+#: ../src/msw/thread.cpp:676
 msgid "Couldn't terminate thread"
 msgstr "Nie można zakończyć wątku"
 
-#: ../src/common/xtistrm.cpp:166
+#: ../src/common/xtistrm.cpp:163
 #, c-format
 msgid "Create Parameter %s not found in declared RTTI Parameters"
 msgstr "NIe odnaleziono parametru %s w zadeklarowanych parametrach RTTI"
 
-#: ../src/generic/dirdlgg.cpp:288
+#: ../src/generic/dirdlgg.cpp:285
 msgid "Create directory"
 msgstr "Tworzenie katalogu"
 
-#: ../src/generic/filedlgg.cpp:212 ../src/generic/dirdlgg.cpp:111
+#: ../src/generic/filedlgg.cpp:209 ../src/generic/dirdlgg.cpp:108
 msgid "Create new directory"
 msgstr "Utwórz nowy katalog"
 
-#: ../src/xrc/xmlres.cpp:2460
+#: ../src/common/stockitem.cpp:264
+#, fuzzy
+msgid "Create new document"
+msgstr "Utwórz nowy katalog"
+
+#: ../src/xrc/xmlres.cpp:2515
 #, fuzzy, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Pobranie '%s' do '%s' nie powiodło się."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1758
+#: ../src/propgrid/advprops.cpp:1659
 msgid "Cross"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:333
+#: ../src/common/accelcmn.cpp:347
 msgid "Ctrl+"
 msgstr "Ctrl+"
 
-#: ../src/richtext/richtextctrl.cpp:332 ../src/osx/textctrl_osx.cpp:576
-#: ../src/common/stockitem.cpp:151 ../src/msw/textctrl.cpp:2507
+#: ../src/osx/textctrl_osx.cpp:594 ../src/common/stockitem.cpp:148
+#: ../src/msw/textctrl.cpp:2772 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "&Wytnij"
 
-#: ../src/generic/filectrlg.cpp:940
+#: ../src/generic/filectrlg.cpp:936
 msgid "Current directory:"
 msgstr "Bieżący katalog:"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:896 ../src/propgrid/advprops.cpp:1574
-#: ../src/propgrid/advprops.cpp:1612
+#: ../src/propgrid/advprops.cpp:797 ../src/propgrid/advprops.cpp:1475
+#: ../src/propgrid/advprops.cpp:1518
 #, fuzzy
 msgid "Custom"
 msgstr "Rozmiar użytkownika"
 
-#: ../src/gtk/print.cpp:217
+#: ../src/gtk/print.cpp:211
 msgid "Custom size"
 msgstr "Rozmiar użytkownika"
 
-#: ../src/common/headerctrlcmn.cpp:60
+#: ../src/common/headerctrlcmn.cpp:58
 msgid "Customize Columns"
 msgstr "Dostosuj kolumny"
 
-#: ../src/common/stockitem.cpp:151 ../src/stc/stc_i18n.cpp:17
+#: ../src/common/stockitem.cpp:148 ../src/stc/stc_i18n.cpp:17
 msgid "Cut"
 msgstr "Wytnij"
 
-#: ../src/common/stockitem.cpp:259
+#: ../src/common/stockitem.cpp:256
 msgid "Cut selection"
 msgstr "Wytnij wybór"
 
-#: ../src/common/fmapbase.cpp:152
+#: ../src/common/fmapbase.cpp:149
 msgid "Cyrillic (ISO-8859-5)"
 msgstr "Cyrylica (ISO-8859-5)"
 
-#: ../src/common/paper.cpp:99
+#: ../src/common/paper.cpp:96
 msgid "D sheet, 22 x 34 in"
 msgstr "Arkusz D, 22 x 34 cali"
 
-#: ../src/msw/dde.cpp:703
+#: ../src/msw/dde.cpp:698
 msgid "DDE poke request failed"
 msgstr "żądanie danych z serwera DDE nie powiodło się"
 
-#: ../src/common/imagbmp.cpp:1169
+#: ../src/common/imagbmp.cpp:1181
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr "Nagłówek DIB: kodowanie nie odpowiada rozdzielczości."
 
@@ -2609,7 +2615,7 @@ msgstr "Nagłówek DIB: Plik z nieznaną rozdzielczością."
 msgid "DIB Header: Unknown encoding in file."
 msgstr "Nagłówek DIB: Plik z nieznanym kodowaniem."
 
-#: ../src/common/paper.cpp:121
+#: ../src/common/paper.cpp:118
 msgid "DL Envelope, 110 x 220 mm"
 msgstr "Koperta DL, 110 x 220 mm"
 
@@ -2617,55 +2623,55 @@ msgstr "Koperta DL, 110 x 220 mm"
 msgid "Dashed"
 msgstr "Linia przerywana"
 
-#: ../src/generic/dbgrptg.cpp:300
+#: ../src/generic/dbgrptg.cpp:301
 #, c-format
 msgid "Debug report \"%s\""
 msgstr "Raport błędów \"%s\""
 
-#: ../src/common/debugrpt.cpp:210
+#: ../src/common/debugrpt.cpp:211
 msgid "Debug report couldn't be created."
 msgstr "Wygenerowanie raport błędów nie powiodło się."
 
-#: ../src/common/debugrpt.cpp:553
+#: ../src/common/debugrpt.cpp:554
 msgid "Debug report generation has failed."
 msgstr "Generowanie raportu błędów nie powiodło się."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:84
+#: ../src/common/accelcmn.cpp:81
 msgid "Decimal"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:323
+#: ../src/generic/fontdlgg.cpp:319
 msgid "Decorative"
 msgstr "Decorative"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1752
+#: ../src/propgrid/advprops.cpp:1653
 #, fuzzy
 msgid "Default"
 msgstr "domyślny"
 
-#: ../src/common/fmapbase.cpp:796
+#: ../src/common/fmapbase.cpp:792
 msgid "Default encoding"
 msgstr "Kodowanie domyślne"
 
-#: ../src/dfb/fontmgr.cpp:180
+#: ../src/dfb/fontmgr.cpp:177
 msgid "Default font"
 msgstr "Domyślna czcionka"
 
-#: ../src/generic/prntdlgg.cpp:510
+#: ../src/generic/prntdlgg.cpp:503
 msgid "Default printer"
 msgstr "Domyślna drukarka"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:51
+#: ../src/common/accelcmn.cpp:48
 #, fuzzy
 msgid "Del"
 msgstr "Usuń"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextbuffer.cpp:8221 ../src/common/stockitem.cpp:152
-#: ../src/common/accelcmn.cpp:50 ../src/stc/stc_i18n.cpp:20
+#: ../src/common/stockitem.cpp:149 ../src/common/accelcmn.cpp:47
+#: ../src/richtext/richtextbuffer.cpp:8217 ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Usuń"
 
@@ -2673,70 +2679,70 @@ msgstr "Usuń"
 msgid "Delete A&ll"
 msgstr "&Usuń wszystko"
 
-#: ../src/richtext/richtextbuffer.cpp:11341
+#: ../src/richtext/richtextbuffer.cpp:11340
 #, fuzzy
 msgid "Delete Column"
 msgstr "Usuń kolumnęUsuń wybór"
 
-#: ../src/richtext/richtextbuffer.cpp:11291
+#: ../src/richtext/richtextbuffer.cpp:11290
 #, fuzzy
 msgid "Delete Row"
 msgstr "Usuń wiersz"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 msgid "Delete Style"
 msgstr "Usuń styl"
 
-#: ../src/richtext/richtextctrl.cpp:1345 ../src/richtext/richtextctrl.cpp:1584
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
 msgid "Delete Text"
 msgstr "Usuń tekst"
 
-#: ../src/generic/editlbox.cpp:170
+#: ../src/generic/editlbox.cpp:147
 msgid "Delete item"
 msgstr "Usuń pozycję"
 
-#: ../src/common/stockitem.cpp:260
+#: ../src/common/stockitem.cpp:257
 msgid "Delete selection"
 msgstr "Usuń wybór"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 #, c-format
 msgid "Delete style %s?"
 msgstr "Usuń styl %s?"
 
-#: ../src/unix/snglinst.cpp:301
+#: ../src/unix/snglinst.cpp:298
 #, c-format
 msgid "Deleted stale lock file '%s'."
 msgstr "Nieaktualny plik blokujący '%s' został usunięty."
 
-#: ../src/common/secretstore.cpp:220
+#: ../src/common/secretstore.cpp:234
 #, fuzzy, c-format
-msgid "Deleting password for \"%s/%s\" failed: %s."
+msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Pobranie '%s' do '%s' nie powiodło się."
 
-#: ../src/common/module.cpp:124
+#: ../src/common/module.cpp:121
 #, c-format
 msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
 msgstr "Zależność \"%s\" z modułu \"%s\" nie istnieje."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "Descending"
 msgstr "MalejącoKodowanie domyślne"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:526 ../src/propgrid/advprops.cpp:882
+#: ../src/generic/dirctrlg.cpp:492 ../src/propgrid/advprops.cpp:783
 msgid "Desktop"
 msgstr "Pulpit"
 
-#: ../src/generic/aboutdlgg.cpp:70
+#: ../src/generic/aboutdlgg.cpp:67
 msgid "Developed by "
 msgstr "Opracowane przez"
 
-#: ../src/generic/aboutdlgg.cpp:176
+#: ../src/generic/aboutdlgg.cpp:173
 msgid "Developers"
 msgstr "Programiści"
 
-#: ../src/msw/dialup.cpp:374
+#: ../src/msw/dialup.cpp:368
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -2744,11 +2750,11 @@ msgstr ""
 "Funkcje Dial up nie są dostępne, ponieważ serwis zdalnego dostępu (RAS) nie "
 "jest zainstalowany na tej maszynie. Zainstaluj go."
 
-#: ../src/generic/tipdlg.cpp:211
+#: ../src/generic/tipdlg.cpp:208
 msgid "Did you know..."
 msgstr "Czy wiesz że..."
 
-#: ../src/dfb/wrapdfb.cpp:63
+#: ../src/dfb/wrapdfb.cpp:60
 #, c-format
 msgid "DirectFB error %d occurred."
 msgstr "Wystąpił błąd DirectFB: %d"
@@ -2757,29 +2763,29 @@ msgstr "Wystąpił błąd DirectFB: %d"
 msgid "Directories"
 msgstr "Katalogi"
 
-#: ../src/common/filefn.cpp:1183
+#: ../src/common/filefn.cpp:1071
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Nie można utworzyć katalogu '%s'"
 
-#: ../src/common/filefn.cpp:1197
+#: ../src/common/filefn.cpp:1085
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "Nie można usunąć katalogu '%s'"
 
-#: ../src/generic/dirdlgg.cpp:204
+#: ../src/generic/dirdlgg.cpp:201
 msgid "Directory does not exist"
 msgstr "Katalog nie istnieje"
 
-#: ../src/generic/filectrlg.cpp:1399
+#: ../src/generic/filectrlg.cpp:1388
 msgid "Directory doesn't exist."
 msgstr "Katalog nie istnieje."
 
-#: ../src/common/docview.cpp:457
+#: ../src/common/docview.cpp:450
 msgid "Discard changes and reload the last saved version?"
 msgstr "Odrzucić zmiany i wczytać ponownie ostatnio zapisaną wersję?"
 
-#: ../src/html/helpwnd.cpp:502
+#: ../src/html/helpwnd.cpp:500
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -2787,45 +2793,45 @@ msgstr ""
 "Wyświetla wszystkie elementy indeksu zawierające podany łańcuch. Szuka bez "
 "uwzględniania wielkości liter."
 
-#: ../src/html/helpwnd.cpp:679
+#: ../src/html/helpwnd.cpp:677
 msgid "Display options dialog"
 msgstr "Wyświetl okno dialogowe opcji"
 
-#: ../src/html/helpwnd.cpp:322
+#: ../src/html/helpwnd.cpp:320
 msgid "Displays help as you browse the books on the left."
 msgstr "Wyświetla pomoc podczas przeglądania książek po lewej."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:85
+#: ../src/common/accelcmn.cpp:83
 msgid "Divide"
 msgstr ""
 
-#: ../src/common/docview.cpp:533
+#: ../src/common/docview.cpp:526
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Chcesz zapisać zmiany w dokumencie %s?"
 
-#: ../src/common/prntbase.cpp:542
+#: ../src/common/prntbase.cpp:537
 msgid "Document:"
 msgstr "Dokument:"
 
-#: ../src/generic/aboutdlgg.cpp:73
+#: ../src/generic/aboutdlgg.cpp:70
 msgid "Documentation by "
 msgstr "Dokumentacja autorstwa"
 
-#: ../src/generic/aboutdlgg.cpp:180
+#: ../src/generic/aboutdlgg.cpp:177
 msgid "Documentation writers"
 msgstr "Autorzy dokumentacji"
 
-#: ../src/common/sizer.cpp:2799
+#: ../src/common/sizer.cpp:2916
 msgid "Don't Save"
 msgstr "Nie Zapisuj"
 
-#: ../src/html/htmlwin.cpp:633
+#: ../src/html/htmlwin.cpp:643
 msgid "Done"
 msgstr "Zrobione"
 
-#: ../src/generic/progdlgg.cpp:448 ../src/msw/progdlg.cpp:407
+#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
 msgid "Done."
 msgstr "Zrobione."
 
@@ -2837,42 +2843,42 @@ msgstr "Kropkowany"
 msgid "Double"
 msgstr "Podwójnie"
 
-#: ../src/common/paper.cpp:176
+#: ../src/common/paper.cpp:173
 msgid "Double Japanese Postcard Rotated 148 x 200 mm"
 msgstr "Podwójna Japońska Pocztówka Obrócona 148 x 200 mm"
 
-#: ../src/common/xtixml.cpp:273
+#: ../src/common/xtixml.cpp:269
 #, c-format
 msgid "Doubly used id : %d"
 msgstr "Dwukrotnie użyty identyfikator : %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:153
-#: ../src/common/accelcmn.cpp:64
+#: ../src/common/stockitem.cpp:150 ../src/common/accelcmn.cpp:61
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Down"
 msgstr "W dół"
 
-#: ../src/richtext/richtextctrl.cpp:865
+#: ../src/richtext/richtextctrl.cpp:864
 msgid "Drag"
 msgstr "Przeciągnij"
 
-#: ../src/common/paper.cpp:100
+#: ../src/common/paper.cpp:97
 msgid "E sheet, 34 x 44 in"
 msgstr "Arkusz E, 34 x 44 cale"
 
-#: ../src/unix/fswatcher_inotify.cpp:561
+#: ../src/unix/fswatcher_inotify.cpp:558
 msgid "EOF while reading from inotify descriptor"
 msgstr "EOF podczas odczytu z deskryptora inotify"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "Edit"
 msgstr "Edytuj"
 
-#: ../src/generic/editlbox.cpp:168
+#: ../src/generic/editlbox.cpp:131
 msgid "Edit item"
 msgstr "Edytuj pozycję"
 
-#: ../include/wx/generic/progdlgg.h:84
+#: ../include/wx/generic/progdlgg.h:85
 msgid "Elapsed time:"
 msgstr "Upłynęło już:"
 
@@ -2944,50 +2950,50 @@ msgid "Enables the shadow spread."
 msgstr "Włącz wartość szerokości."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:66
+#: ../src/common/accelcmn.cpp:63
 msgid "End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:55
+#: ../src/common/accelcmn.cpp:52
 #, fuzzy
 msgid "Enter"
 msgstr "Drukarka"
 
-#: ../src/richtext/richtextstyledlg.cpp:934
+#: ../src/richtext/richtextstyledlg.cpp:930
 msgid "Enter a box style name"
 msgstr "Podaj nową nazwę stylu bloku"
 
-#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:602
 msgid "Enter a character style name"
 msgstr "Wprowadź nazwę stylu znaku"
 
-#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:816
 msgid "Enter a list style name"
 msgstr "Wprowadź nazwę listy stylu"
 
-#: ../src/richtext/richtextstyledlg.cpp:893
+#: ../src/richtext/richtextstyledlg.cpp:889
 msgid "Enter a new style name"
 msgstr "Podaj nową nazwę stylu"
 
-#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:650
 msgid "Enter a paragraph style name"
 msgstr "Wprowadź nazwę stylu paragrafu"
 
-#: ../src/generic/dbgrptg.cpp:174
+#: ../src/generic/dbgrptg.cpp:171
 #, c-format
 msgid "Enter command to open file \"%s\":"
 msgstr "Wprowadź komendę otwierającą plik \"%s\":"
 
-#: ../src/generic/helpext.cpp:459
+#: ../src/generic/helpext.cpp:457
 msgid "Entries found"
 msgstr "Znalezione pozycje"
 
-#: ../src/common/paper.cpp:142
+#: ../src/common/paper.cpp:139
 msgid "Envelope Invite 220 x 220 mm"
 msgstr "Koperta Invite 220 x 220 mm"
 
-#: ../src/common/config.cpp:469
+#: ../src/common/config.cpp:465
 #, c-format
 msgid ""
 "Environment variables expansion failed: missing '%c' at position %u in '%s'."
@@ -2995,13 +3001,13 @@ msgstr ""
 "Rozwinięcie zmiennych środowiskowych nie powiodło się: zabrakło '%c' na "
 "pozycji '%u' w '%s'."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/generic/dirctrlg.cpp:570
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/dirctrlg.cpp:599
-#: ../src/generic/dirdlgg.cpp:323 ../src/generic/filectrlg.cpp:642
-#: ../src/generic/filectrlg.cpp:756 ../src/generic/filectrlg.cpp:770
-#: ../src/generic/filectrlg.cpp:786 ../src/generic/filectrlg.cpp:1368
-#: ../src/generic/filectrlg.cpp:1399 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/gtk1/fontdlg.cpp:74 ../src/generic/dirctrlg.cpp:536
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/dirctrlg.cpp:565
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1357 ../src/generic/filectrlg.cpp:1388
+#: ../src/generic/filedlgg.cpp:354 ../src/generic/dirdlgg.cpp:320
+#: ../src/gtk/filedlg.cpp:74
 msgid "Error"
 msgstr "Błąd"
 
@@ -3009,87 +3015,98 @@ msgstr "Błąd"
 msgid "Error closing epoll descriptor"
 msgstr "Błąd zamknięcia deskryptora epoll"
 
-#: ../src/unix/fswatcher_kqueue.cpp:114
+#: ../src/unix/fswatcher_kqueue.cpp:131
 msgid "Error closing kqueue instance"
 msgstr "Błąd podczas zamykania instancji kqueue"
 
-#: ../src/common/filefn.cpp:1049
+#: ../src/common/filefn.cpp:938
 #, fuzzy, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Nie udało się skopiować pliku '%s' do '%s'."
 
-#: ../src/generic/dirdlgg.cpp:222
+#: ../src/generic/dirdlgg.cpp:219
 msgid "Error creating directory"
 msgstr "Błąd przy tworzeniu katalogu"
 
-#: ../src/common/imagbmp.cpp:1181
+#: ../src/common/imagbmp.cpp:1193
 msgid "Error in reading image DIB."
 msgstr "Błąd odczytu obrazu DIB."
 
-#: ../src/propgrid/propgrid.cpp:6696
+#: ../src/propgrid/propgrid.cpp:6665
 #, c-format
 msgid "Error in resource: %s"
 msgstr "Błąd w zasobie: %s"
 
-#: ../src/common/fileconf.cpp:422
+#: ../src/common/fileconf.cpp:421
 msgid "Error reading config options."
 msgstr "Błąd odczytu opcji konfiguracji."
+
+#: ../src/msw/webview_ie.cpp:1057 ../src/msw/webview_edge.cpp:850
+#: ../src/gtk/webview_webkit2.cpp:1262 ../src/osx/webview_webkit.mm:383
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
 
 #: ../src/common/fileconf.cpp:1029
 msgid "Error saving user configuration data."
 msgstr "Błąd zapisu konfiguracji użytkownika."
 
-#: ../src/gtk/print.cpp:722
+#: ../src/gtk/print.cpp:720
 msgid "Error while printing: "
 msgstr "Błąd podczas drukowania:"
 
-#: ../src/common/log.cpp:219
+#: ../src/common/log.cpp:237
 msgid "Error: "
 msgstr "Błąd: "
 
+#: ../src/common/webrequest.cpp:98
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Błąd: "
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:69
+#: ../src/common/accelcmn.cpp:66
 msgid "Esc"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:70
+#: ../src/common/accelcmn.cpp:67
 #, fuzzy
 msgid "Escape"
 msgstr "Pejzaż"
 
-#: ../src/common/fmapbase.cpp:150
+#: ../src/common/fmapbase.cpp:147
 msgid "Esperanto (ISO-8859-3)"
 msgstr "Esperanto (ISO-8859-3)"
 
-#: ../include/wx/generic/progdlgg.h:85
+#: ../include/wx/generic/progdlgg.h:86
 msgid "Estimated time:"
 msgstr "Szacowany czas:"
 
-#: ../src/generic/dbgrptg.cpp:234
+#: ../src/generic/dbgrptg.cpp:231
 msgid "Executable files (*.exe)|*.exe|"
 msgstr "Pliki wykonywalne (*.exe)|*.exe|"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:155 ../src/common/accelcmn.cpp:78
+#: ../src/common/stockitem.cpp:152 ../src/common/accelcmn.cpp:75
 msgid "Execute"
 msgstr "Uruchom"
 
-#: ../src/msw/utilsexc.cpp:876
+#: ../src/msw/utilsexc.cpp:873
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Wykonanie polecenia '%s' nie powiodło się"
 
-#: ../src/common/paper.cpp:105
+#: ../src/common/paper.cpp:102
 msgid "Executive, 7 1/4 x 10 1/2 in"
 msgstr "Executive, 7 1/4 x 10 1/2 cali"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6009
+#: ../src/generic/datavgen.cpp:6814
 msgid "Expand"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1240
+#: ../src/msw/registry.cpp:1228
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
@@ -3097,152 +3114,161 @@ msgstr ""
 "Eksport klucza rejestrów: plik \"%s\" już istnieje i nie może zostać "
 "nadpisany."
 
-#: ../src/common/fmapbase.cpp:195
+#: ../src/common/fmapbase.cpp:192
 msgid "Extended Unix Codepage for Japanese (EUC-JP)"
 msgstr "Japońska rozszerzona strona kodowa UNIX (EUC-JP)"
 
-#: ../src/html/chm.cpp:725
+#: ../src/html/chm.cpp:718
 #, c-format
 msgid "Extraction of '%s' into '%s' failed."
 msgstr "Pobranie '%s' do '%s' nie powiodło się."
 
-#: ../src/common/accelcmn.cpp:249 ../src/common/accelcmn.cpp:344
+#: ../src/common/accelcmn.cpp:259 ../src/common/accelcmn.cpp:358
 msgid "F"
 msgstr "F"
 
 # To jest maska do tworzenia nazw typu NowaNaz1 itd
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:672
+#: ../src/propgrid/advprops.cpp:582
 msgid "Face Name"
 msgstr "Nazwa"
 
-#: ../src/unix/snglinst.cpp:269
+#: ../src/unix/snglinst.cpp:266
 msgid "Failed to access lock file."
 msgstr "Nie udało się dostać do pliku blokującego."
+
+#: ../src/gtk/font.cpp:572
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Nie udało się wczytanie dokumentu z pliku \"%s\"."
 
 #: ../src/unix/epolldispatcher.cpp:116
 #, c-format
 msgid "Failed to add descriptor %d to epoll descriptor %d"
 msgstr "Nie udało się dodać deskryptora %d do deskryptora epoll %d"
 
-#: ../src/msw/dib.cpp:489
+#: ../src/msw/dib.cpp:535
 #, c-format
 msgid "Failed to allocate %luKb of memory for bitmap data."
 msgstr "Nie udała się rezerwacja %luKb pamięci na dane obrazu."
 
-#: ../src/common/glcmn.cpp:115
+#: ../src/common/glcmn.cpp:112
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Nie udało się przydzielić koloru dla OpenGL"
 
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Nie udało się przydzielić koloru dla OpenGL"
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Nie udało się przydzielić koloru dla OpenGL"
+
 # uchwyt chyba zbędny
-#: ../src/unix/displayx11.cpp:236
+#: ../include/wx/unix/private/displayx11.h:89
 msgid "Failed to change video mode"
 msgstr "Nie udało się zmienić trybu video"
 
-#: ../src/common/image.cpp:3277
+#: ../src/common/image.cpp:3396
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Nie sprawdzić format obrazu z pliku \"%s\"."
 
-#: ../src/common/debugrpt.cpp:239
+#: ../src/common/debugrpt.cpp:240
 #, c-format
 msgid "Failed to clean up debug report directory \"%s\""
 msgstr "Nie udało się czyszczenie katalogu raportu błędów \"%s\""
 
 # uchwyt chyba zbędny
-#: ../src/common/filename.cpp:192
+#: ../src/common/filename.cpp:189
 msgid "Failed to close file handle"
 msgstr "Nie udało się zamknąć pliku."
 
-#: ../src/unix/snglinst.cpp:340
+#: ../src/unix/snglinst.cpp:337
 #, c-format
 msgid "Failed to close lock file '%s'"
 msgstr "Nie udało się zamknąć pliku blokującego '%s'"
 
-#: ../src/msw/clipbrd.cpp:112
+#: ../src/msw/clipbrd.cpp:110
 msgid "Failed to close the clipboard."
 msgstr "Nie udało się zamknąć schowka."
 
-#: ../src/x11/utils.cpp:208
+#: ../src/x11/utils.cpp:170
 #, c-format
 msgid "Failed to close the display \"%s\""
 msgstr "Nie udało się zamknąć ekranu \"%s\""
 
-#: ../src/msw/dialup.cpp:797
+#: ../src/msw/dialup.cpp:791
 msgid "Failed to connect: missing username/password."
 msgstr "Nie udało się połączyć: brakuje użytkownika/hasła."
 
-#: ../src/msw/dialup.cpp:743
+#: ../src/msw/dialup.cpp:737
 msgid "Failed to connect: no ISP to dial."
 msgstr "Nie udało się połączyć: brak ISP."
 
-# uchwyt chyba zbędny
-#: ../src/common/textfile.cpp:203
-#, c-format
-msgid "Failed to convert file \"%s\" to Unicode."
-msgstr "Nie udało się zamienić pliku \"%s\" na Unicode."
-
-#: ../src/generic/logg.cpp:956
+#: ../src/generic/logg.cpp:953
 msgid "Failed to copy dialog contents to the clipboard."
 msgstr "Nie udało się skopiować treści dialogu do schowka."
 
-#: ../src/msw/registry.cpp:692
+#: ../src/msw/registry.cpp:681
 #, c-format
 msgid "Failed to copy registry value '%s'"
 msgstr "Nie udało się skopiować wartości rejestru '%s'"
 
-#: ../src/msw/registry.cpp:701
+#: ../src/msw/registry.cpp:690
 #, c-format
 msgid "Failed to copy the contents of registry key '%s' to '%s'."
 msgstr "Nie udało się skopiować zawartości klucza rejestru '%s' do '%s'."
 
-#: ../src/common/filefn.cpp:1015
+#: ../src/common/filefn.cpp:904
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Nie udało się skopiować pliku '%s' do '%s'."
 
-#: ../src/msw/registry.cpp:679
+#: ../src/msw/registry.cpp:668
 #, c-format
 msgid "Failed to copy the registry subkey '%s' to '%s'."
 msgstr "Nie udało się kopiowanie klucza rejestru '%s' na '%s'."
 
-#: ../src/msw/dde.cpp:1070
+#: ../src/msw/dde.cpp:1134
 msgid "Failed to create DDE string"
 msgstr "Nie udało się utworzyć łańcucha DDE"
 
-#: ../src/msw/mdi.cpp:616
+#: ../src/msw/mdi.cpp:621
 msgid "Failed to create MDI parent frame."
 msgstr "Nie udało się utworzyć ramki rodzica MDI."
 
-#: ../src/common/filename.cpp:1027
+#: ../src/common/filename.cpp:1024
 msgid "Failed to create a temporary file name"
 msgstr "Nie udało się wygenerować nazwy dla pliku tymczasowego"
 
 # dlaczego anonimowego?
-#: ../src/msw/utilsexc.cpp:228
+#: ../src/msw/utilsexc.cpp:225
 msgid "Failed to create an anonymous pipe"
 msgstr "Nie udało się utworzyć potoku"
 
-#: ../src/msw/ole/automtn.cpp:522
+#: ../src/msw/ole/automtn.cpp:513
 #, c-format
 msgid "Failed to create an instance of \"%s\""
 msgstr "Nie udało się utworzenie instancji \"%s\""
 
-#: ../src/msw/dde.cpp:437
+#: ../src/msw/dde.cpp:432
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "Nie udało się utworzyć połączenia do serwera '%s' na temat '%s'"
 
-#: ../src/msw/cursor.cpp:204
+#: ../src/msw/cursor.cpp:195
 msgid "Failed to create cursor."
 msgstr "Nie udało się utworzyć kursora."
 
-#: ../src/common/debugrpt.cpp:209
+#: ../src/common/debugrpt.cpp:210
 #, c-format
 msgid "Failed to create directory \"%s\""
 msgstr "Nie udało się utworzenie katalogu \"%s\""
 
-#: ../src/generic/dirdlgg.cpp:220
+#: ../src/generic/dirdlgg.cpp:217
 #, c-format
 msgid ""
 "Failed to create directory '%s'\n"
@@ -3255,123 +3281,142 @@ msgstr ""
 msgid "Failed to create epoll descriptor"
 msgstr "Nie udało się utworzyć deskryptora epoll"
 
-#: ../src/msw/mimetype.cpp:238
+#: ../src/gtk/font.cpp:562
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "Nie udała się aktualizacja pliku konfiguracyjnego użytkownika."
+
+#: ../src/msw/mimetype.cpp:235
 #, c-format
 msgid "Failed to create registry entry for '%s' files."
 msgstr "Nie udało się utworzyć pozycji rejestru dla plików '%s'."
 
-#: ../src/msw/fdrepdlg.cpp:409
+#: ../src/msw/fdrepdlg.cpp:408
 #, c-format
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr ""
 "Nie udało się utworzyć standardowego okna dialogowego wyszukaj/zastąp (kod "
 "błędu %d)"
 
-#: ../src/unix/wakeuppipe.cpp:52
+#: ../src/unix/wakeuppipe.cpp:49
 msgid "Failed to create wake up pipe used by event loop."
 msgstr "Nie udało się utworzyć potoku budzącego używanego przez pętlę zdarzeń"
 
-#: ../src/html/winpars.cpp:730
+#: ../src/html/winpars.cpp:727
 #, c-format
 msgid "Failed to display HTML document in %s encoding"
 msgstr "Nie udało się wyświelić dokumentu HTML w kodowaniu %s"
 
-#: ../src/msw/clipbrd.cpp:124
+#: ../src/msw/clipbrd.cpp:122
 msgid "Failed to empty the clipboard."
 msgstr "Nie udało się opróżnić schowka."
 
-#: ../src/unix/displayx11.cpp:212
+#: ../include/wx/unix/private/displayx11.h:65
 msgid "Failed to enumerate video modes"
 msgstr "Nie udało się pobranie listy trybów video"
 
 # to moja swobodna interpretacja
-#: ../src/msw/dde.cpp:722
+#: ../src/msw/dde.cpp:717
 msgid "Failed to establish an advise loop with DDE server"
 msgstr ""
 "Nie udało się rozpocząć transakcji doradzającej (advise) z serwerem DDE"
 
-#: ../src/msw/dialup.cpp:629 ../src/msw/dialup.cpp:863
+#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Nie udało się nawiązać połączenia dialup: %s"
 
-#: ../src/unix/utilsunx.cpp:611
+#: ../src/unix/utilsunx.cpp:613
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Nie udało się wykonać '%s'\n"
 
-#: ../src/common/debugrpt.cpp:720
+#: ../src/common/debugrpt.cpp:730
 msgid "Failed to execute curl, please install it in PATH."
 msgstr ""
 "Nie udało się uruchomienie curl, proszę zainstalować go w dostępnym katalogu "
 "(PATH)."
 
-#: ../src/msw/ole/automtn.cpp:505
+#: ../src/msw/ole/automtn.cpp:496
 #, c-format
 msgid "Failed to find CLSID of \"%s\""
 msgstr "Nie znaleziono CLSID dla \"%s\""
 
-#: ../src/common/regex.cpp:431 ../src/common/regex.cpp:479
+#: ../src/common/regex.cpp:428 ../src/common/regex.cpp:476
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "Nie udało się znaleźć połączenia dla regularnego wyrażenia: %s"
 
-#: ../src/msw/dialup.cpp:695
+#: ../src/msw/webview_ie.cpp:978
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:689
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Nie udało się usyskać listy ISP: %s"
 
-#: ../src/msw/ole/automtn.cpp:574
+#: ../src/msw/ole/automtn.cpp:565
 #, c-format
 msgid "Failed to get OLE automation interface for \"%s\""
 msgstr "Nie udało się uzyskać interface'u OLE dla \"%s\""
 
-#: ../src/msw/clipbrd.cpp:711
+#: ../src/msw/clipbrd.cpp:731
 msgid "Failed to get data from the clipboard"
 msgstr "Nie udało się pobrać danych ze schowka"
 
-#: ../src/common/time.cpp:223
+#: ../src/common/time.cpp:216
 msgid "Failed to get the local system time"
 msgstr "Nie udało się pobrać lokalnego czasu systemowego"
 
-#: ../src/common/filefn.cpp:1345
+#: ../src/common/filefn.cpp:1233
 msgid "Failed to get the working directory"
 msgstr "Nie udało się uzyskać katalogu roboczego"
 
-#: ../src/univ/theme.cpp:114
+#: ../src/univ/theme.cpp:111
 msgid "Failed to initialize GUI: no built-in themes found."
 msgstr "Nie udało się zainicjować GUI: brak wbudowanych kompozycji."
 
-#: ../src/msw/helpchm.cpp:63
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:60
 msgid "Failed to initialize MS HTML Help."
 msgstr "Nie udało się zainicjować pomocy MS HTML."
 
-#: ../src/msw/glcanvas.cpp:1381
+#: ../src/msw/glcanvas.cpp:1391
 msgid "Failed to initialize OpenGL"
 msgstr "Nie udało się zainicjować OpenGL"
 
-#: ../src/msw/dialup.cpp:858
+#: ../src/msw/dialup.cpp:852
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Nie udało się rozpocząć połączenia dialup: %s"
 
-#: ../src/gtk/textctrl.cpp:1128
+#: ../src/gtk/textctrl.cpp:1209
 msgid "Failed to insert text in the control."
 msgstr "Nie udało się  wstawić tekstu w kontroli."
 
-#: ../src/unix/snglinst.cpp:241
+#: ../src/unix/snglinst.cpp:238
 #, c-format
 msgid "Failed to inspect the lock file '%s'"
 msgstr "Nie udało się sprawdzenie blokady pliku '%s'"
 
 # uchwyt chyba zbędny
-#: ../src/unix/appunix.cpp:182
+#: ../src/unix/appunix.cpp:179
 msgid "Failed to install signal handler"
 msgstr "Nie udało się zainstalować obsługi sygnału"
 
 # połączyć?
 # wyciek?
-#: ../src/unix/threadpsx.cpp:1167
+#: ../src/unix/threadpsx.cpp:1216
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -3379,71 +3424,71 @@ msgstr ""
 "Nie udało połączyć się z wątkiem, potencjalny wyciek pamięci - uruchom "
 "program ponownie"
 
-#: ../src/msw/utils.cpp:629
+#: ../src/msw/utils.cpp:619
 #, c-format
 msgid "Failed to kill process %d"
 msgstr "Nie udało się zabić procesu %d"
 
-#: ../src/common/image.cpp:2500
+#: ../src/common/image.cpp:2595
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Nie udało się wczytanie obrazu \"%s\" z zasobów."
 
-#: ../src/common/image.cpp:2509
+#: ../src/common/image.cpp:2604
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Nie udało się wczytanie ikony \"%s\" z zasobów."
 
-#: ../src/common/iconbndl.cpp:225
+#: ../src/common/iconbndl.cpp:224
 #, fuzzy, c-format
 msgid "Failed to load icons from resource '%s'."
 msgstr "Nie udało się wczytanie ikony \"%s\" z zasobów."
 
-#: ../src/common/iconbndl.cpp:200
+#: ../src/common/iconbndl.cpp:198
 #, c-format
 msgid "Failed to load image %%d from file '%s'."
 msgstr "Nie udało się wczytanie obrazu %%d z pliku '%s'."
 
-#: ../src/common/iconbndl.cpp:208
+#: ../src/common/iconbndl.cpp:206
 #, c-format
 msgid "Failed to load image %d from stream."
 msgstr "Nie udało się wczytanie obrazu %d ze strumienia."
 
-#: ../src/common/image.cpp:2587 ../src/common/image.cpp:2606
+#: ../src/common/image.cpp:2682 ../src/common/image.cpp:2701
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Nie udało się wczytanie obrazu z pliku \"%s\"."
 
-#: ../src/msw/enhmeta.cpp:97
+#: ../src/msw/enhmeta.cpp:94
 #, c-format
 msgid "Failed to load metafile from file \"%s\"."
 msgstr "Nie udało się załadowanie pliku meta \"%s\"."
 
-#: ../src/msw/volume.cpp:327
+#: ../src/msw/volume.cpp:335
 msgid "Failed to load mpr.dll."
 msgstr "Nie udało się wczytać mpr.dll."
 
-#: ../src/msw/utils.cpp:953
+#: ../src/msw/utils.cpp:943
 #, c-format
 msgid "Failed to load resource \"%s\"."
 msgstr "Nie udało się wczytanie zasobu \"%s\"."
 
-#: ../src/common/dynlib.cpp:92
+#: ../src/common/dynlib.cpp:86
 #, c-format
 msgid "Failed to load shared library '%s'"
 msgstr "Nie udało się wczytać biblioteki '%s'."
 
-#: ../src/osx/core/sound.cpp:145
+#: ../src/osx/core/sound.cpp:143
 #, fuzzy, c-format
 msgid "Failed to load sound from \"%s\" (error %d)."
 msgstr "Nie udało się wczytanie zasobu \"%s\"."
 
-#: ../src/msw/utils.cpp:960
+#: ../src/msw/utils.cpp:950
 #, c-format
 msgid "Failed to lock resource \"%s\"."
 msgstr "Nie udało się zablokowanie zasobu \"%s\"."
 
-#: ../src/unix/snglinst.cpp:198
+#: ../src/unix/snglinst.cpp:195
 #, c-format
 msgid "Failed to lock the lock file '%s'"
 msgstr "Nie udało się zablokować pliku blokującego '%s'"
@@ -3454,33 +3499,38 @@ msgid "Failed to modify descriptor %d in epoll descriptor %d"
 msgstr "Nie można zmienić hasła %d w deskryptorze epoll %d"
 
 # nieładne
-#: ../src/common/filename.cpp:2575
+#: ../src/common/filename.cpp:2658
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Nie udało się zmodyfikować czasów pliku '%s'"
 
-#: ../src/common/selectdispatcher.cpp:258
+#: ../src/common/selectdispatcher.cpp:255
 msgid "Failed to monitor I/O channels"
 msgstr "Nie udało się monitorować kanałów wejściowych/wyjściowych"
 
-#: ../src/common/filename.cpp:175
+#: ../src/common/filename.cpp:172
 #, c-format
 msgid "Failed to open '%s' for reading"
 msgstr "Nie udało się otworzyć '%s' do odczytu"
 
-#: ../src/common/filename.cpp:180
+#: ../src/common/filename.cpp:177
 #, c-format
 msgid "Failed to open '%s' for writing"
 msgstr "Nie udało się otworzyć '%s' do zapisu"
 
-#: ../src/html/chm.cpp:141
+#: ../src/html/chm.cpp:138
 #, c-format
 msgid "Failed to open CHM archive '%s'."
 msgstr "Nie udało się otworzyć archiwum CHM '%s'."
 
-#: ../src/common/utilscmn.cpp:1126
+#: ../src/common/utilscmn.cpp:1140
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Nie udało się otworzyć URL \"%s\" w domyślnej przeglądarce."
+
+#: ../src/common/hyperlnkcmn.cpp:133
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Nie udało się otworzyć URL \"%s\" w domyślnej przeglądarce."
 
 #: ../include/wx/msw/private/fswatcher.h:92
@@ -3488,94 +3538,104 @@ msgstr "Nie udało się otworzyć URL \"%s\" w domyślnej przeglądarce."
 msgid "Failed to open directory \"%s\" for monitoring."
 msgstr "Nie udało się otwarcie monitoringu katalogu \"%s\"."
 
-#: ../src/x11/utils.cpp:227
+#: ../src/x11/utils.cpp:189
 #, c-format
 msgid "Failed to open display \"%s\"."
 msgstr "Nie udało się otworzyć ekranu \"%s\"."
 
-#: ../src/common/filename.cpp:1062
+#: ../src/common/filename.cpp:1059
 msgid "Failed to open temporary file."
 msgstr "Nie udało się otworzyć pliku tymczasowego."
 
-#: ../src/msw/clipbrd.cpp:91
+#: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Nie udało się otworzyć schowka."
 
-#: ../src/common/translation.cpp:1184
+#: ../src/common/translation.cpp:1226
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Nie można przetworzyć formy liczby mnogiej: '%s'"
 
-#: ../src/unix/mediactrl.cpp:1214
+#: ../src/unix/mediactrl.cpp:1239
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Nie udało się przygotowanie odtwarzania \"%s\"."
 
-#: ../src/msw/clipbrd.cpp:600
+#: ../src/msw/clipbrd.cpp:610
 msgid "Failed to put data on the clipboard"
 msgstr "Nie udało się umieścić danych w schowku"
 
-#: ../src/unix/snglinst.cpp:278
+#: ../src/unix/snglinst.cpp:275
 msgid "Failed to read PID from lock file."
 msgstr "Nie udało sie odczytać identyfikatora z pliku blokującego."
 
-#: ../src/common/fileconf.cpp:433
+#: ../src/common/fileconf.cpp:432
 msgid "Failed to read config options."
 msgstr "Nie udało się odczytać opcji konfiguracji."
 
-#: ../src/common/docview.cpp:681
+#: ../src/common/docview.cpp:676
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Nie udało się wczytanie dokumentu z pliku \"%s\"."
 
-#: ../src/dfb/evtloop.cpp:98
+#: ../src/dfb/evtloop.cpp:99
 msgid "Failed to read event from DirectFB pipe"
 msgstr "Błąd odczytu z potoku DirectFB"
 
-#: ../src/unix/wakeuppipe.cpp:120
+#: ../src/unix/wakeuppipe.cpp:117
 msgid "Failed to read from wake-up pipe"
 msgstr "Nie udało się czytać z potoku budzącego "
 
-#: ../src/unix/utilsunx.cpp:679
+#: ../src/common/textfile.cpp:96
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Nie udało się wczytanie dokumentu z pliku \"%s\"."
+
+#: ../src/unix/utilsunx.cpp:681
 msgid "Failed to redirect child process input/output"
 msgstr "Nie udało się przekierować wejścia/wyjścia procesu potomnego."
 
-#: ../src/msw/utilsexc.cpp:701
+#: ../src/msw/utilsexc.cpp:698
 msgid "Failed to redirect the child process IO"
 msgstr "Nie udało się przekierować wejścia/wyjścia procesu potomnego"
 
-#: ../src/msw/dde.cpp:288
+#: ../src/msw/dde.cpp:283
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Nie udało się zarejestrować serwera DDE '%s'"
 
-#: ../src/common/fontmap.cpp:245
+#: ../src/gtk/font.cpp:580
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "Nie udała się aktualizacja pliku konfiguracyjnego użytkownika."
+
+#: ../src/common/fontmap.cpp:242
 #, c-format
 msgid "Failed to remember the encoding for the charset '%s'."
 msgstr "Nie udało się zapamiętać kodowania dla zestawu znaków '%s'"
 
-#: ../src/common/debugrpt.cpp:227
+#: ../src/common/debugrpt.cpp:228
 #, c-format
 msgid "Failed to remove debug report file \"%s\""
 msgstr "Nie udało się usunięcie pliku raportu błędów \"%s\""
 
-#: ../src/unix/snglinst.cpp:328
+#: ../src/unix/snglinst.cpp:325
 #, c-format
 msgid "Failed to remove lock file '%s'"
 msgstr "Nie udało się usunąć pliku blokującego '%s'"
 
 # stale --> ?
-#: ../src/unix/snglinst.cpp:288
+#: ../src/unix/snglinst.cpp:285
 #, c-format
 msgid "Failed to remove stale lock file '%s'."
 msgstr "Nie udało się usunąć nieaktualnego pliku blokującego '%s'."
 
-#: ../src/msw/registry.cpp:529
+#: ../src/msw/registry.cpp:518
 #, c-format
 msgid "Failed to rename registry value '%s' to '%s'."
 msgstr "Nie udało się zmienić nazwy wartości rejestru '%s' do '%s'."
 
-#: ../src/common/filefn.cpp:1122
+#: ../src/common/filefn.cpp:1011
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -3584,116 +3644,125 @@ msgstr ""
 "Nie udało się zmienić nazwy pliku '%s' na '%s', ponieważ plik docelowy już "
 "istnieje."
 
-#: ../src/msw/registry.cpp:634
+#: ../src/msw/registry.cpp:623
 #, c-format
 msgid "Failed to rename the registry key '%s' to '%s'."
 msgstr "Nie udało się zmienić nazwy klucza rejestru '%s' na '%s'."
 
-#: ../src/common/filename.cpp:2671
+#: ../src/msw/webview_ie.cpp:995
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/common/filename.cpp:2754
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Nie udało się odczytać czasów pliku '%s'"
 
-#: ../src/msw/dialup.cpp:468
+#: ../src/msw/dialup.cpp:462
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Nie udało się uzyskać tekstu komunikatu błędu RAS"
 
-#: ../src/msw/clipbrd.cpp:748
+#: ../src/msw/clipbrd.cpp:768
 msgid "Failed to retrieve the supported clipboard formats"
 msgstr "Nie udało się uzyskać listy formatów obsługiwanych przez schowek"
 
-#: ../src/common/docview.cpp:652
+#: ../src/common/docview.cpp:647
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Nie udało się zapisać dokumentu do pliku \"%s\"."
 
-#: ../src/msw/dib.cpp:269
+#: ../src/msw/dib.cpp:312
 #, c-format
 msgid "Failed to save the bitmap image to file \"%s\"."
 msgstr "Nie udało się zapisać obrazu do pliku \"%s\"."
 
-#: ../src/msw/dde.cpp:763
+#: ../src/msw/dde.cpp:811
 msgid "Failed to send DDE advise notification"
 msgstr "Nie udało się wysłać powiadomienia DDE"
 
-#: ../src/common/ftp.cpp:402
+#: ../src/common/ftp.cpp:399
 #, c-format
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "FTP: Nie udało się ustawić trybu transmisji na '%s'."
 
-#: ../src/msw/clipbrd.cpp:427
+#: ../src/msw/clipbrd.cpp:443
 msgid "Failed to set clipboard data."
 msgstr "Nie udało się skorzystać ze schowka."
 
-#: ../src/unix/snglinst.cpp:181
+#: ../src/unix/snglinst.cpp:178
 #, c-format
 msgid "Failed to set permissions on lock file '%s'"
 msgstr "Nie udało się nadanie praw dostępu na blokowanym pliku '%s'"
 
-#: ../src/unix/utilsunx.cpp:668
+#: ../src/unix/utilsunx.cpp:670
 msgid "Failed to set process priority"
 msgstr "Błąd podczas ustawiania priorytetu procesu"
 
-#: ../src/common/file.cpp:559
+#: ../src/common/ffile.cpp:355 ../src/common/file.cpp:586
 msgid "Failed to set temporary file permissions"
 msgstr "Nie udało się nadać praw dostępu pliku tymczasowemu"
 
-#: ../src/gtk/textctrl.cpp:1072
-msgid "Failed to set text in the text control."
-msgstr "Nie udało się ustawić tekstu w kontroli tekstu."
-
-#: ../src/unix/threadpsx.cpp:1298
+#: ../src/unix/threadpsx.cpp:1347
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Błąd podczas ustawiania priorytetu wątku na %lu"
 
-#: ../src/unix/threadpsx.cpp:1424
+#: ../src/unix/threadpsx.cpp:1473
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Nie udało się zmienić priorytetu wątku na %d."
 
-#: ../src/unix/utilsunx.cpp:783
+#: ../src/unix/utilsunx.cpp:785
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr "Nie udało się ustawić nieblokowego potoku, program może się zawiesić."
 
-#: ../src/common/fs_mem.cpp:261
+#: ../src/msw/webview_ie.cpp:987
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:256
 #, c-format
 msgid "Failed to store image '%s' to memory VFS!"
 msgstr "Nie udało się odłożyć obrazu '%s' do pamięci VFS!"
 
-#: ../src/dfb/evtloop.cpp:170
+#: ../src/dfb/evtloop.cpp:171
 msgid "Failed to switch DirectFB pipe to non-blocking mode"
 msgstr "Błąd podczas próby zmiany potoku DirectFB na tryb nieblokujący"
 
-#: ../src/unix/wakeuppipe.cpp:59
+#: ../src/unix/wakeuppipe.cpp:56
 msgid "Failed to switch wake up pipe to non-blocking mode"
 msgstr "Nie udało się przełączyć potoku budzącego na modus nie-blokujący"
 
-#: ../src/unix/threadpsx.cpp:1605
+#: ../src/unix/threadpsx.cpp:1654
 msgid "Failed to terminate a thread."
 msgstr "Nie udało się zakończyć wątku."
 
-#: ../src/msw/dde.cpp:741
+#: ../src/msw/dde.cpp:736
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr ""
 "Nie udało się zakończyć transakcji doradzającej (advise) z serwerem DDE"
 
-#: ../src/msw/dialup.cpp:938
+#: ../src/msw/dialup.cpp:932
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Nie udało się zakończyć połączenia dialup: %s"
 
-#: ../src/common/filename.cpp:2590
+#: ../src/common/filename.cpp:2673
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Nie udało się zmienić czasów pliku '%s'"
 
-#: ../src/unix/snglinst.cpp:334
+#: ../src/unix/dlunix.cpp:90
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "Nie udało się wczytać biblioteki '%s'."
+
+#: ../src/unix/snglinst.cpp:331
 #, c-format
 msgid "Failed to unlock lock file '%s'"
 msgstr "Nie udało się odblokować pliku blokującego '%s'"
 
-#: ../src/msw/dde.cpp:309
+#: ../src/msw/dde.cpp:304
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Nie udało się wyrejestrować serwera DDE '%s'"
@@ -3707,78 +3776,88 @@ msgstr "Nie udało się wyrejestrować deskryptora %d z deskryptora epoll %d"
 msgid "Failed to update user configuration file."
 msgstr "Nie udała się aktualizacja pliku konfiguracyjnego użytkownika."
 
-#: ../src/common/debugrpt.cpp:733
+#: ../src/common/debugrpt.cpp:743
 #, c-format
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Nie udało się przesłanie raportu błędów (kod błędu %d)"
 
 # ze źródeł wynika że chodzi o PID
-#: ../src/unix/snglinst.cpp:168
+#: ../src/unix/snglinst.cpp:165
 #, c-format
 msgid "Failed to write to lock file '%s'"
 msgstr "Nie udało się zapisać identyfikatora do pliku blokującego '%s'"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:209
+#: ../src/propgrid/propgrid.cpp:190
 msgid "False"
 msgstr "Fałsz"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:694
+#: ../src/propgrid/advprops.cpp:604
 msgid "Family"
 msgstr "Rodzina czcionki"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/gtk/glcanvas.cpp:176 ../src/gtk/glcanvas.cpp:187
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Błąd krytyczny "
+
+#: ../src/common/stockitem.cpp:154
 msgid "File"
 msgstr "Plik"
 
-#: ../src/common/docview.cpp:669
+#: ../src/common/docview.cpp:664
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Nie udało się otworzyć pliku '%s' do odczytu"
 
-#: ../src/common/docview.cpp:646
+#: ../src/common/docview.cpp:641
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Nie udało się otworzyć pliku '%s' do zapisu"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "Plik '%s' już istnieje, naprawdę chcesz go zastąpić?"
 
-#: ../src/common/filefn.cpp:1156
+#: ../src/common/filefn.cpp:1044
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Plik '%s' nie mógł zostać usunięty"
 
-#: ../src/common/filefn.cpp:1139
+#: ../src/common/filefn.cpp:1028
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Nazwa pliku '%s' nie mogła zostać zmieniona '%s'"
 
-#: ../src/richtext/richtextctrl.cpp:3081 ../src/common/textcmn.cpp:953
+#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
 msgid "File couldn't be loaded."
 msgstr "Plik nie może być wczytany."
 
-#: ../src/msw/filedlg.cpp:393
+#: ../src/msw/filedlg.cpp:414
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Dialog zawiódł zwracając kod błędu %0lx."
 
-#: ../src/common/docview.cpp:1789
+#: ../src/common/docview.cpp:1783
 msgid "File error"
 msgstr "Błąd plikowy"
 
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/filectrlg.cpp:770
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/filectrlg.cpp:766
 msgid "File name exists already."
 msgstr "Plik o tej nazwie już istnieje."
+
+#: ../src/osx/cocoa/filedlg.mm:264
+#, fuzzy
+msgid "File type:"
+msgstr "Teletype"
 
 #: ../src/motif/filedlg.cpp:220
 msgid "Files"
 msgstr "Pliki"
 
-#: ../src/common/filefn.cpp:1591
+#: ../src/common/filefn.cpp:1479
 #, c-format
 msgid "Files (%s)"
 msgstr "Pliki (%s)"
@@ -3787,15 +3866,29 @@ msgstr "Pliki (%s)"
 msgid "Filter"
 msgstr "Filtr"
 
-#: ../src/common/stockitem.cpp:158 ../src/html/helpwnd.cpp:490
+#: ../src/html/helpwnd.cpp:488
 msgid "Find"
 msgstr "Znajdź"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:259
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:258
+#, fuzzy
+msgid "Find in document"
+msgstr "Otwórz dokument HTML"
+
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "Find..."
+msgstr "Znajdź"
+
+#: ../src/common/stockitem.cpp:156
 msgid "First"
 msgstr "Pierwszy"
 
-#: ../src/common/prntbase.cpp:1548
+#: ../src/common/prntbase.cpp:1573
 msgid "First page"
 msgstr "Pierwsza strona"
 
@@ -3803,11 +3896,11 @@ msgstr "Pierwsza strona"
 msgid "Fixed"
 msgstr "Czcionka o stałej szerokości"
 
-#: ../src/html/helpwnd.cpp:1206
+#: ../src/html/helpwnd.cpp:1204
 msgid "Fixed font:"
 msgstr "Czcionka o stałej szerokości:"
 
-#: ../src/html/helpwnd.cpp:1269
+#: ../src/html/helpwnd.cpp:1267
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Ustalony rozmiar tekstu.<br> <b>pogrubienie</b> <i>kursywa</i> "
 
@@ -3815,16 +3908,16 @@ msgstr "Ustalony rozmiar tekstu.<br> <b>pogrubienie</b> <i>kursywa</i> "
 msgid "Floating"
 msgstr "Pływający"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "Floppy"
 msgstr "Dyskietka"
 
-#: ../src/common/paper.cpp:111
+#: ../src/common/paper.cpp:108
 msgid "Folio, 8 1/2 x 13 in"
 msgstr "Folio, 8 1/2 x 13 cali"
 
-#: ../src/richtext/richtextformatdlg.cpp:344 ../src/osx/carbon/fontdlg.cpp:287
-#: ../src/common/stockitem.cpp:194
+#: ../src/osx/carbon/fontdlg.cpp:284 ../src/common/stockitem.cpp:191
+#: ../src/richtext/richtextformatdlg.cpp:337
 msgid "Font"
 msgstr "Czcionka"
 
@@ -3832,7 +3925,24 @@ msgstr "Czcionka"
 msgid "Font &weight:"
 msgstr "&Waga czcionki:"
 
-#: ../src/html/helpwnd.cpp:1207
+#: ../src/osx/fontutil.cpp:89
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
+"\"."
+msgstr ""
+
+#: ../src/msw/font.cpp:1126
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Plik nie może być wczytany."
+
+#: ../src/osx/fontutil.cpp:81
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "Plik %s nie istnieje."
+
+#: ../src/html/helpwnd.cpp:1205
 msgid "Font size:"
 msgstr "Rozmiar czcionki:"
 
@@ -3840,53 +3950,53 @@ msgstr "Rozmiar czcionki:"
 msgid "Font st&yle:"
 msgstr "&Styl czcionki:"
 
-#: ../src/osx/carbon/fontdlg.cpp:329
+#: ../src/osx/carbon/fontdlg.cpp:326
 msgid "Font:"
 msgstr "Czcionka:"
 
-#: ../src/dfb/fontmgr.cpp:198
+#: ../src/dfb/fontmgr.cpp:195
 #, c-format
 msgid "Fonts index file %s disappeared while loading fonts."
 msgstr "Plik indeksu czcionek %s znikł podczas ładowania czcionek."
 
-#: ../src/unix/utilsunx.cpp:645
+#: ../src/unix/utilsunx.cpp:647
 msgid "Fork failed"
 msgstr "Rozwidlenie nie powiodło się"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "Forward"
 msgstr "Dalej"
 
-#: ../src/common/xtixml.cpp:235
+#: ../src/common/xtixml.cpp:231
 msgid "Forward hrefs are not supported"
 msgstr "Przekazywanie właściwości 'href' nie jest wspierane"
 
-#: ../src/html/helpwnd.cpp:875
+#: ../src/html/helpwnd.cpp:873
 #, c-format
 msgid "Found %i matches"
 msgstr "Znaleziono %i odpowiednik(i/ów)"
 
-#: ../src/generic/prntdlgg.cpp:238
+#: ../src/generic/prntdlgg.cpp:231
 msgid "From:"
 msgstr "Od:"
 
-#: ../src/propgrid/advprops.cpp:1604
+#: ../src/propgrid/advprops.cpp:1510
 msgid "Fuchsia"
 msgstr ""
 
-#: ../src/common/imaggif.cpp:138
+#: ../src/common/imaggif.cpp:135
 msgid "GIF: data stream seems to be truncated."
 msgstr "GIF: strumień daych wygląda na obcięty."
 
-#: ../src/common/imaggif.cpp:128
+#: ../src/common/imaggif.cpp:125
 msgid "GIF: error in GIF image format."
 msgstr "GIF: błąd w formacie obrazu GIF."
 
-#: ../src/common/imaggif.cpp:133
+#: ../src/common/imaggif.cpp:130
 msgid "GIF: not enough memory."
 msgstr "GIF: za mało pamięci."
 
-#: ../src/gtk/window.cpp:4631
+#: ../src/gtk/window.cpp:5635
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -3894,23 +4004,23 @@ msgstr ""
 "GTK+ zainstalowana na tej maszynie jest zbyt stara i nie wspiera kompozycji "
 "ekranu, proszę zainstalować GTK+ 2.12 lub nowszą."
 
-#: ../src/univ/themes/gtk.cpp:525
+#: ../src/univ/themes/gtk.cpp:522
 msgid "GTK+ theme"
 msgstr "Kompozycja GTK+"
 
-#: ../src/common/preferencescmn.cpp:40
+#: ../src/common/preferencescmn.cpp:37
 msgid "General"
 msgstr "Ogólne"
 
-#: ../src/common/prntbase.cpp:258
+#: ../src/common/prntbase.cpp:253
 msgid "Generic PostScript"
 msgstr "PostScript"
 
-#: ../src/common/paper.cpp:135
+#: ../src/common/paper.cpp:132
 msgid "German Legal Fanfold, 8 1/2 x 13 in"
 msgstr "Składanka German Legal, 8 1/2 x 13 cali"
 
-#: ../src/common/paper.cpp:134
+#: ../src/common/paper.cpp:131
 msgid "German Std Fanfold, 8 1/2 x 12 in"
 msgstr "Składanka German Std, 8 1/2 x 12 cali"
 
@@ -3927,49 +4037,49 @@ msgid "GetPropertyCollection called w/o valid collection getter"
 msgstr ""
 "Funkcja GetPropertyCollection wywołana bez poprawnego modułu pobierającego"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:658
 msgid "Go back"
 msgstr "Idź wstecz"
 
-#: ../src/html/helpwnd.cpp:661
+#: ../src/html/helpwnd.cpp:659
 msgid "Go forward"
 msgstr "Idź dalej"
 
-#: ../src/html/helpwnd.cpp:663
+#: ../src/html/helpwnd.cpp:661
 msgid "Go one level up in document hierarchy"
 msgstr "Idź poziom wyżej w hierarchi dokumentu"
 
-#: ../src/generic/filedlgg.cpp:208 ../src/generic/dirdlgg.cpp:116
+#: ../src/generic/filedlgg.cpp:205 ../src/generic/dirdlgg.cpp:113
 msgid "Go to home directory"
 msgstr "Idź do katalogu domowego"
 
-#: ../src/generic/filedlgg.cpp:205
+#: ../src/generic/filedlgg.cpp:202
 msgid "Go to parent directory"
 msgstr "Idź do katalogu nadrzędnego"
 
-#: ../src/generic/aboutdlgg.cpp:76
+#: ../src/generic/aboutdlgg.cpp:73
 msgid "Graphics art by "
 msgstr "Grafika autorstwa"
 
-#: ../src/propgrid/advprops.cpp:1599
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Gray"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:883
+#: ../src/propgrid/advprops.cpp:784
 msgid "GrayText"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:154
+#: ../src/common/fmapbase.cpp:151
 msgid "Greek (ISO-8859-7)"
 msgstr "Grecki (ISO-8859-7)"
 
-#: ../src/propgrid/advprops.cpp:1600
+#: ../src/propgrid/advprops.cpp:1506
 #, fuzzy
 msgid "Green"
 msgstr "MacGrecki"
 
-#: ../src/generic/colrdlgg.cpp:342
+#: ../src/generic/colrdlgg.cpp:362
 #, fuzzy
 msgid "Green:"
 msgstr "MacGrecki"
@@ -3978,113 +4088,113 @@ msgstr "MacGrecki"
 msgid "Groove"
 msgstr "Groove"
 
-#: ../src/common/zstream.cpp:158 ../src/common/zstream.cpp:318
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
 msgid "Gzip not supported by this version of zlib"
 msgstr "Format Gzip nie jest wspierany przez tę wersję biblioteki zlib"
 
-#: ../src/html/helpwnd.cpp:1549
+#: ../src/html/helpwnd.cpp:1547
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "Plik projektu pomocy HTML Help (*.hhp)|*.hhp|"
 
 # Kotwica?
-#: ../src/html/htmlwin.cpp:681
+#: ../src/html/htmlwin.cpp:691
 #, c-format
 msgid "HTML anchor %s does not exist."
 msgstr "HTML: kotwica %s ie istnieje."
 
-#: ../src/html/helpwnd.cpp:1547
+#: ../src/html/helpwnd.cpp:1545
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "Pliki HTML (*.html;*.htm)|*.html;*.htm|"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1759
+#: ../src/propgrid/advprops.cpp:1660
 msgid "Hand"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "Harddisk"
 msgstr "Dysk twardy"
 
-#: ../src/common/fmapbase.cpp:155
+#: ../src/common/fmapbase.cpp:152
 msgid "Hebrew (ISO-8859-8)"
 msgstr "Hebrajski (ISO-8859-8)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:280 ../src/osx/button_osx.cpp:39
-#: ../src/common/stockitem.cpp:163 ../src/common/accelcmn.cpp:80
-#: ../src/html/helpdlg.cpp:66 ../src/html/helpfrm.cpp:111
+#: ../include/wx/msgdlg.h:282 ../src/osx/button_osx.cpp:39
+#: ../src/common/stockitem.cpp:160 ../src/common/accelcmn.cpp:77
+#: ../src/html/helpfrm.cpp:108 ../src/html/helpdlg.cpp:63
 msgid "Help"
 msgstr "Pomoc"
 
-#: ../src/html/helpwnd.cpp:1200
+#: ../src/html/helpwnd.cpp:1198
 msgid "Help Browser Options"
 msgstr "Opcje przeglądarki pomocy"
 
-#: ../src/generic/helpext.cpp:454 ../src/generic/helpext.cpp:455
+#: ../src/generic/helpext.cpp:452 ../src/generic/helpext.cpp:453
 msgid "Help Index"
 msgstr "Spis treści"
 
 # pomoc do drukowania?
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1529
 msgid "Help Printing"
 msgstr "Drukowanie pomocy"
 
-#: ../src/html/helpwnd.cpp:801
+#: ../src/html/helpwnd.cpp:799
 msgid "Help Topics"
 msgstr "Tematy Pomocy"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1546
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Pakiety pomocy (*.htb)|*.htb|Pakiety pomocy (*.zip)|*.zip|"
 
-#: ../src/generic/helpext.cpp:267
+#: ../src/generic/helpext.cpp:265
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "Nie znaleziono katalogu pomocy \"%s\"."
 
 # catalog file --> ?
 # domain --> ?
-#: ../src/generic/helpext.cpp:275
+#: ../src/generic/helpext.cpp:273
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "Nie znaleziono pliku pomocy \"%s\"."
 
-#: ../src/html/helpctrl.cpp:63
+#: ../src/html/helpctrl.cpp:59
 #, c-format
 msgid "Help: %s"
 msgstr "Pomoc: %s"
 
-#: ../src/osx/menu_osx.cpp:577
+#: ../src/osx/menu_osx.cpp:469
 #, c-format
 msgid "Hide %s"
 msgstr "Ukryj %s"
 
-#: ../src/osx/menu_osx.cpp:579
+#: ../src/osx/menu_osx.cpp:471
 msgid "Hide Others"
 msgstr "Ukryj inne"
 
-#: ../src/generic/infobar.cpp:84
+#: ../src/generic/infobar.cpp:81
 msgid "Hide this notification message."
 msgstr "Ukryj to powiadomienie."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:884
+#: ../src/propgrid/advprops.cpp:785
 #, fuzzy
 msgid "Highlight"
 msgstr "lekki"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:885
+#: ../src/propgrid/advprops.cpp:786
 #, fuzzy
 msgid "HighlightText"
 msgstr "Prawe dostosowanie tekstu."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:164 ../src/common/accelcmn.cpp:65
+#: ../src/common/stockitem.cpp:161 ../src/common/accelcmn.cpp:62
 msgid "Home"
 msgstr "Katalog początkowy"
 
-#: ../src/generic/dirctrlg.cpp:524
+#: ../src/generic/dirctrlg.cpp:490
 msgid "Home directory"
 msgstr "Katalog początkowy"
 
@@ -4094,57 +4204,57 @@ msgid "How the object will float relative to the text."
 msgstr "Jak obiekt będzie pływać względem tekstu."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1760
+#: ../src/propgrid/advprops.cpp:1661
 msgid "I-Beam"
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1196
+#: ../src/common/imagbmp.cpp:1208
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: Błąd odczytu maski DIB."
 
-#: ../src/common/imagbmp.cpp:1290 ../src/common/imagbmp.cpp:1390
-#: ../src/common/imagbmp.cpp:1405 ../src/common/imagbmp.cpp:1416
-#: ../src/common/imagbmp.cpp:1430 ../src/common/imagbmp.cpp:1478
-#: ../src/common/imagbmp.cpp:1493 ../src/common/imagbmp.cpp:1507
-#: ../src/common/imagbmp.cpp:1518
+#: ../src/common/imagbmp.cpp:1302 ../src/common/imagbmp.cpp:1402
+#: ../src/common/imagbmp.cpp:1417 ../src/common/imagbmp.cpp:1428
+#: ../src/common/imagbmp.cpp:1442 ../src/common/imagbmp.cpp:1490
+#: ../src/common/imagbmp.cpp:1505 ../src/common/imagbmp.cpp:1519
+#: ../src/common/imagbmp.cpp:1530
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: Błąd przy zapisie do pliku."
 
-#: ../src/common/imagbmp.cpp:1255
+#: ../src/common/imagbmp.cpp:1267
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: Obraz jest zbyt wysoki jak na ikonę."
 
-#: ../src/common/imagbmp.cpp:1263
+#: ../src/common/imagbmp.cpp:1275
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: Obraz jest zbyt szeroki jak na ikonę."
 
 # ...indeks w grafice (?)
 # ideks - katalog, wskanik?
-#: ../src/common/imagbmp.cpp:1603
+#: ../src/common/imagbmp.cpp:1615
 msgid "ICO: Invalid icon index."
 msgstr "ICO: Brak ikony o podanym indeksie.."
 
-#: ../src/common/imagiff.cpp:758
+#: ../src/common/imagiff.cpp:755
 msgid "IFF: data stream seems to be truncated."
 msgstr "IFF: strumień daych wygląda na obcięty."
 
-#: ../src/common/imagiff.cpp:742
+#: ../src/common/imagiff.cpp:739
 msgid "IFF: error in IFF image format."
 msgstr "IFF: błąd w formacie obrazu IFF."
 
-#: ../src/common/imagiff.cpp:745
+#: ../src/common/imagiff.cpp:742
 msgid "IFF: not enough memory."
 msgstr "IFF: za mało pamięci."
 
-#: ../src/common/imagiff.cpp:748
+#: ../src/common/imagiff.cpp:745
 msgid "IFF: unknown error!!!"
 msgstr "IFF: nieznany błąd !!!"
 
-#: ../src/common/fmapbase.cpp:197
+#: ../src/common/fmapbase.cpp:194
 msgid "ISO-2022-JP"
 msgstr "ISO-2022-JP"
 
-#: ../src/html/htmprint.cpp:282
+#: ../src/html/htmprint.cpp:294
 msgid ""
 "If possible, try changing the layout parameters to make the printout more "
 "narrow."
@@ -4152,7 +4262,7 @@ msgstr ""
 "Jeżeli to możliwe, spróbuj zmodyfikować parametry układu, aby uczynić wydruk "
 "węższy."
 
-#: ../src/generic/dbgrptg.cpp:358
+#: ../src/generic/dbgrptg.cpp:362
 msgid ""
 "If you have any additional information pertaining to this bug\n"
 "report, please enter it here and it will be joined to it:"
@@ -4171,46 +4281,50 @@ msgstr ""
 "ale rozważ że to może utrudnić usprawnianie oprogramowania,\n"
 "w związku z tym zachęcamy do kontynuowania raportowania błędów.\n"
 
-#: ../src/msw/registry.cpp:1405
+#: ../src/common/zipstrm.cpp:1043
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1393
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Wartiść \"%s\" klucza \"%s\" zignorowana."
 
-#: ../src/common/xtistrm.cpp:295
+#: ../src/common/xtistrm.cpp:292
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Błędna Klasa Obiekty (nie typu wxEvtHandler) jako Źródło Zdarzenia"
 
-#: ../src/common/xti.cpp:513
+#: ../src/common/xti.cpp:510
 msgid "Illegal Parameter Count for ConstructObject Method"
 msgstr "Nieprawidłowa Liczba Parametrów w Metodzie ConstructObject"
 
-#: ../src/common/xti.cpp:501
+#: ../src/common/xti.cpp:498
 msgid "Illegal Parameter Count for Create Method"
 msgstr "Nieprawidłowa Liczba Parametrów w Metodzie Create"
 
-#: ../src/generic/dirctrlg.cpp:570 ../src/generic/filectrlg.cpp:756
+#: ../src/generic/dirctrlg.cpp:536 ../src/generic/filectrlg.cpp:752
 msgid "Illegal directory name."
 msgstr "Niedozwolona nazwa katalogu."
 
-#: ../src/generic/filectrlg.cpp:1367
+#: ../src/generic/filectrlg.cpp:1356
 msgid "Illegal file specification."
 msgstr "Niedozwolona specyfikacja pliku."
 
-#: ../src/common/image.cpp:2269
+#: ../src/common/image.cpp:2363
 msgid "Image and mask have different sizes."
 msgstr "Obraz i maska mają różne rozmiary."
 
-#: ../src/common/image.cpp:2746
+#: ../src/common/image.cpp:2841
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "Nie jest to obraz typu %d."
 
-#: ../src/common/image.cpp:2877
+#: ../src/common/image.cpp:2995
 #, c-format
 msgid "Image is not of type %s."
 msgstr "Nie jest to obraz typu %s."
 
-#: ../src/msw/textctrl.cpp:488
+#: ../src/msw/textctrl.cpp:534
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -4218,102 +4332,102 @@ msgstr ""
 "Nie jest możliwe utworzenie kontrolki rich edit, użyj zamiast tego prostego "
 "'text control'. Przeinstaluj riched32.dll"
 
-#: ../src/unix/utilsunx.cpp:301
+#: ../src/unix/utilsunx.cpp:303
 msgid "Impossible to get child process input"
 msgstr "Nie jest możliwe uzyskanie wejścia procesu potomnego"
 
-#: ../src/common/filefn.cpp:1028
+#: ../src/common/filefn.cpp:917
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Uzyskanie praw dostępu do pliku '%s' jest niemożliwe"
 
-#: ../src/common/filefn.cpp:1042
+#: ../src/common/filefn.cpp:931
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Zastąpienie pliku '%s' jest niemożliwe"
 
-#: ../src/common/filefn.cpp:1097
+#: ../src/common/filefn.cpp:986
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Nie jest możliwe nadanie praw dostępu plikowi '%s'"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:886
+#: ../src/propgrid/advprops.cpp:787
 #, fuzzy
 msgid "InactiveBorder"
 msgstr "Obramowanie"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:887
+#: ../src/propgrid/advprops.cpp:788
 msgid "InactiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:888
+#: ../src/propgrid/advprops.cpp:789
 msgid "InactiveCaptionText"
 msgstr ""
 
-#: ../src/common/gifdecod.cpp:792
+#: ../src/common/gifdecod.cpp:826
 #, c-format
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "Nieprawidłowy rozmiar ramki GIF (%u, %d) dla ramki #%u"
 
-#: ../src/msw/ole/automtn.cpp:635
+#: ../src/msw/ole/automtn.cpp:626
 msgid "Incorrect number of arguments."
 msgstr "Nieprawidłowa liczba argumentów."
 
-#: ../src/common/stockitem.cpp:165
+#: ../src/common/stockitem.cpp:162
 msgid "Indent"
 msgstr "Wcięcie"
 
-#: ../src/richtext/richtextformatdlg.cpp:349
+#: ../src/richtext/richtextformatdlg.cpp:342
 msgid "Indents && Spacing"
 msgstr "Wcięcia i odstępy"
 
-#: ../src/common/stockitem.cpp:166 ../src/html/helpwnd.cpp:515
+#: ../src/common/stockitem.cpp:163 ../src/html/helpwnd.cpp:513
 msgid "Index"
 msgstr "Indeks"
 
-#: ../src/common/fmapbase.cpp:159
+#: ../src/common/fmapbase.cpp:156
 msgid "Indian (ISO-8859-12)"
 msgstr "Hinduski (ISO-8859-12)"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "Info"
 msgstr "Info"
 
-#: ../src/common/init.cpp:287
+#: ../src/common/init.cpp:284
 msgid "Initialization failed in post init, aborting."
 msgstr "Inicjalizacja nie powiodła się powodując wyjście."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:54
+#: ../src/common/accelcmn.cpp:51
 #, fuzzy
 msgid "Ins"
 msgstr "Wstawka"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextsymboldlg.cpp:472 ../src/common/accelcmn.cpp:53
+#: ../src/common/accelcmn.cpp:50 ../src/richtext/richtextsymboldlg.cpp:469
 msgid "Insert"
 msgstr "Wstawić"
 
-#: ../src/richtext/richtextbuffer.cpp:8067
+#: ../src/richtext/richtextbuffer.cpp:8063
 msgid "Insert Field"
 msgstr "Wstaw pole"
 
-#: ../src/richtext/richtextbuffer.cpp:7978
-#: ../src/richtext/richtextbuffer.cpp:8936
+#: ../src/richtext/richtextbuffer.cpp:7974
+#: ../src/richtext/richtextbuffer.cpp:8934
 msgid "Insert Image"
 msgstr "Wstaw obraz"
 
-#: ../src/richtext/richtextbuffer.cpp:8025
+#: ../src/richtext/richtextbuffer.cpp:8021
 msgid "Insert Object"
 msgstr "Wstaw obiekt"
 
-#: ../src/richtext/richtextctrl.cpp:1286 ../src/richtext/richtextctrl.cpp:1494
-#: ../src/richtext/richtextbuffer.cpp:7822
-#: ../src/richtext/richtextbuffer.cpp:7852
-#: ../src/richtext/richtextbuffer.cpp:7894
+#: ../src/richtext/richtextbuffer.cpp:7818
+#: ../src/richtext/richtextbuffer.cpp:7848
+#: ../src/richtext/richtextbuffer.cpp:7890
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
 msgid "Insert Text"
 msgstr "Wstaw tekst"
 
@@ -4326,18 +4440,13 @@ msgstr "Wstawia łamanie strony przed akapitem."
 msgid "Inset"
 msgstr "Wstawka"
 
-#: ../src/gtk/app.cpp:425
-#, c-format
-msgid "Invalid GTK+ command line option, use \"%s --help\""
-msgstr "Nieprawidłowa opcja GTK+ wiersza poleceń, należy użyć \"%s --help\""
-
 # ...indeks w grafice (?)
 # ideks - katalog, wska?nik?
-#: ../src/common/imagtiff.cpp:311
+#: ../src/common/imagtiff.cpp:308
 msgid "Invalid TIFF image index."
 msgstr "TIFF: Brak obrazu o podanym indeksie."
 
-#: ../src/common/appcmn.cpp:273
+#: ../src/common/appcmn.cpp:294
 #, c-format
 msgid "Invalid display mode specification '%s'."
 msgstr "Błędna specyfikacja trybu wyświetlania '%s'."
@@ -4348,263 +4457,267 @@ msgstr "Błędna specyfikacja trybu wyświetlania '%s'."
 msgid "Invalid geometry specification '%s'"
 msgstr "Niedozwolona specyfikacja \"geometry\" '%s'."
 
-#: ../src/unix/fswatcher_inotify.cpp:323
+#: ../src/unix/fswatcher_inotify.cpp:320
 #, c-format
 msgid "Invalid inotify event for \"%s\""
 msgstr "Nieprawidłowe zdarzenie inotify dla \"%s\""
 
-#: ../src/unix/snglinst.cpp:312
+#: ../src/unix/snglinst.cpp:309
 #, c-format
 msgid "Invalid lock file '%s'."
 msgstr "Nieprawidłowy plik blokujący '%s'."
 
-#: ../src/common/translation.cpp:1125
+#: ../src/common/translation.cpp:1167
 msgid "Invalid message catalog."
 msgstr "Nieprawidłowy katalog komunikatów."
 
-#: ../src/common/xtistrm.cpp:405 ../src/common/xtistrm.cpp:420
+#: ../src/common/xtistrm.cpp:402 ../src/common/xtistrm.cpp:417
 msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
 msgstr ""
 "Błędny lub Pusty Identyfikator Obiektu przekazany do funkcji "
 "GetObjectClassInfo"
 
-#: ../src/common/xtistrm.cpp:435
+#: ../src/common/xtistrm.cpp:432
 msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
 msgstr ""
 "Błędny lub Pusty Identyfikator Obiektu przekazany do funkcji "
 "HasObjectClassInfo"
 
-#: ../src/common/regex.cpp:310
+#: ../src/common/regex.cpp:307
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Nieprawidłowe wyrażenie regularne '%s': %s"
 
-#: ../src/common/config.cpp:226
+#: ../src/common/config.cpp:222
 #, c-format
 msgid "Invalid value %ld for a boolean key \"%s\" in config file."
 msgstr ""
 "Nieprawidłowa wartość %ld dla klucza logicznego\"%s\" w pliku "
 "konfiguracyjnym."
 
-#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:351
-#: ../src/osx/carbon/fontdlg.cpp:361 ../src/common/stockitem.cpp:168
+#: ../src/osx/carbon/fontdlg.cpp:358 ../src/common/stockitem.cpp:165
+#: ../src/generic/fontdlgg.cpp:325 ../src/richtext/richtextfontpage.cpp:351
 msgid "Italic"
 msgstr "Kursywa"
 
-#: ../src/common/paper.cpp:130
+#: ../src/common/paper.cpp:127
 msgid "Italy Envelope, 110 x 230 mm"
 msgstr "Koperta włoska, 110 x 230 mm"
 
-#: ../src/common/imagjpeg.cpp:270
+#: ../src/common/imagjpeg.cpp:257
 msgid "JPEG: Couldn't load - file is probably corrupted."
 msgstr "JPEG: Nie można wczytać - prawdopodobnie plik jest uszkodzony."
 
-#: ../src/common/imagjpeg.cpp:449
+#: ../src/common/imagjpeg.cpp:436
 msgid "JPEG: Couldn't save image."
 msgstr "JPEG: Nie można zapisać obrazu."
 
-#: ../src/common/paper.cpp:163
+#: ../src/common/paper.cpp:160
 msgid "Japanese Double Postcard 200 x 148 mm"
 msgstr "Japońska Podwójna Pocztówka 200 x 148 mm"
 
-#: ../src/common/paper.cpp:167
+#: ../src/common/paper.cpp:164
 msgid "Japanese Envelope Chou #3"
 msgstr "Japońska Koperta Chou #3"
 
-#: ../src/common/paper.cpp:180
+#: ../src/common/paper.cpp:177
 msgid "Japanese Envelope Chou #3 Rotated"
 msgstr "Japońska Koperta Chou #3 Obrócona"
 
-#: ../src/common/paper.cpp:168
+#: ../src/common/paper.cpp:165
 msgid "Japanese Envelope Chou #4"
 msgstr "Japońska Koperta Chou #4"
 
-#: ../src/common/paper.cpp:181
+#: ../src/common/paper.cpp:178
 msgid "Japanese Envelope Chou #4 Rotated"
 msgstr "Japońska Koperta Chou #4 Obrócona"
 
-#: ../src/common/paper.cpp:165
+#: ../src/common/paper.cpp:162
 msgid "Japanese Envelope Kaku #2"
 msgstr "Japońska Koperta Kaku #2"
 
-#: ../src/common/paper.cpp:178
+#: ../src/common/paper.cpp:175
 msgid "Japanese Envelope Kaku #2 Rotated"
 msgstr "Japońska Koperta Kaku #2 Obrócona"
 
-#: ../src/common/paper.cpp:166
+#: ../src/common/paper.cpp:163
 msgid "Japanese Envelope Kaku #3"
 msgstr "Japońska Koperta Kaku #3"
 
-#: ../src/common/paper.cpp:179
+#: ../src/common/paper.cpp:176
 msgid "Japanese Envelope Kaku #3 Rotated"
 msgstr "Japońska Koperta Kaku #3 Obrócona"
 
-#: ../src/common/paper.cpp:185
+#: ../src/common/paper.cpp:182
 msgid "Japanese Envelope You #4"
 msgstr "Japońska Koperta You #4"
 
-#: ../src/common/paper.cpp:186
+#: ../src/common/paper.cpp:183
 msgid "Japanese Envelope You #4 Rotated"
 msgstr "Japońska Koperta You #4 Obrócona"
 
-#: ../src/common/paper.cpp:138
+#: ../src/common/paper.cpp:135
 msgid "Japanese Postcard 100 x 148 mm"
 msgstr "Japońska Pocztówka 100 x 148 mm"
 
-#: ../src/common/paper.cpp:175
+#: ../src/common/paper.cpp:172
 msgid "Japanese Postcard Rotated 148 x 100 mm"
 msgstr "Japońska Pocztówka Obrócona 148 x 100 mm"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "Jump to"
 msgstr "Skocz do"
 
-#: ../src/common/stockitem.cpp:171
+#: ../src/common/stockitem.cpp:168
 msgid "Justified"
 msgstr "Wyrównanie obustronne"
 
-#: ../src/richtext/richtextindentspage.cpp:155
-#: ../src/richtext/richtextindentspage.cpp:157
 #: ../src/richtext/richtextliststylepage.cpp:344
 #: ../src/richtext/richtextliststylepage.cpp:346
+#: ../src/richtext/richtextindentspage.cpp:155
+#: ../src/richtext/richtextindentspage.cpp:157
 msgid "Justify text left and right."
 msgstr "Wyjustuj tekst w lewo i w prawo."
 
-#: ../src/common/fmapbase.cpp:163
+#: ../src/common/fmapbase.cpp:160
 msgid "KOI8-R"
 msgstr "KOI8-R"
 
-#: ../src/common/fmapbase.cpp:164
+#: ../src/common/fmapbase.cpp:161
 msgid "KOI8-U"
 msgstr "KOI8-U"
 
-#: ../src/common/accelcmn.cpp:265 ../src/common/accelcmn.cpp:347
+#: ../src/common/accelcmn.cpp:279 ../src/common/accelcmn.cpp:364
 msgid "KP_"
 msgstr "KP_"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 #, fuzzy
 msgid "KP_Add"
 msgstr "KP_ADD"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "KP_Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "KP_Decimal"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 #, fuzzy
 msgid "KP_Delete"
 msgstr "Usuń"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "KP_Divide"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 #, fuzzy
 msgid "KP_Down"
 msgstr "W dół"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 #, fuzzy
 msgid "KP_End"
 msgstr "KP_END"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 #, fuzzy
 msgid "KP_Enter"
 msgstr "Drukarka"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "KP_Equal"
 msgstr ""
 
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
-#, fuzzy
-msgid "KP_Home"
-msgstr "Katalog początkowy"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
-#, fuzzy
-msgid "KP_Insert"
-msgstr "Wstawić"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
-#, fuzzy
-msgid "KP_Left"
-msgstr "Lewo"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
-msgid "KP_Multiply"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:99
-#, fuzzy
-msgid "KP_Next"
-msgstr "Dalej"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
-msgid "KP_PageDown"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
-msgid "KP_PageUp"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:98
-msgid "KP_Prior"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
-#, fuzzy
-msgid "KP_Right"
-msgstr "Prawy"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
-msgid "KP_Separator"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
-msgid "KP_Space"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
-msgid "KP_Subtract"
+#: ../src/common/accelcmn.cpp:276 ../src/common/accelcmn.cpp:361
+msgid "KP_F"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
 #: ../src/common/accelcmn.cpp:89
 #, fuzzy
+msgid "KP_Home"
+msgstr "Katalog początkowy"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:100
+#, fuzzy
+msgid "KP_Insert"
+msgstr "Wstawić"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:90
+#, fuzzy
+msgid "KP_Left"
+msgstr "Lewo"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:103
+msgid "KP_Multiply"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:97
+#, fuzzy
+msgid "KP_Next"
+msgstr "Dalej"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:95
+msgid "KP_PageDown"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:94
+msgid "KP_PageUp"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:96
+msgid "KP_Prior"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:92
+#, fuzzy
+msgid "KP_Right"
+msgstr "Prawy"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:105
+msgid "KP_Separator"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:86
+msgid "KP_Space"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:106
+msgid "KP_Subtract"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:87
+#, fuzzy
 msgid "KP_Tab"
 msgstr "KP_TAB"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 #, fuzzy
 msgid "KP_Up"
 msgstr "KP_UP"
@@ -4613,19 +4726,34 @@ msgstr "KP_UP"
 msgid "L&ine spacing:"
 msgstr "&Odstęp między wierszami:"
 
-#: ../src/generic/prntdlgg.cpp:613 ../src/generic/prntdlgg.cpp:868
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "błąd kompresji"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "błąd dekompresji"
+
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:861
 msgid "Landscape"
 msgstr "Pejzaż"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "Last"
 msgstr "Ostatni"
 
-#: ../src/common/prntbase.cpp:1572
+#: ../src/common/prntbase.cpp:1597
 msgid "Last page"
 msgstr "Ostatnia strona"
 
-#: ../src/common/log.cpp:305
+#: ../src/common/log.cpp:324
 #, fuzzy, c-format
 msgid "Last repeated message (\"%s\", %u time) wasn't output"
 msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
@@ -4633,93 +4761,93 @@ msgstr[0] "Last repeated message (\"%s\", %lu time) wasn't output"
 msgstr[1] "Last repeated message (\"%s\", %lu times) wasn't output"
 msgstr[2] "Last repeated message (\"%s\", %lu times) wasn't output"
 
-#: ../src/common/paper.cpp:103
+#: ../src/common/paper.cpp:100
 msgid "Ledger, 17 x 11 in"
 msgstr "Ledger, 17 x 11 cali"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6146
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:58 ../src/generic/datavgen.cpp:6951
+#: ../src/richtext/richtextsizepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:252
 #: ../src/richtext/richtextliststylepage.cpp:253
 #: ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
-#: ../src/richtext/richtextsizepage.cpp:249 ../src/common/accelcmn.cpp:61
 msgid "Left"
 msgstr "Lewo"
 
-#: ../src/richtext/richtextindentspage.cpp:204
 #: ../src/richtext/richtextliststylepage.cpp:390
+#: ../src/richtext/richtextindentspage.cpp:204
 msgid "Left (&first line):"
 msgstr "Lewo (&pierwsza linijka):"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1761
+#: ../src/propgrid/advprops.cpp:1662
 msgid "Left Button"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:880
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Left margin (mm):"
 msgstr "Lewy margines (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:141
-#: ../src/richtext/richtextindentspage.cpp:143
 #: ../src/richtext/richtextliststylepage.cpp:330
 #: ../src/richtext/richtextliststylepage.cpp:332
+#: ../src/richtext/richtextindentspage.cpp:141
+#: ../src/richtext/richtextindentspage.cpp:143
 msgid "Left-align text."
 msgstr "Lewe dostosowanie tekstu."
 
-#: ../src/common/paper.cpp:144
+#: ../src/common/paper.cpp:141
 msgid "Legal Extra 9 1/2 x 15 in"
 msgstr "Legal Extra 9 1/2 x 15 cali"
 
-#: ../src/common/paper.cpp:96
+#: ../src/common/paper.cpp:93
 msgid "Legal, 8 1/2 x 14 in"
 msgstr "Legal, 8 1/2 x 14 cali"
 
-#: ../src/common/paper.cpp:143
+#: ../src/common/paper.cpp:140
 msgid "Letter Extra 9 1/2 x 12 in"
 msgstr "List Extra 9 1/2 x 12 cali"
 
-#: ../src/common/paper.cpp:149
+#: ../src/common/paper.cpp:146
 msgid "Letter Extra Transverse 9.275 x 12 in"
 msgstr "List Extra Poprzecznie 9.275 x 12 cali"
 
-#: ../src/common/paper.cpp:152
+#: ../src/common/paper.cpp:149
 msgid "Letter Plus 8 1/2 x 12.69 in"
 msgstr "List Plus 8 1/2 x 12.69 cala"
 
-#: ../src/common/paper.cpp:169
+#: ../src/common/paper.cpp:166
 msgid "Letter Rotated 11 x 8 1/2 in"
 msgstr "List Obrócony 11 x 8 1/2 cala"
 
-#: ../src/common/paper.cpp:101
+#: ../src/common/paper.cpp:98
 msgid "Letter Small, 8 1/2 x 11 in"
 msgstr "Mały list, 8 1/2 x 11 cali"
 
-#: ../src/common/paper.cpp:147
+#: ../src/common/paper.cpp:144
 msgid "Letter Transverse 8 1/2 x 11 in"
 msgstr "List Poprzecznie 8 1/2 x 11 cali"
 
-#: ../src/common/paper.cpp:95
+#: ../src/common/paper.cpp:92
 msgid "Letter, 8 1/2 x 11 in"
 msgstr "List, 8 1/2 x 11 cali"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "License"
 msgstr "Licencja"
 
-#: ../src/generic/fontdlgg.cpp:332
+#: ../src/generic/fontdlgg.cpp:328
 msgid "Light"
 msgstr "Cieńszy"
 
-#: ../src/propgrid/advprops.cpp:1608
+#: ../src/propgrid/advprops.cpp:1514
 msgid "Lime"
 msgstr ""
 
-#: ../src/generic/helpext.cpp:294
+#: ../src/generic/helpext.cpp:292
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr ""
@@ -4729,15 +4857,15 @@ msgstr ""
 msgid "Line spacing:"
 msgstr "Odstęp między wierszami:"
 
-#: ../src/html/chm.cpp:838
+#: ../src/html/chm.cpp:829
 msgid "Link contained '//', converted to absolute link."
 msgstr "Odsyłacz zawierający '//' przekonwertowano do adresu bezwzględnego."
 
-#: ../src/richtext/richtextformatdlg.cpp:364
+#: ../src/richtext/richtextformatdlg.cpp:357
 msgid "List Style"
 msgstr "Styl listy"
 
-#: ../src/richtext/richtextstyles.cpp:1064
+#: ../src/richtext/richtextstyles.cpp:1061
 msgid "List styles"
 msgstr "Style listy"
 
@@ -4751,26 +4879,26 @@ msgstr "Wielkość czcionki listy w punktach."
 msgid "Lists the available fonts."
 msgstr "Lista dostępnych czcionek."
 
-#: ../src/common/fldlgcmn.cpp:340
+#: ../src/common/fldlgcmn.cpp:337
 #, c-format
 msgid "Load %s file"
 msgstr "Wczytaj plik %s"
 
-#: ../src/html/htmlwin.cpp:597
+#: ../src/html/htmlwin.cpp:600
 msgid "Loading : "
 msgstr "Wczytywanie : "
 
-#: ../src/unix/snglinst.cpp:246
+#: ../src/unix/snglinst.cpp:243
 #, c-format
 msgid "Lock file '%s' has incorrect owner."
 msgstr "Blokowany plik '%s' ma niewłaściwego właściciela."
 
-#: ../src/unix/snglinst.cpp:251
+#: ../src/unix/snglinst.cpp:248
 #, c-format
 msgid "Lock file '%s' has incorrect permissions."
 msgstr "Blokowany plik '%s' ma niewłaściwe uprawnienia."
 
-#: ../src/generic/logg.cpp:576
+#: ../src/generic/logg.cpp:573
 #, c-format
 msgid "Log saved to the file '%s'."
 msgstr "Log został zapisany do pliku '%s'."
@@ -4785,11 +4913,11 @@ msgstr "Małe litery"
 msgid "Lower case roman numerals"
 msgstr "Małe litery cyframi rzymskimi"
 
-#: ../src/gtk/mdi.cpp:422 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk1/mdi.cpp:431 ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "potomek MDI"
 
-#: ../src/msw/helpchm.cpp:56
+#: ../src/msw/helpchm.cpp:53
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -4797,189 +4925,189 @@ msgstr ""
 "Funkcje pomocy dla MS HTML Help nie są dostępne, ponieważ biblioteka MS HTML "
 "Help nie jest zainstalowana na tej maszynie. Zainstaluj ją."
 
-#: ../src/univ/themes/win32.cpp:3754
+#: ../src/univ/themes/win32.cpp:3751
 msgid "Ma&ximize"
 msgstr "&Maksymalizuj"
 
-#: ../src/common/fmapbase.cpp:203
+#: ../src/common/fmapbase.cpp:200
 msgid "MacArabic"
 msgstr "MacArabic"
 
-#: ../src/common/fmapbase.cpp:222
+#: ../src/common/fmapbase.cpp:219
 msgid "MacArmenian"
 msgstr "MacOrmiański"
 
-#: ../src/common/fmapbase.cpp:211
+#: ../src/common/fmapbase.cpp:208
 msgid "MacBengali"
 msgstr "MacBengalski"
 
-#: ../src/common/fmapbase.cpp:217
+#: ../src/common/fmapbase.cpp:214
 msgid "MacBurmese"
 msgstr "MacBirmański"
 
-#: ../src/common/fmapbase.cpp:236
+#: ../src/common/fmapbase.cpp:233
 msgid "MacCeltic"
 msgstr "MacCeltic"
 
-#: ../src/common/fmapbase.cpp:227
+#: ../src/common/fmapbase.cpp:224
 msgid "MacCentralEurRoman"
 msgstr "MacŚrodkowoEuroRzymski"
 
-#: ../src/common/fmapbase.cpp:223
+#: ../src/common/fmapbase.cpp:220
 msgid "MacChineseSimp"
 msgstr "MacChińskiUpr"
 
-#: ../src/common/fmapbase.cpp:201
+#: ../src/common/fmapbase.cpp:198
 msgid "MacChineseTrad"
 msgstr "MacChińskiTrad"
 
-#: ../src/common/fmapbase.cpp:233
+#: ../src/common/fmapbase.cpp:230
 msgid "MacCroatian"
 msgstr "MacChorwacki"
 
-#: ../src/common/fmapbase.cpp:206
+#: ../src/common/fmapbase.cpp:203
 msgid "MacCyrillic"
 msgstr "MacCyrylica"
 
-#: ../src/common/fmapbase.cpp:207
+#: ../src/common/fmapbase.cpp:204
 msgid "MacDevanagari"
 msgstr "MacDevanagari"
 
-#: ../src/common/fmapbase.cpp:231
+#: ../src/common/fmapbase.cpp:228
 msgid "MacDingbats"
 msgstr "MacDingbats"
 
-#: ../src/common/fmapbase.cpp:226
+#: ../src/common/fmapbase.cpp:223
 msgid "MacEthiopic"
 msgstr "MacEtiopski"
 
-#: ../src/common/fmapbase.cpp:229
+#: ../src/common/fmapbase.cpp:226
 msgid "MacExtArabic"
 msgstr "MacExtArabic"
 
-#: ../src/common/fmapbase.cpp:237
+#: ../src/common/fmapbase.cpp:234
 msgid "MacGaelic"
 msgstr "MacCeltycki"
 
-#: ../src/common/fmapbase.cpp:221
+#: ../src/common/fmapbase.cpp:218
 msgid "MacGeorgian"
 msgstr "MacGruziński"
 
-#: ../src/common/fmapbase.cpp:205
+#: ../src/common/fmapbase.cpp:202
 msgid "MacGreek"
 msgstr "MacGrecki"
 
-#: ../src/common/fmapbase.cpp:209
+#: ../src/common/fmapbase.cpp:206
 msgid "MacGujarati"
 msgstr "MacGudżarati"
 
-#: ../src/common/fmapbase.cpp:208
+#: ../src/common/fmapbase.cpp:205
 msgid "MacGurmukhi"
 msgstr "MacGurmukhi"
 
-#: ../src/common/fmapbase.cpp:204
+#: ../src/common/fmapbase.cpp:201
 msgid "MacHebrew"
 msgstr "MacHebrajski"
 
-#: ../src/common/fmapbase.cpp:234
+#: ../src/common/fmapbase.cpp:231
 msgid "MacIcelandic"
 msgstr "MacIslandzki"
 
-#: ../src/common/fmapbase.cpp:200
+#: ../src/common/fmapbase.cpp:197
 msgid "MacJapanese"
 msgstr "MacJapoński"
 
-#: ../src/common/fmapbase.cpp:214
+#: ../src/common/fmapbase.cpp:211
 msgid "MacKannada"
 msgstr "MacKannada"
 
-#: ../src/common/fmapbase.cpp:238
+#: ../src/common/fmapbase.cpp:235
 msgid "MacKeyboardGlyphs"
 msgstr "MacKeyboardGlyphs"
 
-#: ../src/common/fmapbase.cpp:218
+#: ../src/common/fmapbase.cpp:215
 msgid "MacKhmer"
 msgstr "MacKhmer"
 
-#: ../src/common/fmapbase.cpp:202
+#: ../src/common/fmapbase.cpp:199
 msgid "MacKorean"
 msgstr "MacKoreański"
 
-#: ../src/common/fmapbase.cpp:220
+#: ../src/common/fmapbase.cpp:217
 msgid "MacLaotian"
 msgstr "MacLaotian"
 
-#: ../src/common/fmapbase.cpp:215
+#: ../src/common/fmapbase.cpp:212
 msgid "MacMalayalam"
 msgstr "MacMalayalam"
 
-#: ../src/common/fmapbase.cpp:225
+#: ../src/common/fmapbase.cpp:222
 msgid "MacMongolian"
 msgstr "MacMongolski"
 
-#: ../src/common/fmapbase.cpp:210
+#: ../src/common/fmapbase.cpp:207
 msgid "MacOriya"
 msgstr "MacOriya"
 
-#: ../src/common/fmapbase.cpp:199
+#: ../src/common/fmapbase.cpp:196
 msgid "MacRoman"
 msgstr "MacRoman"
 
-#: ../src/common/fmapbase.cpp:235
+#: ../src/common/fmapbase.cpp:232
 msgid "MacRomanian"
 msgstr "MacRomanian"
 
-#: ../src/common/fmapbase.cpp:216
+#: ../src/common/fmapbase.cpp:213
 msgid "MacSinhalese"
 msgstr "MacSinhalese"
 
-#: ../src/common/fmapbase.cpp:230
+#: ../src/common/fmapbase.cpp:227
 msgid "MacSymbol"
 msgstr "MacSymbol"
 
-#: ../src/common/fmapbase.cpp:212
+#: ../src/common/fmapbase.cpp:209
 msgid "MacTamil"
 msgstr "MacTamilski"
 
-#: ../src/common/fmapbase.cpp:213
+#: ../src/common/fmapbase.cpp:210
 msgid "MacTelugu"
 msgstr "MacTelugu"
 
-#: ../src/common/fmapbase.cpp:219
+#: ../src/common/fmapbase.cpp:216
 msgid "MacThai"
 msgstr "MacTajski"
 
-#: ../src/common/fmapbase.cpp:224
+#: ../src/common/fmapbase.cpp:221
 msgid "MacTibetan"
 msgstr "MacTybetański"
 
-#: ../src/common/fmapbase.cpp:232
+#: ../src/common/fmapbase.cpp:229
 msgid "MacTurkish"
 msgstr "MacTurecki"
 
-#: ../src/common/fmapbase.cpp:228
+#: ../src/common/fmapbase.cpp:225
 msgid "MacVietnamese"
 msgstr "MacWietnamski"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1762
+#: ../src/propgrid/advprops.cpp:1663
 msgid "Magnifier"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:2143
+#: ../src/propgrid/advprops.cpp:2050
 msgid "Make a selection:"
 msgstr "Dokonaj wyboru:"
 
-#: ../src/richtext/richtextformatdlg.cpp:374
+#: ../src/richtext/richtextformatdlg.cpp:367
 #: ../src/richtext/richtextmarginspage.cpp:171
 msgid "Margins"
 msgstr "Marginesy"
 
-#: ../src/propgrid/advprops.cpp:1595
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Maroon"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:147
+#: ../src/generic/fdrepdlg.cpp:144
 msgid "Match case"
 msgstr "Uwzględniaj wielkość liter"
 
@@ -4991,40 +5119,40 @@ msgstr "Maksymalna wysokość:"
 msgid "Max width:"
 msgstr "Maksymalna szerokość:"
 
-#: ../src/unix/mediactrl.cpp:947
+#: ../src/unix/mediactrl.cpp:972
 #, c-format
 msgid "Media playback error: %s"
 msgstr "Błąd odtwarzania mediów: %s"
 
-#: ../src/common/fs_mem.cpp:175
+#: ../src/common/fs_mem.cpp:170
 #, c-format
 msgid "Memory VFS already contains file '%s'!"
 msgstr "Pamięć VFS już zawiera plik '%s'!"
 
 #. TRANSLATORS: Name of keyboard key
 #. TRANSLATORS: Keyword of system colour
-#: ../src/common/accelcmn.cpp:73 ../src/propgrid/advprops.cpp:889
+#: ../src/common/accelcmn.cpp:70 ../src/propgrid/advprops.cpp:790
 msgid "Menu"
 msgstr "Menu"
 
-#: ../src/common/msgout.cpp:124
+#: ../src/common/msgout.cpp:121
 msgid "Message"
 msgstr "Komunikat"
 
-#: ../src/univ/themes/metal.cpp:168
+#: ../src/univ/themes/metal.cpp:165
 msgid "Metal theme"
 msgstr "Kompozycja metalowa"
 
-#: ../src/msw/ole/automtn.cpp:652
+#: ../src/msw/ole/automtn.cpp:643
 msgid "Method or property not found."
 msgstr "Nie odnaleziono metody lub właściwości."
 
-#: ../src/univ/themes/win32.cpp:3752
+#: ../src/univ/themes/win32.cpp:3749
 msgid "Mi&nimize"
 msgstr "Mi&nimalizuj"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1763
+#: ../src/propgrid/advprops.cpp:1664
 msgid "Middle Button"
 msgstr ""
 
@@ -5036,37 +5164,42 @@ msgstr "Minimalna wysokość:"
 msgid "Min width:"
 msgstr "Min szerokość:"
 
-#: ../src/msw/ole/automtn.cpp:668
+#: ../src/osx/cocoa/menu.mm:281
+#, fuzzy
+msgid "Minimize"
+msgstr "Mi&nimalizuj"
+
+#: ../src/msw/ole/automtn.cpp:659
 msgid "Missing a required parameter."
 msgstr "Brak wymaganego parametru."
 
-#: ../src/generic/fontdlgg.cpp:324
+#: ../src/generic/fontdlgg.cpp:320
 msgid "Modern"
 msgstr "Modern"
 
-#: ../src/generic/filectrlg.cpp:427
+#: ../src/generic/filectrlg.cpp:423
 msgid "Modified"
 msgstr "Zmodyfikowany"
 
-#: ../src/common/module.cpp:133
+#: ../src/common/module.cpp:130
 #, c-format
 msgid "Module \"%s\" initialization failed"
 msgstr "Inicjalizacja modułu \"%s\" nie powiodła się"
 
-#: ../src/common/paper.cpp:131
+#: ../src/common/paper.cpp:128
 msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
 msgstr "Koperta Monarch, 3 7/8 x 7 1/2 cala"
 
-#: ../src/msw/fswatcher.cpp:143
+#: ../src/msw/fswatcher.cpp:140
 msgid "Monitoring individual files for changes is not supported currently."
 msgstr ""
 "Monitorowanie zmian pojedynczych plików nie jest aktualnie obsługiwane."
 
-#: ../src/generic/editlbox.cpp:172
+#: ../src/generic/editlbox.cpp:160
 msgid "Move down"
 msgstr "Przenieś w dół"
 
-#: ../src/generic/editlbox.cpp:171
+#: ../src/generic/editlbox.cpp:155
 msgid "Move up"
 msgstr "Przenieś w górę"
 
@@ -5080,98 +5213,103 @@ msgstr "Przenosi obiekt do następnego akapitu."
 msgid "Moves the object to the previous paragraph."
 msgstr "Przenosi obiekt do poprzedniego paragrafu."
 
-#: ../src/richtext/richtextbuffer.cpp:9966
+#: ../src/richtext/richtextbuffer.cpp:9963
 msgid "Multiple Cell Properties"
 msgstr "Właściwości wielu komórek"
 
-#: ../src/generic/filectrlg.cpp:424
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:82
+msgid "Multiply"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:420
 msgid "Name"
 msgstr "Nazwa"
 
-#: ../src/propgrid/advprops.cpp:1596
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Navy"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "Network"
 msgstr "Sieć"
 
-#: ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173
 msgid "New"
 msgstr "Nowy"
 
-#: ../src/richtext/richtextstyledlg.cpp:243
+#: ../src/richtext/richtextstyledlg.cpp:239
 msgid "New &Box Style..."
 msgstr "Nowy styl &bloku..."
 
-#: ../src/richtext/richtextstyledlg.cpp:225
+#: ../src/richtext/richtextstyledlg.cpp:221
 msgid "New &Character Style..."
 msgstr "Nowy styl &znaku..."
 
-#: ../src/richtext/richtextstyledlg.cpp:237
+#: ../src/richtext/richtextstyledlg.cpp:233
 msgid "New &List Style..."
 msgstr "Nowy styl &listy..."
 
-#: ../src/richtext/richtextstyledlg.cpp:231
+#: ../src/richtext/richtextstyledlg.cpp:227
 msgid "New &Paragraph Style..."
 msgstr "Nowy styl &paragrafu..."
 
-#: ../src/richtext/richtextstyledlg.cpp:606
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:654
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:820
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:893
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:934
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:602
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:650
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:816
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:889
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:930
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "New Style"
 msgstr "Nowy styl"
 
-#: ../src/generic/editlbox.cpp:169
+#: ../src/generic/editlbox.cpp:139
 msgid "New item"
 msgstr "Nowa pozycja"
 
 # To jest maska do tworzenia nazw typu NowaNaz1 itd
-#: ../src/generic/dirdlgg.cpp:297 ../src/generic/dirdlgg.cpp:307
-#: ../src/generic/filectrlg.cpp:618 ../src/generic/filectrlg.cpp:627
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+#: ../src/generic/dirdlgg.cpp:294 ../src/generic/dirdlgg.cpp:304
 msgid "NewName"
 msgstr "NowaNaz"
 
-#: ../src/common/prntbase.cpp:1567 ../src/html/helpwnd.cpp:665
+#: ../src/common/prntbase.cpp:1592 ../src/html/helpwnd.cpp:663
 msgid "Next page"
 msgstr "Następna strona"
 
-#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:177
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:174
 #: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Nie"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1764
+#: ../src/propgrid/advprops.cpp:1665
 msgid "No Entry"
 msgstr ""
 
-#: ../src/generic/animateg.cpp:150
+#: ../src/generic/animateg.cpp:133
 #, c-format
 msgid "No animation handler for type %ld defined."
 msgstr "Brak procedury obsługi animacji dla typu %ld."
 
-#: ../src/dfb/bitmap.cpp:642 ../src/dfb/bitmap.cpp:676
+#: ../src/dfb/bitmap.cpp:639 ../src/dfb/bitmap.cpp:673
 #, c-format
 msgid "No bitmap handler for type %d defined."
 msgstr "Brak procedury obsługi bitmapy dla typu %d."
 
-#: ../src/common/utilscmn.cpp:1077
+#: ../src/common/utilscmn.cpp:1095
 msgid "No default application configured for HTML files."
 msgstr "Nie ma ustawionej domyślnej aplikacji dla plików HTML."
 
-#: ../src/generic/helpext.cpp:445
+#: ../src/generic/helpext.cpp:443
 msgid "No entries found."
 msgstr "Nie znaleziono pozycji."
 
-#: ../src/common/fontmap.cpp:421
+#: ../src/common/fontmap.cpp:418
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found,\n"
@@ -5183,7 +5321,7 @@ msgstr ""
 "jednak dostępne jest alternatywne kodowanie '%s'.\n"
 "Chesz użyć tego kodowania (możesz także wybrać inne)?"
 
-#: ../src/common/fontmap.cpp:426
+#: ../src/common/fontmap.cpp:423
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found.\n"
@@ -5194,206 +5332,206 @@ msgstr ""
 "Chcesz wskazać czcionkę do użycia\n"
 "(inaczej tekst może nie być wyświetlony poprawnie)?"
 
-#: ../src/generic/animateg.cpp:142
+#: ../src/generic/animateg.cpp:125
 msgid "No handler found for animation type."
 msgstr "Brak procedury obsługi typu animacji."
 
-#: ../src/common/image.cpp:2728
+#: ../src/common/image.cpp:2823
 msgid "No handler found for image type."
 msgstr "Brak procedury obsługi grafiki."
 
-#: ../src/common/image.cpp:2736 ../src/common/image.cpp:2848
-#: ../src/common/image.cpp:2901
+#: ../src/common/image.cpp:2831 ../src/common/image.cpp:2954
+#: ../src/common/image.cpp:3020
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "Brak procedury obsługi obrazów typu %d."
 
-#: ../src/common/image.cpp:2871 ../src/common/image.cpp:2915
+#: ../src/common/image.cpp:2986 ../src/common/image.cpp:3034
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "Brak procedury obsługi obrazów typu %s."
 
-#: ../src/html/helpwnd.cpp:858
+#: ../src/html/helpwnd.cpp:856
 msgid "No matching page found yet"
 msgstr "Jeszcze nie znaleziono pasującej strony"
 
-#: ../src/unix/sound.cpp:81
+#: ../src/unix/sound.cpp:78
 msgid "No sound"
 msgstr "Brak dźwięku"
 
-#: ../src/common/image.cpp:2277 ../src/common/image.cpp:2318
+#: ../src/common/image.cpp:2371 ../src/common/image.cpp:2412
 msgid "No unused colour in image being masked."
 msgstr "Brak nieużywanych kolorów w maskowanym obrazie."
 
-#: ../src/common/image.cpp:3374
-msgid "No unused colour in image."
-msgstr "Brak wolnych kolorów w obrazie."
-
-#: ../src/generic/helpext.cpp:302
+#: ../src/generic/helpext.cpp:300
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "Znaleziono nie ważne mapowania w pliku \"%s\"."
 
-#: ../src/richtext/richtextborderspage.cpp:610
 #: ../src/richtext/richtextsizepage.cpp:248
 #: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:610
 msgid "None"
 msgstr "(Brak)"
 
-#: ../src/common/fmapbase.cpp:157
+#: ../src/common/fmapbase.cpp:154
 msgid "Nordic (ISO-8859-10)"
 msgstr "Nordycki (ISO-8859-10)"
 
-#: ../src/generic/fontdlgg.cpp:328 ../src/generic/fontdlgg.cpp:331
+#: ../src/generic/fontdlgg.cpp:324 ../src/generic/fontdlgg.cpp:327
 msgid "Normal"
 msgstr "Normalny"
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1261
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Zwykły tekst<br>i <u>podkreślony</u>. "
 
-#: ../src/html/helpwnd.cpp:1205
+#: ../src/html/helpwnd.cpp:1203
 msgid "Normal font:"
 msgstr "Normalna czcionka:"
 
-#: ../src/propgrid/props.cpp:1128
+#: ../src/propgrid/props.cpp:1115
 #, c-format
 msgid "Not %s"
 msgstr "Nie %s"
 
-#: ../include/wx/filename.h:573 ../include/wx/filename.h:578
-msgid "Not available"
-msgstr "Niedostępne"
+#: ../src/common/secretstore.cpp:168
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/webrequest.cpp:605
+msgid "Not enough free disk space for download."
+msgstr ""
 
 #: ../src/richtext/richtextfontpage.cpp:358
 msgid "Not underlined"
 msgstr "Nie podkreślony"
 
-#: ../src/common/paper.cpp:115
+#: ../src/common/paper.cpp:112
 msgid "Note, 8 1/2 x 11 in"
 msgstr "Note, 8 1/2 x 11 cali"
 
-#: ../src/generic/notifmsgg.cpp:132
+#: ../src/generic/notifmsgg.cpp:129
 msgid "Notice"
 msgstr "Uwaga"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "Num *"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "Num +"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "Num ,"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "Num -"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "Num ."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "Num /"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "Num ="
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "Num Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 #, fuzzy
 msgid "Num Delete"
 msgstr "Usuń"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 #, fuzzy
 msgid "Num Down"
 msgstr "W dół"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "Num End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "Num Enter"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 #, fuzzy
 msgid "Num Home"
 msgstr "Katalog początkowy"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 #, fuzzy
 msgid "Num Insert"
 msgstr "Wstawić"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num Lock"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "Num Page Down"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "Num Page Up"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 #, fuzzy
 msgid "Num Right"
 msgstr "Prawy"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "Num Space"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "Num Tab"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "Num Up"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "Num left"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num_lock"
 msgstr ""
 
@@ -5402,13 +5540,13 @@ msgstr ""
 msgid "Numbered outline"
 msgstr "Numerowane kontury"
 
-#: ../include/wx/msgdlg.h:278 ../src/richtext/richtextstyledlg.cpp:297
-#: ../src/common/stockitem.cpp:178 ../src/msw/msgdlg.cpp:454
-#: ../src/msw/msgdlg.cpp:747 ../src/gtk1/fontdlg.cpp:138
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:175
+#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/msgdlg.cpp:741 ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "OK"
 
-#: ../src/msw/ole/automtn.cpp:692
+#: ../src/msw/ole/automtn.cpp:683
 #, c-format
 msgid "OLE Automation error in %s: %s"
 msgstr "Błąd automatyzacji OLE w %s: %s"
@@ -5417,15 +5555,15 @@ msgstr "Błąd automatyzacji OLE w %s: %s"
 msgid "Object Properties"
 msgstr "&Właściwości obiektu"
 
-#: ../src/msw/ole/automtn.cpp:660
+#: ../src/msw/ole/automtn.cpp:651
 msgid "Object implementation does not support named arguments."
 msgstr "Implementacja obiektu nie obsługuje nazywanych argumentów."
 
-#: ../src/common/xtixml.cpp:264
+#: ../src/common/xtixml.cpp:260
 msgid "Objects must have an id attribute"
 msgstr "Obiekty muszą posiadać właściwość typu 'id'"
 
-#: ../src/propgrid/advprops.cpp:1601
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Olive"
 msgstr ""
 
@@ -5433,64 +5571,69 @@ msgstr ""
 msgid "Opaci&ty:"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:354
+#: ../src/generic/colrdlgg.cpp:374
 msgid "Opacity:"
 msgstr ""
 
-#: ../src/common/docview.cpp:1773 ../src/common/docview.cpp:1815
+#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
 msgid "Open File"
 msgstr "Otwieranie Pliku"
 
-#: ../src/html/helpwnd.cpp:671 ../src/html/helpwnd.cpp:1554
+#: ../src/html/helpwnd.cpp:669 ../src/html/helpwnd.cpp:1552
 msgid "Open HTML document"
 msgstr "Otwórz dokument HTML"
 
-#: ../src/generic/dbgrptg.cpp:163
+#: ../src/common/stockitem.cpp:265
+#, fuzzy
+msgid "Open an existing document"
+msgstr "Otwórz dokument HTML"
+
+#: ../src/generic/dbgrptg.cpp:160
 #, c-format
 msgid "Open file \"%s\""
 msgstr "Otwieranie pliku \"%s\""
 
-#: ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176
 msgid "Open..."
 msgstr "Otwórz..."
 
-#: ../src/unix/glx11.cpp:506 ../src/msw/glcanvas.cpp:592
+#: ../src/msw/glcanvas.cpp:607 ../src/unix/glx11.cpp:513
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr ""
 
-#: ../src/generic/dirctrlg.cpp:599 ../src/generic/dirdlgg.cpp:323
-#: ../src/generic/filectrlg.cpp:642 ../src/generic/filectrlg.cpp:786
+#: ../src/generic/dirctrlg.cpp:565 ../src/generic/filectrlg.cpp:638
+#: ../src/generic/filectrlg.cpp:782 ../src/generic/dirdlgg.cpp:320
 msgid "Operation not permitted."
 msgstr "Operacja nie jest dozwolona."
 
-#: ../src/common/cmdline.cpp:900
+#: ../src/common/cmdline.cpp:896
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "Opcja '%s' nie może zostać zanegowana"
 
-#: ../src/common/cmdline.cpp:1064
+#: ../src/common/cmdline.cpp:1060
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "Opcja '%s' wymaga podania wartości."
 
-#: ../src/common/cmdline.cpp:1147
+#: ../src/common/cmdline.cpp:1143
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Opcja '%s': nie można przekształcić '%s' na datę."
 
-#: ../src/generic/prntdlgg.cpp:618
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Opcje"
 
-#: ../src/propgrid/advprops.cpp:1606
+#: ../src/propgrid/advprops.cpp:1512
 msgid "Orange"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:615 ../src/generic/prntdlgg.cpp:869
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:862
 msgid "Orientation"
 msgstr "Orientacja"
 
-#: ../src/common/windowid.cpp:242
+#: ../src/common/windowid.cpp:237
 msgid "Out of window IDs.  Recommend shutting down application."
 msgstr "Po za identyfikatorami okna. Zalecane jest zamknięcie aplikacji."
 
@@ -5503,148 +5646,148 @@ msgstr "kontur"
 msgid "Outset"
 msgstr "Otoczenie"
 
-#: ../src/msw/ole/automtn.cpp:656
+#: ../src/msw/ole/automtn.cpp:647
 msgid "Overflow while coercing argument values."
 msgstr "Przepełnienie podczas wymuszania wartości argumentów."
 
-#: ../src/common/imagpcx.cpp:457 ../src/common/imagpcx.cpp:480
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:479
 msgid "PCX: couldn't allocate memory"
 msgstr "PCX: Nie można przydzielić pamięci."
 
-#: ../src/common/imagpcx.cpp:456
+#: ../src/common/imagpcx.cpp:455
 msgid "PCX: image format unsupported"
 msgstr "PCX: nieobsługiwany format obrazu."
 
-#: ../src/common/imagpcx.cpp:479
+#: ../src/common/imagpcx.cpp:478
 msgid "PCX: invalid image"
 msgstr "PCX: nieprawidłowy obraz"
 
-#: ../src/common/imagpcx.cpp:442
+#: ../src/common/imagpcx.cpp:441
 msgid "PCX: this is not a PCX file."
 msgstr "PCX: To nie jest plik w formacie PCX."
 
-#: ../src/common/imagpcx.cpp:459 ../src/common/imagpcx.cpp:481
+#: ../src/common/imagpcx.cpp:458 ../src/common/imagpcx.cpp:480
 msgid "PCX: unknown error !!!"
 msgstr "PCX: nieznany błąd !!!"
 
-#: ../src/common/imagpcx.cpp:458
+#: ../src/common/imagpcx.cpp:457
 msgid "PCX: version number too low"
 msgstr "PCX: zbyt niski numer wersji."
 
-#: ../src/common/imagpnm.cpp:91
+#: ../src/common/imagpnm.cpp:89
 msgid "PNM: Couldn't allocate memory."
 msgstr "PNM: Nie można przydzielić pamięci."
 
-#: ../src/common/imagpnm.cpp:73
+#: ../src/common/imagpnm.cpp:71
 msgid "PNM: File format is not recognized."
 msgstr "PNM: Nieznany format pliku."
 
-#: ../src/common/imagpnm.cpp:112 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
 #: ../src/common/imagpnm.cpp:156
 msgid "PNM: File seems truncated."
 msgstr "PNM: Plik wygląda na obcięty."
 
-#: ../src/common/paper.cpp:187
+#: ../src/common/paper.cpp:184
 msgid "PRC 16K 146 x 215 mm"
 msgstr "PRC 16K 146 x 215 mm"
 
-#: ../src/common/paper.cpp:200
+#: ../src/common/paper.cpp:197
 msgid "PRC 16K Rotated"
 msgstr "PRC 16K Obrócony"
 
-#: ../src/common/paper.cpp:188
+#: ../src/common/paper.cpp:185
 msgid "PRC 32K 97 x 151 mm"
 msgstr "PRC 32K 97 x 151 mm"
 
-#: ../src/common/paper.cpp:201
+#: ../src/common/paper.cpp:198
 msgid "PRC 32K Rotated"
 msgstr "PRC 32K Obrócony"
 
-#: ../src/common/paper.cpp:189
+#: ../src/common/paper.cpp:186
 msgid "PRC 32K(Big) 97 x 151 mm"
 msgstr "PRC 32K(Big) 97 x 151 mm"
 
-#: ../src/common/paper.cpp:202
+#: ../src/common/paper.cpp:199
 msgid "PRC 32K(Big) Rotated"
 msgstr "PRC 32K(Big) Obrócony"
 
-#: ../src/common/paper.cpp:190
+#: ../src/common/paper.cpp:187
 msgid "PRC Envelope #1 102 x 165 mm"
 msgstr "Koperta PRC #1, 102 x 165 mm"
 
-#: ../src/common/paper.cpp:203
+#: ../src/common/paper.cpp:200
 msgid "PRC Envelope #1 Rotated 165 x 102 mm"
 msgstr "Koperta PRC #1 Obrócona, 165 x 102 mm"
 
-#: ../src/common/paper.cpp:199
+#: ../src/common/paper.cpp:196
 msgid "PRC Envelope #10 324 x 458 mm"
 msgstr "Koperta PRC #10 324 x 458 mm"
 
-#: ../src/common/paper.cpp:212
+#: ../src/common/paper.cpp:209
 msgid "PRC Envelope #10 Rotated 458 x 324 mm"
 msgstr "Koperta PRC #10 Obrócona 458 x 324 mm"
 
-#: ../src/common/paper.cpp:191
+#: ../src/common/paper.cpp:188
 msgid "PRC Envelope #2 102 x 176 mm"
 msgstr "Koperta PRC #2 102 x 176 mm"
 
-#: ../src/common/paper.cpp:204
+#: ../src/common/paper.cpp:201
 msgid "PRC Envelope #2 Rotated 176 x 102 mm"
 msgstr "Koperta PRC #2 Obrócona 176 x 102 mm"
 
-#: ../src/common/paper.cpp:192
+#: ../src/common/paper.cpp:189
 msgid "PRC Envelope #3 125 x 176 mm"
 msgstr "Koperta PRC #3 125 x 176 mm"
 
-#: ../src/common/paper.cpp:205
+#: ../src/common/paper.cpp:202
 msgid "PRC Envelope #3 Rotated 176 x 125 mm"
 msgstr "Koperta PRC #3 Obrócona 176 x 125 mm"
 
-#: ../src/common/paper.cpp:193
+#: ../src/common/paper.cpp:190
 msgid "PRC Envelope #4 110 x 208 mm"
 msgstr "Koperta PRC #4 110 x 208 mm"
 
-#: ../src/common/paper.cpp:206
+#: ../src/common/paper.cpp:203
 msgid "PRC Envelope #4 Rotated 208 x 110 mm"
 msgstr "Koperta PRC #4 Obrócona 208 x 110 mm"
 
-#: ../src/common/paper.cpp:194
+#: ../src/common/paper.cpp:191
 msgid "PRC Envelope #5 110 x 220 mm"
 msgstr "Koperta PRC #5 110 x 220 mm"
 
-#: ../src/common/paper.cpp:207
+#: ../src/common/paper.cpp:204
 msgid "PRC Envelope #5 Rotated 220 x 110 mm"
 msgstr "Koperta PRC #5 Obrócona 220 x 110 mm"
 
-#: ../src/common/paper.cpp:195
+#: ../src/common/paper.cpp:192
 msgid "PRC Envelope #6 120 x 230 mm"
 msgstr "Koperta PRC #6 120 x 230 mm"
 
-#: ../src/common/paper.cpp:208
+#: ../src/common/paper.cpp:205
 msgid "PRC Envelope #6 Rotated 230 x 120 mm"
 msgstr "Koperta PRC #6 Obrócona 230 x 120 mm"
 
-#: ../src/common/paper.cpp:196
+#: ../src/common/paper.cpp:193
 msgid "PRC Envelope #7 160 x 230 mm"
 msgstr "Koperta PRC #7 160 x 230 mm"
 
-#: ../src/common/paper.cpp:209
+#: ../src/common/paper.cpp:206
 msgid "PRC Envelope #7 Rotated 230 x 160 mm"
 msgstr "Koperta PRC #7 Obrócona 230 x 160 mm"
 
-#: ../src/common/paper.cpp:197
+#: ../src/common/paper.cpp:194
 msgid "PRC Envelope #8 120 x 309 mm"
 msgstr "Koperta PRC #8 120 x 309 mm"
 
-#: ../src/common/paper.cpp:210
+#: ../src/common/paper.cpp:207
 msgid "PRC Envelope #8 Rotated 309 x 120 mm"
 msgstr "Koperta PRC #8 Obrócona 309 x 120 mm"
 
-#: ../src/common/paper.cpp:198
+#: ../src/common/paper.cpp:195
 msgid "PRC Envelope #9 229 x 324 mm"
 msgstr "Koperta PRC #9 229 x 324 mm"
 
-#: ../src/common/paper.cpp:211
+#: ../src/common/paper.cpp:208
 msgid "PRC Envelope #9 Rotated 324 x 229 mm"
 msgstr "Koperta PRC #9 Obrócona 324 x 229 mm"
 
@@ -5652,91 +5795,95 @@ msgstr "Koperta PRC #9 Obrócona 324 x 229 mm"
 msgid "Padding"
 msgstr "Dopełnienie"
 
-#: ../src/common/prntbase.cpp:2074
+#: ../src/common/prntbase.cpp:2096
 #, c-format
 msgid "Page %d"
 msgstr "Strona %d"
 
-#: ../src/common/prntbase.cpp:2072
+#: ../src/common/prntbase.cpp:2094
 #, c-format
 msgid "Page %d of %d"
 msgstr "Strona %d z %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 #, fuzzy
 msgid "Page Down"
 msgstr "Strona %d"
 
-#: ../src/gtk/print.cpp:826
+#: ../src/gtk/print.cpp:829
 msgid "Page Setup"
 msgstr "Ustawienia strony"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 #, fuzzy
 msgid "Page Up"
 msgstr "Strona %d"
 
-#: ../src/generic/prntdlgg.cpp:828 ../src/common/prntbase.cpp:484
+#: ../src/common/prntbase.cpp:479 ../src/generic/prntdlgg.cpp:821
 msgid "Page setup"
 msgstr "Ustawienia strony"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 #, fuzzy
 msgid "PageDown"
 msgstr "W dół"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 #, fuzzy
 msgid "PageUp"
 msgstr "Strony"
 
-#: ../src/generic/prntdlgg.cpp:216
+#: ../src/generic/prntdlgg.cpp:209
 msgid "Pages"
 msgstr "Strony"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1765
+#: ../src/propgrid/advprops.cpp:1666
 msgid "Paint Brush"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:602 ../src/generic/prntdlgg.cpp:801
-#: ../src/generic/prntdlgg.cpp:842 ../src/generic/prntdlgg.cpp:855
-#: ../src/generic/prntdlgg.cpp:1052 ../src/generic/prntdlgg.cpp:1057
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:794
+#: ../src/generic/prntdlgg.cpp:835 ../src/generic/prntdlgg.cpp:848
+#: ../src/generic/prntdlgg.cpp:1045 ../src/generic/prntdlgg.cpp:1050
 msgid "Paper size"
 msgstr "Rozmiar papieru"
 
-#: ../src/richtext/richtextstyles.cpp:1062
+#: ../src/richtext/richtextstyles.cpp:1059
 msgid "Paragraph styles"
 msgstr "Style paragrafu"
 
-#: ../src/common/xtistrm.cpp:465
+#: ../src/common/xtistrm.cpp:462
 msgid "Passing a already registered object to SetObject"
 msgstr "Przekazano już zarejestrowany obiekt do funkcji SetObject"
 
-#: ../src/common/xtistrm.cpp:476
+#: ../src/common/xtistrm.cpp:473
 msgid "Passing an unknown object to GetObject"
 msgstr "Przekazanie nieznanego obiektu do funkcji GetObject"
 
-#: ../src/richtext/richtextctrl.cpp:3513 ../src/common/stockitem.cpp:180
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:177 ../src/richtext/richtextctrl.cpp:3514
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Wklej"
 
-#: ../src/common/stockitem.cpp:262
+#: ../src/common/stockitem.cpp:260
 msgid "Paste selection"
 msgstr "Wklej wybór"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:74
+#: ../src/common/accelcmn.cpp:71
 msgid "Pause"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1766
+#: ../src/propgrid/advprops.cpp:1667
 msgid "Pencil"
 msgstr ""
 
@@ -5746,21 +5893,21 @@ msgid "Peri&od"
 msgstr "&Okres"
 
 # prawa?
-#: ../src/generic/filectrlg.cpp:430
+#: ../src/generic/filectrlg.cpp:426
 msgid "Permissions"
 msgstr "Uprawnienia"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:60
+#: ../src/common/accelcmn.cpp:57
 msgid "PgDn"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:59
+#: ../src/common/accelcmn.cpp:56
 msgid "PgUp"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:12868
+#: ../src/richtext/richtextbuffer.cpp:12863
 msgid "Picture Properties"
 msgstr "&Właściwości obrazu"
 
@@ -5772,44 +5919,44 @@ msgstr "Nie udało się utworzyć potoku."
 msgid "Please choose a valid font."
 msgstr "Proszę wybrać poprawną czcionkę."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
 msgid "Please choose an existing file."
 msgstr "Proszę wybrać istniejący plik."
 
-#: ../src/html/helpwnd.cpp:800
+#: ../src/html/helpwnd.cpp:798
 msgid "Please choose the page to display:"
 msgstr "Wybierz stronę do wyświetlenia:"
 
-#: ../src/msw/dialup.cpp:764
+#: ../src/msw/dialup.cpp:758
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Wybierz ISP, z którym chcesz się połączyć"
 
-#: ../src/common/headerctrlcmn.cpp:59
+#: ../src/common/headerctrlcmn.cpp:57
 msgid "Please select the columns to show and define their order:"
 msgstr "Proszę wybrać kolumny do pokazania i określić ich kolejność:"
 
-#: ../src/common/prntbase.cpp:538
+#: ../src/common/prntbase.cpp:533
 msgid "Please wait while printing..."
 msgstr "Proszę czekać, trwa drukowanie..."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1767
+#: ../src/propgrid/advprops.cpp:1668
 #, fuzzy
 msgid "Point Left"
 msgstr "&Rozmiar punktu:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1768
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgid "Point Right"
 msgstr "Wyrównanie do prawej"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:662
+#: ../src/propgrid/advprops.cpp:572
 msgid "Point Size"
 msgstr "&Rozmiar punktu:"
 
-#: ../src/generic/prntdlgg.cpp:612 ../src/generic/prntdlgg.cpp:867
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:860
 msgid "Portrait"
 msgstr "Portret"
 
@@ -5817,150 +5964,160 @@ msgstr "Portret"
 msgid "Position"
 msgstr "PozycjaPytanie"
 
-#: ../src/generic/prntdlgg.cpp:298
+#: ../src/generic/prntdlgg.cpp:291
 msgid "PostScript file"
 msgstr "plik PostScript"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178 ../src/osx/cocoa/preferences.mm:303
 msgid "Preferences"
 msgstr "Preferencje"
 
-#: ../src/osx/menu_osx.cpp:568
+#: ../src/osx/menu_osx.cpp:460
 msgid "Preferences..."
 msgstr "&Preferencje..."
 
-#: ../src/common/prntbase.cpp:546
+#: ../src/common/prntbase.cpp:541
 msgid "Preparing"
 msgstr "Przygotowywanie"
 
-#: ../src/generic/fontdlgg.cpp:455 ../src/osx/carbon/fontdlg.cpp:390
-#: ../src/html/helpwnd.cpp:1222
+#: ../src/osx/carbon/fontdlg.cpp:387 ../src/generic/fontdlgg.cpp:452
+#: ../src/html/helpwnd.cpp:1220
 msgid "Preview:"
 msgstr "Podgląd:"
 
-#: ../src/common/prntbase.cpp:1553 ../src/html/helpwnd.cpp:664
+#: ../src/common/prntbase.cpp:1578 ../src/html/helpwnd.cpp:662
 msgid "Previous page"
 msgstr "Poprzednia strona"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/prntdlgg.cpp:143 ../src/generic/prntdlgg.cpp:157
-#: ../src/common/prntbase.cpp:426 ../src/common/prntbase.cpp:1541
-#: ../src/common/accelcmn.cpp:77 ../src/gtk/print.cpp:620
-#: ../src/gtk/print.cpp:638
+#: ../src/common/prntbase.cpp:421 ../src/common/prntbase.cpp:1566
+#: ../src/common/accelcmn.cpp:74 ../src/generic/prntdlgg.cpp:136
+#: ../src/generic/prntdlgg.cpp:150 ../src/gtk/print.cpp:616
+#: ../src/gtk/print.cpp:634
 msgid "Print"
 msgstr "Drukuj"
 
-#: ../include/wx/prntbase.h:399 ../src/common/docview.cpp:1268
+#: ../src/common/docview.cpp:1262
 msgid "Print Preview"
 msgstr "Podgląd wydruku"
 
-#: ../src/common/prntbase.cpp:2015 ../src/common/prntbase.cpp:2057
-#: ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2037 ../src/common/prntbase.cpp:2079
+#: ../src/common/prntbase.cpp:2087
 msgid "Print Preview Failure"
 msgstr "Awaria podglądu wydruku"
 
-#: ../src/generic/prntdlgg.cpp:224
+#: ../src/generic/prntdlgg.cpp:217
 msgid "Print Range"
 msgstr "Zakres wydruku"
 
-#: ../src/generic/prntdlgg.cpp:449
+#: ../src/generic/prntdlgg.cpp:442
 msgid "Print Setup"
 msgstr "Ustawienia wydruku"
 
-#: ../src/generic/prntdlgg.cpp:621
+#: ../src/generic/prntdlgg.cpp:614
 msgid "Print in colour"
 msgstr "Wydruk w kolorze"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/osx/webview_webkit.mm:260
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "Opis kolumny nie może być zainicjowany."
+
+#: ../src/common/stockitem.cpp:179
 msgid "Print previe&w..."
 msgstr "Podgląd &wydruku..."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1256
 msgid "Print preview creation failed."
 msgstr "Nie udało się utworzyć podglądu wydruku."
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/common/stockitem.cpp:179
 msgid "Print preview..."
 msgstr "Podgląd wydruku..."
 
-#: ../src/generic/prntdlgg.cpp:630
+#: ../src/generic/prntdlgg.cpp:623
 msgid "Print spooling"
 msgstr "Kolejkowanie wydruków"
 
-#: ../src/html/helpwnd.cpp:675
+#: ../src/html/helpwnd.cpp:673
 msgid "Print this page"
 msgstr "Drukuj stronę"
 
-#: ../src/generic/prntdlgg.cpp:185
+#: ../src/generic/prntdlgg.cpp:178
 msgid "Print to File"
 msgstr "Drukuj do pliku"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "Print..."
 msgstr "Drukuj..."
 
-#: ../src/generic/prntdlgg.cpp:493
+#: ../src/generic/prntdlgg.cpp:486
 msgid "Printer"
 msgstr "Drukarka"
 
-#: ../src/generic/prntdlgg.cpp:633
+#: ../src/generic/prntdlgg.cpp:626
 msgid "Printer command:"
 msgstr "Polecenie drukarki:"
 
-#: ../src/generic/prntdlgg.cpp:180
+#: ../src/generic/prntdlgg.cpp:173
 msgid "Printer options"
 msgstr "Opcje drukarki"
 
-#: ../src/generic/prntdlgg.cpp:645
+#: ../src/generic/prntdlgg.cpp:638
 msgid "Printer options:"
 msgstr "Opcje drukarki:"
 
-#: ../src/generic/prntdlgg.cpp:916
+#: ../src/generic/prntdlgg.cpp:909
 msgid "Printer..."
 msgstr "Drukarka..."
 
-#: ../src/generic/prntdlgg.cpp:196
+#: ../src/generic/prntdlgg.cpp:189
 msgid "Printer:"
 msgstr "Drukarka:"
 
-#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:535
-#: ../src/html/htmprint.cpp:277
+#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:530
+#: ../src/html/htmprint.cpp:289
 msgid "Printing"
 msgstr "Drukowanie"
 
-#: ../src/common/prntbase.cpp:612
+#: ../src/common/prntbase.cpp:607
 msgid "Printing "
 msgstr "Drukowanie "
 
-#: ../src/common/prntbase.cpp:347
+#: ../src/common/prntbase.cpp:342
 msgid "Printing Error"
 msgstr "Błąd wydruku"
 
-#: ../src/common/prntbase.cpp:565
+#: ../src/osx/webview_webkit.mm:251
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "Format Gzip nie jest wspierany przez tę wersję biblioteki zlib"
+
+#: ../src/common/prntbase.cpp:560
 #, fuzzy, c-format
 msgid "Printing page %d"
 msgstr "Drukowanie strony %d..."
 
-#: ../src/common/prntbase.cpp:570
+#: ../src/common/prntbase.cpp:565
 #, c-format
 msgid "Printing page %d of %d"
 msgstr "Drukowanie strony %d z %d"
 
-#: ../src/generic/printps.cpp:201
+#: ../src/generic/printps.cpp:182
 #, c-format
 msgid "Printing page %d..."
 msgstr "Drukowanie strony %d..."
 
-#: ../src/generic/printps.cpp:161
+#: ../src/generic/printps.cpp:142
 msgid "Printing..."
 msgstr "Drukowanie..."
 
-#: ../include/wx/richtext/richtextprint.h:109 ../include/wx/prntbase.h:267
-#: ../src/common/docview.cpp:2132
+#: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
+#: ../src/common/docview.cpp:2137
 msgid "Printout"
 msgstr "Wydruk"
 
-#: ../src/common/debugrpt.cpp:560
+#: ../src/common/debugrpt.cpp:561
 #, c-format
 msgid ""
 "Processing debug report has failed, leaving the files in \"%s\" directory."
@@ -5968,104 +6125,104 @@ msgstr ""
 "Przetwarzanie raportu błędów nie powiodło się, pozostawiając pliku w "
 "katalogu \"%s\"."
 
-#: ../src/common/prntbase.cpp:545
+#: ../src/common/prntbase.cpp:540
 msgid "Progress:"
 msgstr "Postęp:"
 
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181
 msgid "Properties"
 msgstr "Właściwości"
 
-#: ../src/propgrid/manager.cpp:237
+#: ../src/propgrid/manager.cpp:223
 msgid "Property"
 msgstr "Właściwość"
 
 #. TRANSLATORS: Caption of message box displaying any property error
-#: ../src/propgrid/propgrid.cpp:3185 ../src/propgrid/propgrid.cpp:3318
+#: ../src/propgrid/propgrid.cpp:3162 ../src/propgrid/propgrid.cpp:3299
 msgid "Property Error"
 msgstr "Błąd właściwości"
 
-#: ../src/propgrid/advprops.cpp:1597
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Purple"
 msgstr ""
 
-#: ../src/common/paper.cpp:112
+#: ../src/common/paper.cpp:109
 msgid "Quarto, 215 x 275 mm"
 msgstr "Quarto, 215 x 275 mm"
 
-#: ../src/generic/logg.cpp:1016
+#: ../src/generic/logg.cpp:1013
 msgid "Question"
 msgstr "Pytanie"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1769
+#: ../src/propgrid/advprops.cpp:1670
 #, fuzzy
 msgid "Question Arrow"
 msgstr "Pytanie"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "Quit"
 msgstr "Wyjście"
 
-#: ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:477
 #, c-format
 msgid "Quit %s"
 msgstr "&Wyjście z %s"
 
-#: ../src/common/stockitem.cpp:263
+#: ../src/common/stockitem.cpp:261
 msgid "Quit this program"
 msgstr "Zamknij program"
 
-#: ../src/common/accelcmn.cpp:338
+#: ../src/common/accelcmn.cpp:352
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/ffile.cpp:109 ../src/common/ffile.cpp:133
+#: ../src/common/ffile.cpp:107 ../src/common/ffile.cpp:132
 #, c-format
 msgid "Read error on file '%s'"
 msgstr "Błąd odczytu pliku '%s'"
 
-#: ../src/common/secretstore.cpp:199
+#: ../src/common/secretstore.cpp:211
 #, fuzzy, c-format
-msgid "Reading password for \"%s/%s\" failed: %s."
+msgid "Reading password for \"%s\" failed: %s."
 msgstr "Pobranie '%s' do '%s' nie powiodło się."
 
-#: ../src/common/prntbase.cpp:272
+#: ../src/common/prntbase.cpp:267
 msgid "Ready"
 msgstr "Gotowy"
 
-#: ../src/propgrid/advprops.cpp:1605
+#: ../src/propgrid/advprops.cpp:1511
 #, fuzzy
 msgid "Red"
 msgstr "Ponów"
 
-#: ../src/generic/colrdlgg.cpp:339
+#: ../src/generic/colrdlgg.cpp:359
 msgid "Red:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:185 ../src/stc/stc_i18n.cpp:16
+#: ../src/common/stockitem.cpp:182 ../src/stc/stc_i18n.cpp:16
 msgid "Redo"
 msgstr "Ponów"
 
-#: ../src/common/stockitem.cpp:264
+#: ../src/common/stockitem.cpp:262
 msgid "Redo last action"
 msgstr "Powtórz ostatnią czynność"
 
-#: ../src/common/stockitem.cpp:186
+#: ../src/common/stockitem.cpp:183
 msgid "Refresh"
 msgstr "Odśwież"
 
-#: ../src/msw/registry.cpp:626
+#: ../src/msw/registry.cpp:615
 #, c-format
 msgid "Registry key '%s' already exists."
 msgstr "Klucz rejestru '%s' już istnieje."
 
-#: ../src/msw/registry.cpp:595
+#: ../src/msw/registry.cpp:584
 #, c-format
 msgid "Registry key '%s' does not exist, cannot rename it."
 msgstr "Klucz rejestru '%s' nie istnieje, nie można zmienić jego nazwy."
 
-#: ../src/msw/registry.cpp:727
+#: ../src/msw/registry.cpp:716
 #, c-format
 msgid ""
 "Registry key '%s' is needed for normal system operation,\n"
@@ -6076,22 +6233,22 @@ msgstr ""
 "usunięcie go zdestabilizowałoby system:\n"
 "operacja została przerwana."
 
-#: ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:942
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:917
+#: ../src/msw/registry.cpp:905
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1003
+#: ../src/msw/registry.cpp:991
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:521
+#: ../src/msw/registry.cpp:510
 #, c-format
 msgid "Registry value '%s' already exists."
 msgstr "Wartość rejestru '%s' już istnieje."
@@ -6105,71 +6262,77 @@ msgstr "Regularne"
 msgid "Relative"
 msgstr "Względnie"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:456
 msgid "Relevant entries:"
 msgstr "Pozycje związane:"
 
-#: ../include/wx/generic/progdlgg.h:86
+#: ../include/wx/generic/progdlgg.h:87
 msgid "Remaining time:"
 msgstr "Pozostały czas:"
 
-#: ../src/common/stockitem.cpp:187
+#: ../src/common/stockitem.cpp:184
 msgid "Remove"
 msgstr "Usuń"
 
-#: ../src/richtext/richtextctrl.cpp:1562
+#: ../src/richtext/richtextctrl.cpp:1563
 msgid "Remove Bullet"
 msgstr "Usuń wypunktowanie"
 
-#: ../src/html/helpwnd.cpp:433
+#: ../src/html/helpwnd.cpp:431
 msgid "Remove current page from bookmarks"
 msgstr "Usuń bieżącą stronę z listy zakładek"
 
-#: ../src/common/rendcmn.cpp:194
+#: ../src/common/rendcmn.cpp:191
 #, c-format
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 "Wizualizator \"%s\" ma niezgodną wersję %d.%d i nie może być załadowany."
 
-#: ../src/richtext/richtextbuffer.cpp:4527
+#: ../src/richtext/richtextbuffer.cpp:4524
 msgid "Renumber List"
 msgstr "Zmień numerację listy"
 
-#: ../src/common/stockitem.cpp:188
-msgid "Rep&lace"
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Rep&lace..."
 msgstr "&Zastąp"
 
-#: ../src/richtext/richtextctrl.cpp:3673 ../src/common/stockitem.cpp:188
+#: ../src/richtext/richtextctrl.cpp:3674
 msgid "Replace"
 msgstr "Zastąp"
 
-#: ../src/generic/fdrepdlg.cpp:182
+#: ../src/generic/fdrepdlg.cpp:179
 msgid "Replace &all"
 msgstr "Zastąp &wszystko"
 
-#: ../src/common/stockitem.cpp:261
-msgid "Replace selection"
-msgstr "Zastąp wybór"
-
-#: ../src/generic/fdrepdlg.cpp:124
+#: ../src/generic/fdrepdlg.cpp:121
 msgid "Replace with:"
 msgstr "Zastąp przez:"
 
-#: ../src/common/valtext.cpp:163
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Replace..."
+msgstr "Zastąp"
+
+#: ../src/common/valtext.cpp:184
 msgid "Required information entry is empty."
 msgstr "Wymagane pole informacji jest puste."
 
-#: ../src/common/translation.cpp:1975
+#: ../src/common/translation.cpp:2025
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "Zasób '%s' nie jest prawidłowym katalogiem komunikatów."
 
+#: ../src/gtk/webview_webkit.cpp:985
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:56
+#: ../src/common/accelcmn.cpp:53
 msgid "Return"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:189
+#: ../src/common/stockitem.cpp:186
 msgid "Revert to Saved"
 msgstr "Przywróć zapisany"
 
@@ -6181,42 +6344,42 @@ msgstr "Krawędź"
 msgid "Rig&ht-to-left"
 msgstr ""
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6149
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:59 ../src/generic/datavgen.cpp:6954
+#: ../src/richtext/richtextsizepage.cpp:250
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextbulletspage.cpp:188
-#: ../src/richtext/richtextsizepage.cpp:250 ../src/common/accelcmn.cpp:62
 msgid "Right"
 msgstr "Prawy"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1754
+#: ../src/propgrid/advprops.cpp:1655
 #, fuzzy
 msgid "Right Arrow"
 msgstr "Prawy"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1770
+#: ../src/propgrid/advprops.cpp:1671
 msgid "Right Button"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:892
+#: ../src/generic/prntdlgg.cpp:885
 msgid "Right margin (mm):"
 msgstr "Prawy margines (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:148
-#: ../src/richtext/richtextindentspage.cpp:150
 #: ../src/richtext/richtextliststylepage.cpp:337
 #: ../src/richtext/richtextliststylepage.cpp:339
+#: ../src/richtext/richtextindentspage.cpp:148
+#: ../src/richtext/richtextindentspage.cpp:150
 msgid "Right-align text."
 msgstr "Prawe dostosowanie tekstu."
 
-#: ../src/generic/fontdlgg.cpp:322
+#: ../src/generic/fontdlgg.cpp:318
 msgid "Roman"
 msgstr "Roman"
 
-#: ../src/generic/datavgen.cpp:5916
+#: ../src/generic/datavgen.cpp:6721
 #, c-format
 msgid "Row %i"
 msgstr ""
@@ -6226,30 +6389,31 @@ msgstr ""
 msgid "S&tandard bullet name:"
 msgstr "Standardowy styl wypunktowania:"
 
-#: ../src/common/accelcmn.cpp:268 ../src/common/accelcmn.cpp:350
+#: ../src/common/accelcmn.cpp:282 ../src/common/accelcmn.cpp:367
 msgid "SPECIAL"
 msgstr "SPECJALNY"
 
-#: ../src/common/stockitem.cpp:190 ../src/common/sizer.cpp:2797
+#: ../src/common/stockitem.cpp:187 ../src/common/sizer.cpp:2914
 msgid "Save"
 msgstr "Zapisz"
 
-#: ../src/common/fldlgcmn.cpp:342
+#: ../src/common/fldlgcmn.cpp:339
 #, c-format
 msgid "Save %s file"
 msgstr "Zapisz plik %s"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/common/stockitem.cpp:188 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Zapisz J&ako..."
 
-#: ../src/common/docview.cpp:366
+#: ../src/common/docview.cpp:359
 msgid "Save As"
 msgstr "Zapisz Jako"
 
-#: ../src/common/stockitem.cpp:191
-msgid "Save as"
-msgstr "Zapisz jako"
+#: ../src/common/stockitem.cpp:188
+#, fuzzy
+msgid "Save As..."
+msgstr "Zapisz J&ako..."
 
 # perspektywę?
 #: ../src/common/stockitem.cpp:267
@@ -6260,40 +6424,40 @@ msgstr "Zapisz bieżący dokument"
 msgid "Save current document with a different filename"
 msgstr "Zapisz bieżący dokument pod inną nazwą pliku"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/generic/logg.cpp:509
 msgid "Save log contents to file"
 msgstr "Zapisz zawartość dziennika do pliku"
 
-#: ../src/common/secretstore.cpp:179
+#: ../src/common/secretstore.cpp:189
 #, fuzzy, c-format
-msgid "Saving password for \"%s/%s\" failed: %s."
+msgid "Saving password for \"%s\" failed: %s."
 msgstr "Pobranie '%s' do '%s' nie powiodło się."
 
-#: ../src/generic/fontdlgg.cpp:325
+#: ../src/generic/fontdlgg.cpp:321
 msgid "Script"
 msgstr "Script"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll Lock"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll_lock"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:890
+#: ../src/propgrid/advprops.cpp:791
 msgid "Scrollbar"
 msgstr ""
 
-#: ../src/generic/srchctlg.cpp:56 ../src/html/helpwnd.cpp:535
-#: ../src/html/helpwnd.cpp:550
+#: ../src/generic/srchctlg.cpp:55 ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:548 ../src/gtk/srchctrl.cpp:182
 msgid "Search"
 msgstr "Szukaj"
 
-#: ../src/html/helpwnd.cpp:537
+#: ../src/html/helpwnd.cpp:535
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
@@ -6301,58 +6465,58 @@ msgstr ""
 "Przeszukuje zawartość pliku(ów) pomocy dla wszystkich wystąpień "
 "wprowadzonego powyżej tekstu"
 
-#: ../src/generic/fdrepdlg.cpp:160
+#: ../src/generic/fdrepdlg.cpp:157
 msgid "Search direction"
 msgstr "Kierunek szukania"
 
-#: ../src/generic/fdrepdlg.cpp:112
+#: ../src/generic/fdrepdlg.cpp:109
 msgid "Search for:"
 msgstr "Znajdź:"
 
 # spisach?
-#: ../src/html/helpwnd.cpp:1052
+#: ../src/html/helpwnd.cpp:1050
 msgid "Search in all books"
 msgstr "Szukaj we wszystkich plikach pomocy"
 
-#: ../src/html/helpwnd.cpp:857
+#: ../src/html/helpwnd.cpp:855
 msgid "Searching..."
 msgstr "Wyszukiwanie..."
 
-#: ../src/generic/dirctrlg.cpp:446
+#: ../src/generic/dirctrlg.cpp:412
 msgid "Sections"
 msgstr "Sekcje"
 
-#: ../src/common/ffile.cpp:238
+#: ../src/common/ffile.cpp:237
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Błąd pozycjonowania w pliku '%s'"
 
-#: ../src/common/ffile.cpp:228
+#: ../src/common/ffile.cpp:227
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr "Błąd wyszukiwania w pliku '%s' (stdio nie wspiera olbrzymich plików)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:76
+#: ../src/common/accelcmn.cpp:73
 #, fuzzy
 msgid "Select"
 msgstr "Wybór"
 
-#: ../src/richtext/richtextctrl.cpp:337 ../src/osx/textctrl_osx.cpp:581
-#: ../src/common/stockitem.cpp:192 ../src/msw/textctrl.cpp:2512
+#: ../src/osx/textctrl_osx.cpp:599 ../src/common/stockitem.cpp:189
+#: ../src/msw/textctrl.cpp:2777 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "&Zaznacz wszystko"
 
-#: ../src/common/stockitem.cpp:192 ../src/stc/stc_i18n.cpp:21
+#: ../src/common/stockitem.cpp:189 ../src/stc/stc_i18n.cpp:21
 msgid "Select All"
 msgstr "Zaznacz wszystko"
 
-#: ../src/common/docview.cpp:1895
+#: ../src/common/docview.cpp:1900
 msgid "Select a document template"
 msgstr "Wybierz szablon dokumentu"
 
 # perspektywę?
-#: ../src/common/docview.cpp:1969
+#: ../src/common/docview.cpp:1974
 msgid "Select a document view"
 msgstr "Wybierz widok dokumentu"
 
@@ -6381,20 +6545,20 @@ msgid "Selects the list level to edit."
 msgstr "Wybiera poziom listy do edycji."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:82
+#: ../src/common/accelcmn.cpp:79
 msgid "Separator"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1083
+#: ../src/common/cmdline.cpp:1079
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Oczekiwano separatora po opcji '%s'."
 
-#: ../src/osx/menu_osx.cpp:572
+#: ../src/osx/menu_osx.cpp:464
 msgid "Services"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11217
+#: ../src/richtext/richtextbuffer.cpp:11216
 msgid "Set Cell Style"
 msgstr "Usuń styl komórki"
 
@@ -6403,11 +6567,11 @@ msgid "SetProperty called w/o valid setter"
 msgstr ""
 "Funkcja SetProperty wywołana bez poprawnej moduły ustawiającego właściwość"
 
-#: ../src/generic/prntdlgg.cpp:188
+#: ../src/generic/prntdlgg.cpp:181
 msgid "Setup..."
 msgstr "Ustawienia..."
 
-#: ../src/msw/dialup.cpp:544
+#: ../src/msw/dialup.cpp:538
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr "Znalezione kilka dostępnych połączeń dialup, zostanie użyte pierwsze."
 
@@ -6424,40 +6588,40 @@ msgstr ""
 msgid "Shadow c&olour:"
 msgstr "Wybierz kolor"
 
-#: ../src/common/accelcmn.cpp:335
+#: ../src/common/accelcmn.cpp:349
 msgid "Shift+"
 msgstr "Shift+"
 
-#: ../src/generic/dirdlgg.cpp:147
+#: ../src/generic/dirdlgg.cpp:144
 msgid "Show &hidden directories"
 msgstr "Pokaż &ukryte katalogi"
 
-#: ../src/generic/filectrlg.cpp:983
+#: ../src/generic/filectrlg.cpp:979
 msgid "Show &hidden files"
 msgstr "Pokazuj &ukryte pliki"
 
-#: ../src/osx/menu_osx.cpp:580
+#: ../src/osx/menu_osx.cpp:472
 msgid "Show All"
 msgstr "Pokaż wszystko"
 
-#: ../src/common/stockitem.cpp:257
+#: ../src/common/stockitem.cpp:254
 msgid "Show about dialog"
 msgstr "Pokazuje okno O"
 
-#: ../src/html/helpwnd.cpp:492
+#: ../src/html/helpwnd.cpp:490
 msgid "Show all"
 msgstr "Pokaż wszystko"
 
-#: ../src/html/helpwnd.cpp:503
+#: ../src/html/helpwnd.cpp:501
 msgid "Show all items in index"
 msgstr "Pokaż wszystkie elementy indeksu"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:656
 msgid "Show/hide navigation panel"
 msgstr "Pokaż/ukryj panel sterowania"
 
-#: ../src/richtext/richtextsymboldlg.cpp:421
-#: ../src/richtext/richtextsymboldlg.cpp:423
+#: ../src/richtext/richtextsymboldlg.cpp:418
+#: ../src/richtext/richtextsymboldlg.cpp:420
 msgid "Shows a Unicode subset."
 msgstr "Pokazuje podzbiór Unicode."
 
@@ -6473,7 +6637,7 @@ msgstr "Pokazuje podgląd ustawień wypunktowania."
 msgid "Shows a preview of the font settings."
 msgstr "Pokazuje podgląd ustawień czcionki."
 
-#: ../src/osx/carbon/fontdlg.cpp:394 ../src/osx/carbon/fontdlg.cpp:396
+#: ../src/osx/carbon/fontdlg.cpp:391 ../src/osx/carbon/fontdlg.cpp:393
 msgid "Shows a preview of the font."
 msgstr "Pokazuje podgląd czcionki."
 
@@ -6482,62 +6646,62 @@ msgstr "Pokazuje podgląd czcionki."
 msgid "Shows a preview of the paragraph settings."
 msgstr "Pokazuje podgląd ustawień paragrafu."
 
-#: ../src/generic/fontdlgg.cpp:460 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:456 ../src/generic/fontdlgg.cpp:458
 msgid "Shows the font preview."
 msgstr "Podgląd czcionki."
 
-#: ../src/propgrid/advprops.cpp:1607
+#: ../src/propgrid/advprops.cpp:1513
 msgid "Silver"
 msgstr ""
 
-#: ../src/univ/themes/mono.cpp:516
+#: ../src/univ/themes/mono.cpp:513
 msgid "Simple monochrome theme"
 msgstr "Prosty czarno-biały motyw"
 
-#: ../src/richtext/richtextindentspage.cpp:275
 #: ../src/richtext/richtextliststylepage.cpp:449
+#: ../src/richtext/richtextindentspage.cpp:275
 msgid "Single"
 msgstr "Pojedynczy"
 
-#: ../src/generic/filectrlg.cpp:425 ../src/richtext/richtextformatdlg.cpp:369
-#: ../src/richtext/richtextsizepage.cpp:299
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextsizepage.cpp:299
+#: ../src/richtext/richtextformatdlg.cpp:362
 msgid "Size"
 msgstr "Rozmiar"
 
-#: ../src/osx/carbon/fontdlg.cpp:339
+#: ../src/osx/carbon/fontdlg.cpp:336
 msgid "Size:"
 msgstr "Rozmiar:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1775
+#: ../src/propgrid/advprops.cpp:1676
 msgid "Sizing"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1772
+#: ../src/propgrid/advprops.cpp:1673
 msgid "Sizing N-S"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1771
+#: ../src/propgrid/advprops.cpp:1672
 msgid "Sizing NE-SW"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1773
+#: ../src/propgrid/advprops.cpp:1674
 msgid "Sizing NW-SE"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1774
+#: ../src/propgrid/advprops.cpp:1675
 msgid "Sizing W-E"
 msgstr ""
 
-#: ../src/msw/progdlg.cpp:801
+#: ../src/msw/progdlg.cpp:1088
 msgid "Skip"
 msgstr "Pomiń"
 
-#: ../src/generic/fontdlgg.cpp:330
+#: ../src/generic/fontdlgg.cpp:326
 msgid "Slant"
 msgstr "Pochylony"
 
@@ -6546,7 +6710,7 @@ msgid "Small C&apitals"
 msgstr "K&apitaliki"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:79
+#: ../src/common/accelcmn.cpp:76
 msgid "Snapshot"
 msgstr ""
 
@@ -6554,37 +6718,37 @@ msgstr ""
 msgid "Solid"
 msgstr "Pełne"
 
-#: ../src/common/docview.cpp:1791
+#: ../src/common/docview.cpp:1785
 msgid "Sorry, could not open this file."
 msgstr "Niestety nie można otworzyć tego pliku."
 
-#: ../src/common/prntbase.cpp:2057 ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2079 ../src/common/prntbase.cpp:2087
 msgid "Sorry, not enough memory to create a preview."
 msgstr "Niestety za mało pamięci aby przygotować podgląd."
 
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "Sorry, that name is taken. Please choose another."
 msgstr "Niestety, nazwa ta jest zajęta. Proszę wybrać inną."
 
-#: ../src/common/docview.cpp:1814
+#: ../src/common/docview.cpp:1819
 msgid "Sorry, the format for this file is unknown."
 msgstr "Niestety, nieznany format pliku."
 
-#: ../src/unix/sound.cpp:492
+#: ../src/unix/sound.cpp:481
 msgid "Sound data are in unsupported format."
 msgstr "Dane dźwiękowe są w formacie, który nie jest wspierany."
 
-#: ../src/unix/sound.cpp:477
+#: ../src/unix/sound.cpp:466
 #, c-format
 msgid "Sound file '%s' is in unsupported format."
 msgstr "Plik z dźwiękiem '%s' jest w formacie, który nie jest wspierany."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:67
+#: ../src/common/accelcmn.cpp:64
 #, fuzzy
 msgid "Space"
 msgstr "Odstępy"
@@ -6593,12 +6757,12 @@ msgstr "Odstępy"
 msgid "Spacing"
 msgstr "Odstępy"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "Spell Check"
 msgstr "Sprawdzanie pisowni"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1776
+#: ../src/propgrid/advprops.cpp:1677
 msgid "Spraycan"
 msgstr ""
 
@@ -6607,7 +6771,7 @@ msgstr ""
 msgid "Standard"
 msgstr "Standard"
 
-#: ../src/common/paper.cpp:104
+#: ../src/common/paper.cpp:101
 msgid "Statement, 5 1/2 x 8 1/2 in"
 msgstr "Statement, 5 1/2 x 8 1/2 cala"
 
@@ -6616,33 +6780,29 @@ msgstr "Statement, 5 1/2 x 8 1/2 cala"
 msgid "Static"
 msgstr "Statyczny"
 
-#: ../src/generic/prntdlgg.cpp:204
+#: ../src/generic/prntdlgg.cpp:197
 msgid "Status:"
 msgstr "Status:"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "Stop"
 msgstr "Stop"
 
-#: ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196
 msgid "Strikethrough"
 msgstr "Przekreślenie"
 
-#: ../src/common/colourcmn.cpp:45
+#: ../src/common/colourcmn.cpp:42
 #, c-format
 msgid "String To Colour : Incorrect colour specification : %s"
 msgstr "Nieprawidłowa specyfikacja koloru : %s"
 
 #. TRANSLATORS: Label of font style
-#: ../src/richtext/richtextformatdlg.cpp:339 ../src/propgrid/advprops.cpp:680
+#: ../src/propgrid/advprops.cpp:590 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Styl"
 
-#: ../include/wx/richtext/richtextstyledlg.h:46
-msgid "Style Organiser"
-msgstr "Organizator stylu"
-
-#: ../src/osx/carbon/fontdlg.cpp:348
+#: ../src/osx/carbon/fontdlg.cpp:345
 msgid "Style:"
 msgstr "Styl:"
 
@@ -6651,7 +6811,7 @@ msgid "Subscrip&t"
 msgstr "Indeks &dolny"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:83
+#: ../src/common/accelcmn.cpp:80
 msgid "Subtract"
 msgstr ""
 
@@ -6659,11 +6819,11 @@ msgstr ""
 msgid "Supe&rscript"
 msgstr "Indeks &górny"
 
-#: ../src/common/paper.cpp:150
+#: ../src/common/paper.cpp:147
 msgid "SuperA/SuperA/A4 227 x 356 mm"
 msgstr "SuperA/SuperA/A4 227 x 356 mm"
 
-#: ../src/common/paper.cpp:151
+#: ../src/common/paper.cpp:148
 msgid "SuperB/SuperB/A3 305 x 487 mm"
 msgstr "SuperB/SuperB/A3 305 x 487 mm"
 
@@ -6671,7 +6831,7 @@ msgstr "SuperB/SuperB/A3 305 x 487 mm"
 msgid "Suppress hyphe&nation"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:326
+#: ../src/generic/fontdlgg.cpp:322
 msgid "Swiss"
 msgstr "Swiss"
 
@@ -6689,74 +6849,74 @@ msgstr "&Czcionka symbolu:"
 msgid "Symbols"
 msgstr "Symbole"
 
-#: ../src/common/imagtiff.cpp:369 ../src/common/imagtiff.cpp:382
-#: ../src/common/imagtiff.cpp:741
+#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
+#: ../src/common/imagtiff.cpp:738
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: Nie można przydzielić pamięci."
 
-#: ../src/common/imagtiff.cpp:301
+#: ../src/common/imagtiff.cpp:298
 msgid "TIFF: Error loading image."
 msgstr "TIFF: Błąd przy wczytywaniu obrazu."
 
-#: ../src/common/imagtiff.cpp:468
+#: ../src/common/imagtiff.cpp:465
 msgid "TIFF: Error reading image."
 msgstr "TIFF: Błąd odczytu."
 
-#: ../src/common/imagtiff.cpp:608
+#: ../src/common/imagtiff.cpp:605
 msgid "TIFF: Error saving image."
 msgstr "TIFF: Wystąpił błąd przy zapisie."
 
-#: ../src/common/imagtiff.cpp:846
+#: ../src/common/imagtiff.cpp:843
 msgid "TIFF: Error writing image."
 msgstr "TIFF: Błąd zapisu."
 
-#: ../src/common/imagtiff.cpp:355
+#: ../src/common/imagtiff.cpp:352
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: Rozmiar obrazu jest wyjątkowo duży."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:68
+#: ../src/common/accelcmn.cpp:65
 #, fuzzy
 msgid "Tab"
 msgstr "Karty"
 
-#: ../src/richtext/richtextbuffer.cpp:11498
+#: ../src/richtext/richtextbuffer.cpp:11497
 msgid "Table Properties"
 msgstr "&Właściwości tabeli"
 
-#: ../src/common/paper.cpp:145
+#: ../src/common/paper.cpp:142
 msgid "Tabloid Extra 11.69 x 18 in"
 msgstr "Tabloid Extra 11.69 x 18 cali"
 
-#: ../src/common/paper.cpp:102
+#: ../src/common/paper.cpp:99
 msgid "Tabloid, 11 x 17 in"
 msgstr "Tabloid, 11 x 17 cali"
 
-#: ../src/richtext/richtextformatdlg.cpp:354
+#: ../src/richtext/richtextformatdlg.cpp:347
 msgid "Tabs"
 msgstr "Karty"
 
-#: ../src/propgrid/advprops.cpp:1598
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Teal"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:327
+#: ../src/generic/fontdlgg.cpp:323
 msgid "Teletype"
 msgstr "Teletype"
 
-#: ../src/common/docview.cpp:1896
+#: ../src/common/docview.cpp:1901
 msgid "Templates"
 msgstr "Szablony"
 
-#: ../src/common/fmapbase.cpp:158
+#: ../src/common/fmapbase.cpp:155
 msgid "Thai (ISO-8859-11)"
 msgstr "Tajski (ISO-8859-11)"
 
-#: ../src/common/ftp.cpp:619
+#: ../src/common/ftp.cpp:622
 msgid "The FTP server doesn't support passive mode."
 msgstr "Serwer FTP nie obsługuje trybu pasywnego."
 
-#: ../src/common/ftp.cpp:605
+#: ../src/common/ftp.cpp:608
 msgid "The FTP server doesn't support the PORT command."
 msgstr "Serwer FTP nie obsługuje komendy PORT."
 
@@ -6767,8 +6927,8 @@ msgstr "Serwer FTP nie obsługuje komendy PORT."
 msgid "The available bullet styles."
 msgstr "Dostępne style wypunktowania."
 
-#: ../src/richtext/richtextstyledlg.cpp:202
-#: ../src/richtext/richtextstyledlg.cpp:204
+#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:200
 msgid "The available styles."
 msgstr "Dostępne style."
 
@@ -6825,12 +6985,12 @@ msgstr "Pozycja na dole."
 msgid "The bullet character."
 msgstr "Znak wypunktowania."
 
-#: ../src/richtext/richtextsymboldlg.cpp:443
-#: ../src/richtext/richtextsymboldlg.cpp:445
+#: ../src/richtext/richtextsymboldlg.cpp:440
+#: ../src/richtext/richtextsymboldlg.cpp:442
 msgid "The character code."
 msgstr "Kod znaku."
 
-#: ../src/common/fontmap.cpp:203
+#: ../src/common/fontmap.cpp:200
 #, c-format
 msgid ""
 "The charset '%s' is unknown. You may select\n"
@@ -6841,7 +7001,7 @@ msgstr ""
 "inny zestaw aby go zastąpić lub wybierz\n"
 "[Anuluj] jeśli nie można go zastąpić."
 
-#: ../src/msw/ole/dataobj.cpp:394
+#: ../src/msw/ole/dataobj.cpp:402
 #, c-format
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "Format schowka '%d' nie istnieje."
@@ -6851,7 +7011,7 @@ msgstr "Format schowka '%d' nie istnieje."
 msgid "The default style for the next paragraph."
 msgstr "Domyślny styl dla następnego paragrafu."
 
-#: ../src/generic/dirdlgg.cpp:202
+#: ../src/generic/dirdlgg.cpp:199
 #, c-format
 msgid ""
 "The directory '%s' does not exist\n"
@@ -6860,7 +7020,7 @@ msgstr ""
 "Katalog '%s' nie istnieje\n"
 "Utworzyć go teraz?"
 
-#: ../src/html/htmprint.cpp:271
+#: ../src/html/htmprint.cpp:283
 #, c-format
 msgid ""
 "The document \"%s\" doesn't fit on the page horizontally and will be "
@@ -6873,7 +7033,7 @@ msgstr ""
 "\n"
 "Chcesz kontynuować drukowanie mimo to?"
 
-#: ../src/common/docview.cpp:1202
+#: ../src/common/docview.cpp:1196
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -6882,36 +7042,37 @@ msgstr ""
 "Plik '%s' nie istnieje i nie można go otworzyć.\n"
 "Informacja o nim została usunięta z listy ostatnio używanych plików."
 
-#: ../src/richtext/richtextindentspage.cpp:208
-#: ../src/richtext/richtextindentspage.cpp:210
 #: ../src/richtext/richtextliststylepage.cpp:394
 #: ../src/richtext/richtextliststylepage.cpp:396
+#: ../src/richtext/richtextindentspage.cpp:208
+#: ../src/richtext/richtextindentspage.cpp:210
 msgid "The first line indent."
 msgstr "Wcięcie pierwszego wierszu."
 
-#: ../src/gtk/utilsgtk.cpp:481
-msgid "The following standard GTK+ options are also supported:\n"
-msgstr "Następujące opcje standardowe GTK+ także są obsługiwane:\n"
+#: ../src/generic/dbgrptg.cpp:318
+#, fuzzy
+msgid "The following debug report will be generated\n"
+msgstr "*** Raport błędów został wygenerowany\n"
 
-#: ../src/generic/fontdlgg.cpp:414 ../src/generic/fontdlgg.cpp:416
+#: ../src/generic/fontdlgg.cpp:411 ../src/generic/fontdlgg.cpp:413
 msgid "The font colour."
 msgstr "Kolor czcionki."
 
-#: ../src/generic/fontdlgg.cpp:375 ../src/generic/fontdlgg.cpp:377
+#: ../src/generic/fontdlgg.cpp:371 ../src/generic/fontdlgg.cpp:373
 msgid "The font family."
 msgstr "Rodzina czcionki."
 
-#: ../src/richtext/richtextsymboldlg.cpp:405
-#: ../src/richtext/richtextsymboldlg.cpp:407
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "The font from which to take the symbol."
 msgstr "Czcionka z której pobrać symbol."
 
-#: ../src/generic/fontdlgg.cpp:427 ../src/generic/fontdlgg.cpp:429
-#: ../src/generic/fontdlgg.cpp:434 ../src/generic/fontdlgg.cpp:436
+#: ../src/generic/fontdlgg.cpp:424 ../src/generic/fontdlgg.cpp:426
+#: ../src/generic/fontdlgg.cpp:430 ../src/generic/fontdlgg.cpp:432
 msgid "The font point size."
 msgstr "Rozmiar czcionki."
 
-#: ../src/osx/carbon/fontdlg.cpp:343 ../src/osx/carbon/fontdlg.cpp:345
+#: ../src/osx/carbon/fontdlg.cpp:340 ../src/osx/carbon/fontdlg.cpp:342
 msgid "The font size in points."
 msgstr "Rozmiar czcionki w punktach."
 
@@ -6920,15 +7081,15 @@ msgstr "Rozmiar czcionki w punktach."
 msgid "The font size units, points or pixels."
 msgstr "Rozmiar czcionki w punktach lub  pikselach ."
 
-#: ../src/generic/fontdlgg.cpp:386 ../src/generic/fontdlgg.cpp:388
+#: ../src/generic/fontdlgg.cpp:382 ../src/generic/fontdlgg.cpp:384
 msgid "The font style."
 msgstr "Styl czcionki."
 
-#: ../src/generic/fontdlgg.cpp:397 ../src/generic/fontdlgg.cpp:399
+#: ../src/generic/fontdlgg.cpp:393 ../src/generic/fontdlgg.cpp:395
 msgid "The font weight."
 msgstr "Waga czcionki."
 
-#: ../src/common/docview.cpp:1483
+#: ../src/common/docview.cpp:1477
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Nie można wykryć formatu pliku '%s' ."
@@ -6939,10 +7100,10 @@ msgstr "Nie można wykryć formatu pliku '%s' ."
 msgid "The horizontal offset."
 msgstr "&Sąsiadująco w poziomie"
 
-#: ../src/richtext/richtextindentspage.cpp:199
-#: ../src/richtext/richtextindentspage.cpp:201
 #: ../src/richtext/richtextliststylepage.cpp:385
 #: ../src/richtext/richtextliststylepage.cpp:387
+#: ../src/richtext/richtextindentspage.cpp:199
+#: ../src/richtext/richtextindentspage.cpp:201
 msgid "The left indent."
 msgstr "Lewe wcięcie."
 
@@ -6963,10 +7124,10 @@ msgstr "Rozmiar dopełnienia z lewej. "
 msgid "The left position."
 msgstr "Pozycja z lewej."
 
-#: ../src/richtext/richtextindentspage.cpp:288
-#: ../src/richtext/richtextindentspage.cpp:290
 #: ../src/richtext/richtextliststylepage.cpp:462
 #: ../src/richtext/richtextliststylepage.cpp:464
+#: ../src/richtext/richtextindentspage.cpp:288
+#: ../src/richtext/richtextindentspage.cpp:290
 msgid "The line spacing."
 msgstr "Odstęp między wierszami."
 
@@ -6975,7 +7136,7 @@ msgstr "Odstęp między wierszami."
 msgid "The list item number."
 msgstr "Numer pozycji listy."
 
-#: ../src/msw/ole/automtn.cpp:664
+#: ../src/msw/ole/automtn.cpp:655
 msgid "The locale ID is unknown."
 msgstr "Nieznany identyfikator ustawień lokalizacyjnych."
 
@@ -7014,7 +7175,7 @@ msgstr "Szerokość obiektu."
 msgid "The outline level."
 msgstr "Poziom kontur."
 
-#: ../src/common/log.cpp:277
+#: ../src/common/log.cpp:296
 #, fuzzy, c-format
 msgid "The previous message repeated %u time."
 msgid_plural "The previous message repeated %u times."
@@ -7022,12 +7183,12 @@ msgstr[0] "Poprzedni komunikat powtórzył się %lu raz."
 msgstr[1] "Poprzedni komunikat powtórzył się %lu razy."
 msgstr[2] "Poprzedni komunikat powtórzył się %lu razy."
 
-#: ../src/common/log.cpp:270
+#: ../src/common/log.cpp:289
 msgid "The previous message repeated once."
 msgstr "Poprzednia wiadomość była raz powtórzona."
 
-#: ../src/richtext/richtextsymboldlg.cpp:462
-#: ../src/richtext/richtextsymboldlg.cpp:464
+#: ../src/richtext/richtextsymboldlg.cpp:459
+#: ../src/richtext/richtextsymboldlg.cpp:461
 msgid "The range to show."
 msgstr "Zakres do pokazania."
 
@@ -7041,15 +7202,15 @@ msgstr ""
 "zawiera prywatne informacje,\n"
 "proszę odznacz go w celu usunięcia go z raportu.\n"
 
-#: ../src/common/cmdline.cpp:1254
+#: ../src/common/cmdline.cpp:1250
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "Wymagany parametr '%s' nie został podany."
 
-#: ../src/richtext/richtextindentspage.cpp:217
-#: ../src/richtext/richtextindentspage.cpp:219
 #: ../src/richtext/richtextliststylepage.cpp:403
 #: ../src/richtext/richtextliststylepage.cpp:405
+#: ../src/richtext/richtextindentspage.cpp:217
+#: ../src/richtext/richtextindentspage.cpp:219
 msgid "The right indent."
 msgstr "Prawidłowe wcięcie."
 
@@ -7091,16 +7252,16 @@ msgstr ""
 msgid "The shadow spread."
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:267
 #: ../src/richtext/richtextliststylepage.cpp:439
 #: ../src/richtext/richtextliststylepage.cpp:441
+#: ../src/richtext/richtextindentspage.cpp:267
 msgid "The spacing after the paragraph."
 msgstr "Odstępy po paragrafie."
 
-#: ../src/richtext/richtextindentspage.cpp:257
-#: ../src/richtext/richtextindentspage.cpp:259
 #: ../src/richtext/richtextliststylepage.cpp:430
 #: ../src/richtext/richtextliststylepage.cpp:432
+#: ../src/richtext/richtextindentspage.cpp:257
+#: ../src/richtext/richtextindentspage.cpp:259
 msgid "The spacing before the paragraph."
 msgstr "Odstępy przed paragrafem."
 
@@ -7114,12 +7275,12 @@ msgstr "Nazwa stylu."
 msgid "The style on which this style is based."
 msgstr "Styl, na którym ten styl jest oparty."
 
-#: ../src/richtext/richtextstyledlg.cpp:214
-#: ../src/richtext/richtextstyledlg.cpp:216
+#: ../src/richtext/richtextstyledlg.cpp:210
+#: ../src/richtext/richtextstyledlg.cpp:212
 msgid "The style preview."
 msgstr "Podgląd stylu."
 
-#: ../src/msw/ole/automtn.cpp:680
+#: ../src/msw/ole/automtn.cpp:671
 msgid "The system cannot find the file specified."
 msgstr "System nie może odnaleźć określonego pliku."
 
@@ -7132,7 +7293,7 @@ msgstr "Pozycja karty."
 msgid "The tab positions."
 msgstr "Pozycje karty."
 
-#: ../src/richtext/richtextctrl.cpp:3098
+#: ../src/richtext/richtextctrl.cpp:3099
 msgid "The text couldn't be saved."
 msgstr "Tekst nie może być zapisany.."
 
@@ -7153,7 +7314,7 @@ msgstr "Rozmiar dopełnienia od góry."
 msgid "The top position."
 msgstr "Pozycja od góry."
 
-#: ../src/common/cmdline.cpp:1232
+#: ../src/common/cmdline.cpp:1228
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "Wartość opcji '%s' musi zostać podana."
@@ -7163,7 +7324,7 @@ msgstr "Wartość opcji '%s' musi zostać podana."
 msgid "The value of the corner radius."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:433
+#: ../src/msw/dialup.cpp:427
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -7178,30 +7339,30 @@ msgstr ""
 msgid "The vertical offset."
 msgstr "Włącz wyrównanie w pionie."
 
-#: ../src/richtext/richtextprint.cpp:619 ../src/html/htmprint.cpp:745
+#: ../src/html/htmprint.cpp:749 ../src/richtext/richtextprint.cpp:615
 msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr ""
 "Wystąpił błąd podczas konfigurowania strony: powinieneś określić domyślną "
 "drukarkę."
 
-#: ../src/html/htmprint.cpp:255
+#: ../src/html/htmprint.cpp:267
 msgid ""
 "This document doesn't fit on the page horizontally and will be truncated "
 "when it is printed."
 msgstr ""
 "Ten dokument nie mieści się poziomo na stronie i będzie ucięty na wydruku."
 
-#: ../src/common/image.cpp:2854
+#: ../src/common/image.cpp:2963
 #, c-format
 msgid "This is not a %s."
 msgstr "To nie jest %s."
 
-#: ../src/common/wincmn.cpp:1653
+#: ../src/common/wincmn.cpp:1654
 msgid "This platform does not support background transparency."
 msgstr "Ta platforma nie obsługuje przezroczystości tła."
 
-#: ../src/gtk/window.cpp:4660
+#: ../src/gtk/window.cpp:5664
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
@@ -7209,7 +7370,15 @@ msgstr ""
 "Ten program został skompilowany przy użyciu zbyt starej wersji GTK+, proszę "
 "skompilować ponownie z użyciem GTK+ 2.12 or nowszej."
 
-#: ../src/msw/thread.cpp:1240
+#: ../src/gtk/glcanvas.cpp:176
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/msw/thread.cpp:1246
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -7217,13 +7386,13 @@ msgstr ""
 "Zainicjowanie modułu wątków nie powiodło się: nie można odłożyć wartości do "
 "lokalnej pamięci wątków"
 
-#: ../src/unix/threadpsx.cpp:1794
+#: ../src/unix/threadpsx.cpp:1843
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 "Zainicjowanie modułu wątków nie powiodło się: nie udało się utworzyć klucza "
 "wątków"
 
-#: ../src/msw/thread.cpp:1228
+#: ../src/msw/thread.cpp:1234
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -7231,81 +7400,81 @@ msgstr ""
 "Zainicjowanie modułu wątków nie powiodło się: nie jest możliwe przydzielenie "
 "indeksu w lokalnej pamięci wątków."
 
-#: ../src/unix/threadpsx.cpp:1043
+#: ../src/unix/threadpsx.cpp:1061
 msgid "Thread priority setting is ignored."
 msgstr "Ustawienie priorytetu wątku jest ignorowane."
 
-#: ../src/msw/mdi.cpp:176
+#: ../src/msw/mdi.cpp:171
 msgid "Tile &Horizontally"
 msgstr "&Sąsiadująco w poziomie"
 
-#: ../src/msw/mdi.cpp:177
+#: ../src/msw/mdi.cpp:172
 msgid "Tile &Vertically"
 msgstr "Sąsi&adująco w pionie"
 
-#: ../src/common/ftp.cpp:200
+#: ../src/common/ftp.cpp:197
 msgid "Timeout while waiting for FTP server to connect, try passive mode."
 msgstr ""
 "Przekroczono czas oczekiwania dla serwera FTP, spróbuj trybu pasywnego."
 
-#: ../src/generic/tipdlg.cpp:201
+#: ../src/generic/tipdlg.cpp:198
 msgid "Tip of the Day"
 msgstr "Porada dnia"
 
-#: ../src/generic/tipdlg.cpp:140
+#: ../src/generic/tipdlg.cpp:137
 msgid "Tips not available, sorry!"
 msgstr "Niestety, porady nie są dostępne!"
 
-#: ../src/generic/prntdlgg.cpp:242
+#: ../src/generic/prntdlgg.cpp:235
 msgid "To:"
 msgstr "Do:"
 
-#: ../src/richtext/richtextbuffer.cpp:8363
+#: ../src/richtext/richtextbuffer.cpp:8361
 msgid "Too many EndStyle calls!"
 msgstr "Zbyt wiele wezwań EndStyle!"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:891
+#: ../src/propgrid/advprops.cpp:792
 msgid "Tooltip"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:892
+#: ../src/propgrid/advprops.cpp:793
 msgid "TooltipText"
 msgstr ""
 
-#: ../src/richtext/richtextsizepage.cpp:286
-#: ../src/richtext/richtextsizepage.cpp:290 ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197 ../src/richtext/richtextsizepage.cpp:286
+#: ../src/richtext/richtextsizepage.cpp:290
 msgid "Top"
 msgstr "Góra"
 
-#: ../src/generic/prntdlgg.cpp:881
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Top margin (mm):"
 msgstr "Górny margines (mm):"
 
-#: ../src/generic/aboutdlgg.cpp:79
+#: ../src/generic/aboutdlgg.cpp:76
 msgid "Translations by "
 msgstr "Tłumaczenia autorstwa"
 
-#: ../src/generic/aboutdlgg.cpp:188
+#: ../src/generic/aboutdlgg.cpp:185
 msgid "Translators"
 msgstr "Tłumacze"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:211
+#: ../src/propgrid/propgrid.cpp:192
 msgid "True"
 msgstr "Prawda"
 
-#: ../src/common/fs_mem.cpp:227
+#: ../src/common/fs_mem.cpp:222
 #, c-format
 msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
 msgstr "Próbą usunięcia pliku '%s' z pamięci VFS, który nie został wczytany!"
 
-#: ../src/common/fmapbase.cpp:156
+#: ../src/common/fmapbase.cpp:153
 msgid "Turkish (ISO-8859-9)"
 msgstr "Turecki (ISO-8859-9)"
 
-#: ../src/generic/filectrlg.cpp:426
+#: ../src/generic/filectrlg.cpp:422
 msgid "Type"
 msgstr "Typ"
 
@@ -7319,17 +7488,17 @@ msgstr "Wpisz nazwę czcionki."
 msgid "Type a size in points."
 msgstr "Wpisz rozmiar w punktach."
 
-#: ../src/msw/ole/automtn.cpp:676
+#: ../src/msw/ole/automtn.cpp:667
 #, c-format
 msgid "Type mismatch in argument %u."
 msgstr "Niezgodność typów argumentu %u."
 
-#: ../src/common/xtixml.cpp:356 ../src/common/xtixml.cpp:509
-#: ../src/common/xtistrm.cpp:318
+#: ../src/common/xtixml.cpp:352 ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315
 msgid "Type must have enum - long conversion"
 msgstr "Typ musi umożliwiać konswersję enum - long"
 
-#: ../src/propgrid/propgridiface.cpp:401
+#: ../src/propgrid/propgridiface.cpp:385
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
@@ -7338,19 +7507,19 @@ msgstr ""
 "Niepowodzenie operacji typu \"%s\": właściwość nazwana  \"%s\" jest typu \"%s"
 "\", nie \"%s\"."
 
-#: ../src/common/paper.cpp:133
+#: ../src/common/paper.cpp:130
 msgid "US Std Fanfold, 14 7/8 x 11 in"
 msgstr "Składanka US Std, 14 7/8 x 11 cali"
 
-#: ../src/common/fmapbase.cpp:196
+#: ../src/common/fmapbase.cpp:193
 msgid "US-ASCII"
 msgstr "US-ASCII"
 
-#: ../src/unix/fswatcher_inotify.cpp:109
+#: ../src/unix/fswatcher_inotify.cpp:106
 msgid "Unable to add inotify watch"
 msgstr "Nie można dodać czujki inotify"
 
-#: ../src/unix/fswatcher_kqueue.cpp:136
+#: ../src/unix/fswatcher_kqueue.cpp:153
 msgid "Unable to add kqueue watch"
 msgstr "Nie można dodać czujki kolejki"
 
@@ -7364,7 +7533,7 @@ msgid "Unable to close I/O completion port handle"
 msgstr "Nie można zamknąć portu zakończenia I/O."
 
 # uchwyt chyba zbędny
-#: ../src/unix/fswatcher_inotify.cpp:97
+#: ../src/unix/fswatcher_inotify.cpp:94
 msgid "Unable to close inotify instance"
 msgstr "Nie można zamknąć instancji inotify"
 
@@ -7383,15 +7552,15 @@ msgstr "Nie moża zamknąć uchwytu '%s'"
 msgid "Unable to create I/O completion port"
 msgstr "Nie można utworzyć portu zakończenia I/O."
 
-#: ../src/msw/fswatcher.cpp:84
+#: ../src/msw/fswatcher.cpp:81
 msgid "Unable to create IOCP worker thread"
 msgstr "Nie można utworzyć wątku IOCP"
 
-#: ../src/unix/fswatcher_inotify.cpp:74
+#: ../src/unix/fswatcher_inotify.cpp:71
 msgid "Unable to create inotify instance"
 msgstr "Nie można utworzyć instancji inotify"
 
-#: ../src/unix/fswatcher_kqueue.cpp:97
+#: ../src/unix/fswatcher_kqueue.cpp:114
 msgid "Unable to create kqueue instance"
 msgstr "Nie można utworzyć instancji kqueue"
 
@@ -7399,11 +7568,11 @@ msgstr "Nie można utworzyć instancji kqueue"
 msgid "Unable to dequeue completion packet"
 msgstr "Nie można odkolejkować pakietu zakończenia"
 
-#: ../src/unix/fswatcher_kqueue.cpp:185
+#: ../src/unix/fswatcher_kqueue.cpp:202
 msgid "Unable to get events from kqueue"
 msgstr "Nie można pobrać zdarzeń z kolejki"
 
-#: ../src/gtk/app.cpp:435
+#: ../src/gtk/app.cpp:431
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "Nie można ustawić GTK+, czy jest prawidłowo ustawiony EKRAN?"
 
@@ -7412,12 +7581,12 @@ msgstr "Nie można ustawić GTK+, czy jest prawidłowo ustawiony EKRAN?"
 msgid "Unable to open path '%s'"
 msgstr "Nie można otworzyć '%s'"
 
-#: ../src/html/htmlwin.cpp:583
+#: ../src/html/htmlwin.cpp:586
 #, c-format
 msgid "Unable to open requested HTML document: %s"
 msgstr "Nie można otworzyć wskazanego dokumentu HTML: %s"
 
-#: ../src/unix/sound.cpp:368
+#: ../src/unix/sound.cpp:365
 msgid "Unable to play sound asynchronously."
 msgstr "Nie można odtowrzyć dźwięku asynchronicznie."
 
@@ -7425,61 +7594,61 @@ msgstr "Nie można odtowrzyć dźwięku asynchronicznie."
 msgid "Unable to post completion status"
 msgstr "Nie można wysłać stanu zakończenia"
 
-#: ../src/unix/fswatcher_inotify.cpp:556
+#: ../src/unix/fswatcher_inotify.cpp:553
 msgid "Unable to read from inotify descriptor"
 msgstr "Błąd odczytu z deskryptora inotify"
 
-#: ../src/unix/fswatcher_inotify.cpp:141
+#: ../src/unix/fswatcher_inotify.cpp:138
 #, fuzzy, c-format
 msgid "Unable to remove inotify watch %i"
 msgstr "Nie można usunąć czujki inotify"
 
-#: ../src/unix/fswatcher_kqueue.cpp:153
+#: ../src/unix/fswatcher_kqueue.cpp:170
 msgid "Unable to remove kqueue watch"
 msgstr "Nie można usunąć czujki kolejki"
 
-#: ../src/msw/fswatcher.cpp:168
+#: ../src/msw/fswatcher.cpp:165
 #, c-format
 msgid "Unable to set up watch for '%s'"
 msgstr "Nie można zacząć obserwować '%s'"
 
-#: ../src/msw/fswatcher.cpp:91
+#: ../src/msw/fswatcher.cpp:88
 msgid "Unable to start IOCP worker thread"
 msgstr "Nie można uruchomić wątku IOCP"
 
-#: ../src/common/stockitem.cpp:201
+#: ../src/common/stockitem.cpp:198
 msgid "Undelete"
 msgstr "Odzyskaj"
 
-#: ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199
 msgid "Underline"
 msgstr "Podkreślenie"
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/richtext/richtextfontpage.cpp:359 ../src/osx/carbon/fontdlg.cpp:370
-#: ../src/propgrid/advprops.cpp:690
+#: ../src/osx/carbon/fontdlg.cpp:367 ../src/propgrid/advprops.cpp:600
+#: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Podkreślony"
 
-#: ../src/common/stockitem.cpp:203 ../src/stc/stc_i18n.cpp:15
+#: ../src/common/stockitem.cpp:200 ../src/stc/stc_i18n.cpp:15
 msgid "Undo"
 msgstr "Cofnij"
 
-#: ../src/common/stockitem.cpp:265
+#: ../src/common/stockitem.cpp:263
 msgid "Undo last action"
 msgstr "Cofnij ostatnią czynność"
 
-#: ../src/common/cmdline.cpp:1029
+#: ../src/common/cmdline.cpp:1025
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Nieoczekiwane znaki następujących opcji '%s'."
 
-#: ../src/unix/fswatcher_inotify.cpp:274
+#: ../src/unix/fswatcher_inotify.cpp:271
 #, c-format
 msgid "Unexpected event for \"%s\": no matching watch descriptor."
 msgstr "NIeoczekiwane zdarzenie dla \"%s\": brak pasującego deskryptora."
 
-#: ../src/common/cmdline.cpp:1195
+#: ../src/common/cmdline.cpp:1191
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Nieoczekiwany parametr '%s'"
@@ -7488,49 +7657,49 @@ msgstr "Nieoczekiwany parametr '%s'"
 msgid "Unexpectedly new I/O completion port was created"
 msgstr "Nieoczekiwanie został utworzony nowy port zakończenia I/O"
 
-#: ../src/msw/fswatcher.cpp:70
+#: ../src/msw/fswatcher.cpp:67
 msgid "Ungraceful worker thread termination"
 msgstr "Wątek roboczy zakończył się błędem"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:460
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:456
+#: ../src/richtext/richtextsymboldlg.cpp:457
+#: ../src/richtext/richtextsymboldlg.cpp:458
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../src/common/fmapbase.cpp:185 ../src/common/fmapbase.cpp:191
+#: ../src/common/fmapbase.cpp:182 ../src/common/fmapbase.cpp:188
 msgid "Unicode 16 bit (UTF-16)"
 msgstr "Unicode 16 bit (UTF-16)"
 
-#: ../src/common/fmapbase.cpp:190
+#: ../src/common/fmapbase.cpp:187
 msgid "Unicode 16 bit Big Endian (UTF-16BE)"
 msgstr "Unicode 16 bit Big Endian (UTF-16BE)"
 
-#: ../src/common/fmapbase.cpp:186
+#: ../src/common/fmapbase.cpp:183
 msgid "Unicode 16 bit Little Endian (UTF-16LE)"
 msgstr "Unicode 16 bit Little Endian (UTF-16LE)"
 
-#: ../src/common/fmapbase.cpp:187 ../src/common/fmapbase.cpp:193
+#: ../src/common/fmapbase.cpp:184 ../src/common/fmapbase.cpp:190
 msgid "Unicode 32 bit (UTF-32)"
 msgstr "Unicode 32 bit (UTF-32)"
 
-#: ../src/common/fmapbase.cpp:192
+#: ../src/common/fmapbase.cpp:189
 msgid "Unicode 32 bit Big Endian (UTF-32BE)"
 msgstr "Unicode 32 bit Big Endian (UTF-32BE)"
 
-#: ../src/common/fmapbase.cpp:188
+#: ../src/common/fmapbase.cpp:185
 msgid "Unicode 32 bit Little Endian (UTF-32LE)"
 msgstr "Unicode 32 bit Little Endian (UTF-32LE)"
 
-#: ../src/common/fmapbase.cpp:182
+#: ../src/common/fmapbase.cpp:179
 msgid "Unicode 7 bit (UTF-7)"
 msgstr "Unicode 7 bit (UTF-7)"
 
-#: ../src/common/fmapbase.cpp:183
+#: ../src/common/fmapbase.cpp:180
 msgid "Unicode 8 bit (UTF-8)"
 msgstr "Unicode 8 bit (UTF-8)"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "Unindent"
 msgstr "Cofnij wcięcie"
 
@@ -7682,98 +7851,103 @@ msgstr "Jednostki pozycji od góry."
 msgid "Units for this value."
 msgstr "Jednostki lewego marginesu."
 
-#: ../src/generic/progdlgg.cpp:353 ../src/generic/progdlgg.cpp:622
+#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
 msgid "Unknown"
 msgstr "Nieznany"
 
-#: ../src/msw/dde.cpp:1174
+#: ../src/msw/dde.cpp:1238
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Nieznany błąd DDE %08x"
 
-#: ../src/common/xtistrm.cpp:410
+#: ../src/common/xtistrm.cpp:407
 msgid "Unknown Object passed to GetObjectClassInfo"
 msgstr "Nieznany obiekt przekazany do funkcji GetObjectClassInfo"
 
-#: ../src/common/imagpng.cpp:366
+#: ../src/common/imagpng.cpp:383
 #, c-format
 msgid "Unknown PNG resolution unit %d"
 msgstr "Nieznana jednostka rozdzielczości PNG: %d"
 
-#: ../src/common/xtixml.cpp:327
+#: ../src/common/xtixml.cpp:323
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Nieznana właściwość %s"
 
-#: ../src/common/imagtiff.cpp:529
+#: ../src/common/imagtiff.cpp:526
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "Zignorowana nieznana jednostka %d rozdzielczości TIFF"
 
-#: ../src/unix/dlunix.cpp:160
+#: ../src/propgrid/props.cpp:155
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/unix/dlunix.cpp:118
 msgid "Unknown dynamic library error"
 msgstr "Nieznany błąd biblioteki dynamicznej"
 
-#: ../src/common/fmapbase.cpp:810
+#: ../src/common/fmapbase.cpp:806
 #, c-format
 msgid "Unknown encoding (%d)"
 msgstr "Nieznane kodowanie (%d)"
 
-#: ../src/msw/ole/automtn.cpp:688
+#: ../src/msw/ole/automtn.cpp:679
 #, c-format
 msgid "Unknown error %08x"
 msgstr "Nieznany błąd %08x"
 
-#: ../src/msw/ole/automtn.cpp:647
+#: ../src/msw/ole/automtn.cpp:638
 msgid "Unknown exception"
 msgstr "Nieznany wyjątek"
 
-#: ../src/common/image.cpp:2839
+#: ../src/common/image.cpp:2942
 msgid "Unknown image data format."
 msgstr "Nieznany format graficzny"
 
-#: ../src/common/cmdline.cpp:914
+#: ../src/common/cmdline.cpp:910
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Nieznana długa opcja '%s'"
 
-#: ../src/msw/ole/automtn.cpp:631
+#: ../src/msw/ole/automtn.cpp:622
 msgid "Unknown name or named argument."
 msgstr "Nieprawidłowa nazwa lub nazwany argument."
 
-#: ../src/common/cmdline.cpp:929 ../src/common/cmdline.cpp:951
+#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Nieznana opcja '%s'"
 
 # inaczej
-#: ../src/common/mimecmn.cpp:225
+#: ../src/common/mimecmn.cpp:221
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "Nieodpowiedni '{' w pozycji dla typu mime %s."
 
-#: ../src/common/cmdproc.cpp:262 ../src/common/cmdproc.cpp:288
-#: ../src/common/cmdproc.cpp:308
+#: ../src/common/cmdproc.cpp:255 ../src/common/cmdproc.cpp:281
+#: ../src/common/cmdproc.cpp:301
 msgid "Unnamed command"
 msgstr "Polecenie bez nazwy"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:413
+#: ../src/propgrid/propgrid.cpp:392
 msgid "Unspecified"
 msgstr "Nieokreślony"
 
-#: ../src/msw/clipbrd.cpp:311
+#: ../src/msw/clipbrd.cpp:325
 msgid "Unsupported clipboard format."
 msgstr "Nieobsługiwany format schowka."
 
-#: ../src/common/appcmn.cpp:256
+#: ../src/common/appcmn.cpp:277
 #, c-format
 msgid "Unsupported theme '%s'."
 msgstr "Nieobsługiwana kompozycja '%s'."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:205
-#: ../src/common/accelcmn.cpp:63
+#: ../src/common/stockitem.cpp:202 ../src/common/accelcmn.cpp:60
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Up"
 msgstr "W górę"
 
@@ -7788,7 +7962,7 @@ msgid "Upper case roman numerals"
 msgstr "Duże litery cyframi rzymskimi"
 
 # hm
-#: ../src/common/cmdline.cpp:1326
+#: ../src/common/cmdline.cpp:1322
 #, c-format
 msgid "Usage: %s"
 msgstr "Użycie: %s"
@@ -7797,39 +7971,48 @@ msgstr "Użycie: %s"
 msgid "Use &shadow"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:169
-#: ../src/richtext/richtextindentspage.cpp:171
 #: ../src/richtext/richtextliststylepage.cpp:358
 #: ../src/richtext/richtextliststylepage.cpp:360
+#: ../src/richtext/richtextindentspage.cpp:169
+#: ../src/richtext/richtextindentspage.cpp:171
 msgid "Use the current alignment setting."
 msgstr "Użyj bieżącego dostosowywania ustawień."
 
-#: ../src/common/valtext.cpp:179
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/gtk/font.cpp:552
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/common/valtext.cpp:142
 msgid "Validation conflict"
 msgstr "Konflikt kontroli poprawności"
 
-#: ../src/propgrid/manager.cpp:238
+#: ../src/propgrid/manager.cpp:224
 msgid "Value"
 msgstr "Wartość"
 
-#: ../src/propgrid/props.cpp:386 ../src/propgrid/props.cpp:500
+#: ../src/propgrid/props.cpp:309
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "Wartość musi wynosić %s lub więcej."
 
-#: ../src/propgrid/props.cpp:417 ../src/propgrid/props.cpp:531
+#: ../src/propgrid/props.cpp:336
 #, c-format
 msgid "Value must be %s or less."
 msgstr "Wartość musi wynosić %s lub mniej."
 
-#: ../src/propgrid/props.cpp:393 ../src/propgrid/props.cpp:424
-#: ../src/propgrid/props.cpp:507 ../src/propgrid/props.cpp:538
+#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "Wartość musi zawierać się pomiędzy %s i %s."
 
 # prawa?
-#: ../src/generic/aboutdlgg.cpp:128
+#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Wersja"
 
@@ -7838,25 +8021,32 @@ msgstr "Wersja"
 msgid "Vertical alignment."
 msgstr "Wyrównanie pionowe."
 
-#: ../src/generic/filedlgg.cpp:202
+#: ../src/generic/filedlgg.cpp:199
 msgid "View files as a detailed view"
 msgstr "Przeglądaj pliki w formie szczegółowej listy"
 
-#: ../src/generic/filedlgg.cpp:200
+#: ../src/generic/filedlgg.cpp:197
 msgid "View files as a list view"
 msgstr "Przeglądaj pliki w formie listy"
 
-#: ../src/common/docview.cpp:1970
+#: ../src/common/docview.cpp:1975
 msgid "Views"
 msgstr "Widoki"
 
+#: ../src/gtk/app.cpp:348
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1777
+#: ../src/propgrid/advprops.cpp:1678
 msgid "Wait"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1779
+#: ../src/propgrid/advprops.cpp:1680
 msgid "Wait Arrow"
 msgstr ""
 
@@ -7865,244 +8055,241 @@ msgstr ""
 msgid "Waiting for IO on epoll descriptor %d failed"
 msgstr "Oczekiwanie na IO w deskryptorze epoll %d nie powiodło się"
 
-#: ../src/common/log.cpp:223
+#: ../src/common/log.cpp:241
 msgid "Warning: "
 msgstr "Ostrzeżenie: "
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1778
+#: ../src/propgrid/advprops.cpp:1679
 msgid "Watch"
 msgstr ""
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:685
+#: ../src/propgrid/advprops.cpp:595
 msgid "Weight"
 msgstr "Waga"
 
-#: ../src/common/fmapbase.cpp:148
+#: ../src/common/fmapbase.cpp:145
 msgid "Western European (ISO-8859-1)"
 msgstr "Zachodnioeuropejski (ISO-8859-1)"
 
-#: ../src/common/fmapbase.cpp:162
+#: ../src/common/fmapbase.cpp:159
 msgid "Western European with Euro (ISO-8859-15)"
 msgstr "Zachodnioeuropejski z Euro (ISO-8859-15)"
 
-#: ../src/generic/fontdlgg.cpp:446 ../src/generic/fontdlgg.cpp:448
+#: ../src/generic/fontdlgg.cpp:443 ../src/generic/fontdlgg.cpp:445
 msgid "Whether the font is underlined."
 msgstr "Określenie podkreślenia."
 
-#: ../src/propgrid/advprops.cpp:1611
+#: ../src/propgrid/advprops.cpp:1517
 msgid "White"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:144
+#: ../src/generic/fdrepdlg.cpp:141
 msgid "Whole word"
 msgstr "Całe słowo"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:532
 msgid "Whole words only"
 msgstr "Tylko całe słowa"
 
-#: ../src/univ/themes/win32.cpp:1102
+#: ../src/univ/themes/win32.cpp:1099
 msgid "Win32 theme"
 msgstr "Kompozycja Win32"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:893
+#: ../src/propgrid/advprops.cpp:794
 #, fuzzy
 msgid "Window"
 msgstr "&Okno"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:894
+#: ../src/propgrid/advprops.cpp:795
 #, fuzzy
 msgid "WindowFrame"
 msgstr "&Okno"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:895
+#: ../src/propgrid/advprops.cpp:796
 #, fuzzy
 msgid "WindowText"
 msgstr "&Okno"
 
-#: ../src/common/fmapbase.cpp:177
+#: ../src/common/fmapbase.cpp:174
 msgid "Windows Arabic (CP 1256)"
 msgstr "Windows arabski (CP 1256)"
 
-#: ../src/common/fmapbase.cpp:178
+#: ../src/common/fmapbase.cpp:175
 msgid "Windows Baltic (CP 1257)"
 msgstr "Windows bałtycki (CP 1257)"
 
-#: ../src/common/fmapbase.cpp:171
+#: ../src/common/fmapbase.cpp:168
 msgid "Windows Central European (CP 1250)"
 msgstr "Windows środkowoeuropejski (CP 1250)"
 
-#: ../src/common/fmapbase.cpp:168
+#: ../src/common/fmapbase.cpp:165
 msgid "Windows Chinese Simplified (CP 936) or GB-2312"
 msgstr "Windows chiński uproszczony (CP 936) lub GB-2312"
 
-#: ../src/common/fmapbase.cpp:170
+#: ../src/common/fmapbase.cpp:167
 msgid "Windows Chinese Traditional (CP 950) or Big-5"
 msgstr "Windows chiński tradycyjny (CP 950) lub Big-5"
 
-#: ../src/common/fmapbase.cpp:172
+#: ../src/common/fmapbase.cpp:169
 msgid "Windows Cyrillic (CP 1251)"
 msgstr "Windows cyrylica (CP 1251)"
 
-#: ../src/common/fmapbase.cpp:174
+#: ../src/common/fmapbase.cpp:171
 msgid "Windows Greek (CP 1253)"
 msgstr "Windows grecki (CP 1253)"
 
-#: ../src/common/fmapbase.cpp:176
+#: ../src/common/fmapbase.cpp:173
 msgid "Windows Hebrew (CP 1255)"
 msgstr "Windows hebrajski (CP 1255)"
 
-#: ../src/common/fmapbase.cpp:167
+#: ../src/common/fmapbase.cpp:164
 msgid "Windows Japanese (CP 932) or Shift-JIS"
 msgstr "Windows japoński (CP 932) lub Shift-JIS"
 
-#: ../src/common/fmapbase.cpp:180
+#: ../src/common/fmapbase.cpp:177
 msgid "Windows Johab (CP 1361)"
 msgstr "Windows Johab (CP 1361)"
 
-#: ../src/common/fmapbase.cpp:169
+#: ../src/common/fmapbase.cpp:166
 msgid "Windows Korean (CP 949)"
 msgstr "Windows koreański (CP 949)"
 
-#: ../src/common/fmapbase.cpp:166
+#: ../src/common/fmapbase.cpp:163
 msgid "Windows Thai (CP 874)"
 msgstr "Windows Thai (CP 874)"
 
-#: ../src/common/fmapbase.cpp:175
+#: ../src/common/fmapbase.cpp:172
 msgid "Windows Turkish (CP 1254)"
 msgstr "Windows turecki (CP 1254)"
 
-#: ../src/common/fmapbase.cpp:179
+#: ../src/common/fmapbase.cpp:176
 msgid "Windows Vietnamese (CP 1258)"
 msgstr "Windows Wietnamski (CP 1258)"
 
-#: ../src/common/fmapbase.cpp:173
+#: ../src/common/fmapbase.cpp:170
 msgid "Windows Western European (CP 1252)"
 msgstr "Windows zachodnioeuropejski (CP 1252)"
 
-#: ../src/common/fmapbase.cpp:181
+#: ../src/common/fmapbase.cpp:178
 msgid "Windows/DOS OEM (CP 437)"
 msgstr "Windows/DOS OEM (CP 437)"
 
-#: ../src/common/fmapbase.cpp:165
+#: ../src/common/fmapbase.cpp:162
 msgid "Windows/DOS OEM Cyrillic (CP 866)"
 msgstr "Windows/DOS OEM Cyrylica (CP 866)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:111
+#: ../src/common/accelcmn.cpp:109
 #, fuzzy
 msgid "Windows_Left"
 msgstr "Windows 7"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:113
+#: ../src/common/accelcmn.cpp:111
 #, fuzzy
 msgid "Windows_Menu"
 msgstr "Windows ME"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:112
+#: ../src/common/accelcmn.cpp:110
 #, fuzzy
 msgid "Windows_Right"
 msgstr "Windows Vista"
 
-#: ../src/common/ffile.cpp:150
+#: ../src/common/ffile.cpp:149
 #, c-format
 msgid "Write error on file '%s'"
 msgstr "Błąd zapisu do pliku '%s'"
 
-#: ../src/xml/xml.cpp:914
+#: ../src/xml/xml.cpp:925
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "Błąd parsowania XML: '%s' w linii %d"
 
-#: ../src/common/xpmdecod.cpp:796
+#: ../src/common/xpmdecod.cpp:794
 msgid "XPM: Malformed pixel data!"
 msgstr "XPM: Zniekształcone dane obrazu!"
 
-#: ../src/common/xpmdecod.cpp:705
+#: ../src/common/xpmdecod.cpp:702
 #, c-format
 msgid "XPM: incorrect colour description in line %d"
 msgstr "XPM: niepoprawny opis koloru w linijce %d"
 
-#: ../src/common/xpmdecod.cpp:680
+#: ../src/common/xpmdecod.cpp:677
 msgid "XPM: incorrect header format!"
 msgstr "XPM: niepoprawna nagłówka formatu!"
 
-#: ../src/common/xpmdecod.cpp:716 ../src/common/xpmdecod.cpp:725
+#: ../src/common/xpmdecod.cpp:714 ../src/common/xpmdecod.cpp:723
 #, c-format
 msgid "XPM: malformed colour definition '%s' at line %d!"
 msgstr "XPM: niepoprawna definicja koloru '%s 'w linijce %d!"
 
-#: ../src/common/xpmdecod.cpp:755
+#: ../src/common/xpmdecod.cpp:753
 msgid "XPM: no colors left to use for mask!"
 msgstr "XPM: nie zostało kolorów dla maski!"
 
-#: ../src/common/xpmdecod.cpp:782
+#: ../src/common/xpmdecod.cpp:780
 #, c-format
 msgid "XPM: truncated image data at line %d!"
 msgstr "XPM: obcięte dane obrazu w linijce %d!"
 
-#: ../src/propgrid/advprops.cpp:1610
+#: ../src/propgrid/advprops.cpp:1516
 msgid "Yellow"
 msgstr ""
 
-#: ../include/wx/msgdlg.h:276 ../src/common/stockitem.cpp:206
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:203
 #: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Tak"
 
-#: ../src/osx/carbon/overlay.cpp:155
-msgid "You cannot Clear an overlay that is not inited"
-msgstr "Nie można wyczyścić nakładki, która nie jest zainicjowana"
-
-#: ../src/osx/carbon/overlay.cpp:107 ../src/dfb/overlay.cpp:61
-msgid "You cannot Init an overlay twice"
-msgstr "Nie można uruchomić nakładki podwójnie"
-
-#: ../src/generic/dirdlgg.cpp:287
+#: ../src/generic/dirdlgg.cpp:284
 msgid "You cannot add a new directory to this section."
 msgstr "Nie możesz dodać nowego katalogu do tej sekcji."
 
-#: ../src/propgrid/propgrid.cpp:3299
+#: ../src/propgrid/propgrid.cpp:3276
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr "Wprowadzono nieprawidłową wartość. Naciśnij ESC by anulować edycję."
 
-#: ../src/common/stockitem.cpp:209
+#: ../src/osx/cocoa/menu.mm:286
+#, fuzzy
+msgid "Zoom"
+msgstr "Powiększenie"
+
+#: ../src/common/stockitem.cpp:206
 msgid "Zoom &In"
 msgstr "Powiększen&ie"
 
-#: ../src/common/stockitem.cpp:210
+#: ../src/common/stockitem.cpp:207
 msgid "Zoom &Out"
 msgstr "P&omniejszenie"
 
-#: ../src/common/stockitem.cpp:209 ../src/common/prntbase.cpp:1594
+#: ../src/common/stockitem.cpp:206 ../src/common/prntbase.cpp:1619
 msgid "Zoom In"
 msgstr "Powiększenie"
 
-#: ../src/common/stockitem.cpp:210 ../src/common/prntbase.cpp:1580
+#: ../src/common/stockitem.cpp:207 ../src/common/prntbase.cpp:1605
 msgid "Zoom Out"
 msgstr "Pomniejszenie"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to &Fit"
 msgstr "&Dopasowanie powiększenia"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to Fit"
 msgstr "Dopasowanie powiększenia"
 
-#: ../src/msw/dde.cpp:1141
+#: ../src/msw/dde.cpp:1205
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "Aplikacja DDEML utworzyła przedłużony wyścig (race condition)."
 
 # instance -->
-#: ../src/msw/dde.cpp:1129
+#: ../src/msw/dde.cpp:1193
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -8114,43 +8301,43 @@ msgstr ""
 "lub do funkcji DDEML przesłano\n"
 "nieprawidłowy identyfikator instancji."
 
-#: ../src/msw/dde.cpp:1147
+#: ../src/msw/dde.cpp:1211
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "próba nawiązania konwersacji przez klienta nie powiodła się."
 
-#: ../src/msw/dde.cpp:1144
+#: ../src/msw/dde.cpp:1208
 msgid "a memory allocation failed."
 msgstr "przydzielenie pamięci nie powiodło się."
 
-#: ../src/msw/dde.cpp:1138
+#: ../src/msw/dde.cpp:1202
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "parametr nie przeszedł kontroli poprawności DDEML"
 
-#: ../src/msw/dde.cpp:1120
+#: ../src/msw/dde.cpp:1184
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr ""
 "upłynął czas oczekiwania na rozpoczęcie synchronicznej transakcji advise."
 
-#: ../src/msw/dde.cpp:1126
+#: ../src/msw/dde.cpp:1190
 msgid "a request for a synchronous data transaction has timed out."
 msgstr ""
 "upłynął czas oczekiwania na rozpoczęcie synchronicznej transakcji data."
 
-#: ../src/msw/dde.cpp:1135
+#: ../src/msw/dde.cpp:1199
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr ""
 "upłynął czas oczekiwania na rozpoczęcie synchronicznej transakcji execute."
 
-#: ../src/msw/dde.cpp:1153
+#: ../src/msw/dde.cpp:1217
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr ""
 "upłynął czas oczekiwania na rozpoczęcie synchronicznej transakcji poke."
 
-#: ../src/msw/dde.cpp:1168
+#: ../src/msw/dde.cpp:1232
 msgid "a request to end an advise transaction has timed out."
 msgstr "upłynął czas oczekiwania na zakończenie trancakcji advise."
 
-#: ../src/msw/dde.cpp:1162
+#: ../src/msw/dde.cpp:1226
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -8160,16 +8347,16 @@ msgstr ""
 "zakończoną przez klienta, lub serwer\n"
 "zakończył pracę przez zakończeniem transakcji."
 
-#: ../src/msw/dde.cpp:1150
+#: ../src/msw/dde.cpp:1214
 msgid "a transaction failed."
 msgstr "transakcja nie powiodła się."
 
-#: ../src/common/accelcmn.cpp:189
+#: ../src/common/accelcmn.cpp:188
 msgid "alt"
 msgstr "alt"
 
 # transakcję normalnie wykonywaną przez serwer, inaczej
-#: ../src/msw/dde.cpp:1132
+#: ../src/msw/dde.cpp:1196
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -8181,15 +8368,15 @@ msgstr ""
 "lub aplikacja zainicjowana jako APPCMD_CLIENTONLY\n"
 "usiłowała wykonać transakcję serwera."
 
-#: ../src/msw/dde.cpp:1156
+#: ../src/msw/dde.cpp:1220
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "wewnętrzne wywołanie funkcji PostMessage zakończyło się niepowodzeniem"
 
-#: ../src/msw/dde.cpp:1165
+#: ../src/msw/dde.cpp:1229
 msgid "an internal error has occurred in the DDEML."
 msgstr "wystąpił wewnętrzny błąd w DDEML."
 
-#: ../src/msw/dde.cpp:1171
+#: ../src/msw/dde.cpp:1235
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -8199,56 +8386,56 @@ msgstr ""
 "Kiedy aplikacja kończy połączenie zwrotne XTYP_XACT_COMPLETE,\n"
 "identyfikator transakcji dla tego połączenia nie jest dłużej ważny."
 
-#: ../src/common/zipstrm.cpp:1483
+#: ../src/common/zipstrm.cpp:1522
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "założenie że jest to połączony wieloczęściowy zip"
 
-#: ../src/common/fileconf.cpp:1847
+#: ../src/common/fileconf.cpp:1849
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "zignorowano próbę zmiany niezmiennego klucza '%s'."
 
-#: ../src/html/chm.cpp:329
+#: ../src/html/chm.cpp:326
 msgid "bad arguments to library function"
 msgstr "błędne argumenty funkcji bibliotecznej"
 
-#: ../src/html/chm.cpp:341
+#: ../src/html/chm.cpp:338
 msgid "bad signature"
 msgstr "błędne oznaczenie"
 
-#: ../src/common/zipstrm.cpp:1918
+#: ../src/common/zipstrm.cpp:1988
 msgid "bad zipfile offset to entry"
 msgstr "błędne przemieszczenie w pliku zip"
 
-#: ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400
 msgid "binary"
 msgstr "binarny"
 
-#: ../src/common/fontcmn.cpp:996
+#: ../src/common/fontcmn.cpp:1195
 msgid "bold"
 msgstr "pogrubiony"
 
-#: ../src/msw/utils.cpp:1144
+#: ../src/msw/utils.cpp:1135
 #, c-format
 msgid "build %lu"
 msgstr "budowa %lu"
 
-#: ../src/common/ffile.cpp:75
+#: ../src/common/ffile.cpp:73
 #, c-format
 msgid "can't close file '%s'"
 msgstr "nie można zamknąć pliku '%s'"
 
-#: ../src/common/file.cpp:245
+#: ../src/common/file.cpp:242
 #, c-format
 msgid "can't close file descriptor %d"
 msgstr "nie można zamknąć deskryptora pliku %d"
 
-#: ../src/common/file.cpp:586
+#: ../src/common/ffile.cpp:382 ../src/common/file.cpp:613
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "nie można zatwierdzić zmian w pliku '%s'"
 
-#: ../src/common/file.cpp:178
+#: ../src/common/file.cpp:175
 #, c-format
 msgid "can't create file '%s'"
 msgstr "nie można utworzyć pliku '%s'"
@@ -8258,50 +8445,50 @@ msgstr "nie można utworzyć pliku '%s'"
 msgid "can't delete user configuration file '%s'"
 msgstr "nie można usunąć pliku konfiguracyjnego użytkownika '%s'"
 
-#: ../src/common/file.cpp:495
+#: ../src/common/file.cpp:522
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr "nie można określić czy osiągnięto koniec pliku w deskryptorze %d"
 
-#: ../src/common/zipstrm.cpp:1692
+#: ../src/common/zipstrm.cpp:1747
 msgid "can't find central directory in zip"
 msgstr "nie można znaleźć centralnego katalogu zip"
 
-#: ../src/common/file.cpp:465
+#: ../src/common/file.cpp:492
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "nie można znaleźć rozmiaru pliku w deskryptorze pliku %d"
 
-#: ../src/msw/utils.cpp:341
+#: ../src/msw/utils.cpp:336
 msgid "can't find user's HOME, using current directory."
 msgstr "nie można znaleźć katalogu domowego, zostanie użyty bieżący."
 
-#: ../src/common/file.cpp:366
+#: ../src/common/file.cpp:407
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "nie można opróżnić deskryptora pliku %d"
 
-#: ../src/common/file.cpp:422
+#: ../src/common/file.cpp:463
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "nie można odczytać bieżącej pozycji w deskryptorze pliku %d"
 
-#: ../src/common/fontmap.cpp:325
+#: ../src/common/fontmap.cpp:322
 msgid "can't load any font, aborting"
 msgstr "nie można załadować żadnej czcionki, program kończy pracę"
 
-#: ../src/common/file.cpp:231 ../src/common/ffile.cpp:59
+#: ../src/common/ffile.cpp:57 ../src/common/file.cpp:228
 #, c-format
 msgid "can't open file '%s'"
 msgstr "nie można otworzyć pliku '%s'"
 
 # globalnej?
-#: ../src/common/fileconf.cpp:320
+#: ../src/common/fileconf.cpp:314
 #, c-format
 msgid "can't open global configuration file '%s'."
 msgstr "nie można otworzyć globalnego pliku konfiguracji '%s'."
 
-#: ../src/common/fileconf.cpp:336
+#: ../src/common/fileconf.cpp:330
 #, c-format
 msgid "can't open user configuration file '%s'."
 msgstr "nie można otworzyć pliku konfiguracyjnego użytkownika '%s'."
@@ -8310,40 +8497,40 @@ msgstr "nie można otworzyć pliku konfiguracyjnego użytkownika '%s'."
 msgid "can't open user configuration file."
 msgstr "nie można otworzyć pliku konfiguracyjnego użytkownika."
 
-#: ../src/common/zipstrm.cpp:579
+#: ../src/common/zipstrm.cpp:572
 msgid "can't re-initialize zlib deflate stream"
 msgstr "nie można ponownie zainicjować strumienia kompresji biblioteki zlib"
 
-#: ../src/common/zipstrm.cpp:604
+#: ../src/common/zipstrm.cpp:597
 msgid "can't re-initialize zlib inflate stream"
 msgstr "nie można ponownie zainicjować strumienia dekompresji biblioteki zlib"
 
-#: ../src/common/file.cpp:304
+#: ../src/common/file.cpp:345
 #, c-format
 msgid "can't read from file descriptor %d"
 msgstr "nie można czytać z deskryptora pliku %d"
 
-#: ../src/common/file.cpp:581
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:608
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "nie można usunąć pliku '%s'"
 
-#: ../src/common/file.cpp:598
+#: ../src/common/ffile.cpp:394 ../src/common/file.cpp:625
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "nie można usunąć tymczasowego pliku '%s'"
 
-#: ../src/common/file.cpp:408
+#: ../src/common/file.cpp:449
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "nie można ustawić pozycji w deskryptorze pliku %d"
 
-#: ../src/common/textfile.cpp:273
+#: ../src/common/textfile.cpp:161
 #, c-format
 msgid "can't write buffer '%s' to disk."
 msgstr "nie można zapisać bufora '%s' na dysk."
 
-#: ../src/common/file.cpp:323
+#: ../src/common/file.cpp:364
 #, c-format
 msgid "can't write to file descriptor %d"
 msgstr "nie można zapisać do deskryptora pliku %d"
@@ -8353,22 +8540,28 @@ msgid "can't write user configuration file."
 msgstr "nie można zapisać pliku konfiguracyjnego użytkownika."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:482 ../src/generic/datavgen.cpp:1261
+#: ../src/common/datavcmn.cpp:2064 ../src/generic/datavgen.cpp:1384
 msgid "checked"
 msgstr ""
 
-#: ../src/html/chm.cpp:345
+#: ../src/html/chm.cpp:342
 msgid "checksum error"
 msgstr "błąd sumy kontrolnej"
 
-#: ../src/common/tarstrm.cpp:820
+#: ../src/common/tarstrm.cpp:814
 msgid "checksum failure reading tar header block"
 msgstr "Niepowodzenie sumy kontrolnej czytania nagłówka bloku tar"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:226
-#: ../src/richtext/richtextbackgroundpage.cpp:249
-#: ../src/richtext/richtextbackgroundpage.cpp:289
-#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
 #: ../src/richtext/richtextborderspage.cpp:254
 #: ../src/richtext/richtextborderspage.cpp:288
 #: ../src/richtext/richtextborderspage.cpp:322
@@ -8386,106 +8579,129 @@ msgstr "Niepowodzenie sumy kontrolnej czytania nagłówka bloku tar"
 #: ../src/richtext/richtextmarginspage.cpp:340
 #: ../src/richtext/richtextmarginspage.cpp:363
 #: ../src/richtext/richtextmarginspage.cpp:388
-#: ../src/richtext/richtextsizepage.cpp:339
-#: ../src/richtext/richtextsizepage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:400
-#: ../src/richtext/richtextsizepage.cpp:427
-#: ../src/richtext/richtextsizepage.cpp:454
-#: ../src/richtext/richtextsizepage.cpp:481
-#: ../src/richtext/richtextsizepage.cpp:555
-#: ../src/richtext/richtextsizepage.cpp:590
-#: ../src/richtext/richtextsizepage.cpp:625
-#: ../src/richtext/richtextsizepage.cpp:660
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
 msgid "cm"
 msgstr "cm"
 
-#: ../src/html/chm.cpp:347
+#: ../src/html/chm.cpp:344
 msgid "compression error"
 msgstr "błąd kompresji"
 
-#: ../src/common/regex.cpp:236
+#: ../src/common/regex.cpp:233
 msgid "conversion to 8-bit encoding failed"
 msgstr "nie powiodła się konwersja do kodowania '8-bit'"
 
-#: ../src/common/accelcmn.cpp:187
+#: ../src/common/accelcmn.cpp:186
 msgid "ctrl"
 msgstr "ctrl"
 
-#: ../src/common/cmdline.cpp:1500
+#: ../src/common/cmdline.cpp:1496
 msgid "date"
 msgstr "data"
 
-#: ../src/html/chm.cpp:349
+#: ../src/html/chm.cpp:346
 msgid "decompression error"
 msgstr "błąd dekompresji"
 
-#: ../src/richtext/richtextstyles.cpp:780 ../src/common/fmapbase.cpp:820
+#: ../src/common/fmapbase.cpp:816 ../src/richtext/richtextstyles.cpp:777
 msgid "default"
 msgstr "domyślny"
 
-#: ../src/common/cmdline.cpp:1496
+#: ../src/common/cmdline.cpp:1492
 msgid "double"
 msgstr "podwójnie"
 
-#: ../src/common/debugrpt.cpp:538
+#: ../src/common/debugrpt.cpp:539
 msgid "dump of the process state (binary)"
 msgstr "kopia stanu procesu (binarnie)"
 
-#: ../src/common/datetimefmt.cpp:1969
+#: ../src/common/datetimefmt.cpp:1992
 msgid "eighteenth"
 msgstr "osiemnasty"
 
-#: ../src/common/datetimefmt.cpp:1959
+#: ../src/common/datetimefmt.cpp:1982
 msgid "eighth"
 msgstr "ósmy"
 
-#: ../src/common/datetimefmt.cpp:1962
+#: ../src/common/datetimefmt.cpp:1985
 msgid "eleventh"
 msgstr "jedenasty"
 
-#: ../src/common/fileconf.cpp:1833
+#: ../src/common/fileconf.cpp:1835
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "pozycja '%s' występuje w grupie '%s' więcej niż jeden raz"
 
-#: ../src/html/chm.cpp:343
+#: ../src/html/chm.cpp:340
 msgid "error in data format"
 msgstr "błąd w formacie"
 
-#: ../src/html/chm.cpp:331
+#: ../src/html/chm.cpp:328
 msgid "error opening file"
 msgstr "błąd otwarcia pliku"
 
-#: ../src/common/zipstrm.cpp:1778
+#: ../src/common/zipstrm.cpp:1836
 msgid "error reading zip central directory"
 msgstr "błąd przy odczycie centralnego katalogu zip"
 
-#: ../src/common/zipstrm.cpp:1870
+#: ../src/common/zipstrm.cpp:1940
 msgid "error reading zip local header"
 msgstr "błąd odczytu lokalnego nagłówka zip"
 
-#: ../src/common/zipstrm.cpp:2531
+#: ../src/common/zipstrm.cpp:2615
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "błąd zapisu zip '%s': niepoprawna sygnatura crc lub długość"
 
+#: ../src/common/zipstrm.cpp:2608
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "błąd zapisu zip '%s': niepoprawna sygnatura crc lub długość"
+
+#: ../src/common/fontcmn.cpp:1205
+#, fuzzy
+msgid "extrabold"
+msgstr "pogrubiony"
+
+#: ../src/common/fontcmn.cpp:1223
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1167
+#, fuzzy
+msgid "extralight"
+msgstr "lekki"
+
+#: ../src/msw/webview_ie.cpp:1036
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "Nie udało się wykonać '%s'\n"
+
 # nie do końca...
-#: ../src/common/ffile.cpp:188
+#: ../src/common/ffile.cpp:187
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "nie udało się opróżnić (flush) pliku '%s'"
 
+#: ../src/msw/webview_ie.cpp:1045
+#, fuzzy
+msgid "failed to retrieve execution result"
+msgstr "Nie udało się uzyskać tekstu komunikatu błędu RAS"
+
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1030
+#: ../src/generic/datavgen.cpp:1150
 #, fuzzy
 msgid "false"
 msgstr "Fałsz"
 
-#: ../src/common/datetimefmt.cpp:1966
+#: ../src/common/datetimefmt.cpp:1989
 msgid "fifteenth"
 msgstr "piętnasty"
 
-#: ../src/common/datetimefmt.cpp:1956
+#: ../src/common/datetimefmt.cpp:1979
 msgid "fifth"
 msgstr "piąty"
 
@@ -8515,132 +8731,151 @@ msgstr "plik '%s', linia %d: zignorowano wartość dla niezmiennego klucza '%s'.
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "plik '%s': nieoczekiwany znak %c w lini %d."
 
-#: ../src/richtext/richtextbuffer.cpp:8738
+#: ../src/richtext/richtextbuffer.cpp:8736
 msgid "files"
 msgstr "pliki"
 
-#: ../src/common/datetimefmt.cpp:1952
+#: ../src/common/datetimefmt.cpp:1975
 msgid "first"
 msgstr "pierwszy"
 
-#: ../src/html/helpwnd.cpp:1252
+#: ../src/html/helpwnd.cpp:1250
 msgid "font size"
 msgstr "rozmiar czcionki"
 
-#: ../src/common/datetimefmt.cpp:1965
+#: ../src/common/datetimefmt.cpp:1988
 msgid "fourteenth"
 msgstr "czternasty"
 
-#: ../src/common/datetimefmt.cpp:1955
+#: ../src/common/datetimefmt.cpp:1978
 msgid "fourth"
 msgstr "czwarty"
 
 # inaczej
-#: ../src/common/appbase.cpp:783
+#: ../src/common/appbase.cpp:784
 msgid "generate verbose log messages"
 msgstr "generuje listę komunikatów"
 
-#: ../src/richtext/richtextbuffer.cpp:13138
-#: ../src/richtext/richtextbuffer.cpp:13248
+#: ../src/common/fontcmn.cpp:1215
+msgid "heavy"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:13133
+#: ../src/richtext/richtextbuffer.cpp:13243
 msgid "image"
 msgstr "obraz"
 
-#: ../src/common/tarstrm.cpp:796
+#: ../src/common/tarstrm.cpp:790
 msgid "incomplete header block in tar"
 msgstr "niekompletny blok nagłówka w tar"
 
-#: ../src/common/xtixml.cpp:489
+#: ../src/common/xtixml.cpp:485
 msgid "incorrect event handler string, missing dot"
 msgstr "nieprawidłowy uchwyt zdarzenia, brak kropki w nazwie"
 
-#: ../src/common/tarstrm.cpp:1381
+#: ../src/common/tarstrm.cpp:1375
 msgid "incorrect size given for tar entry"
 msgstr "nieprawidłowy rozmiar podany w wpisie tar"
 
-#: ../src/common/tarstrm.cpp:993
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:987
 msgid "invalid data in extended tar header"
 msgstr "nieprawidłowe dane w rozszerzonym nagłówku tar"
 
-#: ../src/generic/logg.cpp:1030
+#: ../src/generic/logg.cpp:1027
 msgid "invalid message box return value"
 msgstr "wartość zwrócona przez okno komunikatu jest nieprawidłowa"
 
-#: ../src/common/zipstrm.cpp:1647
+#: ../src/common/zipstrm.cpp:1688
 msgid "invalid zip file"
 msgstr "nieprawidłowy plik zip"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:1228
 msgid "italic"
 msgstr "kursywa"
 
-#: ../src/common/fontcmn.cpp:991
+#: ../src/common/webrequest_curl.cpp:374
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "Opis kolumny nie może być zainicjowany."
+
+#: ../src/common/fontcmn.cpp:1172
 msgid "light"
 msgstr "lekki"
 
-#: ../src/common/intl.cpp:303
-#, c-format
-msgid "locale '%s' cannot be set."
-msgstr "lokalizacja '%s' nie może być ustawiona."
+#: ../src/common/fontcmn.cpp:1185
+msgid "medium"
+msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2125
+#: ../src/common/datetimefmt.cpp:2148
 msgid "midnight"
 msgstr "północ"
 
-#: ../src/common/datetimefmt.cpp:1970
+#: ../src/common/datetimefmt.cpp:1993
 msgid "nineteenth"
 msgstr "dziewiętnasty"
 
-#: ../src/common/datetimefmt.cpp:1960
+#: ../src/common/datetimefmt.cpp:1983
 msgid "ninth"
 msgstr "dziewiąty"
 
-#: ../src/msw/dde.cpp:1116
+#: ../src/msw/dde.cpp:1180
 msgid "no DDE error."
 msgstr "bez błędu DDE."
 
-#: ../src/html/chm.cpp:327
+#: ../src/html/chm.cpp:324
 msgid "no error"
 msgstr "brak błędu"
 
-#: ../src/dfb/fontmgr.cpp:174
+#: ../src/dfb/fontmgr.cpp:171
 #, c-format
 msgid "no fonts found in %s, using builtin font"
 msgstr "nie znaleziono czcionek w %s, wykorzystując czcionki wypunktowania"
 
-#: ../src/html/helpdata.cpp:657
+#: ../src/html/helpdata.cpp:650
 msgid "noname"
 msgstr "beznazwy"
 
-#: ../src/common/datetimefmt.cpp:2124
+#: ../src/common/datetimefmt.cpp:2147
 msgid "noon"
 msgstr "południe"
 
-#: ../src/richtext/richtextstyles.cpp:779
+#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "Normalny"
 
-#: ../src/common/cmdline.cpp:1492
+#: ../src/common/cmdline.cpp:1488
 msgid "num"
 msgstr "liczba"
 
-#: ../src/common/xtixml.cpp:259
+#: ../src/common/accelcmn.cpp:194
+msgid "num "
+msgstr ""
+
+#: ../src/common/xtixml.cpp:255
 msgid "objects cannot have XML Text Nodes"
 msgstr "obiekty nie może mieć węzłów typu 'XML Text'"
 
-#: ../src/html/chm.cpp:339
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
 msgid "out of memory"
 msgstr "brak wolnej pamięci"
 
-#: ../src/common/debugrpt.cpp:514
+#: ../src/common/debugrpt.cpp:515
 msgid "process context description"
 msgstr "opis kontekstu procesu"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:227
-#: ../src/richtext/richtextbackgroundpage.cpp:250
-#: ../src/richtext/richtextbackgroundpage.cpp:290
-#: ../src/richtext/richtextbackgroundpage.cpp:317
-#: ../src/richtext/richtextfontpage.cpp:177
-#: ../src/richtext/richtextfontpage.cpp:180
 #: ../src/richtext/richtextborderspage.cpp:255
 #: ../src/richtext/richtextborderspage.cpp:289
 #: ../src/richtext/richtextborderspage.cpp:323
@@ -8650,22 +8885,45 @@ msgstr "opis kontekstu procesu"
 #: ../src/richtext/richtextborderspage.cpp:491
 #: ../src/richtext/richtextborderspage.cpp:525
 #: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextfontpage.cpp:180
 msgid "pt"
 msgstr "pt"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:225
-#: ../src/richtext/richtextbackgroundpage.cpp:228
-#: ../src/richtext/richtextbackgroundpage.cpp:229
-#: ../src/richtext/richtextbackgroundpage.cpp:248
-#: ../src/richtext/richtextbackgroundpage.cpp:251
-#: ../src/richtext/richtextbackgroundpage.cpp:252
-#: ../src/richtext/richtextbackgroundpage.cpp:288
-#: ../src/richtext/richtextbackgroundpage.cpp:291
-#: ../src/richtext/richtextbackgroundpage.cpp:292
-#: ../src/richtext/richtextbackgroundpage.cpp:315
-#: ../src/richtext/richtextbackgroundpage.cpp:318
-#: ../src/richtext/richtextbackgroundpage.cpp:319
-#: ../src/richtext/richtextfontpage.cpp:178
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:659
+#: ../src/richtext/richtextsizepage.cpp:662
+#: ../src/richtext/richtextsizepage.cpp:663
 #: ../src/richtext/richtextborderspage.cpp:253
 #: ../src/richtext/richtextborderspage.cpp:256
 #: ../src/richtext/richtextborderspage.cpp:257
@@ -8717,261 +8975,271 @@ msgstr "pt"
 #: ../src/richtext/richtextmarginspage.cpp:387
 #: ../src/richtext/richtextmarginspage.cpp:389
 #: ../src/richtext/richtextmarginspage.cpp:390
-#: ../src/richtext/richtextsizepage.cpp:338
-#: ../src/richtext/richtextsizepage.cpp:341
-#: ../src/richtext/richtextsizepage.cpp:342
-#: ../src/richtext/richtextsizepage.cpp:372
-#: ../src/richtext/richtextsizepage.cpp:375
-#: ../src/richtext/richtextsizepage.cpp:376
-#: ../src/richtext/richtextsizepage.cpp:399
-#: ../src/richtext/richtextsizepage.cpp:402
-#: ../src/richtext/richtextsizepage.cpp:403
-#: ../src/richtext/richtextsizepage.cpp:426
-#: ../src/richtext/richtextsizepage.cpp:429
-#: ../src/richtext/richtextsizepage.cpp:430
-#: ../src/richtext/richtextsizepage.cpp:453
-#: ../src/richtext/richtextsizepage.cpp:456
-#: ../src/richtext/richtextsizepage.cpp:457
-#: ../src/richtext/richtextsizepage.cpp:480
-#: ../src/richtext/richtextsizepage.cpp:483
-#: ../src/richtext/richtextsizepage.cpp:484
-#: ../src/richtext/richtextsizepage.cpp:554
-#: ../src/richtext/richtextsizepage.cpp:557
-#: ../src/richtext/richtextsizepage.cpp:558
-#: ../src/richtext/richtextsizepage.cpp:589
-#: ../src/richtext/richtextsizepage.cpp:592
-#: ../src/richtext/richtextsizepage.cpp:593
-#: ../src/richtext/richtextsizepage.cpp:624
-#: ../src/richtext/richtextsizepage.cpp:627
-#: ../src/richtext/richtextsizepage.cpp:628
-#: ../src/richtext/richtextsizepage.cpp:659
-#: ../src/richtext/richtextsizepage.cpp:662
-#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextfontpage.cpp:178
 msgid "px"
 msgstr "px"
 
-#: ../src/common/accelcmn.cpp:193
+#: ../src/common/accelcmn.cpp:192
 msgid "rawctrl"
 msgstr "rawctrl"
 
-#: ../src/html/chm.cpp:333
+#: ../src/html/chm.cpp:330
 msgid "read error"
 msgstr "błąd odczytu"
 
-#: ../src/common/zipstrm.cpp:2085
+#: ../src/common/zipstrm.cpp:2155
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "odczyt strumienia zip (%s): niepoprawna sygnatura crc"
 
-#: ../src/common/zipstrm.cpp:2080
+#: ../src/common/zipstrm.cpp:2150
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "odczyt strumienia zip (%s): niepoprawna długość"
 
-#: ../src/msw/dde.cpp:1159
+#: ../src/msw/dde.cpp:1223
 msgid "reentrancy problem."
 msgstr "problem współbieżności"
 
-#: ../src/common/datetimefmt.cpp:1953
+#: ../src/common/datetimefmt.cpp:1976
 msgid "second"
 msgstr "drugi"
 
-#: ../src/html/chm.cpp:337
+#: ../src/html/chm.cpp:334
 msgid "seek error"
 msgstr "błąd przeszukiwania"
 
-#: ../src/common/datetimefmt.cpp:1968
+#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#, fuzzy
+msgid "semibold"
+msgstr "pogrubiony"
+
+#: ../src/common/datetimefmt.cpp:1991
 msgid "seventeenth"
 msgstr "siedemnasty"
 
-#: ../src/common/datetimefmt.cpp:1958
+#: ../src/common/datetimefmt.cpp:1981
 msgid "seventh"
 msgstr "siódmy"
 
-#: ../src/common/accelcmn.cpp:191
+#: ../src/common/accelcmn.cpp:190
 msgid "shift"
 msgstr "shift"
 
-#: ../src/common/appbase.cpp:773
+#: ../src/common/appbase.cpp:774
 msgid "show this help message"
 msgstr "wyświetla ten komunikat"
 
-#: ../src/common/datetimefmt.cpp:1967
+#: ../src/common/datetimefmt.cpp:1990
 msgid "sixteenth"
 msgstr "szesnasty"
 
-#: ../src/common/datetimefmt.cpp:1957
+#: ../src/common/datetimefmt.cpp:1980
 msgid "sixth"
 msgstr "szósty"
 
-#: ../src/common/appcmn.cpp:234
+#: ../src/common/appcmn.cpp:255
 msgid "specify display mode to use (e.g. 640x480-16)"
 msgstr "określa tryb wyświetlania, który ma być użyty (np. 640x480-16)"
 
-#: ../src/common/appcmn.cpp:220
+#: ../src/common/appcmn.cpp:241
 msgid "specify the theme to use"
 msgstr "określa kompozycję, który ma być użyta"
 
-#: ../src/richtext/richtextbuffer.cpp:9340
+#: ../src/richtext/richtextbuffer.cpp:9337
 msgid "standard/circle"
 msgstr "standardowy/okrągły"
 
-#: ../src/richtext/richtextbuffer.cpp:9341
+#: ../src/richtext/richtextbuffer.cpp:9338
 msgid "standard/circle-outline"
 msgstr "standardowy/okrągły-kontur"
 
-#: ../src/richtext/richtextbuffer.cpp:9343
+#: ../src/richtext/richtextbuffer.cpp:9340
 msgid "standard/diamond"
 msgstr "standardowy/kątowy"
 
-#: ../src/richtext/richtextbuffer.cpp:9342
+#: ../src/richtext/richtextbuffer.cpp:9339
 msgid "standard/square"
 msgstr "standardowy/prostokątny"
 
-#: ../src/richtext/richtextbuffer.cpp:9344
+#: ../src/richtext/richtextbuffer.cpp:9341
 msgid "standard/triangle"
 msgstr "standardowy/trójkątny"
 
-#: ../src/common/zipstrm.cpp:1985
+#: ../src/common/zipstrm.cpp:2055
 msgid "stored file length not in Zip header"
 msgstr "długość pliku nie w nagłówku Zip"
 
-#: ../src/common/cmdline.cpp:1488
+#: ../src/common/cmdline.cpp:1484
 msgid "str"
 msgstr "tekst"
 
-#: ../src/common/fontcmn.cpp:982
+#: ../src/common/fontcmn.cpp:1145
 msgid "strikethrough"
 msgstr "Przekreślenie"
 
-#: ../src/common/tarstrm.cpp:1003 ../src/common/tarstrm.cpp:1025
-#: ../src/common/tarstrm.cpp:1507 ../src/common/tarstrm.cpp:1529
+#: ../src/common/tarstrm.cpp:997 ../src/common/tarstrm.cpp:1019
+#: ../src/common/tarstrm.cpp:1501 ../src/common/tarstrm.cpp:1523
 msgid "tar entry not open"
 msgstr "wpis tar nie otwarty"
 
-#: ../src/common/datetimefmt.cpp:1961
+#: ../src/common/datetimefmt.cpp:1984
 msgid "tenth"
 msgstr "dziesiąty"
 
 # niezręczne
-#: ../src/msw/dde.cpp:1123
+#: ../src/msw/dde.cpp:1187
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "odpowiedź na transakcję spowodowała ustawienie bitu DDE_FBUSY."
 
-#: ../src/common/datetimefmt.cpp:1954
+#: ../src/common/fontcmn.cpp:1154
+msgid "thin"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:1977
 msgid "third"
 msgstr "trzeci"
 
-#: ../src/common/datetimefmt.cpp:1964
+#: ../src/common/datetimefmt.cpp:1987
 msgid "thirteenth"
 msgstr "trzynasty"
 
-#: ../src/common/datetimefmt.cpp:1758
+#: ../src/common/datetimefmt.cpp:1781
 msgid "today"
 msgstr "dziś"
 
-#: ../src/common/datetimefmt.cpp:1760
+#: ../src/common/datetimefmt.cpp:1783
 msgid "tomorrow"
 msgstr "jutro"
 
-#: ../src/common/fileconf.cpp:1944
+#: ../src/common/fileconf.cpp:1946
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "końcowy ukośnik odwrotny zignorowany w '%s'"
 
-#: ../src/gtk/aboutdlg.cpp:218
+#: ../src/gtk/aboutdlg.cpp:216
 msgid "translator-credits"
 msgstr "Michał Trzebiatowski"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1028
+#: ../src/generic/datavgen.cpp:1148
 msgid "true"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1963
+#: ../src/common/datetimefmt.cpp:1986
 msgid "twelfth"
 msgstr "dwunasty"
 
-#: ../src/common/datetimefmt.cpp:1971
+#: ../src/common/datetimefmt.cpp:1994
 msgid "twentieth"
 msgstr "dwudziesty"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:486 ../src/generic/datavgen.cpp:1263
+#: ../src/common/datavcmn.cpp:2068 ../src/generic/datavgen.cpp:1386
 msgid "unchecked"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:802 ../src/common/fontcmn.cpp:978
+#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
 msgid "underlined"
 msgstr "podkreślony"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:490
+#: ../src/common/datavcmn.cpp:2072
 #, fuzzy
 msgid "undetermined"
 msgstr "podkreślony"
 
-#: ../src/common/fileconf.cpp:1979
+#: ../src/common/fileconf.cpp:1981
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "nieoczekiwany \" na pozycji %d w '%s'."
 
-#: ../src/common/tarstrm.cpp:1045
+#: ../src/common/tarstrm.cpp:1039
 msgid "unexpected end of file"
 msgstr "nieoczekiwany koniec pliku"
 
-#: ../src/generic/progdlgg.cpp:370 ../src/common/tarstrm.cpp:371
-#: ../src/common/tarstrm.cpp:394 ../src/common/tarstrm.cpp:425
+#: ../src/common/tarstrm.cpp:366 ../src/common/tarstrm.cpp:389
+#: ../src/common/tarstrm.cpp:420 ../src/generic/progdlgg.cpp:376
 msgid "unknown"
 msgstr "nieznany"
 
-#: ../src/msw/registry.cpp:150
+#: ../src/msw/registry.cpp:139
 #, fuzzy, c-format
 msgid "unknown (%lu)"
 msgstr "nieznany"
 
-#: ../src/common/xtixml.cpp:253
+#: ../src/common/xtixml.cpp:249
 #, c-format
 msgid "unknown class %s"
 msgstr "nieznana klasa %s"
 
-#: ../src/common/regex.cpp:258 ../src/html/chm.cpp:351
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "błąd kompresji"
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "błąd dekompresji"
+
+#: ../src/common/regex.cpp:255 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "nieznany błąd"
 
-#: ../src/msw/dialup.cpp:471
+#: ../src/msw/dialup.cpp:465
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "nieznany błąd (kod błędu %08x)."
 
-#: ../src/common/fmapbase.cpp:834
+#: ../src/common/fmapbase.cpp:830
 #, c-format
 msgid "unknown-%d"
 msgstr "nieznany-%d"
 
-#: ../src/common/docview.cpp:509
+#: ../src/common/docview.cpp:502
 msgid "unnamed"
 msgstr "beznazwy"
 
-#: ../src/common/docview.cpp:1624
+#: ../src/common/docview.cpp:1618
 #, c-format
 msgid "unnamed%d"
 msgstr "beznazwy%d"
 
-#: ../src/common/zipstrm.cpp:1999 ../src/common/zipstrm.cpp:2319
+#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
 msgid "unsupported Zip compression method"
 msgstr "niewspierana metoda kompresji Zip"
 
-#: ../src/common/translation.cpp:1892
+#: ../src/common/translation.cpp:1942
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "użycie katalogu '%s' z '%s'."
 
-#: ../src/html/chm.cpp:335
+#: ../src/html/chm.cpp:332
 msgid "write error"
 msgstr "błąd zapisu"
 
-#: ../src/common/time.cpp:292
+#: ../src/gtk/glcanvas.cpp:187
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/common/time.cpp:285
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay zwróciło błąd."
 
@@ -8984,15 +9252,15 @@ msgstr "Nie można zainicjować wyświetlania dla '%s': program kończy pracę."
 msgid "wxWidgets could not open display. Exiting."
 msgstr "Nie można zainicjować wyświetlania. Program kończy pracę."
 
-#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:431
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/common/datetimefmt.cpp:1759
+#: ../src/common/datetimefmt.cpp:1782
 msgid "yesterday"
 msgstr "wczoraj"
 
-#: ../src/common/zstream.cpp:251 ../src/common/zstream.cpp:426
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
 #, c-format
 msgid "zlib error %d"
 msgstr "błąd biblioteki zlib %d"
@@ -9001,6 +9269,78 @@ msgstr "błąd biblioteki zlib %d"
 #: ../src/richtext/richtextbulletspage.cpp:288
 msgid "~"
 msgstr "~"
+
+#~ msgid "&Save as"
+#~ msgstr "Zapisz &Jako"
+
+#, fuzzy
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' powinien zawierać tylko wartości znakowe."
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' powinno być numeryczne."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' powinien zawierać tylko znaki ASCII."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' powinien zawierać tylko wartości znakowe."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' powinien zawierać tylko wartości znakowe lub numeryczne."
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' powinien zawierać tylko cyfry."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "Nie można utworzyć okna klasy '%s'"
+
+#, fuzzy
+#~ msgid "Could not initalize libnotify."
+#~ msgstr "Nie można ustawić wyrównania."
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "Nie można utworzyć okna nakładki"
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "Nie można zainicjować kontekstu w oknie nakładki"
+
+# uchwyt chyba zbędny
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "Nie udało się zamienić pliku \"%s\" na Unicode."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "Nie udało się ustawić tekstu w kontroli tekstu."
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr "Nieprawidłowa opcja GTK+ wiersza poleceń, należy użyć \"%s --help\""
+
+#~ msgid "No unused colour in image."
+#~ msgstr "Brak wolnych kolorów w obrazie."
+
+#~ msgid "Not available"
+#~ msgstr "Niedostępne"
+
+#~ msgid "Replace selection"
+#~ msgstr "Zastąp wybór"
+
+#~ msgid "Save as"
+#~ msgstr "Zapisz jako"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Organizator stylu"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "Następujące opcje standardowe GTK+ także są obsługiwane:\n"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "Nie można wyczyścić nakładki, która nie jest zainicjowana"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "Nie można uruchomić nakładki podwójnie"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "lokalizacja '%s' nie może być ustawiona."
 
 #~ msgid "Adding flavor TEXT failed"
 #~ msgstr "Dodanie rodzaju TEXT zawiodło"
@@ -9019,9 +9359,6 @@ msgstr "~"
 
 #~ msgid "Column could not be added."
 #~ msgstr "Kolumna nie mogła być dodana."
-
-#~ msgid "Column description could not be initialized."
-#~ msgstr "Opis kolumny nie może być zainicjowany."
 
 # catalog file --> ?
 # domain --> ?
@@ -9605,9 +9942,6 @@ msgstr "~"
 #~ msgid "Directory '%s' doesn't exist!"
 #~ msgstr "Katalog '%s' nie istnieje!"
 
-#~ msgid "File %s does not exist."
-#~ msgstr "Plik %s nie istnieje."
-
 # sprawdzić "tryb", może "nie jest", "nie" - razem czy osobno,
 #~ msgid "Mode %ix%i-%i not available."
 #~ msgstr "Tryb %ix%i-%i nie jest dostępny."
@@ -9725,9 +10059,6 @@ msgstr "~"
 
 #~ msgid "Failed to register OpenGL window class."
 #~ msgstr "Nie udała się rejestracja klasy okna OpenGL."
-
-#~ msgid "Fatal error"
-#~ msgstr "Błąd krytyczny "
 
 #~ msgid "Fatal error: "
 #~ msgstr "Błąd krytyczny: "
@@ -9920,9 +10251,6 @@ msgstr "~"
 
 #~ msgid "&Print"
 #~ msgstr "&Drukuj"
-
-#~ msgid "*** A debug report has been generated\n"
-#~ msgstr "*** Raport błędów został wygenerowany\n"
 
 #~ msgid "*** It can be found in \"%s\"\n"
 #~ msgstr "*** Znajduje się w \"%s\"\n"

--- a/locale/pt.po
+++ b/locale/pt.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-21 14:25+0200\n"
+"POT-Creation-Date: 2020-10-18 23:11+0300\n"
 "PO-Revision-Date: 2014-03-07 16:07+0100\n"
 "Last-Translator: Alfredo <.>\n"
 "Language-Team: Portuguese <opensuse-pt@opensuse.org>\n"
@@ -20,7 +20,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Virtaal 0.7.1\n"
 
-#: ../src/common/debugrpt.cpp:586
+#: ../src/common/debugrpt.cpp:587
 msgid ""
 "\n"
 "Please send this report to the program maintainer, thank you!\n"
@@ -28,8 +28,8 @@ msgstr ""
 "\n"
 "Por favor, envie este relatório para o programador, obrigado!\n"
 
-#: ../src/richtext/richtextstyledlg.cpp:210
-#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:206
+#: ../src/richtext/richtextstyledlg.cpp:218
 msgid " "
 msgstr " "
 
@@ -37,70 +37,96 @@ msgstr " "
 msgid "              Thank you and we're sorry for the inconvenience!\n"
 msgstr "              Obrigado e desculpe-nos pela inconveniência!\n"
 
-#: ../src/common/prntbase.cpp:573
+#: ../src/common/prntbase.cpp:568
 #, c-format
 msgid " (copy %d of %d)"
 msgstr " (cópia %d de %d)"
 
-#: ../src/common/log.cpp:421
+#: ../src/common/log.cpp:440
 #, c-format
 msgid " (error %ld: %s)"
 msgstr " (erro %ld: %s)"
 
-#: ../src/common/imagtiff.cpp:72
+#: ../src/common/imagtiff.cpp:69
 #, c-format
 msgid " (in module \"%s\")"
 msgstr " (no módulo \"%s\")"
 
-#: ../src/osx/core/secretstore.cpp:138
-msgid " (while overwriting an existing item)"
-msgstr ""
-
-#: ../src/common/docview.cpp:1642
+#: ../src/common/docview.cpp:1636
 msgid " - "
 msgstr " - "
 
-#: ../src/richtext/richtextprint.cpp:593 ../src/html/htmprint.cpp:714
+#: ../src/html/htmprint.cpp:712 ../src/richtext/richtextprint.cpp:589
 msgid " Preview"
 msgstr " Antevisão"
 
-#: ../src/common/fontcmn.cpp:824
+#: ../src/common/fontcmn.cpp:973
 msgid " bold"
 msgstr " negrito"
 
-#: ../src/common/fontcmn.cpp:840
+#: ../src/common/fontcmn.cpp:977
+#, fuzzy
+msgid " extra bold"
+msgstr " negrito"
+
+#: ../src/common/fontcmn.cpp:985
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:957
+#, fuzzy
+msgid " extra light"
+msgstr " leve"
+
+#: ../src/common/fontcmn.cpp:981
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1001
 msgid " italic"
 msgstr " itálico"
 
-#: ../src/common/fontcmn.cpp:820
+#: ../src/common/fontcmn.cpp:961
 msgid " light"
 msgstr " leve"
 
-#: ../src/common/fontcmn.cpp:807
+#: ../src/common/fontcmn.cpp:965
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:969
+#, fuzzy
+msgid " semi bold"
+msgstr " negrito"
+
+#: ../src/common/fontcmn.cpp:940
 msgid " strikethrough"
 msgstr " rasurado"
 
-#: ../src/common/paper.cpp:117
+#: ../src/common/fontcmn.cpp:953
+msgid " thin"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
 msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
 msgstr "Envelope #10, 4 1/8 x 9 1/2 pol."
 
-#: ../src/common/paper.cpp:118
+#: ../src/common/paper.cpp:115
 msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
 msgstr "Envelope #11, 4 1/2 x 10 3/8 pol."
 
-#: ../src/common/paper.cpp:119
+#: ../src/common/paper.cpp:116
 msgid "#12 Envelope, 4 3/4 x 11 in"
 msgstr "Envelope #12, 4 3/4 x 11 pol."
 
-#: ../src/common/paper.cpp:120
+#: ../src/common/paper.cpp:117
 msgid "#14 Envelope, 5 x 11 1/2 in"
 msgstr "Envelope #14, 5 x 11 1/2 pol."
 
-#: ../src/common/paper.cpp:116
+#: ../src/common/paper.cpp:113
 msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
 msgstr "Envelope #9, 3 7/8 x 8 7/8 pol."
 
-#: ../src/richtext/richtextbackgroundpage.cpp:341
 #: ../src/richtext/richtextsizepage.cpp:340
 #: ../src/richtext/richtextsizepage.cpp:374
 #: ../src/richtext/richtextsizepage.cpp:401
@@ -111,82 +137,83 @@ msgstr "Envelope #9, 3 7/8 x 8 7/8 pol."
 #: ../src/richtext/richtextsizepage.cpp:591
 #: ../src/richtext/richtextsizepage.cpp:626
 #: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextbackgroundpage.cpp:341
 #, fuzzy
 msgid "%"
 msgstr "%s B"
 
-#: ../src/html/helpwnd.cpp:1031
+#: ../src/html/helpwnd.cpp:1029
 #, c-format
 msgid "%d of %lu"
 msgstr "%d de %lu"
 
-#: ../src/html/helpwnd.cpp:1678
+#: ../src/html/helpwnd.cpp:1676
 #, fuzzy, c-format
 msgid "%i of %u"
 msgstr "%i de %i"
 
-#: ../src/generic/filectrlg.cpp:279
+#: ../src/generic/filectrlg.cpp:275
 #, c-format
 msgid "%ld byte"
 msgid_plural "%ld bytes"
 msgstr[0] "%ld byte"
 msgstr[1] "%ld bytes"
 
-#: ../src/html/helpwnd.cpp:1033
+#: ../src/html/helpwnd.cpp:1031
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu de %lu"
 
-#: ../src/generic/datavgen.cpp:6028
+#: ../src/generic/datavgen.cpp:6833
 #, fuzzy, c-format
 msgid "%s (%d items)"
 msgstr "%s (ou %s)"
 
-#: ../src/common/cmdline.cpp:1221
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (ou %s)"
 
-#: ../src/generic/logg.cpp:224
+#: ../src/generic/logg.cpp:221
 #, c-format
 msgid "%s Error"
 msgstr "%s Erro"
 
-#: ../src/generic/logg.cpp:236
+#: ../src/generic/logg.cpp:233
 #, c-format
 msgid "%s Information"
 msgstr "%s Informação"
 
-#: ../src/generic/preferencesg.cpp:113
+#: ../src/generic/preferencesg.cpp:110
 #, c-format
 msgid "%s Preferences"
 msgstr "%s Preferências"
 
-#: ../src/generic/logg.cpp:228
+#: ../src/generic/logg.cpp:225
 #, c-format
 msgid "%s Warning"
 msgstr "%s Aviso"
 
-#: ../src/common/tarstrm.cpp:1319
+#: ../src/common/tarstrm.cpp:1313
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s não coube no cabeçalho tar para a entrada '%s'"
 
-#: ../src/common/fldlgcmn.cpp:124
+#: ../src/common/fldlgcmn.cpp:121
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s ficheiros (%s)|%s"
 
-#: ../src/html/helpwnd.cpp:1716
+#: ../src/html/helpwnd.cpp:1714
 #, fuzzy, c-format
 msgid "%u of %u"
 msgstr "%lu de %lu"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "&About"
 msgstr "&Sobre"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "&Actual Size"
 msgstr "T&amanho Atual"
 
@@ -194,28 +221,28 @@ msgstr "T&amanho Atual"
 msgid "&After a paragraph:"
 msgstr "&Depois de um parágrafo:"
 
-#: ../src/richtext/richtextindentspage.cpp:128
 #: ../src/richtext/richtextliststylepage.cpp:319
+#: ../src/richtext/richtextindentspage.cpp:128
 msgid "&Alignment"
 msgstr "&Alinhamento"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "&Apply"
 msgstr "&Aplicar"
 
-#: ../src/richtext/richtextstyledlg.cpp:251
+#: ../src/richtext/richtextstyledlg.cpp:247
 msgid "&Apply Style"
 msgstr "&Aplicar Estilo"
 
-#: ../src/msw/mdi.cpp:179
+#: ../src/msw/mdi.cpp:174
 msgid "&Arrange Icons"
 msgstr "&Organizar Ícones"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "&Ascending"
 msgstr "&Ascendente"
 
-#: ../src/common/stockitem.cpp:142
+#: ../src/common/stockitem.cpp:139
 msgid "&Back"
 msgstr "&Retroceder"
 
@@ -236,24 +263,24 @@ msgstr "&Cor:"
 msgid "&Blur distance:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:143
+#: ../src/common/stockitem.cpp:140
 msgid "&Bold"
 msgstr "&Negrito"
 
-#: ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141
 msgid "&Bottom"
 msgstr "&Base"
 
+#: ../src/richtext/richtextsizepage.cpp:637
+#: ../src/richtext/richtextsizepage.cpp:644
 #: ../src/richtext/richtextborderspage.cpp:345
 #: ../src/richtext/richtextborderspage.cpp:513
 #: ../src/richtext/richtextmarginspage.cpp:259
 #: ../src/richtext/richtextmarginspage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:637
-#: ../src/richtext/richtextsizepage.cpp:644
 msgid "&Bottom:"
 msgstr "&Base:"
 
-#: ../include/wx/richtext/richtextbuffer.h:3866
+#: ../include/wx/richtext/richtextbuffer.h:3861
 #, fuzzy
 msgid "&Box"
 msgstr "&Destacado"
@@ -263,38 +290,38 @@ msgstr "&Destacado"
 msgid "&Bullet style:"
 msgstr "Estilo do &Marcador:"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "&CD-Rom"
 msgstr "&CD-Rom"
 
-#: ../src/generic/wizard.cpp:434 ../src/generic/fontdlgg.cpp:470
-#: ../src/generic/fontdlgg.cpp:489 ../src/osx/carbon/fontdlg.cpp:402
-#: ../src/common/dlgcmn.cpp:279 ../src/common/stockitem.cpp:145
+#: ../src/osx/carbon/fontdlg.cpp:399 ../src/common/stockitem.cpp:142
+#: ../src/generic/wizard.cpp:433 ../src/generic/fontdlgg.cpp:466
+#: ../src/generic/fontdlgg.cpp:485 ../src/osx/cocoa/button.mm:200
 msgid "&Cancel"
 msgstr "&Cancelar"
 
-#: ../src/msw/mdi.cpp:175
+#: ../src/msw/mdi.cpp:170
 msgid "&Cascade"
 msgstr "&Cascata"
 
-#: ../include/wx/richtext/richtextbuffer.h:5960
+#: ../include/wx/richtext/richtextbuffer.h:5955
 msgid "&Cell"
 msgstr "&Célula"
 
-#: ../src/richtext/richtextsymboldlg.cpp:439
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "&Character code:"
 msgstr "Código de &Caracter:"
 
-#: ../src/common/stockitem.cpp:147
+#: ../src/common/stockitem.cpp:144
 msgid "&Clear"
 msgstr "&Limpar"
 
-#: ../src/generic/logg.cpp:516 ../src/common/stockitem.cpp:148
-#: ../src/common/prntbase.cpp:1600 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/stockitem.cpp:145 ../src/common/prntbase.cpp:1625
+#: ../src/univ/themes/win32.cpp:3753 ../src/generic/logg.cpp:513
 msgid "&Close"
 msgstr "&Fechar"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 #, fuzzy
 msgid "&Color"
 msgstr "&Cor:"
@@ -303,20 +330,20 @@ msgstr "&Cor:"
 msgid "&Colour:"
 msgstr "&Cor:"
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "&Convert"
 msgstr "&Converter"
 
-#: ../src/richtext/richtextctrl.cpp:333 ../src/osx/textctrl_osx.cpp:577
-#: ../src/common/stockitem.cpp:150 ../src/msw/textctrl.cpp:2508
+#: ../src/osx/textctrl_osx.cpp:595 ../src/common/stockitem.cpp:147
+#: ../src/msw/textctrl.cpp:2773 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Copiar"
 
-#: ../src/generic/hyperlinkg.cpp:156
+#: ../src/generic/hyperlinkg.cpp:153
 msgid "&Copy URL"
 msgstr "&Copiar URL"
 
-#: ../src/common/headerctrlcmn.cpp:306
+#: ../src/common/headerctrlcmn.cpp:304
 msgid "&Customize..."
 msgstr "&Personalizar ..."
 
@@ -324,53 +351,54 @@ msgstr "&Personalizar ..."
 msgid "&Debug report preview:"
 msgstr "Antevisão do relatório de &depuração:"
 
-#: ../src/richtext/richtexttabspage.cpp:138
-#: ../src/richtext/richtextctrl.cpp:335 ../src/osx/textctrl_osx.cpp:579
-#: ../src/common/stockitem.cpp:152 ../src/msw/textctrl.cpp:2510
+#: ../src/osx/textctrl_osx.cpp:597 ../src/common/stockitem.cpp:149
+#: ../src/msw/textctrl.cpp:2775 ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtextctrl.cpp:334
 msgid "&Delete"
 msgstr "&Apagar"
 
-#: ../src/richtext/richtextstyledlg.cpp:269
+#: ../src/richtext/richtextstyledlg.cpp:265
 msgid "&Delete Style..."
 msgstr "&Apagar Estilo..."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "&Descending"
 msgstr "&Descendente"
 
-#: ../src/generic/logg.cpp:682
+#: ../src/generic/logg.cpp:679
 msgid "&Details"
 msgstr "&Detalhes"
 
-#: ../src/common/stockitem.cpp:153
+#: ../src/common/stockitem.cpp:150
 msgid "&Down"
 msgstr "&Baixo"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "&Edit"
 msgstr "&Editar"
 
-#: ../src/richtext/richtextstyledlg.cpp:263
+#: ../src/richtext/richtextstyledlg.cpp:259
 msgid "&Edit Style..."
 msgstr "&Editar Estilo..."
 
-#: ../src/common/stockitem.cpp:155
+#: ../src/common/stockitem.cpp:152
 msgid "&Execute"
 msgstr "&Executar"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/common/stockitem.cpp:154
 msgid "&File"
 msgstr "&Ficheiro"
 
-#: ../src/common/stockitem.cpp:158
-msgid "&Find"
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "&Find..."
 msgstr "&Procurar"
 
-#: ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:430
 msgid "&Finish"
 msgstr "&Terminar"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:156
 msgid "&First"
 msgstr "&Primeiro"
 
@@ -378,15 +406,15 @@ msgstr "&Primeiro"
 msgid "&Floating mode:"
 msgstr "Modo &Flutuante:"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "&Floppy"
 msgstr "&Disquete"
 
-#: ../src/common/stockitem.cpp:194
+#: ../src/common/stockitem.cpp:191
 msgid "&Font"
 msgstr "&Tipo de letra:"
 
-#: ../src/generic/fontdlgg.cpp:371
+#: ../src/generic/fontdlgg.cpp:367
 msgid "&Font family:"
 msgstr "Família de &fonte:"
 
@@ -394,20 +422,20 @@ msgstr "Família de &fonte:"
 msgid "&Font for Level..."
 msgstr "&Fonte para Nível..."
 
+#: ../src/richtext/richtextsymboldlg.cpp:397
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:400
 msgid "&Font:"
 msgstr "&Fonte:"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "&Forward"
 msgstr "&Avançar"
 
-#: ../src/richtext/richtextsymboldlg.cpp:451
+#: ../src/richtext/richtextsymboldlg.cpp:448
 msgid "&From:"
 msgstr "&De:"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "&Harddisk"
 msgstr "Disco &Rígido"
 
@@ -416,9 +444,9 @@ msgstr "Disco &Rígido"
 msgid "&Height:"
 msgstr "&Altura:"
 
-#: ../src/generic/wizard.cpp:441 ../src/richtext/richtextstyledlg.cpp:303
-#: ../src/richtext/richtextsymboldlg.cpp:479 ../src/osx/menu_osx.cpp:734
-#: ../src/common/stockitem.cpp:163
+#: ../src/common/stockitem.cpp:160 ../src/generic/wizard.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextstyledlg.cpp:299 ../src/osx/cocoa/menu.mm:226
 msgid "&Help"
 msgstr "&Ajuda"
 
@@ -426,7 +454,7 @@ msgstr "&Ajuda"
 msgid "&Hide details"
 msgstr "Ocultar &Detalhes"
 
-#: ../src/common/stockitem.cpp:164
+#: ../src/common/stockitem.cpp:161
 msgid "&Home"
 msgstr "&Início"
 
@@ -434,54 +462,54 @@ msgstr "&Início"
 msgid "&Horizontal offset:"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:184
 #: ../src/richtext/richtextliststylepage.cpp:372
+#: ../src/richtext/richtextindentspage.cpp:184
 msgid "&Indentation (tenths of a mm)"
 msgstr "&Indentação (décimos de mm)"
 
-#: ../src/richtext/richtextindentspage.cpp:167
 #: ../src/richtext/richtextliststylepage.cpp:356
+#: ../src/richtext/richtextindentspage.cpp:167
 msgid "&Indeterminate"
 msgstr "&Indeterminado"
 
-#: ../src/common/stockitem.cpp:166
+#: ../src/common/stockitem.cpp:163
 msgid "&Index"
 msgstr "&Índice"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "&Info"
 msgstr "&Informação"
 
-#: ../src/common/stockitem.cpp:168
+#: ../src/common/stockitem.cpp:165
 msgid "&Italic"
 msgstr "&Itálico"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "&Jump to"
 msgstr "&Ir para"
 
-#: ../src/richtext/richtextindentspage.cpp:153
 #: ../src/richtext/richtextliststylepage.cpp:342
+#: ../src/richtext/richtextindentspage.cpp:153
 msgid "&Justified"
 msgstr "&Justificado"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "&Last"
 msgstr "&Último"
 
-#: ../src/richtext/richtextindentspage.cpp:139
 #: ../src/richtext/richtextliststylepage.cpp:328
+#: ../src/richtext/richtextindentspage.cpp:139
 msgid "&Left"
 msgstr "&Esquerda"
 
-#: ../src/richtext/richtextindentspage.cpp:195
+#: ../src/richtext/richtextsizepage.cpp:532
+#: ../src/richtext/richtextsizepage.cpp:539
 #: ../src/richtext/richtextborderspage.cpp:243
 #: ../src/richtext/richtextborderspage.cpp:411
 #: ../src/richtext/richtextliststylepage.cpp:381
+#: ../src/richtext/richtextindentspage.cpp:195
 #: ../src/richtext/richtextmarginspage.cpp:186
 #: ../src/richtext/richtextmarginspage.cpp:300
-#: ../src/richtext/richtextsizepage.cpp:532
-#: ../src/richtext/richtextsizepage.cpp:539
 msgid "&Left:"
 msgstr "&Esquerda:"
 
@@ -489,11 +517,11 @@ msgstr "&Esquerda:"
 msgid "&List level:"
 msgstr "&Lista de nível:"
 
-#: ../src/generic/logg.cpp:517
+#: ../src/generic/logg.cpp:514
 msgid "&Log"
 msgstr "&Registo"
 
-#: ../src/univ/themes/win32.cpp:3748
+#: ../src/univ/themes/win32.cpp:3745
 msgid "&Move"
 msgstr "&Mover"
 
@@ -501,20 +529,19 @@ msgstr "&Mover"
 msgid "&Move the object to:"
 msgstr "&Mover o objeto para:"
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "&Network"
 msgstr "&Rede"
 
-#: ../src/richtext/richtexttabspage.cpp:132 ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173 ../src/richtext/richtexttabspage.cpp:132
 msgid "&New"
 msgstr "&Novo"
 
-#: ../src/aui/tabmdi.cpp:111 ../src/generic/mdig.cpp:100
-#: ../src/msw/mdi.cpp:180
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
 msgid "&Next"
 msgstr "&Próximo"
 
-#: ../src/generic/wizard.cpp:432 ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:429
 msgid "&Next >"
 msgstr "&Próximo >"
 
@@ -523,7 +550,7 @@ msgstr "&Próximo >"
 msgid "&Next Paragraph"
 msgstr "Depois de um parágrafo:"
 
-#: ../src/generic/tipdlg.cpp:240
+#: ../src/generic/tipdlg.cpp:237
 msgid "&Next Tip"
 msgstr "&Próxima Dica"
 
@@ -531,11 +558,11 @@ msgstr "&Próxima Dica"
 msgid "&Next style:"
 msgstr "&Próximo estilo:"
 
-#: ../src/common/stockitem.cpp:177 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:174 ../src/msw/msgdlg.cpp:435
 msgid "&No"
 msgstr "&Não"
 
-#: ../src/generic/dbgrptg.cpp:356
+#: ../src/generic/dbgrptg.cpp:360
 msgid "&Notes:"
 msgstr "&Notas:"
 
@@ -543,12 +570,12 @@ msgstr "&Notas:"
 msgid "&Number:"
 msgstr "&Número:"
 
-#: ../src/generic/fontdlgg.cpp:475 ../src/generic/fontdlgg.cpp:482
-#: ../src/osx/carbon/fontdlg.cpp:408 ../src/common/stockitem.cpp:178
+#: ../src/osx/carbon/fontdlg.cpp:405 ../src/common/stockitem.cpp:175
+#: ../src/generic/fontdlgg.cpp:471 ../src/generic/fontdlgg.cpp:478
 msgid "&OK"
 msgstr "&OK"
 
-#: ../src/generic/dbgrptg.cpp:342 ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176 ../src/generic/dbgrptg.cpp:342
 msgid "&Open..."
 msgstr "&Abrir..."
 
@@ -561,16 +588,16 @@ msgstr "&Lista de nível:"
 msgid "&Page Break"
 msgstr "Quebra de &Página"
 
-#: ../src/richtext/richtextctrl.cpp:334 ../src/osx/textctrl_osx.cpp:578
-#: ../src/common/stockitem.cpp:180 ../src/msw/textctrl.cpp:2509
+#: ../src/osx/textctrl_osx.cpp:596 ../src/common/stockitem.cpp:177
+#: ../src/msw/textctrl.cpp:2774 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&Colar"
 
-#: ../include/wx/richtext/richtextbuffer.h:5010
+#: ../include/wx/richtext/richtextbuffer.h:5005
 msgid "&Picture"
 msgstr "I&magem"
 
-#: ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:419
 msgid "&Point size:"
 msgstr "Tamanho do &ponto:"
 
@@ -582,12 +609,11 @@ msgstr "&Posição (décimos de mm):"
 msgid "&Position mode:"
 msgstr "Modo de &Posição:"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178
 msgid "&Preferences"
 msgstr "&Preferências"
 
-#: ../src/aui/tabmdi.cpp:112 ../src/generic/mdig.cpp:101
-#: ../src/msw/mdi.cpp:181
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
 msgid "&Previous"
 msgstr "&Anterior"
 
@@ -595,78 +621,74 @@ msgstr "&Anterior"
 msgid "&Previous Paragraph"
 msgstr "Parágrafo &Anterior"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "&Print..."
 msgstr "&Imprimir..."
 
-#: ../src/richtext/richtextctrl.cpp:339 ../src/richtext/richtextctrl.cpp:5514
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtextctrl.cpp:338
+#: ../src/richtext/richtextctrl.cpp:5512
 msgid "&Properties"
 msgstr "&Propriedades"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "&Quit"
 msgstr "&Desistir"
 
-#: ../src/richtext/richtextctrl.cpp:330 ../src/osx/textctrl_osx.cpp:574
-#: ../src/common/stockitem.cpp:185 ../src/common/cmdproc.cpp:293
-#: ../src/common/cmdproc.cpp:300 ../src/msw/textctrl.cpp:2505
+#: ../src/osx/textctrl_osx.cpp:592 ../src/common/stockitem.cpp:182
+#: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
+#: ../src/msw/textctrl.cpp:2770 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Refazer"
 
-#: ../src/common/cmdproc.cpp:289 ../src/common/cmdproc.cpp:309
+#: ../src/common/cmdproc.cpp:282 ../src/common/cmdproc.cpp:302
 msgid "&Redo "
 msgstr "&Refazer "
 
-#: ../src/richtext/richtextstyledlg.cpp:257
+#: ../src/richtext/richtextstyledlg.cpp:253
 msgid "&Rename Style..."
 msgstr "&Renomear Estilo..."
 
-#: ../src/generic/fdrepdlg.cpp:179
+#: ../src/generic/fdrepdlg.cpp:176
 msgid "&Replace"
 msgstr "&Substituir"
 
-#: ../src/richtext/richtextstyledlg.cpp:287
+#: ../src/richtext/richtextstyledlg.cpp:283
 msgid "&Restart numbering"
 msgstr "&Recomeçar numeração"
 
-#: ../src/univ/themes/win32.cpp:3747
+#: ../src/univ/themes/win32.cpp:3744
 msgid "&Restore"
 msgstr "&Restaurar"
 
-#: ../src/richtext/richtextindentspage.cpp:146
 #: ../src/richtext/richtextliststylepage.cpp:335
+#: ../src/richtext/richtextindentspage.cpp:146
 msgid "&Right"
 msgstr "Di&reita"
 
-#: ../src/richtext/richtextindentspage.cpp:213
+#: ../src/richtext/richtextsizepage.cpp:602
+#: ../src/richtext/richtextsizepage.cpp:609
 #: ../src/richtext/richtextborderspage.cpp:277
 #: ../src/richtext/richtextborderspage.cpp:445
 #: ../src/richtext/richtextliststylepage.cpp:399
+#: ../src/richtext/richtextindentspage.cpp:213
 #: ../src/richtext/richtextmarginspage.cpp:211
 #: ../src/richtext/richtextmarginspage.cpp:325
-#: ../src/richtext/richtextsizepage.cpp:602
-#: ../src/richtext/richtextsizepage.cpp:609
 msgid "&Right:"
 msgstr "Di&reita:"
 
-#: ../src/common/stockitem.cpp:190
+#: ../src/common/stockitem.cpp:187
 msgid "&Save"
 msgstr "&Guardar"
-
-#: ../src/common/stockitem.cpp:191
-msgid "&Save as"
-msgstr "&Guardar Como"
 
 #: ../include/wx/richmsgdlg.h:29
 msgid "&See details"
 msgstr "&Ver Detalhes"
 
-#: ../src/generic/tipdlg.cpp:236
+#: ../src/generic/tipdlg.cpp:233
 msgid "&Show tips at startup"
 msgstr "&Mostrar dicas no inicio"
 
-#: ../src/univ/themes/win32.cpp:3750
+#: ../src/univ/themes/win32.cpp:3747
 msgid "&Size"
 msgstr "&Tamanho"
 
@@ -674,36 +696,36 @@ msgstr "&Tamanho"
 msgid "&Size:"
 msgstr "&Tamanho:"
 
-#: ../src/generic/progdlgg.cpp:252
+#: ../src/generic/progdlgg.cpp:249
 msgid "&Skip"
 msgstr "&Ignorar"
 
-#: ../src/richtext/richtextindentspage.cpp:242
 #: ../src/richtext/richtextliststylepage.cpp:417
+#: ../src/richtext/richtextindentspage.cpp:242
 msgid "&Spacing (tenths of a mm)"
 msgstr "E&spaçamento (décimos de mm)"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "&Spell Check"
 msgstr "Corretor &Ortográfico"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "&Stop"
 msgstr "&Parar"
 
-#: ../src/richtext/richtextfontpage.cpp:275 ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196 ../src/richtext/richtextfontpage.cpp:275
 msgid "&Strikethrough"
 msgstr "&Rasurado"
 
-#: ../src/generic/fontdlgg.cpp:382 ../src/richtext/richtextstylepage.cpp:106
+#: ../src/generic/fontdlgg.cpp:378 ../src/richtext/richtextstylepage.cpp:106
 msgid "&Style:"
 msgstr "E&stilo:"
 
-#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:194
 msgid "&Styles:"
 msgstr "E&stilos:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:413
+#: ../src/richtext/richtextsymboldlg.cpp:410
 msgid "&Subset:"
 msgstr "&Subconjunto:"
 
@@ -717,24 +739,24 @@ msgstr "&Símbolo:"
 msgid "&Synchronize values"
 msgstr ""
 
-#: ../include/wx/richtext/richtextbuffer.h:6069
+#: ../include/wx/richtext/richtextbuffer.h:6064
 msgid "&Table"
 msgstr "&Tabela"
 
-#: ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197
 msgid "&Top"
 msgstr "&Topo"
 
+#: ../src/richtext/richtextsizepage.cpp:567
+#: ../src/richtext/richtextsizepage.cpp:574
 #: ../src/richtext/richtextborderspage.cpp:311
 #: ../src/richtext/richtextborderspage.cpp:479
 #: ../src/richtext/richtextmarginspage.cpp:234
 #: ../src/richtext/richtextmarginspage.cpp:348
-#: ../src/richtext/richtextsizepage.cpp:567
-#: ../src/richtext/richtextsizepage.cpp:574
 msgid "&Top:"
 msgstr "&Topo:"
 
-#: ../src/generic/fontdlgg.cpp:444 ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199 ../src/generic/fontdlgg.cpp:441
 msgid "&Underline"
 msgstr "S&ublinhado"
 
@@ -742,21 +764,21 @@ msgstr "S&ublinhado"
 msgid "&Underlining:"
 msgstr "S&ublinhar:"
 
-#: ../src/richtext/richtextctrl.cpp:329 ../src/osx/textctrl_osx.cpp:573
-#: ../src/common/stockitem.cpp:203 ../src/common/cmdproc.cpp:271
-#: ../src/msw/textctrl.cpp:2504
+#: ../src/osx/textctrl_osx.cpp:591 ../src/common/stockitem.cpp:200
+#: ../src/common/cmdproc.cpp:264 ../src/msw/textctrl.cpp:2769
+#: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Desfazer"
 
-#: ../src/common/cmdproc.cpp:265
+#: ../src/common/cmdproc.cpp:258
 msgid "&Undo "
 msgstr "&Desfazer "
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "&Unindent"
 msgstr "&Desindentar"
 
-#: ../src/common/stockitem.cpp:205
+#: ../src/common/stockitem.cpp:202
 msgid "&Up"
 msgstr "&Cima"
 
@@ -773,7 +795,7 @@ msgstr "&Alinhamento Vertical:"
 msgid "&View..."
 msgstr "&Visualizar ..."
 
-#: ../src/generic/fontdlgg.cpp:393
+#: ../src/generic/fontdlgg.cpp:389
 msgid "&Weight:"
 msgstr "&Peso:"
 
@@ -782,88 +804,58 @@ msgstr "&Peso:"
 msgid "&Width:"
 msgstr "&Largura:"
 
-#: ../src/aui/tabmdi.cpp:311 ../src/aui/tabmdi.cpp:327
-#: ../src/aui/tabmdi.cpp:329 ../src/generic/mdig.cpp:294
-#: ../src/generic/mdig.cpp:310 ../src/generic/mdig.cpp:314
-#: ../src/msw/mdi.cpp:78
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
 msgid "&Window"
 msgstr "&Janela"
 
-#: ../src/common/stockitem.cpp:206 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:203 ../src/msw/msgdlg.cpp:435
 msgid "&Yes"
 msgstr "&Sim"
 
-#: ../src/common/valtext.cpp:256
+#: ../src/common/valtext.cpp:197
 #, fuzzy, c-format
-msgid "'%s' contains illegal characters"
+msgid "'%s' contains invalid character(s)"
 msgstr "'%s' deve apenas conter caracteres alfabéticos."
 
-#: ../src/common/valtext.cpp:254
-#, fuzzy, c-format
-msgid "'%s' doesn't consist only of valid characters"
-msgstr "'%s' deve apenas conter caracteres alfabéticos."
-
-#: ../src/common/config.cpp:519 ../src/msw/regconf.cpp:258
+#: ../src/common/config.cpp:515 ../src/msw/regconf.cpp:255
 #, c-format
 msgid "'%s' has extra '..', ignored."
 msgstr "'%s' tem extra '..', ignorado."
 
-#: ../src/common/cmdline.cpp:1113 ../src/common/cmdline.cpp:1131
+#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' não é um valor numérico correcto para a opção '%s'."
 
-#: ../src/common/translation.cpp:1100
+#: ../src/common/translation.cpp:1142
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' não é uma mensagem válida do catálogo."
 
-#: ../src/common/valtext.cpp:165
+#: ../src/common/valtext.cpp:188
 #, fuzzy, c-format
 msgid "'%s' is not one of the valid strings"
 msgstr "'%s' não é uma mensagem válida do catálogo."
 
-#: ../src/common/valtext.cpp:167
+#: ../src/common/valtext.cpp:186
 #, fuzzy, c-format
 msgid "'%s' is one of the invalid strings"
 msgstr "'%s' é inválido"
 
-#: ../src/common/textbuf.cpp:237
+#: ../src/common/textbuf.cpp:233
 #, c-format
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' é capaz de ser um buffer binário."
-
-#: ../src/common/valtext.cpp:252
-#, c-format
-msgid "'%s' should be numeric."
-msgstr "'%s' deve ser numérico."
-
-#: ../src/common/valtext.cpp:244
-#, c-format
-msgid "'%s' should only contain ASCII characters."
-msgstr "'%s' apenas deve conter caracteres ASCII."
-
-#: ../src/common/valtext.cpp:246
-#, c-format
-msgid "'%s' should only contain alphabetic characters."
-msgstr "'%s' deve apenas conter caracteres alfabéticos."
-
-#: ../src/common/valtext.cpp:248
-#, c-format
-msgid "'%s' should only contain alphabetic or numeric characters."
-msgstr "'%s' deve apenas conter caracteres alfabéticos e numéricos."
-
-#: ../src/common/valtext.cpp:250
-#, fuzzy, c-format
-msgid "'%s' should only contain digits."
-msgstr "'%s' apenas deve conter caracteres ASCII."
 
 #: ../src/richtext/richtextliststylepage.cpp:229
 #: ../src/richtext/richtextbulletspage.cpp:166
 msgid "(*)"
 msgstr "(*)"
 
-#: ../src/html/helpwnd.cpp:963
+#: ../src/html/helpwnd.cpp:961
 msgid "(Help)"
 msgstr "(Ajuda)"
 
@@ -872,27 +864,32 @@ msgstr "(Ajuda)"
 msgid "(None)"
 msgstr "(Nenhum)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:504
+#: ../src/richtext/richtextsymboldlg.cpp:503
 msgid "(Normal text)"
 msgstr "(Texto normal)"
 
-#: ../src/html/helpwnd.cpp:419 ../src/html/helpwnd.cpp:1106
-#: ../src/html/helpwnd.cpp:1742
+#: ../src/html/helpwnd.cpp:417 ../src/html/helpwnd.cpp:1104
+#: ../src/html/helpwnd.cpp:1740
 msgid "(bookmarks)"
 msgstr "(marcadores)"
 
+#: ../src/msw/dlmsw.cpp:167
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (erro %ld: %s)"
+
+#: ../src/richtext/richtextformatdlg.cpp:876
+#: ../src/richtext/richtextliststylepage.cpp:448
+#: ../src/richtext/richtextliststylepage.cpp:460
+#: ../src/richtext/richtextliststylepage.cpp:461
 #: ../src/richtext/richtextindentspage.cpp:274
 #: ../src/richtext/richtextindentspage.cpp:286
 #: ../src/richtext/richtextindentspage.cpp:287
 #: ../src/richtext/richtextindentspage.cpp:311
 #: ../src/richtext/richtextindentspage.cpp:326
-#: ../src/richtext/richtextformatdlg.cpp:884
 #: ../src/richtext/richtextfontpage.cpp:349
 #: ../src/richtext/richtextfontpage.cpp:353
 #: ../src/richtext/richtextfontpage.cpp:357
-#: ../src/richtext/richtextliststylepage.cpp:448
-#: ../src/richtext/richtextliststylepage.cpp:460
-#: ../src/richtext/richtextliststylepage.cpp:461
 msgid "(none)"
 msgstr "(nenhum)"
 
@@ -911,7 +908,7 @@ msgstr "*)"
 msgid "+"
 msgstr "+"
 
-#: ../src/msw/utils.cpp:1152
+#: ../src/msw/utils.cpp:1143
 msgid ", 64-bit edition"
 msgstr ", edição 64 bits"
 
@@ -920,163 +917,163 @@ msgstr ", edição 64 bits"
 msgid "-"
 msgstr "-"
 
-#: ../src/generic/filepickerg.cpp:66
+#: ../src/generic/filepickerg.cpp:63
 msgid "..."
 msgstr "..."
 
-#: ../src/richtext/richtextindentspage.cpp:276
 #: ../src/richtext/richtextliststylepage.cpp:450
+#: ../src/richtext/richtextindentspage.cpp:276
 msgid "1.1"
 msgstr "1.1"
 
-#: ../src/richtext/richtextindentspage.cpp:277
 #: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextindentspage.cpp:277
 msgid "1.2"
 msgstr "1.2"
 
-#: ../src/richtext/richtextindentspage.cpp:278
 #: ../src/richtext/richtextliststylepage.cpp:452
+#: ../src/richtext/richtextindentspage.cpp:278
 msgid "1.3"
 msgstr "1.3"
 
-#: ../src/richtext/richtextindentspage.cpp:279
 #: ../src/richtext/richtextliststylepage.cpp:453
+#: ../src/richtext/richtextindentspage.cpp:279
 msgid "1.4"
 msgstr "1.4"
 
-#: ../src/richtext/richtextindentspage.cpp:280
 #: ../src/richtext/richtextliststylepage.cpp:454
+#: ../src/richtext/richtextindentspage.cpp:280
 msgid "1.5"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:281
 #: ../src/richtext/richtextliststylepage.cpp:455
+#: ../src/richtext/richtextindentspage.cpp:281
 msgid "1.6"
 msgstr "1.6"
 
-#: ../src/richtext/richtextindentspage.cpp:282
 #: ../src/richtext/richtextliststylepage.cpp:456
+#: ../src/richtext/richtextindentspage.cpp:282
 msgid "1.7"
 msgstr "1.7"
 
-#: ../src/richtext/richtextindentspage.cpp:283
 #: ../src/richtext/richtextliststylepage.cpp:457
+#: ../src/richtext/richtextindentspage.cpp:283
 msgid "1.8"
 msgstr "1.8"
 
-#: ../src/richtext/richtextindentspage.cpp:284
 #: ../src/richtext/richtextliststylepage.cpp:458
+#: ../src/richtext/richtextindentspage.cpp:284
 msgid "1.9"
 msgstr "1.9"
 
-#: ../src/common/paper.cpp:140
+#: ../src/common/paper.cpp:137
 msgid "10 x 11 in"
 msgstr "10 x 11 pol."
 
-#: ../src/common/paper.cpp:113
+#: ../src/common/paper.cpp:110
 msgid "10 x 14 in"
 msgstr "10 x 14 pol."
 
-#: ../src/common/paper.cpp:114
+#: ../src/common/paper.cpp:111
 msgid "11 x 17 in"
 msgstr "11 x 17 pol."
 
-#: ../src/common/paper.cpp:184
+#: ../src/common/paper.cpp:181
 msgid "12 x 11 in"
 msgstr "12 x 11 pol."
 
-#: ../src/common/paper.cpp:141
+#: ../src/common/paper.cpp:138
 msgid "15 x 11 in"
 msgstr "15 x 11 pol."
 
-#: ../src/richtext/richtextindentspage.cpp:285
 #: ../src/richtext/richtextliststylepage.cpp:459
+#: ../src/richtext/richtextindentspage.cpp:285
 msgid "2"
 msgstr "2"
 
-#: ../src/common/paper.cpp:132
+#: ../src/common/paper.cpp:129
 msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
 msgstr "Envelope 6 3/4, 3 5/8 x 6 1/2 pol."
 
-#: ../src/common/paper.cpp:139
+#: ../src/common/paper.cpp:136
 msgid "9 x 11 in"
 msgstr "9 x 11 pol."
 
-#: ../src/html/htmprint.cpp:431
+#: ../src/html/htmprint.cpp:443
 msgid ": file does not exist!"
 msgstr ": ficheiro inexistente!"
 
-#: ../src/common/fontmap.cpp:199
+#: ../src/common/fontmap.cpp:196
 msgid ": unknown charset"
 msgstr ": conjunto de caracteres desconhecido"
 
-#: ../src/common/fontmap.cpp:413
+#: ../src/common/fontmap.cpp:410
 msgid ": unknown encoding"
 msgstr ": codificação desconhecida"
 
-#: ../src/generic/wizard.cpp:443
+#: ../src/generic/wizard.cpp:438
 msgid "< &Back"
 msgstr "< &Atrás"
 
-#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:628
-#: ../src/osx/carbon/fontdlg.cpp:648
+#: ../src/osx/carbon/fontdlg.cpp:419 ../src/osx/carbon/fontdlg.cpp:625
+#: ../src/osx/carbon/fontdlg.cpp:645
 msgid "<Any Decorative>"
 msgstr "<Qualquer Decorative>"
 
-#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:630
-#: ../src/osx/carbon/fontdlg.cpp:650
+#: ../src/osx/carbon/fontdlg.cpp:420 ../src/osx/carbon/fontdlg.cpp:627
+#: ../src/osx/carbon/fontdlg.cpp:647
 msgid "<Any Modern>"
 msgstr "<Qualquer Modern>"
 
-#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:626
-#: ../src/osx/carbon/fontdlg.cpp:646
+#: ../src/osx/carbon/fontdlg.cpp:418 ../src/osx/carbon/fontdlg.cpp:623
+#: ../src/osx/carbon/fontdlg.cpp:643
 msgid "<Any Roman>"
 msgstr "<Qualquer Roman>"
 
-#: ../src/osx/carbon/fontdlg.cpp:424 ../src/osx/carbon/fontdlg.cpp:632
-#: ../src/osx/carbon/fontdlg.cpp:652
+#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:629
+#: ../src/osx/carbon/fontdlg.cpp:649
 msgid "<Any Script>"
 msgstr "<Qualquer Script>"
 
-#: ../src/osx/carbon/fontdlg.cpp:425 ../src/osx/carbon/fontdlg.cpp:637
-#: ../src/osx/carbon/fontdlg.cpp:656
+#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:634
+#: ../src/osx/carbon/fontdlg.cpp:653
 msgid "<Any Swiss>"
 msgstr "<Qualquer Swiss>"
 
-#: ../src/osx/carbon/fontdlg.cpp:426 ../src/osx/carbon/fontdlg.cpp:634
-#: ../src/osx/carbon/fontdlg.cpp:654
+#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:631
+#: ../src/osx/carbon/fontdlg.cpp:651
 msgid "<Any Teletype>"
 msgstr "<Qualquer Teletype>"
 
-#: ../src/osx/carbon/fontdlg.cpp:420
+#: ../src/osx/carbon/fontdlg.cpp:417
 msgid "<Any>"
 msgstr "<Qualquer>"
 
-#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
 msgid "<DIR>"
 msgstr "<DIR>"
 
-#: ../src/generic/filectrlg.cpp:254 ../src/generic/filectrlg.cpp:277
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
 msgid "<DRIVE>"
 msgstr "<UNIDADE>"
 
-#: ../src/generic/filectrlg.cpp:252 ../src/generic/filectrlg.cpp:275
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
 msgid "<LINK>"
 msgstr "<LINK>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1264
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Face negrito itálico.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1270
+#: ../src/html/helpwnd.cpp:1268
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>negrito itálico <u>sublinhado</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1265
+#: ../src/html/helpwnd.cpp:1263
 msgid "<b>Bold face.</b> "
 msgstr "<b>Face negrito.</b> "
 
-#: ../src/html/helpwnd.cpp:1264
+#: ../src/html/helpwnd.cpp:1262
 msgid "<i>Italic face.</i> "
 msgstr "<i>Face itálico.</i> "
 
@@ -1085,15 +1082,15 @@ msgstr "<i>Face itálico.</i> "
 msgid ">"
 msgstr ">"
 
-#: ../src/generic/dbgrptg.cpp:318
+#: ../src/generic/dbgrptg.cpp:317
 msgid "A debug report has been generated in the directory\n"
 msgstr "Foi gerado um relatório de depuração na diretoria\n"
 
-#: ../src/common/debugrpt.cpp:573
+#: ../src/common/debugrpt.cpp:574
 msgid "A debug report has been generated. It can be found in"
 msgstr "Foi gerado um relatório de depuração. Este pode ser encontrado em"
 
-#: ../src/common/xtixml.cpp:418
+#: ../src/common/xtixml.cpp:414
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "uma colecção não vazia deve consistir em nós de 'element'"
 
@@ -1104,106 +1101,106 @@ msgstr "uma colecção não vazia deve consistir em nós de 'element'"
 msgid "A standard bullet name."
 msgstr "Um nome standard para o marcador."
 
-#: ../src/common/paper.cpp:217
+#: ../src/common/paper.cpp:214
 msgid "A0 sheet, 841 x 1189 mm"
 msgstr "Folha A0, 841 x 1189 mm"
 
-#: ../src/common/paper.cpp:218
+#: ../src/common/paper.cpp:215
 msgid "A1 sheet, 594 x 841 mm"
 msgstr "Folha A1, 594 x 841 mm"
 
-#: ../src/common/paper.cpp:159
+#: ../src/common/paper.cpp:156
 msgid "A2 420 x 594 mm"
 msgstr "A2 420 x 594 mm"
 
-#: ../src/common/paper.cpp:156
+#: ../src/common/paper.cpp:153
 msgid "A3 Extra 322 x 445 mm"
 msgstr "A3 Extra 322 x 445 mm"
 
-#: ../src/common/paper.cpp:161
+#: ../src/common/paper.cpp:158
 msgid "A3 Extra Transverse 322 x 445 mm"
 msgstr "A3 Extra Transverso 322 x 445 mm"
 
-#: ../src/common/paper.cpp:170
+#: ../src/common/paper.cpp:167
 msgid "A3 Rotated 420 x 297 mm"
 msgstr "A3 Rodado 420 x 297 mm"
 
-#: ../src/common/paper.cpp:160
+#: ../src/common/paper.cpp:157
 msgid "A3 Transverse 297 x 420 mm"
 msgstr "A3 Transverso 297 x 420 mm"
 
-#: ../src/common/paper.cpp:106
+#: ../src/common/paper.cpp:103
 msgid "A3 sheet, 297 x 420 mm"
 msgstr "Folha A3, 297 x 420 mm"
 
-#: ../src/common/paper.cpp:146
+#: ../src/common/paper.cpp:143
 msgid "A4 Extra 9.27 x 12.69 in"
 msgstr "A4 Extra 9.27 x 12.69 pol."
 
-#: ../src/common/paper.cpp:153
+#: ../src/common/paper.cpp:150
 msgid "A4 Plus 210 x 330 mm"
 msgstr "A4+ 210 x 330 mm"
 
-#: ../src/common/paper.cpp:171
+#: ../src/common/paper.cpp:168
 msgid "A4 Rotated 297 x 210 mm"
 msgstr "A4 Rodado 297 x 210 mm"
 
-#: ../src/common/paper.cpp:148
+#: ../src/common/paper.cpp:145
 msgid "A4 Transverse 210 x 297 mm"
 msgstr "A4 Transverso 210 x 297 mm"
 
-#: ../src/common/paper.cpp:97
+#: ../src/common/paper.cpp:94
 msgid "A4 sheet, 210 x 297 mm"
 msgstr "Folha A4, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:107
+#: ../src/common/paper.cpp:104
 msgid "A4 small sheet, 210 x 297 mm"
 msgstr "A4 folha pequena, 210x297 mm"
 
-#: ../src/common/paper.cpp:157
+#: ../src/common/paper.cpp:154
 msgid "A5 Extra 174 x 235 mm"
 msgstr "A5 Extra 174 x 235 mm"
 
-#: ../src/common/paper.cpp:172
+#: ../src/common/paper.cpp:169
 msgid "A5 Rotated 210 x 148 mm"
 msgstr "A5 Rodado 210 x 148 mm"
 
-#: ../src/common/paper.cpp:154
+#: ../src/common/paper.cpp:151
 msgid "A5 Transverse 148 x 210 mm"
 msgstr "A5 Transverso 148 x 210 mm"
 
-#: ../src/common/paper.cpp:108
+#: ../src/common/paper.cpp:105
 msgid "A5 sheet, 148 x 210 mm"
 msgstr "A5 folha, 148 x 210 mm"
 
-#: ../src/common/paper.cpp:164
+#: ../src/common/paper.cpp:161
 msgid "A6 105 x 148 mm"
 msgstr "A6 105 x 148 mm"
 
-#: ../src/common/paper.cpp:177
+#: ../src/common/paper.cpp:174
 msgid "A6 Rotated 148 x 105 mm"
 msgstr "A6 Rodado 148 x 105 mm"
 
-#: ../src/generic/fontdlgg.cpp:83 ../src/richtext/richtextformatdlg.cpp:529
-#: ../src/osx/carbon/fontdlg.cpp:153
+#: ../src/osx/carbon/fontdlg.cpp:150 ../src/generic/fontdlgg.cpp:79
+#: ../src/richtext/richtextformatdlg.cpp:521
 msgid "ABCDEFGabcdefg12345"
 msgstr "ABCDEFGabcdefg12345"
 
-#: ../src/richtext/richtextsymboldlg.cpp:458 ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
 msgid "ASCII"
 msgstr "ASCII"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "About"
 msgstr "&Sobre o ..."
 
-#: ../src/generic/aboutdlgg.cpp:140 ../src/osx/menu_osx.cpp:558
-#: ../src/msw/aboutdlg.cpp:64
+#: ../src/osx/menu_osx.cpp:450 ../src/generic/aboutdlgg.cpp:137
+#: ../src/msw/aboutdlg.cpp:61
 #, c-format
 msgid "About %s"
 msgstr "Sobre o %s"
 
-#: ../src/osx/menu_osx.cpp:560
+#: ../src/osx/menu_osx.cpp:452
 #, fuzzy
 msgid "About..."
 msgstr "&Sobre o ..."
@@ -1213,38 +1210,38 @@ msgid "Absolute"
 msgstr "Absoluto"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:873
+#: ../src/propgrid/advprops.cpp:774
 #, fuzzy
 msgid "ActiveBorder"
 msgstr "Margem"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:874
+#: ../src/propgrid/advprops.cpp:775
 msgid "ActiveCaption"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "Actual Size"
 msgstr "T&amanho Atual"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:140 ../src/common/accelcmn.cpp:81
+#: ../src/common/stockitem.cpp:137 ../src/common/accelcmn.cpp:78
 msgid "Add"
 msgstr "Adicionar"
 
-#: ../src/richtext/richtextbuffer.cpp:11455
+#: ../src/richtext/richtextbuffer.cpp:11454
 msgid "Add Column"
 msgstr "Adicionar Coluna"
 
-#: ../src/richtext/richtextbuffer.cpp:11392
+#: ../src/richtext/richtextbuffer.cpp:11391
 msgid "Add Row"
 msgstr "Adicionar Fila"
 
-#: ../src/html/helpwnd.cpp:432
+#: ../src/html/helpwnd.cpp:430
 msgid "Add current page to bookmarks"
 msgstr "Adicionar página atual aos marcadores"
 
-#: ../src/generic/colrdlgg.cpp:366
+#: ../src/generic/colrdlgg.cpp:386
 msgid "Add to custom colours"
 msgstr "Adicionar às cores personalizadas"
 
@@ -1256,12 +1253,12 @@ msgstr "AddToPropertyCollection chamando num acessor genérico"
 msgid "AddToPropertyCollection called w/o valid adder"
 msgstr "AddToPropertyCollection chamando com ou sem adicionador válido"
 
-#: ../src/html/helpctrl.cpp:159
+#: ../src/html/helpctrl.cpp:155
 #, c-format
 msgid "Adding book %s"
 msgstr "A adicionar livro %s"
 
-#: ../src/common/preferencescmn.cpp:43
+#: ../src/common/preferencescmn.cpp:40
 msgid "Advanced"
 msgstr "Avançado"
 
@@ -1269,11 +1266,11 @@ msgstr "Avançado"
 msgid "After a paragraph:"
 msgstr "Depois de um parágrafo:"
 
-#: ../src/common/stockitem.cpp:172
+#: ../src/common/stockitem.cpp:169
 msgid "Align Left"
 msgstr "Alinhar à Esquerda"
 
-#: ../src/common/stockitem.cpp:173
+#: ../src/common/stockitem.cpp:170
 msgid "Align Right"
 msgstr "Alinhar à Direita"
 
@@ -1281,40 +1278,40 @@ msgstr "Alinhar à Direita"
 msgid "Alignment"
 msgstr "Alinhamento"
 
-#: ../src/generic/prntdlgg.cpp:215
+#: ../src/generic/prntdlgg.cpp:208
 msgid "All"
 msgstr "Todos"
 
-#: ../src/generic/filectrlg.cpp:1197 ../src/common/fldlgcmn.cpp:107
+#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1186
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Todos os ficheiros (%s)|%s"
 
-#: ../include/wx/defs.h:2886
+#: ../include/wx/defs.h:2582
 msgid "All files (*)|*"
 msgstr "Todos os ficheiros (*)|*"
 
-#: ../include/wx/defs.h:2883
+#: ../include/wx/defs.h:2579
 msgid "All files (*.*)|*.*"
 msgstr "Todos os ficheiros (*.*)|*.*"
 
-#: ../src/richtext/richtextstyles.cpp:1061
+#: ../src/richtext/richtextstyles.cpp:1058
 msgid "All styles"
 msgstr "Todos os estilos"
 
-#: ../src/propgrid/manager.cpp:1528
+#: ../src/propgrid/manager.cpp:1544
 msgid "Alphabetic Mode"
 msgstr "Modo Alfabético"
 
-#: ../src/common/xtistrm.cpp:425
+#: ../src/common/xtistrm.cpp:422
 msgid "Already Registered Object passed to SetObjectClassInfo"
 msgstr "Objecto Já Registado passado para SetObjectClassInfo"
 
-#: ../src/unix/dialup.cpp:353
+#: ../src/unix/dialup.cpp:352
 msgid "Already dialling ISP."
 msgstr "Já está a ligar ao serviço ISP."
 
-#: ../src/common/accelcmn.cpp:331 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/accelcmn.cpp:345 ../src/univ/themes/win32.cpp:3753
 msgid "Alt+"
 msgstr "Alt+"
 
@@ -1323,36 +1320,36 @@ msgstr "Alt+"
 msgid "An optional corner radius for adding rounded corners."
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:576
+#: ../src/common/debugrpt.cpp:577
 #, fuzzy
 msgid "And includes the following files:\n"
 msgstr "*** E inclui os seguintes ficheiros:\n"
 
-#: ../src/generic/animateg.cpp:162
+#: ../src/generic/animateg.cpp:145
 #, c-format
 msgid "Animation file is not of type %ld."
 msgstr "Ficheiro de animação não é do tipo %ld."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:872
+#: ../src/propgrid/advprops.cpp:773
 msgid "AppWorkspace"
 msgstr ""
 
-#: ../src/generic/logg.cpp:1014
+#: ../src/generic/logg.cpp:1011
 #, c-format
 msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
 msgstr ""
 "Adicionar ao ficheiro de registo '%s' (escolher [Não] vai substitui-lo)?"
 
-#: ../src/osx/menu_osx.cpp:577 ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:469 ../src/osx/menu_osx.cpp:477
 msgid "Application"
 msgstr "Aplicação"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "Apply"
 msgstr "Aplicar"
 
-#: ../src/propgrid/advprops.cpp:1609
+#: ../src/propgrid/advprops.cpp:1515
 msgid "Aqua"
 msgstr ""
 
@@ -1361,30 +1358,30 @@ msgstr ""
 msgid "Arabic"
 msgstr "Árabe"
 
-#: ../src/common/fmapbase.cpp:153
+#: ../src/common/fmapbase.cpp:150
 msgid "Arabic (ISO-8859-6)"
 msgstr "Árabe (ISO-8859-6)"
 
-#: ../src/msw/ole/automtn.cpp:672
+#: ../src/msw/ole/automtn.cpp:663
 #, fuzzy, c-format
 msgid "Argument %u not found."
 msgstr "Ficheiro de ajuda \"%s\" não encontrado."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1753
+#: ../src/propgrid/advprops.cpp:1654
 #, fuzzy
 msgid "Arrow"
 msgstr "amanhã"
 
-#: ../src/generic/aboutdlgg.cpp:184
+#: ../src/generic/aboutdlgg.cpp:181
 msgid "Artists"
 msgstr "Artistas"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "Ascending"
 msgstr "Ascendente"
 
-#: ../src/generic/filectrlg.cpp:433
+#: ../src/generic/filectrlg.cpp:429
 msgid "Attributes"
 msgstr "Atributos"
 
@@ -1394,90 +1391,90 @@ msgstr "Atributos"
 msgid "Available fonts."
 msgstr "Fontes disponíveis."
 
-#: ../src/common/paper.cpp:137
+#: ../src/common/paper.cpp:134
 msgid "B4 (ISO) 250 x 353 mm"
 msgstr "B4 (ISO) 250 x 353 mm"
 
-#: ../src/common/paper.cpp:173
+#: ../src/common/paper.cpp:170
 msgid "B4 (JIS) Rotated 364 x 257 mm"
 msgstr "B4 (JIS) Rodado 364 x 257 mm"
 
-#: ../src/common/paper.cpp:127
+#: ../src/common/paper.cpp:124
 msgid "B4 Envelope, 250 x 353 mm"
 msgstr "Envelope B4, 250x353 mm"
 
-#: ../src/common/paper.cpp:109
+#: ../src/common/paper.cpp:106
 msgid "B4 sheet, 250 x 354 mm"
 msgstr "Folha B4, 250 x 354 mm"
 
-#: ../src/common/paper.cpp:158
+#: ../src/common/paper.cpp:155
 msgid "B5 (ISO) Extra 201 x 276 mm"
 msgstr "B5 (ISO) Extra 201 x 276 mm"
 
-#: ../src/common/paper.cpp:174
+#: ../src/common/paper.cpp:171
 msgid "B5 (JIS) Rotated 257 x 182 mm"
 msgstr "B5 (JIS) Rodado 257 x 182 mm"
 
-#: ../src/common/paper.cpp:155
+#: ../src/common/paper.cpp:152
 msgid "B5 (JIS) Transverse 182 x 257 mm"
 msgstr "B5 (JIS) Transverso 182 x 257 mm"
 
-#: ../src/common/paper.cpp:128
+#: ../src/common/paper.cpp:125
 msgid "B5 Envelope, 176 x 250 mm"
 msgstr "Envelope B5, 176 x 250 mm"
 
-#: ../src/common/paper.cpp:110
+#: ../src/common/paper.cpp:107
 msgid "B5 sheet, 182 x 257 millimeter"
 msgstr "B5 folha, 182 x 257 millimeter"
 
-#: ../src/common/paper.cpp:182
+#: ../src/common/paper.cpp:179
 msgid "B6 (JIS) 128 x 182 mm"
 msgstr "B6 (JIS) 128 x 182 mm"
 
-#: ../src/common/paper.cpp:183
+#: ../src/common/paper.cpp:180
 msgid "B6 (JIS) Rotated 182 x 128 mm"
 msgstr "B6 (JIS) Rodado 182 x 128 mm"
 
-#: ../src/common/paper.cpp:129
+#: ../src/common/paper.cpp:126
 msgid "B6 Envelope, 176 x 125 mm"
 msgstr "Envelope B6, 176 x 125 mm"
 
-#: ../src/common/imagbmp.cpp:531 ../src/common/imagbmp.cpp:561
-#: ../src/common/imagbmp.cpp:576
+#: ../src/common/imagbmp.cpp:528 ../src/common/imagbmp.cpp:558
+#: ../src/common/imagbmp.cpp:573
 msgid "BMP: Couldn't allocate memory."
 msgstr "BMP: Impossível alocar memória."
 
-#: ../src/common/imagbmp.cpp:100
+#: ../src/common/imagbmp.cpp:97
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: Impossível gravar imagem inválida."
 
-#: ../src/common/imagbmp.cpp:356
+#: ../src/common/imagbmp.cpp:353
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: Impossível escrever mapa de cores RGB."
 
-#: ../src/common/imagbmp.cpp:490
+#: ../src/common/imagbmp.cpp:487
 msgid "BMP: Couldn't write data."
 msgstr "BMP: Impossível escrever data."
 
-#: ../src/common/imagbmp.cpp:246
+#: ../src/common/imagbmp.cpp:243
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: Impossível escrever o cabeçalho do ficheiro (Bitmap)."
 
-#: ../src/common/imagbmp.cpp:269
+#: ../src/common/imagbmp.cpp:266
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: Impossível escrever o cabeçalho do ficheiro (BitmapInfo)."
 
-#: ../src/common/imagbmp.cpp:140
+#: ../src/common/imagbmp.cpp:137
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage não tem a sua wxPalette."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:142 ../src/common/accelcmn.cpp:52
+#: ../src/common/stockitem.cpp:139 ../src/common/accelcmn.cpp:49
 msgid "Back"
 msgstr "Voltar"
 
+#: ../src/richtext/richtextformatdlg.cpp:377
 #: ../src/richtext/richtextbackgroundpage.cpp:148
-#: ../src/richtext/richtextformatdlg.cpp:384
 msgid "Background"
 msgstr "Fundo"
 
@@ -1485,21 +1482,21 @@ msgstr "Fundo"
 msgid "Background &colour:"
 msgstr "Cor de Fundo:"
 
-#: ../src/osx/carbon/fontdlg.cpp:220
+#: ../src/osx/carbon/fontdlg.cpp:217
 msgid "Background colour"
 msgstr "Cor de fundo"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:52
+#: ../src/common/accelcmn.cpp:49
 #, fuzzy
 msgid "Backspace"
 msgstr "Voltar"
 
-#: ../src/common/fmapbase.cpp:160
+#: ../src/common/fmapbase.cpp:157
 msgid "Baltic (ISO-8859-13)"
 msgstr "Báltico (ISO-8859-13)"
 
-#: ../src/common/fmapbase.cpp:151
+#: ../src/common/fmapbase.cpp:148
 msgid "Baltic (old) (ISO-8859-4)"
 msgstr "Báltico (antigo) (ISO-8859-4)"
 
@@ -1512,25 +1509,25 @@ msgstr "Antes de um parágrafo:"
 msgid "Bitmap"
 msgstr "Bitmap"
 
-#: ../src/propgrid/advprops.cpp:1594
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Black"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1755
+#: ../src/propgrid/advprops.cpp:1656
 msgid "Blank"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1603
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Blue"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:345
+#: ../src/generic/colrdlgg.cpp:365
 msgid "Blue:"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:333 ../src/richtext/richtextfontpage.cpp:355
-#: ../src/osx/carbon/fontdlg.cpp:354 ../src/common/stockitem.cpp:143
+#: ../src/osx/carbon/fontdlg.cpp:351 ../src/common/stockitem.cpp:140
+#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:355
 msgid "Bold"
 msgstr "Negrito"
 
@@ -1539,34 +1536,38 @@ msgstr "Negrito"
 msgid "Border"
 msgstr "Margem"
 
-#: ../src/richtext/richtextformatdlg.cpp:379
+#: ../src/richtext/richtextformatdlg.cpp:372
 msgid "Borders"
 msgstr "Margens"
 
-#: ../src/richtext/richtextsizepage.cpp:288 ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141 ../src/richtext/richtextsizepage.cpp:288
 msgid "Bottom"
 msgstr "Base"
 
-#: ../src/generic/prntdlgg.cpp:893
+#: ../src/generic/prntdlgg.cpp:886
 msgid "Bottom margin (mm):"
 msgstr "Margem de rodapé (mm):"
 
-#: ../src/richtext/richtextbuffer.cpp:9383
+#: ../src/richtext/richtextbuffer.cpp:9380
 #, fuzzy
 msgid "Box Properties"
 msgstr "&Propriedades"
 
-#: ../src/richtext/richtextstyles.cpp:1065
+#: ../src/richtext/richtextstyles.cpp:1062
 #, fuzzy
 msgid "Box styles"
 msgstr "Todos os estilos"
 
-#: ../src/propgrid/advprops.cpp:1602
+#: ../src/osx/cocoa/menu.mm:292
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1508
 #, fuzzy
 msgid "Brown"
 msgstr "Explorar"
 
-#: ../src/common/filepickercmn.cpp:43 ../src/common/filepickercmn.cpp:44
+#: ../src/common/filepickercmn.cpp:40 ../src/common/filepickercmn.cpp:41
 msgid "Browse"
 msgstr "Explorar"
 
@@ -1579,73 +1580,73 @@ msgstr "&Alinhamento de Marcador:"
 msgid "Bullet style"
 msgstr "Estilo de marcador"
 
-#: ../src/richtext/richtextformatdlg.cpp:359
+#: ../src/richtext/richtextformatdlg.cpp:352
 msgid "Bullets"
 msgstr "Marcadores"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1756
+#: ../src/propgrid/advprops.cpp:1657
 #, fuzzy
 msgid "Bullseye"
 msgstr "Estilo de marcador"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:875
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonFace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:876
+#: ../src/propgrid/advprops.cpp:777
 msgid "ButtonHighlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:877
+#: ../src/propgrid/advprops.cpp:778
 msgid "ButtonShadow"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:878
+#: ../src/propgrid/advprops.cpp:779
 msgid "ButtonText"
 msgstr ""
 
-#: ../src/common/paper.cpp:98
+#: ../src/common/paper.cpp:95
 msgid "C sheet, 17 x 22 in"
 msgstr "Folha C, 17 x 22 pol."
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "C&lear"
 msgstr "&Limpar"
 
-#: ../src/generic/fontdlgg.cpp:406
+#: ../src/generic/fontdlgg.cpp:403
 msgid "C&olour:"
 msgstr "C&or:"
 
-#: ../src/common/paper.cpp:123
+#: ../src/common/paper.cpp:120
 msgid "C3 Envelope, 324 x 458 mm"
 msgstr "Envelope C3, 324 x 458 mm"
 
-#: ../src/common/paper.cpp:124
+#: ../src/common/paper.cpp:121
 msgid "C4 Envelope, 229 x 324 mm"
 msgstr "Envelope C4, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:122
+#: ../src/common/paper.cpp:119
 msgid "C5 Envelope, 162 x 229 mm"
 msgstr "Envelope C5, 162 x 229 mm"
 
-#: ../src/common/paper.cpp:125
+#: ../src/common/paper.cpp:122
 msgid "C6 Envelope, 114 x 162 mm"
 msgstr "Envelope C6, 114 x 162 mm"
 
-#: ../src/common/paper.cpp:126
+#: ../src/common/paper.cpp:123
 msgid "C65 Envelope, 114 x 229 mm"
 msgstr "Envelope C65, 114 x 229 mm"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "CD-Rom"
 msgstr "CD-Rom"
 
-#: ../src/html/chm.cpp:815 ../src/html/chm.cpp:874
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:865
 msgid "CHM handler currently supports only local files!"
 msgstr "O manuseador CHM atualmente apenas suporta ficheiros locais!"
 
@@ -1653,199 +1654,203 @@ msgstr "O manuseador CHM atualmente apenas suporta ficheiros locais!"
 msgid "Ca&pitals"
 msgstr "Maiúsculas"
 
-#: ../src/common/cmdproc.cpp:267
+#: ../src/common/cmdproc.cpp:260
 msgid "Can't &Undo "
 msgstr "Não é possível &Desfazer "
 
-#: ../src/common/image.cpp:2824
+#: ../src/common/image.cpp:2924
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 "Não é possível determinar automaticamente o formato da imagem para entrada "
 "não pesquisável."
 
-#: ../src/msw/registry.cpp:506
+#: ../src/msw/registry.cpp:495
 #, c-format
 msgid "Can't close registry key '%s'"
 msgstr "Não foi possível fechar a chave de registo '%s'"
 
-#: ../src/msw/registry.cpp:584
+#: ../src/msw/registry.cpp:573
 #, c-format
 msgid "Can't copy values of unsupported type %d."
 msgstr "Não foi possível copiar valores do tipo %d não suportado."
 
-#: ../src/msw/registry.cpp:487
+#: ../src/msw/registry.cpp:476
 #, c-format
 msgid "Can't create registry key '%s'"
 msgstr "Não foi possível criar a chave de registo '%s'"
 
-#: ../src/msw/thread.cpp:665
+#: ../src/msw/thread.cpp:657
 msgid "Can't create thread"
 msgstr "Não é possível criar a thread"
 
-#: ../src/msw/window.cpp:3691
-#, c-format
-msgid "Can't create window of class %s"
-msgstr "Não é possível criar janela da classe %s"
-
-#: ../src/msw/registry.cpp:777
+#: ../src/msw/registry.cpp:765
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Não é possível apagar a chave '%s'"
 
-#: ../src/msw/iniconf.cpp:458
+#: ../src/msw/iniconf.cpp:455
 #, c-format
 msgid "Can't delete the INI file '%s'"
 msgstr "Não é possível apagar o ficheiro INI '%s'"
 
-#: ../src/msw/registry.cpp:805
+#: ../src/msw/registry.cpp:793
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Não é possível apagar valor '%s' da chave '%s'"
 
-#: ../src/msw/registry.cpp:1171
+#: ../src/msw/registry.cpp:1159
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Não é possível enumerar as sub-chaves da chave '%s'"
 
-#: ../src/msw/registry.cpp:1132
+#: ../src/msw/registry.cpp:1120
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Não é possível enumerar os valores da chave '%s'"
 
-#: ../src/msw/registry.cpp:1389
+#: ../src/msw/registry.cpp:1377
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Não foi possível exportar valores de tipo %d não suportado."
 
-#: ../src/common/ffile.cpp:254
+#: ../src/common/ffile.cpp:253
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Não foi possível encontrar a posição atual no ficheiro '%s'"
 
-#: ../src/msw/registry.cpp:418
+#: ../src/msw/registry.cpp:407
 #, c-format
 msgid "Can't get info about registry key '%s'"
 msgstr "Não foi possível obter informação sobre a chave de registo '%s'"
 
-#: ../src/common/zstream.cpp:346
+#: ../src/msw/webview_ie.cpp:1024
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "Não foi possível definir prioridade da thread"
+
+#: ../src/common/zstream.cpp:343
 msgid "Can't initialize zlib deflate stream."
 msgstr "Não é possível inicializar o zlib deflate stream."
 
-#: ../src/common/zstream.cpp:185
+#: ../src/common/zstream.cpp:182
 msgid "Can't initialize zlib inflate stream."
 msgstr "Não é possível inicializar o zlib inflate stream."
 
-#: ../src/msw/fswatcher.cpp:476
+#: ../src/msw/fswatcher.cpp:475
 #, c-format
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr ""
 "Não é possível monitorizar a diretoria inexistente \"%s\" para alterações."
 
-#: ../src/msw/registry.cpp:454
+#: ../src/msw/registry.cpp:443
 #, c-format
 msgid "Can't open registry key '%s'"
 msgstr "Não foi possível abrir chave de registo '%s'"
 
-#: ../src/common/zstream.cpp:252
+#: ../src/common/zstream.cpp:249
 #, c-format
 msgid "Can't read from inflate stream: %s"
 msgstr "Não foi possível ler do inflate stream: %s"
 
-#: ../src/common/zstream.cpp:244
+#: ../src/common/zstream.cpp:241
 msgid "Can't read inflate stream: unexpected EOF in underlying stream."
 msgstr ""
 "Não foi possível ler o inflate stream: EOF inexperado no stream subjacente."
 
-#: ../src/msw/registry.cpp:1064
+#: ../src/msw/registry.cpp:1052
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Não foi possível ler valor de '%s'"
 
-#: ../src/msw/registry.cpp:878 ../src/msw/registry.cpp:910
-#: ../src/msw/registry.cpp:975
+#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
+#: ../src/msw/registry.cpp:963
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Não foi possível ler valor da chave '%s'"
 
-#: ../src/common/image.cpp:2620
+#: ../src/msw/webview_ie.cpp:1017
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/common/image.cpp:2715
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr ""
 "Não foi possível gravar imagem para ficheiro '%s': extensão desconhecida."
 
-#: ../src/generic/logg.cpp:573 ../src/generic/logg.cpp:976
+#: ../src/generic/logg.cpp:570 ../src/generic/logg.cpp:973
 msgid "Can't save log contents to file."
 msgstr "Não foi possível gravar conteúdo do registo para ficheiro."
 
-#: ../src/msw/thread.cpp:629
+#: ../src/msw/thread.cpp:621
 msgid "Can't set thread priority"
 msgstr "Não foi possível definir prioridade da thread"
 
-#: ../src/msw/registry.cpp:896 ../src/msw/registry.cpp:938
-#: ../src/msw/registry.cpp:1081
+#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
+#: ../src/msw/registry.cpp:1069
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Não foi possível definir valor de '%s'"
 
-#: ../src/unix/utilsunx.cpp:351
+#: ../src/unix/utilsunx.cpp:353
 #, fuzzy
 msgid "Can't write to child process's stdin"
 msgstr "Falha no encerramento do processo %d"
 
-#: ../src/common/zstream.cpp:427
+#: ../src/common/zstream.cpp:424
 #, c-format
 msgid "Can't write to deflate stream: %s"
 msgstr "Não foi possível escrever no edeflate stream: %s"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:279 ../src/richtext/richtextstyledlg.cpp:300
-#: ../src/common/stockitem.cpp:145 ../src/common/accelcmn.cpp:71
-#: ../src/msw/msgdlg.cpp:454 ../src/msw/progdlg.cpp:673
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:142
+#: ../src/common/accelcmn.cpp:68 ../src/motif/msgdlg.cpp:196
+#: ../src/gtk1/fontdlg.cpp:144 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/progdlg.cpp:940 ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: ../src/common/filefn.cpp:1261
+#: ../src/common/filefn.cpp:1149
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Não foi possível enumerar os ficheiros '%s'"
 
-#: ../src/msw/dir.cpp:263
+#: ../src/msw/dir.cpp:260
 #, c-format
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Não foi possível enumerar os ficheiros na diretoria '%s'"
 
-#: ../src/msw/dialup.cpp:523
+#: ../src/msw/dialup.cpp:517
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Não foi possível encontrar a ligação telefónica ativa: %s"
 
-#: ../src/msw/dialup.cpp:827
+#: ../src/msw/dialup.cpp:821
 msgid "Cannot find the location of address book file"
 msgstr ""
 "Não foi possível encontrar a localização do ficheiro do livro de endereços"
 
-#: ../src/msw/ole/automtn.cpp:562
+#: ../src/msw/ole/automtn.cpp:553
 #, fuzzy, c-format
 msgid "Cannot get an active instance of \"%s\""
 msgstr "Não foi possível encontrar a ligação telefónica ativa: %s"
 
-#: ../src/unix/threadpsx.cpp:1035
+#: ../src/unix/threadpsx.cpp:1053
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr ""
 "Não foi possível obter a gama de prioridade para a política de agendamento "
 "%d."
 
-#: ../src/unix/utilsunx.cpp:987
+#: ../src/unix/utilsunx.cpp:989
 msgid "Cannot get the hostname"
 msgstr "Não foi possível obter o nome de computador"
 
-#: ../src/unix/utilsunx.cpp:1023
+#: ../src/unix/utilsunx.cpp:1025
 msgid "Cannot get the official hostname"
 msgstr "Não foi possível obter o nome de computador oficial"
 
-#: ../src/msw/dialup.cpp:928
+#: ../src/msw/dialup.cpp:922
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Não foi possível desligar - nenhuma ligação telefónica ativa."
 
@@ -1853,128 +1858,128 @@ msgstr "Não foi possível desligar - nenhuma ligação telefónica ativa."
 msgid "Cannot initialize OLE"
 msgstr "Não foi possível inicializar o OLE"
 
-#: ../src/common/socket.cpp:853
+#: ../src/common/socket.cpp:850
 #, fuzzy
 msgid "Cannot initialize sockets"
 msgstr "Não foi possível inicializar o OLE"
 
-#: ../src/msw/volume.cpp:619
+#: ../src/msw/volume.cpp:627
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Não foi possível carregar ícone de '%s'."
 
-#: ../src/xrc/xmlres.cpp:360
+#: ../src/xrc/xmlres.cpp:358
 #, fuzzy, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Não foi possível carregar recursos do ficheiro '%s'."
 
-#: ../src/xrc/xmlres.cpp:742
+#: ../src/xrc/xmlres.cpp:740
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Não foi possível carregar recursos do ficheiro '%s'."
 
-#: ../src/html/htmlfilt.cpp:137
+#: ../src/html/htmlfilt.cpp:134
 #, c-format
 msgid "Cannot open HTML document: %s"
 msgstr "Não foi possível abrir o documento HTML: %s"
 
-#: ../src/html/helpdata.cpp:667
+#: ../src/html/helpdata.cpp:660
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Não foi possível abrir o livro de ajuda HTML: %s"
 
-#: ../src/html/helpdata.cpp:299
+#: ../src/html/helpdata.cpp:296
 #, c-format
 msgid "Cannot open contents file: %s"
 msgstr "Não foi possível abrir o ficheiro de conteúdos: %s"
 
-#: ../src/generic/dcpsg.cpp:1667
+#: ../src/generic/dcpsg.cpp:1665
 msgid "Cannot open file for PostScript printing!"
 msgstr "Não foi possível abrir o ficheiro para impressão em PostScript!"
 
-#: ../src/html/helpdata.cpp:313
+#: ../src/html/helpdata.cpp:310
 #, c-format
 msgid "Cannot open index file: %s"
 msgstr "Não foi possível abrir ficheiro de índice: %s"
 
-#: ../src/xrc/xmlres.cpp:724
+#: ../src/xrc/xmlres.cpp:722
 #, fuzzy, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Não foi possível carregar recursos do ficheiro '%s'."
 
-#: ../src/html/helpwnd.cpp:1534
+#: ../src/html/helpwnd.cpp:1532
 msgid "Cannot print empty page."
 msgstr "Não foi possível imprimir página vazia."
 
-#: ../src/msw/volume.cpp:507
+#: ../src/msw/volume.cpp:515
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Não foi possível ler tipo de nome de '%s'!"
 
-#: ../src/msw/thread.cpp:888
+#: ../src/msw/thread.cpp:894
 #, fuzzy, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Não é possível retomar a thread %x"
 
-#: ../src/unix/threadpsx.cpp:1016
+#: ../src/unix/threadpsx.cpp:1028
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Não foi possível obter thread de política de agendamento."
 
-#: ../src/common/intl.cpp:558
+#: ../src/common/intl.cpp:365
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:831 ../src/msw/thread.cpp:546
+#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
 msgid "Cannot start thread: error writing TLS."
 msgstr "Não é possível iniciar a thread: erro ao escrever o TLS."
 
-#: ../src/msw/thread.cpp:872
+#: ../src/msw/thread.cpp:864
 #, fuzzy, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Não é possível suspender a thread %x"
 
-#: ../src/msw/thread.cpp:794
+#: ../src/msw/thread.cpp:786
 msgid "Cannot wait for thread termination"
 msgstr "Não é possível esperar pela terminação da thread"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:75
+#: ../src/common/accelcmn.cpp:72
 #, fuzzy
 msgid "Capital"
 msgstr "Maiúsculas"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:879
+#: ../src/propgrid/advprops.cpp:780
 msgid "CaptionText"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:531
 msgid "Case sensitive"
 msgstr "Sensível à capitulação"
 
-#: ../src/propgrid/manager.cpp:1509
+#: ../src/propgrid/manager.cpp:1527
 msgid "Categorized Mode"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9968
+#: ../src/richtext/richtextbuffer.cpp:9965
 msgid "Cell Properties"
 msgstr "Propriedades da Célula"
 
-#: ../src/common/fmapbase.cpp:161
+#: ../src/common/fmapbase.cpp:158
 msgid "Celtic (ISO-8859-14)"
 msgstr "Céltico (ISO-8859-14)"
 
-#: ../src/richtext/richtextindentspage.cpp:160
 #: ../src/richtext/richtextliststylepage.cpp:349
+#: ../src/richtext/richtextindentspage.cpp:160
 msgid "Cen&tred"
 msgstr "Cen&trado"
 
-#: ../src/common/stockitem.cpp:170
+#: ../src/common/stockitem.cpp:167
 msgid "Centered"
 msgstr "Centrado"
 
-#: ../src/common/fmapbase.cpp:149
+#: ../src/common/fmapbase.cpp:146
 msgid "Central European (ISO-8859-2)"
 msgstr "Europa Central (ISO-8859-2)"
 
@@ -1983,10 +1988,10 @@ msgstr "Europa Central (ISO-8859-2)"
 msgid "Centre"
 msgstr "Centro"
 
-#: ../src/richtext/richtextindentspage.cpp:162
-#: ../src/richtext/richtextindentspage.cpp:164
 #: ../src/richtext/richtextliststylepage.cpp:351
 #: ../src/richtext/richtextliststylepage.cpp:353
+#: ../src/richtext/richtextindentspage.cpp:162
+#: ../src/richtext/richtextindentspage.cpp:164
 msgid "Centre text."
 msgstr "Centrar texto."
 
@@ -1999,26 +2004,26 @@ msgstr "Centrado"
 msgid "Ch&oose..."
 msgstr "Esc&olher..."
 
-#: ../src/richtext/richtextbuffer.cpp:4354
+#: ../src/richtext/richtextbuffer.cpp:4351
 msgid "Change List Style"
 msgstr "Alterar Lista de Estilos"
 
-#: ../src/richtext/richtextbuffer.cpp:3709
+#: ../src/richtext/richtextbuffer.cpp:3706
 #, fuzzy
 msgid "Change Object Style"
 msgstr "Alterar Lista de Estilos"
 
-#: ../src/richtext/richtextbuffer.cpp:3982
-#: ../src/richtext/richtextbuffer.cpp:8129
+#: ../src/richtext/richtextbuffer.cpp:3979
+#: ../src/richtext/richtextbuffer.cpp:8125
 #, fuzzy
 msgid "Change Properties"
 msgstr "&Propriedades"
 
-#: ../src/richtext/richtextbuffer.cpp:3526
+#: ../src/richtext/richtextbuffer.cpp:3523
 msgid "Change Style"
 msgstr "Alterar Estilo"
 
-#: ../src/common/fileconf.cpp:341
+#: ../src/common/fileconf.cpp:335
 #, c-format
 msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
 msgstr ""
@@ -2029,12 +2034,12 @@ msgid "Changing current directory to \"%s\" failed"
 msgstr "Falha de criação de directório \"%s\""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1757
+#: ../src/propgrid/advprops.cpp:1658
 #, fuzzy
 msgid "Character"
 msgstr "Código de &Caracter:"
 
-#: ../src/richtext/richtextstyles.cpp:1063
+#: ../src/richtext/richtextstyles.cpp:1060
 msgid "Character styles"
 msgstr "Estilos de Caracteres"
 
@@ -2072,20 +2077,20 @@ msgstr "Marque para circundar o marcador entre parêntesis."
 msgid "Check to indicate right-to-left text layout."
 msgstr "Clique para alterar a cor do texto."
 
-#: ../src/osx/carbon/fontdlg.cpp:356 ../src/osx/carbon/fontdlg.cpp:358
+#: ../src/osx/carbon/fontdlg.cpp:353 ../src/osx/carbon/fontdlg.cpp:355
 msgid "Check to make the font bold."
 msgstr "Marque para tornar a letra destacada."
 
-#: ../src/osx/carbon/fontdlg.cpp:363 ../src/osx/carbon/fontdlg.cpp:365
+#: ../src/osx/carbon/fontdlg.cpp:360 ../src/osx/carbon/fontdlg.cpp:362
 msgid "Check to make the font italic."
 msgstr "Marque para tornar a letra itálica."
 
-#: ../src/osx/carbon/fontdlg.cpp:372 ../src/osx/carbon/fontdlg.cpp:374
+#: ../src/osx/carbon/fontdlg.cpp:369 ../src/osx/carbon/fontdlg.cpp:371
 msgid "Check to make the font underlined."
 msgstr "Marque para tornar a letra sublinhada."
 
-#: ../src/richtext/richtextstyledlg.cpp:289
-#: ../src/richtext/richtextstyledlg.cpp:291
+#: ../src/richtext/richtextstyledlg.cpp:285
+#: ../src/richtext/richtextstyledlg.cpp:287
 msgid "Check to restart numbering."
 msgstr "Marque para reiniciar a numeração."
 
@@ -2124,52 +2129,52 @@ msgstr "Marque para circundar o marcador entre parêntesis."
 msgid "Check to suppress hyphenation."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:763
+#: ../src/msw/dialup.cpp:757
 msgid "Choose ISP to dial"
 msgstr "Escolha o ISP para marcar"
 
-#: ../src/propgrid/props.cpp:1922
+#: ../src/propgrid/props.cpp:1904
 #, fuzzy
 msgid "Choose a directory:"
 msgstr "Criar directório"
 
-#: ../src/propgrid/props.cpp:1975
+#: ../src/propgrid/props.cpp:2199
 msgid "Choose a file"
 msgstr "Escolher um ficheiro"
 
-#: ../src/generic/colrdlgg.cpp:158 ../src/gtk/colordlg.cpp:54
+#: ../src/generic/colrdlgg.cpp:156 ../src/gtk/colordlg.cpp:49
 msgid "Choose colour"
 msgstr "Escolher cor"
 
-#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/gtk1/fontdlg.cpp:125 ../src/generic/fontpickerg.cpp:47
+#: ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Escolher fonte"
 
-#: ../src/common/module.cpp:74
+#: ../src/common/module.cpp:71
 #, c-format
 msgid "Circular dependency involving module \"%s\" detected."
 msgstr "Foi detectada uma dependência circular envolvendo o módulo \"%s\"."
 
-#: ../src/aui/tabmdi.cpp:108 ../src/generic/mdig.cpp:97
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
 msgid "Cl&ose"
 msgstr "F&echar"
 
-#: ../src/msw/ole/automtn.cpp:684
+#: ../src/msw/ole/automtn.cpp:675
 msgid "Class not registered."
 msgstr "Classe não registada."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:147 ../src/common/accelcmn.cpp:72
+#: ../src/common/stockitem.cpp:144 ../src/common/accelcmn.cpp:69
 msgid "Clear"
 msgstr "Limpar"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "Clear the log contents"
 msgstr "Limpar o conteúdo do registo"
 
-#: ../src/richtext/richtextstyledlg.cpp:252
-#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:248
+#: ../src/richtext/richtextstyledlg.cpp:250
 msgid "Click to apply the selected style."
 msgstr "Clique para aplicar o estilo Selecionado."
 
@@ -2180,15 +2185,15 @@ msgstr "Clique para aplicar o estilo Selecionado."
 msgid "Click to browse for a symbol."
 msgstr "Clique para procurar por um simbolo."
 
-#: ../src/osx/carbon/fontdlg.cpp:403 ../src/osx/carbon/fontdlg.cpp:405
+#: ../src/osx/carbon/fontdlg.cpp:400 ../src/osx/carbon/fontdlg.cpp:402
 msgid "Click to cancel changes to the font."
 msgstr "Clique para cancelar as alterações à fonte."
 
-#: ../src/generic/fontdlgg.cpp:472 ../src/generic/fontdlgg.cpp:491
+#: ../src/generic/fontdlgg.cpp:468 ../src/generic/fontdlgg.cpp:487
 msgid "Click to cancel the font selection."
 msgstr "Clique para cancelar selecção de fonte."
 
-#: ../src/osx/carbon/fontdlg.cpp:384 ../src/osx/carbon/fontdlg.cpp:386
+#: ../src/osx/carbon/fontdlg.cpp:381 ../src/osx/carbon/fontdlg.cpp:383
 msgid "Click to change the font colour."
 msgstr "Clique para alterar a cor da fonte."
 
@@ -2207,37 +2212,37 @@ msgstr "Clique para alterar a cor do texto."
 msgid "Click to choose the font for this level."
 msgstr "Clique para escolher a fonte para este nível."
 
-#: ../src/richtext/richtextstyledlg.cpp:279
-#: ../src/richtext/richtextstyledlg.cpp:281
+#: ../src/richtext/richtextstyledlg.cpp:275
+#: ../src/richtext/richtextstyledlg.cpp:277
 msgid "Click to close this window."
 msgstr "Clique para fechar esta janela."
 
-#: ../src/osx/carbon/fontdlg.cpp:410 ../src/osx/carbon/fontdlg.cpp:412
+#: ../src/osx/carbon/fontdlg.cpp:407 ../src/osx/carbon/fontdlg.cpp:409
 msgid "Click to confirm changes to the font."
 msgstr "Clique para confirmar alterações a fonte."
 
-#: ../src/generic/fontdlgg.cpp:477 ../src/generic/fontdlgg.cpp:479
-#: ../src/generic/fontdlgg.cpp:484 ../src/generic/fontdlgg.cpp:486
+#: ../src/generic/fontdlgg.cpp:473 ../src/generic/fontdlgg.cpp:475
+#: ../src/generic/fontdlgg.cpp:480 ../src/generic/fontdlgg.cpp:482
 msgid "Click to confirm the font selection."
 msgstr "Clique para confirmar selecção de fonte."
 
-#: ../src/richtext/richtextstyledlg.cpp:244
-#: ../src/richtext/richtextstyledlg.cpp:246
+#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:242
 msgid "Click to create a new box style."
 msgstr "Clique para criar um novo estilo de caixa."
 
-#: ../src/richtext/richtextstyledlg.cpp:226
-#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:224
 msgid "Click to create a new character style."
 msgstr "Clique para criar um novo estilo de caracter."
 
-#: ../src/richtext/richtextstyledlg.cpp:238
-#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:236
 msgid "Click to create a new list style."
 msgstr "Clique para criar uma nova lista de estilos."
 
-#: ../src/richtext/richtextstyledlg.cpp:232
-#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:230
 msgid "Click to create a new paragraph style."
 msgstr "Clique para criar um novo estilo de parágrafo."
 
@@ -2251,8 +2256,8 @@ msgstr "Clique para criar uma nova posição de tabulação."
 msgid "Click to delete all tab positions."
 msgstr "Clique para apagar todas as posições de tabulação."
 
-#: ../src/richtext/richtextstyledlg.cpp:270
-#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:268
 msgid "Click to delete the selected style."
 msgstr "Clique para apagar o estilo Selecionado."
 
@@ -2261,25 +2266,25 @@ msgstr "Clique para apagar o estilo Selecionado."
 msgid "Click to delete the selected tab position."
 msgstr "Clique para apagar a posição de tabulação Selecionada."
 
-#: ../src/richtext/richtextstyledlg.cpp:264
-#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:262
 msgid "Click to edit the selected style."
 msgstr "Clique para editar estilo Selecionado."
 
-#: ../src/richtext/richtextstyledlg.cpp:258
-#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:256
 msgid "Click to rename the selected style."
 msgstr "Clique para renomear estilo Selecionado."
 
-#: ../src/generic/dbgrptg.cpp:97 ../src/generic/progdlgg.cpp:759
-#: ../src/richtext/richtextstyledlg.cpp:277
-#: ../src/richtext/richtextsymboldlg.cpp:476 ../src/common/stockitem.cpp:148
-#: ../src/msw/progdlg.cpp:170 ../src/msw/progdlg.cpp:679
-#: ../src/html/helpdlg.cpp:90
+#: ../src/common/stockitem.cpp:145 ../src/generic/dbgrptg.cpp:94
+#: ../src/generic/progdlgg.cpp:781 ../src/msw/progdlg.cpp:211
+#: ../src/msw/progdlg.cpp:946 ../src/html/helpdlg.cpp:87
+#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextstyledlg.cpp:273
 msgid "Close"
 msgstr "Fechar"
 
-#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:98
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
 msgid "Close All"
 msgstr "Fechar Tudo"
 
@@ -2287,65 +2292,65 @@ msgstr "Fechar Tudo"
 msgid "Close current document"
 msgstr "Fechar documento atual"
 
-#: ../src/generic/logg.cpp:516
+#: ../src/generic/logg.cpp:513
 msgid "Close this window"
 msgstr "Fechar esta janela"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6006
+#: ../src/generic/datavgen.cpp:6811
 msgid "Collapse"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "Color"
 msgstr "Cor"
 
-#: ../src/richtext/richtextformatdlg.cpp:776
+#: ../src/richtext/richtextformatdlg.cpp:768
 msgid "Colour"
 msgstr "Cor"
 
-#: ../src/msw/colordlg.cpp:158
+#: ../src/msw/colordlg.cpp:227
 #, fuzzy, c-format
 msgid "Colour selection dialog failed with error %0lx."
 msgstr "Execução do comando '%s' terminou com o erro: %ul"
 
-#: ../src/osx/carbon/fontdlg.cpp:380
+#: ../src/osx/carbon/fontdlg.cpp:377
 msgid "Colour:"
 msgstr "Cor:"
 
-#: ../src/generic/datavgen.cpp:6077
+#: ../src/generic/datavgen.cpp:6882
 #, fuzzy, c-format
 msgid "Column %u"
 msgstr "Adicionar Coluna"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:114
+#: ../src/common/accelcmn.cpp:112
 msgid "Command"
 msgstr ""
 
-#: ../src/common/init.cpp:196
+#: ../src/common/init.cpp:193
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
 "ignored."
 msgstr ""
 
-#: ../src/msw/fontdlg.cpp:120
+#: ../src/msw/fontdlg.cpp:170
 #, fuzzy, c-format
 msgid "Common dialog failed with error code %0lx."
 msgstr "Execução do comando '%s' terminou com o erro: %ul"
 
-#: ../src/gtk/window.cpp:4649
+#: ../src/gtk/window.cpp:5653
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:1549
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Ficheiro de ajuda HTML comprimido (*.chm)|*.chm|"
 
-#: ../src/generic/dirctrlg.cpp:444
+#: ../src/generic/dirctrlg.cpp:410
 msgid "Computer"
 msgstr "Computador"
 
@@ -2354,53 +2359,57 @@ msgstr "Computador"
 msgid "Config entry name cannot start with '%c'."
 msgstr "Nome de entrada de configuração não pode começar por '%c'."
 
-#: ../src/generic/filedlgg.cpp:349 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
 msgid "Confirm"
 msgstr "Confirmar"
 
-#: ../src/html/htmlwin.cpp:566
+#: ../src/html/htmlwin.cpp:569
 msgid "Connecting..."
 msgstr "A ligar..."
 
-#: ../src/html/helpwnd.cpp:475
+#: ../src/html/helpwnd.cpp:473
 msgid "Contents"
 msgstr "Conteúdos"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:880
+#: ../src/propgrid/advprops.cpp:781
 msgid "ControlDark"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:881
+#: ../src/propgrid/advprops.cpp:782
 msgid "ControlLight"
 msgstr ""
 
-#: ../src/common/strconv.cpp:2262
+#: ../src/common/strconv.cpp:2208
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Conversão código de caracteres '%s' não funciona."
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "Convert"
 msgstr "Converter"
 
-#: ../src/html/htmlwin.cpp:1079
+#: ../src/html/htmlwin.cpp:1020
 #, c-format
 msgid "Copied to clipboard:\"%s\""
 msgstr "Copiado para a área de transferência:\"%s\""
 
-#: ../src/generic/prntdlgg.cpp:247
+#: ../src/generic/prntdlgg.cpp:240
 msgid "Copies:"
 msgstr "Cópias:"
 
-#: ../src/common/stockitem.cpp:150 ../src/stc/stc_i18n.cpp:18
+#: ../src/common/stockitem.cpp:147 ../src/stc/stc_i18n.cpp:18
 msgid "Copy"
 msgstr "Copiar"
 
-#: ../src/common/stockitem.cpp:258
+#: ../src/common/stockitem.cpp:255
 msgid "Copy selection"
 msgstr "Copiar selecção"
+
+#: ../src/generic/grid.cpp:5945
+msgid "Copying more than one selected block to clipboard is not supported."
+msgstr ""
 
 #: ../src/richtext/richtextborderspage.cpp:566
 #: ../src/richtext/richtextborderspage.cpp:601
@@ -2411,204 +2420,200 @@ msgstr ""
 msgid "Corner &radius:"
 msgstr ""
 
-#: ../src/html/chm.cpp:718
+#: ../src/html/chm.cpp:711
 #, c-format
 msgid "Could not create temporary file '%s'"
 msgstr "Não foi possível criar ficheiro temporário '%s'"
 
-#: ../src/html/chm.cpp:273
+#: ../src/html/chm.cpp:270
 #, c-format
 msgid "Could not extract %s into %s: %s"
 msgstr "Não foi possível extrair %s para %s: %s"
 
-#: ../src/generic/tabg.cpp:1048
+#: ../src/generic/tabg.cpp:1045
 msgid "Could not find tab for id"
 msgstr "Não foi possível localizar a tabulação para o id"
 
-#: ../src/gtk/notifmsg.cpp:108
-#, fuzzy
-msgid "Could not initalize libnotify."
-msgstr "Não foi possível inicia a impressão."
-
-#: ../src/html/chm.cpp:444
+#: ../src/html/chm.cpp:437
 #, c-format
 msgid "Could not locate file '%s'."
 msgstr "Não foi possível localizar o ficheiro '%s'."
 
-#: ../src/common/filefn.cpp:1403
+#: ../src/msw/graphicsd2d.cpp:604
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/common/filefn.cpp:1291
 #, fuzzy
 msgid "Could not set current working directory"
 msgstr "Falha na obtenção do directório de trabalho"
 
-#: ../src/common/prntbase.cpp:2015
+#: ../src/common/prntbase.cpp:2037
 msgid "Could not start document preview."
 msgstr "Não foi possível iniciar antevisão do documento."
 
-#: ../src/generic/printps.cpp:178 ../src/msw/printwin.cpp:210
-#: ../src/gtk/print.cpp:1132
+#: ../src/generic/printps.cpp:159 ../src/msw/printwin.cpp:184
+#: ../src/gtk/print.cpp:1129
 msgid "Could not start printing."
 msgstr "Não foi possível inicia a impressão."
 
-#: ../src/common/wincmn.cpp:2125
+#: ../src/common/wincmn.cpp:2126
 msgid "Could not transfer data to window"
 msgstr "Não foi possível transferir dados para a janela"
 
-#: ../src/msw/imaglist.cpp:187 ../src/msw/imaglist.cpp:224
-#: ../src/msw/imaglist.cpp:249 ../src/msw/dragimag.cpp:185
-#: ../src/msw/dragimag.cpp:220
+#: ../src/msw/imaglist.cpp:223 ../src/msw/imaglist.cpp:245
+#: ../src/msw/imaglist.cpp:270 ../src/msw/dragimag.cpp:182
+#: ../src/msw/dragimag.cpp:217
 msgid "Couldn't add an image to the image list."
 msgstr "Não foi possível adicionar uma imagem à lista de imagens."
 
-#: ../src/osx/glcanvas_osx.cpp:414 ../src/unix/glx11.cpp:558
-#: ../src/msw/glcanvas.cpp:616
+#: ../src/osx/glcanvas_osx.cpp:411 ../src/msw/glcanvas.cpp:631
+#: ../src/unix/glegl.cpp:315 ../src/unix/glx11.cpp:559
 #, fuzzy
 msgid "Couldn't create OpenGL context"
 msgstr "Não foi possível criar um temporizador"
 
-#: ../src/msw/timer.cpp:134
+#: ../src/msw/timer.cpp:131
 msgid "Couldn't create a timer"
 msgstr "Não foi possível criar um temporizador"
 
-#: ../src/osx/carbon/overlay.cpp:122
-msgid "Couldn't create the overlay window"
-msgstr "Não foi possível criar a janela de sobreposição"
-
-#: ../src/common/translation.cpp:2024
+#: ../src/common/translation.cpp:2074
 #, fuzzy
 msgid "Couldn't enumerate translations"
 msgstr "Não foi possível terminar a thread"
 
-#: ../src/common/dynlib.cpp:120
+#: ../src/common/dynlib.cpp:110
 #, c-format
 msgid "Couldn't find symbol '%s' in a dynamic library"
 msgstr "Não foi possível encontrar o símbolo '%s' numa livraria dinâmica"
 
-#: ../src/msw/thread.cpp:915
+#: ../src/msw/thread.cpp:921
 msgid "Couldn't get the current thread pointer"
 msgstr "impossível obter o ponteiro atual da thread"
 
-#: ../src/osx/carbon/overlay.cpp:129
-msgid "Couldn't init the context on the overlay window"
-msgstr "Não foi possível inicializar o contexto na janela de sobreposição"
-
-#: ../src/common/imaggif.cpp:244
+#: ../src/common/imaggif.cpp:241
 #, fuzzy
 msgid "Couldn't initialize GIF hash table."
 msgstr "Não é possível inicializar o zlib deflate stream."
 
-#: ../src/common/imagpng.cpp:409
+#: ../src/common/imagpng.cpp:437
 msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
 msgstr ""
 "Não foi possível carregar uma imagem PNG - Ficheiro corrupto ou memória "
 "insuficiente."
 
-#: ../src/unix/sound.cpp:470
+#: ../src/unix/sound.cpp:459
 #, c-format
 msgid "Couldn't load sound data from '%s'."
 msgstr "Não foi possível carregar dados de som a partir de '%s'."
 
-#: ../src/msw/dirdlg.cpp:435
+#: ../src/msw/dirdlg.cpp:287
 #, fuzzy
 msgid "Couldn't obtain folder name"
 msgstr "Não foi possível criar um temporizador"
 
-#: ../src/unix/sound_sdl.cpp:229
+#: ../src/unix/sound_sdl.cpp:226
 #, c-format
 msgid "Couldn't open audio: %s"
 msgstr "Não foi possível abrir o áudio: %s"
 
-#: ../src/msw/ole/dataobj.cpp:377
+#: ../src/msw/ole/dataobj.cpp:385
 #, c-format
 msgid "Couldn't register clipboard format '%s'."
 msgstr "Não foi possível registar o formato da área de transferência '%s'."
 
-#: ../src/msw/listctrl.cpp:869
+#: ../src/msw/listctrl.cpp:933
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr ""
 "Não foi possível obter informação sobre o item da lista de controlo %d."
 
-#: ../src/common/imagpng.cpp:498 ../src/common/imagpng.cpp:509
-#: ../src/common/imagpng.cpp:519
+#: ../src/common/imagpng.cpp:511 ../src/common/imagpng.cpp:522
+#: ../src/common/imagpng.cpp:532
 msgid "Couldn't save PNG image."
 msgstr "Não foi possível gravar a imagem PNG."
 
-#: ../src/msw/thread.cpp:684
+#: ../src/msw/thread.cpp:676
 msgid "Couldn't terminate thread"
 msgstr "Não foi possível terminar a thread"
 
-#: ../src/common/xtistrm.cpp:166
+#: ../src/common/xtistrm.cpp:163
 #, fuzzy, c-format
 msgid "Create Parameter %s not found in declared RTTI Parameters"
 msgstr "Create Parameter não encontrado nos Parâmetros RTTI declarados"
 
-#: ../src/generic/dirdlgg.cpp:288
+#: ../src/generic/dirdlgg.cpp:285
 msgid "Create directory"
 msgstr "Criar directório"
 
-#: ../src/generic/filedlgg.cpp:212 ../src/generic/dirdlgg.cpp:111
+#: ../src/generic/filedlgg.cpp:209 ../src/generic/dirdlgg.cpp:108
 msgid "Create new directory"
 msgstr "Criar novo directório"
 
-#: ../src/xrc/xmlres.cpp:2460
+#: ../src/common/stockitem.cpp:264
+#, fuzzy
+msgid "Create new document"
+msgstr "Criar novo directório"
+
+#: ../src/xrc/xmlres.cpp:2515
 #, fuzzy, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Falhou a extracção de '%s' para '%s'."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1758
+#: ../src/propgrid/advprops.cpp:1659
 msgid "Cross"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:333
+#: ../src/common/accelcmn.cpp:347
 msgid "Ctrl+"
 msgstr "Ctrl+"
 
-#: ../src/richtext/richtextctrl.cpp:332 ../src/osx/textctrl_osx.cpp:576
-#: ../src/common/stockitem.cpp:151 ../src/msw/textctrl.cpp:2507
+#: ../src/osx/textctrl_osx.cpp:594 ../src/common/stockitem.cpp:148
+#: ../src/msw/textctrl.cpp:2772 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "Cor&tar"
 
-#: ../src/generic/filectrlg.cpp:940
+#: ../src/generic/filectrlg.cpp:936
 msgid "Current directory:"
 msgstr "Directório atual:"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:896 ../src/propgrid/advprops.cpp:1574
-#: ../src/propgrid/advprops.cpp:1612
+#: ../src/propgrid/advprops.cpp:797 ../src/propgrid/advprops.cpp:1475
+#: ../src/propgrid/advprops.cpp:1518
 #, fuzzy
 msgid "Custom"
 msgstr "Tamanho Personalizado"
 
-#: ../src/gtk/print.cpp:217
+#: ../src/gtk/print.cpp:211
 msgid "Custom size"
 msgstr "Tamanho Personalizado"
 
-#: ../src/common/headerctrlcmn.cpp:60
+#: ../src/common/headerctrlcmn.cpp:58
 msgid "Customize Columns"
 msgstr "Personalizar Colunas"
 
-#: ../src/common/stockitem.cpp:151 ../src/stc/stc_i18n.cpp:17
+#: ../src/common/stockitem.cpp:148 ../src/stc/stc_i18n.cpp:17
 msgid "Cut"
 msgstr "Cortar"
 
-#: ../src/common/stockitem.cpp:259
+#: ../src/common/stockitem.cpp:256
 msgid "Cut selection"
 msgstr "Cortar selecção"
 
-#: ../src/common/fmapbase.cpp:152
+#: ../src/common/fmapbase.cpp:149
 msgid "Cyrillic (ISO-8859-5)"
 msgstr "Cirílico (ISO-8859-5)"
 
-#: ../src/common/paper.cpp:99
+#: ../src/common/paper.cpp:96
 msgid "D sheet, 22 x 34 in"
 msgstr "Folha D, 22 x 34 pol."
 
-#: ../src/msw/dde.cpp:703
+#: ../src/msw/dde.cpp:698
 msgid "DDE poke request failed"
 msgstr "Falhou o pedido de poke DDE"
 
-#: ../src/common/imagbmp.cpp:1169
+#: ../src/common/imagbmp.cpp:1181
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr "Cabeçalho DIB: Codificação não coincide com o bitdepth."
 
@@ -2628,7 +2633,7 @@ msgstr "Cabeçalho DIB: Bitdepth desconhecido no ficheiro."
 msgid "DIB Header: Unknown encoding in file."
 msgstr "Cabeçalho DIB: Codificação desconhecida no ficheiro."
 
-#: ../src/common/paper.cpp:121
+#: ../src/common/paper.cpp:118
 msgid "DL Envelope, 110 x 220 mm"
 msgstr "Envelope DL, 110 x 220 mm"
 
@@ -2636,55 +2641,55 @@ msgstr "Envelope DL, 110 x 220 mm"
 msgid "Dashed"
 msgstr "Travessões"
 
-#: ../src/generic/dbgrptg.cpp:300
+#: ../src/generic/dbgrptg.cpp:301
 #, c-format
 msgid "Debug report \"%s\""
 msgstr "Relatório de depuração \"%s\""
 
-#: ../src/common/debugrpt.cpp:210
+#: ../src/common/debugrpt.cpp:211
 msgid "Debug report couldn't be created."
 msgstr "Relatório de depuração não pode ser criado."
 
-#: ../src/common/debugrpt.cpp:553
+#: ../src/common/debugrpt.cpp:554
 msgid "Debug report generation has failed."
 msgstr "Falhou a geração do relatório de depuração."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:84
+#: ../src/common/accelcmn.cpp:81
 msgid "Decimal"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:323
+#: ../src/generic/fontdlgg.cpp:319
 msgid "Decorative"
 msgstr "Decorative"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1752
+#: ../src/propgrid/advprops.cpp:1653
 #, fuzzy
 msgid "Default"
 msgstr "pré-definição"
 
-#: ../src/common/fmapbase.cpp:796
+#: ../src/common/fmapbase.cpp:792
 msgid "Default encoding"
 msgstr "Codificação pré-definida"
 
-#: ../src/dfb/fontmgr.cpp:180
+#: ../src/dfb/fontmgr.cpp:177
 msgid "Default font"
 msgstr "Tipo de letra Predefinida"
 
-#: ../src/generic/prntdlgg.cpp:510
+#: ../src/generic/prntdlgg.cpp:503
 msgid "Default printer"
 msgstr "Impressora pré-definida"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:51
+#: ../src/common/accelcmn.cpp:48
 #, fuzzy
 msgid "Del"
 msgstr "Apagar"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextbuffer.cpp:8221 ../src/common/stockitem.cpp:152
-#: ../src/common/accelcmn.cpp:50 ../src/stc/stc_i18n.cpp:20
+#: ../src/common/stockitem.cpp:149 ../src/common/accelcmn.cpp:47
+#: ../src/richtext/richtextbuffer.cpp:8217 ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Apagar"
 
@@ -2692,69 +2697,69 @@ msgstr "Apagar"
 msgid "Delete A&ll"
 msgstr "Apagar T&udo"
 
-#: ../src/richtext/richtextbuffer.cpp:11341
+#: ../src/richtext/richtextbuffer.cpp:11340
 msgid "Delete Column"
 msgstr "Apagar Coluna"
 
-#: ../src/richtext/richtextbuffer.cpp:11291
+#: ../src/richtext/richtextbuffer.cpp:11290
 msgid "Delete Row"
 msgstr "Apagar Fila"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 msgid "Delete Style"
 msgstr "Apagar Estilo"
 
-#: ../src/richtext/richtextctrl.cpp:1345 ../src/richtext/richtextctrl.cpp:1584
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
 msgid "Delete Text"
 msgstr "Apagar Texto"
 
-#: ../src/generic/editlbox.cpp:170
+#: ../src/generic/editlbox.cpp:147
 msgid "Delete item"
 msgstr "Apagar Item"
 
-#: ../src/common/stockitem.cpp:260
+#: ../src/common/stockitem.cpp:257
 msgid "Delete selection"
 msgstr "Apagar selecção"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 #, c-format
 msgid "Delete style %s?"
 msgstr "Apagar estilo %s?"
 
-#: ../src/unix/snglinst.cpp:301
+#: ../src/unix/snglinst.cpp:298
 #, c-format
 msgid "Deleted stale lock file '%s'."
 msgstr "Ficheiro de bloqueio apagado '%s'."
 
-#: ../src/common/secretstore.cpp:220
+#: ../src/common/secretstore.cpp:234
 #, fuzzy, c-format
-msgid "Deleting password for \"%s/%s\" failed: %s."
+msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Falhou a extracção de '%s' para '%s'."
 
-#: ../src/common/module.cpp:124
+#: ../src/common/module.cpp:121
 #, c-format
 msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
 msgstr "Dependência  \"%s\" do módulo \"%s\" não existe."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "Descending"
 msgstr "Descendente"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:526 ../src/propgrid/advprops.cpp:882
+#: ../src/generic/dirctrlg.cpp:492 ../src/propgrid/advprops.cpp:783
 msgid "Desktop"
 msgstr "Ambiente de Trabalho"
 
-#: ../src/generic/aboutdlgg.cpp:70
+#: ../src/generic/aboutdlgg.cpp:67
 msgid "Developed by "
 msgstr "Desenvolvido por "
 
-#: ../src/generic/aboutdlgg.cpp:176
+#: ../src/generic/aboutdlgg.cpp:173
 #, fuzzy
 msgid "Developers"
 msgstr "Desenvolvido por "
 
-#: ../src/msw/dialup.cpp:374
+#: ../src/msw/dialup.cpp:368
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -2763,11 +2768,11 @@ msgstr ""
 "de acesso remoto (RAS) não estar instalado neste computador. Por favor "
 "Instale-o."
 
-#: ../src/generic/tipdlg.cpp:211
+#: ../src/generic/tipdlg.cpp:208
 msgid "Did you know..."
 msgstr "Sabia que..."
 
-#: ../src/dfb/wrapdfb.cpp:63
+#: ../src/dfb/wrapdfb.cpp:60
 #, fuzzy, c-format
 msgid "DirectFB error %d occurred."
 msgstr "Ocorreu um erro %d de DirectFB."
@@ -2776,29 +2781,29 @@ msgstr "Ocorreu um erro %d de DirectFB."
 msgid "Directories"
 msgstr "Directórios"
 
-#: ../src/common/filefn.cpp:1183
+#: ../src/common/filefn.cpp:1071
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Não foi possível criar o directório '%s'"
 
-#: ../src/common/filefn.cpp:1197
+#: ../src/common/filefn.cpp:1085
 #, fuzzy, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "Não foi possível criar o directório '%s'"
 
-#: ../src/generic/dirdlgg.cpp:204
+#: ../src/generic/dirdlgg.cpp:201
 msgid "Directory does not exist"
 msgstr "O directório não existe"
 
-#: ../src/generic/filectrlg.cpp:1399
+#: ../src/generic/filectrlg.cpp:1388
 msgid "Directory doesn't exist."
 msgstr "O directório não existe."
 
-#: ../src/common/docview.cpp:457
+#: ../src/common/docview.cpp:450
 msgid "Discard changes and reload the last saved version?"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:502
+#: ../src/html/helpwnd.cpp:500
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -2806,47 +2811,47 @@ msgstr ""
 "Mostrar todos os items de índice que contenham a seguinte cadeia. A pesquisa "
 "é insensível à capitulação."
 
-#: ../src/html/helpwnd.cpp:679
+#: ../src/html/helpwnd.cpp:677
 msgid "Display options dialog"
 msgstr "Caixa de diálogo do ecrã"
 
-#: ../src/html/helpwnd.cpp:322
+#: ../src/html/helpwnd.cpp:320
 msgid "Displays help as you browse the books on the left."
 msgstr "Mostrar ajuda à medida que navega nos livros à esquerda."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:85
+#: ../src/common/accelcmn.cpp:83
 msgid "Divide"
 msgstr ""
 
-#: ../src/common/docview.cpp:533
+#: ../src/common/docview.cpp:526
 #, fuzzy, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Deseja gravar as alterações ao documento %s?"
 
-#: ../src/common/prntbase.cpp:542
+#: ../src/common/prntbase.cpp:537
 #, fuzzy
 msgid "Document:"
 msgstr "Documentado por "
 
-#: ../src/generic/aboutdlgg.cpp:73
+#: ../src/generic/aboutdlgg.cpp:70
 msgid "Documentation by "
 msgstr "Documentado por "
 
-#: ../src/generic/aboutdlgg.cpp:180
+#: ../src/generic/aboutdlgg.cpp:177
 #, fuzzy
 msgid "Documentation writers"
 msgstr "Documentado por "
 
-#: ../src/common/sizer.cpp:2799
+#: ../src/common/sizer.cpp:2916
 msgid "Don't Save"
 msgstr "Não Gravar"
 
-#: ../src/html/htmlwin.cpp:633
+#: ../src/html/htmlwin.cpp:643
 msgid "Done"
 msgstr "Feito"
 
-#: ../src/generic/progdlgg.cpp:448 ../src/msw/progdlg.cpp:407
+#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
 msgid "Done."
 msgstr "Feito."
 
@@ -2859,43 +2864,43 @@ msgstr "Feito"
 msgid "Double"
 msgstr "Duplo"
 
-#: ../src/common/paper.cpp:176
+#: ../src/common/paper.cpp:173
 msgid "Double Japanese Postcard Rotated 148 x 200 mm"
 msgstr "Postal Japonês Duplo Rodado 148 x 200 mm"
 
-#: ../src/common/xtixml.cpp:273
+#: ../src/common/xtixml.cpp:269
 #, c-format
 msgid "Doubly used id : %d"
 msgstr "Id usado duplamente : %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:153
-#: ../src/common/accelcmn.cpp:64
+#: ../src/common/stockitem.cpp:150 ../src/common/accelcmn.cpp:61
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Down"
 msgstr "Baixo"
 
-#: ../src/richtext/richtextctrl.cpp:865
+#: ../src/richtext/richtextctrl.cpp:864
 msgid "Drag"
 msgstr "Arrastar"
 
-#: ../src/common/paper.cpp:100
+#: ../src/common/paper.cpp:97
 msgid "E sheet, 34 x 44 in"
 msgstr "Folha E, 34 x 44 pol."
 
-#: ../src/unix/fswatcher_inotify.cpp:561
+#: ../src/unix/fswatcher_inotify.cpp:558
 #, fuzzy
 msgid "EOF while reading from inotify descriptor"
 msgstr "não foi possível ler do descritor do ficheiro %d"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "Edit"
 msgstr "Editar"
 
-#: ../src/generic/editlbox.cpp:168
+#: ../src/generic/editlbox.cpp:131
 msgid "Edit item"
 msgstr "Editar item"
 
-#: ../include/wx/generic/progdlgg.h:84
+#: ../include/wx/generic/progdlgg.h:85
 msgid "Elapsed time:"
 msgstr "Tempo decorrido: "
 
@@ -2969,65 +2974,65 @@ msgid "Enables the shadow spread."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:66
+#: ../src/common/accelcmn.cpp:63
 msgid "End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:55
+#: ../src/common/accelcmn.cpp:52
 #, fuzzy
 msgid "Enter"
 msgstr "Impressora"
 
-#: ../src/richtext/richtextstyledlg.cpp:934
+#: ../src/richtext/richtextstyledlg.cpp:930
 #, fuzzy
 msgid "Enter a box style name"
 msgstr "Introduza um nome de estilo de lista"
 
-#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:602
 msgid "Enter a character style name"
 msgstr "Introduza um nome de estilo de caracter"
 
-#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:816
 msgid "Enter a list style name"
 msgstr "Introduza um nome de estilo de lista"
 
-#: ../src/richtext/richtextstyledlg.cpp:893
+#: ../src/richtext/richtextstyledlg.cpp:889
 #, fuzzy
 msgid "Enter a new style name"
 msgstr "Introduza um nome de estilo de lista"
 
-#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:650
 msgid "Enter a paragraph style name"
 msgstr "Introduza um nome de estilo de parágrafo"
 
-#: ../src/generic/dbgrptg.cpp:174
+#: ../src/generic/dbgrptg.cpp:171
 #, c-format
 msgid "Enter command to open file \"%s\":"
 msgstr "Introduza o comando para abrir o ficheiro \"%s\":"
 
-#: ../src/generic/helpext.cpp:459
+#: ../src/generic/helpext.cpp:457
 msgid "Entries found"
 msgstr "Entradas encontradas"
 
-#: ../src/common/paper.cpp:142
+#: ../src/common/paper.cpp:139
 msgid "Envelope Invite 220 x 220 mm"
 msgstr "Envelope de Convite 220 x 220 mm"
 
-#: ../src/common/config.cpp:469
+#: ../src/common/config.cpp:465
 #, c-format
 msgid ""
 "Environment variables expansion failed: missing '%c' at position %u in '%s'."
 msgstr ""
 "Falhou a expansão das variáveis de ambiente: falta %c na posição %u em '%s'."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/generic/dirctrlg.cpp:570
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/dirctrlg.cpp:599
-#: ../src/generic/dirdlgg.cpp:323 ../src/generic/filectrlg.cpp:642
-#: ../src/generic/filectrlg.cpp:756 ../src/generic/filectrlg.cpp:770
-#: ../src/generic/filectrlg.cpp:786 ../src/generic/filectrlg.cpp:1368
-#: ../src/generic/filectrlg.cpp:1399 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/gtk1/fontdlg.cpp:74 ../src/generic/dirctrlg.cpp:536
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/dirctrlg.cpp:565
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1357 ../src/generic/filectrlg.cpp:1388
+#: ../src/generic/filedlgg.cpp:354 ../src/generic/dirdlgg.cpp:320
+#: ../src/gtk/filedlg.cpp:74
 msgid "Error"
 msgstr "Erro"
 
@@ -3036,89 +3041,100 @@ msgstr "Erro"
 msgid "Error closing epoll descriptor"
 msgstr "Erro ao criar directório"
 
-#: ../src/unix/fswatcher_kqueue.cpp:114
+#: ../src/unix/fswatcher_kqueue.cpp:131
 #, fuzzy
 msgid "Error closing kqueue instance"
 msgstr "Erro ao criar directório"
 
-#: ../src/common/filefn.cpp:1049
+#: ../src/common/filefn.cpp:938
 #, fuzzy, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Falha ao copiar o ficheiro '%s' para '%s'"
 
-#: ../src/generic/dirdlgg.cpp:222
+#: ../src/generic/dirdlgg.cpp:219
 msgid "Error creating directory"
 msgstr "Erro ao criar directório"
 
-#: ../src/common/imagbmp.cpp:1181
+#: ../src/common/imagbmp.cpp:1193
 msgid "Error in reading image DIB."
 msgstr "Erro na leitura do DIB da imagem."
 
-#: ../src/propgrid/propgrid.cpp:6696
+#: ../src/propgrid/propgrid.cpp:6665
 #, c-format
 msgid "Error in resource: %s"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:422
+#: ../src/common/fileconf.cpp:421
 msgid "Error reading config options."
 msgstr "Erro ao ler opções de configuração."
+
+#: ../src/msw/webview_ie.cpp:1057 ../src/msw/webview_edge.cpp:850
+#: ../src/gtk/webview_webkit2.cpp:1262 ../src/osx/webview_webkit.mm:383
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
 
 #: ../src/common/fileconf.cpp:1029
 msgid "Error saving user configuration data."
 msgstr "Erro ao gravar dados de configuração do utilizador."
 
-#: ../src/gtk/print.cpp:722
+#: ../src/gtk/print.cpp:720
 #, fuzzy
 msgid "Error while printing: "
 msgstr "Erro durante a espera de um semáforo"
 
-#: ../src/common/log.cpp:219
+#: ../src/common/log.cpp:237
 msgid "Error: "
 msgstr "Erro: "
 
+#: ../src/common/webrequest.cpp:98
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Erro: "
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:69
+#: ../src/common/accelcmn.cpp:66
 msgid "Esc"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:70
+#: ../src/common/accelcmn.cpp:67
 #, fuzzy
 msgid "Escape"
 msgstr "Paisagem"
 
-#: ../src/common/fmapbase.cpp:150
+#: ../src/common/fmapbase.cpp:147
 msgid "Esperanto (ISO-8859-3)"
 msgstr "Esperanto (ISO-8859-3)"
 
-#: ../include/wx/generic/progdlgg.h:85
+#: ../include/wx/generic/progdlgg.h:86
 msgid "Estimated time:"
 msgstr "Tempo estimado: "
 
-#: ../src/generic/dbgrptg.cpp:234
+#: ../src/generic/dbgrptg.cpp:231
 msgid "Executable files (*.exe)|*.exe|"
 msgstr "Ficheiros Executáveis (*.exe)|*.exe|"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:155 ../src/common/accelcmn.cpp:78
+#: ../src/common/stockitem.cpp:152 ../src/common/accelcmn.cpp:75
 msgid "Execute"
 msgstr "Executar"
 
-#: ../src/msw/utilsexc.cpp:876
+#: ../src/msw/utilsexc.cpp:873
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Falhou a execução do comando '%s'"
 
-#: ../src/common/paper.cpp:105
+#: ../src/common/paper.cpp:102
 msgid "Executive, 7 1/4 x 10 1/2 in"
 msgstr "Executivo, 7 1/4 x 10 1/2 pol."
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6009
+#: ../src/generic/datavgen.cpp:6814
 msgid "Expand"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1240
+#: ../src/msw/registry.cpp:1228
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
@@ -3126,150 +3142,160 @@ msgstr ""
 "Exportação da chave de registo: o ficheiro \"%s\" já existe e não vai ser "
 "sobreposto."
 
-#: ../src/common/fmapbase.cpp:195
+#: ../src/common/fmapbase.cpp:192
 msgid "Extended Unix Codepage for Japanese (EUC-JP)"
 msgstr "Código de Página Extendido para Japonês (EUC-JP)"
 
-#: ../src/html/chm.cpp:725
+#: ../src/html/chm.cpp:718
 #, c-format
 msgid "Extraction of '%s' into '%s' failed."
 msgstr "Falhou a extracção de '%s' para '%s'."
 
-#: ../src/common/accelcmn.cpp:249 ../src/common/accelcmn.cpp:344
+#: ../src/common/accelcmn.cpp:259 ../src/common/accelcmn.cpp:358
 msgid "F"
 msgstr "F"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:672
+#: ../src/propgrid/advprops.cpp:582
 #, fuzzy
 msgid "Face Name"
 msgstr "NovoNome"
 
-#: ../src/unix/snglinst.cpp:269
+#: ../src/unix/snglinst.cpp:266
 msgid "Failed to access lock file."
 msgstr "Falha no acesso ao ficheiro de bloqueio."
+
+#: ../src/gtk/font.cpp:572
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Falha na leitura de metafile do ficheiro \"%s\"."
 
 #: ../src/unix/epolldispatcher.cpp:116
 #, fuzzy, c-format
 msgid "Failed to add descriptor %d to epoll descriptor %d"
 msgstr "Não foi possível escrever no descritor de ficheiro %d"
 
-#: ../src/msw/dib.cpp:489
+#: ../src/msw/dib.cpp:535
 #, fuzzy, c-format
 msgid "Failed to allocate %luKb of memory for bitmap data."
 msgstr "Falha ao alocar %luKb de memória para dados bitmap."
 
-#: ../src/common/glcmn.cpp:115
+#: ../src/common/glcmn.cpp:112
 #, fuzzy
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Falha de criação de cursor."
 
-#: ../src/unix/displayx11.cpp:236
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Falha de criação de cursor."
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Falha de criação de cursor."
+
+#: ../include/wx/unix/private/displayx11.h:89
 msgid "Failed to change video mode"
 msgstr "Falha ao alterar o modo de vídeo"
 
-#: ../src/common/image.cpp:3277
+#: ../src/common/image.cpp:3396
 #, fuzzy, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Falha ao gravar imagem de bitmap para ficheiro \"%s\"."
 
-#: ../src/common/debugrpt.cpp:239
+#: ../src/common/debugrpt.cpp:240
 #, c-format
 msgid "Failed to clean up debug report directory \"%s\""
 msgstr "Falha ao limpar a diretoria \"%s\" do relatório de depuração"
 
-#: ../src/common/filename.cpp:192
+#: ../src/common/filename.cpp:189
 msgid "Failed to close file handle"
 msgstr "Falha ao fechar manuseador de ficheiro"
 
-#: ../src/unix/snglinst.cpp:340
+#: ../src/unix/snglinst.cpp:337
 #, c-format
 msgid "Failed to close lock file '%s'"
 msgstr "Falha ao fechar o ficheiro de bloqueio '%s'"
 
-#: ../src/msw/clipbrd.cpp:112
+#: ../src/msw/clipbrd.cpp:110
 msgid "Failed to close the clipboard."
 msgstr "Falha ao fechar a área de transferência."
 
-#: ../src/x11/utils.cpp:208
+#: ../src/x11/utils.cpp:170
 #, c-format
 msgid "Failed to close the display \"%s\""
 msgstr "Falha ao fechar o ecrã \"%s\""
 
-#: ../src/msw/dialup.cpp:797
+#: ../src/msw/dialup.cpp:791
 msgid "Failed to connect: missing username/password."
 msgstr "Falha na ligação: falta nome de utilizador/palavra passe."
 
-#: ../src/msw/dialup.cpp:743
+#: ../src/msw/dialup.cpp:737
 msgid "Failed to connect: no ISP to dial."
 msgstr "Falha na ligação: nenhum serviço ISP para marcar."
 
-#: ../src/common/textfile.cpp:203
-#, fuzzy, c-format
-msgid "Failed to convert file \"%s\" to Unicode."
-msgstr "Falha ao converter conteúdo do ficheiro para Unicode."
-
-#: ../src/generic/logg.cpp:956
+#: ../src/generic/logg.cpp:953
 #, fuzzy
 msgid "Failed to copy dialog contents to the clipboard."
 msgstr "Falha na abertura da área de transferência."
 
-#: ../src/msw/registry.cpp:692
+#: ../src/msw/registry.cpp:681
 #, c-format
 msgid "Failed to copy registry value '%s'"
 msgstr "Falha na cópia do valor do registo '%s'"
 
-#: ../src/msw/registry.cpp:701
+#: ../src/msw/registry.cpp:690
 #, c-format
 msgid "Failed to copy the contents of registry key '%s' to '%s'."
 msgstr "Falha ao copiar os conteúdos da chave de registo '%s' para '%s'."
 
-#: ../src/common/filefn.cpp:1015
+#: ../src/common/filefn.cpp:904
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Falha ao copiar o ficheiro '%s' para '%s'"
 
-#: ../src/msw/registry.cpp:679
+#: ../src/msw/registry.cpp:668
 #, c-format
 msgid "Failed to copy the registry subkey '%s' to '%s'."
 msgstr "Falha ao copiar a sub-chave de registo '%s' para '%s'."
 
-#: ../src/msw/dde.cpp:1070
+#: ../src/msw/dde.cpp:1134
 msgid "Failed to create DDE string"
 msgstr "Falha ne criação da cadeia de caracteres DDE"
 
-#: ../src/msw/mdi.cpp:616
+#: ../src/msw/mdi.cpp:621
 msgid "Failed to create MDI parent frame."
 msgstr "Falha na criação da moldura MDI progenitora."
 
-#: ../src/common/filename.cpp:1027
+#: ../src/common/filename.cpp:1024
 msgid "Failed to create a temporary file name"
 msgstr "Falha a criar nome de ficheiro temporário"
 
-#: ../src/msw/utilsexc.cpp:228
+#: ../src/msw/utilsexc.cpp:225
 msgid "Failed to create an anonymous pipe"
 msgstr "Falha ao criar pipeline anónimo"
 
-#: ../src/msw/ole/automtn.cpp:522
+#: ../src/msw/ole/automtn.cpp:513
 #, fuzzy, c-format
 msgid "Failed to create an instance of \"%s\""
 msgstr "Falha de criação de directório \"%s\""
 
-#: ../src/msw/dde.cpp:437
+#: ../src/msw/dde.cpp:432
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "Falha ao criar ligação ao servidor '%s' no tópico '%s'"
 
-#: ../src/msw/cursor.cpp:204
+#: ../src/msw/cursor.cpp:195
 msgid "Failed to create cursor."
 msgstr "Falha de criação de cursor."
 
-#: ../src/common/debugrpt.cpp:209
+#: ../src/common/debugrpt.cpp:210
 #, c-format
 msgid "Failed to create directory \"%s\""
 msgstr "Falha de criação de directório \"%s\""
 
-#: ../src/generic/dirdlgg.cpp:220
+#: ../src/generic/dirdlgg.cpp:217
 #, c-format
 msgid ""
 "Failed to create directory '%s'\n"
@@ -3283,117 +3309,136 @@ msgstr ""
 msgid "Failed to create epoll descriptor"
 msgstr "Falha de criação de cursor."
 
-#: ../src/msw/mimetype.cpp:238
+#: ../src/gtk/font.cpp:562
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "Falha na atualização do ficheiro de configuração do utilizador."
+
+#: ../src/msw/mimetype.cpp:235
 #, c-format
 msgid "Failed to create registry entry for '%s' files."
 msgstr "Falha de criação de entrada de registo para ficheiros '%s'."
 
-#: ../src/msw/fdrepdlg.cpp:409
+#: ../src/msw/fdrepdlg.cpp:408
 #, c-format
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr ""
 "Falha a criar dialogo standard de procura/substitui (código de erro %d)"
 
-#: ../src/unix/wakeuppipe.cpp:52
+#: ../src/unix/wakeuppipe.cpp:49
 #, fuzzy
 msgid "Failed to create wake up pipe used by event loop."
 msgstr "Falha de criação de barra de estado."
 
-#: ../src/html/winpars.cpp:730
+#: ../src/html/winpars.cpp:727
 #, c-format
 msgid "Failed to display HTML document in %s encoding"
 msgstr "Falha a mostrar documento HTML na codificação %s"
 
-#: ../src/msw/clipbrd.cpp:124
+#: ../src/msw/clipbrd.cpp:122
 msgid "Failed to empty the clipboard."
 msgstr "Falha a limpar a área de transferência."
 
-#: ../src/unix/displayx11.cpp:212
+#: ../include/wx/unix/private/displayx11.h:65
 msgid "Failed to enumerate video modes"
 msgstr "Falha a enumerar modos de vídeo"
 
-#: ../src/msw/dde.cpp:722
+#: ../src/msw/dde.cpp:717
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "Falha ao estabelecer um advise loop com o servidor DDE"
 
-#: ../src/msw/dialup.cpp:629 ../src/msw/dialup.cpp:863
+#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Falha ao estabelecer ligação telefónica: %s"
 
-#: ../src/unix/utilsunx.cpp:611
+#: ../src/unix/utilsunx.cpp:613
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Falha ao executar '%s'\n"
 
-#: ../src/common/debugrpt.cpp:720
+#: ../src/common/debugrpt.cpp:730
 msgid "Failed to execute curl, please install it in PATH."
 msgstr "Falha a executar curl, por favor instale-o no PATH."
 
-#: ../src/msw/ole/automtn.cpp:505
+#: ../src/msw/ole/automtn.cpp:496
 #, fuzzy, c-format
 msgid "Failed to find CLSID of \"%s\""
 msgstr "Falha na abertura do ecrã \"%s\"."
 
-#: ../src/common/regex.cpp:431 ../src/common/regex.cpp:479
+#: ../src/common/regex.cpp:428 ../src/common/regex.cpp:476
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "Falha a encontrar resultados na procura por expressão regular: %s"
 
-#: ../src/msw/dialup.cpp:695
+#: ../src/msw/webview_ie.cpp:978
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:689
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Falha ao obter nomes de ISP: %s"
 
-#: ../src/msw/ole/automtn.cpp:574
+#: ../src/msw/ole/automtn.cpp:565
 #, fuzzy, c-format
 msgid "Failed to get OLE automation interface for \"%s\""
 msgstr "Falha de criação de directório \"%s\""
 
-#: ../src/msw/clipbrd.cpp:711
+#: ../src/msw/clipbrd.cpp:731
 msgid "Failed to get data from the clipboard"
 msgstr "Falha na obtenção de dados da área de transferência"
 
-#: ../src/common/time.cpp:223
+#: ../src/common/time.cpp:216
 msgid "Failed to get the local system time"
 msgstr "Falha na obtenção da hora local do sistema"
 
-#: ../src/common/filefn.cpp:1345
+#: ../src/common/filefn.cpp:1233
 msgid "Failed to get the working directory"
 msgstr "Falha na obtenção do directório de trabalho"
 
-#: ../src/univ/theme.cpp:114
+#: ../src/univ/theme.cpp:111
 msgid "Failed to initialize GUI: no built-in themes found."
 msgstr "Falha ao inicializar o GUI: não foram encontrados temas integrados."
 
-#: ../src/msw/helpchm.cpp:63
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:60
 msgid "Failed to initialize MS HTML Help."
 msgstr "Falha na inicialização da ajuda MS HTML."
 
-#: ../src/msw/glcanvas.cpp:1381
+#: ../src/msw/glcanvas.cpp:1391
 msgid "Failed to initialize OpenGL"
 msgstr "Falha ao inicializar o OpenGL"
 
-#: ../src/msw/dialup.cpp:858
+#: ../src/msw/dialup.cpp:852
 #, fuzzy, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Falha ao terminar a ligação telefónica: %s "
 
-#: ../src/gtk/textctrl.cpp:1128
+#: ../src/gtk/textctrl.cpp:1209
 msgid "Failed to insert text in the control."
 msgstr "Falha de inserção de texto no controlo."
 
-#: ../src/unix/snglinst.cpp:241
+#: ../src/unix/snglinst.cpp:238
 #, c-format
 msgid "Failed to inspect the lock file '%s'"
 msgstr "Falha de inspecção no ficheiro de bloqueio '%s'"
 
-#: ../src/unix/appunix.cpp:182
+#: ../src/unix/appunix.cpp:179
 #, fuzzy
 msgid "Failed to install signal handler"
 msgstr "Falha ao fechar manuseador de ficheiro"
 
-#: ../src/unix/threadpsx.cpp:1167
+#: ../src/unix/threadpsx.cpp:1216
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -3401,71 +3446,71 @@ msgstr ""
 "Falha na associação a uma thread, foi detectada uma potencial fuga de "
 "memória - por favor reinicie o programa"
 
-#: ../src/msw/utils.cpp:629
+#: ../src/msw/utils.cpp:619
 #, c-format
 msgid "Failed to kill process %d"
 msgstr "Falha no encerramento do processo %d"
 
-#: ../src/common/image.cpp:2500
+#: ../src/common/image.cpp:2595
 #, fuzzy, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Falha na abertura da imagem %d do ficheiro '%s'."
 
-#: ../src/common/image.cpp:2509
+#: ../src/common/image.cpp:2604
 #, fuzzy, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Falha na abertura da imagem %d do ficheiro '%s'."
 
-#: ../src/common/iconbndl.cpp:225
+#: ../src/common/iconbndl.cpp:224
 #, fuzzy, c-format
 msgid "Failed to load icons from resource '%s'."
 msgstr "Falha na abertura da imagem %d do ficheiro '%s'."
 
-#: ../src/common/iconbndl.cpp:200
+#: ../src/common/iconbndl.cpp:198
 #, fuzzy, c-format
 msgid "Failed to load image %%d from file '%s'."
 msgstr "Falha na abertura da imagem %d do ficheiro '%s'."
 
-#: ../src/common/iconbndl.cpp:208
+#: ../src/common/iconbndl.cpp:206
 #, fuzzy, c-format
 msgid "Failed to load image %d from stream."
 msgstr "Falha na abertura da imagem %d do ficheiro '%s'."
 
-#: ../src/common/image.cpp:2587 ../src/common/image.cpp:2606
+#: ../src/common/image.cpp:2682 ../src/common/image.cpp:2701
 #, fuzzy, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Falha na abertura da imagem %d do ficheiro '%s'."
 
-#: ../src/msw/enhmeta.cpp:97
+#: ../src/msw/enhmeta.cpp:94
 #, c-format
 msgid "Failed to load metafile from file \"%s\"."
 msgstr "Falha na leitura de metafile do ficheiro \"%s\"."
 
-#: ../src/msw/volume.cpp:327
+#: ../src/msw/volume.cpp:335
 msgid "Failed to load mpr.dll."
 msgstr "Falha na abertura do mpr.dll."
 
-#: ../src/msw/utils.cpp:953
+#: ../src/msw/utils.cpp:943
 #, fuzzy, c-format
 msgid "Failed to load resource \"%s\"."
 msgstr "Falha na leitura de metafile do ficheiro \"%s\"."
 
-#: ../src/common/dynlib.cpp:92
+#: ../src/common/dynlib.cpp:86
 #, c-format
 msgid "Failed to load shared library '%s'"
 msgstr "Falha na abertura da livraria partilhada '%s'"
 
-#: ../src/osx/core/sound.cpp:145
+#: ../src/osx/core/sound.cpp:143
 #, fuzzy, c-format
 msgid "Failed to load sound from \"%s\" (error %d)."
 msgstr "Falha na leitura de metafile do ficheiro \"%s\"."
 
-#: ../src/msw/utils.cpp:960
+#: ../src/msw/utils.cpp:950
 #, fuzzy, c-format
 msgid "Failed to lock resource \"%s\"."
 msgstr "Falha no bloqueio do ficheiro de bloqueio '%s'"
 
-#: ../src/unix/snglinst.cpp:198
+#: ../src/unix/snglinst.cpp:195
 #, c-format
 msgid "Failed to lock the lock file '%s'"
 msgstr "Falha no bloqueio do ficheiro de bloqueio '%s'"
@@ -3475,33 +3520,38 @@ msgstr "Falha no bloqueio do ficheiro de bloqueio '%s'"
 msgid "Failed to modify descriptor %d in epoll descriptor %d"
 msgstr ""
 
-#: ../src/common/filename.cpp:2575
+#: ../src/common/filename.cpp:2658
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Falha a modificar o tempo do ficheiro para '%s'"
 
-#: ../src/common/selectdispatcher.cpp:258
+#: ../src/common/selectdispatcher.cpp:255
 msgid "Failed to monitor I/O channels"
 msgstr ""
 
-#: ../src/common/filename.cpp:175
+#: ../src/common/filename.cpp:172
 #, fuzzy, c-format
 msgid "Failed to open '%s' for reading"
 msgstr "Falha ao abrir '%s' para %s"
 
-#: ../src/common/filename.cpp:180
+#: ../src/common/filename.cpp:177
 #, fuzzy, c-format
 msgid "Failed to open '%s' for writing"
 msgstr "Falha ao abrir '%s' para %s"
 
-#: ../src/html/chm.cpp:141
+#: ../src/html/chm.cpp:138
 #, c-format
 msgid "Failed to open CHM archive '%s'."
 msgstr "Falha na abertura do arquivo CHM '%s'."
 
-#: ../src/common/utilscmn.cpp:1126
+#: ../src/common/utilscmn.cpp:1140
 #, fuzzy, c-format
 msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Falha ao abrir '%s' para %s"
+
+#: ../src/common/hyperlnkcmn.cpp:133
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Falha ao abrir '%s' para %s"
 
 #: ../include/wx/msw/private/fswatcher.h:92
@@ -3509,96 +3559,106 @@ msgstr "Falha ao abrir '%s' para %s"
 msgid "Failed to open directory \"%s\" for monitoring."
 msgstr "Falha ao abrir '%s' para %s"
 
-#: ../src/x11/utils.cpp:227
+#: ../src/x11/utils.cpp:189
 #, c-format
 msgid "Failed to open display \"%s\"."
 msgstr "Falha na abertura do ecrã \"%s\"."
 
-#: ../src/common/filename.cpp:1062
+#: ../src/common/filename.cpp:1059
 msgid "Failed to open temporary file."
 msgstr "Falha na abertura de ficheiro temporário."
 
-#: ../src/msw/clipbrd.cpp:91
+#: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Falha na abertura da área de transferência."
 
-#: ../src/common/translation.cpp:1184
+#: ../src/common/translation.cpp:1226
 #, fuzzy, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Não foi possível analisar gramaticalmente Plural-Forms: '%s'"
 
-#: ../src/unix/mediactrl.cpp:1214
+#: ../src/unix/mediactrl.cpp:1239
 #, fuzzy, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Falha na abertura do ecrã \"%s\"."
 
-#: ../src/msw/clipbrd.cpp:600
+#: ../src/msw/clipbrd.cpp:610
 msgid "Failed to put data on the clipboard"
 msgstr "Falha na inserção de dados na área de transferência"
 
-#: ../src/unix/snglinst.cpp:278
+#: ../src/unix/snglinst.cpp:275
 msgid "Failed to read PID from lock file."
 msgstr "Falha na leitura do PID do ficheiro de bloqueio."
 
-#: ../src/common/fileconf.cpp:433
+#: ../src/common/fileconf.cpp:432
 #, fuzzy
 msgid "Failed to read config options."
 msgstr "Erro ao ler opções de configuração."
 
-#: ../src/common/docview.cpp:681
+#: ../src/common/docview.cpp:676
 #, fuzzy, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Falha na leitura de metafile do ficheiro \"%s\"."
 
-#: ../src/dfb/evtloop.cpp:98
+#: ../src/dfb/evtloop.cpp:99
 #, fuzzy
 msgid "Failed to read event from DirectFB pipe"
 msgstr "Falha na leitura do PID do ficheiro de bloqueio."
 
-#: ../src/unix/wakeuppipe.cpp:120
+#: ../src/unix/wakeuppipe.cpp:117
 #, fuzzy
 msgid "Failed to read from wake-up pipe"
 msgstr "Falha na leitura do PID do ficheiro de bloqueio."
 
-#: ../src/unix/utilsunx.cpp:679
+#: ../src/common/textfile.cpp:96
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Falha na leitura de metafile do ficheiro \"%s\"."
+
+#: ../src/unix/utilsunx.cpp:681
 msgid "Failed to redirect child process input/output"
 msgstr "Falha no redireccionamento do processo filho de entrada/saída"
 
-#: ../src/msw/utilsexc.cpp:701
+#: ../src/msw/utilsexc.cpp:698
 msgid "Failed to redirect the child process IO"
 msgstr "Falha no redireccionamento do processo filho ES"
 
-#: ../src/msw/dde.cpp:288
+#: ../src/msw/dde.cpp:283
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Falha no registo do servidor DDE '%s'"
 
-#: ../src/common/fontmap.cpp:245
+#: ../src/gtk/font.cpp:580
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "Falha na atualização do ficheiro de configuração do utilizador."
+
+#: ../src/common/fontmap.cpp:242
 #, c-format
 msgid "Failed to remember the encoding for the charset '%s'."
 msgstr "Falha ao recordar a codificação para o conjunto de caracteres '%s'."
 
-#: ../src/common/debugrpt.cpp:227
+#: ../src/common/debugrpt.cpp:228
 #, c-format
 msgid "Failed to remove debug report file \"%s\""
 msgstr "Falha ao remover ficheiro \"%s\" do relatório de depuração "
 
-#: ../src/unix/snglinst.cpp:328
+#: ../src/unix/snglinst.cpp:325
 #, c-format
 msgid "Failed to remove lock file '%s'"
 msgstr "Falha ao remover ficheiro de bloqueio '%s'"
 
-#: ../src/unix/snglinst.cpp:288
+#: ../src/unix/snglinst.cpp:285
 #, c-format
 msgid "Failed to remove stale lock file '%s'."
 msgstr "Falha ao remover ficheiro de bloqueio estagnado'%s'."
 
-#: ../src/msw/registry.cpp:529
+#: ../src/msw/registry.cpp:518
 #, c-format
 msgid "Failed to rename registry value '%s' to '%s'."
 msgstr "Falha ao renomear valor de registo de '%s' para '%s'."
 
-#: ../src/common/filefn.cpp:1122
+#: ../src/common/filefn.cpp:1011
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -3607,116 +3667,125 @@ msgstr ""
 "Falha ao renomear o ficheiro de '%s' para '%s' porque o ficheiro de destino "
 "já existe."
 
-#: ../src/msw/registry.cpp:634
+#: ../src/msw/registry.cpp:623
 #, c-format
 msgid "Failed to rename the registry key '%s' to '%s'."
 msgstr "Falha ao renomear a chave de registo de '%s' para '%s'."
 
-#: ../src/common/filename.cpp:2671
+#: ../src/msw/webview_ie.cpp:995
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/common/filename.cpp:2754
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Falha ao obter tempos do ficheiro para '%s'"
 
-#: ../src/msw/dialup.cpp:468
+#: ../src/msw/dialup.cpp:462
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Falha na obtenção do texto da mensagem de erro RAS"
 
-#: ../src/msw/clipbrd.cpp:748
+#: ../src/msw/clipbrd.cpp:768
 msgid "Failed to retrieve the supported clipboard formats"
 msgstr "Falha na obtenção dos formatos suportados pela área de transferência"
 
-#: ../src/common/docview.cpp:652
+#: ../src/common/docview.cpp:647
 #, fuzzy, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Falha ao gravar imagem de bitmap para ficheiro \"%s\"."
 
-#: ../src/msw/dib.cpp:269
+#: ../src/msw/dib.cpp:312
 #, c-format
 msgid "Failed to save the bitmap image to file \"%s\"."
 msgstr "Falha ao gravar imagem de bitmap para ficheiro \"%s\"."
 
-#: ../src/msw/dde.cpp:763
+#: ../src/msw/dde.cpp:811
 msgid "Failed to send DDE advise notification"
 msgstr "Falha ao enviar aviso de notificação DDE"
 
-#: ../src/common/ftp.cpp:402
+#: ../src/common/ftp.cpp:399
 #, c-format
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Falha ao definir modo de transferência FTP para %s."
 
-#: ../src/msw/clipbrd.cpp:427
+#: ../src/msw/clipbrd.cpp:443
 msgid "Failed to set clipboard data."
 msgstr "Falha ao definir dados da área de transferência."
 
-#: ../src/unix/snglinst.cpp:181
+#: ../src/unix/snglinst.cpp:178
 #, c-format
 msgid "Failed to set permissions on lock file '%s'"
 msgstr "Falha ao definir permissões no ficheiro de bloqueio '%s'"
 
-#: ../src/unix/utilsunx.cpp:668
+#: ../src/unix/utilsunx.cpp:670
 #, fuzzy
 msgid "Failed to set process priority"
 msgstr "Falha ao definir prioridade de thread %d."
 
-#: ../src/common/file.cpp:559
+#: ../src/common/ffile.cpp:355 ../src/common/file.cpp:586
 msgid "Failed to set temporary file permissions"
 msgstr "Falha ao definir permissões do ficheiro temporário"
 
-#: ../src/gtk/textctrl.cpp:1072
-msgid "Failed to set text in the text control."
-msgstr "Falha ao definir texto no controlo de texto."
-
-#: ../src/unix/threadpsx.cpp:1298
+#: ../src/unix/threadpsx.cpp:1347
 #, fuzzy, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Falha ao definir prioridade de thread %d."
 
-#: ../src/unix/threadpsx.cpp:1424
+#: ../src/unix/threadpsx.cpp:1473
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Falha ao definir prioridade de thread %d."
 
-#: ../src/unix/utilsunx.cpp:783
+#: ../src/unix/utilsunx.cpp:785
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 
-#: ../src/common/fs_mem.cpp:261
+#: ../src/msw/webview_ie.cpp:987
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:256
 #, c-format
 msgid "Failed to store image '%s' to memory VFS!"
 msgstr "Falha ao armazenar imagem '%s' para memória VFS!"
 
-#: ../src/dfb/evtloop.cpp:170
+#: ../src/dfb/evtloop.cpp:171
 msgid "Failed to switch DirectFB pipe to non-blocking mode"
 msgstr ""
 
-#: ../src/unix/wakeuppipe.cpp:59
+#: ../src/unix/wakeuppipe.cpp:56
 msgid "Failed to switch wake up pipe to non-blocking mode"
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1605
+#: ../src/unix/threadpsx.cpp:1654
 msgid "Failed to terminate a thread."
 msgstr "Falha ao matar a thread."
 
-#: ../src/msw/dde.cpp:741
+#: ../src/msw/dde.cpp:736
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "Falha ao terminar o advise loop com o servidor DDE"
 
-#: ../src/msw/dialup.cpp:938
+#: ../src/msw/dialup.cpp:932
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Falha ao terminar a ligação telefónica: %s "
 
-#: ../src/common/filename.cpp:2590
+#: ../src/common/filename.cpp:2673
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Falha ao tocar no ficheiro '%s'"
 
-#: ../src/unix/snglinst.cpp:334
+#: ../src/unix/dlunix.cpp:90
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "Falha na abertura da livraria partilhada '%s'"
+
+#: ../src/unix/snglinst.cpp:331
 #, c-format
 msgid "Failed to unlock lock file '%s'"
 msgstr "Falha ao desbloquear ficheiro de bloqueio '%s'"
 
-#: ../src/msw/dde.cpp:309
+#: ../src/msw/dde.cpp:304
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Falha ao desregistar servidor DDE '%s'"
@@ -3730,77 +3799,87 @@ msgstr "Falha na obtenção dos dados da área de transferência."
 msgid "Failed to update user configuration file."
 msgstr "Falha na atualização do ficheiro de configuração do utilizador."
 
-#: ../src/common/debugrpt.cpp:733
+#: ../src/common/debugrpt.cpp:743
 #, c-format
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Falha ao enviar o relatório de depuração (código do erro %d)."
 
-#: ../src/unix/snglinst.cpp:168
+#: ../src/unix/snglinst.cpp:165
 #, c-format
 msgid "Failed to write to lock file '%s'"
 msgstr "Falha ao escrever para o ficheiro de bloqueio '%s'"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:209
+#: ../src/propgrid/propgrid.cpp:190
 msgid "False"
 msgstr "Falso"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:694
+#: ../src/propgrid/advprops.cpp:604
 msgid "Family"
 msgstr "Família"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/gtk/glcanvas.cpp:176 ../src/gtk/glcanvas.cpp:187
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Erro Fatal"
+
+#: ../src/common/stockitem.cpp:154
 msgid "File"
 msgstr "Ficheiro"
 
-#: ../src/common/docview.cpp:669
+#: ../src/common/docview.cpp:664
 #, fuzzy, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Falha ao abrir '%s' para %s"
 
-#: ../src/common/docview.cpp:646
+#: ../src/common/docview.cpp:641
 #, fuzzy, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Falha ao abrir '%s' para %s"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "O ficheiro '%s' já existe, deseja substituí-lo?"
 
-#: ../src/common/filefn.cpp:1156
+#: ../src/common/filefn.cpp:1044
 #, fuzzy, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Não foi possível criar o directório '%s'"
 
-#: ../src/common/filefn.cpp:1139
+#: ../src/common/filefn.cpp:1028
 #, fuzzy, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Não foi possível criar o directório '%s'"
 
-#: ../src/richtext/richtextctrl.cpp:3081 ../src/common/textcmn.cpp:953
+#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
 msgid "File couldn't be loaded."
 msgstr "Não foi possível carregar o ficheiro."
 
-#: ../src/msw/filedlg.cpp:393
+#: ../src/msw/filedlg.cpp:414
 #, fuzzy, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Execução do comando '%s' terminou com o erro: %ul"
 
-#: ../src/common/docview.cpp:1789
+#: ../src/common/docview.cpp:1783
 msgid "File error"
 msgstr "Erro de ficheiro"
 
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/filectrlg.cpp:770
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/filectrlg.cpp:766
 msgid "File name exists already."
 msgstr "Nome de ficheiro já existe."
+
+#: ../src/osx/cocoa/filedlg.mm:264
+#, fuzzy
+msgid "File type:"
+msgstr "Teletype"
 
 #: ../src/motif/filedlg.cpp:220
 msgid "Files"
 msgstr "Ficheiros"
 
-#: ../src/common/filefn.cpp:1591
+#: ../src/common/filefn.cpp:1479
 #, c-format
 msgid "Files (%s)"
 msgstr "Ficheiros (%s)"
@@ -3809,15 +3888,29 @@ msgstr "Ficheiros (%s)"
 msgid "Filter"
 msgstr "Filtro"
 
-#: ../src/common/stockitem.cpp:158 ../src/html/helpwnd.cpp:490
+#: ../src/html/helpwnd.cpp:488
 msgid "Find"
 msgstr "Procurar"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:259
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:258
+#, fuzzy
+msgid "Find in document"
+msgstr "Abrir documento HTML"
+
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "Find..."
+msgstr "Procurar"
+
+#: ../src/common/stockitem.cpp:156
 msgid "First"
 msgstr "Primeiro"
 
-#: ../src/common/prntbase.cpp:1548
+#: ../src/common/prntbase.cpp:1573
 msgid "First page"
 msgstr "Primeira Página"
 
@@ -3826,11 +3919,11 @@ msgstr "Primeira Página"
 msgid "Fixed"
 msgstr "Fonte Fixa:"
 
-#: ../src/html/helpwnd.cpp:1206
+#: ../src/html/helpwnd.cpp:1204
 msgid "Fixed font:"
 msgstr "Fonte Fixa:"
 
-#: ../src/html/helpwnd.cpp:1269
+#: ../src/html/helpwnd.cpp:1267
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Tamanho fixo da face.<br> <b>negrito</b> <i>itálico</i> "
 
@@ -3839,16 +3932,16 @@ msgstr "Tamanho fixo da face.<br> <b>negrito</b> <i>itálico</i> "
 msgid "Floating"
 msgstr "A formatar"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "Floppy"
 msgstr "Disquete"
 
-#: ../src/common/paper.cpp:111
+#: ../src/common/paper.cpp:108
 msgid "Folio, 8 1/2 x 13 in"
 msgstr "Folio, 8 1/2 x 13 pol."
 
-#: ../src/richtext/richtextformatdlg.cpp:344 ../src/osx/carbon/fontdlg.cpp:287
-#: ../src/common/stockitem.cpp:194
+#: ../src/osx/carbon/fontdlg.cpp:284 ../src/common/stockitem.cpp:191
+#: ../src/richtext/richtextformatdlg.cpp:337
 msgid "Font"
 msgstr "Fonte"
 
@@ -3856,7 +3949,24 @@ msgstr "Fonte"
 msgid "Font &weight:"
 msgstr "&Peso da fonte:"
 
-#: ../src/html/helpwnd.cpp:1207
+#: ../src/osx/fontutil.cpp:89
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
+"\"."
+msgstr ""
+
+#: ../src/msw/font.cpp:1126
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Não foi possível carregar o ficheiro."
+
+#: ../src/osx/fontutil.cpp:81
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "Ficheiro %s não existe."
+
+#: ../src/html/helpwnd.cpp:1205
 msgid "Font size:"
 msgstr "Tamanho da Fonte:"
 
@@ -3864,75 +3974,75 @@ msgstr "Tamanho da Fonte:"
 msgid "Font st&yle:"
 msgstr "Est&ilo da fonte:"
 
-#: ../src/osx/carbon/fontdlg.cpp:329
+#: ../src/osx/carbon/fontdlg.cpp:326
 msgid "Font:"
 msgstr "Fonte:"
 
-#: ../src/dfb/fontmgr.cpp:198
+#: ../src/dfb/fontmgr.cpp:195
 #, c-format
 msgid "Fonts index file %s disappeared while loading fonts."
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:645
+#: ../src/unix/utilsunx.cpp:647
 msgid "Fork failed"
 msgstr "Falha no fork"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "Forward"
 msgstr "Avançar"
 
-#: ../src/common/xtixml.cpp:235
+#: ../src/common/xtixml.cpp:231
 msgid "Forward hrefs are not supported"
 msgstr "hrefs avançados não são suportados"
 
-#: ../src/html/helpwnd.cpp:875
+#: ../src/html/helpwnd.cpp:873
 #, c-format
 msgid "Found %i matches"
 msgstr "Foram encontradas %i correspondências"
 
-#: ../src/generic/prntdlgg.cpp:238
+#: ../src/generic/prntdlgg.cpp:231
 msgid "From:"
 msgstr "De:"
 
-#: ../src/propgrid/advprops.cpp:1604
+#: ../src/propgrid/advprops.cpp:1510
 msgid "Fuchsia"
 msgstr ""
 
-#: ../src/common/imaggif.cpp:138
+#: ../src/common/imaggif.cpp:135
 msgid "GIF: data stream seems to be truncated."
 msgstr "GIF: corrente de dados parece estar truncada."
 
-#: ../src/common/imaggif.cpp:128
+#: ../src/common/imaggif.cpp:125
 msgid "GIF: error in GIF image format."
 msgstr "GIF: erro no formato de imagem GIF."
 
-#: ../src/common/imaggif.cpp:133
+#: ../src/common/imaggif.cpp:130
 msgid "GIF: not enough memory."
 msgstr "GIF: sem memória suficiente."
 
-#: ../src/gtk/window.cpp:4631
+#: ../src/gtk/window.cpp:5635
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
 msgstr ""
 
-#: ../src/univ/themes/gtk.cpp:525
+#: ../src/univ/themes/gtk.cpp:522
 msgid "GTK+ theme"
 msgstr "Tema GTK+"
 
-#: ../src/common/preferencescmn.cpp:40
+#: ../src/common/preferencescmn.cpp:37
 msgid "General"
 msgstr "Geral"
 
-#: ../src/common/prntbase.cpp:258
+#: ../src/common/prntbase.cpp:253
 msgid "Generic PostScript"
 msgstr "PostScript Genérico"
 
-#: ../src/common/paper.cpp:135
+#: ../src/common/paper.cpp:132
 msgid "German Legal Fanfold, 8 1/2 x 13 in"
 msgstr "Legal Fanfold Alemão, 8 1/2 x 13 pol."
 
-#: ../src/common/paper.cpp:134
+#: ../src/common/paper.cpp:131
 msgid "German Std Fanfold, 8 1/2 x 12 in"
 msgstr "Std Fanfold Alemão, 8 1/2 x 12 pol."
 
@@ -3948,48 +4058,48 @@ msgstr "GetPropertyCollection chamado num acessor genérico"
 msgid "GetPropertyCollection called w/o valid collection getter"
 msgstr "GetPropertyCollection chamado sem colecção de getter válido"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:658
 msgid "Go back"
 msgstr "Ir para trás"
 
-#: ../src/html/helpwnd.cpp:661
+#: ../src/html/helpwnd.cpp:659
 msgid "Go forward"
 msgstr "Ir para a frente"
 
-#: ../src/html/helpwnd.cpp:663
+#: ../src/html/helpwnd.cpp:661
 msgid "Go one level up in document hierarchy"
 msgstr "Subir um nível na hierarquia do documento"
 
-#: ../src/generic/filedlgg.cpp:208 ../src/generic/dirdlgg.cpp:116
+#: ../src/generic/filedlgg.cpp:205 ../src/generic/dirdlgg.cpp:113
 msgid "Go to home directory"
 msgstr "ir para o directório inicial"
 
-#: ../src/generic/filedlgg.cpp:205
+#: ../src/generic/filedlgg.cpp:202
 msgid "Go to parent directory"
 msgstr "Ir para o directório superior"
 
-#: ../src/generic/aboutdlgg.cpp:76
+#: ../src/generic/aboutdlgg.cpp:73
 msgid "Graphics art by "
 msgstr "Arte gráfica por "
 
-#: ../src/propgrid/advprops.cpp:1599
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Gray"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:883
+#: ../src/propgrid/advprops.cpp:784
 msgid "GrayText"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:154
+#: ../src/common/fmapbase.cpp:151
 msgid "Greek (ISO-8859-7)"
 msgstr "Grêgo (ISO-8859-7)"
 
-#: ../src/propgrid/advprops.cpp:1600
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Green"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:342
+#: ../src/generic/colrdlgg.cpp:362
 msgid "Green:"
 msgstr ""
 
@@ -3997,109 +4107,109 @@ msgstr ""
 msgid "Groove"
 msgstr ""
 
-#: ../src/common/zstream.cpp:158 ../src/common/zstream.cpp:318
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
 msgid "Gzip not supported by this version of zlib"
 msgstr "Gzip não suportado nesta versão do zlib"
 
-#: ../src/html/helpwnd.cpp:1549
+#: ../src/html/helpwnd.cpp:1547
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "HTML projecto de ajuda (*.hhp)|*.hhp|"
 
-#: ../src/html/htmlwin.cpp:681
+#: ../src/html/htmlwin.cpp:691
 #, c-format
 msgid "HTML anchor %s does not exist."
 msgstr "Âncora HTML %s não existe."
 
-#: ../src/html/helpwnd.cpp:1547
+#: ../src/html/helpwnd.cpp:1545
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "Ficheiros HTML (*.html;*.htm)|*.html;*.htm|"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1759
+#: ../src/propgrid/advprops.cpp:1660
 msgid "Hand"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "Harddisk"
 msgstr "Disco Rígido"
 
-#: ../src/common/fmapbase.cpp:155
+#: ../src/common/fmapbase.cpp:152
 msgid "Hebrew (ISO-8859-8)"
 msgstr "Hebreu (ISO-8859-8)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:280 ../src/osx/button_osx.cpp:39
-#: ../src/common/stockitem.cpp:163 ../src/common/accelcmn.cpp:80
-#: ../src/html/helpdlg.cpp:66 ../src/html/helpfrm.cpp:111
+#: ../include/wx/msgdlg.h:282 ../src/osx/button_osx.cpp:39
+#: ../src/common/stockitem.cpp:160 ../src/common/accelcmn.cpp:77
+#: ../src/html/helpfrm.cpp:108 ../src/html/helpdlg.cpp:63
 msgid "Help"
 msgstr "Ajuda"
 
-#: ../src/html/helpwnd.cpp:1200
+#: ../src/html/helpwnd.cpp:1198
 msgid "Help Browser Options"
 msgstr "Opções do Navegador de Ajuda"
 
-#: ../src/generic/helpext.cpp:454 ../src/generic/helpext.cpp:455
+#: ../src/generic/helpext.cpp:452 ../src/generic/helpext.cpp:453
 msgid "Help Index"
 msgstr "Índice de Ajuda"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1529
 msgid "Help Printing"
 msgstr "Ajuda de Impressão"
 
-#: ../src/html/helpwnd.cpp:801
+#: ../src/html/helpwnd.cpp:799
 msgid "Help Topics"
 msgstr "Tópicos de Ajuda"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1546
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Livros de ajuda(*.htb)|*.htb|Livros de ajuda(*.zip)|*.zip|"
 
-#: ../src/generic/helpext.cpp:267
+#: ../src/generic/helpext.cpp:265
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "Directório de ajuda \"%s\" não encontrado."
 
-#: ../src/generic/helpext.cpp:275
+#: ../src/generic/helpext.cpp:273
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "Ficheiro de ajuda \"%s\" não encontrado."
 
-#: ../src/html/helpctrl.cpp:63
+#: ../src/html/helpctrl.cpp:59
 #, c-format
 msgid "Help: %s"
 msgstr "Ajuda: %s"
 
-#: ../src/osx/menu_osx.cpp:577
+#: ../src/osx/menu_osx.cpp:469
 #, c-format
 msgid "Hide %s"
 msgstr "Ocultar %s"
 
-#: ../src/osx/menu_osx.cpp:579
+#: ../src/osx/menu_osx.cpp:471
 msgid "Hide Others"
 msgstr "Ocultar Outros"
 
-#: ../src/generic/infobar.cpp:84
+#: ../src/generic/infobar.cpp:81
 msgid "Hide this notification message."
 msgstr "Ocultar esta mensagem de notificação."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:884
+#: ../src/propgrid/advprops.cpp:785
 #, fuzzy
 msgid "Highlight"
 msgstr "leve"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:885
+#: ../src/propgrid/advprops.cpp:786
 #, fuzzy
 msgid "HighlightText"
 msgstr "Alinhar texto à direita."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:164 ../src/common/accelcmn.cpp:65
+#: ../src/common/stockitem.cpp:161 ../src/common/accelcmn.cpp:62
 msgid "Home"
 msgstr "Pasta Pessoal"
 
-#: ../src/generic/dirctrlg.cpp:524
+#: ../src/generic/dirctrlg.cpp:490
 msgid "Home directory"
 msgstr "Directório pessoal"
 
@@ -4109,61 +4219,61 @@ msgid "How the object will float relative to the text."
 msgstr "Como é que o objeto irá flutuar em relação ao texto."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1760
+#: ../src/propgrid/advprops.cpp:1661
 msgid "I-Beam"
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1196
+#: ../src/common/imagbmp.cpp:1208
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: Erro a ler máscara DIB."
 
-#: ../src/common/imagbmp.cpp:1290 ../src/common/imagbmp.cpp:1390
-#: ../src/common/imagbmp.cpp:1405 ../src/common/imagbmp.cpp:1416
-#: ../src/common/imagbmp.cpp:1430 ../src/common/imagbmp.cpp:1478
-#: ../src/common/imagbmp.cpp:1493 ../src/common/imagbmp.cpp:1507
-#: ../src/common/imagbmp.cpp:1518
+#: ../src/common/imagbmp.cpp:1302 ../src/common/imagbmp.cpp:1402
+#: ../src/common/imagbmp.cpp:1417 ../src/common/imagbmp.cpp:1428
+#: ../src/common/imagbmp.cpp:1442 ../src/common/imagbmp.cpp:1490
+#: ../src/common/imagbmp.cpp:1505 ../src/common/imagbmp.cpp:1519
+#: ../src/common/imagbmp.cpp:1530
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: Erro a escrever ficheiro de imagem!"
 
-#: ../src/common/imagbmp.cpp:1255
+#: ../src/common/imagbmp.cpp:1267
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: Imagem alta demais para um ícone."
 
-#: ../src/common/imagbmp.cpp:1263
+#: ../src/common/imagbmp.cpp:1275
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: Imagem larga demais para um ícone."
 
-#: ../src/common/imagbmp.cpp:1603
+#: ../src/common/imagbmp.cpp:1615
 msgid "ICO: Invalid icon index."
 msgstr "ICO: Índice inválido de ícone."
 
-#: ../src/common/imagiff.cpp:758
+#: ../src/common/imagiff.cpp:755
 msgid "IFF: data stream seems to be truncated."
 msgstr "IFF: Corrente de dados parece estar truncada."
 
-#: ../src/common/imagiff.cpp:742
+#: ../src/common/imagiff.cpp:739
 msgid "IFF: error in IFF image format."
 msgstr "IFF: erro no formato de imagem IFF."
 
-#: ../src/common/imagiff.cpp:745
+#: ../src/common/imagiff.cpp:742
 msgid "IFF: not enough memory."
 msgstr "IFF: sem memória suficiente."
 
-#: ../src/common/imagiff.cpp:748
+#: ../src/common/imagiff.cpp:745
 msgid "IFF: unknown error!!!"
 msgstr "IFF: erro desconhecido!!!"
 
-#: ../src/common/fmapbase.cpp:197
+#: ../src/common/fmapbase.cpp:194
 msgid "ISO-2022-JP"
 msgstr "ISO-2022-JP"
 
-#: ../src/html/htmprint.cpp:282
+#: ../src/html/htmprint.cpp:294
 msgid ""
 "If possible, try changing the layout parameters to make the printout more "
 "narrow."
 msgstr ""
 
-#: ../src/generic/dbgrptg.cpp:358
+#: ../src/generic/dbgrptg.cpp:362
 msgid ""
 "If you have any additional information pertaining to this bug\n"
 "report, please enter it here and it will be joined to it:"
@@ -4184,46 +4294,50 @@ msgstr ""
 "possível\n"
 "por favor, continue com a geração do relatório .\n"
 
-#: ../src/msw/registry.cpp:1405
+#: ../src/common/zipstrm.cpp:1043
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1393
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "A ignorar valor \"%s\" da chave \"%s\"."
 
-#: ../src/common/xtistrm.cpp:295
+#: ../src/common/xtistrm.cpp:292
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Classe de objecto ilegal (Não-wxEvtHandler) como EventSource"
 
-#: ../src/common/xti.cpp:513
+#: ../src/common/xti.cpp:510
 msgid "Illegal Parameter Count for ConstructObject Method"
 msgstr "Parâmetro de Contador Ilegal para o Método ConstructObject"
 
-#: ../src/common/xti.cpp:501
+#: ../src/common/xti.cpp:498
 msgid "Illegal Parameter Count for Create Method"
 msgstr "Parâmetro de Contador Ilegal para o Método Create"
 
-#: ../src/generic/dirctrlg.cpp:570 ../src/generic/filectrlg.cpp:756
+#: ../src/generic/dirctrlg.cpp:536 ../src/generic/filectrlg.cpp:752
 msgid "Illegal directory name."
 msgstr "Nome do directório ilegal."
 
-#: ../src/generic/filectrlg.cpp:1367
+#: ../src/generic/filectrlg.cpp:1356
 msgid "Illegal file specification."
 msgstr "Especificação de ficheiro ilegal."
 
-#: ../src/common/image.cpp:2269
+#: ../src/common/image.cpp:2363
 msgid "Image and mask have different sizes."
 msgstr "A imagem e a máscara têm tamanhos diferentes."
 
-#: ../src/common/image.cpp:2746
+#: ../src/common/image.cpp:2841
 #, fuzzy, c-format
 msgid "Image file is not of type %d."
 msgstr "O ficheiro de imagem não é do tipo %ld."
 
-#: ../src/common/image.cpp:2877
+#: ../src/common/image.cpp:2995
 #, fuzzy, c-format
 msgid "Image is not of type %s."
 msgstr "O ficheiro de imagem não é do tipo %s."
 
-#: ../src/msw/textctrl.cpp:488
+#: ../src/msw/textctrl.cpp:534
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -4231,104 +4345,104 @@ msgstr ""
 "Impossível criar um controlo de edição rico, alternativamente usar-se-á um "
 "controlo de texto simples. Por favor reinstale o riched32.dll"
 
-#: ../src/unix/utilsunx.cpp:301
+#: ../src/unix/utilsunx.cpp:303
 msgid "Impossible to get child process input"
 msgstr "Não foi possível obter a entrada do processo filho"
 
-#: ../src/common/filefn.cpp:1028
+#: ../src/common/filefn.cpp:917
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Não foi possível obter permissões do ficheiro '%s'"
 
-#: ../src/common/filefn.cpp:1042
+#: ../src/common/filefn.cpp:931
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Não foi possível sobrepor o ficheiro '%s'"
 
-#: ../src/common/filefn.cpp:1097
+#: ../src/common/filefn.cpp:986
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Não foi possível definir as permissões do ficheiro '%s'"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:886
+#: ../src/propgrid/advprops.cpp:787
 #, fuzzy
 msgid "InactiveBorder"
 msgstr "Margem"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:887
+#: ../src/propgrid/advprops.cpp:788
 msgid "InactiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:888
+#: ../src/propgrid/advprops.cpp:789
 msgid "InactiveCaptionText"
 msgstr ""
 
-#: ../src/common/gifdecod.cpp:792
+#: ../src/common/gifdecod.cpp:826
 #, c-format
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:635
+#: ../src/msw/ole/automtn.cpp:626
 msgid "Incorrect number of arguments."
 msgstr "Número de argumentos incorretos."
 
-#: ../src/common/stockitem.cpp:165
+#: ../src/common/stockitem.cpp:162
 msgid "Indent"
 msgstr "Indentar"
 
-#: ../src/richtext/richtextformatdlg.cpp:349
+#: ../src/richtext/richtextformatdlg.cpp:342
 msgid "Indents && Spacing"
 msgstr "Indentações e Espaçamentos"
 
-#: ../src/common/stockitem.cpp:166 ../src/html/helpwnd.cpp:515
+#: ../src/common/stockitem.cpp:163 ../src/html/helpwnd.cpp:513
 msgid "Index"
 msgstr "Índice"
 
-#: ../src/common/fmapbase.cpp:159
+#: ../src/common/fmapbase.cpp:156
 msgid "Indian (ISO-8859-12)"
 msgstr "Indiano (ISO-8859-12)"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "Info"
 msgstr "Informação"
 
-#: ../src/common/init.cpp:287
+#: ../src/common/init.cpp:284
 msgid "Initialization failed in post init, aborting."
 msgstr "Falha de inicialização no post init, a interromper."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:54
+#: ../src/common/accelcmn.cpp:51
 #, fuzzy
 msgid "Ins"
 msgstr "Inserir"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextsymboldlg.cpp:472 ../src/common/accelcmn.cpp:53
+#: ../src/common/accelcmn.cpp:50 ../src/richtext/richtextsymboldlg.cpp:469
 msgid "Insert"
 msgstr "Inserir"
 
-#: ../src/richtext/richtextbuffer.cpp:8067
+#: ../src/richtext/richtextbuffer.cpp:8063
 #, fuzzy
 msgid "Insert Field"
 msgstr "Inserir Texto"
 
-#: ../src/richtext/richtextbuffer.cpp:7978
-#: ../src/richtext/richtextbuffer.cpp:8936
+#: ../src/richtext/richtextbuffer.cpp:7974
+#: ../src/richtext/richtextbuffer.cpp:8934
 msgid "Insert Image"
 msgstr "Inserir Imagem"
 
-#: ../src/richtext/richtextbuffer.cpp:8025
+#: ../src/richtext/richtextbuffer.cpp:8021
 #, fuzzy
 msgid "Insert Object"
 msgstr "Inserir Texto"
 
-#: ../src/richtext/richtextctrl.cpp:1286 ../src/richtext/richtextctrl.cpp:1494
-#: ../src/richtext/richtextbuffer.cpp:7822
-#: ../src/richtext/richtextbuffer.cpp:7852
-#: ../src/richtext/richtextbuffer.cpp:7894
+#: ../src/richtext/richtextbuffer.cpp:7818
+#: ../src/richtext/richtextbuffer.cpp:7848
+#: ../src/richtext/richtextbuffer.cpp:7890
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
 msgid "Insert Text"
 msgstr "Inserir Texto"
 
@@ -4343,16 +4457,11 @@ msgstr "O espaçamento antes do parágrafo."
 msgid "Inset"
 msgstr "Inserir"
 
-#: ../src/gtk/app.cpp:425
-#, c-format
-msgid "Invalid GTK+ command line option, use \"%s --help\""
-msgstr ""
-
-#: ../src/common/imagtiff.cpp:311
+#: ../src/common/imagtiff.cpp:308
 msgid "Invalid TIFF image index."
 msgstr "Índice inválido para imagem TIFF."
 
-#: ../src/common/appcmn.cpp:273
+#: ../src/common/appcmn.cpp:294
 #, c-format
 msgid "Invalid display mode specification '%s'."
 msgstr "Especificação de modo de ecrã inválida '%s'."
@@ -4362,258 +4471,262 @@ msgstr "Especificação de modo de ecrã inválida '%s'."
 msgid "Invalid geometry specification '%s'"
 msgstr "Especificação de geometria inválida '%s'"
 
-#: ../src/unix/fswatcher_inotify.cpp:323
+#: ../src/unix/fswatcher_inotify.cpp:320
 #, c-format
 msgid "Invalid inotify event for \"%s\""
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:312
+#: ../src/unix/snglinst.cpp:309
 #, c-format
 msgid "Invalid lock file '%s'."
 msgstr "Ficheiro de bloqueio inválido '%s'."
 
-#: ../src/common/translation.cpp:1125
+#: ../src/common/translation.cpp:1167
 #, fuzzy
 msgid "Invalid message catalog."
 msgstr "'%s' não é uma mensagem válida do catálogo."
 
-#: ../src/common/xtistrm.cpp:405 ../src/common/xtistrm.cpp:420
+#: ../src/common/xtistrm.cpp:402 ../src/common/xtistrm.cpp:417
 msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
 msgstr "ID Nulo de Objecto ou inválido passado para GetObjectClassInfo"
 
-#: ../src/common/xtistrm.cpp:435
+#: ../src/common/xtistrm.cpp:432
 msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
 msgstr "ID Nulo de Objecto ou inválido passado para HasObjectClassInfo"
 
-#: ../src/common/regex.cpp:310
+#: ../src/common/regex.cpp:307
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Expressão regular inválida '%s': %s"
 
-#: ../src/common/config.cpp:226
+#: ../src/common/config.cpp:222
 #, c-format
 msgid "Invalid value %ld for a boolean key \"%s\" in config file."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:351
-#: ../src/osx/carbon/fontdlg.cpp:361 ../src/common/stockitem.cpp:168
+#: ../src/osx/carbon/fontdlg.cpp:358 ../src/common/stockitem.cpp:165
+#: ../src/generic/fontdlgg.cpp:325 ../src/richtext/richtextfontpage.cpp:351
 msgid "Italic"
 msgstr "Itálico"
 
-#: ../src/common/paper.cpp:130
+#: ../src/common/paper.cpp:127
 msgid "Italy Envelope, 110 x 230 mm"
 msgstr "Envelope Italiano, 110 x 230 mm"
 
-#: ../src/common/imagjpeg.cpp:270
+#: ../src/common/imagjpeg.cpp:257
 msgid "JPEG: Couldn't load - file is probably corrupted."
 msgstr "JPEG: Impossível ler - o ficheiro provavelmente está corrupto."
 
-#: ../src/common/imagjpeg.cpp:449
+#: ../src/common/imagjpeg.cpp:436
 msgid "JPEG: Couldn't save image."
 msgstr "JPEG: Impossível gravar imagem."
 
-#: ../src/common/paper.cpp:163
+#: ../src/common/paper.cpp:160
 msgid "Japanese Double Postcard 200 x 148 mm"
 msgstr "Postal Duplo Japonês 200 x 148 mm"
 
-#: ../src/common/paper.cpp:167
+#: ../src/common/paper.cpp:164
 msgid "Japanese Envelope Chou #3"
 msgstr "Envelope Japonês Chou #3"
 
-#: ../src/common/paper.cpp:180
+#: ../src/common/paper.cpp:177
 msgid "Japanese Envelope Chou #3 Rotated"
 msgstr "Envelope Japonês Chou #3 Rodado"
 
-#: ../src/common/paper.cpp:168
+#: ../src/common/paper.cpp:165
 msgid "Japanese Envelope Chou #4"
 msgstr "Envelope Japonês Chou #4"
 
-#: ../src/common/paper.cpp:181
+#: ../src/common/paper.cpp:178
 msgid "Japanese Envelope Chou #4 Rotated"
 msgstr "Envelope Japonês Chou #4 Rodado"
 
-#: ../src/common/paper.cpp:165
+#: ../src/common/paper.cpp:162
 msgid "Japanese Envelope Kaku #2"
 msgstr "Envelope Japonês Kaku #2"
 
-#: ../src/common/paper.cpp:178
+#: ../src/common/paper.cpp:175
 msgid "Japanese Envelope Kaku #2 Rotated"
 msgstr "Envelope Japonês Kaku #2 Rodado"
 
-#: ../src/common/paper.cpp:166
+#: ../src/common/paper.cpp:163
 msgid "Japanese Envelope Kaku #3"
 msgstr "Envelope Japonês Kaku #3"
 
-#: ../src/common/paper.cpp:179
+#: ../src/common/paper.cpp:176
 msgid "Japanese Envelope Kaku #3 Rotated"
 msgstr "Envelope Japonês Kaku #3 Rodado"
 
-#: ../src/common/paper.cpp:185
+#: ../src/common/paper.cpp:182
 msgid "Japanese Envelope You #4"
 msgstr "Envelope Japonês You #4"
 
-#: ../src/common/paper.cpp:186
+#: ../src/common/paper.cpp:183
 msgid "Japanese Envelope You #4 Rotated"
 msgstr "Envelope Japonês You #4 Rodado"
 
-#: ../src/common/paper.cpp:138
+#: ../src/common/paper.cpp:135
 msgid "Japanese Postcard 100 x 148 mm"
 msgstr "Postal Japonês 100 x 148 mm"
 
-#: ../src/common/paper.cpp:175
+#: ../src/common/paper.cpp:172
 msgid "Japanese Postcard Rotated 148 x 100 mm"
 msgstr "Postal Japonês Rodado 148 x 100 mm"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "Jump to"
 msgstr "Ir para"
 
-#: ../src/common/stockitem.cpp:171
+#: ../src/common/stockitem.cpp:168
 msgid "Justified"
 msgstr "Justificado"
 
-#: ../src/richtext/richtextindentspage.cpp:155
-#: ../src/richtext/richtextindentspage.cpp:157
 #: ../src/richtext/richtextliststylepage.cpp:344
 #: ../src/richtext/richtextliststylepage.cpp:346
+#: ../src/richtext/richtextindentspage.cpp:155
+#: ../src/richtext/richtextindentspage.cpp:157
 msgid "Justify text left and right."
 msgstr "Justificar texto à esquerda e à direita."
 
-#: ../src/common/fmapbase.cpp:163
+#: ../src/common/fmapbase.cpp:160
 msgid "KOI8-R"
 msgstr "KOI8-R"
 
-#: ../src/common/fmapbase.cpp:164
+#: ../src/common/fmapbase.cpp:161
 msgid "KOI8-U"
 msgstr "KOI8-U"
 
-#: ../src/common/accelcmn.cpp:265 ../src/common/accelcmn.cpp:347
+#: ../src/common/accelcmn.cpp:279 ../src/common/accelcmn.cpp:364
 msgid "KP_"
 msgstr "KP_"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 #, fuzzy
 msgid "KP_Add"
 msgstr "KP_ADD"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "KP_Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "KP_Decimal"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 #, fuzzy
 msgid "KP_Delete"
 msgstr "Apagar"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "KP_Divide"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 #, fuzzy
 msgid "KP_Down"
 msgstr "Baixo"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 #, fuzzy
 msgid "KP_End"
 msgstr "KP_END"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 #, fuzzy
 msgid "KP_Enter"
 msgstr "Impressora"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "KP_Equal"
 msgstr ""
 
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
-#, fuzzy
-msgid "KP_Home"
-msgstr "Pasta Pessoal"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
-#, fuzzy
-msgid "KP_Insert"
-msgstr "Inserir"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
-#, fuzzy
-msgid "KP_Left"
-msgstr "Esquerda"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
-msgid "KP_Multiply"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:99
-#, fuzzy
-msgid "KP_Next"
-msgstr "Seguinte"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
-msgid "KP_PageDown"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
-msgid "KP_PageUp"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:98
-msgid "KP_Prior"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
-#, fuzzy
-msgid "KP_Right"
-msgstr "Direita"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
-msgid "KP_Separator"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
-msgid "KP_Space"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
-msgid "KP_Subtract"
+#: ../src/common/accelcmn.cpp:276 ../src/common/accelcmn.cpp:361
+msgid "KP_F"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
 #: ../src/common/accelcmn.cpp:89
 #, fuzzy
+msgid "KP_Home"
+msgstr "Pasta Pessoal"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:100
+#, fuzzy
+msgid "KP_Insert"
+msgstr "Inserir"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:90
+#, fuzzy
+msgid "KP_Left"
+msgstr "Esquerda"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:103
+msgid "KP_Multiply"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:97
+#, fuzzy
+msgid "KP_Next"
+msgstr "Seguinte"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:95
+msgid "KP_PageDown"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:94
+msgid "KP_PageUp"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:96
+msgid "KP_Prior"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:92
+#, fuzzy
+msgid "KP_Right"
+msgstr "Direita"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:105
+msgid "KP_Separator"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:86
+msgid "KP_Space"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:106
+msgid "KP_Subtract"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:87
+#, fuzzy
 msgid "KP_Tab"
 msgstr "KP_TAB"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 #, fuzzy
 msgid "KP_Up"
 msgstr "KP_UP"
@@ -4623,114 +4736,129 @@ msgstr "KP_UP"
 msgid "L&ine spacing:"
 msgstr "Espaçamento de linhas:"
 
-#: ../src/generic/prntdlgg.cpp:613 ../src/generic/prntdlgg.cpp:868
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "erro de compressão"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "erro de descompressão"
+
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:861
 msgid "Landscape"
 msgstr "Paisagem"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 #, fuzzy
 msgid "Last"
 msgstr "Colar"
 
-#: ../src/common/prntbase.cpp:1572
+#: ../src/common/prntbase.cpp:1597
 #, fuzzy
 msgid "Last page"
 msgstr "Página seguinte"
 
-#: ../src/common/log.cpp:305
+#: ../src/common/log.cpp:324
 #, c-format
 msgid "Last repeated message (\"%s\", %u time) wasn't output"
 msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/common/paper.cpp:103
+#: ../src/common/paper.cpp:100
 msgid "Ledger, 17 x 11 in"
 msgstr "Agenda, 17 x 11 pol."
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6146
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:58 ../src/generic/datavgen.cpp:6951
+#: ../src/richtext/richtextsizepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:252
 #: ../src/richtext/richtextliststylepage.cpp:253
 #: ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
-#: ../src/richtext/richtextsizepage.cpp:249 ../src/common/accelcmn.cpp:61
 msgid "Left"
 msgstr "Esquerda"
 
-#: ../src/richtext/richtextindentspage.cpp:204
 #: ../src/richtext/richtextliststylepage.cpp:390
+#: ../src/richtext/richtextindentspage.cpp:204
 msgid "Left (&first line):"
 msgstr "Esquerda (&primeira linha):"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1761
+#: ../src/propgrid/advprops.cpp:1662
 msgid "Left Button"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:880
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Left margin (mm):"
 msgstr "Margem esquerda (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:141
-#: ../src/richtext/richtextindentspage.cpp:143
 #: ../src/richtext/richtextliststylepage.cpp:330
 #: ../src/richtext/richtextliststylepage.cpp:332
+#: ../src/richtext/richtextindentspage.cpp:141
+#: ../src/richtext/richtextindentspage.cpp:143
 msgid "Left-align text."
 msgstr "Alinhar texto à esquerda."
 
-#: ../src/common/paper.cpp:144
+#: ../src/common/paper.cpp:141
 msgid "Legal Extra 9 1/2 x 15 in"
 msgstr "Legal Extra 9 1/2 x 15 pol."
 
-#: ../src/common/paper.cpp:96
+#: ../src/common/paper.cpp:93
 msgid "Legal, 8 1/2 x 14 in"
 msgstr "Legal, 8 1/2 x 14 pol."
 
-#: ../src/common/paper.cpp:143
+#: ../src/common/paper.cpp:140
 msgid "Letter Extra 9 1/2 x 12 in"
 msgstr "Letter Extra 9 1/2 x 12 pol."
 
-#: ../src/common/paper.cpp:149
+#: ../src/common/paper.cpp:146
 msgid "Letter Extra Transverse 9.275 x 12 in"
 msgstr "Letter Extra Transversal 9.275 x 12 pol."
 
-#: ../src/common/paper.cpp:152
+#: ../src/common/paper.cpp:149
 msgid "Letter Plus 8 1/2 x 12.69 in"
 msgstr "Letter Plus 8 1/2 x 12.69 pol."
 
-#: ../src/common/paper.cpp:169
+#: ../src/common/paper.cpp:166
 msgid "Letter Rotated 11 x 8 1/2 in"
 msgstr "Letter Rodada 11 x 8 1/2 pol."
 
-#: ../src/common/paper.cpp:101
+#: ../src/common/paper.cpp:98
 msgid "Letter Small, 8 1/2 x 11 in"
 msgstr "Letter Pequena, 8 1/2 x 11 pol."
 
-#: ../src/common/paper.cpp:147
+#: ../src/common/paper.cpp:144
 msgid "Letter Transverse 8 1/2 x 11 in"
 msgstr "Letter Transversal 8 1/2 x 11 pol."
 
-#: ../src/common/paper.cpp:95
+#: ../src/common/paper.cpp:92
 msgid "Letter, 8 1/2 x 11 in"
 msgstr "Letter, 8 1/2 x 11 pol."
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "License"
 msgstr "Licença"
 
-#: ../src/generic/fontdlgg.cpp:332
+#: ../src/generic/fontdlgg.cpp:328
 msgid "Light"
 msgstr "Leve"
 
-#: ../src/propgrid/advprops.cpp:1608
+#: ../src/propgrid/advprops.cpp:1514
 msgid "Lime"
 msgstr ""
 
-#: ../src/generic/helpext.cpp:294
+#: ../src/generic/helpext.cpp:292
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr ""
@@ -4740,15 +4868,15 @@ msgstr ""
 msgid "Line spacing:"
 msgstr "Espaçamento de linhas:"
 
-#: ../src/html/chm.cpp:838
+#: ../src/html/chm.cpp:829
 msgid "Link contained '//', converted to absolute link."
 msgstr "O link contém '//', foi convertido para um link absoluto."
 
-#: ../src/richtext/richtextformatdlg.cpp:364
+#: ../src/richtext/richtextformatdlg.cpp:357
 msgid "List Style"
 msgstr "Estilo da Lista"
 
-#: ../src/richtext/richtextstyles.cpp:1064
+#: ../src/richtext/richtextstyles.cpp:1061
 msgid "List styles"
 msgstr "Estilos da lista"
 
@@ -4762,26 +4890,26 @@ msgstr "Lista o tamanho das fontes em pontos."
 msgid "Lists the available fonts."
 msgstr "Lista as fontes disponíveis."
 
-#: ../src/common/fldlgcmn.cpp:340
+#: ../src/common/fldlgcmn.cpp:337
 #, c-format
 msgid "Load %s file"
 msgstr "Abrir %s ficheiros"
 
-#: ../src/html/htmlwin.cpp:597
+#: ../src/html/htmlwin.cpp:600
 msgid "Loading : "
 msgstr "A Abrir : "
 
-#: ../src/unix/snglinst.cpp:246
+#: ../src/unix/snglinst.cpp:243
 #, c-format
 msgid "Lock file '%s' has incorrect owner."
 msgstr "Ficheiro de bloqueio '%s' tem proprietário incorrecto."
 
-#: ../src/unix/snglinst.cpp:251
+#: ../src/unix/snglinst.cpp:248
 #, c-format
 msgid "Lock file '%s' has incorrect permissions."
 msgstr "Ficheiro de bloqueio '%s' tem permissões incorrectas."
 
-#: ../src/generic/logg.cpp:576
+#: ../src/generic/logg.cpp:573
 #, c-format
 msgid "Log saved to the file '%s'."
 msgstr "Registo gravado no ficheiro '%s'."
@@ -4796,11 +4924,11 @@ msgstr "Letras minúsculas"
 msgid "Lower case roman numerals"
 msgstr "Números romanos em minúsculas"
 
-#: ../src/gtk/mdi.cpp:422 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk1/mdi.cpp:431 ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "Fillho MDI"
 
-#: ../src/msw/helpchm.cpp:56
+#: ../src/msw/helpchm.cpp:53
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -4808,196 +4936,196 @@ msgstr ""
 "Funções de ajuda MS HTML não estão disponíveis devido à livraria de ajuda MS "
 "HTML não estar instalada neste computador. por favor instale-a."
 
-#: ../src/univ/themes/win32.cpp:3754
+#: ../src/univ/themes/win32.cpp:3751
 msgid "Ma&ximize"
 msgstr "Ma&ximizar"
 
-#: ../src/common/fmapbase.cpp:203
+#: ../src/common/fmapbase.cpp:200
 #, fuzzy
 msgid "MacArabic"
 msgstr "Árabe"
 
-#: ../src/common/fmapbase.cpp:222
+#: ../src/common/fmapbase.cpp:219
 msgid "MacArmenian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:211
+#: ../src/common/fmapbase.cpp:208
 msgid "MacBengali"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:217
+#: ../src/common/fmapbase.cpp:214
 msgid "MacBurmese"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:236
+#: ../src/common/fmapbase.cpp:233
 msgid "MacCeltic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:227
+#: ../src/common/fmapbase.cpp:224
 msgid "MacCentralEurRoman"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:223
+#: ../src/common/fmapbase.cpp:220
 msgid "MacChineseSimp"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:201
+#: ../src/common/fmapbase.cpp:198
 msgid "MacChineseTrad"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:233
+#: ../src/common/fmapbase.cpp:230
 msgid "MacCroatian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:206
+#: ../src/common/fmapbase.cpp:203
 msgid "MacCyrillic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:207
+#: ../src/common/fmapbase.cpp:204
 msgid "MacDevanagari"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:231
+#: ../src/common/fmapbase.cpp:228
 msgid "MacDingbats"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:226
+#: ../src/common/fmapbase.cpp:223
 msgid "MacEthiopic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:229
+#: ../src/common/fmapbase.cpp:226
 #, fuzzy
 msgid "MacExtArabic"
 msgstr "Árabe"
 
-#: ../src/common/fmapbase.cpp:237
+#: ../src/common/fmapbase.cpp:234
 msgid "MacGaelic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:221
+#: ../src/common/fmapbase.cpp:218
 msgid "MacGeorgian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:205
+#: ../src/common/fmapbase.cpp:202
 msgid "MacGreek"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:209
+#: ../src/common/fmapbase.cpp:206
 msgid "MacGujarati"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:208
+#: ../src/common/fmapbase.cpp:205
 msgid "MacGurmukhi"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:204
+#: ../src/common/fmapbase.cpp:201
 msgid "MacHebrew"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:234
+#: ../src/common/fmapbase.cpp:231
 msgid "MacIcelandic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:200
+#: ../src/common/fmapbase.cpp:197
 msgid "MacJapanese"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:214
+#: ../src/common/fmapbase.cpp:211
 msgid "MacKannada"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:238
+#: ../src/common/fmapbase.cpp:235
 msgid "MacKeyboardGlyphs"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:218
+#: ../src/common/fmapbase.cpp:215
 msgid "MacKhmer"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:202
+#: ../src/common/fmapbase.cpp:199
 msgid "MacKorean"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:220
+#: ../src/common/fmapbase.cpp:217
 msgid "MacLaotian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:215
+#: ../src/common/fmapbase.cpp:212
 msgid "MacMalayalam"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:225
+#: ../src/common/fmapbase.cpp:222
 msgid "MacMongolian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:210
+#: ../src/common/fmapbase.cpp:207
 msgid "MacOriya"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:199
+#: ../src/common/fmapbase.cpp:196
 #, fuzzy
 msgid "MacRoman"
 msgstr "Roman"
 
-#: ../src/common/fmapbase.cpp:235
+#: ../src/common/fmapbase.cpp:232
 #, fuzzy
 msgid "MacRomanian"
 msgstr "Roman"
 
-#: ../src/common/fmapbase.cpp:216
+#: ../src/common/fmapbase.cpp:213
 #, fuzzy
 msgid "MacSinhalese"
 msgstr "Coincidir capitulação"
 
-#: ../src/common/fmapbase.cpp:230
+#: ../src/common/fmapbase.cpp:227
 #, fuzzy
 msgid "MacSymbol"
 msgstr "Symbol"
 
-#: ../src/common/fmapbase.cpp:212
+#: ../src/common/fmapbase.cpp:209
 msgid "MacTamil"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:213
+#: ../src/common/fmapbase.cpp:210
 msgid "MacTelugu"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:219
+#: ../src/common/fmapbase.cpp:216
 msgid "MacThai"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:224
+#: ../src/common/fmapbase.cpp:221
 msgid "MacTibetan"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:232
+#: ../src/common/fmapbase.cpp:229
 msgid "MacTurkish"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:228
+#: ../src/common/fmapbase.cpp:225
 msgid "MacVietnamese"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1762
+#: ../src/propgrid/advprops.cpp:1663
 msgid "Magnifier"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:2143
+#: ../src/propgrid/advprops.cpp:2050
 #, fuzzy
 msgid "Make a selection:"
 msgstr "Colar selecção"
 
-#: ../src/richtext/richtextformatdlg.cpp:374
+#: ../src/richtext/richtextformatdlg.cpp:367
 #: ../src/richtext/richtextmarginspage.cpp:171
 msgid "Margins"
 msgstr "Margens"
 
-#: ../src/propgrid/advprops.cpp:1595
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Maroon"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:147
+#: ../src/generic/fdrepdlg.cpp:144
 msgid "Match case"
 msgstr "Coincidir capitulação"
 
@@ -5011,41 +5139,41 @@ msgstr "&Peso:"
 msgid "Max width:"
 msgstr "Substituir por:"
 
-#: ../src/unix/mediactrl.cpp:947
+#: ../src/unix/mediactrl.cpp:972
 #, c-format
 msgid "Media playback error: %s"
 msgstr "Erro de reprodução de multimédia: %s"
 
-#: ../src/common/fs_mem.cpp:175
+#: ../src/common/fs_mem.cpp:170
 #, c-format
 msgid "Memory VFS already contains file '%s'!"
 msgstr "A memória VFS já contém o ficheiro '%s'!"
 
 #. TRANSLATORS: Name of keyboard key
 #. TRANSLATORS: Keyword of system colour
-#: ../src/common/accelcmn.cpp:73 ../src/propgrid/advprops.cpp:889
+#: ../src/common/accelcmn.cpp:70 ../src/propgrid/advprops.cpp:790
 msgid "Menu"
 msgstr "Menu"
 
-#: ../src/common/msgout.cpp:124
+#: ../src/common/msgout.cpp:121
 #, fuzzy
 msgid "Message"
 msgstr "%s mensagem"
 
-#: ../src/univ/themes/metal.cpp:168
+#: ../src/univ/themes/metal.cpp:165
 msgid "Metal theme"
 msgstr "Tema Metal"
 
-#: ../src/msw/ole/automtn.cpp:652
+#: ../src/msw/ole/automtn.cpp:643
 msgid "Method or property not found."
 msgstr "Método ou propriedade não encontrado."
 
-#: ../src/univ/themes/win32.cpp:3752
+#: ../src/univ/themes/win32.cpp:3749
 msgid "Mi&nimize"
 msgstr "Mi&nimizar"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1763
+#: ../src/propgrid/advprops.cpp:1664
 msgid "Middle Button"
 msgstr ""
 
@@ -5058,36 +5186,41 @@ msgstr "&Peso da fonte:"
 msgid "Min width:"
 msgstr "Largura min.:"
 
-#: ../src/msw/ole/automtn.cpp:668
+#: ../src/osx/cocoa/menu.mm:281
+#, fuzzy
+msgid "Minimize"
+msgstr "Mi&nimizar"
+
+#: ../src/msw/ole/automtn.cpp:659
 msgid "Missing a required parameter."
 msgstr "Está em falta um parâmetro necessário."
 
-#: ../src/generic/fontdlgg.cpp:324
+#: ../src/generic/fontdlgg.cpp:320
 msgid "Modern"
 msgstr "Moderno"
 
-#: ../src/generic/filectrlg.cpp:427
+#: ../src/generic/filectrlg.cpp:423
 msgid "Modified"
 msgstr "Modificado"
 
-#: ../src/common/module.cpp:133
+#: ../src/common/module.cpp:130
 #, c-format
 msgid "Module \"%s\" initialization failed"
 msgstr "Falha de inicialização do Módulo \"%s\""
 
-#: ../src/common/paper.cpp:131
+#: ../src/common/paper.cpp:128
 msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
 msgstr "Envelope Monarch, 3 7/8 x 7 1/2 pol."
 
-#: ../src/msw/fswatcher.cpp:143
+#: ../src/msw/fswatcher.cpp:140
 msgid "Monitoring individual files for changes is not supported currently."
 msgstr ""
 
-#: ../src/generic/editlbox.cpp:172
+#: ../src/generic/editlbox.cpp:160
 msgid "Move down"
 msgstr "Mover para baixo"
 
-#: ../src/generic/editlbox.cpp:171
+#: ../src/generic/editlbox.cpp:155
 msgid "Move up"
 msgstr "Mover para cima"
 
@@ -5103,98 +5236,103 @@ msgstr "O estilo pré-definido para o próximo parágrafo."
 msgid "Moves the object to the previous paragraph."
 msgstr "Voltar para página HTML anterior"
 
-#: ../src/richtext/richtextbuffer.cpp:9966
+#: ../src/richtext/richtextbuffer.cpp:9963
 msgid "Multiple Cell Properties"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:424
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:82
+msgid "Multiply"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:420
 msgid "Name"
 msgstr "Nome"
 
-#: ../src/propgrid/advprops.cpp:1596
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Navy"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "Network"
 msgstr "Rede"
 
-#: ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173
 msgid "New"
 msgstr "Novo"
 
-#: ../src/richtext/richtextstyledlg.cpp:243
+#: ../src/richtext/richtextstyledlg.cpp:239
 #, fuzzy
 msgid "New &Box Style..."
 msgstr "Novo &Estilo de Lista..."
 
-#: ../src/richtext/richtextstyledlg.cpp:225
+#: ../src/richtext/richtextstyledlg.cpp:221
 msgid "New &Character Style..."
 msgstr "Novo Estilo de &Caracter..."
 
-#: ../src/richtext/richtextstyledlg.cpp:237
+#: ../src/richtext/richtextstyledlg.cpp:233
 msgid "New &List Style..."
 msgstr "Novo &Estilo de Lista..."
 
-#: ../src/richtext/richtextstyledlg.cpp:231
+#: ../src/richtext/richtextstyledlg.cpp:227
 msgid "New &Paragraph Style..."
 msgstr "Novo Estilo de &Parágrafo..."
 
-#: ../src/richtext/richtextstyledlg.cpp:606
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:654
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:820
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:893
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:934
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:602
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:650
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:816
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:889
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:930
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "New Style"
 msgstr "Novo Estilo"
 
-#: ../src/generic/editlbox.cpp:169
+#: ../src/generic/editlbox.cpp:139
 msgid "New item"
 msgstr "Novo item"
 
-#: ../src/generic/dirdlgg.cpp:297 ../src/generic/dirdlgg.cpp:307
-#: ../src/generic/filectrlg.cpp:618 ../src/generic/filectrlg.cpp:627
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+#: ../src/generic/dirdlgg.cpp:294 ../src/generic/dirdlgg.cpp:304
 msgid "NewName"
 msgstr "NovoNome"
 
-#: ../src/common/prntbase.cpp:1567 ../src/html/helpwnd.cpp:665
+#: ../src/common/prntbase.cpp:1592 ../src/html/helpwnd.cpp:663
 msgid "Next page"
 msgstr "Página seguinte"
 
-#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:177
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:174
 #: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Não"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1764
+#: ../src/propgrid/advprops.cpp:1665
 msgid "No Entry"
 msgstr ""
 
-#: ../src/generic/animateg.cpp:150
+#: ../src/generic/animateg.cpp:133
 #, c-format
 msgid "No animation handler for type %ld defined."
 msgstr "Não existe um manuseador de animação definida para o tipo %ld."
 
-#: ../src/dfb/bitmap.cpp:642 ../src/dfb/bitmap.cpp:676
+#: ../src/dfb/bitmap.cpp:639 ../src/dfb/bitmap.cpp:673
 #, fuzzy, c-format
 msgid "No bitmap handler for type %d defined."
 msgstr "Não existe um manuseador para o tipo %d definido."
 
-#: ../src/common/utilscmn.cpp:1077
+#: ../src/common/utilscmn.cpp:1095
 msgid "No default application configured for HTML files."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:445
+#: ../src/generic/helpext.cpp:443
 msgid "No entries found."
 msgstr "Não foram encontradas entradas."
 
-#: ../src/common/fontmap.cpp:421
+#: ../src/common/fontmap.cpp:418
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found,\n"
@@ -5206,7 +5344,7 @@ msgstr ""
 "mas uma codificação alternativa '%s' está disponível.\n"
 "Pretende utilizar esta codificação (caso contrário terá de escolher outra)?"
 
-#: ../src/common/fontmap.cpp:426
+#: ../src/common/fontmap.cpp:423
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found.\n"
@@ -5219,209 +5357,208 @@ msgstr ""
 "(caso contrário o texto nesta codificação não será apresentado "
 "correctamente)?"
 
-#: ../src/generic/animateg.cpp:142
+#: ../src/generic/animateg.cpp:125
 msgid "No handler found for animation type."
 msgstr "Não foi encontrado um manuseador para o tipo de animação."
 
-#: ../src/common/image.cpp:2728
+#: ../src/common/image.cpp:2823
 msgid "No handler found for image type."
 msgstr "Não foi encontrado um manuseador para o tipo de imagem."
 
-#: ../src/common/image.cpp:2736 ../src/common/image.cpp:2848
-#: ../src/common/image.cpp:2901
+#: ../src/common/image.cpp:2831 ../src/common/image.cpp:2954
+#: ../src/common/image.cpp:3020
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "Não existe um manuseador para o tipo %d definido."
 
-#: ../src/common/image.cpp:2871 ../src/common/image.cpp:2915
+#: ../src/common/image.cpp:2986 ../src/common/image.cpp:3034
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "Não existe um manuseador de imagem para o tipo %s definido."
 
-#: ../src/html/helpwnd.cpp:858
+#: ../src/html/helpwnd.cpp:856
 msgid "No matching page found yet"
 msgstr "Ainda não foi encontrada uma página correspondente"
 
-#: ../src/unix/sound.cpp:81
+#: ../src/unix/sound.cpp:78
 msgid "No sound"
 msgstr "Sem som"
 
-#: ../src/common/image.cpp:2277 ../src/common/image.cpp:2318
+#: ../src/common/image.cpp:2371 ../src/common/image.cpp:2412
 msgid "No unused colour in image being masked."
 msgstr "Sem cor usada na imagem a ser mascarada."
 
-#: ../src/common/image.cpp:3374
-msgid "No unused colour in image."
-msgstr "Nenhuma cor na imagem por utilizar."
-
-#: ../src/generic/helpext.cpp:302
+#: ../src/generic/helpext.cpp:300
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "Não foram encontrados mapeamentos válidos no ficheiro \"%s\"."
 
-#: ../src/richtext/richtextborderspage.cpp:610
 #: ../src/richtext/richtextsizepage.cpp:248
 #: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:610
 #, fuzzy
 msgid "None"
 msgstr "Nenhum"
 
-#: ../src/common/fmapbase.cpp:157
+#: ../src/common/fmapbase.cpp:154
 msgid "Nordic (ISO-8859-10)"
 msgstr "Nórdico (ISO-8859-10)"
 
-#: ../src/generic/fontdlgg.cpp:328 ../src/generic/fontdlgg.cpp:331
+#: ../src/generic/fontdlgg.cpp:324 ../src/generic/fontdlgg.cpp:327
 msgid "Normal"
 msgstr "Normal"
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1261
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Face normal <br>e <u>sublinhado</u>. "
 
-#: ../src/html/helpwnd.cpp:1205
+#: ../src/html/helpwnd.cpp:1203
 msgid "Normal font:"
 msgstr "Fonte normal:"
 
-#: ../src/propgrid/props.cpp:1128
+#: ../src/propgrid/props.cpp:1115
 #, fuzzy, c-format
 msgid "Not %s"
 msgstr "Não %s"
 
-#: ../include/wx/filename.h:573 ../include/wx/filename.h:578
-#, fuzzy
-msgid "Not available"
-msgstr "Não disponível!"
+#: ../src/common/secretstore.cpp:168
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/webrequest.cpp:605
+msgid "Not enough free disk space for download."
+msgstr ""
 
 #: ../src/richtext/richtextfontpage.cpp:358
 msgid "Not underlined"
 msgstr "Não sublinhado"
 
-#: ../src/common/paper.cpp:115
+#: ../src/common/paper.cpp:112
 msgid "Note, 8 1/2 x 11 in"
 msgstr "Nota, 8 1/2 x 11 pol."
 
-#: ../src/generic/notifmsgg.cpp:132
+#: ../src/generic/notifmsgg.cpp:129
 #, fuzzy
 msgid "Notice"
 msgstr "&Nota:"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "Num *"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "Num +"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "Num ,"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "Num -"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "Num ."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "Num /"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "Num ="
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "Num Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 #, fuzzy
 msgid "Num Delete"
 msgstr "Apagar"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 #, fuzzy
 msgid "Num Down"
 msgstr "Baixo"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "Num End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "Num Enter"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 #, fuzzy
 msgid "Num Home"
 msgstr "Pasta Pessoal"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 #, fuzzy
 msgid "Num Insert"
 msgstr "Inserir"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num Lock"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "Num Page Down"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "Num Page Up"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 #, fuzzy
 msgid "Num Right"
 msgstr "Direita"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "Num Space"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "Num Tab"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "Num Up"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "Num left"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num_lock"
 msgstr ""
 
@@ -5430,13 +5567,13 @@ msgstr ""
 msgid "Numbered outline"
 msgstr "Contorno numerado"
 
-#: ../include/wx/msgdlg.h:278 ../src/richtext/richtextstyledlg.cpp:297
-#: ../src/common/stockitem.cpp:178 ../src/msw/msgdlg.cpp:454
-#: ../src/msw/msgdlg.cpp:747 ../src/gtk1/fontdlg.cpp:138
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:175
+#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/msgdlg.cpp:741 ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "CONFIRMAR"
 
-#: ../src/msw/ole/automtn.cpp:692
+#: ../src/msw/ole/automtn.cpp:683
 #, c-format
 msgid "OLE Automation error in %s: %s"
 msgstr ""
@@ -5446,15 +5583,15 @@ msgstr ""
 msgid "Object Properties"
 msgstr "&Propriedades do Objeto"
 
-#: ../src/msw/ole/automtn.cpp:660
+#: ../src/msw/ole/automtn.cpp:651
 msgid "Object implementation does not support named arguments."
 msgstr ""
 
-#: ../src/common/xtixml.cpp:264
+#: ../src/common/xtixml.cpp:260
 msgid "Objects must have an id attribute"
 msgstr "Os objetos devem ter um atributo de id."
 
-#: ../src/propgrid/advprops.cpp:1601
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Olive"
 msgstr ""
 
@@ -5462,65 +5599,70 @@ msgstr ""
 msgid "Opaci&ty:"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:354
+#: ../src/generic/colrdlgg.cpp:374
 msgid "Opacity:"
 msgstr ""
 
-#: ../src/common/docview.cpp:1773 ../src/common/docview.cpp:1815
+#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
 msgid "Open File"
 msgstr "Abrir Ficheiro"
 
-#: ../src/html/helpwnd.cpp:671 ../src/html/helpwnd.cpp:1554
+#: ../src/html/helpwnd.cpp:669 ../src/html/helpwnd.cpp:1552
 msgid "Open HTML document"
 msgstr "Abrir documento HTML"
 
-#: ../src/generic/dbgrptg.cpp:163
+#: ../src/common/stockitem.cpp:265
+#, fuzzy
+msgid "Open an existing document"
+msgstr "Abrir documento HTML"
+
+#: ../src/generic/dbgrptg.cpp:160
 #, c-format
 msgid "Open file \"%s\""
 msgstr "Abrir ficheiro \"%s\""
 
-#: ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176
 #, fuzzy
 msgid "Open..."
 msgstr "&Abrir ..."
 
-#: ../src/unix/glx11.cpp:506 ../src/msw/glcanvas.cpp:592
+#: ../src/msw/glcanvas.cpp:607 ../src/unix/glx11.cpp:513
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr ""
 
-#: ../src/generic/dirctrlg.cpp:599 ../src/generic/dirdlgg.cpp:323
-#: ../src/generic/filectrlg.cpp:642 ../src/generic/filectrlg.cpp:786
+#: ../src/generic/dirctrlg.cpp:565 ../src/generic/filectrlg.cpp:638
+#: ../src/generic/filectrlg.cpp:782 ../src/generic/dirdlgg.cpp:320
 msgid "Operation not permitted."
 msgstr "Operação não permitida."
 
-#: ../src/common/cmdline.cpp:900
+#: ../src/common/cmdline.cpp:896
 #, fuzzy, c-format
 msgid "Option '%s' can't be negated"
 msgstr "A opção '%s'não pode ser nagada"
 
-#: ../src/common/cmdline.cpp:1064
+#: ../src/common/cmdline.cpp:1060
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "A opção '%s' requer um valor."
 
-#: ../src/common/cmdline.cpp:1147
+#: ../src/common/cmdline.cpp:1143
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "A opção '%s': '%s' não pode ser convertida para uma data."
 
-#: ../src/generic/prntdlgg.cpp:618
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Opções"
 
-#: ../src/propgrid/advprops.cpp:1606
+#: ../src/propgrid/advprops.cpp:1512
 msgid "Orange"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:615 ../src/generic/prntdlgg.cpp:869
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:862
 msgid "Orientation"
 msgstr "Orientação"
 
-#: ../src/common/windowid.cpp:242
+#: ../src/common/windowid.cpp:237
 msgid "Out of window IDs.  Recommend shutting down application."
 msgstr ""
 
@@ -5534,148 +5676,148 @@ msgstr "&Contorno"
 msgid "Outset"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:656
+#: ../src/msw/ole/automtn.cpp:647
 msgid "Overflow while coercing argument values."
 msgstr ""
 
-#: ../src/common/imagpcx.cpp:457 ../src/common/imagpcx.cpp:480
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:479
 msgid "PCX: couldn't allocate memory"
 msgstr "PCX: não é possível alocar memória"
 
-#: ../src/common/imagpcx.cpp:456
+#: ../src/common/imagpcx.cpp:455
 msgid "PCX: image format unsupported"
 msgstr "PCX: formato de imagem não suportado"
 
-#: ../src/common/imagpcx.cpp:479
+#: ../src/common/imagpcx.cpp:478
 msgid "PCX: invalid image"
 msgstr "PCX: imagem inválida"
 
-#: ../src/common/imagpcx.cpp:442
+#: ../src/common/imagpcx.cpp:441
 msgid "PCX: this is not a PCX file."
 msgstr "PCX: este não é um ficheiro PCX."
 
-#: ../src/common/imagpcx.cpp:459 ../src/common/imagpcx.cpp:481
+#: ../src/common/imagpcx.cpp:458 ../src/common/imagpcx.cpp:480
 msgid "PCX: unknown error !!!"
 msgstr "PCX: erro desconhecido!!!"
 
-#: ../src/common/imagpcx.cpp:458
+#: ../src/common/imagpcx.cpp:457
 msgid "PCX: version number too low"
 msgstr "PCX: número de versão muito baixo"
 
-#: ../src/common/imagpnm.cpp:91
+#: ../src/common/imagpnm.cpp:89
 msgid "PNM: Couldn't allocate memory."
 msgstr "PNM: Não é possível alocar memória."
 
-#: ../src/common/imagpnm.cpp:73
+#: ../src/common/imagpnm.cpp:71
 msgid "PNM: File format is not recognized."
 msgstr "PNM: Formato do ficheiro não é reconhecido."
 
-#: ../src/common/imagpnm.cpp:112 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
 #: ../src/common/imagpnm.cpp:156
 msgid "PNM: File seems truncated."
 msgstr "PNM: O ficheiro parece estar truncado."
 
-#: ../src/common/paper.cpp:187
+#: ../src/common/paper.cpp:184
 msgid "PRC 16K 146 x 215 mm"
 msgstr "PRC 16K 146 x 215 mm"
 
-#: ../src/common/paper.cpp:200
+#: ../src/common/paper.cpp:197
 msgid "PRC 16K Rotated"
 msgstr "PRC 16K Rodado"
 
-#: ../src/common/paper.cpp:188
+#: ../src/common/paper.cpp:185
 msgid "PRC 32K 97 x 151 mm"
 msgstr "PRC 32K 97 x 151 mm"
 
-#: ../src/common/paper.cpp:201
+#: ../src/common/paper.cpp:198
 msgid "PRC 32K Rotated"
 msgstr "PRC 32K Rodado"
 
-#: ../src/common/paper.cpp:189
+#: ../src/common/paper.cpp:186
 msgid "PRC 32K(Big) 97 x 151 mm"
 msgstr "PRC 32K(Grande) 97 x 151 mm"
 
-#: ../src/common/paper.cpp:202
+#: ../src/common/paper.cpp:199
 msgid "PRC 32K(Big) Rotated"
 msgstr "PRC 32K(Grande) Rodado"
 
-#: ../src/common/paper.cpp:190
+#: ../src/common/paper.cpp:187
 msgid "PRC Envelope #1 102 x 165 mm"
 msgstr "Envelope PRC #1 102 x 165 mm"
 
-#: ../src/common/paper.cpp:203
+#: ../src/common/paper.cpp:200
 msgid "PRC Envelope #1 Rotated 165 x 102 mm"
 msgstr "Envelope PRC #1 Rodado 165 x 102 mm"
 
-#: ../src/common/paper.cpp:199
+#: ../src/common/paper.cpp:196
 msgid "PRC Envelope #10 324 x 458 mm"
 msgstr "Envelope PRC #10 324 x 458 mm"
 
-#: ../src/common/paper.cpp:212
+#: ../src/common/paper.cpp:209
 msgid "PRC Envelope #10 Rotated 458 x 324 mm"
 msgstr "Envelope PRC #10 Rodado 458 x 324 mm"
 
-#: ../src/common/paper.cpp:191
+#: ../src/common/paper.cpp:188
 msgid "PRC Envelope #2 102 x 176 mm"
 msgstr "Envelope PRC #2 102 x 176 mm"
 
-#: ../src/common/paper.cpp:204
+#: ../src/common/paper.cpp:201
 msgid "PRC Envelope #2 Rotated 176 x 102 mm"
 msgstr "Envelope PRC #2 Rodado 176 x 102 mm"
 
-#: ../src/common/paper.cpp:192
+#: ../src/common/paper.cpp:189
 msgid "PRC Envelope #3 125 x 176 mm"
 msgstr "Envelope PRC #3 125 x 176 mm"
 
-#: ../src/common/paper.cpp:205
+#: ../src/common/paper.cpp:202
 msgid "PRC Envelope #3 Rotated 176 x 125 mm"
 msgstr "Envelope PRC #3 Rodado 176 x 125 mm"
 
-#: ../src/common/paper.cpp:193
+#: ../src/common/paper.cpp:190
 msgid "PRC Envelope #4 110 x 208 mm"
 msgstr "Envelope PRC #4 110 x 208 mm"
 
-#: ../src/common/paper.cpp:206
+#: ../src/common/paper.cpp:203
 msgid "PRC Envelope #4 Rotated 208 x 110 mm"
 msgstr "Envelope PRC #4 Rodado 208 x 110 mm"
 
-#: ../src/common/paper.cpp:194
+#: ../src/common/paper.cpp:191
 msgid "PRC Envelope #5 110 x 220 mm"
 msgstr "Envelope PRC #5 110 x 220 mm"
 
-#: ../src/common/paper.cpp:207
+#: ../src/common/paper.cpp:204
 msgid "PRC Envelope #5 Rotated 220 x 110 mm"
 msgstr "Envelope PRC #5 Rodado 220 x 110 mm"
 
-#: ../src/common/paper.cpp:195
+#: ../src/common/paper.cpp:192
 msgid "PRC Envelope #6 120 x 230 mm"
 msgstr "Envelope PRC #6 120 x 230 mm"
 
-#: ../src/common/paper.cpp:208
+#: ../src/common/paper.cpp:205
 msgid "PRC Envelope #6 Rotated 230 x 120 mm"
 msgstr "Envelope PRC #6 Rodado 230 x 120 mm"
 
-#: ../src/common/paper.cpp:196
+#: ../src/common/paper.cpp:193
 msgid "PRC Envelope #7 160 x 230 mm"
 msgstr "Envelope PRC #7 160 x 230 mm"
 
-#: ../src/common/paper.cpp:209
+#: ../src/common/paper.cpp:206
 msgid "PRC Envelope #7 Rotated 230 x 160 mm"
 msgstr "Envelope PRC #7 Rodado 230 x 160 mm"
 
-#: ../src/common/paper.cpp:197
+#: ../src/common/paper.cpp:194
 msgid "PRC Envelope #8 120 x 309 mm"
 msgstr "Envelope PRC #8 120 x 309 mm"
 
-#: ../src/common/paper.cpp:210
+#: ../src/common/paper.cpp:207
 msgid "PRC Envelope #8 Rotated 309 x 120 mm"
 msgstr "Envelope PRC #8 Rodado 309 x 120 mm"
 
-#: ../src/common/paper.cpp:198
+#: ../src/common/paper.cpp:195
 msgid "PRC Envelope #9 229 x 324 mm"
 msgstr "Envelope PRC #9 229 x 324 mm"
 
-#: ../src/common/paper.cpp:211
+#: ../src/common/paper.cpp:208
 msgid "PRC Envelope #9 Rotated 324 x 229 mm"
 msgstr "Envelope PRC #9 Rodado 324 x 229 mm"
 
@@ -5684,92 +5826,96 @@ msgstr "Envelope PRC #9 Rodado 324 x 229 mm"
 msgid "Padding"
 msgstr "a ler"
 
-#: ../src/common/prntbase.cpp:2074
+#: ../src/common/prntbase.cpp:2096
 #, c-format
 msgid "Page %d"
 msgstr "Página %d"
 
-#: ../src/common/prntbase.cpp:2072
+#: ../src/common/prntbase.cpp:2094
 #, c-format
 msgid "Page %d of %d"
 msgstr "Página %d de %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 #, fuzzy
 msgid "Page Down"
 msgstr "Página %d"
 
-#: ../src/gtk/print.cpp:826
+#: ../src/gtk/print.cpp:829
 msgid "Page Setup"
 msgstr "Configuração de Página"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 #, fuzzy
 msgid "Page Up"
 msgstr "Página %d"
 
-#: ../src/generic/prntdlgg.cpp:828 ../src/common/prntbase.cpp:484
+#: ../src/common/prntbase.cpp:479 ../src/generic/prntdlgg.cpp:821
 msgid "Page setup"
 msgstr "Configuração de página"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 #, fuzzy
 msgid "PageDown"
 msgstr "Baixo"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 #, fuzzy
 msgid "PageUp"
 msgstr "Páginas"
 
-#: ../src/generic/prntdlgg.cpp:216
+#: ../src/generic/prntdlgg.cpp:209
 msgid "Pages"
 msgstr "Páginas"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1765
+#: ../src/propgrid/advprops.cpp:1666
 msgid "Paint Brush"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:602 ../src/generic/prntdlgg.cpp:801
-#: ../src/generic/prntdlgg.cpp:842 ../src/generic/prntdlgg.cpp:855
-#: ../src/generic/prntdlgg.cpp:1052 ../src/generic/prntdlgg.cpp:1057
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:794
+#: ../src/generic/prntdlgg.cpp:835 ../src/generic/prntdlgg.cpp:848
+#: ../src/generic/prntdlgg.cpp:1045 ../src/generic/prntdlgg.cpp:1050
 msgid "Paper size"
 msgstr "Tamanho do papel"
 
-#: ../src/richtext/richtextstyles.cpp:1062
+#: ../src/richtext/richtextstyles.cpp:1059
 msgid "Paragraph styles"
 msgstr "Estilos de parágrafo"
 
-#: ../src/common/xtistrm.cpp:465
+#: ../src/common/xtistrm.cpp:462
 msgid "Passing a already registered object to SetObject"
 msgstr "A passar um objecto já registado para SetObject"
 
-#: ../src/common/xtistrm.cpp:476
+#: ../src/common/xtistrm.cpp:473
 #, fuzzy
 msgid "Passing an unknown object to GetObject"
 msgstr "A passar um objecto desconhecido para GetObject"
 
-#: ../src/richtext/richtextctrl.cpp:3513 ../src/common/stockitem.cpp:180
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:177 ../src/richtext/richtextctrl.cpp:3514
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Colar"
 
-#: ../src/common/stockitem.cpp:262
+#: ../src/common/stockitem.cpp:260
 msgid "Paste selection"
 msgstr "Colar selecção"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:74
+#: ../src/common/accelcmn.cpp:71
 msgid "Pause"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1766
+#: ../src/propgrid/advprops.cpp:1667
 msgid "Pencil"
 msgstr ""
 
@@ -5778,21 +5924,21 @@ msgstr ""
 msgid "Peri&od"
 msgstr "Perí&odo"
 
-#: ../src/generic/filectrlg.cpp:430
+#: ../src/generic/filectrlg.cpp:426
 msgid "Permissions"
 msgstr "Permissões"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:60
+#: ../src/common/accelcmn.cpp:57
 msgid "PgDn"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:59
+#: ../src/common/accelcmn.cpp:56
 msgid "PgUp"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:12868
+#: ../src/richtext/richtextbuffer.cpp:12863
 #, fuzzy
 msgid "Picture Properties"
 msgstr "&Propriedades"
@@ -5805,46 +5951,46 @@ msgstr "Falha na criação do pipe"
 msgid "Please choose a valid font."
 msgstr "Por favor escolha uma fonte válida."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
 msgid "Please choose an existing file."
 msgstr "Por favor escolha um ficheiro existente."
 
-#: ../src/html/helpwnd.cpp:800
+#: ../src/html/helpwnd.cpp:798
 msgid "Please choose the page to display:"
 msgstr "Por favor escolha uma página para mostrar:"
 
-#: ../src/msw/dialup.cpp:764
+#: ../src/msw/dialup.cpp:758
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Por favor escolha ISP a que pretende ligar"
 
-#: ../src/common/headerctrlcmn.cpp:59
+#: ../src/common/headerctrlcmn.cpp:57
 msgid "Please select the columns to show and define their order:"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:538
+#: ../src/common/prntbase.cpp:533
 #, fuzzy
 msgid "Please wait while printing..."
 msgstr "Por favor aguarde enquanto imprime\n"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1767
+#: ../src/propgrid/advprops.cpp:1668
 #, fuzzy
 msgid "Point Left"
 msgstr "Tamanho do &ponto:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1768
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgid "Point Right"
 msgstr "Alinhar à Direita"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:662
+#: ../src/propgrid/advprops.cpp:572
 #, fuzzy
 msgid "Point Size"
 msgstr "Tamanho do &ponto:"
 
-#: ../src/generic/prntdlgg.cpp:612 ../src/generic/prntdlgg.cpp:867
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:860
 msgid "Portrait"
 msgstr "Retrato"
 
@@ -5853,152 +5999,162 @@ msgstr "Retrato"
 msgid "Position"
 msgstr "Pergunta"
 
-#: ../src/generic/prntdlgg.cpp:298
+#: ../src/generic/prntdlgg.cpp:291
 msgid "PostScript file"
 msgstr "Ficheiro PostScript"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178 ../src/osx/cocoa/preferences.mm:303
 #, fuzzy
 msgid "Preferences"
 msgstr "&Preferências"
 
-#: ../src/osx/menu_osx.cpp:568
+#: ../src/osx/menu_osx.cpp:460
 #, fuzzy
 msgid "Preferences..."
 msgstr "&Preferências"
 
-#: ../src/common/prntbase.cpp:546
+#: ../src/common/prntbase.cpp:541
 msgid "Preparing"
 msgstr "A preparar"
 
-#: ../src/generic/fontdlgg.cpp:455 ../src/osx/carbon/fontdlg.cpp:390
-#: ../src/html/helpwnd.cpp:1222
+#: ../src/osx/carbon/fontdlg.cpp:387 ../src/generic/fontdlgg.cpp:452
+#: ../src/html/helpwnd.cpp:1220
 msgid "Preview:"
 msgstr "Antevisão:"
 
-#: ../src/common/prntbase.cpp:1553 ../src/html/helpwnd.cpp:664
+#: ../src/common/prntbase.cpp:1578 ../src/html/helpwnd.cpp:662
 msgid "Previous page"
 msgstr "Página anterior"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/prntdlgg.cpp:143 ../src/generic/prntdlgg.cpp:157
-#: ../src/common/prntbase.cpp:426 ../src/common/prntbase.cpp:1541
-#: ../src/common/accelcmn.cpp:77 ../src/gtk/print.cpp:620
-#: ../src/gtk/print.cpp:638
+#: ../src/common/prntbase.cpp:421 ../src/common/prntbase.cpp:1566
+#: ../src/common/accelcmn.cpp:74 ../src/generic/prntdlgg.cpp:136
+#: ../src/generic/prntdlgg.cpp:150 ../src/gtk/print.cpp:616
+#: ../src/gtk/print.cpp:634
 msgid "Print"
 msgstr "Imprimir"
 
-#: ../include/wx/prntbase.h:399 ../src/common/docview.cpp:1268
+#: ../src/common/docview.cpp:1262
 msgid "Print Preview"
 msgstr "Pré-visualizar Impressão"
 
-#: ../src/common/prntbase.cpp:2015 ../src/common/prntbase.cpp:2057
-#: ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2037 ../src/common/prntbase.cpp:2079
+#: ../src/common/prntbase.cpp:2087
 msgid "Print Preview Failure"
 msgstr "Falha na Pré-visualização da Impressão"
 
-#: ../src/generic/prntdlgg.cpp:224
+#: ../src/generic/prntdlgg.cpp:217
 msgid "Print Range"
 msgstr "Páginas a Imprimir"
 
-#: ../src/generic/prntdlgg.cpp:449
+#: ../src/generic/prntdlgg.cpp:442
 msgid "Print Setup"
 msgstr "Configuração da Impressora"
 
-#: ../src/generic/prntdlgg.cpp:621
+#: ../src/generic/prntdlgg.cpp:614
 msgid "Print in colour"
 msgstr "Imprimir a cores"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/osx/webview_webkit.mm:260
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "Não foi possível inicializar o ecrã."
+
+#: ../src/common/stockitem.cpp:179
 msgid "Print previe&w..."
 msgstr "&Pré-visualizar Impressão ..."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1256
 msgid "Print preview creation failed."
 msgstr "Falha na criação da pré-visualização da impressão."
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/common/stockitem.cpp:179
 msgid "Print preview..."
 msgstr "Pré-visualizar impressão ..."
 
-#: ../src/generic/prntdlgg.cpp:630
+#: ../src/generic/prntdlgg.cpp:623
 msgid "Print spooling"
 msgstr "Colocação da impressão no buffer"
 
-#: ../src/html/helpwnd.cpp:675
+#: ../src/html/helpwnd.cpp:673
 msgid "Print this page"
 msgstr "Imprimir esta página"
 
-#: ../src/generic/prntdlgg.cpp:185
+#: ../src/generic/prntdlgg.cpp:178
 msgid "Print to File"
 msgstr "Imprimir para Ficheiro"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "Print..."
 msgstr "&Imprimir ..."
 
-#: ../src/generic/prntdlgg.cpp:493
+#: ../src/generic/prntdlgg.cpp:486
 msgid "Printer"
 msgstr "Impressora"
 
-#: ../src/generic/prntdlgg.cpp:633
+#: ../src/generic/prntdlgg.cpp:626
 msgid "Printer command:"
 msgstr "Comando da impressora:"
 
-#: ../src/generic/prntdlgg.cpp:180
+#: ../src/generic/prntdlgg.cpp:173
 msgid "Printer options"
 msgstr "Opções da Impressora"
 
-#: ../src/generic/prntdlgg.cpp:645
+#: ../src/generic/prntdlgg.cpp:638
 msgid "Printer options:"
 msgstr "Opções da impressora:"
 
-#: ../src/generic/prntdlgg.cpp:916
+#: ../src/generic/prntdlgg.cpp:909
 msgid "Printer..."
 msgstr "Impressora ..."
 
-#: ../src/generic/prntdlgg.cpp:196
+#: ../src/generic/prntdlgg.cpp:189
 msgid "Printer:"
 msgstr "Impressora:"
 
-#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:535
-#: ../src/html/htmprint.cpp:277
+#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:530
+#: ../src/html/htmprint.cpp:289
 msgid "Printing"
 msgstr "A Imprimir  ..."
 
-#: ../src/common/prntbase.cpp:612
+#: ../src/common/prntbase.cpp:607
 msgid "Printing "
 msgstr "A Imprimir ..."
 
-#: ../src/common/prntbase.cpp:347
+#: ../src/common/prntbase.cpp:342
 msgid "Printing Error"
 msgstr "Erro de Impressão"
 
-#: ../src/common/prntbase.cpp:565
+#: ../src/osx/webview_webkit.mm:251
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "Gzip não suportado nesta versão do zlib"
+
+#: ../src/common/prntbase.cpp:560
 #, fuzzy, c-format
 msgid "Printing page %d"
 msgstr "A imprimir a página %d ..."
 
-#: ../src/common/prntbase.cpp:570
+#: ../src/common/prntbase.cpp:565
 #, c-format
 msgid "Printing page %d of %d"
 msgstr "A imprimir página %d de %d ..."
 
-#: ../src/generic/printps.cpp:201
+#: ../src/generic/printps.cpp:182
 #, c-format
 msgid "Printing page %d..."
 msgstr "A imprimir a página %d ..."
 
-#: ../src/generic/printps.cpp:161
+#: ../src/generic/printps.cpp:142
 msgid "Printing..."
 msgstr "A Imprimir ..."
 
-#: ../include/wx/richtext/richtextprint.h:109 ../include/wx/prntbase.h:267
-#: ../src/common/docview.cpp:2132
+#: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
+#: ../src/common/docview.cpp:2137
 msgid "Printout"
 msgstr "Impressão"
 
-#: ../src/common/debugrpt.cpp:560
+#: ../src/common/debugrpt.cpp:561
 #, c-format
 msgid ""
 "Processing debug report has failed, leaving the files in \"%s\" directory."
@@ -6006,110 +6162,110 @@ msgstr ""
 "O processamento do relatório de depuração falhou, a colocar os ficheiros na "
 "directoria \"%s\"."
 
-#: ../src/common/prntbase.cpp:545
+#: ../src/common/prntbase.cpp:540
 msgid "Progress:"
 msgstr "Progresso:"
 
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181
 #, fuzzy
 msgid "Properties"
 msgstr "&Propriedades"
 
-#: ../src/propgrid/manager.cpp:237
+#: ../src/propgrid/manager.cpp:223
 #, fuzzy
 msgid "Property"
 msgstr "&Propriedades"
 
 #. TRANSLATORS: Caption of message box displaying any property error
-#: ../src/propgrid/propgrid.cpp:3185 ../src/propgrid/propgrid.cpp:3318
+#: ../src/propgrid/propgrid.cpp:3162 ../src/propgrid/propgrid.cpp:3299
 #, fuzzy
 msgid "Property Error"
 msgstr "Erro de Impressão"
 
-#: ../src/propgrid/advprops.cpp:1597
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Purple"
 msgstr ""
 
-#: ../src/common/paper.cpp:112
+#: ../src/common/paper.cpp:109
 msgid "Quarto, 215 x 275 mm"
 msgstr "Quarto, 215 x 275 mm"
 
-#: ../src/generic/logg.cpp:1016
+#: ../src/generic/logg.cpp:1013
 msgid "Question"
 msgstr "Pergunta"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1769
+#: ../src/propgrid/advprops.cpp:1670
 #, fuzzy
 msgid "Question Arrow"
 msgstr "Pergunta"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 #, fuzzy
 msgid "Quit"
 msgstr "&Desistir"
 
-#: ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:477
 #, fuzzy, c-format
 msgid "Quit %s"
 msgstr "&Desistir"
 
-#: ../src/common/stockitem.cpp:263
+#: ../src/common/stockitem.cpp:261
 msgid "Quit this program"
 msgstr "Terminar deste programa"
 
-#: ../src/common/accelcmn.cpp:338
+#: ../src/common/accelcmn.cpp:352
 #, fuzzy
 msgid "RawCtrl+"
 msgstr "Ctrl-"
 
-#: ../src/common/ffile.cpp:109 ../src/common/ffile.cpp:133
+#: ../src/common/ffile.cpp:107 ../src/common/ffile.cpp:132
 #, c-format
 msgid "Read error on file '%s'"
 msgstr "Erro de leitura no ficheiro '%s'"
 
-#: ../src/common/secretstore.cpp:199
+#: ../src/common/secretstore.cpp:211
 #, fuzzy, c-format
-msgid "Reading password for \"%s/%s\" failed: %s."
+msgid "Reading password for \"%s\" failed: %s."
 msgstr "Falhou a extracção de '%s' para '%s'."
 
-#: ../src/common/prntbase.cpp:272
+#: ../src/common/prntbase.cpp:267
 msgid "Ready"
 msgstr "Preparado"
 
-#: ../src/propgrid/advprops.cpp:1605
+#: ../src/propgrid/advprops.cpp:1511
 #, fuzzy
 msgid "Red"
 msgstr "&Refazer"
 
-#: ../src/generic/colrdlgg.cpp:339
+#: ../src/generic/colrdlgg.cpp:359
 msgid "Red:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:185 ../src/stc/stc_i18n.cpp:16
+#: ../src/common/stockitem.cpp:182 ../src/stc/stc_i18n.cpp:16
 #, fuzzy
 msgid "Redo"
 msgstr "&Refazer"
 
-#: ../src/common/stockitem.cpp:264
+#: ../src/common/stockitem.cpp:262
 msgid "Redo last action"
 msgstr "Refazer última acção"
 
-#: ../src/common/stockitem.cpp:186
+#: ../src/common/stockitem.cpp:183
 msgid "Refresh"
 msgstr "Refrescar"
 
-#: ../src/msw/registry.cpp:626
+#: ../src/msw/registry.cpp:615
 #, c-format
 msgid "Registry key '%s' already exists."
 msgstr "Chave de registo '%s' já existe."
 
-#: ../src/msw/registry.cpp:595
+#: ../src/msw/registry.cpp:584
 #, c-format
 msgid "Registry key '%s' does not exist, cannot rename it."
 msgstr "Chave de registo '%s' não existe, impossível renomeá-la."
 
-#: ../src/msw/registry.cpp:727
+#: ../src/msw/registry.cpp:716
 #, c-format
 msgid ""
 "Registry key '%s' is needed for normal system operation,\n"
@@ -6120,22 +6276,22 @@ msgstr ""
 "apagá-lo vai deixar o seu sistema num estado inutilizável:\n"
 "operação interrompida."
 
-#: ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:942
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:917
+#: ../src/msw/registry.cpp:905
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1003
+#: ../src/msw/registry.cpp:991
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:521
+#: ../src/msw/registry.cpp:510
 #, c-format
 msgid "Registry value '%s' already exists."
 msgstr "Valor de registo '%s' já existe."
@@ -6150,74 +6306,80 @@ msgstr "Regular"
 msgid "Relative"
 msgstr "Decorative"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:456
 msgid "Relevant entries:"
 msgstr "Entradas relevantes:"
 
-#: ../include/wx/generic/progdlgg.h:86
+#: ../include/wx/generic/progdlgg.h:87
 #, fuzzy
 msgid "Remaining time:"
 msgstr "Tempo restante : "
 
-#: ../src/common/stockitem.cpp:187
+#: ../src/common/stockitem.cpp:184
 msgid "Remove"
 msgstr "Remover"
 
-#: ../src/richtext/richtextctrl.cpp:1562
+#: ../src/richtext/richtextctrl.cpp:1563
 #, fuzzy
 msgid "Remove Bullet"
 msgstr "Remover"
 
-#: ../src/html/helpwnd.cpp:433
+#: ../src/html/helpwnd.cpp:431
 msgid "Remove current page from bookmarks"
 msgstr "Remover página atual dos marcadores"
 
-#: ../src/common/rendcmn.cpp:194
+#: ../src/common/rendcmn.cpp:191
 #, c-format
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 "Renderizador \"%s\" tem uma versão incompatível %d.%d e não pode ser "
 "carregado."
 
-#: ../src/richtext/richtextbuffer.cpp:4527
+#: ../src/richtext/richtextbuffer.cpp:4524
 msgid "Renumber List"
 msgstr "Renumerar Lista"
 
-#: ../src/common/stockitem.cpp:188
-msgid "Rep&lace"
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Rep&lace..."
 msgstr "Su&bstituir"
 
-#: ../src/richtext/richtextctrl.cpp:3673 ../src/common/stockitem.cpp:188
+#: ../src/richtext/richtextctrl.cpp:3674
 msgid "Replace"
 msgstr "Substituir"
 
-#: ../src/generic/fdrepdlg.cpp:182
+#: ../src/generic/fdrepdlg.cpp:179
 msgid "Replace &all"
 msgstr "Substituir &todos"
 
-#: ../src/common/stockitem.cpp:261
-msgid "Replace selection"
-msgstr "Substituir selecção"
-
-#: ../src/generic/fdrepdlg.cpp:124
+#: ../src/generic/fdrepdlg.cpp:121
 msgid "Replace with:"
 msgstr "Substituir por:"
 
-#: ../src/common/valtext.cpp:163
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Replace..."
+msgstr "Substituir"
+
+#: ../src/common/valtext.cpp:184
 msgid "Required information entry is empty."
 msgstr "A entrada da informação necessária está em branco."
 
-#: ../src/common/translation.cpp:1975
+#: ../src/common/translation.cpp:2025
 #, fuzzy, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "'%s' não é uma mensagem válida do catálogo."
 
+#: ../src/gtk/webview_webkit.cpp:985
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:56
+#: ../src/common/accelcmn.cpp:53
 msgid "Return"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:189
+#: ../src/common/stockitem.cpp:186
 msgid "Revert to Saved"
 msgstr "Reverter para o Gravado"
 
@@ -6230,42 +6392,42 @@ msgstr "Direita"
 msgid "Rig&ht-to-left"
 msgstr ""
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6149
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:59 ../src/generic/datavgen.cpp:6954
+#: ../src/richtext/richtextsizepage.cpp:250
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextbulletspage.cpp:188
-#: ../src/richtext/richtextsizepage.cpp:250 ../src/common/accelcmn.cpp:62
 msgid "Right"
 msgstr "Direita"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1754
+#: ../src/propgrid/advprops.cpp:1655
 #, fuzzy
 msgid "Right Arrow"
 msgstr "Direita"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1770
+#: ../src/propgrid/advprops.cpp:1671
 msgid "Right Button"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:892
+#: ../src/generic/prntdlgg.cpp:885
 msgid "Right margin (mm):"
 msgstr "Margem direita (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:148
-#: ../src/richtext/richtextindentspage.cpp:150
 #: ../src/richtext/richtextliststylepage.cpp:337
 #: ../src/richtext/richtextliststylepage.cpp:339
+#: ../src/richtext/richtextindentspage.cpp:148
+#: ../src/richtext/richtextindentspage.cpp:150
 msgid "Right-align text."
 msgstr "Alinhar texto à direita."
 
-#: ../src/generic/fontdlgg.cpp:322
+#: ../src/generic/fontdlgg.cpp:318
 msgid "Roman"
 msgstr "Roman"
 
-#: ../src/generic/datavgen.cpp:5916
+#: ../src/generic/datavgen.cpp:6721
 #, c-format
 msgid "Row %i"
 msgstr ""
@@ -6275,31 +6437,31 @@ msgstr ""
 msgid "S&tandard bullet name:"
 msgstr "Nome de Marcador S&tandard:"
 
-#: ../src/common/accelcmn.cpp:268 ../src/common/accelcmn.cpp:350
+#: ../src/common/accelcmn.cpp:282 ../src/common/accelcmn.cpp:367
 msgid "SPECIAL"
 msgstr "SPECIAL"
 
-#: ../src/common/stockitem.cpp:190 ../src/common/sizer.cpp:2797
+#: ../src/common/stockitem.cpp:187 ../src/common/sizer.cpp:2914
 msgid "Save"
 msgstr "Gravar"
 
-#: ../src/common/fldlgcmn.cpp:342
+#: ../src/common/fldlgcmn.cpp:339
 #, c-format
 msgid "Save %s file"
 msgstr "Gravar %s ficheiro"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/common/stockitem.cpp:188 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Gravar &Como..."
 
-#: ../src/common/docview.cpp:366
+#: ../src/common/docview.cpp:359
 msgid "Save As"
 msgstr "Gravar Como"
 
-#: ../src/common/stockitem.cpp:191
+#: ../src/common/stockitem.cpp:188
 #, fuzzy
-msgid "Save as"
-msgstr "Gravar Como"
+msgid "Save As..."
+msgstr "Gravar &Como..."
 
 #: ../src/common/stockitem.cpp:267
 msgid "Save current document"
@@ -6309,40 +6471,40 @@ msgstr "Gravar documento atual"
 msgid "Save current document with a different filename"
 msgstr "Gravar documento atual com nome diferente"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/generic/logg.cpp:509
 msgid "Save log contents to file"
 msgstr "Gravar conteúdos do registo para ficheiro"
 
-#: ../src/common/secretstore.cpp:179
+#: ../src/common/secretstore.cpp:189
 #, fuzzy, c-format
-msgid "Saving password for \"%s/%s\" failed: %s."
+msgid "Saving password for \"%s\" failed: %s."
 msgstr "Falhou a extracção de '%s' para '%s'."
 
-#: ../src/generic/fontdlgg.cpp:325
+#: ../src/generic/fontdlgg.cpp:321
 msgid "Script"
 msgstr "Script"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll Lock"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll_lock"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:890
+#: ../src/propgrid/advprops.cpp:791
 msgid "Scrollbar"
 msgstr ""
 
-#: ../src/generic/srchctlg.cpp:56 ../src/html/helpwnd.cpp:535
-#: ../src/html/helpwnd.cpp:550
+#: ../src/generic/srchctlg.cpp:55 ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:548 ../src/gtk/srchctrl.cpp:182
 msgid "Search"
 msgstr "Procurar"
 
-#: ../src/html/helpwnd.cpp:537
+#: ../src/html/helpwnd.cpp:535
 #, fuzzy
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
@@ -6351,32 +6513,32 @@ msgstr ""
 "Procurar conteúdos de livros de ajuda para todas as ocorrências do texto "
 "digitado acima"
 
-#: ../src/generic/fdrepdlg.cpp:160
+#: ../src/generic/fdrepdlg.cpp:157
 msgid "Search direction"
 msgstr "Direcção de procura"
 
-#: ../src/generic/fdrepdlg.cpp:112
+#: ../src/generic/fdrepdlg.cpp:109
 msgid "Search for:"
 msgstr "Procurar por:"
 
-#: ../src/html/helpwnd.cpp:1052
+#: ../src/html/helpwnd.cpp:1050
 msgid "Search in all books"
 msgstr "Procurar em todos os livros"
 
-#: ../src/html/helpwnd.cpp:857
+#: ../src/html/helpwnd.cpp:855
 msgid "Searching..."
 msgstr "A Procurar..."
 
-#: ../src/generic/dirctrlg.cpp:446
+#: ../src/generic/dirctrlg.cpp:412
 msgid "Sections"
 msgstr "Secções"
 
-#: ../src/common/ffile.cpp:238
+#: ../src/common/ffile.cpp:237
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Erro de pesquisa no ficheiro '%s'"
 
-#: ../src/common/ffile.cpp:228
+#: ../src/common/ffile.cpp:227
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
@@ -6384,26 +6546,26 @@ msgstr ""
 "stdio)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:76
+#: ../src/common/accelcmn.cpp:73
 #, fuzzy
 msgid "Select"
 msgstr "Selecção"
 
-#: ../src/richtext/richtextctrl.cpp:337 ../src/osx/textctrl_osx.cpp:581
-#: ../src/common/stockitem.cpp:192 ../src/msw/textctrl.cpp:2512
+#: ../src/osx/textctrl_osx.cpp:599 ../src/common/stockitem.cpp:189
+#: ../src/msw/textctrl.cpp:2777 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Selecion&ar Todos"
 
-#: ../src/common/stockitem.cpp:192 ../src/stc/stc_i18n.cpp:21
+#: ../src/common/stockitem.cpp:189 ../src/stc/stc_i18n.cpp:21
 #, fuzzy
 msgid "Select All"
 msgstr "Selecion&ar Todos"
 
-#: ../src/common/docview.cpp:1895
+#: ../src/common/docview.cpp:1900
 msgid "Select a document template"
 msgstr "Selecionar um modelo de documento"
 
-#: ../src/common/docview.cpp:1969
+#: ../src/common/docview.cpp:1974
 msgid "Select a document view"
 msgstr "Selecionar uma vista de documento"
 
@@ -6432,20 +6594,20 @@ msgid "Selects the list level to edit."
 msgstr "Seleciona o nível de lista a editar."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:82
+#: ../src/common/accelcmn.cpp:79
 msgid "Separator"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1083
+#: ../src/common/cmdline.cpp:1079
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Separador esperado depois da opção '%s'."
 
-#: ../src/osx/menu_osx.cpp:572
+#: ../src/osx/menu_osx.cpp:464
 msgid "Services"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11217
+#: ../src/richtext/richtextbuffer.cpp:11216
 #, fuzzy
 msgid "Set Cell Style"
 msgstr "Apagar Estilo"
@@ -6454,11 +6616,11 @@ msgstr "Apagar Estilo"
 msgid "SetProperty called w/o valid setter"
 msgstr "SetProperty chamado sem 'set' válido"
 
-#: ../src/generic/prntdlgg.cpp:188
+#: ../src/generic/prntdlgg.cpp:181
 msgid "Setup..."
 msgstr "Configurar..."
 
-#: ../src/msw/dialup.cpp:544
+#: ../src/msw/dialup.cpp:538
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr ""
 "Foram encontradas várias ligações telefónicas ativas, a escolher uma "
@@ -6477,41 +6639,41 @@ msgstr ""
 msgid "Shadow c&olour:"
 msgstr "Escolher cor"
 
-#: ../src/common/accelcmn.cpp:335
+#: ../src/common/accelcmn.cpp:349
 #, fuzzy
 msgid "Shift+"
 msgstr "Shift-"
 
-#: ../src/generic/dirdlgg.cpp:147
+#: ../src/generic/dirdlgg.cpp:144
 msgid "Show &hidden directories"
 msgstr "Mostrar diretorias &ocultadas"
 
-#: ../src/generic/filectrlg.cpp:983
+#: ../src/generic/filectrlg.cpp:979
 msgid "Show &hidden files"
 msgstr "Mostrar fic&heiros escondidos"
 
-#: ../src/osx/menu_osx.cpp:580
+#: ../src/osx/menu_osx.cpp:472
 msgid "Show All"
 msgstr "Mostrar Tudo"
 
-#: ../src/common/stockitem.cpp:257
+#: ../src/common/stockitem.cpp:254
 msgid "Show about dialog"
 msgstr "Mostrar janela sobre"
 
-#: ../src/html/helpwnd.cpp:492
+#: ../src/html/helpwnd.cpp:490
 msgid "Show all"
 msgstr "Mostrar tudo"
 
-#: ../src/html/helpwnd.cpp:503
+#: ../src/html/helpwnd.cpp:501
 msgid "Show all items in index"
 msgstr "Mostrar todos os items no índice"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:656
 msgid "Show/hide navigation panel"
 msgstr "Mostra/esconde painel de navegação"
 
-#: ../src/richtext/richtextsymboldlg.cpp:421
-#: ../src/richtext/richtextsymboldlg.cpp:423
+#: ../src/richtext/richtextsymboldlg.cpp:418
+#: ../src/richtext/richtextsymboldlg.cpp:420
 msgid "Shows a Unicode subset."
 msgstr "Mostra um sub-conjunto Unicode."
 
@@ -6527,7 +6689,7 @@ msgstr "Mostra uma antevisão das definições de marcador."
 msgid "Shows a preview of the font settings."
 msgstr "Mostra uma antevisão das definições da fonte."
 
-#: ../src/osx/carbon/fontdlg.cpp:394 ../src/osx/carbon/fontdlg.cpp:396
+#: ../src/osx/carbon/fontdlg.cpp:391 ../src/osx/carbon/fontdlg.cpp:393
 msgid "Shows a preview of the font."
 msgstr "Mostrar uma antevisão da fonte."
 
@@ -6536,62 +6698,62 @@ msgstr "Mostrar uma antevisão da fonte."
 msgid "Shows a preview of the paragraph settings."
 msgstr "Mostra uma antevisão das definições do parágrafo."
 
-#: ../src/generic/fontdlgg.cpp:460 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:456 ../src/generic/fontdlgg.cpp:458
 msgid "Shows the font preview."
 msgstr "Mostra a antevisão da fonte."
 
-#: ../src/propgrid/advprops.cpp:1607
+#: ../src/propgrid/advprops.cpp:1513
 msgid "Silver"
 msgstr ""
 
-#: ../src/univ/themes/mono.cpp:516
+#: ../src/univ/themes/mono.cpp:513
 msgid "Simple monochrome theme"
 msgstr "Tema monocromático simples"
 
-#: ../src/richtext/richtextindentspage.cpp:275
 #: ../src/richtext/richtextliststylepage.cpp:449
+#: ../src/richtext/richtextindentspage.cpp:275
 msgid "Single"
 msgstr "Único"
 
-#: ../src/generic/filectrlg.cpp:425 ../src/richtext/richtextformatdlg.cpp:369
-#: ../src/richtext/richtextsizepage.cpp:299
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextsizepage.cpp:299
+#: ../src/richtext/richtextformatdlg.cpp:362
 msgid "Size"
 msgstr "Tamanho"
 
-#: ../src/osx/carbon/fontdlg.cpp:339
+#: ../src/osx/carbon/fontdlg.cpp:336
 msgid "Size:"
 msgstr "Tamanho:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1775
+#: ../src/propgrid/advprops.cpp:1676
 msgid "Sizing"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1772
+#: ../src/propgrid/advprops.cpp:1673
 msgid "Sizing N-S"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1771
+#: ../src/propgrid/advprops.cpp:1672
 msgid "Sizing NE-SW"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1773
+#: ../src/propgrid/advprops.cpp:1674
 msgid "Sizing NW-SE"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1774
+#: ../src/propgrid/advprops.cpp:1675
 msgid "Sizing W-E"
 msgstr ""
 
-#: ../src/msw/progdlg.cpp:801
+#: ../src/msw/progdlg.cpp:1088
 msgid "Skip"
 msgstr "Saltar"
 
-#: ../src/generic/fontdlgg.cpp:330
+#: ../src/generic/fontdlgg.cpp:326
 msgid "Slant"
 msgstr "Inclinação"
 
@@ -6600,7 +6762,7 @@ msgid "Small C&apitals"
 msgstr "&Minúsculas"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:79
+#: ../src/common/accelcmn.cpp:76
 msgid "Snapshot"
 msgstr ""
 
@@ -6609,37 +6771,37 @@ msgstr ""
 msgid "Solid"
 msgstr "Destacado"
 
-#: ../src/common/docview.cpp:1791
+#: ../src/common/docview.cpp:1785
 msgid "Sorry, could not open this file."
 msgstr "Lamento, não foi possível abrir este ficheiro."
 
-#: ../src/common/prntbase.cpp:2057 ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2079 ../src/common/prntbase.cpp:2087
 msgid "Sorry, not enough memory to create a preview."
 msgstr "Lamento, não existe memória suficiente para criar a antevisão."
 
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "Sorry, that name is taken. Please choose another."
 msgstr "Lamento, este nome já está escolhido. Por favor escolha outro."
 
-#: ../src/common/docview.cpp:1814
+#: ../src/common/docview.cpp:1819
 msgid "Sorry, the format for this file is unknown."
 msgstr "Lamento, o formato deste ficheiro é desconhecido."
 
-#: ../src/unix/sound.cpp:492
+#: ../src/unix/sound.cpp:481
 msgid "Sound data are in unsupported format."
 msgstr "Dados de som estão num formato não suportado."
 
-#: ../src/unix/sound.cpp:477
+#: ../src/unix/sound.cpp:466
 #, c-format
 msgid "Sound file '%s' is in unsupported format."
 msgstr "O ficheiro de som '%s' está num formato não suportado."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:67
+#: ../src/common/accelcmn.cpp:64
 #, fuzzy
 msgid "Space"
 msgstr "Espaçamento"
@@ -6648,12 +6810,12 @@ msgstr "Espaçamento"
 msgid "Spacing"
 msgstr "Espaçamento"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "Spell Check"
 msgstr "Corretor Ortográfico"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1776
+#: ../src/propgrid/advprops.cpp:1677
 msgid "Spraycan"
 msgstr ""
 
@@ -6662,7 +6824,7 @@ msgstr ""
 msgid "Standard"
 msgstr "Padrão"
 
-#: ../src/common/paper.cpp:104
+#: ../src/common/paper.cpp:101
 msgid "Statement, 5 1/2 x 8 1/2 in"
 msgstr "Statement, 5 1/2 x 8 1/2 pol."
 
@@ -6672,34 +6834,30 @@ msgstr "Statement, 5 1/2 x 8 1/2 pol."
 msgid "Static"
 msgstr "Estático"
 
-#: ../src/generic/prntdlgg.cpp:204
+#: ../src/generic/prntdlgg.cpp:197
 msgid "Status:"
 msgstr "Estado:"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 #, fuzzy
 msgid "Stop"
 msgstr "&Parar"
 
-#: ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196
 msgid "Strikethrough"
 msgstr "Rasurado"
 
-#: ../src/common/colourcmn.cpp:45
+#: ../src/common/colourcmn.cpp:42
 #, c-format
 msgid "String To Colour : Incorrect colour specification : %s"
 msgstr "Cadeia de Carateres para a Cor : Especificação de cor incorreta : %s"
 
 #. TRANSLATORS: Label of font style
-#: ../src/richtext/richtextformatdlg.cpp:339 ../src/propgrid/advprops.cpp:680
+#: ../src/propgrid/advprops.cpp:590 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Estilo"
 
-#: ../include/wx/richtext/richtextstyledlg.h:46
-msgid "Style Organiser"
-msgstr "Organizador de Estilos"
-
-#: ../src/osx/carbon/fontdlg.cpp:348
+#: ../src/osx/carbon/fontdlg.cpp:345
 msgid "Style:"
 msgstr "Estilo:"
 
@@ -6709,7 +6867,7 @@ msgid "Subscrip&t"
 msgstr "Subscri&to"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:83
+#: ../src/common/accelcmn.cpp:80
 msgid "Subtract"
 msgstr ""
 
@@ -6718,11 +6876,11 @@ msgstr ""
 msgid "Supe&rscript"
 msgstr "Ex&poente"
 
-#: ../src/common/paper.cpp:150
+#: ../src/common/paper.cpp:147
 msgid "SuperA/SuperA/A4 227 x 356 mm"
 msgstr "SuperA/SuperA/A4 227 x 356 mm"
 
-#: ../src/common/paper.cpp:151
+#: ../src/common/paper.cpp:148
 msgid "SuperB/SuperB/A3 305 x 487 mm"
 msgstr "SuperB/SuperB/A3 305 x 487 mm"
 
@@ -6730,7 +6888,7 @@ msgstr "SuperB/SuperB/A3 305 x 487 mm"
 msgid "Suppress hyphe&nation"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:326
+#: ../src/generic/fontdlgg.cpp:322
 msgid "Swiss"
 msgstr "Suíço"
 
@@ -6748,75 +6906,75 @@ msgstr "&Fonte Symbol:"
 msgid "Symbols"
 msgstr "Símbolos"
 
-#: ../src/common/imagtiff.cpp:369 ../src/common/imagtiff.cpp:382
-#: ../src/common/imagtiff.cpp:741
+#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
+#: ../src/common/imagtiff.cpp:738
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: Não é possível alocar memória."
 
-#: ../src/common/imagtiff.cpp:301
+#: ../src/common/imagtiff.cpp:298
 msgid "TIFF: Error loading image."
 msgstr "TIFF: Erro ao carregar imagem."
 
-#: ../src/common/imagtiff.cpp:468
+#: ../src/common/imagtiff.cpp:465
 msgid "TIFF: Error reading image."
 msgstr "TIFF: Erro ao ler imagem."
 
-#: ../src/common/imagtiff.cpp:608
+#: ../src/common/imagtiff.cpp:605
 msgid "TIFF: Error saving image."
 msgstr "TIFF: Erro ao gravar imagem."
 
-#: ../src/common/imagtiff.cpp:846
+#: ../src/common/imagtiff.cpp:843
 msgid "TIFF: Error writing image."
 msgstr "TIFF: Erro ao escrever imagem."
 
-#: ../src/common/imagtiff.cpp:355
+#: ../src/common/imagtiff.cpp:352
 msgid "TIFF: Image size is abnormally big."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:68
+#: ../src/common/accelcmn.cpp:65
 #, fuzzy
 msgid "Tab"
 msgstr "Tabs"
 
-#: ../src/richtext/richtextbuffer.cpp:11498
+#: ../src/richtext/richtextbuffer.cpp:11497
 #, fuzzy
 msgid "Table Properties"
 msgstr "&Propriedades"
 
-#: ../src/common/paper.cpp:145
+#: ../src/common/paper.cpp:142
 msgid "Tabloid Extra 11.69 x 18 in"
 msgstr "Tabloid Extra 11.69 x 18 pol."
 
-#: ../src/common/paper.cpp:102
+#: ../src/common/paper.cpp:99
 msgid "Tabloid, 11 x 17 in"
 msgstr "Tabloid, 11 x 17 pol."
 
-#: ../src/richtext/richtextformatdlg.cpp:354
+#: ../src/richtext/richtextformatdlg.cpp:347
 msgid "Tabs"
 msgstr "Tabs"
 
-#: ../src/propgrid/advprops.cpp:1598
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Teal"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:327
+#: ../src/generic/fontdlgg.cpp:323
 msgid "Teletype"
 msgstr "Teletype"
 
-#: ../src/common/docview.cpp:1896
+#: ../src/common/docview.cpp:1901
 msgid "Templates"
 msgstr "Modelos"
 
-#: ../src/common/fmapbase.cpp:158
+#: ../src/common/fmapbase.cpp:155
 msgid "Thai (ISO-8859-11)"
 msgstr "Tailandês (ISO-8859-11)"
 
-#: ../src/common/ftp.cpp:619
+#: ../src/common/ftp.cpp:622
 msgid "The FTP server doesn't support passive mode."
 msgstr "O servidor do FTP não suporta modo passivo."
 
-#: ../src/common/ftp.cpp:605
+#: ../src/common/ftp.cpp:608
 msgid "The FTP server doesn't support the PORT command."
 msgstr "O servidor de FTP não suporta o comando PORT."
 
@@ -6827,8 +6985,8 @@ msgstr "O servidor de FTP não suporta o comando PORT."
 msgid "The available bullet styles."
 msgstr "Os estilos de marcador disponíveis."
 
-#: ../src/richtext/richtextstyledlg.cpp:202
-#: ../src/richtext/richtextstyledlg.cpp:204
+#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:200
 msgid "The available styles."
 msgstr "Os estilos disponíveis."
 
@@ -6889,12 +7047,12 @@ msgstr "A posição de tabulação."
 msgid "The bullet character."
 msgstr "O caracter do marcador."
 
-#: ../src/richtext/richtextsymboldlg.cpp:443
-#: ../src/richtext/richtextsymboldlg.cpp:445
+#: ../src/richtext/richtextsymboldlg.cpp:440
+#: ../src/richtext/richtextsymboldlg.cpp:442
 msgid "The character code."
 msgstr "Código do caracter."
 
-#: ../src/common/fontmap.cpp:203
+#: ../src/common/fontmap.cpp:200
 #, c-format
 msgid ""
 "The charset '%s' is unknown. You may select\n"
@@ -6905,7 +7063,7 @@ msgstr ""
 "outro conjunto de caracteres para substituir, ou escolher\n"
 "[Cancelar] se não puder ser trocado"
 
-#: ../src/msw/ole/dataobj.cpp:394
+#: ../src/msw/ole/dataobj.cpp:402
 #, c-format
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "O formato da área de transferência '%d' não existe."
@@ -6915,7 +7073,7 @@ msgstr "O formato da área de transferência '%d' não existe."
 msgid "The default style for the next paragraph."
 msgstr "O estilo pré-definido para o próximo parágrafo."
 
-#: ../src/generic/dirdlgg.cpp:202
+#: ../src/generic/dirdlgg.cpp:199
 #, c-format
 msgid ""
 "The directory '%s' does not exist\n"
@@ -6924,7 +7082,7 @@ msgstr ""
 "O directório '%s' não existe\n"
 "Prtende criá-lo agora?"
 
-#: ../src/html/htmprint.cpp:271
+#: ../src/html/htmprint.cpp:283
 #, c-format
 msgid ""
 "The document \"%s\" doesn't fit on the page horizontally and will be "
@@ -6933,7 +7091,7 @@ msgid ""
 "Would you like to proceed with printing it nevertheless?"
 msgstr ""
 
-#: ../src/common/docview.cpp:1202
+#: ../src/common/docview.cpp:1196
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -6942,36 +7100,37 @@ msgstr ""
 "O ficheiro '%s' não existe e não pode ser aberto.\n"
 "Este foi removido da lista de ficheiros usados mais recentemente."
 
-#: ../src/richtext/richtextindentspage.cpp:208
-#: ../src/richtext/richtextindentspage.cpp:210
 #: ../src/richtext/richtextliststylepage.cpp:394
 #: ../src/richtext/richtextliststylepage.cpp:396
+#: ../src/richtext/richtextindentspage.cpp:208
+#: ../src/richtext/richtextindentspage.cpp:210
 msgid "The first line indent."
 msgstr "A indentação da primeira linha."
 
-#: ../src/gtk/utilsgtk.cpp:481
-msgid "The following standard GTK+ options are also supported:\n"
-msgstr ""
+#: ../src/generic/dbgrptg.cpp:318
+#, fuzzy
+msgid "The following debug report will be generated\n"
+msgstr "*** Foi gerado um relatório de depuração de erros\n"
 
-#: ../src/generic/fontdlgg.cpp:414 ../src/generic/fontdlgg.cpp:416
+#: ../src/generic/fontdlgg.cpp:411 ../src/generic/fontdlgg.cpp:413
 msgid "The font colour."
 msgstr "A cor da fonte."
 
-#: ../src/generic/fontdlgg.cpp:375 ../src/generic/fontdlgg.cpp:377
+#: ../src/generic/fontdlgg.cpp:371 ../src/generic/fontdlgg.cpp:373
 msgid "The font family."
 msgstr "A família da fonte."
 
-#: ../src/richtext/richtextsymboldlg.cpp:405
-#: ../src/richtext/richtextsymboldlg.cpp:407
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "The font from which to take the symbol."
 msgstr "A fonte de onde se retira o símbolo."
 
-#: ../src/generic/fontdlgg.cpp:427 ../src/generic/fontdlgg.cpp:429
-#: ../src/generic/fontdlgg.cpp:434 ../src/generic/fontdlgg.cpp:436
+#: ../src/generic/fontdlgg.cpp:424 ../src/generic/fontdlgg.cpp:426
+#: ../src/generic/fontdlgg.cpp:430 ../src/generic/fontdlgg.cpp:432
 msgid "The font point size."
 msgstr "O tamanho do ponto da fonte."
 
-#: ../src/osx/carbon/fontdlg.cpp:343 ../src/osx/carbon/fontdlg.cpp:345
+#: ../src/osx/carbon/fontdlg.cpp:340 ../src/osx/carbon/fontdlg.cpp:342
 msgid "The font size in points."
 msgstr "O tamanho da fonte em pontos."
 
@@ -6981,15 +7140,15 @@ msgstr "O tamanho da fonte em pontos."
 msgid "The font size units, points or pixels."
 msgstr "O tamanho da fonte em pontos."
 
-#: ../src/generic/fontdlgg.cpp:386 ../src/generic/fontdlgg.cpp:388
+#: ../src/generic/fontdlgg.cpp:382 ../src/generic/fontdlgg.cpp:384
 msgid "The font style."
 msgstr "O estilo da fonte."
 
-#: ../src/generic/fontdlgg.cpp:397 ../src/generic/fontdlgg.cpp:399
+#: ../src/generic/fontdlgg.cpp:393 ../src/generic/fontdlgg.cpp:395
 msgid "The font weight."
 msgstr "O peso da fonte."
 
-#: ../src/common/docview.cpp:1483
+#: ../src/common/docview.cpp:1477
 #, fuzzy, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Não foi possível criar o directório '%s'"
@@ -7000,10 +7159,10 @@ msgstr "Não foi possível criar o directório '%s'"
 msgid "The horizontal offset."
 msgstr "Dispor &Horizontalmente"
 
-#: ../src/richtext/richtextindentspage.cpp:199
-#: ../src/richtext/richtextindentspage.cpp:201
 #: ../src/richtext/richtextliststylepage.cpp:385
 #: ../src/richtext/richtextliststylepage.cpp:387
+#: ../src/richtext/richtextindentspage.cpp:199
+#: ../src/richtext/richtextindentspage.cpp:201
 msgid "The left indent."
 msgstr "A indentação à esquerda."
 
@@ -7027,10 +7186,10 @@ msgstr "O tamanho do ponto da fonte."
 msgid "The left position."
 msgstr "A posição de tabulação."
 
-#: ../src/richtext/richtextindentspage.cpp:288
-#: ../src/richtext/richtextindentspage.cpp:290
 #: ../src/richtext/richtextliststylepage.cpp:462
 #: ../src/richtext/richtextliststylepage.cpp:464
+#: ../src/richtext/richtextindentspage.cpp:288
+#: ../src/richtext/richtextindentspage.cpp:290
 msgid "The line spacing."
 msgstr "O espaçamento de linha."
 
@@ -7039,7 +7198,7 @@ msgstr "O espaçamento de linha."
 msgid "The list item number."
 msgstr "O número de item da lista."
 
-#: ../src/msw/ole/automtn.cpp:664
+#: ../src/msw/ole/automtn.cpp:655
 msgid "The locale ID is unknown."
 msgstr "A Id. do local é desconhecida."
 
@@ -7085,20 +7244,20 @@ msgstr "O peso da fonte."
 msgid "The outline level."
 msgstr "A antevisão do estilo."
 
-#: ../src/common/log.cpp:277
+#: ../src/common/log.cpp:296
 #, fuzzy, c-format
 msgid "The previous message repeated %u time."
 msgid_plural "The previous message repeated %u times."
 msgstr[0] "A mensagem anterior repetida uma vez."
 msgstr[1] "A mensagem anterior repetida %lu vezes."
 
-#: ../src/common/log.cpp:270
+#: ../src/common/log.cpp:289
 #, fuzzy
 msgid "The previous message repeated once."
 msgstr "A mensagem anterior repetida uma vez."
 
-#: ../src/richtext/richtextsymboldlg.cpp:462
-#: ../src/richtext/richtextsymboldlg.cpp:464
+#: ../src/richtext/richtextsymboldlg.cpp:459
+#: ../src/richtext/richtextsymboldlg.cpp:461
 msgid "The range to show."
 msgstr "O alcance a mostrar."
 
@@ -7112,15 +7271,15 @@ msgstr ""
 "informação privada,\n"
 "por favor desmarque-os e eles serão removidos do relatório.\n"
 
-#: ../src/common/cmdline.cpp:1254
+#: ../src/common/cmdline.cpp:1250
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "O parâmetro requerido '%s' não foi especificado."
 
-#: ../src/richtext/richtextindentspage.cpp:217
-#: ../src/richtext/richtextindentspage.cpp:219
 #: ../src/richtext/richtextliststylepage.cpp:403
 #: ../src/richtext/richtextliststylepage.cpp:405
+#: ../src/richtext/richtextindentspage.cpp:217
+#: ../src/richtext/richtextindentspage.cpp:219
 msgid "The right indent."
 msgstr "A indentação à direita."
 
@@ -7165,16 +7324,16 @@ msgstr ""
 msgid "The shadow spread."
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:267
 #: ../src/richtext/richtextliststylepage.cpp:439
 #: ../src/richtext/richtextliststylepage.cpp:441
+#: ../src/richtext/richtextindentspage.cpp:267
 msgid "The spacing after the paragraph."
 msgstr "O espaçamento depois do parágrafo."
 
-#: ../src/richtext/richtextindentspage.cpp:257
-#: ../src/richtext/richtextindentspage.cpp:259
 #: ../src/richtext/richtextliststylepage.cpp:430
 #: ../src/richtext/richtextliststylepage.cpp:432
+#: ../src/richtext/richtextindentspage.cpp:257
+#: ../src/richtext/richtextindentspage.cpp:259
 msgid "The spacing before the paragraph."
 msgstr "O espaçamento antes do parágrafo."
 
@@ -7188,12 +7347,12 @@ msgstr "O nome do estilo."
 msgid "The style on which this style is based."
 msgstr "O estilo do qual este estilo é baseado."
 
-#: ../src/richtext/richtextstyledlg.cpp:214
-#: ../src/richtext/richtextstyledlg.cpp:216
+#: ../src/richtext/richtextstyledlg.cpp:210
+#: ../src/richtext/richtextstyledlg.cpp:212
 msgid "The style preview."
 msgstr "A antevisão do estilo."
 
-#: ../src/msw/ole/automtn.cpp:680
+#: ../src/msw/ole/automtn.cpp:671
 msgid "The system cannot find the file specified."
 msgstr "O sistema não consegue encontrar o ficheiro indicado."
 
@@ -7206,7 +7365,7 @@ msgstr "A posição de tabulação."
 msgid "The tab positions."
 msgstr "As posições de tabulação."
 
-#: ../src/richtext/richtextctrl.cpp:3098
+#: ../src/richtext/richtextctrl.cpp:3099
 msgid "The text couldn't be saved."
 msgstr "O texto não pode ser gravado."
 
@@ -7230,7 +7389,7 @@ msgstr "O tamanho do ponto da fonte."
 msgid "The top position."
 msgstr "A posição de tabulação."
 
-#: ../src/common/cmdline.cpp:1232
+#: ../src/common/cmdline.cpp:1228
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "O valor para a opção '%s' tem de ser especificado."
@@ -7240,7 +7399,7 @@ msgstr "O valor para a opção '%s' tem de ser especificado."
 msgid "The value of the corner radius."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:433
+#: ../src/msw/dialup.cpp:427
 #, fuzzy, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -7256,35 +7415,43 @@ msgstr ""
 msgid "The vertical offset."
 msgstr "Não foi possível inicia a impressão."
 
-#: ../src/richtext/richtextprint.cpp:619 ../src/html/htmprint.cpp:745
+#: ../src/html/htmprint.cpp:749 ../src/richtext/richtextprint.cpp:615
 msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr ""
 "Houve um problema durante a configuração da página: poderá necessitar de "
 "definir uma impressora pré-definida."
 
-#: ../src/html/htmprint.cpp:255
+#: ../src/html/htmprint.cpp:267
 msgid ""
 "This document doesn't fit on the page horizontally and will be truncated "
 "when it is printed."
 msgstr ""
 
-#: ../src/common/image.cpp:2854
+#: ../src/common/image.cpp:2963
 #, fuzzy, c-format
 msgid "This is not a %s."
 msgstr "PCX: este não é um ficheiro PCX."
 
-#: ../src/common/wincmn.cpp:1653
+#: ../src/common/wincmn.cpp:1654
 msgid "This platform does not support background transparency."
 msgstr ""
 
-#: ../src/gtk/window.cpp:4660
+#: ../src/gtk/window.cpp:5664
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
 
-#: ../src/msw/thread.cpp:1240
+#: ../src/gtk/glcanvas.cpp:176
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/msw/thread.cpp:1246
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -7292,13 +7459,13 @@ msgstr ""
 "Falhou a inicialização do módulo da thread: não foi possível armazenar o "
 "valor no armazenamento local da thread"
 
-#: ../src/unix/threadpsx.cpp:1794
+#: ../src/unix/threadpsx.cpp:1843
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 "Falhou a inicialização do módulo da thread: falhou a criação da chave da "
 "thread"
 
-#: ../src/msw/thread.cpp:1228
+#: ../src/msw/thread.cpp:1234
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -7306,85 +7473,85 @@ msgstr ""
 "Falhou a inicialização do módulo da thread: impossível alocar índice no "
 "armazenamento local da thread"
 
-#: ../src/unix/threadpsx.cpp:1043
+#: ../src/unix/threadpsx.cpp:1061
 msgid "Thread priority setting is ignored."
 msgstr "A definição de prioridade da thread é ignorada."
 
-#: ../src/msw/mdi.cpp:176
+#: ../src/msw/mdi.cpp:171
 msgid "Tile &Horizontally"
 msgstr "Dispor &Horizontalmente"
 
-#: ../src/msw/mdi.cpp:177
+#: ../src/msw/mdi.cpp:172
 msgid "Tile &Vertically"
 msgstr "Dispor &Verticalmente"
 
-#: ../src/common/ftp.cpp:200
+#: ../src/common/ftp.cpp:197
 msgid "Timeout while waiting for FTP server to connect, try passive mode."
 msgstr ""
 "Tempo excedido enquanto esperava a ligação do servidor FTP, tente o modo "
 "passivo."
 
-#: ../src/generic/tipdlg.cpp:201
+#: ../src/generic/tipdlg.cpp:198
 msgid "Tip of the Day"
 msgstr "Dica do Dia"
 
-#: ../src/generic/tipdlg.cpp:140
+#: ../src/generic/tipdlg.cpp:137
 msgid "Tips not available, sorry!"
 msgstr "Dicas não disponíveis, desculpe!"
 
-#: ../src/generic/prntdlgg.cpp:242
+#: ../src/generic/prntdlgg.cpp:235
 msgid "To:"
 msgstr "Para:"
 
-#: ../src/richtext/richtextbuffer.cpp:8363
+#: ../src/richtext/richtextbuffer.cpp:8361
 msgid "Too many EndStyle calls!"
 msgstr "Demasiadas chamadas EndStyle!"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:891
+#: ../src/propgrid/advprops.cpp:792
 msgid "Tooltip"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:892
+#: ../src/propgrid/advprops.cpp:793
 msgid "TooltipText"
 msgstr ""
 
-#: ../src/richtext/richtextsizepage.cpp:286
-#: ../src/richtext/richtextsizepage.cpp:290 ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197 ../src/richtext/richtextsizepage.cpp:286
+#: ../src/richtext/richtextsizepage.cpp:290
 #, fuzzy
 msgid "Top"
 msgstr "Para:"
 
-#: ../src/generic/prntdlgg.cpp:881
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Top margin (mm):"
 msgstr "Margem de topo (mm):"
 
-#: ../src/generic/aboutdlgg.cpp:79
+#: ../src/generic/aboutdlgg.cpp:76
 msgid "Translations by "
 msgstr "Traduções por "
 
-#: ../src/generic/aboutdlgg.cpp:188
+#: ../src/generic/aboutdlgg.cpp:185
 #, fuzzy
 msgid "Translators"
 msgstr "Traduções por "
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:211
+#: ../src/propgrid/propgrid.cpp:192
 msgid "True"
 msgstr "Verdadeiro"
 
-#: ../src/common/fs_mem.cpp:227
+#: ../src/common/fs_mem.cpp:222
 #, c-format
 msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
 msgstr ""
 "A Tentar remover o ficheiro '%s' da memória VFS, mas não foi carregado!"
 
-#: ../src/common/fmapbase.cpp:156
+#: ../src/common/fmapbase.cpp:153
 msgid "Turkish (ISO-8859-9)"
 msgstr "Turco (ISO-8859-9)"
 
-#: ../src/generic/filectrlg.cpp:426
+#: ../src/generic/filectrlg.cpp:422
 msgid "Type"
 msgstr "Tipo"
 
@@ -7398,36 +7565,36 @@ msgstr "Escreva o nome da fonte."
 msgid "Type a size in points."
 msgstr "Escreva um tamanho em pontos."
 
-#: ../src/msw/ole/automtn.cpp:676
+#: ../src/msw/ole/automtn.cpp:667
 #, c-format
 msgid "Type mismatch in argument %u."
 msgstr ""
 
-#: ../src/common/xtixml.cpp:356 ../src/common/xtixml.cpp:509
-#: ../src/common/xtistrm.cpp:318
+#: ../src/common/xtixml.cpp:352 ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315
 msgid "Type must have enum - long conversion"
 msgstr "Tipo deve ter conversão enum - long"
 
-#: ../src/propgrid/propgridiface.cpp:401
+#: ../src/propgrid/propgridiface.cpp:385
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
 "\"%s\"."
 msgstr ""
 
-#: ../src/common/paper.cpp:133
+#: ../src/common/paper.cpp:130
 msgid "US Std Fanfold, 14 7/8 x 11 in"
 msgstr "US Std Fanfold, 14 7/8 x 11 pol."
 
-#: ../src/common/fmapbase.cpp:196
+#: ../src/common/fmapbase.cpp:193
 msgid "US-ASCII"
 msgstr "US-ASCII"
 
-#: ../src/unix/fswatcher_inotify.cpp:109
+#: ../src/unix/fswatcher_inotify.cpp:106
 msgid "Unable to add inotify watch"
 msgstr ""
 
-#: ../src/unix/fswatcher_kqueue.cpp:136
+#: ../src/unix/fswatcher_kqueue.cpp:153
 msgid "Unable to add kqueue watch"
 msgstr ""
 
@@ -7440,7 +7607,7 @@ msgstr ""
 msgid "Unable to close I/O completion port handle"
 msgstr "Falha ao fechar manuseador de ficheiro"
 
-#: ../src/unix/fswatcher_inotify.cpp:97
+#: ../src/unix/fswatcher_inotify.cpp:94
 #, fuzzy
 msgid "Unable to close inotify instance"
 msgstr "Falha ao fechar manuseador de ficheiro"
@@ -7460,17 +7627,17 @@ msgstr "Falha ao fechar manuseador de ficheiro"
 msgid "Unable to create I/O completion port"
 msgstr "Não foi possível criar TextEncodingConverter"
 
-#: ../src/msw/fswatcher.cpp:84
+#: ../src/msw/fswatcher.cpp:81
 #, fuzzy
 msgid "Unable to create IOCP worker thread"
 msgstr "Não foi possível criar TextEncodingConverter"
 
-#: ../src/unix/fswatcher_inotify.cpp:74
+#: ../src/unix/fswatcher_inotify.cpp:71
 #, fuzzy
 msgid "Unable to create inotify instance"
 msgstr "Não foi possível criar TextEncodingConverter"
 
-#: ../src/unix/fswatcher_kqueue.cpp:97
+#: ../src/unix/fswatcher_kqueue.cpp:114
 #, fuzzy
 msgid "Unable to create kqueue instance"
 msgstr "Não foi possível criar TextEncodingConverter"
@@ -7479,11 +7646,11 @@ msgstr "Não foi possível criar TextEncodingConverter"
 msgid "Unable to dequeue completion packet"
 msgstr ""
 
-#: ../src/unix/fswatcher_kqueue.cpp:185
+#: ../src/unix/fswatcher_kqueue.cpp:202
 msgid "Unable to get events from kqueue"
 msgstr ""
 
-#: ../src/gtk/app.cpp:435
+#: ../src/gtk/app.cpp:431
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr ""
 
@@ -7492,12 +7659,12 @@ msgstr ""
 msgid "Unable to open path '%s'"
 msgstr "Falha na abertura do arquivo CHM '%s'."
 
-#: ../src/html/htmlwin.cpp:583
+#: ../src/html/htmlwin.cpp:586
 #, c-format
 msgid "Unable to open requested HTML document: %s"
 msgstr "Não foi possível abrir documento HTML pretendido: %s"
 
-#: ../src/unix/sound.cpp:368
+#: ../src/unix/sound.cpp:365
 msgid "Unable to play sound asynchronously."
 msgstr "Não foi possível reproduzir som assincronamente."
 
@@ -7505,64 +7672,64 @@ msgstr "Não foi possível reproduzir som assincronamente."
 msgid "Unable to post completion status"
 msgstr ""
 
-#: ../src/unix/fswatcher_inotify.cpp:556
+#: ../src/unix/fswatcher_inotify.cpp:553
 #, fuzzy
 msgid "Unable to read from inotify descriptor"
 msgstr "não foi possível ler do descritor do ficheiro %d"
 
-#: ../src/unix/fswatcher_inotify.cpp:141
+#: ../src/unix/fswatcher_inotify.cpp:138
 #, fuzzy, c-format
 msgid "Unable to remove inotify watch %i"
 msgstr "Não foi possível criar TextEncodingConverter"
 
-#: ../src/unix/fswatcher_kqueue.cpp:153
+#: ../src/unix/fswatcher_kqueue.cpp:170
 msgid "Unable to remove kqueue watch"
 msgstr ""
 
-#: ../src/msw/fswatcher.cpp:168
+#: ../src/msw/fswatcher.cpp:165
 #, fuzzy, c-format
 msgid "Unable to set up watch for '%s'"
 msgstr "Falha ao tocar no ficheiro '%s'"
 
-#: ../src/msw/fswatcher.cpp:91
+#: ../src/msw/fswatcher.cpp:88
 msgid "Unable to start IOCP worker thread"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:201
+#: ../src/common/stockitem.cpp:198
 msgid "Undelete"
 msgstr "Recuperar"
 
-#: ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199
 #, fuzzy
 msgid "Underline"
 msgstr "S&ublinhado"
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/richtext/richtextfontpage.cpp:359 ../src/osx/carbon/fontdlg.cpp:370
-#: ../src/propgrid/advprops.cpp:690
+#: ../src/osx/carbon/fontdlg.cpp:367 ../src/propgrid/advprops.cpp:600
+#: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Sublinhado"
 
-#: ../src/common/stockitem.cpp:203 ../src/stc/stc_i18n.cpp:15
+#: ../src/common/stockitem.cpp:200 ../src/stc/stc_i18n.cpp:15
 #, fuzzy
 msgid "Undo"
 msgstr "&Desfazer"
 
-#: ../src/common/stockitem.cpp:265
+#: ../src/common/stockitem.cpp:263
 msgid "Undo last action"
 msgstr "Desfazer última acção"
 
-#: ../src/common/cmdline.cpp:1029
+#: ../src/common/cmdline.cpp:1025
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Caracteres inesperados a seguir à opção '%s'."
 
-#: ../src/unix/fswatcher_inotify.cpp:274
+#: ../src/unix/fswatcher_inotify.cpp:271
 #, c-format
 msgid "Unexpected event for \"%s\": no matching watch descriptor."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1195
+#: ../src/common/cmdline.cpp:1191
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Parâmetro inesperado '%s'"
@@ -7571,50 +7738,50 @@ msgstr "Parâmetro inesperado '%s'"
 msgid "Unexpectedly new I/O completion port was created"
 msgstr ""
 
-#: ../src/msw/fswatcher.cpp:70
+#: ../src/msw/fswatcher.cpp:67
 #, fuzzy
 msgid "Ungraceful worker thread termination"
 msgstr "Não é possível esperar pela terminação da thread"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:460
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:456
+#: ../src/richtext/richtextsymboldlg.cpp:457
+#: ../src/richtext/richtextsymboldlg.cpp:458
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../src/common/fmapbase.cpp:185 ../src/common/fmapbase.cpp:191
+#: ../src/common/fmapbase.cpp:182 ../src/common/fmapbase.cpp:188
 msgid "Unicode 16 bit (UTF-16)"
 msgstr "Unicode 16 bit (UTF-16)"
 
-#: ../src/common/fmapbase.cpp:190
+#: ../src/common/fmapbase.cpp:187
 msgid "Unicode 16 bit Big Endian (UTF-16BE)"
 msgstr "Unicode 16 bit Big Endian (UTF-16BE)"
 
-#: ../src/common/fmapbase.cpp:186
+#: ../src/common/fmapbase.cpp:183
 msgid "Unicode 16 bit Little Endian (UTF-16LE)"
 msgstr "Unicode 16 bit Little Endian (UTF-16LE)"
 
-#: ../src/common/fmapbase.cpp:187 ../src/common/fmapbase.cpp:193
+#: ../src/common/fmapbase.cpp:184 ../src/common/fmapbase.cpp:190
 msgid "Unicode 32 bit (UTF-32)"
 msgstr "Unicode 32 bit (UTF-32)"
 
-#: ../src/common/fmapbase.cpp:192
+#: ../src/common/fmapbase.cpp:189
 msgid "Unicode 32 bit Big Endian (UTF-32BE)"
 msgstr "Unicode 32 bit Big Endian (UTF-32BE)"
 
-#: ../src/common/fmapbase.cpp:188
+#: ../src/common/fmapbase.cpp:185
 msgid "Unicode 32 bit Little Endian (UTF-32LE)"
 msgstr "Unicode 32 bit Little Endian (UTF-32LE)"
 
-#: ../src/common/fmapbase.cpp:182
+#: ../src/common/fmapbase.cpp:179
 msgid "Unicode 7 bit (UTF-7)"
 msgstr "Unicode 7 bit (UTF-7)"
 
-#: ../src/common/fmapbase.cpp:183
+#: ../src/common/fmapbase.cpp:180
 msgid "Unicode 8 bit (UTF-8)"
 msgstr "Unicode 8 bit (UTF-8)"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 #, fuzzy
 msgid "Unindent"
 msgstr "&Desindentar"
@@ -7776,100 +7943,105 @@ msgstr "Não é possível esperar pela terminação da thread."
 msgid "Units for this value."
 msgstr "Não é possível esperar pela terminação da thread."
 
-#: ../src/generic/progdlgg.cpp:353 ../src/generic/progdlgg.cpp:622
+#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
 msgid "Unknown"
 msgstr "Desconhecido"
 
-#: ../src/msw/dde.cpp:1174
+#: ../src/msw/dde.cpp:1238
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Erro DDE desconhecido %08x"
 
-#: ../src/common/xtistrm.cpp:410
+#: ../src/common/xtistrm.cpp:407
 msgid "Unknown Object passed to GetObjectClassInfo"
 msgstr "Objecto desconhecido passado para GetObjectClassInfo"
 
-#: ../src/common/imagpng.cpp:366
+#: ../src/common/imagpng.cpp:383
 #, fuzzy, c-format
 msgid "Unknown PNG resolution unit %d"
 msgstr "Opção desconhecida '%s'"
 
-#: ../src/common/xtixml.cpp:327
+#: ../src/common/xtixml.cpp:323
 #, fuzzy, c-format
 msgid "Unknown Property %s"
 msgstr "Propriedade desconhecida %s"
 
-#: ../src/common/imagtiff.cpp:529
+#: ../src/common/imagtiff.cpp:526
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr ""
 
-#: ../src/unix/dlunix.cpp:160
+#: ../src/propgrid/props.cpp:155
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/unix/dlunix.cpp:118
 msgid "Unknown dynamic library error"
 msgstr "Erro desconhecido de livraria dinâmica"
 
-#: ../src/common/fmapbase.cpp:810
+#: ../src/common/fmapbase.cpp:806
 #, c-format
 msgid "Unknown encoding (%d)"
 msgstr "Codificação desconhecida (%d)"
 
-#: ../src/msw/ole/automtn.cpp:688
+#: ../src/msw/ole/automtn.cpp:679
 #, fuzzy, c-format
 msgid "Unknown error %08x"
 msgstr "Erro DDE desconhecido %08x"
 
-#: ../src/msw/ole/automtn.cpp:647
+#: ../src/msw/ole/automtn.cpp:638
 #, fuzzy
 msgid "Unknown exception"
 msgstr "Opção desconhecida '%s'"
 
-#: ../src/common/image.cpp:2839
+#: ../src/common/image.cpp:2942
 #, fuzzy
 msgid "Unknown image data format."
 msgstr "erro no formato do dado"
 
-#: ../src/common/cmdline.cpp:914
+#: ../src/common/cmdline.cpp:910
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Opção longa desconhecida '%s'"
 
-#: ../src/msw/ole/automtn.cpp:631
+#: ../src/msw/ole/automtn.cpp:622
 msgid "Unknown name or named argument."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:929 ../src/common/cmdline.cpp:951
+#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Opção desconhecida '%s'"
 
-#: ../src/common/mimecmn.cpp:225
+#: ../src/common/mimecmn.cpp:221
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "Correspondência não encontrada de '{' numa entrada do tipo mime %s."
 
-#: ../src/common/cmdproc.cpp:262 ../src/common/cmdproc.cpp:288
-#: ../src/common/cmdproc.cpp:308
+#: ../src/common/cmdproc.cpp:255 ../src/common/cmdproc.cpp:281
+#: ../src/common/cmdproc.cpp:301
 msgid "Unnamed command"
 msgstr "Comando não nomeado"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:413
+#: ../src/propgrid/propgrid.cpp:392
 #, fuzzy
 msgid "Unspecified"
 msgstr "Justificado"
 
-#: ../src/msw/clipbrd.cpp:311
+#: ../src/msw/clipbrd.cpp:325
 msgid "Unsupported clipboard format."
 msgstr "Formato da área de transferência não suportado."
 
-#: ../src/common/appcmn.cpp:256
+#: ../src/common/appcmn.cpp:277
 #, c-format
 msgid "Unsupported theme '%s'."
 msgstr "Tema não suportado '%s'."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:205
-#: ../src/common/accelcmn.cpp:63
+#: ../src/common/stockitem.cpp:202 ../src/common/accelcmn.cpp:60
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Up"
 msgstr "Cima"
 
@@ -7883,7 +8055,7 @@ msgstr "Letras maiúsculas"
 msgid "Upper case roman numerals"
 msgstr "Números romanos em maiúsculas"
 
-#: ../src/common/cmdline.cpp:1326
+#: ../src/common/cmdline.cpp:1322
 #, c-format
 msgid "Usage: %s"
 msgstr "Utilização: %s"
@@ -7892,38 +8064,47 @@ msgstr "Utilização: %s"
 msgid "Use &shadow"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:169
-#: ../src/richtext/richtextindentspage.cpp:171
 #: ../src/richtext/richtextliststylepage.cpp:358
 #: ../src/richtext/richtextliststylepage.cpp:360
+#: ../src/richtext/richtextindentspage.cpp:169
+#: ../src/richtext/richtextindentspage.cpp:171
 msgid "Use the current alignment setting."
 msgstr "Utilizar a definição atual de alinhamento."
 
-#: ../src/common/valtext.cpp:179
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/gtk/font.cpp:552
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/common/valtext.cpp:142
 msgid "Validation conflict"
 msgstr "Conflito de validação"
 
-#: ../src/propgrid/manager.cpp:238
+#: ../src/propgrid/manager.cpp:224
 msgid "Value"
 msgstr "Valor"
 
-#: ../src/propgrid/props.cpp:386 ../src/propgrid/props.cpp:500
+#: ../src/propgrid/props.cpp:309
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "O valor deve ser %s ou superior."
 
-#: ../src/propgrid/props.cpp:417 ../src/propgrid/props.cpp:531
+#: ../src/propgrid/props.cpp:336
 #, c-format
 msgid "Value must be %s or less."
 msgstr "O valor deve ser %s ou inferior."
 
-#: ../src/propgrid/props.cpp:393 ../src/propgrid/props.cpp:424
-#: ../src/propgrid/props.cpp:507 ../src/propgrid/props.cpp:538
+#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
 #, fuzzy, c-format
 msgid "Value must be between %s and %s."
 msgstr "Introduza um número de página entre %d e %d:"
 
-#: ../src/generic/aboutdlgg.cpp:128
+#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
 #, fuzzy
 msgid "Version "
 msgstr " Versão "
@@ -7934,25 +8115,32 @@ msgstr " Versão "
 msgid "Vertical alignment."
 msgstr "Não foi possível inicia a impressão."
 
-#: ../src/generic/filedlgg.cpp:202
+#: ../src/generic/filedlgg.cpp:199
 msgid "View files as a detailed view"
 msgstr "Ver ficheiros como uma vista detalhada"
 
-#: ../src/generic/filedlgg.cpp:200
+#: ../src/generic/filedlgg.cpp:197
 msgid "View files as a list view"
 msgstr "Ver ficheiros como uma vista em lista"
 
-#: ../src/common/docview.cpp:1970
+#: ../src/common/docview.cpp:1975
 msgid "Views"
 msgstr "Vistas"
 
+#: ../src/gtk/app.cpp:348
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1777
+#: ../src/propgrid/advprops.cpp:1678
 msgid "Wait"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1779
+#: ../src/propgrid/advprops.cpp:1680
 msgid "Wait Arrow"
 msgstr ""
 
@@ -7961,254 +8149,251 @@ msgstr ""
 msgid "Waiting for IO on epoll descriptor %d failed"
 msgstr "Falha na espera do fim do subprocesso"
 
-#: ../src/common/log.cpp:223
+#: ../src/common/log.cpp:241
 msgid "Warning: "
 msgstr "Aviso: "
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1778
+#: ../src/propgrid/advprops.cpp:1679
 msgid "Watch"
 msgstr ""
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:685
+#: ../src/propgrid/advprops.cpp:595
 #, fuzzy
 msgid "Weight"
 msgstr "&Peso:"
 
-#: ../src/common/fmapbase.cpp:148
+#: ../src/common/fmapbase.cpp:145
 msgid "Western European (ISO-8859-1)"
 msgstr "Europa Ocidental (ISO-8859-1)"
 
-#: ../src/common/fmapbase.cpp:162
+#: ../src/common/fmapbase.cpp:159
 msgid "Western European with Euro (ISO-8859-15)"
 msgstr "Europa Ocidental com Euro (ISO-8859-15)"
 
-#: ../src/generic/fontdlgg.cpp:446 ../src/generic/fontdlgg.cpp:448
+#: ../src/generic/fontdlgg.cpp:443 ../src/generic/fontdlgg.cpp:445
 msgid "Whether the font is underlined."
 msgstr "Se a fonte está sublinhada."
 
-#: ../src/propgrid/advprops.cpp:1611
+#: ../src/propgrid/advprops.cpp:1517
 msgid "White"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:144
+#: ../src/generic/fdrepdlg.cpp:141
 msgid "Whole word"
 msgstr "Palavra completa"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:532
 msgid "Whole words only"
 msgstr "Apenas palavras completas"
 
-#: ../src/univ/themes/win32.cpp:1102
+#: ../src/univ/themes/win32.cpp:1099
 msgid "Win32 theme"
 msgstr "Tema Win32"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:893
+#: ../src/propgrid/advprops.cpp:794
 #, fuzzy
 msgid "Window"
 msgstr "&Janela"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:894
+#: ../src/propgrid/advprops.cpp:795
 #, fuzzy
 msgid "WindowFrame"
 msgstr "&Janela"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:895
+#: ../src/propgrid/advprops.cpp:796
 #, fuzzy
 msgid "WindowText"
 msgstr "&Janela"
 
-#: ../src/common/fmapbase.cpp:177
+#: ../src/common/fmapbase.cpp:174
 msgid "Windows Arabic (CP 1256)"
 msgstr "Árabe de Windows (CP 1256)"
 
-#: ../src/common/fmapbase.cpp:178
+#: ../src/common/fmapbase.cpp:175
 msgid "Windows Baltic (CP 1257)"
 msgstr "Báltico de Windows (CP 1257)"
 
-#: ../src/common/fmapbase.cpp:171
+#: ../src/common/fmapbase.cpp:168
 msgid "Windows Central European (CP 1250)"
 msgstr "Europeu Central de Windows (CP 1250)"
 
-#: ../src/common/fmapbase.cpp:168
+#: ../src/common/fmapbase.cpp:165
 #, fuzzy
 msgid "Windows Chinese Simplified (CP 936) or GB-2312"
 msgstr "Chinês Simplificado de Windows (CP 936)"
 
-#: ../src/common/fmapbase.cpp:170
+#: ../src/common/fmapbase.cpp:167
 #, fuzzy
 msgid "Windows Chinese Traditional (CP 950) or Big-5"
 msgstr "Chinês Tradicional de Windows (CP 950)"
 
-#: ../src/common/fmapbase.cpp:172
+#: ../src/common/fmapbase.cpp:169
 msgid "Windows Cyrillic (CP 1251)"
 msgstr "Cirílico de Windows (CP 1251)"
 
-#: ../src/common/fmapbase.cpp:174
+#: ../src/common/fmapbase.cpp:171
 msgid "Windows Greek (CP 1253)"
 msgstr "Grêgo de Windows (CP 1253)"
 
-#: ../src/common/fmapbase.cpp:176
+#: ../src/common/fmapbase.cpp:173
 msgid "Windows Hebrew (CP 1255)"
 msgstr "Hebreu de Windows (CP 1255)"
 
-#: ../src/common/fmapbase.cpp:167
+#: ../src/common/fmapbase.cpp:164
 #, fuzzy
 msgid "Windows Japanese (CP 932) or Shift-JIS"
 msgstr "Japonês de Windows (CP 932)"
 
-#: ../src/common/fmapbase.cpp:180
+#: ../src/common/fmapbase.cpp:177
 #, fuzzy
 msgid "Windows Johab (CP 1361)"
 msgstr "Árabe de Windows (CP 1256)"
 
-#: ../src/common/fmapbase.cpp:169
+#: ../src/common/fmapbase.cpp:166
 msgid "Windows Korean (CP 949)"
 msgstr "Coreano de Windows (CP 949)"
 
-#: ../src/common/fmapbase.cpp:166
+#: ../src/common/fmapbase.cpp:163
 msgid "Windows Thai (CP 874)"
 msgstr "Tailandês de Windows (CP 874)"
 
-#: ../src/common/fmapbase.cpp:175
+#: ../src/common/fmapbase.cpp:172
 msgid "Windows Turkish (CP 1254)"
 msgstr "Turco de Windows (CP 1254)"
 
-#: ../src/common/fmapbase.cpp:179
+#: ../src/common/fmapbase.cpp:176
 #, fuzzy
 msgid "Windows Vietnamese (CP 1258)"
 msgstr "Grêgo de Windows (CP 1253)"
 
-#: ../src/common/fmapbase.cpp:173
+#: ../src/common/fmapbase.cpp:170
 msgid "Windows Western European (CP 1252)"
 msgstr "Europeu Ocidental de Windows (CP 1252)"
 
-#: ../src/common/fmapbase.cpp:181
+#: ../src/common/fmapbase.cpp:178
 msgid "Windows/DOS OEM (CP 437)"
 msgstr "Windows/DOS OEM (CP 437)"
 
-#: ../src/common/fmapbase.cpp:165
+#: ../src/common/fmapbase.cpp:162
 #, fuzzy
 msgid "Windows/DOS OEM Cyrillic (CP 866)"
 msgstr "Cirílico de Windows (CP 1251)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:111
+#: ../src/common/accelcmn.cpp:109
 #, fuzzy
 msgid "Windows_Left"
 msgstr "Windows 95"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:113
+#: ../src/common/accelcmn.cpp:111
 #, fuzzy
 msgid "Windows_Menu"
 msgstr "Windows ME"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:112
+#: ../src/common/accelcmn.cpp:110
 #, fuzzy
 msgid "Windows_Right"
 msgstr "Windows 95"
 
-#: ../src/common/ffile.cpp:150
+#: ../src/common/ffile.cpp:149
 #, c-format
 msgid "Write error on file '%s'"
 msgstr "Erro de escrita no ficheiro '%s'"
 
-#: ../src/xml/xml.cpp:914
+#: ../src/xml/xml.cpp:925
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "XML erro de verificação gramatical: '%s' na linha %d"
 
-#: ../src/common/xpmdecod.cpp:796
+#: ../src/common/xpmdecod.cpp:794
 msgid "XPM: Malformed pixel data!"
 msgstr "XPM: Dados de pixeis mal formados!"
 
-#: ../src/common/xpmdecod.cpp:705
+#: ../src/common/xpmdecod.cpp:702
 #, c-format
 msgid "XPM: incorrect colour description in line %d"
 msgstr "XPM: descrição incorrecta de cor na linha %d"
 
-#: ../src/common/xpmdecod.cpp:680
+#: ../src/common/xpmdecod.cpp:677
 msgid "XPM: incorrect header format!"
 msgstr "XPM: formato de cabeçalho incorrecto!"
 
-#: ../src/common/xpmdecod.cpp:716 ../src/common/xpmdecod.cpp:725
+#: ../src/common/xpmdecod.cpp:714 ../src/common/xpmdecod.cpp:723
 #, c-format
 msgid "XPM: malformed colour definition '%s' at line %d!"
 msgstr "XPM: definição de cor '%s' mal formada na linha %d!"
 
-#: ../src/common/xpmdecod.cpp:755
+#: ../src/common/xpmdecod.cpp:753
 #, fuzzy
 msgid "XPM: no colors left to use for mask!"
 msgstr "XPM: formato de cabeçalho incorrecto!"
 
-#: ../src/common/xpmdecod.cpp:782
+#: ../src/common/xpmdecod.cpp:780
 #, c-format
 msgid "XPM: truncated image data at line %d!"
 msgstr "XPM: dados de imagem truncados na linha %d!"
 
-#: ../src/propgrid/advprops.cpp:1610
+#: ../src/propgrid/advprops.cpp:1516
 msgid "Yellow"
 msgstr ""
 
-#: ../include/wx/msgdlg.h:276 ../src/common/stockitem.cpp:206
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:203
 #: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Sim"
 
-#: ../src/osx/carbon/overlay.cpp:155
-msgid "You cannot Clear an overlay that is not inited"
-msgstr "Não pode Limpar uma sobreposição que não está inicializada"
-
-#: ../src/osx/carbon/overlay.cpp:107 ../src/dfb/overlay.cpp:61
-msgid "You cannot Init an overlay twice"
-msgstr "Não pode Inicializar uma sobreposição duas vezes"
-
-#: ../src/generic/dirdlgg.cpp:287
+#: ../src/generic/dirdlgg.cpp:284
 msgid "You cannot add a new directory to this section."
 msgstr "Não pode adicionar um novo directório a esta secção."
 
-#: ../src/propgrid/propgrid.cpp:3299
+#: ../src/propgrid/propgrid.cpp:3276
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr "Inseriu um valor inválido. Pressione ESC para cancelar a edição."
 
-#: ../src/common/stockitem.cpp:209
+#: ../src/osx/cocoa/menu.mm:286
+#, fuzzy
+msgid "Zoom"
+msgstr "Ampl&iar"
+
+#: ../src/common/stockitem.cpp:206
 msgid "Zoom &In"
 msgstr "Ampl&iar"
 
-#: ../src/common/stockitem.cpp:210
+#: ../src/common/stockitem.cpp:207
 msgid "Zoom &Out"
 msgstr "Red&uzir"
 
-#: ../src/common/stockitem.cpp:209 ../src/common/prntbase.cpp:1594
+#: ../src/common/stockitem.cpp:206 ../src/common/prntbase.cpp:1619
 #, fuzzy
 msgid "Zoom In"
 msgstr "Ampl&iar"
 
-#: ../src/common/stockitem.cpp:210 ../src/common/prntbase.cpp:1580
+#: ../src/common/stockitem.cpp:207 ../src/common/prntbase.cpp:1605
 #, fuzzy
 msgid "Zoom Out"
 msgstr "Red&uzir"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to &Fit"
 msgstr "Ampliar para &Caber"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 #, fuzzy
 msgid "Zoom to Fit"
 msgstr "Ampliar para &Caber"
 
-#: ../src/msw/dde.cpp:1141
+#: ../src/msw/dde.cpp:1205
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "uma aplicação DDEML criou uma condição de corrida prolongada."
 
-#: ../src/msw/dde.cpp:1129
+#: ../src/msw/dde.cpp:1193
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -8219,45 +8404,45 @@ msgstr ""
 "ou um identificador inválido instância\n"
 "foi passado a uma função DDEML."
 
-#: ../src/msw/dde.cpp:1147
+#: ../src/msw/dde.cpp:1211
 msgid "a client's attempt to establish a conversation has failed."
 msgstr ""
 "a tentativa por parte de um cliente de estabelecer uma conversação falhou."
 
-#: ../src/msw/dde.cpp:1144
+#: ../src/msw/dde.cpp:1208
 msgid "a memory allocation failed."
 msgstr "falhou uma alocação de memória."
 
-#: ../src/msw/dde.cpp:1138
+#: ../src/msw/dde.cpp:1202
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "falhou a validação de um parâmetro pelo DDEML."
 
-#: ../src/msw/dde.cpp:1120
+#: ../src/msw/dde.cpp:1184
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr ""
 "um pedido para uma transacção de conselho síncrona excedeu o tempo limite."
 
-#: ../src/msw/dde.cpp:1126
+#: ../src/msw/dde.cpp:1190
 msgid "a request for a synchronous data transaction has timed out."
 msgstr ""
 "um pedido para uma transacção de dados síncrona excedeu o tempo limite."
 
-#: ../src/msw/dde.cpp:1135
+#: ../src/msw/dde.cpp:1199
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr ""
 "um pedido para uma transacção de execução síncrona excedeu o tempo limite."
 
-#: ../src/msw/dde.cpp:1153
+#: ../src/msw/dde.cpp:1217
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr ""
 "um pedido para uma transacção de 'poke' síncrona excedeu o tempo limite."
 
-#: ../src/msw/dde.cpp:1168
+#: ../src/msw/dde.cpp:1232
 msgid "a request to end an advise transaction has timed out."
 msgstr ""
 "um pedido de término de uma transacção de conselho excedeu o tempo limite."
 
-#: ../src/msw/dde.cpp:1162
+#: ../src/msw/dde.cpp:1226
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -8267,15 +8452,15 @@ msgstr ""
 "que foi terminada pelo cliente, ou o servidor\n"
 "terminou antes do fim da transacção."
 
-#: ../src/msw/dde.cpp:1150
+#: ../src/msw/dde.cpp:1214
 msgid "a transaction failed."
 msgstr "falhou uma transacção."
 
-#: ../src/common/accelcmn.cpp:189
+#: ../src/common/accelcmn.cpp:188
 msgid "alt"
 msgstr "alt"
 
-#: ../src/msw/dde.cpp:1132
+#: ../src/msw/dde.cpp:1196
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -8287,15 +8472,15 @@ msgstr ""
 "ou uma aplicação inicaializada como APPCMD_CLIENTONLY tem\n"
 "tentado realizar transacções de servidor."
 
-#: ../src/msw/dde.cpp:1156
+#: ../src/msw/dde.cpp:1220
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "falha numa chamada interna à função PostMessage. "
 
-#: ../src/msw/dde.cpp:1165
+#: ../src/msw/dde.cpp:1229
 msgid "an internal error has occurred in the DDEML."
 msgstr "ocorreu um erro interno no DDEML."
 
-#: ../src/msw/dde.cpp:1171
+#: ../src/msw/dde.cpp:1235
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -8305,56 +8490,56 @@ msgstr ""
 "Uma vez que a aplicação retornou de uma chamada de um XTYP_XACT_COMPLETE,\n"
 "o identificador de transacção dessa chamada deixou de ser válido."
 
-#: ../src/common/zipstrm.cpp:1483
+#: ../src/common/zipstrm.cpp:1522
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "a assumir que este é um ficheiro zip multi-partes concatenado"
 
-#: ../src/common/fileconf.cpp:1847
+#: ../src/common/fileconf.cpp:1849
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "tentativa de alteração da chave imutável '%s' ignorada."
 
-#: ../src/html/chm.cpp:329
+#: ../src/html/chm.cpp:326
 msgid "bad arguments to library function"
 msgstr "argumentos inválidos a uma função da livraria"
 
-#: ../src/html/chm.cpp:341
+#: ../src/html/chm.cpp:338
 msgid "bad signature"
 msgstr "má assinatura"
 
-#: ../src/common/zipstrm.cpp:1918
+#: ../src/common/zipstrm.cpp:1988
 msgid "bad zipfile offset to entry"
 msgstr "mau offset de entrada de ficheiro zip"
 
-#: ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400
 msgid "binary"
 msgstr "binário"
 
-#: ../src/common/fontcmn.cpp:996
+#: ../src/common/fontcmn.cpp:1195
 msgid "bold"
 msgstr "negrito"
 
-#: ../src/msw/utils.cpp:1144
+#: ../src/msw/utils.cpp:1135
 #, fuzzy, c-format
 msgid "build %lu"
 msgstr "Windows XP (build %lu"
 
-#: ../src/common/ffile.cpp:75
+#: ../src/common/ffile.cpp:73
 #, c-format
 msgid "can't close file '%s'"
 msgstr "impossível fechar o ficheiro '%s'"
 
-#: ../src/common/file.cpp:245
+#: ../src/common/file.cpp:242
 #, c-format
 msgid "can't close file descriptor %d"
 msgstr "impossível fechar o descritor do ficheiro %d"
 
-#: ../src/common/file.cpp:586
+#: ../src/common/ffile.cpp:382 ../src/common/file.cpp:613
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "não é possível garantir as alterações ao ficheiro '%s'"
 
-#: ../src/common/file.cpp:178
+#: ../src/common/file.cpp:175
 #, c-format
 msgid "can't create file '%s'"
 msgstr "impossível criar o ficheiro '%s'"
@@ -8364,54 +8549,54 @@ msgstr "impossível criar o ficheiro '%s'"
 msgid "can't delete user configuration file '%s'"
 msgstr "não foi possível apagar o ficheiro de configuração do utilizador '%s'"
 
-#: ../src/common/file.cpp:495
+#: ../src/common/file.cpp:522
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr ""
 "impossível determinar se o fim do ficheiro foi alcançado no descritor %d"
 
-#: ../src/common/zipstrm.cpp:1692
+#: ../src/common/zipstrm.cpp:1747
 msgid "can't find central directory in zip"
 msgstr "não foi possível localizar o directório central no zip"
 
-#: ../src/common/file.cpp:465
+#: ../src/common/file.cpp:492
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr ""
 "Não foi possível encontrar o comprimento do ficheiro no descritor do "
 "ficheiro %d"
 
-#: ../src/msw/utils.cpp:341
+#: ../src/msw/utils.cpp:336
 msgid "can't find user's HOME, using current directory."
 msgstr ""
 "Não foi possível localizar a pasta pessoal do utilizador, a utilizar o "
 "directório atual."
 
-#: ../src/common/file.cpp:366
+#: ../src/common/file.cpp:407
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "Não foi possível escoar o descritor do ficheiro %d"
 
-#: ../src/common/file.cpp:422
+#: ../src/common/file.cpp:463
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "Não foi possível obter posição de pesquisa no descritor do ficheiro %d"
 
-#: ../src/common/fontmap.cpp:325
+#: ../src/common/fontmap.cpp:322
 msgid "can't load any font, aborting"
 msgstr "não foi possível carregar nenhuma fonte, a abortar"
 
-#: ../src/common/file.cpp:231 ../src/common/ffile.cpp:59
+#: ../src/common/ffile.cpp:57 ../src/common/file.cpp:228
 #, c-format
 msgid "can't open file '%s'"
 msgstr "impossível abrir ficheiro '%s'"
 
-#: ../src/common/fileconf.cpp:320
+#: ../src/common/fileconf.cpp:314
 #, c-format
 msgid "can't open global configuration file '%s'."
 msgstr "não foi possível abrir o ficheiro '%s' global de configuração."
 
-#: ../src/common/fileconf.cpp:336
+#: ../src/common/fileconf.cpp:330
 #, c-format
 msgid "can't open user configuration file '%s'."
 msgstr "não foi possível abrir o ficheiro '%s' de configuração do utilizador."
@@ -8420,40 +8605,40 @@ msgstr "não foi possível abrir o ficheiro '%s' de configuração do utilizador
 msgid "can't open user configuration file."
 msgstr "não foi possível abrir o ficheiro de configuração do utilizador."
 
-#: ../src/common/zipstrm.cpp:579
+#: ../src/common/zipstrm.cpp:572
 msgid "can't re-initialize zlib deflate stream"
 msgstr "não foi possível re-inicializar o 'zlib deflate stream'"
 
-#: ../src/common/zipstrm.cpp:604
+#: ../src/common/zipstrm.cpp:597
 msgid "can't re-initialize zlib inflate stream"
 msgstr "não foi possível re-inicializar o 'zlib inflate stream'"
 
-#: ../src/common/file.cpp:304
+#: ../src/common/file.cpp:345
 #, c-format
 msgid "can't read from file descriptor %d"
 msgstr "não foi possível ler do descritor do ficheiro %d"
 
-#: ../src/common/file.cpp:581
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:608
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "impossível remover ficheiro '%s'"
 
-#: ../src/common/file.cpp:598
+#: ../src/common/ffile.cpp:394 ../src/common/file.cpp:625
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "Não foi possível remover ficheiro temporário '%s'"
 
-#: ../src/common/file.cpp:408
+#: ../src/common/file.cpp:449
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "Não foi possível pesquisar no descritor de ficheiro %d"
 
-#: ../src/common/textfile.cpp:273
+#: ../src/common/textfile.cpp:161
 #, c-format
 msgid "can't write buffer '%s' to disk."
 msgstr "Não foi possível escrever o buffer '%s' para o disco."
 
-#: ../src/common/file.cpp:323
+#: ../src/common/file.cpp:364
 #, c-format
 msgid "can't write to file descriptor %d"
 msgstr "Não foi possível escrever no descritor de ficheiro %d"
@@ -8463,22 +8648,28 @@ msgid "can't write user configuration file."
 msgstr "Não foi possível gravar o ficheiro de configuração do utilizador."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:482 ../src/generic/datavgen.cpp:1261
+#: ../src/common/datavcmn.cpp:2064 ../src/generic/datavgen.cpp:1384
 msgid "checked"
 msgstr ""
 
-#: ../src/html/chm.cpp:345
+#: ../src/html/chm.cpp:342
 msgid "checksum error"
 msgstr "erro de checksum"
 
-#: ../src/common/tarstrm.cpp:820
+#: ../src/common/tarstrm.cpp:814
 msgid "checksum failure reading tar header block"
 msgstr "falha de checksum a ler bloco de cabeçalho tar"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:226
-#: ../src/richtext/richtextbackgroundpage.cpp:249
-#: ../src/richtext/richtextbackgroundpage.cpp:289
-#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
 #: ../src/richtext/richtextborderspage.cpp:254
 #: ../src/richtext/richtextborderspage.cpp:288
 #: ../src/richtext/richtextborderspage.cpp:322
@@ -8496,105 +8687,128 @@ msgstr "falha de checksum a ler bloco de cabeçalho tar"
 #: ../src/richtext/richtextmarginspage.cpp:340
 #: ../src/richtext/richtextmarginspage.cpp:363
 #: ../src/richtext/richtextmarginspage.cpp:388
-#: ../src/richtext/richtextsizepage.cpp:339
-#: ../src/richtext/richtextsizepage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:400
-#: ../src/richtext/richtextsizepage.cpp:427
-#: ../src/richtext/richtextsizepage.cpp:454
-#: ../src/richtext/richtextsizepage.cpp:481
-#: ../src/richtext/richtextsizepage.cpp:555
-#: ../src/richtext/richtextsizepage.cpp:590
-#: ../src/richtext/richtextsizepage.cpp:625
-#: ../src/richtext/richtextsizepage.cpp:660
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
 msgid "cm"
 msgstr "cm"
 
-#: ../src/html/chm.cpp:347
+#: ../src/html/chm.cpp:344
 msgid "compression error"
 msgstr "erro de compressão"
 
-#: ../src/common/regex.cpp:236
+#: ../src/common/regex.cpp:233
 msgid "conversion to 8-bit encoding failed"
 msgstr "falhou a conversão para codificação de 8-bits"
 
-#: ../src/common/accelcmn.cpp:187
+#: ../src/common/accelcmn.cpp:186
 msgid "ctrl"
 msgstr "ctrl"
 
-#: ../src/common/cmdline.cpp:1500
+#: ../src/common/cmdline.cpp:1496
 msgid "date"
 msgstr "data"
 
-#: ../src/html/chm.cpp:349
+#: ../src/html/chm.cpp:346
 msgid "decompression error"
 msgstr "erro de descompressão"
 
-#: ../src/richtext/richtextstyles.cpp:780 ../src/common/fmapbase.cpp:820
+#: ../src/common/fmapbase.cpp:816 ../src/richtext/richtextstyles.cpp:777
 msgid "default"
 msgstr "pré-definição"
 
-#: ../src/common/cmdline.cpp:1496
+#: ../src/common/cmdline.cpp:1492
 msgid "double"
 msgstr "duplo"
 
-#: ../src/common/debugrpt.cpp:538
+#: ../src/common/debugrpt.cpp:539
 msgid "dump of the process state (binary)"
 msgstr "dump do estado do processo (binário)"
 
-#: ../src/common/datetimefmt.cpp:1969
+#: ../src/common/datetimefmt.cpp:1992
 msgid "eighteenth"
 msgstr "décimo oitavo"
 
-#: ../src/common/datetimefmt.cpp:1959
+#: ../src/common/datetimefmt.cpp:1982
 msgid "eighth"
 msgstr "oitavo"
 
-#: ../src/common/datetimefmt.cpp:1962
+#: ../src/common/datetimefmt.cpp:1985
 msgid "eleventh"
 msgstr "décimo primeiro"
 
-#: ../src/common/fileconf.cpp:1833
+#: ../src/common/fileconf.cpp:1835
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "a entrada '%s' aparece mais do uma vez no grupo '%s'"
 
-#: ../src/html/chm.cpp:343
+#: ../src/html/chm.cpp:340
 msgid "error in data format"
 msgstr "erro no formato do dado"
 
-#: ../src/html/chm.cpp:331
+#: ../src/html/chm.cpp:328
 msgid "error opening file"
 msgstr "erro ao abrir ficheiro"
 
-#: ../src/common/zipstrm.cpp:1778
+#: ../src/common/zipstrm.cpp:1836
 msgid "error reading zip central directory"
 msgstr "erro a ler directório central de zip"
 
-#: ../src/common/zipstrm.cpp:1870
+#: ../src/common/zipstrm.cpp:1940
 msgid "error reading zip local header"
 msgstr "erro ao ler cabeçalho local de zip"
 
-#: ../src/common/zipstrm.cpp:2531
+#: ../src/common/zipstrm.cpp:2615
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "erro ao escrever entrada zip '%s': mau comprimento ou crc"
 
-#: ../src/common/ffile.cpp:188
+#: ../src/common/zipstrm.cpp:2608
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "erro ao escrever entrada zip '%s': mau comprimento ou crc"
+
+#: ../src/common/fontcmn.cpp:1205
+#, fuzzy
+msgid "extrabold"
+msgstr "negrito"
+
+#: ../src/common/fontcmn.cpp:1223
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1167
+#, fuzzy
+msgid "extralight"
+msgstr "leve"
+
+#: ../src/msw/webview_ie.cpp:1036
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "Falha ao executar '%s'\n"
+
+#: ../src/common/ffile.cpp:187
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "Falha a escoar o ficheiro '%s'"
 
+#: ../src/msw/webview_ie.cpp:1045
+#, fuzzy
+msgid "failed to retrieve execution result"
+msgstr "Falha na obtenção do texto da mensagem de erro RAS"
+
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1030
+#: ../src/generic/datavgen.cpp:1150
 #, fuzzy
 msgid "false"
 msgstr "Falso"
 
-#: ../src/common/datetimefmt.cpp:1966
+#: ../src/common/datetimefmt.cpp:1989
 msgid "fifteenth"
 msgstr "décimo quinto"
 
-#: ../src/common/datetimefmt.cpp:1956
+#: ../src/common/datetimefmt.cpp:1979
 msgid "fifth"
 msgstr "quinto"
 
@@ -8624,133 +8838,152 @@ msgstr "ficheiro '%s', linha %d: valor para chave imutável '%s' ignorado."
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "ficheiro '%s': caracter inesperado %c na linha %d."
 
-#: ../src/richtext/richtextbuffer.cpp:8738
+#: ../src/richtext/richtextbuffer.cpp:8736
 msgid "files"
 msgstr "ficheiros"
 
-#: ../src/common/datetimefmt.cpp:1952
+#: ../src/common/datetimefmt.cpp:1975
 msgid "first"
 msgstr "primeiro"
 
-#: ../src/html/helpwnd.cpp:1252
+#: ../src/html/helpwnd.cpp:1250
 msgid "font size"
 msgstr "tamanho da fonte"
 
-#: ../src/common/datetimefmt.cpp:1965
+#: ../src/common/datetimefmt.cpp:1988
 msgid "fourteenth"
 msgstr "décimo quarto"
 
-#: ../src/common/datetimefmt.cpp:1955
+#: ../src/common/datetimefmt.cpp:1978
 msgid "fourth"
 msgstr "quarto"
 
-#: ../src/common/appbase.cpp:783
+#: ../src/common/appbase.cpp:784
 msgid "generate verbose log messages"
 msgstr "gerar mensagens de registo verbosas"
 
-#: ../src/richtext/richtextbuffer.cpp:13138
-#: ../src/richtext/richtextbuffer.cpp:13248
+#: ../src/common/fontcmn.cpp:1215
+msgid "heavy"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:13133
+#: ../src/richtext/richtextbuffer.cpp:13243
 msgid "image"
 msgstr "imagem"
 
-#: ../src/common/tarstrm.cpp:796
+#: ../src/common/tarstrm.cpp:790
 msgid "incomplete header block in tar"
 msgstr "bloco de cabeçalho incompleto no tar"
 
-#: ../src/common/xtixml.cpp:489
+#: ../src/common/xtixml.cpp:485
 msgid "incorrect event handler string, missing dot"
 msgstr ""
 "cadeia de caracteres de manuseamento de eventos incorrecta, falta um ponto"
 
-#: ../src/common/tarstrm.cpp:1381
+#: ../src/common/tarstrm.cpp:1375
 msgid "incorrect size given for tar entry"
 msgstr "tamanho incorrecto dado a entrada do tar"
 
-#: ../src/common/tarstrm.cpp:993
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:987
 msgid "invalid data in extended tar header"
 msgstr "dados inválidos no cabeçalho tar estendido"
 
-#: ../src/generic/logg.cpp:1030
+#: ../src/generic/logg.cpp:1027
 msgid "invalid message box return value"
 msgstr "valor de retorno de caixa de diálogo inválido"
 
-#: ../src/common/zipstrm.cpp:1647
+#: ../src/common/zipstrm.cpp:1688
 msgid "invalid zip file"
 msgstr "ficheiro zip inválido"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:1228
 msgid "italic"
 msgstr "itálico"
 
-#: ../src/common/fontcmn.cpp:991
+#: ../src/common/webrequest_curl.cpp:374
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "Não foi possível carregar o ficheiro."
+
+#: ../src/common/fontcmn.cpp:1172
 msgid "light"
 msgstr "leve"
 
-#: ../src/common/intl.cpp:303
-#, c-format
-msgid "locale '%s' cannot be set."
-msgstr "localização '%s' não pode ser definida."
+#: ../src/common/fontcmn.cpp:1185
+msgid "medium"
+msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2125
+#: ../src/common/datetimefmt.cpp:2148
 msgid "midnight"
 msgstr "meia noite"
 
-#: ../src/common/datetimefmt.cpp:1970
+#: ../src/common/datetimefmt.cpp:1993
 msgid "nineteenth"
 msgstr "décimo nono"
 
-#: ../src/common/datetimefmt.cpp:1960
+#: ../src/common/datetimefmt.cpp:1983
 msgid "ninth"
 msgstr "nono"
 
-#: ../src/msw/dde.cpp:1116
+#: ../src/msw/dde.cpp:1180
 msgid "no DDE error."
 msgstr "sem erro DDE."
 
-#: ../src/html/chm.cpp:327
+#: ../src/html/chm.cpp:324
 msgid "no error"
 msgstr "sem erro"
 
-#: ../src/dfb/fontmgr.cpp:174
+#: ../src/dfb/fontmgr.cpp:171
 #, c-format
 msgid "no fonts found in %s, using builtin font"
 msgstr ""
 
-#: ../src/html/helpdata.cpp:657
+#: ../src/html/helpdata.cpp:650
 msgid "noname"
 msgstr "sem nome"
 
-#: ../src/common/datetimefmt.cpp:2124
+#: ../src/common/datetimefmt.cpp:2147
 msgid "noon"
 msgstr "meio-dia"
 
-#: ../src/richtext/richtextstyles.cpp:779
+#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
 #, fuzzy
 msgid "normal"
 msgstr "Normal"
 
-#: ../src/common/cmdline.cpp:1492
+#: ../src/common/cmdline.cpp:1488
 msgid "num"
 msgstr "num"
 
-#: ../src/common/xtixml.cpp:259
+#: ../src/common/accelcmn.cpp:194
+msgid "num "
+msgstr ""
+
+#: ../src/common/xtixml.cpp:255
 msgid "objects cannot have XML Text Nodes"
 msgstr "os objectos não podem ter TextNodes XML"
 
-#: ../src/html/chm.cpp:339
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
 msgid "out of memory"
 msgstr "memória esgotada"
 
-#: ../src/common/debugrpt.cpp:514
+#: ../src/common/debugrpt.cpp:515
 msgid "process context description"
 msgstr "descrição de contexto do processo"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:227
-#: ../src/richtext/richtextbackgroundpage.cpp:250
-#: ../src/richtext/richtextbackgroundpage.cpp:290
-#: ../src/richtext/richtextbackgroundpage.cpp:317
-#: ../src/richtext/richtextfontpage.cpp:177
-#: ../src/richtext/richtextfontpage.cpp:180
 #: ../src/richtext/richtextborderspage.cpp:255
 #: ../src/richtext/richtextborderspage.cpp:289
 #: ../src/richtext/richtextborderspage.cpp:323
@@ -8760,22 +8993,45 @@ msgstr "descrição de contexto do processo"
 #: ../src/richtext/richtextborderspage.cpp:491
 #: ../src/richtext/richtextborderspage.cpp:525
 #: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextfontpage.cpp:180
 msgid "pt"
 msgstr "pt"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:225
-#: ../src/richtext/richtextbackgroundpage.cpp:228
-#: ../src/richtext/richtextbackgroundpage.cpp:229
-#: ../src/richtext/richtextbackgroundpage.cpp:248
-#: ../src/richtext/richtextbackgroundpage.cpp:251
-#: ../src/richtext/richtextbackgroundpage.cpp:252
-#: ../src/richtext/richtextbackgroundpage.cpp:288
-#: ../src/richtext/richtextbackgroundpage.cpp:291
-#: ../src/richtext/richtextbackgroundpage.cpp:292
-#: ../src/richtext/richtextbackgroundpage.cpp:315
-#: ../src/richtext/richtextbackgroundpage.cpp:318
-#: ../src/richtext/richtextbackgroundpage.cpp:319
-#: ../src/richtext/richtextfontpage.cpp:178
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:659
+#: ../src/richtext/richtextsizepage.cpp:662
+#: ../src/richtext/richtextsizepage.cpp:663
 #: ../src/richtext/richtextborderspage.cpp:253
 #: ../src/richtext/richtextborderspage.cpp:256
 #: ../src/richtext/richtextborderspage.cpp:257
@@ -8827,263 +9083,273 @@ msgstr "pt"
 #: ../src/richtext/richtextmarginspage.cpp:387
 #: ../src/richtext/richtextmarginspage.cpp:389
 #: ../src/richtext/richtextmarginspage.cpp:390
-#: ../src/richtext/richtextsizepage.cpp:338
-#: ../src/richtext/richtextsizepage.cpp:341
-#: ../src/richtext/richtextsizepage.cpp:342
-#: ../src/richtext/richtextsizepage.cpp:372
-#: ../src/richtext/richtextsizepage.cpp:375
-#: ../src/richtext/richtextsizepage.cpp:376
-#: ../src/richtext/richtextsizepage.cpp:399
-#: ../src/richtext/richtextsizepage.cpp:402
-#: ../src/richtext/richtextsizepage.cpp:403
-#: ../src/richtext/richtextsizepage.cpp:426
-#: ../src/richtext/richtextsizepage.cpp:429
-#: ../src/richtext/richtextsizepage.cpp:430
-#: ../src/richtext/richtextsizepage.cpp:453
-#: ../src/richtext/richtextsizepage.cpp:456
-#: ../src/richtext/richtextsizepage.cpp:457
-#: ../src/richtext/richtextsizepage.cpp:480
-#: ../src/richtext/richtextsizepage.cpp:483
-#: ../src/richtext/richtextsizepage.cpp:484
-#: ../src/richtext/richtextsizepage.cpp:554
-#: ../src/richtext/richtextsizepage.cpp:557
-#: ../src/richtext/richtextsizepage.cpp:558
-#: ../src/richtext/richtextsizepage.cpp:589
-#: ../src/richtext/richtextsizepage.cpp:592
-#: ../src/richtext/richtextsizepage.cpp:593
-#: ../src/richtext/richtextsizepage.cpp:624
-#: ../src/richtext/richtextsizepage.cpp:627
-#: ../src/richtext/richtextsizepage.cpp:628
-#: ../src/richtext/richtextsizepage.cpp:659
-#: ../src/richtext/richtextsizepage.cpp:662
-#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextfontpage.cpp:178
 msgid "px"
 msgstr "px"
 
-#: ../src/common/accelcmn.cpp:193
+#: ../src/common/accelcmn.cpp:192
 #, fuzzy
 msgid "rawctrl"
 msgstr "ctrl"
 
-#: ../src/html/chm.cpp:333
+#: ../src/html/chm.cpp:330
 msgid "read error"
 msgstr "erro de leitura"
 
-#: ../src/common/zipstrm.cpp:2085
+#: ../src/common/zipstrm.cpp:2155
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "a ler corrente de dados zip (entrada %s): mau crc"
 
-#: ../src/common/zipstrm.cpp:2080
+#: ../src/common/zipstrm.cpp:2150
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "a ler corrente de dados zip (entrada %s): mau comprimento"
 
-#: ../src/msw/dde.cpp:1159
+#: ../src/msw/dde.cpp:1223
 msgid "reentrancy problem."
 msgstr "problema recursivo."
 
-#: ../src/common/datetimefmt.cpp:1953
+#: ../src/common/datetimefmt.cpp:1976
 msgid "second"
 msgstr "segundo"
 
-#: ../src/html/chm.cpp:337
+#: ../src/html/chm.cpp:334
 msgid "seek error"
 msgstr "erro de pesquisa"
 
-#: ../src/common/datetimefmt.cpp:1968
+#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#, fuzzy
+msgid "semibold"
+msgstr "negrito"
+
+#: ../src/common/datetimefmt.cpp:1991
 msgid "seventeenth"
 msgstr "décimo sétimo"
 
-#: ../src/common/datetimefmt.cpp:1958
+#: ../src/common/datetimefmt.cpp:1981
 msgid "seventh"
 msgstr "sétimo"
 
-#: ../src/common/accelcmn.cpp:191
+#: ../src/common/accelcmn.cpp:190
 msgid "shift"
 msgstr "deslocar"
 
-#: ../src/common/appbase.cpp:773
+#: ../src/common/appbase.cpp:774
 msgid "show this help message"
 msgstr "mostra esta mensagem de ajuda"
 
-#: ../src/common/datetimefmt.cpp:1967
+#: ../src/common/datetimefmt.cpp:1990
 msgid "sixteenth"
 msgstr "décimo sexto"
 
-#: ../src/common/datetimefmt.cpp:1957
+#: ../src/common/datetimefmt.cpp:1980
 msgid "sixth"
 msgstr "sexto"
 
-#: ../src/common/appcmn.cpp:234
+#: ../src/common/appcmn.cpp:255
 msgid "specify display mode to use (e.g. 640x480-16)"
 msgstr "especificar modo de ecrã a utilizar (ex: 640x480-16)"
 
-#: ../src/common/appcmn.cpp:220
+#: ../src/common/appcmn.cpp:241
 msgid "specify the theme to use"
 msgstr "especifica o tema a utilizar"
 
-#: ../src/richtext/richtextbuffer.cpp:9340
+#: ../src/richtext/richtextbuffer.cpp:9337
 #, fuzzy
 msgid "standard/circle"
 msgstr "Standard"
 
-#: ../src/richtext/richtextbuffer.cpp:9341
+#: ../src/richtext/richtextbuffer.cpp:9338
 msgid "standard/circle-outline"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9343
+#: ../src/richtext/richtextbuffer.cpp:9340
 msgid "standard/diamond"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9342
+#: ../src/richtext/richtextbuffer.cpp:9339
 #, fuzzy
 msgid "standard/square"
 msgstr "Standard"
 
-#: ../src/richtext/richtextbuffer.cpp:9344
+#: ../src/richtext/richtextbuffer.cpp:9341
 msgid "standard/triangle"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1985
+#: ../src/common/zipstrm.cpp:2055
 msgid "stored file length not in Zip header"
 msgstr "guardado tamanho do ficheiro não no cabeçalho Zip"
 
-#: ../src/common/cmdline.cpp:1488
+#: ../src/common/cmdline.cpp:1484
 msgid "str"
 msgstr "str"
 
-#: ../src/common/fontcmn.cpp:982
+#: ../src/common/fontcmn.cpp:1145
 msgid "strikethrough"
 msgstr "Rasurado"
 
-#: ../src/common/tarstrm.cpp:1003 ../src/common/tarstrm.cpp:1025
-#: ../src/common/tarstrm.cpp:1507 ../src/common/tarstrm.cpp:1529
+#: ../src/common/tarstrm.cpp:997 ../src/common/tarstrm.cpp:1019
+#: ../src/common/tarstrm.cpp:1501 ../src/common/tarstrm.cpp:1523
 msgid "tar entry not open"
 msgstr "entrada tar não aberta"
 
-#: ../src/common/datetimefmt.cpp:1961
+#: ../src/common/datetimefmt.cpp:1984
 msgid "tenth"
 msgstr "décimo"
 
-#: ../src/msw/dde.cpp:1123
+#: ../src/msw/dde.cpp:1187
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "a resposta à transacção causou a definição do bit DDE_FBUSY."
 
-#: ../src/common/datetimefmt.cpp:1954
+#: ../src/common/fontcmn.cpp:1154
+msgid "thin"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:1977
 msgid "third"
 msgstr "terceiro"
 
-#: ../src/common/datetimefmt.cpp:1964
+#: ../src/common/datetimefmt.cpp:1987
 msgid "thirteenth"
 msgstr "décimo terceiro"
 
-#: ../src/common/datetimefmt.cpp:1758
+#: ../src/common/datetimefmt.cpp:1781
 msgid "today"
 msgstr "hoje"
 
-#: ../src/common/datetimefmt.cpp:1760
+#: ../src/common/datetimefmt.cpp:1783
 msgid "tomorrow"
 msgstr "amanhã"
 
-#: ../src/common/fileconf.cpp:1944
+#: ../src/common/fileconf.cpp:1946
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr ""
 
-#: ../src/gtk/aboutdlg.cpp:218
+#: ../src/gtk/aboutdlg.cpp:216
 msgid "translator-credits"
 msgstr "créditos dos tradutores"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1028
+#: ../src/generic/datavgen.cpp:1148
 msgid "true"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1963
+#: ../src/common/datetimefmt.cpp:1986
 msgid "twelfth"
 msgstr "décimo segundo"
 
-#: ../src/common/datetimefmt.cpp:1971
+#: ../src/common/datetimefmt.cpp:1994
 msgid "twentieth"
 msgstr "vigésimo"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:486 ../src/generic/datavgen.cpp:1263
+#: ../src/common/datavcmn.cpp:2068 ../src/generic/datavgen.cpp:1386
 msgid "unchecked"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:802 ../src/common/fontcmn.cpp:978
+#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
 msgid "underlined"
 msgstr "sublinhado"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:490
+#: ../src/common/datavcmn.cpp:2072
 #, fuzzy
 msgid "undetermined"
 msgstr "sublinhado"
 
-#: ../src/common/fileconf.cpp:1979
+#: ../src/common/fileconf.cpp:1981
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "\" inesperado na posição %d em '%s'."
 
-#: ../src/common/tarstrm.cpp:1045
+#: ../src/common/tarstrm.cpp:1039
 msgid "unexpected end of file"
 msgstr "fim de ficheiro inesperado"
 
-#: ../src/generic/progdlgg.cpp:370 ../src/common/tarstrm.cpp:371
-#: ../src/common/tarstrm.cpp:394 ../src/common/tarstrm.cpp:425
+#: ../src/common/tarstrm.cpp:366 ../src/common/tarstrm.cpp:389
+#: ../src/common/tarstrm.cpp:420 ../src/generic/progdlgg.cpp:376
 msgid "unknown"
 msgstr "desconhecido"
 
-#: ../src/msw/registry.cpp:150
+#: ../src/msw/registry.cpp:139
 #, fuzzy, c-format
 msgid "unknown (%lu)"
 msgstr "desconhecido"
 
-#: ../src/common/xtixml.cpp:253
+#: ../src/common/xtixml.cpp:249
 #, c-format
 msgid "unknown class %s"
 msgstr "classe %s desconhecida"
 
-#: ../src/common/regex.cpp:258 ../src/html/chm.cpp:351
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "erro de compressão"
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "erro de descompressão"
+
+#: ../src/common/regex.cpp:255 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "erro desconhecido"
 
-#: ../src/msw/dialup.cpp:471
+#: ../src/msw/dialup.cpp:465
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "erro desconhecido ( código de erro %08x)."
 
-#: ../src/common/fmapbase.cpp:834
+#: ../src/common/fmapbase.cpp:830
 #, c-format
 msgid "unknown-%d"
 msgstr "desconhecido %d"
 
-#: ../src/common/docview.cpp:509
+#: ../src/common/docview.cpp:502
 msgid "unnamed"
 msgstr "sem nome"
 
-#: ../src/common/docview.cpp:1624
+#: ../src/common/docview.cpp:1618
 #, c-format
 msgid "unnamed%d"
 msgstr "sem nome%d"
 
-#: ../src/common/zipstrm.cpp:1999 ../src/common/zipstrm.cpp:2319
+#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
 msgid "unsupported Zip compression method"
 msgstr "método de compressão Zip não suportado"
 
-#: ../src/common/translation.cpp:1892
+#: ../src/common/translation.cpp:1942
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "a utilizar catálogo '%s' de '%s'."
 
-#: ../src/html/chm.cpp:335
+#: ../src/html/chm.cpp:332
 msgid "write error"
 msgstr "erro de escrita"
 
-#: ../src/common/time.cpp:292
+#: ../src/gtk/glcanvas.cpp:187
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/common/time.cpp:285
 msgid "wxGetTimeOfDay failed."
 msgstr "falhou o wxGetTimeOfDay."
 
@@ -9096,15 +9362,15 @@ msgstr "wxWidgets não foi possível abrir ecrã para '%s': a sair."
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets não foi possível abrir o ecrã. A sair."
 
-#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:431
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/common/datetimefmt.cpp:1759
+#: ../src/common/datetimefmt.cpp:1782
 msgid "yesterday"
 msgstr "ontem"
 
-#: ../src/common/zstream.cpp:251 ../src/common/zstream.cpp:426
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
 #, c-format
 msgid "zlib error %d"
 msgstr "erro zlib %d"
@@ -9114,9 +9380,74 @@ msgstr "erro zlib %d"
 msgid "~"
 msgstr "~"
 
+#~ msgid "&Save as"
+#~ msgstr "&Guardar Como"
+
 #, fuzzy
-#~ msgid "Column could not be added."
-#~ msgstr "Não foi possível carregar o ficheiro."
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' deve apenas conter caracteres alfabéticos."
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' deve ser numérico."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' apenas deve conter caracteres ASCII."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' deve apenas conter caracteres alfabéticos."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' deve apenas conter caracteres alfabéticos e numéricos."
+
+#, fuzzy
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' apenas deve conter caracteres ASCII."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "Não é possível criar janela da classe %s"
+
+#, fuzzy
+#~ msgid "Could not initalize libnotify."
+#~ msgstr "Não foi possível inicia a impressão."
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "Não foi possível criar a janela de sobreposição"
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "Não foi possível inicializar o contexto na janela de sobreposição"
+
+#, fuzzy
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "Falha ao converter conteúdo do ficheiro para Unicode."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "Falha ao definir texto no controlo de texto."
+
+#~ msgid "No unused colour in image."
+#~ msgstr "Nenhuma cor na imagem por utilizar."
+
+#, fuzzy
+#~ msgid "Not available"
+#~ msgstr "Não disponível!"
+
+#~ msgid "Replace selection"
+#~ msgstr "Substituir selecção"
+
+#, fuzzy
+#~ msgid "Save as"
+#~ msgstr "Gravar Como"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Organizador de Estilos"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "Não pode Limpar uma sobreposição que não está inicializada"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "Não pode Inicializar uma sobreposição duas vezes"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "localização '%s' não pode ser definida."
 
 #, fuzzy
 #~ msgid "Column index not found."
@@ -9357,10 +9688,6 @@ msgstr "~"
 
 #~ msgid "unknown seek origin"
 #~ msgstr "origem de pesquisa desconhecida"
-
-#, fuzzy
-#~ msgid "wxWidget's control not initialized."
-#~ msgstr "Não foi possível inicializar o ecrã."
 
 #~ msgid "ADD"
 #~ msgstr "ADICIONAR"
@@ -9624,9 +9951,6 @@ msgstr "~"
 #~ msgid "Directory '%s' doesn't exist!"
 #~ msgstr "O directório '%s' não existe!"
 
-#~ msgid "File %s does not exist."
-#~ msgstr "Ficheiro %s não existe."
-
 #~ msgid "Mode %ix%i-%i not available."
 #~ msgstr "Modo %ix%i-%i não disponível."
 
@@ -9722,9 +10046,6 @@ msgstr "~"
 
 #~ msgid "Failed to register OpenGL window class."
 #~ msgstr "Falha ao registar classe de janela OpenGL."
-
-#~ msgid "Fatal error"
-#~ msgstr "Erro Fatal"
 
 #~ msgid "Fatal error: "
 #~ msgstr "Erro Fatal: "
@@ -9913,9 +10234,6 @@ msgstr "~"
 
 #~ msgid "&Print"
 #~ msgstr "&Imprimir"
-
-#~ msgid "*** A debug report has been generated\n"
-#~ msgstr "*** Foi gerado um relatório de depuração de erros\n"
 
 #~ msgid "*** It can be found in \"%s\"\n"
 #~ msgstr "***Pode ser encontrado em \"%s\"\n"

--- a/locale/pt_BR.po
+++ b/locale/pt_BR.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-03-17 17:48-0300\n"
+"POT-Creation-Date: 2020-10-18 23:11+0300\n"
 "PO-Revision-Date: 2018-03-17 18:20-0300\n"
 "Last-Translator: Felipe\n"
 "Language-Team: Felipe <felipefplzx@gmail.com>\n"
@@ -18,7 +18,7 @@ msgstr ""
 "X-Generator: Poedit 2.0.2\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: ../src/common/debugrpt.cpp:586
+#: ../src/common/debugrpt.cpp:587
 msgid ""
 "\n"
 "Please send this report to the program maintainer, thank you!\n"
@@ -26,8 +26,8 @@ msgstr ""
 "\n"
 "Por favor envie este relatório ao mantedor do programa, obrigado a você!\n"
 
-#: ../src/richtext/richtextstyledlg.cpp:210
-#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:206
+#: ../src/richtext/richtextstyledlg.cpp:218
 msgid " "
 msgstr " "
 
@@ -35,70 +35,96 @@ msgstr " "
 msgid "              Thank you and we're sorry for the inconvenience!\n"
 msgstr "              Obrigado a você e nós lamentamos pela inconveniência!\n"
 
-#: ../src/common/prntbase.cpp:573
+#: ../src/common/prntbase.cpp:568
 #, c-format
 msgid " (copy %d of %d)"
 msgstr " (cópia %d de %d)"
 
-#: ../src/common/log.cpp:421
+#: ../src/common/log.cpp:440
 #, c-format
 msgid " (error %ld: %s)"
 msgstr " (erro %ld: %s)"
 
-#: ../src/common/imagtiff.cpp:72
+#: ../src/common/imagtiff.cpp:69
 #, c-format
 msgid " (in module \"%s\")"
 msgstr " (no módulo \"%s\")"
 
-#: ../src/osx/core/secretstore.cpp:138
-msgid " (while overwriting an existing item)"
-msgstr " (enquanto sobrescrevendo um item existente)"
-
-#: ../src/common/docview.cpp:1642
+#: ../src/common/docview.cpp:1636
 msgid " - "
 msgstr " - "
 
-#: ../src/richtext/richtextprint.cpp:593 ../src/html/htmprint.cpp:714
+#: ../src/html/htmprint.cpp:712 ../src/richtext/richtextprint.cpp:589
 msgid " Preview"
 msgstr " Pré-visualizar"
 
-#: ../src/common/fontcmn.cpp:824
+#: ../src/common/fontcmn.cpp:973
 msgid " bold"
 msgstr " negrito"
 
-#: ../src/common/fontcmn.cpp:840
+#: ../src/common/fontcmn.cpp:977
+#, fuzzy
+msgid " extra bold"
+msgstr " negrito"
+
+#: ../src/common/fontcmn.cpp:985
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:957
+#, fuzzy
+msgid " extra light"
+msgstr " leve"
+
+#: ../src/common/fontcmn.cpp:981
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1001
 msgid " italic"
 msgstr " itálico"
 
-#: ../src/common/fontcmn.cpp:820
+#: ../src/common/fontcmn.cpp:961
 msgid " light"
 msgstr " leve"
 
-#: ../src/common/fontcmn.cpp:807
+#: ../src/common/fontcmn.cpp:965
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:969
+#, fuzzy
+msgid " semi bold"
+msgstr " negrito"
+
+#: ../src/common/fontcmn.cpp:940
 msgid " strikethrough"
 msgstr " sublinhado"
 
-#: ../src/common/paper.cpp:117
+#: ../src/common/fontcmn.cpp:953
+msgid " thin"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
 msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
 msgstr "#10 Envelope, 4 1/8 x 9 1/2 em"
 
-#: ../src/common/paper.cpp:118
+#: ../src/common/paper.cpp:115
 msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
 msgstr "#11 Envelope 4 1/2 x 10 3/8 em"
 
-#: ../src/common/paper.cpp:119
+#: ../src/common/paper.cpp:116
 msgid "#12 Envelope, 4 3/4 x 11 in"
 msgstr "#12 Envelope 4 3/4 x 11 em"
 
-#: ../src/common/paper.cpp:120
+#: ../src/common/paper.cpp:117
 msgid "#14 Envelope, 5 x 11 1/2 in"
 msgstr "#14 Envelope 5 x 11 1/2 em"
 
-#: ../src/common/paper.cpp:116
+#: ../src/common/paper.cpp:113
 msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
 msgstr "#9 Envelope 3 7/8 x 8 7/8 em"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:341
 #: ../src/richtext/richtextsizepage.cpp:340
 #: ../src/richtext/richtextsizepage.cpp:374
 #: ../src/richtext/richtextsizepage.cpp:401
@@ -109,81 +135,82 @@ msgstr "#9 Envelope 3 7/8 x 8 7/8 em"
 #: ../src/richtext/richtextsizepage.cpp:591
 #: ../src/richtext/richtextsizepage.cpp:626
 #: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextbackgroundpage.cpp:341
 msgid "%"
 msgstr "%"
 
-#: ../src/html/helpwnd.cpp:1031
+#: ../src/html/helpwnd.cpp:1029
 #, c-format
 msgid "%d of %lu"
 msgstr "%d de %lu"
 
-#: ../src/html/helpwnd.cpp:1678
+#: ../src/html/helpwnd.cpp:1676
 #, c-format
 msgid "%i of %u"
 msgstr "%i de %u"
 
-#: ../src/generic/filectrlg.cpp:279
+#: ../src/generic/filectrlg.cpp:275
 #, c-format
 msgid "%ld byte"
 msgid_plural "%ld bytes"
 msgstr[0] "%ld byte"
 msgstr[1] "%ld bytes"
 
-#: ../src/html/helpwnd.cpp:1033
+#: ../src/html/helpwnd.cpp:1031
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu de %lu"
 
-#: ../src/generic/datavgen.cpp:6028
+#: ../src/generic/datavgen.cpp:6833
 #, c-format
 msgid "%s (%d items)"
 msgstr "%s (%d itens)"
 
-#: ../src/common/cmdline.cpp:1221
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (ou %s)"
 
-#: ../src/generic/logg.cpp:224
+#: ../src/generic/logg.cpp:221
 #, c-format
 msgid "%s Error"
 msgstr "Erro do %s"
 
-#: ../src/generic/logg.cpp:236
+#: ../src/generic/logg.cpp:233
 #, c-format
 msgid "%s Information"
 msgstr "Informação do %s"
 
-#: ../src/generic/preferencesg.cpp:113
+#: ../src/generic/preferencesg.cpp:110
 #, c-format
 msgid "%s Preferences"
 msgstr "Preferências da %s"
 
-#: ../src/generic/logg.cpp:228
+#: ../src/generic/logg.cpp:225
 #, c-format
 msgid "%s Warning"
 msgstr "Aviso do %s"
 
-#: ../src/common/tarstrm.cpp:1319
+#: ../src/common/tarstrm.cpp:1313
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s não encaixou no cabeçalho tar para a entrada '%s'"
 
-#: ../src/common/fldlgcmn.cpp:124
+#: ../src/common/fldlgcmn.cpp:121
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "Arquivos %s (%s)|%s"
 
-#: ../src/html/helpwnd.cpp:1716
+#: ../src/html/helpwnd.cpp:1714
 #, c-format
 msgid "%u of %u"
 msgstr "%u de %u"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "&About"
 msgstr "&Sobre"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "&Actual Size"
 msgstr "&Tamanho Real"
 
@@ -191,28 +218,28 @@ msgstr "&Tamanho Real"
 msgid "&After a paragraph:"
 msgstr "&Após um parágrafo:"
 
-#: ../src/richtext/richtextindentspage.cpp:128
 #: ../src/richtext/richtextliststylepage.cpp:319
+#: ../src/richtext/richtextindentspage.cpp:128
 msgid "&Alignment"
 msgstr "&Alinhamento"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "&Apply"
 msgstr "&Aplicar"
 
-#: ../src/richtext/richtextstyledlg.cpp:251
+#: ../src/richtext/richtextstyledlg.cpp:247
 msgid "&Apply Style"
 msgstr "&Aplicar Estilo"
 
-#: ../src/msw/mdi.cpp:179
+#: ../src/msw/mdi.cpp:174
 msgid "&Arrange Icons"
 msgstr "&Organizar Ícones"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "&Ascending"
 msgstr "&Ascendente"
 
-#: ../src/common/stockitem.cpp:142
+#: ../src/common/stockitem.cpp:139
 msgid "&Back"
 msgstr "&Voltar"
 
@@ -232,24 +259,24 @@ msgstr "&Côr de fundo:"
 msgid "&Blur distance:"
 msgstr "&Distância do blur:"
 
-#: ../src/common/stockitem.cpp:143
+#: ../src/common/stockitem.cpp:140
 msgid "&Bold"
 msgstr "&Negrito"
 
-#: ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141
 msgid "&Bottom"
 msgstr "&Fundo"
 
+#: ../src/richtext/richtextsizepage.cpp:637
+#: ../src/richtext/richtextsizepage.cpp:644
 #: ../src/richtext/richtextborderspage.cpp:345
 #: ../src/richtext/richtextborderspage.cpp:513
 #: ../src/richtext/richtextmarginspage.cpp:259
 #: ../src/richtext/richtextmarginspage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:637
-#: ../src/richtext/richtextsizepage.cpp:644
 msgid "&Bottom:"
 msgstr "&Fundo:"
 
-#: ../include/wx/richtext/richtextbuffer.h:3866
+#: ../include/wx/richtext/richtextbuffer.h:3861
 msgid "&Box"
 msgstr "&Caixa"
 
@@ -258,38 +285,38 @@ msgstr "&Caixa"
 msgid "&Bullet style:"
 msgstr "&Estilo da projétil:"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "&CD-Rom"
 msgstr "&CD-Rom"
 
-#: ../src/generic/wizard.cpp:434 ../src/generic/fontdlgg.cpp:470
-#: ../src/generic/fontdlgg.cpp:489 ../src/osx/carbon/fontdlg.cpp:402
-#: ../src/common/dlgcmn.cpp:279 ../src/common/stockitem.cpp:145
+#: ../src/osx/carbon/fontdlg.cpp:399 ../src/common/stockitem.cpp:142
+#: ../src/generic/wizard.cpp:433 ../src/generic/fontdlgg.cpp:466
+#: ../src/generic/fontdlgg.cpp:485 ../src/osx/cocoa/button.mm:200
 msgid "&Cancel"
 msgstr "&Cancelar"
 
-#: ../src/msw/mdi.cpp:175
+#: ../src/msw/mdi.cpp:170
 msgid "&Cascade"
 msgstr "&Em cascata"
 
-#: ../include/wx/richtext/richtextbuffer.h:5960
+#: ../include/wx/richtext/richtextbuffer.h:5955
 msgid "&Cell"
 msgstr "&Célula"
 
-#: ../src/richtext/richtextsymboldlg.cpp:439
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "&Character code:"
 msgstr "&Código dos caracteres:"
 
-#: ../src/common/stockitem.cpp:147
+#: ../src/common/stockitem.cpp:144
 msgid "&Clear"
 msgstr "&Limpar"
 
-#: ../src/generic/logg.cpp:516 ../src/common/stockitem.cpp:148
-#: ../src/common/prntbase.cpp:1600 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/stockitem.cpp:145 ../src/common/prntbase.cpp:1625
+#: ../src/univ/themes/win32.cpp:3753 ../src/generic/logg.cpp:513
 msgid "&Close"
 msgstr "&Fechar"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "&Color"
 msgstr "&Côr"
 
@@ -297,20 +324,20 @@ msgstr "&Côr"
 msgid "&Colour:"
 msgstr "&Côr:"
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "&Convert"
 msgstr "&Converter"
 
-#: ../src/richtext/richtextctrl.cpp:333 ../src/osx/textctrl_osx.cpp:577
-#: ../src/common/stockitem.cpp:150 ../src/msw/textctrl.cpp:2508
+#: ../src/osx/textctrl_osx.cpp:595 ../src/common/stockitem.cpp:147
+#: ../src/msw/textctrl.cpp:2773 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Copiar"
 
-#: ../src/generic/hyperlinkg.cpp:156
+#: ../src/generic/hyperlinkg.cpp:153
 msgid "&Copy URL"
 msgstr "&Copiar URL"
 
-#: ../src/common/headerctrlcmn.cpp:306
+#: ../src/common/headerctrlcmn.cpp:304
 msgid "&Customize..."
 msgstr "&Personalizar..."
 
@@ -318,53 +345,54 @@ msgstr "&Personalizar..."
 msgid "&Debug report preview:"
 msgstr "&Pré-visualizar o relatório do debug:"
 
-#: ../src/richtext/richtexttabspage.cpp:138
-#: ../src/richtext/richtextctrl.cpp:335 ../src/osx/textctrl_osx.cpp:579
-#: ../src/common/stockitem.cpp:152 ../src/msw/textctrl.cpp:2510
+#: ../src/osx/textctrl_osx.cpp:597 ../src/common/stockitem.cpp:149
+#: ../src/msw/textctrl.cpp:2775 ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtextctrl.cpp:334
 msgid "&Delete"
 msgstr "&Apagar"
 
-#: ../src/richtext/richtextstyledlg.cpp:269
+#: ../src/richtext/richtextstyledlg.cpp:265
 msgid "&Delete Style..."
 msgstr "&Apagar o Estilo..."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "&Descending"
 msgstr "&Descendente"
 
-#: ../src/generic/logg.cpp:682
+#: ../src/generic/logg.cpp:679
 msgid "&Details"
 msgstr "&Detalhes"
 
-#: ../src/common/stockitem.cpp:153
+#: ../src/common/stockitem.cpp:150
 msgid "&Down"
 msgstr "&Pra baixo"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "&Edit"
 msgstr "&Editar"
 
-#: ../src/richtext/richtextstyledlg.cpp:263
+#: ../src/richtext/richtextstyledlg.cpp:259
 msgid "&Edit Style..."
 msgstr "&Editar Estilo..."
 
-#: ../src/common/stockitem.cpp:155
+#: ../src/common/stockitem.cpp:152
 msgid "&Execute"
 msgstr "&Executar"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/common/stockitem.cpp:154
 msgid "&File"
 msgstr "&Arquivo"
 
-#: ../src/common/stockitem.cpp:158
-msgid "&Find"
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "&Find..."
 msgstr "&Achar"
 
-#: ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:430
 msgid "&Finish"
 msgstr "&Concluir"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:156
 msgid "&First"
 msgstr "&Primeiro"
 
@@ -372,15 +400,15 @@ msgstr "&Primeiro"
 msgid "&Floating mode:"
 msgstr "&Modo flutuante:"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "&Floppy"
 msgstr "&Disquete"
 
-#: ../src/common/stockitem.cpp:194
+#: ../src/common/stockitem.cpp:191
 msgid "&Font"
 msgstr "&Fonte"
 
-#: ../src/generic/fontdlgg.cpp:371
+#: ../src/generic/fontdlgg.cpp:367
 msgid "&Font family:"
 msgstr "&Família da fonte:"
 
@@ -388,20 +416,20 @@ msgstr "&Família da fonte:"
 msgid "&Font for Level..."
 msgstr "&Fonte para o Nível..."
 
+#: ../src/richtext/richtextsymboldlg.cpp:397
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:400
 msgid "&Font:"
 msgstr "&Fonte:"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "&Forward"
 msgstr "&Pra frente"
 
-#: ../src/richtext/richtextsymboldlg.cpp:451
+#: ../src/richtext/richtextsymboldlg.cpp:448
 msgid "&From:"
 msgstr "&De:"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "&Harddisk"
 msgstr "&Disco rígido"
 
@@ -410,9 +438,9 @@ msgstr "&Disco rígido"
 msgid "&Height:"
 msgstr "&Altura:"
 
-#: ../src/generic/wizard.cpp:441 ../src/richtext/richtextstyledlg.cpp:303
-#: ../src/richtext/richtextsymboldlg.cpp:479 ../src/osx/menu_osx.cpp:734
-#: ../src/common/stockitem.cpp:163
+#: ../src/common/stockitem.cpp:160 ../src/generic/wizard.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextstyledlg.cpp:299 ../src/osx/cocoa/menu.mm:226
 msgid "&Help"
 msgstr "&Ajuda"
 
@@ -420,7 +448,7 @@ msgstr "&Ajuda"
 msgid "&Hide details"
 msgstr "&Esconder detalhes"
 
-#: ../src/common/stockitem.cpp:164
+#: ../src/common/stockitem.cpp:161
 msgid "&Home"
 msgstr "&Home"
 
@@ -428,54 +456,54 @@ msgstr "&Home"
 msgid "&Horizontal offset:"
 msgstr "&Offset horizontal:"
 
-#: ../src/richtext/richtextindentspage.cpp:184
 #: ../src/richtext/richtextliststylepage.cpp:372
+#: ../src/richtext/richtextindentspage.cpp:184
 msgid "&Indentation (tenths of a mm)"
 msgstr "&Recorte (décimos de um mm)"
 
-#: ../src/richtext/richtextindentspage.cpp:167
 #: ../src/richtext/richtextliststylepage.cpp:356
+#: ../src/richtext/richtextindentspage.cpp:167
 msgid "&Indeterminate"
 msgstr "&Indeterminado"
 
-#: ../src/common/stockitem.cpp:166
+#: ../src/common/stockitem.cpp:163
 msgid "&Index"
 msgstr "&Índice"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "&Info"
 msgstr "&Info"
 
-#: ../src/common/stockitem.cpp:168
+#: ../src/common/stockitem.cpp:165
 msgid "&Italic"
 msgstr "&Itálico"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "&Jump to"
 msgstr "&Pular para"
 
-#: ../src/richtext/richtextindentspage.cpp:153
 #: ../src/richtext/richtextliststylepage.cpp:342
+#: ../src/richtext/richtextindentspage.cpp:153
 msgid "&Justified"
 msgstr "&Justificado"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "&Last"
 msgstr "&Último"
 
-#: ../src/richtext/richtextindentspage.cpp:139
 #: ../src/richtext/richtextliststylepage.cpp:328
+#: ../src/richtext/richtextindentspage.cpp:139
 msgid "&Left"
 msgstr "&Esquerda"
 
-#: ../src/richtext/richtextindentspage.cpp:195
+#: ../src/richtext/richtextsizepage.cpp:532
+#: ../src/richtext/richtextsizepage.cpp:539
 #: ../src/richtext/richtextborderspage.cpp:243
 #: ../src/richtext/richtextborderspage.cpp:411
 #: ../src/richtext/richtextliststylepage.cpp:381
+#: ../src/richtext/richtextindentspage.cpp:195
 #: ../src/richtext/richtextmarginspage.cpp:186
 #: ../src/richtext/richtextmarginspage.cpp:300
-#: ../src/richtext/richtextsizepage.cpp:532
-#: ../src/richtext/richtextsizepage.cpp:539
 msgid "&Left:"
 msgstr "&Esquerda:"
 
@@ -483,11 +511,11 @@ msgstr "&Esquerda:"
 msgid "&List level:"
 msgstr "&Nível da lista:"
 
-#: ../src/generic/logg.cpp:517
+#: ../src/generic/logg.cpp:514
 msgid "&Log"
 msgstr "&Log"
 
-#: ../src/univ/themes/win32.cpp:3748
+#: ../src/univ/themes/win32.cpp:3745
 msgid "&Move"
 msgstr "&Mover"
 
@@ -495,19 +523,19 @@ msgstr "&Mover"
 msgid "&Move the object to:"
 msgstr "&Mover o objeto para:"
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "&Network"
 msgstr "&Rede"
 
-#: ../src/richtext/richtexttabspage.cpp:132 ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173 ../src/richtext/richtexttabspage.cpp:132
 msgid "&New"
 msgstr "&Novo"
 
-#: ../src/aui/tabmdi.cpp:111 ../src/generic/mdig.cpp:100 ../src/msw/mdi.cpp:180
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
 msgid "&Next"
 msgstr "&Próximo"
 
-#: ../src/generic/wizard.cpp:432 ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:429
 msgid "&Next >"
 msgstr "&Próximo >"
 
@@ -515,7 +543,7 @@ msgstr "&Próximo >"
 msgid "&Next Paragraph"
 msgstr "&Parágrafo Seguinte"
 
-#: ../src/generic/tipdlg.cpp:240
+#: ../src/generic/tipdlg.cpp:237
 msgid "&Next Tip"
 msgstr "&Próxima Dica"
 
@@ -523,11 +551,11 @@ msgstr "&Próxima Dica"
 msgid "&Next style:"
 msgstr "&Próximo estilo:"
 
-#: ../src/common/stockitem.cpp:177 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:174 ../src/msw/msgdlg.cpp:435
 msgid "&No"
 msgstr "&Não"
 
-#: ../src/generic/dbgrptg.cpp:356
+#: ../src/generic/dbgrptg.cpp:360
 msgid "&Notes:"
 msgstr "&Notas:"
 
@@ -535,12 +563,12 @@ msgstr "&Notas:"
 msgid "&Number:"
 msgstr "&Número:"
 
-#: ../src/generic/fontdlgg.cpp:475 ../src/generic/fontdlgg.cpp:482
-#: ../src/osx/carbon/fontdlg.cpp:408 ../src/common/stockitem.cpp:178
+#: ../src/osx/carbon/fontdlg.cpp:405 ../src/common/stockitem.cpp:175
+#: ../src/generic/fontdlgg.cpp:471 ../src/generic/fontdlgg.cpp:478
 msgid "&OK"
 msgstr "&OK"
 
-#: ../src/generic/dbgrptg.cpp:342 ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176 ../src/generic/dbgrptg.cpp:342
 msgid "&Open..."
 msgstr "&Abrir..."
 
@@ -552,16 +580,16 @@ msgstr "&Nível do contorno:"
 msgid "&Page Break"
 msgstr "&Quebra da Página"
 
-#: ../src/richtext/richtextctrl.cpp:334 ../src/osx/textctrl_osx.cpp:578
-#: ../src/common/stockitem.cpp:180 ../src/msw/textctrl.cpp:2509
+#: ../src/osx/textctrl_osx.cpp:596 ../src/common/stockitem.cpp:177
+#: ../src/msw/textctrl.cpp:2774 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&Colar"
 
-#: ../include/wx/richtext/richtextbuffer.h:5010
+#: ../include/wx/richtext/richtextbuffer.h:5005
 msgid "&Picture"
 msgstr "&Foto"
 
-#: ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:419
 msgid "&Point size:"
 msgstr "&Tamanho do ponto:"
 
@@ -573,11 +601,11 @@ msgstr "&Posição (décimos de um milímetro):"
 msgid "&Position mode:"
 msgstr "&Modo da posição:"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178
 msgid "&Preferences"
 msgstr "&Preferências"
 
-#: ../src/aui/tabmdi.cpp:112 ../src/generic/mdig.cpp:101 ../src/msw/mdi.cpp:181
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
 msgid "&Previous"
 msgstr "&Anterior"
 
@@ -585,78 +613,74 @@ msgstr "&Anterior"
 msgid "&Previous Paragraph"
 msgstr "&Parágrafo Anterior"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "&Print..."
 msgstr "&Imprimir..."
 
-#: ../src/richtext/richtextctrl.cpp:339 ../src/richtext/richtextctrl.cpp:5514
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtextctrl.cpp:338
+#: ../src/richtext/richtextctrl.cpp:5512
 msgid "&Properties"
 msgstr "&Propriedades"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "&Quit"
 msgstr "&Sair"
 
-#: ../src/richtext/richtextctrl.cpp:330 ../src/osx/textctrl_osx.cpp:574
-#: ../src/common/stockitem.cpp:185 ../src/common/cmdproc.cpp:293
-#: ../src/common/cmdproc.cpp:300 ../src/msw/textctrl.cpp:2505
+#: ../src/osx/textctrl_osx.cpp:592 ../src/common/stockitem.cpp:182
+#: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
+#: ../src/msw/textctrl.cpp:2770 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Refazer"
 
-#: ../src/common/cmdproc.cpp:289 ../src/common/cmdproc.cpp:309
+#: ../src/common/cmdproc.cpp:282 ../src/common/cmdproc.cpp:302
 msgid "&Redo "
 msgstr "&Refazer "
 
-#: ../src/richtext/richtextstyledlg.cpp:257
+#: ../src/richtext/richtextstyledlg.cpp:253
 msgid "&Rename Style..."
 msgstr "&Renomear Estilo..."
 
-#: ../src/generic/fdrepdlg.cpp:179
+#: ../src/generic/fdrepdlg.cpp:176
 msgid "&Replace"
 msgstr "&Substituir"
 
-#: ../src/richtext/richtextstyledlg.cpp:287
+#: ../src/richtext/richtextstyledlg.cpp:283
 msgid "&Restart numbering"
 msgstr "&Reiniciar a numeração"
 
-#: ../src/univ/themes/win32.cpp:3747
+#: ../src/univ/themes/win32.cpp:3744
 msgid "&Restore"
 msgstr "&Restaurar"
 
-#: ../src/richtext/richtextindentspage.cpp:146
 #: ../src/richtext/richtextliststylepage.cpp:335
+#: ../src/richtext/richtextindentspage.cpp:146
 msgid "&Right"
 msgstr "&Direita"
 
-#: ../src/richtext/richtextindentspage.cpp:213
+#: ../src/richtext/richtextsizepage.cpp:602
+#: ../src/richtext/richtextsizepage.cpp:609
 #: ../src/richtext/richtextborderspage.cpp:277
 #: ../src/richtext/richtextborderspage.cpp:445
 #: ../src/richtext/richtextliststylepage.cpp:399
+#: ../src/richtext/richtextindentspage.cpp:213
 #: ../src/richtext/richtextmarginspage.cpp:211
 #: ../src/richtext/richtextmarginspage.cpp:325
-#: ../src/richtext/richtextsizepage.cpp:602
-#: ../src/richtext/richtextsizepage.cpp:609
 msgid "&Right:"
 msgstr "&Direita:"
 
-#: ../src/common/stockitem.cpp:190
+#: ../src/common/stockitem.cpp:187
 msgid "&Save"
 msgstr "&Salvar"
-
-#: ../src/common/stockitem.cpp:191
-msgid "&Save as"
-msgstr "&Salvar como"
 
 #: ../include/wx/richmsgdlg.h:29
 msgid "&See details"
 msgstr "&Ver detalhes"
 
-#: ../src/generic/tipdlg.cpp:236
+#: ../src/generic/tipdlg.cpp:233
 msgid "&Show tips at startup"
 msgstr "&Mostrar dicas ao iniciar"
 
-#: ../src/univ/themes/win32.cpp:3750
+#: ../src/univ/themes/win32.cpp:3747
 msgid "&Size"
 msgstr "&Tamanho"
 
@@ -664,36 +688,36 @@ msgstr "&Tamanho"
 msgid "&Size:"
 msgstr "&Tamanho:"
 
-#: ../src/generic/progdlgg.cpp:252
+#: ../src/generic/progdlgg.cpp:249
 msgid "&Skip"
 msgstr "&Pular"
 
-#: ../src/richtext/richtextindentspage.cpp:242
 #: ../src/richtext/richtextliststylepage.cpp:417
+#: ../src/richtext/richtextindentspage.cpp:242
 msgid "&Spacing (tenths of a mm)"
 msgstr "&Espaçamento (décimos de um mm)"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "&Spell Check"
 msgstr "&Verificação da Ortografia"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "&Stop"
 msgstr "&Parar"
 
-#: ../src/richtext/richtextfontpage.cpp:275 ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196 ../src/richtext/richtextfontpage.cpp:275
 msgid "&Strikethrough"
 msgstr "&Sublinhado"
 
-#: ../src/generic/fontdlgg.cpp:382 ../src/richtext/richtextstylepage.cpp:106
+#: ../src/generic/fontdlgg.cpp:378 ../src/richtext/richtextstylepage.cpp:106
 msgid "&Style:"
 msgstr "&Estilo:"
 
-#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:194
 msgid "&Styles:"
 msgstr "&Estilos:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:413
+#: ../src/richtext/richtextsymboldlg.cpp:410
 msgid "&Subset:"
 msgstr "&Subset:"
 
@@ -707,24 +731,24 @@ msgstr "&Símbolo:"
 msgid "&Synchronize values"
 msgstr "&Sincronizar valores"
 
-#: ../include/wx/richtext/richtextbuffer.h:6069
+#: ../include/wx/richtext/richtextbuffer.h:6064
 msgid "&Table"
 msgstr "&Tabela"
 
-#: ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197
 msgid "&Top"
 msgstr "&Topo"
 
+#: ../src/richtext/richtextsizepage.cpp:567
+#: ../src/richtext/richtextsizepage.cpp:574
 #: ../src/richtext/richtextborderspage.cpp:311
 #: ../src/richtext/richtextborderspage.cpp:479
 #: ../src/richtext/richtextmarginspage.cpp:234
 #: ../src/richtext/richtextmarginspage.cpp:348
-#: ../src/richtext/richtextsizepage.cpp:567
-#: ../src/richtext/richtextsizepage.cpp:574
 msgid "&Top:"
 msgstr "&Topo:"
 
-#: ../src/generic/fontdlgg.cpp:444 ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199 ../src/generic/fontdlgg.cpp:441
 msgid "&Underline"
 msgstr "&Sublinhar"
 
@@ -732,21 +756,21 @@ msgstr "&Sublinhar"
 msgid "&Underlining:"
 msgstr "&Sublinhado:"
 
-#: ../src/richtext/richtextctrl.cpp:329 ../src/osx/textctrl_osx.cpp:573
-#: ../src/common/stockitem.cpp:203 ../src/common/cmdproc.cpp:271
-#: ../src/msw/textctrl.cpp:2504
+#: ../src/osx/textctrl_osx.cpp:591 ../src/common/stockitem.cpp:200
+#: ../src/common/cmdproc.cpp:264 ../src/msw/textctrl.cpp:2769
+#: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Desfazer"
 
-#: ../src/common/cmdproc.cpp:265
+#: ../src/common/cmdproc.cpp:258
 msgid "&Undo "
 msgstr "&Desfazer "
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "&Unindent"
 msgstr "&Sem parágrafo"
 
-#: ../src/common/stockitem.cpp:205
+#: ../src/common/stockitem.cpp:202
 msgid "&Up"
 msgstr "&Pra cima"
 
@@ -762,7 +786,7 @@ msgstr "&Offset Vertical:"
 msgid "&View..."
 msgstr "&Visualizar..."
 
-#: ../src/generic/fontdlgg.cpp:393
+#: ../src/generic/fontdlgg.cpp:389
 msgid "&Weight:"
 msgstr "&Peso:"
 
@@ -771,88 +795,58 @@ msgstr "&Peso:"
 msgid "&Width:"
 msgstr "&Largura:"
 
-#: ../src/aui/tabmdi.cpp:311 ../src/aui/tabmdi.cpp:327
-#: ../src/aui/tabmdi.cpp:329 ../src/generic/mdig.cpp:294
-#: ../src/generic/mdig.cpp:310 ../src/generic/mdig.cpp:314
-#: ../src/msw/mdi.cpp:78
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
 msgid "&Window"
 msgstr "&Janela"
 
-#: ../src/common/stockitem.cpp:206 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:203 ../src/msw/msgdlg.cpp:435
 msgid "&Yes"
 msgstr "&Sim"
 
-#: ../src/common/valtext.cpp:256
-#, c-format
-msgid "'%s' contains illegal characters"
+#: ../src/common/valtext.cpp:197
+#, fuzzy, c-format
+msgid "'%s' contains invalid character(s)"
 msgstr "'%s' contém caracteres ilegais"
 
-#: ../src/common/valtext.cpp:254
-#, c-format
-msgid "'%s' doesn't consist only of valid characters"
-msgstr "'%s' não consiste apenas de caracteres válidos"
-
-#: ../src/common/config.cpp:519 ../src/msw/regconf.cpp:258
+#: ../src/common/config.cpp:515 ../src/msw/regconf.cpp:255
 #, c-format
 msgid "'%s' has extra '..', ignored."
 msgstr "'%s' tem extras '..'; ignorados."
 
-#: ../src/common/cmdline.cpp:1113 ../src/common/cmdline.cpp:1131
+#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' não é um valor numérico correto para a opção '%s'."
 
-#: ../src/common/translation.cpp:1100
+#: ../src/common/translation.cpp:1142
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' não é um catálogo de mensagens válido."
 
-#: ../src/common/valtext.cpp:165
+#: ../src/common/valtext.cpp:188
 #, c-format
 msgid "'%s' is not one of the valid strings"
 msgstr "'%s' não é uma das sequências válidas"
 
-#: ../src/common/valtext.cpp:167
+#: ../src/common/valtext.cpp:186
 #, c-format
 msgid "'%s' is one of the invalid strings"
 msgstr "'%s' é uma das sequências inválidas"
 
-#: ../src/common/textbuf.cpp:237
+#: ../src/common/textbuf.cpp:233
 #, c-format
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' é provavelmente um buffer binário."
-
-#: ../src/common/valtext.cpp:252
-#, c-format
-msgid "'%s' should be numeric."
-msgstr "'%s' deve ser numérico."
-
-#: ../src/common/valtext.cpp:244
-#, c-format
-msgid "'%s' should only contain ASCII characters."
-msgstr "'%s' deve conter apenas caracteres ASCII."
-
-#: ../src/common/valtext.cpp:246
-#, c-format
-msgid "'%s' should only contain alphabetic characters."
-msgstr "'%s' deve conter apenas caracteres alfabéticos."
-
-#: ../src/common/valtext.cpp:248
-#, c-format
-msgid "'%s' should only contain alphabetic or numeric characters."
-msgstr "'%s' deve conter apenas caracteres alfabéticos ou numéricos."
-
-#: ../src/common/valtext.cpp:250
-#, c-format
-msgid "'%s' should only contain digits."
-msgstr "'%s' deve conter apenas dígitos."
 
 #: ../src/richtext/richtextliststylepage.cpp:229
 #: ../src/richtext/richtextbulletspage.cpp:166
 msgid "(*)"
 msgstr "(*)"
 
-#: ../src/html/helpwnd.cpp:963
+#: ../src/html/helpwnd.cpp:961
 msgid "(Help)"
 msgstr "(Ajuda)"
 
@@ -861,27 +855,32 @@ msgstr "(Ajuda)"
 msgid "(None)"
 msgstr "(Nenhum)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:504
+#: ../src/richtext/richtextsymboldlg.cpp:503
 msgid "(Normal text)"
 msgstr "(Texto normal)"
 
-#: ../src/html/helpwnd.cpp:419 ../src/html/helpwnd.cpp:1106
-#: ../src/html/helpwnd.cpp:1742
+#: ../src/html/helpwnd.cpp:417 ../src/html/helpwnd.cpp:1104
+#: ../src/html/helpwnd.cpp:1740
 msgid "(bookmarks)"
 msgstr "(favoritos)"
 
+#: ../src/msw/dlmsw.cpp:167
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (erro %ld: %s)"
+
+#: ../src/richtext/richtextformatdlg.cpp:876
+#: ../src/richtext/richtextliststylepage.cpp:448
+#: ../src/richtext/richtextliststylepage.cpp:460
+#: ../src/richtext/richtextliststylepage.cpp:461
 #: ../src/richtext/richtextindentspage.cpp:274
 #: ../src/richtext/richtextindentspage.cpp:286
 #: ../src/richtext/richtextindentspage.cpp:287
 #: ../src/richtext/richtextindentspage.cpp:311
 #: ../src/richtext/richtextindentspage.cpp:326
-#: ../src/richtext/richtextformatdlg.cpp:884
 #: ../src/richtext/richtextfontpage.cpp:349
 #: ../src/richtext/richtextfontpage.cpp:353
 #: ../src/richtext/richtextfontpage.cpp:357
-#: ../src/richtext/richtextliststylepage.cpp:448
-#: ../src/richtext/richtextliststylepage.cpp:460
-#: ../src/richtext/richtextliststylepage.cpp:461
 msgid "(none)"
 msgstr "(nenhum)"
 
@@ -900,7 +899,7 @@ msgstr "*)"
 msgid "+"
 msgstr "+"
 
-#: ../src/msw/utils.cpp:1152
+#: ../src/msw/utils.cpp:1143
 msgid ", 64-bit edition"
 msgstr ", edição de 64 bits"
 
@@ -909,163 +908,163 @@ msgstr ", edição de 64 bits"
 msgid "-"
 msgstr "-"
 
-#: ../src/generic/filepickerg.cpp:66
+#: ../src/generic/filepickerg.cpp:63
 msgid "..."
 msgstr "..."
 
-#: ../src/richtext/richtextindentspage.cpp:276
 #: ../src/richtext/richtextliststylepage.cpp:450
+#: ../src/richtext/richtextindentspage.cpp:276
 msgid "1.1"
 msgstr "1.1"
 
-#: ../src/richtext/richtextindentspage.cpp:277
 #: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextindentspage.cpp:277
 msgid "1.2"
 msgstr "1.2"
 
-#: ../src/richtext/richtextindentspage.cpp:278
 #: ../src/richtext/richtextliststylepage.cpp:452
+#: ../src/richtext/richtextindentspage.cpp:278
 msgid "1.3"
 msgstr "1.3"
 
-#: ../src/richtext/richtextindentspage.cpp:279
 #: ../src/richtext/richtextliststylepage.cpp:453
+#: ../src/richtext/richtextindentspage.cpp:279
 msgid "1.4"
 msgstr "1.4"
 
-#: ../src/richtext/richtextindentspage.cpp:280
 #: ../src/richtext/richtextliststylepage.cpp:454
+#: ../src/richtext/richtextindentspage.cpp:280
 msgid "1.5"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:281
 #: ../src/richtext/richtextliststylepage.cpp:455
+#: ../src/richtext/richtextindentspage.cpp:281
 msgid "1.6"
 msgstr "1.6"
 
-#: ../src/richtext/richtextindentspage.cpp:282
 #: ../src/richtext/richtextliststylepage.cpp:456
+#: ../src/richtext/richtextindentspage.cpp:282
 msgid "1.7"
 msgstr "1.7"
 
-#: ../src/richtext/richtextindentspage.cpp:283
 #: ../src/richtext/richtextliststylepage.cpp:457
+#: ../src/richtext/richtextindentspage.cpp:283
 msgid "1.8"
 msgstr "1.8"
 
-#: ../src/richtext/richtextindentspage.cpp:284
 #: ../src/richtext/richtextliststylepage.cpp:458
+#: ../src/richtext/richtextindentspage.cpp:284
 msgid "1.9"
 msgstr "1.9"
 
-#: ../src/common/paper.cpp:140
+#: ../src/common/paper.cpp:137
 msgid "10 x 11 in"
 msgstr "10 x 11 em"
 
-#: ../src/common/paper.cpp:113
+#: ../src/common/paper.cpp:110
 msgid "10 x 14 in"
 msgstr "10 x 14 em"
 
-#: ../src/common/paper.cpp:114
+#: ../src/common/paper.cpp:111
 msgid "11 x 17 in"
 msgstr "11 x 17 em"
 
-#: ../src/common/paper.cpp:184
+#: ../src/common/paper.cpp:181
 msgid "12 x 11 in"
 msgstr "12 x 11 em"
 
-#: ../src/common/paper.cpp:141
+#: ../src/common/paper.cpp:138
 msgid "15 x 11 in"
 msgstr "15 x 11 em"
 
-#: ../src/richtext/richtextindentspage.cpp:285
 #: ../src/richtext/richtextliststylepage.cpp:459
+#: ../src/richtext/richtextindentspage.cpp:285
 msgid "2"
 msgstr "2"
 
-#: ../src/common/paper.cpp:132
+#: ../src/common/paper.cpp:129
 msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
 msgstr "Envelope 6 3/4, 3 5/8 x 6 1/2 em"
 
-#: ../src/common/paper.cpp:139
+#: ../src/common/paper.cpp:136
 msgid "9 x 11 in"
 msgstr "9 x 11 em"
 
-#: ../src/html/htmprint.cpp:431
+#: ../src/html/htmprint.cpp:443
 msgid ": file does not exist!"
 msgstr ": o arquivo não existe!"
 
-#: ../src/common/fontmap.cpp:199
+#: ../src/common/fontmap.cpp:196
 msgid ": unknown charset"
 msgstr ": conjunto de caracteres desconhecido"
 
-#: ../src/common/fontmap.cpp:413
+#: ../src/common/fontmap.cpp:410
 msgid ": unknown encoding"
 msgstr ": codificação desconhecida"
 
-#: ../src/generic/wizard.cpp:443
+#: ../src/generic/wizard.cpp:438
 msgid "< &Back"
 msgstr "< &Voltar"
 
-#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:628
-#: ../src/osx/carbon/fontdlg.cpp:648
+#: ../src/osx/carbon/fontdlg.cpp:419 ../src/osx/carbon/fontdlg.cpp:625
+#: ../src/osx/carbon/fontdlg.cpp:645
 msgid "<Any Decorative>"
 msgstr "<Qualquer Decorativo>"
 
-#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:630
-#: ../src/osx/carbon/fontdlg.cpp:650
+#: ../src/osx/carbon/fontdlg.cpp:420 ../src/osx/carbon/fontdlg.cpp:627
+#: ../src/osx/carbon/fontdlg.cpp:647
 msgid "<Any Modern>"
 msgstr "<Qualquer Moderno>"
 
-#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:626
-#: ../src/osx/carbon/fontdlg.cpp:646
+#: ../src/osx/carbon/fontdlg.cpp:418 ../src/osx/carbon/fontdlg.cpp:623
+#: ../src/osx/carbon/fontdlg.cpp:643
 msgid "<Any Roman>"
 msgstr "<Qualquer Romano>"
 
-#: ../src/osx/carbon/fontdlg.cpp:424 ../src/osx/carbon/fontdlg.cpp:632
-#: ../src/osx/carbon/fontdlg.cpp:652
+#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:629
+#: ../src/osx/carbon/fontdlg.cpp:649
 msgid "<Any Script>"
 msgstr "<Qualquer Script>"
 
-#: ../src/osx/carbon/fontdlg.cpp:425 ../src/osx/carbon/fontdlg.cpp:637
-#: ../src/osx/carbon/fontdlg.cpp:656
+#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:634
+#: ../src/osx/carbon/fontdlg.cpp:653
 msgid "<Any Swiss>"
 msgstr "<Qualquer Suíço>"
 
-#: ../src/osx/carbon/fontdlg.cpp:426 ../src/osx/carbon/fontdlg.cpp:634
-#: ../src/osx/carbon/fontdlg.cpp:654
+#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:631
+#: ../src/osx/carbon/fontdlg.cpp:651
 msgid "<Any Teletype>"
 msgstr "<Qualquer Teletipo>"
 
-#: ../src/osx/carbon/fontdlg.cpp:420
+#: ../src/osx/carbon/fontdlg.cpp:417
 msgid "<Any>"
 msgstr "<Qualquer>"
 
-#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
 msgid "<DIR>"
 msgstr "<DIR>"
 
-#: ../src/generic/filectrlg.cpp:254 ../src/generic/filectrlg.cpp:277
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
 msgid "<DRIVE>"
 msgstr "<DRIVE>"
 
-#: ../src/generic/filectrlg.cpp:252 ../src/generic/filectrlg.cpp:275
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
 msgid "<LINK>"
 msgstr "<LINK>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1264
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Face em negrito itálico.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1270
+#: ../src/html/helpwnd.cpp:1268
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>negrito itálico <u>sublinhado</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1265
+#: ../src/html/helpwnd.cpp:1263
 msgid "<b>Bold face.</b> "
 msgstr "<b>Face em negrito.</b> "
 
-#: ../src/html/helpwnd.cpp:1264
+#: ../src/html/helpwnd.cpp:1262
 msgid "<i>Italic face.</i> "
 msgstr "<i>Face em itálico.</i> "
 
@@ -1074,15 +1073,15 @@ msgstr "<i>Face em itálico.</i> "
 msgid ">"
 msgstr ">"
 
-#: ../src/generic/dbgrptg.cpp:318
+#: ../src/generic/dbgrptg.cpp:317
 msgid "A debug report has been generated in the directory\n"
 msgstr "Um relatório de debug foi gerado no diretório\n"
 
-#: ../src/common/debugrpt.cpp:573
+#: ../src/common/debugrpt.cpp:574
 msgid "A debug report has been generated. It can be found in"
 msgstr "Um relatório de debug foi gerado. Ele pode ser achado em"
 
-#: ../src/common/xtixml.cpp:418
+#: ../src/common/xtixml.cpp:414
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Uma coleção não vazia deve consistir de nodes do elemento"
 
@@ -1093,106 +1092,106 @@ msgstr "Uma coleção não vazia deve consistir de nodes do elemento"
 msgid "A standard bullet name."
 msgstr "Um nome padrão para a projétil."
 
-#: ../src/common/paper.cpp:217
+#: ../src/common/paper.cpp:214
 msgid "A0 sheet, 841 x 1189 mm"
 msgstr "Folha A0, 841 x 1189 mm"
 
-#: ../src/common/paper.cpp:218
+#: ../src/common/paper.cpp:215
 msgid "A1 sheet, 594 x 841 mm"
 msgstr "Folha A1, 594 x 841 mm"
 
-#: ../src/common/paper.cpp:159
+#: ../src/common/paper.cpp:156
 msgid "A2 420 x 594 mm"
 msgstr "A2 420 x 594 mm"
 
-#: ../src/common/paper.cpp:156
+#: ../src/common/paper.cpp:153
 msgid "A3 Extra 322 x 445 mm"
 msgstr "A3 Extra 322 x 445 mm"
 
-#: ../src/common/paper.cpp:161
+#: ../src/common/paper.cpp:158
 msgid "A3 Extra Transverse 322 x 445 mm"
 msgstr "A3 Extra transversal 322 x 445 mm"
 
-#: ../src/common/paper.cpp:170
+#: ../src/common/paper.cpp:167
 msgid "A3 Rotated 420 x 297 mm"
 msgstr "A3 Rotacionada 420 x 297 mm"
 
-#: ../src/common/paper.cpp:160
+#: ../src/common/paper.cpp:157
 msgid "A3 Transverse 297 x 420 mm"
 msgstr "A3 transversal 297 x 420 mm"
 
-#: ../src/common/paper.cpp:106
+#: ../src/common/paper.cpp:103
 msgid "A3 sheet, 297 x 420 mm"
 msgstr "Folha A3, 297 x 420 mm"
 
-#: ../src/common/paper.cpp:146
+#: ../src/common/paper.cpp:143
 msgid "A4 Extra 9.27 x 12.69 in"
 msgstr "A4 Extra 9.27 x 12.69 em"
 
-#: ../src/common/paper.cpp:153
+#: ../src/common/paper.cpp:150
 msgid "A4 Plus 210 x 330 mm"
 msgstr "A4 Plus 210 x 330 mm"
 
-#: ../src/common/paper.cpp:171
+#: ../src/common/paper.cpp:168
 msgid "A4 Rotated 297 x 210 mm"
 msgstr "A4 Rotacionada 297 x 210 mm"
 
-#: ../src/common/paper.cpp:148
+#: ../src/common/paper.cpp:145
 msgid "A4 Transverse 210 x 297 mm"
 msgstr "A4 Transversal 210 x 297 mm"
 
-#: ../src/common/paper.cpp:97
+#: ../src/common/paper.cpp:94
 msgid "A4 sheet, 210 x 297 mm"
 msgstr "Folha A4 210 x 297 mm"
 
-#: ../src/common/paper.cpp:107
+#: ../src/common/paper.cpp:104
 msgid "A4 small sheet, 210 x 297 mm"
 msgstr "Folha A4 pequena, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:157
+#: ../src/common/paper.cpp:154
 msgid "A5 Extra 174 x 235 mm"
 msgstr "A5 Extra 174 x 235 mm"
 
-#: ../src/common/paper.cpp:172
+#: ../src/common/paper.cpp:169
 msgid "A5 Rotated 210 x 148 mm"
 msgstr "A5 Rotacionada 210 x 148 mm"
 
-#: ../src/common/paper.cpp:154
+#: ../src/common/paper.cpp:151
 msgid "A5 Transverse 148 x 210 mm"
 msgstr "A5 Tranversal 148 x 210 mm"
 
-#: ../src/common/paper.cpp:108
+#: ../src/common/paper.cpp:105
 msgid "A5 sheet, 148 x 210 mm"
 msgstr "Folha A5, 148 x 210 mm"
 
-#: ../src/common/paper.cpp:164
+#: ../src/common/paper.cpp:161
 msgid "A6 105 x 148 mm"
 msgstr "A6 105 x 148 mm"
 
-#: ../src/common/paper.cpp:177
+#: ../src/common/paper.cpp:174
 msgid "A6 Rotated 148 x 105 mm"
 msgstr "A6 Rotacionada 148 x 105 mm"
 
-#: ../src/generic/fontdlgg.cpp:83 ../src/richtext/richtextformatdlg.cpp:529
-#: ../src/osx/carbon/fontdlg.cpp:153
+#: ../src/osx/carbon/fontdlg.cpp:150 ../src/generic/fontdlgg.cpp:79
+#: ../src/richtext/richtextformatdlg.cpp:521
 msgid "ABCDEFGabcdefg12345"
 msgstr "ABCDEFGabcdefg12345"
 
-#: ../src/richtext/richtextsymboldlg.cpp:458 ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
 msgid "ASCII"
 msgstr "ASCII"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "About"
 msgstr "Sobre"
 
-#: ../src/generic/aboutdlgg.cpp:140 ../src/osx/menu_osx.cpp:558
-#: ../src/msw/aboutdlg.cpp:64
+#: ../src/osx/menu_osx.cpp:450 ../src/generic/aboutdlgg.cpp:137
+#: ../src/msw/aboutdlg.cpp:61
 #, c-format
 msgid "About %s"
 msgstr "Sobre o %s"
 
-#: ../src/osx/menu_osx.cpp:560
+#: ../src/osx/menu_osx.cpp:452
 msgid "About..."
 msgstr "Sobre..."
 
@@ -1201,37 +1200,37 @@ msgid "Absolute"
 msgstr "Absoluto"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:873
+#: ../src/propgrid/advprops.cpp:774
 msgid "ActiveBorder"
 msgstr "BordaAtiva"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:874
+#: ../src/propgrid/advprops.cpp:775
 msgid "ActiveCaption"
 msgstr "CaptionAtivo"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "Actual Size"
 msgstr "Tamanho Real"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:140 ../src/common/accelcmn.cpp:81
+#: ../src/common/stockitem.cpp:137 ../src/common/accelcmn.cpp:78
 msgid "Add"
 msgstr "Adicionar"
 
-#: ../src/richtext/richtextbuffer.cpp:11455
+#: ../src/richtext/richtextbuffer.cpp:11454
 msgid "Add Column"
 msgstr "Adicionar Coluna"
 
-#: ../src/richtext/richtextbuffer.cpp:11392
+#: ../src/richtext/richtextbuffer.cpp:11391
 msgid "Add Row"
 msgstr "Adicionar Fileira"
 
-#: ../src/html/helpwnd.cpp:432
+#: ../src/html/helpwnd.cpp:430
 msgid "Add current page to bookmarks"
 msgstr "Adicionar a página atual aos favoritos"
 
-#: ../src/generic/colrdlgg.cpp:366
+#: ../src/generic/colrdlgg.cpp:386
 msgid "Add to custom colours"
 msgstr "Adicionar as cores personalizadas"
 
@@ -1243,12 +1242,12 @@ msgstr "AddToPropertyCollection chamado num acessor genérico"
 msgid "AddToPropertyCollection called w/o valid adder"
 msgstr "AddToPropertyCollection chamado com ou sem adicionador válido"
 
-#: ../src/html/helpctrl.cpp:159
+#: ../src/html/helpctrl.cpp:155
 #, c-format
 msgid "Adding book %s"
 msgstr "Adicionando o livro %s"
 
-#: ../src/common/preferencescmn.cpp:43
+#: ../src/common/preferencescmn.cpp:40
 msgid "Advanced"
 msgstr "Avançado"
 
@@ -1256,11 +1255,11 @@ msgstr "Avançado"
 msgid "After a paragraph:"
 msgstr "Após um parágrafo:"
 
-#: ../src/common/stockitem.cpp:172
+#: ../src/common/stockitem.cpp:169
 msgid "Align Left"
 msgstr "Alinhar a Esquerda"
 
-#: ../src/common/stockitem.cpp:173
+#: ../src/common/stockitem.cpp:170
 msgid "Align Right"
 msgstr "Alinhar a Direita"
 
@@ -1268,40 +1267,40 @@ msgstr "Alinhar a Direita"
 msgid "Alignment"
 msgstr "Alinhamento"
 
-#: ../src/generic/prntdlgg.cpp:215
+#: ../src/generic/prntdlgg.cpp:208
 msgid "All"
 msgstr "Tudo"
 
-#: ../src/generic/filectrlg.cpp:1197 ../src/common/fldlgcmn.cpp:107
+#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1186
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Todos os arquivos (%s)|%s"
 
-#: ../include/wx/defs.h:2886
+#: ../include/wx/defs.h:2582
 msgid "All files (*)|*"
 msgstr "Todos os arquivos (*)|*"
 
-#: ../include/wx/defs.h:2883
+#: ../include/wx/defs.h:2579
 msgid "All files (*.*)|*.*"
 msgstr "Todos os arquivos (*.*)|*.*"
 
-#: ../src/richtext/richtextstyles.cpp:1061
+#: ../src/richtext/richtextstyles.cpp:1058
 msgid "All styles"
 msgstr "Todos os estilos"
 
-#: ../src/propgrid/manager.cpp:1528
+#: ../src/propgrid/manager.cpp:1544
 msgid "Alphabetic Mode"
 msgstr "Modo Alfabético"
 
-#: ../src/common/xtistrm.cpp:425
+#: ../src/common/xtistrm.cpp:422
 msgid "Already Registered Object passed to SetObjectClassInfo"
 msgstr "Objeto Já Registrado passado para o SetObjectClassInfo"
 
-#: ../src/unix/dialup.cpp:353
+#: ../src/unix/dialup.cpp:352
 msgid "Already dialling ISP."
 msgstr "Já discando para o ISP."
 
-#: ../src/common/accelcmn.cpp:331 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/accelcmn.cpp:345 ../src/univ/themes/win32.cpp:3753
 msgid "Alt+"
 msgstr "Alt+"
 
@@ -1310,34 +1309,34 @@ msgstr "Alt+"
 msgid "An optional corner radius for adding rounded corners."
 msgstr "Um raio adicional do canto para adicionar cantos arredondados."
 
-#: ../src/common/debugrpt.cpp:576
+#: ../src/common/debugrpt.cpp:577
 msgid "And includes the following files:\n"
 msgstr "E inclui os seguintes arquivos:\n"
 
-#: ../src/generic/animateg.cpp:162
+#: ../src/generic/animateg.cpp:145
 #, c-format
 msgid "Animation file is not of type %ld."
 msgstr "O arquivo de animação não é do tipo %ld."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:872
+#: ../src/propgrid/advprops.cpp:773
 msgid "AppWorkspace"
 msgstr "AppWorkspace"
 
-#: ../src/generic/logg.cpp:1014
+#: ../src/generic/logg.cpp:1011
 #, c-format
 msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
 msgstr "Anexar o log ao arquivo '%s'? (escolher [Não] sobrescreverá ele)?"
 
-#: ../src/osx/menu_osx.cpp:577 ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:469 ../src/osx/menu_osx.cpp:477
 msgid "Application"
 msgstr "Aplicativo"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "Apply"
 msgstr "Aplicar"
 
-#: ../src/propgrid/advprops.cpp:1609
+#: ../src/propgrid/advprops.cpp:1515
 msgid "Aqua"
 msgstr "Aqua"
 
@@ -1346,29 +1345,29 @@ msgstr "Aqua"
 msgid "Arabic"
 msgstr "Árabe"
 
-#: ../src/common/fmapbase.cpp:153
+#: ../src/common/fmapbase.cpp:150
 msgid "Arabic (ISO-8859-6)"
 msgstr "Árabe (ISO-8859-6)"
 
-#: ../src/msw/ole/automtn.cpp:672
+#: ../src/msw/ole/automtn.cpp:663
 #, c-format
 msgid "Argument %u not found."
 msgstr "Argumento %u não achado."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1753
+#: ../src/propgrid/advprops.cpp:1654
 msgid "Arrow"
 msgstr "Seta"
 
-#: ../src/generic/aboutdlgg.cpp:184
+#: ../src/generic/aboutdlgg.cpp:181
 msgid "Artists"
 msgstr "Artistas"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "Ascending"
 msgstr "Ascendente"
 
-#: ../src/generic/filectrlg.cpp:433
+#: ../src/generic/filectrlg.cpp:429
 msgid "Attributes"
 msgstr "Atributos"
 
@@ -1378,90 +1377,90 @@ msgstr "Atributos"
 msgid "Available fonts."
 msgstr "Fontes disponíveis."
 
-#: ../src/common/paper.cpp:137
+#: ../src/common/paper.cpp:134
 msgid "B4 (ISO) 250 x 353 mm"
 msgstr "B4 (ISO) 250 x 353 mm"
 
-#: ../src/common/paper.cpp:173
+#: ../src/common/paper.cpp:170
 msgid "B4 (JIS) Rotated 364 x 257 mm"
 msgstr "B4 (JIS) Rotacionada 364 x 257 mm"
 
-#: ../src/common/paper.cpp:127
+#: ../src/common/paper.cpp:124
 msgid "B4 Envelope, 250 x 353 mm"
 msgstr "Envelope B4, 250 x 353 mm"
 
-#: ../src/common/paper.cpp:109
+#: ../src/common/paper.cpp:106
 msgid "B4 sheet, 250 x 354 mm"
 msgstr "Folha B4, 250 x 354 mm"
 
-#: ../src/common/paper.cpp:158
+#: ../src/common/paper.cpp:155
 msgid "B5 (ISO) Extra 201 x 276 mm"
 msgstr "B5 (ISO) Extra 201 x 276 mm"
 
-#: ../src/common/paper.cpp:174
+#: ../src/common/paper.cpp:171
 msgid "B5 (JIS) Rotated 257 x 182 mm"
 msgstr "B5 (JIS) Rotacionada 257 x 182 mm"
 
-#: ../src/common/paper.cpp:155
+#: ../src/common/paper.cpp:152
 msgid "B5 (JIS) Transverse 182 x 257 mm"
 msgstr "B5 (JIS) Transversal 182 x 257 mm"
 
-#: ../src/common/paper.cpp:128
+#: ../src/common/paper.cpp:125
 msgid "B5 Envelope, 176 x 250 mm"
 msgstr "Envelope B5, 176 x 250 mm"
 
-#: ../src/common/paper.cpp:110
+#: ../src/common/paper.cpp:107
 msgid "B5 sheet, 182 x 257 millimeter"
 msgstr "Folha B5, 182 x 257 milímetros"
 
-#: ../src/common/paper.cpp:182
+#: ../src/common/paper.cpp:179
 msgid "B6 (JIS) 128 x 182 mm"
 msgstr "B6 (JIS) 128 x 182 mm"
 
-#: ../src/common/paper.cpp:183
+#: ../src/common/paper.cpp:180
 msgid "B6 (JIS) Rotated 182 x 128 mm"
 msgstr "B6 (JIS) Rotacionada 182 x 128 mm"
 
-#: ../src/common/paper.cpp:129
+#: ../src/common/paper.cpp:126
 msgid "B6 Envelope, 176 x 125 mm"
 msgstr "Envelope B6, 176 x 125 mm"
 
-#: ../src/common/imagbmp.cpp:531 ../src/common/imagbmp.cpp:561
-#: ../src/common/imagbmp.cpp:576
+#: ../src/common/imagbmp.cpp:528 ../src/common/imagbmp.cpp:558
+#: ../src/common/imagbmp.cpp:573
 msgid "BMP: Couldn't allocate memory."
 msgstr "BMP: Não consegue distribuir a memória."
 
-#: ../src/common/imagbmp.cpp:100
+#: ../src/common/imagbmp.cpp:97
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: Não consegue salvar a imagem inválida."
 
-#: ../src/common/imagbmp.cpp:356
+#: ../src/common/imagbmp.cpp:353
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: Não consegue gravar o mapa das cores RGB."
 
-#: ../src/common/imagbmp.cpp:490
+#: ../src/common/imagbmp.cpp:487
 msgid "BMP: Couldn't write data."
 msgstr "BMP: Não consegue gravar os dados."
 
-#: ../src/common/imagbmp.cpp:246
+#: ../src/common/imagbmp.cpp:243
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: Não consegue gravar o cabeçalho do arquivo (Bitmap)."
 
-#: ../src/common/imagbmp.cpp:269
+#: ../src/common/imagbmp.cpp:266
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: Não consegue gravar o cabeçalho do arquivo (BitmapInfo)."
 
-#: ../src/common/imagbmp.cpp:140
+#: ../src/common/imagbmp.cpp:137
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: o wxImage não tem uma wxPalette própria."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:142 ../src/common/accelcmn.cpp:52
+#: ../src/common/stockitem.cpp:139 ../src/common/accelcmn.cpp:49
 msgid "Back"
 msgstr "Voltar"
 
+#: ../src/richtext/richtextformatdlg.cpp:377
 #: ../src/richtext/richtextbackgroundpage.cpp:148
-#: ../src/richtext/richtextformatdlg.cpp:384
 msgid "Background"
 msgstr "2º plano"
 
@@ -1469,20 +1468,20 @@ msgstr "2º plano"
 msgid "Background &colour:"
 msgstr "Côr do &2º plano:"
 
-#: ../src/osx/carbon/fontdlg.cpp:220
+#: ../src/osx/carbon/fontdlg.cpp:217
 msgid "Background colour"
 msgstr "Côr do 2º plano"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:52
+#: ../src/common/accelcmn.cpp:49
 msgid "Backspace"
 msgstr "Backspace"
 
-#: ../src/common/fmapbase.cpp:160
+#: ../src/common/fmapbase.cpp:157
 msgid "Baltic (ISO-8859-13)"
 msgstr "Báltico (ISO-8859-13)"
 
-#: ../src/common/fmapbase.cpp:151
+#: ../src/common/fmapbase.cpp:148
 msgid "Baltic (old) (ISO-8859-4)"
 msgstr "Báltico (antigo) (ISO-8859-4)"
 
@@ -1495,25 +1494,25 @@ msgstr "Antes de um parágrafo:"
 msgid "Bitmap"
 msgstr "Bitmap"
 
-#: ../src/propgrid/advprops.cpp:1594
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Black"
 msgstr "Preto"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1755
+#: ../src/propgrid/advprops.cpp:1656
 msgid "Blank"
 msgstr "Em branco"
 
-#: ../src/propgrid/advprops.cpp:1603
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Blue"
 msgstr "Azul"
 
-#: ../src/generic/colrdlgg.cpp:345
+#: ../src/generic/colrdlgg.cpp:365
 msgid "Blue:"
 msgstr "Azul:"
 
-#: ../src/generic/fontdlgg.cpp:333 ../src/richtext/richtextfontpage.cpp:355
-#: ../src/osx/carbon/fontdlg.cpp:354 ../src/common/stockitem.cpp:143
+#: ../src/osx/carbon/fontdlg.cpp:351 ../src/common/stockitem.cpp:140
+#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:355
 msgid "Bold"
 msgstr "Negrito"
 
@@ -1522,31 +1521,35 @@ msgstr "Negrito"
 msgid "Border"
 msgstr "Borda"
 
-#: ../src/richtext/richtextformatdlg.cpp:379
+#: ../src/richtext/richtextformatdlg.cpp:372
 msgid "Borders"
 msgstr "Bordas"
 
-#: ../src/richtext/richtextsizepage.cpp:288 ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141 ../src/richtext/richtextsizepage.cpp:288
 msgid "Bottom"
 msgstr "Rodapé"
 
-#: ../src/generic/prntdlgg.cpp:893
+#: ../src/generic/prntdlgg.cpp:886
 msgid "Bottom margin (mm):"
 msgstr "Margem do rodapé (mm):"
 
-#: ../src/richtext/richtextbuffer.cpp:9383
+#: ../src/richtext/richtextbuffer.cpp:9380
 msgid "Box Properties"
 msgstr "Propriedades da Caixa"
 
-#: ../src/richtext/richtextstyles.cpp:1065
+#: ../src/richtext/richtextstyles.cpp:1062
 msgid "Box styles"
 msgstr "Estilos de caixa"
 
-#: ../src/propgrid/advprops.cpp:1602
+#: ../src/osx/cocoa/menu.mm:292
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Brown"
 msgstr "Marrom"
 
-#: ../src/common/filepickercmn.cpp:43 ../src/common/filepickercmn.cpp:44
+#: ../src/common/filepickercmn.cpp:40 ../src/common/filepickercmn.cpp:41
 msgid "Browse"
 msgstr "Procurar"
 
@@ -1559,72 +1562,72 @@ msgstr "Alinhamento da &Bala:"
 msgid "Bullet style"
 msgstr "Estilo da projétil"
 
-#: ../src/richtext/richtextformatdlg.cpp:359
+#: ../src/richtext/richtextformatdlg.cpp:352
 msgid "Bullets"
 msgstr "Balas"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1756
+#: ../src/propgrid/advprops.cpp:1657
 msgid "Bullseye"
 msgstr "Bullseye"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:875
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonFace"
 msgstr "FaceDoBotão"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:876
+#: ../src/propgrid/advprops.cpp:777
 msgid "ButtonHighlight"
 msgstr "DestaqueDoBotão"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:877
+#: ../src/propgrid/advprops.cpp:778
 msgid "ButtonShadow"
 msgstr "SombraDoBotão"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:878
+#: ../src/propgrid/advprops.cpp:779
 msgid "ButtonText"
 msgstr "TextoDoBotão"
 
-#: ../src/common/paper.cpp:98
+#: ../src/common/paper.cpp:95
 msgid "C sheet, 17 x 22 in"
 msgstr "Folha C, 17 x 22 em"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "C&lear"
 msgstr "L&impar"
 
-#: ../src/generic/fontdlgg.cpp:406
+#: ../src/generic/fontdlgg.cpp:403
 msgid "C&olour:"
 msgstr "C&ôr:"
 
-#: ../src/common/paper.cpp:123
+#: ../src/common/paper.cpp:120
 msgid "C3 Envelope, 324 x 458 mm"
 msgstr "Envelope C3, 324 x 458 mm"
 
-#: ../src/common/paper.cpp:124
+#: ../src/common/paper.cpp:121
 msgid "C4 Envelope, 229 x 324 mm"
 msgstr "Envelope C4, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:122
+#: ../src/common/paper.cpp:119
 msgid "C5 Envelope, 162 x 229 mm"
 msgstr "Envelope C5, 162 x 229 mm"
 
-#: ../src/common/paper.cpp:125
+#: ../src/common/paper.cpp:122
 msgid "C6 Envelope, 114 x 162 mm"
 msgstr "Envelope C6, 114 x 162 mm"
 
-#: ../src/common/paper.cpp:126
+#: ../src/common/paper.cpp:123
 msgid "C65 Envelope, 114 x 229 mm"
 msgstr "Envelope C65, 114 x 229 mm"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "CD-Rom"
 msgstr "CD-Rom"
 
-#: ../src/html/chm.cpp:815 ../src/html/chm.cpp:874
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:865
 msgid "CHM handler currently supports only local files!"
 msgstr "O manejador CHM suporta atualmente apenas arquivos locais!"
 
@@ -1632,194 +1635,198 @@ msgstr "O manejador CHM suporta atualmente apenas arquivos locais!"
 msgid "Ca&pitals"
 msgstr "Ma&iúsculas"
 
-#: ../src/common/cmdproc.cpp:267
+#: ../src/common/cmdproc.cpp:260
 msgid "Can't &Undo "
 msgstr "Não Consegue &Desfazer "
 
-#: ../src/common/image.cpp:2824
+#: ../src/common/image.cpp:2924
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 "Não consegue determinar automaticamente o formato da imagem para entrada de "
 "dados não-procuráveis."
 
-#: ../src/msw/registry.cpp:506
+#: ../src/msw/registry.cpp:495
 #, c-format
 msgid "Can't close registry key '%s'"
 msgstr "Não consegue fechar a chave de registro '%s'"
 
-#: ../src/msw/registry.cpp:584
+#: ../src/msw/registry.cpp:573
 #, c-format
 msgid "Can't copy values of unsupported type %d."
 msgstr "Não consegue copiar os valores dos tipos não suportados %d."
 
-#: ../src/msw/registry.cpp:487
+#: ../src/msw/registry.cpp:476
 #, c-format
 msgid "Can't create registry key '%s'"
 msgstr "Não consegue criar a chave de registro '%s'"
 
-#: ../src/msw/thread.cpp:665
+#: ../src/msw/thread.cpp:657
 msgid "Can't create thread"
 msgstr "Não consegue criar o thread"
 
-#: ../src/msw/window.cpp:3691
-#, c-format
-msgid "Can't create window of class %s"
-msgstr "Não consegue criar a janela da classe %s"
-
-#: ../src/msw/registry.cpp:777
+#: ../src/msw/registry.cpp:765
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Não consegue apagar a chave '%s'"
 
-#: ../src/msw/iniconf.cpp:458
+#: ../src/msw/iniconf.cpp:455
 #, c-format
 msgid "Can't delete the INI file '%s'"
 msgstr "Não consegue apagar o arquivo INI '%s'"
 
-#: ../src/msw/registry.cpp:805
+#: ../src/msw/registry.cpp:793
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Não consegue apagar o valor '%s' da chave '%s'"
 
-#: ../src/msw/registry.cpp:1171
+#: ../src/msw/registry.cpp:1159
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Não consegue enumerar as sub-chaves da chave '%s'"
 
-#: ../src/msw/registry.cpp:1132
+#: ../src/msw/registry.cpp:1120
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Não consegue enumerar os valores da chave '%s'"
 
-#: ../src/msw/registry.cpp:1389
+#: ../src/msw/registry.cpp:1377
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Não consegue exportar o valor do tipo não suportado %d."
 
-#: ../src/common/ffile.cpp:254
+#: ../src/common/ffile.cpp:253
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Não consegue achar a posição atual no arquivo '%s'"
 
-#: ../src/msw/registry.cpp:418
+#: ../src/msw/registry.cpp:407
 #, c-format
 msgid "Can't get info about registry key '%s'"
 msgstr "Não consegue obter a info sobre a chave de registro '%s'"
 
-#: ../src/common/zstream.cpp:346
+#: ../src/msw/webview_ie.cpp:1024
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "Não consegue definir a prioridade do thread"
+
+#: ../src/common/zstream.cpp:343
 msgid "Can't initialize zlib deflate stream."
 msgstr "Não consegue inicializar o fluxo de deflação do zlib."
 
-#: ../src/common/zstream.cpp:185
+#: ../src/common/zstream.cpp:182
 msgid "Can't initialize zlib inflate stream."
 msgstr "Não consegue inicializar o fluxo de inflação do zlib."
 
-#: ../src/msw/fswatcher.cpp:476
+#: ../src/msw/fswatcher.cpp:475
 #, c-format
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "Não consegue monitorar o diretório não-existente \"%s\" por mudanças."
 
-#: ../src/msw/registry.cpp:454
+#: ../src/msw/registry.cpp:443
 #, c-format
 msgid "Can't open registry key '%s'"
 msgstr "Não consegue abrir a chave do registro '%s'"
 
-#: ../src/common/zstream.cpp:252
+#: ../src/common/zstream.cpp:249
 #, c-format
 msgid "Can't read from inflate stream: %s"
 msgstr "Não consegue ler do fluxo de inflação: %s"
 
-#: ../src/common/zstream.cpp:244
+#: ../src/common/zstream.cpp:241
 msgid "Can't read inflate stream: unexpected EOF in underlying stream."
 msgstr "Não consegue ler o fluxo da inflação: EOF inexperado no fluxo básico."
 
-#: ../src/msw/registry.cpp:1064
+#: ../src/msw/registry.cpp:1052
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Não consegue ler o valor de '%s'"
 
-#: ../src/msw/registry.cpp:878 ../src/msw/registry.cpp:910
-#: ../src/msw/registry.cpp:975
+#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
+#: ../src/msw/registry.cpp:963
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Não consegue ler o valor da chave '%s'"
 
-#: ../src/common/image.cpp:2620
+#: ../src/msw/webview_ie.cpp:1017
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/common/image.cpp:2715
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "Nâo consegue salvar a imagem no arquivo '%s': extensão desconhecida."
 
-#: ../src/generic/logg.cpp:573 ../src/generic/logg.cpp:976
+#: ../src/generic/logg.cpp:570 ../src/generic/logg.cpp:973
 msgid "Can't save log contents to file."
 msgstr "Não consegue salvar os conteúdos do log no arquivo."
 
-#: ../src/msw/thread.cpp:629
+#: ../src/msw/thread.cpp:621
 msgid "Can't set thread priority"
 msgstr "Não consegue definir a prioridade do thread"
 
-#: ../src/msw/registry.cpp:896 ../src/msw/registry.cpp:938
-#: ../src/msw/registry.cpp:1081
+#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
+#: ../src/msw/registry.cpp:1069
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Não consegue definir o valor de '%s'"
 
-#: ../src/unix/utilsunx.cpp:351
+#: ../src/unix/utilsunx.cpp:353
 msgid "Can't write to child process's stdin"
 msgstr "Não consegue gravar como processo criança do stdin"
 
-#: ../src/common/zstream.cpp:427
+#: ../src/common/zstream.cpp:424
 #, c-format
 msgid "Can't write to deflate stream: %s"
 msgstr "Não consegue gravar no fluxo de deflação: %s"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:279 ../src/richtext/richtextstyledlg.cpp:300
-#: ../src/common/stockitem.cpp:145 ../src/common/accelcmn.cpp:71
-#: ../src/msw/msgdlg.cpp:454 ../src/msw/progdlg.cpp:673
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:142
+#: ../src/common/accelcmn.cpp:68 ../src/motif/msgdlg.cpp:196
+#: ../src/gtk1/fontdlg.cpp:144 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/progdlg.cpp:940 ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: ../src/common/filefn.cpp:1261
+#: ../src/common/filefn.cpp:1149
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Não consegue enumerar os arquivos '%s'"
 
-#: ../src/msw/dir.cpp:263
+#: ../src/msw/dir.cpp:260
 #, c-format
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Não consegue enumerar os arquivos no diretório '%s'"
 
-#: ../src/msw/dialup.cpp:523
+#: ../src/msw/dialup.cpp:517
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Não consegue achar uma conexão dial-up ativa: %s"
 
-#: ../src/msw/dialup.cpp:827
+#: ../src/msw/dialup.cpp:821
 msgid "Cannot find the location of address book file"
 msgstr "Não consegue achar o local do arquivo do livro de endereços"
 
-#: ../src/msw/ole/automtn.cpp:562
+#: ../src/msw/ole/automtn.cpp:553
 #, c-format
 msgid "Cannot get an active instance of \"%s\""
 msgstr "Não consegue obter uma instância ativa de \"%s\""
 
-#: ../src/unix/threadpsx.cpp:1035
+#: ../src/unix/threadpsx.cpp:1053
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr ""
 "Não consegue obter o alcance da prioridade para a norma de conduta do "
 "agendamento %d."
 
-#: ../src/unix/utilsunx.cpp:987
+#: ../src/unix/utilsunx.cpp:989
 msgid "Cannot get the hostname"
 msgstr "Não consegue obter o nome do host"
 
-#: ../src/unix/utilsunx.cpp:1023
+#: ../src/unix/utilsunx.cpp:1025
 msgid "Cannot get the official hostname"
 msgstr "Não consegue obter o nome oficial do host"
 
-#: ../src/msw/dialup.cpp:928
+#: ../src/msw/dialup.cpp:922
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Não consegue desligar - nenhuma conexão dial-up ativa."
 
@@ -1827,126 +1834,126 @@ msgstr "Não consegue desligar - nenhuma conexão dial-up ativa."
 msgid "Cannot initialize OLE"
 msgstr "Não consegue inicializar o OLE"
 
-#: ../src/common/socket.cpp:853
+#: ../src/common/socket.cpp:850
 msgid "Cannot initialize sockets"
 msgstr "Não consegue inicializar os sockets"
 
-#: ../src/msw/volume.cpp:619
+#: ../src/msw/volume.cpp:627
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Não consegue carregar o ícone do '%s'."
 
-#: ../src/xrc/xmlres.cpp:360
+#: ../src/xrc/xmlres.cpp:358
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Não consegue carregar os recursos de '%s'."
 
-#: ../src/xrc/xmlres.cpp:742
+#: ../src/xrc/xmlres.cpp:740
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Não consegue carregar os recursos do arquivo '%s'."
 
-#: ../src/html/htmlfilt.cpp:137
+#: ../src/html/htmlfilt.cpp:134
 #, c-format
 msgid "Cannot open HTML document: %s"
 msgstr "Não consegue abrir o documento HTML: %s"
 
-#: ../src/html/helpdata.cpp:667
+#: ../src/html/helpdata.cpp:660
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Não consegue abrir o livro de ajuda em HTML: %s"
 
-#: ../src/html/helpdata.cpp:299
+#: ../src/html/helpdata.cpp:296
 #, c-format
 msgid "Cannot open contents file: %s"
 msgstr "Não consegue abrir o arquivo dos conteúdos: %s"
 
-#: ../src/generic/dcpsg.cpp:1667
+#: ../src/generic/dcpsg.cpp:1665
 msgid "Cannot open file for PostScript printing!"
 msgstr "Não consegue abrir o arquivo para a impressão PostScript!"
 
-#: ../src/html/helpdata.cpp:313
+#: ../src/html/helpdata.cpp:310
 #, c-format
 msgid "Cannot open index file: %s"
 msgstr "Não consegue abrir o arquivo do índice: %s"
 
-#: ../src/xrc/xmlres.cpp:724
+#: ../src/xrc/xmlres.cpp:722
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Não consegue abrir os recursos de '%s'."
 
-#: ../src/html/helpwnd.cpp:1534
+#: ../src/html/helpwnd.cpp:1532
 msgid "Cannot print empty page."
 msgstr "Não consegue imprimir a página vazia."
 
-#: ../src/msw/volume.cpp:507
+#: ../src/msw/volume.cpp:515
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Não consegue ler o nome do tipo de '%s'!"
 
-#: ../src/msw/thread.cpp:888
+#: ../src/msw/thread.cpp:894
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Não consegue resumir o thread %lx"
 
-#: ../src/unix/threadpsx.cpp:1016
+#: ../src/unix/threadpsx.cpp:1028
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Não consegue recuperar a norma de conduta do agendamento dos threads."
 
-#: ../src/common/intl.cpp:558
+#: ../src/common/intl.cpp:365
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "Não consegue definir o locale pro idioma \"%s\"."
 
-#: ../src/unix/threadpsx.cpp:831 ../src/msw/thread.cpp:546
+#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
 msgid "Cannot start thread: error writing TLS."
 msgstr "Não consegue iniciar o thread: erro ao gravar o TLS."
 
-#: ../src/msw/thread.cpp:872
+#: ../src/msw/thread.cpp:864
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Não consegue suspender o thread %lx"
 
-#: ../src/msw/thread.cpp:794
+#: ../src/msw/thread.cpp:786
 msgid "Cannot wait for thread termination"
 msgstr "Não consegue esperar pelo término do thread"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:75
+#: ../src/common/accelcmn.cpp:72
 msgid "Capital"
 msgstr "Maiúscula"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:879
+#: ../src/propgrid/advprops.cpp:780
 msgid "CaptionText"
 msgstr "TextoDoCaption"
 
-#: ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:531
 msgid "Case sensitive"
 msgstr "Caso sensitivo"
 
-#: ../src/propgrid/manager.cpp:1509
+#: ../src/propgrid/manager.cpp:1527
 msgid "Categorized Mode"
 msgstr "Modo Categorizado"
 
-#: ../src/richtext/richtextbuffer.cpp:9968
+#: ../src/richtext/richtextbuffer.cpp:9965
 msgid "Cell Properties"
 msgstr "Propriedades da Célula"
 
-#: ../src/common/fmapbase.cpp:161
+#: ../src/common/fmapbase.cpp:158
 msgid "Celtic (ISO-8859-14)"
 msgstr "Celta (ISO-8859-14)"
 
-#: ../src/richtext/richtextindentspage.cpp:160
 #: ../src/richtext/richtextliststylepage.cpp:349
+#: ../src/richtext/richtextindentspage.cpp:160
 msgid "Cen&tred"
 msgstr "Cen&tralizado"
 
-#: ../src/common/stockitem.cpp:170
+#: ../src/common/stockitem.cpp:167
 msgid "Centered"
 msgstr "Centralizado"
 
-#: ../src/common/fmapbase.cpp:149
+#: ../src/common/fmapbase.cpp:146
 msgid "Central European (ISO-8859-2)"
 msgstr "Europeu Central (ISO-8859-2)"
 
@@ -1955,10 +1962,10 @@ msgstr "Europeu Central (ISO-8859-2)"
 msgid "Centre"
 msgstr "Centro"
 
-#: ../src/richtext/richtextindentspage.cpp:162
-#: ../src/richtext/richtextindentspage.cpp:164
 #: ../src/richtext/richtextliststylepage.cpp:351
 #: ../src/richtext/richtextliststylepage.cpp:353
+#: ../src/richtext/richtextindentspage.cpp:162
+#: ../src/richtext/richtextindentspage.cpp:164
 msgid "Centre text."
 msgstr "Centralizar texto."
 
@@ -1971,24 +1978,24 @@ msgstr "Centralizado"
 msgid "Ch&oose..."
 msgstr "Es&colher..."
 
-#: ../src/richtext/richtextbuffer.cpp:4354
+#: ../src/richtext/richtextbuffer.cpp:4351
 msgid "Change List Style"
 msgstr "Mudar o Estilo da Lista"
 
-#: ../src/richtext/richtextbuffer.cpp:3709
+#: ../src/richtext/richtextbuffer.cpp:3706
 msgid "Change Object Style"
 msgstr "Mudar o Estilo do Objeto"
 
-#: ../src/richtext/richtextbuffer.cpp:3982
-#: ../src/richtext/richtextbuffer.cpp:8129
+#: ../src/richtext/richtextbuffer.cpp:3979
+#: ../src/richtext/richtextbuffer.cpp:8125
 msgid "Change Properties"
 msgstr "Mudar Propriedades"
 
-#: ../src/richtext/richtextbuffer.cpp:3526
+#: ../src/richtext/richtextbuffer.cpp:3523
 msgid "Change Style"
 msgstr "Mudar o Estilo"
 
-#: ../src/common/fileconf.cpp:341
+#: ../src/common/fileconf.cpp:335
 #, c-format
 msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
 msgstr ""
@@ -2001,11 +2008,11 @@ msgid "Changing current directory to \"%s\" failed"
 msgstr "Falhou em mudar o diretório atual para %s"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1757
+#: ../src/propgrid/advprops.cpp:1658
 msgid "Character"
 msgstr "Caractere"
 
-#: ../src/richtext/richtextstyles.cpp:1063
+#: ../src/richtext/richtextstyles.cpp:1060
 msgid "Character styles"
 msgstr "Estilos dos caracteres"
 
@@ -2042,20 +2049,20 @@ msgstr "Marque para cercar a projétil com parênteses."
 msgid "Check to indicate right-to-left text layout."
 msgstr "Marque pra indicar o layout do texto da direita-pra-esquerda."
 
-#: ../src/osx/carbon/fontdlg.cpp:356 ../src/osx/carbon/fontdlg.cpp:358
+#: ../src/osx/carbon/fontdlg.cpp:353 ../src/osx/carbon/fontdlg.cpp:355
 msgid "Check to make the font bold."
 msgstr "Marque para fazer a fonte ficar em negrito."
 
-#: ../src/osx/carbon/fontdlg.cpp:363 ../src/osx/carbon/fontdlg.cpp:365
+#: ../src/osx/carbon/fontdlg.cpp:360 ../src/osx/carbon/fontdlg.cpp:362
 msgid "Check to make the font italic."
 msgstr "Marque para fazer a fonte ficar em itálico."
 
-#: ../src/osx/carbon/fontdlg.cpp:372 ../src/osx/carbon/fontdlg.cpp:374
+#: ../src/osx/carbon/fontdlg.cpp:369 ../src/osx/carbon/fontdlg.cpp:371
 msgid "Check to make the font underlined."
 msgstr "Marque para fazer a fonte ficar sublinhada."
 
-#: ../src/richtext/richtextstyledlg.cpp:289
-#: ../src/richtext/richtextstyledlg.cpp:291
+#: ../src/richtext/richtextstyledlg.cpp:285
+#: ../src/richtext/richtextstyledlg.cpp:287
 msgid "Check to restart numbering."
 msgstr "Marque para reiniciar a numeração."
 
@@ -2089,51 +2096,51 @@ msgstr "Marque para mostrar o texto em superscript."
 msgid "Check to suppress hyphenation."
 msgstr "Marque pra suprimir a hifenação."
 
-#: ../src/msw/dialup.cpp:763
+#: ../src/msw/dialup.cpp:757
 msgid "Choose ISP to dial"
 msgstr "Escolha um ISP para discar"
 
-#: ../src/propgrid/props.cpp:1922
+#: ../src/propgrid/props.cpp:1904
 msgid "Choose a directory:"
 msgstr "Escolha um diretório:"
 
-#: ../src/propgrid/props.cpp:1975
+#: ../src/propgrid/props.cpp:2199
 msgid "Choose a file"
 msgstr "Escolha um arquivo"
 
-#: ../src/generic/colrdlgg.cpp:158 ../src/gtk/colordlg.cpp:54
+#: ../src/generic/colrdlgg.cpp:156 ../src/gtk/colordlg.cpp:49
 msgid "Choose colour"
 msgstr "Escolha uma côr"
 
-#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/gtk1/fontdlg.cpp:125 ../src/generic/fontpickerg.cpp:47
+#: ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Escolha uma fonte"
 
-#: ../src/common/module.cpp:74
+#: ../src/common/module.cpp:71
 #, c-format
 msgid "Circular dependency involving module \"%s\" detected."
 msgstr "Dependência circular envolvendo o módulo \"%s\" detectada."
 
-#: ../src/aui/tabmdi.cpp:108 ../src/generic/mdig.cpp:97
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
 msgid "Cl&ose"
 msgstr "Fe&char"
 
-#: ../src/msw/ole/automtn.cpp:684
+#: ../src/msw/ole/automtn.cpp:675
 msgid "Class not registered."
 msgstr "Classe não registrada."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:147 ../src/common/accelcmn.cpp:72
+#: ../src/common/stockitem.cpp:144 ../src/common/accelcmn.cpp:69
 msgid "Clear"
 msgstr "Limpar"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "Clear the log contents"
 msgstr "Limpar os conteúdos do log"
 
-#: ../src/richtext/richtextstyledlg.cpp:252
-#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:248
+#: ../src/richtext/richtextstyledlg.cpp:250
 msgid "Click to apply the selected style."
 msgstr "Clique para aplicar o estilo selecionado."
 
@@ -2144,15 +2151,15 @@ msgstr "Clique para aplicar o estilo selecionado."
 msgid "Click to browse for a symbol."
 msgstr "Clique para procurar por um símbolo."
 
-#: ../src/osx/carbon/fontdlg.cpp:403 ../src/osx/carbon/fontdlg.cpp:405
+#: ../src/osx/carbon/fontdlg.cpp:400 ../src/osx/carbon/fontdlg.cpp:402
 msgid "Click to cancel changes to the font."
 msgstr "Clique para cancelar as mudanças na fonte."
 
-#: ../src/generic/fontdlgg.cpp:472 ../src/generic/fontdlgg.cpp:491
+#: ../src/generic/fontdlgg.cpp:468 ../src/generic/fontdlgg.cpp:487
 msgid "Click to cancel the font selection."
 msgstr "Clique para cancelar a seleção da fonte."
 
-#: ../src/osx/carbon/fontdlg.cpp:384 ../src/osx/carbon/fontdlg.cpp:386
+#: ../src/osx/carbon/fontdlg.cpp:381 ../src/osx/carbon/fontdlg.cpp:383
 msgid "Click to change the font colour."
 msgstr "Clique para mudar a côr da fonte."
 
@@ -2171,37 +2178,37 @@ msgstr "Clique pra mudar a côr do texto."
 msgid "Click to choose the font for this level."
 msgstr "Clique pra escolher a fonte para este nível."
 
-#: ../src/richtext/richtextstyledlg.cpp:279
-#: ../src/richtext/richtextstyledlg.cpp:281
+#: ../src/richtext/richtextstyledlg.cpp:275
+#: ../src/richtext/richtextstyledlg.cpp:277
 msgid "Click to close this window."
 msgstr "Clique pra fechar esta janela."
 
-#: ../src/osx/carbon/fontdlg.cpp:410 ../src/osx/carbon/fontdlg.cpp:412
+#: ../src/osx/carbon/fontdlg.cpp:407 ../src/osx/carbon/fontdlg.cpp:409
 msgid "Click to confirm changes to the font."
 msgstr "Clique para confirmar as mudanças na fonte."
 
-#: ../src/generic/fontdlgg.cpp:477 ../src/generic/fontdlgg.cpp:479
-#: ../src/generic/fontdlgg.cpp:484 ../src/generic/fontdlgg.cpp:486
+#: ../src/generic/fontdlgg.cpp:473 ../src/generic/fontdlgg.cpp:475
+#: ../src/generic/fontdlgg.cpp:480 ../src/generic/fontdlgg.cpp:482
 msgid "Click to confirm the font selection."
 msgstr "Clique para confirmar a seleção da fonte."
 
-#: ../src/richtext/richtextstyledlg.cpp:244
-#: ../src/richtext/richtextstyledlg.cpp:246
+#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:242
 msgid "Click to create a new box style."
 msgstr "Clique para criar um novo estilo de caixas."
 
-#: ../src/richtext/richtextstyledlg.cpp:226
-#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:224
 msgid "Click to create a new character style."
 msgstr "Clique para criar um novo estilo de caracteres."
 
-#: ../src/richtext/richtextstyledlg.cpp:238
-#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:236
 msgid "Click to create a new list style."
 msgstr "Clique para criar um novo estilo de listas."
 
-#: ../src/richtext/richtextstyledlg.cpp:232
-#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:230
 msgid "Click to create a new paragraph style."
 msgstr "Clique para criar um novo estilo de parágrafo."
 
@@ -2215,8 +2222,8 @@ msgstr "Clique para criar uma nova posição de aba."
 msgid "Click to delete all tab positions."
 msgstr "Clique para apagar todas as posições da aba."
 
-#: ../src/richtext/richtextstyledlg.cpp:270
-#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:268
 msgid "Click to delete the selected style."
 msgstr "Clique para apagar o estilo selecionado."
 
@@ -2225,25 +2232,25 @@ msgstr "Clique para apagar o estilo selecionado."
 msgid "Click to delete the selected tab position."
 msgstr "Clique para apagar a posição da aba selecionada."
 
-#: ../src/richtext/richtextstyledlg.cpp:264
-#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:262
 msgid "Click to edit the selected style."
 msgstr "Clique para editar o estilo selecionado."
 
-#: ../src/richtext/richtextstyledlg.cpp:258
-#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:256
 msgid "Click to rename the selected style."
 msgstr "Clique para renomear o estilo selecionado."
 
-#: ../src/generic/dbgrptg.cpp:97 ../src/generic/progdlgg.cpp:759
-#: ../src/richtext/richtextstyledlg.cpp:277
-#: ../src/richtext/richtextsymboldlg.cpp:476 ../src/common/stockitem.cpp:148
-#: ../src/msw/progdlg.cpp:170 ../src/msw/progdlg.cpp:679
-#: ../src/html/helpdlg.cpp:90
+#: ../src/common/stockitem.cpp:145 ../src/generic/dbgrptg.cpp:94
+#: ../src/generic/progdlgg.cpp:781 ../src/msw/progdlg.cpp:211
+#: ../src/msw/progdlg.cpp:946 ../src/html/helpdlg.cpp:87
+#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextstyledlg.cpp:273
 msgid "Close"
 msgstr "Fechar"
 
-#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:98
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
 msgid "Close All"
 msgstr "Fechar Tudo"
 
@@ -2251,43 +2258,43 @@ msgstr "Fechar Tudo"
 msgid "Close current document"
 msgstr "Fechar o documento atual"
 
-#: ../src/generic/logg.cpp:516
+#: ../src/generic/logg.cpp:513
 msgid "Close this window"
 msgstr "Fechar esta janela"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6006
+#: ../src/generic/datavgen.cpp:6811
 msgid "Collapse"
 msgstr "Retrair"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "Color"
 msgstr "Côr"
 
-#: ../src/richtext/richtextformatdlg.cpp:776
+#: ../src/richtext/richtextformatdlg.cpp:768
 msgid "Colour"
 msgstr "Côr"
 
-#: ../src/msw/colordlg.cpp:158
+#: ../src/msw/colordlg.cpp:227
 #, c-format
 msgid "Colour selection dialog failed with error %0lx."
 msgstr "O diálogo da seleção de cores falhou com o erro %0lx."
 
-#: ../src/osx/carbon/fontdlg.cpp:380
+#: ../src/osx/carbon/fontdlg.cpp:377
 msgid "Colour:"
 msgstr "Côr:"
 
-#: ../src/generic/datavgen.cpp:6077
+#: ../src/generic/datavgen.cpp:6882
 #, c-format
 msgid "Column %u"
 msgstr "Coluna %u"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:114
+#: ../src/common/accelcmn.cpp:112
 msgid "Command"
 msgstr "Comando"
 
-#: ../src/common/init.cpp:196
+#: ../src/common/init.cpp:193
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
@@ -2296,12 +2303,12 @@ msgstr ""
 "O argumento da linha de comando %d não pôde ser convertido para o Unicode e "
 "será ignorado."
 
-#: ../src/msw/fontdlg.cpp:120
+#: ../src/msw/fontdlg.cpp:170
 #, c-format
 msgid "Common dialog failed with error code %0lx."
 msgstr "O diálogo comum falhou com o código do erro %0lx."
 
-#: ../src/gtk/window.cpp:4649
+#: ../src/gtk/window.cpp:5653
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
@@ -2309,11 +2316,11 @@ msgstr ""
 "Composição não suportado por este sistema, por favor ative-a no seu "
 "Gerenciador de Janelas."
 
-#: ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:1549
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Arquivo de ajuda em HTML Compactado (*.chm)|*.chm|"
 
-#: ../src/generic/dirctrlg.cpp:444
+#: ../src/generic/dirctrlg.cpp:410
 msgid "Computer"
 msgstr "Computador"
 
@@ -2322,53 +2329,57 @@ msgstr "Computador"
 msgid "Config entry name cannot start with '%c'."
 msgstr "O nome da entrada da config não pode iniciar com '%c'."
 
-#: ../src/generic/filedlgg.cpp:349 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
 msgid "Confirm"
 msgstr "Confirmar"
 
-#: ../src/html/htmlwin.cpp:566
+#: ../src/html/htmlwin.cpp:569
 msgid "Connecting..."
 msgstr "Conectando..."
 
-#: ../src/html/helpwnd.cpp:475
+#: ../src/html/helpwnd.cpp:473
 msgid "Contents"
 msgstr "Conteúdos"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:880
+#: ../src/propgrid/advprops.cpp:781
 msgid "ControlDark"
 msgstr "ControlEscuro"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:881
+#: ../src/propgrid/advprops.cpp:782
 msgid "ControlLight"
 msgstr "ControlClaro"
 
-#: ../src/common/strconv.cpp:2262
+#: ../src/common/strconv.cpp:2208
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "A conversão para o conjunto de caracteres '%s' não funciona."
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "Convert"
 msgstr "Converter"
 
-#: ../src/html/htmlwin.cpp:1079
+#: ../src/html/htmlwin.cpp:1020
 #, c-format
 msgid "Copied to clipboard:\"%s\""
 msgstr "Copiado para a área de transferência:\"%s\""
 
-#: ../src/generic/prntdlgg.cpp:247
+#: ../src/generic/prntdlgg.cpp:240
 msgid "Copies:"
 msgstr "Cópias:"
 
-#: ../src/common/stockitem.cpp:150 ../src/stc/stc_i18n.cpp:18
+#: ../src/common/stockitem.cpp:147 ../src/stc/stc_i18n.cpp:18
 msgid "Copy"
 msgstr "Copiar"
 
-#: ../src/common/stockitem.cpp:258
+#: ../src/common/stockitem.cpp:255
 msgid "Copy selection"
 msgstr "Copiar a seleção"
+
+#: ../src/generic/grid.cpp:5945
+msgid "Copying more than one selected block to clipboard is not supported."
+msgstr ""
 
 #: ../src/richtext/richtextborderspage.cpp:566
 #: ../src/richtext/richtextborderspage.cpp:601
@@ -2379,197 +2390,194 @@ msgstr "Canto"
 msgid "Corner &radius:"
 msgstr "Raio do &canto:"
 
-#: ../src/html/chm.cpp:718
+#: ../src/html/chm.cpp:711
 #, c-format
 msgid "Could not create temporary file '%s'"
 msgstr "Não pôde criar o arquivo temporário '%s'"
 
-#: ../src/html/chm.cpp:273
+#: ../src/html/chm.cpp:270
 #, c-format
 msgid "Could not extract %s into %s: %s"
 msgstr "Não pôde extrair %s para %s: %s"
 
-#: ../src/generic/tabg.cpp:1048
+#: ../src/generic/tabg.cpp:1045
 msgid "Could not find tab for id"
 msgstr "Não pôde achar a aba pela id"
 
-#: ../src/gtk/notifmsg.cpp:108
-msgid "Could not initalize libnotify."
-msgstr "Não pôde inicializar o libnotify."
-
-#: ../src/html/chm.cpp:444
+#: ../src/html/chm.cpp:437
 #, c-format
 msgid "Could not locate file '%s'."
 msgstr "Não pôde localizar o arquivo '%s'."
 
-#: ../src/common/filefn.cpp:1403
+#: ../src/msw/graphicsd2d.cpp:604
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/common/filefn.cpp:1291
 msgid "Could not set current working directory"
 msgstr "Não pôde definir o diretório de trabalho atual"
 
-#: ../src/common/prntbase.cpp:2015
+#: ../src/common/prntbase.cpp:2037
 msgid "Could not start document preview."
 msgstr "Não pôde iniciar a pré-visualização do documento."
 
-#: ../src/generic/printps.cpp:178 ../src/msw/printwin.cpp:210
-#: ../src/gtk/print.cpp:1132
+#: ../src/generic/printps.cpp:159 ../src/msw/printwin.cpp:184
+#: ../src/gtk/print.cpp:1129
 msgid "Could not start printing."
 msgstr "Não pôde iniciar a impressão."
 
-#: ../src/common/wincmn.cpp:2125
+#: ../src/common/wincmn.cpp:2126
 msgid "Could not transfer data to window"
 msgstr "Não pôde transferir os dados para a janela"
 
-#: ../src/msw/imaglist.cpp:187 ../src/msw/imaglist.cpp:224
-#: ../src/msw/imaglist.cpp:249 ../src/msw/dragimag.cpp:185
-#: ../src/msw/dragimag.cpp:220
+#: ../src/msw/imaglist.cpp:223 ../src/msw/imaglist.cpp:245
+#: ../src/msw/imaglist.cpp:270 ../src/msw/dragimag.cpp:182
+#: ../src/msw/dragimag.cpp:217
 msgid "Couldn't add an image to the image list."
 msgstr "Não pôde adicionar uma imagem a lista de imagens."
 
-#: ../src/osx/glcanvas_osx.cpp:414 ../src/unix/glx11.cpp:558
-#: ../src/msw/glcanvas.cpp:616
+#: ../src/osx/glcanvas_osx.cpp:411 ../src/msw/glcanvas.cpp:631
+#: ../src/unix/glegl.cpp:315 ../src/unix/glx11.cpp:559
 msgid "Couldn't create OpenGL context"
 msgstr "Não pôde criar o contexto do OpenGL"
 
-#: ../src/msw/timer.cpp:134
+#: ../src/msw/timer.cpp:131
 msgid "Couldn't create a timer"
 msgstr "Não pôde criar um timer"
 
-#: ../src/osx/carbon/overlay.cpp:122
-msgid "Couldn't create the overlay window"
-msgstr "Não pôde criar a janela do overlay"
-
-#: ../src/common/translation.cpp:2024
+#: ../src/common/translation.cpp:2074
 msgid "Couldn't enumerate translations"
 msgstr "Não pôde enumerar as traduções"
 
-#: ../src/common/dynlib.cpp:120
+#: ../src/common/dynlib.cpp:110
 #, c-format
 msgid "Couldn't find symbol '%s' in a dynamic library"
 msgstr "Não pôde achar o símbolo '%s' em uma biblioteca dinâmica"
 
-#: ../src/msw/thread.cpp:915
+#: ../src/msw/thread.cpp:921
 msgid "Couldn't get the current thread pointer"
 msgstr "Não pôde obter o ponteiro atual do thread"
 
-#: ../src/osx/carbon/overlay.cpp:129
-msgid "Couldn't init the context on the overlay window"
-msgstr "Não pôde inicializar o contexto na janela do overlay"
-
-#: ../src/common/imaggif.cpp:244
+#: ../src/common/imaggif.cpp:241
 msgid "Couldn't initialize GIF hash table."
 msgstr "Não pôde inicializar a tabela de hashes do GIF."
 
-#: ../src/common/imagpng.cpp:409
+#: ../src/common/imagpng.cpp:437
 msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
 msgstr ""
 "Não pôde carregar uma imagem PNG - o arquivo está corrompido ou não tem "
 "memória o bastante."
 
-#: ../src/unix/sound.cpp:470
+#: ../src/unix/sound.cpp:459
 #, c-format
 msgid "Couldn't load sound data from '%s'."
 msgstr "Não pôde carregar os dados do som de '%s'."
 
-#: ../src/msw/dirdlg.cpp:435
+#: ../src/msw/dirdlg.cpp:287
 msgid "Couldn't obtain folder name"
 msgstr "Não pôde obter o nome da pasta"
 
-#: ../src/unix/sound_sdl.cpp:229
+#: ../src/unix/sound_sdl.cpp:226
 #, c-format
 msgid "Couldn't open audio: %s"
 msgstr "Não pôde abrir o áudio: %s"
 
-#: ../src/msw/ole/dataobj.cpp:377
+#: ../src/msw/ole/dataobj.cpp:385
 #, c-format
 msgid "Couldn't register clipboard format '%s'."
 msgstr "Não pôde registrar o formato da área de transferência '%s'."
 
-#: ../src/msw/listctrl.cpp:869
+#: ../src/msw/listctrl.cpp:933
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr ""
 "Não pôde recuperar a informação sobre o item de controle das listas %d."
 
-#: ../src/common/imagpng.cpp:498 ../src/common/imagpng.cpp:509
-#: ../src/common/imagpng.cpp:519
+#: ../src/common/imagpng.cpp:511 ../src/common/imagpng.cpp:522
+#: ../src/common/imagpng.cpp:532
 msgid "Couldn't save PNG image."
 msgstr "Não pôde salvar a imagem PNG."
 
-#: ../src/msw/thread.cpp:684
+#: ../src/msw/thread.cpp:676
 msgid "Couldn't terminate thread"
 msgstr "Não pôde encerrar o thread"
 
-#: ../src/common/xtistrm.cpp:166
+#: ../src/common/xtistrm.cpp:163
 #, c-format
 msgid "Create Parameter %s not found in declared RTTI Parameters"
 msgstr "Criar Parâmetro %s não achado nos Parâmetros RTTI declarados"
 
-#: ../src/generic/dirdlgg.cpp:288
+#: ../src/generic/dirdlgg.cpp:285
 msgid "Create directory"
 msgstr "Criar diretório"
 
-#: ../src/generic/filedlgg.cpp:212 ../src/generic/dirdlgg.cpp:111
+#: ../src/generic/filedlgg.cpp:209 ../src/generic/dirdlgg.cpp:108
 msgid "Create new directory"
 msgstr "Criar novo diretório"
 
-#: ../src/xrc/xmlres.cpp:2460
+#: ../src/common/stockitem.cpp:264
+#, fuzzy
+msgid "Create new document"
+msgstr "Criar novo diretório"
+
+#: ../src/xrc/xmlres.cpp:2515
 #, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Falhou em criar %s \"%s\"."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1758
+#: ../src/propgrid/advprops.cpp:1659
 msgid "Cross"
 msgstr "Cruz"
 
-#: ../src/common/accelcmn.cpp:333
+#: ../src/common/accelcmn.cpp:347
 msgid "Ctrl+"
 msgstr "Ctrl+"
 
-#: ../src/richtext/richtextctrl.cpp:332 ../src/osx/textctrl_osx.cpp:576
-#: ../src/common/stockitem.cpp:151 ../src/msw/textctrl.cpp:2507
+#: ../src/osx/textctrl_osx.cpp:594 ../src/common/stockitem.cpp:148
+#: ../src/msw/textctrl.cpp:2772 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "Co&rtar"
 
-#: ../src/generic/filectrlg.cpp:940
+#: ../src/generic/filectrlg.cpp:936
 msgid "Current directory:"
 msgstr "Diretório atual:"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:896 ../src/propgrid/advprops.cpp:1574
-#: ../src/propgrid/advprops.cpp:1612
+#: ../src/propgrid/advprops.cpp:797 ../src/propgrid/advprops.cpp:1475
+#: ../src/propgrid/advprops.cpp:1518
 msgid "Custom"
 msgstr "Personalizado"
 
-#: ../src/gtk/print.cpp:217
+#: ../src/gtk/print.cpp:211
 msgid "Custom size"
 msgstr "Tamanho personalizado"
 
-#: ../src/common/headerctrlcmn.cpp:60
+#: ../src/common/headerctrlcmn.cpp:58
 msgid "Customize Columns"
 msgstr "Personalizar Colunas"
 
-#: ../src/common/stockitem.cpp:151 ../src/stc/stc_i18n.cpp:17
+#: ../src/common/stockitem.cpp:148 ../src/stc/stc_i18n.cpp:17
 msgid "Cut"
 msgstr "Cortar"
 
-#: ../src/common/stockitem.cpp:259
+#: ../src/common/stockitem.cpp:256
 msgid "Cut selection"
 msgstr "Cortar a seleção"
 
-#: ../src/common/fmapbase.cpp:152
+#: ../src/common/fmapbase.cpp:149
 msgid "Cyrillic (ISO-8859-5)"
 msgstr "Cirílico (ISO-8859-5)"
 
-#: ../src/common/paper.cpp:99
+#: ../src/common/paper.cpp:96
 msgid "D sheet, 22 x 34 in"
 msgstr "Folha D, 22 x 34 em"
 
-#: ../src/msw/dde.cpp:703
+#: ../src/msw/dde.cpp:698
 msgid "DDE poke request failed"
 msgstr "O pedido para cutucar do DDE falhou"
 
-#: ../src/common/imagbmp.cpp:1169
+#: ../src/common/imagbmp.cpp:1181
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr ""
 "Cabeçalho do DIB: A codificação não combina com a profundidade dos bits."
@@ -2590,7 +2598,7 @@ msgstr "Cabeçalho do DIB: Profundidade dos bits desconhecida no arquivo."
 msgid "DIB Header: Unknown encoding in file."
 msgstr "Cabeçalho do DIB: Codificação desconhecida no arquivo."
 
-#: ../src/common/paper.cpp:121
+#: ../src/common/paper.cpp:118
 msgid "DL Envelope, 110 x 220 mm"
 msgstr "Envelope DL, 110 x 220 mm"
 
@@ -2598,53 +2606,53 @@ msgstr "Envelope DL, 110 x 220 mm"
 msgid "Dashed"
 msgstr "Tracejado"
 
-#: ../src/generic/dbgrptg.cpp:300
+#: ../src/generic/dbgrptg.cpp:301
 #, c-format
 msgid "Debug report \"%s\""
 msgstr "Relatório do debug \"%s\""
 
-#: ../src/common/debugrpt.cpp:210
+#: ../src/common/debugrpt.cpp:211
 msgid "Debug report couldn't be created."
 msgstr "O relatório de debug não pôde ser criado."
 
-#: ../src/common/debugrpt.cpp:553
+#: ../src/common/debugrpt.cpp:554
 msgid "Debug report generation has failed."
 msgstr "A geração do relatório de debug falhou."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:84
+#: ../src/common/accelcmn.cpp:81
 msgid "Decimal"
 msgstr "Decimal"
 
-#: ../src/generic/fontdlgg.cpp:323
+#: ../src/generic/fontdlgg.cpp:319
 msgid "Decorative"
 msgstr "Decorativo"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1752
+#: ../src/propgrid/advprops.cpp:1653
 msgid "Default"
 msgstr "Padrão"
 
-#: ../src/common/fmapbase.cpp:796
+#: ../src/common/fmapbase.cpp:792
 msgid "Default encoding"
 msgstr "Codificação padrão"
 
-#: ../src/dfb/fontmgr.cpp:180
+#: ../src/dfb/fontmgr.cpp:177
 msgid "Default font"
 msgstr "Fonte padrão"
 
-#: ../src/generic/prntdlgg.cpp:510
+#: ../src/generic/prntdlgg.cpp:503
 msgid "Default printer"
 msgstr "Impressora padrão"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:51
+#: ../src/common/accelcmn.cpp:48
 msgid "Del"
 msgstr "Del"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextbuffer.cpp:8221 ../src/common/stockitem.cpp:152
-#: ../src/common/accelcmn.cpp:50 ../src/stc/stc_i18n.cpp:20
+#: ../src/common/stockitem.cpp:149 ../src/common/accelcmn.cpp:47
+#: ../src/richtext/richtextbuffer.cpp:8217 ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Apagar"
 
@@ -2652,68 +2660,68 @@ msgstr "Apagar"
 msgid "Delete A&ll"
 msgstr "Apagar T&udo"
 
-#: ../src/richtext/richtextbuffer.cpp:11341
+#: ../src/richtext/richtextbuffer.cpp:11340
 msgid "Delete Column"
 msgstr "Apagar a Coluna"
 
-#: ../src/richtext/richtextbuffer.cpp:11291
+#: ../src/richtext/richtextbuffer.cpp:11290
 msgid "Delete Row"
 msgstr "Apagar a Fileira"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 msgid "Delete Style"
 msgstr "Apagar o Estilo"
 
-#: ../src/richtext/richtextctrl.cpp:1345 ../src/richtext/richtextctrl.cpp:1584
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
 msgid "Delete Text"
 msgstr "Apagar o Texto"
 
-#: ../src/generic/editlbox.cpp:170
+#: ../src/generic/editlbox.cpp:147
 msgid "Delete item"
 msgstr "Apagar o item"
 
-#: ../src/common/stockitem.cpp:260
+#: ../src/common/stockitem.cpp:257
 msgid "Delete selection"
 msgstr "Apagar a seleção"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 #, c-format
 msgid "Delete style %s?"
 msgstr "Apagar o estilo %s?"
 
-#: ../src/unix/snglinst.cpp:301
+#: ../src/unix/snglinst.cpp:298
 #, c-format
 msgid "Deleted stale lock file '%s'."
 msgstr "Arquivo do stale lock apagado '%s'."
 
-#: ../src/common/secretstore.cpp:220
-#, c-format
-msgid "Deleting password for \"%s/%s\" failed: %s."
+#: ../src/common/secretstore.cpp:234
+#, fuzzy, c-format
+msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Falhou em apagar a senha do %s/%s\": %s."
 
-#: ../src/common/module.cpp:124
+#: ../src/common/module.cpp:121
 #, c-format
 msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
 msgstr "A dependência \"%s\" do módulo \"%s\" não existe."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "Descending"
 msgstr "Descendente"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:526 ../src/propgrid/advprops.cpp:882
+#: ../src/generic/dirctrlg.cpp:492 ../src/propgrid/advprops.cpp:783
 msgid "Desktop"
 msgstr "Área de trabalho"
 
-#: ../src/generic/aboutdlgg.cpp:70
+#: ../src/generic/aboutdlgg.cpp:67
 msgid "Developed by "
 msgstr "Desenvolvido por "
 
-#: ../src/generic/aboutdlgg.cpp:176
+#: ../src/generic/aboutdlgg.cpp:173
 msgid "Developers"
 msgstr "Desenvolvedores"
 
-#: ../src/msw/dialup.cpp:374
+#: ../src/msw/dialup.cpp:368
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -2721,11 +2729,11 @@ msgstr ""
 "As funções de discagem estão indisponíveis porque o serviço de acesso remoto "
 "(RAS) não está instalado nesta máquina. Por favor instale-o."
 
-#: ../src/generic/tipdlg.cpp:211
+#: ../src/generic/tipdlg.cpp:208
 msgid "Did you know..."
 msgstr "Você sabia..."
 
-#: ../src/dfb/wrapdfb.cpp:63
+#: ../src/dfb/wrapdfb.cpp:60
 #, c-format
 msgid "DirectFB error %d occurred."
 msgstr "Ocorreu um erro do DirectFB %d."
@@ -2734,29 +2742,29 @@ msgstr "Ocorreu um erro do DirectFB %d."
 msgid "Directories"
 msgstr "Diretórios"
 
-#: ../src/common/filefn.cpp:1183
+#: ../src/common/filefn.cpp:1071
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "O diretório '%s' não pôde ser criado"
 
-#: ../src/common/filefn.cpp:1197
+#: ../src/common/filefn.cpp:1085
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "O diretório '%s' não pôde ser apagado"
 
-#: ../src/generic/dirdlgg.cpp:204
+#: ../src/generic/dirdlgg.cpp:201
 msgid "Directory does not exist"
 msgstr "O diretório não existe"
 
-#: ../src/generic/filectrlg.cpp:1399
+#: ../src/generic/filectrlg.cpp:1388
 msgid "Directory doesn't exist."
 msgstr "O diretório não existe."
 
-#: ../src/common/docview.cpp:457
+#: ../src/common/docview.cpp:450
 msgid "Discard changes and reload the last saved version?"
 msgstr "Descartar mudanças e recarregar a última versão salva?"
 
-#: ../src/html/helpwnd.cpp:502
+#: ../src/html/helpwnd.cpp:500
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -2764,45 +2772,45 @@ msgstr ""
 "Exibe todos os itens do índice que contém a sub-sequência dada. A busca é "
 "caso sensitivo."
 
-#: ../src/html/helpwnd.cpp:679
+#: ../src/html/helpwnd.cpp:677
 msgid "Display options dialog"
 msgstr "Exibir o diálogo das opções"
 
-#: ../src/html/helpwnd.cpp:322
+#: ../src/html/helpwnd.cpp:320
 msgid "Displays help as you browse the books on the left."
 msgstr "Exibe a ajuda conforme você navega pelos livros a esquerda."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:85
+#: ../src/common/accelcmn.cpp:83
 msgid "Divide"
 msgstr "Dividir"
 
-#: ../src/common/docview.cpp:533
+#: ../src/common/docview.cpp:526
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Você quer salvar as mudanças em %s?"
 
-#: ../src/common/prntbase.cpp:542
+#: ../src/common/prntbase.cpp:537
 msgid "Document:"
 msgstr "Documento:"
 
-#: ../src/generic/aboutdlgg.cpp:73
+#: ../src/generic/aboutdlgg.cpp:70
 msgid "Documentation by "
 msgstr "Documentação de "
 
-#: ../src/generic/aboutdlgg.cpp:180
+#: ../src/generic/aboutdlgg.cpp:177
 msgid "Documentation writers"
 msgstr "Escritores da documentação"
 
-#: ../src/common/sizer.cpp:2799
+#: ../src/common/sizer.cpp:2916
 msgid "Don't Save"
 msgstr "Não Salvar"
 
-#: ../src/html/htmlwin.cpp:633
+#: ../src/html/htmlwin.cpp:643
 msgid "Done"
 msgstr "Feito"
 
-#: ../src/generic/progdlgg.cpp:448 ../src/msw/progdlg.cpp:407
+#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
 msgid "Done."
 msgstr "Feito."
 
@@ -2814,42 +2822,42 @@ msgstr "Pontilhado"
 msgid "Double"
 msgstr "Duplo"
 
-#: ../src/common/paper.cpp:176
+#: ../src/common/paper.cpp:173
 msgid "Double Japanese Postcard Rotated 148 x 200 mm"
 msgstr "Cartão Postal Japonês Duplo Rotacionado 148 x 200 mm"
 
-#: ../src/common/xtixml.cpp:273
+#: ../src/common/xtixml.cpp:269
 #, c-format
 msgid "Doubly used id : %d"
 msgstr "ID usada duas vezes : %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:153
-#: ../src/common/accelcmn.cpp:64
+#: ../src/common/stockitem.cpp:150 ../src/common/accelcmn.cpp:61
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Down"
 msgstr "Pra baixo"
 
-#: ../src/richtext/richtextctrl.cpp:865
+#: ../src/richtext/richtextctrl.cpp:864
 msgid "Drag"
 msgstr "Arrastar"
 
-#: ../src/common/paper.cpp:100
+#: ../src/common/paper.cpp:97
 msgid "E sheet, 34 x 44 in"
 msgstr "Folha E, 34 x 44"
 
-#: ../src/unix/fswatcher_inotify.cpp:561
+#: ../src/unix/fswatcher_inotify.cpp:558
 msgid "EOF while reading from inotify descriptor"
 msgstr "EOF enquanto lia do descritor inotify"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "Edit"
 msgstr "Editar"
 
-#: ../src/generic/editlbox.cpp:168
+#: ../src/generic/editlbox.cpp:131
 msgid "Edit item"
 msgstr "Editar item"
 
-#: ../include/wx/generic/progdlgg.h:84
+#: ../include/wx/generic/progdlgg.h:85
 msgid "Elapsed time:"
 msgstr "Tempo decorrido:"
 
@@ -2916,49 +2924,49 @@ msgid "Enables the shadow spread."
 msgstr "Ativa o espalhar da sombra."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:66
+#: ../src/common/accelcmn.cpp:63
 msgid "End"
 msgstr "End"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:55
+#: ../src/common/accelcmn.cpp:52
 msgid "Enter"
 msgstr "Enter"
 
-#: ../src/richtext/richtextstyledlg.cpp:934
+#: ../src/richtext/richtextstyledlg.cpp:930
 msgid "Enter a box style name"
 msgstr "Insira um nome de estilo da caixa"
 
-#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:602
 msgid "Enter a character style name"
 msgstr "Insira um nome de estilo de caracteres"
 
-#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:816
 msgid "Enter a list style name"
 msgstr "Insira um nome de estilo de listas"
 
-#: ../src/richtext/richtextstyledlg.cpp:893
+#: ../src/richtext/richtextstyledlg.cpp:889
 msgid "Enter a new style name"
 msgstr "Insira um novo nome de estilo"
 
-#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:650
 msgid "Enter a paragraph style name"
 msgstr "Insira um nome de estilo do parágrafo"
 
-#: ../src/generic/dbgrptg.cpp:174
+#: ../src/generic/dbgrptg.cpp:171
 #, c-format
 msgid "Enter command to open file \"%s\":"
 msgstr "Insira o comando para abrir o arquivo \"%s\":"
 
-#: ../src/generic/helpext.cpp:459
+#: ../src/generic/helpext.cpp:457
 msgid "Entries found"
 msgstr "Entradas achadas"
 
-#: ../src/common/paper.cpp:142
+#: ../src/common/paper.cpp:139
 msgid "Envelope Invite 220 x 220 mm"
 msgstr "Envelope de Convite 220 x 220 mm"
 
-#: ../src/common/config.cpp:469
+#: ../src/common/config.cpp:465
 #, c-format
 msgid ""
 "Environment variables expansion failed: missing '%c' at position %u in '%s'."
@@ -2966,13 +2974,13 @@ msgstr ""
 "A expansão das variáveis do ambiente falhou: '%c' desaparecido na posição %u "
 "em '%s'."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/generic/dirctrlg.cpp:570
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/dirctrlg.cpp:599
-#: ../src/generic/dirdlgg.cpp:323 ../src/generic/filectrlg.cpp:642
-#: ../src/generic/filectrlg.cpp:756 ../src/generic/filectrlg.cpp:770
-#: ../src/generic/filectrlg.cpp:786 ../src/generic/filectrlg.cpp:1368
-#: ../src/generic/filectrlg.cpp:1399 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/gtk1/fontdlg.cpp:74 ../src/generic/dirctrlg.cpp:536
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/dirctrlg.cpp:565
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1357 ../src/generic/filectrlg.cpp:1388
+#: ../src/generic/filedlgg.cpp:354 ../src/generic/dirdlgg.cpp:320
+#: ../src/gtk/filedlg.cpp:74
 msgid "Error"
 msgstr "Erro"
 
@@ -2980,86 +2988,97 @@ msgstr "Erro"
 msgid "Error closing epoll descriptor"
 msgstr "Erro ao fechar o descritor epoll"
 
-#: ../src/unix/fswatcher_kqueue.cpp:114
+#: ../src/unix/fswatcher_kqueue.cpp:131
 msgid "Error closing kqueue instance"
 msgstr "Erro ao fechar a instância kqueue"
 
-#: ../src/common/filefn.cpp:1049
+#: ../src/common/filefn.cpp:938
 #, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Erro ao copiar o arquivo '%s' para '%s'."
 
-#: ../src/generic/dirdlgg.cpp:222
+#: ../src/generic/dirdlgg.cpp:219
 msgid "Error creating directory"
 msgstr "Erro ao criar o diretório"
 
-#: ../src/common/imagbmp.cpp:1181
+#: ../src/common/imagbmp.cpp:1193
 msgid "Error in reading image DIB."
 msgstr "Erro ao ler a imagem do DIB."
 
-#: ../src/propgrid/propgrid.cpp:6696
+#: ../src/propgrid/propgrid.cpp:6665
 #, c-format
 msgid "Error in resource: %s"
 msgstr "Erro no recurso: %s"
 
-#: ../src/common/fileconf.cpp:422
+#: ../src/common/fileconf.cpp:421
 msgid "Error reading config options."
 msgstr "Erro ao ler as opções da config."
+
+#: ../src/msw/webview_ie.cpp:1057 ../src/msw/webview_edge.cpp:850
+#: ../src/gtk/webview_webkit2.cpp:1262 ../src/osx/webview_webkit.mm:383
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
 
 #: ../src/common/fileconf.cpp:1029
 msgid "Error saving user configuration data."
 msgstr "Erro ao salvar os dados de configuração do usuário."
 
-#: ../src/gtk/print.cpp:722
+#: ../src/gtk/print.cpp:720
 msgid "Error while printing: "
 msgstr "Erro enquanto imprimia: "
 
-#: ../src/common/log.cpp:219
+#: ../src/common/log.cpp:237
 msgid "Error: "
 msgstr "Erro: "
 
+#: ../src/common/webrequest.cpp:98
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Erro: "
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:69
+#: ../src/common/accelcmn.cpp:66
 msgid "Esc"
 msgstr "Esc"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:70
+#: ../src/common/accelcmn.cpp:67
 msgid "Escape"
 msgstr "Esc"
 
-#: ../src/common/fmapbase.cpp:150
+#: ../src/common/fmapbase.cpp:147
 msgid "Esperanto (ISO-8859-3)"
 msgstr "Esperanto (ISO-8859-3)"
 
-#: ../include/wx/generic/progdlgg.h:85
+#: ../include/wx/generic/progdlgg.h:86
 msgid "Estimated time:"
 msgstr "Tempo estimado:"
 
-#: ../src/generic/dbgrptg.cpp:234
+#: ../src/generic/dbgrptg.cpp:231
 msgid "Executable files (*.exe)|*.exe|"
 msgstr "Arquivos executáveis (*.exe)|*.exe|"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:155 ../src/common/accelcmn.cpp:78
+#: ../src/common/stockitem.cpp:152 ../src/common/accelcmn.cpp:75
 msgid "Execute"
 msgstr "Executar"
 
-#: ../src/msw/utilsexc.cpp:876
+#: ../src/msw/utilsexc.cpp:873
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "A execução do comando '%s' falhou"
 
-#: ../src/common/paper.cpp:105
+#: ../src/common/paper.cpp:102
 msgid "Executive, 7 1/4 x 10 1/2 in"
 msgstr "Executivo, 7 1/4 x 10 1/2 em"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6009
+#: ../src/generic/datavgen.cpp:6814
 msgid "Expand"
 msgstr "Expandir"
 
-#: ../src/msw/registry.cpp:1240
+#: ../src/msw/registry.cpp:1228
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
@@ -3067,147 +3086,157 @@ msgstr ""
 "Exportando a chave de registro: o arquivo \"%s\" já existe e não será "
 "sobrescrito."
 
-#: ../src/common/fmapbase.cpp:195
+#: ../src/common/fmapbase.cpp:192
 msgid "Extended Unix Codepage for Japanese (EUC-JP)"
 msgstr "Página do Código Unix Extendida para Japonês (EUC-JP)"
 
-#: ../src/html/chm.cpp:725
+#: ../src/html/chm.cpp:718
 #, c-format
 msgid "Extraction of '%s' into '%s' failed."
 msgstr "A extração de '%s' para '%s' falhou."
 
-#: ../src/common/accelcmn.cpp:249 ../src/common/accelcmn.cpp:344
+#: ../src/common/accelcmn.cpp:259 ../src/common/accelcmn.cpp:358
 msgid "F"
 msgstr "F"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:672
+#: ../src/propgrid/advprops.cpp:582
 msgid "Face Name"
 msgstr "Nome da Face"
 
-#: ../src/unix/snglinst.cpp:269
+#: ../src/unix/snglinst.cpp:266
 msgid "Failed to access lock file."
 msgstr "Falhou em acessar o arquivo da tranca."
+
+#: ../src/gtk/font.cpp:572
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Falhou em ler o documento do arquivo \"%s\"."
 
 #: ../src/unix/epolldispatcher.cpp:116
 #, c-format
 msgid "Failed to add descriptor %d to epoll descriptor %d"
 msgstr "Falhou em adicionar o descritor %d ao descritor epoll %d"
 
-#: ../src/msw/dib.cpp:489
+#: ../src/msw/dib.cpp:535
 #, c-format
 msgid "Failed to allocate %luKb of memory for bitmap data."
 msgstr "Falhou em distribuir %luKb de memória pros dados do bitmap."
 
-#: ../src/common/glcmn.cpp:115
+#: ../src/common/glcmn.cpp:112
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Falhou em distribuir a côr para o OpenGL"
 
-#: ../src/unix/displayx11.cpp:236
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Falhou em distribuir a côr para o OpenGL"
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Falhou em distribuir a côr para o OpenGL"
+
+#: ../include/wx/unix/private/displayx11.h:89
 msgid "Failed to change video mode"
 msgstr "Falhou em mudar o modo de vídeo"
 
-#: ../src/common/image.cpp:3277
+#: ../src/common/image.cpp:3396
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Falhou em verificar o formato do arquivo de imagem \"%s\"."
 
-#: ../src/common/debugrpt.cpp:239
+#: ../src/common/debugrpt.cpp:240
 #, c-format
 msgid "Failed to clean up debug report directory \"%s\""
 msgstr "Falhou em limpar o diretório do relatório de debug \"%s\""
 
-#: ../src/common/filename.cpp:192
+#: ../src/common/filename.cpp:189
 msgid "Failed to close file handle"
 msgstr "Falhou em fechar o manejamento dos arquivos"
 
-#: ../src/unix/snglinst.cpp:340
+#: ../src/unix/snglinst.cpp:337
 #, c-format
 msgid "Failed to close lock file '%s'"
 msgstr "Falhou em fechar o arquivo da tranca '%s'"
 
-#: ../src/msw/clipbrd.cpp:112
+#: ../src/msw/clipbrd.cpp:110
 msgid "Failed to close the clipboard."
 msgstr "Falhou em fechar a área de transferência."
 
-#: ../src/x11/utils.cpp:208
+#: ../src/x11/utils.cpp:170
 #, c-format
 msgid "Failed to close the display \"%s\""
 msgstr "Falhou em fechar a exibição \"%s\""
 
-#: ../src/msw/dialup.cpp:797
+#: ../src/msw/dialup.cpp:791
 msgid "Failed to connect: missing username/password."
 msgstr "Falhou em conectar: faltando o nome de usuário/senha."
 
-#: ../src/msw/dialup.cpp:743
+#: ../src/msw/dialup.cpp:737
 msgid "Failed to connect: no ISP to dial."
 msgstr "Falhou em conectar: nenhum ISP para discar."
 
-#: ../src/common/textfile.cpp:203
-#, c-format
-msgid "Failed to convert file \"%s\" to Unicode."
-msgstr "Falhou em converter o arquivo \"%s\" para o Unicode."
-
-#: ../src/generic/logg.cpp:956
+#: ../src/generic/logg.cpp:953
 msgid "Failed to copy dialog contents to the clipboard."
 msgstr "Falhou em copiar os conteúdos do diálogo pra área de transferência."
 
-#: ../src/msw/registry.cpp:692
+#: ../src/msw/registry.cpp:681
 #, c-format
 msgid "Failed to copy registry value '%s'"
 msgstr "Falhou em copiar o valor do registro '%s'"
 
-#: ../src/msw/registry.cpp:701
+#: ../src/msw/registry.cpp:690
 #, c-format
 msgid "Failed to copy the contents of registry key '%s' to '%s'."
 msgstr "Falhou em copiar os conteúdos da chave de registro '%s' para '%s'."
 
-#: ../src/common/filefn.cpp:1015
+#: ../src/common/filefn.cpp:904
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Falhou em copiar o arquivo '%s' para '%s'"
 
-#: ../src/msw/registry.cpp:679
+#: ../src/msw/registry.cpp:668
 #, c-format
 msgid "Failed to copy the registry subkey '%s' to '%s'."
 msgstr "Falhou em copiar a sub-chave do registro '%s' para '%s'."
 
-#: ../src/msw/dde.cpp:1070
+#: ../src/msw/dde.cpp:1134
 msgid "Failed to create DDE string"
 msgstr "Falhou em criar a sequência do DDE"
 
-#: ../src/msw/mdi.cpp:616
+#: ../src/msw/mdi.cpp:621
 msgid "Failed to create MDI parent frame."
 msgstr "Falhou em criar o frame pai do MDI."
 
-#: ../src/common/filename.cpp:1027
+#: ../src/common/filename.cpp:1024
 msgid "Failed to create a temporary file name"
 msgstr "Falhou em criar um nome de arquivo temporário"
 
-#: ../src/msw/utilsexc.cpp:228
+#: ../src/msw/utilsexc.cpp:225
 msgid "Failed to create an anonymous pipe"
 msgstr "Falhou em criar um pipe anônimo"
 
-#: ../src/msw/ole/automtn.cpp:522
+#: ../src/msw/ole/automtn.cpp:513
 #, c-format
 msgid "Failed to create an instance of \"%s\""
 msgstr "Falhou em criar uma instância de \"%s\""
 
-#: ../src/msw/dde.cpp:437
+#: ../src/msw/dde.cpp:432
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "Falhou em criar uma conexão com o servidor '%s' no tópico '%s'"
 
-#: ../src/msw/cursor.cpp:204
+#: ../src/msw/cursor.cpp:195
 msgid "Failed to create cursor."
 msgstr "Falhou em criar o cursor."
 
-#: ../src/common/debugrpt.cpp:209
+#: ../src/common/debugrpt.cpp:210
 #, c-format
 msgid "Failed to create directory \"%s\""
 msgstr "Falhou em criar o diretório \"%s\""
 
-#: ../src/generic/dirdlgg.cpp:220
+#: ../src/generic/dirdlgg.cpp:217
 #, c-format
 msgid ""
 "Failed to create directory '%s'\n"
@@ -3220,114 +3249,133 @@ msgstr ""
 msgid "Failed to create epoll descriptor"
 msgstr "Falhou em criar o descritor epoll"
 
-#: ../src/msw/mimetype.cpp:238
+#: ../src/gtk/font.cpp:562
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "Falhou em atualizar o arquivo de configuração do usuário."
+
+#: ../src/msw/mimetype.cpp:235
 #, c-format
 msgid "Failed to create registry entry for '%s' files."
 msgstr "Falhou em criar a entrada no registro para os arquivos '%s'."
 
-#: ../src/msw/fdrepdlg.cpp:409
+#: ../src/msw/fdrepdlg.cpp:408
 #, c-format
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr "Falhou em criar o diálogo achar/substituir padrão (código do erro %d)"
 
-#: ../src/unix/wakeuppipe.cpp:52
+#: ../src/unix/wakeuppipe.cpp:49
 msgid "Failed to create wake up pipe used by event loop."
 msgstr "Falhou em criar o wake up pipe usado pelo loop de eventos."
 
-#: ../src/html/winpars.cpp:730
+#: ../src/html/winpars.cpp:727
 #, c-format
 msgid "Failed to display HTML document in %s encoding"
 msgstr "Falhou em exibir o documento em HTML na codificação %s"
 
-#: ../src/msw/clipbrd.cpp:124
+#: ../src/msw/clipbrd.cpp:122
 msgid "Failed to empty the clipboard."
 msgstr "Falhou em esvaziar a área de transferência."
 
-#: ../src/unix/displayx11.cpp:212
+#: ../include/wx/unix/private/displayx11.h:65
 msgid "Failed to enumerate video modes"
 msgstr "Falhou em enumerar os modos de vídeo"
 
-#: ../src/msw/dde.cpp:722
+#: ../src/msw/dde.cpp:717
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "Falhou em estabelecer um loop de recomendação com o servidor DDE"
 
-#: ../src/msw/dialup.cpp:629 ../src/msw/dialup.cpp:863
+#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Falhou em estabelecer uma conexão dial-up: %s"
 
-#: ../src/unix/utilsunx.cpp:611
+#: ../src/unix/utilsunx.cpp:613
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Falhou em executar o '%s'\n"
 
-#: ../src/common/debugrpt.cpp:720
+#: ../src/common/debugrpt.cpp:730
 msgid "Failed to execute curl, please install it in PATH."
 msgstr "Falhou ao executar o curl, por favor instale-o no PATH."
 
-#: ../src/msw/ole/automtn.cpp:505
+#: ../src/msw/ole/automtn.cpp:496
 #, c-format
 msgid "Failed to find CLSID of \"%s\""
 msgstr "Falhou em achar a CLSID de \"%s\""
 
-#: ../src/common/regex.cpp:431 ../src/common/regex.cpp:479
+#: ../src/common/regex.cpp:428 ../src/common/regex.cpp:476
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "Falhou em achar a combinação para a expressão regular: %s"
 
-#: ../src/msw/dialup.cpp:695
+#: ../src/msw/webview_ie.cpp:978
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:689
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Falhou em obter os nomes dos ISPs: %s"
 
-#: ../src/msw/ole/automtn.cpp:574
+#: ../src/msw/ole/automtn.cpp:565
 #, c-format
 msgid "Failed to get OLE automation interface for \"%s\""
 msgstr "Falhou em obter a interface de automação do OLE para \"%s\""
 
-#: ../src/msw/clipbrd.cpp:711
+#: ../src/msw/clipbrd.cpp:731
 msgid "Failed to get data from the clipboard"
 msgstr "Falhou em obter os dados da área de transferência"
 
-#: ../src/common/time.cpp:223
+#: ../src/common/time.cpp:216
 msgid "Failed to get the local system time"
 msgstr "Falhou em obter a hora local do sistema"
 
-#: ../src/common/filefn.cpp:1345
+#: ../src/common/filefn.cpp:1233
 msgid "Failed to get the working directory"
 msgstr "Falhou em obter o diretório de trabalho"
 
-#: ../src/univ/theme.cpp:114
+#: ../src/univ/theme.cpp:111
 msgid "Failed to initialize GUI: no built-in themes found."
 msgstr "Falhou em inicializar a GUI: não foram achados temas embutidos."
 
-#: ../src/msw/helpchm.cpp:63
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:60
 msgid "Failed to initialize MS HTML Help."
 msgstr "Falhou em inicializar a Ajuda do MS HTML."
 
-#: ../src/msw/glcanvas.cpp:1381
+#: ../src/msw/glcanvas.cpp:1391
 msgid "Failed to initialize OpenGL"
 msgstr "Falhou em inicializar o OpenGL"
 
-#: ../src/msw/dialup.cpp:858
+#: ../src/msw/dialup.cpp:852
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Falhou em iniciar a conexão dial-up: %s"
 
-#: ../src/gtk/textctrl.cpp:1128
+#: ../src/gtk/textctrl.cpp:1209
 msgid "Failed to insert text in the control."
 msgstr "Falhou em inserir o texto no controle."
 
-#: ../src/unix/snglinst.cpp:241
+#: ../src/unix/snglinst.cpp:238
 #, c-format
 msgid "Failed to inspect the lock file '%s'"
 msgstr "Falhou em inspecionar o arquivo da tranca '%s'"
 
-#: ../src/unix/appunix.cpp:182
+#: ../src/unix/appunix.cpp:179
 msgid "Failed to install signal handler"
 msgstr "Falhou em instalar o manejador do sinal"
 
-#: ../src/unix/threadpsx.cpp:1167
+#: ../src/unix/threadpsx.cpp:1216
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -3335,71 +3383,71 @@ msgstr ""
 "Falhou em se juntar a um thread, vazamento potencial de memória detectado - "
 "por favor reinicie o programa"
 
-#: ../src/msw/utils.cpp:629
+#: ../src/msw/utils.cpp:619
 #, c-format
 msgid "Failed to kill process %d"
 msgstr "Falhou em matar o processo %d"
 
-#: ../src/common/image.cpp:2500
+#: ../src/common/image.cpp:2595
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Falhou em carregar o bitmap \"%s\" dos recursos."
 
-#: ../src/common/image.cpp:2509
+#: ../src/common/image.cpp:2604
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Falhou em carregar o ícone \"%s\" dos recursos."
 
-#: ../src/common/iconbndl.cpp:225
+#: ../src/common/iconbndl.cpp:224
 #, c-format
 msgid "Failed to load icons from resource '%s'."
 msgstr "Falhou em carregar os ícones do recurso '%s'."
 
-#: ../src/common/iconbndl.cpp:200
+#: ../src/common/iconbndl.cpp:198
 #, c-format
 msgid "Failed to load image %%d from file '%s'."
 msgstr "Falhou em carregar a imagem %%d do arquivo '%s'."
 
-#: ../src/common/iconbndl.cpp:208
+#: ../src/common/iconbndl.cpp:206
 #, c-format
 msgid "Failed to load image %d from stream."
 msgstr "Falhou em carregar a imagem %d do fluxo."
 
-#: ../src/common/image.cpp:2587 ../src/common/image.cpp:2606
+#: ../src/common/image.cpp:2682 ../src/common/image.cpp:2701
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Falhou em carregar a imagem do arquivo \"%s\"."
 
-#: ../src/msw/enhmeta.cpp:97
+#: ../src/msw/enhmeta.cpp:94
 #, c-format
 msgid "Failed to load metafile from file \"%s\"."
 msgstr "Falhou em carregar o metafile do arquivo \"%s\"."
 
-#: ../src/msw/volume.cpp:327
+#: ../src/msw/volume.cpp:335
 msgid "Failed to load mpr.dll."
 msgstr "Falhou em carregar o mpr.dll."
 
-#: ../src/msw/utils.cpp:953
+#: ../src/msw/utils.cpp:943
 #, c-format
 msgid "Failed to load resource \"%s\"."
 msgstr "Falhou em carregar o recurso \"%s\"."
 
-#: ../src/common/dynlib.cpp:92
+#: ../src/common/dynlib.cpp:86
 #, c-format
 msgid "Failed to load shared library '%s'"
 msgstr "Falhou em carregar a biblioteca compartilhada '%s'"
 
-#: ../src/osx/core/sound.cpp:145
+#: ../src/osx/core/sound.cpp:143
 #, c-format
 msgid "Failed to load sound from \"%s\" (error %d)."
 msgstr "Falhou em carregar o som de \"%s\" (erro %d)."
 
-#: ../src/msw/utils.cpp:960
+#: ../src/msw/utils.cpp:950
 #, c-format
 msgid "Failed to lock resource \"%s\"."
 msgstr "Falhou em trancar o recurso \"%s\"."
 
-#: ../src/unix/snglinst.cpp:198
+#: ../src/unix/snglinst.cpp:195
 #, c-format
 msgid "Failed to lock the lock file '%s'"
 msgstr "Falhou em trancar o arquivo da tranca '%s'"
@@ -3409,33 +3457,38 @@ msgstr "Falhou em trancar o arquivo da tranca '%s'"
 msgid "Failed to modify descriptor %d in epoll descriptor %d"
 msgstr "Falhou em modificar o descritor %d no descritor epoll %d"
 
-#: ../src/common/filename.cpp:2575
+#: ../src/common/filename.cpp:2658
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Falhou em modificar as horas do arquivo para '%s'"
 
-#: ../src/common/selectdispatcher.cpp:258
+#: ../src/common/selectdispatcher.cpp:255
 msgid "Failed to monitor I/O channels"
 msgstr "Falhou em monitorar os canais de E/S"
 
-#: ../src/common/filename.cpp:175
+#: ../src/common/filename.cpp:172
 #, c-format
 msgid "Failed to open '%s' for reading"
 msgstr "Falhou em abrir '%s' para leitura"
 
-#: ../src/common/filename.cpp:180
+#: ../src/common/filename.cpp:177
 #, c-format
 msgid "Failed to open '%s' for writing"
 msgstr "Falhou em abrir '%s' para gravação"
 
-#: ../src/html/chm.cpp:141
+#: ../src/html/chm.cpp:138
 #, c-format
 msgid "Failed to open CHM archive '%s'."
 msgstr "Falhou em abrir o arquivo CHM '%s'."
 
-#: ../src/common/utilscmn.cpp:1126
+#: ../src/common/utilscmn.cpp:1140
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Falhou em abrir a URL '%s' no navegador padrão."
+
+#: ../src/common/hyperlnkcmn.cpp:133
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Falhou em abrir a URL '%s' no navegador padrão."
 
 #: ../include/wx/msw/private/fswatcher.h:92
@@ -3443,93 +3496,103 @@ msgstr "Falhou em abrir a URL '%s' no navegador padrão."
 msgid "Failed to open directory \"%s\" for monitoring."
 msgstr "Falhou em abrir o diretório \"%s\" pro monitoramento."
 
-#: ../src/x11/utils.cpp:227
+#: ../src/x11/utils.cpp:189
 #, c-format
 msgid "Failed to open display \"%s\"."
 msgstr "Falhou em abrir a exibição \"%s\"."
 
-#: ../src/common/filename.cpp:1062
+#: ../src/common/filename.cpp:1059
 msgid "Failed to open temporary file."
 msgstr "Falhou em abrir o arquivo temporário."
 
-#: ../src/msw/clipbrd.cpp:91
+#: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Falhou em abrir a área de transferência."
 
-#: ../src/common/translation.cpp:1184
+#: ../src/common/translation.cpp:1226
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Falhou em analisar as Formas-do-Plural: '%s'"
 
-#: ../src/unix/mediactrl.cpp:1214
+#: ../src/unix/mediactrl.cpp:1239
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Falhou em preparar a reprodução do \"%s\"."
 
-#: ../src/msw/clipbrd.cpp:600
+#: ../src/msw/clipbrd.cpp:610
 msgid "Failed to put data on the clipboard"
 msgstr "Falhou em pôr os dados na área de transferência"
 
-#: ../src/unix/snglinst.cpp:278
+#: ../src/unix/snglinst.cpp:275
 msgid "Failed to read PID from lock file."
 msgstr "Falhou em ler o PID do arquivo da tranca."
 
-#: ../src/common/fileconf.cpp:433
+#: ../src/common/fileconf.cpp:432
 msgid "Failed to read config options."
 msgstr "Falhou em ler as opções de config."
 
-#: ../src/common/docview.cpp:681
+#: ../src/common/docview.cpp:676
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Falhou em ler o documento do arquivo \"%s\"."
 
-#: ../src/dfb/evtloop.cpp:98
+#: ../src/dfb/evtloop.cpp:99
 msgid "Failed to read event from DirectFB pipe"
 msgstr "Falhou em ler o evento do DirectFB pipe"
 
-#: ../src/unix/wakeuppipe.cpp:120
+#: ../src/unix/wakeuppipe.cpp:117
 msgid "Failed to read from wake-up pipe"
 msgstr "Falhou em ler do wake-up pipe"
 
-#: ../src/unix/utilsunx.cpp:679
+#: ../src/common/textfile.cpp:96
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Falhou em ler o documento do arquivo \"%s\"."
+
+#: ../src/unix/utilsunx.cpp:681
 msgid "Failed to redirect child process input/output"
 msgstr "Falhou em redirecionar a entrada/saída do processo filho"
 
-#: ../src/msw/utilsexc.cpp:701
+#: ../src/msw/utilsexc.cpp:698
 msgid "Failed to redirect the child process IO"
 msgstr "Falhou em redirecionar a E/S do processo filho"
 
-#: ../src/msw/dde.cpp:288
+#: ../src/msw/dde.cpp:283
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Falhou em registrar o servidor DDE '%s'"
 
-#: ../src/common/fontmap.cpp:245
+#: ../src/gtk/font.cpp:580
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "Falhou em atualizar o arquivo de configuração do usuário."
+
+#: ../src/common/fontmap.cpp:242
 #, c-format
 msgid "Failed to remember the encoding for the charset '%s'."
 msgstr "Falhou em lembrar a codificação do conjunto de caracteres '%s'."
 
-#: ../src/common/debugrpt.cpp:227
+#: ../src/common/debugrpt.cpp:228
 #, c-format
 msgid "Failed to remove debug report file \"%s\""
 msgstr "Falhou em remover o arquivo do relatório do debug \"%s\""
 
-#: ../src/unix/snglinst.cpp:328
+#: ../src/unix/snglinst.cpp:325
 #, c-format
 msgid "Failed to remove lock file '%s'"
 msgstr "Falhou em remover o arquivo da tranca '%s'"
 
-#: ../src/unix/snglinst.cpp:288
+#: ../src/unix/snglinst.cpp:285
 #, c-format
 msgid "Failed to remove stale lock file '%s'."
 msgstr "Falhou em remover o arquivo do stale lock '%s'."
 
-#: ../src/msw/registry.cpp:529
+#: ../src/msw/registry.cpp:518
 #, c-format
 msgid "Failed to rename registry value '%s' to '%s'."
 msgstr "Falhou em renomear o valor do registro de '%s' para '%s'."
 
-#: ../src/common/filefn.cpp:1122
+#: ../src/common/filefn.cpp:1011
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -3538,115 +3601,124 @@ msgstr ""
 "Falhou em renomear o arquivo '%s' para '%s' porque o arquivo destino já "
 "existe."
 
-#: ../src/msw/registry.cpp:634
+#: ../src/msw/registry.cpp:623
 #, c-format
 msgid "Failed to rename the registry key '%s' to '%s'."
 msgstr "Falhou em renomear a chave do registro de '%s' para '%s'."
 
-#: ../src/common/filename.cpp:2671
+#: ../src/msw/webview_ie.cpp:995
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/common/filename.cpp:2754
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Falhou em recuperar as horas do arquivo para '%s'"
 
-#: ../src/msw/dialup.cpp:468
+#: ../src/msw/dialup.cpp:462
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Falhou em recuperar o texto da mensagem de erro do RAS"
 
-#: ../src/msw/clipbrd.cpp:748
+#: ../src/msw/clipbrd.cpp:768
 msgid "Failed to retrieve the supported clipboard formats"
 msgstr "Falhou em recuperar os formatos da área de transferência suportados"
 
-#: ../src/common/docview.cpp:652
+#: ../src/common/docview.cpp:647
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Falhou em salvar o documento como arquivo \"%s\"."
 
-#: ../src/msw/dib.cpp:269
+#: ../src/msw/dib.cpp:312
 #, c-format
 msgid "Failed to save the bitmap image to file \"%s\"."
 msgstr "Falhou em salvar a imagem bitmap como arquivo \"%s\"."
 
-#: ../src/msw/dde.cpp:763
+#: ../src/msw/dde.cpp:811
 msgid "Failed to send DDE advise notification"
 msgstr "Falhou em enviar a notificação de recomendação do DDE"
 
-#: ../src/common/ftp.cpp:402
+#: ../src/common/ftp.cpp:399
 #, c-format
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Falhou em definir o modo de transferência do FTP para %s."
 
-#: ../src/msw/clipbrd.cpp:427
+#: ../src/msw/clipbrd.cpp:443
 msgid "Failed to set clipboard data."
 msgstr "Falhou em definir os dados da área de transferência."
 
-#: ../src/unix/snglinst.cpp:181
+#: ../src/unix/snglinst.cpp:178
 #, c-format
 msgid "Failed to set permissions on lock file '%s'"
 msgstr "Falhou em definir as permissões sobre o arquivo da tranca '%s'"
 
-#: ../src/unix/utilsunx.cpp:668
+#: ../src/unix/utilsunx.cpp:670
 msgid "Failed to set process priority"
 msgstr "Falhou em definir a prioridade do processo"
 
-#: ../src/common/file.cpp:559
+#: ../src/common/ffile.cpp:355 ../src/common/file.cpp:586
 msgid "Failed to set temporary file permissions"
 msgstr "Falhou em definir as permissões do arquivo temporário"
 
-#: ../src/gtk/textctrl.cpp:1072
-msgid "Failed to set text in the text control."
-msgstr "Falhou em definir o texto no controle de texto."
-
-#: ../src/unix/threadpsx.cpp:1298
+#: ../src/unix/threadpsx.cpp:1347
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Falhou em definir o nível de concordância do thread em %lu"
 
-#: ../src/unix/threadpsx.cpp:1424
+#: ../src/unix/threadpsx.cpp:1473
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Falhou em definir a prioridade do thread %d."
 
-#: ../src/unix/utilsunx.cpp:783
+#: ../src/unix/utilsunx.cpp:785
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr "Falhou em configurar o pipe não-bloqueador, o programa poderia travar."
 
-#: ../src/common/fs_mem.cpp:261
+#: ../src/msw/webview_ie.cpp:987
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:256
 #, c-format
 msgid "Failed to store image '%s' to memory VFS!"
 msgstr "Falhou em armazenar a imagem '%s' na memória VFS!"
 
-#: ../src/dfb/evtloop.cpp:170
+#: ../src/dfb/evtloop.cpp:171
 msgid "Failed to switch DirectFB pipe to non-blocking mode"
 msgstr "Falhou em trocar o DirectFB pipe pro modo não bloqueador"
 
-#: ../src/unix/wakeuppipe.cpp:59
+#: ../src/unix/wakeuppipe.cpp:56
 msgid "Failed to switch wake up pipe to non-blocking mode"
 msgstr "Falhou em trocar o wake up pipe para o modo não bloqueador"
 
-#: ../src/unix/threadpsx.cpp:1605
+#: ../src/unix/threadpsx.cpp:1654
 msgid "Failed to terminate a thread."
 msgstr "Falhou em concluir um thread."
 
-#: ../src/msw/dde.cpp:741
+#: ../src/msw/dde.cpp:736
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "Falhou em concluir o loop de recomendação com o servidor DDE"
 
-#: ../src/msw/dialup.cpp:938
+#: ../src/msw/dialup.cpp:932
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Falhou em finalizar a conexão dial-up: %s"
 
-#: ../src/common/filename.cpp:2590
+#: ../src/common/filename.cpp:2673
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Falhou em tocar o arquivo '%s'"
 
-#: ../src/unix/snglinst.cpp:334
+#: ../src/unix/dlunix.cpp:90
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "Falhou em carregar a biblioteca compartilhada '%s'"
+
+#: ../src/unix/snglinst.cpp:331
 #, c-format
 msgid "Failed to unlock lock file '%s'"
 msgstr "Falhou em destrancar o arquivo da tranca '%s'"
 
-#: ../src/msw/dde.cpp:309
+#: ../src/msw/dde.cpp:304
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Falhou em des-registrar o servidor DDE '%s'"
@@ -3660,77 +3732,87 @@ msgstr "Falhou em des-registrar o descritor %d do descritor epoll %d"
 msgid "Failed to update user configuration file."
 msgstr "Falhou em atualizar o arquivo de configuração do usuário."
 
-#: ../src/common/debugrpt.cpp:733
+#: ../src/common/debugrpt.cpp:743
 #, c-format
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Falhou em enviar o relatório de debug (código do erro %d)."
 
-#: ../src/unix/snglinst.cpp:168
+#: ../src/unix/snglinst.cpp:165
 #, c-format
 msgid "Failed to write to lock file '%s'"
 msgstr "Falhou em gravar no arquivo da tranca '%s'"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:209
+#: ../src/propgrid/propgrid.cpp:190
 msgid "False"
 msgstr "Falso"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:694
+#: ../src/propgrid/advprops.cpp:604
 msgid "Family"
 msgstr "Família"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/gtk/glcanvas.cpp:176 ../src/gtk/glcanvas.cpp:187
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Erro fatal"
+
+#: ../src/common/stockitem.cpp:154
 msgid "File"
 msgstr "Arquivo"
 
-#: ../src/common/docview.cpp:669
+#: ../src/common/docview.cpp:664
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "O arquivo \"%s\" não pôde ser aberto para leitura."
 
-#: ../src/common/docview.cpp:646
+#: ../src/common/docview.cpp:641
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "O arquivo \"%s\" não pôde ser aberto para gravação."
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "O arquivo '%s' já existe; você realmente quer sobrescrevê-lo?"
 
-#: ../src/common/filefn.cpp:1156
+#: ../src/common/filefn.cpp:1044
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "O arquivo '%s' não pôde ser removido"
 
-#: ../src/common/filefn.cpp:1139
+#: ../src/common/filefn.cpp:1028
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "O arquivo '%s' não pôde ser renomeado '%s'"
 
-#: ../src/richtext/richtextctrl.cpp:3081 ../src/common/textcmn.cpp:953
+#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
 msgid "File couldn't be loaded."
 msgstr "O arquivo não pôde ser carregado."
 
-#: ../src/msw/filedlg.cpp:393
+#: ../src/msw/filedlg.cpp:414
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "O diálogo do arquivo falhou com o código de erro %0lx."
 
-#: ../src/common/docview.cpp:1789
+#: ../src/common/docview.cpp:1783
 msgid "File error"
 msgstr "Erro do arquivo"
 
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/filectrlg.cpp:770
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/filectrlg.cpp:766
 msgid "File name exists already."
 msgstr "O nome do arquivo já existe."
+
+#: ../src/osx/cocoa/filedlg.mm:264
+#, fuzzy
+msgid "File type:"
+msgstr "Teletipo"
 
 #: ../src/motif/filedlg.cpp:220
 msgid "Files"
 msgstr "Arquivos"
 
-#: ../src/common/filefn.cpp:1591
+#: ../src/common/filefn.cpp:1479
 #, c-format
 msgid "Files (%s)"
 msgstr "Arquivos (%s)"
@@ -3739,15 +3821,29 @@ msgstr "Arquivos (%s)"
 msgid "Filter"
 msgstr "Filtro"
 
-#: ../src/common/stockitem.cpp:158 ../src/html/helpwnd.cpp:490
+#: ../src/html/helpwnd.cpp:488
 msgid "Find"
 msgstr "Achar"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:259
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:258
+#, fuzzy
+msgid "Find in document"
+msgstr "Abrir documento HTML"
+
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "Find..."
+msgstr "Achar"
+
+#: ../src/common/stockitem.cpp:156
 msgid "First"
 msgstr "Primeiro"
 
-#: ../src/common/prntbase.cpp:1548
+#: ../src/common/prntbase.cpp:1573
 msgid "First page"
 msgstr "Primeira página"
 
@@ -3755,11 +3851,11 @@ msgstr "Primeira página"
 msgid "Fixed"
 msgstr "Fixo"
 
-#: ../src/html/helpwnd.cpp:1206
+#: ../src/html/helpwnd.cpp:1204
 msgid "Fixed font:"
 msgstr "Fonte fixa:"
 
-#: ../src/html/helpwnd.cpp:1269
+#: ../src/html/helpwnd.cpp:1267
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Face do tamanho fixo.<br> <b>negrito</b> <i>itálico</i> "
 
@@ -3767,16 +3863,16 @@ msgstr "Face do tamanho fixo.<br> <b>negrito</b> <i>itálico</i> "
 msgid "Floating"
 msgstr "Flutuante"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "Floppy"
 msgstr "Disquete"
 
-#: ../src/common/paper.cpp:111
+#: ../src/common/paper.cpp:108
 msgid "Folio, 8 1/2 x 13 in"
 msgstr "Folio, 8 1/2 x 13 em"
 
-#: ../src/richtext/richtextformatdlg.cpp:344 ../src/osx/carbon/fontdlg.cpp:287
-#: ../src/common/stockitem.cpp:194
+#: ../src/osx/carbon/fontdlg.cpp:284 ../src/common/stockitem.cpp:191
+#: ../src/richtext/richtextformatdlg.cpp:337
 msgid "Font"
 msgstr "Fonte"
 
@@ -3784,7 +3880,24 @@ msgstr "Fonte"
 msgid "Font &weight:"
 msgstr "Peso da &fonte:"
 
-#: ../src/html/helpwnd.cpp:1207
+#: ../src/osx/fontutil.cpp:89
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
+"\"."
+msgstr ""
+
+#: ../src/msw/font.cpp:1126
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "O arquivo não pôde ser carregado."
+
+#: ../src/osx/fontutil.cpp:81
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "O arquivo %s não existe."
+
+#: ../src/html/helpwnd.cpp:1205
 msgid "Font size:"
 msgstr "Tamanho da fonte:"
 
@@ -3792,54 +3905,54 @@ msgstr "Tamanho da fonte:"
 msgid "Font st&yle:"
 msgstr "Estilo da f&onte:"
 
-#: ../src/osx/carbon/fontdlg.cpp:329
+#: ../src/osx/carbon/fontdlg.cpp:326
 msgid "Font:"
 msgstr "Fonte:"
 
-#: ../src/dfb/fontmgr.cpp:198
+#: ../src/dfb/fontmgr.cpp:195
 #, c-format
 msgid "Fonts index file %s disappeared while loading fonts."
 msgstr ""
 "O arquivo do índice das fontes %s desapareceu enquanto carregava as fontes."
 
-#: ../src/unix/utilsunx.cpp:645
+#: ../src/unix/utilsunx.cpp:647
 msgid "Fork failed"
 msgstr "A bifurcação falhou"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "Forward"
 msgstr "Pra frente"
 
-#: ../src/common/xtixml.cpp:235
+#: ../src/common/xtixml.cpp:231
 msgid "Forward hrefs are not supported"
 msgstr "As hrefs adiantadas não são suportadas"
 
-#: ../src/html/helpwnd.cpp:875
+#: ../src/html/helpwnd.cpp:873
 #, c-format
 msgid "Found %i matches"
 msgstr "Achou %i combinações"
 
-#: ../src/generic/prntdlgg.cpp:238
+#: ../src/generic/prntdlgg.cpp:231
 msgid "From:"
 msgstr "De:"
 
-#: ../src/propgrid/advprops.cpp:1604
+#: ../src/propgrid/advprops.cpp:1510
 msgid "Fuchsia"
 msgstr "Fúcsia"
 
-#: ../src/common/imaggif.cpp:138
+#: ../src/common/imaggif.cpp:135
 msgid "GIF: data stream seems to be truncated."
 msgstr "GIF: fluxo de dados parece estar truncado."
 
-#: ../src/common/imaggif.cpp:128
+#: ../src/common/imaggif.cpp:125
 msgid "GIF: error in GIF image format."
 msgstr "GIF: erro no formato da imagem GIF."
 
-#: ../src/common/imaggif.cpp:133
+#: ../src/common/imaggif.cpp:130
 msgid "GIF: not enough memory."
 msgstr "GIF: memória insuficiente."
 
-#: ../src/gtk/window.cpp:4631
+#: ../src/gtk/window.cpp:5635
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -3847,23 +3960,23 @@ msgstr ""
 "O GTK+ instalado nesta máquina é muito antigo pra suportar a composição de "
 "tela, por favor instale GTK+ 2.12 ou superior."
 
-#: ../src/univ/themes/gtk.cpp:525
+#: ../src/univ/themes/gtk.cpp:522
 msgid "GTK+ theme"
 msgstr "Tema do GTK+"
 
-#: ../src/common/preferencescmn.cpp:40
+#: ../src/common/preferencescmn.cpp:37
 msgid "General"
 msgstr "Geral"
 
-#: ../src/common/prntbase.cpp:258
+#: ../src/common/prntbase.cpp:253
 msgid "Generic PostScript"
 msgstr "PostScript Genérico"
 
-#: ../src/common/paper.cpp:135
+#: ../src/common/paper.cpp:132
 msgid "German Legal Fanfold, 8 1/2 x 13 in"
 msgstr "Fanfold Legal Alemão, 8 1/2 x 13 em"
 
-#: ../src/common/paper.cpp:134
+#: ../src/common/paper.cpp:131
 msgid "German Std Fanfold, 8 1/2 x 12 in"
 msgstr "Fanfold Std Alemão, 8 1/2 x 12 em"
 
@@ -3879,48 +3992,48 @@ msgstr "GetPropertyCollection chamada num acessor genérico"
 msgid "GetPropertyCollection called w/o valid collection getter"
 msgstr "GetPropertyCollection chamada com ou sem um collection getter válido"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:658
 msgid "Go back"
 msgstr "Voltar"
 
-#: ../src/html/helpwnd.cpp:661
+#: ../src/html/helpwnd.cpp:659
 msgid "Go forward"
 msgstr "Avançar"
 
-#: ../src/html/helpwnd.cpp:663
+#: ../src/html/helpwnd.cpp:661
 msgid "Go one level up in document hierarchy"
 msgstr "Ir um nível acima na hierarquia do documento"
 
-#: ../src/generic/filedlgg.cpp:208 ../src/generic/dirdlgg.cpp:116
+#: ../src/generic/filedlgg.cpp:205 ../src/generic/dirdlgg.cpp:113
 msgid "Go to home directory"
 msgstr "Ir para o diretório home"
 
-#: ../src/generic/filedlgg.cpp:205
+#: ../src/generic/filedlgg.cpp:202
 msgid "Go to parent directory"
 msgstr "Ir para o diretório pai"
 
-#: ../src/generic/aboutdlgg.cpp:76
+#: ../src/generic/aboutdlgg.cpp:73
 msgid "Graphics art by "
 msgstr "Arte gráfica de "
 
-#: ../src/propgrid/advprops.cpp:1599
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Gray"
 msgstr "Cinza"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:883
+#: ../src/propgrid/advprops.cpp:784
 msgid "GrayText"
 msgstr "TextoCinza"
 
-#: ../src/common/fmapbase.cpp:154
+#: ../src/common/fmapbase.cpp:151
 msgid "Greek (ISO-8859-7)"
 msgstr "Grego (ISO-8859-7)"
 
-#: ../src/propgrid/advprops.cpp:1600
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Green"
 msgstr "Verde"
 
-#: ../src/generic/colrdlgg.cpp:342
+#: ../src/generic/colrdlgg.cpp:362
 msgid "Green:"
 msgstr "Verde:"
 
@@ -3928,107 +4041,107 @@ msgstr "Verde:"
 msgid "Groove"
 msgstr "Ranhura"
 
-#: ../src/common/zstream.cpp:158 ../src/common/zstream.cpp:318
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
 msgid "Gzip not supported by this version of zlib"
 msgstr "Gzip não suportado por esta versão do zlib"
 
-#: ../src/html/helpwnd.cpp:1549
+#: ../src/html/helpwnd.cpp:1547
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "Projeto de Ajuda em HTML (*.hhp)|*.hhp|"
 
-#: ../src/html/htmlwin.cpp:681
+#: ../src/html/htmlwin.cpp:691
 #, c-format
 msgid "HTML anchor %s does not exist."
 msgstr "A âncora em HTML %s não existe."
 
-#: ../src/html/helpwnd.cpp:1547
+#: ../src/html/helpwnd.cpp:1545
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "Arquivos HTML (*.html;*.htm)|*.html;*.htm|"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1759
+#: ../src/propgrid/advprops.cpp:1660
 msgid "Hand"
 msgstr "Mão"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "Harddisk"
 msgstr "Disco rígido"
 
-#: ../src/common/fmapbase.cpp:155
+#: ../src/common/fmapbase.cpp:152
 msgid "Hebrew (ISO-8859-8)"
 msgstr "Hebraico (ISO-8859-8)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:280 ../src/osx/button_osx.cpp:39
-#: ../src/common/stockitem.cpp:163 ../src/common/accelcmn.cpp:80
-#: ../src/html/helpdlg.cpp:66 ../src/html/helpfrm.cpp:111
+#: ../include/wx/msgdlg.h:282 ../src/osx/button_osx.cpp:39
+#: ../src/common/stockitem.cpp:160 ../src/common/accelcmn.cpp:77
+#: ../src/html/helpfrm.cpp:108 ../src/html/helpdlg.cpp:63
 msgid "Help"
 msgstr "Ajuda"
 
-#: ../src/html/helpwnd.cpp:1200
+#: ../src/html/helpwnd.cpp:1198
 msgid "Help Browser Options"
 msgstr "Opções de Ajuda do Navegador"
 
-#: ../src/generic/helpext.cpp:454 ../src/generic/helpext.cpp:455
+#: ../src/generic/helpext.cpp:452 ../src/generic/helpext.cpp:453
 msgid "Help Index"
 msgstr "Índice da Ajuda"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1529
 msgid "Help Printing"
 msgstr "Ajuda com a Impressão"
 
-#: ../src/html/helpwnd.cpp:801
+#: ../src/html/helpwnd.cpp:799
 msgid "Help Topics"
 msgstr "Tópicos da Ajuda"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1546
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Livros de ajuda (*.htb)|*.htb|Livros de ajuda (*.zip)|*.zip|"
 
-#: ../src/generic/helpext.cpp:267
+#: ../src/generic/helpext.cpp:265
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "Diretório da ajuda \"%s\" não achado."
 
-#: ../src/generic/helpext.cpp:275
+#: ../src/generic/helpext.cpp:273
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "O arquivo de ajuda \"%s\" não foi achado."
 
-#: ../src/html/helpctrl.cpp:63
+#: ../src/html/helpctrl.cpp:59
 #, c-format
 msgid "Help: %s"
 msgstr "Ajuda: %s"
 
-#: ../src/osx/menu_osx.cpp:577
+#: ../src/osx/menu_osx.cpp:469
 #, c-format
 msgid "Hide %s"
 msgstr "Esconder %s"
 
-#: ../src/osx/menu_osx.cpp:579
+#: ../src/osx/menu_osx.cpp:471
 msgid "Hide Others"
 msgstr "Esconder Outros"
 
-#: ../src/generic/infobar.cpp:84
+#: ../src/generic/infobar.cpp:81
 msgid "Hide this notification message."
 msgstr "Esconder esta mensagem de notificação."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:884
+#: ../src/propgrid/advprops.cpp:785
 msgid "Highlight"
 msgstr "Destacar"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:885
+#: ../src/propgrid/advprops.cpp:786
 msgid "HighlightText"
 msgstr "DestacarTexto"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:164 ../src/common/accelcmn.cpp:65
+#: ../src/common/stockitem.cpp:161 ../src/common/accelcmn.cpp:62
 msgid "Home"
 msgstr "Home"
 
-#: ../src/generic/dirctrlg.cpp:524
+#: ../src/generic/dirctrlg.cpp:490
 msgid "Home directory"
 msgstr "Diretório home"
 
@@ -4038,55 +4151,55 @@ msgid "How the object will float relative to the text."
 msgstr "Como o objeto flutuará relativo ao texto."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1760
+#: ../src/propgrid/advprops.cpp:1661
 msgid "I-Beam"
 msgstr "I-Beam"
 
-#: ../src/common/imagbmp.cpp:1196
+#: ../src/common/imagbmp.cpp:1208
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: Erro ao ler a máscara do DIB."
 
-#: ../src/common/imagbmp.cpp:1290 ../src/common/imagbmp.cpp:1390
-#: ../src/common/imagbmp.cpp:1405 ../src/common/imagbmp.cpp:1416
-#: ../src/common/imagbmp.cpp:1430 ../src/common/imagbmp.cpp:1478
-#: ../src/common/imagbmp.cpp:1493 ../src/common/imagbmp.cpp:1507
-#: ../src/common/imagbmp.cpp:1518
+#: ../src/common/imagbmp.cpp:1302 ../src/common/imagbmp.cpp:1402
+#: ../src/common/imagbmp.cpp:1417 ../src/common/imagbmp.cpp:1428
+#: ../src/common/imagbmp.cpp:1442 ../src/common/imagbmp.cpp:1490
+#: ../src/common/imagbmp.cpp:1505 ../src/common/imagbmp.cpp:1519
+#: ../src/common/imagbmp.cpp:1530
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: Erro ao gravar o arquivo de imagem!"
 
-#: ../src/common/imagbmp.cpp:1255
+#: ../src/common/imagbmp.cpp:1267
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: Imagem muito alta para um ícone."
 
-#: ../src/common/imagbmp.cpp:1263
+#: ../src/common/imagbmp.cpp:1275
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: Imagem muito larga para um ícone."
 
-#: ../src/common/imagbmp.cpp:1603
+#: ../src/common/imagbmp.cpp:1615
 msgid "ICO: Invalid icon index."
 msgstr "ICO: Índice do ícone inválido ."
 
-#: ../src/common/imagiff.cpp:758
+#: ../src/common/imagiff.cpp:755
 msgid "IFF: data stream seems to be truncated."
 msgstr "IFF: o fluxo de dados parece estar truncado."
 
-#: ../src/common/imagiff.cpp:742
+#: ../src/common/imagiff.cpp:739
 msgid "IFF: error in IFF image format."
 msgstr "IFF: erro no formato da imagem IFF."
 
-#: ../src/common/imagiff.cpp:745
+#: ../src/common/imagiff.cpp:742
 msgid "IFF: not enough memory."
 msgstr "IFF: memória insuficiente."
 
-#: ../src/common/imagiff.cpp:748
+#: ../src/common/imagiff.cpp:745
 msgid "IFF: unknown error!!!"
 msgstr "IFF: erro desconhecido!!!"
 
-#: ../src/common/fmapbase.cpp:197
+#: ../src/common/fmapbase.cpp:194
 msgid "ISO-2022-JP"
 msgstr "ISO-2022-JP"
 
-#: ../src/html/htmprint.cpp:282
+#: ../src/html/htmprint.cpp:294
 msgid ""
 "If possible, try changing the layout parameters to make the printout more "
 "narrow."
@@ -4094,7 +4207,7 @@ msgstr ""
 "Se possível, tente mudar os parâmetros do layout pra tornar a impressão mais "
 "reduzida."
 
-#: ../src/generic/dbgrptg.cpp:358
+#: ../src/generic/dbgrptg.cpp:362
 msgid ""
 "If you have any additional information pertaining to this bug\n"
 "report, please enter it here and it will be joined to it:"
@@ -4114,46 +4227,50 @@ msgstr ""
 "mas esteja avisado que pode impedir de melhorar o programa, então se\n"
 "possível de algum modo por favor continue com a geração do relatório.\n"
 
-#: ../src/msw/registry.cpp:1405
+#: ../src/common/zipstrm.cpp:1043
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1393
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Ignorando o valor \"%s\" da chave \"%s\"."
 
-#: ../src/common/xtistrm.cpp:295
+#: ../src/common/xtistrm.cpp:292
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Classe de Objeto Ilegal (Não-wxEvtHandler) como Fonte do Evento"
 
-#: ../src/common/xti.cpp:513
+#: ../src/common/xti.cpp:510
 msgid "Illegal Parameter Count for ConstructObject Method"
 msgstr "Contagem Ilegal de Parâmetros pro Método ConstructObject"
 
-#: ../src/common/xti.cpp:501
+#: ../src/common/xti.cpp:498
 msgid "Illegal Parameter Count for Create Method"
 msgstr "Contagem Ilegal de Parâmetros pro Metodo Create"
 
-#: ../src/generic/dirctrlg.cpp:570 ../src/generic/filectrlg.cpp:756
+#: ../src/generic/dirctrlg.cpp:536 ../src/generic/filectrlg.cpp:752
 msgid "Illegal directory name."
 msgstr "Nome ilegal de diretório."
 
-#: ../src/generic/filectrlg.cpp:1367
+#: ../src/generic/filectrlg.cpp:1356
 msgid "Illegal file specification."
 msgstr "Especificação ilegal do arquivo."
 
-#: ../src/common/image.cpp:2269
+#: ../src/common/image.cpp:2363
 msgid "Image and mask have different sizes."
 msgstr "Imagem e máscara tem tamanhos diferentes."
 
-#: ../src/common/image.cpp:2746
+#: ../src/common/image.cpp:2841
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "O arquivo de imagem não é do tipo %d."
 
-#: ../src/common/image.cpp:2877
+#: ../src/common/image.cpp:2995
 #, c-format
 msgid "Image is not of type %s."
 msgstr "A imagem não é do tipo %s."
 
-#: ../src/msw/textctrl.cpp:488
+#: ../src/msw/textctrl.cpp:534
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -4161,100 +4278,100 @@ msgstr ""
 "Impossível criar um controle de edição rico, usando o controle de texto "
 "simples ao invés disso. Por favor reinstale o riched32.dll"
 
-#: ../src/unix/utilsunx.cpp:301
+#: ../src/unix/utilsunx.cpp:303
 msgid "Impossible to get child process input"
 msgstr "Impossível obter a entrada do processo filho"
 
-#: ../src/common/filefn.cpp:1028
+#: ../src/common/filefn.cpp:917
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Impossível obter as permissões para o arquivo '%s'"
 
-#: ../src/common/filefn.cpp:1042
+#: ../src/common/filefn.cpp:931
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Impossível sobrescrever o arquivo '%s'"
 
-#: ../src/common/filefn.cpp:1097
+#: ../src/common/filefn.cpp:986
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Impossível definir as permissões para o arquivo '%s'"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:886
+#: ../src/propgrid/advprops.cpp:787
 msgid "InactiveBorder"
 msgstr "BordaInativa"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:887
+#: ../src/propgrid/advprops.cpp:788
 msgid "InactiveCaption"
 msgstr "CaptionInativo"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:888
+#: ../src/propgrid/advprops.cpp:789
 msgid "InactiveCaptionText"
 msgstr "TextoDoCaptionInativo"
 
-#: ../src/common/gifdecod.cpp:792
+#: ../src/common/gifdecod.cpp:826
 #, c-format
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "Tamanho do frame do GIF incorreto (%u, %d) para o frame #%u"
 
-#: ../src/msw/ole/automtn.cpp:635
+#: ../src/msw/ole/automtn.cpp:626
 msgid "Incorrect number of arguments."
 msgstr "Número incorreto de argumentos."
 
-#: ../src/common/stockitem.cpp:165
+#: ../src/common/stockitem.cpp:162
 msgid "Indent"
 msgstr "Recuo"
 
-#: ../src/richtext/richtextformatdlg.cpp:349
+#: ../src/richtext/richtextformatdlg.cpp:342
 msgid "Indents && Spacing"
 msgstr "Recuos && Espaçamento"
 
-#: ../src/common/stockitem.cpp:166 ../src/html/helpwnd.cpp:515
+#: ../src/common/stockitem.cpp:163 ../src/html/helpwnd.cpp:513
 msgid "Index"
 msgstr "Índice"
 
-#: ../src/common/fmapbase.cpp:159
+#: ../src/common/fmapbase.cpp:156
 msgid "Indian (ISO-8859-12)"
 msgstr "Indiano (ISO-8859-12)"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "Info"
 msgstr "Info"
 
-#: ../src/common/init.cpp:287
+#: ../src/common/init.cpp:284
 msgid "Initialization failed in post init, aborting."
 msgstr "A inicialização falhou no post init, abortando."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:54
+#: ../src/common/accelcmn.cpp:51
 msgid "Ins"
 msgstr "Ins"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextsymboldlg.cpp:472 ../src/common/accelcmn.cpp:53
+#: ../src/common/accelcmn.cpp:50 ../src/richtext/richtextsymboldlg.cpp:469
 msgid "Insert"
 msgstr "Insert"
 
-#: ../src/richtext/richtextbuffer.cpp:8067
+#: ../src/richtext/richtextbuffer.cpp:8063
 msgid "Insert Field"
 msgstr "Inserir Campo"
 
-#: ../src/richtext/richtextbuffer.cpp:7978
-#: ../src/richtext/richtextbuffer.cpp:8936
+#: ../src/richtext/richtextbuffer.cpp:7974
+#: ../src/richtext/richtextbuffer.cpp:8934
 msgid "Insert Image"
 msgstr "Inserir Imagem"
 
-#: ../src/richtext/richtextbuffer.cpp:8025
+#: ../src/richtext/richtextbuffer.cpp:8021
 msgid "Insert Object"
 msgstr "Inserir Objeto"
 
-#: ../src/richtext/richtextctrl.cpp:1286 ../src/richtext/richtextctrl.cpp:1494
-#: ../src/richtext/richtextbuffer.cpp:7822
-#: ../src/richtext/richtextbuffer.cpp:7852
-#: ../src/richtext/richtextbuffer.cpp:7894
+#: ../src/richtext/richtextbuffer.cpp:7818
+#: ../src/richtext/richtextbuffer.cpp:7848
+#: ../src/richtext/richtextbuffer.cpp:7890
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
 msgid "Insert Text"
 msgstr "Inserir Texto"
 
@@ -4267,16 +4384,11 @@ msgstr "Insere uma quebra de página antes do parágrafo."
 msgid "Inset"
 msgstr "Inserir"
 
-#: ../src/gtk/app.cpp:425
-#, c-format
-msgid "Invalid GTK+ command line option, use \"%s --help\""
-msgstr "Opção da linha de comando do GTK+ inválida, use \"%s --help\""
-
-#: ../src/common/imagtiff.cpp:311
+#: ../src/common/imagtiff.cpp:308
 msgid "Invalid TIFF image index."
 msgstr "Índice da imagem TIFF inválido."
 
-#: ../src/common/appcmn.cpp:273
+#: ../src/common/appcmn.cpp:294
 #, c-format
 msgid "Invalid display mode specification '%s'."
 msgstr "Especificação do modo de exibição '%s' inválida."
@@ -4286,247 +4398,251 @@ msgstr "Especificação do modo de exibição '%s' inválida."
 msgid "Invalid geometry specification '%s'"
 msgstr "Inválida a especificação da geometria '%s'"
 
-#: ../src/unix/fswatcher_inotify.cpp:323
+#: ../src/unix/fswatcher_inotify.cpp:320
 #, c-format
 msgid "Invalid inotify event for \"%s\""
 msgstr "Evento inotify inválido para \"%s\""
 
-#: ../src/unix/snglinst.cpp:312
+#: ../src/unix/snglinst.cpp:309
 #, c-format
 msgid "Invalid lock file '%s'."
 msgstr "Arquivo da tranca '%s' inválido."
 
-#: ../src/common/translation.cpp:1125
+#: ../src/common/translation.cpp:1167
 msgid "Invalid message catalog."
 msgstr "Catálogo de mensagens inválido."
 
-#: ../src/common/xtistrm.cpp:405 ../src/common/xtistrm.cpp:420
+#: ../src/common/xtistrm.cpp:402 ../src/common/xtistrm.cpp:417
 msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
 msgstr "ID do Objeto passada para o GetObjectClassInfo Inválida ou Nula"
 
-#: ../src/common/xtistrm.cpp:435
+#: ../src/common/xtistrm.cpp:432
 msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
 msgstr "ID do Objeto passada para o HasObjectClassInfo Inválida ou Nula"
 
-#: ../src/common/regex.cpp:310
+#: ../src/common/regex.cpp:307
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Expressão regular '%s' inválida: %s"
 
-#: ../src/common/config.cpp:226
+#: ../src/common/config.cpp:222
 #, c-format
 msgid "Invalid value %ld for a boolean key \"%s\" in config file."
 msgstr "Valor inválido %ld para uma chave boolean \"%s\" no arquivo config."
 
-#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:351
-#: ../src/osx/carbon/fontdlg.cpp:361 ../src/common/stockitem.cpp:168
+#: ../src/osx/carbon/fontdlg.cpp:358 ../src/common/stockitem.cpp:165
+#: ../src/generic/fontdlgg.cpp:325 ../src/richtext/richtextfontpage.cpp:351
 msgid "Italic"
 msgstr "Itálico"
 
-#: ../src/common/paper.cpp:130
+#: ../src/common/paper.cpp:127
 msgid "Italy Envelope, 110 x 230 mm"
 msgstr "Envelope da Itália, 110 x 230 mm"
 
-#: ../src/common/imagjpeg.cpp:270
+#: ../src/common/imagjpeg.cpp:257
 msgid "JPEG: Couldn't load - file is probably corrupted."
 msgstr ""
 "JPEG: Não conseguiu carregar - o arquivo está provavelmente corrompido."
 
-#: ../src/common/imagjpeg.cpp:449
+#: ../src/common/imagjpeg.cpp:436
 msgid "JPEG: Couldn't save image."
 msgstr "JPEG: Não pôde salvar a imagem."
 
-#: ../src/common/paper.cpp:163
+#: ../src/common/paper.cpp:160
 msgid "Japanese Double Postcard 200 x 148 mm"
 msgstr "Cartão Postal Japonês Duplo 200 x 148 mm"
 
-#: ../src/common/paper.cpp:167
+#: ../src/common/paper.cpp:164
 msgid "Japanese Envelope Chou #3"
 msgstr "Envelope Japonês Chou #3"
 
-#: ../src/common/paper.cpp:180
+#: ../src/common/paper.cpp:177
 msgid "Japanese Envelope Chou #3 Rotated"
 msgstr "Envelope Japonês Chou #3 Rotacionado"
 
-#: ../src/common/paper.cpp:168
+#: ../src/common/paper.cpp:165
 msgid "Japanese Envelope Chou #4"
 msgstr "Envelope Japonês Chou #4"
 
-#: ../src/common/paper.cpp:181
+#: ../src/common/paper.cpp:178
 msgid "Japanese Envelope Chou #4 Rotated"
 msgstr "Envelope Japonês Chou #4 Rotacionado"
 
-#: ../src/common/paper.cpp:165
+#: ../src/common/paper.cpp:162
 msgid "Japanese Envelope Kaku #2"
 msgstr "Envelope Japonês Kaku #2"
 
-#: ../src/common/paper.cpp:178
+#: ../src/common/paper.cpp:175
 msgid "Japanese Envelope Kaku #2 Rotated"
 msgstr "Envelope Japonês Kaku #2 Rotacionado"
 
-#: ../src/common/paper.cpp:166
+#: ../src/common/paper.cpp:163
 msgid "Japanese Envelope Kaku #3"
 msgstr "Envelope Japonês Kaku #3"
 
-#: ../src/common/paper.cpp:179
+#: ../src/common/paper.cpp:176
 msgid "Japanese Envelope Kaku #3 Rotated"
 msgstr "Envelope Japonês Kaku #3 Rotacionado"
 
-#: ../src/common/paper.cpp:185
+#: ../src/common/paper.cpp:182
 msgid "Japanese Envelope You #4"
 msgstr "Envelope Japonês You #4"
 
-#: ../src/common/paper.cpp:186
+#: ../src/common/paper.cpp:183
 msgid "Japanese Envelope You #4 Rotated"
 msgstr "Envelope Japonês You #4 Rotacionado"
 
-#: ../src/common/paper.cpp:138
+#: ../src/common/paper.cpp:135
 msgid "Japanese Postcard 100 x 148 mm"
 msgstr "Cartão Postal Japonês 100 x 148 mm"
 
-#: ../src/common/paper.cpp:175
+#: ../src/common/paper.cpp:172
 msgid "Japanese Postcard Rotated 148 x 100 mm"
 msgstr "Cartão Postal Japonês Rotacionado 148 x 100 mm"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "Jump to"
 msgstr "Pular para"
 
-#: ../src/common/stockitem.cpp:171
+#: ../src/common/stockitem.cpp:168
 msgid "Justified"
 msgstr "Justificado"
 
-#: ../src/richtext/richtextindentspage.cpp:155
-#: ../src/richtext/richtextindentspage.cpp:157
 #: ../src/richtext/richtextliststylepage.cpp:344
 #: ../src/richtext/richtextliststylepage.cpp:346
+#: ../src/richtext/richtextindentspage.cpp:155
+#: ../src/richtext/richtextindentspage.cpp:157
 msgid "Justify text left and right."
 msgstr "Justificar o texto a esquerda e a direita."
 
-#: ../src/common/fmapbase.cpp:163
+#: ../src/common/fmapbase.cpp:160
 msgid "KOI8-R"
 msgstr "KOI8-R"
 
-#: ../src/common/fmapbase.cpp:164
+#: ../src/common/fmapbase.cpp:161
 msgid "KOI8-U"
 msgstr "KOI8-U"
 
-#: ../src/common/accelcmn.cpp:265 ../src/common/accelcmn.cpp:347
+#: ../src/common/accelcmn.cpp:279 ../src/common/accelcmn.cpp:364
 msgid "KP_"
 msgstr "KP_"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "KP_Add"
 msgstr "KP_Adicionar"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "KP_Begin"
 msgstr "KP_Começar"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "KP_Decimal"
 msgstr "KP_Decimal"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 msgid "KP_Delete"
 msgstr "KP_Apagar"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "KP_Divide"
 msgstr "KP_Dividir"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 msgid "KP_Down"
 msgstr "KP_Pra Baixo"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "KP_End"
 msgstr "KP_End"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "KP_Enter"
 msgstr "KP_Enter"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "KP_Equal"
 msgstr "KP_Igual"
 
+#: ../src/common/accelcmn.cpp:276 ../src/common/accelcmn.cpp:361
+msgid "KP_F"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 msgid "KP_Home"
 msgstr "KP_Home"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 msgid "KP_Insert"
 msgstr "KP_Insert"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "KP_Left"
 msgstr "KP_Esquerda"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "KP_Multiply"
 msgstr "KP_Multiplicar"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:99
+#: ../src/common/accelcmn.cpp:97
 msgid "KP_Next"
 msgstr "KP_Próximo"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "KP_PageDown"
 msgstr "KP_PageDown"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "KP_PageUp"
 msgstr "KP_PageUp"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:98
+#: ../src/common/accelcmn.cpp:96
 msgid "KP_Prior"
 msgstr "KP_Anterior"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 msgid "KP_Right"
 msgstr "KP_Direita"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "KP_Separator"
 msgstr "KP_Separador"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "KP_Space"
 msgstr "KP_Brra de Espaço"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "KP_Subtract"
 msgstr "KP_Subtrair"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "KP_Tab"
 msgstr "KP_Aba"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "KP_Up"
 msgstr "KP_Pra Cima"
 
@@ -4534,19 +4650,34 @@ msgstr "KP_Pra Cima"
 msgid "L&ine spacing:"
 msgstr "E&spaçamento das linhas:"
 
-#: ../src/generic/prntdlgg.cpp:613 ../src/generic/prntdlgg.cpp:868
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "erro de compressão"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "erro de descompressão"
+
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:861
 msgid "Landscape"
 msgstr "Paisagem"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "Last"
 msgstr "Último"
 
-#: ../src/common/prntbase.cpp:1572
+#: ../src/common/prntbase.cpp:1597
 msgid "Last page"
 msgstr "Última página"
 
-#: ../src/common/log.cpp:305
+#: ../src/common/log.cpp:324
 #, c-format
 msgid "Last repeated message (\"%s\", %u time) wasn't output"
 msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
@@ -4555,93 +4686,93 @@ msgstr[0] ""
 msgstr[1] ""
 "As últimas mensagens repetidas (\"%s\", %u vezes) não eram da saída de dados"
 
-#: ../src/common/paper.cpp:103
+#: ../src/common/paper.cpp:100
 msgid "Ledger, 17 x 11 in"
 msgstr "Ledger, 17 x 11 em"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6146
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:58 ../src/generic/datavgen.cpp:6951
+#: ../src/richtext/richtextsizepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:252
 #: ../src/richtext/richtextliststylepage.cpp:253
 #: ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
-#: ../src/richtext/richtextsizepage.cpp:249 ../src/common/accelcmn.cpp:61
 msgid "Left"
 msgstr "Esquerda"
 
-#: ../src/richtext/richtextindentspage.cpp:204
 #: ../src/richtext/richtextliststylepage.cpp:390
+#: ../src/richtext/richtextindentspage.cpp:204
 msgid "Left (&first line):"
 msgstr "Esquerda (&primeira linha):"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1761
+#: ../src/propgrid/advprops.cpp:1662
 msgid "Left Button"
 msgstr "Botão Esquerdo"
 
-#: ../src/generic/prntdlgg.cpp:880
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Left margin (mm):"
 msgstr "Margem esquerda (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:141
-#: ../src/richtext/richtextindentspage.cpp:143
 #: ../src/richtext/richtextliststylepage.cpp:330
 #: ../src/richtext/richtextliststylepage.cpp:332
+#: ../src/richtext/richtextindentspage.cpp:141
+#: ../src/richtext/richtextindentspage.cpp:143
 msgid "Left-align text."
 msgstr "Alinhar o texto a esquerda."
 
-#: ../src/common/paper.cpp:144
+#: ../src/common/paper.cpp:141
 msgid "Legal Extra 9 1/2 x 15 in"
 msgstr "Extra Legal, 9 1/2 x 15 em"
 
-#: ../src/common/paper.cpp:96
+#: ../src/common/paper.cpp:93
 msgid "Legal, 8 1/2 x 14 in"
 msgstr "Legal, 8 1/2 x 14 em"
 
-#: ../src/common/paper.cpp:143
+#: ../src/common/paper.cpp:140
 msgid "Letter Extra 9 1/2 x 12 in"
 msgstr "Carta Extra 9 1/2 x 12 em"
 
-#: ../src/common/paper.cpp:149
+#: ../src/common/paper.cpp:146
 msgid "Letter Extra Transverse 9.275 x 12 in"
 msgstr "Carta Extra Transversal 9.275 x 12 em"
 
-#: ../src/common/paper.cpp:152
+#: ../src/common/paper.cpp:149
 msgid "Letter Plus 8 1/2 x 12.69 in"
 msgstr "Carta Plus, 8 1/2 x 12.69 em"
 
-#: ../src/common/paper.cpp:169
+#: ../src/common/paper.cpp:166
 msgid "Letter Rotated 11 x 8 1/2 in"
 msgstr "Carta Rotacionada 11 x 8 1/2 em"
 
-#: ../src/common/paper.cpp:101
+#: ../src/common/paper.cpp:98
 msgid "Letter Small, 8 1/2 x 11 in"
 msgstr "Carta Pequena, 8 1/2 x 11 em"
 
-#: ../src/common/paper.cpp:147
+#: ../src/common/paper.cpp:144
 msgid "Letter Transverse 8 1/2 x 11 in"
 msgstr "Carta Transversal 8 1/2 x 11 em"
 
-#: ../src/common/paper.cpp:95
+#: ../src/common/paper.cpp:92
 msgid "Letter, 8 1/2 x 11 in"
 msgstr "Carta, 8 1/2 x 11 em"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "License"
 msgstr "Licença"
 
-#: ../src/generic/fontdlgg.cpp:332
+#: ../src/generic/fontdlgg.cpp:328
 msgid "Light"
 msgstr "Leve"
 
-#: ../src/propgrid/advprops.cpp:1608
+#: ../src/propgrid/advprops.cpp:1514
 msgid "Lime"
 msgstr "Lima"
 
-#: ../src/generic/helpext.cpp:294
+#: ../src/generic/helpext.cpp:292
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr "A linha %lu do arquivo do mapa \"%s\" tem sintaxe inválida, ignorada."
@@ -4650,15 +4781,15 @@ msgstr "A linha %lu do arquivo do mapa \"%s\" tem sintaxe inválida, ignorada."
 msgid "Line spacing:"
 msgstr "Espaçamento das linhas:"
 
-#: ../src/html/chm.cpp:838
+#: ../src/html/chm.cpp:829
 msgid "Link contained '//', converted to absolute link."
 msgstr "O link continha '//'; convertido para link absoluto."
 
-#: ../src/richtext/richtextformatdlg.cpp:364
+#: ../src/richtext/richtextformatdlg.cpp:357
 msgid "List Style"
 msgstr "Estilo das Listas"
 
-#: ../src/richtext/richtextstyles.cpp:1064
+#: ../src/richtext/richtextstyles.cpp:1061
 msgid "List styles"
 msgstr "Estilos das listas"
 
@@ -4672,26 +4803,26 @@ msgstr "Lista os tamanhos das fontes em pontos."
 msgid "Lists the available fonts."
 msgstr "Lista as fontes disponíveis."
 
-#: ../src/common/fldlgcmn.cpp:340
+#: ../src/common/fldlgcmn.cpp:337
 #, c-format
 msgid "Load %s file"
 msgstr "Carrega o arquivo %s"
 
-#: ../src/html/htmlwin.cpp:597
+#: ../src/html/htmlwin.cpp:600
 msgid "Loading : "
 msgstr "Carregando : "
 
-#: ../src/unix/snglinst.cpp:246
+#: ../src/unix/snglinst.cpp:243
 #, c-format
 msgid "Lock file '%s' has incorrect owner."
 msgstr "O arquivo da tranca '%s' tem dono incorreto."
 
-#: ../src/unix/snglinst.cpp:251
+#: ../src/unix/snglinst.cpp:248
 #, c-format
 msgid "Lock file '%s' has incorrect permissions."
 msgstr "O arquivo da tranca '%s' tem permissões incorretas."
 
-#: ../src/generic/logg.cpp:576
+#: ../src/generic/logg.cpp:573
 #, c-format
 msgid "Log saved to the file '%s'."
 msgstr "Log salvo no arquivo '%s'."
@@ -4706,11 +4837,11 @@ msgstr "Letras minúsculas"
 msgid "Lower case roman numerals"
 msgstr "Numerais romanos minúsculos"
 
-#: ../src/gtk/mdi.cpp:422 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk1/mdi.cpp:431 ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "Filho do MDI"
 
-#: ../src/msw/helpchm.cpp:56
+#: ../src/msw/helpchm.cpp:53
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -4718,189 +4849,189 @@ msgstr ""
 "As funções de Ajuda do MS HTML não estão disponíveis porque a biblioteca de "
 "Ajuda do MS HTML não está instalada nesta máquina. Por favor instale-a."
 
-#: ../src/univ/themes/win32.cpp:3754
+#: ../src/univ/themes/win32.cpp:3751
 msgid "Ma&ximize"
 msgstr "Ma&ximizar"
 
-#: ../src/common/fmapbase.cpp:203
+#: ../src/common/fmapbase.cpp:200
 msgid "MacArabic"
 msgstr "MacÁrabe"
 
-#: ../src/common/fmapbase.cpp:222
+#: ../src/common/fmapbase.cpp:219
 msgid "MacArmenian"
 msgstr "MacArmênio"
 
-#: ../src/common/fmapbase.cpp:211
+#: ../src/common/fmapbase.cpp:208
 msgid "MacBengali"
 msgstr "MacBengalês"
 
-#: ../src/common/fmapbase.cpp:217
+#: ../src/common/fmapbase.cpp:214
 msgid "MacBurmese"
 msgstr "MacBirmanês"
 
-#: ../src/common/fmapbase.cpp:236
+#: ../src/common/fmapbase.cpp:233
 msgid "MacCeltic"
 msgstr "MacCelta"
 
-#: ../src/common/fmapbase.cpp:227
+#: ../src/common/fmapbase.cpp:224
 msgid "MacCentralEurRoman"
 msgstr "MacEuropeuCentralRomano"
 
-#: ../src/common/fmapbase.cpp:223
+#: ../src/common/fmapbase.cpp:220
 msgid "MacChineseSimp"
 msgstr "MacChinêsSimplificado"
 
-#: ../src/common/fmapbase.cpp:201
+#: ../src/common/fmapbase.cpp:198
 msgid "MacChineseTrad"
 msgstr "MacChinêsTradicional"
 
-#: ../src/common/fmapbase.cpp:233
+#: ../src/common/fmapbase.cpp:230
 msgid "MacCroatian"
 msgstr "MacCroata"
 
-#: ../src/common/fmapbase.cpp:206
+#: ../src/common/fmapbase.cpp:203
 msgid "MacCyrillic"
 msgstr "MacCirílico"
 
-#: ../src/common/fmapbase.cpp:207
+#: ../src/common/fmapbase.cpp:204
 msgid "MacDevanagari"
 msgstr "MacDevanagari"
 
-#: ../src/common/fmapbase.cpp:231
+#: ../src/common/fmapbase.cpp:228
 msgid "MacDingbats"
 msgstr "MacDingbats"
 
-#: ../src/common/fmapbase.cpp:226
+#: ../src/common/fmapbase.cpp:223
 msgid "MacEthiopic"
 msgstr "MacEtíope"
 
-#: ../src/common/fmapbase.cpp:229
+#: ../src/common/fmapbase.cpp:226
 msgid "MacExtArabic"
 msgstr "MacExtÁrabe"
 
-#: ../src/common/fmapbase.cpp:237
+#: ../src/common/fmapbase.cpp:234
 msgid "MacGaelic"
 msgstr "MacGaélico"
 
-#: ../src/common/fmapbase.cpp:221
+#: ../src/common/fmapbase.cpp:218
 msgid "MacGeorgian"
 msgstr "MacGeorgiano"
 
-#: ../src/common/fmapbase.cpp:205
+#: ../src/common/fmapbase.cpp:202
 msgid "MacGreek"
 msgstr "MacGrego"
 
-#: ../src/common/fmapbase.cpp:209
+#: ../src/common/fmapbase.cpp:206
 msgid "MacGujarati"
 msgstr "MacGuzerate"
 
-#: ../src/common/fmapbase.cpp:208
+#: ../src/common/fmapbase.cpp:205
 msgid "MacGurmukhi"
 msgstr "MacGurmukhi"
 
-#: ../src/common/fmapbase.cpp:204
+#: ../src/common/fmapbase.cpp:201
 msgid "MacHebrew"
 msgstr "MacHebreu"
 
-#: ../src/common/fmapbase.cpp:234
+#: ../src/common/fmapbase.cpp:231
 msgid "MacIcelandic"
 msgstr "MacIslandês"
 
-#: ../src/common/fmapbase.cpp:200
+#: ../src/common/fmapbase.cpp:197
 msgid "MacJapanese"
 msgstr "MacJaponês"
 
-#: ../src/common/fmapbase.cpp:214
+#: ../src/common/fmapbase.cpp:211
 msgid "MacKannada"
 msgstr "MacKannada"
 
-#: ../src/common/fmapbase.cpp:238
+#: ../src/common/fmapbase.cpp:235
 msgid "MacKeyboardGlyphs"
 msgstr "MacGlifosdoTeclado"
 
-#: ../src/common/fmapbase.cpp:218
+#: ../src/common/fmapbase.cpp:215
 msgid "MacKhmer"
 msgstr "MacKhmer"
 
-#: ../src/common/fmapbase.cpp:202
+#: ../src/common/fmapbase.cpp:199
 msgid "MacKorean"
 msgstr "MacCoreano"
 
-#: ../src/common/fmapbase.cpp:220
+#: ../src/common/fmapbase.cpp:217
 msgid "MacLaotian"
 msgstr "MacLaociano"
 
-#: ../src/common/fmapbase.cpp:215
+#: ../src/common/fmapbase.cpp:212
 msgid "MacMalayalam"
 msgstr "MacMalaio"
 
-#: ../src/common/fmapbase.cpp:225
+#: ../src/common/fmapbase.cpp:222
 msgid "MacMongolian"
 msgstr "MacMongol"
 
-#: ../src/common/fmapbase.cpp:210
+#: ../src/common/fmapbase.cpp:207
 msgid "MacOriya"
 msgstr "MacOriá"
 
-#: ../src/common/fmapbase.cpp:199
+#: ../src/common/fmapbase.cpp:196
 msgid "MacRoman"
 msgstr "MacRomano"
 
-#: ../src/common/fmapbase.cpp:235
+#: ../src/common/fmapbase.cpp:232
 msgid "MacRomanian"
 msgstr "MacRomeno"
 
-#: ../src/common/fmapbase.cpp:216
+#: ../src/common/fmapbase.cpp:213
 msgid "MacSinhalese"
 msgstr "MacCingalês"
 
-#: ../src/common/fmapbase.cpp:230
+#: ../src/common/fmapbase.cpp:227
 msgid "MacSymbol"
 msgstr "MacSímbolo"
 
-#: ../src/common/fmapbase.cpp:212
+#: ../src/common/fmapbase.cpp:209
 msgid "MacTamil"
 msgstr "MacTâmil"
 
-#: ../src/common/fmapbase.cpp:213
+#: ../src/common/fmapbase.cpp:210
 msgid "MacTelugu"
 msgstr "MacTelugu"
 
-#: ../src/common/fmapbase.cpp:219
+#: ../src/common/fmapbase.cpp:216
 msgid "MacThai"
 msgstr "MacTailandês"
 
-#: ../src/common/fmapbase.cpp:224
+#: ../src/common/fmapbase.cpp:221
 msgid "MacTibetan"
 msgstr "MacTibetano"
 
-#: ../src/common/fmapbase.cpp:232
+#: ../src/common/fmapbase.cpp:229
 msgid "MacTurkish"
 msgstr "MacTurco"
 
-#: ../src/common/fmapbase.cpp:228
+#: ../src/common/fmapbase.cpp:225
 msgid "MacVietnamese"
 msgstr "MacVietnamita"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1762
+#: ../src/propgrid/advprops.cpp:1663
 msgid "Magnifier"
 msgstr "Lupa"
 
-#: ../src/propgrid/advprops.cpp:2143
+#: ../src/propgrid/advprops.cpp:2050
 msgid "Make a selection:"
 msgstr "Fazer uma seleção:"
 
-#: ../src/richtext/richtextformatdlg.cpp:374
+#: ../src/richtext/richtextformatdlg.cpp:367
 #: ../src/richtext/richtextmarginspage.cpp:171
 msgid "Margins"
 msgstr "Margens"
 
-#: ../src/propgrid/advprops.cpp:1595
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Maroon"
 msgstr "Castanho"
 
-#: ../src/generic/fdrepdlg.cpp:147
+#: ../src/generic/fdrepdlg.cpp:144
 msgid "Match case"
 msgstr "Combinar com maiúsculas ou minúsculas"
 
@@ -4912,40 +5043,40 @@ msgstr "Altura máx:"
 msgid "Max width:"
 msgstr "Largura máx:"
 
-#: ../src/unix/mediactrl.cpp:947
+#: ../src/unix/mediactrl.cpp:972
 #, c-format
 msgid "Media playback error: %s"
 msgstr "Erro do playback da mídia: %s"
 
-#: ../src/common/fs_mem.cpp:175
+#: ../src/common/fs_mem.cpp:170
 #, c-format
 msgid "Memory VFS already contains file '%s'!"
 msgstr "A memória VFS já contém o arquivo '%s'!"
 
 #. TRANSLATORS: Name of keyboard key
 #. TRANSLATORS: Keyword of system colour
-#: ../src/common/accelcmn.cpp:73 ../src/propgrid/advprops.cpp:889
+#: ../src/common/accelcmn.cpp:70 ../src/propgrid/advprops.cpp:790
 msgid "Menu"
 msgstr "Menu"
 
-#: ../src/common/msgout.cpp:124
+#: ../src/common/msgout.cpp:121
 msgid "Message"
 msgstr "Mensagem"
 
-#: ../src/univ/themes/metal.cpp:168
+#: ../src/univ/themes/metal.cpp:165
 msgid "Metal theme"
 msgstr "Tema Metal"
 
-#: ../src/msw/ole/automtn.cpp:652
+#: ../src/msw/ole/automtn.cpp:643
 msgid "Method or property not found."
 msgstr "Método ou propriedade não achada."
 
-#: ../src/univ/themes/win32.cpp:3752
+#: ../src/univ/themes/win32.cpp:3749
 msgid "Mi&nimize"
 msgstr "Mi&nimizar"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1763
+#: ../src/propgrid/advprops.cpp:1664
 msgid "Middle Button"
 msgstr "Botão do Meio"
 
@@ -4957,37 +5088,42 @@ msgstr "Altura mín:"
 msgid "Min width:"
 msgstr "Largura mín:"
 
-#: ../src/msw/ole/automtn.cpp:668
+#: ../src/osx/cocoa/menu.mm:281
+#, fuzzy
+msgid "Minimize"
+msgstr "Mi&nimizar"
+
+#: ../src/msw/ole/automtn.cpp:659
 msgid "Missing a required parameter."
 msgstr "Está faltando um parâmetro requerido."
 
-#: ../src/generic/fontdlgg.cpp:324
+#: ../src/generic/fontdlgg.cpp:320
 msgid "Modern"
 msgstr "Moderno"
 
-#: ../src/generic/filectrlg.cpp:427
+#: ../src/generic/filectrlg.cpp:423
 msgid "Modified"
 msgstr "Modificado"
 
-#: ../src/common/module.cpp:133
+#: ../src/common/module.cpp:130
 #, c-format
 msgid "Module \"%s\" initialization failed"
 msgstr "A inicialização do módulo \"%s\" falhou"
 
-#: ../src/common/paper.cpp:131
+#: ../src/common/paper.cpp:128
 msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
 msgstr "Envelope Monarca, 3 7/8 x 7 1/2 em"
 
-#: ../src/msw/fswatcher.cpp:143
+#: ../src/msw/fswatcher.cpp:140
 msgid "Monitoring individual files for changes is not supported currently."
 msgstr ""
 "Atualmente não é suportado monitorar arquivos individuais por mudanças."
 
-#: ../src/generic/editlbox.cpp:172
+#: ../src/generic/editlbox.cpp:160
 msgid "Move down"
 msgstr "Mover pra baixo"
 
-#: ../src/generic/editlbox.cpp:171
+#: ../src/generic/editlbox.cpp:155
 msgid "Move up"
 msgstr "Mover pra cima"
 
@@ -5001,97 +5137,103 @@ msgstr "Move o objeto para o próximo parágrafo."
 msgid "Moves the object to the previous paragraph."
 msgstr "Move o objeto para o parágrafo anterior."
 
-#: ../src/richtext/richtextbuffer.cpp:9966
+#: ../src/richtext/richtextbuffer.cpp:9963
 msgid "Multiple Cell Properties"
 msgstr "Propriedades Múltiplas das Células"
 
-#: ../src/generic/filectrlg.cpp:424
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:82
+#, fuzzy
+msgid "Multiply"
+msgstr "KP_Multiplicar"
+
+#: ../src/generic/filectrlg.cpp:420
 msgid "Name"
 msgstr "Nome"
 
-#: ../src/propgrid/advprops.cpp:1596
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Navy"
 msgstr "Marinho"
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "Network"
 msgstr "Rede"
 
-#: ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173
 msgid "New"
 msgstr "Novo"
 
-#: ../src/richtext/richtextstyledlg.cpp:243
+#: ../src/richtext/richtextstyledlg.cpp:239
 msgid "New &Box Style..."
 msgstr "Novo &Estilo da Caixa..."
 
-#: ../src/richtext/richtextstyledlg.cpp:225
+#: ../src/richtext/richtextstyledlg.cpp:221
 msgid "New &Character Style..."
 msgstr "Novo &Estilo de Caractere..."
 
-#: ../src/richtext/richtextstyledlg.cpp:237
+#: ../src/richtext/richtextstyledlg.cpp:233
 msgid "New &List Style..."
 msgstr "Novo &Estilo de Lista..."
 
-#: ../src/richtext/richtextstyledlg.cpp:231
+#: ../src/richtext/richtextstyledlg.cpp:227
 msgid "New &Paragraph Style..."
 msgstr "Novo &Estilo de Parágrafo..."
 
-#: ../src/richtext/richtextstyledlg.cpp:606
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:654
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:820
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:893
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:934
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:602
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:650
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:816
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:889
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:930
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "New Style"
 msgstr "Novo Estilo"
 
-#: ../src/generic/editlbox.cpp:169
+#: ../src/generic/editlbox.cpp:139
 msgid "New item"
 msgstr "Novo item"
 
-#: ../src/generic/dirdlgg.cpp:297 ../src/generic/dirdlgg.cpp:307
-#: ../src/generic/filectrlg.cpp:618 ../src/generic/filectrlg.cpp:627
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+#: ../src/generic/dirdlgg.cpp:294 ../src/generic/dirdlgg.cpp:304
 msgid "NewName"
 msgstr "NovoNome"
 
-#: ../src/common/prntbase.cpp:1567 ../src/html/helpwnd.cpp:665
+#: ../src/common/prntbase.cpp:1592 ../src/html/helpwnd.cpp:663
 msgid "Next page"
 msgstr "Próxima página"
 
-#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:177
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:174
 #: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Não"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1764
+#: ../src/propgrid/advprops.cpp:1665
 msgid "No Entry"
 msgstr "Nenhuma Entrada"
 
-#: ../src/generic/animateg.cpp:150
+#: ../src/generic/animateg.cpp:133
 #, c-format
 msgid "No animation handler for type %ld defined."
 msgstr "Nenhum manejador de animação para o tipo %ld definido."
 
-#: ../src/dfb/bitmap.cpp:642 ../src/dfb/bitmap.cpp:676
+#: ../src/dfb/bitmap.cpp:639 ../src/dfb/bitmap.cpp:673
 #, c-format
 msgid "No bitmap handler for type %d defined."
 msgstr "Nenhum manejador de bitmap para o tipo %d definido."
 
-#: ../src/common/utilscmn.cpp:1077
+#: ../src/common/utilscmn.cpp:1095
 msgid "No default application configured for HTML files."
 msgstr "Nenhum aplicativo padrão configurado para os arquivos HTML."
 
-#: ../src/generic/helpext.cpp:445
+#: ../src/generic/helpext.cpp:443
 msgid "No entries found."
 msgstr "Não foram achadas entradas."
 
-#: ../src/common/fontmap.cpp:421
+#: ../src/common/fontmap.cpp:418
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found,\n"
@@ -5103,7 +5245,7 @@ msgstr ""
 "mas uma codificação alternativa '%s' está disponível.\n"
 "Você quer usar esta codificação (de outro modo você terá que escolher outra)?"
 
-#: ../src/common/fontmap.cpp:426
+#: ../src/common/fontmap.cpp:423
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found.\n"
@@ -5114,201 +5256,201 @@ msgstr ""
 "Você gostaria de selecionar a fonte a ser usada para esta codificação?\n"
 "(de outro modo o texto nesta codificação não será mostrado corretamente)?"
 
-#: ../src/generic/animateg.cpp:142
+#: ../src/generic/animateg.cpp:125
 msgid "No handler found for animation type."
 msgstr "Nenhum manejador achado para o tipo de animação."
 
-#: ../src/common/image.cpp:2728
+#: ../src/common/image.cpp:2823
 msgid "No handler found for image type."
 msgstr "Nenhum manejador achado para o tipo de imagem."
 
-#: ../src/common/image.cpp:2736 ../src/common/image.cpp:2848
-#: ../src/common/image.cpp:2901
+#: ../src/common/image.cpp:2831 ../src/common/image.cpp:2954
+#: ../src/common/image.cpp:3020
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "Nenhum manejador de imagem para o tipo %d definido."
 
-#: ../src/common/image.cpp:2871 ../src/common/image.cpp:2915
+#: ../src/common/image.cpp:2986 ../src/common/image.cpp:3034
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "Nenhum manejador de imagem para o tipo %s definido."
 
-#: ../src/html/helpwnd.cpp:858
+#: ../src/html/helpwnd.cpp:856
 msgid "No matching page found yet"
 msgstr "Nenhuma página que combine ainda foi achada"
 
-#: ../src/unix/sound.cpp:81
+#: ../src/unix/sound.cpp:78
 msgid "No sound"
 msgstr "Sem som"
 
-#: ../src/common/image.cpp:2277 ../src/common/image.cpp:2318
+#: ../src/common/image.cpp:2371 ../src/common/image.cpp:2412
 msgid "No unused colour in image being masked."
 msgstr "Nenhuma côr sem uso na imagem sendo mascarada."
 
-#: ../src/common/image.cpp:3374
-msgid "No unused colour in image."
-msgstr "Nenhuma côr sem uso na imagem."
-
-#: ../src/generic/helpext.cpp:302
+#: ../src/generic/helpext.cpp:300
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "Nenhum mapeamento válido achado no arquivo \"%s\"."
 
-#: ../src/richtext/richtextborderspage.cpp:610
 #: ../src/richtext/richtextsizepage.cpp:248
 #: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:610
 msgid "None"
 msgstr "Nenhum"
 
-#: ../src/common/fmapbase.cpp:157
+#: ../src/common/fmapbase.cpp:154
 msgid "Nordic (ISO-8859-10)"
 msgstr "Nórdico (ISO-8859-10)"
 
-#: ../src/generic/fontdlgg.cpp:328 ../src/generic/fontdlgg.cpp:331
+#: ../src/generic/fontdlgg.cpp:324 ../src/generic/fontdlgg.cpp:327
 msgid "Normal"
 msgstr "Normal"
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1261
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Face normal<br>e <u>sublinhado</u>. "
 
-#: ../src/html/helpwnd.cpp:1205
+#: ../src/html/helpwnd.cpp:1203
 msgid "Normal font:"
 msgstr "Fonte normal:"
 
-#: ../src/propgrid/props.cpp:1128
+#: ../src/propgrid/props.cpp:1115
 #, c-format
 msgid "Not %s"
 msgstr "Não %s"
 
-#: ../include/wx/filename.h:573 ../include/wx/filename.h:578
-msgid "Not available"
-msgstr "Não disponível"
+#: ../src/common/secretstore.cpp:168
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/webrequest.cpp:605
+msgid "Not enough free disk space for download."
+msgstr ""
 
 #: ../src/richtext/richtextfontpage.cpp:358
 msgid "Not underlined"
 msgstr "Não sublinhado"
 
-#: ../src/common/paper.cpp:115
+#: ../src/common/paper.cpp:112
 msgid "Note, 8 1/2 x 11 in"
 msgstr "Nota, 8 1/2 x 11 em"
 
-#: ../src/generic/notifmsgg.cpp:132
+#: ../src/generic/notifmsgg.cpp:129
 msgid "Notice"
 msgstr "Nota"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "Num *"
 msgstr "Num *"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "Num +"
 msgstr "Num +"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "Num ,"
 msgstr "Num ,"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "Num -"
 msgstr "Num -"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "Num ."
 msgstr "Num ."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "Num /"
 msgstr "Num /"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "Num ="
 msgstr "Num ="
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "Num Begin"
 msgstr "Num Começar"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 msgid "Num Delete"
 msgstr "Num Apagar"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 msgid "Num Down"
 msgstr "Num Pra Baixo"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "Num End"
 msgstr "Num End"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "Num Enter"
 msgstr "Num Enter"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 msgid "Num Home"
 msgstr "Num Home"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 msgid "Num Insert"
 msgstr "Num Insert"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num Lock"
 msgstr "Num Lock"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "Num Page Down"
 msgstr "Num Page Down"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "Num Page Up"
 msgstr "Num Page Up"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 msgid "Num Right"
 msgstr "Num Direita"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "Num Space"
 msgstr "Num Barra de Espaço"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "Num Tab"
 msgstr "Num Aba"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "Num Up"
 msgstr "Num Pra Cima"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "Num left"
 msgstr "Num Esquerda"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num_lock"
 msgstr "Num_lock"
 
@@ -5317,13 +5459,13 @@ msgstr "Num_lock"
 msgid "Numbered outline"
 msgstr "Contornos numerados"
 
-#: ../include/wx/msgdlg.h:278 ../src/richtext/richtextstyledlg.cpp:297
-#: ../src/common/stockitem.cpp:178 ../src/msw/msgdlg.cpp:454
-#: ../src/msw/msgdlg.cpp:747 ../src/gtk1/fontdlg.cpp:138
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:175
+#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/msgdlg.cpp:741 ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "OK"
 
-#: ../src/msw/ole/automtn.cpp:692
+#: ../src/msw/ole/automtn.cpp:683
 #, c-format
 msgid "OLE Automation error in %s: %s"
 msgstr "Erro de automação do OLE em %s: %s"
@@ -5332,15 +5474,15 @@ msgstr "Erro de automação do OLE em %s: %s"
 msgid "Object Properties"
 msgstr "Propriedades do Objeto"
 
-#: ../src/msw/ole/automtn.cpp:660
+#: ../src/msw/ole/automtn.cpp:651
 msgid "Object implementation does not support named arguments."
 msgstr "A implementação do objeto não suporta argumentos nomeados."
 
-#: ../src/common/xtixml.cpp:264
+#: ../src/common/xtixml.cpp:260
 msgid "Objects must have an id attribute"
 msgstr "Os objetos devem ter um atributo id"
 
-#: ../src/propgrid/advprops.cpp:1601
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Olive"
 msgstr "Oliva"
 
@@ -5348,64 +5490,69 @@ msgstr "Oliva"
 msgid "Opaci&ty:"
 msgstr "Opaci&dade:"
 
-#: ../src/generic/colrdlgg.cpp:354
+#: ../src/generic/colrdlgg.cpp:374
 msgid "Opacity:"
 msgstr "Opacidade:"
 
-#: ../src/common/docview.cpp:1773 ../src/common/docview.cpp:1815
+#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
 msgid "Open File"
 msgstr "Abrir Arquivo"
 
-#: ../src/html/helpwnd.cpp:671 ../src/html/helpwnd.cpp:1554
+#: ../src/html/helpwnd.cpp:669 ../src/html/helpwnd.cpp:1552
 msgid "Open HTML document"
 msgstr "Abrir documento HTML"
 
-#: ../src/generic/dbgrptg.cpp:163
+#: ../src/common/stockitem.cpp:265
+#, fuzzy
+msgid "Open an existing document"
+msgstr "Abrir documento HTML"
+
+#: ../src/generic/dbgrptg.cpp:160
 #, c-format
 msgid "Open file \"%s\""
 msgstr "Abrir arquivo \"%s\""
 
-#: ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176
 msgid "Open..."
 msgstr "Abrir..."
 
-#: ../src/unix/glx11.cpp:506 ../src/msw/glcanvas.cpp:592
+#: ../src/msw/glcanvas.cpp:607 ../src/unix/glx11.cpp:513
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr "OpenGL 3.0 ou superior não é suportado pelo driver do OpenGL."
 
-#: ../src/generic/dirctrlg.cpp:599 ../src/generic/dirdlgg.cpp:323
-#: ../src/generic/filectrlg.cpp:642 ../src/generic/filectrlg.cpp:786
+#: ../src/generic/dirctrlg.cpp:565 ../src/generic/filectrlg.cpp:638
+#: ../src/generic/filectrlg.cpp:782 ../src/generic/dirdlgg.cpp:320
 msgid "Operation not permitted."
 msgstr "Operação não permitida."
 
-#: ../src/common/cmdline.cpp:900
+#: ../src/common/cmdline.cpp:896
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "A opção '%s' não pode ser negada"
 
-#: ../src/common/cmdline.cpp:1064
+#: ../src/common/cmdline.cpp:1060
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "A opção '%s' requer um valor."
 
-#: ../src/common/cmdline.cpp:1147
+#: ../src/common/cmdline.cpp:1143
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "A opção '%s': '%s' não pode ser convertida para uma data."
 
-#: ../src/generic/prntdlgg.cpp:618
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Opções"
 
-#: ../src/propgrid/advprops.cpp:1606
+#: ../src/propgrid/advprops.cpp:1512
 msgid "Orange"
 msgstr "Laranja"
 
-#: ../src/generic/prntdlgg.cpp:615 ../src/generic/prntdlgg.cpp:869
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:862
 msgid "Orientation"
 msgstr "Orientação"
 
-#: ../src/common/windowid.cpp:242
+#: ../src/common/windowid.cpp:237
 msgid "Out of window IDs.  Recommend shutting down application."
 msgstr "IDs fora da janela. Recomendar o fechamento do aplicativo."
 
@@ -5418,148 +5565,148 @@ msgstr "Contorno"
 msgid "Outset"
 msgstr "Começo"
 
-#: ../src/msw/ole/automtn.cpp:656
+#: ../src/msw/ole/automtn.cpp:647
 msgid "Overflow while coercing argument values."
 msgstr "Sobrecarga enquanto força os valores do argumento."
 
-#: ../src/common/imagpcx.cpp:457 ../src/common/imagpcx.cpp:480
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:479
 msgid "PCX: couldn't allocate memory"
 msgstr "PCX: não pôde distribuir a memória"
 
-#: ../src/common/imagpcx.cpp:456
+#: ../src/common/imagpcx.cpp:455
 msgid "PCX: image format unsupported"
 msgstr "PCX: formato da imagem não suportado"
 
-#: ../src/common/imagpcx.cpp:479
+#: ../src/common/imagpcx.cpp:478
 msgid "PCX: invalid image"
 msgstr "PCX: imagem inválida"
 
-#: ../src/common/imagpcx.cpp:442
+#: ../src/common/imagpcx.cpp:441
 msgid "PCX: this is not a PCX file."
 msgstr "PCX: este não é um arquivo PCX."
 
-#: ../src/common/imagpcx.cpp:459 ../src/common/imagpcx.cpp:481
+#: ../src/common/imagpcx.cpp:458 ../src/common/imagpcx.cpp:480
 msgid "PCX: unknown error !!!"
 msgstr "PCX: erro desconhecido !!!"
 
-#: ../src/common/imagpcx.cpp:458
+#: ../src/common/imagpcx.cpp:457
 msgid "PCX: version number too low"
 msgstr "PCX: número de versão muito baixo"
 
-#: ../src/common/imagpnm.cpp:91
+#: ../src/common/imagpnm.cpp:89
 msgid "PNM: Couldn't allocate memory."
 msgstr "PNM: Não pôde distribuir a memória."
 
-#: ../src/common/imagpnm.cpp:73
+#: ../src/common/imagpnm.cpp:71
 msgid "PNM: File format is not recognized."
 msgstr "PNM: O formato do arquivo não é reconhecido."
 
-#: ../src/common/imagpnm.cpp:112 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
 #: ../src/common/imagpnm.cpp:156
 msgid "PNM: File seems truncated."
 msgstr "PNM: O arquivo parece truncado."
 
-#: ../src/common/paper.cpp:187
+#: ../src/common/paper.cpp:184
 msgid "PRC 16K 146 x 215 mm"
 msgstr "PRC 16K 146 x 215 mm"
 
-#: ../src/common/paper.cpp:200
+#: ../src/common/paper.cpp:197
 msgid "PRC 16K Rotated"
 msgstr "PRC 16K Rotacionado"
 
-#: ../src/common/paper.cpp:188
+#: ../src/common/paper.cpp:185
 msgid "PRC 32K 97 x 151 mm"
 msgstr "PRC 32K 97 x 151 mm"
 
-#: ../src/common/paper.cpp:201
+#: ../src/common/paper.cpp:198
 msgid "PRC 32K Rotated"
 msgstr "PRC 32K Rotacionado"
 
-#: ../src/common/paper.cpp:189
+#: ../src/common/paper.cpp:186
 msgid "PRC 32K(Big) 97 x 151 mm"
 msgstr "PRC 32K (Grande) 97 x 151 mm"
 
-#: ../src/common/paper.cpp:202
+#: ../src/common/paper.cpp:199
 msgid "PRC 32K(Big) Rotated"
 msgstr "PRC 32K (Grande) Rotacionado"
 
-#: ../src/common/paper.cpp:190
+#: ../src/common/paper.cpp:187
 msgid "PRC Envelope #1 102 x 165 mm"
 msgstr "Envelope PRC #1 102 x 165 mm"
 
-#: ../src/common/paper.cpp:203
+#: ../src/common/paper.cpp:200
 msgid "PRC Envelope #1 Rotated 165 x 102 mm"
 msgstr "Envelope PRC #1 Rotacionado 165 x 102 mm"
 
-#: ../src/common/paper.cpp:199
+#: ../src/common/paper.cpp:196
 msgid "PRC Envelope #10 324 x 458 mm"
 msgstr "Envelope PRC #10 324 x 458 mm"
 
-#: ../src/common/paper.cpp:212
+#: ../src/common/paper.cpp:209
 msgid "PRC Envelope #10 Rotated 458 x 324 mm"
 msgstr "Envelope PRC #10 Rotacionado 458 x 324 mm"
 
-#: ../src/common/paper.cpp:191
+#: ../src/common/paper.cpp:188
 msgid "PRC Envelope #2 102 x 176 mm"
 msgstr "Envelope PRC #2 102 x 176 mm"
 
-#: ../src/common/paper.cpp:204
+#: ../src/common/paper.cpp:201
 msgid "PRC Envelope #2 Rotated 176 x 102 mm"
 msgstr "Envelope PRC #2 Rotacionado 176 x 102 mm"
 
-#: ../src/common/paper.cpp:192
+#: ../src/common/paper.cpp:189
 msgid "PRC Envelope #3 125 x 176 mm"
 msgstr "Envelope PRC #3 125 x 176 mm"
 
-#: ../src/common/paper.cpp:205
+#: ../src/common/paper.cpp:202
 msgid "PRC Envelope #3 Rotated 176 x 125 mm"
 msgstr "Envelope B6 #3 Rotacionado 176 x 125 mm"
 
-#: ../src/common/paper.cpp:193
+#: ../src/common/paper.cpp:190
 msgid "PRC Envelope #4 110 x 208 mm"
 msgstr "Envelope PRC #4 110 x 208 mm"
 
-#: ../src/common/paper.cpp:206
+#: ../src/common/paper.cpp:203
 msgid "PRC Envelope #4 Rotated 208 x 110 mm"
 msgstr "Envelope PRC #4 Rotacionado 208 x 110 mm"
 
-#: ../src/common/paper.cpp:194
+#: ../src/common/paper.cpp:191
 msgid "PRC Envelope #5 110 x 220 mm"
 msgstr "Envelope PRC #5 110 x 220 mm"
 
-#: ../src/common/paper.cpp:207
+#: ../src/common/paper.cpp:204
 msgid "PRC Envelope #5 Rotated 220 x 110 mm"
 msgstr "Envelope PRC #5 Rotacionado 220 x 110 mm"
 
-#: ../src/common/paper.cpp:195
+#: ../src/common/paper.cpp:192
 msgid "PRC Envelope #6 120 x 230 mm"
 msgstr "Envelope PRC #6 120 x 230 mm"
 
-#: ../src/common/paper.cpp:208
+#: ../src/common/paper.cpp:205
 msgid "PRC Envelope #6 Rotated 230 x 120 mm"
 msgstr "Envelope PRC #6 Rotacionado 230 x 120 mm"
 
-#: ../src/common/paper.cpp:196
+#: ../src/common/paper.cpp:193
 msgid "PRC Envelope #7 160 x 230 mm"
 msgstr "Envelope PRC #7 160 x 230 mm"
 
-#: ../src/common/paper.cpp:209
+#: ../src/common/paper.cpp:206
 msgid "PRC Envelope #7 Rotated 230 x 160 mm"
 msgstr "Envelope PRC #7 Rotacionado 230 x 160 mm"
 
-#: ../src/common/paper.cpp:197
+#: ../src/common/paper.cpp:194
 msgid "PRC Envelope #8 120 x 309 mm"
 msgstr "Envelope PRC #8 120 x 309 mm"
 
-#: ../src/common/paper.cpp:210
+#: ../src/common/paper.cpp:207
 msgid "PRC Envelope #8 Rotated 309 x 120 mm"
 msgstr "Envelope PRC #8 Rotacionado 309 x 120 mm"
 
-#: ../src/common/paper.cpp:198
+#: ../src/common/paper.cpp:195
 msgid "PRC Envelope #9 229 x 324 mm"
 msgstr "Envelope PRC #9 229 x 324 mm"
 
-#: ../src/common/paper.cpp:211
+#: ../src/common/paper.cpp:208
 msgid "PRC Envelope #9 Rotated 324 x 229 mm"
 msgstr "Envelope PRC #9 Rotacionado 324 x 229 mm"
 
@@ -5567,87 +5714,91 @@ msgstr "Envelope PRC #9 Rotacionado 324 x 229 mm"
 msgid "Padding"
 msgstr "Enchimento"
 
-#: ../src/common/prntbase.cpp:2074
+#: ../src/common/prntbase.cpp:2096
 #, c-format
 msgid "Page %d"
 msgstr "Página %d"
 
-#: ../src/common/prntbase.cpp:2072
+#: ../src/common/prntbase.cpp:2094
 #, c-format
 msgid "Page %d of %d"
 msgstr "Página %d de %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 msgid "Page Down"
 msgstr "Page Down"
 
-#: ../src/gtk/print.cpp:826
+#: ../src/gtk/print.cpp:829
 msgid "Page Setup"
 msgstr "Configuração da Página"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 msgid "Page Up"
 msgstr "Page Up"
 
-#: ../src/generic/prntdlgg.cpp:828 ../src/common/prntbase.cpp:484
+#: ../src/common/prntbase.cpp:479 ../src/generic/prntdlgg.cpp:821
 msgid "Page setup"
 msgstr "Configuração da página"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 msgid "PageDown"
 msgstr "PageDown"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 msgid "PageUp"
 msgstr "PageUp"
 
-#: ../src/generic/prntdlgg.cpp:216
+#: ../src/generic/prntdlgg.cpp:209
 msgid "Pages"
 msgstr "Páginas"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1765
+#: ../src/propgrid/advprops.cpp:1666
 msgid "Paint Brush"
 msgstr "Pincel do Paint"
 
-#: ../src/generic/prntdlgg.cpp:602 ../src/generic/prntdlgg.cpp:801
-#: ../src/generic/prntdlgg.cpp:842 ../src/generic/prntdlgg.cpp:855
-#: ../src/generic/prntdlgg.cpp:1052 ../src/generic/prntdlgg.cpp:1057
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:794
+#: ../src/generic/prntdlgg.cpp:835 ../src/generic/prntdlgg.cpp:848
+#: ../src/generic/prntdlgg.cpp:1045 ../src/generic/prntdlgg.cpp:1050
 msgid "Paper size"
 msgstr "Tamanho do papel"
 
-#: ../src/richtext/richtextstyles.cpp:1062
+#: ../src/richtext/richtextstyles.cpp:1059
 msgid "Paragraph styles"
 msgstr "Estilos de parágrafo"
 
-#: ../src/common/xtistrm.cpp:465
+#: ../src/common/xtistrm.cpp:462
 msgid "Passing a already registered object to SetObject"
 msgstr "Passando um objeto já registrado pro SetObject"
 
-#: ../src/common/xtistrm.cpp:476
+#: ../src/common/xtistrm.cpp:473
 msgid "Passing an unknown object to GetObject"
 msgstr "Passando um objeto desconhecido pro GetObject"
 
-#: ../src/richtext/richtextctrl.cpp:3513 ../src/common/stockitem.cpp:180
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:177 ../src/richtext/richtextctrl.cpp:3514
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Colar"
 
-#: ../src/common/stockitem.cpp:262
+#: ../src/common/stockitem.cpp:260
 msgid "Paste selection"
 msgstr "Colar a seleção"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:74
+#: ../src/common/accelcmn.cpp:71
 msgid "Pause"
 msgstr "Pausa"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1766
+#: ../src/propgrid/advprops.cpp:1667
 msgid "Pencil"
 msgstr "Lápis"
 
@@ -5656,21 +5807,21 @@ msgstr "Lápis"
 msgid "Peri&od"
 msgstr "Pon&to"
 
-#: ../src/generic/filectrlg.cpp:430
+#: ../src/generic/filectrlg.cpp:426
 msgid "Permissions"
 msgstr "Permissões"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:60
+#: ../src/common/accelcmn.cpp:57
 msgid "PgDn"
 msgstr "PgDn"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:59
+#: ../src/common/accelcmn.cpp:56
 msgid "PgUp"
 msgstr "PgUp"
 
-#: ../src/richtext/richtextbuffer.cpp:12868
+#: ../src/richtext/richtextbuffer.cpp:12863
 msgid "Picture Properties"
 msgstr "Propriedades da Foto"
 
@@ -5682,42 +5833,42 @@ msgstr "A criação do pipe falhou"
 msgid "Please choose a valid font."
 msgstr "Por favor escolha uma fonte válida."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
 msgid "Please choose an existing file."
 msgstr "Por favor escolha um arquivo existente."
 
-#: ../src/html/helpwnd.cpp:800
+#: ../src/html/helpwnd.cpp:798
 msgid "Please choose the page to display:"
 msgstr "Por favor escolha a página a exibir:"
 
-#: ../src/msw/dialup.cpp:764
+#: ../src/msw/dialup.cpp:758
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Por favor escolha com qual ISP vocé quer se conectar"
 
-#: ../src/common/headerctrlcmn.cpp:59
+#: ../src/common/headerctrlcmn.cpp:57
 msgid "Please select the columns to show and define their order:"
 msgstr "Por favor selecione as colunas a mostrar e defina a ordem delas:"
 
-#: ../src/common/prntbase.cpp:538
+#: ../src/common/prntbase.cpp:533
 msgid "Please wait while printing..."
 msgstr "Por favor espere enquanto imprime..."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1767
+#: ../src/propgrid/advprops.cpp:1668
 msgid "Point Left"
 msgstr "Ponto a Esquerda"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1768
+#: ../src/propgrid/advprops.cpp:1669
 msgid "Point Right"
 msgstr "Ponto a Direita"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:662
+#: ../src/propgrid/advprops.cpp:572
 msgid "Point Size"
 msgstr "Tamanho do Ponto"
 
-#: ../src/generic/prntdlgg.cpp:612 ../src/generic/prntdlgg.cpp:867
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:860
 msgid "Portrait"
 msgstr "Retrato"
 
@@ -5725,150 +5876,160 @@ msgstr "Retrato"
 msgid "Position"
 msgstr "Posição"
 
-#: ../src/generic/prntdlgg.cpp:298
+#: ../src/generic/prntdlgg.cpp:291
 msgid "PostScript file"
 msgstr "Arquivo do PostScript"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178 ../src/osx/cocoa/preferences.mm:303
 msgid "Preferences"
 msgstr "Preferências"
 
-#: ../src/osx/menu_osx.cpp:568
+#: ../src/osx/menu_osx.cpp:460
 msgid "Preferences..."
 msgstr "Preferências..."
 
-#: ../src/common/prntbase.cpp:546
+#: ../src/common/prntbase.cpp:541
 msgid "Preparing"
 msgstr "Preparando"
 
-#: ../src/generic/fontdlgg.cpp:455 ../src/osx/carbon/fontdlg.cpp:390
-#: ../src/html/helpwnd.cpp:1222
+#: ../src/osx/carbon/fontdlg.cpp:387 ../src/generic/fontdlgg.cpp:452
+#: ../src/html/helpwnd.cpp:1220
 msgid "Preview:"
 msgstr "Pré-visualização:"
 
-#: ../src/common/prntbase.cpp:1553 ../src/html/helpwnd.cpp:664
+#: ../src/common/prntbase.cpp:1578 ../src/html/helpwnd.cpp:662
 msgid "Previous page"
 msgstr "Página anterior"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/prntdlgg.cpp:143 ../src/generic/prntdlgg.cpp:157
-#: ../src/common/prntbase.cpp:426 ../src/common/prntbase.cpp:1541
-#: ../src/common/accelcmn.cpp:77 ../src/gtk/print.cpp:620
-#: ../src/gtk/print.cpp:638
+#: ../src/common/prntbase.cpp:421 ../src/common/prntbase.cpp:1566
+#: ../src/common/accelcmn.cpp:74 ../src/generic/prntdlgg.cpp:136
+#: ../src/generic/prntdlgg.cpp:150 ../src/gtk/print.cpp:616
+#: ../src/gtk/print.cpp:634
 msgid "Print"
 msgstr "Imprimir"
 
-#: ../include/wx/prntbase.h:399 ../src/common/docview.cpp:1268
+#: ../src/common/docview.cpp:1262
 msgid "Print Preview"
 msgstr "Pré-visualização da Impressão"
 
-#: ../src/common/prntbase.cpp:2015 ../src/common/prntbase.cpp:2057
-#: ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2037 ../src/common/prntbase.cpp:2079
+#: ../src/common/prntbase.cpp:2087
 msgid "Print Preview Failure"
 msgstr "Falha ao Pré-visualizar a Impressão"
 
-#: ../src/generic/prntdlgg.cpp:224
+#: ../src/generic/prntdlgg.cpp:217
 msgid "Print Range"
 msgstr "Alcance da Impressão"
 
-#: ../src/generic/prntdlgg.cpp:449
+#: ../src/generic/prntdlgg.cpp:442
 msgid "Print Setup"
 msgstr "Configuração da Impressão"
 
-#: ../src/generic/prntdlgg.cpp:621
+#: ../src/generic/prntdlgg.cpp:614
 msgid "Print in colour"
 msgstr "Imprimir em cores"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/osx/webview_webkit.mm:260
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "A descrição da coluna não pôde ser inicializada."
+
+#: ../src/common/stockitem.cpp:179
 msgid "Print previe&w..."
 msgstr "Pré-visualizar impressã&o..."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1256
 msgid "Print preview creation failed."
 msgstr "A criação da pré-visualização da impressão falhou."
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/common/stockitem.cpp:179
 msgid "Print preview..."
 msgstr "Pré-visualização da impressão..."
 
-#: ../src/generic/prntdlgg.cpp:630
+#: ../src/generic/prntdlgg.cpp:623
 msgid "Print spooling"
 msgstr "Buffering da impressão"
 
-#: ../src/html/helpwnd.cpp:675
+#: ../src/html/helpwnd.cpp:673
 msgid "Print this page"
 msgstr "Imprimir esta página"
 
-#: ../src/generic/prntdlgg.cpp:185
+#: ../src/generic/prntdlgg.cpp:178
 msgid "Print to File"
 msgstr "Imprimir pro Arquivo"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "Print..."
 msgstr "Imprimir..."
 
-#: ../src/generic/prntdlgg.cpp:493
+#: ../src/generic/prntdlgg.cpp:486
 msgid "Printer"
 msgstr "Impressora"
 
-#: ../src/generic/prntdlgg.cpp:633
+#: ../src/generic/prntdlgg.cpp:626
 msgid "Printer command:"
 msgstr "Comando da impressora:"
 
-#: ../src/generic/prntdlgg.cpp:180
+#: ../src/generic/prntdlgg.cpp:173
 msgid "Printer options"
 msgstr "Opções da impressora"
 
-#: ../src/generic/prntdlgg.cpp:645
+#: ../src/generic/prntdlgg.cpp:638
 msgid "Printer options:"
 msgstr "Opções da impressora:"
 
-#: ../src/generic/prntdlgg.cpp:916
+#: ../src/generic/prntdlgg.cpp:909
 msgid "Printer..."
 msgstr "Impressora..."
 
-#: ../src/generic/prntdlgg.cpp:196
+#: ../src/generic/prntdlgg.cpp:189
 msgid "Printer:"
 msgstr "Impressora:"
 
-#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:535
-#: ../src/html/htmprint.cpp:277
+#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:530
+#: ../src/html/htmprint.cpp:289
 msgid "Printing"
 msgstr "Imprimindo"
 
-#: ../src/common/prntbase.cpp:612
+#: ../src/common/prntbase.cpp:607
 msgid "Printing "
 msgstr "Imprimindo "
 
-#: ../src/common/prntbase.cpp:347
+#: ../src/common/prntbase.cpp:342
 msgid "Printing Error"
 msgstr "Erro ao imprimir"
 
-#: ../src/common/prntbase.cpp:565
+#: ../src/osx/webview_webkit.mm:251
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "Gzip não suportado por esta versão do zlib"
+
+#: ../src/common/prntbase.cpp:560
 #, c-format
 msgid "Printing page %d"
 msgstr "Imprimindo a página %d"
 
-#: ../src/common/prntbase.cpp:570
+#: ../src/common/prntbase.cpp:565
 #, c-format
 msgid "Printing page %d of %d"
 msgstr "Imprimindo a página %d de %d"
 
-#: ../src/generic/printps.cpp:201
+#: ../src/generic/printps.cpp:182
 #, c-format
 msgid "Printing page %d..."
 msgstr "Imprimindo a página %d..."
 
-#: ../src/generic/printps.cpp:161
+#: ../src/generic/printps.cpp:142
 msgid "Printing..."
 msgstr "Imprimindo..."
 
-#: ../include/wx/richtext/richtextprint.h:109 ../include/wx/prntbase.h:267
-#: ../src/common/docview.cpp:2132
+#: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
+#: ../src/common/docview.cpp:2137
 msgid "Printout"
 msgstr "Imprimir"
 
-#: ../src/common/debugrpt.cpp:560
+#: ../src/common/debugrpt.cpp:561
 #, c-format
 msgid ""
 "Processing debug report has failed, leaving the files in \"%s\" directory."
@@ -5876,102 +6037,102 @@ msgstr ""
 "O processamento do relatório do debug falhou, deixando os arquivos no "
 "diretório \"%s\"."
 
-#: ../src/common/prntbase.cpp:545
+#: ../src/common/prntbase.cpp:540
 msgid "Progress:"
 msgstr "Progresso:"
 
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181
 msgid "Properties"
 msgstr "Propriedades"
 
-#: ../src/propgrid/manager.cpp:237
+#: ../src/propgrid/manager.cpp:223
 msgid "Property"
 msgstr "Propriedade"
 
 #. TRANSLATORS: Caption of message box displaying any property error
-#: ../src/propgrid/propgrid.cpp:3185 ../src/propgrid/propgrid.cpp:3318
+#: ../src/propgrid/propgrid.cpp:3162 ../src/propgrid/propgrid.cpp:3299
 msgid "Property Error"
 msgstr "Erro da Propriedade"
 
-#: ../src/propgrid/advprops.cpp:1597
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Purple"
 msgstr "Púrpura"
 
-#: ../src/common/paper.cpp:112
+#: ../src/common/paper.cpp:109
 msgid "Quarto, 215 x 275 mm"
 msgstr "Quarto, 215 x 275 mm"
 
-#: ../src/generic/logg.cpp:1016
+#: ../src/generic/logg.cpp:1013
 msgid "Question"
 msgstr "Pergunta"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1769
+#: ../src/propgrid/advprops.cpp:1670
 msgid "Question Arrow"
 msgstr "Seta da Pergunta"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "Quit"
 msgstr "Sair"
 
-#: ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:477
 #, c-format
 msgid "Quit %s"
 msgstr "Sair %s"
 
-#: ../src/common/stockitem.cpp:263
+#: ../src/common/stockitem.cpp:261
 msgid "Quit this program"
 msgstr "Sair deste programa"
 
-#: ../src/common/accelcmn.cpp:338
+#: ../src/common/accelcmn.cpp:352
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/ffile.cpp:109 ../src/common/ffile.cpp:133
+#: ../src/common/ffile.cpp:107 ../src/common/ffile.cpp:132
 #, c-format
 msgid "Read error on file '%s'"
 msgstr "Erro de leitura no arquivo '%s'"
 
-#: ../src/common/secretstore.cpp:199
-#, c-format
-msgid "Reading password for \"%s/%s\" failed: %s."
+#: ../src/common/secretstore.cpp:211
+#, fuzzy, c-format
+msgid "Reading password for \"%s\" failed: %s."
 msgstr "Falhou em ler a senha do \"%s/%s\": %s."
 
-#: ../src/common/prntbase.cpp:272
+#: ../src/common/prntbase.cpp:267
 msgid "Ready"
 msgstr "Pronto"
 
-#: ../src/propgrid/advprops.cpp:1605
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Red"
 msgstr "Vermelho"
 
-#: ../src/generic/colrdlgg.cpp:339
+#: ../src/generic/colrdlgg.cpp:359
 msgid "Red:"
 msgstr "Vermelho:"
 
-#: ../src/common/stockitem.cpp:185 ../src/stc/stc_i18n.cpp:16
+#: ../src/common/stockitem.cpp:182 ../src/stc/stc_i18n.cpp:16
 msgid "Redo"
 msgstr "Refazer"
 
-#: ../src/common/stockitem.cpp:264
+#: ../src/common/stockitem.cpp:262
 msgid "Redo last action"
 msgstr "Refazer a última ação"
 
-#: ../src/common/stockitem.cpp:186
+#: ../src/common/stockitem.cpp:183
 msgid "Refresh"
 msgstr "Atualizar"
 
-#: ../src/msw/registry.cpp:626
+#: ../src/msw/registry.cpp:615
 #, c-format
 msgid "Registry key '%s' already exists."
 msgstr "A chave de registro '%s' já existe."
 
-#: ../src/msw/registry.cpp:595
+#: ../src/msw/registry.cpp:584
 #, c-format
 msgid "Registry key '%s' does not exist, cannot rename it."
 msgstr "A chave de registro '%s' não existe; não pode renomeá-la."
 
-#: ../src/msw/registry.cpp:727
+#: ../src/msw/registry.cpp:716
 #, c-format
 msgid ""
 "Registry key '%s' is needed for normal system operation,\n"
@@ -5982,22 +6143,22 @@ msgstr ""
 "apagando-a deixará seu sistema num estado inutilizável:\n"
 "operação abortada."
 
-#: ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:942
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr "O valor do registro \"%s\" não é binário (mas do tipo %s)"
 
-#: ../src/msw/registry.cpp:917
+#: ../src/msw/registry.cpp:905
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr "O valor do registro \"%s\" não é numérico (mas do tipo %s)"
 
-#: ../src/msw/registry.cpp:1003
+#: ../src/msw/registry.cpp:991
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr "O valor do registro \"%s\" não é de texto (mas do tipo %s)"
 
-#: ../src/msw/registry.cpp:521
+#: ../src/msw/registry.cpp:510
 #, c-format
 msgid "Registry value '%s' already exists."
 msgstr "O valor do registro '%s' já existe."
@@ -6011,72 +6172,78 @@ msgstr "Regular"
 msgid "Relative"
 msgstr "Relativo"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:456
 msgid "Relevant entries:"
 msgstr "Entradas relevantes:"
 
-#: ../include/wx/generic/progdlgg.h:86
+#: ../include/wx/generic/progdlgg.h:87
 msgid "Remaining time:"
 msgstr "Tempo restante:"
 
-#: ../src/common/stockitem.cpp:187
+#: ../src/common/stockitem.cpp:184
 msgid "Remove"
 msgstr "Remover"
 
-#: ../src/richtext/richtextctrl.cpp:1562
+#: ../src/richtext/richtextctrl.cpp:1563
 msgid "Remove Bullet"
 msgstr "Remover a Bala"
 
-#: ../src/html/helpwnd.cpp:433
+#: ../src/html/helpwnd.cpp:431
 msgid "Remove current page from bookmarks"
 msgstr "Remover a página atual dos favoritos"
 
-#: ../src/common/rendcmn.cpp:194
+#: ../src/common/rendcmn.cpp:191
 #, c-format
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 "O renderizador \"%s\" tem uma versão incompatível, %d.%d; e não pôde ser "
 "carregado."
 
-#: ../src/richtext/richtextbuffer.cpp:4527
+#: ../src/richtext/richtextbuffer.cpp:4524
 msgid "Renumber List"
 msgstr "Renumerar a Lista"
 
-#: ../src/common/stockitem.cpp:188
-msgid "Rep&lace"
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Rep&lace..."
 msgstr "Sub&stituir"
 
-#: ../src/richtext/richtextctrl.cpp:3673 ../src/common/stockitem.cpp:188
+#: ../src/richtext/richtextctrl.cpp:3674
 msgid "Replace"
 msgstr "Substituir"
 
-#: ../src/generic/fdrepdlg.cpp:182
+#: ../src/generic/fdrepdlg.cpp:179
 msgid "Replace &all"
 msgstr "Substituir &tudo"
 
-#: ../src/common/stockitem.cpp:261
-msgid "Replace selection"
-msgstr "Substituir a seleção"
-
-#: ../src/generic/fdrepdlg.cpp:124
+#: ../src/generic/fdrepdlg.cpp:121
 msgid "Replace with:"
 msgstr "Substituir por:"
 
-#: ../src/common/valtext.cpp:163
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Replace..."
+msgstr "Substituir"
+
+#: ../src/common/valtext.cpp:184
 msgid "Required information entry is empty."
 msgstr "O espaço da informação requerida está vazio."
 
-#: ../src/common/translation.cpp:1975
+#: ../src/common/translation.cpp:2025
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "O recurso '%s' não é um catálogo de mensagens válido."
 
+#: ../src/gtk/webview_webkit.cpp:985
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:56
+#: ../src/common/accelcmn.cpp:53
 msgid "Return"
 msgstr "Retornar"
 
-#: ../src/common/stockitem.cpp:189
+#: ../src/common/stockitem.cpp:186
 msgid "Revert to Saved"
 msgstr "Reverter pro Salvo"
 
@@ -6088,41 +6255,41 @@ msgstr "Cume"
 msgid "Rig&ht-to-left"
 msgstr "Dir&eita-pra-esquerda"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6149
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:59 ../src/generic/datavgen.cpp:6954
+#: ../src/richtext/richtextsizepage.cpp:250
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextbulletspage.cpp:188
-#: ../src/richtext/richtextsizepage.cpp:250 ../src/common/accelcmn.cpp:62
 msgid "Right"
 msgstr "Direita"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1754
+#: ../src/propgrid/advprops.cpp:1655
 msgid "Right Arrow"
 msgstr "Seta a Direita"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1770
+#: ../src/propgrid/advprops.cpp:1671
 msgid "Right Button"
 msgstr "Botão Direito"
 
-#: ../src/generic/prntdlgg.cpp:892
+#: ../src/generic/prntdlgg.cpp:885
 msgid "Right margin (mm):"
 msgstr "Margem direita (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:148
-#: ../src/richtext/richtextindentspage.cpp:150
 #: ../src/richtext/richtextliststylepage.cpp:337
 #: ../src/richtext/richtextliststylepage.cpp:339
+#: ../src/richtext/richtextindentspage.cpp:148
+#: ../src/richtext/richtextindentspage.cpp:150
 msgid "Right-align text."
 msgstr "Alinhar o texto a direita."
 
-#: ../src/generic/fontdlgg.cpp:322
+#: ../src/generic/fontdlgg.cpp:318
 msgid "Roman"
 msgstr "Romano"
 
-#: ../src/generic/datavgen.cpp:5916
+#: ../src/generic/datavgen.cpp:6721
 #, c-format
 msgid "Row %i"
 msgstr "Fileira %i"
@@ -6132,30 +6299,31 @@ msgstr "Fileira %i"
 msgid "S&tandard bullet name:"
 msgstr "N&ome padrão da projétil:"
 
-#: ../src/common/accelcmn.cpp:268 ../src/common/accelcmn.cpp:350
+#: ../src/common/accelcmn.cpp:282 ../src/common/accelcmn.cpp:367
 msgid "SPECIAL"
 msgstr "ESPECIAL"
 
-#: ../src/common/stockitem.cpp:190 ../src/common/sizer.cpp:2797
+#: ../src/common/stockitem.cpp:187 ../src/common/sizer.cpp:2914
 msgid "Save"
 msgstr "Salvar"
 
-#: ../src/common/fldlgcmn.cpp:342
+#: ../src/common/fldlgcmn.cpp:339
 #, c-format
 msgid "Save %s file"
 msgstr "Salvar arquivo %s"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/common/stockitem.cpp:188 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Salvar &Como..."
 
-#: ../src/common/docview.cpp:366
+#: ../src/common/docview.cpp:359
 msgid "Save As"
 msgstr "Salvar Como"
 
-#: ../src/common/stockitem.cpp:191
-msgid "Save as"
-msgstr "Salvar como"
+#: ../src/common/stockitem.cpp:188
+#, fuzzy
+msgid "Save As..."
+msgstr "Salvar &Como..."
 
 #: ../src/common/stockitem.cpp:267
 msgid "Save current document"
@@ -6165,40 +6333,40 @@ msgstr "Salvar o documento atual"
 msgid "Save current document with a different filename"
 msgstr "Salvar o documento atual com um nome de arquivo diferente"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/generic/logg.cpp:509
 msgid "Save log contents to file"
 msgstr "Salvar os conteúdos do log num arquivo"
 
-#: ../src/common/secretstore.cpp:179
-#, c-format
-msgid "Saving password for \"%s/%s\" failed: %s."
+#: ../src/common/secretstore.cpp:189
+#, fuzzy, c-format
+msgid "Saving password for \"%s\" failed: %s."
 msgstr "Falhou em salvar a senha para o \"%s/%s\": %s."
 
-#: ../src/generic/fontdlgg.cpp:325
+#: ../src/generic/fontdlgg.cpp:321
 msgid "Script"
 msgstr "Script"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll Lock"
 msgstr "Scroll Lock"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll_lock"
 msgstr "Scroll_lock"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:890
+#: ../src/propgrid/advprops.cpp:791
 msgid "Scrollbar"
 msgstr "Barra de Rolagem"
 
-#: ../src/generic/srchctlg.cpp:56 ../src/html/helpwnd.cpp:535
-#: ../src/html/helpwnd.cpp:550
+#: ../src/generic/srchctlg.cpp:55 ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:548 ../src/gtk/srchctrl.cpp:182
 msgid "Search"
 msgstr "Procurar"
 
-#: ../src/html/helpwnd.cpp:537
+#: ../src/html/helpwnd.cpp:535
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
@@ -6206,56 +6374,56 @@ msgstr ""
 "Pesquisar conteúdos do(s) livro(s) de ajuda pra todas as ocorrências do "
 "texto que você digitou acima"
 
-#: ../src/generic/fdrepdlg.cpp:160
+#: ../src/generic/fdrepdlg.cpp:157
 msgid "Search direction"
 msgstr "Direção da busca"
 
-#: ../src/generic/fdrepdlg.cpp:112
+#: ../src/generic/fdrepdlg.cpp:109
 msgid "Search for:"
 msgstr "Procurar por:"
 
-#: ../src/html/helpwnd.cpp:1052
+#: ../src/html/helpwnd.cpp:1050
 msgid "Search in all books"
 msgstr "Procurar em todos os livros"
 
-#: ../src/html/helpwnd.cpp:857
+#: ../src/html/helpwnd.cpp:855
 msgid "Searching..."
 msgstr "Procurando..."
 
-#: ../src/generic/dirctrlg.cpp:446
+#: ../src/generic/dirctrlg.cpp:412
 msgid "Sections"
 msgstr "Seções"
 
-#: ../src/common/ffile.cpp:238
+#: ../src/common/ffile.cpp:237
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Erro de busca no arquivo '%s'"
 
-#: ../src/common/ffile.cpp:228
+#: ../src/common/ffile.cpp:227
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
 "Erro de busca no arquivo '%s' (arquivos grandes não suportados pela stdio)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:76
+#: ../src/common/accelcmn.cpp:73
 msgid "Select"
 msgstr "Selecionar"
 
-#: ../src/richtext/richtextctrl.cpp:337 ../src/osx/textctrl_osx.cpp:581
-#: ../src/common/stockitem.cpp:192 ../src/msw/textctrl.cpp:2512
+#: ../src/osx/textctrl_osx.cpp:599 ../src/common/stockitem.cpp:189
+#: ../src/msw/textctrl.cpp:2777 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Selecionar &Tudo"
 
-#: ../src/common/stockitem.cpp:192 ../src/stc/stc_i18n.cpp:21
+#: ../src/common/stockitem.cpp:189 ../src/stc/stc_i18n.cpp:21
 msgid "Select All"
 msgstr "Selecionar Tudo"
 
-#: ../src/common/docview.cpp:1895
+#: ../src/common/docview.cpp:1900
 msgid "Select a document template"
 msgstr "Selecione um modelo de documento"
 
-#: ../src/common/docview.cpp:1969
+#: ../src/common/docview.cpp:1974
 msgid "Select a document view"
 msgstr "Selecione uma visualização do documento"
 
@@ -6284,20 +6452,20 @@ msgid "Selects the list level to edit."
 msgstr "Seleciona o nível da lista para editar."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:82
+#: ../src/common/accelcmn.cpp:79
 msgid "Separator"
 msgstr "Separador"
 
-#: ../src/common/cmdline.cpp:1083
+#: ../src/common/cmdline.cpp:1079
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Separador esperado após a opção '%s'."
 
-#: ../src/osx/menu_osx.cpp:572
+#: ../src/osx/menu_osx.cpp:464
 msgid "Services"
 msgstr "Serviços"
 
-#: ../src/richtext/richtextbuffer.cpp:11217
+#: ../src/richtext/richtextbuffer.cpp:11216
 msgid "Set Cell Style"
 msgstr "Definir o Estilo da Célula"
 
@@ -6305,11 +6473,11 @@ msgstr "Definir o Estilo da Célula"
 msgid "SetProperty called w/o valid setter"
 msgstr "SetProperty chamada sem um \"setter\" válido"
 
-#: ../src/generic/prntdlgg.cpp:188
+#: ../src/generic/prntdlgg.cpp:181
 msgid "Setup..."
 msgstr "Configurar..."
 
-#: ../src/msw/dialup.cpp:544
+#: ../src/msw/dialup.cpp:538
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr "Várias conexões dial-up ativas achadas, escolhendo uma aleatoriamente."
 
@@ -6325,40 +6493,40 @@ msgstr "Sombra"
 msgid "Shadow c&olour:"
 msgstr "Côr da S&ombra:"
 
-#: ../src/common/accelcmn.cpp:335
+#: ../src/common/accelcmn.cpp:349
 msgid "Shift+"
 msgstr "Shift+"
 
-#: ../src/generic/dirdlgg.cpp:147
+#: ../src/generic/dirdlgg.cpp:144
 msgid "Show &hidden directories"
 msgstr "Mostrar &diretórios ocultos"
 
-#: ../src/generic/filectrlg.cpp:983
+#: ../src/generic/filectrlg.cpp:979
 msgid "Show &hidden files"
 msgstr "Mostrar &arquivos ocultos"
 
-#: ../src/osx/menu_osx.cpp:580
+#: ../src/osx/menu_osx.cpp:472
 msgid "Show All"
 msgstr "Mostrar Tudo"
 
-#: ../src/common/stockitem.cpp:257
+#: ../src/common/stockitem.cpp:254
 msgid "Show about dialog"
 msgstr "Mostrar o diálogo sobre"
 
-#: ../src/html/helpwnd.cpp:492
+#: ../src/html/helpwnd.cpp:490
 msgid "Show all"
 msgstr "Mostrar tudo"
 
-#: ../src/html/helpwnd.cpp:503
+#: ../src/html/helpwnd.cpp:501
 msgid "Show all items in index"
 msgstr "Mostrar todos os itens no índice"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:656
 msgid "Show/hide navigation panel"
 msgstr "Mostrar/ocultar o painel de navegação"
 
-#: ../src/richtext/richtextsymboldlg.cpp:421
-#: ../src/richtext/richtextsymboldlg.cpp:423
+#: ../src/richtext/richtextsymboldlg.cpp:418
+#: ../src/richtext/richtextsymboldlg.cpp:420
 msgid "Shows a Unicode subset."
 msgstr "Mostra um subset do Unicode."
 
@@ -6374,7 +6542,7 @@ msgstr "Mostra uma pré-visualização das configurações das projéteis."
 msgid "Shows a preview of the font settings."
 msgstr "Mostra uma pré-visualização das configurações da fonte."
 
-#: ../src/osx/carbon/fontdlg.cpp:394 ../src/osx/carbon/fontdlg.cpp:396
+#: ../src/osx/carbon/fontdlg.cpp:391 ../src/osx/carbon/fontdlg.cpp:393
 msgid "Shows a preview of the font."
 msgstr "Mostra uma pré-visualização da fonte."
 
@@ -6383,62 +6551,62 @@ msgstr "Mostra uma pré-visualização da fonte."
 msgid "Shows a preview of the paragraph settings."
 msgstr "Mostra uma pré-visualização das configurações do parágrafo."
 
-#: ../src/generic/fontdlgg.cpp:460 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:456 ../src/generic/fontdlgg.cpp:458
 msgid "Shows the font preview."
 msgstr "Mostra a pré-visualização da fonte."
 
-#: ../src/propgrid/advprops.cpp:1607
+#: ../src/propgrid/advprops.cpp:1513
 msgid "Silver"
 msgstr "Prata"
 
-#: ../src/univ/themes/mono.cpp:516
+#: ../src/univ/themes/mono.cpp:513
 msgid "Simple monochrome theme"
 msgstr "Tema monocromático simples"
 
-#: ../src/richtext/richtextindentspage.cpp:275
 #: ../src/richtext/richtextliststylepage.cpp:449
+#: ../src/richtext/richtextindentspage.cpp:275
 msgid "Single"
 msgstr "Único"
 
-#: ../src/generic/filectrlg.cpp:425 ../src/richtext/richtextformatdlg.cpp:369
-#: ../src/richtext/richtextsizepage.cpp:299
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextsizepage.cpp:299
+#: ../src/richtext/richtextformatdlg.cpp:362
 msgid "Size"
 msgstr "Tamanho"
 
-#: ../src/osx/carbon/fontdlg.cpp:339
+#: ../src/osx/carbon/fontdlg.cpp:336
 msgid "Size:"
 msgstr "Tamanho:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1775
+#: ../src/propgrid/advprops.cpp:1676
 msgid "Sizing"
 msgstr "Dimensionamento"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1772
+#: ../src/propgrid/advprops.cpp:1673
 msgid "Sizing N-S"
 msgstr "Dimensionamento N-S"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1771
+#: ../src/propgrid/advprops.cpp:1672
 msgid "Sizing NE-SW"
 msgstr "Dimensionamento NE-SO"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1773
+#: ../src/propgrid/advprops.cpp:1674
 msgid "Sizing NW-SE"
 msgstr "Dimensionamento NO-SE"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1774
+#: ../src/propgrid/advprops.cpp:1675
 msgid "Sizing W-E"
 msgstr "Dimensionamento O-L"
 
-#: ../src/msw/progdlg.cpp:801
+#: ../src/msw/progdlg.cpp:1088
 msgid "Skip"
 msgstr "Pular"
 
-#: ../src/generic/fontdlgg.cpp:330
+#: ../src/generic/fontdlgg.cpp:326
 msgid "Slant"
 msgstr "Inclinar"
 
@@ -6447,7 +6615,7 @@ msgid "Small C&apitals"
 msgstr "Mi&núsculas"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:79
+#: ../src/common/accelcmn.cpp:76
 msgid "Snapshot"
 msgstr "Fotografia"
 
@@ -6455,37 +6623,37 @@ msgstr "Fotografia"
 msgid "Solid"
 msgstr "Sólido"
 
-#: ../src/common/docview.cpp:1791
+#: ../src/common/docview.cpp:1785
 msgid "Sorry, could not open this file."
 msgstr "Lamento, não pude abrir este arquivo."
 
-#: ../src/common/prntbase.cpp:2057 ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2079 ../src/common/prntbase.cpp:2087
 msgid "Sorry, not enough memory to create a preview."
 msgstr "Lamento, memória não o bastante pra criar uma pré-visualização."
 
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "Sorry, that name is taken. Please choose another."
 msgstr "Lamento, este nome está tomado. Por favor escolha outro."
 
-#: ../src/common/docview.cpp:1814
+#: ../src/common/docview.cpp:1819
 msgid "Sorry, the format for this file is unknown."
 msgstr "Lamento, o formato para este arquivo é desconhecido."
 
-#: ../src/unix/sound.cpp:492
+#: ../src/unix/sound.cpp:481
 msgid "Sound data are in unsupported format."
 msgstr "Os dados do som estão num formato não suportado."
 
-#: ../src/unix/sound.cpp:477
+#: ../src/unix/sound.cpp:466
 #, c-format
 msgid "Sound file '%s' is in unsupported format."
 msgstr "O arquivo de som '%s' está num formato não suportado."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:67
+#: ../src/common/accelcmn.cpp:64
 msgid "Space"
 msgstr "Barra de Espaço"
 
@@ -6493,12 +6661,12 @@ msgstr "Barra de Espaço"
 msgid "Spacing"
 msgstr "Espaçamento"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "Spell Check"
 msgstr "&Verificação da Ortografia"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1776
+#: ../src/propgrid/advprops.cpp:1677
 msgid "Spraycan"
 msgstr "Lata de spray"
 
@@ -6507,7 +6675,7 @@ msgstr "Lata de spray"
 msgid "Standard"
 msgstr "Padrão"
 
-#: ../src/common/paper.cpp:104
+#: ../src/common/paper.cpp:101
 msgid "Statement, 5 1/2 x 8 1/2 in"
 msgstr "Declaração, 5 1/2 x 8 1/2 em"
 
@@ -6516,33 +6684,29 @@ msgstr "Declaração, 5 1/2 x 8 1/2 em"
 msgid "Static"
 msgstr "Estático"
 
-#: ../src/generic/prntdlgg.cpp:204
+#: ../src/generic/prntdlgg.cpp:197
 msgid "Status:"
 msgstr "Status:"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "Stop"
 msgstr "Parar"
 
-#: ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196
 msgid "Strikethrough"
 msgstr "Riscar"
 
-#: ../src/common/colourcmn.cpp:45
+#: ../src/common/colourcmn.cpp:42
 #, c-format
 msgid "String To Colour : Incorrect colour specification : %s"
 msgstr "String para a Côr: Especificação de côr incorreta: %s"
 
 #. TRANSLATORS: Label of font style
-#: ../src/richtext/richtextformatdlg.cpp:339 ../src/propgrid/advprops.cpp:680
+#: ../src/propgrid/advprops.cpp:590 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Estilo"
 
-#: ../include/wx/richtext/richtextstyledlg.h:46
-msgid "Style Organiser"
-msgstr "Organizador de Estilos"
-
-#: ../src/osx/carbon/fontdlg.cpp:348
+#: ../src/osx/carbon/fontdlg.cpp:345
 msgid "Style:"
 msgstr "Estilo:"
 
@@ -6551,7 +6715,7 @@ msgid "Subscrip&t"
 msgstr "Subscrip&t"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:83
+#: ../src/common/accelcmn.cpp:80
 msgid "Subtract"
 msgstr "Subtrair"
 
@@ -6559,11 +6723,11 @@ msgstr "Subtrair"
 msgid "Supe&rscript"
 msgstr "Supe&rscript"
 
-#: ../src/common/paper.cpp:150
+#: ../src/common/paper.cpp:147
 msgid "SuperA/SuperA/A4 227 x 356 mm"
 msgstr "SuperA/SuperA/A4 227 x 356 mm"
 
-#: ../src/common/paper.cpp:151
+#: ../src/common/paper.cpp:148
 msgid "SuperB/SuperB/A3 305 x 487 mm"
 msgstr "SuperB/SuperB/A3 305 x 487 mm"
 
@@ -6571,7 +6735,7 @@ msgstr "SuperB/SuperB/A3 305 x 487 mm"
 msgid "Suppress hyphe&nation"
 msgstr "Suprimir hifen&ação"
 
-#: ../src/generic/fontdlgg.cpp:326
+#: ../src/generic/fontdlgg.cpp:322
 msgid "Swiss"
 msgstr "Suíço"
 
@@ -6589,73 +6753,73 @@ msgstr "Fonte dos &símbolos:"
 msgid "Symbols"
 msgstr "Símbolos"
 
-#: ../src/common/imagtiff.cpp:369 ../src/common/imagtiff.cpp:382
-#: ../src/common/imagtiff.cpp:741
+#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
+#: ../src/common/imagtiff.cpp:738
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: Não pôde distribuir a memória."
 
-#: ../src/common/imagtiff.cpp:301
+#: ../src/common/imagtiff.cpp:298
 msgid "TIFF: Error loading image."
 msgstr "TIFF: Erro ao carregar a imagem."
 
-#: ../src/common/imagtiff.cpp:468
+#: ../src/common/imagtiff.cpp:465
 msgid "TIFF: Error reading image."
 msgstr "TIFF: Erro ao ler a imagem."
 
-#: ../src/common/imagtiff.cpp:608
+#: ../src/common/imagtiff.cpp:605
 msgid "TIFF: Error saving image."
 msgstr "TIFF: Erro ao salvar a imagem."
 
-#: ../src/common/imagtiff.cpp:846
+#: ../src/common/imagtiff.cpp:843
 msgid "TIFF: Error writing image."
 msgstr "TIFF: Erro ao gravar a imagem."
 
-#: ../src/common/imagtiff.cpp:355
+#: ../src/common/imagtiff.cpp:352
 msgid "TIFF: Image size is abnormally big."
 msgstr "TiFF: O tamanho da imagem é anormalmente grande."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:68
+#: ../src/common/accelcmn.cpp:65
 msgid "Tab"
 msgstr "Aba"
 
-#: ../src/richtext/richtextbuffer.cpp:11498
+#: ../src/richtext/richtextbuffer.cpp:11497
 msgid "Table Properties"
 msgstr "Propriedades da Tabela"
 
-#: ../src/common/paper.cpp:145
+#: ../src/common/paper.cpp:142
 msgid "Tabloid Extra 11.69 x 18 in"
 msgstr "Tablóide Extra 11.69 x 18 em"
 
-#: ../src/common/paper.cpp:102
+#: ../src/common/paper.cpp:99
 msgid "Tabloid, 11 x 17 in"
 msgstr "Tablóide, 11 x 17 em"
 
-#: ../src/richtext/richtextformatdlg.cpp:354
+#: ../src/richtext/richtextformatdlg.cpp:347
 msgid "Tabs"
 msgstr "Abas"
 
-#: ../src/propgrid/advprops.cpp:1598
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Teal"
 msgstr "Azul petróleo"
 
-#: ../src/generic/fontdlgg.cpp:327
+#: ../src/generic/fontdlgg.cpp:323
 msgid "Teletype"
 msgstr "Teletipo"
 
-#: ../src/common/docview.cpp:1896
+#: ../src/common/docview.cpp:1901
 msgid "Templates"
 msgstr "Modelos"
 
-#: ../src/common/fmapbase.cpp:158
+#: ../src/common/fmapbase.cpp:155
 msgid "Thai (ISO-8859-11)"
 msgstr "Tailandês (ISO-8859-11)"
 
-#: ../src/common/ftp.cpp:619
+#: ../src/common/ftp.cpp:622
 msgid "The FTP server doesn't support passive mode."
 msgstr "O servidor FTP não suporta o modo passivo."
 
-#: ../src/common/ftp.cpp:605
+#: ../src/common/ftp.cpp:608
 msgid "The FTP server doesn't support the PORT command."
 msgstr "O servidor FTP não suporta o comando \"PORT\"."
 
@@ -6666,8 +6830,8 @@ msgstr "O servidor FTP não suporta o comando \"PORT\"."
 msgid "The available bullet styles."
 msgstr "Os estilos de projéteis disponíveis."
 
-#: ../src/richtext/richtextstyledlg.cpp:202
-#: ../src/richtext/richtextstyledlg.cpp:204
+#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:200
 msgid "The available styles."
 msgstr "Os estilos disponíveis."
 
@@ -6723,12 +6887,12 @@ msgstr "A posição do rodapé."
 msgid "The bullet character."
 msgstr "O caractere do projétil."
 
-#: ../src/richtext/richtextsymboldlg.cpp:443
-#: ../src/richtext/richtextsymboldlg.cpp:445
+#: ../src/richtext/richtextsymboldlg.cpp:440
+#: ../src/richtext/richtextsymboldlg.cpp:442
 msgid "The character code."
 msgstr "O código do caracteres."
 
-#: ../src/common/fontmap.cpp:203
+#: ../src/common/fontmap.cpp:200
 #, c-format
 msgid ""
 "The charset '%s' is unknown. You may select\n"
@@ -6739,7 +6903,7 @@ msgstr ""
 "outro conjunto de caracteres para substituí-lo ou escolher\n"
 "[Cancelar] se ele não pode ser substituído"
 
-#: ../src/msw/ole/dataobj.cpp:394
+#: ../src/msw/ole/dataobj.cpp:402
 #, c-format
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "O formato '%d' da área de transferência não existe."
@@ -6749,7 +6913,7 @@ msgstr "O formato '%d' da área de transferência não existe."
 msgid "The default style for the next paragraph."
 msgstr "O estilo padrão para o próximo parágrafo."
 
-#: ../src/generic/dirdlgg.cpp:202
+#: ../src/generic/dirdlgg.cpp:199
 #, c-format
 msgid ""
 "The directory '%s' does not exist\n"
@@ -6758,7 +6922,7 @@ msgstr ""
 "O diretório '%s' não existe\n"
 "Criá-lo agora?"
 
-#: ../src/html/htmprint.cpp:271
+#: ../src/html/htmprint.cpp:283
 #, c-format
 msgid ""
 "The document \"%s\" doesn't fit on the page horizontally and will be "
@@ -6771,7 +6935,7 @@ msgstr ""
 "\n"
 "Você gostaria de prosseguir com a impressão apesar disso?"
 
-#: ../src/common/docview.cpp:1202
+#: ../src/common/docview.cpp:1196
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -6780,36 +6944,37 @@ msgstr ""
 "O arquivo '%s' não existe e não pôde ser aberto.\n"
 "Foi removido da lista dos arquivos mais usados recentemente."
 
-#: ../src/richtext/richtextindentspage.cpp:208
-#: ../src/richtext/richtextindentspage.cpp:210
 #: ../src/richtext/richtextliststylepage.cpp:394
 #: ../src/richtext/richtextliststylepage.cpp:396
+#: ../src/richtext/richtextindentspage.cpp:208
+#: ../src/richtext/richtextindentspage.cpp:210
 msgid "The first line indent."
 msgstr "O recuo da primeira linha."
 
-#: ../src/gtk/utilsgtk.cpp:481
-msgid "The following standard GTK+ options are also supported:\n"
-msgstr "As seguintes opções padrão do GTK+ também são suportadas:\n"
+#: ../src/generic/dbgrptg.cpp:318
+#, fuzzy
+msgid "The following debug report will be generated\n"
+msgstr "Um relatï¿½rio de depuraï¿½ï¿½o foi gerado no diretï¿½rio\n"
 
-#: ../src/generic/fontdlgg.cpp:414 ../src/generic/fontdlgg.cpp:416
+#: ../src/generic/fontdlgg.cpp:411 ../src/generic/fontdlgg.cpp:413
 msgid "The font colour."
 msgstr "A côr da fonte."
 
-#: ../src/generic/fontdlgg.cpp:375 ../src/generic/fontdlgg.cpp:377
+#: ../src/generic/fontdlgg.cpp:371 ../src/generic/fontdlgg.cpp:373
 msgid "The font family."
 msgstr "A família da fonte."
 
-#: ../src/richtext/richtextsymboldlg.cpp:405
-#: ../src/richtext/richtextsymboldlg.cpp:407
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "The font from which to take the symbol."
 msgstr "A fonte da qual tomar o símbolo."
 
-#: ../src/generic/fontdlgg.cpp:427 ../src/generic/fontdlgg.cpp:429
-#: ../src/generic/fontdlgg.cpp:434 ../src/generic/fontdlgg.cpp:436
+#: ../src/generic/fontdlgg.cpp:424 ../src/generic/fontdlgg.cpp:426
+#: ../src/generic/fontdlgg.cpp:430 ../src/generic/fontdlgg.cpp:432
 msgid "The font point size."
 msgstr "O tamanho do ponto da fonte."
 
-#: ../src/osx/carbon/fontdlg.cpp:343 ../src/osx/carbon/fontdlg.cpp:345
+#: ../src/osx/carbon/fontdlg.cpp:340 ../src/osx/carbon/fontdlg.cpp:342
 msgid "The font size in points."
 msgstr "O tamanho da fonte em pontos."
 
@@ -6818,15 +6983,15 @@ msgstr "O tamanho da fonte em pontos."
 msgid "The font size units, points or pixels."
 msgstr "As unidades de tamanho da fonte, pontos ou pixels."
 
-#: ../src/generic/fontdlgg.cpp:386 ../src/generic/fontdlgg.cpp:388
+#: ../src/generic/fontdlgg.cpp:382 ../src/generic/fontdlgg.cpp:384
 msgid "The font style."
 msgstr "O estilo da fonte."
 
-#: ../src/generic/fontdlgg.cpp:397 ../src/generic/fontdlgg.cpp:399
+#: ../src/generic/fontdlgg.cpp:393 ../src/generic/fontdlgg.cpp:395
 msgid "The font weight."
 msgstr "O peso da fonte."
 
-#: ../src/common/docview.cpp:1483
+#: ../src/common/docview.cpp:1477
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "O formato do arquivo '%s' não pôde ser determinado."
@@ -6836,10 +7001,10 @@ msgstr "O formato do arquivo '%s' não pôde ser determinado."
 msgid "The horizontal offset."
 msgstr "O offset horizontal."
 
-#: ../src/richtext/richtextindentspage.cpp:199
-#: ../src/richtext/richtextindentspage.cpp:201
 #: ../src/richtext/richtextliststylepage.cpp:385
 #: ../src/richtext/richtextliststylepage.cpp:387
+#: ../src/richtext/richtextindentspage.cpp:199
+#: ../src/richtext/richtextindentspage.cpp:201
 msgid "The left indent."
 msgstr "O recuo a esquerda."
 
@@ -6860,10 +7025,10 @@ msgstr "O tamanho do enchimento a esquerda."
 msgid "The left position."
 msgstr "A posição da esquerda."
 
-#: ../src/richtext/richtextindentspage.cpp:288
-#: ../src/richtext/richtextindentspage.cpp:290
 #: ../src/richtext/richtextliststylepage.cpp:462
 #: ../src/richtext/richtextliststylepage.cpp:464
+#: ../src/richtext/richtextindentspage.cpp:288
+#: ../src/richtext/richtextindentspage.cpp:290
 msgid "The line spacing."
 msgstr "O espaçamento da linha."
 
@@ -6872,7 +7037,7 @@ msgstr "O espaçamento da linha."
 msgid "The list item number."
 msgstr "O número do item da lista."
 
-#: ../src/msw/ole/automtn.cpp:664
+#: ../src/msw/ole/automtn.cpp:655
 msgid "The locale ID is unknown."
 msgstr "A ID do idioma é desconhecida."
 
@@ -6911,19 +7076,19 @@ msgstr "A largura do objeto."
 msgid "The outline level."
 msgstr "O nível do contorno."
 
-#: ../src/common/log.cpp:277
+#: ../src/common/log.cpp:296
 #, c-format
 msgid "The previous message repeated %u time."
 msgid_plural "The previous message repeated %u times."
 msgstr[0] "A mensagem anterior repetida %u vez."
 msgstr[1] "A mensagem anterior repetida %u vezes."
 
-#: ../src/common/log.cpp:270
+#: ../src/common/log.cpp:289
 msgid "The previous message repeated once."
 msgstr "A mensagem anterior repetida uma vez."
 
-#: ../src/richtext/richtextsymboldlg.cpp:462
-#: ../src/richtext/richtextsymboldlg.cpp:464
+#: ../src/richtext/richtextsymboldlg.cpp:459
+#: ../src/richtext/richtextsymboldlg.cpp:461
 msgid "The range to show."
 msgstr "O alcance a mostrar."
 
@@ -6937,15 +7102,15 @@ msgstr ""
 "contém informação privada,\n"
 "por favor desmarque-os e eles serão removidos do relatório.\n"
 
-#: ../src/common/cmdline.cpp:1254
+#: ../src/common/cmdline.cpp:1250
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "O parâmetro requerido '%s' não foi especificado."
 
-#: ../src/richtext/richtextindentspage.cpp:217
-#: ../src/richtext/richtextindentspage.cpp:219
 #: ../src/richtext/richtextliststylepage.cpp:403
 #: ../src/richtext/richtextliststylepage.cpp:405
+#: ../src/richtext/richtextindentspage.cpp:217
+#: ../src/richtext/richtextindentspage.cpp:219
 msgid "The right indent."
 msgstr "O recuo a direita."
 
@@ -6986,16 +7151,16 @@ msgstr "A opacidade da sombra."
 msgid "The shadow spread."
 msgstr "O espalhar da sombra."
 
-#: ../src/richtext/richtextindentspage.cpp:267
 #: ../src/richtext/richtextliststylepage.cpp:439
 #: ../src/richtext/richtextliststylepage.cpp:441
+#: ../src/richtext/richtextindentspage.cpp:267
 msgid "The spacing after the paragraph."
 msgstr "O espaçamento após o parágrafo."
 
-#: ../src/richtext/richtextindentspage.cpp:257
-#: ../src/richtext/richtextindentspage.cpp:259
 #: ../src/richtext/richtextliststylepage.cpp:430
 #: ../src/richtext/richtextliststylepage.cpp:432
+#: ../src/richtext/richtextindentspage.cpp:257
+#: ../src/richtext/richtextindentspage.cpp:259
 msgid "The spacing before the paragraph."
 msgstr "O espaçamento antes do parágrafo."
 
@@ -7009,12 +7174,12 @@ msgstr "O nome do estilo."
 msgid "The style on which this style is based."
 msgstr "O estilo no qual este estilo é baseado."
 
-#: ../src/richtext/richtextstyledlg.cpp:214
-#: ../src/richtext/richtextstyledlg.cpp:216
+#: ../src/richtext/richtextstyledlg.cpp:210
+#: ../src/richtext/richtextstyledlg.cpp:212
 msgid "The style preview."
 msgstr "A pré-visualização do estilo."
 
-#: ../src/msw/ole/automtn.cpp:680
+#: ../src/msw/ole/automtn.cpp:671
 msgid "The system cannot find the file specified."
 msgstr "O sistema não consegue achar o arquivo especificado."
 
@@ -7027,7 +7192,7 @@ msgstr "A posição da aba."
 msgid "The tab positions."
 msgstr "As posições das abas."
 
-#: ../src/richtext/richtextctrl.cpp:3098
+#: ../src/richtext/richtextctrl.cpp:3099
 msgid "The text couldn't be saved."
 msgstr "O texto não pôde ser salvo."
 
@@ -7048,7 +7213,7 @@ msgstr "O tamanho do enchimento do topo."
 msgid "The top position."
 msgstr "A posição do topo."
 
-#: ../src/common/cmdline.cpp:1232
+#: ../src/common/cmdline.cpp:1228
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "O valor para a opção '%s' deve ser especificado."
@@ -7058,7 +7223,7 @@ msgstr "O valor para a opção '%s' deve ser especificado."
 msgid "The value of the corner radius."
 msgstr "O valor do raio do canto."
 
-#: ../src/msw/dialup.cpp:433
+#: ../src/msw/dialup.cpp:427
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -7073,14 +7238,14 @@ msgstr ""
 msgid "The vertical offset."
 msgstr "O offset vertical."
 
-#: ../src/richtext/richtextprint.cpp:619 ../src/html/htmprint.cpp:745
+#: ../src/html/htmprint.cpp:749 ../src/richtext/richtextprint.cpp:615
 msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr ""
 "Houve um problema durante a configuração da página: você pode precisar "
 "definir uma impressora padrão."
 
-#: ../src/html/htmprint.cpp:255
+#: ../src/html/htmprint.cpp:267
 msgid ""
 "This document doesn't fit on the page horizontally and will be truncated "
 "when it is printed."
@@ -7088,16 +7253,16 @@ msgstr ""
 "Este documento não se encaixa na página horizontalmente e será truncado "
 "quando for impresso."
 
-#: ../src/common/image.cpp:2854
+#: ../src/common/image.cpp:2963
 #, c-format
 msgid "This is not a %s."
 msgstr "Isto não é um %s."
 
-#: ../src/common/wincmn.cpp:1653
+#: ../src/common/wincmn.cpp:1654
 msgid "This platform does not support background transparency."
 msgstr "Esta plataforma não suporta transparência de 2º plano."
 
-#: ../src/gtk/window.cpp:4660
+#: ../src/gtk/window.cpp:5664
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
@@ -7105,7 +7270,15 @@ msgstr ""
 "Este programa foi compilado com uma versão muito velha do GTK+, por favor "
 "reconstrua com o GTK+ 2.12 ou mais novo."
 
-#: ../src/msw/thread.cpp:1240
+#: ../src/gtk/glcanvas.cpp:176
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/msw/thread.cpp:1246
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -7113,13 +7286,13 @@ msgstr ""
 "O módulo de inicialização do thread falhou: não pôde armazenar o valor no "
 "armazém local do thread"
 
-#: ../src/unix/threadpsx.cpp:1794
+#: ../src/unix/threadpsx.cpp:1843
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 "A inicialização do módulo dos threads falhou: falhou em criar a chave do "
 "thread"
 
-#: ../src/msw/thread.cpp:1228
+#: ../src/msw/thread.cpp:1234
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -7127,83 +7300,83 @@ msgstr ""
 "A inicialização do módulo dos threads falhou: impossível distribuir o índice "
 "no armazém local dos threads"
 
-#: ../src/unix/threadpsx.cpp:1043
+#: ../src/unix/threadpsx.cpp:1061
 msgid "Thread priority setting is ignored."
 msgstr "A configuração da prioridade do thread é ignorada."
 
-#: ../src/msw/mdi.cpp:176
+#: ../src/msw/mdi.cpp:171
 msgid "Tile &Horizontally"
 msgstr "Lado a Lado &Horizontalmente"
 
-#: ../src/msw/mdi.cpp:177
+#: ../src/msw/mdi.cpp:172
 msgid "Tile &Vertically"
 msgstr "Lado a Lado &Verticalmente"
 
-#: ../src/common/ftp.cpp:200
+#: ../src/common/ftp.cpp:197
 msgid "Timeout while waiting for FTP server to connect, try passive mode."
 msgstr ""
 "Tempo para esgotar enquanto espera o servidor FTP se conectar, tente o modo "
 "passivo."
 
-#: ../src/generic/tipdlg.cpp:201
+#: ../src/generic/tipdlg.cpp:198
 msgid "Tip of the Day"
 msgstr "Dica do Dia"
 
-#: ../src/generic/tipdlg.cpp:140
+#: ../src/generic/tipdlg.cpp:137
 msgid "Tips not available, sorry!"
 msgstr "Dicas não disponíveis, lamento!"
 
-#: ../src/generic/prntdlgg.cpp:242
+#: ../src/generic/prntdlgg.cpp:235
 msgid "To:"
 msgstr "Para:"
 
-#: ../src/richtext/richtextbuffer.cpp:8363
+#: ../src/richtext/richtextbuffer.cpp:8361
 msgid "Too many EndStyle calls!"
 msgstr "Chamadas demais do EndStyle!"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:891
+#: ../src/propgrid/advprops.cpp:792
 msgid "Tooltip"
 msgstr "Dica da ferramenta"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:892
+#: ../src/propgrid/advprops.cpp:793
 msgid "TooltipText"
 msgstr "TextoDaDicaDaFerramenta"
 
-#: ../src/richtext/richtextsizepage.cpp:286
-#: ../src/richtext/richtextsizepage.cpp:290 ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197 ../src/richtext/richtextsizepage.cpp:286
+#: ../src/richtext/richtextsizepage.cpp:290
 msgid "Top"
 msgstr "Topo"
 
-#: ../src/generic/prntdlgg.cpp:881
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Top margin (mm):"
 msgstr "Margem superior (mm):"
 
-#: ../src/generic/aboutdlgg.cpp:79
+#: ../src/generic/aboutdlgg.cpp:76
 msgid "Translations by "
 msgstr "Traduções de "
 
-#: ../src/generic/aboutdlgg.cpp:188
+#: ../src/generic/aboutdlgg.cpp:185
 msgid "Translators"
 msgstr "Tradutores"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:211
+#: ../src/propgrid/propgrid.cpp:192
 msgid "True"
 msgstr "Verdadeiro"
 
-#: ../src/common/fs_mem.cpp:227
+#: ../src/common/fs_mem.cpp:222
 #, c-format
 msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
 msgstr ""
 "Tentando remover o arquivo '%s' da memória VFS, mas ele não está carregado!"
 
-#: ../src/common/fmapbase.cpp:156
+#: ../src/common/fmapbase.cpp:153
 msgid "Turkish (ISO-8859-9)"
 msgstr "Turco (ISO-8859-9)"
 
-#: ../src/generic/filectrlg.cpp:426
+#: ../src/generic/filectrlg.cpp:422
 msgid "Type"
 msgstr "Tipo"
 
@@ -7217,17 +7390,17 @@ msgstr "Digite um nome de fonte."
 msgid "Type a size in points."
 msgstr "Digite um tamanho em pontos."
 
-#: ../src/msw/ole/automtn.cpp:676
+#: ../src/msw/ole/automtn.cpp:667
 #, c-format
 msgid "Type mismatch in argument %u."
 msgstr "Incompatibilidade do tipo no argumento %u."
 
-#: ../src/common/xtixml.cpp:356 ../src/common/xtixml.cpp:509
-#: ../src/common/xtistrm.cpp:318
+#: ../src/common/xtixml.cpp:352 ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315
 msgid "Type must have enum - long conversion"
 msgstr "O tipo precisa ter conversão enum - long"
 
-#: ../src/propgrid/propgridiface.cpp:401
+#: ../src/propgrid/propgridiface.cpp:385
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
@@ -7236,19 +7409,19 @@ msgstr ""
 "A operação do tipo \"%s\" falhou: A propriedade rotulada \"%s\" é do tipo "
 "\"%s\", NÃO \"%s\"."
 
-#: ../src/common/paper.cpp:133
+#: ../src/common/paper.cpp:130
 msgid "US Std Fanfold, 14 7/8 x 11 in"
 msgstr "Fanfold Std US, 14 7/8 x 11 em"
 
-#: ../src/common/fmapbase.cpp:196
+#: ../src/common/fmapbase.cpp:193
 msgid "US-ASCII"
 msgstr "US-ASCII"
 
-#: ../src/unix/fswatcher_inotify.cpp:109
+#: ../src/unix/fswatcher_inotify.cpp:106
 msgid "Unable to add inotify watch"
 msgstr "Incapaz de adicionar a observação do inotify"
 
-#: ../src/unix/fswatcher_kqueue.cpp:136
+#: ../src/unix/fswatcher_kqueue.cpp:153
 msgid "Unable to add kqueue watch"
 msgstr "Incapaz de adicionar a observação do kqueue"
 
@@ -7260,7 +7433,7 @@ msgstr "Incapaz de associar o manejar com a porta de término de E/S"
 msgid "Unable to close I/O completion port handle"
 msgstr "Incapaz de fechar o manejamento do término da porta de E/S"
 
-#: ../src/unix/fswatcher_inotify.cpp:97
+#: ../src/unix/fswatcher_inotify.cpp:94
 msgid "Unable to close inotify instance"
 msgstr "Incapaz de fechar a instância do inotify"
 
@@ -7278,15 +7451,15 @@ msgstr "Incapaz de fechar o manejamento para '%s'"
 msgid "Unable to create I/O completion port"
 msgstr "Incapaz de criar a porta do término da E/S"
 
-#: ../src/msw/fswatcher.cpp:84
+#: ../src/msw/fswatcher.cpp:81
 msgid "Unable to create IOCP worker thread"
 msgstr "Incapaz de criar o thread do trabalhador IOCP"
 
-#: ../src/unix/fswatcher_inotify.cpp:74
+#: ../src/unix/fswatcher_inotify.cpp:71
 msgid "Unable to create inotify instance"
 msgstr "Incapaz de criar a instância do inotify"
 
-#: ../src/unix/fswatcher_kqueue.cpp:97
+#: ../src/unix/fswatcher_kqueue.cpp:114
 msgid "Unable to create kqueue instance"
 msgstr "Incapaz de criar a instância do kqueue"
 
@@ -7294,11 +7467,11 @@ msgstr "Incapaz de criar a instância do kqueue"
 msgid "Unable to dequeue completion packet"
 msgstr "Incapaz de tirar da fila o pacote do término"
 
-#: ../src/unix/fswatcher_kqueue.cpp:185
+#: ../src/unix/fswatcher_kqueue.cpp:202
 msgid "Unable to get events from kqueue"
 msgstr "Incapaz de obter eventos do kqueue"
 
-#: ../src/gtk/app.cpp:435
+#: ../src/gtk/app.cpp:431
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr ""
 "Incapaz de inicializar o GTK+, o DISPLAY está configurado apropriadamente?"
@@ -7308,12 +7481,12 @@ msgstr ""
 msgid "Unable to open path '%s'"
 msgstr "Incapaz de abrir o caminho '%s'"
 
-#: ../src/html/htmlwin.cpp:583
+#: ../src/html/htmlwin.cpp:586
 #, c-format
 msgid "Unable to open requested HTML document: %s"
 msgstr "Incapaz de abrir o documento HTML pedido: %s"
 
-#: ../src/unix/sound.cpp:368
+#: ../src/unix/sound.cpp:365
 msgid "Unable to play sound asynchronously."
 msgstr "Incapaz de reproduzir o som de forma assíncrona."
 
@@ -7321,62 +7494,62 @@ msgstr "Incapaz de reproduzir o som de forma assíncrona."
 msgid "Unable to post completion status"
 msgstr "Incapaz de postar o status do término"
 
-#: ../src/unix/fswatcher_inotify.cpp:556
+#: ../src/unix/fswatcher_inotify.cpp:553
 msgid "Unable to read from inotify descriptor"
 msgstr "Incapaz de ler do descritor do inotify"
 
-#: ../src/unix/fswatcher_inotify.cpp:141
+#: ../src/unix/fswatcher_inotify.cpp:138
 #, c-format
 msgid "Unable to remove inotify watch %i"
 msgstr "Incapaz de remover a observação do inotify %i"
 
-#: ../src/unix/fswatcher_kqueue.cpp:153
+#: ../src/unix/fswatcher_kqueue.cpp:170
 msgid "Unable to remove kqueue watch"
 msgstr "Incapaz de removar a observação do kqueue"
 
-#: ../src/msw/fswatcher.cpp:168
+#: ../src/msw/fswatcher.cpp:165
 #, c-format
 msgid "Unable to set up watch for '%s'"
 msgstr "Incapaz de configurar a observação para '%s'"
 
-#: ../src/msw/fswatcher.cpp:91
+#: ../src/msw/fswatcher.cpp:88
 msgid "Unable to start IOCP worker thread"
 msgstr "Incapaz de iniciar o thread do trabalhador IOCP"
 
-#: ../src/common/stockitem.cpp:201
+#: ../src/common/stockitem.cpp:198
 msgid "Undelete"
 msgstr "Restaurar"
 
-#: ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199
 msgid "Underline"
 msgstr "Sublinhar"
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/richtext/richtextfontpage.cpp:359 ../src/osx/carbon/fontdlg.cpp:370
-#: ../src/propgrid/advprops.cpp:690
+#: ../src/osx/carbon/fontdlg.cpp:367 ../src/propgrid/advprops.cpp:600
+#: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "&Sublinhado"
 
-#: ../src/common/stockitem.cpp:203 ../src/stc/stc_i18n.cpp:15
+#: ../src/common/stockitem.cpp:200 ../src/stc/stc_i18n.cpp:15
 msgid "Undo"
 msgstr "Desfazer"
 
-#: ../src/common/stockitem.cpp:265
+#: ../src/common/stockitem.cpp:263
 msgid "Undo last action"
 msgstr "Desfazer a última ação"
 
-#: ../src/common/cmdline.cpp:1029
+#: ../src/common/cmdline.cpp:1025
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Caracteres inesperados seguindo a opção '%s'."
 
-#: ../src/unix/fswatcher_inotify.cpp:274
+#: ../src/unix/fswatcher_inotify.cpp:271
 #, c-format
 msgid "Unexpected event for \"%s\": no matching watch descriptor."
 msgstr ""
 "Evento inesperado para \"%s\": sem descritor de observação que combine."
 
-#: ../src/common/cmdline.cpp:1195
+#: ../src/common/cmdline.cpp:1191
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Parâmetro inesperado '%s'"
@@ -7385,49 +7558,49 @@ msgstr "Parâmetro inesperado '%s'"
 msgid "Unexpectedly new I/O completion port was created"
 msgstr "Inesperadamente a nova porta do término de E/S foi criada"
 
-#: ../src/msw/fswatcher.cpp:70
+#: ../src/msw/fswatcher.cpp:67
 msgid "Ungraceful worker thread termination"
 msgstr "Término deselegante do thread do trabalhador"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:460
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:456
+#: ../src/richtext/richtextsymboldlg.cpp:457
+#: ../src/richtext/richtextsymboldlg.cpp:458
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../src/common/fmapbase.cpp:185 ../src/common/fmapbase.cpp:191
+#: ../src/common/fmapbase.cpp:182 ../src/common/fmapbase.cpp:188
 msgid "Unicode 16 bit (UTF-16)"
 msgstr "Unicode 16 bits (UTF-16)"
 
-#: ../src/common/fmapbase.cpp:190
+#: ../src/common/fmapbase.cpp:187
 msgid "Unicode 16 bit Big Endian (UTF-16BE)"
 msgstr "Unicode 16 bits Big Endian (UTF-16BE)"
 
-#: ../src/common/fmapbase.cpp:186
+#: ../src/common/fmapbase.cpp:183
 msgid "Unicode 16 bit Little Endian (UTF-16LE)"
 msgstr "Unicode 16 bits Little Endian (UTF-16LE)"
 
-#: ../src/common/fmapbase.cpp:187 ../src/common/fmapbase.cpp:193
+#: ../src/common/fmapbase.cpp:184 ../src/common/fmapbase.cpp:190
 msgid "Unicode 32 bit (UTF-32)"
 msgstr "Unicode 32 bits (UTF-32)"
 
-#: ../src/common/fmapbase.cpp:192
+#: ../src/common/fmapbase.cpp:189
 msgid "Unicode 32 bit Big Endian (UTF-32BE)"
 msgstr "Unicode 32 bits Big Endian (UTF-32BE)"
 
-#: ../src/common/fmapbase.cpp:188
+#: ../src/common/fmapbase.cpp:185
 msgid "Unicode 32 bit Little Endian (UTF-32LE)"
 msgstr "Unicode 32 bits Little Endian (UTF-32LE)"
 
-#: ../src/common/fmapbase.cpp:182
+#: ../src/common/fmapbase.cpp:179
 msgid "Unicode 7 bit (UTF-7)"
 msgstr "Unicode 7 bits (UTF-7)"
 
-#: ../src/common/fmapbase.cpp:183
+#: ../src/common/fmapbase.cpp:180
 msgid "Unicode 8 bit (UTF-8)"
 msgstr "Unicode 8 bits (UTF-8)"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "Unindent"
 msgstr "Sem parágrafo"
 
@@ -7577,97 +7750,102 @@ msgstr "Unidades para a posição do topo."
 msgid "Units for this value."
 msgstr "Unidades para este valor."
 
-#: ../src/generic/progdlgg.cpp:353 ../src/generic/progdlgg.cpp:622
+#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
 msgid "Unknown"
 msgstr "Desconhecido"
 
-#: ../src/msw/dde.cpp:1174
+#: ../src/msw/dde.cpp:1238
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Erro DDE desconhecido %08x"
 
-#: ../src/common/xtistrm.cpp:410
+#: ../src/common/xtistrm.cpp:407
 msgid "Unknown Object passed to GetObjectClassInfo"
 msgstr "Objeto Desconhecido passado para o GetObjectClassInfo"
 
-#: ../src/common/imagpng.cpp:366
+#: ../src/common/imagpng.cpp:383
 #, c-format
 msgid "Unknown PNG resolution unit %d"
 msgstr "Unidade de resolução do PNG %d desconhecida"
 
-#: ../src/common/xtixml.cpp:327
+#: ../src/common/xtixml.cpp:323
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Propriedade %s Desconhecida"
 
-#: ../src/common/imagtiff.cpp:529
+#: ../src/common/imagtiff.cpp:526
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "Unidade de resolução do TIFF desconhecida %d ignorada"
 
-#: ../src/unix/dlunix.cpp:160
+#: ../src/propgrid/props.cpp:155
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/unix/dlunix.cpp:118
 msgid "Unknown dynamic library error"
 msgstr "Erro desconhecido da biblioteca dinâmica"
 
-#: ../src/common/fmapbase.cpp:810
+#: ../src/common/fmapbase.cpp:806
 #, c-format
 msgid "Unknown encoding (%d)"
 msgstr "Codificação desconhecida (%d)"
 
-#: ../src/msw/ole/automtn.cpp:688
+#: ../src/msw/ole/automtn.cpp:679
 #, c-format
 msgid "Unknown error %08x"
 msgstr "Erro %08x desconhecido"
 
-#: ../src/msw/ole/automtn.cpp:647
+#: ../src/msw/ole/automtn.cpp:638
 msgid "Unknown exception"
 msgstr "Exceção desconhecida"
 
-#: ../src/common/image.cpp:2839
+#: ../src/common/image.cpp:2942
 msgid "Unknown image data format."
 msgstr "Formato desconhecido dos dados da imagem."
 
-#: ../src/common/cmdline.cpp:914
+#: ../src/common/cmdline.cpp:910
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Opção longa desconhecida '%s'"
 
-#: ../src/msw/ole/automtn.cpp:631
+#: ../src/msw/ole/automtn.cpp:622
 msgid "Unknown name or named argument."
 msgstr "Nome ou argumento nomeado desconhecido."
 
-#: ../src/common/cmdline.cpp:929 ../src/common/cmdline.cpp:951
+#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Opção desconhecida '%s'"
 
-#: ../src/common/mimecmn.cpp:225
+#: ../src/common/mimecmn.cpp:221
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "'{' incomparável em uma entrada para o tipo mime %s."
 
-#: ../src/common/cmdproc.cpp:262 ../src/common/cmdproc.cpp:288
-#: ../src/common/cmdproc.cpp:308
+#: ../src/common/cmdproc.cpp:255 ../src/common/cmdproc.cpp:281
+#: ../src/common/cmdproc.cpp:301
 msgid "Unnamed command"
 msgstr "Comando sem nome"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:413
+#: ../src/propgrid/propgrid.cpp:392
 msgid "Unspecified"
 msgstr "Não especificado"
 
-#: ../src/msw/clipbrd.cpp:311
+#: ../src/msw/clipbrd.cpp:325
 msgid "Unsupported clipboard format."
 msgstr "Formato da área de transferência não suportado."
 
-#: ../src/common/appcmn.cpp:256
+#: ../src/common/appcmn.cpp:277
 #, c-format
 msgid "Unsupported theme '%s'."
 msgstr "Tema não suportado '%s'."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:205
-#: ../src/common/accelcmn.cpp:63
+#: ../src/common/stockitem.cpp:202 ../src/common/accelcmn.cpp:60
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Up"
 msgstr "Pra cima"
 
@@ -7681,7 +7859,7 @@ msgstr "Letras maiúsculas"
 msgid "Upper case roman numerals"
 msgstr "Numerais romanos maiúsculos"
 
-#: ../src/common/cmdline.cpp:1326
+#: ../src/common/cmdline.cpp:1322
 #, c-format
 msgid "Usage: %s"
 msgstr "Uso: %s"
@@ -7690,38 +7868,47 @@ msgstr "Uso: %s"
 msgid "Use &shadow"
 msgstr "Usar &sombra"
 
-#: ../src/richtext/richtextindentspage.cpp:169
-#: ../src/richtext/richtextindentspage.cpp:171
 #: ../src/richtext/richtextliststylepage.cpp:358
 #: ../src/richtext/richtextliststylepage.cpp:360
+#: ../src/richtext/richtextindentspage.cpp:169
+#: ../src/richtext/richtextindentspage.cpp:171
 msgid "Use the current alignment setting."
 msgstr "Usar a configuração de alinhamento atual."
 
-#: ../src/common/valtext.cpp:179
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/gtk/font.cpp:552
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/common/valtext.cpp:142
 msgid "Validation conflict"
 msgstr "Conflito de validação"
 
-#: ../src/propgrid/manager.cpp:238
+#: ../src/propgrid/manager.cpp:224
 msgid "Value"
 msgstr "Valor"
 
-#: ../src/propgrid/props.cpp:386 ../src/propgrid/props.cpp:500
+#: ../src/propgrid/props.cpp:309
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "O valor deve ser %s ou maior."
 
-#: ../src/propgrid/props.cpp:417 ../src/propgrid/props.cpp:531
+#: ../src/propgrid/props.cpp:336
 #, c-format
 msgid "Value must be %s or less."
 msgstr "O valor deve ser %s ou menor."
 
-#: ../src/propgrid/props.cpp:393 ../src/propgrid/props.cpp:424
-#: ../src/propgrid/props.cpp:507 ../src/propgrid/props.cpp:538
+#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "O valor deve estar entre %s e %s."
 
-#: ../src/generic/aboutdlgg.cpp:128
+#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Versão "
 
@@ -7730,25 +7917,32 @@ msgstr "Versão "
 msgid "Vertical alignment."
 msgstr "Alinhamento vertical."
 
-#: ../src/generic/filedlgg.cpp:202
+#: ../src/generic/filedlgg.cpp:199
 msgid "View files as a detailed view"
 msgstr "Visualizar arquivos numa visualização detalhada"
 
-#: ../src/generic/filedlgg.cpp:200
+#: ../src/generic/filedlgg.cpp:197
 msgid "View files as a list view"
 msgstr "Visualizar arquivos numa visualização de listas"
 
-#: ../src/common/docview.cpp:1970
+#: ../src/common/docview.cpp:1975
 msgid "Views"
 msgstr "Visualizações"
 
+#: ../src/gtk/app.cpp:348
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1777
+#: ../src/propgrid/advprops.cpp:1678
 msgid "Wait"
 msgstr "Aguardar"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1779
+#: ../src/propgrid/advprops.cpp:1680
 msgid "Wait Arrow"
 msgstr "Aguardar a Seta"
 
@@ -7757,237 +7951,234 @@ msgstr "Aguardar a Seta"
 msgid "Waiting for IO on epoll descriptor %d failed"
 msgstr "Falhou em esperar pelo IO no descritor epoll %d"
 
-#: ../src/common/log.cpp:223
+#: ../src/common/log.cpp:241
 msgid "Warning: "
 msgstr "Aviso: "
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1778
+#: ../src/propgrid/advprops.cpp:1679
 msgid "Watch"
 msgstr "Observar"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:685
+#: ../src/propgrid/advprops.cpp:595
 msgid "Weight"
 msgstr "Peso"
 
-#: ../src/common/fmapbase.cpp:148
+#: ../src/common/fmapbase.cpp:145
 msgid "Western European (ISO-8859-1)"
 msgstr "Europeu Ocidental (ISO-8859-1)"
 
-#: ../src/common/fmapbase.cpp:162
+#: ../src/common/fmapbase.cpp:159
 msgid "Western European with Euro (ISO-8859-15)"
 msgstr "Europeu Ocidental com Euro (ISO-8859-15)"
 
-#: ../src/generic/fontdlgg.cpp:446 ../src/generic/fontdlgg.cpp:448
+#: ../src/generic/fontdlgg.cpp:443 ../src/generic/fontdlgg.cpp:445
 msgid "Whether the font is underlined."
 msgstr "Se a fonte está sublinhada."
 
-#: ../src/propgrid/advprops.cpp:1611
+#: ../src/propgrid/advprops.cpp:1517
 msgid "White"
 msgstr "Branco"
 
-#: ../src/generic/fdrepdlg.cpp:144
+#: ../src/generic/fdrepdlg.cpp:141
 msgid "Whole word"
 msgstr "Palavra inteira"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:532
 msgid "Whole words only"
 msgstr "Só palavras inteiras"
 
-#: ../src/univ/themes/win32.cpp:1102
+#: ../src/univ/themes/win32.cpp:1099
 msgid "Win32 theme"
 msgstr "Tema do Win32"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:893
+#: ../src/propgrid/advprops.cpp:794
 msgid "Window"
 msgstr "Janela"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:894
+#: ../src/propgrid/advprops.cpp:795
 msgid "WindowFrame"
 msgstr "FrameDaJanela"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:895
+#: ../src/propgrid/advprops.cpp:796
 msgid "WindowText"
 msgstr "TextoDaJanela"
 
-#: ../src/common/fmapbase.cpp:177
+#: ../src/common/fmapbase.cpp:174
 msgid "Windows Arabic (CP 1256)"
 msgstr "Windows Árabe (CP 1256)"
 
-#: ../src/common/fmapbase.cpp:178
+#: ../src/common/fmapbase.cpp:175
 msgid "Windows Baltic (CP 1257)"
 msgstr "Windows Báltico (CP 1257)"
 
-#: ../src/common/fmapbase.cpp:171
+#: ../src/common/fmapbase.cpp:168
 msgid "Windows Central European (CP 1250)"
 msgstr "Windows Europeu Central (CP 1250)"
 
-#: ../src/common/fmapbase.cpp:168
+#: ../src/common/fmapbase.cpp:165
 msgid "Windows Chinese Simplified (CP 936) or GB-2312"
 msgstr "Windows Chinês Simplificado (CP 936) ou GB-2312"
 
-#: ../src/common/fmapbase.cpp:170
+#: ../src/common/fmapbase.cpp:167
 msgid "Windows Chinese Traditional (CP 950) or Big-5"
 msgstr "Windows Chinês Tradicional (CP 950) ou Big-5"
 
-#: ../src/common/fmapbase.cpp:172
+#: ../src/common/fmapbase.cpp:169
 msgid "Windows Cyrillic (CP 1251)"
 msgstr "Windows Cirílico (CP 1251)"
 
-#: ../src/common/fmapbase.cpp:174
+#: ../src/common/fmapbase.cpp:171
 msgid "Windows Greek (CP 1253)"
 msgstr "Windows Grego (CP 1253)"
 
-#: ../src/common/fmapbase.cpp:176
+#: ../src/common/fmapbase.cpp:173
 msgid "Windows Hebrew (CP 1255)"
 msgstr "Windows Hebraico (CP 1255)"
 
-#: ../src/common/fmapbase.cpp:167
+#: ../src/common/fmapbase.cpp:164
 msgid "Windows Japanese (CP 932) or Shift-JIS"
 msgstr "Windows Japonês (CP 932) ou Shift-JIS"
 
-#: ../src/common/fmapbase.cpp:180
+#: ../src/common/fmapbase.cpp:177
 msgid "Windows Johab (CP 1361)"
 msgstr "Windows Johab (CP 1361)"
 
-#: ../src/common/fmapbase.cpp:169
+#: ../src/common/fmapbase.cpp:166
 msgid "Windows Korean (CP 949)"
 msgstr "Windows Coreano (CP 949)"
 
-#: ../src/common/fmapbase.cpp:166
+#: ../src/common/fmapbase.cpp:163
 msgid "Windows Thai (CP 874)"
 msgstr "Windows Tailandês (CP 874)"
 
-#: ../src/common/fmapbase.cpp:175
+#: ../src/common/fmapbase.cpp:172
 msgid "Windows Turkish (CP 1254)"
 msgstr "Windows Turco (CP 1254)"
 
-#: ../src/common/fmapbase.cpp:179
+#: ../src/common/fmapbase.cpp:176
 msgid "Windows Vietnamese (CP 1258)"
 msgstr "Windows Vietnamita (CP 1258)"
 
-#: ../src/common/fmapbase.cpp:173
+#: ../src/common/fmapbase.cpp:170
 msgid "Windows Western European (CP 1252)"
 msgstr "Windows Europeu Ocidental (CP 1252)"
 
-#: ../src/common/fmapbase.cpp:181
+#: ../src/common/fmapbase.cpp:178
 msgid "Windows/DOS OEM (CP 437)"
 msgstr "Windows/DOS OEM (CP 437)"
 
-#: ../src/common/fmapbase.cpp:165
+#: ../src/common/fmapbase.cpp:162
 msgid "Windows/DOS OEM Cyrillic (CP 866)"
 msgstr "Windows/DOS OEM Cirílico (CP 866)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:111
+#: ../src/common/accelcmn.cpp:109
 msgid "Windows_Left"
 msgstr "Janelas_Esquerda"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:113
+#: ../src/common/accelcmn.cpp:111
 msgid "Windows_Menu"
 msgstr "Janelas_Menu"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:112
+#: ../src/common/accelcmn.cpp:110
 msgid "Windows_Right"
 msgstr "Janelas_Direita"
 
-#: ../src/common/ffile.cpp:150
+#: ../src/common/ffile.cpp:149
 #, c-format
 msgid "Write error on file '%s'"
 msgstr "Erro de gravação no arquivo '%s'"
 
-#: ../src/xml/xml.cpp:914
+#: ../src/xml/xml.cpp:925
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "Erro de análise do XML: '%s' na linha %d"
 
-#: ../src/common/xpmdecod.cpp:796
+#: ../src/common/xpmdecod.cpp:794
 msgid "XPM: Malformed pixel data!"
 msgstr "XPM: Dados dos pixels mal formados!"
 
-#: ../src/common/xpmdecod.cpp:705
+#: ../src/common/xpmdecod.cpp:702
 #, c-format
 msgid "XPM: incorrect colour description in line %d"
 msgstr "XPM: descrição da côr incorreta na linha %d"
 
-#: ../src/common/xpmdecod.cpp:680
+#: ../src/common/xpmdecod.cpp:677
 msgid "XPM: incorrect header format!"
 msgstr "XPM: formato do cabeçalho inválido!"
 
-#: ../src/common/xpmdecod.cpp:716 ../src/common/xpmdecod.cpp:725
+#: ../src/common/xpmdecod.cpp:714 ../src/common/xpmdecod.cpp:723
 #, c-format
 msgid "XPM: malformed colour definition '%s' at line %d!"
 msgstr "XPM: definição da côr mal formada '%s' na linha %d!"
 
-#: ../src/common/xpmdecod.cpp:755
+#: ../src/common/xpmdecod.cpp:753
 msgid "XPM: no colors left to use for mask!"
 msgstr "XPM: nenhuma côr restou pra usar na máscara!"
 
-#: ../src/common/xpmdecod.cpp:782
+#: ../src/common/xpmdecod.cpp:780
 #, c-format
 msgid "XPM: truncated image data at line %d!"
 msgstr "XPM: dados da imagem truncados na linha %d!"
 
-#: ../src/propgrid/advprops.cpp:1610
+#: ../src/propgrid/advprops.cpp:1516
 msgid "Yellow"
 msgstr "Amarelo"
 
-#: ../include/wx/msgdlg.h:276 ../src/common/stockitem.cpp:206
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:203
 #: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Sim"
 
-#: ../src/osx/carbon/overlay.cpp:155
-msgid "You cannot Clear an overlay that is not inited"
-msgstr "Você não pode limpar um overlay que não está iniciado"
-
-#: ../src/osx/carbon/overlay.cpp:107 ../src/dfb/overlay.cpp:61
-msgid "You cannot Init an overlay twice"
-msgstr "Você não pode iniciar um overlay duas vezes"
-
-#: ../src/generic/dirdlgg.cpp:287
+#: ../src/generic/dirdlgg.cpp:284
 msgid "You cannot add a new directory to this section."
 msgstr "Você não pode adicionar um novo diretório a esta seção."
 
-#: ../src/propgrid/propgrid.cpp:3299
+#: ../src/propgrid/propgrid.cpp:3276
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr "Você inseriu um valor inválido. Pressione ESC pra cancelar a edição."
 
-#: ../src/common/stockitem.cpp:209
+#: ../src/osx/cocoa/menu.mm:286
+#, fuzzy
+msgid "Zoom"
+msgstr "Aumentar Zoom"
+
+#: ../src/common/stockitem.cpp:206
 msgid "Zoom &In"
 msgstr "Aumentar &Zoom"
 
-#: ../src/common/stockitem.cpp:210
+#: ../src/common/stockitem.cpp:207
 msgid "Zoom &Out"
 msgstr "Diminuir &Zoom"
 
-#: ../src/common/stockitem.cpp:209 ../src/common/prntbase.cpp:1594
+#: ../src/common/stockitem.cpp:206 ../src/common/prntbase.cpp:1619
 msgid "Zoom In"
 msgstr "Aumentar Zoom"
 
-#: ../src/common/stockitem.cpp:210 ../src/common/prntbase.cpp:1580
+#: ../src/common/stockitem.cpp:207 ../src/common/prntbase.cpp:1605
 msgid "Zoom Out"
 msgstr "Diminuir Zoom"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to &Fit"
 msgstr "Zoom para &Encaixar"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to Fit"
 msgstr "Zoom pra Encaixar"
 
-#: ../src/msw/dde.cpp:1141
+#: ../src/msw/dde.cpp:1205
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "um aplicativo DDEML criou uma condição de corrida prolongada."
 
-#: ../src/msw/dde.cpp:1129
+#: ../src/msw/dde.cpp:1193
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -7998,41 +8189,41 @@ msgstr ""
 "ou um identificador de instância inválido\n"
 "foi passado para uma função DDEML."
 
-#: ../src/msw/dde.cpp:1147
+#: ../src/msw/dde.cpp:1211
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "uma tentativa de um cliente de estabelecer uma conversação falhou."
 
-#: ../src/msw/dde.cpp:1144
+#: ../src/msw/dde.cpp:1208
 msgid "a memory allocation failed."
 msgstr "uma distribuição de memória falhou."
 
-#: ../src/msw/dde.cpp:1138
+#: ../src/msw/dde.cpp:1202
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "um parâmetro falhou em ser validado pelo DDEML."
 
-#: ../src/msw/dde.cpp:1120
+#: ../src/msw/dde.cpp:1184
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr ""
 "o tempo de um pedido pra uma transação de recomendação síncrona se esgotou."
 
-#: ../src/msw/dde.cpp:1126
+#: ../src/msw/dde.cpp:1190
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "o tempo de um pedido pra uma transação de dados síncrona se esgotou."
 
-#: ../src/msw/dde.cpp:1135
+#: ../src/msw/dde.cpp:1199
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr ""
 "o tempo de um pedido pra uma transação de execução síncrona se esgotou."
 
-#: ../src/msw/dde.cpp:1153
+#: ../src/msw/dde.cpp:1217
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "o tempo de um pedido pra uma transação de cutucão síncrona se esgotou."
 
-#: ../src/msw/dde.cpp:1168
+#: ../src/msw/dde.cpp:1232
 msgid "a request to end an advise transaction has timed out."
 msgstr "o tempo pra encerrar uma transação de recomendação se esgotou."
 
-#: ../src/msw/dde.cpp:1162
+#: ../src/msw/dde.cpp:1226
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -8042,15 +8233,15 @@ msgstr ""
 "que foi terminada pelo cliente, ou o servidor\n"
 "encerrou antes de completar uma transação."
 
-#: ../src/msw/dde.cpp:1150
+#: ../src/msw/dde.cpp:1214
 msgid "a transaction failed."
 msgstr "um transação falhou."
 
-#: ../src/common/accelcmn.cpp:189
+#: ../src/common/accelcmn.cpp:188
 msgid "alt"
 msgstr "alt"
 
-#: ../src/msw/dde.cpp:1132
+#: ../src/msw/dde.cpp:1196
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -8062,15 +8253,15 @@ msgstr ""
 "um aplicativo inicializado como APPCMD_CLIENTONLY tentou \n"
 "realizar transações de servidor."
 
-#: ../src/msw/dde.cpp:1156
+#: ../src/msw/dde.cpp:1220
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "uma chamada interna para a função PostMessage falhou. "
 
-#: ../src/msw/dde.cpp:1165
+#: ../src/msw/dde.cpp:1229
 msgid "an internal error has occurred in the DDEML."
 msgstr "um erro interno ocorreu no DDEML."
 
-#: ../src/msw/dde.cpp:1171
+#: ../src/msw/dde.cpp:1235
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -8080,56 +8271,56 @@ msgstr ""
 "Uma vez que o aplicativo retornou de um callback XTYP_XACT_COMPLETE,\n"
 "o identificador da transação para aquele callback não é mais válido."
 
-#: ../src/common/zipstrm.cpp:1483
+#: ../src/common/zipstrm.cpp:1522
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "assumindo que este é um zip multi-partes concatenado"
 
-#: ../src/common/fileconf.cpp:1847
+#: ../src/common/fileconf.cpp:1849
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "tentativa de mudar a chave imutável '%s' ignorada."
 
-#: ../src/html/chm.cpp:329
+#: ../src/html/chm.cpp:326
 msgid "bad arguments to library function"
 msgstr "argumentos ruins para a função da biblioteca"
 
-#: ../src/html/chm.cpp:341
+#: ../src/html/chm.cpp:338
 msgid "bad signature"
 msgstr "assinatura ruim"
 
-#: ../src/common/zipstrm.cpp:1918
+#: ../src/common/zipstrm.cpp:1988
 msgid "bad zipfile offset to entry"
 msgstr "offset ruim do arquivo zip para a entrada"
 
-#: ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400
 msgid "binary"
 msgstr "binário"
 
-#: ../src/common/fontcmn.cpp:996
+#: ../src/common/fontcmn.cpp:1195
 msgid "bold"
 msgstr "negrito"
 
-#: ../src/msw/utils.cpp:1144
+#: ../src/msw/utils.cpp:1135
 #, c-format
 msgid "build %lu"
 msgstr "build %lu"
 
-#: ../src/common/ffile.cpp:75
+#: ../src/common/ffile.cpp:73
 #, c-format
 msgid "can't close file '%s'"
 msgstr "não pode fechar o arquivo '%s'"
 
-#: ../src/common/file.cpp:245
+#: ../src/common/file.cpp:242
 #, c-format
 msgid "can't close file descriptor %d"
 msgstr "não pode fechar o descritor do arquivo %d"
 
-#: ../src/common/file.cpp:586
+#: ../src/common/ffile.cpp:382 ../src/common/file.cpp:613
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "não pode fazer as mudanças no arquivo '%s'"
 
-#: ../src/common/file.cpp:178
+#: ../src/common/file.cpp:175
 #, c-format
 msgid "can't create file '%s'"
 msgstr "não pode criar o arquivo '%s'"
@@ -8139,49 +8330,49 @@ msgstr "não pode criar o arquivo '%s'"
 msgid "can't delete user configuration file '%s'"
 msgstr "não pode apagar o arquivo de configuração do usuário '%s'"
 
-#: ../src/common/file.cpp:495
+#: ../src/common/file.cpp:522
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr "não pode determinar se o final do arquivo é alcançado no descritor %d"
 
-#: ../src/common/zipstrm.cpp:1692
+#: ../src/common/zipstrm.cpp:1747
 msgid "can't find central directory in zip"
 msgstr "não pode achar o diretório central no zip"
 
-#: ../src/common/file.cpp:465
+#: ../src/common/file.cpp:492
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "não pode achar o tamanho do arquivo no descritor de arquivos %d"
 
-#: ../src/msw/utils.cpp:341
+#: ../src/msw/utils.cpp:336
 msgid "can't find user's HOME, using current directory."
 msgstr "não pode achar o HOME do usuário, usando o diretório atual."
 
-#: ../src/common/file.cpp:366
+#: ../src/common/file.cpp:407
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "não pode dar descarga no descritor de arquivos %d"
 
-#: ../src/common/file.cpp:422
+#: ../src/common/file.cpp:463
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "não pode obter a posição da busca no descritor de arquivos %d"
 
-#: ../src/common/fontmap.cpp:325
+#: ../src/common/fontmap.cpp:322
 msgid "can't load any font, aborting"
 msgstr "não pode carregar qualquer fonte, abortando"
 
-#: ../src/common/file.cpp:231 ../src/common/ffile.cpp:59
+#: ../src/common/ffile.cpp:57 ../src/common/file.cpp:228
 #, c-format
 msgid "can't open file '%s'"
 msgstr "não pode abrir o arquivo '%s'"
 
-#: ../src/common/fileconf.cpp:320
+#: ../src/common/fileconf.cpp:314
 #, c-format
 msgid "can't open global configuration file '%s'."
 msgstr "não pode abrir o arquivo de configuração global '%s'."
 
-#: ../src/common/fileconf.cpp:336
+#: ../src/common/fileconf.cpp:330
 #, c-format
 msgid "can't open user configuration file '%s'."
 msgstr "não pode abrir o arquivo de configuração do usuário '%s'."
@@ -8190,40 +8381,40 @@ msgstr "não pode abrir o arquivo de configuração do usuário '%s'."
 msgid "can't open user configuration file."
 msgstr "não pode abrir o arquivo de configuração do usuário."
 
-#: ../src/common/zipstrm.cpp:579
+#: ../src/common/zipstrm.cpp:572
 msgid "can't re-initialize zlib deflate stream"
 msgstr "não pode reinicializar o fluxo de deflação do zlib"
 
-#: ../src/common/zipstrm.cpp:604
+#: ../src/common/zipstrm.cpp:597
 msgid "can't re-initialize zlib inflate stream"
 msgstr "não pode reinicializar o sistema de inflação do zlib"
 
-#: ../src/common/file.cpp:304
+#: ../src/common/file.cpp:345
 #, c-format
 msgid "can't read from file descriptor %d"
 msgstr "não pode ler do descritor de arquivos %d"
 
-#: ../src/common/file.cpp:581
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:608
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "não pode remover o arquivo '%s'"
 
-#: ../src/common/file.cpp:598
+#: ../src/common/ffile.cpp:394 ../src/common/file.cpp:625
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "não pode remover o arquivo temporário '%s'"
 
-#: ../src/common/file.cpp:408
+#: ../src/common/file.cpp:449
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "não pode procurar no descritor de arquivos %d"
 
-#: ../src/common/textfile.cpp:273
+#: ../src/common/textfile.cpp:161
 #, c-format
 msgid "can't write buffer '%s' to disk."
 msgstr "não pode gravar o buffer '%s' no disco."
 
-#: ../src/common/file.cpp:323
+#: ../src/common/file.cpp:364
 #, c-format
 msgid "can't write to file descriptor %d"
 msgstr "não pode gravar no descritor de arquivos %d"
@@ -8233,22 +8424,28 @@ msgid "can't write user configuration file."
 msgstr "não pode gravar o arquivo de configuração do usuário."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:482 ../src/generic/datavgen.cpp:1261
+#: ../src/common/datavcmn.cpp:2064 ../src/generic/datavgen.cpp:1384
 msgid "checked"
 msgstr "verificado"
 
-#: ../src/html/chm.cpp:345
+#: ../src/html/chm.cpp:342
 msgid "checksum error"
 msgstr "erro de checksum"
 
-#: ../src/common/tarstrm.cpp:820
+#: ../src/common/tarstrm.cpp:814
 msgid "checksum failure reading tar header block"
 msgstr "falha do checksum ao ler o bloco do cabeçalho tar"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:226
-#: ../src/richtext/richtextbackgroundpage.cpp:249
-#: ../src/richtext/richtextbackgroundpage.cpp:289
-#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
 #: ../src/richtext/richtextborderspage.cpp:254
 #: ../src/richtext/richtextborderspage.cpp:288
 #: ../src/richtext/richtextborderspage.cpp:322
@@ -8266,104 +8463,127 @@ msgstr "falha do checksum ao ler o bloco do cabeçalho tar"
 #: ../src/richtext/richtextmarginspage.cpp:340
 #: ../src/richtext/richtextmarginspage.cpp:363
 #: ../src/richtext/richtextmarginspage.cpp:388
-#: ../src/richtext/richtextsizepage.cpp:339
-#: ../src/richtext/richtextsizepage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:400
-#: ../src/richtext/richtextsizepage.cpp:427
-#: ../src/richtext/richtextsizepage.cpp:454
-#: ../src/richtext/richtextsizepage.cpp:481
-#: ../src/richtext/richtextsizepage.cpp:555
-#: ../src/richtext/richtextsizepage.cpp:590
-#: ../src/richtext/richtextsizepage.cpp:625
-#: ../src/richtext/richtextsizepage.cpp:660
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
 msgid "cm"
 msgstr "cm"
 
-#: ../src/html/chm.cpp:347
+#: ../src/html/chm.cpp:344
 msgid "compression error"
 msgstr "erro de compressão"
 
-#: ../src/common/regex.cpp:236
+#: ../src/common/regex.cpp:233
 msgid "conversion to 8-bit encoding failed"
 msgstr "conversão para a codificação de 8 bits falhou"
 
-#: ../src/common/accelcmn.cpp:187
+#: ../src/common/accelcmn.cpp:186
 msgid "ctrl"
 msgstr "ctrl"
 
-#: ../src/common/cmdline.cpp:1500
+#: ../src/common/cmdline.cpp:1496
 msgid "date"
 msgstr "data"
 
-#: ../src/html/chm.cpp:349
+#: ../src/html/chm.cpp:346
 msgid "decompression error"
 msgstr "erro de descompressão"
 
-#: ../src/richtext/richtextstyles.cpp:780 ../src/common/fmapbase.cpp:820
+#: ../src/common/fmapbase.cpp:816 ../src/richtext/richtextstyles.cpp:777
 msgid "default"
 msgstr "padrão"
 
-#: ../src/common/cmdline.cpp:1496
+#: ../src/common/cmdline.cpp:1492
 msgid "double"
 msgstr "duplo"
 
-#: ../src/common/debugrpt.cpp:538
+#: ../src/common/debugrpt.cpp:539
 msgid "dump of the process state (binary)"
 msgstr "dump do estado do processo (binário)"
 
-#: ../src/common/datetimefmt.cpp:1969
+#: ../src/common/datetimefmt.cpp:1992
 msgid "eighteenth"
 msgstr "décimo-oitavo"
 
-#: ../src/common/datetimefmt.cpp:1959
+#: ../src/common/datetimefmt.cpp:1982
 msgid "eighth"
 msgstr "oitavo"
 
-#: ../src/common/datetimefmt.cpp:1962
+#: ../src/common/datetimefmt.cpp:1985
 msgid "eleventh"
 msgstr "décimo-primeiro"
 
-#: ../src/common/fileconf.cpp:1833
+#: ../src/common/fileconf.cpp:1835
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "a entrada '%s' aparece mais do que uma vez no grupo '%s'"
 
-#: ../src/html/chm.cpp:343
+#: ../src/html/chm.cpp:340
 msgid "error in data format"
 msgstr "erro no formato dos dados"
 
-#: ../src/html/chm.cpp:331
+#: ../src/html/chm.cpp:328
 msgid "error opening file"
 msgstr "erro ao abrir o arquivo"
 
-#: ../src/common/zipstrm.cpp:1778
+#: ../src/common/zipstrm.cpp:1836
 msgid "error reading zip central directory"
 msgstr "erro lendo o diretório central do zip"
 
-#: ../src/common/zipstrm.cpp:1870
+#: ../src/common/zipstrm.cpp:1940
 msgid "error reading zip local header"
 msgstr "erro lendo o cabeçalho local do zip"
 
-#: ../src/common/zipstrm.cpp:2531
+#: ../src/common/zipstrm.cpp:2615
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "erro gravando a entrada do zip '%s': crc ou tamanho ruim"
 
-#: ../src/common/ffile.cpp:188
+#: ../src/common/zipstrm.cpp:2608
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "erro gravando a entrada do zip '%s': crc ou tamanho ruim"
+
+#: ../src/common/fontcmn.cpp:1205
+#, fuzzy
+msgid "extrabold"
+msgstr "negrito"
+
+#: ../src/common/fontcmn.cpp:1223
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1167
+#, fuzzy
+msgid "extralight"
+msgstr "leve"
+
+#: ../src/msw/webview_ie.cpp:1036
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "Falhou em executar o '%s'\n"
+
+#: ../src/common/ffile.cpp:187
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "falhou em dar descarga no arquivo '%s'"
 
+#: ../src/msw/webview_ie.cpp:1045
+#, fuzzy
+msgid "failed to retrieve execution result"
+msgstr "Falhou em recuperar o texto da mensagem de erro do RAS"
+
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1030
+#: ../src/generic/datavgen.cpp:1150
 msgid "false"
 msgstr "falso"
 
-#: ../src/common/datetimefmt.cpp:1966
+#: ../src/common/datetimefmt.cpp:1989
 msgid "fifteenth"
 msgstr "décimo-quinto"
 
-#: ../src/common/datetimefmt.cpp:1956
+#: ../src/common/datetimefmt.cpp:1979
 msgid "fifth"
 msgstr "quinto"
 
@@ -8392,131 +8612,150 @@ msgstr "arquivo '%s', linha %zu: valor para a chave imutável '%s' ignorado."
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "arquivo '%s': caractere ineperado %c na linha %zu."
 
-#: ../src/richtext/richtextbuffer.cpp:8738
+#: ../src/richtext/richtextbuffer.cpp:8736
 msgid "files"
 msgstr "arquivos"
 
-#: ../src/common/datetimefmt.cpp:1952
+#: ../src/common/datetimefmt.cpp:1975
 msgid "first"
 msgstr "primeiro"
 
-#: ../src/html/helpwnd.cpp:1252
+#: ../src/html/helpwnd.cpp:1250
 msgid "font size"
 msgstr "tamanho da fonte"
 
-#: ../src/common/datetimefmt.cpp:1965
+#: ../src/common/datetimefmt.cpp:1988
 msgid "fourteenth"
 msgstr "décimo-quarto"
 
-#: ../src/common/datetimefmt.cpp:1955
+#: ../src/common/datetimefmt.cpp:1978
 msgid "fourth"
 msgstr "quarto"
 
-#: ../src/common/appbase.cpp:783
+#: ../src/common/appbase.cpp:784
 msgid "generate verbose log messages"
 msgstr "gerar mensagens de log prolixas"
 
-#: ../src/richtext/richtextbuffer.cpp:13138
-#: ../src/richtext/richtextbuffer.cpp:13248
+#: ../src/common/fontcmn.cpp:1215
+msgid "heavy"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:13133
+#: ../src/richtext/richtextbuffer.cpp:13243
 msgid "image"
 msgstr "imagem"
 
-#: ../src/common/tarstrm.cpp:796
+#: ../src/common/tarstrm.cpp:790
 msgid "incomplete header block in tar"
 msgstr "bloco do cabeçalho incompleto no tar"
 
-#: ../src/common/xtixml.cpp:489
+#: ../src/common/xtixml.cpp:485
 msgid "incorrect event handler string, missing dot"
 msgstr "sequência do manejador de eventos incorreta; ponto desaparecido"
 
-#: ../src/common/tarstrm.cpp:1381
+#: ../src/common/tarstrm.cpp:1375
 msgid "incorrect size given for tar entry"
 msgstr "tamanho incorreto dado para a entrada do tar"
 
-#: ../src/common/tarstrm.cpp:993
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:987
 msgid "invalid data in extended tar header"
 msgstr "dados inválidos no cabeçalho estendido do tar"
 
-#: ../src/generic/logg.cpp:1030
+#: ../src/generic/logg.cpp:1027
 msgid "invalid message box return value"
 msgstr "valor de retorno da caixa de mensagem inválido"
 
-#: ../src/common/zipstrm.cpp:1647
+#: ../src/common/zipstrm.cpp:1688
 msgid "invalid zip file"
 msgstr "arquivo zip inválido"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:1228
 msgid "italic"
 msgstr "itálico"
 
-#: ../src/common/fontcmn.cpp:991
+#: ../src/common/webrequest_curl.cpp:374
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "A descrição da coluna não pôde ser inicializada."
+
+#: ../src/common/fontcmn.cpp:1172
 msgid "light"
 msgstr "leve"
 
-#: ../src/common/intl.cpp:303
-#, c-format
-msgid "locale '%s' cannot be set."
-msgstr "o idioma '%s' não pode ser definido."
+#: ../src/common/fontcmn.cpp:1185
+msgid "medium"
+msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2125
+#: ../src/common/datetimefmt.cpp:2148
 msgid "midnight"
 msgstr "meia-noite"
 
-#: ../src/common/datetimefmt.cpp:1970
+#: ../src/common/datetimefmt.cpp:1993
 msgid "nineteenth"
 msgstr "décimo-nono"
 
-#: ../src/common/datetimefmt.cpp:1960
+#: ../src/common/datetimefmt.cpp:1983
 msgid "ninth"
 msgstr "nono"
 
-#: ../src/msw/dde.cpp:1116
+#: ../src/msw/dde.cpp:1180
 msgid "no DDE error."
 msgstr "nenhum erro do DDE."
 
-#: ../src/html/chm.cpp:327
+#: ../src/html/chm.cpp:324
 msgid "no error"
 msgstr "nenhum erro"
 
-#: ../src/dfb/fontmgr.cpp:174
+#: ../src/dfb/fontmgr.cpp:171
 #, c-format
 msgid "no fonts found in %s, using builtin font"
 msgstr "nenhuma fonte achada em %s, usando a fonte embutida"
 
-#: ../src/html/helpdata.cpp:657
+#: ../src/html/helpdata.cpp:650
 msgid "noname"
 msgstr "sem nome"
 
-#: ../src/common/datetimefmt.cpp:2124
+#: ../src/common/datetimefmt.cpp:2147
 msgid "noon"
 msgstr "meio-dia"
 
-#: ../src/richtext/richtextstyles.cpp:779
+#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "normal"
 
-#: ../src/common/cmdline.cpp:1492
+#: ../src/common/cmdline.cpp:1488
 msgid "num"
 msgstr "num"
 
-#: ../src/common/xtixml.cpp:259
+#: ../src/common/accelcmn.cpp:194
+msgid "num "
+msgstr ""
+
+#: ../src/common/xtixml.cpp:255
 msgid "objects cannot have XML Text Nodes"
 msgstr "objetos não podem ter Nodes de Texto do XML"
 
-#: ../src/html/chm.cpp:339
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
 msgid "out of memory"
 msgstr "sem memória"
 
-#: ../src/common/debugrpt.cpp:514
+#: ../src/common/debugrpt.cpp:515
 msgid "process context description"
 msgstr "descrição do contexto do processo"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:227
-#: ../src/richtext/richtextbackgroundpage.cpp:250
-#: ../src/richtext/richtextbackgroundpage.cpp:290
-#: ../src/richtext/richtextbackgroundpage.cpp:317
-#: ../src/richtext/richtextfontpage.cpp:177
-#: ../src/richtext/richtextfontpage.cpp:180
 #: ../src/richtext/richtextborderspage.cpp:255
 #: ../src/richtext/richtextborderspage.cpp:289
 #: ../src/richtext/richtextborderspage.cpp:323
@@ -8526,22 +8765,45 @@ msgstr "descrição do contexto do processo"
 #: ../src/richtext/richtextborderspage.cpp:491
 #: ../src/richtext/richtextborderspage.cpp:525
 #: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextfontpage.cpp:180
 msgid "pt"
 msgstr "pt"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:225
-#: ../src/richtext/richtextbackgroundpage.cpp:228
-#: ../src/richtext/richtextbackgroundpage.cpp:229
-#: ../src/richtext/richtextbackgroundpage.cpp:248
-#: ../src/richtext/richtextbackgroundpage.cpp:251
-#: ../src/richtext/richtextbackgroundpage.cpp:252
-#: ../src/richtext/richtextbackgroundpage.cpp:288
-#: ../src/richtext/richtextbackgroundpage.cpp:291
-#: ../src/richtext/richtextbackgroundpage.cpp:292
-#: ../src/richtext/richtextbackgroundpage.cpp:315
-#: ../src/richtext/richtextbackgroundpage.cpp:318
-#: ../src/richtext/richtextbackgroundpage.cpp:319
-#: ../src/richtext/richtextfontpage.cpp:178
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:659
+#: ../src/richtext/richtextsizepage.cpp:662
+#: ../src/richtext/richtextsizepage.cpp:663
 #: ../src/richtext/richtextborderspage.cpp:253
 #: ../src/richtext/richtextborderspage.cpp:256
 #: ../src/richtext/richtextborderspage.cpp:257
@@ -8593,259 +8855,269 @@ msgstr "pt"
 #: ../src/richtext/richtextmarginspage.cpp:387
 #: ../src/richtext/richtextmarginspage.cpp:389
 #: ../src/richtext/richtextmarginspage.cpp:390
-#: ../src/richtext/richtextsizepage.cpp:338
-#: ../src/richtext/richtextsizepage.cpp:341
-#: ../src/richtext/richtextsizepage.cpp:342
-#: ../src/richtext/richtextsizepage.cpp:372
-#: ../src/richtext/richtextsizepage.cpp:375
-#: ../src/richtext/richtextsizepage.cpp:376
-#: ../src/richtext/richtextsizepage.cpp:399
-#: ../src/richtext/richtextsizepage.cpp:402
-#: ../src/richtext/richtextsizepage.cpp:403
-#: ../src/richtext/richtextsizepage.cpp:426
-#: ../src/richtext/richtextsizepage.cpp:429
-#: ../src/richtext/richtextsizepage.cpp:430
-#: ../src/richtext/richtextsizepage.cpp:453
-#: ../src/richtext/richtextsizepage.cpp:456
-#: ../src/richtext/richtextsizepage.cpp:457
-#: ../src/richtext/richtextsizepage.cpp:480
-#: ../src/richtext/richtextsizepage.cpp:483
-#: ../src/richtext/richtextsizepage.cpp:484
-#: ../src/richtext/richtextsizepage.cpp:554
-#: ../src/richtext/richtextsizepage.cpp:557
-#: ../src/richtext/richtextsizepage.cpp:558
-#: ../src/richtext/richtextsizepage.cpp:589
-#: ../src/richtext/richtextsizepage.cpp:592
-#: ../src/richtext/richtextsizepage.cpp:593
-#: ../src/richtext/richtextsizepage.cpp:624
-#: ../src/richtext/richtextsizepage.cpp:627
-#: ../src/richtext/richtextsizepage.cpp:628
-#: ../src/richtext/richtextsizepage.cpp:659
-#: ../src/richtext/richtextsizepage.cpp:662
-#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextfontpage.cpp:178
 msgid "px"
 msgstr "px"
 
-#: ../src/common/accelcmn.cpp:193
+#: ../src/common/accelcmn.cpp:192
 msgid "rawctrl"
 msgstr "rawctrl"
 
-#: ../src/html/chm.cpp:333
+#: ../src/html/chm.cpp:330
 msgid "read error"
 msgstr "erro de leitura"
 
-#: ../src/common/zipstrm.cpp:2085
+#: ../src/common/zipstrm.cpp:2155
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "lendo o fluxo do zip (entrada %s): crc ruim"
 
-#: ../src/common/zipstrm.cpp:2080
+#: ../src/common/zipstrm.cpp:2150
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "lendo o fluxo do zip (entrada %s): tamanho ruim"
 
-#: ../src/msw/dde.cpp:1159
+#: ../src/msw/dde.cpp:1223
 msgid "reentrancy problem."
 msgstr "problema na re-entrada."
 
-#: ../src/common/datetimefmt.cpp:1953
+#: ../src/common/datetimefmt.cpp:1976
 msgid "second"
 msgstr "segundo"
 
-#: ../src/html/chm.cpp:337
+#: ../src/html/chm.cpp:334
 msgid "seek error"
 msgstr "erro de busca"
 
-#: ../src/common/datetimefmt.cpp:1968
+#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#, fuzzy
+msgid "semibold"
+msgstr "negrito"
+
+#: ../src/common/datetimefmt.cpp:1991
 msgid "seventeenth"
 msgstr "décimo-sétimo"
 
-#: ../src/common/datetimefmt.cpp:1958
+#: ../src/common/datetimefmt.cpp:1981
 msgid "seventh"
 msgstr "sétimo"
 
-#: ../src/common/accelcmn.cpp:191
+#: ../src/common/accelcmn.cpp:190
 msgid "shift"
 msgstr "shift"
 
-#: ../src/common/appbase.cpp:773
+#: ../src/common/appbase.cpp:774
 msgid "show this help message"
 msgstr "mostrar esta mensagem de ajuda"
 
-#: ../src/common/datetimefmt.cpp:1967
+#: ../src/common/datetimefmt.cpp:1990
 msgid "sixteenth"
 msgstr "décimo-sexto"
 
-#: ../src/common/datetimefmt.cpp:1957
+#: ../src/common/datetimefmt.cpp:1980
 msgid "sixth"
 msgstr "sexto"
 
-#: ../src/common/appcmn.cpp:234
+#: ../src/common/appcmn.cpp:255
 msgid "specify display mode to use (e.g. 640x480-16)"
 msgstr "especificar o modo de exibição a usar (ex: 640x480-16)"
 
-#: ../src/common/appcmn.cpp:220
+#: ../src/common/appcmn.cpp:241
 msgid "specify the theme to use"
 msgstr "especificar o tema a usar"
 
-#: ../src/richtext/richtextbuffer.cpp:9340
+#: ../src/richtext/richtextbuffer.cpp:9337
 msgid "standard/circle"
 msgstr "padrão/círculo"
 
-#: ../src/richtext/richtextbuffer.cpp:9341
+#: ../src/richtext/richtextbuffer.cpp:9338
 msgid "standard/circle-outline"
 msgstr "padrão/círculo-contorno"
 
-#: ../src/richtext/richtextbuffer.cpp:9343
+#: ../src/richtext/richtextbuffer.cpp:9340
 msgid "standard/diamond"
 msgstr "padrão/diamante"
 
-#: ../src/richtext/richtextbuffer.cpp:9342
+#: ../src/richtext/richtextbuffer.cpp:9339
 msgid "standard/square"
 msgstr "padrão/quadrado"
 
-#: ../src/richtext/richtextbuffer.cpp:9344
+#: ../src/richtext/richtextbuffer.cpp:9341
 msgid "standard/triangle"
 msgstr "padrão/triângulo"
 
-#: ../src/common/zipstrm.cpp:1985
+#: ../src/common/zipstrm.cpp:2055
 msgid "stored file length not in Zip header"
 msgstr "tamanho do arquivo armazenado não está no cabeçalho do Zip"
 
-#: ../src/common/cmdline.cpp:1488
+#: ../src/common/cmdline.cpp:1484
 msgid "str"
 msgstr "str"
 
-#: ../src/common/fontcmn.cpp:982
+#: ../src/common/fontcmn.cpp:1145
 msgid "strikethrough"
 msgstr "riscar"
 
-#: ../src/common/tarstrm.cpp:1003 ../src/common/tarstrm.cpp:1025
-#: ../src/common/tarstrm.cpp:1507 ../src/common/tarstrm.cpp:1529
+#: ../src/common/tarstrm.cpp:997 ../src/common/tarstrm.cpp:1019
+#: ../src/common/tarstrm.cpp:1501 ../src/common/tarstrm.cpp:1523
 msgid "tar entry not open"
 msgstr "entrada do tar não aberta"
 
-#: ../src/common/datetimefmt.cpp:1961
+#: ../src/common/datetimefmt.cpp:1984
 msgid "tenth"
 msgstr "décimo"
 
-#: ../src/msw/dde.cpp:1123
+#: ../src/msw/dde.cpp:1187
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "a resposta para a transação fez o bit do DDE_FBUSY ser definido."
 
-#: ../src/common/datetimefmt.cpp:1954
+#: ../src/common/fontcmn.cpp:1154
+msgid "thin"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:1977
 msgid "third"
 msgstr "terceiro"
 
-#: ../src/common/datetimefmt.cpp:1964
+#: ../src/common/datetimefmt.cpp:1987
 msgid "thirteenth"
 msgstr "décimo-terceiro"
 
-#: ../src/common/datetimefmt.cpp:1758
+#: ../src/common/datetimefmt.cpp:1781
 msgid "today"
 msgstr "hoje"
 
-#: ../src/common/datetimefmt.cpp:1760
+#: ../src/common/datetimefmt.cpp:1783
 msgid "tomorrow"
 msgstr "amanhã"
 
-#: ../src/common/fileconf.cpp:1944
+#: ../src/common/fileconf.cpp:1946
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "barra invertida do rastreamento ignorado em '%s'"
 
-#: ../src/gtk/aboutdlg.cpp:218
+#: ../src/gtk/aboutdlg.cpp:216
 msgid "translator-credits"
 msgstr "tradutor-créditos"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1028
+#: ../src/generic/datavgen.cpp:1148
 msgid "true"
 msgstr "verdadeiro"
 
-#: ../src/common/datetimefmt.cpp:1963
+#: ../src/common/datetimefmt.cpp:1986
 msgid "twelfth"
 msgstr "décimo-segundo"
 
-#: ../src/common/datetimefmt.cpp:1971
+#: ../src/common/datetimefmt.cpp:1994
 msgid "twentieth"
 msgstr "vigésimo"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:486 ../src/generic/datavgen.cpp:1263
+#: ../src/common/datavcmn.cpp:2068 ../src/generic/datavgen.cpp:1386
 msgid "unchecked"
 msgstr "não verificado"
 
-#: ../src/common/fontcmn.cpp:802 ../src/common/fontcmn.cpp:978
+#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
 msgid "underlined"
 msgstr "sublinhado"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:490
+#: ../src/common/datavcmn.cpp:2072
 msgid "undetermined"
 msgstr "não determinado"
 
-#: ../src/common/fileconf.cpp:1979
+#: ../src/common/fileconf.cpp:1981
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "inesperado \" na posição %d em '%s'."
 
-#: ../src/common/tarstrm.cpp:1045
+#: ../src/common/tarstrm.cpp:1039
 msgid "unexpected end of file"
 msgstr "fim inesperado do arquivo"
 
-#: ../src/generic/progdlgg.cpp:370 ../src/common/tarstrm.cpp:371
-#: ../src/common/tarstrm.cpp:394 ../src/common/tarstrm.cpp:425
+#: ../src/common/tarstrm.cpp:366 ../src/common/tarstrm.cpp:389
+#: ../src/common/tarstrm.cpp:420 ../src/generic/progdlgg.cpp:376
 msgid "unknown"
 msgstr "desconhecido"
 
-#: ../src/msw/registry.cpp:150
+#: ../src/msw/registry.cpp:139
 #, c-format
 msgid "unknown (%lu)"
 msgstr "desconhecido (%lu)"
 
-#: ../src/common/xtixml.cpp:253
+#: ../src/common/xtixml.cpp:249
 #, c-format
 msgid "unknown class %s"
 msgstr "classe %s desconhecida"
 
-#: ../src/common/regex.cpp:258 ../src/html/chm.cpp:351
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "erro de compressão"
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "erro de descompressão"
+
+#: ../src/common/regex.cpp:255 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "erro desconhecido"
 
-#: ../src/msw/dialup.cpp:471
+#: ../src/msw/dialup.cpp:465
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "erro desconhecido (código do erro %08x)."
 
-#: ../src/common/fmapbase.cpp:834
+#: ../src/common/fmapbase.cpp:830
 #, c-format
 msgid "unknown-%d"
 msgstr "desconhecido- %d"
 
-#: ../src/common/docview.cpp:509
+#: ../src/common/docview.cpp:502
 msgid "unnamed"
 msgstr "sem nome"
 
-#: ../src/common/docview.cpp:1624
+#: ../src/common/docview.cpp:1618
 #, c-format
 msgid "unnamed%d"
 msgstr "%d sem nome"
 
-#: ../src/common/zipstrm.cpp:1999 ../src/common/zipstrm.cpp:2319
+#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
 msgid "unsupported Zip compression method"
 msgstr "método de compressão do Zip não suportado"
 
-#: ../src/common/translation.cpp:1892
+#: ../src/common/translation.cpp:1942
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "usando o catálogo '%s' de '%s'."
 
-#: ../src/html/chm.cpp:335
+#: ../src/html/chm.cpp:332
 msgid "write error"
 msgstr "erro de gravação"
 
-#: ../src/common/time.cpp:292
+#: ../src/gtk/glcanvas.cpp:187
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/common/time.cpp:285
 msgid "wxGetTimeOfDay failed."
 msgstr "o wxGetTimeOfDay falhou."
 
@@ -8858,15 +9130,15 @@ msgstr "wxWidgets não pôde abrir a exibição pro '%s': saindo."
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets não pôde abrir a exibição. Saindo."
 
-#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:431
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/common/datetimefmt.cpp:1759
+#: ../src/common/datetimefmt.cpp:1782
 msgid "yesterday"
 msgstr "ontem"
 
-#: ../src/common/zstream.cpp:251 ../src/common/zstream.cpp:426
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
 #, c-format
 msgid "zlib error %d"
 msgstr "erro do zlib %d"
@@ -8875,6 +9147,78 @@ msgstr "erro do zlib %d"
 #: ../src/richtext/richtextbulletspage.cpp:288
 msgid "~"
 msgstr "~"
+
+#~ msgid " (while overwriting an existing item)"
+#~ msgstr " (enquanto sobrescrevendo um item existente)"
+
+#~ msgid "&Save as"
+#~ msgstr "&Salvar como"
+
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' não consiste apenas de caracteres válidos"
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' deve ser numérico."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' deve conter apenas caracteres ASCII."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' deve conter apenas caracteres alfabéticos."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' deve conter apenas caracteres alfabéticos ou numéricos."
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' deve conter apenas dígitos."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "Não consegue criar a janela da classe %s"
+
+#~ msgid "Could not initalize libnotify."
+#~ msgstr "Não pôde inicializar o libnotify."
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "Não pôde criar a janela do overlay"
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "Não pôde inicializar o contexto na janela do overlay"
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "Falhou em converter o arquivo \"%s\" para o Unicode."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "Falhou em definir o texto no controle de texto."
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr "Opção da linha de comando do GTK+ inválida, use \"%s --help\""
+
+#~ msgid "No unused colour in image."
+#~ msgstr "Nenhuma côr sem uso na imagem."
+
+#~ msgid "Not available"
+#~ msgstr "Não disponível"
+
+#~ msgid "Replace selection"
+#~ msgstr "Substituir a seleção"
+
+#~ msgid "Save as"
+#~ msgstr "Salvar como"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Organizador de Estilos"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "As seguintes opções padrão do GTK+ também são suportadas:\n"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "Você não pode limpar um overlay que não está iniciado"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "Você não pode iniciar um overlay duas vezes"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "o idioma '%s' não pode ser definido."
 
 #~ msgid "Adding flavor TEXT failed"
 #~ msgstr "Falhou em adicionar o sabor TEXT"
@@ -8894,9 +9238,6 @@ msgstr "~"
 
 #~ msgid "Column could not be added."
 #~ msgstr "A coluna não pôde ser adicionada."
-
-#~ msgid "Column description could not be initialized."
-#~ msgstr "A descrição da coluna não pôde ser inicializada."
 
 #~ msgid "Column index not found."
 #~ msgstr "Índice da coluna não achado."
@@ -9491,9 +9832,6 @@ msgstr "~"
 #~ msgid "Directory '%s' doesn't exist!"
 #~ msgstr "O diretório '%s' não existe!"
 
-#~ msgid "File %s does not exist."
-#~ msgstr "O arquivo %s não existe."
-
 #~ msgid "Mode %ix%i-%i not available."
 #~ msgstr "Modo %ix%i-%i não disponível."
 
@@ -9610,9 +9948,6 @@ msgstr "~"
 
 #~ msgid "Failed to register OpenGL window class."
 #~ msgstr "Falhou em registrar a classe de janela do OpenGL."
-
-#~ msgid "Fatal error"
-#~ msgstr "Erro fatal"
 
 #~ msgid "Fatal error: "
 #~ msgstr "Erro fatal: "
@@ -9801,10 +10136,6 @@ msgstr "~"
 
 #~ msgid "&Print"
 #~ msgstr "&Imprimir"
-
-#, fuzzy
-#~ msgid "*** A debug report has been generated\n"
-#~ msgstr "Um relatï¿½rio de depuraï¿½ï¿½o foi gerado no diretï¿½rio\n"
 
 #~ msgid ""
 #~ ", expected static, #include or #define\n"

--- a/locale/ro.po
+++ b/locale/ro.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-21 14:25+0200\n"
+"POT-Creation-Date: 2020-10-18 23:11+0300\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Cătălin Răceanu <cata_sr@yahoo.com>\n"
 "Language-Team: ro.ro\n"
@@ -17,7 +17,7 @@ msgstr ""
 "X-Generator: Poedit 1.5.7\n"
 "X-Poedit-SearchPath-0: \n"
 
-#: ../src/common/debugrpt.cpp:586
+#: ../src/common/debugrpt.cpp:587
 msgid ""
 "\n"
 "Please send this report to the program maintainer, thank you!\n"
@@ -25,8 +25,8 @@ msgstr ""
 "\n"
 "Trimiteți acest raport dezvoltatorului programului, mulțumim!\n"
 
-#: ../src/richtext/richtextstyledlg.cpp:210
-#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:206
+#: ../src/richtext/richtextstyledlg.cpp:218
 msgid " "
 msgstr " "
 
@@ -34,70 +34,96 @@ msgstr " "
 msgid "              Thank you and we're sorry for the inconvenience!\n"
 msgstr "              Mulțumim și ne pare rău pentru inconveniență!\n"
 
-#: ../src/common/prntbase.cpp:573
+#: ../src/common/prntbase.cpp:568
 #, c-format
 msgid " (copy %d of %d)"
 msgstr " (copia %d din %d)"
 
-#: ../src/common/log.cpp:421
+#: ../src/common/log.cpp:440
 #, c-format
 msgid " (error %ld: %s)"
 msgstr " (eroarea %ld: %s)"
 
-#: ../src/common/imagtiff.cpp:72
+#: ../src/common/imagtiff.cpp:69
 #, c-format
 msgid " (in module \"%s\")"
 msgstr " (în modulul \"%s\")"
 
-#: ../src/osx/core/secretstore.cpp:138
-msgid " (while overwriting an existing item)"
-msgstr ""
-
-#: ../src/common/docview.cpp:1642
+#: ../src/common/docview.cpp:1636
 msgid " - "
 msgstr " - "
 
-#: ../src/richtext/richtextprint.cpp:593 ../src/html/htmprint.cpp:714
+#: ../src/html/htmprint.cpp:712 ../src/richtext/richtextprint.cpp:589
 msgid " Preview"
 msgstr " Previzualizare"
 
-#: ../src/common/fontcmn.cpp:824
+#: ../src/common/fontcmn.cpp:973
 msgid " bold"
 msgstr " îngroșat"
 
-#: ../src/common/fontcmn.cpp:840
+#: ../src/common/fontcmn.cpp:977
+#, fuzzy
+msgid " extra bold"
+msgstr " îngroșat"
+
+#: ../src/common/fontcmn.cpp:985
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:957
+#, fuzzy
+msgid " extra light"
+msgstr " subțire"
+
+#: ../src/common/fontcmn.cpp:981
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1001
 msgid " italic"
 msgstr " cursiv"
 
-#: ../src/common/fontcmn.cpp:820
+#: ../src/common/fontcmn.cpp:961
 msgid " light"
 msgstr " subțire"
 
-#: ../src/common/fontcmn.cpp:807
+#: ../src/common/fontcmn.cpp:965
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:969
+#, fuzzy
+msgid " semi bold"
+msgstr " îngroșat"
+
+#: ../src/common/fontcmn.cpp:940
 msgid " strikethrough"
 msgstr " tăiat"
 
-#: ../src/common/paper.cpp:117
+#: ../src/common/fontcmn.cpp:953
+msgid " thin"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
 msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
 msgstr "#10 Plic, 4 1/8 x 9 1/2 in"
 
-#: ../src/common/paper.cpp:118
+#: ../src/common/paper.cpp:115
 msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
 msgstr "#11 Plic, 4 1/2 x 10 3/8 in"
 
-#: ../src/common/paper.cpp:119
+#: ../src/common/paper.cpp:116
 msgid "#12 Envelope, 4 3/4 x 11 in"
 msgstr "#12 Plic, 4 3/4 x 11 in"
 
-#: ../src/common/paper.cpp:120
+#: ../src/common/paper.cpp:117
 msgid "#14 Envelope, 5 x 11 1/2 in"
 msgstr "#14 Plic, 5 x 11 1/2 in"
 
-#: ../src/common/paper.cpp:116
+#: ../src/common/paper.cpp:113
 msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
 msgstr "#9 Plic, 3 7/8 x 8 7/8 in"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:341
 #: ../src/richtext/richtextsizepage.cpp:340
 #: ../src/richtext/richtextsizepage.cpp:374
 #: ../src/richtext/richtextsizepage.cpp:401
@@ -108,20 +134,21 @@ msgstr "#9 Plic, 3 7/8 x 8 7/8 in"
 #: ../src/richtext/richtextsizepage.cpp:591
 #: ../src/richtext/richtextsizepage.cpp:626
 #: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextbackgroundpage.cpp:341
 msgid "%"
 msgstr "%"
 
-#: ../src/html/helpwnd.cpp:1031
+#: ../src/html/helpwnd.cpp:1029
 #, c-format
 msgid "%d of %lu"
 msgstr "%d din %lu"
 
-#: ../src/html/helpwnd.cpp:1678
+#: ../src/html/helpwnd.cpp:1676
 #, fuzzy, c-format
 msgid "%i of %u"
 msgstr "%i din %i"
 
-#: ../src/generic/filectrlg.cpp:279
+#: ../src/generic/filectrlg.cpp:275
 #, c-format
 msgid "%ld byte"
 msgid_plural "%ld bytes"
@@ -129,61 +156,61 @@ msgstr[0] "%ld byte"
 msgstr[1] "%ld byte-i"
 msgstr[2] "%ld byte-i"
 
-#: ../src/html/helpwnd.cpp:1033
+#: ../src/html/helpwnd.cpp:1031
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu din %lu"
 
-#: ../src/generic/datavgen.cpp:6028
+#: ../src/generic/datavgen.cpp:6833
 #, fuzzy, c-format
 msgid "%s (%d items)"
 msgstr "%s (sau %s)"
 
-#: ../src/common/cmdline.cpp:1221
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (sau %s)"
 
-#: ../src/generic/logg.cpp:224
+#: ../src/generic/logg.cpp:221
 #, c-format
 msgid "%s Error"
 msgstr "%s Eroare"
 
-#: ../src/generic/logg.cpp:236
+#: ../src/generic/logg.cpp:233
 #, c-format
 msgid "%s Information"
 msgstr "%s Informație"
 
-#: ../src/generic/preferencesg.cpp:113
+#: ../src/generic/preferencesg.cpp:110
 #, c-format
 msgid "%s Preferences"
 msgstr "%s, Preferințe"
 
-#: ../src/generic/logg.cpp:228
+#: ../src/generic/logg.cpp:225
 #, c-format
 msgid "%s Warning"
 msgstr "%s Avertizare"
 
-#: ../src/common/tarstrm.cpp:1319
+#: ../src/common/tarstrm.cpp:1313
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s nu a corespuns antetului tar pentru înregistrarea '%s'"
 
-#: ../src/common/fldlgcmn.cpp:124
+#: ../src/common/fldlgcmn.cpp:121
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "fișiere %s (%s)|%s"
 
-#: ../src/html/helpwnd.cpp:1716
+#: ../src/html/helpwnd.cpp:1714
 #, fuzzy, c-format
 msgid "%u of %u"
 msgstr "%lu din %lu"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "&About"
 msgstr "&Despre"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "&Actual Size"
 msgstr "Dimensiune re&ală"
 
@@ -191,28 +218,28 @@ msgstr "Dimensiune re&ală"
 msgid "&After a paragraph:"
 msgstr "&După un paragraf:"
 
-#: ../src/richtext/richtextindentspage.cpp:128
 #: ../src/richtext/richtextliststylepage.cpp:319
+#: ../src/richtext/richtextindentspage.cpp:128
 msgid "&Alignment"
 msgstr "&Aliniere"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "&Apply"
 msgstr "&Aplică"
 
-#: ../src/richtext/richtextstyledlg.cpp:251
+#: ../src/richtext/richtextstyledlg.cpp:247
 msgid "&Apply Style"
 msgstr "&Aplică stil"
 
-#: ../src/msw/mdi.cpp:179
+#: ../src/msw/mdi.cpp:174
 msgid "&Arrange Icons"
 msgstr "&Aranjează pictograme"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "&Ascending"
 msgstr "&Crescător"
 
-#: ../src/common/stockitem.cpp:142
+#: ../src/common/stockitem.cpp:139
 msgid "&Back"
 msgstr "Î&napoi"
 
@@ -232,24 +259,24 @@ msgstr "&Fundal:"
 msgid "&Blur distance:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:143
+#: ../src/common/stockitem.cpp:140
 msgid "&Bold"
 msgstr "În&groșat"
 
-#: ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141
 msgid "&Bottom"
 msgstr "&Jos"
 
+#: ../src/richtext/richtextsizepage.cpp:637
+#: ../src/richtext/richtextsizepage.cpp:644
 #: ../src/richtext/richtextborderspage.cpp:345
 #: ../src/richtext/richtextborderspage.cpp:513
 #: ../src/richtext/richtextmarginspage.cpp:259
 #: ../src/richtext/richtextmarginspage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:637
-#: ../src/richtext/richtextsizepage.cpp:644
 msgid "&Bottom:"
 msgstr "&Jos:"
 
-#: ../include/wx/richtext/richtextbuffer.h:3866
+#: ../include/wx/richtext/richtextbuffer.h:3861
 msgid "&Box"
 msgstr "&Casetă"
 
@@ -258,38 +285,38 @@ msgstr "&Casetă"
 msgid "&Bullet style:"
 msgstr "Stil &marcator:"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "&CD-Rom"
 msgstr "&CD-Rom"
 
-#: ../src/generic/wizard.cpp:434 ../src/generic/fontdlgg.cpp:470
-#: ../src/generic/fontdlgg.cpp:489 ../src/osx/carbon/fontdlg.cpp:402
-#: ../src/common/dlgcmn.cpp:279 ../src/common/stockitem.cpp:145
+#: ../src/osx/carbon/fontdlg.cpp:399 ../src/common/stockitem.cpp:142
+#: ../src/generic/wizard.cpp:433 ../src/generic/fontdlgg.cpp:466
+#: ../src/generic/fontdlgg.cpp:485 ../src/osx/cocoa/button.mm:200
 msgid "&Cancel"
 msgstr "&Renunță"
 
-#: ../src/msw/mdi.cpp:175
+#: ../src/msw/mdi.cpp:170
 msgid "&Cascade"
 msgstr "&Cascadă"
 
-#: ../include/wx/richtext/richtextbuffer.h:5960
+#: ../include/wx/richtext/richtextbuffer.h:5955
 msgid "&Cell"
 msgstr "&Celulă"
 
-#: ../src/richtext/richtextsymboldlg.cpp:439
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "&Character code:"
 msgstr "&Cod caracter:"
 
-#: ../src/common/stockitem.cpp:147
+#: ../src/common/stockitem.cpp:144
 msgid "&Clear"
 msgstr "&Curăță"
 
-#: ../src/generic/logg.cpp:516 ../src/common/stockitem.cpp:148
-#: ../src/common/prntbase.cpp:1600 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/stockitem.cpp:145 ../src/common/prntbase.cpp:1625
+#: ../src/univ/themes/win32.cpp:3753 ../src/generic/logg.cpp:513
 msgid "&Close"
 msgstr "În&chide"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "&Color"
 msgstr "&Culoare"
 
@@ -297,20 +324,20 @@ msgstr "&Culoare"
 msgid "&Colour:"
 msgstr "&Culoare:"
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "&Convert"
 msgstr "&Transformă"
 
-#: ../src/richtext/richtextctrl.cpp:333 ../src/osx/textctrl_osx.cpp:577
-#: ../src/common/stockitem.cpp:150 ../src/msw/textctrl.cpp:2508
+#: ../src/osx/textctrl_osx.cpp:595 ../src/common/stockitem.cpp:147
+#: ../src/msw/textctrl.cpp:2773 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Copiază"
 
-#: ../src/generic/hyperlinkg.cpp:156
+#: ../src/generic/hyperlinkg.cpp:153
 msgid "&Copy URL"
 msgstr "&Copiază URL"
 
-#: ../src/common/headerctrlcmn.cpp:306
+#: ../src/common/headerctrlcmn.cpp:304
 msgid "&Customize..."
 msgstr "&Personalizează..."
 
@@ -318,53 +345,54 @@ msgstr "&Personalizează..."
 msgid "&Debug report preview:"
 msgstr "Previzualizare raport de &depanare (debug):"
 
-#: ../src/richtext/richtexttabspage.cpp:138
-#: ../src/richtext/richtextctrl.cpp:335 ../src/osx/textctrl_osx.cpp:579
-#: ../src/common/stockitem.cpp:152 ../src/msw/textctrl.cpp:2510
+#: ../src/osx/textctrl_osx.cpp:597 ../src/common/stockitem.cpp:149
+#: ../src/msw/textctrl.cpp:2775 ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtextctrl.cpp:334
 msgid "&Delete"
 msgstr "Ște&rge"
 
-#: ../src/richtext/richtextstyledlg.cpp:269
+#: ../src/richtext/richtextstyledlg.cpp:265
 msgid "&Delete Style..."
 msgstr "Ște&rge Stil..."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "&Descending"
 msgstr "&Descrescător"
 
-#: ../src/generic/logg.cpp:682
+#: ../src/generic/logg.cpp:679
 msgid "&Details"
 msgstr "&Detalii"
 
-#: ../src/common/stockitem.cpp:153
+#: ../src/common/stockitem.cpp:150
 msgid "&Down"
 msgstr "&Jos"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "&Edit"
 msgstr "&Editează"
 
-#: ../src/richtext/richtextstyledlg.cpp:263
+#: ../src/richtext/richtextstyledlg.cpp:259
 msgid "&Edit Style..."
 msgstr "&Editează Stil..."
 
-#: ../src/common/stockitem.cpp:155
+#: ../src/common/stockitem.cpp:152
 msgid "&Execute"
 msgstr "&Execută"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/common/stockitem.cpp:154
 msgid "&File"
 msgstr "&Fișier"
 
-#: ../src/common/stockitem.cpp:158
-msgid "&Find"
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "&Find..."
 msgstr "&Caută"
 
-#: ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:430
 msgid "&Finish"
 msgstr "&Termină"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:156
 msgid "&First"
 msgstr "&Primul"
 
@@ -372,15 +400,15 @@ msgstr "&Primul"
 msgid "&Floating mode:"
 msgstr "&Mod mișcare:"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "&Floppy"
 msgstr "&Dischetă"
 
-#: ../src/common/stockitem.cpp:194
+#: ../src/common/stockitem.cpp:191
 msgid "&Font"
 msgstr "&Font"
 
-#: ../src/generic/fontdlgg.cpp:371
+#: ../src/generic/fontdlgg.cpp:367
 msgid "&Font family:"
 msgstr "&Familie font:"
 
@@ -388,20 +416,20 @@ msgstr "&Familie font:"
 msgid "&Font for Level..."
 msgstr "&Font pentru Nivelul..."
 
+#: ../src/richtext/richtextsymboldlg.cpp:397
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:400
 msgid "&Font:"
 msgstr "&Font:"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "&Forward"
 msgstr "În&ainte"
 
-#: ../src/richtext/richtextsymboldlg.cpp:451
+#: ../src/richtext/richtextsymboldlg.cpp:448
 msgid "&From:"
 msgstr "&De la:"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "&Harddisk"
 msgstr "&Harddisk"
 
@@ -410,9 +438,9 @@ msgstr "&Harddisk"
 msgid "&Height:"
 msgstr "Î&nălțime:"
 
-#: ../src/generic/wizard.cpp:441 ../src/richtext/richtextstyledlg.cpp:303
-#: ../src/richtext/richtextsymboldlg.cpp:479 ../src/osx/menu_osx.cpp:734
-#: ../src/common/stockitem.cpp:163
+#: ../src/common/stockitem.cpp:160 ../src/generic/wizard.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextstyledlg.cpp:299 ../src/osx/cocoa/menu.mm:226
 msgid "&Help"
 msgstr "&Ajutor"
 
@@ -420,7 +448,7 @@ msgstr "&Ajutor"
 msgid "&Hide details"
 msgstr "&Ascunde detalii"
 
-#: ../src/common/stockitem.cpp:164
+#: ../src/common/stockitem.cpp:161
 msgid "&Home"
 msgstr "&Acasă"
 
@@ -428,54 +456,54 @@ msgstr "&Acasă"
 msgid "&Horizontal offset:"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:184
 #: ../src/richtext/richtextliststylepage.cpp:372
+#: ../src/richtext/richtextindentspage.cpp:184
 msgid "&Indentation (tenths of a mm)"
 msgstr "&Indent (zecimi de mm)"
 
-#: ../src/richtext/richtextindentspage.cpp:167
 #: ../src/richtext/richtextliststylepage.cpp:356
+#: ../src/richtext/richtextindentspage.cpp:167
 msgid "&Indeterminate"
 msgstr "&Nedeterminat"
 
-#: ../src/common/stockitem.cpp:166
+#: ../src/common/stockitem.cpp:163
 msgid "&Index"
 msgstr "&Index"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "&Info"
 msgstr "&Info"
 
-#: ../src/common/stockitem.cpp:168
+#: ../src/common/stockitem.cpp:165
 msgid "&Italic"
 msgstr "Curs&iv"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "&Jump to"
 msgstr "&Mergi la"
 
-#: ../src/richtext/richtextindentspage.cpp:153
 #: ../src/richtext/richtextliststylepage.cpp:342
+#: ../src/richtext/richtextindentspage.cpp:153
 msgid "&Justified"
 msgstr "&Aliniat la margini"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "&Last"
 msgstr "&Ultimul"
 
-#: ../src/richtext/richtextindentspage.cpp:139
 #: ../src/richtext/richtextliststylepage.cpp:328
+#: ../src/richtext/richtextindentspage.cpp:139
 msgid "&Left"
 msgstr "&Stânga"
 
-#: ../src/richtext/richtextindentspage.cpp:195
+#: ../src/richtext/richtextsizepage.cpp:532
+#: ../src/richtext/richtextsizepage.cpp:539
 #: ../src/richtext/richtextborderspage.cpp:243
 #: ../src/richtext/richtextborderspage.cpp:411
 #: ../src/richtext/richtextliststylepage.cpp:381
+#: ../src/richtext/richtextindentspage.cpp:195
 #: ../src/richtext/richtextmarginspage.cpp:186
 #: ../src/richtext/richtextmarginspage.cpp:300
-#: ../src/richtext/richtextsizepage.cpp:532
-#: ../src/richtext/richtextsizepage.cpp:539
 msgid "&Left:"
 msgstr "&Stânga:"
 
@@ -483,11 +511,11 @@ msgstr "&Stânga:"
 msgid "&List level:"
 msgstr "Nivel &listă"
 
-#: ../src/generic/logg.cpp:517
+#: ../src/generic/logg.cpp:514
 msgid "&Log"
 msgstr "&Jurnal"
 
-#: ../src/univ/themes/win32.cpp:3748
+#: ../src/univ/themes/win32.cpp:3745
 msgid "&Move"
 msgstr "&Mută"
 
@@ -495,20 +523,19 @@ msgstr "&Mută"
 msgid "&Move the object to:"
 msgstr "&Mută obiectul în:"
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "&Network"
 msgstr "&Rețea"
 
-#: ../src/richtext/richtexttabspage.cpp:132 ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173 ../src/richtext/richtexttabspage.cpp:132
 msgid "&New"
 msgstr "&Nou"
 
-#: ../src/aui/tabmdi.cpp:111 ../src/generic/mdig.cpp:100
-#: ../src/msw/mdi.cpp:180
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
 msgid "&Next"
 msgstr "&Următor"
 
-#: ../src/generic/wizard.cpp:432 ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:429
 msgid "&Next >"
 msgstr "&Următor >"
 
@@ -516,7 +543,7 @@ msgstr "&Următor >"
 msgid "&Next Paragraph"
 msgstr "&Paragraful următor:"
 
-#: ../src/generic/tipdlg.cpp:240
+#: ../src/generic/tipdlg.cpp:237
 msgid "&Next Tip"
 msgstr "Sfatul &următor"
 
@@ -524,11 +551,11 @@ msgstr "Sfatul &următor"
 msgid "&Next style:"
 msgstr "Stilul &următor:"
 
-#: ../src/common/stockitem.cpp:177 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:174 ../src/msw/msgdlg.cpp:435
 msgid "&No"
 msgstr "&Nu"
 
-#: ../src/generic/dbgrptg.cpp:356
+#: ../src/generic/dbgrptg.cpp:360
 msgid "&Notes:"
 msgstr "&Note:"
 
@@ -536,12 +563,12 @@ msgstr "&Note:"
 msgid "&Number:"
 msgstr "&Număr:"
 
-#: ../src/generic/fontdlgg.cpp:475 ../src/generic/fontdlgg.cpp:482
-#: ../src/osx/carbon/fontdlg.cpp:408 ../src/common/stockitem.cpp:178
+#: ../src/osx/carbon/fontdlg.cpp:405 ../src/common/stockitem.cpp:175
+#: ../src/generic/fontdlgg.cpp:471 ../src/generic/fontdlgg.cpp:478
 msgid "&OK"
 msgstr "&OK"
 
-#: ../src/generic/dbgrptg.cpp:342 ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176 ../src/generic/dbgrptg.cpp:342
 msgid "&Open..."
 msgstr "&Deschide..."
 
@@ -553,16 +580,16 @@ msgstr "Nivel &delimitare:"
 msgid "&Page Break"
 msgstr "Întrerupere de &pagină"
 
-#: ../src/richtext/richtextctrl.cpp:334 ../src/osx/textctrl_osx.cpp:578
-#: ../src/common/stockitem.cpp:180 ../src/msw/textctrl.cpp:2509
+#: ../src/osx/textctrl_osx.cpp:596 ../src/common/stockitem.cpp:177
+#: ../src/msw/textctrl.cpp:2774 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "Li&pește"
 
-#: ../include/wx/richtext/richtextbuffer.h:5010
+#: ../include/wx/richtext/richtextbuffer.h:5005
 msgid "&Picture"
 msgstr "&Imagine"
 
-#: ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:419
 msgid "&Point size:"
 msgstr "Dimensiune în &puncte:"
 
@@ -574,12 +601,11 @@ msgstr "&Poziție (zecimi de mm):"
 msgid "&Position mode:"
 msgstr "&Mode de poziționare"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178
 msgid "&Preferences"
 msgstr "&Preferințe"
 
-#: ../src/aui/tabmdi.cpp:112 ../src/generic/mdig.cpp:101
-#: ../src/msw/mdi.cpp:181
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
 msgid "&Previous"
 msgstr "&Anterior"
 
@@ -587,78 +613,74 @@ msgstr "&Anterior"
 msgid "&Previous Paragraph"
 msgstr "&Paragraful anterior"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "&Print..."
 msgstr "Ti&părește..."
 
-#: ../src/richtext/richtextctrl.cpp:339 ../src/richtext/richtextctrl.cpp:5514
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtextctrl.cpp:338
+#: ../src/richtext/richtextctrl.cpp:5512
 msgid "&Properties"
 msgstr "&Proprietăți"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "&Quit"
 msgstr "&Ieșire"
 
-#: ../src/richtext/richtextctrl.cpp:330 ../src/osx/textctrl_osx.cpp:574
-#: ../src/common/stockitem.cpp:185 ../src/common/cmdproc.cpp:293
-#: ../src/common/cmdproc.cpp:300 ../src/msw/textctrl.cpp:2505
+#: ../src/osx/textctrl_osx.cpp:592 ../src/common/stockitem.cpp:182
+#: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
+#: ../src/msw/textctrl.cpp:2770 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Repetă acțiune"
 
-#: ../src/common/cmdproc.cpp:289 ../src/common/cmdproc.cpp:309
+#: ../src/common/cmdproc.cpp:282 ../src/common/cmdproc.cpp:302
 msgid "&Redo "
 msgstr "&Repetă acțiunea "
 
-#: ../src/richtext/richtextstyledlg.cpp:257
+#: ../src/richtext/richtextstyledlg.cpp:253
 msgid "&Rename Style..."
 msgstr "&Redenumește stil..."
 
-#: ../src/generic/fdrepdlg.cpp:179
+#: ../src/generic/fdrepdlg.cpp:176
 msgid "&Replace"
 msgstr "Înl&ocuiește"
 
-#: ../src/richtext/richtextstyledlg.cpp:287
+#: ../src/richtext/richtextstyledlg.cpp:283
 msgid "&Restart numbering"
 msgstr "&Reîncepe numerotarea"
 
-#: ../src/univ/themes/win32.cpp:3747
+#: ../src/univ/themes/win32.cpp:3744
 msgid "&Restore"
 msgstr "&Restaurează"
 
-#: ../src/richtext/richtextindentspage.cpp:146
 #: ../src/richtext/richtextliststylepage.cpp:335
+#: ../src/richtext/richtextindentspage.cpp:146
 msgid "&Right"
 msgstr "&Dreapta"
 
-#: ../src/richtext/richtextindentspage.cpp:213
+#: ../src/richtext/richtextsizepage.cpp:602
+#: ../src/richtext/richtextsizepage.cpp:609
 #: ../src/richtext/richtextborderspage.cpp:277
 #: ../src/richtext/richtextborderspage.cpp:445
 #: ../src/richtext/richtextliststylepage.cpp:399
+#: ../src/richtext/richtextindentspage.cpp:213
 #: ../src/richtext/richtextmarginspage.cpp:211
 #: ../src/richtext/richtextmarginspage.cpp:325
-#: ../src/richtext/richtextsizepage.cpp:602
-#: ../src/richtext/richtextsizepage.cpp:609
 msgid "&Right:"
 msgstr "&Dreapta:"
 
-#: ../src/common/stockitem.cpp:190
+#: ../src/common/stockitem.cpp:187
 msgid "&Save"
 msgstr "&Salvează"
-
-#: ../src/common/stockitem.cpp:191
-msgid "&Save as"
-msgstr "&Salvează ca"
 
 #: ../include/wx/richmsgdlg.h:29
 msgid "&See details"
 msgstr "&Vezi detalii"
 
-#: ../src/generic/tipdlg.cpp:236
+#: ../src/generic/tipdlg.cpp:233
 msgid "&Show tips at startup"
 msgstr "Arată &sfaturi la pornire"
 
-#: ../src/univ/themes/win32.cpp:3750
+#: ../src/univ/themes/win32.cpp:3747
 msgid "&Size"
 msgstr "Dimen&siune"
 
@@ -666,36 +688,36 @@ msgstr "Dimen&siune"
 msgid "&Size:"
 msgstr "Dimen&siune:"
 
-#: ../src/generic/progdlgg.cpp:252
+#: ../src/generic/progdlgg.cpp:249
 msgid "&Skip"
 msgstr "&Omite"
 
-#: ../src/richtext/richtextindentspage.cpp:242
 #: ../src/richtext/richtextliststylepage.cpp:417
+#: ../src/richtext/richtextindentspage.cpp:242
 msgid "&Spacing (tenths of a mm)"
 msgstr "&Spațiere (zecimi de mm)"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "&Spell Check"
 msgstr "&Verificare ortografie"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "&Stop"
 msgstr "&Stop"
 
-#: ../src/richtext/richtextfontpage.cpp:275 ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196 ../src/richtext/richtextfontpage.cpp:275
 msgid "&Strikethrough"
 msgstr "&Tăiat cu o linie"
 
-#: ../src/generic/fontdlgg.cpp:382 ../src/richtext/richtextstylepage.cpp:106
+#: ../src/generic/fontdlgg.cpp:378 ../src/richtext/richtextstylepage.cpp:106
 msgid "&Style:"
 msgstr "&Stil:"
 
-#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:194
 msgid "&Styles:"
 msgstr "&Stiluri:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:413
+#: ../src/richtext/richtextsymboldlg.cpp:410
 msgid "&Subset:"
 msgstr "&Subset:"
 
@@ -709,24 +731,24 @@ msgstr "&Simbol:"
 msgid "&Synchronize values"
 msgstr "&Sincronizează valorile"
 
-#: ../include/wx/richtext/richtextbuffer.h:6069
+#: ../include/wx/richtext/richtextbuffer.h:6064
 msgid "&Table"
 msgstr "&Tabela"
 
-#: ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197
 msgid "&Top"
 msgstr "&Sus"
 
+#: ../src/richtext/richtextsizepage.cpp:567
+#: ../src/richtext/richtextsizepage.cpp:574
 #: ../src/richtext/richtextborderspage.cpp:311
 #: ../src/richtext/richtextborderspage.cpp:479
 #: ../src/richtext/richtextmarginspage.cpp:234
 #: ../src/richtext/richtextmarginspage.cpp:348
-#: ../src/richtext/richtextsizepage.cpp:567
-#: ../src/richtext/richtextsizepage.cpp:574
 msgid "&Top:"
 msgstr "&Sus:"
 
-#: ../src/generic/fontdlgg.cpp:444 ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199 ../src/generic/fontdlgg.cpp:441
 msgid "&Underline"
 msgstr "S&ubliniat"
 
@@ -734,21 +756,21 @@ msgstr "S&ubliniat"
 msgid "&Underlining:"
 msgstr "S&ubliniere:"
 
-#: ../src/richtext/richtextctrl.cpp:329 ../src/osx/textctrl_osx.cpp:573
-#: ../src/common/stockitem.cpp:203 ../src/common/cmdproc.cpp:271
-#: ../src/msw/textctrl.cpp:2504
+#: ../src/osx/textctrl_osx.cpp:591 ../src/common/stockitem.cpp:200
+#: ../src/common/cmdproc.cpp:264 ../src/msw/textctrl.cpp:2769
+#: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "An&ulează acțiune"
 
-#: ../src/common/cmdproc.cpp:265
+#: ../src/common/cmdproc.cpp:258
 msgid "&Undo "
 msgstr "An&ulează acțiunea "
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "&Unindent"
 msgstr "An&ulează indentare"
 
-#: ../src/common/stockitem.cpp:205
+#: ../src/common/stockitem.cpp:202
 msgid "&Up"
 msgstr "S&us"
 
@@ -765,7 +787,7 @@ msgstr "&Aliniere verticală:"
 msgid "&View..."
 msgstr "&Vizualizare..."
 
-#: ../src/generic/fontdlgg.cpp:393
+#: ../src/generic/fontdlgg.cpp:389
 msgid "&Weight:"
 msgstr "&Greutate:"
 
@@ -774,88 +796,58 @@ msgstr "&Greutate:"
 msgid "&Width:"
 msgstr "&Lățime:"
 
-#: ../src/aui/tabmdi.cpp:311 ../src/aui/tabmdi.cpp:327
-#: ../src/aui/tabmdi.cpp:329 ../src/generic/mdig.cpp:294
-#: ../src/generic/mdig.cpp:310 ../src/generic/mdig.cpp:314
-#: ../src/msw/mdi.cpp:78
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
 msgid "&Window"
 msgstr "&Fereastră"
 
-#: ../src/common/stockitem.cpp:206 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:203 ../src/msw/msgdlg.cpp:435
 msgid "&Yes"
 msgstr "&Da"
 
-#: ../src/common/valtext.cpp:256
-#, c-format
-msgid "'%s' contains illegal characters"
+#: ../src/common/valtext.cpp:197
+#, fuzzy, c-format
+msgid "'%s' contains invalid character(s)"
 msgstr "'%s' conține caractere nepermise"
 
-#: ../src/common/valtext.cpp:254
-#, c-format
-msgid "'%s' doesn't consist only of valid characters"
-msgstr "'%s' nu conține numai caractere valide"
-
-#: ../src/common/config.cpp:519 ../src/msw/regconf.cpp:258
+#: ../src/common/config.cpp:515 ../src/msw/regconf.cpp:255
 #, c-format
 msgid "'%s' has extra '..', ignored."
 msgstr "'%s' are mai multe caractere '..', sunt ignorate."
 
-#: ../src/common/cmdline.cpp:1113 ../src/common/cmdline.cpp:1131
+#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' este o valoare numerică incorectă pentru opțiunea '%s'."
 
-#: ../src/common/translation.cpp:1100
+#: ../src/common/translation.cpp:1142
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' nu este un catalog de mesaje valid."
 
-#: ../src/common/valtext.cpp:165
+#: ../src/common/valtext.cpp:188
 #, c-format
 msgid "'%s' is not one of the valid strings"
 msgstr "'%s' nu este unul dintre șirurile de caractere valide."
 
-#: ../src/common/valtext.cpp:167
+#: ../src/common/valtext.cpp:186
 #, c-format
 msgid "'%s' is one of the invalid strings"
 msgstr "'%s' este unul dintre șirurile de caractere invalide"
 
-#: ../src/common/textbuf.cpp:237
+#: ../src/common/textbuf.cpp:233
 #, c-format
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' este probabil un buffer binar."
-
-#: ../src/common/valtext.cpp:252
-#, c-format
-msgid "'%s' should be numeric."
-msgstr "'%s' ar trebui să fie număr."
-
-#: ../src/common/valtext.cpp:244
-#, c-format
-msgid "'%s' should only contain ASCII characters."
-msgstr "'%s' ar trebui să conțină doar caractere ASCII."
-
-#: ../src/common/valtext.cpp:246
-#, c-format
-msgid "'%s' should only contain alphabetic characters."
-msgstr "'%s' ar trebui să conțină doar caractere alfabetice."
-
-#: ../src/common/valtext.cpp:248
-#, c-format
-msgid "'%s' should only contain alphabetic or numeric characters."
-msgstr "'%s' ar trebui să conțină doar caractere alfabetice sau numerice."
-
-#: ../src/common/valtext.cpp:250
-#, c-format
-msgid "'%s' should only contain digits."
-msgstr "'%s' ar trebui să conțină doar cifre."
 
 #: ../src/richtext/richtextliststylepage.cpp:229
 #: ../src/richtext/richtextbulletspage.cpp:166
 msgid "(*)"
 msgstr "(*)"
 
-#: ../src/html/helpwnd.cpp:963
+#: ../src/html/helpwnd.cpp:961
 msgid "(Help)"
 msgstr "(Ajutor)"
 
@@ -864,27 +856,32 @@ msgstr "(Ajutor)"
 msgid "(None)"
 msgstr "(Nimic)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:504
+#: ../src/richtext/richtextsymboldlg.cpp:503
 msgid "(Normal text)"
 msgstr "(Text normal)"
 
-#: ../src/html/helpwnd.cpp:419 ../src/html/helpwnd.cpp:1106
-#: ../src/html/helpwnd.cpp:1742
+#: ../src/html/helpwnd.cpp:417 ../src/html/helpwnd.cpp:1104
+#: ../src/html/helpwnd.cpp:1740
 msgid "(bookmarks)"
 msgstr "(însemne)"
 
+#: ../src/msw/dlmsw.cpp:167
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (eroarea %ld: %s)"
+
+#: ../src/richtext/richtextformatdlg.cpp:876
+#: ../src/richtext/richtextliststylepage.cpp:448
+#: ../src/richtext/richtextliststylepage.cpp:460
+#: ../src/richtext/richtextliststylepage.cpp:461
 #: ../src/richtext/richtextindentspage.cpp:274
 #: ../src/richtext/richtextindentspage.cpp:286
 #: ../src/richtext/richtextindentspage.cpp:287
 #: ../src/richtext/richtextindentspage.cpp:311
 #: ../src/richtext/richtextindentspage.cpp:326
-#: ../src/richtext/richtextformatdlg.cpp:884
 #: ../src/richtext/richtextfontpage.cpp:349
 #: ../src/richtext/richtextfontpage.cpp:353
 #: ../src/richtext/richtextfontpage.cpp:357
-#: ../src/richtext/richtextliststylepage.cpp:448
-#: ../src/richtext/richtextliststylepage.cpp:460
-#: ../src/richtext/richtextliststylepage.cpp:461
 msgid "(none)"
 msgstr "(nimic)"
 
@@ -903,7 +900,7 @@ msgstr "*)"
 msgid "+"
 msgstr "+"
 
-#: ../src/msw/utils.cpp:1152
+#: ../src/msw/utils.cpp:1143
 msgid ", 64-bit edition"
 msgstr ", ediție 64-bit"
 
@@ -912,163 +909,163 @@ msgstr ", ediție 64-bit"
 msgid "-"
 msgstr "-"
 
-#: ../src/generic/filepickerg.cpp:66
+#: ../src/generic/filepickerg.cpp:63
 msgid "..."
 msgstr "..."
 
-#: ../src/richtext/richtextindentspage.cpp:276
 #: ../src/richtext/richtextliststylepage.cpp:450
+#: ../src/richtext/richtextindentspage.cpp:276
 msgid "1.1"
 msgstr "1.1"
 
-#: ../src/richtext/richtextindentspage.cpp:277
 #: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextindentspage.cpp:277
 msgid "1.2"
 msgstr "1.2"
 
-#: ../src/richtext/richtextindentspage.cpp:278
 #: ../src/richtext/richtextliststylepage.cpp:452
+#: ../src/richtext/richtextindentspage.cpp:278
 msgid "1.3"
 msgstr "1.3"
 
-#: ../src/richtext/richtextindentspage.cpp:279
 #: ../src/richtext/richtextliststylepage.cpp:453
+#: ../src/richtext/richtextindentspage.cpp:279
 msgid "1.4"
 msgstr "1.4"
 
-#: ../src/richtext/richtextindentspage.cpp:280
 #: ../src/richtext/richtextliststylepage.cpp:454
+#: ../src/richtext/richtextindentspage.cpp:280
 msgid "1.5"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:281
 #: ../src/richtext/richtextliststylepage.cpp:455
+#: ../src/richtext/richtextindentspage.cpp:281
 msgid "1.6"
 msgstr "1.6"
 
-#: ../src/richtext/richtextindentspage.cpp:282
 #: ../src/richtext/richtextliststylepage.cpp:456
+#: ../src/richtext/richtextindentspage.cpp:282
 msgid "1.7"
 msgstr "1.7"
 
-#: ../src/richtext/richtextindentspage.cpp:283
 #: ../src/richtext/richtextliststylepage.cpp:457
+#: ../src/richtext/richtextindentspage.cpp:283
 msgid "1.8"
 msgstr "1.8"
 
-#: ../src/richtext/richtextindentspage.cpp:284
 #: ../src/richtext/richtextliststylepage.cpp:458
+#: ../src/richtext/richtextindentspage.cpp:284
 msgid "1.9"
 msgstr "1.9"
 
-#: ../src/common/paper.cpp:140
+#: ../src/common/paper.cpp:137
 msgid "10 x 11 in"
 msgstr "10 x 11 in"
 
-#: ../src/common/paper.cpp:113
+#: ../src/common/paper.cpp:110
 msgid "10 x 14 in"
 msgstr "10 x 14 in"
 
-#: ../src/common/paper.cpp:114
+#: ../src/common/paper.cpp:111
 msgid "11 x 17 in"
 msgstr "11 x 17 in"
 
-#: ../src/common/paper.cpp:184
+#: ../src/common/paper.cpp:181
 msgid "12 x 11 in"
 msgstr "12 x 11 in"
 
-#: ../src/common/paper.cpp:141
+#: ../src/common/paper.cpp:138
 msgid "15 x 11 in"
 msgstr "15 x 11 in"
 
-#: ../src/richtext/richtextindentspage.cpp:285
 #: ../src/richtext/richtextliststylepage.cpp:459
+#: ../src/richtext/richtextindentspage.cpp:285
 msgid "2"
 msgstr "2"
 
-#: ../src/common/paper.cpp:132
+#: ../src/common/paper.cpp:129
 msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
 msgstr "6 3/4 Plic, 3 5/8 x 6 1/2 in"
 
-#: ../src/common/paper.cpp:139
+#: ../src/common/paper.cpp:136
 msgid "9 x 11 in"
 msgstr "9 x 11 in"
 
-#: ../src/html/htmprint.cpp:431
+#: ../src/html/htmprint.cpp:443
 msgid ": file does not exist!"
 msgstr ": fișierul nu există!"
 
-#: ../src/common/fontmap.cpp:199
+#: ../src/common/fontmap.cpp:196
 msgid ": unknown charset"
 msgstr ": set de caractere necunoscut"
 
-#: ../src/common/fontmap.cpp:413
+#: ../src/common/fontmap.cpp:410
 msgid ": unknown encoding"
 msgstr ": codificare necunoscută"
 
-#: ../src/generic/wizard.cpp:443
+#: ../src/generic/wizard.cpp:438
 msgid "< &Back"
 msgstr "< Î&napoi"
 
-#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:628
-#: ../src/osx/carbon/fontdlg.cpp:648
+#: ../src/osx/carbon/fontdlg.cpp:419 ../src/osx/carbon/fontdlg.cpp:625
+#: ../src/osx/carbon/fontdlg.cpp:645
 msgid "<Any Decorative>"
 msgstr "<Oricare Decorativ>"
 
-#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:630
-#: ../src/osx/carbon/fontdlg.cpp:650
+#: ../src/osx/carbon/fontdlg.cpp:420 ../src/osx/carbon/fontdlg.cpp:627
+#: ../src/osx/carbon/fontdlg.cpp:647
 msgid "<Any Modern>"
 msgstr "<Oricare Modern>"
 
-#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:626
-#: ../src/osx/carbon/fontdlg.cpp:646
+#: ../src/osx/carbon/fontdlg.cpp:418 ../src/osx/carbon/fontdlg.cpp:623
+#: ../src/osx/carbon/fontdlg.cpp:643
 msgid "<Any Roman>"
 msgstr "<Oricare Roman>"
 
-#: ../src/osx/carbon/fontdlg.cpp:424 ../src/osx/carbon/fontdlg.cpp:632
-#: ../src/osx/carbon/fontdlg.cpp:652
+#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:629
+#: ../src/osx/carbon/fontdlg.cpp:649
 msgid "<Any Script>"
 msgstr "<Oricare Script>"
 
-#: ../src/osx/carbon/fontdlg.cpp:425 ../src/osx/carbon/fontdlg.cpp:637
-#: ../src/osx/carbon/fontdlg.cpp:656
+#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:634
+#: ../src/osx/carbon/fontdlg.cpp:653
 msgid "<Any Swiss>"
 msgstr "<Oricare Swiss>"
 
-#: ../src/osx/carbon/fontdlg.cpp:426 ../src/osx/carbon/fontdlg.cpp:634
-#: ../src/osx/carbon/fontdlg.cpp:654
+#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:631
+#: ../src/osx/carbon/fontdlg.cpp:651
 msgid "<Any Teletype>"
 msgstr "<Oricare Teletype>"
 
-#: ../src/osx/carbon/fontdlg.cpp:420
+#: ../src/osx/carbon/fontdlg.cpp:417
 msgid "<Any>"
 msgstr "<Oricare>"
 
-#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
 msgid "<DIR>"
 msgstr "<DIRECTOR>"
 
-#: ../src/generic/filectrlg.cpp:254 ../src/generic/filectrlg.cpp:277
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
 msgid "<DRIVE>"
 msgstr "<DISC>"
 
-#: ../src/generic/filectrlg.cpp:252 ../src/generic/filectrlg.cpp:275
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
 msgid "<LINK>"
 msgstr "<LEGĂTURĂ>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1264
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Îngroșat cursiv.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1270
+#: ../src/html/helpwnd.cpp:1268
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>îngroșat cursiv <u>subliniat</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1265
+#: ../src/html/helpwnd.cpp:1263
 msgid "<b>Bold face.</b> "
 msgstr "<b>Îngroșat.</b> "
 
-#: ../src/html/helpwnd.cpp:1264
+#: ../src/html/helpwnd.cpp:1262
 msgid "<i>Italic face.</i> "
 msgstr "<i>Cursiv.</i> "
 
@@ -1077,15 +1074,15 @@ msgstr "<i>Cursiv.</i> "
 msgid ">"
 msgstr ">"
 
-#: ../src/generic/dbgrptg.cpp:318
+#: ../src/generic/dbgrptg.cpp:317
 msgid "A debug report has been generated in the directory\n"
 msgstr "Un raport de depanare a fost generat în directorul\n"
 
-#: ../src/common/debugrpt.cpp:573
+#: ../src/common/debugrpt.cpp:574
 msgid "A debug report has been generated. It can be found in"
 msgstr "Un raport de depanare a fost generat. Poate fi găsit în"
 
-#: ../src/common/xtixml.cpp:418
+#: ../src/common/xtixml.cpp:414
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "O colecție care nu e goală trebuie să conțină noduri 'element'"
 
@@ -1096,106 +1093,106 @@ msgstr "O colecție care nu e goală trebuie să conțină noduri 'element'"
 msgid "A standard bullet name."
 msgstr "Un nume de marcator standard."
 
-#: ../src/common/paper.cpp:217
+#: ../src/common/paper.cpp:214
 msgid "A0 sheet, 841 x 1189 mm"
 msgstr "A0 foaie, 841 x 1189 mm"
 
-#: ../src/common/paper.cpp:218
+#: ../src/common/paper.cpp:215
 msgid "A1 sheet, 594 x 841 mm"
 msgstr "A1 foaie, 594 x 841 mm"
 
-#: ../src/common/paper.cpp:159
+#: ../src/common/paper.cpp:156
 msgid "A2 420 x 594 mm"
 msgstr "A2 420 x 594 mm"
 
-#: ../src/common/paper.cpp:156
+#: ../src/common/paper.cpp:153
 msgid "A3 Extra 322 x 445 mm"
 msgstr "A3 Extra 322 x 445 mm"
 
-#: ../src/common/paper.cpp:161
+#: ../src/common/paper.cpp:158
 msgid "A3 Extra Transverse 322 x 445 mm"
 msgstr "A3 Extra Transversal 322 x 445 mm"
 
-#: ../src/common/paper.cpp:170
+#: ../src/common/paper.cpp:167
 msgid "A3 Rotated 420 x 297 mm"
 msgstr "A3 Rotit 420 x 297 mm"
 
-#: ../src/common/paper.cpp:160
+#: ../src/common/paper.cpp:157
 msgid "A3 Transverse 297 x 420 mm"
 msgstr "A3 Transversal 297 x 420 mm"
 
-#: ../src/common/paper.cpp:106
+#: ../src/common/paper.cpp:103
 msgid "A3 sheet, 297 x 420 mm"
 msgstr "A3 foaie, 297 x 420 mm"
 
-#: ../src/common/paper.cpp:146
+#: ../src/common/paper.cpp:143
 msgid "A4 Extra 9.27 x 12.69 in"
 msgstr "A4 Extra 9.27 x 12.69 in"
 
-#: ../src/common/paper.cpp:153
+#: ../src/common/paper.cpp:150
 msgid "A4 Plus 210 x 330 mm"
 msgstr "A4 Plus 210 x 330 mm"
 
-#: ../src/common/paper.cpp:171
+#: ../src/common/paper.cpp:168
 msgid "A4 Rotated 297 x 210 mm"
 msgstr "A4 Rotit 297 x 210 mm"
 
-#: ../src/common/paper.cpp:148
+#: ../src/common/paper.cpp:145
 msgid "A4 Transverse 210 x 297 mm"
 msgstr "A4 Transversal 210 x 297 mm"
 
-#: ../src/common/paper.cpp:97
+#: ../src/common/paper.cpp:94
 msgid "A4 sheet, 210 x 297 mm"
 msgstr "A4 foaie, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:107
+#: ../src/common/paper.cpp:104
 msgid "A4 small sheet, 210 x 297 mm"
 msgstr "A4 foaie mică, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:157
+#: ../src/common/paper.cpp:154
 msgid "A5 Extra 174 x 235 mm"
 msgstr "A5 Extra 174 x 235 mm"
 
-#: ../src/common/paper.cpp:172
+#: ../src/common/paper.cpp:169
 msgid "A5 Rotated 210 x 148 mm"
 msgstr "A5 Rotit 210 x 148 mm"
 
-#: ../src/common/paper.cpp:154
+#: ../src/common/paper.cpp:151
 msgid "A5 Transverse 148 x 210 mm"
 msgstr "A5 Transversal 148 x 210 mm"
 
-#: ../src/common/paper.cpp:108
+#: ../src/common/paper.cpp:105
 msgid "A5 sheet, 148 x 210 mm"
 msgstr "A5 foaie, 148 x 210 mm"
 
-#: ../src/common/paper.cpp:164
+#: ../src/common/paper.cpp:161
 msgid "A6 105 x 148 mm"
 msgstr "A6 105 x 148 mm"
 
-#: ../src/common/paper.cpp:177
+#: ../src/common/paper.cpp:174
 msgid "A6 Rotated 148 x 105 mm"
 msgstr "A6 Rotit 148 x 105 mm"
 
-#: ../src/generic/fontdlgg.cpp:83 ../src/richtext/richtextformatdlg.cpp:529
-#: ../src/osx/carbon/fontdlg.cpp:153
+#: ../src/osx/carbon/fontdlg.cpp:150 ../src/generic/fontdlgg.cpp:79
+#: ../src/richtext/richtextformatdlg.cpp:521
 msgid "ABCDEFGabcdefg12345"
 msgstr "ABCDEFGabcdefg12345"
 
-#: ../src/richtext/richtextsymboldlg.cpp:458 ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
 msgid "ASCII"
 msgstr "ASCII"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "About"
 msgstr "Despre"
 
-#: ../src/generic/aboutdlgg.cpp:140 ../src/osx/menu_osx.cpp:558
-#: ../src/msw/aboutdlg.cpp:64
+#: ../src/osx/menu_osx.cpp:450 ../src/generic/aboutdlgg.cpp:137
+#: ../src/msw/aboutdlg.cpp:61
 #, c-format
 msgid "About %s"
 msgstr "Despre %s"
 
-#: ../src/osx/menu_osx.cpp:560
+#: ../src/osx/menu_osx.cpp:452
 msgid "About..."
 msgstr "Despre..."
 
@@ -1204,38 +1201,38 @@ msgid "Absolute"
 msgstr "Absolută"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:873
+#: ../src/propgrid/advprops.cpp:774
 #, fuzzy
 msgid "ActiveBorder"
 msgstr "Margine"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:874
+#: ../src/propgrid/advprops.cpp:775
 msgid "ActiveCaption"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "Actual Size"
 msgstr "Dimensiune reală"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:140 ../src/common/accelcmn.cpp:81
+#: ../src/common/stockitem.cpp:137 ../src/common/accelcmn.cpp:78
 msgid "Add"
 msgstr "Adaugă"
 
-#: ../src/richtext/richtextbuffer.cpp:11455
+#: ../src/richtext/richtextbuffer.cpp:11454
 msgid "Add Column"
 msgstr "Adaugă coloană"
 
-#: ../src/richtext/richtextbuffer.cpp:11392
+#: ../src/richtext/richtextbuffer.cpp:11391
 msgid "Add Row"
 msgstr "Adaugă rând"
 
-#: ../src/html/helpwnd.cpp:432
+#: ../src/html/helpwnd.cpp:430
 msgid "Add current page to bookmarks"
 msgstr "Adaugă pagina curentă la însemne"
 
-#: ../src/generic/colrdlgg.cpp:366
+#: ../src/generic/colrdlgg.cpp:386
 msgid "Add to custom colours"
 msgstr "Adaugă la culori personalizate"
 
@@ -1247,12 +1244,12 @@ msgstr "AddToPropertyCollection apelat pentru un accesor generic"
 msgid "AddToPropertyCollection called w/o valid adder"
 msgstr "AddToPropertyCollection apelat cu adder invalid"
 
-#: ../src/html/helpctrl.cpp:159
+#: ../src/html/helpctrl.cpp:155
 #, c-format
 msgid "Adding book %s"
 msgstr "Adaugă cartea %s"
 
-#: ../src/common/preferencescmn.cpp:43
+#: ../src/common/preferencescmn.cpp:40
 msgid "Advanced"
 msgstr "Avansat"
 
@@ -1260,11 +1257,11 @@ msgstr "Avansat"
 msgid "After a paragraph:"
 msgstr "După un paragraf:"
 
-#: ../src/common/stockitem.cpp:172
+#: ../src/common/stockitem.cpp:169
 msgid "Align Left"
 msgstr "Aliniază la stânga"
 
-#: ../src/common/stockitem.cpp:173
+#: ../src/common/stockitem.cpp:170
 msgid "Align Right"
 msgstr "Aliniază la dreapta"
 
@@ -1272,40 +1269,40 @@ msgstr "Aliniază la dreapta"
 msgid "Alignment"
 msgstr "Aliniere"
 
-#: ../src/generic/prntdlgg.cpp:215
+#: ../src/generic/prntdlgg.cpp:208
 msgid "All"
 msgstr "Tot"
 
-#: ../src/generic/filectrlg.cpp:1197 ../src/common/fldlgcmn.cpp:107
+#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1186
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Toate fișierele (%s)|%s"
 
-#: ../include/wx/defs.h:2886
+#: ../include/wx/defs.h:2582
 msgid "All files (*)|*"
 msgstr "Toate fișierele (*)|*"
 
-#: ../include/wx/defs.h:2883
+#: ../include/wx/defs.h:2579
 msgid "All files (*.*)|*.*"
 msgstr "Toate fișierele (*.*)|*.*"
 
-#: ../src/richtext/richtextstyles.cpp:1061
+#: ../src/richtext/richtextstyles.cpp:1058
 msgid "All styles"
 msgstr "Toate stilurile"
 
-#: ../src/propgrid/manager.cpp:1528
+#: ../src/propgrid/manager.cpp:1544
 msgid "Alphabetic Mode"
 msgstr "După  alfabet"
 
-#: ../src/common/xtistrm.cpp:425
+#: ../src/common/xtistrm.cpp:422
 msgid "Already Registered Object passed to SetObjectClassInfo"
 msgstr "Obiect deja înregistrat transmis către metoda SetObjectClassInfo"
 
-#: ../src/unix/dialup.cpp:353
+#: ../src/unix/dialup.cpp:352
 msgid "Already dialling ISP."
 msgstr "Deja se apelează ISP-ul."
 
-#: ../src/common/accelcmn.cpp:331 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/accelcmn.cpp:345 ../src/univ/themes/win32.cpp:3753
 msgid "Alt+"
 msgstr "Alt+"
 
@@ -1314,35 +1311,35 @@ msgstr "Alt+"
 msgid "An optional corner radius for adding rounded corners."
 msgstr "Rază optională pentru colțuri rotunjite."
 
-#: ../src/common/debugrpt.cpp:576
+#: ../src/common/debugrpt.cpp:577
 msgid "And includes the following files:\n"
 msgstr "Și include următoarele fișiere:\n"
 
-#: ../src/generic/animateg.cpp:162
+#: ../src/generic/animateg.cpp:145
 #, c-format
 msgid "Animation file is not of type %ld."
 msgstr "Fișierul de animație nu este de tipul %ld."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:872
+#: ../src/propgrid/advprops.cpp:773
 msgid "AppWorkspace"
 msgstr ""
 
-#: ../src/generic/logg.cpp:1014
+#: ../src/generic/logg.cpp:1011
 #, c-format
 msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
 msgstr ""
 "Să fie adăugat raportul la fișierul '%s' (alegând [Nu] îl va suprascrie)?"
 
-#: ../src/osx/menu_osx.cpp:577 ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:469 ../src/osx/menu_osx.cpp:477
 msgid "Application"
 msgstr "Aplicație"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "Apply"
 msgstr "Aplică"
 
-#: ../src/propgrid/advprops.cpp:1609
+#: ../src/propgrid/advprops.cpp:1515
 msgid "Aqua"
 msgstr ""
 
@@ -1351,30 +1348,30 @@ msgstr ""
 msgid "Arabic"
 msgstr "Arabă"
 
-#: ../src/common/fmapbase.cpp:153
+#: ../src/common/fmapbase.cpp:150
 msgid "Arabic (ISO-8859-6)"
 msgstr "Arabă (ISO-8859-6)"
 
-#: ../src/msw/ole/automtn.cpp:672
+#: ../src/msw/ole/automtn.cpp:663
 #, c-format
 msgid "Argument %u not found."
 msgstr "Argumentul %u nu a fost găsit."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1753
+#: ../src/propgrid/advprops.cpp:1654
 #, fuzzy
 msgid "Arrow"
 msgstr "mâine"
 
-#: ../src/generic/aboutdlgg.cpp:184
+#: ../src/generic/aboutdlgg.cpp:181
 msgid "Artists"
 msgstr "Artiști"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "Ascending"
 msgstr "Crescător"
 
-#: ../src/generic/filectrlg.cpp:433
+#: ../src/generic/filectrlg.cpp:429
 msgid "Attributes"
 msgstr "Atribute"
 
@@ -1384,90 +1381,90 @@ msgstr "Atribute"
 msgid "Available fonts."
 msgstr "Fonturi disponibile."
 
-#: ../src/common/paper.cpp:137
+#: ../src/common/paper.cpp:134
 msgid "B4 (ISO) 250 x 353 mm"
 msgstr "B4 (ISO) 250 x 353 mm"
 
-#: ../src/common/paper.cpp:173
+#: ../src/common/paper.cpp:170
 msgid "B4 (JIS) Rotated 364 x 257 mm"
 msgstr "B4 (JIS) Rotit 364 x 257 mm"
 
-#: ../src/common/paper.cpp:127
+#: ../src/common/paper.cpp:124
 msgid "B4 Envelope, 250 x 353 mm"
 msgstr "B4 Plic, 250 x 353 mm"
 
-#: ../src/common/paper.cpp:109
+#: ../src/common/paper.cpp:106
 msgid "B4 sheet, 250 x 354 mm"
 msgstr "B4 foaie, 250 x 354 mm"
 
-#: ../src/common/paper.cpp:158
+#: ../src/common/paper.cpp:155
 msgid "B5 (ISO) Extra 201 x 276 mm"
 msgstr "B5 (ISO) Extra 201 x 276 mm"
 
-#: ../src/common/paper.cpp:174
+#: ../src/common/paper.cpp:171
 msgid "B5 (JIS) Rotated 257 x 182 mm"
 msgstr "B5 (JIS) Rotit 257 x 182 mm"
 
-#: ../src/common/paper.cpp:155
+#: ../src/common/paper.cpp:152
 msgid "B5 (JIS) Transverse 182 x 257 mm"
 msgstr "B5 (JIS) Transversal 182 x 257 mm"
 
-#: ../src/common/paper.cpp:128
+#: ../src/common/paper.cpp:125
 msgid "B5 Envelope, 176 x 250 mm"
 msgstr "B5 Plic, 176 x 250 mm"
 
-#: ../src/common/paper.cpp:110
+#: ../src/common/paper.cpp:107
 msgid "B5 sheet, 182 x 257 millimeter"
 msgstr "B5 foaie, 182 x 257 milimetri"
 
-#: ../src/common/paper.cpp:182
+#: ../src/common/paper.cpp:179
 msgid "B6 (JIS) 128 x 182 mm"
 msgstr "B6 (JIS) 128 x 182 mm"
 
-#: ../src/common/paper.cpp:183
+#: ../src/common/paper.cpp:180
 msgid "B6 (JIS) Rotated 182 x 128 mm"
 msgstr "B6 (JIS) Rotit 182 x 128 mm"
 
-#: ../src/common/paper.cpp:129
+#: ../src/common/paper.cpp:126
 msgid "B6 Envelope, 176 x 125 mm"
 msgstr "B6 Plic, 176 x 125 mm"
 
-#: ../src/common/imagbmp.cpp:531 ../src/common/imagbmp.cpp:561
-#: ../src/common/imagbmp.cpp:576
+#: ../src/common/imagbmp.cpp:528 ../src/common/imagbmp.cpp:558
+#: ../src/common/imagbmp.cpp:573
 msgid "BMP: Couldn't allocate memory."
 msgstr "BMP: Nu a putut fi alocată memorie."
 
-#: ../src/common/imagbmp.cpp:100
+#: ../src/common/imagbmp.cpp:97
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: Nu a putut fi salvată imaginea invalidă."
 
-#: ../src/common/imagbmp.cpp:356
+#: ../src/common/imagbmp.cpp:353
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: Nu a putut fi scrisă harta RGB."
 
-#: ../src/common/imagbmp.cpp:490
+#: ../src/common/imagbmp.cpp:487
 msgid "BMP: Couldn't write data."
 msgstr "BMP: Nu au putut fi scrise datele."
 
-#: ../src/common/imagbmp.cpp:246
+#: ../src/common/imagbmp.cpp:243
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: Nu a putut fi scris antetul (Bitmap) fișierului."
 
-#: ../src/common/imagbmp.cpp:269
+#: ../src/common/imagbmp.cpp:266
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: Nu a putut fi scris antetul (BitmapInfo) fișierului."
 
-#: ../src/common/imagbmp.cpp:140
+#: ../src/common/imagbmp.cpp:137
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage nu are un obiect wxPalette propriu."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:142 ../src/common/accelcmn.cpp:52
+#: ../src/common/stockitem.cpp:139 ../src/common/accelcmn.cpp:49
 msgid "Back"
 msgstr "Înapoi"
 
+#: ../src/richtext/richtextformatdlg.cpp:377
 #: ../src/richtext/richtextbackgroundpage.cpp:148
-#: ../src/richtext/richtextformatdlg.cpp:384
 msgid "Background"
 msgstr "Fundal"
 
@@ -1475,21 +1472,21 @@ msgstr "Fundal"
 msgid "Background &colour:"
 msgstr "&Culoare de fundal:"
 
-#: ../src/osx/carbon/fontdlg.cpp:220
+#: ../src/osx/carbon/fontdlg.cpp:217
 msgid "Background colour"
 msgstr "Culoare de fundal"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:52
+#: ../src/common/accelcmn.cpp:49
 #, fuzzy
 msgid "Backspace"
 msgstr "Înapoi"
 
-#: ../src/common/fmapbase.cpp:160
+#: ../src/common/fmapbase.cpp:157
 msgid "Baltic (ISO-8859-13)"
 msgstr "Baltică (ISO-8859-13)"
 
-#: ../src/common/fmapbase.cpp:151
+#: ../src/common/fmapbase.cpp:148
 msgid "Baltic (old) (ISO-8859-4)"
 msgstr "Baltică (veche) (ISO-8859-4)"
 
@@ -1502,25 +1499,25 @@ msgstr "Înainte de un paragraf:"
 msgid "Bitmap"
 msgstr "Imagine rastru"
 
-#: ../src/propgrid/advprops.cpp:1594
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Black"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1755
+#: ../src/propgrid/advprops.cpp:1656
 msgid "Blank"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1603
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Blue"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:345
+#: ../src/generic/colrdlgg.cpp:365
 msgid "Blue:"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:333 ../src/richtext/richtextfontpage.cpp:355
-#: ../src/osx/carbon/fontdlg.cpp:354 ../src/common/stockitem.cpp:143
+#: ../src/osx/carbon/fontdlg.cpp:351 ../src/common/stockitem.cpp:140
+#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:355
 msgid "Bold"
 msgstr "Îngroșat"
 
@@ -1529,32 +1526,36 @@ msgstr "Îngroșat"
 msgid "Border"
 msgstr "Margine"
 
-#: ../src/richtext/richtextformatdlg.cpp:379
+#: ../src/richtext/richtextformatdlg.cpp:372
 msgid "Borders"
 msgstr "Margini"
 
-#: ../src/richtext/richtextsizepage.cpp:288 ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141 ../src/richtext/richtextsizepage.cpp:288
 msgid "Bottom"
 msgstr "Jos"
 
-#: ../src/generic/prntdlgg.cpp:893
+#: ../src/generic/prntdlgg.cpp:886
 msgid "Bottom margin (mm):"
 msgstr "Marginea de jos (mm):"
 
-#: ../src/richtext/richtextbuffer.cpp:9383
+#: ../src/richtext/richtextbuffer.cpp:9380
 msgid "Box Properties"
 msgstr "Proprietăți Casetă"
 
-#: ../src/richtext/richtextstyles.cpp:1065
+#: ../src/richtext/richtextstyles.cpp:1062
 msgid "Box styles"
 msgstr "Stiluri casetă"
 
-#: ../src/propgrid/advprops.cpp:1602
+#: ../src/osx/cocoa/menu.mm:292
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1508
 #, fuzzy
 msgid "Brown"
 msgstr "Răsfoiește"
 
-#: ../src/common/filepickercmn.cpp:43 ../src/common/filepickercmn.cpp:44
+#: ../src/common/filepickercmn.cpp:40 ../src/common/filepickercmn.cpp:41
 msgid "Browse"
 msgstr "Răsfoiește"
 
@@ -1567,73 +1568,73 @@ msgstr "&Aliniere marcatori:"
 msgid "Bullet style"
 msgstr "Stil marcatori"
 
-#: ../src/richtext/richtextformatdlg.cpp:359
+#: ../src/richtext/richtextformatdlg.cpp:352
 msgid "Bullets"
 msgstr "Marcatori"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1756
+#: ../src/propgrid/advprops.cpp:1657
 #, fuzzy
 msgid "Bullseye"
 msgstr "Stil marcatori"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:875
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonFace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:876
+#: ../src/propgrid/advprops.cpp:777
 msgid "ButtonHighlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:877
+#: ../src/propgrid/advprops.cpp:778
 msgid "ButtonShadow"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:878
+#: ../src/propgrid/advprops.cpp:779
 msgid "ButtonText"
 msgstr ""
 
-#: ../src/common/paper.cpp:98
+#: ../src/common/paper.cpp:95
 msgid "C sheet, 17 x 22 in"
 msgstr "C foaie, 17 x 22 in"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "C&lear"
 msgstr "&Curăță"
 
-#: ../src/generic/fontdlgg.cpp:406
+#: ../src/generic/fontdlgg.cpp:403
 msgid "C&olour:"
 msgstr "Cul&oare:"
 
-#: ../src/common/paper.cpp:123
+#: ../src/common/paper.cpp:120
 msgid "C3 Envelope, 324 x 458 mm"
 msgstr "C3 Plic, 324 x 458 mm"
 
-#: ../src/common/paper.cpp:124
+#: ../src/common/paper.cpp:121
 msgid "C4 Envelope, 229 x 324 mm"
 msgstr "C4 Plic, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:122
+#: ../src/common/paper.cpp:119
 msgid "C5 Envelope, 162 x 229 mm"
 msgstr "C5 Plic, 162 x 229 mm"
 
-#: ../src/common/paper.cpp:125
+#: ../src/common/paper.cpp:122
 msgid "C6 Envelope, 114 x 162 mm"
 msgstr "C6 Plic, 114 x 162 mm"
 
-#: ../src/common/paper.cpp:126
+#: ../src/common/paper.cpp:123
 msgid "C65 Envelope, 114 x 229 mm"
 msgstr "C65 Plic, 114 x 229 mm"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "CD-Rom"
 msgstr "CD-Rom"
 
-#: ../src/html/chm.cpp:815 ../src/html/chm.cpp:874
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:865
 msgid "CHM handler currently supports only local files!"
 msgstr "Funcționalitatea pentru CHM suportă numai fișiere locale!"
 
@@ -1641,195 +1642,199 @@ msgstr "Funcționalitatea pentru CHM suportă numai fișiere locale!"
 msgid "Ca&pitals"
 msgstr "&Majuscule"
 
-#: ../src/common/cmdproc.cpp:267
+#: ../src/common/cmdproc.cpp:260
 msgid "Can't &Undo "
 msgstr "Nu se poate an&ula acțiunea "
 
-#: ../src/common/image.cpp:2824
+#: ../src/common/image.cpp:2924
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 "Formatul imaginii nu poate fi automat determinat pentru input ce nu poate fi "
 "examinat."
 
-#: ../src/msw/registry.cpp:506
+#: ../src/msw/registry.cpp:495
 #, c-format
 msgid "Can't close registry key '%s'"
 msgstr "Nu se poate închide cheia de regiștri '%s'"
 
-#: ../src/msw/registry.cpp:584
+#: ../src/msw/registry.cpp:573
 #, c-format
 msgid "Can't copy values of unsupported type %d."
 msgstr "Nu se pot copia valorile de tipul nesuportat %d."
 
-#: ../src/msw/registry.cpp:487
+#: ../src/msw/registry.cpp:476
 #, c-format
 msgid "Can't create registry key '%s'"
 msgstr "Nu se poate crea cheia de regiștri '%s'"
 
-#: ../src/msw/thread.cpp:665
+#: ../src/msw/thread.cpp:657
 msgid "Can't create thread"
 msgstr "Nu se poate crea firul de execuție"
 
-#: ../src/msw/window.cpp:3691
-#, c-format
-msgid "Can't create window of class %s"
-msgstr "Nu se poate crea fereastra de clasa %s"
-
-#: ../src/msw/registry.cpp:777
+#: ../src/msw/registry.cpp:765
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Nu se poate șterge cheia '%s'"
 
-#: ../src/msw/iniconf.cpp:458
+#: ../src/msw/iniconf.cpp:455
 #, c-format
 msgid "Can't delete the INI file '%s'"
 msgstr "Nu se poate șterge fișierul INI '%s'"
 
-#: ../src/msw/registry.cpp:805
+#: ../src/msw/registry.cpp:793
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Nu se poate șterge valoarea '%s' din cheia '%s'"
 
-#: ../src/msw/registry.cpp:1171
+#: ../src/msw/registry.cpp:1159
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Nu se pot enumera sub-cheile cheii '%s'"
 
-#: ../src/msw/registry.cpp:1132
+#: ../src/msw/registry.cpp:1120
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Nu se pot enumera valorile cheii '%s'"
 
-#: ../src/msw/registry.cpp:1389
+#: ../src/msw/registry.cpp:1377
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Nu se poate exporta valoarea de tipul nesuportat %d."
 
-#: ../src/common/ffile.cpp:254
+#: ../src/common/ffile.cpp:253
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Nu se poate determina poziția curentă în fișierul '%s'"
 
-#: ../src/msw/registry.cpp:418
+#: ../src/msw/registry.cpp:407
 #, c-format
 msgid "Can't get info about registry key '%s'"
 msgstr "Nu se pot obține informații despre cheia de regiștri '%s'"
 
-#: ../src/common/zstream.cpp:346
+#: ../src/msw/webview_ie.cpp:1024
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "Nu se poate seta prioritatea pentru fire de execuție"
+
+#: ../src/common/zstream.cpp:343
 msgid "Can't initialize zlib deflate stream."
 msgstr "Nu poate fi inițializat fluxul de compresie zlib."
 
-#: ../src/common/zstream.cpp:185
+#: ../src/common/zstream.cpp:182
 msgid "Can't initialize zlib inflate stream."
 msgstr "Nu poate fi inițializat fluxul de decompresie zlib."
 
-#: ../src/msw/fswatcher.cpp:476
+#: ../src/msw/fswatcher.cpp:475
 #, c-format
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "Directorul inexistent \"%s\" nu poate fi monitorizat pentru schimbari."
 
-#: ../src/msw/registry.cpp:454
+#: ../src/msw/registry.cpp:443
 #, c-format
 msgid "Can't open registry key '%s'"
 msgstr "Nu se poate deschide cheia de regiștri '%s'"
 
-#: ../src/common/zstream.cpp:252
+#: ../src/common/zstream.cpp:249
 #, c-format
 msgid "Can't read from inflate stream: %s"
 msgstr "Nu poate fi citit fluxul de decompresie: %s"
 
-#: ../src/common/zstream.cpp:244
+#: ../src/common/zstream.cpp:241
 msgid "Can't read inflate stream: unexpected EOF in underlying stream."
 msgstr ""
 "Nu poate fi citit fluxul de decompresie: EOF neașteptat în fluxul de bază."
 
-#: ../src/msw/registry.cpp:1064
+#: ../src/msw/registry.cpp:1052
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Nu se poate citi valoarea din '%s'"
 
-#: ../src/msw/registry.cpp:878 ../src/msw/registry.cpp:910
-#: ../src/msw/registry.cpp:975
+#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
+#: ../src/msw/registry.cpp:963
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Nu se poate citi valoarea cheii '%s'"
 
-#: ../src/common/image.cpp:2620
+#: ../src/msw/webview_ie.cpp:1017
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/common/image.cpp:2715
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "Nu se poate salva imaginea în fișierul '%s': extensie necunoscută."
 
-#: ../src/generic/logg.cpp:573 ../src/generic/logg.cpp:976
+#: ../src/generic/logg.cpp:570 ../src/generic/logg.cpp:973
 msgid "Can't save log contents to file."
 msgstr "Nu se poate salva conținutul raportului în fișier."
 
-#: ../src/msw/thread.cpp:629
+#: ../src/msw/thread.cpp:621
 msgid "Can't set thread priority"
 msgstr "Nu se poate seta prioritatea pentru fire de execuție"
 
-#: ../src/msw/registry.cpp:896 ../src/msw/registry.cpp:938
-#: ../src/msw/registry.cpp:1081
+#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
+#: ../src/msw/registry.cpp:1069
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Nu se poate seta valoarea '%s'"
 
-#: ../src/unix/utilsunx.cpp:351
+#: ../src/unix/utilsunx.cpp:353
 msgid "Can't write to child process's stdin"
 msgstr "Nu se poate scrie la stdin-ul procesului copil"
 
-#: ../src/common/zstream.cpp:427
+#: ../src/common/zstream.cpp:424
 #, c-format
 msgid "Can't write to deflate stream: %s"
 msgstr "Nu se poate scrie în fluxul de decompresie: %s"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:279 ../src/richtext/richtextstyledlg.cpp:300
-#: ../src/common/stockitem.cpp:145 ../src/common/accelcmn.cpp:71
-#: ../src/msw/msgdlg.cpp:454 ../src/msw/progdlg.cpp:673
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:142
+#: ../src/common/accelcmn.cpp:68 ../src/motif/msgdlg.cpp:196
+#: ../src/gtk1/fontdlg.cpp:144 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/progdlg.cpp:940 ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Anulează"
 
-#: ../src/common/filefn.cpp:1261
+#: ../src/common/filefn.cpp:1149
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Nu se pot enumera fișierele '%s'"
 
-#: ../src/msw/dir.cpp:263
+#: ../src/msw/dir.cpp:260
 #, c-format
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Nu se pot enumera fișierele din directorul '%s'"
 
-#: ../src/msw/dialup.cpp:523
+#: ../src/msw/dialup.cpp:517
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Nu se poate determina conexiunea dialup activă: %s"
 
-#: ../src/msw/dialup.cpp:827
+#: ../src/msw/dialup.cpp:821
 msgid "Cannot find the location of address book file"
 msgstr "Nu se poate determina locația fișierului agendă"
 
-#: ../src/msw/ole/automtn.cpp:562
+#: ../src/msw/ole/automtn.cpp:553
 #, c-format
 msgid "Cannot get an active instance of \"%s\""
 msgstr "Nu se poate obține o instanță activă pentru \"%s\""
 
-#: ../src/unix/threadpsx.cpp:1035
+#: ../src/unix/threadpsx.cpp:1053
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr ""
 "Nu se poate obține intervalul de priorități pentru politica de planificare "
 "%d."
 
-#: ../src/unix/utilsunx.cpp:987
+#: ../src/unix/utilsunx.cpp:989
 msgid "Cannot get the hostname"
 msgstr "Nu se poate obține numele mașinii gazdă"
 
-#: ../src/unix/utilsunx.cpp:1023
+#: ../src/unix/utilsunx.cpp:1025
 msgid "Cannot get the official hostname"
 msgstr "Nu se poate obține numele oficial al mașinii gazdă"
 
-#: ../src/msw/dialup.cpp:928
+#: ../src/msw/dialup.cpp:922
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Nu se poate închide - nu există o conexiune dialup activă."
 
@@ -1837,127 +1842,127 @@ msgstr "Nu se poate închide - nu există o conexiune dialup activă."
 msgid "Cannot initialize OLE"
 msgstr "Nu se poate inițializa OLE"
 
-#: ../src/common/socket.cpp:853
+#: ../src/common/socket.cpp:850
 msgid "Cannot initialize sockets"
 msgstr "Nu se poate face inițializare socket"
 
-#: ../src/msw/volume.cpp:619
+#: ../src/msw/volume.cpp:627
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Nu se poate încărca pictograma din '%s'."
 
-#: ../src/xrc/xmlres.cpp:360
+#: ../src/xrc/xmlres.cpp:358
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Nu se pot încărca resursele din '%s'."
 
-#: ../src/xrc/xmlres.cpp:742
+#: ../src/xrc/xmlres.cpp:740
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Nu se pot încărca resursele din fișierul '%s'."
 
-#: ../src/html/htmlfilt.cpp:137
+#: ../src/html/htmlfilt.cpp:134
 #, c-format
 msgid "Cannot open HTML document: %s"
 msgstr "Nu se poate deschide documentul HTML: %s"
 
-#: ../src/html/helpdata.cpp:667
+#: ../src/html/helpdata.cpp:660
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Nu se poate deschide manualul HTML: %s"
 
-#: ../src/html/helpdata.cpp:299
+#: ../src/html/helpdata.cpp:296
 #, c-format
 msgid "Cannot open contents file: %s"
 msgstr "Nu se poate deschide fișierul de cuprins: %s"
 
-#: ../src/generic/dcpsg.cpp:1667
+#: ../src/generic/dcpsg.cpp:1665
 msgid "Cannot open file for PostScript printing!"
 msgstr "Nu se poate deschide fișierul pentru tipărire cu PostScript!"
 
-#: ../src/html/helpdata.cpp:313
+#: ../src/html/helpdata.cpp:310
 #, c-format
 msgid "Cannot open index file: %s"
 msgstr "Nu se poate deschide fișierul index: %s"
 
-#: ../src/xrc/xmlres.cpp:724
+#: ../src/xrc/xmlres.cpp:722
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Nu se poatet deschide fișierul resursă '%s'."
 
-#: ../src/html/helpwnd.cpp:1534
+#: ../src/html/helpwnd.cpp:1532
 msgid "Cannot print empty page."
 msgstr "Nu se poate tipări o pagină goală."
 
-#: ../src/msw/volume.cpp:507
+#: ../src/msw/volume.cpp:515
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Nu se poate citi denumirea tipului din '%s'!"
 
-#: ../src/msw/thread.cpp:888
+#: ../src/msw/thread.cpp:894
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Nu poate continua firul de execuție %lx"
 
-#: ../src/unix/threadpsx.cpp:1016
+#: ../src/unix/threadpsx.cpp:1028
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Nu se poate obține politica de planificare a firului de execuție."
 
-#: ../src/common/intl.cpp:558
+#: ../src/common/intl.cpp:365
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "Nu se poate seta locala la limba \"%s\"."
 
-#: ../src/unix/threadpsx.cpp:831 ../src/msw/thread.cpp:546
+#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
 msgid "Cannot start thread: error writing TLS."
 msgstr "Nu se poate porni firul de execuție: eroare la scrierea TLS."
 
-#: ../src/msw/thread.cpp:872
+#: ../src/msw/thread.cpp:864
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Nu se poate suspenda firul de execuție %lx"
 
-#: ../src/msw/thread.cpp:794
+#: ../src/msw/thread.cpp:786
 msgid "Cannot wait for thread termination"
 msgstr "Nu se poate aștepta terminarea firului de execuție"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:75
+#: ../src/common/accelcmn.cpp:72
 #, fuzzy
 msgid "Capital"
 msgstr "&Majuscule"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:879
+#: ../src/propgrid/advprops.cpp:780
 msgid "CaptionText"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:531
 msgid "Case sensitive"
 msgstr "Cu majuscule semnificative"
 
-#: ../src/propgrid/manager.cpp:1509
+#: ../src/propgrid/manager.cpp:1527
 msgid "Categorized Mode"
 msgstr "După categorie"
 
-#: ../src/richtext/richtextbuffer.cpp:9968
+#: ../src/richtext/richtextbuffer.cpp:9965
 msgid "Cell Properties"
 msgstr "Proprietăți pentru celulă"
 
-#: ../src/common/fmapbase.cpp:161
+#: ../src/common/fmapbase.cpp:158
 msgid "Celtic (ISO-8859-14)"
 msgstr "Celtică (ISO-8859-14)"
 
-#: ../src/richtext/richtextindentspage.cpp:160
 #: ../src/richtext/richtextliststylepage.cpp:349
+#: ../src/richtext/richtextindentspage.cpp:160
 msgid "Cen&tred"
 msgstr "Cen&trat"
 
-#: ../src/common/stockitem.cpp:170
+#: ../src/common/stockitem.cpp:167
 msgid "Centered"
 msgstr "Centrat"
 
-#: ../src/common/fmapbase.cpp:149
+#: ../src/common/fmapbase.cpp:146
 msgid "Central European (ISO-8859-2)"
 msgstr "Central-europeană (ISO-8859-2)"
 
@@ -1966,10 +1971,10 @@ msgstr "Central-europeană (ISO-8859-2)"
 msgid "Centre"
 msgstr "Centru"
 
-#: ../src/richtext/richtextindentspage.cpp:162
-#: ../src/richtext/richtextindentspage.cpp:164
 #: ../src/richtext/richtextliststylepage.cpp:351
 #: ../src/richtext/richtextliststylepage.cpp:353
+#: ../src/richtext/richtextindentspage.cpp:162
+#: ../src/richtext/richtextindentspage.cpp:164
 msgid "Centre text."
 msgstr "Centrează textul."
 
@@ -1982,24 +1987,24 @@ msgstr "Centrat"
 msgid "Ch&oose..."
 msgstr "&Alege..."
 
-#: ../src/richtext/richtextbuffer.cpp:4354
+#: ../src/richtext/richtextbuffer.cpp:4351
 msgid "Change List Style"
 msgstr "Schimbă stilul listei"
 
-#: ../src/richtext/richtextbuffer.cpp:3709
+#: ../src/richtext/richtextbuffer.cpp:3706
 msgid "Change Object Style"
 msgstr "Schimbă Stilul Obiectului"
 
-#: ../src/richtext/richtextbuffer.cpp:3982
-#: ../src/richtext/richtextbuffer.cpp:8129
+#: ../src/richtext/richtextbuffer.cpp:3979
+#: ../src/richtext/richtextbuffer.cpp:8125
 msgid "Change Properties"
 msgstr "Schimbă Proprietățile"
 
-#: ../src/richtext/richtextbuffer.cpp:3526
+#: ../src/richtext/richtextbuffer.cpp:3523
 msgid "Change Style"
 msgstr "Schimbă stilul"
 
-#: ../src/common/fileconf.cpp:341
+#: ../src/common/fileconf.cpp:335
 #, c-format
 msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
 msgstr ""
@@ -2012,12 +2017,12 @@ msgid "Changing current directory to \"%s\" failed"
 msgstr "A eșuat crearea directorului \"%s\""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1757
+#: ../src/propgrid/advprops.cpp:1658
 #, fuzzy
 msgid "Character"
 msgstr "&Cod caracter:"
 
-#: ../src/richtext/richtextstyles.cpp:1063
+#: ../src/richtext/richtextstyles.cpp:1060
 msgid "Character styles"
 msgstr "Stiluri de caractere"
 
@@ -2054,20 +2059,20 @@ msgstr "Bifează pentru a încadra marcatorul între paranteze."
 msgid "Check to indicate right-to-left text layout."
 msgstr "Bifează pentru a indica afișarea textului de la stânga la dreapta."
 
-#: ../src/osx/carbon/fontdlg.cpp:356 ../src/osx/carbon/fontdlg.cpp:358
+#: ../src/osx/carbon/fontdlg.cpp:353 ../src/osx/carbon/fontdlg.cpp:355
 msgid "Check to make the font bold."
 msgstr "Bifează pentru a îngroșa fontul."
 
-#: ../src/osx/carbon/fontdlg.cpp:363 ../src/osx/carbon/fontdlg.cpp:365
+#: ../src/osx/carbon/fontdlg.cpp:360 ../src/osx/carbon/fontdlg.cpp:362
 msgid "Check to make the font italic."
 msgstr "Bifează pentru a face fontul cursiv."
 
-#: ../src/osx/carbon/fontdlg.cpp:372 ../src/osx/carbon/fontdlg.cpp:374
+#: ../src/osx/carbon/fontdlg.cpp:369 ../src/osx/carbon/fontdlg.cpp:371
 msgid "Check to make the font underlined."
 msgstr "Bifează pentru a face fontul subliniat."
 
-#: ../src/richtext/richtextstyledlg.cpp:289
-#: ../src/richtext/richtextstyledlg.cpp:291
+#: ../src/richtext/richtextstyledlg.cpp:285
+#: ../src/richtext/richtextstyledlg.cpp:287
 msgid "Check to restart numbering."
 msgstr "Bifează pentru a reîncepe numărătoarea."
 
@@ -2101,51 +2106,51 @@ msgstr "Bifează pentru a afișa textul ca indice superior (superscript)."
 msgid "Check to suppress hyphenation."
 msgstr "Bifează pentru a suprima despărțirea în silabe."
 
-#: ../src/msw/dialup.cpp:763
+#: ../src/msw/dialup.cpp:757
 msgid "Choose ISP to dial"
 msgstr "Alege ISP pentru a forma"
 
-#: ../src/propgrid/props.cpp:1922
+#: ../src/propgrid/props.cpp:1904
 msgid "Choose a directory:"
 msgstr "Alege un director:"
 
-#: ../src/propgrid/props.cpp:1975
+#: ../src/propgrid/props.cpp:2199
 msgid "Choose a file"
 msgstr "Alege un fișier"
 
-#: ../src/generic/colrdlgg.cpp:158 ../src/gtk/colordlg.cpp:54
+#: ../src/generic/colrdlgg.cpp:156 ../src/gtk/colordlg.cpp:49
 msgid "Choose colour"
 msgstr "Alege culoare"
 
-#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/gtk1/fontdlg.cpp:125 ../src/generic/fontpickerg.cpp:47
+#: ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Alege font"
 
-#: ../src/common/module.cpp:74
+#: ../src/common/module.cpp:71
 #, c-format
 msgid "Circular dependency involving module \"%s\" detected."
 msgstr "A fost detectată o dependență circulară care implică modulul \"%s\""
 
-#: ../src/aui/tabmdi.cpp:108 ../src/generic/mdig.cpp:97
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
 msgid "Cl&ose"
 msgstr "Î&nchide"
 
-#: ../src/msw/ole/automtn.cpp:684
+#: ../src/msw/ole/automtn.cpp:675
 msgid "Class not registered."
 msgstr "Clasa nu este inregistrată."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:147 ../src/common/accelcmn.cpp:72
+#: ../src/common/stockitem.cpp:144 ../src/common/accelcmn.cpp:69
 msgid "Clear"
 msgstr "Curăță"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "Clear the log contents"
 msgstr "Curăță conținutul jurnalului"
 
-#: ../src/richtext/richtextstyledlg.cpp:252
-#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:248
+#: ../src/richtext/richtextstyledlg.cpp:250
 msgid "Click to apply the selected style."
 msgstr "Clic pentru a aplica stilul selectat."
 
@@ -2156,15 +2161,15 @@ msgstr "Clic pentru a aplica stilul selectat."
 msgid "Click to browse for a symbol."
 msgstr "Clic pentru a căuta un simbol."
 
-#: ../src/osx/carbon/fontdlg.cpp:403 ../src/osx/carbon/fontdlg.cpp:405
+#: ../src/osx/carbon/fontdlg.cpp:400 ../src/osx/carbon/fontdlg.cpp:402
 msgid "Click to cancel changes to the font."
 msgstr "Clic pentru a anula modificările aduse fontului."
 
-#: ../src/generic/fontdlgg.cpp:472 ../src/generic/fontdlgg.cpp:491
+#: ../src/generic/fontdlgg.cpp:468 ../src/generic/fontdlgg.cpp:487
 msgid "Click to cancel the font selection."
 msgstr "Clic pentru a anula selectarea fontului."
 
-#: ../src/osx/carbon/fontdlg.cpp:384 ../src/osx/carbon/fontdlg.cpp:386
+#: ../src/osx/carbon/fontdlg.cpp:381 ../src/osx/carbon/fontdlg.cpp:383
 msgid "Click to change the font colour."
 msgstr "Clic pentru a schimba culoarea fontului."
 
@@ -2183,37 +2188,37 @@ msgstr "Clic pentru a schimba culoarea textului."
 msgid "Click to choose the font for this level."
 msgstr "Clic pentru a alege fontul pentru acest nivel."
 
-#: ../src/richtext/richtextstyledlg.cpp:279
-#: ../src/richtext/richtextstyledlg.cpp:281
+#: ../src/richtext/richtextstyledlg.cpp:275
+#: ../src/richtext/richtextstyledlg.cpp:277
 msgid "Click to close this window."
 msgstr "Clic pentru a închide această fereastră."
 
-#: ../src/osx/carbon/fontdlg.cpp:410 ../src/osx/carbon/fontdlg.cpp:412
+#: ../src/osx/carbon/fontdlg.cpp:407 ../src/osx/carbon/fontdlg.cpp:409
 msgid "Click to confirm changes to the font."
 msgstr "Clic pentru a confirma modificările aduse fontului."
 
-#: ../src/generic/fontdlgg.cpp:477 ../src/generic/fontdlgg.cpp:479
-#: ../src/generic/fontdlgg.cpp:484 ../src/generic/fontdlgg.cpp:486
+#: ../src/generic/fontdlgg.cpp:473 ../src/generic/fontdlgg.cpp:475
+#: ../src/generic/fontdlgg.cpp:480 ../src/generic/fontdlgg.cpp:482
 msgid "Click to confirm the font selection."
 msgstr "Clic pentru a confirma selectarea fontului."
 
-#: ../src/richtext/richtextstyledlg.cpp:244
-#: ../src/richtext/richtextstyledlg.cpp:246
+#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:242
 msgid "Click to create a new box style."
 msgstr "Clic pentru a crea un nou stil de casetă."
 
-#: ../src/richtext/richtextstyledlg.cpp:226
-#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:224
 msgid "Click to create a new character style."
 msgstr "Clic pentru a crea un nou stil de caracter."
 
-#: ../src/richtext/richtextstyledlg.cpp:238
-#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:236
 msgid "Click to create a new list style."
 msgstr "Clic pentru a crea un nou stil de listă."
 
-#: ../src/richtext/richtextstyledlg.cpp:232
-#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:230
 msgid "Click to create a new paragraph style."
 msgstr "Clic pentru a crea un nou stil de paragraf."
 
@@ -2227,8 +2232,8 @@ msgstr "Clic pentru a crea o nouă poziție de indentare."
 msgid "Click to delete all tab positions."
 msgstr "Clic pentru a șterge toate pozițiile de indentare."
 
-#: ../src/richtext/richtextstyledlg.cpp:270
-#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:268
 msgid "Click to delete the selected style."
 msgstr "Clic pentru a șterge stilul selectat."
 
@@ -2237,25 +2242,25 @@ msgstr "Clic pentru a șterge stilul selectat."
 msgid "Click to delete the selected tab position."
 msgstr "Clic pentru a șterge poziția de indentare selectată."
 
-#: ../src/richtext/richtextstyledlg.cpp:264
-#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:262
 msgid "Click to edit the selected style."
 msgstr "Clic pentru a modifica stilul selectat."
 
-#: ../src/richtext/richtextstyledlg.cpp:258
-#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:256
 msgid "Click to rename the selected style."
 msgstr "Clic pentru a redenumi stilul selectat."
 
-#: ../src/generic/dbgrptg.cpp:97 ../src/generic/progdlgg.cpp:759
-#: ../src/richtext/richtextstyledlg.cpp:277
-#: ../src/richtext/richtextsymboldlg.cpp:476 ../src/common/stockitem.cpp:148
-#: ../src/msw/progdlg.cpp:170 ../src/msw/progdlg.cpp:679
-#: ../src/html/helpdlg.cpp:90
+#: ../src/common/stockitem.cpp:145 ../src/generic/dbgrptg.cpp:94
+#: ../src/generic/progdlgg.cpp:781 ../src/msw/progdlg.cpp:211
+#: ../src/msw/progdlg.cpp:946 ../src/html/helpdlg.cpp:87
+#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextstyledlg.cpp:273
 msgid "Close"
 msgstr "Închide"
 
-#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:98
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
 msgid "Close All"
 msgstr "Închide toate"
 
@@ -2263,43 +2268,43 @@ msgstr "Închide toate"
 msgid "Close current document"
 msgstr "Închide documentul curent"
 
-#: ../src/generic/logg.cpp:516
+#: ../src/generic/logg.cpp:513
 msgid "Close this window"
 msgstr "Închide această fereastră"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6006
+#: ../src/generic/datavgen.cpp:6811
 msgid "Collapse"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "Color"
 msgstr "Culoare"
 
-#: ../src/richtext/richtextformatdlg.cpp:776
+#: ../src/richtext/richtextformatdlg.cpp:768
 msgid "Colour"
 msgstr "Culoare"
 
-#: ../src/msw/colordlg.cpp:158
+#: ../src/msw/colordlg.cpp:227
 #, c-format
 msgid "Colour selection dialog failed with error %0lx."
 msgstr "Dialogul de selecție a culorii a eșuat cu eroarea %0lx."
 
-#: ../src/osx/carbon/fontdlg.cpp:380
+#: ../src/osx/carbon/fontdlg.cpp:377
 msgid "Colour:"
 msgstr "Culoare:"
 
-#: ../src/generic/datavgen.cpp:6077
+#: ../src/generic/datavgen.cpp:6882
 #, fuzzy, c-format
 msgid "Column %u"
 msgstr "Adaugă coloană"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:114
+#: ../src/common/accelcmn.cpp:112
 msgid "Command"
 msgstr ""
 
-#: ../src/common/init.cpp:196
+#: ../src/common/init.cpp:193
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
@@ -2308,12 +2313,12 @@ msgstr ""
 "Argumentul %d din linia de comandă nu a putut fi convertit la Unicode și va "
 "fi ignorat."
 
-#: ../src/msw/fontdlg.cpp:120
+#: ../src/msw/fontdlg.cpp:170
 #, c-format
 msgid "Common dialog failed with error code %0lx."
 msgstr "Dialogul comun a eșuat cu eroarea %0lx."
 
-#: ../src/gtk/window.cpp:4649
+#: ../src/gtk/window.cpp:5653
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
@@ -2321,11 +2326,11 @@ msgstr ""
 "Compunerea nu este suportată de acest sistem, trebuie activată din Managerul "
 "de Ferestre."
 
-#: ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:1549
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Fișier HTML Manual comprimat (*.chm)|*.chm|"
 
-#: ../src/generic/dirctrlg.cpp:444
+#: ../src/generic/dirctrlg.cpp:410
 msgid "Computer"
 msgstr "Computer"
 
@@ -2334,53 +2339,57 @@ msgstr "Computer"
 msgid "Config entry name cannot start with '%c'."
 msgstr "Numele intrării de configurare nu poate începe cu '%c'."
 
-#: ../src/generic/filedlgg.cpp:349 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
 msgid "Confirm"
 msgstr "Confirmă"
 
-#: ../src/html/htmlwin.cpp:566
+#: ../src/html/htmlwin.cpp:569
 msgid "Connecting..."
 msgstr "Se conectează..."
 
-#: ../src/html/helpwnd.cpp:475
+#: ../src/html/helpwnd.cpp:473
 msgid "Contents"
 msgstr "Cuprins"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:880
+#: ../src/propgrid/advprops.cpp:781
 msgid "ControlDark"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:881
+#: ../src/propgrid/advprops.cpp:782
 msgid "ControlLight"
 msgstr ""
 
-#: ../src/common/strconv.cpp:2262
+#: ../src/common/strconv.cpp:2208
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Conversia la setul de caractere '%s' nu funcționează."
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "Convert"
 msgstr "Transformă"
 
-#: ../src/html/htmlwin.cpp:1079
+#: ../src/html/htmlwin.cpp:1020
 #, c-format
 msgid "Copied to clipboard:\"%s\""
 msgstr "Copiat în clipboard:\"%s\""
 
-#: ../src/generic/prntdlgg.cpp:247
+#: ../src/generic/prntdlgg.cpp:240
 msgid "Copies:"
 msgstr "Copii:"
 
-#: ../src/common/stockitem.cpp:150 ../src/stc/stc_i18n.cpp:18
+#: ../src/common/stockitem.cpp:147 ../src/stc/stc_i18n.cpp:18
 msgid "Copy"
 msgstr "Copiază"
 
-#: ../src/common/stockitem.cpp:258
+#: ../src/common/stockitem.cpp:255
 msgid "Copy selection"
 msgstr "Copiază selecția"
+
+#: ../src/generic/grid.cpp:5945
+msgid "Copying more than one selected block to clipboard is not supported."
+msgstr ""
 
 #: ../src/richtext/richtextborderspage.cpp:566
 #: ../src/richtext/richtextborderspage.cpp:601
@@ -2391,201 +2400,197 @@ msgstr "Colț"
 msgid "Corner &radius:"
 msgstr "&Raza colțului rotunjit:"
 
-#: ../src/html/chm.cpp:718
+#: ../src/html/chm.cpp:711
 #, c-format
 msgid "Could not create temporary file '%s'"
 msgstr "Nu s-a putut crea fișierul temporar '%s'"
 
-#: ../src/html/chm.cpp:273
+#: ../src/html/chm.cpp:270
 #, c-format
 msgid "Could not extract %s into %s: %s"
 msgstr "Nu s-a putut extrage %s în %s: %s"
 
-#: ../src/generic/tabg.cpp:1048
+#: ../src/generic/tabg.cpp:1045
 msgid "Could not find tab for id"
 msgstr "Nu s-a putut găsi indentarea pentru id"
 
-#: ../src/gtk/notifmsg.cpp:108
-#, fuzzy
-msgid "Could not initalize libnotify."
-msgstr "Nu a putut fi setată alinierea."
-
-#: ../src/html/chm.cpp:444
+#: ../src/html/chm.cpp:437
 #, c-format
 msgid "Could not locate file '%s'."
 msgstr "Nu a putut fi localizat fișierul '%s'."
 
-#: ../src/common/filefn.cpp:1403
+#: ../src/msw/graphicsd2d.cpp:604
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/common/filefn.cpp:1291
 msgid "Could not set current working directory"
 msgstr "A eșuat setarea directorului de lucru"
 
-#: ../src/common/prntbase.cpp:2015
+#: ../src/common/prntbase.cpp:2037
 msgid "Could not start document preview."
 msgstr "Nu a putut fi pornită previzualizarea documentului."
 
-#: ../src/generic/printps.cpp:178 ../src/msw/printwin.cpp:210
-#: ../src/gtk/print.cpp:1132
+#: ../src/generic/printps.cpp:159 ../src/msw/printwin.cpp:184
+#: ../src/gtk/print.cpp:1129
 msgid "Could not start printing."
 msgstr "Nu s-a putut începe tipărirea."
 
-#: ../src/common/wincmn.cpp:2125
+#: ../src/common/wincmn.cpp:2126
 msgid "Could not transfer data to window"
 msgstr "Nu s-au putut transfera datele către fereastră"
 
-#: ../src/msw/imaglist.cpp:187 ../src/msw/imaglist.cpp:224
-#: ../src/msw/imaglist.cpp:249 ../src/msw/dragimag.cpp:185
-#: ../src/msw/dragimag.cpp:220
+#: ../src/msw/imaglist.cpp:223 ../src/msw/imaglist.cpp:245
+#: ../src/msw/imaglist.cpp:270 ../src/msw/dragimag.cpp:182
+#: ../src/msw/dragimag.cpp:217
 msgid "Couldn't add an image to the image list."
 msgstr "Nu s-a putut adăuga o imagine la lista de imagini."
 
-#: ../src/osx/glcanvas_osx.cpp:414 ../src/unix/glx11.cpp:558
-#: ../src/msw/glcanvas.cpp:616
+#: ../src/osx/glcanvas_osx.cpp:411 ../src/msw/glcanvas.cpp:631
+#: ../src/unix/glegl.cpp:315 ../src/unix/glx11.cpp:559
 #, fuzzy
 msgid "Couldn't create OpenGL context"
 msgstr "Nu a putut fi creat un temporizator"
 
-#: ../src/msw/timer.cpp:134
+#: ../src/msw/timer.cpp:131
 msgid "Couldn't create a timer"
 msgstr "Nu a putut fi creat un temporizator"
 
-#: ../src/osx/carbon/overlay.cpp:122
-msgid "Couldn't create the overlay window"
-msgstr "Nu a putut fi creată fereastra de acoperire (overlay)"
-
-#: ../src/common/translation.cpp:2024
+#: ../src/common/translation.cpp:2074
 msgid "Couldn't enumerate translations"
 msgstr "Nu au putut fi enumerate traducerile"
 
-#: ../src/common/dynlib.cpp:120
+#: ../src/common/dynlib.cpp:110
 #, c-format
 msgid "Couldn't find symbol '%s' in a dynamic library"
 msgstr "Nu a fost găsit simbolul '%s' într-o librărie dinamică"
 
-#: ../src/msw/thread.cpp:915
+#: ../src/msw/thread.cpp:921
 msgid "Couldn't get the current thread pointer"
 msgstr "Nu s-a putut obține pointerul pentru firul de execuție curent"
 
-#: ../src/osx/carbon/overlay.cpp:129
-msgid "Couldn't init the context on the overlay window"
-msgstr "Nu a putut fi inițializat contextul ferestrei de acoperire (overlay)"
-
-#: ../src/common/imaggif.cpp:244
+#: ../src/common/imaggif.cpp:241
 msgid "Couldn't initialize GIF hash table."
 msgstr "Tabela de dispersie GIF nu a putut fi inițializată."
 
-#: ../src/common/imagpng.cpp:409
+#: ../src/common/imagpng.cpp:437
 msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
 msgstr ""
 "Nu s-a putut încărca o imagine PNG - fișierul este corupt sau nu este "
 "suficientă memorie."
 
-#: ../src/unix/sound.cpp:470
+#: ../src/unix/sound.cpp:459
 #, c-format
 msgid "Couldn't load sound data from '%s'."
 msgstr "Nu s-a putut încărca sunetul din '%s'."
 
-#: ../src/msw/dirdlg.cpp:435
+#: ../src/msw/dirdlg.cpp:287
 msgid "Couldn't obtain folder name"
 msgstr "Nu a putut fi obtinut numele directorului"
 
-#: ../src/unix/sound_sdl.cpp:229
+#: ../src/unix/sound_sdl.cpp:226
 #, c-format
 msgid "Couldn't open audio: %s"
 msgstr "Nu s-a putut deschide fișierul audio: %s"
 
-#: ../src/msw/ole/dataobj.cpp:377
+#: ../src/msw/ole/dataobj.cpp:385
 #, c-format
 msgid "Couldn't register clipboard format '%s'."
 msgstr "Nu s-a putut înregistra formatul de clipboard '%s'."
 
-#: ../src/msw/listctrl.cpp:869
+#: ../src/msw/listctrl.cpp:933
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr ""
 "Nu s-au putut obține informații despre elementul %d din controlul de tip "
 "listă."
 
-#: ../src/common/imagpng.cpp:498 ../src/common/imagpng.cpp:509
-#: ../src/common/imagpng.cpp:519
+#: ../src/common/imagpng.cpp:511 ../src/common/imagpng.cpp:522
+#: ../src/common/imagpng.cpp:532
 msgid "Couldn't save PNG image."
 msgstr "Nu a putut fi salvată imaginea PNG."
 
-#: ../src/msw/thread.cpp:684
+#: ../src/msw/thread.cpp:676
 msgid "Couldn't terminate thread"
 msgstr "Nu a putut fi terminat firul de execuție"
 
-#: ../src/common/xtistrm.cpp:166
+#: ../src/common/xtistrm.cpp:163
 #, c-format
 msgid "Create Parameter %s not found in declared RTTI Parameters"
 msgstr "Create Parameter %s nu a fost găsit între parametrii RTTI declarați"
 
-#: ../src/generic/dirdlgg.cpp:288
+#: ../src/generic/dirdlgg.cpp:285
 msgid "Create directory"
 msgstr "Creează director"
 
-#: ../src/generic/filedlgg.cpp:212 ../src/generic/dirdlgg.cpp:111
+#: ../src/generic/filedlgg.cpp:209 ../src/generic/dirdlgg.cpp:108
 msgid "Create new directory"
 msgstr "Creează director nou"
 
-#: ../src/xrc/xmlres.cpp:2460
+#: ../src/common/stockitem.cpp:264
+#, fuzzy
+msgid "Create new document"
+msgstr "Creează director nou"
+
+#: ../src/xrc/xmlres.cpp:2515
 #, fuzzy, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Extragerea '%s' în '%s' a eșuat."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1758
+#: ../src/propgrid/advprops.cpp:1659
 msgid "Cross"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:333
+#: ../src/common/accelcmn.cpp:347
 msgid "Ctrl+"
 msgstr "Ctrl+"
 
-#: ../src/richtext/richtextctrl.cpp:332 ../src/osx/textctrl_osx.cpp:576
-#: ../src/common/stockitem.cpp:151 ../src/msw/textctrl.cpp:2507
+#: ../src/osx/textctrl_osx.cpp:594 ../src/common/stockitem.cpp:148
+#: ../src/msw/textctrl.cpp:2772 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "&Decupează"
 
-#: ../src/generic/filectrlg.cpp:940
+#: ../src/generic/filectrlg.cpp:936
 msgid "Current directory:"
 msgstr "Directorul curent:"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:896 ../src/propgrid/advprops.cpp:1574
-#: ../src/propgrid/advprops.cpp:1612
+#: ../src/propgrid/advprops.cpp:797 ../src/propgrid/advprops.cpp:1475
+#: ../src/propgrid/advprops.cpp:1518
 #, fuzzy
 msgid "Custom"
 msgstr "Dimensiune personalizată"
 
-#: ../src/gtk/print.cpp:217
+#: ../src/gtk/print.cpp:211
 msgid "Custom size"
 msgstr "Dimensiune personalizată"
 
-#: ../src/common/headerctrlcmn.cpp:60
+#: ../src/common/headerctrlcmn.cpp:58
 msgid "Customize Columns"
 msgstr "Personalizează coloane"
 
-#: ../src/common/stockitem.cpp:151 ../src/stc/stc_i18n.cpp:17
+#: ../src/common/stockitem.cpp:148 ../src/stc/stc_i18n.cpp:17
 msgid "Cut"
 msgstr "Decupează"
 
-#: ../src/common/stockitem.cpp:259
+#: ../src/common/stockitem.cpp:256
 msgid "Cut selection"
 msgstr "Decupează selecție"
 
-#: ../src/common/fmapbase.cpp:152
+#: ../src/common/fmapbase.cpp:149
 msgid "Cyrillic (ISO-8859-5)"
 msgstr "Chirilică (ISO-8859-5)"
 
-#: ../src/common/paper.cpp:99
+#: ../src/common/paper.cpp:96
 msgid "D sheet, 22 x 34 in"
 msgstr "D foaie, 22 x 34 in"
 
-#: ../src/msw/dde.cpp:703
+#: ../src/msw/dde.cpp:698
 msgid "DDE poke request failed"
 msgstr "Cererea DDE de test a eșuat"
 
-#: ../src/common/imagbmp.cpp:1169
+#: ../src/common/imagbmp.cpp:1181
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr "Antet DIB: Codificarea nu corespunde adâncimii de biți."
 
@@ -2605,7 +2610,7 @@ msgstr "Antet DIB: Adâncime de biți necunoscută în fișier."
 msgid "DIB Header: Unknown encoding in file."
 msgstr "Antet DIB: Codificare necunoscută in fișier."
 
-#: ../src/common/paper.cpp:121
+#: ../src/common/paper.cpp:118
 msgid "DL Envelope, 110 x 220 mm"
 msgstr "DL Plic, 110 x 220 mm"
 
@@ -2613,55 +2618,55 @@ msgstr "DL Plic, 110 x 220 mm"
 msgid "Dashed"
 msgstr "Linie întreruptă"
 
-#: ../src/generic/dbgrptg.cpp:300
+#: ../src/generic/dbgrptg.cpp:301
 #, c-format
 msgid "Debug report \"%s\""
 msgstr "Raport de depanare \"%s\""
 
-#: ../src/common/debugrpt.cpp:210
+#: ../src/common/debugrpt.cpp:211
 msgid "Debug report couldn't be created."
 msgstr "Raportul de depanare nu a putut fi creat."
 
-#: ../src/common/debugrpt.cpp:553
+#: ../src/common/debugrpt.cpp:554
 msgid "Debug report generation has failed."
 msgstr "Generarea raportului de depanare a eșuat."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:84
+#: ../src/common/accelcmn.cpp:81
 msgid "Decimal"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:323
+#: ../src/generic/fontdlgg.cpp:319
 msgid "Decorative"
 msgstr "Decorativ"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1752
+#: ../src/propgrid/advprops.cpp:1653
 #, fuzzy
 msgid "Default"
 msgstr "implicit"
 
-#: ../src/common/fmapbase.cpp:796
+#: ../src/common/fmapbase.cpp:792
 msgid "Default encoding"
 msgstr "Codificare implicită"
 
-#: ../src/dfb/fontmgr.cpp:180
+#: ../src/dfb/fontmgr.cpp:177
 msgid "Default font"
 msgstr "Font implicit"
 
-#: ../src/generic/prntdlgg.cpp:510
+#: ../src/generic/prntdlgg.cpp:503
 msgid "Default printer"
 msgstr "Imprimantă implicită"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:51
+#: ../src/common/accelcmn.cpp:48
 #, fuzzy
 msgid "Del"
 msgstr "Șterge"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextbuffer.cpp:8221 ../src/common/stockitem.cpp:152
-#: ../src/common/accelcmn.cpp:50 ../src/stc/stc_i18n.cpp:20
+#: ../src/common/stockitem.cpp:149 ../src/common/accelcmn.cpp:47
+#: ../src/richtext/richtextbuffer.cpp:8217 ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Șterge"
 
@@ -2669,68 +2674,68 @@ msgstr "Șterge"
 msgid "Delete A&ll"
 msgstr "Șter&ge tot"
 
-#: ../src/richtext/richtextbuffer.cpp:11341
+#: ../src/richtext/richtextbuffer.cpp:11340
 msgid "Delete Column"
 msgstr "Șterge coloană"
 
-#: ../src/richtext/richtextbuffer.cpp:11291
+#: ../src/richtext/richtextbuffer.cpp:11290
 msgid "Delete Row"
 msgstr "Șterge rând"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 msgid "Delete Style"
 msgstr "Șterge stil"
 
-#: ../src/richtext/richtextctrl.cpp:1345 ../src/richtext/richtextctrl.cpp:1584
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
 msgid "Delete Text"
 msgstr "Șterge text"
 
-#: ../src/generic/editlbox.cpp:170
+#: ../src/generic/editlbox.cpp:147
 msgid "Delete item"
 msgstr "Șterge element"
 
-#: ../src/common/stockitem.cpp:260
+#: ../src/common/stockitem.cpp:257
 msgid "Delete selection"
 msgstr "Șterge selecție"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 #, c-format
 msgid "Delete style %s?"
 msgstr "Ștergeți stilul %s?"
 
-#: ../src/unix/snglinst.cpp:301
+#: ../src/unix/snglinst.cpp:298
 #, c-format
 msgid "Deleted stale lock file '%s'."
 msgstr "Vechiul fișier de blocaj '%s' a fost șters."
 
-#: ../src/common/secretstore.cpp:220
+#: ../src/common/secretstore.cpp:234
 #, fuzzy, c-format
-msgid "Deleting password for \"%s/%s\" failed: %s."
+msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Extragerea '%s' în '%s' a eșuat."
 
-#: ../src/common/module.cpp:124
+#: ../src/common/module.cpp:121
 #, c-format
 msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
 msgstr "Dependința \"%s\" a modulului \"%s\" nu există."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "Descending"
 msgstr "Descrescător"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:526 ../src/propgrid/advprops.cpp:882
+#: ../src/generic/dirctrlg.cpp:492 ../src/propgrid/advprops.cpp:783
 msgid "Desktop"
 msgstr "Spațiu de lucru"
 
-#: ../src/generic/aboutdlgg.cpp:70
+#: ../src/generic/aboutdlgg.cpp:67
 msgid "Developed by "
 msgstr "Dezvoltat de "
 
-#: ../src/generic/aboutdlgg.cpp:176
+#: ../src/generic/aboutdlgg.cpp:173
 msgid "Developers"
 msgstr "Dezvoltatori"
 
-#: ../src/msw/dialup.cpp:374
+#: ../src/msw/dialup.cpp:368
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -2738,11 +2743,11 @@ msgstr ""
 "Funcțiile de dialup nu sunt disponibile pentru că serviciul de acces la "
 "distanță (RAS) nu este instalat. Trebuie să îl instalați."
 
-#: ../src/generic/tipdlg.cpp:211
+#: ../src/generic/tipdlg.cpp:208
 msgid "Did you know..."
 msgstr "Știați că..."
 
-#: ../src/dfb/wrapdfb.cpp:63
+#: ../src/dfb/wrapdfb.cpp:60
 #, c-format
 msgid "DirectFB error %d occurred."
 msgstr "A intervenit eroarea %d de DirectFB."
@@ -2751,29 +2756,29 @@ msgstr "A intervenit eroarea %d de DirectFB."
 msgid "Directories"
 msgstr "Directoare"
 
-#: ../src/common/filefn.cpp:1183
+#: ../src/common/filefn.cpp:1071
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Directorul '%s' nu a putut fi creat"
 
-#: ../src/common/filefn.cpp:1197
+#: ../src/common/filefn.cpp:1085
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "Directorul '%s' nu a putut fi șters"
 
-#: ../src/generic/dirdlgg.cpp:204
+#: ../src/generic/dirdlgg.cpp:201
 msgid "Directory does not exist"
 msgstr "Directorul nu există"
 
-#: ../src/generic/filectrlg.cpp:1399
+#: ../src/generic/filectrlg.cpp:1388
 msgid "Directory doesn't exist."
 msgstr "Directorul nu există."
 
-#: ../src/common/docview.cpp:457
+#: ../src/common/docview.cpp:450
 msgid "Discard changes and reload the last saved version?"
 msgstr "Anulează modificările și reîncarcă ultima versiune salvată?"
 
-#: ../src/html/helpwnd.cpp:502
+#: ../src/html/helpwnd.cpp:500
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -2781,45 +2786,45 @@ msgstr ""
 "Afișează toate elementele index care conțin șirul de caractere dat. "
 "Majusculele nu sunt semnificative pentru căutare."
 
-#: ../src/html/helpwnd.cpp:679
+#: ../src/html/helpwnd.cpp:677
 msgid "Display options dialog"
 msgstr "Afișează dialogul de opțiuni"
 
-#: ../src/html/helpwnd.cpp:322
+#: ../src/html/helpwnd.cpp:320
 msgid "Displays help as you browse the books on the left."
 msgstr "Afișează manualul de ajutor în timp ce răsfoiești cărțile din stânga."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:85
+#: ../src/common/accelcmn.cpp:83
 msgid "Divide"
 msgstr ""
 
-#: ../src/common/docview.cpp:533
+#: ../src/common/docview.cpp:526
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Vreți să salvați modificările în %s?"
 
-#: ../src/common/prntbase.cpp:542
+#: ../src/common/prntbase.cpp:537
 msgid "Document:"
 msgstr "Documentul:"
 
-#: ../src/generic/aboutdlgg.cpp:73
+#: ../src/generic/aboutdlgg.cpp:70
 msgid "Documentation by "
 msgstr "Documentație de"
 
-#: ../src/generic/aboutdlgg.cpp:180
+#: ../src/generic/aboutdlgg.cpp:177
 msgid "Documentation writers"
 msgstr "Autorii documentației"
 
-#: ../src/common/sizer.cpp:2799
+#: ../src/common/sizer.cpp:2916
 msgid "Don't Save"
 msgstr "Nu salva"
 
-#: ../src/html/htmlwin.cpp:633
+#: ../src/html/htmlwin.cpp:643
 msgid "Done"
 msgstr "Gata"
 
-#: ../src/generic/progdlgg.cpp:448 ../src/msw/progdlg.cpp:407
+#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
 msgid "Done."
 msgstr "Gata."
 
@@ -2831,42 +2836,42 @@ msgstr "Punctată"
 msgid "Double"
 msgstr "Dublă"
 
-#: ../src/common/paper.cpp:176
+#: ../src/common/paper.cpp:173
 msgid "Double Japanese Postcard Rotated 148 x 200 mm"
 msgstr "Carte Poștală Japoneză Dublă Rotită 148 x 200 mm"
 
-#: ../src/common/xtixml.cpp:273
+#: ../src/common/xtixml.cpp:269
 #, c-format
 msgid "Doubly used id : %d"
 msgstr "Id folosit de două ori : %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:153
-#: ../src/common/accelcmn.cpp:64
+#: ../src/common/stockitem.cpp:150 ../src/common/accelcmn.cpp:61
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Down"
 msgstr "Jos"
 
-#: ../src/richtext/richtextctrl.cpp:865
+#: ../src/richtext/richtextctrl.cpp:864
 msgid "Drag"
 msgstr "Trage"
 
-#: ../src/common/paper.cpp:100
+#: ../src/common/paper.cpp:97
 msgid "E sheet, 34 x 44 in"
 msgstr "E foaie, 34 x 44 in"
 
-#: ../src/unix/fswatcher_inotify.cpp:561
+#: ../src/unix/fswatcher_inotify.cpp:558
 msgid "EOF while reading from inotify descriptor"
 msgstr "EOF in timpul citirii din descriptorul inotify"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "Edit"
 msgstr "Editează"
 
-#: ../src/generic/editlbox.cpp:168
+#: ../src/generic/editlbox.cpp:131
 msgid "Edit item"
 msgstr "Modifică element"
 
-#: ../include/wx/generic/progdlgg.h:84
+#: ../include/wx/generic/progdlgg.h:85
 msgid "Elapsed time:"
 msgstr "Timp scurs:"
 
@@ -2938,50 +2943,50 @@ msgid "Enables the shadow spread."
 msgstr "Activează valoarea pentru lățime."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:66
+#: ../src/common/accelcmn.cpp:63
 msgid "End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:55
+#: ../src/common/accelcmn.cpp:52
 #, fuzzy
 msgid "Enter"
 msgstr "Imprimantă"
 
-#: ../src/richtext/richtextstyledlg.cpp:934
+#: ../src/richtext/richtextstyledlg.cpp:930
 msgid "Enter a box style name"
 msgstr "Introduceți un nume de stil pentru casetă"
 
-#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:602
 msgid "Enter a character style name"
 msgstr "Introduceți numele unui stil de caractere"
 
-#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:816
 msgid "Enter a list style name"
 msgstr "Introduceți numele unui stil de listă"
 
-#: ../src/richtext/richtextstyledlg.cpp:893
+#: ../src/richtext/richtextstyledlg.cpp:889
 msgid "Enter a new style name"
 msgstr "Introduceți un nou nume de stil"
 
-#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:650
 msgid "Enter a paragraph style name"
 msgstr "Introduceți un nume de stil de paragraf"
 
-#: ../src/generic/dbgrptg.cpp:174
+#: ../src/generic/dbgrptg.cpp:171
 #, c-format
 msgid "Enter command to open file \"%s\":"
 msgstr "Introduceți comanda pentru a deschide fișierul \"%s\":"
 
-#: ../src/generic/helpext.cpp:459
+#: ../src/generic/helpext.cpp:457
 msgid "Entries found"
 msgstr "Intrări găsite"
 
-#: ../src/common/paper.cpp:142
+#: ../src/common/paper.cpp:139
 msgid "Envelope Invite 220 x 220 mm"
 msgstr "Plic Invitație 220 x 220 mm"
 
-#: ../src/common/config.cpp:469
+#: ../src/common/config.cpp:465
 #, c-format
 msgid ""
 "Environment variables expansion failed: missing '%c' at position %u in '%s'."
@@ -2989,13 +2994,13 @@ msgstr ""
 "Expandarea variabilelor de mediu a eșuat: lipsește '%c' la poziția %u în "
 "'%s'."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/generic/dirctrlg.cpp:570
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/dirctrlg.cpp:599
-#: ../src/generic/dirdlgg.cpp:323 ../src/generic/filectrlg.cpp:642
-#: ../src/generic/filectrlg.cpp:756 ../src/generic/filectrlg.cpp:770
-#: ../src/generic/filectrlg.cpp:786 ../src/generic/filectrlg.cpp:1368
-#: ../src/generic/filectrlg.cpp:1399 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/gtk1/fontdlg.cpp:74 ../src/generic/dirctrlg.cpp:536
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/dirctrlg.cpp:565
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1357 ../src/generic/filectrlg.cpp:1388
+#: ../src/generic/filedlgg.cpp:354 ../src/generic/dirdlgg.cpp:320
+#: ../src/gtk/filedlg.cpp:74
 msgid "Error"
 msgstr "Eroare"
 
@@ -3003,87 +3008,98 @@ msgstr "Eroare"
 msgid "Error closing epoll descriptor"
 msgstr "Eroare la închiderea descriptorului epoll"
 
-#: ../src/unix/fswatcher_kqueue.cpp:114
+#: ../src/unix/fswatcher_kqueue.cpp:131
 msgid "Error closing kqueue instance"
 msgstr "Eroare la închiderea instanței kqueue"
 
-#: ../src/common/filefn.cpp:1049
+#: ../src/common/filefn.cpp:938
 #, fuzzy, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "A eșuat copierea fișierului '%s' la '%s'"
 
-#: ../src/generic/dirdlgg.cpp:222
+#: ../src/generic/dirdlgg.cpp:219
 msgid "Error creating directory"
 msgstr "Eroare la crearea directorului"
 
-#: ../src/common/imagbmp.cpp:1181
+#: ../src/common/imagbmp.cpp:1193
 msgid "Error in reading image DIB."
 msgstr "Eroare la citirea DIB a imaginii."
 
-#: ../src/propgrid/propgrid.cpp:6696
+#: ../src/propgrid/propgrid.cpp:6665
 #, c-format
 msgid "Error in resource: %s"
 msgstr "Eroare în resurse: %s"
 
-#: ../src/common/fileconf.cpp:422
+#: ../src/common/fileconf.cpp:421
 msgid "Error reading config options."
 msgstr "Eroare la citirea opțiunilor de configurare."
+
+#: ../src/msw/webview_ie.cpp:1057 ../src/msw/webview_edge.cpp:850
+#: ../src/gtk/webview_webkit2.cpp:1262 ../src/osx/webview_webkit.mm:383
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
 
 #: ../src/common/fileconf.cpp:1029
 msgid "Error saving user configuration data."
 msgstr "Eroare la salvarea datelor de configurare ale utilizatorului."
 
-#: ../src/gtk/print.cpp:722
+#: ../src/gtk/print.cpp:720
 msgid "Error while printing: "
 msgstr "Eroare la tipărire: "
 
-#: ../src/common/log.cpp:219
+#: ../src/common/log.cpp:237
 msgid "Error: "
 msgstr "Eroare: "
 
+#: ../src/common/webrequest.cpp:98
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Eroare: "
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:69
+#: ../src/common/accelcmn.cpp:66
 msgid "Esc"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:70
+#: ../src/common/accelcmn.cpp:67
 #, fuzzy
 msgid "Escape"
 msgstr "Orizontal"
 
-#: ../src/common/fmapbase.cpp:150
+#: ../src/common/fmapbase.cpp:147
 msgid "Esperanto (ISO-8859-3)"
 msgstr "Esperanto (ISO-8859-3)"
 
-#: ../include/wx/generic/progdlgg.h:85
+#: ../include/wx/generic/progdlgg.h:86
 msgid "Estimated time:"
 msgstr "Durata estimată:"
 
-#: ../src/generic/dbgrptg.cpp:234
+#: ../src/generic/dbgrptg.cpp:231
 msgid "Executable files (*.exe)|*.exe|"
 msgstr "Fișiere executabile (*.exe)|*.exe|"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:155 ../src/common/accelcmn.cpp:78
+#: ../src/common/stockitem.cpp:152 ../src/common/accelcmn.cpp:75
 msgid "Execute"
 msgstr "Execută"
 
-#: ../src/msw/utilsexc.cpp:876
+#: ../src/msw/utilsexc.cpp:873
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Executarea comenzii '%s' a eșuat"
 
-#: ../src/common/paper.cpp:105
+#: ../src/common/paper.cpp:102
 msgid "Executive, 7 1/4 x 10 1/2 in"
 msgstr "Executiv, 7 1/4 x 10 1/2 in"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6009
+#: ../src/generic/datavgen.cpp:6814
 msgid "Expand"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1240
+#: ../src/msw/registry.cpp:1228
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
@@ -3091,147 +3107,157 @@ msgstr ""
 "Exportare cheie de regiștri: fișierul \"%s\" există deja și nu va fi "
 "suprascris."
 
-#: ../src/common/fmapbase.cpp:195
+#: ../src/common/fmapbase.cpp:192
 msgid "Extended Unix Codepage for Japanese (EUC-JP)"
 msgstr "Pagina Unix de coduri extinse pentru limba japoneză (EUC-JP)"
 
-#: ../src/html/chm.cpp:725
+#: ../src/html/chm.cpp:718
 #, c-format
 msgid "Extraction of '%s' into '%s' failed."
 msgstr "Extragerea '%s' în '%s' a eșuat."
 
-#: ../src/common/accelcmn.cpp:249 ../src/common/accelcmn.cpp:344
+#: ../src/common/accelcmn.cpp:259 ../src/common/accelcmn.cpp:358
 msgid "F"
 msgstr "F"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:672
+#: ../src/propgrid/advprops.cpp:582
 msgid "Face Name"
 msgstr "Nume font"
 
-#: ../src/unix/snglinst.cpp:269
+#: ../src/unix/snglinst.cpp:266
 msgid "Failed to access lock file."
 msgstr "A eșuat accesarea fișierului de blocaj."
+
+#: ../src/gtk/font.cpp:572
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "A eșuat citirea documentului din fișierul \"%s\"."
 
 #: ../src/unix/epolldispatcher.cpp:116
 #, c-format
 msgid "Failed to add descriptor %d to epoll descriptor %d"
 msgstr "A eșuat adăugarea descriptorului %d la descriptorul epoll %d"
 
-#: ../src/msw/dib.cpp:489
+#: ../src/msw/dib.cpp:535
 #, c-format
 msgid "Failed to allocate %luKb of memory for bitmap data."
 msgstr "A eșuat alocarea a %luKb de memorie pentru bitmap."
 
-#: ../src/common/glcmn.cpp:115
+#: ../src/common/glcmn.cpp:112
 msgid "Failed to allocate colour for OpenGL"
 msgstr "A eșuat alocarea culorii pentru OpenGL"
 
-#: ../src/unix/displayx11.cpp:236
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "A eșuat alocarea culorii pentru OpenGL"
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "A eșuat alocarea culorii pentru OpenGL"
+
+#: ../include/wx/unix/private/displayx11.h:89
 msgid "Failed to change video mode"
 msgstr "A eșuat schimbarea modului video"
 
-#: ../src/common/image.cpp:3277
+#: ../src/common/image.cpp:3396
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "A eșuat detectarea formatului fișierului imagine \"%s\"."
 
-#: ../src/common/debugrpt.cpp:239
+#: ../src/common/debugrpt.cpp:240
 #, c-format
 msgid "Failed to clean up debug report directory \"%s\""
 msgstr "A eșuat curățarea directorului de rapoarte de depanare \"%s\""
 
-#: ../src/common/filename.cpp:192
+#: ../src/common/filename.cpp:189
 msgid "Failed to close file handle"
 msgstr "A eșuat închiderea manipulatorului de fișiere"
 
-#: ../src/unix/snglinst.cpp:340
+#: ../src/unix/snglinst.cpp:337
 #, c-format
 msgid "Failed to close lock file '%s'"
 msgstr "A eșuat închiderea fișierului de blocaj '%s'"
 
-#: ../src/msw/clipbrd.cpp:112
+#: ../src/msw/clipbrd.cpp:110
 msgid "Failed to close the clipboard."
 msgstr "A eșuat închiderea memoriei clipboard."
 
-#: ../src/x11/utils.cpp:208
+#: ../src/x11/utils.cpp:170
 #, c-format
 msgid "Failed to close the display \"%s\""
 msgstr "A eșuat închiderea ecranului \"%s\""
 
-#: ../src/msw/dialup.cpp:797
+#: ../src/msw/dialup.cpp:791
 msgid "Failed to connect: missing username/password."
 msgstr "A eșuat conectarea: lipsește utilizator/parola."
 
-#: ../src/msw/dialup.cpp:743
+#: ../src/msw/dialup.cpp:737
 msgid "Failed to connect: no ISP to dial."
 msgstr "A eșuat conectarea: nu există niciun ISP pentru apelare."
 
-#: ../src/common/textfile.cpp:203
-#, c-format
-msgid "Failed to convert file \"%s\" to Unicode."
-msgstr "A eșuat conversia fișierului \"%s\" la Unicode."
-
-#: ../src/generic/logg.cpp:956
+#: ../src/generic/logg.cpp:953
 msgid "Failed to copy dialog contents to the clipboard."
 msgstr "A eșuat copierea conținutului dialogului în memoria clipboard."
 
-#: ../src/msw/registry.cpp:692
+#: ../src/msw/registry.cpp:681
 #, c-format
 msgid "Failed to copy registry value '%s'"
 msgstr "A eșuat copierea valorii de regiștri '%s'"
 
-#: ../src/msw/registry.cpp:701
+#: ../src/msw/registry.cpp:690
 #, c-format
 msgid "Failed to copy the contents of registry key '%s' to '%s'."
 msgstr "A eșuat copierea conținutului cheii de regiștri '%s' în '%s'."
 
-#: ../src/common/filefn.cpp:1015
+#: ../src/common/filefn.cpp:904
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "A eșuat copierea fișierului '%s' la '%s'"
 
-#: ../src/msw/registry.cpp:679
+#: ../src/msw/registry.cpp:668
 #, c-format
 msgid "Failed to copy the registry subkey '%s' to '%s'."
 msgstr "A eșuat copierea sub-cheii de regiștri '%s' în '%s'."
 
-#: ../src/msw/dde.cpp:1070
+#: ../src/msw/dde.cpp:1134
 msgid "Failed to create DDE string"
 msgstr "A eșuat crearea șirului DDE de caractere"
 
-#: ../src/msw/mdi.cpp:616
+#: ../src/msw/mdi.cpp:621
 msgid "Failed to create MDI parent frame."
 msgstr "A eșuat crearea cadrului părinte MDI."
 
-#: ../src/common/filename.cpp:1027
+#: ../src/common/filename.cpp:1024
 msgid "Failed to create a temporary file name"
 msgstr "A eșuat crearea unui nume de fișier temporar"
 
-#: ../src/msw/utilsexc.cpp:228
+#: ../src/msw/utilsexc.cpp:225
 msgid "Failed to create an anonymous pipe"
 msgstr "A eșuat crearea unui canal (pipe) anonim"
 
-#: ../src/msw/ole/automtn.cpp:522
+#: ../src/msw/ole/automtn.cpp:513
 #, c-format
 msgid "Failed to create an instance of \"%s\""
 msgstr "A eșuat crearea unei instanțe \"%s\""
 
-#: ../src/msw/dde.cpp:437
+#: ../src/msw/dde.cpp:432
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "A eșuat crearea conexiunii cu serverul '%s' pentru subiectul '%s'"
 
-#: ../src/msw/cursor.cpp:204
+#: ../src/msw/cursor.cpp:195
 msgid "Failed to create cursor."
 msgstr "A eșuat crearea unui cursor."
 
-#: ../src/common/debugrpt.cpp:209
+#: ../src/common/debugrpt.cpp:210
 #, c-format
 msgid "Failed to create directory \"%s\""
 msgstr "A eșuat crearea directorului \"%s\""
 
-#: ../src/generic/dirdlgg.cpp:220
+#: ../src/generic/dirdlgg.cpp:217
 #, c-format
 msgid ""
 "Failed to create directory '%s'\n"
@@ -3244,119 +3270,138 @@ msgstr ""
 msgid "Failed to create epoll descriptor"
 msgstr "A eșuat crearea unui descriptor epoll"
 
-#: ../src/msw/mimetype.cpp:238
+#: ../src/gtk/font.cpp:562
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "A eșuat actualizarea fișierului de configurare pentru utilizator."
+
+#: ../src/msw/mimetype.cpp:235
 #, c-format
 msgid "Failed to create registry entry for '%s' files."
 msgstr "A eșuat crearea intrării în regiștri pentru fișierele '%s'."
 
-#: ../src/msw/fdrepdlg.cpp:409
+#: ../src/msw/fdrepdlg.cpp:408
 #, c-format
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr ""
 "A eșuat crearea dialogului standard de căutare/înlocuire (cod de eroare %d)"
 
-#: ../src/unix/wakeuppipe.cpp:52
+#: ../src/unix/wakeuppipe.cpp:49
 msgid "Failed to create wake up pipe used by event loop."
 msgstr ""
 "A eșuat crearea canalului de răspuns (wake up pipe) folosit de bucla de "
 "evenimente."
 
-#: ../src/html/winpars.cpp:730
+#: ../src/html/winpars.cpp:727
 #, c-format
 msgid "Failed to display HTML document in %s encoding"
 msgstr "A eșuat afișarea documentului HTML în codificarea %s"
 
-#: ../src/msw/clipbrd.cpp:124
+#: ../src/msw/clipbrd.cpp:122
 msgid "Failed to empty the clipboard."
 msgstr "A eșuat golirea memoriei clipboard."
 
-#: ../src/unix/displayx11.cpp:212
+#: ../include/wx/unix/private/displayx11.h:65
 msgid "Failed to enumerate video modes"
 msgstr "A eșuat enumerarea modurilor video"
 
-#: ../src/msw/dde.cpp:722
+#: ../src/msw/dde.cpp:717
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "A eșuat stabilirea unei bucle de informare cu serverul DDE"
 
-#: ../src/msw/dialup.cpp:629 ../src/msw/dialup.cpp:863
+#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "A eșuat stabilirea unei conexiuni dialup: %s"
 
-#: ../src/unix/utilsunx.cpp:611
+#: ../src/unix/utilsunx.cpp:613
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "A eșuat executarea '%s'\n"
 
-#: ../src/common/debugrpt.cpp:720
+#: ../src/common/debugrpt.cpp:730
 msgid "Failed to execute curl, please install it in PATH."
 msgstr "A eșuat executarea curl, trebuie instalat în PATH."
 
-#: ../src/msw/ole/automtn.cpp:505
+#: ../src/msw/ole/automtn.cpp:496
 #, c-format
 msgid "Failed to find CLSID of \"%s\""
 msgstr "Nu a fost găsit CLSID al \"%s\""
 
-#: ../src/common/regex.cpp:431 ../src/common/regex.cpp:479
+#: ../src/common/regex.cpp:428 ../src/common/regex.cpp:476
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "A eșuat găsirea unui rezultat pentru expresia regulată: %s"
 
-#: ../src/msw/dialup.cpp:695
+#: ../src/msw/webview_ie.cpp:978
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:689
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "A eșuat obținerea numelor ISP: %s"
 
-#: ../src/msw/ole/automtn.cpp:574
+#: ../src/msw/ole/automtn.cpp:565
 #, c-format
 msgid "Failed to get OLE automation interface for \"%s\""
 msgstr "Nu a fost gasită interfața de automatizare OLE a \"%s\""
 
-#: ../src/msw/clipbrd.cpp:711
+#: ../src/msw/clipbrd.cpp:731
 msgid "Failed to get data from the clipboard"
 msgstr "A eșuat obținerea datelor din memoria clipboard"
 
-#: ../src/common/time.cpp:223
+#: ../src/common/time.cpp:216
 msgid "Failed to get the local system time"
 msgstr "A eșuat obținerea timpului local pentru sistem"
 
-#: ../src/common/filefn.cpp:1345
+#: ../src/common/filefn.cpp:1233
 msgid "Failed to get the working directory"
 msgstr "A eșuat obținerea directorului de lucru"
 
-#: ../src/univ/theme.cpp:114
+#: ../src/univ/theme.cpp:111
 msgid "Failed to initialize GUI: no built-in themes found."
 msgstr ""
 "A eșuat inițializarea interfeței grafice (GUI): nu s-a găsit nicio temă "
 "integrată."
 
-#: ../src/msw/helpchm.cpp:63
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:60
 msgid "Failed to initialize MS HTML Help."
 msgstr "A eșuat inițializarea sistemului de ajutor MS HTML Help."
 
-#: ../src/msw/glcanvas.cpp:1381
+#: ../src/msw/glcanvas.cpp:1391
 msgid "Failed to initialize OpenGL"
 msgstr "A eșuat inițializarea OpenGL"
 
-#: ../src/msw/dialup.cpp:858
+#: ../src/msw/dialup.cpp:852
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "A eșuat inițializarea conexiunii dialup: %s"
 
-#: ../src/gtk/textctrl.cpp:1128
+#: ../src/gtk/textctrl.cpp:1209
 msgid "Failed to insert text in the control."
 msgstr "A eșuat inserarea textului în control."
 
-#: ../src/unix/snglinst.cpp:241
+#: ../src/unix/snglinst.cpp:238
 #, c-format
 msgid "Failed to inspect the lock file '%s'"
 msgstr "A eșuat inspectarea fișierului de blocaj '%s'"
 
-#: ../src/unix/appunix.cpp:182
+#: ../src/unix/appunix.cpp:179
 msgid "Failed to install signal handler"
 msgstr "A eșuat instalarea manipulatorului de semnale"
 
-#: ../src/unix/threadpsx.cpp:1167
+#: ../src/unix/threadpsx.cpp:1216
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -3364,72 +3409,72 @@ msgstr ""
 "A eșuat sincronizarea cu un fir de execuție, posibilă scurgere de memorie "
 "detectată - programul trebuie repornit"
 
-#: ../src/msw/utils.cpp:629
+#: ../src/msw/utils.cpp:619
 #, c-format
 msgid "Failed to kill process %d"
 msgstr "A eșuat terminarea forțată a procesului %d"
 
-#: ../src/common/image.cpp:2500
+#: ../src/common/image.cpp:2595
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "A eșuat încărcarea imaginii \"%s\" din resurse."
 
-#: ../src/common/image.cpp:2509
+#: ../src/common/image.cpp:2604
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "A eșuat încărcarea iconiței \"%s\" din resurse."
 
-#: ../src/common/iconbndl.cpp:225
+#: ../src/common/iconbndl.cpp:224
 #, fuzzy, c-format
 msgid "Failed to load icons from resource '%s'."
 msgstr "A eșuat încărcarea iconiței \"%s\" din resurse."
 
-#: ../src/common/iconbndl.cpp:200
+#: ../src/common/iconbndl.cpp:198
 #, c-format
 msgid "Failed to load image %%d from file '%s'."
 msgstr "A eșuat încărcarea imaginii %%d din fișierul '%s'."
 
-#: ../src/common/iconbndl.cpp:208
+#: ../src/common/iconbndl.cpp:206
 #, c-format
 msgid "Failed to load image %d from stream."
 msgstr "A eșuat încărcarea imaginii %d din fluxul de date."
 
-#: ../src/common/image.cpp:2587 ../src/common/image.cpp:2606
+#: ../src/common/image.cpp:2682 ../src/common/image.cpp:2701
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "A eșuat încărcarea imaginii din fișierul \"%s\"."
 
-#: ../src/msw/enhmeta.cpp:97
+#: ../src/msw/enhmeta.cpp:94
 #, c-format
 msgid "Failed to load metafile from file \"%s\"."
 msgstr ""
 "A eșuat încărcarea fișierului de tip meta (metafile) din fișierul \"%s\"."
 
-#: ../src/msw/volume.cpp:327
+#: ../src/msw/volume.cpp:335
 msgid "Failed to load mpr.dll."
 msgstr "A eșuat încărcarea mpr.dll."
 
-#: ../src/msw/utils.cpp:953
+#: ../src/msw/utils.cpp:943
 #, c-format
 msgid "Failed to load resource \"%s\"."
 msgstr "A eșuat încărcarea resursei \"%s\"."
 
-#: ../src/common/dynlib.cpp:92
+#: ../src/common/dynlib.cpp:86
 #, c-format
 msgid "Failed to load shared library '%s'"
 msgstr "A eșuat incărcarea librăriei partajate '%s'"
 
-#: ../src/osx/core/sound.cpp:145
+#: ../src/osx/core/sound.cpp:143
 #, fuzzy, c-format
 msgid "Failed to load sound from \"%s\" (error %d)."
 msgstr "A eșuat încărcarea resursei \"%s\"."
 
-#: ../src/msw/utils.cpp:960
+#: ../src/msw/utils.cpp:950
 #, c-format
 msgid "Failed to lock resource \"%s\"."
 msgstr "A eșuat blocarea resursei \"%s\"."
 
-#: ../src/unix/snglinst.cpp:198
+#: ../src/unix/snglinst.cpp:195
 #, c-format
 msgid "Failed to lock the lock file '%s'"
 msgstr "A eșuat blocarea fișierului de blocaj '%s'"
@@ -3439,33 +3484,38 @@ msgstr "A eșuat blocarea fișierului de blocaj '%s'"
 msgid "Failed to modify descriptor %d in epoll descriptor %d"
 msgstr "A eșuat modificarea descriptorului %d în descriptorul epoll %d"
 
-#: ../src/common/filename.cpp:2575
+#: ../src/common/filename.cpp:2658
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "A eșuat modificarea timpilor fișierului pentru '%s'"
 
-#: ../src/common/selectdispatcher.cpp:258
+#: ../src/common/selectdispatcher.cpp:255
 msgid "Failed to monitor I/O channels"
 msgstr "A eșuat monitorizarea canalelor I/O"
 
-#: ../src/common/filename.cpp:175
+#: ../src/common/filename.cpp:172
 #, c-format
 msgid "Failed to open '%s' for reading"
 msgstr "A eșuat deschiderea '%s' pentru citire"
 
-#: ../src/common/filename.cpp:180
+#: ../src/common/filename.cpp:177
 #, c-format
 msgid "Failed to open '%s' for writing"
 msgstr "A eșuat deschiderea '%s' pentru scriere"
 
-#: ../src/html/chm.cpp:141
+#: ../src/html/chm.cpp:138
 #, c-format
 msgid "Failed to open CHM archive '%s'."
 msgstr "A eșuat deschiderea arhivei CHM '%s'."
 
-#: ../src/common/utilscmn.cpp:1126
+#: ../src/common/utilscmn.cpp:1140
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
+msgstr "A eșuat deschiderea URL-ului \"%s\" in browser-ul implicit."
+
+#: ../src/common/hyperlnkcmn.cpp:133
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "A eșuat deschiderea URL-ului \"%s\" in browser-ul implicit."
 
 #: ../include/wx/msw/private/fswatcher.h:92
@@ -3473,93 +3523,103 @@ msgstr "A eșuat deschiderea URL-ului \"%s\" in browser-ul implicit."
 msgid "Failed to open directory \"%s\" for monitoring."
 msgstr "A eșuat deschiderea directorului \"%s\" pentru monitorizare."
 
-#: ../src/x11/utils.cpp:227
+#: ../src/x11/utils.cpp:189
 #, c-format
 msgid "Failed to open display \"%s\"."
 msgstr "A eșuat deschiderea ecranului \"%s\"."
 
-#: ../src/common/filename.cpp:1062
+#: ../src/common/filename.cpp:1059
 msgid "Failed to open temporary file."
 msgstr "A eșuat deschiderea fișierului temporar."
 
-#: ../src/msw/clipbrd.cpp:91
+#: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "A eșuat deschiderea memoriei clipboard."
 
-#: ../src/common/translation.cpp:1184
+#: ../src/common/translation.cpp:1226
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Nu se pot interpreta formele de plural:'%s'"
 
-#: ../src/unix/mediactrl.cpp:1214
+#: ../src/unix/mediactrl.cpp:1239
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "A eșuat pregătirea redării \"%s\"."
 
-#: ../src/msw/clipbrd.cpp:600
+#: ../src/msw/clipbrd.cpp:610
 msgid "Failed to put data on the clipboard"
 msgstr "A eșuat punerea datelor în memoria clipboard"
 
-#: ../src/unix/snglinst.cpp:278
+#: ../src/unix/snglinst.cpp:275
 msgid "Failed to read PID from lock file."
 msgstr "A eșuat citirea PID-ului din fișierul de blocaj."
 
-#: ../src/common/fileconf.cpp:433
+#: ../src/common/fileconf.cpp:432
 msgid "Failed to read config options."
 msgstr "A eșuat citirea opțiunilor de configurare."
 
-#: ../src/common/docview.cpp:681
+#: ../src/common/docview.cpp:676
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "A eșuat citirea documentului din fișierul \"%s\"."
 
-#: ../src/dfb/evtloop.cpp:98
+#: ../src/dfb/evtloop.cpp:99
 msgid "Failed to read event from DirectFB pipe"
 msgstr "A eșuat citirea evenimentului din canalul (pipe) DirectFB"
 
-#: ../src/unix/wakeuppipe.cpp:120
+#: ../src/unix/wakeuppipe.cpp:117
 msgid "Failed to read from wake-up pipe"
 msgstr "A eșuat citirea din canalul de răspuns (wake-up pipe)"
 
-#: ../src/unix/utilsunx.cpp:679
+#: ../src/common/textfile.cpp:96
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "A eșuat citirea documentului din fișierul \"%s\"."
+
+#: ../src/unix/utilsunx.cpp:681
 msgid "Failed to redirect child process input/output"
 msgstr "A eșuat redirectarea intrărilor/ieșirilor pentru procesul copil"
 
-#: ../src/msw/utilsexc.cpp:701
+#: ../src/msw/utilsexc.cpp:698
 msgid "Failed to redirect the child process IO"
 msgstr "A eșuat redirectarea IO ale procesului copil"
 
-#: ../src/msw/dde.cpp:288
+#: ../src/msw/dde.cpp:283
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "A eșuat înregistrarea server-ului DDE '%s'"
 
-#: ../src/common/fontmap.cpp:245
+#: ../src/gtk/font.cpp:580
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "A eșuat actualizarea fișierului de configurare pentru utilizator."
+
+#: ../src/common/fontmap.cpp:242
 #, c-format
 msgid "Failed to remember the encoding for the charset '%s'."
 msgstr "A eșuat memorarea codificării setului de caractere '%s'."
 
-#: ../src/common/debugrpt.cpp:227
+#: ../src/common/debugrpt.cpp:228
 #, c-format
 msgid "Failed to remove debug report file \"%s\""
 msgstr "A eșuat ștergerea fișierului raport de depanare \"%s\""
 
-#: ../src/unix/snglinst.cpp:328
+#: ../src/unix/snglinst.cpp:325
 #, c-format
 msgid "Failed to remove lock file '%s'"
 msgstr "A eșuat înlăturarea fișierului de blocaj '%s'"
 
-#: ../src/unix/snglinst.cpp:288
+#: ../src/unix/snglinst.cpp:285
 #, c-format
 msgid "Failed to remove stale lock file '%s'."
 msgstr "A eșuat înlăturarea vechiului fișier de blocaj '%s'."
 
-#: ../src/msw/registry.cpp:529
+#: ../src/msw/registry.cpp:518
 #, c-format
 msgid "Failed to rename registry value '%s' to '%s'."
 msgstr "A eșuat redenumirea valorii de regiștri '%s' în '%s'."
 
-#: ../src/common/filefn.cpp:1122
+#: ../src/common/filefn.cpp:1011
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -3568,117 +3628,126 @@ msgstr ""
 "A eșuat redenumirea fișierului '%s' în '%s' pentru că fișierul destinație "
 "există deja."
 
-#: ../src/msw/registry.cpp:634
+#: ../src/msw/registry.cpp:623
 #, c-format
 msgid "Failed to rename the registry key '%s' to '%s'."
 msgstr "A eșuat redenumirea cheii de regiștri '%s' în '%s'."
 
-#: ../src/common/filename.cpp:2671
+#: ../src/msw/webview_ie.cpp:995
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/common/filename.cpp:2754
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "A eșuat obținerea timpilor fișierului pentru '%s'"
 
-#: ../src/msw/dialup.cpp:468
+#: ../src/msw/dialup.cpp:462
 msgid "Failed to retrieve text of RAS error message"
 msgstr "A eșuat obținerea textului din mesajul de eroare RAS"
 
-#: ../src/msw/clipbrd.cpp:748
+#: ../src/msw/clipbrd.cpp:768
 msgid "Failed to retrieve the supported clipboard formats"
 msgstr "A eșuat obținerea formatelor suportate de memoria clipboard"
 
-#: ../src/common/docview.cpp:652
+#: ../src/common/docview.cpp:647
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "A eșuat salvarea documentului în fișierul \"%s\"."
 
-#: ../src/msw/dib.cpp:269
+#: ../src/msw/dib.cpp:312
 #, c-format
 msgid "Failed to save the bitmap image to file \"%s\"."
 msgstr "A eșuat salvarea imaginii de tip bitmap în fișierul \"%s\"."
 
-#: ../src/msw/dde.cpp:763
+#: ../src/msw/dde.cpp:811
 msgid "Failed to send DDE advise notification"
 msgstr "A eșuat trimiterea notificării DDE"
 
-#: ../src/common/ftp.cpp:402
+#: ../src/common/ftp.cpp:399
 #, c-format
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "A eșuat setarea modului de transfer FTP la %s."
 
-#: ../src/msw/clipbrd.cpp:427
+#: ../src/msw/clipbrd.cpp:443
 msgid "Failed to set clipboard data."
 msgstr "A eșuat setarea datelor în memoria clipboard."
 
-#: ../src/unix/snglinst.cpp:181
+#: ../src/unix/snglinst.cpp:178
 #, c-format
 msgid "Failed to set permissions on lock file '%s'"
 msgstr "A eșuat setarea permisiunilor pentru fișierul de blocaj '%s'"
 
-#: ../src/unix/utilsunx.cpp:668
+#: ../src/unix/utilsunx.cpp:670
 msgid "Failed to set process priority"
 msgstr "A eșuat setarea priorității procesului"
 
-#: ../src/common/file.cpp:559
+#: ../src/common/ffile.cpp:355 ../src/common/file.cpp:586
 msgid "Failed to set temporary file permissions"
 msgstr "A eșuat setarea permisiunilor pentru fișierul temporar"
 
-#: ../src/gtk/textctrl.cpp:1072
-msgid "Failed to set text in the text control."
-msgstr "A eșuat setarea textului în controlul de text."
-
-#: ../src/unix/threadpsx.cpp:1298
+#: ../src/unix/threadpsx.cpp:1347
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "A eșuat setarea nivelului de concurență la %lu"
 
-#: ../src/unix/threadpsx.cpp:1424
+#: ../src/unix/threadpsx.cpp:1473
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "A eșuat setarea priorității %d pentru firul de execuție."
 
-#: ../src/unix/utilsunx.cpp:783
+#: ../src/unix/utilsunx.cpp:785
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 "A eșuat setarea unui canal (pipe) non-blocant, programul poate fi suspendat."
 
-#: ../src/common/fs_mem.cpp:261
+#: ../src/msw/webview_ie.cpp:987
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:256
 #, c-format
 msgid "Failed to store image '%s' to memory VFS!"
 msgstr "A eșuat stocarea imaginii '%s' în VFS din memorie!"
 
-#: ../src/dfb/evtloop.cpp:170
+#: ../src/dfb/evtloop.cpp:171
 msgid "Failed to switch DirectFB pipe to non-blocking mode"
 msgstr "A eșuat trecerea canalului (pipe) DirectFB în mod non-blocant"
 
-#: ../src/unix/wakeuppipe.cpp:59
+#: ../src/unix/wakeuppipe.cpp:56
 msgid "Failed to switch wake up pipe to non-blocking mode"
 msgstr ""
 "A eșuat trecerea canalului de răspuns (wake up pipe) în mod non-blocant"
 
-#: ../src/unix/threadpsx.cpp:1605
+#: ../src/unix/threadpsx.cpp:1654
 msgid "Failed to terminate a thread."
 msgstr "A eșuat terminarea unui fir de execuție."
 
-#: ../src/msw/dde.cpp:741
+#: ../src/msw/dde.cpp:736
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "A eșuat terminarea buclei de informare cu serverul DDE"
 
-#: ../src/msw/dialup.cpp:938
+#: ../src/msw/dialup.cpp:932
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "A eșuat terminarea conexiunii dialup: %s"
 
-#: ../src/common/filename.cpp:2590
+#: ../src/common/filename.cpp:2673
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "A eșuat modificarea timpilor fișierului '%s'"
 
-#: ../src/unix/snglinst.cpp:334
+#: ../src/unix/dlunix.cpp:90
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "A eșuat incărcarea librăriei partajate '%s'"
+
+#: ../src/unix/snglinst.cpp:331
 #, c-format
 msgid "Failed to unlock lock file '%s'"
 msgstr "A eșuat deblocarea fișierului de blocaj '%s'"
 
-#: ../src/msw/dde.cpp:309
+#: ../src/msw/dde.cpp:304
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "A eșuat înlăturarea înregistrării serverului DDE '%s'"
@@ -3693,77 +3762,87 @@ msgstr ""
 msgid "Failed to update user configuration file."
 msgstr "A eșuat actualizarea fișierului de configurare pentru utilizator."
 
-#: ../src/common/debugrpt.cpp:733
+#: ../src/common/debugrpt.cpp:743
 #, c-format
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "A eșuat transferul raportului de depanare (cod de eroare %d)."
 
-#: ../src/unix/snglinst.cpp:168
+#: ../src/unix/snglinst.cpp:165
 #, c-format
 msgid "Failed to write to lock file '%s'"
 msgstr "A eșuat scrierea în fișierul de blocaj '%s'"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:209
+#: ../src/propgrid/propgrid.cpp:190
 msgid "False"
 msgstr "Fals"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:694
+#: ../src/propgrid/advprops.cpp:604
 msgid "Family"
 msgstr "Familie"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/gtk/glcanvas.cpp:176 ../src/gtk/glcanvas.cpp:187
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Eroare de fișier"
+
+#: ../src/common/stockitem.cpp:154
 msgid "File"
 msgstr "Fișier"
 
-#: ../src/common/docview.cpp:669
+#: ../src/common/docview.cpp:664
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Fișierul \"%s\" nu a putut fi deschis pentru citire."
 
-#: ../src/common/docview.cpp:646
+#: ../src/common/docview.cpp:641
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Fișierul \"%s\" nu a putut fi deschis pentru scriere."
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "Fișierul '%s' există deja, sigur vreți să fie suprascris?"
 
-#: ../src/common/filefn.cpp:1156
+#: ../src/common/filefn.cpp:1044
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Fișierul '%s' nu a putut fi șters."
 
-#: ../src/common/filefn.cpp:1139
+#: ../src/common/filefn.cpp:1028
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Fișierul '%s' nu a putut fi redenumit '%s'."
 
-#: ../src/richtext/richtextctrl.cpp:3081 ../src/common/textcmn.cpp:953
+#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
 msgid "File couldn't be loaded."
 msgstr "Fișierul nu a putut fi încărcat."
 
-#: ../src/msw/filedlg.cpp:393
+#: ../src/msw/filedlg.cpp:414
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Dialogul pentru fișiere a eșuat cu eroarea %0lx."
 
-#: ../src/common/docview.cpp:1789
+#: ../src/common/docview.cpp:1783
 msgid "File error"
 msgstr "Eroare de fișier"
 
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/filectrlg.cpp:770
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/filectrlg.cpp:766
 msgid "File name exists already."
 msgstr "Numele de fișier există deja."
+
+#: ../src/osx/cocoa/filedlg.mm:264
+#, fuzzy
+msgid "File type:"
+msgstr "Teletype"
 
 #: ../src/motif/filedlg.cpp:220
 msgid "Files"
 msgstr "Fișiere"
 
-#: ../src/common/filefn.cpp:1591
+#: ../src/common/filefn.cpp:1479
 #, c-format
 msgid "Files (%s)"
 msgstr "Fișierele (%s)"
@@ -3772,15 +3851,29 @@ msgstr "Fișierele (%s)"
 msgid "Filter"
 msgstr "Filtru"
 
-#: ../src/common/stockitem.cpp:158 ../src/html/helpwnd.cpp:490
+#: ../src/html/helpwnd.cpp:488
 msgid "Find"
 msgstr "Caută"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:259
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:258
+#, fuzzy
+msgid "Find in document"
+msgstr "Deschide document HTML"
+
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "Find..."
+msgstr "Caută"
+
+#: ../src/common/stockitem.cpp:156
 msgid "First"
 msgstr "Primul"
 
-#: ../src/common/prntbase.cpp:1548
+#: ../src/common/prntbase.cpp:1573
 msgid "First page"
 msgstr "Prima pagină"
 
@@ -3788,11 +3881,11 @@ msgstr "Prima pagină"
 msgid "Fixed"
 msgstr "Fixă"
 
-#: ../src/html/helpwnd.cpp:1206
+#: ../src/html/helpwnd.cpp:1204
 msgid "Fixed font:"
 msgstr "Font fix:"
 
-#: ../src/html/helpwnd.cpp:1269
+#: ../src/html/helpwnd.cpp:1267
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Font cu dimensiune fixă.<br> <b>îngroșat</b> <i>cursiv</i> "
 
@@ -3800,16 +3893,16 @@ msgstr "Font cu dimensiune fixă.<br> <b>îngroșat</b> <i>cursiv</i> "
 msgid "Floating"
 msgstr "În mișcare"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "Floppy"
 msgstr "Dischetă"
 
-#: ../src/common/paper.cpp:111
+#: ../src/common/paper.cpp:108
 msgid "Folio, 8 1/2 x 13 in"
 msgstr "Folio, 8 1/2 x 13 in"
 
-#: ../src/richtext/richtextformatdlg.cpp:344 ../src/osx/carbon/fontdlg.cpp:287
-#: ../src/common/stockitem.cpp:194
+#: ../src/osx/carbon/fontdlg.cpp:284 ../src/common/stockitem.cpp:191
+#: ../src/richtext/richtextformatdlg.cpp:337
 msgid "Font"
 msgstr "Font"
 
@@ -3817,7 +3910,24 @@ msgstr "Font"
 msgid "Font &weight:"
 msgstr "Îngroșare fon&t:"
 
-#: ../src/html/helpwnd.cpp:1207
+#: ../src/osx/fontutil.cpp:89
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
+"\"."
+msgstr ""
+
+#: ../src/msw/font.cpp:1126
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Fișierul nu a putut fi încărcat."
+
+#: ../src/osx/fontutil.cpp:81
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "Fișierul %s nu există."
+
+#: ../src/html/helpwnd.cpp:1205
 msgid "Font size:"
 msgstr "Dimensiune font:"
 
@@ -3825,54 +3935,54 @@ msgstr "Dimensiune font:"
 msgid "Font st&yle:"
 msgstr "St&il font:"
 
-#: ../src/osx/carbon/fontdlg.cpp:329
+#: ../src/osx/carbon/fontdlg.cpp:326
 msgid "Font:"
 msgstr "Font:"
 
-#: ../src/dfb/fontmgr.cpp:198
+#: ../src/dfb/fontmgr.cpp:195
 #, c-format
 msgid "Fonts index file %s disappeared while loading fonts."
 msgstr ""
 "Fișierul index de fonturi %s a dispărut în timp ce se încărcau fonturile."
 
-#: ../src/unix/utilsunx.cpp:645
+#: ../src/unix/utilsunx.cpp:647
 msgid "Fork failed"
 msgstr "A eșuat apelul fork"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "Forward"
 msgstr "Înainte"
 
-#: ../src/common/xtixml.cpp:235
+#: ../src/common/xtixml.cpp:231
 msgid "Forward hrefs are not supported"
 msgstr "Nu sunt acceptate declarații în avans pentru href"
 
-#: ../src/html/helpwnd.cpp:875
+#: ../src/html/helpwnd.cpp:873
 #, c-format
 msgid "Found %i matches"
 msgstr "S-au găsit %i rezultate"
 
-#: ../src/generic/prntdlgg.cpp:238
+#: ../src/generic/prntdlgg.cpp:231
 msgid "From:"
 msgstr "De la:"
 
-#: ../src/propgrid/advprops.cpp:1604
+#: ../src/propgrid/advprops.cpp:1510
 msgid "Fuchsia"
 msgstr ""
 
-#: ../src/common/imaggif.cpp:138
+#: ../src/common/imaggif.cpp:135
 msgid "GIF: data stream seems to be truncated."
 msgstr "GIF: fluxul de date pare să fie trunchiat."
 
-#: ../src/common/imaggif.cpp:128
+#: ../src/common/imaggif.cpp:125
 msgid "GIF: error in GIF image format."
 msgstr "GIF: eroare în formatul de imagine GIF."
 
-#: ../src/common/imaggif.cpp:133
+#: ../src/common/imaggif.cpp:130
 msgid "GIF: not enough memory."
 msgstr "GIF: memorie insuficientă."
 
-#: ../src/gtk/window.cpp:4631
+#: ../src/gtk/window.cpp:5635
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -3880,23 +3990,23 @@ msgstr ""
 "GTK+ instalat pe această mașină este prea vechi pentru a suporta compunerea "
 "ecranului, instalați GTK+ 2.12 sau ulterior."
 
-#: ../src/univ/themes/gtk.cpp:525
+#: ../src/univ/themes/gtk.cpp:522
 msgid "GTK+ theme"
 msgstr "Temă GTK+"
 
-#: ../src/common/preferencescmn.cpp:40
+#: ../src/common/preferencescmn.cpp:37
 msgid "General"
 msgstr "General"
 
-#: ../src/common/prntbase.cpp:258
+#: ../src/common/prntbase.cpp:253
 msgid "Generic PostScript"
 msgstr "PostScript generic"
 
-#: ../src/common/paper.cpp:135
+#: ../src/common/paper.cpp:132
 msgid "German Legal Fanfold, 8 1/2 x 13 in"
 msgstr "German Legal Fanfold, 8 1/2 x 13 in"
 
-#: ../src/common/paper.cpp:134
+#: ../src/common/paper.cpp:131
 msgid "German Std Fanfold, 8 1/2 x 12 in"
 msgstr "German Std Fanfold, 8 1/2 x 12 in"
 
@@ -3912,49 +4022,49 @@ msgstr "GetPropertyCollection apelat pentru un accesor generic"
 msgid "GetPropertyCollection called w/o valid collection getter"
 msgstr "GetPropertyCollection apelat cu un getter de colecție invalid"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:658
 msgid "Go back"
 msgstr "Înapoi"
 
-#: ../src/html/helpwnd.cpp:661
+#: ../src/html/helpwnd.cpp:659
 msgid "Go forward"
 msgstr "Înainte"
 
-#: ../src/html/helpwnd.cpp:663
+#: ../src/html/helpwnd.cpp:661
 msgid "Go one level up in document hierarchy"
 msgstr "În sus un nivel în ierarhia documentelor"
 
-#: ../src/generic/filedlgg.cpp:208 ../src/generic/dirdlgg.cpp:116
+#: ../src/generic/filedlgg.cpp:205 ../src/generic/dirdlgg.cpp:113
 msgid "Go to home directory"
 msgstr "Spre directorul inițial"
 
-#: ../src/generic/filedlgg.cpp:205
+#: ../src/generic/filedlgg.cpp:202
 msgid "Go to parent directory"
 msgstr "Spre directorul părinte"
 
-#: ../src/generic/aboutdlgg.cpp:76
+#: ../src/generic/aboutdlgg.cpp:73
 msgid "Graphics art by "
 msgstr "Arta grafică de "
 
-#: ../src/propgrid/advprops.cpp:1599
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Gray"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:883
+#: ../src/propgrid/advprops.cpp:784
 msgid "GrayText"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:154
+#: ../src/common/fmapbase.cpp:151
 msgid "Greek (ISO-8859-7)"
 msgstr "Greacă (ISO-8859-7)"
 
-#: ../src/propgrid/advprops.cpp:1600
+#: ../src/propgrid/advprops.cpp:1506
 #, fuzzy
 msgid "Green"
 msgstr "MacGreek"
 
-#: ../src/generic/colrdlgg.cpp:342
+#: ../src/generic/colrdlgg.cpp:362
 #, fuzzy
 msgid "Green:"
 msgstr "MacGreek"
@@ -3963,109 +4073,109 @@ msgstr "MacGreek"
 msgid "Groove"
 msgstr "Canelură"
 
-#: ../src/common/zstream.cpp:158 ../src/common/zstream.cpp:318
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
 msgid "Gzip not supported by this version of zlib"
 msgstr "Gzip nu e suportat de această versiune de zlib"
 
-#: ../src/html/helpwnd.cpp:1549
+#: ../src/html/helpwnd.cpp:1547
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "HTML Help Project (*.hhp)|*.hhp|"
 
-#: ../src/html/htmlwin.cpp:681
+#: ../src/html/htmlwin.cpp:691
 #, c-format
 msgid "HTML anchor %s does not exist."
 msgstr "Ancora HTML %s nu există."
 
-#: ../src/html/helpwnd.cpp:1547
+#: ../src/html/helpwnd.cpp:1545
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "Fișiere HTML (*.html;*.htm)|*.html;*.htm|"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1759
+#: ../src/propgrid/advprops.cpp:1660
 msgid "Hand"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "Harddisk"
 msgstr "Harddisk"
 
-#: ../src/common/fmapbase.cpp:155
+#: ../src/common/fmapbase.cpp:152
 msgid "Hebrew (ISO-8859-8)"
 msgstr "Ebraică (ISO-8859-8)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:280 ../src/osx/button_osx.cpp:39
-#: ../src/common/stockitem.cpp:163 ../src/common/accelcmn.cpp:80
-#: ../src/html/helpdlg.cpp:66 ../src/html/helpfrm.cpp:111
+#: ../include/wx/msgdlg.h:282 ../src/osx/button_osx.cpp:39
+#: ../src/common/stockitem.cpp:160 ../src/common/accelcmn.cpp:77
+#: ../src/html/helpfrm.cpp:108 ../src/html/helpdlg.cpp:63
 msgid "Help"
 msgstr "Ajutor"
 
-#: ../src/html/helpwnd.cpp:1200
+#: ../src/html/helpwnd.cpp:1198
 msgid "Help Browser Options"
 msgstr "Ajutor pentru opțiunile bowser-ului"
 
-#: ../src/generic/helpext.cpp:454 ../src/generic/helpext.cpp:455
+#: ../src/generic/helpext.cpp:452 ../src/generic/helpext.cpp:453
 msgid "Help Index"
 msgstr "Index ajutor"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1529
 msgid "Help Printing"
 msgstr "Ajutor pentru tipărire "
 
-#: ../src/html/helpwnd.cpp:801
+#: ../src/html/helpwnd.cpp:799
 msgid "Help Topics"
 msgstr "Subiecte de ajutor"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1546
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Manuale de ajutor (*.htb)|*.htb|Manuale de ajutor (*.zip)|*.zip|"
 
-#: ../src/generic/helpext.cpp:267
+#: ../src/generic/helpext.cpp:265
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "Directorul de ajutor \"%s\" nu a fost găsit."
 
-#: ../src/generic/helpext.cpp:275
+#: ../src/generic/helpext.cpp:273
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "Fișierul de ajutor \"%s\" nu a fost găsit."
 
-#: ../src/html/helpctrl.cpp:63
+#: ../src/html/helpctrl.cpp:59
 #, c-format
 msgid "Help: %s"
 msgstr "Ajutor: %s"
 
-#: ../src/osx/menu_osx.cpp:577
+#: ../src/osx/menu_osx.cpp:469
 #, c-format
 msgid "Hide %s"
 msgstr "Ascunde %s"
 
-#: ../src/osx/menu_osx.cpp:579
+#: ../src/osx/menu_osx.cpp:471
 msgid "Hide Others"
 msgstr "Ascunde Restul"
 
-#: ../src/generic/infobar.cpp:84
+#: ../src/generic/infobar.cpp:81
 msgid "Hide this notification message."
 msgstr "Ascunde această notificare."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:884
+#: ../src/propgrid/advprops.cpp:785
 #, fuzzy
 msgid "Highlight"
 msgstr "subțire"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:885
+#: ../src/propgrid/advprops.cpp:786
 #, fuzzy
 msgid "HighlightText"
 msgstr "Aliniază text la dreapta."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:164 ../src/common/accelcmn.cpp:65
+#: ../src/common/stockitem.cpp:161 ../src/common/accelcmn.cpp:62
 msgid "Home"
 msgstr "Acasă"
 
-#: ../src/generic/dirctrlg.cpp:524
+#: ../src/generic/dirctrlg.cpp:490
 msgid "Home directory"
 msgstr "Director acasă"
 
@@ -4075,55 +4185,55 @@ msgid "How the object will float relative to the text."
 msgstr "Cum se va mișca obiectul relativ la text."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1760
+#: ../src/propgrid/advprops.cpp:1661
 msgid "I-Beam"
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1196
+#: ../src/common/imagbmp.cpp:1208
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: Eroare la citirea maștii DIB."
 
-#: ../src/common/imagbmp.cpp:1290 ../src/common/imagbmp.cpp:1390
-#: ../src/common/imagbmp.cpp:1405 ../src/common/imagbmp.cpp:1416
-#: ../src/common/imagbmp.cpp:1430 ../src/common/imagbmp.cpp:1478
-#: ../src/common/imagbmp.cpp:1493 ../src/common/imagbmp.cpp:1507
-#: ../src/common/imagbmp.cpp:1518
+#: ../src/common/imagbmp.cpp:1302 ../src/common/imagbmp.cpp:1402
+#: ../src/common/imagbmp.cpp:1417 ../src/common/imagbmp.cpp:1428
+#: ../src/common/imagbmp.cpp:1442 ../src/common/imagbmp.cpp:1490
+#: ../src/common/imagbmp.cpp:1505 ../src/common/imagbmp.cpp:1519
+#: ../src/common/imagbmp.cpp:1530
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: Eroare la scrierea fișierului imagine!"
 
-#: ../src/common/imagbmp.cpp:1255
+#: ../src/common/imagbmp.cpp:1267
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: Imagine prea înaltă pentru o pictogramă."
 
-#: ../src/common/imagbmp.cpp:1263
+#: ../src/common/imagbmp.cpp:1275
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: Imagine prea lată pentru o pictogramă."
 
-#: ../src/common/imagbmp.cpp:1603
+#: ../src/common/imagbmp.cpp:1615
 msgid "ICO: Invalid icon index."
 msgstr "ICO: Index de pictogramă invalid."
 
-#: ../src/common/imagiff.cpp:758
+#: ../src/common/imagiff.cpp:755
 msgid "IFF: data stream seems to be truncated."
 msgstr "IFF: fluxul de date pare a fi trunchiat."
 
-#: ../src/common/imagiff.cpp:742
+#: ../src/common/imagiff.cpp:739
 msgid "IFF: error in IFF image format."
 msgstr "IFF: eroare în formatul imaginii IFF."
 
-#: ../src/common/imagiff.cpp:745
+#: ../src/common/imagiff.cpp:742
 msgid "IFF: not enough memory."
 msgstr "IFF: memorie insuficientă."
 
-#: ../src/common/imagiff.cpp:748
+#: ../src/common/imagiff.cpp:745
 msgid "IFF: unknown error!!!"
 msgstr "IFF: eroare necunoscută!!!"
 
-#: ../src/common/fmapbase.cpp:197
+#: ../src/common/fmapbase.cpp:194
 msgid "ISO-2022-JP"
 msgstr "ISO-2022-JP"
 
-#: ../src/html/htmprint.cpp:282
+#: ../src/html/htmprint.cpp:294
 msgid ""
 "If possible, try changing the layout parameters to make the printout more "
 "narrow."
@@ -4131,7 +4241,7 @@ msgstr ""
 "Dacă este posibil, schimbați parametrii de formatare pentru a ingusta zona "
 "tiparită."
 
-#: ../src/generic/dbgrptg.cpp:358
+#: ../src/generic/dbgrptg.cpp:362
 msgid ""
 "If you have any additional information pertaining to this bug\n"
 "report, please enter it here and it will be joined to it:"
@@ -4152,46 +4262,50 @@ msgstr ""
 "că\n"
 "dacă se poate este indicat să fie permisă generarea raportului.\n"
 
-#: ../src/msw/registry.cpp:1405
+#: ../src/common/zipstrm.cpp:1043
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1393
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Este ignorată valoarea \"%s\" a cheii \"%s\"."
 
-#: ../src/common/xtistrm.cpp:295
+#: ../src/common/xtistrm.cpp:292
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Obiect de tip nepermis (Non-wxEvtHandler) ca Sursă a Evenimentului"
 
-#: ../src/common/xti.cpp:513
+#: ../src/common/xti.cpp:510
 msgid "Illegal Parameter Count for ConstructObject Method"
 msgstr "Număr incorect de parametri pentru metoda ConstructObject"
 
-#: ../src/common/xti.cpp:501
+#: ../src/common/xti.cpp:498
 msgid "Illegal Parameter Count for Create Method"
 msgstr "Număr de parametri incorect pentru metoda Create"
 
-#: ../src/generic/dirctrlg.cpp:570 ../src/generic/filectrlg.cpp:756
+#: ../src/generic/dirctrlg.cpp:536 ../src/generic/filectrlg.cpp:752
 msgid "Illegal directory name."
 msgstr "Nume ilegal de director."
 
-#: ../src/generic/filectrlg.cpp:1367
+#: ../src/generic/filectrlg.cpp:1356
 msgid "Illegal file specification."
 msgstr "Specificație ilegală de fișier."
 
-#: ../src/common/image.cpp:2269
+#: ../src/common/image.cpp:2363
 msgid "Image and mask have different sizes."
 msgstr "Imaginea și masca au dimensiuni diferite."
 
-#: ../src/common/image.cpp:2746
+#: ../src/common/image.cpp:2841
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "Fișierul imagine nu e de tipul %d."
 
-#: ../src/common/image.cpp:2877
+#: ../src/common/image.cpp:2995
 #, c-format
 msgid "Image is not of type %s."
 msgstr "Imaginea nu e de tipul %s."
 
-#: ../src/msw/textctrl.cpp:488
+#: ../src/msw/textctrl.cpp:534
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -4199,102 +4313,102 @@ msgstr ""
 "Este imposibilă crearea unui control de tip rich edit, se înlocuiește cu un "
 "control simplu de text. Trebuie reinstalat riched32.dll"
 
-#: ../src/unix/utilsunx.cpp:301
+#: ../src/unix/utilsunx.cpp:303
 msgid "Impossible to get child process input"
 msgstr "Sunt imposibil de obținut intrările procesului copil"
 
-#: ../src/common/filefn.cpp:1028
+#: ../src/common/filefn.cpp:917
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Sunt imposibil de obținut permisiunile pentru fișierul '%s'"
 
-#: ../src/common/filefn.cpp:1042
+#: ../src/common/filefn.cpp:931
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Este imposibilă suprascrierea fișierul '%s'"
 
-#: ../src/common/filefn.cpp:1097
+#: ../src/common/filefn.cpp:986
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Este imposibilă setarea permisiunilor pentru fișierul '%s'"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:886
+#: ../src/propgrid/advprops.cpp:787
 #, fuzzy
 msgid "InactiveBorder"
 msgstr "Margine"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:887
+#: ../src/propgrid/advprops.cpp:788
 msgid "InactiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:888
+#: ../src/propgrid/advprops.cpp:789
 msgid "InactiveCaptionText"
 msgstr ""
 
-#: ../src/common/gifdecod.cpp:792
+#: ../src/common/gifdecod.cpp:826
 #, c-format
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "Cadru GIF cu dimensiunea (%u, %d) incorectă pentru cadrul #%u"
 
-#: ../src/msw/ole/automtn.cpp:635
+#: ../src/msw/ole/automtn.cpp:626
 msgid "Incorrect number of arguments."
 msgstr "Numar de argumente incorect."
 
-#: ../src/common/stockitem.cpp:165
+#: ../src/common/stockitem.cpp:162
 msgid "Indent"
 msgstr "Indentare"
 
-#: ../src/richtext/richtextformatdlg.cpp:349
+#: ../src/richtext/richtextformatdlg.cpp:342
 msgid "Indents && Spacing"
 msgstr "Indentare && Spațiere"
 
-#: ../src/common/stockitem.cpp:166 ../src/html/helpwnd.cpp:515
+#: ../src/common/stockitem.cpp:163 ../src/html/helpwnd.cpp:513
 msgid "Index"
 msgstr "Index"
 
-#: ../src/common/fmapbase.cpp:159
+#: ../src/common/fmapbase.cpp:156
 msgid "Indian (ISO-8859-12)"
 msgstr "Indian (ISO-8859-12)"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "Info"
 msgstr "Info"
 
-#: ../src/common/init.cpp:287
+#: ../src/common/init.cpp:284
 msgid "Initialization failed in post init, aborting."
 msgstr "Inițializare eșuată în post-init, se anulează."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:54
+#: ../src/common/accelcmn.cpp:51
 #, fuzzy
 msgid "Ins"
 msgstr "Spre interior"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextsymboldlg.cpp:472 ../src/common/accelcmn.cpp:53
+#: ../src/common/accelcmn.cpp:50 ../src/richtext/richtextsymboldlg.cpp:469
 msgid "Insert"
 msgstr "Inserează"
 
-#: ../src/richtext/richtextbuffer.cpp:8067
+#: ../src/richtext/richtextbuffer.cpp:8063
 msgid "Insert Field"
 msgstr "Inserează Câmp"
 
-#: ../src/richtext/richtextbuffer.cpp:7978
-#: ../src/richtext/richtextbuffer.cpp:8936
+#: ../src/richtext/richtextbuffer.cpp:7974
+#: ../src/richtext/richtextbuffer.cpp:8934
 msgid "Insert Image"
 msgstr "Inserează imagine"
 
-#: ../src/richtext/richtextbuffer.cpp:8025
+#: ../src/richtext/richtextbuffer.cpp:8021
 msgid "Insert Object"
 msgstr "Inserează Obiect"
 
-#: ../src/richtext/richtextctrl.cpp:1286 ../src/richtext/richtextctrl.cpp:1494
-#: ../src/richtext/richtextbuffer.cpp:7822
-#: ../src/richtext/richtextbuffer.cpp:7852
-#: ../src/richtext/richtextbuffer.cpp:7894
+#: ../src/richtext/richtextbuffer.cpp:7818
+#: ../src/richtext/richtextbuffer.cpp:7848
+#: ../src/richtext/richtextbuffer.cpp:7890
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
 msgid "Insert Text"
 msgstr "Inserează text"
 
@@ -4307,16 +4421,11 @@ msgstr "Inserează o intrerupere de pagină înaintea paragrafului."
 msgid "Inset"
 msgstr "Spre interior"
 
-#: ../src/gtk/app.cpp:425
-#, c-format
-msgid "Invalid GTK+ command line option, use \"%s --help\""
-msgstr "Opțiune invalidă pentru linia de comandă GTK+, folosește \"%s --help\""
-
-#: ../src/common/imagtiff.cpp:311
+#: ../src/common/imagtiff.cpp:308
 msgid "Invalid TIFF image index."
 msgstr "Indexul imaginii TIFF este invalid."
 
-#: ../src/common/appcmn.cpp:273
+#: ../src/common/appcmn.cpp:294
 #, c-format
 msgid "Invalid display mode specification '%s'."
 msgstr "Specificația de afișare '%s' este invalidă."
@@ -4326,259 +4435,263 @@ msgstr "Specificația de afișare '%s' este invalidă."
 msgid "Invalid geometry specification '%s'"
 msgstr "Specificația de geometrie '%s' este invalidă"
 
-#: ../src/unix/fswatcher_inotify.cpp:323
+#: ../src/unix/fswatcher_inotify.cpp:320
 #, c-format
 msgid "Invalid inotify event for \"%s\""
 msgstr "Eveniment inotify invalid pentru \"%s\""
 
-#: ../src/unix/snglinst.cpp:312
+#: ../src/unix/snglinst.cpp:309
 #, c-format
 msgid "Invalid lock file '%s'."
 msgstr "Fișier de blocaj '%s' invalid."
 
-#: ../src/common/translation.cpp:1125
+#: ../src/common/translation.cpp:1167
 msgid "Invalid message catalog."
 msgstr "Catalog de mesaje invalid."
 
-#: ../src/common/xtistrm.cpp:405 ../src/common/xtistrm.cpp:420
+#: ../src/common/xtistrm.cpp:402 ../src/common/xtistrm.cpp:417
 msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
 msgstr "ID-ul obiectului pasat către GetObjectClassInfo este invalid sau Null"
 
-#: ../src/common/xtistrm.cpp:435
+#: ../src/common/xtistrm.cpp:432
 msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
 msgstr "ID-ul obiectului pasat către HasObjectClassInfo este invalid sau Null"
 
-#: ../src/common/regex.cpp:310
+#: ../src/common/regex.cpp:307
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Expresie regulată invalidă '%s': %s"
 
-#: ../src/common/config.cpp:226
+#: ../src/common/config.cpp:222
 #, c-format
 msgid "Invalid value %ld for a boolean key \"%s\" in config file."
 msgstr ""
 "Valoarea %ld invalidă pentru cheia boolean \"%s\" din fișierul de "
 "configurare."
 
-#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:351
-#: ../src/osx/carbon/fontdlg.cpp:361 ../src/common/stockitem.cpp:168
+#: ../src/osx/carbon/fontdlg.cpp:358 ../src/common/stockitem.cpp:165
+#: ../src/generic/fontdlgg.cpp:325 ../src/richtext/richtextfontpage.cpp:351
 msgid "Italic"
 msgstr "Cursiv"
 
-#: ../src/common/paper.cpp:130
+#: ../src/common/paper.cpp:127
 msgid "Italy Envelope, 110 x 230 mm"
 msgstr "Italy Plic, 110 x 230 mm"
 
-#: ../src/common/imagjpeg.cpp:270
+#: ../src/common/imagjpeg.cpp:257
 msgid "JPEG: Couldn't load - file is probably corrupted."
 msgstr "JPEG: Nu a putut fi încărcat - fișierul poate fi corupt."
 
-#: ../src/common/imagjpeg.cpp:449
+#: ../src/common/imagjpeg.cpp:436
 msgid "JPEG: Couldn't save image."
 msgstr "JPEG: Nu a putut fi salvată imaginea."
 
-#: ../src/common/paper.cpp:163
+#: ../src/common/paper.cpp:160
 msgid "Japanese Double Postcard 200 x 148 mm"
 msgstr "Japoneză, carte poștală dublă 200 x 148 mm"
 
-#: ../src/common/paper.cpp:167
+#: ../src/common/paper.cpp:164
 msgid "Japanese Envelope Chou #3"
 msgstr "Japoneză, Plic Chou #3"
 
-#: ../src/common/paper.cpp:180
+#: ../src/common/paper.cpp:177
 msgid "Japanese Envelope Chou #3 Rotated"
 msgstr "Japoneză, Plic Chou #3 Rotit"
 
-#: ../src/common/paper.cpp:168
+#: ../src/common/paper.cpp:165
 msgid "Japanese Envelope Chou #4"
 msgstr "Japoneză, Plic Chou #4"
 
-#: ../src/common/paper.cpp:181
+#: ../src/common/paper.cpp:178
 msgid "Japanese Envelope Chou #4 Rotated"
 msgstr "Japoneză, Plic Chou #4 Rotit"
 
-#: ../src/common/paper.cpp:165
+#: ../src/common/paper.cpp:162
 msgid "Japanese Envelope Kaku #2"
 msgstr "Japoneză, Plic Kaku #2"
 
-#: ../src/common/paper.cpp:178
+#: ../src/common/paper.cpp:175
 msgid "Japanese Envelope Kaku #2 Rotated"
 msgstr "Japoneză, Plic Kaku #2 Rotit"
 
-#: ../src/common/paper.cpp:166
+#: ../src/common/paper.cpp:163
 msgid "Japanese Envelope Kaku #3"
 msgstr "Japoneză, Plic Kaku #3"
 
-#: ../src/common/paper.cpp:179
+#: ../src/common/paper.cpp:176
 msgid "Japanese Envelope Kaku #3 Rotated"
 msgstr "Japoneză, Plic Kaku #3 Rotit"
 
-#: ../src/common/paper.cpp:185
+#: ../src/common/paper.cpp:182
 msgid "Japanese Envelope You #4"
 msgstr "Japoneză, Plic You #4"
 
-#: ../src/common/paper.cpp:186
+#: ../src/common/paper.cpp:183
 msgid "Japanese Envelope You #4 Rotated"
 msgstr "Japoneză, Plic You #4 Rotit"
 
-#: ../src/common/paper.cpp:138
+#: ../src/common/paper.cpp:135
 msgid "Japanese Postcard 100 x 148 mm"
 msgstr "Japoneză, carte postală 100 x 148 mm"
 
-#: ../src/common/paper.cpp:175
+#: ../src/common/paper.cpp:172
 msgid "Japanese Postcard Rotated 148 x 100 mm"
 msgstr "Japoneză, Carte Postală Rotită 148 x 100 mm"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "Jump to"
 msgstr "Mergi la"
 
-#: ../src/common/stockitem.cpp:171
+#: ../src/common/stockitem.cpp:168
 msgid "Justified"
 msgstr "Aliniat la margini"
 
-#: ../src/richtext/richtextindentspage.cpp:155
-#: ../src/richtext/richtextindentspage.cpp:157
 #: ../src/richtext/richtextliststylepage.cpp:344
 #: ../src/richtext/richtextliststylepage.cpp:346
+#: ../src/richtext/richtextindentspage.cpp:155
+#: ../src/richtext/richtextindentspage.cpp:157
 msgid "Justify text left and right."
 msgstr "Aliniază text la stânga și la dreapta."
 
-#: ../src/common/fmapbase.cpp:163
+#: ../src/common/fmapbase.cpp:160
 msgid "KOI8-R"
 msgstr "KOI8-R"
 
-#: ../src/common/fmapbase.cpp:164
+#: ../src/common/fmapbase.cpp:161
 msgid "KOI8-U"
 msgstr "KOI8-U"
 
-#: ../src/common/accelcmn.cpp:265 ../src/common/accelcmn.cpp:347
+#: ../src/common/accelcmn.cpp:279 ../src/common/accelcmn.cpp:364
 msgid "KP_"
 msgstr "KP_"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 #, fuzzy
 msgid "KP_Add"
 msgstr "KP_ADD"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "KP_Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "KP_Decimal"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 #, fuzzy
 msgid "KP_Delete"
 msgstr "Șterge"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "KP_Divide"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 #, fuzzy
 msgid "KP_Down"
 msgstr "Jos"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 #, fuzzy
 msgid "KP_End"
 msgstr "KP_END"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 #, fuzzy
 msgid "KP_Enter"
 msgstr "Imprimantă"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "KP_Equal"
 msgstr ""
 
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
-#, fuzzy
-msgid "KP_Home"
-msgstr "Acasă"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
-#, fuzzy
-msgid "KP_Insert"
-msgstr "Inserează"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
-#, fuzzy
-msgid "KP_Left"
-msgstr "Stânga"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
-msgid "KP_Multiply"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:99
-#, fuzzy
-msgid "KP_Next"
-msgstr "Următorul"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
-msgid "KP_PageDown"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
-msgid "KP_PageUp"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:98
-msgid "KP_Prior"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
-#, fuzzy
-msgid "KP_Right"
-msgstr "Dreapta"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
-msgid "KP_Separator"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
-msgid "KP_Space"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
-msgid "KP_Subtract"
+#: ../src/common/accelcmn.cpp:276 ../src/common/accelcmn.cpp:361
+msgid "KP_F"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
 #: ../src/common/accelcmn.cpp:89
 #, fuzzy
+msgid "KP_Home"
+msgstr "Acasă"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:100
+#, fuzzy
+msgid "KP_Insert"
+msgstr "Inserează"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:90
+#, fuzzy
+msgid "KP_Left"
+msgstr "Stânga"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:103
+msgid "KP_Multiply"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:97
+#, fuzzy
+msgid "KP_Next"
+msgstr "Următorul"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:95
+msgid "KP_PageDown"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:94
+msgid "KP_PageUp"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:96
+msgid "KP_Prior"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:92
+#, fuzzy
+msgid "KP_Right"
+msgstr "Dreapta"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:105
+msgid "KP_Separator"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:86
+msgid "KP_Space"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:106
+msgid "KP_Subtract"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:87
+#, fuzzy
 msgid "KP_Tab"
 msgstr "KP_TAB"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 #, fuzzy
 msgid "KP_Up"
 msgstr "KP_UP"
@@ -4587,19 +4700,34 @@ msgstr "KP_UP"
 msgid "L&ine spacing:"
 msgstr "&Spațiere linii:"
 
-#: ../src/generic/prntdlgg.cpp:613 ../src/generic/prntdlgg.cpp:868
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "eroare la comprimare"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "eroare la decomprimare"
+
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:861
 msgid "Landscape"
 msgstr "Orizontal"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "Last"
 msgstr "Ultimul"
 
-#: ../src/common/prntbase.cpp:1572
+#: ../src/common/prntbase.cpp:1597
 msgid "Last page"
 msgstr "Ultima pagină"
 
-#: ../src/common/log.cpp:305
+#: ../src/common/log.cpp:324
 #, fuzzy, c-format
 msgid "Last repeated message (\"%s\", %u time) wasn't output"
 msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
@@ -4607,93 +4735,93 @@ msgstr[0] "Ultimul mesaj repetat (\"%s\", %lu data) nu a fost afișat"
 msgstr[1] "Ultimul mesaj repetat (\"%s\", %lu ori) nu a fost afișat"
 msgstr[2] "Ultimul mesaj repetat (\"%s\", %lu de ori) nu a fost afișat"
 
-#: ../src/common/paper.cpp:103
+#: ../src/common/paper.cpp:100
 msgid "Ledger, 17 x 11 in"
 msgstr "Registru, 17 x 11 in"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6146
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:58 ../src/generic/datavgen.cpp:6951
+#: ../src/richtext/richtextsizepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:252
 #: ../src/richtext/richtextliststylepage.cpp:253
 #: ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
-#: ../src/richtext/richtextsizepage.cpp:249 ../src/common/accelcmn.cpp:61
 msgid "Left"
 msgstr "Stânga"
 
-#: ../src/richtext/richtextindentspage.cpp:204
 #: ../src/richtext/richtextliststylepage.cpp:390
+#: ../src/richtext/richtextindentspage.cpp:204
 msgid "Left (&first line):"
 msgstr "Stânga (pri&ma linie):"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1761
+#: ../src/propgrid/advprops.cpp:1662
 msgid "Left Button"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:880
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Left margin (mm):"
 msgstr "Margine stânga (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:141
-#: ../src/richtext/richtextindentspage.cpp:143
 #: ../src/richtext/richtextliststylepage.cpp:330
 #: ../src/richtext/richtextliststylepage.cpp:332
+#: ../src/richtext/richtextindentspage.cpp:141
+#: ../src/richtext/richtextindentspage.cpp:143
 msgid "Left-align text."
 msgstr "Aliniază text la stânga."
 
-#: ../src/common/paper.cpp:144
+#: ../src/common/paper.cpp:141
 msgid "Legal Extra 9 1/2 x 15 in"
 msgstr "Legal Extra 9 1/2 x 15 in"
 
-#: ../src/common/paper.cpp:96
+#: ../src/common/paper.cpp:93
 msgid "Legal, 8 1/2 x 14 in"
 msgstr "Legal, 8 1/2 x 14 in"
 
-#: ../src/common/paper.cpp:143
+#: ../src/common/paper.cpp:140
 msgid "Letter Extra 9 1/2 x 12 in"
 msgstr "Letter Extra 9 1/2 x 12 in"
 
-#: ../src/common/paper.cpp:149
+#: ../src/common/paper.cpp:146
 msgid "Letter Extra Transverse 9.275 x 12 in"
 msgstr "Letter Extra Transverse 9.275 x 12 in"
 
-#: ../src/common/paper.cpp:152
+#: ../src/common/paper.cpp:149
 msgid "Letter Plus 8 1/2 x 12.69 in"
 msgstr "Letter Plus 8 1/2 x 12.69 in"
 
-#: ../src/common/paper.cpp:169
+#: ../src/common/paper.cpp:166
 msgid "Letter Rotated 11 x 8 1/2 in"
 msgstr "Letter rotit 11 x 8 1/2 in"
 
-#: ../src/common/paper.cpp:101
+#: ../src/common/paper.cpp:98
 msgid "Letter Small, 8 1/2 x 11 in"
 msgstr "Letter mic, 8 1/2 x 11 in"
 
-#: ../src/common/paper.cpp:147
+#: ../src/common/paper.cpp:144
 msgid "Letter Transverse 8 1/2 x 11 in"
 msgstr "Letter Transverse 8 1/2 x 11 in"
 
-#: ../src/common/paper.cpp:95
+#: ../src/common/paper.cpp:92
 msgid "Letter, 8 1/2 x 11 in"
 msgstr "Letter, 8 1/2 x 11 in"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "License"
 msgstr "Licență"
 
-#: ../src/generic/fontdlgg.cpp:332
+#: ../src/generic/fontdlgg.cpp:328
 msgid "Light"
 msgstr "Subțiat"
 
-#: ../src/propgrid/advprops.cpp:1608
+#: ../src/propgrid/advprops.cpp:1514
 msgid "Lime"
 msgstr ""
 
-#: ../src/generic/helpext.cpp:294
+#: ../src/generic/helpext.cpp:292
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr "Linia %lu a fișierului hartă \"%s\" are sintaxa incorectă, sărită."
@@ -4702,15 +4830,15 @@ msgstr "Linia %lu a fișierului hartă \"%s\" are sintaxa incorectă, sărită."
 msgid "Line spacing:"
 msgstr "Spațiere linii:"
 
-#: ../src/html/chm.cpp:838
+#: ../src/html/chm.cpp:829
 msgid "Link contained '//', converted to absolute link."
 msgstr "Legătura conținea '//', a fost convertită la legătură absolută."
 
-#: ../src/richtext/richtextformatdlg.cpp:364
+#: ../src/richtext/richtextformatdlg.cpp:357
 msgid "List Style"
 msgstr "Stil de listă"
 
-#: ../src/richtext/richtextstyles.cpp:1064
+#: ../src/richtext/richtextstyles.cpp:1061
 msgid "List styles"
 msgstr "Stiluri de listă"
 
@@ -4724,26 +4852,26 @@ msgstr "Afișează dimensiunile fonturilor în puncte."
 msgid "Lists the available fonts."
 msgstr "Afișează fonturile disponibile."
 
-#: ../src/common/fldlgcmn.cpp:340
+#: ../src/common/fldlgcmn.cpp:337
 #, c-format
 msgid "Load %s file"
 msgstr "Încarcă fișier %s"
 
-#: ../src/html/htmlwin.cpp:597
+#: ../src/html/htmlwin.cpp:600
 msgid "Loading : "
 msgstr "Se încarcă : "
 
-#: ../src/unix/snglinst.cpp:246
+#: ../src/unix/snglinst.cpp:243
 #, c-format
 msgid "Lock file '%s' has incorrect owner."
 msgstr "Fișierul de blocaj '%s' are proprietar incorect."
 
-#: ../src/unix/snglinst.cpp:251
+#: ../src/unix/snglinst.cpp:248
 #, c-format
 msgid "Lock file '%s' has incorrect permissions."
 msgstr "Fișierul de blocaj '%s' are permisiuni incorecte."
 
-#: ../src/generic/logg.cpp:576
+#: ../src/generic/logg.cpp:573
 #, c-format
 msgid "Log saved to the file '%s'."
 msgstr "Raport salvat în fișierul '%s'."
@@ -4758,11 +4886,11 @@ msgstr "Litere mici"
 msgid "Lower case roman numerals"
 msgstr "Numere romane în litere mici"
 
-#: ../src/gtk/mdi.cpp:422 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk1/mdi.cpp:431 ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "Copil MDI"
 
-#: ../src/msw/helpchm.cpp:56
+#: ../src/msw/helpchm.cpp:53
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -4770,189 +4898,189 @@ msgstr ""
 "Funcțiile MS HTML Help nu sunt disponibile pentru că librăria MS HTML Help "
 "nu este instalată pe această mașină. Trebuie instalată."
 
-#: ../src/univ/themes/win32.cpp:3754
+#: ../src/univ/themes/win32.cpp:3751
 msgid "Ma&ximize"
 msgstr "Ma&ximizează"
 
-#: ../src/common/fmapbase.cpp:203
+#: ../src/common/fmapbase.cpp:200
 msgid "MacArabic"
 msgstr "MacArabic"
 
-#: ../src/common/fmapbase.cpp:222
+#: ../src/common/fmapbase.cpp:219
 msgid "MacArmenian"
 msgstr "MacArmenian"
 
-#: ../src/common/fmapbase.cpp:211
+#: ../src/common/fmapbase.cpp:208
 msgid "MacBengali"
 msgstr "MacBengali"
 
-#: ../src/common/fmapbase.cpp:217
+#: ../src/common/fmapbase.cpp:214
 msgid "MacBurmese"
 msgstr "MacBurmese"
 
-#: ../src/common/fmapbase.cpp:236
+#: ../src/common/fmapbase.cpp:233
 msgid "MacCeltic"
 msgstr "MacCeltic"
 
-#: ../src/common/fmapbase.cpp:227
+#: ../src/common/fmapbase.cpp:224
 msgid "MacCentralEurRoman"
 msgstr "MacCentralEurRoman"
 
-#: ../src/common/fmapbase.cpp:223
+#: ../src/common/fmapbase.cpp:220
 msgid "MacChineseSimp"
 msgstr "MacChineseSimp"
 
-#: ../src/common/fmapbase.cpp:201
+#: ../src/common/fmapbase.cpp:198
 msgid "MacChineseTrad"
 msgstr "MacChineseTrad"
 
-#: ../src/common/fmapbase.cpp:233
+#: ../src/common/fmapbase.cpp:230
 msgid "MacCroatian"
 msgstr "MacCroatian"
 
-#: ../src/common/fmapbase.cpp:206
+#: ../src/common/fmapbase.cpp:203
 msgid "MacCyrillic"
 msgstr "MacCyrillic"
 
-#: ../src/common/fmapbase.cpp:207
+#: ../src/common/fmapbase.cpp:204
 msgid "MacDevanagari"
 msgstr "MacDevanagari"
 
-#: ../src/common/fmapbase.cpp:231
+#: ../src/common/fmapbase.cpp:228
 msgid "MacDingbats"
 msgstr "MacDingbats"
 
-#: ../src/common/fmapbase.cpp:226
+#: ../src/common/fmapbase.cpp:223
 msgid "MacEthiopic"
 msgstr "MacEthiopic"
 
-#: ../src/common/fmapbase.cpp:229
+#: ../src/common/fmapbase.cpp:226
 msgid "MacExtArabic"
 msgstr "MacExtArabic"
 
-#: ../src/common/fmapbase.cpp:237
+#: ../src/common/fmapbase.cpp:234
 msgid "MacGaelic"
 msgstr "MacGaelic"
 
-#: ../src/common/fmapbase.cpp:221
+#: ../src/common/fmapbase.cpp:218
 msgid "MacGeorgian"
 msgstr "MacGeorgian"
 
-#: ../src/common/fmapbase.cpp:205
+#: ../src/common/fmapbase.cpp:202
 msgid "MacGreek"
 msgstr "MacGreek"
 
-#: ../src/common/fmapbase.cpp:209
+#: ../src/common/fmapbase.cpp:206
 msgid "MacGujarati"
 msgstr "MacGujarati"
 
-#: ../src/common/fmapbase.cpp:208
+#: ../src/common/fmapbase.cpp:205
 msgid "MacGurmukhi"
 msgstr "MacGurmukhi"
 
-#: ../src/common/fmapbase.cpp:204
+#: ../src/common/fmapbase.cpp:201
 msgid "MacHebrew"
 msgstr "MacHebrew"
 
-#: ../src/common/fmapbase.cpp:234
+#: ../src/common/fmapbase.cpp:231
 msgid "MacIcelandic"
 msgstr "MacIcelandic"
 
-#: ../src/common/fmapbase.cpp:200
+#: ../src/common/fmapbase.cpp:197
 msgid "MacJapanese"
 msgstr "MacJapanese"
 
-#: ../src/common/fmapbase.cpp:214
+#: ../src/common/fmapbase.cpp:211
 msgid "MacKannada"
 msgstr "MacKannada"
 
-#: ../src/common/fmapbase.cpp:238
+#: ../src/common/fmapbase.cpp:235
 msgid "MacKeyboardGlyphs"
 msgstr "MacKeyboardGlyphs"
 
-#: ../src/common/fmapbase.cpp:218
+#: ../src/common/fmapbase.cpp:215
 msgid "MacKhmer"
 msgstr "MacKhmer"
 
-#: ../src/common/fmapbase.cpp:202
+#: ../src/common/fmapbase.cpp:199
 msgid "MacKorean"
 msgstr "MacKorean"
 
-#: ../src/common/fmapbase.cpp:220
+#: ../src/common/fmapbase.cpp:217
 msgid "MacLaotian"
 msgstr "MacLaotian"
 
-#: ../src/common/fmapbase.cpp:215
+#: ../src/common/fmapbase.cpp:212
 msgid "MacMalayalam"
 msgstr "MacMalayalam"
 
-#: ../src/common/fmapbase.cpp:225
+#: ../src/common/fmapbase.cpp:222
 msgid "MacMongolian"
 msgstr "MacMongolian"
 
-#: ../src/common/fmapbase.cpp:210
+#: ../src/common/fmapbase.cpp:207
 msgid "MacOriya"
 msgstr "MacOriya"
 
-#: ../src/common/fmapbase.cpp:199
+#: ../src/common/fmapbase.cpp:196
 msgid "MacRoman"
 msgstr "MacRoman"
 
-#: ../src/common/fmapbase.cpp:235
+#: ../src/common/fmapbase.cpp:232
 msgid "MacRomanian"
 msgstr "MacRomanian"
 
-#: ../src/common/fmapbase.cpp:216
+#: ../src/common/fmapbase.cpp:213
 msgid "MacSinhalese"
 msgstr "MacSinhalese"
 
-#: ../src/common/fmapbase.cpp:230
+#: ../src/common/fmapbase.cpp:227
 msgid "MacSymbol"
 msgstr "MacSymbol"
 
-#: ../src/common/fmapbase.cpp:212
+#: ../src/common/fmapbase.cpp:209
 msgid "MacTamil"
 msgstr "MacTamil"
 
-#: ../src/common/fmapbase.cpp:213
+#: ../src/common/fmapbase.cpp:210
 msgid "MacTelugu"
 msgstr "MacTelugu"
 
-#: ../src/common/fmapbase.cpp:219
+#: ../src/common/fmapbase.cpp:216
 msgid "MacThai"
 msgstr "MacThai"
 
-#: ../src/common/fmapbase.cpp:224
+#: ../src/common/fmapbase.cpp:221
 msgid "MacTibetan"
 msgstr "MacTibetan"
 
-#: ../src/common/fmapbase.cpp:232
+#: ../src/common/fmapbase.cpp:229
 msgid "MacTurkish"
 msgstr "MacTurkish"
 
-#: ../src/common/fmapbase.cpp:228
+#: ../src/common/fmapbase.cpp:225
 msgid "MacVietnamese"
 msgstr "MacVietnamese"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1762
+#: ../src/propgrid/advprops.cpp:1663
 msgid "Magnifier"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:2143
+#: ../src/propgrid/advprops.cpp:2050
 msgid "Make a selection:"
 msgstr "Selectează:"
 
-#: ../src/richtext/richtextformatdlg.cpp:374
+#: ../src/richtext/richtextformatdlg.cpp:367
 #: ../src/richtext/richtextmarginspage.cpp:171
 msgid "Margins"
 msgstr "Margini"
 
-#: ../src/propgrid/advprops.cpp:1595
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Maroon"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:147
+#: ../src/generic/fdrepdlg.cpp:144
 msgid "Match case"
 msgstr "Conform majuscule/minuscule"
 
@@ -4964,40 +5092,40 @@ msgstr "Înălțimea maximă:"
 msgid "Max width:"
 msgstr "Lățimea maximă:"
 
-#: ../src/unix/mediactrl.cpp:947
+#: ../src/unix/mediactrl.cpp:972
 #, c-format
 msgid "Media playback error: %s"
 msgstr "Eroare de redare media: %s"
 
-#: ../src/common/fs_mem.cpp:175
+#: ../src/common/fs_mem.cpp:170
 #, c-format
 msgid "Memory VFS already contains file '%s'!"
 msgstr "VFS din memorie conține deja fișierul '%s'!"
 
 #. TRANSLATORS: Name of keyboard key
 #. TRANSLATORS: Keyword of system colour
-#: ../src/common/accelcmn.cpp:73 ../src/propgrid/advprops.cpp:889
+#: ../src/common/accelcmn.cpp:70 ../src/propgrid/advprops.cpp:790
 msgid "Menu"
 msgstr "Meniu"
 
-#: ../src/common/msgout.cpp:124
+#: ../src/common/msgout.cpp:121
 msgid "Message"
 msgstr "Mesaj"
 
-#: ../src/univ/themes/metal.cpp:168
+#: ../src/univ/themes/metal.cpp:165
 msgid "Metal theme"
 msgstr "Tema Metal"
 
-#: ../src/msw/ole/automtn.cpp:652
+#: ../src/msw/ole/automtn.cpp:643
 msgid "Method or property not found."
 msgstr "Metoda sau proprietatea nu a fost găsită."
 
-#: ../src/univ/themes/win32.cpp:3752
+#: ../src/univ/themes/win32.cpp:3749
 msgid "Mi&nimize"
 msgstr "Mi&nimizează"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1763
+#: ../src/propgrid/advprops.cpp:1664
 msgid "Middle Button"
 msgstr ""
 
@@ -5009,37 +5137,42 @@ msgstr "Înălțimea minimă:"
 msgid "Min width:"
 msgstr "Lățime minimă:"
 
-#: ../src/msw/ole/automtn.cpp:668
+#: ../src/osx/cocoa/menu.mm:281
+#, fuzzy
+msgid "Minimize"
+msgstr "Mi&nimizează"
+
+#: ../src/msw/ole/automtn.cpp:659
 msgid "Missing a required parameter."
 msgstr "Lipsește un parametru necesar."
 
-#: ../src/generic/fontdlgg.cpp:324
+#: ../src/generic/fontdlgg.cpp:320
 msgid "Modern"
 msgstr "Modern"
 
-#: ../src/generic/filectrlg.cpp:427
+#: ../src/generic/filectrlg.cpp:423
 msgid "Modified"
 msgstr "Modificat"
 
-#: ../src/common/module.cpp:133
+#: ../src/common/module.cpp:130
 #, c-format
 msgid "Module \"%s\" initialization failed"
 msgstr "Inițializarea modulului \"%s\" a eșuat"
 
-#: ../src/common/paper.cpp:131
+#: ../src/common/paper.cpp:128
 msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
 msgstr "Monarch Plic, 3 7/8 x 7 1/2 in"
 
-#: ../src/msw/fswatcher.cpp:143
+#: ../src/msw/fswatcher.cpp:140
 msgid "Monitoring individual files for changes is not supported currently."
 msgstr ""
 "Monitorizarea pentru schimbări a fișierelor individuale nu este suportată."
 
-#: ../src/generic/editlbox.cpp:172
+#: ../src/generic/editlbox.cpp:160
 msgid "Move down"
 msgstr "Mută în jos"
 
-#: ../src/generic/editlbox.cpp:171
+#: ../src/generic/editlbox.cpp:155
 msgid "Move up"
 msgstr "Mută în sus"
 
@@ -5053,97 +5186,102 @@ msgstr "Mută obiectul în următorul paragraf."
 msgid "Moves the object to the previous paragraph."
 msgstr "Mută obiectul în paragraful anterior."
 
-#: ../src/richtext/richtextbuffer.cpp:9966
+#: ../src/richtext/richtextbuffer.cpp:9963
 msgid "Multiple Cell Properties"
 msgstr "Proprietăți pentru celule multiple"
 
-#: ../src/generic/filectrlg.cpp:424
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:82
+msgid "Multiply"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:420
 msgid "Name"
 msgstr "Nume"
 
-#: ../src/propgrid/advprops.cpp:1596
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Navy"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "Network"
 msgstr "Rețea"
 
-#: ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173
 msgid "New"
 msgstr "Nou"
 
-#: ../src/richtext/richtextstyledlg.cpp:243
+#: ../src/richtext/richtextstyledlg.cpp:239
 msgid "New &Box Style..."
 msgstr "Stil nou de &casetă..."
 
-#: ../src/richtext/richtextstyledlg.cpp:225
+#: ../src/richtext/richtextstyledlg.cpp:221
 msgid "New &Character Style..."
 msgstr "Stil nou de &caractere..."
 
-#: ../src/richtext/richtextstyledlg.cpp:237
+#: ../src/richtext/richtextstyledlg.cpp:233
 msgid "New &List Style..."
 msgstr "Stil nou de &listă..."
 
-#: ../src/richtext/richtextstyledlg.cpp:231
+#: ../src/richtext/richtextstyledlg.cpp:227
 msgid "New &Paragraph Style..."
 msgstr "Stil nou de &paragraf..."
 
-#: ../src/richtext/richtextstyledlg.cpp:606
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:654
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:820
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:893
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:934
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:602
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:650
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:816
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:889
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:930
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "New Style"
 msgstr "Stil nou"
 
-#: ../src/generic/editlbox.cpp:169
+#: ../src/generic/editlbox.cpp:139
 msgid "New item"
 msgstr "Element nou"
 
-#: ../src/generic/dirdlgg.cpp:297 ../src/generic/dirdlgg.cpp:307
-#: ../src/generic/filectrlg.cpp:618 ../src/generic/filectrlg.cpp:627
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+#: ../src/generic/dirdlgg.cpp:294 ../src/generic/dirdlgg.cpp:304
 msgid "NewName"
 msgstr "NumeNou"
 
-#: ../src/common/prntbase.cpp:1567 ../src/html/helpwnd.cpp:665
+#: ../src/common/prntbase.cpp:1592 ../src/html/helpwnd.cpp:663
 msgid "Next page"
 msgstr "Pagina următoare"
 
-#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:177
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:174
 #: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Nu"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1764
+#: ../src/propgrid/advprops.cpp:1665
 msgid "No Entry"
 msgstr ""
 
-#: ../src/generic/animateg.cpp:150
+#: ../src/generic/animateg.cpp:133
 #, c-format
 msgid "No animation handler for type %ld defined."
 msgstr "Nu există manipulator de animație pentru tipul %ld definit."
 
-#: ../src/dfb/bitmap.cpp:642 ../src/dfb/bitmap.cpp:676
+#: ../src/dfb/bitmap.cpp:639 ../src/dfb/bitmap.cpp:673
 #, c-format
 msgid "No bitmap handler for type %d defined."
 msgstr "Nu există manipulator de bitmap pentru tipul %d definit."
 
-#: ../src/common/utilscmn.cpp:1077
+#: ../src/common/utilscmn.cpp:1095
 msgid "No default application configured for HTML files."
 msgstr "Nu există aplicație implicită configurată pentru fișierele HTML."
 
-#: ../src/generic/helpext.cpp:445
+#: ../src/generic/helpext.cpp:443
 msgid "No entries found."
 msgstr "Nu s-au găsit intrări."
 
-#: ../src/common/fontmap.cpp:421
+#: ../src/common/fontmap.cpp:418
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found,\n"
@@ -5155,7 +5293,7 @@ msgstr ""
 "dar o codificare alternativă '%s' este disponibilă.\n"
 "Vreți să folosiți această codificare (altfel va trebui aleasă alta diferită)?"
 
-#: ../src/common/fontmap.cpp:426
+#: ../src/common/fontmap.cpp:423
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found.\n"
@@ -5166,206 +5304,206 @@ msgstr ""
 "Vreți să alegeți un font pentru a fi folosit cu această codificare\n"
 "(altfel textul folosind această codificare nu va fi afișat corect)?"
 
-#: ../src/generic/animateg.cpp:142
+#: ../src/generic/animateg.cpp:125
 msgid "No handler found for animation type."
 msgstr "Nu a fost găsit niciun manipulator pentru tipul de animație."
 
-#: ../src/common/image.cpp:2728
+#: ../src/common/image.cpp:2823
 msgid "No handler found for image type."
 msgstr "Nu a fost găsit niciun manipulator pentru tipul de imagine."
 
-#: ../src/common/image.cpp:2736 ../src/common/image.cpp:2848
-#: ../src/common/image.cpp:2901
+#: ../src/common/image.cpp:2831 ../src/common/image.cpp:2954
+#: ../src/common/image.cpp:3020
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "Nu a fost definit niciun manipulator de imagine pentru tipul %d."
 
-#: ../src/common/image.cpp:2871 ../src/common/image.cpp:2915
+#: ../src/common/image.cpp:2986 ../src/common/image.cpp:3034
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "Nu a fost definit niciun manipulator de imagine pentru tipul %s."
 
-#: ../src/html/helpwnd.cpp:858
+#: ../src/html/helpwnd.cpp:856
 msgid "No matching page found yet"
 msgstr "Nicio pagină corespunzătoare găsită încă"
 
-#: ../src/unix/sound.cpp:81
+#: ../src/unix/sound.cpp:78
 msgid "No sound"
 msgstr "Fără sunet"
 
-#: ../src/common/image.cpp:2277 ../src/common/image.cpp:2318
+#: ../src/common/image.cpp:2371 ../src/common/image.cpp:2412
 msgid "No unused colour in image being masked."
 msgstr "Nicio culoare nefolosită din imagine nu este mascată."
 
-#: ../src/common/image.cpp:3374
-msgid "No unused colour in image."
-msgstr "Nu există culoare nefolosită în imagine."
-
-#: ../src/generic/helpext.cpp:302
+#: ../src/generic/helpext.cpp:300
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "Nu au fost găsite asocieri valide în fișierul \"%s\"."
 
-#: ../src/richtext/richtextborderspage.cpp:610
 #: ../src/richtext/richtextsizepage.cpp:248
 #: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:610
 msgid "None"
 msgstr "Niciuna"
 
-#: ../src/common/fmapbase.cpp:157
+#: ../src/common/fmapbase.cpp:154
 msgid "Nordic (ISO-8859-10)"
 msgstr "Nordică (ISO-8859-10)"
 
-#: ../src/generic/fontdlgg.cpp:328 ../src/generic/fontdlgg.cpp:331
+#: ../src/generic/fontdlgg.cpp:324 ../src/generic/fontdlgg.cpp:327
 msgid "Normal"
 msgstr "Normal"
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1261
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Font normal<br>și <u>subliniat</u>. "
 
-#: ../src/html/helpwnd.cpp:1205
+#: ../src/html/helpwnd.cpp:1203
 msgid "Normal font:"
 msgstr "Font normal:"
 
-#: ../src/propgrid/props.cpp:1128
+#: ../src/propgrid/props.cpp:1115
 #, c-format
 msgid "Not %s"
 msgstr "Nu %s"
 
-#: ../include/wx/filename.h:573 ../include/wx/filename.h:578
-msgid "Not available"
-msgstr "Indisponibil"
+#: ../src/common/secretstore.cpp:168
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/webrequest.cpp:605
+msgid "Not enough free disk space for download."
+msgstr ""
 
 #: ../src/richtext/richtextfontpage.cpp:358
 msgid "Not underlined"
 msgstr "Nesubliniat"
 
-#: ../src/common/paper.cpp:115
+#: ../src/common/paper.cpp:112
 msgid "Note, 8 1/2 x 11 in"
 msgstr "Note, 8 1/2 x 11 in"
 
-#: ../src/generic/notifmsgg.cpp:132
+#: ../src/generic/notifmsgg.cpp:129
 msgid "Notice"
 msgstr "Notificare"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "Num *"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "Num +"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "Num ,"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "Num -"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "Num ."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "Num /"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "Num ="
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "Num Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 #, fuzzy
 msgid "Num Delete"
 msgstr "Șterge"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 #, fuzzy
 msgid "Num Down"
 msgstr "Jos"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "Num End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "Num Enter"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 #, fuzzy
 msgid "Num Home"
 msgstr "Acasă"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 #, fuzzy
 msgid "Num Insert"
 msgstr "Inserează"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num Lock"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "Num Page Down"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "Num Page Up"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 #, fuzzy
 msgid "Num Right"
 msgstr "Dreapta"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "Num Space"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "Num Tab"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "Num Up"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "Num left"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num_lock"
 msgstr ""
 
@@ -5374,13 +5512,13 @@ msgstr ""
 msgid "Numbered outline"
 msgstr "Contur cu numerotare"
 
-#: ../include/wx/msgdlg.h:278 ../src/richtext/richtextstyledlg.cpp:297
-#: ../src/common/stockitem.cpp:178 ../src/msw/msgdlg.cpp:454
-#: ../src/msw/msgdlg.cpp:747 ../src/gtk1/fontdlg.cpp:138
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:175
+#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/msgdlg.cpp:741 ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "OK"
 
-#: ../src/msw/ole/automtn.cpp:692
+#: ../src/msw/ole/automtn.cpp:683
 #, c-format
 msgid "OLE Automation error in %s: %s"
 msgstr "Eroare de automatizare OLE în %s: %s"
@@ -5389,15 +5527,15 @@ msgstr "Eroare de automatizare OLE în %s: %s"
 msgid "Object Properties"
 msgstr "Proprietăți Obiect"
 
-#: ../src/msw/ole/automtn.cpp:660
+#: ../src/msw/ole/automtn.cpp:651
 msgid "Object implementation does not support named arguments."
 msgstr "Implementearea obiectului nu suportă argumente cu denumire."
 
-#: ../src/common/xtixml.cpp:264
+#: ../src/common/xtixml.cpp:260
 msgid "Objects must have an id attribute"
 msgstr "Obiectele trebuie să aibă un atribut id"
 
-#: ../src/propgrid/advprops.cpp:1601
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Olive"
 msgstr ""
 
@@ -5405,64 +5543,69 @@ msgstr ""
 msgid "Opaci&ty:"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:354
+#: ../src/generic/colrdlgg.cpp:374
 msgid "Opacity:"
 msgstr ""
 
-#: ../src/common/docview.cpp:1773 ../src/common/docview.cpp:1815
+#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
 msgid "Open File"
 msgstr "Deschide fișier"
 
-#: ../src/html/helpwnd.cpp:671 ../src/html/helpwnd.cpp:1554
+#: ../src/html/helpwnd.cpp:669 ../src/html/helpwnd.cpp:1552
 msgid "Open HTML document"
 msgstr "Deschide document HTML"
 
-#: ../src/generic/dbgrptg.cpp:163
+#: ../src/common/stockitem.cpp:265
+#, fuzzy
+msgid "Open an existing document"
+msgstr "Deschide document HTML"
+
+#: ../src/generic/dbgrptg.cpp:160
 #, c-format
 msgid "Open file \"%s\""
 msgstr "Deschide fișierul \"%s\""
 
-#: ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176
 msgid "Open..."
 msgstr "Deschide..."
 
-#: ../src/unix/glx11.cpp:506 ../src/msw/glcanvas.cpp:592
+#: ../src/msw/glcanvas.cpp:607 ../src/unix/glx11.cpp:513
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr ""
 
-#: ../src/generic/dirctrlg.cpp:599 ../src/generic/dirdlgg.cpp:323
-#: ../src/generic/filectrlg.cpp:642 ../src/generic/filectrlg.cpp:786
+#: ../src/generic/dirctrlg.cpp:565 ../src/generic/filectrlg.cpp:638
+#: ../src/generic/filectrlg.cpp:782 ../src/generic/dirdlgg.cpp:320
 msgid "Operation not permitted."
 msgstr "Operație nepermisă."
 
-#: ../src/common/cmdline.cpp:900
+#: ../src/common/cmdline.cpp:896
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "Opțiunea '%s' nu poate fi negată"
 
-#: ../src/common/cmdline.cpp:1064
+#: ../src/common/cmdline.cpp:1060
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "Opțiunea '%s' necesită o valoare."
 
-#: ../src/common/cmdline.cpp:1147
+#: ../src/common/cmdline.cpp:1143
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Opțiunea '%s': '%s' nu poate fi convertită la o dată."
 
-#: ../src/generic/prntdlgg.cpp:618
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Opțiuni"
 
-#: ../src/propgrid/advprops.cpp:1606
+#: ../src/propgrid/advprops.cpp:1512
 msgid "Orange"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:615 ../src/generic/prntdlgg.cpp:869
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:862
 msgid "Orientation"
 msgstr "Orientare"
 
-#: ../src/common/windowid.cpp:242
+#: ../src/common/windowid.cpp:237
 msgid "Out of window IDs.  Recommend shutting down application."
 msgstr ""
 "Nu mai sunt ID-uri de ferestre disponibile. Se recomandă închiderea "
@@ -5477,148 +5620,148 @@ msgstr "Contur"
 msgid "Outset"
 msgstr "Spre exterior"
 
-#: ../src/msw/ole/automtn.cpp:656
+#: ../src/msw/ole/automtn.cpp:647
 msgid "Overflow while coercing argument values."
 msgstr "Overflow în timpul validării valorilor argumentelor."
 
-#: ../src/common/imagpcx.cpp:457 ../src/common/imagpcx.cpp:480
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:479
 msgid "PCX: couldn't allocate memory"
 msgstr "PCX: nu s-a putut aloca memorie"
 
-#: ../src/common/imagpcx.cpp:456
+#: ../src/common/imagpcx.cpp:455
 msgid "PCX: image format unsupported"
 msgstr "PCX: format de imagine nesuportat"
 
-#: ../src/common/imagpcx.cpp:479
+#: ../src/common/imagpcx.cpp:478
 msgid "PCX: invalid image"
 msgstr "PCX: imagine invalidă"
 
-#: ../src/common/imagpcx.cpp:442
+#: ../src/common/imagpcx.cpp:441
 msgid "PCX: this is not a PCX file."
 msgstr "PCX: acesta nu este un fișier PCX."
 
-#: ../src/common/imagpcx.cpp:459 ../src/common/imagpcx.cpp:481
+#: ../src/common/imagpcx.cpp:458 ../src/common/imagpcx.cpp:480
 msgid "PCX: unknown error !!!"
 msgstr "PCX: eroare necunoscută!!"
 
-#: ../src/common/imagpcx.cpp:458
+#: ../src/common/imagpcx.cpp:457
 msgid "PCX: version number too low"
 msgstr "PCX: numărul versiunii prea mic"
 
-#: ../src/common/imagpnm.cpp:91
+#: ../src/common/imagpnm.cpp:89
 msgid "PNM: Couldn't allocate memory."
 msgstr "PNM: Nu s-a putut aloca memorie."
 
-#: ../src/common/imagpnm.cpp:73
+#: ../src/common/imagpnm.cpp:71
 msgid "PNM: File format is not recognized."
 msgstr "PNM: Formatul fișierului nu este recunoscut."
 
-#: ../src/common/imagpnm.cpp:112 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
 #: ../src/common/imagpnm.cpp:156
 msgid "PNM: File seems truncated."
 msgstr "PNM: Fișierul pare trunchiat."
 
-#: ../src/common/paper.cpp:187
+#: ../src/common/paper.cpp:184
 msgid "PRC 16K 146 x 215 mm"
 msgstr "PRC 16K 146 x 215 mm"
 
-#: ../src/common/paper.cpp:200
+#: ../src/common/paper.cpp:197
 msgid "PRC 16K Rotated"
 msgstr "PRC 16K Rotit"
 
-#: ../src/common/paper.cpp:188
+#: ../src/common/paper.cpp:185
 msgid "PRC 32K 97 x 151 mm"
 msgstr "PRC 32K 97 x 151 mm"
 
-#: ../src/common/paper.cpp:201
+#: ../src/common/paper.cpp:198
 msgid "PRC 32K Rotated"
 msgstr "PRC 32K Rotit"
 
-#: ../src/common/paper.cpp:189
+#: ../src/common/paper.cpp:186
 msgid "PRC 32K(Big) 97 x 151 mm"
 msgstr "PRC 32K(Mare) 97 x 151 mm"
 
-#: ../src/common/paper.cpp:202
+#: ../src/common/paper.cpp:199
 msgid "PRC 32K(Big) Rotated"
 msgstr "PRC 32K(Mare) Rotit"
 
-#: ../src/common/paper.cpp:190
+#: ../src/common/paper.cpp:187
 msgid "PRC Envelope #1 102 x 165 mm"
 msgstr "PRC Plic #1 102 x 165 mm"
 
-#: ../src/common/paper.cpp:203
+#: ../src/common/paper.cpp:200
 msgid "PRC Envelope #1 Rotated 165 x 102 mm"
 msgstr "PRC Plic #1 Rotit 165 x 102 mm"
 
-#: ../src/common/paper.cpp:199
+#: ../src/common/paper.cpp:196
 msgid "PRC Envelope #10 324 x 458 mm"
 msgstr "PRC Plic #10 324 x 458 mm"
 
-#: ../src/common/paper.cpp:212
+#: ../src/common/paper.cpp:209
 msgid "PRC Envelope #10 Rotated 458 x 324 mm"
 msgstr "PRC Plic #10 Rotit 458 x 324 mm"
 
-#: ../src/common/paper.cpp:191
+#: ../src/common/paper.cpp:188
 msgid "PRC Envelope #2 102 x 176 mm"
 msgstr "PRC Plic #2 102 x 176 mm"
 
-#: ../src/common/paper.cpp:204
+#: ../src/common/paper.cpp:201
 msgid "PRC Envelope #2 Rotated 176 x 102 mm"
 msgstr "PRC Plic #2 Rotit 176 x 102 mm"
 
-#: ../src/common/paper.cpp:192
+#: ../src/common/paper.cpp:189
 msgid "PRC Envelope #3 125 x 176 mm"
 msgstr "PRC Plic #3 125 x 176 mm"
 
-#: ../src/common/paper.cpp:205
+#: ../src/common/paper.cpp:202
 msgid "PRC Envelope #3 Rotated 176 x 125 mm"
 msgstr "PRC Plic #3 Rotit 176 x 125 mm"
 
-#: ../src/common/paper.cpp:193
+#: ../src/common/paper.cpp:190
 msgid "PRC Envelope #4 110 x 208 mm"
 msgstr "PRC Plic #4 110 x 208 mm"
 
-#: ../src/common/paper.cpp:206
+#: ../src/common/paper.cpp:203
 msgid "PRC Envelope #4 Rotated 208 x 110 mm"
 msgstr "PRC Plic #4 Rotit 208 x 110 mm"
 
-#: ../src/common/paper.cpp:194
+#: ../src/common/paper.cpp:191
 msgid "PRC Envelope #5 110 x 220 mm"
 msgstr "PRC Plic #5 110 x 220 mm"
 
-#: ../src/common/paper.cpp:207
+#: ../src/common/paper.cpp:204
 msgid "PRC Envelope #5 Rotated 220 x 110 mm"
 msgstr "PRC Plic #5 Rotit 220 x 110 mm"
 
-#: ../src/common/paper.cpp:195
+#: ../src/common/paper.cpp:192
 msgid "PRC Envelope #6 120 x 230 mm"
 msgstr "PRC Plic #6 120 x 230 mm"
 
-#: ../src/common/paper.cpp:208
+#: ../src/common/paper.cpp:205
 msgid "PRC Envelope #6 Rotated 230 x 120 mm"
 msgstr "PRC Plic #6 Rotit 230 x 120 mm"
 
-#: ../src/common/paper.cpp:196
+#: ../src/common/paper.cpp:193
 msgid "PRC Envelope #7 160 x 230 mm"
 msgstr "PRC Plic #7 160 x 230 mm"
 
-#: ../src/common/paper.cpp:209
+#: ../src/common/paper.cpp:206
 msgid "PRC Envelope #7 Rotated 230 x 160 mm"
 msgstr "PRC Plic #7 Rotit 230 x 160 mm"
 
-#: ../src/common/paper.cpp:197
+#: ../src/common/paper.cpp:194
 msgid "PRC Envelope #8 120 x 309 mm"
 msgstr "PRC Plic #8 120 x 309 mm"
 
-#: ../src/common/paper.cpp:210
+#: ../src/common/paper.cpp:207
 msgid "PRC Envelope #8 Rotated 309 x 120 mm"
 msgstr "PRC Plic #8 Rotit 309 x 120 mm"
 
-#: ../src/common/paper.cpp:198
+#: ../src/common/paper.cpp:195
 msgid "PRC Envelope #9 229 x 324 mm"
 msgstr "PRC Plic #9 229 x 324 mm"
 
-#: ../src/common/paper.cpp:211
+#: ../src/common/paper.cpp:208
 msgid "PRC Envelope #9 Rotated 324 x 229 mm"
 msgstr "PRC Plic #9 Rotit 324 x 229 mm"
 
@@ -5626,91 +5769,95 @@ msgstr "PRC Plic #9 Rotit 324 x 229 mm"
 msgid "Padding"
 msgstr "Umplere"
 
-#: ../src/common/prntbase.cpp:2074
+#: ../src/common/prntbase.cpp:2096
 #, c-format
 msgid "Page %d"
 msgstr "Pagina %d"
 
-#: ../src/common/prntbase.cpp:2072
+#: ../src/common/prntbase.cpp:2094
 #, c-format
 msgid "Page %d of %d"
 msgstr "Pagina %d din %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 #, fuzzy
 msgid "Page Down"
 msgstr "Pagina %d"
 
-#: ../src/gtk/print.cpp:826
+#: ../src/gtk/print.cpp:829
 msgid "Page Setup"
 msgstr "Setări pagină"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 #, fuzzy
 msgid "Page Up"
 msgstr "Pagina %d"
 
-#: ../src/generic/prntdlgg.cpp:828 ../src/common/prntbase.cpp:484
+#: ../src/common/prntbase.cpp:479 ../src/generic/prntdlgg.cpp:821
 msgid "Page setup"
 msgstr "Setări pagină"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 #, fuzzy
 msgid "PageDown"
 msgstr "Jos"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 #, fuzzy
 msgid "PageUp"
 msgstr "Pagini"
 
-#: ../src/generic/prntdlgg.cpp:216
+#: ../src/generic/prntdlgg.cpp:209
 msgid "Pages"
 msgstr "Pagini"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1765
+#: ../src/propgrid/advprops.cpp:1666
 msgid "Paint Brush"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:602 ../src/generic/prntdlgg.cpp:801
-#: ../src/generic/prntdlgg.cpp:842 ../src/generic/prntdlgg.cpp:855
-#: ../src/generic/prntdlgg.cpp:1052 ../src/generic/prntdlgg.cpp:1057
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:794
+#: ../src/generic/prntdlgg.cpp:835 ../src/generic/prntdlgg.cpp:848
+#: ../src/generic/prntdlgg.cpp:1045 ../src/generic/prntdlgg.cpp:1050
 msgid "Paper size"
 msgstr "Dimensiune hârtie"
 
-#: ../src/richtext/richtextstyles.cpp:1062
+#: ../src/richtext/richtextstyles.cpp:1059
 msgid "Paragraph styles"
 msgstr "Stiluri de paragraf"
 
-#: ../src/common/xtistrm.cpp:465
+#: ../src/common/xtistrm.cpp:462
 msgid "Passing a already registered object to SetObject"
 msgstr "S-a pasat un obiect deja înregistrat către SetObject"
 
-#: ../src/common/xtistrm.cpp:476
+#: ../src/common/xtistrm.cpp:473
 msgid "Passing an unknown object to GetObject"
 msgstr "S-a pasat un obiect necunoscut către GetObject"
 
-#: ../src/richtext/richtextctrl.cpp:3513 ../src/common/stockitem.cpp:180
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:177 ../src/richtext/richtextctrl.cpp:3514
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Lipește"
 
-#: ../src/common/stockitem.cpp:262
+#: ../src/common/stockitem.cpp:260
 msgid "Paste selection"
 msgstr "Lipește selecția"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:74
+#: ../src/common/accelcmn.cpp:71
 msgid "Pause"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1766
+#: ../src/propgrid/advprops.cpp:1667
 msgid "Pencil"
 msgstr ""
 
@@ -5719,21 +5866,21 @@ msgstr ""
 msgid "Peri&od"
 msgstr "P&unct"
 
-#: ../src/generic/filectrlg.cpp:430
+#: ../src/generic/filectrlg.cpp:426
 msgid "Permissions"
 msgstr "Permisiuni"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:60
+#: ../src/common/accelcmn.cpp:57
 msgid "PgDn"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:59
+#: ../src/common/accelcmn.cpp:56
 msgid "PgUp"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:12868
+#: ../src/richtext/richtextbuffer.cpp:12863
 msgid "Picture Properties"
 msgstr "Proprietăți Imagine"
 
@@ -5745,44 +5892,44 @@ msgstr "Crearea canalului de comunicare (pipe) a eșuat"
 msgid "Please choose a valid font."
 msgstr "Alegeți un font valid."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
 msgid "Please choose an existing file."
 msgstr "Alegeți un fișier existent."
 
-#: ../src/html/helpwnd.cpp:800
+#: ../src/html/helpwnd.cpp:798
 msgid "Please choose the page to display:"
 msgstr "Alegeți pagina de afișat:"
 
-#: ../src/msw/dialup.cpp:764
+#: ../src/msw/dialup.cpp:758
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Alegeți ISP-ul la care vreți să vă conectați"
 
-#: ../src/common/headerctrlcmn.cpp:59
+#: ../src/common/headerctrlcmn.cpp:57
 msgid "Please select the columns to show and define their order:"
 msgstr "Alegeți coloanele ce trebuiesc afișate și stabiliți-le ordinea:"
 
-#: ../src/common/prntbase.cpp:538
+#: ../src/common/prntbase.cpp:533
 msgid "Please wait while printing..."
 msgstr "Așteptați cât timp se tipărește..."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1767
+#: ../src/propgrid/advprops.cpp:1668
 #, fuzzy
 msgid "Point Left"
 msgstr "Dimensiune în puncte"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1768
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgid "Point Right"
 msgstr "Aliniază la dreapta"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:662
+#: ../src/propgrid/advprops.cpp:572
 msgid "Point Size"
 msgstr "Dimensiune în puncte"
 
-#: ../src/generic/prntdlgg.cpp:612 ../src/generic/prntdlgg.cpp:867
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:860
 msgid "Portrait"
 msgstr "Vertical"
 
@@ -5790,150 +5937,160 @@ msgstr "Vertical"
 msgid "Position"
 msgstr "Poziție"
 
-#: ../src/generic/prntdlgg.cpp:298
+#: ../src/generic/prntdlgg.cpp:291
 msgid "PostScript file"
 msgstr "Fișier PostScript"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178 ../src/osx/cocoa/preferences.mm:303
 msgid "Preferences"
 msgstr "Preferințe"
 
-#: ../src/osx/menu_osx.cpp:568
+#: ../src/osx/menu_osx.cpp:460
 msgid "Preferences..."
 msgstr "Preferințe..."
 
-#: ../src/common/prntbase.cpp:546
+#: ../src/common/prntbase.cpp:541
 msgid "Preparing"
 msgstr "Pregătește"
 
-#: ../src/generic/fontdlgg.cpp:455 ../src/osx/carbon/fontdlg.cpp:390
-#: ../src/html/helpwnd.cpp:1222
+#: ../src/osx/carbon/fontdlg.cpp:387 ../src/generic/fontdlgg.cpp:452
+#: ../src/html/helpwnd.cpp:1220
 msgid "Preview:"
 msgstr "Previzualizare:"
 
-#: ../src/common/prntbase.cpp:1553 ../src/html/helpwnd.cpp:664
+#: ../src/common/prntbase.cpp:1578 ../src/html/helpwnd.cpp:662
 msgid "Previous page"
 msgstr "Pagina anterioară"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/prntdlgg.cpp:143 ../src/generic/prntdlgg.cpp:157
-#: ../src/common/prntbase.cpp:426 ../src/common/prntbase.cpp:1541
-#: ../src/common/accelcmn.cpp:77 ../src/gtk/print.cpp:620
-#: ../src/gtk/print.cpp:638
+#: ../src/common/prntbase.cpp:421 ../src/common/prntbase.cpp:1566
+#: ../src/common/accelcmn.cpp:74 ../src/generic/prntdlgg.cpp:136
+#: ../src/generic/prntdlgg.cpp:150 ../src/gtk/print.cpp:616
+#: ../src/gtk/print.cpp:634
 msgid "Print"
 msgstr "Tipărește"
 
-#: ../include/wx/prntbase.h:399 ../src/common/docview.cpp:1268
+#: ../src/common/docview.cpp:1262
 msgid "Print Preview"
 msgstr "Previzualizează tipărire"
 
-#: ../src/common/prntbase.cpp:2015 ../src/common/prntbase.cpp:2057
-#: ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2037 ../src/common/prntbase.cpp:2079
+#: ../src/common/prntbase.cpp:2087
 msgid "Print Preview Failure"
 msgstr "Eroare la previzualizarea tipăririi"
 
-#: ../src/generic/prntdlgg.cpp:224
+#: ../src/generic/prntdlgg.cpp:217
 msgid "Print Range"
 msgstr "Interval de tipărire"
 
-#: ../src/generic/prntdlgg.cpp:449
+#: ../src/generic/prntdlgg.cpp:442
 msgid "Print Setup"
 msgstr "Setări tipărire"
 
-#: ../src/generic/prntdlgg.cpp:621
+#: ../src/generic/prntdlgg.cpp:614
 msgid "Print in colour"
 msgstr "Tipărește color"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/osx/webview_webkit.mm:260
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "Descrierea coloanei nu a putut fi inițializată."
+
+#: ../src/common/stockitem.cpp:179
 msgid "Print previe&w..."
 msgstr "Pre&vizualizează tipărire..."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1256
 msgid "Print preview creation failed."
 msgstr "Previzualizarea pentru tipărire a eșuat."
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/common/stockitem.cpp:179
 msgid "Print preview..."
 msgstr "Previzualizează tipărire..."
 
-#: ../src/generic/prntdlgg.cpp:630
+#: ../src/generic/prntdlgg.cpp:623
 msgid "Print spooling"
 msgstr "Tipărire cu buffer"
 
-#: ../src/html/helpwnd.cpp:675
+#: ../src/html/helpwnd.cpp:673
 msgid "Print this page"
 msgstr "Tipărește această pagină"
 
-#: ../src/generic/prntdlgg.cpp:185
+#: ../src/generic/prntdlgg.cpp:178
 msgid "Print to File"
 msgstr "Tipărește în fișier"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "Print..."
 msgstr "Tipărește..."
 
-#: ../src/generic/prntdlgg.cpp:493
+#: ../src/generic/prntdlgg.cpp:486
 msgid "Printer"
 msgstr "Imprimantă"
 
-#: ../src/generic/prntdlgg.cpp:633
+#: ../src/generic/prntdlgg.cpp:626
 msgid "Printer command:"
 msgstr "Comandă imprimantă:"
 
-#: ../src/generic/prntdlgg.cpp:180
+#: ../src/generic/prntdlgg.cpp:173
 msgid "Printer options"
 msgstr "Opțiuni imprimantă"
 
-#: ../src/generic/prntdlgg.cpp:645
+#: ../src/generic/prntdlgg.cpp:638
 msgid "Printer options:"
 msgstr "Opțiuni imprimantă:"
 
-#: ../src/generic/prntdlgg.cpp:916
+#: ../src/generic/prntdlgg.cpp:909
 msgid "Printer..."
 msgstr "Imprimantă..."
 
-#: ../src/generic/prntdlgg.cpp:196
+#: ../src/generic/prntdlgg.cpp:189
 msgid "Printer:"
 msgstr "Imprimantă:"
 
-#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:535
-#: ../src/html/htmprint.cpp:277
+#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:530
+#: ../src/html/htmprint.cpp:289
 msgid "Printing"
 msgstr "Tipărește"
 
-#: ../src/common/prntbase.cpp:612
+#: ../src/common/prntbase.cpp:607
 msgid "Printing "
 msgstr "Tipărire "
 
-#: ../src/common/prntbase.cpp:347
+#: ../src/common/prntbase.cpp:342
 msgid "Printing Error"
 msgstr "Eroare de tipărire"
 
-#: ../src/common/prntbase.cpp:565
+#: ../src/osx/webview_webkit.mm:251
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "Gzip nu e suportat de această versiune de zlib"
+
+#: ../src/common/prntbase.cpp:560
 #, fuzzy, c-format
 msgid "Printing page %d"
 msgstr "Se tipărește pagina %d..."
 
-#: ../src/common/prntbase.cpp:570
+#: ../src/common/prntbase.cpp:565
 #, c-format
 msgid "Printing page %d of %d"
 msgstr "Se tipărește pagina %d din %d"
 
-#: ../src/generic/printps.cpp:201
+#: ../src/generic/printps.cpp:182
 #, c-format
 msgid "Printing page %d..."
 msgstr "Se tipărește pagina %d..."
 
-#: ../src/generic/printps.cpp:161
+#: ../src/generic/printps.cpp:142
 msgid "Printing..."
 msgstr "Se tipărește..."
 
-#: ../include/wx/richtext/richtextprint.h:109 ../include/wx/prntbase.h:267
-#: ../src/common/docview.cpp:2132
+#: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
+#: ../src/common/docview.cpp:2137
 msgid "Printout"
 msgstr "Tipărire"
 
-#: ../src/common/debugrpt.cpp:560
+#: ../src/common/debugrpt.cpp:561
 #, c-format
 msgid ""
 "Processing debug report has failed, leaving the files in \"%s\" directory."
@@ -5941,104 +6098,104 @@ msgstr ""
 "Procesarea raportului de depanare a eșuat, fișierele răman în directorul \"%s"
 "\"."
 
-#: ../src/common/prntbase.cpp:545
+#: ../src/common/prntbase.cpp:540
 msgid "Progress:"
 msgstr "Progres:"
 
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181
 msgid "Properties"
 msgstr "Proprietăți"
 
-#: ../src/propgrid/manager.cpp:237
+#: ../src/propgrid/manager.cpp:223
 msgid "Property"
 msgstr "Proprietate"
 
 #. TRANSLATORS: Caption of message box displaying any property error
-#: ../src/propgrid/propgrid.cpp:3185 ../src/propgrid/propgrid.cpp:3318
+#: ../src/propgrid/propgrid.cpp:3162 ../src/propgrid/propgrid.cpp:3299
 msgid "Property Error"
 msgstr "Proprietate Eronata"
 
-#: ../src/propgrid/advprops.cpp:1597
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Purple"
 msgstr ""
 
-#: ../src/common/paper.cpp:112
+#: ../src/common/paper.cpp:109
 msgid "Quarto, 215 x 275 mm"
 msgstr "Quarto, 215 x 275 mm"
 
-#: ../src/generic/logg.cpp:1016
+#: ../src/generic/logg.cpp:1013
 msgid "Question"
 msgstr "Întrebare"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1769
+#: ../src/propgrid/advprops.cpp:1670
 #, fuzzy
 msgid "Question Arrow"
 msgstr "Întrebare"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "Quit"
 msgstr "Ieșire"
 
-#: ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:477
 #, c-format
 msgid "Quit %s"
 msgstr "Ieșire din %s"
 
-#: ../src/common/stockitem.cpp:263
+#: ../src/common/stockitem.cpp:261
 msgid "Quit this program"
 msgstr "Părăsește acest program"
 
-#: ../src/common/accelcmn.cpp:338
+#: ../src/common/accelcmn.cpp:352
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/ffile.cpp:109 ../src/common/ffile.cpp:133
+#: ../src/common/ffile.cpp:107 ../src/common/ffile.cpp:132
 #, c-format
 msgid "Read error on file '%s'"
 msgstr "Eroare la citirea fișierului '%s'"
 
-#: ../src/common/secretstore.cpp:199
+#: ../src/common/secretstore.cpp:211
 #, fuzzy, c-format
-msgid "Reading password for \"%s/%s\" failed: %s."
+msgid "Reading password for \"%s\" failed: %s."
 msgstr "Extragerea '%s' în '%s' a eșuat."
 
-#: ../src/common/prntbase.cpp:272
+#: ../src/common/prntbase.cpp:267
 msgid "Ready"
 msgstr "Gata"
 
-#: ../src/propgrid/advprops.cpp:1605
+#: ../src/propgrid/advprops.cpp:1511
 #, fuzzy
 msgid "Red"
 msgstr "Repetă acțiunea"
 
-#: ../src/generic/colrdlgg.cpp:339
+#: ../src/generic/colrdlgg.cpp:359
 msgid "Red:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:185 ../src/stc/stc_i18n.cpp:16
+#: ../src/common/stockitem.cpp:182 ../src/stc/stc_i18n.cpp:16
 msgid "Redo"
 msgstr "Repetă acțiunea"
 
-#: ../src/common/stockitem.cpp:264
+#: ../src/common/stockitem.cpp:262
 msgid "Redo last action"
 msgstr "Repetă ultima acțiune"
 
-#: ../src/common/stockitem.cpp:186
+#: ../src/common/stockitem.cpp:183
 msgid "Refresh"
 msgstr "Actualizează"
 
-#: ../src/msw/registry.cpp:626
+#: ../src/msw/registry.cpp:615
 #, c-format
 msgid "Registry key '%s' already exists."
 msgstr "Cheia de regiștri '%s' există deja."
 
-#: ../src/msw/registry.cpp:595
+#: ../src/msw/registry.cpp:584
 #, c-format
 msgid "Registry key '%s' does not exist, cannot rename it."
 msgstr "Cheia de regiștri '%s' nu există, nu se poate redenumi."
 
-#: ../src/msw/registry.cpp:727
+#: ../src/msw/registry.cpp:716
 #, c-format
 msgid ""
 "Registry key '%s' is needed for normal system operation,\n"
@@ -6050,22 +6207,22 @@ msgstr ""
 "ștergerea ei va lăsa sistemul intr-o stare inutilizabilă:\n"
 "operație anulată."
 
-#: ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:942
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:917
+#: ../src/msw/registry.cpp:905
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1003
+#: ../src/msw/registry.cpp:991
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:521
+#: ../src/msw/registry.cpp:510
 #, c-format
 msgid "Registry value '%s' already exists."
 msgstr "Valoarea de regiștri '%s' există deja."
@@ -6079,72 +6236,78 @@ msgstr "Normal"
 msgid "Relative"
 msgstr "Relativă"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:456
 msgid "Relevant entries:"
 msgstr "Intrări relevante:"
 
-#: ../include/wx/generic/progdlgg.h:86
+#: ../include/wx/generic/progdlgg.h:87
 msgid "Remaining time:"
 msgstr "Timp rămas:"
 
-#: ../src/common/stockitem.cpp:187
+#: ../src/common/stockitem.cpp:184
 msgid "Remove"
 msgstr "Elimină"
 
-#: ../src/richtext/richtextctrl.cpp:1562
+#: ../src/richtext/richtextctrl.cpp:1563
 msgid "Remove Bullet"
 msgstr "Elimină marcator"
 
-#: ../src/html/helpwnd.cpp:433
+#: ../src/html/helpwnd.cpp:431
 msgid "Remove current page from bookmarks"
 msgstr "Șterge pagina curentă dintre semnele de carte"
 
-#: ../src/common/rendcmn.cpp:194
+#: ../src/common/rendcmn.cpp:191
 #, c-format
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 "Renderer-ul \"%s\" are versiunea incompatibilă %d.%d și nu a putut fi "
 "încărcat."
 
-#: ../src/richtext/richtextbuffer.cpp:4527
+#: ../src/richtext/richtextbuffer.cpp:4524
 msgid "Renumber List"
 msgstr "Renumerotează lista"
 
-#: ../src/common/stockitem.cpp:188
-msgid "Rep&lace"
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Rep&lace..."
 msgstr "Înl&ocuiește"
 
-#: ../src/richtext/richtextctrl.cpp:3673 ../src/common/stockitem.cpp:188
+#: ../src/richtext/richtextctrl.cpp:3674
 msgid "Replace"
 msgstr "Înlocuiește"
 
-#: ../src/generic/fdrepdlg.cpp:182
+#: ../src/generic/fdrepdlg.cpp:179
 msgid "Replace &all"
 msgstr "Înlocuiește peste &tot"
 
-#: ../src/common/stockitem.cpp:261
-msgid "Replace selection"
-msgstr "Înlocuiește selecția"
-
-#: ../src/generic/fdrepdlg.cpp:124
+#: ../src/generic/fdrepdlg.cpp:121
 msgid "Replace with:"
 msgstr "Înlocuiește cu:"
 
-#: ../src/common/valtext.cpp:163
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Replace..."
+msgstr "Înlocuiește"
+
+#: ../src/common/valtext.cpp:184
 msgid "Required information entry is empty."
 msgstr "Intrarea pentru informația necesară este goală."
 
-#: ../src/common/translation.cpp:1975
+#: ../src/common/translation.cpp:2025
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "Resursa '%s' nu este un catalog de mesaje valid."
 
+#: ../src/gtk/webview_webkit.cpp:985
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:56
+#: ../src/common/accelcmn.cpp:53
 msgid "Return"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:189
+#: ../src/common/stockitem.cpp:186
 msgid "Revert to Saved"
 msgstr "Revenire la versiunea salvată"
 
@@ -6156,42 +6319,42 @@ msgstr "Crestată"
 msgid "Rig&ht-to-left"
 msgstr "De la &stânga la dreapta"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6149
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:59 ../src/generic/datavgen.cpp:6954
+#: ../src/richtext/richtextsizepage.cpp:250
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextbulletspage.cpp:188
-#: ../src/richtext/richtextsizepage.cpp:250 ../src/common/accelcmn.cpp:62
 msgid "Right"
 msgstr "Dreapta"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1754
+#: ../src/propgrid/advprops.cpp:1655
 #, fuzzy
 msgid "Right Arrow"
 msgstr "Dreapta"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1770
+#: ../src/propgrid/advprops.cpp:1671
 msgid "Right Button"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:892
+#: ../src/generic/prntdlgg.cpp:885
 msgid "Right margin (mm):"
 msgstr "Margine dreapta (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:148
-#: ../src/richtext/richtextindentspage.cpp:150
 #: ../src/richtext/richtextliststylepage.cpp:337
 #: ../src/richtext/richtextliststylepage.cpp:339
+#: ../src/richtext/richtextindentspage.cpp:148
+#: ../src/richtext/richtextindentspage.cpp:150
 msgid "Right-align text."
 msgstr "Aliniază text la dreapta."
 
-#: ../src/generic/fontdlgg.cpp:322
+#: ../src/generic/fontdlgg.cpp:318
 msgid "Roman"
 msgstr "Roman"
 
-#: ../src/generic/datavgen.cpp:5916
+#: ../src/generic/datavgen.cpp:6721
 #, c-format
 msgid "Row %i"
 msgstr ""
@@ -6201,30 +6364,31 @@ msgstr ""
 msgid "S&tandard bullet name:"
 msgstr "Nume de marcator s&tandard:"
 
-#: ../src/common/accelcmn.cpp:268 ../src/common/accelcmn.cpp:350
+#: ../src/common/accelcmn.cpp:282 ../src/common/accelcmn.cpp:367
 msgid "SPECIAL"
 msgstr "SPECIAL"
 
-#: ../src/common/stockitem.cpp:190 ../src/common/sizer.cpp:2797
+#: ../src/common/stockitem.cpp:187 ../src/common/sizer.cpp:2914
 msgid "Save"
 msgstr "Salvează"
 
-#: ../src/common/fldlgcmn.cpp:342
+#: ../src/common/fldlgcmn.cpp:339
 #, c-format
 msgid "Save %s file"
 msgstr "Salvează fișierul %s"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/common/stockitem.cpp:188 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "S&alvează ca..."
 
-#: ../src/common/docview.cpp:366
+#: ../src/common/docview.cpp:359
 msgid "Save As"
 msgstr "Salvează ca"
 
-#: ../src/common/stockitem.cpp:191
-msgid "Save as"
-msgstr "Salvează ca"
+#: ../src/common/stockitem.cpp:188
+#, fuzzy
+msgid "Save As..."
+msgstr "S&alvează ca..."
 
 #: ../src/common/stockitem.cpp:267
 msgid "Save current document"
@@ -6234,40 +6398,40 @@ msgstr "Salvează documentul curent"
 msgid "Save current document with a different filename"
 msgstr "Salvează documentul curent cu un nume de fișier diferit"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/generic/logg.cpp:509
 msgid "Save log contents to file"
 msgstr "Salvează conținutul raportului în fișier"
 
-#: ../src/common/secretstore.cpp:179
+#: ../src/common/secretstore.cpp:189
 #, fuzzy, c-format
-msgid "Saving password for \"%s/%s\" failed: %s."
+msgid "Saving password for \"%s\" failed: %s."
 msgstr "Extragerea '%s' în '%s' a eșuat."
 
-#: ../src/generic/fontdlgg.cpp:325
+#: ../src/generic/fontdlgg.cpp:321
 msgid "Script"
 msgstr "Script"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll Lock"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll_lock"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:890
+#: ../src/propgrid/advprops.cpp:791
 msgid "Scrollbar"
 msgstr ""
 
-#: ../src/generic/srchctlg.cpp:56 ../src/html/helpwnd.cpp:535
-#: ../src/html/helpwnd.cpp:550
+#: ../src/generic/srchctlg.cpp:55 ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:548 ../src/gtk/srchctrl.cpp:182
 msgid "Search"
 msgstr "Caută"
 
-#: ../src/html/helpwnd.cpp:537
+#: ../src/html/helpwnd.cpp:535
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
@@ -6275,32 +6439,32 @@ msgstr ""
 "Caută în conținutul cărții(-lor) de ajutor toate aparițiile textului "
 "introdus mai sus"
 
-#: ../src/generic/fdrepdlg.cpp:160
+#: ../src/generic/fdrepdlg.cpp:157
 msgid "Search direction"
 msgstr "Direcție căutare"
 
-#: ../src/generic/fdrepdlg.cpp:112
+#: ../src/generic/fdrepdlg.cpp:109
 msgid "Search for:"
 msgstr "Caută:"
 
-#: ../src/html/helpwnd.cpp:1052
+#: ../src/html/helpwnd.cpp:1050
 msgid "Search in all books"
 msgstr "Caută în toate cărțile"
 
-#: ../src/html/helpwnd.cpp:857
+#: ../src/html/helpwnd.cpp:855
 msgid "Searching..."
 msgstr "Caută..."
 
-#: ../src/generic/dirctrlg.cpp:446
+#: ../src/generic/dirctrlg.cpp:412
 msgid "Sections"
 msgstr "Secțiuni"
 
-#: ../src/common/ffile.cpp:238
+#: ../src/common/ffile.cpp:237
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Eroare de căutare pentru fișierul '%s'"
 
-#: ../src/common/ffile.cpp:228
+#: ../src/common/ffile.cpp:227
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
@@ -6308,25 +6472,25 @@ msgstr ""
 "stdio)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:76
+#: ../src/common/accelcmn.cpp:73
 #, fuzzy
 msgid "Select"
 msgstr "Selecție"
 
-#: ../src/richtext/richtextctrl.cpp:337 ../src/osx/textctrl_osx.cpp:581
-#: ../src/common/stockitem.cpp:192 ../src/msw/textctrl.cpp:2512
+#: ../src/osx/textctrl_osx.cpp:599 ../src/common/stockitem.cpp:189
+#: ../src/msw/textctrl.cpp:2777 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Selecte&ază tot"
 
-#: ../src/common/stockitem.cpp:192 ../src/stc/stc_i18n.cpp:21
+#: ../src/common/stockitem.cpp:189 ../src/stc/stc_i18n.cpp:21
 msgid "Select All"
 msgstr "Selectează tot"
 
-#: ../src/common/docview.cpp:1895
+#: ../src/common/docview.cpp:1900
 msgid "Select a document template"
 msgstr "Selectează un document șablon"
 
-#: ../src/common/docview.cpp:1969
+#: ../src/common/docview.cpp:1974
 msgid "Select a document view"
 msgstr "Selectează o vizualizare pentru document"
 
@@ -6355,20 +6519,20 @@ msgid "Selects the list level to edit."
 msgstr "Selectează nivelul din listă care să fie modificat."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:82
+#: ../src/common/accelcmn.cpp:79
 msgid "Separator"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1083
+#: ../src/common/cmdline.cpp:1079
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Lipsește separatorul după opțiunea '%s'."
 
-#: ../src/osx/menu_osx.cpp:572
+#: ../src/osx/menu_osx.cpp:464
 msgid "Services"
 msgstr "Servicii"
 
-#: ../src/richtext/richtextbuffer.cpp:11217
+#: ../src/richtext/richtextbuffer.cpp:11216
 msgid "Set Cell Style"
 msgstr "Aplică stilul de celulă"
 
@@ -6376,11 +6540,11 @@ msgstr "Aplică stilul de celulă"
 msgid "SetProperty called w/o valid setter"
 msgstr "SetProperty apelat cu setter invalid"
 
-#: ../src/generic/prntdlgg.cpp:188
+#: ../src/generic/prntdlgg.cpp:181
 msgid "Setup..."
 msgstr "Setări..."
 
-#: ../src/msw/dialup.cpp:544
+#: ../src/msw/dialup.cpp:538
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr ""
 "S-au găsit mai multe conexiuni dialup active, se alege una la întâmplare."
@@ -6398,40 +6562,40 @@ msgstr ""
 msgid "Shadow c&olour:"
 msgstr "Alege culoare"
 
-#: ../src/common/accelcmn.cpp:335
+#: ../src/common/accelcmn.cpp:349
 msgid "Shift+"
 msgstr "Shift+"
 
-#: ../src/generic/dirdlgg.cpp:147
+#: ../src/generic/dirdlgg.cpp:144
 msgid "Show &hidden directories"
 msgstr "Arată &directoare ascunse"
 
-#: ../src/generic/filectrlg.cpp:983
+#: ../src/generic/filectrlg.cpp:979
 msgid "Show &hidden files"
 msgstr "Arată &fișiere ascunse"
 
-#: ../src/osx/menu_osx.cpp:580
+#: ../src/osx/menu_osx.cpp:472
 msgid "Show All"
 msgstr "Arată Tot"
 
-#: ../src/common/stockitem.cpp:257
+#: ../src/common/stockitem.cpp:254
 msgid "Show about dialog"
 msgstr "Arată dialog informativ"
 
-#: ../src/html/helpwnd.cpp:492
+#: ../src/html/helpwnd.cpp:490
 msgid "Show all"
 msgstr "Arată tot"
 
-#: ../src/html/helpwnd.cpp:503
+#: ../src/html/helpwnd.cpp:501
 msgid "Show all items in index"
 msgstr "Afișează toate elementele din index"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:656
 msgid "Show/hide navigation panel"
 msgstr "Afișează/ascunde panoul de navigare"
 
-#: ../src/richtext/richtextsymboldlg.cpp:421
-#: ../src/richtext/richtextsymboldlg.cpp:423
+#: ../src/richtext/richtextsymboldlg.cpp:418
+#: ../src/richtext/richtextsymboldlg.cpp:420
 msgid "Shows a Unicode subset."
 msgstr "Afișează un subset Unicode."
 
@@ -6447,7 +6611,7 @@ msgstr "Afișează o previzualizare a setărilor pentru marcatori."
 msgid "Shows a preview of the font settings."
 msgstr "Afișează o previzualizare a setărilor pentru font."
 
-#: ../src/osx/carbon/fontdlg.cpp:394 ../src/osx/carbon/fontdlg.cpp:396
+#: ../src/osx/carbon/fontdlg.cpp:391 ../src/osx/carbon/fontdlg.cpp:393
 msgid "Shows a preview of the font."
 msgstr "Afișează o previzualizare a fontului."
 
@@ -6456,62 +6620,62 @@ msgstr "Afișează o previzualizare a fontului."
 msgid "Shows a preview of the paragraph settings."
 msgstr "Afișează o previzualizare a setărilor pentru paragraf."
 
-#: ../src/generic/fontdlgg.cpp:460 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:456 ../src/generic/fontdlgg.cpp:458
 msgid "Shows the font preview."
 msgstr "Afișează previzualizarea fontului."
 
-#: ../src/propgrid/advprops.cpp:1607
+#: ../src/propgrid/advprops.cpp:1513
 msgid "Silver"
 msgstr ""
 
-#: ../src/univ/themes/mono.cpp:516
+#: ../src/univ/themes/mono.cpp:513
 msgid "Simple monochrome theme"
 msgstr "Temă monocromă simplă"
 
-#: ../src/richtext/richtextindentspage.cpp:275
 #: ../src/richtext/richtextliststylepage.cpp:449
+#: ../src/richtext/richtextindentspage.cpp:275
 msgid "Single"
 msgstr "Singur"
 
-#: ../src/generic/filectrlg.cpp:425 ../src/richtext/richtextformatdlg.cpp:369
-#: ../src/richtext/richtextsizepage.cpp:299
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextsizepage.cpp:299
+#: ../src/richtext/richtextformatdlg.cpp:362
 msgid "Size"
 msgstr "Dimensiune"
 
-#: ../src/osx/carbon/fontdlg.cpp:339
+#: ../src/osx/carbon/fontdlg.cpp:336
 msgid "Size:"
 msgstr "Dimensiune:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1775
+#: ../src/propgrid/advprops.cpp:1676
 msgid "Sizing"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1772
+#: ../src/propgrid/advprops.cpp:1673
 msgid "Sizing N-S"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1771
+#: ../src/propgrid/advprops.cpp:1672
 msgid "Sizing NE-SW"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1773
+#: ../src/propgrid/advprops.cpp:1674
 msgid "Sizing NW-SE"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1774
+#: ../src/propgrid/advprops.cpp:1675
 msgid "Sizing W-E"
 msgstr ""
 
-#: ../src/msw/progdlg.cpp:801
+#: ../src/msw/progdlg.cpp:1088
 msgid "Skip"
 msgstr "Omite"
 
-#: ../src/generic/fontdlgg.cpp:330
+#: ../src/generic/fontdlgg.cpp:326
 msgid "Slant"
 msgstr "Înclinat"
 
@@ -6520,7 +6684,7 @@ msgid "Small C&apitals"
 msgstr "&Majuscule de format mic"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:79
+#: ../src/common/accelcmn.cpp:76
 msgid "Snapshot"
 msgstr ""
 
@@ -6528,37 +6692,37 @@ msgstr ""
 msgid "Solid"
 msgstr "Îngroșată"
 
-#: ../src/common/docview.cpp:1791
+#: ../src/common/docview.cpp:1785
 msgid "Sorry, could not open this file."
 msgstr "Nu s-a putut deschide acest fișier."
 
-#: ../src/common/prntbase.cpp:2057 ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2079 ../src/common/prntbase.cpp:2087
 msgid "Sorry, not enough memory to create a preview."
 msgstr "Nu este suficientă memorie pentru a crea o previzualizare."
 
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "Sorry, that name is taken. Please choose another."
 msgstr "Acel nume este luat. Alegeți altul."
 
-#: ../src/common/docview.cpp:1814
+#: ../src/common/docview.cpp:1819
 msgid "Sorry, the format for this file is unknown."
 msgstr "Formatul pentru acest fișier este necunoscut."
 
-#: ../src/unix/sound.cpp:492
+#: ../src/unix/sound.cpp:481
 msgid "Sound data are in unsupported format."
 msgstr "Formatul datelor de sunet nu este suportat."
 
-#: ../src/unix/sound.cpp:477
+#: ../src/unix/sound.cpp:466
 #, c-format
 msgid "Sound file '%s' is in unsupported format."
 msgstr "Fișierul cu sunet '%s' este într-un format nesuportat."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:67
+#: ../src/common/accelcmn.cpp:64
 #, fuzzy
 msgid "Space"
 msgstr "Spațiere"
@@ -6567,12 +6731,12 @@ msgstr "Spațiere"
 msgid "Spacing"
 msgstr "Spațiere"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "Spell Check"
 msgstr "Verificare ortografiei"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1776
+#: ../src/propgrid/advprops.cpp:1677
 msgid "Spraycan"
 msgstr ""
 
@@ -6581,7 +6745,7 @@ msgstr ""
 msgid "Standard"
 msgstr "Standard"
 
-#: ../src/common/paper.cpp:104
+#: ../src/common/paper.cpp:101
 msgid "Statement, 5 1/2 x 8 1/2 in"
 msgstr "Declarație, 5 1/2 x 8 1/2 in"
 
@@ -6590,34 +6754,30 @@ msgstr "Declarație, 5 1/2 x 8 1/2 in"
 msgid "Static"
 msgstr "Statică"
 
-#: ../src/generic/prntdlgg.cpp:204
+#: ../src/generic/prntdlgg.cpp:197
 msgid "Status:"
 msgstr "Stare:"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "Stop"
 msgstr "Stop"
 
-#: ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196
 msgid "Strikethrough"
 msgstr "Tăiat"
 
-#: ../src/common/colourcmn.cpp:45
+#: ../src/common/colourcmn.cpp:42
 #, c-format
 msgid "String To Colour : Incorrect colour specification : %s"
 msgstr ""
 "Din șir de caractere în culoare : Specificație de culoare incorectă : %s"
 
 #. TRANSLATORS: Label of font style
-#: ../src/richtext/richtextformatdlg.cpp:339 ../src/propgrid/advprops.cpp:680
+#: ../src/propgrid/advprops.cpp:590 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Stil"
 
-#: ../include/wx/richtext/richtextstyledlg.h:46
-msgid "Style Organiser"
-msgstr "Organizator de stiluri"
-
-#: ../src/osx/carbon/fontdlg.cpp:348
+#: ../src/osx/carbon/fontdlg.cpp:345
 msgid "Style:"
 msgstr "Stil:"
 
@@ -6626,7 +6786,7 @@ msgid "Subscrip&t"
 msgstr "Indice i&nferior"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:83
+#: ../src/common/accelcmn.cpp:80
 msgid "Subtract"
 msgstr ""
 
@@ -6634,11 +6794,11 @@ msgstr ""
 msgid "Supe&rscript"
 msgstr "Indice supe&rior"
 
-#: ../src/common/paper.cpp:150
+#: ../src/common/paper.cpp:147
 msgid "SuperA/SuperA/A4 227 x 356 mm"
 msgstr "SuperA/SuperA/A4 227 x 356 mm"
 
-#: ../src/common/paper.cpp:151
+#: ../src/common/paper.cpp:148
 msgid "SuperB/SuperB/A3 305 x 487 mm"
 msgstr "SuperB/SuperB/A3 305 x 487 mm"
 
@@ -6646,7 +6806,7 @@ msgstr "SuperB/SuperB/A3 305 x 487 mm"
 msgid "Suppress hyphe&nation"
 msgstr "&Suprimă despărțirea în silabe"
 
-#: ../src/generic/fontdlgg.cpp:326
+#: ../src/generic/fontdlgg.cpp:322
 msgid "Swiss"
 msgstr "Swiss"
 
@@ -6664,74 +6824,74 @@ msgstr "&Font simbol:"
 msgid "Symbols"
 msgstr "Simboluri"
 
-#: ../src/common/imagtiff.cpp:369 ../src/common/imagtiff.cpp:382
-#: ../src/common/imagtiff.cpp:741
+#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
+#: ../src/common/imagtiff.cpp:738
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: Nu s-a putut aloca memorie."
 
-#: ../src/common/imagtiff.cpp:301
+#: ../src/common/imagtiff.cpp:298
 msgid "TIFF: Error loading image."
 msgstr "TIFF: Eroare la încărcarea imaginii."
 
-#: ../src/common/imagtiff.cpp:468
+#: ../src/common/imagtiff.cpp:465
 msgid "TIFF: Error reading image."
 msgstr "TIFF: Eroare la citirea imaginii."
 
-#: ../src/common/imagtiff.cpp:608
+#: ../src/common/imagtiff.cpp:605
 msgid "TIFF: Error saving image."
 msgstr "TIFF: Eroare la salvarea imaginii."
 
-#: ../src/common/imagtiff.cpp:846
+#: ../src/common/imagtiff.cpp:843
 msgid "TIFF: Error writing image."
 msgstr "TIFF: Eroare la scrierea imaginii."
 
-#: ../src/common/imagtiff.cpp:355
+#: ../src/common/imagtiff.cpp:352
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: Dimensiunea imaginii este anormal de mare."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:68
+#: ../src/common/accelcmn.cpp:65
 #, fuzzy
 msgid "Tab"
 msgstr "Indentări"
 
-#: ../src/richtext/richtextbuffer.cpp:11498
+#: ../src/richtext/richtextbuffer.cpp:11497
 msgid "Table Properties"
 msgstr "Proprietăți Tabelă"
 
-#: ../src/common/paper.cpp:145
+#: ../src/common/paper.cpp:142
 msgid "Tabloid Extra 11.69 x 18 in"
 msgstr "Tabloid Extra 11.69 x 18 in"
 
-#: ../src/common/paper.cpp:102
+#: ../src/common/paper.cpp:99
 msgid "Tabloid, 11 x 17 in"
 msgstr "Tabloid, 11 x 17 in"
 
-#: ../src/richtext/richtextformatdlg.cpp:354
+#: ../src/richtext/richtextformatdlg.cpp:347
 msgid "Tabs"
 msgstr "Indentări"
 
-#: ../src/propgrid/advprops.cpp:1598
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Teal"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:327
+#: ../src/generic/fontdlgg.cpp:323
 msgid "Teletype"
 msgstr "Teletype"
 
-#: ../src/common/docview.cpp:1896
+#: ../src/common/docview.cpp:1901
 msgid "Templates"
 msgstr "Șabloane"
 
-#: ../src/common/fmapbase.cpp:158
+#: ../src/common/fmapbase.cpp:155
 msgid "Thai (ISO-8859-11)"
 msgstr "Tailandeză (ISO-8859-11)"
 
-#: ../src/common/ftp.cpp:619
+#: ../src/common/ftp.cpp:622
 msgid "The FTP server doesn't support passive mode."
 msgstr "Serverul FTP nu suportă modul pasiv."
 
-#: ../src/common/ftp.cpp:605
+#: ../src/common/ftp.cpp:608
 msgid "The FTP server doesn't support the PORT command."
 msgstr "Serverul FTP nu suportă comanda PORT."
 
@@ -6742,8 +6902,8 @@ msgstr "Serverul FTP nu suportă comanda PORT."
 msgid "The available bullet styles."
 msgstr "Stilurile de marcatori disponibile."
 
-#: ../src/richtext/richtextstyledlg.cpp:202
-#: ../src/richtext/richtextstyledlg.cpp:204
+#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:200
 msgid "The available styles."
 msgstr "Stilurile disponibile."
 
@@ -6799,12 +6959,12 @@ msgstr "Poziția de jos."
 msgid "The bullet character."
 msgstr "Caracterul de marcaj."
 
-#: ../src/richtext/richtextsymboldlg.cpp:443
-#: ../src/richtext/richtextsymboldlg.cpp:445
+#: ../src/richtext/richtextsymboldlg.cpp:440
+#: ../src/richtext/richtextsymboldlg.cpp:442
 msgid "The character code."
 msgstr "Codul caracterului."
 
-#: ../src/common/fontmap.cpp:203
+#: ../src/common/fontmap.cpp:200
 #, c-format
 msgid ""
 "The charset '%s' is unknown. You may select\n"
@@ -6815,7 +6975,7 @@ msgstr ""
 "alt set de caractere să-l înlocuiască sau alegeți\n"
 "[Anulează] dacă nu poate fi înlocuit"
 
-#: ../src/msw/ole/dataobj.cpp:394
+#: ../src/msw/ole/dataobj.cpp:402
 #, c-format
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "Formatul '%d' pentru memoria de clipboard nu există."
@@ -6825,7 +6985,7 @@ msgstr "Formatul '%d' pentru memoria de clipboard nu există."
 msgid "The default style for the next paragraph."
 msgstr "Stilul implicit pentru următorul paragraf."
 
-#: ../src/generic/dirdlgg.cpp:202
+#: ../src/generic/dirdlgg.cpp:199
 #, c-format
 msgid ""
 "The directory '%s' does not exist\n"
@@ -6834,7 +6994,7 @@ msgstr ""
 "Directorul '%s' nu există\n"
 "Să fie creat acum?"
 
-#: ../src/html/htmprint.cpp:271
+#: ../src/html/htmprint.cpp:283
 #, c-format
 msgid ""
 "The document \"%s\" doesn't fit on the page horizontally and will be "
@@ -6847,7 +7007,7 @@ msgstr ""
 "\n"
 "Doriți să fie tipărit oricum?"
 
-#: ../src/common/docview.cpp:1202
+#: ../src/common/docview.cpp:1196
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -6856,36 +7016,36 @@ msgstr ""
 "Fișierul '%s' nu există și nu a putut fi deschis\n"
 "A fost șters din lista fișierelor recent folosite."
 
-#: ../src/richtext/richtextindentspage.cpp:208
-#: ../src/richtext/richtextindentspage.cpp:210
 #: ../src/richtext/richtextliststylepage.cpp:394
 #: ../src/richtext/richtextliststylepage.cpp:396
+#: ../src/richtext/richtextindentspage.cpp:208
+#: ../src/richtext/richtextindentspage.cpp:210
 msgid "The first line indent."
 msgstr "Indentarea primei linii."
 
-#: ../src/gtk/utilsgtk.cpp:481
-msgid "The following standard GTK+ options are also supported:\n"
-msgstr "Următoarele opțiuni GTK+ standard sunt de asemenea suportate:\n"
+#: ../src/generic/dbgrptg.cpp:318
+msgid "The following debug report will be generated\n"
+msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:414 ../src/generic/fontdlgg.cpp:416
+#: ../src/generic/fontdlgg.cpp:411 ../src/generic/fontdlgg.cpp:413
 msgid "The font colour."
 msgstr "Culoarea fontului."
 
-#: ../src/generic/fontdlgg.cpp:375 ../src/generic/fontdlgg.cpp:377
+#: ../src/generic/fontdlgg.cpp:371 ../src/generic/fontdlgg.cpp:373
 msgid "The font family."
 msgstr "Familia fontului."
 
-#: ../src/richtext/richtextsymboldlg.cpp:405
-#: ../src/richtext/richtextsymboldlg.cpp:407
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "The font from which to take the symbol."
 msgstr "Fontul din care se va extrage simbolul."
 
-#: ../src/generic/fontdlgg.cpp:427 ../src/generic/fontdlgg.cpp:429
-#: ../src/generic/fontdlgg.cpp:434 ../src/generic/fontdlgg.cpp:436
+#: ../src/generic/fontdlgg.cpp:424 ../src/generic/fontdlgg.cpp:426
+#: ../src/generic/fontdlgg.cpp:430 ../src/generic/fontdlgg.cpp:432
 msgid "The font point size."
 msgstr "Dimensiunea în puncte a fontului."
 
-#: ../src/osx/carbon/fontdlg.cpp:343 ../src/osx/carbon/fontdlg.cpp:345
+#: ../src/osx/carbon/fontdlg.cpp:340 ../src/osx/carbon/fontdlg.cpp:342
 msgid "The font size in points."
 msgstr "Dimensiunea fontului în puncte."
 
@@ -6894,15 +7054,15 @@ msgstr "Dimensiunea fontului în puncte."
 msgid "The font size units, points or pixels."
 msgstr "Unitățile de măsura pentru mărimea fontului, puncte sau pixeli."
 
-#: ../src/generic/fontdlgg.cpp:386 ../src/generic/fontdlgg.cpp:388
+#: ../src/generic/fontdlgg.cpp:382 ../src/generic/fontdlgg.cpp:384
 msgid "The font style."
 msgstr "Stilul fontului."
 
-#: ../src/generic/fontdlgg.cpp:397 ../src/generic/fontdlgg.cpp:399
+#: ../src/generic/fontdlgg.cpp:393 ../src/generic/fontdlgg.cpp:395
 msgid "The font weight."
 msgstr "Îngroșarea fontului."
 
-#: ../src/common/docview.cpp:1483
+#: ../src/common/docview.cpp:1477
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Formatul fișierului '%s' nu a putut fi determinat."
@@ -6913,10 +7073,10 @@ msgstr "Formatul fișierului '%s' nu a putut fi determinat."
 msgid "The horizontal offset."
 msgstr "Aranjează pe &orizontală"
 
-#: ../src/richtext/richtextindentspage.cpp:199
-#: ../src/richtext/richtextindentspage.cpp:201
 #: ../src/richtext/richtextliststylepage.cpp:385
 #: ../src/richtext/richtextliststylepage.cpp:387
+#: ../src/richtext/richtextindentspage.cpp:199
+#: ../src/richtext/richtextindentspage.cpp:201
 msgid "The left indent."
 msgstr "Indent stânga."
 
@@ -6937,10 +7097,10 @@ msgstr "Dimensiunea spațierii din stânga."
 msgid "The left position."
 msgstr "Poziția din stânga."
 
-#: ../src/richtext/richtextindentspage.cpp:288
-#: ../src/richtext/richtextindentspage.cpp:290
 #: ../src/richtext/richtextliststylepage.cpp:462
 #: ../src/richtext/richtextliststylepage.cpp:464
+#: ../src/richtext/richtextindentspage.cpp:288
+#: ../src/richtext/richtextindentspage.cpp:290
 msgid "The line spacing."
 msgstr "Spațierea dintre linii."
 
@@ -6949,7 +7109,7 @@ msgstr "Spațierea dintre linii."
 msgid "The list item number."
 msgstr "Numărul elementului din listă."
 
-#: ../src/msw/ole/automtn.cpp:664
+#: ../src/msw/ole/automtn.cpp:655
 msgid "The locale ID is unknown."
 msgstr "ID-ul pentru localizare este necunoscut."
 
@@ -6988,7 +7148,7 @@ msgstr "Lățimea obiectului."
 msgid "The outline level."
 msgstr "Nivelul conturului."
 
-#: ../src/common/log.cpp:277
+#: ../src/common/log.cpp:296
 #, fuzzy, c-format
 msgid "The previous message repeated %u time."
 msgid_plural "The previous message repeated %u times."
@@ -6996,12 +7156,12 @@ msgstr[0] "Mesajul anterior e repetat %lu dată."
 msgstr[1] "Mesajul anterior e repetat de %lu ori."
 msgstr[2] "Mesajul anterior e repetat de %lu de ori."
 
-#: ../src/common/log.cpp:270
+#: ../src/common/log.cpp:289
 msgid "The previous message repeated once."
 msgstr "Mesajul anterior e repetat o dată."
 
-#: ../src/richtext/richtextsymboldlg.cpp:462
-#: ../src/richtext/richtextsymboldlg.cpp:464
+#: ../src/richtext/richtextsymboldlg.cpp:459
+#: ../src/richtext/richtextsymboldlg.cpp:461
 msgid "The range to show."
 msgstr "Intervalul de afișat."
 
@@ -7015,15 +7175,15 @@ msgstr ""
 "informații private,\n"
 "debifați-le și vor fi eliminate din raport.\n"
 
-#: ../src/common/cmdline.cpp:1254
+#: ../src/common/cmdline.cpp:1250
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "Parametrul necesar '%s' nu a fost specificat."
 
-#: ../src/richtext/richtextindentspage.cpp:217
-#: ../src/richtext/richtextindentspage.cpp:219
 #: ../src/richtext/richtextliststylepage.cpp:403
 #: ../src/richtext/richtextliststylepage.cpp:405
+#: ../src/richtext/richtextindentspage.cpp:217
+#: ../src/richtext/richtextindentspage.cpp:219
 msgid "The right indent."
 msgstr "Indent dreapta."
 
@@ -7065,16 +7225,16 @@ msgstr ""
 msgid "The shadow spread."
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:267
 #: ../src/richtext/richtextliststylepage.cpp:439
 #: ../src/richtext/richtextliststylepage.cpp:441
+#: ../src/richtext/richtextindentspage.cpp:267
 msgid "The spacing after the paragraph."
 msgstr "Spațierea dupa paragraf."
 
-#: ../src/richtext/richtextindentspage.cpp:257
-#: ../src/richtext/richtextindentspage.cpp:259
 #: ../src/richtext/richtextliststylepage.cpp:430
 #: ../src/richtext/richtextliststylepage.cpp:432
+#: ../src/richtext/richtextindentspage.cpp:257
+#: ../src/richtext/richtextindentspage.cpp:259
 msgid "The spacing before the paragraph."
 msgstr "Spațierea înainte de paragraf."
 
@@ -7088,12 +7248,12 @@ msgstr "Numele stilului."
 msgid "The style on which this style is based."
 msgstr "Stilul de bază pentru acest stil."
 
-#: ../src/richtext/richtextstyledlg.cpp:214
-#: ../src/richtext/richtextstyledlg.cpp:216
+#: ../src/richtext/richtextstyledlg.cpp:210
+#: ../src/richtext/richtextstyledlg.cpp:212
 msgid "The style preview."
 msgstr "Previzualizarea stilului."
 
-#: ../src/msw/ole/automtn.cpp:680
+#: ../src/msw/ole/automtn.cpp:671
 msgid "The system cannot find the file specified."
 msgstr "Sistemul nu poate găsi fișierul specificat."
 
@@ -7106,7 +7266,7 @@ msgstr "Poziția de indentare."
 msgid "The tab positions."
 msgstr "Pozițiile de indentare."
 
-#: ../src/richtext/richtextctrl.cpp:3098
+#: ../src/richtext/richtextctrl.cpp:3099
 msgid "The text couldn't be saved."
 msgstr "Textul nu a putut fi salvat."
 
@@ -7127,7 +7287,7 @@ msgstr "Dimensiunea spațierii superioare."
 msgid "The top position."
 msgstr "Poziția de sus."
 
-#: ../src/common/cmdline.cpp:1232
+#: ../src/common/cmdline.cpp:1228
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "Valoarea pentru opțiunea '%s' trebuie specificată."
@@ -7137,7 +7297,7 @@ msgstr "Valoarea pentru opțiunea '%s' trebuie specificată."
 msgid "The value of the corner radius."
 msgstr "Valoarea razei colțului rotunjit."
 
-#: ../src/msw/dialup.cpp:433
+#: ../src/msw/dialup.cpp:427
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -7153,14 +7313,14 @@ msgstr ""
 msgid "The vertical offset."
 msgstr "Activează alinierea verticală."
 
-#: ../src/richtext/richtextprint.cpp:619 ../src/html/htmprint.cpp:745
+#: ../src/html/htmprint.cpp:749 ../src/richtext/richtextprint.cpp:615
 msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr ""
 "A fost o problemă în timpul setării paginii: se poate să trebuiască setată o "
 "imprimantă implicită."
 
-#: ../src/html/htmprint.cpp:255
+#: ../src/html/htmprint.cpp:267
 msgid ""
 "This document doesn't fit on the page horizontally and will be truncated "
 "when it is printed."
@@ -7168,16 +7328,16 @@ msgstr ""
 "Acest document nu încape în pagină pe orizontală și va fi trunchiat la "
 "tipărire."
 
-#: ../src/common/image.cpp:2854
+#: ../src/common/image.cpp:2963
 #, c-format
 msgid "This is not a %s."
 msgstr "Acesta nu este un %s."
 
-#: ../src/common/wincmn.cpp:1653
+#: ../src/common/wincmn.cpp:1654
 msgid "This platform does not support background transparency."
 msgstr "Această platformă nu suportă transparență pentru fundal."
 
-#: ../src/gtk/window.cpp:4660
+#: ../src/gtk/window.cpp:5664
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
@@ -7185,7 +7345,15 @@ msgstr ""
 "Acest program a fost compilat cu o versiune de GTK+ prea veche, recompilați "
 "cu GTK+ 2.12 sau mai recent."
 
-#: ../src/msw/thread.cpp:1240
+#: ../src/gtk/glcanvas.cpp:176
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/msw/thread.cpp:1246
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -7193,13 +7361,13 @@ msgstr ""
 "Inițializarea modulului pentru fire de execuție a eșuat: valoarea nu poate "
 "fi memorată în memoria locală a firului de execuție"
 
-#: ../src/unix/threadpsx.cpp:1794
+#: ../src/unix/threadpsx.cpp:1843
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 "Inițializarea modulului pentru fire de execuție a eșuat: cheia pentru firul "
 "de execuție nu a putut fi creată"
 
-#: ../src/msw/thread.cpp:1228
+#: ../src/msw/thread.cpp:1234
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -7207,84 +7375,84 @@ msgstr ""
 "Inițializarea modulului pentru fire de execuție a eșuat: indexul nu poate fi "
 "alocat în memoria locală a firului de execuție"
 
-#: ../src/unix/threadpsx.cpp:1043
+#: ../src/unix/threadpsx.cpp:1061
 msgid "Thread priority setting is ignored."
 msgstr "Prioritatea setată pentru firul de excuție este ignorată."
 
-#: ../src/msw/mdi.cpp:176
+#: ../src/msw/mdi.cpp:171
 msgid "Tile &Horizontally"
 msgstr "Aranjează pe &orizontală"
 
-#: ../src/msw/mdi.cpp:177
+#: ../src/msw/mdi.cpp:172
 msgid "Tile &Vertically"
 msgstr "Aranjează pe &verticală"
 
-#: ../src/common/ftp.cpp:200
+#: ../src/common/ftp.cpp:197
 msgid "Timeout while waiting for FTP server to connect, try passive mode."
 msgstr ""
 "Timpul a expirat așteptând serverul FTP să se conecteze, încercați modul "
 "pasiv."
 
-#: ../src/generic/tipdlg.cpp:201
+#: ../src/generic/tipdlg.cpp:198
 msgid "Tip of the Day"
 msgstr "Sfatul zilei"
 
-#: ../src/generic/tipdlg.cpp:140
+#: ../src/generic/tipdlg.cpp:137
 msgid "Tips not available, sorry!"
 msgstr "Sfaturile nu sunt disponibile, ne pare rău!"
 
-#: ../src/generic/prntdlgg.cpp:242
+#: ../src/generic/prntdlgg.cpp:235
 msgid "To:"
 msgstr "Către:"
 
-#: ../src/richtext/richtextbuffer.cpp:8363
+#: ../src/richtext/richtextbuffer.cpp:8361
 msgid "Too many EndStyle calls!"
 msgstr "Prea multe apeluri EndStyle!"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:891
+#: ../src/propgrid/advprops.cpp:792
 msgid "Tooltip"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:892
+#: ../src/propgrid/advprops.cpp:793
 msgid "TooltipText"
 msgstr ""
 
-#: ../src/richtext/richtextsizepage.cpp:286
-#: ../src/richtext/richtextsizepage.cpp:290 ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197 ../src/richtext/richtextsizepage.cpp:286
+#: ../src/richtext/richtextsizepage.cpp:290
 msgid "Top"
 msgstr "Sus"
 
-#: ../src/generic/prntdlgg.cpp:881
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Top margin (mm):"
 msgstr "Margine sus (mm):"
 
-#: ../src/generic/aboutdlgg.cpp:79
+#: ../src/generic/aboutdlgg.cpp:76
 msgid "Translations by "
 msgstr "Traduceri de "
 
-#: ../src/generic/aboutdlgg.cpp:188
+#: ../src/generic/aboutdlgg.cpp:185
 msgid "Translators"
 msgstr "Traducători"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:211
+#: ../src/propgrid/propgrid.cpp:192
 msgid "True"
 msgstr "Adevărat"
 
-#: ../src/common/fs_mem.cpp:227
+#: ../src/common/fs_mem.cpp:222
 #, c-format
 msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
 msgstr ""
 "Se încearcă eliminarea fișierului '%s' din memoria VFS, dar acesta nu este "
 "încărcat!"
 
-#: ../src/common/fmapbase.cpp:156
+#: ../src/common/fmapbase.cpp:153
 msgid "Turkish (ISO-8859-9)"
 msgstr "Turcă (ISO-8859-9)"
 
-#: ../src/generic/filectrlg.cpp:426
+#: ../src/generic/filectrlg.cpp:422
 msgid "Type"
 msgstr "Tip"
 
@@ -7298,17 +7466,17 @@ msgstr "Tastați un nume de font."
 msgid "Type a size in points."
 msgstr "Tastați o dimensiune în puncte."
 
-#: ../src/msw/ole/automtn.cpp:676
+#: ../src/msw/ole/automtn.cpp:667
 #, c-format
 msgid "Type mismatch in argument %u."
 msgstr "Tip nepotrivit pentru argumentul %u."
 
-#: ../src/common/xtixml.cpp:356 ../src/common/xtixml.cpp:509
-#: ../src/common/xtistrm.cpp:318
+#: ../src/common/xtixml.cpp:352 ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315
 msgid "Type must have enum - long conversion"
 msgstr "Tipul trebuie să aibă o conversie enum - long"
 
-#: ../src/propgrid/propgridiface.cpp:401
+#: ../src/propgrid/propgridiface.cpp:385
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
@@ -7317,19 +7485,19 @@ msgstr ""
 "Operația de tipul \"%s\" a eșuat: Proprietatea  \"%s\" este de tipul \"%s\", "
 "NU \"%s\"."
 
-#: ../src/common/paper.cpp:133
+#: ../src/common/paper.cpp:130
 msgid "US Std Fanfold, 14 7/8 x 11 in"
 msgstr "US Std Fanfold, 14 7/8 x 11 in"
 
-#: ../src/common/fmapbase.cpp:196
+#: ../src/common/fmapbase.cpp:193
 msgid "US-ASCII"
 msgstr "US-ASCII"
 
-#: ../src/unix/fswatcher_inotify.cpp:109
+#: ../src/unix/fswatcher_inotify.cpp:106
 msgid "Unable to add inotify watch"
 msgstr "Monitorul inotify nu poate fi adaugat"
 
-#: ../src/unix/fswatcher_kqueue.cpp:136
+#: ../src/unix/fswatcher_kqueue.cpp:153
 msgid "Unable to add kqueue watch"
 msgstr "Monitorul kqueue nu poate fi adăugat"
 
@@ -7341,7 +7509,7 @@ msgstr "Nu se poate asocia operator cu portul I/O de completare"
 msgid "Unable to close I/O completion port handle"
 msgstr "Nu se poate închide operatorul pentru portul I/O de completare"
 
-#: ../src/unix/fswatcher_inotify.cpp:97
+#: ../src/unix/fswatcher_inotify.cpp:94
 msgid "Unable to close inotify instance"
 msgstr "Nu se poate închide instanța inotify"
 
@@ -7359,15 +7527,15 @@ msgstr "Nu se poate închide operatorul pentru '%s'"
 msgid "Unable to create I/O completion port"
 msgstr "Nu se poate crea portul I/O de completare"
 
-#: ../src/msw/fswatcher.cpp:84
+#: ../src/msw/fswatcher.cpp:81
 msgid "Unable to create IOCP worker thread"
 msgstr "Nu se poate crea firul de execuție IOCP lucrător"
 
-#: ../src/unix/fswatcher_inotify.cpp:74
+#: ../src/unix/fswatcher_inotify.cpp:71
 msgid "Unable to create inotify instance"
 msgstr "Nu se poate crea instanță inotify"
 
-#: ../src/unix/fswatcher_kqueue.cpp:97
+#: ../src/unix/fswatcher_kqueue.cpp:114
 msgid "Unable to create kqueue instance"
 msgstr "Nu se poate crea instanță kqueue"
 
@@ -7375,11 +7543,11 @@ msgstr "Nu se poate crea instanță kqueue"
 msgid "Unable to dequeue completion packet"
 msgstr "Pachetul de completare nu poate fi eliminat"
 
-#: ../src/unix/fswatcher_kqueue.cpp:185
+#: ../src/unix/fswatcher_kqueue.cpp:202
 msgid "Unable to get events from kqueue"
 msgstr "Nu se pot citi evenimente din kqueue"
 
-#: ../src/gtk/app.cpp:435
+#: ../src/gtk/app.cpp:431
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "Nu se poate inițializa GTK+, este variabila DISPLAY setată corect?"
 
@@ -7388,12 +7556,12 @@ msgstr "Nu se poate inițializa GTK+, este variabila DISPLAY setată corect?"
 msgid "Unable to open path '%s'"
 msgstr "Nu se poate deschide calea '%s'"
 
-#: ../src/html/htmlwin.cpp:583
+#: ../src/html/htmlwin.cpp:586
 #, c-format
 msgid "Unable to open requested HTML document: %s"
 msgstr "Nu se poate deschide documentul HTML cerut: %s"
 
-#: ../src/unix/sound.cpp:368
+#: ../src/unix/sound.cpp:365
 msgid "Unable to play sound asynchronously."
 msgstr "Nu se poate reda sunet asincron."
 
@@ -7401,63 +7569,63 @@ msgstr "Nu se poate reda sunet asincron."
 msgid "Unable to post completion status"
 msgstr "Nu se poate trimite statusul de completare"
 
-#: ../src/unix/fswatcher_inotify.cpp:556
+#: ../src/unix/fswatcher_inotify.cpp:553
 msgid "Unable to read from inotify descriptor"
 msgstr "Nu se poate citi din descriptorul inotify"
 
-#: ../src/unix/fswatcher_inotify.cpp:141
+#: ../src/unix/fswatcher_inotify.cpp:138
 #, fuzzy, c-format
 msgid "Unable to remove inotify watch %i"
 msgstr "Monitorul inotify nu poate fi eliminat"
 
-#: ../src/unix/fswatcher_kqueue.cpp:153
+#: ../src/unix/fswatcher_kqueue.cpp:170
 msgid "Unable to remove kqueue watch"
 msgstr "Monitorul kqueue nu poate fi eliminat"
 
-#: ../src/msw/fswatcher.cpp:168
+#: ../src/msw/fswatcher.cpp:165
 #, c-format
 msgid "Unable to set up watch for '%s'"
 msgstr "Nu se poate seta monitor pentru '%s'"
 
-#: ../src/msw/fswatcher.cpp:91
+#: ../src/msw/fswatcher.cpp:88
 msgid "Unable to start IOCP worker thread"
 msgstr "Firul de execuție IOCP lucrător nu poate fi pornit"
 
-#: ../src/common/stockitem.cpp:201
+#: ../src/common/stockitem.cpp:198
 msgid "Undelete"
 msgstr "Restaurează"
 
-#: ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199
 msgid "Underline"
 msgstr "Subliniat"
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/richtext/richtextfontpage.cpp:359 ../src/osx/carbon/fontdlg.cpp:370
-#: ../src/propgrid/advprops.cpp:690
+#: ../src/osx/carbon/fontdlg.cpp:367 ../src/propgrid/advprops.cpp:600
+#: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Subliniat"
 
-#: ../src/common/stockitem.cpp:203 ../src/stc/stc_i18n.cpp:15
+#: ../src/common/stockitem.cpp:200 ../src/stc/stc_i18n.cpp:15
 msgid "Undo"
 msgstr "Anulează acțiunea"
 
-#: ../src/common/stockitem.cpp:265
+#: ../src/common/stockitem.cpp:263
 msgid "Undo last action"
 msgstr "Anulează ultima acțiune"
 
-#: ../src/common/cmdline.cpp:1029
+#: ../src/common/cmdline.cpp:1025
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "După opțiunea '%s' apar caractere neașteptate."
 
-#: ../src/unix/fswatcher_inotify.cpp:274
+#: ../src/unix/fswatcher_inotify.cpp:271
 #, c-format
 msgid "Unexpected event for \"%s\": no matching watch descriptor."
 msgstr ""
 "Eveniment neașteptat pentru \"%s\": nu există descriptor de monitorizare "
 "potrivit."
 
-#: ../src/common/cmdline.cpp:1195
+#: ../src/common/cmdline.cpp:1191
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Parametru neașteptat '%s'"
@@ -7466,49 +7634,49 @@ msgstr "Parametru neașteptat '%s'"
 msgid "Unexpectedly new I/O completion port was created"
 msgstr "Un nou port I/O pentru completare a fost creat pe neașteptate"
 
-#: ../src/msw/fswatcher.cpp:70
+#: ../src/msw/fswatcher.cpp:67
 msgid "Ungraceful worker thread termination"
 msgstr "Terminare neelegantă a firului de execuție lucrător"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:460
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:456
+#: ../src/richtext/richtextsymboldlg.cpp:457
+#: ../src/richtext/richtextsymboldlg.cpp:458
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../src/common/fmapbase.cpp:185 ../src/common/fmapbase.cpp:191
+#: ../src/common/fmapbase.cpp:182 ../src/common/fmapbase.cpp:188
 msgid "Unicode 16 bit (UTF-16)"
 msgstr "Unicode 16 bit (UTF-16)"
 
-#: ../src/common/fmapbase.cpp:190
+#: ../src/common/fmapbase.cpp:187
 msgid "Unicode 16 bit Big Endian (UTF-16BE)"
 msgstr "Unicode 16 bit Big Endian (UTF-16BE)"
 
-#: ../src/common/fmapbase.cpp:186
+#: ../src/common/fmapbase.cpp:183
 msgid "Unicode 16 bit Little Endian (UTF-16LE)"
 msgstr "Unicode 16 bit Little Endian (UTF-16LE)"
 
-#: ../src/common/fmapbase.cpp:187 ../src/common/fmapbase.cpp:193
+#: ../src/common/fmapbase.cpp:184 ../src/common/fmapbase.cpp:190
 msgid "Unicode 32 bit (UTF-32)"
 msgstr "Unicode 32 bit (UTF-32)"
 
-#: ../src/common/fmapbase.cpp:192
+#: ../src/common/fmapbase.cpp:189
 msgid "Unicode 32 bit Big Endian (UTF-32BE)"
 msgstr "Unicode 32 bit Big Endian (UTF-32BE)"
 
-#: ../src/common/fmapbase.cpp:188
+#: ../src/common/fmapbase.cpp:185
 msgid "Unicode 32 bit Little Endian (UTF-32LE)"
 msgstr "Unicode 32 bit Little Endian (UTF-32LE)"
 
-#: ../src/common/fmapbase.cpp:182
+#: ../src/common/fmapbase.cpp:179
 msgid "Unicode 7 bit (UTF-7)"
 msgstr "Unicode 7 bit (UTF-7)"
 
-#: ../src/common/fmapbase.cpp:183
+#: ../src/common/fmapbase.cpp:180
 msgid "Unicode 8 bit (UTF-8)"
 msgstr "Unicode 8 bit (UTF-8)"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "Unindent"
 msgstr "Anulează indentare"
 
@@ -7659,97 +7827,102 @@ msgstr "Unități pentru poziție sus."
 msgid "Units for this value."
 msgstr "Unități pentru marginea stângă."
 
-#: ../src/generic/progdlgg.cpp:353 ../src/generic/progdlgg.cpp:622
+#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
 msgid "Unknown"
 msgstr "Necunoscut"
 
-#: ../src/msw/dde.cpp:1174
+#: ../src/msw/dde.cpp:1238
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Eroare DDE necunoscută %08x"
 
-#: ../src/common/xtistrm.cpp:410
+#: ../src/common/xtistrm.cpp:407
 msgid "Unknown Object passed to GetObjectClassInfo"
 msgstr "Obiect necunoscut pasat către GetObjectClassInfo"
 
-#: ../src/common/imagpng.cpp:366
+#: ../src/common/imagpng.cpp:383
 #, c-format
 msgid "Unknown PNG resolution unit %d"
 msgstr "Unitatea %d de rezoluție pentru PNG necunoscută"
 
-#: ../src/common/xtixml.cpp:327
+#: ../src/common/xtixml.cpp:323
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Proprietate %s necunoscută"
 
-#: ../src/common/imagtiff.cpp:529
+#: ../src/common/imagtiff.cpp:526
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "Unitatea de rezoluție TIFF necunoscută %d ignorată"
 
-#: ../src/unix/dlunix.cpp:160
+#: ../src/propgrid/props.cpp:155
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/unix/dlunix.cpp:118
 msgid "Unknown dynamic library error"
 msgstr "Eroare necunoscută de librărie dinamică"
 
-#: ../src/common/fmapbase.cpp:810
+#: ../src/common/fmapbase.cpp:806
 #, c-format
 msgid "Unknown encoding (%d)"
 msgstr "Codificare necunoscută (%d)"
 
-#: ../src/msw/ole/automtn.cpp:688
+#: ../src/msw/ole/automtn.cpp:679
 #, c-format
 msgid "Unknown error %08x"
 msgstr "Eroare necunoscută %08x"
 
-#: ../src/msw/ole/automtn.cpp:647
+#: ../src/msw/ole/automtn.cpp:638
 msgid "Unknown exception"
 msgstr "Exceptie necunoscută"
 
-#: ../src/common/image.cpp:2839
+#: ../src/common/image.cpp:2942
 msgid "Unknown image data format."
 msgstr "Format de imagine necunoscut."
 
-#: ../src/common/cmdline.cpp:914
+#: ../src/common/cmdline.cpp:910
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Opțiune lungă necunoscută '%s'"
 
-#: ../src/msw/ole/automtn.cpp:631
+#: ../src/msw/ole/automtn.cpp:622
 msgid "Unknown name or named argument."
 msgstr "Nume sau denumire de argument necunoscute."
 
-#: ../src/common/cmdline.cpp:929 ../src/common/cmdline.cpp:951
+#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Opțiune %s necunoscută"
 
-#: ../src/common/mimecmn.cpp:225
+#: ../src/common/mimecmn.cpp:221
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "'{' fără pereche într-o intrare pentru tipul mime %s."
 
-#: ../src/common/cmdproc.cpp:262 ../src/common/cmdproc.cpp:288
-#: ../src/common/cmdproc.cpp:308
+#: ../src/common/cmdproc.cpp:255 ../src/common/cmdproc.cpp:281
+#: ../src/common/cmdproc.cpp:301
 msgid "Unnamed command"
 msgstr "Comandă fără nume"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:413
+#: ../src/propgrid/propgrid.cpp:392
 msgid "Unspecified"
 msgstr "Nespecificat"
 
-#: ../src/msw/clipbrd.cpp:311
+#: ../src/msw/clipbrd.cpp:325
 msgid "Unsupported clipboard format."
 msgstr "Format de clipboard nesuportat."
 
-#: ../src/common/appcmn.cpp:256
+#: ../src/common/appcmn.cpp:277
 #, c-format
 msgid "Unsupported theme '%s'."
 msgstr "Temă nesuportată '%s'."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:205
-#: ../src/common/accelcmn.cpp:63
+#: ../src/common/stockitem.cpp:202 ../src/common/accelcmn.cpp:60
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Up"
 msgstr "Sus"
 
@@ -7763,7 +7936,7 @@ msgstr "Majuscule"
 msgid "Upper case roman numerals"
 msgstr "Numere romane în majuscule"
 
-#: ../src/common/cmdline.cpp:1326
+#: ../src/common/cmdline.cpp:1322
 #, c-format
 msgid "Usage: %s"
 msgstr "Utlizare: %s"
@@ -7772,38 +7945,47 @@ msgstr "Utlizare: %s"
 msgid "Use &shadow"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:169
-#: ../src/richtext/richtextindentspage.cpp:171
 #: ../src/richtext/richtextliststylepage.cpp:358
 #: ../src/richtext/richtextliststylepage.cpp:360
+#: ../src/richtext/richtextindentspage.cpp:169
+#: ../src/richtext/richtextindentspage.cpp:171
 msgid "Use the current alignment setting."
 msgstr "Folosește setările curente pentru aliniere."
 
-#: ../src/common/valtext.cpp:179
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/gtk/font.cpp:552
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/common/valtext.cpp:142
 msgid "Validation conflict"
 msgstr "Conflict de validare"
 
-#: ../src/propgrid/manager.cpp:238
+#: ../src/propgrid/manager.cpp:224
 msgid "Value"
 msgstr "Valoare"
 
-#: ../src/propgrid/props.cpp:386 ../src/propgrid/props.cpp:500
+#: ../src/propgrid/props.cpp:309
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "Valoarea trebuie să fie %s sau mai mare."
 
-#: ../src/propgrid/props.cpp:417 ../src/propgrid/props.cpp:531
+#: ../src/propgrid/props.cpp:336
 #, c-format
 msgid "Value must be %s or less."
 msgstr "Valoarea trebuie să fie %s sau mai mică."
 
-#: ../src/propgrid/props.cpp:393 ../src/propgrid/props.cpp:424
-#: ../src/propgrid/props.cpp:507 ../src/propgrid/props.cpp:538
+#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "Valoarea trebuie să fie între %s și %s."
 
-#: ../src/generic/aboutdlgg.cpp:128
+#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Versiunea "
 
@@ -7812,25 +7994,32 @@ msgstr "Versiunea "
 msgid "Vertical alignment."
 msgstr "Aliniere verticală."
 
-#: ../src/generic/filedlgg.cpp:202
+#: ../src/generic/filedlgg.cpp:199
 msgid "View files as a detailed view"
 msgstr "Afișează detaliat fișierele"
 
-#: ../src/generic/filedlgg.cpp:200
+#: ../src/generic/filedlgg.cpp:197
 msgid "View files as a list view"
 msgstr "Afișează fișierele ca listă"
 
-#: ../src/common/docview.cpp:1970
+#: ../src/common/docview.cpp:1975
 msgid "Views"
 msgstr "Vizualizări"
 
+#: ../src/gtk/app.cpp:348
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1777
+#: ../src/propgrid/advprops.cpp:1678
 msgid "Wait"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1779
+#: ../src/propgrid/advprops.cpp:1680
 msgid "Wait Arrow"
 msgstr ""
 
@@ -7839,246 +8028,241 @@ msgstr ""
 msgid "Waiting for IO on epoll descriptor %d failed"
 msgstr "Așteptarea pentru IO pe descriptorul epoll %d a eșuat"
 
-#: ../src/common/log.cpp:223
+#: ../src/common/log.cpp:241
 msgid "Warning: "
 msgstr "Avertisment: "
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1778
+#: ../src/propgrid/advprops.cpp:1679
 msgid "Watch"
 msgstr ""
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:685
+#: ../src/propgrid/advprops.cpp:595
 msgid "Weight"
 msgstr "Îngroșare"
 
-#: ../src/common/fmapbase.cpp:148
+#: ../src/common/fmapbase.cpp:145
 msgid "Western European (ISO-8859-1)"
 msgstr "Vest Europeană (ISO-8859-1)"
 
-#: ../src/common/fmapbase.cpp:162
+#: ../src/common/fmapbase.cpp:159
 msgid "Western European with Euro (ISO-8859-15)"
 msgstr "Vest Europeană cu Euro (ISO-8859-15)"
 
-#: ../src/generic/fontdlgg.cpp:446 ../src/generic/fontdlgg.cpp:448
+#: ../src/generic/fontdlgg.cpp:443 ../src/generic/fontdlgg.cpp:445
 msgid "Whether the font is underlined."
 msgstr "Determină sublinierea."
 
-#: ../src/propgrid/advprops.cpp:1611
+#: ../src/propgrid/advprops.cpp:1517
 msgid "White"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:144
+#: ../src/generic/fdrepdlg.cpp:141
 msgid "Whole word"
 msgstr "Cuvânt întreg"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:532
 msgid "Whole words only"
 msgstr "Numai cuvinte întregi"
 
-#: ../src/univ/themes/win32.cpp:1102
+#: ../src/univ/themes/win32.cpp:1099
 msgid "Win32 theme"
 msgstr "Tema Win32"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:893
+#: ../src/propgrid/advprops.cpp:794
 #, fuzzy
 msgid "Window"
 msgstr "&Fereastră"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:894
+#: ../src/propgrid/advprops.cpp:795
 #, fuzzy
 msgid "WindowFrame"
 msgstr "&Fereastră"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:895
+#: ../src/propgrid/advprops.cpp:796
 #, fuzzy
 msgid "WindowText"
 msgstr "&Fereastră"
 
-#: ../src/common/fmapbase.cpp:177
+#: ../src/common/fmapbase.cpp:174
 msgid "Windows Arabic (CP 1256)"
 msgstr "Windows Arabică (CP 1256)"
 
-#: ../src/common/fmapbase.cpp:178
+#: ../src/common/fmapbase.cpp:175
 msgid "Windows Baltic (CP 1257)"
 msgstr "Windows Baltică (CP 1257)"
 
-#: ../src/common/fmapbase.cpp:171
+#: ../src/common/fmapbase.cpp:168
 msgid "Windows Central European (CP 1250)"
 msgstr "Windows Central Europeană (CP 1250)"
 
-#: ../src/common/fmapbase.cpp:168
+#: ../src/common/fmapbase.cpp:165
 msgid "Windows Chinese Simplified (CP 936) or GB-2312"
 msgstr "Windows Chineză Simplificată (CP 936) sau GB-2312"
 
-#: ../src/common/fmapbase.cpp:170
+#: ../src/common/fmapbase.cpp:167
 msgid "Windows Chinese Traditional (CP 950) or Big-5"
 msgstr "Windows Chineză Traditională (CP 950) sau Big-5"
 
-#: ../src/common/fmapbase.cpp:172
+#: ../src/common/fmapbase.cpp:169
 msgid "Windows Cyrillic (CP 1251)"
 msgstr "Windows Chirilică (CP 1251)"
 
-#: ../src/common/fmapbase.cpp:174
+#: ../src/common/fmapbase.cpp:171
 msgid "Windows Greek (CP 1253)"
 msgstr "Windows Greacă (CP 1253)"
 
-#: ../src/common/fmapbase.cpp:176
+#: ../src/common/fmapbase.cpp:173
 msgid "Windows Hebrew (CP 1255)"
 msgstr "Windows Ebraică (CP 1255)"
 
-#: ../src/common/fmapbase.cpp:167
+#: ../src/common/fmapbase.cpp:164
 msgid "Windows Japanese (CP 932) or Shift-JIS"
 msgstr "Windows Japoneză (CP 932) sau Shift-JIS"
 
-#: ../src/common/fmapbase.cpp:180
+#: ../src/common/fmapbase.cpp:177
 msgid "Windows Johab (CP 1361)"
 msgstr "Windows Johab (CP 1361)"
 
-#: ../src/common/fmapbase.cpp:169
+#: ../src/common/fmapbase.cpp:166
 msgid "Windows Korean (CP 949)"
 msgstr "Windows Coreeană (CP 949)"
 
-#: ../src/common/fmapbase.cpp:166
+#: ../src/common/fmapbase.cpp:163
 msgid "Windows Thai (CP 874)"
 msgstr "Windows Tailandeză (CP 874)"
 
-#: ../src/common/fmapbase.cpp:175
+#: ../src/common/fmapbase.cpp:172
 msgid "Windows Turkish (CP 1254)"
 msgstr "Windows Turcă (CP 1254)"
 
-#: ../src/common/fmapbase.cpp:179
+#: ../src/common/fmapbase.cpp:176
 msgid "Windows Vietnamese (CP 1258)"
 msgstr "Windows Vietnameză (CP 1258)"
 
-#: ../src/common/fmapbase.cpp:173
+#: ../src/common/fmapbase.cpp:170
 msgid "Windows Western European (CP 1252)"
 msgstr "Windows Vest Europeană (CP 1252)"
 
-#: ../src/common/fmapbase.cpp:181
+#: ../src/common/fmapbase.cpp:178
 msgid "Windows/DOS OEM (CP 437)"
 msgstr "Windows/DOS OEM (CP 437)"
 
-#: ../src/common/fmapbase.cpp:165
+#: ../src/common/fmapbase.cpp:162
 msgid "Windows/DOS OEM Cyrillic (CP 866)"
 msgstr "Windows/DOS OEM Chirilică (CP 866)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:111
+#: ../src/common/accelcmn.cpp:109
 #, fuzzy
 msgid "Windows_Left"
 msgstr "Windows 7"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:113
+#: ../src/common/accelcmn.cpp:111
 #, fuzzy
 msgid "Windows_Menu"
 msgstr "Windows ME"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:112
+#: ../src/common/accelcmn.cpp:110
 #, fuzzy
 msgid "Windows_Right"
 msgstr "Windows Vista"
 
-#: ../src/common/ffile.cpp:150
+#: ../src/common/ffile.cpp:149
 #, c-format
 msgid "Write error on file '%s'"
 msgstr "Eroare la scriere în fișierul '%s'"
 
-#: ../src/xml/xml.cpp:914
+#: ../src/xml/xml.cpp:925
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "Eroare la analiza XML: '%s' la linia %d"
 
-#: ../src/common/xpmdecod.cpp:796
+#: ../src/common/xpmdecod.cpp:794
 msgid "XPM: Malformed pixel data!"
 msgstr "XPM: Date de pixel eronate!"
 
-#: ../src/common/xpmdecod.cpp:705
+#: ../src/common/xpmdecod.cpp:702
 #, c-format
 msgid "XPM: incorrect colour description in line %d"
 msgstr "XPM: descriere incorectă a culorii la linia %d"
 
-#: ../src/common/xpmdecod.cpp:680
+#: ../src/common/xpmdecod.cpp:677
 msgid "XPM: incorrect header format!"
 msgstr "XPM: format incorect pentru antet!"
 
-#: ../src/common/xpmdecod.cpp:716 ../src/common/xpmdecod.cpp:725
+#: ../src/common/xpmdecod.cpp:714 ../src/common/xpmdecod.cpp:723
 #, c-format
 msgid "XPM: malformed colour definition '%s' at line %d!"
 msgstr "XPM: definiție incorectă a culorii '%s' la linia %d!"
 
-#: ../src/common/xpmdecod.cpp:755
+#: ../src/common/xpmdecod.cpp:753
 msgid "XPM: no colors left to use for mask!"
 msgstr "XPM: nu a rămas nicio culoare pentru a se folosi drept mască!"
 
-#: ../src/common/xpmdecod.cpp:782
+#: ../src/common/xpmdecod.cpp:780
 #, c-format
 msgid "XPM: truncated image data at line %d!"
 msgstr "XPM: datele imaginii sunt trunchiate la linia %d!"
 
-#: ../src/propgrid/advprops.cpp:1610
+#: ../src/propgrid/advprops.cpp:1516
 msgid "Yellow"
 msgstr ""
 
-#: ../include/wx/msgdlg.h:276 ../src/common/stockitem.cpp:206
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:203
 #: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Da"
 
-#: ../src/osx/carbon/overlay.cpp:155
-msgid "You cannot Clear an overlay that is not inited"
-msgstr ""
-"Nu se poate curăța o suprafață de acoperire (overlay) care nu a fost "
-"inițializată"
-
-#: ../src/osx/carbon/overlay.cpp:107 ../src/dfb/overlay.cpp:61
-msgid "You cannot Init an overlay twice"
-msgstr "O suprafață de acoperire (overlay) nu se poate inițializa de două ori"
-
-#: ../src/generic/dirdlgg.cpp:287
+#: ../src/generic/dirdlgg.cpp:284
 msgid "You cannot add a new directory to this section."
 msgstr "Nu se poate adăuga un nou director la această secțiune."
 
-#: ../src/propgrid/propgrid.cpp:3299
+#: ../src/propgrid/propgrid.cpp:3276
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 "Ați introdus o valoare incorectă. Apăsati ESC pentru anularea editării."
 
-#: ../src/common/stockitem.cpp:209
+#: ../src/osx/cocoa/menu.mm:286
+#, fuzzy
+msgid "Zoom"
+msgstr "Mărește"
+
+#: ../src/common/stockitem.cpp:206
 msgid "Zoom &In"
 msgstr "Mă&rește"
 
-#: ../src/common/stockitem.cpp:210
+#: ../src/common/stockitem.cpp:207
 msgid "Zoom &Out"
 msgstr "Mi&cșorează"
 
-#: ../src/common/stockitem.cpp:209 ../src/common/prntbase.cpp:1594
+#: ../src/common/stockitem.cpp:206 ../src/common/prntbase.cpp:1619
 msgid "Zoom In"
 msgstr "Mărește"
 
-#: ../src/common/stockitem.cpp:210 ../src/common/prntbase.cpp:1580
+#: ../src/common/stockitem.cpp:207 ../src/common/prntbase.cpp:1605
 msgid "Zoom Out"
 msgstr "Micșorează"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to &Fit"
 msgstr "Redimensione&ază cât să încapă"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to Fit"
 msgstr "Redimensionează cât să încapă"
 
-#: ../src/msw/dde.cpp:1141
+#: ../src/msw/dde.cpp:1205
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "o aplicație DDEML a creat o condiție de rulare concurentă prelungită."
 
-#: ../src/msw/dde.cpp:1129
+#: ../src/msw/dde.cpp:1193
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -8090,39 +8274,39 @@ msgstr ""
 "sau un identificator de instanță invalid\n"
 "a fost pasat unei funcții DDEML."
 
-#: ../src/msw/dde.cpp:1147
+#: ../src/msw/dde.cpp:1211
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "o tentativă a unui client de a stabili o conversație a eșuat."
 
-#: ../src/msw/dde.cpp:1144
+#: ../src/msw/dde.cpp:1208
 msgid "a memory allocation failed."
 msgstr "o alocare de memorie a eșuat."
 
-#: ../src/msw/dde.cpp:1138
+#: ../src/msw/dde.cpp:1202
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "un parametru nu a fost validat de DDEML."
 
-#: ../src/msw/dde.cpp:1120
+#: ../src/msw/dde.cpp:1184
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "o cerere pentru o tranzacție sincronă de informare a expirat."
 
-#: ../src/msw/dde.cpp:1126
+#: ../src/msw/dde.cpp:1190
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "o cerere pentru o tranzacție sincronă de date a expirat."
 
-#: ../src/msw/dde.cpp:1135
+#: ../src/msw/dde.cpp:1199
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "o cerere pentru o tranzacție sincronă de execuție a expirat."
 
-#: ../src/msw/dde.cpp:1153
+#: ../src/msw/dde.cpp:1217
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "o cerere pentru o tranzacție sincronă de test a expirat."
 
-#: ../src/msw/dde.cpp:1168
+#: ../src/msw/dde.cpp:1232
 msgid "a request to end an advise transaction has timed out."
 msgstr "o cerere de încheiere a unei tranzacții de informare a expirat."
 
-#: ../src/msw/dde.cpp:1162
+#: ../src/msw/dde.cpp:1226
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -8132,15 +8316,15 @@ msgstr ""
 "într-o conversație întreruptă de client, sau serverul\n"
 "a terminat înainte de încheierea tranzacției."
 
-#: ../src/msw/dde.cpp:1150
+#: ../src/msw/dde.cpp:1214
 msgid "a transaction failed."
 msgstr "o tranzacție a eșuat."
 
-#: ../src/common/accelcmn.cpp:189
+#: ../src/common/accelcmn.cpp:188
 msgid "alt"
 msgstr "alt"
 
-#: ../src/msw/dde.cpp:1132
+#: ../src/msw/dde.cpp:1196
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -8152,15 +8336,15 @@ msgstr ""
 "sau o aplicație inițializată ca APPCMD_CLIENTONLY\n"
 "a încercat să execute o tranzacție de server."
 
-#: ../src/msw/dde.cpp:1156
+#: ../src/msw/dde.cpp:1220
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "un apel intern către funcția PostMessage a eșuat. "
 
-#: ../src/msw/dde.cpp:1165
+#: ../src/msw/dde.cpp:1229
 msgid "an internal error has occurred in the DDEML."
 msgstr "o eroare internă a survenit în DDEML."
 
-#: ../src/msw/dde.cpp:1171
+#: ../src/msw/dde.cpp:1235
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -8170,56 +8354,56 @@ msgstr ""
 "La revenirea din funcția de apel invers XTYP_XACT_COMPLETE,\n"
 "identificatorul de tranzacție al funcției nu mai este valid."
 
-#: ../src/common/zipstrm.cpp:1483
+#: ../src/common/zipstrm.cpp:1522
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "presupunând că acesta este un zip concatenat din mai multe părți"
 
-#: ../src/common/fileconf.cpp:1847
+#: ../src/common/fileconf.cpp:1849
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "tentativă ignorată de a schimba cheia imuabilă '%s'."
 
-#: ../src/html/chm.cpp:329
+#: ../src/html/chm.cpp:326
 msgid "bad arguments to library function"
 msgstr "argumente eronate date unei funcții din librărie"
 
-#: ../src/html/chm.cpp:341
+#: ../src/html/chm.cpp:338
 msgid "bad signature"
 msgstr "semnătură incorectă"
 
-#: ../src/common/zipstrm.cpp:1918
+#: ../src/common/zipstrm.cpp:1988
 msgid "bad zipfile offset to entry"
 msgstr "deplasament eronat pentru intrarea fișierului zip"
 
-#: ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400
 msgid "binary"
 msgstr "binar"
 
-#: ../src/common/fontcmn.cpp:996
+#: ../src/common/fontcmn.cpp:1195
 msgid "bold"
 msgstr "îngroșat"
 
-#: ../src/msw/utils.cpp:1144
+#: ../src/msw/utils.cpp:1135
 #, c-format
 msgid "build %lu"
 msgstr "build %lu"
 
-#: ../src/common/ffile.cpp:75
+#: ../src/common/ffile.cpp:73
 #, c-format
 msgid "can't close file '%s'"
 msgstr "nu poate fi închis fișierul '%s'"
 
-#: ../src/common/file.cpp:245
+#: ../src/common/file.cpp:242
 #, c-format
 msgid "can't close file descriptor %d"
 msgstr "nu poate fi închis descriptorul de fișier '%d'"
 
-#: ../src/common/file.cpp:586
+#: ../src/common/ffile.cpp:382 ../src/common/file.cpp:613
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "nu pot fi memorate schimbările în fișierul '%s'"
 
-#: ../src/common/file.cpp:178
+#: ../src/common/file.cpp:175
 #, c-format
 msgid "can't create file '%s'"
 msgstr "nu poate fi creat fișierul '%s'"
@@ -8229,54 +8413,54 @@ msgstr "nu poate fi creat fișierul '%s'"
 msgid "can't delete user configuration file '%s'"
 msgstr "nu poate fi șters fișierul de configurări pentru utilizator '%s'"
 
-#: ../src/common/file.cpp:495
+#: ../src/common/file.cpp:522
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr ""
 "nu se poate determina dacă sfârșitul fișierului a fost atins în descriptorul "
 "%d"
 
-#: ../src/common/zipstrm.cpp:1692
+#: ../src/common/zipstrm.cpp:1747
 msgid "can't find central directory in zip"
 msgstr "Nu a fost găsit directorul central in zip"
 
-#: ../src/common/file.cpp:465
+#: ../src/common/file.cpp:492
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr ""
 "nu poate fi determinată lungimea fișierului pentru descriptorul de fișier %d"
 
-#: ../src/msw/utils.cpp:341
+#: ../src/msw/utils.cpp:336
 msgid "can't find user's HOME, using current directory."
 msgstr ""
 "nu poate fi găsit directorul ACASĂ al utilizatorului, se folosește "
 "directorul curent."
 
-#: ../src/common/file.cpp:366
+#: ../src/common/file.cpp:407
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "nu se poate transmite către descriptorul de fisier %d"
 
-#: ../src/common/file.cpp:422
+#: ../src/common/file.cpp:463
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "nu se poate obține poziția de căutare pentru descriptorul de fișier %d"
 
-#: ../src/common/fontmap.cpp:325
+#: ../src/common/fontmap.cpp:322
 msgid "can't load any font, aborting"
 msgstr "nu poate fi încărcat niciun font, se abandonează"
 
-#: ../src/common/file.cpp:231 ../src/common/ffile.cpp:59
+#: ../src/common/ffile.cpp:57 ../src/common/file.cpp:228
 #, c-format
 msgid "can't open file '%s'"
 msgstr "nu poate fi deschis fișierul '%s'"
 
-#: ../src/common/fileconf.cpp:320
+#: ../src/common/fileconf.cpp:314
 #, c-format
 msgid "can't open global configuration file '%s'."
 msgstr "nu poate fi deschis fișierul global de configurări '%s'."
 
-#: ../src/common/fileconf.cpp:336
+#: ../src/common/fileconf.cpp:330
 #, c-format
 msgid "can't open user configuration file '%s'."
 msgstr "nu poate fi deschis fișierul de configurări al utilizatrului '%s'."
@@ -8285,40 +8469,40 @@ msgstr "nu poate fi deschis fișierul de configurări al utilizatrului '%s'."
 msgid "can't open user configuration file."
 msgstr "nu poate fi deschis fișierul de configurări al utilizatrului."
 
-#: ../src/common/zipstrm.cpp:579
+#: ../src/common/zipstrm.cpp:572
 msgid "can't re-initialize zlib deflate stream"
 msgstr "nu se poate reinițializa fluxul de compresie zlib"
 
-#: ../src/common/zipstrm.cpp:604
+#: ../src/common/zipstrm.cpp:597
 msgid "can't re-initialize zlib inflate stream"
 msgstr "nu se poate reinițializa fluxul de decompresie zlib"
 
-#: ../src/common/file.cpp:304
+#: ../src/common/file.cpp:345
 #, c-format
 msgid "can't read from file descriptor %d"
 msgstr "nu se poate citi din descriptorul de fișier %d"
 
-#: ../src/common/file.cpp:581
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:608
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "nu poate fi șters fișierul '%s'"
 
-#: ../src/common/file.cpp:598
+#: ../src/common/ffile.cpp:394 ../src/common/file.cpp:625
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "nu poate fi șters fișierul temporar '%s'"
 
-#: ../src/common/file.cpp:408
+#: ../src/common/file.cpp:449
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "nu se poate căuta în descriptorul de fișier %d"
 
-#: ../src/common/textfile.cpp:273
+#: ../src/common/textfile.cpp:161
 #, c-format
 msgid "can't write buffer '%s' to disk."
 msgstr "nu se poate scrie buffer-ul %s pe disc."
 
-#: ../src/common/file.cpp:323
+#: ../src/common/file.cpp:364
 #, c-format
 msgid "can't write to file descriptor %d"
 msgstr "nu se poate scrie în descriptorul de fișier %d"
@@ -8328,22 +8512,28 @@ msgid "can't write user configuration file."
 msgstr "nu se poate scrie fișierul de configurări pentru utilizator."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:482 ../src/generic/datavgen.cpp:1261
+#: ../src/common/datavcmn.cpp:2064 ../src/generic/datavgen.cpp:1384
 msgid "checked"
 msgstr ""
 
-#: ../src/html/chm.cpp:345
+#: ../src/html/chm.cpp:342
 msgid "checksum error"
 msgstr "suma de control eronată"
 
-#: ../src/common/tarstrm.cpp:820
+#: ../src/common/tarstrm.cpp:814
 msgid "checksum failure reading tar header block"
 msgstr "suma de control eronată în blocul antet pentru tar"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:226
-#: ../src/richtext/richtextbackgroundpage.cpp:249
-#: ../src/richtext/richtextbackgroundpage.cpp:289
-#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
 #: ../src/richtext/richtextborderspage.cpp:254
 #: ../src/richtext/richtextborderspage.cpp:288
 #: ../src/richtext/richtextborderspage.cpp:322
@@ -8361,105 +8551,128 @@ msgstr "suma de control eronată în blocul antet pentru tar"
 #: ../src/richtext/richtextmarginspage.cpp:340
 #: ../src/richtext/richtextmarginspage.cpp:363
 #: ../src/richtext/richtextmarginspage.cpp:388
-#: ../src/richtext/richtextsizepage.cpp:339
-#: ../src/richtext/richtextsizepage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:400
-#: ../src/richtext/richtextsizepage.cpp:427
-#: ../src/richtext/richtextsizepage.cpp:454
-#: ../src/richtext/richtextsizepage.cpp:481
-#: ../src/richtext/richtextsizepage.cpp:555
-#: ../src/richtext/richtextsizepage.cpp:590
-#: ../src/richtext/richtextsizepage.cpp:625
-#: ../src/richtext/richtextsizepage.cpp:660
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
 msgid "cm"
 msgstr "cm"
 
-#: ../src/html/chm.cpp:347
+#: ../src/html/chm.cpp:344
 msgid "compression error"
 msgstr "eroare la comprimare"
 
-#: ../src/common/regex.cpp:236
+#: ../src/common/regex.cpp:233
 msgid "conversion to 8-bit encoding failed"
 msgstr "conversia la codificare pe 8 biți a eșuat"
 
-#: ../src/common/accelcmn.cpp:187
+#: ../src/common/accelcmn.cpp:186
 msgid "ctrl"
 msgstr "ctrl"
 
-#: ../src/common/cmdline.cpp:1500
+#: ../src/common/cmdline.cpp:1496
 msgid "date"
 msgstr "dată"
 
-#: ../src/html/chm.cpp:349
+#: ../src/html/chm.cpp:346
 msgid "decompression error"
 msgstr "eroare la decomprimare"
 
-#: ../src/richtext/richtextstyles.cpp:780 ../src/common/fmapbase.cpp:820
+#: ../src/common/fmapbase.cpp:816 ../src/richtext/richtextstyles.cpp:777
 msgid "default"
 msgstr "implicit"
 
-#: ../src/common/cmdline.cpp:1496
+#: ../src/common/cmdline.cpp:1492
 msgid "double"
 msgstr "double"
 
-#: ../src/common/debugrpt.cpp:538
+#: ../src/common/debugrpt.cpp:539
 msgid "dump of the process state (binary)"
 msgstr "copie a stării procesului (binară)"
 
-#: ../src/common/datetimefmt.cpp:1969
+#: ../src/common/datetimefmt.cpp:1992
 msgid "eighteenth"
 msgstr "al(a) optsprezecelea(optsprezecea)"
 
-#: ../src/common/datetimefmt.cpp:1959
+#: ../src/common/datetimefmt.cpp:1982
 msgid "eighth"
 msgstr "al(a) optulea(opta)"
 
-#: ../src/common/datetimefmt.cpp:1962
+#: ../src/common/datetimefmt.cpp:1985
 msgid "eleventh"
 msgstr "al(a) unsprezecelea(unsprezecea)"
 
-#: ../src/common/fileconf.cpp:1833
+#: ../src/common/fileconf.cpp:1835
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "intrarea '%s' apare mai mult de o dată în grupul '%s'"
 
-#: ../src/html/chm.cpp:343
+#: ../src/html/chm.cpp:340
 msgid "error in data format"
 msgstr "eroare în formatul de date"
 
-#: ../src/html/chm.cpp:331
+#: ../src/html/chm.cpp:328
 msgid "error opening file"
 msgstr "eroare la deschiderea fișierului"
 
-#: ../src/common/zipstrm.cpp:1778
+#: ../src/common/zipstrm.cpp:1836
 msgid "error reading zip central directory"
 msgstr "eroare la citirea directorului central din zip"
 
-#: ../src/common/zipstrm.cpp:1870
+#: ../src/common/zipstrm.cpp:1940
 msgid "error reading zip local header"
 msgstr "eroare la citirea antetului local din zip"
 
-#: ../src/common/zipstrm.cpp:2531
+#: ../src/common/zipstrm.cpp:2615
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "eroare la scrierea intrării zip '%s': eroare de crc sau lungime"
 
-#: ../src/common/ffile.cpp:188
+#: ../src/common/zipstrm.cpp:2608
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "eroare la scrierea intrării zip '%s': eroare de crc sau lungime"
+
+#: ../src/common/fontcmn.cpp:1205
+#, fuzzy
+msgid "extrabold"
+msgstr "îngroșat"
+
+#: ../src/common/fontcmn.cpp:1223
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1167
+#, fuzzy
+msgid "extralight"
+msgstr "subțire"
+
+#: ../src/msw/webview_ie.cpp:1036
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "A eșuat executarea '%s'\n"
+
+#: ../src/common/ffile.cpp:187
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "transmitere eșuată către fișierul '%s'"
 
+#: ../src/msw/webview_ie.cpp:1045
+#, fuzzy
+msgid "failed to retrieve execution result"
+msgstr "A eșuat obținerea textului din mesajul de eroare RAS"
+
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1030
+#: ../src/generic/datavgen.cpp:1150
 #, fuzzy
 msgid "false"
 msgstr "Fals"
 
-#: ../src/common/datetimefmt.cpp:1966
+#: ../src/common/datetimefmt.cpp:1989
 msgid "fifteenth"
 msgstr "al(a) cincisprezecealea(cincisprezecea)"
 
-#: ../src/common/datetimefmt.cpp:1956
+#: ../src/common/datetimefmt.cpp:1979
 msgid "fifth"
 msgstr "al(a) cincelea(cincea)"
 
@@ -8489,133 +8702,152 @@ msgstr "fișierul '%s', linia %d: valoarea cheii imuabile '%s' ignorată."
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "fișierul '%s': caracterul %c neașteptat la linia %d."
 
-#: ../src/richtext/richtextbuffer.cpp:8738
+#: ../src/richtext/richtextbuffer.cpp:8736
 msgid "files"
 msgstr "fișiere"
 
-#: ../src/common/datetimefmt.cpp:1952
+#: ../src/common/datetimefmt.cpp:1975
 msgid "first"
 msgstr "prima"
 
-#: ../src/html/helpwnd.cpp:1252
+#: ../src/html/helpwnd.cpp:1250
 msgid "font size"
 msgstr "dimensiune font"
 
-#: ../src/common/datetimefmt.cpp:1965
+#: ../src/common/datetimefmt.cpp:1988
 msgid "fourteenth"
 msgstr "al(a) paisprezecelea(paisprezecea)"
 
-#: ../src/common/datetimefmt.cpp:1955
+#: ../src/common/datetimefmt.cpp:1978
 msgid "fourth"
 msgstr "al(a) patrulea(patra)"
 
-#: ../src/common/appbase.cpp:783
+#: ../src/common/appbase.cpp:784
 msgid "generate verbose log messages"
 msgstr "generează mesaje detaliate pentru jurnal"
 
-#: ../src/richtext/richtextbuffer.cpp:13138
-#: ../src/richtext/richtextbuffer.cpp:13248
+#: ../src/common/fontcmn.cpp:1215
+msgid "heavy"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:13133
+#: ../src/richtext/richtextbuffer.cpp:13243
 msgid "image"
 msgstr "imagine"
 
-#: ../src/common/tarstrm.cpp:796
+#: ../src/common/tarstrm.cpp:790
 msgid "incomplete header block in tar"
 msgstr "bloc de antet incomplet în tar"
 
-#: ../src/common/xtixml.cpp:489
+#: ../src/common/xtixml.cpp:485
 msgid "incorrect event handler string, missing dot"
 msgstr ""
 "șir de caractere incorect pentru un manipulator de evenimente, lipsește un "
 "punct"
 
-#: ../src/common/tarstrm.cpp:1381
+#: ../src/common/tarstrm.cpp:1375
 msgid "incorrect size given for tar entry"
 msgstr "dimensiune incorectă dată pentru intrarea tar"
 
-#: ../src/common/tarstrm.cpp:993
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:987
 msgid "invalid data in extended tar header"
 msgstr "date incorecte în antetul extins tar"
 
-#: ../src/generic/logg.cpp:1030
+#: ../src/generic/logg.cpp:1027
 msgid "invalid message box return value"
 msgstr "valoare invalidă returnată de caseta de mesaje"
 
-#: ../src/common/zipstrm.cpp:1647
+#: ../src/common/zipstrm.cpp:1688
 msgid "invalid zip file"
 msgstr "fișier zip invalid"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:1228
 msgid "italic"
 msgstr "cursiv"
 
-#: ../src/common/fontcmn.cpp:991
+#: ../src/common/webrequest_curl.cpp:374
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "Descrierea coloanei nu a putut fi inițializată."
+
+#: ../src/common/fontcmn.cpp:1172
 msgid "light"
 msgstr "subțire"
 
-#: ../src/common/intl.cpp:303
-#, c-format
-msgid "locale '%s' cannot be set."
-msgstr "locala '%s' nu poate fi setată."
+#: ../src/common/fontcmn.cpp:1185
+msgid "medium"
+msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2125
+#: ../src/common/datetimefmt.cpp:2148
 msgid "midnight"
 msgstr "miezul nopții"
 
-#: ../src/common/datetimefmt.cpp:1970
+#: ../src/common/datetimefmt.cpp:1993
 msgid "nineteenth"
 msgstr "al(a) nouăsprezecelea(nouăsprezecea)"
 
-#: ../src/common/datetimefmt.cpp:1960
+#: ../src/common/datetimefmt.cpp:1983
 msgid "ninth"
 msgstr "al(a) nouălea(noua)"
 
-#: ../src/msw/dde.cpp:1116
+#: ../src/msw/dde.cpp:1180
 msgid "no DDE error."
 msgstr "nicio eroare DDE"
 
-#: ../src/html/chm.cpp:327
+#: ../src/html/chm.cpp:324
 msgid "no error"
 msgstr "nicio eroare"
 
-#: ../src/dfb/fontmgr.cpp:174
+#: ../src/dfb/fontmgr.cpp:171
 #, c-format
 msgid "no fonts found in %s, using builtin font"
 msgstr "niciun font găsit în %s, se va folosi fontul încorporat"
 
-#: ../src/html/helpdata.cpp:657
+#: ../src/html/helpdata.cpp:650
 msgid "noname"
 msgstr "nedenumit"
 
-#: ../src/common/datetimefmt.cpp:2124
+#: ../src/common/datetimefmt.cpp:2147
 msgid "noon"
 msgstr "amiază"
 
-#: ../src/richtext/richtextstyles.cpp:779
+#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "normal"
 
-#: ../src/common/cmdline.cpp:1492
+#: ../src/common/cmdline.cpp:1488
 msgid "num"
 msgstr "numeric"
 
-#: ../src/common/xtixml.cpp:259
+#: ../src/common/accelcmn.cpp:194
+msgid "num "
+msgstr ""
+
+#: ../src/common/xtixml.cpp:255
 msgid "objects cannot have XML Text Nodes"
 msgstr "obiectele nu pot avea noduri de text XML"
 
-#: ../src/html/chm.cpp:339
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
 msgid "out of memory"
 msgstr "memorie epuizată"
 
-#: ../src/common/debugrpt.cpp:514
+#: ../src/common/debugrpt.cpp:515
 msgid "process context description"
 msgstr "descriere pentru contextul procesului"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:227
-#: ../src/richtext/richtextbackgroundpage.cpp:250
-#: ../src/richtext/richtextbackgroundpage.cpp:290
-#: ../src/richtext/richtextbackgroundpage.cpp:317
-#: ../src/richtext/richtextfontpage.cpp:177
-#: ../src/richtext/richtextfontpage.cpp:180
 #: ../src/richtext/richtextborderspage.cpp:255
 #: ../src/richtext/richtextborderspage.cpp:289
 #: ../src/richtext/richtextborderspage.cpp:323
@@ -8625,22 +8857,45 @@ msgstr "descriere pentru contextul procesului"
 #: ../src/richtext/richtextborderspage.cpp:491
 #: ../src/richtext/richtextborderspage.cpp:525
 #: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextfontpage.cpp:180
 msgid "pt"
 msgstr "pt"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:225
-#: ../src/richtext/richtextbackgroundpage.cpp:228
-#: ../src/richtext/richtextbackgroundpage.cpp:229
-#: ../src/richtext/richtextbackgroundpage.cpp:248
-#: ../src/richtext/richtextbackgroundpage.cpp:251
-#: ../src/richtext/richtextbackgroundpage.cpp:252
-#: ../src/richtext/richtextbackgroundpage.cpp:288
-#: ../src/richtext/richtextbackgroundpage.cpp:291
-#: ../src/richtext/richtextbackgroundpage.cpp:292
-#: ../src/richtext/richtextbackgroundpage.cpp:315
-#: ../src/richtext/richtextbackgroundpage.cpp:318
-#: ../src/richtext/richtextbackgroundpage.cpp:319
-#: ../src/richtext/richtextfontpage.cpp:178
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:659
+#: ../src/richtext/richtextsizepage.cpp:662
+#: ../src/richtext/richtextsizepage.cpp:663
 #: ../src/richtext/richtextborderspage.cpp:253
 #: ../src/richtext/richtextborderspage.cpp:256
 #: ../src/richtext/richtextborderspage.cpp:257
@@ -8692,260 +8947,270 @@ msgstr "pt"
 #: ../src/richtext/richtextmarginspage.cpp:387
 #: ../src/richtext/richtextmarginspage.cpp:389
 #: ../src/richtext/richtextmarginspage.cpp:390
-#: ../src/richtext/richtextsizepage.cpp:338
-#: ../src/richtext/richtextsizepage.cpp:341
-#: ../src/richtext/richtextsizepage.cpp:342
-#: ../src/richtext/richtextsizepage.cpp:372
-#: ../src/richtext/richtextsizepage.cpp:375
-#: ../src/richtext/richtextsizepage.cpp:376
-#: ../src/richtext/richtextsizepage.cpp:399
-#: ../src/richtext/richtextsizepage.cpp:402
-#: ../src/richtext/richtextsizepage.cpp:403
-#: ../src/richtext/richtextsizepage.cpp:426
-#: ../src/richtext/richtextsizepage.cpp:429
-#: ../src/richtext/richtextsizepage.cpp:430
-#: ../src/richtext/richtextsizepage.cpp:453
-#: ../src/richtext/richtextsizepage.cpp:456
-#: ../src/richtext/richtextsizepage.cpp:457
-#: ../src/richtext/richtextsizepage.cpp:480
-#: ../src/richtext/richtextsizepage.cpp:483
-#: ../src/richtext/richtextsizepage.cpp:484
-#: ../src/richtext/richtextsizepage.cpp:554
-#: ../src/richtext/richtextsizepage.cpp:557
-#: ../src/richtext/richtextsizepage.cpp:558
-#: ../src/richtext/richtextsizepage.cpp:589
-#: ../src/richtext/richtextsizepage.cpp:592
-#: ../src/richtext/richtextsizepage.cpp:593
-#: ../src/richtext/richtextsizepage.cpp:624
-#: ../src/richtext/richtextsizepage.cpp:627
-#: ../src/richtext/richtextsizepage.cpp:628
-#: ../src/richtext/richtextsizepage.cpp:659
-#: ../src/richtext/richtextsizepage.cpp:662
-#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextfontpage.cpp:178
 msgid "px"
 msgstr "px"
 
-#: ../src/common/accelcmn.cpp:193
+#: ../src/common/accelcmn.cpp:192
 msgid "rawctrl"
 msgstr "rawctrl"
 
-#: ../src/html/chm.cpp:333
+#: ../src/html/chm.cpp:330
 msgid "read error"
 msgstr "eroare la citire"
 
-#: ../src/common/zipstrm.cpp:2085
+#: ../src/common/zipstrm.cpp:2155
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "citire flux zip (intrarea %s): crc eronat"
 
-#: ../src/common/zipstrm.cpp:2080
+#: ../src/common/zipstrm.cpp:2150
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "citire flux zip (intrarea %s): lungime eronată"
 
-#: ../src/msw/dde.cpp:1159
+#: ../src/msw/dde.cpp:1223
 msgid "reentrancy problem."
 msgstr "problema de reentranță."
 
-#: ../src/common/datetimefmt.cpp:1953
+#: ../src/common/datetimefmt.cpp:1976
 msgid "second"
 msgstr "secundă"
 
-#: ../src/html/chm.cpp:337
+#: ../src/html/chm.cpp:334
 msgid "seek error"
 msgstr "eroare la căutare"
 
-#: ../src/common/datetimefmt.cpp:1968
+#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#, fuzzy
+msgid "semibold"
+msgstr "îngroșat"
+
+#: ../src/common/datetimefmt.cpp:1991
 msgid "seventeenth"
 msgstr "al(a) șaptesprezecelea(șaptesprezecea)"
 
-#: ../src/common/datetimefmt.cpp:1958
+#: ../src/common/datetimefmt.cpp:1981
 msgid "seventh"
 msgstr "al(a) șaptelea(șaptea)"
 
-#: ../src/common/accelcmn.cpp:191
+#: ../src/common/accelcmn.cpp:190
 msgid "shift"
 msgstr "shift"
 
-#: ../src/common/appbase.cpp:773
+#: ../src/common/appbase.cpp:774
 msgid "show this help message"
 msgstr "afișeaza acest mesaj de ajutor"
 
-#: ../src/common/datetimefmt.cpp:1967
+#: ../src/common/datetimefmt.cpp:1990
 msgid "sixteenth"
 msgstr "al(a) șaisprezecelea(șaisprezecea)"
 
-#: ../src/common/datetimefmt.cpp:1957
+#: ../src/common/datetimefmt.cpp:1980
 msgid "sixth"
 msgstr "al(a) șaselea(șasea)"
 
-#: ../src/common/appcmn.cpp:234
+#: ../src/common/appcmn.cpp:255
 msgid "specify display mode to use (e.g. 640x480-16)"
 msgstr "specifică modul de afișare (ex. 640x480-16)"
 
-#: ../src/common/appcmn.cpp:220
+#: ../src/common/appcmn.cpp:241
 msgid "specify the theme to use"
 msgstr "specifică tema ce va fi folosită"
 
-#: ../src/richtext/richtextbuffer.cpp:9340
+#: ../src/richtext/richtextbuffer.cpp:9337
 msgid "standard/circle"
 msgstr "standard/cerc"
 
-#: ../src/richtext/richtextbuffer.cpp:9341
+#: ../src/richtext/richtextbuffer.cpp:9338
 msgid "standard/circle-outline"
 msgstr "standard/contur-cerc"
 
-#: ../src/richtext/richtextbuffer.cpp:9343
+#: ../src/richtext/richtextbuffer.cpp:9340
 msgid "standard/diamond"
 msgstr "standard/romb"
 
-#: ../src/richtext/richtextbuffer.cpp:9342
+#: ../src/richtext/richtextbuffer.cpp:9339
 msgid "standard/square"
 msgstr "standard/pătrat"
 
-#: ../src/richtext/richtextbuffer.cpp:9344
+#: ../src/richtext/richtextbuffer.cpp:9341
 msgid "standard/triangle"
 msgstr "standard/triunghi"
 
-#: ../src/common/zipstrm.cpp:1985
+#: ../src/common/zipstrm.cpp:2055
 msgid "stored file length not in Zip header"
 msgstr "lungimea fișierului conținut nu este in antetul Zip"
 
-#: ../src/common/cmdline.cpp:1488
+#: ../src/common/cmdline.cpp:1484
 msgid "str"
 msgstr "str"
 
-#: ../src/common/fontcmn.cpp:982
+#: ../src/common/fontcmn.cpp:1145
 msgid "strikethrough"
 msgstr "tăiat"
 
-#: ../src/common/tarstrm.cpp:1003 ../src/common/tarstrm.cpp:1025
-#: ../src/common/tarstrm.cpp:1507 ../src/common/tarstrm.cpp:1529
+#: ../src/common/tarstrm.cpp:997 ../src/common/tarstrm.cpp:1019
+#: ../src/common/tarstrm.cpp:1501 ../src/common/tarstrm.cpp:1523
 msgid "tar entry not open"
 msgstr "intrarea tar nu a fost deschisă"
 
-#: ../src/common/datetimefmt.cpp:1961
+#: ../src/common/datetimefmt.cpp:1984
 msgid "tenth"
 msgstr "al(a) zecelea(zecea)"
 
-#: ../src/msw/dde.cpp:1123
+#: ../src/msw/dde.cpp:1187
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "răspunsul la tranzacție a determinat setarea bitului DDE_FBUSY."
 
-#: ../src/common/datetimefmt.cpp:1954
+#: ../src/common/fontcmn.cpp:1154
+msgid "thin"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:1977
 msgid "third"
 msgstr "al(a) treilea(treia)"
 
-#: ../src/common/datetimefmt.cpp:1964
+#: ../src/common/datetimefmt.cpp:1987
 msgid "thirteenth"
 msgstr "al(a) treisprezecelea(treisprezecea)"
 
-#: ../src/common/datetimefmt.cpp:1758
+#: ../src/common/datetimefmt.cpp:1781
 msgid "today"
 msgstr "astăzi"
 
-#: ../src/common/datetimefmt.cpp:1760
+#: ../src/common/datetimefmt.cpp:1783
 msgid "tomorrow"
 msgstr "mâine"
 
-#: ../src/common/fileconf.cpp:1944
+#: ../src/common/fileconf.cpp:1946
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "caracter \\ terminal ignorat în '%s'"
 
-#: ../src/gtk/aboutdlg.cpp:218
+#: ../src/gtk/aboutdlg.cpp:216
 msgid "translator-credits"
 msgstr "merite de traducere"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1028
+#: ../src/generic/datavgen.cpp:1148
 msgid "true"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1963
+#: ../src/common/datetimefmt.cpp:1986
 msgid "twelfth"
 msgstr "al(a) doisprezecelea(doisprezecea)"
 
-#: ../src/common/datetimefmt.cpp:1971
+#: ../src/common/datetimefmt.cpp:1994
 msgid "twentieth"
 msgstr "al(a) douăzecelea(douăzecea)"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:486 ../src/generic/datavgen.cpp:1263
+#: ../src/common/datavcmn.cpp:2068 ../src/generic/datavgen.cpp:1386
 msgid "unchecked"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:802 ../src/common/fontcmn.cpp:978
+#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
 msgid "underlined"
 msgstr "subliniat"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:490
+#: ../src/common/datavcmn.cpp:2072
 #, fuzzy
 msgid "undetermined"
 msgstr "subliniat"
 
-#: ../src/common/fileconf.cpp:1979
+#: ../src/common/fileconf.cpp:1981
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "caracter \" neașteptat la poziția %d în '%s'."
 
-#: ../src/common/tarstrm.cpp:1045
+#: ../src/common/tarstrm.cpp:1039
 msgid "unexpected end of file"
 msgstr "sfârșit de fișier neașteptat"
 
-#: ../src/generic/progdlgg.cpp:370 ../src/common/tarstrm.cpp:371
-#: ../src/common/tarstrm.cpp:394 ../src/common/tarstrm.cpp:425
+#: ../src/common/tarstrm.cpp:366 ../src/common/tarstrm.cpp:389
+#: ../src/common/tarstrm.cpp:420 ../src/generic/progdlgg.cpp:376
 msgid "unknown"
 msgstr "necunoscut"
 
-#: ../src/msw/registry.cpp:150
+#: ../src/msw/registry.cpp:139
 #, fuzzy, c-format
 msgid "unknown (%lu)"
 msgstr "necunoscut"
 
-#: ../src/common/xtixml.cpp:253
+#: ../src/common/xtixml.cpp:249
 #, c-format
 msgid "unknown class %s"
 msgstr "clasă necunoscută %s"
 
-#: ../src/common/regex.cpp:258 ../src/html/chm.cpp:351
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "eroare la comprimare"
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "eroare la decomprimare"
+
+#: ../src/common/regex.cpp:255 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "eroare necunoscută"
 
-#: ../src/msw/dialup.cpp:471
+#: ../src/msw/dialup.cpp:465
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "eroare necunoscută (cod de eroare %08x)."
 
-#: ../src/common/fmapbase.cpp:834
+#: ../src/common/fmapbase.cpp:830
 #, c-format
 msgid "unknown-%d"
 msgstr "necunoscut-%d"
 
-#: ../src/common/docview.cpp:509
+#: ../src/common/docview.cpp:502
 msgid "unnamed"
 msgstr "nedenumit"
 
-#: ../src/common/docview.cpp:1624
+#: ../src/common/docview.cpp:1618
 #, c-format
 msgid "unnamed%d"
 msgstr "nedenumit%d"
 
-#: ../src/common/zipstrm.cpp:1999 ../src/common/zipstrm.cpp:2319
+#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
 msgid "unsupported Zip compression method"
 msgstr "metodă de comprimare Zip nesuportată"
 
-#: ../src/common/translation.cpp:1892
+#: ../src/common/translation.cpp:1942
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "folosește catalogul '%s' din '%s'."
 
-#: ../src/html/chm.cpp:335
+#: ../src/html/chm.cpp:332
 msgid "write error"
 msgstr "eroare la scriere"
 
-#: ../src/common/time.cpp:292
+#: ../src/gtk/glcanvas.cpp:187
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/common/time.cpp:285
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay a eșuat."
 
@@ -8958,15 +9223,15 @@ msgstr "wxWidgets nu a putut deschide ecranul pentru '%s': se închide."
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets nu a putut deschide ecranul. Se închide."
 
-#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:431
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/common/datetimefmt.cpp:1759
+#: ../src/common/datetimefmt.cpp:1782
 msgid "yesterday"
 msgstr "ieri"
 
-#: ../src/common/zstream.cpp:251 ../src/common/zstream.cpp:426
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
 #, c-format
 msgid "zlib error %d"
 msgstr "eroare zlib %d"
@@ -8975,6 +9240,81 @@ msgstr "eroare zlib %d"
 #: ../src/richtext/richtextbulletspage.cpp:288
 msgid "~"
 msgstr "~"
+
+#~ msgid "&Save as"
+#~ msgstr "&Salvează ca"
+
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' nu conține numai caractere valide"
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' ar trebui să fie număr."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' ar trebui să conțină doar caractere ASCII."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' ar trebui să conțină doar caractere alfabetice."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' ar trebui să conțină doar caractere alfabetice sau numerice."
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' ar trebui să conțină doar cifre."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "Nu se poate crea fereastra de clasa %s"
+
+#, fuzzy
+#~ msgid "Could not initalize libnotify."
+#~ msgstr "Nu a putut fi setată alinierea."
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "Nu a putut fi creată fereastra de acoperire (overlay)"
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr ""
+#~ "Nu a putut fi inițializat contextul ferestrei de acoperire (overlay)"
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "A eșuat conversia fișierului \"%s\" la Unicode."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "A eșuat setarea textului în controlul de text."
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr ""
+#~ "Opțiune invalidă pentru linia de comandă GTK+, folosește \"%s --help\""
+
+#~ msgid "No unused colour in image."
+#~ msgstr "Nu există culoare nefolosită în imagine."
+
+#~ msgid "Not available"
+#~ msgstr "Indisponibil"
+
+#~ msgid "Replace selection"
+#~ msgstr "Înlocuiește selecția"
+
+#~ msgid "Save as"
+#~ msgstr "Salvează ca"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Organizator de stiluri"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "Următoarele opțiuni GTK+ standard sunt de asemenea suportate:\n"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr ""
+#~ "Nu se poate curăța o suprafață de acoperire (overlay) care nu a fost "
+#~ "inițializată"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr ""
+#~ "O suprafață de acoperire (overlay) nu se poate inițializa de două ori"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "locala '%s' nu poate fi setată."
 
 #~ msgid "Adding flavor TEXT failed"
 #~ msgstr "Adăugarea de TEXT a eșuat"
@@ -8994,9 +9334,6 @@ msgstr "~"
 
 #~ msgid "Column could not be added."
 #~ msgstr "Coloana nu a putut fi adăugată."
-
-#~ msgid "Column description could not be initialized."
-#~ msgstr "Descrierea coloanei nu a putut fi inițializată."
 
 #~ msgid "Column index not found."
 #~ msgstr "Indexul coloanei nu a fost găsit."
@@ -9588,9 +9925,6 @@ msgstr "~"
 
 #~ msgid "Directory '%s' doesn't exist!"
 #~ msgstr "Directorul '%s' nu există!"
-
-#~ msgid "File %s does not exist."
-#~ msgstr "Fișierul %s nu există."
 
 #~ msgid "Mode %ix%i-%i not available."
 #~ msgstr "Modul %ix%i-%i nu este disponibil."

--- a/locale/ru.po
+++ b/locale/ru.po
@@ -7,19 +7,19 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-21 14:25+0200\n"
+"POT-Creation-Date: 2020-10-18 23:11+0300\n"
 "PO-Revision-Date: 2018-09-06 07:55+0500\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
 "Last-Translator: Alexander Kovalenko <nktch@yandex.ru>\n"
 "Language-Team: wxWidgets translators <wx-translators@wxwidgets.org>\n"
 "Language: ru_RU\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && "
-"(n%100<12 || n%100>14) ? 1 : 2);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
 "X-Generator: Poedit 2.1.1\n"
 
-#: ../src/common/debugrpt.cpp:586
+#: ../src/common/debugrpt.cpp:587
 msgid ""
 "\n"
 "Please send this report to the program maintainer, thank you!\n"
@@ -27,7 +27,8 @@ msgstr ""
 "\n"
 "Отправьте этот отчёт сопровождающему программы. Заранее спасибо.\n"
 
-#: ../src/richtext/richtextstyledlg.cpp:210 ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:206
+#: ../src/richtext/richtextstyledlg.cpp:218
 msgid " "
 msgstr " "
 
@@ -35,89 +36,121 @@ msgstr " "
 msgid "              Thank you and we're sorry for the inconvenience!\n"
 msgstr "              Приносим извинения за доставленные неудобства.\n"
 
-#: ../src/common/prntbase.cpp:573
+#: ../src/common/prntbase.cpp:568
 #, c-format
 msgid " (copy %d of %d)"
 msgstr " (копия %d из %d)"
 
-#: ../src/common/log.cpp:421
+#: ../src/common/log.cpp:440
 #, c-format
 msgid " (error %ld: %s)"
 msgstr " (ошибка %ld: %s)"
 
-#: ../src/common/imagtiff.cpp:72
+#: ../src/common/imagtiff.cpp:69
 #, c-format
 msgid " (in module \"%s\")"
 msgstr " (в модуле \"%s\")"
 
-#: ../src/osx/core/secretstore.cpp:138
-msgid " (while overwriting an existing item)"
-msgstr " (при перезаписи существующего элемента)"
-
-#: ../src/common/docview.cpp:1642
+#: ../src/common/docview.cpp:1636
 msgid " - "
 msgstr " - "
 
-#: ../src/richtext/richtextprint.cpp:593 ../src/html/htmprint.cpp:714
+#: ../src/html/htmprint.cpp:712 ../src/richtext/richtextprint.cpp:589
 msgid " Preview"
 msgstr " Предпросмотр"
 
-#: ../src/common/fontcmn.cpp:824
+#: ../src/common/fontcmn.cpp:973
 msgid " bold"
 msgstr " полужирный"
 
-#: ../src/common/fontcmn.cpp:840
+#: ../src/common/fontcmn.cpp:977
+#, fuzzy
+msgid " extra bold"
+msgstr " полужирный"
+
+#: ../src/common/fontcmn.cpp:985
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:957
+#, fuzzy
+msgid " extra light"
+msgstr " лёгкий"
+
+#: ../src/common/fontcmn.cpp:981
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1001
 msgid " italic"
 msgstr " курсив"
 
-#: ../src/common/fontcmn.cpp:820
+#: ../src/common/fontcmn.cpp:961
 msgid " light"
 msgstr " лёгкий"
 
-#: ../src/common/fontcmn.cpp:807
+#: ../src/common/fontcmn.cpp:965
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:969
+#, fuzzy
+msgid " semi bold"
+msgstr " полужирный"
+
+#: ../src/common/fontcmn.cpp:940
 msgid " strikethrough"
 msgstr " перечёркивание"
 
-#: ../src/common/paper.cpp:117
+#: ../src/common/fontcmn.cpp:953
+msgid " thin"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
 msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
 msgstr "Конверт #10, 4 1/8 x 9 1/2 дюйма"
 
-#: ../src/common/paper.cpp:118
+#: ../src/common/paper.cpp:115
 msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
 msgstr "Конверт #11, 4 1/2 x 10 3/8 дюйма"
 
-#: ../src/common/paper.cpp:119
+#: ../src/common/paper.cpp:116
 msgid "#12 Envelope, 4 3/4 x 11 in"
 msgstr "Конверт #12, 4 3/4 x 11 дюйма"
 
-#: ../src/common/paper.cpp:120
+#: ../src/common/paper.cpp:117
 msgid "#14 Envelope, 5 x 11 1/2 in"
 msgstr "Конверт #14, 5 x 11 1/2 дюйма"
 
-#: ../src/common/paper.cpp:116
+#: ../src/common/paper.cpp:113
 msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
 msgstr "Конверт #9, 3 7/8 x 8 7/8 дюйма"
 
+#: ../src/richtext/richtextsizepage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:374
+#: ../src/richtext/richtextsizepage.cpp:401
+#: ../src/richtext/richtextsizepage.cpp:428
+#: ../src/richtext/richtextsizepage.cpp:455
+#: ../src/richtext/richtextsizepage.cpp:482
+#: ../src/richtext/richtextsizepage.cpp:556
+#: ../src/richtext/richtextsizepage.cpp:591
+#: ../src/richtext/richtextsizepage.cpp:626
+#: ../src/richtext/richtextsizepage.cpp:661
 #: ../src/richtext/richtextbackgroundpage.cpp:341
-#: ../src/richtext/richtextsizepage.cpp:340 ../src/richtext/richtextsizepage.cpp:374
-#: ../src/richtext/richtextsizepage.cpp:401 ../src/richtext/richtextsizepage.cpp:428
-#: ../src/richtext/richtextsizepage.cpp:455 ../src/richtext/richtextsizepage.cpp:482
-#: ../src/richtext/richtextsizepage.cpp:556 ../src/richtext/richtextsizepage.cpp:591
-#: ../src/richtext/richtextsizepage.cpp:626 ../src/richtext/richtextsizepage.cpp:661
 msgid "%"
 msgstr "%"
 
-#: ../src/html/helpwnd.cpp:1031
+#: ../src/html/helpwnd.cpp:1029
 #, c-format
 msgid "%d of %lu"
 msgstr "%d из %lu"
 
-#: ../src/html/helpwnd.cpp:1678
+#: ../src/html/helpwnd.cpp:1676
 #, c-format
 msgid "%i of %u"
 msgstr "%i из %u"
 
-#: ../src/generic/filectrlg.cpp:279
+#: ../src/generic/filectrlg.cpp:275
 #, c-format
 msgid "%ld byte"
 msgid_plural "%ld bytes"
@@ -125,61 +158,61 @@ msgstr[0] "%ld байт"
 msgstr[1] "%ld байта"
 msgstr[2] "%ld байт"
 
-#: ../src/html/helpwnd.cpp:1033
+#: ../src/html/helpwnd.cpp:1031
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu из %lu"
 
-#: ../src/generic/datavgen.cpp:6028
+#: ../src/generic/datavgen.cpp:6833
 #, c-format
 msgid "%s (%d items)"
 msgstr "%s (%d элементов)"
 
-#: ../src/common/cmdline.cpp:1221
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (или %s)"
 
-#: ../src/generic/logg.cpp:224
+#: ../src/generic/logg.cpp:221
 #, c-format
 msgid "%s Error"
 msgstr "Ошибка %s"
 
-#: ../src/generic/logg.cpp:236
+#: ../src/generic/logg.cpp:233
 #, c-format
 msgid "%s Information"
 msgstr "Информация %s"
 
-#: ../src/generic/preferencesg.cpp:113
+#: ../src/generic/preferencesg.cpp:110
 #, c-format
 msgid "%s Preferences"
 msgstr "Настройки %s"
 
-#: ../src/generic/logg.cpp:228
+#: ../src/generic/logg.cpp:225
 #, c-format
 msgid "%s Warning"
 msgstr "Предупреждение %s"
 
-#: ../src/common/tarstrm.cpp:1319
+#: ../src/common/tarstrm.cpp:1313
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s не соответствует заголовок tar для записи '%s'"
 
-#: ../src/common/fldlgcmn.cpp:124
+#: ../src/common/fldlgcmn.cpp:121
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s файлы (%s)|%s"
 
-#: ../src/html/helpwnd.cpp:1716
+#: ../src/html/helpwnd.cpp:1714
 #, c-format
 msgid "%u of %u"
 msgstr "%u из %u"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "&About"
 msgstr "&О программе"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "&Actual Size"
 msgstr "&Исходный размер"
 
@@ -187,28 +220,28 @@ msgstr "&Исходный размер"
 msgid "&After a paragraph:"
 msgstr "&После абзаца:"
 
-#: ../src/richtext/richtextindentspage.cpp:128
 #: ../src/richtext/richtextliststylepage.cpp:319
+#: ../src/richtext/richtextindentspage.cpp:128
 msgid "&Alignment"
 msgstr "&Выравнивание"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "&Apply"
 msgstr "&Применить"
 
-#: ../src/richtext/richtextstyledlg.cpp:251
+#: ../src/richtext/richtextstyledlg.cpp:247
 msgid "&Apply Style"
 msgstr "&Применить стиль"
 
-#: ../src/msw/mdi.cpp:179
+#: ../src/msw/mdi.cpp:174
 msgid "&Arrange Icons"
 msgstr "&Упорядочить значки"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "&Ascending"
 msgstr "По &возрастанию"
 
-#: ../src/common/stockitem.cpp:142
+#: ../src/common/stockitem.cpp:139
 msgid "&Back"
 msgstr "&Назад"
 
@@ -228,23 +261,24 @@ msgstr "Цвет &фона:"
 msgid "&Blur distance:"
 msgstr "Расстояние &размытия:"
 
-#: ../src/common/stockitem.cpp:143
+#: ../src/common/stockitem.cpp:140
 msgid "&Bold"
 msgstr "&Жирный"
 
-#: ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141
 msgid "&Bottom"
 msgstr "В&низу"
 
+#: ../src/richtext/richtextsizepage.cpp:637
+#: ../src/richtext/richtextsizepage.cpp:644
 #: ../src/richtext/richtextborderspage.cpp:345
 #: ../src/richtext/richtextborderspage.cpp:513
 #: ../src/richtext/richtextmarginspage.cpp:259
 #: ../src/richtext/richtextmarginspage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:637 ../src/richtext/richtextsizepage.cpp:644
 msgid "&Bottom:"
 msgstr "В&низу:"
 
-#: ../include/wx/richtext/richtextbuffer.h:3866
+#: ../include/wx/richtext/richtextbuffer.h:3861
 msgid "&Box"
 msgstr "&Поле"
 
@@ -253,38 +287,38 @@ msgstr "&Поле"
 msgid "&Bullet style:"
 msgstr "Стиль &маркера:"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "&CD-Rom"
 msgstr "&CD-Rom"
 
-#: ../src/generic/wizard.cpp:434 ../src/generic/fontdlgg.cpp:470
-#: ../src/generic/fontdlgg.cpp:489 ../src/osx/carbon/fontdlg.cpp:402
-#: ../src/common/dlgcmn.cpp:279 ../src/common/stockitem.cpp:145
+#: ../src/osx/carbon/fontdlg.cpp:399 ../src/common/stockitem.cpp:142
+#: ../src/generic/wizard.cpp:433 ../src/generic/fontdlgg.cpp:466
+#: ../src/generic/fontdlgg.cpp:485 ../src/osx/cocoa/button.mm:200
 msgid "&Cancel"
 msgstr "&Отмена"
 
-#: ../src/msw/mdi.cpp:175
+#: ../src/msw/mdi.cpp:170
 msgid "&Cascade"
 msgstr "&Каскадом"
 
-#: ../include/wx/richtext/richtextbuffer.h:5960
+#: ../include/wx/richtext/richtextbuffer.h:5955
 msgid "&Cell"
 msgstr "&Ячейка"
 
-#: ../src/richtext/richtextsymboldlg.cpp:439
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "&Character code:"
 msgstr "Код &символа:"
 
-#: ../src/common/stockitem.cpp:147
+#: ../src/common/stockitem.cpp:144
 msgid "&Clear"
 msgstr "О&чистить"
 
-#: ../src/generic/logg.cpp:516 ../src/common/stockitem.cpp:148
-#: ../src/common/prntbase.cpp:1600 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/stockitem.cpp:145 ../src/common/prntbase.cpp:1625
+#: ../src/univ/themes/win32.cpp:3753 ../src/generic/logg.cpp:513
 msgid "&Close"
 msgstr "&Закрыть"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "&Color"
 msgstr "&Цвет"
 
@@ -292,20 +326,20 @@ msgstr "&Цвет"
 msgid "&Colour:"
 msgstr "&Цвет:"
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "&Convert"
 msgstr "&Конвертировать"
 
-#: ../src/richtext/richtextctrl.cpp:333 ../src/osx/textctrl_osx.cpp:577
-#: ../src/common/stockitem.cpp:150 ../src/msw/textctrl.cpp:2508
+#: ../src/osx/textctrl_osx.cpp:595 ../src/common/stockitem.cpp:147
+#: ../src/msw/textctrl.cpp:2773 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Копировать"
 
-#: ../src/generic/hyperlinkg.cpp:156
+#: ../src/generic/hyperlinkg.cpp:153
 msgid "&Copy URL"
 msgstr "&Копировать URL"
 
-#: ../src/common/headerctrlcmn.cpp:306
+#: ../src/common/headerctrlcmn.cpp:304
 msgid "&Customize..."
 msgstr "&Настроить..."
 
@@ -313,53 +347,54 @@ msgstr "&Настроить..."
 msgid "&Debug report preview:"
 msgstr "Предпросмотр отчёта &отладки:"
 
-#: ../src/richtext/richtexttabspage.cpp:138 ../src/richtext/richtextctrl.cpp:335
-#: ../src/osx/textctrl_osx.cpp:579 ../src/common/stockitem.cpp:152
-#: ../src/msw/textctrl.cpp:2510
+#: ../src/osx/textctrl_osx.cpp:597 ../src/common/stockitem.cpp:149
+#: ../src/msw/textctrl.cpp:2775 ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtextctrl.cpp:334
 msgid "&Delete"
 msgstr "&Удалить"
 
-#: ../src/richtext/richtextstyledlg.cpp:269
+#: ../src/richtext/richtextstyledlg.cpp:265
 msgid "&Delete Style..."
 msgstr "&Удалить стиль..."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "&Descending"
 msgstr "По &убыванию"
 
-#: ../src/generic/logg.cpp:682
+#: ../src/generic/logg.cpp:679
 msgid "&Details"
 msgstr "&Подробности"
 
-#: ../src/common/stockitem.cpp:153
+#: ../src/common/stockitem.cpp:150
 msgid "&Down"
 msgstr "&Вниз"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "&Edit"
 msgstr "&Правка"
 
-#: ../src/richtext/richtextstyledlg.cpp:263
+#: ../src/richtext/richtextstyledlg.cpp:259
 msgid "&Edit Style..."
 msgstr "&Правка стиля..."
 
-#: ../src/common/stockitem.cpp:155
+#: ../src/common/stockitem.cpp:152
 msgid "&Execute"
 msgstr "&Выполнить"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/common/stockitem.cpp:154
 msgid "&File"
 msgstr "&Файл"
 
-#: ../src/common/stockitem.cpp:158
-msgid "&Find"
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "&Find..."
 msgstr "&Найти"
 
-#: ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:430
 msgid "&Finish"
 msgstr "&Завершить"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:156
 msgid "&First"
 msgstr "&Первый"
 
@@ -367,15 +402,15 @@ msgstr "&Первый"
 msgid "&Floating mode:"
 msgstr "&Плавающий режим:"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "&Floppy"
 msgstr "&Дискета"
 
-#: ../src/common/stockitem.cpp:194
+#: ../src/common/stockitem.cpp:191
 msgid "&Font"
 msgstr "&Шрифт"
 
-#: ../src/generic/fontdlgg.cpp:371
+#: ../src/generic/fontdlgg.cpp:367
 msgid "&Font family:"
 msgstr "&Семейство шрифтов::"
 
@@ -383,29 +418,31 @@ msgstr "&Семейство шрифтов::"
 msgid "&Font for Level..."
 msgstr "&Шрифт для уровня..."
 
-#: ../src/richtext/richtextfontpage.cpp:147 ../src/richtext/richtextsymboldlg.cpp:400
+#: ../src/richtext/richtextsymboldlg.cpp:397
+#: ../src/richtext/richtextfontpage.cpp:147
 msgid "&Font:"
 msgstr "&Шрифт:"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "&Forward"
 msgstr "&Вперёд"
 
-#: ../src/richtext/richtextsymboldlg.cpp:451
+#: ../src/richtext/richtextsymboldlg.cpp:448
 msgid "&From:"
 msgstr "&От:"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "&Harddisk"
 msgstr "&Жёсткий диск"
 
-#: ../src/richtext/richtextsizepage.cpp:351 ../src/richtext/richtextsizepage.cpp:358
+#: ../src/richtext/richtextsizepage.cpp:351
+#: ../src/richtext/richtextsizepage.cpp:358
 msgid "&Height:"
 msgstr "&Высота:"
 
-#: ../src/generic/wizard.cpp:441 ../src/richtext/richtextstyledlg.cpp:303
-#: ../src/richtext/richtextsymboldlg.cpp:479 ../src/osx/menu_osx.cpp:734
-#: ../src/common/stockitem.cpp:163
+#: ../src/common/stockitem.cpp:160 ../src/generic/wizard.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextstyledlg.cpp:299 ../src/osx/cocoa/menu.mm:226
 msgid "&Help"
 msgstr "&Справка"
 
@@ -413,7 +450,7 @@ msgstr "&Справка"
 msgid "&Hide details"
 msgstr "&Скрыть подробности"
 
-#: ../src/common/stockitem.cpp:164
+#: ../src/common/stockitem.cpp:161
 msgid "&Home"
 msgstr "В &начало"
 
@@ -421,53 +458,54 @@ msgstr "В &начало"
 msgid "&Horizontal offset:"
 msgstr "&Горизонтальное смещение:"
 
-#: ../src/richtext/richtextindentspage.cpp:184
 #: ../src/richtext/richtextliststylepage.cpp:372
+#: ../src/richtext/richtextindentspage.cpp:184
 msgid "&Indentation (tenths of a mm)"
 msgstr "&Отступы (десятые доли мм)"
 
-#: ../src/richtext/richtextindentspage.cpp:167
 #: ../src/richtext/richtextliststylepage.cpp:356
+#: ../src/richtext/richtextindentspage.cpp:167
 msgid "&Indeterminate"
 msgstr "&Неопределённый"
 
-#: ../src/common/stockitem.cpp:166
+#: ../src/common/stockitem.cpp:163
 msgid "&Index"
 msgstr "&Индекс"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "&Info"
 msgstr "&Инфо"
 
-#: ../src/common/stockitem.cpp:168
+#: ../src/common/stockitem.cpp:165
 msgid "&Italic"
 msgstr "&Курсив"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "&Jump to"
 msgstr "&Перейти к"
 
-#: ../src/richtext/richtextindentspage.cpp:153
 #: ../src/richtext/richtextliststylepage.cpp:342
+#: ../src/richtext/richtextindentspage.cpp:153
 msgid "&Justified"
 msgstr "&По ширине"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "&Last"
 msgstr "&Последний"
 
-#: ../src/richtext/richtextindentspage.cpp:139
 #: ../src/richtext/richtextliststylepage.cpp:328
+#: ../src/richtext/richtextindentspage.cpp:139
 msgid "&Left"
 msgstr "С&лева"
 
-#: ../src/richtext/richtextindentspage.cpp:195
+#: ../src/richtext/richtextsizepage.cpp:532
+#: ../src/richtext/richtextsizepage.cpp:539
 #: ../src/richtext/richtextborderspage.cpp:243
 #: ../src/richtext/richtextborderspage.cpp:411
 #: ../src/richtext/richtextliststylepage.cpp:381
+#: ../src/richtext/richtextindentspage.cpp:195
 #: ../src/richtext/richtextmarginspage.cpp:186
 #: ../src/richtext/richtextmarginspage.cpp:300
-#: ../src/richtext/richtextsizepage.cpp:532 ../src/richtext/richtextsizepage.cpp:539
 msgid "&Left:"
 msgstr "С&лева:"
 
@@ -475,11 +513,11 @@ msgstr "С&лева:"
 msgid "&List level:"
 msgstr "&Уровень списка:"
 
-#: ../src/generic/logg.cpp:517
+#: ../src/generic/logg.cpp:514
 msgid "&Log"
 msgstr "&Журнал"
 
-#: ../src/univ/themes/win32.cpp:3748
+#: ../src/univ/themes/win32.cpp:3745
 msgid "&Move"
 msgstr "П&ереместить"
 
@@ -487,19 +525,19 @@ msgstr "П&ереместить"
 msgid "&Move the object to:"
 msgstr "&Переместить объект в:"
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "&Network"
 msgstr "&Сеть"
 
-#: ../src/richtext/richtexttabspage.cpp:132 ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173 ../src/richtext/richtexttabspage.cpp:132
 msgid "&New"
 msgstr "&Новый"
 
-#: ../src/aui/tabmdi.cpp:111 ../src/generic/mdig.cpp:100 ../src/msw/mdi.cpp:180
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
 msgid "&Next"
 msgstr "&Следующий"
 
-#: ../src/generic/wizard.cpp:432 ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:429
 msgid "&Next >"
 msgstr "&Далее >"
 
@@ -507,7 +545,7 @@ msgstr "&Далее >"
 msgid "&Next Paragraph"
 msgstr "&Следующий абзац"
 
-#: ../src/generic/tipdlg.cpp:240
+#: ../src/generic/tipdlg.cpp:237
 msgid "&Next Tip"
 msgstr "&Следующий совет"
 
@@ -515,11 +553,11 @@ msgstr "&Следующий совет"
 msgid "&Next style:"
 msgstr "&Cледующий стиль:"
 
-#: ../src/common/stockitem.cpp:177 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:174 ../src/msw/msgdlg.cpp:435
 msgid "&No"
 msgstr "&Нет"
 
-#: ../src/generic/dbgrptg.cpp:356
+#: ../src/generic/dbgrptg.cpp:360
 msgid "&Notes:"
 msgstr "&Заметки:"
 
@@ -527,12 +565,12 @@ msgstr "&Заметки:"
 msgid "&Number:"
 msgstr "&Число:"
 
-#: ../src/generic/fontdlgg.cpp:475 ../src/generic/fontdlgg.cpp:482
-#: ../src/osx/carbon/fontdlg.cpp:408 ../src/common/stockitem.cpp:178
+#: ../src/osx/carbon/fontdlg.cpp:405 ../src/common/stockitem.cpp:175
+#: ../src/generic/fontdlgg.cpp:471 ../src/generic/fontdlgg.cpp:478
 msgid "&OK"
 msgstr "&ОК"
 
-#: ../src/generic/dbgrptg.cpp:342 ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176 ../src/generic/dbgrptg.cpp:342
 msgid "&Open..."
 msgstr "&Открыть..."
 
@@ -544,16 +582,16 @@ msgstr "&Уровень структуры:"
 msgid "&Page Break"
 msgstr "&Разрыв страницы"
 
-#: ../src/richtext/richtextctrl.cpp:334 ../src/osx/textctrl_osx.cpp:578
-#: ../src/common/stockitem.cpp:180 ../src/msw/textctrl.cpp:2509
+#: ../src/osx/textctrl_osx.cpp:596 ../src/common/stockitem.cpp:177
+#: ../src/msw/textctrl.cpp:2774 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "Вст&авить"
 
-#: ../include/wx/richtext/richtextbuffer.h:5010
+#: ../include/wx/richtext/richtextbuffer.h:5005
 msgid "&Picture"
 msgstr "&Рисунок"
 
-#: ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:419
 msgid "&Point size:"
 msgstr "&Размер шрифта:"
 
@@ -565,11 +603,11 @@ msgstr "&Позиция (десятые доли мм):"
 msgid "&Position mode:"
 msgstr "Режим &размещения:"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178
 msgid "&Preferences"
 msgstr "&Настройки"
 
-#: ../src/aui/tabmdi.cpp:112 ../src/generic/mdig.cpp:101 ../src/msw/mdi.cpp:181
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
 msgid "&Previous"
 msgstr "&Предыдущий"
 
@@ -577,77 +615,74 @@ msgstr "&Предыдущий"
 msgid "&Previous Paragraph"
 msgstr "&Предыдущий абзац"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "&Print..."
 msgstr "&Печать..."
 
-#: ../src/richtext/richtextctrl.cpp:339 ../src/richtext/richtextctrl.cpp:5514
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtextctrl.cpp:338
+#: ../src/richtext/richtextctrl.cpp:5512
 msgid "&Properties"
 msgstr "&Свойства"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "&Quit"
 msgstr "Вы&ход"
 
-#: ../src/richtext/richtextctrl.cpp:330 ../src/osx/textctrl_osx.cpp:574
-#: ../src/common/stockitem.cpp:185 ../src/common/cmdproc.cpp:293
-#: ../src/common/cmdproc.cpp:300 ../src/msw/textctrl.cpp:2505
+#: ../src/osx/textctrl_osx.cpp:592 ../src/common/stockitem.cpp:182
+#: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
+#: ../src/msw/textctrl.cpp:2770 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Вернуть"
 
-#: ../src/common/cmdproc.cpp:289 ../src/common/cmdproc.cpp:309
+#: ../src/common/cmdproc.cpp:282 ../src/common/cmdproc.cpp:302
 msgid "&Redo "
 msgstr "&Вернуть "
 
-#: ../src/richtext/richtextstyledlg.cpp:257
+#: ../src/richtext/richtextstyledlg.cpp:253
 msgid "&Rename Style..."
 msgstr "&Переименовать стиль..."
 
-#: ../src/generic/fdrepdlg.cpp:179
+#: ../src/generic/fdrepdlg.cpp:176
 msgid "&Replace"
 msgstr "&Заменить"
 
-#: ../src/richtext/richtextstyledlg.cpp:287
+#: ../src/richtext/richtextstyledlg.cpp:283
 msgid "&Restart numbering"
 msgstr "&Перезапустить нумерацию"
 
-#: ../src/univ/themes/win32.cpp:3747
+#: ../src/univ/themes/win32.cpp:3744
 msgid "&Restore"
 msgstr "&Восстановить"
 
-#: ../src/richtext/richtextindentspage.cpp:146
 #: ../src/richtext/richtextliststylepage.cpp:335
+#: ../src/richtext/richtextindentspage.cpp:146
 msgid "&Right"
 msgstr "Сп&рава"
 
-#: ../src/richtext/richtextindentspage.cpp:213
+#: ../src/richtext/richtextsizepage.cpp:602
+#: ../src/richtext/richtextsizepage.cpp:609
 #: ../src/richtext/richtextborderspage.cpp:277
 #: ../src/richtext/richtextborderspage.cpp:445
 #: ../src/richtext/richtextliststylepage.cpp:399
+#: ../src/richtext/richtextindentspage.cpp:213
 #: ../src/richtext/richtextmarginspage.cpp:211
 #: ../src/richtext/richtextmarginspage.cpp:325
-#: ../src/richtext/richtextsizepage.cpp:602 ../src/richtext/richtextsizepage.cpp:609
 msgid "&Right:"
 msgstr "Сп&рава:"
 
-#: ../src/common/stockitem.cpp:190
+#: ../src/common/stockitem.cpp:187
 msgid "&Save"
 msgstr "&Сохранить"
-
-#: ../src/common/stockitem.cpp:191
-msgid "&Save as"
-msgstr "&Сохранить как"
 
 #: ../include/wx/richmsgdlg.h:29
 msgid "&See details"
 msgstr "&Просмотр деталей"
 
-#: ../src/generic/tipdlg.cpp:236
+#: ../src/generic/tipdlg.cpp:233
 msgid "&Show tips at startup"
 msgstr "&Показывать советы при запуске"
 
-#: ../src/univ/themes/win32.cpp:3750
+#: ../src/univ/themes/win32.cpp:3747
 msgid "&Size"
 msgstr "&Размер"
 
@@ -655,36 +690,36 @@ msgstr "&Размер"
 msgid "&Size:"
 msgstr "&Размер:"
 
-#: ../src/generic/progdlgg.cpp:252
+#: ../src/generic/progdlgg.cpp:249
 msgid "&Skip"
 msgstr "&Пропустить"
 
-#: ../src/richtext/richtextindentspage.cpp:242
 #: ../src/richtext/richtextliststylepage.cpp:417
+#: ../src/richtext/richtextindentspage.cpp:242
 msgid "&Spacing (tenths of a mm)"
 msgstr "&Интервал (десятые доли мм)"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "&Spell Check"
 msgstr "&Проверка правописания"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "&Stop"
 msgstr "&Остановить"
 
-#: ../src/richtext/richtextfontpage.cpp:275 ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196 ../src/richtext/richtextfontpage.cpp:275
 msgid "&Strikethrough"
 msgstr "&Зачёркивание"
 
-#: ../src/generic/fontdlgg.cpp:382 ../src/richtext/richtextstylepage.cpp:106
+#: ../src/generic/fontdlgg.cpp:378 ../src/richtext/richtextstylepage.cpp:106
 msgid "&Style:"
 msgstr "&Стиль:"
 
-#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:194
 msgid "&Styles:"
 msgstr "&Стили:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:413
+#: ../src/richtext/richtextsymboldlg.cpp:410
 msgid "&Subset:"
 msgstr "&Подмножество:"
 
@@ -698,23 +733,24 @@ msgstr "&Символ:"
 msgid "&Synchronize values"
 msgstr "&Синхронизация значений"
 
-#: ../include/wx/richtext/richtextbuffer.h:6069
+#: ../include/wx/richtext/richtextbuffer.h:6064
 msgid "&Table"
 msgstr "&Таблица"
 
-#: ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197
 msgid "&Top"
 msgstr "С&верху"
 
+#: ../src/richtext/richtextsizepage.cpp:567
+#: ../src/richtext/richtextsizepage.cpp:574
 #: ../src/richtext/richtextborderspage.cpp:311
 #: ../src/richtext/richtextborderspage.cpp:479
 #: ../src/richtext/richtextmarginspage.cpp:234
 #: ../src/richtext/richtextmarginspage.cpp:348
-#: ../src/richtext/richtextsizepage.cpp:567 ../src/richtext/richtextsizepage.cpp:574
 msgid "&Top:"
 msgstr "С&верху:"
 
-#: ../src/generic/fontdlgg.cpp:444 ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199 ../src/generic/fontdlgg.cpp:441
 msgid "&Underline"
 msgstr "&Подчёркивание"
 
@@ -722,21 +758,21 @@ msgstr "&Подчёркивание"
 msgid "&Underlining:"
 msgstr "&Подчёркивание:"
 
-#: ../src/richtext/richtextctrl.cpp:329 ../src/osx/textctrl_osx.cpp:573
-#: ../src/common/stockitem.cpp:203 ../src/common/cmdproc.cpp:271
-#: ../src/msw/textctrl.cpp:2504
+#: ../src/osx/textctrl_osx.cpp:591 ../src/common/stockitem.cpp:200
+#: ../src/common/cmdproc.cpp:264 ../src/msw/textctrl.cpp:2769
+#: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Отменить"
 
-#: ../src/common/cmdproc.cpp:265
+#: ../src/common/cmdproc.cpp:258
 msgid "&Undo "
 msgstr "&Отменить "
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "&Unindent"
 msgstr "Убрать &отступ"
 
-#: ../src/common/stockitem.cpp:205
+#: ../src/common/stockitem.cpp:202
 msgid "&Up"
 msgstr "&Вверх"
 
@@ -752,95 +788,67 @@ msgstr "&Вертикальное смещение:"
 msgid "&View..."
 msgstr "&Вид..."
 
-#: ../src/generic/fontdlgg.cpp:393
+#: ../src/generic/fontdlgg.cpp:389
 msgid "&Weight:"
 msgstr "&Толщина:"
 
-#: ../src/richtext/richtextsizepage.cpp:317 ../src/richtext/richtextsizepage.cpp:324
+#: ../src/richtext/richtextsizepage.cpp:317
+#: ../src/richtext/richtextsizepage.cpp:324
 msgid "&Width:"
 msgstr "&Ширина:"
 
-#: ../src/aui/tabmdi.cpp:311 ../src/aui/tabmdi.cpp:327 ../src/aui/tabmdi.cpp:329
-#: ../src/generic/mdig.cpp:294 ../src/generic/mdig.cpp:310 ../src/generic/mdig.cpp:314
-#: ../src/msw/mdi.cpp:78
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
 msgid "&Window"
 msgstr "&Окно"
 
-#: ../src/common/stockitem.cpp:206 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:203 ../src/msw/msgdlg.cpp:435
 msgid "&Yes"
 msgstr "&Да"
 
-#: ../src/common/valtext.cpp:256
-#, c-format
-msgid "'%s' contains illegal characters"
+#: ../src/common/valtext.cpp:197
+#, fuzzy, c-format
+msgid "'%s' contains invalid character(s)"
 msgstr "'%s' содержит недопустмые знаки"
 
-#: ../src/common/valtext.cpp:254
-#, c-format
-msgid "'%s' doesn't consist only of valid characters"
-msgstr "'%s' должно содержать только допустимые символы"
-
-#: ../src/common/config.cpp:519 ../src/msw/regconf.cpp:258
+#: ../src/common/config.cpp:515 ../src/msw/regconf.cpp:255
 #, c-format
 msgid "'%s' has extra '..', ignored."
 msgstr "'%s' содержит лишние '..', игнорировано."
 
-#: ../src/common/cmdline.cpp:1113 ../src/common/cmdline.cpp:1131
+#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' - некорректное числовое значение для параметра '%s'."
 
-#: ../src/common/translation.cpp:1100
+#: ../src/common/translation.cpp:1142
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' - неверный каталог сообщений."
 
-#: ../src/common/valtext.cpp:165
+#: ../src/common/valtext.cpp:188
 #, c-format
 msgid "'%s' is not one of the valid strings"
 msgstr "'%s' - недопустимая строка"
 
-#: ../src/common/valtext.cpp:167
+#: ../src/common/valtext.cpp:186
 #, c-format
 msgid "'%s' is one of the invalid strings"
 msgstr "'%s' - недопустимая строка"
 
-#: ../src/common/textbuf.cpp:237
+#: ../src/common/textbuf.cpp:233
 #, c-format
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' возможно является двоичным буфером."
-
-#: ../src/common/valtext.cpp:252
-#, c-format
-msgid "'%s' should be numeric."
-msgstr "'%s' должно быть числом."
-
-#: ../src/common/valtext.cpp:244
-#, c-format
-msgid "'%s' should only contain ASCII characters."
-msgstr "'%s' должно содержать только символы ASCII."
-
-#: ../src/common/valtext.cpp:246
-#, c-format
-msgid "'%s' should only contain alphabetic characters."
-msgstr "'%s' должно содержать только символы алфавита."
-
-#: ../src/common/valtext.cpp:248
-#, c-format
-msgid "'%s' should only contain alphabetic or numeric characters."
-msgstr "'%s' должно содержать только символы алфавита или цифры."
-
-#: ../src/common/valtext.cpp:250
-#, c-format
-msgid "'%s' should only contain digits."
-msgstr "'%s' должно содержать только цифры."
 
 #: ../src/richtext/richtextliststylepage.cpp:229
 #: ../src/richtext/richtextbulletspage.cpp:166
 msgid "(*)"
 msgstr "(*)"
 
-#: ../src/html/helpwnd.cpp:963
+#: ../src/html/helpwnd.cpp:961
 msgid "(Help)"
 msgstr "(Справка)"
 
@@ -849,25 +857,32 @@ msgstr "(Справка)"
 msgid "(None)"
 msgstr "(Ничего)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:504
+#: ../src/richtext/richtextsymboldlg.cpp:503
 msgid "(Normal text)"
 msgstr "(Обычный текст)"
 
-#: ../src/html/helpwnd.cpp:419 ../src/html/helpwnd.cpp:1106
-#: ../src/html/helpwnd.cpp:1742
+#: ../src/html/helpwnd.cpp:417 ../src/html/helpwnd.cpp:1104
+#: ../src/html/helpwnd.cpp:1740
 msgid "(bookmarks)"
 msgstr "(закладки)"
 
+#: ../src/msw/dlmsw.cpp:167
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (ошибка %ld: %s)"
+
+#: ../src/richtext/richtextformatdlg.cpp:876
+#: ../src/richtext/richtextliststylepage.cpp:448
+#: ../src/richtext/richtextliststylepage.cpp:460
+#: ../src/richtext/richtextliststylepage.cpp:461
 #: ../src/richtext/richtextindentspage.cpp:274
 #: ../src/richtext/richtextindentspage.cpp:286
 #: ../src/richtext/richtextindentspage.cpp:287
 #: ../src/richtext/richtextindentspage.cpp:311
 #: ../src/richtext/richtextindentspage.cpp:326
-#: ../src/richtext/richtextformatdlg.cpp:884 ../src/richtext/richtextfontpage.cpp:349
-#: ../src/richtext/richtextfontpage.cpp:353 ../src/richtext/richtextfontpage.cpp:357
-#: ../src/richtext/richtextliststylepage.cpp:448
-#: ../src/richtext/richtextliststylepage.cpp:460
-#: ../src/richtext/richtextliststylepage.cpp:461
+#: ../src/richtext/richtextfontpage.cpp:349
+#: ../src/richtext/richtextfontpage.cpp:353
+#: ../src/richtext/richtextfontpage.cpp:357
 msgid "(none)"
 msgstr "(ничего)"
 
@@ -886,7 +901,7 @@ msgstr "*)"
 msgid "+"
 msgstr "+"
 
-#: ../src/msw/utils.cpp:1152
+#: ../src/msw/utils.cpp:1143
 msgid ", 64-bit edition"
 msgstr ", 64-бит редакция"
 
@@ -895,163 +910,163 @@ msgstr ", 64-бит редакция"
 msgid "-"
 msgstr "-"
 
-#: ../src/generic/filepickerg.cpp:66
+#: ../src/generic/filepickerg.cpp:63
 msgid "..."
 msgstr "..."
 
-#: ../src/richtext/richtextindentspage.cpp:276
 #: ../src/richtext/richtextliststylepage.cpp:450
+#: ../src/richtext/richtextindentspage.cpp:276
 msgid "1.1"
 msgstr "1.1"
 
-#: ../src/richtext/richtextindentspage.cpp:277
 #: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextindentspage.cpp:277
 msgid "1.2"
 msgstr "1.2"
 
-#: ../src/richtext/richtextindentspage.cpp:278
 #: ../src/richtext/richtextliststylepage.cpp:452
+#: ../src/richtext/richtextindentspage.cpp:278
 msgid "1.3"
 msgstr "1.3"
 
-#: ../src/richtext/richtextindentspage.cpp:279
 #: ../src/richtext/richtextliststylepage.cpp:453
+#: ../src/richtext/richtextindentspage.cpp:279
 msgid "1.4"
 msgstr "1.4"
 
-#: ../src/richtext/richtextindentspage.cpp:280
 #: ../src/richtext/richtextliststylepage.cpp:454
+#: ../src/richtext/richtextindentspage.cpp:280
 msgid "1.5"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:281
 #: ../src/richtext/richtextliststylepage.cpp:455
+#: ../src/richtext/richtextindentspage.cpp:281
 msgid "1.6"
 msgstr "1.6"
 
-#: ../src/richtext/richtextindentspage.cpp:282
 #: ../src/richtext/richtextliststylepage.cpp:456
+#: ../src/richtext/richtextindentspage.cpp:282
 msgid "1.7"
 msgstr "1.7"
 
-#: ../src/richtext/richtextindentspage.cpp:283
 #: ../src/richtext/richtextliststylepage.cpp:457
+#: ../src/richtext/richtextindentspage.cpp:283
 msgid "1.8"
 msgstr "1.8"
 
-#: ../src/richtext/richtextindentspage.cpp:284
 #: ../src/richtext/richtextliststylepage.cpp:458
+#: ../src/richtext/richtextindentspage.cpp:284
 msgid "1.9"
 msgstr "1.9"
 
-#: ../src/common/paper.cpp:140
+#: ../src/common/paper.cpp:137
 msgid "10 x 11 in"
 msgstr "10 x 11 дюймов"
 
-#: ../src/common/paper.cpp:113
+#: ../src/common/paper.cpp:110
 msgid "10 x 14 in"
 msgstr "10 x 14 дюйма"
 
-#: ../src/common/paper.cpp:114
+#: ../src/common/paper.cpp:111
 msgid "11 x 17 in"
 msgstr "11 x 17 дюйма"
 
-#: ../src/common/paper.cpp:184
+#: ../src/common/paper.cpp:181
 msgid "12 x 11 in"
 msgstr "12 x 11 дюймов"
 
-#: ../src/common/paper.cpp:141
+#: ../src/common/paper.cpp:138
 msgid "15 x 11 in"
 msgstr "15 x 11 дюймов"
 
-#: ../src/richtext/richtextindentspage.cpp:285
 #: ../src/richtext/richtextliststylepage.cpp:459
+#: ../src/richtext/richtextindentspage.cpp:285
 msgid "2"
 msgstr "2"
 
-#: ../src/common/paper.cpp:132
+#: ../src/common/paper.cpp:129
 msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
 msgstr "Конверт 6 3/4, 3 5/8 x 6 1/2 дюйма"
 
-#: ../src/common/paper.cpp:139
+#: ../src/common/paper.cpp:136
 msgid "9 x 11 in"
 msgstr "9 x 11 дюймов"
 
-#: ../src/html/htmprint.cpp:431
+#: ../src/html/htmprint.cpp:443
 msgid ": file does not exist!"
 msgstr ": файл не существует!"
 
-#: ../src/common/fontmap.cpp:199
+#: ../src/common/fontmap.cpp:196
 msgid ": unknown charset"
 msgstr ": неизвестный набор символов"
 
-#: ../src/common/fontmap.cpp:413
+#: ../src/common/fontmap.cpp:410
 msgid ": unknown encoding"
 msgstr ": неизвестная кодировка"
 
-#: ../src/generic/wizard.cpp:443
+#: ../src/generic/wizard.cpp:438
 msgid "< &Back"
 msgstr "< &Назад"
 
-#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:628
-#: ../src/osx/carbon/fontdlg.cpp:648
+#: ../src/osx/carbon/fontdlg.cpp:419 ../src/osx/carbon/fontdlg.cpp:625
+#: ../src/osx/carbon/fontdlg.cpp:645
 msgid "<Any Decorative>"
 msgstr "<Любой декоративный>"
 
-#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:630
-#: ../src/osx/carbon/fontdlg.cpp:650
+#: ../src/osx/carbon/fontdlg.cpp:420 ../src/osx/carbon/fontdlg.cpp:627
+#: ../src/osx/carbon/fontdlg.cpp:647
 msgid "<Any Modern>"
 msgstr "<Любой современный>"
 
-#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:626
-#: ../src/osx/carbon/fontdlg.cpp:646
+#: ../src/osx/carbon/fontdlg.cpp:418 ../src/osx/carbon/fontdlg.cpp:623
+#: ../src/osx/carbon/fontdlg.cpp:643
 msgid "<Any Roman>"
 msgstr "<Любой Римский>"
 
-#: ../src/osx/carbon/fontdlg.cpp:424 ../src/osx/carbon/fontdlg.cpp:632
-#: ../src/osx/carbon/fontdlg.cpp:652
+#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:629
+#: ../src/osx/carbon/fontdlg.cpp:649
 msgid "<Any Script>"
 msgstr "<Любой скрипт>"
 
-#: ../src/osx/carbon/fontdlg.cpp:425 ../src/osx/carbon/fontdlg.cpp:637
-#: ../src/osx/carbon/fontdlg.cpp:656
+#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:634
+#: ../src/osx/carbon/fontdlg.cpp:653
 msgid "<Any Swiss>"
 msgstr "<Любой Швейцарский>"
 
-#: ../src/osx/carbon/fontdlg.cpp:426 ../src/osx/carbon/fontdlg.cpp:634
-#: ../src/osx/carbon/fontdlg.cpp:654
+#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:631
+#: ../src/osx/carbon/fontdlg.cpp:651
 msgid "<Any Teletype>"
 msgstr "<Любой телетайп>"
 
-#: ../src/osx/carbon/fontdlg.cpp:420
+#: ../src/osx/carbon/fontdlg.cpp:417
 msgid "<Any>"
 msgstr "<Всем>"
 
-#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
 msgid "<DIR>"
 msgstr "<КАТАЛОГ>"
 
-#: ../src/generic/filectrlg.cpp:254 ../src/generic/filectrlg.cpp:277
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
 msgid "<DRIVE>"
 msgstr "<ДИСК>"
 
-#: ../src/generic/filectrlg.cpp:252 ../src/generic/filectrlg.cpp:275
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
 msgid "<LINK>"
 msgstr "<ССЫЛКА>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1264
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Жирный курсив.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1270
+#: ../src/html/helpwnd.cpp:1268
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>жирный курсив <u>подчёркнутый</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1265
+#: ../src/html/helpwnd.cpp:1263
 msgid "<b>Bold face.</b> "
 msgstr "<b>Жирный.</b> "
 
-#: ../src/html/helpwnd.cpp:1264
+#: ../src/html/helpwnd.cpp:1262
 msgid "<i>Italic face.</i> "
 msgstr "<i>Курсив.</i> "
 
@@ -1060,15 +1075,15 @@ msgstr "<i>Курсив.</i> "
 msgid ">"
 msgstr ">"
 
-#: ../src/generic/dbgrptg.cpp:318
+#: ../src/generic/dbgrptg.cpp:317
 msgid "A debug report has been generated in the directory\n"
 msgstr "Отчёт об отладке был создан в папке\n"
 
-#: ../src/common/debugrpt.cpp:573
+#: ../src/common/debugrpt.cpp:574
 msgid "A debug report has been generated. It can be found in"
 msgstr "Отладочный отчёт был сформирован. Его можно найти в"
 
-#: ../src/common/xtixml.cpp:418
+#: ../src/common/xtixml.cpp:414
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Непустая коллекция должна состоять из узлов 'element'"
 
@@ -1079,106 +1094,106 @@ msgstr "Непустая коллекция должна состоять из �
 msgid "A standard bullet name."
 msgstr "Стандартное название маркера."
 
-#: ../src/common/paper.cpp:217
+#: ../src/common/paper.cpp:214
 msgid "A0 sheet, 841 x 1189 mm"
 msgstr "A0 лист, 841 х 1189 мм"
 
-#: ../src/common/paper.cpp:218
+#: ../src/common/paper.cpp:215
 msgid "A1 sheet, 594 x 841 mm"
 msgstr "А1 лист, 594 х 841 мм"
 
-#: ../src/common/paper.cpp:159
+#: ../src/common/paper.cpp:156
 msgid "A2 420 x 594 mm"
 msgstr "A2 420 х 594 мм"
 
-#: ../src/common/paper.cpp:156
+#: ../src/common/paper.cpp:153
 msgid "A3 Extra 322 x 445 mm"
 msgstr "A3 Экстра 322 x 445 мм"
 
-#: ../src/common/paper.cpp:161
+#: ../src/common/paper.cpp:158
 msgid "A3 Extra Transverse 322 x 445 mm"
 msgstr "A3 Экстра поперечный 322 x 445 мм"
 
-#: ../src/common/paper.cpp:170
+#: ../src/common/paper.cpp:167
 msgid "A3 Rotated 420 x 297 mm"
 msgstr "A3 Повёрнут 420 х 297 мм"
 
-#: ../src/common/paper.cpp:160
+#: ../src/common/paper.cpp:157
 msgid "A3 Transverse 297 x 420 mm"
 msgstr "A3 Поперечный 297 x 420 мм"
 
-#: ../src/common/paper.cpp:106
+#: ../src/common/paper.cpp:103
 msgid "A3 sheet, 297 x 420 mm"
 msgstr "Лист A3 297 x 420 мм"
 
-#: ../src/common/paper.cpp:146
+#: ../src/common/paper.cpp:143
 msgid "A4 Extra 9.27 x 12.69 in"
 msgstr "A4 Экстра 9.27 x в 12.69"
 
-#: ../src/common/paper.cpp:153
+#: ../src/common/paper.cpp:150
 msgid "A4 Plus 210 x 330 mm"
 msgstr "A4 Плюс 210 x 330 мм"
 
-#: ../src/common/paper.cpp:171
+#: ../src/common/paper.cpp:168
 msgid "A4 Rotated 297 x 210 mm"
 msgstr "A4 Повёрнут 297 x 210 мм"
 
-#: ../src/common/paper.cpp:148
+#: ../src/common/paper.cpp:145
 msgid "A4 Transverse 210 x 297 mm"
 msgstr "A4 Поперечный 210 x 297 мм"
 
-#: ../src/common/paper.cpp:97
+#: ../src/common/paper.cpp:94
 msgid "A4 sheet, 210 x 297 mm"
 msgstr "Лист A4, 210 x 297 мм"
 
-#: ../src/common/paper.cpp:107
+#: ../src/common/paper.cpp:104
 msgid "A4 small sheet, 210 x 297 mm"
 msgstr "Малый лист A4, 210 x 297 мм"
 
-#: ../src/common/paper.cpp:157
+#: ../src/common/paper.cpp:154
 msgid "A5 Extra 174 x 235 mm"
 msgstr "A5 Экстра 174 x 235 мм"
 
-#: ../src/common/paper.cpp:172
+#: ../src/common/paper.cpp:169
 msgid "A5 Rotated 210 x 148 mm"
 msgstr "A5 Повёрнут 210 х 148 мм"
 
-#: ../src/common/paper.cpp:154
+#: ../src/common/paper.cpp:151
 msgid "A5 Transverse 148 x 210 mm"
 msgstr "A5 Поперечный 148 x 210 мм"
 
-#: ../src/common/paper.cpp:108
+#: ../src/common/paper.cpp:105
 msgid "A5 sheet, 148 x 210 mm"
 msgstr "Лист A5, 148 x 210 мм"
 
-#: ../src/common/paper.cpp:164
+#: ../src/common/paper.cpp:161
 msgid "A6 105 x 148 mm"
 msgstr "A6 105 х 148 мм"
 
-#: ../src/common/paper.cpp:177
+#: ../src/common/paper.cpp:174
 msgid "A6 Rotated 148 x 105 mm"
 msgstr "A6 Развёрнут 148 x 105 мм"
 
-#: ../src/generic/fontdlgg.cpp:83 ../src/richtext/richtextformatdlg.cpp:529
-#: ../src/osx/carbon/fontdlg.cpp:153
+#: ../src/osx/carbon/fontdlg.cpp:150 ../src/generic/fontdlgg.cpp:79
+#: ../src/richtext/richtextformatdlg.cpp:521
 msgid "ABCDEFGabcdefg12345"
 msgstr "ABCDEFGabcdefg12345"
 
-#: ../src/richtext/richtextsymboldlg.cpp:458 ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
 msgid "ASCII"
 msgstr "ASCII"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "About"
 msgstr "О программе"
 
-#: ../src/generic/aboutdlgg.cpp:140 ../src/osx/menu_osx.cpp:558
-#: ../src/msw/aboutdlg.cpp:64
+#: ../src/osx/menu_osx.cpp:450 ../src/generic/aboutdlgg.cpp:137
+#: ../src/msw/aboutdlg.cpp:61
 #, c-format
 msgid "About %s"
 msgstr "О программе %s"
 
-#: ../src/osx/menu_osx.cpp:560
+#: ../src/osx/menu_osx.cpp:452
 msgid "About..."
 msgstr "О программе..."
 
@@ -1187,37 +1202,37 @@ msgid "Absolute"
 msgstr "Абсолютный"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:873
+#: ../src/propgrid/advprops.cpp:774
 msgid "ActiveBorder"
 msgstr "АктивнаяГраница"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:874
+#: ../src/propgrid/advprops.cpp:775
 msgid "ActiveCaption"
 msgstr "АктивныйЗаголовок"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "Actual Size"
 msgstr "Исходный размер"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:140 ../src/common/accelcmn.cpp:81
+#: ../src/common/stockitem.cpp:137 ../src/common/accelcmn.cpp:78
 msgid "Add"
 msgstr "Добавить"
 
-#: ../src/richtext/richtextbuffer.cpp:11455
+#: ../src/richtext/richtextbuffer.cpp:11454
 msgid "Add Column"
 msgstr "Добавить колонку"
 
-#: ../src/richtext/richtextbuffer.cpp:11392
+#: ../src/richtext/richtextbuffer.cpp:11391
 msgid "Add Row"
 msgstr "Добавить строку"
 
-#: ../src/html/helpwnd.cpp:432
+#: ../src/html/helpwnd.cpp:430
 msgid "Add current page to bookmarks"
 msgstr "Добавить текущую страницу в закладки"
 
-#: ../src/generic/colrdlgg.cpp:366
+#: ../src/generic/colrdlgg.cpp:386
 msgid "Add to custom colours"
 msgstr "Добавить к цветам пользователя"
 
@@ -1229,12 +1244,12 @@ msgstr "AddToPropertyCollection  вызывается для универсал�
 msgid "AddToPropertyCollection called w/o valid adder"
 msgstr "AddToPropertyCollection вызывается без действительного сумматора"
 
-#: ../src/html/helpctrl.cpp:159
+#: ../src/html/helpctrl.cpp:155
 #, c-format
 msgid "Adding book %s"
 msgstr "Добавление книги %s"
 
-#: ../src/common/preferencescmn.cpp:43
+#: ../src/common/preferencescmn.cpp:40
 msgid "Advanced"
 msgstr "Дополнительно"
 
@@ -1242,11 +1257,11 @@ msgstr "Дополнительно"
 msgid "After a paragraph:"
 msgstr "После абзаца:"
 
-#: ../src/common/stockitem.cpp:172
+#: ../src/common/stockitem.cpp:169
 msgid "Align Left"
 msgstr "Выровнять слева"
 
-#: ../src/common/stockitem.cpp:173
+#: ../src/common/stockitem.cpp:170
 msgid "Align Right"
 msgstr "Выровнять справа"
 
@@ -1254,40 +1269,40 @@ msgstr "Выровнять справа"
 msgid "Alignment"
 msgstr "Выравнивание"
 
-#: ../src/generic/prntdlgg.cpp:215
+#: ../src/generic/prntdlgg.cpp:208
 msgid "All"
 msgstr "Всё"
 
-#: ../src/generic/filectrlg.cpp:1197 ../src/common/fldlgcmn.cpp:107
+#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1186
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Все файлы (%s)|%s"
 
-#: ../include/wx/defs.h:2886
+#: ../include/wx/defs.h:2582
 msgid "All files (*)|*"
 msgstr "Все файлы (*)|*"
 
-#: ../include/wx/defs.h:2883
+#: ../include/wx/defs.h:2579
 msgid "All files (*.*)|*.*"
 msgstr "Все файлы (*.*)|*.*"
 
-#: ../src/richtext/richtextstyles.cpp:1061
+#: ../src/richtext/richtextstyles.cpp:1058
 msgid "All styles"
 msgstr "Все стили"
 
-#: ../src/propgrid/manager.cpp:1528
+#: ../src/propgrid/manager.cpp:1544
 msgid "Alphabetic Mode"
 msgstr "Алфавитный режим"
 
-#: ../src/common/xtistrm.cpp:425
+#: ../src/common/xtistrm.cpp:422
 msgid "Already Registered Object passed to SetObjectClassInfo"
 msgstr "Уже зарегистрированный объект передан в SetObjectClassInfo"
 
-#: ../src/unix/dialup.cpp:353
+#: ../src/unix/dialup.cpp:352
 msgid "Already dialling ISP."
 msgstr "Уже звоним ISP."
 
-#: ../src/common/accelcmn.cpp:331 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/accelcmn.cpp:345 ../src/univ/themes/win32.cpp:3753
 msgid "Alt+"
 msgstr "Alt+"
 
@@ -1296,34 +1311,34 @@ msgstr "Alt+"
 msgid "An optional corner radius for adding rounded corners."
 msgstr "Дополнительный радиус закругления для добавления закруглённых углов."
 
-#: ../src/common/debugrpt.cpp:576
+#: ../src/common/debugrpt.cpp:577
 msgid "And includes the following files:\n"
 msgstr "И включает в себя следующие файлы:\n"
 
-#: ../src/generic/animateg.cpp:162
+#: ../src/generic/animateg.cpp:145
 #, c-format
 msgid "Animation file is not of type %ld."
 msgstr "Файл анимации не имеет типа %ld."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:872
+#: ../src/propgrid/advprops.cpp:773
 msgid "AppWorkspace"
 msgstr "AppWorkspace"
 
-#: ../src/generic/logg.cpp:1014
+#: ../src/generic/logg.cpp:1011
 #, c-format
 msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
 msgstr "Добавить в файл журнала '%s' (выбор [Нет] его перепишет)?"
 
-#: ../src/osx/menu_osx.cpp:577 ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:469 ../src/osx/menu_osx.cpp:477
 msgid "Application"
 msgstr "Приложение"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "Apply"
 msgstr "Применить"
 
-#: ../src/propgrid/advprops.cpp:1609
+#: ../src/propgrid/advprops.cpp:1515
 msgid "Aqua"
 msgstr "Аква"
 
@@ -1332,29 +1347,29 @@ msgstr "Аква"
 msgid "Arabic"
 msgstr "Арабский"
 
-#: ../src/common/fmapbase.cpp:153
+#: ../src/common/fmapbase.cpp:150
 msgid "Arabic (ISO-8859-6)"
 msgstr "Арабский (ISO-8859-6)"
 
-#: ../src/msw/ole/automtn.cpp:672
+#: ../src/msw/ole/automtn.cpp:663
 #, c-format
 msgid "Argument %u not found."
 msgstr "Аргумент %u не найден."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1753
+#: ../src/propgrid/advprops.cpp:1654
 msgid "Arrow"
 msgstr "Стрелка"
 
-#: ../src/generic/aboutdlgg.cpp:184
+#: ../src/generic/aboutdlgg.cpp:181
 msgid "Artists"
 msgstr "Художники"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "Ascending"
 msgstr "По возрастанию"
 
-#: ../src/generic/filectrlg.cpp:433
+#: ../src/generic/filectrlg.cpp:429
 msgid "Attributes"
 msgstr "Атрибуты"
 
@@ -1364,90 +1379,90 @@ msgstr "Атрибуты"
 msgid "Available fonts."
 msgstr "Доступные шрифты."
 
-#: ../src/common/paper.cpp:137
+#: ../src/common/paper.cpp:134
 msgid "B4 (ISO) 250 x 353 mm"
 msgstr "B4 (ISO) 250 х 353 мм"
 
-#: ../src/common/paper.cpp:173
+#: ../src/common/paper.cpp:170
 msgid "B4 (JIS) Rotated 364 x 257 mm"
 msgstr "B4 (JIS) Повёрнут 364 x 257 мм"
 
-#: ../src/common/paper.cpp:127
+#: ../src/common/paper.cpp:124
 msgid "B4 Envelope, 250 x 353 mm"
 msgstr "Конверт B4, 250 x 353 мм"
 
-#: ../src/common/paper.cpp:109
+#: ../src/common/paper.cpp:106
 msgid "B4 sheet, 250 x 354 mm"
 msgstr "Лист B4, 250 x 354 мм"
 
-#: ../src/common/paper.cpp:158
+#: ../src/common/paper.cpp:155
 msgid "B5 (ISO) Extra 201 x 276 mm"
 msgstr "B5 (ISO) Экстра 201 x 276 мм"
 
-#: ../src/common/paper.cpp:174
+#: ../src/common/paper.cpp:171
 msgid "B5 (JIS) Rotated 257 x 182 mm"
 msgstr "B5 (JIS) Повёрнут 257 x 182 мм"
 
-#: ../src/common/paper.cpp:155
+#: ../src/common/paper.cpp:152
 msgid "B5 (JIS) Transverse 182 x 257 mm"
 msgstr "B5 (JIS) Поперечный 182 x 257 мм"
 
-#: ../src/common/paper.cpp:128
+#: ../src/common/paper.cpp:125
 msgid "B5 Envelope, 176 x 250 mm"
 msgstr "Конверт B5, 176 x 250 мм"
 
-#: ../src/common/paper.cpp:110
+#: ../src/common/paper.cpp:107
 msgid "B5 sheet, 182 x 257 millimeter"
 msgstr "Лист B5, 182 x 257 мм"
 
-#: ../src/common/paper.cpp:182
+#: ../src/common/paper.cpp:179
 msgid "B6 (JIS) 128 x 182 mm"
 msgstr "В6 (JIS) 128 x 182 мм"
 
-#: ../src/common/paper.cpp:183
+#: ../src/common/paper.cpp:180
 msgid "B6 (JIS) Rotated 182 x 128 mm"
 msgstr "В6 (JIS) Повёрнут 182 x 128 мм"
 
-#: ../src/common/paper.cpp:129
+#: ../src/common/paper.cpp:126
 msgid "B6 Envelope, 176 x 125 mm"
 msgstr "Конверт B6, 176 x 125 мм"
 
-#: ../src/common/imagbmp.cpp:531 ../src/common/imagbmp.cpp:561
-#: ../src/common/imagbmp.cpp:576
+#: ../src/common/imagbmp.cpp:528 ../src/common/imagbmp.cpp:558
+#: ../src/common/imagbmp.cpp:573
 msgid "BMP: Couldn't allocate memory."
 msgstr "BMP: невозможно выделить память."
 
-#: ../src/common/imagbmp.cpp:100
+#: ../src/common/imagbmp.cpp:97
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: невозможно сохранить недействительное изображение."
 
-#: ../src/common/imagbmp.cpp:356
+#: ../src/common/imagbmp.cpp:353
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: невозможно записать цветовую карту RGB."
 
-#: ../src/common/imagbmp.cpp:490
+#: ../src/common/imagbmp.cpp:487
 msgid "BMP: Couldn't write data."
 msgstr "BMP: невозможно записать данные."
 
-#: ../src/common/imagbmp.cpp:246
+#: ../src/common/imagbmp.cpp:243
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: невозможно записать заголовок файла (Bitmap)."
 
-#: ../src/common/imagbmp.cpp:269
+#: ../src/common/imagbmp.cpp:266
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: невозможно записать заголовок файла (BitmapInfo)."
 
-#: ../src/common/imagbmp.cpp:140
+#: ../src/common/imagbmp.cpp:137
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage не имеет собственного wxPalette."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:142 ../src/common/accelcmn.cpp:52
+#: ../src/common/stockitem.cpp:139 ../src/common/accelcmn.cpp:49
 msgid "Back"
 msgstr "Назад"
 
+#: ../src/richtext/richtextformatdlg.cpp:377
 #: ../src/richtext/richtextbackgroundpage.cpp:148
-#: ../src/richtext/richtextformatdlg.cpp:384
 msgid "Background"
 msgstr "Фон"
 
@@ -1455,20 +1470,20 @@ msgstr "Фон"
 msgid "Background &colour:"
 msgstr "&Цвет фона:"
 
-#: ../src/osx/carbon/fontdlg.cpp:220
+#: ../src/osx/carbon/fontdlg.cpp:217
 msgid "Background colour"
 msgstr "Цвет фона"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:52
+#: ../src/common/accelcmn.cpp:49
 msgid "Backspace"
 msgstr "Backspace"
 
-#: ../src/common/fmapbase.cpp:160
+#: ../src/common/fmapbase.cpp:157
 msgid "Baltic (ISO-8859-13)"
 msgstr "Балтийский (ISO-8859-13)"
 
-#: ../src/common/fmapbase.cpp:151
+#: ../src/common/fmapbase.cpp:148
 msgid "Baltic (old) (ISO-8859-4)"
 msgstr "Балтийский (старый) (ISO-8859-4)"
 
@@ -1481,25 +1496,25 @@ msgstr "Перед абзацем:"
 msgid "Bitmap"
 msgstr "Растровое изображение"
 
-#: ../src/propgrid/advprops.cpp:1594
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Black"
 msgstr "Чёрный"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1755
+#: ../src/propgrid/advprops.cpp:1656
 msgid "Blank"
 msgstr "Поле имени должно быть заполнено"
 
-#: ../src/propgrid/advprops.cpp:1603
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Blue"
 msgstr "Голубой"
 
-#: ../src/generic/colrdlgg.cpp:345
+#: ../src/generic/colrdlgg.cpp:365
 msgid "Blue:"
 msgstr "Голубой:"
 
-#: ../src/generic/fontdlgg.cpp:333 ../src/richtext/richtextfontpage.cpp:355
-#: ../src/osx/carbon/fontdlg.cpp:354 ../src/common/stockitem.cpp:143
+#: ../src/osx/carbon/fontdlg.cpp:351 ../src/common/stockitem.cpp:140
+#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:355
 msgid "Bold"
 msgstr "Жирный"
 
@@ -1508,31 +1523,35 @@ msgstr "Жирный"
 msgid "Border"
 msgstr "Граница"
 
-#: ../src/richtext/richtextformatdlg.cpp:379
+#: ../src/richtext/richtextformatdlg.cpp:372
 msgid "Borders"
 msgstr "Границы"
 
-#: ../src/richtext/richtextsizepage.cpp:288 ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141 ../src/richtext/richtextsizepage.cpp:288
 msgid "Bottom"
 msgstr "Внизу"
 
-#: ../src/generic/prntdlgg.cpp:893
+#: ../src/generic/prntdlgg.cpp:886
 msgid "Bottom margin (mm):"
 msgstr "Нижнее поле (мм):"
 
-#: ../src/richtext/richtextbuffer.cpp:9383
+#: ../src/richtext/richtextbuffer.cpp:9380
 msgid "Box Properties"
 msgstr "Свойства поля"
 
-#: ../src/richtext/richtextstyles.cpp:1065
+#: ../src/richtext/richtextstyles.cpp:1062
 msgid "Box styles"
 msgstr "Стили полей"
 
-#: ../src/propgrid/advprops.cpp:1602
+#: ../src/osx/cocoa/menu.mm:292
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Brown"
 msgstr "Коричневый"
 
-#: ../src/common/filepickercmn.cpp:43 ../src/common/filepickercmn.cpp:44
+#: ../src/common/filepickercmn.cpp:40 ../src/common/filepickercmn.cpp:41
 msgid "Browse"
 msgstr "Обзор"
 
@@ -1545,72 +1564,72 @@ msgstr "&Выравнивание маркера:"
 msgid "Bullet style"
 msgstr "Cтиль маркера"
 
-#: ../src/richtext/richtextformatdlg.cpp:359
+#: ../src/richtext/richtextformatdlg.cpp:352
 msgid "Bullets"
 msgstr "Маркеры"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1756
+#: ../src/propgrid/advprops.cpp:1657
 msgid "Bullseye"
 msgstr "Яблочко"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:875
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonFace"
 msgstr "ВерхКнопки"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:876
+#: ../src/propgrid/advprops.cpp:777
 msgid "ButtonHighlight"
 msgstr "ПодсветкаКнопки"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:877
+#: ../src/propgrid/advprops.cpp:778
 msgid "ButtonShadow"
 msgstr "ТеньКнопки"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:878
+#: ../src/propgrid/advprops.cpp:779
 msgid "ButtonText"
 msgstr "ButtonText"
 
-#: ../src/common/paper.cpp:98
+#: ../src/common/paper.cpp:95
 msgid "C sheet, 17 x 22 in"
 msgstr "Лист C, 17 x 22 дюйма"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "C&lear"
 msgstr "О&чистить"
 
-#: ../src/generic/fontdlgg.cpp:406
+#: ../src/generic/fontdlgg.cpp:403
 msgid "C&olour:"
 msgstr "&Цвет:"
 
-#: ../src/common/paper.cpp:123
+#: ../src/common/paper.cpp:120
 msgid "C3 Envelope, 324 x 458 mm"
 msgstr "Конверт C3, 324 x 458 мм"
 
-#: ../src/common/paper.cpp:124
+#: ../src/common/paper.cpp:121
 msgid "C4 Envelope, 229 x 324 mm"
 msgstr "Конверт C4, 229 x 324 мм"
 
-#: ../src/common/paper.cpp:122
+#: ../src/common/paper.cpp:119
 msgid "C5 Envelope, 162 x 229 mm"
 msgstr "Конверт C5, 162 x 229 мм"
 
-#: ../src/common/paper.cpp:125
+#: ../src/common/paper.cpp:122
 msgid "C6 Envelope, 114 x 162 mm"
 msgstr "Конверт C6, 114 x 162 мм"
 
-#: ../src/common/paper.cpp:126
+#: ../src/common/paper.cpp:123
 msgid "C65 Envelope, 114 x 229 mm"
 msgstr "Конверт C65, 114 x 229 мм"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "CD-Rom"
 msgstr "CD-Rom"
 
-#: ../src/html/chm.cpp:815 ../src/html/chm.cpp:874
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:865
 msgid "CHM handler currently supports only local files!"
 msgstr "В настоящее время обработчик CHM поддерживает только локальные файлы!"
 
@@ -1618,189 +1637,196 @@ msgstr "В настоящее время обработчик CHM поддерж
 msgid "Ca&pitals"
 msgstr "Ca&pitals"
 
-#: ../src/common/cmdproc.cpp:267
+#: ../src/common/cmdproc.cpp:260
 msgid "Can't &Undo "
 msgstr "О&тменить невозможно "
 
-#: ../src/common/image.cpp:2824
+#: ../src/common/image.cpp:2924
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr "Не удаётся автоопределить формат изображения для ввода без поиска."
 
-#: ../src/msw/registry.cpp:506
+#: ../src/msw/registry.cpp:495
 #, c-format
 msgid "Can't close registry key '%s'"
 msgstr "Невозможно закрыть ключ реестра '%s'"
 
-#: ../src/msw/registry.cpp:584
+#: ../src/msw/registry.cpp:573
 #, c-format
 msgid "Can't copy values of unsupported type %d."
 msgstr "Невозможно скопировать значения неподдерживаемого типа %d."
 
-#: ../src/msw/registry.cpp:487
+#: ../src/msw/registry.cpp:476
 #, c-format
 msgid "Can't create registry key '%s'"
 msgstr "Невозможно создать ключ реестра '%s'"
 
-#: ../src/msw/thread.cpp:665
+#: ../src/msw/thread.cpp:657
 msgid "Can't create thread"
 msgstr "Невозможно создать поток"
 
-#: ../src/msw/window.cpp:3691
-#, c-format
-msgid "Can't create window of class %s"
-msgstr "Невозможно создать окно класса %s"
-
-#: ../src/msw/registry.cpp:777
+#: ../src/msw/registry.cpp:765
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Невозможно удалить ключ '%s'"
 
-#: ../src/msw/iniconf.cpp:458
+#: ../src/msw/iniconf.cpp:455
 #, c-format
 msgid "Can't delete the INI file '%s'"
 msgstr "Невозможно удалить INI-файл '%s'"
 
-#: ../src/msw/registry.cpp:805
+#: ../src/msw/registry.cpp:793
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Невозможно удалить значение '%s' из ключа '%s'"
 
-#: ../src/msw/registry.cpp:1171
+#: ../src/msw/registry.cpp:1159
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Невозможно пересчитать подключи ключа '%s'"
 
-#: ../src/msw/registry.cpp:1132
+#: ../src/msw/registry.cpp:1120
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Невозможно пересчитать значения ключа '%s'"
 
-#: ../src/msw/registry.cpp:1389
+#: ../src/msw/registry.cpp:1377
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Экспорт значения неподдерживаемого типа %d невозможен."
 
-#: ../src/common/ffile.cpp:254
+#: ../src/common/ffile.cpp:253
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Не удаётся найти текущую позицию в файле '%s'"
 
-#: ../src/msw/registry.cpp:418
+#: ../src/msw/registry.cpp:407
 #, c-format
 msgid "Can't get info about registry key '%s'"
 msgstr "Невозможно получить информацию о ключе реестра '%s'"
 
-#: ../src/common/zstream.cpp:346
+#: ../src/msw/webview_ie.cpp:1024
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "Невозможно установить приоритет потока"
+
+#: ../src/common/zstream.cpp:343
 msgid "Can't initialize zlib deflate stream."
 msgstr "Невозможно инициализировать распаковку данных zlib."
 
-#: ../src/common/zstream.cpp:185
+#: ../src/common/zstream.cpp:182
 msgid "Can't initialize zlib inflate stream."
 msgstr "Невозможно инициализировать сжатие данных zlib."
 
-#: ../src/msw/fswatcher.cpp:476
+#: ../src/msw/fswatcher.cpp:475
 #, c-format
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "Невозможно контролировать несуществующий каталог '%s' для изменений."
 
-#: ../src/msw/registry.cpp:454
+#: ../src/msw/registry.cpp:443
 #, c-format
 msgid "Can't open registry key '%s'"
 msgstr "Невозможно открыть ключ реестра '%s'"
 
-#: ../src/common/zstream.cpp:252
+#: ../src/common/zstream.cpp:249
 #, c-format
 msgid "Can't read from inflate stream: %s"
 msgstr "Невозможно чтение сжимаемого потока: %s"
 
-#: ../src/common/zstream.cpp:244
+#: ../src/common/zstream.cpp:241
 msgid "Can't read inflate stream: unexpected EOF in underlying stream."
-msgstr "Невозможно чтение сжимаемого потока: неожиданный EOF в нижлежащем потоке."
+msgstr ""
+"Невозможно чтение сжимаемого потока: неожиданный EOF в нижлежащем потоке."
 
-#: ../src/msw/registry.cpp:1064
+#: ../src/msw/registry.cpp:1052
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Невозможно прочесть значение '%s'"
 
-#: ../src/msw/registry.cpp:878 ../src/msw/registry.cpp:910 ../src/msw/registry.cpp:975
+#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
+#: ../src/msw/registry.cpp:963
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Невозможно прочесть значение ключа '%s'"
 
-#: ../src/common/image.cpp:2620
+#: ../src/msw/webview_ie.cpp:1017
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/common/image.cpp:2715
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
-msgstr "Невозможно сохранить изображение в файл '%s': неизвестное расширение файла."
+msgstr ""
+"Невозможно сохранить изображение в файл '%s': неизвестное расширение файла."
 
-#: ../src/generic/logg.cpp:573 ../src/generic/logg.cpp:976
+#: ../src/generic/logg.cpp:570 ../src/generic/logg.cpp:973
 msgid "Can't save log contents to file."
 msgstr "Невозможно сохранение содержания журнала в файл."
 
-#: ../src/msw/thread.cpp:629
+#: ../src/msw/thread.cpp:621
 msgid "Can't set thread priority"
 msgstr "Невозможно установить приоритет потока"
 
-#: ../src/msw/registry.cpp:896 ../src/msw/registry.cpp:938
-#: ../src/msw/registry.cpp:1081
+#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
+#: ../src/msw/registry.cpp:1069
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Невозможно установить значение '%s'"
 
-#: ../src/unix/utilsunx.cpp:351
+#: ../src/unix/utilsunx.cpp:353
 msgid "Can't write to child process's stdin"
 msgstr "Не удаётся записать в стандартный ввод дочернего процесса"
 
-#: ../src/common/zstream.cpp:427
+#: ../src/common/zstream.cpp:424
 #, c-format
 msgid "Can't write to deflate stream: %s"
 msgstr "Невозможно записать в разжимаемый поток: %s"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:279 ../src/richtext/richtextstyledlg.cpp:300
-#: ../src/common/stockitem.cpp:145 ../src/common/accelcmn.cpp:71
-#: ../src/msw/msgdlg.cpp:454 ../src/msw/progdlg.cpp:673 ../src/gtk1/fontdlg.cpp:144
-#: ../src/motif/msgdlg.cpp:196
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:142
+#: ../src/common/accelcmn.cpp:68 ../src/motif/msgdlg.cpp:196
+#: ../src/gtk1/fontdlg.cpp:144 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/progdlg.cpp:940 ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Отмена"
 
-#: ../src/common/filefn.cpp:1261
+#: ../src/common/filefn.cpp:1149
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Не удаётся перечислить файлы '%s'"
 
-#: ../src/msw/dir.cpp:263
+#: ../src/msw/dir.cpp:260
 #, c-format
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Не удаётся перечислить файлы в каталоге '%s'"
 
-#: ../src/msw/dialup.cpp:523
+#: ../src/msw/dialup.cpp:517
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Невозможно найти активное модемное соединение: %s"
 
-#: ../src/msw/dialup.cpp:827
+#: ../src/msw/dialup.cpp:821
 msgid "Cannot find the location of address book file"
 msgstr "Файл с адресной книжкой не найден"
 
-#: ../src/msw/ole/automtn.cpp:562
+#: ../src/msw/ole/automtn.cpp:553
 #, c-format
 msgid "Cannot get an active instance of \"%s\""
 msgstr "Не удается получить активный экземпляр '%s'"
 
-#: ../src/unix/threadpsx.cpp:1035
+#: ../src/unix/threadpsx.cpp:1053
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "Невозможно получить диапазон приоритетов для политики планирования %d."
 
-#: ../src/unix/utilsunx.cpp:987
+#: ../src/unix/utilsunx.cpp:989
 msgid "Cannot get the hostname"
 msgstr "Невозможно получить имя хоста"
 
-#: ../src/unix/utilsunx.cpp:1023
+#: ../src/unix/utilsunx.cpp:1025
 msgid "Cannot get the official hostname"
 msgstr "Невозможно получить официальное имя хоста"
 
-#: ../src/msw/dialup.cpp:928
+#: ../src/msw/dialup.cpp:922
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Невозможно повесить трубку - нет активного модемного соединения."
 
@@ -1808,126 +1834,126 @@ msgstr "Невозможно повесить трубку - нет активн
 msgid "Cannot initialize OLE"
 msgstr "Невозможно инициализировать OLE"
 
-#: ../src/common/socket.cpp:853
+#: ../src/common/socket.cpp:850
 msgid "Cannot initialize sockets"
 msgstr "Не удалось инициализировать сокеты"
 
-#: ../src/msw/volume.cpp:619
+#: ../src/msw/volume.cpp:627
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Невозможно загрузить значок из '%s'."
 
-#: ../src/xrc/xmlres.cpp:360
+#: ../src/xrc/xmlres.cpp:358
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Не удалось загрузить ресурсы из '%s'."
 
-#: ../src/xrc/xmlres.cpp:742
+#: ../src/xrc/xmlres.cpp:740
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Невозможно загрузить ресурсы из файла '%s'."
 
-#: ../src/html/htmlfilt.cpp:137
+#: ../src/html/htmlfilt.cpp:134
 #, c-format
 msgid "Cannot open HTML document: %s"
 msgstr "Невозможно открыть HTML документ: %s"
 
-#: ../src/html/helpdata.cpp:667
+#: ../src/html/helpdata.cpp:660
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Невозможно открыть книгу справки HTML: %s"
 
-#: ../src/html/helpdata.cpp:299
+#: ../src/html/helpdata.cpp:296
 #, c-format
 msgid "Cannot open contents file: %s"
 msgstr "Невозможно открыть файл содержания: %s"
 
-#: ../src/generic/dcpsg.cpp:1667
+#: ../src/generic/dcpsg.cpp:1665
 msgid "Cannot open file for PostScript printing!"
 msgstr "Невозможно открыть файл для печати в PostScript!"
 
-#: ../src/html/helpdata.cpp:313
+#: ../src/html/helpdata.cpp:310
 #, c-format
 msgid "Cannot open index file: %s"
 msgstr "Невозможно открыть файл индекса: %s"
 
-#: ../src/xrc/xmlres.cpp:724
+#: ../src/xrc/xmlres.cpp:722
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Невозможно открыть файл ресурсов '%s'."
 
-#: ../src/html/helpwnd.cpp:1534
+#: ../src/html/helpwnd.cpp:1532
 msgid "Cannot print empty page."
 msgstr "Невозможно напечатать пустую страницу."
 
-#: ../src/msw/volume.cpp:507
+#: ../src/msw/volume.cpp:515
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Чтение имени типа из '%s' невозможно!"
 
-#: ../src/msw/thread.cpp:888
+#: ../src/msw/thread.cpp:894
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Не удалось возобновить поток %lx"
 
-#: ../src/unix/threadpsx.cpp:1016
+#: ../src/unix/threadpsx.cpp:1028
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Невозможно извлечь политику планировки потока."
 
-#: ../src/common/intl.cpp:558
+#: ../src/common/intl.cpp:365
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "Не удалось установить локали для языка \"%s\"."
 
-#: ../src/unix/threadpsx.cpp:831 ../src/msw/thread.cpp:546
+#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
 msgid "Cannot start thread: error writing TLS."
 msgstr "Невозможно запустить выполнение потока: ошибка записи TLS."
 
-#: ../src/msw/thread.cpp:872
+#: ../src/msw/thread.cpp:864
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Не удалось приостановить поток %lx"
 
-#: ../src/msw/thread.cpp:794
+#: ../src/msw/thread.cpp:786
 msgid "Cannot wait for thread termination"
 msgstr "Невозможно дождаться окончания выполнения потока"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:75
+#: ../src/common/accelcmn.cpp:72
 msgid "Capital"
 msgstr "Заглавная"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:879
+#: ../src/propgrid/advprops.cpp:780
 msgid "CaptionText"
 msgstr "CaptionText"
 
-#: ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:531
 msgid "Case sensitive"
 msgstr "Чувствителен к регистру"
 
-#: ../src/propgrid/manager.cpp:1509
+#: ../src/propgrid/manager.cpp:1527
 msgid "Categorized Mode"
 msgstr "Режим По категориям"
 
-#: ../src/richtext/richtextbuffer.cpp:9968
+#: ../src/richtext/richtextbuffer.cpp:9965
 msgid "Cell Properties"
 msgstr "Свойства ячейки"
 
-#: ../src/common/fmapbase.cpp:161
+#: ../src/common/fmapbase.cpp:158
 msgid "Celtic (ISO-8859-14)"
 msgstr "Кельтский (ISO-8859-14)"
 
-#: ../src/richtext/richtextindentspage.cpp:160
 #: ../src/richtext/richtextliststylepage.cpp:349
+#: ../src/richtext/richtextindentspage.cpp:160
 msgid "Cen&tred"
 msgstr "Цен&трировано"
 
-#: ../src/common/stockitem.cpp:170
+#: ../src/common/stockitem.cpp:167
 msgid "Centered"
 msgstr "Центрированный"
 
-#: ../src/common/fmapbase.cpp:149
+#: ../src/common/fmapbase.cpp:146
 msgid "Central European (ISO-8859-2)"
 msgstr "Центрально-европейский (ISO-8859-2)"
 
@@ -1936,10 +1962,10 @@ msgstr "Центрально-европейский (ISO-8859-2)"
 msgid "Centre"
 msgstr "Центр"
 
-#: ../src/richtext/richtextindentspage.cpp:162
-#: ../src/richtext/richtextindentspage.cpp:164
 #: ../src/richtext/richtextliststylepage.cpp:351
 #: ../src/richtext/richtextliststylepage.cpp:353
+#: ../src/richtext/richtextindentspage.cpp:162
+#: ../src/richtext/richtextindentspage.cpp:164
 msgid "Centre text."
 msgstr "Центрировать текст."
 
@@ -1952,26 +1978,28 @@ msgstr "По центру"
 msgid "Ch&oose..."
 msgstr "Вы&брать..."
 
-#: ../src/richtext/richtextbuffer.cpp:4354
+#: ../src/richtext/richtextbuffer.cpp:4351
 msgid "Change List Style"
 msgstr "Изменить стиль списка"
 
-#: ../src/richtext/richtextbuffer.cpp:3709
+#: ../src/richtext/richtextbuffer.cpp:3706
 msgid "Change Object Style"
 msgstr "Изменить стиль объекта"
 
-#: ../src/richtext/richtextbuffer.cpp:3982 ../src/richtext/richtextbuffer.cpp:8129
+#: ../src/richtext/richtextbuffer.cpp:3979
+#: ../src/richtext/richtextbuffer.cpp:8125
 msgid "Change Properties"
 msgstr "Изменить свойства"
 
-#: ../src/richtext/richtextbuffer.cpp:3526
+#: ../src/richtext/richtextbuffer.cpp:3523
 msgid "Change Style"
 msgstr "Изменение стиля"
 
-#: ../src/common/fileconf.cpp:341
+#: ../src/common/fileconf.cpp:335
 #, c-format
 msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
-msgstr "Изменения не будут сохранены во избежание перезаписи существующего файла '%s'"
+msgstr ""
+"Изменения не будут сохранены во избежание перезаписи существующего файла '%s'"
 
 #: ../src/gtk/filepicker.cpp:190 ../src/gtk/filedlg.cpp:87
 #, c-format
@@ -1979,11 +2007,11 @@ msgid "Changing current directory to \"%s\" failed"
 msgstr "Ошибка смены текущего каталога на '%s'"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1757
+#: ../src/propgrid/advprops.cpp:1658
 msgid "Character"
 msgstr "Знак"
 
-#: ../src/richtext/richtextstyles.cpp:1063
+#: ../src/richtext/richtextstyles.cpp:1060
 msgid "Character styles"
 msgstr "Стили знаков"
 
@@ -2015,94 +2043,103 @@ msgstr "Установите флажок для правки всех гран�
 msgid "Check to enclose the bullet in parentheses."
 msgstr "Установите флажок для заключения маркера в круглые скобки."
 
-#: ../src/richtext/richtextfontpage.cpp:315 ../src/richtext/richtextfontpage.cpp:317
+#: ../src/richtext/richtextfontpage.cpp:315
+#: ../src/richtext/richtextfontpage.cpp:317
 msgid "Check to indicate right-to-left text layout."
 msgstr "Установите флажок для указания макета текста справа налево."
 
-#: ../src/osx/carbon/fontdlg.cpp:356 ../src/osx/carbon/fontdlg.cpp:358
+#: ../src/osx/carbon/fontdlg.cpp:353 ../src/osx/carbon/fontdlg.cpp:355
 msgid "Check to make the font bold."
 msgstr "Установите флажок, чтобы сделать шрифт полужирным."
 
-#: ../src/osx/carbon/fontdlg.cpp:363 ../src/osx/carbon/fontdlg.cpp:365
+#: ../src/osx/carbon/fontdlg.cpp:360 ../src/osx/carbon/fontdlg.cpp:362
 msgid "Check to make the font italic."
 msgstr "Установите флажок, чтобы сделать шрифт курсивом."
 
-#: ../src/osx/carbon/fontdlg.cpp:372 ../src/osx/carbon/fontdlg.cpp:374
+#: ../src/osx/carbon/fontdlg.cpp:369 ../src/osx/carbon/fontdlg.cpp:371
 msgid "Check to make the font underlined."
 msgstr "Установите флажок, чтобы сделать шрифт подчёркнутым."
 
-#: ../src/richtext/richtextstyledlg.cpp:289 ../src/richtext/richtextstyledlg.cpp:291
+#: ../src/richtext/richtextstyledlg.cpp:285
+#: ../src/richtext/richtextstyledlg.cpp:287
 msgid "Check to restart numbering."
 msgstr "Установите флажок для перезапуска нумерации."
 
-#: ../src/richtext/richtextfontpage.cpp:277 ../src/richtext/richtextfontpage.cpp:279
+#: ../src/richtext/richtextfontpage.cpp:277
+#: ../src/richtext/richtextfontpage.cpp:279
 msgid "Check to show a line through the text."
 msgstr "Установите флажок, чтобы отобразить текст перечёркнутым."
 
-#: ../src/richtext/richtextfontpage.cpp:284 ../src/richtext/richtextfontpage.cpp:286
+#: ../src/richtext/richtextfontpage.cpp:284
+#: ../src/richtext/richtextfontpage.cpp:286
 msgid "Check to show the text in capitals."
 msgstr "Установите флажок, чтобы отобразить текст заглавными буквами."
 
-#: ../src/richtext/richtextfontpage.cpp:291 ../src/richtext/richtextfontpage.cpp:293
+#: ../src/richtext/richtextfontpage.cpp:291
+#: ../src/richtext/richtextfontpage.cpp:293
 msgid "Check to show the text in small capitals."
 msgstr "Установите флажок, чтобы отобразить текст в маленькими заглавными."
 
-#: ../src/richtext/richtextfontpage.cpp:305 ../src/richtext/richtextfontpage.cpp:307
+#: ../src/richtext/richtextfontpage.cpp:305
+#: ../src/richtext/richtextfontpage.cpp:307
 msgid "Check to show the text in subscript."
 msgstr "Установите флажок, чтобы отобразить текст как нижний индекс."
 
-#: ../src/richtext/richtextfontpage.cpp:298 ../src/richtext/richtextfontpage.cpp:300
+#: ../src/richtext/richtextfontpage.cpp:298
+#: ../src/richtext/richtextfontpage.cpp:300
 msgid "Check to show the text in superscript."
 msgstr "Установите флажок, чтобы отобразить текст в скрипте."
 
-#: ../src/richtext/richtextfontpage.cpp:322 ../src/richtext/richtextfontpage.cpp:324
+#: ../src/richtext/richtextfontpage.cpp:322
+#: ../src/richtext/richtextfontpage.cpp:324
 msgid "Check to suppress hyphenation."
 msgstr "Установите флажок для подавления расстановки переносов."
 
-#: ../src/msw/dialup.cpp:763
+#: ../src/msw/dialup.cpp:757
 msgid "Choose ISP to dial"
 msgstr "Выберите провайдера для набора номера"
 
-#: ../src/propgrid/props.cpp:1922
+#: ../src/propgrid/props.cpp:1904
 msgid "Choose a directory:"
 msgstr "Выберите каталог:"
 
-#: ../src/propgrid/props.cpp:1975
+#: ../src/propgrid/props.cpp:2199
 msgid "Choose a file"
 msgstr "Выберите файл"
 
-#: ../src/generic/colrdlgg.cpp:158 ../src/gtk/colordlg.cpp:54
+#: ../src/generic/colrdlgg.cpp:156 ../src/gtk/colordlg.cpp:49
 msgid "Choose colour"
 msgstr "Выберите цвет"
 
-#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/gtk1/fontdlg.cpp:125 ../src/generic/fontpickerg.cpp:47
+#: ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Выберите шрифт"
 
-#: ../src/common/module.cpp:74
+#: ../src/common/module.cpp:71
 #, c-format
 msgid "Circular dependency involving module \"%s\" detected."
 msgstr "Обнаружена циклическая зависимость с модулем '%s'."
 
-#: ../src/aui/tabmdi.cpp:108 ../src/generic/mdig.cpp:97
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
 msgid "Cl&ose"
 msgstr "&Закрыть"
 
-#: ../src/msw/ole/automtn.cpp:684
+#: ../src/msw/ole/automtn.cpp:675
 msgid "Class not registered."
 msgstr "Класс не зарегистрирован."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:147 ../src/common/accelcmn.cpp:72
+#: ../src/common/stockitem.cpp:144 ../src/common/accelcmn.cpp:69
 msgid "Clear"
 msgstr "Очистить"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "Clear the log contents"
 msgstr "Очистить содержимое журнала"
 
-#: ../src/richtext/richtextstyledlg.cpp:252 ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:248
+#: ../src/richtext/richtextstyledlg.cpp:250
 msgid "Click to apply the selected style."
 msgstr "Щёлкните, чтобы применить выбранный стиль."
 
@@ -2113,23 +2150,25 @@ msgstr "Щёлкните, чтобы применить выбранный ст�
 msgid "Click to browse for a symbol."
 msgstr "Щёлкните, чтобы выбрать символ."
 
-#: ../src/osx/carbon/fontdlg.cpp:403 ../src/osx/carbon/fontdlg.cpp:405
+#: ../src/osx/carbon/fontdlg.cpp:400 ../src/osx/carbon/fontdlg.cpp:402
 msgid "Click to cancel changes to the font."
 msgstr "Щёлкните, чтобы отменить изменения шрифта."
 
-#: ../src/generic/fontdlgg.cpp:472 ../src/generic/fontdlgg.cpp:491
+#: ../src/generic/fontdlgg.cpp:468 ../src/generic/fontdlgg.cpp:487
 msgid "Click to cancel the font selection."
 msgstr "Щёлкните для отмены выбора шрифта'."
 
-#: ../src/osx/carbon/fontdlg.cpp:384 ../src/osx/carbon/fontdlg.cpp:386
+#: ../src/osx/carbon/fontdlg.cpp:381 ../src/osx/carbon/fontdlg.cpp:383
 msgid "Click to change the font colour."
 msgstr "Щёлкните, чтобы изменить цвет шрифта."
 
-#: ../src/richtext/richtextfontpage.cpp:267 ../src/richtext/richtextfontpage.cpp:269
+#: ../src/richtext/richtextfontpage.cpp:267
+#: ../src/richtext/richtextfontpage.cpp:269
 msgid "Click to change the text background colour."
 msgstr "Щёлкните, чтобы изменить цвет фона текста."
 
-#: ../src/richtext/richtextfontpage.cpp:254 ../src/richtext/richtextfontpage.cpp:256
+#: ../src/richtext/richtextfontpage.cpp:254
+#: ../src/richtext/richtextfontpage.cpp:256
 msgid "Click to change the text colour."
 msgstr "Щёлкните, чтобы изменить цвет текста."
 
@@ -2138,67 +2177,79 @@ msgstr "Щёлкните, чтобы изменить цвет текста."
 msgid "Click to choose the font for this level."
 msgstr "Щёлкните, чтобы выбрать шрифт для этого уровня."
 
-#: ../src/richtext/richtextstyledlg.cpp:279 ../src/richtext/richtextstyledlg.cpp:281
+#: ../src/richtext/richtextstyledlg.cpp:275
+#: ../src/richtext/richtextstyledlg.cpp:277
 msgid "Click to close this window."
 msgstr "Щёлкните, чтобы закрыть это окно."
 
-#: ../src/osx/carbon/fontdlg.cpp:410 ../src/osx/carbon/fontdlg.cpp:412
+#: ../src/osx/carbon/fontdlg.cpp:407 ../src/osx/carbon/fontdlg.cpp:409
 msgid "Click to confirm changes to the font."
 msgstr "Щёлкните, чтобы подтвердить изменения в шрифте."
 
-#: ../src/generic/fontdlgg.cpp:477 ../src/generic/fontdlgg.cpp:479
-#: ../src/generic/fontdlgg.cpp:484 ../src/generic/fontdlgg.cpp:486
+#: ../src/generic/fontdlgg.cpp:473 ../src/generic/fontdlgg.cpp:475
+#: ../src/generic/fontdlgg.cpp:480 ../src/generic/fontdlgg.cpp:482
 msgid "Click to confirm the font selection."
 msgstr "Щёлкните 'подтвердить смену шрифта'."
 
-#: ../src/richtext/richtextstyledlg.cpp:244 ../src/richtext/richtextstyledlg.cpp:246
+#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:242
 msgid "Click to create a new box style."
 msgstr "Щёлкните, чтобы создать новый стиль поля."
 
-#: ../src/richtext/richtextstyledlg.cpp:226 ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:224
 msgid "Click to create a new character style."
 msgstr "Щелкните, чтобы создать новый стиль символов."
 
-#: ../src/richtext/richtextstyledlg.cpp:238 ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:236
 msgid "Click to create a new list style."
 msgstr "Щёлкните, чтобы создать новый стиль списка."
 
-#: ../src/richtext/richtextstyledlg.cpp:232 ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:230
 msgid "Click to create a new paragraph style."
 msgstr "Щелкните, чтобы создать новый стиль абзаца."
 
-#: ../src/richtext/richtexttabspage.cpp:133 ../src/richtext/richtexttabspage.cpp:135
+#: ../src/richtext/richtexttabspage.cpp:133
+#: ../src/richtext/richtexttabspage.cpp:135
 msgid "Click to create a new tab position."
 msgstr "Щёлкните, чтобы создать новую позицию табуляции."
 
-#: ../src/richtext/richtexttabspage.cpp:145 ../src/richtext/richtexttabspage.cpp:147
+#: ../src/richtext/richtexttabspage.cpp:145
+#: ../src/richtext/richtexttabspage.cpp:147
 msgid "Click to delete all tab positions."
 msgstr "Щёлкните, чтобы удалить все позиции табуляции."
 
-#: ../src/richtext/richtextstyledlg.cpp:270 ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:268
 msgid "Click to delete the selected style."
 msgstr "Щёлкните, чтобы удалить выбранный стиль."
 
-#: ../src/richtext/richtexttabspage.cpp:139 ../src/richtext/richtexttabspage.cpp:141
+#: ../src/richtext/richtexttabspage.cpp:139
+#: ../src/richtext/richtexttabspage.cpp:141
 msgid "Click to delete the selected tab position."
 msgstr "Щёлкните, чтобы удалить выбранную позицию табуляции."
 
-#: ../src/richtext/richtextstyledlg.cpp:264 ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:262
 msgid "Click to edit the selected style."
 msgstr "Щёлкните, чтобы изменить выбранный стиль."
 
-#: ../src/richtext/richtextstyledlg.cpp:258 ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:256
 msgid "Click to rename the selected style."
 msgstr "Щёлкните, чтобы переименовать выбранный стиль."
 
-#: ../src/generic/dbgrptg.cpp:97 ../src/generic/progdlgg.cpp:759
-#: ../src/richtext/richtextstyledlg.cpp:277 ../src/richtext/richtextsymboldlg.cpp:476
-#: ../src/common/stockitem.cpp:148 ../src/msw/progdlg.cpp:170
-#: ../src/msw/progdlg.cpp:679 ../src/html/helpdlg.cpp:90
+#: ../src/common/stockitem.cpp:145 ../src/generic/dbgrptg.cpp:94
+#: ../src/generic/progdlgg.cpp:781 ../src/msw/progdlg.cpp:211
+#: ../src/msw/progdlg.cpp:946 ../src/html/helpdlg.cpp:87
+#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextstyledlg.cpp:273
 msgid "Close"
 msgstr "Закрыть"
 
-#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:98
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
 msgid "Close All"
 msgstr "Закрыть всё"
 
@@ -2206,64 +2257,69 @@ msgstr "Закрыть всё"
 msgid "Close current document"
 msgstr "Закрыть текущий документ"
 
-#: ../src/generic/logg.cpp:516
+#: ../src/generic/logg.cpp:513
 msgid "Close this window"
 msgstr "Закрыть это окно"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6006
+#: ../src/generic/datavgen.cpp:6811
 msgid "Collapse"
 msgstr "Свернуть"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "Color"
 msgstr "Цвет"
 
-#: ../src/richtext/richtextformatdlg.cpp:776
+#: ../src/richtext/richtextformatdlg.cpp:768
 msgid "Colour"
 msgstr "Цвет"
 
-#: ../src/msw/colordlg.cpp:158
+#: ../src/msw/colordlg.cpp:227
 #, c-format
 msgid "Colour selection dialog failed with error %0lx."
 msgstr "В диалоговом окне выбора цвета произошла ошибка %0lx."
 
-#: ../src/osx/carbon/fontdlg.cpp:380
+#: ../src/osx/carbon/fontdlg.cpp:377
 msgid "Colour:"
 msgstr "Цвет:"
 
-#: ../src/generic/datavgen.cpp:6077
+#: ../src/generic/datavgen.cpp:6882
 #, c-format
 msgid "Column %u"
 msgstr "Колонка %u"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:114
+#: ../src/common/accelcmn.cpp:112
 msgid "Command"
 msgstr "&Команда"
 
-#: ../src/common/init.cpp:196
+#: ../src/common/init.cpp:193
 #, c-format
-msgid "Command line argument %d couldn't be converted to Unicode and will be ignored."
+msgid ""
+"Command line argument %d couldn't be converted to Unicode and will be "
+"ignored."
 msgstr ""
-"Аргумент командной строки %d не может быть преобразован в Юникод и проигнорирован."
+"Аргумент командной строки %d не может быть преобразован в Юникод и "
+"проигнорирован."
 
-#: ../src/msw/fontdlg.cpp:120
+#: ../src/msw/fontdlg.cpp:170
 #, c-format
 msgid "Common dialog failed with error code %0lx."
 msgstr "В общим диалоговом окне произошла ошибка с кодом %0lx."
 
-#: ../src/gtk/window.cpp:4649
+#: ../src/gtk/window.cpp:5653
 msgid ""
-"Compositing not supported by this system, please enable it in your Window Manager."
+"Compositing not supported by this system, please enable it in your Window "
+"Manager."
 msgstr ""
-"Композитинг не поддерживается этой системой, включите его в своём оконном менеджере."
+"Композитинг не поддерживается этой системой, включите его в своём оконном "
+"менеджере."
 
-#: ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:1549
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Сжатый файл справки HTML (*.chm)|*.chm|"
 
-#: ../src/generic/dirctrlg.cpp:444
+#: ../src/generic/dirctrlg.cpp:410
 msgid "Computer"
 msgstr "Компьютер"
 
@@ -2272,53 +2328,57 @@ msgstr "Компьютер"
 msgid "Config entry name cannot start with '%c'."
 msgstr "Имя поля в файле конфигурации не может начинаться с '%c'."
 
-#: ../src/generic/filedlgg.cpp:349 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
 msgid "Confirm"
 msgstr "Подтвердите"
 
-#: ../src/html/htmlwin.cpp:566
+#: ../src/html/htmlwin.cpp:569
 msgid "Connecting..."
 msgstr "Соединение..."
 
-#: ../src/html/helpwnd.cpp:475
+#: ../src/html/helpwnd.cpp:473
 msgid "Contents"
 msgstr "Содержание"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:880
+#: ../src/propgrid/advprops.cpp:781
 msgid "ControlDark"
 msgstr "ControlDark"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:881
+#: ../src/propgrid/advprops.cpp:782
 msgid "ControlLight"
 msgstr "ControlLight"
 
-#: ../src/common/strconv.cpp:2262
+#: ../src/common/strconv.cpp:2208
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Преобразование кодировки в '%s' не работает."
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "Convert"
 msgstr "Преобразовать"
 
-#: ../src/html/htmlwin.cpp:1079
+#: ../src/html/htmlwin.cpp:1020
 #, c-format
 msgid "Copied to clipboard:\"%s\""
 msgstr "Скопировано в буфер обмена: '%s'"
 
-#: ../src/generic/prntdlgg.cpp:247
+#: ../src/generic/prntdlgg.cpp:240
 msgid "Copies:"
 msgstr "Копии:"
 
-#: ../src/common/stockitem.cpp:150 ../src/stc/stc_i18n.cpp:18
+#: ../src/common/stockitem.cpp:147 ../src/stc/stc_i18n.cpp:18
 msgid "Copy"
 msgstr "Копировать"
 
-#: ../src/common/stockitem.cpp:258
+#: ../src/common/stockitem.cpp:255
 msgid "Copy selection"
 msgstr "Копировать выбранное"
+
+#: ../src/generic/grid.cpp:5945
+msgid "Copying more than one selected block to clipboard is not supported."
+msgstr ""
 
 #: ../src/richtext/richtextborderspage.cpp:566
 #: ../src/richtext/richtextborderspage.cpp:601
@@ -2329,195 +2389,193 @@ msgstr "Угол"
 msgid "Corner &radius:"
 msgstr "&Радиус угла:"
 
-#: ../src/html/chm.cpp:718
+#: ../src/html/chm.cpp:711
 #, c-format
 msgid "Could not create temporary file '%s'"
 msgstr "Невозможно создать временный файл '%s'"
 
-#: ../src/html/chm.cpp:273
+#: ../src/html/chm.cpp:270
 #, c-format
 msgid "Could not extract %s into %s: %s"
 msgstr "Невозможно извлечь %s в %s: %s"
 
-#: ../src/generic/tabg.cpp:1048
+#: ../src/generic/tabg.cpp:1045
 msgid "Could not find tab for id"
 msgstr "Невозможно найти закладку для id"
 
-#: ../src/gtk/notifmsg.cpp:108
-msgid "Could not initalize libnotify."
-msgstr "Не удалось инициализировать libnotify."
-
-#: ../src/html/chm.cpp:444
+#: ../src/html/chm.cpp:437
 #, c-format
 msgid "Could not locate file '%s'."
 msgstr "Невозможно найти файл '%s'."
 
-#: ../src/common/filefn.cpp:1403
+#: ../src/msw/graphicsd2d.cpp:604
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/common/filefn.cpp:1291
 msgid "Could not set current working directory"
 msgstr "Не удалось установить текущий рабочий каталог"
 
-#: ../src/common/prntbase.cpp:2015
+#: ../src/common/prntbase.cpp:2037
 msgid "Could not start document preview."
 msgstr "Невозможно начать предпросмотр документа."
 
-#: ../src/generic/printps.cpp:178 ../src/msw/printwin.cpp:210
-#: ../src/gtk/print.cpp:1132
+#: ../src/generic/printps.cpp:159 ../src/msw/printwin.cpp:184
+#: ../src/gtk/print.cpp:1129
 msgid "Could not start printing."
 msgstr "Невозможно начать печать."
 
-#: ../src/common/wincmn.cpp:2125
+#: ../src/common/wincmn.cpp:2126
 msgid "Could not transfer data to window"
 msgstr "Невозможно передать данные в окно"
 
-#: ../src/msw/imaglist.cpp:187 ../src/msw/imaglist.cpp:224 ../src/msw/imaglist.cpp:249
-#: ../src/msw/dragimag.cpp:185 ../src/msw/dragimag.cpp:220
+#: ../src/msw/imaglist.cpp:223 ../src/msw/imaglist.cpp:245
+#: ../src/msw/imaglist.cpp:270 ../src/msw/dragimag.cpp:182
+#: ../src/msw/dragimag.cpp:217
 msgid "Couldn't add an image to the image list."
 msgstr "Невозможно добавить изображение в список изображений."
 
-#: ../src/osx/glcanvas_osx.cpp:414 ../src/unix/glx11.cpp:558
-#: ../src/msw/glcanvas.cpp:616
+#: ../src/osx/glcanvas_osx.cpp:411 ../src/msw/glcanvas.cpp:631
+#: ../src/unix/glegl.cpp:315 ../src/unix/glx11.cpp:559
 msgid "Couldn't create OpenGL context"
 msgstr "Не удалось создать контекст OpenGL"
 
-#: ../src/msw/timer.cpp:134
+#: ../src/msw/timer.cpp:131
 msgid "Couldn't create a timer"
 msgstr "Невозможно создать таймер"
 
-#: ../src/osx/carbon/overlay.cpp:122
-msgid "Couldn't create the overlay window"
-msgstr "Не удалось создать перекрывающееся окно"
-
-#: ../src/common/translation.cpp:2024
+#: ../src/common/translation.cpp:2074
 msgid "Couldn't enumerate translations"
 msgstr "Не удалось перечислить переводы"
 
-#: ../src/common/dynlib.cpp:120
+#: ../src/common/dynlib.cpp:110
 #, c-format
 msgid "Couldn't find symbol '%s' in a dynamic library"
 msgstr "Невозможно найти символ '%s' в динамической библиотеке"
 
-#: ../src/msw/thread.cpp:915
+#: ../src/msw/thread.cpp:921
 msgid "Couldn't get the current thread pointer"
 msgstr "Невозможно получить указатель на текущий поток"
 
-#: ../src/osx/carbon/overlay.cpp:129
-msgid "Couldn't init the context on the overlay window"
-msgstr "Не удалось инициализировать контекст в перекрывающемся окне"
-
-#: ../src/common/imaggif.cpp:244
+#: ../src/common/imaggif.cpp:241
 msgid "Couldn't initialize GIF hash table."
 msgstr "Не удалось инициализировать хэш-таблицу GIF."
 
-#: ../src/common/imagpng.cpp:409
+#: ../src/common/imagpng.cpp:437
 msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
 msgstr ""
-"Невозможно загрузить изображение PNG - возможно повреждён файл или недостаточно "
-"памяти."
+"Невозможно загрузить изображение PNG - возможно повреждён файл или "
+"недостаточно памяти."
 
-#: ../src/unix/sound.cpp:470
+#: ../src/unix/sound.cpp:459
 #, c-format
 msgid "Couldn't load sound data from '%s'."
 msgstr "Невозможно загрузить звуковые данные из '%s'."
 
-#: ../src/msw/dirdlg.cpp:435
+#: ../src/msw/dirdlg.cpp:287
 msgid "Couldn't obtain folder name"
 msgstr "Не удалось получить имя папки"
 
-#: ../src/unix/sound_sdl.cpp:229
+#: ../src/unix/sound_sdl.cpp:226
 #, c-format
 msgid "Couldn't open audio: %s"
 msgstr "Невозможно открыть аудио: %s"
 
-#: ../src/msw/ole/dataobj.cpp:377
+#: ../src/msw/ole/dataobj.cpp:385
 #, c-format
 msgid "Couldn't register clipboard format '%s'."
 msgstr "Невозможно зарегистрировать формат буфера обмена '%s'."
 
-#: ../src/msw/listctrl.cpp:869
+#: ../src/msw/listctrl.cpp:933
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "Невозможно получить информацию об элементе списка %d."
 
-#: ../src/common/imagpng.cpp:498 ../src/common/imagpng.cpp:509
-#: ../src/common/imagpng.cpp:519
+#: ../src/common/imagpng.cpp:511 ../src/common/imagpng.cpp:522
+#: ../src/common/imagpng.cpp:532
 msgid "Couldn't save PNG image."
 msgstr "Невозможно сохранить изображение PNG."
 
-#: ../src/msw/thread.cpp:684
+#: ../src/msw/thread.cpp:676
 msgid "Couldn't terminate thread"
 msgstr "Не могу завершить поток"
 
-#: ../src/common/xtistrm.cpp:166
+#: ../src/common/xtistrm.cpp:163
 #, c-format
 msgid "Create Parameter %s not found in declared RTTI Parameters"
 msgstr "Параметр создания %s не найден в объявленных параметрах RTTI"
 
-#: ../src/generic/dirdlgg.cpp:288
+#: ../src/generic/dirdlgg.cpp:285
 msgid "Create directory"
 msgstr "Создать каталог"
 
-#: ../src/generic/filedlgg.cpp:212 ../src/generic/dirdlgg.cpp:111
+#: ../src/generic/filedlgg.cpp:209 ../src/generic/dirdlgg.cpp:108
 msgid "Create new directory"
 msgstr "Создать новый каталог"
 
-#: ../src/xrc/xmlres.cpp:2460
+#: ../src/common/stockitem.cpp:264
+#, fuzzy
+msgid "Create new document"
+msgstr "Создать новый каталог"
+
+#: ../src/xrc/xmlres.cpp:2515
 #, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Не удалось создать '%s' в '%s'."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1758
+#: ../src/propgrid/advprops.cpp:1659
 msgid "Cross"
 msgstr "Через"
 
-#: ../src/common/accelcmn.cpp:333
+#: ../src/common/accelcmn.cpp:347
 msgid "Ctrl+"
 msgstr "Ctrl+"
 
-#: ../src/richtext/richtextctrl.cpp:332 ../src/osx/textctrl_osx.cpp:576
-#: ../src/common/stockitem.cpp:151 ../src/msw/textctrl.cpp:2507
+#: ../src/osx/textctrl_osx.cpp:594 ../src/common/stockitem.cpp:148
+#: ../src/msw/textctrl.cpp:2772 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "&Вырезать"
 
-#: ../src/generic/filectrlg.cpp:940
+#: ../src/generic/filectrlg.cpp:936
 msgid "Current directory:"
 msgstr "Текущий каталог:"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:896 ../src/propgrid/advprops.cpp:1574
-#: ../src/propgrid/advprops.cpp:1612
+#: ../src/propgrid/advprops.cpp:797 ../src/propgrid/advprops.cpp:1475
+#: ../src/propgrid/advprops.cpp:1518
 msgid "Custom"
 msgstr "Задать"
 
-#: ../src/gtk/print.cpp:217
+#: ../src/gtk/print.cpp:211
 msgid "Custom size"
 msgstr "Задать размер"
 
-#: ../src/common/headerctrlcmn.cpp:60
+#: ../src/common/headerctrlcmn.cpp:58
 msgid "Customize Columns"
 msgstr "Настроить столбцы"
 
-#: ../src/common/stockitem.cpp:151 ../src/stc/stc_i18n.cpp:17
+#: ../src/common/stockitem.cpp:148 ../src/stc/stc_i18n.cpp:17
 msgid "Cut"
 msgstr "Вырезать"
 
-#: ../src/common/stockitem.cpp:259
+#: ../src/common/stockitem.cpp:256
 msgid "Cut selection"
 msgstr "Вырезать выделение"
 
-#: ../src/common/fmapbase.cpp:152
+#: ../src/common/fmapbase.cpp:149
 msgid "Cyrillic (ISO-8859-5)"
 msgstr "Кириллица (ISO-8859-5)"
 
-#: ../src/common/paper.cpp:99
+#: ../src/common/paper.cpp:96
 msgid "D sheet, 22 x 34 in"
 msgstr "Лист D, 22 x 34 дюйма"
 
-#: ../src/msw/dde.cpp:703
+#: ../src/msw/dde.cpp:698
 msgid "DDE poke request failed"
 msgstr "Ошибка запроса DDE poke"
 
-#: ../src/common/imagbmp.cpp:1169
+#: ../src/common/imagbmp.cpp:1181
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr "Заголовок DIB: кодировка не совпадает с битовойглубиной."
 
@@ -2537,7 +2595,7 @@ msgstr "Заголовок DIB: неизвестная битовая глуби
 msgid "DIB Header: Unknown encoding in file."
 msgstr "Заголовок DIB: неизвестная кодировка файла."
 
-#: ../src/common/paper.cpp:121
+#: ../src/common/paper.cpp:118
 msgid "DL Envelope, 110 x 220 mm"
 msgstr "Конверт DL, 110 x 220 мм"
 
@@ -2545,53 +2603,53 @@ msgstr "Конверт DL, 110 x 220 мм"
 msgid "Dashed"
 msgstr "Пунктирная"
 
-#: ../src/generic/dbgrptg.cpp:300
+#: ../src/generic/dbgrptg.cpp:301
 #, c-format
 msgid "Debug report \"%s\""
 msgstr "Отчёт об отладке \"%s\""
 
-#: ../src/common/debugrpt.cpp:210
+#: ../src/common/debugrpt.cpp:211
 msgid "Debug report couldn't be created."
 msgstr "Отчёт об отладке не может быть создан."
 
-#: ../src/common/debugrpt.cpp:553
+#: ../src/common/debugrpt.cpp:554
 msgid "Debug report generation has failed."
 msgstr "Создание отчёта завершилось с ошибкой."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:84
+#: ../src/common/accelcmn.cpp:81
 msgid "Decimal"
 msgstr "Десятичная дробь"
 
-#: ../src/generic/fontdlgg.cpp:323
+#: ../src/generic/fontdlgg.cpp:319
 msgid "Decorative"
 msgstr "Декоративный"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1752
+#: ../src/propgrid/advprops.cpp:1653
 msgid "Default"
 msgstr "По умолчанию"
 
-#: ../src/common/fmapbase.cpp:796
+#: ../src/common/fmapbase.cpp:792
 msgid "Default encoding"
 msgstr "Кодировка по-умолчанию"
 
-#: ../src/dfb/fontmgr.cpp:180
+#: ../src/dfb/fontmgr.cpp:177
 msgid "Default font"
 msgstr "Шрифт по умолчанию"
 
-#: ../src/generic/prntdlgg.cpp:510
+#: ../src/generic/prntdlgg.cpp:503
 msgid "Default printer"
 msgstr "Принтер по-умолчанию"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:51
+#: ../src/common/accelcmn.cpp:48
 msgid "Del"
 msgstr "Del"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextbuffer.cpp:8221 ../src/common/stockitem.cpp:152
-#: ../src/common/accelcmn.cpp:50 ../src/stc/stc_i18n.cpp:20
+#: ../src/common/stockitem.cpp:149 ../src/common/accelcmn.cpp:47
+#: ../src/richtext/richtextbuffer.cpp:8217 ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Удалить"
 
@@ -2599,80 +2657,80 @@ msgstr "Удалить"
 msgid "Delete A&ll"
 msgstr "Удалить вс&ё"
 
-#: ../src/richtext/richtextbuffer.cpp:11341
+#: ../src/richtext/richtextbuffer.cpp:11340
 msgid "Delete Column"
 msgstr "Удалить колонку"
 
-#: ../src/richtext/richtextbuffer.cpp:11291
+#: ../src/richtext/richtextbuffer.cpp:11290
 msgid "Delete Row"
 msgstr "Удалить строку"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 msgid "Delete Style"
 msgstr "Удалить стиль"
 
-#: ../src/richtext/richtextctrl.cpp:1345 ../src/richtext/richtextctrl.cpp:1584
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
 msgid "Delete Text"
 msgstr "Удалить текст"
 
-#: ../src/generic/editlbox.cpp:170
+#: ../src/generic/editlbox.cpp:147
 msgid "Delete item"
 msgstr "Удалить элемент"
 
-#: ../src/common/stockitem.cpp:260
+#: ../src/common/stockitem.cpp:257
 msgid "Delete selection"
 msgstr "Удалить выделение"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 #, c-format
 msgid "Delete style %s?"
 msgstr "Удалить стиль %s?"
 
-#: ../src/unix/snglinst.cpp:301
+#: ../src/unix/snglinst.cpp:298
 #, c-format
 msgid "Deleted stale lock file '%s'."
 msgstr "Удалён старый файл блокировки '%s'."
 
-#: ../src/common/secretstore.cpp:220
-#, c-format
-msgid "Deleting password for \"%s/%s\" failed: %s."
+#: ../src/common/secretstore.cpp:234
+#, fuzzy, c-format
+msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Не удалось удалить пароль для  '%s/%s': %s."
 
-#: ../src/common/module.cpp:124
+#: ../src/common/module.cpp:121
 #, c-format
 msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
 msgstr "Зависимость \"%s\" модуль \"%s\" не существует."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "Descending"
 msgstr "По убыванию"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:526 ../src/propgrid/advprops.cpp:882
+#: ../src/generic/dirctrlg.cpp:492 ../src/propgrid/advprops.cpp:783
 msgid "Desktop"
 msgstr "Рабочий стол"
 
-#: ../src/generic/aboutdlgg.cpp:70
+#: ../src/generic/aboutdlgg.cpp:67
 msgid "Developed by "
 msgstr "Разработка "
 
-#: ../src/generic/aboutdlgg.cpp:176
+#: ../src/generic/aboutdlgg.cpp:173
 msgid "Developers"
 msgstr "Разработчики"
 
-#: ../src/msw/dialup.cpp:374
+#: ../src/msw/dialup.cpp:368
 msgid ""
-"Dial up functions are unavailable because the remote access service (RAS) is not "
-"installed on this machine. Please install it."
+"Dial up functions are unavailable because the remote access service (RAS) is "
+"not installed on this machine. Please install it."
 msgstr ""
 "Функции набора номера недоступны, так как сервис удалённого доступа (RAS) не "
 "установлен на этой машине. Установите его."
 
-#: ../src/generic/tipdlg.cpp:211
+#: ../src/generic/tipdlg.cpp:208
 msgid "Did you know..."
 msgstr "А вы знаете, что..."
 
-#: ../src/dfb/wrapdfb.cpp:63
+#: ../src/dfb/wrapdfb.cpp:60
 #, c-format
 msgid "DirectFB error %d occurred."
 msgstr "Ошибка DirectFB % d."
@@ -2681,74 +2739,75 @@ msgstr "Ошибка DirectFB % d."
 msgid "Directories"
 msgstr "Каталоги"
 
-#: ../src/common/filefn.cpp:1183
+#: ../src/common/filefn.cpp:1071
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Не удалось создать каталог  '%s'"
 
-#: ../src/common/filefn.cpp:1197
+#: ../src/common/filefn.cpp:1085
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "Не удалось удалить каталог  '%s'"
 
-#: ../src/generic/dirdlgg.cpp:204
+#: ../src/generic/dirdlgg.cpp:201
 msgid "Directory does not exist"
 msgstr "Каталог не существует"
 
-#: ../src/generic/filectrlg.cpp:1399
+#: ../src/generic/filectrlg.cpp:1388
 msgid "Directory doesn't exist."
 msgstr "Каталог не существует."
 
-#: ../src/common/docview.cpp:457
+#: ../src/common/docview.cpp:450
 msgid "Discard changes and reload the last saved version?"
 msgstr "Отменить изменения и загрузить повторно последнюю сохранённую версию?"
 
-#: ../src/html/helpwnd.cpp:502
+#: ../src/html/helpwnd.cpp:500
 msgid ""
-"Display all index items that contain given substring. Search is case insensitive."
+"Display all index items that contain given substring. Search is case "
+"insensitive."
 msgstr ""
 "Показать все элементы индекса с заданной подстрокой. При поиске регистр не "
 "учитывается."
 
-#: ../src/html/helpwnd.cpp:679
+#: ../src/html/helpwnd.cpp:677
 msgid "Display options dialog"
 msgstr "Открыть диалог настройки параметров"
 
-#: ../src/html/helpwnd.cpp:322
+#: ../src/html/helpwnd.cpp:320
 msgid "Displays help as you browse the books on the left."
 msgstr "Отображает справку при просмотре книг слева."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:85
+#: ../src/common/accelcmn.cpp:83
 msgid "Divide"
 msgstr "Разделить"
 
-#: ../src/common/docview.cpp:533
+#: ../src/common/docview.cpp:526
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Сохранить изменения в %s?"
 
-#: ../src/common/prntbase.cpp:542
+#: ../src/common/prntbase.cpp:537
 msgid "Document:"
 msgstr "Документ:"
 
-#: ../src/generic/aboutdlgg.cpp:73
+#: ../src/generic/aboutdlgg.cpp:70
 msgid "Documentation by "
 msgstr "Документацию по "
 
-#: ../src/generic/aboutdlgg.cpp:180
+#: ../src/generic/aboutdlgg.cpp:177
 msgid "Documentation writers"
 msgstr "Авторы документации"
 
-#: ../src/common/sizer.cpp:2799
+#: ../src/common/sizer.cpp:2916
 msgid "Don't Save"
 msgstr "Не сохранять"
 
-#: ../src/html/htmlwin.cpp:633
+#: ../src/html/htmlwin.cpp:643
 msgid "Done"
 msgstr "Готово"
 
-#: ../src/generic/progdlgg.cpp:448 ../src/msw/progdlg.cpp:407
+#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
 msgid "Done."
 msgstr "Готово."
 
@@ -2760,67 +2819,74 @@ msgstr "Точечная"
 msgid "Double"
 msgstr "Двойная"
 
-#: ../src/common/paper.cpp:176
+#: ../src/common/paper.cpp:173
 msgid "Double Japanese Postcard Rotated 148 x 200 mm"
 msgstr "Двухместный японская Открытка Повёрнута 148 x 200 мм"
 
-#: ../src/common/xtixml.cpp:273
+#: ../src/common/xtixml.cpp:269
 #, c-format
 msgid "Doubly used id : %d"
 msgstr "Повторно используемый id : %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:153
-#: ../src/common/accelcmn.cpp:64
+#: ../src/common/stockitem.cpp:150 ../src/common/accelcmn.cpp:61
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Down"
 msgstr "Вниз"
 
-#: ../src/richtext/richtextctrl.cpp:865
+#: ../src/richtext/richtextctrl.cpp:864
 msgid "Drag"
 msgstr "Перетащить"
 
-#: ../src/common/paper.cpp:100
+#: ../src/common/paper.cpp:97
 msgid "E sheet, 34 x 44 in"
 msgstr "Лист E, 34 x 44 дюйма"
 
-#: ../src/unix/fswatcher_inotify.cpp:561
+#: ../src/unix/fswatcher_inotify.cpp:558
 msgid "EOF while reading from inotify descriptor"
 msgstr "EOF при чтении из дескриптора inotify"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "Edit"
 msgstr "Правка"
 
-#: ../src/generic/editlbox.cpp:168
+#: ../src/generic/editlbox.cpp:131
 msgid "Edit item"
 msgstr "Правка элемента"
 
-#: ../include/wx/generic/progdlgg.h:84
+#: ../include/wx/generic/progdlgg.h:85
 msgid "Elapsed time:"
 msgstr "Прошло времени:"
 
-#: ../src/richtext/richtextsizepage.cpp:353 ../src/richtext/richtextsizepage.cpp:355
-#: ../src/richtext/richtextsizepage.cpp:465 ../src/richtext/richtextsizepage.cpp:467
+#: ../src/richtext/richtextsizepage.cpp:353
+#: ../src/richtext/richtextsizepage.cpp:355
+#: ../src/richtext/richtextsizepage.cpp:465
+#: ../src/richtext/richtextsizepage.cpp:467
 msgid "Enable the height value."
 msgstr "Включите значение высоты."
 
-#: ../src/richtext/richtextsizepage.cpp:438 ../src/richtext/richtextsizepage.cpp:440
+#: ../src/richtext/richtextsizepage.cpp:438
+#: ../src/richtext/richtextsizepage.cpp:440
 msgid "Enable the maximum width value."
 msgstr "Включить максимальное значение ширины."
 
-#: ../src/richtext/richtextsizepage.cpp:411 ../src/richtext/richtextsizepage.cpp:413
+#: ../src/richtext/richtextsizepage.cpp:411
+#: ../src/richtext/richtextsizepage.cpp:413
 msgid "Enable the minimum height value."
 msgstr "Включить минимальное значение высоты."
 
-#: ../src/richtext/richtextsizepage.cpp:384 ../src/richtext/richtextsizepage.cpp:386
+#: ../src/richtext/richtextsizepage.cpp:384
+#: ../src/richtext/richtextsizepage.cpp:386
 msgid "Enable the minimum width value."
 msgstr "Включить минимальное значение ширины."
 
-#: ../src/richtext/richtextsizepage.cpp:319 ../src/richtext/richtextsizepage.cpp:321
+#: ../src/richtext/richtextsizepage.cpp:319
+#: ../src/richtext/richtextsizepage.cpp:321
 msgid "Enable the width value."
 msgstr "Включить значение ширины."
 
-#: ../src/richtext/richtextsizepage.cpp:280 ../src/richtext/richtextsizepage.cpp:282
+#: ../src/richtext/richtextsizepage.cpp:280
+#: ../src/richtext/richtextsizepage.cpp:282
 msgid "Enable vertical alignment."
 msgstr "Включить выравнивание по вертикали."
 
@@ -2855,60 +2921,62 @@ msgid "Enables the shadow spread."
 msgstr "Включает разброс тени."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:66
+#: ../src/common/accelcmn.cpp:63
 msgid "End"
 msgstr "END"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:55
+#: ../src/common/accelcmn.cpp:52
 msgid "Enter"
 msgstr "Enter"
 
-#: ../src/richtext/richtextstyledlg.cpp:934
+#: ../src/richtext/richtextstyledlg.cpp:930
 msgid "Enter a box style name"
 msgstr "Введите в поле имя стиля"
 
-#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:602
 msgid "Enter a character style name"
 msgstr "Ввод символа с именем стиля"
 
-#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:816
 msgid "Enter a list style name"
 msgstr "Ввод списка имя стиля"
 
-#: ../src/richtext/richtextstyledlg.cpp:893
+#: ../src/richtext/richtextstyledlg.cpp:889
 msgid "Enter a new style name"
 msgstr "Введите имя нового стиля"
 
-#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:650
 msgid "Enter a paragraph style name"
 msgstr "Введите имя стиля абзаца"
 
-#: ../src/generic/dbgrptg.cpp:174
+#: ../src/generic/dbgrptg.cpp:171
 #, c-format
 msgid "Enter command to open file \"%s\":"
 msgstr "Введите команду для открытия файла \"%s\":"
 
-#: ../src/generic/helpext.cpp:459
+#: ../src/generic/helpext.cpp:457
 msgid "Entries found"
 msgstr "Найдено записей"
 
-#: ../src/common/paper.cpp:142
+#: ../src/common/paper.cpp:139
 msgid "Envelope Invite 220 x 220 mm"
 msgstr "Конверт приглашение 220 x 220 мм"
 
-#: ../src/common/config.cpp:469
+#: ../src/common/config.cpp:465
 #, c-format
-msgid "Environment variables expansion failed: missing '%c' at position %u in '%s'."
-msgstr "Ошибка расширения переменных окружения: отсутствует '%c' в позиции %u в '%s'."
+msgid ""
+"Environment variables expansion failed: missing '%c' at position %u in '%s'."
+msgstr ""
+"Ошибка расширения переменных окружения: отсутствует '%c' в позиции %u в '%s'."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/generic/dirctrlg.cpp:570
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/dirctrlg.cpp:599
-#: ../src/generic/dirdlgg.cpp:323 ../src/generic/filectrlg.cpp:642
-#: ../src/generic/filectrlg.cpp:756 ../src/generic/filectrlg.cpp:770
-#: ../src/generic/filectrlg.cpp:786 ../src/generic/filectrlg.cpp:1368
-#: ../src/generic/filectrlg.cpp:1399 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/gtk1/fontdlg.cpp:74 ../src/generic/dirctrlg.cpp:536
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/dirctrlg.cpp:565
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1357 ../src/generic/filectrlg.cpp:1388
+#: ../src/generic/filedlgg.cpp:354 ../src/generic/dirdlgg.cpp:320
+#: ../src/gtk/filedlg.cpp:74
 msgid "Error"
 msgstr "Ошибка"
 
@@ -2916,231 +2984,254 @@ msgstr "Ошибка"
 msgid "Error closing epoll descriptor"
 msgstr "Ошибка при закрытии epoll дескриптора"
 
-#: ../src/unix/fswatcher_kqueue.cpp:114
+#: ../src/unix/fswatcher_kqueue.cpp:131
 msgid "Error closing kqueue instance"
 msgstr "Ошибка при закрытии экземпляра kqueue"
 
-#: ../src/common/filefn.cpp:1049
+#: ../src/common/filefn.cpp:938
 #, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Ошибка копирования файла '%s' в '%s'."
 
-#: ../src/generic/dirdlgg.cpp:222
+#: ../src/generic/dirdlgg.cpp:219
 msgid "Error creating directory"
 msgstr "Ошибка создания каталога"
 
-#: ../src/common/imagbmp.cpp:1181
+#: ../src/common/imagbmp.cpp:1193
 msgid "Error in reading image DIB."
 msgstr "Ошибка при чтении изображения DIB."
 
-#: ../src/propgrid/propgrid.cpp:6696
+#: ../src/propgrid/propgrid.cpp:6665
 #, c-format
 msgid "Error in resource: %s"
 msgstr "Ошибка в ресурс: %s"
 
-#: ../src/common/fileconf.cpp:422
+#: ../src/common/fileconf.cpp:421
 msgid "Error reading config options."
 msgstr "Ошибка чтения параметров настройки."
+
+#: ../src/msw/webview_ie.cpp:1057 ../src/msw/webview_edge.cpp:850
+#: ../src/gtk/webview_webkit2.cpp:1262 ../src/osx/webview_webkit.mm:383
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
 
 #: ../src/common/fileconf.cpp:1029
 msgid "Error saving user configuration data."
 msgstr "Ошибка сохранения данных конфигурации пользователя."
 
-#: ../src/gtk/print.cpp:722
+#: ../src/gtk/print.cpp:720
 msgid "Error while printing: "
 msgstr "Ошибка при печати: "
 
-#: ../src/common/log.cpp:219
+#: ../src/common/log.cpp:237
 msgid "Error: "
 msgstr "Ошибка: "
 
+#: ../src/common/webrequest.cpp:98
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Ошибка: "
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:69
+#: ../src/common/accelcmn.cpp:66
 msgid "Esc"
 msgstr "ESC"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:70
+#: ../src/common/accelcmn.cpp:67
 msgid "Escape"
 msgstr "ESCAPE"
 
-#: ../src/common/fmapbase.cpp:150
+#: ../src/common/fmapbase.cpp:147
 msgid "Esperanto (ISO-8859-3)"
 msgstr "Эсперанто (ISO-8859-3)"
 
-#: ../include/wx/generic/progdlgg.h:85
+#: ../include/wx/generic/progdlgg.h:86
 msgid "Estimated time:"
 msgstr "Расчётное время:"
 
-#: ../src/generic/dbgrptg.cpp:234
+#: ../src/generic/dbgrptg.cpp:231
 msgid "Executable files (*.exe)|*.exe|"
 msgstr "Исполняемые файлы (*.exe)|*.exe"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:155 ../src/common/accelcmn.cpp:78
+#: ../src/common/stockitem.cpp:152 ../src/common/accelcmn.cpp:75
 msgid "Execute"
 msgstr "Выполнить"
 
-#: ../src/msw/utilsexc.cpp:876
+#: ../src/msw/utilsexc.cpp:873
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Ошибка выполнения команды '%s'"
 
-#: ../src/common/paper.cpp:105
+#: ../src/common/paper.cpp:102
 msgid "Executive, 7 1/4 x 10 1/2 in"
 msgstr "Исполнительный, 7 1/4 x 10 1/2 дюйма"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6009
+#: ../src/generic/datavgen.cpp:6814
 msgid "Expand"
 msgstr "Расширить"
 
-#: ../src/msw/registry.cpp:1240
+#: ../src/msw/registry.cpp:1228
 #, c-format
-msgid "Exporting registry key: file \"%s\" already exists and won't be overwritten."
-msgstr "Экспорт ключа реестра: файл '%s' уже существует и не будет перезаписан."
+msgid ""
+"Exporting registry key: file \"%s\" already exists and won't be overwritten."
+msgstr ""
+"Экспорт ключа реестра: файл '%s' уже существует и не будет перезаписан."
 
-#: ../src/common/fmapbase.cpp:195
+#: ../src/common/fmapbase.cpp:192
 msgid "Extended Unix Codepage for Japanese (EUC-JP)"
 msgstr "Расширенная кодировка Unix для Японского (EUC-JP)"
 
-#: ../src/html/chm.cpp:725
+#: ../src/html/chm.cpp:718
 #, c-format
 msgid "Extraction of '%s' into '%s' failed."
 msgstr "Извлечение '%s' в '%s' завершилось неудачно."
 
-#: ../src/common/accelcmn.cpp:249 ../src/common/accelcmn.cpp:344
+#: ../src/common/accelcmn.cpp:259 ../src/common/accelcmn.cpp:358
 msgid "F"
 msgstr "F"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:672
+#: ../src/propgrid/advprops.cpp:582
 msgid "Face Name"
 msgstr "Название семейства"
 
-#: ../src/unix/snglinst.cpp:269
+#: ../src/unix/snglinst.cpp:266
 msgid "Failed to access lock file."
 msgstr "Не удалось обратиться к файлу блокировки."
+
+#: ../src/gtk/font.cpp:572
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Не удалось прочесть документ из файла \"%s\"."
 
 #: ../src/unix/epolldispatcher.cpp:116
 #, c-format
 msgid "Failed to add descriptor %d to epoll descriptor %d"
 msgstr "Не удалось добавить дескриптор %d в epoll дескриптор %d"
 
-#: ../src/msw/dib.cpp:489
+#: ../src/msw/dib.cpp:535
 #, c-format
 msgid "Failed to allocate %luKb of memory for bitmap data."
 msgstr "Не удалось выделить %lu Кб памяти для растровых данных."
 
-#: ../src/common/glcmn.cpp:115
+#: ../src/common/glcmn.cpp:112
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Не удалось разместить цвет для OpenGL"
 
-#: ../src/unix/displayx11.cpp:236
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Не удалось разместить цвет для OpenGL"
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Не удалось разместить цвет для OpenGL"
+
+#: ../include/wx/unix/private/displayx11.h:89
 msgid "Failed to change video mode"
 msgstr "Не удалось изменить видео-режим"
 
-#: ../src/common/image.cpp:3277
+#: ../src/common/image.cpp:3396
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Не удалось проверить Формат файла изображения \"%s'."
 
-#: ../src/common/debugrpt.cpp:239
+#: ../src/common/debugrpt.cpp:240
 #, c-format
 msgid "Failed to clean up debug report directory \"%s\""
 msgstr "Ошибка очистки каталога отчёта об отладке \"%s\""
 
-#: ../src/common/filename.cpp:192
+#: ../src/common/filename.cpp:189
 msgid "Failed to close file handle"
 msgstr "Не удалось закрыть дескриптор файла"
 
-#: ../src/unix/snglinst.cpp:340
+#: ../src/unix/snglinst.cpp:337
 #, c-format
 msgid "Failed to close lock file '%s'"
 msgstr "Ошибка закрытия файла блокировки '%s'"
 
-#: ../src/msw/clipbrd.cpp:112
+#: ../src/msw/clipbrd.cpp:110
 msgid "Failed to close the clipboard."
 msgstr "Не удалось закрыть буфер обмена."
 
-#: ../src/x11/utils.cpp:208
+#: ../src/x11/utils.cpp:170
 #, c-format
 msgid "Failed to close the display \"%s\""
 msgstr "Не удалось закрыть дисплей \"%s\""
 
-#: ../src/msw/dialup.cpp:797
+#: ../src/msw/dialup.cpp:791
 msgid "Failed to connect: missing username/password."
 msgstr "Невозможно подключиться: отсутствует имя/пароль."
 
-#: ../src/msw/dialup.cpp:743
+#: ../src/msw/dialup.cpp:737
 msgid "Failed to connect: no ISP to dial."
 msgstr "Невозможно подключиться: нет ISP для набора номера."
 
-#: ../src/common/textfile.cpp:203
-#, c-format
-msgid "Failed to convert file \"%s\" to Unicode."
-msgstr "Не удалось преобразовать файл \"%s\" в Unicode."
-
-#: ../src/generic/logg.cpp:956
+#: ../src/generic/logg.cpp:953
 msgid "Failed to copy dialog contents to the clipboard."
 msgstr "Не удалось скопировать содержимое диалога в буфер обмена."
 
-#: ../src/msw/registry.cpp:692
+#: ../src/msw/registry.cpp:681
 #, c-format
 msgid "Failed to copy registry value '%s'"
 msgstr "Невозможно скопировать значение реестра '%s'"
 
-#: ../src/msw/registry.cpp:701
+#: ../src/msw/registry.cpp:690
 #, c-format
 msgid "Failed to copy the contents of registry key '%s' to '%s'."
 msgstr "Невозможно копировать содержимое ключа реестра '%s' в '%s'."
 
-#: ../src/common/filefn.cpp:1015
+#: ../src/common/filefn.cpp:904
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Сбой копирования файла '%s' в '%s'."
 
-#: ../src/msw/registry.cpp:679
+#: ../src/msw/registry.cpp:668
 #, c-format
 msgid "Failed to copy the registry subkey '%s' to '%s'."
 msgstr "Невозможно скопировать подключ реестра '%s' в '%s."
 
-#: ../src/msw/dde.cpp:1070
+#: ../src/msw/dde.cpp:1134
 msgid "Failed to create DDE string"
 msgstr "Ошибка создания строки DDE"
 
-#: ../src/msw/mdi.cpp:616
+#: ../src/msw/mdi.cpp:621
 msgid "Failed to create MDI parent frame."
 msgstr "Ошибка создания родительского фрейма MDI."
 
-#: ../src/common/filename.cpp:1027
+#: ../src/common/filename.cpp:1024
 msgid "Failed to create a temporary file name"
 msgstr "Сбой формирования имени временного файла"
 
-#: ../src/msw/utilsexc.cpp:228
+#: ../src/msw/utilsexc.cpp:225
 msgid "Failed to create an anonymous pipe"
 msgstr "Ошибка при создании anonymous pipe"
 
-#: ../src/msw/ole/automtn.cpp:522
+#: ../src/msw/ole/automtn.cpp:513
 #, c-format
 msgid "Failed to create an instance of \"%s\""
 msgstr "Ошибка создания экземпляра  '%s'"
 
-#: ../src/msw/dde.cpp:437
+#: ../src/msw/dde.cpp:432
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "Невозможно создать подключение к серверу '%s' по теме '%s'"
 
-#: ../src/msw/cursor.cpp:204
+#: ../src/msw/cursor.cpp:195
 msgid "Failed to create cursor."
 msgstr "Ошибка создания курсора."
 
-#: ../src/common/debugrpt.cpp:209
+#: ../src/common/debugrpt.cpp:210
 #, c-format
 msgid "Failed to create directory \"%s\""
 msgstr "Ошибка создания каталога \"%s\""
 
-#: ../src/generic/dirdlgg.cpp:220
+#: ../src/generic/dirdlgg.cpp:217
 #, c-format
 msgid ""
 "Failed to create directory '%s'\n"
@@ -3153,185 +3244,205 @@ msgstr ""
 msgid "Failed to create epoll descriptor"
 msgstr "Не удалось создать дескриптор epoll"
 
-#: ../src/msw/mimetype.cpp:238
+#: ../src/gtk/font.cpp:562
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "Не удалось обновить пользовательский файл конфигурации."
+
+#: ../src/msw/mimetype.cpp:235
 #, c-format
 msgid "Failed to create registry entry for '%s' files."
 msgstr "Невозможно создать элемент реестра для '%s' файлов."
 
-#: ../src/msw/fdrepdlg.cpp:409
+#: ../src/msw/fdrepdlg.cpp:408
 #, c-format
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr "Невозможно создать стандартный диалог поиска/замены (код ошибки %d)"
 
-#: ../src/unix/wakeuppipe.cpp:52
+#: ../src/unix/wakeuppipe.cpp:49
 msgid "Failed to create wake up pipe used by event loop."
 msgstr "Не удалось создать канал пробуждения, используемый циклом событий."
 
-#: ../src/html/winpars.cpp:730
+#: ../src/html/winpars.cpp:727
 #, c-format
 msgid "Failed to display HTML document in %s encoding"
 msgstr "Не удалось отобразить документ HTML в кодировке %s"
 
-#: ../src/msw/clipbrd.cpp:124
+#: ../src/msw/clipbrd.cpp:122
 msgid "Failed to empty the clipboard."
 msgstr "Не удалось очистить буфер обмена."
 
-#: ../src/unix/displayx11.cpp:212
+#: ../include/wx/unix/private/displayx11.h:65
 msgid "Failed to enumerate video modes"
 msgstr "Не удалось перечислить режимы видео"
 
-#: ../src/msw/dde.cpp:722
+#: ../src/msw/dde.cpp:717
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "Невозможно установить 'advise loop' с DDE сервером"
 
-#: ../src/msw/dialup.cpp:629 ../src/msw/dialup.cpp:863
+#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Невозможно установить модемное соединение: %s"
 
-#: ../src/unix/utilsunx.cpp:611
+#: ../src/unix/utilsunx.cpp:613
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Не удалось выполнить '%s'\n"
 
-#: ../src/common/debugrpt.cpp:720
+#: ../src/common/debugrpt.cpp:730
 msgid "Failed to execute curl, please install it in PATH."
 msgstr "Невозможно выполнить curl, установите его в PATH."
 
-#: ../src/msw/ole/automtn.cpp:505
+#: ../src/msw/ole/automtn.cpp:496
 #, c-format
 msgid "Failed to find CLSID of \"%s\""
 msgstr "Не удалось найти CLSID '%s'"
 
-#: ../src/common/regex.cpp:431 ../src/common/regex.cpp:479
+#: ../src/common/regex.cpp:428 ../src/common/regex.cpp:476
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "Не удалось найти соответствие для регулярного выражения: %s"
 
-#: ../src/msw/dialup.cpp:695
+#: ../src/msw/webview_ie.cpp:978
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:689
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Не удалось получить имена ISP: %s"
 
-#: ../src/msw/ole/automtn.cpp:574
+#: ../src/msw/ole/automtn.cpp:565
 #, c-format
 msgid "Failed to get OLE automation interface for \"%s\""
 msgstr "Не удалось получить интерфейс OLE-автоматизации для \" %s\""
 
-#: ../src/msw/clipbrd.cpp:711
+#: ../src/msw/clipbrd.cpp:731
 msgid "Failed to get data from the clipboard"
 msgstr "Не удалось получить данные из буфера обмена"
 
-#: ../src/common/time.cpp:223
+#: ../src/common/time.cpp:216
 msgid "Failed to get the local system time"
 msgstr "Не удалось получить локальное системное время"
 
-#: ../src/common/filefn.cpp:1345
+#: ../src/common/filefn.cpp:1233
 msgid "Failed to get the working directory"
 msgstr "Не удалось получить рабочий каталог"
 
-#: ../src/univ/theme.cpp:114
+#: ../src/univ/theme.cpp:111
 msgid "Failed to initialize GUI: no built-in themes found."
 msgstr "Ошибка при инициализации GUI: не найдено встроенных тем."
 
-#: ../src/msw/helpchm.cpp:63
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:60
 msgid "Failed to initialize MS HTML Help."
 msgstr "Ошибка инициализации справки MS HTML."
 
-#: ../src/msw/glcanvas.cpp:1381
+#: ../src/msw/glcanvas.cpp:1391
 msgid "Failed to initialize OpenGL"
 msgstr "Невозможно инициализировать OpenGL"
 
-#: ../src/msw/dialup.cpp:858
+#: ../src/msw/dialup.cpp:852
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Не удалось установить модемное соединение: %s"
 
-#: ../src/gtk/textctrl.cpp:1128
+#: ../src/gtk/textctrl.cpp:1209
 msgid "Failed to insert text in the control."
 msgstr "Не удалось вставить текст в элемент управления."
 
-#: ../src/unix/snglinst.cpp:241
+#: ../src/unix/snglinst.cpp:238
 #, c-format
 msgid "Failed to inspect the lock file '%s'"
 msgstr "Ошибка проверки файла блокировки '%s'"
 
-#: ../src/unix/appunix.cpp:182
+#: ../src/unix/appunix.cpp:179
 msgid "Failed to install signal handler"
 msgstr "Не удалось установить обработчик сигнала"
 
-#: ../src/unix/threadpsx.cpp:1167
+#: ../src/unix/threadpsx.cpp:1216
 msgid ""
-"Failed to join a thread, potential memory leak detected - please restart the program"
+"Failed to join a thread, potential memory leak detected - please restart the "
+"program"
 msgstr ""
 "Не удалось соединиться с потоком, обнаружена потенциальная утечка памяти - "
 "перезапустите программу"
 
-#: ../src/msw/utils.cpp:629
+#: ../src/msw/utils.cpp:619
 #, c-format
 msgid "Failed to kill process %d"
 msgstr "Не удалось завершить процесс %d"
 
-#: ../src/common/image.cpp:2500
+#: ../src/common/image.cpp:2595
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Не удалось загрузить растровое изображение '%s' из ресурсов."
 
-#: ../src/common/image.cpp:2509
+#: ../src/common/image.cpp:2604
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Невозможно загрузить значок '%s' из ресурсов."
 
-#: ../src/common/iconbndl.cpp:225
+#: ../src/common/iconbndl.cpp:224
 #, c-format
 msgid "Failed to load icons from resource '%s'."
 msgstr "Не удалось загрузить значки из ресурса '%s'."
 
-#: ../src/common/iconbndl.cpp:200
+#: ../src/common/iconbndl.cpp:198
 #, c-format
 msgid "Failed to load image %%d from file '%s'."
 msgstr "Не удалось загрузить изображение %%d из файла '%s'."
 
-#: ../src/common/iconbndl.cpp:208
+#: ../src/common/iconbndl.cpp:206
 #, c-format
 msgid "Failed to load image %d from stream."
 msgstr "Не удалось загрузить изображение %d из потока."
 
-#: ../src/common/image.cpp:2587 ../src/common/image.cpp:2606
+#: ../src/common/image.cpp:2682 ../src/common/image.cpp:2701
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Не удалось загрузить изображение из файла '%s'."
 
-#: ../src/msw/enhmeta.cpp:97
+#: ../src/msw/enhmeta.cpp:94
 #, c-format
 msgid "Failed to load metafile from file \"%s\"."
 msgstr "Невозможно загрузить метафайл из файла \"%s\"."
 
-#: ../src/msw/volume.cpp:327
+#: ../src/msw/volume.cpp:335
 msgid "Failed to load mpr.dll."
 msgstr "Невозможно загрузить mpr.dll."
 
-#: ../src/msw/utils.cpp:953
+#: ../src/msw/utils.cpp:943
 #, c-format
 msgid "Failed to load resource \"%s\"."
 msgstr "Не удалось загрузить ресурс \"%s\"."
 
-#: ../src/common/dynlib.cpp:92
+#: ../src/common/dynlib.cpp:86
 #, c-format
 msgid "Failed to load shared library '%s'"
 msgstr "Ошибка загрузки разделяемой библиотеки '%s'"
 
-#: ../src/osx/core/sound.cpp:145
+#: ../src/osx/core/sound.cpp:143
 #, c-format
 msgid "Failed to load sound from \"%s\" (error %d)."
 msgstr "Не удалось загрузить звук из '%s' (ошибка %d)."
 
-#: ../src/msw/utils.cpp:960
+#: ../src/msw/utils.cpp:950
 #, c-format
 msgid "Failed to lock resource \"%s\"."
 msgstr "Не удалось заблокировать ресурс \"%s\"."
 
-#: ../src/unix/snglinst.cpp:198
+#: ../src/unix/snglinst.cpp:195
 #, c-format
 msgid "Failed to lock the lock file '%s'"
 msgstr "Ошибка блокировки файла блокировки '%s'"
@@ -3341,33 +3452,38 @@ msgstr "Ошибка блокировки файла блокировки '%s'"
 msgid "Failed to modify descriptor %d in epoll descriptor %d"
 msgstr "Не удалось изменить дескриптором %d в epoll дескриптором %d"
 
-#: ../src/common/filename.cpp:2575
+#: ../src/common/filename.cpp:2658
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Ошибка изменения времени файла '%s'"
 
-#: ../src/common/selectdispatcher.cpp:258
+#: ../src/common/selectdispatcher.cpp:255
 msgid "Failed to monitor I/O channels"
 msgstr "Не удалось отследить каналы ввода-вывода"
 
-#: ../src/common/filename.cpp:175
+#: ../src/common/filename.cpp:172
 #, c-format
 msgid "Failed to open '%s' for reading"
 msgstr "Не удалось открыть '%s' для чтения"
 
-#: ../src/common/filename.cpp:180
+#: ../src/common/filename.cpp:177
 #, c-format
 msgid "Failed to open '%s' for writing"
 msgstr "Не удалось открыть '%s' для записи"
 
-#: ../src/html/chm.cpp:141
+#: ../src/html/chm.cpp:138
 #, c-format
 msgid "Failed to open CHM archive '%s'."
 msgstr "Не удалось открыть архив CHM '%s'."
 
-#: ../src/common/utilscmn.cpp:1126
+#: ../src/common/utilscmn.cpp:1140
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Не удалось открыть URL-адрес \"%s\" в браузере по умолчанию."
+
+#: ../src/common/hyperlnkcmn.cpp:133
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Не удалось открыть URL-адрес \"%s\" в браузере по умолчанию."
 
 #: ../include/wx/msw/private/fswatcher.h:92
@@ -3375,207 +3491,228 @@ msgstr "Не удалось открыть URL-адрес \"%s\" в браузе
 msgid "Failed to open directory \"%s\" for monitoring."
 msgstr "Не удалось открыть каталог \"%s\" для мониторинга."
 
-#: ../src/x11/utils.cpp:227
+#: ../src/x11/utils.cpp:189
 #, c-format
 msgid "Failed to open display \"%s\"."
 msgstr "Не удалось открыть дисплей \"%s\"."
 
-#: ../src/common/filename.cpp:1062
+#: ../src/common/filename.cpp:1059
 msgid "Failed to open temporary file."
 msgstr "Не удалось открыть временный файл."
 
-#: ../src/msw/clipbrd.cpp:91
+#: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Не удалось открыть буфер обмена."
 
-#: ../src/common/translation.cpp:1184
+#: ../src/common/translation.cpp:1226
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Не удалось разобрать формы нножественного числа: '%s'"
 
-#: ../src/unix/mediactrl.cpp:1214
+#: ../src/unix/mediactrl.cpp:1239
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Не удалось подготовить проигрывание '%s'."
 
-#: ../src/msw/clipbrd.cpp:600
+#: ../src/msw/clipbrd.cpp:610
 msgid "Failed to put data on the clipboard"
 msgstr "Не удалось поместить данные в буфер обмена"
 
-#: ../src/unix/snglinst.cpp:278
+#: ../src/unix/snglinst.cpp:275
 msgid "Failed to read PID from lock file."
 msgstr "Не удалось прочесть PID из файла блокировки."
 
-#: ../src/common/fileconf.cpp:433
+#: ../src/common/fileconf.cpp:432
 msgid "Failed to read config options."
 msgstr "Не удалось прочесть параметры конфигурации."
 
-#: ../src/common/docview.cpp:681
+#: ../src/common/docview.cpp:676
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Не удалось прочесть документ из файла \"%s\"."
 
-#: ../src/dfb/evtloop.cpp:98
+#: ../src/dfb/evtloop.cpp:99
 msgid "Failed to read event from DirectFB pipe"
 msgstr "Не удалось выполнить чтение событий из канала DirectFB"
 
-#: ../src/unix/wakeuppipe.cpp:120
+#: ../src/unix/wakeuppipe.cpp:117
 msgid "Failed to read from wake-up pipe"
 msgstr "Не удалось прочесть из канала пробуждения"
 
-#: ../src/unix/utilsunx.cpp:679
+#: ../src/common/textfile.cpp:96
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Не удалось прочесть документ из файла \"%s\"."
+
+#: ../src/unix/utilsunx.cpp:681
 msgid "Failed to redirect child process input/output"
 msgstr "Не удалось перенаправить ввод/вывод порожденного процесса"
 
-#: ../src/msw/utilsexc.cpp:701
+#: ../src/msw/utilsexc.cpp:698
 msgid "Failed to redirect the child process IO"
 msgstr "Не удалось перенаправить ввод/вывод порожденного процесса"
 
-#: ../src/msw/dde.cpp:288
+#: ../src/msw/dde.cpp:283
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Не удалось зарегистрировать сервер DDE '%s'"
 
-#: ../src/common/fontmap.cpp:245
+#: ../src/gtk/font.cpp:580
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "Не удалось обновить пользовательский файл конфигурации."
+
+#: ../src/common/fontmap.cpp:242
 #, c-format
 msgid "Failed to remember the encoding for the charset '%s'."
 msgstr "Не удалось запомнить кодировку для набора символов '%s'."
 
-#: ../src/common/debugrpt.cpp:227
+#: ../src/common/debugrpt.cpp:228
 #, c-format
 msgid "Failed to remove debug report file \"%s\""
 msgstr "Не удалось удалить файл отчёта об отладке \"%s\""
 
-#: ../src/unix/snglinst.cpp:328
+#: ../src/unix/snglinst.cpp:325
 #, c-format
 msgid "Failed to remove lock file '%s'"
 msgstr "Ошибка удаления файла блокировки '%s'"
 
-#: ../src/unix/snglinst.cpp:288
+#: ../src/unix/snglinst.cpp:285
 #, c-format
 msgid "Failed to remove stale lock file '%s'."
 msgstr "Не удалось удалить устаревший файл блокировки '%s'."
 
-#: ../src/msw/registry.cpp:529
+#: ../src/msw/registry.cpp:518
 #, c-format
 msgid "Failed to rename registry value '%s' to '%s'."
 msgstr "Невозможно переименовать значение реестра из '%s' в '%s'."
 
-#: ../src/common/filefn.cpp:1122
+#: ../src/common/filefn.cpp:1011
 #, c-format
 msgid ""
-"Failed to rename the file '%s' to '%s' because the destination file already exists."
-msgstr "Не удалось переименовать файл '%s' в '%s' - файл назначения уже существует."
+"Failed to rename the file '%s' to '%s' because the destination file already "
+"exists."
+msgstr ""
+"Не удалось переименовать файл '%s' в '%s' - файл назначения уже существует."
 
-#: ../src/msw/registry.cpp:634
+#: ../src/msw/registry.cpp:623
 #, c-format
 msgid "Failed to rename the registry key '%s' to '%s'."
 msgstr "Невозможно переименовать ключ реестра из '%s' в '%s'."
 
-#: ../src/common/filename.cpp:2671
+#: ../src/msw/webview_ie.cpp:995
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/common/filename.cpp:2754
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Не удалось извлечь время файла '%s'"
 
-#: ../src/msw/dialup.cpp:468
+#: ../src/msw/dialup.cpp:462
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Не удалось получить текст сообщения об ошибке RAS"
 
-#: ../src/msw/clipbrd.cpp:748
+#: ../src/msw/clipbrd.cpp:768
 msgid "Failed to retrieve the supported clipboard formats"
 msgstr "Не удалось найти форматы, поддерживаемые буфером обмена"
 
-#: ../src/common/docview.cpp:652
+#: ../src/common/docview.cpp:647
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Не удалось сохранить документ в файл \"%s\"."
 
-#: ../src/msw/dib.cpp:269
+#: ../src/msw/dib.cpp:312
 #, c-format
 msgid "Failed to save the bitmap image to file \"%s\"."
 msgstr "Невозможно сохранить изображение в файл \"%s\"."
 
-#: ../src/msw/dde.cpp:763
+#: ../src/msw/dde.cpp:811
 msgid "Failed to send DDE advise notification"
 msgstr "Невозможно послать advise уведомление DDE"
 
-#: ../src/common/ftp.cpp:402
+#: ../src/common/ftp.cpp:399
 #, c-format
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Не удалось установить режим передачи FTP в %s."
 
-#: ../src/msw/clipbrd.cpp:427
+#: ../src/msw/clipbrd.cpp:443
 msgid "Failed to set clipboard data."
 msgstr "Не удалось установить данные буфера обмена."
 
-#: ../src/unix/snglinst.cpp:181
+#: ../src/unix/snglinst.cpp:178
 #, c-format
 msgid "Failed to set permissions on lock file '%s'"
 msgstr "Невозможно установить разрешения файлу блокировки '%s'"
 
-#: ../src/unix/utilsunx.cpp:668
+#: ../src/unix/utilsunx.cpp:670
 msgid "Failed to set process priority"
 msgstr "Не удалось установить приоритет процесса"
 
-#: ../src/common/file.cpp:559
+#: ../src/common/ffile.cpp:355 ../src/common/file.cpp:586
 msgid "Failed to set temporary file permissions"
 msgstr "Невозможно установить разрешения временному файлу"
 
-#: ../src/gtk/textctrl.cpp:1072
-msgid "Failed to set text in the text control."
-msgstr "Не удалось установить текст в текстовое поле."
-
-#: ../src/unix/threadpsx.cpp:1298
+#: ../src/unix/threadpsx.cpp:1347
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Не удалось задать уровень параллелизма потоков %lu"
 
-#: ../src/unix/threadpsx.cpp:1424
+#: ../src/unix/threadpsx.cpp:1473
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Не удалось установить приоритет потока %d."
 
-#: ../src/unix/utilsunx.cpp:783
+#: ../src/unix/utilsunx.cpp:785
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr "Не удалось настроить неблокирующий канал, программа может зависать."
 
-#: ../src/common/fs_mem.cpp:261
+#: ../src/msw/webview_ie.cpp:987
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:256
 #, c-format
 msgid "Failed to store image '%s' to memory VFS!"
 msgstr "Не удалось сохранить изображение '%s' в памяти VFS!"
 
-#: ../src/dfb/evtloop.cpp:170
+#: ../src/dfb/evtloop.cpp:171
 msgid "Failed to switch DirectFB pipe to non-blocking mode"
 msgstr "Не удалось переключить канал DirectFB в неблокирующий режим"
 
-#: ../src/unix/wakeuppipe.cpp:59
+#: ../src/unix/wakeuppipe.cpp:56
 msgid "Failed to switch wake up pipe to non-blocking mode"
 msgstr "Не удалось переключить Звонок трубы неблокирующий режим"
 
-#: ../src/unix/threadpsx.cpp:1605
+#: ../src/unix/threadpsx.cpp:1654
 msgid "Failed to terminate a thread."
 msgstr "Не удалось завершить поток."
 
-#: ../src/msw/dde.cpp:741
+#: ../src/msw/dde.cpp:736
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "Не удалось завершить 'advise loop' у DDE сервера"
 
-#: ../src/msw/dialup.cpp:938
+#: ../src/msw/dialup.cpp:932
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Не удалось завершить модемное подключение: %s"
 
-#: ../src/common/filename.cpp:2590
+#: ../src/common/filename.cpp:2673
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Не удалось открыть файл '%s'"
 
-#: ../src/unix/snglinst.cpp:334
+#: ../src/unix/dlunix.cpp:90
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "Ошибка загрузки разделяемой библиотеки '%s'"
+
+#: ../src/unix/snglinst.cpp:331
 #, c-format
 msgid "Failed to unlock lock file '%s'"
 msgstr "Не удалось разблокировать файл блокировки '%s'"
 
-#: ../src/msw/dde.cpp:309
+#: ../src/msw/dde.cpp:304
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Не удалось отменить регистрацию DDE сервера '%s'"
@@ -3589,77 +3726,87 @@ msgstr "Не удалось отменить регистрацию дескри
 msgid "Failed to update user configuration file."
 msgstr "Не удалось обновить пользовательский файл конфигурации."
 
-#: ../src/common/debugrpt.cpp:733
+#: ../src/common/debugrpt.cpp:743
 #, c-format
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Не удалось отправить отчёт об отладке (код ошибки %d)."
 
-#: ../src/unix/snglinst.cpp:168
+#: ../src/unix/snglinst.cpp:165
 #, c-format
 msgid "Failed to write to lock file '%s'"
 msgstr "Не удалось записать файл блокировки '%s'"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:209
+#: ../src/propgrid/propgrid.cpp:190
 msgid "False"
 msgstr "Ложно"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:694
+#: ../src/propgrid/advprops.cpp:604
 msgid "Family"
 msgstr "Семейство"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/gtk/glcanvas.cpp:176 ../src/gtk/glcanvas.cpp:187
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Ошибка файла"
+
+#: ../src/common/stockitem.cpp:154
 msgid "File"
 msgstr "Файл"
 
-#: ../src/common/docview.cpp:669
+#: ../src/common/docview.cpp:664
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Не удалось открыть файл '%s' для чтения."
 
-#: ../src/common/docview.cpp:646
+#: ../src/common/docview.cpp:641
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Невозможно открыть файл '%s' для записи."
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "Файл '%s' уже существует, вы точно хотите его переписать?"
 
-#: ../src/common/filefn.cpp:1156
+#: ../src/common/filefn.cpp:1044
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Не удалось записать в файл: %s"
 
-#: ../src/common/filefn.cpp:1139
+#: ../src/common/filefn.cpp:1028
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Файл '%s' не может быть переименован в '%s'"
 
-#: ../src/richtext/richtextctrl.cpp:3081 ../src/common/textcmn.cpp:953
+#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
 msgid "File couldn't be loaded."
 msgstr "Не удалось загрузить файл."
 
-#: ../src/msw/filedlg.cpp:393
+#: ../src/msw/filedlg.cpp:414
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "В файловом диалоговом окне произошла ошибка с кодом %0lx."
 
-#: ../src/common/docview.cpp:1789
+#: ../src/common/docview.cpp:1783
 msgid "File error"
 msgstr "Ошибка файла"
 
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/filectrlg.cpp:770
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/filectrlg.cpp:766
 msgid "File name exists already."
 msgstr "Имя файла уже существует."
+
+#: ../src/osx/cocoa/filedlg.mm:264
+#, fuzzy
+msgid "File type:"
+msgstr "Телетайп"
 
 #: ../src/motif/filedlg.cpp:220
 msgid "Files"
 msgstr "Файлы"
 
-#: ../src/common/filefn.cpp:1591
+#: ../src/common/filefn.cpp:1479
 #, c-format
 msgid "Files (%s)"
 msgstr "Файлы (%s)"
@@ -3668,15 +3815,29 @@ msgstr "Файлы (%s)"
 msgid "Filter"
 msgstr "Фильтр"
 
-#: ../src/common/stockitem.cpp:158 ../src/html/helpwnd.cpp:490
+#: ../src/html/helpwnd.cpp:488
 msgid "Find"
 msgstr "Найти"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:259
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:258
+#, fuzzy
+msgid "Find in document"
+msgstr "Открыть документ HTML"
+
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "Find..."
+msgstr "Найти"
+
+#: ../src/common/stockitem.cpp:156
 msgid "First"
 msgstr "Первый"
 
-#: ../src/common/prntbase.cpp:1548
+#: ../src/common/prntbase.cpp:1573
 msgid "First page"
 msgstr "Первая страница"
 
@@ -3684,11 +3845,11 @@ msgstr "Первая страница"
 msgid "Fixed"
 msgstr "Фиксированный"
 
-#: ../src/html/helpwnd.cpp:1206
+#: ../src/html/helpwnd.cpp:1204
 msgid "Fixed font:"
 msgstr "Фиксированный шрифт:"
 
-#: ../src/html/helpwnd.cpp:1269
+#: ../src/html/helpwnd.cpp:1267
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Шрифт фиксированного размера.<br> <b>жирный</b> <i>курсив</i> "
 
@@ -3696,16 +3857,16 @@ msgstr "Шрифт фиксированного размера.<br> <b>жирн�
 msgid "Floating"
 msgstr "Плавающий"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "Floppy"
 msgstr "Дискета"
 
-#: ../src/common/paper.cpp:111
+#: ../src/common/paper.cpp:108
 msgid "Folio, 8 1/2 x 13 in"
 msgstr "Фолио, 8 1/2 x 13 дюймов"
 
-#: ../src/richtext/richtextformatdlg.cpp:344 ../src/osx/carbon/fontdlg.cpp:287
-#: ../src/common/stockitem.cpp:194
+#: ../src/osx/carbon/fontdlg.cpp:284 ../src/common/stockitem.cpp:191
+#: ../src/richtext/richtextformatdlg.cpp:337
 msgid "Font"
 msgstr "Шрифт"
 
@@ -3713,7 +3874,24 @@ msgstr "Шрифт"
 msgid "Font &weight:"
 msgstr "&Толщина шрифта:"
 
-#: ../src/html/helpwnd.cpp:1207
+#: ../src/osx/fontutil.cpp:89
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
+"\"."
+msgstr ""
+
+#: ../src/msw/font.cpp:1126
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Не удалось загрузить файл."
+
+#: ../src/osx/fontutil.cpp:81
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr ": файл не существует!"
+
+#: ../src/html/helpwnd.cpp:1205
 msgid "Font size:"
 msgstr "Размер шрифта:"
 
@@ -3721,77 +3899,77 @@ msgstr "Размер шрифта:"
 msgid "Font st&yle:"
 msgstr "Ст&иль шрифта:"
 
-#: ../src/osx/carbon/fontdlg.cpp:329
+#: ../src/osx/carbon/fontdlg.cpp:326
 msgid "Font:"
 msgstr "Шрифт:"
 
-#: ../src/dfb/fontmgr.cpp:198
+#: ../src/dfb/fontmgr.cpp:195
 #, c-format
 msgid "Fonts index file %s disappeared while loading fonts."
 msgstr "Файл индекса шрифтов %s исчез при загрузке шрифтов."
 
-#: ../src/unix/utilsunx.cpp:645
+#: ../src/unix/utilsunx.cpp:647
 msgid "Fork failed"
 msgstr "Ветка не удалась"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "Forward"
 msgstr "Вперёд"
 
-#: ../src/common/xtixml.cpp:235
+#: ../src/common/xtixml.cpp:231
 msgid "Forward hrefs are not supported"
 msgstr "Перекрёстные ссылки не поддерживаются"
 
-#: ../src/html/helpwnd.cpp:875
+#: ../src/html/helpwnd.cpp:873
 #, c-format
 msgid "Found %i matches"
 msgstr "Найдено %i соответствий"
 
-#: ../src/generic/prntdlgg.cpp:238
+#: ../src/generic/prntdlgg.cpp:231
 msgid "From:"
 msgstr "От:"
 
-#: ../src/propgrid/advprops.cpp:1604
+#: ../src/propgrid/advprops.cpp:1510
 msgid "Fuchsia"
 msgstr "Пурпурный"
 
-#: ../src/common/imaggif.cpp:138
+#: ../src/common/imaggif.cpp:135
 msgid "GIF: data stream seems to be truncated."
 msgstr "GIF: поток данных кажется усечённым."
 
-#: ../src/common/imaggif.cpp:128
+#: ../src/common/imaggif.cpp:125
 msgid "GIF: error in GIF image format."
 msgstr "GIF: ошибка в формате изображения GIF."
 
-#: ../src/common/imaggif.cpp:133
+#: ../src/common/imaggif.cpp:130
 msgid "GIF: not enough memory."
 msgstr "GIF: недостаточно памяти."
 
-#: ../src/gtk/window.cpp:4631
+#: ../src/gtk/window.cpp:5635
 msgid ""
-"GTK+ installed on this machine is too old to support screen compositing, please "
-"install GTK+ 2.12 or later."
+"GTK+ installed on this machine is too old to support screen compositing, "
+"please install GTK+ 2.12 or later."
 msgstr ""
 "GTK + установленный на этом компьютере слишком стар для поддержки композиции "
 "экрана, установите GTK + 2,12 или новее."
 
-#: ../src/univ/themes/gtk.cpp:525
+#: ../src/univ/themes/gtk.cpp:522
 msgid "GTK+ theme"
 msgstr "Тема GTK+"
 
-#: ../src/common/preferencescmn.cpp:40
+#: ../src/common/preferencescmn.cpp:37
 msgid "General"
 msgstr "Общие"
 
-#: ../src/common/prntbase.cpp:258
+#: ../src/common/prntbase.cpp:253
 msgid "Generic PostScript"
 msgstr "Общий PostScript"
 
-#: ../src/common/paper.cpp:135
+#: ../src/common/paper.cpp:132
 msgid "German Legal Fanfold, 8 1/2 x 13 in"
 msgstr "Немецкий правовой фальцованный, 8 1/2 x 13 дюйма"
 
-#: ../src/common/paper.cpp:134
+#: ../src/common/paper.cpp:131
 msgid "German Std Fanfold, 8 1/2 x 12 in"
 msgstr "Немецкий STD фальцованный, 8 1/2 x 12 дюйма"
 
@@ -3805,50 +3983,51 @@ msgstr "GetPropertyCollection вызывается для универсальн
 
 #: ../include/wx/xtiprop.h:202
 msgid "GetPropertyCollection called w/o valid collection getter"
-msgstr "GetPropertyCollection вызывается без действительного получателя коллекции"
+msgstr ""
+"GetPropertyCollection вызывается без действительного получателя коллекции"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:658
 msgid "Go back"
 msgstr "Перейти назад"
 
-#: ../src/html/helpwnd.cpp:661
+#: ../src/html/helpwnd.cpp:659
 msgid "Go forward"
 msgstr "Перейти вперёд"
 
-#: ../src/html/helpwnd.cpp:663
+#: ../src/html/helpwnd.cpp:661
 msgid "Go one level up in document hierarchy"
 msgstr "Перейти на один уровень вверх в иерархии документа"
 
-#: ../src/generic/filedlgg.cpp:208 ../src/generic/dirdlgg.cpp:116
+#: ../src/generic/filedlgg.cpp:205 ../src/generic/dirdlgg.cpp:113
 msgid "Go to home directory"
 msgstr "В начальный каталог"
 
-#: ../src/generic/filedlgg.cpp:205
+#: ../src/generic/filedlgg.cpp:202
 msgid "Go to parent directory"
 msgstr "Перейти в родительский каталог"
 
-#: ../src/generic/aboutdlgg.cpp:76
+#: ../src/generic/aboutdlgg.cpp:73
 msgid "Graphics art by "
 msgstr "Графика "
 
-#: ../src/propgrid/advprops.cpp:1599
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Gray"
 msgstr "Серый"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:883
+#: ../src/propgrid/advprops.cpp:784
 msgid "GrayText"
 msgstr "СерыйТекст"
 
-#: ../src/common/fmapbase.cpp:154
+#: ../src/common/fmapbase.cpp:151
 msgid "Greek (ISO-8859-7)"
 msgstr "Греческий (ISO-8859-7)"
 
-#: ../src/propgrid/advprops.cpp:1600
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Green"
 msgstr "Зелёный"
 
-#: ../src/generic/colrdlgg.cpp:342
+#: ../src/generic/colrdlgg.cpp:362
 msgid "Green:"
 msgstr "Зелёный:"
 
@@ -3856,171 +4035,173 @@ msgstr "Зелёный:"
 msgid "Groove"
 msgstr "Слот"
 
-#: ../src/common/zstream.cpp:158 ../src/common/zstream.cpp:318
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
 msgid "Gzip not supported by this version of zlib"
 msgstr "Gzip не поддерживается этой версией zlib"
 
-#: ../src/html/helpwnd.cpp:1549
+#: ../src/html/helpwnd.cpp:1547
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "Проект справки HTML (*.hhp)|*.hhp|"
 
-#: ../src/html/htmlwin.cpp:681
+#: ../src/html/htmlwin.cpp:691
 #, c-format
 msgid "HTML anchor %s does not exist."
 msgstr "HTML-якорь %s не существует."
 
-#: ../src/html/helpwnd.cpp:1547
+#: ../src/html/helpwnd.cpp:1545
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "Файлы HTML (*.html;*.htm)|*.html;*.htm|"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1759
+#: ../src/propgrid/advprops.cpp:1660
 msgid "Hand"
 msgstr "Рука"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "Harddisk"
 msgstr "Жёсткий диск"
 
-#: ../src/common/fmapbase.cpp:155
+#: ../src/common/fmapbase.cpp:152
 msgid "Hebrew (ISO-8859-8)"
 msgstr "Иврит (ISO-8859-8)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:280 ../src/osx/button_osx.cpp:39
-#: ../src/common/stockitem.cpp:163 ../src/common/accelcmn.cpp:80
-#: ../src/html/helpdlg.cpp:66 ../src/html/helpfrm.cpp:111
+#: ../include/wx/msgdlg.h:282 ../src/osx/button_osx.cpp:39
+#: ../src/common/stockitem.cpp:160 ../src/common/accelcmn.cpp:77
+#: ../src/html/helpfrm.cpp:108 ../src/html/helpdlg.cpp:63
 msgid "Help"
 msgstr "Справка"
 
-#: ../src/html/helpwnd.cpp:1200
+#: ../src/html/helpwnd.cpp:1198
 msgid "Help Browser Options"
 msgstr "Параметры просмотра помощи"
 
-#: ../src/generic/helpext.cpp:454 ../src/generic/helpext.cpp:455
+#: ../src/generic/helpext.cpp:452 ../src/generic/helpext.cpp:453
 msgid "Help Index"
 msgstr "Индекс справки"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1529
 msgid "Help Printing"
 msgstr "Печать помощи"
 
-#: ../src/html/helpwnd.cpp:801
+#: ../src/html/helpwnd.cpp:799
 msgid "Help Topics"
 msgstr "Содержание справки"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1546
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Книги справки (*.htb)|*.htb|Книги справки (*.zip)|*.zip|"
 
-#: ../src/generic/helpext.cpp:267
+#: ../src/generic/helpext.cpp:265
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "Каталог справки '%s' не найден."
 
-#: ../src/generic/helpext.cpp:275
+#: ../src/generic/helpext.cpp:273
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "Файл справки '%s' не найден."
 
-#: ../src/html/helpctrl.cpp:63
+#: ../src/html/helpctrl.cpp:59
 #, c-format
 msgid "Help: %s"
 msgstr "Справка: %s"
 
-#: ../src/osx/menu_osx.cpp:577
+#: ../src/osx/menu_osx.cpp:469
 #, c-format
 msgid "Hide %s"
 msgstr "Скрыть %s"
 
-#: ../src/osx/menu_osx.cpp:579
+#: ../src/osx/menu_osx.cpp:471
 msgid "Hide Others"
 msgstr "Скрыть остальные"
 
-#: ../src/generic/infobar.cpp:84
+#: ../src/generic/infobar.cpp:81
 msgid "Hide this notification message."
 msgstr "Скрыть это сообщение уведомления."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:884
+#: ../src/propgrid/advprops.cpp:785
 msgid "Highlight"
 msgstr "Подсветка"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:885
+#: ../src/propgrid/advprops.cpp:786
 msgid "HighlightText"
 msgstr "Выделить текст"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:164 ../src/common/accelcmn.cpp:65
+#: ../src/common/stockitem.cpp:161 ../src/common/accelcmn.cpp:62
 msgid "Home"
 msgstr "В начало"
 
-#: ../src/generic/dirctrlg.cpp:524
+#: ../src/generic/dirctrlg.cpp:490
 msgid "Home directory"
 msgstr "Начальный каталог"
 
-#: ../src/richtext/richtextsizepage.cpp:253 ../src/richtext/richtextsizepage.cpp:255
+#: ../src/richtext/richtextsizepage.cpp:253
+#: ../src/richtext/richtextsizepage.cpp:255
 msgid "How the object will float relative to the text."
 msgstr "Как объект будет плавать относительно текста."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1760
+#: ../src/propgrid/advprops.cpp:1661
 msgid "I-Beam"
 msgstr "I-Beam"
 
-#: ../src/common/imagbmp.cpp:1196
+#: ../src/common/imagbmp.cpp:1208
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: ошибка чтения маски DIB."
 
-#: ../src/common/imagbmp.cpp:1290 ../src/common/imagbmp.cpp:1390
-#: ../src/common/imagbmp.cpp:1405 ../src/common/imagbmp.cpp:1416
-#: ../src/common/imagbmp.cpp:1430 ../src/common/imagbmp.cpp:1478
-#: ../src/common/imagbmp.cpp:1493 ../src/common/imagbmp.cpp:1507
-#: ../src/common/imagbmp.cpp:1518
+#: ../src/common/imagbmp.cpp:1302 ../src/common/imagbmp.cpp:1402
+#: ../src/common/imagbmp.cpp:1417 ../src/common/imagbmp.cpp:1428
+#: ../src/common/imagbmp.cpp:1442 ../src/common/imagbmp.cpp:1490
+#: ../src/common/imagbmp.cpp:1505 ../src/common/imagbmp.cpp:1519
+#: ../src/common/imagbmp.cpp:1530
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: ошибка записи файла изображения!"
 
-#: ../src/common/imagbmp.cpp:1255
+#: ../src/common/imagbmp.cpp:1267
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: изображение слишком высоко для значка."
 
-#: ../src/common/imagbmp.cpp:1263
+#: ../src/common/imagbmp.cpp:1275
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: изображение слишком широкое для значка."
 
-#: ../src/common/imagbmp.cpp:1603
+#: ../src/common/imagbmp.cpp:1615
 msgid "ICO: Invalid icon index."
 msgstr "ICO: неверный индекс значка."
 
-#: ../src/common/imagiff.cpp:758
+#: ../src/common/imagiff.cpp:755
 msgid "IFF: data stream seems to be truncated."
 msgstr "IFF: поток данных кажется усечённым."
 
-#: ../src/common/imagiff.cpp:742
+#: ../src/common/imagiff.cpp:739
 msgid "IFF: error in IFF image format."
 msgstr "IFF: ошибка в формате изображения IFF."
 
-#: ../src/common/imagiff.cpp:745
+#: ../src/common/imagiff.cpp:742
 msgid "IFF: not enough memory."
 msgstr "IFF: недостаточно памяти."
 
-#: ../src/common/imagiff.cpp:748
+#: ../src/common/imagiff.cpp:745
 msgid "IFF: unknown error!!!"
 msgstr "IIF: неизвестная ошибка!!!"
 
-#: ../src/common/fmapbase.cpp:197
+#: ../src/common/fmapbase.cpp:194
 msgid "ISO-2022-JP"
 msgstr "ISO-2022-JP"
 
-#: ../src/html/htmprint.cpp:282
+#: ../src/html/htmprint.cpp:294
 msgid ""
-"If possible, try changing the layout parameters to make the printout more narrow."
+"If possible, try changing the layout parameters to make the printout more "
+"narrow."
 msgstr ""
-"Если возможно, попробуйте изменить параметры макета, чтобы сделать печать более "
-"узкой."
+"Если возможно, попробуйте изменить параметры макета, чтобы сделать печать "
+"более узкой."
 
-#: ../src/generic/dbgrptg.cpp:358
+#: ../src/generic/dbgrptg.cpp:362
 msgid ""
 "If you have any additional information pertaining to this bug\n"
 "report, please enter it here and it will be joined to it:"
@@ -4030,8 +4211,8 @@ msgstr ""
 
 #: ../src/generic/dbgrptg.cpp:324
 msgid ""
-"If you wish to suppress this debug report completely, please choose the \"Cancel\" "
-"button,\n"
+"If you wish to suppress this debug report completely, please choose the "
+"\"Cancel\" button,\n"
 "but be warned that it may hinder improving the program, so if\n"
 "at all possible please do continue with the report generation.\n"
 msgstr ""
@@ -4040,145 +4221,151 @@ msgstr ""
 "но учтите, что это может воспрепятствовать улучшению программы.\n"
 "Если это возможно, продолжайте создание отчёта.\n"
 
-#: ../src/msw/registry.cpp:1405
+#: ../src/common/zipstrm.cpp:1043
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1393
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Значение \"%s\" ключа \"%s\" проигнорировано."
 
-#: ../src/common/xtistrm.cpp:295
+#: ../src/common/xtistrm.cpp:292
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Недопустимый класс объекта (не wxEvtHandler) как источник события"
 
-#: ../src/common/xti.cpp:513
+#: ../src/common/xti.cpp:510
 msgid "Illegal Parameter Count for ConstructObject Method"
 msgstr "Недопустимое число параметров для метода ConstructObject"
 
-#: ../src/common/xti.cpp:501
+#: ../src/common/xti.cpp:498
 msgid "Illegal Parameter Count for Create Method"
 msgstr "Недопустимое число параметров для метода Create"
 
-#: ../src/generic/dirctrlg.cpp:570 ../src/generic/filectrlg.cpp:756
+#: ../src/generic/dirctrlg.cpp:536 ../src/generic/filectrlg.cpp:752
 msgid "Illegal directory name."
 msgstr "Недопустимое имя каталога."
 
-#: ../src/generic/filectrlg.cpp:1367
+#: ../src/generic/filectrlg.cpp:1356
 msgid "Illegal file specification."
 msgstr "Неправильная спецификация файла."
 
-#: ../src/common/image.cpp:2269
+#: ../src/common/image.cpp:2363
 msgid "Image and mask have different sizes."
 msgstr "Изображение и маска имеют различные размеры."
 
-#: ../src/common/image.cpp:2746
+#: ../src/common/image.cpp:2841
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "Файл изображения не тип %d."
 
-#: ../src/common/image.cpp:2877
+#: ../src/common/image.cpp:2995
 #, c-format
 msgid "Image is not of type %s."
 msgstr "Изображение не тип %s."
 
-#: ../src/msw/textctrl.cpp:488
+#: ../src/msw/textctrl.cpp:534
 msgid ""
-"Impossible to create a rich edit control, using simple text control instead. Please "
-"reinstall riched32.dll"
+"Impossible to create a rich edit control, using simple text control instead. "
+"Please reinstall riched32.dll"
 msgstr ""
 "Невозможно создать расширенный элемент управления редактированием с помощью "
 "простого текстового элемента управления. Переустановите riched32.dll"
 
-#: ../src/unix/utilsunx.cpp:301
+#: ../src/unix/utilsunx.cpp:303
 msgid "Impossible to get child process input"
 msgstr "Невозможно получить ввод дочернего процесса"
 
-#: ../src/common/filefn.cpp:1028
+#: ../src/common/filefn.cpp:917
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Невозможно получить разрешения файла '%s'"
 
-#: ../src/common/filefn.cpp:1042
+#: ../src/common/filefn.cpp:931
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Невозможно переписать файл '%s'"
 
-#: ../src/common/filefn.cpp:1097
+#: ../src/common/filefn.cpp:986
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Невозможно установить разрешения файлу '%s'"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:886
+#: ../src/propgrid/advprops.cpp:787
 msgid "InactiveBorder"
 msgstr "НеактивнаяГраница"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:887
+#: ../src/propgrid/advprops.cpp:788
 msgid "InactiveCaption"
 msgstr "InactiveCaption"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:888
+#: ../src/propgrid/advprops.cpp:789
 msgid "InactiveCaptionText"
 msgstr "InactiveCaptionText"
 
-#: ../src/common/gifdecod.cpp:792
+#: ../src/common/gifdecod.cpp:826
 #, c-format
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "Неправильный GIF размер кадра (%u, %d) для frame #%u"
 
-#: ../src/msw/ole/automtn.cpp:635
+#: ../src/msw/ole/automtn.cpp:626
 msgid "Incorrect number of arguments."
 msgstr "Неверное количество аргументов."
 
-#: ../src/common/stockitem.cpp:165
+#: ../src/common/stockitem.cpp:162
 msgid "Indent"
 msgstr "Отступ"
 
-#: ../src/richtext/richtextformatdlg.cpp:349
+#: ../src/richtext/richtextformatdlg.cpp:342
 msgid "Indents && Spacing"
 msgstr "Отступы и интервалы"
 
-#: ../src/common/stockitem.cpp:166 ../src/html/helpwnd.cpp:515
+#: ../src/common/stockitem.cpp:163 ../src/html/helpwnd.cpp:513
 msgid "Index"
 msgstr "Индекс"
 
-#: ../src/common/fmapbase.cpp:159
+#: ../src/common/fmapbase.cpp:156
 msgid "Indian (ISO-8859-12)"
 msgstr "Индийский (ISO-8859-12)"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "Info"
 msgstr "Инфо"
 
-#: ../src/common/init.cpp:287
+#: ../src/common/init.cpp:284
 msgid "Initialization failed in post init, aborting."
 msgstr "Сбой инициализации в post init, прерывание."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:54
+#: ../src/common/accelcmn.cpp:51
 msgid "Ins"
 msgstr "INS"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextsymboldlg.cpp:472 ../src/common/accelcmn.cpp:53
+#: ../src/common/accelcmn.cpp:50 ../src/richtext/richtextsymboldlg.cpp:469
 msgid "Insert"
 msgstr "Insert"
 
-#: ../src/richtext/richtextbuffer.cpp:8067
+#: ../src/richtext/richtextbuffer.cpp:8063
 msgid "Insert Field"
 msgstr "Вставить поле"
 
-#: ../src/richtext/richtextbuffer.cpp:7978 ../src/richtext/richtextbuffer.cpp:8936
+#: ../src/richtext/richtextbuffer.cpp:7974
+#: ../src/richtext/richtextbuffer.cpp:8934
 msgid "Insert Image"
 msgstr "Вставить изображение"
 
-#: ../src/richtext/richtextbuffer.cpp:8025
+#: ../src/richtext/richtextbuffer.cpp:8021
 msgid "Insert Object"
 msgstr "Вставить объект"
 
-#: ../src/richtext/richtextctrl.cpp:1286 ../src/richtext/richtextctrl.cpp:1494
-#: ../src/richtext/richtextbuffer.cpp:7822 ../src/richtext/richtextbuffer.cpp:7852
-#: ../src/richtext/richtextbuffer.cpp:7894
+#: ../src/richtext/richtextbuffer.cpp:7818
+#: ../src/richtext/richtextbuffer.cpp:7848
+#: ../src/richtext/richtextbuffer.cpp:7890
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
 msgid "Insert Text"
 msgstr "Вставить текст"
 
@@ -4191,16 +4378,11 @@ msgstr "Вставляет разрыв страницы перед абзаце
 msgid "Inset"
 msgstr "Вставка"
 
-#: ../src/gtk/app.cpp:425
-#, c-format
-msgid "Invalid GTK+ command line option, use \"%s --help\""
-msgstr "Повреждены опции командной строки GTK+, используйте '%s --help'"
-
-#: ../src/common/imagtiff.cpp:311
+#: ../src/common/imagtiff.cpp:308
 msgid "Invalid TIFF image index."
 msgstr "Недопустимый индекс изображения TIFF."
 
-#: ../src/common/appcmn.cpp:273
+#: ../src/common/appcmn.cpp:294
 #, c-format
 msgid "Invalid display mode specification '%s'."
 msgstr "Неправильная спецификация режима экрана '%s'."
@@ -4210,246 +4392,253 @@ msgstr "Неправильная спецификация режима экра�
 msgid "Invalid geometry specification '%s'"
 msgstr "Неправильная спецификация геометрии '%s'"
 
-#: ../src/unix/fswatcher_inotify.cpp:323
+#: ../src/unix/fswatcher_inotify.cpp:320
 #, c-format
 msgid "Invalid inotify event for \"%s\""
 msgstr "Недопустимое событие inotify для '%s'"
 
-#: ../src/unix/snglinst.cpp:312
+#: ../src/unix/snglinst.cpp:309
 #, c-format
 msgid "Invalid lock file '%s'."
 msgstr "Неверный файл блокировки '%s'."
 
-#: ../src/common/translation.cpp:1125
+#: ../src/common/translation.cpp:1167
 msgid "Invalid message catalog."
 msgstr "Неверный каталог сообщений."
 
-#: ../src/common/xtistrm.cpp:405 ../src/common/xtistrm.cpp:420
+#: ../src/common/xtistrm.cpp:402 ../src/common/xtistrm.cpp:417
 msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
-msgstr "Неверный или нулевой идентификатор объекта передан в GetObjectClassInfo"
+msgstr ""
+"Неверный или нулевой идентификатор объекта передан в GetObjectClassInfo"
 
-#: ../src/common/xtistrm.cpp:435
+#: ../src/common/xtistrm.cpp:432
 msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
-msgstr "Неверный или нулевой идентификатор объекта передан в HasObjectClassInfo"
+msgstr ""
+"Неверный или нулевой идентификатор объекта передан в HasObjectClassInfo"
 
-#: ../src/common/regex.cpp:310
+#: ../src/common/regex.cpp:307
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Неверное регулярное выражение '%s': %s"
 
-#: ../src/common/config.cpp:226
+#: ../src/common/config.cpp:222
 #, c-format
 msgid "Invalid value %ld for a boolean key \"%s\" in config file."
-msgstr "Недопустимое значение %ld для логического ключа  '%s' в файле конфигурации."
+msgstr ""
+"Недопустимое значение %ld для логического ключа  '%s' в файле конфигурации."
 
-#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:351
-#: ../src/osx/carbon/fontdlg.cpp:361 ../src/common/stockitem.cpp:168
+#: ../src/osx/carbon/fontdlg.cpp:358 ../src/common/stockitem.cpp:165
+#: ../src/generic/fontdlgg.cpp:325 ../src/richtext/richtextfontpage.cpp:351
 msgid "Italic"
 msgstr "Курсив"
 
-#: ../src/common/paper.cpp:130
+#: ../src/common/paper.cpp:127
 msgid "Italy Envelope, 110 x 230 mm"
 msgstr "Итальянский конверт, 110 x 230 мм"
 
-#: ../src/common/imagjpeg.cpp:270
+#: ../src/common/imagjpeg.cpp:257
 msgid "JPEG: Couldn't load - file is probably corrupted."
 msgstr "JPEG: невозможно загрузить - возможно файл повреждён."
 
-#: ../src/common/imagjpeg.cpp:449
+#: ../src/common/imagjpeg.cpp:436
 msgid "JPEG: Couldn't save image."
 msgstr "JPEG: невозможно сохранить изображение."
 
-#: ../src/common/paper.cpp:163
+#: ../src/common/paper.cpp:160
 msgid "Japanese Double Postcard 200 x 148 mm"
 msgstr "Японская двойная открытка 200 x 148 мм"
 
-#: ../src/common/paper.cpp:167
+#: ../src/common/paper.cpp:164
 msgid "Japanese Envelope Chou #3"
 msgstr "Японский конверт  Chou #3"
 
-#: ../src/common/paper.cpp:180
+#: ../src/common/paper.cpp:177
 msgid "Japanese Envelope Chou #3 Rotated"
 msgstr "Японский конверт Chou #3 повёрнут"
 
-#: ../src/common/paper.cpp:168
+#: ../src/common/paper.cpp:165
 msgid "Japanese Envelope Chou #4"
 msgstr "Японский конверт Chou #4"
 
-#: ../src/common/paper.cpp:181
+#: ../src/common/paper.cpp:178
 msgid "Japanese Envelope Chou #4 Rotated"
 msgstr "Японский конверт Chou #4 повёрнут"
 
-#: ../src/common/paper.cpp:165
+#: ../src/common/paper.cpp:162
 msgid "Japanese Envelope Kaku #2"
 msgstr "Японский конверт Kaku #2"
 
-#: ../src/common/paper.cpp:178
+#: ../src/common/paper.cpp:175
 msgid "Japanese Envelope Kaku #2 Rotated"
 msgstr "Японский конверт Kaku #2 Повёрнут"
 
-#: ../src/common/paper.cpp:166
+#: ../src/common/paper.cpp:163
 msgid "Japanese Envelope Kaku #3"
 msgstr "Японский конверт Kaku #3"
 
-#: ../src/common/paper.cpp:179
+#: ../src/common/paper.cpp:176
 msgid "Japanese Envelope Kaku #3 Rotated"
 msgstr "Японский конверт Kaku #3 повёрнут"
 
-#: ../src/common/paper.cpp:185
+#: ../src/common/paper.cpp:182
 msgid "Japanese Envelope You #4"
 msgstr "Японский конверт You # 4"
 
-#: ../src/common/paper.cpp:186
+#: ../src/common/paper.cpp:183
 msgid "Japanese Envelope You #4 Rotated"
 msgstr "Японский конверт You #4 повёрнут"
 
-#: ../src/common/paper.cpp:138
+#: ../src/common/paper.cpp:135
 msgid "Japanese Postcard 100 x 148 mm"
 msgstr "Японские открытки (100 x 148 мм"
 
-#: ../src/common/paper.cpp:175
+#: ../src/common/paper.cpp:172
 msgid "Japanese Postcard Rotated 148 x 100 mm"
 msgstr "Японская открытка повёрнута 148 x 100 мм"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "Jump to"
 msgstr "Перейти к"
 
-#: ../src/common/stockitem.cpp:171
+#: ../src/common/stockitem.cpp:168
 msgid "Justified"
 msgstr "Выровненный"
 
-#: ../src/richtext/richtextindentspage.cpp:155
-#: ../src/richtext/richtextindentspage.cpp:157
 #: ../src/richtext/richtextliststylepage.cpp:344
 #: ../src/richtext/richtextliststylepage.cpp:346
+#: ../src/richtext/richtextindentspage.cpp:155
+#: ../src/richtext/richtextindentspage.cpp:157
 msgid "Justify text left and right."
 msgstr "Выравнивание текста слева и справа."
 
-#: ../src/common/fmapbase.cpp:163
+#: ../src/common/fmapbase.cpp:160
 msgid "KOI8-R"
 msgstr "KOI8-R"
 
-#: ../src/common/fmapbase.cpp:164
+#: ../src/common/fmapbase.cpp:161
 msgid "KOI8-U"
 msgstr "KOI8-U"
 
-#: ../src/common/accelcmn.cpp:265 ../src/common/accelcmn.cpp:347
+#: ../src/common/accelcmn.cpp:279 ../src/common/accelcmn.cpp:364
 msgid "KP_"
 msgstr "KP_"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "KP_Add"
 msgstr "KP_Add"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "KP_Begin"
 msgstr "KP_Begin"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "KP_Decimal"
 msgstr "KP_десятичная дробь"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 msgid "KP_Delete"
 msgstr "KP_Delete"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "KP_Divide"
 msgstr "KP_Divide"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 msgid "KP_Down"
 msgstr "KP_Down"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "KP_End"
 msgstr "KP_End"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "KP_Enter"
 msgstr "KP_Enter"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "KP_Equal"
 msgstr "KP_Equal"
 
+#: ../src/common/accelcmn.cpp:276 ../src/common/accelcmn.cpp:361
+msgid "KP_F"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 msgid "KP_Home"
 msgstr "KP_Home"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 msgid "KP_Insert"
 msgstr "KP_Insert"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "KP_Left"
 msgstr "KP_Left"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "KP_Multiply"
 msgstr "KP_Multiply"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:99
+#: ../src/common/accelcmn.cpp:97
 msgid "KP_Next"
 msgstr "KP_Next"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "KP_PageDown"
 msgstr "PageDown"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "KP_PageUp"
 msgstr "PageUp"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:98
+#: ../src/common/accelcmn.cpp:96
 msgid "KP_Prior"
 msgstr "KP_Prior"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 msgid "KP_Right"
 msgstr "KP_Right"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "KP_Separator"
 msgstr "KP_Separator"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "KP_Space"
 msgstr "KP_пробел"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "KP_Subtract"
 msgstr "KP_Subtract"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "KP_Tab"
 msgstr "KP_Tab"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "KP_Up"
 msgstr "KP_Up"
 
@@ -4457,19 +4646,34 @@ msgstr "KP_Up"
 msgid "L&ine spacing:"
 msgstr "Ме&жстрочный интервал:"
 
-#: ../src/generic/prntdlgg.cpp:613 ../src/generic/prntdlgg.cpp:868
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "ошибка сжатия"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "ошибка распаковки"
+
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:861
 msgid "Landscape"
 msgstr "Пейзаж"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "Last"
 msgstr "Последний"
 
-#: ../src/common/prntbase.cpp:1572
+#: ../src/common/prntbase.cpp:1597
 msgid "Last page"
 msgstr "Последняя станица"
 
-#: ../src/common/log.cpp:305
+#: ../src/common/log.cpp:324
 #, c-format
 msgid "Last repeated message (\"%s\", %u time) wasn't output"
 msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
@@ -4477,140 +4681,144 @@ msgstr[0] "Последнее повторяющееся сообщение ('%s
 msgstr[1] "Последнее повторяющееся сообщение ('%s', %u раза) не выводится"
 msgstr[2] "Последнее повторяющееся сообщение ('%s', %u раз) не выводится"
 
-#: ../src/common/paper.cpp:103
+#: ../src/common/paper.cpp:100
 msgid "Ledger, 17 x 11 in"
 msgstr "Леджер, 17 x 11 дюйма"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6146 ../src/richtext/richtextliststylepage.cpp:249
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:58 ../src/generic/datavgen.cpp:6951
+#: ../src/richtext/richtextsizepage.cpp:249
+#: ../src/richtext/richtextliststylepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:252
 #: ../src/richtext/richtextliststylepage.cpp:253
 #: ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
-#: ../src/richtext/richtextsizepage.cpp:249 ../src/common/accelcmn.cpp:61
 msgid "Left"
 msgstr "Слева"
 
-#: ../src/richtext/richtextindentspage.cpp:204
 #: ../src/richtext/richtextliststylepage.cpp:390
+#: ../src/richtext/richtextindentspage.cpp:204
 msgid "Left (&first line):"
 msgstr "Слева (первые строки):"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1761
+#: ../src/propgrid/advprops.cpp:1662
 msgid "Left Button"
 msgstr "Левая кнопка"
 
-#: ../src/generic/prntdlgg.cpp:880
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Left margin (mm):"
 msgstr "Левое поле (мм):"
 
-#: ../src/richtext/richtextindentspage.cpp:141
-#: ../src/richtext/richtextindentspage.cpp:143
 #: ../src/richtext/richtextliststylepage.cpp:330
 #: ../src/richtext/richtextliststylepage.cpp:332
+#: ../src/richtext/richtextindentspage.cpp:141
+#: ../src/richtext/richtextindentspage.cpp:143
 msgid "Left-align text."
 msgstr "Выровнять текст слева."
 
-#: ../src/common/paper.cpp:144
+#: ../src/common/paper.cpp:141
 msgid "Legal Extra 9 1/2 x 15 in"
 msgstr "Правовая экстра, 9 1/2 x 15 дюйма"
 
-#: ../src/common/paper.cpp:96
+#: ../src/common/paper.cpp:93
 msgid "Legal, 8 1/2 x 14 in"
 msgstr "Правовая, 8 1/2 x 14 дюймов"
 
-#: ../src/common/paper.cpp:143
+#: ../src/common/paper.cpp:140
 msgid "Letter Extra 9 1/2 x 12 in"
 msgstr "Письмо экстра 9 1/2 x 12 дюймов"
 
-#: ../src/common/paper.cpp:149
+#: ../src/common/paper.cpp:146
 msgid "Letter Extra Transverse 9.275 x 12 in"
 msgstr "Письмо экстра Поперечое 9.275 x 12 в"
 
-#: ../src/common/paper.cpp:152
+#: ../src/common/paper.cpp:149
 msgid "Letter Plus 8 1/2 x 12.69 in"
 msgstr "Письмо плюс 8 1/2 x 12.69 дюймов"
 
-#: ../src/common/paper.cpp:169
+#: ../src/common/paper.cpp:166
 msgid "Letter Rotated 11 x 8 1/2 in"
 msgstr "Письмо повёрнуто 11 х 8 1/2 дюймов"
 
-#: ../src/common/paper.cpp:101
+#: ../src/common/paper.cpp:98
 msgid "Letter Small, 8 1/2 x 11 in"
 msgstr "Маленькое письмо 8 1/2 x 11 дюйма"
 
-#: ../src/common/paper.cpp:147
+#: ../src/common/paper.cpp:144
 msgid "Letter Transverse 8 1/2 x 11 in"
 msgstr "Письмо поперечное 8 1/2 x 11 дюймов"
 
-#: ../src/common/paper.cpp:95
+#: ../src/common/paper.cpp:92
 msgid "Letter, 8 1/2 x 11 in"
 msgstr "Письмо, 8 1/2 x 11 дюйма"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "License"
 msgstr "Лицензии"
 
-#: ../src/generic/fontdlgg.cpp:332
+#: ../src/generic/fontdlgg.cpp:328
 msgid "Light"
 msgstr "Светлый"
 
-#: ../src/propgrid/advprops.cpp:1608
+#: ../src/propgrid/advprops.cpp:1514
 msgid "Lime"
 msgstr "Лайм"
 
-#: ../src/generic/helpext.cpp:294
+#: ../src/generic/helpext.cpp:292
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
-msgstr "Строка %lu файла сопоставления  '%s' имеет неверный синтаксис и пропущена."
+msgstr ""
+"Строка %lu файла сопоставления  '%s' имеет неверный синтаксис и пропущена."
 
 #: ../src/richtext/richtextliststylepage.cpp:444
 msgid "Line spacing:"
 msgstr "Межстрочный интервал:"
 
-#: ../src/html/chm.cpp:838
+#: ../src/html/chm.cpp:829
 msgid "Link contained '//', converted to absolute link."
 msgstr "Ссылка содержит '//', преобразована в абсолютную ссылку."
 
-#: ../src/richtext/richtextformatdlg.cpp:364
+#: ../src/richtext/richtextformatdlg.cpp:357
 msgid "List Style"
 msgstr "Стиль списка"
 
-#: ../src/richtext/richtextstyles.cpp:1064
+#: ../src/richtext/richtextstyles.cpp:1061
 msgid "List styles"
 msgstr "Список стилей"
 
-#: ../src/richtext/richtextfontpage.cpp:197 ../src/richtext/richtextfontpage.cpp:199
+#: ../src/richtext/richtextfontpage.cpp:197
+#: ../src/richtext/richtextfontpage.cpp:199
 msgid "Lists font sizes in points."
 msgstr "Списки размеров шрифта в пунктах."
 
-#: ../src/richtext/richtextfontpage.cpp:190 ../src/richtext/richtextfontpage.cpp:192
+#: ../src/richtext/richtextfontpage.cpp:190
+#: ../src/richtext/richtextfontpage.cpp:192
 msgid "Lists the available fonts."
 msgstr "Списки доступных шрифтов."
 
-#: ../src/common/fldlgcmn.cpp:340
+#: ../src/common/fldlgcmn.cpp:337
 #, c-format
 msgid "Load %s file"
 msgstr "Загрузить файл %s"
 
-#: ../src/html/htmlwin.cpp:597
+#: ../src/html/htmlwin.cpp:600
 msgid "Loading : "
 msgstr "Загрузка : "
 
-#: ../src/unix/snglinst.cpp:246
+#: ../src/unix/snglinst.cpp:243
 #, c-format
 msgid "Lock file '%s' has incorrect owner."
 msgstr "Файл блокировки '%s' имеет неверного владельца."
 
-#: ../src/unix/snglinst.cpp:251
+#: ../src/unix/snglinst.cpp:248
 #, c-format
 msgid "Lock file '%s' has incorrect permissions."
 msgstr "Файл блокировки '%s' имеет неверные разрешения."
 
-#: ../src/generic/logg.cpp:576
+#: ../src/generic/logg.cpp:573
 #, c-format
 msgid "Log saved to the file '%s'."
 msgstr "Журнал записан в файл '%s'."
@@ -4625,201 +4833,201 @@ msgstr "Строчные буквы"
 msgid "Lower case roman numerals"
 msgstr "Строчные римские цифры"
 
-#: ../src/gtk/mdi.cpp:422 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk1/mdi.cpp:431 ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "Дочерний MDI"
 
-#: ../src/msw/helpchm.cpp:56
+#: ../src/msw/helpchm.cpp:53
 msgid ""
-"MS HTML Help functions are unavailable because the MS HTML Help library is not "
-"installed on this machine. Please install it."
+"MS HTML Help functions are unavailable because the MS HTML Help library is "
+"not installed on this machine. Please install it."
 msgstr ""
 "Функции справки MS HTML недоступны, так как библиотека справки MS HTML не "
 "установлена на этой машине. Установите её."
 
-#: ../src/univ/themes/win32.cpp:3754
+#: ../src/univ/themes/win32.cpp:3751
 msgid "Ma&ximize"
 msgstr "&Развернуть"
 
-#: ../src/common/fmapbase.cpp:203
+#: ../src/common/fmapbase.cpp:200
 msgid "MacArabic"
 msgstr "MacArabic"
 
-#: ../src/common/fmapbase.cpp:222
+#: ../src/common/fmapbase.cpp:219
 msgid "MacArmenian"
 msgstr "MacArmenian"
 
-#: ../src/common/fmapbase.cpp:211
+#: ../src/common/fmapbase.cpp:208
 msgid "MacBengali"
 msgstr "MacBengali"
 
-#: ../src/common/fmapbase.cpp:217
+#: ../src/common/fmapbase.cpp:214
 msgid "MacBurmese"
 msgstr "MacBurmese"
 
-#: ../src/common/fmapbase.cpp:236
+#: ../src/common/fmapbase.cpp:233
 msgid "MacCeltic"
 msgstr "MacCeltic"
 
-#: ../src/common/fmapbase.cpp:227
+#: ../src/common/fmapbase.cpp:224
 msgid "MacCentralEurRoman"
 msgstr "MacCentralEurRoman"
 
-#: ../src/common/fmapbase.cpp:223
+#: ../src/common/fmapbase.cpp:220
 msgid "MacChineseSimp"
 msgstr "MacChineseSimp"
 
-#: ../src/common/fmapbase.cpp:201
+#: ../src/common/fmapbase.cpp:198
 msgid "MacChineseTrad"
 msgstr "MacChineseTrad"
 
-#: ../src/common/fmapbase.cpp:233
+#: ../src/common/fmapbase.cpp:230
 msgid "MacCroatian"
 msgstr "MacCroatian"
 
-#: ../src/common/fmapbase.cpp:206
+#: ../src/common/fmapbase.cpp:203
 msgid "MacCyrillic"
 msgstr "MacCyrillic"
 
-#: ../src/common/fmapbase.cpp:207
+#: ../src/common/fmapbase.cpp:204
 msgid "MacDevanagari"
 msgstr "MacDevanagari"
 
-#: ../src/common/fmapbase.cpp:231
+#: ../src/common/fmapbase.cpp:228
 msgid "MacDingbats"
 msgstr "MacDingbats"
 
-#: ../src/common/fmapbase.cpp:226
+#: ../src/common/fmapbase.cpp:223
 msgid "MacEthiopic"
 msgstr "MacEthiopic"
 
-#: ../src/common/fmapbase.cpp:229
+#: ../src/common/fmapbase.cpp:226
 msgid "MacExtArabic"
 msgstr "MacExtArabic"
 
-#: ../src/common/fmapbase.cpp:237
+#: ../src/common/fmapbase.cpp:234
 msgid "MacGaelic"
 msgstr "MacGaelic"
 
-#: ../src/common/fmapbase.cpp:221
+#: ../src/common/fmapbase.cpp:218
 msgid "MacGeorgian"
 msgstr "MacGeorgian"
 
-#: ../src/common/fmapbase.cpp:205
+#: ../src/common/fmapbase.cpp:202
 msgid "MacGreek"
 msgstr "MacGreek"
 
-#: ../src/common/fmapbase.cpp:209
+#: ../src/common/fmapbase.cpp:206
 msgid "MacGujarati"
 msgstr "MacGujarati"
 
-#: ../src/common/fmapbase.cpp:208
+#: ../src/common/fmapbase.cpp:205
 msgid "MacGurmukhi"
 msgstr "MacGurmukhi"
 
-#: ../src/common/fmapbase.cpp:204
+#: ../src/common/fmapbase.cpp:201
 msgid "MacHebrew"
 msgstr "MacHebrew"
 
-#: ../src/common/fmapbase.cpp:234
+#: ../src/common/fmapbase.cpp:231
 msgid "MacIcelandic"
 msgstr "MacIcelandic"
 
-#: ../src/common/fmapbase.cpp:200
+#: ../src/common/fmapbase.cpp:197
 msgid "MacJapanese"
 msgstr "MacJapanese"
 
-#: ../src/common/fmapbase.cpp:214
+#: ../src/common/fmapbase.cpp:211
 msgid "MacKannada"
 msgstr "MacKannada"
 
-#: ../src/common/fmapbase.cpp:238
+#: ../src/common/fmapbase.cpp:235
 msgid "MacKeyboardGlyphs"
 msgstr "MacKeyboardGlyphs"
 
-#: ../src/common/fmapbase.cpp:218
+#: ../src/common/fmapbase.cpp:215
 msgid "MacKhmer"
 msgstr "MacKhmer"
 
-#: ../src/common/fmapbase.cpp:202
+#: ../src/common/fmapbase.cpp:199
 msgid "MacKorean"
 msgstr "MacKorean"
 
-#: ../src/common/fmapbase.cpp:220
+#: ../src/common/fmapbase.cpp:217
 msgid "MacLaotian"
 msgstr "MacLaotian"
 
-#: ../src/common/fmapbase.cpp:215
+#: ../src/common/fmapbase.cpp:212
 msgid "MacMalayalam"
 msgstr "MacMalayalam"
 
-#: ../src/common/fmapbase.cpp:225
+#: ../src/common/fmapbase.cpp:222
 msgid "MacMongolian"
 msgstr "MacMongolian"
 
-#: ../src/common/fmapbase.cpp:210
+#: ../src/common/fmapbase.cpp:207
 msgid "MacOriya"
 msgstr "MacOriya"
 
-#: ../src/common/fmapbase.cpp:199
+#: ../src/common/fmapbase.cpp:196
 msgid "MacRoman"
 msgstr "MacRoman"
 
-#: ../src/common/fmapbase.cpp:235
+#: ../src/common/fmapbase.cpp:232
 msgid "MacRomanian"
 msgstr "MacRomanian"
 
-#: ../src/common/fmapbase.cpp:216
+#: ../src/common/fmapbase.cpp:213
 msgid "MacSinhalese"
 msgstr "MacSinhalese"
 
-#: ../src/common/fmapbase.cpp:230
+#: ../src/common/fmapbase.cpp:227
 msgid "MacSymbol"
 msgstr "MacSymbol"
 
-#: ../src/common/fmapbase.cpp:212
+#: ../src/common/fmapbase.cpp:209
 msgid "MacTamil"
 msgstr "MacTamil"
 
-#: ../src/common/fmapbase.cpp:213
+#: ../src/common/fmapbase.cpp:210
 msgid "MacTelugu"
 msgstr "MacTelugu"
 
-#: ../src/common/fmapbase.cpp:219
+#: ../src/common/fmapbase.cpp:216
 msgid "MacThai"
 msgstr "MacThai"
 
-#: ../src/common/fmapbase.cpp:224
+#: ../src/common/fmapbase.cpp:221
 msgid "MacTibetan"
 msgstr "MacTibetan"
 
-#: ../src/common/fmapbase.cpp:232
+#: ../src/common/fmapbase.cpp:229
 msgid "MacTurkish"
 msgstr "MacTurkish"
 
-#: ../src/common/fmapbase.cpp:228
+#: ../src/common/fmapbase.cpp:225
 msgid "MacVietnamese"
 msgstr "MacVietnamese"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1762
+#: ../src/propgrid/advprops.cpp:1663
 msgid "Magnifier"
 msgstr "Лупа"
 
-#: ../src/propgrid/advprops.cpp:2143
+#: ../src/propgrid/advprops.cpp:2050
 msgid "Make a selection:"
 msgstr "Сделайте выбор:"
 
-#: ../src/richtext/richtextformatdlg.cpp:374
+#: ../src/richtext/richtextformatdlg.cpp:367
 #: ../src/richtext/richtextmarginspage.cpp:171
 msgid "Margins"
 msgstr "Поля"
 
-#: ../src/propgrid/advprops.cpp:1595
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Maroon"
 msgstr "Каштановый"
 
-#: ../src/generic/fdrepdlg.cpp:147
+#: ../src/generic/fdrepdlg.cpp:144
 msgid "Match case"
 msgstr "С учётом регистра"
 
@@ -4831,40 +5039,40 @@ msgstr "Макс. высота:"
 msgid "Max width:"
 msgstr "Макс. ширина:"
 
-#: ../src/unix/mediactrl.cpp:947
+#: ../src/unix/mediactrl.cpp:972
 #, c-format
 msgid "Media playback error: %s"
 msgstr "Ошибка проигрывания мультимедиа: %s"
 
-#: ../src/common/fs_mem.cpp:175
+#: ../src/common/fs_mem.cpp:170
 #, c-format
 msgid "Memory VFS already contains file '%s'!"
 msgstr "Память VFS уже содержит файл '%s'!"
 
 #. TRANSLATORS: Name of keyboard key
 #. TRANSLATORS: Keyword of system colour
-#: ../src/common/accelcmn.cpp:73 ../src/propgrid/advprops.cpp:889
+#: ../src/common/accelcmn.cpp:70 ../src/propgrid/advprops.cpp:790
 msgid "Menu"
 msgstr "Меню"
 
-#: ../src/common/msgout.cpp:124
+#: ../src/common/msgout.cpp:121
 msgid "Message"
 msgstr "Сообщение"
 
-#: ../src/univ/themes/metal.cpp:168
+#: ../src/univ/themes/metal.cpp:165
 msgid "Metal theme"
 msgstr "Тема Metal"
 
-#: ../src/msw/ole/automtn.cpp:652
+#: ../src/msw/ole/automtn.cpp:643
 msgid "Method or property not found."
 msgstr "Метод или свойство не найдено."
 
-#: ../src/univ/themes/win32.cpp:3752
+#: ../src/univ/themes/win32.cpp:3749
 msgid "Mi&nimize"
 msgstr "&Свернуть"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1763
+#: ../src/propgrid/advprops.cpp:1664
 msgid "Middle Button"
 msgstr "Средняя кнопка"
 
@@ -4876,144 +5084,164 @@ msgstr "Мин. высота:"
 msgid "Min width:"
 msgstr "Мин. ширина:"
 
-#: ../src/msw/ole/automtn.cpp:668
+#: ../src/osx/cocoa/menu.mm:281
+#, fuzzy
+msgid "Minimize"
+msgstr "&Свернуть"
+
+#: ../src/msw/ole/automtn.cpp:659
 msgid "Missing a required parameter."
 msgstr "Отсутствует обязательный параметр."
 
-#: ../src/generic/fontdlgg.cpp:324
+#: ../src/generic/fontdlgg.cpp:320
 msgid "Modern"
 msgstr "Современный"
 
-#: ../src/generic/filectrlg.cpp:427
+#: ../src/generic/filectrlg.cpp:423
 msgid "Modified"
 msgstr "Изменён"
 
-#: ../src/common/module.cpp:133
+#: ../src/common/module.cpp:130
 #, c-format
 msgid "Module \"%s\" initialization failed"
 msgstr "Ошибка инициализации модуля '%s'"
 
-#: ../src/common/paper.cpp:131
+#: ../src/common/paper.cpp:128
 msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
 msgstr "Конверт монарха, 3 7/8 x 7 1/2 дюйма"
 
-#: ../src/msw/fswatcher.cpp:143
+#: ../src/msw/fswatcher.cpp:140
 msgid "Monitoring individual files for changes is not supported currently."
-msgstr "Мониторинг измененй отдельных файлов  в настоящее время не поддерживается."
+msgstr ""
+"Мониторинг измененй отдельных файлов  в настоящее время не поддерживается."
 
-#: ../src/generic/editlbox.cpp:172
+#: ../src/generic/editlbox.cpp:160
 msgid "Move down"
 msgstr "Перейти вниз"
 
-#: ../src/generic/editlbox.cpp:171
+#: ../src/generic/editlbox.cpp:155
 msgid "Move up"
 msgstr "Перейти вверх"
 
-#: ../src/richtext/richtextsizepage.cpp:682 ../src/richtext/richtextsizepage.cpp:684
+#: ../src/richtext/richtextsizepage.cpp:682
+#: ../src/richtext/richtextsizepage.cpp:684
 msgid "Moves the object to the next paragraph."
 msgstr "Перемещает объект в следующий абзац."
 
-#: ../src/richtext/richtextsizepage.cpp:676 ../src/richtext/richtextsizepage.cpp:678
+#: ../src/richtext/richtextsizepage.cpp:676
+#: ../src/richtext/richtextsizepage.cpp:678
 msgid "Moves the object to the previous paragraph."
 msgstr "Перемещает объект в предыдущий абзац."
 
-#: ../src/richtext/richtextbuffer.cpp:9966
+#: ../src/richtext/richtextbuffer.cpp:9963
 msgid "Multiple Cell Properties"
 msgstr "Свойства нескольких ячеек"
 
-#: ../src/generic/filectrlg.cpp:424
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:82
+#, fuzzy
+msgid "Multiply"
+msgstr "KP_Multiply"
+
+#: ../src/generic/filectrlg.cpp:420
 msgid "Name"
 msgstr "Имя"
 
-#: ../src/propgrid/advprops.cpp:1596
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Navy"
 msgstr "Синий"
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "Network"
 msgstr "Сеть"
 
-#: ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173
 msgid "New"
 msgstr "Новый"
 
-#: ../src/richtext/richtextstyledlg.cpp:243
+#: ../src/richtext/richtextstyledlg.cpp:239
 msgid "New &Box Style..."
 msgstr "Новый стиль &поля..."
 
-#: ../src/richtext/richtextstyledlg.cpp:225
+#: ../src/richtext/richtextstyledlg.cpp:221
 msgid "New &Character Style..."
 msgstr "Новый стиль &символа..."
 
-#: ../src/richtext/richtextstyledlg.cpp:237
+#: ../src/richtext/richtextstyledlg.cpp:233
 msgid "New &List Style..."
 msgstr "Новые стиль &списка..."
 
-#: ../src/richtext/richtextstyledlg.cpp:231
+#: ../src/richtext/richtextstyledlg.cpp:227
 msgid "New &Paragraph Style..."
 msgstr "Новый стиль &абзаца..."
 
-#: ../src/richtext/richtextstyledlg.cpp:606 ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:654 ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:820 ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:893 ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:934 ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:602
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:650
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:816
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:889
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:930
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "New Style"
 msgstr "Новый стиль"
 
-#: ../src/generic/editlbox.cpp:169
+#: ../src/generic/editlbox.cpp:139
 msgid "New item"
 msgstr "Новый элемент"
 
-#: ../src/generic/dirdlgg.cpp:297 ../src/generic/dirdlgg.cpp:307
-#: ../src/generic/filectrlg.cpp:618 ../src/generic/filectrlg.cpp:627
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+#: ../src/generic/dirdlgg.cpp:294 ../src/generic/dirdlgg.cpp:304
 msgid "NewName"
 msgstr "НовоеИмя"
 
-#: ../src/common/prntbase.cpp:1567 ../src/html/helpwnd.cpp:665
+#: ../src/common/prntbase.cpp:1592 ../src/html/helpwnd.cpp:663
 msgid "Next page"
 msgstr "Следующая станица"
 
-#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:177
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:174
 #: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Нет"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1764
+#: ../src/propgrid/advprops.cpp:1665
 msgid "No Entry"
 msgstr "Нет записи"
 
-#: ../src/generic/animateg.cpp:150
+#: ../src/generic/animateg.cpp:133
 #, c-format
 msgid "No animation handler for type %ld defined."
 msgstr "Не определён обработчик анимации для типа %ld."
 
-#: ../src/dfb/bitmap.cpp:642 ../src/dfb/bitmap.cpp:676
+#: ../src/dfb/bitmap.cpp:639 ../src/dfb/bitmap.cpp:673
 #, c-format
 msgid "No bitmap handler for type %d defined."
 msgstr "Не определён обработчик растрового рисунка для типа %d."
 
-#: ../src/common/utilscmn.cpp:1077
+#: ../src/common/utilscmn.cpp:1095
 msgid "No default application configured for HTML files."
 msgstr "Приложение по умолчанию не настроено для HTML-файлов."
 
-#: ../src/generic/helpext.cpp:445
+#: ../src/generic/helpext.cpp:443
 msgid "No entries found."
 msgstr "Запись не найдена."
 
-#: ../src/common/fontmap.cpp:421
+#: ../src/common/fontmap.cpp:418
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found,\n"
 "but an alternative encoding '%s' is available.\n"
-"Do you want to use this encoding (otherwise you will have to choose another one)?"
+"Do you want to use this encoding (otherwise you will have to choose another "
+"one)?"
 msgstr ""
 "Не найден шрифт для отображения текста в кодировке '%s',\n"
 "но доступна альтернативная кодировка '%s'.\n"
 "Хотите использовать эту кодировку (в противном случае надо выбрать другую)?"
 
-#: ../src/common/fontmap.cpp:426
+#: ../src/common/fontmap.cpp:423
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found.\n"
@@ -5024,200 +5252,201 @@ msgstr ""
 "Хотите выбрать шрифт, который будет использоваться для этой кодировки\n"
 "(инаече текст в этой кодировке будет отображаться некорректно)?"
 
-#: ../src/generic/animateg.cpp:142
+#: ../src/generic/animateg.cpp:125
 msgid "No handler found for animation type."
 msgstr "Не найден обработчик для эого типа анимации."
 
-#: ../src/common/image.cpp:2728
+#: ../src/common/image.cpp:2823
 msgid "No handler found for image type."
 msgstr "Не найден обработчик для этого типа изображения."
 
-#: ../src/common/image.cpp:2736 ../src/common/image.cpp:2848
-#: ../src/common/image.cpp:2901
+#: ../src/common/image.cpp:2831 ../src/common/image.cpp:2954
+#: ../src/common/image.cpp:3020
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "Не определён обработчик для изображения типа %d."
 
-#: ../src/common/image.cpp:2871 ../src/common/image.cpp:2915
+#: ../src/common/image.cpp:2986 ../src/common/image.cpp:3034
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "Не определён обработчик для изображения типа %s."
 
-#: ../src/html/helpwnd.cpp:858
+#: ../src/html/helpwnd.cpp:856
 msgid "No matching page found yet"
 msgstr "Не найдена соответствующая страница"
 
-#: ../src/unix/sound.cpp:81
+#: ../src/unix/sound.cpp:78
 msgid "No sound"
 msgstr "Нет звука"
 
-#: ../src/common/image.cpp:2277 ../src/common/image.cpp:2318
+#: ../src/common/image.cpp:2371 ../src/common/image.cpp:2412
 msgid "No unused colour in image being masked."
 msgstr "Нет неиспользованного цвета в маскируемом изображении."
 
-#: ../src/common/image.cpp:3374
-msgid "No unused colour in image."
-msgstr "В изображении нет неиспользуемых цветов."
-
-#: ../src/generic/helpext.cpp:302
+#: ../src/generic/helpext.cpp:300
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "Не найдены допустимые сопоставления в файле '%s'."
 
+#: ../src/richtext/richtextsizepage.cpp:248
+#: ../src/richtext/richtextsizepage.cpp:252
 #: ../src/richtext/richtextborderspage.cpp:610
-#: ../src/richtext/richtextsizepage.cpp:248 ../src/richtext/richtextsizepage.cpp:252
 msgid "None"
 msgstr "Ничего"
 
-#: ../src/common/fmapbase.cpp:157
+#: ../src/common/fmapbase.cpp:154
 msgid "Nordic (ISO-8859-10)"
 msgstr "Скандинавский (ISO-8859-10)"
 
-#: ../src/generic/fontdlgg.cpp:328 ../src/generic/fontdlgg.cpp:331
+#: ../src/generic/fontdlgg.cpp:324 ../src/generic/fontdlgg.cpp:327
 msgid "Normal"
 msgstr "Нормальный"
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1261
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Нормальный шрифт<br>и <u>подчёркнутый</u>. "
 
-#: ../src/html/helpwnd.cpp:1205
+#: ../src/html/helpwnd.cpp:1203
 msgid "Normal font:"
 msgstr "Нормальный шрифт:"
 
-#: ../src/propgrid/props.cpp:1128
+#: ../src/propgrid/props.cpp:1115
 #, c-format
 msgid "Not %s"
 msgstr "Не %s"
 
-#: ../include/wx/filename.h:573 ../include/wx/filename.h:578
-msgid "Not available"
-msgstr "Не доступно"
+#: ../src/common/secretstore.cpp:168
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/webrequest.cpp:605
+msgid "Not enough free disk space for download."
+msgstr ""
 
 #: ../src/richtext/richtextfontpage.cpp:358
 msgid "Not underlined"
 msgstr "Не подчёркнутый"
 
-#: ../src/common/paper.cpp:115
+#: ../src/common/paper.cpp:112
 msgid "Note, 8 1/2 x 11 in"
 msgstr "Примечание, 8 1/2 x 11 дюйма"
 
-#: ../src/generic/notifmsgg.cpp:132
+#: ../src/generic/notifmsgg.cpp:129
 msgid "Notice"
 msgstr "Уведомление"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "Num *"
 msgstr "Num *"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "Num +"
 msgstr "Num +"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "Num ,"
 msgstr "Num ,"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "Num -"
 msgstr "Num -"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "Num ."
 msgstr "Num ."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "Num /"
 msgstr "Num /"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "Num ="
 msgstr "Num ="
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "Num Begin"
 msgstr "Num Begin"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 msgid "Num Delete"
 msgstr "Num Delete"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 msgid "Num Down"
 msgstr "Num Down"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "Num End"
 msgstr "Num End"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "Num Enter"
 msgstr "Num Enter"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 msgid "Num Home"
 msgstr "Num Home"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 msgid "Num Insert"
 msgstr "Num Insert"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num Lock"
 msgstr "Num Lock"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "Num Page Down"
 msgstr "Page Down"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "Num Page Up"
 msgstr "Page Up"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 msgid "Num Right"
 msgstr "Num Right"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "Num Space"
 msgstr "Num Space"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "Num Tab"
 msgstr "Num Tab"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "Num Up"
 msgstr "Num Up"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "Num left"
 msgstr "Num left"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num_lock"
 msgstr "Num_lock"
 
@@ -5226,13 +5455,13 @@ msgstr "Num_lock"
 msgid "Numbered outline"
 msgstr "Пронумерованный контур"
 
-#: ../include/wx/msgdlg.h:278 ../src/richtext/richtextstyledlg.cpp:297
-#: ../src/common/stockitem.cpp:178 ../src/msw/msgdlg.cpp:454 ../src/msw/msgdlg.cpp:747
-#: ../src/gtk1/fontdlg.cpp:138
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:175
+#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/msgdlg.cpp:741 ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "OK"
 
-#: ../src/msw/ole/automtn.cpp:692
+#: ../src/msw/ole/automtn.cpp:683
 #, c-format
 msgid "OLE Automation error in %s: %s"
 msgstr "Ошибка OLE-автоматизации в %s: %s"
@@ -5241,15 +5470,15 @@ msgstr "Ошибка OLE-автоматизации в %s: %s"
 msgid "Object Properties"
 msgstr "Свойства объекта"
 
-#: ../src/msw/ole/automtn.cpp:660
+#: ../src/msw/ole/automtn.cpp:651
 msgid "Object implementation does not support named arguments."
 msgstr "Реализация объекта не поддерживает именованные аргументы."
 
-#: ../src/common/xtixml.cpp:264
+#: ../src/common/xtixml.cpp:260
 msgid "Objects must have an id attribute"
 msgstr "Объекты должны иметь атрибут id"
 
-#: ../src/propgrid/advprops.cpp:1601
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Olive"
 msgstr "Оливковый"
 
@@ -5257,64 +5486,70 @@ msgstr "Оливковый"
 msgid "Opaci&ty:"
 msgstr "Не&прозрачность:"
 
-#: ../src/generic/colrdlgg.cpp:354
+#: ../src/generic/colrdlgg.cpp:374
 msgid "Opacity:"
 msgstr "Непрозрачность:"
 
-#: ../src/common/docview.cpp:1773 ../src/common/docview.cpp:1815
+#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
 msgid "Open File"
 msgstr "Открыть файл"
 
-#: ../src/html/helpwnd.cpp:671 ../src/html/helpwnd.cpp:1554
+#: ../src/html/helpwnd.cpp:669 ../src/html/helpwnd.cpp:1552
 msgid "Open HTML document"
 msgstr "Открыть документ HTML"
 
-#: ../src/generic/dbgrptg.cpp:163
+#: ../src/common/stockitem.cpp:265
+#, fuzzy
+msgid "Open an existing document"
+msgstr "Открыть документ HTML"
+
+#: ../src/generic/dbgrptg.cpp:160
 #, c-format
 msgid "Open file \"%s\""
 msgstr "Открыть файл \"%s\""
 
-#: ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176
 msgid "Open..."
 msgstr "Открыть..."
 
-#: ../src/unix/glx11.cpp:506 ../src/msw/glcanvas.cpp:592
+#: ../src/msw/glcanvas.cpp:607 ../src/unix/glx11.cpp:513
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
-msgstr "OpenGL 3,0 или более поздней версии не поддерживается драйвером OpenGL."
+msgstr ""
+"OpenGL 3,0 или более поздней версии не поддерживается драйвером OpenGL."
 
-#: ../src/generic/dirctrlg.cpp:599 ../src/generic/dirdlgg.cpp:323
-#: ../src/generic/filectrlg.cpp:642 ../src/generic/filectrlg.cpp:786
+#: ../src/generic/dirctrlg.cpp:565 ../src/generic/filectrlg.cpp:638
+#: ../src/generic/filectrlg.cpp:782 ../src/generic/dirdlgg.cpp:320
 msgid "Operation not permitted."
 msgstr "Операция не разрешена."
 
-#: ../src/common/cmdline.cpp:900
+#: ../src/common/cmdline.cpp:896
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "Параметр '%s' не может быть отрицательным"
 
-#: ../src/common/cmdline.cpp:1064
+#: ../src/common/cmdline.cpp:1060
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "Параметр '%s' требует значение."
 
-#: ../src/common/cmdline.cpp:1147
+#: ../src/common/cmdline.cpp:1143
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Параметр '%s': '%s' не может быть преобразован в дату."
 
-#: ../src/generic/prntdlgg.cpp:618
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Параметры"
 
-#: ../src/propgrid/advprops.cpp:1606
+#: ../src/propgrid/advprops.cpp:1512
 msgid "Orange"
 msgstr "Оранжевый"
 
-#: ../src/generic/prntdlgg.cpp:615 ../src/generic/prntdlgg.cpp:869
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:862
 msgid "Orientation"
 msgstr "Ориентация"
 
-#: ../src/common/windowid.cpp:242
+#: ../src/common/windowid.cpp:237
 msgid "Out of window IDs.  Recommend shutting down application."
 msgstr "Идентификаторы вне окна. Рекомендуем закрыть приложениея."
 
@@ -5327,148 +5562,148 @@ msgstr "Контур"
 msgid "Outset"
 msgstr "Начальный этап"
 
-#: ../src/msw/ole/automtn.cpp:656
+#: ../src/msw/ole/automtn.cpp:647
 msgid "Overflow while coercing argument values."
 msgstr "Переполнение при принудительном значении аргументов."
 
-#: ../src/common/imagpcx.cpp:457 ../src/common/imagpcx.cpp:480
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:479
 msgid "PCX: couldn't allocate memory"
 msgstr "PCX: не удалось выделить память"
 
-#: ../src/common/imagpcx.cpp:456
+#: ../src/common/imagpcx.cpp:455
 msgid "PCX: image format unsupported"
 msgstr "PCX: формат изображения не поддерживается"
 
-#: ../src/common/imagpcx.cpp:479
+#: ../src/common/imagpcx.cpp:478
 msgid "PCX: invalid image"
 msgstr "PCX: недопустимое изображение"
 
-#: ../src/common/imagpcx.cpp:442
+#: ../src/common/imagpcx.cpp:441
 msgid "PCX: this is not a PCX file."
 msgstr "PCX: это не файл PCX."
 
-#: ../src/common/imagpcx.cpp:459 ../src/common/imagpcx.cpp:481
+#: ../src/common/imagpcx.cpp:458 ../src/common/imagpcx.cpp:480
 msgid "PCX: unknown error !!!"
 msgstr "PCX: неизвестная ошибка !!!"
 
-#: ../src/common/imagpcx.cpp:458
+#: ../src/common/imagpcx.cpp:457
 msgid "PCX: version number too low"
 msgstr "PCX: номер версии слишком мал"
 
-#: ../src/common/imagpnm.cpp:91
+#: ../src/common/imagpnm.cpp:89
 msgid "PNM: Couldn't allocate memory."
 msgstr "PNM: не удалось выделить память."
 
-#: ../src/common/imagpnm.cpp:73
+#: ../src/common/imagpnm.cpp:71
 msgid "PNM: File format is not recognized."
 msgstr "PNM: формат файла не распознан."
 
-#: ../src/common/imagpnm.cpp:112 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
 #: ../src/common/imagpnm.cpp:156
 msgid "PNM: File seems truncated."
 msgstr "PNM: файл кажется усечённым."
 
-#: ../src/common/paper.cpp:187
+#: ../src/common/paper.cpp:184
 msgid "PRC 16K 146 x 215 mm"
 msgstr "КНР 16K 146 x 215 мм"
 
-#: ../src/common/paper.cpp:200
+#: ../src/common/paper.cpp:197
 msgid "PRC 16K Rotated"
 msgstr "КНР 16K Повёрнут"
 
-#: ../src/common/paper.cpp:188
+#: ../src/common/paper.cpp:185
 msgid "PRC 32K 97 x 151 mm"
 msgstr "КНР 32K 97 x 151 мм"
 
-#: ../src/common/paper.cpp:201
+#: ../src/common/paper.cpp:198
 msgid "PRC 32K Rotated"
 msgstr "КНР Повёрнут 32K"
 
-#: ../src/common/paper.cpp:189
+#: ../src/common/paper.cpp:186
 msgid "PRC 32K(Big) 97 x 151 mm"
 msgstr "КНР 32K(большой) : 97 x 151 мм"
 
-#: ../src/common/paper.cpp:202
+#: ../src/common/paper.cpp:199
 msgid "PRC 32K(Big) Rotated"
 msgstr "КНР 32K(большой) повёрнут"
 
-#: ../src/common/paper.cpp:190
+#: ../src/common/paper.cpp:187
 msgid "PRC Envelope #1 102 x 165 mm"
 msgstr "КНР Конверт №1 102 х 165 мм"
 
-#: ../src/common/paper.cpp:203
+#: ../src/common/paper.cpp:200
 msgid "PRC Envelope #1 Rotated 165 x 102 mm"
 msgstr "КНР Конверт №1 повёрнут 165 x 102 мм"
 
-#: ../src/common/paper.cpp:199
+#: ../src/common/paper.cpp:196
 msgid "PRC Envelope #10 324 x 458 mm"
 msgstr "КНР Конверт №10 324 х 458 мм"
 
-#: ../src/common/paper.cpp:212
+#: ../src/common/paper.cpp:209
 msgid "PRC Envelope #10 Rotated 458 x 324 mm"
 msgstr "КНР Конверт №10 повёрнут 458 x 324 мм"
 
-#: ../src/common/paper.cpp:191
+#: ../src/common/paper.cpp:188
 msgid "PRC Envelope #2 102 x 176 mm"
 msgstr "КНР Конверт №2 102 x 176 мм"
 
-#: ../src/common/paper.cpp:204
+#: ../src/common/paper.cpp:201
 msgid "PRC Envelope #2 Rotated 176 x 102 mm"
 msgstr "КНР Конверт №2 повёрнут 176 102 мм"
 
-#: ../src/common/paper.cpp:192
+#: ../src/common/paper.cpp:189
 msgid "PRC Envelope #3 125 x 176 mm"
 msgstr "КНР Конверт №3 125 x 176 мм"
 
-#: ../src/common/paper.cpp:205
+#: ../src/common/paper.cpp:202
 msgid "PRC Envelope #3 Rotated 176 x 125 mm"
 msgstr "КНР Конверт №3 повёрнут 176 x 125 мм"
 
-#: ../src/common/paper.cpp:193
+#: ../src/common/paper.cpp:190
 msgid "PRC Envelope #4 110 x 208 mm"
 msgstr "КНР Конверт №4 110 x 208 мм"
 
-#: ../src/common/paper.cpp:206
+#: ../src/common/paper.cpp:203
 msgid "PRC Envelope #4 Rotated 208 x 110 mm"
 msgstr "КНР Конверт №4 повёрнут 208 x 110 мм"
 
-#: ../src/common/paper.cpp:194
+#: ../src/common/paper.cpp:191
 msgid "PRC Envelope #5 110 x 220 mm"
 msgstr "КНР Конверт №5 110 x 220 мм"
 
-#: ../src/common/paper.cpp:207
+#: ../src/common/paper.cpp:204
 msgid "PRC Envelope #5 Rotated 220 x 110 mm"
 msgstr "КНР Конверт №5 повёрнут 220 x 110 мм"
 
-#: ../src/common/paper.cpp:195
+#: ../src/common/paper.cpp:192
 msgid "PRC Envelope #6 120 x 230 mm"
 msgstr "КНР Конверт №6 120 x 230 мм"
 
-#: ../src/common/paper.cpp:208
+#: ../src/common/paper.cpp:205
 msgid "PRC Envelope #6 Rotated 230 x 120 mm"
 msgstr "КНР Конверт №6 повёрнут 230 x 120 мм"
 
-#: ../src/common/paper.cpp:196
+#: ../src/common/paper.cpp:193
 msgid "PRC Envelope #7 160 x 230 mm"
 msgstr "КНР Конверт №7 160 x 230 мм"
 
-#: ../src/common/paper.cpp:209
+#: ../src/common/paper.cpp:206
 msgid "PRC Envelope #7 Rotated 230 x 160 mm"
 msgstr "КНР Конверт №7 повёрнут 230 х 160 мм"
 
-#: ../src/common/paper.cpp:197
+#: ../src/common/paper.cpp:194
 msgid "PRC Envelope #8 120 x 309 mm"
 msgstr "КНР Конверт №8 120 x 309 мм"
 
-#: ../src/common/paper.cpp:210
+#: ../src/common/paper.cpp:207
 msgid "PRC Envelope #8 Rotated 309 x 120 mm"
 msgstr "КНР Конверт №8 повёрнут 309 x 120 мм"
 
-#: ../src/common/paper.cpp:198
+#: ../src/common/paper.cpp:195
 msgid "PRC Envelope #9 229 x 324 mm"
 msgstr "КНР Конверт №9 229 x 324 мм"
 
-#: ../src/common/paper.cpp:211
+#: ../src/common/paper.cpp:208
 msgid "PRC Envelope #9 Rotated 324 x 229 mm"
 msgstr "КНР Конверт №9 повёрнут 324 x 229 мм"
 
@@ -5476,87 +5711,91 @@ msgstr "КНР Конверт №9 повёрнут 324 x 229 мм"
 msgid "Padding"
 msgstr "Заполнение"
 
-#: ../src/common/prntbase.cpp:2074
+#: ../src/common/prntbase.cpp:2096
 #, c-format
 msgid "Page %d"
 msgstr "Страница %d"
 
-#: ../src/common/prntbase.cpp:2072
+#: ../src/common/prntbase.cpp:2094
 #, c-format
 msgid "Page %d of %d"
 msgstr "Страница %d из %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 msgid "Page Down"
 msgstr "Page Down"
 
-#: ../src/gtk/print.cpp:826
+#: ../src/gtk/print.cpp:829
 msgid "Page Setup"
 msgstr "Настройки страницы"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 msgid "Page Up"
 msgstr "Page Up"
 
-#: ../src/generic/prntdlgg.cpp:828 ../src/common/prntbase.cpp:484
+#: ../src/common/prntbase.cpp:479 ../src/generic/prntdlgg.cpp:821
 msgid "Page setup"
 msgstr "Настройки страницы"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 msgid "PageDown"
 msgstr "PageDown"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 msgid "PageUp"
 msgstr "PageUp"
 
-#: ../src/generic/prntdlgg.cpp:216
+#: ../src/generic/prntdlgg.cpp:209
 msgid "Pages"
 msgstr "Страницы"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1765
+#: ../src/propgrid/advprops.cpp:1666
 msgid "Paint Brush"
 msgstr "Кисть отрисовки"
 
-#: ../src/generic/prntdlgg.cpp:602 ../src/generic/prntdlgg.cpp:801
-#: ../src/generic/prntdlgg.cpp:842 ../src/generic/prntdlgg.cpp:855
-#: ../src/generic/prntdlgg.cpp:1052 ../src/generic/prntdlgg.cpp:1057
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:794
+#: ../src/generic/prntdlgg.cpp:835 ../src/generic/prntdlgg.cpp:848
+#: ../src/generic/prntdlgg.cpp:1045 ../src/generic/prntdlgg.cpp:1050
 msgid "Paper size"
 msgstr "Размер бумаги"
 
-#: ../src/richtext/richtextstyles.cpp:1062
+#: ../src/richtext/richtextstyles.cpp:1059
 msgid "Paragraph styles"
 msgstr "Стили абзаца"
 
-#: ../src/common/xtistrm.cpp:465
+#: ../src/common/xtistrm.cpp:462
 msgid "Passing a already registered object to SetObject"
 msgstr "Передача уже зарегистрированного объекта в SetObject"
 
-#: ../src/common/xtistrm.cpp:476
+#: ../src/common/xtistrm.cpp:473
 msgid "Passing an unknown object to GetObject"
 msgstr "Передача неизвестного объекта в GetObject"
 
-#: ../src/richtext/richtextctrl.cpp:3513 ../src/common/stockitem.cpp:180
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:177 ../src/richtext/richtextctrl.cpp:3514
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Вставить"
 
-#: ../src/common/stockitem.cpp:262
+#: ../src/common/stockitem.cpp:260
 msgid "Paste selection"
 msgstr "Вставить выбранное"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:74
+#: ../src/common/accelcmn.cpp:71
 msgid "Pause"
 msgstr "Пауза"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1766
+#: ../src/propgrid/advprops.cpp:1667
 msgid "Pencil"
 msgstr "Карандаш"
 
@@ -5565,21 +5804,21 @@ msgstr "Карандаш"
 msgid "Peri&od"
 msgstr "Пери&od"
 
-#: ../src/generic/filectrlg.cpp:430
+#: ../src/generic/filectrlg.cpp:426
 msgid "Permissions"
 msgstr "Разрешения"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:60
+#: ../src/common/accelcmn.cpp:57
 msgid "PgDn"
 msgstr "PgDn"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:59
+#: ../src/common/accelcmn.cpp:56
 msgid "PgUp"
 msgstr "PgUp"
 
-#: ../src/richtext/richtextbuffer.cpp:12868
+#: ../src/richtext/richtextbuffer.cpp:12863
 msgid "Picture Properties"
 msgstr "Свойства рисунка"
 
@@ -5591,42 +5830,42 @@ msgstr "Ошибка создания потока ввода-вывода"
 msgid "Please choose a valid font."
 msgstr "Выберите допустимый шрифт."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
 msgid "Please choose an existing file."
 msgstr "Выберите существующий файл."
 
-#: ../src/html/helpwnd.cpp:800
+#: ../src/html/helpwnd.cpp:798
 msgid "Please choose the page to display:"
 msgstr "Выберите страницу для отображения:"
 
-#: ../src/msw/dialup.cpp:764
+#: ../src/msw/dialup.cpp:758
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Выберите ISP, к которому хотите подключиться"
 
-#: ../src/common/headerctrlcmn.cpp:59
+#: ../src/common/headerctrlcmn.cpp:57
 msgid "Please select the columns to show and define their order:"
 msgstr "Выберите колонки для отображения и определите их порядок:"
 
-#: ../src/common/prntbase.cpp:538
+#: ../src/common/prntbase.cpp:533
 msgid "Please wait while printing..."
 msgstr "Дождитесь окончания печати..."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1767
+#: ../src/propgrid/advprops.cpp:1668
 msgid "Point Left"
 msgstr "Точка слева"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1768
+#: ../src/propgrid/advprops.cpp:1669
 msgid "Point Right"
 msgstr "Точка вправо"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:662
+#: ../src/propgrid/advprops.cpp:572
 msgid "Point Size"
 msgstr "Размер точки"
 
-#: ../src/generic/prntdlgg.cpp:612 ../src/generic/prntdlgg.cpp:867
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:860
 msgid "Portrait"
 msgstr "Портрет"
 
@@ -5634,250 +5873,262 @@ msgstr "Портрет"
 msgid "Position"
 msgstr "Позиция"
 
-#: ../src/generic/prntdlgg.cpp:298
+#: ../src/generic/prntdlgg.cpp:291
 msgid "PostScript file"
 msgstr "Файл PostScript"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178 ../src/osx/cocoa/preferences.mm:303
 msgid "Preferences"
 msgstr "Настройки"
 
-#: ../src/osx/menu_osx.cpp:568
+#: ../src/osx/menu_osx.cpp:460
 msgid "Preferences..."
 msgstr "Параметры..."
 
-#: ../src/common/prntbase.cpp:546
+#: ../src/common/prntbase.cpp:541
 msgid "Preparing"
 msgstr "Подготовка"
 
-#: ../src/generic/fontdlgg.cpp:455 ../src/osx/carbon/fontdlg.cpp:390
-#: ../src/html/helpwnd.cpp:1222
+#: ../src/osx/carbon/fontdlg.cpp:387 ../src/generic/fontdlgg.cpp:452
+#: ../src/html/helpwnd.cpp:1220
 msgid "Preview:"
 msgstr "Предпросмотр:"
 
-#: ../src/common/prntbase.cpp:1553 ../src/html/helpwnd.cpp:664
+#: ../src/common/prntbase.cpp:1578 ../src/html/helpwnd.cpp:662
 msgid "Previous page"
 msgstr "Предыдущая страница"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/prntdlgg.cpp:143 ../src/generic/prntdlgg.cpp:157
-#: ../src/common/prntbase.cpp:426 ../src/common/prntbase.cpp:1541
-#: ../src/common/accelcmn.cpp:77 ../src/gtk/print.cpp:620 ../src/gtk/print.cpp:638
+#: ../src/common/prntbase.cpp:421 ../src/common/prntbase.cpp:1566
+#: ../src/common/accelcmn.cpp:74 ../src/generic/prntdlgg.cpp:136
+#: ../src/generic/prntdlgg.cpp:150 ../src/gtk/print.cpp:616
+#: ../src/gtk/print.cpp:634
 msgid "Print"
 msgstr "Печать"
 
-#: ../include/wx/prntbase.h:399 ../src/common/docview.cpp:1268
+#: ../src/common/docview.cpp:1262
 msgid "Print Preview"
 msgstr "Предпросмотр печати"
 
-#: ../src/common/prntbase.cpp:2015 ../src/common/prntbase.cpp:2057
-#: ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2037 ../src/common/prntbase.cpp:2079
+#: ../src/common/prntbase.cpp:2087
 msgid "Print Preview Failure"
 msgstr "Ошибка предпросмотра печати"
 
-#: ../src/generic/prntdlgg.cpp:224
+#: ../src/generic/prntdlgg.cpp:217
 msgid "Print Range"
 msgstr "Интервал печати"
 
-#: ../src/generic/prntdlgg.cpp:449
+#: ../src/generic/prntdlgg.cpp:442
 msgid "Print Setup"
 msgstr "Настройки печати"
 
-#: ../src/generic/prntdlgg.cpp:621
+#: ../src/generic/prntdlgg.cpp:614
 msgid "Print in colour"
 msgstr "Печать в цвете"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/osx/webview_webkit.mm:260
+msgid "Print operation could not be initialized"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:179
 msgid "Print previe&w..."
 msgstr "П&редпросмотр печати..."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1256
 msgid "Print preview creation failed."
 msgstr "Сбой при создании предпросмотра печати."
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/common/stockitem.cpp:179
 msgid "Print preview..."
 msgstr "Предпросмотр печати..."
 
-#: ../src/generic/prntdlgg.cpp:630
+#: ../src/generic/prntdlgg.cpp:623
 msgid "Print spooling"
 msgstr "Очередь печати"
 
-#: ../src/html/helpwnd.cpp:675
+#: ../src/html/helpwnd.cpp:673
 msgid "Print this page"
 msgstr "Напечатать эту страницу"
 
-#: ../src/generic/prntdlgg.cpp:185
+#: ../src/generic/prntdlgg.cpp:178
 msgid "Print to File"
 msgstr "Печать в файл"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "Print..."
 msgstr "Печать..."
 
-#: ../src/generic/prntdlgg.cpp:493
+#: ../src/generic/prntdlgg.cpp:486
 msgid "Printer"
 msgstr "Принтер"
 
-#: ../src/generic/prntdlgg.cpp:633
+#: ../src/generic/prntdlgg.cpp:626
 msgid "Printer command:"
 msgstr "Команда принтера:"
 
-#: ../src/generic/prntdlgg.cpp:180
+#: ../src/generic/prntdlgg.cpp:173
 msgid "Printer options"
 msgstr "Параметры принтера"
 
-#: ../src/generic/prntdlgg.cpp:645
+#: ../src/generic/prntdlgg.cpp:638
 msgid "Printer options:"
 msgstr "Параметры принтера:"
 
-#: ../src/generic/prntdlgg.cpp:916
+#: ../src/generic/prntdlgg.cpp:909
 msgid "Printer..."
 msgstr "Принтер..."
 
-#: ../src/generic/prntdlgg.cpp:196
+#: ../src/generic/prntdlgg.cpp:189
 msgid "Printer:"
 msgstr "Принтер:"
 
-#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:535
-#: ../src/html/htmprint.cpp:277
+#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:530
+#: ../src/html/htmprint.cpp:289
 msgid "Printing"
 msgstr "Печать"
 
-#: ../src/common/prntbase.cpp:612
+#: ../src/common/prntbase.cpp:607
 msgid "Printing "
 msgstr "Печать "
 
-#: ../src/common/prntbase.cpp:347
+#: ../src/common/prntbase.cpp:342
 msgid "Printing Error"
 msgstr "Ошибка печати"
 
-#: ../src/common/prntbase.cpp:565
+#: ../src/osx/webview_webkit.mm:251
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "Gzip не поддерживается этой версией zlib"
+
+#: ../src/common/prntbase.cpp:560
 #, c-format
 msgid "Printing page %d"
 msgstr "Печать страницы %d"
 
-#: ../src/common/prntbase.cpp:570
+#: ../src/common/prntbase.cpp:565
 #, c-format
 msgid "Printing page %d of %d"
 msgstr "Печать страницы %d из %d"
 
-#: ../src/generic/printps.cpp:201
+#: ../src/generic/printps.cpp:182
 #, c-format
 msgid "Printing page %d..."
 msgstr "Печать страницы %d..."
 
-#: ../src/generic/printps.cpp:161
+#: ../src/generic/printps.cpp:142
 msgid "Printing..."
 msgstr "Печать..."
 
-#: ../include/wx/richtext/richtextprint.h:109 ../include/wx/prntbase.h:267
-#: ../src/common/docview.cpp:2132
+#: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
+#: ../src/common/docview.cpp:2137
 msgid "Printout"
 msgstr "Распечатка"
 
-#: ../src/common/debugrpt.cpp:560
+#: ../src/common/debugrpt.cpp:561
 #, c-format
-msgid "Processing debug report has failed, leaving the files in \"%s\" directory."
+msgid ""
+"Processing debug report has failed, leaving the files in \"%s\" directory."
 msgstr ""
-"Обработка отчёта об отладке завершена с ошибкой, файлы остались в каталоге '%s'."
+"Обработка отчёта об отладке завершена с ошибкой, файлы остались в каталоге "
+"'%s'."
 
-#: ../src/common/prntbase.cpp:545
+#: ../src/common/prntbase.cpp:540
 msgid "Progress:"
 msgstr "Выполнение:"
 
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181
 msgid "Properties"
 msgstr "Свойства"
 
-#: ../src/propgrid/manager.cpp:237
+#: ../src/propgrid/manager.cpp:223
 msgid "Property"
 msgstr "Свойство"
 
 #. TRANSLATORS: Caption of message box displaying any property error
-#: ../src/propgrid/propgrid.cpp:3185 ../src/propgrid/propgrid.cpp:3318
+#: ../src/propgrid/propgrid.cpp:3162 ../src/propgrid/propgrid.cpp:3299
 msgid "Property Error"
 msgstr "Ошибка свойства"
 
-#: ../src/propgrid/advprops.cpp:1597
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Purple"
 msgstr "Фиолетовый"
 
-#: ../src/common/paper.cpp:112
+#: ../src/common/paper.cpp:109
 msgid "Quarto, 215 x 275 mm"
 msgstr "Кварто, 215 x 275 мм"
 
-#: ../src/generic/logg.cpp:1016
+#: ../src/generic/logg.cpp:1013
 msgid "Question"
 msgstr "Вопрос"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1769
+#: ../src/propgrid/advprops.cpp:1670
 msgid "Question Arrow"
 msgstr "Вопрос"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "Quit"
 msgstr "Выход"
 
-#: ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:477
 #, c-format
 msgid "Quit %s"
 msgstr "Выход из %s"
 
-#: ../src/common/stockitem.cpp:263
+#: ../src/common/stockitem.cpp:261
 msgid "Quit this program"
 msgstr "Завершить работу программы"
 
-#: ../src/common/accelcmn.cpp:338
+#: ../src/common/accelcmn.cpp:352
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/ffile.cpp:109 ../src/common/ffile.cpp:133
+#: ../src/common/ffile.cpp:107 ../src/common/ffile.cpp:132
 #, c-format
 msgid "Read error on file '%s'"
 msgstr "Ошибка чтения файла '%s'"
 
-#: ../src/common/secretstore.cpp:199
-#, c-format
-msgid "Reading password for \"%s/%s\" failed: %s."
+#: ../src/common/secretstore.cpp:211
+#, fuzzy, c-format
+msgid "Reading password for \"%s\" failed: %s."
 msgstr "Не удалось прочесть пароль для  '%s/%s': %s."
 
-#: ../src/common/prntbase.cpp:272
+#: ../src/common/prntbase.cpp:267
 msgid "Ready"
 msgstr "Готов"
 
-#: ../src/propgrid/advprops.cpp:1605
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Red"
 msgstr "Красный"
 
-#: ../src/generic/colrdlgg.cpp:339
+#: ../src/generic/colrdlgg.cpp:359
 msgid "Red:"
 msgstr "Красный:"
 
-#: ../src/common/stockitem.cpp:185 ../src/stc/stc_i18n.cpp:16
+#: ../src/common/stockitem.cpp:182 ../src/stc/stc_i18n.cpp:16
 msgid "Redo"
 msgstr "Повторить"
 
-#: ../src/common/stockitem.cpp:264
+#: ../src/common/stockitem.cpp:262
 msgid "Redo last action"
 msgstr "Повторить последнее действие"
 
-#: ../src/common/stockitem.cpp:186
+#: ../src/common/stockitem.cpp:183
 msgid "Refresh"
 msgstr "Обновить"
 
-#: ../src/msw/registry.cpp:626
+#: ../src/msw/registry.cpp:615
 #, c-format
 msgid "Registry key '%s' already exists."
 msgstr "Ключ реестра '%s' уже существует."
 
-#: ../src/msw/registry.cpp:595
+#: ../src/msw/registry.cpp:584
 #, c-format
 msgid "Registry key '%s' does not exist, cannot rename it."
 msgstr "Ключ реестра '%s' не существует, невозможно его переименовать."
 
-#: ../src/msw/registry.cpp:727
+#: ../src/msw/registry.cpp:716
 #, c-format
 msgid ""
 "Registry key '%s' is needed for normal system operation,\n"
@@ -5888,27 +6139,28 @@ msgstr ""
 "его удаление приведёт вашу систему в нерабочее состояние:\n"
 "операция прервана."
 
-#: ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:942
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr "Значение реестра  '%s' не является двоичным (но имеет тип %s)"
 
-#: ../src/msw/registry.cpp:917
+#: ../src/msw/registry.cpp:905
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr "Значение реестре '%s' не числовое (но имеет тип %s)"
 
-#: ../src/msw/registry.cpp:1003
+#: ../src/msw/registry.cpp:991
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr "Значение реестра  '%s' не является текстом (но имеет тип %s)"
 
-#: ../src/msw/registry.cpp:521
+#: ../src/msw/registry.cpp:510
 #, c-format
 msgid "Registry value '%s' already exists."
 msgstr "Значение реестра '%s' уже существует."
 
-#: ../src/richtext/richtextfontpage.cpp:350 ../src/richtext/richtextfontpage.cpp:354
+#: ../src/richtext/richtextfontpage.cpp:350
+#: ../src/richtext/richtextfontpage.cpp:354
 msgid "Regular"
 msgstr "Регулярные"
 
@@ -5916,70 +6168,77 @@ msgstr "Регулярные"
 msgid "Relative"
 msgstr "Относительно"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:456
 msgid "Relevant entries:"
 msgstr "Подходящие записи:"
 
-#: ../include/wx/generic/progdlgg.h:86
+#: ../include/wx/generic/progdlgg.h:87
 msgid "Remaining time:"
 msgstr "Оставшееся время:"
 
-#: ../src/common/stockitem.cpp:187
+#: ../src/common/stockitem.cpp:184
 msgid "Remove"
 msgstr "Удалить"
 
-#: ../src/richtext/richtextctrl.cpp:1562
+#: ../src/richtext/richtextctrl.cpp:1563
 msgid "Remove Bullet"
 msgstr "Удалить маркер"
 
-#: ../src/html/helpwnd.cpp:433
+#: ../src/html/helpwnd.cpp:431
 msgid "Remove current page from bookmarks"
 msgstr "Удалить текущую страницу из закладок"
 
-#: ../src/common/rendcmn.cpp:194
+#: ../src/common/rendcmn.cpp:191
 #, c-format
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
-msgstr "Визуализатор '%s' имеет несовместимую версию %d.%d и не может быть загружен."
+msgstr ""
+"Визуализатор '%s' имеет несовместимую версию %d.%d и не может быть загружен."
 
-#: ../src/richtext/richtextbuffer.cpp:4527
+#: ../src/richtext/richtextbuffer.cpp:4524
 msgid "Renumber List"
 msgstr "Перенумеровать список"
 
-#: ../src/common/stockitem.cpp:188
-msgid "Rep&lace"
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Rep&lace..."
 msgstr "За&менить"
 
-#: ../src/richtext/richtextctrl.cpp:3673 ../src/common/stockitem.cpp:188
+#: ../src/richtext/richtextctrl.cpp:3674
 msgid "Replace"
 msgstr "Заменить"
 
-#: ../src/generic/fdrepdlg.cpp:182
+#: ../src/generic/fdrepdlg.cpp:179
 msgid "Replace &all"
 msgstr "Заменить вс&ё"
 
-#: ../src/common/stockitem.cpp:261
-msgid "Replace selection"
-msgstr "Заменить выделенное"
-
-#: ../src/generic/fdrepdlg.cpp:124
+#: ../src/generic/fdrepdlg.cpp:121
 msgid "Replace with:"
 msgstr "Заменить на:"
 
-#: ../src/common/valtext.cpp:163
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Replace..."
+msgstr "Заменить"
+
+#: ../src/common/valtext.cpp:184
 msgid "Required information entry is empty."
 msgstr "Необходимая запись информации пуста."
 
-#: ../src/common/translation.cpp:1975
+#: ../src/common/translation.cpp:2025
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "Ресурс '%s' не является допустимым каталогом сообщений."
 
+#: ../src/gtk/webview_webkit.cpp:985
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:56
+#: ../src/common/accelcmn.cpp:53
 msgid "Return"
 msgstr "Возврат"
 
-#: ../src/common/stockitem.cpp:189
+#: ../src/common/stockitem.cpp:186
 msgid "Revert to Saved"
 msgstr "Откатить к сохранённому"
 
@@ -5991,40 +6250,41 @@ msgstr "Ребро"
 msgid "Rig&ht-to-left"
 msgstr "&Слева направо"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6149 ../src/richtext/richtextliststylepage.cpp:251
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:59 ../src/generic/datavgen.cpp:6954
+#: ../src/richtext/richtextsizepage.cpp:250
+#: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextbulletspage.cpp:188
-#: ../src/richtext/richtextsizepage.cpp:250 ../src/common/accelcmn.cpp:62
 msgid "Right"
 msgstr "Направо"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1754
+#: ../src/propgrid/advprops.cpp:1655
 msgid "Right Arrow"
 msgstr "Стрелка вправо"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1770
+#: ../src/propgrid/advprops.cpp:1671
 msgid "Right Button"
 msgstr "Правая кнопка"
 
-#: ../src/generic/prntdlgg.cpp:892
+#: ../src/generic/prntdlgg.cpp:885
 msgid "Right margin (mm):"
 msgstr "Правое поле (мм):"
 
-#: ../src/richtext/richtextindentspage.cpp:148
-#: ../src/richtext/richtextindentspage.cpp:150
 #: ../src/richtext/richtextliststylepage.cpp:337
 #: ../src/richtext/richtextliststylepage.cpp:339
+#: ../src/richtext/richtextindentspage.cpp:148
+#: ../src/richtext/richtextindentspage.cpp:150
 msgid "Right-align text."
 msgstr "Выровнять текст справа."
 
-#: ../src/generic/fontdlgg.cpp:322
+#: ../src/generic/fontdlgg.cpp:318
 msgid "Roman"
 msgstr "Римский"
 
-#: ../src/generic/datavgen.cpp:5916
+#: ../src/generic/datavgen.cpp:6721
 #, c-format
 msgid "Row %i"
 msgstr "Строка %i"
@@ -6034,30 +6294,31 @@ msgstr "Строка %i"
 msgid "S&tandard bullet name:"
 msgstr "Стандартное название маркера:"
 
-#: ../src/common/accelcmn.cpp:268 ../src/common/accelcmn.cpp:350
+#: ../src/common/accelcmn.cpp:282 ../src/common/accelcmn.cpp:367
 msgid "SPECIAL"
 msgstr "СПЕЦИАЛЬНЫЕ"
 
-#: ../src/common/stockitem.cpp:190 ../src/common/sizer.cpp:2797
+#: ../src/common/stockitem.cpp:187 ../src/common/sizer.cpp:2914
 msgid "Save"
 msgstr "Сохранить"
 
-#: ../src/common/fldlgcmn.cpp:342
+#: ../src/common/fldlgcmn.cpp:339
 #, c-format
 msgid "Save %s file"
 msgstr "Сохранить файл %s"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/common/stockitem.cpp:188 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Сохранить &как..."
 
-#: ../src/common/docview.cpp:366
+#: ../src/common/docview.cpp:359
 msgid "Save As"
 msgstr "Сохранить как"
 
-#: ../src/common/stockitem.cpp:191
-msgid "Save as"
-msgstr "Сохранить как"
+#: ../src/common/stockitem.cpp:188
+#, fuzzy
+msgid "Save As..."
+msgstr "Сохранить &как..."
 
 #: ../src/common/stockitem.cpp:267
 msgid "Save current document"
@@ -6067,105 +6328,109 @@ msgstr "Сохранить текущий документ"
 msgid "Save current document with a different filename"
 msgstr "Сохранить текущий документ с другим именем"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/generic/logg.cpp:509
 msgid "Save log contents to file"
 msgstr "Сохранить содержание журнала в файл"
 
-#: ../src/common/secretstore.cpp:179
-#, c-format
-msgid "Saving password for \"%s/%s\" failed: %s."
+#: ../src/common/secretstore.cpp:189
+#, fuzzy, c-format
+msgid "Saving password for \"%s\" failed: %s."
 msgstr "Не удалось сохранить пароль для  '%s/%s': %s."
 
-#: ../src/generic/fontdlgg.cpp:325
+#: ../src/generic/fontdlgg.cpp:321
 msgid "Script"
 msgstr "Скрипт"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll Lock"
 msgstr "Блок прокрутки"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll_lock"
 msgstr "Scroll_lock"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:890
+#: ../src/propgrid/advprops.cpp:791
 msgid "Scrollbar"
 msgstr "Полоса прокрутки"
 
-#: ../src/generic/srchctlg.cpp:56 ../src/html/helpwnd.cpp:535
-#: ../src/html/helpwnd.cpp:550
+#: ../src/generic/srchctlg.cpp:55 ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:548 ../src/gtk/srchctrl.cpp:182
 msgid "Search"
 msgstr "Поиск"
 
-#: ../src/html/helpwnd.cpp:537
+#: ../src/html/helpwnd.cpp:535
 msgid ""
-"Search contents of help book(s) for all occurrences of the text you typed above"
+"Search contents of help book(s) for all occurrences of the text you typed "
+"above"
 msgstr "Поиск содержимого книги справки для всех вхождений введённого текста"
 
-#: ../src/generic/fdrepdlg.cpp:160
+#: ../src/generic/fdrepdlg.cpp:157
 msgid "Search direction"
 msgstr "Направление поиска"
 
-#: ../src/generic/fdrepdlg.cpp:112
+#: ../src/generic/fdrepdlg.cpp:109
 msgid "Search for:"
 msgstr "Найти:"
 
-#: ../src/html/helpwnd.cpp:1052
+#: ../src/html/helpwnd.cpp:1050
 msgid "Search in all books"
 msgstr "Поиск во всех книгах"
 
-#: ../src/html/helpwnd.cpp:857
+#: ../src/html/helpwnd.cpp:855
 msgid "Searching..."
 msgstr "Поиск..."
 
-#: ../src/generic/dirctrlg.cpp:446
+#: ../src/generic/dirctrlg.cpp:412
 msgid "Sections"
 msgstr "Разделы"
 
-#: ../src/common/ffile.cpp:238
+#: ../src/common/ffile.cpp:237
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Ошибка смещения в файле '%s'"
 
-#: ../src/common/ffile.cpp:228
+#: ../src/common/ffile.cpp:227
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr "Ошибка смещения в файле '%s' (большие строки не поддерживаются stdio)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:76
+#: ../src/common/accelcmn.cpp:73
 msgid "Select"
 msgstr "Выделить"
 
-#: ../src/richtext/richtextctrl.cpp:337 ../src/osx/textctrl_osx.cpp:581
-#: ../src/common/stockitem.cpp:192 ../src/msw/textctrl.cpp:2512
+#: ../src/osx/textctrl_osx.cpp:599 ../src/common/stockitem.cpp:189
+#: ../src/msw/textctrl.cpp:2777 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Выделить вс&ё"
 
-#: ../src/common/stockitem.cpp:192 ../src/stc/stc_i18n.cpp:21
+#: ../src/common/stockitem.cpp:189 ../src/stc/stc_i18n.cpp:21
 msgid "Select All"
 msgstr "Выделить всё"
 
-#: ../src/common/docview.cpp:1895
+#: ../src/common/docview.cpp:1900
 msgid "Select a document template"
 msgstr "Выбрать шаблон документа"
 
-#: ../src/common/docview.cpp:1969
+#: ../src/common/docview.cpp:1974
 msgid "Select a document view"
 msgstr "Выбрать вид документа"
 
-#: ../src/richtext/richtextfontpage.cpp:226 ../src/richtext/richtextfontpage.cpp:228
+#: ../src/richtext/richtextfontpage.cpp:226
+#: ../src/richtext/richtextfontpage.cpp:228
 msgid "Select regular or bold."
 msgstr "Выбрать регулярный или жирный."
 
-#: ../src/richtext/richtextfontpage.cpp:213 ../src/richtext/richtextfontpage.cpp:215
+#: ../src/richtext/richtextfontpage.cpp:213
+#: ../src/richtext/richtextfontpage.cpp:215
 msgid "Select regular or italic style."
 msgstr "Выбрать регулярный или курсив."
 
-#: ../src/richtext/richtextfontpage.cpp:239 ../src/richtext/richtextfontpage.cpp:241
+#: ../src/richtext/richtextfontpage.cpp:239
+#: ../src/richtext/richtextfontpage.cpp:241
 msgid "Select underlining or no underlining."
 msgstr "Выбрать подчёркивание или без подчёркивания."
 
@@ -6179,20 +6444,20 @@ msgid "Selects the list level to edit."
 msgstr "Выбирает уровень списка для правки."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:82
+#: ../src/common/accelcmn.cpp:79
 msgid "Separator"
 msgstr "Разделитель"
 
-#: ../src/common/cmdline.cpp:1083
+#: ../src/common/cmdline.cpp:1079
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Разделитель, ожидаемый после параметра '%s'."
 
-#: ../src/osx/menu_osx.cpp:572
+#: ../src/osx/menu_osx.cpp:464
 msgid "Services"
 msgstr "Службы"
 
-#: ../src/richtext/richtextbuffer.cpp:11217
+#: ../src/richtext/richtextbuffer.cpp:11216
 msgid "Set Cell Style"
 msgstr "Задать стиль ячейки"
 
@@ -6200,13 +6465,14 @@ msgstr "Задать стиль ячейки"
 msgid "SetProperty called w/o valid setter"
 msgstr "SetProperty вызывается без действительного сеттера"
 
-#: ../src/generic/prntdlgg.cpp:188
+#: ../src/generic/prntdlgg.cpp:181
 msgid "Setup..."
 msgstr "Настройки..."
 
-#: ../src/msw/dialup.cpp:544
+#: ../src/msw/dialup.cpp:538
 msgid "Several active dialup connections found, choosing one randomly."
-msgstr "Найдено несколько активных соединений, выбираем одно случайным образом."
+msgstr ""
+"Найдено несколько активных соединений, выбираем одно случайным образом."
 
 #: ../src/richtext/richtextbackgroundpage.cpp:271
 msgid "Sh&adow spread:"
@@ -6220,39 +6486,40 @@ msgstr "Тень"
 msgid "Shadow c&olour:"
 msgstr "Цвет &тени:"
 
-#: ../src/common/accelcmn.cpp:335
+#: ../src/common/accelcmn.cpp:349
 msgid "Shift+"
 msgstr "Shift+"
 
-#: ../src/generic/dirdlgg.cpp:147
+#: ../src/generic/dirdlgg.cpp:144
 msgid "Show &hidden directories"
 msgstr "Показать &скрытые каталоги"
 
-#: ../src/generic/filectrlg.cpp:983
+#: ../src/generic/filectrlg.cpp:979
 msgid "Show &hidden files"
 msgstr "Показать &скрытые файлы"
 
-#: ../src/osx/menu_osx.cpp:580
+#: ../src/osx/menu_osx.cpp:472
 msgid "Show All"
 msgstr "Показать всё"
 
-#: ../src/common/stockitem.cpp:257
+#: ../src/common/stockitem.cpp:254
 msgid "Show about dialog"
 msgstr "Посмотреть в окне о программе"
 
-#: ../src/html/helpwnd.cpp:492
+#: ../src/html/helpwnd.cpp:490
 msgid "Show all"
 msgstr "Показать всё"
 
-#: ../src/html/helpwnd.cpp:503
+#: ../src/html/helpwnd.cpp:501
 msgid "Show all items in index"
 msgstr "Показать все элементы в индексе"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:656
 msgid "Show/hide navigation panel"
 msgstr "Показать/скрыть панель навигации"
 
-#: ../src/richtext/richtextsymboldlg.cpp:421 ../src/richtext/richtextsymboldlg.cpp:423
+#: ../src/richtext/richtextsymboldlg.cpp:418
+#: ../src/richtext/richtextsymboldlg.cpp:420
 msgid "Shows a Unicode subset."
 msgstr "Показывает Unicode подмножество."
 
@@ -6263,11 +6530,12 @@ msgstr "Показывает Unicode подмножество."
 msgid "Shows a preview of the bullet settings."
 msgstr "Показывает пред просмотр параметров маркера."
 
-#: ../src/richtext/richtextfontpage.cpp:330 ../src/richtext/richtextfontpage.cpp:332
+#: ../src/richtext/richtextfontpage.cpp:330
+#: ../src/richtext/richtextfontpage.cpp:332
 msgid "Shows a preview of the font settings."
 msgstr "Позволяет просмотреть параметры шрифта."
 
-#: ../src/osx/carbon/fontdlg.cpp:394 ../src/osx/carbon/fontdlg.cpp:396
+#: ../src/osx/carbon/fontdlg.cpp:391 ../src/osx/carbon/fontdlg.cpp:393
 msgid "Shows a preview of the font."
 msgstr "Показывает как выглядит шрифт."
 
@@ -6276,62 +6544,62 @@ msgstr "Показывает как выглядит шрифт."
 msgid "Shows a preview of the paragraph settings."
 msgstr "Показывает предпросмотр параметров абзаца."
 
-#: ../src/generic/fontdlgg.cpp:460 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:456 ../src/generic/fontdlgg.cpp:458
 msgid "Shows the font preview."
 msgstr "Показывает предпросмотр шрифта."
 
-#: ../src/propgrid/advprops.cpp:1607
+#: ../src/propgrid/advprops.cpp:1513
 msgid "Silver"
 msgstr "Серебряный"
 
-#: ../src/univ/themes/mono.cpp:516
+#: ../src/univ/themes/mono.cpp:513
 msgid "Simple monochrome theme"
 msgstr "Простая одноцветная тема"
 
-#: ../src/richtext/richtextindentspage.cpp:275
 #: ../src/richtext/richtextliststylepage.cpp:449
+#: ../src/richtext/richtextindentspage.cpp:275
 msgid "Single"
 msgstr "Один"
 
-#: ../src/generic/filectrlg.cpp:425 ../src/richtext/richtextformatdlg.cpp:369
-#: ../src/richtext/richtextsizepage.cpp:299
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextsizepage.cpp:299
+#: ../src/richtext/richtextformatdlg.cpp:362
 msgid "Size"
 msgstr "Размер"
 
-#: ../src/osx/carbon/fontdlg.cpp:339
+#: ../src/osx/carbon/fontdlg.cpp:336
 msgid "Size:"
 msgstr "Размер:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1775
+#: ../src/propgrid/advprops.cpp:1676
 msgid "Sizing"
 msgstr "Изменение размеров"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1772
+#: ../src/propgrid/advprops.cpp:1673
 msgid "Sizing N-S"
 msgstr "Размеры N-S"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1771
+#: ../src/propgrid/advprops.cpp:1672
 msgid "Sizing NE-SW"
 msgstr "Изменение размеров NE-SW"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1773
+#: ../src/propgrid/advprops.cpp:1674
 msgid "Sizing NW-SE"
 msgstr "Изменение размеров NW-SE"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1774
+#: ../src/propgrid/advprops.cpp:1675
 msgid "Sizing W-E"
 msgstr "D♯/E♭"
 
-#: ../src/msw/progdlg.cpp:801
+#: ../src/msw/progdlg.cpp:1088
 msgid "Skip"
 msgstr "Пропустить"
 
-#: ../src/generic/fontdlgg.cpp:330
+#: ../src/generic/fontdlgg.cpp:326
 msgid "Slant"
 msgstr "Наклонный"
 
@@ -6340,7 +6608,7 @@ msgid "Small C&apitals"
 msgstr "&Малые заглавные"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:79
+#: ../src/common/accelcmn.cpp:76
 msgid "Snapshot"
 msgstr "Снимок"
 
@@ -6348,35 +6616,37 @@ msgstr "Снимок"
 msgid "Solid"
 msgstr "Сплошной"
 
-#: ../src/common/docview.cpp:1791
+#: ../src/common/docview.cpp:1785
 msgid "Sorry, could not open this file."
 msgstr "Этот файл открыть нельзя."
 
-#: ../src/common/prntbase.cpp:2057 ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2079 ../src/common/prntbase.cpp:2087
 msgid "Sorry, not enough memory to create a preview."
 msgstr "Недостаточно памяти для создания окна предпросмотра."
 
-#: ../src/richtext/richtextstyledlg.cpp:611 ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:825 ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "Sorry, that name is taken. Please choose another."
 msgstr "Это имя занято. Пожалуйста, выберите другое."
 
-#: ../src/common/docview.cpp:1814
+#: ../src/common/docview.cpp:1819
 msgid "Sorry, the format for this file is unknown."
 msgstr "Формат этого файла неизвестен."
 
-#: ../src/unix/sound.cpp:492
+#: ../src/unix/sound.cpp:481
 msgid "Sound data are in unsupported format."
 msgstr "Данные звука имеют неподдерживаемый формат."
 
-#: ../src/unix/sound.cpp:477
+#: ../src/unix/sound.cpp:466
 #, c-format
 msgid "Sound file '%s' is in unsupported format."
 msgstr "Звуковой файл '%s' неподдерживаемого формата."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:67
+#: ../src/common/accelcmn.cpp:64
 msgid "Space"
 msgstr "ПРОБЕЛ"
 
@@ -6384,12 +6654,12 @@ msgstr "ПРОБЕЛ"
 msgid "Spacing"
 msgstr "Интервал"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "Spell Check"
 msgstr "Проверка правописания"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1776
+#: ../src/propgrid/advprops.cpp:1677
 msgid "Spraycan"
 msgstr "Аэрозоль"
 
@@ -6398,41 +6668,38 @@ msgstr "Аэрозоль"
 msgid "Standard"
 msgstr "Стандарт"
 
-#: ../src/common/paper.cpp:104
+#: ../src/common/paper.cpp:101
 msgid "Statement, 5 1/2 x 8 1/2 in"
 msgstr "Заявление, 5 1/2 x 8 1/2 дюйма"
 
-#: ../src/richtext/richtextsizepage.cpp:518 ../src/richtext/richtextsizepage.cpp:523
+#: ../src/richtext/richtextsizepage.cpp:518
+#: ../src/richtext/richtextsizepage.cpp:523
 msgid "Static"
 msgstr "Static"
 
-#: ../src/generic/prntdlgg.cpp:204
+#: ../src/generic/prntdlgg.cpp:197
 msgid "Status:"
 msgstr "Состояние:"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "Stop"
 msgstr "Остановить"
 
-#: ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196
 msgid "Strikethrough"
 msgstr "Перечёркивание"
 
-#: ../src/common/colourcmn.cpp:45
+#: ../src/common/colourcmn.cpp:42
 #, c-format
 msgid "String To Colour : Incorrect colour specification : %s"
 msgstr "Строка в цвет : неверная спецификация цвета : %s"
 
 #. TRANSLATORS: Label of font style
-#: ../src/richtext/richtextformatdlg.cpp:339 ../src/propgrid/advprops.cpp:680
+#: ../src/propgrid/advprops.cpp:590 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Стиль"
 
-#: ../include/wx/richtext/richtextstyledlg.h:46
-msgid "Style Organiser"
-msgstr "Органайзер стиля"
-
-#: ../src/osx/carbon/fontdlg.cpp:348
+#: ../src/osx/carbon/fontdlg.cpp:345
 msgid "Style:"
 msgstr "Стиль:"
 
@@ -6441,7 +6708,7 @@ msgid "Subscrip&t"
 msgstr "&Субиндекс"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:83
+#: ../src/common/accelcmn.cpp:80
 msgid "Subtract"
 msgstr "Вычесть"
 
@@ -6449,11 +6716,11 @@ msgstr "Вычесть"
 msgid "Supe&rscript"
 msgstr "&Верхний индекс"
 
-#: ../src/common/paper.cpp:150
+#: ../src/common/paper.cpp:147
 msgid "SuperA/SuperA/A4 227 x 356 mm"
 msgstr "СуперA/СуперA/A4 227 x 356 мм"
 
-#: ../src/common/paper.cpp:151
+#: ../src/common/paper.cpp:148
 msgid "SuperB/SuperB/A3 305 x 487 mm"
 msgstr "СуперB/СуперB/A3 305 x 487 мм"
 
@@ -6461,7 +6728,7 @@ msgstr "СуперB/СуперB/A3 305 x 487 мм"
 msgid "Suppress hyphe&nation"
 msgstr "&Подавить переносы"
 
-#: ../src/generic/fontdlgg.cpp:326
+#: ../src/generic/fontdlgg.cpp:322
 msgid "Swiss"
 msgstr "Швейцарский"
 
@@ -6479,73 +6746,73 @@ msgstr "Шрифт &символов:"
 msgid "Symbols"
 msgstr "Символы"
 
-#: ../src/common/imagtiff.cpp:369 ../src/common/imagtiff.cpp:382
-#: ../src/common/imagtiff.cpp:741
+#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
+#: ../src/common/imagtiff.cpp:738
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: не удалось выделить память."
 
-#: ../src/common/imagtiff.cpp:301
+#: ../src/common/imagtiff.cpp:298
 msgid "TIFF: Error loading image."
 msgstr "TIFF: ошибка загрузки изображения."
 
-#: ../src/common/imagtiff.cpp:468
+#: ../src/common/imagtiff.cpp:465
 msgid "TIFF: Error reading image."
 msgstr "TIFF: ошибка чтения изображения."
 
-#: ../src/common/imagtiff.cpp:608
+#: ../src/common/imagtiff.cpp:605
 msgid "TIFF: Error saving image."
 msgstr "TIFF: ошибка сохранения изображения."
 
-#: ../src/common/imagtiff.cpp:846
+#: ../src/common/imagtiff.cpp:843
 msgid "TIFF: Error writing image."
 msgstr "TIFF: ошибка записи изображения."
 
-#: ../src/common/imagtiff.cpp:355
+#: ../src/common/imagtiff.cpp:352
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: размер изображения ненормально большой."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:68
+#: ../src/common/accelcmn.cpp:65
 msgid "Tab"
 msgstr "Tab"
 
-#: ../src/richtext/richtextbuffer.cpp:11498
+#: ../src/richtext/richtextbuffer.cpp:11497
 msgid "Table Properties"
 msgstr "Свойства таблицы"
 
-#: ../src/common/paper.cpp:145
+#: ../src/common/paper.cpp:142
 msgid "Tabloid Extra 11.69 x 18 in"
 msgstr "Таблоид экстра 11,69 x 18  дюйма"
 
-#: ../src/common/paper.cpp:102
+#: ../src/common/paper.cpp:99
 msgid "Tabloid, 11 x 17 in"
 msgstr "Таблоид, 11 x 17  дюйма"
 
-#: ../src/richtext/richtextformatdlg.cpp:354
+#: ../src/richtext/richtextformatdlg.cpp:347
 msgid "Tabs"
 msgstr "Вкладки"
 
-#: ../src/propgrid/advprops.cpp:1598
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Teal"
 msgstr "Сине-зелёный"
 
-#: ../src/generic/fontdlgg.cpp:327
+#: ../src/generic/fontdlgg.cpp:323
 msgid "Teletype"
 msgstr "Телетайп"
 
-#: ../src/common/docview.cpp:1896
+#: ../src/common/docview.cpp:1901
 msgid "Templates"
 msgstr "Шаблоны"
 
-#: ../src/common/fmapbase.cpp:158
+#: ../src/common/fmapbase.cpp:155
 msgid "Thai (ISO-8859-11)"
 msgstr "Тайский (ISO-8859-11)"
 
-#: ../src/common/ftp.cpp:619
+#: ../src/common/ftp.cpp:622
 msgid "The FTP server doesn't support passive mode."
 msgstr "Сервер FTP не поддерживает пассивный режим."
 
-#: ../src/common/ftp.cpp:605
+#: ../src/common/ftp.cpp:608
 msgid "The FTP server doesn't support the PORT command."
 msgstr "Сервер FTP не поддерживает команду PORT."
 
@@ -6556,7 +6823,8 @@ msgstr "Сервер FTP не поддерживает команду PORT."
 msgid "The available bullet styles."
 msgstr "Доступные стили списка."
 
-#: ../src/richtext/richtextstyledlg.cpp:202 ../src/richtext/richtextstyledlg.cpp:204
+#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:200
 msgid "The available styles."
 msgstr "Доступные стили."
 
@@ -6594,8 +6862,10 @@ msgstr "Размер нижнего поля."
 msgid "The bottom padding size."
 msgstr "Размер заполнения внизу."
 
-#: ../src/richtext/richtextsizepage.cpp:639 ../src/richtext/richtextsizepage.cpp:641
-#: ../src/richtext/richtextsizepage.cpp:653 ../src/richtext/richtextsizepage.cpp:655
+#: ../src/richtext/richtextsizepage.cpp:639
+#: ../src/richtext/richtextsizepage.cpp:641
+#: ../src/richtext/richtextsizepage.cpp:653
+#: ../src/richtext/richtextsizepage.cpp:655
 msgid "The bottom position."
 msgstr "Позиция внизу."
 
@@ -6610,11 +6880,12 @@ msgstr "Позиция внизу."
 msgid "The bullet character."
 msgstr "Знак маркера."
 
-#: ../src/richtext/richtextsymboldlg.cpp:443 ../src/richtext/richtextsymboldlg.cpp:445
+#: ../src/richtext/richtextsymboldlg.cpp:440
+#: ../src/richtext/richtextsymboldlg.cpp:442
 msgid "The character code."
 msgstr "Код символа."
 
-#: ../src/common/fontmap.cpp:203
+#: ../src/common/fontmap.cpp:200
 #, c-format
 msgid ""
 "The charset '%s' is unknown. You may select\n"
@@ -6625,16 +6896,17 @@ msgstr ""
 "вместо него другой набор или нажать [Отмена] \n"
 "если он не может быть заменён"
 
-#: ../src/msw/ole/dataobj.cpp:394
+#: ../src/msw/ole/dataobj.cpp:402
 #, c-format
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "Формат буфера обмена '%d' не существует."
 
-#: ../src/richtext/richtextstylepage.cpp:130 ../src/richtext/richtextstylepage.cpp:132
+#: ../src/richtext/richtextstylepage.cpp:130
+#: ../src/richtext/richtextstylepage.cpp:132
 msgid "The default style for the next paragraph."
 msgstr "Стиль по умолчанию для следующего абзаца."
 
-#: ../src/generic/dirdlgg.cpp:202
+#: ../src/generic/dirdlgg.cpp:199
 #, c-format
 msgid ""
 "The directory '%s' does not exist\n"
@@ -6643,19 +6915,20 @@ msgstr ""
 "Каталог '%s' не существует\n"
 "Создать его сейчас?"
 
-#: ../src/html/htmprint.cpp:271
+#: ../src/html/htmprint.cpp:283
 #, c-format
 msgid ""
-"The document \"%s\" doesn't fit on the page horizontally and will be truncated if "
-"printed.\n"
+"The document \"%s\" doesn't fit on the page horizontally and will be "
+"truncated if printed.\n"
 "\n"
 "Would you like to proceed with printing it nevertheless?"
 msgstr ""
-"Документ '%s' не помещается на странице горизонтально и будет обрезан при печати.\n"
+"Документ '%s' не помещается на странице горизонтально и будет обрезан при "
+"печати.\n"
 "\n"
 "Тем не менее, вы  точно хотите продолжить печать?"
 
-#: ../src/common/docview.cpp:1202
+#: ../src/common/docview.cpp:1196
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -6664,51 +6937,53 @@ msgstr ""
 "Файл '%s' не существует и его открыть нельзя.\n"
 "Он был удалён из списка последних использованных файлов."
 
-#: ../src/richtext/richtextindentspage.cpp:208
-#: ../src/richtext/richtextindentspage.cpp:210
 #: ../src/richtext/richtextliststylepage.cpp:394
 #: ../src/richtext/richtextliststylepage.cpp:396
+#: ../src/richtext/richtextindentspage.cpp:208
+#: ../src/richtext/richtextindentspage.cpp:210
 msgid "The first line indent."
 msgstr "Отступ первой строки."
 
-#: ../src/gtk/utilsgtk.cpp:481
-msgid "The following standard GTK+ options are also supported:\n"
-msgstr "Также поддерживаются следующие стандартные параметры GTK+:\n"
+#: ../src/generic/dbgrptg.cpp:318
+msgid "The following debug report will be generated\n"
+msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:414 ../src/generic/fontdlgg.cpp:416
+#: ../src/generic/fontdlgg.cpp:411 ../src/generic/fontdlgg.cpp:413
 msgid "The font colour."
 msgstr "Цвет шрифта."
 
-#: ../src/generic/fontdlgg.cpp:375 ../src/generic/fontdlgg.cpp:377
+#: ../src/generic/fontdlgg.cpp:371 ../src/generic/fontdlgg.cpp:373
 msgid "The font family."
 msgstr "Название шрифта."
 
-#: ../src/richtext/richtextsymboldlg.cpp:405 ../src/richtext/richtextsymboldlg.cpp:407
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "The font from which to take the symbol."
 msgstr "Шрифт, из которого следует взять символ."
 
-#: ../src/generic/fontdlgg.cpp:427 ../src/generic/fontdlgg.cpp:429
-#: ../src/generic/fontdlgg.cpp:434 ../src/generic/fontdlgg.cpp:436
+#: ../src/generic/fontdlgg.cpp:424 ../src/generic/fontdlgg.cpp:426
+#: ../src/generic/fontdlgg.cpp:430 ../src/generic/fontdlgg.cpp:432
 msgid "The font point size."
 msgstr "Размер шрифта."
 
-#: ../src/osx/carbon/fontdlg.cpp:343 ../src/osx/carbon/fontdlg.cpp:345
+#: ../src/osx/carbon/fontdlg.cpp:340 ../src/osx/carbon/fontdlg.cpp:342
 msgid "The font size in points."
 msgstr "Размер шрифта в точках."
 
-#: ../src/richtext/richtextfontpage.cpp:181 ../src/richtext/richtextfontpage.cpp:183
+#: ../src/richtext/richtextfontpage.cpp:181
+#: ../src/richtext/richtextfontpage.cpp:183
 msgid "The font size units, points or pixels."
 msgstr "Единицы размера шрифта, точки или пиксели."
 
-#: ../src/generic/fontdlgg.cpp:386 ../src/generic/fontdlgg.cpp:388
+#: ../src/generic/fontdlgg.cpp:382 ../src/generic/fontdlgg.cpp:384
 msgid "The font style."
 msgstr "Стиль шрифта."
 
-#: ../src/generic/fontdlgg.cpp:397 ../src/generic/fontdlgg.cpp:399
+#: ../src/generic/fontdlgg.cpp:393 ../src/generic/fontdlgg.cpp:395
 msgid "The font weight."
 msgstr "Толщина шрифта."
 
-#: ../src/common/docview.cpp:1483
+#: ../src/common/docview.cpp:1477
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Не удалось определить формат файла '%s' ."
@@ -6718,10 +6993,10 @@ msgstr "Не удалось определить формат файла '%s' ."
 msgid "The horizontal offset."
 msgstr "Смещение по горизонтали."
 
-#: ../src/richtext/richtextindentspage.cpp:199
-#: ../src/richtext/richtextindentspage.cpp:201
 #: ../src/richtext/richtextliststylepage.cpp:385
 #: ../src/richtext/richtextliststylepage.cpp:387
+#: ../src/richtext/richtextindentspage.cpp:199
+#: ../src/richtext/richtextindentspage.cpp:201
 msgid "The left indent."
 msgstr "Отступ слева."
 
@@ -6735,15 +7010,17 @@ msgstr "Размер левого поля."
 msgid "The left padding size."
 msgstr "Размер заполнения слева."
 
-#: ../src/richtext/richtextsizepage.cpp:534 ../src/richtext/richtextsizepage.cpp:536
-#: ../src/richtext/richtextsizepage.cpp:548 ../src/richtext/richtextsizepage.cpp:550
+#: ../src/richtext/richtextsizepage.cpp:534
+#: ../src/richtext/richtextsizepage.cpp:536
+#: ../src/richtext/richtextsizepage.cpp:548
+#: ../src/richtext/richtextsizepage.cpp:550
 msgid "The left position."
 msgstr "Слева от позиции проигрывания."
 
-#: ../src/richtext/richtextindentspage.cpp:288
-#: ../src/richtext/richtextindentspage.cpp:290
 #: ../src/richtext/richtextliststylepage.cpp:462
 #: ../src/richtext/richtextliststylepage.cpp:464
+#: ../src/richtext/richtextindentspage.cpp:288
+#: ../src/richtext/richtextindentspage.cpp:290
 msgid "The line spacing."
 msgstr "Межстрочный интервал."
 
@@ -6752,31 +7029,37 @@ msgstr "Межстрочный интервал."
 msgid "The list item number."
 msgstr "Номер элемента списка."
 
-#: ../src/msw/ole/automtn.cpp:664
+#: ../src/msw/ole/automtn.cpp:655
 msgid "The locale ID is unknown."
 msgstr "ID языкового стандарта неизвестен."
 
-#: ../src/richtext/richtextsizepage.cpp:366 ../src/richtext/richtextsizepage.cpp:368
+#: ../src/richtext/richtextsizepage.cpp:366
+#: ../src/richtext/richtextsizepage.cpp:368
 msgid "The object height."
 msgstr "Высота объекта."
 
-#: ../src/richtext/richtextsizepage.cpp:474 ../src/richtext/richtextsizepage.cpp:476
+#: ../src/richtext/richtextsizepage.cpp:474
+#: ../src/richtext/richtextsizepage.cpp:476
 msgid "The object maximum height."
 msgstr "Максимальная высота объекта."
 
-#: ../src/richtext/richtextsizepage.cpp:447 ../src/richtext/richtextsizepage.cpp:449
+#: ../src/richtext/richtextsizepage.cpp:447
+#: ../src/richtext/richtextsizepage.cpp:449
 msgid "The object maximum width."
 msgstr "Максимальная ширина объекта."
 
-#: ../src/richtext/richtextsizepage.cpp:420 ../src/richtext/richtextsizepage.cpp:422
+#: ../src/richtext/richtextsizepage.cpp:420
+#: ../src/richtext/richtextsizepage.cpp:422
 msgid "The object minimum height."
 msgstr "Минимальная высота объекта."
 
-#: ../src/richtext/richtextsizepage.cpp:393 ../src/richtext/richtextsizepage.cpp:395
+#: ../src/richtext/richtextsizepage.cpp:393
+#: ../src/richtext/richtextsizepage.cpp:395
 msgid "The object minimum width."
 msgstr "Минимальная ширина объекта."
 
-#: ../src/richtext/richtextsizepage.cpp:332 ../src/richtext/richtextsizepage.cpp:334
+#: ../src/richtext/richtextsizepage.cpp:332
+#: ../src/richtext/richtextsizepage.cpp:334
 msgid "The object width."
 msgstr "Ширина объекта."
 
@@ -6785,7 +7068,7 @@ msgstr "Ширина объекта."
 msgid "The outline level."
 msgstr "Уровень структуры."
 
-#: ../src/common/log.cpp:277
+#: ../src/common/log.cpp:296
 #, c-format
 msgid "The previous message repeated %u time."
 msgid_plural "The previous message repeated %u times."
@@ -6793,33 +7076,34 @@ msgstr[0] "Предыдущее сообщение повторено %u раз.
 msgstr[1] "Предыдущее сообщение повторено %u раза."
 msgstr[2] "Предыдущее сообщение повторено %u раз."
 
-#: ../src/common/log.cpp:270
+#: ../src/common/log.cpp:289
 msgid "The previous message repeated once."
 msgstr "Предыдущее сообщение повторено один раз."
 
-#: ../src/richtext/richtextsymboldlg.cpp:462 ../src/richtext/richtextsymboldlg.cpp:464
+#: ../src/richtext/richtextsymboldlg.cpp:459
+#: ../src/richtext/richtextsymboldlg.cpp:461
 msgid "The range to show."
 msgstr "Диапазон отображения."
 
 #: ../src/generic/dbgrptg.cpp:322
 msgid ""
-"The report contains the files listed below. If any of these files contain private "
-"information,\n"
+"The report contains the files listed below. If any of these files contain "
+"private information,\n"
 "please uncheck them and they will be removed from the report.\n"
 msgstr ""
-"Отчёт содержит перечисленные ниже файлы. Если любой из этих файлов содержит личную "
-"информацию,\n"
+"Отчёт содержит перечисленные ниже файлы. Если любой из этих файлов содержит "
+"личную информацию,\n"
 "снимите с них флажки, и они будут удалены из отчёта.\n"
 
-#: ../src/common/cmdline.cpp:1254
+#: ../src/common/cmdline.cpp:1250
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "Обязательный параметр '%s' не определён."
 
-#: ../src/richtext/richtextindentspage.cpp:217
-#: ../src/richtext/richtextindentspage.cpp:219
 #: ../src/richtext/richtextliststylepage.cpp:403
 #: ../src/richtext/richtextliststylepage.cpp:405
+#: ../src/richtext/richtextindentspage.cpp:217
+#: ../src/richtext/richtextindentspage.cpp:219
 msgid "The right indent."
 msgstr "Отступ справа."
 
@@ -6833,8 +7117,10 @@ msgstr "Размер правого поля."
 msgid "The right padding size."
 msgstr "Размер заполнения справа."
 
-#: ../src/richtext/richtextsizepage.cpp:604 ../src/richtext/richtextsizepage.cpp:606
-#: ../src/richtext/richtextsizepage.cpp:618 ../src/richtext/richtextsizepage.cpp:620
+#: ../src/richtext/richtextsizepage.cpp:604
+#: ../src/richtext/richtextsizepage.cpp:606
+#: ../src/richtext/richtextsizepage.cpp:618
+#: ../src/richtext/richtextsizepage.cpp:620
 msgid "The right position."
 msgstr "Правая позиция."
 
@@ -6858,36 +7144,40 @@ msgstr "Непрозрачность тени."
 msgid "The shadow spread."
 msgstr "Разброс тени."
 
-#: ../src/richtext/richtextindentspage.cpp:267
 #: ../src/richtext/richtextliststylepage.cpp:439
 #: ../src/richtext/richtextliststylepage.cpp:441
+#: ../src/richtext/richtextindentspage.cpp:267
 msgid "The spacing after the paragraph."
 msgstr "Интервал после абзаца."
 
-#: ../src/richtext/richtextindentspage.cpp:257
-#: ../src/richtext/richtextindentspage.cpp:259
 #: ../src/richtext/richtextliststylepage.cpp:430
 #: ../src/richtext/richtextliststylepage.cpp:432
+#: ../src/richtext/richtextindentspage.cpp:257
+#: ../src/richtext/richtextindentspage.cpp:259
 msgid "The spacing before the paragraph."
 msgstr "Интервал перед абзацем."
 
-#: ../src/richtext/richtextstylepage.cpp:110 ../src/richtext/richtextstylepage.cpp:112
+#: ../src/richtext/richtextstylepage.cpp:110
+#: ../src/richtext/richtextstylepage.cpp:112
 msgid "The style name."
 msgstr "Имя стиля."
 
-#: ../src/richtext/richtextstylepage.cpp:120 ../src/richtext/richtextstylepage.cpp:122
+#: ../src/richtext/richtextstylepage.cpp:120
+#: ../src/richtext/richtextstylepage.cpp:122
 msgid "The style on which this style is based."
 msgstr "Стиль на котором этот стиль основывается."
 
-#: ../src/richtext/richtextstyledlg.cpp:214 ../src/richtext/richtextstyledlg.cpp:216
+#: ../src/richtext/richtextstyledlg.cpp:210
+#: ../src/richtext/richtextstyledlg.cpp:212
 msgid "The style preview."
 msgstr "Предпросмотр стиля."
 
-#: ../src/msw/ole/automtn.cpp:680
+#: ../src/msw/ole/automtn.cpp:671
 msgid "The system cannot find the file specified."
 msgstr "Система не может найти указанный файл."
 
-#: ../src/richtext/richtexttabspage.cpp:114 ../src/richtext/richtexttabspage.cpp:116
+#: ../src/richtext/richtexttabspage.cpp:114
+#: ../src/richtext/richtexttabspage.cpp:116
 msgid "The tab position."
 msgstr "Позиция табуляции."
 
@@ -6895,7 +7185,7 @@ msgstr "Позиция табуляции."
 msgid "The tab positions."
 msgstr "Позиции табуляции."
 
-#: ../src/richtext/richtextctrl.cpp:3098
+#: ../src/richtext/richtextctrl.cpp:3099
 msgid "The text couldn't be saved."
 msgstr "Не удалось сохранить текст."
 
@@ -6909,12 +7199,14 @@ msgstr "Размер верхнего поля."
 msgid "The top padding size."
 msgstr "Размер заполнения вверху."
 
-#: ../src/richtext/richtextsizepage.cpp:569 ../src/richtext/richtextsizepage.cpp:571
-#: ../src/richtext/richtextsizepage.cpp:583 ../src/richtext/richtextsizepage.cpp:585
+#: ../src/richtext/richtextsizepage.cpp:569
+#: ../src/richtext/richtextsizepage.cpp:571
+#: ../src/richtext/richtextsizepage.cpp:583
+#: ../src/richtext/richtextsizepage.cpp:585
 msgid "The top position."
 msgstr "Верхняя позиция."
 
-#: ../src/common/cmdline.cpp:1232
+#: ../src/common/cmdline.cpp:1228
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "Значение параметра '%s' должно быть определено."
@@ -6924,184 +7216,201 @@ msgstr "Значение параметра '%s' должно быть опре�
 msgid "The value of the corner radius."
 msgstr "Значение радиуса угла."
 
-#: ../src/msw/dialup.cpp:433
+#: ../src/msw/dialup.cpp:427
 #, c-format
 msgid ""
-"The version of remote access service (RAS) installed on this machine is too old, "
-"please upgrade (the following required function is missing: %s)."
+"The version of remote access service (RAS) installed on this machine is too "
+"old, please upgrade (the following required function is missing: %s)."
 msgstr ""
-"Версия службы удаленного доступа (RAS), установленная на этом компьютере, слишком "
-"старая, обновите её (отсутствует следующая необходимая функция: %s)."
+"Версия службы удаленного доступа (RAS), установленная на этом компьютере, "
+"слишком старая, обновите её (отсутствует следующая необходимая функция: %s)."
 
 #: ../src/richtext/richtextbackgroundpage.cpp:242
 #: ../src/richtext/richtextbackgroundpage.cpp:244
 msgid "The vertical offset."
 msgstr "Вертикальное смещение."
 
-#: ../src/richtext/richtextprint.cpp:619 ../src/html/htmprint.cpp:745
-msgid "There was a problem during page setup: you may need to set a default printer."
-msgstr ""
-"Возникла проблема при настройке страницы: необходимо задать принтер по-умолчанию."
-
-#: ../src/html/htmprint.cpp:255
+#: ../src/html/htmprint.cpp:749 ../src/richtext/richtextprint.cpp:615
 msgid ""
-"This document doesn't fit on the page horizontally and will be truncated when it is "
-"printed."
+"There was a problem during page setup: you may need to set a default printer."
 msgstr ""
-"Этот документ не помещается на странице горизонтально и будет обрезан при печати."
+"Возникла проблема при настройке страницы: необходимо задать принтер по-"
+"умолчанию."
 
-#: ../src/common/image.cpp:2854
+#: ../src/html/htmprint.cpp:267
+msgid ""
+"This document doesn't fit on the page horizontally and will be truncated "
+"when it is printed."
+msgstr ""
+"Этот документ не помещается на странице горизонтально и будет обрезан при "
+"печати."
+
+#: ../src/common/image.cpp:2963
 #, c-format
 msgid "This is not a %s."
 msgstr "Это не %s."
 
-#: ../src/common/wincmn.cpp:1653
+#: ../src/common/wincmn.cpp:1654
 msgid "This platform does not support background transparency."
 msgstr "Эта платформа не поддерживает прозрачность фона."
 
-#: ../src/gtk/window.cpp:4660
+#: ../src/gtk/window.cpp:5664
 msgid ""
-"This program was compiled with a too old version of GTK+, please rebuild with GTK+ "
-"2.12 or newer."
+"This program was compiled with a too old version of GTK+, please rebuild "
+"with GTK+ 2.12 or newer."
 msgstr ""
-"Эта программа была скомпилирована со слишком старой версией GTK+,  пересоберите её "
-"с GTK+ 2.12 или новее."
+"Эта программа была скомпилирована со слишком старой версией GTK+,  "
+"пересоберите её с GTK+ 2.12 или новее."
 
-#: ../src/msw/thread.cpp:1240
+#: ../src/gtk/glcanvas.cpp:176
 msgid ""
-"Thread module initialization failed: cannot store value in thread local storage"
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
 msgstr ""
-"Ошибка инициализации модуля потоков: невозможно сохранить значение в локальном "
-"пространстве потока"
 
-#: ../src/unix/threadpsx.cpp:1794
+#: ../src/msw/thread.cpp:1246
+msgid ""
+"Thread module initialization failed: cannot store value in thread local "
+"storage"
+msgstr ""
+"Ошибка инициализации модуля потоков: невозможно сохранить значение в "
+"локальном пространстве потока"
+
+#: ../src/unix/threadpsx.cpp:1843
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr "Ошибка инициализации модуля потоков: не удалось создать ключ потока"
 
-#: ../src/msw/thread.cpp:1228
+#: ../src/msw/thread.cpp:1234
 msgid ""
-"Thread module initialization failed: impossible to allocate index in thread local "
-"storage"
+"Thread module initialization failed: impossible to allocate index in thread "
+"local storage"
 msgstr ""
 "Ошибка инициализации модуля потоков: невозможно выделить индекс в локальном "
 "пространстве потока"
 
-#: ../src/unix/threadpsx.cpp:1043
+#: ../src/unix/threadpsx.cpp:1061
 msgid "Thread priority setting is ignored."
 msgstr "Установка приоритета потока проигнорирована."
 
-#: ../src/msw/mdi.cpp:176
+#: ../src/msw/mdi.cpp:171
 msgid "Tile &Horizontally"
 msgstr "Плитка по &горизонтали"
 
-#: ../src/msw/mdi.cpp:177
+#: ../src/msw/mdi.cpp:172
 msgid "Tile &Vertically"
 msgstr "Плитка &вертикально"
 
-#: ../src/common/ftp.cpp:200
+#: ../src/common/ftp.cpp:197
 msgid "Timeout while waiting for FTP server to connect, try passive mode."
 msgstr ""
-"При ожидании подключения к FTP серверу возник тайм-аут, попробуйте пассивный режим."
+"При ожидании подключения к FTP серверу возник тайм-аут, попробуйте пассивный "
+"режим."
 
-#: ../src/generic/tipdlg.cpp:201
+#: ../src/generic/tipdlg.cpp:198
 msgid "Tip of the Day"
 msgstr "Совет на день"
 
-#: ../src/generic/tipdlg.cpp:140
+#: ../src/generic/tipdlg.cpp:137
 msgid "Tips not available, sorry!"
 msgstr "Подсказки недоступны!"
 
-#: ../src/generic/prntdlgg.cpp:242
+#: ../src/generic/prntdlgg.cpp:235
 msgid "To:"
 msgstr "До:"
 
-#: ../src/richtext/richtextbuffer.cpp:8363
+#: ../src/richtext/richtextbuffer.cpp:8361
 msgid "Too many EndStyle calls!"
 msgstr "Слишком много звонков EndStyle !"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:891
+#: ../src/propgrid/advprops.cpp:792
 msgid "Tooltip"
 msgstr "Подсказка"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:892
+#: ../src/propgrid/advprops.cpp:793
 msgid "TooltipText"
 msgstr "ТекстПодсказки"
 
-#: ../src/richtext/richtextsizepage.cpp:286 ../src/richtext/richtextsizepage.cpp:290
-#: ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197 ../src/richtext/richtextsizepage.cpp:286
+#: ../src/richtext/richtextsizepage.cpp:290
 msgid "Top"
 msgstr "Верх"
 
-#: ../src/generic/prntdlgg.cpp:881
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Top margin (mm):"
 msgstr "Верхняя граница (мм):"
 
-#: ../src/generic/aboutdlgg.cpp:79
+#: ../src/generic/aboutdlgg.cpp:76
 msgid "Translations by "
 msgstr "Переводы "
 
-#: ../src/generic/aboutdlgg.cpp:188
+#: ../src/generic/aboutdlgg.cpp:185
 msgid "Translators"
 msgstr "Переводчики"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:211
+#: ../src/propgrid/propgrid.cpp:192
 msgid "True"
 msgstr "Истинное"
 
-#: ../src/common/fs_mem.cpp:227
+#: ../src/common/fs_mem.cpp:222
 #, c-format
 msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
 msgstr "Попытка удаления файла '%s' из памяти VFS, но он не загружен!"
 
-#: ../src/common/fmapbase.cpp:156
+#: ../src/common/fmapbase.cpp:153
 msgid "Turkish (ISO-8859-9)"
 msgstr "Турецкий (ISO-8859-9)"
 
-#: ../src/generic/filectrlg.cpp:426
+#: ../src/generic/filectrlg.cpp:422
 msgid "Type"
 msgstr "Тип"
 
-#: ../src/richtext/richtextfontpage.cpp:151 ../src/richtext/richtextfontpage.cpp:153
+#: ../src/richtext/richtextfontpage.cpp:151
+#: ../src/richtext/richtextfontpage.cpp:153
 msgid "Type a font name."
 msgstr "Введите имя шрифта."
 
-#: ../src/richtext/richtextfontpage.cpp:166 ../src/richtext/richtextfontpage.cpp:168
+#: ../src/richtext/richtextfontpage.cpp:166
+#: ../src/richtext/richtextfontpage.cpp:168
 msgid "Type a size in points."
 msgstr "Введите размер в точках."
 
-#: ../src/msw/ole/automtn.cpp:676
+#: ../src/msw/ole/automtn.cpp:667
 #, c-format
 msgid "Type mismatch in argument %u."
 msgstr "Несоответствие типов в аргументе %u."
 
-#: ../src/common/xtixml.cpp:356 ../src/common/xtixml.cpp:509
-#: ../src/common/xtistrm.cpp:318
+#: ../src/common/xtixml.cpp:352 ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315
 msgid "Type must have enum - long conversion"
 msgstr "Тип должен иметь преобразование enum-long"
 
-#: ../src/propgrid/propgridiface.cpp:401
+#: ../src/propgrid/propgridiface.cpp:385
 #, c-format
 msgid ""
-"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT \"%s\"."
+"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
+"\"%s\"."
 msgstr ""
-"Операция типа '%s' не удалась: свойство с меткой '%s' имеет тип '%s', а не '%s'."
+"Операция типа '%s' не удалась: свойство с меткой '%s' имеет тип '%s', а не "
+"'%s'."
 
-#: ../src/common/paper.cpp:133
+#: ../src/common/paper.cpp:130
 msgid "US Std Fanfold, 14 7/8 x 11 in"
 msgstr "US Std фальцованный, 14 7/8 x 11 дюйма"
 
-#: ../src/common/fmapbase.cpp:196
+#: ../src/common/fmapbase.cpp:193
 msgid "US-ASCII"
 msgstr "US-ASCII"
 
-#: ../src/unix/fswatcher_inotify.cpp:109
+#: ../src/unix/fswatcher_inotify.cpp:106
 msgid "Unable to add inotify watch"
 msgstr "Не удалось добавить inotify"
 
-#: ../src/unix/fswatcher_kqueue.cpp:136
+#: ../src/unix/fswatcher_kqueue.cpp:153
 msgid "Unable to add kqueue watch"
 msgstr "Не удалось добавить отслеживание kqueue"
 
@@ -7113,7 +7422,7 @@ msgstr "Не удалось связать дескриптор с портом 
 msgid "Unable to close I/O completion port handle"
 msgstr "Невозможно закрыть дескриптор порта завершения ввода-вывода"
 
-#: ../src/unix/fswatcher_inotify.cpp:97
+#: ../src/unix/fswatcher_inotify.cpp:94
 msgid "Unable to close inotify instance"
 msgstr "Невозможно закрыть экземпляр inotify"
 
@@ -7131,15 +7440,15 @@ msgstr "Не удалось закрыть дескриптор для '%s'"
 msgid "Unable to create I/O completion port"
 msgstr "Невозможно создать порт завершения ввода/вывода"
 
-#: ../src/msw/fswatcher.cpp:84
+#: ../src/msw/fswatcher.cpp:81
 msgid "Unable to create IOCP worker thread"
 msgstr "Невозможно создать рабочий поток IOCP"
 
-#: ../src/unix/fswatcher_inotify.cpp:74
+#: ../src/unix/fswatcher_inotify.cpp:71
 msgid "Unable to create inotify instance"
 msgstr "Невозможно создать экземпляр inotify"
 
-#: ../src/unix/fswatcher_kqueue.cpp:97
+#: ../src/unix/fswatcher_kqueue.cpp:114
 msgid "Unable to create kqueue instance"
 msgstr "Невозможно создать экземпляр kqueue"
 
@@ -7147,11 +7456,11 @@ msgstr "Невозможно создать экземпляр kqueue"
 msgid "Unable to dequeue completion packet"
 msgstr "Не удалось удалить пакет завершения очереди"
 
-#: ../src/unix/fswatcher_kqueue.cpp:185
+#: ../src/unix/fswatcher_kqueue.cpp:202
 msgid "Unable to get events from kqueue"
 msgstr "Не удалось получать события от kqueue"
 
-#: ../src/gtk/app.cpp:435
+#: ../src/gtk/app.cpp:431
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "Не удалось инициализировать GTK+, ДИСПЛЕЙ настроен правильно?"
 
@@ -7160,12 +7469,12 @@ msgstr "Не удалось инициализировать GTK+, ДИСПЛЕ�
 msgid "Unable to open path '%s'"
 msgstr "Не удалось открыть путь '%s'"
 
-#: ../src/html/htmlwin.cpp:583
+#: ../src/html/htmlwin.cpp:586
 #, c-format
 msgid "Unable to open requested HTML document: %s"
 msgstr "Невозможно открыть запрошенный документ HTML: %s"
 
-#: ../src/unix/sound.cpp:368
+#: ../src/unix/sound.cpp:365
 msgid "Unable to play sound asynchronously."
 msgstr "Невозможно проиграть звук асинхронно."
 
@@ -7173,61 +7482,62 @@ msgstr "Невозможно проиграть звук асинхронно."
 msgid "Unable to post completion status"
 msgstr "Не удалось разместить статус завершения"
 
-#: ../src/unix/fswatcher_inotify.cpp:556
+#: ../src/unix/fswatcher_inotify.cpp:553
 msgid "Unable to read from inotify descriptor"
 msgstr "Не удалось прочесть из inotify дескриптора"
 
-#: ../src/unix/fswatcher_inotify.cpp:141
+#: ../src/unix/fswatcher_inotify.cpp:138
 #, c-format
 msgid "Unable to remove inotify watch %i"
 msgstr "Невозможно удалить отслеживание inotify %i"
 
-#: ../src/unix/fswatcher_kqueue.cpp:153
+#: ../src/unix/fswatcher_kqueue.cpp:170
 msgid "Unable to remove kqueue watch"
 msgstr "Не удалось удалить отслеживание kqueue"
 
-#: ../src/msw/fswatcher.cpp:168
+#: ../src/msw/fswatcher.cpp:165
 #, c-format
 msgid "Unable to set up watch for '%s'"
 msgstr "Не удалось настроить отслеживание '%s'"
 
-#: ../src/msw/fswatcher.cpp:91
+#: ../src/msw/fswatcher.cpp:88
 msgid "Unable to start IOCP worker thread"
 msgstr "Не удалось запустить IOCP Рабочий поток"
 
-#: ../src/common/stockitem.cpp:201
+#: ../src/common/stockitem.cpp:198
 msgid "Undelete"
 msgstr "Отмена удаления"
 
-#: ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199
 msgid "Underline"
 msgstr "Подчёркивание"
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/richtext/richtextfontpage.cpp:359 ../src/osx/carbon/fontdlg.cpp:370
-#: ../src/propgrid/advprops.cpp:690
+#: ../src/osx/carbon/fontdlg.cpp:367 ../src/propgrid/advprops.cpp:600
+#: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Подчёркнутый"
 
-#: ../src/common/stockitem.cpp:203 ../src/stc/stc_i18n.cpp:15
+#: ../src/common/stockitem.cpp:200 ../src/stc/stc_i18n.cpp:15
 msgid "Undo"
 msgstr "Отменить"
 
-#: ../src/common/stockitem.cpp:265
+#: ../src/common/stockitem.cpp:263
 msgid "Undo last action"
 msgstr "Отмеить последне действие"
 
-#: ../src/common/cmdline.cpp:1029
+#: ../src/common/cmdline.cpp:1025
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Неожиданные символы, следующие за опцией '%s'."
 
-#: ../src/unix/fswatcher_inotify.cpp:274
+#: ../src/unix/fswatcher_inotify.cpp:271
 #, c-format
 msgid "Unexpected event for \"%s\": no matching watch descriptor."
-msgstr "Непредвиденное событие для '%s': нет соответствующего дескриптора наблюдения."
+msgstr ""
+"Непредвиденное событие для '%s': нет соответствующего дескриптора наблюдения."
 
-#: ../src/common/cmdline.cpp:1195
+#: ../src/common/cmdline.cpp:1191
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Неожиданный параметр '%s'"
@@ -7236,48 +7546,49 @@ msgstr "Неожиданный параметр '%s'"
 msgid "Unexpectedly new I/O completion port was created"
 msgstr "Неожиданно был создан новый порт завершения ввода-вывода"
 
-#: ../src/msw/fswatcher.cpp:70
+#: ../src/msw/fswatcher.cpp:67
 msgid "Ungraceful worker thread termination"
 msgstr "Неизящное завершение рабочего потока"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459 ../src/richtext/richtextsymboldlg.cpp:460
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:456
+#: ../src/richtext/richtextsymboldlg.cpp:457
+#: ../src/richtext/richtextsymboldlg.cpp:458
 msgid "Unicode"
 msgstr "Юникод"
 
-#: ../src/common/fmapbase.cpp:185 ../src/common/fmapbase.cpp:191
+#: ../src/common/fmapbase.cpp:182 ../src/common/fmapbase.cpp:188
 msgid "Unicode 16 bit (UTF-16)"
 msgstr "16-бит юникод (UTF-16)"
 
-#: ../src/common/fmapbase.cpp:190
+#: ../src/common/fmapbase.cpp:187
 msgid "Unicode 16 bit Big Endian (UTF-16BE)"
 msgstr "16-бит юникод Big Endian (UTF-16BE)"
 
-#: ../src/common/fmapbase.cpp:186
+#: ../src/common/fmapbase.cpp:183
 msgid "Unicode 16 bit Little Endian (UTF-16LE)"
 msgstr "16-бит юникод Little Endian (UTF-16LE)"
 
-#: ../src/common/fmapbase.cpp:187 ../src/common/fmapbase.cpp:193
+#: ../src/common/fmapbase.cpp:184 ../src/common/fmapbase.cpp:190
 msgid "Unicode 32 bit (UTF-32)"
 msgstr "32-бит юникод (UTF-32)"
 
-#: ../src/common/fmapbase.cpp:192
+#: ../src/common/fmapbase.cpp:189
 msgid "Unicode 32 bit Big Endian (UTF-32BE)"
 msgstr "32-бит юникод Big Endian (UTF-32BE)"
 
-#: ../src/common/fmapbase.cpp:188
+#: ../src/common/fmapbase.cpp:185
 msgid "Unicode 32 bit Little Endian (UTF-32LE)"
 msgstr "32-бит юникод Little Endian (UTF-32LE)"
 
-#: ../src/common/fmapbase.cpp:182
+#: ../src/common/fmapbase.cpp:179
 msgid "Unicode 7 bit (UTF-7)"
 msgstr "7-бит юникод (UTF-7)"
 
-#: ../src/common/fmapbase.cpp:183
+#: ../src/common/fmapbase.cpp:180
 msgid "Unicode 8 bit (UTF-8)"
 msgstr "8-бит юникод (UTF-8)"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "Unindent"
 msgstr "Убрать отступ"
 
@@ -7301,7 +7612,8 @@ msgstr "Единицы ширины нижнего контура."
 msgid "Units for the bottom padding."
 msgstr "Единицы нижнего заполнения."
 
-#: ../src/richtext/richtextsizepage.cpp:664 ../src/richtext/richtextsizepage.cpp:666
+#: ../src/richtext/richtextsizepage.cpp:664
+#: ../src/richtext/richtextsizepage.cpp:666
 msgid "Units for the bottom position."
 msgstr "Единицы нижней позиции."
 
@@ -7330,31 +7642,38 @@ msgstr "Единицы ширины левого контура."
 msgid "Units for the left padding."
 msgstr "Единицы левого заполнения."
 
-#: ../src/richtext/richtextsizepage.cpp:559 ../src/richtext/richtextsizepage.cpp:561
+#: ../src/richtext/richtextsizepage.cpp:559
+#: ../src/richtext/richtextsizepage.cpp:561
 msgid "Units for the left position."
 msgstr "Единицы левой позиции."
 
-#: ../src/richtext/richtextsizepage.cpp:485 ../src/richtext/richtextsizepage.cpp:487
+#: ../src/richtext/richtextsizepage.cpp:485
+#: ../src/richtext/richtextsizepage.cpp:487
 msgid "Units for the maximum object height."
 msgstr "Единицы максимальной высоты объекта."
 
-#: ../src/richtext/richtextsizepage.cpp:458 ../src/richtext/richtextsizepage.cpp:460
+#: ../src/richtext/richtextsizepage.cpp:458
+#: ../src/richtext/richtextsizepage.cpp:460
 msgid "Units for the maximum object width."
 msgstr "Единицы максимальной ширины объекта."
 
-#: ../src/richtext/richtextsizepage.cpp:431 ../src/richtext/richtextsizepage.cpp:433
+#: ../src/richtext/richtextsizepage.cpp:431
+#: ../src/richtext/richtextsizepage.cpp:433
 msgid "Units for the minimum object height."
 msgstr "Единицы минимальной высоты объекта."
 
-#: ../src/richtext/richtextsizepage.cpp:404 ../src/richtext/richtextsizepage.cpp:406
+#: ../src/richtext/richtextsizepage.cpp:404
+#: ../src/richtext/richtextsizepage.cpp:406
 msgid "Units for the minimum object width."
 msgstr "Единицы минимальной ширины объекта."
 
-#: ../src/richtext/richtextsizepage.cpp:377 ../src/richtext/richtextsizepage.cpp:379
+#: ../src/richtext/richtextsizepage.cpp:377
+#: ../src/richtext/richtextsizepage.cpp:379
 msgid "Units for the object height."
 msgstr "Единицы высоты объекта."
 
-#: ../src/richtext/richtextsizepage.cpp:343 ../src/richtext/richtextsizepage.cpp:345
+#: ../src/richtext/richtextsizepage.cpp:343
+#: ../src/richtext/richtextsizepage.cpp:345
 msgid "Units for the object width."
 msgstr "Единицы ширины объекта."
 
@@ -7378,7 +7697,8 @@ msgstr "Единицы правой ширины контура."
 msgid "Units for the right padding."
 msgstr "Единицы правого заполнения."
 
-#: ../src/richtext/richtextsizepage.cpp:629 ../src/richtext/richtextsizepage.cpp:631
+#: ../src/richtext/richtextsizepage.cpp:629
+#: ../src/richtext/richtextsizepage.cpp:631
 msgid "Units for the right position."
 msgstr "Единицы правой позиции."
 
@@ -7402,7 +7722,8 @@ msgstr "Единицы ширины верхнего контура."
 msgid "Units for the top padding."
 msgstr "Единицы верхнего заполнения."
 
-#: ../src/richtext/richtextsizepage.cpp:594 ../src/richtext/richtextsizepage.cpp:596
+#: ../src/richtext/richtextsizepage.cpp:594
+#: ../src/richtext/richtextsizepage.cpp:596
 msgid "Units for the top position."
 msgstr "Единицы верхней позиции."
 
@@ -7417,97 +7738,102 @@ msgstr "Единицы верхней позиции."
 msgid "Units for this value."
 msgstr "Единицы этого значения."
 
-#: ../src/generic/progdlgg.cpp:353 ../src/generic/progdlgg.cpp:622
+#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
 msgid "Unknown"
 msgstr "Неизвестно"
 
-#: ../src/msw/dde.cpp:1174
+#: ../src/msw/dde.cpp:1238
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Неизвестная ошибка DDE %08x"
 
-#: ../src/common/xtistrm.cpp:410
+#: ../src/common/xtistrm.cpp:407
 msgid "Unknown Object passed to GetObjectClassInfo"
 msgstr "Неизвестный объект передан в GetObjectClassInfo"
 
-#: ../src/common/imagpng.cpp:366
+#: ../src/common/imagpng.cpp:383
 #, c-format
 msgid "Unknown PNG resolution unit %d"
 msgstr "Неизвестный блок разрешения PNG %d"
 
-#: ../src/common/xtixml.cpp:327
+#: ../src/common/xtixml.cpp:323
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Неизвестное свойство %s"
 
-#: ../src/common/imagtiff.cpp:529
+#: ../src/common/imagtiff.cpp:526
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "Неизвестная единица разрешения TIFF %d игнорирована"
 
-#: ../src/unix/dlunix.cpp:160
+#: ../src/propgrid/props.cpp:155
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/unix/dlunix.cpp:118
 msgid "Unknown dynamic library error"
 msgstr "Неизвестная ошибка динамической библиотеки"
 
-#: ../src/common/fmapbase.cpp:810
+#: ../src/common/fmapbase.cpp:806
 #, c-format
 msgid "Unknown encoding (%d)"
 msgstr "Неизвестная кодировка (%d)"
 
-#: ../src/msw/ole/automtn.cpp:688
+#: ../src/msw/ole/automtn.cpp:679
 #, c-format
 msgid "Unknown error %08x"
 msgstr "Неизвестная ошибка %08x"
 
-#: ../src/msw/ole/automtn.cpp:647
+#: ../src/msw/ole/automtn.cpp:638
 msgid "Unknown exception"
 msgstr "Неизвестное исключение"
 
-#: ../src/common/image.cpp:2839
+#: ../src/common/image.cpp:2942
 msgid "Unknown image data format."
 msgstr "Неизвестный формат данных изображения."
 
-#: ../src/common/cmdline.cpp:914
+#: ../src/common/cmdline.cpp:910
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Неизвестный длинный параметр '%s'"
 
-#: ../src/msw/ole/automtn.cpp:631
+#: ../src/msw/ole/automtn.cpp:622
 msgid "Unknown name or named argument."
 msgstr "Неизвестное имя или именованный аргумент."
 
-#: ../src/common/cmdline.cpp:929 ../src/common/cmdline.cpp:951
+#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Неизвестный параметр '%s'"
 
-#: ../src/common/mimecmn.cpp:225
+#: ../src/common/mimecmn.cpp:221
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "Незакрытая скобка '{' в записи для mime типа %s."
 
-#: ../src/common/cmdproc.cpp:262 ../src/common/cmdproc.cpp:288
-#: ../src/common/cmdproc.cpp:308
+#: ../src/common/cmdproc.cpp:255 ../src/common/cmdproc.cpp:281
+#: ../src/common/cmdproc.cpp:301
 msgid "Unnamed command"
 msgstr "Команда без имени"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:413
+#: ../src/propgrid/propgrid.cpp:392
 msgid "Unspecified"
 msgstr "Не указано"
 
-#: ../src/msw/clipbrd.cpp:311
+#: ../src/msw/clipbrd.cpp:325
 msgid "Unsupported clipboard format."
 msgstr "Неподдерживаемый формат буфера обмена."
 
-#: ../src/common/appcmn.cpp:256
+#: ../src/common/appcmn.cpp:277
 #, c-format
 msgid "Unsupported theme '%s'."
 msgstr "Неподдерживаемая тема '%s'."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:205
-#: ../src/common/accelcmn.cpp:63
+#: ../src/common/stockitem.cpp:202 ../src/common/accelcmn.cpp:60
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Up"
 msgstr "Выше"
 
@@ -7521,7 +7847,7 @@ msgstr "Заглавные буквы"
 msgid "Upper case roman numerals"
 msgstr "Римские цифры в верхнем регистре"
 
-#: ../src/common/cmdline.cpp:1326
+#: ../src/common/cmdline.cpp:1322
 #, c-format
 msgid "Usage: %s"
 msgstr "Использование: %s"
@@ -7530,64 +7856,81 @@ msgstr "Использование: %s"
 msgid "Use &shadow"
 msgstr "Использовать &тень"
 
-#: ../src/richtext/richtextindentspage.cpp:169
-#: ../src/richtext/richtextindentspage.cpp:171
 #: ../src/richtext/richtextliststylepage.cpp:358
 #: ../src/richtext/richtextliststylepage.cpp:360
+#: ../src/richtext/richtextindentspage.cpp:169
+#: ../src/richtext/richtextindentspage.cpp:171
 msgid "Use the current alignment setting."
 msgstr "Использовать текущий параметр выравнивания."
 
-#: ../src/common/valtext.cpp:179
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/gtk/font.cpp:552
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/common/valtext.cpp:142
 msgid "Validation conflict"
 msgstr "Конфликт проверки"
 
-#: ../src/propgrid/manager.cpp:238
+#: ../src/propgrid/manager.cpp:224
 msgid "Value"
 msgstr "Значение"
 
-#: ../src/propgrid/props.cpp:386 ../src/propgrid/props.cpp:500
+#: ../src/propgrid/props.cpp:309
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "Значение должно быть %s или более."
 
-#: ../src/propgrid/props.cpp:417 ../src/propgrid/props.cpp:531
+#: ../src/propgrid/props.cpp:336
 #, c-format
 msgid "Value must be %s or less."
 msgstr "Значение должно быть %s или менее."
 
-#: ../src/propgrid/props.cpp:393 ../src/propgrid/props.cpp:424
-#: ../src/propgrid/props.cpp:507 ../src/propgrid/props.cpp:538
+#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "Значение должно быть между %s и %s."
 
-#: ../src/generic/aboutdlgg.cpp:128
+#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Версия "
 
-#: ../src/richtext/richtextsizepage.cpp:291 ../src/richtext/richtextsizepage.cpp:293
+#: ../src/richtext/richtextsizepage.cpp:291
+#: ../src/richtext/richtextsizepage.cpp:293
 msgid "Vertical alignment."
 msgstr "Вертикальное выравнивание."
 
-#: ../src/generic/filedlgg.cpp:202
+#: ../src/generic/filedlgg.cpp:199
 msgid "View files as a detailed view"
 msgstr "Просмотр файлов в виде подробного списка"
 
-#: ../src/generic/filedlgg.cpp:200
+#: ../src/generic/filedlgg.cpp:197
 msgid "View files as a list view"
 msgstr "Просмотр файлов в виде списка"
 
-#: ../src/common/docview.cpp:1970
+#: ../src/common/docview.cpp:1975
 msgid "Views"
 msgstr "Виды"
 
+#: ../src/gtk/app.cpp:348
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1777
+#: ../src/propgrid/advprops.cpp:1678
 msgid "Wait"
 msgstr "Подождите"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1779
+#: ../src/propgrid/advprops.cpp:1680
 msgid "Wait Arrow"
 msgstr "Стрелка ожидания"
 
@@ -7596,279 +7939,279 @@ msgstr "Стрелка ожидания"
 msgid "Waiting for IO on epoll descriptor %d failed"
 msgstr "Ошибка ожидания ввода/ввывода от epoll дескриптора %d"
 
-#: ../src/common/log.cpp:223
+#: ../src/common/log.cpp:241
 msgid "Warning: "
 msgstr "Предупреждение: "
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1778
+#: ../src/propgrid/advprops.cpp:1679
 msgid "Watch"
 msgstr "Отслеживание"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:685
+#: ../src/propgrid/advprops.cpp:595
 msgid "Weight"
 msgstr "Вес"
 
-#: ../src/common/fmapbase.cpp:148
+#: ../src/common/fmapbase.cpp:145
 msgid "Western European (ISO-8859-1)"
 msgstr "Западно-европейский (ISO-8859-1)"
 
-#: ../src/common/fmapbase.cpp:162
+#: ../src/common/fmapbase.cpp:159
 msgid "Western European with Euro (ISO-8859-15)"
 msgstr "Западно-европейский с символом Евро (ISO-8859-15)"
 
-#: ../src/generic/fontdlgg.cpp:446 ../src/generic/fontdlgg.cpp:448
+#: ../src/generic/fontdlgg.cpp:443 ../src/generic/fontdlgg.cpp:445
 msgid "Whether the font is underlined."
 msgstr "Либо шрифт подчёркнут."
 
-#: ../src/propgrid/advprops.cpp:1611
+#: ../src/propgrid/advprops.cpp:1517
 msgid "White"
 msgstr "Белый"
 
-#: ../src/generic/fdrepdlg.cpp:144
+#: ../src/generic/fdrepdlg.cpp:141
 msgid "Whole word"
 msgstr "Слово целиком"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:532
 msgid "Whole words only"
 msgstr "Только слова целиком"
 
-#: ../src/univ/themes/win32.cpp:1102
+#: ../src/univ/themes/win32.cpp:1099
 msgid "Win32 theme"
 msgstr "Тема Win32"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:893
+#: ../src/propgrid/advprops.cpp:794
 msgid "Window"
 msgstr "Окно"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:894
+#: ../src/propgrid/advprops.cpp:795
 msgid "WindowFrame"
 msgstr "РамкаОкна"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:895
+#: ../src/propgrid/advprops.cpp:796
 msgid "WindowText"
 msgstr "WindowText"
 
-#: ../src/common/fmapbase.cpp:177
+#: ../src/common/fmapbase.cpp:174
 msgid "Windows Arabic (CP 1256)"
 msgstr "Арабский Windows (CP 1256)"
 
-#: ../src/common/fmapbase.cpp:178
+#: ../src/common/fmapbase.cpp:175
 msgid "Windows Baltic (CP 1257)"
 msgstr "Балтийский Windows (CP 1257)"
 
-#: ../src/common/fmapbase.cpp:171
+#: ../src/common/fmapbase.cpp:168
 msgid "Windows Central European (CP 1250)"
 msgstr "Центрально-европейский Windows (CP 1250)"
 
-#: ../src/common/fmapbase.cpp:168
+#: ../src/common/fmapbase.cpp:165
 msgid "Windows Chinese Simplified (CP 936) or GB-2312"
 msgstr "Китайский упрощенный Windows (CP 936) или GB-2312"
 
-#: ../src/common/fmapbase.cpp:170
+#: ../src/common/fmapbase.cpp:167
 msgid "Windows Chinese Traditional (CP 950) or Big-5"
 msgstr "Китайский традиционный Windows (CP 950) или Big-5"
 
-#: ../src/common/fmapbase.cpp:172
+#: ../src/common/fmapbase.cpp:169
 msgid "Windows Cyrillic (CP 1251)"
 msgstr "Кириллица Windows (CP 1251)"
 
-#: ../src/common/fmapbase.cpp:174
+#: ../src/common/fmapbase.cpp:171
 msgid "Windows Greek (CP 1253)"
 msgstr "Греческий Windows (CP 1253)"
 
-#: ../src/common/fmapbase.cpp:176
+#: ../src/common/fmapbase.cpp:173
 msgid "Windows Hebrew (CP 1255)"
 msgstr "Иврит Windows (CP 1255)"
 
-#: ../src/common/fmapbase.cpp:167
+#: ../src/common/fmapbase.cpp:164
 msgid "Windows Japanese (CP 932) or Shift-JIS"
 msgstr "Японский Windows (CP 932) или Shift-JIS"
 
-#: ../src/common/fmapbase.cpp:180
+#: ../src/common/fmapbase.cpp:177
 msgid "Windows Johab (CP 1361)"
 msgstr "Windows Johab (CP 1361)"
 
-#: ../src/common/fmapbase.cpp:169
+#: ../src/common/fmapbase.cpp:166
 msgid "Windows Korean (CP 949)"
 msgstr "Корейский Windows (CP 949)"
 
-#: ../src/common/fmapbase.cpp:166
+#: ../src/common/fmapbase.cpp:163
 msgid "Windows Thai (CP 874)"
 msgstr "Тайский Windows (CP 874)"
 
-#: ../src/common/fmapbase.cpp:175
+#: ../src/common/fmapbase.cpp:172
 msgid "Windows Turkish (CP 1254)"
 msgstr "Турецкий Windows (CP 1254)"
 
-#: ../src/common/fmapbase.cpp:179
+#: ../src/common/fmapbase.cpp:176
 msgid "Windows Vietnamese (CP 1258)"
 msgstr "Вьетнамский Windows (CP 1258)"
 
-#: ../src/common/fmapbase.cpp:173
+#: ../src/common/fmapbase.cpp:170
 msgid "Windows Western European (CP 1252)"
 msgstr "Западно-европейский Windows (CP 1252)"
 
-#: ../src/common/fmapbase.cpp:181
+#: ../src/common/fmapbase.cpp:178
 msgid "Windows/DOS OEM (CP 437)"
 msgstr "Windows/DOS OEM (CP 437)"
 
-#: ../src/common/fmapbase.cpp:165
+#: ../src/common/fmapbase.cpp:162
 msgid "Windows/DOS OEM Cyrillic (CP 866)"
 msgstr "Кириллица Windows/DOS OEM (CP 866)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:111
+#: ../src/common/accelcmn.cpp:109
 msgid "Windows_Left"
 msgstr "Windows_Left"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:113
+#: ../src/common/accelcmn.cpp:111
 msgid "Windows_Menu"
 msgstr "Windows_Menu"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:112
+#: ../src/common/accelcmn.cpp:110
 msgid "Windows_Right"
 msgstr "Windows_Right"
 
-#: ../src/common/ffile.cpp:150
+#: ../src/common/ffile.cpp:149
 #, c-format
 msgid "Write error on file '%s'"
 msgstr "Ошибка записи в файл '%s'"
 
-#: ../src/xml/xml.cpp:914
+#: ../src/xml/xml.cpp:925
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "Ошибка разбора XML: '%s' в строке %d"
 
-#: ../src/common/xpmdecod.cpp:796
+#: ../src/common/xpmdecod.cpp:794
 msgid "XPM: Malformed pixel data!"
 msgstr "XPM: искажённые пиксельные данные!"
 
-#: ../src/common/xpmdecod.cpp:705
+#: ../src/common/xpmdecod.cpp:702
 #, c-format
 msgid "XPM: incorrect colour description in line %d"
 msgstr "XPM: неправильное описание цвета в строке %d"
 
-#: ../src/common/xpmdecod.cpp:680
+#: ../src/common/xpmdecod.cpp:677
 msgid "XPM: incorrect header format!"
 msgstr "XPM: неверный формат заголовка!"
 
-#: ../src/common/xpmdecod.cpp:716 ../src/common/xpmdecod.cpp:725
+#: ../src/common/xpmdecod.cpp:714 ../src/common/xpmdecod.cpp:723
 #, c-format
 msgid "XPM: malformed colour definition '%s' at line %d!"
 msgstr "XPM: некорректное определение цвета '%s' в строке %d!"
 
-#: ../src/common/xpmdecod.cpp:755
+#: ../src/common/xpmdecod.cpp:753
 msgid "XPM: no colors left to use for mask!"
 msgstr "XPM: нет цвета слева для использования в маске!"
 
-#: ../src/common/xpmdecod.cpp:782
+#: ../src/common/xpmdecod.cpp:780
 #, c-format
 msgid "XPM: truncated image data at line %d!"
 msgstr "XPM: усечённые данные изображения в строке %d!"
 
-#: ../src/propgrid/advprops.cpp:1610
+#: ../src/propgrid/advprops.cpp:1516
 msgid "Yellow"
 msgstr "Жёлтый"
 
-#: ../include/wx/msgdlg.h:276 ../src/common/stockitem.cpp:206
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:203
 #: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Да"
 
-#: ../src/osx/carbon/overlay.cpp:155
-msgid "You cannot Clear an overlay that is not inited"
-msgstr "Нельзя очистить наложение на изображение без инициализации"
-
-#: ../src/osx/carbon/overlay.cpp:107 ../src/dfb/overlay.cpp:61
-msgid "You cannot Init an overlay twice"
-msgstr "Нельзя Init наложить два раза"
-
-#: ../src/generic/dirdlgg.cpp:287
+#: ../src/generic/dirdlgg.cpp:284
 msgid "You cannot add a new directory to this section."
 msgstr "Нельзя добавить новый каталог в эту секцию."
 
-#: ../src/propgrid/propgrid.cpp:3299
+#: ../src/propgrid/propgrid.cpp:3276
 msgid "You have entered invalid value. Press ESC to cancel editing."
-msgstr "Вы ввели недопустимое значение. Нажмите  ESC, чтобы отменить изменения."
+msgstr ""
+"Вы ввели недопустимое значение. Нажмите  ESC, чтобы отменить изменения."
 
-#: ../src/common/stockitem.cpp:209
+#: ../src/osx/cocoa/menu.mm:286
+#, fuzzy
+msgid "Zoom"
+msgstr "Увеличить"
+
+#: ../src/common/stockitem.cpp:206
 msgid "Zoom &In"
 msgstr "&Увеличить"
 
-#: ../src/common/stockitem.cpp:210
+#: ../src/common/stockitem.cpp:207
 msgid "Zoom &Out"
 msgstr "У&меньшить"
 
-#: ../src/common/stockitem.cpp:209 ../src/common/prntbase.cpp:1594
+#: ../src/common/stockitem.cpp:206 ../src/common/prntbase.cpp:1619
 msgid "Zoom In"
 msgstr "Увеличить"
 
-#: ../src/common/stockitem.cpp:210 ../src/common/prntbase.cpp:1580
+#: ../src/common/stockitem.cpp:207 ../src/common/prntbase.cpp:1605
 msgid "Zoom Out"
 msgstr "Уменьшить"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to &Fit"
 msgstr "&Вписать"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to Fit"
 msgstr "Вписать"
 
-#: ../src/msw/dde.cpp:1141
+#: ../src/msw/dde.cpp:1205
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "приложение DDEML создало длительный race condition."
 
-#: ../src/msw/dde.cpp:1129
+#: ../src/msw/dde.cpp:1193
 msgid ""
-"a DDEML function was called without first calling the DdeInitialize function,\n"
+"a DDEML function was called without first calling the DdeInitialize "
+"function,\n"
 "or an invalid instance identifier\n"
 "was passed to a DDEML function."
 msgstr ""
-"функция DDEML была вызвана без первоначального вызова функции DdeInitialize,\n"
+"функция DDEML была вызвана без первоначального вызова функции "
+"DdeInitialize,\n"
 "или неверный идентификатор экземпляра\n"
 "был передан в функцию DDEML."
 
-#: ../src/msw/dde.cpp:1147
+#: ../src/msw/dde.cpp:1211
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "не удалась попытка клиента установить диалог."
 
-#: ../src/msw/dde.cpp:1144
+#: ../src/msw/dde.cpp:1208
 msgid "a memory allocation failed."
 msgstr "ошибка выделения памяти."
 
-#: ../src/msw/dde.cpp:1138
+#: ../src/msw/dde.cpp:1202
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "не удалось проверить параметр с помощью DDEML."
 
-#: ../src/msw/dde.cpp:1120
+#: ../src/msw/dde.cpp:1184
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "тайм-аут запроса для синхронной консультации."
 
-#: ../src/msw/dde.cpp:1126
+#: ../src/msw/dde.cpp:1190
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "тайм-аут запроса на синхронную транзакцию данных."
 
-#: ../src/msw/dde.cpp:1135
+#: ../src/msw/dde.cpp:1199
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "тайм-аут запроса для синхронной транзакции Execute."
 
-#: ../src/msw/dde.cpp:1153
+#: ../src/msw/dde.cpp:1217
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "тайм-аут запроса на синхронную транзакцию."
 
-#: ../src/msw/dde.cpp:1168
+#: ../src/msw/dde.cpp:1232
 msgid "a request to end an advise transaction has timed out."
 msgstr "тайм-аут запроса на завершение проводки рекомендаций."
 
-#: ../src/msw/dde.cpp:1162
+#: ../src/msw/dde.cpp:1226
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -7878,15 +8221,15 @@ msgstr ""
 "который был прерван клиентом, либо работа сервера\n"
 "была остановлена до завершения транзакции."
 
-#: ../src/msw/dde.cpp:1150
+#: ../src/msw/dde.cpp:1214
 msgid "a transaction failed."
 msgstr "транзакция завершилась с ошибкой."
 
-#: ../src/common/accelcmn.cpp:189
+#: ../src/common/accelcmn.cpp:188
 msgid "alt"
 msgstr "alt"
 
-#: ../src/msw/dde.cpp:1132
+#: ../src/msw/dde.cpp:1196
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -7898,15 +8241,15 @@ msgstr ""
 "или приложение, инициализированное как APPCMD_CLIENTONLY,\n"
 "пыталось осуществить серверную транзакцию."
 
-#: ../src/msw/dde.cpp:1156
+#: ../src/msw/dde.cpp:1220
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "внутренний вызов функции PostMessage не удался. "
 
-#: ../src/msw/dde.cpp:1165
+#: ../src/msw/dde.cpp:1229
 msgid "an internal error has occurred in the DDEML."
 msgstr "в DDEML произошла внутренняя ошибка."
 
-#: ../src/msw/dde.cpp:1171
+#: ../src/msw/dde.cpp:1235
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -7916,56 +8259,56 @@ msgstr ""
 "Как только приложение вернётся из обратного вызова XTYP_XACT_COMPLETE,\n"
 "идентификатор транзакции для этого обратного вызова более недействителен."
 
-#: ../src/common/zipstrm.cpp:1483
+#: ../src/common/zipstrm.cpp:1522
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "подразумевается, что это объединение многотомного zip-архива"
 
-#: ../src/common/fileconf.cpp:1847
+#: ../src/common/fileconf.cpp:1849
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "попытка изменить неизменяемый ключ '%s' проигнорирована."
 
-#: ../src/html/chm.cpp:329
+#: ../src/html/chm.cpp:326
 msgid "bad arguments to library function"
 msgstr "неверные аргументы у библиотечной функции"
 
-#: ../src/html/chm.cpp:341
+#: ../src/html/chm.cpp:338
 msgid "bad signature"
 msgstr "неверная подпись"
 
-#: ../src/common/zipstrm.cpp:1918
+#: ../src/common/zipstrm.cpp:1988
 msgid "bad zipfile offset to entry"
 msgstr "неверное смещение zip-файла к записи"
 
-#: ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400
 msgid "binary"
 msgstr "двоичный"
 
-#: ../src/common/fontcmn.cpp:996
+#: ../src/common/fontcmn.cpp:1195
 msgid "bold"
 msgstr "жирный"
 
-#: ../src/msw/utils.cpp:1144
+#: ../src/msw/utils.cpp:1135
 #, c-format
 msgid "build %lu"
 msgstr "сборка %lu"
 
-#: ../src/common/ffile.cpp:75
+#: ../src/common/ffile.cpp:73
 #, c-format
 msgid "can't close file '%s'"
 msgstr "невозможно закрыть файл '%s'"
 
-#: ../src/common/file.cpp:245
+#: ../src/common/file.cpp:242
 #, c-format
 msgid "can't close file descriptor %d"
 msgstr "невозможно закрыть дескриптор файла %d"
 
-#: ../src/common/file.cpp:586
+#: ../src/common/ffile.cpp:382 ../src/common/file.cpp:613
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "невозможно записать изменения в файл '%s'"
 
-#: ../src/common/file.cpp:178
+#: ../src/common/file.cpp:175
 #, c-format
 msgid "can't create file '%s'"
 msgstr "невозможно создать файл '%s'"
@@ -7975,49 +8318,49 @@ msgstr "невозможно создать файл '%s'"
 msgid "can't delete user configuration file '%s'"
 msgstr "невозможно удалить файл конфигурации пользователя '%s'"
 
-#: ../src/common/file.cpp:495
+#: ../src/common/file.cpp:522
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr "невозможно определить достижение конца файла с дескриптором %d"
 
-#: ../src/common/zipstrm.cpp:1692
+#: ../src/common/zipstrm.cpp:1747
 msgid "can't find central directory in zip"
 msgstr "невозможно найти центральный каталог в zip"
 
-#: ../src/common/file.cpp:465
+#: ../src/common/file.cpp:492
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "невозможно найти длину файла с дескриптором %d"
 
-#: ../src/msw/utils.cpp:341
+#: ../src/msw/utils.cpp:336
 msgid "can't find user's HOME, using current directory."
 msgstr "не удалось найи домашний каталог, используется текущий каталог."
 
-#: ../src/common/file.cpp:366
+#: ../src/common/file.cpp:407
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "невозможно сбросить буфер файла с дескриптором %d"
 
-#: ../src/common/file.cpp:422
+#: ../src/common/file.cpp:463
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "невозможно получить текущую позицию файла с дескриптором %d"
 
-#: ../src/common/fontmap.cpp:325
+#: ../src/common/fontmap.cpp:322
 msgid "can't load any font, aborting"
 msgstr "не удаётся загрузить любой шрифт, прерывая"
 
-#: ../src/common/file.cpp:231 ../src/common/ffile.cpp:59
+#: ../src/common/ffile.cpp:57 ../src/common/file.cpp:228
 #, c-format
 msgid "can't open file '%s'"
 msgstr "невозможно открыть файл '%s'"
 
-#: ../src/common/fileconf.cpp:320
+#: ../src/common/fileconf.cpp:314
 #, c-format
 msgid "can't open global configuration file '%s'."
 msgstr "невозможно открыть глобальный файл конфигурации '%s'."
 
-#: ../src/common/fileconf.cpp:336
+#: ../src/common/fileconf.cpp:330
 #, c-format
 msgid "can't open user configuration file '%s'."
 msgstr "невозможно открыть файл конфигурации пользователя '%s'."
@@ -8026,40 +8369,40 @@ msgstr "невозможно открыть файл конфигурации п
 msgid "can't open user configuration file."
 msgstr "невозможно открыть файл конфигурации пользователя."
 
-#: ../src/common/zipstrm.cpp:579
+#: ../src/common/zipstrm.cpp:572
 msgid "can't re-initialize zlib deflate stream"
 msgstr "невозможно переинициализировать поток распаковки zlib"
 
-#: ../src/common/zipstrm.cpp:604
+#: ../src/common/zipstrm.cpp:597
 msgid "can't re-initialize zlib inflate stream"
 msgstr "невозможно переинициализировать поток сжатия zlib"
 
-#: ../src/common/file.cpp:304
+#: ../src/common/file.cpp:345
 #, c-format
 msgid "can't read from file descriptor %d"
 msgstr "ошибка чтения файла с дескриптором %d"
 
-#: ../src/common/file.cpp:581
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:608
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "ошибка удаления файла '%s'"
 
-#: ../src/common/file.cpp:598
+#: ../src/common/ffile.cpp:394 ../src/common/file.cpp:625
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "ошибка удаления временного файла '%s'"
 
-#: ../src/common/file.cpp:408
+#: ../src/common/file.cpp:449
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "невозможно переместиться по файлу с дескриптором %d"
 
-#: ../src/common/textfile.cpp:273
+#: ../src/common/textfile.cpp:161
 #, c-format
 msgid "can't write buffer '%s' to disk."
 msgstr "ошибка записи буфера '%s' на диск."
 
-#: ../src/common/file.cpp:323
+#: ../src/common/file.cpp:364
 #, c-format
 msgid "can't write to file descriptor %d"
 msgstr "невозможно записать в файл с дескриптором %d"
@@ -8069,22 +8412,28 @@ msgid "can't write user configuration file."
 msgstr "невозможно записать файл конфигурации пользователя."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:482 ../src/generic/datavgen.cpp:1261
+#: ../src/common/datavcmn.cpp:2064 ../src/generic/datavgen.cpp:1384
 msgid "checked"
 msgstr "выбрано"
 
-#: ../src/html/chm.cpp:345
+#: ../src/html/chm.cpp:342
 msgid "checksum error"
 msgstr "ошибка контрольной суммы"
 
-#: ../src/common/tarstrm.cpp:820
+#: ../src/common/tarstrm.cpp:814
 msgid "checksum failure reading tar header block"
 msgstr "ошибка контрольной суммы читая заголовок блока tar"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:226
-#: ../src/richtext/richtextbackgroundpage.cpp:249
-#: ../src/richtext/richtextbackgroundpage.cpp:289
-#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
 #: ../src/richtext/richtextborderspage.cpp:254
 #: ../src/richtext/richtextborderspage.cpp:288
 #: ../src/richtext/richtextborderspage.cpp:322
@@ -8102,99 +8451,127 @@ msgstr "ошибка контрольной суммы читая заголов
 #: ../src/richtext/richtextmarginspage.cpp:340
 #: ../src/richtext/richtextmarginspage.cpp:363
 #: ../src/richtext/richtextmarginspage.cpp:388
-#: ../src/richtext/richtextsizepage.cpp:339 ../src/richtext/richtextsizepage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:400 ../src/richtext/richtextsizepage.cpp:427
-#: ../src/richtext/richtextsizepage.cpp:454 ../src/richtext/richtextsizepage.cpp:481
-#: ../src/richtext/richtextsizepage.cpp:555 ../src/richtext/richtextsizepage.cpp:590
-#: ../src/richtext/richtextsizepage.cpp:625 ../src/richtext/richtextsizepage.cpp:660
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
 msgid "cm"
 msgstr "см"
 
-#: ../src/html/chm.cpp:347
+#: ../src/html/chm.cpp:344
 msgid "compression error"
 msgstr "ошибка сжатия"
 
-#: ../src/common/regex.cpp:236
+#: ../src/common/regex.cpp:233
 msgid "conversion to 8-bit encoding failed"
 msgstr "не удалось преобразование в 8-бит кодировку"
 
-#: ../src/common/accelcmn.cpp:187
+#: ../src/common/accelcmn.cpp:186
 msgid "ctrl"
 msgstr "ctrl"
 
-#: ../src/common/cmdline.cpp:1500
+#: ../src/common/cmdline.cpp:1496
 msgid "date"
 msgstr "дата"
 
-#: ../src/html/chm.cpp:349
+#: ../src/html/chm.cpp:346
 msgid "decompression error"
 msgstr "ошибка распаковки"
 
-#: ../src/richtext/richtextstyles.cpp:780 ../src/common/fmapbase.cpp:820
+#: ../src/common/fmapbase.cpp:816 ../src/richtext/richtextstyles.cpp:777
 msgid "default"
 msgstr "по-умолчанию"
 
-#: ../src/common/cmdline.cpp:1496
+#: ../src/common/cmdline.cpp:1492
 msgid "double"
 msgstr "двухместный"
 
-#: ../src/common/debugrpt.cpp:538
+#: ../src/common/debugrpt.cpp:539
 msgid "dump of the process state (binary)"
 msgstr "дамп состояния процесса (двоичный)"
 
-#: ../src/common/datetimefmt.cpp:1969
+#: ../src/common/datetimefmt.cpp:1992
 msgid "eighteenth"
 msgstr "восемнадцатый"
 
-#: ../src/common/datetimefmt.cpp:1959
+#: ../src/common/datetimefmt.cpp:1982
 msgid "eighth"
 msgstr "восьмой"
 
-#: ../src/common/datetimefmt.cpp:1962
+#: ../src/common/datetimefmt.cpp:1985
 msgid "eleventh"
 msgstr "одиннадцатый"
 
-#: ../src/common/fileconf.cpp:1833
+#: ../src/common/fileconf.cpp:1835
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "запись '%s' появляется более одного раза в группе '%s'"
 
-#: ../src/html/chm.cpp:343
+#: ../src/html/chm.cpp:340
 msgid "error in data format"
 msgstr "ошибка в формате данных"
 
-#: ../src/html/chm.cpp:331
+#: ../src/html/chm.cpp:328
 msgid "error opening file"
 msgstr "ошибка открытия файла"
 
-#: ../src/common/zipstrm.cpp:1778
+#: ../src/common/zipstrm.cpp:1836
 msgid "error reading zip central directory"
 msgstr "ошибка чтения центрального каталога zip"
 
-#: ../src/common/zipstrm.cpp:1870
+#: ../src/common/zipstrm.cpp:1940
 msgid "error reading zip local header"
 msgstr "ошибка чтения локального заголовка zip"
 
-#: ../src/common/zipstrm.cpp:2531
+#: ../src/common/zipstrm.cpp:2615
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "ошибка записи элемента zip '%s': неверная длина или контрольная сумма"
 
-#: ../src/common/ffile.cpp:188
+#: ../src/common/zipstrm.cpp:2608
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "ошибка записи элемента zip '%s': неверная длина или контрольная сумма"
+
+#: ../src/common/fontcmn.cpp:1205
+#, fuzzy
+msgid "extrabold"
+msgstr "жирный"
+
+#: ../src/common/fontcmn.cpp:1223
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1167
+#, fuzzy
+msgid "extralight"
+msgstr "светлый"
+
+#: ../src/msw/webview_ie.cpp:1036
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "Не удалось выполнить '%s'\n"
+
+#: ../src/common/ffile.cpp:187
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "ошибка сброса буфера файла '%s'."
 
+#: ../src/msw/webview_ie.cpp:1045
+#, fuzzy
+msgid "failed to retrieve execution result"
+msgstr "Не удалось получить текст сообщения об ошибке RAS"
+
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1030
+#: ../src/generic/datavgen.cpp:1150
 msgid "false"
 msgstr "ложно"
 
-#: ../src/common/datetimefmt.cpp:1966
+#: ../src/common/datetimefmt.cpp:1989
 msgid "fifteenth"
 msgstr "пятнадцатый"
 
-#: ../src/common/datetimefmt.cpp:1956
+#: ../src/common/datetimefmt.cpp:1979
 msgid "fifth"
 msgstr "пятый"
 
@@ -8216,136 +8593,158 @@ msgstr "файл '%s', строка %zu: ключ '%s' был впервые н�
 #: ../src/common/fileconf.cpp:621
 #, c-format
 msgid "file '%s', line %zu: value for immutable key '%s' ignored."
-msgstr "файл '%s', строка %zu: значение для неизменяемого ключа '%s' игнорируется."
+msgstr ""
+"файл '%s', строка %zu: значение для неизменяемого ключа '%s' игнорируется."
 
 #: ../src/common/fileconf.cpp:543
 #, c-format
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "файл '%s': непредвиденный символ %c в строке %zu."
 
-#: ../src/richtext/richtextbuffer.cpp:8738
+#: ../src/richtext/richtextbuffer.cpp:8736
 msgid "files"
 msgstr "файлы"
 
-#: ../src/common/datetimefmt.cpp:1952
+#: ../src/common/datetimefmt.cpp:1975
 msgid "first"
 msgstr "первый"
 
-#: ../src/html/helpwnd.cpp:1252
+#: ../src/html/helpwnd.cpp:1250
 msgid "font size"
 msgstr "размер шрифта"
 
-#: ../src/common/datetimefmt.cpp:1965
+#: ../src/common/datetimefmt.cpp:1988
 msgid "fourteenth"
 msgstr "четырнадцатый"
 
-#: ../src/common/datetimefmt.cpp:1955
+#: ../src/common/datetimefmt.cpp:1978
 msgid "fourth"
 msgstr "четвёртый"
 
-#: ../src/common/appbase.cpp:783
+#: ../src/common/appbase.cpp:784
 msgid "generate verbose log messages"
 msgstr "генерировать подробные сообщения отладки"
 
-#: ../src/richtext/richtextbuffer.cpp:13138 ../src/richtext/richtextbuffer.cpp:13248
+#: ../src/common/fontcmn.cpp:1215
+msgid "heavy"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:13133
+#: ../src/richtext/richtextbuffer.cpp:13243
 msgid "image"
 msgstr "изображения"
 
-#: ../src/common/tarstrm.cpp:796
+#: ../src/common/tarstrm.cpp:790
 msgid "incomplete header block in tar"
 msgstr "неполный заголовок блока tar"
 
-#: ../src/common/xtixml.cpp:489
+#: ../src/common/xtixml.cpp:485
 msgid "incorrect event handler string, missing dot"
 msgstr "неверная строка обработчика события, отсутствует точка"
 
-#: ../src/common/tarstrm.cpp:1381
+#: ../src/common/tarstrm.cpp:1375
 msgid "incorrect size given for tar entry"
 msgstr "неправильные размеры даны для записи tar"
 
-#: ../src/common/tarstrm.cpp:993
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:987
 msgid "invalid data in extended tar header"
 msgstr "недопустимые данные в расширенном заголовке tar"
 
-#: ../src/generic/logg.cpp:1030
+#: ../src/generic/logg.cpp:1027
 msgid "invalid message box return value"
 msgstr "недопустимое значение возврата из окна сообщения"
 
-#: ../src/common/zipstrm.cpp:1647
+#: ../src/common/zipstrm.cpp:1688
 msgid "invalid zip file"
 msgstr "неверный zip-файл"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:1228
 msgid "italic"
 msgstr "курсив"
 
-#: ../src/common/fontcmn.cpp:991
+#: ../src/common/webrequest_curl.cpp:374
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "Не удалось загрузить файл."
+
+#: ../src/common/fontcmn.cpp:1172
 msgid "light"
 msgstr "светлый"
 
-#: ../src/common/intl.cpp:303
-#, c-format
-msgid "locale '%s' cannot be set."
-msgstr "локаль '%s' установить нельзя."
+#: ../src/common/fontcmn.cpp:1185
+msgid "medium"
+msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2125
+#: ../src/common/datetimefmt.cpp:2148
 msgid "midnight"
 msgstr "полночь"
 
-#: ../src/common/datetimefmt.cpp:1970
+#: ../src/common/datetimefmt.cpp:1993
 msgid "nineteenth"
 msgstr "девятнадцатый"
 
-#: ../src/common/datetimefmt.cpp:1960
+#: ../src/common/datetimefmt.cpp:1983
 msgid "ninth"
 msgstr "девятый"
 
-#: ../src/msw/dde.cpp:1116
+#: ../src/msw/dde.cpp:1180
 msgid "no DDE error."
 msgstr "нет ошибки DDE."
 
-#: ../src/html/chm.cpp:327
+#: ../src/html/chm.cpp:324
 msgid "no error"
 msgstr "нет ошибки"
 
-#: ../src/dfb/fontmgr.cpp:174
+#: ../src/dfb/fontmgr.cpp:171
 #, c-format
 msgid "no fonts found in %s, using builtin font"
 msgstr "в %s шрифты не найдены, используется встроенный шрифт"
 
-#: ../src/html/helpdata.cpp:657
+#: ../src/html/helpdata.cpp:650
 msgid "noname"
 msgstr "без имени"
 
-#: ../src/common/datetimefmt.cpp:2124
+#: ../src/common/datetimefmt.cpp:2147
 msgid "noon"
 msgstr "полдень"
 
-#: ../src/richtext/richtextstyles.cpp:779
+#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "нормальный"
 
-#: ../src/common/cmdline.cpp:1492
+#: ../src/common/cmdline.cpp:1488
 msgid "num"
 msgstr "num"
 
-#: ../src/common/xtixml.cpp:259
+#: ../src/common/accelcmn.cpp:194
+msgid "num "
+msgstr ""
+
+#: ../src/common/xtixml.cpp:255
 msgid "objects cannot have XML Text Nodes"
 msgstr "объекты не могут иметь текстовые узлы XML"
 
-#: ../src/html/chm.cpp:339
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
 msgid "out of memory"
 msgstr "недостаточно памяти"
 
-#: ../src/common/debugrpt.cpp:514
+#: ../src/common/debugrpt.cpp:515
 msgid "process context description"
 msgstr "описание контекста процесса"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:227
-#: ../src/richtext/richtextbackgroundpage.cpp:250
-#: ../src/richtext/richtextbackgroundpage.cpp:290
-#: ../src/richtext/richtextbackgroundpage.cpp:317
-#: ../src/richtext/richtextfontpage.cpp:177 ../src/richtext/richtextfontpage.cpp:180
 #: ../src/richtext/richtextborderspage.cpp:255
 #: ../src/richtext/richtextborderspage.cpp:289
 #: ../src/richtext/richtextborderspage.cpp:323
@@ -8355,22 +8754,45 @@ msgstr "описание контекста процесса"
 #: ../src/richtext/richtextborderspage.cpp:491
 #: ../src/richtext/richtextborderspage.cpp:525
 #: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextfontpage.cpp:180
 msgid "pt"
 msgstr "pt"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:225
-#: ../src/richtext/richtextbackgroundpage.cpp:228
-#: ../src/richtext/richtextbackgroundpage.cpp:229
-#: ../src/richtext/richtextbackgroundpage.cpp:248
-#: ../src/richtext/richtextbackgroundpage.cpp:251
-#: ../src/richtext/richtextbackgroundpage.cpp:252
-#: ../src/richtext/richtextbackgroundpage.cpp:288
-#: ../src/richtext/richtextbackgroundpage.cpp:291
-#: ../src/richtext/richtextbackgroundpage.cpp:292
-#: ../src/richtext/richtextbackgroundpage.cpp:315
-#: ../src/richtext/richtextbackgroundpage.cpp:318
-#: ../src/richtext/richtextbackgroundpage.cpp:319
-#: ../src/richtext/richtextfontpage.cpp:178
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:659
+#: ../src/richtext/richtextsizepage.cpp:662
+#: ../src/richtext/richtextsizepage.cpp:663
 #: ../src/richtext/richtextborderspage.cpp:253
 #: ../src/richtext/richtextborderspage.cpp:256
 #: ../src/richtext/richtextborderspage.cpp:257
@@ -8422,244 +8844,269 @@ msgstr "pt"
 #: ../src/richtext/richtextmarginspage.cpp:387
 #: ../src/richtext/richtextmarginspage.cpp:389
 #: ../src/richtext/richtextmarginspage.cpp:390
-#: ../src/richtext/richtextsizepage.cpp:338 ../src/richtext/richtextsizepage.cpp:341
-#: ../src/richtext/richtextsizepage.cpp:342 ../src/richtext/richtextsizepage.cpp:372
-#: ../src/richtext/richtextsizepage.cpp:375 ../src/richtext/richtextsizepage.cpp:376
-#: ../src/richtext/richtextsizepage.cpp:399 ../src/richtext/richtextsizepage.cpp:402
-#: ../src/richtext/richtextsizepage.cpp:403 ../src/richtext/richtextsizepage.cpp:426
-#: ../src/richtext/richtextsizepage.cpp:429 ../src/richtext/richtextsizepage.cpp:430
-#: ../src/richtext/richtextsizepage.cpp:453 ../src/richtext/richtextsizepage.cpp:456
-#: ../src/richtext/richtextsizepage.cpp:457 ../src/richtext/richtextsizepage.cpp:480
-#: ../src/richtext/richtextsizepage.cpp:483 ../src/richtext/richtextsizepage.cpp:484
-#: ../src/richtext/richtextsizepage.cpp:554 ../src/richtext/richtextsizepage.cpp:557
-#: ../src/richtext/richtextsizepage.cpp:558 ../src/richtext/richtextsizepage.cpp:589
-#: ../src/richtext/richtextsizepage.cpp:592 ../src/richtext/richtextsizepage.cpp:593
-#: ../src/richtext/richtextsizepage.cpp:624 ../src/richtext/richtextsizepage.cpp:627
-#: ../src/richtext/richtextsizepage.cpp:628 ../src/richtext/richtextsizepage.cpp:659
-#: ../src/richtext/richtextsizepage.cpp:662 ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextfontpage.cpp:178
 msgid "px"
 msgstr "px"
 
-#: ../src/common/accelcmn.cpp:193
+#: ../src/common/accelcmn.cpp:192
 msgid "rawctrl"
 msgstr "rawctrl"
 
-#: ../src/html/chm.cpp:333
+#: ../src/html/chm.cpp:330
 msgid "read error"
 msgstr "ошибка чтения"
 
-#: ../src/common/zipstrm.cpp:2085
+#: ../src/common/zipstrm.cpp:2155
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "чтение потока zip (точка входа %s): неверная контрольная сумма"
 
-#: ../src/common/zipstrm.cpp:2080
+#: ../src/common/zipstrm.cpp:2150
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "чтение потока zip (точка входа %s): неверная длина"
 
-#: ../src/msw/dde.cpp:1159
+#: ../src/msw/dde.cpp:1223
 msgid "reentrancy problem."
 msgstr "проблема повторного входа."
 
-#: ../src/common/datetimefmt.cpp:1953
+#: ../src/common/datetimefmt.cpp:1976
 msgid "second"
 msgstr "второй"
 
-#: ../src/html/chm.cpp:337
+#: ../src/html/chm.cpp:334
 msgid "seek error"
 msgstr "ошибка поиска"
 
-#: ../src/common/datetimefmt.cpp:1968
+#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#, fuzzy
+msgid "semibold"
+msgstr "жирный"
+
+#: ../src/common/datetimefmt.cpp:1991
 msgid "seventeenth"
 msgstr "семнадцатый"
 
-#: ../src/common/datetimefmt.cpp:1958
+#: ../src/common/datetimefmt.cpp:1981
 msgid "seventh"
 msgstr "седьмой"
 
-#: ../src/common/accelcmn.cpp:191
+#: ../src/common/accelcmn.cpp:190
 msgid "shift"
 msgstr "shift"
 
-#: ../src/common/appbase.cpp:773
+#: ../src/common/appbase.cpp:774
 msgid "show this help message"
 msgstr "показать это справочное сообщение"
 
-#: ../src/common/datetimefmt.cpp:1967
+#: ../src/common/datetimefmt.cpp:1990
 msgid "sixteenth"
 msgstr "шестнадцатый"
 
-#: ../src/common/datetimefmt.cpp:1957
+#: ../src/common/datetimefmt.cpp:1980
 msgid "sixth"
 msgstr "шестой"
 
-#: ../src/common/appcmn.cpp:234
+#: ../src/common/appcmn.cpp:255
 msgid "specify display mode to use (e.g. 640x480-16)"
 msgstr "укажите используемый режим экрана (например, 640x480-16)"
 
-#: ../src/common/appcmn.cpp:220
+#: ../src/common/appcmn.cpp:241
 msgid "specify the theme to use"
 msgstr "укажите тему для использования"
 
-#: ../src/richtext/richtextbuffer.cpp:9340
+#: ../src/richtext/richtextbuffer.cpp:9337
 msgid "standard/circle"
 msgstr "стандартный/круг"
 
-#: ../src/richtext/richtextbuffer.cpp:9341
+#: ../src/richtext/richtextbuffer.cpp:9338
 msgid "standard/circle-outline"
 msgstr "стандартный/круг-контур"
 
-#: ../src/richtext/richtextbuffer.cpp:9343
+#: ../src/richtext/richtextbuffer.cpp:9340
 msgid "standard/diamond"
 msgstr "стандартный/ромб"
 
-#: ../src/richtext/richtextbuffer.cpp:9342
+#: ../src/richtext/richtextbuffer.cpp:9339
 msgid "standard/square"
 msgstr "стандартный/квадрат"
 
-#: ../src/richtext/richtextbuffer.cpp:9344
+#: ../src/richtext/richtextbuffer.cpp:9341
 msgid "standard/triangle"
 msgstr "стандартный/треугольник"
 
-#: ../src/common/zipstrm.cpp:1985
+#: ../src/common/zipstrm.cpp:2055
 msgid "stored file length not in Zip header"
 msgstr "сохранённая длина файла не находится в заголовке Zip"
 
-#: ../src/common/cmdline.cpp:1488
+#: ../src/common/cmdline.cpp:1484
 msgid "str"
 msgstr "str"
 
-#: ../src/common/fontcmn.cpp:982
+#: ../src/common/fontcmn.cpp:1145
 msgid "strikethrough"
 msgstr "перечёркивание"
 
-#: ../src/common/tarstrm.cpp:1003 ../src/common/tarstrm.cpp:1025
-#: ../src/common/tarstrm.cpp:1507 ../src/common/tarstrm.cpp:1529
+#: ../src/common/tarstrm.cpp:997 ../src/common/tarstrm.cpp:1019
+#: ../src/common/tarstrm.cpp:1501 ../src/common/tarstrm.cpp:1523
 msgid "tar entry not open"
 msgstr "запись tar не открыта"
 
-#: ../src/common/datetimefmt.cpp:1961
+#: ../src/common/datetimefmt.cpp:1984
 msgid "tenth"
 msgstr "десятый"
 
-#: ../src/msw/dde.cpp:1123
+#: ../src/msw/dde.cpp:1187
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "ответ на транзакцию вызвал бит DDE_FBUSY."
 
-#: ../src/common/datetimefmt.cpp:1954
+#: ../src/common/fontcmn.cpp:1154
+msgid "thin"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:1977
 msgid "third"
 msgstr "третий"
 
-#: ../src/common/datetimefmt.cpp:1964
+#: ../src/common/datetimefmt.cpp:1987
 msgid "thirteenth"
 msgstr "тринадцатый"
 
-#: ../src/common/datetimefmt.cpp:1758
+#: ../src/common/datetimefmt.cpp:1781
 msgid "today"
 msgstr "сегодня"
 
-#: ../src/common/datetimefmt.cpp:1760
+#: ../src/common/datetimefmt.cpp:1783
 msgid "tomorrow"
 msgstr "завтра"
 
-#: ../src/common/fileconf.cpp:1944
+#: ../src/common/fileconf.cpp:1946
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "косая черта в '%s' игнорируется"
 
-#: ../src/gtk/aboutdlg.cpp:218
+#: ../src/gtk/aboutdlg.cpp:216
 msgid "translator-credits"
 msgstr "Список переводчиков"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1028
+#: ../src/generic/datavgen.cpp:1148
 msgid "true"
 msgstr "истинно"
 
-#: ../src/common/datetimefmt.cpp:1963
+#: ../src/common/datetimefmt.cpp:1986
 msgid "twelfth"
 msgstr "двенадцатый"
 
-#: ../src/common/datetimefmt.cpp:1971
+#: ../src/common/datetimefmt.cpp:1994
 msgid "twentieth"
 msgstr "двадцатый"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:486 ../src/generic/datavgen.cpp:1263
+#: ../src/common/datavcmn.cpp:2068 ../src/generic/datavgen.cpp:1386
 msgid "unchecked"
 msgstr "сброшенный"
 
-#: ../src/common/fontcmn.cpp:802 ../src/common/fontcmn.cpp:978
+#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
 msgid "underlined"
 msgstr "подчёркнутый"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:490
+#: ../src/common/datavcmn.cpp:2072
 msgid "undetermined"
 msgstr "неопределён"
 
-#: ../src/common/fileconf.cpp:1979
+#: ../src/common/fileconf.cpp:1981
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "неожиданный \" в позиции %d в '%s'."
 
-#: ../src/common/tarstrm.cpp:1045
+#: ../src/common/tarstrm.cpp:1039
 msgid "unexpected end of file"
 msgstr "неожиданный конец файла"
 
-#: ../src/generic/progdlgg.cpp:370 ../src/common/tarstrm.cpp:371
-#: ../src/common/tarstrm.cpp:394 ../src/common/tarstrm.cpp:425
+#: ../src/common/tarstrm.cpp:366 ../src/common/tarstrm.cpp:389
+#: ../src/common/tarstrm.cpp:420 ../src/generic/progdlgg.cpp:376
 msgid "unknown"
 msgstr "неизвестный"
 
-#: ../src/msw/registry.cpp:150
+#: ../src/msw/registry.cpp:139
 #, c-format
 msgid "unknown (%lu)"
 msgstr "неизвестно (%lu)"
 
-#: ../src/common/xtixml.cpp:253
+#: ../src/common/xtixml.cpp:249
 #, c-format
 msgid "unknown class %s"
 msgstr "неизвестный класс %s"
 
-#: ../src/common/regex.cpp:258 ../src/html/chm.cpp:351
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "ошибка сжатия"
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "ошибка распаковки"
+
+#: ../src/common/regex.cpp:255 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "неизвестная ошибка"
 
-#: ../src/msw/dialup.cpp:471
+#: ../src/msw/dialup.cpp:465
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "неизвестная ошибка (код ошибки %08x)"
 
-#: ../src/common/fmapbase.cpp:834
+#: ../src/common/fmapbase.cpp:830
 #, c-format
 msgid "unknown-%d"
 msgstr "неизвестный-%d"
 
-#: ../src/common/docview.cpp:509
+#: ../src/common/docview.cpp:502
 msgid "unnamed"
 msgstr "без_имени"
 
-#: ../src/common/docview.cpp:1624
+#: ../src/common/docview.cpp:1618
 #, c-format
 msgid "unnamed%d"
 msgstr "без_имени%d"
 
-#: ../src/common/zipstrm.cpp:1999 ../src/common/zipstrm.cpp:2319
+#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
 msgid "unsupported Zip compression method"
 msgstr "неподдерживаемый метод сжатия Zip"
 
-#: ../src/common/translation.cpp:1892
+#: ../src/common/translation.cpp:1942
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "используется каталог '%s' из '%s'."
 
-#: ../src/html/chm.cpp:335
+#: ../src/html/chm.cpp:332
 msgid "write error"
 msgstr "ошибка записи"
 
-#: ../src/common/time.cpp:292
+#: ../src/gtk/glcanvas.cpp:187
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/common/time.cpp:285
 msgid "wxGetTimeOfDay failed."
 msgstr "ошибка wxGetTimeOfDay."
 
@@ -8672,15 +9119,15 @@ msgstr "wxWidgets не удалось открыть дисплей для '%s':
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets не удалось открыть дисплей. Выход."
 
-#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:431
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/common/datetimefmt.cpp:1759
+#: ../src/common/datetimefmt.cpp:1782
 msgid "yesterday"
 msgstr "вчера"
 
-#: ../src/common/zstream.cpp:251 ../src/common/zstream.cpp:426
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
 #, c-format
 msgid "zlib error %d"
 msgstr "ошибка zlib %d"
@@ -8689,3 +9136,75 @@ msgstr "ошибка zlib %d"
 #: ../src/richtext/richtextbulletspage.cpp:288
 msgid "~"
 msgstr "~"
+
+#~ msgid " (while overwriting an existing item)"
+#~ msgstr " (при перезаписи существующего элемента)"
+
+#~ msgid "&Save as"
+#~ msgstr "&Сохранить как"
+
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' должно содержать только допустимые символы"
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' должно быть числом."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' должно содержать только символы ASCII."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' должно содержать только символы алфавита."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' должно содержать только символы алфавита или цифры."
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' должно содержать только цифры."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "Невозможно создать окно класса %s"
+
+#~ msgid "Could not initalize libnotify."
+#~ msgstr "Не удалось инициализировать libnotify."
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "Не удалось создать перекрывающееся окно"
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "Не удалось инициализировать контекст в перекрывающемся окне"
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "Не удалось преобразовать файл \"%s\" в Unicode."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "Не удалось установить текст в текстовое поле."
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr "Повреждены опции командной строки GTK+, используйте '%s --help'"
+
+#~ msgid "No unused colour in image."
+#~ msgstr "В изображении нет неиспользуемых цветов."
+
+#~ msgid "Not available"
+#~ msgstr "Не доступно"
+
+#~ msgid "Replace selection"
+#~ msgstr "Заменить выделенное"
+
+#~ msgid "Save as"
+#~ msgstr "Сохранить как"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Органайзер стиля"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "Также поддерживаются следующие стандартные параметры GTK+:\n"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "Нельзя очистить наложение на изображение без инициализации"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "Нельзя Init наложить два раза"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "локаль '%s' установить нельзя."

--- a/locale/sk.po
+++ b/locale/sk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-21 14:25+0200\n"
+"POT-Creation-Date: 2020-10-18 23:11+0300\n"
 "PO-Revision-Date: 2020-10-19 12:24+0200\n"
 "Last-Translator: Jozef Matta <jozef.m923@gmail.com>\n"
 "Language-Team: Slovak <sk-i18n@lists.linux.sk>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "X-Generator: Poedit 2.4.1\n"
 "X-Poedit-Bookmarks: -1,1760,-1,-1,-1,-1,-1,-1,-1,-1\n"
 
-#: ../src/common/debugrpt.cpp:586
+#: ../src/common/debugrpt.cpp:587
 msgid ""
 "\n"
 "Please send this report to the program maintainer, thank you!\n"
@@ -27,8 +27,8 @@ msgstr ""
 "\n"
 "Pošlite, prosím, toto hlásenie správcovi balíka, ďakujeme!\n"
 
-#: ../src/richtext/richtextstyledlg.cpp:210
-#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:206
+#: ../src/richtext/richtextstyledlg.cpp:218
 msgid " "
 msgstr " "
 
@@ -36,70 +36,96 @@ msgstr " "
 msgid "              Thank you and we're sorry for the inconvenience!\n"
 msgstr "              Ďakujeme a prepáčte za nepríjemnosti!\n"
 
-#: ../src/common/prntbase.cpp:573
+#: ../src/common/prntbase.cpp:568
 #, c-format
 msgid " (copy %d of %d)"
 msgstr " (kópia %d z %d)"
 
-#: ../src/common/log.cpp:421
+#: ../src/common/log.cpp:440
 #, c-format
 msgid " (error %ld: %s)"
 msgstr " (chyba %ld: %s)"
 
-#: ../src/common/imagtiff.cpp:72
+#: ../src/common/imagtiff.cpp:69
 #, c-format
 msgid " (in module \"%s\")"
 msgstr " (v module '%s')"
 
-#: ../src/osx/core/secretstore.cpp:138
-msgid " (while overwriting an existing item)"
-msgstr " (pri prepísaní existujúcej položky)"
-
-#: ../src/common/docview.cpp:1642
+#: ../src/common/docview.cpp:1636
 msgid " - "
 msgstr " - "
 
-#: ../src/richtext/richtextprint.cpp:593 ../src/html/htmprint.cpp:714
+#: ../src/html/htmprint.cpp:712 ../src/richtext/richtextprint.cpp:589
 msgid " Preview"
 msgstr " Náhľad"
 
-#: ../src/common/fontcmn.cpp:824
+#: ../src/common/fontcmn.cpp:973
 msgid " bold"
 msgstr " tučné"
 
-#: ../src/common/fontcmn.cpp:840
+#: ../src/common/fontcmn.cpp:977
+#, fuzzy
+msgid " extra bold"
+msgstr " tučné"
+
+#: ../src/common/fontcmn.cpp:985
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:957
+#, fuzzy
+msgid " extra light"
+msgstr " tenké"
+
+#: ../src/common/fontcmn.cpp:981
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1001
 msgid " italic"
 msgstr " kurzíva"
 
-#: ../src/common/fontcmn.cpp:820
+#: ../src/common/fontcmn.cpp:961
 msgid " light"
 msgstr " tenké"
 
-#: ../src/common/fontcmn.cpp:807
+#: ../src/common/fontcmn.cpp:965
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:969
+#, fuzzy
+msgid " semi bold"
+msgstr " tučné"
+
+#: ../src/common/fontcmn.cpp:940
 msgid " strikethrough"
 msgstr " preškrtnuté"
 
-#: ../src/common/paper.cpp:117
+#: ../src/common/fontcmn.cpp:953
+msgid " thin"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
 msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
 msgstr "#10 obálka, 4 1/8 x 9 1/2 palca"
 
-#: ../src/common/paper.cpp:118
+#: ../src/common/paper.cpp:115
 msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
 msgstr "#11 obálka, 4 1/2 x 10 3/8 palca"
 
-#: ../src/common/paper.cpp:119
+#: ../src/common/paper.cpp:116
 msgid "#12 Envelope, 4 3/4 x 11 in"
 msgstr "#12 obálka, 4 3/4 x 11 palca"
 
-#: ../src/common/paper.cpp:120
+#: ../src/common/paper.cpp:117
 msgid "#14 Envelope, 5 x 11 1/2 in"
 msgstr "#14 obálka, 5 x 11 1/2 palca"
 
-#: ../src/common/paper.cpp:116
+#: ../src/common/paper.cpp:113
 msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
 msgstr "#9 obálka, 3 7/8 x 8 7/8 palca"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:341
 #: ../src/richtext/richtextsizepage.cpp:340
 #: ../src/richtext/richtextsizepage.cpp:374
 #: ../src/richtext/richtextsizepage.cpp:401
@@ -110,20 +136,21 @@ msgstr "#9 obálka, 3 7/8 x 8 7/8 palca"
 #: ../src/richtext/richtextsizepage.cpp:591
 #: ../src/richtext/richtextsizepage.cpp:626
 #: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextbackgroundpage.cpp:341
 msgid "%"
 msgstr "%"
 
-#: ../src/html/helpwnd.cpp:1031
+#: ../src/html/helpwnd.cpp:1029
 #, c-format
 msgid "%d of %lu"
 msgstr "%d z %lu"
 
-#: ../src/html/helpwnd.cpp:1678
+#: ../src/html/helpwnd.cpp:1676
 #, c-format
 msgid "%i of %u"
 msgstr "%i z %u"
 
-#: ../src/generic/filectrlg.cpp:279
+#: ../src/generic/filectrlg.cpp:275
 #, c-format
 msgid "%ld byte"
 msgid_plural "%ld bytes"
@@ -131,61 +158,61 @@ msgstr[0] "%ld bajt"
 msgstr[1] "%ld bajty"
 msgstr[2] "%ld bajtov"
 
-#: ../src/html/helpwnd.cpp:1033
+#: ../src/html/helpwnd.cpp:1031
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu z %lu"
 
-#: ../src/generic/datavgen.cpp:6028
+#: ../src/generic/datavgen.cpp:6833
 #, c-format
 msgid "%s (%d items)"
 msgstr "%s (%d položiek)"
 
-#: ../src/common/cmdline.cpp:1221
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (alebo %s)"
 
-#: ../src/generic/logg.cpp:224
+#: ../src/generic/logg.cpp:221
 #, c-format
 msgid "%s Error"
 msgstr "%s Chyba"
 
-#: ../src/generic/logg.cpp:236
+#: ../src/generic/logg.cpp:233
 #, c-format
 msgid "%s Information"
 msgstr "%s Informácia"
 
-#: ../src/generic/preferencesg.cpp:113
+#: ../src/generic/preferencesg.cpp:110
 #, c-format
 msgid "%s Preferences"
 msgstr "Predvoľby %s"
 
-#: ../src/generic/logg.cpp:228
+#: ../src/generic/logg.cpp:225
 #, c-format
 msgid "%s Warning"
 msgstr "%s Varovanie"
 
-#: ../src/common/tarstrm.cpp:1319
+#: ../src/common/tarstrm.cpp:1313
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s sa nehodilo do tar hlavičky záznamu '%s'"
 
-#: ../src/common/fldlgcmn.cpp:124
+#: ../src/common/fldlgcmn.cpp:121
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s súborov (%s)|%s"
 
-#: ../src/html/helpwnd.cpp:1716
+#: ../src/html/helpwnd.cpp:1714
 #, c-format
 msgid "%u of %u"
 msgstr "%u z %u"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "&About"
 msgstr "&O aplikácii"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "&Actual Size"
 msgstr "&Skutočná veľkosť"
 
@@ -193,28 +220,28 @@ msgstr "&Skutočná veľkosť"
 msgid "&After a paragraph:"
 msgstr "& Za odsekom:"
 
-#: ../src/richtext/richtextindentspage.cpp:128
 #: ../src/richtext/richtextliststylepage.cpp:319
+#: ../src/richtext/richtextindentspage.cpp:128
 msgid "&Alignment"
 msgstr "&Zarovnanie"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "&Apply"
 msgstr "&Použiť"
 
-#: ../src/richtext/richtextstyledlg.cpp:251
+#: ../src/richtext/richtextstyledlg.cpp:247
 msgid "&Apply Style"
 msgstr "&Použiť štýl"
 
-#: ../src/msw/mdi.cpp:179
+#: ../src/msw/mdi.cpp:174
 msgid "&Arrange Icons"
 msgstr "&Zoradiť ikony"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "&Ascending"
 msgstr "&Vzostupne"
 
-#: ../src/common/stockitem.cpp:142
+#: ../src/common/stockitem.cpp:139
 msgid "&Back"
 msgstr "&Späť"
 
@@ -234,24 +261,24 @@ msgstr "&Bg farba:"
 msgid "&Blur distance:"
 msgstr "&Dĺžka rozostrenia:"
 
-#: ../src/common/stockitem.cpp:143
+#: ../src/common/stockitem.cpp:140
 msgid "&Bold"
 msgstr "&Tučné"
 
-#: ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141
 msgid "&Bottom"
 msgstr "&Dole"
 
+#: ../src/richtext/richtextsizepage.cpp:637
+#: ../src/richtext/richtextsizepage.cpp:644
 #: ../src/richtext/richtextborderspage.cpp:345
 #: ../src/richtext/richtextborderspage.cpp:513
 #: ../src/richtext/richtextmarginspage.cpp:259
 #: ../src/richtext/richtextmarginspage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:637
-#: ../src/richtext/richtextsizepage.cpp:644
 msgid "&Bottom:"
 msgstr "&Dole:"
 
-#: ../include/wx/richtext/richtextbuffer.h:3866
+#: ../include/wx/richtext/richtextbuffer.h:3861
 msgid "&Box"
 msgstr "&Box"
 
@@ -260,38 +287,38 @@ msgstr "&Box"
 msgid "&Bullet style:"
 msgstr "& Štýl odrážky:"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "&CD-Rom"
 msgstr "&CD-Rom"
 
-#: ../src/generic/wizard.cpp:434 ../src/generic/fontdlgg.cpp:470
-#: ../src/generic/fontdlgg.cpp:489 ../src/osx/carbon/fontdlg.cpp:402
-#: ../src/common/dlgcmn.cpp:279 ../src/common/stockitem.cpp:145
+#: ../src/osx/carbon/fontdlg.cpp:399 ../src/common/stockitem.cpp:142
+#: ../src/generic/wizard.cpp:433 ../src/generic/fontdlgg.cpp:466
+#: ../src/generic/fontdlgg.cpp:485 ../src/osx/cocoa/button.mm:200
 msgid "&Cancel"
 msgstr "&Zrušiť"
 
-#: ../src/msw/mdi.cpp:175
+#: ../src/msw/mdi.cpp:170
 msgid "&Cascade"
 msgstr "&Kaskáda"
 
-#: ../include/wx/richtext/richtextbuffer.h:5960
+#: ../include/wx/richtext/richtextbuffer.h:5955
 msgid "&Cell"
 msgstr "&Bunka"
 
-#: ../src/richtext/richtextsymboldlg.cpp:439
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "&Character code:"
 msgstr "&Kód znaku:"
 
-#: ../src/common/stockitem.cpp:147
+#: ../src/common/stockitem.cpp:144
 msgid "&Clear"
 msgstr "&Zmazať"
 
-#: ../src/generic/logg.cpp:516 ../src/common/stockitem.cpp:148
-#: ../src/common/prntbase.cpp:1600 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/stockitem.cpp:145 ../src/common/prntbase.cpp:1625
+#: ../src/univ/themes/win32.cpp:3753 ../src/generic/logg.cpp:513
 msgid "&Close"
 msgstr "&Zatvoriť"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "&Color"
 msgstr "&Farba"
 
@@ -299,20 +326,20 @@ msgstr "&Farba"
 msgid "&Colour:"
 msgstr "&Farba:"
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "&Convert"
 msgstr "&Konvertovať"
 
-#: ../src/richtext/richtextctrl.cpp:333 ../src/osx/textctrl_osx.cpp:577
-#: ../src/common/stockitem.cpp:150 ../src/msw/textctrl.cpp:2508
+#: ../src/osx/textctrl_osx.cpp:595 ../src/common/stockitem.cpp:147
+#: ../src/msw/textctrl.cpp:2773 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Kopírovať"
 
-#: ../src/generic/hyperlinkg.cpp:156
+#: ../src/generic/hyperlinkg.cpp:153
 msgid "&Copy URL"
 msgstr "&Kopírovať URL"
 
-#: ../src/common/headerctrlcmn.cpp:306
+#: ../src/common/headerctrlcmn.cpp:304
 msgid "&Customize..."
 msgstr "&Prispôsobiť ..."
 
@@ -320,53 +347,54 @@ msgstr "&Prispôsobiť ..."
 msgid "&Debug report preview:"
 msgstr "&Náhľad správy ladenia:"
 
-#: ../src/richtext/richtexttabspage.cpp:138
-#: ../src/richtext/richtextctrl.cpp:335 ../src/osx/textctrl_osx.cpp:579
-#: ../src/common/stockitem.cpp:152 ../src/msw/textctrl.cpp:2510
+#: ../src/osx/textctrl_osx.cpp:597 ../src/common/stockitem.cpp:149
+#: ../src/msw/textctrl.cpp:2775 ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtextctrl.cpp:334
 msgid "&Delete"
 msgstr "&Odstrániť"
 
-#: ../src/richtext/richtextstyledlg.cpp:269
+#: ../src/richtext/richtextstyledlg.cpp:265
 msgid "&Delete Style..."
 msgstr "&Odstrániť štýl..."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "&Descending"
 msgstr "&Zostupne"
 
-#: ../src/generic/logg.cpp:682
+#: ../src/generic/logg.cpp:679
 msgid "&Details"
 msgstr "&Podrobnosti"
 
-#: ../src/common/stockitem.cpp:153
+#: ../src/common/stockitem.cpp:150
 msgid "&Down"
 msgstr "&Dolu"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "&Edit"
 msgstr "&Upraviť"
 
-#: ../src/richtext/richtextstyledlg.cpp:263
+#: ../src/richtext/richtextstyledlg.cpp:259
 msgid "&Edit Style..."
 msgstr "&Upraviť štýl..."
 
-#: ../src/common/stockitem.cpp:155
+#: ../src/common/stockitem.cpp:152
 msgid "&Execute"
 msgstr "&Vykonať"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/common/stockitem.cpp:154
 msgid "&File"
 msgstr "&Súbor"
 
-#: ../src/common/stockitem.cpp:158
-msgid "&Find"
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "&Find..."
 msgstr "&Hľadať"
 
-#: ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:430
 msgid "&Finish"
 msgstr "&Dokončiť"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:156
 msgid "&First"
 msgstr "&Najprv"
 
@@ -374,15 +402,15 @@ msgstr "&Najprv"
 msgid "&Floating mode:"
 msgstr "&Režim pohyblivej čiarky:"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "&Floppy"
 msgstr "&Disketa"
 
-#: ../src/common/stockitem.cpp:194
+#: ../src/common/stockitem.cpp:191
 msgid "&Font"
 msgstr "&Písmo"
 
-#: ../src/generic/fontdlgg.cpp:371
+#: ../src/generic/fontdlgg.cpp:367
 msgid "&Font family:"
 msgstr "&Príbuzné písmo:"
 
@@ -390,20 +418,20 @@ msgstr "&Príbuzné písmo:"
 msgid "&Font for Level..."
 msgstr "&Písmo pre úroveň..."
 
+#: ../src/richtext/richtextsymboldlg.cpp:397
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:400
 msgid "&Font:"
 msgstr "&Písmo:"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "&Forward"
 msgstr "&Vpred"
 
-#: ../src/richtext/richtextsymboldlg.cpp:451
+#: ../src/richtext/richtextsymboldlg.cpp:448
 msgid "&From:"
 msgstr "&Od:"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "&Harddisk"
 msgstr "&Pevný disk"
 
@@ -412,9 +440,9 @@ msgstr "&Pevný disk"
 msgid "&Height:"
 msgstr "&Výška:"
 
-#: ../src/generic/wizard.cpp:441 ../src/richtext/richtextstyledlg.cpp:303
-#: ../src/richtext/richtextsymboldlg.cpp:479 ../src/osx/menu_osx.cpp:734
-#: ../src/common/stockitem.cpp:163
+#: ../src/common/stockitem.cpp:160 ../src/generic/wizard.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextstyledlg.cpp:299 ../src/osx/cocoa/menu.mm:226
 msgid "&Help"
 msgstr "&Pomoc"
 
@@ -422,7 +450,7 @@ msgstr "&Pomoc"
 msgid "&Hide details"
 msgstr "&Skryť detaily"
 
-#: ../src/common/stockitem.cpp:164
+#: ../src/common/stockitem.cpp:161
 msgid "&Home"
 msgstr "&Domov"
 
@@ -430,54 +458,54 @@ msgstr "&Domov"
 msgid "&Horizontal offset:"
 msgstr "&Vodorovný posuv:"
 
-#: ../src/richtext/richtextindentspage.cpp:184
 #: ../src/richtext/richtextliststylepage.cpp:372
+#: ../src/richtext/richtextindentspage.cpp:184
 msgid "&Indentation (tenths of a mm)"
 msgstr "&Odsadenie (desatiny milimetra)"
 
-#: ../src/richtext/richtextindentspage.cpp:167
 #: ../src/richtext/richtextliststylepage.cpp:356
+#: ../src/richtext/richtextindentspage.cpp:167
 msgid "&Indeterminate"
 msgstr "&Neurčitý"
 
-#: ../src/common/stockitem.cpp:166
+#: ../src/common/stockitem.cpp:163
 msgid "&Index"
 msgstr "&Index"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "&Info"
 msgstr "&Info"
 
-#: ../src/common/stockitem.cpp:168
+#: ../src/common/stockitem.cpp:165
 msgid "&Italic"
 msgstr "&Kurzíva"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "&Jump to"
 msgstr "&Skoč na"
 
-#: ../src/richtext/richtextindentspage.cpp:153
 #: ../src/richtext/richtextliststylepage.cpp:342
+#: ../src/richtext/richtextindentspage.cpp:153
 msgid "&Justified"
 msgstr "&Zarovnaný"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "&Last"
 msgstr "&Posledný"
 
-#: ../src/richtext/richtextindentspage.cpp:139
 #: ../src/richtext/richtextliststylepage.cpp:328
+#: ../src/richtext/richtextindentspage.cpp:139
 msgid "&Left"
 msgstr "&Vľavo"
 
-#: ../src/richtext/richtextindentspage.cpp:195
+#: ../src/richtext/richtextsizepage.cpp:532
+#: ../src/richtext/richtextsizepage.cpp:539
 #: ../src/richtext/richtextborderspage.cpp:243
 #: ../src/richtext/richtextborderspage.cpp:411
 #: ../src/richtext/richtextliststylepage.cpp:381
+#: ../src/richtext/richtextindentspage.cpp:195
 #: ../src/richtext/richtextmarginspage.cpp:186
 #: ../src/richtext/richtextmarginspage.cpp:300
-#: ../src/richtext/richtextsizepage.cpp:532
-#: ../src/richtext/richtextsizepage.cpp:539
 msgid "&Left:"
 msgstr "&Vľavo:"
 
@@ -485,11 +513,11 @@ msgstr "&Vľavo:"
 msgid "&List level:"
 msgstr "Ú&roveň zoznamu:"
 
-#: ../src/generic/logg.cpp:517
+#: ../src/generic/logg.cpp:514
 msgid "&Log"
 msgstr "&Záznam"
 
-#: ../src/univ/themes/win32.cpp:3748
+#: ../src/univ/themes/win32.cpp:3745
 msgid "&Move"
 msgstr "&Presunúť"
 
@@ -497,19 +525,19 @@ msgstr "&Presunúť"
 msgid "&Move the object to:"
 msgstr "&Presunúť objekt do:"
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "&Network"
 msgstr "&Sieť"
 
-#: ../src/richtext/richtexttabspage.cpp:132 ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173 ../src/richtext/richtexttabspage.cpp:132
 msgid "&New"
 msgstr "&Nový"
 
-#: ../src/aui/tabmdi.cpp:111 ../src/generic/mdig.cpp:100 ../src/msw/mdi.cpp:180
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
 msgid "&Next"
 msgstr "&Ďalej"
 
-#: ../src/generic/wizard.cpp:432 ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:429
 msgid "&Next >"
 msgstr "&Ďalej >"
 
@@ -517,7 +545,7 @@ msgstr "&Ďalej >"
 msgid "&Next Paragraph"
 msgstr "&Nasledujúci odsek"
 
-#: ../src/generic/tipdlg.cpp:240
+#: ../src/generic/tipdlg.cpp:237
 msgid "&Next Tip"
 msgstr "&Ďalší tip"
 
@@ -525,11 +553,11 @@ msgstr "&Ďalší tip"
 msgid "&Next style:"
 msgstr "&Ďalší štýl:"
 
-#: ../src/common/stockitem.cpp:177 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:174 ../src/msw/msgdlg.cpp:435
 msgid "&No"
 msgstr "&Nie"
 
-#: ../src/generic/dbgrptg.cpp:356
+#: ../src/generic/dbgrptg.cpp:360
 msgid "&Notes:"
 msgstr "&Poznámky:"
 
@@ -537,12 +565,12 @@ msgstr "&Poznámky:"
 msgid "&Number:"
 msgstr "&Číslo:"
 
-#: ../src/generic/fontdlgg.cpp:475 ../src/generic/fontdlgg.cpp:482
-#: ../src/osx/carbon/fontdlg.cpp:408 ../src/common/stockitem.cpp:178
+#: ../src/osx/carbon/fontdlg.cpp:405 ../src/common/stockitem.cpp:175
+#: ../src/generic/fontdlgg.cpp:471 ../src/generic/fontdlgg.cpp:478
 msgid "&OK"
 msgstr "&OK"
 
-#: ../src/generic/dbgrptg.cpp:342 ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176 ../src/generic/dbgrptg.cpp:342
 msgid "&Open..."
 msgstr "&Otvoriť..."
 
@@ -554,16 +582,16 @@ msgstr "&Úroveň osnovy:"
 msgid "&Page Break"
 msgstr "&Zlom strany"
 
-#: ../src/richtext/richtextctrl.cpp:334 ../src/osx/textctrl_osx.cpp:578
-#: ../src/common/stockitem.cpp:180 ../src/msw/textctrl.cpp:2509
+#: ../src/osx/textctrl_osx.cpp:596 ../src/common/stockitem.cpp:177
+#: ../src/msw/textctrl.cpp:2774 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&Prilepiť"
 
-#: ../include/wx/richtext/richtextbuffer.h:5010
+#: ../include/wx/richtext/richtextbuffer.h:5005
 msgid "&Picture"
 msgstr "&Obrázok"
 
-#: ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:419
 msgid "&Point size:"
 msgstr "&Veľkosť bodu:"
 
@@ -575,11 +603,11 @@ msgstr "&Umiestnenie (desatiny milimetra):"
 msgid "&Position mode:"
 msgstr "Režim &pozície:"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178
 msgid "&Preferences"
 msgstr "&Nastavenia"
 
-#: ../src/aui/tabmdi.cpp:112 ../src/generic/mdig.cpp:101 ../src/msw/mdi.cpp:181
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
 msgid "&Previous"
 msgstr "&Predchádzajúci"
 
@@ -587,78 +615,74 @@ msgstr "&Predchádzajúci"
 msgid "&Previous Paragraph"
 msgstr "&Predošlý odsek"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "&Print..."
 msgstr "&Tlačiť..."
 
-#: ../src/richtext/richtextctrl.cpp:339 ../src/richtext/richtextctrl.cpp:5514
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtextctrl.cpp:338
+#: ../src/richtext/richtextctrl.cpp:5512
 msgid "&Properties"
 msgstr "&Vlastnosti"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "&Quit"
 msgstr "&Skončiť"
 
-#: ../src/richtext/richtextctrl.cpp:330 ../src/osx/textctrl_osx.cpp:574
-#: ../src/common/stockitem.cpp:185 ../src/common/cmdproc.cpp:293
-#: ../src/common/cmdproc.cpp:300 ../src/msw/textctrl.cpp:2505
+#: ../src/osx/textctrl_osx.cpp:592 ../src/common/stockitem.cpp:182
+#: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
+#: ../src/msw/textctrl.cpp:2770 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Vpred"
 
-#: ../src/common/cmdproc.cpp:289 ../src/common/cmdproc.cpp:309
+#: ../src/common/cmdproc.cpp:282 ../src/common/cmdproc.cpp:302
 msgid "&Redo "
 msgstr "&Vpred "
 
-#: ../src/richtext/richtextstyledlg.cpp:257
+#: ../src/richtext/richtextstyledlg.cpp:253
 msgid "&Rename Style..."
 msgstr "&Premenovať štýl..."
 
-#: ../src/generic/fdrepdlg.cpp:179
+#: ../src/generic/fdrepdlg.cpp:176
 msgid "&Replace"
 msgstr "&Nahradiť"
 
-#: ../src/richtext/richtextstyledlg.cpp:287
+#: ../src/richtext/richtextstyledlg.cpp:283
 msgid "&Restart numbering"
 msgstr "&Reštartovať číslovanie"
 
-#: ../src/univ/themes/win32.cpp:3747
+#: ../src/univ/themes/win32.cpp:3744
 msgid "&Restore"
 msgstr "&Obnoviť"
 
-#: ../src/richtext/richtextindentspage.cpp:146
 #: ../src/richtext/richtextliststylepage.cpp:335
+#: ../src/richtext/richtextindentspage.cpp:146
 msgid "&Right"
 msgstr "&Vpravo"
 
-#: ../src/richtext/richtextindentspage.cpp:213
+#: ../src/richtext/richtextsizepage.cpp:602
+#: ../src/richtext/richtextsizepage.cpp:609
 #: ../src/richtext/richtextborderspage.cpp:277
 #: ../src/richtext/richtextborderspage.cpp:445
 #: ../src/richtext/richtextliststylepage.cpp:399
+#: ../src/richtext/richtextindentspage.cpp:213
 #: ../src/richtext/richtextmarginspage.cpp:211
 #: ../src/richtext/richtextmarginspage.cpp:325
-#: ../src/richtext/richtextsizepage.cpp:602
-#: ../src/richtext/richtextsizepage.cpp:609
 msgid "&Right:"
 msgstr "&Vpravo:"
 
-#: ../src/common/stockitem.cpp:190
+#: ../src/common/stockitem.cpp:187
 msgid "&Save"
 msgstr "&Uložiť"
-
-#: ../src/common/stockitem.cpp:191
-msgid "&Save as"
-msgstr "&Uložiť Ako"
 
 #: ../include/wx/richmsgdlg.h:29
 msgid "&See details"
 msgstr "&Pozrieť detaily"
 
-#: ../src/generic/tipdlg.cpp:236
+#: ../src/generic/tipdlg.cpp:233
 msgid "&Show tips at startup"
 msgstr "&Zobrazovať tipy pri spustení"
 
-#: ../src/univ/themes/win32.cpp:3750
+#: ../src/univ/themes/win32.cpp:3747
 msgid "&Size"
 msgstr "&Veľkosť"
 
@@ -666,36 +690,36 @@ msgstr "&Veľkosť"
 msgid "&Size:"
 msgstr "&Veľkosť:"
 
-#: ../src/generic/progdlgg.cpp:252
+#: ../src/generic/progdlgg.cpp:249
 msgid "&Skip"
 msgstr "&Preskočiť"
 
-#: ../src/richtext/richtextindentspage.cpp:242
 #: ../src/richtext/richtextliststylepage.cpp:417
+#: ../src/richtext/richtextindentspage.cpp:242
 msgid "&Spacing (tenths of a mm)"
 msgstr "&Rozostup (desatiny milimetra)"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "&Spell Check"
 msgstr "&Kontrola pravopisu"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "&Stop"
 msgstr "&Stop"
 
-#: ../src/richtext/richtextfontpage.cpp:275 ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196 ../src/richtext/richtextfontpage.cpp:275
 msgid "&Strikethrough"
 msgstr "&Preškrtnuté"
 
-#: ../src/generic/fontdlgg.cpp:382 ../src/richtext/richtextstylepage.cpp:106
+#: ../src/generic/fontdlgg.cpp:378 ../src/richtext/richtextstylepage.cpp:106
 msgid "&Style:"
 msgstr "&Štýl:"
 
-#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:194
 msgid "&Styles:"
 msgstr "&Štýly:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:413
+#: ../src/richtext/richtextsymboldlg.cpp:410
 msgid "&Subset:"
 msgstr "&Podmnožina:"
 
@@ -709,24 +733,24 @@ msgstr "&Symbol:"
 msgid "&Synchronize values"
 msgstr "&Synchronizovať hodnoty"
 
-#: ../include/wx/richtext/richtextbuffer.h:6069
+#: ../include/wx/richtext/richtextbuffer.h:6064
 msgid "&Table"
 msgstr "&Karta"
 
-#: ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197
 msgid "&Top"
 msgstr "&Navrchu"
 
+#: ../src/richtext/richtextsizepage.cpp:567
+#: ../src/richtext/richtextsizepage.cpp:574
 #: ../src/richtext/richtextborderspage.cpp:311
 #: ../src/richtext/richtextborderspage.cpp:479
 #: ../src/richtext/richtextmarginspage.cpp:234
 #: ../src/richtext/richtextmarginspage.cpp:348
-#: ../src/richtext/richtextsizepage.cpp:567
-#: ../src/richtext/richtextsizepage.cpp:574
 msgid "&Top:"
 msgstr "&Navrchu:"
 
-#: ../src/generic/fontdlgg.cpp:444 ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199 ../src/generic/fontdlgg.cpp:441
 msgid "&Underline"
 msgstr "&Podčiarknuté"
 
@@ -734,21 +758,21 @@ msgstr "&Podčiarknuté"
 msgid "&Underlining:"
 msgstr "&Podčiarknuté:"
 
-#: ../src/richtext/richtextctrl.cpp:329 ../src/osx/textctrl_osx.cpp:573
-#: ../src/common/stockitem.cpp:203 ../src/common/cmdproc.cpp:271
-#: ../src/msw/textctrl.cpp:2504
+#: ../src/osx/textctrl_osx.cpp:591 ../src/common/stockitem.cpp:200
+#: ../src/common/cmdproc.cpp:264 ../src/msw/textctrl.cpp:2769
+#: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Späť"
 
-#: ../src/common/cmdproc.cpp:265
+#: ../src/common/cmdproc.cpp:258
 msgid "&Undo "
 msgstr "&Späť "
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "&Unindent"
 msgstr "&Zrušiť odsadenie"
 
-#: ../src/common/stockitem.cpp:205
+#: ../src/common/stockitem.cpp:202
 msgid "&Up"
 msgstr "&Hore"
 
@@ -764,7 +788,7 @@ msgstr "&Vertikálny posuv:"
 msgid "&View..."
 msgstr "&Zobrazenie..."
 
-#: ../src/generic/fontdlgg.cpp:393
+#: ../src/generic/fontdlgg.cpp:389
 msgid "&Weight:"
 msgstr "&Váha:"
 
@@ -773,88 +797,58 @@ msgstr "&Váha:"
 msgid "&Width:"
 msgstr "Ší&rka:"
 
-#: ../src/aui/tabmdi.cpp:311 ../src/aui/tabmdi.cpp:327
-#: ../src/aui/tabmdi.cpp:329 ../src/generic/mdig.cpp:294
-#: ../src/generic/mdig.cpp:310 ../src/generic/mdig.cpp:314
-#: ../src/msw/mdi.cpp:78
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
 msgid "&Window"
 msgstr "&Okno"
 
-#: ../src/common/stockitem.cpp:206 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:203 ../src/msw/msgdlg.cpp:435
 msgid "&Yes"
 msgstr "Á&no"
 
-#: ../src/common/valtext.cpp:256
-#, c-format
-msgid "'%s' contains illegal characters"
+#: ../src/common/valtext.cpp:197
+#, fuzzy, c-format
+msgid "'%s' contains invalid character(s)"
 msgstr "'%s' obsahuje nepovolené znaky"
 
-#: ../src/common/valtext.cpp:254
-#, c-format
-msgid "'%s' doesn't consist only of valid characters"
-msgstr "'%s' neobsahuje iba platné znaky"
-
-#: ../src/common/config.cpp:519 ../src/msw/regconf.cpp:258
+#: ../src/common/config.cpp:515 ../src/msw/regconf.cpp:255
 #, c-format
 msgid "'%s' has extra '..', ignored."
 msgstr "'%s' obsahuje prebytočné '..', ignorované."
 
-#: ../src/common/cmdline.cpp:1113 ../src/common/cmdline.cpp:1131
+#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' nie je správna číselná hodnota voľby '%s'."
 
-#: ../src/common/translation.cpp:1100
+#: ../src/common/translation.cpp:1142
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' nie je platný katalóg správ."
 
-#: ../src/common/valtext.cpp:165
+#: ../src/common/valtext.cpp:188
 #, c-format
 msgid "'%s' is not one of the valid strings"
 msgstr "'%s' nie je jeden z platných reťazcov"
 
-#: ../src/common/valtext.cpp:167
+#: ../src/common/valtext.cpp:186
 #, c-format
 msgid "'%s' is one of the invalid strings"
 msgstr "'%s' je jeden z platných reťazcov"
 
-#: ../src/common/textbuf.cpp:237
+#: ../src/common/textbuf.cpp:233
 #, c-format
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' je pravdepodobne binárny buffer."
-
-#: ../src/common/valtext.cpp:252
-#, c-format
-msgid "'%s' should be numeric."
-msgstr "'%s' by mala byť číselná hodnota."
-
-#: ../src/common/valtext.cpp:244
-#, c-format
-msgid "'%s' should only contain ASCII characters."
-msgstr "'%s' by mal obsahovať iba ASCII znaky."
-
-#: ../src/common/valtext.cpp:246
-#, c-format
-msgid "'%s' should only contain alphabetic characters."
-msgstr "'%s' by mal obsahovať iba znaky abecedy."
-
-#: ../src/common/valtext.cpp:248
-#, c-format
-msgid "'%s' should only contain alphabetic or numeric characters."
-msgstr "'%s' by mal obsahovať iba znaky abecedy alebo čísla."
-
-#: ../src/common/valtext.cpp:250
-#, c-format
-msgid "'%s' should only contain digits."
-msgstr "'%s' by mal obsahovať iba číslice."
 
 #: ../src/richtext/richtextliststylepage.cpp:229
 #: ../src/richtext/richtextbulletspage.cpp:166
 msgid "(*)"
 msgstr "(*)"
 
-#: ../src/html/helpwnd.cpp:963
+#: ../src/html/helpwnd.cpp:961
 msgid "(Help)"
 msgstr "(Pomoc)"
 
@@ -863,27 +857,32 @@ msgstr "(Pomoc)"
 msgid "(None)"
 msgstr "(Žiadny)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:504
+#: ../src/richtext/richtextsymboldlg.cpp:503
 msgid "(Normal text)"
 msgstr "(Normálny text)"
 
-#: ../src/html/helpwnd.cpp:419 ../src/html/helpwnd.cpp:1106
-#: ../src/html/helpwnd.cpp:1742
+#: ../src/html/helpwnd.cpp:417 ../src/html/helpwnd.cpp:1104
+#: ../src/html/helpwnd.cpp:1740
 msgid "(bookmarks)"
 msgstr "(záložky)"
 
+#: ../src/msw/dlmsw.cpp:167
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (chyba %ld: %s)"
+
+#: ../src/richtext/richtextformatdlg.cpp:876
+#: ../src/richtext/richtextliststylepage.cpp:448
+#: ../src/richtext/richtextliststylepage.cpp:460
+#: ../src/richtext/richtextliststylepage.cpp:461
 #: ../src/richtext/richtextindentspage.cpp:274
 #: ../src/richtext/richtextindentspage.cpp:286
 #: ../src/richtext/richtextindentspage.cpp:287
 #: ../src/richtext/richtextindentspage.cpp:311
 #: ../src/richtext/richtextindentspage.cpp:326
-#: ../src/richtext/richtextformatdlg.cpp:884
 #: ../src/richtext/richtextfontpage.cpp:349
 #: ../src/richtext/richtextfontpage.cpp:353
 #: ../src/richtext/richtextfontpage.cpp:357
-#: ../src/richtext/richtextliststylepage.cpp:448
-#: ../src/richtext/richtextliststylepage.cpp:460
-#: ../src/richtext/richtextliststylepage.cpp:461
 msgid "(none)"
 msgstr "(žiadny)"
 
@@ -902,7 +901,7 @@ msgstr "*)"
 msgid "+"
 msgstr "+"
 
-#: ../src/msw/utils.cpp:1152
+#: ../src/msw/utils.cpp:1143
 msgid ", 64-bit edition"
 msgstr ", 64-bitové vydanie"
 
@@ -911,163 +910,163 @@ msgstr ", 64-bitové vydanie"
 msgid "-"
 msgstr "-"
 
-#: ../src/generic/filepickerg.cpp:66
+#: ../src/generic/filepickerg.cpp:63
 msgid "..."
 msgstr "..."
 
-#: ../src/richtext/richtextindentspage.cpp:276
 #: ../src/richtext/richtextliststylepage.cpp:450
+#: ../src/richtext/richtextindentspage.cpp:276
 msgid "1.1"
 msgstr "1.1"
 
-#: ../src/richtext/richtextindentspage.cpp:277
 #: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextindentspage.cpp:277
 msgid "1.2"
 msgstr "1.2"
 
-#: ../src/richtext/richtextindentspage.cpp:278
 #: ../src/richtext/richtextliststylepage.cpp:452
+#: ../src/richtext/richtextindentspage.cpp:278
 msgid "1.3"
 msgstr "1.3"
 
-#: ../src/richtext/richtextindentspage.cpp:279
 #: ../src/richtext/richtextliststylepage.cpp:453
+#: ../src/richtext/richtextindentspage.cpp:279
 msgid "1.4"
 msgstr "1.4"
 
-#: ../src/richtext/richtextindentspage.cpp:280
 #: ../src/richtext/richtextliststylepage.cpp:454
+#: ../src/richtext/richtextindentspage.cpp:280
 msgid "1.5"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:281
 #: ../src/richtext/richtextliststylepage.cpp:455
+#: ../src/richtext/richtextindentspage.cpp:281
 msgid "1.6"
 msgstr "1.6"
 
-#: ../src/richtext/richtextindentspage.cpp:282
 #: ../src/richtext/richtextliststylepage.cpp:456
+#: ../src/richtext/richtextindentspage.cpp:282
 msgid "1.7"
 msgstr "1.7"
 
-#: ../src/richtext/richtextindentspage.cpp:283
 #: ../src/richtext/richtextliststylepage.cpp:457
+#: ../src/richtext/richtextindentspage.cpp:283
 msgid "1.8"
 msgstr "1.8"
 
-#: ../src/richtext/richtextindentspage.cpp:284
 #: ../src/richtext/richtextliststylepage.cpp:458
+#: ../src/richtext/richtextindentspage.cpp:284
 msgid "1.9"
 msgstr "1.9"
 
-#: ../src/common/paper.cpp:140
+#: ../src/common/paper.cpp:137
 msgid "10 x 11 in"
 msgstr "10 x 11 palca"
 
-#: ../src/common/paper.cpp:113
+#: ../src/common/paper.cpp:110
 msgid "10 x 14 in"
 msgstr "10 x 14 palca"
 
-#: ../src/common/paper.cpp:114
+#: ../src/common/paper.cpp:111
 msgid "11 x 17 in"
 msgstr "11 x 17 palca"
 
-#: ../src/common/paper.cpp:184
+#: ../src/common/paper.cpp:181
 msgid "12 x 11 in"
 msgstr "12 x 11 palca"
 
-#: ../src/common/paper.cpp:141
+#: ../src/common/paper.cpp:138
 msgid "15 x 11 in"
 msgstr "15 x 11 palca"
 
-#: ../src/richtext/richtextindentspage.cpp:285
 #: ../src/richtext/richtextliststylepage.cpp:459
+#: ../src/richtext/richtextindentspage.cpp:285
 msgid "2"
 msgstr "2"
 
-#: ../src/common/paper.cpp:132
+#: ../src/common/paper.cpp:129
 msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
 msgstr "6 3/4 obálka, 3 5/8 x 6 1/2 palca"
 
-#: ../src/common/paper.cpp:139
+#: ../src/common/paper.cpp:136
 msgid "9 x 11 in"
 msgstr "9 x 11 palca"
 
-#: ../src/html/htmprint.cpp:431
+#: ../src/html/htmprint.cpp:443
 msgid ": file does not exist!"
 msgstr ": súbor neexistuje!"
 
-#: ../src/common/fontmap.cpp:199
+#: ../src/common/fontmap.cpp:196
 msgid ": unknown charset"
 msgstr ": neznáma znaková sada"
 
-#: ../src/common/fontmap.cpp:413
+#: ../src/common/fontmap.cpp:410
 msgid ": unknown encoding"
 msgstr ": neznáme kódovanie"
 
-#: ../src/generic/wizard.cpp:443
+#: ../src/generic/wizard.cpp:438
 msgid "< &Back"
 msgstr "< &Späť"
 
-#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:628
-#: ../src/osx/carbon/fontdlg.cpp:648
+#: ../src/osx/carbon/fontdlg.cpp:419 ../src/osx/carbon/fontdlg.cpp:625
+#: ../src/osx/carbon/fontdlg.cpp:645
 msgid "<Any Decorative>"
 msgstr "<ľubovoľné okrasné>"
 
-#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:630
-#: ../src/osx/carbon/fontdlg.cpp:650
+#: ../src/osx/carbon/fontdlg.cpp:420 ../src/osx/carbon/fontdlg.cpp:627
+#: ../src/osx/carbon/fontdlg.cpp:647
 msgid "<Any Modern>"
 msgstr "<ľubovoľné moderné>"
 
-#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:626
-#: ../src/osx/carbon/fontdlg.cpp:646
+#: ../src/osx/carbon/fontdlg.cpp:418 ../src/osx/carbon/fontdlg.cpp:623
+#: ../src/osx/carbon/fontdlg.cpp:643
 msgid "<Any Roman>"
 msgstr "<ľubovoľné rímske>"
 
-#: ../src/osx/carbon/fontdlg.cpp:424 ../src/osx/carbon/fontdlg.cpp:632
-#: ../src/osx/carbon/fontdlg.cpp:652
+#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:629
+#: ../src/osx/carbon/fontdlg.cpp:649
 msgid "<Any Script>"
 msgstr "<ľubovoľné písané>"
 
-#: ../src/osx/carbon/fontdlg.cpp:425 ../src/osx/carbon/fontdlg.cpp:637
-#: ../src/osx/carbon/fontdlg.cpp:656
+#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:634
+#: ../src/osx/carbon/fontdlg.cpp:653
 msgid "<Any Swiss>"
 msgstr "<ľubovoľné švajčiarske>"
 
-#: ../src/osx/carbon/fontdlg.cpp:426 ../src/osx/carbon/fontdlg.cpp:634
-#: ../src/osx/carbon/fontdlg.cpp:654
+#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:631
+#: ../src/osx/carbon/fontdlg.cpp:651
 msgid "<Any Teletype>"
 msgstr "<ľubovoľné terminálové>"
 
-#: ../src/osx/carbon/fontdlg.cpp:420
+#: ../src/osx/carbon/fontdlg.cpp:417
 msgid "<Any>"
 msgstr "<ľubovoľné>"
 
-#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
 msgid "<DIR>"
 msgstr "<PRIEČINOK>"
 
-#: ../src/generic/filectrlg.cpp:254 ../src/generic/filectrlg.cpp:277
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
 msgid "<DRIVE>"
 msgstr "<JEDNOTKA>"
 
-#: ../src/generic/filectrlg.cpp:252 ../src/generic/filectrlg.cpp:275
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
 msgid "<LINK>"
 msgstr "<ODKAZ>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1264
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Hrubé kurzívou.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1270
+#: ../src/html/helpwnd.cpp:1268
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>Hrubé kurzívou, <u>podčiarknuté</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1265
+#: ../src/html/helpwnd.cpp:1263
 msgid "<b>Bold face.</b> "
 msgstr "<b>Hrubé.</b> "
 
-#: ../src/html/helpwnd.cpp:1264
+#: ../src/html/helpwnd.cpp:1262
 msgid "<i>Italic face.</i> "
 msgstr "<i>Kurzívou.</i> "
 
@@ -1076,15 +1075,15 @@ msgstr "<i>Kurzívou.</i> "
 msgid ">"
 msgstr ">"
 
-#: ../src/generic/dbgrptg.cpp:318
+#: ../src/generic/dbgrptg.cpp:317
 msgid "A debug report has been generated in the directory\n"
 msgstr "V adresári bolo vytvorené hlásenie o chybe\n"
 
-#: ../src/common/debugrpt.cpp:573
+#: ../src/common/debugrpt.cpp:574
 msgid "A debug report has been generated. It can be found in"
 msgstr "Bola vygenerovaná správa o ladení. Nachádza sa v"
 
-#: ../src/common/xtixml.cpp:418
+#: ../src/common/xtixml.cpp:414
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Neprázdna kolekcia musí pozostávať z uzlov 'element'"
 
@@ -1095,106 +1094,106 @@ msgstr "Neprázdna kolekcia musí pozostávať z uzlov 'element'"
 msgid "A standard bullet name."
 msgstr "Názov štandardného oddeľovača položiek zoznamu."
 
-#: ../src/common/paper.cpp:217
+#: ../src/common/paper.cpp:214
 msgid "A0 sheet, 841 x 1189 mm"
 msgstr "Hárok A0, 841 x 1189 mm"
 
-#: ../src/common/paper.cpp:218
+#: ../src/common/paper.cpp:215
 msgid "A1 sheet, 594 x 841 mm"
 msgstr "Hárok A1, 594 x 841 mm"
 
-#: ../src/common/paper.cpp:159
+#: ../src/common/paper.cpp:156
 msgid "A2 420 x 594 mm"
 msgstr "A2 420 x 594 mm"
 
-#: ../src/common/paper.cpp:156
+#: ../src/common/paper.cpp:153
 msgid "A3 Extra 322 x 445 mm"
 msgstr "A3 extra 322 x 445 mm"
 
-#: ../src/common/paper.cpp:161
+#: ../src/common/paper.cpp:158
 msgid "A3 Extra Transverse 322 x 445 mm"
 msgstr "A3 extra priečny 322 x 445 mm"
 
-#: ../src/common/paper.cpp:170
+#: ../src/common/paper.cpp:167
 msgid "A3 Rotated 420 x 297 mm"
 msgstr "A3 otočený 420 x 297 mm"
 
-#: ../src/common/paper.cpp:160
+#: ../src/common/paper.cpp:157
 msgid "A3 Transverse 297 x 420 mm"
 msgstr "A3 priečny 297 x 420 mm"
 
-#: ../src/common/paper.cpp:106
+#: ../src/common/paper.cpp:103
 msgid "A3 sheet, 297 x 420 mm"
 msgstr "A3 hárok, 297 x 420 mm"
 
-#: ../src/common/paper.cpp:146
+#: ../src/common/paper.cpp:143
 msgid "A4 Extra 9.27 x 12.69 in"
 msgstr "A4 extra 9.27 x 12.69 in"
 
-#: ../src/common/paper.cpp:153
+#: ../src/common/paper.cpp:150
 msgid "A4 Plus 210 x 330 mm"
 msgstr "A4 plus 210 x 330 mm"
 
-#: ../src/common/paper.cpp:171
+#: ../src/common/paper.cpp:168
 msgid "A4 Rotated 297 x 210 mm"
 msgstr "A4 otočený 297 x 210 mm"
 
-#: ../src/common/paper.cpp:148
+#: ../src/common/paper.cpp:145
 msgid "A4 Transverse 210 x 297 mm"
 msgstr "A4 priečny 210 x 297 mm"
 
-#: ../src/common/paper.cpp:97
+#: ../src/common/paper.cpp:94
 msgid "A4 sheet, 210 x 297 mm"
 msgstr "A4 hárok, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:107
+#: ../src/common/paper.cpp:104
 msgid "A4 small sheet, 210 x 297 mm"
 msgstr "A4 malý hárok, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:157
+#: ../src/common/paper.cpp:154
 msgid "A5 Extra 174 x 235 mm"
 msgstr "A5 extra 174 x 235 mm"
 
-#: ../src/common/paper.cpp:172
+#: ../src/common/paper.cpp:169
 msgid "A5 Rotated 210 x 148 mm"
 msgstr "A5 otočený 210 x 148 mm"
 
-#: ../src/common/paper.cpp:154
+#: ../src/common/paper.cpp:151
 msgid "A5 Transverse 148 x 210 mm"
 msgstr "A5 priečny 148 x 210 mm"
 
-#: ../src/common/paper.cpp:108
+#: ../src/common/paper.cpp:105
 msgid "A5 sheet, 148 x 210 mm"
 msgstr "A5 hárok, 148 x 210 mm"
 
-#: ../src/common/paper.cpp:164
+#: ../src/common/paper.cpp:161
 msgid "A6 105 x 148 mm"
 msgstr "A6 105 x 148 mm"
 
-#: ../src/common/paper.cpp:177
+#: ../src/common/paper.cpp:174
 msgid "A6 Rotated 148 x 105 mm"
 msgstr "A6 otočený 148 x 105 mm"
 
-#: ../src/generic/fontdlgg.cpp:83 ../src/richtext/richtextformatdlg.cpp:529
-#: ../src/osx/carbon/fontdlg.cpp:153
+#: ../src/osx/carbon/fontdlg.cpp:150 ../src/generic/fontdlgg.cpp:79
+#: ../src/richtext/richtextformatdlg.cpp:521
 msgid "ABCDEFGabcdefg12345"
 msgstr "ABCDabcd12345žšťď$€¢"
 
-#: ../src/richtext/richtextsymboldlg.cpp:458 ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
 msgid "ASCII"
 msgstr "ASCII"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "About"
 msgstr "&O aplikácii"
 
-#: ../src/generic/aboutdlgg.cpp:140 ../src/osx/menu_osx.cpp:558
-#: ../src/msw/aboutdlg.cpp:64
+#: ../src/osx/menu_osx.cpp:450 ../src/generic/aboutdlgg.cpp:137
+#: ../src/msw/aboutdlg.cpp:61
 #, c-format
 msgid "About %s"
 msgstr "O aplikácii %s"
 
-#: ../src/osx/menu_osx.cpp:560
+#: ../src/osx/menu_osx.cpp:452
 msgid "About..."
 msgstr "&O aplikácii..."
 
@@ -1203,37 +1202,37 @@ msgid "Absolute"
 msgstr "Absolútne"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:873
+#: ../src/propgrid/advprops.cpp:774
 msgid "ActiveBorder"
 msgstr "Aktívny okraj"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:874
+#: ../src/propgrid/advprops.cpp:775
 msgid "ActiveCaption"
 msgstr "Aktívny nadpis"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "Actual Size"
 msgstr "&Skutočná veľkosť"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:140 ../src/common/accelcmn.cpp:81
+#: ../src/common/stockitem.cpp:137 ../src/common/accelcmn.cpp:78
 msgid "Add"
 msgstr "Pridať"
 
-#: ../src/richtext/richtextbuffer.cpp:11455
+#: ../src/richtext/richtextbuffer.cpp:11454
 msgid "Add Column"
 msgstr "Pridať stĺpec"
 
-#: ../src/richtext/richtextbuffer.cpp:11392
+#: ../src/richtext/richtextbuffer.cpp:11391
 msgid "Add Row"
 msgstr "Pridať riadok"
 
-#: ../src/html/helpwnd.cpp:432
+#: ../src/html/helpwnd.cpp:430
 msgid "Add current page to bookmarks"
 msgstr "Pridať aktuálnu stránku medzi záložky"
 
-#: ../src/generic/colrdlgg.cpp:366
+#: ../src/generic/colrdlgg.cpp:386
 msgid "Add to custom colours"
 msgstr "Pridať k vlastným farbám"
 
@@ -1245,12 +1244,12 @@ msgstr "AddToPropertyCollection volaná pri všeobecnom prístupe"
 msgid "AddToPropertyCollection called w/o valid adder"
 msgstr "AddToPropertyCollection volaná bez platného pridávateľa"
 
-#: ../src/html/helpctrl.cpp:159
+#: ../src/html/helpctrl.cpp:155
 #, c-format
 msgid "Adding book %s"
 msgstr "Pridáva sa kniha %s"
 
-#: ../src/common/preferencescmn.cpp:43
+#: ../src/common/preferencescmn.cpp:40
 msgid "Advanced"
 msgstr "Pokročilé"
 
@@ -1258,11 +1257,11 @@ msgstr "Pokročilé"
 msgid "After a paragraph:"
 msgstr "Za odstavcom:"
 
-#: ../src/common/stockitem.cpp:172
+#: ../src/common/stockitem.cpp:169
 msgid "Align Left"
 msgstr "Zarovnať vľavo"
 
-#: ../src/common/stockitem.cpp:173
+#: ../src/common/stockitem.cpp:170
 msgid "Align Right"
 msgstr "Zarovnať vpravo"
 
@@ -1270,40 +1269,40 @@ msgstr "Zarovnať vpravo"
 msgid "Alignment"
 msgstr "&Zarovnanie"
 
-#: ../src/generic/prntdlgg.cpp:215
+#: ../src/generic/prntdlgg.cpp:208
 msgid "All"
 msgstr "Všetky"
 
-#: ../src/generic/filectrlg.cpp:1197 ../src/common/fldlgcmn.cpp:107
+#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1186
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Všetky súbory (%s)|%s"
 
-#: ../include/wx/defs.h:2886
+#: ../include/wx/defs.h:2582
 msgid "All files (*)|*"
 msgstr "Všetky súbory (*)|*"
 
-#: ../include/wx/defs.h:2883
+#: ../include/wx/defs.h:2579
 msgid "All files (*.*)|*.*"
 msgstr "Všetky súbory (*.*)|*.*"
 
-#: ../src/richtext/richtextstyles.cpp:1061
+#: ../src/richtext/richtextstyles.cpp:1058
 msgid "All styles"
 msgstr "Všetky štýly"
 
-#: ../src/propgrid/manager.cpp:1528
+#: ../src/propgrid/manager.cpp:1544
 msgid "Alphabetic Mode"
 msgstr "Abecedný režim"
 
-#: ../src/common/xtistrm.cpp:425
+#: ../src/common/xtistrm.cpp:422
 msgid "Already Registered Object passed to SetObjectClassInfo"
 msgstr "Ako parameter SetObjectClassInfo bol zadaný už zaregistrovaný objekt"
 
-#: ../src/unix/dialup.cpp:353
+#: ../src/unix/dialup.cpp:352
 msgid "Already dialling ISP."
 msgstr "Už prebieha vytáčanie poskytovateľa."
 
-#: ../src/common/accelcmn.cpp:331 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/accelcmn.cpp:345 ../src/univ/themes/win32.cpp:3753
 msgid "Alt+"
 msgstr "Alt+"
 
@@ -1312,34 +1311,34 @@ msgstr "Alt+"
 msgid "An optional corner radius for adding rounded corners."
 msgstr "Nepovinný polomer zaoblenia pre pridanie zaoblených rohov."
 
-#: ../src/common/debugrpt.cpp:576
+#: ../src/common/debugrpt.cpp:577
 msgid "And includes the following files:\n"
 msgstr "Zahrnuté nasledujúce súbory:\n"
 
-#: ../src/generic/animateg.cpp:162
+#: ../src/generic/animateg.cpp:145
 #, c-format
 msgid "Animation file is not of type %ld."
 msgstr "Súbor s animáciou nie je typu %ld."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:872
+#: ../src/propgrid/advprops.cpp:773
 msgid "AppWorkspace"
 msgstr "Priestor aplikácie"
 
-#: ../src/generic/logg.cpp:1014
+#: ../src/generic/logg.cpp:1011
 #, c-format
 msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
 msgstr "Pridať záznam do súboru '%s' (voľba [Nie] ho prepíše)?"
 
-#: ../src/osx/menu_osx.cpp:577 ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:469 ../src/osx/menu_osx.cpp:477
 msgid "Application"
 msgstr "Aplikácia"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "Apply"
 msgstr "Použiť"
 
-#: ../src/propgrid/advprops.cpp:1609
+#: ../src/propgrid/advprops.cpp:1515
 msgid "Aqua"
 msgstr "Aqua"
 
@@ -1348,29 +1347,29 @@ msgstr "Aqua"
 msgid "Arabic"
 msgstr "Arabčina"
 
-#: ../src/common/fmapbase.cpp:153
+#: ../src/common/fmapbase.cpp:150
 msgid "Arabic (ISO-8859-6)"
 msgstr "Arabské (ISO-8859-6)"
 
-#: ../src/msw/ole/automtn.cpp:672
+#: ../src/msw/ole/automtn.cpp:663
 #, c-format
 msgid "Argument %u not found."
 msgstr "Argument% u sa nenašiel."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1753
+#: ../src/propgrid/advprops.cpp:1654
 msgid "Arrow"
 msgstr "Šípka"
 
-#: ../src/generic/aboutdlgg.cpp:184
+#: ../src/generic/aboutdlgg.cpp:181
 msgid "Artists"
 msgstr "Účinkujúci"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "Ascending"
 msgstr "Vzostupne"
 
-#: ../src/generic/filectrlg.cpp:433
+#: ../src/generic/filectrlg.cpp:429
 msgid "Attributes"
 msgstr "Atribúty"
 
@@ -1380,90 +1379,90 @@ msgstr "Atribúty"
 msgid "Available fonts."
 msgstr "Dostupné písma."
 
-#: ../src/common/paper.cpp:137
+#: ../src/common/paper.cpp:134
 msgid "B4 (ISO) 250 x 353 mm"
 msgstr "B4 (ISO) 250 x 353 mm"
 
-#: ../src/common/paper.cpp:173
+#: ../src/common/paper.cpp:170
 msgid "B4 (JIS) Rotated 364 x 257 mm"
 msgstr "B4 (JIS) otočený 364 x 257 mm"
 
-#: ../src/common/paper.cpp:127
+#: ../src/common/paper.cpp:124
 msgid "B4 Envelope, 250 x 353 mm"
 msgstr "B4 obálka, 250 x 353 mm"
 
-#: ../src/common/paper.cpp:109
+#: ../src/common/paper.cpp:106
 msgid "B4 sheet, 250 x 354 mm"
 msgstr "B4 hárok, 250 x 354 mm"
 
-#: ../src/common/paper.cpp:158
+#: ../src/common/paper.cpp:155
 msgid "B5 (ISO) Extra 201 x 276 mm"
 msgstr "B5 (ISO) extra 201 x 276 mm"
 
-#: ../src/common/paper.cpp:174
+#: ../src/common/paper.cpp:171
 msgid "B5 (JIS) Rotated 257 x 182 mm"
 msgstr "B5 (JIS) otočený 257 x 182 mm"
 
-#: ../src/common/paper.cpp:155
+#: ../src/common/paper.cpp:152
 msgid "B5 (JIS) Transverse 182 x 257 mm"
 msgstr "B5 (JIS) priečny 182 x 257 mm"
 
-#: ../src/common/paper.cpp:128
+#: ../src/common/paper.cpp:125
 msgid "B5 Envelope, 176 x 250 mm"
 msgstr "B5 obálka, 176 x 250 mm"
 
-#: ../src/common/paper.cpp:110
+#: ../src/common/paper.cpp:107
 msgid "B5 sheet, 182 x 257 millimeter"
 msgstr "B5 hárok, 182 x 257 millimeter"
 
-#: ../src/common/paper.cpp:182
+#: ../src/common/paper.cpp:179
 msgid "B6 (JIS) 128 x 182 mm"
 msgstr "B6 (JIS) 128 x 182 mm"
 
-#: ../src/common/paper.cpp:183
+#: ../src/common/paper.cpp:180
 msgid "B6 (JIS) Rotated 182 x 128 mm"
 msgstr "B6 (JIS) otočený 182 x 128 mm"
 
-#: ../src/common/paper.cpp:129
+#: ../src/common/paper.cpp:126
 msgid "B6 Envelope, 176 x 125 mm"
 msgstr "B6 obálka, 176 x 125 mm"
 
-#: ../src/common/imagbmp.cpp:531 ../src/common/imagbmp.cpp:561
-#: ../src/common/imagbmp.cpp:576
+#: ../src/common/imagbmp.cpp:528 ../src/common/imagbmp.cpp:558
+#: ../src/common/imagbmp.cpp:573
 msgid "BMP: Couldn't allocate memory."
 msgstr "BMP: Nemožno vymedziť pamäť."
 
-#: ../src/common/imagbmp.cpp:100
+#: ../src/common/imagbmp.cpp:97
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: Nemožno uložiť neplatný obrázok."
 
-#: ../src/common/imagbmp.cpp:356
+#: ../src/common/imagbmp.cpp:353
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: Nemožno zapísať mapu RGB farieb."
 
-#: ../src/common/imagbmp.cpp:490
+#: ../src/common/imagbmp.cpp:487
 msgid "BMP: Couldn't write data."
 msgstr "BMP: Nemožno zapísať údaje."
 
-#: ../src/common/imagbmp.cpp:246
+#: ../src/common/imagbmp.cpp:243
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: Nemožno zapísať hlavičku (Bitmap) súboru."
 
-#: ../src/common/imagbmp.cpp:269
+#: ../src/common/imagbmp.cpp:266
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: Nemožno zapísať hlavičku (BitmapInfo) súboru."
 
-#: ../src/common/imagbmp.cpp:140
+#: ../src/common/imagbmp.cpp:137
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage nemá vlastnú wxPalette."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:142 ../src/common/accelcmn.cpp:52
+#: ../src/common/stockitem.cpp:139 ../src/common/accelcmn.cpp:49
 msgid "Back"
 msgstr "Zo zadu"
 
+#: ../src/richtext/richtextformatdlg.cpp:377
 #: ../src/richtext/richtextbackgroundpage.cpp:148
-#: ../src/richtext/richtextformatdlg.cpp:384
 msgid "Background"
 msgstr "Pozadie"
 
@@ -1471,20 +1470,20 @@ msgstr "Pozadie"
 msgid "Background &colour:"
 msgstr "&Farba pozadia:"
 
-#: ../src/osx/carbon/fontdlg.cpp:220
+#: ../src/osx/carbon/fontdlg.cpp:217
 msgid "Background colour"
 msgstr "Farba pozadia"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:52
+#: ../src/common/accelcmn.cpp:49
 msgid "Backspace"
 msgstr "Backspace"
 
-#: ../src/common/fmapbase.cpp:160
+#: ../src/common/fmapbase.cpp:157
 msgid "Baltic (ISO-8859-13)"
 msgstr "Baltské (ISO-8859-13)"
 
-#: ../src/common/fmapbase.cpp:151
+#: ../src/common/fmapbase.cpp:148
 msgid "Baltic (old) (ISO-8859-4)"
 msgstr "Baltské (staré) (ISO-8859-4)"
 
@@ -1497,25 +1496,25 @@ msgstr "Pred odstavcom:"
 msgid "Bitmap"
 msgstr "Bitmapa"
 
-#: ../src/propgrid/advprops.cpp:1594
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Black"
 msgstr "Čierna"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1755
+#: ../src/propgrid/advprops.cpp:1656
 msgid "Blank"
 msgstr "Prázdna"
 
-#: ../src/propgrid/advprops.cpp:1603
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Blue"
 msgstr "Modrá"
 
-#: ../src/generic/colrdlgg.cpp:345
+#: ../src/generic/colrdlgg.cpp:365
 msgid "Blue:"
 msgstr "Modrá:"
 
-#: ../src/generic/fontdlgg.cpp:333 ../src/richtext/richtextfontpage.cpp:355
-#: ../src/osx/carbon/fontdlg.cpp:354 ../src/common/stockitem.cpp:143
+#: ../src/osx/carbon/fontdlg.cpp:351 ../src/common/stockitem.cpp:140
+#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:355
 msgid "Bold"
 msgstr "Hrubé"
 
@@ -1524,31 +1523,35 @@ msgstr "Hrubé"
 msgid "Border"
 msgstr "Okraj"
 
-#: ../src/richtext/richtextformatdlg.cpp:379
+#: ../src/richtext/richtextformatdlg.cpp:372
 msgid "Borders"
 msgstr "Okraje"
 
-#: ../src/richtext/richtextsizepage.cpp:288 ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141 ../src/richtext/richtextsizepage.cpp:288
 msgid "Bottom"
 msgstr "Zdola"
 
-#: ../src/generic/prntdlgg.cpp:893
+#: ../src/generic/prntdlgg.cpp:886
 msgid "Bottom margin (mm):"
 msgstr "Spodný okraj (mm):"
 
-#: ../src/richtext/richtextbuffer.cpp:9383
+#: ../src/richtext/richtextbuffer.cpp:9380
 msgid "Box Properties"
 msgstr "Vlastnosti schránky"
 
-#: ../src/richtext/richtextstyles.cpp:1065
+#: ../src/richtext/richtextstyles.cpp:1062
 msgid "Box styles"
 msgstr "Štýly schránky"
 
-#: ../src/propgrid/advprops.cpp:1602
+#: ../src/osx/cocoa/menu.mm:292
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Brown"
 msgstr "Hnedá"
 
-#: ../src/common/filepickercmn.cpp:43 ../src/common/filepickercmn.cpp:44
+#: ../src/common/filepickercmn.cpp:40 ../src/common/filepickercmn.cpp:41
 msgid "Browse"
 msgstr "Prehľadávať"
 
@@ -1561,72 +1564,72 @@ msgstr "Odrážka a zarovnanie:"
 msgid "Bullet style"
 msgstr "Štýl odrážok"
 
-#: ../src/richtext/richtextformatdlg.cpp:359
+#: ../src/richtext/richtextformatdlg.cpp:352
 msgid "Bullets"
 msgstr "Odrážky"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1756
+#: ../src/propgrid/advprops.cpp:1657
 msgid "Bullseye"
 msgstr "Stredový znak"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:875
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonFace"
 msgstr "Plocha tlačidla"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:876
+#: ../src/propgrid/advprops.cpp:777
 msgid "ButtonHighlight"
 msgstr "Zvýraznenie tlačidla"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:877
+#: ../src/propgrid/advprops.cpp:778
 msgid "ButtonShadow"
 msgstr "Tieň tlačidla"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:878
+#: ../src/propgrid/advprops.cpp:779
 msgid "ButtonText"
 msgstr "Text tlačidla"
 
-#: ../src/common/paper.cpp:98
+#: ../src/common/paper.cpp:95
 msgid "C sheet, 17 x 22 in"
 msgstr "C hárok, 17 x 22 palca"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "C&lear"
 msgstr "&Zmazať"
 
-#: ../src/generic/fontdlgg.cpp:406
+#: ../src/generic/fontdlgg.cpp:403
 msgid "C&olour:"
 msgstr "&Farba:"
 
-#: ../src/common/paper.cpp:123
+#: ../src/common/paper.cpp:120
 msgid "C3 Envelope, 324 x 458 mm"
 msgstr "C3 obálka, 324 x 458 mm"
 
-#: ../src/common/paper.cpp:124
+#: ../src/common/paper.cpp:121
 msgid "C4 Envelope, 229 x 324 mm"
 msgstr "C4 obálka, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:122
+#: ../src/common/paper.cpp:119
 msgid "C5 Envelope, 162 x 229 mm"
 msgstr "C5 obálka, 162 x 229 mm"
 
-#: ../src/common/paper.cpp:125
+#: ../src/common/paper.cpp:122
 msgid "C6 Envelope, 114 x 162 mm"
 msgstr "C6 obálka, 114 x 162 mm"
 
-#: ../src/common/paper.cpp:126
+#: ../src/common/paper.cpp:123
 msgid "C65 Envelope, 114 x 229 mm"
 msgstr "C65 obálka, 114 x 229 mm"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "CD-Rom"
 msgstr "CD-Rom"
 
-#: ../src/html/chm.cpp:815 ../src/html/chm.cpp:874
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:865
 msgid "CHM handler currently supports only local files!"
 msgstr "Obsluha CHM momentálne podporuje iba lokálne súbory!"
 
@@ -1634,190 +1637,194 @@ msgstr "Obsluha CHM momentálne podporuje iba lokálne súbory!"
 msgid "Ca&pitals"
 msgstr "&Kapitálky"
 
-#: ../src/common/cmdproc.cpp:267
+#: ../src/common/cmdproc.cpp:260
 msgid "Can't &Undo "
 msgstr "Nemožno &Späť "
 
-#: ../src/common/image.cpp:2824
+#: ../src/common/image.cpp:2924
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr "Nemožno automaticky určiť formát obrázka pre neviditeľný vstup."
 
-#: ../src/msw/registry.cpp:506
+#: ../src/msw/registry.cpp:495
 #, c-format
 msgid "Can't close registry key '%s'"
 msgstr "Nemožno zatvoriť kľúč registra '%s'"
 
-#: ../src/msw/registry.cpp:584
+#: ../src/msw/registry.cpp:573
 #, c-format
 msgid "Can't copy values of unsupported type %d."
 msgstr "Nemožno skopírovať hodnoty nepodporovaného typu %d."
 
-#: ../src/msw/registry.cpp:487
+#: ../src/msw/registry.cpp:476
 #, c-format
 msgid "Can't create registry key '%s'"
 msgstr "Nemožno vytvoriť kľúč registra '%s'"
 
-#: ../src/msw/thread.cpp:665
+#: ../src/msw/thread.cpp:657
 msgid "Can't create thread"
 msgstr "Nemožno vytvoriť vlákno"
 
-#: ../src/msw/window.cpp:3691
-#, c-format
-msgid "Can't create window of class %s"
-msgstr "Nemožno vytvoriť okno triedy %s"
-
-#: ../src/msw/registry.cpp:777
+#: ../src/msw/registry.cpp:765
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Nemožno zmazať kľúč '%s'"
 
-#: ../src/msw/iniconf.cpp:458
+#: ../src/msw/iniconf.cpp:455
 #, c-format
 msgid "Can't delete the INI file '%s'"
 msgstr "Nemožno zmazať INI súbor '%s'"
 
-#: ../src/msw/registry.cpp:805
+#: ../src/msw/registry.cpp:793
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Nemožno zmazať hodnotu '%s' z kľúča '%s'"
 
-#: ../src/msw/registry.cpp:1171
+#: ../src/msw/registry.cpp:1159
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Nemožno vymenovať podkľúče kľúča '%s'"
 
-#: ../src/msw/registry.cpp:1132
+#: ../src/msw/registry.cpp:1120
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Nemožno vymenovať hodnoty kľúča '%s'"
 
-#: ../src/msw/registry.cpp:1389
+#: ../src/msw/registry.cpp:1377
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Nemožno exportovať hodnotu nepodporovaného typu %d."
 
-#: ../src/common/ffile.cpp:254
+#: ../src/common/ffile.cpp:253
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Nemožno zistiť súčasnú pozíciu v súbore '%s'"
 
-#: ../src/msw/registry.cpp:418
+#: ../src/msw/registry.cpp:407
 #, c-format
 msgid "Can't get info about registry key '%s'"
 msgstr "Nemožno získať info o kľúči registra '%s'"
 
-#: ../src/common/zstream.cpp:346
+#: ../src/msw/webview_ie.cpp:1024
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "Nemožno nastaviť prioritu vlákna"
+
+#: ../src/common/zstream.cpp:343
 msgid "Can't initialize zlib deflate stream."
 msgstr "Nemožno inicializovať zlib deflate tok."
 
-#: ../src/common/zstream.cpp:185
+#: ../src/common/zstream.cpp:182
 msgid "Can't initialize zlib inflate stream."
 msgstr "Nemožno inicializovať zlib inflate tok."
 
-#: ../src/msw/fswatcher.cpp:476
+#: ../src/msw/fswatcher.cpp:475
 #, c-format
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "Nemožno sledovať zmeny v neexistujúcom priečinku '%s'."
 
-#: ../src/msw/registry.cpp:454
+#: ../src/msw/registry.cpp:443
 #, c-format
 msgid "Can't open registry key '%s'"
 msgstr "Nemožno otvoriť kľúč registra '%s'"
 
-#: ../src/common/zstream.cpp:252
+#: ../src/common/zstream.cpp:249
 #, c-format
 msgid "Can't read from inflate stream: %s"
 msgstr "Nemožno čítať z inflate toku: %s"
 
-#: ../src/common/zstream.cpp:244
+#: ../src/common/zstream.cpp:241
 msgid "Can't read inflate stream: unexpected EOF in underlying stream."
 msgstr "Nemožno prečítať inflate tok: nočakávaný znak konca súboru v toku."
 
-#: ../src/msw/registry.cpp:1064
+#: ../src/msw/registry.cpp:1052
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Nemožno prečítať hodnotu '%s'"
 
-#: ../src/msw/registry.cpp:878 ../src/msw/registry.cpp:910
-#: ../src/msw/registry.cpp:975
+#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
+#: ../src/msw/registry.cpp:963
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Nemožno prečítať hodnotu kľúča '%s'"
 
-#: ../src/common/image.cpp:2620
+#: ../src/msw/webview_ie.cpp:1017
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/common/image.cpp:2715
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "Nemožno uložiť obrázok do súboru '%s': neznáma prípona súboru."
 
-#: ../src/generic/logg.cpp:573 ../src/generic/logg.cpp:976
+#: ../src/generic/logg.cpp:570 ../src/generic/logg.cpp:973
 msgid "Can't save log contents to file."
 msgstr "Nemožno zapísať obsah záznamu do súboru."
 
-#: ../src/msw/thread.cpp:629
+#: ../src/msw/thread.cpp:621
 msgid "Can't set thread priority"
 msgstr "Nemožno nastaviť prioritu vlákna"
 
-#: ../src/msw/registry.cpp:896 ../src/msw/registry.cpp:938
-#: ../src/msw/registry.cpp:1081
+#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
+#: ../src/msw/registry.cpp:1069
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Nemožno nastaviť hodnotu '%s'"
 
-#: ../src/unix/utilsunx.cpp:351
+#: ../src/unix/utilsunx.cpp:353
 msgid "Can't write to child process's stdin"
 msgstr "Nemožno zapisovať do podriadeného procesu stdin"
 
-#: ../src/common/zstream.cpp:427
+#: ../src/common/zstream.cpp:424
 #, c-format
 msgid "Can't write to deflate stream: %s"
 msgstr "Nemožno zapísať do vypusteného prúdu: %s"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:279 ../src/richtext/richtextstyledlg.cpp:300
-#: ../src/common/stockitem.cpp:145 ../src/common/accelcmn.cpp:71
-#: ../src/msw/msgdlg.cpp:454 ../src/msw/progdlg.cpp:673
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:142
+#: ../src/common/accelcmn.cpp:68 ../src/motif/msgdlg.cpp:196
+#: ../src/gtk1/fontdlg.cpp:144 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/progdlg.cpp:940 ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Zrušiť"
 
-#: ../src/common/filefn.cpp:1261
+#: ../src/common/filefn.cpp:1149
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Nemožno vymenovať súbory '%s'"
 
-#: ../src/msw/dir.cpp:263
+#: ../src/msw/dir.cpp:260
 #, c-format
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Nemožno vymenovať súbory v adresári '%s'"
 
-#: ../src/msw/dialup.cpp:523
+#: ../src/msw/dialup.cpp:517
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Nemožno nájsť aktívne vytáčané spojenie: %s"
 
-#: ../src/msw/dialup.cpp:827
+#: ../src/msw/dialup.cpp:821
 msgid "Cannot find the location of address book file"
 msgstr "Nemožno nájsť umiestnenie súboru so zoznamom kontaktov"
 
-#: ../src/msw/ole/automtn.cpp:562
+#: ../src/msw/ole/automtn.cpp:553
 #, c-format
 msgid "Cannot get an active instance of \"%s\""
 msgstr "Nemožno nájsť aktívnu inštanciu pre '%s'"
 
-#: ../src/unix/threadpsx.cpp:1035
+#: ../src/unix/threadpsx.cpp:1053
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "Nemožno získať rozsah priorít pre plánovaciu politiku %d."
 
-#: ../src/unix/utilsunx.cpp:987
+#: ../src/unix/utilsunx.cpp:989
 msgid "Cannot get the hostname"
 msgstr "Nemožno získať názov hostiteľa"
 
-#: ../src/unix/utilsunx.cpp:1023
+#: ../src/unix/utilsunx.cpp:1025
 msgid "Cannot get the official hostname"
 msgstr "Nemožno získať oficálny názov hostiteľa"
 
-#: ../src/msw/dialup.cpp:928
+#: ../src/msw/dialup.cpp:922
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Nemožno zavesiť - nie je aktívne žiadne vytáčané spojenie."
 
@@ -1825,126 +1832,126 @@ msgstr "Nemožno zavesiť - nie je aktívne žiadne vytáčané spojenie."
 msgid "Cannot initialize OLE"
 msgstr "Nemožno inicializovať OLE"
 
-#: ../src/common/socket.cpp:853
+#: ../src/common/socket.cpp:850
 msgid "Cannot initialize sockets"
 msgstr "Nemožno inicializovať zásuvku"
 
-#: ../src/msw/volume.cpp:619
+#: ../src/msw/volume.cpp:627
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Nemožno načítať ikonu z '%s'."
 
-#: ../src/xrc/xmlres.cpp:360
+#: ../src/xrc/xmlres.cpp:358
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Nemožno načítať zdroje zo '%s'."
 
-#: ../src/xrc/xmlres.cpp:742
+#: ../src/xrc/xmlres.cpp:740
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Nemožno načítať zdroje zo súboru '%s'."
 
-#: ../src/html/htmlfilt.cpp:137
+#: ../src/html/htmlfilt.cpp:134
 #, c-format
 msgid "Cannot open HTML document: %s"
 msgstr "Nemožno otvoriť HTML dokument: %s"
 
-#: ../src/html/helpdata.cpp:667
+#: ../src/html/helpdata.cpp:660
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Nemožno otvoriť HTML príručku: %s"
 
-#: ../src/html/helpdata.cpp:299
+#: ../src/html/helpdata.cpp:296
 #, c-format
 msgid "Cannot open contents file: %s"
 msgstr "Nemožno otvoriť súbor s obsahom: %s"
 
-#: ../src/generic/dcpsg.cpp:1667
+#: ../src/generic/dcpsg.cpp:1665
 msgid "Cannot open file for PostScript printing!"
 msgstr "Nemožno otvoriť súbor pre tlač PostScript!"
 
-#: ../src/html/helpdata.cpp:313
+#: ../src/html/helpdata.cpp:310
 #, c-format
 msgid "Cannot open index file: %s"
 msgstr "Nemožno otvoriť indexový súbor: %s"
 
-#: ../src/xrc/xmlres.cpp:724
+#: ../src/xrc/xmlres.cpp:722
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Nemožno otvoriť zdroje súboru '%s'."
 
-#: ../src/html/helpwnd.cpp:1534
+#: ../src/html/helpwnd.cpp:1532
 msgid "Cannot print empty page."
 msgstr "Nemožno vytlačiť prázdnu stránku."
 
-#: ../src/msw/volume.cpp:507
+#: ../src/msw/volume.cpp:515
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Nemožno prečítať názov typu z '%s'!"
 
-#: ../src/msw/thread.cpp:888
+#: ../src/msw/thread.cpp:894
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Nemožno znovu získať vlákno %lx"
 
-#: ../src/unix/threadpsx.cpp:1016
+#: ../src/unix/threadpsx.cpp:1028
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Nemožno získať plánovaciu politiku vlákna."
 
-#: ../src/common/intl.cpp:558
+#: ../src/common/intl.cpp:365
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "Nemožno nastaviť miestne prostredie pre jazyk '%s'."
 
-#: ../src/unix/threadpsx.cpp:831 ../src/msw/thread.cpp:546
+#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
 msgid "Cannot start thread: error writing TLS."
 msgstr "Nemožno sputiť vlákno: chyba zápisu TLS."
 
-#: ../src/msw/thread.cpp:872
+#: ../src/msw/thread.cpp:864
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Nemožno pozastaviť vlákno %lx"
 
-#: ../src/msw/thread.cpp:794
+#: ../src/msw/thread.cpp:786
 msgid "Cannot wait for thread termination"
 msgstr "Nemožno čakať na ukončenie vlákna"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:75
+#: ../src/common/accelcmn.cpp:72
 msgid "Capital"
 msgstr "Kapitálka"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:879
+#: ../src/propgrid/advprops.cpp:780
 msgid "CaptionText"
 msgstr "Text popisku"
 
-#: ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:531
 msgid "Case sensitive"
 msgstr "Rozlišovať malé/veľké"
 
-#: ../src/propgrid/manager.cpp:1509
+#: ../src/propgrid/manager.cpp:1527
 msgid "Categorized Mode"
 msgstr "Kategorizovaný režim"
 
-#: ../src/richtext/richtextbuffer.cpp:9968
+#: ../src/richtext/richtextbuffer.cpp:9965
 msgid "Cell Properties"
 msgstr "Vlastnosti bunky"
 
-#: ../src/common/fmapbase.cpp:161
+#: ../src/common/fmapbase.cpp:158
 msgid "Celtic (ISO-8859-14)"
 msgstr "Keltské (ISO-8859-14)"
 
-#: ../src/richtext/richtextindentspage.cpp:160
 #: ../src/richtext/richtextliststylepage.cpp:349
+#: ../src/richtext/richtextindentspage.cpp:160
 msgid "Cen&tred"
 msgstr "Cen&trovaný"
 
-#: ../src/common/stockitem.cpp:170
+#: ../src/common/stockitem.cpp:167
 msgid "Centered"
 msgstr "Centrovaný"
 
-#: ../src/common/fmapbase.cpp:149
+#: ../src/common/fmapbase.cpp:146
 msgid "Central European (ISO-8859-2)"
 msgstr "Stredoeurópske (ISO-8859-2)"
 
@@ -1953,10 +1960,10 @@ msgstr "Stredoeurópske (ISO-8859-2)"
 msgid "Centre"
 msgstr "Centrovať"
 
-#: ../src/richtext/richtextindentspage.cpp:162
-#: ../src/richtext/richtextindentspage.cpp:164
 #: ../src/richtext/richtextliststylepage.cpp:351
 #: ../src/richtext/richtextliststylepage.cpp:353
+#: ../src/richtext/richtextindentspage.cpp:162
+#: ../src/richtext/richtextindentspage.cpp:164
 msgid "Centre text."
 msgstr "Centrovať text."
 
@@ -1969,24 +1976,24 @@ msgstr "Na stred"
 msgid "Ch&oose..."
 msgstr "Zv&oliť..."
 
-#: ../src/richtext/richtextbuffer.cpp:4354
+#: ../src/richtext/richtextbuffer.cpp:4351
 msgid "Change List Style"
 msgstr "Zmeniť štýl zoznamu"
 
-#: ../src/richtext/richtextbuffer.cpp:3709
+#: ../src/richtext/richtextbuffer.cpp:3706
 msgid "Change Object Style"
 msgstr "Zmeniť štýl objektu"
 
-#: ../src/richtext/richtextbuffer.cpp:3982
-#: ../src/richtext/richtextbuffer.cpp:8129
+#: ../src/richtext/richtextbuffer.cpp:3979
+#: ../src/richtext/richtextbuffer.cpp:8125
 msgid "Change Properties"
 msgstr "Zmeniť vlastnosti"
 
-#: ../src/richtext/richtextbuffer.cpp:3526
+#: ../src/richtext/richtextbuffer.cpp:3523
 msgid "Change Style"
 msgstr "Zmeniť štýl"
 
-#: ../src/common/fileconf.cpp:341
+#: ../src/common/fileconf.cpp:335
 #, c-format
 msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
 msgstr "Zmeny nebudú uložené, aby sa zabránilo prepísaniu súboru '%s'"
@@ -1997,11 +2004,11 @@ msgid "Changing current directory to \"%s\" failed"
 msgstr "Zmena súčasného priečinka na '%s' zlyhala"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1757
+#: ../src/propgrid/advprops.cpp:1658
 msgid "Character"
 msgstr "Znak"
 
-#: ../src/richtext/richtextstyles.cpp:1063
+#: ../src/richtext/richtextstyles.cpp:1060
 msgid "Character styles"
 msgstr "Štýly znakov"
 
@@ -2038,20 +2045,20 @@ msgstr "Zaškrtnite pre uzatvorenie odrážok do zátvoriek."
 msgid "Check to indicate right-to-left text layout."
 msgstr "Zaškrtnite pre rozvrhnutie textu z prava doľava."
 
-#: ../src/osx/carbon/fontdlg.cpp:356 ../src/osx/carbon/fontdlg.cpp:358
+#: ../src/osx/carbon/fontdlg.cpp:353 ../src/osx/carbon/fontdlg.cpp:355
 msgid "Check to make the font bold."
 msgstr "Zaškrtnite pre tučné písmo."
 
-#: ../src/osx/carbon/fontdlg.cpp:363 ../src/osx/carbon/fontdlg.cpp:365
+#: ../src/osx/carbon/fontdlg.cpp:360 ../src/osx/carbon/fontdlg.cpp:362
 msgid "Check to make the font italic."
 msgstr "Zaškrtnite pre kurzívu."
 
-#: ../src/osx/carbon/fontdlg.cpp:372 ../src/osx/carbon/fontdlg.cpp:374
+#: ../src/osx/carbon/fontdlg.cpp:369 ../src/osx/carbon/fontdlg.cpp:371
 msgid "Check to make the font underlined."
 msgstr "Zaškrtnite pre podčiarknuté písmo."
 
-#: ../src/richtext/richtextstyledlg.cpp:289
-#: ../src/richtext/richtextstyledlg.cpp:291
+#: ../src/richtext/richtextstyledlg.cpp:285
+#: ../src/richtext/richtextstyledlg.cpp:287
 msgid "Check to restart numbering."
 msgstr "Zaškrtnite pre číslovanie od začiatku."
 
@@ -2085,51 +2092,51 @@ msgstr "Zaškrtnite pre zobrazenie textu s horným indexom."
 msgid "Check to suppress hyphenation."
 msgstr "Zaškrtnite pre potlačenie delenia slov."
 
-#: ../src/msw/dialup.cpp:763
+#: ../src/msw/dialup.cpp:757
 msgid "Choose ISP to dial"
 msgstr "Vyberte ISP na vytočenie"
 
-#: ../src/propgrid/props.cpp:1922
+#: ../src/propgrid/props.cpp:1904
 msgid "Choose a directory:"
 msgstr "Vybrať priečinok:"
 
-#: ../src/propgrid/props.cpp:1975
+#: ../src/propgrid/props.cpp:2199
 msgid "Choose a file"
 msgstr "Vybrať súbor"
 
-#: ../src/generic/colrdlgg.cpp:158 ../src/gtk/colordlg.cpp:54
+#: ../src/generic/colrdlgg.cpp:156 ../src/gtk/colordlg.cpp:49
 msgid "Choose colour"
 msgstr "Vybrať farbu"
 
-#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/gtk1/fontdlg.cpp:125 ../src/generic/fontpickerg.cpp:47
+#: ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Vybrať písmo"
 
-#: ../src/common/module.cpp:74
+#: ../src/common/module.cpp:71
 #, c-format
 msgid "Circular dependency involving module \"%s\" detected."
 msgstr "Zistená kruhová závislosť zahrňujúca modul '%s'."
 
-#: ../src/aui/tabmdi.cpp:108 ../src/generic/mdig.cpp:97
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
 msgid "Cl&ose"
 msgstr "&Zatvoriť"
 
-#: ../src/msw/ole/automtn.cpp:684
+#: ../src/msw/ole/automtn.cpp:675
 msgid "Class not registered."
 msgstr "Trieda nie je zaregistrovaná."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:147 ../src/common/accelcmn.cpp:72
+#: ../src/common/stockitem.cpp:144 ../src/common/accelcmn.cpp:69
 msgid "Clear"
 msgstr "Zmazať"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "Clear the log contents"
 msgstr "Vymazať obsah záznamu"
 
-#: ../src/richtext/richtextstyledlg.cpp:252
-#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:248
+#: ../src/richtext/richtextstyledlg.cpp:250
 msgid "Click to apply the selected style."
 msgstr "Kliknite pre použitie vybraného štýlu."
 
@@ -2140,15 +2147,15 @@ msgstr "Kliknite pre použitie vybraného štýlu."
 msgid "Click to browse for a symbol."
 msgstr "Kliknite pre prechádzanie symbolmi."
 
-#: ../src/osx/carbon/fontdlg.cpp:403 ../src/osx/carbon/fontdlg.cpp:405
+#: ../src/osx/carbon/fontdlg.cpp:400 ../src/osx/carbon/fontdlg.cpp:402
 msgid "Click to cancel changes to the font."
 msgstr "Kliknite pre zrušenie zmien v písme."
 
-#: ../src/generic/fontdlgg.cpp:472 ../src/generic/fontdlgg.cpp:491
+#: ../src/generic/fontdlgg.cpp:468 ../src/generic/fontdlgg.cpp:487
 msgid "Click to cancel the font selection."
 msgstr "Kliknite pre zrušenie výberu písma."
 
-#: ../src/osx/carbon/fontdlg.cpp:384 ../src/osx/carbon/fontdlg.cpp:386
+#: ../src/osx/carbon/fontdlg.cpp:381 ../src/osx/carbon/fontdlg.cpp:383
 msgid "Click to change the font colour."
 msgstr "Kliknite pre zmenu farby písma."
 
@@ -2167,37 +2174,37 @@ msgstr "Kliknite pre zmenu farby písma."
 msgid "Click to choose the font for this level."
 msgstr "Kliknite pre výber písma tejto úrovne."
 
-#: ../src/richtext/richtextstyledlg.cpp:279
-#: ../src/richtext/richtextstyledlg.cpp:281
+#: ../src/richtext/richtextstyledlg.cpp:275
+#: ../src/richtext/richtextstyledlg.cpp:277
 msgid "Click to close this window."
 msgstr "Kliknite pre zatvorenie tohoto okna."
 
-#: ../src/osx/carbon/fontdlg.cpp:410 ../src/osx/carbon/fontdlg.cpp:412
+#: ../src/osx/carbon/fontdlg.cpp:407 ../src/osx/carbon/fontdlg.cpp:409
 msgid "Click to confirm changes to the font."
 msgstr "Kliknite pre potvrdenie zmien písma."
 
-#: ../src/generic/fontdlgg.cpp:477 ../src/generic/fontdlgg.cpp:479
-#: ../src/generic/fontdlgg.cpp:484 ../src/generic/fontdlgg.cpp:486
+#: ../src/generic/fontdlgg.cpp:473 ../src/generic/fontdlgg.cpp:475
+#: ../src/generic/fontdlgg.cpp:480 ../src/generic/fontdlgg.cpp:482
 msgid "Click to confirm the font selection."
 msgstr "Kliknite pre potvrdenie výberu písma."
 
-#: ../src/richtext/richtextstyledlg.cpp:244
-#: ../src/richtext/richtextstyledlg.cpp:246
+#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:242
 msgid "Click to create a new box style."
 msgstr "Kliknite pre vytvorenie nového štýlu schránky."
 
-#: ../src/richtext/richtextstyledlg.cpp:226
-#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:224
 msgid "Click to create a new character style."
 msgstr "Kliknite pre vytvorenie nového štýlu znakov."
 
-#: ../src/richtext/richtextstyledlg.cpp:238
-#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:236
 msgid "Click to create a new list style."
 msgstr "Kliknite pre vytvorenie nového štýlu zoznamu."
 
-#: ../src/richtext/richtextstyledlg.cpp:232
-#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:230
 msgid "Click to create a new paragraph style."
 msgstr "Kliknite pre vytvorenie nového štýlu odstavca."
 
@@ -2211,8 +2218,8 @@ msgstr "Kliknite pre vytvorenie novej pozície tabulátora."
 msgid "Click to delete all tab positions."
 msgstr "Kliknite pre zmazanie všetkých pozícií tabulátorov."
 
-#: ../src/richtext/richtextstyledlg.cpp:270
-#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:268
 msgid "Click to delete the selected style."
 msgstr "Kliknite pre zmazanie vybraného štýlu."
 
@@ -2221,25 +2228,25 @@ msgstr "Kliknite pre zmazanie vybraného štýlu."
 msgid "Click to delete the selected tab position."
 msgstr "Kliknite pre zmazanie pozécií vybraných tabulátorov."
 
-#: ../src/richtext/richtextstyledlg.cpp:264
-#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:262
 msgid "Click to edit the selected style."
 msgstr "Kliknite pre úpravu vybraného štýlu."
 
-#: ../src/richtext/richtextstyledlg.cpp:258
-#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:256
 msgid "Click to rename the selected style."
 msgstr "Kliknite pre premenovanie vybraného štýlu."
 
-#: ../src/generic/dbgrptg.cpp:97 ../src/generic/progdlgg.cpp:759
-#: ../src/richtext/richtextstyledlg.cpp:277
-#: ../src/richtext/richtextsymboldlg.cpp:476 ../src/common/stockitem.cpp:148
-#: ../src/msw/progdlg.cpp:170 ../src/msw/progdlg.cpp:679
-#: ../src/html/helpdlg.cpp:90
+#: ../src/common/stockitem.cpp:145 ../src/generic/dbgrptg.cpp:94
+#: ../src/generic/progdlgg.cpp:781 ../src/msw/progdlg.cpp:211
+#: ../src/msw/progdlg.cpp:946 ../src/html/helpdlg.cpp:87
+#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextstyledlg.cpp:273
 msgid "Close"
 msgstr "Zatvoriť"
 
-#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:98
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
 msgid "Close All"
 msgstr "Zatvoriť všetky"
 
@@ -2247,43 +2254,43 @@ msgstr "Zatvoriť všetky"
 msgid "Close current document"
 msgstr "Zatvoriť aktuálny dokument"
 
-#: ../src/generic/logg.cpp:516
+#: ../src/generic/logg.cpp:513
 msgid "Close this window"
 msgstr "Zatvoriť toto okno"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6006
+#: ../src/generic/datavgen.cpp:6811
 msgid "Collapse"
 msgstr "Zvinúť"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "Color"
 msgstr "Farba"
 
-#: ../src/richtext/richtextformatdlg.cpp:776
+#: ../src/richtext/richtextformatdlg.cpp:768
 msgid "Colour"
 msgstr "Farba"
 
-#: ../src/msw/colordlg.cpp:158
+#: ../src/msw/colordlg.cpp:227
 #, c-format
 msgid "Colour selection dialog failed with error %0lx."
 msgstr "Dialógové okno výberu farby zlyhalo s chybou %0lx."
 
-#: ../src/osx/carbon/fontdlg.cpp:380
+#: ../src/osx/carbon/fontdlg.cpp:377
 msgid "Colour:"
 msgstr "Farba:"
 
-#: ../src/generic/datavgen.cpp:6077
+#: ../src/generic/datavgen.cpp:6882
 #, c-format
 msgid "Column %u"
 msgstr "Stĺpec %u"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:114
+#: ../src/common/accelcmn.cpp:112
 msgid "Command"
 msgstr "Prikaz"
 
-#: ../src/common/init.cpp:196
+#: ../src/common/init.cpp:193
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
@@ -2292,12 +2299,12 @@ msgstr ""
 "Argument príkazového riadku %d nemožno previesť na Unicode a preto bude "
 "ignorovaný."
 
-#: ../src/msw/fontdlg.cpp:120
+#: ../src/msw/fontdlg.cpp:170
 #, c-format
 msgid "Common dialog failed with error code %0lx."
 msgstr "Spoločné dialógové okno zlyhalo s kódom chyby %0lx."
 
-#: ../src/gtk/window.cpp:4649
+#: ../src/gtk/window.cpp:5653
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
@@ -2305,11 +2312,11 @@ msgstr ""
 "Skladanie nie je podporované v tomto systéme, povoľte ho prosím v Správcovi "
 "okien."
 
-#: ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:1549
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Komprimovaný HTML súbor Pomocníka (*.chm)|*.chm|"
 
-#: ../src/generic/dirctrlg.cpp:444
+#: ../src/generic/dirctrlg.cpp:410
 msgid "Computer"
 msgstr "Počítač"
 
@@ -2318,53 +2325,57 @@ msgstr "Počítač"
 msgid "Config entry name cannot start with '%c'."
 msgstr "Záznam konfigurácie nemôže začínať '%c'."
 
-#: ../src/generic/filedlgg.cpp:349 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
 msgid "Confirm"
 msgstr "Potvrdiť"
 
-#: ../src/html/htmlwin.cpp:566
+#: ../src/html/htmlwin.cpp:569
 msgid "Connecting..."
 msgstr "Pripája sa..."
 
-#: ../src/html/helpwnd.cpp:475
+#: ../src/html/helpwnd.cpp:473
 msgid "Contents"
 msgstr "Obsah"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:880
+#: ../src/propgrid/advprops.cpp:781
 msgid "ControlDark"
 msgstr "Tmavý ovládač"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:881
+#: ../src/propgrid/advprops.cpp:782
 msgid "ControlLight"
 msgstr "Svetlý ovládač"
 
-#: ../src/common/strconv.cpp:2262
+#: ../src/common/strconv.cpp:2208
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Konverzia do znakovej sady '%s' nefunguje."
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "Convert"
 msgstr "Konvertovať"
 
-#: ../src/html/htmlwin.cpp:1079
+#: ../src/html/htmlwin.cpp:1020
 #, c-format
 msgid "Copied to clipboard:\"%s\""
 msgstr "Skopírované do schránky:'%s'"
 
-#: ../src/generic/prntdlgg.cpp:247
+#: ../src/generic/prntdlgg.cpp:240
 msgid "Copies:"
 msgstr "Kópie:"
 
-#: ../src/common/stockitem.cpp:150 ../src/stc/stc_i18n.cpp:18
+#: ../src/common/stockitem.cpp:147 ../src/stc/stc_i18n.cpp:18
 msgid "Copy"
 msgstr "Kopírovať"
 
-#: ../src/common/stockitem.cpp:258
+#: ../src/common/stockitem.cpp:255
 msgid "Copy selection"
 msgstr "Kopírovať výber"
+
+#: ../src/generic/grid.cpp:5945
+msgid "Copying more than one selected block to clipboard is not supported."
+msgstr ""
 
 #: ../src/richtext/richtextborderspage.cpp:566
 #: ../src/richtext/richtextborderspage.cpp:601
@@ -2375,195 +2386,192 @@ msgstr "Rohové"
 msgid "Corner &radius:"
 msgstr "Zaoblenie &rohu:"
 
-#: ../src/html/chm.cpp:718
+#: ../src/html/chm.cpp:711
 #, c-format
 msgid "Could not create temporary file '%s'"
 msgstr "Nemožno vytvoriť dočasný súbor '%s'"
 
-#: ../src/html/chm.cpp:273
+#: ../src/html/chm.cpp:270
 #, c-format
 msgid "Could not extract %s into %s: %s"
 msgstr "Nemožno rozbaliť %s do %s: %s"
 
-#: ../src/generic/tabg.cpp:1048
+#: ../src/generic/tabg.cpp:1045
 msgid "Could not find tab for id"
 msgstr "Nemožno nájsť tabulátor pre id"
 
-#: ../src/gtk/notifmsg.cpp:108
-msgid "Could not initalize libnotify."
-msgstr "Zlyhala inicializácia libnotify."
-
-#: ../src/html/chm.cpp:444
+#: ../src/html/chm.cpp:437
 #, c-format
 msgid "Could not locate file '%s'."
 msgstr "Nemožno nájsť súbor '%s'."
 
-#: ../src/common/filefn.cpp:1403
+#: ../src/msw/graphicsd2d.cpp:604
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/common/filefn.cpp:1291
 msgid "Could not set current working directory"
 msgstr "Nemožno nastaviť súčasný pracovný priečinok"
 
-#: ../src/common/prntbase.cpp:2015
+#: ../src/common/prntbase.cpp:2037
 msgid "Could not start document preview."
 msgstr "Nemožno spustiť náhľad dokumentu."
 
-#: ../src/generic/printps.cpp:178 ../src/msw/printwin.cpp:210
-#: ../src/gtk/print.cpp:1132
+#: ../src/generic/printps.cpp:159 ../src/msw/printwin.cpp:184
+#: ../src/gtk/print.cpp:1129
 msgid "Could not start printing."
 msgstr "Nemožno začať tlačiť."
 
-#: ../src/common/wincmn.cpp:2125
+#: ../src/common/wincmn.cpp:2126
 msgid "Could not transfer data to window"
 msgstr "Nemožno preniesť dáta do okna"
 
-#: ../src/msw/imaglist.cpp:187 ../src/msw/imaglist.cpp:224
-#: ../src/msw/imaglist.cpp:249 ../src/msw/dragimag.cpp:185
-#: ../src/msw/dragimag.cpp:220
+#: ../src/msw/imaglist.cpp:223 ../src/msw/imaglist.cpp:245
+#: ../src/msw/imaglist.cpp:270 ../src/msw/dragimag.cpp:182
+#: ../src/msw/dragimag.cpp:217
 msgid "Couldn't add an image to the image list."
 msgstr "Nemožno pridať obrázok do zoznamu obrázkov."
 
-#: ../src/osx/glcanvas_osx.cpp:414 ../src/unix/glx11.cpp:558
-#: ../src/msw/glcanvas.cpp:616
+#: ../src/osx/glcanvas_osx.cpp:411 ../src/msw/glcanvas.cpp:631
+#: ../src/unix/glegl.cpp:315 ../src/unix/glx11.cpp:559
 msgid "Couldn't create OpenGL context"
 msgstr "Nemožno vytvoriť kontext OpenGL"
 
-#: ../src/msw/timer.cpp:134
+#: ../src/msw/timer.cpp:131
 msgid "Couldn't create a timer"
 msgstr "Nemožno vytvoriť časovač"
 
-#: ../src/osx/carbon/overlay.cpp:122
-msgid "Couldn't create the overlay window"
-msgstr "Nemožno vytvoriť preložené okno"
-
-#: ../src/common/translation.cpp:2024
+#: ../src/common/translation.cpp:2074
 msgid "Couldn't enumerate translations"
 msgstr "Nemožno vymenovať preklady"
 
-#: ../src/common/dynlib.cpp:120
+#: ../src/common/dynlib.cpp:110
 #, c-format
 msgid "Couldn't find symbol '%s' in a dynamic library"
 msgstr "Nemožno nájsť symbol '%s' v dynamickej knižnici"
 
-#: ../src/msw/thread.cpp:915
+#: ../src/msw/thread.cpp:921
 msgid "Couldn't get the current thread pointer"
 msgstr "Nemožno získať ukazovateľ na súčasné vlákno"
 
-#: ../src/osx/carbon/overlay.cpp:129
-msgid "Couldn't init the context on the overlay window"
-msgstr "Nemožno inicializovať kontext preloženého okna"
-
-#: ../src/common/imaggif.cpp:244
+#: ../src/common/imaggif.cpp:241
 msgid "Couldn't initialize GIF hash table."
 msgstr "Nemožné inicializovať hash tabuľku GIF."
 
-#: ../src/common/imagpng.cpp:409
+#: ../src/common/imagpng.cpp:437
 msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
 msgstr ""
 "Nemožno načítať PNG obrázok - súbor je porušený alebo nie je dostatok pamäte."
 
-#: ../src/unix/sound.cpp:470
+#: ../src/unix/sound.cpp:459
 #, c-format
 msgid "Couldn't load sound data from '%s'."
 msgstr "Nemožno načítať zvukové údaje z '%s'."
 
-#: ../src/msw/dirdlg.cpp:435
+#: ../src/msw/dirdlg.cpp:287
 msgid "Couldn't obtain folder name"
 msgstr "Nemožno získať názov priečinka"
 
-#: ../src/unix/sound_sdl.cpp:229
+#: ../src/unix/sound_sdl.cpp:226
 #, c-format
 msgid "Couldn't open audio: %s"
 msgstr "Nemožno otvoriť audio: %s"
 
-#: ../src/msw/ole/dataobj.cpp:377
+#: ../src/msw/ole/dataobj.cpp:385
 #, c-format
 msgid "Couldn't register clipboard format '%s'."
 msgstr "Nemožno  zaregistrovať formát schránky '%s'."
 
-#: ../src/msw/listctrl.cpp:869
+#: ../src/msw/listctrl.cpp:933
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "Nemožno získať informácie o riadiacej položke zoznamu %d."
 
-#: ../src/common/imagpng.cpp:498 ../src/common/imagpng.cpp:509
-#: ../src/common/imagpng.cpp:519
+#: ../src/common/imagpng.cpp:511 ../src/common/imagpng.cpp:522
+#: ../src/common/imagpng.cpp:532
 msgid "Couldn't save PNG image."
 msgstr "Nemožno uložiť PNG obrázok."
 
-#: ../src/msw/thread.cpp:684
+#: ../src/msw/thread.cpp:676
 msgid "Couldn't terminate thread"
 msgstr "Nemožno ukončiť vlákno"
 
-#: ../src/common/xtistrm.cpp:166
+#: ../src/common/xtistrm.cpp:163
 #, c-format
 msgid "Create Parameter %s not found in declared RTTI Parameters"
 msgstr "Parameter vytvárania %s nebol nájdený v deklarovaných parametroch RTTI"
 
-#: ../src/generic/dirdlgg.cpp:288
+#: ../src/generic/dirdlgg.cpp:285
 msgid "Create directory"
 msgstr "Vytvoriť priečinok"
 
-#: ../src/generic/filedlgg.cpp:212 ../src/generic/dirdlgg.cpp:111
+#: ../src/generic/filedlgg.cpp:209 ../src/generic/dirdlgg.cpp:108
 msgid "Create new directory"
 msgstr "Vytvoriť nový priečinok"
 
-#: ../src/xrc/xmlres.cpp:2460
+#: ../src/common/stockitem.cpp:264
+#, fuzzy
+msgid "Create new document"
+msgstr "Vytvoriť nový priečinok"
+
+#: ../src/xrc/xmlres.cpp:2515
 #, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Vytváranie %s '%s' zlyhalo."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1758
+#: ../src/propgrid/advprops.cpp:1659
 msgid "Cross"
 msgstr "Krížom"
 
-#: ../src/common/accelcmn.cpp:333
+#: ../src/common/accelcmn.cpp:347
 msgid "Ctrl+"
 msgstr "Ctrl+"
 
-#: ../src/richtext/richtextctrl.cpp:332 ../src/osx/textctrl_osx.cpp:576
-#: ../src/common/stockitem.cpp:151 ../src/msw/textctrl.cpp:2507
+#: ../src/osx/textctrl_osx.cpp:594 ../src/common/stockitem.cpp:148
+#: ../src/msw/textctrl.cpp:2772 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "&Vystrihnúť"
 
-#: ../src/generic/filectrlg.cpp:940
+#: ../src/generic/filectrlg.cpp:936
 msgid "Current directory:"
 msgstr "Aktuálny priečinok:"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:896 ../src/propgrid/advprops.cpp:1574
-#: ../src/propgrid/advprops.cpp:1612
+#: ../src/propgrid/advprops.cpp:797 ../src/propgrid/advprops.cpp:1475
+#: ../src/propgrid/advprops.cpp:1518
 msgid "Custom"
 msgstr "Vlastné"
 
-#: ../src/gtk/print.cpp:217
+#: ../src/gtk/print.cpp:211
 msgid "Custom size"
 msgstr "Vlastná veľkosť"
 
-#: ../src/common/headerctrlcmn.cpp:60
+#: ../src/common/headerctrlcmn.cpp:58
 msgid "Customize Columns"
 msgstr "Prispôsobiť stĺpce"
 
-#: ../src/common/stockitem.cpp:151 ../src/stc/stc_i18n.cpp:17
+#: ../src/common/stockitem.cpp:148 ../src/stc/stc_i18n.cpp:17
 msgid "Cut"
 msgstr "Vystrihnúť"
 
-#: ../src/common/stockitem.cpp:259
+#: ../src/common/stockitem.cpp:256
 msgid "Cut selection"
 msgstr "Vystrihnúť výber"
 
-#: ../src/common/fmapbase.cpp:152
+#: ../src/common/fmapbase.cpp:149
 msgid "Cyrillic (ISO-8859-5)"
 msgstr "Cyrilika (ISO-8859-5)"
 
-#: ../src/common/paper.cpp:99
+#: ../src/common/paper.cpp:96
 msgid "D sheet, 22 x 34 in"
 msgstr "D hárok, 22 x 34 in"
 
-#: ../src/msw/dde.cpp:703
+#: ../src/msw/dde.cpp:698
 msgid "DDE poke request failed"
 msgstr "Požiadavka DDE poke zlyhala"
 
-#: ../src/common/imagbmp.cpp:1169
+#: ../src/common/imagbmp.cpp:1181
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr "Hlavička DIB: Kódovanie nezodpovedá bitovej hĺbke."
 
@@ -2583,7 +2591,7 @@ msgstr "Hlavička DIB: Neznáma bitová hĺbka v súbore."
 msgid "DIB Header: Unknown encoding in file."
 msgstr "Hlavička DIB: Neznáme kódovanie v súbore."
 
-#: ../src/common/paper.cpp:121
+#: ../src/common/paper.cpp:118
 msgid "DL Envelope, 110 x 220 mm"
 msgstr "DL obálka, 110 x 220 mm"
 
@@ -2591,53 +2599,53 @@ msgstr "DL obálka, 110 x 220 mm"
 msgid "Dashed"
 msgstr "Čiarkovaná"
 
-#: ../src/generic/dbgrptg.cpp:300
+#: ../src/generic/dbgrptg.cpp:301
 #, c-format
 msgid "Debug report \"%s\""
 msgstr "Hlásenie o chybe '%s'"
 
-#: ../src/common/debugrpt.cpp:210
+#: ../src/common/debugrpt.cpp:211
 msgid "Debug report couldn't be created."
 msgstr "Nemožno vytvoriť hlásenie o chybe."
 
-#: ../src/common/debugrpt.cpp:553
+#: ../src/common/debugrpt.cpp:554
 msgid "Debug report generation has failed."
 msgstr "Zlyhalo vytvorenie hlásenia o chybe."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:84
+#: ../src/common/accelcmn.cpp:81
 msgid "Decimal"
 msgstr "Desatinné"
 
-#: ../src/generic/fontdlgg.cpp:323
+#: ../src/generic/fontdlgg.cpp:319
 msgid "Decorative"
 msgstr "Okrasné"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1752
+#: ../src/propgrid/advprops.cpp:1653
 msgid "Default"
 msgstr "Predvolené"
 
-#: ../src/common/fmapbase.cpp:796
+#: ../src/common/fmapbase.cpp:792
 msgid "Default encoding"
 msgstr "Predvolené kódovanie"
 
-#: ../src/dfb/fontmgr.cpp:180
+#: ../src/dfb/fontmgr.cpp:177
 msgid "Default font"
 msgstr "Predvolené písmo"
 
-#: ../src/generic/prntdlgg.cpp:510
+#: ../src/generic/prntdlgg.cpp:503
 msgid "Default printer"
 msgstr "Predvolená tlačiareň"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:51
+#: ../src/common/accelcmn.cpp:48
 msgid "Del"
 msgstr "Del"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextbuffer.cpp:8221 ../src/common/stockitem.cpp:152
-#: ../src/common/accelcmn.cpp:50 ../src/stc/stc_i18n.cpp:20
+#: ../src/common/stockitem.cpp:149 ../src/common/accelcmn.cpp:47
+#: ../src/richtext/richtextbuffer.cpp:8217 ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Odstrániť"
 
@@ -2645,68 +2653,68 @@ msgstr "Odstrániť"
 msgid "Delete A&ll"
 msgstr "Odstrániť &všetky"
 
-#: ../src/richtext/richtextbuffer.cpp:11341
+#: ../src/richtext/richtextbuffer.cpp:11340
 msgid "Delete Column"
 msgstr "Odstrániť stĺpec"
 
-#: ../src/richtext/richtextbuffer.cpp:11291
+#: ../src/richtext/richtextbuffer.cpp:11290
 msgid "Delete Row"
 msgstr "Odstrániť riadok"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 msgid "Delete Style"
 msgstr "Odstrániť štýl"
 
-#: ../src/richtext/richtextctrl.cpp:1345 ../src/richtext/richtextctrl.cpp:1584
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
 msgid "Delete Text"
 msgstr "Odstrániť text"
 
-#: ../src/generic/editlbox.cpp:170
+#: ../src/generic/editlbox.cpp:147
 msgid "Delete item"
 msgstr "Odstrániť položku"
 
-#: ../src/common/stockitem.cpp:260
+#: ../src/common/stockitem.cpp:257
 msgid "Delete selection"
 msgstr "Odstrániť výber"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 #, c-format
 msgid "Delete style %s?"
 msgstr "Odstrániť štýl %s?"
 
-#: ../src/unix/snglinst.cpp:301
+#: ../src/unix/snglinst.cpp:298
 #, c-format
 msgid "Deleted stale lock file '%s'."
 msgstr "Odstránený zastaralý súbor zámku ' %s'."
 
-#: ../src/common/secretstore.cpp:220
-#, c-format
-msgid "Deleting password for \"%s/%s\" failed: %s."
+#: ../src/common/secretstore.cpp:234
+#, fuzzy, c-format
+msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Odstránenie hesla pre \"%s / %s\" zlyhalo: %s."
 
-#: ../src/common/module.cpp:124
+#: ../src/common/module.cpp:121
 #, c-format
 msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
 msgstr "Závislosť '%s' modulu '%s' neexistuje."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "Descending"
 msgstr "Zostupne"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:526 ../src/propgrid/advprops.cpp:882
+#: ../src/generic/dirctrlg.cpp:492 ../src/propgrid/advprops.cpp:783
 msgid "Desktop"
 msgstr "Plocha"
 
-#: ../src/generic/aboutdlgg.cpp:70
+#: ../src/generic/aboutdlgg.cpp:67
 msgid "Developed by "
 msgstr "Vyvinuté podľa "
 
-#: ../src/generic/aboutdlgg.cpp:176
+#: ../src/generic/aboutdlgg.cpp:173
 msgid "Developers"
 msgstr "Vývojári"
 
-#: ../src/msw/dialup.cpp:374
+#: ../src/msw/dialup.cpp:368
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -2714,11 +2722,11 @@ msgstr ""
 "Funkcie vytáčaného spojenia nie sú dostupné, lebo služba vzdialeného "
 "prístupu (RAS) nie je na tomto stroji nainštalovaná. Prosím, nainštalujte ju."
 
-#: ../src/generic/tipdlg.cpp:211
+#: ../src/generic/tipdlg.cpp:208
 msgid "Did you know..."
 msgstr "Viete, že..."
 
-#: ../src/dfb/wrapdfb.cpp:63
+#: ../src/dfb/wrapdfb.cpp:60
 #, c-format
 msgid "DirectFB error %d occurred."
 msgstr "Vyskytla sa chyba DirectFB %d."
@@ -2727,29 +2735,29 @@ msgstr "Vyskytla sa chyba DirectFB %d."
 msgid "Directories"
 msgstr "Priečinky"
 
-#: ../src/common/filefn.cpp:1183
+#: ../src/common/filefn.cpp:1071
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Nemožno vytvoriť priečinok '%s'"
 
-#: ../src/common/filefn.cpp:1197
+#: ../src/common/filefn.cpp:1085
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "Nemožno odstrániť priečinok '%s'"
 
-#: ../src/generic/dirdlgg.cpp:204
+#: ../src/generic/dirdlgg.cpp:201
 msgid "Directory does not exist"
 msgstr "Priečinok neexistuje"
 
-#: ../src/generic/filectrlg.cpp:1399
+#: ../src/generic/filectrlg.cpp:1388
 msgid "Directory doesn't exist."
 msgstr "Priečinok neexistuje."
 
-#: ../src/common/docview.cpp:457
+#: ../src/common/docview.cpp:450
 msgid "Discard changes and reload the last saved version?"
 msgstr "Zahodiť zmeny a znovu načítať poslednú uloženú verziu?"
 
-#: ../src/html/helpwnd.cpp:502
+#: ../src/html/helpwnd.cpp:500
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -2757,45 +2765,45 @@ msgstr ""
 "Zobraziť všetky položky indexu, ktoré obsahujú daný podreťazec. Vyhľadávanie "
 "rozlišuje malé a veľké písmená."
 
-#: ../src/html/helpwnd.cpp:679
+#: ../src/html/helpwnd.cpp:677
 msgid "Display options dialog"
 msgstr "Zobraziť dialóg nastavení"
 
-#: ../src/html/helpwnd.cpp:322
+#: ../src/html/helpwnd.cpp:320
 msgid "Displays help as you browse the books on the left."
 msgstr "Zobrazí pomocníka počas prehliadania kníh vľavo."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:85
+#: ../src/common/accelcmn.cpp:83
 msgid "Divide"
 msgstr "Delenie"
 
-#: ../src/common/docview.cpp:533
+#: ../src/common/docview.cpp:526
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Chcete uložiť zmeny do %s?"
 
-#: ../src/common/prntbase.cpp:542
+#: ../src/common/prntbase.cpp:537
 msgid "Document:"
 msgstr "Dokument:"
 
-#: ../src/generic/aboutdlgg.cpp:73
+#: ../src/generic/aboutdlgg.cpp:70
 msgid "Documentation by "
 msgstr "Dokumentácia podľa "
 
-#: ../src/generic/aboutdlgg.cpp:180
+#: ../src/generic/aboutdlgg.cpp:177
 msgid "Documentation writers"
 msgstr "Autori dokumentácie"
 
-#: ../src/common/sizer.cpp:2799
+#: ../src/common/sizer.cpp:2916
 msgid "Don't Save"
 msgstr "Neukladať"
 
-#: ../src/html/htmlwin.cpp:633
+#: ../src/html/htmlwin.cpp:643
 msgid "Done"
 msgstr "Hotovo"
 
-#: ../src/generic/progdlgg.cpp:448 ../src/msw/progdlg.cpp:407
+#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
 msgid "Done."
 msgstr "Hotovo."
 
@@ -2807,42 +2815,42 @@ msgstr "Bodkovaná"
 msgid "Double"
 msgstr "Dvojitá"
 
-#: ../src/common/paper.cpp:176
+#: ../src/common/paper.cpp:173
 msgid "Double Japanese Postcard Rotated 148 x 200 mm"
 msgstr "Dvojitá japonská pohľadnica otočená 148 x 200 mm"
 
-#: ../src/common/xtixml.cpp:273
+#: ../src/common/xtixml.cpp:269
 #, c-format
 msgid "Doubly used id : %d"
 msgstr "Duplicitne použitý id : %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:153
-#: ../src/common/accelcmn.cpp:64
+#: ../src/common/stockitem.cpp:150 ../src/common/accelcmn.cpp:61
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Down"
 msgstr "Dolu"
 
-#: ../src/richtext/richtextctrl.cpp:865
+#: ../src/richtext/richtextctrl.cpp:864
 msgid "Drag"
 msgstr "Ťahať"
 
-#: ../src/common/paper.cpp:100
+#: ../src/common/paper.cpp:97
 msgid "E sheet, 34 x 44 in"
 msgstr "E hárok, 34 x 44 in"
 
-#: ../src/unix/fswatcher_inotify.cpp:561
+#: ../src/unix/fswatcher_inotify.cpp:558
 msgid "EOF while reading from inotify descriptor"
 msgstr "EOF pri načítaní popisovača štruktúry súborov"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "Edit"
 msgstr "Upraviť"
 
-#: ../src/generic/editlbox.cpp:168
+#: ../src/generic/editlbox.cpp:131
 msgid "Edit item"
 msgstr "Upraviť položku"
 
-#: ../include/wx/generic/progdlgg.h:84
+#: ../include/wx/generic/progdlgg.h:85
 msgid "Elapsed time:"
 msgstr "Uplynutý čas:"
 
@@ -2909,62 +2917,62 @@ msgid "Enables the shadow spread."
 msgstr "Povolí rozprestrenie tieňa."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:66
+#: ../src/common/accelcmn.cpp:63
 msgid "End"
 msgstr "End"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:55
+#: ../src/common/accelcmn.cpp:52
 msgid "Enter"
 msgstr "Enter"
 
-#: ../src/richtext/richtextstyledlg.cpp:934
+#: ../src/richtext/richtextstyledlg.cpp:930
 msgid "Enter a box style name"
 msgstr "Zadajte názov štýlu schránky"
 
-#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:602
 msgid "Enter a character style name"
 msgstr "Zadajte názov štýlu znaku"
 
-#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:816
 msgid "Enter a list style name"
 msgstr "Zadajte názov štýlu zoznamu"
 
-#: ../src/richtext/richtextstyledlg.cpp:893
+#: ../src/richtext/richtextstyledlg.cpp:889
 msgid "Enter a new style name"
 msgstr "Zadajte nový názov štýlu"
 
-#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:650
 msgid "Enter a paragraph style name"
 msgstr "Zadajte názov štýlu odstavca"
 
-#: ../src/generic/dbgrptg.cpp:174
+#: ../src/generic/dbgrptg.cpp:171
 #, c-format
 msgid "Enter command to open file \"%s\":"
 msgstr "Zadajte príkaz pre otvorenie súboru '%s':"
 
-#: ../src/generic/helpext.cpp:459
+#: ../src/generic/helpext.cpp:457
 msgid "Entries found"
 msgstr "Nájdených záznamov"
 
-#: ../src/common/paper.cpp:142
+#: ../src/common/paper.cpp:139
 msgid "Envelope Invite 220 x 220 mm"
 msgstr "Obálka pozvánky 220 x 220 mm"
 
-#: ../src/common/config.cpp:469
+#: ../src/common/config.cpp:465
 #, c-format
 msgid ""
 "Environment variables expansion failed: missing '%c' at position %u in '%s'."
 msgstr ""
 "Expanzia premenných prostredia zlyhala: chýba '%c' na pozícii %u v '%s'."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/generic/dirctrlg.cpp:570
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/dirctrlg.cpp:599
-#: ../src/generic/dirdlgg.cpp:323 ../src/generic/filectrlg.cpp:642
-#: ../src/generic/filectrlg.cpp:756 ../src/generic/filectrlg.cpp:770
-#: ../src/generic/filectrlg.cpp:786 ../src/generic/filectrlg.cpp:1368
-#: ../src/generic/filectrlg.cpp:1399 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/gtk1/fontdlg.cpp:74 ../src/generic/dirctrlg.cpp:536
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/dirctrlg.cpp:565
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1357 ../src/generic/filectrlg.cpp:1388
+#: ../src/generic/filedlgg.cpp:354 ../src/generic/dirdlgg.cpp:320
+#: ../src/gtk/filedlg.cpp:74
 msgid "Error"
 msgstr "Chyba"
 
@@ -2972,235 +2980,256 @@ msgstr "Chyba"
 msgid "Error closing epoll descriptor"
 msgstr "Chyba pri zatváraní popisovača epoll"
 
-#: ../src/unix/fswatcher_kqueue.cpp:114
+#: ../src/unix/fswatcher_kqueue.cpp:131
 msgid "Error closing kqueue instance"
 msgstr "Chyba pri zatváraní inštancie kqueue"
 
-#: ../src/common/filefn.cpp:1049
+#: ../src/common/filefn.cpp:938
 #, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Chyba pri kopírovaní súboru '%s' do '%s'."
 
-#: ../src/generic/dirdlgg.cpp:222
+#: ../src/generic/dirdlgg.cpp:219
 msgid "Error creating directory"
 msgstr "Chyba pri vytváraní priečinka"
 
-#: ../src/common/imagbmp.cpp:1181
+#: ../src/common/imagbmp.cpp:1193
 msgid "Error in reading image DIB."
 msgstr "Chyba pri čítaní obrázka DIB."
 
-#: ../src/propgrid/propgrid.cpp:6696
+#: ../src/propgrid/propgrid.cpp:6665
 #, c-format
 msgid "Error in resource: %s"
 msgstr "Chyba v zdroji: %s"
 
-#: ../src/common/fileconf.cpp:422
+#: ../src/common/fileconf.cpp:421
 msgid "Error reading config options."
 msgstr "Chyba pri čítaní konfiguračných volieb."
+
+#: ../src/msw/webview_ie.cpp:1057 ../src/msw/webview_edge.cpp:850
+#: ../src/gtk/webview_webkit2.cpp:1262 ../src/osx/webview_webkit.mm:383
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
 
 #: ../src/common/fileconf.cpp:1029
 msgid "Error saving user configuration data."
 msgstr "Chyba pri ukladaní používateľských konfiguračných údajov."
 
-#: ../src/gtk/print.cpp:722
+#: ../src/gtk/print.cpp:720
 msgid "Error while printing: "
 msgstr "Chyba pri tlači: "
 
-#: ../src/common/log.cpp:219
+#: ../src/common/log.cpp:237
 msgid "Error: "
 msgstr "Chyba: "
 
+#: ../src/common/webrequest.cpp:98
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Chyba: "
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:69
+#: ../src/common/accelcmn.cpp:66
 msgid "Esc"
 msgstr "Esc"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:70
+#: ../src/common/accelcmn.cpp:67
 msgid "Escape"
 msgstr "Escape"
 
-#: ../src/common/fmapbase.cpp:150
+#: ../src/common/fmapbase.cpp:147
 msgid "Esperanto (ISO-8859-3)"
 msgstr "Esperanto (ISO-8859-3)"
 
-#: ../include/wx/generic/progdlgg.h:85
+#: ../include/wx/generic/progdlgg.h:86
 msgid "Estimated time:"
 msgstr "Odhadovaný čas:"
 
-#: ../src/generic/dbgrptg.cpp:234
+#: ../src/generic/dbgrptg.cpp:231
 msgid "Executable files (*.exe)|*.exe|"
 msgstr "Spustiteľné súbory (*.exe)|*.exe|"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:155 ../src/common/accelcmn.cpp:78
+#: ../src/common/stockitem.cpp:152 ../src/common/accelcmn.cpp:75
 msgid "Execute"
 msgstr "Vykonať"
 
-#: ../src/msw/utilsexc.cpp:876
+#: ../src/msw/utilsexc.cpp:873
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Vykonávanie príkazu '%s' zlyhalo"
 
-#: ../src/common/paper.cpp:105
+#: ../src/common/paper.cpp:102
 msgid "Executive, 7 1/4 x 10 1/2 in"
 msgstr "Executive, 7 1/4 x 10 1/2 palcov"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6009
+#: ../src/generic/datavgen.cpp:6814
 msgid "Expand"
 msgstr "Rozvinúť"
 
-#: ../src/msw/registry.cpp:1240
+#: ../src/msw/registry.cpp:1228
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
 msgstr ""
 "Exportovanie kľúča registra: súbor '%s' už existuje a nebude prepísaný."
 
-#: ../src/common/fmapbase.cpp:195
+#: ../src/common/fmapbase.cpp:192
 msgid "Extended Unix Codepage for Japanese (EUC-JP)"
 msgstr "Rozšírená kódová stránka Unix pre japončinu (EUC-JP)"
 
-#: ../src/html/chm.cpp:725
+#: ../src/html/chm.cpp:718
 #, c-format
 msgid "Extraction of '%s' into '%s' failed."
 msgstr "Rozbalenie '%s' do '%s' zlyhala."
 
-#: ../src/common/accelcmn.cpp:249 ../src/common/accelcmn.cpp:344
+#: ../src/common/accelcmn.cpp:259 ../src/common/accelcmn.cpp:358
 msgid "F"
 msgstr "F"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:672
+#: ../src/propgrid/advprops.cpp:582
 msgid "Face Name"
 msgstr "Názov plôšky"
 
-#: ../src/unix/snglinst.cpp:269
+#: ../src/unix/snglinst.cpp:266
 msgid "Failed to access lock file."
 msgstr "Zlyhal prístup  zamknutému súboru."
+
+#: ../src/gtk/font.cpp:572
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Zlyhalo načítanie dokument zo súboru '%s'."
 
 #: ../src/unix/epolldispatcher.cpp:116
 #, c-format
 msgid "Failed to add descriptor %d to epoll descriptor %d"
 msgstr "Zlyhalo pridanie popisovača %d do popisovača epoll %d"
 
-#: ../src/msw/dib.cpp:489
+#: ../src/msw/dib.cpp:535
 #, c-format
 msgid "Failed to allocate %luKb of memory for bitmap data."
 msgstr "Zlyhalo vymedzenie %lukb pamäte pre údaje bitmapy."
 
-#: ../src/common/glcmn.cpp:115
+#: ../src/common/glcmn.cpp:112
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Zlyhalo vymedzenie farby pre OpenGL"
 
-#: ../src/unix/displayx11.cpp:236
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Zlyhalo vymedzenie farby pre OpenGL"
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Zlyhalo vymedzenie farby pre OpenGL"
+
+#: ../include/wx/unix/private/displayx11.h:89
 msgid "Failed to change video mode"
 msgstr "Zlyhala zmena video režimu"
 
-#: ../src/common/image.cpp:3277
+#: ../src/common/image.cpp:3396
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Zlyhalo uloženie bitmapového obrázku do súboru '%s'."
 
-#: ../src/common/debugrpt.cpp:239
+#: ../src/common/debugrpt.cpp:240
 #, c-format
 msgid "Failed to clean up debug report directory \"%s\""
 msgstr "Zlyhalo vyčistenie priečinka pre hlásenia o chybe '%s'"
 
-#: ../src/common/filename.cpp:192
+#: ../src/common/filename.cpp:189
 msgid "Failed to close file handle"
 msgstr "Zlyhalo zatvorenie súboru"
 
-#: ../src/unix/snglinst.cpp:340
+#: ../src/unix/snglinst.cpp:337
 #, c-format
 msgid "Failed to close lock file '%s'"
 msgstr "Zlyhalo zatvorenie súboru zámku '%s'"
 
-#: ../src/msw/clipbrd.cpp:112
+#: ../src/msw/clipbrd.cpp:110
 msgid "Failed to close the clipboard."
 msgstr "Zlyhalo zatvorenie schránky."
 
-#: ../src/x11/utils.cpp:208
+#: ../src/x11/utils.cpp:170
 #, c-format
 msgid "Failed to close the display \"%s\""
 msgstr "Zlyhalo zatvorenie zobrazenia '%s'"
 
-#: ../src/msw/dialup.cpp:797
+#: ../src/msw/dialup.cpp:791
 msgid "Failed to connect: missing username/password."
 msgstr "Zlyhalo pripojenie: chýba používateľské meno/heslo."
 
-#: ../src/msw/dialup.cpp:743
+#: ../src/msw/dialup.cpp:737
 msgid "Failed to connect: no ISP to dial."
 msgstr ""
 "Zlyhalo pripojenie: nie je žiadny poskytovateľ, ktorého by bolo možné "
 "vytočiť."
 
-#: ../src/common/textfile.cpp:203
-#, c-format
-msgid "Failed to convert file \"%s\" to Unicode."
-msgstr "Zlyhala konverzia súboru '%s' na Unicode."
-
-#: ../src/generic/logg.cpp:956
+#: ../src/generic/logg.cpp:953
 msgid "Failed to copy dialog contents to the clipboard."
 msgstr "Zlyhalo skopírovanie obsahu dialógového okna do schránky."
 
-#: ../src/msw/registry.cpp:692
+#: ../src/msw/registry.cpp:681
 #, c-format
 msgid "Failed to copy registry value '%s'"
 msgstr "Zlyhalo skopírovanie hodnoty registra '%s'"
 
-#: ../src/msw/registry.cpp:701
+#: ../src/msw/registry.cpp:690
 #, c-format
 msgid "Failed to copy the contents of registry key '%s' to '%s'."
 msgstr "Zlyhalo skopírovanie obsahu kľúča registra '%s' do '%s'."
 
-#: ../src/common/filefn.cpp:1015
+#: ../src/common/filefn.cpp:904
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Zlyhalo skopírovanie súboru '%s' do '%s'"
 
-#: ../src/msw/registry.cpp:679
+#: ../src/msw/registry.cpp:668
 #, c-format
 msgid "Failed to copy the registry subkey '%s' to '%s'."
 msgstr "Zlyhalo skopírovanie podkľúča registra '%s' do '%s'."
 
-#: ../src/msw/dde.cpp:1070
+#: ../src/msw/dde.cpp:1134
 msgid "Failed to create DDE string"
 msgstr "Zlyhalo vytvorenie DDE reťazca"
 
-#: ../src/msw/mdi.cpp:616
+#: ../src/msw/mdi.cpp:621
 msgid "Failed to create MDI parent frame."
 msgstr "Zlyhalo vytvorenie rodičovského okna MDI."
 
-#: ../src/common/filename.cpp:1027
+#: ../src/common/filename.cpp:1024
 msgid "Failed to create a temporary file name"
 msgstr "Zlyhalo vytvorenie dočasného mena súboru"
 
-#: ../src/msw/utilsexc.cpp:228
+#: ../src/msw/utilsexc.cpp:225
 msgid "Failed to create an anonymous pipe"
 msgstr "Zlyhalo vytvorenie anonymného potrubia"
 
-#: ../src/msw/ole/automtn.cpp:522
+#: ../src/msw/ole/automtn.cpp:513
 #, c-format
 msgid "Failed to create an instance of \"%s\""
 msgstr "Zlyhalo vytvorenie priečinku '%s'"
 
-#: ../src/msw/dde.cpp:437
+#: ../src/msw/dde.cpp:432
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "Zlyhalo vytvorenie spojenia so serverom '%s' na tému '%s'"
 
-#: ../src/msw/cursor.cpp:204
+#: ../src/msw/cursor.cpp:195
 msgid "Failed to create cursor."
 msgstr "Zlyhalo vytvorenie kurzora."
 
-#: ../src/common/debugrpt.cpp:209
+#: ../src/common/debugrpt.cpp:210
 #, c-format
 msgid "Failed to create directory \"%s\""
 msgstr "Zlyhalo vytvorenie priečinku '%s'"
 
-#: ../src/generic/dirdlgg.cpp:220
+#: ../src/generic/dirdlgg.cpp:217
 #, c-format
 msgid ""
 "Failed to create directory '%s'\n"
@@ -3213,115 +3242,134 @@ msgstr ""
 msgid "Failed to create epoll descriptor"
 msgstr "Zlyhalo sa vytvorenie popisovača epolly"
 
-#: ../src/msw/mimetype.cpp:238
+#: ../src/gtk/font.cpp:562
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "Zlyhala aktualizácia používateľského konfiguračného súboru."
+
+#: ../src/msw/mimetype.cpp:235
 #, c-format
 msgid "Failed to create registry entry for '%s' files."
 msgstr "Zlyhalo vytvorenie záznamu registra pre súbory '%s'."
 
-#: ../src/msw/fdrepdlg.cpp:409
+#: ../src/msw/fdrepdlg.cpp:408
 #, c-format
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr ""
 "Zlyhalo vytvorenie štandardného dialógu hľadať/nahradiť (chybový kód %d)"
 
-#: ../src/unix/wakeuppipe.cpp:52
+#: ../src/unix/wakeuppipe.cpp:49
 msgid "Failed to create wake up pipe used by event loop."
 msgstr "Zlyhalo vytvorenie prebudenie potrubia používaného slučkou udalostí."
 
-#: ../src/html/winpars.cpp:730
+#: ../src/html/winpars.cpp:727
 #, c-format
 msgid "Failed to display HTML document in %s encoding"
 msgstr "Zlyhalo zobrazenie HTML dokumentu v kódovaní %s"
 
-#: ../src/msw/clipbrd.cpp:124
+#: ../src/msw/clipbrd.cpp:122
 msgid "Failed to empty the clipboard."
 msgstr "Zlyhalo vyprázdnenie schránky."
 
-#: ../src/unix/displayx11.cpp:212
+#: ../include/wx/unix/private/displayx11.h:65
 msgid "Failed to enumerate video modes"
 msgstr "Zlyhalo zistenie zoznamu video režimov"
 
-#: ../src/msw/dde.cpp:722
+#: ../src/msw/dde.cpp:717
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "Zlyhalo nadviazanie pomocného spojenia s DDE serverom"
 
-#: ../src/msw/dialup.cpp:629 ../src/msw/dialup.cpp:863
+#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Zlyhalo nadviazanie vytáčaného spojenia: %s"
 
-#: ../src/unix/utilsunx.cpp:611
+#: ../src/unix/utilsunx.cpp:613
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Zlyhalo vykonanie '%s'\n"
 
-#: ../src/common/debugrpt.cpp:720
+#: ../src/common/debugrpt.cpp:730
 msgid "Failed to execute curl, please install it in PATH."
 msgstr "Zlyhalo zvlnenie, nainštalujte ho, prosím, do premennej PATH."
 
-#: ../src/msw/ole/automtn.cpp:505
+#: ../src/msw/ole/automtn.cpp:496
 #, c-format
 msgid "Failed to find CLSID of \"%s\""
 msgstr "Zlyhalo nájdenie identifikátora CLSID '%s'"
 
-#: ../src/common/regex.cpp:431 ../src/common/regex.cpp:479
+#: ../src/common/regex.cpp:428 ../src/common/regex.cpp:476
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "Zlyhalo nájdenie výsledku regulárneho výrazu : %s"
 
-#: ../src/msw/dialup.cpp:695
+#: ../src/msw/webview_ie.cpp:978
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:689
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Zlyhalo získanie zoznamu názvov poskytovateľov pripojenia: %s"
 
-#: ../src/msw/ole/automtn.cpp:574
+#: ../src/msw/ole/automtn.cpp:565
 #, c-format
 msgid "Failed to get OLE automation interface for \"%s\""
 msgstr "Zlyhalo získanie rozhrania automatizácie OLE pre '%s'"
 
-#: ../src/msw/clipbrd.cpp:711
+#: ../src/msw/clipbrd.cpp:731
 msgid "Failed to get data from the clipboard"
 msgstr "Zlyhalo získanie údajov zo schránky"
 
-#: ../src/common/time.cpp:223
+#: ../src/common/time.cpp:216
 msgid "Failed to get the local system time"
 msgstr "Zlyhalo zistenie miestneho systémového času"
 
-#: ../src/common/filefn.cpp:1345
+#: ../src/common/filefn.cpp:1233
 msgid "Failed to get the working directory"
 msgstr "Zlyhalo zistenie pracovného priečinku"
 
-#: ../src/univ/theme.cpp:114
+#: ../src/univ/theme.cpp:111
 msgid "Failed to initialize GUI: no built-in themes found."
 msgstr "Zlyhala inicializácia GUI: neboli nájdené žiadne vstavané témy."
 
-#: ../src/msw/helpchm.cpp:63
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:60
 msgid "Failed to initialize MS HTML Help."
 msgstr "Zlyhala inicializácia Pomocníka MS HTML."
 
-#: ../src/msw/glcanvas.cpp:1381
+#: ../src/msw/glcanvas.cpp:1391
 msgid "Failed to initialize OpenGL"
 msgstr "Zlyhala inicializácia OpenGL"
 
-#: ../src/msw/dialup.cpp:858
+#: ../src/msw/dialup.cpp:852
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Zlyhalo nadviazanie telefonického pripojenia: %s"
 
-#: ../src/gtk/textctrl.cpp:1128
+#: ../src/gtk/textctrl.cpp:1209
 msgid "Failed to insert text in the control."
 msgstr "Zlyhalo vloženie textu do ovládacieho prvku."
 
-#: ../src/unix/snglinst.cpp:241
+#: ../src/unix/snglinst.cpp:238
 #, c-format
 msgid "Failed to inspect the lock file '%s'"
 msgstr "Zlyhalo preskúmanie súboru zámku '%s'"
 
-#: ../src/unix/appunix.cpp:182
+#: ../src/unix/appunix.cpp:179
 msgid "Failed to install signal handler"
 msgstr "Zlyhala inštalácia obslužného programu signálu"
 
-#: ../src/unix/threadpsx.cpp:1167
+#: ../src/unix/threadpsx.cpp:1216
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -3329,71 +3377,71 @@ msgstr ""
 "Zlyhalo pridanie vlákna, zistený potenciálny výpadok pamäte - reštartujte, "
 "prosím, program"
 
-#: ../src/msw/utils.cpp:629
+#: ../src/msw/utils.cpp:619
 #, c-format
 msgid "Failed to kill process %d"
 msgstr "Zlyhalo zabitie procesu %d"
 
-#: ../src/common/image.cpp:2500
+#: ../src/common/image.cpp:2595
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Zlyhalo načítanie bitmapy '%s' zo zdrojov."
 
-#: ../src/common/image.cpp:2509
+#: ../src/common/image.cpp:2604
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Zlyhalo načítanie ikony '%s' zo zdrojov."
 
-#: ../src/common/iconbndl.cpp:225
+#: ../src/common/iconbndl.cpp:224
 #, c-format
 msgid "Failed to load icons from resource '%s'."
 msgstr "Zlyhalo načítanie ikony zo zdroja '%s'."
 
-#: ../src/common/iconbndl.cpp:200
+#: ../src/common/iconbndl.cpp:198
 #, c-format
 msgid "Failed to load image %%d from file '%s'."
 msgstr "Zlyhalo načítanie obrázku %%d zo súboru '%s'."
 
-#: ../src/common/iconbndl.cpp:208
+#: ../src/common/iconbndl.cpp:206
 #, c-format
 msgid "Failed to load image %d from stream."
 msgstr "Zlyhalo načítanie obrázok %d z prúdu."
 
-#: ../src/common/image.cpp:2587 ../src/common/image.cpp:2606
+#: ../src/common/image.cpp:2682 ../src/common/image.cpp:2701
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Zlyhalo načítanie obrázku zo súboru '%s'."
 
-#: ../src/msw/enhmeta.cpp:97
+#: ../src/msw/enhmeta.cpp:94
 #, c-format
 msgid "Failed to load metafile from file \"%s\"."
 msgstr "Zlyhalo načítanie metasúboru zo súboru '%s'."
 
-#: ../src/msw/volume.cpp:327
+#: ../src/msw/volume.cpp:335
 msgid "Failed to load mpr.dll."
 msgstr "Zlyhalo načítanie mpr.dll."
 
-#: ../src/msw/utils.cpp:953
+#: ../src/msw/utils.cpp:943
 #, c-format
 msgid "Failed to load resource \"%s\"."
 msgstr "Zlyhalo načítanie zdroja '%s'."
 
-#: ../src/common/dynlib.cpp:92
+#: ../src/common/dynlib.cpp:86
 #, c-format
 msgid "Failed to load shared library '%s'"
 msgstr "Zlyhalo načítanie zdieľanej knižnice '%s'"
 
-#: ../src/osx/core/sound.cpp:145
+#: ../src/osx/core/sound.cpp:143
 #, c-format
 msgid "Failed to load sound from \"%s\" (error %d)."
 msgstr "Zlyhalo načítanie zvuku z '%s' (chyba %d)."
 
-#: ../src/msw/utils.cpp:960
+#: ../src/msw/utils.cpp:950
 #, c-format
 msgid "Failed to lock resource \"%s\"."
 msgstr "Zlyhalo uzamknutie zdroja '%s'."
 
-#: ../src/unix/snglinst.cpp:198
+#: ../src/unix/snglinst.cpp:195
 #, c-format
 msgid "Failed to lock the lock file '%s'"
 msgstr "Zlyhalo zamknutie súbor zámku '%s'"
@@ -3403,33 +3451,38 @@ msgstr "Zlyhalo zamknutie súbor zámku '%s'"
 msgid "Failed to modify descriptor %d in epoll descriptor %d"
 msgstr "Zlyhala úprava popisovača %d v popisovači epoll %d"
 
-#: ../src/common/filename.cpp:2575
+#: ../src/common/filename.cpp:2658
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Zlyhala zmena času súboru '%s'"
 
-#: ../src/common/selectdispatcher.cpp:258
+#: ../src/common/selectdispatcher.cpp:255
 msgid "Failed to monitor I/O channels"
 msgstr "Zlyhalo monitorovanie I/O kanálov"
 
-#: ../src/common/filename.cpp:175
+#: ../src/common/filename.cpp:172
 #, c-format
 msgid "Failed to open '%s' for reading"
 msgstr "Zlyhalo otvorenie '%s' na čítanie"
 
-#: ../src/common/filename.cpp:180
+#: ../src/common/filename.cpp:177
 #, c-format
 msgid "Failed to open '%s' for writing"
 msgstr "Zlyhalo otvorenie '%s' na zápis"
 
-#: ../src/html/chm.cpp:141
+#: ../src/html/chm.cpp:138
 #, c-format
 msgid "Failed to open CHM archive '%s'."
 msgstr "Zlyhalo otvorenie CHM archívu '%s'."
 
-#: ../src/common/utilscmn.cpp:1126
+#: ../src/common/utilscmn.cpp:1140
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Zlyhalo otvorenie adresy URL '%s' v predvolenom prehliadači."
+
+#: ../src/common/hyperlnkcmn.cpp:133
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Zlyhalo otvorenie adresy URL '%s' v predvolenom prehliadači."
 
 #: ../include/wx/msw/private/fswatcher.h:92
@@ -3437,93 +3490,103 @@ msgstr "Zlyhalo otvorenie adresy URL '%s' v predvolenom prehliadači."
 msgid "Failed to open directory \"%s\" for monitoring."
 msgstr "Zlyhalo otvorenie priečinka '%s' na sledovanie."
 
-#: ../src/x11/utils.cpp:227
+#: ../src/x11/utils.cpp:189
 #, c-format
 msgid "Failed to open display \"%s\"."
 msgstr "Zlyhalo otvorenie zobrazenia '%s'."
 
-#: ../src/common/filename.cpp:1062
+#: ../src/common/filename.cpp:1059
 msgid "Failed to open temporary file."
 msgstr "Zlyhalo otvorenie dočasného súboru."
 
-#: ../src/msw/clipbrd.cpp:91
+#: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Zlyhalo otvorenie schránky."
 
-#: ../src/common/translation.cpp:1184
+#: ../src/common/translation.cpp:1226
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Zlyhala analýza množného čísla: '%s'"
 
-#: ../src/unix/mediactrl.cpp:1214
+#: ../src/unix/mediactrl.cpp:1239
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Zlyhala príprava hry '%s'."
 
-#: ../src/msw/clipbrd.cpp:600
+#: ../src/msw/clipbrd.cpp:610
 msgid "Failed to put data on the clipboard"
 msgstr "Zlyhalo vloženie údajov do schránky"
 
-#: ../src/unix/snglinst.cpp:278
+#: ../src/unix/snglinst.cpp:275
 msgid "Failed to read PID from lock file."
 msgstr "Zlyhalo prečítanie PID zo súboru zámku."
 
-#: ../src/common/fileconf.cpp:433
+#: ../src/common/fileconf.cpp:432
 msgid "Failed to read config options."
 msgstr "Zlyhalo načítanie možností konfigurácie."
 
-#: ../src/common/docview.cpp:681
+#: ../src/common/docview.cpp:676
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Zlyhalo načítanie dokument zo súboru '%s'."
 
-#: ../src/dfb/evtloop.cpp:98
+#: ../src/dfb/evtloop.cpp:99
 msgid "Failed to read event from DirectFB pipe"
 msgstr "Nepodarilo sa načítať udalosť z kanálu DirectFB"
 
-#: ../src/unix/wakeuppipe.cpp:120
+#: ../src/unix/wakeuppipe.cpp:117
 msgid "Failed to read from wake-up pipe"
 msgstr "Zlyhalo načítanie prebudenie potrubia"
 
-#: ../src/unix/utilsunx.cpp:679
+#: ../src/common/textfile.cpp:96
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Zlyhalo načítanie dokument zo súboru '%s'."
+
+#: ../src/unix/utilsunx.cpp:681
 msgid "Failed to redirect child process input/output"
 msgstr "Zlyhalo presmerovanie vstupu/výstupu detského procesu"
 
-#: ../src/msw/utilsexc.cpp:701
+#: ../src/msw/utilsexc.cpp:698
 msgid "Failed to redirect the child process IO"
 msgstr "Zlyhalo presmerovanie V/V detského procesu"
 
-#: ../src/msw/dde.cpp:288
+#: ../src/msw/dde.cpp:283
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Zlyhalo zaregistrovanie DDE serveru '%s'"
 
-#: ../src/common/fontmap.cpp:245
+#: ../src/gtk/font.cpp:580
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "Zlyhala aktualizácia používateľského konfiguračného súboru."
+
+#: ../src/common/fontmap.cpp:242
 #, c-format
 msgid "Failed to remember the encoding for the charset '%s'."
 msgstr "Zlyhalo zapamätanie kódovania znakovej sady '%s'."
 
-#: ../src/common/debugrpt.cpp:227
+#: ../src/common/debugrpt.cpp:228
 #, c-format
 msgid "Failed to remove debug report file \"%s\""
 msgstr "Zlyhalo odstránenie súboru hlásenia o chybe '%s'"
 
-#: ../src/unix/snglinst.cpp:328
+#: ../src/unix/snglinst.cpp:325
 #, c-format
 msgid "Failed to remove lock file '%s'"
 msgstr "Zlyhalo odstránenie súboru zámku '%s'"
 
-#: ../src/unix/snglinst.cpp:288
+#: ../src/unix/snglinst.cpp:285
 #, c-format
 msgid "Failed to remove stale lock file '%s'."
 msgstr "Zlyhalo odstránenie starého súboru zámku '%s'."
 
-#: ../src/msw/registry.cpp:529
+#: ../src/msw/registry.cpp:518
 #, c-format
 msgid "Failed to rename registry value '%s' to '%s'."
 msgstr "Zlyhalo premenovanie hodnoty registra '%s' na '%s'."
 
-#: ../src/common/filefn.cpp:1122
+#: ../src/common/filefn.cpp:1011
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -3532,116 +3595,125 @@ msgstr ""
 "Zlyhalo premenovanie súboru '%s' na '%s', pretože cieľový názov súboru už "
 "existuje."
 
-#: ../src/msw/registry.cpp:634
+#: ../src/msw/registry.cpp:623
 #, c-format
 msgid "Failed to rename the registry key '%s' to '%s'."
 msgstr "Zlyhalo premenovanie kľúča registra '%s' na '%s'."
 
-#: ../src/common/filename.cpp:2671
+#: ../src/msw/webview_ie.cpp:995
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/common/filename.cpp:2754
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Zlyhalo získanie čas súboru '%s'"
 
-#: ../src/msw/dialup.cpp:468
+#: ../src/msw/dialup.cpp:462
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Zlyhalo získanie textu chybovej správy RAS"
 
-#: ../src/msw/clipbrd.cpp:748
+#: ../src/msw/clipbrd.cpp:768
 msgid "Failed to retrieve the supported clipboard formats"
 msgstr "Zlyhalo získanie podporovaných formátov schránky"
 
-#: ../src/common/docview.cpp:652
+#: ../src/common/docview.cpp:647
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Zlyhalo uloženie dokumentu do súboru '%s'."
 
-#: ../src/msw/dib.cpp:269
+#: ../src/msw/dib.cpp:312
 #, c-format
 msgid "Failed to save the bitmap image to file \"%s\"."
 msgstr "Zlyhalo uloženie bitmapového obrázku do súboru '%s'."
 
-#: ../src/msw/dde.cpp:763
+#: ../src/msw/dde.cpp:811
 msgid "Failed to send DDE advise notification"
 msgstr "Zlyhalo zaslanie DDE oznámenia"
 
-#: ../src/common/ftp.cpp:402
+#: ../src/common/ftp.cpp:399
 #, c-format
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Zlyhalo nastavenie FTP prenosového režimu na %s."
 
-#: ../src/msw/clipbrd.cpp:427
+#: ../src/msw/clipbrd.cpp:443
 msgid "Failed to set clipboard data."
 msgstr "Zlyhalo nastavenie údajov do schránky."
 
-#: ../src/unix/snglinst.cpp:181
+#: ../src/unix/snglinst.cpp:178
 #, c-format
 msgid "Failed to set permissions on lock file '%s'"
 msgstr "Zlyhalo nastavenie oprávnenia súboru zámku '%s'"
 
-#: ../src/unix/utilsunx.cpp:668
+#: ../src/unix/utilsunx.cpp:670
 msgid "Failed to set process priority"
 msgstr "Zlyhalo nastavenie priority procesu"
 
-#: ../src/common/file.cpp:559
+#: ../src/common/ffile.cpp:355 ../src/common/file.cpp:586
 msgid "Failed to set temporary file permissions"
 msgstr "Zlyhalo nastavenie oprávnenia dočasného súboru"
 
-#: ../src/gtk/textctrl.cpp:1072
-msgid "Failed to set text in the text control."
-msgstr "Zlyhalo nastavenie textu textového ovládacieho prvku."
-
-#: ../src/unix/threadpsx.cpp:1298
+#: ../src/unix/threadpsx.cpp:1347
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Zlyhalo nastavenie úrovne súbežnosti vlákna na %lu"
 
-#: ../src/unix/threadpsx.cpp:1424
+#: ../src/unix/threadpsx.cpp:1473
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Zlyhalo nastavenie priority vlákna %d."
 
-#: ../src/unix/utilsunx.cpp:783
+#: ../src/unix/utilsunx.cpp:785
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 "Zlyhalo nastavenie neblokujúceho potrubia, program môže prestať reagovať."
 
-#: ../src/common/fs_mem.cpp:261
+#: ../src/msw/webview_ie.cpp:987
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:256
 #, c-format
 msgid "Failed to store image '%s' to memory VFS!"
 msgstr "Zlyhalo uloženie obrázok '%s' do pamäte VFS!"
 
-#: ../src/dfb/evtloop.cpp:170
+#: ../src/dfb/evtloop.cpp:171
 msgid "Failed to switch DirectFB pipe to non-blocking mode"
 msgstr "Zlyhalo prepnutie potrubia DirectFB do neblokujúceho režimu"
 
-#: ../src/unix/wakeuppipe.cpp:59
+#: ../src/unix/wakeuppipe.cpp:56
 msgid "Failed to switch wake up pipe to non-blocking mode"
 msgstr "Zlyhalo prepnutie prebudenia potrubia do neblokujúceho režimu"
 
-#: ../src/unix/threadpsx.cpp:1605
+#: ../src/unix/threadpsx.cpp:1654
 msgid "Failed to terminate a thread."
 msgstr "Zlyhalo ukončenie vlákna."
 
-#: ../src/msw/dde.cpp:741
+#: ../src/msw/dde.cpp:736
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "Zlyhalo ukončenie pomocného spojenia s DDE serverom"
 
-#: ../src/msw/dialup.cpp:938
+#: ../src/msw/dialup.cpp:932
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Zlyhalo ukončenie vytáčaného spojenia: %s"
 
-#: ../src/common/filename.cpp:2590
+#: ../src/common/filename.cpp:2673
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Zlyhal styk so súborom '%s'"
 
-#: ../src/unix/snglinst.cpp:334
+#: ../src/unix/dlunix.cpp:90
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "Zlyhalo načítanie zdieľanej knižnice '%s'"
+
+#: ../src/unix/snglinst.cpp:331
 #, c-format
 msgid "Failed to unlock lock file '%s'"
 msgstr "Zlyhalo odomknutie súboru zámku '%s'"
 
-#: ../src/msw/dde.cpp:309
+#: ../src/msw/dde.cpp:304
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Zlyhalo zrušenie registrácie DDE servera '%s'"
@@ -3655,77 +3727,87 @@ msgstr "Zlyhalo zrušenie registrácie popisovača %d z popisovača epoll %d"
 msgid "Failed to update user configuration file."
 msgstr "Zlyhala aktualizácia používateľského konfiguračného súboru."
 
-#: ../src/common/debugrpt.cpp:733
+#: ../src/common/debugrpt.cpp:743
 #, c-format
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Zlyhalo vynovenie hlásenia o chybe (chybový kód %d)."
 
-#: ../src/unix/snglinst.cpp:168
+#: ../src/unix/snglinst.cpp:165
 #, c-format
 msgid "Failed to write to lock file '%s'"
 msgstr "Zlyhalo zapísanie súboru zámku '%s'"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:209
+#: ../src/propgrid/propgrid.cpp:190
 msgid "False"
 msgstr "Nepravda"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:694
+#: ../src/propgrid/advprops.cpp:604
 msgid "Family"
 msgstr "Rodina"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/gtk/glcanvas.cpp:176 ../src/gtk/glcanvas.cpp:187
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Osudová chyba"
+
+#: ../src/common/stockitem.cpp:154
 msgid "File"
 msgstr "Súbor"
 
-#: ../src/common/docview.cpp:669
+#: ../src/common/docview.cpp:664
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Zlyhalo otvorenie súboru '%s' na čítanie."
 
-#: ../src/common/docview.cpp:646
+#: ../src/common/docview.cpp:641
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Zlyhalo otvorenie súboru '%s' na zápis."
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "Súbor '%s' už existuje, naozaj ho chcete prepísať?"
 
-#: ../src/common/filefn.cpp:1156
+#: ../src/common/filefn.cpp:1044
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Súbor '%s' sa nepodarilo odstrániť"
 
-#: ../src/common/filefn.cpp:1139
+#: ../src/common/filefn.cpp:1028
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Súbor '%s' nemožno premenovať na '%s'"
 
-#: ../src/richtext/richtextctrl.cpp:3081 ../src/common/textcmn.cpp:953
+#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
 msgid "File couldn't be loaded."
 msgstr "Súbor nmožno načítať."
 
-#: ../src/msw/filedlg.cpp:393
+#: ../src/msw/filedlg.cpp:414
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Súborový dialóg zlyhal s kódom chyby %0lx."
 
-#: ../src/common/docview.cpp:1789
+#: ../src/common/docview.cpp:1783
 msgid "File error"
 msgstr "Chyba súboru"
 
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/filectrlg.cpp:770
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/filectrlg.cpp:766
 msgid "File name exists already."
 msgstr "Názov súboru už existuje."
+
+#: ../src/osx/cocoa/filedlg.mm:264
+#, fuzzy
+msgid "File type:"
+msgstr "Ďalekopis"
 
 #: ../src/motif/filedlg.cpp:220
 msgid "Files"
 msgstr "Súbory"
 
-#: ../src/common/filefn.cpp:1591
+#: ../src/common/filefn.cpp:1479
 #, c-format
 msgid "Files (%s)"
 msgstr "Súborov (%s)"
@@ -3734,15 +3816,29 @@ msgstr "Súborov (%s)"
 msgid "Filter"
 msgstr "Filter"
 
-#: ../src/common/stockitem.cpp:158 ../src/html/helpwnd.cpp:490
+#: ../src/html/helpwnd.cpp:488
 msgid "Find"
 msgstr "Hľadať"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:259
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:258
+#, fuzzy
+msgid "Find in document"
+msgstr "Otvorte dokument HTML"
+
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "Find..."
+msgstr "Hľadať"
+
+#: ../src/common/stockitem.cpp:156
 msgid "First"
 msgstr "Prvá"
 
-#: ../src/common/prntbase.cpp:1548
+#: ../src/common/prntbase.cpp:1573
 msgid "First page"
 msgstr "Prvá stránka"
 
@@ -3750,11 +3846,11 @@ msgstr "Prvá stránka"
 msgid "Fixed"
 msgstr "Pevné"
 
-#: ../src/html/helpwnd.cpp:1206
+#: ../src/html/helpwnd.cpp:1204
 msgid "Fixed font:"
 msgstr "Písmo s pevnou šírkou:"
 
-#: ../src/html/helpwnd.cpp:1269
+#: ../src/html/helpwnd.cpp:1267
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Písmo s pevnou šírkou.<br> <b>tučné</b> <i>kurzíva</i> "
 
@@ -3762,16 +3858,16 @@ msgstr "Písmo s pevnou šírkou.<br> <b>tučné</b> <i>kurzíva</i> "
 msgid "Floating"
 msgstr "Plávajúce"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "Floppy"
 msgstr "Disketa"
 
-#: ../src/common/paper.cpp:111
+#: ../src/common/paper.cpp:108
 msgid "Folio, 8 1/2 x 13 in"
 msgstr "Folio, 8 1/2 x 13 in"
 
-#: ../src/richtext/richtextformatdlg.cpp:344 ../src/osx/carbon/fontdlg.cpp:287
-#: ../src/common/stockitem.cpp:194
+#: ../src/osx/carbon/fontdlg.cpp:284 ../src/common/stockitem.cpp:191
+#: ../src/richtext/richtextformatdlg.cpp:337
 msgid "Font"
 msgstr "Písmo"
 
@@ -3779,7 +3875,24 @@ msgstr "Písmo"
 msgid "Font &weight:"
 msgstr "&Hrúbka písma:"
 
-#: ../src/html/helpwnd.cpp:1207
+#: ../src/osx/fontutil.cpp:89
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
+"\"."
+msgstr ""
+
+#: ../src/msw/font.cpp:1126
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Súbor nmožno načítať."
+
+#: ../src/osx/fontutil.cpp:81
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "Súbor %s neexistuje."
+
+#: ../src/html/helpwnd.cpp:1205
 msgid "Font size:"
 msgstr "Veľkosť písma:"
 
@@ -3787,53 +3900,53 @@ msgstr "Veľkosť písma:"
 msgid "Font st&yle:"
 msgstr "Š&týl písma:"
 
-#: ../src/osx/carbon/fontdlg.cpp:329
+#: ../src/osx/carbon/fontdlg.cpp:326
 msgid "Font:"
 msgstr "Písmo:"
 
-#: ../src/dfb/fontmgr.cpp:198
+#: ../src/dfb/fontmgr.cpp:195
 #, c-format
 msgid "Fonts index file %s disappeared while loading fonts."
 msgstr "Počas načítania písma zmizol indexový súbor typov písma %s."
 
-#: ../src/unix/utilsunx.cpp:645
+#: ../src/unix/utilsunx.cpp:647
 msgid "Fork failed"
 msgstr "Zlyhala vidlica"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "Forward"
 msgstr "Spredu"
 
-#: ../src/common/xtixml.cpp:235
+#: ../src/common/xtixml.cpp:231
 msgid "Forward hrefs are not supported"
 msgstr "Predné href odkazy nie sú podporované"
 
-#: ../src/html/helpwnd.cpp:875
+#: ../src/html/helpwnd.cpp:873
 #, c-format
 msgid "Found %i matches"
 msgstr "Nájdených %i zhôd"
 
-#: ../src/generic/prntdlgg.cpp:238
+#: ../src/generic/prntdlgg.cpp:231
 msgid "From:"
 msgstr "Od:"
 
-#: ../src/propgrid/advprops.cpp:1604
+#: ../src/propgrid/advprops.cpp:1510
 msgid "Fuchsia"
 msgstr "Červeno fialová"
 
-#: ../src/common/imaggif.cpp:138
+#: ../src/common/imaggif.cpp:135
 msgid "GIF: data stream seems to be truncated."
 msgstr "GIF: zdá sa, že údajový prúd bol prerušený."
 
-#: ../src/common/imaggif.cpp:128
+#: ../src/common/imaggif.cpp:125
 msgid "GIF: error in GIF image format."
 msgstr "GIF: chyba vo formáte obrázka GIF."
 
-#: ../src/common/imaggif.cpp:133
+#: ../src/common/imaggif.cpp:130
 msgid "GIF: not enough memory."
 msgstr "GIF: nedostatok pamäte."
 
-#: ../src/gtk/window.cpp:4631
+#: ../src/gtk/window.cpp:5635
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -3841,23 +3954,23 @@ msgstr ""
 "GTK + nainštalovaný v tomto počítači je príliš starý na to, aby podporoval "
 "vytváranie obrazoviek, nainštalujte si GTK + 2.12 alebo novší."
 
-#: ../src/univ/themes/gtk.cpp:525
+#: ../src/univ/themes/gtk.cpp:522
 msgid "GTK+ theme"
 msgstr "Téma GTK+"
 
-#: ../src/common/preferencescmn.cpp:40
+#: ../src/common/preferencescmn.cpp:37
 msgid "General"
 msgstr "Všeobecné"
 
-#: ../src/common/prntbase.cpp:258
+#: ../src/common/prntbase.cpp:253
 msgid "Generic PostScript"
 msgstr "Všeobecný PostScript"
 
-#: ../src/common/paper.cpp:135
+#: ../src/common/paper.cpp:132
 msgid "German Legal Fanfold, 8 1/2 x 13 in"
 msgstr "German Legal Fanfold, 8 1/2 x 13 in"
 
-#: ../src/common/paper.cpp:134
+#: ../src/common/paper.cpp:131
 msgid "German Std Fanfold, 8 1/2 x 12 in"
 msgstr "German Std Fanfold, 8 1/2 x 12 in"
 
@@ -3873,48 +3986,48 @@ msgstr "GetPropertyCollection volá všeobecný objekt príslušenstva"
 msgid "GetPropertyCollection called w/o valid collection getter"
 msgstr "GetPropertyCollection volá w/o platný getter kolekcie"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:658
 msgid "Go back"
 msgstr "Ísť späť"
 
-#: ../src/html/helpwnd.cpp:661
+#: ../src/html/helpwnd.cpp:659
 msgid "Go forward"
 msgstr "Ísť vpred"
 
-#: ../src/html/helpwnd.cpp:663
+#: ../src/html/helpwnd.cpp:661
 msgid "Go one level up in document hierarchy"
 msgstr "Ísť o úroveň vyššie v hierarchii dokumentov"
 
-#: ../src/generic/filedlgg.cpp:208 ../src/generic/dirdlgg.cpp:116
+#: ../src/generic/filedlgg.cpp:205 ../src/generic/dirdlgg.cpp:113
 msgid "Go to home directory"
 msgstr "Ísť do domáceho priečinka"
 
-#: ../src/generic/filedlgg.cpp:205
+#: ../src/generic/filedlgg.cpp:202
 msgid "Go to parent directory"
 msgstr "Ísť do nadradeného priečinka"
 
-#: ../src/generic/aboutdlgg.cpp:76
+#: ../src/generic/aboutdlgg.cpp:73
 msgid "Graphics art by "
 msgstr "Grafické umenie podľa "
 
-#: ../src/propgrid/advprops.cpp:1599
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Gray"
 msgstr "Sivá"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:883
+#: ../src/propgrid/advprops.cpp:784
 msgid "GrayText"
 msgstr "Sivý text"
 
-#: ../src/common/fmapbase.cpp:154
+#: ../src/common/fmapbase.cpp:151
 msgid "Greek (ISO-8859-7)"
 msgstr "Grécke (ISO-8859-7)"
 
-#: ../src/propgrid/advprops.cpp:1600
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Green"
 msgstr "Zelená"
 
-#: ../src/generic/colrdlgg.cpp:342
+#: ../src/generic/colrdlgg.cpp:362
 msgid "Green:"
 msgstr "Zelená:"
 
@@ -3922,107 +4035,107 @@ msgstr "Zelená:"
 msgid "Groove"
 msgstr "Drážka"
 
-#: ../src/common/zstream.cpp:158 ../src/common/zstream.cpp:318
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
 msgid "Gzip not supported by this version of zlib"
 msgstr "Táto verzia zlib nepodporuje Gzip"
 
-#: ../src/html/helpwnd.cpp:1549
+#: ../src/html/helpwnd.cpp:1547
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "HTML Help Project (*.hhp)|*.hhp|"
 
-#: ../src/html/htmlwin.cpp:681
+#: ../src/html/htmlwin.cpp:691
 #, c-format
 msgid "HTML anchor %s does not exist."
 msgstr "HTML kotva %s neexistuje."
 
-#: ../src/html/helpwnd.cpp:1547
+#: ../src/html/helpwnd.cpp:1545
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "HTML súbory (*.html;*.htm)|*.html;*.htm|"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1759
+#: ../src/propgrid/advprops.cpp:1660
 msgid "Hand"
 msgstr "Ruka"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "Harddisk"
 msgstr "Pevný disk"
 
-#: ../src/common/fmapbase.cpp:155
+#: ../src/common/fmapbase.cpp:152
 msgid "Hebrew (ISO-8859-8)"
 msgstr "Hebrejské (ISO-8859-8)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:280 ../src/osx/button_osx.cpp:39
-#: ../src/common/stockitem.cpp:163 ../src/common/accelcmn.cpp:80
-#: ../src/html/helpdlg.cpp:66 ../src/html/helpfrm.cpp:111
+#: ../include/wx/msgdlg.h:282 ../src/osx/button_osx.cpp:39
+#: ../src/common/stockitem.cpp:160 ../src/common/accelcmn.cpp:77
+#: ../src/html/helpfrm.cpp:108 ../src/html/helpdlg.cpp:63
 msgid "Help"
 msgstr "Pomocník"
 
-#: ../src/html/helpwnd.cpp:1200
+#: ../src/html/helpwnd.cpp:1198
 msgid "Help Browser Options"
 msgstr "Možnosti prehliadača Pomocníka"
 
-#: ../src/generic/helpext.cpp:454 ../src/generic/helpext.cpp:455
+#: ../src/generic/helpext.cpp:452 ../src/generic/helpext.cpp:453
 msgid "Help Index"
 msgstr "Index Pomocníka"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1529
 msgid "Help Printing"
 msgstr "Pomocník pre tlač"
 
-#: ../src/html/helpwnd.cpp:801
+#: ../src/html/helpwnd.cpp:799
 msgid "Help Topics"
 msgstr "Témy Pomocníka"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1546
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Knihy Pomocníka (*.htb)|*.htb|Knihy Pomocníka (*.zip)|*.zip|"
 
-#: ../src/generic/helpext.cpp:267
+#: ../src/generic/helpext.cpp:265
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "Priečinok Pomocníka '%s' nenájdený."
 
-#: ../src/generic/helpext.cpp:275
+#: ../src/generic/helpext.cpp:273
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "Súbor Pomocníka '%s' nenájdený."
 
-#: ../src/html/helpctrl.cpp:63
+#: ../src/html/helpctrl.cpp:59
 #, c-format
 msgid "Help: %s"
 msgstr "Pomocník: %s"
 
-#: ../src/osx/menu_osx.cpp:577
+#: ../src/osx/menu_osx.cpp:469
 #, c-format
 msgid "Hide %s"
 msgstr "Skryť %s"
 
-#: ../src/osx/menu_osx.cpp:579
+#: ../src/osx/menu_osx.cpp:471
 msgid "Hide Others"
 msgstr "Skryť ostatné"
 
-#: ../src/generic/infobar.cpp:84
+#: ../src/generic/infobar.cpp:81
 msgid "Hide this notification message."
 msgstr "Skryť túto správu s upozornením."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:884
+#: ../src/propgrid/advprops.cpp:785
 msgid "Highlight"
 msgstr "Zvýraznenie"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:885
+#: ../src/propgrid/advprops.cpp:786
 msgid "HighlightText"
 msgstr "Zvýrazniť text"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:164 ../src/common/accelcmn.cpp:65
+#: ../src/common/stockitem.cpp:161 ../src/common/accelcmn.cpp:62
 msgid "Home"
 msgstr "Domov"
 
-#: ../src/generic/dirctrlg.cpp:524
+#: ../src/generic/dirctrlg.cpp:490
 msgid "Home directory"
 msgstr "Domáci priečinok"
 
@@ -4032,55 +4145,55 @@ msgid "How the object will float relative to the text."
 msgstr "Ako sa bude objekt pohybovať vo vzťahu k textu."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1760
+#: ../src/propgrid/advprops.cpp:1661
 msgid "I-Beam"
 msgstr "I-Beam"
 
-#: ../src/common/imagbmp.cpp:1196
+#: ../src/common/imagbmp.cpp:1208
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: Chyba pri čítaní masky DIB."
 
-#: ../src/common/imagbmp.cpp:1290 ../src/common/imagbmp.cpp:1390
-#: ../src/common/imagbmp.cpp:1405 ../src/common/imagbmp.cpp:1416
-#: ../src/common/imagbmp.cpp:1430 ../src/common/imagbmp.cpp:1478
-#: ../src/common/imagbmp.cpp:1493 ../src/common/imagbmp.cpp:1507
-#: ../src/common/imagbmp.cpp:1518
+#: ../src/common/imagbmp.cpp:1302 ../src/common/imagbmp.cpp:1402
+#: ../src/common/imagbmp.cpp:1417 ../src/common/imagbmp.cpp:1428
+#: ../src/common/imagbmp.cpp:1442 ../src/common/imagbmp.cpp:1490
+#: ../src/common/imagbmp.cpp:1505 ../src/common/imagbmp.cpp:1519
+#: ../src/common/imagbmp.cpp:1530
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: Chyba pri zapisovaní súboru obrázka!"
 
-#: ../src/common/imagbmp.cpp:1255
+#: ../src/common/imagbmp.cpp:1267
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: Obrázok je na ikonu príliš vysoký."
 
-#: ../src/common/imagbmp.cpp:1263
+#: ../src/common/imagbmp.cpp:1275
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: Obrázok je na ikonu príliš široký."
 
-#: ../src/common/imagbmp.cpp:1603
+#: ../src/common/imagbmp.cpp:1615
 msgid "ICO: Invalid icon index."
 msgstr "ICO: Neplatný index ikony."
 
-#: ../src/common/imagiff.cpp:758
+#: ../src/common/imagiff.cpp:755
 msgid "IFF: data stream seems to be truncated."
 msgstr "IFF: zdá sa, že dátový tok bol prerušený."
 
-#: ../src/common/imagiff.cpp:742
+#: ../src/common/imagiff.cpp:739
 msgid "IFF: error in IFF image format."
 msgstr "IFF: chyba v IFF formáte obrázka."
 
-#: ../src/common/imagiff.cpp:745
+#: ../src/common/imagiff.cpp:742
 msgid "IFF: not enough memory."
 msgstr "IFF: nedostatok pamäte."
 
-#: ../src/common/imagiff.cpp:748
+#: ../src/common/imagiff.cpp:745
 msgid "IFF: unknown error!!!"
 msgstr "IFF: neznáma chyba!!!"
 
-#: ../src/common/fmapbase.cpp:197
+#: ../src/common/fmapbase.cpp:194
 msgid "ISO-2022-JP"
 msgstr "ISO-2022-JP"
 
-#: ../src/html/htmprint.cpp:282
+#: ../src/html/htmprint.cpp:294
 msgid ""
 "If possible, try changing the layout parameters to make the printout more "
 "narrow."
@@ -4088,7 +4201,7 @@ msgstr ""
 "Ak je to možné, pokúste sa zmeniť parametre rozloženia, aby sa vytvoril "
 "výtlačok čo najužší."
 
-#: ../src/generic/dbgrptg.cpp:358
+#: ../src/generic/dbgrptg.cpp:362
 msgid ""
 "If you have any additional information pertaining to this bug\n"
 "report, please enter it here and it will be joined to it:"
@@ -4109,46 +4222,50 @@ msgstr ""
 "to\n"
 "možné, pokračujte, prosím, v tvorbe hlásenia o chybe.\n"
 
-#: ../src/msw/registry.cpp:1405
+#: ../src/common/zipstrm.cpp:1043
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1393
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Ignorovanie hodnoty '%s' kľúča '%s'."
 
-#: ../src/common/xtistrm.cpp:295
+#: ../src/common/xtistrm.cpp:292
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Trieda nelegálneho objektu (Non-wxEvtHandler) ako zdroj udalosti"
 
-#: ../src/common/xti.cpp:513
+#: ../src/common/xti.cpp:510
 msgid "Illegal Parameter Count for ConstructObject Method"
 msgstr "Počet nelegálnych parametrov pre metódu ConstructObject"
 
-#: ../src/common/xti.cpp:501
+#: ../src/common/xti.cpp:498
 msgid "Illegal Parameter Count for Create Method"
 msgstr "Počet nelegálnych parametrov pre metódu vytvorenia"
 
-#: ../src/generic/dirctrlg.cpp:570 ../src/generic/filectrlg.cpp:756
+#: ../src/generic/dirctrlg.cpp:536 ../src/generic/filectrlg.cpp:752
 msgid "Illegal directory name."
 msgstr "Neplatný názov adresára."
 
-#: ../src/generic/filectrlg.cpp:1367
+#: ../src/generic/filectrlg.cpp:1356
 msgid "Illegal file specification."
 msgstr "Neplatná špecifikácia súboru."
 
-#: ../src/common/image.cpp:2269
+#: ../src/common/image.cpp:2363
 msgid "Image and mask have different sizes."
 msgstr "Obrázok a maska majú rôzne veľkosti."
 
-#: ../src/common/image.cpp:2746
+#: ../src/common/image.cpp:2841
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "Súbor obrázka nie je typu %d."
 
-#: ../src/common/image.cpp:2877
+#: ../src/common/image.cpp:2995
 #, c-format
 msgid "Image is not of type %s."
 msgstr "Obrázok nie je typu %s."
 
-#: ../src/msw/textctrl.cpp:488
+#: ../src/msw/textctrl.cpp:534
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -4156,100 +4273,100 @@ msgstr ""
 "Nemožno vytvoriť ovládací prvok formátu RTF použitím jednoduchého "
 "ovládacieho prvku textu. Preinštalujte, prosím, riched32.dll"
 
-#: ../src/unix/utilsunx.cpp:301
+#: ../src/unix/utilsunx.cpp:303
 msgid "Impossible to get child process input"
 msgstr "Nemožno získať podradený vstup procesu"
 
-#: ../src/common/filefn.cpp:1028
+#: ../src/common/filefn.cpp:917
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Nemožno získať povolenia pre súbor '%s'"
 
-#: ../src/common/filefn.cpp:1042
+#: ../src/common/filefn.cpp:931
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Nemožno prepísať súbor '%s'"
 
-#: ../src/common/filefn.cpp:1097
+#: ../src/common/filefn.cpp:986
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Nemožno nastaviť povolenia pre súbor '%s'"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:886
+#: ../src/propgrid/advprops.cpp:787
 msgid "InactiveBorder"
 msgstr "Neaktívny okraj"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:887
+#: ../src/propgrid/advprops.cpp:788
 msgid "InactiveCaption"
 msgstr "Neaktívny popisok"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:888
+#: ../src/propgrid/advprops.cpp:789
 msgid "InactiveCaptionText"
 msgstr "Neaktívny text popisku"
 
-#: ../src/common/gifdecod.cpp:792
+#: ../src/common/gifdecod.cpp:826
 #, c-format
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "Nekorektná veľkosť snímky GIF (%u, %d) pre snímku #%u"
 
-#: ../src/msw/ole/automtn.cpp:635
+#: ../src/msw/ole/automtn.cpp:626
 msgid "Incorrect number of arguments."
 msgstr "Nekorektný počet argumentov."
 
-#: ../src/common/stockitem.cpp:165
+#: ../src/common/stockitem.cpp:162
 msgid "Indent"
 msgstr "Odsadenie"
 
-#: ../src/richtext/richtextformatdlg.cpp:349
+#: ../src/richtext/richtextformatdlg.cpp:342
 msgid "Indents && Spacing"
 msgstr "Odsadenie && medzery"
 
-#: ../src/common/stockitem.cpp:166 ../src/html/helpwnd.cpp:515
+#: ../src/common/stockitem.cpp:163 ../src/html/helpwnd.cpp:513
 msgid "Index"
 msgstr "Index"
 
-#: ../src/common/fmapbase.cpp:159
+#: ../src/common/fmapbase.cpp:156
 msgid "Indian (ISO-8859-12)"
 msgstr "Indické (ISO-8859-12)"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "Info"
 msgstr "Informácia"
 
-#: ../src/common/init.cpp:287
+#: ../src/common/init.cpp:284
 msgid "Initialization failed in post init, aborting."
 msgstr "Inicializácia zlyhala v príspevku init, prerušuje sa."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:54
+#: ../src/common/accelcmn.cpp:51
 msgid "Ins"
 msgstr "Ins"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextsymboldlg.cpp:472 ../src/common/accelcmn.cpp:53
+#: ../src/common/accelcmn.cpp:50 ../src/richtext/richtextsymboldlg.cpp:469
 msgid "Insert"
 msgstr "Vložiť"
 
-#: ../src/richtext/richtextbuffer.cpp:8067
+#: ../src/richtext/richtextbuffer.cpp:8063
 msgid "Insert Field"
 msgstr "Vložiť pole"
 
-#: ../src/richtext/richtextbuffer.cpp:7978
-#: ../src/richtext/richtextbuffer.cpp:8936
+#: ../src/richtext/richtextbuffer.cpp:7974
+#: ../src/richtext/richtextbuffer.cpp:8934
 msgid "Insert Image"
 msgstr "Vložiť obrázok"
 
-#: ../src/richtext/richtextbuffer.cpp:8025
+#: ../src/richtext/richtextbuffer.cpp:8021
 msgid "Insert Object"
 msgstr "Vložiť objekt"
 
-#: ../src/richtext/richtextctrl.cpp:1286 ../src/richtext/richtextctrl.cpp:1494
-#: ../src/richtext/richtextbuffer.cpp:7822
-#: ../src/richtext/richtextbuffer.cpp:7852
-#: ../src/richtext/richtextbuffer.cpp:7894
+#: ../src/richtext/richtextbuffer.cpp:7818
+#: ../src/richtext/richtextbuffer.cpp:7848
+#: ../src/richtext/richtextbuffer.cpp:7890
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
 msgid "Insert Text"
 msgstr "Vložiť text"
 
@@ -4262,16 +4379,11 @@ msgstr "Vloží zalomenie stránky pred odsek."
 msgid "Inset"
 msgstr "Vložiť"
 
-#: ../src/gtk/app.cpp:425
-#, c-format
-msgid "Invalid GTK+ command line option, use \"%s --help\""
-msgstr "Neplatná možnosť príkazového riadku GTK+, použite príkaz \"%s --help\""
-
-#: ../src/common/imagtiff.cpp:311
+#: ../src/common/imagtiff.cpp:308
 msgid "Invalid TIFF image index."
 msgstr "Neplatný index obrázka TIFF."
 
-#: ../src/common/appcmn.cpp:273
+#: ../src/common/appcmn.cpp:294
 #, c-format
 msgid "Invalid display mode specification '%s'."
 msgstr "Neplatná špecifikácia režimu zobrazenia '%s'."
@@ -4281,246 +4393,250 @@ msgstr "Neplatná špecifikácia režimu zobrazenia '%s'."
 msgid "Invalid geometry specification '%s'"
 msgstr "Neplatná špecifikácia geometrie '%s'"
 
-#: ../src/unix/fswatcher_inotify.cpp:323
+#: ../src/unix/fswatcher_inotify.cpp:320
 #, c-format
 msgid "Invalid inotify event for \"%s\""
 msgstr "Neplatná udalosť inotifikácie pre dopyt '%s'"
 
-#: ../src/unix/snglinst.cpp:312
+#: ../src/unix/snglinst.cpp:309
 #, c-format
 msgid "Invalid lock file '%s'."
 msgstr "Neplatný súbor zámku '%s'."
 
-#: ../src/common/translation.cpp:1125
+#: ../src/common/translation.cpp:1167
 msgid "Invalid message catalog."
 msgstr "Neplatný katalóg správ."
 
-#: ../src/common/xtistrm.cpp:405 ../src/common/xtistrm.cpp:420
+#: ../src/common/xtistrm.cpp:402 ../src/common/xtistrm.cpp:417
 msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
 msgstr "GetObjectClassInfo bolo odoslané neplatné alebo nulové ID objektu"
 
-#: ../src/common/xtistrm.cpp:435
+#: ../src/common/xtistrm.cpp:432
 msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
 msgstr "HasObjectClassInfo sa odovzdalo neplatné alebo nulové ID objektu"
 
-#: ../src/common/regex.cpp:310
+#: ../src/common/regex.cpp:307
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Neplatný regulárny výraz '%s': %s"
 
-#: ../src/common/config.cpp:226
+#: ../src/common/config.cpp:222
 #, c-format
 msgid "Invalid value %ld for a boolean key \"%s\" in config file."
 msgstr "Neplatná hodnota %ld pre booleovský kľúč '%s' v konfiguračnom súbore."
 
-#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:351
-#: ../src/osx/carbon/fontdlg.cpp:361 ../src/common/stockitem.cpp:168
+#: ../src/osx/carbon/fontdlg.cpp:358 ../src/common/stockitem.cpp:165
+#: ../src/generic/fontdlgg.cpp:325 ../src/richtext/richtextfontpage.cpp:351
 msgid "Italic"
 msgstr "Kurzíva"
 
-#: ../src/common/paper.cpp:130
+#: ../src/common/paper.cpp:127
 msgid "Italy Envelope, 110 x 230 mm"
 msgstr "Talianska obálka, 110 x 230 mm"
 
-#: ../src/common/imagjpeg.cpp:270
+#: ../src/common/imagjpeg.cpp:257
 msgid "JPEG: Couldn't load - file is probably corrupted."
 msgstr "JPEG: Nemožno načítať - súbor je pravdepodobne poškodený."
 
-#: ../src/common/imagjpeg.cpp:449
+#: ../src/common/imagjpeg.cpp:436
 msgid "JPEG: Couldn't save image."
 msgstr "JPEG: Nemožno uložiť obrázok."
 
-#: ../src/common/paper.cpp:163
+#: ../src/common/paper.cpp:160
 msgid "Japanese Double Postcard 200 x 148 mm"
 msgstr "Japonská dvojitá pohľadnica 200 x 148 mm"
 
-#: ../src/common/paper.cpp:167
+#: ../src/common/paper.cpp:164
 msgid "Japanese Envelope Chou #3"
 msgstr "Japonská obálka Chou #3"
 
-#: ../src/common/paper.cpp:180
+#: ../src/common/paper.cpp:177
 msgid "Japanese Envelope Chou #3 Rotated"
 msgstr "Japonská obálka Chou #3 Rotated"
 
-#: ../src/common/paper.cpp:168
+#: ../src/common/paper.cpp:165
 msgid "Japanese Envelope Chou #4"
 msgstr "Japonská obálka Chou #4"
 
-#: ../src/common/paper.cpp:181
+#: ../src/common/paper.cpp:178
 msgid "Japanese Envelope Chou #4 Rotated"
 msgstr "Japonská obálka Chou #4 Rotated"
 
-#: ../src/common/paper.cpp:165
+#: ../src/common/paper.cpp:162
 msgid "Japanese Envelope Kaku #2"
 msgstr "Japonská obálka Kaku #2"
 
-#: ../src/common/paper.cpp:178
+#: ../src/common/paper.cpp:175
 msgid "Japanese Envelope Kaku #2 Rotated"
 msgstr "Japonská obálka Kaku #2 Rotated"
 
-#: ../src/common/paper.cpp:166
+#: ../src/common/paper.cpp:163
 msgid "Japanese Envelope Kaku #3"
 msgstr "Japonská obálka Kaku #3"
 
-#: ../src/common/paper.cpp:179
+#: ../src/common/paper.cpp:176
 msgid "Japanese Envelope Kaku #3 Rotated"
 msgstr "Japonská obálka Kaku #3 Rotated"
 
-#: ../src/common/paper.cpp:185
+#: ../src/common/paper.cpp:182
 msgid "Japanese Envelope You #4"
 msgstr "Japonská obálka You #4"
 
-#: ../src/common/paper.cpp:186
+#: ../src/common/paper.cpp:183
 msgid "Japanese Envelope You #4 Rotated"
 msgstr "Japonská obálka You #4 Rotated"
 
-#: ../src/common/paper.cpp:138
+#: ../src/common/paper.cpp:135
 msgid "Japanese Postcard 100 x 148 mm"
 msgstr "Japonská pohľadnica 100 x 148 mm"
 
-#: ../src/common/paper.cpp:175
+#: ../src/common/paper.cpp:172
 msgid "Japanese Postcard Rotated 148 x 100 mm"
 msgstr "Japonská pohľadnica Rotated 148 x 100 mm"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "Jump to"
 msgstr "Skoč na"
 
-#: ../src/common/stockitem.cpp:171
+#: ../src/common/stockitem.cpp:168
 msgid "Justified"
 msgstr "Zarovnaný"
 
-#: ../src/richtext/richtextindentspage.cpp:155
-#: ../src/richtext/richtextindentspage.cpp:157
 #: ../src/richtext/richtextliststylepage.cpp:344
 #: ../src/richtext/richtextliststylepage.cpp:346
+#: ../src/richtext/richtextindentspage.cpp:155
+#: ../src/richtext/richtextindentspage.cpp:157
 msgid "Justify text left and right."
 msgstr "Zarovná text doľava a doprava."
 
-#: ../src/common/fmapbase.cpp:163
+#: ../src/common/fmapbase.cpp:160
 msgid "KOI8-R"
 msgstr "KOI8-R"
 
-#: ../src/common/fmapbase.cpp:164
+#: ../src/common/fmapbase.cpp:161
 msgid "KOI8-U"
 msgstr "KOI8-U"
 
-#: ../src/common/accelcmn.cpp:265 ../src/common/accelcmn.cpp:347
+#: ../src/common/accelcmn.cpp:279 ../src/common/accelcmn.cpp:364
 msgid "KP_"
 msgstr "KP_"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "KP_Add"
 msgstr "KP_Add"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "KP_Begin"
 msgstr "KP_Begin"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "KP_Decimal"
 msgstr "KP_Decimal"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 msgid "KP_Delete"
 msgstr "KP_Delete"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "KP_Divide"
 msgstr "KP_Divide"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 msgid "KP_Down"
 msgstr "KP_Down"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "KP_End"
 msgstr "KP_End"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "KP_Enter"
 msgstr "KP_Enter"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "KP_Equal"
 msgstr "KP_Equal"
 
+#: ../src/common/accelcmn.cpp:276 ../src/common/accelcmn.cpp:361
+msgid "KP_F"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 msgid "KP_Home"
 msgstr "KP_Home"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 msgid "KP_Insert"
 msgstr "KP_Insert"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "KP_Left"
 msgstr "KP_Left"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "KP_Multiply"
 msgstr "KP_Multiply"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:99
+#: ../src/common/accelcmn.cpp:97
 msgid "KP_Next"
 msgstr "KP_Next"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "KP_PageDown"
 msgstr "KP_PageDown"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "KP_PageUp"
 msgstr "KP_PageUp"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:98
+#: ../src/common/accelcmn.cpp:96
 msgid "KP_Prior"
 msgstr "KP_Prior"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 msgid "KP_Right"
 msgstr "KP_Right"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "KP_Separator"
 msgstr "KP_Separator"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "KP_Space"
 msgstr "KP_Space"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "KP_Subtract"
 msgstr "KP_Subtract"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "KP_Tab"
 msgstr "KP_Tab"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "KP_Up"
 msgstr "KP_Up"
 
@@ -4528,19 +4644,34 @@ msgstr "KP_Up"
 msgid "L&ine spacing:"
 msgstr "&Riadkovanie:"
 
-#: ../src/generic/prntdlgg.cpp:613 ../src/generic/prntdlgg.cpp:868
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "chyba kompresie"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "chyba dekompresie"
+
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:861
 msgid "Landscape"
 msgstr "Krajinka"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "Last"
 msgstr "Posledná"
 
-#: ../src/common/prntbase.cpp:1572
+#: ../src/common/prntbase.cpp:1597
 msgid "Last page"
 msgstr "Posledná stránka"
 
-#: ../src/common/log.cpp:305
+#: ../src/common/log.cpp:324
 #, c-format
 msgid "Last repeated message (\"%s\", %u time) wasn't output"
 msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
@@ -4548,93 +4679,93 @@ msgstr[0] "Posledná opakovaná správa ('%s', %u krát) sa nevydala"
 msgstr[1] "Posledná opakovaná správa ('%s', %u krát) sa nevydala"
 msgstr[2] "Posledná opakovaná správa ('%s', %u krát) sa nevydala"
 
-#: ../src/common/paper.cpp:103
+#: ../src/common/paper.cpp:100
 msgid "Ledger, 17 x 11 in"
 msgstr "Ledger, 17 x 11 in"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6146
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:58 ../src/generic/datavgen.cpp:6951
+#: ../src/richtext/richtextsizepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:252
 #: ../src/richtext/richtextliststylepage.cpp:253
 #: ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
-#: ../src/richtext/richtextsizepage.cpp:249 ../src/common/accelcmn.cpp:61
 msgid "Left"
 msgstr "Zľava"
 
-#: ../src/richtext/richtextindentspage.cpp:204
 #: ../src/richtext/richtextliststylepage.cpp:390
+#: ../src/richtext/richtextindentspage.cpp:204
 msgid "Left (&first line):"
 msgstr "Zľava (&prvý riadok):"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1761
+#: ../src/propgrid/advprops.cpp:1662
 msgid "Left Button"
 msgstr "Ľavé tlačidlo"
 
-#: ../src/generic/prntdlgg.cpp:880
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Left margin (mm):"
 msgstr "Ľavý okraj (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:141
-#: ../src/richtext/richtextindentspage.cpp:143
 #: ../src/richtext/richtextliststylepage.cpp:330
 #: ../src/richtext/richtextliststylepage.cpp:332
+#: ../src/richtext/richtextindentspage.cpp:141
+#: ../src/richtext/richtextindentspage.cpp:143
 msgid "Left-align text."
 msgstr "Zarovnať text vľavo."
 
-#: ../src/common/paper.cpp:144
+#: ../src/common/paper.cpp:141
 msgid "Legal Extra 9 1/2 x 15 in"
 msgstr "Legal Extra 9 1/2 x 15 in"
 
-#: ../src/common/paper.cpp:96
+#: ../src/common/paper.cpp:93
 msgid "Legal, 8 1/2 x 14 in"
 msgstr "Legal, 8 1/2 x 14 in"
 
-#: ../src/common/paper.cpp:143
+#: ../src/common/paper.cpp:140
 msgid "Letter Extra 9 1/2 x 12 in"
 msgstr "List extra 9 1/2 x 12 in"
 
-#: ../src/common/paper.cpp:149
+#: ../src/common/paper.cpp:146
 msgid "Letter Extra Transverse 9.275 x 12 in"
 msgstr "List extra priečny 9.275 x 12 in"
 
-#: ../src/common/paper.cpp:152
+#: ../src/common/paper.cpp:149
 msgid "Letter Plus 8 1/2 x 12.69 in"
 msgstr "List plus 8 1/2 x 12.69 in"
 
-#: ../src/common/paper.cpp:169
+#: ../src/common/paper.cpp:166
 msgid "Letter Rotated 11 x 8 1/2 in"
 msgstr "List otočený 11 x 8 1/2 in"
 
-#: ../src/common/paper.cpp:101
+#: ../src/common/paper.cpp:98
 msgid "Letter Small, 8 1/2 x 11 in"
 msgstr "List malý, 8 1/2 x 11 in"
 
-#: ../src/common/paper.cpp:147
+#: ../src/common/paper.cpp:144
 msgid "Letter Transverse 8 1/2 x 11 in"
 msgstr "List priečny 8 1/2 x 11 in"
 
-#: ../src/common/paper.cpp:95
+#: ../src/common/paper.cpp:92
 msgid "Letter, 8 1/2 x 11 in"
 msgstr "List, 8 1/2 x 11 in"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "License"
 msgstr "Licencia"
 
-#: ../src/generic/fontdlgg.cpp:332
+#: ../src/generic/fontdlgg.cpp:328
 msgid "Light"
 msgstr "Svetlá"
 
-#: ../src/propgrid/advprops.cpp:1608
+#: ../src/propgrid/advprops.cpp:1514
 msgid "Lime"
 msgstr "Riadok"
 
-#: ../src/generic/helpext.cpp:294
+#: ../src/generic/helpext.cpp:292
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr "Riadok %lu mapového súboru '%s' má neplatnú syntax, preskočené."
@@ -4643,15 +4774,15 @@ msgstr "Riadok %lu mapového súboru '%s' má neplatnú syntax, preskočené."
 msgid "Line spacing:"
 msgstr "Riadkovanie:"
 
-#: ../src/html/chm.cpp:838
+#: ../src/html/chm.cpp:829
 msgid "Link contained '//', converted to absolute link."
 msgstr "Odkaz obsahoval '//' konvertovaný na absolútny odkaz."
 
-#: ../src/richtext/richtextformatdlg.cpp:364
+#: ../src/richtext/richtextformatdlg.cpp:357
 msgid "List Style"
 msgstr "Štýl zoznamu"
 
-#: ../src/richtext/richtextstyles.cpp:1064
+#: ../src/richtext/richtextstyles.cpp:1061
 msgid "List styles"
 msgstr "Štýly zoznamu"
 
@@ -4665,26 +4796,26 @@ msgstr "Zoznamy veľkosti písma v bodoch."
 msgid "Lists the available fonts."
 msgstr "Zoznamy dostupných typov písma."
 
-#: ../src/common/fldlgcmn.cpp:340
+#: ../src/common/fldlgcmn.cpp:337
 #, c-format
 msgid "Load %s file"
 msgstr "Načítať súbor %s"
 
-#: ../src/html/htmlwin.cpp:597
+#: ../src/html/htmlwin.cpp:600
 msgid "Loading : "
 msgstr "Načítanie: "
 
-#: ../src/unix/snglinst.cpp:246
+#: ../src/unix/snglinst.cpp:243
 #, c-format
 msgid "Lock file '%s' has incorrect owner."
 msgstr "Súbor zámku '%s' má nesprávneho vlastníka."
 
-#: ../src/unix/snglinst.cpp:251
+#: ../src/unix/snglinst.cpp:248
 #, c-format
 msgid "Lock file '%s' has incorrect permissions."
 msgstr "Súbor zámku '%s' má nesprávnepovolenia."
 
-#: ../src/generic/logg.cpp:576
+#: ../src/generic/logg.cpp:573
 #, c-format
 msgid "Log saved to the file '%s'."
 msgstr "Záznam bol uložený do súboru '%s'."
@@ -4699,11 +4830,11 @@ msgstr "Malé písmená"
 msgid "Lower case roman numerals"
 msgstr "Malé rímske číslice"
 
-#: ../src/gtk/mdi.cpp:422 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk1/mdi.cpp:431 ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "MDI potomok"
 
-#: ../src/msw/helpchm.cpp:56
+#: ../src/msw/helpchm.cpp:53
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -4711,189 +4842,189 @@ msgstr ""
 "Funkcie pomocníka MS HTML nie sú k dispozícii, pretože v tomto zariadení nie "
 "je nainštalovaná knižnica pomocníka MS HTML. Nainštalujte si ho."
 
-#: ../src/univ/themes/win32.cpp:3754
+#: ../src/univ/themes/win32.cpp:3751
 msgid "Ma&ximize"
 msgstr "Ma&ximalizovať"
 
-#: ../src/common/fmapbase.cpp:203
+#: ../src/common/fmapbase.cpp:200
 msgid "MacArabic"
 msgstr "MacArabic"
 
-#: ../src/common/fmapbase.cpp:222
+#: ../src/common/fmapbase.cpp:219
 msgid "MacArmenian"
 msgstr "MacArmenian"
 
-#: ../src/common/fmapbase.cpp:211
+#: ../src/common/fmapbase.cpp:208
 msgid "MacBengali"
 msgstr "MacBengali"
 
-#: ../src/common/fmapbase.cpp:217
+#: ../src/common/fmapbase.cpp:214
 msgid "MacBurmese"
 msgstr "MacBurmese"
 
-#: ../src/common/fmapbase.cpp:236
+#: ../src/common/fmapbase.cpp:233
 msgid "MacCeltic"
 msgstr "MacCeltic"
 
-#: ../src/common/fmapbase.cpp:227
+#: ../src/common/fmapbase.cpp:224
 msgid "MacCentralEurRoman"
 msgstr "MacCentralEurRoman"
 
-#: ../src/common/fmapbase.cpp:223
+#: ../src/common/fmapbase.cpp:220
 msgid "MacChineseSimp"
 msgstr "MacChineseSimp"
 
-#: ../src/common/fmapbase.cpp:201
+#: ../src/common/fmapbase.cpp:198
 msgid "MacChineseTrad"
 msgstr "MacChineseTrad"
 
-#: ../src/common/fmapbase.cpp:233
+#: ../src/common/fmapbase.cpp:230
 msgid "MacCroatian"
 msgstr "MacCroatian"
 
-#: ../src/common/fmapbase.cpp:206
+#: ../src/common/fmapbase.cpp:203
 msgid "MacCyrillic"
 msgstr "MacCyrillic"
 
-#: ../src/common/fmapbase.cpp:207
+#: ../src/common/fmapbase.cpp:204
 msgid "MacDevanagari"
 msgstr "MacDevanagari"
 
-#: ../src/common/fmapbase.cpp:231
+#: ../src/common/fmapbase.cpp:228
 msgid "MacDingbats"
 msgstr "MacDingbats"
 
-#: ../src/common/fmapbase.cpp:226
+#: ../src/common/fmapbase.cpp:223
 msgid "MacEthiopic"
 msgstr "MacEthiopic"
 
-#: ../src/common/fmapbase.cpp:229
+#: ../src/common/fmapbase.cpp:226
 msgid "MacExtArabic"
 msgstr "MacExtArabic"
 
-#: ../src/common/fmapbase.cpp:237
+#: ../src/common/fmapbase.cpp:234
 msgid "MacGaelic"
 msgstr "MacGaelic"
 
-#: ../src/common/fmapbase.cpp:221
+#: ../src/common/fmapbase.cpp:218
 msgid "MacGeorgian"
 msgstr "MacGeorgian"
 
-#: ../src/common/fmapbase.cpp:205
+#: ../src/common/fmapbase.cpp:202
 msgid "MacGreek"
 msgstr "MacGreek"
 
-#: ../src/common/fmapbase.cpp:209
+#: ../src/common/fmapbase.cpp:206
 msgid "MacGujarati"
 msgstr "MacGujarati"
 
-#: ../src/common/fmapbase.cpp:208
+#: ../src/common/fmapbase.cpp:205
 msgid "MacGurmukhi"
 msgstr "MacGurmukhi"
 
-#: ../src/common/fmapbase.cpp:204
+#: ../src/common/fmapbase.cpp:201
 msgid "MacHebrew"
 msgstr "MacHebrew"
 
-#: ../src/common/fmapbase.cpp:234
+#: ../src/common/fmapbase.cpp:231
 msgid "MacIcelandic"
 msgstr "MacIcelandic"
 
-#: ../src/common/fmapbase.cpp:200
+#: ../src/common/fmapbase.cpp:197
 msgid "MacJapanese"
 msgstr "MacJapanese"
 
-#: ../src/common/fmapbase.cpp:214
+#: ../src/common/fmapbase.cpp:211
 msgid "MacKannada"
 msgstr "MacKannada"
 
-#: ../src/common/fmapbase.cpp:238
+#: ../src/common/fmapbase.cpp:235
 msgid "MacKeyboardGlyphs"
 msgstr "MacKeyboardGlyphs"
 
-#: ../src/common/fmapbase.cpp:218
+#: ../src/common/fmapbase.cpp:215
 msgid "MacKhmer"
 msgstr "MacKhmer"
 
-#: ../src/common/fmapbase.cpp:202
+#: ../src/common/fmapbase.cpp:199
 msgid "MacKorean"
 msgstr "MacKorean"
 
-#: ../src/common/fmapbase.cpp:220
+#: ../src/common/fmapbase.cpp:217
 msgid "MacLaotian"
 msgstr "MacLaotian"
 
-#: ../src/common/fmapbase.cpp:215
+#: ../src/common/fmapbase.cpp:212
 msgid "MacMalayalam"
 msgstr "MacMalayalam"
 
-#: ../src/common/fmapbase.cpp:225
+#: ../src/common/fmapbase.cpp:222
 msgid "MacMongolian"
 msgstr "MacMongolian"
 
-#: ../src/common/fmapbase.cpp:210
+#: ../src/common/fmapbase.cpp:207
 msgid "MacOriya"
 msgstr "MacOriya"
 
-#: ../src/common/fmapbase.cpp:199
+#: ../src/common/fmapbase.cpp:196
 msgid "MacRoman"
 msgstr "MacRoman"
 
-#: ../src/common/fmapbase.cpp:235
+#: ../src/common/fmapbase.cpp:232
 msgid "MacRomanian"
 msgstr "MacRomanian"
 
-#: ../src/common/fmapbase.cpp:216
+#: ../src/common/fmapbase.cpp:213
 msgid "MacSinhalese"
 msgstr "MacSinhalese"
 
-#: ../src/common/fmapbase.cpp:230
+#: ../src/common/fmapbase.cpp:227
 msgid "MacSymbol"
 msgstr "MacSymbol"
 
-#: ../src/common/fmapbase.cpp:212
+#: ../src/common/fmapbase.cpp:209
 msgid "MacTamil"
 msgstr "MacTamil"
 
-#: ../src/common/fmapbase.cpp:213
+#: ../src/common/fmapbase.cpp:210
 msgid "MacTelugu"
 msgstr "MacTelugu"
 
-#: ../src/common/fmapbase.cpp:219
+#: ../src/common/fmapbase.cpp:216
 msgid "MacThai"
 msgstr "MacThai"
 
-#: ../src/common/fmapbase.cpp:224
+#: ../src/common/fmapbase.cpp:221
 msgid "MacTibetan"
 msgstr "MacTibetan"
 
-#: ../src/common/fmapbase.cpp:232
+#: ../src/common/fmapbase.cpp:229
 msgid "MacTurkish"
 msgstr "MacTurkish"
 
-#: ../src/common/fmapbase.cpp:228
+#: ../src/common/fmapbase.cpp:225
 msgid "MacVietnamese"
 msgstr "MacVietnamese"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1762
+#: ../src/propgrid/advprops.cpp:1663
 msgid "Magnifier"
 msgstr "Zväčšovač"
 
-#: ../src/propgrid/advprops.cpp:2143
+#: ../src/propgrid/advprops.cpp:2050
 msgid "Make a selection:"
 msgstr "Vytvoriť výber:"
 
-#: ../src/richtext/richtextformatdlg.cpp:374
+#: ../src/richtext/richtextformatdlg.cpp:367
 #: ../src/richtext/richtextmarginspage.cpp:171
 msgid "Margins"
 msgstr "Okraje"
 
-#: ../src/propgrid/advprops.cpp:1595
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Maroon"
 msgstr "Gaštanová"
 
-#: ../src/generic/fdrepdlg.cpp:147
+#: ../src/generic/fdrepdlg.cpp:144
 msgid "Match case"
 msgstr "Rozlišovať malé/veľké"
 
@@ -4905,40 +5036,40 @@ msgstr "Max. výška:"
 msgid "Max width:"
 msgstr "Max. šírka:"
 
-#: ../src/unix/mediactrl.cpp:947
+#: ../src/unix/mediactrl.cpp:972
 #, c-format
 msgid "Media playback error: %s"
 msgstr "Chyba prehrávania médií: %s"
 
-#: ../src/common/fs_mem.cpp:175
+#: ../src/common/fs_mem.cpp:170
 #, c-format
 msgid "Memory VFS already contains file '%s'!"
 msgstr "Pamäť VFS už obsahuje súbor '%s'!"
 
 #. TRANSLATORS: Name of keyboard key
 #. TRANSLATORS: Keyword of system colour
-#: ../src/common/accelcmn.cpp:73 ../src/propgrid/advprops.cpp:889
+#: ../src/common/accelcmn.cpp:70 ../src/propgrid/advprops.cpp:790
 msgid "Menu"
 msgstr "Ponuka"
 
-#: ../src/common/msgout.cpp:124
+#: ../src/common/msgout.cpp:121
 msgid "Message"
 msgstr "Správa"
 
-#: ../src/univ/themes/metal.cpp:168
+#: ../src/univ/themes/metal.cpp:165
 msgid "Metal theme"
 msgstr "Motív kovový"
 
-#: ../src/msw/ole/automtn.cpp:652
+#: ../src/msw/ole/automtn.cpp:643
 msgid "Method or property not found."
 msgstr "Metóda alebo vlastnosť sa nenašli."
 
-#: ../src/univ/themes/win32.cpp:3752
+#: ../src/univ/themes/win32.cpp:3749
 msgid "Mi&nimize"
 msgstr "Mi&nimalizovať"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1763
+#: ../src/propgrid/advprops.cpp:1664
 msgid "Middle Button"
 msgstr "Stredné tlačidlo"
 
@@ -4950,37 +5081,42 @@ msgstr "Min. výška:"
 msgid "Min width:"
 msgstr "Min. šírka:"
 
-#: ../src/msw/ole/automtn.cpp:668
+#: ../src/osx/cocoa/menu.mm:281
+#, fuzzy
+msgid "Minimize"
+msgstr "Mi&nimalizovať"
+
+#: ../src/msw/ole/automtn.cpp:659
 msgid "Missing a required parameter."
 msgstr "Chýba požadovaný parameter."
 
-#: ../src/generic/fontdlgg.cpp:324
+#: ../src/generic/fontdlgg.cpp:320
 msgid "Modern"
 msgstr "Moderný"
 
-#: ../src/generic/filectrlg.cpp:427
+#: ../src/generic/filectrlg.cpp:423
 msgid "Modified"
 msgstr "Upravený"
 
-#: ../src/common/module.cpp:133
+#: ../src/common/module.cpp:130
 #, c-format
 msgid "Module \"%s\" initialization failed"
 msgstr "Inicializácia modulu '%s' zlyhala"
 
-#: ../src/common/paper.cpp:131
+#: ../src/common/paper.cpp:128
 msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
 msgstr "Obálka Monarch, 3 7/8 x 7 1/2 palca"
 
-#: ../src/msw/fswatcher.cpp:143
+#: ../src/msw/fswatcher.cpp:140
 msgid "Monitoring individual files for changes is not supported currently."
 msgstr ""
 "Monitorovanie zmien jednotlivých súborov nie je momentálne podporované."
 
-#: ../src/generic/editlbox.cpp:172
+#: ../src/generic/editlbox.cpp:160
 msgid "Move down"
 msgstr "Posunúť dole"
 
-#: ../src/generic/editlbox.cpp:171
+#: ../src/generic/editlbox.cpp:155
 msgid "Move up"
 msgstr "Posunúť hore"
 
@@ -4994,97 +5130,103 @@ msgstr "Presunie objekt na nasledujúci odsek."
 msgid "Moves the object to the previous paragraph."
 msgstr "Presunie objekt na predošlý odsek."
 
-#: ../src/richtext/richtextbuffer.cpp:9966
+#: ../src/richtext/richtextbuffer.cpp:9963
 msgid "Multiple Cell Properties"
 msgstr "Vlastnosti viacerých buniek"
 
-#: ../src/generic/filectrlg.cpp:424
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:82
+#, fuzzy
+msgid "Multiply"
+msgstr "KP_Multiply"
+
+#: ../src/generic/filectrlg.cpp:420
 msgid "Name"
 msgstr "Názov"
 
-#: ../src/propgrid/advprops.cpp:1596
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Navy"
 msgstr "Námorníctvo"
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "Network"
 msgstr "Sieť"
 
-#: ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173
 msgid "New"
 msgstr "Nový"
 
-#: ../src/richtext/richtextstyledlg.cpp:243
+#: ../src/richtext/richtextstyledlg.cpp:239
 msgid "New &Box Style..."
 msgstr "Nový štýl &schránky..."
 
-#: ../src/richtext/richtextstyledlg.cpp:225
+#: ../src/richtext/richtextstyledlg.cpp:221
 msgid "New &Character Style..."
 msgstr "Nový štýl &znakov..."
 
-#: ../src/richtext/richtextstyledlg.cpp:237
+#: ../src/richtext/richtextstyledlg.cpp:233
 msgid "New &List Style..."
 msgstr "Nový štýl zoz&namu..."
 
-#: ../src/richtext/richtextstyledlg.cpp:231
+#: ../src/richtext/richtextstyledlg.cpp:227
 msgid "New &Paragraph Style..."
 msgstr "Nový štýl &odseku..."
 
-#: ../src/richtext/richtextstyledlg.cpp:606
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:654
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:820
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:893
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:934
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:602
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:650
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:816
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:889
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:930
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "New Style"
 msgstr "Nový štýl"
 
-#: ../src/generic/editlbox.cpp:169
+#: ../src/generic/editlbox.cpp:139
 msgid "New item"
 msgstr "Nová položka"
 
-#: ../src/generic/dirdlgg.cpp:297 ../src/generic/dirdlgg.cpp:307
-#: ../src/generic/filectrlg.cpp:618 ../src/generic/filectrlg.cpp:627
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+#: ../src/generic/dirdlgg.cpp:294 ../src/generic/dirdlgg.cpp:304
 msgid "NewName"
 msgstr "Nový názov"
 
-#: ../src/common/prntbase.cpp:1567 ../src/html/helpwnd.cpp:665
+#: ../src/common/prntbase.cpp:1592 ../src/html/helpwnd.cpp:663
 msgid "Next page"
 msgstr "Ďalšia stránka"
 
-#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:177
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:174
 #: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Nie"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1764
+#: ../src/propgrid/advprops.cpp:1665
 msgid "No Entry"
 msgstr "Nevstupovať"
 
-#: ../src/generic/animateg.cpp:150
+#: ../src/generic/animateg.cpp:133
 #, c-format
 msgid "No animation handler for type %ld defined."
 msgstr "Nie je definovaný žiadny obslužný program animácie pre typ %ld."
 
-#: ../src/dfb/bitmap.cpp:642 ../src/dfb/bitmap.cpp:676
+#: ../src/dfb/bitmap.cpp:639 ../src/dfb/bitmap.cpp:673
 #, c-format
 msgid "No bitmap handler for type %d defined."
 msgstr "Nie je definovaný žiadny obslužný program bitmapy pre typ %d."
 
-#: ../src/common/utilscmn.cpp:1077
+#: ../src/common/utilscmn.cpp:1095
 msgid "No default application configured for HTML files."
 msgstr "Pre súbory HTML nie je nakonfigurovaná žiadna predvolená aplikácia."
 
-#: ../src/generic/helpext.cpp:445
+#: ../src/generic/helpext.cpp:443
 msgid "No entries found."
 msgstr "Neboli nájdené žiadne záznamy."
 
-#: ../src/common/fontmap.cpp:421
+#: ../src/common/fontmap.cpp:418
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found,\n"
@@ -5096,7 +5238,7 @@ msgstr ""
 "ale je k dispozícii alternatívne kódovanie '%s'.\n"
 "Chcete použiť toto kódovanie (inak si budete musieť zvoliť iné)?"
 
-#: ../src/common/fontmap.cpp:426
+#: ../src/common/fontmap.cpp:423
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found.\n"
@@ -5107,201 +5249,201 @@ msgstr ""
 "Prajete si zvoliť písmo, ktoré sa použije pre toto kódovanie\n"
 "(inak sa text v tomto kódovaní nebude zobrazovať správne)?"
 
-#: ../src/generic/animateg.cpp:142
+#: ../src/generic/animateg.cpp:125
 msgid "No handler found for animation type."
 msgstr "Pre typ animácie sa nenašiel žiadny obslužný program."
 
-#: ../src/common/image.cpp:2728
+#: ../src/common/image.cpp:2823
 msgid "No handler found for image type."
 msgstr "Pre typ obrázka sa nenašiel žiadny obslužný program."
 
-#: ../src/common/image.cpp:2736 ../src/common/image.cpp:2848
-#: ../src/common/image.cpp:2901
+#: ../src/common/image.cpp:2831 ../src/common/image.cpp:2954
+#: ../src/common/image.cpp:3020
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "Nie je definovaný žiadny obslužný program obrázkov pre typ %d."
 
-#: ../src/common/image.cpp:2871 ../src/common/image.cpp:2915
+#: ../src/common/image.cpp:2986 ../src/common/image.cpp:3034
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "Nie je definovaný žiadny obslužný program obrázkov pre typ %s."
 
-#: ../src/html/helpwnd.cpp:858
+#: ../src/html/helpwnd.cpp:856
 msgid "No matching page found yet"
 msgstr "Zatiaľ sa nenašla žiadna zodpovedajúca stránka"
 
-#: ../src/unix/sound.cpp:81
+#: ../src/unix/sound.cpp:78
 msgid "No sound"
 msgstr "Bez zvuku"
 
-#: ../src/common/image.cpp:2277 ../src/common/image.cpp:2318
+#: ../src/common/image.cpp:2371 ../src/common/image.cpp:2412
 msgid "No unused colour in image being masked."
 msgstr "Na obrázku nie je namaskovaná žiadna nepoužitá farba."
 
-#: ../src/common/image.cpp:3374
-msgid "No unused colour in image."
-msgstr "Žiadna nepoužitá farba na obrázku."
-
-#: ../src/generic/helpext.cpp:302
+#: ../src/generic/helpext.cpp:300
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "V súbore '%s' sa nenašli žiadne platné priradenia."
 
-#: ../src/richtext/richtextborderspage.cpp:610
 #: ../src/richtext/richtextsizepage.cpp:248
 #: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:610
 msgid "None"
 msgstr "Nič"
 
-#: ../src/common/fmapbase.cpp:157
+#: ../src/common/fmapbase.cpp:154
 msgid "Nordic (ISO-8859-10)"
 msgstr "Severské (ISO-8859-10)"
 
-#: ../src/generic/fontdlgg.cpp:328 ../src/generic/fontdlgg.cpp:331
+#: ../src/generic/fontdlgg.cpp:324 ../src/generic/fontdlgg.cpp:327
 msgid "Normal"
 msgstr "Normálna"
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1261
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Normálna plôška<br> a <u>podčiarknuté</u>. "
 
-#: ../src/html/helpwnd.cpp:1205
+#: ../src/html/helpwnd.cpp:1203
 msgid "Normal font:"
 msgstr "Normálne písmo:"
 
-#: ../src/propgrid/props.cpp:1128
+#: ../src/propgrid/props.cpp:1115
 #, c-format
 msgid "Not %s"
 msgstr "Bez %s"
 
-#: ../include/wx/filename.h:573 ../include/wx/filename.h:578
-msgid "Not available"
-msgstr "Nie je k dispozícii"
+#: ../src/common/secretstore.cpp:168
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/webrequest.cpp:605
+msgid "Not enough free disk space for download."
+msgstr ""
 
 #: ../src/richtext/richtextfontpage.cpp:358
 msgid "Not underlined"
 msgstr "Nie podčiarknuté"
 
-#: ../src/common/paper.cpp:115
+#: ../src/common/paper.cpp:112
 msgid "Note, 8 1/2 x 11 in"
 msgstr "Poznámka, 8 1/2 x 11 palcov"
 
-#: ../src/generic/notifmsgg.cpp:132
+#: ../src/generic/notifmsgg.cpp:129
 msgid "Notice"
 msgstr "Poznámky"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "Num *"
 msgstr "Num *"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "Num +"
 msgstr "Num +"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "Num ,"
 msgstr "Num ,"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "Num -"
 msgstr "Num -"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "Num ."
 msgstr "Num ."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "Num /"
 msgstr "Num /"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "Num ="
 msgstr "Num ="
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "Num Begin"
 msgstr "Num Begin"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 msgid "Num Delete"
 msgstr "Num Delete"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 msgid "Num Down"
 msgstr "Num Down"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "Num End"
 msgstr "Num End"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "Num Enter"
 msgstr "Num Enter"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 msgid "Num Home"
 msgstr "Num Home"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 msgid "Num Insert"
 msgstr "Num Insert"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num Lock"
 msgstr "Num Lock"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "Num Page Down"
 msgstr "Num Page Down"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "Num Page Up"
 msgstr "Num Page Up"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 msgid "Num Right"
 msgstr "Num Right"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "Num Space"
 msgstr "Num Space"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "Num Tab"
 msgstr "Num Tab"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "Num Up"
 msgstr "Num Up"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "Num left"
 msgstr "Num left"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num_lock"
 msgstr "Num_lock"
 
@@ -5310,13 +5452,13 @@ msgstr "Num_lock"
 msgid "Numbered outline"
 msgstr "Očíslovaný obrys"
 
-#: ../include/wx/msgdlg.h:278 ../src/richtext/richtextstyledlg.cpp:297
-#: ../src/common/stockitem.cpp:178 ../src/msw/msgdlg.cpp:454
-#: ../src/msw/msgdlg.cpp:747 ../src/gtk1/fontdlg.cpp:138
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:175
+#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/msgdlg.cpp:741 ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "OK"
 
-#: ../src/msw/ole/automtn.cpp:692
+#: ../src/msw/ole/automtn.cpp:683
 #, c-format
 msgid "OLE Automation error in %s: %s"
 msgstr "Chyba automatizácie OLE v %s: %s"
@@ -5325,15 +5467,15 @@ msgstr "Chyba automatizácie OLE v %s: %s"
 msgid "Object Properties"
 msgstr "Vlastnosti objektu"
 
-#: ../src/msw/ole/automtn.cpp:660
+#: ../src/msw/ole/automtn.cpp:651
 msgid "Object implementation does not support named arguments."
 msgstr "Implementácia objektu nepodporuje pomenované argumenty."
 
-#: ../src/common/xtixml.cpp:264
+#: ../src/common/xtixml.cpp:260
 msgid "Objects must have an id attribute"
 msgstr "Objekty musia mať ID atribút"
 
-#: ../src/propgrid/advprops.cpp:1601
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Olive"
 msgstr "Olivový"
 
@@ -5341,64 +5483,69 @@ msgstr "Olivový"
 msgid "Opaci&ty:"
 msgstr "Neprie&hľadnosť:"
 
-#: ../src/generic/colrdlgg.cpp:354
+#: ../src/generic/colrdlgg.cpp:374
 msgid "Opacity:"
 msgstr "Nepriehľadnosť:"
 
-#: ../src/common/docview.cpp:1773 ../src/common/docview.cpp:1815
+#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
 msgid "Open File"
 msgstr "Otvoriť súbor"
 
-#: ../src/html/helpwnd.cpp:671 ../src/html/helpwnd.cpp:1554
+#: ../src/html/helpwnd.cpp:669 ../src/html/helpwnd.cpp:1552
 msgid "Open HTML document"
 msgstr "Otvorte dokument HTML"
 
-#: ../src/generic/dbgrptg.cpp:163
+#: ../src/common/stockitem.cpp:265
+#, fuzzy
+msgid "Open an existing document"
+msgstr "Otvorte dokument HTML"
+
+#: ../src/generic/dbgrptg.cpp:160
 #, c-format
 msgid "Open file \"%s\""
 msgstr "Otvoriť súbor '%s'"
 
-#: ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176
 msgid "Open..."
 msgstr "Otvoriť..."
 
-#: ../src/unix/glx11.cpp:506 ../src/msw/glcanvas.cpp:592
+#: ../src/msw/glcanvas.cpp:607 ../src/unix/glx11.cpp:513
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr "OpenGL 3.0 alebo novší nie je ovládačom OpenGL podporovaný."
 
-#: ../src/generic/dirctrlg.cpp:599 ../src/generic/dirdlgg.cpp:323
-#: ../src/generic/filectrlg.cpp:642 ../src/generic/filectrlg.cpp:786
+#: ../src/generic/dirctrlg.cpp:565 ../src/generic/filectrlg.cpp:638
+#: ../src/generic/filectrlg.cpp:782 ../src/generic/dirdlgg.cpp:320
 msgid "Operation not permitted."
 msgstr "Operácia nie je povolená."
 
-#: ../src/common/cmdline.cpp:900
+#: ../src/common/cmdline.cpp:896
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "Možnosť '%s' nemôže byť negovaná"
 
-#: ../src/common/cmdline.cpp:1064
+#: ../src/common/cmdline.cpp:1060
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "Možnosť '%s' vyžaduje hodnotu."
 
-#: ../src/common/cmdline.cpp:1147
+#: ../src/common/cmdline.cpp:1143
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Možnosť '%s': '%s' nemožno konvertovať na dátum."
 
-#: ../src/generic/prntdlgg.cpp:618
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Možnosti"
 
-#: ../src/propgrid/advprops.cpp:1606
+#: ../src/propgrid/advprops.cpp:1512
 msgid "Orange"
 msgstr "Oranžová"
 
-#: ../src/generic/prntdlgg.cpp:615 ../src/generic/prntdlgg.cpp:869
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:862
 msgid "Orientation"
 msgstr "Orientácia"
 
-#: ../src/common/windowid.cpp:242
+#: ../src/common/windowid.cpp:237
 msgid "Out of window IDs.  Recommend shutting down application."
 msgstr "ID mimo okna.  Odporučte vypnúť aplikáciu."
 
@@ -5411,148 +5558,148 @@ msgstr "Obrys"
 msgid "Outset"
 msgstr "Napred"
 
-#: ../src/msw/ole/automtn.cpp:656
+#: ../src/msw/ole/automtn.cpp:647
 msgid "Overflow while coercing argument values."
 msgstr "Pretečenie pri vynucovaní hodnôt argumentov."
 
-#: ../src/common/imagpcx.cpp:457 ../src/common/imagpcx.cpp:480
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:479
 msgid "PCX: couldn't allocate memory"
 msgstr "PCX: Nemožno alokovať pamäť"
 
-#: ../src/common/imagpcx.cpp:456
+#: ../src/common/imagpcx.cpp:455
 msgid "PCX: image format unsupported"
 msgstr "PCX: nepodporovaný formát obrázka"
 
-#: ../src/common/imagpcx.cpp:479
+#: ../src/common/imagpcx.cpp:478
 msgid "PCX: invalid image"
 msgstr "PCX: neplatný obrázok"
 
-#: ../src/common/imagpcx.cpp:442
+#: ../src/common/imagpcx.cpp:441
 msgid "PCX: this is not a PCX file."
 msgstr "PCX: toto nie je PCX súbor."
 
-#: ../src/common/imagpcx.cpp:459 ../src/common/imagpcx.cpp:481
+#: ../src/common/imagpcx.cpp:458 ../src/common/imagpcx.cpp:480
 msgid "PCX: unknown error !!!"
 msgstr "PCX: neznáma chyba !!!"
 
-#: ../src/common/imagpcx.cpp:458
+#: ../src/common/imagpcx.cpp:457
 msgid "PCX: version number too low"
 msgstr "PCX: príliš nízke číslo verzie"
 
-#: ../src/common/imagpnm.cpp:91
+#: ../src/common/imagpnm.cpp:89
 msgid "PNM: Couldn't allocate memory."
 msgstr "PNM: Nemožno vymedziť pamäť."
 
-#: ../src/common/imagpnm.cpp:73
+#: ../src/common/imagpnm.cpp:71
 msgid "PNM: File format is not recognized."
 msgstr "PNM: Nerozpoznaný formát súboru."
 
-#: ../src/common/imagpnm.cpp:112 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
 #: ../src/common/imagpnm.cpp:156
 msgid "PNM: File seems truncated."
 msgstr "PNM: Súbor vyzerá byť orezaný."
 
-#: ../src/common/paper.cpp:187
+#: ../src/common/paper.cpp:184
 msgid "PRC 16K 146 x 215 mm"
 msgstr "PRC 16K 146 x 215 mm"
 
-#: ../src/common/paper.cpp:200
+#: ../src/common/paper.cpp:197
 msgid "PRC 16K Rotated"
 msgstr "PRC 16K otočený"
 
-#: ../src/common/paper.cpp:188
+#: ../src/common/paper.cpp:185
 msgid "PRC 32K 97 x 151 mm"
 msgstr "PRC 32K 97 x 151 mm"
 
-#: ../src/common/paper.cpp:201
+#: ../src/common/paper.cpp:198
 msgid "PRC 32K Rotated"
 msgstr "PRC 32K otočený"
 
-#: ../src/common/paper.cpp:189
+#: ../src/common/paper.cpp:186
 msgid "PRC 32K(Big) 97 x 151 mm"
 msgstr "PRC 32K(Big) 97 x 151 mm"
 
-#: ../src/common/paper.cpp:202
+#: ../src/common/paper.cpp:199
 msgid "PRC 32K(Big) Rotated"
 msgstr "PRC 32K(Big) otočený"
 
-#: ../src/common/paper.cpp:190
+#: ../src/common/paper.cpp:187
 msgid "PRC Envelope #1 102 x 165 mm"
 msgstr "PRC obálka #1 102 x 165 mm"
 
-#: ../src/common/paper.cpp:203
+#: ../src/common/paper.cpp:200
 msgid "PRC Envelope #1 Rotated 165 x 102 mm"
 msgstr "PRC obálka #1 otočený 165 x 102 mm"
 
-#: ../src/common/paper.cpp:199
+#: ../src/common/paper.cpp:196
 msgid "PRC Envelope #10 324 x 458 mm"
 msgstr "PRC obálka #10 324 x 458 mm"
 
-#: ../src/common/paper.cpp:212
+#: ../src/common/paper.cpp:209
 msgid "PRC Envelope #10 Rotated 458 x 324 mm"
 msgstr "PRC obálka #10 otočený 458 x 324 mm"
 
-#: ../src/common/paper.cpp:191
+#: ../src/common/paper.cpp:188
 msgid "PRC Envelope #2 102 x 176 mm"
 msgstr "PRC obálka #2 102 x 176 mm"
 
-#: ../src/common/paper.cpp:204
+#: ../src/common/paper.cpp:201
 msgid "PRC Envelope #2 Rotated 176 x 102 mm"
 msgstr "PRC obálka #2 otočený 176 x 102 mm"
 
-#: ../src/common/paper.cpp:192
+#: ../src/common/paper.cpp:189
 msgid "PRC Envelope #3 125 x 176 mm"
 msgstr "PRC obálka #3 125 x 176 mm"
 
-#: ../src/common/paper.cpp:205
+#: ../src/common/paper.cpp:202
 msgid "PRC Envelope #3 Rotated 176 x 125 mm"
 msgstr "PRC obálka #3 otočený 176 x 125 mm"
 
-#: ../src/common/paper.cpp:193
+#: ../src/common/paper.cpp:190
 msgid "PRC Envelope #4 110 x 208 mm"
 msgstr "PRC obálka #4 110 x 208 mm"
 
-#: ../src/common/paper.cpp:206
+#: ../src/common/paper.cpp:203
 msgid "PRC Envelope #4 Rotated 208 x 110 mm"
 msgstr "PRC obálka #4 otočený 208 x 110 mm"
 
-#: ../src/common/paper.cpp:194
+#: ../src/common/paper.cpp:191
 msgid "PRC Envelope #5 110 x 220 mm"
 msgstr "PRC obálka #5 110 x 220 mm"
 
-#: ../src/common/paper.cpp:207
+#: ../src/common/paper.cpp:204
 msgid "PRC Envelope #5 Rotated 220 x 110 mm"
 msgstr "PRC obálka #5 otočený 220 x 110 mm"
 
-#: ../src/common/paper.cpp:195
+#: ../src/common/paper.cpp:192
 msgid "PRC Envelope #6 120 x 230 mm"
 msgstr "PRC obálka #6 120 x 230 mm"
 
-#: ../src/common/paper.cpp:208
+#: ../src/common/paper.cpp:205
 msgid "PRC Envelope #6 Rotated 230 x 120 mm"
 msgstr "PRC obálka #6 otočený 230 x 120 mm"
 
-#: ../src/common/paper.cpp:196
+#: ../src/common/paper.cpp:193
 msgid "PRC Envelope #7 160 x 230 mm"
 msgstr "PRC obálka #7 160 x 230 mm"
 
-#: ../src/common/paper.cpp:209
+#: ../src/common/paper.cpp:206
 msgid "PRC Envelope #7 Rotated 230 x 160 mm"
 msgstr "PRC obálka #7 otočený 230 x 160 mm"
 
-#: ../src/common/paper.cpp:197
+#: ../src/common/paper.cpp:194
 msgid "PRC Envelope #8 120 x 309 mm"
 msgstr "PRC obálka #8 120 x 309 mm"
 
-#: ../src/common/paper.cpp:210
+#: ../src/common/paper.cpp:207
 msgid "PRC Envelope #8 Rotated 309 x 120 mm"
 msgstr "PRC obálka #8 otočený 309 x 120 mm"
 
-#: ../src/common/paper.cpp:198
+#: ../src/common/paper.cpp:195
 msgid "PRC Envelope #9 229 x 324 mm"
 msgstr "PRC obálka #9 229 x 324 mm"
 
-#: ../src/common/paper.cpp:211
+#: ../src/common/paper.cpp:208
 msgid "PRC Envelope #9 Rotated 324 x 229 mm"
 msgstr "PRC obálka #9 otočený 324 x 229 mm"
 
@@ -5560,87 +5707,91 @@ msgstr "PRC obálka #9 otočený 324 x 229 mm"
 msgid "Padding"
 msgstr "Priestor vyplnenia"
 
-#: ../src/common/prntbase.cpp:2074
+#: ../src/common/prntbase.cpp:2096
 #, c-format
 msgid "Page %d"
 msgstr "Strana %d"
 
-#: ../src/common/prntbase.cpp:2072
+#: ../src/common/prntbase.cpp:2094
 #, c-format
 msgid "Page %d of %d"
 msgstr "Strana %d z %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 msgid "Page Down"
 msgstr "O stránku nadol"
 
-#: ../src/gtk/print.cpp:826
+#: ../src/gtk/print.cpp:829
 msgid "Page Setup"
 msgstr "Nastavenie strany"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 msgid "Page Up"
 msgstr "O stránku nahor"
 
-#: ../src/generic/prntdlgg.cpp:828 ../src/common/prntbase.cpp:484
+#: ../src/common/prntbase.cpp:479 ../src/generic/prntdlgg.cpp:821
 msgid "Page setup"
 msgstr "Nastavenie strany"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 msgid "PageDown"
 msgstr "PageDown"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 msgid "PageUp"
 msgstr "PageUp"
 
-#: ../src/generic/prntdlgg.cpp:216
+#: ../src/generic/prntdlgg.cpp:209
 msgid "Pages"
 msgstr "Strán"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1765
+#: ../src/propgrid/advprops.cpp:1666
 msgid "Paint Brush"
 msgstr "Maľba štetcom"
 
-#: ../src/generic/prntdlgg.cpp:602 ../src/generic/prntdlgg.cpp:801
-#: ../src/generic/prntdlgg.cpp:842 ../src/generic/prntdlgg.cpp:855
-#: ../src/generic/prntdlgg.cpp:1052 ../src/generic/prntdlgg.cpp:1057
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:794
+#: ../src/generic/prntdlgg.cpp:835 ../src/generic/prntdlgg.cpp:848
+#: ../src/generic/prntdlgg.cpp:1045 ../src/generic/prntdlgg.cpp:1050
 msgid "Paper size"
 msgstr "Paper size"
 
-#: ../src/richtext/richtextstyles.cpp:1062
+#: ../src/richtext/richtextstyles.cpp:1059
 msgid "Paragraph styles"
 msgstr "Štýly odstavca"
 
-#: ../src/common/xtistrm.cpp:465
+#: ../src/common/xtistrm.cpp:462
 msgid "Passing a already registered object to SetObject"
 msgstr "Odovzdanie už registrovaného objektu do SetObject"
 
-#: ../src/common/xtistrm.cpp:476
+#: ../src/common/xtistrm.cpp:473
 msgid "Passing an unknown object to GetObject"
 msgstr "Odovzdanie neznámeho objektu do GetObject"
 
-#: ../src/richtext/richtextctrl.cpp:3513 ../src/common/stockitem.cpp:180
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:177 ../src/richtext/richtextctrl.cpp:3514
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Prilepiť"
 
-#: ../src/common/stockitem.cpp:262
+#: ../src/common/stockitem.cpp:260
 msgid "Paste selection"
 msgstr "Prilepiť výber"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:74
+#: ../src/common/accelcmn.cpp:71
 msgid "Pause"
 msgstr "Pauza"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1766
+#: ../src/propgrid/advprops.cpp:1667
 msgid "Pencil"
 msgstr "Ceruzka"
 
@@ -5649,21 +5800,21 @@ msgstr "Ceruzka"
 msgid "Peri&od"
 msgstr "Perió&da"
 
-#: ../src/generic/filectrlg.cpp:430
+#: ../src/generic/filectrlg.cpp:426
 msgid "Permissions"
 msgstr "Povolenia"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:60
+#: ../src/common/accelcmn.cpp:57
 msgid "PgDn"
 msgstr "PgDn"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:59
+#: ../src/common/accelcmn.cpp:56
 msgid "PgUp"
 msgstr "PgUp"
 
-#: ../src/richtext/richtextbuffer.cpp:12868
+#: ../src/richtext/richtextbuffer.cpp:12863
 msgid "Picture Properties"
 msgstr "Vlastnosti obrázka"
 
@@ -5675,43 +5826,43 @@ msgstr "Vytvorenie potrubia zlyhalo"
 msgid "Please choose a valid font."
 msgstr "Vyberte, prosím, platné písmo."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
 msgid "Please choose an existing file."
 msgstr "Vyberte, prosím, existujúci súbor."
 
-#: ../src/html/helpwnd.cpp:800
+#: ../src/html/helpwnd.cpp:798
 msgid "Please choose the page to display:"
 msgstr "Vyberte, prosím, stránku, ktorá sa má zobraziť:"
 
-#: ../src/msw/dialup.cpp:764
+#: ../src/msw/dialup.cpp:758
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Vyberte, prosím, poskytovateľa, ku ktorému sa chcete pripájať"
 
-#: ../src/common/headerctrlcmn.cpp:59
+#: ../src/common/headerctrlcmn.cpp:57
 msgid "Please select the columns to show and define their order:"
 msgstr ""
 "Vyberte, prosím, stĺpce, ktoré chcete zobraziť a definujte ich poradie:"
 
-#: ../src/common/prntbase.cpp:538
+#: ../src/common/prntbase.cpp:533
 msgid "Please wait while printing..."
 msgstr "Počkajte, prosím, počas tlačenia ..."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1767
+#: ../src/propgrid/advprops.cpp:1668
 msgid "Point Left"
 msgstr "Bod vľavo"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1768
+#: ../src/propgrid/advprops.cpp:1669
 msgid "Point Right"
 msgstr "Bod vpravo"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:662
+#: ../src/propgrid/advprops.cpp:572
 msgid "Point Size"
 msgstr "Veľkosť bodu"
 
-#: ../src/generic/prntdlgg.cpp:612 ../src/generic/prntdlgg.cpp:867
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:860
 msgid "Portrait"
 msgstr "Portrét"
 
@@ -5719,251 +5870,261 @@ msgstr "Portrét"
 msgid "Position"
 msgstr "Poloha"
 
-#: ../src/generic/prntdlgg.cpp:298
+#: ../src/generic/prntdlgg.cpp:291
 msgid "PostScript file"
 msgstr "Súbor PostScript"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178 ../src/osx/cocoa/preferences.mm:303
 msgid "Preferences"
 msgstr "Predvoľby"
 
-#: ../src/osx/menu_osx.cpp:568
+#: ../src/osx/menu_osx.cpp:460
 msgid "Preferences..."
 msgstr "Predvoľby..."
 
-#: ../src/common/prntbase.cpp:546
+#: ../src/common/prntbase.cpp:541
 msgid "Preparing"
 msgstr "Príprava"
 
-#: ../src/generic/fontdlgg.cpp:455 ../src/osx/carbon/fontdlg.cpp:390
-#: ../src/html/helpwnd.cpp:1222
+#: ../src/osx/carbon/fontdlg.cpp:387 ../src/generic/fontdlgg.cpp:452
+#: ../src/html/helpwnd.cpp:1220
 msgid "Preview:"
 msgstr "Náhľad:"
 
-#: ../src/common/prntbase.cpp:1553 ../src/html/helpwnd.cpp:664
+#: ../src/common/prntbase.cpp:1578 ../src/html/helpwnd.cpp:662
 msgid "Previous page"
 msgstr "Predošlá strana"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/prntdlgg.cpp:143 ../src/generic/prntdlgg.cpp:157
-#: ../src/common/prntbase.cpp:426 ../src/common/prntbase.cpp:1541
-#: ../src/common/accelcmn.cpp:77 ../src/gtk/print.cpp:620
-#: ../src/gtk/print.cpp:638
+#: ../src/common/prntbase.cpp:421 ../src/common/prntbase.cpp:1566
+#: ../src/common/accelcmn.cpp:74 ../src/generic/prntdlgg.cpp:136
+#: ../src/generic/prntdlgg.cpp:150 ../src/gtk/print.cpp:616
+#: ../src/gtk/print.cpp:634
 msgid "Print"
 msgstr "Tlačiť"
 
-#: ../include/wx/prntbase.h:399 ../src/common/docview.cpp:1268
+#: ../src/common/docview.cpp:1262
 msgid "Print Preview"
 msgstr "Náhľad pred tlačou"
 
-#: ../src/common/prntbase.cpp:2015 ../src/common/prntbase.cpp:2057
-#: ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2037 ../src/common/prntbase.cpp:2079
+#: ../src/common/prntbase.cpp:2087
 msgid "Print Preview Failure"
 msgstr "Chyba náhľadu pred tlačou"
 
-#: ../src/generic/prntdlgg.cpp:224
+#: ../src/generic/prntdlgg.cpp:217
 msgid "Print Range"
 msgstr "Rozsah tlače"
 
-#: ../src/generic/prntdlgg.cpp:449
+#: ../src/generic/prntdlgg.cpp:442
 msgid "Print Setup"
 msgstr "Nastavenie tlače"
 
-#: ../src/generic/prntdlgg.cpp:621
+#: ../src/generic/prntdlgg.cpp:614
 msgid "Print in colour"
 msgstr "Tlačiť farebne"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/osx/webview_webkit.mm:260
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "Nebolo možné inicializovať obrazovku."
+
+#: ../src/common/stockitem.cpp:179
 msgid "Print previe&w..."
 msgstr "Tlač náhľadu..."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1256
 msgid "Print preview creation failed."
 msgstr "Vytvorenie ukážky tlače zlyhalo."
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/common/stockitem.cpp:179
 msgid "Print preview..."
 msgstr "Náhľad pred tlačou..."
 
-#: ../src/generic/prntdlgg.cpp:630
+#: ../src/generic/prntdlgg.cpp:623
 msgid "Print spooling"
 msgstr "Zaradenie tlače"
 
-#: ../src/html/helpwnd.cpp:675
+#: ../src/html/helpwnd.cpp:673
 msgid "Print this page"
 msgstr "Vytlačiť túto stránku"
 
-#: ../src/generic/prntdlgg.cpp:185
+#: ../src/generic/prntdlgg.cpp:178
 msgid "Print to File"
 msgstr "Tlačiť do súboru"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "Print..."
 msgstr "Tlačiť ..."
 
-#: ../src/generic/prntdlgg.cpp:493
+#: ../src/generic/prntdlgg.cpp:486
 msgid "Printer"
 msgstr "Tlačiareň"
 
-#: ../src/generic/prntdlgg.cpp:633
+#: ../src/generic/prntdlgg.cpp:626
 msgid "Printer command:"
 msgstr "Príkaz tlačiarne:"
 
-#: ../src/generic/prntdlgg.cpp:180
+#: ../src/generic/prntdlgg.cpp:173
 msgid "Printer options"
 msgstr "Voľby tlačiarne"
 
-#: ../src/generic/prntdlgg.cpp:645
+#: ../src/generic/prntdlgg.cpp:638
 msgid "Printer options:"
 msgstr "Voľby tlačiarne:"
 
-#: ../src/generic/prntdlgg.cpp:916
+#: ../src/generic/prntdlgg.cpp:909
 msgid "Printer..."
 msgstr "Tlačiareň..."
 
-#: ../src/generic/prntdlgg.cpp:196
+#: ../src/generic/prntdlgg.cpp:189
 msgid "Printer:"
 msgstr "Tlačiareň:"
 
-#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:535
-#: ../src/html/htmprint.cpp:277
+#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:530
+#: ../src/html/htmprint.cpp:289
 msgid "Printing"
 msgstr "Tlačí sa"
 
-#: ../src/common/prntbase.cpp:612
+#: ../src/common/prntbase.cpp:607
 msgid "Printing "
 msgstr "Tlačí sa "
 
-#: ../src/common/prntbase.cpp:347
+#: ../src/common/prntbase.cpp:342
 msgid "Printing Error"
 msgstr "Chyba tlače"
 
-#: ../src/common/prntbase.cpp:565
+#: ../src/osx/webview_webkit.mm:251
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "Táto verzia zlib nepodporuje Gzip"
+
+#: ../src/common/prntbase.cpp:560
 #, c-format
 msgid "Printing page %d"
 msgstr "Tlačí sa stránka %d"
 
-#: ../src/common/prntbase.cpp:570
+#: ../src/common/prntbase.cpp:565
 #, c-format
 msgid "Printing page %d of %d"
 msgstr "Tlačí sa stránka %d z %d"
 
-#: ../src/generic/printps.cpp:201
+#: ../src/generic/printps.cpp:182
 #, c-format
 msgid "Printing page %d..."
 msgstr "Tlačí sa stránka %d..."
 
-#: ../src/generic/printps.cpp:161
+#: ../src/generic/printps.cpp:142
 msgid "Printing..."
 msgstr "Tlačí sa..."
 
-#: ../include/wx/richtext/richtextprint.h:109 ../include/wx/prntbase.h:267
-#: ../src/common/docview.cpp:2132
+#: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
+#: ../src/common/docview.cpp:2137
 msgid "Printout"
 msgstr "Vytlačiť"
 
-#: ../src/common/debugrpt.cpp:560
+#: ../src/common/debugrpt.cpp:561
 #, c-format
 msgid ""
 "Processing debug report has failed, leaving the files in \"%s\" directory."
 msgstr "Spracovanie správy o chybe zlyhalo, nechávam súbory v priečinku '%s'."
 
-#: ../src/common/prntbase.cpp:545
+#: ../src/common/prntbase.cpp:540
 msgid "Progress:"
 msgstr "Priebeh:"
 
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181
 msgid "Properties"
 msgstr "Vlastnosti"
 
-#: ../src/propgrid/manager.cpp:237
+#: ../src/propgrid/manager.cpp:223
 msgid "Property"
 msgstr "Vlastnosť"
 
 #. TRANSLATORS: Caption of message box displaying any property error
-#: ../src/propgrid/propgrid.cpp:3185 ../src/propgrid/propgrid.cpp:3318
+#: ../src/propgrid/propgrid.cpp:3162 ../src/propgrid/propgrid.cpp:3299
 msgid "Property Error"
 msgstr "Chyba vlastnosti"
 
-#: ../src/propgrid/advprops.cpp:1597
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Purple"
 msgstr "Fialová"
 
-#: ../src/common/paper.cpp:112
+#: ../src/common/paper.cpp:109
 msgid "Quarto, 215 x 275 mm"
 msgstr "Quarto, 215 x 275 mm"
 
-#: ../src/generic/logg.cpp:1016
+#: ../src/generic/logg.cpp:1013
 msgid "Question"
 msgstr "Otázka"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1769
+#: ../src/propgrid/advprops.cpp:1670
 msgid "Question Arrow"
 msgstr "Šípka otázky"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "Quit"
 msgstr "Ukončiť"
 
-#: ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:477
 #, c-format
 msgid "Quit %s"
 msgstr "Ukončiť %s"
 
-#: ../src/common/stockitem.cpp:263
+#: ../src/common/stockitem.cpp:261
 msgid "Quit this program"
 msgstr "Ukončí tento program"
 
-#: ../src/common/accelcmn.cpp:338
+#: ../src/common/accelcmn.cpp:352
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/ffile.cpp:109 ../src/common/ffile.cpp:133
+#: ../src/common/ffile.cpp:107 ../src/common/ffile.cpp:132
 #, c-format
 msgid "Read error on file '%s'"
 msgstr "Chyba pri čítaní súboru '%s'"
 
-#: ../src/common/secretstore.cpp:199
-#, c-format
-msgid "Reading password for \"%s/%s\" failed: %s."
+#: ../src/common/secretstore.cpp:211
+#, fuzzy, c-format
+msgid "Reading password for \"%s\" failed: %s."
 msgstr "Čítanie hesla pre \"%s / %s\" zlyhalo: %s."
 
-#: ../src/common/prntbase.cpp:272
+#: ../src/common/prntbase.cpp:267
 msgid "Ready"
 msgstr "Priravený"
 
-#: ../src/propgrid/advprops.cpp:1605
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Red"
 msgstr "Červená"
 
-#: ../src/generic/colrdlgg.cpp:339
+#: ../src/generic/colrdlgg.cpp:359
 msgid "Red:"
 msgstr "Červená:"
 
-#: ../src/common/stockitem.cpp:185 ../src/stc/stc_i18n.cpp:16
+#: ../src/common/stockitem.cpp:182 ../src/stc/stc_i18n.cpp:16
 msgid "Redo"
 msgstr "Vpred"
 
-#: ../src/common/stockitem.cpp:264
+#: ../src/common/stockitem.cpp:262
 msgid "Redo last action"
 msgstr "Zopakuje poslednú vrátenú činnosť"
 
-#: ../src/common/stockitem.cpp:186
+#: ../src/common/stockitem.cpp:183
 msgid "Refresh"
 msgstr "Obnoviť"
 
-#: ../src/msw/registry.cpp:626
+#: ../src/msw/registry.cpp:615
 #, c-format
 msgid "Registry key '%s' already exists."
 msgstr "Kľúč registra '%s' už existuje."
 
-#: ../src/msw/registry.cpp:595
+#: ../src/msw/registry.cpp:584
 #, c-format
 msgid "Registry key '%s' does not exist, cannot rename it."
 msgstr "Kľúč registra '%s' neexistuje, nie je ho možné premenovať."
 
-#: ../src/msw/registry.cpp:727
+#: ../src/msw/registry.cpp:716
 #, c-format
 msgid ""
 "Registry key '%s' is needed for normal system operation,\n"
@@ -5974,22 +6135,22 @@ msgstr ""
 "jeho zmazanie by zanechalo systém v nepoužiteľnom stave:\n"
 "operácia bola zrušená."
 
-#: ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:942
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr "Hodnota registra '%s' nie je binárna (ale typu %s)"
 
-#: ../src/msw/registry.cpp:917
+#: ../src/msw/registry.cpp:905
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr "Hodnota registra '%s' nie je číselná (ale typu %s)"
 
-#: ../src/msw/registry.cpp:1003
+#: ../src/msw/registry.cpp:991
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr "Hodnota registra '%s' nie je text (ale typu %s)"
 
-#: ../src/msw/registry.cpp:521
+#: ../src/msw/registry.cpp:510
 #, c-format
 msgid "Registry value '%s' already exists."
 msgstr "Hodnota registra '%s' už existuje."
@@ -6003,71 +6164,77 @@ msgstr "Bežné"
 msgid "Relative"
 msgstr "Relatívne"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:456
 msgid "Relevant entries:"
 msgstr "Relevantné položky:"
 
-#: ../include/wx/generic/progdlgg.h:86
+#: ../include/wx/generic/progdlgg.h:87
 msgid "Remaining time:"
 msgstr "Zostávajúci čas:"
 
-#: ../src/common/stockitem.cpp:187
+#: ../src/common/stockitem.cpp:184
 msgid "Remove"
 msgstr "Odstrániť"
 
-#: ../src/richtext/richtextctrl.cpp:1562
+#: ../src/richtext/richtextctrl.cpp:1563
 msgid "Remove Bullet"
 msgstr "Odstrániť oddeľovač"
 
-#: ../src/html/helpwnd.cpp:433
+#: ../src/html/helpwnd.cpp:431
 msgid "Remove current page from bookmarks"
 msgstr "Odstráni aktuálnu stránku zo záložiek"
 
-#: ../src/common/rendcmn.cpp:194
+#: ../src/common/rendcmn.cpp:191
 #, c-format
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 "Vykresľovacie jadro '%s' má nekompatibilnú verziu %d.%d a nemožno ho načítať."
 
-#: ../src/richtext/richtextbuffer.cpp:4527
+#: ../src/richtext/richtextbuffer.cpp:4524
 msgid "Renumber List"
 msgstr "Prečíslovať zoznam"
 
-#: ../src/common/stockitem.cpp:188
-msgid "Rep&lace"
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Rep&lace..."
 msgstr "Nah&radiť"
 
-#: ../src/richtext/richtextctrl.cpp:3673 ../src/common/stockitem.cpp:188
+#: ../src/richtext/richtextctrl.cpp:3674
 msgid "Replace"
 msgstr "Nahradiť"
 
-#: ../src/generic/fdrepdlg.cpp:182
+#: ../src/generic/fdrepdlg.cpp:179
 msgid "Replace &all"
 msgstr "Nahradiť &všetko"
 
-#: ../src/common/stockitem.cpp:261
-msgid "Replace selection"
-msgstr "Nahradiť výber"
-
-#: ../src/generic/fdrepdlg.cpp:124
+#: ../src/generic/fdrepdlg.cpp:121
 msgid "Replace with:"
 msgstr "Nahradiť čím:"
 
-#: ../src/common/valtext.cpp:163
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Replace..."
+msgstr "Nahradiť"
+
+#: ../src/common/valtext.cpp:184
 msgid "Required information entry is empty."
 msgstr "Požadovaná položka informácie je prázdna."
 
-#: ../src/common/translation.cpp:1975
+#: ../src/common/translation.cpp:2025
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "Zdroj '%s' nie je platným katalógom správ."
 
+#: ../src/gtk/webview_webkit.cpp:985
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:56
+#: ../src/common/accelcmn.cpp:53
 msgid "Return"
 msgstr "Enter"
 
-#: ../src/common/stockitem.cpp:189
+#: ../src/common/stockitem.cpp:186
 msgid "Revert to Saved"
 msgstr "Návrat k uloženej verzii"
 
@@ -6079,41 +6246,41 @@ msgstr "Vrcholky"
 msgid "Rig&ht-to-left"
 msgstr "S&prava doľava"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6149
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:59 ../src/generic/datavgen.cpp:6954
+#: ../src/richtext/richtextsizepage.cpp:250
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextbulletspage.cpp:188
-#: ../src/richtext/richtextsizepage.cpp:250 ../src/common/accelcmn.cpp:62
 msgid "Right"
 msgstr "Vpravo"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1754
+#: ../src/propgrid/advprops.cpp:1655
 msgid "Right Arrow"
 msgstr "Šípka vpravo"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1770
+#: ../src/propgrid/advprops.cpp:1671
 msgid "Right Button"
 msgstr "Pravé tlačidlo"
 
-#: ../src/generic/prntdlgg.cpp:892
+#: ../src/generic/prntdlgg.cpp:885
 msgid "Right margin (mm):"
 msgstr "Pravý okraj (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:148
-#: ../src/richtext/richtextindentspage.cpp:150
 #: ../src/richtext/richtextliststylepage.cpp:337
 #: ../src/richtext/richtextliststylepage.cpp:339
+#: ../src/richtext/richtextindentspage.cpp:148
+#: ../src/richtext/richtextindentspage.cpp:150
 msgid "Right-align text."
 msgstr "Zarovnať text doprava."
 
-#: ../src/generic/fontdlgg.cpp:322
+#: ../src/generic/fontdlgg.cpp:318
 msgid "Roman"
 msgstr "Rímske"
 
-#: ../src/generic/datavgen.cpp:5916
+#: ../src/generic/datavgen.cpp:6721
 #, c-format
 msgid "Row %i"
 msgstr "Riadok %i"
@@ -6123,30 +6290,31 @@ msgstr "Riadok %i"
 msgid "S&tandard bullet name:"
 msgstr "Názov š&tandardného oddeľovača položiek zoznamu:"
 
-#: ../src/common/accelcmn.cpp:268 ../src/common/accelcmn.cpp:350
+#: ../src/common/accelcmn.cpp:282 ../src/common/accelcmn.cpp:367
 msgid "SPECIAL"
 msgstr "ŠPECIÁLNE"
 
-#: ../src/common/stockitem.cpp:190 ../src/common/sizer.cpp:2797
+#: ../src/common/stockitem.cpp:187 ../src/common/sizer.cpp:2914
 msgid "Save"
 msgstr "Uložiť"
 
-#: ../src/common/fldlgcmn.cpp:342
+#: ../src/common/fldlgcmn.cpp:339
 #, c-format
 msgid "Save %s file"
 msgstr "Uložiť súbor %s"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/common/stockitem.cpp:188 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Uložiť &ako..."
 
-#: ../src/common/docview.cpp:366
+#: ../src/common/docview.cpp:359
 msgid "Save As"
 msgstr "Uložiť ako"
 
-#: ../src/common/stockitem.cpp:191
-msgid "Save as"
-msgstr "Uložiť ako"
+#: ../src/common/stockitem.cpp:188
+#, fuzzy
+msgid "Save As..."
+msgstr "Uložiť &ako..."
 
 #: ../src/common/stockitem.cpp:267
 msgid "Save current document"
@@ -6156,96 +6324,96 @@ msgstr "Uložiť aktuálny dokument"
 msgid "Save current document with a different filename"
 msgstr "Uložiť aktuálny dokument pod odlišným názvom"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/generic/logg.cpp:509
 msgid "Save log contents to file"
 msgstr "Uložiť obsah záznamu do súboru"
 
-#: ../src/common/secretstore.cpp:179
-#, c-format
-msgid "Saving password for \"%s/%s\" failed: %s."
+#: ../src/common/secretstore.cpp:189
+#, fuzzy, c-format
+msgid "Saving password for \"%s\" failed: %s."
 msgstr "Uloženie hesla pre \"%s / %s\" zlyhalo: %s."
 
-#: ../src/generic/fontdlgg.cpp:325
+#: ../src/generic/fontdlgg.cpp:321
 msgid "Script"
 msgstr "Skript"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll Lock"
 msgstr "Scroll Lock"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll_lock"
 msgstr "Scroll_lock"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:890
+#: ../src/propgrid/advprops.cpp:791
 msgid "Scrollbar"
 msgstr "Posuvník"
 
-#: ../src/generic/srchctlg.cpp:56 ../src/html/helpwnd.cpp:535
-#: ../src/html/helpwnd.cpp:550
+#: ../src/generic/srchctlg.cpp:55 ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:548 ../src/gtk/srchctrl.cpp:182
 msgid "Search"
 msgstr "Hľadať"
 
-#: ../src/html/helpwnd.cpp:537
+#: ../src/html/helpwnd.cpp:535
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
 msgstr ""
 "Vyhľadá v obsahu pomocníka všetky výskyty textu, ktorý ste napísali vyššie"
 
-#: ../src/generic/fdrepdlg.cpp:160
+#: ../src/generic/fdrepdlg.cpp:157
 msgid "Search direction"
 msgstr "Smer hľadania"
 
-#: ../src/generic/fdrepdlg.cpp:112
+#: ../src/generic/fdrepdlg.cpp:109
 msgid "Search for:"
 msgstr "Hľadať pre:"
 
-#: ../src/html/helpwnd.cpp:1052
+#: ../src/html/helpwnd.cpp:1050
 msgid "Search in all books"
 msgstr "Hľadá vo všetkých knihách"
 
-#: ../src/html/helpwnd.cpp:857
+#: ../src/html/helpwnd.cpp:855
 msgid "Searching..."
 msgstr "Hľadá sa..."
 
-#: ../src/generic/dirctrlg.cpp:446
+#: ../src/generic/dirctrlg.cpp:412
 msgid "Sections"
 msgstr "Sekcie"
 
-#: ../src/common/ffile.cpp:238
+#: ../src/common/ffile.cpp:237
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Chyba presunu na pozíciu v súbore '%s'"
 
-#: ../src/common/ffile.cpp:228
+#: ../src/common/ffile.cpp:227
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
 "Chyba presunu na pozíciu v súbore '%s' (stdio nepodporuje veľké súbory)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:76
+#: ../src/common/accelcmn.cpp:73
 msgid "Select"
 msgstr "Vybrať"
 
-#: ../src/richtext/richtextctrl.cpp:337 ../src/osx/textctrl_osx.cpp:581
-#: ../src/common/stockitem.cpp:192 ../src/msw/textctrl.cpp:2512
+#: ../src/osx/textctrl_osx.cpp:599 ../src/common/stockitem.cpp:189
+#: ../src/msw/textctrl.cpp:2777 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Vybrať &všetko"
 
-#: ../src/common/stockitem.cpp:192 ../src/stc/stc_i18n.cpp:21
+#: ../src/common/stockitem.cpp:189 ../src/stc/stc_i18n.cpp:21
 msgid "Select All"
 msgstr "Vybrať všetko"
 
-#: ../src/common/docview.cpp:1895
+#: ../src/common/docview.cpp:1900
 msgid "Select a document template"
 msgstr "Vybrať šablónu dokumentu"
 
-#: ../src/common/docview.cpp:1969
+#: ../src/common/docview.cpp:1974
 msgid "Select a document view"
 msgstr "Vybrať náhľad dokumentu"
 
@@ -6274,20 +6442,20 @@ msgid "Selects the list level to edit."
 msgstr "Vyberá, ktorá úroveň zoznamu sa bude upravovať."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:82
+#: ../src/common/accelcmn.cpp:79
 msgid "Separator"
 msgstr "Oddeľovač"
 
-#: ../src/common/cmdline.cpp:1083
+#: ../src/common/cmdline.cpp:1079
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Za voľbou '%s' sa očakáva oddeľovač."
 
-#: ../src/osx/menu_osx.cpp:572
+#: ../src/osx/menu_osx.cpp:464
 msgid "Services"
 msgstr "Služby"
 
-#: ../src/richtext/richtextbuffer.cpp:11217
+#: ../src/richtext/richtextbuffer.cpp:11216
 msgid "Set Cell Style"
 msgstr "Nastaviť štýl bunky"
 
@@ -6295,11 +6463,11 @@ msgstr "Nastaviť štýl bunky"
 msgid "SetProperty called w/o valid setter"
 msgstr "SetProperty volá w/o platný nastavovač"
 
-#: ../src/generic/prntdlgg.cpp:188
+#: ../src/generic/prntdlgg.cpp:181
 msgid "Setup..."
 msgstr "Nastavenie..."
 
-#: ../src/msw/dialup.cpp:544
+#: ../src/msw/dialup.cpp:538
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr ""
 "Bolo nájdených niekoľko aktívnych vytáčaných spojení, vyberám náhodne jedno."
@@ -6316,40 +6484,40 @@ msgstr "Tieň"
 msgid "Shadow c&olour:"
 msgstr "&Farba tieňa:"
 
-#: ../src/common/accelcmn.cpp:335
+#: ../src/common/accelcmn.cpp:349
 msgid "Shift+"
 msgstr "Shift+"
 
-#: ../src/generic/dirdlgg.cpp:147
+#: ../src/generic/dirdlgg.cpp:144
 msgid "Show &hidden directories"
 msgstr "Zobraziť &skryté priečinky"
 
-#: ../src/generic/filectrlg.cpp:983
+#: ../src/generic/filectrlg.cpp:979
 msgid "Show &hidden files"
 msgstr "Zobraziť &skryté súbory"
 
-#: ../src/osx/menu_osx.cpp:580
+#: ../src/osx/menu_osx.cpp:472
 msgid "Show All"
 msgstr "Zobraziť všetko"
 
-#: ../src/common/stockitem.cpp:257
+#: ../src/common/stockitem.cpp:254
 msgid "Show about dialog"
 msgstr "Zobraziť dialóg O aplikácii"
 
-#: ../src/html/helpwnd.cpp:492
+#: ../src/html/helpwnd.cpp:490
 msgid "Show all"
 msgstr "Zobraziť všetko"
 
-#: ../src/html/helpwnd.cpp:503
+#: ../src/html/helpwnd.cpp:501
 msgid "Show all items in index"
 msgstr "Zobrazí všetky položky v indexe"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:656
 msgid "Show/hide navigation panel"
 msgstr "Zobrazí/skryje navigačný panel"
 
-#: ../src/richtext/richtextsymboldlg.cpp:421
-#: ../src/richtext/richtextsymboldlg.cpp:423
+#: ../src/richtext/richtextsymboldlg.cpp:418
+#: ../src/richtext/richtextsymboldlg.cpp:420
 msgid "Shows a Unicode subset."
 msgstr "Zobrazí náhľad podsadu Unicode."
 
@@ -6365,7 +6533,7 @@ msgstr "Zobrazí náhľad nastavení oddeľovačov položiek zoznamu."
 msgid "Shows a preview of the font settings."
 msgstr "Zobrazí náhľad nastavení písma."
 
-#: ../src/osx/carbon/fontdlg.cpp:394 ../src/osx/carbon/fontdlg.cpp:396
+#: ../src/osx/carbon/fontdlg.cpp:391 ../src/osx/carbon/fontdlg.cpp:393
 msgid "Shows a preview of the font."
 msgstr "Zobrazí náhľad písma."
 
@@ -6374,62 +6542,62 @@ msgstr "Zobrazí náhľad písma."
 msgid "Shows a preview of the paragraph settings."
 msgstr "Zobrazí náhľad nastavení odstavca."
 
-#: ../src/generic/fontdlgg.cpp:460 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:456 ../src/generic/fontdlgg.cpp:458
 msgid "Shows the font preview."
 msgstr "Zobrazí náhľad písma."
 
-#: ../src/propgrid/advprops.cpp:1607
+#: ../src/propgrid/advprops.cpp:1513
 msgid "Silver"
 msgstr "Strieborná"
 
-#: ../src/univ/themes/mono.cpp:516
+#: ../src/univ/themes/mono.cpp:513
 msgid "Simple monochrome theme"
 msgstr "Jednoduchá monochromatická téma"
 
-#: ../src/richtext/richtextindentspage.cpp:275
 #: ../src/richtext/richtextliststylepage.cpp:449
+#: ../src/richtext/richtextindentspage.cpp:275
 msgid "Single"
 msgstr "Osamotene"
 
-#: ../src/generic/filectrlg.cpp:425 ../src/richtext/richtextformatdlg.cpp:369
-#: ../src/richtext/richtextsizepage.cpp:299
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextsizepage.cpp:299
+#: ../src/richtext/richtextformatdlg.cpp:362
 msgid "Size"
 msgstr "Veľkosť"
 
-#: ../src/osx/carbon/fontdlg.cpp:339
+#: ../src/osx/carbon/fontdlg.cpp:336
 msgid "Size:"
 msgstr "Veľkosť:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1775
+#: ../src/propgrid/advprops.cpp:1676
 msgid "Sizing"
 msgstr "Úprav veľkosti"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1772
+#: ../src/propgrid/advprops.cpp:1673
 msgid "Sizing N-S"
 msgstr "Úprava veľkosti S-J"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1771
+#: ../src/propgrid/advprops.cpp:1672
 msgid "Sizing NE-SW"
 msgstr "Úprava veľkosti SV-JZ"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1773
+#: ../src/propgrid/advprops.cpp:1674
 msgid "Sizing NW-SE"
 msgstr "Úprava veľkosti SZ-JV"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1774
+#: ../src/propgrid/advprops.cpp:1675
 msgid "Sizing W-E"
 msgstr "Úprava veľkosti Z-V"
 
-#: ../src/msw/progdlg.cpp:801
+#: ../src/msw/progdlg.cpp:1088
 msgid "Skip"
 msgstr "Preskočiť"
 
-#: ../src/generic/fontdlgg.cpp:330
+#: ../src/generic/fontdlgg.cpp:326
 msgid "Slant"
 msgstr "Šikmý"
 
@@ -6438,7 +6606,7 @@ msgid "Small C&apitals"
 msgstr "Malé &kapitálky"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:79
+#: ../src/common/accelcmn.cpp:76
 msgid "Snapshot"
 msgstr "Momentka"
 
@@ -6446,37 +6614,37 @@ msgstr "Momentka"
 msgid "Solid"
 msgstr "Plný"
 
-#: ../src/common/docview.cpp:1791
+#: ../src/common/docview.cpp:1785
 msgid "Sorry, could not open this file."
 msgstr "Prepáčte, nebolo možné otvoriť tento súbor."
 
-#: ../src/common/prntbase.cpp:2057 ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2079 ../src/common/prntbase.cpp:2087
 msgid "Sorry, not enough memory to create a preview."
 msgstr "Prepáčte, nie je dostatok pamäte pre vytvorenie náhľadu."
 
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "Sorry, that name is taken. Please choose another."
 msgstr "Prepáčte, taký názov je už použitý. Vyberte, prosím, iný."
 
-#: ../src/common/docview.cpp:1814
+#: ../src/common/docview.cpp:1819
 msgid "Sorry, the format for this file is unknown."
 msgstr "Prepáčte, formát tohto súboru je neznámy."
 
-#: ../src/unix/sound.cpp:492
+#: ../src/unix/sound.cpp:481
 msgid "Sound data are in unsupported format."
 msgstr "Zvukové údaje sú v nepodporovanom formáte."
 
-#: ../src/unix/sound.cpp:477
+#: ../src/unix/sound.cpp:466
 #, c-format
 msgid "Sound file '%s' is in unsupported format."
 msgstr "Zvukový súbor '%s' je v nepodporovanom formáte."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:67
+#: ../src/common/accelcmn.cpp:64
 msgid "Space"
 msgstr "Space"
 
@@ -6484,12 +6652,12 @@ msgstr "Space"
 msgid "Spacing"
 msgstr "Rozostup"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "Spell Check"
 msgstr "Kontrola pravopisu"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1776
+#: ../src/propgrid/advprops.cpp:1677
 msgid "Spraycan"
 msgstr "Rozprašovač"
 
@@ -6498,7 +6666,7 @@ msgstr "Rozprašovač"
 msgid "Standard"
 msgstr "Štandard"
 
-#: ../src/common/paper.cpp:104
+#: ../src/common/paper.cpp:101
 msgid "Statement, 5 1/2 x 8 1/2 in"
 msgstr "Vyhlásenie, 5 1/2 x 8 1/2 palca"
 
@@ -6507,33 +6675,29 @@ msgstr "Vyhlásenie, 5 1/2 x 8 1/2 palca"
 msgid "Static"
 msgstr "Statické"
 
-#: ../src/generic/prntdlgg.cpp:204
+#: ../src/generic/prntdlgg.cpp:197
 msgid "Status:"
 msgstr "Stav:"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "Stop"
 msgstr "Stop"
 
-#: ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196
 msgid "Strikethrough"
 msgstr "Preškrtnuté"
 
-#: ../src/common/colourcmn.cpp:45
+#: ../src/common/colourcmn.cpp:42
 #, c-format
 msgid "String To Colour : Incorrect colour specification : %s"
 msgstr "Reťazec na farbu : Nesprávna špecifikácia farby: %s"
 
 #. TRANSLATORS: Label of font style
-#: ../src/richtext/richtextformatdlg.cpp:339 ../src/propgrid/advprops.cpp:680
+#: ../src/propgrid/advprops.cpp:590 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Štýl"
 
-#: ../include/wx/richtext/richtextstyledlg.h:46
-msgid "Style Organiser"
-msgstr "Organizátor štýlov"
-
-#: ../src/osx/carbon/fontdlg.cpp:348
+#: ../src/osx/carbon/fontdlg.cpp:345
 msgid "Style:"
 msgstr "Štýl:"
 
@@ -6542,7 +6706,7 @@ msgid "Subscrip&t"
 msgstr "Pod&skript"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:83
+#: ../src/common/accelcmn.cpp:80
 msgid "Subtract"
 msgstr "Odpočítať"
 
@@ -6550,11 +6714,11 @@ msgstr "Odpočítať"
 msgid "Supe&rscript"
 msgstr "Supers&kript"
 
-#: ../src/common/paper.cpp:150
+#: ../src/common/paper.cpp:147
 msgid "SuperA/SuperA/A4 227 x 356 mm"
 msgstr "SuperA/SuperA/A4 227 x 356 mm"
 
-#: ../src/common/paper.cpp:151
+#: ../src/common/paper.cpp:148
 msgid "SuperB/SuperB/A3 305 x 487 mm"
 msgstr "SuperB/SuperB/A3 305 x 487 mm"
 
@@ -6562,7 +6726,7 @@ msgstr "SuperB/SuperB/A3 305 x 487 mm"
 msgid "Suppress hyphe&nation"
 msgstr "Potlačiť &delenie slov"
 
-#: ../src/generic/fontdlgg.cpp:326
+#: ../src/generic/fontdlgg.cpp:322
 msgid "Swiss"
 msgstr "Švajčiarske"
 
@@ -6580,73 +6744,73 @@ msgstr "&Písmo symbolu:"
 msgid "Symbols"
 msgstr "Symboly"
 
-#: ../src/common/imagtiff.cpp:369 ../src/common/imagtiff.cpp:382
-#: ../src/common/imagtiff.cpp:741
+#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
+#: ../src/common/imagtiff.cpp:738
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: Nemožno vymedziť pamäť."
 
-#: ../src/common/imagtiff.cpp:301
+#: ../src/common/imagtiff.cpp:298
 msgid "TIFF: Error loading image."
 msgstr "TIFF: Chyba pri načítaní obrázka."
 
-#: ../src/common/imagtiff.cpp:468
+#: ../src/common/imagtiff.cpp:465
 msgid "TIFF: Error reading image."
 msgstr "TIFF: Chyba pri čítaní obrázka."
 
-#: ../src/common/imagtiff.cpp:608
+#: ../src/common/imagtiff.cpp:605
 msgid "TIFF: Error saving image."
 msgstr "TIFF: Chyba pri ukladaní obrázka."
 
-#: ../src/common/imagtiff.cpp:846
+#: ../src/common/imagtiff.cpp:843
 msgid "TIFF: Error writing image."
 msgstr "TIFF: Chyba pri zápise obrázka."
 
-#: ../src/common/imagtiff.cpp:355
+#: ../src/common/imagtiff.cpp:352
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: Veľkosť obrázka je neobvykle veľká."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:68
+#: ../src/common/accelcmn.cpp:65
 msgid "Tab"
 msgstr "Tab"
 
-#: ../src/richtext/richtextbuffer.cpp:11498
+#: ../src/richtext/richtextbuffer.cpp:11497
 msgid "Table Properties"
 msgstr "Vlastnosti tabuľky"
 
-#: ../src/common/paper.cpp:145
+#: ../src/common/paper.cpp:142
 msgid "Tabloid Extra 11.69 x 18 in"
 msgstr "Zhustený extra 11.69 x 18 palcov"
 
-#: ../src/common/paper.cpp:102
+#: ../src/common/paper.cpp:99
 msgid "Tabloid, 11 x 17 in"
 msgstr "Zhustený, 11 x 17 palcov"
 
-#: ../src/richtext/richtextformatdlg.cpp:354
+#: ../src/richtext/richtextformatdlg.cpp:347
 msgid "Tabs"
 msgstr "Tabelátory"
 
-#: ../src/propgrid/advprops.cpp:1598
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Teal"
 msgstr "Modrozelená"
 
-#: ../src/generic/fontdlgg.cpp:327
+#: ../src/generic/fontdlgg.cpp:323
 msgid "Teletype"
 msgstr "Ďalekopis"
 
-#: ../src/common/docview.cpp:1896
+#: ../src/common/docview.cpp:1901
 msgid "Templates"
 msgstr "Šablóny"
 
-#: ../src/common/fmapbase.cpp:158
+#: ../src/common/fmapbase.cpp:155
 msgid "Thai (ISO-8859-11)"
 msgstr "Thajské (ISO-8859-11)"
 
-#: ../src/common/ftp.cpp:619
+#: ../src/common/ftp.cpp:622
 msgid "The FTP server doesn't support passive mode."
 msgstr "FTP server nepodporuje pasívny režim."
 
-#: ../src/common/ftp.cpp:605
+#: ../src/common/ftp.cpp:608
 msgid "The FTP server doesn't support the PORT command."
 msgstr "FTP server nepodporuje príkaz PORT."
 
@@ -6657,8 +6821,8 @@ msgstr "FTP server nepodporuje príkaz PORT."
 msgid "The available bullet styles."
 msgstr "Dostupné štýly oddeľovačov položiek zoznamu."
 
-#: ../src/richtext/richtextstyledlg.cpp:202
-#: ../src/richtext/richtextstyledlg.cpp:204
+#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:200
 msgid "The available styles."
 msgstr "Dostupné štýly."
 
@@ -6714,12 +6878,12 @@ msgstr "Spodná poloha."
 msgid "The bullet character."
 msgstr "Znak oddeľovača položiek zoznamu."
 
-#: ../src/richtext/richtextsymboldlg.cpp:443
-#: ../src/richtext/richtextsymboldlg.cpp:445
+#: ../src/richtext/richtextsymboldlg.cpp:440
+#: ../src/richtext/richtextsymboldlg.cpp:442
 msgid "The character code."
 msgstr "Kód znaku."
 
-#: ../src/common/fontmap.cpp:203
+#: ../src/common/fontmap.cpp:200
 #, c-format
 msgid ""
 "The charset '%s' is unknown. You may select\n"
@@ -6730,7 +6894,7 @@ msgstr ""
 "inú znakovú sadu, ktorá ju nahradí, alebo zvoliť\n"
 "[Zrušiť] ak ju nemožno nahradiť"
 
-#: ../src/msw/ole/dataobj.cpp:394
+#: ../src/msw/ole/dataobj.cpp:402
 #, c-format
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "Formát schránky '%d' neexistuje."
@@ -6740,7 +6904,7 @@ msgstr "Formát schránky '%d' neexistuje."
 msgid "The default style for the next paragraph."
 msgstr "Štandardný štýl ďalšieho odstavca."
 
-#: ../src/generic/dirdlgg.cpp:202
+#: ../src/generic/dirdlgg.cpp:199
 #, c-format
 msgid ""
 "The directory '%s' does not exist\n"
@@ -6749,7 +6913,7 @@ msgstr ""
 "Priečinok '%s' neexistuje\n"
 "Chcete ho teraz vytvoriť?"
 
-#: ../src/html/htmprint.cpp:271
+#: ../src/html/htmprint.cpp:283
 #, c-format
 msgid ""
 "The document \"%s\" doesn't fit on the page horizontally and will be "
@@ -6761,7 +6925,7 @@ msgstr ""
 "\n"
 "Chcete napriek tomu pokračovať v jeho tlači?"
 
-#: ../src/common/docview.cpp:1202
+#: ../src/common/docview.cpp:1196
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -6770,36 +6934,37 @@ msgstr ""
 "Súbor '%s' neexistuje a nebolo možné ho otvoriť.\n"
 "Bol odstránený zo zoznamu naposledy použitých súborov."
 
-#: ../src/richtext/richtextindentspage.cpp:208
-#: ../src/richtext/richtextindentspage.cpp:210
 #: ../src/richtext/richtextliststylepage.cpp:394
 #: ../src/richtext/richtextliststylepage.cpp:396
+#: ../src/richtext/richtextindentspage.cpp:208
+#: ../src/richtext/richtextindentspage.cpp:210
 msgid "The first line indent."
 msgstr "Odsadenie prvého riadka."
 
-#: ../src/gtk/utilsgtk.cpp:481
-msgid "The following standard GTK+ options are also supported:\n"
-msgstr "Podporované sú aj nasledujúce štandardné možnosti GTK +:\n"
+#: ../src/generic/dbgrptg.cpp:318
+#, fuzzy
+msgid "The following debug report will be generated\n"
+msgstr "*** Bolo vytvorené hlásenie o chybe\n"
 
-#: ../src/generic/fontdlgg.cpp:414 ../src/generic/fontdlgg.cpp:416
+#: ../src/generic/fontdlgg.cpp:411 ../src/generic/fontdlgg.cpp:413
 msgid "The font colour."
 msgstr "Farba písma."
 
-#: ../src/generic/fontdlgg.cpp:375 ../src/generic/fontdlgg.cpp:377
+#: ../src/generic/fontdlgg.cpp:371 ../src/generic/fontdlgg.cpp:373
 msgid "The font family."
 msgstr "Príbuzné písma."
 
-#: ../src/richtext/richtextsymboldlg.cpp:405
-#: ../src/richtext/richtextsymboldlg.cpp:407
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "The font from which to take the symbol."
 msgstr "Písmo pre použitie symbolu."
 
-#: ../src/generic/fontdlgg.cpp:427 ../src/generic/fontdlgg.cpp:429
-#: ../src/generic/fontdlgg.cpp:434 ../src/generic/fontdlgg.cpp:436
+#: ../src/generic/fontdlgg.cpp:424 ../src/generic/fontdlgg.cpp:426
+#: ../src/generic/fontdlgg.cpp:430 ../src/generic/fontdlgg.cpp:432
 msgid "The font point size."
 msgstr "Veľkosť bodu písma."
 
-#: ../src/osx/carbon/fontdlg.cpp:343 ../src/osx/carbon/fontdlg.cpp:345
+#: ../src/osx/carbon/fontdlg.cpp:340 ../src/osx/carbon/fontdlg.cpp:342
 msgid "The font size in points."
 msgstr "Veľkosť písma v bodoch."
 
@@ -6808,15 +6973,15 @@ msgstr "Veľkosť písma v bodoch."
 msgid "The font size units, points or pixels."
 msgstr "Jednotky veľkosti písma, body alebo pixely."
 
-#: ../src/generic/fontdlgg.cpp:386 ../src/generic/fontdlgg.cpp:388
+#: ../src/generic/fontdlgg.cpp:382 ../src/generic/fontdlgg.cpp:384
 msgid "The font style."
 msgstr "Štýl písma."
 
-#: ../src/generic/fontdlgg.cpp:397 ../src/generic/fontdlgg.cpp:399
+#: ../src/generic/fontdlgg.cpp:393 ../src/generic/fontdlgg.cpp:395
 msgid "The font weight."
 msgstr "Hrúbka písma."
 
-#: ../src/common/docview.cpp:1483
+#: ../src/common/docview.cpp:1477
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Formát súboru '%s' sa nepodarilo určiť."
@@ -6826,10 +6991,10 @@ msgstr "Formát súboru '%s' sa nepodarilo určiť."
 msgid "The horizontal offset."
 msgstr "Horizontálny posuv."
 
-#: ../src/richtext/richtextindentspage.cpp:199
-#: ../src/richtext/richtextindentspage.cpp:201
 #: ../src/richtext/richtextliststylepage.cpp:385
 #: ../src/richtext/richtextliststylepage.cpp:387
+#: ../src/richtext/richtextindentspage.cpp:199
+#: ../src/richtext/richtextindentspage.cpp:201
 msgid "The left indent."
 msgstr "Odsadenie zľava."
 
@@ -6850,10 +7015,10 @@ msgstr "Veľkosť ľavého priestoru výplne."
 msgid "The left position."
 msgstr "Ľavá poloha."
 
-#: ../src/richtext/richtextindentspage.cpp:288
-#: ../src/richtext/richtextindentspage.cpp:290
 #: ../src/richtext/richtextliststylepage.cpp:462
 #: ../src/richtext/richtextliststylepage.cpp:464
+#: ../src/richtext/richtextindentspage.cpp:288
+#: ../src/richtext/richtextindentspage.cpp:290
 msgid "The line spacing."
 msgstr "Riadkovanie."
 
@@ -6862,7 +7027,7 @@ msgstr "Riadkovanie."
 msgid "The list item number."
 msgstr "Číslo položky zoznamu."
 
-#: ../src/msw/ole/automtn.cpp:664
+#: ../src/msw/ole/automtn.cpp:655
 msgid "The locale ID is unknown."
 msgstr "ID miestneho nastavenia nie je známy."
 
@@ -6901,7 +7066,7 @@ msgstr "Šírka objektu."
 msgid "The outline level."
 msgstr "Úroveň obrysu."
 
-#: ../src/common/log.cpp:277
+#: ../src/common/log.cpp:296
 #, c-format
 msgid "The previous message repeated %u time."
 msgid_plural "The previous message repeated %u times."
@@ -6909,12 +7074,12 @@ msgstr[0] "Predchádzajúca správa sa opakovala %u krát."
 msgstr[1] "Predchádzajúca správa sa opakovala %u krát."
 msgstr[2] "Predchádzajúca správa sa opakovala %u krát."
 
-#: ../src/common/log.cpp:270
+#: ../src/common/log.cpp:289
 msgid "The previous message repeated once."
 msgstr "Predošlá správa sa opakovala raz."
 
-#: ../src/richtext/richtextsymboldlg.cpp:462
-#: ../src/richtext/richtextsymboldlg.cpp:464
+#: ../src/richtext/richtextsymboldlg.cpp:459
+#: ../src/richtext/richtextsymboldlg.cpp:461
 msgid "The range to show."
 msgstr "Obraziť rozsah."
 
@@ -6928,15 +7093,15 @@ msgstr ""
 "súkromné informácie,\n"
 "zrušte ich zaškrtnutie a budú z prehľadu odstránené.\n"
 
-#: ../src/common/cmdline.cpp:1254
+#: ../src/common/cmdline.cpp:1250
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "Požadovaný parameter '%s' nebol zadaný."
 
-#: ../src/richtext/richtextindentspage.cpp:217
-#: ../src/richtext/richtextindentspage.cpp:219
 #: ../src/richtext/richtextliststylepage.cpp:403
 #: ../src/richtext/richtextliststylepage.cpp:405
+#: ../src/richtext/richtextindentspage.cpp:217
+#: ../src/richtext/richtextindentspage.cpp:219
 msgid "The right indent."
 msgstr "Pravé odsadenie."
 
@@ -6977,16 +7142,16 @@ msgstr "Nepriehľadnosť tieňa."
 msgid "The shadow spread."
 msgstr "Rozprestrenie tieňa."
 
-#: ../src/richtext/richtextindentspage.cpp:267
 #: ../src/richtext/richtextliststylepage.cpp:439
 #: ../src/richtext/richtextliststylepage.cpp:441
+#: ../src/richtext/richtextindentspage.cpp:267
 msgid "The spacing after the paragraph."
 msgstr "Šírka medzery po odseku."
 
-#: ../src/richtext/richtextindentspage.cpp:257
-#: ../src/richtext/richtextindentspage.cpp:259
 #: ../src/richtext/richtextliststylepage.cpp:430
 #: ../src/richtext/richtextliststylepage.cpp:432
+#: ../src/richtext/richtextindentspage.cpp:257
+#: ../src/richtext/richtextindentspage.cpp:259
 msgid "The spacing before the paragraph."
 msgstr "Šírka medzery pred odsekom."
 
@@ -7000,12 +7165,12 @@ msgstr "Názov štýlu."
 msgid "The style on which this style is based."
 msgstr "Štýl, na ktorom je tento štýl založený."
 
-#: ../src/richtext/richtextstyledlg.cpp:214
-#: ../src/richtext/richtextstyledlg.cpp:216
+#: ../src/richtext/richtextstyledlg.cpp:210
+#: ../src/richtext/richtextstyledlg.cpp:212
 msgid "The style preview."
 msgstr "Náhľad štýlu."
 
-#: ../src/msw/ole/automtn.cpp:680
+#: ../src/msw/ole/automtn.cpp:671
 msgid "The system cannot find the file specified."
 msgstr "Systém nemôže nájsť zadaný súbor."
 
@@ -7018,7 +7183,7 @@ msgstr "Pozícia tabelátora."
 msgid "The tab positions."
 msgstr "Pozície tabelátora."
 
-#: ../src/richtext/richtextctrl.cpp:3098
+#: ../src/richtext/richtextctrl.cpp:3099
 msgid "The text couldn't be saved."
 msgstr "Nemožno uložiť text."
 
@@ -7039,7 +7204,7 @@ msgstr "Veľkosť vrchného priestoru výplne."
 msgid "The top position."
 msgstr "Horná poloha."
 
-#: ../src/common/cmdline.cpp:1232
+#: ../src/common/cmdline.cpp:1228
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "Je potrebné zadať hodnotu voľby '%s'."
@@ -7049,7 +7214,7 @@ msgstr "Je potrebné zadať hodnotu voľby '%s'."
 msgid "The value of the corner radius."
 msgstr "Hodnota polomeru rohu."
 
-#: ../src/msw/dialup.cpp:433
+#: ../src/msw/dialup.cpp:427
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -7063,29 +7228,29 @@ msgstr ""
 msgid "The vertical offset."
 msgstr "Vertikálny pusuv."
 
-#: ../src/richtext/richtextprint.cpp:619 ../src/html/htmprint.cpp:745
+#: ../src/html/htmprint.cpp:749 ../src/richtext/richtextprint.cpp:615
 msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr ""
 "Počas nastavenia stránky nastal problém: zrejme treba nastaviť štandardnú "
 "tlačiareň."
 
-#: ../src/html/htmprint.cpp:255
+#: ../src/html/htmprint.cpp:267
 msgid ""
 "This document doesn't fit on the page horizontally and will be truncated "
 "when it is printed."
 msgstr "Tento dokument sa nezmestí na stránku vodorovne a pri tlači sa skráti."
 
-#: ../src/common/image.cpp:2854
+#: ../src/common/image.cpp:2963
 #, c-format
 msgid "This is not a %s."
 msgstr "Toto nie je %s."
 
-#: ../src/common/wincmn.cpp:1653
+#: ../src/common/wincmn.cpp:1654
 msgid "This platform does not support background transparency."
 msgstr "Táto platforma nepodporuje priehľadnosť pozadia."
 
-#: ../src/gtk/window.cpp:4660
+#: ../src/gtk/window.cpp:5664
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
@@ -7093,7 +7258,15 @@ msgstr ""
 "Tento program bol skompilovaný s príliš starou verziou GTK+. Znova ju "
 "zostavte s GTK+ 2.12 alebo novšou verziou."
 
-#: ../src/msw/thread.cpp:1240
+#: ../src/gtk/glcanvas.cpp:176
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/msw/thread.cpp:1246
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -7101,12 +7274,12 @@ msgstr ""
 "Zlyhala inicializácia modulu vlákien: nemožno uložiť hodnotu v lokálnom "
 "priestore vlákna"
 
-#: ../src/unix/threadpsx.cpp:1794
+#: ../src/unix/threadpsx.cpp:1843
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 "Zlyhala inicializácia modulu vlákien: nepodarilo sa vytvoriť kľúč vlákna"
 
-#: ../src/msw/thread.cpp:1228
+#: ../src/msw/thread.cpp:1234
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -7114,82 +7287,82 @@ msgstr ""
 "Zlyhala inicializácia modulu vlákien: nebolo možné alokovať index v lokálnom "
 "priestore vlákna"
 
-#: ../src/unix/threadpsx.cpp:1043
+#: ../src/unix/threadpsx.cpp:1061
 msgid "Thread priority setting is ignored."
 msgstr "Nastavenie priority vlákna bolo ignorované."
 
-#: ../src/msw/mdi.cpp:176
+#: ../src/msw/mdi.cpp:171
 msgid "Tile &Horizontally"
 msgstr "Dlaždice &horizontálne"
 
-#: ../src/msw/mdi.cpp:177
+#: ../src/msw/mdi.cpp:172
 msgid "Tile &Vertically"
 msgstr "Dlaždice &vertikálne"
 
-#: ../src/common/ftp.cpp:200
+#: ../src/common/ftp.cpp:197
 msgid "Timeout while waiting for FTP server to connect, try passive mode."
 msgstr ""
 "Interval, počas ktorého sa čaká na pripojenie k FTP serveru, skúste pasívny "
 "režim."
 
-#: ../src/generic/tipdlg.cpp:201
+#: ../src/generic/tipdlg.cpp:198
 msgid "Tip of the Day"
 msgstr "Tip dňa"
 
-#: ../src/generic/tipdlg.cpp:140
+#: ../src/generic/tipdlg.cpp:137
 msgid "Tips not available, sorry!"
 msgstr "Tipy nie sú dostupné, prepáčte!"
 
-#: ../src/generic/prntdlgg.cpp:242
+#: ../src/generic/prntdlgg.cpp:235
 msgid "To:"
 msgstr "Do:"
 
-#: ../src/richtext/richtextbuffer.cpp:8363
+#: ../src/richtext/richtextbuffer.cpp:8361
 msgid "Too many EndStyle calls!"
 msgstr "Príliš veľa volaní EndStyle!"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:891
+#: ../src/propgrid/advprops.cpp:792
 msgid "Tooltip"
 msgstr "Popis"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:892
+#: ../src/propgrid/advprops.cpp:793
 msgid "TooltipText"
 msgstr "Text popisu"
 
-#: ../src/richtext/richtextsizepage.cpp:286
-#: ../src/richtext/richtextsizepage.cpp:290 ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197 ../src/richtext/richtextsizepage.cpp:286
+#: ../src/richtext/richtextsizepage.cpp:290
 msgid "Top"
 msgstr "Zhora"
 
-#: ../src/generic/prntdlgg.cpp:881
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Top margin (mm):"
 msgstr "Horný okraj (mm):"
 
-#: ../src/generic/aboutdlgg.cpp:79
+#: ../src/generic/aboutdlgg.cpp:76
 msgid "Translations by "
 msgstr "Preložil "
 
-#: ../src/generic/aboutdlgg.cpp:188
+#: ../src/generic/aboutdlgg.cpp:185
 msgid "Translators"
 msgstr "Prekladatelia"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:211
+#: ../src/propgrid/propgrid.cpp:192
 msgid "True"
 msgstr "Pravda"
 
-#: ../src/common/fs_mem.cpp:227
+#: ../src/common/fs_mem.cpp:222
 #, c-format
 msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
 msgstr "Pokúšam sa odstrániť súbor '%s' z pamäte VFS, ale nie je načítaný!"
 
-#: ../src/common/fmapbase.cpp:156
+#: ../src/common/fmapbase.cpp:153
 msgid "Turkish (ISO-8859-9)"
 msgstr "Turecké (ISO-8859-9)"
 
-#: ../src/generic/filectrlg.cpp:426
+#: ../src/generic/filectrlg.cpp:422
 msgid "Type"
 msgstr "Typ"
 
@@ -7203,17 +7376,17 @@ msgstr "Zadajte názov písma."
 msgid "Type a size in points."
 msgstr "Zadajte veľkosť v bodoch."
 
-#: ../src/msw/ole/automtn.cpp:676
+#: ../src/msw/ole/automtn.cpp:667
 #, c-format
 msgid "Type mismatch in argument %u."
 msgstr "Nezhoda typu v argumente %u."
 
-#: ../src/common/xtixml.cpp:356 ../src/common/xtixml.cpp:509
-#: ../src/common/xtistrm.cpp:318
+#: ../src/common/xtixml.cpp:352 ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315
 msgid "Type must have enum - long conversion"
 msgstr "Typ musí mať enum - dlhú konverziu"
 
-#: ../src/propgrid/propgridiface.cpp:401
+#: ../src/propgrid/propgridiface.cpp:385
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
@@ -7221,19 +7394,19 @@ msgid ""
 msgstr ""
 "Zadanie typu '%s' zlyhalo: Vlastnosť s označením '%s' je typu '%s', NIE '%s'."
 
-#: ../src/common/paper.cpp:133
+#: ../src/common/paper.cpp:130
 msgid "US Std Fanfold, 14 7/8 x 11 in"
 msgstr "US Std Fanfold, 14 7/8 x 11 in"
 
-#: ../src/common/fmapbase.cpp:196
+#: ../src/common/fmapbase.cpp:193
 msgid "US-ASCII"
 msgstr "US-ASCII"
 
-#: ../src/unix/fswatcher_inotify.cpp:109
+#: ../src/unix/fswatcher_inotify.cpp:106
 msgid "Unable to add inotify watch"
 msgstr "Nemožno pridať sledovanie inotify"
 
-#: ../src/unix/fswatcher_kqueue.cpp:136
+#: ../src/unix/fswatcher_kqueue.cpp:153
 msgid "Unable to add kqueue watch"
 msgstr "Nemožno pridať sledovanie kqueue"
 
@@ -7245,7 +7418,7 @@ msgstr "Nemožno priradiť manipulátor k I/O portu dokončenia"
 msgid "Unable to close I/O completion port handle"
 msgstr "Nemožno zatvoriť manipulátor I/O portu dokončenia"
 
-#: ../src/unix/fswatcher_inotify.cpp:97
+#: ../src/unix/fswatcher_inotify.cpp:94
 msgid "Unable to close inotify instance"
 msgstr "Nemožno zavrieť inštanciu inotify"
 
@@ -7263,15 +7436,15 @@ msgstr "Nemožno zatvoriť manipulátor pre '%s'"
 msgid "Unable to create I/O completion port"
 msgstr "Nemožno vytvoriť port dokončenia I/O"
 
-#: ../src/msw/fswatcher.cpp:84
+#: ../src/msw/fswatcher.cpp:81
 msgid "Unable to create IOCP worker thread"
 msgstr "Nemožno vytvoriť pracovné vlákno IOCP"
 
-#: ../src/unix/fswatcher_inotify.cpp:74
+#: ../src/unix/fswatcher_inotify.cpp:71
 msgid "Unable to create inotify instance"
 msgstr "Nemožno vytvoriť inštanciu inotify"
 
-#: ../src/unix/fswatcher_kqueue.cpp:97
+#: ../src/unix/fswatcher_kqueue.cpp:114
 msgid "Unable to create kqueue instance"
 msgstr "Nemožno vytvoriť inštanciu kqueue"
 
@@ -7279,11 +7452,11 @@ msgstr "Nemožno vytvoriť inštanciu kqueue"
 msgid "Unable to dequeue completion packet"
 msgstr "Nemožno vyradiť paket"
 
-#: ../src/unix/fswatcher_kqueue.cpp:185
+#: ../src/unix/fswatcher_kqueue.cpp:202
 msgid "Unable to get events from kqueue"
 msgstr "Nemožno načítať udalosti z kqueue"
 
-#: ../src/gtk/app.cpp:435
+#: ../src/gtk/app.cpp:431
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "Nemožno inicializovať GTK+, je DISPLAY nastavený správne?"
 
@@ -7292,12 +7465,12 @@ msgstr "Nemožno inicializovať GTK+, je DISPLAY nastavený správne?"
 msgid "Unable to open path '%s'"
 msgstr "Nemožno otvoriť cestu '%s'"
 
-#: ../src/html/htmlwin.cpp:583
+#: ../src/html/htmlwin.cpp:586
 #, c-format
 msgid "Unable to open requested HTML document: %s"
 msgstr "Nemožno otvoriť požadovaný dokument HTML: %s"
 
-#: ../src/unix/sound.cpp:368
+#: ../src/unix/sound.cpp:365
 msgid "Unable to play sound asynchronously."
 msgstr "Nemožno prehrať zvuk asynchrónne."
 
@@ -7305,62 +7478,62 @@ msgstr "Nemožno prehrať zvuk asynchrónne."
 msgid "Unable to post completion status"
 msgstr "Nemožno odoslať stav dokončenia"
 
-#: ../src/unix/fswatcher_inotify.cpp:556
+#: ../src/unix/fswatcher_inotify.cpp:553
 msgid "Unable to read from inotify descriptor"
 msgstr "Nemožno čítať z popisovača inotify"
 
-#: ../src/unix/fswatcher_inotify.cpp:141
+#: ../src/unix/fswatcher_inotify.cpp:138
 #, c-format
 msgid "Unable to remove inotify watch %i"
 msgstr "Nemožno odstrániť sledovanie inotify %i"
 
-#: ../src/unix/fswatcher_kqueue.cpp:153
+#: ../src/unix/fswatcher_kqueue.cpp:170
 msgid "Unable to remove kqueue watch"
 msgstr "Nemožno odstrániť sledovanie kqueue %i"
 
-#: ../src/msw/fswatcher.cpp:168
+#: ../src/msw/fswatcher.cpp:165
 #, c-format
 msgid "Unable to set up watch for '%s'"
 msgstr "Nemožno nastaviť sledovanie pre \"%s\""
 
-#: ../src/msw/fswatcher.cpp:91
+#: ../src/msw/fswatcher.cpp:88
 msgid "Unable to start IOCP worker thread"
 msgstr "Nemožno spustiť pracovné vlákno IOCP"
 
-#: ../src/common/stockitem.cpp:201
+#: ../src/common/stockitem.cpp:198
 msgid "Undelete"
 msgstr "Obnoviť zmazané"
 
-#: ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199
 msgid "Underline"
 msgstr "Podčiarknuté"
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/richtext/richtextfontpage.cpp:359 ../src/osx/carbon/fontdlg.cpp:370
-#: ../src/propgrid/advprops.cpp:690
+#: ../src/osx/carbon/fontdlg.cpp:367 ../src/propgrid/advprops.cpp:600
+#: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Podčiarknuté"
 
-#: ../src/common/stockitem.cpp:203 ../src/stc/stc_i18n.cpp:15
+#: ../src/common/stockitem.cpp:200 ../src/stc/stc_i18n.cpp:15
 msgid "Undo"
 msgstr "Späť"
 
-#: ../src/common/stockitem.cpp:265
+#: ../src/common/stockitem.cpp:263
 msgid "Undo last action"
 msgstr "Vráti poslednú činnosť"
 
-#: ../src/common/cmdline.cpp:1029
+#: ../src/common/cmdline.cpp:1025
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Neočakávané znaky po voľbe '%s'."
 
-#: ../src/unix/fswatcher_inotify.cpp:274
+#: ../src/unix/fswatcher_inotify.cpp:271
 #, c-format
 msgid "Unexpected event for \"%s\": no matching watch descriptor."
 msgstr ""
 "Neočakávaná udalosť pre '%s': žiadny zodpovedajúci popisovač sledovania."
 
-#: ../src/common/cmdline.cpp:1195
+#: ../src/common/cmdline.cpp:1191
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Očakávaný parameter '%s'"
@@ -7369,49 +7542,49 @@ msgstr "Očakávaný parameter '%s'"
 msgid "Unexpectedly new I/O completion port was created"
 msgstr "Bol neočakávane vytvorený nový port dokončenia I/O"
 
-#: ../src/msw/fswatcher.cpp:70
+#: ../src/msw/fswatcher.cpp:67
 msgid "Ungraceful worker thread termination"
 msgstr "Nepríjemné ukončenie pracovného vlákna"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:460
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:456
+#: ../src/richtext/richtextsymboldlg.cpp:457
+#: ../src/richtext/richtextsymboldlg.cpp:458
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../src/common/fmapbase.cpp:185 ../src/common/fmapbase.cpp:191
+#: ../src/common/fmapbase.cpp:182 ../src/common/fmapbase.cpp:188
 msgid "Unicode 16 bit (UTF-16)"
 msgstr "Unicode 16-bitov (UTF-16)"
 
-#: ../src/common/fmapbase.cpp:190
+#: ../src/common/fmapbase.cpp:187
 msgid "Unicode 16 bit Big Endian (UTF-16BE)"
 msgstr "Unicode 16-bitov Big Endian (UTF-16BE)"
 
-#: ../src/common/fmapbase.cpp:186
+#: ../src/common/fmapbase.cpp:183
 msgid "Unicode 16 bit Little Endian (UTF-16LE)"
 msgstr "Unicode 16-bitov Little Endian (UTF-16LE)"
 
-#: ../src/common/fmapbase.cpp:187 ../src/common/fmapbase.cpp:193
+#: ../src/common/fmapbase.cpp:184 ../src/common/fmapbase.cpp:190
 msgid "Unicode 32 bit (UTF-32)"
 msgstr "Unicode 32-bitov (UTF-32)"
 
-#: ../src/common/fmapbase.cpp:192
+#: ../src/common/fmapbase.cpp:189
 msgid "Unicode 32 bit Big Endian (UTF-32BE)"
 msgstr "Unicode 32-bitov Big Endian (UTF-32BE)"
 
-#: ../src/common/fmapbase.cpp:188
+#: ../src/common/fmapbase.cpp:185
 msgid "Unicode 32 bit Little Endian (UTF-32LE)"
 msgstr "Unicode 32-bitov Little Endian (UTF-32LE)"
 
-#: ../src/common/fmapbase.cpp:182
+#: ../src/common/fmapbase.cpp:179
 msgid "Unicode 7 bit (UTF-7)"
 msgstr "Unicode 7-bitov (UTF-7)"
 
-#: ../src/common/fmapbase.cpp:183
+#: ../src/common/fmapbase.cpp:180
 msgid "Unicode 8 bit (UTF-8)"
 msgstr "Unicode 8-bitov (UTF-8)"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "Unindent"
 msgstr "Zrušiť odsadenie"
 
@@ -7561,97 +7734,102 @@ msgstr "Jednotky pre hornú polohu."
 msgid "Units for this value."
 msgstr "Jednotky pre túto hodnotu."
 
-#: ../src/generic/progdlgg.cpp:353 ../src/generic/progdlgg.cpp:622
+#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
 msgid "Unknown"
 msgstr "Neznámy"
 
-#: ../src/msw/dde.cpp:1174
+#: ../src/msw/dde.cpp:1238
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Neznáma chyba DDE %08x"
 
-#: ../src/common/xtistrm.cpp:410
+#: ../src/common/xtistrm.cpp:407
 msgid "Unknown Object passed to GetObjectClassInfo"
 msgstr "GetObjectClassInfo bol daný ako parameter neznámy objekt"
 
-#: ../src/common/imagpng.cpp:366
+#: ../src/common/imagpng.cpp:383
 #, c-format
 msgid "Unknown PNG resolution unit %d"
 msgstr "Neznáma jednotka rozlíšenia PNG %d"
 
-#: ../src/common/xtixml.cpp:327
+#: ../src/common/xtixml.cpp:323
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Neznáme vlastnosť %s"
 
-#: ../src/common/imagtiff.cpp:529
+#: ../src/common/imagtiff.cpp:526
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "Neznáma jednotka rozlíšenia TIFF %d je ignorovaná"
 
-#: ../src/unix/dlunix.cpp:160
+#: ../src/propgrid/props.cpp:155
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/unix/dlunix.cpp:118
 msgid "Unknown dynamic library error"
 msgstr "Neznáma chyba dynamickej knižnice"
 
-#: ../src/common/fmapbase.cpp:810
+#: ../src/common/fmapbase.cpp:806
 #, c-format
 msgid "Unknown encoding (%d)"
 msgstr "Neznáme kódovanie (%d)"
 
-#: ../src/msw/ole/automtn.cpp:688
+#: ../src/msw/ole/automtn.cpp:679
 #, c-format
 msgid "Unknown error %08x"
 msgstr "Neznáma chyba %08x"
 
-#: ../src/msw/ole/automtn.cpp:647
+#: ../src/msw/ole/automtn.cpp:638
 msgid "Unknown exception"
 msgstr "Neznáma výnimka"
 
-#: ../src/common/image.cpp:2839
+#: ../src/common/image.cpp:2942
 msgid "Unknown image data format."
 msgstr "Neznámy formát údajov obrázka."
 
-#: ../src/common/cmdline.cpp:914
+#: ../src/common/cmdline.cpp:910
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Neznámy dlhý parameter '%s'"
 
-#: ../src/msw/ole/automtn.cpp:631
+#: ../src/msw/ole/automtn.cpp:622
 msgid "Unknown name or named argument."
 msgstr "Neznáme meno alebo pomenovaný argument."
 
-#: ../src/common/cmdline.cpp:929 ../src/common/cmdline.cpp:951
+#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Neznámy parameter '%s'"
 
-#: ../src/common/mimecmn.cpp:225
+#: ../src/common/mimecmn.cpp:221
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "Nespárovaná '{' v zázname mime typu %s."
 
-#: ../src/common/cmdproc.cpp:262 ../src/common/cmdproc.cpp:288
-#: ../src/common/cmdproc.cpp:308
+#: ../src/common/cmdproc.cpp:255 ../src/common/cmdproc.cpp:281
+#: ../src/common/cmdproc.cpp:301
 msgid "Unnamed command"
 msgstr "Nepomenovaný príkaz"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:413
+#: ../src/propgrid/propgrid.cpp:392
 msgid "Unspecified"
 msgstr "Nešpecifikované"
 
-#: ../src/msw/clipbrd.cpp:311
+#: ../src/msw/clipbrd.cpp:325
 msgid "Unsupported clipboard format."
 msgstr "Nepodporovaný formát schránky."
 
-#: ../src/common/appcmn.cpp:256
+#: ../src/common/appcmn.cpp:277
 #, c-format
 msgid "Unsupported theme '%s'."
 msgstr "Nepodporovaná téma '%s'."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:205
-#: ../src/common/accelcmn.cpp:63
+#: ../src/common/stockitem.cpp:202 ../src/common/accelcmn.cpp:60
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Up"
 msgstr "Hore"
 
@@ -7665,7 +7843,7 @@ msgstr "Veľké písmená"
 msgid "Upper case roman numerals"
 msgstr "Veľké rímske číslice"
 
-#: ../src/common/cmdline.cpp:1326
+#: ../src/common/cmdline.cpp:1322
 #, c-format
 msgid "Usage: %s"
 msgstr "Použitie: %s"
@@ -7674,38 +7852,47 @@ msgstr "Použitie: %s"
 msgid "Use &shadow"
 msgstr "Použiť &tieň"
 
-#: ../src/richtext/richtextindentspage.cpp:169
-#: ../src/richtext/richtextindentspage.cpp:171
 #: ../src/richtext/richtextliststylepage.cpp:358
 #: ../src/richtext/richtextliststylepage.cpp:360
+#: ../src/richtext/richtextindentspage.cpp:169
+#: ../src/richtext/richtextindentspage.cpp:171
 msgid "Use the current alignment setting."
 msgstr "Použiť súčasné nastavenie zarovnania."
 
-#: ../src/common/valtext.cpp:179
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/gtk/font.cpp:552
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/common/valtext.cpp:142
 msgid "Validation conflict"
 msgstr "Konflikt overovania"
 
-#: ../src/propgrid/manager.cpp:238
+#: ../src/propgrid/manager.cpp:224
 msgid "Value"
 msgstr "Hodnota"
 
-#: ../src/propgrid/props.cpp:386 ../src/propgrid/props.cpp:500
+#: ../src/propgrid/props.cpp:309
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "Hodnota musí byť %s alebo vyššia."
 
-#: ../src/propgrid/props.cpp:417 ../src/propgrid/props.cpp:531
+#: ../src/propgrid/props.cpp:336
 #, c-format
 msgid "Value must be %s or less."
 msgstr "Hodnota musí byť %s alebo nižšia."
 
-#: ../src/propgrid/props.cpp:393 ../src/propgrid/props.cpp:424
-#: ../src/propgrid/props.cpp:507 ../src/propgrid/props.cpp:538
+#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "Hodnota musí byť medzi %s a %s."
 
-#: ../src/generic/aboutdlgg.cpp:128
+#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Verzia "
 
@@ -7714,25 +7901,32 @@ msgstr "Verzia "
 msgid "Vertical alignment."
 msgstr "Vertikálne zarovnanie."
 
-#: ../src/generic/filedlgg.cpp:202
+#: ../src/generic/filedlgg.cpp:199
 msgid "View files as a detailed view"
 msgstr "Zobraziť súbory v detailnom pohľade"
 
-#: ../src/generic/filedlgg.cpp:200
+#: ../src/generic/filedlgg.cpp:197
 msgid "View files as a list view"
 msgstr "Zobraziť súbory v náhľade zoznamu"
 
-#: ../src/common/docview.cpp:1970
+#: ../src/common/docview.cpp:1975
 msgid "Views"
 msgstr "Náhľady"
 
+#: ../src/gtk/app.cpp:348
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1777
+#: ../src/propgrid/advprops.cpp:1678
 msgid "Wait"
 msgstr "Čakajte"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1779
+#: ../src/propgrid/advprops.cpp:1680
 msgid "Wait Arrow"
 msgstr "Šípka čakania"
 
@@ -7741,237 +7935,234 @@ msgstr "Šípka čakania"
 msgid "Waiting for IO on epoll descriptor %d failed"
 msgstr "Čakanie na IO v popisovač epoll %d zlyhalo"
 
-#: ../src/common/log.cpp:223
+#: ../src/common/log.cpp:241
 msgid "Warning: "
 msgstr "Varovanie: "
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1778
+#: ../src/propgrid/advprops.cpp:1679
 msgid "Watch"
 msgstr "Sledovať"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:685
+#: ../src/propgrid/advprops.cpp:595
 msgid "Weight"
 msgstr "Hrúbka"
 
-#: ../src/common/fmapbase.cpp:148
+#: ../src/common/fmapbase.cpp:145
 msgid "Western European (ISO-8859-1)"
 msgstr "Západoeurópske (ISO-8859-1)"
 
-#: ../src/common/fmapbase.cpp:162
+#: ../src/common/fmapbase.cpp:159
 msgid "Western European with Euro (ISO-8859-15)"
 msgstr "Západoeurópske so znakom euro (ISO-8859-15)"
 
-#: ../src/generic/fontdlgg.cpp:446 ../src/generic/fontdlgg.cpp:448
+#: ../src/generic/fontdlgg.cpp:443 ../src/generic/fontdlgg.cpp:445
 msgid "Whether the font is underlined."
 msgstr "Či je písmo podčiarknuté."
 
-#: ../src/propgrid/advprops.cpp:1611
+#: ../src/propgrid/advprops.cpp:1517
 msgid "White"
 msgstr "Biela"
 
-#: ../src/generic/fdrepdlg.cpp:144
+#: ../src/generic/fdrepdlg.cpp:141
 msgid "Whole word"
 msgstr "Celé slová"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:532
 msgid "Whole words only"
 msgstr "Iba celé slová"
 
-#: ../src/univ/themes/win32.cpp:1102
+#: ../src/univ/themes/win32.cpp:1099
 msgid "Win32 theme"
 msgstr "Motív Win32"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:893
+#: ../src/propgrid/advprops.cpp:794
 msgid "Window"
 msgstr "Okno"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:894
+#: ../src/propgrid/advprops.cpp:795
 msgid "WindowFrame"
 msgstr "Rám okna"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:895
+#: ../src/propgrid/advprops.cpp:796
 msgid "WindowText"
 msgstr "Text okna"
 
-#: ../src/common/fmapbase.cpp:177
+#: ../src/common/fmapbase.cpp:174
 msgid "Windows Arabic (CP 1256)"
 msgstr "Windows arabské (CP 1256)"
 
-#: ../src/common/fmapbase.cpp:178
+#: ../src/common/fmapbase.cpp:175
 msgid "Windows Baltic (CP 1257)"
 msgstr "Windows baltské (CP 1257)"
 
-#: ../src/common/fmapbase.cpp:171
+#: ../src/common/fmapbase.cpp:168
 msgid "Windows Central European (CP 1250)"
 msgstr "Windows stredoeurópske (CP 1250)"
 
-#: ../src/common/fmapbase.cpp:168
+#: ../src/common/fmapbase.cpp:165
 msgid "Windows Chinese Simplified (CP 936) or GB-2312"
 msgstr "Windows zjednodušená čínština (CP 936) or GB-2312"
 
-#: ../src/common/fmapbase.cpp:170
+#: ../src/common/fmapbase.cpp:167
 msgid "Windows Chinese Traditional (CP 950) or Big-5"
 msgstr "Windows tradičná čínština (CP 950) alebo Big-5"
 
-#: ../src/common/fmapbase.cpp:172
+#: ../src/common/fmapbase.cpp:169
 msgid "Windows Cyrillic (CP 1251)"
 msgstr "Windows cyrilika (CP 1251)"
 
-#: ../src/common/fmapbase.cpp:174
+#: ../src/common/fmapbase.cpp:171
 msgid "Windows Greek (CP 1253)"
 msgstr "Windows grécke (CP 1253)"
 
-#: ../src/common/fmapbase.cpp:176
+#: ../src/common/fmapbase.cpp:173
 msgid "Windows Hebrew (CP 1255)"
 msgstr "Windows hebrejské (CP 1255)"
 
-#: ../src/common/fmapbase.cpp:167
+#: ../src/common/fmapbase.cpp:164
 msgid "Windows Japanese (CP 932) or Shift-JIS"
 msgstr "Windows japonské (CP 932) alebo Shift-JIS"
 
-#: ../src/common/fmapbase.cpp:180
+#: ../src/common/fmapbase.cpp:177
 msgid "Windows Johab (CP 1361)"
 msgstr "Windows johabské (CP 1361)"
 
-#: ../src/common/fmapbase.cpp:169
+#: ../src/common/fmapbase.cpp:166
 msgid "Windows Korean (CP 949)"
 msgstr "Windows kórejské (CP 949)"
 
-#: ../src/common/fmapbase.cpp:166
+#: ../src/common/fmapbase.cpp:163
 msgid "Windows Thai (CP 874)"
 msgstr "Windows thaské (CP 874)"
 
-#: ../src/common/fmapbase.cpp:175
+#: ../src/common/fmapbase.cpp:172
 msgid "Windows Turkish (CP 1254)"
 msgstr "Windows turecké (CP 1254)"
 
-#: ../src/common/fmapbase.cpp:179
+#: ../src/common/fmapbase.cpp:176
 msgid "Windows Vietnamese (CP 1258)"
 msgstr "Windows vietnamské (CP 125á)"
 
-#: ../src/common/fmapbase.cpp:173
+#: ../src/common/fmapbase.cpp:170
 msgid "Windows Western European (CP 1252)"
 msgstr "Windows západoeurópske (CP 1252)"
 
-#: ../src/common/fmapbase.cpp:181
+#: ../src/common/fmapbase.cpp:178
 msgid "Windows/DOS OEM (CP 437)"
 msgstr "Windows/DOS OEM (CP 437)"
 
-#: ../src/common/fmapbase.cpp:165
+#: ../src/common/fmapbase.cpp:162
 msgid "Windows/DOS OEM Cyrillic (CP 866)"
 msgstr "Windows/DOS OEM cyrilika (CP 866)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:111
+#: ../src/common/accelcmn.cpp:109
 msgid "Windows_Left"
 msgstr "Windows_vľavo"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:113
+#: ../src/common/accelcmn.cpp:111
 msgid "Windows_Menu"
 msgstr "Windows_ponuka"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:112
+#: ../src/common/accelcmn.cpp:110
 msgid "Windows_Right"
 msgstr "Windows_vpravo"
 
-#: ../src/common/ffile.cpp:150
+#: ../src/common/ffile.cpp:149
 #, c-format
 msgid "Write error on file '%s'"
 msgstr "Chyba zápisu do súboru '%s'"
 
-#: ../src/xml/xml.cpp:914
+#: ../src/xml/xml.cpp:925
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "Chyba parsovania XML: '%s' na riadku %d"
 
-#: ../src/common/xpmdecod.cpp:796
+#: ../src/common/xpmdecod.cpp:794
 msgid "XPM: Malformed pixel data!"
 msgstr "XPM: Chybné údaje pixelov!"
 
-#: ../src/common/xpmdecod.cpp:705
+#: ../src/common/xpmdecod.cpp:702
 #, c-format
 msgid "XPM: incorrect colour description in line %d"
 msgstr "XPM: nesprávny popis farby na riadku %d"
 
-#: ../src/common/xpmdecod.cpp:680
+#: ../src/common/xpmdecod.cpp:677
 msgid "XPM: incorrect header format!"
 msgstr "XPM: nesprávny formát hlavičky!"
 
-#: ../src/common/xpmdecod.cpp:716 ../src/common/xpmdecod.cpp:725
+#: ../src/common/xpmdecod.cpp:714 ../src/common/xpmdecod.cpp:723
 #, c-format
 msgid "XPM: malformed colour definition '%s' at line %d!"
 msgstr "XPM: zlá definícia farby '%s' na riadku %d!"
 
-#: ../src/common/xpmdecod.cpp:755
+#: ../src/common/xpmdecod.cpp:753
 msgid "XPM: no colors left to use for mask!"
 msgstr "XPM: pre masku už nie sú potrebné žiadne farby!"
 
-#: ../src/common/xpmdecod.cpp:782
+#: ../src/common/xpmdecod.cpp:780
 #, c-format
 msgid "XPM: truncated image data at line %d!"
 msgstr "XPM: orezané dáta obrázka na %d!"
 
-#: ../src/propgrid/advprops.cpp:1610
+#: ../src/propgrid/advprops.cpp:1516
 msgid "Yellow"
 msgstr "Žltá"
 
-#: ../include/wx/msgdlg.h:276 ../src/common/stockitem.cpp:206
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:203
 #: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Áno"
 
-#: ../src/osx/carbon/overlay.cpp:155
-msgid "You cannot Clear an overlay that is not inited"
-msgstr "Nemôžete vymazať prekrytie, ktoré nie je pôvodné"
-
-#: ../src/osx/carbon/overlay.cpp:107 ../src/dfb/overlay.cpp:61
-msgid "You cannot Init an overlay twice"
-msgstr "Prekrytie nemôžete inicializovať dvakrát"
-
-#: ../src/generic/dirdlgg.cpp:287
+#: ../src/generic/dirdlgg.cpp:284
 msgid "You cannot add a new directory to this section."
 msgstr "Do tejto sekcie nemôžete pridať nový priečinok."
 
-#: ../src/propgrid/propgrid.cpp:3299
+#: ../src/propgrid/propgrid.cpp:3276
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr "Zadali ste neplatnú hodnotu. Stlačením ESC editáciu zrušíte."
 
-#: ../src/common/stockitem.cpp:209
+#: ../src/osx/cocoa/menu.mm:286
+#, fuzzy
+msgid "Zoom"
+msgstr "Priblížiť"
+
+#: ../src/common/stockitem.cpp:206
 msgid "Zoom &In"
 msgstr "&Priblížiť"
 
-#: ../src/common/stockitem.cpp:210
+#: ../src/common/stockitem.cpp:207
 msgid "Zoom &Out"
 msgstr "&Oddialiť"
 
-#: ../src/common/stockitem.cpp:209 ../src/common/prntbase.cpp:1594
+#: ../src/common/stockitem.cpp:206 ../src/common/prntbase.cpp:1619
 msgid "Zoom In"
 msgstr "Priblížiť"
 
-#: ../src/common/stockitem.cpp:210 ../src/common/prntbase.cpp:1580
+#: ../src/common/stockitem.cpp:207 ../src/common/prntbase.cpp:1605
 msgid "Zoom Out"
 msgstr "Oddialiť"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to &Fit"
 msgstr "Prispôsobiť priblížením"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to Fit"
 msgstr "Prispôsobiť priblížením"
 
-#: ../src/msw/dde.cpp:1141
+#: ../src/msw/dde.cpp:1205
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "aplikácia DDEML vytvorila podmienku predĺženej trasy."
 
-#: ../src/msw/dde.cpp:1129
+#: ../src/msw/dde.cpp:1193
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -7982,39 +8173,39 @@ msgstr ""
 "alebo neplatný identifikátor inštancie\n"
 "bol odovzdaný funkcii DDEML."
 
-#: ../src/msw/dde.cpp:1147
+#: ../src/msw/dde.cpp:1211
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "pokus klienta o nadviazanie konverzácie zlyhal."
 
-#: ../src/msw/dde.cpp:1144
+#: ../src/msw/dde.cpp:1208
 msgid "a memory allocation failed."
 msgstr "vymedzenie pamäte zlyhalo."
 
-#: ../src/msw/dde.cpp:1138
+#: ../src/msw/dde.cpp:1202
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "parameter sa nepodarilo overiť pomocou DDEML."
 
-#: ../src/msw/dde.cpp:1120
+#: ../src/msw/dde.cpp:1184
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "vypršala platnosť žiadosti o synchrónnu transakciu upozornenia."
 
-#: ../src/msw/dde.cpp:1126
+#: ../src/msw/dde.cpp:1190
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "vypršal časový limit žiadosti o synchrónnu dátovú transakciu."
 
-#: ../src/msw/dde.cpp:1135
+#: ../src/msw/dde.cpp:1199
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "vypršal čas na žiadosť o transakciu synchrónneho vykonania."
 
-#: ../src/msw/dde.cpp:1153
+#: ../src/msw/dde.cpp:1217
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "časový limit žiadosti o synchrónnu transakciu poke."
 
-#: ../src/msw/dde.cpp:1168
+#: ../src/msw/dde.cpp:1232
 msgid "a request to end an advise transaction has timed out."
 msgstr "platnosť žiadosti o ukončenie transakcie s oznámením vypršala."
 
-#: ../src/msw/dde.cpp:1162
+#: ../src/msw/dde.cpp:1226
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -8024,15 +8215,15 @@ msgstr ""
 "ktorý bol ukončený klientom alebo serverom\n"
 "ukončená pred dokončením transakcie."
 
-#: ../src/msw/dde.cpp:1150
+#: ../src/msw/dde.cpp:1214
 msgid "a transaction failed."
 msgstr "transakcia zlyhala."
 
-#: ../src/common/accelcmn.cpp:189
+#: ../src/common/accelcmn.cpp:188
 msgid "alt"
 msgstr "alt"
 
-#: ../src/msw/dde.cpp:1132
+#: ../src/msw/dde.cpp:1196
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -8044,15 +8235,15 @@ msgstr ""
 "alebo aplikácia inicializovaná ako APPCMD_CLIENTONLY\n"
 "sa pokúsil vykonať transakcie so serverom."
 
-#: ../src/msw/dde.cpp:1156
+#: ../src/msw/dde.cpp:1220
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "zlyhalo interné volanie do funkcie PostMessage. "
 
-#: ../src/msw/dde.cpp:1165
+#: ../src/msw/dde.cpp:1229
 msgid "an internal error has occurred in the DDEML."
 msgstr "v súbore DDEML sa vyskytla interná chyba."
 
-#: ../src/msw/dde.cpp:1171
+#: ../src/msw/dde.cpp:1235
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -8062,56 +8253,56 @@ msgstr ""
 "Len čo sa aplikácia vráti z XTYP_XACT_COMPLETE spätného volania,\n"
 "identifikátor transakcie pre dané spätné volanie už nie je platný."
 
-#: ../src/common/zipstrm.cpp:1483
+#: ../src/common/zipstrm.cpp:1522
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "za predpokladu, že sa jedná o viacdielny zreťazený zips"
 
-#: ../src/common/fileconf.cpp:1847
+#: ../src/common/fileconf.cpp:1849
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "pokus o zmenu nemenného kľúča '%s' bol ignorovaný."
 
-#: ../src/html/chm.cpp:329
+#: ../src/html/chm.cpp:326
 msgid "bad arguments to library function"
 msgstr "zlé argumenty pre funkciu knižnice"
 
-#: ../src/html/chm.cpp:341
+#: ../src/html/chm.cpp:338
 msgid "bad signature"
 msgstr "zlý podpis"
 
-#: ../src/common/zipstrm.cpp:1918
+#: ../src/common/zipstrm.cpp:1988
 msgid "bad zipfile offset to entry"
 msgstr "zlý posuv súboru zip pri vstupe"
 
-#: ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400
 msgid "binary"
 msgstr "binárne"
 
-#: ../src/common/fontcmn.cpp:996
+#: ../src/common/fontcmn.cpp:1195
 msgid "bold"
 msgstr "tučné"
 
-#: ../src/msw/utils.cpp:1144
+#: ../src/msw/utils.cpp:1135
 #, c-format
 msgid "build %lu"
 msgstr "zostava %lu"
 
-#: ../src/common/ffile.cpp:75
+#: ../src/common/ffile.cpp:73
 #, c-format
 msgid "can't close file '%s'"
 msgstr "nemožno zavrieť súbor '%s'"
 
-#: ../src/common/file.cpp:245
+#: ../src/common/file.cpp:242
 #, c-format
 msgid "can't close file descriptor %d"
 msgstr "nemožno zavrieť popisovač súboru %d"
 
-#: ../src/common/file.cpp:586
+#: ../src/common/ffile.cpp:382 ../src/common/file.cpp:613
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "nemožno vykonať zmeny v súbore '%s'"
 
-#: ../src/common/file.cpp:178
+#: ../src/common/file.cpp:175
 #, c-format
 msgid "can't create file '%s'"
 msgstr "nemožno vytvoriť súbor '%s'"
@@ -8121,49 +8312,49 @@ msgstr "nemožno vytvoriť súbor '%s'"
 msgid "can't delete user configuration file '%s'"
 msgstr "nemožno odstrániť konfiguračný súbor používateľa '%s'"
 
-#: ../src/common/file.cpp:495
+#: ../src/common/file.cpp:522
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr "nemožno určiť, či sa v popisovači %d dosiahol koniec súboru"
 
-#: ../src/common/zipstrm.cpp:1692
+#: ../src/common/zipstrm.cpp:1747
 msgid "can't find central directory in zip"
 msgstr "nemožno nájsť centrálny priečinok v zip"
 
-#: ../src/common/file.cpp:465
+#: ../src/common/file.cpp:492
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "nemožno nájsť dĺžku súboru v popisovači súboru %d"
 
-#: ../src/msw/utils.cpp:341
+#: ../src/msw/utils.cpp:336
 msgid "can't find user's HOME, using current directory."
 msgstr "nemožno nájsť DOMOV používateľa pomocou aktuálneho priečinka."
 
-#: ../src/common/file.cpp:366
+#: ../src/common/file.cpp:407
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "nemožno vyprázdniť popisovač súboru %d"
 
-#: ../src/common/file.cpp:422
+#: ../src/common/file.cpp:463
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "nemožno nájsť pozíciu v popisovači súboru %d"
 
-#: ../src/common/fontmap.cpp:325
+#: ../src/common/fontmap.cpp:322
 msgid "can't load any font, aborting"
 msgstr "nemožno načítať žiadne písmo, prerušuje sa"
 
-#: ../src/common/file.cpp:231 ../src/common/ffile.cpp:59
+#: ../src/common/ffile.cpp:57 ../src/common/file.cpp:228
 #, c-format
 msgid "can't open file '%s'"
 msgstr "nemožno otvoriť súbor '%s'"
 
-#: ../src/common/fileconf.cpp:320
+#: ../src/common/fileconf.cpp:314
 #, c-format
 msgid "can't open global configuration file '%s'."
 msgstr "nemožno otvoriť globálny konfiguračný súbor '%s'."
 
-#: ../src/common/fileconf.cpp:336
+#: ../src/common/fileconf.cpp:330
 #, c-format
 msgid "can't open user configuration file '%s'."
 msgstr "nemožno otvoriť konfiguračný súbor používateľa '%s'."
@@ -8172,40 +8363,40 @@ msgstr "nemožno otvoriť konfiguračný súbor používateľa '%s'."
 msgid "can't open user configuration file."
 msgstr "nemožno otvoriť konfiguračný súbor používateľa."
 
-#: ../src/common/zipstrm.cpp:579
+#: ../src/common/zipstrm.cpp:572
 msgid "can't re-initialize zlib deflate stream"
 msgstr "nemožno znova inicializovať vypustený prúd zlib"
 
-#: ../src/common/zipstrm.cpp:604
+#: ../src/common/zipstrm.cpp:597
 msgid "can't re-initialize zlib inflate stream"
 msgstr "nemožno znova inicializovať nafúknutý prúd zlib"
 
-#: ../src/common/file.cpp:304
+#: ../src/common/file.cpp:345
 #, c-format
 msgid "can't read from file descriptor %d"
 msgstr "nemôže čítať z popisovača súborov %d"
 
-#: ../src/common/file.cpp:581
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:608
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "nemožno odstrániť súbor '%s'"
 
-#: ../src/common/file.cpp:598
+#: ../src/common/ffile.cpp:394 ../src/common/file.cpp:625
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "nemožno odstrániť dočasný súbor '%s'"
 
-#: ../src/common/file.cpp:408
+#: ../src/common/file.cpp:449
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "nemožno hľadať v popisovači súboru %d"
 
-#: ../src/common/textfile.cpp:273
+#: ../src/common/textfile.cpp:161
 #, c-format
 msgid "can't write buffer '%s' to disk."
 msgstr "nemožno zapísať zásobník '%s' na disk."
 
-#: ../src/common/file.cpp:323
+#: ../src/common/file.cpp:364
 #, c-format
 msgid "can't write to file descriptor %d"
 msgstr "nemožno zapisovať do popisovača súboru %d"
@@ -8215,22 +8406,28 @@ msgid "can't write user configuration file."
 msgstr "nemožno zapísať konfiguračný súbor používateľa."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:482 ../src/generic/datavgen.cpp:1261
+#: ../src/common/datavcmn.cpp:2064 ../src/generic/datavgen.cpp:1384
 msgid "checked"
 msgstr "skontrolované"
 
-#: ../src/html/chm.cpp:345
+#: ../src/html/chm.cpp:342
 msgid "checksum error"
 msgstr "chyba kontrolného súčtu"
 
-#: ../src/common/tarstrm.cpp:820
+#: ../src/common/tarstrm.cpp:814
 msgid "checksum failure reading tar header block"
 msgstr "zlyhanie kontrolného súčtu pri čítaní bloku hlavičky tar"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:226
-#: ../src/richtext/richtextbackgroundpage.cpp:249
-#: ../src/richtext/richtextbackgroundpage.cpp:289
-#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
 #: ../src/richtext/richtextborderspage.cpp:254
 #: ../src/richtext/richtextborderspage.cpp:288
 #: ../src/richtext/richtextborderspage.cpp:322
@@ -8248,104 +8445,127 @@ msgstr "zlyhanie kontrolného súčtu pri čítaní bloku hlavičky tar"
 #: ../src/richtext/richtextmarginspage.cpp:340
 #: ../src/richtext/richtextmarginspage.cpp:363
 #: ../src/richtext/richtextmarginspage.cpp:388
-#: ../src/richtext/richtextsizepage.cpp:339
-#: ../src/richtext/richtextsizepage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:400
-#: ../src/richtext/richtextsizepage.cpp:427
-#: ../src/richtext/richtextsizepage.cpp:454
-#: ../src/richtext/richtextsizepage.cpp:481
-#: ../src/richtext/richtextsizepage.cpp:555
-#: ../src/richtext/richtextsizepage.cpp:590
-#: ../src/richtext/richtextsizepage.cpp:625
-#: ../src/richtext/richtextsizepage.cpp:660
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
 msgid "cm"
 msgstr "cm"
 
-#: ../src/html/chm.cpp:347
+#: ../src/html/chm.cpp:344
 msgid "compression error"
 msgstr "chyba kompresie"
 
-#: ../src/common/regex.cpp:236
+#: ../src/common/regex.cpp:233
 msgid "conversion to 8-bit encoding failed"
 msgstr "zlyhal prevod na 8-bitové kódovanie"
 
-#: ../src/common/accelcmn.cpp:187
+#: ../src/common/accelcmn.cpp:186
 msgid "ctrl"
 msgstr "ctrl"
 
-#: ../src/common/cmdline.cpp:1500
+#: ../src/common/cmdline.cpp:1496
 msgid "date"
 msgstr "dátum"
 
-#: ../src/html/chm.cpp:349
+#: ../src/html/chm.cpp:346
 msgid "decompression error"
 msgstr "chyba dekompresie"
 
-#: ../src/richtext/richtextstyles.cpp:780 ../src/common/fmapbase.cpp:820
+#: ../src/common/fmapbase.cpp:816 ../src/richtext/richtextstyles.cpp:777
 msgid "default"
 msgstr "pôvodné"
 
-#: ../src/common/cmdline.cpp:1496
+#: ../src/common/cmdline.cpp:1492
 msgid "double"
 msgstr "dvojité"
 
-#: ../src/common/debugrpt.cpp:538
+#: ../src/common/debugrpt.cpp:539
 msgid "dump of the process state (binary)"
 msgstr "výpis stavu procesu (binárny)"
 
-#: ../src/common/datetimefmt.cpp:1969
+#: ../src/common/datetimefmt.cpp:1992
 msgid "eighteenth"
 msgstr "osemnásteho"
 
-#: ../src/common/datetimefmt.cpp:1959
+#: ../src/common/datetimefmt.cpp:1982
 msgid "eighth"
 msgstr "ôsmeho"
 
-#: ../src/common/datetimefmt.cpp:1962
+#: ../src/common/datetimefmt.cpp:1985
 msgid "eleventh"
 msgstr "deviateho"
 
-#: ../src/common/fileconf.cpp:1833
+#: ../src/common/fileconf.cpp:1835
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "položka '%s' sa v skupine '%s' vyskytuje viackrát"
 
-#: ../src/html/chm.cpp:343
+#: ../src/html/chm.cpp:340
 msgid "error in data format"
 msgstr "chyba vo formáte údajov"
 
-#: ../src/html/chm.cpp:331
+#: ../src/html/chm.cpp:328
 msgid "error opening file"
 msgstr "chyba pri otváraní súboru"
 
-#: ../src/common/zipstrm.cpp:1778
+#: ../src/common/zipstrm.cpp:1836
 msgid "error reading zip central directory"
 msgstr "chyba pri čítaní zip centrálneho priečinka"
 
-#: ../src/common/zipstrm.cpp:1870
+#: ../src/common/zipstrm.cpp:1940
 msgid "error reading zip local header"
 msgstr "chyba pri čítaní zip miestnej hlavičky"
 
-#: ../src/common/zipstrm.cpp:2531
+#: ../src/common/zipstrm.cpp:2615
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "chyba pri zápise záznamu zip „%s“: zlý crc alebo dĺžka"
 
-#: ../src/common/ffile.cpp:188
+#: ../src/common/zipstrm.cpp:2608
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "chyba pri zápise záznamu zip „%s“: zlý crc alebo dĺžka"
+
+#: ../src/common/fontcmn.cpp:1205
+#, fuzzy
+msgid "extrabold"
+msgstr "tučné"
+
+#: ../src/common/fontcmn.cpp:1223
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1167
+#, fuzzy
+msgid "extralight"
+msgstr "tenké"
+
+#: ../src/msw/webview_ie.cpp:1036
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "Zlyhalo vykonanie '%s'\n"
+
+#: ../src/common/ffile.cpp:187
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "nepodarilo sa vyprázdniť súbor '%s'"
 
+#: ../src/msw/webview_ie.cpp:1045
+#, fuzzy
+msgid "failed to retrieve execution result"
+msgstr "Zlyhalo získanie textu chybovej správy RAS"
+
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1030
+#: ../src/generic/datavgen.cpp:1150
 msgid "false"
 msgstr "nepravda"
 
-#: ../src/common/datetimefmt.cpp:1966
+#: ../src/common/datetimefmt.cpp:1989
 msgid "fifteenth"
 msgstr "pätnásteho"
 
-#: ../src/common/datetimefmt.cpp:1956
+#: ../src/common/datetimefmt.cpp:1979
 msgid "fifth"
 msgstr "piateho"
 
@@ -8374,131 +8594,150 @@ msgstr "súbor '%s', riadok %zu: hodnota pre nemenný kľúč '%s' je ignorovan�
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "súbor „%s“: neočakávaný znak %c v riadku %zu."
 
-#: ../src/richtext/richtextbuffer.cpp:8738
+#: ../src/richtext/richtextbuffer.cpp:8736
 msgid "files"
 msgstr "súborov"
 
-#: ../src/common/datetimefmt.cpp:1952
+#: ../src/common/datetimefmt.cpp:1975
 msgid "first"
 msgstr "prvý"
 
-#: ../src/html/helpwnd.cpp:1252
+#: ../src/html/helpwnd.cpp:1250
 msgid "font size"
 msgstr "veľkosť písma"
 
-#: ../src/common/datetimefmt.cpp:1965
+#: ../src/common/datetimefmt.cpp:1988
 msgid "fourteenth"
 msgstr "štrnásteho"
 
-#: ../src/common/datetimefmt.cpp:1955
+#: ../src/common/datetimefmt.cpp:1978
 msgid "fourth"
 msgstr "štvrtého"
 
-#: ../src/common/appbase.cpp:783
+#: ../src/common/appbase.cpp:784
 msgid "generate verbose log messages"
 msgstr "tvoriť výrečné správy záznamu"
 
-#: ../src/richtext/richtextbuffer.cpp:13138
-#: ../src/richtext/richtextbuffer.cpp:13248
+#: ../src/common/fontcmn.cpp:1215
+msgid "heavy"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:13133
+#: ../src/richtext/richtextbuffer.cpp:13243
 msgid "image"
 msgstr "obrázok"
 
-#: ../src/common/tarstrm.cpp:796
+#: ../src/common/tarstrm.cpp:790
 msgid "incomplete header block in tar"
 msgstr "neplatný blok hlavičky v tar"
 
-#: ../src/common/xtixml.cpp:489
+#: ../src/common/xtixml.cpp:485
 msgid "incorrect event handler string, missing dot"
 msgstr "nesprávny reťazec obsluhy udalosti, chýba bodka"
 
-#: ../src/common/tarstrm.cpp:1381
+#: ../src/common/tarstrm.cpp:1375
 msgid "incorrect size given for tar entry"
 msgstr "bola zadaná neplatná veľkosť tar záznamu"
 
-#: ../src/common/tarstrm.cpp:993
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:987
 msgid "invalid data in extended tar header"
 msgstr "neplatné dáta v rozšírenej tar hlavičke"
 
-#: ../src/generic/logg.cpp:1030
+#: ../src/generic/logg.cpp:1027
 msgid "invalid message box return value"
 msgstr "neplatná návratová hodnota okna so správou"
 
-#: ../src/common/zipstrm.cpp:1647
+#: ../src/common/zipstrm.cpp:1688
 msgid "invalid zip file"
 msgstr "neplatný zip súbor"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:1228
 msgid "italic"
 msgstr "kurzíva"
 
-#: ../src/common/fontcmn.cpp:991
+#: ../src/common/webrequest_curl.cpp:374
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "Súbor nie je možné načítať."
+
+#: ../src/common/fontcmn.cpp:1172
 msgid "light"
 msgstr "tenké"
 
-#: ../src/common/intl.cpp:303
-#, c-format
-msgid "locale '%s' cannot be set."
-msgstr "nemožno nastaviť miestne '%s'."
+#: ../src/common/fontcmn.cpp:1185
+msgid "medium"
+msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2125
+#: ../src/common/datetimefmt.cpp:2148
 msgid "midnight"
 msgstr "polnoc"
 
-#: ../src/common/datetimefmt.cpp:1970
+#: ../src/common/datetimefmt.cpp:1993
 msgid "nineteenth"
 msgstr "devätnásteho"
 
-#: ../src/common/datetimefmt.cpp:1960
+#: ../src/common/datetimefmt.cpp:1983
 msgid "ninth"
 msgstr "deviateho"
 
-#: ../src/msw/dde.cpp:1116
+#: ../src/msw/dde.cpp:1180
 msgid "no DDE error."
 msgstr "žiadna DDE chyba."
 
-#: ../src/html/chm.cpp:327
+#: ../src/html/chm.cpp:324
 msgid "no error"
 msgstr "žiadna chyba"
 
-#: ../src/dfb/fontmgr.cpp:174
+#: ../src/dfb/fontmgr.cpp:171
 #, c-format
 msgid "no fonts found in %s, using builtin font"
 msgstr "v jazyku %s sa nenašli žiadne písma, používajú sa zabudované písma"
 
-#: ../src/html/helpdata.cpp:657
+#: ../src/html/helpdata.cpp:650
 msgid "noname"
 msgstr "nepomenované"
 
-#: ../src/common/datetimefmt.cpp:2124
+#: ../src/common/datetimefmt.cpp:2147
 msgid "noon"
 msgstr "poludnie"
 
-#: ../src/richtext/richtextstyles.cpp:779
+#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "normálne"
 
-#: ../src/common/cmdline.cpp:1492
+#: ../src/common/cmdline.cpp:1488
 msgid "num"
 msgstr "počet"
 
-#: ../src/common/xtixml.cpp:259
+#: ../src/common/accelcmn.cpp:194
+msgid "num "
+msgstr ""
+
+#: ../src/common/xtixml.cpp:255
 msgid "objects cannot have XML Text Nodes"
 msgstr "objekty nemôžu mať XML textové uzly"
 
-#: ../src/html/chm.cpp:339
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
 msgid "out of memory"
 msgstr "nedostatok pamäte"
 
-#: ../src/common/debugrpt.cpp:514
+#: ../src/common/debugrpt.cpp:515
 msgid "process context description"
 msgstr "opis kontextu procesu"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:227
-#: ../src/richtext/richtextbackgroundpage.cpp:250
-#: ../src/richtext/richtextbackgroundpage.cpp:290
-#: ../src/richtext/richtextbackgroundpage.cpp:317
-#: ../src/richtext/richtextfontpage.cpp:177
-#: ../src/richtext/richtextfontpage.cpp:180
 #: ../src/richtext/richtextborderspage.cpp:255
 #: ../src/richtext/richtextborderspage.cpp:289
 #: ../src/richtext/richtextborderspage.cpp:323
@@ -8508,22 +8747,45 @@ msgstr "opis kontextu procesu"
 #: ../src/richtext/richtextborderspage.cpp:491
 #: ../src/richtext/richtextborderspage.cpp:525
 #: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextfontpage.cpp:180
 msgid "pt"
 msgstr "pt"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:225
-#: ../src/richtext/richtextbackgroundpage.cpp:228
-#: ../src/richtext/richtextbackgroundpage.cpp:229
-#: ../src/richtext/richtextbackgroundpage.cpp:248
-#: ../src/richtext/richtextbackgroundpage.cpp:251
-#: ../src/richtext/richtextbackgroundpage.cpp:252
-#: ../src/richtext/richtextbackgroundpage.cpp:288
-#: ../src/richtext/richtextbackgroundpage.cpp:291
-#: ../src/richtext/richtextbackgroundpage.cpp:292
-#: ../src/richtext/richtextbackgroundpage.cpp:315
-#: ../src/richtext/richtextbackgroundpage.cpp:318
-#: ../src/richtext/richtextbackgroundpage.cpp:319
-#: ../src/richtext/richtextfontpage.cpp:178
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:659
+#: ../src/richtext/richtextsizepage.cpp:662
+#: ../src/richtext/richtextsizepage.cpp:663
 #: ../src/richtext/richtextborderspage.cpp:253
 #: ../src/richtext/richtextborderspage.cpp:256
 #: ../src/richtext/richtextborderspage.cpp:257
@@ -8575,259 +8837,269 @@ msgstr "pt"
 #: ../src/richtext/richtextmarginspage.cpp:387
 #: ../src/richtext/richtextmarginspage.cpp:389
 #: ../src/richtext/richtextmarginspage.cpp:390
-#: ../src/richtext/richtextsizepage.cpp:338
-#: ../src/richtext/richtextsizepage.cpp:341
-#: ../src/richtext/richtextsizepage.cpp:342
-#: ../src/richtext/richtextsizepage.cpp:372
-#: ../src/richtext/richtextsizepage.cpp:375
-#: ../src/richtext/richtextsizepage.cpp:376
-#: ../src/richtext/richtextsizepage.cpp:399
-#: ../src/richtext/richtextsizepage.cpp:402
-#: ../src/richtext/richtextsizepage.cpp:403
-#: ../src/richtext/richtextsizepage.cpp:426
-#: ../src/richtext/richtextsizepage.cpp:429
-#: ../src/richtext/richtextsizepage.cpp:430
-#: ../src/richtext/richtextsizepage.cpp:453
-#: ../src/richtext/richtextsizepage.cpp:456
-#: ../src/richtext/richtextsizepage.cpp:457
-#: ../src/richtext/richtextsizepage.cpp:480
-#: ../src/richtext/richtextsizepage.cpp:483
-#: ../src/richtext/richtextsizepage.cpp:484
-#: ../src/richtext/richtextsizepage.cpp:554
-#: ../src/richtext/richtextsizepage.cpp:557
-#: ../src/richtext/richtextsizepage.cpp:558
-#: ../src/richtext/richtextsizepage.cpp:589
-#: ../src/richtext/richtextsizepage.cpp:592
-#: ../src/richtext/richtextsizepage.cpp:593
-#: ../src/richtext/richtextsizepage.cpp:624
-#: ../src/richtext/richtextsizepage.cpp:627
-#: ../src/richtext/richtextsizepage.cpp:628
-#: ../src/richtext/richtextsizepage.cpp:659
-#: ../src/richtext/richtextsizepage.cpp:662
-#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextfontpage.cpp:178
 msgid "px"
 msgstr "px"
 
-#: ../src/common/accelcmn.cpp:193
+#: ../src/common/accelcmn.cpp:192
 msgid "rawctrl"
 msgstr "rawctrl"
 
-#: ../src/html/chm.cpp:333
+#: ../src/html/chm.cpp:330
 msgid "read error"
 msgstr "chyba čítania"
 
-#: ../src/common/zipstrm.cpp:2085
+#: ../src/common/zipstrm.cpp:2155
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "čítanie toku zip (záznam %s): chyba crc"
 
-#: ../src/common/zipstrm.cpp:2080
+#: ../src/common/zipstrm.cpp:2150
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "čítanie toku zip (záznam %s): chybná dĺžka"
 
-#: ../src/msw/dde.cpp:1159
+#: ../src/msw/dde.cpp:1223
 msgid "reentrancy problem."
 msgstr "problém s opakovaným zhrnutím."
 
-#: ../src/common/datetimefmt.cpp:1953
+#: ../src/common/datetimefmt.cpp:1976
 msgid "second"
 msgstr "sekunda"
 
-#: ../src/html/chm.cpp:337
+#: ../src/html/chm.cpp:334
 msgid "seek error"
 msgstr "chyba vyhľadávania v súbore"
 
-#: ../src/common/datetimefmt.cpp:1968
+#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#, fuzzy
+msgid "semibold"
+msgstr "tučné"
+
+#: ../src/common/datetimefmt.cpp:1991
 msgid "seventeenth"
 msgstr "sedemnásteho"
 
-#: ../src/common/datetimefmt.cpp:1958
+#: ../src/common/datetimefmt.cpp:1981
 msgid "seventh"
 msgstr "siedmeho"
 
-#: ../src/common/accelcmn.cpp:191
+#: ../src/common/accelcmn.cpp:190
 msgid "shift"
 msgstr "shift"
 
-#: ../src/common/appbase.cpp:773
+#: ../src/common/appbase.cpp:774
 msgid "show this help message"
 msgstr "zobrazovať túto správu Pomocníka"
 
-#: ../src/common/datetimefmt.cpp:1967
+#: ../src/common/datetimefmt.cpp:1990
 msgid "sixteenth"
 msgstr "šestnásteho"
 
-#: ../src/common/datetimefmt.cpp:1957
+#: ../src/common/datetimefmt.cpp:1980
 msgid "sixth"
 msgstr "šiesteho"
 
-#: ../src/common/appcmn.cpp:234
+#: ../src/common/appcmn.cpp:255
 msgid "specify display mode to use (e.g. 640x480-16)"
 msgstr "uveďte zobrazovací režim, ktorý sa má použiť (napr. 640x480-16)"
 
-#: ../src/common/appcmn.cpp:220
+#: ../src/common/appcmn.cpp:241
 msgid "specify the theme to use"
 msgstr "uveďte tému, ktorá sa má použiť"
 
-#: ../src/richtext/richtextbuffer.cpp:9340
+#: ../src/richtext/richtextbuffer.cpp:9337
 msgid "standard/circle"
 msgstr "štandardné/kruh"
 
-#: ../src/richtext/richtextbuffer.cpp:9341
+#: ../src/richtext/richtextbuffer.cpp:9338
 msgid "standard/circle-outline"
 msgstr "štandardné/obrys kruhu"
 
-#: ../src/richtext/richtextbuffer.cpp:9343
+#: ../src/richtext/richtextbuffer.cpp:9340
 msgid "standard/diamond"
 msgstr "štandardné/diamant"
 
-#: ../src/richtext/richtextbuffer.cpp:9342
+#: ../src/richtext/richtextbuffer.cpp:9339
 msgid "standard/square"
 msgstr "štandardné/štvorec"
 
-#: ../src/richtext/richtextbuffer.cpp:9344
+#: ../src/richtext/richtextbuffer.cpp:9341
 msgid "standard/triangle"
 msgstr "štandardné/trojuholník"
 
-#: ../src/common/zipstrm.cpp:1985
+#: ../src/common/zipstrm.cpp:2055
 msgid "stored file length not in Zip header"
 msgstr "uložená dĺžka súboru nie je v hlavičke Zip"
 
-#: ../src/common/cmdline.cpp:1488
+#: ../src/common/cmdline.cpp:1484
 msgid "str"
 msgstr "str"
 
-#: ../src/common/fontcmn.cpp:982
+#: ../src/common/fontcmn.cpp:1145
 msgid "strikethrough"
 msgstr "preškrtnuté"
 
-#: ../src/common/tarstrm.cpp:1003 ../src/common/tarstrm.cpp:1025
-#: ../src/common/tarstrm.cpp:1507 ../src/common/tarstrm.cpp:1529
+#: ../src/common/tarstrm.cpp:997 ../src/common/tarstrm.cpp:1019
+#: ../src/common/tarstrm.cpp:1501 ../src/common/tarstrm.cpp:1523
 msgid "tar entry not open"
 msgstr "položka tar nebola otvorená"
 
-#: ../src/common/datetimefmt.cpp:1961
+#: ../src/common/datetimefmt.cpp:1984
 msgid "tenth"
 msgstr "desiateho"
 
-#: ../src/msw/dde.cpp:1123
+#: ../src/msw/dde.cpp:1187
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "odpoveď na transakciu spôsobila nastavenie bitu DDE_FBUSY."
 
-#: ../src/common/datetimefmt.cpp:1954
+#: ../src/common/fontcmn.cpp:1154
+msgid "thin"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:1977
 msgid "third"
 msgstr "tretieho"
 
-#: ../src/common/datetimefmt.cpp:1964
+#: ../src/common/datetimefmt.cpp:1987
 msgid "thirteenth"
 msgstr "trinásteho"
 
-#: ../src/common/datetimefmt.cpp:1758
+#: ../src/common/datetimefmt.cpp:1781
 msgid "today"
 msgstr "dnes"
 
-#: ../src/common/datetimefmt.cpp:1760
+#: ../src/common/datetimefmt.cpp:1783
 msgid "tomorrow"
 msgstr "zajtra"
 
-#: ../src/common/fileconf.cpp:1944
+#: ../src/common/fileconf.cpp:1946
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "koncová spätná lomka ignorovaná v ' %s'"
 
-#: ../src/gtk/aboutdlg.cpp:218
+#: ../src/gtk/aboutdlg.cpp:216
 msgid "translator-credits"
 msgstr "prekladatelia"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1028
+#: ../src/generic/datavgen.cpp:1148
 msgid "true"
 msgstr "pravda"
 
-#: ../src/common/datetimefmt.cpp:1963
+#: ../src/common/datetimefmt.cpp:1986
 msgid "twelfth"
 msgstr "dvanásteho"
 
-#: ../src/common/datetimefmt.cpp:1971
+#: ../src/common/datetimefmt.cpp:1994
 msgid "twentieth"
 msgstr "dvadsiateho"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:486 ../src/generic/datavgen.cpp:1263
+#: ../src/common/datavcmn.cpp:2068 ../src/generic/datavgen.cpp:1386
 msgid "unchecked"
 msgstr "nezaškrtnuté"
 
-#: ../src/common/fontcmn.cpp:802 ../src/common/fontcmn.cpp:978
+#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
 msgid "underlined"
 msgstr "podčiarknuté"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:490
+#: ../src/common/datavcmn.cpp:2072
 msgid "undetermined"
 msgstr "neurčené"
 
-#: ../src/common/fileconf.cpp:1979
+#: ../src/common/fileconf.cpp:1981
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "\"neočakávané\" na pozícii %d v '%s'."
 
-#: ../src/common/tarstrm.cpp:1045
+#: ../src/common/tarstrm.cpp:1039
 msgid "unexpected end of file"
 msgstr "neočakávaný koniec súboru"
 
-#: ../src/generic/progdlgg.cpp:370 ../src/common/tarstrm.cpp:371
-#: ../src/common/tarstrm.cpp:394 ../src/common/tarstrm.cpp:425
+#: ../src/common/tarstrm.cpp:366 ../src/common/tarstrm.cpp:389
+#: ../src/common/tarstrm.cpp:420 ../src/generic/progdlgg.cpp:376
 msgid "unknown"
 msgstr "neznáme"
 
-#: ../src/msw/registry.cpp:150
+#: ../src/msw/registry.cpp:139
 #, c-format
 msgid "unknown (%lu)"
 msgstr "neznáme (%lu)"
 
-#: ../src/common/xtixml.cpp:253
+#: ../src/common/xtixml.cpp:249
 #, c-format
 msgid "unknown class %s"
 msgstr "neznáma trieda %s"
 
-#: ../src/common/regex.cpp:258 ../src/html/chm.cpp:351
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "chyba kompresie"
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "chyba dekompresie"
+
+#: ../src/common/regex.cpp:255 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "neznáma chyba"
 
-#: ../src/msw/dialup.cpp:471
+#: ../src/msw/dialup.cpp:465
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "neznáma chyba (chybový kód %08x)."
 
-#: ../src/common/fmapbase.cpp:834
+#: ../src/common/fmapbase.cpp:830
 #, c-format
 msgid "unknown-%d"
 msgstr "neznáme-%d"
 
-#: ../src/common/docview.cpp:509
+#: ../src/common/docview.cpp:502
 msgid "unnamed"
 msgstr "nepomenované"
 
-#: ../src/common/docview.cpp:1624
+#: ../src/common/docview.cpp:1618
 #, c-format
 msgid "unnamed%d"
 msgstr "nemenované%d"
 
-#: ../src/common/zipstrm.cpp:1999 ../src/common/zipstrm.cpp:2319
+#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
 msgid "unsupported Zip compression method"
 msgstr "nepodporovaná metóda kompresie Zip"
 
-#: ../src/common/translation.cpp:1892
+#: ../src/common/translation.cpp:1942
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "použitím katalógu '%s' z '%s'."
 
-#: ../src/html/chm.cpp:335
+#: ../src/html/chm.cpp:332
 msgid "write error"
 msgstr "chyba zápisu"
 
-#: ../src/common/time.cpp:292
+#: ../src/gtk/glcanvas.cpp:187
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/common/time.cpp:285
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay zlyhal."
 
@@ -8840,15 +9112,15 @@ msgstr "wxWidgets nemohol otvoriť displej pre '%s': ukončuje sa."
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets nemohol otvoriť displej. Ukončuje sa."
 
-#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:431
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/common/datetimefmt.cpp:1759
+#: ../src/common/datetimefmt.cpp:1782
 msgid "yesterday"
 msgstr "včera"
 
-#: ../src/common/zstream.cpp:251 ../src/common/zstream.cpp:426
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
 #, c-format
 msgid "zlib error %d"
 msgstr "chyba zlib %d"
@@ -8858,9 +9130,78 @@ msgstr "chyba zlib %d"
 msgid "~"
 msgstr "~"
 
-#, fuzzy
-#~ msgid "Column could not be added."
-#~ msgstr "Súbor nie je možné načítať."
+#~ msgid " (while overwriting an existing item)"
+#~ msgstr " (pri prepísaní existujúcej položky)"
+
+#~ msgid "&Save as"
+#~ msgstr "&Uložiť Ako"
+
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' neobsahuje iba platné znaky"
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' by mala byť číselná hodnota."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' by mal obsahovať iba ASCII znaky."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' by mal obsahovať iba znaky abecedy."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' by mal obsahovať iba znaky abecedy alebo čísla."
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' by mal obsahovať iba číslice."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "Nemožno vytvoriť okno triedy %s"
+
+#~ msgid "Could not initalize libnotify."
+#~ msgstr "Zlyhala inicializácia libnotify."
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "Nemožno vytvoriť preložené okno"
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "Nemožno inicializovať kontext preloženého okna"
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "Zlyhala konverzia súboru '%s' na Unicode."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "Zlyhalo nastavenie textu textového ovládacieho prvku."
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr ""
+#~ "Neplatná možnosť príkazového riadku GTK+, použite príkaz \"%s --help\""
+
+#~ msgid "No unused colour in image."
+#~ msgstr "Žiadna nepoužitá farba na obrázku."
+
+#~ msgid "Not available"
+#~ msgstr "Nie je k dispozícii"
+
+#~ msgid "Replace selection"
+#~ msgstr "Nahradiť výber"
+
+#~ msgid "Save as"
+#~ msgstr "Uložiť ako"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Organizátor štýlov"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "Podporované sú aj nasledujúce štandardné možnosti GTK +:\n"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "Nemôžete vymazať prekrytie, ktoré nie je pôvodné"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "Prekrytie nemôžete inicializovať dvakrát"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "nemožno nastaviť miestne '%s'."
 
 #, fuzzy
 #~ msgid "Column index not found."
@@ -9072,10 +9413,6 @@ msgstr "~"
 #~ msgid "Windows XP"
 #~ msgstr "Windows 95"
 
-#, fuzzy
-#~ msgid "wxWidget's control not initialized."
-#~ msgstr "Nebolo možné inicializovať obrazovku."
-
 #~ msgid "ADD"
 #~ msgstr "PRIDAŤ"
 
@@ -9221,9 +9558,6 @@ msgstr "~"
 #~ msgid "Directory '%s' doesn't exist!"
 #~ msgstr "Adresár '%s' neexistuje!"
 
-#~ msgid "File %s does not exist."
-#~ msgstr "Súbor %s neexistuje."
-
 #~ msgid "Paper Size"
 #~ msgstr "Veľkosť papiera"
 
@@ -9312,9 +9646,6 @@ msgstr "~"
 
 #~ msgid "Failed to register OpenGL window class."
 #~ msgstr "Nepodarilo sa zaregistrovať triedu okna OpenGL."
-
-#~ msgid "Fatal error"
-#~ msgstr "Osudová chyba"
 
 #~ msgid "Fatal error: "
 #~ msgstr "Osudová chyba:"
@@ -9416,9 +9747,6 @@ msgstr "~"
 
 #~ msgid "&Print"
 #~ msgstr "&Tlačiť"
-
-#~ msgid "*** A debug report has been generated\n"
-#~ msgstr "*** Bolo vytvorené hlásenie o chybe\n"
 
 #~ msgid "*** It can be found in \"%s\"\n"
 #~ msgstr "*** Nachádza sa v \"%s\"\n"

--- a/locale/sl.po
+++ b/locale/sl.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-21 14:25+0200\n"
+"POT-Creation-Date: 2020-10-18 23:11+0300\n"
 "PO-Revision-Date: 2017-11-06 09:47+0100\n"
 "Last-Translator: Martin Srebotnjak <miles@filmsi.net>\n"
 "Language-Team: Martin Srebotnjak <miles@filmsi.net>\n"
@@ -15,7 +15,7 @@ msgstr ""
 "X-Poedit-SourceCharset: iso-8859-1\n"
 "X-Generator: Poedit 2.0.4\n"
 
-#: ../src/common/debugrpt.cpp:586
+#: ../src/common/debugrpt.cpp:587
 msgid ""
 "\n"
 "Please send this report to the program maintainer, thank you!\n"
@@ -23,8 +23,8 @@ msgstr ""
 "\n"
 "Prosimo, pošljite to poročilo vzdrževalcu programa, hvala!\n"
 
-#: ../src/richtext/richtextstyledlg.cpp:210
-#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:206
+#: ../src/richtext/richtextstyledlg.cpp:218
 msgid " "
 msgstr " "
 
@@ -33,76 +33,105 @@ msgid "              Thank you and we're sorry for the inconvenience!\n"
 msgstr "              Hvala lepa, za nevšečnosti se opravičujemo!\n"
 
 # common/prntbase.cpp:729
-#: ../src/common/prntbase.cpp:573
+#: ../src/common/prntbase.cpp:568
 #, c-format
 msgid " (copy %d of %d)"
 msgstr " (kopija %d od %d)"
 
 # common/log.cpp:242
-#: ../src/common/log.cpp:421
+#: ../src/common/log.cpp:440
 #, c-format
 msgid " (error %ld: %s)"
 msgstr " (napaka %ld: %s)"
 
-#: ../src/common/imagtiff.cpp:72
+#: ../src/common/imagtiff.cpp:69
 #, c-format
 msgid " (in module \"%s\")"
 msgstr " (v modulu \"%s\")"
 
-#: ../src/osx/core/secretstore.cpp:138
-msgid " (while overwriting an existing item)"
-msgstr " (med prepisovanjem obstoječe postavke)"
-
 # common/docview.cpp:1206
-#: ../src/common/docview.cpp:1642
+#: ../src/common/docview.cpp:1636
 msgid " - "
 msgstr " - "
 
 # html/htmprint.cpp:490
-#: ../src/richtext/richtextprint.cpp:593 ../src/html/htmprint.cpp:714
+#: ../src/html/htmprint.cpp:712 ../src/richtext/richtextprint.cpp:589
 msgid " Preview"
 msgstr " Predogled"
 
 # generic/fontdlgg.cpp:217
-#: ../src/common/fontcmn.cpp:824
+#: ../src/common/fontcmn.cpp:973
 msgid " bold"
 msgstr " krepko"
 
+# generic/fontdlgg.cpp:217
+#: ../src/common/fontcmn.cpp:977
+#, fuzzy
+msgid " extra bold"
+msgstr " krepko"
+
+#: ../src/common/fontcmn.cpp:985
+msgid " extra heavy"
+msgstr ""
+
+# generic/fontdlgg.cpp:216
+#: ../src/common/fontcmn.cpp:957
+#, fuzzy
+msgid " extra light"
+msgstr " rahlo"
+
+#: ../src/common/fontcmn.cpp:981
+msgid " heavy"
+msgstr ""
+
 # generic/fontdlgg.cpp:213
-#: ../src/common/fontcmn.cpp:840
+#: ../src/common/fontcmn.cpp:1001
 msgid " italic"
 msgstr " ležeče"
 
 # generic/fontdlgg.cpp:216
-#: ../src/common/fontcmn.cpp:820
+#: ../src/common/fontcmn.cpp:961
 msgid " light"
 msgstr " rahlo"
 
-#: ../src/common/fontcmn.cpp:807
+#: ../src/common/fontcmn.cpp:965
+msgid " medium"
+msgstr ""
+
+# generic/fontdlgg.cpp:217
+#: ../src/common/fontcmn.cpp:969
+#, fuzzy
+msgid " semi bold"
+msgstr " krepko"
+
+#: ../src/common/fontcmn.cpp:940
 msgid " strikethrough"
 msgstr " prečrtano"
 
-#: ../src/common/paper.cpp:117
+#: ../src/common/fontcmn.cpp:953
+msgid " thin"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
 msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
 msgstr "kuverta #10, 4 1/8 x 9 1/2 pal."
 
-#: ../src/common/paper.cpp:118
+#: ../src/common/paper.cpp:115
 msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
 msgstr "kuverta #11, 4 1/2 x 10 3/8 pal."
 
-#: ../src/common/paper.cpp:119
+#: ../src/common/paper.cpp:116
 msgid "#12 Envelope, 4 3/4 x 11 in"
 msgstr "kuverta #12, 4 3/4 x 11 pal."
 
-#: ../src/common/paper.cpp:120
+#: ../src/common/paper.cpp:117
 msgid "#14 Envelope, 5 x 11 1/2 in"
 msgstr "kuverta #14, 5 x 11 1/2 pal."
 
-#: ../src/common/paper.cpp:116
+#: ../src/common/paper.cpp:113
 msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
 msgstr "kuverta #9, 3 7/8 x 8 7/8 pal."
 
-#: ../src/richtext/richtextbackgroundpage.cpp:341
 #: ../src/richtext/richtextsizepage.cpp:340
 #: ../src/richtext/richtextsizepage.cpp:374
 #: ../src/richtext/richtextsizepage.cpp:401
@@ -113,6 +142,7 @@ msgstr "kuverta #9, 3 7/8 x 8 7/8 pal."
 #: ../src/richtext/richtextsizepage.cpp:591
 #: ../src/richtext/richtextsizepage.cpp:626
 #: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextbackgroundpage.cpp:341
 msgid "%"
 msgstr " %"
 
@@ -120,7 +150,7 @@ msgstr " %"
 # html/helpfrm.cpp:719
 # html/helpfrm.cpp:1277
 # html/helpfrm.cpp:1304
-#: ../src/html/helpwnd.cpp:1031
+#: ../src/html/helpwnd.cpp:1029
 #, c-format
 msgid "%d of %lu"
 msgstr "%d od %lu"
@@ -129,13 +159,13 @@ msgstr "%d od %lu"
 # html/helpfrm.cpp:719
 # html/helpfrm.cpp:1277
 # html/helpfrm.cpp:1304
-#: ../src/html/helpwnd.cpp:1678
+#: ../src/html/helpwnd.cpp:1676
 #, c-format
 msgid "%i of %u"
 msgstr "%i od %u"
 
 # generic/filedlgg.cpp:328
-#: ../src/generic/filectrlg.cpp:279
+#: ../src/generic/filectrlg.cpp:275
 #, c-format
 msgid "%ld byte"
 msgid_plural "%ld bytes"
@@ -148,53 +178,53 @@ msgstr[3] "%ld bajtov"
 # html/helpfrm.cpp:719
 # html/helpfrm.cpp:1277
 # html/helpfrm.cpp:1304
-#: ../src/html/helpwnd.cpp:1033
+#: ../src/html/helpwnd.cpp:1031
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu od %lu"
 
 # common/cmdline.cpp:735
-#: ../src/generic/datavgen.cpp:6028
+#: ../src/generic/datavgen.cpp:6833
 #, c-format
 msgid "%s (%d items)"
 msgstr "%s (%d elementov)"
 
 # common/cmdline.cpp:735
-#: ../src/common/cmdline.cpp:1221
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (ali %s)"
 
 # generic/logg.cpp:243
-#: ../src/generic/logg.cpp:224
+#: ../src/generic/logg.cpp:221
 #, c-format
 msgid "%s Error"
 msgstr "Napaka %s"
 
 # generic/logg.cpp:251
-#: ../src/generic/logg.cpp:236
+#: ../src/generic/logg.cpp:233
 #, c-format
 msgid "%s Information"
 msgstr "Informacija %s"
 
-#: ../src/generic/preferencesg.cpp:113
+#: ../src/generic/preferencesg.cpp:110
 #, c-format
 msgid "%s Preferences"
 msgstr "Možnosti %s"
 
 # generic/logg.cpp:247
-#: ../src/generic/logg.cpp:228
+#: ../src/generic/logg.cpp:225
 #, c-format
 msgid "%s Warning"
 msgstr "Opozorilo %s"
 
-#: ../src/common/tarstrm.cpp:1319
+#: ../src/common/tarstrm.cpp:1313
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s ne ustreza glavi tar za vnos »%s«"
 
 # generic/filedlgg.cpp:825
-#: ../src/common/fldlgcmn.cpp:124
+#: ../src/common/fldlgcmn.cpp:121
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "datoteke %s (%s)|%s"
@@ -203,16 +233,16 @@ msgstr "datoteke %s (%s)|%s"
 # html/helpfrm.cpp:719
 # html/helpfrm.cpp:1277
 # html/helpfrm.cpp:1304
-#: ../src/html/helpwnd.cpp:1716
+#: ../src/html/helpwnd.cpp:1714
 #, c-format
 msgid "%u of %u"
 msgstr "%u od %u"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "&About"
 msgstr "&O programu"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "&Actual Size"
 msgstr "&Dejanska velikost"
 
@@ -220,30 +250,30 @@ msgstr "&Dejanska velikost"
 msgid "&After a paragraph:"
 msgstr "&Za odstavkom:"
 
-#: ../src/richtext/richtextindentspage.cpp:128
 #: ../src/richtext/richtextliststylepage.cpp:319
+#: ../src/richtext/richtextindentspage.cpp:128
 msgid "&Alignment"
 msgstr "&Poravnava"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "&Apply"
 msgstr "&Uporabi"
 
-#: ../src/richtext/richtextstyledlg.cpp:251
+#: ../src/richtext/richtextstyledlg.cpp:247
 msgid "&Apply Style"
 msgstr "&Uporabi slog"
 
 # msw/mdi.cpp:187
-#: ../src/msw/mdi.cpp:179
+#: ../src/msw/mdi.cpp:174
 msgid "&Arrange Icons"
 msgstr "&Uredi ikone"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "&Ascending"
 msgstr "&Naraščajoče"
 
 # generic/helpwxht.cpp:157
-#: ../src/common/stockitem.cpp:142
+#: ../src/common/stockitem.cpp:139
 msgid "&Back"
 msgstr "&Nazaj"
 
@@ -264,25 +294,25 @@ msgid "&Blur distance:"
 msgstr "O&ddaljenost zabrisanosti:"
 
 # generic/fontdlgg.cpp:217
-#: ../src/common/stockitem.cpp:143
+#: ../src/common/stockitem.cpp:140
 msgid "&Bold"
 msgstr "&Krepko"
 
-#: ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141
 msgid "&Bottom"
 msgstr "&Spodaj"
 
+#: ../src/richtext/richtextsizepage.cpp:637
+#: ../src/richtext/richtextsizepage.cpp:644
 #: ../src/richtext/richtextborderspage.cpp:345
 #: ../src/richtext/richtextborderspage.cpp:513
 #: ../src/richtext/richtextmarginspage.cpp:259
 #: ../src/richtext/richtextmarginspage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:637
-#: ../src/richtext/richtextsizepage.cpp:644
 msgid "&Bottom:"
 msgstr "&Spodaj:"
 
 # generic/fontdlgg.cpp:217
-#: ../include/wx/richtext/richtextbuffer.h:3866
+#: ../include/wx/richtext/richtextbuffer.h:3861
 msgid "&Box"
 msgstr "&Polje"
 
@@ -291,7 +321,7 @@ msgstr "&Polje"
 msgid "&Bullet style:"
 msgstr "Slog &oznak:"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "&CD-Rom"
 msgstr "&CD-pogon"
 
@@ -306,14 +336,14 @@ msgstr "&CD-pogon"
 # generic/proplist.cpp:523
 # generic/wizard.cpp:192
 # html/helpfrm.cpp:910
-#: ../src/generic/wizard.cpp:434 ../src/generic/fontdlgg.cpp:470
-#: ../src/generic/fontdlgg.cpp:489 ../src/osx/carbon/fontdlg.cpp:402
-#: ../src/common/dlgcmn.cpp:279 ../src/common/stockitem.cpp:145
+#: ../src/osx/carbon/fontdlg.cpp:399 ../src/common/stockitem.cpp:142
+#: ../src/generic/wizard.cpp:433 ../src/generic/fontdlgg.cpp:466
+#: ../src/generic/fontdlgg.cpp:485 ../src/osx/cocoa/button.mm:200
 msgid "&Cancel"
 msgstr "&Prekliči"
 
 # msw/mdi.cpp:183
-#: ../src/msw/mdi.cpp:175
+#: ../src/msw/mdi.cpp:170
 msgid "&Cascade"
 msgstr "&Kaskadno"
 
@@ -328,27 +358,27 @@ msgstr "&Kaskadno"
 # generic/proplist.cpp:523
 # generic/wizard.cpp:192
 # html/helpfrm.cpp:910
-#: ../include/wx/richtext/richtextbuffer.h:5960
+#: ../include/wx/richtext/richtextbuffer.h:5955
 msgid "&Cell"
 msgstr "&Celica"
 
-#: ../src/richtext/richtextsymboldlg.cpp:439
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "&Character code:"
 msgstr "&Koda znaka:"
 
 # generic/logg.cpp:475
-#: ../src/common/stockitem.cpp:147
+#: ../src/common/stockitem.cpp:144
 msgid "&Clear"
 msgstr "&Počisti"
 
 # generic/logg.cpp:477
 # generic/tipdlg.cpp:170
-#: ../src/generic/logg.cpp:516 ../src/common/stockitem.cpp:148
-#: ../src/common/prntbase.cpp:1600 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/stockitem.cpp:145 ../src/common/prntbase.cpp:1625
+#: ../src/univ/themes/win32.cpp:3753 ../src/generic/logg.cpp:513
 msgid "&Close"
 msgstr "&Zapri"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "&Color"
 msgstr "&Barva"
 
@@ -359,21 +389,21 @@ msgstr "&Barva:"
 # generic/helpwxht.cpp:159
 # html/helpfrm.cpp:303
 # html/helpfrm.cpp:312
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "&Convert"
 msgstr "&Pretvori"
 
-#: ../src/richtext/richtextctrl.cpp:333 ../src/osx/textctrl_osx.cpp:577
-#: ../src/common/stockitem.cpp:150 ../src/msw/textctrl.cpp:2508
+#: ../src/osx/textctrl_osx.cpp:595 ../src/common/stockitem.cpp:147
+#: ../src/msw/textctrl.cpp:2773 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Kopiraj"
 
-#: ../src/generic/hyperlinkg.cpp:156
+#: ../src/generic/hyperlinkg.cpp:153
 msgid "&Copy URL"
 msgstr "&Kopiraj URL"
 
 # html/helpfrm.cpp:899
-#: ../src/common/headerctrlcmn.cpp:306
+#: ../src/common/headerctrlcmn.cpp:304
 msgid "&Customize..."
 msgstr "Prila&godi ..."
 
@@ -381,57 +411,58 @@ msgstr "Prila&godi ..."
 msgid "&Debug report preview:"
 msgstr "&Predogled poročila o razhroščevanju:"
 
-#: ../src/richtext/richtexttabspage.cpp:138
-#: ../src/richtext/richtextctrl.cpp:335 ../src/osx/textctrl_osx.cpp:579
-#: ../src/common/stockitem.cpp:152 ../src/msw/textctrl.cpp:2510
+#: ../src/osx/textctrl_osx.cpp:597 ../src/common/stockitem.cpp:149
+#: ../src/msw/textctrl.cpp:2775 ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtextctrl.cpp:334
 msgid "&Delete"
 msgstr "&Izbriši"
 
-#: ../src/richtext/richtextstyledlg.cpp:269
+#: ../src/richtext/richtextstyledlg.cpp:265
 msgid "&Delete Style..."
 msgstr "&Izbriši slog ..."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "&Descending"
 msgstr "&Padajoče"
 
-#: ../src/generic/logg.cpp:682
+#: ../src/generic/logg.cpp:679
 msgid "&Details"
 msgstr "&Podrobnosti"
 
 # html/htmlwin.cpp:216
-#: ../src/common/stockitem.cpp:153
+#: ../src/common/stockitem.cpp:150
 msgid "&Down"
 msgstr "&Dol"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "&Edit"
 msgstr "&Uredi"
 
-#: ../src/richtext/richtextstyledlg.cpp:263
+#: ../src/richtext/richtextstyledlg.cpp:259
 msgid "&Edit Style..."
 msgstr "&Uredi slog ..."
 
-#: ../src/common/stockitem.cpp:155
+#: ../src/common/stockitem.cpp:152
 msgid "&Execute"
 msgstr "&Izvedi"
 
 # generic/filedlgg.cpp:534
-#: ../src/common/stockitem.cpp:157
+#: ../src/common/stockitem.cpp:154
 msgid "&File"
 msgstr "&Datoteka"
 
 # html/helpfrm.cpp:340
-#: ../src/common/stockitem.cpp:158
-msgid "&Find"
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "&Find..."
 msgstr "&Najdi"
 
 # generic/wizard.cpp:284
-#: ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:430
 msgid "&Finish"
 msgstr "&Dokončaj"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:156
 msgid "&First"
 msgstr "&Prvi"
 
@@ -439,17 +470,17 @@ msgstr "&Prvi"
 msgid "&Floating mode:"
 msgstr "&Plavajoči način:"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "&Floppy"
 msgstr "&Disketa"
 
 # html/helpfrm.cpp:899
-#: ../src/common/stockitem.cpp:194
+#: ../src/common/stockitem.cpp:191
 msgid "&Font"
 msgstr "&Pisava"
 
 # html/helpfrm.cpp:899
-#: ../src/generic/fontdlgg.cpp:371
+#: ../src/generic/fontdlgg.cpp:367
 msgid "&Font family:"
 msgstr "&Družina pisave:"
 
@@ -458,23 +489,23 @@ msgid "&Font for Level..."
 msgstr "&Pisava za raven ..."
 
 # html/helpfrm.cpp:899
+#: ../src/richtext/richtextsymboldlg.cpp:397
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:400
 msgid "&Font:"
 msgstr "&Pisava:"
 
 # common/dlgcmn.cpp:132
 # generic/helpwxht.cpp:158
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "&Forward"
 msgstr "&Naprej"
 
 # generic/prntdlgg.cpp:187
-#: ../src/richtext/richtextsymboldlg.cpp:451
+#: ../src/richtext/richtextsymboldlg.cpp:448
 msgid "&From:"
 msgstr "&Od:"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "&Harddisk"
 msgstr "&Trdi disk"
 
@@ -488,9 +519,9 @@ msgstr "&Višina:"
 # generic/proplist.cpp:528
 # html/helpfrm.cpp:208
 # msw/mdi.cpp:1283
-#: ../src/generic/wizard.cpp:441 ../src/richtext/richtextstyledlg.cpp:303
-#: ../src/richtext/richtextsymboldlg.cpp:479 ../src/osx/menu_osx.cpp:734
-#: ../src/common/stockitem.cpp:163
+#: ../src/common/stockitem.cpp:160 ../src/generic/wizard.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextstyledlg.cpp:299 ../src/osx/cocoa/menu.mm:226
 msgid "&Help"
 msgstr "&Pomoč"
 
@@ -499,7 +530,7 @@ msgid "&Hide details"
 msgstr "&Skrij podrobnosti"
 
 # generic/dirdlgg.cpp:212
-#: ../src/common/stockitem.cpp:164
+#: ../src/common/stockitem.cpp:161
 msgid "&Home"
 msgstr "&Domov"
 
@@ -507,59 +538,59 @@ msgstr "&Domov"
 msgid "&Horizontal offset:"
 msgstr "&Vodoravni odmik:"
 
-#: ../src/richtext/richtextindentspage.cpp:184
 #: ../src/richtext/richtextliststylepage.cpp:372
+#: ../src/richtext/richtextindentspage.cpp:184
 msgid "&Indentation (tenths of a mm)"
 msgstr "&Zamik (v desetinkah mm)"
 
 # generic/fontdlgg.cpp:242
-#: ../src/richtext/richtextindentspage.cpp:167
 #: ../src/richtext/richtextliststylepage.cpp:356
+#: ../src/richtext/richtextindentspage.cpp:167
 msgid "&Indeterminate"
 msgstr "&Nedoločeno"
 
 # html/helpfrm.cpp:372
-#: ../src/common/stockitem.cpp:166
+#: ../src/common/stockitem.cpp:163
 msgid "&Index"
 msgstr "&Kazalo"
 
 # common/docview.cpp:1951
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "&Info"
 msgstr "&Podatki"
 
 # generic/fontdlgg.cpp:213
-#: ../src/common/stockitem.cpp:168
+#: ../src/common/stockitem.cpp:165
 msgid "&Italic"
 msgstr "&Ležeče"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "&Jump to"
 msgstr "&Skoči na"
 
-#: ../src/richtext/richtextindentspage.cpp:153
 #: ../src/richtext/richtextliststylepage.cpp:342
+#: ../src/richtext/richtextindentspage.cpp:153
 msgid "&Justified"
 msgstr "&Poravnano"
 
 # common/cmdline.cpp:912
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "&Last"
 msgstr "&Zadnji"
 
-#: ../src/richtext/richtextindentspage.cpp:139
 #: ../src/richtext/richtextliststylepage.cpp:328
+#: ../src/richtext/richtextindentspage.cpp:139
 msgid "&Left"
 msgstr "&Levo"
 
-#: ../src/richtext/richtextindentspage.cpp:195
+#: ../src/richtext/richtextsizepage.cpp:532
+#: ../src/richtext/richtextsizepage.cpp:539
 #: ../src/richtext/richtextborderspage.cpp:243
 #: ../src/richtext/richtextborderspage.cpp:411
 #: ../src/richtext/richtextliststylepage.cpp:381
+#: ../src/richtext/richtextindentspage.cpp:195
 #: ../src/richtext/richtextmarginspage.cpp:186
 #: ../src/richtext/richtextmarginspage.cpp:300
-#: ../src/richtext/richtextsizepage.cpp:532
-#: ../src/richtext/richtextsizepage.cpp:539
 msgid "&Left:"
 msgstr "&Levo:"
 
@@ -568,11 +599,11 @@ msgid "&List level:"
 msgstr "&Raven seznama:"
 
 # generic/logg.cpp:478
-#: ../src/generic/logg.cpp:517
+#: ../src/generic/logg.cpp:514
 msgid "&Log"
 msgstr "&Dnevnik"
 
-#: ../src/univ/themes/win32.cpp:3748
+#: ../src/univ/themes/win32.cpp:3745
 msgid "&Move"
 msgstr "&Premakni"
 
@@ -581,23 +612,23 @@ msgid "&Move the object to:"
 msgstr "&Premakni predmet v:"
 
 # msw/mdi.cpp:188
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "&Network"
 msgstr "&Omrežje"
 
 # msw/mdi.cpp:188
-#: ../src/richtext/richtexttabspage.cpp:132 ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173 ../src/richtext/richtexttabspage.cpp:132
 msgid "&New"
 msgstr "&Nov"
 
 # msw/mdi.cpp:188
-#: ../src/aui/tabmdi.cpp:111 ../src/generic/mdig.cpp:100 ../src/msw/mdi.cpp:180
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
 msgid "&Next"
 msgstr "&Naslednji"
 
 # generic/wizard.cpp:189
 # generic/wizard.cpp:286
-#: ../src/generic/wizard.cpp:432 ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:429
 msgid "&Next >"
 msgstr "&Naslednji >"
 
@@ -606,7 +637,7 @@ msgid "&Next Paragraph"
 msgstr "&Naslednji odstavek"
 
 # generic/tipdlg.cpp:175
-#: ../src/generic/tipdlg.cpp:240
+#: ../src/generic/tipdlg.cpp:237
 msgid "&Next Tip"
 msgstr "N&aslednji namig"
 
@@ -618,11 +649,11 @@ msgstr "&Naslednji slog:"
 
 # common/dlgcmn.cpp:111
 # common/dlgcmn.cpp:121
-#: ../src/common/stockitem.cpp:177 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:174 ../src/msw/msgdlg.cpp:435
 msgid "&No"
 msgstr "&Ne"
 
-#: ../src/generic/dbgrptg.cpp:356
+#: ../src/generic/dbgrptg.cpp:360
 msgid "&Notes:"
 msgstr "&Opombe:"
 
@@ -639,14 +670,14 @@ msgstr "&Številka:"
 # generic/prntdlgg.cpp:467
 # generic/proplist.cpp:511
 # html/helpfrm.cpp:909
-#: ../src/generic/fontdlgg.cpp:475 ../src/generic/fontdlgg.cpp:482
-#: ../src/osx/carbon/fontdlg.cpp:408 ../src/common/stockitem.cpp:178
+#: ../src/osx/carbon/fontdlg.cpp:405 ../src/common/stockitem.cpp:175
+#: ../src/generic/fontdlgg.cpp:471 ../src/generic/fontdlgg.cpp:478
 msgid "&OK"
 msgstr "&V redu"
 
 # generic/logg.cpp:473
 # generic/logg.cpp:774
-#: ../src/generic/dbgrptg.cpp:342 ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176 ../src/generic/dbgrptg.cpp:342
 msgid "&Open..."
 msgstr "&Odpri ..."
 
@@ -659,17 +690,17 @@ msgid "&Page Break"
 msgstr "&Prelom strani"
 
 # common/cmdline.cpp:912
-#: ../src/richtext/richtextctrl.cpp:334 ../src/osx/textctrl_osx.cpp:578
-#: ../src/common/stockitem.cpp:180 ../src/msw/textctrl.cpp:2509
+#: ../src/osx/textctrl_osx.cpp:596 ../src/common/stockitem.cpp:177
+#: ../src/msw/textctrl.cpp:2774 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&Prilepi"
 
-#: ../include/wx/richtext/richtextbuffer.h:5010
+#: ../include/wx/richtext/richtextbuffer.h:5005
 msgid "&Picture"
 msgstr "&Slika"
 
 # html/helpfrm.cpp:899
-#: ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:419
 msgid "&Point size:"
 msgstr "&Velikost pisave:"
 
@@ -682,12 +713,12 @@ msgstr "&Položaj (v desetinkah mm):"
 msgid "&Position mode:"
 msgstr "&Način položaja:"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178
 msgid "&Preferences"
 msgstr "&Možnosti"
 
 # html/helpfrm.cpp:512
-#: ../src/aui/tabmdi.cpp:112 ../src/generic/mdig.cpp:101 ../src/msw/mdi.cpp:181
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
 msgid "&Previous"
 msgstr "&Prejšnji"
 
@@ -697,92 +728,87 @@ msgid "&Previous Paragraph"
 msgstr "&Prejšnji odstavek"
 
 # common/prntbase.cpp:366
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "&Print..."
 msgstr "&Natisni ..."
 
 # html/helpfrm.cpp:512
-#: ../src/richtext/richtextctrl.cpp:339 ../src/richtext/richtextctrl.cpp:5514
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtextctrl.cpp:338
+#: ../src/richtext/richtextctrl.cpp:5512
 msgid "&Properties"
 msgstr "&Lastnosti"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "&Quit"
 msgstr "&Izhod"
 
 # common/docview.cpp:1945
 # common/docview.cpp:1956
-#: ../src/richtext/richtextctrl.cpp:330 ../src/osx/textctrl_osx.cpp:574
-#: ../src/common/stockitem.cpp:185 ../src/common/cmdproc.cpp:293
-#: ../src/common/cmdproc.cpp:300 ../src/msw/textctrl.cpp:2505
+#: ../src/osx/textctrl_osx.cpp:592 ../src/common/stockitem.cpp:182
+#: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
+#: ../src/msw/textctrl.cpp:2770 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Ponovi"
 
 # common/docview.cpp:1939
 # common/docview.cpp:1966
-#: ../src/common/cmdproc.cpp:289 ../src/common/cmdproc.cpp:309
+#: ../src/common/cmdproc.cpp:282 ../src/common/cmdproc.cpp:302
 msgid "&Redo "
 msgstr "&Ponovi "
 
-#: ../src/richtext/richtextstyledlg.cpp:257
+#: ../src/richtext/richtextstyledlg.cpp:253
 msgid "&Rename Style..."
 msgstr "&Preimenuj slog ..."
 
-#: ../src/generic/fdrepdlg.cpp:179
+#: ../src/generic/fdrepdlg.cpp:176
 msgid "&Replace"
 msgstr "&Zamenjaj"
 
-#: ../src/richtext/richtextstyledlg.cpp:287
+#: ../src/richtext/richtextstyledlg.cpp:283
 msgid "&Restart numbering"
 msgstr "&Znova oštevilči"
 
 # common/docview.cpp:1945
 # common/docview.cpp:1956
-#: ../src/univ/themes/win32.cpp:3747
+#: ../src/univ/themes/win32.cpp:3744
 msgid "&Restore"
 msgstr "&Obnovi"
 
 # generic/fontdlgg.cpp:216
-#: ../src/richtext/richtextindentspage.cpp:146
 #: ../src/richtext/richtextliststylepage.cpp:335
+#: ../src/richtext/richtextindentspage.cpp:146
 msgid "&Right"
 msgstr "&Desno"
 
 # generic/fontdlgg.cpp:216
-#: ../src/richtext/richtextindentspage.cpp:213
+#: ../src/richtext/richtextsizepage.cpp:602
+#: ../src/richtext/richtextsizepage.cpp:609
 #: ../src/richtext/richtextborderspage.cpp:277
 #: ../src/richtext/richtextborderspage.cpp:445
 #: ../src/richtext/richtextliststylepage.cpp:399
+#: ../src/richtext/richtextindentspage.cpp:213
 #: ../src/richtext/richtextmarginspage.cpp:211
 #: ../src/richtext/richtextmarginspage.cpp:325
-#: ../src/richtext/richtextsizepage.cpp:602
-#: ../src/richtext/richtextsizepage.cpp:609
 msgid "&Right:"
 msgstr "&Desno:"
 
 # generic/logg.cpp:473
 # generic/logg.cpp:774
-#: ../src/common/stockitem.cpp:190
+#: ../src/common/stockitem.cpp:187
 msgid "&Save"
 msgstr "&Shrani"
-
-# common/docview.cpp:249
-#: ../src/common/stockitem.cpp:191
-msgid "&Save as"
-msgstr "&Shrani kot"
 
 #: ../include/wx/richmsgdlg.h:29
 msgid "&See details"
 msgstr "&Pokaži podrobnosti"
 
 # generic/tipdlg.cpp:172
-#: ../src/generic/tipdlg.cpp:236
+#: ../src/generic/tipdlg.cpp:233
 msgid "&Show tips at startup"
 msgstr "&Pokaži namige ob zagonu"
 
 # generic/filedlgg.cpp:534
-#: ../src/univ/themes/win32.cpp:3750
+#: ../src/univ/themes/win32.cpp:3747
 msgid "&Size"
 msgstr "&Velikost"
 
@@ -791,37 +817,37 @@ msgstr "&Velikost"
 msgid "&Size:"
 msgstr "&Velikost:"
 
-#: ../src/generic/progdlgg.cpp:252
+#: ../src/generic/progdlgg.cpp:249
 msgid "&Skip"
 msgstr "Pres&koči"
 
-#: ../src/richtext/richtextindentspage.cpp:242
 #: ../src/richtext/richtextliststylepage.cpp:417
+#: ../src/richtext/richtextindentspage.cpp:242
 msgid "&Spacing (tenths of a mm)"
 msgstr "&Razmik (v desetinah mm)"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "&Spell Check"
 msgstr "&Preverjanje črkovanja"
 
 # common/dlgcmn.cpp:138
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "&Stop"
 msgstr "&Ustavi"
 
-#: ../src/richtext/richtextfontpage.cpp:275 ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196 ../src/richtext/richtextfontpage.cpp:275
 msgid "&Strikethrough"
 msgstr "Pre&črtano"
 
-#: ../src/generic/fontdlgg.cpp:382 ../src/richtext/richtextstylepage.cpp:106
+#: ../src/generic/fontdlgg.cpp:378 ../src/richtext/richtextstylepage.cpp:106
 msgid "&Style:"
 msgstr "&Slog:"
 
-#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:194
 msgid "&Styles:"
 msgstr "&Slogi:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:413
+#: ../src/richtext/richtextsymboldlg.cpp:410
 msgid "&Subset:"
 msgstr "&Podmnožica:"
 
@@ -835,26 +861,26 @@ msgstr "&Simbol:"
 msgid "&Synchronize values"
 msgstr "&Uskladi vrednosti"
 
-#: ../include/wx/richtext/richtextbuffer.h:6069
+#: ../include/wx/richtext/richtextbuffer.h:6064
 msgid "&Table"
 msgstr "&Tabela"
 
-#: ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197
 msgid "&Top"
 msgstr "&Vrh"
 
 # generic/prntdlgg.cpp:191
+#: ../src/richtext/richtextsizepage.cpp:567
+#: ../src/richtext/richtextsizepage.cpp:574
 #: ../src/richtext/richtextborderspage.cpp:311
 #: ../src/richtext/richtextborderspage.cpp:479
 #: ../src/richtext/richtextmarginspage.cpp:234
 #: ../src/richtext/richtextmarginspage.cpp:348
-#: ../src/richtext/richtextsizepage.cpp:567
-#: ../src/richtext/richtextsizepage.cpp:574
 msgid "&Top:"
 msgstr "&Vrh:"
 
 # generic/fontdlgg.cpp:242
-#: ../src/generic/fontdlgg.cpp:444 ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199 ../src/generic/fontdlgg.cpp:441
 msgid "&Underline"
 msgstr "&Podčrtaj"
 
@@ -864,22 +890,22 @@ msgid "&Underlining:"
 msgstr "&Podčrtovanje:"
 
 # common/docview.cpp:1951
-#: ../src/richtext/richtextctrl.cpp:329 ../src/osx/textctrl_osx.cpp:573
-#: ../src/common/stockitem.cpp:203 ../src/common/cmdproc.cpp:271
-#: ../src/msw/textctrl.cpp:2504
+#: ../src/osx/textctrl_osx.cpp:591 ../src/common/stockitem.cpp:200
+#: ../src/common/cmdproc.cpp:264 ../src/msw/textctrl.cpp:2769
+#: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Razveljavi"
 
 # common/docview.cpp:1926
-#: ../src/common/cmdproc.cpp:265
+#: ../src/common/cmdproc.cpp:258
 msgid "&Undo "
 msgstr "&Razveljavi"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "&Unindent"
 msgstr "&Nezamaknjeno"
 
-#: ../src/common/stockitem.cpp:205
+#: ../src/common/stockitem.cpp:202
 msgid "&Up"
 msgstr "&Gor"
 
@@ -898,7 +924,7 @@ msgid "&View..."
 msgstr "&Pogled ..."
 
 # generic/fontdlgg.cpp:216
-#: ../src/generic/fontdlgg.cpp:393
+#: ../src/generic/fontdlgg.cpp:389
 msgid "&Weight:"
 msgstr "&Debelina:"
 
@@ -911,96 +937,60 @@ msgstr "&Širina:"
 # msw/mdi.cpp:1287
 # msw/mdi.cpp:1294
 # msw/window.cpp:2286
-#: ../src/aui/tabmdi.cpp:311 ../src/aui/tabmdi.cpp:327
-#: ../src/aui/tabmdi.cpp:329 ../src/generic/mdig.cpp:294
-#: ../src/generic/mdig.cpp:310 ../src/generic/mdig.cpp:314
-#: ../src/msw/mdi.cpp:78
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
 msgid "&Window"
 msgstr "&Okno"
 
 # common/dlgcmn.cpp:109
 # common/dlgcmn.cpp:116
-#: ../src/common/stockitem.cpp:206 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:203 ../src/msw/msgdlg.cpp:435
 msgid "&Yes"
 msgstr "&Da"
 
 # common/valtext.cpp:166
-#: ../src/common/valtext.cpp:256
-#, c-format
-msgid "'%s' contains illegal characters"
+#: ../src/common/valtext.cpp:197
+#, fuzzy, c-format
+msgid "'%s' contains invalid character(s)"
 msgstr "»%s« vsebuje neveljavne znake."
-
-# common/valtext.cpp:166
-#: ../src/common/valtext.cpp:254
-#, c-format
-msgid "'%s' doesn't consist only of valid characters"
-msgstr "»%s« ni sestavljen le iz veljavnih znakov."
 
 # common/config.cpp:396
 # msw/regconf.cpp:264
-#: ../src/common/config.cpp:519 ../src/msw/regconf.cpp:258
+#: ../src/common/config.cpp:515 ../src/msw/regconf.cpp:255
 #, c-format
 msgid "'%s' has extra '..', ignored."
 msgstr "»%s« ima dodaten »..«, prezrto."
 
 # common/cmdline.cpp:657
-#: ../src/common/cmdline.cpp:1113 ../src/common/cmdline.cpp:1131
+#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "»%s« ni pravilna numerična vrednost za možnost »%s«."
 
 # common/intl.cpp:412
-#: ../src/common/translation.cpp:1100
+#: ../src/common/translation.cpp:1142
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "»%s« ni veljaven katalog sporočil."
 
 # common/intl.cpp:412
-#: ../src/common/valtext.cpp:165
+#: ../src/common/valtext.cpp:188
 #, c-format
 msgid "'%s' is not one of the valid strings"
 msgstr "»%s« ni veljavno sporočilo."
 
 # common/valtext.cpp:140
-#: ../src/common/valtext.cpp:167
+#: ../src/common/valtext.cpp:186
 #, c-format
 msgid "'%s' is one of the invalid strings"
 msgstr "»%s« je neveljavno sporočilo."
 
-#: ../src/common/textbuf.cpp:237
+#: ../src/common/textbuf.cpp:233
 #, c-format
 msgid "'%s' is probably a binary buffer."
 msgstr "»%s« je verjetno binarni medpomnilnik."
-
-# common/valtext.cpp:178
-#: ../src/common/valtext.cpp:252
-#, c-format
-msgid "'%s' should be numeric."
-msgstr "»%s« sme biti le število."
-
-# common/valtext.cpp:160
-#: ../src/common/valtext.cpp:244
-#, c-format
-msgid "'%s' should only contain ASCII characters."
-msgstr "»%s« sme vsebovati samo znake ASCII."
-
-# common/valtext.cpp:166
-#: ../src/common/valtext.cpp:246
-#, c-format
-msgid "'%s' should only contain alphabetic characters."
-msgstr "»%s« sme vsebovati samo črkovne znake."
-
-# common/valtext.cpp:172
-#: ../src/common/valtext.cpp:248
-#, c-format
-msgid "'%s' should only contain alphabetic or numeric characters."
-msgstr "»%s« sme vsebovati samo črkovne ali številčne znake."
-
-# common/valtext.cpp:160
-#: ../src/common/valtext.cpp:250
-#, c-format
-msgid "'%s' should only contain digits."
-msgstr "»%s« sme vsebovati samo števke."
 
 #: ../src/richtext/richtextliststylepage.cpp:229
 #: ../src/richtext/richtextbulletspage.cpp:166
@@ -1008,7 +998,7 @@ msgid "(*)"
 msgstr "(*)"
 
 # html/helpfrm.cpp:679
-#: ../src/html/helpwnd.cpp:963
+#: ../src/html/helpwnd.cpp:961
 msgid "(Help)"
 msgstr "(Pomoč)"
 
@@ -1018,31 +1008,37 @@ msgid "(None)"
 msgstr "(brez)"
 
 # html/helpfrm.cpp:881
-#: ../src/richtext/richtextsymboldlg.cpp:504
+#: ../src/richtext/richtextsymboldlg.cpp:503
 msgid "(Normal text)"
 msgstr "(navadno besedilo)"
 
 # html/helpfrm.cpp:276
 # html/helpfrm.cpp:783
 # html/helpfrm.cpp:1330
-#: ../src/html/helpwnd.cpp:419 ../src/html/helpwnd.cpp:1106
-#: ../src/html/helpwnd.cpp:1742
+#: ../src/html/helpwnd.cpp:417 ../src/html/helpwnd.cpp:1104
+#: ../src/html/helpwnd.cpp:1740
 msgid "(bookmarks)"
 msgstr "(zaznamki)"
 
+# common/log.cpp:242
+#: ../src/msw/dlmsw.cpp:167
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (napaka %ld: %s)"
+
 # html/helpdata.cpp:644
+#: ../src/richtext/richtextformatdlg.cpp:876
+#: ../src/richtext/richtextliststylepage.cpp:448
+#: ../src/richtext/richtextliststylepage.cpp:460
+#: ../src/richtext/richtextliststylepage.cpp:461
 #: ../src/richtext/richtextindentspage.cpp:274
 #: ../src/richtext/richtextindentspage.cpp:286
 #: ../src/richtext/richtextindentspage.cpp:287
 #: ../src/richtext/richtextindentspage.cpp:311
 #: ../src/richtext/richtextindentspage.cpp:326
-#: ../src/richtext/richtextformatdlg.cpp:884
 #: ../src/richtext/richtextfontpage.cpp:349
 #: ../src/richtext/richtextfontpage.cpp:353
 #: ../src/richtext/richtextfontpage.cpp:357
-#: ../src/richtext/richtextliststylepage.cpp:448
-#: ../src/richtext/richtextliststylepage.cpp:460
-#: ../src/richtext/richtextliststylepage.cpp:461
 msgid "(none)"
 msgstr "(brez)"
 
@@ -1061,7 +1057,7 @@ msgstr "*)"
 msgid "+"
 msgstr "+"
 
-#: ../src/msw/utils.cpp:1152
+#: ../src/msw/utils.cpp:1143
 msgid ", 64-bit edition"
 msgstr ", 64-bitna izdaja"
 
@@ -1070,176 +1066,176 @@ msgstr ", 64-bitna izdaja"
 msgid "-"
 msgstr "-"
 
-#: ../src/generic/filepickerg.cpp:66
+#: ../src/generic/filepickerg.cpp:63
 msgid "..."
 msgstr "..."
 
-#: ../src/richtext/richtextindentspage.cpp:276
 #: ../src/richtext/richtextliststylepage.cpp:450
+#: ../src/richtext/richtextindentspage.cpp:276
 msgid "1.1"
 msgstr "1.1"
 
-#: ../src/richtext/richtextindentspage.cpp:277
 #: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextindentspage.cpp:277
 msgid "1.2"
 msgstr "1.2"
 
-#: ../src/richtext/richtextindentspage.cpp:278
 #: ../src/richtext/richtextliststylepage.cpp:452
+#: ../src/richtext/richtextindentspage.cpp:278
 msgid "1.3"
 msgstr "1.3"
 
-#: ../src/richtext/richtextindentspage.cpp:279
 #: ../src/richtext/richtextliststylepage.cpp:453
+#: ../src/richtext/richtextindentspage.cpp:279
 msgid "1.4"
 msgstr "1.4"
 
-#: ../src/richtext/richtextindentspage.cpp:280
 #: ../src/richtext/richtextliststylepage.cpp:454
+#: ../src/richtext/richtextindentspage.cpp:280
 msgid "1.5"
 msgstr "1,5"
 
-#: ../src/richtext/richtextindentspage.cpp:281
 #: ../src/richtext/richtextliststylepage.cpp:455
+#: ../src/richtext/richtextindentspage.cpp:281
 msgid "1.6"
 msgstr "1.6"
 
-#: ../src/richtext/richtextindentspage.cpp:282
 #: ../src/richtext/richtextliststylepage.cpp:456
+#: ../src/richtext/richtextindentspage.cpp:282
 msgid "1.7"
 msgstr "1.7"
 
-#: ../src/richtext/richtextindentspage.cpp:283
 #: ../src/richtext/richtextliststylepage.cpp:457
+#: ../src/richtext/richtextindentspage.cpp:283
 msgid "1.8"
 msgstr "1.8"
 
-#: ../src/richtext/richtextindentspage.cpp:284
 #: ../src/richtext/richtextliststylepage.cpp:458
+#: ../src/richtext/richtextindentspage.cpp:284
 msgid "1.9"
 msgstr "1.9"
 
-#: ../src/common/paper.cpp:140
+#: ../src/common/paper.cpp:137
 msgid "10 x 11 in"
 msgstr "10 x 11 pal."
 
-#: ../src/common/paper.cpp:113
+#: ../src/common/paper.cpp:110
 msgid "10 x 14 in"
 msgstr "10 x 14 pal."
 
-#: ../src/common/paper.cpp:114
+#: ../src/common/paper.cpp:111
 msgid "11 x 17 in"
 msgstr "11 x 17 pal."
 
-#: ../src/common/paper.cpp:184
+#: ../src/common/paper.cpp:181
 msgid "12 x 11 in"
 msgstr "12 x 11 pal."
 
-#: ../src/common/paper.cpp:141
+#: ../src/common/paper.cpp:138
 msgid "15 x 11 in"
 msgstr "15 x 11 pal."
 
-#: ../src/richtext/richtextindentspage.cpp:285
 #: ../src/richtext/richtextliststylepage.cpp:459
+#: ../src/richtext/richtextindentspage.cpp:285
 msgid "2"
 msgstr "2"
 
-#: ../src/common/paper.cpp:132
+#: ../src/common/paper.cpp:129
 msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
 msgstr "kuverta 6 3/4, 3 5/8 x 6 1/2 in."
 
-#: ../src/common/paper.cpp:139
+#: ../src/common/paper.cpp:136
 msgid "9 x 11 in"
 msgstr "9 x 11 pal."
 
 # html/htmprint.cpp:272
-#: ../src/html/htmprint.cpp:431
+#: ../src/html/htmprint.cpp:443
 msgid ": file does not exist!"
 msgstr ": datoteka ne obstaja!"
 
 # common/fontmap.cpp:507
-#: ../src/common/fontmap.cpp:199
+#: ../src/common/fontmap.cpp:196
 msgid ": unknown charset"
 msgstr ": neznan nabor znakov"
 
 # common/fontmap.cpp:712
-#: ../src/common/fontmap.cpp:413
+#: ../src/common/fontmap.cpp:410
 msgid ": unknown encoding"
 msgstr ": neznano kodiranje"
 
 # generic/wizard.cpp:186
-#: ../src/generic/wizard.cpp:443
+#: ../src/generic/wizard.cpp:438
 msgid "< &Back"
 msgstr "< &Nazaj"
 
 # generic/fontdlgg.cpp:207
-#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:628
-#: ../src/osx/carbon/fontdlg.cpp:648
+#: ../src/osx/carbon/fontdlg.cpp:419 ../src/osx/carbon/fontdlg.cpp:625
+#: ../src/osx/carbon/fontdlg.cpp:645
 msgid "<Any Decorative>"
 msgstr "<poljubna okrasna>"
 
 # generic/fontdlgg.cpp:208
-#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:630
-#: ../src/osx/carbon/fontdlg.cpp:650
+#: ../src/osx/carbon/fontdlg.cpp:420 ../src/osx/carbon/fontdlg.cpp:627
+#: ../src/osx/carbon/fontdlg.cpp:647
 msgid "<Any Modern>"
 msgstr "<poljubna sodobna>"
 
 # generic/fontdlgg.cpp:206
-#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:626
-#: ../src/osx/carbon/fontdlg.cpp:646
+#: ../src/osx/carbon/fontdlg.cpp:418 ../src/osx/carbon/fontdlg.cpp:623
+#: ../src/osx/carbon/fontdlg.cpp:643
 msgid "<Any Roman>"
 msgstr "<poljubna serifna>"
 
 # generic/fontdlgg.cpp:209
-#: ../src/osx/carbon/fontdlg.cpp:424 ../src/osx/carbon/fontdlg.cpp:632
-#: ../src/osx/carbon/fontdlg.cpp:652
+#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:629
+#: ../src/osx/carbon/fontdlg.cpp:649
 msgid "<Any Script>"
 msgstr "<poljubna pisana>"
 
 # generic/fontdlgg.cpp:210
-#: ../src/osx/carbon/fontdlg.cpp:425 ../src/osx/carbon/fontdlg.cpp:637
-#: ../src/osx/carbon/fontdlg.cpp:656
+#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:634
+#: ../src/osx/carbon/fontdlg.cpp:653
 msgid "<Any Swiss>"
 msgstr "<poljubna neserifna>"
 
 # generic/fontdlgg.cpp:211
-#: ../src/osx/carbon/fontdlg.cpp:426 ../src/osx/carbon/fontdlg.cpp:634
-#: ../src/osx/carbon/fontdlg.cpp:654
+#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:631
+#: ../src/osx/carbon/fontdlg.cpp:651
 msgid "<Any Teletype>"
 msgstr "<poljubna strojna>"
 
-#: ../src/osx/carbon/fontdlg.cpp:420
+#: ../src/osx/carbon/fontdlg.cpp:417
 msgid "<Any>"
 msgstr "<poljubna>"
 
 # generic/filedlgg.cpp:356
-#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
 msgid "<DIR>"
 msgstr "<MAPA>"
 
 # generic/filedlgg.cpp:356
-#: ../src/generic/filectrlg.cpp:254 ../src/generic/filectrlg.cpp:277
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
 msgid "<DRIVE>"
 msgstr "<POGON>"
 
 # generic/filedlgg.cpp:357
-#: ../src/generic/filectrlg.cpp:252 ../src/generic/filectrlg.cpp:275
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
 msgid "<LINK>"
 msgstr "<POVEZAVA>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1264
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Krepka ležeča pisava.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1270
+#: ../src/html/helpwnd.cpp:1268
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>krepko ležeče <u>podčrtano</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1265
+#: ../src/html/helpwnd.cpp:1263
 msgid "<b>Bold face.</b> "
 msgstr "<b>Kepka pisava.</b> "
 
-#: ../src/html/helpwnd.cpp:1264
+#: ../src/html/helpwnd.cpp:1262
 msgid "<i>Italic face.</i> "
 msgstr "<i>Ležeča pisava.</i> "
 
@@ -1248,15 +1244,15 @@ msgstr "<i>Ležeča pisava.</i> "
 msgid ">"
 msgstr ">"
 
-#: ../src/generic/dbgrptg.cpp:318
+#: ../src/generic/dbgrptg.cpp:317
 msgid "A debug report has been generated in the directory\n"
 msgstr "Poročilo o razhroščevanju je bilo ustvarjeno v mapi\n"
 
-#: ../src/common/debugrpt.cpp:573
+#: ../src/common/debugrpt.cpp:574
 msgid "A debug report has been generated. It can be found in"
 msgstr "Poročilo o razhroščevanju je bilo ustvarjeno. Nahaja se v"
 
-#: ../src/common/xtixml.cpp:418
+#: ../src/common/xtixml.cpp:414
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Neprazno zbirko morajo tvoriti vozli 'elementov'"
 
@@ -1268,120 +1264,120 @@ msgid "A standard bullet name."
 msgstr "Standardno ime oznake."
 
 # generic/dcpsg.cpp:2547
-#: ../src/common/paper.cpp:217
+#: ../src/common/paper.cpp:214
 msgid "A0 sheet, 841 x 1189 mm"
 msgstr "A0, 841 x 1189 mm"
 
 # generic/dcpsg.cpp:2547
-#: ../src/common/paper.cpp:218
+#: ../src/common/paper.cpp:215
 msgid "A1 sheet, 594 x 841 mm"
 msgstr "A1, 594 x 841 mm"
 
-#: ../src/common/paper.cpp:159
+#: ../src/common/paper.cpp:156
 msgid "A2 420 x 594 mm"
 msgstr "A2, 420 x 594 mm"
 
-#: ../src/common/paper.cpp:156
+#: ../src/common/paper.cpp:153
 msgid "A3 Extra 322 x 445 mm"
 msgstr "kuverta A3 Extra, 322 x 445 mm"
 
-#: ../src/common/paper.cpp:161
+#: ../src/common/paper.cpp:158
 msgid "A3 Extra Transverse 322 x 445 mm"
 msgstr "kuverta A3 Extra prečno, 322 x 445 mm"
 
 # generic/dcpsg.cpp:2547
-#: ../src/common/paper.cpp:170
+#: ../src/common/paper.cpp:167
 msgid "A3 Rotated 420 x 297 mm"
 msgstr "A3 rotirano, 420 x 297 mm"
 
 # generic/dcpsg.cpp:2547
-#: ../src/common/paper.cpp:160
+#: ../src/common/paper.cpp:157
 msgid "A3 Transverse 297 x 420 mm"
 msgstr "A3 prečno, 297 x 420 mm"
 
 # generic/dcpsg.cpp:2547
-#: ../src/common/paper.cpp:106
+#: ../src/common/paper.cpp:103
 msgid "A3 sheet, 297 x 420 mm"
 msgstr "A3, 297 x 420 mm"
 
-#: ../src/common/paper.cpp:146
+#: ../src/common/paper.cpp:143
 msgid "A4 Extra 9.27 x 12.69 in"
 msgstr "A4 posebno, 9,27 x 12,69 pal."
 
 # generic/dcpsg.cpp:2547
-#: ../src/common/paper.cpp:153
+#: ../src/common/paper.cpp:150
 msgid "A4 Plus 210 x 330 mm"
 msgstr "A4 Plus, 210 x 330 mm"
 
 # generic/dcpsg.cpp:2547
-#: ../src/common/paper.cpp:171
+#: ../src/common/paper.cpp:168
 msgid "A4 Rotated 297 x 210 mm"
 msgstr "A4 rotirano, 297 x 210 mm"
 
 # generic/dcpsg.cpp:2547
-#: ../src/common/paper.cpp:148
+#: ../src/common/paper.cpp:145
 msgid "A4 Transverse 210 x 297 mm"
 msgstr "A4 prečno, 210 x 297 mm"
 
 # generic/dcpsg.cpp:2547
-#: ../src/common/paper.cpp:97
+#: ../src/common/paper.cpp:94
 msgid "A4 sheet, 210 x 297 mm"
 msgstr "A4, 210 x 297 mm"
 
 # generic/dcpsg.cpp:2547
-#: ../src/common/paper.cpp:107
+#: ../src/common/paper.cpp:104
 msgid "A4 small sheet, 210 x 297 mm"
 msgstr "A4-mali, 210 x 297 mm"
 
 # generic/dcpsg.cpp:2547
-#: ../src/common/paper.cpp:157
+#: ../src/common/paper.cpp:154
 msgid "A5 Extra 174 x 235 mm"
 msgstr "A5 posebno, 174 x 235 mm"
 
-#: ../src/common/paper.cpp:172
+#: ../src/common/paper.cpp:169
 msgid "A5 Rotated 210 x 148 mm"
 msgstr "A5 rotirano, 210 x 148 mm"
 
 # generic/dcpsg.cpp:2547
-#: ../src/common/paper.cpp:154
+#: ../src/common/paper.cpp:151
 msgid "A5 Transverse 148 x 210 mm"
 msgstr "A5 prečno, 148 x 210 mm"
 
 # generic/dcpsg.cpp:2547
-#: ../src/common/paper.cpp:108
+#: ../src/common/paper.cpp:105
 msgid "A5 sheet, 148 x 210 mm"
 msgstr "A5, 148 x 210 mm"
 
-#: ../src/common/paper.cpp:164
+#: ../src/common/paper.cpp:161
 msgid "A6 105 x 148 mm"
 msgstr "A6, 105 x 148 mm"
 
 # generic/dcpsg.cpp:2547
-#: ../src/common/paper.cpp:177
+#: ../src/common/paper.cpp:174
 msgid "A6 Rotated 148 x 105 mm"
 msgstr "A6 rotirano, 148 x 105 mm"
 
 # generic/fontdlgg.cpp:325
-#: ../src/generic/fontdlgg.cpp:83 ../src/richtext/richtextformatdlg.cpp:529
-#: ../src/osx/carbon/fontdlg.cpp:153
+#: ../src/osx/carbon/fontdlg.cpp:150 ../src/generic/fontdlgg.cpp:79
+#: ../src/richtext/richtextformatdlg.cpp:521
 msgid "ABCDEFGabcdefg12345"
 msgstr "Ščinkavec želi 12345 češenj."
 
-#: ../src/richtext/richtextsymboldlg.cpp:458 ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
 msgid "ASCII"
 msgstr "ASCII"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "About"
 msgstr "O programu"
 
-#: ../src/generic/aboutdlgg.cpp:140 ../src/osx/menu_osx.cpp:558
-#: ../src/msw/aboutdlg.cpp:64
+#: ../src/osx/menu_osx.cpp:450 ../src/generic/aboutdlgg.cpp:137
+#: ../src/msw/aboutdlg.cpp:61
 #, c-format
 msgid "About %s"
 msgstr "O programu %s ..."
 
-#: ../src/osx/menu_osx.cpp:560
+#: ../src/osx/menu_osx.cpp:452
 msgid "About..."
 msgstr "O programu …"
 
@@ -1391,39 +1387,39 @@ msgstr "Absolutno"
 
 # generic/fontdlgg.cpp:208
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:873
+#: ../src/propgrid/advprops.cpp:774
 msgid "ActiveBorder"
 msgstr "DejavnaObroba"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:874
+#: ../src/propgrid/advprops.cpp:775
 msgid "ActiveCaption"
 msgstr "DejavniNapis"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "Actual Size"
 msgstr "Dejanska velikost"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:140 ../src/common/accelcmn.cpp:81
+#: ../src/common/stockitem.cpp:137 ../src/common/accelcmn.cpp:78
 msgid "Add"
 msgstr "Dodaj"
 
-#: ../src/richtext/richtextbuffer.cpp:11455
+#: ../src/richtext/richtextbuffer.cpp:11454
 msgid "Add Column"
 msgstr "Dodaj stolpec"
 
-#: ../src/richtext/richtextbuffer.cpp:11392
+#: ../src/richtext/richtextbuffer.cpp:11391
 msgid "Add Row"
 msgstr "Dodaj vrstico"
 
 # html/helpfrm.cpp:270
-#: ../src/html/helpwnd.cpp:432
+#: ../src/html/helpwnd.cpp:430
 msgid "Add current page to bookmarks"
 msgstr "Dodaj trenutno stran med zaznamke"
 
 # generic/colrdlgg.cpp:269
-#: ../src/generic/colrdlgg.cpp:366
+#: ../src/generic/colrdlgg.cpp:386
 msgid "Add to custom colours"
 msgstr "Dodaj k predelanim barvam"
 
@@ -1436,12 +1432,12 @@ msgid "AddToPropertyCollection called w/o valid adder"
 msgstr "AddToPropertyCollection klicana brez veljavnega dodajalnika"
 
 # html/helpctrl.cpp:83
-#: ../src/html/helpctrl.cpp:159
+#: ../src/html/helpctrl.cpp:155
 #, c-format
 msgid "Adding book %s"
 msgstr "Dodajanje knjige %s"
 
-#: ../src/common/preferencescmn.cpp:43
+#: ../src/common/preferencescmn.cpp:40
 msgid "Advanced"
 msgstr "Napredno"
 
@@ -1449,12 +1445,12 @@ msgstr "Napredno"
 msgid "After a paragraph:"
 msgstr "Za odstavkom:"
 
-#: ../src/common/stockitem.cpp:172
+#: ../src/common/stockitem.cpp:169
 msgid "Align Left"
 msgstr "Poravnaj levo"
 
 # generic/fontdlgg.cpp:216
-#: ../src/common/stockitem.cpp:173
+#: ../src/common/stockitem.cpp:170
 msgid "Align Right"
 msgstr "Poravnaj desno"
 
@@ -1463,43 +1459,43 @@ msgid "Alignment"
 msgstr "Poravnava"
 
 # generic/prntdlgg.cpp:163
-#: ../src/generic/prntdlgg.cpp:215
+#: ../src/generic/prntdlgg.cpp:208
 msgid "All"
 msgstr "Vse"
 
 # generic/filedlgg.cpp:825
-#: ../src/generic/filectrlg.cpp:1197 ../src/common/fldlgcmn.cpp:107
+#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1186
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Vse datoteke (%s)|%s"
 
 # generic/filedlgg.cpp:825
-#: ../include/wx/defs.h:2886
+#: ../include/wx/defs.h:2582
 msgid "All files (*)|*"
 msgstr "Vse datoteke (*)|*"
 
 # generic/filedlgg.cpp:825
-#: ../include/wx/defs.h:2883
+#: ../include/wx/defs.h:2579
 msgid "All files (*.*)|*.*"
 msgstr "Vse datoteke (*.*)|*.*"
 
-#: ../src/richtext/richtextstyles.cpp:1061
+#: ../src/richtext/richtextstyles.cpp:1058
 msgid "All styles"
 msgstr "Vsi slogi"
 
-#: ../src/propgrid/manager.cpp:1528
+#: ../src/propgrid/manager.cpp:1544
 msgid "Alphabetic Mode"
 msgstr "Abecedni način"
 
-#: ../src/common/xtistrm.cpp:425
+#: ../src/common/xtistrm.cpp:422
 msgid "Already Registered Object passed to SetObjectClassInfo"
 msgstr "V SetObjectClassInfo je bil podan že registriran predmet."
 
-#: ../src/unix/dialup.cpp:353
+#: ../src/unix/dialup.cpp:352
 msgid "Already dialling ISP."
 msgstr "Klicanje ponudnika spletnih storitev je v teku."
 
-#: ../src/common/accelcmn.cpp:331 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/accelcmn.cpp:345 ../src/univ/themes/win32.cpp:3753
 msgid "Alt+"
 msgstr "Dvigalka+"
 
@@ -1508,22 +1504,22 @@ msgstr "Dvigalka+"
 msgid "An optional corner radius for adding rounded corners."
 msgstr "Neobvezni polmer kotov za zaobljanje robov."
 
-#: ../src/common/debugrpt.cpp:576
+#: ../src/common/debugrpt.cpp:577
 msgid "And includes the following files:\n"
 msgstr "in vsebuje naslednje datoteke:\n"
 
-#: ../src/generic/animateg.cpp:162
+#: ../src/generic/animateg.cpp:145
 #, c-format
 msgid "Animation file is not of type %ld."
 msgstr "Datoteka animacije ni vrste %ld."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:872
+#: ../src/propgrid/advprops.cpp:773
 msgid "AppWorkspace"
 msgstr "Delovna površina programa"
 
 # generic/logg.cpp:1021
-#: ../src/generic/logg.cpp:1014
+#: ../src/generic/logg.cpp:1011
 #, c-format
 msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
 msgstr ""
@@ -1531,15 +1527,15 @@ msgstr ""
 "datoteke)?"
 
 # generic/dirdlgg.cpp:191
-#: ../src/osx/menu_osx.cpp:577 ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:469 ../src/osx/menu_osx.cpp:477
 msgid "Application"
 msgstr "Program"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "Apply"
 msgstr "Uporabi"
 
-#: ../src/propgrid/advprops.cpp:1609
+#: ../src/propgrid/advprops.cpp:1515
 msgid "Aqua"
 msgstr "Aqua"
 
@@ -1548,31 +1544,31 @@ msgstr "Aqua"
 msgid "Arabic"
 msgstr "arabsko"
 
-#: ../src/common/fmapbase.cpp:153
+#: ../src/common/fmapbase.cpp:150
 msgid "Arabic (ISO-8859-6)"
 msgstr "arabsko (ISO-8859-6)"
 
 # common/intl.cpp:374
-#: ../src/msw/ole/automtn.cpp:672
+#: ../src/msw/ole/automtn.cpp:663
 #, c-format
 msgid "Argument %u not found."
 msgstr "Argumenta %u ni mogoče najti."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1753
+#: ../src/propgrid/advprops.cpp:1654
 msgid "Arrow"
 msgstr "Puščica"
 
-#: ../src/generic/aboutdlgg.cpp:184
+#: ../src/generic/aboutdlgg.cpp:181
 msgid "Artists"
 msgstr "Oblikovalci"
 
 # common/fontmap.cpp:332
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "Ascending"
 msgstr "Naraščajoče"
 
-#: ../src/generic/filectrlg.cpp:433
+#: ../src/generic/filectrlg.cpp:429
 msgid "Attributes"
 msgstr "Atributi"
 
@@ -1583,101 +1579,101 @@ msgid "Available fonts."
 msgstr "Pisave na voljo."
 
 # generic/dcpsg.cpp:2547
-#: ../src/common/paper.cpp:137
+#: ../src/common/paper.cpp:134
 msgid "B4 (ISO) 250 x 353 mm"
 msgstr "B4 (ISO), 250 x 354 mm"
 
-#: ../src/common/paper.cpp:173
+#: ../src/common/paper.cpp:170
 msgid "B4 (JIS) Rotated 364 x 257 mm"
 msgstr "B4 (JIS) rotirano, 364 x 257 mm"
 
-#: ../src/common/paper.cpp:127
+#: ../src/common/paper.cpp:124
 msgid "B4 Envelope, 250 x 353 mm"
 msgstr "kuverta B4, 250 x 353 mm"
 
 # generic/dcpsg.cpp:2547
-#: ../src/common/paper.cpp:109
+#: ../src/common/paper.cpp:106
 msgid "B4 sheet, 250 x 354 mm"
 msgstr "B4, 250 x 354 mm"
 
-#: ../src/common/paper.cpp:158
+#: ../src/common/paper.cpp:155
 msgid "B5 (ISO) Extra 201 x 276 mm"
 msgstr "B5 (ISO) Extra, 201 x 276 mm"
 
-#: ../src/common/paper.cpp:174
+#: ../src/common/paper.cpp:171
 msgid "B5 (JIS) Rotated 257 x 182 mm"
 msgstr "B5 (JIS) rotirano, 257 x 182 mm"
 
 # generic/dcpsg.cpp:2547
-#: ../src/common/paper.cpp:155
+#: ../src/common/paper.cpp:152
 msgid "B5 (JIS) Transverse 182 x 257 mm"
 msgstr "B5 (JIS) prečno, 182 x 257 mm"
 
-#: ../src/common/paper.cpp:128
+#: ../src/common/paper.cpp:125
 msgid "B5 Envelope, 176 x 250 mm"
 msgstr "kuverta B5, 176 x 250 mm"
 
 # generic/dcpsg.cpp:2547
-#: ../src/common/paper.cpp:110
+#: ../src/common/paper.cpp:107
 msgid "B5 sheet, 182 x 257 millimeter"
 msgstr "B5, 182 x 257 mm"
 
-#: ../src/common/paper.cpp:182
+#: ../src/common/paper.cpp:179
 msgid "B6 (JIS) 128 x 182 mm"
 msgstr "B6 (JIS), 128 x 182 mm"
 
-#: ../src/common/paper.cpp:183
+#: ../src/common/paper.cpp:180
 msgid "B6 (JIS) Rotated 182 x 128 mm"
 msgstr "B6 (JIS) rotirano, 182 x 128 mm"
 
-#: ../src/common/paper.cpp:129
+#: ../src/common/paper.cpp:126
 msgid "B6 Envelope, 176 x 125 mm"
 msgstr "kuverta B6, 176 x 125 mm"
 
 # common/imagbmp.cpp:266
 # common/imagbmp.cpp:278
-#: ../src/common/imagbmp.cpp:531 ../src/common/imagbmp.cpp:561
-#: ../src/common/imagbmp.cpp:576
+#: ../src/common/imagbmp.cpp:528 ../src/common/imagbmp.cpp:558
+#: ../src/common/imagbmp.cpp:573
 msgid "BMP: Couldn't allocate memory."
 msgstr "BMP: pomnilnika ni mogoče alocirati."
 
 # common/imagbmp.cpp:62
-#: ../src/common/imagbmp.cpp:100
+#: ../src/common/imagbmp.cpp:97
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: nepravilne slike ni mogoče shraniti."
 
 # common/imagbmp.cpp:154
-#: ../src/common/imagbmp.cpp:356
+#: ../src/common/imagbmp.cpp:353
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: barvnega zemljevida RGB ni mogoče shraniti."
 
 # common/imagbmp.cpp:154
-#: ../src/common/imagbmp.cpp:490
+#: ../src/common/imagbmp.cpp:487
 msgid "BMP: Couldn't write data."
 msgstr "BMP: podatkov ni mogoče zapisati"
 
 # common/imagbmp.cpp:131
-#: ../src/common/imagbmp.cpp:246
+#: ../src/common/imagbmp.cpp:243
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: datotečne glave (Bitmap) ni mogoče zapisati."
 
 # common/imagbmp.cpp:131
-#: ../src/common/imagbmp.cpp:269
+#: ../src/common/imagbmp.cpp:266
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: datotečne glave (BitmapInfo) ni mogoče zapisati."
 
-#: ../src/common/imagbmp.cpp:140
+#: ../src/common/imagbmp.cpp:137
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage nima lastne wxPalette."
 
 # generic/helpwxht.cpp:157
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:142 ../src/common/accelcmn.cpp:52
+#: ../src/common/stockitem.cpp:139 ../src/common/accelcmn.cpp:49
 msgid "Back"
 msgstr "Nazaj"
 
+#: ../src/richtext/richtextformatdlg.cpp:377
 #: ../src/richtext/richtextbackgroundpage.cpp:148
-#: ../src/richtext/richtextformatdlg.cpp:384
 msgid "Background"
 msgstr "Ozadje"
 
@@ -1685,21 +1681,21 @@ msgstr "Ozadje"
 msgid "Background &colour:"
 msgstr "&Barva ozadja:"
 
-#: ../src/osx/carbon/fontdlg.cpp:220
+#: ../src/osx/carbon/fontdlg.cpp:217
 msgid "Background colour"
 msgstr "Barva ozadja"
 
 # generic/helpwxht.cpp:157
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:52
+#: ../src/common/accelcmn.cpp:49
 msgid "Backspace"
 msgstr "Vračalka"
 
-#: ../src/common/fmapbase.cpp:160
+#: ../src/common/fmapbase.cpp:157
 msgid "Baltic (ISO-8859-13)"
 msgstr "baltsko (ISO-8859-13)"
 
-#: ../src/common/fmapbase.cpp:151
+#: ../src/common/fmapbase.cpp:148
 msgid "Baltic (old) (ISO-8859-4)"
 msgstr "baltsko (staro) (ISO-8859-4)"
 
@@ -1712,26 +1708,26 @@ msgstr "Pred odstavkom:"
 msgid "Bitmap"
 msgstr "Bitna slika"
 
-#: ../src/propgrid/advprops.cpp:1594
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Black"
 msgstr "Črna"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1755
+#: ../src/propgrid/advprops.cpp:1656
 msgid "Blank"
 msgstr "Prazno"
 
-#: ../src/propgrid/advprops.cpp:1603
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Blue"
 msgstr "Modra"
 
-#: ../src/generic/colrdlgg.cpp:345
+#: ../src/generic/colrdlgg.cpp:365
 msgid "Blue:"
 msgstr "Modra:"
 
 # generic/fontdlgg.cpp:217
-#: ../src/generic/fontdlgg.cpp:333 ../src/richtext/richtextfontpage.cpp:355
-#: ../src/osx/carbon/fontdlg.cpp:354 ../src/common/stockitem.cpp:143
+#: ../src/osx/carbon/fontdlg.cpp:351 ../src/common/stockitem.cpp:140
+#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:355
 msgid "Bold"
 msgstr "Krepko"
 
@@ -1742,33 +1738,37 @@ msgid "Border"
 msgstr "Obroba"
 
 # generic/fontdlgg.cpp:208
-#: ../src/richtext/richtextformatdlg.cpp:379
+#: ../src/richtext/richtextformatdlg.cpp:372
 msgid "Borders"
 msgstr "Obrobe"
 
-#: ../src/richtext/richtextsizepage.cpp:288 ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141 ../src/richtext/richtextsizepage.cpp:288
 msgid "Bottom"
 msgstr "Na dnu"
 
 # generic/prntdlgg.cpp:662
-#: ../src/generic/prntdlgg.cpp:893
+#: ../src/generic/prntdlgg.cpp:886
 msgid "Bottom margin (mm):"
 msgstr "Spodnji rob (mm):"
 
 # html/helpfrm.cpp:512
-#: ../src/richtext/richtextbuffer.cpp:9383
+#: ../src/richtext/richtextbuffer.cpp:9380
 msgid "Box Properties"
 msgstr "Lastnosti polja"
 
-#: ../src/richtext/richtextstyles.cpp:1065
+#: ../src/richtext/richtextstyles.cpp:1062
 msgid "Box styles"
 msgstr "Slogi polja"
 
-#: ../src/propgrid/advprops.cpp:1602
+#: ../src/osx/cocoa/menu.mm:292
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Brown"
 msgstr "Rjava"
 
-#: ../src/common/filepickercmn.cpp:43 ../src/common/filepickercmn.cpp:44
+#: ../src/common/filepickercmn.cpp:40 ../src/common/filepickercmn.cpp:41
 msgid "Browse"
 msgstr "Prebrskaj"
 
@@ -1781,74 +1781,74 @@ msgstr "Po&ravnava oznak:"
 msgid "Bullet style"
 msgstr "Slog oznak"
 
-#: ../src/richtext/richtextformatdlg.cpp:359
+#: ../src/richtext/richtextformatdlg.cpp:352
 msgid "Bullets"
 msgstr "Oznake"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1756
+#: ../src/propgrid/advprops.cpp:1657
 msgid "Bullseye"
 msgstr "Tarča"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:875
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonFace"
 msgstr "PloskevGumba"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:876
+#: ../src/propgrid/advprops.cpp:777
 msgid "ButtonHighlight"
 msgstr "PoudarekGumba"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:877
+#: ../src/propgrid/advprops.cpp:778
 msgid "ButtonShadow"
 msgstr "SencaGumba"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:878
+#: ../src/propgrid/advprops.cpp:779
 msgid "ButtonText"
 msgstr "BesediloGumba"
 
 # generic/dcpsg.cpp:2547
-#: ../src/common/paper.cpp:98
+#: ../src/common/paper.cpp:95
 msgid "C sheet, 17 x 22 in"
 msgstr "C, 17 x 22 pal."
 
 # generic/logg.cpp:475
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "C&lear"
 msgstr "&Izprazni"
 
-#: ../src/generic/fontdlgg.cpp:406
+#: ../src/generic/fontdlgg.cpp:403
 msgid "C&olour:"
 msgstr "&Barva:"
 
-#: ../src/common/paper.cpp:123
+#: ../src/common/paper.cpp:120
 msgid "C3 Envelope, 324 x 458 mm"
 msgstr "kuverta C3, 324 x 458 mm"
 
-#: ../src/common/paper.cpp:124
+#: ../src/common/paper.cpp:121
 msgid "C4 Envelope, 229 x 324 mm"
 msgstr "kuverta C4, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:122
+#: ../src/common/paper.cpp:119
 msgid "C5 Envelope, 162 x 229 mm"
 msgstr "kuverta C5, 162 x 229 mm"
 
-#: ../src/common/paper.cpp:125
+#: ../src/common/paper.cpp:122
 msgid "C6 Envelope, 114 x 162 mm"
 msgstr "kuverta C6, 114 x 162 mm"
 
-#: ../src/common/paper.cpp:126
+#: ../src/common/paper.cpp:123
 msgid "C65 Envelope, 114 x 229 mm"
 msgstr "kuverta C65, 114 x 229 mm"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "CD-Rom"
 msgstr "CD-pogon"
 
-#: ../src/html/chm.cpp:815 ../src/html/chm.cpp:874
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:865
 msgid "CHM handler currently supports only local files!"
 msgstr "Upravljalec CHM trenutno podpira le lokalne datoteke!"
 
@@ -1857,11 +1857,11 @@ msgid "Ca&pitals"
 msgstr "Ve&like začetnice"
 
 # common/docview.cpp:1928
-#: ../src/common/cmdproc.cpp:267
+#: ../src/common/cmdproc.cpp:260
 msgid "Can't &Undo "
 msgstr "Nemogoča &razveljavitev"
 
-#: ../src/common/image.cpp:2824
+#: ../src/common/image.cpp:2924
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr "Ni mogoče samodejno določiti obliko slike za vnos brez iskanja."
 
@@ -1870,13 +1870,13 @@ msgstr "Ni mogoče samodejno določiti obliko slike za vnos brez iskanja."
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 # msw/registry.cpp:418
-#: ../src/msw/registry.cpp:506
+#: ../src/msw/registry.cpp:495
 #, c-format
 msgid "Can't close registry key '%s'"
 msgstr "Registrskega ključa »%s« ni mogoče zapreti."
 
 # msw/registry.cpp:490
-#: ../src/msw/registry.cpp:584
+#: ../src/msw/registry.cpp:573
 #, c-format
 msgid "Can't copy values of unsupported type %d."
 msgstr "Vrednosti nepodprtega tipa %d ni mogoče kopirati."
@@ -1886,7 +1886,7 @@ msgstr "Vrednosti nepodprtega tipa %d ni mogoče kopirati."
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 # msw/registry.cpp:399
-#: ../src/msw/registry.cpp:487
+#: ../src/msw/registry.cpp:476
 #, c-format
 msgid "Can't create registry key '%s'"
 msgstr "Registrskega ključa »%s« ni mogoče ustvariti."
@@ -1896,7 +1896,7 @@ msgstr "Registrskega ključa »%s« ni mogoče ustvariti."
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 # msw/thread.cpp:519
-#: ../src/msw/thread.cpp:665
+#: ../src/msw/thread.cpp:657
 msgid "Can't create thread"
 msgstr "Niti ni mogoče ustvariti."
 
@@ -1904,18 +1904,8 @@ msgstr "Niti ni mogoče ustvariti."
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-# common/file.cpp:200
-#: ../src/msw/window.cpp:3691
-#, c-format
-msgid "Can't create window of class %s"
-msgstr "Okna ali razreda %s ni mogoče ustvariti."
-
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR Free Software Foundation, Inc.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
 # msw/registry.cpp:658
-#: ../src/msw/registry.cpp:777
+#: ../src/msw/registry.cpp:765
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Ključa »%s« ni mogoče izbrisati."
@@ -1925,19 +1915,19 @@ msgstr "Ključa »%s« ni mogoče izbrisati."
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 # msw/iniconf.cpp:476
-#: ../src/msw/iniconf.cpp:458
+#: ../src/msw/iniconf.cpp:455
 #, c-format
 msgid "Can't delete the INI file '%s'"
 msgstr "Datoteke INI »%s« ni mogoče izbrisati."
 
 # msw/registry.cpp:683
-#: ../src/msw/registry.cpp:805
+#: ../src/msw/registry.cpp:793
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Vrednosti »%s« ni mogoče izbrisati iz ključa »%s«."
 
 # msw/registry.cpp:1020
-#: ../src/msw/registry.cpp:1171
+#: ../src/msw/registry.cpp:1159
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Podključev ključa »%s« ni mogoče prešteti."
@@ -1947,13 +1937,13 @@ msgstr "Podključev ključa »%s« ni mogoče prešteti."
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 # msw/registry.cpp:975
-#: ../src/msw/registry.cpp:1132
+#: ../src/msw/registry.cpp:1120
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Vrednosti ključa »%s« ni mogoče prešteti."
 
 # msw/registry.cpp:490
-#: ../src/msw/registry.cpp:1389
+#: ../src/msw/registry.cpp:1377
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Vrednosti nepodprtega tipa %d ni mogoče izvoziti."
@@ -1963,45 +1953,51 @@ msgstr "Vrednosti nepodprtega tipa %d ni mogoče izvoziti."
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 # common/ffile.cpp:234
-#: ../src/common/ffile.cpp:254
+#: ../src/common/ffile.cpp:253
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Trenutne pozicije v datoteki »%s« ni mogoče najti."
 
 # msw/registry.cpp:348
-#: ../src/msw/registry.cpp:418
+#: ../src/msw/registry.cpp:407
 #, c-format
 msgid "Can't get info about registry key '%s'"
 msgstr "Informacije o ključu »%s« niso dosegljive."
 
+# msw/thread.cpp:485
+#: ../src/msw/webview_ie.cpp:1024
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "Prioritet niti ni bilo mogoče nastaviti."
+
 # html/helpfrm.cpp:1174
-#: ../src/common/zstream.cpp:346
+#: ../src/common/zstream.cpp:343
 msgid "Can't initialize zlib deflate stream."
 msgstr "Ni mogoče inicializirati upadalnega toka zlib."
 
 # html/helpfrm.cpp:1174
-#: ../src/common/zstream.cpp:185
+#: ../src/common/zstream.cpp:182
 msgid "Can't initialize zlib inflate stream."
 msgstr "Ni mogoče inicializirati napihovalnega toka zlib."
 
-#: ../src/msw/fswatcher.cpp:476
+#: ../src/msw/fswatcher.cpp:475
 #, c-format
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "Sprememb v neobstoječi mapi »%s« ni mogoče spremljati."
 
 # msw/registry.cpp:374
-#: ../src/msw/registry.cpp:454
+#: ../src/msw/registry.cpp:443
 #, c-format
 msgid "Can't open registry key '%s'"
 msgstr "Registrskega ključa »%s« ni mogoče odpreti."
 
 # common/file.cpp:285
-#: ../src/common/zstream.cpp:252
+#: ../src/common/zstream.cpp:249
 #, c-format
 msgid "Can't read from inflate stream: %s"
 msgstr "Branje iz napihovalnega toka ni možno: %s"
 
-#: ../src/common/zstream.cpp:244
+#: ../src/common/zstream.cpp:241
 msgid "Can't read inflate stream: unexpected EOF in underlying stream."
 msgstr "Branje napihovalnega toka ni uspelo: nepričakovan EOF v osnovnem toku."
 
@@ -2010,7 +2006,7 @@ msgstr "Branje napihovalnega toka ni uspelo: nepričakovan EOF v osnovnem toku."
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 # msw/registry.cpp:899
-#: ../src/msw/registry.cpp:1064
+#: ../src/msw/registry.cpp:1052
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Vrednosti »%s« ni mogoče prebrati."
@@ -2021,27 +2017,31 @@ msgstr "Vrednosti »%s« ni mogoče prebrati."
 #
 # msw/registry.cpp:774
 # msw/registry.cpp:813
-#: ../src/msw/registry.cpp:878 ../src/msw/registry.cpp:910
-#: ../src/msw/registry.cpp:975
+#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
+#: ../src/msw/registry.cpp:963
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Vrednosti ključa »%s« ni mogoče prebrati."
 
+#: ../src/msw/webview_ie.cpp:1017
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
 # common/image.cpp:653
 # common/image.cpp:673
-#: ../src/common/image.cpp:2620
+#: ../src/common/image.cpp:2715
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "Slike ni mogoče shraniti v datoteko »%s«: neznana končnica."
 
 # generic/logg.cpp:535
 # generic/logg.cpp:932
-#: ../src/generic/logg.cpp:573 ../src/generic/logg.cpp:976
+#: ../src/generic/logg.cpp:570 ../src/generic/logg.cpp:973
 msgid "Can't save log contents to file."
 msgstr "Vsebine dnevnika ni mogoče shraniti v datoteko."
 
 # msw/thread.cpp:485
-#: ../src/msw/thread.cpp:629
+#: ../src/msw/thread.cpp:621
 msgid "Can't set thread priority"
 msgstr "Prioritet niti ni bilo mogoče nastaviti."
 
@@ -2051,18 +2051,18 @@ msgstr "Prioritet niti ni bilo mogoče nastaviti."
 #
 # msw/registry.cpp:799
 # msw/registry.cpp:923
-#: ../src/msw/registry.cpp:896 ../src/msw/registry.cpp:938
-#: ../src/msw/registry.cpp:1081
+#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
+#: ../src/msw/registry.cpp:1069
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Vrednosti ključa »%s« ni mogoče nastaviti."
 
-#: ../src/unix/utilsunx.cpp:351
+#: ../src/unix/utilsunx.cpp:353
 msgid "Can't write to child process's stdin"
 msgstr "Ni mogoče pisati v stdin podrejenega procesa"
 
 # common/file.cpp:304
-#: ../src/common/zstream.cpp:427
+#: ../src/common/zstream.cpp:424
 #, c-format
 msgid "Can't write to deflate stream: %s"
 msgstr "Pisanje v upadalni tok ni možno: %s"
@@ -2079,59 +2079,59 @@ msgstr "Pisanje v upadalni tok ni možno: %s"
 # generic/wizard.cpp:192
 # html/helpfrm.cpp:910
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:279 ../src/richtext/richtextstyledlg.cpp:300
-#: ../src/common/stockitem.cpp:145 ../src/common/accelcmn.cpp:71
-#: ../src/msw/msgdlg.cpp:454 ../src/msw/progdlg.cpp:673
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:142
+#: ../src/common/accelcmn.cpp:68 ../src/motif/msgdlg.cpp:196
+#: ../src/gtk1/fontdlg.cpp:144 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/progdlg.cpp:940 ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Prekliči"
 
 # common/filefn.cpp:1287
 # msw/dir.cpp:294
-#: ../src/common/filefn.cpp:1261
+#: ../src/common/filefn.cpp:1149
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Oštevilčenje datotek »%s« ni možno"
 
 # common/filefn.cpp:1287
 # msw/dir.cpp:294
-#: ../src/msw/dir.cpp:263
+#: ../src/msw/dir.cpp:260
 #, c-format
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Oštevilčenje datotek v mapi »%s« ni možno."
 
 # msw/dialup.cpp:518
-#: ../src/msw/dialup.cpp:523
+#: ../src/msw/dialup.cpp:517
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Aktivne klicne povezave ni mogoče najti: %s"
 
 # msw/dialup.cpp:832
-#: ../src/msw/dialup.cpp:827
+#: ../src/msw/dialup.cpp:821
 msgid "Cannot find the location of address book file"
 msgstr "Ni možno najti mesta datoteke adresarja"
 
 # msw/dialup.cpp:518
-#: ../src/msw/ole/automtn.cpp:562
+#: ../src/msw/ole/automtn.cpp:553
 #, c-format
 msgid "Cannot get an active instance of \"%s\""
 msgstr "Aktivne instance »%s« ni mogoče pridobiti"
 
-#: ../src/unix/threadpsx.cpp:1035
+#: ../src/unix/threadpsx.cpp:1053
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "Za politiko razporejanja %d ni mogoče pridobiti razpona prioritet."
 
-#: ../src/unix/utilsunx.cpp:987
+#: ../src/unix/utilsunx.cpp:989
 msgid "Cannot get the hostname"
 msgstr "Imena gostitelja ni mogoče dobiti"
 
-#: ../src/unix/utilsunx.cpp:1023
+#: ../src/unix/utilsunx.cpp:1025
 msgid "Cannot get the official hostname"
 msgstr "Imena uradnega gostitelja ni mogoče dobiti"
 
 # msw/dialup.cpp:925
-#: ../src/msw/dialup.cpp:928
+#: ../src/msw/dialup.cpp:922
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Povezave ni mogoče prekiniti - ni aktivne klicne povezave."
 
@@ -2141,146 +2141,146 @@ msgid "Cannot initialize OLE"
 msgstr "Inicializacija OLE ni možna"
 
 # msw/app.cpp:252
-#: ../src/common/socket.cpp:853
+#: ../src/common/socket.cpp:850
 msgid "Cannot initialize sockets"
 msgstr "Inicializacija vrat ni možna"
 
 # common/filefn.cpp:1287
 # msw/dir.cpp:294
-#: ../src/msw/volume.cpp:619
+#: ../src/msw/volume.cpp:627
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Nalaganje ikone z »%s« ni možno."
 
 # common/ffile.cpp:101
-#: ../src/xrc/xmlres.cpp:360
+#: ../src/xrc/xmlres.cpp:358
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Virov iz datoteke »%s« ni mogoče naložiti."
 
 # common/ffile.cpp:101
-#: ../src/xrc/xmlres.cpp:742
+#: ../src/xrc/xmlres.cpp:740
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Ni mogoče naložiti virov iz datoteke »%s«."
 
 # html/htmlfilt.cpp:146
-#: ../src/html/htmlfilt.cpp:137
+#: ../src/html/htmlfilt.cpp:134
 #, c-format
 msgid "Cannot open HTML document: %s"
 msgstr "Dokumenta HTML ni mogoče odpreti: %s"
 
 # html/helpdata.cpp:657
-#: ../src/html/helpdata.cpp:667
+#: ../src/html/helpdata.cpp:660
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Knjige s HTML pomočjo ni mogoče odpreti: %s"
 
 # html/helpdata.cpp:353
-#: ../src/html/helpdata.cpp:299
+#: ../src/html/helpdata.cpp:296
 #, c-format
 msgid "Cannot open contents file: %s"
 msgstr "Datoteke z vsebino ni mogoče odpreti: %s"
 
 # generic/dcpsg.cpp:1584
-#: ../src/generic/dcpsg.cpp:1667
+#: ../src/generic/dcpsg.cpp:1665
 msgid "Cannot open file for PostScript printing!"
 msgstr "Datoteke za tiskanje PostScript ni mogoče odpreti!"
 
 # html/helpdata.cpp:368
-#: ../src/html/helpdata.cpp:313
+#: ../src/html/helpdata.cpp:310
 #, c-format
 msgid "Cannot open index file: %s"
 msgstr "Indeksne datoteke ni mogoče odpreti: %s"
 
 # common/ffile.cpp:101
-#: ../src/xrc/xmlres.cpp:724
+#: ../src/xrc/xmlres.cpp:722
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Datoteke virov »%s« ni mogoče odpreti."
 
 # html/helpfrm.cpp:1174
-#: ../src/html/helpwnd.cpp:1534
+#: ../src/html/helpwnd.cpp:1532
 msgid "Cannot print empty page."
 msgstr "Prazne strani ni mogoče natisniti."
 
 # html/helpdata.cpp:353
-#: ../src/msw/volume.cpp:507
+#: ../src/msw/volume.cpp:515
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Imena tipa ni mogoče prebrati iz »%s«!"
 
 # msw/thread.cpp:552
-#: ../src/msw/thread.cpp:888
+#: ../src/msw/thread.cpp:894
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Niti %lx ni mogoče nadaljevati"
 
-#: ../src/unix/threadpsx.cpp:1016
+#: ../src/unix/threadpsx.cpp:1028
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Ni mogoče pridobiti politiko razporejanja niti."
 
-#: ../src/common/intl.cpp:558
+#: ../src/common/intl.cpp:365
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "Jezika programa ni mogoče nastaviti na \"%s\"."
 
 # msw/thread.cpp:433
-#: ../src/unix/threadpsx.cpp:831 ../src/msw/thread.cpp:546
+#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
 msgid "Cannot start thread: error writing TLS."
 msgstr "Niti ni mogoče začeti: napaka pri pisanju TLS."
 
 # msw/thread.cpp:537
-#: ../src/msw/thread.cpp:872
+#: ../src/msw/thread.cpp:864
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Niti %lx ni mogoče začasno ustaviti."
 
 # msw/thread.cpp:871
-#: ../src/msw/thread.cpp:794
+#: ../src/msw/thread.cpp:786
 msgid "Cannot wait for thread termination"
 msgstr "Ustavitve niti ni mogoče pričakati."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:75
+#: ../src/common/accelcmn.cpp:72
 msgid "Capital"
 msgstr "Velike začetnice"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:879
+#: ../src/propgrid/advprops.cpp:780
 msgid "CaptionText"
 msgstr "BesediloNapisa"
 
 # html/helpfrm.cpp:398
-#: ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:531
 msgid "Case sensitive"
 msgstr "Razlikovanje malih/velikih črk"
 
-#: ../src/propgrid/manager.cpp:1509
+#: ../src/propgrid/manager.cpp:1527
 msgid "Categorized Mode"
 msgstr "Kategoriziran način"
 
 # html/helpfrm.cpp:512
-#: ../src/richtext/richtextbuffer.cpp:9968
+#: ../src/richtext/richtextbuffer.cpp:9965
 msgid "Cell Properties"
 msgstr "Lastnosti celice"
 
-#: ../src/common/fmapbase.cpp:161
+#: ../src/common/fmapbase.cpp:158
 msgid "Celtic (ISO-8859-14)"
 msgstr "keltsko (ISO-8859-14)"
 
 # generic/dirdlgg.cpp:217
-#: ../src/richtext/richtextindentspage.cpp:160
 #: ../src/richtext/richtextliststylepage.cpp:349
+#: ../src/richtext/richtextindentspage.cpp:160
 msgid "Cen&tred"
 msgstr "&Sredinsko"
 
 # generic/dirdlgg.cpp:217
-#: ../src/common/stockitem.cpp:170
+#: ../src/common/stockitem.cpp:167
 msgid "Centered"
 msgstr "Poravnano na sredino"
 
-#: ../src/common/fmapbase.cpp:149
+#: ../src/common/fmapbase.cpp:146
 msgid "Central European (ISO-8859-2)"
 msgstr "srednjeevropsko (ISO-8859-2)"
 
@@ -2295,10 +2295,10 @@ msgstr "Sredinsko"
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 # msw/thread.cpp:519
-#: ../src/richtext/richtextindentspage.cpp:162
-#: ../src/richtext/richtextindentspage.cpp:164
 #: ../src/richtext/richtextliststylepage.cpp:351
 #: ../src/richtext/richtextliststylepage.cpp:353
+#: ../src/richtext/richtextindentspage.cpp:162
+#: ../src/richtext/richtextindentspage.cpp:164
 msgid "Centre text."
 msgstr "Sredinsko poravnaj besedilo."
 
@@ -2312,25 +2312,25 @@ msgstr "Sredinsko"
 msgid "Ch&oose..."
 msgstr "&Izberi ..."
 
-#: ../src/richtext/richtextbuffer.cpp:4354
+#: ../src/richtext/richtextbuffer.cpp:4351
 msgid "Change List Style"
 msgstr "Spremeni slog seznama"
 
-#: ../src/richtext/richtextbuffer.cpp:3709
+#: ../src/richtext/richtextbuffer.cpp:3706
 msgid "Change Object Style"
 msgstr "Spremeni slog predmeta"
 
 # html/helpfrm.cpp:512
-#: ../src/richtext/richtextbuffer.cpp:3982
-#: ../src/richtext/richtextbuffer.cpp:8129
+#: ../src/richtext/richtextbuffer.cpp:3979
+#: ../src/richtext/richtextbuffer.cpp:8125
 msgid "Change Properties"
 msgstr "Spremeni lastnosti"
 
-#: ../src/richtext/richtextbuffer.cpp:3526
+#: ../src/richtext/richtextbuffer.cpp:3523
 msgid "Change Style"
 msgstr "Spremeni slog"
 
-#: ../src/common/fileconf.cpp:341
+#: ../src/common/fileconf.cpp:335
 #, c-format
 msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
 msgstr "Spremembe ne bodo shranjene v izogib prepisu obstoječe datoteke \"%s\""
@@ -2346,11 +2346,11 @@ msgid "Changing current directory to \"%s\" failed"
 msgstr "Sprememba iz trenutne mape v »%s« je spodletela."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1757
+#: ../src/propgrid/advprops.cpp:1658
 msgid "Character"
 msgstr "Znak"
 
-#: ../src/richtext/richtextstyles.cpp:1063
+#: ../src/richtext/richtextstyles.cpp:1060
 msgid "Character styles"
 msgstr "Slogi znakov"
 
@@ -2387,20 +2387,20 @@ msgstr "Označite polje za umestitev oznake med oklepaj in zaklepaj."
 msgid "Check to indicate right-to-left text layout."
 msgstr "Potrdite za spremembo smeri besedila v D-L."
 
-#: ../src/osx/carbon/fontdlg.cpp:356 ../src/osx/carbon/fontdlg.cpp:358
+#: ../src/osx/carbon/fontdlg.cpp:353 ../src/osx/carbon/fontdlg.cpp:355
 msgid "Check to make the font bold."
 msgstr "Označite za krepko pisavo."
 
-#: ../src/osx/carbon/fontdlg.cpp:363 ../src/osx/carbon/fontdlg.cpp:365
+#: ../src/osx/carbon/fontdlg.cpp:360 ../src/osx/carbon/fontdlg.cpp:362
 msgid "Check to make the font italic."
 msgstr "Označite za ležečo pisavo."
 
-#: ../src/osx/carbon/fontdlg.cpp:372 ../src/osx/carbon/fontdlg.cpp:374
+#: ../src/osx/carbon/fontdlg.cpp:369 ../src/osx/carbon/fontdlg.cpp:371
 msgid "Check to make the font underlined."
 msgstr "Označite za podčrtano pisavo."
 
-#: ../src/richtext/richtextstyledlg.cpp:289
-#: ../src/richtext/richtextstyledlg.cpp:291
+#: ../src/richtext/richtextstyledlg.cpp:285
+#: ../src/richtext/richtextstyledlg.cpp:287
 msgid "Check to restart numbering."
 msgstr "Označite za ponoven začetek oštevilčevanja."
 
@@ -2435,29 +2435,29 @@ msgid "Check to suppress hyphenation."
 msgstr "Potrdite za preprečitev deljenja besed."
 
 # msw/dialup.cpp:767
-#: ../src/msw/dialup.cpp:763
+#: ../src/msw/dialup.cpp:757
 msgid "Choose ISP to dial"
 msgstr "Izberite ponudnika spletnih storitev, ki ga želite poklicati."
 
 # generic/dirdlgg.cpp:572
-#: ../src/propgrid/props.cpp:1922
+#: ../src/propgrid/props.cpp:1904
 msgid "Choose a directory:"
 msgstr "Izberite mapo:"
 
-#: ../src/propgrid/props.cpp:1975
+#: ../src/propgrid/props.cpp:2199
 msgid "Choose a file"
 msgstr "Izberite datoteko"
 
-#: ../src/generic/colrdlgg.cpp:158 ../src/gtk/colordlg.cpp:54
+#: ../src/generic/colrdlgg.cpp:156 ../src/gtk/colordlg.cpp:49
 msgid "Choose colour"
 msgstr "Izberite barvo"
 
-#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/gtk1/fontdlg.cpp:125 ../src/generic/fontpickerg.cpp:47
+#: ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Izberite pisavo"
 
-#: ../src/common/module.cpp:74
+#: ../src/common/module.cpp:71
 #, c-format
 msgid "Circular dependency involving module \"%s\" detected."
 msgstr "Odkrita je bila krožna odvisnost, ki vključuje modul \"%s\"."
@@ -2465,7 +2465,7 @@ msgstr "Odkrita je bila krožna odvisnost, ki vključuje modul \"%s\"."
 # common/prntbase.cpp:359
 # generic/progdlgg.cpp:307
 # generic/proplist.cpp:518
-#: ../src/aui/tabmdi.cpp:108 ../src/generic/mdig.cpp:97
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
 msgid "Cl&ose"
 msgstr "&Zapri "
 
@@ -2474,23 +2474,23 @@ msgstr "&Zapri "
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 # msw/thread.cpp:519
-#: ../src/msw/ole/automtn.cpp:684
+#: ../src/msw/ole/automtn.cpp:675
 msgid "Class not registered."
 msgstr "Razred ni registriran."
 
 # generic/logg.cpp:475
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:147 ../src/common/accelcmn.cpp:72
+#: ../src/common/stockitem.cpp:144 ../src/common/accelcmn.cpp:69
 msgid "Clear"
 msgstr "Počisti"
 
 # generic/logg.cpp:475
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "Clear the log contents"
 msgstr "Izprazni vsebino dnevnika"
 
-#: ../src/richtext/richtextstyledlg.cpp:252
-#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:248
+#: ../src/richtext/richtextstyledlg.cpp:250
 msgid "Click to apply the selected style."
 msgstr "Kliknite za uveljavitev izbranega sloga."
 
@@ -2501,15 +2501,15 @@ msgstr "Kliknite za uveljavitev izbranega sloga."
 msgid "Click to browse for a symbol."
 msgstr "Kliknite za iskanje posebnega znaka."
 
-#: ../src/osx/carbon/fontdlg.cpp:403 ../src/osx/carbon/fontdlg.cpp:405
+#: ../src/osx/carbon/fontdlg.cpp:400 ../src/osx/carbon/fontdlg.cpp:402
 msgid "Click to cancel changes to the font."
 msgstr "Kliknite za preklic sprememb pisave."
 
-#: ../src/generic/fontdlgg.cpp:472 ../src/generic/fontdlgg.cpp:491
+#: ../src/generic/fontdlgg.cpp:468 ../src/generic/fontdlgg.cpp:487
 msgid "Click to cancel the font selection."
 msgstr "Kliknite za preklic izbire pisave."
 
-#: ../src/osx/carbon/fontdlg.cpp:384 ../src/osx/carbon/fontdlg.cpp:386
+#: ../src/osx/carbon/fontdlg.cpp:381 ../src/osx/carbon/fontdlg.cpp:383
 msgid "Click to change the font colour."
 msgstr "Kliknite za spremembo barve pisave."
 
@@ -2529,37 +2529,37 @@ msgid "Click to choose the font for this level."
 msgstr "Kliknite za izbor pisave za to raven."
 
 # generic/logg.cpp:477
-#: ../src/richtext/richtextstyledlg.cpp:279
-#: ../src/richtext/richtextstyledlg.cpp:281
+#: ../src/richtext/richtextstyledlg.cpp:275
+#: ../src/richtext/richtextstyledlg.cpp:277
 msgid "Click to close this window."
 msgstr "Kliknite za zaprtje tega okna."
 
-#: ../src/osx/carbon/fontdlg.cpp:410 ../src/osx/carbon/fontdlg.cpp:412
+#: ../src/osx/carbon/fontdlg.cpp:407 ../src/osx/carbon/fontdlg.cpp:409
 msgid "Click to confirm changes to the font."
 msgstr "Kliknite za potrditev sprememb pisave."
 
-#: ../src/generic/fontdlgg.cpp:477 ../src/generic/fontdlgg.cpp:479
-#: ../src/generic/fontdlgg.cpp:484 ../src/generic/fontdlgg.cpp:486
+#: ../src/generic/fontdlgg.cpp:473 ../src/generic/fontdlgg.cpp:475
+#: ../src/generic/fontdlgg.cpp:480 ../src/generic/fontdlgg.cpp:482
 msgid "Click to confirm the font selection."
 msgstr "Kliknite za potrditev izbire pisave."
 
-#: ../src/richtext/richtextstyledlg.cpp:244
-#: ../src/richtext/richtextstyledlg.cpp:246
+#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:242
 msgid "Click to create a new box style."
 msgstr "Kliknite za tvorbo novega sloga polja."
 
-#: ../src/richtext/richtextstyledlg.cpp:226
-#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:224
 msgid "Click to create a new character style."
 msgstr "Kliknite za stvaritev novega sloga znakov."
 
-#: ../src/richtext/richtextstyledlg.cpp:238
-#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:236
 msgid "Click to create a new list style."
 msgstr "Kliknite za tvorbo novega seznamskega sloga."
 
-#: ../src/richtext/richtextstyledlg.cpp:232
-#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:230
 msgid "Click to create a new paragraph style."
 msgstr "Kliknite za stvaritev novega sloga odstavka."
 
@@ -2573,8 +2573,8 @@ msgstr "Kliknite za nastavitev novega položaja tabulatorja."
 msgid "Click to delete all tab positions."
 msgstr "Kliknite za brisanje vseh položajev tabulatorja."
 
-#: ../src/richtext/richtextstyledlg.cpp:270
-#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:268
 msgid "Click to delete the selected style."
 msgstr "Kliknite za brisanje izbranega sloga."
 
@@ -2583,31 +2583,31 @@ msgstr "Kliknite za brisanje izbranega sloga."
 msgid "Click to delete the selected tab position."
 msgstr "Kliknite za brisanje izbranega položaja tabulatorja."
 
-#: ../src/richtext/richtextstyledlg.cpp:264
-#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:262
 msgid "Click to edit the selected style."
 msgstr "Kliknite za urejanje izbranega sloga."
 
-#: ../src/richtext/richtextstyledlg.cpp:258
-#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:256
 msgid "Click to rename the selected style."
 msgstr "Kliknite za preimenovanje izbranega sloga."
 
 # common/prntbase.cpp:359
 # generic/progdlgg.cpp:307
 # generic/proplist.cpp:518
-#: ../src/generic/dbgrptg.cpp:97 ../src/generic/progdlgg.cpp:759
-#: ../src/richtext/richtextstyledlg.cpp:277
-#: ../src/richtext/richtextsymboldlg.cpp:476 ../src/common/stockitem.cpp:148
-#: ../src/msw/progdlg.cpp:170 ../src/msw/progdlg.cpp:679
-#: ../src/html/helpdlg.cpp:90
+#: ../src/common/stockitem.cpp:145 ../src/generic/dbgrptg.cpp:94
+#: ../src/generic/progdlgg.cpp:781 ../src/msw/progdlg.cpp:211
+#: ../src/msw/progdlg.cpp:946 ../src/html/helpdlg.cpp:87
+#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextstyledlg.cpp:273
 msgid "Close"
 msgstr "Zapri "
 
 # common/prntbase.cpp:359
 # generic/progdlgg.cpp:307
 # generic/proplist.cpp:518
-#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:98
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
 msgid "Close All"
 msgstr "Zapri vse"
 
@@ -2616,43 +2616,43 @@ msgid "Close current document"
 msgstr "Zapri trenutni dokument"
 
 # generic/logg.cpp:477
-#: ../src/generic/logg.cpp:516
+#: ../src/generic/logg.cpp:513
 msgid "Close this window"
 msgstr "Zapri to okno"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6006
+#: ../src/generic/datavgen.cpp:6811
 msgid "Collapse"
 msgstr "Strni"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "Color"
 msgstr "Barva"
 
-#: ../src/richtext/richtextformatdlg.cpp:776
+#: ../src/richtext/richtextformatdlg.cpp:768
 msgid "Colour"
 msgstr "Barva"
 
-#: ../src/msw/colordlg.cpp:158
+#: ../src/msw/colordlg.cpp:227
 #, c-format
 msgid "Colour selection dialog failed with error %0lx."
 msgstr "Pogovorno okno izbirnika barv ni uspelo, z napako %0lx."
 
-#: ../src/osx/carbon/fontdlg.cpp:380
+#: ../src/osx/carbon/fontdlg.cpp:377
 msgid "Colour:"
 msgstr "Barva:"
 
-#: ../src/generic/datavgen.cpp:6077
+#: ../src/generic/datavgen.cpp:6882
 #, c-format
 msgid "Column %u"
 msgstr "Stolpec %u"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:114
+#: ../src/common/accelcmn.cpp:112
 msgid "Command"
 msgstr "Ukazovalka"
 
-#: ../src/common/init.cpp:196
+#: ../src/common/init.cpp:193
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
@@ -2660,24 +2660,24 @@ msgid ""
 msgstr ""
 "Argumenta ukazne vrstice %d ni mogoče pretvoriti v Unicode, zato bo prezrt."
 
-#: ../src/msw/fontdlg.cpp:120
+#: ../src/msw/fontdlg.cpp:170
 #, c-format
 msgid "Common dialog failed with error code %0lx."
 msgstr "Pogovorno okno je spodletelo z napako %0lx."
 
-#: ../src/gtk/window.cpp:4649
+#: ../src/gtk/window.cpp:5653
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
 msgstr ""
 "Sestavljanja ta sistem ne podpira, omogočite ga v svojem upravitelju oken."
 
-#: ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:1549
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "datoteka stisnjene pomoči HTML (*.chm)|*.chm|"
 
 # generic/dirdlgg.cpp:210
-#: ../src/generic/dirctrlg.cpp:444
+#: ../src/generic/dirctrlg.cpp:410
 msgid "Computer"
 msgstr "Računalnik"
 
@@ -2688,33 +2688,33 @@ msgid "Config entry name cannot start with '%c'."
 msgstr "Vstopno konfiguracijsko ime se ne more začeti s »%c«."
 
 # generic/filedlgg.cpp:1077
-#: ../src/generic/filedlgg.cpp:349 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
 msgid "Confirm"
 msgstr "Potrdi"
 
 # html/htmlwin.cpp:166
-#: ../src/html/htmlwin.cpp:566
+#: ../src/html/htmlwin.cpp:569
 msgid "Connecting..."
 msgstr "Povezovanje poteka ..."
 
 # generic/helpwxht.cpp:159
 # html/helpfrm.cpp:303
 # html/helpfrm.cpp:312
-#: ../src/html/helpwnd.cpp:475
+#: ../src/html/helpwnd.cpp:473
 msgid "Contents"
 msgstr "Vsebina"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:880
+#: ../src/propgrid/advprops.cpp:781
 msgid "ControlDark"
 msgstr "KrmilnikTemno"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:881
+#: ../src/propgrid/advprops.cpp:782
 msgid "ControlLight"
 msgstr "KrmilnikSvetlo"
 
-#: ../src/common/strconv.cpp:2262
+#: ../src/common/strconv.cpp:2208
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Pretvorba v nabor znakov »%s« ne deluje."
@@ -2722,29 +2722,33 @@ msgstr "Pretvorba v nabor znakov »%s« ne deluje."
 # generic/helpwxht.cpp:159
 # html/helpfrm.cpp:303
 # html/helpfrm.cpp:312
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "Convert"
 msgstr "Pretvori"
 
 # generic/dirdlgg.cpp:550
-#: ../src/html/htmlwin.cpp:1079
+#: ../src/html/htmlwin.cpp:1020
 #, c-format
 msgid "Copied to clipboard:\"%s\""
 msgstr "Kopirano v odložišče:\"%s\""
 
 # generic/prntdlgg.cpp:196
-#: ../src/generic/prntdlgg.cpp:247
+#: ../src/generic/prntdlgg.cpp:240
 msgid "Copies:"
 msgstr "Št. kopij"
 
-#: ../src/common/stockitem.cpp:150 ../src/stc/stc_i18n.cpp:18
+#: ../src/common/stockitem.cpp:147 ../src/stc/stc_i18n.cpp:18
 msgid "Copy"
 msgstr "Kopiraj"
 
 # generic/dirdlgg.cpp:191
-#: ../src/common/stockitem.cpp:258
+#: ../src/common/stockitem.cpp:255
 msgid "Copy selection"
 msgstr "Kopiraj izbor"
+
+#: ../src/generic/grid.cpp:5945
+msgid "Copying more than one selected block to clipboard is not supported."
+msgstr ""
 
 #: ../src/richtext/richtextborderspage.cpp:566
 #: ../src/richtext/richtextborderspage.cpp:601
@@ -2761,52 +2765,50 @@ msgstr "Polmer o&glišča:"
 #
 # common/file.cpp:580
 # common/file.cpp:583
-#: ../src/html/chm.cpp:718
+#: ../src/html/chm.cpp:711
 #, c-format
 msgid "Could not create temporary file '%s'"
 msgstr "Začasne datoteke »%s« ni mogoče ustvariti."
 
-#: ../src/html/chm.cpp:273
+#: ../src/html/chm.cpp:270
 #, c-format
 msgid "Could not extract %s into %s: %s"
 msgstr "Ni mogoče izvleči %s v %s: %s"
 
 # generic/tabg.cpp:1042
-#: ../src/generic/tabg.cpp:1048
+#: ../src/generic/tabg.cpp:1045
 msgid "Could not find tab for id"
 msgstr "Tabulatorja za id ni mogoče najti."
 
-# generic/printps.cpp:209
-# msw/printwin.cpp:252
-#: ../src/gtk/notifmsg.cpp:108
-msgid "Could not initalize libnotify."
-msgstr "libnotify ni mogoče inicializirati."
-
 # msw/dib.cpp:434
-#: ../src/html/chm.cpp:444
+#: ../src/html/chm.cpp:437
 #, c-format
 msgid "Could not locate file '%s'."
 msgstr "Datoteke »%s« ni mogoče najti."
 
+#: ../src/msw/graphicsd2d.cpp:604
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
 # generic/dirdlgg.cpp:550
-#: ../src/common/filefn.cpp:1403
+#: ../src/common/filefn.cpp:1291
 msgid "Could not set current working directory"
 msgstr "Delovne mape ni mogoče določiti."
 
 # common/prntbase.cpp:711
-#: ../src/common/prntbase.cpp:2015
+#: ../src/common/prntbase.cpp:2037
 msgid "Could not start document preview."
 msgstr "Predogleda dokumenta ni mogoče začeti."
 
 # generic/printps.cpp:209
 # msw/printwin.cpp:252
-#: ../src/generic/printps.cpp:178 ../src/msw/printwin.cpp:210
-#: ../src/gtk/print.cpp:1132
+#: ../src/generic/printps.cpp:159 ../src/msw/printwin.cpp:184
+#: ../src/gtk/print.cpp:1129
 msgid "Could not start printing."
 msgstr "Tiskanja ni mogoče pognati."
 
 # common/wincmn.cpp:784
-#: ../src/common/wincmn.cpp:2125
+#: ../src/common/wincmn.cpp:2126
 msgid "Could not transfer data to window"
 msgstr "Podatkov ni mogoče prenesti v okno."
 
@@ -2815,56 +2817,46 @@ msgstr "Podatkov ni mogoče prenesti v okno."
 # msw/imaglist.cpp:152
 # msw/imaglist.cpp:174
 # msw/imaglist.cpp:187
-#: ../src/msw/imaglist.cpp:187 ../src/msw/imaglist.cpp:224
-#: ../src/msw/imaglist.cpp:249 ../src/msw/dragimag.cpp:185
-#: ../src/msw/dragimag.cpp:220
+#: ../src/msw/imaglist.cpp:223 ../src/msw/imaglist.cpp:245
+#: ../src/msw/imaglist.cpp:270 ../src/msw/dragimag.cpp:182
+#: ../src/msw/dragimag.cpp:217
 msgid "Couldn't add an image to the image list."
 msgstr "Na seznam slik ni mogoče dodati slike."
 
 # msw/timer.cpp:96
-#: ../src/osx/glcanvas_osx.cpp:414 ../src/unix/glx11.cpp:558
-#: ../src/msw/glcanvas.cpp:616
+#: ../src/osx/glcanvas_osx.cpp:411 ../src/msw/glcanvas.cpp:631
+#: ../src/unix/glegl.cpp:315 ../src/unix/glx11.cpp:559
 msgid "Couldn't create OpenGL context"
 msgstr "Konteksta OpenGL ni mogoče ustvariti"
 
 # msw/timer.cpp:96
-#: ../src/msw/timer.cpp:134
+#: ../src/msw/timer.cpp:131
 msgid "Couldn't create a timer"
 msgstr "Časovnika ni mogoče ustvariti"
 
-# msw/timer.cpp:96
-#: ../src/osx/carbon/overlay.cpp:122
-msgid "Couldn't create the overlay window"
-msgstr "Prekrivnega okna ni mogoče ustvariti."
-
 # msw/thread.cpp:958
-#: ../src/common/translation.cpp:2024
+#: ../src/common/translation.cpp:2074
 msgid "Couldn't enumerate translations"
 msgstr "Prevodov ni mogoče oštevilčiti."
 
 # common/dynlib.cpp:309
-#: ../src/common/dynlib.cpp:120
+#: ../src/common/dynlib.cpp:110
 #, c-format
 msgid "Couldn't find symbol '%s' in a dynamic library"
 msgstr "Simbola »%s« v dinamični knjižnici ni mogoče najti."
 
 # msw/thread.cpp:578
-#: ../src/msw/thread.cpp:915
+#: ../src/msw/thread.cpp:921
 msgid "Couldn't get the current thread pointer"
 msgstr "Trenutnega kazalca niti ni mogoče dobiti"
 
-# msw/thread.cpp:578
-#: ../src/osx/carbon/overlay.cpp:129
-msgid "Couldn't init the context on the overlay window"
-msgstr "Ni mogoče inicializirati konteksta prekrivnega okna."
-
 # html/helpfrm.cpp:1174
-#: ../src/common/imaggif.cpp:244
+#: ../src/common/imaggif.cpp:241
 msgid "Couldn't initialize GIF hash table."
 msgstr "Ni mogoče inicializirati zgoščene tabele GIF."
 
 # common/imagpng.cpp:251
-#: ../src/common/imagpng.cpp:409
+#: ../src/common/imagpng.cpp:437
 msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
 msgstr ""
 "Slike PNG ni mogoče naložiti - datoteka je pokvarjena ali pa primanjkuje "
@@ -2872,128 +2864,134 @@ msgstr ""
 
 # common/filefn.cpp:1287
 # msw/dir.cpp:294
-#: ../src/unix/sound.cpp:470
+#: ../src/unix/sound.cpp:459
 #, c-format
 msgid "Couldn't load sound data from '%s'."
 msgstr "Zvočnih podatkov iz »%s« ni mogoče naložiti."
 
 # msw/timer.cpp:96
-#: ../src/msw/dirdlg.cpp:435
+#: ../src/msw/dirdlg.cpp:287
 msgid "Couldn't obtain folder name"
 msgstr "Imena mape ni mogoče pridobiti"
 
 # msw/dib.cpp:434
-#: ../src/unix/sound_sdl.cpp:229
+#: ../src/unix/sound_sdl.cpp:226
 #, c-format
 msgid "Couldn't open audio: %s"
 msgstr "Zvoka ni mogoče odpreti: %s"
 
 # msw/ole/dataobj.cpp:151
-#: ../src/msw/ole/dataobj.cpp:377
+#: ../src/msw/ole/dataobj.cpp:385
 #, c-format
 msgid "Couldn't register clipboard format '%s'."
 msgstr "Registracija oblike zapisa odložišča »%s« ni uspela."
 
 # msw/listctrl.cpp:616
-#: ../src/msw/listctrl.cpp:869
+#: ../src/msw/listctrl.cpp:933
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "Podatkov o kontrolnem elementu seznama %d ni mogoče pridobiti."
 
 # common/imagbmp.cpp:62
-#: ../src/common/imagpng.cpp:498 ../src/common/imagpng.cpp:509
-#: ../src/common/imagpng.cpp:519
+#: ../src/common/imagpng.cpp:511 ../src/common/imagpng.cpp:522
+#: ../src/common/imagpng.cpp:532
 msgid "Couldn't save PNG image."
 msgstr "Slike PNG ni mogoče shraniti."
 
 # msw/thread.cpp:958
-#: ../src/msw/thread.cpp:684
+#: ../src/msw/thread.cpp:676
 msgid "Couldn't terminate thread"
 msgstr "Niti ni mogoče končati."
 
-#: ../src/common/xtistrm.cpp:166
+#: ../src/common/xtistrm.cpp:163
 #, c-format
 msgid "Create Parameter %s not found in declared RTTI Parameters"
 msgstr ""
 "V prijavljenih spremenljivkah RTTI ustvarjenega parametra %s ni mogoče najti."
 
 # generic/dirdlgg.cpp:572
-#: ../src/generic/dirdlgg.cpp:288
+#: ../src/generic/dirdlgg.cpp:285
 msgid "Create directory"
 msgstr "Ustvari mapo"
 
 # generic/filedlgg.cpp:883
-#: ../src/generic/filedlgg.cpp:212 ../src/generic/dirdlgg.cpp:111
+#: ../src/generic/filedlgg.cpp:209 ../src/generic/dirdlgg.cpp:108
 msgid "Create new directory"
 msgstr "Ustvari novo mapo"
 
-#: ../src/xrc/xmlres.cpp:2460
+# generic/filedlgg.cpp:883
+#: ../src/common/stockitem.cpp:264
+#, fuzzy
+msgid "Create new document"
+msgstr "Ustvari novo mapo"
+
+#: ../src/xrc/xmlres.cpp:2515
 #, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Ustvarjanje %s »%s« ni uspelo."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1758
+#: ../src/propgrid/advprops.cpp:1659
 msgid "Cross"
 msgstr "Križec"
 
 # common/utilscmn.cpp:464
-#: ../src/common/accelcmn.cpp:333
+#: ../src/common/accelcmn.cpp:347
 msgid "Ctrl+"
 msgstr "Krmilka-"
 
-#: ../src/richtext/richtextctrl.cpp:332 ../src/osx/textctrl_osx.cpp:576
-#: ../src/common/stockitem.cpp:151 ../src/msw/textctrl.cpp:2507
+#: ../src/osx/textctrl_osx.cpp:594 ../src/common/stockitem.cpp:148
+#: ../src/msw/textctrl.cpp:2772 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "&Izreži"
 
 # generic/filedlgg.cpp:890
-#: ../src/generic/filectrlg.cpp:940
+#: ../src/generic/filectrlg.cpp:936
 msgid "Current directory:"
 msgstr "Trenutna mapa:"
 
 # html/helpfrm.cpp:899
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:896 ../src/propgrid/advprops.cpp:1574
-#: ../src/propgrid/advprops.cpp:1612
+#: ../src/propgrid/advprops.cpp:797 ../src/propgrid/advprops.cpp:1475
+#: ../src/propgrid/advprops.cpp:1518
 msgid "Custom"
 msgstr "Po meri"
 
 # html/helpfrm.cpp:899
-#: ../src/gtk/print.cpp:217
+#: ../src/gtk/print.cpp:211
 msgid "Custom size"
 msgstr "Velikost po meri"
 
 # html/helpfrm.cpp:899
-#: ../src/common/headerctrlcmn.cpp:60
+#: ../src/common/headerctrlcmn.cpp:58
 msgid "Customize Columns"
 msgstr "Prilagodi stolpce"
 
-#: ../src/common/stockitem.cpp:151 ../src/stc/stc_i18n.cpp:17
+#: ../src/common/stockitem.cpp:148 ../src/stc/stc_i18n.cpp:17
 msgid "Cut"
 msgstr "Izreži"
 
 # generic/dirdlgg.cpp:191
-#: ../src/common/stockitem.cpp:259
+#: ../src/common/stockitem.cpp:256
 msgid "Cut selection"
 msgstr "Prilepi izbor"
 
-#: ../src/common/fmapbase.cpp:152
+#: ../src/common/fmapbase.cpp:149
 msgid "Cyrillic (ISO-8859-5)"
 msgstr "cirilično (ISO-8859-5)"
 
 # generic/dcpsg.cpp:2547
-#: ../src/common/paper.cpp:99
+#: ../src/common/paper.cpp:96
 msgid "D sheet, 22 x 34 in"
 msgstr "D, 22 x 34 pal."
 
 # msw/dde.cpp:597
-#: ../src/msw/dde.cpp:703
+#: ../src/msw/dde.cpp:698
 msgid "DDE poke request failed"
 msgstr "Zahteva za poke DDE ni uspela."
 
 # common/imagbmp.cpp:257
-#: ../src/common/imagbmp.cpp:1169
+#: ../src/common/imagbmp.cpp:1181
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr "Glava DIB: kodiranje se ne ujema z bitno globino."
 
@@ -3017,7 +3015,7 @@ msgstr "Glava DIB: neznana bitna globina v datoteki."
 msgid "DIB Header: Unknown encoding in file."
 msgstr "Glava DIB: neznano kodiranje v datoteki."
 
-#: ../src/common/paper.cpp:121
+#: ../src/common/paper.cpp:118
 msgid "DL Envelope, 110 x 220 mm"
 msgstr "kuverta DL, 110 x 220 mm"
 
@@ -3025,55 +3023,55 @@ msgstr "kuverta DL, 110 x 220 mm"
 msgid "Dashed"
 msgstr "Črtkano"
 
-#: ../src/generic/dbgrptg.cpp:300
+#: ../src/generic/dbgrptg.cpp:301
 #, c-format
 msgid "Debug report \"%s\""
 msgstr "Poročilo o razhroščevanju \"%s\""
 
 # common/filefn.cpp:1086
-#: ../src/common/debugrpt.cpp:210
+#: ../src/common/debugrpt.cpp:211
 msgid "Debug report couldn't be created."
 msgstr "Poročila o razhroščevanju ni mogoče ustvariti."
 
-#: ../src/common/debugrpt.cpp:553
+#: ../src/common/debugrpt.cpp:554
 msgid "Debug report generation has failed."
 msgstr "Tvorba poročila o razhroščevanju ni uspela."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:84
+#: ../src/common/accelcmn.cpp:81
 msgid "Decimal"
 msgstr "Decimalno"
 
 # generic/fontdlgg.cpp:207
-#: ../src/generic/fontdlgg.cpp:323
+#: ../src/generic/fontdlgg.cpp:319
 msgid "Decorative"
 msgstr "Okrasno"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1752
+#: ../src/propgrid/advprops.cpp:1653
 msgid "Default"
 msgstr "Privzeto"
 
-#: ../src/common/fmapbase.cpp:796
+#: ../src/common/fmapbase.cpp:792
 msgid "Default encoding"
 msgstr "Privzeto kodiranje"
 
-#: ../src/dfb/fontmgr.cpp:180
+#: ../src/dfb/fontmgr.cpp:177
 msgid "Default font"
 msgstr "Privzeta pisava"
 
-#: ../src/generic/prntdlgg.cpp:510
+#: ../src/generic/prntdlgg.cpp:503
 msgid "Default printer"
 msgstr "Privzeti tiskalnik"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:51
+#: ../src/common/accelcmn.cpp:48
 msgid "Del"
 msgstr "Brisalka"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextbuffer.cpp:8221 ../src/common/stockitem.cpp:152
-#: ../src/common/accelcmn.cpp:50 ../src/stc/stc_i18n.cpp:20
+#: ../src/common/stockitem.cpp:149 ../src/common/accelcmn.cpp:47
+#: ../src/richtext/richtextbuffer.cpp:8217 ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Izbriši"
 
@@ -3084,32 +3082,32 @@ msgid "Delete A&ll"
 msgstr "Izbriši &vse"
 
 # generic/dirdlgg.cpp:191
-#: ../src/richtext/richtextbuffer.cpp:11341
+#: ../src/richtext/richtextbuffer.cpp:11340
 msgid "Delete Column"
 msgstr "Izbriši stolpec"
 
-#: ../src/richtext/richtextbuffer.cpp:11291
+#: ../src/richtext/richtextbuffer.cpp:11290
 msgid "Delete Row"
 msgstr "Izbriši vrstico"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 msgid "Delete Style"
 msgstr "Izbriši slog"
 
-#: ../src/richtext/richtextctrl.cpp:1345 ../src/richtext/richtextctrl.cpp:1584
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
 msgid "Delete Text"
 msgstr "Izbriši besedilo"
 
-#: ../src/generic/editlbox.cpp:170
+#: ../src/generic/editlbox.cpp:147
 msgid "Delete item"
 msgstr "Izbriši element"
 
 # generic/dirdlgg.cpp:191
-#: ../src/common/stockitem.cpp:260
+#: ../src/common/stockitem.cpp:257
 msgid "Delete selection"
 msgstr "Izbriši izbor"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 #, c-format
 msgid "Delete style %s?"
 msgstr "Želite izbrisati slog %s?"
@@ -3119,40 +3117,40 @@ msgstr "Želite izbrisati slog %s?"
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 # msw/iniconf.cpp:476
-#: ../src/unix/snglinst.cpp:301
+#: ../src/unix/snglinst.cpp:298
 #, c-format
 msgid "Deleted stale lock file '%s'."
 msgstr "Izbrisana stara zaklenjena datoteka »%s«."
 
-#: ../src/common/secretstore.cpp:220
-#, c-format
-msgid "Deleting password for \"%s/%s\" failed: %s."
+#: ../src/common/secretstore.cpp:234
+#, fuzzy, c-format
+msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Brisanje gesla za »%s/%s« je spodletelo: %s."
 
-#: ../src/common/module.cpp:124
+#: ../src/common/module.cpp:121
 #, c-format
 msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
 msgstr "Odvisnost \"%s\" od modula \"%s\" ne obstaja."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "Descending"
 msgstr "Padajoče"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:526 ../src/propgrid/advprops.cpp:882
+#: ../src/generic/dirctrlg.cpp:492 ../src/propgrid/advprops.cpp:783
 msgid "Desktop"
 msgstr "Namizje"
 
-#: ../src/generic/aboutdlgg.cpp:70
+#: ../src/generic/aboutdlgg.cpp:67
 msgid "Developed by "
 msgstr "Razvijalci"
 
-#: ../src/generic/aboutdlgg.cpp:176
+#: ../src/generic/aboutdlgg.cpp:173
 msgid "Developers"
 msgstr "Razvijalci"
 
 # msw/dialup.cpp:354
-#: ../src/msw/dialup.cpp:374
+#: ../src/msw/dialup.cpp:368
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -3161,11 +3159,11 @@ msgstr ""
 "(RAS) na tem računalniku ni nameščena. Prosimo, namestite jo."
 
 # generic/tipdlg.cpp:177
-#: ../src/generic/tipdlg.cpp:211
+#: ../src/generic/tipdlg.cpp:208
 msgid "Did you know..."
 msgstr "Ali ste vedeli, da ..."
 
-#: ../src/dfb/wrapdfb.cpp:63
+#: ../src/dfb/wrapdfb.cpp:60
 #, c-format
 msgid "DirectFB error %d occurred."
 msgstr "Pojavila se je napaka DirectFB %d."
@@ -3176,34 +3174,34 @@ msgid "Directories"
 msgstr "Mape"
 
 # common/filefn.cpp:1086
-#: ../src/common/filefn.cpp:1183
+#: ../src/common/filefn.cpp:1071
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Mape »%s« ni mogoče ustvariti."
 
 # common/filefn.cpp:1086
-#: ../src/common/filefn.cpp:1197
+#: ../src/common/filefn.cpp:1085
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "Mape »%s« ni mogoče izbrisati."
 
 # generic/dirdlgg.cpp:539
-#: ../src/generic/dirdlgg.cpp:204
+#: ../src/generic/dirdlgg.cpp:201
 msgid "Directory does not exist"
 msgstr "Mapa ne obstaja"
 
 # generic/dirdlgg.cpp:539
-#: ../src/generic/filectrlg.cpp:1399
+#: ../src/generic/filectrlg.cpp:1388
 msgid "Directory doesn't exist."
 msgstr "Mapa ne obstaja."
 
-#: ../src/common/docview.cpp:457
+#: ../src/common/docview.cpp:450
 msgid "Discard changes and reload the last saved version?"
 msgstr ""
 "Želite opustiti spremembe in ponovno naložiti nazadnje shranjeno različico?"
 
 # html/helpfrm.cpp:366
-#: ../src/html/helpwnd.cpp:502
+#: ../src/html/helpwnd.cpp:500
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -3212,48 +3210,48 @@ msgstr ""
 "glede na velikost črk."
 
 # html/helpfrm.cpp:535
-#: ../src/html/helpwnd.cpp:679
+#: ../src/html/helpwnd.cpp:677
 msgid "Display options dialog"
 msgstr "Pokaži pogovorno okno z možnostmi"
 
-#: ../src/html/helpwnd.cpp:322
+#: ../src/html/helpwnd.cpp:320
 msgid "Displays help as you browse the books on the left."
 msgstr "Prikaže pomoč med brskanjem po knjigah na levi."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:85
+#: ../src/common/accelcmn.cpp:83
 msgid "Divide"
 msgstr "Razdeli"
 
 # common/docview.cpp:440
-#: ../src/common/docview.cpp:533
+#: ../src/common/docview.cpp:526
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Ali želite shraniti spremembe dokumenta %s?"
 
-#: ../src/common/prntbase.cpp:542
+#: ../src/common/prntbase.cpp:537
 msgid "Document:"
 msgstr "Dokument:"
 
-#: ../src/generic/aboutdlgg.cpp:73
+#: ../src/generic/aboutdlgg.cpp:70
 msgid "Documentation by "
 msgstr "Avtor dokumentacije "
 
-#: ../src/generic/aboutdlgg.cpp:180
+#: ../src/generic/aboutdlgg.cpp:177
 msgid "Documentation writers"
 msgstr "Avtorji dokumentacije "
 
-#: ../src/common/sizer.cpp:2799
+#: ../src/common/sizer.cpp:2916
 msgid "Don't Save"
 msgstr "Ne shrani"
 
 # html/htmlwin.cpp:216
-#: ../src/html/htmlwin.cpp:633
+#: ../src/html/htmlwin.cpp:643
 msgid "Done"
 msgstr "Končano"
 
 # generic/progdlgg.cpp:313
-#: ../src/generic/progdlgg.cpp:448 ../src/msw/progdlg.cpp:407
+#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
 msgid "Done."
 msgstr "Končano."
 
@@ -3266,44 +3264,44 @@ msgstr "Pikčasto"
 msgid "Double"
 msgstr "Dvojno"
 
-#: ../src/common/paper.cpp:176
+#: ../src/common/paper.cpp:173
 msgid "Double Japanese Postcard Rotated 148 x 200 mm"
 msgstr "dvojna japonska razglednica, rotirano, 148 x 200 mm"
 
-#: ../src/common/xtixml.cpp:273
+#: ../src/common/xtixml.cpp:269
 #, c-format
 msgid "Doubly used id : %d"
 msgstr "Dvojno uporabljen id: %d"
 
 # html/htmlwin.cpp:216
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:153
-#: ../src/common/accelcmn.cpp:64
+#: ../src/common/stockitem.cpp:150 ../src/common/accelcmn.cpp:61
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Down"
 msgstr "Dol"
 
-#: ../src/richtext/richtextctrl.cpp:865
+#: ../src/richtext/richtextctrl.cpp:864
 msgid "Drag"
 msgstr "Povleci"
 
-#: ../src/common/paper.cpp:100
+#: ../src/common/paper.cpp:97
 msgid "E sheet, 34 x 44 in"
 msgstr "E, 34 x 44 pal."
 
 # common/file.cpp:285
-#: ../src/unix/fswatcher_inotify.cpp:561
+#: ../src/unix/fswatcher_inotify.cpp:558
 msgid "EOF while reading from inotify descriptor"
 msgstr "EOF pri branju iz deskriptorja inotify"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "Edit"
 msgstr "Uredi"
 
-#: ../src/generic/editlbox.cpp:168
+#: ../src/generic/editlbox.cpp:131
 msgid "Edit item"
 msgstr "Uredi element"
 
-#: ../include/wx/generic/progdlgg.h:84
+#: ../include/wx/generic/progdlgg.h:85
 msgid "Elapsed time:"
 msgstr "Pretekli čas:"
 
@@ -3376,55 +3374,55 @@ msgid "Enables the shadow spread."
 msgstr "Omogoči razširjanje sence."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:66
+#: ../src/common/accelcmn.cpp:63
 msgid "End"
 msgstr "Konec"
 
 # generic/prntdlgg.cpp:113
 # generic/prntdlgg.cpp:127
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:55
+#: ../src/common/accelcmn.cpp:52
 msgid "Enter"
 msgstr "Vnašalka"
 
-#: ../src/richtext/richtextstyledlg.cpp:934
+#: ../src/richtext/richtextstyledlg.cpp:930
 msgid "Enter a box style name"
 msgstr "Vnesite ime sloga polja"
 
-#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:602
 msgid "Enter a character style name"
 msgstr "Vnesite ime znakovnega sloga"
 
-#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:816
 msgid "Enter a list style name"
 msgstr "Vnesite ime sloga seznama"
 
-#: ../src/richtext/richtextstyledlg.cpp:893
+#: ../src/richtext/richtextstyledlg.cpp:889
 msgid "Enter a new style name"
 msgstr "Vnesite ime novega sloga"
 
-#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:650
 msgid "Enter a paragraph style name"
 msgstr "Vnesite ime sloga odstavka"
 
 # common/ffile.cpp:85
 # common/file.cpp:243
-#: ../src/generic/dbgrptg.cpp:174
+#: ../src/generic/dbgrptg.cpp:171
 #, c-format
 msgid "Enter command to open file \"%s\":"
 msgstr "Vnesite ukaz za odprtje datoteke \"%s\":"
 
 # generic/helphtml.cpp:320
-#: ../src/generic/helpext.cpp:459
+#: ../src/generic/helpext.cpp:457
 msgid "Entries found"
 msgstr "Najdeni vnosi"
 
-#: ../src/common/paper.cpp:142
+#: ../src/common/paper.cpp:139
 msgid "Envelope Invite 220 x 220 mm"
 msgstr "kuverta Invite, 220 x 220 mm"
 
 # common/config.cpp:349
-#: ../src/common/config.cpp:469
+#: ../src/common/config.cpp:465
 #, c-format
 msgid ""
 "Environment variables expansion failed: missing '%c' at position %u in '%s'."
@@ -3442,13 +3440,13 @@ msgstr ""
 # generic/filedlgg.cpp:1043
 # generic/filedlgg.cpp:1092
 # generic/helpxlp.cpp:241
-#: ../src/generic/filedlgg.cpp:357 ../src/generic/dirctrlg.cpp:570
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/dirctrlg.cpp:599
-#: ../src/generic/dirdlgg.cpp:323 ../src/generic/filectrlg.cpp:642
-#: ../src/generic/filectrlg.cpp:756 ../src/generic/filectrlg.cpp:770
-#: ../src/generic/filectrlg.cpp:786 ../src/generic/filectrlg.cpp:1368
-#: ../src/generic/filectrlg.cpp:1399 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/gtk1/fontdlg.cpp:74 ../src/generic/dirctrlg.cpp:536
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/dirctrlg.cpp:565
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1357 ../src/generic/filectrlg.cpp:1388
+#: ../src/generic/filedlgg.cpp:354 ../src/generic/dirdlgg.cpp:320
+#: ../src/gtk/filedlg.cpp:74
 msgid "Error"
 msgstr "Napaka"
 
@@ -3458,51 +3456,63 @@ msgid "Error closing epoll descriptor"
 msgstr "Napaka pri zapiranju deskriptorja epoll"
 
 # generic/dirdlgg.cpp:552
-#: ../src/unix/fswatcher_kqueue.cpp:114
+#: ../src/unix/fswatcher_kqueue.cpp:131
 msgid "Error closing kqueue instance"
 msgstr "Napaka pri zapiranju instance kqueue"
 
 # common/ffile.cpp:182
-#: ../src/common/filefn.cpp:1049
+#: ../src/common/filefn.cpp:938
 #, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Napaka pri kopiranju datoteke »%s« v »%s«."
 
 # generic/dirdlgg.cpp:552
-#: ../src/generic/dirdlgg.cpp:222
+#: ../src/generic/dirdlgg.cpp:219
 msgid "Error creating directory"
 msgstr "Napaka pri ustvarjanju mape"
 
-#: ../src/common/imagbmp.cpp:1181
+#: ../src/common/imagbmp.cpp:1193
 msgid "Error in reading image DIB."
 msgstr "Error in reading image DIB."
 
-#: ../src/propgrid/propgrid.cpp:6696
+#: ../src/propgrid/propgrid.cpp:6665
 #, c-format
 msgid "Error in resource: %s"
 msgstr "Napaka v viru: %s"
 
 # generic/dirdlgg.cpp:552
-#: ../src/common/fileconf.cpp:422
+#: ../src/common/fileconf.cpp:421
 msgid "Error reading config options."
 msgstr "Napaka pri branju konfiguracijskih možnosti."
+
+#: ../src/msw/webview_ie.cpp:1057 ../src/msw/webview_edge.cpp:850
+#: ../src/gtk/webview_webkit2.cpp:1262 ../src/osx/webview_webkit.mm:383
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
 
 # generic/dirdlgg.cpp:552
 #: ../src/common/fileconf.cpp:1029
 msgid "Error saving user configuration data."
 msgstr "Napaka pri shranjevanju podatkov nastavitev uporabnika."
 
-#: ../src/gtk/print.cpp:722
+#: ../src/gtk/print.cpp:720
 msgid "Error while printing: "
 msgstr "Napaka pri tiskanju: "
 
 # common/log.cpp:362
-#: ../src/common/log.cpp:219
+#: ../src/common/log.cpp:237
 msgid "Error: "
 msgstr "Napaka:"
 
+# common/log.cpp:362
+#: ../src/common/webrequest.cpp:98
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Napaka:"
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:69
+#: ../src/common/accelcmn.cpp:66
 msgid "Esc"
 msgstr "Ubežnica"
 
@@ -3510,71 +3520,77 @@ msgstr "Ubežnica"
 # generic/prntdlgg.cpp:441
 # generic/prntdlgg.cpp:637
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:70
+#: ../src/common/accelcmn.cpp:67
 msgid "Escape"
 msgstr "Ubežnica"
 
-#: ../src/common/fmapbase.cpp:150
+#: ../src/common/fmapbase.cpp:147
 msgid "Esperanto (ISO-8859-3)"
 msgstr "esperantsko (ISO-8859-3)"
 
-#: ../include/wx/generic/progdlgg.h:85
+#: ../include/wx/generic/progdlgg.h:86
 msgid "Estimated time:"
 msgstr "Predviden čas:"
 
-#: ../src/generic/dbgrptg.cpp:234
+#: ../src/generic/dbgrptg.cpp:231
 msgid "Executable files (*.exe)|*.exe|"
 msgstr "Izvršljive datoteke (*.exe)|*.exe|"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:155 ../src/common/accelcmn.cpp:78
+#: ../src/common/stockitem.cpp:152 ../src/common/accelcmn.cpp:75
 msgid "Execute"
 msgstr "Izvedi"
 
 # msw/utilsexc.cpp:585
-#: ../src/msw/utilsexc.cpp:876
+#: ../src/msw/utilsexc.cpp:873
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Izvajanje ukaza »%s« ni uspelo."
 
-#: ../src/common/paper.cpp:105
+#: ../src/common/paper.cpp:102
 msgid "Executive, 7 1/4 x 10 1/2 in"
 msgstr "Executive, 7 1/4 x 10 1/2 pal."
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6009
+#: ../src/generic/datavgen.cpp:6814
 msgid "Expand"
 msgstr "Razpostri"
 
-#: ../src/msw/registry.cpp:1240
+#: ../src/msw/registry.cpp:1228
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
 msgstr ""
 "Izvoz registrskega ključa: datoteka \"%s\" že obstaja in ne bo prepisana."
 
-#: ../src/common/fmapbase.cpp:195
+#: ../src/common/fmapbase.cpp:192
 msgid "Extended Unix Codepage for Japanese (EUC-JP)"
 msgstr "razširjena kodna stran Unix za Japonščino (EUC-JP)"
 
-#: ../src/html/chm.cpp:725
+#: ../src/html/chm.cpp:718
 #, c-format
 msgid "Extraction of '%s' into '%s' failed."
 msgstr "Iztis »%s« v »%s« ni uspel."
 
-#: ../src/common/accelcmn.cpp:249 ../src/common/accelcmn.cpp:344
+#: ../src/common/accelcmn.cpp:259 ../src/common/accelcmn.cpp:358
 msgid "F"
 msgstr "F"
 
 # generic/filedlgg.cpp:610
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:672
+#: ../src/propgrid/advprops.cpp:582
 msgid "Face Name"
 msgstr "Ime pisave"
 
-#: ../src/unix/snglinst.cpp:269
+#: ../src/unix/snglinst.cpp:266
 msgid "Failed to access lock file."
 msgstr "Neuspešen dostop do zaklenjene datoteke."
+
+# common/ffile.cpp:182
+#: ../src/gtk/font.cpp:572
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Dokumenta iz datoteke \"%s\" ni mogoče prebrati."
 
 # common/file.cpp:304
 #: ../src/unix/epolldispatcher.cpp:116
@@ -3582,24 +3598,38 @@ msgstr "Neuspešen dostop do zaklenjene datoteke."
 msgid "Failed to add descriptor %d to epoll descriptor %d"
 msgstr "Deskriptorja %d ni mogoče dodati deskriptorju epoll %d"
 
-#: ../src/msw/dib.cpp:489
+#: ../src/msw/dib.cpp:535
 #, c-format
 msgid "Failed to allocate %luKb of memory for bitmap data."
 msgstr "Za podatke bitne slike alokacija %lu Kb pomnilnika ni uspela."
 
 # common/imagbmp.cpp:266
 # common/imagbmp.cpp:278
-#: ../src/common/glcmn.cpp:115
+#: ../src/common/glcmn.cpp:112
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Barve za OpenGL ni mogoče dodeliti."
 
+# common/imagbmp.cpp:266
+# common/imagbmp.cpp:278
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Barve za OpenGL ni mogoče dodeliti."
+
+# common/imagbmp.cpp:266
+# common/imagbmp.cpp:278
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Barve za OpenGL ni mogoče dodeliti."
+
 # common/ffile.cpp:182
-#: ../src/unix/displayx11.cpp:236
+#: ../include/wx/unix/private/displayx11.h:89
 msgid "Failed to change video mode"
 msgstr "Sprememba video načina ni uspela."
 
 # common/ffile.cpp:182
-#: ../src/common/image.cpp:3277
+#: ../src/common/image.cpp:3396
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Neuspešno preverjanje zapisa slikovne datoteke \"%s\"."
@@ -3609,95 +3639,89 @@ msgstr "Neuspešno preverjanje zapisa slikovne datoteke \"%s\"."
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 # msw/registry.cpp:399
-#: ../src/common/debugrpt.cpp:239
+#: ../src/common/debugrpt.cpp:240
 #, c-format
 msgid "Failed to clean up debug report directory \"%s\""
 msgstr "Mape poročila o razhroščevanju »%s« ni mogoče počistiti."
 
 # common/ffile.cpp:182
-#: ../src/common/filename.cpp:192
+#: ../src/common/filename.cpp:189
 msgid "Failed to close file handle"
 msgstr "Neuspešno zapiranje datotečne ročice."
 
 # common/ffile.cpp:182
-#: ../src/unix/snglinst.cpp:340
+#: ../src/unix/snglinst.cpp:337
 #, c-format
 msgid "Failed to close lock file '%s'"
 msgstr "Zapiranje zaklenjene datoteke »%s« ni uspelo."
 
 # msw/clipbrd.cpp:122
-#: ../src/msw/clipbrd.cpp:112
+#: ../src/msw/clipbrd.cpp:110
 msgid "Failed to close the clipboard."
 msgstr "Zaprtje odložišča ni uspelo."
 
 # msw/clipbrd.cpp:122
-#: ../src/x11/utils.cpp:208
+#: ../src/x11/utils.cpp:170
 #, c-format
 msgid "Failed to close the display \"%s\""
 msgstr "Zaprtje prikaza »%s« ni uspelo."
 
 # msw/dialup.cpp:801
-#: ../src/msw/dialup.cpp:797
+#: ../src/msw/dialup.cpp:791
 msgid "Failed to connect: missing username/password."
 msgstr "Neuspela povezava: manjkajoče uporabniško ime/geslo."
 
 # msw/dialup.cpp:747
-#: ../src/msw/dialup.cpp:743
+#: ../src/msw/dialup.cpp:737
 msgid "Failed to connect: no ISP to dial."
 msgstr "Neuspela povezava: ni ISP za klicanje"
 
-# common/ffile.cpp:182
-#: ../src/common/textfile.cpp:203
-#, c-format
-msgid "Failed to convert file \"%s\" to Unicode."
-msgstr "Neuspešna pretvorba datoteke \"%s\" v Unicode."
-
 # msw/clipbrd.cpp:102
-#: ../src/generic/logg.cpp:956
+#: ../src/generic/logg.cpp:953
 msgid "Failed to copy dialog contents to the clipboard."
 msgstr "Vsebine pogovornega okna ni mogoče kopirati na odložišče."
 
 # msw/registry.cpp:594
-#: ../src/msw/registry.cpp:692
+#: ../src/msw/registry.cpp:681
 #, c-format
 msgid "Failed to copy registry value '%s'"
 msgstr "Neuspelo kopiranje vrednosti registra »%s«"
 
 # msw/registry.cpp:603
-#: ../src/msw/registry.cpp:701
+#: ../src/msw/registry.cpp:690
 #, c-format
 msgid "Failed to copy the contents of registry key '%s' to '%s'."
 msgstr "Kopiranje vsebine registrskega ključa »%s« v »%s« ni uspelo."
 
 # common/ffile.cpp:182
-#: ../src/common/filefn.cpp:1015
+#: ../src/common/filefn.cpp:904
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Datoteke »%s« ni mogoče kopirati v »%s«"
 
 # common/ffile.cpp:182
-#: ../src/msw/registry.cpp:679
+#: ../src/msw/registry.cpp:668
 #, c-format
 msgid "Failed to copy the registry subkey '%s' to '%s'."
 msgstr "Registrskega podključa '%s' ni mogoče kopirati v '%s'."
 
 # msw/dde.cpp:934
-#: ../src/msw/dde.cpp:1070
+#: ../src/msw/dde.cpp:1134
 msgid "Failed to create DDE string"
 msgstr "Niza DDE ni mogoče ustvariti."
 
 # msw/mdi.cpp:428
-#: ../src/msw/mdi.cpp:616
+#: ../src/msw/mdi.cpp:621
 msgid "Failed to create MDI parent frame."
 msgstr "Ustvarjanje starševskega okvira MDI ni uspelo."
 
 # generic/dirdlgg.cpp:550
-#: ../src/common/filename.cpp:1027
+#: ../src/common/filename.cpp:1024
 msgid "Failed to create a temporary file name"
 msgstr "Začasnega imena datoteke ni mogoče ustvariti."
 
 # generic/dirdlgg.cpp:550
-#: ../src/msw/utilsexc.cpp:228
+#: ../src/msw/utilsexc.cpp:225
 msgid "Failed to create an anonymous pipe"
 msgstr "Brezimne cevi ni mogoče ustvariti."
 
@@ -3706,20 +3730,20 @@ msgstr "Brezimne cevi ni mogoče ustvariti."
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 # msw/registry.cpp:399
-#: ../src/msw/ole/automtn.cpp:522
+#: ../src/msw/ole/automtn.cpp:513
 #, c-format
 msgid "Failed to create an instance of \"%s\""
 msgstr "Ustvarjanje instance %s ni uspelo."
 
 # msw/dde.cpp:401
-#: ../src/msw/dde.cpp:437
+#: ../src/msw/dde.cpp:432
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "Povezava s strežnikom »%s« na temo »%s« ni uspela."
 
 # common/imagbmp.cpp:266
 # common/imagbmp.cpp:278
-#: ../src/msw/cursor.cpp:204
+#: ../src/msw/cursor.cpp:195
 msgid "Failed to create cursor."
 msgstr "Kazalke ni mogoče ustvariti."
 
@@ -3728,13 +3752,13 @@ msgstr "Kazalke ni mogoče ustvariti."
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 # msw/registry.cpp:399
-#: ../src/common/debugrpt.cpp:209
+#: ../src/common/debugrpt.cpp:210
 #, c-format
 msgid "Failed to create directory \"%s\""
 msgstr "Mape »%s« ni mogoče ustvariti."
 
 # generic/dirdlgg.cpp:551
-#: ../src/generic/dirdlgg.cpp:220
+#: ../src/generic/dirdlgg.cpp:217
 #, c-format
 msgid ""
 "Failed to create directory '%s'\n"
@@ -3749,17 +3773,23 @@ msgstr ""
 msgid "Failed to create epoll descriptor"
 msgstr "Deskriptorja epoll ni mogoče ustvariti"
 
+# common/fileconf.cpp:800
+#: ../src/gtk/font.cpp:562
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "Uporabniške konfiguracijske datoteke ni mogoče posodobiti."
+
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 # msw/registry.cpp:399
-#: ../src/msw/mimetype.cpp:238
+#: ../src/msw/mimetype.cpp:235
 #, c-format
 msgid "Failed to create registry entry for '%s' files."
 msgstr "Ključa registra za datoteke '%s' ni mogoče uspešno ustvariti."
 
-#: ../src/msw/fdrepdlg.cpp:409
+#: ../src/msw/fdrepdlg.cpp:408
 #, c-format
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr ""
@@ -3767,18 +3797,18 @@ msgstr ""
 "(koda napake %d)"
 
 # msw/statbr95.cpp:149
-#: ../src/unix/wakeuppipe.cpp:52
+#: ../src/unix/wakeuppipe.cpp:49
 msgid "Failed to create wake up pipe used by event loop."
 msgstr "Cevi z bujenjem, ki jo uporablja zanka dogodka, ni mogoče ustvariti."
 
 # html/winpars.cpp:364
-#: ../src/html/winpars.cpp:730
+#: ../src/html/winpars.cpp:727
 #, c-format
 msgid "Failed to display HTML document in %s encoding"
 msgstr "Dokumenta HTML, kodiranega v %s, ni mogoče prikazati."
 
 # msw/clipbrd.cpp:134
-#: ../src/msw/clipbrd.cpp:124
+#: ../src/msw/clipbrd.cpp:122
 msgid "Failed to empty the clipboard."
 msgstr "Izpraznitev odložišča ni uspela."
 
@@ -3787,44 +3817,48 @@ msgstr "Izpraznitev odložišča ni uspela."
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 # msw/registry.cpp:399
-#: ../src/unix/displayx11.cpp:212
+#: ../include/wx/unix/private/displayx11.h:65
 msgid "Failed to enumerate video modes"
 msgstr "Preštevanje video-načinov ni uspelo."
 
 # msw/dde.cpp:616
-#: ../src/msw/dde.cpp:722
+#: ../src/msw/dde.cpp:717
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "Vzpostavitev usklajevalne zanke s strežnikom DDE ni uspela."
 
 # msw/dialup.cpp:639
-#: ../src/msw/dialup.cpp:629 ../src/msw/dialup.cpp:863
+#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Klicna povezava ni bila uspešno vzpostavljena: %s"
 
 # common/ffile.cpp:182
-#: ../src/unix/utilsunx.cpp:611
+#: ../src/unix/utilsunx.cpp:613
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "'%s' ni mogoče izvesti\n"
 
-#: ../src/common/debugrpt.cpp:720
+#: ../src/common/debugrpt.cpp:730
 msgid "Failed to execute curl, please install it in PATH."
 msgstr "curl ni bilo mogoče izvesti, prosimo, namestite ga v poti PATH."
 
 # generic/dirdlgg.cpp:550
-#: ../src/msw/ole/automtn.cpp:505
+#: ../src/msw/ole/automtn.cpp:496
 #, c-format
 msgid "Failed to find CLSID of \"%s\""
 msgstr "CLSID za »%s« ni mogoče najti."
 
-#: ../src/common/regex.cpp:431 ../src/common/regex.cpp:479
+#: ../src/common/regex.cpp:428 ../src/common/regex.cpp:476
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "Ujemanje v regularnem izrazu neuspešno: %s"
 
+#: ../src/msw/webview_ie.cpp:978
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
 # msw/dialup.cpp:699
-#: ../src/msw/dialup.cpp:695
+#: ../src/msw/dialup.cpp:689
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Neuspešno pridobivanje imen ISP: %s"
@@ -3834,61 +3868,71 @@ msgstr "Neuspešno pridobivanje imen ISP: %s"
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 # msw/registry.cpp:399
-#: ../src/msw/ole/automtn.cpp:574
+#: ../src/msw/ole/automtn.cpp:565
 #, c-format
 msgid "Failed to get OLE automation interface for \"%s\""
 msgstr "Vmesnika avtomatizacije OLE za »%s« ni mogoče pridobiti."
 
 # msw/clipbrd.cpp:623
-#: ../src/msw/clipbrd.cpp:711
+#: ../src/msw/clipbrd.cpp:731
 msgid "Failed to get data from the clipboard"
 msgstr "Podatkov z odložišča ni mogoče pridobiti."
 
 # common/timercmn.cpp:196
-#: ../src/common/time.cpp:223
+#: ../src/common/time.cpp:216
 msgid "Failed to get the local system time"
 msgstr "Lokalnega sistemskega časa ni mogoče razbrati."
 
 # generic/dirdlgg.cpp:550
-#: ../src/common/filefn.cpp:1345
+#: ../src/common/filefn.cpp:1233
 msgid "Failed to get the working directory"
 msgstr "Delovne mape ni mogoče pridobiti."
 
-#: ../src/univ/theme.cpp:114
+#: ../src/univ/theme.cpp:111
 msgid "Failed to initialize GUI: no built-in themes found."
 msgstr "Inicializacija GUI ni uspela: vgrajenih tem ni mogoče najti."
 
-#: ../src/msw/helpchm.cpp:63
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:60
 msgid "Failed to initialize MS HTML Help."
 msgstr "Pomoč MS HTML neuspešno inicializirana."
 
-#: ../src/msw/glcanvas.cpp:1381
+#: ../src/msw/glcanvas.cpp:1391
 msgid "Failed to initialize OpenGL"
 msgstr "OpenGl neuspešno inicializiran."
 
 # msw/dialup.cpp:933
-#: ../src/msw/dialup.cpp:858
+#: ../src/msw/dialup.cpp:852
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Inicializacija klicne povezave ni uspela: %s"
 
 # generic/dirdlgg.cpp:550
-#: ../src/gtk/textctrl.cpp:1128
+#: ../src/gtk/textctrl.cpp:1209
 msgid "Failed to insert text in the control."
 msgstr "V kontrolnik ni bilo mogoče vstaviti besedila."
 
 # common/ffile.cpp:182
-#: ../src/unix/snglinst.cpp:241
+#: ../src/unix/snglinst.cpp:238
 #, c-format
 msgid "Failed to inspect the lock file '%s'"
 msgstr "Zaklenjene datoteke »%s« ni mogoče pregledati."
 
 # common/ffile.cpp:182
-#: ../src/unix/appunix.cpp:182
+#: ../src/unix/appunix.cpp:179
 msgid "Failed to install signal handler"
 msgstr "Nameščanje signalne ročice ni bilo uspešno."
 
-#: ../src/unix/threadpsx.cpp:1167
+#: ../src/unix/threadpsx.cpp:1216
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -3896,84 +3940,84 @@ msgstr ""
 "Pridružitev k niti ni uspela, odkrita možna izguba spomina - prosimo, "
 "ponovno zaženite program"
 
-#: ../src/msw/utils.cpp:629
+#: ../src/msw/utils.cpp:619
 #, c-format
 msgid "Failed to kill process %d"
 msgstr "Neuspešen uboj procesa %d"
 
 # common/ffile.cpp:182
-#: ../src/common/image.cpp:2500
+#: ../src/common/image.cpp:2595
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Bitne slike \"%s\" iz virov ni mogoče naložiti."
 
 # common/ffile.cpp:182
-#: ../src/common/image.cpp:2509
+#: ../src/common/image.cpp:2604
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Ikone \"%s\" iz virov ni mogoče naložiti."
 
 # common/ffile.cpp:182
-#: ../src/common/iconbndl.cpp:225
+#: ../src/common/iconbndl.cpp:224
 #, c-format
 msgid "Failed to load icons from resource '%s'."
 msgstr "Ikon iz vira »%s« ni mogoče naložiti."
 
 # common/ffile.cpp:182
-#: ../src/common/iconbndl.cpp:200
+#: ../src/common/iconbndl.cpp:198
 #, c-format
 msgid "Failed to load image %%d from file '%s'."
 msgstr "Slike %%d iz datoteke '%s' ni mogoče naložiti."
 
 # common/ffile.cpp:182
-#: ../src/common/iconbndl.cpp:208
+#: ../src/common/iconbndl.cpp:206
 #, c-format
 msgid "Failed to load image %d from stream."
 msgstr "Slike %d ni mogoče naložiti iz toka."
 
 # common/ffile.cpp:182
-#: ../src/common/image.cpp:2587 ../src/common/image.cpp:2606
+#: ../src/common/image.cpp:2682 ../src/common/image.cpp:2701
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Slike iz datoteke \"%s\" ni mogoče naložiti."
 
 # common/ffile.cpp:182
-#: ../src/msw/enhmeta.cpp:97
+#: ../src/msw/enhmeta.cpp:94
 #, c-format
 msgid "Failed to load metafile from file \"%s\"."
 msgstr "Meta-datoteke iz datoteke \"%s\" ni mogoče naložiti."
 
 # generic/dirdlgg.cpp:550
-#: ../src/msw/volume.cpp:327
+#: ../src/msw/volume.cpp:335
 msgid "Failed to load mpr.dll."
 msgstr "Nalaganje mpr.dll ni uspelo."
 
 # common/ffile.cpp:182
-#: ../src/msw/utils.cpp:953
+#: ../src/msw/utils.cpp:943
 #, c-format
 msgid "Failed to load resource \"%s\"."
 msgstr "Vira \"%s\" ni mogoče naložiti."
 
 # common/dynlib.cpp:239
-#: ../src/common/dynlib.cpp:92
+#: ../src/common/dynlib.cpp:86
 #, c-format
 msgid "Failed to load shared library '%s'"
 msgstr "Deljene knjižnice »%s« ni mogoče odpreti."
 
 # common/ffile.cpp:182
-#: ../src/osx/core/sound.cpp:145
+#: ../src/osx/core/sound.cpp:143
 #, c-format
 msgid "Failed to load sound from \"%s\" (error %d)."
 msgstr "Vira iz »%s« ni mogoče naložiti (napaka %d)."
 
 # common/ffile.cpp:182
-#: ../src/msw/utils.cpp:960
+#: ../src/msw/utils.cpp:950
 #, c-format
 msgid "Failed to lock resource \"%s\"."
 msgstr "Vira \"%s\" ni mogoče zakleniti."
 
 # common/ffile.cpp:182
-#: ../src/unix/snglinst.cpp:198
+#: ../src/unix/snglinst.cpp:195
 #, c-format
 msgid "Failed to lock the lock file '%s'"
 msgstr "Zaklenjene datoteke »%s« ni mogoče zakleniti."
@@ -3984,37 +4028,43 @@ msgid "Failed to modify descriptor %d in epoll descriptor %d"
 msgstr "Deskriptorja %d v deskriptorju epoll %d ni mogoče spremeniti"
 
 # common/ffile.cpp:182
-#: ../src/common/filename.cpp:2575
+#: ../src/common/filename.cpp:2658
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Sprememba datotečnih časov za »%s« ni uspela."
 
-#: ../src/common/selectdispatcher.cpp:258
+#: ../src/common/selectdispatcher.cpp:255
 msgid "Failed to monitor I/O channels"
 msgstr "V/I kanalov ni bilo mogoče nadzirati"
 
 # generic/dirdlgg.cpp:550
-#: ../src/common/filename.cpp:175
+#: ../src/common/filename.cpp:172
 #, c-format
 msgid "Failed to open '%s' for reading"
 msgstr "'%s' ni mogoče odpreti za branje"
 
 # generic/dirdlgg.cpp:550
-#: ../src/common/filename.cpp:180
+#: ../src/common/filename.cpp:177
 #, c-format
 msgid "Failed to open '%s' for writing"
 msgstr "'%s' ni mogoče odpreti za pisanje"
 
 # generic/dirdlgg.cpp:550
-#: ../src/html/chm.cpp:141
+#: ../src/html/chm.cpp:138
 #, c-format
 msgid "Failed to open CHM archive '%s'."
 msgstr "Arhiva CHM '%s' ni mogoče odpreti."
 
 # generic/dirdlgg.cpp:550
-#: ../src/common/utilscmn.cpp:1126
+#: ../src/common/utilscmn.cpp:1140
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
+msgstr "URL-ja \"%s\" ni mogoče odpreti v privzetem brskalniku."
+
+# generic/dirdlgg.cpp:550
+#: ../src/common/hyperlnkcmn.cpp:133
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "URL-ja \"%s\" ni mogoče odpreti v privzetem brskalniku."
 
 # generic/dirdlgg.cpp:550
@@ -4024,7 +4074,7 @@ msgid "Failed to open directory \"%s\" for monitoring."
 msgstr "Mape \"%s\" ni mogoče odpreti za spremljanje."
 
 # generic/dirdlgg.cpp:550
-#: ../src/x11/utils.cpp:227
+#: ../src/x11/utils.cpp:189
 #, c-format
 msgid "Failed to open display \"%s\"."
 msgstr "Zaslona \"%s\" ni mogoče odpreti."
@@ -4035,72 +4085,84 @@ msgstr "Zaslona \"%s\" ni mogoče odpreti."
 #
 # common/file.cpp:580
 # common/file.cpp:583
-#: ../src/common/filename.cpp:1062
+#: ../src/common/filename.cpp:1059
 msgid "Failed to open temporary file."
 msgstr "Začasne datoteke ni mogoče odpreti."
 
 # msw/clipbrd.cpp:102
-#: ../src/msw/clipbrd.cpp:91
+#: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Odložišča ni mogoče odpreti."
 
 # html/helpdata.cpp:353
-#: ../src/common/translation.cpp:1184
+#: ../src/common/translation.cpp:1226
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Množinskih oblik ni mogoče razčleniti: »%s«"
 
 # generic/dirdlgg.cpp:550
-#: ../src/unix/mediactrl.cpp:1214
+#: ../src/unix/mediactrl.cpp:1239
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Predvajanja »%s« ni mogoče pripraviti."
 
 # msw/clipbrd.cpp:539
-#: ../src/msw/clipbrd.cpp:600
+#: ../src/msw/clipbrd.cpp:610
 msgid "Failed to put data on the clipboard"
 msgstr "Podatkov ni mogoče postaviti na odložišče."
 
-#: ../src/unix/snglinst.cpp:278
+#: ../src/unix/snglinst.cpp:275
 msgid "Failed to read PID from lock file."
 msgstr "Branje PID iz zaklenjene datoteke ni uspelo."
 
 # generic/dirdlgg.cpp:552
-#: ../src/common/fileconf.cpp:433
+#: ../src/common/fileconf.cpp:432
 msgid "Failed to read config options."
 msgstr "Napaka pri branju konfiguracijskih možnosti."
 
 # common/ffile.cpp:182
-#: ../src/common/docview.cpp:681
+#: ../src/common/docview.cpp:676
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Dokumenta iz datoteke \"%s\" ni mogoče prebrati."
 
-#: ../src/dfb/evtloop.cpp:98
+#: ../src/dfb/evtloop.cpp:99
 msgid "Failed to read event from DirectFB pipe"
 msgstr "Branje dogodka iz cevi DirectFB je spodletelo."
 
-#: ../src/unix/wakeuppipe.cpp:120
+#: ../src/unix/wakeuppipe.cpp:117
 msgid "Failed to read from wake-up pipe"
 msgstr "Branje iz cevi z bujenjem ni uspelo."
 
-#: ../src/unix/utilsunx.cpp:679
+# common/ffile.cpp:182
+#: ../src/common/textfile.cpp:96
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Dokumenta iz datoteke \"%s\" ni mogoče prebrati."
+
+#: ../src/unix/utilsunx.cpp:681
 msgid "Failed to redirect child process input/output"
 msgstr "Preusmeritev vhoda/izhoda podrejenega procesa ni uspela."
 
 # generic/dirdlgg.cpp:550
-#: ../src/msw/utilsexc.cpp:701
+#: ../src/msw/utilsexc.cpp:698
 msgid "Failed to redirect the child process IO"
 msgstr "Preusmeritev otroških procesov IO ni uspela."
 
 # msw/dde.cpp:285
-#: ../src/msw/dde.cpp:288
+#: ../src/msw/dde.cpp:283
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Registracija strežnika DDE »%s« ni uspela."
 
+# common/fileconf.cpp:800
+#: ../src/gtk/font.cpp:580
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "Uporabniške konfiguracijske datoteke ni mogoče posodobiti."
+
 # common/fontmap.cpp:552
-#: ../src/common/fontmap.cpp:245
+#: ../src/common/fontmap.cpp:242
 #, c-format
 msgid "Failed to remember the encoding for the charset '%s'."
 msgstr "Kodiranja za nabor znakov '%s' ni bilo mogoče zapomniti."
@@ -4111,7 +4173,7 @@ msgstr "Kodiranja za nabor znakov '%s' ni bilo mogoče zapomniti."
 #
 # common/file.cpp:552
 # common/file.cpp:562
-#: ../src/common/debugrpt.cpp:227
+#: ../src/common/debugrpt.cpp:228
 #, c-format
 msgid "Failed to remove debug report file \"%s\""
 msgstr "Datoteke poročila o razhroščevanju »%s« ni mogoče odstraniti."
@@ -4122,7 +4184,7 @@ msgstr "Datoteke poročila o razhroščevanju »%s« ni mogoče odstraniti."
 #
 # common/file.cpp:552
 # common/file.cpp:562
-#: ../src/unix/snglinst.cpp:328
+#: ../src/unix/snglinst.cpp:325
 #, c-format
 msgid "Failed to remove lock file '%s'"
 msgstr "Zaklenjene datoteke »%s« ni mogoče odstraniti."
@@ -4133,18 +4195,18 @@ msgstr "Zaklenjene datoteke »%s« ni mogoče odstraniti."
 #
 # common/file.cpp:580
 # common/file.cpp:583
-#: ../src/unix/snglinst.cpp:288
+#: ../src/unix/snglinst.cpp:285
 #, c-format
 msgid "Failed to remove stale lock file '%s'."
 msgstr "Odstranjevanje stare zaklenjene datoteke '%s' ni uspelo."
 
 # msw/registry.cpp:440
-#: ../src/msw/registry.cpp:529
+#: ../src/msw/registry.cpp:518
 #, c-format
 msgid "Failed to rename registry value '%s' to '%s'."
 msgstr "Preimenovanje vrednosti registra iz '%s' v '%s' ni uspelo."
 
-#: ../src/common/filefn.cpp:1122
+#: ../src/common/filefn.cpp:1011
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -4153,136 +4215,145 @@ msgstr ""
 "Datoteke''%s' ni mogoče preimenovati v '%s', ker ciljna datoteka že obstaja."
 
 # msw/registry.cpp:540
-#: ../src/msw/registry.cpp:634
+#: ../src/msw/registry.cpp:623
 #, c-format
 msgid "Failed to rename the registry key '%s' to '%s'."
 msgstr "Preimenovanje ključa registra '%s' v '%s' ni uspelo."
 
+#: ../src/msw/webview_ie.cpp:995
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
 # generic/dirdlgg.cpp:550
-#: ../src/common/filename.cpp:2671
+#: ../src/common/filename.cpp:2754
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Neuspešno pridobivanje datotečnih časov za '%s'"
 
 # msw/dialup.cpp:463
-#: ../src/msw/dialup.cpp:468
+#: ../src/msw/dialup.cpp:462
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Besedila sporočila o napaki RAS ni mogoče pridobiti."
 
 # msw/clipbrd.cpp:652
-#: ../src/msw/clipbrd.cpp:748
+#: ../src/msw/clipbrd.cpp:768
 msgid "Failed to retrieve the supported clipboard formats"
 msgstr "Podprte oblike zapisa odložišča ni mogoče pridobiti."
 
 # common/ffile.cpp:182
-#: ../src/common/docview.cpp:652
+#: ../src/common/docview.cpp:647
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Neuspešno shranjevanje dokumenta v datoteko \"%s\"."
 
 # common/ffile.cpp:182
-#: ../src/msw/dib.cpp:269
+#: ../src/msw/dib.cpp:312
 #, c-format
 msgid "Failed to save the bitmap image to file \"%s\"."
 msgstr "Neuspešno shranjevanje bitne slike v datoteko \"%s\"."
 
 # msw/dde.cpp:661
-#: ../src/msw/dde.cpp:763
+#: ../src/msw/dde.cpp:811
 msgid "Failed to send DDE advise notification"
 msgstr "Pošiljanje usklajevalne transakcije DDE ni uspelo."
 
 # generic/dirdlgg.cpp:550
-#: ../src/common/ftp.cpp:402
+#: ../src/common/ftp.cpp:399
 #, c-format
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Prenosnega načina FTP ni mogoče nastaviti na %s."
 
 # msw/clipbrd.cpp:300
-#: ../src/msw/clipbrd.cpp:427
+#: ../src/msw/clipbrd.cpp:443
 msgid "Failed to set clipboard data."
 msgstr "Neuspešno določanje podatkov za odložišče."
 
 # common/ffile.cpp:182
-#: ../src/unix/snglinst.cpp:181
+#: ../src/unix/snglinst.cpp:178
 #, c-format
 msgid "Failed to set permissions on lock file '%s'"
 msgstr "Zaklenjeni datoteki »%s« ni bilo možno nastaviti pravic."
 
 # generic/dirdlgg.cpp:550
-#: ../src/unix/utilsunx.cpp:668
+#: ../src/unix/utilsunx.cpp:670
 msgid "Failed to set process priority"
 msgstr "Prioritete procesa ni bilo mogoče nastaviti."
 
 # common/ffile.cpp:182
-#: ../src/common/file.cpp:559
+#: ../src/common/ffile.cpp:355 ../src/common/file.cpp:586
 msgid "Failed to set temporary file permissions"
 msgstr "Neuspešno nastavljanje pravic za trenutno datoteko"
 
 # generic/dirdlgg.cpp:550
-#: ../src/gtk/textctrl.cpp:1072
-msgid "Failed to set text in the text control."
-msgstr "Besedila v kontrolniku besedila ni mogoče nastaviti."
-
-# generic/dirdlgg.cpp:550
-#: ../src/unix/threadpsx.cpp:1298
+#: ../src/unix/threadpsx.cpp:1347
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Ravni sočasnosti niti ni bilo mogoče nastaviti na %lu."
 
 # generic/dirdlgg.cpp:550
-#: ../src/unix/threadpsx.cpp:1424
+#: ../src/unix/threadpsx.cpp:1473
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Prioritete niti %d ni bilo mogoče nastaviti."
 
-#: ../src/unix/utilsunx.cpp:783
+#: ../src/unix/utilsunx.cpp:785
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr "Neuspešno vzpostavljena neblokirana cev, program se lahko obesi."
 
+#: ../src/msw/webview_ie.cpp:987
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
 # common/fs_mem.cpp:167
-#: ../src/common/fs_mem.cpp:261
+#: ../src/common/fs_mem.cpp:256
 #, c-format
 msgid "Failed to store image '%s' to memory VFS!"
 msgstr "Slike '%s' ni mogoče shraniti v spominski VFS!"
 
-#: ../src/dfb/evtloop.cpp:170
+#: ../src/dfb/evtloop.cpp:171
 msgid "Failed to switch DirectFB pipe to non-blocking mode"
 msgstr "Preklop cevi DirectFB v neblokirani način ni uspel"
 
-#: ../src/unix/wakeuppipe.cpp:59
+#: ../src/unix/wakeuppipe.cpp:56
 msgid "Failed to switch wake up pipe to non-blocking mode"
 msgstr "Preklop cevi z bujenjem v neblokirani način ni uspel"
 
 # generic/dirdlgg.cpp:550
-#: ../src/unix/threadpsx.cpp:1605
+#: ../src/unix/threadpsx.cpp:1654
 msgid "Failed to terminate a thread."
 msgstr "Niti ni mogoče prekiniti."
 
 # msw/dde.cpp:635
-#: ../src/msw/dde.cpp:741
+#: ../src/msw/dde.cpp:736
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "Ustavitev usklajevalne zanke s strežnikom DDE ni uspela."
 
 # msw/dialup.cpp:933
-#: ../src/msw/dialup.cpp:938
+#: ../src/msw/dialup.cpp:932
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Prekinitev klicne povezave ni uspela: %s"
 
 # common/ffile.cpp:182
-#: ../src/common/filename.cpp:2590
+#: ../src/common/filename.cpp:2673
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Datoteke »%s« se ni mogoče dotakniti."
 
+# common/dynlib.cpp:239
+#: ../src/unix/dlunix.cpp:90
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "Deljene knjižnice »%s« ni mogoče odpreti."
+
 # common/ffile.cpp:182
-#: ../src/unix/snglinst.cpp:334
+#: ../src/unix/snglinst.cpp:331
 #, c-format
 msgid "Failed to unlock lock file '%s'"
 msgstr "Zaklenjene datoteke »%s« ni mogoče odkleniti."
 
 # msw/dde.cpp:301
-#: ../src/msw/dde.cpp:309
+#: ../src/msw/dde.cpp:304
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Odjava strežnika DDE »%s« ni uspela."
@@ -4298,70 +4369,78 @@ msgstr "Deskriptorja %d ni uspelo odregistrirati iz deskriptorja epoll %d"
 msgid "Failed to update user configuration file."
 msgstr "Uporabniške konfiguracijske datoteke ni mogoče posodobiti."
 
-#: ../src/common/debugrpt.cpp:733
+#: ../src/common/debugrpt.cpp:743
 #, c-format
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Poročila o razhroščevanju ni bilo mogoče prenesti (koda napake %d)"
 
 # common/ffile.cpp:182
-#: ../src/unix/snglinst.cpp:168
+#: ../src/unix/snglinst.cpp:165
 #, c-format
 msgid "Failed to write to lock file '%s'"
 msgstr "V datoteko zaklopa »%s« ni mogoče pisati."
 
 # generic/filedlgg.cpp:534
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:209
+#: ../src/propgrid/propgrid.cpp:190
 msgid "False"
 msgstr "Ne velja"
 
 # html/helpfrm.cpp:899
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:694
+#: ../src/propgrid/advprops.cpp:604
 msgid "Family"
 msgstr "Družina"
 
+# common/docview.cpp:296
+# common/docview.cpp:332
+# common/docview.cpp:1388
+#: ../src/gtk/glcanvas.cpp:176 ../src/gtk/glcanvas.cpp:187
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Datotečna napaka"
+
 # generic/filedlgg.cpp:534
-#: ../src/common/stockitem.cpp:157
+#: ../src/common/stockitem.cpp:154
 msgid "File"
 msgstr "Datoteka"
 
 # generic/dirdlgg.cpp:550
-#: ../src/common/docview.cpp:669
+#: ../src/common/docview.cpp:664
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Datoteke \"%s\" ni mogoče odpreti za branje."
 
 # generic/dirdlgg.cpp:550
-#: ../src/common/docview.cpp:646
+#: ../src/common/docview.cpp:641
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Datoteke \"%s\" ni mogoče odpreti za pisanje."
 
 # generic/filedlgg.cpp:1074
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "Datoteka %s že obstaja, jo resnično želite prepisati?"
 
 # common/filefn.cpp:1086
-#: ../src/common/filefn.cpp:1156
+#: ../src/common/filefn.cpp:1044
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Datoteke »%s« ni mogoče odstraniti."
 
 # common/filefn.cpp:1086
-#: ../src/common/filefn.cpp:1139
+#: ../src/common/filefn.cpp:1028
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Datoteke »%s« ni mogoče preimenovati v »%s«."
 
 # common/textcmn.cpp:94
-#: ../src/richtext/richtextctrl.cpp:3081 ../src/common/textcmn.cpp:953
+#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
 msgid "File couldn't be loaded."
 msgstr "Datoteke ni mogoče naložiti."
 
-#: ../src/msw/filedlg.cpp:393
+#: ../src/msw/filedlg.cpp:414
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Pogovorno okno izbirnika datotek je spodletelo, napaka %0lx."
@@ -4369,15 +4448,21 @@ msgstr "Pogovorno okno izbirnika datotek je spodletelo, napaka %0lx."
 # common/docview.cpp:296
 # common/docview.cpp:332
 # common/docview.cpp:1388
-#: ../src/common/docview.cpp:1789
+#: ../src/common/docview.cpp:1783
 msgid "File error"
 msgstr "Datotečna napaka"
 
 # generic/dirdlgg.cpp:286
 # generic/filedlgg.cpp:731
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/filectrlg.cpp:770
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/filectrlg.cpp:766
 msgid "File name exists already."
 msgstr "Ime datoteke že obstaja."
+
+# generic/fontdlgg.cpp:211
+#: ../src/osx/cocoa/filedlg.mm:264
+#, fuzzy
+msgid "File type:"
+msgstr "strojna"
 
 # generic/filedlgg.cpp:534
 #: ../src/motif/filedlg.cpp:220
@@ -4385,7 +4470,7 @@ msgid "Files"
 msgstr "Datoteke"
 
 # generic/filedlgg.cpp:825
-#: ../src/common/filefn.cpp:1591
+#: ../src/common/filefn.cpp:1479
 #, c-format
 msgid "Files (%s)"
 msgstr "Datoteke (%s)"
@@ -4396,16 +4481,33 @@ msgid "Filter"
 msgstr "Končnica"
 
 # html/helpfrm.cpp:340
-#: ../src/common/stockitem.cpp:158 ../src/html/helpwnd.cpp:490
+#: ../src/html/helpwnd.cpp:488
 msgid "Find"
 msgstr "Poišči"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:259
+msgid "Find and replace in document"
+msgstr ""
+
+# html/helpfrm.cpp:523
+# html/helpfrm.cpp:1183
+#: ../src/common/stockitem.cpp:258
+#, fuzzy
+msgid "Find in document"
+msgstr "Odpri dokument HTML"
+
+# html/helpfrm.cpp:340
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "Find..."
+msgstr "Poišči"
+
+#: ../src/common/stockitem.cpp:156
 msgid "First"
 msgstr "Prvi"
 
 # html/helpfrm.cpp:515
-#: ../src/common/prntbase.cpp:1548
+#: ../src/common/prntbase.cpp:1573
 msgid "First page"
 msgstr "Prva stran"
 
@@ -4415,11 +4517,11 @@ msgid "Fixed"
 msgstr "Nespremenljivo"
 
 # html/helpfrm.cpp:889
-#: ../src/html/helpwnd.cpp:1206
+#: ../src/html/helpwnd.cpp:1204
 msgid "Fixed font:"
 msgstr "Nespremenljiva pisava:"
 
-#: ../src/html/helpwnd.cpp:1269
+#: ../src/html/helpwnd.cpp:1267
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Pisava nespremenljive velikosti.<br> <b>krepko</b> <i>ležeče</i>"
 
@@ -4427,16 +4529,16 @@ msgstr "Pisava nespremenljive velikosti.<br> <b>krepko</b> <i>ležeče</i>"
 msgid "Floating"
 msgstr "Plavajoče"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "Floppy"
 msgstr "Disketa"
 
-#: ../src/common/paper.cpp:111
+#: ../src/common/paper.cpp:108
 msgid "Folio, 8 1/2 x 13 in"
 msgstr "Folio, 8 1/2 x 13 pal."
 
-#: ../src/richtext/richtextformatdlg.cpp:344 ../src/osx/carbon/fontdlg.cpp:287
-#: ../src/common/stockitem.cpp:194
+#: ../src/osx/carbon/fontdlg.cpp:284 ../src/common/stockitem.cpp:191
+#: ../src/richtext/richtextformatdlg.cpp:337
 msgid "Font"
 msgstr "Pisava"
 
@@ -4444,8 +4546,27 @@ msgstr "Pisava"
 msgid "Font &weight:"
 msgstr "&Odebeljenost pisave:"
 
+#: ../src/osx/fontutil.cpp:89
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
+"\"."
+msgstr ""
+
+# common/textcmn.cpp:94
+#: ../src/msw/font.cpp:1126
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Datoteke ni mogoče naložiti."
+
+# html/htmprint.cpp:272
+#: ../src/osx/fontutil.cpp:81
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr ": datoteka ne obstaja!"
+
 # html/helpfrm.cpp:899
-#: ../src/html/helpwnd.cpp:1207
+#: ../src/html/helpwnd.cpp:1205
 msgid "Font size:"
 msgstr "Velikost pisave"
 
@@ -4455,60 +4576,60 @@ msgid "Font st&yle:"
 msgstr "Slo&g pisave:"
 
 # html/helpfrm.cpp:899
-#: ../src/osx/carbon/fontdlg.cpp:329
+#: ../src/osx/carbon/fontdlg.cpp:326
 msgid "Font:"
 msgstr "Pisava:"
 
-#: ../src/dfb/fontmgr.cpp:198
+#: ../src/dfb/fontmgr.cpp:195
 #, c-format
 msgid "Fonts index file %s disappeared while loading fonts."
 msgstr "Pri nalaganju pisav je datoteka kazala pisav %s izginila."
 
-#: ../src/unix/utilsunx.cpp:645
+#: ../src/unix/utilsunx.cpp:647
 msgid "Fork failed"
 msgstr "Razcepitev ni uspela"
 
 # common/dlgcmn.cpp:132
 # generic/helpwxht.cpp:158
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "Forward"
 msgstr "Naprej"
 
-#: ../src/common/xtixml.cpp:235
+#: ../src/common/xtixml.cpp:231
 msgid "Forward hrefs are not supported"
 msgstr "Naslovi href za preusmerjanje niso podprti."
 
 # html/helpfrm.cpp:637
-#: ../src/html/helpwnd.cpp:875
+#: ../src/html/helpwnd.cpp:873
 #, c-format
 msgid "Found %i matches"
 msgstr "Najdenih %i ujemanj"
 
 # generic/prntdlgg.cpp:187
-#: ../src/generic/prntdlgg.cpp:238
+#: ../src/generic/prntdlgg.cpp:231
 msgid "From:"
 msgstr "Od:"
 
-#: ../src/propgrid/advprops.cpp:1604
+#: ../src/propgrid/advprops.cpp:1510
 msgid "Fuchsia"
 msgstr "Fuksija"
 
 # common/imaggif.cpp:74
-#: ../src/common/imaggif.cpp:138
+#: ../src/common/imaggif.cpp:135
 msgid "GIF: data stream seems to be truncated."
 msgstr "GIF: podatkovni tok se zdi skrajšan."
 
 # common/imaggif.cpp:58
-#: ../src/common/imaggif.cpp:128
+#: ../src/common/imaggif.cpp:125
 msgid "GIF: error in GIF image format."
 msgstr "GIF: napaka v zapisu slike GIF."
 
 # common/imaggif.cpp:61
-#: ../src/common/imaggif.cpp:133
+#: ../src/common/imaggif.cpp:130
 msgid "GIF: not enough memory."
 msgstr "GIF: premalo spomina."
 
-#: ../src/gtk/window.cpp:4631
+#: ../src/gtk/window.cpp:5635
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -4516,24 +4637,24 @@ msgstr ""
 "GTK+, nameščen na tem računalniku, je prestar, da bi podpiral zaslonsko "
 "skladanje, namestiti morate GTK+ 2.12 ali novejšega."
 
-#: ../src/univ/themes/gtk.cpp:525
+#: ../src/univ/themes/gtk.cpp:522
 msgid "GTK+ theme"
 msgstr "Tema GTK+"
 
-#: ../src/common/preferencescmn.cpp:40
+#: ../src/common/preferencescmn.cpp:37
 msgid "General"
 msgstr "Splošno"
 
 # generic/prntdlgg.cpp:272
-#: ../src/common/prntbase.cpp:258
+#: ../src/common/prntbase.cpp:253
 msgid "Generic PostScript"
 msgstr "Splošni PostScript"
 
-#: ../src/common/paper.cpp:135
+#: ../src/common/paper.cpp:132
 msgid "German Legal Fanfold, 8 1/2 x 13 in"
 msgstr "German Legal Fanfold, 8 1/2 x 13 pal."
 
-#: ../src/common/paper.cpp:134
+#: ../src/common/paper.cpp:131
 msgid "German Std Fanfold, 8 1/2 x 12 in"
 msgstr "German Std Fanfold, 8 1/2 x 12 pal."
 
@@ -4550,52 +4671,52 @@ msgid "GetPropertyCollection called w/o valid collection getter"
 msgstr "GetPropertyCollection klicana brez veljavnega pridobivalnika zbirke"
 
 # html/helpfrm.cpp:501
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:658
 msgid "Go back"
 msgstr "Pojdi nazaj"
 
 # html/helpfrm.cpp:504
-#: ../src/html/helpwnd.cpp:661
+#: ../src/html/helpwnd.cpp:659
 msgid "Go forward"
 msgstr "Pojdi naprej"
 
 # html/helpfrm.cpp:509
-#: ../src/html/helpwnd.cpp:663
+#: ../src/html/helpwnd.cpp:661
 msgid "Go one level up in document hierarchy"
 msgstr "Pojdi nivo višje v hierarhiji dokumenta"
 
 # generic/filedlgg.cpp:875
-#: ../src/generic/filedlgg.cpp:208 ../src/generic/dirdlgg.cpp:116
+#: ../src/generic/filedlgg.cpp:205 ../src/generic/dirdlgg.cpp:113
 msgid "Go to home directory"
 msgstr "Pojdi v domačo mapo"
 
 # generic/filedlgg.cpp:869
-#: ../src/generic/filedlgg.cpp:205
+#: ../src/generic/filedlgg.cpp:202
 msgid "Go to parent directory"
 msgstr "Pojdi v starševsko mapo"
 
-#: ../src/generic/aboutdlgg.cpp:76
+#: ../src/generic/aboutdlgg.cpp:73
 msgid "Graphics art by "
 msgstr "Avtor grafik "
 
-#: ../src/propgrid/advprops.cpp:1599
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Gray"
 msgstr "Siva"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:883
+#: ../src/propgrid/advprops.cpp:784
 msgid "GrayText"
 msgstr "SivoBesedilo"
 
-#: ../src/common/fmapbase.cpp:154
+#: ../src/common/fmapbase.cpp:151
 msgid "Greek (ISO-8859-7)"
 msgstr "grško (ISO-8859-7)"
 
-#: ../src/propgrid/advprops.cpp:1600
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Green"
 msgstr "Zelena"
 
-#: ../src/generic/colrdlgg.cpp:342
+#: ../src/generic/colrdlgg.cpp:362
 msgid "Green:"
 msgstr "Zelena:"
 
@@ -4603,34 +4724,34 @@ msgstr "Zelena:"
 msgid "Groove"
 msgstr "Groove"
 
-#: ../src/common/zstream.cpp:158 ../src/common/zstream.cpp:318
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
 msgid "Gzip not supported by this version of zlib"
 msgstr "Ta različica zlib ne podpira Gzip"
 
-#: ../src/html/helpwnd.cpp:1549
+#: ../src/html/helpwnd.cpp:1547
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "projekt pomoči HTML (*.hhp)|*.hhp|"
 
 # html/htmlwin.cpp:251
-#: ../src/html/htmlwin.cpp:681
+#: ../src/html/htmlwin.cpp:691
 #, c-format
 msgid "HTML anchor %s does not exist."
 msgstr "HTML sidro %s ne obstaja"
 
-#: ../src/html/helpwnd.cpp:1547
+#: ../src/html/helpwnd.cpp:1545
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "Datoteke HTML (*.html;*.htm)|*.html;*.htm|"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1759
+#: ../src/propgrid/advprops.cpp:1660
 msgid "Hand"
 msgstr "Roka"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "Harddisk"
 msgstr "Trdi disk"
 
-#: ../src/common/fmapbase.cpp:155
+#: ../src/common/fmapbase.cpp:152
 msgid "Hebrew (ISO-8859-8)"
 msgstr "hebrejsko (ISO-8859-8)"
 
@@ -4639,90 +4760,90 @@ msgstr "hebrejsko (ISO-8859-8)"
 # html/helpfrm.cpp:208
 # msw/mdi.cpp:1283
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:280 ../src/osx/button_osx.cpp:39
-#: ../src/common/stockitem.cpp:163 ../src/common/accelcmn.cpp:80
-#: ../src/html/helpdlg.cpp:66 ../src/html/helpfrm.cpp:111
+#: ../include/wx/msgdlg.h:282 ../src/osx/button_osx.cpp:39
+#: ../src/common/stockitem.cpp:160 ../src/common/accelcmn.cpp:77
+#: ../src/html/helpfrm.cpp:108 ../src/html/helpdlg.cpp:63
 msgid "Help"
 msgstr "Pomoč"
 
 # html/helpfrm.cpp:872
-#: ../src/html/helpwnd.cpp:1200
+#: ../src/html/helpwnd.cpp:1198
 msgid "Help Browser Options"
 msgstr "Možnosti brskalnika pomoči"
 
 # generic/helphtml.cpp:319
 # generic/helphtml.cpp:320
-#: ../src/generic/helpext.cpp:454 ../src/generic/helpext.cpp:455
+#: ../src/generic/helpext.cpp:452 ../src/generic/helpext.cpp:453
 msgid "Help Index"
 msgstr "Indeks pomoči"
 
 # html/helpfrm.cpp:1172
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1529
 msgid "Help Printing"
 msgstr "Pomoč pri tiskanju"
 
 # generic/helpwxht.cpp:251
 # html/helpctrl.cpp:38
-#: ../src/html/helpwnd.cpp:801
+#: ../src/html/helpwnd.cpp:799
 msgid "Help Topics"
 msgstr "Teme pomoči"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1546
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "knjige pomoči (*.htb)|*.htb|knjige pomoči (*.zip)|*.zip|"
 
-#: ../src/generic/helpext.cpp:267
+#: ../src/generic/helpext.cpp:265
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "Mape pomoči \"%s\" ni mogoče najti."
 
 # common/intl.cpp:374
-#: ../src/generic/helpext.cpp:275
+#: ../src/generic/helpext.cpp:273
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "Datoteke pomoči \"%s\" ni mogoče najti."
 
 # generic/helpwxht.cpp:251
 # html/helpctrl.cpp:38
-#: ../src/html/helpctrl.cpp:63
+#: ../src/html/helpctrl.cpp:59
 #, c-format
 msgid "Help: %s"
 msgstr "Pomoč: %s"
 
 # generic/helpwxht.cpp:251
 # html/helpctrl.cpp:38
-#: ../src/osx/menu_osx.cpp:577
+#: ../src/osx/menu_osx.cpp:469
 #, c-format
 msgid "Hide %s"
 msgstr "Skrij %s"
 
-#: ../src/osx/menu_osx.cpp:579
+#: ../src/osx/menu_osx.cpp:471
 msgid "Hide Others"
 msgstr "Skrij druge"
 
-#: ../src/generic/infobar.cpp:84
+#: ../src/generic/infobar.cpp:81
 msgid "Hide this notification message."
 msgstr "Skrij to obvestilo."
 
 # generic/fontdlgg.cpp:216
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:884
+#: ../src/propgrid/advprops.cpp:785
 msgid "Highlight"
 msgstr "Poudari"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:885
+#: ../src/propgrid/advprops.cpp:786
 msgid "HighlightText"
 msgstr "PoudariBesedilo"
 
 # generic/dirdlgg.cpp:212
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:164 ../src/common/accelcmn.cpp:65
+#: ../src/common/stockitem.cpp:161 ../src/common/accelcmn.cpp:62
 msgid "Home"
 msgstr "Domov"
 
 # generic/dirdlgg.cpp:536
-#: ../src/generic/dirctrlg.cpp:524
+#: ../src/generic/dirctrlg.cpp:490
 msgid "Home directory"
 msgstr "Domača mapa"
 
@@ -4732,63 +4853,63 @@ msgid "How the object will float relative to the text."
 msgstr "Kako bo plaval predmet relativno glede na besedilo."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1760
+#: ../src/propgrid/advprops.cpp:1661
 msgid "I-Beam"
 msgstr "I-Beam"
 
-#: ../src/common/imagbmp.cpp:1196
+#: ../src/common/imagbmp.cpp:1208
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: napaka pri branju maske DIB."
 
-#: ../src/common/imagbmp.cpp:1290 ../src/common/imagbmp.cpp:1390
-#: ../src/common/imagbmp.cpp:1405 ../src/common/imagbmp.cpp:1416
-#: ../src/common/imagbmp.cpp:1430 ../src/common/imagbmp.cpp:1478
-#: ../src/common/imagbmp.cpp:1493 ../src/common/imagbmp.cpp:1507
-#: ../src/common/imagbmp.cpp:1518
+#: ../src/common/imagbmp.cpp:1302 ../src/common/imagbmp.cpp:1402
+#: ../src/common/imagbmp.cpp:1417 ../src/common/imagbmp.cpp:1428
+#: ../src/common/imagbmp.cpp:1442 ../src/common/imagbmp.cpp:1490
+#: ../src/common/imagbmp.cpp:1505 ../src/common/imagbmp.cpp:1519
+#: ../src/common/imagbmp.cpp:1530
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: napaka pri pisanju v datoteko slike!"
 
-#: ../src/common/imagbmp.cpp:1255
+#: ../src/common/imagbmp.cpp:1267
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: slika je previsoka za ikono."
 
-#: ../src/common/imagbmp.cpp:1263
+#: ../src/common/imagbmp.cpp:1275
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: slika je preširoka za ikono."
 
-#: ../src/common/imagbmp.cpp:1603
+#: ../src/common/imagbmp.cpp:1615
 msgid "ICO: Invalid icon index."
 msgstr "ICO: neveljaven indeks ikone."
 
-#: ../src/common/imagiff.cpp:758
+#: ../src/common/imagiff.cpp:755
 msgid "IFF: data stream seems to be truncated."
 msgstr "IFF: podatkovni tok se zdi okrajšan."
 
-#: ../src/common/imagiff.cpp:742
+#: ../src/common/imagiff.cpp:739
 msgid "IFF: error in IFF image format."
 msgstr "IFF: napaka v zapisu slike IFF."
 
-#: ../src/common/imagiff.cpp:745
+#: ../src/common/imagiff.cpp:742
 msgid "IFF: not enough memory."
 msgstr "IFF: premalo spomina."
 
 # generic/progdlgg.cpp:241
-#: ../src/common/imagiff.cpp:748
+#: ../src/common/imagiff.cpp:745
 msgid "IFF: unknown error!!!"
 msgstr "IFF: neznana napaka!!!"
 
-#: ../src/common/fmapbase.cpp:197
+#: ../src/common/fmapbase.cpp:194
 msgid "ISO-2022-JP"
 msgstr "ISO-2022-JP"
 
-#: ../src/html/htmprint.cpp:282
+#: ../src/html/htmprint.cpp:294
 msgid ""
 "If possible, try changing the layout parameters to make the printout more "
 "narrow."
 msgstr ""
 "Če je mogoče, poskusite spremeniti parametre postavitve, da bo izpis ožji."
 
-#: ../src/generic/dbgrptg.cpp:358
+#: ../src/generic/dbgrptg.cpp:362
 msgid ""
 "If you have any additional information pertaining to this bug\n"
 "report, please enter it here and it will be joined to it:"
@@ -4808,50 +4929,54 @@ msgstr ""
 "vendar vedite, da to lahko onemogoča izboljšanje programa, tako da če je\n"
 "le mogoče, prosimo, nadaljujte s tvorbo poročila.\n"
 
-#: ../src/msw/registry.cpp:1405
+#: ../src/common/zipstrm.cpp:1043
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1393
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Neupoštevanje vrednosti \"%s\" ključa \"%s\"."
 
-#: ../src/common/xtistrm.cpp:295
+#: ../src/common/xtistrm.cpp:292
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Neveljavni razred predmetov (ne wxEvtHandler) kot izvor dogodka."
 
-#: ../src/common/xti.cpp:513
+#: ../src/common/xti.cpp:510
 msgid "Illegal Parameter Count for ConstructObject Method"
 msgstr "Neveljavno število parametrov za metodo ConstructObject"
 
-#: ../src/common/xti.cpp:501
+#: ../src/common/xti.cpp:498
 msgid "Illegal Parameter Count for Create Method"
 msgstr "Neveljavno število parametrov za metodo ustvarjanja"
 
 # generic/dirdlgg.cpp:268
 # generic/filedlgg.cpp:717
-#: ../src/generic/dirctrlg.cpp:570 ../src/generic/filectrlg.cpp:756
+#: ../src/generic/dirctrlg.cpp:536 ../src/generic/filectrlg.cpp:752
 msgid "Illegal directory name."
 msgstr "Neveljavno ime mape."
 
 # generic/filedlgg.cpp:1043
-#: ../src/generic/filectrlg.cpp:1367
+#: ../src/generic/filectrlg.cpp:1356
 msgid "Illegal file specification."
 msgstr "Napačna specifikacija datoteke"
 
-#: ../src/common/image.cpp:2269
+#: ../src/common/image.cpp:2363
 msgid "Image and mask have different sizes."
 msgstr "Slika in maska imata različno velikost."
 
-#: ../src/common/image.cpp:2746
+#: ../src/common/image.cpp:2841
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "Datoteka slike ni vrste %d."
 
-#: ../src/common/image.cpp:2877
+#: ../src/common/image.cpp:2995
 #, c-format
 msgid "Image is not of type %s."
 msgstr "Slika ni vrste %s."
 
 # msw/textctrl.cpp:219
-#: ../src/msw/textctrl.cpp:488
+#: ../src/msw/textctrl.cpp:534
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -4860,106 +4985,106 @@ msgstr ""
 "uporabljen kontrolnik za enostavno urejanje besedila. Prosimo, ponovno "
 "namestite riched32.dll"
 
-#: ../src/unix/utilsunx.cpp:301
+#: ../src/unix/utilsunx.cpp:303
 msgid "Impossible to get child process input"
 msgstr "Vhoda podrejenega procesa ni mogoče pridobiti."
 
-#: ../src/common/filefn.cpp:1028
+#: ../src/common/filefn.cpp:917
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Pravic za datoteko »%s« ni mogoče dobiti."
 
 # common/ffile.cpp:182
-#: ../src/common/filefn.cpp:1042
+#: ../src/common/filefn.cpp:931
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Datoteke »%s« ni mogoče prepisati."
 
-#: ../src/common/filefn.cpp:1097
+#: ../src/common/filefn.cpp:986
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Pravic za datoteko »%s« ni mogoče nastaviti."
 
 # generic/fontdlgg.cpp:208
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:886
+#: ../src/propgrid/advprops.cpp:787
 msgid "InactiveBorder"
 msgstr "NedejavnaObroba"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:887
+#: ../src/propgrid/advprops.cpp:788
 msgid "InactiveCaption"
 msgstr "NedejavenNapis"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:888
+#: ../src/propgrid/advprops.cpp:789
 msgid "InactiveCaptionText"
 msgstr "BesediloNedejavnegaNapisa"
 
-#: ../src/common/gifdecod.cpp:792
+#: ../src/common/gifdecod.cpp:826
 #, c-format
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "Nepravilna velikost okvira GIF (%u, %d) za okvir #%u"
 
-#: ../src/msw/ole/automtn.cpp:635
+#: ../src/msw/ole/automtn.cpp:626
 msgid "Incorrect number of arguments."
 msgstr "Nepravilno število argumentov."
 
 # html/helpfrm.cpp:372
-#: ../src/common/stockitem.cpp:165
+#: ../src/common/stockitem.cpp:162
 msgid "Indent"
 msgstr "Zamaknjeno"
 
-#: ../src/richtext/richtextformatdlg.cpp:349
+#: ../src/richtext/richtextformatdlg.cpp:342
 msgid "Indents && Spacing"
 msgstr "Zamiki in razmiki"
 
 # html/helpfrm.cpp:372
-#: ../src/common/stockitem.cpp:166 ../src/html/helpwnd.cpp:515
+#: ../src/common/stockitem.cpp:163 ../src/html/helpwnd.cpp:513
 msgid "Index"
 msgstr "Indeks"
 
-#: ../src/common/fmapbase.cpp:159
+#: ../src/common/fmapbase.cpp:156
 msgid "Indian (ISO-8859-12)"
 msgstr "indijsko (ISO-8859-12)"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "Info"
 msgstr "Podatki"
 
-#: ../src/common/init.cpp:287
+#: ../src/common/init.cpp:284
 msgid "Initialization failed in post init, aborting."
 msgstr "Inicializacija ni uspela v po-inicializaciji, sledi prekinitev."
 
 # html/helpfrm.cpp:372
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:54
+#: ../src/common/accelcmn.cpp:51
 msgid "Ins"
 msgstr "Vstavljalka"
 
 # html/helpfrm.cpp:372
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextsymboldlg.cpp:472 ../src/common/accelcmn.cpp:53
+#: ../src/common/accelcmn.cpp:50 ../src/richtext/richtextsymboldlg.cpp:469
 msgid "Insert"
 msgstr "Vstavi"
 
-#: ../src/richtext/richtextbuffer.cpp:8067
+#: ../src/richtext/richtextbuffer.cpp:8063
 msgid "Insert Field"
 msgstr "Vstavi polje"
 
-#: ../src/richtext/richtextbuffer.cpp:7978
-#: ../src/richtext/richtextbuffer.cpp:8936
+#: ../src/richtext/richtextbuffer.cpp:7974
+#: ../src/richtext/richtextbuffer.cpp:8934
 msgid "Insert Image"
 msgstr "Vstavi sliko"
 
-#: ../src/richtext/richtextbuffer.cpp:8025
+#: ../src/richtext/richtextbuffer.cpp:8021
 msgid "Insert Object"
 msgstr "Vstavi predmet"
 
-#: ../src/richtext/richtextctrl.cpp:1286 ../src/richtext/richtextctrl.cpp:1494
-#: ../src/richtext/richtextbuffer.cpp:7822
-#: ../src/richtext/richtextbuffer.cpp:7852
-#: ../src/richtext/richtextbuffer.cpp:7894
+#: ../src/richtext/richtextbuffer.cpp:7818
+#: ../src/richtext/richtextbuffer.cpp:7848
+#: ../src/richtext/richtextbuffer.cpp:7890
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
 msgid "Insert Text"
 msgstr "Vstavi besedilo"
 
@@ -4973,18 +5098,13 @@ msgstr "Vstavi prelom strani pred odstavek."
 msgid "Inset"
 msgstr "Vstavek"
 
-#: ../src/gtk/app.cpp:425
-#, c-format
-msgid "Invalid GTK+ command line option, use \"%s --help\""
-msgstr "Neveljavna možnost ukazne vrstice GTK+, uporabite \"%s --help\""
-
 # common/imagtiff.cpp:171
-#: ../src/common/imagtiff.cpp:311
+#: ../src/common/imagtiff.cpp:308
 msgid "Invalid TIFF image index."
 msgstr "Neveljaven indeks slike TIFF."
 
 # generic/filedlgg.cpp:1043
-#: ../src/common/appcmn.cpp:273
+#: ../src/common/appcmn.cpp:294
 #, c-format
 msgid "Invalid display mode specification '%s'."
 msgstr "Napačna specifikacija načina prikaza '%s'."
@@ -4995,259 +5115,263 @@ msgstr "Napačna specifikacija načina prikaza '%s'."
 msgid "Invalid geometry specification '%s'"
 msgstr "Neveljavna specifikacija geometrije '%s'"
 
-#: ../src/unix/fswatcher_inotify.cpp:323
+#: ../src/unix/fswatcher_inotify.cpp:320
 #, c-format
 msgid "Invalid inotify event for \"%s\""
 msgstr "Neveljaven dogodek inotify za »%s«"
 
 # common/ffile.cpp:101
-#: ../src/unix/snglinst.cpp:312
+#: ../src/unix/snglinst.cpp:309
 #, c-format
 msgid "Invalid lock file '%s'."
 msgstr "Datoteka '%s' ni veljavna datoteka zaklopa."
 
 # common/intl.cpp:412
-#: ../src/common/translation.cpp:1125
+#: ../src/common/translation.cpp:1167
 msgid "Invalid message catalog."
 msgstr "Neveljaven katalog sporočil."
 
-#: ../src/common/xtistrm.cpp:405 ../src/common/xtistrm.cpp:420
+#: ../src/common/xtistrm.cpp:402 ../src/common/xtistrm.cpp:417
 msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
 msgstr "V GetObjectClassInfo podan neveljaven ali ničelni predmetni ID."
 
-#: ../src/common/xtistrm.cpp:435
+#: ../src/common/xtistrm.cpp:432
 msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
 msgstr "V HasObjectClassInfo podan neveljaven ali ničelni predmetni ID."
 
-#: ../src/common/regex.cpp:310
+#: ../src/common/regex.cpp:307
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Neveljaven pravilni izraz '%s': %s"
 
-#: ../src/common/config.cpp:226
+#: ../src/common/config.cpp:222
 #, c-format
 msgid "Invalid value %ld for a boolean key \"%s\" in config file."
 msgstr ""
 "Neveljavna vrednost %ld za logični ključ »%s« v prilagoditveni datoteki."
 
 # generic/fontdlgg.cpp:213
-#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:351
-#: ../src/osx/carbon/fontdlg.cpp:361 ../src/common/stockitem.cpp:168
+#: ../src/osx/carbon/fontdlg.cpp:358 ../src/common/stockitem.cpp:165
+#: ../src/generic/fontdlgg.cpp:325 ../src/richtext/richtextfontpage.cpp:351
 msgid "Italic"
 msgstr "Kurzivno"
 
-#: ../src/common/paper.cpp:130
+#: ../src/common/paper.cpp:127
 msgid "Italy Envelope, 110 x 230 mm"
 msgstr "kuverta Italijanka, 110 x 230 mm"
 
 # common/imagjpeg.cpp:202
-#: ../src/common/imagjpeg.cpp:270
+#: ../src/common/imagjpeg.cpp:257
 msgid "JPEG: Couldn't load - file is probably corrupted."
 msgstr "JPEG: nalaganje ni možno - datoteka je najverjetneje pokvarjena."
 
 # common/imagjpeg.cpp:315
-#: ../src/common/imagjpeg.cpp:449
+#: ../src/common/imagjpeg.cpp:436
 msgid "JPEG: Couldn't save image."
 msgstr "JPEG: slike ni bilo mogoče shraniti."
 
-#: ../src/common/paper.cpp:163
+#: ../src/common/paper.cpp:160
 msgid "Japanese Double Postcard 200 x 148 mm"
 msgstr "japonska dvojna razglednica, 200 x 148 mm"
 
-#: ../src/common/paper.cpp:167
+#: ../src/common/paper.cpp:164
 msgid "Japanese Envelope Chou #3"
 msgstr "japonska kuverta Čou #3"
 
-#: ../src/common/paper.cpp:180
+#: ../src/common/paper.cpp:177
 msgid "Japanese Envelope Chou #3 Rotated"
 msgstr "japonska kuverta Čou #3 rotirano"
 
-#: ../src/common/paper.cpp:168
+#: ../src/common/paper.cpp:165
 msgid "Japanese Envelope Chou #4"
 msgstr "japonska kuverta Čou #4"
 
-#: ../src/common/paper.cpp:181
+#: ../src/common/paper.cpp:178
 msgid "Japanese Envelope Chou #4 Rotated"
 msgstr "japonska kuverta Čou #4 rotirano"
 
-#: ../src/common/paper.cpp:165
+#: ../src/common/paper.cpp:162
 msgid "Japanese Envelope Kaku #2"
 msgstr "japonska kuverta Kaku #2"
 
-#: ../src/common/paper.cpp:178
+#: ../src/common/paper.cpp:175
 msgid "Japanese Envelope Kaku #2 Rotated"
 msgstr "japonska kuverta Kaku #2 rotirano"
 
-#: ../src/common/paper.cpp:166
+#: ../src/common/paper.cpp:163
 msgid "Japanese Envelope Kaku #3"
 msgstr "japonska kuverta Kaku #3"
 
-#: ../src/common/paper.cpp:179
+#: ../src/common/paper.cpp:176
 msgid "Japanese Envelope Kaku #3 Rotated"
 msgstr "japonska kuverta Kaku #3 rotirano"
 
-#: ../src/common/paper.cpp:185
+#: ../src/common/paper.cpp:182
 msgid "Japanese Envelope You #4"
 msgstr "japonska kuverta Ju #4"
 
-#: ../src/common/paper.cpp:186
+#: ../src/common/paper.cpp:183
 msgid "Japanese Envelope You #4 Rotated"
 msgstr "japonska kuverta Ju #4 rotirano"
 
-#: ../src/common/paper.cpp:138
+#: ../src/common/paper.cpp:135
 msgid "Japanese Postcard 100 x 148 mm"
 msgstr "japonska razglednica, 100 x 148 mm"
 
-#: ../src/common/paper.cpp:175
+#: ../src/common/paper.cpp:172
 msgid "Japanese Postcard Rotated 148 x 100 mm"
 msgstr "japonska razglednica rotirano, 148 x 100 mm"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "Jump to"
 msgstr "Skoči na"
 
-#: ../src/common/stockitem.cpp:171
+#: ../src/common/stockitem.cpp:168
 msgid "Justified"
 msgstr "Poravnano"
 
-#: ../src/richtext/richtextindentspage.cpp:155
-#: ../src/richtext/richtextindentspage.cpp:157
 #: ../src/richtext/richtextliststylepage.cpp:344
 #: ../src/richtext/richtextliststylepage.cpp:346
+#: ../src/richtext/richtextindentspage.cpp:155
+#: ../src/richtext/richtextindentspage.cpp:157
 msgid "Justify text left and right."
 msgstr "Poravnaj besedilo levo in desno."
 
-#: ../src/common/fmapbase.cpp:163
+#: ../src/common/fmapbase.cpp:160
 msgid "KOI8-R"
 msgstr "KOI8-R"
 
-#: ../src/common/fmapbase.cpp:164
+#: ../src/common/fmapbase.cpp:161
 msgid "KOI8-U"
 msgstr "KOI8-U"
 
-#: ../src/common/accelcmn.cpp:265 ../src/common/accelcmn.cpp:347
+#: ../src/common/accelcmn.cpp:279 ../src/common/accelcmn.cpp:364
 msgid "KP_"
 msgstr "ŠT_"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "KP_Add"
 msgstr "ŠT_Dodaj"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "KP_Begin"
 msgstr "ŠT_Začni"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "KP_Decimal"
 msgstr "ŠT_Vejica"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 msgid "KP_Delete"
 msgstr "ŠT_Brisalka"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "KP_Divide"
 msgstr "ŠT_Deli"
 
 # html/htmlwin.cpp:216
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 msgid "KP_Down"
 msgstr "ŠT_Navzdol"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "KP_End"
 msgstr "ŠT_Konec"
 
 # generic/prntdlgg.cpp:113
 # generic/prntdlgg.cpp:127
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "KP_Enter"
 msgstr "ŠT_Vnašalka"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "KP_Equal"
 msgstr "ŠT_Enako"
 
+#: ../src/common/accelcmn.cpp:276 ../src/common/accelcmn.cpp:361
+msgid "KP_F"
+msgstr ""
+
 # generic/dirdlgg.cpp:212
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 msgid "KP_Home"
 msgstr "ŠT_Začetek"
 
 # html/helpfrm.cpp:372
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 msgid "KP_Insert"
 msgstr "ŠT_Vstavljalka"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "KP_Left"
 msgstr "ŠT_Levo"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "KP_Multiply"
 msgstr "ŠT_Množi"
 
 # msw/mdi.cpp:188
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:99
+#: ../src/common/accelcmn.cpp:97
 msgid "KP_Next"
 msgstr "ŠT_Naslednji"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "KP_PageDown"
 msgstr "ŠT_Naslednjastran"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "KP_PageUp"
 msgstr "ŠT_Prejšnjastran"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:98
+#: ../src/common/accelcmn.cpp:96
 msgid "KP_Prior"
 msgstr "ŠT_Prejšnji"
 
 # generic/fontdlgg.cpp:216
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 msgid "KP_Right"
 msgstr "ŠT_Desno"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "KP_Separator"
 msgstr "ŠT_Ločilo"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "KP_Space"
 msgstr "ŠT_Preslednica"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "KP_Subtract"
 msgstr "ŠT_Odštej"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "KP_Tab"
 msgstr "ŠT_Tabulatorka"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "KP_Up"
 msgstr "ŠT_Navzgor"
 
@@ -5255,24 +5379,39 @@ msgstr "ŠT_Navzgor"
 msgid "L&ine spacing:"
 msgstr "&Razmik med vrsticami:"
 
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "napaka pri stiskanju"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "napaka pri razširjanju"
+
 # generic/dcpsg.cpp:2262
 # generic/prntdlgg.cpp:441
 # generic/prntdlgg.cpp:637
-#: ../src/generic/prntdlgg.cpp:613 ../src/generic/prntdlgg.cpp:868
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:861
 msgid "Landscape"
 msgstr "Ležeče"
 
 # common/cmdline.cpp:912
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "Last"
 msgstr "Zadnji"
 
 # html/helpfrm.cpp:515
-#: ../src/common/prntbase.cpp:1572
+#: ../src/common/prntbase.cpp:1597
 msgid "Last page"
 msgstr "Zadnja stran"
 
-#: ../src/common/log.cpp:305
+#: ../src/common/log.cpp:324
 #, c-format
 msgid "Last repeated message (\"%s\", %u time) wasn't output"
 msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
@@ -5281,95 +5420,95 @@ msgstr[1] "Zadnje ponovljeno sporočilo (»%s«, %u-krat) ni bilo izpisano"
 msgstr[2] "Zadnje ponovljeno sporočilo (»%s«, %u-krat) ni bilo izpisano"
 msgstr[3] "Zadnje ponovljeno sporočilo (»%s«, %u-krat) ni bilo izpisano"
 
-#: ../src/common/paper.cpp:103
+#: ../src/common/paper.cpp:100
 msgid "Ledger, 17 x 11 in"
 msgstr "Ledger, 17 x 11 in"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6146
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:58 ../src/generic/datavgen.cpp:6951
+#: ../src/richtext/richtextsizepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:252
 #: ../src/richtext/richtextliststylepage.cpp:253
 #: ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
-#: ../src/richtext/richtextsizepage.cpp:249 ../src/common/accelcmn.cpp:61
 msgid "Left"
 msgstr "Levo"
 
-#: ../src/richtext/richtextindentspage.cpp:204
 #: ../src/richtext/richtextliststylepage.cpp:390
+#: ../src/richtext/richtextindentspage.cpp:204
 msgid "Left (&first line):"
 msgstr "Levo (&prva vrstica):"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1761
+#: ../src/propgrid/advprops.cpp:1662
 msgid "Left Button"
 msgstr "Levi gumb"
 
 # generic/prntdlgg.cpp:649
-#: ../src/generic/prntdlgg.cpp:880
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Left margin (mm):"
 msgstr "Levi rob (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:141
-#: ../src/richtext/richtextindentspage.cpp:143
 #: ../src/richtext/richtextliststylepage.cpp:330
 #: ../src/richtext/richtextliststylepage.cpp:332
+#: ../src/richtext/richtextindentspage.cpp:141
+#: ../src/richtext/richtextindentspage.cpp:143
 msgid "Left-align text."
 msgstr "Levo poravnano besedilo."
 
-#: ../src/common/paper.cpp:144
+#: ../src/common/paper.cpp:141
 msgid "Legal Extra 9 1/2 x 15 in"
 msgstr "Legal Extra, 9 1/2 x 15 pal."
 
-#: ../src/common/paper.cpp:96
+#: ../src/common/paper.cpp:93
 msgid "Legal, 8 1/2 x 14 in"
 msgstr "Legal, 8 1/2 x 14 pal."
 
-#: ../src/common/paper.cpp:143
+#: ../src/common/paper.cpp:140
 msgid "Letter Extra 9 1/2 x 12 in"
 msgstr "Letter Extra, 9 1/2 x 12 pal."
 
-#: ../src/common/paper.cpp:149
+#: ../src/common/paper.cpp:146
 msgid "Letter Extra Transverse 9.275 x 12 in"
 msgstr "Letter Extra prečno, 9,275 x 12 pal."
 
-#: ../src/common/paper.cpp:152
+#: ../src/common/paper.cpp:149
 msgid "Letter Plus 8 1/2 x 12.69 in"
 msgstr "Letter Plus, 8 1/2 x 12,69 pal."
 
-#: ../src/common/paper.cpp:169
+#: ../src/common/paper.cpp:166
 msgid "Letter Rotated 11 x 8 1/2 in"
 msgstr "Letter rotirano, 11 x 8 1/2 pal."
 
-#: ../src/common/paper.cpp:101
+#: ../src/common/paper.cpp:98
 msgid "Letter Small, 8 1/2 x 11 in"
 msgstr "Letter Small, 8 1/2 x 11 pal."
 
-#: ../src/common/paper.cpp:147
+#: ../src/common/paper.cpp:144
 msgid "Letter Transverse 8 1/2 x 11 in"
 msgstr "Letter prečno, 8 1/2 x 11 pal."
 
-#: ../src/common/paper.cpp:95
+#: ../src/common/paper.cpp:92
 msgid "Letter, 8 1/2 x 11 in"
 msgstr "Letter, 8 1/2 x 11 pal."
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "License"
 msgstr "Licenca"
 
 # generic/fontdlgg.cpp:216
-#: ../src/generic/fontdlgg.cpp:332
+#: ../src/generic/fontdlgg.cpp:328
 msgid "Light"
 msgstr "Svetlo"
 
-#: ../src/propgrid/advprops.cpp:1608
+#: ../src/propgrid/advprops.cpp:1514
 msgid "Lime"
 msgstr "Limetna"
 
-#: ../src/generic/helpext.cpp:294
+#: ../src/generic/helpext.cpp:292
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr "Vrstica %lu datoteke \"%s\" ima neveljavno skladnjo; preskočeno."
@@ -5378,15 +5517,15 @@ msgstr "Vrstica %lu datoteke \"%s\" ima neveljavno skladnjo; preskočeno."
 msgid "Line spacing:"
 msgstr "Razmik med vrsticami:"
 
-#: ../src/html/chm.cpp:838
+#: ../src/html/chm.cpp:829
 msgid "Link contained '//', converted to absolute link."
 msgstr "Povezava je vsebovala '//', pretvorjeno nazaj v absolutno povezavo."
 
-#: ../src/richtext/richtextformatdlg.cpp:364
+#: ../src/richtext/richtextformatdlg.cpp:357
 msgid "List Style"
 msgstr "Slog seznama"
 
-#: ../src/richtext/richtextstyles.cpp:1064
+#: ../src/richtext/richtextstyles.cpp:1061
 msgid "List styles"
 msgstr "Slogi seznama"
 
@@ -5403,22 +5542,22 @@ msgstr "Izpiše pisave, ki so na voljo."
 
 # generic/filedlgg.cpp:1270
 # msw/filedlg.cpp:483
-#: ../src/common/fldlgcmn.cpp:340
+#: ../src/common/fldlgcmn.cpp:337
 #, c-format
 msgid "Load %s file"
 msgstr "Naloži datoteko %s"
 
 # html/htmlwin.cpp:187
-#: ../src/html/htmlwin.cpp:597
+#: ../src/html/htmlwin.cpp:600
 msgid "Loading : "
 msgstr "Nalaganje: "
 
-#: ../src/unix/snglinst.cpp:246
+#: ../src/unix/snglinst.cpp:243
 #, c-format
 msgid "Lock file '%s' has incorrect owner."
 msgstr "Zaklenjena datoteka '%s' ima nepravega lastnika."
 
-#: ../src/unix/snglinst.cpp:251
+#: ../src/unix/snglinst.cpp:248
 #, c-format
 msgid "Lock file '%s' has incorrect permissions."
 msgstr "Zaklenjena datoteka '%s' ima nepravilna dovoljenja."
@@ -5428,7 +5567,7 @@ msgstr "Zaklenjena datoteka '%s' ima nepravilna dovoljenja."
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 # generic/logg.cpp:538
-#: ../src/generic/logg.cpp:576
+#: ../src/generic/logg.cpp:573
 #, c-format
 msgid "Log saved to the file '%s'."
 msgstr "Dnevnik je bil shranjen v datoteko »%s«."
@@ -5443,11 +5582,11 @@ msgstr "Male črke"
 msgid "Lower case roman numerals"
 msgstr "Majhne rimske številke"
 
-#: ../src/gtk/mdi.cpp:422 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk1/mdi.cpp:431 ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "Otrok MDI"
 
-#: ../src/msw/helpchm.cpp:56
+#: ../src/msw/helpchm.cpp:53
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -5455,192 +5594,192 @@ msgstr ""
 "Funkcije MS HTML Help niso na voljo, ker knjižnica MS HTML Help ni nameščena "
 "na tem računalniku. Prosimo, namestite jo."
 
-#: ../src/univ/themes/win32.cpp:3754
+#: ../src/univ/themes/win32.cpp:3751
 msgid "Ma&ximize"
 msgstr "Po&večaj"
 
-#: ../src/common/fmapbase.cpp:203
+#: ../src/common/fmapbase.cpp:200
 msgid "MacArabic"
 msgstr "Mac, arabski"
 
-#: ../src/common/fmapbase.cpp:222
+#: ../src/common/fmapbase.cpp:219
 msgid "MacArmenian"
 msgstr "Mac, armenski"
 
-#: ../src/common/fmapbase.cpp:211
+#: ../src/common/fmapbase.cpp:208
 msgid "MacBengali"
 msgstr "Mac, bengalski"
 
-#: ../src/common/fmapbase.cpp:217
+#: ../src/common/fmapbase.cpp:214
 msgid "MacBurmese"
 msgstr "Mac, burmanski"
 
-#: ../src/common/fmapbase.cpp:236
+#: ../src/common/fmapbase.cpp:233
 msgid "MacCeltic"
 msgstr "Mac, keltski"
 
-#: ../src/common/fmapbase.cpp:227
+#: ../src/common/fmapbase.cpp:224
 msgid "MacCentralEurRoman"
 msgstr "Mac, srednjeevropski, latinični"
 
-#: ../src/common/fmapbase.cpp:223
+#: ../src/common/fmapbase.cpp:220
 msgid "MacChineseSimp"
 msgstr "Mac, kitajski poenostavljeni"
 
-#: ../src/common/fmapbase.cpp:201
+#: ../src/common/fmapbase.cpp:198
 msgid "MacChineseTrad"
 msgstr "Mac, kitajski tradicionalni"
 
-#: ../src/common/fmapbase.cpp:233
+#: ../src/common/fmapbase.cpp:230
 msgid "MacCroatian"
 msgstr "Mac, hrvaški"
 
-#: ../src/common/fmapbase.cpp:206
+#: ../src/common/fmapbase.cpp:203
 msgid "MacCyrillic"
 msgstr "Mac, cirilica"
 
-#: ../src/common/fmapbase.cpp:207
+#: ../src/common/fmapbase.cpp:204
 msgid "MacDevanagari"
 msgstr "Mac, devanagarski"
 
-#: ../src/common/fmapbase.cpp:231
+#: ../src/common/fmapbase.cpp:228
 msgid "MacDingbats"
 msgstr "Mac, znakovni"
 
-#: ../src/common/fmapbase.cpp:226
+#: ../src/common/fmapbase.cpp:223
 msgid "MacEthiopic"
 msgstr "Mac, etiopski"
 
-#: ../src/common/fmapbase.cpp:229
+#: ../src/common/fmapbase.cpp:226
 msgid "MacExtArabic"
 msgstr "Mac, arabski, razširjeni"
 
-#: ../src/common/fmapbase.cpp:237
+#: ../src/common/fmapbase.cpp:234
 msgid "MacGaelic"
 msgstr "Mac, galski"
 
-#: ../src/common/fmapbase.cpp:221
+#: ../src/common/fmapbase.cpp:218
 msgid "MacGeorgian"
 msgstr "Mac, gruzijski"
 
-#: ../src/common/fmapbase.cpp:205
+#: ../src/common/fmapbase.cpp:202
 msgid "MacGreek"
 msgstr "Mac, grški"
 
-#: ../src/common/fmapbase.cpp:209
+#: ../src/common/fmapbase.cpp:206
 msgid "MacGujarati"
 msgstr "Mac, gudžaratski"
 
-#: ../src/common/fmapbase.cpp:208
+#: ../src/common/fmapbase.cpp:205
 msgid "MacGurmukhi"
 msgstr "Mac, gurmuški"
 
-#: ../src/common/fmapbase.cpp:204
+#: ../src/common/fmapbase.cpp:201
 msgid "MacHebrew"
 msgstr "Mac, hebrejski"
 
-#: ../src/common/fmapbase.cpp:234
+#: ../src/common/fmapbase.cpp:231
 msgid "MacIcelandic"
 msgstr "Mac, islandski"
 
-#: ../src/common/fmapbase.cpp:200
+#: ../src/common/fmapbase.cpp:197
 msgid "MacJapanese"
 msgstr "Mac, japonski"
 
-#: ../src/common/fmapbase.cpp:214
+#: ../src/common/fmapbase.cpp:211
 msgid "MacKannada"
 msgstr "Mac, kanareški"
 
-#: ../src/common/fmapbase.cpp:238
+#: ../src/common/fmapbase.cpp:235
 msgid "MacKeyboardGlyphs"
 msgstr "Mac, pismenke tipkovnice"
 
-#: ../src/common/fmapbase.cpp:218
+#: ../src/common/fmapbase.cpp:215
 msgid "MacKhmer"
 msgstr "Mac, kmerski"
 
-#: ../src/common/fmapbase.cpp:202
+#: ../src/common/fmapbase.cpp:199
 msgid "MacKorean"
 msgstr "Mac, korejski"
 
-#: ../src/common/fmapbase.cpp:220
+#: ../src/common/fmapbase.cpp:217
 msgid "MacLaotian"
 msgstr "Mac, laoški"
 
-#: ../src/common/fmapbase.cpp:215
+#: ../src/common/fmapbase.cpp:212
 msgid "MacMalayalam"
 msgstr "Mac, malajalamski"
 
-#: ../src/common/fmapbase.cpp:225
+#: ../src/common/fmapbase.cpp:222
 msgid "MacMongolian"
 msgstr "Mac, mongolski"
 
-#: ../src/common/fmapbase.cpp:210
+#: ../src/common/fmapbase.cpp:207
 msgid "MacOriya"
 msgstr "Mac, orijski"
 
 # generic/fontdlgg.cpp:206
-#: ../src/common/fmapbase.cpp:199
+#: ../src/common/fmapbase.cpp:196
 msgid "MacRoman"
 msgstr "Mac, latinični"
 
 # generic/fontdlgg.cpp:206
-#: ../src/common/fmapbase.cpp:235
+#: ../src/common/fmapbase.cpp:232
 msgid "MacRomanian"
 msgstr "Mac, romunski"
 
-#: ../src/common/fmapbase.cpp:216
+#: ../src/common/fmapbase.cpp:213
 msgid "MacSinhalese"
 msgstr "Mac, sinhalski"
 
-#: ../src/common/fmapbase.cpp:230
+#: ../src/common/fmapbase.cpp:227
 msgid "MacSymbol"
 msgstr "Mac, simbolni"
 
-#: ../src/common/fmapbase.cpp:212
+#: ../src/common/fmapbase.cpp:209
 msgid "MacTamil"
 msgstr "Mac, tamilski"
 
-#: ../src/common/fmapbase.cpp:213
+#: ../src/common/fmapbase.cpp:210
 msgid "MacTelugu"
 msgstr "Mac, teluški"
 
-#: ../src/common/fmapbase.cpp:219
+#: ../src/common/fmapbase.cpp:216
 msgid "MacThai"
 msgstr "Mac, tajski"
 
-#: ../src/common/fmapbase.cpp:224
+#: ../src/common/fmapbase.cpp:221
 msgid "MacTibetan"
 msgstr "Mac, tibetanski"
 
-#: ../src/common/fmapbase.cpp:232
+#: ../src/common/fmapbase.cpp:229
 msgid "MacTurkish"
 msgstr "Mac, turški"
 
-#: ../src/common/fmapbase.cpp:228
+#: ../src/common/fmapbase.cpp:225
 msgid "MacVietnamese"
 msgstr "Mac, vietnamski"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1762
+#: ../src/propgrid/advprops.cpp:1663
 msgid "Magnifier"
 msgstr "Povečevalo"
 
 # generic/dirdlgg.cpp:191
-#: ../src/propgrid/advprops.cpp:2143
+#: ../src/propgrid/advprops.cpp:2050
 msgid "Make a selection:"
 msgstr "Opravite izbor:"
 
-#: ../src/richtext/richtextformatdlg.cpp:374
+#: ../src/richtext/richtextformatdlg.cpp:367
 #: ../src/richtext/richtextmarginspage.cpp:171
 msgid "Margins"
 msgstr "Robovi"
 
-#: ../src/propgrid/advprops.cpp:1595
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Maroon"
 msgstr "Kostanjeva"
 
-#: ../src/generic/fdrepdlg.cpp:147
+#: ../src/generic/fdrepdlg.cpp:144
 msgid "Match case"
 msgstr "Ujemanje velikosti črk"
 
@@ -5653,41 +5792,41 @@ msgstr "Najv. višina:"
 msgid "Max width:"
 msgstr "Najv. širina:"
 
-#: ../src/unix/mediactrl.cpp:947
+#: ../src/unix/mediactrl.cpp:972
 #, c-format
 msgid "Media playback error: %s"
 msgstr "Napaka pri predvajanju datoteke: %s"
 
 # common/fs_mem.cpp:144
-#: ../src/common/fs_mem.cpp:175
+#: ../src/common/fs_mem.cpp:170
 #, c-format
 msgid "Memory VFS already contains file '%s'!"
 msgstr "Spominski VFS že vsebuje datoteko »%s«!"
 
 #. TRANSLATORS: Name of keyboard key
 #. TRANSLATORS: Keyword of system colour
-#: ../src/common/accelcmn.cpp:73 ../src/propgrid/advprops.cpp:889
+#: ../src/common/accelcmn.cpp:70 ../src/propgrid/advprops.cpp:790
 msgid "Menu"
 msgstr "Meni"
 
-#: ../src/common/msgout.cpp:124
+#: ../src/common/msgout.cpp:121
 msgid "Message"
 msgstr "Sporočilo"
 
-#: ../src/univ/themes/metal.cpp:168
+#: ../src/univ/themes/metal.cpp:165
 msgid "Metal theme"
 msgstr "Metalna tema"
 
-#: ../src/msw/ole/automtn.cpp:652
+#: ../src/msw/ole/automtn.cpp:643
 msgid "Method or property not found."
 msgstr "Metode ali lastnosti ni mogoče najti."
 
-#: ../src/univ/themes/win32.cpp:3752
+#: ../src/univ/themes/win32.cpp:3749
 msgid "Mi&nimize"
 msgstr "Po&manjšaj"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1763
+#: ../src/propgrid/advprops.cpp:1664
 msgid "Middle Button"
 msgstr "Srednji gumb"
 
@@ -5699,37 +5838,42 @@ msgstr "Najm. širina:"
 msgid "Min width:"
 msgstr "Najm. širina:"
 
-#: ../src/msw/ole/automtn.cpp:668
+#: ../src/osx/cocoa/menu.mm:281
+#, fuzzy
+msgid "Minimize"
+msgstr "Po&manjšaj"
+
+#: ../src/msw/ole/automtn.cpp:659
 msgid "Missing a required parameter."
 msgstr "Zahtevani parameter manjka."
 
 # generic/fontdlgg.cpp:208
-#: ../src/generic/fontdlgg.cpp:324
+#: ../src/generic/fontdlgg.cpp:320
 msgid "Modern"
 msgstr "Sodobno"
 
-#: ../src/generic/filectrlg.cpp:427
+#: ../src/generic/filectrlg.cpp:423
 msgid "Modified"
 msgstr "Spremenjeno"
 
-#: ../src/common/module.cpp:133
+#: ../src/common/module.cpp:130
 #, c-format
 msgid "Module \"%s\" initialization failed"
 msgstr "Inicializacija modula \"%s\" ni uspela"
 
-#: ../src/common/paper.cpp:131
+#: ../src/common/paper.cpp:128
 msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
 msgstr "kuverta Monarch, 3 7/8 x 7 1/2 pal."
 
-#: ../src/msw/fswatcher.cpp:143
+#: ../src/msw/fswatcher.cpp:140
 msgid "Monitoring individual files for changes is not supported currently."
 msgstr "Spremljanje posameznih datotek za spremembe trenutno ni podprto."
 
-#: ../src/generic/editlbox.cpp:172
+#: ../src/generic/editlbox.cpp:160
 msgid "Move down"
 msgstr "Premakni navzdol"
 
-#: ../src/generic/editlbox.cpp:171
+#: ../src/generic/editlbox.cpp:155
 msgid "Move up"
 msgstr "Premakni navzgor"
 
@@ -5743,109 +5887,115 @@ msgstr "Premakne predmet v naslednji odstavek."
 msgid "Moves the object to the previous paragraph."
 msgstr "Premakne predmet v prejšnji odstavek."
 
-#: ../src/richtext/richtextbuffer.cpp:9966
+#: ../src/richtext/richtextbuffer.cpp:9963
 msgid "Multiple Cell Properties"
 msgstr "Lastnosti več vrstic"
 
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:82
+#, fuzzy
+msgid "Multiply"
+msgstr "ŠT_Množi"
+
 # generic/filedlgg.cpp:533
-#: ../src/generic/filectrlg.cpp:424
+#: ../src/generic/filectrlg.cpp:420
 msgid "Name"
 msgstr "Ime"
 
-#: ../src/propgrid/advprops.cpp:1596
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Navy"
 msgstr "Mornarska"
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "Network"
 msgstr "Omrežje"
 
 # msw/mdi.cpp:188
-#: ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173
 msgid "New"
 msgstr "Nov"
 
-#: ../src/richtext/richtextstyledlg.cpp:243
+#: ../src/richtext/richtextstyledlg.cpp:239
 msgid "New &Box Style..."
 msgstr "Nov slog po&lja ..."
 
-#: ../src/richtext/richtextstyledlg.cpp:225
+#: ../src/richtext/richtextstyledlg.cpp:221
 msgid "New &Character Style..."
 msgstr "Nov &znakovni slog ..."
 
-#: ../src/richtext/richtextstyledlg.cpp:237
+#: ../src/richtext/richtextstyledlg.cpp:233
 msgid "New &List Style..."
 msgstr "Nov &seznamski slog ..."
 
-#: ../src/richtext/richtextstyledlg.cpp:231
+#: ../src/richtext/richtextstyledlg.cpp:227
 msgid "New &Paragraph Style..."
 msgstr "Nov slog &odstavka ..."
 
-#: ../src/richtext/richtextstyledlg.cpp:606
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:654
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:820
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:893
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:934
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:602
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:650
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:816
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:889
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:930
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "New Style"
 msgstr "Nov slog"
 
-#: ../src/generic/editlbox.cpp:169
+#: ../src/generic/editlbox.cpp:139
 msgid "New item"
 msgstr "Nov element"
 
 # generic/filedlgg.cpp:610
-#: ../src/generic/dirdlgg.cpp:297 ../src/generic/dirdlgg.cpp:307
-#: ../src/generic/filectrlg.cpp:618 ../src/generic/filectrlg.cpp:627
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+#: ../src/generic/dirdlgg.cpp:294 ../src/generic/dirdlgg.cpp:304
 msgid "NewName"
 msgstr "NovoIme"
 
 # html/helpfrm.cpp:515
-#: ../src/common/prntbase.cpp:1567 ../src/html/helpwnd.cpp:665
+#: ../src/common/prntbase.cpp:1592 ../src/html/helpwnd.cpp:663
 msgid "Next page"
 msgstr "Naslednja stran"
 
 # common/dlgcmn.cpp:111
 # common/dlgcmn.cpp:121
-#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:177
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:174
 #: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Ne"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1764
+#: ../src/propgrid/advprops.cpp:1665
 msgid "No Entry"
 msgstr "Ni vnosa"
 
 # common/image.cpp:766
 # common/image.cpp:800
-#: ../src/generic/animateg.cpp:150
+#: ../src/generic/animateg.cpp:133
 #, c-format
 msgid "No animation handler for type %ld defined."
 msgstr "Ta vrsto %ld ni določen noben upravljavec animacije."
 
 # common/image.cpp:766
 # common/image.cpp:800
-#: ../src/dfb/bitmap.cpp:642 ../src/dfb/bitmap.cpp:676
+#: ../src/dfb/bitmap.cpp:639 ../src/dfb/bitmap.cpp:673
 #, c-format
 msgid "No bitmap handler for type %d defined."
 msgstr "Za bitne slike vrste %d ni določen noben upravljalec slik."
 
-#: ../src/common/utilscmn.cpp:1077
+#: ../src/common/utilscmn.cpp:1095
 msgid "No default application configured for HTML files."
 msgstr "Za datoteke HTML ni nastavljen privzeti program."
 
 # generic/helphtml.cpp:314
-#: ../src/generic/helpext.cpp:445
+#: ../src/generic/helpext.cpp:443
 msgid "No entries found."
 msgstr "Vnosa ni mogoče najti."
 
 # common/fontmap.cpp:716
-#: ../src/common/fontmap.cpp:421
+#: ../src/common/fontmap.cpp:418
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found,\n"
@@ -5858,7 +6008,7 @@ msgstr ""
 "Želite izbrati to kodiranje (sicer boste morali izbrati drugega)?"
 
 # common/fontmap.cpp:716
-#: ../src/common/fontmap.cpp:426
+#: ../src/common/fontmap.cpp:423
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found.\n"
@@ -5870,217 +6020,216 @@ msgstr ""
 "(secer besedilo ne bo prikazano pravilno)?"
 
 # common/image.cpp:758
-#: ../src/generic/animateg.cpp:142
+#: ../src/generic/animateg.cpp:125
 msgid "No handler found for animation type."
 msgstr "Upravljalca za vrsto animacije ni mogoče najti."
 
 # common/image.cpp:758
-#: ../src/common/image.cpp:2728
+#: ../src/common/image.cpp:2823
 msgid "No handler found for image type."
 msgstr "Upravljalca za vrsto slike ni mogoče najti."
 
 # common/image.cpp:766
 # common/image.cpp:800
-#: ../src/common/image.cpp:2736 ../src/common/image.cpp:2848
-#: ../src/common/image.cpp:2901
+#: ../src/common/image.cpp:2831 ../src/common/image.cpp:2954
+#: ../src/common/image.cpp:3020
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "Za vrsto %d ni določen noben upravljalec slik."
 
 # common/image.cpp:784
 # common/image.cpp:816
-#: ../src/common/image.cpp:2871 ../src/common/image.cpp:2915
+#: ../src/common/image.cpp:2986 ../src/common/image.cpp:3034
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "Za vrsto %s ni določen noben upravljalec slik."
 
 # html/helpfrm.cpp:628
-#: ../src/html/helpwnd.cpp:858
+#: ../src/html/helpwnd.cpp:856
 msgid "No matching page found yet"
 msgstr "Ujemajoča stran še ni najdena."
 
 # generic/helphtml.cpp:314
-#: ../src/unix/sound.cpp:81
+#: ../src/unix/sound.cpp:78
 msgid "No sound"
 msgstr "Brez zvoka"
 
-#: ../src/common/image.cpp:2277 ../src/common/image.cpp:2318
+#: ../src/common/image.cpp:2371 ../src/common/image.cpp:2412
 msgid "No unused colour in image being masked."
 msgstr "Nobena neuporabljena barva v sliki ni maskirana."
 
-#: ../src/common/image.cpp:3374
-msgid "No unused colour in image."
-msgstr "V sliki ni neuporabljene barve."
-
-#: ../src/generic/helpext.cpp:302
+#: ../src/generic/helpext.cpp:300
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "Ni veljavnih preslikav v datoteki \"%s\"."
 
-#: ../src/richtext/richtextborderspage.cpp:610
 #: ../src/richtext/richtextsizepage.cpp:248
 #: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:610
 msgid "None"
 msgstr "Brez"
 
-#: ../src/common/fmapbase.cpp:157
+#: ../src/common/fmapbase.cpp:154
 msgid "Nordic (ISO-8859-10)"
 msgstr "nordijsko (ISO-8859-10)"
 
 # generic/fontdlgg.cpp:212
 # generic/fontdlgg.cpp:215
-#: ../src/generic/fontdlgg.cpp:328 ../src/generic/fontdlgg.cpp:331
+#: ../src/generic/fontdlgg.cpp:324 ../src/generic/fontdlgg.cpp:327
 msgid "Normal"
 msgstr "Običajno"
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1261
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Običajna pisava<br>in <u>podčrtana</u>. "
 
 # html/helpfrm.cpp:881
-#: ../src/html/helpwnd.cpp:1205
+#: ../src/html/helpwnd.cpp:1203
 msgid "Normal font:"
 msgstr "Običajna pisava:"
 
-#: ../src/propgrid/props.cpp:1128
+#: ../src/propgrid/props.cpp:1115
 #, c-format
 msgid "Not %s"
 msgstr "Ni %s"
 
-# generic/tipdlg.cpp:138
-#: ../include/wx/filename.h:573 ../include/wx/filename.h:578
-msgid "Not available"
-msgstr "Ni na voljo"
+#: ../src/common/secretstore.cpp:168
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/webrequest.cpp:605
+msgid "Not enough free disk space for download."
+msgstr ""
 
 # generic/fontdlgg.cpp:242
 #: ../src/richtext/richtextfontpage.cpp:358
 msgid "Not underlined"
 msgstr "Nepodčrtano"
 
-#: ../src/common/paper.cpp:115
+#: ../src/common/paper.cpp:112
 msgid "Note, 8 1/2 x 11 in"
 msgstr "Note, 8 1/2 x 11 pal."
 
-#: ../src/generic/notifmsgg.cpp:132
+#: ../src/generic/notifmsgg.cpp:129
 msgid "Notice"
 msgstr "Obvestilo"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "Num *"
 msgstr "Št *"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "Num +"
 msgstr "Št +"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "Num ,"
 msgstr "Št ,"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "Num -"
 msgstr "Št -"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "Num ."
 msgstr "Št ."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "Num /"
 msgstr "Št /"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "Num ="
 msgstr "Št ="
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "Num Begin"
 msgstr "Št Začetek"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 msgid "Num Delete"
 msgstr "Št Brisalka"
 
 # html/htmlwin.cpp:216
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 msgid "Num Down"
 msgstr "Št Navzdol"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "Num End"
 msgstr "Št Konec"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "Num Enter"
 msgstr "Št Vnašalka"
 
 # generic/dirdlgg.cpp:212
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 msgid "Num Home"
 msgstr "Št Domov"
 
 # html/helpfrm.cpp:372
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 msgid "Num Insert"
 msgstr "Št Vstavi"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num Lock"
 msgstr "Zaklepalka številčnice"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "Num Page Down"
 msgstr "Št Naslednja stran"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "Num Page Up"
 msgstr "Št Prejšnja stran"
 
 # generic/fontdlgg.cpp:216
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 msgid "Num Right"
 msgstr "Št Desno"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "Num Space"
 msgstr "Št Preslednica"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "Num Tab"
 msgstr "Št Tabulatorka"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "Num Up"
 msgstr "Št Navzgor"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "Num left"
 msgstr "Št Levo"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num_lock"
 msgstr "Zakl_štev"
 
@@ -6098,13 +6247,13 @@ msgstr "Oštevilčen oris"
 # generic/prntdlgg.cpp:467
 # generic/proplist.cpp:511
 # html/helpfrm.cpp:909
-#: ../include/wx/msgdlg.h:278 ../src/richtext/richtextstyledlg.cpp:297
-#: ../src/common/stockitem.cpp:178 ../src/msw/msgdlg.cpp:454
-#: ../src/msw/msgdlg.cpp:747 ../src/gtk1/fontdlg.cpp:138
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:175
+#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/msgdlg.cpp:741 ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "V redu"
 
-#: ../src/msw/ole/automtn.cpp:692
+#: ../src/msw/ole/automtn.cpp:683
 #, c-format
 msgid "OLE Automation error in %s: %s"
 msgstr "Napaka pri avtomatizaciji OLE v %s: %s"
@@ -6114,15 +6263,15 @@ msgstr "Napaka pri avtomatizaciji OLE v %s: %s"
 msgid "Object Properties"
 msgstr "Lastnosti predmeta"
 
-#: ../src/msw/ole/automtn.cpp:660
+#: ../src/msw/ole/automtn.cpp:651
 msgid "Object implementation does not support named arguments."
 msgstr "Implementacija predmeta ne podpira imenovanih argumentov."
 
-#: ../src/common/xtixml.cpp:264
+#: ../src/common/xtixml.cpp:260
 msgid "Objects must have an id attribute"
 msgstr "Objekti morajo imeti atribut id"
 
-#: ../src/propgrid/advprops.cpp:1601
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Olive"
 msgstr "Oljčna"
 
@@ -6130,32 +6279,39 @@ msgstr "Oljčna"
 msgid "Opaci&ty:"
 msgstr "Pre&krivnost:"
 
-#: ../src/generic/colrdlgg.cpp:354
+#: ../src/generic/colrdlgg.cpp:374
 msgid "Opacity:"
 msgstr "Prekrivnost:"
 
-#: ../src/common/docview.cpp:1773 ../src/common/docview.cpp:1815
+#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
 msgid "Open File"
 msgstr "Odpri datoteko"
 
 # html/helpfrm.cpp:523
 # html/helpfrm.cpp:1183
-#: ../src/html/helpwnd.cpp:671 ../src/html/helpwnd.cpp:1554
+#: ../src/html/helpwnd.cpp:669 ../src/html/helpwnd.cpp:1552
 msgid "Open HTML document"
 msgstr "Odpri dokument HTML"
 
-#: ../src/generic/dbgrptg.cpp:163
+# html/helpfrm.cpp:523
+# html/helpfrm.cpp:1183
+#: ../src/common/stockitem.cpp:265
+#, fuzzy
+msgid "Open an existing document"
+msgstr "Odpri dokument HTML"
+
+#: ../src/generic/dbgrptg.cpp:160
 #, c-format
 msgid "Open file \"%s\""
 msgstr "Odpri datoteko \"%s\""
 
 # generic/logg.cpp:473
 # generic/logg.cpp:774
-#: ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176
 msgid "Open..."
 msgstr "Odpri ..."
 
-#: ../src/unix/glx11.cpp:506 ../src/msw/glcanvas.cpp:592
+#: ../src/msw/glcanvas.cpp:607 ../src/unix/glx11.cpp:513
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr "Gonilnik OpenGL ne podpira OpenGL 3.0 ali novejšega."
 
@@ -6163,45 +6319,45 @@ msgstr "Gonilnik OpenGL ne podpira OpenGL 3.0 ali novejšega."
 # generic/dirdlgg.cpp:605
 # generic/filedlgg.cpp:625
 # generic/filedlgg.cpp:744
-#: ../src/generic/dirctrlg.cpp:599 ../src/generic/dirdlgg.cpp:323
-#: ../src/generic/filectrlg.cpp:642 ../src/generic/filectrlg.cpp:786
+#: ../src/generic/dirctrlg.cpp:565 ../src/generic/filectrlg.cpp:638
+#: ../src/generic/filectrlg.cpp:782 ../src/generic/dirdlgg.cpp:320
 msgid "Operation not permitted."
 msgstr "Operacija ni dovoljena."
 
 # common/filefn.cpp:1086
-#: ../src/common/cmdline.cpp:900
+#: ../src/common/cmdline.cpp:896
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "Možnosti »%s« ni mogoče negirati."
 
 # common/cmdline.cpp:610
-#: ../src/common/cmdline.cpp:1064
+#: ../src/common/cmdline.cpp:1060
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "Možnost '%s' zahteva vrednost."
 
 # common/cmdline.cpp:671
-#: ../src/common/cmdline.cpp:1147
+#: ../src/common/cmdline.cpp:1143
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Možnosti '%s':'%s' ni mogoče pretvoriti v datum."
 
 # generic/prntdlgg.cpp:447
-#: ../src/generic/prntdlgg.cpp:618
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Možnosti"
 
-#: ../src/propgrid/advprops.cpp:1606
+#: ../src/propgrid/advprops.cpp:1512
 msgid "Orange"
 msgstr "Oranžna"
 
 # generic/prntdlgg.cpp:443
 # generic/prntdlgg.cpp:638
-#: ../src/generic/prntdlgg.cpp:615 ../src/generic/prntdlgg.cpp:869
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:862
 msgid "Orientation"
 msgstr "Usmeritev"
 
-#: ../src/common/windowid.cpp:242
+#: ../src/common/windowid.cpp:237
 msgid "Out of window IDs.  Recommend shutting down application."
 msgstr "Zmanjkalo je ID-jev za okna.  Priporočamo zaprtje programa."
 
@@ -6214,159 +6370,159 @@ msgstr "Oris"
 msgid "Outset"
 msgstr "Izraščeno"
 
-#: ../src/msw/ole/automtn.cpp:656
+#: ../src/msw/ole/automtn.cpp:647
 msgid "Overflow while coercing argument values."
 msgstr "Prekoračitev med prisiljevanjem vrednosti argumentov."
 
 # common/imagpcx.cpp:448
 # common/imagpcx.cpp:471
-#: ../src/common/imagpcx.cpp:457 ../src/common/imagpcx.cpp:480
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:479
 msgid "PCX: couldn't allocate memory"
 msgstr "PCX: pomnilnika ni mogoče alocirati."
 
 # common/imagpcx.cpp:447
-#: ../src/common/imagpcx.cpp:456
+#: ../src/common/imagpcx.cpp:455
 msgid "PCX: image format unsupported"
 msgstr "PCX: oblika zapisa slike ni podprt."
 
 # common/imagpcx.cpp:470
-#: ../src/common/imagpcx.cpp:479
+#: ../src/common/imagpcx.cpp:478
 msgid "PCX: invalid image"
 msgstr "PCX: neveljavna slika"
 
 # common/imagpcx.cpp:434
-#: ../src/common/imagpcx.cpp:442
+#: ../src/common/imagpcx.cpp:441
 msgid "PCX: this is not a PCX file."
 msgstr "PCX: to ni datoteka PCX."
 
 # common/imagpcx.cpp:450
 # common/imagpcx.cpp:472
-#: ../src/common/imagpcx.cpp:459 ../src/common/imagpcx.cpp:481
+#: ../src/common/imagpcx.cpp:458 ../src/common/imagpcx.cpp:480
 msgid "PCX: unknown error !!!"
 msgstr "PCX: neznana napaka!"
 
 # common/imagpcx.cpp:449
-#: ../src/common/imagpcx.cpp:458
+#: ../src/common/imagpcx.cpp:457
 msgid "PCX: version number too low"
 msgstr "PCX: številka različice prenizka"
 
 # common/imagpnm.cpp:96
-#: ../src/common/imagpnm.cpp:91
+#: ../src/common/imagpnm.cpp:89
 msgid "PNM: Couldn't allocate memory."
 msgstr "PNM: alokacija pomnilnika ni uspela."
 
 # common/imagpnm.cpp:80
-#: ../src/common/imagpnm.cpp:73
+#: ../src/common/imagpnm.cpp:71
 msgid "PNM: File format is not recognized."
 msgstr "PNM: datotečni zapis ni prepoznan."
 
 # common/imagpnm.cpp:112
-#: ../src/common/imagpnm.cpp:112 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
 #: ../src/common/imagpnm.cpp:156
 msgid "PNM: File seems truncated."
 msgstr "PNM: datoteka se zdi okrnjena."
 
-#: ../src/common/paper.cpp:187
+#: ../src/common/paper.cpp:184
 msgid "PRC 16K 146 x 215 mm"
 msgstr "PRC 16K, 146 x 215 mm"
 
-#: ../src/common/paper.cpp:200
+#: ../src/common/paper.cpp:197
 msgid "PRC 16K Rotated"
 msgstr "PRC 16K, rotirano"
 
-#: ../src/common/paper.cpp:188
+#: ../src/common/paper.cpp:185
 msgid "PRC 32K 97 x 151 mm"
 msgstr "PRC 32K, 97 x 151 mm"
 
-#: ../src/common/paper.cpp:201
+#: ../src/common/paper.cpp:198
 msgid "PRC 32K Rotated"
 msgstr "PRC 32K totirano"
 
-#: ../src/common/paper.cpp:189
+#: ../src/common/paper.cpp:186
 msgid "PRC 32K(Big) 97 x 151 mm"
 msgstr "PRC 32K(velik), 97 x 151 mm"
 
-#: ../src/common/paper.cpp:202
+#: ../src/common/paper.cpp:199
 msgid "PRC 32K(Big) Rotated"
 msgstr "PRC 32K(velik) rotirano"
 
-#: ../src/common/paper.cpp:190
+#: ../src/common/paper.cpp:187
 msgid "PRC Envelope #1 102 x 165 mm"
 msgstr "kuverta PRC #1, 102 x 165 mm"
 
-#: ../src/common/paper.cpp:203
+#: ../src/common/paper.cpp:200
 msgid "PRC Envelope #1 Rotated 165 x 102 mm"
 msgstr "kuverta PRC #1 rotirano, 165 x 102 mm"
 
-#: ../src/common/paper.cpp:199
+#: ../src/common/paper.cpp:196
 msgid "PRC Envelope #10 324 x 458 mm"
 msgstr "kuverta PRC #10, 324 x 458 mm"
 
-#: ../src/common/paper.cpp:212
+#: ../src/common/paper.cpp:209
 msgid "PRC Envelope #10 Rotated 458 x 324 mm"
 msgstr "kuverta PRC #10 rotirano, 458 x 324 mm"
 
-#: ../src/common/paper.cpp:191
+#: ../src/common/paper.cpp:188
 msgid "PRC Envelope #2 102 x 176 mm"
 msgstr "kuverta PRC #2, 102 x 176 mm"
 
-#: ../src/common/paper.cpp:204
+#: ../src/common/paper.cpp:201
 msgid "PRC Envelope #2 Rotated 176 x 102 mm"
 msgstr "kuverta PRC #2 rotirano, 176 x 102 mm"
 
-#: ../src/common/paper.cpp:192
+#: ../src/common/paper.cpp:189
 msgid "PRC Envelope #3 125 x 176 mm"
 msgstr "kuverta PRC #3, 125 x 176 mm"
 
-#: ../src/common/paper.cpp:205
+#: ../src/common/paper.cpp:202
 msgid "PRC Envelope #3 Rotated 176 x 125 mm"
 msgstr "kuverta PRC #3 rotirano, 176 x 125 mm"
 
-#: ../src/common/paper.cpp:193
+#: ../src/common/paper.cpp:190
 msgid "PRC Envelope #4 110 x 208 mm"
 msgstr "kuverta PRC #4, 110 x 208 mm"
 
-#: ../src/common/paper.cpp:206
+#: ../src/common/paper.cpp:203
 msgid "PRC Envelope #4 Rotated 208 x 110 mm"
 msgstr "kuverta PRC #4 rotirano, 208 x 110 mm"
 
-#: ../src/common/paper.cpp:194
+#: ../src/common/paper.cpp:191
 msgid "PRC Envelope #5 110 x 220 mm"
 msgstr "kuverta PRC #5, 110 x 220 mm"
 
-#: ../src/common/paper.cpp:207
+#: ../src/common/paper.cpp:204
 msgid "PRC Envelope #5 Rotated 220 x 110 mm"
 msgstr "kuverta PRC #5 rotirano, 220 x 110 mm"
 
-#: ../src/common/paper.cpp:195
+#: ../src/common/paper.cpp:192
 msgid "PRC Envelope #6 120 x 230 mm"
 msgstr "kuverta PRC #6, 120 x 230 mm"
 
-#: ../src/common/paper.cpp:208
+#: ../src/common/paper.cpp:205
 msgid "PRC Envelope #6 Rotated 230 x 120 mm"
 msgstr "kuverta PRC #6 rotirano, 230 x 120 mm"
 
-#: ../src/common/paper.cpp:196
+#: ../src/common/paper.cpp:193
 msgid "PRC Envelope #7 160 x 230 mm"
 msgstr "kuverta PRC #7, 160 x 230 mm"
 
-#: ../src/common/paper.cpp:209
+#: ../src/common/paper.cpp:206
 msgid "PRC Envelope #7 Rotated 230 x 160 mm"
 msgstr "kuverta PRC #7 rotirano, 230 x 160 mm"
 
-#: ../src/common/paper.cpp:197
+#: ../src/common/paper.cpp:194
 msgid "PRC Envelope #8 120 x 309 mm"
 msgstr "kuverta PRC #8, 120 x 309 mm"
 
-#: ../src/common/paper.cpp:210
+#: ../src/common/paper.cpp:207
 msgid "PRC Envelope #8 Rotated 309 x 120 mm"
 msgstr "kuverta PRC #8 rotirana, 309 x 120 mm"
 
-#: ../src/common/paper.cpp:198
+#: ../src/common/paper.cpp:195
 msgid "PRC Envelope #9 229 x 324 mm"
 msgstr "kuverta PRC #9, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:211
+#: ../src/common/paper.cpp:208
 msgid "PRC Envelope #9 Rotated 324 x 229 mm"
 msgstr "kuverta PRC #9 rotirano, 324 x 229 mm"
 
@@ -6375,100 +6531,104 @@ msgid "Padding"
 msgstr "Blazinjenje"
 
 # common/prntbase.cpp:731
-#: ../src/common/prntbase.cpp:2074
+#: ../src/common/prntbase.cpp:2096
 #, c-format
 msgid "Page %d"
 msgstr "Stran %d"
 
 # common/prntbase.cpp:729
-#: ../src/common/prntbase.cpp:2072
+#: ../src/common/prntbase.cpp:2094
 #, c-format
 msgid "Page %d of %d"
 msgstr "Stran %d od %d"
 
 # common/prntbase.cpp:731
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 msgid "Page Down"
 msgstr "Naslednja stran"
 
 # generic/prntdlgg.cpp:604
-#: ../src/gtk/print.cpp:826
+#: ../src/gtk/print.cpp:829
 msgid "Page Setup"
 msgstr "Nastavitev strani"
 
 # common/prntbase.cpp:731
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 msgid "Page Up"
 msgstr "Prejšnja stran"
 
 # generic/prntdlgg.cpp:604
-#: ../src/generic/prntdlgg.cpp:828 ../src/common/prntbase.cpp:484
+#: ../src/common/prntbase.cpp:479 ../src/generic/prntdlgg.cpp:821
 msgid "Page setup"
 msgstr "Nastavitev strani"
 
 # html/htmlwin.cpp:216
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 msgid "PageDown"
 msgstr "NaslStran"
 
 # generic/prntdlgg.cpp:164
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 msgid "PageUp"
 msgstr "PrejStran"
 
 # generic/prntdlgg.cpp:164
-#: ../src/generic/prntdlgg.cpp:216
+#: ../src/generic/prntdlgg.cpp:209
 msgid "Pages"
 msgstr "Strani"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1765
+#: ../src/propgrid/advprops.cpp:1666
 msgid "Paint Brush"
 msgstr "Čopič"
 
 # generic/prntdlgg.cpp:433
 # generic/prntdlgg.cpp:615
 # generic/prntdlgg.cpp:804
-#: ../src/generic/prntdlgg.cpp:602 ../src/generic/prntdlgg.cpp:801
-#: ../src/generic/prntdlgg.cpp:842 ../src/generic/prntdlgg.cpp:855
-#: ../src/generic/prntdlgg.cpp:1052 ../src/generic/prntdlgg.cpp:1057
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:794
+#: ../src/generic/prntdlgg.cpp:835 ../src/generic/prntdlgg.cpp:848
+#: ../src/generic/prntdlgg.cpp:1045 ../src/generic/prntdlgg.cpp:1050
 msgid "Paper size"
 msgstr "Velikost papirja"
 
-#: ../src/richtext/richtextstyles.cpp:1062
+#: ../src/richtext/richtextstyles.cpp:1059
 msgid "Paragraph styles"
 msgstr "Slogi odstavka"
 
-#: ../src/common/xtistrm.cpp:465
+#: ../src/common/xtistrm.cpp:462
 msgid "Passing a already registered object to SetObject"
 msgstr "Podajanje že registriranega objekta k SetObject"
 
-#: ../src/common/xtistrm.cpp:476
+#: ../src/common/xtistrm.cpp:473
 msgid "Passing an unknown object to GetObject"
 msgstr "Podajanje neznanega predmeta k GetObject"
 
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
 # common/cmdline.cpp:912
-#: ../src/richtext/richtextctrl.cpp:3513 ../src/common/stockitem.cpp:180
+#: ../src/common/stockitem.cpp:177 ../src/richtext/richtextctrl.cpp:3514
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Prilepi"
 
 # generic/dirdlgg.cpp:191
-#: ../src/common/stockitem.cpp:262
+#: ../src/common/stockitem.cpp:260
 msgid "Paste selection"
 msgstr "Prilepi izbor"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:74
+#: ../src/common/accelcmn.cpp:71
 msgid "Pause"
 msgstr "Prekinitev"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1766
+#: ../src/propgrid/advprops.cpp:1667
 msgid "Pencil"
 msgstr "Pisalo"
 
@@ -6478,22 +6638,22 @@ msgid "Peri&od"
 msgstr "Pi&ka"
 
 # generic/filedlgg.cpp:537
-#: ../src/generic/filectrlg.cpp:430
+#: ../src/generic/filectrlg.cpp:426
 msgid "Permissions"
 msgstr "Dovoljenja"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:60
+#: ../src/common/accelcmn.cpp:57
 msgid "PgDn"
 msgstr "Naslednja stran"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:59
+#: ../src/common/accelcmn.cpp:56
 msgid "PgUp"
 msgstr "Prejšnja stran"
 
 # html/helpfrm.cpp:512
-#: ../src/richtext/richtextbuffer.cpp:12868
+#: ../src/richtext/richtextbuffer.cpp:12863
 msgid "Picture Properties"
 msgstr "Lastnosti slike"
 
@@ -6507,51 +6667,51 @@ msgid "Please choose a valid font."
 msgstr "Prosimo, izberite veljavno pisavo."
 
 # generic/filedlgg.cpp:1092
-#: ../src/generic/filedlgg.cpp:357 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
 msgid "Please choose an existing file."
 msgstr "Prosimo, izberite obstoječo datoteko."
 
 # generic/filedlgg.cpp:1092
-#: ../src/html/helpwnd.cpp:800
+#: ../src/html/helpwnd.cpp:798
 msgid "Please choose the page to display:"
 msgstr "Prosimo, izberite stran za prikaz:"
 
 # msw/dialup.cpp:768
-#: ../src/msw/dialup.cpp:764
+#: ../src/msw/dialup.cpp:758
 msgid "Please choose which ISP do you want to connect to"
 msgstr ""
 "Prosimo, izberite ponudnika spletnih storitev, s katerim se želite povezati."
 
-#: ../src/common/headerctrlcmn.cpp:59
+#: ../src/common/headerctrlcmn.cpp:57
 msgid "Please select the columns to show and define their order:"
 msgstr "Izberite stolpce za prikaz in določite njihovo razvrstitev:"
 
-#: ../src/common/prntbase.cpp:538
+#: ../src/common/prntbase.cpp:533
 msgid "Please wait while printing..."
 msgstr "Prosimo, počakajte, dokler poteka tiskanje ..."
 
 # html/helpfrm.cpp:899
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1767
+#: ../src/propgrid/advprops.cpp:1668
 msgid "Point Left"
 msgstr "Usmeri levo"
 
 # generic/fontdlgg.cpp:216
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1768
+#: ../src/propgrid/advprops.cpp:1669
 msgid "Point Right"
 msgstr "Usmeri desno"
 
 # html/helpfrm.cpp:899
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:662
+#: ../src/propgrid/advprops.cpp:572
 msgid "Point Size"
 msgstr "Velikost točke"
 
 # generic/dcpsg.cpp:2261
 # generic/prntdlgg.cpp:440
 # generic/prntdlgg.cpp:636
-#: ../src/generic/prntdlgg.cpp:612 ../src/generic/prntdlgg.cpp:867
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:860
 msgid "Portrait"
 msgstr "Portet"
 
@@ -6561,186 +6721,195 @@ msgid "Position"
 msgstr "Položaj"
 
 # generic/prntdlgg.cpp:272
-#: ../src/generic/prntdlgg.cpp:298
+#: ../src/generic/prntdlgg.cpp:291
 msgid "PostScript file"
 msgstr "PostScript datoteka"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178 ../src/osx/cocoa/preferences.mm:303
 msgid "Preferences"
 msgstr "Možnosti"
 
-#: ../src/osx/menu_osx.cpp:568
+#: ../src/osx/menu_osx.cpp:460
 msgid "Preferences..."
 msgstr "Možnosti ..."
 
-#: ../src/common/prntbase.cpp:546
+#: ../src/common/prntbase.cpp:541
 msgid "Preparing"
 msgstr "Priprava"
 
 # html/helpfrm.cpp:903
-#: ../src/generic/fontdlgg.cpp:455 ../src/osx/carbon/fontdlg.cpp:390
-#: ../src/html/helpwnd.cpp:1222
+#: ../src/osx/carbon/fontdlg.cpp:387 ../src/generic/fontdlgg.cpp:452
+#: ../src/html/helpwnd.cpp:1220
 msgid "Preview:"
 msgstr "Predogled:"
 
 # html/helpfrm.cpp:512
-#: ../src/common/prntbase.cpp:1553 ../src/html/helpwnd.cpp:664
+#: ../src/common/prntbase.cpp:1578 ../src/html/helpwnd.cpp:662
 msgid "Previous page"
 msgstr "Prejšnja stran"
 
 # generic/prntdlgg.cpp:113
 # generic/prntdlgg.cpp:127
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/prntdlgg.cpp:143 ../src/generic/prntdlgg.cpp:157
-#: ../src/common/prntbase.cpp:426 ../src/common/prntbase.cpp:1541
-#: ../src/common/accelcmn.cpp:77 ../src/gtk/print.cpp:620
-#: ../src/gtk/print.cpp:638
+#: ../src/common/prntbase.cpp:421 ../src/common/prntbase.cpp:1566
+#: ../src/common/accelcmn.cpp:74 ../src/generic/prntdlgg.cpp:136
+#: ../src/generic/prntdlgg.cpp:150 ../src/gtk/print.cpp:616
+#: ../src/gtk/print.cpp:634
 msgid "Print"
 msgstr "Tiskanje"
 
 # common/docview.cpp:897
-#: ../include/wx/prntbase.h:399 ../src/common/docview.cpp:1268
+#: ../src/common/docview.cpp:1262
 msgid "Print Preview"
 msgstr "Predogled tiskanja"
 
 # common/prntbase.cpp:687
 # common/prntbase.cpp:711
-#: ../src/common/prntbase.cpp:2015 ../src/common/prntbase.cpp:2057
-#: ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2037 ../src/common/prntbase.cpp:2079
+#: ../src/common/prntbase.cpp:2087
 msgid "Print Preview Failure"
 msgstr "Napaka pri predogledu tiskanja"
 
 # generic/prntdlgg.cpp:172
-#: ../src/generic/prntdlgg.cpp:224
+#: ../src/generic/prntdlgg.cpp:217
 msgid "Print Range"
 msgstr "Obseg tiskanja"
 
 # generic/prntdlgg.cpp:408
 # generic/prntdlgg.cpp:415
-#: ../src/generic/prntdlgg.cpp:449
+#: ../src/generic/prntdlgg.cpp:442
 msgid "Print Setup"
 msgstr "Nastavitev tiskanja"
 
 # generic/prntdlgg.cpp:455
-#: ../src/generic/prntdlgg.cpp:621
+#: ../src/generic/prntdlgg.cpp:614
 msgid "Print in colour"
 msgstr "Bravno tiskanje"
 
+#: ../src/osx/webview_webkit.mm:260
+msgid "Print operation could not be initialized"
+msgstr ""
+
 # common/docview.cpp:897
-#: ../src/common/stockitem.cpp:182
+#: ../src/common/stockitem.cpp:179
 msgid "Print previe&w..."
 msgstr "Predogle&d tiskanja ..."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1256
 msgid "Print preview creation failed."
 msgstr "Tvorba predogleda tiskanja ni uspela."
 
 # common/docview.cpp:897
-#: ../src/common/stockitem.cpp:182
+#: ../src/common/stockitem.cpp:179
 msgid "Print preview..."
 msgstr "Predogled tiskanja ..."
 
 # generic/prntdlgg.cpp:457
-#: ../src/generic/prntdlgg.cpp:630
+#: ../src/generic/prntdlgg.cpp:623
 msgid "Print spooling"
 msgstr "Čakalna vrsta tiskanja"
 
 # html/helpfrm.cpp:529
-#: ../src/html/helpwnd.cpp:675
+#: ../src/html/helpwnd.cpp:673
 msgid "Print this page"
 msgstr "Natisni to stran"
 
 # generic/dcpsg.cpp:2265
 # generic/prntdlgg.cpp:150
-#: ../src/generic/prntdlgg.cpp:185
+#: ../src/generic/prntdlgg.cpp:178
 msgid "Print to File"
 msgstr "Pošli v datoteko"
 
 # common/prntbase.cpp:366
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "Print..."
 msgstr "Natisni ..."
 
 # generic/prntdlgg.cpp:113
 # generic/prntdlgg.cpp:127
-#: ../src/generic/prntdlgg.cpp:493
+#: ../src/generic/prntdlgg.cpp:486
 msgid "Printer"
 msgstr "Tiskalnik"
 
 # generic/prntdlgg.cpp:459
-#: ../src/generic/prntdlgg.cpp:633
+#: ../src/generic/prntdlgg.cpp:626
 msgid "Printer command:"
 msgstr "Ukaz tiskalniku:"
 
 # generic/prntdlgg.cpp:149
-#: ../src/generic/prntdlgg.cpp:180
+#: ../src/generic/prntdlgg.cpp:173
 msgid "Printer options"
 msgstr "Možnosti tiskalnika"
 
 # generic/prntdlgg.cpp:463
-#: ../src/generic/prntdlgg.cpp:645
+#: ../src/generic/prntdlgg.cpp:638
 msgid "Printer options:"
 msgstr "Možnosti tiskalnika:"
 
 # generic/prntdlgg.cpp:682
-#: ../src/generic/prntdlgg.cpp:916
+#: ../src/generic/prntdlgg.cpp:909
 msgid "Printer..."
 msgstr "Tiskalnik ..."
 
 # generic/prntdlgg.cpp:682
-#: ../src/generic/prntdlgg.cpp:196
+#: ../src/generic/prntdlgg.cpp:189
 msgid "Printer:"
 msgstr "Tiskalnik:"
 
 # common/prntbase.cpp:106
 # common/prntbase.cpp:148
-#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:535
-#: ../src/html/htmprint.cpp:277
+#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:530
+#: ../src/html/htmprint.cpp:289
 msgid "Printing"
 msgstr "Tiskanje poteka"
 
 # common/prntbase.cpp:106
 # common/prntbase.cpp:148
-#: ../src/common/prntbase.cpp:612
+#: ../src/common/prntbase.cpp:607
 msgid "Printing "
 msgstr "Tiskanje poteka"
 
 # common/prntbase.cpp:120
-#: ../src/common/prntbase.cpp:347
+#: ../src/common/prntbase.cpp:342
 msgid "Printing Error"
 msgstr "Napaka pri tiskanju"
 
+#: ../src/osx/webview_webkit.mm:251
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "Ta različica zlib ne podpira Gzip"
+
 # generic/printps.cpp:232
-#: ../src/common/prntbase.cpp:565
+#: ../src/common/prntbase.cpp:560
 #, c-format
 msgid "Printing page %d"
 msgstr "Tiskanje strani %d"
 
 # generic/printps.cpp:232
-#: ../src/common/prntbase.cpp:570
+#: ../src/common/prntbase.cpp:565
 #, c-format
 msgid "Printing page %d of %d"
 msgstr "Tiskanje strani %d od %d ..."
 
 # generic/printps.cpp:232
-#: ../src/generic/printps.cpp:201
+#: ../src/generic/printps.cpp:182
 #, c-format
 msgid "Printing page %d..."
 msgstr "Tiskanje strani %d ..."
 
 # generic/printps.cpp:192
-#: ../src/generic/printps.cpp:161
+#: ../src/generic/printps.cpp:142
 msgid "Printing..."
 msgstr "Tiskanje ..."
 
 # generic/prntdlgg.cpp:113
 # generic/prntdlgg.cpp:127
-#: ../include/wx/richtext/richtextprint.h:109 ../include/wx/prntbase.h:267
-#: ../src/common/docview.cpp:2132
+#: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
+#: ../src/common/docview.cpp:2137
 msgid "Printout"
 msgstr "Izpis"
 
-#: ../src/common/debugrpt.cpp:560
+#: ../src/common/debugrpt.cpp:561
 #, c-format
 msgid ""
 "Processing debug report has failed, leaving the files in \"%s\" directory."
@@ -6748,119 +6917,119 @@ msgstr ""
 "Obdelava poročila o razhroščevanju ni uspela, datoteke so ostale v mapi \"%s"
 "\"."
 
-#: ../src/common/prntbase.cpp:545
+#: ../src/common/prntbase.cpp:540
 msgid "Progress:"
 msgstr "Napredek:"
 
 # html/helpfrm.cpp:512
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181
 msgid "Properties"
 msgstr "Lastnosti"
 
 # html/helpfrm.cpp:512
-#: ../src/propgrid/manager.cpp:237
+#: ../src/propgrid/manager.cpp:223
 msgid "Property"
 msgstr "Lastnost"
 
 # common/prntbase.cpp:120
 #. TRANSLATORS: Caption of message box displaying any property error
-#: ../src/propgrid/propgrid.cpp:3185 ../src/propgrid/propgrid.cpp:3318
+#: ../src/propgrid/propgrid.cpp:3162 ../src/propgrid/propgrid.cpp:3299
 msgid "Property Error"
 msgstr "Napaka lastnosti"
 
-#: ../src/propgrid/advprops.cpp:1597
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Purple"
 msgstr "Škrlatna"
 
 # generic/dcpsg.cpp:2547
-#: ../src/common/paper.cpp:112
+#: ../src/common/paper.cpp:109
 msgid "Quarto, 215 x 275 mm"
 msgstr "Quarto, 215 x 275 mm"
 
 # generic/logg.cpp:1023
-#: ../src/generic/logg.cpp:1016
+#: ../src/generic/logg.cpp:1013
 msgid "Question"
 msgstr "Vprašanje"
 
 # generic/logg.cpp:1023
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1769
+#: ../src/propgrid/advprops.cpp:1670
 msgid "Question Arrow"
 msgstr "Vprašaj s puščico"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "Quit"
 msgstr "Izhod"
 
-#: ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:477
 #, c-format
 msgid "Quit %s"
 msgstr "Izhod iz %s"
 
 # html/helpfrm.cpp:529
-#: ../src/common/stockitem.cpp:263
+#: ../src/common/stockitem.cpp:261
 msgid "Quit this program"
 msgstr "Zapri ta program"
 
 # common/utilscmn.cpp:464
-#: ../src/common/accelcmn.cpp:338
+#: ../src/common/accelcmn.cpp:352
 msgid "RawCtrl+"
 msgstr "SurovaKrmilka-"
 
 # common/ffile.cpp:133
 # common/ffile.cpp:154
-#: ../src/common/ffile.cpp:109 ../src/common/ffile.cpp:133
+#: ../src/common/ffile.cpp:107 ../src/common/ffile.cpp:132
 #, c-format
 msgid "Read error on file '%s'"
 msgstr "Napaka pri branju datoteke '%s'"
 
-#: ../src/common/secretstore.cpp:199
-#, c-format
-msgid "Reading password for \"%s/%s\" failed: %s."
+#: ../src/common/secretstore.cpp:211
+#, fuzzy, c-format
+msgid "Reading password for \"%s\" failed: %s."
 msgstr "Branje gesla za »%s/%s« ni uspelo: %s"
 
-#: ../src/common/prntbase.cpp:272
+#: ../src/common/prntbase.cpp:267
 msgid "Ready"
 msgstr "Pripravljen"
 
 # common/docview.cpp:1945
 # common/docview.cpp:1956
-#: ../src/propgrid/advprops.cpp:1605
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Red"
 msgstr "Rdeča"
 
-#: ../src/generic/colrdlgg.cpp:339
+#: ../src/generic/colrdlgg.cpp:359
 msgid "Red:"
 msgstr "Rdeča:"
 
 # common/docview.cpp:1945
 # common/docview.cpp:1956
-#: ../src/common/stockitem.cpp:185 ../src/stc/stc_i18n.cpp:16
+#: ../src/common/stockitem.cpp:182 ../src/stc/stc_i18n.cpp:16
 msgid "Redo"
 msgstr "Ponovi"
 
-#: ../src/common/stockitem.cpp:264
+#: ../src/common/stockitem.cpp:262
 msgid "Redo last action"
 msgstr "Ponovi zadnje dejanje"
 
-#: ../src/common/stockitem.cpp:186
+#: ../src/common/stockitem.cpp:183
 msgid "Refresh"
 msgstr "Osveži"
 
 # msw/registry.cpp:532
-#: ../src/msw/registry.cpp:626
+#: ../src/msw/registry.cpp:615
 #, c-format
 msgid "Registry key '%s' already exists."
 msgstr "Ključ registra '%s' že obstaja."
 
 # msw/registry.cpp:501
-#: ../src/msw/registry.cpp:595
+#: ../src/msw/registry.cpp:584
 #, c-format
 msgid "Registry key '%s' does not exist, cannot rename it."
 msgstr "Ključ registra '%s' ne obstaja, ni ga mogoče preimenovati."
 
 # msw/registry.cpp:628
-#: ../src/msw/registry.cpp:727
+#: ../src/msw/registry.cpp:716
 #, c-format
 msgid ""
 "Registry key '%s' is needed for normal system operation,\n"
@@ -6871,23 +7040,23 @@ msgstr ""
 "z njegovim brisanjem svoj sistem prepuščate v neuporabno stanje:\n"
 "operacija prekinjena."
 
-#: ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:942
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr "Vrednost registra »%s« ni binarna (temveč vrste %s)"
 
-#: ../src/msw/registry.cpp:917
+#: ../src/msw/registry.cpp:905
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr "Vrednost registra »%s« ni numerična (temveč vrste %s)"
 
-#: ../src/msw/registry.cpp:1003
+#: ../src/msw/registry.cpp:991
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr "Vrednost registra »%s« ni besedilna (temveč vrste %s)"
 
 # msw/registry.cpp:432
-#: ../src/msw/registry.cpp:521
+#: ../src/msw/registry.cpp:510
 #, c-format
 msgid "Registry value '%s' already exists."
 msgstr "Vrednost registra '%s' že obstaja."
@@ -6903,35 +7072,35 @@ msgid "Relative"
 msgstr "Relativno"
 
 # generic/helphtml.cpp:319
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:456
 msgid "Relevant entries:"
 msgstr "Ustrezni naslovi:"
 
-#: ../include/wx/generic/progdlgg.h:86
+#: ../include/wx/generic/progdlgg.h:87
 msgid "Remaining time:"
 msgstr "Preostali čas:"
 
-#: ../src/common/stockitem.cpp:187
+#: ../src/common/stockitem.cpp:184
 msgid "Remove"
 msgstr "Odstrani"
 
-#: ../src/richtext/richtextctrl.cpp:1562
+#: ../src/richtext/richtextctrl.cpp:1563
 msgid "Remove Bullet"
 msgstr "Odstrani oznako"
 
 # html/helpfrm.cpp:269
-#: ../src/html/helpwnd.cpp:433
+#: ../src/html/helpwnd.cpp:431
 msgid "Remove current page from bookmarks"
 msgstr "Odstrani trenutno stran iz zaznamkov"
 
-#: ../src/common/rendcmn.cpp:194
+#: ../src/common/rendcmn.cpp:191
 #, c-format
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 "Prikazovalnik \"%s\" je nezdružljive različice %d.%d in ga ni mogoče "
 "naložiti."
 
-#: ../src/richtext/richtextbuffer.cpp:4527
+#: ../src/richtext/richtextbuffer.cpp:4524
 msgid "Renumber List"
 msgstr "Ponovno oštevilči seznam"
 
@@ -6940,11 +7109,12 @@ msgstr "Ponovno oštevilči seznam"
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 # msw/filedlg.cpp:445
-#: ../src/common/stockitem.cpp:188
-msgid "Rep&lace"
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Rep&lace..."
 msgstr "&Zamenjaj"
 
-#: ../src/richtext/richtextctrl.cpp:3673 ../src/common/stockitem.cpp:188
+#: ../src/richtext/richtextctrl.cpp:3674
 msgid "Replace"
 msgstr "Zamenjaj"
 
@@ -6953,39 +7123,39 @@ msgstr "Zamenjaj"
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 # msw/filedlg.cpp:445
-#: ../src/generic/fdrepdlg.cpp:182
+#: ../src/generic/fdrepdlg.cpp:179
 msgid "Replace &all"
 msgstr "Zamenjaj &vse"
 
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR Free Software Foundation, Inc.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
-# msw/filedlg.cpp:445
-#: ../src/common/stockitem.cpp:261
-msgid "Replace selection"
-msgstr "Zamenjaj izbor"
-
-#: ../src/generic/fdrepdlg.cpp:124
+#: ../src/generic/fdrepdlg.cpp:121
 msgid "Replace with:"
 msgstr "Zamenjaj z:"
 
-#: ../src/common/valtext.cpp:163
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Replace..."
+msgstr "Zamenjaj"
+
+#: ../src/common/valtext.cpp:184
 msgid "Required information entry is empty."
 msgstr "Vnos z zahtevanimi podatki je prazen."
 
 # common/intl.cpp:412
-#: ../src/common/translation.cpp:1975
+#: ../src/common/translation.cpp:2025
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "Vir '%s' ni veljaven katalog sporočil."
 
+#: ../src/gtk/webview_webkit.cpp:985
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:56
+#: ../src/common/accelcmn.cpp:53
 msgid "Return"
 msgstr "Vračalka"
 
-#: ../src/common/stockitem.cpp:189
+#: ../src/common/stockitem.cpp:186
 msgid "Revert to Saved"
 msgstr "Povrni v shranjeno"
 
@@ -6999,44 +7169,44 @@ msgid "Rig&ht-to-left"
 msgstr "Z de&sne na levo"
 
 # generic/fontdlgg.cpp:216
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6149
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:59 ../src/generic/datavgen.cpp:6954
+#: ../src/richtext/richtextsizepage.cpp:250
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextbulletspage.cpp:188
-#: ../src/richtext/richtextsizepage.cpp:250 ../src/common/accelcmn.cpp:62
 msgid "Right"
 msgstr "Desno"
 
 # generic/fontdlgg.cpp:216
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1754
+#: ../src/propgrid/advprops.cpp:1655
 msgid "Right Arrow"
 msgstr "Smerna tipka desno"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1770
+#: ../src/propgrid/advprops.cpp:1671
 msgid "Right Button"
 msgstr "Desni gumb"
 
 # generic/prntdlgg.cpp:661
-#: ../src/generic/prntdlgg.cpp:892
+#: ../src/generic/prntdlgg.cpp:885
 msgid "Right margin (mm):"
 msgstr "Desni rob (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:148
-#: ../src/richtext/richtextindentspage.cpp:150
 #: ../src/richtext/richtextliststylepage.cpp:337
 #: ../src/richtext/richtextliststylepage.cpp:339
+#: ../src/richtext/richtextindentspage.cpp:148
+#: ../src/richtext/richtextindentspage.cpp:150
 msgid "Right-align text."
 msgstr "Desno poravnaj besedilo."
 
 # generic/fontdlgg.cpp:206
-#: ../src/generic/fontdlgg.cpp:322
+#: ../src/generic/fontdlgg.cpp:318
 msgid "Roman"
 msgstr "serifna"
 
-#: ../src/generic/datavgen.cpp:5916
+#: ../src/generic/datavgen.cpp:6721
 #, c-format
 msgid "Row %i"
 msgstr "Vrstica %i"
@@ -7046,38 +7216,40 @@ msgstr "Vrstica %i"
 msgid "S&tandard bullet name:"
 msgstr "&Navadno ime oznake:"
 
-#: ../src/common/accelcmn.cpp:268 ../src/common/accelcmn.cpp:350
+#: ../src/common/accelcmn.cpp:282 ../src/common/accelcmn.cpp:367
 msgid "SPECIAL"
 msgstr "POSEBNO"
 
 # generic/logg.cpp:473
 # generic/logg.cpp:774
-#: ../src/common/stockitem.cpp:190 ../src/common/sizer.cpp:2797
+#: ../src/common/stockitem.cpp:187 ../src/common/sizer.cpp:2914
 msgid "Save"
 msgstr "Shrani"
 
 # generic/filedlgg.cpp:1286
 # msw/filedlg.cpp:484
-#: ../src/common/fldlgcmn.cpp:342
+#: ../src/common/fldlgcmn.cpp:339
 #, c-format
 msgid "Save %s file"
 msgstr "Shrani datoteko %s"
 
 # generic/logg.cpp:473
 # generic/logg.cpp:774
-#: ../src/generic/logg.cpp:512
+#: ../src/common/stockitem.cpp:188 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "&Shrani kot ..."
 
 # common/docview.cpp:249
-#: ../src/common/docview.cpp:366
+#: ../src/common/docview.cpp:359
 msgid "Save As"
 msgstr "Shrani kot"
 
-# common/docview.cpp:249
-#: ../src/common/stockitem.cpp:191
-msgid "Save as"
-msgstr "Shrani kot"
+# generic/logg.cpp:473
+# generic/logg.cpp:774
+#: ../src/common/stockitem.cpp:188
+#, fuzzy
+msgid "Save As..."
+msgstr "&Shrani kot ..."
 
 # common/docview.cpp:1494
 #: ../src/common/stockitem.cpp:267
@@ -7089,45 +7261,45 @@ msgid "Save current document with a different filename"
 msgstr "Shrani trenutni dokument pod drugim imenom datoteke."
 
 # generic/logg.cpp:473
-#: ../src/generic/logg.cpp:512
+#: ../src/generic/logg.cpp:509
 msgid "Save log contents to file"
 msgstr "Shrani vsebino dnevnika v datoteko"
 
-#: ../src/common/secretstore.cpp:179
-#, c-format
-msgid "Saving password for \"%s/%s\" failed: %s."
+#: ../src/common/secretstore.cpp:189
+#, fuzzy, c-format
+msgid "Saving password for \"%s\" failed: %s."
 msgstr "Shranjevanje gesla za »%s/%s« je spodletelo: %s."
 
 # generic/fontdlgg.cpp:209
-#: ../src/generic/fontdlgg.cpp:325
+#: ../src/generic/fontdlgg.cpp:321
 msgid "Script"
 msgstr "Skript"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll Lock"
 msgstr "Zaklepalka drsenja"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll_lock"
 msgstr "Zakl_drs"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:890
+#: ../src/propgrid/advprops.cpp:791
 msgid "Scrollbar"
 msgstr "Drsnik"
 
 # generic/helpwxht.cpp:161
 # html/helpfrm.cpp:414
 # html/helpfrm.cpp:434
-#: ../src/generic/srchctlg.cpp:56 ../src/html/helpwnd.cpp:535
-#: ../src/html/helpwnd.cpp:550
+#: ../src/generic/srchctlg.cpp:55 ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:548 ../src/gtk/srchctrl.cpp:182
 msgid "Search"
 msgstr "Iskanje"
 
 # html/helpfrm.cpp:416
-#: ../src/html/helpwnd.cpp:537
+#: ../src/html/helpwnd.cpp:535
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
@@ -7135,69 +7307,69 @@ msgstr ""
 "Iskanje v knjigah s pomočjo za vse pojavitve zgoraj natipkanega besedila"
 
 # generic/dirdlgg.cpp:572
-#: ../src/generic/fdrepdlg.cpp:160
+#: ../src/generic/fdrepdlg.cpp:157
 msgid "Search direction"
 msgstr "Smer iskanja"
 
 # generic/helpwxht.cpp:161
 # html/helpfrm.cpp:414
 # html/helpfrm.cpp:434
-#: ../src/generic/fdrepdlg.cpp:112
+#: ../src/generic/fdrepdlg.cpp:109
 msgid "Search for:"
 msgstr "Najdi:"
 
 # html/helpfrm.cpp:735
-#: ../src/html/helpwnd.cpp:1052
+#: ../src/html/helpwnd.cpp:1050
 msgid "Search in all books"
 msgstr "Išči v vseh knjigah"
 
 # html/helpfrm.cpp:628
-#: ../src/html/helpwnd.cpp:857
+#: ../src/html/helpwnd.cpp:855
 msgid "Searching..."
 msgstr "Iskanje v teku ..."
 
 # generic/dirdlgg.cpp:191
-#: ../src/generic/dirctrlg.cpp:446
+#: ../src/generic/dirctrlg.cpp:412
 msgid "Sections"
 msgstr "Razdelki"
 
 # common/ffile.cpp:221
-#: ../src/common/ffile.cpp:238
+#: ../src/common/ffile.cpp:237
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Napaka pri iskanju v datoteki '%s'"
 
-#: ../src/common/ffile.cpp:228
+#: ../src/common/ffile.cpp:227
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr "Najdi napako na datoteki '%s' (velike datoteke niso podprte v stdio)"
 
 # generic/dirdlgg.cpp:191
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:76
+#: ../src/common/accelcmn.cpp:73
 msgid "Select"
 msgstr "Izbiralka"
 
 # common/docview.cpp:1371
 # common/docview.cpp:1422
-#: ../src/richtext/richtextctrl.cpp:337 ../src/osx/textctrl_osx.cpp:581
-#: ../src/common/stockitem.cpp:192 ../src/msw/textctrl.cpp:2512
+#: ../src/osx/textctrl_osx.cpp:599 ../src/common/stockitem.cpp:189
+#: ../src/msw/textctrl.cpp:2777 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Izberi &vse"
 
 # common/docview.cpp:1371
 # common/docview.cpp:1422
-#: ../src/common/stockitem.cpp:192 ../src/stc/stc_i18n.cpp:21
+#: ../src/common/stockitem.cpp:189 ../src/stc/stc_i18n.cpp:21
 msgid "Select All"
 msgstr "Izberi vse"
 
 # common/docview.cpp:1469
-#: ../src/common/docview.cpp:1895
+#: ../src/common/docview.cpp:1900
 msgid "Select a document template"
 msgstr "Izberi predlogo dokumenta"
 
 # common/docview.cpp:1494
-#: ../src/common/docview.cpp:1969
+#: ../src/common/docview.cpp:1974
 msgid "Select a document view"
 msgstr "Izberi pogled dokumenta"
 
@@ -7227,21 +7399,21 @@ msgid "Selects the list level to edit."
 msgstr "Izbere raven seznama za urejanje."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:82
+#: ../src/common/accelcmn.cpp:79
 msgid "Separator"
 msgstr "Ločilo"
 
 # common/cmdline.cpp:627
-#: ../src/common/cmdline.cpp:1083
+#: ../src/common/cmdline.cpp:1079
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Po možnosti '%s' je pričakovano ločilo."
 
-#: ../src/osx/menu_osx.cpp:572
+#: ../src/osx/menu_osx.cpp:464
 msgid "Services"
 msgstr "Storitve"
 
-#: ../src/richtext/richtextbuffer.cpp:11217
+#: ../src/richtext/richtextbuffer.cpp:11216
 msgid "Set Cell Style"
 msgstr "Določite slog celice"
 
@@ -7250,12 +7422,12 @@ msgid "SetProperty called w/o valid setter"
 msgstr "SetProperty klicana brez veljavnega nastavljavca"
 
 # generic/prntdlgg.cpp:155
-#: ../src/generic/prntdlgg.cpp:188
+#: ../src/generic/prntdlgg.cpp:181
 msgid "Setup..."
 msgstr "Nastavitve ..."
 
 # msw/dialup.cpp:539
-#: ../src/msw/dialup.cpp:544
+#: ../src/msw/dialup.cpp:538
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr ""
 "Najdenih je več aktivnih klicnih povezav, izbrana bo naključna med njimi."
@@ -7273,46 +7445,46 @@ msgid "Shadow c&olour:"
 msgstr "Barva sen&ce:"
 
 # common/utilscmn.cpp:468
-#: ../src/common/accelcmn.cpp:335
+#: ../src/common/accelcmn.cpp:349
 msgid "Shift+"
 msgstr "Dvigalka-"
 
 # generic/filedlgg.cpp:913
-#: ../src/generic/dirdlgg.cpp:147
+#: ../src/generic/dirdlgg.cpp:144
 msgid "Show &hidden directories"
 msgstr "Pokaži skrite &mape"
 
 # generic/filedlgg.cpp:913
-#: ../src/generic/filectrlg.cpp:983
+#: ../src/generic/filectrlg.cpp:979
 msgid "Show &hidden files"
 msgstr "Pokaži skrite &datoteke"
 
 # html/helpfrm.cpp:331
-#: ../src/osx/menu_osx.cpp:580
+#: ../src/osx/menu_osx.cpp:472
 msgid "Show All"
 msgstr "Pokaži vse"
 
-#: ../src/common/stockitem.cpp:257
+#: ../src/common/stockitem.cpp:254
 msgid "Show about dialog"
 msgstr "Pokaži pogovorno okno o programu"
 
 # html/helpfrm.cpp:331
-#: ../src/html/helpwnd.cpp:492
+#: ../src/html/helpwnd.cpp:490
 msgid "Show all"
 msgstr "Pokaži vse"
 
 # html/helpfrm.cpp:365
-#: ../src/html/helpwnd.cpp:503
+#: ../src/html/helpwnd.cpp:501
 msgid "Show all items in index"
 msgstr "Pokaži vse predmete v indeksu"
 
 # html/helpfrm.cpp:496
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:656
 msgid "Show/hide navigation panel"
 msgstr "Pokaži/skrij navigacijski pano"
 
-#: ../src/richtext/richtextsymboldlg.cpp:421
-#: ../src/richtext/richtextsymboldlg.cpp:423
+#: ../src/richtext/richtextsymboldlg.cpp:418
+#: ../src/richtext/richtextsymboldlg.cpp:420
 msgid "Shows a Unicode subset."
 msgstr "Pokaže podmnožico Unicode."
 
@@ -7328,7 +7500,7 @@ msgstr "Pokaže predogled nastavitev oznak."
 msgid "Shows a preview of the font settings."
 msgstr "Pokaže predogled nastavitev pisave."
 
-#: ../src/osx/carbon/fontdlg.cpp:394 ../src/osx/carbon/fontdlg.cpp:396
+#: ../src/osx/carbon/fontdlg.cpp:391 ../src/osx/carbon/fontdlg.cpp:393
 msgid "Shows a preview of the font."
 msgstr "Pokaže predogled pisave."
 
@@ -7337,65 +7509,65 @@ msgstr "Pokaže predogled pisave."
 msgid "Shows a preview of the paragraph settings."
 msgstr "Pokaže predogled nastavitev odstavka."
 
-#: ../src/generic/fontdlgg.cpp:460 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:456 ../src/generic/fontdlgg.cpp:458
 msgid "Shows the font preview."
 msgstr "Prikaže predogled pisave."
 
-#: ../src/propgrid/advprops.cpp:1607
+#: ../src/propgrid/advprops.cpp:1513
 msgid "Silver"
 msgstr "Srebrna"
 
-#: ../src/univ/themes/mono.cpp:516
+#: ../src/univ/themes/mono.cpp:513
 msgid "Simple monochrome theme"
 msgstr "Enostavna enobarvna tema"
 
-#: ../src/richtext/richtextindentspage.cpp:275
 #: ../src/richtext/richtextliststylepage.cpp:449
+#: ../src/richtext/richtextindentspage.cpp:275
 msgid "Single"
 msgstr "Posamično"
 
 # generic/filedlgg.cpp:534
-#: ../src/generic/filectrlg.cpp:425 ../src/richtext/richtextformatdlg.cpp:369
-#: ../src/richtext/richtextsizepage.cpp:299
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextsizepage.cpp:299
+#: ../src/richtext/richtextformatdlg.cpp:362
 msgid "Size"
 msgstr "Velikost"
 
 # generic/filedlgg.cpp:534
-#: ../src/osx/carbon/fontdlg.cpp:339
+#: ../src/osx/carbon/fontdlg.cpp:336
 msgid "Size:"
 msgstr "Velikost:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1775
+#: ../src/propgrid/advprops.cpp:1676
 msgid "Sizing"
 msgstr "Določanje velikosti"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1772
+#: ../src/propgrid/advprops.cpp:1673
 msgid "Sizing N-S"
 msgstr "Določanje velikosti S-J"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1771
+#: ../src/propgrid/advprops.cpp:1672
 msgid "Sizing NE-SW"
 msgstr "Določanje velikosti SV-JZ"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1773
+#: ../src/propgrid/advprops.cpp:1674
 msgid "Sizing NW-SE"
 msgstr "Določanje velikosti SZ-JV"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1774
+#: ../src/propgrid/advprops.cpp:1675
 msgid "Sizing W-E"
 msgstr "Določanje velikosti Z-V"
 
-#: ../src/msw/progdlg.cpp:801
+#: ../src/msw/progdlg.cpp:1088
 msgid "Skip"
 msgstr "Preskoči"
 
 # generic/fontdlgg.cpp:214
-#: ../src/generic/fontdlgg.cpp:330
+#: ../src/generic/fontdlgg.cpp:326
 msgid "Slant"
 msgstr "Levo kurzivno"
 
@@ -7404,7 +7576,7 @@ msgid "Small C&apitals"
 msgstr "&Male začetnice"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:79
+#: ../src/common/accelcmn.cpp:76
 msgid "Snapshot"
 msgstr "Posnetek"
 
@@ -7416,42 +7588,42 @@ msgstr "Zapolnjeno"
 # common/docview.cpp:342
 # common/docview.cpp:354
 # common/docview.cpp:1390
-#: ../src/common/docview.cpp:1791
+#: ../src/common/docview.cpp:1785
 msgid "Sorry, could not open this file."
 msgstr "Oprostite, te datoteke ni moč odpreti."
 
 # common/prntbase.cpp:687
-#: ../src/common/prntbase.cpp:2057 ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2079 ../src/common/prntbase.cpp:2087
 msgid "Sorry, not enough memory to create a preview."
 msgstr "Oprostite, ni dovolj spomina za predogled tiskanja."
 
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "Sorry, that name is taken. Please choose another."
 msgstr "Ime je že zasedeno. Izberite drugo."
 
 # common/docview.cpp:342
 # common/docview.cpp:354
 # common/docview.cpp:1390
-#: ../src/common/docview.cpp:1814
+#: ../src/common/docview.cpp:1819
 msgid "Sorry, the format for this file is unknown."
 msgstr "Oprostite, ta zapis datoteke je neznan."
 
-#: ../src/unix/sound.cpp:492
+#: ../src/unix/sound.cpp:481
 msgid "Sound data are in unsupported format."
 msgstr "Zvočni podatki so v nepodprtem zapisu."
 
-#: ../src/unix/sound.cpp:477
+#: ../src/unix/sound.cpp:466
 #, c-format
 msgid "Sound file '%s' is in unsupported format."
 msgstr "Zvočna datoteka '%s' je v nepodprtem zapisu."
 
 # html/helpfrm.cpp:628
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:67
+#: ../src/common/accelcmn.cpp:64
 msgid "Space"
 msgstr "Preslednica"
 
@@ -7460,12 +7632,12 @@ msgstr "Preslednica"
 msgid "Spacing"
 msgstr "Razmik"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "Spell Check"
 msgstr "Preveri črkovanje"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1776
+#: ../src/propgrid/advprops.cpp:1677
 msgid "Spraycan"
 msgstr "Pršilka"
 
@@ -7474,7 +7646,7 @@ msgstr "Pršilka"
 msgid "Standard"
 msgstr "Navadno"
 
-#: ../src/common/paper.cpp:104
+#: ../src/common/paper.cpp:101
 msgid "Statement, 5 1/2 x 8 1/2 in"
 msgstr "Statement, 5 1/2 x 8 1/2 pal."
 
@@ -7485,34 +7657,30 @@ msgid "Static"
 msgstr "Statično"
 
 # generic/logg.cpp:598
-#: ../src/generic/prntdlgg.cpp:204
+#: ../src/generic/prntdlgg.cpp:197
 msgid "Status:"
 msgstr "Stanje:"
 
 # common/dlgcmn.cpp:138
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "Stop"
 msgstr "Ustavi"
 
-#: ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196
 msgid "Strikethrough"
 msgstr "Prečrtano"
 
-#: ../src/common/colourcmn.cpp:45
+#: ../src/common/colourcmn.cpp:42
 #, c-format
 msgid "String To Colour : Incorrect colour specification : %s"
 msgstr "Niz v barvo: nepravilna specifikacija barve: %s"
 
 #. TRANSLATORS: Label of font style
-#: ../src/richtext/richtextformatdlg.cpp:339 ../src/propgrid/advprops.cpp:680
+#: ../src/propgrid/advprops.cpp:590 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Slog"
 
-#: ../include/wx/richtext/richtextstyledlg.h:46
-msgid "Style Organiser"
-msgstr "Organizator slogov"
-
-#: ../src/osx/carbon/fontdlg.cpp:348
+#: ../src/osx/carbon/fontdlg.cpp:345
 msgid "Style:"
 msgstr "Slog:"
 
@@ -7522,7 +7690,7 @@ msgid "Subscrip&t"
 msgstr "Po&dpisano"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:83
+#: ../src/common/accelcmn.cpp:80
 msgid "Subtract"
 msgstr "Odštej"
 
@@ -7531,11 +7699,11 @@ msgstr "Odštej"
 msgid "Supe&rscript"
 msgstr "&Nadpisano"
 
-#: ../src/common/paper.cpp:150
+#: ../src/common/paper.cpp:147
 msgid "SuperA/SuperA/A4 227 x 356 mm"
 msgstr "SuperA/SuperA/A4, 227 x 356 mm"
 
-#: ../src/common/paper.cpp:151
+#: ../src/common/paper.cpp:148
 msgid "SuperB/SuperB/A3 305 x 487 mm"
 msgstr "SuperB/SuperB/A3, 305 x 487 mm"
 
@@ -7544,7 +7712,7 @@ msgid "Suppress hyphe&nation"
 msgstr "Preskoči deljenje &besed"
 
 # generic/fontdlgg.cpp:210
-#: ../src/generic/fontdlgg.cpp:326
+#: ../src/generic/fontdlgg.cpp:322
 msgid "Swiss"
 msgstr "neserifna"
 
@@ -7566,80 +7734,80 @@ msgstr "Simboli"
 # common/imagtiff.cpp:192
 # common/imagtiff.cpp:203
 # common/imagtiff.cpp:314
-#: ../src/common/imagtiff.cpp:369 ../src/common/imagtiff.cpp:382
-#: ../src/common/imagtiff.cpp:741
+#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
+#: ../src/common/imagtiff.cpp:738
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: spomina ni mogoče alocirati."
 
 # common/imagtiff.cpp:163
-#: ../src/common/imagtiff.cpp:301
+#: ../src/common/imagtiff.cpp:298
 msgid "TIFF: Error loading image."
 msgstr "TIFF: napaka pri nalaganju slike."
 
 # common/imagtiff.cpp:214
-#: ../src/common/imagtiff.cpp:468
+#: ../src/common/imagtiff.cpp:465
 msgid "TIFF: Error reading image."
 msgstr "TIFF: napaka pri branju slike."
 
 # common/imagtiff.cpp:291
-#: ../src/common/imagtiff.cpp:608
+#: ../src/common/imagtiff.cpp:605
 msgid "TIFF: Error saving image."
 msgstr "TIFF: napaka pri shranjevanju slike."
 
 # common/imagtiff.cpp:338
-#: ../src/common/imagtiff.cpp:846
+#: ../src/common/imagtiff.cpp:843
 msgid "TIFF: Error writing image."
 msgstr "TIFF: napaka pri zapisovanju slike."
 
-#: ../src/common/imagtiff.cpp:355
+#: ../src/common/imagtiff.cpp:352
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: slika je nenaravno velika."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:68
+#: ../src/common/accelcmn.cpp:65
 msgid "Tab"
 msgstr "Tabulatorka"
 
 # html/helpfrm.cpp:512
-#: ../src/richtext/richtextbuffer.cpp:11498
+#: ../src/richtext/richtextbuffer.cpp:11497
 msgid "Table Properties"
 msgstr "Lastnosti tabele"
 
-#: ../src/common/paper.cpp:145
+#: ../src/common/paper.cpp:142
 msgid "Tabloid Extra 11.69 x 18 in"
 msgstr "tabloid Extra, 11,69 x 18 pal."
 
-#: ../src/common/paper.cpp:102
+#: ../src/common/paper.cpp:99
 msgid "Tabloid, 11 x 17 in"
 msgstr "tabloid, 11 x 17 pal."
 
-#: ../src/richtext/richtextformatdlg.cpp:354
+#: ../src/richtext/richtextformatdlg.cpp:347
 msgid "Tabs"
 msgstr "Tabulatorji"
 
-#: ../src/propgrid/advprops.cpp:1598
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Teal"
 msgstr "Modrozelena"
 
 # generic/fontdlgg.cpp:211
-#: ../src/generic/fontdlgg.cpp:327
+#: ../src/generic/fontdlgg.cpp:323
 msgid "Teletype"
 msgstr "strojna"
 
 # common/docview.cpp:1469
-#: ../src/common/docview.cpp:1896
+#: ../src/common/docview.cpp:1901
 msgid "Templates"
 msgstr "Šablone"
 
-#: ../src/common/fmapbase.cpp:158
+#: ../src/common/fmapbase.cpp:155
 msgid "Thai (ISO-8859-11)"
 msgstr "tajsko (ISO-8859-11)"
 
-#: ../src/common/ftp.cpp:619
+#: ../src/common/ftp.cpp:622
 msgid "The FTP server doesn't support passive mode."
 msgstr "Strežnik FTP ne podpira pasivnega načina."
 
-#: ../src/common/ftp.cpp:605
+#: ../src/common/ftp.cpp:608
 msgid "The FTP server doesn't support the PORT command."
 msgstr "Strežnik FTP ne podpira ukaza PORT."
 
@@ -7650,8 +7818,8 @@ msgstr "Strežnik FTP ne podpira ukaza PORT."
 msgid "The available bullet styles."
 msgstr "Slogi oznak, ki so na voljo."
 
-#: ../src/richtext/richtextstyledlg.cpp:202
-#: ../src/richtext/richtextstyledlg.cpp:204
+#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:200
 msgid "The available styles."
 msgstr "Slogi na voljo."
 
@@ -7710,13 +7878,13 @@ msgstr "Spodnji položaj."
 msgid "The bullet character."
 msgstr "Znak za oznake."
 
-#: ../src/richtext/richtextsymboldlg.cpp:443
-#: ../src/richtext/richtextsymboldlg.cpp:445
+#: ../src/richtext/richtextsymboldlg.cpp:440
+#: ../src/richtext/richtextsymboldlg.cpp:442
 msgid "The character code."
 msgstr "Koda znaka."
 
 # common/fontmap.cpp:511
-#: ../src/common/fontmap.cpp:203
+#: ../src/common/fontmap.cpp:200
 #, c-format
 msgid ""
 "The charset '%s' is unknown. You may select\n"
@@ -7728,7 +7896,7 @@ msgstr ""
 "[Prekličil] če ne more biti zamenjan"
 
 # msw/ole/dataobj.cpp:169
-#: ../src/msw/ole/dataobj.cpp:394
+#: ../src/msw/ole/dataobj.cpp:402
 #, c-format
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "Oblika zapisa odložišča '%d' ne obstaja."
@@ -7739,7 +7907,7 @@ msgid "The default style for the next paragraph."
 msgstr "Privzeti slog za naslednji odstavek."
 
 # generic/dirdlgg.cpp:538
-#: ../src/generic/dirdlgg.cpp:202
+#: ../src/generic/dirdlgg.cpp:199
 #, c-format
 msgid ""
 "The directory '%s' does not exist\n"
@@ -7748,7 +7916,7 @@ msgstr ""
 "Mapa '%s' ne obstaja.\n"
 "Jo želite ustvariti?"
 
-#: ../src/html/htmprint.cpp:271
+#: ../src/html/htmprint.cpp:283
 #, c-format
 msgid ""
 "The document \"%s\" doesn't fit on the page horizontally and will be "
@@ -7761,7 +7929,7 @@ msgstr ""
 "Želite kljub temu nadaljevati z njegovim tiskanjem?"
 
 # common/docview.cpp:1676
-#: ../src/common/docview.cpp:1202
+#: ../src/common/docview.cpp:1196
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -7771,38 +7939,38 @@ msgstr ""
 "Izbisana je bila iz seznama zadnjih uporabljenih datotek."
 
 # html/helpfrm.cpp:899
-#: ../src/richtext/richtextindentspage.cpp:208
-#: ../src/richtext/richtextindentspage.cpp:210
 #: ../src/richtext/richtextliststylepage.cpp:394
 #: ../src/richtext/richtextliststylepage.cpp:396
+#: ../src/richtext/richtextindentspage.cpp:208
+#: ../src/richtext/richtextindentspage.cpp:210
 msgid "The first line indent."
 msgstr "Zamik prve vrstice."
 
-#: ../src/gtk/utilsgtk.cpp:481
-msgid "The following standard GTK+ options are also supported:\n"
-msgstr "Podprte so tudi naslednje standardne možnosti GTK+:\n"
+#: ../src/generic/dbgrptg.cpp:318
+msgid "The following debug report will be generated\n"
+msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:414 ../src/generic/fontdlgg.cpp:416
+#: ../src/generic/fontdlgg.cpp:411 ../src/generic/fontdlgg.cpp:413
 msgid "The font colour."
 msgstr "Barva pisave."
 
-#: ../src/generic/fontdlgg.cpp:375 ../src/generic/fontdlgg.cpp:377
+#: ../src/generic/fontdlgg.cpp:371 ../src/generic/fontdlgg.cpp:373
 msgid "The font family."
 msgstr "Družina pisave."
 
-#: ../src/richtext/richtextsymboldlg.cpp:405
-#: ../src/richtext/richtextsymboldlg.cpp:407
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "The font from which to take the symbol."
 msgstr "Pisava, iz katere naj bodo prikazani posebni znaki."
 
 # html/helpfrm.cpp:899
-#: ../src/generic/fontdlgg.cpp:427 ../src/generic/fontdlgg.cpp:429
-#: ../src/generic/fontdlgg.cpp:434 ../src/generic/fontdlgg.cpp:436
+#: ../src/generic/fontdlgg.cpp:424 ../src/generic/fontdlgg.cpp:426
+#: ../src/generic/fontdlgg.cpp:430 ../src/generic/fontdlgg.cpp:432
 msgid "The font point size."
 msgstr "Velikost pisave."
 
 # html/helpfrm.cpp:899
-#: ../src/osx/carbon/fontdlg.cpp:343 ../src/osx/carbon/fontdlg.cpp:345
+#: ../src/osx/carbon/fontdlg.cpp:340 ../src/osx/carbon/fontdlg.cpp:342
 msgid "The font size in points."
 msgstr "Velikost pisave v točkah."
 
@@ -7812,15 +7980,15 @@ msgstr "Velikost pisave v točkah."
 msgid "The font size units, points or pixels."
 msgstr "Enote velikosti pisave, točke ali slikovne točke."
 
-#: ../src/generic/fontdlgg.cpp:386 ../src/generic/fontdlgg.cpp:388
+#: ../src/generic/fontdlgg.cpp:382 ../src/generic/fontdlgg.cpp:384
 msgid "The font style."
 msgstr "Slog pisave."
 
-#: ../src/generic/fontdlgg.cpp:397 ../src/generic/fontdlgg.cpp:399
+#: ../src/generic/fontdlgg.cpp:393 ../src/generic/fontdlgg.cpp:395
 msgid "The font weight."
 msgstr "Odebeljenost pisave."
 
-#: ../src/common/docview.cpp:1483
+#: ../src/common/docview.cpp:1477
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Vrste datoteke '%s' ni mogoče ugotoviti."
@@ -7831,10 +7999,10 @@ msgstr "Vrste datoteke '%s' ni mogoče ugotoviti."
 msgid "The horizontal offset."
 msgstr "Vodoravni odmik."
 
-#: ../src/richtext/richtextindentspage.cpp:199
-#: ../src/richtext/richtextindentspage.cpp:201
 #: ../src/richtext/richtextliststylepage.cpp:385
 #: ../src/richtext/richtextliststylepage.cpp:387
+#: ../src/richtext/richtextindentspage.cpp:199
+#: ../src/richtext/richtextindentspage.cpp:201
 msgid "The left indent."
 msgstr "Levi zamik."
 
@@ -7858,10 +8026,10 @@ msgstr "Velikost zapolnjevanja na levi."
 msgid "The left position."
 msgstr "Levi položaj."
 
-#: ../src/richtext/richtextindentspage.cpp:288
-#: ../src/richtext/richtextindentspage.cpp:290
 #: ../src/richtext/richtextliststylepage.cpp:462
 #: ../src/richtext/richtextliststylepage.cpp:464
+#: ../src/richtext/richtextindentspage.cpp:288
+#: ../src/richtext/richtextindentspage.cpp:290
 msgid "The line spacing."
 msgstr "Razmik med vrsticami."
 
@@ -7870,7 +8038,7 @@ msgstr "Razmik med vrsticami."
 msgid "The list item number."
 msgstr "Številka elementa seznama."
 
-#: ../src/msw/ole/automtn.cpp:664
+#: ../src/msw/ole/automtn.cpp:655
 msgid "The locale ID is unknown."
 msgstr "ID krajevnih nastavitev ni znan."
 
@@ -7909,7 +8077,7 @@ msgstr "Širina predmeta."
 msgid "The outline level."
 msgstr "Raven orisa."
 
-#: ../src/common/log.cpp:277
+#: ../src/common/log.cpp:296
 #, c-format
 msgid "The previous message repeated %u time."
 msgid_plural "The previous message repeated %u times."
@@ -7918,12 +8086,12 @@ msgstr[1] "Prejšnje sporočilo ponovljeno %u-krat."
 msgstr[2] "Prejšnje sporočilo ponovljeno %u-krat."
 msgstr[3] "Prejšnje sporočilo ponovljeno %u-krat."
 
-#: ../src/common/log.cpp:270
+#: ../src/common/log.cpp:289
 msgid "The previous message repeated once."
 msgstr "Prejšnje sporočilo ponovljeno enkrat."
 
-#: ../src/richtext/richtextsymboldlg.cpp:462
-#: ../src/richtext/richtextsymboldlg.cpp:464
+#: ../src/richtext/richtextsymboldlg.cpp:459
+#: ../src/richtext/richtextsymboldlg.cpp:461
 msgid "The range to show."
 msgstr "Prikazano območje."
 
@@ -7938,15 +8106,15 @@ msgstr ""
 "jih, prosimo, odznačite in odstranjene bodo iz poročila.\n"
 
 # common/cmdline.cpp:761
-#: ../src/common/cmdline.cpp:1254
+#: ../src/common/cmdline.cpp:1250
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "Zahtevani parameter '%s' ni bil podan."
 
-#: ../src/richtext/richtextindentspage.cpp:217
-#: ../src/richtext/richtextindentspage.cpp:219
 #: ../src/richtext/richtextliststylepage.cpp:403
 #: ../src/richtext/richtextliststylepage.cpp:405
+#: ../src/richtext/richtextindentspage.cpp:217
+#: ../src/richtext/richtextindentspage.cpp:219
 msgid "The right indent."
 msgstr "Desni odmik."
 
@@ -7988,16 +8156,16 @@ msgstr "Prekrivnost sence."
 msgid "The shadow spread."
 msgstr "Razširjanje sence."
 
-#: ../src/richtext/richtextindentspage.cpp:267
 #: ../src/richtext/richtextliststylepage.cpp:439
 #: ../src/richtext/richtextliststylepage.cpp:441
+#: ../src/richtext/richtextindentspage.cpp:267
 msgid "The spacing after the paragraph."
 msgstr "Razmik pod odstavkom."
 
-#: ../src/richtext/richtextindentspage.cpp:257
-#: ../src/richtext/richtextindentspage.cpp:259
 #: ../src/richtext/richtextliststylepage.cpp:430
 #: ../src/richtext/richtextliststylepage.cpp:432
+#: ../src/richtext/richtextindentspage.cpp:257
+#: ../src/richtext/richtextindentspage.cpp:259
 msgid "The spacing before the paragraph."
 msgstr "Razmik nad odstavkom."
 
@@ -8011,12 +8179,12 @@ msgstr "Ime sloga."
 msgid "The style on which this style is based."
 msgstr "Slog, na katerem temelji ta slog."
 
-#: ../src/richtext/richtextstyledlg.cpp:214
-#: ../src/richtext/richtextstyledlg.cpp:216
+#: ../src/richtext/richtextstyledlg.cpp:210
+#: ../src/richtext/richtextstyledlg.cpp:212
 msgid "The style preview."
 msgstr "Predogled sloga."
 
-#: ../src/msw/ole/automtn.cpp:680
+#: ../src/msw/ole/automtn.cpp:671
 msgid "The system cannot find the file specified."
 msgstr "Sistem ne more najti navedene datoteke."
 
@@ -8032,7 +8200,7 @@ msgid "The tab positions."
 msgstr "Položaji tabulatorjev."
 
 # common/textcmn.cpp:121
-#: ../src/richtext/richtextctrl.cpp:3098
+#: ../src/richtext/richtextctrl.cpp:3099
 msgid "The text couldn't be saved."
 msgstr "Besedila ni mogoče shraniti."
 
@@ -8057,7 +8225,7 @@ msgid "The top position."
 msgstr "Vrhnji položaj."
 
 # common/cmdline.cpp:740
-#: ../src/common/cmdline.cpp:1232
+#: ../src/common/cmdline.cpp:1228
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "Vrednost opcije '%s' mora biti podana."
@@ -8067,7 +8235,7 @@ msgstr "Vrednost opcije '%s' mora biti podana."
 msgid "The value of the corner radius."
 msgstr "Vrednost polmera koda."
 
-#: ../src/msw/dialup.cpp:433
+#: ../src/msw/dialup.cpp:427
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -8084,30 +8252,30 @@ msgstr ""
 msgid "The vertical offset."
 msgstr "Navpični odmik."
 
-#: ../src/richtext/richtextprint.cpp:619 ../src/html/htmprint.cpp:745
+#: ../src/html/htmprint.cpp:749 ../src/richtext/richtextprint.cpp:615
 msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr ""
 "Med pripravo strani je prišlo do težave: morda morate nastaviti privzeti "
 "tiskalnik."
 
-#: ../src/html/htmprint.cpp:255
+#: ../src/html/htmprint.cpp:267
 msgid ""
 "This document doesn't fit on the page horizontally and will be truncated "
 "when it is printed."
 msgstr "Ta dokument je vodoravno prevelik za stran in bo pri tiskanju porezan."
 
 # common/imagpcx.cpp:434
-#: ../src/common/image.cpp:2854
+#: ../src/common/image.cpp:2963
 #, c-format
 msgid "This is not a %s."
 msgstr "To ni %s."
 
-#: ../src/common/wincmn.cpp:1653
+#: ../src/common/wincmn.cpp:1654
 msgid "This platform does not support background transparency."
 msgstr "Ta platforma ne podpira prosojnosti ozadja."
 
-#: ../src/gtk/window.cpp:4660
+#: ../src/gtk/window.cpp:5664
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
@@ -8115,8 +8283,16 @@ msgstr ""
 "Program je bil preveden z zastarelo različico GTK+, ponovno ga zgradite z GTK"
 "+ 2.12 ali novejšim."
 
+#: ../src/gtk/glcanvas.cpp:176
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
 # msw/thread.cpp:1083
-#: ../src/msw/thread.cpp:1240
+#: ../src/msw/thread.cpp:1246
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -8124,12 +8300,12 @@ msgstr ""
 "Inicializacija modula niti ni uspela: vrednosti ni mogoče shraniti v lokalni "
 "shrambi niti"
 
-#: ../src/unix/threadpsx.cpp:1794
+#: ../src/unix/threadpsx.cpp:1843
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr "Inicializacija modula niti ni uspela: ključa niti ni mogoče ustvariti"
 
 # msw/thread.cpp:1071
-#: ../src/msw/thread.cpp:1228
+#: ../src/msw/thread.cpp:1234
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -8137,91 +8313,91 @@ msgstr ""
 "Inicializacija modula niti ni uspela: indeksa ni mogoče alocirati v lokalni "
 "shrambi niti"
 
-#: ../src/unix/threadpsx.cpp:1043
+#: ../src/unix/threadpsx.cpp:1061
 msgid "Thread priority setting is ignored."
 msgstr "Nastavitev prioritete niti je ignorirana."
 
 # msw/mdi.cpp:184
-#: ../src/msw/mdi.cpp:176
+#: ../src/msw/mdi.cpp:171
 msgid "Tile &Horizontally"
 msgstr "Razporedi &vodoravno"
 
 # msw/mdi.cpp:185
-#: ../src/msw/mdi.cpp:177
+#: ../src/msw/mdi.cpp:172
 msgid "Tile &Vertically"
 msgstr "Razporedi &navpično"
 
-#: ../src/common/ftp.cpp:200
+#: ../src/common/ftp.cpp:197
 msgid "Timeout while waiting for FTP server to connect, try passive mode."
 msgstr ""
 "Časovna prekoračitev pri čakanju na strežnik FTP za povezavo, poskusite "
 "pasiven način."
 
 # generic/tipdlg.cpp:162
-#: ../src/generic/tipdlg.cpp:201
+#: ../src/generic/tipdlg.cpp:198
 msgid "Tip of the Day"
 msgstr "Namig dneva"
 
 # generic/tipdlg.cpp:138
-#: ../src/generic/tipdlg.cpp:140
+#: ../src/generic/tipdlg.cpp:137
 msgid "Tips not available, sorry!"
 msgstr "Oprostite, namigi niso na voljo!"
 
 # generic/prntdlgg.cpp:191
-#: ../src/generic/prntdlgg.cpp:242
+#: ../src/generic/prntdlgg.cpp:235
 msgid "To:"
 msgstr "Za:"
 
-#: ../src/richtext/richtextbuffer.cpp:8363
+#: ../src/richtext/richtextbuffer.cpp:8361
 msgid "Too many EndStyle calls!"
 msgstr "Preveč klicev EndStyle!"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:891
+#: ../src/propgrid/advprops.cpp:792
 msgid "Tooltip"
 msgstr "Orodni namig"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:892
+#: ../src/propgrid/advprops.cpp:793
 msgid "TooltipText"
 msgstr "BesediloOrodnegaNamiga"
 
 # generic/prntdlgg.cpp:191
-#: ../src/richtext/richtextsizepage.cpp:286
-#: ../src/richtext/richtextsizepage.cpp:290 ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197 ../src/richtext/richtextsizepage.cpp:286
+#: ../src/richtext/richtextsizepage.cpp:290
 msgid "Top"
 msgstr "Na vrhu"
 
 # generic/prntdlgg.cpp:650
-#: ../src/generic/prntdlgg.cpp:881
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Top margin (mm):"
 msgstr "Zgornji rob (mm):"
 
-#: ../src/generic/aboutdlgg.cpp:79
+#: ../src/generic/aboutdlgg.cpp:76
 msgid "Translations by "
 msgstr "Prevajalci"
 
-#: ../src/generic/aboutdlgg.cpp:188
+#: ../src/generic/aboutdlgg.cpp:185
 msgid "Translators"
 msgstr "Prevajalci"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:211
+#: ../src/propgrid/propgrid.cpp:192
 msgid "True"
 msgstr "Resnično"
 
 # common/fs_mem.cpp:202
-#: ../src/common/fs_mem.cpp:227
+#: ../src/common/fs_mem.cpp:222
 #, c-format
 msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
 msgstr ""
 "Poskus odstanitve datoteke '%s' iz spominskega VFS, vendar ni naložena!"
 
-#: ../src/common/fmapbase.cpp:156
+#: ../src/common/fmapbase.cpp:153
 msgid "Turkish (ISO-8859-9)"
 msgstr "turško (ISO-8859-9)"
 
-#: ../src/generic/filectrlg.cpp:426
+#: ../src/generic/filectrlg.cpp:422
 msgid "Type"
 msgstr "Vrsta"
 
@@ -8235,17 +8411,17 @@ msgstr "Vpišite ime pisave."
 msgid "Type a size in points."
 msgstr "Vnesite velikost v točkah."
 
-#: ../src/msw/ole/automtn.cpp:676
+#: ../src/msw/ole/automtn.cpp:667
 #, c-format
 msgid "Type mismatch in argument %u."
 msgstr "Neujemanje vrste v argumentu %u."
 
-#: ../src/common/xtixml.cpp:356 ../src/common/xtixml.cpp:509
-#: ../src/common/xtistrm.cpp:318
+#: ../src/common/xtixml.cpp:352 ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315
 msgid "Type must have enum - long conversion"
 msgstr "Tip mora imeti pretvorbo enum - long"
 
-#: ../src/propgrid/propgridiface.cpp:401
+#: ../src/propgrid/propgridiface.cpp:385
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
@@ -8254,19 +8430,19 @@ msgstr ""
 "Operacija »%s« je spodletela: lastnost z oznako »%s« je vrste »%s« in NE "
 "»%s«."
 
-#: ../src/common/paper.cpp:133
+#: ../src/common/paper.cpp:130
 msgid "US Std Fanfold, 14 7/8 x 11 in"
 msgstr "US Std Fanfold, 14 7/8 x 11 pal."
 
-#: ../src/common/fmapbase.cpp:196
+#: ../src/common/fmapbase.cpp:193
 msgid "US-ASCII"
 msgstr "US-ASCII"
 
-#: ../src/unix/fswatcher_inotify.cpp:109
+#: ../src/unix/fswatcher_inotify.cpp:106
 msgid "Unable to add inotify watch"
 msgstr "Ni mogoče dodati opazovalnice inotify."
 
-#: ../src/unix/fswatcher_kqueue.cpp:136
+#: ../src/unix/fswatcher_kqueue.cpp:153
 msgid "Unable to add kqueue watch"
 msgstr "Ni mogoče dodati opazovalnice kqueue"
 
@@ -8280,7 +8456,7 @@ msgid "Unable to close I/O completion port handle"
 msgstr "Ni mogoče zapreti ročice vrat dokončanja V/I."
 
 # common/ffile.cpp:182
-#: ../src/unix/fswatcher_inotify.cpp:97
+#: ../src/unix/fswatcher_inotify.cpp:94
 msgid "Unable to close inotify instance"
 msgstr "Neuspešno zapiranje instance inotify"
 
@@ -8303,17 +8479,17 @@ msgid "Unable to create I/O completion port"
 msgstr "Ni mogoče ustvariti ročice vrat dokončanja V/I."
 
 # msw/mdi.cpp:428
-#: ../src/msw/fswatcher.cpp:84
+#: ../src/msw/fswatcher.cpp:81
 msgid "Unable to create IOCP worker thread"
 msgstr "Ni mogoče ustvariti niti delovanja IOCP"
 
 # msw/dde.cpp:934
-#: ../src/unix/fswatcher_inotify.cpp:74
+#: ../src/unix/fswatcher_inotify.cpp:71
 msgid "Unable to create inotify instance"
 msgstr "Instance inotify ni mogoče ustvariti."
 
 # msw/dde.cpp:934
-#: ../src/unix/fswatcher_kqueue.cpp:97
+#: ../src/unix/fswatcher_kqueue.cpp:114
 msgid "Unable to create kqueue instance"
 msgstr "Instance kqueue ni mogoče ustvariti."
 
@@ -8321,11 +8497,11 @@ msgstr "Instance kqueue ni mogoče ustvariti."
 msgid "Unable to dequeue completion packet"
 msgstr "Paketa dokončanja ni mogoče postaviti iz vrste"
 
-#: ../src/unix/fswatcher_kqueue.cpp:185
+#: ../src/unix/fswatcher_kqueue.cpp:202
 msgid "Unable to get events from kqueue"
 msgstr "Ni mogoče pridobiti dogodkov iz kqueue"
 
-#: ../src/gtk/app.cpp:435
+#: ../src/gtk/app.cpp:431
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr ""
 "GTK+ ni mogoče inicializirati, je spremenljivka DISPLAY nastavljena pravilno?"
@@ -8337,12 +8513,12 @@ msgid "Unable to open path '%s'"
 msgstr "Poti »%s« ni mogoče odpreti."
 
 # html/htmlwin.cpp:175
-#: ../src/html/htmlwin.cpp:583
+#: ../src/html/htmlwin.cpp:586
 #, c-format
 msgid "Unable to open requested HTML document: %s"
 msgstr "Zahtevanega HTML dokumenta ni mogoče odpreti: %s"
 
-#: ../src/unix/sound.cpp:368
+#: ../src/unix/sound.cpp:365
 msgid "Unable to play sound asynchronously."
 msgstr "Zvoka ni bilo mogoče predvajati nesinhrono."
 
@@ -8351,69 +8527,69 @@ msgid "Unable to post completion status"
 msgstr "Ni mogoče objaviti stanje dokončanosti."
 
 # common/file.cpp:285
-#: ../src/unix/fswatcher_inotify.cpp:556
+#: ../src/unix/fswatcher_inotify.cpp:553
 msgid "Unable to read from inotify descriptor"
 msgstr "Ni mogoče brati iz deskriptorja inotify"
 
-#: ../src/unix/fswatcher_inotify.cpp:141
+#: ../src/unix/fswatcher_inotify.cpp:138
 #, c-format
 msgid "Unable to remove inotify watch %i"
 msgstr "Ni mogoče odstraniti opazovalnice inotify %i."
 
-#: ../src/unix/fswatcher_kqueue.cpp:153
+#: ../src/unix/fswatcher_kqueue.cpp:170
 msgid "Unable to remove kqueue watch"
 msgstr "Ni mogoče odstraniti opazovalnice kqueue."
 
 # common/ffile.cpp:182
-#: ../src/msw/fswatcher.cpp:168
+#: ../src/msw/fswatcher.cpp:165
 #, c-format
 msgid "Unable to set up watch for '%s'"
 msgstr "Datoteki »%s« ni mogoče določiti opazovanja."
 
-#: ../src/msw/fswatcher.cpp:91
+#: ../src/msw/fswatcher.cpp:88
 msgid "Unable to start IOCP worker thread"
 msgstr "Ni mogoče začeti niti delovanja IOCP"
 
 # generic/fontdlgg.cpp:242
-#: ../src/common/stockitem.cpp:201
+#: ../src/common/stockitem.cpp:198
 msgid "Undelete"
 msgstr "Razveljavi brisanje"
 
 # generic/fontdlgg.cpp:242
-#: ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199
 msgid "Underline"
 msgstr "Podčrtaj"
 
 # generic/fontdlgg.cpp:242
 #. TRANSLATORS: Label of underlined font
-#: ../src/richtext/richtextfontpage.cpp:359 ../src/osx/carbon/fontdlg.cpp:370
-#: ../src/propgrid/advprops.cpp:690
+#: ../src/osx/carbon/fontdlg.cpp:367 ../src/propgrid/advprops.cpp:600
+#: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Podčrtano"
 
 # common/docview.cpp:1951
-#: ../src/common/stockitem.cpp:203 ../src/stc/stc_i18n.cpp:15
+#: ../src/common/stockitem.cpp:200 ../src/stc/stc_i18n.cpp:15
 msgid "Undo"
 msgstr "Razveljavi"
 
-#: ../src/common/stockitem.cpp:265
+#: ../src/common/stockitem.cpp:263
 msgid "Undo last action"
 msgstr "Razveljavi zadnje dejanje"
 
 # common/cmdline.cpp:712
-#: ../src/common/cmdline.cpp:1029
+#: ../src/common/cmdline.cpp:1025
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Parametru '%s' sledijo nepričakovani znaki."
 
-#: ../src/unix/fswatcher_inotify.cpp:274
+#: ../src/unix/fswatcher_inotify.cpp:271
 #, c-format
 msgid "Unexpected event for \"%s\": no matching watch descriptor."
 msgstr ""
 "Nepričakovan dogodek za »%s«: ni ujemajočega opazovalnega deskriptorja."
 
 # common/cmdline.cpp:712
-#: ../src/common/cmdline.cpp:1195
+#: ../src/common/cmdline.cpp:1191
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Nepričakovan parameter '%s'"
@@ -8423,49 +8599,49 @@ msgid "Unexpectedly new I/O completion port was created"
 msgstr "Nepričakovano so ustvarjena nova vrata dokončanja V/I."
 
 # msw/thread.cpp:871
-#: ../src/msw/fswatcher.cpp:70
+#: ../src/msw/fswatcher.cpp:67
 msgid "Ungraceful worker thread termination"
 msgstr "Nerodno dokončanje niti delovanja"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:460
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:456
+#: ../src/richtext/richtextsymboldlg.cpp:457
+#: ../src/richtext/richtextsymboldlg.cpp:458
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../src/common/fmapbase.cpp:185 ../src/common/fmapbase.cpp:191
+#: ../src/common/fmapbase.cpp:182 ../src/common/fmapbase.cpp:188
 msgid "Unicode 16 bit (UTF-16)"
 msgstr "Unicode, 16-bitno (UTF-16)"
 
-#: ../src/common/fmapbase.cpp:190
+#: ../src/common/fmapbase.cpp:187
 msgid "Unicode 16 bit Big Endian (UTF-16BE)"
 msgstr "Unicode, 16-bitno Big Endian (UTF-16BE)"
 
-#: ../src/common/fmapbase.cpp:186
+#: ../src/common/fmapbase.cpp:183
 msgid "Unicode 16 bit Little Endian (UTF-16LE)"
 msgstr "Unicode, 16-bitno Little Endian (UTF-16LE)"
 
-#: ../src/common/fmapbase.cpp:187 ../src/common/fmapbase.cpp:193
+#: ../src/common/fmapbase.cpp:184 ../src/common/fmapbase.cpp:190
 msgid "Unicode 32 bit (UTF-32)"
 msgstr "Unicode, 32-bitno (UTF-32)"
 
-#: ../src/common/fmapbase.cpp:192
+#: ../src/common/fmapbase.cpp:189
 msgid "Unicode 32 bit Big Endian (UTF-32BE)"
 msgstr "Unicode, 32-bitno Big Endian (UTF-32BE)"
 
-#: ../src/common/fmapbase.cpp:188
+#: ../src/common/fmapbase.cpp:185
 msgid "Unicode 32 bit Little Endian (UTF-32LE)"
 msgstr "Unicode, 32-bitno Little Endian (UTF-32LE)"
 
-#: ../src/common/fmapbase.cpp:182
+#: ../src/common/fmapbase.cpp:179
 msgid "Unicode 7 bit (UTF-7)"
 msgstr "Unicode, 7-bitno (UTF-7)"
 
-#: ../src/common/fmapbase.cpp:183
+#: ../src/common/fmapbase.cpp:180
 msgid "Unicode 8 bit (UTF-8)"
 msgstr "Unicode, 8-bitno (UTF-8)"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "Unindent"
 msgstr "Nezamaknjeno"
 
@@ -8622,79 +8798,84 @@ msgid "Units for this value."
 msgstr "Enote za to vrednost."
 
 # generic/progdlgg.cpp:241
-#: ../src/generic/progdlgg.cpp:353 ../src/generic/progdlgg.cpp:622
+#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
 msgid "Unknown"
 msgstr "neznan"
 
 # msw/dde.cpp:1030
-#: ../src/msw/dde.cpp:1174
+#: ../src/msw/dde.cpp:1238
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Neznana napaka DDE %08x"
 
-#: ../src/common/xtistrm.cpp:410
+#: ../src/common/xtistrm.cpp:407
 msgid "Unknown Object passed to GetObjectClassInfo"
 msgstr "Neznan objekt pripuščen k GetObjectClassInfo"
 
-#: ../src/common/imagpng.cpp:366
+#: ../src/common/imagpng.cpp:383
 #, c-format
 msgid "Unknown PNG resolution unit %d"
 msgstr "Neznana enota ločljivosti PNG %d"
 
 # common/cmdline.cpp:518
-#: ../src/common/xtixml.cpp:327
+#: ../src/common/xtixml.cpp:323
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Neznana lastnost %s"
 
-#: ../src/common/imagtiff.cpp:529
+#: ../src/common/imagtiff.cpp:526
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "Neznana enota ločljivosti TIFF %d bo prezrta"
 
-#: ../src/unix/dlunix.cpp:160
+#: ../src/propgrid/props.cpp:155
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/unix/dlunix.cpp:118
 msgid "Unknown dynamic library error"
 msgstr "Neznana napaka dinamične knjižnice"
 
 # common/fontmap.cpp:332
-#: ../src/common/fmapbase.cpp:810
+#: ../src/common/fmapbase.cpp:806
 #, c-format
 msgid "Unknown encoding (%d)"
 msgstr "nepoznano kodiranje (%d)"
 
 # msw/dde.cpp:1030
-#: ../src/msw/ole/automtn.cpp:688
+#: ../src/msw/ole/automtn.cpp:679
 #, c-format
 msgid "Unknown error %08x"
 msgstr "Neznana napaka %08x"
 
 # common/cmdline.cpp:518
-#: ../src/msw/ole/automtn.cpp:647
+#: ../src/msw/ole/automtn.cpp:638
 msgid "Unknown exception"
 msgstr "Nepoznana izjema"
 
-#: ../src/common/image.cpp:2839
+#: ../src/common/image.cpp:2942
 msgid "Unknown image data format."
 msgstr "Neznana vrsta slikovnih podatkov."
 
 # common/cmdline.cpp:496
-#: ../src/common/cmdline.cpp:914
+#: ../src/common/cmdline.cpp:910
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Nepoznana dolga opcija '%s'"
 
-#: ../src/msw/ole/automtn.cpp:631
+#: ../src/msw/ole/automtn.cpp:622
 msgid "Unknown name or named argument."
 msgstr "Neznano ime ali imenovani argument."
 
 # common/cmdline.cpp:518
-#: ../src/common/cmdline.cpp:929 ../src/common/cmdline.cpp:951
+#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Nepoznana opcija '%s'"
 
 # common/mimecmn.cpp:161
-#: ../src/common/mimecmn.cpp:225
+#: ../src/common/mimecmn.cpp:221
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "Neujemajoči '{' v vnosu za vsto mime %s."
@@ -8702,30 +8883,30 @@ msgstr "Neujemajoči '{' v vnosu za vsto mime %s."
 # common/docview.cpp:1923
 # common/docview.cpp:1938
 # common/docview.cpp:1965
-#: ../src/common/cmdproc.cpp:262 ../src/common/cmdproc.cpp:288
-#: ../src/common/cmdproc.cpp:308
+#: ../src/common/cmdproc.cpp:255 ../src/common/cmdproc.cpp:281
+#: ../src/common/cmdproc.cpp:301
 msgid "Unnamed command"
 msgstr "Neimenovan ukaz"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:413
+#: ../src/propgrid/propgrid.cpp:392
 msgid "Unspecified"
 msgstr "Nedoločeno"
 
 # msw/clipbrd.cpp:268
 # msw/clipbrd.cpp:369
-#: ../src/msw/clipbrd.cpp:311
+#: ../src/msw/clipbrd.cpp:325
 msgid "Unsupported clipboard format."
 msgstr "Nepodprta oblika zapisa za odložišče."
 
-#: ../src/common/appcmn.cpp:256
+#: ../src/common/appcmn.cpp:277
 #, c-format
 msgid "Unsupported theme '%s'."
 msgstr "Nepodprta tema '%s'."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:205
-#: ../src/common/accelcmn.cpp:63
+#: ../src/common/stockitem.cpp:202 ../src/common/accelcmn.cpp:60
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Up"
 msgstr "Navzgor"
 
@@ -8740,7 +8921,7 @@ msgid "Upper case roman numerals"
 msgstr "Velike rimske številke"
 
 # common/cmdline.cpp:797
-#: ../src/common/cmdline.cpp:1326
+#: ../src/common/cmdline.cpp:1322
 #, c-format
 msgid "Usage: %s"
 msgstr "Uporaba: %s"
@@ -8749,39 +8930,48 @@ msgstr "Uporaba: %s"
 msgid "Use &shadow"
 msgstr "Uporabi &senco"
 
-#: ../src/richtext/richtextindentspage.cpp:169
-#: ../src/richtext/richtextindentspage.cpp:171
 #: ../src/richtext/richtextliststylepage.cpp:358
 #: ../src/richtext/richtextliststylepage.cpp:360
+#: ../src/richtext/richtextindentspage.cpp:169
+#: ../src/richtext/richtextindentspage.cpp:171
 msgid "Use the current alignment setting."
 msgstr "Uporabi trenutno nastavitev poravnave."
 
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/gtk/font.cpp:552
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
 # common/valtext.cpp:188
-#: ../src/common/valtext.cpp:179
+#: ../src/common/valtext.cpp:142
 msgid "Validation conflict"
 msgstr "Konflikt pri preverjanju"
 
-#: ../src/propgrid/manager.cpp:238
+#: ../src/propgrid/manager.cpp:224
 msgid "Value"
 msgstr "Vrednost"
 
-#: ../src/propgrid/props.cpp:386 ../src/propgrid/props.cpp:500
+#: ../src/propgrid/props.cpp:309
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "Vrednost mora biti enaka %s ali višja."
 
-#: ../src/propgrid/props.cpp:417 ../src/propgrid/props.cpp:531
+#: ../src/propgrid/props.cpp:336
 #, c-format
 msgid "Value must be %s or less."
 msgstr "Vrednost mora biti enaka %s ali manjša."
 
-#: ../src/propgrid/props.cpp:393 ../src/propgrid/props.cpp:424
-#: ../src/propgrid/props.cpp:507 ../src/propgrid/props.cpp:538
+#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "Vnesite številko strani med %s in %s."
 
-#: ../src/generic/aboutdlgg.cpp:128
+#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Različica "
 
@@ -8793,27 +8983,34 @@ msgid "Vertical alignment."
 msgstr "Navpična poravnava."
 
 # generic/filedlgg.cpp:861
-#: ../src/generic/filedlgg.cpp:202
+#: ../src/generic/filedlgg.cpp:199
 msgid "View files as a detailed view"
 msgstr "Prikaži datoteke s podrobnostmi"
 
 # generic/filedlgg.cpp:855
-#: ../src/generic/filedlgg.cpp:200
+#: ../src/generic/filedlgg.cpp:197
 msgid "View files as a list view"
 msgstr "Prikaži datoteke kot seznam"
 
 # common/docview.cpp:1494
-#: ../src/common/docview.cpp:1970
+#: ../src/common/docview.cpp:1975
 msgid "Views"
 msgstr "Pogledi"
 
+#: ../src/gtk/app.cpp:348
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1777
+#: ../src/propgrid/advprops.cpp:1678
 msgid "Wait"
 msgstr "Čakaj"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1779
+#: ../src/propgrid/advprops.cpp:1680
 msgid "Wait Arrow"
 msgstr "Puščica čakanja"
 
@@ -8823,48 +9020,48 @@ msgid "Waiting for IO on epoll descriptor %d failed"
 msgstr "Čakanje na V/I na deskriptorju epoll %d ni uspelo"
 
 # common/log.cpp:366
-#: ../src/common/log.cpp:223
+#: ../src/common/log.cpp:241
 msgid "Warning: "
 msgstr "Opozorilo: "
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1778
+#: ../src/propgrid/advprops.cpp:1679
 msgid "Watch"
 msgstr "Opazuj"
 
 # generic/fontdlgg.cpp:216
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:685
+#: ../src/propgrid/advprops.cpp:595
 msgid "Weight"
 msgstr "Debelina"
 
-#: ../src/common/fmapbase.cpp:148
+#: ../src/common/fmapbase.cpp:145
 msgid "Western European (ISO-8859-1)"
 msgstr "zahodnoevropsko (ISO-8859-1)"
 
-#: ../src/common/fmapbase.cpp:162
+#: ../src/common/fmapbase.cpp:159
 msgid "Western European with Euro (ISO-8859-15)"
 msgstr "zahodnoevropsko z Evrom (ISO-8859-15)"
 
-#: ../src/generic/fontdlgg.cpp:446 ../src/generic/fontdlgg.cpp:448
+#: ../src/generic/fontdlgg.cpp:443 ../src/generic/fontdlgg.cpp:445
 msgid "Whether the font is underlined."
 msgstr "Če je pisava podčrtana ali ne."
 
-#: ../src/propgrid/advprops.cpp:1611
+#: ../src/propgrid/advprops.cpp:1517
 msgid "White"
 msgstr "Bela"
 
 # html/helpfrm.cpp:406
-#: ../src/generic/fdrepdlg.cpp:144
+#: ../src/generic/fdrepdlg.cpp:141
 msgid "Whole word"
 msgstr "Cela beseda"
 
 # html/helpfrm.cpp:406
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:532
 msgid "Whole words only"
 msgstr "Samo cele besede"
 
-#: ../src/univ/themes/win32.cpp:1102
+#: ../src/univ/themes/win32.cpp:1099
 msgid "Win32 theme"
 msgstr "Tema Win32"
 
@@ -8872,7 +9069,7 @@ msgstr "Tema Win32"
 # msw/mdi.cpp:1294
 # msw/window.cpp:2286
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:893
+#: ../src/propgrid/advprops.cpp:794
 msgid "Window"
 msgstr "Okno"
 
@@ -8880,7 +9077,7 @@ msgstr "Okno"
 # msw/mdi.cpp:1294
 # msw/window.cpp:2286
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:894
+#: ../src/propgrid/advprops.cpp:795
 msgid "WindowFrame"
 msgstr "OkvirOkna"
 
@@ -8888,195 +9085,191 @@ msgstr "OkvirOkna"
 # msw/mdi.cpp:1294
 # msw/window.cpp:2286
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:895
+#: ../src/propgrid/advprops.cpp:796
 msgid "WindowText"
 msgstr "BesediloOkna"
 
-#: ../src/common/fmapbase.cpp:177
+#: ../src/common/fmapbase.cpp:174
 msgid "Windows Arabic (CP 1256)"
 msgstr "Windows - arabsko (CP 1256)"
 
-#: ../src/common/fmapbase.cpp:178
+#: ../src/common/fmapbase.cpp:175
 msgid "Windows Baltic (CP 1257)"
 msgstr "Windows - baltsko (CP 1257)"
 
-#: ../src/common/fmapbase.cpp:171
+#: ../src/common/fmapbase.cpp:168
 msgid "Windows Central European (CP 1250)"
 msgstr "Windows - srednjeevropsko (CP 1250)"
 
-#: ../src/common/fmapbase.cpp:168
+#: ../src/common/fmapbase.cpp:165
 msgid "Windows Chinese Simplified (CP 936) or GB-2312"
 msgstr "Windows - kitajsko, poenostavljeno (CP 936) ali GB-2312"
 
-#: ../src/common/fmapbase.cpp:170
+#: ../src/common/fmapbase.cpp:167
 msgid "Windows Chinese Traditional (CP 950) or Big-5"
 msgstr "Windows - kitajsko, tradicionalno (CP 950) ali Big-5"
 
-#: ../src/common/fmapbase.cpp:172
+#: ../src/common/fmapbase.cpp:169
 msgid "Windows Cyrillic (CP 1251)"
 msgstr "Windows - cirilično (CP 1251)"
 
-#: ../src/common/fmapbase.cpp:174
+#: ../src/common/fmapbase.cpp:171
 msgid "Windows Greek (CP 1253)"
 msgstr "Windows - grško (CP 1253)"
 
-#: ../src/common/fmapbase.cpp:176
+#: ../src/common/fmapbase.cpp:173
 msgid "Windows Hebrew (CP 1255)"
 msgstr "Windows - hebrejsko (CP 1255)"
 
-#: ../src/common/fmapbase.cpp:167
+#: ../src/common/fmapbase.cpp:164
 msgid "Windows Japanese (CP 932) or Shift-JIS"
 msgstr "Windows - japonsko (CP 932) ali Shift-JIS"
 
-#: ../src/common/fmapbase.cpp:180
+#: ../src/common/fmapbase.cpp:177
 msgid "Windows Johab (CP 1361)"
 msgstr "Windows - johabsko (CP 1361)"
 
-#: ../src/common/fmapbase.cpp:169
+#: ../src/common/fmapbase.cpp:166
 msgid "Windows Korean (CP 949)"
 msgstr "Windows - korejsko (CP 949)"
 
-#: ../src/common/fmapbase.cpp:166
+#: ../src/common/fmapbase.cpp:163
 msgid "Windows Thai (CP 874)"
 msgstr "Windows - tajsko (CP 874)"
 
-#: ../src/common/fmapbase.cpp:175
+#: ../src/common/fmapbase.cpp:172
 msgid "Windows Turkish (CP 1254)"
 msgstr "Windows - turško (CP 1254)"
 
-#: ../src/common/fmapbase.cpp:179
+#: ../src/common/fmapbase.cpp:176
 msgid "Windows Vietnamese (CP 1258)"
 msgstr "Windows - vietnamsko (CP 1258)"
 
-#: ../src/common/fmapbase.cpp:173
+#: ../src/common/fmapbase.cpp:170
 msgid "Windows Western European (CP 1252)"
 msgstr "Windows - zahodnoevropsko (CP 1252)"
 
-#: ../src/common/fmapbase.cpp:181
+#: ../src/common/fmapbase.cpp:178
 msgid "Windows/DOS OEM (CP 437)"
 msgstr "Windows/DOS OEM (CP 437)"
 
-#: ../src/common/fmapbase.cpp:165
+#: ../src/common/fmapbase.cpp:162
 msgid "Windows/DOS OEM Cyrillic (CP 866)"
 msgstr "Windows/DOS OEM - cirilično (CP 866)"
 
 # msw/utils.cpp:549
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:111
+#: ../src/common/accelcmn.cpp:109
 msgid "Windows_Left"
 msgstr "Windows_Levo"
 
 # msw/utils.cpp:549
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:113
+#: ../src/common/accelcmn.cpp:111
 msgid "Windows_Menu"
 msgstr "Windows_Meni"
 
 # msw/utils.cpp:549
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:112
+#: ../src/common/accelcmn.cpp:110
 msgid "Windows_Right"
 msgstr "Windows_Desno"
 
 # common/ffile.cpp:168
-#: ../src/common/ffile.cpp:150
+#: ../src/common/ffile.cpp:149
 #, c-format
 msgid "Write error on file '%s'"
 msgstr "Napaka pri pisanju datoteke »%s«"
 
-#: ../src/xml/xml.cpp:914
+#: ../src/xml/xml.cpp:925
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "Napaka razčlenjevanja XML: '%s' v vrstici %d"
 
-#: ../src/common/xpmdecod.cpp:796
+#: ../src/common/xpmdecod.cpp:794
 msgid "XPM: Malformed pixel data!"
 msgstr "XPM: napačno oblikovani podatki točk!"
 
-#: ../src/common/xpmdecod.cpp:705
+#: ../src/common/xpmdecod.cpp:702
 #, c-format
 msgid "XPM: incorrect colour description in line %d"
 msgstr "XPM: napačen opis barve v vrstici %d"
 
-#: ../src/common/xpmdecod.cpp:680
+#: ../src/common/xpmdecod.cpp:677
 msgid "XPM: incorrect header format!"
 msgstr "XPM: napačno oblikovana glava!"
 
-#: ../src/common/xpmdecod.cpp:716 ../src/common/xpmdecod.cpp:725
+#: ../src/common/xpmdecod.cpp:714 ../src/common/xpmdecod.cpp:723
 #, c-format
 msgid "XPM: malformed colour definition '%s' at line %d!"
 msgstr "XPM: napačno oblikovana definicija barve '%s' v vrstici %d!"
 
-#: ../src/common/xpmdecod.cpp:755
+#: ../src/common/xpmdecod.cpp:753
 msgid "XPM: no colors left to use for mask!"
 msgstr "XPM: ni več barv na voljo za masko!"
 
-#: ../src/common/xpmdecod.cpp:782
+#: ../src/common/xpmdecod.cpp:780
 #, c-format
 msgid "XPM: truncated image data at line %d!"
 msgstr "XPM: nedokončani podatki slike v vrstici %d!"
 
-#: ../src/propgrid/advprops.cpp:1610
+#: ../src/propgrid/advprops.cpp:1516
 msgid "Yellow"
 msgstr "Rumena"
 
 # common/dlgcmn.cpp:109
 # common/dlgcmn.cpp:116
-#: ../include/wx/msgdlg.h:276 ../src/common/stockitem.cpp:206
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:203
 #: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Da"
 
 # generic/dirdlgg.cpp:571
-#: ../src/osx/carbon/overlay.cpp:155
-msgid "You cannot Clear an overlay that is not inited"
-msgstr "Ne morete počistiti prekrivanja, ki ni inicializirano"
-
-#: ../src/osx/carbon/overlay.cpp:107 ../src/dfb/overlay.cpp:61
-msgid "You cannot Init an overlay twice"
-msgstr "Init zaslona ni možen dvakrat"
-
-# generic/dirdlgg.cpp:571
-#: ../src/generic/dirdlgg.cpp:287
+#: ../src/generic/dirdlgg.cpp:284
 msgid "You cannot add a new directory to this section."
 msgstr "Ne morete dodati nove mape v ta del."
 
-#: ../src/propgrid/propgrid.cpp:3299
+#: ../src/propgrid/propgrid.cpp:3276
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 "Vnesli ste neveljavno vrednost. Pritisnite ubežnico za preklic urejanja."
 
-#: ../src/common/stockitem.cpp:209
+#: ../src/osx/cocoa/menu.mm:286
+#, fuzzy
+msgid "Zoom"
+msgstr "Povečaj"
+
+#: ../src/common/stockitem.cpp:206
 msgid "Zoom &In"
 msgstr "Pove&čaj"
 
-#: ../src/common/stockitem.cpp:210
+#: ../src/common/stockitem.cpp:207
 msgid "Zoom &Out"
 msgstr "Po&manjšaj"
 
-#: ../src/common/stockitem.cpp:209 ../src/common/prntbase.cpp:1594
+#: ../src/common/stockitem.cpp:206 ../src/common/prntbase.cpp:1619
 msgid "Zoom In"
 msgstr "Povečaj"
 
-#: ../src/common/stockitem.cpp:210 ../src/common/prntbase.cpp:1580
+#: ../src/common/stockitem.cpp:207 ../src/common/prntbase.cpp:1605
 msgid "Zoom Out"
 msgstr "Pomanjšaj"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to &Fit"
 msgstr "Prilagodi &pogledu"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to Fit"
 msgstr "Prilagodi pogledu"
 
 # msw/dde.cpp:997
-#: ../src/msw/dde.cpp:1141
+#: ../src/msw/dde.cpp:1205
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "Program DDEML je ustvaril podaljšano stanje sledenja."
 
 # msw/dde.cpp:985
-#: ../src/msw/dde.cpp:1129
+#: ../src/msw/dde.cpp:1193
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -9088,47 +9281,47 @@ msgstr ""
 "neveljaven določitelj instance."
 
 # msw/dde.cpp:1003
-#: ../src/msw/dde.cpp:1147
+#: ../src/msw/dde.cpp:1211
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "poskus odjemalca, da bi vzpostavil pogovor, ni uspel."
 
 # msw/dde.cpp:1000
-#: ../src/msw/dde.cpp:1144
+#: ../src/msw/dde.cpp:1208
 msgid "a memory allocation failed."
 msgstr "alokacija spomina ni uspela."
 
 # msw/dde.cpp:994
-#: ../src/msw/dde.cpp:1138
+#: ../src/msw/dde.cpp:1202
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "DDEML ni uspešno potrdil veljavnosti parametra."
 
 # msw/dde.cpp:976
-#: ../src/msw/dde.cpp:1120
+#: ../src/msw/dde.cpp:1184
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "zahteva za sinhrono usklajevalno transakcijo je časovno potekla."
 
 # msw/dde.cpp:982
-#: ../src/msw/dde.cpp:1126
+#: ../src/msw/dde.cpp:1190
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "zahteva za sinhrono podatkovno transakcijo je časovno potekla."
 
 # msw/dde.cpp:991
-#: ../src/msw/dde.cpp:1135
+#: ../src/msw/dde.cpp:1199
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "zahteva za sinhrono izvajalno transakcijo je časovno potekla."
 
 # msw/dde.cpp:1009
-#: ../src/msw/dde.cpp:1153
+#: ../src/msw/dde.cpp:1217
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "zahteva za sinhrono transakcijo poke je časovno potekla."
 
 # msw/dde.cpp:1024
-#: ../src/msw/dde.cpp:1168
+#: ../src/msw/dde.cpp:1232
 msgid "a request to end an advise transaction has timed out."
 msgstr "zahteva za prekinitev usklajevalne transakcije je časovno potekla."
 
 # msw/dde.cpp:1018
-#: ../src/msw/dde.cpp:1162
+#: ../src/msw/dde.cpp:1226
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -9139,17 +9332,17 @@ msgstr ""
 "prekinil odjemalec ali strežnik."
 
 # msw/dde.cpp:1006
-#: ../src/msw/dde.cpp:1150
+#: ../src/msw/dde.cpp:1214
 msgid "a transaction failed."
 msgstr "transakcija ni uspela"
 
 # common/utilscmn.cpp:466
-#: ../src/common/accelcmn.cpp:189
+#: ../src/common/accelcmn.cpp:188
 msgid "alt"
 msgstr "ALT"
 
 # msw/dde.cpp:988
-#: ../src/msw/dde.cpp:1132
+#: ../src/msw/dde.cpp:1196
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -9162,17 +9355,17 @@ msgstr ""
 "poskusila izvesti strežniške transakcije."
 
 # msw/dde.cpp:1012
-#: ../src/msw/dde.cpp:1156
+#: ../src/msw/dde.cpp:1220
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "notranji klic funkcije PostMessage ni uspel."
 
 # msw/dde.cpp:1021
-#: ../src/msw/dde.cpp:1165
+#: ../src/msw/dde.cpp:1229
 msgid "an internal error has occurred in the DDEML."
 msgstr "v DDEML je prišlo do notranje napake."
 
 # msw/dde.cpp:1027
-#: ../src/msw/dde.cpp:1171
+#: ../src/msw/dde.cpp:1235
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -9182,50 +9375,50 @@ msgstr ""
 "Ko se je aplikacija vrnila s povratnega klica XTYP_XACT_COMPLETE,\n"
 "identifikator transakcije za ta povratni klic ni več veljaven."
 
-#: ../src/common/zipstrm.cpp:1483
+#: ../src/common/zipstrm.cpp:1522
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "predvidevajoč, da gre za povezan večdelni zip"
 
 # common/fileconf.cpp:1450
-#: ../src/common/fileconf.cpp:1847
+#: ../src/common/fileconf.cpp:1849
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "poskus spremembe nestremenjivega ključa '%s' je bil ignoriran."
 
-#: ../src/html/chm.cpp:329
+#: ../src/html/chm.cpp:326
 msgid "bad arguments to library function"
 msgstr "neustrezni argumenti za funkcijo iz knjižnice"
 
-#: ../src/html/chm.cpp:341
+#: ../src/html/chm.cpp:338
 msgid "bad signature"
 msgstr "neuporaben podpis"
 
-#: ../src/common/zipstrm.cpp:1918
+#: ../src/common/zipstrm.cpp:1988
 msgid "bad zipfile offset to entry"
 msgstr "slab odmik zipfile od vnosa"
 
-#: ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400
 msgid "binary"
 msgstr "binarno"
 
 # generic/fontdlgg.cpp:217
-#: ../src/common/fontcmn.cpp:996
+#: ../src/common/fontcmn.cpp:1195
 msgid "bold"
 msgstr "krepko"
 
-#: ../src/msw/utils.cpp:1144
+#: ../src/msw/utils.cpp:1135
 #, c-format
 msgid "build %lu"
 msgstr "gradnja %lu"
 
 # common/ffile.cpp:101
-#: ../src/common/ffile.cpp:75
+#: ../src/common/ffile.cpp:73
 #, c-format
 msgid "can't close file '%s'"
 msgstr "ni mogoče zapreti datoteke '%s'"
 
 # common/file.cpp:257
-#: ../src/common/file.cpp:245
+#: ../src/common/file.cpp:242
 #, c-format
 msgid "can't close file descriptor %d"
 msgstr "ni mogoče zapreti datotečnega deskriptorja %d"
@@ -9236,7 +9429,7 @@ msgstr "ni mogoče zapreti datotečnega deskriptorja %d"
 #
 # common/file.cpp:557
 # common/file.cpp:567
-#: ../src/common/file.cpp:586
+#: ../src/common/ffile.cpp:382 ../src/common/file.cpp:613
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "ni mogoče uveljaviti sprememb datoteke '%s'"
@@ -9246,7 +9439,7 @@ msgstr "ni mogoče uveljaviti sprememb datoteke '%s'"
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 # common/file.cpp:200
-#: ../src/common/file.cpp:178
+#: ../src/common/file.cpp:175
 #, c-format
 msgid "can't create file '%s'"
 msgstr "ni mogoče ustvariti datoteke '%s'"
@@ -9262,7 +9455,7 @@ msgid "can't delete user configuration file '%s'"
 msgstr "ni mogoče uzbrisati uporabniške datoteke '%s'"
 
 # common/file.cpp:438
-#: ../src/common/file.cpp:495
+#: ../src/common/file.cpp:522
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr ""
@@ -9273,53 +9466,53 @@ msgstr ""
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 # common/ffile.cpp:234
-#: ../src/common/zipstrm.cpp:1692
+#: ../src/common/zipstrm.cpp:1747
 msgid "can't find central directory in zip"
 msgstr "ni mogoče najti osrednje mape v datoteki zip"
 
 # common/file.cpp:404
-#: ../src/common/file.cpp:465
+#: ../src/common/file.cpp:492
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "ni mogoče najti dolžine datoteke na datotečnem deskriptorju %d"
 
 # msw/utils.cpp:376
-#: ../src/msw/utils.cpp:341
+#: ../src/msw/utils.cpp:336
 msgid "can't find user's HOME, using current directory."
 msgstr "uporabnikove mape HOME ni mogoče najti, v uporabi je trenutna mapa."
 
 # common/file.cpp:319
-#: ../src/common/file.cpp:366
+#: ../src/common/file.cpp:407
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "ni mogoče izprazniti deskriptorja %d"
 
 # common/file.cpp:373
-#: ../src/common/file.cpp:422
+#: ../src/common/file.cpp:463
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "ni mogoče najti iskalne pozicije v datotečnem deskriptorju %d"
 
 # common/fontmap.cpp:646
-#: ../src/common/fontmap.cpp:325
+#: ../src/common/fontmap.cpp:322
 msgid "can't load any font, aborting"
 msgstr "ni mogoče naložiti katere koli posave, prekinjam"
 
 # common/ffile.cpp:85
 # common/file.cpp:243
-#: ../src/common/file.cpp:231 ../src/common/ffile.cpp:59
+#: ../src/common/ffile.cpp:57 ../src/common/file.cpp:228
 #, c-format
 msgid "can't open file '%s'"
 msgstr "ni mogoče odpreti datoteke '%s'"
 
 # common/fileconf.cpp:319
-#: ../src/common/fileconf.cpp:320
+#: ../src/common/fileconf.cpp:314
 #, c-format
 msgid "can't open global configuration file '%s'."
 msgstr "ni mogoče odpreti globalne konfiguracijske datoteke '%s'."
 
 # common/fileconf.cpp:331
-#: ../src/common/fileconf.cpp:336
+#: ../src/common/fileconf.cpp:330
 #, c-format
 msgid "can't open user configuration file '%s'."
 msgstr "ni mogoče odpreti uporabnikove konfiguracijske datoteke '%s'."
@@ -9330,17 +9523,17 @@ msgid "can't open user configuration file."
 msgstr "ni mogoče odpreti uporabniške konfiguracijske datoteke."
 
 # html/helpfrm.cpp:1174
-#: ../src/common/zipstrm.cpp:579
+#: ../src/common/zipstrm.cpp:572
 msgid "can't re-initialize zlib deflate stream"
 msgstr "ni mogoče ponovno incializirati upadalnega toka zlib"
 
 # html/helpfrm.cpp:1174
-#: ../src/common/zipstrm.cpp:604
+#: ../src/common/zipstrm.cpp:597
 msgid "can't re-initialize zlib inflate stream"
 msgstr "ni mogoče ponovno incializirati napihovalnega toka zlib"
 
 # common/file.cpp:285
-#: ../src/common/file.cpp:304
+#: ../src/common/file.cpp:345
 #, c-format
 msgid "can't read from file descriptor %d"
 msgstr "ni mogoče brati iz deskriptorja %d"
@@ -9351,7 +9544,7 @@ msgstr "ni mogoče brati iz deskriptorja %d"
 #
 # common/file.cpp:552
 # common/file.cpp:562
-#: ../src/common/file.cpp:581
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:608
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "ni mogoče odstraniti datoteke '%s'"
@@ -9362,13 +9555,13 @@ msgstr "ni mogoče odstraniti datoteke '%s'"
 #
 # common/file.cpp:580
 # common/file.cpp:583
-#: ../src/common/file.cpp:598
+#: ../src/common/ffile.cpp:394 ../src/common/file.cpp:625
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "ni mogoče odstraniti začasne datoteke '%s'"
 
 # common/file.cpp:359
-#: ../src/common/file.cpp:408
+#: ../src/common/file.cpp:449
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "ni mogoče iskati na datotečnem deskriptorju %d"
@@ -9378,13 +9571,13 @@ msgstr "ni mogoče iskati na datotečnem deskriptorju %d"
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 # common/textfile.cpp:359
-#: ../src/common/textfile.cpp:273
+#: ../src/common/textfile.cpp:161
 #, c-format
 msgid "can't write buffer '%s' to disk."
 msgstr "medpomnilnika '%s' ni možno zapisati na disk."
 
 # common/file.cpp:304
-#: ../src/common/file.cpp:323
+#: ../src/common/file.cpp:364
 #, c-format
 msgid "can't write to file descriptor %d"
 msgstr "ni mogoče pisati na deskriptor %d"
@@ -9395,22 +9588,28 @@ msgid "can't write user configuration file."
 msgstr "ni mogoče zapisati uporabniške konfiguracijske datoteke."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:482 ../src/generic/datavgen.cpp:1261
+#: ../src/common/datavcmn.cpp:2064 ../src/generic/datavgen.cpp:1384
 msgid "checked"
 msgstr "potrjeno"
 
-#: ../src/html/chm.cpp:345
+#: ../src/html/chm.cpp:342
 msgid "checksum error"
 msgstr "napaka kontrolne vsote"
 
-#: ../src/common/tarstrm.cpp:820
+#: ../src/common/tarstrm.cpp:814
 msgid "checksum failure reading tar header block"
 msgstr "napaka preverjanja preizkusne vsote pri branju bloka glave tar"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:226
-#: ../src/richtext/richtextbackgroundpage.cpp:249
-#: ../src/richtext/richtextbackgroundpage.cpp:289
-#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
 #: ../src/richtext/richtextborderspage.cpp:254
 #: ../src/richtext/richtextborderspage.cpp:288
 #: ../src/richtext/richtextborderspage.cpp:322
@@ -9428,113 +9627,140 @@ msgstr "napaka preverjanja preizkusne vsote pri branju bloka glave tar"
 #: ../src/richtext/richtextmarginspage.cpp:340
 #: ../src/richtext/richtextmarginspage.cpp:363
 #: ../src/richtext/richtextmarginspage.cpp:388
-#: ../src/richtext/richtextsizepage.cpp:339
-#: ../src/richtext/richtextsizepage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:400
-#: ../src/richtext/richtextsizepage.cpp:427
-#: ../src/richtext/richtextsizepage.cpp:454
-#: ../src/richtext/richtextsizepage.cpp:481
-#: ../src/richtext/richtextsizepage.cpp:555
-#: ../src/richtext/richtextsizepage.cpp:590
-#: ../src/richtext/richtextsizepage.cpp:625
-#: ../src/richtext/richtextsizepage.cpp:660
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
 msgid "cm"
 msgstr "cm"
 
-#: ../src/html/chm.cpp:347
+#: ../src/html/chm.cpp:344
 msgid "compression error"
 msgstr "napaka pri stiskanju"
 
-#: ../src/common/regex.cpp:236
+#: ../src/common/regex.cpp:233
 msgid "conversion to 8-bit encoding failed"
 msgstr "pretvorba v 8-bitno kodiranje ni uspela"
 
 # common/utilscmn.cpp:464
-#: ../src/common/accelcmn.cpp:187
+#: ../src/common/accelcmn.cpp:186
 msgid "ctrl"
 msgstr "KRMILKA"
 
 # common/cmdline.cpp:912
-#: ../src/common/cmdline.cpp:1500
+#: ../src/common/cmdline.cpp:1496
 msgid "date"
 msgstr "datum"
 
-#: ../src/html/chm.cpp:349
+#: ../src/html/chm.cpp:346
 msgid "decompression error"
 msgstr "napaka pri razširjanju"
 
-#: ../src/richtext/richtextstyles.cpp:780 ../src/common/fmapbase.cpp:820
+#: ../src/common/fmapbase.cpp:816 ../src/richtext/richtextstyles.cpp:777
 msgid "default"
 msgstr "privzeto"
 
-#: ../src/common/cmdline.cpp:1496
+#: ../src/common/cmdline.cpp:1492
 msgid "double"
 msgstr "dvojno"
 
-#: ../src/common/debugrpt.cpp:538
+#: ../src/common/debugrpt.cpp:539
 msgid "dump of the process state (binary)"
 msgstr "izmet stanja procesa (binarni)"
 
-#: ../src/common/datetimefmt.cpp:1969
+#: ../src/common/datetimefmt.cpp:1992
 msgid "eighteenth"
 msgstr "osemnajsti"
 
 # generic/fontdlgg.cpp:216
-#: ../src/common/datetimefmt.cpp:1959
+#: ../src/common/datetimefmt.cpp:1982
 msgid "eighth"
 msgstr "osmi"
 
-#: ../src/common/datetimefmt.cpp:1962
+#: ../src/common/datetimefmt.cpp:1985
 msgid "eleventh"
 msgstr "enajsti"
 
 # common/fileconf.cpp:1437
-#: ../src/common/fileconf.cpp:1833
+#: ../src/common/fileconf.cpp:1835
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "vnos '%s' se pojavi večkrat v skupini '%s'"
 
-#: ../src/html/chm.cpp:343
+#: ../src/html/chm.cpp:340
 msgid "error in data format"
 msgstr "napaka v zapisu podatkov"
 
 # common/ffile.cpp:133
 # common/ffile.cpp:154
-#: ../src/html/chm.cpp:331
+#: ../src/html/chm.cpp:328
 msgid "error opening file"
 msgstr "napaka pri odpiranju datoteke"
 
 # generic/dirdlgg.cpp:552
-#: ../src/common/zipstrm.cpp:1778
+#: ../src/common/zipstrm.cpp:1836
 msgid "error reading zip central directory"
 msgstr "napaka pri branju osrednje mape zip"
 
-#: ../src/common/zipstrm.cpp:1870
+#: ../src/common/zipstrm.cpp:1940
 msgid "error reading zip local header"
 msgstr "napaka pri branju lokalne glave zip"
 
-#: ../src/common/zipstrm.cpp:2531
+#: ../src/common/zipstrm.cpp:2615
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "napaka pri pisanju vnosa zip '%s': slab crc ali dolžina"
 
+#: ../src/common/zipstrm.cpp:2608
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "napaka pri pisanju vnosa zip '%s': slab crc ali dolžina"
+
+# generic/fontdlgg.cpp:217
+#: ../src/common/fontcmn.cpp:1205
+#, fuzzy
+msgid "extrabold"
+msgstr "krepko"
+
+#: ../src/common/fontcmn.cpp:1223
+msgid "extraheavy"
+msgstr ""
+
+# generic/fontdlgg.cpp:216
+#: ../src/common/fontcmn.cpp:1167
+#, fuzzy
+msgid "extralight"
+msgstr "svetlo"
+
 # common/ffile.cpp:182
-#: ../src/common/ffile.cpp:188
+#: ../src/msw/webview_ie.cpp:1036
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "'%s' ni mogoče izvesti\n"
+
+# common/ffile.cpp:182
+#: ../src/common/ffile.cpp:187
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "ne morem izprazniti datoteke '%s'"
 
+# msw/dialup.cpp:463
+#: ../src/msw/webview_ie.cpp:1045
+#, fuzzy
+msgid "failed to retrieve execution result"
+msgstr "Besedila sporočila o napaki RAS ni mogoče pridobiti."
+
 # generic/filedlgg.cpp:534
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1030
+#: ../src/generic/datavgen.cpp:1150
 msgid "false"
 msgstr "ni resnično"
 
-#: ../src/common/datetimefmt.cpp:1966
+#: ../src/common/datetimefmt.cpp:1989
 msgid "fifteenth"
 msgstr "petnajsti"
 
-#: ../src/common/datetimefmt.cpp:1956
+#: ../src/common/datetimefmt.cpp:1979
 msgid "fifth"
 msgstr "peti"
 
@@ -9570,147 +9796,166 @@ msgid "file '%s': unexpected character %c at line %zu."
 msgstr "datoteka »%s«: nepričakovan znak %c v vrstici %zu."
 
 # generic/filedlgg.cpp:534
-#: ../src/richtext/richtextbuffer.cpp:8738
+#: ../src/richtext/richtextbuffer.cpp:8736
 msgid "files"
 msgstr "datotek"
 
-#: ../src/common/datetimefmt.cpp:1952
+#: ../src/common/datetimefmt.cpp:1975
 msgid "first"
 msgstr "prvi"
 
 # html/helpfrm.cpp:899
-#: ../src/html/helpwnd.cpp:1252
+#: ../src/html/helpwnd.cpp:1250
 msgid "font size"
 msgstr "velikost pisave"
 
-#: ../src/common/datetimefmt.cpp:1965
+#: ../src/common/datetimefmt.cpp:1988
 msgid "fourteenth"
 msgstr "štirinajsti"
 
-#: ../src/common/datetimefmt.cpp:1955
+#: ../src/common/datetimefmt.cpp:1978
 msgid "fourth"
 msgstr "četrti"
 
-#: ../src/common/appbase.cpp:783
+#: ../src/common/appbase.cpp:784
 msgid "generate verbose log messages"
 msgstr "ustvari obširna dnevniška sporočila"
 
-#: ../src/richtext/richtextbuffer.cpp:13138
-#: ../src/richtext/richtextbuffer.cpp:13248
+#: ../src/common/fontcmn.cpp:1215
+msgid "heavy"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:13133
+#: ../src/richtext/richtextbuffer.cpp:13243
 msgid "image"
 msgstr "slika"
 
-#: ../src/common/tarstrm.cpp:796
+#: ../src/common/tarstrm.cpp:790
 msgid "incomplete header block in tar"
 msgstr "nepopolni blok glave v tar"
 
-#: ../src/common/xtixml.cpp:489
+#: ../src/common/xtixml.cpp:485
 msgid "incorrect event handler string, missing dot"
 msgstr "nepravilen niz ročice dogodka, manjka pika"
 
-#: ../src/common/tarstrm.cpp:1381
+#: ../src/common/tarstrm.cpp:1375
 msgid "incorrect size given for tar entry"
 msgstr "nepravilna velikost za vnos tar"
 
-#: ../src/common/tarstrm.cpp:993
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:987
 msgid "invalid data in extended tar header"
 msgstr "neveljavni podatki v razširjeni glavi tar"
 
 # generic/logg.cpp:1037
-#: ../src/generic/logg.cpp:1030
+#: ../src/generic/logg.cpp:1027
 msgid "invalid message box return value"
 msgstr "napačna vrnjena vrednost sporočilnega okna"
 
 # common/ffile.cpp:101
-#: ../src/common/zipstrm.cpp:1647
+#: ../src/common/zipstrm.cpp:1688
 msgid "invalid zip file"
 msgstr "neveljavna datoteka zip"
 
 # generic/fontdlgg.cpp:213
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:1228
 msgid "italic"
 msgstr "ležeče"
 
+# common/textcmn.cpp:94
+#: ../src/common/webrequest_curl.cpp:374
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "Datoteke ni mogoče naložiti."
+
 # generic/fontdlgg.cpp:216
-#: ../src/common/fontcmn.cpp:991
+#: ../src/common/fontcmn.cpp:1172
 msgid "light"
 msgstr "svetlo"
 
-# common/intl.cpp:575
-#: ../src/common/intl.cpp:303
-#, c-format
-msgid "locale '%s' cannot be set."
-msgstr "ne morem nastaviti locale '%s'."
+#: ../src/common/fontcmn.cpp:1185
+msgid "medium"
+msgstr ""
 
 # generic/fontdlgg.cpp:216
-#: ../src/common/datetimefmt.cpp:2125
+#: ../src/common/datetimefmt.cpp:2148
 msgid "midnight"
 msgstr "opolnoči"
 
-#: ../src/common/datetimefmt.cpp:1970
+#: ../src/common/datetimefmt.cpp:1993
 msgid "nineteenth"
 msgstr "devetnajsti"
 
 # generic/prntdlgg.cpp:113
 # generic/prntdlgg.cpp:127
-#: ../src/common/datetimefmt.cpp:1960
+#: ../src/common/datetimefmt.cpp:1983
 msgid "ninth"
 msgstr "deveti"
 
 # msw/dde.cpp:972
-#: ../src/msw/dde.cpp:1116
+#: ../src/msw/dde.cpp:1180
 msgid "no DDE error."
 msgstr "ni napake DDE."
 
 # generic/progdlgg.cpp:241
-#: ../src/html/chm.cpp:327
+#: ../src/html/chm.cpp:324
 msgid "no error"
 msgstr "brez napake"
 
-#: ../src/dfb/fontmgr.cpp:174
+#: ../src/dfb/fontmgr.cpp:171
 #, c-format
 msgid "no fonts found in %s, using builtin font"
 msgstr "v %s ni najdenih pisav, uporabljena bo vgrajena pisava"
 
 # html/helpdata.cpp:644
-#: ../src/html/helpdata.cpp:657
+#: ../src/html/helpdata.cpp:650
 msgid "noname"
 msgstr "neimanovana"
 
 # html/helpdata.cpp:644
-#: ../src/common/datetimefmt.cpp:2124
+#: ../src/common/datetimefmt.cpp:2147
 msgid "noon"
 msgstr "opoldne"
 
 # generic/fontdlgg.cpp:212
 # generic/fontdlgg.cpp:215
-#: ../src/richtext/richtextstyles.cpp:779
+#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "navadno"
 
 # common/cmdline.cpp:911
-#: ../src/common/cmdline.cpp:1492
+#: ../src/common/cmdline.cpp:1488
 msgid "num"
 msgstr "št"
 
-#: ../src/common/xtixml.cpp:259
+#: ../src/common/accelcmn.cpp:194
+msgid "num "
+msgstr ""
+
+#: ../src/common/xtixml.cpp:255
 msgid "objects cannot have XML Text Nodes"
 msgstr "objekti ne morejo imeti besedilnih vozlišč XML"
 
-#: ../src/html/chm.cpp:339
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
 msgid "out of memory"
 msgstr "premalo spomina"
 
-#: ../src/common/debugrpt.cpp:514
+#: ../src/common/debugrpt.cpp:515
 msgid "process context description"
 msgstr "opis konteksta procesa"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:227
-#: ../src/richtext/richtextbackgroundpage.cpp:250
-#: ../src/richtext/richtextbackgroundpage.cpp:290
-#: ../src/richtext/richtextbackgroundpage.cpp:317
-#: ../src/richtext/richtextfontpage.cpp:177
-#: ../src/richtext/richtextfontpage.cpp:180
 #: ../src/richtext/richtextborderspage.cpp:255
 #: ../src/richtext/richtextborderspage.cpp:289
 #: ../src/richtext/richtextborderspage.cpp:323
@@ -9720,22 +9965,45 @@ msgstr "opis konteksta procesa"
 #: ../src/richtext/richtextborderspage.cpp:491
 #: ../src/richtext/richtextborderspage.cpp:525
 #: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextfontpage.cpp:180
 msgid "pt"
 msgstr "pk"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:225
-#: ../src/richtext/richtextbackgroundpage.cpp:228
-#: ../src/richtext/richtextbackgroundpage.cpp:229
-#: ../src/richtext/richtextbackgroundpage.cpp:248
-#: ../src/richtext/richtextbackgroundpage.cpp:251
-#: ../src/richtext/richtextbackgroundpage.cpp:252
-#: ../src/richtext/richtextbackgroundpage.cpp:288
-#: ../src/richtext/richtextbackgroundpage.cpp:291
-#: ../src/richtext/richtextbackgroundpage.cpp:292
-#: ../src/richtext/richtextbackgroundpage.cpp:315
-#: ../src/richtext/richtextbackgroundpage.cpp:318
-#: ../src/richtext/richtextbackgroundpage.cpp:319
-#: ../src/richtext/richtextfontpage.cpp:178
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:659
+#: ../src/richtext/richtextsizepage.cpp:662
+#: ../src/richtext/richtextsizepage.cpp:663
 #: ../src/richtext/richtextborderspage.cpp:253
 #: ../src/richtext/richtextborderspage.cpp:256
 #: ../src/richtext/richtextborderspage.cpp:257
@@ -9787,276 +10055,279 @@ msgstr "pk"
 #: ../src/richtext/richtextmarginspage.cpp:387
 #: ../src/richtext/richtextmarginspage.cpp:389
 #: ../src/richtext/richtextmarginspage.cpp:390
-#: ../src/richtext/richtextsizepage.cpp:338
-#: ../src/richtext/richtextsizepage.cpp:341
-#: ../src/richtext/richtextsizepage.cpp:342
-#: ../src/richtext/richtextsizepage.cpp:372
-#: ../src/richtext/richtextsizepage.cpp:375
-#: ../src/richtext/richtextsizepage.cpp:376
-#: ../src/richtext/richtextsizepage.cpp:399
-#: ../src/richtext/richtextsizepage.cpp:402
-#: ../src/richtext/richtextsizepage.cpp:403
-#: ../src/richtext/richtextsizepage.cpp:426
-#: ../src/richtext/richtextsizepage.cpp:429
-#: ../src/richtext/richtextsizepage.cpp:430
-#: ../src/richtext/richtextsizepage.cpp:453
-#: ../src/richtext/richtextsizepage.cpp:456
-#: ../src/richtext/richtextsizepage.cpp:457
-#: ../src/richtext/richtextsizepage.cpp:480
-#: ../src/richtext/richtextsizepage.cpp:483
-#: ../src/richtext/richtextsizepage.cpp:484
-#: ../src/richtext/richtextsizepage.cpp:554
-#: ../src/richtext/richtextsizepage.cpp:557
-#: ../src/richtext/richtextsizepage.cpp:558
-#: ../src/richtext/richtextsizepage.cpp:589
-#: ../src/richtext/richtextsizepage.cpp:592
-#: ../src/richtext/richtextsizepage.cpp:593
-#: ../src/richtext/richtextsizepage.cpp:624
-#: ../src/richtext/richtextsizepage.cpp:627
-#: ../src/richtext/richtextsizepage.cpp:628
-#: ../src/richtext/richtextsizepage.cpp:659
-#: ../src/richtext/richtextsizepage.cpp:662
-#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextfontpage.cpp:178
 msgid "px"
 msgstr "sl. točka"
 
 # common/utilscmn.cpp:464
-#: ../src/common/accelcmn.cpp:193
+#: ../src/common/accelcmn.cpp:192
 msgid "rawctrl"
 msgstr "surovakrmilka"
 
 # common/docview.cpp:296
 # common/docview.cpp:332
 # common/docview.cpp:1388
-#: ../src/html/chm.cpp:333
+#: ../src/html/chm.cpp:330
 msgid "read error"
 msgstr "napaka pri branju"
 
-#: ../src/common/zipstrm.cpp:2085
+#: ../src/common/zipstrm.cpp:2155
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "branje toka zip (vnos %s): napačen crc"
 
-#: ../src/common/zipstrm.cpp:2080
+#: ../src/common/zipstrm.cpp:2150
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "branje toka zip (vnos %s): napačna dolžina"
 
 # msw/dde.cpp:1015
-#: ../src/msw/dde.cpp:1159
+#: ../src/msw/dde.cpp:1223
 msgid "reentrancy problem."
 msgstr "napaka ponovnega vstopa."
 
-#: ../src/common/datetimefmt.cpp:1953
+#: ../src/common/datetimefmt.cpp:1976
 msgid "second"
 msgstr "drugi"
 
 # common/docview.cpp:296
 # common/docview.cpp:332
 # common/docview.cpp:1388
-#: ../src/html/chm.cpp:337
+#: ../src/html/chm.cpp:334
 msgid "seek error"
 msgstr "napaka pri iskanju"
 
-#: ../src/common/datetimefmt.cpp:1968
+# generic/fontdlgg.cpp:217
+#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#, fuzzy
+msgid "semibold"
+msgstr "krepko"
+
+#: ../src/common/datetimefmt.cpp:1991
 msgid "seventeenth"
 msgstr "sedemnajsti"
 
-#: ../src/common/datetimefmt.cpp:1958
+#: ../src/common/datetimefmt.cpp:1981
 msgid "seventh"
 msgstr "sedmi"
 
 # common/utilscmn.cpp:468
-#: ../src/common/accelcmn.cpp:191
+#: ../src/common/accelcmn.cpp:190
 msgid "shift"
 msgstr "DVIGALKA"
 
-#: ../src/common/appbase.cpp:773
+#: ../src/common/appbase.cpp:774
 msgid "show this help message"
 msgstr "pokaži to sporočilo pomoči"
 
-#: ../src/common/datetimefmt.cpp:1967
+#: ../src/common/datetimefmt.cpp:1990
 msgid "sixteenth"
 msgstr "šestnajsti"
 
-#: ../src/common/datetimefmt.cpp:1957
+#: ../src/common/datetimefmt.cpp:1980
 msgid "sixth"
 msgstr "šesti"
 
-#: ../src/common/appcmn.cpp:234
+#: ../src/common/appcmn.cpp:255
 msgid "specify display mode to use (e.g. 640x480-16)"
 msgstr "določite zaslonski način (npr. 640x480-16)"
 
-#: ../src/common/appcmn.cpp:220
+#: ../src/common/appcmn.cpp:241
 msgid "specify the theme to use"
 msgstr "določi temo za uporabo"
 
-#: ../src/richtext/richtextbuffer.cpp:9340
+#: ../src/richtext/richtextbuffer.cpp:9337
 msgid "standard/circle"
 msgstr "navadno/krog"
 
-#: ../src/richtext/richtextbuffer.cpp:9341
+#: ../src/richtext/richtextbuffer.cpp:9338
 msgid "standard/circle-outline"
 msgstr "navadno/oris-kroga"
 
-#: ../src/richtext/richtextbuffer.cpp:9343
+#: ../src/richtext/richtextbuffer.cpp:9340
 msgid "standard/diamond"
 msgstr "navadno/karo"
 
-#: ../src/richtext/richtextbuffer.cpp:9342
+#: ../src/richtext/richtextbuffer.cpp:9339
 msgid "standard/square"
 msgstr "navadno/kvadrat"
 
-#: ../src/richtext/richtextbuffer.cpp:9344
+#: ../src/richtext/richtextbuffer.cpp:9341
 msgid "standard/triangle"
 msgstr "navadno/trikotnik"
 
-#: ../src/common/zipstrm.cpp:1985
+#: ../src/common/zipstrm.cpp:2055
 msgid "stored file length not in Zip header"
 msgstr "dolžine shranjene datoteke ni v glavi Zip"
 
 # common/cmdline.cpp:910
-#: ../src/common/cmdline.cpp:1488
+#: ../src/common/cmdline.cpp:1484
 msgid "str"
 msgstr "str"
 
-#: ../src/common/fontcmn.cpp:982
+#: ../src/common/fontcmn.cpp:1145
 msgid "strikethrough"
 msgstr "prečrtano"
 
-#: ../src/common/tarstrm.cpp:1003 ../src/common/tarstrm.cpp:1025
-#: ../src/common/tarstrm.cpp:1507 ../src/common/tarstrm.cpp:1529
+#: ../src/common/tarstrm.cpp:997 ../src/common/tarstrm.cpp:1019
+#: ../src/common/tarstrm.cpp:1501 ../src/common/tarstrm.cpp:1523
 msgid "tar entry not open"
 msgstr "vnos tar ni odprt"
 
 # generic/helpwxht.cpp:159
 # html/helpfrm.cpp:303
 # html/helpfrm.cpp:312
-#: ../src/common/datetimefmt.cpp:1961
+#: ../src/common/datetimefmt.cpp:1984
 msgid "tenth"
 msgstr "deseti"
 
 # msw/dde.cpp:979
-#: ../src/msw/dde.cpp:1123
+#: ../src/msw/dde.cpp:1187
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "odziv na transakcijo je povzročil, da je nastavljen bit DDE_FBUSY."
 
-#: ../src/common/datetimefmt.cpp:1954
+#: ../src/common/fontcmn.cpp:1154
+msgid "thin"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:1977
 msgid "third"
 msgstr "tretji"
 
-#: ../src/common/datetimefmt.cpp:1964
+#: ../src/common/datetimefmt.cpp:1987
 msgid "thirteenth"
 msgstr "trinajsti"
 
-#: ../src/common/datetimefmt.cpp:1758
+#: ../src/common/datetimefmt.cpp:1781
 msgid "today"
 msgstr "danes"
 
-#: ../src/common/datetimefmt.cpp:1760
+#: ../src/common/datetimefmt.cpp:1783
 msgid "tomorrow"
 msgstr "jutri"
 
-#: ../src/common/fileconf.cpp:1944
+#: ../src/common/fileconf.cpp:1946
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "leva poševnica na koncu v »%s« prezrta"
 
-#: ../src/gtk/aboutdlg.cpp:218
+#: ../src/gtk/aboutdlg.cpp:216
 msgid "translator-credits"
 msgstr "Zasluge prevajalcev"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1028
+#: ../src/generic/datavgen.cpp:1148
 msgid "true"
 msgstr "je resnično"
 
-#: ../src/common/datetimefmt.cpp:1963
+#: ../src/common/datetimefmt.cpp:1986
 msgid "twelfth"
 msgstr "dvanajsti"
 
-#: ../src/common/datetimefmt.cpp:1971
+#: ../src/common/datetimefmt.cpp:1994
 msgid "twentieth"
 msgstr "dvajseti"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:486 ../src/generic/datavgen.cpp:1263
+#: ../src/common/datavcmn.cpp:2068 ../src/generic/datavgen.cpp:1386
 msgid "unchecked"
 msgstr "nepotrjeno"
 
 # generic/fontdlgg.cpp:242
-#: ../src/common/fontcmn.cpp:802 ../src/common/fontcmn.cpp:978
+#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
 msgid "underlined"
 msgstr "podčrtano"
 
 # generic/fontdlgg.cpp:242
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:490
+#: ../src/common/datavcmn.cpp:2072
 msgid "undetermined"
 msgstr "nedoločeno"
 
 # common/fileconf.cpp:1557
-#: ../src/common/fileconf.cpp:1979
+#: ../src/common/fileconf.cpp:1981
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "nepričakovan \" na poziciji %d v '%s'."
 
-#: ../src/common/tarstrm.cpp:1045
+#: ../src/common/tarstrm.cpp:1039
 msgid "unexpected end of file"
 msgstr "nepričakovan konec datoteke"
 
 # generic/progdlgg.cpp:241
-#: ../src/generic/progdlgg.cpp:370 ../src/common/tarstrm.cpp:371
-#: ../src/common/tarstrm.cpp:394 ../src/common/tarstrm.cpp:425
+#: ../src/common/tarstrm.cpp:366 ../src/common/tarstrm.cpp:389
+#: ../src/common/tarstrm.cpp:420 ../src/generic/progdlgg.cpp:376
 msgid "unknown"
 msgstr "nepoznan"
 
 # generic/progdlgg.cpp:241
-#: ../src/msw/registry.cpp:150
+#: ../src/msw/registry.cpp:139
 #, c-format
 msgid "unknown (%lu)"
 msgstr "neznano (%lu)"
 
 # common/fontmap.cpp:507
-#: ../src/common/xtixml.cpp:253
+#: ../src/common/xtixml.cpp:249
 #, c-format
 msgid "unknown class %s"
 msgstr "neznani razred %s"
 
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "napaka pri stiskanju"
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "napaka pri razširjanju"
+
 # generic/progdlgg.cpp:241
-#: ../src/common/regex.cpp:258 ../src/html/chm.cpp:351
+#: ../src/common/regex.cpp:255 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "neznana napaka"
 
 # msw/dialup.cpp:466
-#: ../src/msw/dialup.cpp:471
+#: ../src/msw/dialup.cpp:465
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "neznana napaka (koda napake %08x)."
 
 # common/fontmap.cpp:354
-#: ../src/common/fmapbase.cpp:834
+#: ../src/common/fmapbase.cpp:830
 #, c-format
 msgid "unknown-%d"
 msgstr "nepoznan-%d"
 
 # common/docview.cpp:406
-#: ../src/common/docview.cpp:509
+#: ../src/common/docview.cpp:502
 msgid "unnamed"
 msgstr "neimenovana"
 
 # common/docview.cpp:1188
-#: ../src/common/docview.cpp:1624
+#: ../src/common/docview.cpp:1618
 #, c-format
 msgid "unnamed%d"
 msgstr "neimenovana%d"
 
-#: ../src/common/zipstrm.cpp:1999 ../src/common/zipstrm.cpp:2319
+#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
 msgid "unsupported Zip compression method"
 msgstr "nepodprta metoda stiskanja Zip"
 
 # common/intl.cpp:379
-#: ../src/common/translation.cpp:1892
+#: ../src/common/translation.cpp:1942
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "uporabljen je katalog »%s« iz »%s«."
@@ -10064,12 +10335,20 @@ msgstr "uporabljen je katalog »%s« iz »%s«."
 # common/docview.cpp:296
 # common/docview.cpp:332
 # common/docview.cpp:1388
-#: ../src/html/chm.cpp:335
+#: ../src/html/chm.cpp:332
 msgid "write error"
 msgstr "napaka pri pisanju"
 
+#: ../src/gtk/glcanvas.cpp:187
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
 # common/timercmn.cpp:267
-#: ../src/common/time.cpp:292
+#: ../src/common/time.cpp:285
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay ni uspela."
 
@@ -10084,16 +10363,16 @@ msgstr "wxWidgets ne more odpreti zaslona za '%s': izhod iz programa."
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets ne more odpreti zaslona. Izhod."
 
-#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:431
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/common/datetimefmt.cpp:1759
+#: ../src/common/datetimefmt.cpp:1782
 msgid "yesterday"
 msgstr "včeraj"
 
 # common/log.cpp:242
-#: ../src/common/zstream.cpp:251 ../src/common/zstream.cpp:426
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
 #, c-format
 msgid "zlib error %d"
 msgstr "napaka zlib %d"
@@ -10102,3 +10381,102 @@ msgstr "napaka zlib %d"
 #: ../src/richtext/richtextbulletspage.cpp:288
 msgid "~"
 msgstr "~"
+
+#~ msgid " (while overwriting an existing item)"
+#~ msgstr " (med prepisovanjem obstoječe postavke)"
+
+# common/docview.cpp:249
+#~ msgid "&Save as"
+#~ msgstr "&Shrani kot"
+
+# common/valtext.cpp:166
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "»%s« ni sestavljen le iz veljavnih znakov."
+
+# common/valtext.cpp:178
+#~ msgid "'%s' should be numeric."
+#~ msgstr "»%s« sme biti le število."
+
+# common/valtext.cpp:160
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "»%s« sme vsebovati samo znake ASCII."
+
+# common/valtext.cpp:166
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "»%s« sme vsebovati samo črkovne znake."
+
+# common/valtext.cpp:172
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "»%s« sme vsebovati samo črkovne ali številčne znake."
+
+# common/valtext.cpp:160
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "»%s« sme vsebovati samo števke."
+
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+# common/file.cpp:200
+#~ msgid "Can't create window of class %s"
+#~ msgstr "Okna ali razreda %s ni mogoče ustvariti."
+
+# generic/printps.cpp:209
+# msw/printwin.cpp:252
+#~ msgid "Could not initalize libnotify."
+#~ msgstr "libnotify ni mogoče inicializirati."
+
+# msw/timer.cpp:96
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "Prekrivnega okna ni mogoče ustvariti."
+
+# msw/thread.cpp:578
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "Ni mogoče inicializirati konteksta prekrivnega okna."
+
+# common/ffile.cpp:182
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "Neuspešna pretvorba datoteke \"%s\" v Unicode."
+
+# generic/dirdlgg.cpp:550
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "Besedila v kontrolniku besedila ni mogoče nastaviti."
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr "Neveljavna možnost ukazne vrstice GTK+, uporabite \"%s --help\""
+
+#~ msgid "No unused colour in image."
+#~ msgstr "V sliki ni neuporabljene barve."
+
+# generic/tipdlg.cpp:138
+#~ msgid "Not available"
+#~ msgstr "Ni na voljo"
+
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+# msw/filedlg.cpp:445
+#~ msgid "Replace selection"
+#~ msgstr "Zamenjaj izbor"
+
+# common/docview.cpp:249
+#~ msgid "Save as"
+#~ msgstr "Shrani kot"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Organizator slogov"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "Podprte so tudi naslednje standardne možnosti GTK+:\n"
+
+# generic/dirdlgg.cpp:571
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "Ne morete počistiti prekrivanja, ki ni inicializirano"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "Init zaslona ni možen dvakrat"
+
+# common/intl.cpp:575
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "ne morem nastaviti locale '%s'."

--- a/locale/sq.po
+++ b/locale/sq.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-21 14:25+0200\n"
+"POT-Creation-Date: 2020-10-18 23:11+0300\n"
 "PO-Revision-Date: 2019-11-03 13:41+0200\n"
 "Last-Translator: Besnik Bleta <besnik@programeshqip.org>\n"
 "Language-Team: <wx-translators@wxwidgets.org>\n"
@@ -14,7 +14,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.2\n"
 
-#: ../src/common/debugrpt.cpp:586
+#: ../src/common/debugrpt.cpp:587
 msgid ""
 "\n"
 "Please send this report to the program maintainer, thank you!\n"
@@ -22,8 +22,8 @@ msgstr ""
 "\n"
 "Ju lutemi, dërgojani këtë raport mirëmbajtësit të programit, faleminderit!\n"
 
-#: ../src/richtext/richtextstyledlg.cpp:210
-#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:206
+#: ../src/richtext/richtextstyledlg.cpp:218
 msgid " "
 msgstr " "
 
@@ -31,70 +31,96 @@ msgstr " "
 msgid "              Thank you and we're sorry for the inconvenience!\n"
 msgstr "              Faleminderit dhe na ndjeni për këtë rast!\n"
 
-#: ../src/common/prntbase.cpp:573
+#: ../src/common/prntbase.cpp:568
 #, c-format
 msgid " (copy %d of %d)"
 msgstr " (kopje %d e %d)"
 
-#: ../src/common/log.cpp:421
+#: ../src/common/log.cpp:440
 #, c-format
 msgid " (error %ld: %s)"
 msgstr " (gabim %ld: %s)"
 
-#: ../src/common/imagtiff.cpp:72
+#: ../src/common/imagtiff.cpp:69
 #, c-format
 msgid " (in module \"%s\")"
 msgstr " (në modulin \"%s\")"
 
-#: ../src/osx/core/secretstore.cpp:138
-msgid " (while overwriting an existing item)"
-msgstr " (teksa mbishkruhet një element ekzistues)"
-
-#: ../src/common/docview.cpp:1642
+#: ../src/common/docview.cpp:1636
 msgid " - "
 msgstr " - "
 
-#: ../src/richtext/richtextprint.cpp:593 ../src/html/htmprint.cpp:714
+#: ../src/html/htmprint.cpp:712 ../src/richtext/richtextprint.cpp:589
 msgid " Preview"
 msgstr " Paraparje"
 
-#: ../src/common/fontcmn.cpp:824
+#: ../src/common/fontcmn.cpp:973
 msgid " bold"
 msgstr " të trasha"
 
-#: ../src/common/fontcmn.cpp:840
+#: ../src/common/fontcmn.cpp:977
+#, fuzzy
+msgid " extra bold"
+msgstr " të trasha"
+
+#: ../src/common/fontcmn.cpp:985
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:957
+#, fuzzy
+msgid " extra light"
+msgstr " të lehta"
+
+#: ../src/common/fontcmn.cpp:981
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1001
 msgid " italic"
 msgstr " të pjerrëta"
 
-#: ../src/common/fontcmn.cpp:820
+#: ../src/common/fontcmn.cpp:961
 msgid " light"
 msgstr " të lehta"
 
-#: ../src/common/fontcmn.cpp:807
+#: ../src/common/fontcmn.cpp:965
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:969
+#, fuzzy
+msgid " semi bold"
+msgstr " të trasha"
+
+#: ../src/common/fontcmn.cpp:940
 msgid " strikethrough"
 msgstr " hequrvije"
 
-#: ../src/common/paper.cpp:117
+#: ../src/common/fontcmn.cpp:953
+msgid " thin"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
 msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
 msgstr "Zarf #10, 4 1/8 x 9 1/2 inç"
 
-#: ../src/common/paper.cpp:118
+#: ../src/common/paper.cpp:115
 msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
 msgstr "Zarf #11, 4 1/2 x 10 3/8 inç"
 
-#: ../src/common/paper.cpp:119
+#: ../src/common/paper.cpp:116
 msgid "#12 Envelope, 4 3/4 x 11 in"
 msgstr "Zarf #12, 4 3/4 x 11 inç"
 
-#: ../src/common/paper.cpp:120
+#: ../src/common/paper.cpp:117
 msgid "#14 Envelope, 5 x 11 1/2 in"
 msgstr "Zarf #14, 5 x 11 1/2 inç"
 
-#: ../src/common/paper.cpp:116
+#: ../src/common/paper.cpp:113
 msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
 msgstr "Zarf #9, 3 7/8 x 8 7/8 inç"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:341
 #: ../src/richtext/richtextsizepage.cpp:340
 #: ../src/richtext/richtextsizepage.cpp:374
 #: ../src/richtext/richtextsizepage.cpp:401
@@ -105,82 +131,82 @@ msgstr "Zarf #9, 3 7/8 x 8 7/8 inç"
 #: ../src/richtext/richtextsizepage.cpp:591
 #: ../src/richtext/richtextsizepage.cpp:626
 #: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextbackgroundpage.cpp:341
 msgid "%"
 msgstr "%"
 
-#: ../src/html/helpwnd.cpp:1031
+#: ../src/html/helpwnd.cpp:1029
 #, c-format
 msgid "%d of %lu"
 msgstr "%d nga %lu"
 
-#: ../src/html/helpwnd.cpp:1678
+#: ../src/html/helpwnd.cpp:1676
 #, c-format
 msgid "%i of %u"
 msgstr "%i nga %u"
 
-#: ../src/generic/filectrlg.cpp:279
+#: ../src/generic/filectrlg.cpp:275
 #, c-format
 msgid "%ld byte"
 msgid_plural "%ld bytes"
 msgstr[0] "%ld bajt"
 msgstr[1] "%ld bajte"
 
-#: ../src/html/helpwnd.cpp:1033
+#: ../src/html/helpwnd.cpp:1031
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu nga %lu"
 
-#: ../src/generic/datavgen.cpp:6028
+#: ../src/generic/datavgen.cpp:6833
 #, c-format
-#| msgid "%s (or %s)"
 msgid "%s (%d items)"
 msgstr "%s (%d elementë)"
 
-#: ../src/common/cmdline.cpp:1221
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (ose %s)"
 
-#: ../src/generic/logg.cpp:224
+#: ../src/generic/logg.cpp:221
 #, c-format
 msgid "%s Error"
 msgstr "Gabim %s"
 
-#: ../src/generic/logg.cpp:236
+#: ../src/generic/logg.cpp:233
 #, c-format
 msgid "%s Information"
 msgstr "Të dhëna %s"
 
-#: ../src/generic/preferencesg.cpp:113
+#: ../src/generic/preferencesg.cpp:110
 #, c-format
 msgid "%s Preferences"
 msgstr "Parapëlqime mbi %s"
 
-#: ../src/generic/logg.cpp:228
+#: ../src/generic/logg.cpp:225
 #, c-format
 msgid "%s Warning"
 msgstr "Sinjalizim %s"
 
-#: ../src/common/tarstrm.cpp:1319
+#: ../src/common/tarstrm.cpp:1313
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s s’u përputh dot me krye tar për zërin '%s'"
 
-#: ../src/common/fldlgcmn.cpp:124
+#: ../src/common/fldlgcmn.cpp:121
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s kartela (%s)|%s"
 
-#: ../src/html/helpwnd.cpp:1716
+#: ../src/html/helpwnd.cpp:1714
 #, c-format
 msgid "%u of %u"
 msgstr "%u nga %u"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "&About"
 msgstr "&Rreth"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "&Actual Size"
 msgstr "Madhësi &Faktike"
 
@@ -188,28 +214,28 @@ msgstr "Madhësi &Faktike"
 msgid "&After a paragraph:"
 msgstr "&Pas një paragrafi:"
 
-#: ../src/richtext/richtextindentspage.cpp:128
 #: ../src/richtext/richtextliststylepage.cpp:319
+#: ../src/richtext/richtextindentspage.cpp:128
 msgid "&Alignment"
 msgstr "&Drejtim"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "&Apply"
 msgstr "&Zbatoje"
 
-#: ../src/richtext/richtextstyledlg.cpp:251
+#: ../src/richtext/richtextstyledlg.cpp:247
 msgid "&Apply Style"
 msgstr "&Zbatoje Stilin"
 
-#: ../src/msw/mdi.cpp:179
+#: ../src/msw/mdi.cpp:174
 msgid "&Arrange Icons"
 msgstr "&Sistemoni Ikona"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "&Ascending"
 msgstr "&Rritës"
 
-#: ../src/common/stockitem.cpp:142
+#: ../src/common/stockitem.cpp:139
 msgid "&Back"
 msgstr "&Mbrapsht"
 
@@ -229,24 +255,24 @@ msgstr "Ngjyrë &Bg:"
 msgid "&Blur distance:"
 msgstr "Distancë &turbullimi:"
 
-#: ../src/common/stockitem.cpp:143
+#: ../src/common/stockitem.cpp:140
 msgid "&Bold"
 msgstr "&Të trasha"
 
-#: ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141
 msgid "&Bottom"
 msgstr "&Në fund"
 
+#: ../src/richtext/richtextsizepage.cpp:637
+#: ../src/richtext/richtextsizepage.cpp:644
 #: ../src/richtext/richtextborderspage.cpp:345
 #: ../src/richtext/richtextborderspage.cpp:513
 #: ../src/richtext/richtextmarginspage.cpp:259
 #: ../src/richtext/richtextmarginspage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:637
-#: ../src/richtext/richtextsizepage.cpp:644
 msgid "&Bottom:"
 msgstr "&Në fund:"
 
-#: ../include/wx/richtext/richtextbuffer.h:3866
+#: ../include/wx/richtext/richtextbuffer.h:3861
 msgid "&Box"
 msgstr "&Kuadrat"
 
@@ -255,38 +281,38 @@ msgstr "&Kuadrat"
 msgid "&Bullet style:"
 msgstr "Stil me t&optha:"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "&CD-Rom"
 msgstr "&CD-ROM"
 
-#: ../src/generic/wizard.cpp:434 ../src/generic/fontdlgg.cpp:470
-#: ../src/generic/fontdlgg.cpp:489 ../src/osx/carbon/fontdlg.cpp:402
-#: ../src/common/dlgcmn.cpp:279 ../src/common/stockitem.cpp:145
+#: ../src/osx/carbon/fontdlg.cpp:399 ../src/common/stockitem.cpp:142
+#: ../src/generic/wizard.cpp:433 ../src/generic/fontdlgg.cpp:466
+#: ../src/generic/fontdlgg.cpp:485 ../src/osx/cocoa/button.mm:200
 msgid "&Cancel"
 msgstr "&Anuloje"
 
-#: ../src/msw/mdi.cpp:175
+#: ../src/msw/mdi.cpp:170
 msgid "&Cascade"
 msgstr "&Ujvarë"
 
-#: ../include/wx/richtext/richtextbuffer.h:5960
+#: ../include/wx/richtext/richtextbuffer.h:5955
 msgid "&Cell"
 msgstr "&Kutizë"
 
-#: ../src/richtext/richtextsymboldlg.cpp:439
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "&Character code:"
 msgstr "Kod &shenjash:"
 
-#: ../src/common/stockitem.cpp:147
+#: ../src/common/stockitem.cpp:144
 msgid "&Clear"
 msgstr "&Spastroje"
 
-#: ../src/generic/logg.cpp:516 ../src/common/stockitem.cpp:148
-#: ../src/common/prntbase.cpp:1600 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/stockitem.cpp:145 ../src/common/prntbase.cpp:1625
+#: ../src/univ/themes/win32.cpp:3753 ../src/generic/logg.cpp:513
 msgid "&Close"
 msgstr "&Mbylle"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "&Color"
 msgstr "&Ngjyrë"
 
@@ -294,20 +320,20 @@ msgstr "&Ngjyrë"
 msgid "&Colour:"
 msgstr "&Ngjyrë:"
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "&Convert"
 msgstr "&Shndërroje"
 
-#: ../src/richtext/richtextctrl.cpp:333 ../src/osx/textctrl_osx.cpp:577
-#: ../src/common/stockitem.cpp:150 ../src/msw/textctrl.cpp:2508
+#: ../src/osx/textctrl_osx.cpp:595 ../src/common/stockitem.cpp:147
+#: ../src/msw/textctrl.cpp:2773 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Kopjoje"
 
-#: ../src/generic/hyperlinkg.cpp:156
+#: ../src/generic/hyperlinkg.cpp:153
 msgid "&Copy URL"
 msgstr "&Kopjoji URL-në"
 
-#: ../src/common/headerctrlcmn.cpp:306
+#: ../src/common/headerctrlcmn.cpp:304
 msgid "&Customize..."
 msgstr "&Përshtateni…"
 
@@ -315,53 +341,54 @@ msgstr "&Përshtateni…"
 msgid "&Debug report preview:"
 msgstr "Paraparjeje raporti &diagnostikimi:"
 
-#: ../src/richtext/richtexttabspage.cpp:138
-#: ../src/richtext/richtextctrl.cpp:335 ../src/osx/textctrl_osx.cpp:579
-#: ../src/common/stockitem.cpp:152 ../src/msw/textctrl.cpp:2510
+#: ../src/osx/textctrl_osx.cpp:597 ../src/common/stockitem.cpp:149
+#: ../src/msw/textctrl.cpp:2775 ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtextctrl.cpp:334
 msgid "&Delete"
 msgstr "&Fshije"
 
-#: ../src/richtext/richtextstyledlg.cpp:269
+#: ../src/richtext/richtextstyledlg.cpp:265
 msgid "&Delete Style..."
 msgstr "&Fshini Stil…"
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "&Descending"
 msgstr "&Zbritës"
 
-#: ../src/generic/logg.cpp:682
+#: ../src/generic/logg.cpp:679
 msgid "&Details"
 msgstr "&Hollësi"
 
-#: ../src/common/stockitem.cpp:153
+#: ../src/common/stockitem.cpp:150
 msgid "&Down"
 msgstr "&Poshtë"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "&Edit"
 msgstr "&Përpunojeni"
 
-#: ../src/richtext/richtextstyledlg.cpp:263
+#: ../src/richtext/richtextstyledlg.cpp:259
 msgid "&Edit Style..."
 msgstr "&Përpunoni Stil…"
 
-#: ../src/common/stockitem.cpp:155
+#: ../src/common/stockitem.cpp:152
 msgid "&Execute"
 msgstr "&Kryeje"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/common/stockitem.cpp:154
 msgid "&File"
 msgstr "&Kartelë"
 
-#: ../src/common/stockitem.cpp:158
-msgid "&Find"
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "&Find..."
 msgstr "&Gjej"
 
-#: ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:430
 msgid "&Finish"
 msgstr "&Përfundoje"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:156
 msgid "&First"
 msgstr "I &pari"
 
@@ -369,15 +396,15 @@ msgstr "I &pari"
 msgid "&Floating mode:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "&Floppy"
 msgstr "&Disketë"
 
-#: ../src/common/stockitem.cpp:194
+#: ../src/common/stockitem.cpp:191
 msgid "&Font"
 msgstr "&Shkronja"
 
-#: ../src/generic/fontdlgg.cpp:371
+#: ../src/generic/fontdlgg.cpp:367
 msgid "&Font family:"
 msgstr "&Familje shkronjash:"
 
@@ -385,20 +412,20 @@ msgstr "&Familje shkronjash:"
 msgid "&Font for Level..."
 msgstr "&Shkronja për Shkallë…"
 
+#: ../src/richtext/richtextsymboldlg.cpp:397
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:400
 msgid "&Font:"
 msgstr "&Shkronja:"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "&Forward"
 msgstr "&Përpara"
 
-#: ../src/richtext/richtextsymboldlg.cpp:451
+#: ../src/richtext/richtextsymboldlg.cpp:448
 msgid "&From:"
 msgstr "&Nga:"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "&Harddisk"
 msgstr "&HD"
 
@@ -407,9 +434,9 @@ msgstr "&HD"
 msgid "&Height:"
 msgstr "&Lartësi:"
 
-#: ../src/generic/wizard.cpp:441 ../src/richtext/richtextstyledlg.cpp:303
-#: ../src/richtext/richtextsymboldlg.cpp:479 ../src/osx/menu_osx.cpp:734
-#: ../src/common/stockitem.cpp:163
+#: ../src/common/stockitem.cpp:160 ../src/generic/wizard.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextstyledlg.cpp:299 ../src/osx/cocoa/menu.mm:226
 msgid "&Help"
 msgstr "&Ndihmë"
 
@@ -417,7 +444,7 @@ msgstr "&Ndihmë"
 msgid "&Hide details"
 msgstr "&Fshihi hollësitë"
 
-#: ../src/common/stockitem.cpp:164
+#: ../src/common/stockitem.cpp:161
 msgid "&Home"
 msgstr "&Kreu"
 
@@ -425,54 +452,54 @@ msgstr "&Kreu"
 msgid "&Horizontal offset:"
 msgstr "Shmangie &horizontale:"
 
-#: ../src/richtext/richtextindentspage.cpp:184
 #: ../src/richtext/richtextliststylepage.cpp:372
+#: ../src/richtext/richtextindentspage.cpp:184
 msgid "&Indentation (tenths of a mm)"
 msgstr "&Hapësirë kryeradhe (të dhjeta të mm-it)"
 
-#: ../src/richtext/richtextindentspage.cpp:167
 #: ../src/richtext/richtextliststylepage.cpp:356
+#: ../src/richtext/richtextindentspage.cpp:167
 msgid "&Indeterminate"
 msgstr "E papër&caktuar"
 
-#: ../src/common/stockitem.cpp:166
+#: ../src/common/stockitem.cpp:163
 msgid "&Index"
 msgstr "&Tregues"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "&Info"
 msgstr "&Info"
 
-#: ../src/common/stockitem.cpp:168
+#: ../src/common/stockitem.cpp:165
 msgid "&Italic"
 msgstr "&Të pjerrëta"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "&Jump to"
 msgstr "&Hidhu te"
 
-#: ../src/richtext/richtextindentspage.cpp:153
 #: ../src/richtext/richtextliststylepage.cpp:342
+#: ../src/richtext/richtextindentspage.cpp:153
 msgid "&Justified"
 msgstr "&Përligjur"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "&Last"
 msgstr "E &fundit"
 
-#: ../src/richtext/richtextindentspage.cpp:139
 #: ../src/richtext/richtextliststylepage.cpp:328
+#: ../src/richtext/richtextindentspage.cpp:139
 msgid "&Left"
 msgstr "&Majtas"
 
-#: ../src/richtext/richtextindentspage.cpp:195
+#: ../src/richtext/richtextsizepage.cpp:532
+#: ../src/richtext/richtextsizepage.cpp:539
 #: ../src/richtext/richtextborderspage.cpp:243
 #: ../src/richtext/richtextborderspage.cpp:411
 #: ../src/richtext/richtextliststylepage.cpp:381
+#: ../src/richtext/richtextindentspage.cpp:195
 #: ../src/richtext/richtextmarginspage.cpp:186
 #: ../src/richtext/richtextmarginspage.cpp:300
-#: ../src/richtext/richtextsizepage.cpp:532
-#: ../src/richtext/richtextsizepage.cpp:539
 msgid "&Left:"
 msgstr "&Majtas:"
 
@@ -480,11 +507,11 @@ msgstr "&Majtas:"
 msgid "&List level:"
 msgstr "Shkallë &Liste:"
 
-#: ../src/generic/logg.cpp:517
+#: ../src/generic/logg.cpp:514
 msgid "&Log"
 msgstr "&Regjistrim"
 
-#: ../src/univ/themes/win32.cpp:3748
+#: ../src/univ/themes/win32.cpp:3745
 msgid "&Move"
 msgstr "&Zhvendose"
 
@@ -492,19 +519,19 @@ msgstr "&Zhvendose"
 msgid "&Move the object to:"
 msgstr "&Shpjere objektin te:"
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "&Network"
 msgstr "&Rrjet"
 
-#: ../src/richtext/richtexttabspage.cpp:132 ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173 ../src/richtext/richtexttabspage.cpp:132
 msgid "&New"
 msgstr "I &ri"
 
-#: ../src/aui/tabmdi.cpp:111 ../src/generic/mdig.cpp:100 ../src/msw/mdi.cpp:180
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
 msgid "&Next"
 msgstr "&Pasuesi"
 
-#: ../src/generic/wizard.cpp:432 ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:429
 msgid "&Next >"
 msgstr "&Pasuesi >"
 
@@ -512,7 +539,7 @@ msgstr "&Pasuesi >"
 msgid "&Next Paragraph"
 msgstr "Paragrafi &Pasues"
 
-#: ../src/generic/tipdlg.cpp:240
+#: ../src/generic/tipdlg.cpp:237
 msgid "&Next Tip"
 msgstr "Ndihmëza &Pasuese"
 
@@ -520,11 +547,11 @@ msgstr "Ndihmëza &Pasuese"
 msgid "&Next style:"
 msgstr "Stili &pasues:"
 
-#: ../src/common/stockitem.cpp:177 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:174 ../src/msw/msgdlg.cpp:435
 msgid "&No"
 msgstr "&Jo"
 
-#: ../src/generic/dbgrptg.cpp:356
+#: ../src/generic/dbgrptg.cpp:360
 msgid "&Notes:"
 msgstr "&Shënime:"
 
@@ -532,12 +559,12 @@ msgstr "&Shënime:"
 msgid "&Number:"
 msgstr "&Numër:"
 
-#: ../src/generic/fontdlgg.cpp:475 ../src/generic/fontdlgg.cpp:482
-#: ../src/osx/carbon/fontdlg.cpp:408 ../src/common/stockitem.cpp:178
+#: ../src/osx/carbon/fontdlg.cpp:405 ../src/common/stockitem.cpp:175
+#: ../src/generic/fontdlgg.cpp:471 ../src/generic/fontdlgg.cpp:478
 msgid "&OK"
 msgstr "&OK"
 
-#: ../src/generic/dbgrptg.cpp:342 ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176 ../src/generic/dbgrptg.cpp:342
 msgid "&Open..."
 msgstr "&Hapni…"
 
@@ -549,16 +576,16 @@ msgstr ""
 msgid "&Page Break"
 msgstr "Ndërprerje &Faqeje"
 
-#: ../src/richtext/richtextctrl.cpp:334 ../src/osx/textctrl_osx.cpp:578
-#: ../src/common/stockitem.cpp:180 ../src/msw/textctrl.cpp:2509
+#: ../src/osx/textctrl_osx.cpp:596 ../src/common/stockitem.cpp:177
+#: ../src/msw/textctrl.cpp:2774 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&Ngjite"
 
-#: ../include/wx/richtext/richtextbuffer.h:5010
+#: ../include/wx/richtext/richtextbuffer.h:5005
 msgid "&Picture"
 msgstr "&Foto"
 
-#: ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:419
 msgid "&Point size:"
 msgstr "Madhësia në &pikë:"
 
@@ -570,11 +597,11 @@ msgstr "&Pozicion (të dhjeta të mm-it)"
 msgid "&Position mode:"
 msgstr "Mënyrë &pozicioni:"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178
 msgid "&Preferences"
 msgstr "&Parapëlqime"
 
-#: ../src/aui/tabmdi.cpp:112 ../src/generic/mdig.cpp:101 ../src/msw/mdi.cpp:181
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
 msgid "&Previous"
 msgstr "&I mëparshmi"
 
@@ -582,78 +609,74 @@ msgstr "&I mëparshmi"
 msgid "&Previous Paragraph"
 msgstr "Paragrafi i &Mëparshëm"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "&Print..."
 msgstr "&Shtypni…"
 
-#: ../src/richtext/richtextctrl.cpp:339 ../src/richtext/richtextctrl.cpp:5514
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtextctrl.cpp:338
+#: ../src/richtext/richtextctrl.cpp:5512
 msgid "&Properties"
 msgstr "&Veti"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "&Quit"
 msgstr "&Dilni"
 
-#: ../src/richtext/richtextctrl.cpp:330 ../src/osx/textctrl_osx.cpp:574
-#: ../src/common/stockitem.cpp:185 ../src/common/cmdproc.cpp:293
-#: ../src/common/cmdproc.cpp:300 ../src/msw/textctrl.cpp:2505
+#: ../src/osx/textctrl_osx.cpp:592 ../src/common/stockitem.cpp:182
+#: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
+#: ../src/msw/textctrl.cpp:2770 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Ribëje"
 
-#: ../src/common/cmdproc.cpp:289 ../src/common/cmdproc.cpp:309
+#: ../src/common/cmdproc.cpp:282 ../src/common/cmdproc.cpp:302
 msgid "&Redo "
 msgstr "&Ribëje "
 
-#: ../src/richtext/richtextstyledlg.cpp:257
+#: ../src/richtext/richtextstyledlg.cpp:253
 msgid "&Rename Style..."
 msgstr "&Riemërtoni Stil…"
 
-#: ../src/generic/fdrepdlg.cpp:179
+#: ../src/generic/fdrepdlg.cpp:176
 msgid "&Replace"
 msgstr "&Zëvendëso"
 
-#: ../src/richtext/richtextstyledlg.cpp:287
+#: ../src/richtext/richtextstyledlg.cpp:283
 msgid "&Restart numbering"
 msgstr "&Rinis numërimin"
 
-#: ../src/univ/themes/win32.cpp:3747
+#: ../src/univ/themes/win32.cpp:3744
 msgid "&Restore"
 msgstr "&Riktheje"
 
-#: ../src/richtext/richtextindentspage.cpp:146
 #: ../src/richtext/richtextliststylepage.cpp:335
+#: ../src/richtext/richtextindentspage.cpp:146
 msgid "&Right"
 msgstr "&Djathtas"
 
-#: ../src/richtext/richtextindentspage.cpp:213
+#: ../src/richtext/richtextsizepage.cpp:602
+#: ../src/richtext/richtextsizepage.cpp:609
 #: ../src/richtext/richtextborderspage.cpp:277
 #: ../src/richtext/richtextborderspage.cpp:445
 #: ../src/richtext/richtextliststylepage.cpp:399
+#: ../src/richtext/richtextindentspage.cpp:213
 #: ../src/richtext/richtextmarginspage.cpp:211
 #: ../src/richtext/richtextmarginspage.cpp:325
-#: ../src/richtext/richtextsizepage.cpp:602
-#: ../src/richtext/richtextsizepage.cpp:609
 msgid "&Right:"
 msgstr "&Djathtas:"
 
-#: ../src/common/stockitem.cpp:190
+#: ../src/common/stockitem.cpp:187
 msgid "&Save"
 msgstr "&Ruaje"
-
-#: ../src/common/stockitem.cpp:191
-msgid "&Save as"
-msgstr "&Ruaje si"
 
 #: ../include/wx/richmsgdlg.h:29
 msgid "&See details"
 msgstr "&Shihni hollësi"
 
-#: ../src/generic/tipdlg.cpp:236
+#: ../src/generic/tipdlg.cpp:233
 msgid "&Show tips at startup"
 msgstr "&Shfaq ndihmëza në nisje"
 
-#: ../src/univ/themes/win32.cpp:3750
+#: ../src/univ/themes/win32.cpp:3747
 msgid "&Size"
 msgstr "&Madhësi"
 
@@ -661,36 +684,36 @@ msgstr "&Madhësi"
 msgid "&Size:"
 msgstr "&Madhësi:"
 
-#: ../src/generic/progdlgg.cpp:252
+#: ../src/generic/progdlgg.cpp:249
 msgid "&Skip"
 msgstr "&Anashkaloje"
 
-#: ../src/richtext/richtextindentspage.cpp:242
 #: ../src/richtext/richtextliststylepage.cpp:417
+#: ../src/richtext/richtextindentspage.cpp:242
 msgid "&Spacing (tenths of a mm)"
 msgstr "&Hapësirë (të dhjeta të mm-it)"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "&Spell Check"
 msgstr "&Kontroll Drejtshkrimi"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "&Stop"
 msgstr "&Ndal"
 
-#: ../src/richtext/richtextfontpage.cpp:275 ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196 ../src/richtext/richtextfontpage.cpp:275
 msgid "&Strikethrough"
 msgstr "&Hequrvije"
 
-#: ../src/generic/fontdlgg.cpp:382 ../src/richtext/richtextstylepage.cpp:106
+#: ../src/generic/fontdlgg.cpp:378 ../src/richtext/richtextstylepage.cpp:106
 msgid "&Style:"
 msgstr "&Stil:"
 
-#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:194
 msgid "&Styles:"
 msgstr "&Stile:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:413
+#: ../src/richtext/richtextsymboldlg.cpp:410
 msgid "&Subset:"
 msgstr "&Nëngrup:"
 
@@ -704,24 +727,24 @@ msgstr "&Simbol:"
 msgid "&Synchronize values"
 msgstr "&Njëkohëso vlera"
 
-#: ../include/wx/richtext/richtextbuffer.h:6069
+#: ../include/wx/richtext/richtextbuffer.h:6064
 msgid "&Table"
 msgstr "&Tabelë"
 
-#: ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197
 msgid "&Top"
 msgstr "Në &Krye"
 
+#: ../src/richtext/richtextsizepage.cpp:567
+#: ../src/richtext/richtextsizepage.cpp:574
 #: ../src/richtext/richtextborderspage.cpp:311
 #: ../src/richtext/richtextborderspage.cpp:479
 #: ../src/richtext/richtextmarginspage.cpp:234
 #: ../src/richtext/richtextmarginspage.cpp:348
-#: ../src/richtext/richtextsizepage.cpp:567
-#: ../src/richtext/richtextsizepage.cpp:574
 msgid "&Top:"
 msgstr "Në &Krye:"
 
-#: ../src/generic/fontdlgg.cpp:444 ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199 ../src/generic/fontdlgg.cpp:441
 msgid "&Underline"
 msgstr "&Nënvijë"
 
@@ -729,21 +752,21 @@ msgstr "&Nënvijë"
 msgid "&Underlining:"
 msgstr "&Nënvijëzim:"
 
-#: ../src/richtext/richtextctrl.cpp:329 ../src/osx/textctrl_osx.cpp:573
-#: ../src/common/stockitem.cpp:203 ../src/common/cmdproc.cpp:271
-#: ../src/msw/textctrl.cpp:2504
+#: ../src/osx/textctrl_osx.cpp:591 ../src/common/stockitem.cpp:200
+#: ../src/common/cmdproc.cpp:264 ../src/msw/textctrl.cpp:2769
+#: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Zhbëje"
 
-#: ../src/common/cmdproc.cpp:265
+#: ../src/common/cmdproc.cpp:258
 msgid "&Undo "
 msgstr "&Zhbëje "
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "&Unindent"
 msgstr "Hiqi &Shmangien"
 
-#: ../src/common/stockitem.cpp:205
+#: ../src/common/stockitem.cpp:202
 msgid "&Up"
 msgstr "&Sipër"
 
@@ -759,7 +782,7 @@ msgstr "Shmangie &vertikale:"
 msgid "&View..."
 msgstr "&Shihni…"
 
-#: ../src/generic/fontdlgg.cpp:393
+#: ../src/generic/fontdlgg.cpp:389
 msgid "&Weight:"
 msgstr "&Lartësi:"
 
@@ -768,88 +791,58 @@ msgstr "&Lartësi:"
 msgid "&Width:"
 msgstr "&Gjerësi:"
 
-#: ../src/aui/tabmdi.cpp:311 ../src/aui/tabmdi.cpp:327
-#: ../src/aui/tabmdi.cpp:329 ../src/generic/mdig.cpp:294
-#: ../src/generic/mdig.cpp:310 ../src/generic/mdig.cpp:314
-#: ../src/msw/mdi.cpp:78
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
 msgid "&Window"
 msgstr "&Dritare"
 
-#: ../src/common/stockitem.cpp:206 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:203 ../src/msw/msgdlg.cpp:435
 msgid "&Yes"
 msgstr "&Po"
 
-#: ../src/common/valtext.cpp:256
-#, c-format
-msgid "'%s' contains illegal characters"
+#: ../src/common/valtext.cpp:197
+#, fuzzy, c-format
+msgid "'%s' contains invalid character(s)"
 msgstr "'%s' përmban shenja të paligjshme"
 
-#: ../src/common/valtext.cpp:254
-#, c-format
-msgid "'%s' doesn't consist only of valid characters"
-msgstr "'%s' s’përbëhet vetëm nga shenja të vlefshme"
-
-#: ../src/common/config.cpp:519 ../src/msw/regconf.cpp:258
+#: ../src/common/config.cpp:515 ../src/msw/regconf.cpp:255
 #, c-format
 msgid "'%s' has extra '..', ignored."
 msgstr "'%s' ka '..' ekstra, u shpërfill."
 
-#: ../src/common/cmdline.cpp:1113 ../src/common/cmdline.cpp:1131
+#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' s’është vlerë numerike e saktë për mundësinë '%s'."
 
-#: ../src/common/translation.cpp:1100
+#: ../src/common/translation.cpp:1142
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' s’është katalog i vlefshëm mesazhesh."
 
-#: ../src/common/valtext.cpp:165
+#: ../src/common/valtext.cpp:188
 #, c-format
 msgid "'%s' is not one of the valid strings"
 msgstr "'%s' s’është një nga vargjet e vlefshëm"
 
-#: ../src/common/valtext.cpp:167
+#: ../src/common/valtext.cpp:186
 #, c-format
 msgid "'%s' is one of the invalid strings"
 msgstr "'%s' është një nga vargjet e pavlefshëm"
 
-#: ../src/common/textbuf.cpp:237
+#: ../src/common/textbuf.cpp:233
 #, c-format
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' ka gjasa të jetë shtytëz dyore."
-
-#: ../src/common/valtext.cpp:252
-#, c-format
-msgid "'%s' should be numeric."
-msgstr "'%s' duhet të jetë numerik."
-
-#: ../src/common/valtext.cpp:244
-#, c-format
-msgid "'%s' should only contain ASCII characters."
-msgstr "'%s' duhet të përmbajë vetëm shenja ASCII."
-
-#: ../src/common/valtext.cpp:246
-#, c-format
-msgid "'%s' should only contain alphabetic characters."
-msgstr "'%s' duhet të përmbajë vetëm shenja abc-je."
-
-#: ../src/common/valtext.cpp:248
-#, c-format
-msgid "'%s' should only contain alphabetic or numeric characters."
-msgstr "'%s' duhet të përmbajë vetëm shenja abc-je ose numerike."
-
-#: ../src/common/valtext.cpp:250
-#, c-format
-msgid "'%s' should only contain digits."
-msgstr "'%s' duhet të përmbajë vetëm shifra."
 
 #: ../src/richtext/richtextliststylepage.cpp:229
 #: ../src/richtext/richtextbulletspage.cpp:166
 msgid "(*)"
 msgstr "(*)"
 
-#: ../src/html/helpwnd.cpp:963
+#: ../src/html/helpwnd.cpp:961
 msgid "(Help)"
 msgstr "(Ndihmë)"
 
@@ -858,27 +851,32 @@ msgstr "(Ndihmë)"
 msgid "(None)"
 msgstr "(Asnjë)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:504
+#: ../src/richtext/richtextsymboldlg.cpp:503
 msgid "(Normal text)"
 msgstr "(Tekst normal)"
 
-#: ../src/html/helpwnd.cpp:419 ../src/html/helpwnd.cpp:1106
-#: ../src/html/helpwnd.cpp:1742
+#: ../src/html/helpwnd.cpp:417 ../src/html/helpwnd.cpp:1104
+#: ../src/html/helpwnd.cpp:1740
 msgid "(bookmarks)"
 msgstr "(faqerojtës)"
 
+#: ../src/msw/dlmsw.cpp:167
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (gabim %ld: %s)"
+
+#: ../src/richtext/richtextformatdlg.cpp:876
+#: ../src/richtext/richtextliststylepage.cpp:448
+#: ../src/richtext/richtextliststylepage.cpp:460
+#: ../src/richtext/richtextliststylepage.cpp:461
 #: ../src/richtext/richtextindentspage.cpp:274
 #: ../src/richtext/richtextindentspage.cpp:286
 #: ../src/richtext/richtextindentspage.cpp:287
 #: ../src/richtext/richtextindentspage.cpp:311
 #: ../src/richtext/richtextindentspage.cpp:326
-#: ../src/richtext/richtextformatdlg.cpp:884
 #: ../src/richtext/richtextfontpage.cpp:349
 #: ../src/richtext/richtextfontpage.cpp:353
 #: ../src/richtext/richtextfontpage.cpp:357
-#: ../src/richtext/richtextliststylepage.cpp:448
-#: ../src/richtext/richtextliststylepage.cpp:460
-#: ../src/richtext/richtextliststylepage.cpp:461
 msgid "(none)"
 msgstr "(asnjë)"
 
@@ -897,7 +895,7 @@ msgstr "*)"
 msgid "+"
 msgstr "+"
 
-#: ../src/msw/utils.cpp:1152
+#: ../src/msw/utils.cpp:1143
 msgid ", 64-bit edition"
 msgstr ", varianti 64-bitësh"
 
@@ -906,163 +904,163 @@ msgstr ", varianti 64-bitësh"
 msgid "-"
 msgstr "-"
 
-#: ../src/generic/filepickerg.cpp:66
+#: ../src/generic/filepickerg.cpp:63
 msgid "..."
 msgstr "…"
 
-#: ../src/richtext/richtextindentspage.cpp:276
 #: ../src/richtext/richtextliststylepage.cpp:450
+#: ../src/richtext/richtextindentspage.cpp:276
 msgid "1.1"
 msgstr "1.1"
 
-#: ../src/richtext/richtextindentspage.cpp:277
 #: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextindentspage.cpp:277
 msgid "1.2"
 msgstr "1.2"
 
-#: ../src/richtext/richtextindentspage.cpp:278
 #: ../src/richtext/richtextliststylepage.cpp:452
+#: ../src/richtext/richtextindentspage.cpp:278
 msgid "1.3"
 msgstr "1.3"
 
-#: ../src/richtext/richtextindentspage.cpp:279
 #: ../src/richtext/richtextliststylepage.cpp:453
+#: ../src/richtext/richtextindentspage.cpp:279
 msgid "1.4"
 msgstr "1.4"
 
-#: ../src/richtext/richtextindentspage.cpp:280
 #: ../src/richtext/richtextliststylepage.cpp:454
+#: ../src/richtext/richtextindentspage.cpp:280
 msgid "1.5"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:281
 #: ../src/richtext/richtextliststylepage.cpp:455
+#: ../src/richtext/richtextindentspage.cpp:281
 msgid "1.6"
 msgstr "1.6"
 
-#: ../src/richtext/richtextindentspage.cpp:282
 #: ../src/richtext/richtextliststylepage.cpp:456
+#: ../src/richtext/richtextindentspage.cpp:282
 msgid "1.7"
 msgstr "1.7"
 
-#: ../src/richtext/richtextindentspage.cpp:283
 #: ../src/richtext/richtextliststylepage.cpp:457
+#: ../src/richtext/richtextindentspage.cpp:283
 msgid "1.8"
 msgstr "1.8"
 
-#: ../src/richtext/richtextindentspage.cpp:284
 #: ../src/richtext/richtextliststylepage.cpp:458
+#: ../src/richtext/richtextindentspage.cpp:284
 msgid "1.9"
 msgstr "1.9"
 
-#: ../src/common/paper.cpp:140
+#: ../src/common/paper.cpp:137
 msgid "10 x 11 in"
 msgstr "10 x 11 inç"
 
-#: ../src/common/paper.cpp:113
+#: ../src/common/paper.cpp:110
 msgid "10 x 14 in"
 msgstr "10 x 14 inç"
 
-#: ../src/common/paper.cpp:114
+#: ../src/common/paper.cpp:111
 msgid "11 x 17 in"
 msgstr "11 x 17 inç"
 
-#: ../src/common/paper.cpp:184
+#: ../src/common/paper.cpp:181
 msgid "12 x 11 in"
 msgstr "12 x 11 inç"
 
-#: ../src/common/paper.cpp:141
+#: ../src/common/paper.cpp:138
 msgid "15 x 11 in"
 msgstr "15 x 11 inç"
 
-#: ../src/richtext/richtextindentspage.cpp:285
 #: ../src/richtext/richtextliststylepage.cpp:459
+#: ../src/richtext/richtextindentspage.cpp:285
 msgid "2"
 msgstr "2"
 
-#: ../src/common/paper.cpp:132
+#: ../src/common/paper.cpp:129
 msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
 msgstr "Zarf 6 3/4, 3 5/8 x 6 1/2 inç"
 
-#: ../src/common/paper.cpp:139
+#: ../src/common/paper.cpp:136
 msgid "9 x 11 in"
 msgstr "9 x 11 inç"
 
-#: ../src/html/htmprint.cpp:431
+#: ../src/html/htmprint.cpp:443
 msgid ": file does not exist!"
 msgstr ": kartela nuk ekziston!"
 
-#: ../src/common/fontmap.cpp:199
+#: ../src/common/fontmap.cpp:196
 msgid ": unknown charset"
 msgstr ": shkronja të panjohura"
 
-#: ../src/common/fontmap.cpp:413
+#: ../src/common/fontmap.cpp:410
 msgid ": unknown encoding"
 msgstr ": kodim i panjohur"
 
-#: ../src/generic/wizard.cpp:443
+#: ../src/generic/wizard.cpp:438
 msgid "< &Back"
 msgstr "< &Mbrapsht"
 
-#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:628
-#: ../src/osx/carbon/fontdlg.cpp:648
+#: ../src/osx/carbon/fontdlg.cpp:419 ../src/osx/carbon/fontdlg.cpp:625
+#: ../src/osx/carbon/fontdlg.cpp:645
 msgid "<Any Decorative>"
 msgstr "<Çfarëdo Decorative>"
 
-#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:630
-#: ../src/osx/carbon/fontdlg.cpp:650
+#: ../src/osx/carbon/fontdlg.cpp:420 ../src/osx/carbon/fontdlg.cpp:627
+#: ../src/osx/carbon/fontdlg.cpp:647
 msgid "<Any Modern>"
 msgstr "<Çfarëdo Modern>"
 
-#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:626
-#: ../src/osx/carbon/fontdlg.cpp:646
+#: ../src/osx/carbon/fontdlg.cpp:418 ../src/osx/carbon/fontdlg.cpp:623
+#: ../src/osx/carbon/fontdlg.cpp:643
 msgid "<Any Roman>"
 msgstr "<Çfarëdo Roman>"
 
-#: ../src/osx/carbon/fontdlg.cpp:424 ../src/osx/carbon/fontdlg.cpp:632
-#: ../src/osx/carbon/fontdlg.cpp:652
+#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:629
+#: ../src/osx/carbon/fontdlg.cpp:649
 msgid "<Any Script>"
 msgstr "<Çfarëdo Script>"
 
-#: ../src/osx/carbon/fontdlg.cpp:425 ../src/osx/carbon/fontdlg.cpp:637
-#: ../src/osx/carbon/fontdlg.cpp:656
+#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:634
+#: ../src/osx/carbon/fontdlg.cpp:653
 msgid "<Any Swiss>"
 msgstr "<Çfarëdo Swiss>"
 
-#: ../src/osx/carbon/fontdlg.cpp:426 ../src/osx/carbon/fontdlg.cpp:634
-#: ../src/osx/carbon/fontdlg.cpp:654
+#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:631
+#: ../src/osx/carbon/fontdlg.cpp:651
 msgid "<Any Teletype>"
 msgstr "<Çfarëdo Teletype>"
 
-#: ../src/osx/carbon/fontdlg.cpp:420
+#: ../src/osx/carbon/fontdlg.cpp:417
 msgid "<Any>"
 msgstr "<Çfarëdo>"
 
-#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
 msgid "<DIR>"
 msgstr "<DIR>"
 
-#: ../src/generic/filectrlg.cpp:254 ../src/generic/filectrlg.cpp:277
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
 msgid "<DRIVE>"
 msgstr "<DRIVE>"
 
-#: ../src/generic/filectrlg.cpp:252 ../src/generic/filectrlg.cpp:275
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
 msgid "<LINK>"
 msgstr "<LINK>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1264
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Shkronja të pjerrëta të trasha.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1270
+#: ../src/html/helpwnd.cpp:1268
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>të pjerrëta të trasha <u>të nënvizuara</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1265
+#: ../src/html/helpwnd.cpp:1263
 msgid "<b>Bold face.</b> "
 msgstr "<b>Shkronja të trasha.</b> "
 
-#: ../src/html/helpwnd.cpp:1264
+#: ../src/html/helpwnd.cpp:1262
 msgid "<i>Italic face.</i> "
 msgstr "<i>Shkronja të pjerrëta.</i> "
 
@@ -1071,15 +1069,15 @@ msgstr "<i>Shkronja të pjerrëta.</i> "
 msgid ">"
 msgstr ">"
 
-#: ../src/generic/dbgrptg.cpp:318
+#: ../src/generic/dbgrptg.cpp:317
 msgid "A debug report has been generated in the directory\n"
 msgstr "Te drejtoria u prodhua një raport diagnostikimi\n"
 
-#: ../src/common/debugrpt.cpp:573
+#: ../src/common/debugrpt.cpp:574
 msgid "A debug report has been generated. It can be found in"
 msgstr "Te drejtoria u prodhua një raport diagnostikimi. Mund të gjendet te"
 
-#: ../src/common/xtixml.cpp:418
+#: ../src/common/xtixml.cpp:414
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Një koleksion jo i zbrazët duhet të përbëhet nga nyje 'elementësh'"
 
@@ -1090,106 +1088,106 @@ msgstr "Një koleksion jo i zbrazët duhet të përbëhet nga nyje 'elementësh'
 msgid "A standard bullet name."
 msgstr "Emër standard stili me toptha."
 
-#: ../src/common/paper.cpp:217
+#: ../src/common/paper.cpp:214
 msgid "A0 sheet, 841 x 1189 mm"
 msgstr "Fletë A0, 841 x 1189 mm"
 
-#: ../src/common/paper.cpp:218
+#: ../src/common/paper.cpp:215
 msgid "A1 sheet, 594 x 841 mm"
 msgstr "Fletë A1, 594 x 841 mm"
 
-#: ../src/common/paper.cpp:159
+#: ../src/common/paper.cpp:156
 msgid "A2 420 x 594 mm"
 msgstr "A2 420 x 594 mm"
 
-#: ../src/common/paper.cpp:156
+#: ../src/common/paper.cpp:153
 msgid "A3 Extra 322 x 445 mm"
 msgstr "A3 Ekstra 322 x 445 mm"
 
-#: ../src/common/paper.cpp:161
+#: ../src/common/paper.cpp:158
 msgid "A3 Extra Transverse 322 x 445 mm"
 msgstr "EkA3 Ekstra Transverse 322 x 445 mm"
 
-#: ../src/common/paper.cpp:170
+#: ../src/common/paper.cpp:167
 msgid "A3 Rotated 420 x 297 mm"
 msgstr "A3 e Rrotulluar 420 x 297 mm"
 
-#: ../src/common/paper.cpp:160
+#: ../src/common/paper.cpp:157
 msgid "A3 Transverse 297 x 420 mm"
 msgstr "A3 Transverse 297 x 420 mm"
 
-#: ../src/common/paper.cpp:106
+#: ../src/common/paper.cpp:103
 msgid "A3 sheet, 297 x 420 mm"
 msgstr "Fletë A3, 297 x 420 mm"
 
-#: ../src/common/paper.cpp:146
+#: ../src/common/paper.cpp:143
 msgid "A4 Extra 9.27 x 12.69 in"
 msgstr "A4 Ekstra 9.27 x 12.69 inç"
 
-#: ../src/common/paper.cpp:153
+#: ../src/common/paper.cpp:150
 msgid "A4 Plus 210 x 330 mm"
 msgstr "A4 Plus 210 x 330 mm"
 
-#: ../src/common/paper.cpp:171
+#: ../src/common/paper.cpp:168
 msgid "A4 Rotated 297 x 210 mm"
 msgstr "A4 e Rrotulluar 297 x 210 mm"
 
-#: ../src/common/paper.cpp:148
+#: ../src/common/paper.cpp:145
 msgid "A4 Transverse 210 x 297 mm"
 msgstr "A4 Transverse 210 x 297 mm"
 
-#: ../src/common/paper.cpp:97
+#: ../src/common/paper.cpp:94
 msgid "A4 sheet, 210 x 297 mm"
 msgstr "Fletë A4, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:107
+#: ../src/common/paper.cpp:104
 msgid "A4 small sheet, 210 x 297 mm"
 msgstr "Fletë e vogël A4, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:157
+#: ../src/common/paper.cpp:154
 msgid "A5 Extra 174 x 235 mm"
 msgstr "A5 Ekstra 174 x 235 mm"
 
-#: ../src/common/paper.cpp:172
+#: ../src/common/paper.cpp:169
 msgid "A5 Rotated 210 x 148 mm"
 msgstr "A5 e Rrotulluar 210 x 148 mm"
 
-#: ../src/common/paper.cpp:154
+#: ../src/common/paper.cpp:151
 msgid "A5 Transverse 148 x 210 mm"
 msgstr "A5 Transverse 148 x 210 mm"
 
-#: ../src/common/paper.cpp:108
+#: ../src/common/paper.cpp:105
 msgid "A5 sheet, 148 x 210 mm"
 msgstr "Fletë A5, 148 x 210 mm"
 
-#: ../src/common/paper.cpp:164
+#: ../src/common/paper.cpp:161
 msgid "A6 105 x 148 mm"
 msgstr "A6 105 x 148 mm"
 
-#: ../src/common/paper.cpp:177
+#: ../src/common/paper.cpp:174
 msgid "A6 Rotated 148 x 105 mm"
 msgstr "A6 e Rrotulluar 148 x 105 mm"
 
-#: ../src/generic/fontdlgg.cpp:83 ../src/richtext/richtextformatdlg.cpp:529
-#: ../src/osx/carbon/fontdlg.cpp:153
+#: ../src/osx/carbon/fontdlg.cpp:150 ../src/generic/fontdlgg.cpp:79
+#: ../src/richtext/richtextformatdlg.cpp:521
 msgid "ABCDEFGabcdefg12345"
 msgstr "ABCDEFGabcdefg12345"
 
-#: ../src/richtext/richtextsymboldlg.cpp:458 ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
 msgid "ASCII"
 msgstr "ASCII"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "About"
 msgstr "Rreth"
 
-#: ../src/generic/aboutdlgg.cpp:140 ../src/osx/menu_osx.cpp:558
-#: ../src/msw/aboutdlg.cpp:64
+#: ../src/osx/menu_osx.cpp:450 ../src/generic/aboutdlgg.cpp:137
+#: ../src/msw/aboutdlg.cpp:61
 #, c-format
 msgid "About %s"
 msgstr "Rreth %s"
 
-#: ../src/osx/menu_osx.cpp:560
+#: ../src/osx/menu_osx.cpp:452
 msgid "About..."
 msgstr "Rreth…"
 
@@ -1198,37 +1196,37 @@ msgid "Absolute"
 msgstr "Absolute"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:873
+#: ../src/propgrid/advprops.cpp:774
 msgid "ActiveBorder"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:874
+#: ../src/propgrid/advprops.cpp:775
 msgid "ActiveCaption"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "Actual Size"
 msgstr "Madhësi Faktike"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:140 ../src/common/accelcmn.cpp:81
+#: ../src/common/stockitem.cpp:137 ../src/common/accelcmn.cpp:78
 msgid "Add"
 msgstr "Shtoni"
 
-#: ../src/richtext/richtextbuffer.cpp:11455
+#: ../src/richtext/richtextbuffer.cpp:11454
 msgid "Add Column"
 msgstr "Shtoni Shtyllë"
 
-#: ../src/richtext/richtextbuffer.cpp:11392
+#: ../src/richtext/richtextbuffer.cpp:11391
 msgid "Add Row"
 msgstr "Shtoni Rresht"
 
-#: ../src/html/helpwnd.cpp:432
+#: ../src/html/helpwnd.cpp:430
 msgid "Add current page to bookmarks"
 msgstr "Shto te faqerojtësit faqen e çastit"
 
-#: ../src/generic/colrdlgg.cpp:366
+#: ../src/generic/colrdlgg.cpp:386
 msgid "Add to custom colours"
 msgstr "Shto tek ngjyra vetjake"
 
@@ -1240,12 +1238,12 @@ msgstr ""
 msgid "AddToPropertyCollection called w/o valid adder"
 msgstr "AddToPropertyCollection u thirr pa shtues të vlefshëm"
 
-#: ../src/html/helpctrl.cpp:159
+#: ../src/html/helpctrl.cpp:155
 #, c-format
 msgid "Adding book %s"
 msgstr "Po shtohet libër %s"
 
-#: ../src/common/preferencescmn.cpp:43
+#: ../src/common/preferencescmn.cpp:40
 msgid "Advanced"
 msgstr "Të mëtejshme"
 
@@ -1253,11 +1251,11 @@ msgstr "Të mëtejshme"
 msgid "After a paragraph:"
 msgstr "Pas një paragrafi:"
 
-#: ../src/common/stockitem.cpp:172
+#: ../src/common/stockitem.cpp:169
 msgid "Align Left"
 msgstr "Vendose Majtas"
 
-#: ../src/common/stockitem.cpp:173
+#: ../src/common/stockitem.cpp:170
 msgid "Align Right"
 msgstr "Vendose Djathtas"
 
@@ -1265,40 +1263,40 @@ msgstr "Vendose Djathtas"
 msgid "Alignment"
 msgstr "Drejtim"
 
-#: ../src/generic/prntdlgg.cpp:215
+#: ../src/generic/prntdlgg.cpp:208
 msgid "All"
 msgstr "Krejt"
 
-#: ../src/generic/filectrlg.cpp:1197 ../src/common/fldlgcmn.cpp:107
+#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1186
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Krejt kartelat (%s)|%s"
 
-#: ../include/wx/defs.h:2886
+#: ../include/wx/defs.h:2582
 msgid "All files (*)|*"
 msgstr "Krejt kartelat (*)|*"
 
-#: ../include/wx/defs.h:2883
+#: ../include/wx/defs.h:2579
 msgid "All files (*.*)|*.*"
 msgstr "Krejt kartelat (*.*)|*.*"
 
-#: ../src/richtext/richtextstyles.cpp:1061
+#: ../src/richtext/richtextstyles.cpp:1058
 msgid "All styles"
 msgstr "Krejt stilet"
 
-#: ../src/propgrid/manager.cpp:1528
+#: ../src/propgrid/manager.cpp:1544
 msgid "Alphabetic Mode"
 msgstr "Mënyrë Alfabetike"
 
-#: ../src/common/xtistrm.cpp:425
+#: ../src/common/xtistrm.cpp:422
 msgid "Already Registered Object passed to SetObjectClassInfo"
 msgstr "SetObjectClassInfo-s iu kalua një Objekt tashmë i Regjistruar"
 
-#: ../src/unix/dialup.cpp:353
+#: ../src/unix/dialup.cpp:352
 msgid "Already dialling ISP."
 msgstr "Po provohet tashmë numri i ISP-së."
 
-#: ../src/common/accelcmn.cpp:331 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/accelcmn.cpp:345 ../src/univ/themes/win32.cpp:3753
 msgid "Alt+"
 msgstr "Alt+"
 
@@ -1307,36 +1305,36 @@ msgstr "Alt+"
 msgid "An optional corner radius for adding rounded corners."
 msgstr "Një rreze opsionale këndesh për shtim cepash të rrumbullakuar."
 
-#: ../src/common/debugrpt.cpp:576
+#: ../src/common/debugrpt.cpp:577
 msgid "And includes the following files:\n"
 msgstr "Dhe përmban kartelat vijuese:\n"
 
-#: ../src/generic/animateg.cpp:162
+#: ../src/generic/animateg.cpp:145
 #, c-format
 msgid "Animation file is not of type %ld."
 msgstr "Kartela e animacionit s’është e llojit %ld."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:872
+#: ../src/propgrid/advprops.cpp:773
 msgid "AppWorkspace"
 msgstr ""
 
-#: ../src/generic/logg.cpp:1014
+#: ../src/generic/logg.cpp:1011
 #, c-format
 msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
 msgstr ""
 "Të shtohet regjistrimi te kartela '%s' (zgjedhja e [Jo]-së do ta "
 "mbishkruajë)?"
 
-#: ../src/osx/menu_osx.cpp:577 ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:469 ../src/osx/menu_osx.cpp:477
 msgid "Application"
 msgstr "Aplikacion"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "Apply"
 msgstr "Zbatoje"
 
-#: ../src/propgrid/advprops.cpp:1609
+#: ../src/propgrid/advprops.cpp:1515
 msgid "Aqua"
 msgstr "Blu e gjelbër"
 
@@ -1345,29 +1343,29 @@ msgstr "Blu e gjelbër"
 msgid "Arabic"
 msgstr "Arabike"
 
-#: ../src/common/fmapbase.cpp:153
+#: ../src/common/fmapbase.cpp:150
 msgid "Arabic (ISO-8859-6)"
 msgstr "Arabe (ISO-8859-6)"
 
-#: ../src/msw/ole/automtn.cpp:672
+#: ../src/msw/ole/automtn.cpp:663
 #, c-format
 msgid "Argument %u not found."
 msgstr "S’u gjet argumenti %u."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1753
+#: ../src/propgrid/advprops.cpp:1654
 msgid "Arrow"
 msgstr "Shigjetë"
 
-#: ../src/generic/aboutdlgg.cpp:184
+#: ../src/generic/aboutdlgg.cpp:181
 msgid "Artists"
 msgstr "Artistë"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "Ascending"
 msgstr "Rritës"
 
-#: ../src/generic/filectrlg.cpp:433
+#: ../src/generic/filectrlg.cpp:429
 msgid "Attributes"
 msgstr "Atribute"
 
@@ -1377,90 +1375,90 @@ msgstr "Atribute"
 msgid "Available fonts."
 msgstr "Shkronja të gatshme."
 
-#: ../src/common/paper.cpp:137
+#: ../src/common/paper.cpp:134
 msgid "B4 (ISO) 250 x 353 mm"
 msgstr "B4 (ISO) 250 x 353 mm"
 
-#: ../src/common/paper.cpp:173
+#: ../src/common/paper.cpp:170
 msgid "B4 (JIS) Rotated 364 x 257 mm"
 msgstr "B4 (JIS) e Rrotulluar 364 x 257 mm"
 
-#: ../src/common/paper.cpp:127
+#: ../src/common/paper.cpp:124
 msgid "B4 Envelope, 250 x 353 mm"
 msgstr "Zarf B4, 250 x 353 mm"
 
-#: ../src/common/paper.cpp:109
+#: ../src/common/paper.cpp:106
 msgid "B4 sheet, 250 x 354 mm"
 msgstr "Fletë B4, 250 x 354 mm"
 
-#: ../src/common/paper.cpp:158
+#: ../src/common/paper.cpp:155
 msgid "B5 (ISO) Extra 201 x 276 mm"
 msgstr "B5 (ISO) Ekstra 201 x 276 mm"
 
-#: ../src/common/paper.cpp:174
+#: ../src/common/paper.cpp:171
 msgid "B5 (JIS) Rotated 257 x 182 mm"
 msgstr "B5 (JIS) e Rrotulluar 257 x 182 mm"
 
-#: ../src/common/paper.cpp:155
+#: ../src/common/paper.cpp:152
 msgid "B5 (JIS) Transverse 182 x 257 mm"
 msgstr "B5 (JIS) Transverse 182 x 257 mm"
 
-#: ../src/common/paper.cpp:128
+#: ../src/common/paper.cpp:125
 msgid "B5 Envelope, 176 x 250 mm"
 msgstr "Zarf B5, 176 x 250 mm"
 
-#: ../src/common/paper.cpp:110
+#: ../src/common/paper.cpp:107
 msgid "B5 sheet, 182 x 257 millimeter"
 msgstr "Fletë B5, 182 x 257 milimetra"
 
-#: ../src/common/paper.cpp:182
+#: ../src/common/paper.cpp:179
 msgid "B6 (JIS) 128 x 182 mm"
 msgstr "B6 (JIS) 128 x 182 mm"
 
-#: ../src/common/paper.cpp:183
+#: ../src/common/paper.cpp:180
 msgid "B6 (JIS) Rotated 182 x 128 mm"
 msgstr "B6 (JIS) e Rrotulluar 182 x 128 mm"
 
-#: ../src/common/paper.cpp:129
+#: ../src/common/paper.cpp:126
 msgid "B6 Envelope, 176 x 125 mm"
 msgstr "Zarf B6, 176 x 125 mm"
 
-#: ../src/common/imagbmp.cpp:531 ../src/common/imagbmp.cpp:561
-#: ../src/common/imagbmp.cpp:576
+#: ../src/common/imagbmp.cpp:528 ../src/common/imagbmp.cpp:558
+#: ../src/common/imagbmp.cpp:573
 msgid "BMP: Couldn't allocate memory."
 msgstr "BMP: S’u sigurua dot kujtesë."
 
-#: ../src/common/imagbmp.cpp:100
+#: ../src/common/imagbmp.cpp:97
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: S’u ruajt dot figurë e pavlefshme."
 
-#: ../src/common/imagbmp.cpp:356
+#: ../src/common/imagbmp.cpp:353
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: S’u shkrua dot hartë ngjyrash RGB."
 
-#: ../src/common/imagbmp.cpp:490
+#: ../src/common/imagbmp.cpp:487
 msgid "BMP: Couldn't write data."
 msgstr "BMP: S’u shkruan dot të dhëna."
 
-#: ../src/common/imagbmp.cpp:246
+#: ../src/common/imagbmp.cpp:243
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: S’u shkrua dot krye kartele (Bitmap)."
 
-#: ../src/common/imagbmp.cpp:269
+#: ../src/common/imagbmp.cpp:266
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: S’u shkrua dot krye kartele (BitmapInfo)."
 
-#: ../src/common/imagbmp.cpp:140
+#: ../src/common/imagbmp.cpp:137
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage s’ka wxPalette të vetën."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:142 ../src/common/accelcmn.cpp:52
+#: ../src/common/stockitem.cpp:139 ../src/common/accelcmn.cpp:49
 msgid "Back"
 msgstr "Mbrapsht"
 
+#: ../src/richtext/richtextformatdlg.cpp:377
 #: ../src/richtext/richtextbackgroundpage.cpp:148
-#: ../src/richtext/richtextformatdlg.cpp:384
 msgid "Background"
 msgstr "Sfond"
 
@@ -1468,20 +1466,20 @@ msgstr "Sfond"
 msgid "Background &colour:"
 msgstr "&Ngjyrë sfondi:"
 
-#: ../src/osx/carbon/fontdlg.cpp:220
+#: ../src/osx/carbon/fontdlg.cpp:217
 msgid "Background colour"
 msgstr "Ngjyrë sfondi"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:52
+#: ../src/common/accelcmn.cpp:49
 msgid "Backspace"
 msgstr "Tasti Backspace"
 
-#: ../src/common/fmapbase.cpp:160
+#: ../src/common/fmapbase.cpp:157
 msgid "Baltic (ISO-8859-13)"
 msgstr "Baltike (ISO-8859-13)"
 
-#: ../src/common/fmapbase.cpp:151
+#: ../src/common/fmapbase.cpp:148
 msgid "Baltic (old) (ISO-8859-4)"
 msgstr "Baltike (të vjetra) (ISO-8859-4)"
 
@@ -1494,25 +1492,25 @@ msgstr "Para një paragrafi:"
 msgid "Bitmap"
 msgstr "Bitmap"
 
-#: ../src/propgrid/advprops.cpp:1594
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Black"
 msgstr "E zezë"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1755
+#: ../src/propgrid/advprops.cpp:1656
 msgid "Blank"
 msgstr "E zbrazët"
 
-#: ../src/propgrid/advprops.cpp:1603
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Blue"
 msgstr "Blu"
 
-#: ../src/generic/colrdlgg.cpp:345
+#: ../src/generic/colrdlgg.cpp:365
 msgid "Blue:"
 msgstr "Blu:"
 
-#: ../src/generic/fontdlgg.cpp:333 ../src/richtext/richtextfontpage.cpp:355
-#: ../src/osx/carbon/fontdlg.cpp:354 ../src/common/stockitem.cpp:143
+#: ../src/osx/carbon/fontdlg.cpp:351 ../src/common/stockitem.cpp:140
+#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:355
 msgid "Bold"
 msgstr "Të trasha"
 
@@ -1521,31 +1519,35 @@ msgstr "Të trasha"
 msgid "Border"
 msgstr "Anë"
 
-#: ../src/richtext/richtextformatdlg.cpp:379
+#: ../src/richtext/richtextformatdlg.cpp:372
 msgid "Borders"
 msgstr "Anë"
 
-#: ../src/richtext/richtextsizepage.cpp:288 ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141 ../src/richtext/richtextsizepage.cpp:288
 msgid "Bottom"
 msgstr "Në Fund"
 
-#: ../src/generic/prntdlgg.cpp:893
+#: ../src/generic/prntdlgg.cpp:886
 msgid "Bottom margin (mm):"
 msgstr "Mënjanë fundi (mm):"
 
-#: ../src/richtext/richtextbuffer.cpp:9383
+#: ../src/richtext/richtextbuffer.cpp:9380
 msgid "Box Properties"
 msgstr "Veti Kuadrati"
 
-#: ../src/richtext/richtextstyles.cpp:1065
+#: ../src/richtext/richtextstyles.cpp:1062
 msgid "Box styles"
 msgstr "Stile kuadrati"
 
-#: ../src/propgrid/advprops.cpp:1602
+#: ../src/osx/cocoa/menu.mm:292
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Brown"
 msgstr "Kafe"
 
-#: ../src/common/filepickercmn.cpp:43 ../src/common/filepickercmn.cpp:44
+#: ../src/common/filepickercmn.cpp:40 ../src/common/filepickercmn.cpp:41
 msgid "Browse"
 msgstr "Shfletoni"
 
@@ -1558,72 +1560,72 @@ msgstr "&Drejtim Topthash:"
 msgid "Bullet style"
 msgstr "Stil topthash"
 
-#: ../src/richtext/richtextformatdlg.cpp:359
+#: ../src/richtext/richtextformatdlg.cpp:352
 msgid "Bullets"
 msgstr "Toptha"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1756
+#: ../src/propgrid/advprops.cpp:1657
 msgid "Bullseye"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:875
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonFace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:876
+#: ../src/propgrid/advprops.cpp:777
 msgid "ButtonHighlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:877
+#: ../src/propgrid/advprops.cpp:778
 msgid "ButtonShadow"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:878
+#: ../src/propgrid/advprops.cpp:779
 msgid "ButtonText"
 msgstr ""
 
-#: ../src/common/paper.cpp:98
+#: ../src/common/paper.cpp:95
 msgid "C sheet, 17 x 22 in"
 msgstr "Fletë C, 17 x 22 inç"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "C&lear"
 msgstr "Spa&stroje"
 
-#: ../src/generic/fontdlgg.cpp:406
+#: ../src/generic/fontdlgg.cpp:403
 msgid "C&olour:"
 msgstr "N&gjyrë:"
 
-#: ../src/common/paper.cpp:123
+#: ../src/common/paper.cpp:120
 msgid "C3 Envelope, 324 x 458 mm"
 msgstr "Zarf C3, 324 x 458 mm"
 
-#: ../src/common/paper.cpp:124
+#: ../src/common/paper.cpp:121
 msgid "C4 Envelope, 229 x 324 mm"
 msgstr "Zarf C4, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:122
+#: ../src/common/paper.cpp:119
 msgid "C5 Envelope, 162 x 229 mm"
 msgstr "Zarf C5, 162 x 229 mm"
 
-#: ../src/common/paper.cpp:125
+#: ../src/common/paper.cpp:122
 msgid "C6 Envelope, 114 x 162 mm"
 msgstr "Zarf C6, 114 x 162 mm"
 
-#: ../src/common/paper.cpp:126
+#: ../src/common/paper.cpp:123
 msgid "C65 Envelope, 114 x 229 mm"
 msgstr "Zarf C65, 114 x 229 mm"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "CD-Rom"
 msgstr "CD-Rom"
 
-#: ../src/html/chm.cpp:815 ../src/html/chm.cpp:874
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:865
 msgid "CHM handler currently supports only local files!"
 msgstr "Hëpërhë, trajtuesi CHM, mbulon vetëm kartela vendore!"
 
@@ -1631,190 +1633,194 @@ msgstr "Hëpërhë, trajtuesi CHM, mbulon vetëm kartela vendore!"
 msgid "Ca&pitals"
 msgstr ""
 
-#: ../src/common/cmdproc.cpp:267
+#: ../src/common/cmdproc.cpp:260
 msgid "Can't &Undo "
 msgstr "S’&zhbëhet Dot "
 
-#: ../src/common/image.cpp:2824
+#: ../src/common/image.cpp:2924
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 
-#: ../src/msw/registry.cpp:506
+#: ../src/msw/registry.cpp:495
 #, c-format
 msgid "Can't close registry key '%s'"
 msgstr "S’mbyllet dot kyç regjistri '%s'"
 
-#: ../src/msw/registry.cpp:584
+#: ../src/msw/registry.cpp:573
 #, c-format
 msgid "Can't copy values of unsupported type %d."
 msgstr "S’kopjohen dot vlera lloji të pambuluar %d."
 
-#: ../src/msw/registry.cpp:487
+#: ../src/msw/registry.cpp:476
 #, c-format
 msgid "Can't create registry key '%s'"
 msgstr "S’krijohet dot kyç regjistri '%s'"
 
-#: ../src/msw/thread.cpp:665
+#: ../src/msw/thread.cpp:657
 msgid "Can't create thread"
 msgstr "S’krijohet dot rrjedhë"
 
-#: ../src/msw/window.cpp:3691
-#, c-format
-msgid "Can't create window of class %s"
-msgstr "S’krijohet dritare klase %s"
-
-#: ../src/msw/registry.cpp:777
+#: ../src/msw/registry.cpp:765
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "S’fshihet dot kyç '%s'"
 
-#: ../src/msw/iniconf.cpp:458
+#: ../src/msw/iniconf.cpp:455
 #, c-format
 msgid "Can't delete the INI file '%s'"
 msgstr "S’fshihet dot kartela INI '%s'"
 
-#: ../src/msw/registry.cpp:805
+#: ../src/msw/registry.cpp:793
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "S’fshihet dot vlerë '%s' prej kyçit '%s'"
 
-#: ../src/msw/registry.cpp:1171
+#: ../src/msw/registry.cpp:1159
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "S’numërtohen dot nënkyçe të kyçit '%s'"
 
-#: ../src/msw/registry.cpp:1132
+#: ../src/msw/registry.cpp:1120
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "S’numërtohen dot vlera kyçi '%s'"
 
-#: ../src/msw/registry.cpp:1389
+#: ../src/msw/registry.cpp:1377
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "S’eksportohet dot vlerë lloji të pambuluar %d."
 
-#: ../src/common/ffile.cpp:254
+#: ../src/common/ffile.cpp:253
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "S’gjendet dot pozicioni i tanishëm te kartela '%s'"
 
-#: ../src/msw/registry.cpp:418
+#: ../src/msw/registry.cpp:407
 #, c-format
 msgid "Can't get info about registry key '%s'"
 msgstr "S’merren dot dhëna rreth kyçi regjistrash '%s'"
 
-#: ../src/common/zstream.cpp:346
+#: ../src/msw/webview_ie.cpp:1024
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "S’caktohet dot përparësi rrjedhe"
+
+#: ../src/common/zstream.cpp:343
 msgid "Can't initialize zlib deflate stream."
 msgstr "S’gatitet dot rrymë zlib \"deflate\"."
 
-#: ../src/common/zstream.cpp:185
+#: ../src/common/zstream.cpp:182
 msgid "Can't initialize zlib inflate stream."
 msgstr "S’gatitet dot rrjedhë zlib \"inflate\"."
 
-#: ../src/msw/fswatcher.cpp:476
+#: ../src/msw/fswatcher.cpp:475
 #, c-format
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "S’mund të mbikëqyret për ndryshime drejtori \"%s\" që s’ekziston."
 
-#: ../src/msw/registry.cpp:454
+#: ../src/msw/registry.cpp:443
 #, c-format
 msgid "Can't open registry key '%s'"
 msgstr "S’hapet dot kyç regjistri '%s'"
 
-#: ../src/common/zstream.cpp:252
+#: ../src/common/zstream.cpp:249
 #, c-format
 msgid "Can't read from inflate stream: %s"
 msgstr "S’lexohet dot prej rrjedhe \"inflate\": %s"
 
-#: ../src/common/zstream.cpp:244
+#: ../src/common/zstream.cpp:241
 msgid "Can't read inflate stream: unexpected EOF in underlying stream."
 msgstr "S’lexohet dot rrjedhë \"inflate\": EOF i papritur nën rrjedhë."
 
-#: ../src/msw/registry.cpp:1064
+#: ../src/msw/registry.cpp:1052
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "S’lexohet dot vlera e '%s'"
 
-#: ../src/msw/registry.cpp:878 ../src/msw/registry.cpp:910
-#: ../src/msw/registry.cpp:975
+#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
+#: ../src/msw/registry.cpp:963
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "S’lexohet dot vlerë kyçi '%s'"
 
-#: ../src/common/image.cpp:2620
+#: ../src/msw/webview_ie.cpp:1017
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/common/image.cpp:2715
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "S’ruhet dot figurë te kartela '%s': zgjatim i panjohur."
 
-#: ../src/generic/logg.cpp:573 ../src/generic/logg.cpp:976
+#: ../src/generic/logg.cpp:570 ../src/generic/logg.cpp:973
 msgid "Can't save log contents to file."
 msgstr "S’ruhet dot lëndë regjistrimi te kartelë."
 
-#: ../src/msw/thread.cpp:629
+#: ../src/msw/thread.cpp:621
 msgid "Can't set thread priority"
 msgstr "S’caktohet dot përparësi rrjedhe"
 
-#: ../src/msw/registry.cpp:896 ../src/msw/registry.cpp:938
-#: ../src/msw/registry.cpp:1081
+#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
+#: ../src/msw/registry.cpp:1069
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "S’caktohet dot vlerë e '%s'"
 
-#: ../src/unix/utilsunx.cpp:351
+#: ../src/unix/utilsunx.cpp:353
 msgid "Can't write to child process's stdin"
 msgstr "S’shkruhet dot te stdin procesi pjelle"
 
-#: ../src/common/zstream.cpp:427
+#: ../src/common/zstream.cpp:424
 #, c-format
 msgid "Can't write to deflate stream: %s"
 msgstr "S’shkruhet dot te rrjedhë \"deflate\": %s"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:279 ../src/richtext/richtextstyledlg.cpp:300
-#: ../src/common/stockitem.cpp:145 ../src/common/accelcmn.cpp:71
-#: ../src/msw/msgdlg.cpp:454 ../src/msw/progdlg.cpp:673
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:142
+#: ../src/common/accelcmn.cpp:68 ../src/motif/msgdlg.cpp:196
+#: ../src/gtk1/fontdlg.cpp:144 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/progdlg.cpp:940 ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Anuloje"
 
-#: ../src/common/filefn.cpp:1261
+#: ../src/common/filefn.cpp:1149
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "S’numërtohen dot kartela '%s'"
 
-#: ../src/msw/dir.cpp:263
+#: ../src/msw/dir.cpp:260
 #, c-format
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "S’numërtohen dot kartela në drejtori '%s'"
 
-#: ../src/msw/dialup.cpp:523
+#: ../src/msw/dialup.cpp:517
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "S’gjendet dot lidhje \"dialup\" aktive: %s"
 
-#: ../src/msw/dialup.cpp:827
+#: ../src/msw/dialup.cpp:821
 msgid "Cannot find the location of address book file"
 msgstr "S’gjendet dot vendi i kartelës së librit të adresave"
 
-#: ../src/msw/ole/automtn.cpp:562
+#: ../src/msw/ole/automtn.cpp:553
 #, c-format
 msgid "Cannot get an active instance of \"%s\""
 msgstr "S’merret dot një instancë aktive e \"%s\""
 
-#: ../src/unix/threadpsx.cpp:1035
+#: ../src/unix/threadpsx.cpp:1053
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "S’merret dot interval përparësie për rregull planifikimi %d."
 
-#: ../src/unix/utilsunx.cpp:987
+#: ../src/unix/utilsunx.cpp:989
 msgid "Cannot get the hostname"
 msgstr "S’merret dot strehëemër"
 
-#: ../src/unix/utilsunx.cpp:1023
+#: ../src/unix/utilsunx.cpp:1025
 msgid "Cannot get the official hostname"
 msgstr "S’merret dot strehëemër zyrtar"
 
-#: ../src/msw/dialup.cpp:928
+#: ../src/msw/dialup.cpp:922
 msgid "Cannot hang up - no active dialup connection."
 msgstr "S’bëhet dot mbyllje - s’ka lidhje \"dialup\" aktive."
 
@@ -1822,126 +1828,126 @@ msgstr "S’bëhet dot mbyllje - s’ka lidhje \"dialup\" aktive."
 msgid "Cannot initialize OLE"
 msgstr "S’gatitet dot OLE"
 
-#: ../src/common/socket.cpp:853
+#: ../src/common/socket.cpp:850
 msgid "Cannot initialize sockets"
 msgstr "S’gatiten dot socket-e"
 
-#: ../src/msw/volume.cpp:619
+#: ../src/msw/volume.cpp:627
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "S’ngarkohet dot ikonë prej '%s'."
 
-#: ../src/xrc/xmlres.cpp:360
+#: ../src/xrc/xmlres.cpp:358
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "S’ngarkohen dot burime prej kartele '%s'."
 
-#: ../src/xrc/xmlres.cpp:742
+#: ../src/xrc/xmlres.cpp:740
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "S’ngarkohen dot burime prej kartele '%s'."
 
-#: ../src/html/htmlfilt.cpp:137
+#: ../src/html/htmlfilt.cpp:134
 #, c-format
 msgid "Cannot open HTML document: %s"
 msgstr "S’hapet dot dokument HTML: %s"
 
-#: ../src/html/helpdata.cpp:667
+#: ../src/html/helpdata.cpp:660
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "S’hap dot libër HTML ndihme: %s"
 
-#: ../src/html/helpdata.cpp:299
+#: ../src/html/helpdata.cpp:296
 #, c-format
 msgid "Cannot open contents file: %s"
 msgstr "S’hapet dot kartelë lëndësh: %s"
 
-#: ../src/generic/dcpsg.cpp:1667
+#: ../src/generic/dcpsg.cpp:1665
 msgid "Cannot open file for PostScript printing!"
 msgstr "S’hapet dot kartelë për shtypje PostScript!"
 
-#: ../src/html/helpdata.cpp:313
+#: ../src/html/helpdata.cpp:310
 #, c-format
 msgid "Cannot open index file: %s"
 msgstr "S’hap dot kartelë treguesi: %s"
 
-#: ../src/xrc/xmlres.cpp:724
+#: ../src/xrc/xmlres.cpp:722
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "S’hapet dot kartelë burimesh %s."
 
-#: ../src/html/helpwnd.cpp:1534
+#: ../src/html/helpwnd.cpp:1532
 msgid "Cannot print empty page."
 msgstr "S’shtypet dot faqe e zbrazët."
 
-#: ../src/msw/volume.cpp:507
+#: ../src/msw/volume.cpp:515
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "S’lexohet dot emër lloji prej '%s'!"
 
-#: ../src/msw/thread.cpp:888
+#: ../src/msw/thread.cpp:894
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "S’rimerret dot rrjedha %lx"
 
-#: ../src/unix/threadpsx.cpp:1016
+#: ../src/unix/threadpsx.cpp:1028
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "S’merret dot rregull planifikimi rrjedhe."
 
-#: ../src/common/intl.cpp:558
+#: ../src/common/intl.cpp:365
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "S’caktohet dot gjuha '%s' si vendore."
 
-#: ../src/unix/threadpsx.cpp:831 ../src/msw/thread.cpp:546
+#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
 msgid "Cannot start thread: error writing TLS."
 msgstr "S’fillohet dot rrjedhë: gabim në shkrim TLS-je."
 
-#: ../src/msw/thread.cpp:872
+#: ../src/msw/thread.cpp:864
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "S’pezullohet dot rrjedha %lx"
 
-#: ../src/msw/thread.cpp:794
+#: ../src/msw/thread.cpp:786
 msgid "Cannot wait for thread termination"
 msgstr "S’pritet dot për përfundim rrjedhe"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:75
+#: ../src/common/accelcmn.cpp:72
 msgid "Capital"
 msgstr "Të mëdha"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:879
+#: ../src/propgrid/advprops.cpp:780
 msgid "CaptionText"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:531
 msgid "Case sensitive"
 msgstr "Siç është shkruajtur"
 
-#: ../src/propgrid/manager.cpp:1509
+#: ../src/propgrid/manager.cpp:1527
 msgid "Categorized Mode"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9968
+#: ../src/richtext/richtextbuffer.cpp:9965
 msgid "Cell Properties"
 msgstr "Veti Kutize"
 
-#: ../src/common/fmapbase.cpp:161
+#: ../src/common/fmapbase.cpp:158
 msgid "Celtic (ISO-8859-14)"
 msgstr "Kelte (ISO-8859-14)"
 
-#: ../src/richtext/richtextindentspage.cpp:160
 #: ../src/richtext/richtextliststylepage.cpp:349
+#: ../src/richtext/richtextindentspage.cpp:160
 msgid "Cen&tred"
 msgstr "Në &qendër"
 
-#: ../src/common/stockitem.cpp:170
+#: ../src/common/stockitem.cpp:167
 msgid "Centered"
 msgstr "Në qendër"
 
-#: ../src/common/fmapbase.cpp:149
+#: ../src/common/fmapbase.cpp:146
 msgid "Central European (ISO-8859-2)"
 msgstr "Europiane Qendrore (ISO-8859-2)"
 
@@ -1950,10 +1956,10 @@ msgstr "Europiane Qendrore (ISO-8859-2)"
 msgid "Centre"
 msgstr "Në qendër"
 
-#: ../src/richtext/richtextindentspage.cpp:162
-#: ../src/richtext/richtextindentspage.cpp:164
 #: ../src/richtext/richtextliststylepage.cpp:351
 #: ../src/richtext/richtextliststylepage.cpp:353
+#: ../src/richtext/richtextindentspage.cpp:162
+#: ../src/richtext/richtextindentspage.cpp:164
 msgid "Centre text."
 msgstr "Vendose tekstin në qendër."
 
@@ -1966,24 +1972,24 @@ msgstr "Në qendër"
 msgid "Ch&oose..."
 msgstr "&Zgjidhni…"
 
-#: ../src/richtext/richtextbuffer.cpp:4354
+#: ../src/richtext/richtextbuffer.cpp:4351
 msgid "Change List Style"
 msgstr "Ndryshoni Stil Liste"
 
-#: ../src/richtext/richtextbuffer.cpp:3709
+#: ../src/richtext/richtextbuffer.cpp:3706
 msgid "Change Object Style"
 msgstr "Ndryshoni Stil Objekti"
 
-#: ../src/richtext/richtextbuffer.cpp:3982
-#: ../src/richtext/richtextbuffer.cpp:8129
+#: ../src/richtext/richtextbuffer.cpp:3979
+#: ../src/richtext/richtextbuffer.cpp:8125
 msgid "Change Properties"
 msgstr "Ndryshoni Veti"
 
-#: ../src/richtext/richtextbuffer.cpp:3526
+#: ../src/richtext/richtextbuffer.cpp:3523
 msgid "Change Style"
 msgstr "Ndryshoni Stil"
 
-#: ../src/common/fileconf.cpp:341
+#: ../src/common/fileconf.cpp:335
 #, c-format
 msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
 msgstr ""
@@ -1996,11 +2002,11 @@ msgid "Changing current directory to \"%s\" failed"
 msgstr "S’u arrit të ndryshohej drejtoria e tanishme si \"%s\""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1757
+#: ../src/propgrid/advprops.cpp:1658
 msgid "Character"
 msgstr "Shenjë"
 
-#: ../src/richtext/richtextstyles.cpp:1063
+#: ../src/richtext/richtextstyles.cpp:1060
 msgid "Character styles"
 msgstr "Stile shenjash"
 
@@ -2037,20 +2043,20 @@ msgstr "I vini shenjë që topthit t’i vihen kllapa."
 msgid "Check to indicate right-to-left text layout."
 msgstr "I vini shenjë për të treguar skemë teksti nga-e-djathta-në-të-majtë."
 
-#: ../src/osx/carbon/fontdlg.cpp:356 ../src/osx/carbon/fontdlg.cpp:358
+#: ../src/osx/carbon/fontdlg.cpp:353 ../src/osx/carbon/fontdlg.cpp:355
 msgid "Check to make the font bold."
 msgstr "I vini shenjë për t’i bërë shkronjat të trasha."
 
-#: ../src/osx/carbon/fontdlg.cpp:363 ../src/osx/carbon/fontdlg.cpp:365
+#: ../src/osx/carbon/fontdlg.cpp:360 ../src/osx/carbon/fontdlg.cpp:362
 msgid "Check to make the font italic."
 msgstr "I vini shenjë për t’i bërë shkronjat të pjerrëta."
 
-#: ../src/osx/carbon/fontdlg.cpp:372 ../src/osx/carbon/fontdlg.cpp:374
+#: ../src/osx/carbon/fontdlg.cpp:369 ../src/osx/carbon/fontdlg.cpp:371
 msgid "Check to make the font underlined."
 msgstr "I vini shenjë për t’i bërë shkronjat të nënvizuara."
 
-#: ../src/richtext/richtextstyledlg.cpp:289
-#: ../src/richtext/richtextstyledlg.cpp:291
+#: ../src/richtext/richtextstyledlg.cpp:285
+#: ../src/richtext/richtextstyledlg.cpp:287
 msgid "Check to restart numbering."
 msgstr "I vini shenjë që të rinisë numërimi."
 
@@ -2084,51 +2090,51 @@ msgstr "I vini shenjë që teksti të shfaqet me superskript."
 msgid "Check to suppress hyphenation."
 msgstr "I vini shenjë që të hiqen vijat ndarëse."
 
-#: ../src/msw/dialup.cpp:763
+#: ../src/msw/dialup.cpp:757
 msgid "Choose ISP to dial"
 msgstr "Zgjidhni ISP për t’i rënë numrit"
 
-#: ../src/propgrid/props.cpp:1922
+#: ../src/propgrid/props.cpp:1904
 msgid "Choose a directory:"
 msgstr "Zgjidhni një drejtori:"
 
-#: ../src/propgrid/props.cpp:1975
+#: ../src/propgrid/props.cpp:2199
 msgid "Choose a file"
 msgstr "Zgjidhni një kartelë"
 
-#: ../src/generic/colrdlgg.cpp:158 ../src/gtk/colordlg.cpp:54
+#: ../src/generic/colrdlgg.cpp:156 ../src/gtk/colordlg.cpp:49
 msgid "Choose colour"
 msgstr "Zgjidhni ngjyrë"
 
-#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/gtk1/fontdlg.cpp:125 ../src/generic/fontpickerg.cpp:47
+#: ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Zgjidhni shkronja"
 
-#: ../src/common/module.cpp:74
+#: ../src/common/module.cpp:71
 #, c-format
 msgid "Circular dependency involving module \"%s\" detected."
 msgstr "U pikas varësi rrethore që përfshin modulin \"%s\"."
 
-#: ../src/aui/tabmdi.cpp:108 ../src/generic/mdig.cpp:97
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
 msgid "Cl&ose"
 msgstr "MB&ylle"
 
-#: ../src/msw/ole/automtn.cpp:684
+#: ../src/msw/ole/automtn.cpp:675
 msgid "Class not registered."
 msgstr "Klasë e paregjistruar."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:147 ../src/common/accelcmn.cpp:72
+#: ../src/common/stockitem.cpp:144 ../src/common/accelcmn.cpp:69
 msgid "Clear"
 msgstr "Spastroje"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "Clear the log contents"
 msgstr "Spastro lëndën e regjistrit"
 
-#: ../src/richtext/richtextstyledlg.cpp:252
-#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:248
+#: ../src/richtext/richtextstyledlg.cpp:250
 msgid "Click to apply the selected style."
 msgstr "Klikoni që të zbatohet stili i përzgjedhur."
 
@@ -2139,15 +2145,15 @@ msgstr "Klikoni që të zbatohet stili i përzgjedhur."
 msgid "Click to browse for a symbol."
 msgstr "Klikoni që të shfletoni për një simbol."
 
-#: ../src/osx/carbon/fontdlg.cpp:403 ../src/osx/carbon/fontdlg.cpp:405
+#: ../src/osx/carbon/fontdlg.cpp:400 ../src/osx/carbon/fontdlg.cpp:402
 msgid "Click to cancel changes to the font."
 msgstr "Klikoni që të anulohen ndryshime te shkronjat."
 
-#: ../src/generic/fontdlgg.cpp:472 ../src/generic/fontdlgg.cpp:491
+#: ../src/generic/fontdlgg.cpp:468 ../src/generic/fontdlgg.cpp:487
 msgid "Click to cancel the font selection."
 msgstr "Klikoni për anulim përzgjedhjeje shkronjash."
 
-#: ../src/osx/carbon/fontdlg.cpp:384 ../src/osx/carbon/fontdlg.cpp:386
+#: ../src/osx/carbon/fontdlg.cpp:381 ../src/osx/carbon/fontdlg.cpp:383
 msgid "Click to change the font colour."
 msgstr "Klikoni që të ndryshohet ngjyra e shkronjave."
 
@@ -2166,37 +2172,37 @@ msgstr "Klikoni që të ndryshohet ngjyra e tekstit."
 msgid "Click to choose the font for this level."
 msgstr "Klikoni për të zgjedhur shkronjat për këtë shkallë."
 
-#: ../src/richtext/richtextstyledlg.cpp:279
-#: ../src/richtext/richtextstyledlg.cpp:281
+#: ../src/richtext/richtextstyledlg.cpp:275
+#: ../src/richtext/richtextstyledlg.cpp:277
 msgid "Click to close this window."
 msgstr "Klikoni që të mbyllet kjo dritare."
 
-#: ../src/osx/carbon/fontdlg.cpp:410 ../src/osx/carbon/fontdlg.cpp:412
+#: ../src/osx/carbon/fontdlg.cpp:407 ../src/osx/carbon/fontdlg.cpp:409
 msgid "Click to confirm changes to the font."
 msgstr "Klikoni për ripohim të ndryshimeve te shkronjat."
 
-#: ../src/generic/fontdlgg.cpp:477 ../src/generic/fontdlgg.cpp:479
-#: ../src/generic/fontdlgg.cpp:484 ../src/generic/fontdlgg.cpp:486
+#: ../src/generic/fontdlgg.cpp:473 ../src/generic/fontdlgg.cpp:475
+#: ../src/generic/fontdlgg.cpp:480 ../src/generic/fontdlgg.cpp:482
 msgid "Click to confirm the font selection."
 msgstr "Klikoni për ripohim përzgjedhjeje shkronjash."
 
-#: ../src/richtext/richtextstyledlg.cpp:244
-#: ../src/richtext/richtextstyledlg.cpp:246
+#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:242
 msgid "Click to create a new box style."
 msgstr "Klikoni që të krijoni një stil të ri kuadrati."
 
-#: ../src/richtext/richtextstyledlg.cpp:226
-#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:224
 msgid "Click to create a new character style."
 msgstr "Klikoni që të krijoni një stil të ri shkronjash."
 
-#: ../src/richtext/richtextstyledlg.cpp:238
-#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:236
 msgid "Click to create a new list style."
 msgstr "Klikoni që të krijoni një stil të ri listash."
 
-#: ../src/richtext/richtextstyledlg.cpp:232
-#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:230
 msgid "Click to create a new paragraph style."
 msgstr "Klikoni që të krijoni një stil të ri paragrafësh."
 
@@ -2210,8 +2216,8 @@ msgstr "Klikoni që të krijoni një pozicion të ri tabulacioni."
 msgid "Click to delete all tab positions."
 msgstr "Klikoni që të fshihen krejt pozicionet e tabulacionit."
 
-#: ../src/richtext/richtextstyledlg.cpp:270
-#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:268
 msgid "Click to delete the selected style."
 msgstr "Klikoni që të fshihet stili i përzgjedhur."
 
@@ -2220,25 +2226,25 @@ msgstr "Klikoni që të fshihet stili i përzgjedhur."
 msgid "Click to delete the selected tab position."
 msgstr "Klikoni që të fshihet pozicioni i përzgjedhur i tabulacionit."
 
-#: ../src/richtext/richtextstyledlg.cpp:264
-#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:262
 msgid "Click to edit the selected style."
 msgstr "Klikoni për përpunim të stilit të përzgjedhur."
 
-#: ../src/richtext/richtextstyledlg.cpp:258
-#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:256
 msgid "Click to rename the selected style."
 msgstr "Klikoni që të riemërtoni stilin e përzgjedhur."
 
-#: ../src/generic/dbgrptg.cpp:97 ../src/generic/progdlgg.cpp:759
-#: ../src/richtext/richtextstyledlg.cpp:277
-#: ../src/richtext/richtextsymboldlg.cpp:476 ../src/common/stockitem.cpp:148
-#: ../src/msw/progdlg.cpp:170 ../src/msw/progdlg.cpp:679
-#: ../src/html/helpdlg.cpp:90
+#: ../src/common/stockitem.cpp:145 ../src/generic/dbgrptg.cpp:94
+#: ../src/generic/progdlgg.cpp:781 ../src/msw/progdlg.cpp:211
+#: ../src/msw/progdlg.cpp:946 ../src/html/helpdlg.cpp:87
+#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextstyledlg.cpp:273
 msgid "Close"
 msgstr "Mbylle"
 
-#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:98
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
 msgid "Close All"
 msgstr "Mbylli Krejt"
 
@@ -2246,43 +2252,43 @@ msgstr "Mbylli Krejt"
 msgid "Close current document"
 msgstr "Mbyll dokumentin e tanishëm"
 
-#: ../src/generic/logg.cpp:516
+#: ../src/generic/logg.cpp:513
 msgid "Close this window"
 msgstr "Mbyll këtë dritare"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6006
+#: ../src/generic/datavgen.cpp:6811
 msgid "Collapse"
 msgstr "Tkurre"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "Color"
 msgstr "Ngjyrë"
 
-#: ../src/richtext/richtextformatdlg.cpp:776
+#: ../src/richtext/richtextformatdlg.cpp:768
 msgid "Colour"
 msgstr "Ngjyrë"
 
-#: ../src/msw/colordlg.cpp:158
+#: ../src/msw/colordlg.cpp:227
 #, c-format
 msgid "Colour selection dialog failed with error %0lx."
 msgstr "Dialogu i përzgjedhjes së ngjyrës dështoi me gabimin %0lx."
 
-#: ../src/osx/carbon/fontdlg.cpp:380
+#: ../src/osx/carbon/fontdlg.cpp:377
 msgid "Colour:"
 msgstr "Ngjyrë:"
 
-#: ../src/generic/datavgen.cpp:6077
+#: ../src/generic/datavgen.cpp:6882
 #, c-format
 msgid "Column %u"
 msgstr "Shtylla %u"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:114
+#: ../src/common/accelcmn.cpp:112
 msgid "Command"
 msgstr "Urdhër"
 
-#: ../src/common/init.cpp:196
+#: ../src/common/init.cpp:193
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
@@ -2291,12 +2297,12 @@ msgstr ""
 "S’u shndërrua dot në Unikod argumenti %d për rresht urdhrash dhe do të "
 "shpërfillet."
 
-#: ../src/msw/fontdlg.cpp:120
+#: ../src/msw/fontdlg.cpp:170
 #, c-format
 msgid "Common dialog failed with error code %0lx."
 msgstr "Dialogu i rëndomtë dështoi me kod gabimi %0lx."
 
-#: ../src/gtk/window.cpp:4649
+#: ../src/gtk/window.cpp:5653
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
@@ -2304,11 +2310,11 @@ msgstr ""
 "Hartimi nuk mbulohet nga ky sistem, ju lutemi, aktivizojeni te Window "
 "Manager juaj."
 
-#: ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:1549
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Kartelë e ngjeshur HTML ndihme HTML (*.chm)|*.chm|"
 
-#: ../src/generic/dirctrlg.cpp:444
+#: ../src/generic/dirctrlg.cpp:410
 msgid "Computer"
 msgstr "Kompjuter"
 
@@ -2317,53 +2323,57 @@ msgstr "Kompjuter"
 msgid "Config entry name cannot start with '%c'."
 msgstr "Emër zëri formësimi s’mund të fillojë me '%c'."
 
-#: ../src/generic/filedlgg.cpp:349 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
 msgid "Confirm"
 msgstr "Ripohojeni"
 
-#: ../src/html/htmlwin.cpp:566
+#: ../src/html/htmlwin.cpp:569
 msgid "Connecting..."
 msgstr "Po lidhet…"
 
-#: ../src/html/helpwnd.cpp:475
+#: ../src/html/helpwnd.cpp:473
 msgid "Contents"
 msgstr "Lëndë"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:880
+#: ../src/propgrid/advprops.cpp:781
 msgid "ControlDark"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:881
+#: ../src/propgrid/advprops.cpp:782
 msgid "ControlLight"
 msgstr ""
 
-#: ../src/common/strconv.cpp:2262
+#: ../src/common/strconv.cpp:2208
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Shndërrimi në shkronjat '%s' nuk funksionon."
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "Convert"
 msgstr "Shndërroje"
 
-#: ../src/html/htmlwin.cpp:1079
+#: ../src/html/htmlwin.cpp:1020
 #, c-format
 msgid "Copied to clipboard:\"%s\""
 msgstr "U kopjua në të papastër:\"%s\""
 
-#: ../src/generic/prntdlgg.cpp:247
+#: ../src/generic/prntdlgg.cpp:240
 msgid "Copies:"
 msgstr "Kopje:"
 
-#: ../src/common/stockitem.cpp:150 ../src/stc/stc_i18n.cpp:18
+#: ../src/common/stockitem.cpp:147 ../src/stc/stc_i18n.cpp:18
 msgid "Copy"
 msgstr "Kopjoje"
 
-#: ../src/common/stockitem.cpp:258
+#: ../src/common/stockitem.cpp:255
 msgid "Copy selection"
 msgstr "Kopjo përzgjedhjen"
+
+#: ../src/generic/grid.cpp:5945
+msgid "Copying more than one selected block to clipboard is not supported."
+msgstr ""
 
 #: ../src/richtext/richtextborderspage.cpp:566
 #: ../src/richtext/richtextborderspage.cpp:601
@@ -2374,196 +2384,193 @@ msgstr "Cep"
 msgid "Corner &radius:"
 msgstr "&Rreze cepi:"
 
-#: ../src/html/chm.cpp:718
+#: ../src/html/chm.cpp:711
 #, c-format
 msgid "Could not create temporary file '%s'"
 msgstr "S’u krijua dot kartelë të përkohshme '%s'"
 
-#: ../src/html/chm.cpp:273
+#: ../src/html/chm.cpp:270
 #, c-format
 msgid "Could not extract %s into %s: %s"
 msgstr "S’u përftua dot %s te %s: %s"
 
-#: ../src/generic/tabg.cpp:1048
+#: ../src/generic/tabg.cpp:1045
 msgid "Could not find tab for id"
 msgstr "S’u gjet dot skedë për id"
 
-#: ../src/gtk/notifmsg.cpp:108
-msgid "Could not initalize libnotify."
-msgstr "S’u gatit dot libnotify."
-
-#: ../src/html/chm.cpp:444
+#: ../src/html/chm.cpp:437
 #, c-format
 msgid "Could not locate file '%s'."
 msgstr "S’u lokalizua dot kartelë '%s'."
 
-#: ../src/common/filefn.cpp:1403
+#: ../src/msw/graphicsd2d.cpp:604
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/common/filefn.cpp:1291
 msgid "Could not set current working directory"
 msgstr "S’u caktua dot drejtori e tanishme e punës"
 
-#: ../src/common/prntbase.cpp:2015
+#: ../src/common/prntbase.cpp:2037
 msgid "Could not start document preview."
 msgstr "S’u nis dot paraparje dokumenti."
 
-#: ../src/generic/printps.cpp:178 ../src/msw/printwin.cpp:210
-#: ../src/gtk/print.cpp:1132
+#: ../src/generic/printps.cpp:159 ../src/msw/printwin.cpp:184
+#: ../src/gtk/print.cpp:1129
 msgid "Could not start printing."
 msgstr "S’u nis dot shtypje."
 
-#: ../src/common/wincmn.cpp:2125
+#: ../src/common/wincmn.cpp:2126
 msgid "Could not transfer data to window"
 msgstr "S’u shpërngulën dot të dhëna te dritare"
 
-#: ../src/msw/imaglist.cpp:187 ../src/msw/imaglist.cpp:224
-#: ../src/msw/imaglist.cpp:249 ../src/msw/dragimag.cpp:185
-#: ../src/msw/dragimag.cpp:220
+#: ../src/msw/imaglist.cpp:223 ../src/msw/imaglist.cpp:245
+#: ../src/msw/imaglist.cpp:270 ../src/msw/dragimag.cpp:182
+#: ../src/msw/dragimag.cpp:217
 msgid "Couldn't add an image to the image list."
 msgstr "S’u shtua dot një figurë te lista e figurave."
 
-#: ../src/osx/glcanvas_osx.cpp:414 ../src/unix/glx11.cpp:558
-#: ../src/msw/glcanvas.cpp:616
+#: ../src/osx/glcanvas_osx.cpp:411 ../src/msw/glcanvas.cpp:631
+#: ../src/unix/glegl.cpp:315 ../src/unix/glx11.cpp:559
 msgid "Couldn't create OpenGL context"
 msgstr "S’u krijua dot kontekst OpenGL"
 
-#: ../src/msw/timer.cpp:134
+#: ../src/msw/timer.cpp:131
 msgid "Couldn't create a timer"
 msgstr "S’u krijua dot kohëmatës"
 
-#: ../src/osx/carbon/overlay.cpp:122
-msgid "Couldn't create the overlay window"
-msgstr "S’u krijua dot dritarja përsipër"
-
-#: ../src/common/translation.cpp:2024
+#: ../src/common/translation.cpp:2074
 msgid "Couldn't enumerate translations"
 msgstr "S’u numërtuan dot përkthimet"
 
-#: ../src/common/dynlib.cpp:120
+#: ../src/common/dynlib.cpp:110
 #, c-format
 msgid "Couldn't find symbol '%s' in a dynamic library"
 msgstr "S’u gjet dot simbol '%s' në një librari dinamike"
 
-#: ../src/msw/thread.cpp:915
+#: ../src/msw/thread.cpp:921
 msgid "Couldn't get the current thread pointer"
 msgstr ""
 
-#: ../src/osx/carbon/overlay.cpp:129
-msgid "Couldn't init the context on the overlay window"
-msgstr ""
-
-#: ../src/common/imaggif.cpp:244
+#: ../src/common/imaggif.cpp:241
 msgid "Couldn't initialize GIF hash table."
 msgstr "S’u gatit dot tabelë hashesh GIF-i."
 
-#: ../src/common/imagpng.cpp:409
+#: ../src/common/imagpng.cpp:437
 msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
 msgstr ""
 "S’u ngarkua dot figurë PNG - kartela është e dëmtuar ose kujtesë e "
 "pamjaftueshme."
 
-#: ../src/unix/sound.cpp:470
+#: ../src/unix/sound.cpp:459
 #, c-format
 msgid "Couldn't load sound data from '%s'."
 msgstr "S’u ngarkuan dot të dhëna tingujsh prej '%s'."
 
-#: ../src/msw/dirdlg.cpp:435
+#: ../src/msw/dirdlg.cpp:287
 msgid "Couldn't obtain folder name"
 msgstr "S’u mor dot emër dosjeje"
 
-#: ../src/unix/sound_sdl.cpp:229
+#: ../src/unix/sound_sdl.cpp:226
 #, c-format
 msgid "Couldn't open audio: %s"
 msgstr "S’u hap dot audio: %s"
 
-#: ../src/msw/ole/dataobj.cpp:377
+#: ../src/msw/ole/dataobj.cpp:385
 #, c-format
 msgid "Couldn't register clipboard format '%s'."
 msgstr "S’u regjistrua dot format të papastre '%s'."
 
-#: ../src/msw/listctrl.cpp:869
+#: ../src/msw/listctrl.cpp:933
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "S’u morën dot të dhëna rreth objekti kontrolli liste %d."
 
-#: ../src/common/imagpng.cpp:498 ../src/common/imagpng.cpp:509
-#: ../src/common/imagpng.cpp:519
+#: ../src/common/imagpng.cpp:511 ../src/common/imagpng.cpp:522
+#: ../src/common/imagpng.cpp:532
 msgid "Couldn't save PNG image."
 msgstr "S’u ruajt dot figurë PNG."
 
-#: ../src/msw/thread.cpp:684
+#: ../src/msw/thread.cpp:676
 msgid "Couldn't terminate thread"
 msgstr "S’u përfundua dot rrjedhë"
 
-#: ../src/common/xtistrm.cpp:166
+#: ../src/common/xtistrm.cpp:163
 #, c-format
 msgid "Create Parameter %s not found in declared RTTI Parameters"
 msgstr ""
 
-#: ../src/generic/dirdlgg.cpp:288
+#: ../src/generic/dirdlgg.cpp:285
 msgid "Create directory"
 msgstr "Krijoni drejtori"
 
-#: ../src/generic/filedlgg.cpp:212 ../src/generic/dirdlgg.cpp:111
+#: ../src/generic/filedlgg.cpp:209 ../src/generic/dirdlgg.cpp:108
 msgid "Create new directory"
 msgstr "Krijoni drejtori të re"
 
-#: ../src/xrc/xmlres.cpp:2460
+#: ../src/common/stockitem.cpp:264
+#, fuzzy
+msgid "Create new document"
+msgstr "Krijoni drejtori të re"
+
+#: ../src/xrc/xmlres.cpp:2515
 #, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Krijimi i %s \"%s\" dështoi."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1758
+#: ../src/propgrid/advprops.cpp:1659
 msgid "Cross"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:333
+#: ../src/common/accelcmn.cpp:347
 msgid "Ctrl+"
 msgstr "Ctrl+"
 
-#: ../src/richtext/richtextctrl.cpp:332 ../src/osx/textctrl_osx.cpp:576
-#: ../src/common/stockitem.cpp:151 ../src/msw/textctrl.cpp:2507
+#: ../src/osx/textctrl_osx.cpp:594 ../src/common/stockitem.cpp:148
+#: ../src/msw/textctrl.cpp:2772 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "P&rije"
 
-#: ../src/generic/filectrlg.cpp:940
+#: ../src/generic/filectrlg.cpp:936
 msgid "Current directory:"
 msgstr "Drejtoria e çastit:"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:896 ../src/propgrid/advprops.cpp:1574
-#: ../src/propgrid/advprops.cpp:1612
+#: ../src/propgrid/advprops.cpp:797 ../src/propgrid/advprops.cpp:1475
+#: ../src/propgrid/advprops.cpp:1518
 msgid "Custom"
 msgstr "Vetjake"
 
-#: ../src/gtk/print.cpp:217
+#: ../src/gtk/print.cpp:211
 msgid "Custom size"
 msgstr "Madhësi vetjake"
 
-#: ../src/common/headerctrlcmn.cpp:60
+#: ../src/common/headerctrlcmn.cpp:58
 msgid "Customize Columns"
 msgstr "Përshtatni Shtylla"
 
-#: ../src/common/stockitem.cpp:151 ../src/stc/stc_i18n.cpp:17
+#: ../src/common/stockitem.cpp:148 ../src/stc/stc_i18n.cpp:17
 msgid "Cut"
 msgstr "Prije"
 
-#: ../src/common/stockitem.cpp:259
+#: ../src/common/stockitem.cpp:256
 msgid "Cut selection"
 msgstr "Prije përzgjedhjen"
 
-#: ../src/common/fmapbase.cpp:152
+#: ../src/common/fmapbase.cpp:149
 msgid "Cyrillic (ISO-8859-5)"
 msgstr "Cirilike, (ISO-8859-5)"
 
-#: ../src/common/paper.cpp:99
+#: ../src/common/paper.cpp:96
 msgid "D sheet, 22 x 34 in"
 msgstr "Fletë D, 22 x 34 inç"
 
-#: ../src/msw/dde.cpp:703
+#: ../src/msw/dde.cpp:698
 msgid "DDE poke request failed"
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1169
+#: ../src/common/imagbmp.cpp:1181
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr "Krye DIB: Kodimi s’përputhet me \"bitdepth\"."
 
@@ -2583,7 +2590,7 @@ msgstr "Krye DIB: \"Bitdepth\" i panjohur në kartelë."
 msgid "DIB Header: Unknown encoding in file."
 msgstr "Krye DIB: Kodim i panjohur në kartelë."
 
-#: ../src/common/paper.cpp:121
+#: ../src/common/paper.cpp:118
 msgid "DL Envelope, 110 x 220 mm"
 msgstr "Zarf DL, 110 x 220 mm"
 
@@ -2591,53 +2598,53 @@ msgstr "Zarf DL, 110 x 220 mm"
 msgid "Dashed"
 msgstr ""
 
-#: ../src/generic/dbgrptg.cpp:300
+#: ../src/generic/dbgrptg.cpp:301
 #, c-format
 msgid "Debug report \"%s\""
 msgstr "Raport diagnostikimi \"%s\""
 
-#: ../src/common/debugrpt.cpp:210
+#: ../src/common/debugrpt.cpp:211
 msgid "Debug report couldn't be created."
 msgstr "S'u krijua dot raport diagnostikimi."
 
-#: ../src/common/debugrpt.cpp:553
+#: ../src/common/debugrpt.cpp:554
 msgid "Debug report generation has failed."
 msgstr "Dështoi prodhimi i një raporti diagnostikimi."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:84
+#: ../src/common/accelcmn.cpp:81
 msgid "Decimal"
 msgstr "Dhjetor"
 
-#: ../src/generic/fontdlgg.cpp:323
+#: ../src/generic/fontdlgg.cpp:319
 msgid "Decorative"
 msgstr "Zbukures(e)"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1752
+#: ../src/propgrid/advprops.cpp:1653
 msgid "Default"
 msgstr "Parazgjedhje"
 
-#: ../src/common/fmapbase.cpp:796
+#: ../src/common/fmapbase.cpp:792
 msgid "Default encoding"
 msgstr "Kodim parazgjedhje"
 
-#: ../src/dfb/fontmgr.cpp:180
+#: ../src/dfb/fontmgr.cpp:177
 msgid "Default font"
 msgstr "Shkronja parazgjedhje"
 
-#: ../src/generic/prntdlgg.cpp:510
+#: ../src/generic/prntdlgg.cpp:503
 msgid "Default printer"
 msgstr "Shtypës parazgjedhje"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:51
+#: ../src/common/accelcmn.cpp:48
 msgid "Del"
 msgstr "Del"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextbuffer.cpp:8221 ../src/common/stockitem.cpp:152
-#: ../src/common/accelcmn.cpp:50 ../src/stc/stc_i18n.cpp:20
+#: ../src/common/stockitem.cpp:149 ../src/common/accelcmn.cpp:47
+#: ../src/richtext/richtextbuffer.cpp:8217 ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Fshije"
 
@@ -2645,68 +2652,68 @@ msgstr "Fshije"
 msgid "Delete A&ll"
 msgstr "Fshiji &Krejt"
 
-#: ../src/richtext/richtextbuffer.cpp:11341
+#: ../src/richtext/richtextbuffer.cpp:11340
 msgid "Delete Column"
 msgstr "Fshije Shtyllën"
 
-#: ../src/richtext/richtextbuffer.cpp:11291
+#: ../src/richtext/richtextbuffer.cpp:11290
 msgid "Delete Row"
 msgstr "Fshije Rreshtin"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 msgid "Delete Style"
 msgstr "Fshije Stilin"
 
-#: ../src/richtext/richtextctrl.cpp:1345 ../src/richtext/richtextctrl.cpp:1584
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
 msgid "Delete Text"
 msgstr "Fshije Tekstin"
 
-#: ../src/generic/editlbox.cpp:170
+#: ../src/generic/editlbox.cpp:147
 msgid "Delete item"
 msgstr "Fshije objektin"
 
-#: ../src/common/stockitem.cpp:260
+#: ../src/common/stockitem.cpp:257
 msgid "Delete selection"
 msgstr "Fshije përzgjedhjen"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 #, c-format
 msgid "Delete style %s?"
 msgstr "Të fshihet stili %s?"
 
-#: ../src/unix/snglinst.cpp:301
+#: ../src/unix/snglinst.cpp:298
 #, c-format
 msgid "Deleted stale lock file '%s'."
 msgstr "U fshi kartelë kyçjeje '%s' e ndenjur."
 
-#: ../src/common/secretstore.cpp:220
-#, c-format
-msgid "Deleting password for \"%s/%s\" failed: %s."
+#: ../src/common/secretstore.cpp:234
+#, fuzzy, c-format
+msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Fshirja e fjalëkalimit për \"%s/%s\" dështoi: %s."
 
-#: ../src/common/module.cpp:124
+#: ../src/common/module.cpp:121
 #, c-format
 msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
 msgstr "Varësia \"%s\" e modulit \"%s\" s’ekziston."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "Descending"
 msgstr "Zbritës"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:526 ../src/propgrid/advprops.cpp:882
+#: ../src/generic/dirctrlg.cpp:492 ../src/propgrid/advprops.cpp:783
 msgid "Desktop"
 msgstr "Desktop"
 
-#: ../src/generic/aboutdlgg.cpp:70
+#: ../src/generic/aboutdlgg.cpp:67
 msgid "Developed by "
 msgstr "Zhvilluar prej "
 
-#: ../src/generic/aboutdlgg.cpp:176
+#: ../src/generic/aboutdlgg.cpp:173
 msgid "Developers"
 msgstr "Zhvillues"
 
-#: ../src/msw/dialup.cpp:374
+#: ../src/msw/dialup.cpp:368
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -2714,11 +2721,11 @@ msgstr ""
 "S’janë të passhëm funksione \"dial up\", ngaqë shërbimi i hyrjes në largësi "
 "(RAS) s’është i instaluar në këtë makinë. Ju lutemi, instalojeni."
 
-#: ../src/generic/tipdlg.cpp:211
+#: ../src/generic/tipdlg.cpp:208
 msgid "Did you know..."
 msgstr "E dinit se…"
 
-#: ../src/dfb/wrapdfb.cpp:63
+#: ../src/dfb/wrapdfb.cpp:60
 #, c-format
 msgid "DirectFB error %d occurred."
 msgstr "Ndodhi gabim DirectFB %d."
@@ -2727,30 +2734,30 @@ msgstr "Ndodhi gabim DirectFB %d."
 msgid "Directories"
 msgstr "Drejtori"
 
-#: ../src/common/filefn.cpp:1183
+#: ../src/common/filefn.cpp:1071
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "S’u krjiua dot drejtoria '%s'"
 
-#: ../src/common/filefn.cpp:1197
+#: ../src/common/filefn.cpp:1085
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "S’u fshi dot drejtoria '%s'"
 
-#: ../src/generic/dirdlgg.cpp:204
+#: ../src/generic/dirdlgg.cpp:201
 msgid "Directory does not exist"
 msgstr "Drejtoria s’ekziston"
 
-#: ../src/generic/filectrlg.cpp:1399
+#: ../src/generic/filectrlg.cpp:1388
 msgid "Directory doesn't exist."
 msgstr "Drejtoria s’ekziston."
 
-#: ../src/common/docview.cpp:457
+#: ../src/common/docview.cpp:450
 msgid "Discard changes and reload the last saved version?"
 msgstr ""
 "Të hidhen tej ndryshimet dhe të ringarkohet versioni i fundit i ruajtur?"
 
-#: ../src/html/helpwnd.cpp:502
+#: ../src/html/helpwnd.cpp:500
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -2758,45 +2765,45 @@ msgstr ""
 "Shfaq tërë zërat e treguesit që përmbajnë nënvargun e dhënë. Kërkim ashtu si "
 "është shkruar."
 
-#: ../src/html/helpwnd.cpp:679
+#: ../src/html/helpwnd.cpp:677
 msgid "Display options dialog"
 msgstr "Dialog mundësish paraqitjeje"
 
-#: ../src/html/helpwnd.cpp:322
+#: ../src/html/helpwnd.cpp:320
 msgid "Displays help as you browse the books on the left."
 msgstr "Shfaq ndihmën teksa shfletoni librat në të majtë."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:85
+#: ../src/common/accelcmn.cpp:83
 msgid "Divide"
 msgstr ""
 
-#: ../src/common/docview.cpp:533
+#: ../src/common/docview.cpp:526
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Doni të ruhen ndryshimet te %s?"
 
-#: ../src/common/prntbase.cpp:542
+#: ../src/common/prntbase.cpp:537
 msgid "Document:"
 msgstr "Dokument:"
 
-#: ../src/generic/aboutdlgg.cpp:73
+#: ../src/generic/aboutdlgg.cpp:70
 msgid "Documentation by "
 msgstr "Dokumentim nga "
 
-#: ../src/generic/aboutdlgg.cpp:180
+#: ../src/generic/aboutdlgg.cpp:177
 msgid "Documentation writers"
 msgstr "Shkrues dokumentimi"
 
-#: ../src/common/sizer.cpp:2799
+#: ../src/common/sizer.cpp:2916
 msgid "Don't Save"
 msgstr "Mos e Ruaj"
 
-#: ../src/html/htmlwin.cpp:633
+#: ../src/html/htmlwin.cpp:643
 msgid "Done"
 msgstr "U bë"
 
-#: ../src/generic/progdlgg.cpp:448 ../src/msw/progdlg.cpp:407
+#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
 msgid "Done."
 msgstr "U bë."
 
@@ -2808,42 +2815,42 @@ msgstr "Me pika"
 msgid "Double"
 msgstr "Dyshe"
 
-#: ../src/common/paper.cpp:176
+#: ../src/common/paper.cpp:173
 msgid "Double Japanese Postcard Rotated 148 x 200 mm"
 msgstr "Kartolinë Japoneze Dyshe e Rrotulluar 148 x 200 mm"
 
-#: ../src/common/xtixml.cpp:273
+#: ../src/common/xtixml.cpp:269
 #, c-format
 msgid "Doubly used id : %d"
 msgstr "Id i përdorur dy herë : %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:153
-#: ../src/common/accelcmn.cpp:64
+#: ../src/common/stockitem.cpp:150 ../src/common/accelcmn.cpp:61
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Down"
 msgstr "Poshtë"
 
-#: ../src/richtext/richtextctrl.cpp:865
+#: ../src/richtext/richtextctrl.cpp:864
 msgid "Drag"
 msgstr ""
 
-#: ../src/common/paper.cpp:100
+#: ../src/common/paper.cpp:97
 msgid "E sheet, 34 x 44 in"
 msgstr "Fletë E, 34 x 44 inç"
 
-#: ../src/unix/fswatcher_inotify.cpp:561
+#: ../src/unix/fswatcher_inotify.cpp:558
 msgid "EOF while reading from inotify descriptor"
 msgstr "EOF teksa lexohej prej përshkruesi inotify"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "Edit"
 msgstr "Përpunoni"
 
-#: ../src/generic/editlbox.cpp:168
+#: ../src/generic/editlbox.cpp:131
 msgid "Edit item"
 msgstr "Përpunoni objekt"
 
-#: ../include/wx/generic/progdlgg.h:84
+#: ../include/wx/generic/progdlgg.h:85
 msgid "Elapsed time:"
 msgstr "Kohë e rrjedhur:"
 
@@ -2910,62 +2917,62 @@ msgid "Enables the shadow spread."
 msgstr "Aktivizon shtrirje hijeje."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:66
+#: ../src/common/accelcmn.cpp:63
 msgid "End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:55
+#: ../src/common/accelcmn.cpp:52
 msgid "Enter"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:934
+#: ../src/richtext/richtextstyledlg.cpp:930
 msgid "Enter a box style name"
 msgstr "Jepni emër stili kuadrati"
 
-#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:602
 msgid "Enter a character style name"
 msgstr "Jepni emër stili shkronjash"
 
-#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:816
 msgid "Enter a list style name"
 msgstr "Jepni emër stili liste"
 
-#: ../src/richtext/richtextstyledlg.cpp:893
+#: ../src/richtext/richtextstyledlg.cpp:889
 msgid "Enter a new style name"
 msgstr "Jepni emër stili të ri"
 
-#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:650
 msgid "Enter a paragraph style name"
 msgstr "Jepni emër stili paragrafi"
 
-#: ../src/generic/dbgrptg.cpp:174
+#: ../src/generic/dbgrptg.cpp:171
 #, c-format
 msgid "Enter command to open file \"%s\":"
 msgstr "Jepni një urdhër për hapjen e kartelës \"%s\":"
 
-#: ../src/generic/helpext.cpp:459
+#: ../src/generic/helpext.cpp:457
 msgid "Entries found"
 msgstr "U gjetën zëra"
 
-#: ../src/common/paper.cpp:142
+#: ../src/common/paper.cpp:139
 msgid "Envelope Invite 220 x 220 mm"
 msgstr "Zarf Ftese 220 x 220 mm"
 
-#: ../src/common/config.cpp:469
+#: ../src/common/config.cpp:465
 #, c-format
 msgid ""
 "Environment variables expansion failed: missing '%c' at position %u in '%s'."
 msgstr ""
 "Dështoi zgjerimi i ndryshoreve të mjedisit: mungon '%c' në vendin %u te '%s'."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/generic/dirctrlg.cpp:570
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/dirctrlg.cpp:599
-#: ../src/generic/dirdlgg.cpp:323 ../src/generic/filectrlg.cpp:642
-#: ../src/generic/filectrlg.cpp:756 ../src/generic/filectrlg.cpp:770
-#: ../src/generic/filectrlg.cpp:786 ../src/generic/filectrlg.cpp:1368
-#: ../src/generic/filectrlg.cpp:1399 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/gtk1/fontdlg.cpp:74 ../src/generic/dirctrlg.cpp:536
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/dirctrlg.cpp:565
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1357 ../src/generic/filectrlg.cpp:1388
+#: ../src/generic/filedlgg.cpp:354 ../src/generic/dirdlgg.cpp:320
+#: ../src/gtk/filedlg.cpp:74
 msgid "Error"
 msgstr "Gabim"
 
@@ -2973,86 +2980,97 @@ msgstr "Gabim"
 msgid "Error closing epoll descriptor"
 msgstr "Gabim në mbylljen e përshkruesit epoll"
 
-#: ../src/unix/fswatcher_kqueue.cpp:114
+#: ../src/unix/fswatcher_kqueue.cpp:131
 msgid "Error closing kqueue instance"
 msgstr "Gabim në mbylljen e instancës kqueue"
 
-#: ../src/common/filefn.cpp:1049
+#: ../src/common/filefn.cpp:938
 #, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Gabim në kopjimin e kartelës '%s' te '%s'."
 
-#: ../src/generic/dirdlgg.cpp:222
+#: ../src/generic/dirdlgg.cpp:219
 msgid "Error creating directory"
 msgstr "Gabim në krijim drejtorie"
 
-#: ../src/common/imagbmp.cpp:1181
+#: ../src/common/imagbmp.cpp:1193
 msgid "Error in reading image DIB."
 msgstr "Gabim në lexim DIB figure."
 
-#: ../src/propgrid/propgrid.cpp:6696
+#: ../src/propgrid/propgrid.cpp:6665
 #, c-format
 msgid "Error in resource: %s"
 msgstr "Gabim në burimi: %s"
 
-#: ../src/common/fileconf.cpp:422
+#: ../src/common/fileconf.cpp:421
 msgid "Error reading config options."
 msgstr "Gabim në lexim mundësish formësimi."
+
+#: ../src/msw/webview_ie.cpp:1057 ../src/msw/webview_edge.cpp:850
+#: ../src/gtk/webview_webkit2.cpp:1262 ../src/osx/webview_webkit.mm:383
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
 
 #: ../src/common/fileconf.cpp:1029
 msgid "Error saving user configuration data."
 msgstr "Gabim gjatë ruajtjes së të dhënave formësimi të përdoruesit."
 
-#: ../src/gtk/print.cpp:722
+#: ../src/gtk/print.cpp:720
 msgid "Error while printing: "
 msgstr "Gabim teksa shtypej: "
 
-#: ../src/common/log.cpp:219
+#: ../src/common/log.cpp:237
 msgid "Error: "
 msgstr "Gabim: "
 
+#: ../src/common/webrequest.cpp:98
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Gabim: "
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:69
+#: ../src/common/accelcmn.cpp:66
 msgid "Esc"
 msgstr "Esc"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:70
+#: ../src/common/accelcmn.cpp:67
 msgid "Escape"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:150
+#: ../src/common/fmapbase.cpp:147
 msgid "Esperanto (ISO-8859-3)"
 msgstr "Esperanto (ISO-8859-3)"
 
-#: ../include/wx/generic/progdlgg.h:85
+#: ../include/wx/generic/progdlgg.h:86
 msgid "Estimated time:"
 msgstr "Kohë përafërsisht:"
 
-#: ../src/generic/dbgrptg.cpp:234
+#: ../src/generic/dbgrptg.cpp:231
 msgid "Executable files (*.exe)|*.exe|"
 msgstr "Kartela të ekzekutueshmish (*.exe)|*.exe|"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:155 ../src/common/accelcmn.cpp:78
+#: ../src/common/stockitem.cpp:152 ../src/common/accelcmn.cpp:75
 msgid "Execute"
 msgstr "Përmbushe"
 
-#: ../src/msw/utilsexc.cpp:876
+#: ../src/msw/utilsexc.cpp:873
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Dështoi përmbushja e urdhrit '%s'"
 
-#: ../src/common/paper.cpp:105
+#: ../src/common/paper.cpp:102
 msgid "Executive, 7 1/4 x 10 1/2 in"
 msgstr "Ekzekutive, 7 1/4 x 10 1/2 inç"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6009
+#: ../src/generic/datavgen.cpp:6814
 msgid "Expand"
 msgstr "Zgjeroje"
 
-#: ../src/msw/registry.cpp:1240
+#: ../src/msw/registry.cpp:1228
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
@@ -3060,147 +3078,157 @@ msgstr ""
 "Po eksportohet kyç regjistri: kartela \"%s\" ekziston tashmë dhe s’do të "
 "mbishkruhet."
 
-#: ../src/common/fmapbase.cpp:195
+#: ../src/common/fmapbase.cpp:192
 msgid "Extended Unix Codepage for Japanese (EUC-JP)"
 msgstr "Kodim i Zgjeruar Unix për Japonishten (EUC-JP)"
 
-#: ../src/html/chm.cpp:725
+#: ../src/html/chm.cpp:718
 #, c-format
 msgid "Extraction of '%s' into '%s' failed."
 msgstr "Dështoi përftimi i '%s' te '%s'."
 
-#: ../src/common/accelcmn.cpp:249 ../src/common/accelcmn.cpp:344
+#: ../src/common/accelcmn.cpp:259 ../src/common/accelcmn.cpp:358
 msgid "F"
 msgstr "P"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:672
+#: ../src/propgrid/advprops.cpp:582
 msgid "Face Name"
 msgstr "Emër Shkronjash"
 
-#: ../src/unix/snglinst.cpp:269
+#: ../src/unix/snglinst.cpp:266
 msgid "Failed to access lock file."
 msgstr "S’u arrit të përdorej kartelë kyçjeje."
+
+#: ../src/gtk/font.cpp:572
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "S’u arrit të lexohej dokument prej kartelës \"%s\"."
 
 #: ../src/unix/epolldispatcher.cpp:116
 #, c-format
 msgid "Failed to add descriptor %d to epoll descriptor %d"
 msgstr "S’u arrit të shtohej përshkrues %d te përshkrues epoll %d"
 
-#: ../src/msw/dib.cpp:489
+#: ../src/msw/dib.cpp:535
 #, c-format
 msgid "Failed to allocate %luKb of memory for bitmap data."
 msgstr "S’u arrit të jepeshin %luKb kujtesë për të dhëna bitmap."
 
-#: ../src/common/glcmn.cpp:115
+#: ../src/common/glcmn.cpp:112
 msgid "Failed to allocate colour for OpenGL"
 msgstr "S’u arrit të jepej ngjyrë për OpeGL"
 
-#: ../src/unix/displayx11.cpp:236
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "S’u arrit të jepej ngjyrë për OpeGL"
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "S’u arrit të jepej ngjyrë për OpeGL"
+
+#: ../include/wx/unix/private/displayx11.h:89
 msgid "Failed to change video mode"
 msgstr "S’u arrit të ndryshohej mënyrë video"
 
-#: ../src/common/image.cpp:3277
+#: ../src/common/image.cpp:3396
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "S’u arrit të kontrollohej format kartele figurash \"%s\"."
 
-#: ../src/common/debugrpt.cpp:239
+#: ../src/common/debugrpt.cpp:240
 #, c-format
 msgid "Failed to clean up debug report directory \"%s\""
 msgstr "S’u arrit të pastrohej drejtori \"%s\" raportesh diagnostikimi"
 
-#: ../src/common/filename.cpp:192
+#: ../src/common/filename.cpp:189
 msgid "Failed to close file handle"
 msgstr "S’u arrit të mbyllej trajtues kartele"
 
-#: ../src/unix/snglinst.cpp:340
+#: ../src/unix/snglinst.cpp:337
 #, c-format
 msgid "Failed to close lock file '%s'"
 msgstr "S’u arrit të mbyllej kartelë kyçjeje '%s'"
 
-#: ../src/msw/clipbrd.cpp:112
+#: ../src/msw/clipbrd.cpp:110
 msgid "Failed to close the clipboard."
 msgstr "S’u arrit të mbyllej e papastra."
 
-#: ../src/x11/utils.cpp:208
+#: ../src/x11/utils.cpp:170
 #, c-format
 msgid "Failed to close the display \"%s\""
 msgstr "S’u arrit të mbyllej ekrani '%s'"
 
-#: ../src/msw/dialup.cpp:797
+#: ../src/msw/dialup.cpp:791
 msgid "Failed to connect: missing username/password."
 msgstr "S’u arrit të lidhej: mungon emër përdoruesi/fjalëkalim."
 
-#: ../src/msw/dialup.cpp:743
+#: ../src/msw/dialup.cpp:737
 msgid "Failed to connect: no ISP to dial."
 msgstr "S’u arrit të lidhej: pa ISP për thirrje."
 
-#: ../src/common/textfile.cpp:203
-#, c-format
-msgid "Failed to convert file \"%s\" to Unicode."
-msgstr "S’u arrit të shndërrohej kartela \"%s\" në Unikod."
-
-#: ../src/generic/logg.cpp:956
+#: ../src/generic/logg.cpp:953
 msgid "Failed to copy dialog contents to the clipboard."
 msgstr "S’u arrit të kopjohej në të papastër lënda e dialogut."
 
-#: ../src/msw/registry.cpp:692
+#: ../src/msw/registry.cpp:681
 #, c-format
 msgid "Failed to copy registry value '%s'"
 msgstr "S’u arrit të kopjohej vlerë regjistri '%s'"
 
-#: ../src/msw/registry.cpp:701
+#: ../src/msw/registry.cpp:690
 #, c-format
 msgid "Failed to copy the contents of registry key '%s' to '%s'."
 msgstr "S’u arrit të kopjohej lënda e kyçit të regjistrit '%s' te '%s'."
 
-#: ../src/common/filefn.cpp:1015
+#: ../src/common/filefn.cpp:904
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "S’u arrit të kopjohej kartela '%s' te '%s'"
 
-#: ../src/msw/registry.cpp:679
+#: ../src/msw/registry.cpp:668
 #, c-format
 msgid "Failed to copy the registry subkey '%s' to '%s'."
 msgstr "S’u arrit të kopjohej nënkyçi i regjistrit '%s' si '%s'."
 
-#: ../src/msw/dde.cpp:1070
+#: ../src/msw/dde.cpp:1134
 msgid "Failed to create DDE string"
 msgstr "S’u arrit të krijohej varg DDE"
 
-#: ../src/msw/mdi.cpp:616
+#: ../src/msw/mdi.cpp:621
 msgid "Failed to create MDI parent frame."
 msgstr "S’u arrit të krijohej kornizë mëmë MDI."
 
-#: ../src/common/filename.cpp:1027
+#: ../src/common/filename.cpp:1024
 msgid "Failed to create a temporary file name"
 msgstr "S’u arrit të krijohej emër kartele të përkohshme"
 
-#: ../src/msw/utilsexc.cpp:228
+#: ../src/msw/utilsexc.cpp:225
 msgid "Failed to create an anonymous pipe"
 msgstr "S’u arrit të krijohej kanal i paemër"
 
-#: ../src/msw/ole/automtn.cpp:522
+#: ../src/msw/ole/automtn.cpp:513
 #, c-format
 msgid "Failed to create an instance of \"%s\""
 msgstr "S’u arrit të krijohej një instancë e \"%s\""
 
-#: ../src/msw/dde.cpp:437
+#: ../src/msw/dde.cpp:432
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "S’u arrit të krijohej lidhje te shërbyes '%s' mbi temën '%s'"
 
-#: ../src/msw/cursor.cpp:204
+#: ../src/msw/cursor.cpp:195
 msgid "Failed to create cursor."
 msgstr "S’u arrit të krijohej kursor."
 
-#: ../src/common/debugrpt.cpp:209
+#: ../src/common/debugrpt.cpp:210
 #, c-format
 msgid "Failed to create directory \"%s\""
 msgstr "S’u arrit të krijohej drejtori \"%s\""
 
-#: ../src/generic/dirdlgg.cpp:220
+#: ../src/generic/dirdlgg.cpp:217
 #, c-format
 msgid ""
 "Failed to create directory '%s'\n"
@@ -3213,114 +3241,133 @@ msgstr ""
 msgid "Failed to create epoll descriptor"
 msgstr "S’u arrit të krijohej përshkrues epoll"
 
-#: ../src/msw/mimetype.cpp:238
+#: ../src/gtk/font.cpp:562
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "S’u arrit të përditësohej kartelë përdoruesi për formësimin."
+
+#: ../src/msw/mimetype.cpp:235
 #, c-format
 msgid "Failed to create registry entry for '%s' files."
 msgstr "S’u arrit të krijohej zë regjistri për kartela '%s'."
 
-#: ../src/msw/fdrepdlg.cpp:409
+#: ../src/msw/fdrepdlg.cpp:408
 #, c-format
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr "S’u arrit të krijohej dialogu standard gjej/zëvendëso (kod gabimi %d)"
 
-#: ../src/unix/wakeuppipe.cpp:52
+#: ../src/unix/wakeuppipe.cpp:49
 msgid "Failed to create wake up pipe used by event loop."
 msgstr "S’u arrit të krijohej kanal zgjimi nga qerthull akti."
 
-#: ../src/html/winpars.cpp:730
+#: ../src/html/winpars.cpp:727
 #, c-format
 msgid "Failed to display HTML document in %s encoding"
 msgstr "S’u arrit të shfaqej dokument HTML në kodimin %s"
 
-#: ../src/msw/clipbrd.cpp:124
+#: ../src/msw/clipbrd.cpp:122
 msgid "Failed to empty the clipboard."
 msgstr "S’u arrit të zbrazej e papastra."
 
-#: ../src/unix/displayx11.cpp:212
+#: ../include/wx/unix/private/displayx11.h:65
 msgid "Failed to enumerate video modes"
 msgstr "S’u arrit të numërtohen mënyra video"
 
-#: ../src/msw/dde.cpp:722
+#: ../src/msw/dde.cpp:717
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "S’u arrit të vendosej një qerthull këshillimi me shërbyesin DDE"
 
-#: ../src/msw/dialup.cpp:629 ../src/msw/dialup.cpp:863
+#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "S’u arrit të vendosej lidhjeje \"dialup\": %s"
 
-#: ../src/unix/utilsunx.cpp:611
+#: ../src/unix/utilsunx.cpp:613
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "S’u arrit të përmbushej '%s'\n"
 
-#: ../src/common/debugrpt.cpp:720
+#: ../src/common/debugrpt.cpp:730
 msgid "Failed to execute curl, please install it in PATH."
 msgstr "S’u arrit të përmbushej curl-i, ju lutemi, instalojeni në PATH."
 
-#: ../src/msw/ole/automtn.cpp:505
+#: ../src/msw/ole/automtn.cpp:496
 #, c-format
 msgid "Failed to find CLSID of \"%s\""
 msgstr "S’u arrit të gjendet CLSID e \"%s\""
 
-#: ../src/common/regex.cpp:431 ../src/common/regex.cpp:479
+#: ../src/common/regex.cpp:428 ../src/common/regex.cpp:476
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "S’u arrit të gjendej përputhje për shprehje të rregullt: %s"
 
-#: ../src/msw/dialup.cpp:695
+#: ../src/msw/webview_ie.cpp:978
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:689
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "S’u arrit të merreshin emra ISP-sh: %s"
 
-#: ../src/msw/ole/automtn.cpp:574
+#: ../src/msw/ole/automtn.cpp:565
 #, c-format
 msgid "Failed to get OLE automation interface for \"%s\""
 msgstr "S’u arrit të merrej ndërfaqe automatizimi OLE për \"%s\""
 
-#: ../src/msw/clipbrd.cpp:711
+#: ../src/msw/clipbrd.cpp:731
 msgid "Failed to get data from the clipboard"
 msgstr "S’u arrit të merren të dhëna nga e papastra"
 
-#: ../src/common/time.cpp:223
+#: ../src/common/time.cpp:216
 msgid "Failed to get the local system time"
 msgstr "S’u arrit të merret koha vendore e sistemit"
 
-#: ../src/common/filefn.cpp:1345
+#: ../src/common/filefn.cpp:1233
 msgid "Failed to get the working directory"
 msgstr "S’u arrit të merrej drejtoria e punës"
 
-#: ../src/univ/theme.cpp:114
+#: ../src/univ/theme.cpp:111
 msgid "Failed to initialize GUI: no built-in themes found."
 msgstr "S’u arrit të gatitej GUI: s’u gjetën tema të brendshme."
 
-#: ../src/msw/helpchm.cpp:63
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:60
 msgid "Failed to initialize MS HTML Help."
 msgstr "S’u arrit të gatitej Ndihmë MS HTML."
 
-#: ../src/msw/glcanvas.cpp:1381
+#: ../src/msw/glcanvas.cpp:1391
 msgid "Failed to initialize OpenGL"
 msgstr "S’u arrit të gatitej OpeGL-i"
 
-#: ../src/msw/dialup.cpp:858
+#: ../src/msw/dialup.cpp:852
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "S’u arrit të nisej lidhje \"dialup\": %s"
 
-#: ../src/gtk/textctrl.cpp:1128
+#: ../src/gtk/textctrl.cpp:1209
 msgid "Failed to insert text in the control."
 msgstr "S’u arrit të futej tekst te kontrolli."
 
-#: ../src/unix/snglinst.cpp:241
+#: ../src/unix/snglinst.cpp:238
 #, c-format
 msgid "Failed to inspect the lock file '%s'"
 msgstr "S’u arrit të inspektohej kartela e kyçjes '%s'"
 
-#: ../src/unix/appunix.cpp:182
+#: ../src/unix/appunix.cpp:179
 msgid "Failed to install signal handler"
 msgstr "S’u arrit të instalohej trajtues sinjali"
 
-#: ../src/unix/threadpsx.cpp:1167
+#: ../src/unix/threadpsx.cpp:1216
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -3328,71 +3375,71 @@ msgstr ""
 "S’u arrit të merrej pjesë në një rrjedhë, u zbulua rrjedhje potenciale "
 "kujtese - ju lutemi, rinisni programin"
 
-#: ../src/msw/utils.cpp:629
+#: ../src/msw/utils.cpp:619
 #, c-format
 msgid "Failed to kill process %d"
 msgstr "S’u arrit të asgjësohej procesi %d"
 
-#: ../src/common/image.cpp:2500
+#: ../src/common/image.cpp:2595
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "S’u arrit të ngarkohej bitmap \"%s\" prej burimesh."
 
-#: ../src/common/image.cpp:2509
+#: ../src/common/image.cpp:2604
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "S’u arrit të ngarkohej ikonë \"%s\" prej burimesh."
 
-#: ../src/common/iconbndl.cpp:225
+#: ../src/common/iconbndl.cpp:224
 #, c-format
 msgid "Failed to load icons from resource '%s'."
 msgstr "S’u arrit të shtohen ikona prej burimi '%s'."
 
-#: ../src/common/iconbndl.cpp:200
+#: ../src/common/iconbndl.cpp:198
 #, c-format
 msgid "Failed to load image %%d from file '%s'."
 msgstr "S’u arrit të ngarkohej figurë %%d prej kartelës \"%s\"."
 
-#: ../src/common/iconbndl.cpp:208
+#: ../src/common/iconbndl.cpp:206
 #, c-format
 msgid "Failed to load image %d from stream."
 msgstr "S’u arrit të ngarkohej figurë %d prej rrjedhe."
 
-#: ../src/common/image.cpp:2587 ../src/common/image.cpp:2606
+#: ../src/common/image.cpp:2682 ../src/common/image.cpp:2701
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "S’u arrit të ngarkohej figurë prej kartelës \"%s\"."
 
-#: ../src/msw/enhmeta.cpp:97
+#: ../src/msw/enhmeta.cpp:94
 #, c-format
 msgid "Failed to load metafile from file \"%s\"."
 msgstr "S’u arrit të ngarkohej metafile prej kartelës \"%s\"."
 
-#: ../src/msw/volume.cpp:327
+#: ../src/msw/volume.cpp:335
 msgid "Failed to load mpr.dll."
 msgstr "S’u arrit të ngarkohej mpr.dll."
 
-#: ../src/msw/utils.cpp:953
+#: ../src/msw/utils.cpp:943
 #, c-format
 msgid "Failed to load resource \"%s\"."
 msgstr "S’u arrit të ngarkohej burimi \"%s\"."
 
-#: ../src/common/dynlib.cpp:92
+#: ../src/common/dynlib.cpp:86
 #, c-format
 msgid "Failed to load shared library '%s'"
 msgstr "S’u arrit të ngarkohej librari e përbashkët '%s'"
 
-#: ../src/osx/core/sound.cpp:145
+#: ../src/osx/core/sound.cpp:143
 #, c-format
 msgid "Failed to load sound from \"%s\" (error %d)."
 msgstr "S’u arrit të ngarkohej tingull prej \"%s\" (gabim %d)."
 
-#: ../src/msw/utils.cpp:960
+#: ../src/msw/utils.cpp:950
 #, c-format
 msgid "Failed to lock resource \"%s\"."
 msgstr "S’u arrit të kyçej burimi \"%s\"."
 
-#: ../src/unix/snglinst.cpp:198
+#: ../src/unix/snglinst.cpp:195
 #, c-format
 msgid "Failed to lock the lock file '%s'"
 msgstr "S’u arrit të kyçej kartelë kyçjeje '%s'"
@@ -3402,33 +3449,38 @@ msgstr "S’u arrit të kyçej kartelë kyçjeje '%s'"
 msgid "Failed to modify descriptor %d in epoll descriptor %d"
 msgstr "S’u arrit të modifikohej përshkrues %d te përshkrues epoll %d"
 
-#: ../src/common/filename.cpp:2575
+#: ../src/common/filename.cpp:2658
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "S’u arrit të ndryshoheshin kohë kartele për '%s'"
 
-#: ../src/common/selectdispatcher.cpp:258
+#: ../src/common/selectdispatcher.cpp:255
 msgid "Failed to monitor I/O channels"
 msgstr "S’u arrit të mbikëqyren kanale I/O"
 
-#: ../src/common/filename.cpp:175
+#: ../src/common/filename.cpp:172
 #, c-format
 msgid "Failed to open '%s' for reading"
 msgstr "S’u arrit të hapej '%s' për lexim"
 
-#: ../src/common/filename.cpp:180
+#: ../src/common/filename.cpp:177
 #, c-format
 msgid "Failed to open '%s' for writing"
 msgstr "S’u arrit të hapej '%s' për shkrim"
 
-#: ../src/html/chm.cpp:141
+#: ../src/html/chm.cpp:138
 #, c-format
 msgid "Failed to open CHM archive '%s'."
 msgstr "S’u arrit të hapej arkiv CHM '%s'."
 
-#: ../src/common/utilscmn.cpp:1126
+#: ../src/common/utilscmn.cpp:1140
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
+msgstr "S’u arrit të hapej URL-ja \"%s\" në shfletuesin parazgjedhje."
+
+#: ../src/common/hyperlnkcmn.cpp:133
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "S’u arrit të hapej URL-ja \"%s\" në shfletuesin parazgjedhje."
 
 #: ../include/wx/msw/private/fswatcher.h:92
@@ -3436,93 +3488,103 @@ msgstr "S’u arrit të hapej URL-ja \"%s\" në shfletuesin parazgjedhje."
 msgid "Failed to open directory \"%s\" for monitoring."
 msgstr "S’u arrit të hapej drejtoria \"%s\" për mbikëqyrje."
 
-#: ../src/x11/utils.cpp:227
+#: ../src/x11/utils.cpp:189
 #, c-format
 msgid "Failed to open display \"%s\"."
 msgstr "S’u arrit të hapej ekrani \"%s\"."
 
-#: ../src/common/filename.cpp:1062
+#: ../src/common/filename.cpp:1059
 msgid "Failed to open temporary file."
 msgstr "S’u arrit të hapej kartelë e përkohshme."
 
-#: ../src/msw/clipbrd.cpp:91
+#: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "S’u arrit të hapej e papastra."
 
-#: ../src/common/translation.cpp:1184
+#: ../src/common/translation.cpp:1226
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "S’u arrit të përtypeshin Plural-Forms: '%s'"
 
-#: ../src/unix/mediactrl.cpp:1214
+#: ../src/unix/mediactrl.cpp:1239
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "S’u arrit të përgatitej për luajtje \"%s\"."
 
-#: ../src/msw/clipbrd.cpp:600
+#: ../src/msw/clipbrd.cpp:610
 msgid "Failed to put data on the clipboard"
 msgstr "S’u arrit të hidheshin të dhëna në të papastër"
 
-#: ../src/unix/snglinst.cpp:278
+#: ../src/unix/snglinst.cpp:275
 msgid "Failed to read PID from lock file."
 msgstr "S’u arrit të lexohej PID prej kartele kyçjeje."
 
-#: ../src/common/fileconf.cpp:433
+#: ../src/common/fileconf.cpp:432
 msgid "Failed to read config options."
 msgstr "S’u arrit të lexoheshin mundësi formësimi."
 
-#: ../src/common/docview.cpp:681
+#: ../src/common/docview.cpp:676
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "S’u arrit të lexohej dokument prej kartelës \"%s\"."
 
-#: ../src/dfb/evtloop.cpp:98
+#: ../src/dfb/evtloop.cpp:99
 msgid "Failed to read event from DirectFB pipe"
 msgstr "S’u arrit të lexohej akt prej kanali DirectFB"
 
-#: ../src/unix/wakeuppipe.cpp:120
+#: ../src/unix/wakeuppipe.cpp:117
 msgid "Failed to read from wake-up pipe"
 msgstr "S’u arrit të lexohej prej kanali zgjimi"
 
-#: ../src/unix/utilsunx.cpp:679
+#: ../src/common/textfile.cpp:96
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "S’u arrit të lexohej dokument prej kartelës \"%s\"."
+
+#: ../src/unix/utilsunx.cpp:681
 msgid "Failed to redirect child process input/output"
 msgstr "S’u arrit të ridrejtohej input/output procesi pjellë"
 
-#: ../src/msw/utilsexc.cpp:701
+#: ../src/msw/utilsexc.cpp:698
 msgid "Failed to redirect the child process IO"
 msgstr "S’u arrit të ridrejtohej IO procesi pjellë"
 
-#: ../src/msw/dde.cpp:288
+#: ../src/msw/dde.cpp:283
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "S’u arrit të regjistrohej shërbyesi DDE '%s'"
 
-#: ../src/common/fontmap.cpp:245
+#: ../src/gtk/font.cpp:580
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "S’u arrit të përditësohej kartelë përdoruesi për formësimin."
+
+#: ../src/common/fontmap.cpp:242
 #, c-format
 msgid "Failed to remember the encoding for the charset '%s'."
 msgstr "S’u arrit të mbahej mend kodimi për shkronjat '%s'."
 
-#: ../src/common/debugrpt.cpp:227
+#: ../src/common/debugrpt.cpp:228
 #, c-format
 msgid "Failed to remove debug report file \"%s\""
 msgstr "S’u arrit të hiqej kartela raporti diagnostikimi \"%s\""
 
-#: ../src/unix/snglinst.cpp:328
+#: ../src/unix/snglinst.cpp:325
 #, c-format
 msgid "Failed to remove lock file '%s'"
 msgstr "S’u arrit të hiqej kartelë kyçjeje '%s'"
 
-#: ../src/unix/snglinst.cpp:288
+#: ../src/unix/snglinst.cpp:285
 #, c-format
 msgid "Failed to remove stale lock file '%s'."
 msgstr "S’u arrit të hiqej kartelë e ndenjur kyçjeje '%s'."
 
-#: ../src/msw/registry.cpp:529
+#: ../src/msw/registry.cpp:518
 #, c-format
 msgid "Failed to rename registry value '%s' to '%s'."
 msgstr "S’u arrit të riemërtohej vlerë regjistri '%s' si '%s'."
 
-#: ../src/common/filefn.cpp:1122
+#: ../src/common/filefn.cpp:1011
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -3531,115 +3593,124 @@ msgstr ""
 "S’u arrit të riemërtohej kartela '%s' si '%s', ngaqë kartela vendmbërritje "
 "ekziston tashmë."
 
-#: ../src/msw/registry.cpp:634
+#: ../src/msw/registry.cpp:623
 #, c-format
 msgid "Failed to rename the registry key '%s' to '%s'."
 msgstr "S’u arrit të riemërtohej kyç regjistri '%s' si '%s'."
 
-#: ../src/common/filename.cpp:2671
+#: ../src/msw/webview_ie.cpp:995
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/common/filename.cpp:2754
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "S’u arrit të merreshin kohë kartele për '%s'"
 
-#: ../src/msw/dialup.cpp:468
+#: ../src/msw/dialup.cpp:462
 msgid "Failed to retrieve text of RAS error message"
 msgstr "S’u arrit të merrej tekst mesazhi gabimi RAS"
 
-#: ../src/msw/clipbrd.cpp:748
+#: ../src/msw/clipbrd.cpp:768
 msgid "Failed to retrieve the supported clipboard formats"
 msgstr "S’u arrit të merreshin formate të mbuluar për të papastrën"
 
-#: ../src/common/docview.cpp:652
+#: ../src/common/docview.cpp:647
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "S’u arrit të ruhej dokument te kartela \"%s\"."
 
-#: ../src/msw/dib.cpp:269
+#: ../src/msw/dib.cpp:312
 #, c-format
 msgid "Failed to save the bitmap image to file \"%s\"."
 msgstr "S’u arrit të ruhej figurë bitmap te kartela \"%s\"."
 
-#: ../src/msw/dde.cpp:763
+#: ../src/msw/dde.cpp:811
 msgid "Failed to send DDE advise notification"
 msgstr "S’u arrit të dërgohej njoftim këshillues DDE"
 
-#: ../src/common/ftp.cpp:402
+#: ../src/common/ftp.cpp:399
 #, c-format
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "S’u arrit të caktohej mënyrë shpërnguljesh FTP si %s."
 
-#: ../src/msw/clipbrd.cpp:427
+#: ../src/msw/clipbrd.cpp:443
 msgid "Failed to set clipboard data."
 msgstr "S’u arrit të caktoheshin të dhëna të papastre."
 
-#: ../src/unix/snglinst.cpp:181
+#: ../src/unix/snglinst.cpp:178
 #, c-format
 msgid "Failed to set permissions on lock file '%s'"
 msgstr "S’u arrit të caktohen leje mbi kartelë kyçjeje '%s'"
 
-#: ../src/unix/utilsunx.cpp:668
+#: ../src/unix/utilsunx.cpp:670
 msgid "Failed to set process priority"
 msgstr "S’u arrit të caktohej përparësi procesi"
 
-#: ../src/common/file.cpp:559
+#: ../src/common/ffile.cpp:355 ../src/common/file.cpp:586
 msgid "Failed to set temporary file permissions"
 msgstr "S’u arrit të caktohen leje kartele të përkohshme"
 
-#: ../src/gtk/textctrl.cpp:1072
-msgid "Failed to set text in the text control."
-msgstr "S’u arrit të caktohej tekst te kontrolli i tekstit."
-
-#: ../src/unix/threadpsx.cpp:1298
+#: ../src/unix/threadpsx.cpp:1347
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1424
+#: ../src/unix/threadpsx.cpp:1473
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "S’u arrit të caktohej përparësie rrjedhe %d."
 
-#: ../src/unix/utilsunx.cpp:783
+#: ../src/unix/utilsunx.cpp:785
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr "S’u arrit të ujdisej kanal jobllokues, programi mund të ngecë."
 
-#: ../src/common/fs_mem.cpp:261
+#: ../src/msw/webview_ie.cpp:987
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:256
 #, c-format
 msgid "Failed to store image '%s' to memory VFS!"
 msgstr "S’u arrit të depozitohej figura '%s' te kujtesë VFS!"
 
-#: ../src/dfb/evtloop.cpp:170
+#: ../src/dfb/evtloop.cpp:171
 msgid "Failed to switch DirectFB pipe to non-blocking mode"
 msgstr "S’u arrit të kalohej kanali DirectFB në mënyrën jobllokuese"
 
-#: ../src/unix/wakeuppipe.cpp:59
+#: ../src/unix/wakeuppipe.cpp:56
 msgid "Failed to switch wake up pipe to non-blocking mode"
 msgstr "S’u arrit të kalohej kanal zgjimi në mënyrën jobllokuese"
 
-#: ../src/unix/threadpsx.cpp:1605
+#: ../src/unix/threadpsx.cpp:1654
 msgid "Failed to terminate a thread."
 msgstr "S’u arrit të përfundohej një rrjedhë."
 
-#: ../src/msw/dde.cpp:741
+#: ../src/msw/dde.cpp:736
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "S’u arrit të përfundohej qerthull këshillimi me shërbyesin DDE"
 
-#: ../src/msw/dialup.cpp:938
+#: ../src/msw/dialup.cpp:932
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "S’u arrit të ndërpritej lidhja \"dialup\": %s"
 
-#: ../src/common/filename.cpp:2590
+#: ../src/common/filename.cpp:2673
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "S’u arrit të kryhej \"touch\" për kartelën '%s'"
 
-#: ../src/unix/snglinst.cpp:334
+#: ../src/unix/dlunix.cpp:90
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "S’u arrit të ngarkohej librari e përbashkët '%s'"
+
+#: ../src/unix/snglinst.cpp:331
 #, c-format
 msgid "Failed to unlock lock file '%s'"
 msgstr "S’u arrit të shkyçej kartelë kyçje '%s'"
 
-#: ../src/msw/dde.cpp:309
+#: ../src/msw/dde.cpp:304
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "S’u arrit të çregjistrohej shërbyesi DDE '%s'"
@@ -3653,77 +3724,87 @@ msgstr "S’u arrit të çregjistrohej përshkrues %d prej përshkruesi epoll %d
 msgid "Failed to update user configuration file."
 msgstr "S’u arrit të përditësohej kartelë përdoruesi për formësimin."
 
-#: ../src/common/debugrpt.cpp:733
+#: ../src/common/debugrpt.cpp:743
 #, c-format
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "S’u arrit të ngarkohej raporti i diagnostikimit (kod gabimi %d)."
 
-#: ../src/unix/snglinst.cpp:168
+#: ../src/unix/snglinst.cpp:165
 #, c-format
 msgid "Failed to write to lock file '%s'"
 msgstr "S’u arrit të shkruhej kartelë kyçjeje '%s'"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:209
+#: ../src/propgrid/propgrid.cpp:190
 msgid "False"
 msgstr ""
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:694
+#: ../src/propgrid/advprops.cpp:604
 msgid "Family"
 msgstr "Familje"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/gtk/glcanvas.cpp:176 ../src/gtk/glcanvas.cpp:187
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Gabim kartele"
+
+#: ../src/common/stockitem.cpp:154
 msgid "File"
 msgstr "Kartelë"
 
-#: ../src/common/docview.cpp:669
+#: ../src/common/docview.cpp:664
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Kartela \"%s\" s’u hap dot për lexim."
 
-#: ../src/common/docview.cpp:646
+#: ../src/common/docview.cpp:641
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Kartela \"%s\" s’u hap dot për shkrim."
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "Ka tashmë një kartelë %s, doni vërtet të mbishkruhet?"
 
-#: ../src/common/filefn.cpp:1156
+#: ../src/common/filefn.cpp:1044
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "S’u hoq dot kartela '%s'"
 
-#: ../src/common/filefn.cpp:1139
+#: ../src/common/filefn.cpp:1028
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Kartela '%s' s’u riemërtua dot si '%s'"
 
-#: ../src/richtext/richtextctrl.cpp:3081 ../src/common/textcmn.cpp:953
+#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
 msgid "File couldn't be loaded."
 msgstr "Kartela s’u ngarkua dot."
 
-#: ../src/msw/filedlg.cpp:393
+#: ../src/msw/filedlg.cpp:414
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Dialogu i kartelës dështoi me kod gabimi %0lx."
 
-#: ../src/common/docview.cpp:1789
+#: ../src/common/docview.cpp:1783
 msgid "File error"
 msgstr "Gabim kartele"
 
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/filectrlg.cpp:770
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/filectrlg.cpp:766
 msgid "File name exists already."
 msgstr "Ka një emër të tillë kartele."
+
+#: ../src/osx/cocoa/filedlg.mm:264
+#, fuzzy
+msgid "File type:"
+msgstr "Teleshkrim"
 
 #: ../src/motif/filedlg.cpp:220
 msgid "Files"
 msgstr "Kartela"
 
-#: ../src/common/filefn.cpp:1591
+#: ../src/common/filefn.cpp:1479
 #, c-format
 msgid "Files (%s)"
 msgstr "Kartela (%s)"
@@ -3732,15 +3813,29 @@ msgstr "Kartela (%s)"
 msgid "Filter"
 msgstr "Filtër"
 
-#: ../src/common/stockitem.cpp:158 ../src/html/helpwnd.cpp:490
+#: ../src/html/helpwnd.cpp:488
 msgid "Find"
 msgstr "Gjej"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:259
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:258
+#, fuzzy
+msgid "Find in document"
+msgstr "Hap dokument HTML"
+
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "Find..."
+msgstr "Gjej"
+
+#: ../src/common/stockitem.cpp:156
 msgid "First"
 msgstr "E para"
 
-#: ../src/common/prntbase.cpp:1548
+#: ../src/common/prntbase.cpp:1573
 msgid "First page"
 msgstr "Faqja e parë"
 
@@ -3748,11 +3843,11 @@ msgstr "Faqja e parë"
 msgid "Fixed"
 msgstr "E fiksuar"
 
-#: ../src/html/helpwnd.cpp:1206
+#: ../src/html/helpwnd.cpp:1204
 msgid "Fixed font:"
 msgstr "Shkronja të fiksuara:"
 
-#: ../src/html/helpwnd.cpp:1269
+#: ../src/html/helpwnd.cpp:1267
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr ""
 "Shkronja me madhësi të fiksuar.<br> <b>të trasha</b> <i>të pjerrëta</i> "
@@ -3761,16 +3856,16 @@ msgstr ""
 msgid "Floating"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "Floppy"
 msgstr "Disketë"
 
-#: ../src/common/paper.cpp:111
+#: ../src/common/paper.cpp:108
 msgid "Folio, 8 1/2 x 13 in"
 msgstr "Folio, 8 1/2 x 13 inç"
 
-#: ../src/richtext/richtextformatdlg.cpp:344 ../src/osx/carbon/fontdlg.cpp:287
-#: ../src/common/stockitem.cpp:194
+#: ../src/osx/carbon/fontdlg.cpp:284 ../src/common/stockitem.cpp:191
+#: ../src/richtext/richtextformatdlg.cpp:337
 msgid "Font"
 msgstr "Shkronja"
 
@@ -3778,7 +3873,24 @@ msgstr "Shkronja"
 msgid "Font &weight:"
 msgstr "&Madhësi shkronjash:"
 
-#: ../src/html/helpwnd.cpp:1207
+#: ../src/osx/fontutil.cpp:89
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
+"\"."
+msgstr ""
+
+#: ../src/msw/font.cpp:1126
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Kartela s’u ngarkua dot."
+
+#: ../src/osx/fontutil.cpp:81
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr ": kartela nuk ekziston!"
+
+#: ../src/html/helpwnd.cpp:1205
 msgid "Font size:"
 msgstr "Madhësi shkronjash:"
 
@@ -3786,53 +3898,53 @@ msgstr "Madhësi shkronjash:"
 msgid "Font st&yle:"
 msgstr "&Stil shkronjash:"
 
-#: ../src/osx/carbon/fontdlg.cpp:329
+#: ../src/osx/carbon/fontdlg.cpp:326
 msgid "Font:"
 msgstr "Shkronja:"
 
-#: ../src/dfb/fontmgr.cpp:198
+#: ../src/dfb/fontmgr.cpp:195
 #, c-format
 msgid "Fonts index file %s disappeared while loading fonts."
 msgstr "Kartela tregues shkronjash %s u zhduk teksa ngarkoheshin shkronjat."
 
-#: ../src/unix/utilsunx.cpp:645
+#: ../src/unix/utilsunx.cpp:647
 msgid "Fork failed"
 msgstr "Degëzimi dështoi"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "Forward"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:235
+#: ../src/common/xtixml.cpp:231
 msgid "Forward hrefs are not supported"
 msgstr "Nuk mbulohen href-e përcjeIlëse"
 
-#: ../src/html/helpwnd.cpp:875
+#: ../src/html/helpwnd.cpp:873
 #, c-format
 msgid "Found %i matches"
 msgstr "U gjetën %i përputhje"
 
-#: ../src/generic/prntdlgg.cpp:238
+#: ../src/generic/prntdlgg.cpp:231
 msgid "From:"
 msgstr "Prej:"
 
-#: ../src/propgrid/advprops.cpp:1604
+#: ../src/propgrid/advprops.cpp:1510
 msgid "Fuchsia"
 msgstr "Fuksia"
 
-#: ../src/common/imaggif.cpp:138
+#: ../src/common/imaggif.cpp:135
 msgid "GIF: data stream seems to be truncated."
 msgstr "GIF: rrjedha e të dhënave duket se është e cunguar."
 
-#: ../src/common/imaggif.cpp:128
+#: ../src/common/imaggif.cpp:125
 msgid "GIF: error in GIF image format."
 msgstr "GIF: gabim në format figurash GIF."
 
-#: ../src/common/imaggif.cpp:133
+#: ../src/common/imaggif.cpp:130
 msgid "GIF: not enough memory."
 msgstr "GIF: kujtesë e pamjaftueshme."
 
-#: ../src/gtk/window.cpp:4631
+#: ../src/gtk/window.cpp:5635
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -3840,23 +3952,23 @@ msgstr ""
 "GTK+ i instaluar në këtë makinë është shumë i vjetër për të mbuluar hartim "
 "skenash, ju lutemi, instaloni GTK+ 2.12 ose të mëvonshëm."
 
-#: ../src/univ/themes/gtk.cpp:525
+#: ../src/univ/themes/gtk.cpp:522
 msgid "GTK+ theme"
 msgstr "Temë GTK+"
 
-#: ../src/common/preferencescmn.cpp:40
+#: ../src/common/preferencescmn.cpp:37
 msgid "General"
 msgstr "Të përgjithshme"
 
-#: ../src/common/prntbase.cpp:258
+#: ../src/common/prntbase.cpp:253
 msgid "Generic PostScript"
 msgstr "PostScript Bazë"
 
-#: ../src/common/paper.cpp:135
+#: ../src/common/paper.cpp:132
 msgid "German Legal Fanfold, 8 1/2 x 13 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:134
+#: ../src/common/paper.cpp:131
 msgid "German Std Fanfold, 8 1/2 x 12 in"
 msgstr ""
 
@@ -3872,48 +3984,48 @@ msgstr ""
 msgid "GetPropertyCollection called w/o valid collection getter"
 msgstr "GetPropertyCollection u thirr pa marrës të vlefshëm përmbledhjeje"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:658
 msgid "Go back"
 msgstr "Shko prapa"
 
-#: ../src/html/helpwnd.cpp:661
+#: ../src/html/helpwnd.cpp:659
 msgid "Go forward"
 msgstr "Shko përpara"
 
-#: ../src/html/helpwnd.cpp:663
+#: ../src/html/helpwnd.cpp:661
 msgid "Go one level up in document hierarchy"
 msgstr "Shko një shkallë më sipër në hierarki dokumenti"
 
-#: ../src/generic/filedlgg.cpp:208 ../src/generic/dirdlgg.cpp:116
+#: ../src/generic/filedlgg.cpp:205 ../src/generic/dirdlgg.cpp:113
 msgid "Go to home directory"
 msgstr "Shko te drejtoria krye"
 
-#: ../src/generic/filedlgg.cpp:205
+#: ../src/generic/filedlgg.cpp:202
 msgid "Go to parent directory"
 msgstr "Shko te drejtoria mëmë"
 
-#: ../src/generic/aboutdlgg.cpp:76
+#: ../src/generic/aboutdlgg.cpp:73
 msgid "Graphics art by "
 msgstr "Art grafik nga "
 
-#: ../src/propgrid/advprops.cpp:1599
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Gray"
 msgstr "Gri"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:883
+#: ../src/propgrid/advprops.cpp:784
 msgid "GrayText"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:154
+#: ../src/common/fmapbase.cpp:151
 msgid "Greek (ISO-8859-7)"
 msgstr "Greke (ISO-8859-7)"
 
-#: ../src/propgrid/advprops.cpp:1600
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Green"
 msgstr "E gjelbër"
 
-#: ../src/generic/colrdlgg.cpp:342
+#: ../src/generic/colrdlgg.cpp:362
 msgid "Green:"
 msgstr "E gjelbër:"
 
@@ -3921,107 +4033,107 @@ msgstr "E gjelbër:"
 msgid "Groove"
 msgstr ""
 
-#: ../src/common/zstream.cpp:158 ../src/common/zstream.cpp:318
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
 msgid "Gzip not supported by this version of zlib"
 msgstr "Gzip-i s’mbulohet nga ky version i zlib-it"
 
-#: ../src/html/helpwnd.cpp:1549
+#: ../src/html/helpwnd.cpp:1547
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "Projekt Ndihme HTML (*.hhp)|*.hhp|"
 
-#: ../src/html/htmlwin.cpp:681
+#: ../src/html/htmlwin.cpp:691
 #, c-format
 msgid "HTML anchor %s does not exist."
 msgstr "Spiranca HTML %s s’ekziston."
 
-#: ../src/html/helpwnd.cpp:1547
+#: ../src/html/helpwnd.cpp:1545
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "Kartela HTML (*.html;*.htm)|*.html;*.htm|"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1759
+#: ../src/propgrid/advprops.cpp:1660
 msgid "Hand"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "Harddisk"
 msgstr "HD"
 
-#: ../src/common/fmapbase.cpp:155
+#: ../src/common/fmapbase.cpp:152
 msgid "Hebrew (ISO-8859-8)"
 msgstr "Hebraishte, (ISO-8859-8)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:280 ../src/osx/button_osx.cpp:39
-#: ../src/common/stockitem.cpp:163 ../src/common/accelcmn.cpp:80
-#: ../src/html/helpdlg.cpp:66 ../src/html/helpfrm.cpp:111
+#: ../include/wx/msgdlg.h:282 ../src/osx/button_osx.cpp:39
+#: ../src/common/stockitem.cpp:160 ../src/common/accelcmn.cpp:77
+#: ../src/html/helpfrm.cpp:108 ../src/html/helpdlg.cpp:63
 msgid "Help"
 msgstr "Ndihmë"
 
-#: ../src/html/helpwnd.cpp:1200
+#: ../src/html/helpwnd.cpp:1198
 msgid "Help Browser Options"
 msgstr "Mundësi Shfletuesi Ndihme"
 
-#: ../src/generic/helpext.cpp:454 ../src/generic/helpext.cpp:455
+#: ../src/generic/helpext.cpp:452 ../src/generic/helpext.cpp:453
 msgid "Help Index"
 msgstr "Tregues i Ndihmës"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1529
 msgid "Help Printing"
 msgstr "Ndihmë për Shtypjen"
 
-#: ../src/html/helpwnd.cpp:801
+#: ../src/html/helpwnd.cpp:799
 msgid "Help Topics"
 msgstr "Tema Ndihme"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1546
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Libra ndihme (*.htb)|*.htb|Libra ndihme (*.zip)|*.zip|"
 
-#: ../src/generic/helpext.cpp:267
+#: ../src/generic/helpext.cpp:265
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "S’u gjet drejtori ndihme \"%s\"."
 
-#: ../src/generic/helpext.cpp:275
+#: ../src/generic/helpext.cpp:273
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "S’u gjet kartelë ndihme \"%s\"."
 
-#: ../src/html/helpctrl.cpp:63
+#: ../src/html/helpctrl.cpp:59
 #, c-format
 msgid "Help: %s"
 msgstr "Ndihmë: %s"
 
-#: ../src/osx/menu_osx.cpp:577
+#: ../src/osx/menu_osx.cpp:469
 #, c-format
 msgid "Hide %s"
 msgstr "Fshihe %s"
 
-#: ../src/osx/menu_osx.cpp:579
+#: ../src/osx/menu_osx.cpp:471
 msgid "Hide Others"
 msgstr "Fshihi të Tjerat"
 
-#: ../src/generic/infobar.cpp:84
+#: ../src/generic/infobar.cpp:81
 msgid "Hide this notification message."
 msgstr "Fshihe këtë mesazh njoftimi."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:884
+#: ../src/propgrid/advprops.cpp:785
 msgid "Highlight"
 msgstr "Theksim"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:885
+#: ../src/propgrid/advprops.cpp:786
 msgid "HighlightText"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:164 ../src/common/accelcmn.cpp:65
+#: ../src/common/stockitem.cpp:161 ../src/common/accelcmn.cpp:62
 msgid "Home"
 msgstr "Hyrje"
 
-#: ../src/generic/dirctrlg.cpp:524
+#: ../src/generic/dirctrlg.cpp:490
 msgid "Home directory"
 msgstr "Drejtori krye"
 
@@ -4031,55 +4143,55 @@ msgid "How the object will float relative to the text."
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1760
+#: ../src/propgrid/advprops.cpp:1661
 msgid "I-Beam"
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1196
+#: ../src/common/imagbmp.cpp:1208
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: Gabim në lexim maske DIB."
 
-#: ../src/common/imagbmp.cpp:1290 ../src/common/imagbmp.cpp:1390
-#: ../src/common/imagbmp.cpp:1405 ../src/common/imagbmp.cpp:1416
-#: ../src/common/imagbmp.cpp:1430 ../src/common/imagbmp.cpp:1478
-#: ../src/common/imagbmp.cpp:1493 ../src/common/imagbmp.cpp:1507
-#: ../src/common/imagbmp.cpp:1518
+#: ../src/common/imagbmp.cpp:1302 ../src/common/imagbmp.cpp:1402
+#: ../src/common/imagbmp.cpp:1417 ../src/common/imagbmp.cpp:1428
+#: ../src/common/imagbmp.cpp:1442 ../src/common/imagbmp.cpp:1490
+#: ../src/common/imagbmp.cpp:1505 ../src/common/imagbmp.cpp:1519
+#: ../src/common/imagbmp.cpp:1530
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: Gabim gjatë shkrimit të kartelës figurë!"
 
-#: ../src/common/imagbmp.cpp:1255
+#: ../src/common/imagbmp.cpp:1267
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: Figurë shumë e lartë për ikonë."
 
-#: ../src/common/imagbmp.cpp:1263
+#: ../src/common/imagbmp.cpp:1275
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: Figurë shumë e gjerë për ikonë."
 
-#: ../src/common/imagbmp.cpp:1603
+#: ../src/common/imagbmp.cpp:1615
 msgid "ICO: Invalid icon index."
 msgstr "ICO: tregues i pavlefshëm ikone."
 
-#: ../src/common/imagiff.cpp:758
+#: ../src/common/imagiff.cpp:755
 msgid "IFF: data stream seems to be truncated."
 msgstr "IFF: rrjedhë të dhënash që duket të jetë e cunguar."
 
-#: ../src/common/imagiff.cpp:742
+#: ../src/common/imagiff.cpp:739
 msgid "IFF: error in IFF image format."
 msgstr "IFF: gabim në format figurash IFF."
 
-#: ../src/common/imagiff.cpp:745
+#: ../src/common/imagiff.cpp:742
 msgid "IFF: not enough memory."
 msgstr "IFF: kujtesë e pamjaftueshme."
 
-#: ../src/common/imagiff.cpp:748
+#: ../src/common/imagiff.cpp:745
 msgid "IFF: unknown error!!!"
 msgstr "IFF: gabim i panjohur!!!"
 
-#: ../src/common/fmapbase.cpp:197
+#: ../src/common/fmapbase.cpp:194
 msgid "ISO-2022-JP"
 msgstr "ISO-2022-JP"
 
-#: ../src/html/htmprint.cpp:282
+#: ../src/html/htmprint.cpp:294
 msgid ""
 "If possible, try changing the layout parameters to make the printout more "
 "narrow."
@@ -4087,7 +4199,7 @@ msgstr ""
 "Nëse mundet, provoni të ndryshoni parametrat e skemës për ta bërë çka "
 "shtypet më të ngushtë."
 
-#: ../src/generic/dbgrptg.cpp:358
+#: ../src/generic/dbgrptg.cpp:362
 msgid ""
 "If you have any additional information pertaining to this bug\n"
 "report, please enter it here and it will be joined to it:"
@@ -4107,46 +4219,50 @@ msgstr ""
 "por kini parasysh që kjo mund të zvarrisë përmirësimin e programit, ndaj,\n"
 "në qoftë e mundur, ju lutemi të vazhdoni me prodhimin e raportit.\n"
 
-#: ../src/msw/registry.cpp:1405
+#: ../src/common/zipstrm.cpp:1043
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1393
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Po shpërfillet vlera \"%s\" e kyçit \"%s\"."
 
-#: ../src/common/xtistrm.cpp:295
+#: ../src/common/xtistrm.cpp:292
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Klasë e Paligjshme Objektesh (Non-wxEvtHandler) si Burim Akti"
 
-#: ../src/common/xti.cpp:513
+#: ../src/common/xti.cpp:510
 msgid "Illegal Parameter Count for ConstructObject Method"
 msgstr "Numër i Paligjshëm Parametri për Metodë ConstructObject"
 
-#: ../src/common/xti.cpp:501
+#: ../src/common/xti.cpp:498
 msgid "Illegal Parameter Count for Create Method"
 msgstr "Numër i Paligjshëm Parametri për Metodë Create"
 
-#: ../src/generic/dirctrlg.cpp:570 ../src/generic/filectrlg.cpp:756
+#: ../src/generic/dirctrlg.cpp:536 ../src/generic/filectrlg.cpp:752
 msgid "Illegal directory name."
 msgstr "Emër i paligjshëm drejtorie."
 
-#: ../src/generic/filectrlg.cpp:1367
+#: ../src/generic/filectrlg.cpp:1356
 msgid "Illegal file specification."
 msgstr "Specifikim i paligjshëm kartele."
 
-#: ../src/common/image.cpp:2269
+#: ../src/common/image.cpp:2363
 msgid "Image and mask have different sizes."
 msgstr "Figura dhe maska kanë madhësi të ndryshme."
 
-#: ../src/common/image.cpp:2746
+#: ../src/common/image.cpp:2841
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "Kartela figurë s’është e llojit %d."
 
-#: ../src/common/image.cpp:2877
+#: ../src/common/image.cpp:2995
 #, c-format
 msgid "Image is not of type %s."
 msgstr "Figura s’është e llojit %s."
 
-#: ../src/msw/textctrl.cpp:488
+#: ../src/msw/textctrl.cpp:534
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -4154,100 +4270,100 @@ msgstr ""
 "E pamundur të krijohet kontroll përpunimi të pasur, në vend të tij po "
 "përdoret kontroll teksti të thjeshtë. Ju lutemi, riinstaloni riched32.dll"
 
-#: ../src/unix/utilsunx.cpp:301
+#: ../src/unix/utilsunx.cpp:303
 msgid "Impossible to get child process input"
 msgstr "E pamundur të merret \"input\" procesi pjelle"
 
-#: ../src/common/filefn.cpp:1028
+#: ../src/common/filefn.cpp:917
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "E pamundur të kihen leje për kartelë '%s'"
 
-#: ../src/common/filefn.cpp:1042
+#: ../src/common/filefn.cpp:931
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "E pamundur të mbishkruhet kartela '%s'"
 
-#: ../src/common/filefn.cpp:1097
+#: ../src/common/filefn.cpp:986
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "E pamundur të caktohen leje për kartelën '%s'"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:886
+#: ../src/propgrid/advprops.cpp:787
 msgid "InactiveBorder"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:887
+#: ../src/propgrid/advprops.cpp:788
 msgid "InactiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:888
+#: ../src/propgrid/advprops.cpp:789
 msgid "InactiveCaptionText"
 msgstr ""
 
-#: ../src/common/gifdecod.cpp:792
+#: ../src/common/gifdecod.cpp:826
 #, c-format
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "Madhësi e pasaktë kuadri GIF (%u, %d) për kuadrin #%u"
 
-#: ../src/msw/ole/automtn.cpp:635
+#: ../src/msw/ole/automtn.cpp:626
 msgid "Incorrect number of arguments."
 msgstr "Numër i pasaktë argumentesh."
 
-#: ../src/common/stockitem.cpp:165
+#: ../src/common/stockitem.cpp:162
 msgid "Indent"
 msgstr "Kryeradhë"
 
-#: ../src/richtext/richtextformatdlg.cpp:349
+#: ../src/richtext/richtextformatdlg.cpp:342
 msgid "Indents && Spacing"
 msgstr "Kryeradhë && Hapësira"
 
-#: ../src/common/stockitem.cpp:166 ../src/html/helpwnd.cpp:515
+#: ../src/common/stockitem.cpp:163 ../src/html/helpwnd.cpp:513
 msgid "Index"
 msgstr "Tregues"
 
-#: ../src/common/fmapbase.cpp:159
+#: ../src/common/fmapbase.cpp:156
 msgid "Indian (ISO-8859-12)"
 msgstr "Indiane (ISO-8859-12)"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "Info"
 msgstr "Info"
 
-#: ../src/common/init.cpp:287
+#: ../src/common/init.cpp:284
 msgid "Initialization failed in post init, aborting."
 msgstr "Gatitja në post init dështoi, po ndërpritet."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:54
+#: ../src/common/accelcmn.cpp:51
 msgid "Ins"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextsymboldlg.cpp:472 ../src/common/accelcmn.cpp:53
+#: ../src/common/accelcmn.cpp:50 ../src/richtext/richtextsymboldlg.cpp:469
 msgid "Insert"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:8067
+#: ../src/richtext/richtextbuffer.cpp:8063
 msgid "Insert Field"
 msgstr "Futni Fushë"
 
-#: ../src/richtext/richtextbuffer.cpp:7978
-#: ../src/richtext/richtextbuffer.cpp:8936
+#: ../src/richtext/richtextbuffer.cpp:7974
+#: ../src/richtext/richtextbuffer.cpp:8934
 msgid "Insert Image"
 msgstr "Futni Figurë"
 
-#: ../src/richtext/richtextbuffer.cpp:8025
+#: ../src/richtext/richtextbuffer.cpp:8021
 msgid "Insert Object"
 msgstr "Futni Objekt"
 
-#: ../src/richtext/richtextctrl.cpp:1286 ../src/richtext/richtextctrl.cpp:1494
-#: ../src/richtext/richtextbuffer.cpp:7822
-#: ../src/richtext/richtextbuffer.cpp:7852
-#: ../src/richtext/richtextbuffer.cpp:7894
+#: ../src/richtext/richtextbuffer.cpp:7818
+#: ../src/richtext/richtextbuffer.cpp:7848
+#: ../src/richtext/richtextbuffer.cpp:7890
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
 msgid "Insert Text"
 msgstr "Futni Tekst"
 
@@ -4260,16 +4376,11 @@ msgstr "Fut para paragrafit një ndërprerje faqeje."
 msgid "Inset"
 msgstr ""
 
-#: ../src/gtk/app.cpp:425
-#, c-format
-msgid "Invalid GTK+ command line option, use \"%s --help\""
-msgstr "Mundësi e paligjshme rreshti urdhrash GTK+, përdorni \"%s --help\""
-
-#: ../src/common/imagtiff.cpp:311
+#: ../src/common/imagtiff.cpp:308
 msgid "Invalid TIFF image index."
 msgstr "Tregues i pavlefshëm figurash TIFF."
 
-#: ../src/common/appcmn.cpp:273
+#: ../src/common/appcmn.cpp:294
 #, c-format
 msgid "Invalid display mode specification '%s'."
 msgstr "Specifikim i pavlefshëm mënyre ekrani '%s'."
@@ -4279,246 +4390,250 @@ msgstr "Specifikim i pavlefshëm mënyre ekrani '%s'."
 msgid "Invalid geometry specification '%s'"
 msgstr "Specifikim i pavlefshëm gjeometrie '%s'"
 
-#: ../src/unix/fswatcher_inotify.cpp:323
+#: ../src/unix/fswatcher_inotify.cpp:320
 #, c-format
 msgid "Invalid inotify event for \"%s\""
 msgstr "Akt i paligjshëm inotify për \"%s\""
 
-#: ../src/unix/snglinst.cpp:312
+#: ../src/unix/snglinst.cpp:309
 #, c-format
 msgid "Invalid lock file '%s'."
 msgstr "Kartelë e pavlefshme kyçjeje '%s'."
 
-#: ../src/common/translation.cpp:1125
+#: ../src/common/translation.cpp:1167
 msgid "Invalid message catalog."
 msgstr "Katalog i pavlefshëm mesazhi."
 
-#: ../src/common/xtistrm.cpp:405 ../src/common/xtistrm.cpp:420
+#: ../src/common/xtistrm.cpp:402 ../src/common/xtistrm.cpp:417
 msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
 msgstr "ID Objekti e pavlefshme ose Null dhënë te GetObjectClassInfo"
 
-#: ../src/common/xtistrm.cpp:435
+#: ../src/common/xtistrm.cpp:432
 msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
 msgstr "ID Objekti e pavlefshme ose Null dhënë te HasObjectClassInfo"
 
-#: ../src/common/regex.cpp:310
+#: ../src/common/regex.cpp:307
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Shprehje e rregullt e pavlefshme '%s': %s"
 
-#: ../src/common/config.cpp:226
+#: ../src/common/config.cpp:222
 #, c-format
 msgid "Invalid value %ld for a boolean key \"%s\" in config file."
 msgstr "Vlerë %ld e pavlefshme për element bulean \"%s\" në kartelë formësimi."
 
-#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:351
-#: ../src/osx/carbon/fontdlg.cpp:361 ../src/common/stockitem.cpp:168
+#: ../src/osx/carbon/fontdlg.cpp:358 ../src/common/stockitem.cpp:165
+#: ../src/generic/fontdlgg.cpp:325 ../src/richtext/richtextfontpage.cpp:351
 msgid "Italic"
 msgstr "Të pjerrta"
 
-#: ../src/common/paper.cpp:130
+#: ../src/common/paper.cpp:127
 msgid "Italy Envelope, 110 x 230 mm"
 msgstr "Zarf Italie, 110 x 230 mm"
 
-#: ../src/common/imagjpeg.cpp:270
+#: ../src/common/imagjpeg.cpp:257
 msgid "JPEG: Couldn't load - file is probably corrupted."
 msgstr "JPEG: S’u ngarkua dot - mundet që kartela të jetë e dëmtuar."
 
-#: ../src/common/imagjpeg.cpp:449
+#: ../src/common/imagjpeg.cpp:436
 msgid "JPEG: Couldn't save image."
 msgstr "JPEG: S’u ruajt dot figura."
 
-#: ../src/common/paper.cpp:163
+#: ../src/common/paper.cpp:160
 msgid "Japanese Double Postcard 200 x 148 mm"
 msgstr "Kartolinë Japoneze Dyshe 200 x 148 mm"
 
-#: ../src/common/paper.cpp:167
+#: ../src/common/paper.cpp:164
 msgid "Japanese Envelope Chou #3"
 msgstr "Zarf Japonez Chou #3"
 
-#: ../src/common/paper.cpp:180
+#: ../src/common/paper.cpp:177
 msgid "Japanese Envelope Chou #3 Rotated"
 msgstr "Zarf Japonez Chou #3 i Rrotulluar"
 
-#: ../src/common/paper.cpp:168
+#: ../src/common/paper.cpp:165
 msgid "Japanese Envelope Chou #4"
 msgstr "Zarf Japonez Chou #4"
 
-#: ../src/common/paper.cpp:181
+#: ../src/common/paper.cpp:178
 msgid "Japanese Envelope Chou #4 Rotated"
 msgstr "Zarf Japonez Chou #4 i Rrotulluar"
 
-#: ../src/common/paper.cpp:165
+#: ../src/common/paper.cpp:162
 msgid "Japanese Envelope Kaku #2"
 msgstr "Zarf Japonez Kaku #2"
 
-#: ../src/common/paper.cpp:178
+#: ../src/common/paper.cpp:175
 msgid "Japanese Envelope Kaku #2 Rotated"
 msgstr "Zarf Japonez Kaku #2 i Rrotulluar"
 
-#: ../src/common/paper.cpp:166
+#: ../src/common/paper.cpp:163
 msgid "Japanese Envelope Kaku #3"
 msgstr "Zarf Japonez Kaku #3"
 
-#: ../src/common/paper.cpp:179
+#: ../src/common/paper.cpp:176
 msgid "Japanese Envelope Kaku #3 Rotated"
 msgstr "Zarf Japonez Kaku #3 i Rrotulluar"
 
-#: ../src/common/paper.cpp:185
+#: ../src/common/paper.cpp:182
 msgid "Japanese Envelope You #4"
 msgstr "Zarf Japonez You #4"
 
-#: ../src/common/paper.cpp:186
+#: ../src/common/paper.cpp:183
 msgid "Japanese Envelope You #4 Rotated"
 msgstr "Zarf Japonez You #4 i Rrotulluar"
 
-#: ../src/common/paper.cpp:138
+#: ../src/common/paper.cpp:135
 msgid "Japanese Postcard 100 x 148 mm"
 msgstr "Kartolinë Japoneze 100 x 148 mm"
 
-#: ../src/common/paper.cpp:175
+#: ../src/common/paper.cpp:172
 msgid "Japanese Postcard Rotated 148 x 100 mm"
 msgstr "Kartolinë Japoneze e Rrotulluar 148 x 100 mm"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "Jump to"
 msgstr "Hidhu te"
 
-#: ../src/common/stockitem.cpp:171
+#: ../src/common/stockitem.cpp:168
 msgid "Justified"
 msgstr "Përligjur"
 
-#: ../src/richtext/richtextindentspage.cpp:155
-#: ../src/richtext/richtextindentspage.cpp:157
 #: ../src/richtext/richtextliststylepage.cpp:344
 #: ../src/richtext/richtextliststylepage.cpp:346
+#: ../src/richtext/richtextindentspage.cpp:155
+#: ../src/richtext/richtextindentspage.cpp:157
 msgid "Justify text left and right."
 msgstr "Përligje tekstin majtas dhe djathtas."
 
-#: ../src/common/fmapbase.cpp:163
+#: ../src/common/fmapbase.cpp:160
 msgid "KOI8-R"
 msgstr "KOI8-R"
 
-#: ../src/common/fmapbase.cpp:164
+#: ../src/common/fmapbase.cpp:161
 msgid "KOI8-U"
 msgstr "KOI8-U"
 
-#: ../src/common/accelcmn.cpp:265 ../src/common/accelcmn.cpp:347
+#: ../src/common/accelcmn.cpp:279 ../src/common/accelcmn.cpp:364
 msgid "KP_"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "KP_Add"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "KP_Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "KP_Decimal"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 msgid "KP_Delete"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "KP_Divide"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 msgid "KP_Down"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "KP_End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "KP_Enter"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "KP_Equal"
 msgstr ""
 
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
-msgid "KP_Home"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
-msgid "KP_Insert"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
-msgid "KP_Left"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
-msgid "KP_Multiply"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:99
-msgid "KP_Next"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
-msgid "KP_PageDown"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
-msgid "KP_PageUp"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:98
-msgid "KP_Prior"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
-msgid "KP_Right"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
-msgid "KP_Separator"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
-msgid "KP_Space"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
-msgid "KP_Subtract"
+#: ../src/common/accelcmn.cpp:276 ../src/common/accelcmn.cpp:361
+msgid "KP_F"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
 #: ../src/common/accelcmn.cpp:89
+msgid "KP_Home"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:100
+msgid "KP_Insert"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:90
+msgid "KP_Left"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:103
+msgid "KP_Multiply"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:97
+msgid "KP_Next"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:95
+msgid "KP_PageDown"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:94
+msgid "KP_PageUp"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:96
+msgid "KP_Prior"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:92
+msgid "KP_Right"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:105
+msgid "KP_Separator"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:86
+msgid "KP_Space"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:106
+msgid "KP_Subtract"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:87
 msgid "KP_Tab"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "KP_Up"
 msgstr ""
 
@@ -4526,112 +4641,127 @@ msgstr ""
 msgid "L&ine spacing:"
 msgstr "Hapës&irë rreshtash:"
 
-#: ../src/generic/prntdlgg.cpp:613 ../src/generic/prntdlgg.cpp:868
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "gabim ngjeshjeje"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "gabim çngjeshjeje"
+
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:861
 msgid "Landscape"
 msgstr "Së gjeri"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "Last"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:1572
+#: ../src/common/prntbase.cpp:1597
 msgid "Last page"
 msgstr "Faqja e fundit"
 
-#: ../src/common/log.cpp:305
+#: ../src/common/log.cpp:324
 #, c-format
 msgid "Last repeated message (\"%s\", %u time) wasn't output"
 msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
 msgstr[0] "Mesazhi i fundit i përsëritur (\"%s\", %u herë) s’qe output"
 msgstr[1] "Mesazhi i fundit i përsëritur (\"%s\", %u herë) s’qe output"
 
-#: ../src/common/paper.cpp:103
+#: ../src/common/paper.cpp:100
 msgid "Ledger, 17 x 11 in"
 msgstr "Ledger, 17 x 11 inç"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6146
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:58 ../src/generic/datavgen.cpp:6951
+#: ../src/richtext/richtextsizepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:252
 #: ../src/richtext/richtextliststylepage.cpp:253
 #: ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
-#: ../src/richtext/richtextsizepage.cpp:249 ../src/common/accelcmn.cpp:61
 msgid "Left"
 msgstr "Majtas"
 
-#: ../src/richtext/richtextindentspage.cpp:204
 #: ../src/richtext/richtextliststylepage.cpp:390
+#: ../src/richtext/richtextindentspage.cpp:204
 msgid "Left (&first line):"
 msgstr "Majtas (rreshti i &parë):"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1761
+#: ../src/propgrid/advprops.cpp:1662
 msgid "Left Button"
 msgstr "Butoni Majtas"
 
-#: ../src/generic/prntdlgg.cpp:880
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Left margin (mm):"
 msgstr "Mënjanë majtas (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:141
-#: ../src/richtext/richtextindentspage.cpp:143
 #: ../src/richtext/richtextliststylepage.cpp:330
 #: ../src/richtext/richtextliststylepage.cpp:332
+#: ../src/richtext/richtextindentspage.cpp:141
+#: ../src/richtext/richtextindentspage.cpp:143
 msgid "Left-align text."
 msgstr "Vëre tekstin majtas."
 
-#: ../src/common/paper.cpp:144
+#: ../src/common/paper.cpp:141
 msgid "Legal Extra 9 1/2 x 15 in"
 msgstr "Legal Ekstra 9 1/2 x 15 inç"
 
-#: ../src/common/paper.cpp:96
+#: ../src/common/paper.cpp:93
 msgid "Legal, 8 1/2 x 14 in"
 msgstr "Legal, 8 1/2 x 14 inç"
 
-#: ../src/common/paper.cpp:143
+#: ../src/common/paper.cpp:140
 msgid "Letter Extra 9 1/2 x 12 in"
 msgstr "Letër Ekstra 9 1/2 x 12 inç"
 
-#: ../src/common/paper.cpp:149
+#: ../src/common/paper.cpp:146
 msgid "Letter Extra Transverse 9.275 x 12 in"
 msgstr "Letër Ekstra Transverse 9.275 x 12 inç"
 
-#: ../src/common/paper.cpp:152
+#: ../src/common/paper.cpp:149
 msgid "Letter Plus 8 1/2 x 12.69 in"
 msgstr "Letër Plus 8 1/2 x 12.69 inç"
 
-#: ../src/common/paper.cpp:169
+#: ../src/common/paper.cpp:166
 msgid "Letter Rotated 11 x 8 1/2 in"
 msgstr "Letër e Rrotulluar 11 x 8 1/2 inç"
 
-#: ../src/common/paper.cpp:101
+#: ../src/common/paper.cpp:98
 msgid "Letter Small, 8 1/2 x 11 in"
 msgstr "Letër e Vogël, 8 1/2 x 11 inç"
 
-#: ../src/common/paper.cpp:147
+#: ../src/common/paper.cpp:144
 msgid "Letter Transverse 8 1/2 x 11 in"
 msgstr "Letër Transverse 8 1/2 x 11 inç"
 
-#: ../src/common/paper.cpp:95
+#: ../src/common/paper.cpp:92
 msgid "Letter, 8 1/2 x 11 in"
 msgstr "Letër, 8 1/2 x 11 inç"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "License"
 msgstr "Licencë"
 
-#: ../src/generic/fontdlgg.cpp:332
+#: ../src/generic/fontdlgg.cpp:328
 msgid "Light"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1608
+#: ../src/propgrid/advprops.cpp:1514
 msgid "Lime"
 msgstr "Qitro"
 
-#: ../src/generic/helpext.cpp:294
+#: ../src/generic/helpext.cpp:292
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr ""
@@ -4642,15 +4772,15 @@ msgstr ""
 msgid "Line spacing:"
 msgstr "Hapësirë mes rreshtash:"
 
-#: ../src/html/chm.cpp:838
+#: ../src/html/chm.cpp:829
 msgid "Link contained '//', converted to absolute link."
 msgstr "Lidhja përmbante '//', u shndërrua në lidhje absolute."
 
-#: ../src/richtext/richtextformatdlg.cpp:364
+#: ../src/richtext/richtextformatdlg.cpp:357
 msgid "List Style"
 msgstr "Stil Liste"
 
-#: ../src/richtext/richtextstyles.cpp:1064
+#: ../src/richtext/richtextstyles.cpp:1061
 msgid "List styles"
 msgstr "Stile liste"
 
@@ -4664,26 +4794,26 @@ msgstr "Madhësi shkronjash liste, në pikë."
 msgid "Lists the available fonts."
 msgstr "Lista shkronjash të gatshme."
 
-#: ../src/common/fldlgcmn.cpp:340
+#: ../src/common/fldlgcmn.cpp:337
 #, c-format
 msgid "Load %s file"
 msgstr "Ngarko kartelë %s"
 
-#: ../src/html/htmlwin.cpp:597
+#: ../src/html/htmlwin.cpp:600
 msgid "Loading : "
 msgstr "Po ngarkohert : "
 
-#: ../src/unix/snglinst.cpp:246
+#: ../src/unix/snglinst.cpp:243
 #, c-format
 msgid "Lock file '%s' has incorrect owner."
 msgstr "Kartela '%s' e kyçjes ka pronar të pasaktë."
 
-#: ../src/unix/snglinst.cpp:251
+#: ../src/unix/snglinst.cpp:248
 #, c-format
 msgid "Lock file '%s' has incorrect permissions."
 msgstr "Kartela '%s' e kyçjes ka leje të pasakta."
 
-#: ../src/generic/logg.cpp:576
+#: ../src/generic/logg.cpp:573
 #, c-format
 msgid "Log saved to the file '%s'."
 msgstr "Regjistrim u ruajt te kartela '%s'."
@@ -4698,11 +4828,11 @@ msgstr "Shkronja të vogla"
 msgid "Lower case roman numerals"
 msgstr "Numra romakë me të vogla"
 
-#: ../src/gtk/mdi.cpp:422 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk1/mdi.cpp:431 ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "Pjellë MDI"
 
-#: ../src/msw/helpchm.cpp:56
+#: ../src/msw/helpchm.cpp:53
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -4710,189 +4840,189 @@ msgstr ""
 "Funksionet MS HTML Help nuk janë të passhëm, ngaqë libraria MS HTML Help "
 "s’është e instaluar në këtë makinë. Ju lutemi, instalojeni."
 
-#: ../src/univ/themes/win32.cpp:3754
+#: ../src/univ/themes/win32.cpp:3751
 msgid "Ma&ximize"
 msgstr "Ma&ksimizo"
 
-#: ../src/common/fmapbase.cpp:203
+#: ../src/common/fmapbase.cpp:200
 msgid "MacArabic"
 msgstr "MacArabic"
 
-#: ../src/common/fmapbase.cpp:222
+#: ../src/common/fmapbase.cpp:219
 msgid "MacArmenian"
 msgstr "MacArmenian"
 
-#: ../src/common/fmapbase.cpp:211
+#: ../src/common/fmapbase.cpp:208
 msgid "MacBengali"
 msgstr "MacBengali"
 
-#: ../src/common/fmapbase.cpp:217
+#: ../src/common/fmapbase.cpp:214
 msgid "MacBurmese"
 msgstr "MacBurmese"
 
-#: ../src/common/fmapbase.cpp:236
+#: ../src/common/fmapbase.cpp:233
 msgid "MacCeltic"
 msgstr "MacCeltic"
 
-#: ../src/common/fmapbase.cpp:227
+#: ../src/common/fmapbase.cpp:224
 msgid "MacCentralEurRoman"
 msgstr "MacCentralEurRoman"
 
-#: ../src/common/fmapbase.cpp:223
+#: ../src/common/fmapbase.cpp:220
 msgid "MacChineseSimp"
 msgstr "MacChineseSimp"
 
-#: ../src/common/fmapbase.cpp:201
+#: ../src/common/fmapbase.cpp:198
 msgid "MacChineseTrad"
 msgstr "MacChineseTrad"
 
-#: ../src/common/fmapbase.cpp:233
+#: ../src/common/fmapbase.cpp:230
 msgid "MacCroatian"
 msgstr "MacCroatian"
 
-#: ../src/common/fmapbase.cpp:206
+#: ../src/common/fmapbase.cpp:203
 msgid "MacCyrillic"
 msgstr "MacCyrillic"
 
-#: ../src/common/fmapbase.cpp:207
+#: ../src/common/fmapbase.cpp:204
 msgid "MacDevanagari"
 msgstr "MacDevanagari"
 
-#: ../src/common/fmapbase.cpp:231
+#: ../src/common/fmapbase.cpp:228
 msgid "MacDingbats"
 msgstr "MacDingbats"
 
-#: ../src/common/fmapbase.cpp:226
+#: ../src/common/fmapbase.cpp:223
 msgid "MacEthiopic"
 msgstr "MacEthiopic"
 
-#: ../src/common/fmapbase.cpp:229
+#: ../src/common/fmapbase.cpp:226
 msgid "MacExtArabic"
 msgstr "MacExtArabic"
 
-#: ../src/common/fmapbase.cpp:237
+#: ../src/common/fmapbase.cpp:234
 msgid "MacGaelic"
 msgstr "MacGaelic"
 
-#: ../src/common/fmapbase.cpp:221
+#: ../src/common/fmapbase.cpp:218
 msgid "MacGeorgian"
 msgstr "MacGeorgian"
 
-#: ../src/common/fmapbase.cpp:205
+#: ../src/common/fmapbase.cpp:202
 msgid "MacGreek"
 msgstr "MacGreek"
 
-#: ../src/common/fmapbase.cpp:209
+#: ../src/common/fmapbase.cpp:206
 msgid "MacGujarati"
 msgstr "MacGujarati"
 
-#: ../src/common/fmapbase.cpp:208
+#: ../src/common/fmapbase.cpp:205
 msgid "MacGurmukhi"
 msgstr "MacGurmukhi"
 
-#: ../src/common/fmapbase.cpp:204
+#: ../src/common/fmapbase.cpp:201
 msgid "MacHebrew"
 msgstr "MacHebrew"
 
-#: ../src/common/fmapbase.cpp:234
+#: ../src/common/fmapbase.cpp:231
 msgid "MacIcelandic"
 msgstr "MacIcelandic"
 
-#: ../src/common/fmapbase.cpp:200
+#: ../src/common/fmapbase.cpp:197
 msgid "MacJapanese"
 msgstr "MacJapanese"
 
-#: ../src/common/fmapbase.cpp:214
+#: ../src/common/fmapbase.cpp:211
 msgid "MacKannada"
 msgstr "MacKannada"
 
-#: ../src/common/fmapbase.cpp:238
+#: ../src/common/fmapbase.cpp:235
 msgid "MacKeyboardGlyphs"
 msgstr "MacKeyboardGlyphs"
 
-#: ../src/common/fmapbase.cpp:218
+#: ../src/common/fmapbase.cpp:215
 msgid "MacKhmer"
 msgstr "MacKhmer"
 
-#: ../src/common/fmapbase.cpp:202
+#: ../src/common/fmapbase.cpp:199
 msgid "MacKorean"
 msgstr "MacKorean"
 
-#: ../src/common/fmapbase.cpp:220
+#: ../src/common/fmapbase.cpp:217
 msgid "MacLaotian"
 msgstr "MacLaotian"
 
-#: ../src/common/fmapbase.cpp:215
+#: ../src/common/fmapbase.cpp:212
 msgid "MacMalayalam"
 msgstr "MacMalayalam"
 
-#: ../src/common/fmapbase.cpp:225
+#: ../src/common/fmapbase.cpp:222
 msgid "MacMongolian"
 msgstr "MacMongolian"
 
-#: ../src/common/fmapbase.cpp:210
+#: ../src/common/fmapbase.cpp:207
 msgid "MacOriya"
 msgstr "MacOriya"
 
-#: ../src/common/fmapbase.cpp:199
+#: ../src/common/fmapbase.cpp:196
 msgid "MacRoman"
 msgstr "MacRoman"
 
-#: ../src/common/fmapbase.cpp:235
+#: ../src/common/fmapbase.cpp:232
 msgid "MacRomanian"
 msgstr "MacRomanian"
 
-#: ../src/common/fmapbase.cpp:216
+#: ../src/common/fmapbase.cpp:213
 msgid "MacSinhalese"
 msgstr "MacSinhalese"
 
-#: ../src/common/fmapbase.cpp:230
+#: ../src/common/fmapbase.cpp:227
 msgid "MacSymbol"
 msgstr "MacSymbol"
 
-#: ../src/common/fmapbase.cpp:212
+#: ../src/common/fmapbase.cpp:209
 msgid "MacTamil"
 msgstr "MacTamil"
 
-#: ../src/common/fmapbase.cpp:213
+#: ../src/common/fmapbase.cpp:210
 msgid "MacTelugu"
 msgstr "MacTelugu"
 
-#: ../src/common/fmapbase.cpp:219
+#: ../src/common/fmapbase.cpp:216
 msgid "MacThai"
 msgstr "MacThai"
 
-#: ../src/common/fmapbase.cpp:224
+#: ../src/common/fmapbase.cpp:221
 msgid "MacTibetan"
 msgstr "MacTibetan"
 
-#: ../src/common/fmapbase.cpp:232
+#: ../src/common/fmapbase.cpp:229
 msgid "MacTurkish"
 msgstr "MacTurkish"
 
-#: ../src/common/fmapbase.cpp:228
+#: ../src/common/fmapbase.cpp:225
 msgid "MacVietnamese"
 msgstr "MacVietnamese"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1762
+#: ../src/propgrid/advprops.cpp:1663
 msgid "Magnifier"
 msgstr "Zmadhues"
 
-#: ../src/propgrid/advprops.cpp:2143
+#: ../src/propgrid/advprops.cpp:2050
 msgid "Make a selection:"
 msgstr "Bëni një përzgjedhje:"
 
-#: ../src/richtext/richtextformatdlg.cpp:374
+#: ../src/richtext/richtextformatdlg.cpp:367
 #: ../src/richtext/richtextmarginspage.cpp:171
 msgid "Margins"
 msgstr "Mënjana"
 
-#: ../src/propgrid/advprops.cpp:1595
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Maroon"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:147
+#: ../src/generic/fdrepdlg.cpp:144
 msgid "Match case"
 msgstr "Siç është shkruajtur"
 
@@ -4904,40 +5034,40 @@ msgstr "Lartësi maksimum:"
 msgid "Max width:"
 msgstr "Gjerësi maksimum:"
 
-#: ../src/unix/mediactrl.cpp:947
+#: ../src/unix/mediactrl.cpp:972
 #, c-format
 msgid "Media playback error: %s"
 msgstr "Gabim në luajtje mediash: %s"
 
-#: ../src/common/fs_mem.cpp:175
+#: ../src/common/fs_mem.cpp:170
 #, c-format
 msgid "Memory VFS already contains file '%s'!"
 msgstr "Kujtesa VFS përmban tashmë një kartelë '%s'!"
 
 #. TRANSLATORS: Name of keyboard key
 #. TRANSLATORS: Keyword of system colour
-#: ../src/common/accelcmn.cpp:73 ../src/propgrid/advprops.cpp:889
+#: ../src/common/accelcmn.cpp:70 ../src/propgrid/advprops.cpp:790
 msgid "Menu"
 msgstr "Menu"
 
-#: ../src/common/msgout.cpp:124
+#: ../src/common/msgout.cpp:121
 msgid "Message"
 msgstr "Mesazh"
 
-#: ../src/univ/themes/metal.cpp:168
+#: ../src/univ/themes/metal.cpp:165
 msgid "Metal theme"
 msgstr "Temë metal"
 
-#: ../src/msw/ole/automtn.cpp:652
+#: ../src/msw/ole/automtn.cpp:643
 msgid "Method or property not found."
 msgstr "S’u gjet metodë ose veti."
 
-#: ../src/univ/themes/win32.cpp:3752
+#: ../src/univ/themes/win32.cpp:3749
 msgid "Mi&nimize"
 msgstr "Mi&nimizo"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1763
+#: ../src/propgrid/advprops.cpp:1664
 msgid "Middle Button"
 msgstr "Butoni i Mesit i Miut"
 
@@ -4949,36 +5079,41 @@ msgstr "Lartësi minimum:"
 msgid "Min width:"
 msgstr "Gjerësi minimum:"
 
-#: ../src/msw/ole/automtn.cpp:668
+#: ../src/osx/cocoa/menu.mm:281
+#, fuzzy
+msgid "Minimize"
+msgstr "Mi&nimizo"
+
+#: ../src/msw/ole/automtn.cpp:659
 msgid "Missing a required parameter."
 msgstr "I mungon një parametër i domosdoshëm."
 
-#: ../src/generic/fontdlgg.cpp:324
+#: ../src/generic/fontdlgg.cpp:320
 msgid "Modern"
 msgstr "Modern"
 
-#: ../src/generic/filectrlg.cpp:427
+#: ../src/generic/filectrlg.cpp:423
 msgid "Modified"
 msgstr "Ndryshuar"
 
-#: ../src/common/module.cpp:133
+#: ../src/common/module.cpp:130
 #, c-format
 msgid "Module \"%s\" initialization failed"
 msgstr "Gatitja e modulit \"%s\" dështoi"
 
-#: ../src/common/paper.cpp:131
+#: ../src/common/paper.cpp:128
 msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
 msgstr "#10 Envelope, 4 1/8 x 9 1/2 inç"
 
-#: ../src/msw/fswatcher.cpp:143
+#: ../src/msw/fswatcher.cpp:140
 msgid "Monitoring individual files for changes is not supported currently."
 msgstr "Hëpërhë nuk mbulohet mbikëqyrja për ndryshime e kartelave individuale."
 
-#: ../src/generic/editlbox.cpp:172
+#: ../src/generic/editlbox.cpp:160
 msgid "Move down"
 msgstr "Ule"
 
-#: ../src/generic/editlbox.cpp:171
+#: ../src/generic/editlbox.cpp:155
 msgid "Move up"
 msgstr "Ngrije"
 
@@ -4992,97 +5127,102 @@ msgstr "E kalon objektin te paragrafi pasues."
 msgid "Moves the object to the previous paragraph."
 msgstr "E kalon objektin te paragrafi i mëparshëm."
 
-#: ../src/richtext/richtextbuffer.cpp:9966
+#: ../src/richtext/richtextbuffer.cpp:9963
 msgid "Multiple Cell Properties"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:424
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:82
+msgid "Multiply"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:420
 msgid "Name"
 msgstr "Emër"
 
-#: ../src/propgrid/advprops.cpp:1596
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Navy"
 msgstr "Blu"
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "Network"
 msgstr "Rrjet"
 
-#: ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173
 msgid "New"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:243
+#: ../src/richtext/richtextstyledlg.cpp:239
 msgid "New &Box Style..."
 msgstr "Stil i Ri &Kuadrati…"
 
-#: ../src/richtext/richtextstyledlg.cpp:225
+#: ../src/richtext/richtextstyledlg.cpp:221
 msgid "New &Character Style..."
 msgstr "Stil i Ri &Shenje…"
 
-#: ../src/richtext/richtextstyledlg.cpp:237
+#: ../src/richtext/richtextstyledlg.cpp:233
 msgid "New &List Style..."
 msgstr "Stil i Ri &Liste…"
 
-#: ../src/richtext/richtextstyledlg.cpp:231
+#: ../src/richtext/richtextstyledlg.cpp:227
 msgid "New &Paragraph Style..."
 msgstr "Stil i Ri &Paragrafi…"
 
-#: ../src/richtext/richtextstyledlg.cpp:606
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:654
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:820
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:893
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:934
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:602
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:650
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:816
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:889
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:930
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "New Style"
 msgstr "Stil i Ri"
 
-#: ../src/generic/editlbox.cpp:169
+#: ../src/generic/editlbox.cpp:139
 msgid "New item"
 msgstr "Objekt i ri"
 
-#: ../src/generic/dirdlgg.cpp:297 ../src/generic/dirdlgg.cpp:307
-#: ../src/generic/filectrlg.cpp:618 ../src/generic/filectrlg.cpp:627
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+#: ../src/generic/dirdlgg.cpp:294 ../src/generic/dirdlgg.cpp:304
 msgid "NewName"
 msgstr "Emër i ri"
 
-#: ../src/common/prntbase.cpp:1567 ../src/html/helpwnd.cpp:665
+#: ../src/common/prntbase.cpp:1592 ../src/html/helpwnd.cpp:663
 msgid "Next page"
 msgstr "Faqe pasuese"
 
-#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:177
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:174
 #: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Jo"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1764
+#: ../src/propgrid/advprops.cpp:1665
 msgid "No Entry"
 msgstr "Pa Zë"
 
-#: ../src/generic/animateg.cpp:150
+#: ../src/generic/animateg.cpp:133
 #, c-format
 msgid "No animation handler for type %ld defined."
 msgstr "S’ka trajtues animacioni të përcaktuar për llojin %ld."
 
-#: ../src/dfb/bitmap.cpp:642 ../src/dfb/bitmap.cpp:676
+#: ../src/dfb/bitmap.cpp:639 ../src/dfb/bitmap.cpp:673
 #, c-format
 msgid "No bitmap handler for type %d defined."
 msgstr "S’ka trajtues bitmap të përcaktuar për llojin %d."
 
-#: ../src/common/utilscmn.cpp:1077
+#: ../src/common/utilscmn.cpp:1095
 msgid "No default application configured for HTML files."
 msgstr "S’ka aplikacion parazgjedhje të formësuar për kartela HTML."
 
-#: ../src/generic/helpext.cpp:445
+#: ../src/generic/helpext.cpp:443
 msgid "No entries found."
 msgstr "S’u gjetën zëra."
 
-#: ../src/common/fontmap.cpp:421
+#: ../src/common/fontmap.cpp:418
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found,\n"
@@ -5094,7 +5234,7 @@ msgstr ""
 "por është i passhëm një kodim alternativ '%s'.\n"
 "Doni të përdoret ky kodim (përndryshe do t’ju duhet të zgjidhni një tjetër)?"
 
-#: ../src/common/fontmap.cpp:426
+#: ../src/common/fontmap.cpp:423
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found.\n"
@@ -5106,201 +5246,201 @@ msgstr ""
 "kodim\n"
 "(përndryshe teksti me këtë kodim s’do të shfaqet si duhet)?"
 
-#: ../src/generic/animateg.cpp:142
+#: ../src/generic/animateg.cpp:125
 msgid "No handler found for animation type."
 msgstr "S’u gjet trajtues për llojin e animacionit."
 
-#: ../src/common/image.cpp:2728
+#: ../src/common/image.cpp:2823
 msgid "No handler found for image type."
 msgstr "S’u gjet trajtues për llojin e figurave."
 
-#: ../src/common/image.cpp:2736 ../src/common/image.cpp:2848
-#: ../src/common/image.cpp:2901
+#: ../src/common/image.cpp:2831 ../src/common/image.cpp:2954
+#: ../src/common/image.cpp:3020
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "S’është përcaktuar trajtues figurash për llojin %d."
 
-#: ../src/common/image.cpp:2871 ../src/common/image.cpp:2915
+#: ../src/common/image.cpp:2986 ../src/common/image.cpp:3034
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "S’është përcaktuar trajtues figurash për llojin %s."
 
-#: ../src/html/helpwnd.cpp:858
+#: ../src/html/helpwnd.cpp:856
 msgid "No matching page found yet"
 msgstr "Ende s’u gjet faqe me përputhje"
 
-#: ../src/unix/sound.cpp:81
+#: ../src/unix/sound.cpp:78
 msgid "No sound"
 msgstr "Pa zë"
 
-#: ../src/common/image.cpp:2277 ../src/common/image.cpp:2318
+#: ../src/common/image.cpp:2371 ../src/common/image.cpp:2412
 msgid "No unused colour in image being masked."
 msgstr "Pa maskim ngjyre të papërdorur në figurë."
 
-#: ../src/common/image.cpp:3374
-msgid "No unused colour in image."
-msgstr "Pa ngjyrë të papërdorur në figurë."
-
-#: ../src/generic/helpext.cpp:302
+#: ../src/generic/helpext.cpp:300
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "S’u gjetën përshoqërime të vlefshme te kartela \"%s\"."
 
-#: ../src/richtext/richtextborderspage.cpp:610
 #: ../src/richtext/richtextsizepage.cpp:248
 #: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:610
 msgid "None"
 msgstr "Asnjë"
 
-#: ../src/common/fmapbase.cpp:157
+#: ../src/common/fmapbase.cpp:154
 msgid "Nordic (ISO-8859-10)"
 msgstr "Nordike (ISO-8859-10)"
 
-#: ../src/generic/fontdlgg.cpp:328 ../src/generic/fontdlgg.cpp:331
+#: ../src/generic/fontdlgg.cpp:324 ../src/generic/fontdlgg.cpp:327
 msgid "Normal"
 msgstr "Normale"
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1261
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Normale<br>dhe <u>të nënvijëzuara</u>. "
 
-#: ../src/html/helpwnd.cpp:1205
+#: ../src/html/helpwnd.cpp:1203
 msgid "Normal font:"
 msgstr "Shkronja normale:"
 
-#: ../src/propgrid/props.cpp:1128
+#: ../src/propgrid/props.cpp:1115
 #, c-format
 msgid "Not %s"
 msgstr "Jo %s"
 
-#: ../include/wx/filename.h:573 ../include/wx/filename.h:578
-msgid "Not available"
-msgstr "S’ka"
+#: ../src/common/secretstore.cpp:168
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/webrequest.cpp:605
+msgid "Not enough free disk space for download."
+msgstr ""
 
 #: ../src/richtext/richtextfontpage.cpp:358
 msgid "Not underlined"
 msgstr "Jo të nënvijëzuara"
 
-#: ../src/common/paper.cpp:115
+#: ../src/common/paper.cpp:112
 msgid "Note, 8 1/2 x 11 in"
 msgstr "Shënim, 8 1/2 x 11 inç"
 
-#: ../src/generic/notifmsgg.cpp:132
+#: ../src/generic/notifmsgg.cpp:129
 msgid "Notice"
 msgstr "Shënim"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "Num *"
 msgstr "Num *"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "Num +"
 msgstr "Num +"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "Num ,"
 msgstr "Num ,"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "Num -"
 msgstr "Num -"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "Num ."
 msgstr "Num ."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "Num /"
 msgstr "Num /"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "Num ="
 msgstr "Num ="
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "Num Begin"
 msgstr "Num Begin"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 msgid "Num Delete"
 msgstr "Num Delete"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 msgid "Num Down"
 msgstr "Num Down"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "Num End"
 msgstr "Num End"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "Num Enter"
 msgstr "Num Enter"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 msgid "Num Home"
 msgstr "Num Home"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 msgid "Num Insert"
 msgstr "Num Insert"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num Lock"
 msgstr "Num Lock"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "Num Page Down"
 msgstr "Num Page Down"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "Num Page Up"
 msgstr "Num Page Up"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 msgid "Num Right"
 msgstr "Num Right"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "Num Space"
 msgstr "Num Space"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "Num Tab"
 msgstr "Num Tab"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "Num Up"
 msgstr "Num Up"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "Num left"
 msgstr "Num left"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num_lock"
 msgstr "Num_lock"
 
@@ -5309,13 +5449,13 @@ msgstr "Num_lock"
 msgid "Numbered outline"
 msgstr ""
 
-#: ../include/wx/msgdlg.h:278 ../src/richtext/richtextstyledlg.cpp:297
-#: ../src/common/stockitem.cpp:178 ../src/msw/msgdlg.cpp:454
-#: ../src/msw/msgdlg.cpp:747 ../src/gtk1/fontdlg.cpp:138
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:175
+#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/msgdlg.cpp:741 ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "OK"
 
-#: ../src/msw/ole/automtn.cpp:692
+#: ../src/msw/ole/automtn.cpp:683
 #, c-format
 msgid "OLE Automation error in %s: %s"
 msgstr "Gabim Automatizimi OLE te %s: %s"
@@ -5324,15 +5464,15 @@ msgstr "Gabim Automatizimi OLE te %s: %s"
 msgid "Object Properties"
 msgstr "Veti Objekti"
 
-#: ../src/msw/ole/automtn.cpp:660
+#: ../src/msw/ole/automtn.cpp:651
 msgid "Object implementation does not support named arguments."
 msgstr "Sendërtimi i objektit nuk mbulon argumente të emërtuar."
 
-#: ../src/common/xtixml.cpp:264
+#: ../src/common/xtixml.cpp:260
 msgid "Objects must have an id attribute"
 msgstr "Objektet duhet të kenë një atribut id"
 
-#: ../src/propgrid/advprops.cpp:1601
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Olive"
 msgstr "Ulli"
 
@@ -5340,64 +5480,69 @@ msgstr "Ulli"
 msgid "Opaci&ty:"
 msgstr "Pa&tejdukshmëri:"
 
-#: ../src/generic/colrdlgg.cpp:354
+#: ../src/generic/colrdlgg.cpp:374
 msgid "Opacity:"
 msgstr "Patejdukshmëri:"
 
-#: ../src/common/docview.cpp:1773 ../src/common/docview.cpp:1815
+#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
 msgid "Open File"
 msgstr "Hap Kartelë"
 
-#: ../src/html/helpwnd.cpp:671 ../src/html/helpwnd.cpp:1554
+#: ../src/html/helpwnd.cpp:669 ../src/html/helpwnd.cpp:1552
 msgid "Open HTML document"
 msgstr "Hap dokument HTML"
 
-#: ../src/generic/dbgrptg.cpp:163
+#: ../src/common/stockitem.cpp:265
+#, fuzzy
+msgid "Open an existing document"
+msgstr "Hap dokument HTML"
+
+#: ../src/generic/dbgrptg.cpp:160
 #, c-format
 msgid "Open file \"%s\""
 msgstr "Hap kartelë \"%s\""
 
-#: ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176
 msgid "Open..."
 msgstr "Hapni…"
 
-#: ../src/unix/glx11.cpp:506 ../src/msw/glcanvas.cpp:592
+#: ../src/msw/glcanvas.cpp:607 ../src/unix/glx11.cpp:513
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr "OpenGL 3.0 ose i mëvonshëm nuk mbulohet nga përudhësi OpenGL."
 
-#: ../src/generic/dirctrlg.cpp:599 ../src/generic/dirdlgg.cpp:323
-#: ../src/generic/filectrlg.cpp:642 ../src/generic/filectrlg.cpp:786
+#: ../src/generic/dirctrlg.cpp:565 ../src/generic/filectrlg.cpp:638
+#: ../src/generic/filectrlg.cpp:782 ../src/generic/dirdlgg.cpp:320
 msgid "Operation not permitted."
 msgstr "Veprim i palejuar."
 
-#: ../src/common/cmdline.cpp:900
+#: ../src/common/cmdline.cpp:896
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "Mundësia '%s' s’mund të mohohet"
 
-#: ../src/common/cmdline.cpp:1064
+#: ../src/common/cmdline.cpp:1060
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "Mundësia '%s' lyp një vlerë."
 
-#: ../src/common/cmdline.cpp:1147
+#: ../src/common/cmdline.cpp:1143
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Mundësi '%s': '%s' s’mund të shndërrohet në datë."
 
-#: ../src/generic/prntdlgg.cpp:618
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Mundësi"
 
-#: ../src/propgrid/advprops.cpp:1606
+#: ../src/propgrid/advprops.cpp:1512
 msgid "Orange"
 msgstr "Portokalli"
 
-#: ../src/generic/prntdlgg.cpp:615 ../src/generic/prntdlgg.cpp:869
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:862
 msgid "Orientation"
 msgstr "Drejtim"
 
-#: ../src/common/windowid.cpp:242
+#: ../src/common/windowid.cpp:237
 msgid "Out of window IDs.  Recommend shutting down application."
 msgstr "Mbaruan ID-të e dritareve.  Këshillohet mbyllja e aplikacionit."
 
@@ -5410,148 +5555,148 @@ msgstr ""
 msgid "Outset"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:656
+#: ../src/msw/ole/automtn.cpp:647
 msgid "Overflow while coercing argument values."
 msgstr ""
 
-#: ../src/common/imagpcx.cpp:457 ../src/common/imagpcx.cpp:480
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:479
 msgid "PCX: couldn't allocate memory"
 msgstr "BMP: s’u sigurua dot kujtesë"
 
-#: ../src/common/imagpcx.cpp:456
+#: ../src/common/imagpcx.cpp:455
 msgid "PCX: image format unsupported"
 msgstr "PCX: format i pambuluar figurash"
 
-#: ../src/common/imagpcx.cpp:479
+#: ../src/common/imagpcx.cpp:478
 msgid "PCX: invalid image"
 msgstr "PCX: figurë e pavlefshme"
 
-#: ../src/common/imagpcx.cpp:442
+#: ../src/common/imagpcx.cpp:441
 msgid "PCX: this is not a PCX file."
 msgstr "PCX: kjo s’është kartelë PCX."
 
-#: ../src/common/imagpcx.cpp:459 ../src/common/imagpcx.cpp:481
+#: ../src/common/imagpcx.cpp:458 ../src/common/imagpcx.cpp:480
 msgid "PCX: unknown error !!!"
 msgstr "PCX: gabim i panjohur!!!"
 
-#: ../src/common/imagpcx.cpp:458
+#: ../src/common/imagpcx.cpp:457
 msgid "PCX: version number too low"
 msgstr "PCX: numër versioni shumë i vogël"
 
-#: ../src/common/imagpnm.cpp:91
+#: ../src/common/imagpnm.cpp:89
 msgid "PNM: Couldn't allocate memory."
 msgstr "BMP: S’u sigurua dot kujtesë."
 
-#: ../src/common/imagpnm.cpp:73
+#: ../src/common/imagpnm.cpp:71
 msgid "PNM: File format is not recognized."
 msgstr "PNM: Format kartele i papranuar."
 
-#: ../src/common/imagpnm.cpp:112 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
 #: ../src/common/imagpnm.cpp:156
 msgid "PNM: File seems truncated."
 msgstr "PNM: Kartela duket si e cunguar."
 
-#: ../src/common/paper.cpp:187
+#: ../src/common/paper.cpp:184
 msgid "PRC 16K 146 x 215 mm"
 msgstr "PRC 16K 146 x 215 mm"
 
-#: ../src/common/paper.cpp:200
+#: ../src/common/paper.cpp:197
 msgid "PRC 16K Rotated"
 msgstr "PRC 16K e Rrotulluar"
 
-#: ../src/common/paper.cpp:188
+#: ../src/common/paper.cpp:185
 msgid "PRC 32K 97 x 151 mm"
 msgstr "PRC 32K 97 x 151 mm"
 
-#: ../src/common/paper.cpp:201
+#: ../src/common/paper.cpp:198
 msgid "PRC 32K Rotated"
 msgstr "PRC 32K e Rrotulluar"
 
-#: ../src/common/paper.cpp:189
+#: ../src/common/paper.cpp:186
 msgid "PRC 32K(Big) 97 x 151 mm"
 msgstr "PRC 32K(e Madhe) 97 x 151 mm"
 
-#: ../src/common/paper.cpp:202
+#: ../src/common/paper.cpp:199
 msgid "PRC 32K(Big) Rotated"
 msgstr "PRC 32K(e Madhe) e Rrotulluar"
 
-#: ../src/common/paper.cpp:190
+#: ../src/common/paper.cpp:187
 msgid "PRC Envelope #1 102 x 165 mm"
 msgstr "Zarf PRC #1 102 x 165 mm"
 
-#: ../src/common/paper.cpp:203
+#: ../src/common/paper.cpp:200
 msgid "PRC Envelope #1 Rotated 165 x 102 mm"
 msgstr "Zarf PRC #1 i Rrotulluar 165 x 102 mm"
 
-#: ../src/common/paper.cpp:199
+#: ../src/common/paper.cpp:196
 msgid "PRC Envelope #10 324 x 458 mm"
 msgstr "Zarf PRC #10 324 x 458 mm"
 
-#: ../src/common/paper.cpp:212
+#: ../src/common/paper.cpp:209
 msgid "PRC Envelope #10 Rotated 458 x 324 mm"
 msgstr "Zarf PRC #10 i Rrotulluar 458 x 324 mm"
 
-#: ../src/common/paper.cpp:191
+#: ../src/common/paper.cpp:188
 msgid "PRC Envelope #2 102 x 176 mm"
 msgstr "Zarf PRC #2 102 x 176 mm"
 
-#: ../src/common/paper.cpp:204
+#: ../src/common/paper.cpp:201
 msgid "PRC Envelope #2 Rotated 176 x 102 mm"
 msgstr "Zarf PRC #2 i Rrotulluar 176 x 102 mm"
 
-#: ../src/common/paper.cpp:192
+#: ../src/common/paper.cpp:189
 msgid "PRC Envelope #3 125 x 176 mm"
 msgstr "Zarf PRC #3 125 x 176 mm"
 
-#: ../src/common/paper.cpp:205
+#: ../src/common/paper.cpp:202
 msgid "PRC Envelope #3 Rotated 176 x 125 mm"
 msgstr "Zarf PRC #3 i Rrotulluar 176 x 125 mm"
 
-#: ../src/common/paper.cpp:193
+#: ../src/common/paper.cpp:190
 msgid "PRC Envelope #4 110 x 208 mm"
 msgstr "Zarf PRC #4 110 x 208 mm"
 
-#: ../src/common/paper.cpp:206
+#: ../src/common/paper.cpp:203
 msgid "PRC Envelope #4 Rotated 208 x 110 mm"
 msgstr "Zarf PRC #4 i Rrotulluar 208 x 110 mm"
 
-#: ../src/common/paper.cpp:194
+#: ../src/common/paper.cpp:191
 msgid "PRC Envelope #5 110 x 220 mm"
 msgstr "Zarf PRC #5 110 x 220 mm"
 
-#: ../src/common/paper.cpp:207
+#: ../src/common/paper.cpp:204
 msgid "PRC Envelope #5 Rotated 220 x 110 mm"
 msgstr "Zarf PRC #5 i Rrotulluar 220 x 110 mm"
 
-#: ../src/common/paper.cpp:195
+#: ../src/common/paper.cpp:192
 msgid "PRC Envelope #6 120 x 230 mm"
 msgstr "Zarf PRC #6 120 x 230 mm"
 
-#: ../src/common/paper.cpp:208
+#: ../src/common/paper.cpp:205
 msgid "PRC Envelope #6 Rotated 230 x 120 mm"
 msgstr "Zarf PRC #6 i Rrotulluar 230 x 120 mm"
 
-#: ../src/common/paper.cpp:196
+#: ../src/common/paper.cpp:193
 msgid "PRC Envelope #7 160 x 230 mm"
 msgstr "Zarf PRC #7 160 x 230 mm"
 
-#: ../src/common/paper.cpp:209
+#: ../src/common/paper.cpp:206
 msgid "PRC Envelope #7 Rotated 230 x 160 mm"
 msgstr "Zarf PRC #7 i Rrotulluar 230 x 160 mm"
 
-#: ../src/common/paper.cpp:197
+#: ../src/common/paper.cpp:194
 msgid "PRC Envelope #8 120 x 309 mm"
 msgstr "Zarf PRC #8 120 x 309 mm"
 
-#: ../src/common/paper.cpp:210
+#: ../src/common/paper.cpp:207
 msgid "PRC Envelope #8 Rotated 309 x 120 mm"
 msgstr "Zarf PRC #8 i Rrotulluar 309 x 120 mm"
 
-#: ../src/common/paper.cpp:198
+#: ../src/common/paper.cpp:195
 msgid "PRC Envelope #9 229 x 324 mm"
 msgstr "Zarf PRC #9 229 x 324 mm"
 
-#: ../src/common/paper.cpp:211
+#: ../src/common/paper.cpp:208
 msgid "PRC Envelope #9 Rotated 324 x 229 mm"
 msgstr "Zarf PRC #9 i Rrotulluar 324 x 229 mm"
 
@@ -5559,87 +5704,91 @@ msgstr "Zarf PRC #9 i Rrotulluar 324 x 229 mm"
 msgid "Padding"
 msgstr "Mbushje"
 
-#: ../src/common/prntbase.cpp:2074
+#: ../src/common/prntbase.cpp:2096
 #, c-format
 msgid "Page %d"
 msgstr "Faqe %d"
 
-#: ../src/common/prntbase.cpp:2072
+#: ../src/common/prntbase.cpp:2094
 #, c-format
 msgid "Page %d of %d"
 msgstr "Faqe %d nga %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 msgid "Page Down"
 msgstr "Tasti Page Down"
 
-#: ../src/gtk/print.cpp:826
+#: ../src/gtk/print.cpp:829
 msgid "Page Setup"
 msgstr "Rregullim Faqeje"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 msgid "Page Up"
 msgstr "Tasti Page Up"
 
-#: ../src/generic/prntdlgg.cpp:828 ../src/common/prntbase.cpp:484
+#: ../src/common/prntbase.cpp:479 ../src/generic/prntdlgg.cpp:821
 msgid "Page setup"
 msgstr "Rregullim faqeje"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 msgid "PageDown"
 msgstr "Tasti PageDown"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 msgid "PageUp"
 msgstr "Tasti PageUp"
 
-#: ../src/generic/prntdlgg.cpp:216
+#: ../src/generic/prntdlgg.cpp:209
 msgid "Pages"
 msgstr "Faqe"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1765
+#: ../src/propgrid/advprops.cpp:1666
 msgid "Paint Brush"
 msgstr "Penel"
 
-#: ../src/generic/prntdlgg.cpp:602 ../src/generic/prntdlgg.cpp:801
-#: ../src/generic/prntdlgg.cpp:842 ../src/generic/prntdlgg.cpp:855
-#: ../src/generic/prntdlgg.cpp:1052 ../src/generic/prntdlgg.cpp:1057
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:794
+#: ../src/generic/prntdlgg.cpp:835 ../src/generic/prntdlgg.cpp:848
+#: ../src/generic/prntdlgg.cpp:1045 ../src/generic/prntdlgg.cpp:1050
 msgid "Paper size"
 msgstr "Madhësi letre"
 
-#: ../src/richtext/richtextstyles.cpp:1062
+#: ../src/richtext/richtextstyles.cpp:1059
 msgid "Paragraph styles"
 msgstr "Stile paragrafi"
 
-#: ../src/common/xtistrm.cpp:465
+#: ../src/common/xtistrm.cpp:462
 msgid "Passing a already registered object to SetObject"
 msgstr "SetObject-it po i kalohet një objekt tashmë të regjistruar"
 
-#: ../src/common/xtistrm.cpp:476
+#: ../src/common/xtistrm.cpp:473
 msgid "Passing an unknown object to GetObject"
 msgstr "GetObject-it po i kalohet një objekt i panjohur"
 
-#: ../src/richtext/richtextctrl.cpp:3513 ../src/common/stockitem.cpp:180
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:177 ../src/richtext/richtextctrl.cpp:3514
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Ngjitje"
 
-#: ../src/common/stockitem.cpp:262
+#: ../src/common/stockitem.cpp:260
 msgid "Paste selection"
 msgstr "Ngjite përzgjedhjen"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:74
+#: ../src/common/accelcmn.cpp:71
 msgid "Pause"
 msgstr "Pushim"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1766
+#: ../src/propgrid/advprops.cpp:1667
 msgid "Pencil"
 msgstr "Laps"
 
@@ -5648,21 +5797,21 @@ msgstr "Laps"
 msgid "Peri&od"
 msgstr "Peri&udhë"
 
-#: ../src/generic/filectrlg.cpp:430
+#: ../src/generic/filectrlg.cpp:426
 msgid "Permissions"
 msgstr "Leje"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:60
+#: ../src/common/accelcmn.cpp:57
 msgid "PgDn"
 msgstr "PgDn"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:59
+#: ../src/common/accelcmn.cpp:56
 msgid "PgUp"
 msgstr "PgUp"
 
-#: ../src/richtext/richtextbuffer.cpp:12868
+#: ../src/richtext/richtextbuffer.cpp:12863
 msgid "Picture Properties"
 msgstr "Veti Fotoje"
 
@@ -5674,43 +5823,43 @@ msgstr "Dështoi krijimi i kanalit"
 msgid "Please choose a valid font."
 msgstr "Ju lutemi, zgjidhni shkronja të vlefshme."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
 msgid "Please choose an existing file."
 msgstr "Ju lutem, zgjidhni një kartelë ekzistuese."
 
-#: ../src/html/helpwnd.cpp:800
+#: ../src/html/helpwnd.cpp:798
 msgid "Please choose the page to display:"
 msgstr "Ju lutemi, zgjidhni faqen për shfaqje:"
 
-#: ../src/msw/dialup.cpp:764
+#: ../src/msw/dialup.cpp:758
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Ju lutemi, zgjidhni te cili ISP doni të lidheni"
 
-#: ../src/common/headerctrlcmn.cpp:59
+#: ../src/common/headerctrlcmn.cpp:57
 msgid "Please select the columns to show and define their order:"
 msgstr ""
 "Ju lutemi, përzgjidhni shtyllat për shfaqje dhe përcaktoni renditjen e tyre:"
 
-#: ../src/common/prntbase.cpp:538
+#: ../src/common/prntbase.cpp:533
 msgid "Please wait while printing..."
 msgstr "Ju lutemi, prisni, teksa shtypet…"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1767
+#: ../src/propgrid/advprops.cpp:1668
 msgid "Point Left"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1768
+#: ../src/propgrid/advprops.cpp:1669
 msgid "Point Right"
 msgstr ""
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:662
+#: ../src/propgrid/advprops.cpp:572
 msgid "Point Size"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:612 ../src/generic/prntdlgg.cpp:867
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:860
 msgid "Portrait"
 msgstr "Portret"
 
@@ -5718,150 +5867,159 @@ msgstr "Portret"
 msgid "Position"
 msgstr "Pozicion"
 
-#: ../src/generic/prntdlgg.cpp:298
+#: ../src/generic/prntdlgg.cpp:291
 msgid "PostScript file"
 msgstr "Kartelë PostScript"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178 ../src/osx/cocoa/preferences.mm:303
 msgid "Preferences"
 msgstr "Parapëlqime"
 
-#: ../src/osx/menu_osx.cpp:568
+#: ../src/osx/menu_osx.cpp:460
 msgid "Preferences..."
 msgstr "Parapëlqime…"
 
-#: ../src/common/prntbase.cpp:546
+#: ../src/common/prntbase.cpp:541
 msgid "Preparing"
 msgstr "Po përgatitet"
 
-#: ../src/generic/fontdlgg.cpp:455 ../src/osx/carbon/fontdlg.cpp:390
-#: ../src/html/helpwnd.cpp:1222
+#: ../src/osx/carbon/fontdlg.cpp:387 ../src/generic/fontdlgg.cpp:452
+#: ../src/html/helpwnd.cpp:1220
 msgid "Preview:"
 msgstr "Paraparje:"
 
-#: ../src/common/prntbase.cpp:1553 ../src/html/helpwnd.cpp:664
+#: ../src/common/prntbase.cpp:1578 ../src/html/helpwnd.cpp:662
 msgid "Previous page"
 msgstr "Faqja e mëparshme"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/prntdlgg.cpp:143 ../src/generic/prntdlgg.cpp:157
-#: ../src/common/prntbase.cpp:426 ../src/common/prntbase.cpp:1541
-#: ../src/common/accelcmn.cpp:77 ../src/gtk/print.cpp:620
-#: ../src/gtk/print.cpp:638
+#: ../src/common/prntbase.cpp:421 ../src/common/prntbase.cpp:1566
+#: ../src/common/accelcmn.cpp:74 ../src/generic/prntdlgg.cpp:136
+#: ../src/generic/prntdlgg.cpp:150 ../src/gtk/print.cpp:616
+#: ../src/gtk/print.cpp:634
 msgid "Print"
 msgstr "Shtyp"
 
-#: ../include/wx/prntbase.h:399 ../src/common/docview.cpp:1268
+#: ../src/common/docview.cpp:1262
 msgid "Print Preview"
 msgstr "Paraparje Shtypjeje"
 
-#: ../src/common/prntbase.cpp:2015 ../src/common/prntbase.cpp:2057
-#: ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2037 ../src/common/prntbase.cpp:2079
+#: ../src/common/prntbase.cpp:2087
 msgid "Print Preview Failure"
 msgstr "Dështim Paraparje Shtypjeje"
 
-#: ../src/generic/prntdlgg.cpp:224
+#: ../src/generic/prntdlgg.cpp:217
 msgid "Print Range"
 msgstr "Interval Shtypjeje"
 
-#: ../src/generic/prntdlgg.cpp:449
+#: ../src/generic/prntdlgg.cpp:442
 msgid "Print Setup"
 msgstr "Rregullim Shtypjeje"
 
-#: ../src/generic/prntdlgg.cpp:621
+#: ../src/generic/prntdlgg.cpp:614
 msgid "Print in colour"
 msgstr "Shtyp me ngjyra"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/osx/webview_webkit.mm:260
+msgid "Print operation could not be initialized"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:179
 msgid "Print previe&w..."
 msgstr "Par&aparje shtypjeje…"
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1256
 msgid "Print preview creation failed."
 msgstr "Krijimi i paraparjes së shtypjes dështoi."
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/common/stockitem.cpp:179
 msgid "Print preview..."
 msgstr "Paraparje shtypjeje…"
 
-#: ../src/generic/prntdlgg.cpp:630
+#: ../src/generic/prntdlgg.cpp:623
 msgid "Print spooling"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:675
+#: ../src/html/helpwnd.cpp:673
 msgid "Print this page"
 msgstr "Shtyp këtë faqe"
 
-#: ../src/generic/prntdlgg.cpp:185
+#: ../src/generic/prntdlgg.cpp:178
 msgid "Print to File"
 msgstr "Shtype në Kartelë"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "Print..."
 msgstr "Shtypni…"
 
-#: ../src/generic/prntdlgg.cpp:493
+#: ../src/generic/prntdlgg.cpp:486
 msgid "Printer"
 msgstr "Shtypës"
 
-#: ../src/generic/prntdlgg.cpp:633
+#: ../src/generic/prntdlgg.cpp:626
 msgid "Printer command:"
 msgstr "Urdhër shtypësi:"
 
-#: ../src/generic/prntdlgg.cpp:180
+#: ../src/generic/prntdlgg.cpp:173
 msgid "Printer options"
 msgstr "Mundësi shtypësi"
 
-#: ../src/generic/prntdlgg.cpp:645
+#: ../src/generic/prntdlgg.cpp:638
 msgid "Printer options:"
 msgstr "Mundësi shtypësi:"
 
-#: ../src/generic/prntdlgg.cpp:916
+#: ../src/generic/prntdlgg.cpp:909
 msgid "Printer..."
 msgstr "Shtypës…"
 
-#: ../src/generic/prntdlgg.cpp:196
+#: ../src/generic/prntdlgg.cpp:189
 msgid "Printer:"
 msgstr "Shtypës:"
 
-#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:535
-#: ../src/html/htmprint.cpp:277
+#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:530
+#: ../src/html/htmprint.cpp:289
 msgid "Printing"
 msgstr "Po shtypet"
 
-#: ../src/common/prntbase.cpp:612
+#: ../src/common/prntbase.cpp:607
 msgid "Printing "
 msgstr "Po shtypet "
 
-#: ../src/common/prntbase.cpp:347
+#: ../src/common/prntbase.cpp:342
 msgid "Printing Error"
 msgstr "Gabim Shtypjeje"
 
-#: ../src/common/prntbase.cpp:565
+#: ../src/osx/webview_webkit.mm:251
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "Gzip-i s’mbulohet nga ky version i zlib-it"
+
+#: ../src/common/prntbase.cpp:560
 #, c-format
 msgid "Printing page %d"
 msgstr "Po shtypet faqja %d"
 
-#: ../src/common/prntbase.cpp:570
+#: ../src/common/prntbase.cpp:565
 #, c-format
 msgid "Printing page %d of %d"
 msgstr "Po shtypet faqja %d nga %d"
 
-#: ../src/generic/printps.cpp:201
+#: ../src/generic/printps.cpp:182
 #, c-format
 msgid "Printing page %d..."
 msgstr "Po shtypet faqja %d…"
 
-#: ../src/generic/printps.cpp:161
+#: ../src/generic/printps.cpp:142
 msgid "Printing..."
 msgstr "Po shtypet…"
 
-#: ../include/wx/richtext/richtextprint.h:109 ../include/wx/prntbase.h:267
-#: ../src/common/docview.cpp:2132
+#: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
+#: ../src/common/docview.cpp:2137
 msgid "Printout"
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:560
+#: ../src/common/debugrpt.cpp:561
 #, c-format
 msgid ""
 "Processing debug report has failed, leaving the files in \"%s\" directory."
@@ -5869,102 +6027,102 @@ msgstr ""
 "Përpunimi i raportit të diagnostikimit dështoi, kartelat po lihen te "
 "drejtoria \"%s\"."
 
-#: ../src/common/prntbase.cpp:545
+#: ../src/common/prntbase.cpp:540
 msgid "Progress:"
 msgstr "Ecuri:"
 
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181
 msgid "Properties"
 msgstr "Veti"
 
-#: ../src/propgrid/manager.cpp:237
+#: ../src/propgrid/manager.cpp:223
 msgid "Property"
 msgstr "Veti"
 
 #. TRANSLATORS: Caption of message box displaying any property error
-#: ../src/propgrid/propgrid.cpp:3185 ../src/propgrid/propgrid.cpp:3318
+#: ../src/propgrid/propgrid.cpp:3162 ../src/propgrid/propgrid.cpp:3299
 msgid "Property Error"
 msgstr "Gabim Vetie"
 
-#: ../src/propgrid/advprops.cpp:1597
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Purple"
 msgstr "E purpurt"
 
-#: ../src/common/paper.cpp:112
+#: ../src/common/paper.cpp:109
 msgid "Quarto, 215 x 275 mm"
 msgstr "Quarto, 215 x 275 mm"
 
-#: ../src/generic/logg.cpp:1016
+#: ../src/generic/logg.cpp:1013
 msgid "Question"
 msgstr "Pyetje"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1769
+#: ../src/propgrid/advprops.cpp:1670
 msgid "Question Arrow"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "Quit"
 msgstr "Dilni"
 
-#: ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:477
 #, c-format
 msgid "Quit %s"
 msgstr "Mbylleni %s"
 
-#: ../src/common/stockitem.cpp:263
+#: ../src/common/stockitem.cpp:261
 msgid "Quit this program"
 msgstr "Dilni nga ky program"
 
-#: ../src/common/accelcmn.cpp:338
+#: ../src/common/accelcmn.cpp:352
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/ffile.cpp:109 ../src/common/ffile.cpp:133
+#: ../src/common/ffile.cpp:107 ../src/common/ffile.cpp:132
 #, c-format
 msgid "Read error on file '%s'"
 msgstr "Gabim leximi në kartelën '%s'"
 
-#: ../src/common/secretstore.cpp:199
-#, c-format
-msgid "Reading password for \"%s/%s\" failed: %s."
+#: ../src/common/secretstore.cpp:211
+#, fuzzy, c-format
+msgid "Reading password for \"%s\" failed: %s."
 msgstr "S’u arrit të lexohej fjalëkalimi për \"%s/%s\": %s."
 
-#: ../src/common/prntbase.cpp:272
+#: ../src/common/prntbase.cpp:267
 msgid "Ready"
 msgstr "Gati"
 
-#: ../src/propgrid/advprops.cpp:1605
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Red"
 msgstr "E kuqe"
 
-#: ../src/generic/colrdlgg.cpp:339
+#: ../src/generic/colrdlgg.cpp:359
 msgid "Red:"
 msgstr "E kuqe:"
 
-#: ../src/common/stockitem.cpp:185 ../src/stc/stc_i18n.cpp:16
+#: ../src/common/stockitem.cpp:182 ../src/stc/stc_i18n.cpp:16
 msgid "Redo"
 msgstr "Ribëje"
 
-#: ../src/common/stockitem.cpp:264
+#: ../src/common/stockitem.cpp:262
 msgid "Redo last action"
 msgstr "Ribëje veprimin e fundit"
 
-#: ../src/common/stockitem.cpp:186
+#: ../src/common/stockitem.cpp:183
 msgid "Refresh"
 msgstr "Rifreskoje"
 
-#: ../src/msw/registry.cpp:626
+#: ../src/msw/registry.cpp:615
 #, c-format
 msgid "Registry key '%s' already exists."
 msgstr "Ka tashmë një kyç '%s' regjistri."
 
-#: ../src/msw/registry.cpp:595
+#: ../src/msw/registry.cpp:584
 #, c-format
 msgid "Registry key '%s' does not exist, cannot rename it."
 msgstr "Kyçi '%s' i regjistrit s’ekziston, s’mund të riemërtohet."
 
-#: ../src/msw/registry.cpp:727
+#: ../src/msw/registry.cpp:716
 #, c-format
 msgid ""
 "Registry key '%s' is needed for normal system operation,\n"
@@ -5975,22 +6133,22 @@ msgstr ""
 "fshirja e tij do ta lërë sistemin tuaj në gjendje të paqëndrueshme:\n"
 "veprimi u ndërpre."
 
-#: ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:942
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr "Vlera e regjistrit \"%s\" s’është dyore (por e llojit %s)"
 
-#: ../src/msw/registry.cpp:917
+#: ../src/msw/registry.cpp:905
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr "Vlera e regjistrit \"%s\" s’është numerike (por e llojit %s)"
 
-#: ../src/msw/registry.cpp:1003
+#: ../src/msw/registry.cpp:991
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr "Vlera e regjistrit \"%s\" s’është tekst (por e llojit %s)"
 
-#: ../src/msw/registry.cpp:521
+#: ../src/msw/registry.cpp:510
 #, c-format
 msgid "Registry value '%s' already exists."
 msgstr "Ka tashmë një vlerë '%s' regjistri."
@@ -6004,71 +6162,77 @@ msgstr "Të rregullta"
 msgid "Relative"
 msgstr "Relative"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:456
 msgid "Relevant entries:"
 msgstr "Zëra me peshë:"
 
-#: ../include/wx/generic/progdlgg.h:86
+#: ../include/wx/generic/progdlgg.h:87
 msgid "Remaining time:"
 msgstr "Kohë e mbetur:"
 
-#: ../src/common/stockitem.cpp:187
+#: ../src/common/stockitem.cpp:184
 msgid "Remove"
 msgstr "Hiqe"
 
-#: ../src/richtext/richtextctrl.cpp:1562
+#: ../src/richtext/richtextctrl.cpp:1563
 msgid "Remove Bullet"
 msgstr "Hiqe Topthin"
 
-#: ../src/html/helpwnd.cpp:433
+#: ../src/html/helpwnd.cpp:431
 msgid "Remove current page from bookmarks"
 msgstr "Hiq prej faqerojtësish faqen e tanishme"
 
-#: ../src/common/rendcmn.cpp:194
+#: ../src/common/rendcmn.cpp:191
 #, c-format
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 "Vizatuesi \"%s\" ka version %d.%d të papërputhshëm dhe s’u ngarkua dot."
 
-#: ../src/richtext/richtextbuffer.cpp:4527
+#: ../src/richtext/richtextbuffer.cpp:4524
 msgid "Renumber List"
 msgstr "Rinumërto Listën"
 
-#: ../src/common/stockitem.cpp:188
-msgid "Rep&lace"
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Rep&lace..."
 msgstr "&Zëvendësoje"
 
-#: ../src/richtext/richtextctrl.cpp:3673 ../src/common/stockitem.cpp:188
+#: ../src/richtext/richtextctrl.cpp:3674
 msgid "Replace"
 msgstr "Zëvendësoje"
 
-#: ../src/generic/fdrepdlg.cpp:182
+#: ../src/generic/fdrepdlg.cpp:179
 msgid "Replace &all"
 msgstr "Zëvendësoji &krejt"
 
-#: ../src/common/stockitem.cpp:261
-msgid "Replace selection"
-msgstr "Zëvendëso përzgjedhjen"
-
-#: ../src/generic/fdrepdlg.cpp:124
+#: ../src/generic/fdrepdlg.cpp:121
 msgid "Replace with:"
 msgstr "Zëvendëso me:"
 
-#: ../src/common/valtext.cpp:163
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Replace..."
+msgstr "Zëvendësoje"
+
+#: ../src/common/valtext.cpp:184
 msgid "Required information entry is empty."
 msgstr "Zë i domosdoshëm informacioni është i zbrazët."
 
-#: ../src/common/translation.cpp:1975
+#: ../src/common/translation.cpp:2025
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "Burimi '%s' s’është katalog i vlefshëm mesazhesh."
 
+#: ../src/gtk/webview_webkit.cpp:985
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:56
+#: ../src/common/accelcmn.cpp:53
 msgid "Return"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:189
+#: ../src/common/stockitem.cpp:186
 msgid "Revert to Saved"
 msgstr "Riktheje tek i Ruajturi"
 
@@ -6080,41 +6244,41 @@ msgstr ""
 msgid "Rig&ht-to-left"
 msgstr "Nga-e-djat&hta-në-të-majtë"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6149
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:59 ../src/generic/datavgen.cpp:6954
+#: ../src/richtext/richtextsizepage.cpp:250
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextbulletspage.cpp:188
-#: ../src/richtext/richtextsizepage.cpp:250 ../src/common/accelcmn.cpp:62
 msgid "Right"
 msgstr "Djathtas"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1754
+#: ../src/propgrid/advprops.cpp:1655
 msgid "Right Arrow"
 msgstr "Tasti Shigjetë Djathtas"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1770
+#: ../src/propgrid/advprops.cpp:1671
 msgid "Right Button"
 msgstr "Butoni Djathtas"
 
-#: ../src/generic/prntdlgg.cpp:892
+#: ../src/generic/prntdlgg.cpp:885
 msgid "Right margin (mm):"
 msgstr "Mënjanë djathtas (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:148
-#: ../src/richtext/richtextindentspage.cpp:150
 #: ../src/richtext/richtextliststylepage.cpp:337
 #: ../src/richtext/richtextliststylepage.cpp:339
+#: ../src/richtext/richtextindentspage.cpp:148
+#: ../src/richtext/richtextindentspage.cpp:150
 msgid "Right-align text."
 msgstr "Vendose tekstin djathtas"
 
-#: ../src/generic/fontdlgg.cpp:322
+#: ../src/generic/fontdlgg.cpp:318
 msgid "Roman"
 msgstr "Roman"
 
-#: ../src/generic/datavgen.cpp:5916
+#: ../src/generic/datavgen.cpp:6721
 #, c-format
 msgid "Row %i"
 msgstr "Rreshti %i"
@@ -6124,30 +6288,31 @@ msgstr "Rreshti %i"
 msgid "S&tandard bullet name:"
 msgstr "Emër topthi &standard:"
 
-#: ../src/common/accelcmn.cpp:268 ../src/common/accelcmn.cpp:350
+#: ../src/common/accelcmn.cpp:282 ../src/common/accelcmn.cpp:367
 msgid "SPECIAL"
 msgstr "SPECIAL"
 
-#: ../src/common/stockitem.cpp:190 ../src/common/sizer.cpp:2797
+#: ../src/common/stockitem.cpp:187 ../src/common/sizer.cpp:2914
 msgid "Save"
 msgstr "Ruaje"
 
-#: ../src/common/fldlgcmn.cpp:342
+#: ../src/common/fldlgcmn.cpp:339
 #, c-format
 msgid "Save %s file"
 msgstr "Ruaje kartelën %s"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/common/stockitem.cpp:188 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Ruajeni &Si…"
 
-#: ../src/common/docview.cpp:366
+#: ../src/common/docview.cpp:359
 msgid "Save As"
 msgstr "Ruaje Si"
 
-#: ../src/common/stockitem.cpp:191
-msgid "Save as"
-msgstr "Ruajeni si"
+#: ../src/common/stockitem.cpp:188
+#, fuzzy
+msgid "Save As..."
+msgstr "Ruajeni &Si…"
 
 #: ../src/common/stockitem.cpp:267
 msgid "Save current document"
@@ -6157,40 +6322,40 @@ msgstr "Ruaj dokumentin e tanishëm"
 msgid "Save current document with a different filename"
 msgstr "Ruajeni dokumentin e tanishëm nën një tjetër emër kartele"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/generic/logg.cpp:509
 msgid "Save log contents to file"
 msgstr "Ruaj lëndë regjistrimi te kartelë"
 
-#: ../src/common/secretstore.cpp:179
-#, c-format
-msgid "Saving password for \"%s/%s\" failed: %s."
+#: ../src/common/secretstore.cpp:189
+#, fuzzy, c-format
+msgid "Saving password for \"%s\" failed: %s."
 msgstr "S\"u arrit të ruhej fjalëkalimi për \"%s/%s\": %s."
 
-#: ../src/generic/fontdlgg.cpp:325
+#: ../src/generic/fontdlgg.cpp:321
 msgid "Script"
 msgstr "Programth"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll Lock"
 msgstr "Tasti Scroll Lock"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll_lock"
 msgstr "Tasti Scroll_lock"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:890
+#: ../src/propgrid/advprops.cpp:791
 msgid "Scrollbar"
 msgstr "Rrëshqitës"
 
-#: ../src/generic/srchctlg.cpp:56 ../src/html/helpwnd.cpp:535
-#: ../src/html/helpwnd.cpp:550
+#: ../src/generic/srchctlg.cpp:55 ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:548 ../src/gtk/srchctrl.cpp:182
 msgid "Search"
 msgstr "Kërko"
 
-#: ../src/html/helpwnd.cpp:537
+#: ../src/html/helpwnd.cpp:535
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
@@ -6198,56 +6363,56 @@ msgstr ""
 "Kërko në lëndën e librit(ve) të ndihmës për krejt hasjet e tekstit që "
 "shtypët më sipër"
 
-#: ../src/generic/fdrepdlg.cpp:160
+#: ../src/generic/fdrepdlg.cpp:157
 msgid "Search direction"
 msgstr "Kah kërkimi"
 
-#: ../src/generic/fdrepdlg.cpp:112
+#: ../src/generic/fdrepdlg.cpp:109
 msgid "Search for:"
 msgstr "Kërko për:"
 
-#: ../src/html/helpwnd.cpp:1052
+#: ../src/html/helpwnd.cpp:1050
 msgid "Search in all books"
 msgstr "Kërko në tërë librat"
 
-#: ../src/html/helpwnd.cpp:857
+#: ../src/html/helpwnd.cpp:855
 msgid "Searching..."
 msgstr "Po kërkohet…"
 
-#: ../src/generic/dirctrlg.cpp:446
+#: ../src/generic/dirctrlg.cpp:412
 msgid "Sections"
 msgstr "Ndarje"
 
-#: ../src/common/ffile.cpp:238
+#: ../src/common/ffile.cpp:237
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Gabim kërkimi te kartela '%s'"
 
-#: ../src/common/ffile.cpp:228
+#: ../src/common/ffile.cpp:227
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
 "Gabim kërkimi te kartela '%s' (kartela të mëdha të pambuluara nga stdio)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:76
+#: ../src/common/accelcmn.cpp:73
 msgid "Select"
 msgstr "Përzgjidhe"
 
-#: ../src/richtext/richtextctrl.cpp:337 ../src/osx/textctrl_osx.cpp:581
-#: ../src/common/stockitem.cpp:192 ../src/msw/textctrl.cpp:2512
+#: ../src/osx/textctrl_osx.cpp:599 ../src/common/stockitem.cpp:189
+#: ../src/msw/textctrl.cpp:2777 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Përzgjidhni &Krejt"
 
-#: ../src/common/stockitem.cpp:192 ../src/stc/stc_i18n.cpp:21
+#: ../src/common/stockitem.cpp:189 ../src/stc/stc_i18n.cpp:21
 msgid "Select All"
 msgstr "Përzgjidhi Krejt"
 
-#: ../src/common/docview.cpp:1895
+#: ../src/common/docview.cpp:1900
 msgid "Select a document template"
 msgstr "Përzgjidhni një gjedhe dokumenti"
 
-#: ../src/common/docview.cpp:1969
+#: ../src/common/docview.cpp:1974
 msgid "Select a document view"
 msgstr "Përzgjidhni parje dokumenti"
 
@@ -6276,20 +6441,20 @@ msgid "Selects the list level to edit."
 msgstr "Përzgjedh shkallë liste për përpunim."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:82
+#: ../src/common/accelcmn.cpp:79
 msgid "Separator"
 msgstr "Ndarës"
 
-#: ../src/common/cmdline.cpp:1083
+#: ../src/common/cmdline.cpp:1079
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Pritej ndarës pas mundësisë '%s'."
 
-#: ../src/osx/menu_osx.cpp:572
+#: ../src/osx/menu_osx.cpp:464
 msgid "Services"
 msgstr "Shërbime"
 
-#: ../src/richtext/richtextbuffer.cpp:11217
+#: ../src/richtext/richtextbuffer.cpp:11216
 msgid "Set Cell Style"
 msgstr "Caktoni Stil Kutize"
 
@@ -6297,11 +6462,11 @@ msgstr "Caktoni Stil Kutize"
 msgid "SetProperty called w/o valid setter"
 msgstr "SetProperty u thirr pa marrës të vlefshëm"
 
-#: ../src/generic/prntdlgg.cpp:188
+#: ../src/generic/prntdlgg.cpp:181
 msgid "Setup..."
 msgstr "Rregullim…"
 
-#: ../src/msw/dialup.cpp:544
+#: ../src/msw/dialup.cpp:538
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr "U gjetën disa lidhje dialup vepruese, po zgjidhet një kuturu."
 
@@ -6317,40 +6482,40 @@ msgstr "Hije"
 msgid "Shadow c&olour:"
 msgstr "&Ngjyrë hijeje:"
 
-#: ../src/common/accelcmn.cpp:335
+#: ../src/common/accelcmn.cpp:349
 msgid "Shift+"
 msgstr "Shift+"
 
-#: ../src/generic/dirdlgg.cpp:147
+#: ../src/generic/dirdlgg.cpp:144
 msgid "Show &hidden directories"
 msgstr "Shfaq drejtori të &fshehura"
 
-#: ../src/generic/filectrlg.cpp:983
+#: ../src/generic/filectrlg.cpp:979
 msgid "Show &hidden files"
 msgstr "Shfaq kartela të &fshehura"
 
-#: ../src/osx/menu_osx.cpp:580
+#: ../src/osx/menu_osx.cpp:472
 msgid "Show All"
 msgstr "Shfaqi Krejt"
 
-#: ../src/common/stockitem.cpp:257
+#: ../src/common/stockitem.cpp:254
 msgid "Show about dialog"
 msgstr "Shfaq dialogun Rreth"
 
-#: ../src/html/helpwnd.cpp:492
+#: ../src/html/helpwnd.cpp:490
 msgid "Show all"
 msgstr "Shfaqi krejt"
 
-#: ../src/html/helpwnd.cpp:503
+#: ../src/html/helpwnd.cpp:501
 msgid "Show all items in index"
 msgstr "Shfaq tërë objektet në tregues"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:656
 msgid "Show/hide navigation panel"
 msgstr "Shfaq/fshih panel lëvizjeje"
 
-#: ../src/richtext/richtextsymboldlg.cpp:421
-#: ../src/richtext/richtextsymboldlg.cpp:423
+#: ../src/richtext/richtextsymboldlg.cpp:418
+#: ../src/richtext/richtextsymboldlg.cpp:420
 msgid "Shows a Unicode subset."
 msgstr "Shfaq një nëngrup Unikod."
 
@@ -6366,7 +6531,7 @@ msgstr "Shfaq një paraparje të rregullimeve të topthave."
 msgid "Shows a preview of the font settings."
 msgstr "Shfaq një paraparje të rregullimeve të shkronjave."
 
-#: ../src/osx/carbon/fontdlg.cpp:394 ../src/osx/carbon/fontdlg.cpp:396
+#: ../src/osx/carbon/fontdlg.cpp:391 ../src/osx/carbon/fontdlg.cpp:393
 msgid "Shows a preview of the font."
 msgstr "Shfaq një paraparje të shkronjave."
 
@@ -6375,62 +6540,62 @@ msgstr "Shfaq një paraparje të shkronjave."
 msgid "Shows a preview of the paragraph settings."
 msgstr "Shfaq një paraparje të rregullimeve të paragrafit."
 
-#: ../src/generic/fontdlgg.cpp:460 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:456 ../src/generic/fontdlgg.cpp:458
 msgid "Shows the font preview."
 msgstr "Shfaq paraparjen e shkronjave."
 
-#: ../src/propgrid/advprops.cpp:1607
+#: ../src/propgrid/advprops.cpp:1513
 msgid "Silver"
 msgstr "E argjendtë"
 
-#: ../src/univ/themes/mono.cpp:516
+#: ../src/univ/themes/mono.cpp:513
 msgid "Simple monochrome theme"
 msgstr "Temë e thjeshtë njëngjyrëshe"
 
-#: ../src/richtext/richtextindentspage.cpp:275
 #: ../src/richtext/richtextliststylepage.cpp:449
+#: ../src/richtext/richtextindentspage.cpp:275
 msgid "Single"
 msgstr "Njëshe"
 
-#: ../src/generic/filectrlg.cpp:425 ../src/richtext/richtextformatdlg.cpp:369
-#: ../src/richtext/richtextsizepage.cpp:299
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextsizepage.cpp:299
+#: ../src/richtext/richtextformatdlg.cpp:362
 msgid "Size"
 msgstr "Madhësi"
 
-#: ../src/osx/carbon/fontdlg.cpp:339
+#: ../src/osx/carbon/fontdlg.cpp:336
 msgid "Size:"
 msgstr "Madhësi:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1775
+#: ../src/propgrid/advprops.cpp:1676
 msgid "Sizing"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1772
+#: ../src/propgrid/advprops.cpp:1673
 msgid "Sizing N-S"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1771
+#: ../src/propgrid/advprops.cpp:1672
 msgid "Sizing NE-SW"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1773
+#: ../src/propgrid/advprops.cpp:1674
 msgid "Sizing NW-SE"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1774
+#: ../src/propgrid/advprops.cpp:1675
 msgid "Sizing W-E"
 msgstr ""
 
-#: ../src/msw/progdlg.cpp:801
+#: ../src/msw/progdlg.cpp:1088
 msgid "Skip"
 msgstr "Anashkaloje"
 
-#: ../src/generic/fontdlgg.cpp:330
+#: ../src/generic/fontdlgg.cpp:326
 msgid "Slant"
 msgstr ""
 
@@ -6439,7 +6604,7 @@ msgid "Small C&apitals"
 msgstr "K&apitale të Vogla"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:79
+#: ../src/common/accelcmn.cpp:76
 msgid "Snapshot"
 msgstr "Fotografim"
 
@@ -6447,37 +6612,37 @@ msgstr "Fotografim"
 msgid "Solid"
 msgstr ""
 
-#: ../src/common/docview.cpp:1791
+#: ../src/common/docview.cpp:1785
 msgid "Sorry, could not open this file."
 msgstr "Na ndjeni, s’u hap dot kjo kartelë."
 
-#: ../src/common/prntbase.cpp:2057 ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2079 ../src/common/prntbase.cpp:2087
 msgid "Sorry, not enough memory to create a preview."
 msgstr "Na ndjeni, s’ka kujtesë të mjaftueshme për krijim paraparjeje."
 
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "Sorry, that name is taken. Please choose another."
 msgstr "Na ndjeni, ky emër është i zënë. Ju lutemi, zgjidhni një tjetër."
 
-#: ../src/common/docview.cpp:1814
+#: ../src/common/docview.cpp:1819
 msgid "Sorry, the format for this file is unknown."
 msgstr "Na ndjeni, formati i kësaj kartele është i panjohur."
 
-#: ../src/unix/sound.cpp:492
+#: ../src/unix/sound.cpp:481
 msgid "Sound data are in unsupported format."
 msgstr "Të dhëna tingulli janë në format të pambuluar."
 
-#: ../src/unix/sound.cpp:477
+#: ../src/unix/sound.cpp:466
 #, c-format
 msgid "Sound file '%s' is in unsupported format."
 msgstr "Kartela zanore '%s' është e një formati të pambuluar."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:67
+#: ../src/common/accelcmn.cpp:64
 msgid "Space"
 msgstr "Hapësirë"
 
@@ -6485,12 +6650,12 @@ msgstr "Hapësirë"
 msgid "Spacing"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "Spell Check"
 msgstr "Kontroll Drejtshkrimi"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1776
+#: ../src/propgrid/advprops.cpp:1677
 msgid "Spraycan"
 msgstr ""
 
@@ -6499,7 +6664,7 @@ msgstr ""
 msgid "Standard"
 msgstr "Standarde"
 
-#: ../src/common/paper.cpp:104
+#: ../src/common/paper.cpp:101
 msgid "Statement, 5 1/2 x 8 1/2 in"
 msgstr "Deklaratë, 5 1/2 x 8 1/2 inç"
 
@@ -6508,33 +6673,29 @@ msgstr "Deklaratë, 5 1/2 x 8 1/2 inç"
 msgid "Static"
 msgstr "Statike"
 
-#: ../src/generic/prntdlgg.cpp:204
+#: ../src/generic/prntdlgg.cpp:197
 msgid "Status:"
 msgstr "Gjendje:"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "Stop"
 msgstr "Ndal"
 
-#: ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196
 msgid "Strikethrough"
 msgstr "Hequrvije"
 
-#: ../src/common/colourcmn.cpp:45
+#: ../src/common/colourcmn.cpp:42
 #, c-format
 msgid "String To Colour : Incorrect colour specification : %s"
 msgstr "Varg për Ngjyrë : Specifikim i pavlefshëm ngjyre : %s"
 
 #. TRANSLATORS: Label of font style
-#: ../src/richtext/richtextformatdlg.cpp:339 ../src/propgrid/advprops.cpp:680
+#: ../src/propgrid/advprops.cpp:590 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Stil"
 
-#: ../include/wx/richtext/richtextstyledlg.h:46
-msgid "Style Organiser"
-msgstr "Organizues Stilesh"
-
-#: ../src/osx/carbon/fontdlg.cpp:348
+#: ../src/osx/carbon/fontdlg.cpp:345
 msgid "Style:"
 msgstr "Stil:"
 
@@ -6543,7 +6704,7 @@ msgid "Subscrip&t"
 msgstr "P&oshtëshkrim"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:83
+#: ../src/common/accelcmn.cpp:80
 msgid "Subtract"
 msgstr ""
 
@@ -6551,11 +6712,11 @@ msgstr ""
 msgid "Supe&rscript"
 msgstr "S&ipërshkrim"
 
-#: ../src/common/paper.cpp:150
+#: ../src/common/paper.cpp:147
 msgid "SuperA/SuperA/A4 227 x 356 mm"
 msgstr "SuperA/SuperA/A4 227 x 356 mm"
 
-#: ../src/common/paper.cpp:151
+#: ../src/common/paper.cpp:148
 msgid "SuperB/SuperB/A3 305 x 487 mm"
 msgstr "SuperB/SuperB/A3 305 x 487 mm"
 
@@ -6563,7 +6724,7 @@ msgstr "SuperB/SuperB/A3 305 x 487 mm"
 msgid "Suppress hyphe&nation"
 msgstr "Ndale &ndarjen me vija"
 
-#: ../src/generic/fontdlgg.cpp:326
+#: ../src/generic/fontdlgg.cpp:322
 msgid "Swiss"
 msgstr "Zvicerane"
 
@@ -6581,73 +6742,73 @@ msgstr ""
 msgid "Symbols"
 msgstr "Simbole"
 
-#: ../src/common/imagtiff.cpp:369 ../src/common/imagtiff.cpp:382
-#: ../src/common/imagtiff.cpp:741
+#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
+#: ../src/common/imagtiff.cpp:738
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: S’u sigurua dot kujtesë."
 
-#: ../src/common/imagtiff.cpp:301
+#: ../src/common/imagtiff.cpp:298
 msgid "TIFF: Error loading image."
 msgstr "TIFF: Gabim në ngarkim figure."
 
-#: ../src/common/imagtiff.cpp:468
+#: ../src/common/imagtiff.cpp:465
 msgid "TIFF: Error reading image."
 msgstr "TIFF: Gabim në lexim figure."
 
-#: ../src/common/imagtiff.cpp:608
+#: ../src/common/imagtiff.cpp:605
 msgid "TIFF: Error saving image."
 msgstr "TIFF: Gabim në ruajtje figure."
 
-#: ../src/common/imagtiff.cpp:846
+#: ../src/common/imagtiff.cpp:843
 msgid "TIFF: Error writing image."
 msgstr "TIFF: Gabim në shkrim figure."
 
-#: ../src/common/imagtiff.cpp:355
+#: ../src/common/imagtiff.cpp:352
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: Madhësia e figurës është anormalisht e madhe."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:68
+#: ../src/common/accelcmn.cpp:65
 msgid "Tab"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11498
+#: ../src/richtext/richtextbuffer.cpp:11497
 msgid "Table Properties"
 msgstr "Veti Tabele"
 
-#: ../src/common/paper.cpp:145
+#: ../src/common/paper.cpp:142
 msgid "Tabloid Extra 11.69 x 18 in"
 msgstr "Tabloid Ekstra 11.69 x 18 in"
 
-#: ../src/common/paper.cpp:102
+#: ../src/common/paper.cpp:99
 msgid "Tabloid, 11 x 17 in"
 msgstr "Tabloid, 11 x 17 inç"
 
-#: ../src/richtext/richtextformatdlg.cpp:354
+#: ../src/richtext/richtextformatdlg.cpp:347
 msgid "Tabs"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1598
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Teal"
 msgstr "Blu e gjelbër"
 
-#: ../src/generic/fontdlgg.cpp:327
+#: ../src/generic/fontdlgg.cpp:323
 msgid "Teletype"
 msgstr "Teleshkrim"
 
-#: ../src/common/docview.cpp:1896
+#: ../src/common/docview.cpp:1901
 msgid "Templates"
 msgstr "Gjedhe"
 
-#: ../src/common/fmapbase.cpp:158
+#: ../src/common/fmapbase.cpp:155
 msgid "Thai (ISO-8859-11)"
 msgstr "Tai (ISO-8859-11)"
 
-#: ../src/common/ftp.cpp:619
+#: ../src/common/ftp.cpp:622
 msgid "The FTP server doesn't support passive mode."
 msgstr "Shërbyesi FTP s’mbulon mënyrë pasive."
 
-#: ../src/common/ftp.cpp:605
+#: ../src/common/ftp.cpp:608
 msgid "The FTP server doesn't support the PORT command."
 msgstr "Shërbyesi FTP s’mbulon urdhrin PORT."
 
@@ -6658,8 +6819,8 @@ msgstr "Shërbyesi FTP s’mbulon urdhrin PORT."
 msgid "The available bullet styles."
 msgstr "Stilet e gatshëm me toptha."
 
-#: ../src/richtext/richtextstyledlg.cpp:202
-#: ../src/richtext/richtextstyledlg.cpp:204
+#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:200
 msgid "The available styles."
 msgstr "Stilet e gatshëm."
 
@@ -6715,12 +6876,12 @@ msgstr "Pozicioni poshtë."
 msgid "The bullet character."
 msgstr "Shenja e topthit."
 
-#: ../src/richtext/richtextsymboldlg.cpp:443
-#: ../src/richtext/richtextsymboldlg.cpp:445
+#: ../src/richtext/richtextsymboldlg.cpp:440
+#: ../src/richtext/richtextsymboldlg.cpp:442
 msgid "The character code."
 msgstr "Kodi i shenjave."
 
-#: ../src/common/fontmap.cpp:203
+#: ../src/common/fontmap.cpp:200
 #, c-format
 msgid ""
 "The charset '%s' is unknown. You may select\n"
@@ -6731,7 +6892,7 @@ msgstr ""
 "të tjera për zëvendësim ose zgjidhni\n"
 "[Anuloje], nëse s’mund të zëvendësohen"
 
-#: ../src/msw/ole/dataobj.cpp:394
+#: ../src/msw/ole/dataobj.cpp:402
 #, c-format
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "Formati '%d' për të papastrën s’ekziston."
@@ -6741,7 +6902,7 @@ msgstr "Formati '%d' për të papastrën s’ekziston."
 msgid "The default style for the next paragraph."
 msgstr "Stili parazgjedhje për paragrafin pasues."
 
-#: ../src/generic/dirdlgg.cpp:202
+#: ../src/generic/dirdlgg.cpp:199
 #, c-format
 msgid ""
 "The directory '%s' does not exist\n"
@@ -6750,7 +6911,7 @@ msgstr ""
 "Drejtoria '%s' s’ekziston\n"
 "Të krijohet tani?"
 
-#: ../src/html/htmprint.cpp:271
+#: ../src/html/htmprint.cpp:283
 #, c-format
 msgid ""
 "The document \"%s\" doesn't fit on the page horizontally and will be "
@@ -6763,7 +6924,7 @@ msgstr ""
 "\n"
 "Do të doni të vazhdohet me shtypjen, sido që të jetë?"
 
-#: ../src/common/docview.cpp:1202
+#: ../src/common/docview.cpp:1196
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -6772,36 +6933,36 @@ msgstr ""
 "Kartela '%s' s’ekziston, ndaj s’mund të hapej.\n"
 "Është hequr nga lista e kartelave më të përdorura së fundi."
 
-#: ../src/richtext/richtextindentspage.cpp:208
-#: ../src/richtext/richtextindentspage.cpp:210
 #: ../src/richtext/richtextliststylepage.cpp:394
 #: ../src/richtext/richtextliststylepage.cpp:396
+#: ../src/richtext/richtextindentspage.cpp:208
+#: ../src/richtext/richtextindentspage.cpp:210
 msgid "The first line indent."
 msgstr "Shmangia brendazi e rreshtit të parë."
 
-#: ../src/gtk/utilsgtk.cpp:481
-msgid "The following standard GTK+ options are also supported:\n"
-msgstr "Mbulohen edhe mundësitë standarde GTK+ vijuese:\n"
+#: ../src/generic/dbgrptg.cpp:318
+msgid "The following debug report will be generated\n"
+msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:414 ../src/generic/fontdlgg.cpp:416
+#: ../src/generic/fontdlgg.cpp:411 ../src/generic/fontdlgg.cpp:413
 msgid "The font colour."
 msgstr "Ngjyra e shkronjave."
 
-#: ../src/generic/fontdlgg.cpp:375 ../src/generic/fontdlgg.cpp:377
+#: ../src/generic/fontdlgg.cpp:371 ../src/generic/fontdlgg.cpp:373
 msgid "The font family."
 msgstr "Familja e shkronjave."
 
-#: ../src/richtext/richtextsymboldlg.cpp:405
-#: ../src/richtext/richtextsymboldlg.cpp:407
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "The font from which to take the symbol."
 msgstr "Shkronjat prej nga të merret simboli."
 
-#: ../src/generic/fontdlgg.cpp:427 ../src/generic/fontdlgg.cpp:429
-#: ../src/generic/fontdlgg.cpp:434 ../src/generic/fontdlgg.cpp:436
+#: ../src/generic/fontdlgg.cpp:424 ../src/generic/fontdlgg.cpp:426
+#: ../src/generic/fontdlgg.cpp:430 ../src/generic/fontdlgg.cpp:432
 msgid "The font point size."
 msgstr "Madhësia e shkronjasve në pikë."
 
-#: ../src/osx/carbon/fontdlg.cpp:343 ../src/osx/carbon/fontdlg.cpp:345
+#: ../src/osx/carbon/fontdlg.cpp:340 ../src/osx/carbon/fontdlg.cpp:342
 msgid "The font size in points."
 msgstr "Madhësia e shkronjave në pikë."
 
@@ -6810,15 +6971,15 @@ msgstr "Madhësia e shkronjave në pikë."
 msgid "The font size units, points or pixels."
 msgstr "Njësitë e madhësisë së shkronjave, pikë ose piksel."
 
-#: ../src/generic/fontdlgg.cpp:386 ../src/generic/fontdlgg.cpp:388
+#: ../src/generic/fontdlgg.cpp:382 ../src/generic/fontdlgg.cpp:384
 msgid "The font style."
 msgstr "Stili i shkronjave."
 
-#: ../src/generic/fontdlgg.cpp:397 ../src/generic/fontdlgg.cpp:399
+#: ../src/generic/fontdlgg.cpp:393 ../src/generic/fontdlgg.cpp:395
 msgid "The font weight."
 msgstr "Lartësia e shkronjave."
 
-#: ../src/common/docview.cpp:1483
+#: ../src/common/docview.cpp:1477
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "S’u përcaktua dot formati i kartelës '%s'."
@@ -6828,10 +6989,10 @@ msgstr "S’u përcaktua dot formati i kartelës '%s'."
 msgid "The horizontal offset."
 msgstr "Shmangia horizontale."
 
-#: ../src/richtext/richtextindentspage.cpp:199
-#: ../src/richtext/richtextindentspage.cpp:201
 #: ../src/richtext/richtextliststylepage.cpp:385
 #: ../src/richtext/richtextliststylepage.cpp:387
+#: ../src/richtext/richtextindentspage.cpp:199
+#: ../src/richtext/richtextindentspage.cpp:201
 msgid "The left indent."
 msgstr "Shmangia brendazi majtas."
 
@@ -6852,10 +7013,10 @@ msgstr "Madhësia e mbushjes majtas."
 msgid "The left position."
 msgstr "Pozicioni majtas."
 
-#: ../src/richtext/richtextindentspage.cpp:288
-#: ../src/richtext/richtextindentspage.cpp:290
 #: ../src/richtext/richtextliststylepage.cpp:462
 #: ../src/richtext/richtextliststylepage.cpp:464
+#: ../src/richtext/richtextindentspage.cpp:288
+#: ../src/richtext/richtextindentspage.cpp:290
 msgid "The line spacing."
 msgstr "Hapësira mes rreshtash."
 
@@ -6864,7 +7025,7 @@ msgstr "Hapësira mes rreshtash."
 msgid "The list item number."
 msgstr "Numri i objektit në listë."
 
-#: ../src/msw/ole/automtn.cpp:664
+#: ../src/msw/ole/automtn.cpp:655
 msgid "The locale ID is unknown."
 msgstr "ID-ja e vendore është e panjohur."
 
@@ -6903,19 +7064,19 @@ msgstr "Gjerësia e objektit."
 msgid "The outline level."
 msgstr ""
 
-#: ../src/common/log.cpp:277
+#: ../src/common/log.cpp:296
 #, c-format
 msgid "The previous message repeated %u time."
 msgid_plural "The previous message repeated %u times."
 msgstr[0] "Mesazhi i mëparshëm u përsërit %u herë."
 msgstr[1] "Mesazhi i mëparshëm u përsërit %u herë."
 
-#: ../src/common/log.cpp:270
+#: ../src/common/log.cpp:289
 msgid "The previous message repeated once."
 msgstr "Mesazhi i mëparshëm u përsërit një herë."
 
-#: ../src/richtext/richtextsymboldlg.cpp:462
-#: ../src/richtext/richtextsymboldlg.cpp:464
+#: ../src/richtext/richtextsymboldlg.cpp:459
+#: ../src/richtext/richtextsymboldlg.cpp:461
 msgid "The range to show."
 msgstr "Intervali për shfaqje."
 
@@ -6929,15 +7090,15 @@ msgstr ""
 "përmban\n"
 "të dhëna private, ju lutemi, hiquani shenjën dhe do të hiqen prej raportit.\n"
 
-#: ../src/common/cmdline.cpp:1254
+#: ../src/common/cmdline.cpp:1250
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "S’është përcaktuar parametri i domosdoshëm '%s'."
 
-#: ../src/richtext/richtextindentspage.cpp:217
-#: ../src/richtext/richtextindentspage.cpp:219
 #: ../src/richtext/richtextliststylepage.cpp:403
 #: ../src/richtext/richtextliststylepage.cpp:405
+#: ../src/richtext/richtextindentspage.cpp:217
+#: ../src/richtext/richtextindentspage.cpp:219
 msgid "The right indent."
 msgstr "Shmangia brendazi djathtas."
 
@@ -6978,16 +7139,16 @@ msgstr "Patejdukshmëria e hijes."
 msgid "The shadow spread."
 msgstr "Shtrirja e hijes."
 
-#: ../src/richtext/richtextindentspage.cpp:267
 #: ../src/richtext/richtextliststylepage.cpp:439
 #: ../src/richtext/richtextliststylepage.cpp:441
+#: ../src/richtext/richtextindentspage.cpp:267
 msgid "The spacing after the paragraph."
 msgstr "Hapësira pas paragrafit."
 
-#: ../src/richtext/richtextindentspage.cpp:257
-#: ../src/richtext/richtextindentspage.cpp:259
 #: ../src/richtext/richtextliststylepage.cpp:430
 #: ../src/richtext/richtextliststylepage.cpp:432
+#: ../src/richtext/richtextindentspage.cpp:257
+#: ../src/richtext/richtextindentspage.cpp:259
 msgid "The spacing before the paragraph."
 msgstr "Hapësira para paragrafit."
 
@@ -7001,12 +7162,12 @@ msgstr "Emri i stilit."
 msgid "The style on which this style is based."
 msgstr "Stili në të cilin bazohet ky stil."
 
-#: ../src/richtext/richtextstyledlg.cpp:214
-#: ../src/richtext/richtextstyledlg.cpp:216
+#: ../src/richtext/richtextstyledlg.cpp:210
+#: ../src/richtext/richtextstyledlg.cpp:212
 msgid "The style preview."
 msgstr "Paraparja e stilit."
 
-#: ../src/msw/ole/automtn.cpp:680
+#: ../src/msw/ole/automtn.cpp:671
 msgid "The system cannot find the file specified."
 msgstr "Sistemi s’gjen dot kartelën e treguar."
 
@@ -7019,7 +7180,7 @@ msgstr "Pozicioni i tabulacionit."
 msgid "The tab positions."
 msgstr "Pozicionet e tabulacionit."
 
-#: ../src/richtext/richtextctrl.cpp:3098
+#: ../src/richtext/richtextctrl.cpp:3099
 msgid "The text couldn't be saved."
 msgstr "Teksti s’u ruajt dot."
 
@@ -7040,7 +7201,7 @@ msgstr "Madhësia e mbushjes së sipërme."
 msgid "The top position."
 msgstr "Pozicioni i sipërm."
 
-#: ../src/common/cmdline.cpp:1232
+#: ../src/common/cmdline.cpp:1228
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "Vlera për mundësinë '%s' duhet përcaktuar."
@@ -7050,7 +7211,7 @@ msgstr "Vlera për mundësinë '%s' duhet përcaktuar."
 msgid "The value of the corner radius."
 msgstr "Vlera e rrezes së këndit."
 
-#: ../src/msw/dialup.cpp:433
+#: ../src/msw/dialup.cpp:427
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -7065,30 +7226,30 @@ msgstr ""
 msgid "The vertical offset."
 msgstr "Shmangia vertikale."
 
-#: ../src/richtext/richtextprint.cpp:619 ../src/html/htmprint.cpp:745
+#: ../src/html/htmprint.cpp:749 ../src/richtext/richtextprint.cpp:615
 msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr ""
 "Pati një problem gjatë ujdisjes së faqes: mund t’ju duhet të caktoni një "
 "shtypës parazgjedhje."
 
-#: ../src/html/htmprint.cpp:255
+#: ../src/html/htmprint.cpp:267
 msgid ""
 "This document doesn't fit on the page horizontally and will be truncated "
 "when it is printed."
 msgstr ""
 "Këtë dokument s’e nxë faqja horizontalisht dhe do të qethet, kur të shtypet."
 
-#: ../src/common/image.cpp:2854
+#: ../src/common/image.cpp:2963
 #, c-format
 msgid "This is not a %s."
 msgstr "Kjo s’është %s."
 
-#: ../src/common/wincmn.cpp:1653
+#: ../src/common/wincmn.cpp:1654
 msgid "This platform does not support background transparency."
 msgstr "Kjo platformë nuk mbulon tejdukshmëri sfondesh."
 
-#: ../src/gtk/window.cpp:4660
+#: ../src/gtk/window.cpp:5664
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
@@ -7096,7 +7257,15 @@ msgstr ""
 "Ky program qe përpiluar me një version shumë të vjetër të GTK+, ju lutemi, "
 "rimontojeni me GTK+ 2.12 ose më të ri."
 
-#: ../src/msw/thread.cpp:1240
+#: ../src/gtk/glcanvas.cpp:176
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/msw/thread.cpp:1246
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -7104,12 +7273,12 @@ msgstr ""
 "Gatitja e modulit të rrjedhës dështoi: s’mund të depozitohet vlerë në depo "
 "vendore rrjedhe"
 
-#: ../src/unix/threadpsx.cpp:1794
+#: ../src/unix/threadpsx.cpp:1843
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 "Gatitja e modulit të rrjedhës dështoi: s’u arrit të krijohej kyç rrjedhe"
 
-#: ../src/msw/thread.cpp:1228
+#: ../src/msw/thread.cpp:1234
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -7117,82 +7286,82 @@ msgstr ""
 "Gatitja e modulit të rrjedhës dështoi: e pamundur jepet tregues te depo "
 "vendore rrjedhe"
 
-#: ../src/unix/threadpsx.cpp:1043
+#: ../src/unix/threadpsx.cpp:1061
 msgid "Thread priority setting is ignored."
 msgstr "U shpërfill ujdisje përparësish rrjedhash."
 
-#: ../src/msw/mdi.cpp:176
+#: ../src/msw/mdi.cpp:171
 msgid "Tile &Horizontally"
 msgstr "Tjegullzoje &Horizontalisht"
 
-#: ../src/msw/mdi.cpp:177
+#: ../src/msw/mdi.cpp:172
 msgid "Tile &Vertically"
 msgstr "Tjegullzoje &Vertikalisht"
 
-#: ../src/common/ftp.cpp:200
+#: ../src/common/ftp.cpp:197
 msgid "Timeout while waiting for FTP server to connect, try passive mode."
 msgstr ""
 "Skadim kohe teksa pritej që shërbyesi FTP të lidhej, provoni mënyrë pasive."
 
-#: ../src/generic/tipdlg.cpp:201
+#: ../src/generic/tipdlg.cpp:198
 msgid "Tip of the Day"
 msgstr "Ndihmëza e Ditës"
 
-#: ../src/generic/tipdlg.cpp:140
+#: ../src/generic/tipdlg.cpp:137
 msgid "Tips not available, sorry!"
 msgstr "Na ndjeni, nuk ka ndihmëza të gatshme!"
 
-#: ../src/generic/prntdlgg.cpp:242
+#: ../src/generic/prntdlgg.cpp:235
 msgid "To:"
 msgstr "Për:"
 
-#: ../src/richtext/richtextbuffer.cpp:8363
+#: ../src/richtext/richtextbuffer.cpp:8361
 msgid "Too many EndStyle calls!"
 msgstr "Shumë thirrje EndStyle!"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:891
+#: ../src/propgrid/advprops.cpp:792
 msgid "Tooltip"
 msgstr "Ndihmëz"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:892
+#: ../src/propgrid/advprops.cpp:793
 msgid "TooltipText"
 msgstr ""
 
-#: ../src/richtext/richtextsizepage.cpp:286
-#: ../src/richtext/richtextsizepage.cpp:290 ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197 ../src/richtext/richtextsizepage.cpp:286
+#: ../src/richtext/richtextsizepage.cpp:290
 msgid "Top"
 msgstr "Në krye"
 
-#: ../src/generic/prntdlgg.cpp:881
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Top margin (mm):"
 msgstr "Mënjanë në krye (mm):"
 
-#: ../src/generic/aboutdlgg.cpp:79
+#: ../src/generic/aboutdlgg.cpp:76
 msgid "Translations by "
 msgstr "Përkthime nga "
 
-#: ../src/generic/aboutdlgg.cpp:188
+#: ../src/generic/aboutdlgg.cpp:185
 msgid "Translators"
 msgstr "Përkthyes"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:211
+#: ../src/propgrid/propgrid.cpp:192
 msgid "True"
 msgstr ""
 
-#: ../src/common/fs_mem.cpp:227
+#: ../src/common/fs_mem.cpp:222
 #, c-format
 msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
 msgstr ""
 "Po provohet të hiqet kartela '%s' prej kujtese VFS, por s’është e ngarkuar!"
 
-#: ../src/common/fmapbase.cpp:156
+#: ../src/common/fmapbase.cpp:153
 msgid "Turkish (ISO-8859-9)"
 msgstr "Turke (ISO-8859-9)"
 
-#: ../src/generic/filectrlg.cpp:426
+#: ../src/generic/filectrlg.cpp:422
 msgid "Type"
 msgstr "Lloj"
 
@@ -7206,17 +7375,17 @@ msgstr "Shtypni një emër shkronjash."
 msgid "Type a size in points."
 msgstr "Shtypni një madhësi në pikë."
 
-#: ../src/msw/ole/automtn.cpp:676
+#: ../src/msw/ole/automtn.cpp:667
 #, c-format
 msgid "Type mismatch in argument %u."
 msgstr "Mospërputhje lloji te argument %u."
 
-#: ../src/common/xtixml.cpp:356 ../src/common/xtixml.cpp:509
-#: ../src/common/xtistrm.cpp:318
+#: ../src/common/xtixml.cpp:352 ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315
 msgid "Type must have enum - long conversion"
 msgstr ""
 
-#: ../src/propgrid/propgridiface.cpp:401
+#: ../src/propgrid/propgridiface.cpp:385
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
@@ -7225,19 +7394,19 @@ msgstr ""
 "Veprimi i shtypjes \"%s\" dështoi: Vetia e etiketuar \"%s\" është e llojit "
 "\"%s\", JO \"%s\"."
 
-#: ../src/common/paper.cpp:133
+#: ../src/common/paper.cpp:130
 msgid "US Std Fanfold, 14 7/8 x 11 in"
 msgstr "US Std Fanfold, 14 7/8 x 11 inç"
 
-#: ../src/common/fmapbase.cpp:196
+#: ../src/common/fmapbase.cpp:193
 msgid "US-ASCII"
 msgstr "US-ASCII"
 
-#: ../src/unix/fswatcher_inotify.cpp:109
+#: ../src/unix/fswatcher_inotify.cpp:106
 msgid "Unable to add inotify watch"
 msgstr "S’arrihet të shtohet mbikëqyrës inotify"
 
-#: ../src/unix/fswatcher_kqueue.cpp:136
+#: ../src/unix/fswatcher_kqueue.cpp:153
 msgid "Unable to add kqueue watch"
 msgstr "S’arrihet të shtohet mbikëqyrës kqueue"
 
@@ -7249,7 +7418,7 @@ msgstr ""
 msgid "Unable to close I/O completion port handle"
 msgstr ""
 
-#: ../src/unix/fswatcher_inotify.cpp:97
+#: ../src/unix/fswatcher_inotify.cpp:94
 msgid "Unable to close inotify instance"
 msgstr "S’arrihet të mbyllet instancë inotify"
 
@@ -7267,15 +7436,15 @@ msgstr "S’arrihet të mbyllet trajtuesi për '%s'"
 msgid "Unable to create I/O completion port"
 msgstr "S’arrihet të krijohet portë plotësimi I/O"
 
-#: ../src/msw/fswatcher.cpp:84
+#: ../src/msw/fswatcher.cpp:81
 msgid "Unable to create IOCP worker thread"
 msgstr ""
 
-#: ../src/unix/fswatcher_inotify.cpp:74
+#: ../src/unix/fswatcher_inotify.cpp:71
 msgid "Unable to create inotify instance"
 msgstr "S’arrihet të krijohet instancë inotify"
 
-#: ../src/unix/fswatcher_kqueue.cpp:97
+#: ../src/unix/fswatcher_kqueue.cpp:114
 msgid "Unable to create kqueue instance"
 msgstr "S’arrihet të krijohet instancë kqueue"
 
@@ -7283,11 +7452,11 @@ msgstr "S’arrihet të krijohet instancë kqueue"
 msgid "Unable to dequeue completion packet"
 msgstr ""
 
-#: ../src/unix/fswatcher_kqueue.cpp:185
+#: ../src/unix/fswatcher_kqueue.cpp:202
 msgid "Unable to get events from kqueue"
 msgstr "S’arrihet të merret akte prej kqueue"
 
-#: ../src/gtk/app.cpp:435
+#: ../src/gtk/app.cpp:431
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "S’arrihet të gatitet GTK+, a është caktuar saktë DISPLAY?"
 
@@ -7296,12 +7465,12 @@ msgstr "S’arrihet të gatitet GTK+, a është caktuar saktë DISPLAY?"
 msgid "Unable to open path '%s'"
 msgstr "S’arrihet të hapet shtegu '%s'"
 
-#: ../src/html/htmlwin.cpp:583
+#: ../src/html/htmlwin.cpp:586
 #, c-format
 msgid "Unable to open requested HTML document: %s"
 msgstr "S’arrihet të hapet dokumenti HTML i kërkuar: %s"
 
-#: ../src/unix/sound.cpp:368
+#: ../src/unix/sound.cpp:365
 msgid "Unable to play sound asynchronously."
 msgstr "S’arrihet të luhen tinguj në mënyrë jo të njëkohshme."
 
@@ -7309,61 +7478,61 @@ msgstr "S’arrihet të luhen tinguj në mënyrë jo të njëkohshme."
 msgid "Unable to post completion status"
 msgstr "S’arrihet të postohet gjendje plotësimi"
 
-#: ../src/unix/fswatcher_inotify.cpp:556
+#: ../src/unix/fswatcher_inotify.cpp:553
 msgid "Unable to read from inotify descriptor"
 msgstr "S’arrihet të lexohet nga përshkrues inotify"
 
-#: ../src/unix/fswatcher_inotify.cpp:141
+#: ../src/unix/fswatcher_inotify.cpp:138
 #, c-format
 msgid "Unable to remove inotify watch %i"
 msgstr "S’arrihet të hiqet mbikëqyrës inotifyi %i"
 
-#: ../src/unix/fswatcher_kqueue.cpp:153
+#: ../src/unix/fswatcher_kqueue.cpp:170
 msgid "Unable to remove kqueue watch"
 msgstr "S’arrihet të hiqet mbikëqyrës kqueue"
 
-#: ../src/msw/fswatcher.cpp:168
+#: ../src/msw/fswatcher.cpp:165
 #, c-format
 msgid "Unable to set up watch for '%s'"
 msgstr "S’arrihet të ujdiset mbikëqyrës për '%s'"
 
-#: ../src/msw/fswatcher.cpp:91
+#: ../src/msw/fswatcher.cpp:88
 msgid "Unable to start IOCP worker thread"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:201
+#: ../src/common/stockitem.cpp:198
 msgid "Undelete"
 msgstr "Shfshije"
 
-#: ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199
 msgid "Underline"
 msgstr "Nënvijë"
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/richtext/richtextfontpage.cpp:359 ../src/osx/carbon/fontdlg.cpp:370
-#: ../src/propgrid/advprops.cpp:690
+#: ../src/osx/carbon/fontdlg.cpp:367 ../src/propgrid/advprops.cpp:600
+#: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Nënvijëzuar"
 
-#: ../src/common/stockitem.cpp:203 ../src/stc/stc_i18n.cpp:15
+#: ../src/common/stockitem.cpp:200 ../src/stc/stc_i18n.cpp:15
 msgid "Undo"
 msgstr "Zhbëje"
 
-#: ../src/common/stockitem.cpp:265
+#: ../src/common/stockitem.cpp:263
 msgid "Undo last action"
 msgstr "Zhbëje veprimin e fundit"
 
-#: ../src/common/cmdline.cpp:1029
+#: ../src/common/cmdline.cpp:1025
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Shenja të papritura në vijim të mundësisë '%s'."
 
-#: ../src/unix/fswatcher_inotify.cpp:274
+#: ../src/unix/fswatcher_inotify.cpp:271
 #, c-format
 msgid "Unexpected event for \"%s\": no matching watch descriptor."
 msgstr "Akt i papritur për \"%s\": s’ka përshkrues mbikëqyrësi me përputhje."
 
-#: ../src/common/cmdline.cpp:1195
+#: ../src/common/cmdline.cpp:1191
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Parametër '%s' i papritur"
@@ -7372,49 +7541,49 @@ msgstr "Parametër '%s' i papritur"
 msgid "Unexpectedly new I/O completion port was created"
 msgstr "U krijua papritmas portë e re plotësimi I/O"
 
-#: ../src/msw/fswatcher.cpp:70
+#: ../src/msw/fswatcher.cpp:67
 msgid "Ungraceful worker thread termination"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:460
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:456
+#: ../src/richtext/richtextsymboldlg.cpp:457
+#: ../src/richtext/richtextsymboldlg.cpp:458
 msgid "Unicode"
 msgstr "Unikod"
 
-#: ../src/common/fmapbase.cpp:185 ../src/common/fmapbase.cpp:191
+#: ../src/common/fmapbase.cpp:182 ../src/common/fmapbase.cpp:188
 msgid "Unicode 16 bit (UTF-16)"
 msgstr "Unikod 16 bit (UTF-16)"
 
-#: ../src/common/fmapbase.cpp:190
+#: ../src/common/fmapbase.cpp:187
 msgid "Unicode 16 bit Big Endian (UTF-16BE)"
 msgstr "Unikod 16 bit Big Endian (UTF-16BE)"
 
-#: ../src/common/fmapbase.cpp:186
+#: ../src/common/fmapbase.cpp:183
 msgid "Unicode 16 bit Little Endian (UTF-16LE)"
 msgstr "Unikod 16 bit Little Endian (UTF-16LE)"
 
-#: ../src/common/fmapbase.cpp:187 ../src/common/fmapbase.cpp:193
+#: ../src/common/fmapbase.cpp:184 ../src/common/fmapbase.cpp:190
 msgid "Unicode 32 bit (UTF-32)"
 msgstr "Unikod 32 bit (UTF-32)"
 
-#: ../src/common/fmapbase.cpp:192
+#: ../src/common/fmapbase.cpp:189
 msgid "Unicode 32 bit Big Endian (UTF-32BE)"
 msgstr "Unikod 32 bit Big Endian (UTF-32BE)"
 
-#: ../src/common/fmapbase.cpp:188
+#: ../src/common/fmapbase.cpp:185
 msgid "Unicode 32 bit Little Endian (UTF-32LE)"
 msgstr "Unikod 32 bit Little Endian (UTF-32LE)"
 
-#: ../src/common/fmapbase.cpp:182
+#: ../src/common/fmapbase.cpp:179
 msgid "Unicode 7 bit (UTF-7)"
 msgstr "Unikod 7 bit (UTF-7)"
 
-#: ../src/common/fmapbase.cpp:183
+#: ../src/common/fmapbase.cpp:180
 msgid "Unicode 8 bit (UTF-8)"
 msgstr "Unikod 8 bit (UTF-8)"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "Unindent"
 msgstr "Hiqi shmangien"
 
@@ -7564,97 +7733,102 @@ msgstr "Njësi për pozicionin e sipërm."
 msgid "Units for this value."
 msgstr "Njësi për këtë vlerë."
 
-#: ../src/generic/progdlgg.cpp:353 ../src/generic/progdlgg.cpp:622
+#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
 msgid "Unknown"
 msgstr "I panjohur"
 
-#: ../src/msw/dde.cpp:1174
+#: ../src/msw/dde.cpp:1238
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Gabim i panjohur DDE %08x"
 
-#: ../src/common/xtistrm.cpp:410
+#: ../src/common/xtistrm.cpp:407
 msgid "Unknown Object passed to GetObjectClassInfo"
 msgstr "Objekt i panjohur dhënë te GetObjectClassInfo"
 
-#: ../src/common/imagpng.cpp:366
+#: ../src/common/imagpng.cpp:383
 #, c-format
 msgid "Unknown PNG resolution unit %d"
 msgstr "Njësi e panjohur qartësie PNG %d"
 
-#: ../src/common/xtixml.cpp:327
+#: ../src/common/xtixml.cpp:323
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Veti %s e Panjohur"
 
-#: ../src/common/imagtiff.cpp:529
+#: ../src/common/imagtiff.cpp:526
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "U shpërfill njësi e panjohur qartësie TIFF %d"
 
-#: ../src/unix/dlunix.cpp:160
+#: ../src/propgrid/props.cpp:155
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/unix/dlunix.cpp:118
 msgid "Unknown dynamic library error"
 msgstr "Gabim i panjohur librarie dinamike"
 
-#: ../src/common/fmapbase.cpp:810
+#: ../src/common/fmapbase.cpp:806
 #, c-format
 msgid "Unknown encoding (%d)"
 msgstr "Kodim i panjohur (%d)"
 
-#: ../src/msw/ole/automtn.cpp:688
+#: ../src/msw/ole/automtn.cpp:679
 #, c-format
 msgid "Unknown error %08x"
 msgstr "Gabim i panjohur %08x"
 
-#: ../src/msw/ole/automtn.cpp:647
+#: ../src/msw/ole/automtn.cpp:638
 msgid "Unknown exception"
 msgstr "Përjashtim i panjohur"
 
-#: ../src/common/image.cpp:2839
+#: ../src/common/image.cpp:2942
 msgid "Unknown image data format."
 msgstr "Format i panjohur të dhënash figure."
 
-#: ../src/common/cmdline.cpp:914
+#: ../src/common/cmdline.cpp:910
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Mundësi e gjatë '%s' e panjohur"
 
-#: ../src/msw/ole/automtn.cpp:631
+#: ../src/msw/ole/automtn.cpp:622
 msgid "Unknown name or named argument."
 msgstr "Emër ose argument i emërtuar i panjohur."
 
-#: ../src/common/cmdline.cpp:929 ../src/common/cmdline.cpp:951
+#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Mundësi e panjohur '%s'"
 
-#: ../src/common/mimecmn.cpp:225
+#: ../src/common/mimecmn.cpp:221
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "'{' pa shoqe te zë për lloj mime %s."
 
-#: ../src/common/cmdproc.cpp:262 ../src/common/cmdproc.cpp:288
-#: ../src/common/cmdproc.cpp:308
+#: ../src/common/cmdproc.cpp:255 ../src/common/cmdproc.cpp:281
+#: ../src/common/cmdproc.cpp:301
 msgid "Unnamed command"
 msgstr "Urdhër i paemërtuar"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:413
+#: ../src/propgrid/propgrid.cpp:392
 msgid "Unspecified"
 msgstr "E papërcaktuar"
 
-#: ../src/msw/clipbrd.cpp:311
+#: ../src/msw/clipbrd.cpp:325
 msgid "Unsupported clipboard format."
 msgstr "Format i pambuluar për të papastrën."
 
-#: ../src/common/appcmn.cpp:256
+#: ../src/common/appcmn.cpp:277
 #, c-format
 msgid "Unsupported theme '%s'."
 msgstr "Temë '%s' e pambuluar."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:205
-#: ../src/common/accelcmn.cpp:63
+#: ../src/common/stockitem.cpp:202 ../src/common/accelcmn.cpp:60
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Up"
 msgstr "Sipër"
 
@@ -7668,7 +7842,7 @@ msgstr "Shkronja të mëdha"
 msgid "Upper case roman numerals"
 msgstr "Numra romakë me të mëdha"
 
-#: ../src/common/cmdline.cpp:1326
+#: ../src/common/cmdline.cpp:1322
 #, c-format
 msgid "Usage: %s"
 msgstr "Përdorim: %s"
@@ -7677,38 +7851,47 @@ msgstr "Përdorim: %s"
 msgid "Use &shadow"
 msgstr "Përdor &hije"
 
-#: ../src/richtext/richtextindentspage.cpp:169
-#: ../src/richtext/richtextindentspage.cpp:171
 #: ../src/richtext/richtextliststylepage.cpp:358
 #: ../src/richtext/richtextliststylepage.cpp:360
+#: ../src/richtext/richtextindentspage.cpp:169
+#: ../src/richtext/richtextindentspage.cpp:171
 msgid "Use the current alignment setting."
 msgstr "Përdor rregullimin e tanishëm të drejtimit."
 
-#: ../src/common/valtext.cpp:179
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/gtk/font.cpp:552
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/common/valtext.cpp:142
 msgid "Validation conflict"
 msgstr "Kundërshti vleftësimesh"
 
-#: ../src/propgrid/manager.cpp:238
+#: ../src/propgrid/manager.cpp:224
 msgid "Value"
 msgstr "Vlerë"
 
-#: ../src/propgrid/props.cpp:386 ../src/propgrid/props.cpp:500
+#: ../src/propgrid/props.cpp:309
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "Vlera duhet të jetë %s ose më e madhe."
 
-#: ../src/propgrid/props.cpp:417 ../src/propgrid/props.cpp:531
+#: ../src/propgrid/props.cpp:336
 #, c-format
 msgid "Value must be %s or less."
 msgstr "Vlera duhet të jetë %s ose më e vogël."
 
-#: ../src/propgrid/props.cpp:393 ../src/propgrid/props.cpp:424
-#: ../src/propgrid/props.cpp:507 ../src/propgrid/props.cpp:538
+#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "Vlera duhet të jetë mes %s dhe %s."
 
-#: ../src/generic/aboutdlgg.cpp:128
+#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Version "
 
@@ -7717,25 +7900,32 @@ msgstr "Version "
 msgid "Vertical alignment."
 msgstr "Drejtim vertikalisht."
 
-#: ../src/generic/filedlgg.cpp:202
+#: ../src/generic/filedlgg.cpp:199
 msgid "View files as a detailed view"
 msgstr "Shihini kartelat nën pamjen me hollësitë"
 
-#: ../src/generic/filedlgg.cpp:200
+#: ../src/generic/filedlgg.cpp:197
 msgid "View files as a list view"
 msgstr "Shihini kartelat nën pamjen listë"
 
-#: ../src/common/docview.cpp:1970
+#: ../src/common/docview.cpp:1975
 msgid "Views"
 msgstr "Pamje"
 
+#: ../src/gtk/app.cpp:348
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1777
+#: ../src/propgrid/advprops.cpp:1678
 msgid "Wait"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1779
+#: ../src/propgrid/advprops.cpp:1680
 msgid "Wait Arrow"
 msgstr ""
 
@@ -7744,238 +7934,235 @@ msgstr ""
 msgid "Waiting for IO on epoll descriptor %d failed"
 msgstr "Dështoi pritja për IO në përshkrues epoll %d"
 
-#: ../src/common/log.cpp:223
+#: ../src/common/log.cpp:241
 msgid "Warning: "
 msgstr "Kujdes: "
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1778
+#: ../src/propgrid/advprops.cpp:1679
 msgid "Watch"
 msgstr ""
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:685
+#: ../src/propgrid/advprops.cpp:595
 msgid "Weight"
 msgstr "Madhësi"
 
-#: ../src/common/fmapbase.cpp:148
+#: ../src/common/fmapbase.cpp:145
 msgid "Western European (ISO-8859-1)"
 msgstr "Europiane Perëndimore (ISO-8859-1)"
 
-#: ../src/common/fmapbase.cpp:162
+#: ../src/common/fmapbase.cpp:159
 msgid "Western European with Euro (ISO-8859-15)"
 msgstr "Europiane Perëndimore me Euro (ISO-8859-15)"
 
-#: ../src/generic/fontdlgg.cpp:446 ../src/generic/fontdlgg.cpp:448
+#: ../src/generic/fontdlgg.cpp:443 ../src/generic/fontdlgg.cpp:445
 msgid "Whether the font is underlined."
 msgstr "Nëse janë apo jo të nënvizuara shkronjat."
 
-#: ../src/propgrid/advprops.cpp:1611
+#: ../src/propgrid/advprops.cpp:1517
 msgid "White"
 msgstr "E bardhë"
 
-#: ../src/generic/fdrepdlg.cpp:144
+#: ../src/generic/fdrepdlg.cpp:141
 msgid "Whole word"
 msgstr "Tërë fjalën"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:532
 msgid "Whole words only"
 msgstr "Vetëm fjalë të plota"
 
-#: ../src/univ/themes/win32.cpp:1102
+#: ../src/univ/themes/win32.cpp:1099
 msgid "Win32 theme"
 msgstr "Temë Win32"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:893
+#: ../src/propgrid/advprops.cpp:794
 msgid "Window"
 msgstr "Dritare"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:894
+#: ../src/propgrid/advprops.cpp:795
 msgid "WindowFrame"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:895
+#: ../src/propgrid/advprops.cpp:796
 msgid "WindowText"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:177
+#: ../src/common/fmapbase.cpp:174
 msgid "Windows Arabic (CP 1256)"
 msgstr "Arabike Windows (CP 1256)"
 
-#: ../src/common/fmapbase.cpp:178
+#: ../src/common/fmapbase.cpp:175
 msgid "Windows Baltic (CP 1257)"
 msgstr "Baltike Windows (CP 1257)"
 
-#: ../src/common/fmapbase.cpp:171
+#: ../src/common/fmapbase.cpp:168
 msgid "Windows Central European (CP 1250)"
 msgstr "Europiane Qendrore Windows (CP 1250)"
 
-#: ../src/common/fmapbase.cpp:168
+#: ../src/common/fmapbase.cpp:165
 msgid "Windows Chinese Simplified (CP 936) or GB-2312"
 msgstr "Kineze e Thjeshtuar, Windows (CP 936) ose GB-2312"
 
-#: ../src/common/fmapbase.cpp:170
+#: ../src/common/fmapbase.cpp:167
 msgid "Windows Chinese Traditional (CP 950) or Big-5"
 msgstr "Kineze Tradicionale, Windows (CP 950) ose Big-5"
 
-#: ../src/common/fmapbase.cpp:172
+#: ../src/common/fmapbase.cpp:169
 msgid "Windows Cyrillic (CP 1251)"
 msgstr "Cirilike Windows (CP 1251)"
 
-#: ../src/common/fmapbase.cpp:174
+#: ../src/common/fmapbase.cpp:171
 msgid "Windows Greek (CP 1253)"
 msgstr "Greke Windows (CP 1253)"
 
-#: ../src/common/fmapbase.cpp:176
+#: ../src/common/fmapbase.cpp:173
 msgid "Windows Hebrew (CP 1255)"
 msgstr "Hebraishte Windows (CP 1255)"
 
-#: ../src/common/fmapbase.cpp:167
+#: ../src/common/fmapbase.cpp:164
 msgid "Windows Japanese (CP 932) or Shift-JIS"
 msgstr "Japoneze Windows (CP 932) ose Shift-JIS"
 
-#: ../src/common/fmapbase.cpp:180
+#: ../src/common/fmapbase.cpp:177
 msgid "Windows Johab (CP 1361)"
 msgstr "Johab Windows (CP 1361)"
 
-#: ../src/common/fmapbase.cpp:169
+#: ../src/common/fmapbase.cpp:166
 msgid "Windows Korean (CP 949)"
 msgstr "Koreane Windows (CP 949)"
 
-#: ../src/common/fmapbase.cpp:166
+#: ../src/common/fmapbase.cpp:163
 msgid "Windows Thai (CP 874)"
 msgstr "Tajlandeze Windows (CP 874)"
 
-#: ../src/common/fmapbase.cpp:175
+#: ../src/common/fmapbase.cpp:172
 msgid "Windows Turkish (CP 1254)"
 msgstr "Turke Windows (CP 1254)"
 
-#: ../src/common/fmapbase.cpp:179
+#: ../src/common/fmapbase.cpp:176
 msgid "Windows Vietnamese (CP 1258)"
 msgstr "Vietnameze Windows (CP 1258)"
 
-#: ../src/common/fmapbase.cpp:173
+#: ../src/common/fmapbase.cpp:170
 msgid "Windows Western European (CP 1252)"
 msgstr "Europiane Qendrore Windows (CP 1252)"
 
-#: ../src/common/fmapbase.cpp:181
+#: ../src/common/fmapbase.cpp:178
 msgid "Windows/DOS OEM (CP 437)"
 msgstr "Windows/DOS OEM (CP 437)"
 
-#: ../src/common/fmapbase.cpp:165
+#: ../src/common/fmapbase.cpp:162
 msgid "Windows/DOS OEM Cyrillic (CP 866)"
 msgstr "Cirilike Windows/DOS OEM (CP 866)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:111
+#: ../src/common/accelcmn.cpp:109
 msgid "Windows_Left"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:113
+#: ../src/common/accelcmn.cpp:111
 msgid "Windows_Menu"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:112
+#: ../src/common/accelcmn.cpp:110
 msgid "Windows_Right"
 msgstr ""
 
-#: ../src/common/ffile.cpp:150
+#: ../src/common/ffile.cpp:149
 #, c-format
 msgid "Write error on file '%s'"
 msgstr "Gabim shkrimi në kartelën '%s'"
 
-#: ../src/xml/xml.cpp:914
+#: ../src/xml/xml.cpp:925
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "Gabim përtypjeje XML: '%s' te rresht %d"
 
-#: ../src/common/xpmdecod.cpp:796
+#: ../src/common/xpmdecod.cpp:794
 msgid "XPM: Malformed pixel data!"
 msgstr "XPM: Të dhëna pikseli të keqformuara!"
 
-#: ../src/common/xpmdecod.cpp:705
+#: ../src/common/xpmdecod.cpp:702
 #, c-format
 msgid "XPM: incorrect colour description in line %d"
 msgstr "XPM: përshkrim i pasaktë ngjyre në rreshtin %d"
 
-#: ../src/common/xpmdecod.cpp:680
+#: ../src/common/xpmdecod.cpp:677
 msgid "XPM: incorrect header format!"
 msgstr "XPM: Format kryesh i pasaktë!"
 
-#: ../src/common/xpmdecod.cpp:716 ../src/common/xpmdecod.cpp:725
+#: ../src/common/xpmdecod.cpp:714 ../src/common/xpmdecod.cpp:723
 #, c-format
 msgid "XPM: malformed colour definition '%s' at line %d!"
 msgstr "XPM: përcaktim i keqformuar ngjyre '%s' në rreshtin %d!"
 
-#: ../src/common/xpmdecod.cpp:755
+#: ../src/common/xpmdecod.cpp:753
 msgid "XPM: no colors left to use for mask!"
 msgstr "XPM: s’ka më ngjyra për t’u përdorur për maskë!"
 
-#: ../src/common/xpmdecod.cpp:782
+#: ../src/common/xpmdecod.cpp:780
 #, c-format
 msgid "XPM: truncated image data at line %d!"
 msgstr "XPM: të dhëna të cunguara figure në rreshtin %d!"
 
-#: ../src/propgrid/advprops.cpp:1610
+#: ../src/propgrid/advprops.cpp:1516
 msgid "Yellow"
 msgstr "E verdhë"
 
-#: ../include/wx/msgdlg.h:276 ../src/common/stockitem.cpp:206
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:203
 #: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Po"
 
-#: ../src/osx/carbon/overlay.cpp:155
-msgid "You cannot Clear an overlay that is not inited"
-msgstr ""
-
-#: ../src/osx/carbon/overlay.cpp:107 ../src/dfb/overlay.cpp:61
-msgid "You cannot Init an overlay twice"
-msgstr ""
-
-#: ../src/generic/dirdlgg.cpp:287
+#: ../src/generic/dirdlgg.cpp:284
 msgid "You cannot add a new directory to this section."
 msgstr "S’mund të shtoni drejtori të re në këtë ndarje."
 
-#: ../src/propgrid/propgrid.cpp:3299
+#: ../src/propgrid/propgrid.cpp:3276
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 "Keni dhënë vlerë të pavlefshme. Shtypni tastin ESC që të anulohet përpunimi."
 
-#: ../src/common/stockitem.cpp:209
+#: ../src/osx/cocoa/menu.mm:286
+#, fuzzy
+msgid "Zoom"
+msgstr "Zmadhoje"
+
+#: ../src/common/stockitem.cpp:206
 msgid "Zoom &In"
 msgstr "Z&madhoje"
 
-#: ../src/common/stockitem.cpp:210
+#: ../src/common/stockitem.cpp:207
 msgid "Zoom &Out"
 msgstr "Z&vogëloje"
 
-#: ../src/common/stockitem.cpp:209 ../src/common/prntbase.cpp:1594
+#: ../src/common/stockitem.cpp:206 ../src/common/prntbase.cpp:1619
 msgid "Zoom In"
 msgstr "Zmadhoje"
 
-#: ../src/common/stockitem.cpp:210 ../src/common/prntbase.cpp:1580
+#: ../src/common/stockitem.cpp:207 ../src/common/prntbase.cpp:1605
 msgid "Zoom Out"
 msgstr "Zvogëloje"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to &Fit"
 msgstr "Sa ta N&xërë"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to Fit"
 msgstr "Sa ta Nxërë"
 
-#: ../src/msw/dde.cpp:1141
+#: ../src/msw/dde.cpp:1205
 msgid "a DDEML application has created a prolonged race condition."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1129
+#: ../src/msw/dde.cpp:1193
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -7986,39 +8173,39 @@ msgstr ""
 "ose funksionit DDEML iu kalua një\n"
 "identifikues i pavlefshëm instancash."
 
-#: ../src/msw/dde.cpp:1147
+#: ../src/msw/dde.cpp:1211
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "dështoi një përpjekje klienti për të vendosur bisedë."
 
-#: ../src/msw/dde.cpp:1144
+#: ../src/msw/dde.cpp:1208
 msgid "a memory allocation failed."
 msgstr "dështoi një caktim kujtese."
 
-#: ../src/msw/dde.cpp:1138
+#: ../src/msw/dde.cpp:1202
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "dështoi vleftësimi nga DDEML i një parametri."
 
-#: ../src/msw/dde.cpp:1120
+#: ../src/msw/dde.cpp:1184
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "një kërkese për transaksion të njëkohshëm \"advise\" i mbaroi koha."
 
-#: ../src/msw/dde.cpp:1126
+#: ../src/msw/dde.cpp:1190
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "një kërkese për transaksion të njëkohshëm të dhënash i mbaroi koha."
 
-#: ../src/msw/dde.cpp:1135
+#: ../src/msw/dde.cpp:1199
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "një kërkese për transaksion të njëkohshëm \"execute\" i mbaroi koha."
 
-#: ../src/msw/dde.cpp:1153
+#: ../src/msw/dde.cpp:1217
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "një kërkese për transaksion të njëkohshëm \"poke\" i mbaroi koha."
 
-#: ../src/msw/dde.cpp:1168
+#: ../src/msw/dde.cpp:1232
 msgid "a request to end an advise transaction has timed out."
 msgstr "një kërkese për përfundim transaksioni këshille i mbaroi koha."
 
-#: ../src/msw/dde.cpp:1162
+#: ../src/msw/dde.cpp:1226
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -8028,15 +8215,15 @@ msgstr ""
 "një bisedë që u përfundua nga klienti, ose shërbyesi\n"
 "e mbylli me aq, para se të plotësohej transaksioni."
 
-#: ../src/msw/dde.cpp:1150
+#: ../src/msw/dde.cpp:1214
 msgid "a transaction failed."
 msgstr "dështoi një transaksion."
 
-#: ../src/common/accelcmn.cpp:189
+#: ../src/common/accelcmn.cpp:188
 msgid "alt"
 msgstr "alt"
 
-#: ../src/msw/dde.cpp:1132
+#: ../src/msw/dde.cpp:1196
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -8048,15 +8235,15 @@ msgstr ""
 "ose një aplikacion i filluar si APPCMD_CLIENTONLY \n"
 "u përpoq të kryejë transaksion shërbyesish."
 
-#: ../src/msw/dde.cpp:1156
+#: ../src/msw/dde.cpp:1220
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "dështoi një thirrje e brendshme për funksionin PostMessage. "
 
-#: ../src/msw/dde.cpp:1165
+#: ../src/msw/dde.cpp:1229
 msgid "an internal error has occurred in the DDEML."
 msgstr "te DDEML ndodhi një gabim i brendshëm."
 
-#: ../src/msw/dde.cpp:1171
+#: ../src/msw/dde.cpp:1235
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -8066,56 +8253,56 @@ msgstr ""
 "Pasi aplikacioni jetë përgjigjur me një callback XTYP_XACT_COMPLETE,\n"
 "identifikuesi i transaksionit për atë callback s’është më i vlefshëm."
 
-#: ../src/common/zipstrm.cpp:1483
+#: ../src/common/zipstrm.cpp:1522
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "po merret si e mirëqenë që kjo është zip shumëpjesësh i vargëzuar"
 
-#: ../src/common/fileconf.cpp:1847
+#: ../src/common/fileconf.cpp:1849
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "u shpërfill përpjekja për ndryshim kyçi të pandryshueshëm '%s'."
 
-#: ../src/html/chm.cpp:329
+#: ../src/html/chm.cpp:326
 msgid "bad arguments to library function"
 msgstr "argumente të gabuar në funksion librarie"
 
-#: ../src/html/chm.cpp:341
+#: ../src/html/chm.cpp:338
 msgid "bad signature"
 msgstr "nënshkrim i gabuar"
 
-#: ../src/common/zipstrm.cpp:1918
+#: ../src/common/zipstrm.cpp:1988
 msgid "bad zipfile offset to entry"
 msgstr ""
 
-#: ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400
 msgid "binary"
 msgstr "dyore"
 
-#: ../src/common/fontcmn.cpp:996
+#: ../src/common/fontcmn.cpp:1195
 msgid "bold"
 msgstr "të trasha"
 
-#: ../src/msw/utils.cpp:1144
+#: ../src/msw/utils.cpp:1135
 #, c-format
 msgid "build %lu"
 msgstr ""
 
-#: ../src/common/ffile.cpp:75
+#: ../src/common/ffile.cpp:73
 #, c-format
 msgid "can't close file '%s'"
 msgstr "s’mbyllet dot kartela '%s'"
 
-#: ../src/common/file.cpp:245
+#: ../src/common/file.cpp:242
 #, c-format
 msgid "can't close file descriptor %d"
 msgstr "s’mbyllet dot përshkrues kartele %d"
 
-#: ../src/common/file.cpp:586
+#: ../src/common/ffile.cpp:382 ../src/common/file.cpp:613
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "s’kryhen dot ndryshimet te kartelë '%s'"
 
-#: ../src/common/file.cpp:178
+#: ../src/common/file.cpp:175
 #, c-format
 msgid "can't create file '%s'"
 msgstr "s’krijohet dot kartelë '%s'"
@@ -8125,50 +8312,50 @@ msgstr "s’krijohet dot kartelë '%s'"
 msgid "can't delete user configuration file '%s'"
 msgstr "s’fshihet dot kartelë formësimi e përdoruesit '%s'"
 
-#: ../src/common/file.cpp:495
+#: ../src/common/file.cpp:522
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr ""
 "s’përcaktohet dot nëse te përshkruesi %d është mbërritur te fund kartele"
 
-#: ../src/common/zipstrm.cpp:1692
+#: ../src/common/zipstrm.cpp:1747
 msgid "can't find central directory in zip"
 msgstr "s’gjendet dot drejtori qendrore te zip-i"
 
-#: ../src/common/file.cpp:465
+#: ../src/common/file.cpp:492
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "s’gjendet dot gjatësi kartele te përshkrues kartele %d"
 
-#: ../src/msw/utils.cpp:341
+#: ../src/msw/utils.cpp:336
 msgid "can't find user's HOME, using current directory."
 msgstr "s’gjendet dot SHTËPI të përdoruesit, po përdoret drejtoria e tanishme."
 
-#: ../src/common/file.cpp:366
+#: ../src/common/file.cpp:407
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "s’zbrazet dot përshkrues kartele %d"
 
-#: ../src/common/file.cpp:422
+#: ../src/common/file.cpp:463
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr ""
 
-#: ../src/common/fontmap.cpp:325
+#: ../src/common/fontmap.cpp:322
 msgid "can't load any font, aborting"
 msgstr "s’ngarkohet dot ndonjë shkronjë, po ndërpritet"
 
-#: ../src/common/file.cpp:231 ../src/common/ffile.cpp:59
+#: ../src/common/ffile.cpp:57 ../src/common/file.cpp:228
 #, c-format
 msgid "can't open file '%s'"
 msgstr "s’hapet dot kartelë '%s'"
 
-#: ../src/common/fileconf.cpp:320
+#: ../src/common/fileconf.cpp:314
 #, c-format
 msgid "can't open global configuration file '%s'."
 msgstr "s’hapet dot kartelë formësimi të përgjithshëm '%s'."
 
-#: ../src/common/fileconf.cpp:336
+#: ../src/common/fileconf.cpp:330
 #, c-format
 msgid "can't open user configuration file '%s'."
 msgstr "s’hapet dot kartelë formësimi e përdoruesit '%s'."
@@ -8177,40 +8364,40 @@ msgstr "s’hapet dot kartelë formësimi e përdoruesit '%s'."
 msgid "can't open user configuration file."
 msgstr "s’hapet dot kartelë formësimi e përdoruesit."
 
-#: ../src/common/zipstrm.cpp:579
+#: ../src/common/zipstrm.cpp:572
 msgid "can't re-initialize zlib deflate stream"
 msgstr "s’rigatitet dot rrjedhë zlib \"deflate\""
 
-#: ../src/common/zipstrm.cpp:604
+#: ../src/common/zipstrm.cpp:597
 msgid "can't re-initialize zlib inflate stream"
 msgstr "s’rigatitet dot rrjedhë zlib \"inflate\""
 
-#: ../src/common/file.cpp:304
+#: ../src/common/file.cpp:345
 #, c-format
 msgid "can't read from file descriptor %d"
 msgstr "s’lexohet dot prej përshkruesi kartele %d"
 
-#: ../src/common/file.cpp:581
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:608
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "s’hiqet dot kartelë '%s'"
 
-#: ../src/common/file.cpp:598
+#: ../src/common/ffile.cpp:394 ../src/common/file.cpp:625
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "s’hiqet dot kartelë të përkohshme '%s'"
 
-#: ../src/common/file.cpp:408
+#: ../src/common/file.cpp:449
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "s’shihet dot te përshkrues kartele %d"
 
-#: ../src/common/textfile.cpp:273
+#: ../src/common/textfile.cpp:161
 #, c-format
 msgid "can't write buffer '%s' to disk."
 msgstr "s’shkruhet dot shtytëza '%s' në disk."
 
-#: ../src/common/file.cpp:323
+#: ../src/common/file.cpp:364
 #, c-format
 msgid "can't write to file descriptor %d"
 msgstr "s’shkruhet dot te përshkrues kartele %d"
@@ -8220,22 +8407,28 @@ msgid "can't write user configuration file."
 msgstr "s’shkruhet dot kartelë formësimi e përdoruesit."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:482 ../src/generic/datavgen.cpp:1261
+#: ../src/common/datavcmn.cpp:2064 ../src/generic/datavgen.cpp:1384
 msgid "checked"
 msgstr ""
 
-#: ../src/html/chm.cpp:345
+#: ../src/html/chm.cpp:342
 msgid "checksum error"
 msgstr "gabim \"checksum\""
 
-#: ../src/common/tarstrm.cpp:820
+#: ../src/common/tarstrm.cpp:814
 msgid "checksum failure reading tar header block"
 msgstr ""
 
-#: ../src/richtext/richtextbackgroundpage.cpp:226
-#: ../src/richtext/richtextbackgroundpage.cpp:249
-#: ../src/richtext/richtextbackgroundpage.cpp:289
-#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
 #: ../src/richtext/richtextborderspage.cpp:254
 #: ../src/richtext/richtextborderspage.cpp:288
 #: ../src/richtext/richtextborderspage.cpp:322
@@ -8253,104 +8446,127 @@ msgstr ""
 #: ../src/richtext/richtextmarginspage.cpp:340
 #: ../src/richtext/richtextmarginspage.cpp:363
 #: ../src/richtext/richtextmarginspage.cpp:388
-#: ../src/richtext/richtextsizepage.cpp:339
-#: ../src/richtext/richtextsizepage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:400
-#: ../src/richtext/richtextsizepage.cpp:427
-#: ../src/richtext/richtextsizepage.cpp:454
-#: ../src/richtext/richtextsizepage.cpp:481
-#: ../src/richtext/richtextsizepage.cpp:555
-#: ../src/richtext/richtextsizepage.cpp:590
-#: ../src/richtext/richtextsizepage.cpp:625
-#: ../src/richtext/richtextsizepage.cpp:660
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
 msgid "cm"
 msgstr "cm"
 
-#: ../src/html/chm.cpp:347
+#: ../src/html/chm.cpp:344
 msgid "compression error"
 msgstr "gabim ngjeshjeje"
 
-#: ../src/common/regex.cpp:236
+#: ../src/common/regex.cpp:233
 msgid "conversion to 8-bit encoding failed"
 msgstr "shndërrimi në kodim 8-bit dështoi"
 
-#: ../src/common/accelcmn.cpp:187
+#: ../src/common/accelcmn.cpp:186
 msgid "ctrl"
 msgstr "ctrl"
 
-#: ../src/common/cmdline.cpp:1500
+#: ../src/common/cmdline.cpp:1496
 msgid "date"
 msgstr "datë"
 
-#: ../src/html/chm.cpp:349
+#: ../src/html/chm.cpp:346
 msgid "decompression error"
 msgstr "gabim çngjeshjeje"
 
-#: ../src/richtext/richtextstyles.cpp:780 ../src/common/fmapbase.cpp:820
+#: ../src/common/fmapbase.cpp:816 ../src/richtext/richtextstyles.cpp:777
 msgid "default"
 msgstr "parazgjedhje"
 
-#: ../src/common/cmdline.cpp:1496
+#: ../src/common/cmdline.cpp:1492
 msgid "double"
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:538
+#: ../src/common/debugrpt.cpp:539
 msgid "dump of the process state (binary)"
 msgstr "zbrazje e gjendjes së procesit (dyor)"
 
-#: ../src/common/datetimefmt.cpp:1969
+#: ../src/common/datetimefmt.cpp:1992
 msgid "eighteenth"
 msgstr "i tetëmbëdhjeti"
 
-#: ../src/common/datetimefmt.cpp:1959
+#: ../src/common/datetimefmt.cpp:1982
 msgid "eighth"
 msgstr "i teti"
 
-#: ../src/common/datetimefmt.cpp:1962
+#: ../src/common/datetimefmt.cpp:1985
 msgid "eleventh"
 msgstr "i njëmbëdhjeti"
 
-#: ../src/common/fileconf.cpp:1833
+#: ../src/common/fileconf.cpp:1835
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "zëri '%s' duket në më shumë se një grup '%s'"
 
-#: ../src/html/chm.cpp:343
+#: ../src/html/chm.cpp:340
 msgid "error in data format"
 msgstr "gabim në format të dhënash"
 
-#: ../src/html/chm.cpp:331
+#: ../src/html/chm.cpp:328
 msgid "error opening file"
 msgstr "gabim në hapje kartele"
 
-#: ../src/common/zipstrm.cpp:1778
+#: ../src/common/zipstrm.cpp:1836
 msgid "error reading zip central directory"
 msgstr "gabim në lexim drejtorie qendrore zip"
 
-#: ../src/common/zipstrm.cpp:1870
+#: ../src/common/zipstrm.cpp:1940
 msgid "error reading zip local header"
 msgstr "gabim në leximi kryesh vendore zip"
 
-#: ../src/common/zipstrm.cpp:2531
+#: ../src/common/zipstrm.cpp:2615
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "gabim në shkrim zëri zip '%s': crc ose gjatësi e gabuar"
 
-#: ../src/common/ffile.cpp:188
+#: ../src/common/zipstrm.cpp:2608
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "gabim në shkrim zëri zip '%s': crc ose gjatësi e gabuar"
+
+#: ../src/common/fontcmn.cpp:1205
+#, fuzzy
+msgid "extrabold"
+msgstr "të trasha"
+
+#: ../src/common/fontcmn.cpp:1223
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1167
+#, fuzzy
+msgid "extralight"
+msgstr " të lehta"
+
+#: ../src/msw/webview_ie.cpp:1036
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "S’u arrit të përmbushej '%s'\n"
+
+#: ../src/common/ffile.cpp:187
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "s’u arrit të zbrazej kartela '%s'"
 
+#: ../src/msw/webview_ie.cpp:1045
+#, fuzzy
+msgid "failed to retrieve execution result"
+msgstr "S’u arrit të merrej tekst mesazhi gabimi RAS"
+
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1030
+#: ../src/generic/datavgen.cpp:1150
 msgid "false"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1966
+#: ../src/common/datetimefmt.cpp:1989
 msgid "fifteenth"
 msgstr "i pesëmbëdhjeti"
 
-#: ../src/common/datetimefmt.cpp:1956
+#: ../src/common/datetimefmt.cpp:1979
 msgid "fifth"
 msgstr "i pesti"
 
@@ -8379,131 +8595,150 @@ msgstr ""
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "kartela '%s': shenjë e papritur %c te rreshti %zu."
 
-#: ../src/richtext/richtextbuffer.cpp:8738
+#: ../src/richtext/richtextbuffer.cpp:8736
 msgid "files"
 msgstr "kartela"
 
-#: ../src/common/datetimefmt.cpp:1952
+#: ../src/common/datetimefmt.cpp:1975
 msgid "first"
 msgstr "i pari"
 
-#: ../src/html/helpwnd.cpp:1252
+#: ../src/html/helpwnd.cpp:1250
 msgid "font size"
 msgstr "madhësi shkronjash"
 
-#: ../src/common/datetimefmt.cpp:1965
+#: ../src/common/datetimefmt.cpp:1988
 msgid "fourteenth"
 msgstr "i katërmbëdhjeti"
 
-#: ../src/common/datetimefmt.cpp:1955
+#: ../src/common/datetimefmt.cpp:1978
 msgid "fourth"
 msgstr "i katërti"
 
-#: ../src/common/appbase.cpp:783
+#: ../src/common/appbase.cpp:784
 msgid "generate verbose log messages"
 msgstr "prodho mesazhe fjalamanë regjistrimi"
 
-#: ../src/richtext/richtextbuffer.cpp:13138
-#: ../src/richtext/richtextbuffer.cpp:13248
+#: ../src/common/fontcmn.cpp:1215
+msgid "heavy"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:13133
+#: ../src/richtext/richtextbuffer.cpp:13243
 msgid "image"
 msgstr "figurë"
 
-#: ../src/common/tarstrm.cpp:796
+#: ../src/common/tarstrm.cpp:790
 msgid "incomplete header block in tar"
 msgstr "bllok i paplotë kryesh në tar"
 
-#: ../src/common/xtixml.cpp:489
+#: ../src/common/xtixml.cpp:485
 msgid "incorrect event handler string, missing dot"
 msgstr "varg i pasaktë trajtuesi aktesh, mungon një pikë"
 
-#: ../src/common/tarstrm.cpp:1381
+#: ../src/common/tarstrm.cpp:1375
 msgid "incorrect size given for tar entry"
 msgstr "u dha madhësi i pasaktë për zë tar"
 
-#: ../src/common/tarstrm.cpp:993
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:987
 msgid "invalid data in extended tar header"
 msgstr "të dhëna të pavlefshme në krye të zgjeruara tar-i"
 
-#: ../src/generic/logg.cpp:1030
+#: ../src/generic/logg.cpp:1027
 msgid "invalid message box return value"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1647
+#: ../src/common/zipstrm.cpp:1688
 msgid "invalid zip file"
 msgstr "kartelë zip e pavlefshme"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:1228
 msgid "italic"
 msgstr "të pjerrta"
 
-#: ../src/common/fontcmn.cpp:991
+#: ../src/common/webrequest_curl.cpp:374
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "Kartela s’u ngarkua dot."
+
+#: ../src/common/fontcmn.cpp:1172
 msgid "light"
 msgstr ""
 
-#: ../src/common/intl.cpp:303
-#, c-format
-msgid "locale '%s' cannot be set."
-msgstr "nuk caktohet dot vendorja '%s'."
+#: ../src/common/fontcmn.cpp:1185
+msgid "medium"
+msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2125
+#: ../src/common/datetimefmt.cpp:2148
 msgid "midnight"
 msgstr "mesnatë"
 
-#: ../src/common/datetimefmt.cpp:1970
+#: ../src/common/datetimefmt.cpp:1993
 msgid "nineteenth"
 msgstr "i nëntëmbëdhjeti"
 
-#: ../src/common/datetimefmt.cpp:1960
+#: ../src/common/datetimefmt.cpp:1983
 msgid "ninth"
 msgstr "i nënti"
 
-#: ../src/msw/dde.cpp:1116
+#: ../src/msw/dde.cpp:1180
 msgid "no DDE error."
 msgstr "pa gabim DDE."
 
-#: ../src/html/chm.cpp:327
+#: ../src/html/chm.cpp:324
 msgid "no error"
 msgstr "pa gabim"
 
-#: ../src/dfb/fontmgr.cpp:174
+#: ../src/dfb/fontmgr.cpp:171
 #, c-format
 msgid "no fonts found in %s, using builtin font"
 msgstr "s’u gjetën shkronja te %s, po përdoren shkronja të brendshme"
 
-#: ../src/html/helpdata.cpp:657
+#: ../src/html/helpdata.cpp:650
 msgid "noname"
 msgstr "paemër"
 
-#: ../src/common/datetimefmt.cpp:2124
+#: ../src/common/datetimefmt.cpp:2147
 msgid "noon"
 msgstr "mesditë"
 
-#: ../src/richtext/richtextstyles.cpp:779
+#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "normale"
 
-#: ../src/common/cmdline.cpp:1492
+#: ../src/common/cmdline.cpp:1488
 msgid "num"
 msgstr "num"
 
-#: ../src/common/xtixml.cpp:259
+#: ../src/common/accelcmn.cpp:194
+msgid "num "
+msgstr ""
+
+#: ../src/common/xtixml.cpp:255
 msgid "objects cannot have XML Text Nodes"
 msgstr "objektet s’mund të kenë Nyje Teksti XML"
 
-#: ../src/html/chm.cpp:339
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
 msgid "out of memory"
 msgstr "kujtesë e pamjaftueshme"
 
-#: ../src/common/debugrpt.cpp:514
+#: ../src/common/debugrpt.cpp:515
 msgid "process context description"
 msgstr "përshkrim konteksti procesi"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:227
-#: ../src/richtext/richtextbackgroundpage.cpp:250
-#: ../src/richtext/richtextbackgroundpage.cpp:290
-#: ../src/richtext/richtextbackgroundpage.cpp:317
-#: ../src/richtext/richtextfontpage.cpp:177
-#: ../src/richtext/richtextfontpage.cpp:180
 #: ../src/richtext/richtextborderspage.cpp:255
 #: ../src/richtext/richtextborderspage.cpp:289
 #: ../src/richtext/richtextborderspage.cpp:323
@@ -8513,22 +8748,45 @@ msgstr "përshkrim konteksti procesi"
 #: ../src/richtext/richtextborderspage.cpp:491
 #: ../src/richtext/richtextborderspage.cpp:525
 #: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextfontpage.cpp:180
 msgid "pt"
 msgstr "pt"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:225
-#: ../src/richtext/richtextbackgroundpage.cpp:228
-#: ../src/richtext/richtextbackgroundpage.cpp:229
-#: ../src/richtext/richtextbackgroundpage.cpp:248
-#: ../src/richtext/richtextbackgroundpage.cpp:251
-#: ../src/richtext/richtextbackgroundpage.cpp:252
-#: ../src/richtext/richtextbackgroundpage.cpp:288
-#: ../src/richtext/richtextbackgroundpage.cpp:291
-#: ../src/richtext/richtextbackgroundpage.cpp:292
-#: ../src/richtext/richtextbackgroundpage.cpp:315
-#: ../src/richtext/richtextbackgroundpage.cpp:318
-#: ../src/richtext/richtextbackgroundpage.cpp:319
-#: ../src/richtext/richtextfontpage.cpp:178
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:659
+#: ../src/richtext/richtextsizepage.cpp:662
+#: ../src/richtext/richtextsizepage.cpp:663
 #: ../src/richtext/richtextborderspage.cpp:253
 #: ../src/richtext/richtextborderspage.cpp:256
 #: ../src/richtext/richtextborderspage.cpp:257
@@ -8580,259 +8838,269 @@ msgstr "pt"
 #: ../src/richtext/richtextmarginspage.cpp:387
 #: ../src/richtext/richtextmarginspage.cpp:389
 #: ../src/richtext/richtextmarginspage.cpp:390
-#: ../src/richtext/richtextsizepage.cpp:338
-#: ../src/richtext/richtextsizepage.cpp:341
-#: ../src/richtext/richtextsizepage.cpp:342
-#: ../src/richtext/richtextsizepage.cpp:372
-#: ../src/richtext/richtextsizepage.cpp:375
-#: ../src/richtext/richtextsizepage.cpp:376
-#: ../src/richtext/richtextsizepage.cpp:399
-#: ../src/richtext/richtextsizepage.cpp:402
-#: ../src/richtext/richtextsizepage.cpp:403
-#: ../src/richtext/richtextsizepage.cpp:426
-#: ../src/richtext/richtextsizepage.cpp:429
-#: ../src/richtext/richtextsizepage.cpp:430
-#: ../src/richtext/richtextsizepage.cpp:453
-#: ../src/richtext/richtextsizepage.cpp:456
-#: ../src/richtext/richtextsizepage.cpp:457
-#: ../src/richtext/richtextsizepage.cpp:480
-#: ../src/richtext/richtextsizepage.cpp:483
-#: ../src/richtext/richtextsizepage.cpp:484
-#: ../src/richtext/richtextsizepage.cpp:554
-#: ../src/richtext/richtextsizepage.cpp:557
-#: ../src/richtext/richtextsizepage.cpp:558
-#: ../src/richtext/richtextsizepage.cpp:589
-#: ../src/richtext/richtextsizepage.cpp:592
-#: ../src/richtext/richtextsizepage.cpp:593
-#: ../src/richtext/richtextsizepage.cpp:624
-#: ../src/richtext/richtextsizepage.cpp:627
-#: ../src/richtext/richtextsizepage.cpp:628
-#: ../src/richtext/richtextsizepage.cpp:659
-#: ../src/richtext/richtextsizepage.cpp:662
-#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextfontpage.cpp:178
 msgid "px"
 msgstr "px"
 
-#: ../src/common/accelcmn.cpp:193
+#: ../src/common/accelcmn.cpp:192
 msgid "rawctrl"
 msgstr "rawctrl"
 
-#: ../src/html/chm.cpp:333
+#: ../src/html/chm.cpp:330
 msgid "read error"
 msgstr "gabim leximi"
 
-#: ../src/common/zipstrm.cpp:2085
+#: ../src/common/zipstrm.cpp:2155
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "po lexohet rrjedhë zip (zëri %s): crc e gabuar"
 
-#: ../src/common/zipstrm.cpp:2080
+#: ../src/common/zipstrm.cpp:2150
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "po lexohet rrjedhë zip (zëri %s): gjatësi e gabuar"
 
-#: ../src/msw/dde.cpp:1159
+#: ../src/msw/dde.cpp:1223
 msgid "reentrancy problem."
 msgstr "problem rihyrjeje."
 
-#: ../src/common/datetimefmt.cpp:1953
+#: ../src/common/datetimefmt.cpp:1976
 msgid "second"
 msgstr "i dyti"
 
-#: ../src/html/chm.cpp:337
+#: ../src/html/chm.cpp:334
 msgid "seek error"
 msgstr "gabim kërkimi"
 
-#: ../src/common/datetimefmt.cpp:1968
+#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#, fuzzy
+msgid "semibold"
+msgstr "të trasha"
+
+#: ../src/common/datetimefmt.cpp:1991
 msgid "seventeenth"
 msgstr "i shtatëmbëdhjeti"
 
-#: ../src/common/datetimefmt.cpp:1958
+#: ../src/common/datetimefmt.cpp:1981
 msgid "seventh"
 msgstr "i shtati"
 
-#: ../src/common/accelcmn.cpp:191
+#: ../src/common/accelcmn.cpp:190
 msgid "shift"
 msgstr "shift"
 
-#: ../src/common/appbase.cpp:773
+#: ../src/common/appbase.cpp:774
 msgid "show this help message"
 msgstr "shfaq këtë mesazh ndihme"
 
-#: ../src/common/datetimefmt.cpp:1967
+#: ../src/common/datetimefmt.cpp:1990
 msgid "sixteenth"
 msgstr "i gjashtëmbëdhjeti"
 
-#: ../src/common/datetimefmt.cpp:1957
+#: ../src/common/datetimefmt.cpp:1980
 msgid "sixth"
 msgstr "i gjashti"
 
-#: ../src/common/appcmn.cpp:234
+#: ../src/common/appcmn.cpp:255
 msgid "specify display mode to use (e.g. 640x480-16)"
 msgstr "caktoni një mënyrë ekrani për përdorim (p.sh., 640x480-16)"
 
-#: ../src/common/appcmn.cpp:220
+#: ../src/common/appcmn.cpp:241
 msgid "specify the theme to use"
 msgstr "caktoni temë për t’u përdorur"
 
-#: ../src/richtext/richtextbuffer.cpp:9340
+#: ../src/richtext/richtextbuffer.cpp:9337
 msgid "standard/circle"
 msgstr "standard/rreth"
 
-#: ../src/richtext/richtextbuffer.cpp:9341
+#: ../src/richtext/richtextbuffer.cpp:9338
 msgid "standard/circle-outline"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9343
+#: ../src/richtext/richtextbuffer.cpp:9340
 msgid "standard/diamond"
 msgstr "standard/romb"
 
-#: ../src/richtext/richtextbuffer.cpp:9342
+#: ../src/richtext/richtextbuffer.cpp:9339
 msgid "standard/square"
 msgstr "standard/katror"
 
-#: ../src/richtext/richtextbuffer.cpp:9344
+#: ../src/richtext/richtextbuffer.cpp:9341
 msgid "standard/triangle"
 msgstr "standard/trikëndësh"
 
-#: ../src/common/zipstrm.cpp:1985
+#: ../src/common/zipstrm.cpp:2055
 msgid "stored file length not in Zip header"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1488
+#: ../src/common/cmdline.cpp:1484
 msgid "str"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:982
+#: ../src/common/fontcmn.cpp:1145
 msgid "strikethrough"
 msgstr "hequrvije"
 
-#: ../src/common/tarstrm.cpp:1003 ../src/common/tarstrm.cpp:1025
-#: ../src/common/tarstrm.cpp:1507 ../src/common/tarstrm.cpp:1529
+#: ../src/common/tarstrm.cpp:997 ../src/common/tarstrm.cpp:1019
+#: ../src/common/tarstrm.cpp:1501 ../src/common/tarstrm.cpp:1523
 msgid "tar entry not open"
 msgstr "zë tar i pahapur"
 
-#: ../src/common/datetimefmt.cpp:1961
+#: ../src/common/datetimefmt.cpp:1984
 msgid "tenth"
 msgstr "i dhjeti"
 
-#: ../src/msw/dde.cpp:1123
+#: ../src/msw/dde.cpp:1187
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "përgjigja te transaksioni shkaktoi caktimin e bitit DDE_FBUSY."
 
-#: ../src/common/datetimefmt.cpp:1954
+#: ../src/common/fontcmn.cpp:1154
+msgid "thin"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:1977
 msgid "third"
 msgstr "i treti"
 
-#: ../src/common/datetimefmt.cpp:1964
+#: ../src/common/datetimefmt.cpp:1987
 msgid "thirteenth"
 msgstr "i trembëdhjeti"
 
-#: ../src/common/datetimefmt.cpp:1758
+#: ../src/common/datetimefmt.cpp:1781
 msgid "today"
 msgstr "sot"
 
-#: ../src/common/datetimefmt.cpp:1760
+#: ../src/common/datetimefmt.cpp:1783
 msgid "tomorrow"
 msgstr "nesër"
 
-#: ../src/common/fileconf.cpp:1944
+#: ../src/common/fileconf.cpp:1946
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr ""
 
-#: ../src/gtk/aboutdlg.cpp:218
+#: ../src/gtk/aboutdlg.cpp:216
 msgid "translator-credits"
 msgstr "kredite përkthyesish"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1028
+#: ../src/generic/datavgen.cpp:1148
 msgid "true"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1963
+#: ../src/common/datetimefmt.cpp:1986
 msgid "twelfth"
 msgstr "i dymbëdhjeti"
 
-#: ../src/common/datetimefmt.cpp:1971
+#: ../src/common/datetimefmt.cpp:1994
 msgid "twentieth"
 msgstr "i njëzeti"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:486 ../src/generic/datavgen.cpp:1263
+#: ../src/common/datavcmn.cpp:2068 ../src/generic/datavgen.cpp:1386
 msgid "unchecked"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:802 ../src/common/fontcmn.cpp:978
+#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
 msgid "underlined"
 msgstr "nënvijëzuar"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:490
+#: ../src/common/datavcmn.cpp:2072
 msgid "undetermined"
 msgstr "e papërcaktuar"
 
-#: ../src/common/fileconf.cpp:1979
+#: ../src/common/fileconf.cpp:1981
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "\" të papritura në vendin %d te '%s'."
 
-#: ../src/common/tarstrm.cpp:1045
+#: ../src/common/tarstrm.cpp:1039
 msgid "unexpected end of file"
 msgstr "fund i papritur kartele"
 
-#: ../src/generic/progdlgg.cpp:370 ../src/common/tarstrm.cpp:371
-#: ../src/common/tarstrm.cpp:394 ../src/common/tarstrm.cpp:425
+#: ../src/common/tarstrm.cpp:366 ../src/common/tarstrm.cpp:389
+#: ../src/common/tarstrm.cpp:420 ../src/generic/progdlgg.cpp:376
 msgid "unknown"
 msgstr "i/e panjohur"
 
-#: ../src/msw/registry.cpp:150
+#: ../src/msw/registry.cpp:139
 #, c-format
 msgid "unknown (%lu)"
 msgstr "e panjohur (%lu)"
 
-#: ../src/common/xtixml.cpp:253
+#: ../src/common/xtixml.cpp:249
 #, c-format
 msgid "unknown class %s"
 msgstr "klasë e panjohur %s"
 
-#: ../src/common/regex.cpp:258 ../src/html/chm.cpp:351
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "gabim ngjeshjeje"
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "gabim çngjeshjeje"
+
+#: ../src/common/regex.cpp:255 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "gabim i panjohur"
 
-#: ../src/msw/dialup.cpp:471
+#: ../src/msw/dialup.cpp:465
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "gabim i panjohur (kod gabimi %08x)."
 
-#: ../src/common/fmapbase.cpp:834
+#: ../src/common/fmapbase.cpp:830
 #, c-format
 msgid "unknown-%d"
 msgstr "i/e panjohur-%d"
 
-#: ../src/common/docview.cpp:509
+#: ../src/common/docview.cpp:502
 msgid "unnamed"
 msgstr "pa emër"
 
-#: ../src/common/docview.cpp:1624
+#: ../src/common/docview.cpp:1618
 #, c-format
 msgid "unnamed%d"
 msgstr "i paemër%d"
 
-#: ../src/common/zipstrm.cpp:1999 ../src/common/zipstrm.cpp:2319
+#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
 msgid "unsupported Zip compression method"
 msgstr "metodë e pambuluar ngjeshjeje Zip"
 
-#: ../src/common/translation.cpp:1892
+#: ../src/common/translation.cpp:1942
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "po përdoret katalog '%s' prej '%s'."
 
-#: ../src/html/chm.cpp:335
+#: ../src/html/chm.cpp:332
 msgid "write error"
 msgstr "gabim shkrimi"
 
-#: ../src/common/time.cpp:292
+#: ../src/gtk/glcanvas.cpp:187
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/common/time.cpp:285
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay dështoi."
 
@@ -8845,15 +9113,15 @@ msgstr "wxWidgets s’hapi dot ekranin për '%s': po dilet."
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets s’hapi dot ekranin. Po dilet."
 
-#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:431
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/common/datetimefmt.cpp:1759
+#: ../src/common/datetimefmt.cpp:1782
 msgid "yesterday"
 msgstr "dje"
 
-#: ../src/common/zstream.cpp:251 ../src/common/zstream.cpp:426
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
 #, c-format
 msgid "zlib error %d"
 msgstr "gabim zlib %d“"
@@ -8862,3 +9130,66 @@ msgstr "gabim zlib %d“"
 #: ../src/richtext/richtextbulletspage.cpp:288
 msgid "~"
 msgstr "~"
+
+#~ msgid " (while overwriting an existing item)"
+#~ msgstr " (teksa mbishkruhet një element ekzistues)"
+
+#~ msgid "&Save as"
+#~ msgstr "&Ruaje si"
+
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' s’përbëhet vetëm nga shenja të vlefshme"
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' duhet të jetë numerik."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' duhet të përmbajë vetëm shenja ASCII."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' duhet të përmbajë vetëm shenja abc-je."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' duhet të përmbajë vetëm shenja abc-je ose numerike."
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' duhet të përmbajë vetëm shifra."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "S’krijohet dritare klase %s"
+
+#~ msgid "Could not initalize libnotify."
+#~ msgstr "S’u gatit dot libnotify."
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "S’u krijua dot dritarja përsipër"
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "S’u arrit të shndërrohej kartela \"%s\" në Unikod."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "S’u arrit të caktohej tekst te kontrolli i tekstit."
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr "Mundësi e paligjshme rreshti urdhrash GTK+, përdorni \"%s --help\""
+
+#~ msgid "No unused colour in image."
+#~ msgstr "Pa ngjyrë të papërdorur në figurë."
+
+#~ msgid "Not available"
+#~ msgstr "S’ka"
+
+#~ msgid "Replace selection"
+#~ msgstr "Zëvendëso përzgjedhjen"
+
+#~ msgid "Save as"
+#~ msgstr "Ruajeni si"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Organizues Stilesh"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "Mbulohen edhe mundësitë standarde GTK+ vijuese:\n"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "nuk caktohet dot vendorja '%s'."

--- a/locale/sv.po
+++ b/locale/sv.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-21 14:25+0200\n"
+"POT-Creation-Date: 2020-10-18 23:11+0300\n"
 "PO-Revision-Date: 2014-02-23 11:45+0100\n"
 "Last-Translator: Jonas Rydberg <jonas@drevo.se>\n"
 "Language-Team: wxWidgets translators <wx-translators@googlegroups.com>\n"
@@ -12,7 +12,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-#: ../src/common/debugrpt.cpp:586
+#: ../src/common/debugrpt.cpp:587
 msgid ""
 "\n"
 "Please send this report to the program maintainer, thank you!\n"
@@ -20,8 +20,8 @@ msgstr ""
 "\n"
 "Skicka den här rapporten till programansvarig. Tack!\n"
 
-#: ../src/richtext/richtextstyledlg.cpp:210
-#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:206
+#: ../src/richtext/richtextstyledlg.cpp:218
 msgid " "
 msgstr " "
 
@@ -29,70 +29,96 @@ msgstr " "
 msgid "              Thank you and we're sorry for the inconvenience!\n"
 msgstr "              Tack så mycket, och vi är ledsna för besväret!\n"
 
-#: ../src/common/prntbase.cpp:573
+#: ../src/common/prntbase.cpp:568
 #, c-format
 msgid " (copy %d of %d)"
 msgstr " (kopia %d av %d)"
 
-#: ../src/common/log.cpp:421
+#: ../src/common/log.cpp:440
 #, c-format
 msgid " (error %ld: %s)"
 msgstr " (fel %ld: %s)"
 
-#: ../src/common/imagtiff.cpp:72
+#: ../src/common/imagtiff.cpp:69
 #, c-format
 msgid " (in module \"%s\")"
 msgstr " (i modul \"%s\")"
 
-#: ../src/osx/core/secretstore.cpp:138
-msgid " (while overwriting an existing item)"
-msgstr ""
-
-#: ../src/common/docview.cpp:1642
+#: ../src/common/docview.cpp:1636
 msgid " - "
 msgstr " - "
 
-#: ../src/richtext/richtextprint.cpp:593 ../src/html/htmprint.cpp:714
+#: ../src/html/htmprint.cpp:712 ../src/richtext/richtextprint.cpp:589
 msgid " Preview"
 msgstr " Förhandsgranska"
 
-#: ../src/common/fontcmn.cpp:824
+#: ../src/common/fontcmn.cpp:973
 msgid " bold"
 msgstr " fet"
 
-#: ../src/common/fontcmn.cpp:840
+#: ../src/common/fontcmn.cpp:977
+#, fuzzy
+msgid " extra bold"
+msgstr " fet"
+
+#: ../src/common/fontcmn.cpp:985
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:957
+#, fuzzy
+msgid " extra light"
+msgstr " tunn"
+
+#: ../src/common/fontcmn.cpp:981
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1001
 msgid " italic"
 msgstr " kursiv"
 
-#: ../src/common/fontcmn.cpp:820
+#: ../src/common/fontcmn.cpp:961
 msgid " light"
 msgstr " tunn"
 
-#: ../src/common/fontcmn.cpp:807
+#: ../src/common/fontcmn.cpp:965
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:969
+#, fuzzy
+msgid " semi bold"
+msgstr " fet"
+
+#: ../src/common/fontcmn.cpp:940
 msgid " strikethrough"
 msgstr " genomstruken"
 
-#: ../src/common/paper.cpp:117
+#: ../src/common/fontcmn.cpp:953
+msgid " thin"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
 msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
 msgstr "#10 kuvert, 4 1/8 x 9 1/2 tum"
 
-#: ../src/common/paper.cpp:118
+#: ../src/common/paper.cpp:115
 msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
 msgstr "#11 kuvert, 4 1/2 x 10 3/8 tum"
 
-#: ../src/common/paper.cpp:119
+#: ../src/common/paper.cpp:116
 msgid "#12 Envelope, 4 3/4 x 11 in"
 msgstr "#12 kuvert, 4 3/4 x 11 tum"
 
-#: ../src/common/paper.cpp:120
+#: ../src/common/paper.cpp:117
 msgid "#14 Envelope, 5 x 11 1/2 in"
 msgstr "#14 kuvert, 5 x 11 1/2 tum"
 
-#: ../src/common/paper.cpp:116
+#: ../src/common/paper.cpp:113
 msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
 msgstr "#9 kuvert, 3 7/8 x 8 7/8 tum"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:341
 #: ../src/richtext/richtextsizepage.cpp:340
 #: ../src/richtext/richtextsizepage.cpp:374
 #: ../src/richtext/richtextsizepage.cpp:401
@@ -103,81 +129,82 @@ msgstr "#9 kuvert, 3 7/8 x 8 7/8 tum"
 #: ../src/richtext/richtextsizepage.cpp:591
 #: ../src/richtext/richtextsizepage.cpp:626
 #: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextbackgroundpage.cpp:341
 msgid "%"
 msgstr "%"
 
-#: ../src/html/helpwnd.cpp:1031
+#: ../src/html/helpwnd.cpp:1029
 #, c-format
 msgid "%d of %lu"
 msgstr "%d av %lu"
 
-#: ../src/html/helpwnd.cpp:1678
+#: ../src/html/helpwnd.cpp:1676
 #, fuzzy, c-format
 msgid "%i of %u"
 msgstr "%i av %i"
 
-#: ../src/generic/filectrlg.cpp:279
+#: ../src/generic/filectrlg.cpp:275
 #, c-format
 msgid "%ld byte"
 msgid_plural "%ld bytes"
 msgstr[0] "%ld byte"
 msgstr[1] "%ld byte"
 
-#: ../src/html/helpwnd.cpp:1033
+#: ../src/html/helpwnd.cpp:1031
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu av %lu"
 
-#: ../src/generic/datavgen.cpp:6028
+#: ../src/generic/datavgen.cpp:6833
 #, fuzzy, c-format
 msgid "%s (%d items)"
 msgstr "%s (eller %s)"
 
-#: ../src/common/cmdline.cpp:1221
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (eller %s)"
 
-#: ../src/generic/logg.cpp:224
+#: ../src/generic/logg.cpp:221
 #, c-format
 msgid "%s Error"
 msgstr "%s fel"
 
-#: ../src/generic/logg.cpp:236
+#: ../src/generic/logg.cpp:233
 #, c-format
 msgid "%s Information"
 msgstr "%s information"
 
-#: ../src/generic/preferencesg.cpp:113
+#: ../src/generic/preferencesg.cpp:110
 #, c-format
 msgid "%s Preferences"
 msgstr "%s inställningar"
 
-#: ../src/generic/logg.cpp:228
+#: ../src/generic/logg.cpp:225
 #, c-format
 msgid "%s Warning"
 msgstr "%s varning"
 
-#: ../src/common/tarstrm.cpp:1319
+#: ../src/common/tarstrm.cpp:1313
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s passade inte tar-huvudet för post \"%s\""
 
-#: ../src/common/fldlgcmn.cpp:124
+#: ../src/common/fldlgcmn.cpp:121
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s filer (%s)|%s"
 
-#: ../src/html/helpwnd.cpp:1716
+#: ../src/html/helpwnd.cpp:1714
 #, fuzzy, c-format
 msgid "%u of %u"
 msgstr "%lu av %lu"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "&About"
 msgstr "&Om"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "&Actual Size"
 msgstr "V&erklig storlek"
 
@@ -185,28 +212,28 @@ msgstr "V&erklig storlek"
 msgid "&After a paragraph:"
 msgstr "&Efter ett stycke:"
 
-#: ../src/richtext/richtextindentspage.cpp:128
 #: ../src/richtext/richtextliststylepage.cpp:319
+#: ../src/richtext/richtextindentspage.cpp:128
 msgid "&Alignment"
 msgstr "&Justering"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "&Apply"
 msgstr "&Verkställ"
 
-#: ../src/richtext/richtextstyledlg.cpp:251
+#: ../src/richtext/richtextstyledlg.cpp:247
 msgid "&Apply Style"
 msgstr "&Använd stil"
 
-#: ../src/msw/mdi.cpp:179
+#: ../src/msw/mdi.cpp:174
 msgid "&Arrange Icons"
 msgstr "Ordna &ikoner"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "&Ascending"
 msgstr "&Stigande"
 
-#: ../src/common/stockitem.cpp:142
+#: ../src/common/stockitem.cpp:139
 msgid "&Back"
 msgstr "&Bakåt"
 
@@ -226,24 +253,24 @@ msgstr "&Bg-färg:"
 msgid "&Blur distance:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:143
+#: ../src/common/stockitem.cpp:140
 msgid "&Bold"
 msgstr "&Fet"
 
-#: ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141
 msgid "&Bottom"
 msgstr "&Botten"
 
+#: ../src/richtext/richtextsizepage.cpp:637
+#: ../src/richtext/richtextsizepage.cpp:644
 #: ../src/richtext/richtextborderspage.cpp:345
 #: ../src/richtext/richtextborderspage.cpp:513
 #: ../src/richtext/richtextmarginspage.cpp:259
 #: ../src/richtext/richtextmarginspage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:637
-#: ../src/richtext/richtextsizepage.cpp:644
 msgid "&Bottom:"
 msgstr "&Undre"
 
-#: ../include/wx/richtext/richtextbuffer.h:3866
+#: ../include/wx/richtext/richtextbuffer.h:3861
 msgid "&Box"
 msgstr "&Låda"
 
@@ -252,38 +279,38 @@ msgstr "&Låda"
 msgid "&Bullet style:"
 msgstr "&Punktlisttecken:"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "&CD-Rom"
 msgstr "&cd-rom"
 
-#: ../src/generic/wizard.cpp:434 ../src/generic/fontdlgg.cpp:470
-#: ../src/generic/fontdlgg.cpp:489 ../src/osx/carbon/fontdlg.cpp:402
-#: ../src/common/dlgcmn.cpp:279 ../src/common/stockitem.cpp:145
+#: ../src/osx/carbon/fontdlg.cpp:399 ../src/common/stockitem.cpp:142
+#: ../src/generic/wizard.cpp:433 ../src/generic/fontdlgg.cpp:466
+#: ../src/generic/fontdlgg.cpp:485 ../src/osx/cocoa/button.mm:200
 msgid "&Cancel"
 msgstr "&Avbryt"
 
-#: ../src/msw/mdi.cpp:175
+#: ../src/msw/mdi.cpp:170
 msgid "&Cascade"
 msgstr "Över&lappande"
 
-#: ../include/wx/richtext/richtextbuffer.h:5960
+#: ../include/wx/richtext/richtextbuffer.h:5955
 msgid "&Cell"
 msgstr "&Cell"
 
-#: ../src/richtext/richtextsymboldlg.cpp:439
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "&Character code:"
 msgstr "&Teckenkod:"
 
-#: ../src/common/stockitem.cpp:147
+#: ../src/common/stockitem.cpp:144
 msgid "&Clear"
 msgstr "&Töm"
 
-#: ../src/generic/logg.cpp:516 ../src/common/stockitem.cpp:148
-#: ../src/common/prntbase.cpp:1600 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/stockitem.cpp:145 ../src/common/prntbase.cpp:1625
+#: ../src/univ/themes/win32.cpp:3753 ../src/generic/logg.cpp:513
 msgid "&Close"
 msgstr "St&äng"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "&Color"
 msgstr "F&ärg"
 
@@ -291,20 +318,20 @@ msgstr "F&ärg"
 msgid "&Colour:"
 msgstr "F&ärg:"
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "&Convert"
 msgstr "&Konvertera"
 
-#: ../src/richtext/richtextctrl.cpp:333 ../src/osx/textctrl_osx.cpp:577
-#: ../src/common/stockitem.cpp:150 ../src/msw/textctrl.cpp:2508
+#: ../src/osx/textctrl_osx.cpp:595 ../src/common/stockitem.cpp:147
+#: ../src/msw/textctrl.cpp:2773 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "K&opiera"
 
-#: ../src/generic/hyperlinkg.cpp:156
+#: ../src/generic/hyperlinkg.cpp:153
 msgid "&Copy URL"
 msgstr "K&opiera URL"
 
-#: ../src/common/headerctrlcmn.cpp:306
+#: ../src/common/headerctrlcmn.cpp:304
 msgid "&Customize..."
 msgstr "&Anpassa..."
 
@@ -312,53 +339,54 @@ msgstr "&Anpassa..."
 msgid "&Debug report preview:"
 msgstr "Förhandsgranskning av &debugrapport:"
 
-#: ../src/richtext/richtexttabspage.cpp:138
-#: ../src/richtext/richtextctrl.cpp:335 ../src/osx/textctrl_osx.cpp:579
-#: ../src/common/stockitem.cpp:152 ../src/msw/textctrl.cpp:2510
+#: ../src/osx/textctrl_osx.cpp:597 ../src/common/stockitem.cpp:149
+#: ../src/msw/textctrl.cpp:2775 ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtextctrl.cpp:334
 msgid "&Delete"
 msgstr "&Ta bort"
 
-#: ../src/richtext/richtextstyledlg.cpp:269
+#: ../src/richtext/richtextstyledlg.cpp:265
 msgid "&Delete Style..."
 msgstr "Ta &bort stil..."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "&Descending"
 msgstr "&Fallande"
 
-#: ../src/generic/logg.cpp:682
+#: ../src/generic/logg.cpp:679
 msgid "&Details"
 msgstr "&Detaljer"
 
-#: ../src/common/stockitem.cpp:153
+#: ../src/common/stockitem.cpp:150
 msgid "&Down"
 msgstr "&Ner"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "&Edit"
 msgstr "&Redigera"
 
-#: ../src/richtext/richtextstyledlg.cpp:263
+#: ../src/richtext/richtextstyledlg.cpp:259
 msgid "&Edit Style..."
 msgstr "&Redigera stil..."
 
-#: ../src/common/stockitem.cpp:155
+#: ../src/common/stockitem.cpp:152
 msgid "&Execute"
 msgstr "&Kör"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/common/stockitem.cpp:154
 msgid "&File"
 msgstr "&Arkiv"
 
-#: ../src/common/stockitem.cpp:158
-msgid "&Find"
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "&Find..."
 msgstr "&Sök"
 
-#: ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:430
 msgid "&Finish"
 msgstr "&Avsluta"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:156
 msgid "&First"
 msgstr "&Första"
 
@@ -366,15 +394,15 @@ msgstr "&Första"
 msgid "&Floating mode:"
 msgstr "&Flytande läge:"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "&Floppy"
 msgstr "&Diskett"
 
-#: ../src/common/stockitem.cpp:194
+#: ../src/common/stockitem.cpp:191
 msgid "&Font"
 msgstr "&Typsnitt"
 
-#: ../src/generic/fontdlgg.cpp:371
+#: ../src/generic/fontdlgg.cpp:367
 msgid "&Font family:"
 msgstr "&Typsnittsfamilj:"
 
@@ -382,20 +410,20 @@ msgstr "&Typsnittsfamilj:"
 msgid "&Font for Level..."
 msgstr "&Typsnitt för nivå..."
 
+#: ../src/richtext/richtextsymboldlg.cpp:397
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:400
 msgid "&Font:"
 msgstr "&Typsnitt:"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "&Forward"
 msgstr "&Framåt"
 
-#: ../src/richtext/richtextsymboldlg.cpp:451
+#: ../src/richtext/richtextsymboldlg.cpp:448
 msgid "&From:"
 msgstr "&Från:"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "&Harddisk"
 msgstr "&Hårddisk"
 
@@ -404,9 +432,9 @@ msgstr "&Hårddisk"
 msgid "&Height:"
 msgstr "&Höjd:"
 
-#: ../src/generic/wizard.cpp:441 ../src/richtext/richtextstyledlg.cpp:303
-#: ../src/richtext/richtextsymboldlg.cpp:479 ../src/osx/menu_osx.cpp:734
-#: ../src/common/stockitem.cpp:163
+#: ../src/common/stockitem.cpp:160 ../src/generic/wizard.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextstyledlg.cpp:299 ../src/osx/cocoa/menu.mm:226
 msgid "&Help"
 msgstr "&Hjälp"
 
@@ -414,7 +442,7 @@ msgstr "&Hjälp"
 msgid "&Hide details"
 msgstr "&Dölj detaljer"
 
-#: ../src/common/stockitem.cpp:164
+#: ../src/common/stockitem.cpp:161
 msgid "&Home"
 msgstr "&Hem"
 
@@ -422,54 +450,54 @@ msgstr "&Hem"
 msgid "&Horizontal offset:"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:184
 #: ../src/richtext/richtextliststylepage.cpp:372
+#: ../src/richtext/richtextindentspage.cpp:184
 msgid "&Indentation (tenths of a mm)"
 msgstr "&Indrag (tiondelar av mm)"
 
-#: ../src/richtext/richtextindentspage.cpp:167
 #: ../src/richtext/richtextliststylepage.cpp:356
+#: ../src/richtext/richtextindentspage.cpp:167
 msgid "&Indeterminate"
 msgstr "&Obestämd"
 
-#: ../src/common/stockitem.cpp:166
+#: ../src/common/stockitem.cpp:163
 msgid "&Index"
 msgstr "&Index"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "&Info"
 msgstr "&Info"
 
-#: ../src/common/stockitem.cpp:168
+#: ../src/common/stockitem.cpp:165
 msgid "&Italic"
 msgstr "&Kursiv"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "&Jump to"
 msgstr "&Hoppa till"
 
-#: ../src/richtext/richtextindentspage.cpp:153
 #: ../src/richtext/richtextliststylepage.cpp:342
+#: ../src/richtext/richtextindentspage.cpp:153
 msgid "&Justified"
 msgstr "Marginal&justerad"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "&Last"
 msgstr "&Sista"
 
-#: ../src/richtext/richtextindentspage.cpp:139
 #: ../src/richtext/richtextliststylepage.cpp:328
+#: ../src/richtext/richtextindentspage.cpp:139
 msgid "&Left"
 msgstr "&Vänster"
 
-#: ../src/richtext/richtextindentspage.cpp:195
+#: ../src/richtext/richtextsizepage.cpp:532
+#: ../src/richtext/richtextsizepage.cpp:539
 #: ../src/richtext/richtextborderspage.cpp:243
 #: ../src/richtext/richtextborderspage.cpp:411
 #: ../src/richtext/richtextliststylepage.cpp:381
+#: ../src/richtext/richtextindentspage.cpp:195
 #: ../src/richtext/richtextmarginspage.cpp:186
 #: ../src/richtext/richtextmarginspage.cpp:300
-#: ../src/richtext/richtextsizepage.cpp:532
-#: ../src/richtext/richtextsizepage.cpp:539
 msgid "&Left:"
 msgstr "&Vänster:"
 
@@ -477,11 +505,11 @@ msgstr "&Vänster:"
 msgid "&List level:"
 msgstr "&Listnivå:"
 
-#: ../src/generic/logg.cpp:517
+#: ../src/generic/logg.cpp:514
 msgid "&Log"
 msgstr "&Logga"
 
-#: ../src/univ/themes/win32.cpp:3748
+#: ../src/univ/themes/win32.cpp:3745
 msgid "&Move"
 msgstr "&Flytta"
 
@@ -489,20 +517,19 @@ msgstr "&Flytta"
 msgid "&Move the object to:"
 msgstr "&Flytta objektet till:"
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "&Network"
 msgstr "&Nätverk"
 
-#: ../src/richtext/richtexttabspage.cpp:132 ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173 ../src/richtext/richtexttabspage.cpp:132
 msgid "&New"
 msgstr "&Ny"
 
-#: ../src/aui/tabmdi.cpp:111 ../src/generic/mdig.cpp:100
-#: ../src/msw/mdi.cpp:180
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
 msgid "&Next"
 msgstr "&Nästa"
 
-#: ../src/generic/wizard.cpp:432 ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:429
 msgid "&Next >"
 msgstr "&Nästa >"
 
@@ -510,7 +537,7 @@ msgstr "&Nästa >"
 msgid "&Next Paragraph"
 msgstr "&Nästa stycke"
 
-#: ../src/generic/tipdlg.cpp:240
+#: ../src/generic/tipdlg.cpp:237
 msgid "&Next Tip"
 msgstr "&Nästa tips"
 
@@ -518,11 +545,11 @@ msgstr "&Nästa tips"
 msgid "&Next style:"
 msgstr "&Nästa stil:"
 
-#: ../src/common/stockitem.cpp:177 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:174 ../src/msw/msgdlg.cpp:435
 msgid "&No"
 msgstr "&Nej"
 
-#: ../src/generic/dbgrptg.cpp:356
+#: ../src/generic/dbgrptg.cpp:360
 msgid "&Notes:"
 msgstr "&Anteckningar:"
 
@@ -530,12 +557,12 @@ msgstr "&Anteckningar:"
 msgid "&Number:"
 msgstr "&Nummer:"
 
-#: ../src/generic/fontdlgg.cpp:475 ../src/generic/fontdlgg.cpp:482
-#: ../src/osx/carbon/fontdlg.cpp:408 ../src/common/stockitem.cpp:178
+#: ../src/osx/carbon/fontdlg.cpp:405 ../src/common/stockitem.cpp:175
+#: ../src/generic/fontdlgg.cpp:471 ../src/generic/fontdlgg.cpp:478
 msgid "&OK"
 msgstr "&OK"
 
-#: ../src/generic/dbgrptg.cpp:342 ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176 ../src/generic/dbgrptg.cpp:342
 msgid "&Open..."
 msgstr "&Öppna..."
 
@@ -547,16 +574,16 @@ msgstr "&Sammanfattningsnivå:"
 msgid "&Page Break"
 msgstr "&Sidbrytning"
 
-#: ../src/richtext/richtextctrl.cpp:334 ../src/osx/textctrl_osx.cpp:578
-#: ../src/common/stockitem.cpp:180 ../src/msw/textctrl.cpp:2509
+#: ../src/osx/textctrl_osx.cpp:596 ../src/common/stockitem.cpp:177
+#: ../src/msw/textctrl.cpp:2774 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "K&listra in"
 
-#: ../include/wx/richtext/richtextbuffer.h:5010
+#: ../include/wx/richtext/richtextbuffer.h:5005
 msgid "&Picture"
 msgstr "&Bild"
 
-#: ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:419
 msgid "&Point size:"
 msgstr "&Punktstorlek:"
 
@@ -568,12 +595,11 @@ msgstr "&Position (tiondelar av mm):"
 msgid "&Position mode:"
 msgstr "&Positionsläge:"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178
 msgid "&Preferences"
 msgstr "&Inställningar"
 
-#: ../src/aui/tabmdi.cpp:112 ../src/generic/mdig.cpp:101
-#: ../src/msw/mdi.cpp:181
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
 msgid "&Previous"
 msgstr "&Föregående"
 
@@ -581,78 +607,74 @@ msgstr "&Föregående"
 msgid "&Previous Paragraph"
 msgstr "&Föregående stycke"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "&Print..."
 msgstr "Skriv &ut..."
 
-#: ../src/richtext/richtextctrl.cpp:339 ../src/richtext/richtextctrl.cpp:5514
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtextctrl.cpp:338
+#: ../src/richtext/richtextctrl.cpp:5512
 msgid "&Properties"
 msgstr "&Egenskaper"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "&Quit"
 msgstr "&Avsluta"
 
-#: ../src/richtext/richtextctrl.cpp:330 ../src/osx/textctrl_osx.cpp:574
-#: ../src/common/stockitem.cpp:185 ../src/common/cmdproc.cpp:293
-#: ../src/common/cmdproc.cpp:300 ../src/msw/textctrl.cpp:2505
+#: ../src/osx/textctrl_osx.cpp:592 ../src/common/stockitem.cpp:182
+#: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
+#: ../src/msw/textctrl.cpp:2770 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Upprepa"
 
-#: ../src/common/cmdproc.cpp:289 ../src/common/cmdproc.cpp:309
+#: ../src/common/cmdproc.cpp:282 ../src/common/cmdproc.cpp:302
 msgid "&Redo "
 msgstr "&Upprepa "
 
-#: ../src/richtext/richtextstyledlg.cpp:257
+#: ../src/richtext/richtextstyledlg.cpp:253
 msgid "&Rename Style..."
 msgstr "&Byt namn på stil..."
 
-#: ../src/generic/fdrepdlg.cpp:179
+#: ../src/generic/fdrepdlg.cpp:176
 msgid "&Replace"
 msgstr "&Ersätt"
 
-#: ../src/richtext/richtextstyledlg.cpp:287
+#: ../src/richtext/richtextstyledlg.cpp:283
 msgid "&Restart numbering"
 msgstr "&Börja om numrering"
 
-#: ../src/univ/themes/win32.cpp:3747
+#: ../src/univ/themes/win32.cpp:3744
 msgid "&Restore"
 msgstr "&Återställ"
 
-#: ../src/richtext/richtextindentspage.cpp:146
 #: ../src/richtext/richtextliststylepage.cpp:335
+#: ../src/richtext/richtextindentspage.cpp:146
 msgid "&Right"
 msgstr "&Höger"
 
-#: ../src/richtext/richtextindentspage.cpp:213
+#: ../src/richtext/richtextsizepage.cpp:602
+#: ../src/richtext/richtextsizepage.cpp:609
 #: ../src/richtext/richtextborderspage.cpp:277
 #: ../src/richtext/richtextborderspage.cpp:445
 #: ../src/richtext/richtextliststylepage.cpp:399
+#: ../src/richtext/richtextindentspage.cpp:213
 #: ../src/richtext/richtextmarginspage.cpp:211
 #: ../src/richtext/richtextmarginspage.cpp:325
-#: ../src/richtext/richtextsizepage.cpp:602
-#: ../src/richtext/richtextsizepage.cpp:609
 msgid "&Right:"
 msgstr "&Höger:"
 
-#: ../src/common/stockitem.cpp:190
+#: ../src/common/stockitem.cpp:187
 msgid "&Save"
 msgstr "&Spara"
-
-#: ../src/common/stockitem.cpp:191
-msgid "&Save as"
-msgstr "Spara s&om"
 
 #: ../include/wx/richmsgdlg.h:29
 msgid "&See details"
 msgstr "&Visa detaljer"
 
-#: ../src/generic/tipdlg.cpp:236
+#: ../src/generic/tipdlg.cpp:233
 msgid "&Show tips at startup"
 msgstr "&Visa tips vid start"
 
-#: ../src/univ/themes/win32.cpp:3750
+#: ../src/univ/themes/win32.cpp:3747
 msgid "&Size"
 msgstr "&Storlek"
 
@@ -660,36 +682,36 @@ msgstr "&Storlek"
 msgid "&Size:"
 msgstr "&Storlek:"
 
-#: ../src/generic/progdlgg.cpp:252
+#: ../src/generic/progdlgg.cpp:249
 msgid "&Skip"
 msgstr "&Hoppa över"
 
-#: ../src/richtext/richtextindentspage.cpp:242
 #: ../src/richtext/richtextliststylepage.cpp:417
+#: ../src/richtext/richtextindentspage.cpp:242
 msgid "&Spacing (tenths of a mm)"
 msgstr "&Avstånd (tiondelar av mm)"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "&Spell Check"
 msgstr "&Stavningskontroll"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "&Stop"
 msgstr "&Stopp"
 
-#: ../src/richtext/richtextfontpage.cpp:275 ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196 ../src/richtext/richtextfontpage.cpp:275
 msgid "&Strikethrough"
 msgstr "&Genomstruken"
 
-#: ../src/generic/fontdlgg.cpp:382 ../src/richtext/richtextstylepage.cpp:106
+#: ../src/generic/fontdlgg.cpp:378 ../src/richtext/richtextstylepage.cpp:106
 msgid "&Style:"
 msgstr "&Stil:"
 
-#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:194
 msgid "&Styles:"
 msgstr "&Stilar:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:413
+#: ../src/richtext/richtextsymboldlg.cpp:410
 msgid "&Subset:"
 msgstr "&Delmängd:"
 
@@ -703,24 +725,24 @@ msgstr "&Symbol:"
 msgid "&Synchronize values"
 msgstr "&Synkronisera värden"
 
-#: ../include/wx/richtext/richtextbuffer.h:6069
+#: ../include/wx/richtext/richtextbuffer.h:6064
 msgid "&Table"
 msgstr "&Tabell"
 
-#: ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197
 msgid "&Top"
 msgstr "&Toppen"
 
+#: ../src/richtext/richtextsizepage.cpp:567
+#: ../src/richtext/richtextsizepage.cpp:574
 #: ../src/richtext/richtextborderspage.cpp:311
 #: ../src/richtext/richtextborderspage.cpp:479
 #: ../src/richtext/richtextmarginspage.cpp:234
 #: ../src/richtext/richtextmarginspage.cpp:348
-#: ../src/richtext/richtextsizepage.cpp:567
-#: ../src/richtext/richtextsizepage.cpp:574
 msgid "&Top:"
 msgstr "&Övre:"
 
-#: ../src/generic/fontdlgg.cpp:444 ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199 ../src/generic/fontdlgg.cpp:441
 msgid "&Underline"
 msgstr "&Understrykning"
 
@@ -728,21 +750,21 @@ msgstr "&Understrykning"
 msgid "&Underlining:"
 msgstr "&Understrykning:"
 
-#: ../src/richtext/richtextctrl.cpp:329 ../src/osx/textctrl_osx.cpp:573
-#: ../src/common/stockitem.cpp:203 ../src/common/cmdproc.cpp:271
-#: ../src/msw/textctrl.cpp:2504
+#: ../src/osx/textctrl_osx.cpp:591 ../src/common/stockitem.cpp:200
+#: ../src/common/cmdproc.cpp:264 ../src/msw/textctrl.cpp:2769
+#: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Ångra"
 
-#: ../src/common/cmdproc.cpp:265
+#: ../src/common/cmdproc.cpp:258
 msgid "&Undo "
 msgstr "&Ångra "
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "&Unindent"
 msgstr "&Utindentera"
 
-#: ../src/common/stockitem.cpp:205
+#: ../src/common/stockitem.cpp:202
 msgid "&Up"
 msgstr "&Upp"
 
@@ -759,7 +781,7 @@ msgstr "&Vertical justering:"
 msgid "&View..."
 msgstr "&Visa..."
 
-#: ../src/generic/fontdlgg.cpp:393
+#: ../src/generic/fontdlgg.cpp:389
 msgid "&Weight:"
 msgstr "&Vikt:"
 
@@ -768,88 +790,58 @@ msgstr "&Vikt:"
 msgid "&Width:"
 msgstr "&Bredd:"
 
-#: ../src/aui/tabmdi.cpp:311 ../src/aui/tabmdi.cpp:327
-#: ../src/aui/tabmdi.cpp:329 ../src/generic/mdig.cpp:294
-#: ../src/generic/mdig.cpp:310 ../src/generic/mdig.cpp:314
-#: ../src/msw/mdi.cpp:78
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
 msgid "&Window"
 msgstr "&Fönster"
 
-#: ../src/common/stockitem.cpp:206 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:203 ../src/msw/msgdlg.cpp:435
 msgid "&Yes"
 msgstr "&Ja"
 
-#: ../src/common/valtext.cpp:256
+#: ../src/common/valtext.cpp:197
 #, fuzzy, c-format
-msgid "'%s' contains illegal characters"
+msgid "'%s' contains invalid character(s)"
 msgstr "\"%s\" får bara innehålla alfabetiska tecken."
 
-#: ../src/common/valtext.cpp:254
-#, fuzzy, c-format
-msgid "'%s' doesn't consist only of valid characters"
-msgstr "\"%s\" får bara innehålla alfabetiska tecken."
-
-#: ../src/common/config.cpp:519 ../src/msw/regconf.cpp:258
+#: ../src/common/config.cpp:515 ../src/msw/regconf.cpp:255
 #, c-format
 msgid "'%s' has extra '..', ignored."
 msgstr "\"%s\" har extra \"..\", ignoreras."
 
-#: ../src/common/cmdline.cpp:1113 ../src/common/cmdline.cpp:1131
+#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "\"%s\" är inte ett korrekt numeriskt värde för flagga \"%s\"."
 
-#: ../src/common/translation.cpp:1100
+#: ../src/common/translation.cpp:1142
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "\"%s\" är inte en giltig meddelandekatalog."
 
-#: ../src/common/valtext.cpp:165
+#: ../src/common/valtext.cpp:188
 #, fuzzy, c-format
 msgid "'%s' is not one of the valid strings"
 msgstr "\"%s\" är inte en giltig meddelandekatalog."
 
-#: ../src/common/valtext.cpp:167
+#: ../src/common/valtext.cpp:186
 #, fuzzy, c-format
 msgid "'%s' is one of the invalid strings"
 msgstr "\"%s\" är ogiltig"
 
-#: ../src/common/textbuf.cpp:237
+#: ../src/common/textbuf.cpp:233
 #, c-format
 msgid "'%s' is probably a binary buffer."
 msgstr "\"%s\" är troligen en binär buffer."
-
-#: ../src/common/valtext.cpp:252
-#, c-format
-msgid "'%s' should be numeric."
-msgstr "\"%s\" skall vara numerisk."
-
-#: ../src/common/valtext.cpp:244
-#, c-format
-msgid "'%s' should only contain ASCII characters."
-msgstr "\"%s\" får bara innehålla ASCII-tecken."
-
-#: ../src/common/valtext.cpp:246
-#, c-format
-msgid "'%s' should only contain alphabetic characters."
-msgstr "\"%s\" får bara innehålla alfabetiska tecken."
-
-#: ../src/common/valtext.cpp:248
-#, c-format
-msgid "'%s' should only contain alphabetic or numeric characters."
-msgstr "\"%s\" får bara innehålla alfabetiska eller numeriska tecken."
-
-#: ../src/common/valtext.cpp:250
-#, c-format
-msgid "'%s' should only contain digits."
-msgstr "\"%s\" får bara innehålla siffror."
 
 #: ../src/richtext/richtextliststylepage.cpp:229
 #: ../src/richtext/richtextbulletspage.cpp:166
 msgid "(*)"
 msgstr "(*)"
 
-#: ../src/html/helpwnd.cpp:963
+#: ../src/html/helpwnd.cpp:961
 msgid "(Help)"
 msgstr "(Hjälp)"
 
@@ -858,27 +850,32 @@ msgstr "(Hjälp)"
 msgid "(None)"
 msgstr "(Ingen)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:504
+#: ../src/richtext/richtextsymboldlg.cpp:503
 msgid "(Normal text)"
 msgstr "(Normal text)"
 
-#: ../src/html/helpwnd.cpp:419 ../src/html/helpwnd.cpp:1106
-#: ../src/html/helpwnd.cpp:1742
+#: ../src/html/helpwnd.cpp:417 ../src/html/helpwnd.cpp:1104
+#: ../src/html/helpwnd.cpp:1740
 msgid "(bookmarks)"
 msgstr "(bokmärken)"
 
+#: ../src/msw/dlmsw.cpp:167
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (fel %ld: %s)"
+
+#: ../src/richtext/richtextformatdlg.cpp:876
+#: ../src/richtext/richtextliststylepage.cpp:448
+#: ../src/richtext/richtextliststylepage.cpp:460
+#: ../src/richtext/richtextliststylepage.cpp:461
 #: ../src/richtext/richtextindentspage.cpp:274
 #: ../src/richtext/richtextindentspage.cpp:286
 #: ../src/richtext/richtextindentspage.cpp:287
 #: ../src/richtext/richtextindentspage.cpp:311
 #: ../src/richtext/richtextindentspage.cpp:326
-#: ../src/richtext/richtextformatdlg.cpp:884
 #: ../src/richtext/richtextfontpage.cpp:349
 #: ../src/richtext/richtextfontpage.cpp:353
 #: ../src/richtext/richtextfontpage.cpp:357
-#: ../src/richtext/richtextliststylepage.cpp:448
-#: ../src/richtext/richtextliststylepage.cpp:460
-#: ../src/richtext/richtextliststylepage.cpp:461
 msgid "(none)"
 msgstr "(ingen)"
 
@@ -897,7 +894,7 @@ msgstr "*)"
 msgid "+"
 msgstr "+"
 
-#: ../src/msw/utils.cpp:1152
+#: ../src/msw/utils.cpp:1143
 msgid ", 64-bit edition"
 msgstr ", 64-bitarsutgåva"
 
@@ -906,163 +903,163 @@ msgstr ", 64-bitarsutgåva"
 msgid "-"
 msgstr "-"
 
-#: ../src/generic/filepickerg.cpp:66
+#: ../src/generic/filepickerg.cpp:63
 msgid "..."
 msgstr "…"
 
-#: ../src/richtext/richtextindentspage.cpp:276
 #: ../src/richtext/richtextliststylepage.cpp:450
+#: ../src/richtext/richtextindentspage.cpp:276
 msgid "1.1"
 msgstr "1.1"
 
-#: ../src/richtext/richtextindentspage.cpp:277
 #: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextindentspage.cpp:277
 msgid "1.2"
 msgstr "1.2"
 
-#: ../src/richtext/richtextindentspage.cpp:278
 #: ../src/richtext/richtextliststylepage.cpp:452
+#: ../src/richtext/richtextindentspage.cpp:278
 msgid "1.3"
 msgstr "1.3"
 
-#: ../src/richtext/richtextindentspage.cpp:279
 #: ../src/richtext/richtextliststylepage.cpp:453
+#: ../src/richtext/richtextindentspage.cpp:279
 msgid "1.4"
 msgstr "1.4"
 
-#: ../src/richtext/richtextindentspage.cpp:280
 #: ../src/richtext/richtextliststylepage.cpp:454
+#: ../src/richtext/richtextindentspage.cpp:280
 msgid "1.5"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:281
 #: ../src/richtext/richtextliststylepage.cpp:455
+#: ../src/richtext/richtextindentspage.cpp:281
 msgid "1.6"
 msgstr "1.6"
 
-#: ../src/richtext/richtextindentspage.cpp:282
 #: ../src/richtext/richtextliststylepage.cpp:456
+#: ../src/richtext/richtextindentspage.cpp:282
 msgid "1.7"
 msgstr "1.7"
 
-#: ../src/richtext/richtextindentspage.cpp:283
 #: ../src/richtext/richtextliststylepage.cpp:457
+#: ../src/richtext/richtextindentspage.cpp:283
 msgid "1.8"
 msgstr "1.8"
 
-#: ../src/richtext/richtextindentspage.cpp:284
 #: ../src/richtext/richtextliststylepage.cpp:458
+#: ../src/richtext/richtextindentspage.cpp:284
 msgid "1.9"
 msgstr "1.9"
 
-#: ../src/common/paper.cpp:140
+#: ../src/common/paper.cpp:137
 msgid "10 x 11 in"
 msgstr "10 x 11 tum"
 
-#: ../src/common/paper.cpp:113
+#: ../src/common/paper.cpp:110
 msgid "10 x 14 in"
 msgstr "10 x 14 tum"
 
-#: ../src/common/paper.cpp:114
+#: ../src/common/paper.cpp:111
 msgid "11 x 17 in"
 msgstr "11 x 17 tum"
 
-#: ../src/common/paper.cpp:184
+#: ../src/common/paper.cpp:181
 msgid "12 x 11 in"
 msgstr "12 x 11 tum"
 
-#: ../src/common/paper.cpp:141
+#: ../src/common/paper.cpp:138
 msgid "15 x 11 in"
 msgstr "15 x 11 tum"
 
-#: ../src/richtext/richtextindentspage.cpp:285
 #: ../src/richtext/richtextliststylepage.cpp:459
+#: ../src/richtext/richtextindentspage.cpp:285
 msgid "2"
 msgstr "2"
 
-#: ../src/common/paper.cpp:132
+#: ../src/common/paper.cpp:129
 msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
 msgstr "6 3/4 kuvert, 3 5/8 x 6 1/2 tum"
 
-#: ../src/common/paper.cpp:139
+#: ../src/common/paper.cpp:136
 msgid "9 x 11 in"
 msgstr "9 x 11 tum"
 
-#: ../src/html/htmprint.cpp:431
+#: ../src/html/htmprint.cpp:443
 msgid ": file does not exist!"
 msgstr ": filen finns inte!"
 
-#: ../src/common/fontmap.cpp:199
+#: ../src/common/fontmap.cpp:196
 msgid ": unknown charset"
 msgstr ": okänd teckenuppsättning"
 
-#: ../src/common/fontmap.cpp:413
+#: ../src/common/fontmap.cpp:410
 msgid ": unknown encoding"
 msgstr ": okänd kodning"
 
-#: ../src/generic/wizard.cpp:443
+#: ../src/generic/wizard.cpp:438
 msgid "< &Back"
 msgstr "< &Bakåt"
 
-#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:628
-#: ../src/osx/carbon/fontdlg.cpp:648
+#: ../src/osx/carbon/fontdlg.cpp:419 ../src/osx/carbon/fontdlg.cpp:625
+#: ../src/osx/carbon/fontdlg.cpp:645
 msgid "<Any Decorative>"
 msgstr "<Någon dekorativ>"
 
-#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:630
-#: ../src/osx/carbon/fontdlg.cpp:650
+#: ../src/osx/carbon/fontdlg.cpp:420 ../src/osx/carbon/fontdlg.cpp:627
+#: ../src/osx/carbon/fontdlg.cpp:647
 msgid "<Any Modern>"
 msgstr "<Någon modern>"
 
-#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:626
-#: ../src/osx/carbon/fontdlg.cpp:646
+#: ../src/osx/carbon/fontdlg.cpp:418 ../src/osx/carbon/fontdlg.cpp:623
+#: ../src/osx/carbon/fontdlg.cpp:643
 msgid "<Any Roman>"
 msgstr "<Någon roman>"
 
-#: ../src/osx/carbon/fontdlg.cpp:424 ../src/osx/carbon/fontdlg.cpp:632
-#: ../src/osx/carbon/fontdlg.cpp:652
+#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:629
+#: ../src/osx/carbon/fontdlg.cpp:649
 msgid "<Any Script>"
 msgstr "<Någon skrivstil>"
 
-#: ../src/osx/carbon/fontdlg.cpp:425 ../src/osx/carbon/fontdlg.cpp:637
-#: ../src/osx/carbon/fontdlg.cpp:656
+#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:634
+#: ../src/osx/carbon/fontdlg.cpp:653
 msgid "<Any Swiss>"
 msgstr "<Någon swiss>"
 
-#: ../src/osx/carbon/fontdlg.cpp:426 ../src/osx/carbon/fontdlg.cpp:634
-#: ../src/osx/carbon/fontdlg.cpp:654
+#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:631
+#: ../src/osx/carbon/fontdlg.cpp:651
 msgid "<Any Teletype>"
 msgstr "<Någon teletyp>"
 
-#: ../src/osx/carbon/fontdlg.cpp:420
+#: ../src/osx/carbon/fontdlg.cpp:417
 msgid "<Any>"
 msgstr "<Någon>"
 
-#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
 msgid "<DIR>"
 msgstr "<KAT>"
 
-#: ../src/generic/filectrlg.cpp:254 ../src/generic/filectrlg.cpp:277
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
 msgid "<DRIVE>"
 msgstr "<ENHET>"
 
-#: ../src/generic/filectrlg.cpp:252 ../src/generic/filectrlg.cpp:275
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
 msgid "<LINK>"
 msgstr "<LÄNK>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1264
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Fet kursiv.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1270
+#: ../src/html/helpwnd.cpp:1268
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>fet kursiv <u>understruket</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1265
+#: ../src/html/helpwnd.cpp:1263
 msgid "<b>Bold face.</b> "
 msgstr "<b>Fet.</b> "
 
-#: ../src/html/helpwnd.cpp:1264
+#: ../src/html/helpwnd.cpp:1262
 msgid "<i>Italic face.</i> "
 msgstr "<i>Kursiv.</i> "
 
@@ -1071,15 +1068,15 @@ msgstr "<i>Kursiv.</i> "
 msgid ">"
 msgstr ">"
 
-#: ../src/generic/dbgrptg.cpp:318
+#: ../src/generic/dbgrptg.cpp:317
 msgid "A debug report has been generated in the directory\n"
 msgstr "En debugrapport har skapats i katalogen\n"
 
-#: ../src/common/debugrpt.cpp:573
+#: ../src/common/debugrpt.cpp:574
 msgid "A debug report has been generated. It can be found in"
 msgstr "En debugrapport har skapats. Den kan hittas i"
 
-#: ../src/common/xtixml.cpp:418
+#: ../src/common/xtixml.cpp:414
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "En icke tom samling måste bestå av \"element\"-noder"
 
@@ -1090,106 +1087,106 @@ msgstr "En icke tom samling måste bestå av \"element\"-noder"
 msgid "A standard bullet name."
 msgstr "Ett standard punktlisttecken."
 
-#: ../src/common/paper.cpp:217
+#: ../src/common/paper.cpp:214
 msgid "A0 sheet, 841 x 1189 mm"
 msgstr "A0 ark, 841 x 1189 mm"
 
-#: ../src/common/paper.cpp:218
+#: ../src/common/paper.cpp:215
 msgid "A1 sheet, 594 x 841 mm"
 msgstr "A1 ark, 594 x 841 mm"
 
-#: ../src/common/paper.cpp:159
+#: ../src/common/paper.cpp:156
 msgid "A2 420 x 594 mm"
 msgstr "A2 420 x 594 mm"
 
-#: ../src/common/paper.cpp:156
+#: ../src/common/paper.cpp:153
 msgid "A3 Extra 322 x 445 mm"
 msgstr "A3 extra 322 x 445 mm"
 
-#: ../src/common/paper.cpp:161
+#: ../src/common/paper.cpp:158
 msgid "A3 Extra Transverse 322 x 445 mm"
 msgstr "A3 extra transverserad 322 x 445 mm"
 
-#: ../src/common/paper.cpp:170
+#: ../src/common/paper.cpp:167
 msgid "A3 Rotated 420 x 297 mm"
 msgstr "A3 roterad 420 x 297 mm"
 
-#: ../src/common/paper.cpp:160
+#: ../src/common/paper.cpp:157
 msgid "A3 Transverse 297 x 420 mm"
 msgstr "A3 transverserad 297 x 420 mm"
 
-#: ../src/common/paper.cpp:106
+#: ../src/common/paper.cpp:103
 msgid "A3 sheet, 297 x 420 mm"
 msgstr "A3 ark, 297 x 420 mm"
 
-#: ../src/common/paper.cpp:146
+#: ../src/common/paper.cpp:143
 msgid "A4 Extra 9.27 x 12.69 in"
 msgstr "A4 extra 9,27 x 12,69 tum"
 
-#: ../src/common/paper.cpp:153
+#: ../src/common/paper.cpp:150
 msgid "A4 Plus 210 x 330 mm"
 msgstr "A4 plus 210 x 330 mm"
 
-#: ../src/common/paper.cpp:171
+#: ../src/common/paper.cpp:168
 msgid "A4 Rotated 297 x 210 mm"
 msgstr "A4 roterad 297 x 210 mm"
 
-#: ../src/common/paper.cpp:148
+#: ../src/common/paper.cpp:145
 msgid "A4 Transverse 210 x 297 mm"
 msgstr "A4 transverserad 210 x 297 mm"
 
-#: ../src/common/paper.cpp:97
+#: ../src/common/paper.cpp:94
 msgid "A4 sheet, 210 x 297 mm"
 msgstr "A4 ark, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:107
+#: ../src/common/paper.cpp:104
 msgid "A4 small sheet, 210 x 297 mm"
 msgstr "A4 litet ark, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:157
+#: ../src/common/paper.cpp:154
 msgid "A5 Extra 174 x 235 mm"
 msgstr "A5 extra 174 x 235 mm"
 
-#: ../src/common/paper.cpp:172
+#: ../src/common/paper.cpp:169
 msgid "A5 Rotated 210 x 148 mm"
 msgstr "A5 roterad 210 x 148 mm"
 
-#: ../src/common/paper.cpp:154
+#: ../src/common/paper.cpp:151
 msgid "A5 Transverse 148 x 210 mm"
 msgstr "A5 transverserad 148 x 210 mm"
 
-#: ../src/common/paper.cpp:108
+#: ../src/common/paper.cpp:105
 msgid "A5 sheet, 148 x 210 mm"
 msgstr "A5 ark, 148 x 210 mm"
 
-#: ../src/common/paper.cpp:164
+#: ../src/common/paper.cpp:161
 msgid "A6 105 x 148 mm"
 msgstr "A6 105 x 148 mm"
 
-#: ../src/common/paper.cpp:177
+#: ../src/common/paper.cpp:174
 msgid "A6 Rotated 148 x 105 mm"
 msgstr "A6 roterad 148 x 105 mm"
 
-#: ../src/generic/fontdlgg.cpp:83 ../src/richtext/richtextformatdlg.cpp:529
-#: ../src/osx/carbon/fontdlg.cpp:153
+#: ../src/osx/carbon/fontdlg.cpp:150 ../src/generic/fontdlgg.cpp:79
+#: ../src/richtext/richtextformatdlg.cpp:521
 msgid "ABCDEFGabcdefg12345"
 msgstr "ABCDEFGabcdefg12345"
 
-#: ../src/richtext/richtextsymboldlg.cpp:458 ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
 msgid "ASCII"
 msgstr "ASCII"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "About"
 msgstr "Om"
 
-#: ../src/generic/aboutdlgg.cpp:140 ../src/osx/menu_osx.cpp:558
-#: ../src/msw/aboutdlg.cpp:64
+#: ../src/osx/menu_osx.cpp:450 ../src/generic/aboutdlgg.cpp:137
+#: ../src/msw/aboutdlg.cpp:61
 #, c-format
 msgid "About %s"
 msgstr "Om %s"
 
-#: ../src/osx/menu_osx.cpp:560
+#: ../src/osx/menu_osx.cpp:452
 msgid "About..."
 msgstr "Om..."
 
@@ -1198,38 +1195,38 @@ msgid "Absolute"
 msgstr "Absolut"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:873
+#: ../src/propgrid/advprops.cpp:774
 #, fuzzy
 msgid "ActiveBorder"
 msgstr "Ram"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:874
+#: ../src/propgrid/advprops.cpp:775
 msgid "ActiveCaption"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "Actual Size"
 msgstr "Verklig storlek"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:140 ../src/common/accelcmn.cpp:81
+#: ../src/common/stockitem.cpp:137 ../src/common/accelcmn.cpp:78
 msgid "Add"
 msgstr "Lägg till"
 
-#: ../src/richtext/richtextbuffer.cpp:11455
+#: ../src/richtext/richtextbuffer.cpp:11454
 msgid "Add Column"
 msgstr "Lägg till kolumn"
 
-#: ../src/richtext/richtextbuffer.cpp:11392
+#: ../src/richtext/richtextbuffer.cpp:11391
 msgid "Add Row"
 msgstr "Lägg till rad"
 
-#: ../src/html/helpwnd.cpp:432
+#: ../src/html/helpwnd.cpp:430
 msgid "Add current page to bookmarks"
 msgstr "Lägg till aktuell sida till bokmärken"
 
-#: ../src/generic/colrdlgg.cpp:366
+#: ../src/generic/colrdlgg.cpp:386
 msgid "Add to custom colours"
 msgstr "Lägg till till egendefinierade färger"
 
@@ -1241,12 +1238,12 @@ msgstr "AddToPropertyCollection anropad på ett allmänt åtkomstobjekt"
 msgid "AddToPropertyCollection called w/o valid adder"
 msgstr "AddToPropertyCollection anropad utan giltigt tilläggsobjekt"
 
-#: ../src/html/helpctrl.cpp:159
+#: ../src/html/helpctrl.cpp:155
 #, c-format
 msgid "Adding book %s"
 msgstr "Lägger till bok %s"
 
-#: ../src/common/preferencescmn.cpp:43
+#: ../src/common/preferencescmn.cpp:40
 msgid "Advanced"
 msgstr "Avancerad"
 
@@ -1254,11 +1251,11 @@ msgstr "Avancerad"
 msgid "After a paragraph:"
 msgstr "Efter ett stycke:"
 
-#: ../src/common/stockitem.cpp:172
+#: ../src/common/stockitem.cpp:169
 msgid "Align Left"
 msgstr "Vänsterjustera"
 
-#: ../src/common/stockitem.cpp:173
+#: ../src/common/stockitem.cpp:170
 msgid "Align Right"
 msgstr "Högerjustera"
 
@@ -1266,40 +1263,40 @@ msgstr "Högerjustera"
 msgid "Alignment"
 msgstr "Justering"
 
-#: ../src/generic/prntdlgg.cpp:215
+#: ../src/generic/prntdlgg.cpp:208
 msgid "All"
 msgstr "Alla"
 
-#: ../src/generic/filectrlg.cpp:1197 ../src/common/fldlgcmn.cpp:107
+#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1186
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Alla filer (%s)|%s"
 
-#: ../include/wx/defs.h:2886
+#: ../include/wx/defs.h:2582
 msgid "All files (*)|*"
 msgstr "Alla filer (*)|*"
 
-#: ../include/wx/defs.h:2883
+#: ../include/wx/defs.h:2579
 msgid "All files (*.*)|*.*"
 msgstr "Alla filer (*.*)|*.*"
 
-#: ../src/richtext/richtextstyles.cpp:1061
+#: ../src/richtext/richtextstyles.cpp:1058
 msgid "All styles"
 msgstr "Alla stilar"
 
-#: ../src/propgrid/manager.cpp:1528
+#: ../src/propgrid/manager.cpp:1544
 msgid "Alphabetic Mode"
 msgstr "Alfabetiskt läge"
 
-#: ../src/common/xtistrm.cpp:425
+#: ../src/common/xtistrm.cpp:422
 msgid "Already Registered Object passed to SetObjectClassInfo"
 msgstr "Redan registrerat objekt skickades till SetObjectClassInfo"
 
-#: ../src/unix/dialup.cpp:353
+#: ../src/unix/dialup.cpp:352
 msgid "Already dialling ISP."
 msgstr "Ringer redan Internetleverantör."
 
-#: ../src/common/accelcmn.cpp:331 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/accelcmn.cpp:345 ../src/univ/themes/win32.cpp:3753
 msgid "Alt+"
 msgstr "Alt-"
 
@@ -1308,34 +1305,34 @@ msgstr "Alt-"
 msgid "An optional corner radius for adding rounded corners."
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:576
+#: ../src/common/debugrpt.cpp:577
 msgid "And includes the following files:\n"
 msgstr "Och innehåller följande filer:\n"
 
-#: ../src/generic/animateg.cpp:162
+#: ../src/generic/animateg.cpp:145
 #, c-format
 msgid "Animation file is not of type %ld."
 msgstr "Animationsfilen är inte av typen %ld."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:872
+#: ../src/propgrid/advprops.cpp:773
 msgid "AppWorkspace"
 msgstr ""
 
-#: ../src/generic/logg.cpp:1014
+#: ../src/generic/logg.cpp:1011
 #, c-format
 msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
 msgstr "Lägg till logg till fil \"%s\" (om du väljer [Nej] skrivs den över)?"
 
-#: ../src/osx/menu_osx.cpp:577 ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:469 ../src/osx/menu_osx.cpp:477
 msgid "Application"
 msgstr "program"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "Apply"
 msgstr "Verkställ"
 
-#: ../src/propgrid/advprops.cpp:1609
+#: ../src/propgrid/advprops.cpp:1515
 msgid "Aqua"
 msgstr ""
 
@@ -1344,30 +1341,30 @@ msgstr ""
 msgid "Arabic"
 msgstr "Arabiska"
 
-#: ../src/common/fmapbase.cpp:153
+#: ../src/common/fmapbase.cpp:150
 msgid "Arabic (ISO-8859-6)"
 msgstr "Arabiska (ISO-8859-6)"
 
-#: ../src/msw/ole/automtn.cpp:672
+#: ../src/msw/ole/automtn.cpp:663
 #, c-format
 msgid "Argument %u not found."
 msgstr "Argument %u hittades inte."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1753
+#: ../src/propgrid/advprops.cpp:1654
 #, fuzzy
 msgid "Arrow"
 msgstr "i morgon"
 
-#: ../src/generic/aboutdlgg.cpp:184
+#: ../src/generic/aboutdlgg.cpp:181
 msgid "Artists"
 msgstr "Konstnärer"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "Ascending"
 msgstr "Stigande"
 
-#: ../src/generic/filectrlg.cpp:433
+#: ../src/generic/filectrlg.cpp:429
 msgid "Attributes"
 msgstr "Attribut"
 
@@ -1377,90 +1374,90 @@ msgstr "Attribut"
 msgid "Available fonts."
 msgstr "Tillgängliga typsnitt."
 
-#: ../src/common/paper.cpp:137
+#: ../src/common/paper.cpp:134
 msgid "B4 (ISO) 250 x 353 mm"
 msgstr "B4 (ISO) 250 x 353 mm"
 
-#: ../src/common/paper.cpp:173
+#: ../src/common/paper.cpp:170
 msgid "B4 (JIS) Rotated 364 x 257 mm"
 msgstr "B4 (JIS) Roterad 364 x 257 mm"
 
-#: ../src/common/paper.cpp:127
+#: ../src/common/paper.cpp:124
 msgid "B4 Envelope, 250 x 353 mm"
 msgstr "B4 kuvert, 250 x 353 mm"
 
-#: ../src/common/paper.cpp:109
+#: ../src/common/paper.cpp:106
 msgid "B4 sheet, 250 x 354 mm"
 msgstr "B4 ark, 250 x 354 mm"
 
-#: ../src/common/paper.cpp:158
+#: ../src/common/paper.cpp:155
 msgid "B5 (ISO) Extra 201 x 276 mm"
 msgstr "B5 (ISO) Extra 201 x 276 mm"
 
-#: ../src/common/paper.cpp:174
+#: ../src/common/paper.cpp:171
 msgid "B5 (JIS) Rotated 257 x 182 mm"
 msgstr "B5 (JIS) Roterad 257 x 182 mm"
 
-#: ../src/common/paper.cpp:155
+#: ../src/common/paper.cpp:152
 msgid "B5 (JIS) Transverse 182 x 257 mm"
 msgstr "B5 (JIS) transverserad 182 x 257 mm"
 
-#: ../src/common/paper.cpp:128
+#: ../src/common/paper.cpp:125
 msgid "B5 Envelope, 176 x 250 mm"
 msgstr "B5 kuvert, 176 x 250 mm"
 
-#: ../src/common/paper.cpp:110
+#: ../src/common/paper.cpp:107
 msgid "B5 sheet, 182 x 257 millimeter"
 msgstr "B5 ark, 182 x 257 millimeter"
 
-#: ../src/common/paper.cpp:182
+#: ../src/common/paper.cpp:179
 msgid "B6 (JIS) 128 x 182 mm"
 msgstr "B6 (JIS) 128 x 182 mm"
 
-#: ../src/common/paper.cpp:183
+#: ../src/common/paper.cpp:180
 msgid "B6 (JIS) Rotated 182 x 128 mm"
 msgstr "B6 (JIS) Roterad 182 x 128 mm"
 
-#: ../src/common/paper.cpp:129
+#: ../src/common/paper.cpp:126
 msgid "B6 Envelope, 176 x 125 mm"
 msgstr "B6 kuvert, 176 x 125 mm"
 
-#: ../src/common/imagbmp.cpp:531 ../src/common/imagbmp.cpp:561
-#: ../src/common/imagbmp.cpp:576
+#: ../src/common/imagbmp.cpp:528 ../src/common/imagbmp.cpp:558
+#: ../src/common/imagbmp.cpp:573
 msgid "BMP: Couldn't allocate memory."
 msgstr "BMP: Kunde inte allokera minne."
 
-#: ../src/common/imagbmp.cpp:100
+#: ../src/common/imagbmp.cpp:97
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: Kunde inte spara ogiltig bild."
 
-#: ../src/common/imagbmp.cpp:356
+#: ../src/common/imagbmp.cpp:353
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: Kunde inte skriva RGB-färgkarta."
 
-#: ../src/common/imagbmp.cpp:490
+#: ../src/common/imagbmp.cpp:487
 msgid "BMP: Couldn't write data."
 msgstr "BMP: Kunde inte skriva data."
 
-#: ../src/common/imagbmp.cpp:246
+#: ../src/common/imagbmp.cpp:243
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: Kunde inte skriva filhuvudet (Bitmap)."
 
-#: ../src/common/imagbmp.cpp:269
+#: ../src/common/imagbmp.cpp:266
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: Kunde inte skriva filhuvudet (BitmapInfo)."
 
-#: ../src/common/imagbmp.cpp:140
+#: ../src/common/imagbmp.cpp:137
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage saknar egen wxPalette."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:142 ../src/common/accelcmn.cpp:52
+#: ../src/common/stockitem.cpp:139 ../src/common/accelcmn.cpp:49
 msgid "Back"
 msgstr "Bakåt"
 
+#: ../src/richtext/richtextformatdlg.cpp:377
 #: ../src/richtext/richtextbackgroundpage.cpp:148
-#: ../src/richtext/richtextformatdlg.cpp:384
 msgid "Background"
 msgstr "Bakgrund"
 
@@ -1468,21 +1465,21 @@ msgstr "Bakgrund"
 msgid "Background &colour:"
 msgstr "Bakgrunds&färg:"
 
-#: ../src/osx/carbon/fontdlg.cpp:220
+#: ../src/osx/carbon/fontdlg.cpp:217
 msgid "Background colour"
 msgstr "Bakgrundsfärg"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:52
+#: ../src/common/accelcmn.cpp:49
 #, fuzzy
 msgid "Backspace"
 msgstr "Bakåt"
 
-#: ../src/common/fmapbase.cpp:160
+#: ../src/common/fmapbase.cpp:157
 msgid "Baltic (ISO-8859-13)"
 msgstr "Baltiska språk (ISO-8859-13)"
 
-#: ../src/common/fmapbase.cpp:151
+#: ../src/common/fmapbase.cpp:148
 msgid "Baltic (old) (ISO-8859-4)"
 msgstr "Baltiska språk (gammal) (ISO-8859-4)"
 
@@ -1495,25 +1492,25 @@ msgstr "Före ett stycke:"
 msgid "Bitmap"
 msgstr "Bitmapp"
 
-#: ../src/propgrid/advprops.cpp:1594
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Black"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1755
+#: ../src/propgrid/advprops.cpp:1656
 msgid "Blank"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1603
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Blue"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:345
+#: ../src/generic/colrdlgg.cpp:365
 msgid "Blue:"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:333 ../src/richtext/richtextfontpage.cpp:355
-#: ../src/osx/carbon/fontdlg.cpp:354 ../src/common/stockitem.cpp:143
+#: ../src/osx/carbon/fontdlg.cpp:351 ../src/common/stockitem.cpp:140
+#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:355
 msgid "Bold"
 msgstr "Fet"
 
@@ -1522,32 +1519,36 @@ msgstr "Fet"
 msgid "Border"
 msgstr "Ram"
 
-#: ../src/richtext/richtextformatdlg.cpp:379
+#: ../src/richtext/richtextformatdlg.cpp:372
 msgid "Borders"
 msgstr "Ramar"
 
-#: ../src/richtext/richtextsizepage.cpp:288 ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141 ../src/richtext/richtextsizepage.cpp:288
 msgid "Bottom"
 msgstr "Botten"
 
-#: ../src/generic/prntdlgg.cpp:893
+#: ../src/generic/prntdlgg.cpp:886
 msgid "Bottom margin (mm):"
 msgstr "Undre marginal (mm):"
 
-#: ../src/richtext/richtextbuffer.cpp:9383
+#: ../src/richtext/richtextbuffer.cpp:9380
 msgid "Box Properties"
 msgstr "Egenskaper för låda"
 
-#: ../src/richtext/richtextstyles.cpp:1065
+#: ../src/richtext/richtextstyles.cpp:1062
 msgid "Box styles"
 msgstr "Lådstilar"
 
-#: ../src/propgrid/advprops.cpp:1602
+#: ../src/osx/cocoa/menu.mm:292
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1508
 #, fuzzy
 msgid "Brown"
 msgstr "Bläddra"
 
-#: ../src/common/filepickercmn.cpp:43 ../src/common/filepickercmn.cpp:44
+#: ../src/common/filepickercmn.cpp:40 ../src/common/filepickercmn.cpp:41
 msgid "Browse"
 msgstr "Bläddra"
 
@@ -1560,73 +1561,73 @@ msgstr "Justering &av punktlista:"
 msgid "Bullet style"
 msgstr "Punktliststil"
 
-#: ../src/richtext/richtextformatdlg.cpp:359
+#: ../src/richtext/richtextformatdlg.cpp:352
 msgid "Bullets"
 msgstr "Punktlisttecken"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1756
+#: ../src/propgrid/advprops.cpp:1657
 #, fuzzy
 msgid "Bullseye"
 msgstr "Punktliststil"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:875
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonFace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:876
+#: ../src/propgrid/advprops.cpp:777
 msgid "ButtonHighlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:877
+#: ../src/propgrid/advprops.cpp:778
 msgid "ButtonShadow"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:878
+#: ../src/propgrid/advprops.cpp:779
 msgid "ButtonText"
 msgstr ""
 
-#: ../src/common/paper.cpp:98
+#: ../src/common/paper.cpp:95
 msgid "C sheet, 17 x 22 in"
 msgstr "C ark, 17 x 22 tum"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "C&lear"
 msgstr "&Töm"
 
-#: ../src/generic/fontdlgg.cpp:406
+#: ../src/generic/fontdlgg.cpp:403
 msgid "C&olour:"
 msgstr "F&ärg:"
 
-#: ../src/common/paper.cpp:123
+#: ../src/common/paper.cpp:120
 msgid "C3 Envelope, 324 x 458 mm"
 msgstr "C3 kuvert, 324 x 458 mm"
 
-#: ../src/common/paper.cpp:124
+#: ../src/common/paper.cpp:121
 msgid "C4 Envelope, 229 x 324 mm"
 msgstr "C4 kuvert, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:122
+#: ../src/common/paper.cpp:119
 msgid "C5 Envelope, 162 x 229 mm"
 msgstr "C5 kuvert, 162 x 229 mm"
 
-#: ../src/common/paper.cpp:125
+#: ../src/common/paper.cpp:122
 msgid "C6 Envelope, 114 x 162 mm"
 msgstr "C6 kuvert, 114 x 162 mm"
 
-#: ../src/common/paper.cpp:126
+#: ../src/common/paper.cpp:123
 msgid "C65 Envelope, 114 x 229 mm"
 msgstr "C65 kuvert, 114 x 229 mm"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "CD-Rom"
 msgstr "cd-rom"
 
-#: ../src/html/chm.cpp:815 ../src/html/chm.cpp:874
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:865
 msgid "CHM handler currently supports only local files!"
 msgstr "CHM-hanteraren stöder för närvarande endast lokala filer!"
 
@@ -1634,190 +1635,194 @@ msgstr "CHM-hanteraren stöder för närvarande endast lokala filer!"
 msgid "Ca&pitals"
 msgstr "&Versaler"
 
-#: ../src/common/cmdproc.cpp:267
+#: ../src/common/cmdproc.cpp:260
 msgid "Can't &Undo "
 msgstr "Kan inte &ångra "
 
-#: ../src/common/image.cpp:2824
+#: ../src/common/image.cpp:2924
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr "Kan inte automatiskt avgöra bildformat för icke-sökbar indata."
 
-#: ../src/msw/registry.cpp:506
+#: ../src/msw/registry.cpp:495
 #, c-format
 msgid "Can't close registry key '%s'"
 msgstr "Kan inte stänga registernyckel \"%s\""
 
-#: ../src/msw/registry.cpp:584
+#: ../src/msw/registry.cpp:573
 #, c-format
 msgid "Can't copy values of unsupported type %d."
 msgstr "Kan inte kopiera värden av ej stödd typ %d."
 
-#: ../src/msw/registry.cpp:487
+#: ../src/msw/registry.cpp:476
 #, c-format
 msgid "Can't create registry key '%s'"
 msgstr "Kan inte skapa registernyckel \"%s\""
 
-#: ../src/msw/thread.cpp:665
+#: ../src/msw/thread.cpp:657
 msgid "Can't create thread"
 msgstr "Kan inte skapa tråd"
 
-#: ../src/msw/window.cpp:3691
-#, c-format
-msgid "Can't create window of class %s"
-msgstr "Kan inte skapa fönster av klass %s"
-
-#: ../src/msw/registry.cpp:777
+#: ../src/msw/registry.cpp:765
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Kan inte ta bort nyckel \"%s\""
 
-#: ../src/msw/iniconf.cpp:458
+#: ../src/msw/iniconf.cpp:455
 #, c-format
 msgid "Can't delete the INI file '%s'"
 msgstr "Kan inte ta bort INI-filen \"%s\""
 
-#: ../src/msw/registry.cpp:805
+#: ../src/msw/registry.cpp:793
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Kan inte ta bort värde \"%s\" från nyckel \"%s\""
 
-#: ../src/msw/registry.cpp:1171
+#: ../src/msw/registry.cpp:1159
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Kan inte räkna upp undernycklar för nyckel \"%s\""
 
-#: ../src/msw/registry.cpp:1132
+#: ../src/msw/registry.cpp:1120
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Kan inte räkna upp värden för nyckel \"%s\""
 
-#: ../src/msw/registry.cpp:1389
+#: ../src/msw/registry.cpp:1377
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Kan inte exportera värde av ej stödd typ %d."
 
-#: ../src/common/ffile.cpp:254
+#: ../src/common/ffile.cpp:253
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Kan inte hitta aktuell position i fil \"%s\""
 
-#: ../src/msw/registry.cpp:418
+#: ../src/msw/registry.cpp:407
 #, c-format
 msgid "Can't get info about registry key '%s'"
 msgstr "Kan inte hämta information om registernyckel \"%s\""
 
-#: ../src/common/zstream.cpp:346
+#: ../src/msw/webview_ie.cpp:1024
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "Kan inte sätta trådprioritet"
+
+#: ../src/common/zstream.cpp:343
 msgid "Can't initialize zlib deflate stream."
 msgstr "Kan inte initiera zlib deflate-ström."
 
-#: ../src/common/zstream.cpp:185
+#: ../src/common/zstream.cpp:182
 msgid "Can't initialize zlib inflate stream."
 msgstr "Kan inte initiera zlib inflate-ström."
 
-#: ../src/msw/fswatcher.cpp:476
+#: ../src/msw/fswatcher.cpp:475
 #, c-format
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "Kan inte bevaka icke existerande katalog \"%s\" för ändringar."
 
-#: ../src/msw/registry.cpp:454
+#: ../src/msw/registry.cpp:443
 #, c-format
 msgid "Can't open registry key '%s'"
 msgstr "Kan inte öppna registernyckel \"%s\""
 
-#: ../src/common/zstream.cpp:252
+#: ../src/common/zstream.cpp:249
 #, c-format
 msgid "Can't read from inflate stream: %s"
 msgstr "Kan inte läsa från inflate-ström: %s"
 
-#: ../src/common/zstream.cpp:244
+#: ../src/common/zstream.cpp:241
 msgid "Can't read inflate stream: unexpected EOF in underlying stream."
 msgstr "Kan inte läsa inflate-ström: Oväntat filslut i underliggande ström."
 
-#: ../src/msw/registry.cpp:1064
+#: ../src/msw/registry.cpp:1052
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Kan inte läsa värdet av \"%s\""
 
-#: ../src/msw/registry.cpp:878 ../src/msw/registry.cpp:910
-#: ../src/msw/registry.cpp:975
+#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
+#: ../src/msw/registry.cpp:963
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Kan inte läsa värdet av nyckel \"%s\""
 
-#: ../src/common/image.cpp:2620
+#: ../src/msw/webview_ie.cpp:1017
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/common/image.cpp:2715
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "Kan inte spara bild till fil \"%s\": Okänd filändelse."
 
-#: ../src/generic/logg.cpp:573 ../src/generic/logg.cpp:976
+#: ../src/generic/logg.cpp:570 ../src/generic/logg.cpp:973
 msgid "Can't save log contents to file."
 msgstr "Kan inte spara logginnehållet till fil."
 
-#: ../src/msw/thread.cpp:629
+#: ../src/msw/thread.cpp:621
 msgid "Can't set thread priority"
 msgstr "Kan inte sätta trådprioritet"
 
-#: ../src/msw/registry.cpp:896 ../src/msw/registry.cpp:938
-#: ../src/msw/registry.cpp:1081
+#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
+#: ../src/msw/registry.cpp:1069
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Kan inte sätta värdet på \"%s\""
 
-#: ../src/unix/utilsunx.cpp:351
+#: ../src/unix/utilsunx.cpp:353
 msgid "Can't write to child process's stdin"
 msgstr "Kan inte skriva till stdin för barnprocess"
 
-#: ../src/common/zstream.cpp:427
+#: ../src/common/zstream.cpp:424
 #, c-format
 msgid "Can't write to deflate stream: %s"
 msgstr "Kan inte skriva till deflate-ström: %s"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:279 ../src/richtext/richtextstyledlg.cpp:300
-#: ../src/common/stockitem.cpp:145 ../src/common/accelcmn.cpp:71
-#: ../src/msw/msgdlg.cpp:454 ../src/msw/progdlg.cpp:673
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:142
+#: ../src/common/accelcmn.cpp:68 ../src/motif/msgdlg.cpp:196
+#: ../src/gtk1/fontdlg.cpp:144 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/progdlg.cpp:940 ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: ../src/common/filefn.cpp:1261
+#: ../src/common/filefn.cpp:1149
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Kan inte räkna upp filerna \"%s\""
 
-#: ../src/msw/dir.cpp:263
+#: ../src/msw/dir.cpp:260
 #, c-format
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Kan inte räkna upp filerna i katalogen \"%s\""
 
-#: ../src/msw/dialup.cpp:523
+#: ../src/msw/dialup.cpp:517
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Kan inte hitta aktiv uppringningsanslutning: %s"
 
-#: ../src/msw/dialup.cpp:827
+#: ../src/msw/dialup.cpp:821
 msgid "Cannot find the location of address book file"
 msgstr "Kan inte hitta platsen för adressboksfil"
 
-#: ../src/msw/ole/automtn.cpp:562
+#: ../src/msw/ole/automtn.cpp:553
 #, c-format
 msgid "Cannot get an active instance of \"%s\""
 msgstr "Kan inte hitta aktiv instans av \"%s\""
 
-#: ../src/unix/threadpsx.cpp:1035
+#: ../src/unix/threadpsx.cpp:1053
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "Kan inte hämta prioritetsräckvidden för schemaläggningsregler %d."
 
-#: ../src/unix/utilsunx.cpp:987
+#: ../src/unix/utilsunx.cpp:989
 msgid "Cannot get the hostname"
 msgstr "Kan inte hämta värdnamnet"
 
-#: ../src/unix/utilsunx.cpp:1023
+#: ../src/unix/utilsunx.cpp:1025
 msgid "Cannot get the official hostname"
 msgstr "Kan inte hämta det officiella värdnamnet"
 
-#: ../src/msw/dialup.cpp:928
+#: ../src/msw/dialup.cpp:922
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Kan inte lägga på - ingen aktiv uppringningsanslutning."
 
@@ -1825,127 +1830,127 @@ msgstr "Kan inte lägga på - ingen aktiv uppringningsanslutning."
 msgid "Cannot initialize OLE"
 msgstr "Kan inte initiera OLE"
 
-#: ../src/common/socket.cpp:853
+#: ../src/common/socket.cpp:850
 msgid "Cannot initialize sockets"
 msgstr "Kan inte initiera uttag (socket)"
 
-#: ../src/msw/volume.cpp:619
+#: ../src/msw/volume.cpp:627
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Kan inte läsa in ikon från \"%s\"."
 
-#: ../src/xrc/xmlres.cpp:360
+#: ../src/xrc/xmlres.cpp:358
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Kan inte läsa in resurser från \"%s\"."
 
-#: ../src/xrc/xmlres.cpp:742
+#: ../src/xrc/xmlres.cpp:740
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Kan inte läsa in resurser från fil \"%s\"."
 
-#: ../src/html/htmlfilt.cpp:137
+#: ../src/html/htmlfilt.cpp:134
 #, c-format
 msgid "Cannot open HTML document: %s"
 msgstr "Kan inte öppna HTML-dokument: %s"
 
-#: ../src/html/helpdata.cpp:667
+#: ../src/html/helpdata.cpp:660
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Kan inte öppna HTML-hjälpbok: %s"
 
-#: ../src/html/helpdata.cpp:299
+#: ../src/html/helpdata.cpp:296
 #, c-format
 msgid "Cannot open contents file: %s"
 msgstr "Kan inte öppna innehållsfil: %s"
 
-#: ../src/generic/dcpsg.cpp:1667
+#: ../src/generic/dcpsg.cpp:1665
 msgid "Cannot open file for PostScript printing!"
 msgstr "Kan inte öppna fil för PostScript-utskrift!"
 
-#: ../src/html/helpdata.cpp:313
+#: ../src/html/helpdata.cpp:310
 #, c-format
 msgid "Cannot open index file: %s"
 msgstr "Kan inte öppna indexfil: %s"
 
-#: ../src/xrc/xmlres.cpp:724
+#: ../src/xrc/xmlres.cpp:722
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Kan inte öppna resursfil \"%s\"."
 
-#: ../src/html/helpwnd.cpp:1534
+#: ../src/html/helpwnd.cpp:1532
 msgid "Cannot print empty page."
 msgstr "Kan inte skriva ut tom sida."
 
-#: ../src/msw/volume.cpp:507
+#: ../src/msw/volume.cpp:515
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Kan inte läsa typnamn från \"%s\"!"
 
-#: ../src/msw/thread.cpp:888
+#: ../src/msw/thread.cpp:894
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Kan inte återuppta tråden %lx"
 
-#: ../src/unix/threadpsx.cpp:1016
+#: ../src/unix/threadpsx.cpp:1028
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Kan inte hämta trådschemaläggningsregler."
 
-#: ../src/common/intl.cpp:558
+#: ../src/common/intl.cpp:365
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "Kan inte ange lokal för språk \"%s\"."
 
-#: ../src/unix/threadpsx.cpp:831 ../src/msw/thread.cpp:546
+#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
 msgid "Cannot start thread: error writing TLS."
 msgstr "Kan inte starta tråden: Fel vid skrivning av TLS."
 
-#: ../src/msw/thread.cpp:872
+#: ../src/msw/thread.cpp:864
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Kan inte hålla inne tråd %lx"
 
-#: ../src/msw/thread.cpp:794
+#: ../src/msw/thread.cpp:786
 msgid "Cannot wait for thread termination"
 msgstr "Kan inte vänta på att tråden avslutas"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:75
+#: ../src/common/accelcmn.cpp:72
 #, fuzzy
 msgid "Capital"
 msgstr "&Versaler"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:879
+#: ../src/propgrid/advprops.cpp:780
 msgid "CaptionText"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:531
 msgid "Case sensitive"
 msgstr "Skiftlägeskänslig"
 
-#: ../src/propgrid/manager.cpp:1509
+#: ../src/propgrid/manager.cpp:1527
 msgid "Categorized Mode"
 msgstr "Kategoriserat läge"
 
-#: ../src/richtext/richtextbuffer.cpp:9968
+#: ../src/richtext/richtextbuffer.cpp:9965
 msgid "Cell Properties"
 msgstr "Egenskaper för cell"
 
-#: ../src/common/fmapbase.cpp:161
+#: ../src/common/fmapbase.cpp:158
 msgid "Celtic (ISO-8859-14)"
 msgstr "Keltiska språk (ISO-8859-14)"
 
-#: ../src/richtext/richtextindentspage.cpp:160
 #: ../src/richtext/richtextliststylepage.cpp:349
+#: ../src/richtext/richtextindentspage.cpp:160
 msgid "Cen&tred"
 msgstr "Cen&trerad"
 
-#: ../src/common/stockitem.cpp:170
+#: ../src/common/stockitem.cpp:167
 msgid "Centered"
 msgstr "Centrerad"
 
-#: ../src/common/fmapbase.cpp:149
+#: ../src/common/fmapbase.cpp:146
 msgid "Central European (ISO-8859-2)"
 msgstr "Centraleuropeisk (ISO-8859-2)"
 
@@ -1954,10 +1959,10 @@ msgstr "Centraleuropeisk (ISO-8859-2)"
 msgid "Centre"
 msgstr "Centrera"
 
-#: ../src/richtext/richtextindentspage.cpp:162
-#: ../src/richtext/richtextindentspage.cpp:164
 #: ../src/richtext/richtextliststylepage.cpp:351
 #: ../src/richtext/richtextliststylepage.cpp:353
+#: ../src/richtext/richtextindentspage.cpp:162
+#: ../src/richtext/richtextindentspage.cpp:164
 msgid "Centre text."
 msgstr "Centrera text."
 
@@ -1970,24 +1975,24 @@ msgstr "Centrerad"
 msgid "Ch&oose..."
 msgstr "V&älj..."
 
-#: ../src/richtext/richtextbuffer.cpp:4354
+#: ../src/richtext/richtextbuffer.cpp:4351
 msgid "Change List Style"
 msgstr "Byt liststil"
 
-#: ../src/richtext/richtextbuffer.cpp:3709
+#: ../src/richtext/richtextbuffer.cpp:3706
 msgid "Change Object Style"
 msgstr "Ändra objektstil"
 
-#: ../src/richtext/richtextbuffer.cpp:3982
-#: ../src/richtext/richtextbuffer.cpp:8129
+#: ../src/richtext/richtextbuffer.cpp:3979
+#: ../src/richtext/richtextbuffer.cpp:8125
 msgid "Change Properties"
 msgstr "Ändra egenskaper"
 
-#: ../src/richtext/richtextbuffer.cpp:3526
+#: ../src/richtext/richtextbuffer.cpp:3523
 msgid "Change Style"
 msgstr "Ändra stil"
 
-#: ../src/common/fileconf.cpp:341
+#: ../src/common/fileconf.cpp:335
 #, c-format
 msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
 msgstr ""
@@ -2000,12 +2005,12 @@ msgid "Changing current directory to \"%s\" failed"
 msgstr "Kunde inte skapa katalog \"%s\""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1757
+#: ../src/propgrid/advprops.cpp:1658
 #, fuzzy
 msgid "Character"
 msgstr "&Teckenkod:"
 
-#: ../src/richtext/richtextstyles.cpp:1063
+#: ../src/richtext/richtextstyles.cpp:1060
 msgid "Character styles"
 msgstr "Teckenstilar"
 
@@ -2043,20 +2048,20 @@ msgstr "Kryssa i för att innesluta punktlisttecknet i paranteser."
 msgid "Check to indicate right-to-left text layout."
 msgstr "Klicka för att ändra textfärgen."
 
-#: ../src/osx/carbon/fontdlg.cpp:356 ../src/osx/carbon/fontdlg.cpp:358
+#: ../src/osx/carbon/fontdlg.cpp:353 ../src/osx/carbon/fontdlg.cpp:355
 msgid "Check to make the font bold."
 msgstr "Kryssa i för att göra typsnittet fet."
 
-#: ../src/osx/carbon/fontdlg.cpp:363 ../src/osx/carbon/fontdlg.cpp:365
+#: ../src/osx/carbon/fontdlg.cpp:360 ../src/osx/carbon/fontdlg.cpp:362
 msgid "Check to make the font italic."
 msgstr "Kryssa i för att göra typsnittet kursiv."
 
-#: ../src/osx/carbon/fontdlg.cpp:372 ../src/osx/carbon/fontdlg.cpp:374
+#: ../src/osx/carbon/fontdlg.cpp:369 ../src/osx/carbon/fontdlg.cpp:371
 msgid "Check to make the font underlined."
 msgstr "Kryssa i för att göra typsnittet understruket."
 
-#: ../src/richtext/richtextstyledlg.cpp:289
-#: ../src/richtext/richtextstyledlg.cpp:291
+#: ../src/richtext/richtextstyledlg.cpp:285
+#: ../src/richtext/richtextstyledlg.cpp:287
 msgid "Check to restart numbering."
 msgstr "Kryssa i för att börja om numrering."
 
@@ -2090,51 +2095,51 @@ msgstr "Kryssa i för visa texten upphöjd."
 msgid "Check to suppress hyphenation."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:763
+#: ../src/msw/dialup.cpp:757
 msgid "Choose ISP to dial"
 msgstr "Välj Internetleverantör att ringa upp"
 
-#: ../src/propgrid/props.cpp:1922
+#: ../src/propgrid/props.cpp:1904
 msgid "Choose a directory:"
 msgstr "Välj en katalog:"
 
-#: ../src/propgrid/props.cpp:1975
+#: ../src/propgrid/props.cpp:2199
 msgid "Choose a file"
 msgstr "Välj en fil"
 
-#: ../src/generic/colrdlgg.cpp:158 ../src/gtk/colordlg.cpp:54
+#: ../src/generic/colrdlgg.cpp:156 ../src/gtk/colordlg.cpp:49
 msgid "Choose colour"
 msgstr "Välj färg"
 
-#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/gtk1/fontdlg.cpp:125 ../src/generic/fontpickerg.cpp:47
+#: ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Välj typsnitt"
 
-#: ../src/common/module.cpp:74
+#: ../src/common/module.cpp:71
 #, c-format
 msgid "Circular dependency involving module \"%s\" detected."
 msgstr "Cirkulärt beroende involverande modul \"%s\" upptäckt."
 
-#: ../src/aui/tabmdi.cpp:108 ../src/generic/mdig.cpp:97
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
 msgid "Cl&ose"
 msgstr "St&äng"
 
-#: ../src/msw/ole/automtn.cpp:684
+#: ../src/msw/ole/automtn.cpp:675
 msgid "Class not registered."
 msgstr "Klassen är inte registrerad."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:147 ../src/common/accelcmn.cpp:72
+#: ../src/common/stockitem.cpp:144 ../src/common/accelcmn.cpp:69
 msgid "Clear"
 msgstr "Töm"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "Clear the log contents"
 msgstr "Töm logginnehållet"
 
-#: ../src/richtext/richtextstyledlg.cpp:252
-#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:248
+#: ../src/richtext/richtextstyledlg.cpp:250
 msgid "Click to apply the selected style."
 msgstr "Klicka för att använda den valda stilen."
 
@@ -2145,15 +2150,15 @@ msgstr "Klicka för att använda den valda stilen."
 msgid "Click to browse for a symbol."
 msgstr "Klicka för att bläddra efter en symbol."
 
-#: ../src/osx/carbon/fontdlg.cpp:403 ../src/osx/carbon/fontdlg.cpp:405
+#: ../src/osx/carbon/fontdlg.cpp:400 ../src/osx/carbon/fontdlg.cpp:402
 msgid "Click to cancel changes to the font."
 msgstr "Klicka för att avbryta ändringarna i typsnittet."
 
-#: ../src/generic/fontdlgg.cpp:472 ../src/generic/fontdlgg.cpp:491
+#: ../src/generic/fontdlgg.cpp:468 ../src/generic/fontdlgg.cpp:487
 msgid "Click to cancel the font selection."
 msgstr "Klicka för att avbryta typsnittsvalet."
 
-#: ../src/osx/carbon/fontdlg.cpp:384 ../src/osx/carbon/fontdlg.cpp:386
+#: ../src/osx/carbon/fontdlg.cpp:381 ../src/osx/carbon/fontdlg.cpp:383
 msgid "Click to change the font colour."
 msgstr "Klicka för att ändra typsnittsfärgen."
 
@@ -2172,37 +2177,37 @@ msgstr "Klicka för att ändra textfärgen."
 msgid "Click to choose the font for this level."
 msgstr "Klicka för att välja typsnitt för den här nivån."
 
-#: ../src/richtext/richtextstyledlg.cpp:279
-#: ../src/richtext/richtextstyledlg.cpp:281
+#: ../src/richtext/richtextstyledlg.cpp:275
+#: ../src/richtext/richtextstyledlg.cpp:277
 msgid "Click to close this window."
 msgstr "Klicka för att stänga fönstret."
 
-#: ../src/osx/carbon/fontdlg.cpp:410 ../src/osx/carbon/fontdlg.cpp:412
+#: ../src/osx/carbon/fontdlg.cpp:407 ../src/osx/carbon/fontdlg.cpp:409
 msgid "Click to confirm changes to the font."
 msgstr "Klicka för att bekräfta ändringar i typsnittet."
 
-#: ../src/generic/fontdlgg.cpp:477 ../src/generic/fontdlgg.cpp:479
-#: ../src/generic/fontdlgg.cpp:484 ../src/generic/fontdlgg.cpp:486
+#: ../src/generic/fontdlgg.cpp:473 ../src/generic/fontdlgg.cpp:475
+#: ../src/generic/fontdlgg.cpp:480 ../src/generic/fontdlgg.cpp:482
 msgid "Click to confirm the font selection."
 msgstr "Klicka för att bekräfta typsnittsvalet."
 
-#: ../src/richtext/richtextstyledlg.cpp:244
-#: ../src/richtext/richtextstyledlg.cpp:246
+#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:242
 msgid "Click to create a new box style."
 msgstr "Klicka för att skapa en ny lådstil."
 
-#: ../src/richtext/richtextstyledlg.cpp:226
-#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:224
 msgid "Click to create a new character style."
 msgstr "Klicka för att skapa en ny teckenstil."
 
-#: ../src/richtext/richtextstyledlg.cpp:238
-#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:236
 msgid "Click to create a new list style."
 msgstr "Klicka för att skapa en ny liststil."
 
-#: ../src/richtext/richtextstyledlg.cpp:232
-#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:230
 msgid "Click to create a new paragraph style."
 msgstr "Klicka för att skapa en ny styckestil."
 
@@ -2216,8 +2221,8 @@ msgstr "Klicka för att skapa en ny tabbposition"
 msgid "Click to delete all tab positions."
 msgstr "Klicka för att ta bort alla tabbpositioner."
 
-#: ../src/richtext/richtextstyledlg.cpp:270
-#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:268
 msgid "Click to delete the selected style."
 msgstr "Klicka för att ta bort stilen."
 
@@ -2226,25 +2231,25 @@ msgstr "Klicka för att ta bort stilen."
 msgid "Click to delete the selected tab position."
 msgstr "Klicka för att ta bort tabbpositionen."
 
-#: ../src/richtext/richtextstyledlg.cpp:264
-#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:262
 msgid "Click to edit the selected style."
 msgstr "Klicka för att redigera stilen."
 
-#: ../src/richtext/richtextstyledlg.cpp:258
-#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:256
 msgid "Click to rename the selected style."
 msgstr "Klicka för att döpa om stilen."
 
-#: ../src/generic/dbgrptg.cpp:97 ../src/generic/progdlgg.cpp:759
-#: ../src/richtext/richtextstyledlg.cpp:277
-#: ../src/richtext/richtextsymboldlg.cpp:476 ../src/common/stockitem.cpp:148
-#: ../src/msw/progdlg.cpp:170 ../src/msw/progdlg.cpp:679
-#: ../src/html/helpdlg.cpp:90
+#: ../src/common/stockitem.cpp:145 ../src/generic/dbgrptg.cpp:94
+#: ../src/generic/progdlgg.cpp:781 ../src/msw/progdlg.cpp:211
+#: ../src/msw/progdlg.cpp:946 ../src/html/helpdlg.cpp:87
+#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextstyledlg.cpp:273
 msgid "Close"
 msgstr "Stäng"
 
-#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:98
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
 msgid "Close All"
 msgstr "Stäng alla"
 
@@ -2252,43 +2257,43 @@ msgstr "Stäng alla"
 msgid "Close current document"
 msgstr "Stäng aktuellt dokument"
 
-#: ../src/generic/logg.cpp:516
+#: ../src/generic/logg.cpp:513
 msgid "Close this window"
 msgstr "Stäng detta fönster"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6006
+#: ../src/generic/datavgen.cpp:6811
 msgid "Collapse"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "Color"
 msgstr "Färg"
 
-#: ../src/richtext/richtextformatdlg.cpp:776
+#: ../src/richtext/richtextformatdlg.cpp:768
 msgid "Colour"
 msgstr "Färg"
 
-#: ../src/msw/colordlg.cpp:158
+#: ../src/msw/colordlg.cpp:227
 #, c-format
 msgid "Colour selection dialog failed with error %0lx."
 msgstr "Färgväljningsdialogrutan misslyckades med fel %0lx."
 
-#: ../src/osx/carbon/fontdlg.cpp:380
+#: ../src/osx/carbon/fontdlg.cpp:377
 msgid "Colour:"
 msgstr "Färg:"
 
-#: ../src/generic/datavgen.cpp:6077
+#: ../src/generic/datavgen.cpp:6882
 #, fuzzy, c-format
 msgid "Column %u"
 msgstr "Lägg till kolumn"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:114
+#: ../src/common/accelcmn.cpp:112
 msgid "Command"
 msgstr ""
 
-#: ../src/common/init.cpp:196
+#: ../src/common/init.cpp:193
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
@@ -2297,23 +2302,23 @@ msgstr ""
 "Kommandoradsargument %d kunde inte bli konverterad till Unicode och kommer "
 "att ignoreras."
 
-#: ../src/msw/fontdlg.cpp:120
+#: ../src/msw/fontdlg.cpp:170
 #, c-format
 msgid "Common dialog failed with error code %0lx."
 msgstr "Vanlig dialogruta misslyckades med felkod %0lx."
 
-#: ../src/gtk/window.cpp:4649
+#: ../src/gtk/window.cpp:5653
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
 msgstr ""
 "Kompositering stöds inte på detta system, slå på det i din fönsterhanterare."
 
-#: ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:1549
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Komprimerad HTML-hjälpfil (*.chm)|*.chm|"
 
-#: ../src/generic/dirctrlg.cpp:444
+#: ../src/generic/dirctrlg.cpp:410
 msgid "Computer"
 msgstr "Dator"
 
@@ -2322,53 +2327,57 @@ msgstr "Dator"
 msgid "Config entry name cannot start with '%c'."
 msgstr "Konfigurationspost kan inte starta med \"%c\"."
 
-#: ../src/generic/filedlgg.cpp:349 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
 msgid "Confirm"
 msgstr "Bekräfta"
 
-#: ../src/html/htmlwin.cpp:566
+#: ../src/html/htmlwin.cpp:569
 msgid "Connecting..."
 msgstr "Ansluter..."
 
-#: ../src/html/helpwnd.cpp:475
+#: ../src/html/helpwnd.cpp:473
 msgid "Contents"
 msgstr "Innehåll"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:880
+#: ../src/propgrid/advprops.cpp:781
 msgid "ControlDark"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:881
+#: ../src/propgrid/advprops.cpp:782
 msgid "ControlLight"
 msgstr ""
 
-#: ../src/common/strconv.cpp:2262
+#: ../src/common/strconv.cpp:2208
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Konvertering till teckenuppsättning \"%s\" fungerar inte."
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "Convert"
 msgstr "Konvertera"
 
-#: ../src/html/htmlwin.cpp:1079
+#: ../src/html/htmlwin.cpp:1020
 #, c-format
 msgid "Copied to clipboard:\"%s\""
 msgstr "Kopierat till urklippsdata: \"%s\""
 
-#: ../src/generic/prntdlgg.cpp:247
+#: ../src/generic/prntdlgg.cpp:240
 msgid "Copies:"
 msgstr "Kopior:"
 
-#: ../src/common/stockitem.cpp:150 ../src/stc/stc_i18n.cpp:18
+#: ../src/common/stockitem.cpp:147 ../src/stc/stc_i18n.cpp:18
 msgid "Copy"
 msgstr "Kopiera"
 
-#: ../src/common/stockitem.cpp:258
+#: ../src/common/stockitem.cpp:255
 msgid "Copy selection"
 msgstr "Kopiera markerat"
+
+#: ../src/generic/grid.cpp:5945
+msgid "Copying more than one selected block to clipboard is not supported."
+msgstr ""
 
 #: ../src/richtext/richtextborderspage.cpp:566
 #: ../src/richtext/richtextborderspage.cpp:601
@@ -2379,197 +2388,193 @@ msgstr ""
 msgid "Corner &radius:"
 msgstr ""
 
-#: ../src/html/chm.cpp:718
+#: ../src/html/chm.cpp:711
 #, c-format
 msgid "Could not create temporary file '%s'"
 msgstr "Kunde inte skapa temporär fil \"%s\""
 
-#: ../src/html/chm.cpp:273
+#: ../src/html/chm.cpp:270
 #, c-format
 msgid "Could not extract %s into %s: %s"
 msgstr "Kunde inte extrahera %s till %s: %s"
 
-#: ../src/generic/tabg.cpp:1048
+#: ../src/generic/tabg.cpp:1045
 msgid "Could not find tab for id"
 msgstr "Kunde inte hitta flik för id"
 
-#: ../src/gtk/notifmsg.cpp:108
-#, fuzzy
-msgid "Could not initalize libnotify."
-msgstr "Kunde inte ange justering."
-
-#: ../src/html/chm.cpp:444
+#: ../src/html/chm.cpp:437
 #, c-format
 msgid "Could not locate file '%s'."
 msgstr "Kunde inte hitta fil \"%s\"."
 
-#: ../src/common/filefn.cpp:1403
+#: ../src/msw/graphicsd2d.cpp:604
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/common/filefn.cpp:1291
 msgid "Could not set current working directory"
 msgstr "Kunde inte ange aktuell katalog"
 
-#: ../src/common/prntbase.cpp:2015
+#: ../src/common/prntbase.cpp:2037
 msgid "Could not start document preview."
 msgstr "Kunde inte påbörja förhandsgranskning av dokumentet."
 
-#: ../src/generic/printps.cpp:178 ../src/msw/printwin.cpp:210
-#: ../src/gtk/print.cpp:1132
+#: ../src/generic/printps.cpp:159 ../src/msw/printwin.cpp:184
+#: ../src/gtk/print.cpp:1129
 msgid "Could not start printing."
 msgstr "Kunde inte påbörja utskrift."
 
-#: ../src/common/wincmn.cpp:2125
+#: ../src/common/wincmn.cpp:2126
 msgid "Could not transfer data to window"
 msgstr "Kunde inte föra över data till fönstret"
 
-#: ../src/msw/imaglist.cpp:187 ../src/msw/imaglist.cpp:224
-#: ../src/msw/imaglist.cpp:249 ../src/msw/dragimag.cpp:185
-#: ../src/msw/dragimag.cpp:220
+#: ../src/msw/imaglist.cpp:223 ../src/msw/imaglist.cpp:245
+#: ../src/msw/imaglist.cpp:270 ../src/msw/dragimag.cpp:182
+#: ../src/msw/dragimag.cpp:217
 msgid "Couldn't add an image to the image list."
 msgstr "Kunde inte lägga till en bild till bildlistan."
 
-#: ../src/osx/glcanvas_osx.cpp:414 ../src/unix/glx11.cpp:558
-#: ../src/msw/glcanvas.cpp:616
+#: ../src/osx/glcanvas_osx.cpp:411 ../src/msw/glcanvas.cpp:631
+#: ../src/unix/glegl.cpp:315 ../src/unix/glx11.cpp:559
 #, fuzzy
 msgid "Couldn't create OpenGL context"
 msgstr "Kunde inte skapa en timer"
 
-#: ../src/msw/timer.cpp:134
+#: ../src/msw/timer.cpp:131
 msgid "Couldn't create a timer"
 msgstr "Kunde inte skapa en timer"
 
-#: ../src/osx/carbon/overlay.cpp:122
-msgid "Couldn't create the overlay window"
-msgstr "Kunde inte skapa överläggsfönster"
-
-#: ../src/common/translation.cpp:2024
+#: ../src/common/translation.cpp:2074
 msgid "Couldn't enumerate translations"
 msgstr "Kunde inte räkna upp översättningar"
 
-#: ../src/common/dynlib.cpp:120
+#: ../src/common/dynlib.cpp:110
 #, c-format
 msgid "Couldn't find symbol '%s' in a dynamic library"
 msgstr "Kunde inte hitta symbolen \"%s\" i ett dynamiskt bibliotek"
 
-#: ../src/msw/thread.cpp:915
+#: ../src/msw/thread.cpp:921
 msgid "Couldn't get the current thread pointer"
 msgstr "Kunde inte hämta den aktuella trådpekaren"
 
-#: ../src/osx/carbon/overlay.cpp:129
-msgid "Couldn't init the context on the overlay window"
-msgstr "Kunde inte initera kontexten på överläggsfönstret"
-
-#: ../src/common/imaggif.cpp:244
+#: ../src/common/imaggif.cpp:241
 msgid "Couldn't initialize GIF hash table."
 msgstr "Kunde inte initiera GIF-hashtabell."
 
-#: ../src/common/imagpng.cpp:409
+#: ../src/common/imagpng.cpp:437
 msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
 msgstr "Kunde inte läsa in PNG-bild - filen är förstörd eller för lite minne."
 
-#: ../src/unix/sound.cpp:470
+#: ../src/unix/sound.cpp:459
 #, c-format
 msgid "Couldn't load sound data from '%s'."
 msgstr "Kunde inte läsa in ljuddata från \"%s\"."
 
-#: ../src/msw/dirdlg.cpp:435
+#: ../src/msw/dirdlg.cpp:287
 msgid "Couldn't obtain folder name"
 msgstr "Kunde inte erhålla katalognamn"
 
-#: ../src/unix/sound_sdl.cpp:229
+#: ../src/unix/sound_sdl.cpp:226
 #, c-format
 msgid "Couldn't open audio: %s"
 msgstr "Kunde inte öppna ljud: %s"
 
-#: ../src/msw/ole/dataobj.cpp:377
+#: ../src/msw/ole/dataobj.cpp:385
 #, c-format
 msgid "Couldn't register clipboard format '%s'."
 msgstr "Kunde inte registrera urklippsformat \"%s\"."
 
-#: ../src/msw/listctrl.cpp:869
+#: ../src/msw/listctrl.cpp:933
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "Kunde inte hämta information om listkontrollpost %d."
 
-#: ../src/common/imagpng.cpp:498 ../src/common/imagpng.cpp:509
-#: ../src/common/imagpng.cpp:519
+#: ../src/common/imagpng.cpp:511 ../src/common/imagpng.cpp:522
+#: ../src/common/imagpng.cpp:532
 msgid "Couldn't save PNG image."
 msgstr "Kunde inte spara PNG-bild."
 
-#: ../src/msw/thread.cpp:684
+#: ../src/msw/thread.cpp:676
 msgid "Couldn't terminate thread"
 msgstr "Kunde inte avsluta tråd"
 
-#: ../src/common/xtistrm.cpp:166
+#: ../src/common/xtistrm.cpp:163
 #, c-format
 msgid "Create Parameter %s not found in declared RTTI Parameters"
 msgstr "Skapa-parameter %s hittades inte i deklarerade RTTI-parametrar"
 
-#: ../src/generic/dirdlgg.cpp:288
+#: ../src/generic/dirdlgg.cpp:285
 msgid "Create directory"
 msgstr "Skapa katalog"
 
-#: ../src/generic/filedlgg.cpp:212 ../src/generic/dirdlgg.cpp:111
+#: ../src/generic/filedlgg.cpp:209 ../src/generic/dirdlgg.cpp:108
 msgid "Create new directory"
 msgstr "Skapa ny katalog"
 
-#: ../src/xrc/xmlres.cpp:2460
+#: ../src/common/stockitem.cpp:264
+#, fuzzy
+msgid "Create new document"
+msgstr "Skapa ny katalog"
+
+#: ../src/xrc/xmlres.cpp:2515
 #, fuzzy, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Uppackning av \"%s\" till \"%s\" misslyckades."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1758
+#: ../src/propgrid/advprops.cpp:1659
 msgid "Cross"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:333
+#: ../src/common/accelcmn.cpp:347
 msgid "Ctrl+"
 msgstr "Ctrl+"
 
-#: ../src/richtext/richtextctrl.cpp:332 ../src/osx/textctrl_osx.cpp:576
-#: ../src/common/stockitem.cpp:151 ../src/msw/textctrl.cpp:2507
+#: ../src/osx/textctrl_osx.cpp:594 ../src/common/stockitem.cpp:148
+#: ../src/msw/textctrl.cpp:2772 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "&Klipp ut"
 
-#: ../src/generic/filectrlg.cpp:940
+#: ../src/generic/filectrlg.cpp:936
 msgid "Current directory:"
 msgstr "Aktuell katalog:"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:896 ../src/propgrid/advprops.cpp:1574
-#: ../src/propgrid/advprops.cpp:1612
+#: ../src/propgrid/advprops.cpp:797 ../src/propgrid/advprops.cpp:1475
+#: ../src/propgrid/advprops.cpp:1518
 #, fuzzy
 msgid "Custom"
 msgstr "Valfri storlek"
 
-#: ../src/gtk/print.cpp:217
+#: ../src/gtk/print.cpp:211
 msgid "Custom size"
 msgstr "Valfri storlek"
 
-#: ../src/common/headerctrlcmn.cpp:60
+#: ../src/common/headerctrlcmn.cpp:58
 msgid "Customize Columns"
 msgstr "Anpassa kolumner"
 
-#: ../src/common/stockitem.cpp:151 ../src/stc/stc_i18n.cpp:17
+#: ../src/common/stockitem.cpp:148 ../src/stc/stc_i18n.cpp:17
 msgid "Cut"
 msgstr "Klipp ut"
 
-#: ../src/common/stockitem.cpp:259
+#: ../src/common/stockitem.cpp:256
 msgid "Cut selection"
 msgstr "Klipp ut markerat"
 
-#: ../src/common/fmapbase.cpp:152
+#: ../src/common/fmapbase.cpp:149
 msgid "Cyrillic (ISO-8859-5)"
 msgstr "Kyrillisk (ISO-8859-5)"
 
-#: ../src/common/paper.cpp:99
+#: ../src/common/paper.cpp:96
 msgid "D sheet, 22 x 34 in"
 msgstr "D ark, 22 x 34 tum"
 
-#: ../src/msw/dde.cpp:703
+#: ../src/msw/dde.cpp:698
 msgid "DDE poke request failed"
 msgstr "DDE poke-förfrågan misslyckades"
 
-#: ../src/common/imagbmp.cpp:1169
+#: ../src/common/imagbmp.cpp:1181
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr "DIB-huvud: Kodning matchar inte bitdjup."
 
@@ -2589,7 +2594,7 @@ msgstr "DIB-huvud: Okänt bitdjup i fil."
 msgid "DIB Header: Unknown encoding in file."
 msgstr "DIB-huvud: Okänd kodning i fil."
 
-#: ../src/common/paper.cpp:121
+#: ../src/common/paper.cpp:118
 msgid "DL Envelope, 110 x 220 mm"
 msgstr "DL kuvert, 110 x 220 mm"
 
@@ -2597,55 +2602,55 @@ msgstr "DL kuvert, 110 x 220 mm"
 msgid "Dashed"
 msgstr "Streckad"
 
-#: ../src/generic/dbgrptg.cpp:300
+#: ../src/generic/dbgrptg.cpp:301
 #, c-format
 msgid "Debug report \"%s\""
 msgstr "Debugrapport \"%s\""
 
-#: ../src/common/debugrpt.cpp:210
+#: ../src/common/debugrpt.cpp:211
 msgid "Debug report couldn't be created."
 msgstr "Debugrapporten kunde inte skapas."
 
-#: ../src/common/debugrpt.cpp:553
+#: ../src/common/debugrpt.cpp:554
 msgid "Debug report generation has failed."
 msgstr "Skapande av debugrapport har misslyckats."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:84
+#: ../src/common/accelcmn.cpp:81
 msgid "Decimal"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:323
+#: ../src/generic/fontdlgg.cpp:319
 msgid "Decorative"
 msgstr "Dekorativ"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1752
+#: ../src/propgrid/advprops.cpp:1653
 #, fuzzy
 msgid "Default"
 msgstr "förvald"
 
-#: ../src/common/fmapbase.cpp:796
+#: ../src/common/fmapbase.cpp:792
 msgid "Default encoding"
 msgstr "Standardkodning"
 
-#: ../src/dfb/fontmgr.cpp:180
+#: ../src/dfb/fontmgr.cpp:177
 msgid "Default font"
 msgstr "Standardtypsnitt"
 
-#: ../src/generic/prntdlgg.cpp:510
+#: ../src/generic/prntdlgg.cpp:503
 msgid "Default printer"
 msgstr "Standardskrivare"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:51
+#: ../src/common/accelcmn.cpp:48
 #, fuzzy
 msgid "Del"
 msgstr "Ta bort"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextbuffer.cpp:8221 ../src/common/stockitem.cpp:152
-#: ../src/common/accelcmn.cpp:50 ../src/stc/stc_i18n.cpp:20
+#: ../src/common/stockitem.cpp:149 ../src/common/accelcmn.cpp:47
+#: ../src/richtext/richtextbuffer.cpp:8217 ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Ta bort"
 
@@ -2653,68 +2658,68 @@ msgstr "Ta bort"
 msgid "Delete A&ll"
 msgstr "Ta bort a&llt"
 
-#: ../src/richtext/richtextbuffer.cpp:11341
+#: ../src/richtext/richtextbuffer.cpp:11340
 msgid "Delete Column"
 msgstr "Ta bort kolumn"
 
-#: ../src/richtext/richtextbuffer.cpp:11291
+#: ../src/richtext/richtextbuffer.cpp:11290
 msgid "Delete Row"
 msgstr "Ta bort rad"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 msgid "Delete Style"
 msgstr "Ta bort stil"
 
-#: ../src/richtext/richtextctrl.cpp:1345 ../src/richtext/richtextctrl.cpp:1584
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
 msgid "Delete Text"
 msgstr "Ta bort text"
 
-#: ../src/generic/editlbox.cpp:170
+#: ../src/generic/editlbox.cpp:147
 msgid "Delete item"
 msgstr "Ta bort post"
 
-#: ../src/common/stockitem.cpp:260
+#: ../src/common/stockitem.cpp:257
 msgid "Delete selection"
 msgstr "Ta bort markerat"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 #, c-format
 msgid "Delete style %s?"
 msgstr "Ta bort stil %s?"
 
-#: ../src/unix/snglinst.cpp:301
+#: ../src/unix/snglinst.cpp:298
 #, c-format
 msgid "Deleted stale lock file '%s'."
 msgstr "Tog bort förlegad låsfil \"%s\"."
 
-#: ../src/common/secretstore.cpp:220
+#: ../src/common/secretstore.cpp:234
 #, fuzzy, c-format
-msgid "Deleting password for \"%s/%s\" failed: %s."
+msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Uppackning av \"%s\" till \"%s\" misslyckades."
 
-#: ../src/common/module.cpp:124
+#: ../src/common/module.cpp:121
 #, c-format
 msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
 msgstr "Beroende \"%s\" av modul \"%s\" finns inte."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "Descending"
 msgstr "Fallande"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:526 ../src/propgrid/advprops.cpp:882
+#: ../src/generic/dirctrlg.cpp:492 ../src/propgrid/advprops.cpp:783
 msgid "Desktop"
 msgstr "Skrivbord"
 
-#: ../src/generic/aboutdlgg.cpp:70
+#: ../src/generic/aboutdlgg.cpp:67
 msgid "Developed by "
 msgstr "Utvecklat av "
 
-#: ../src/generic/aboutdlgg.cpp:176
+#: ../src/generic/aboutdlgg.cpp:173
 msgid "Developers"
 msgstr "Utvecklare"
 
-#: ../src/msw/dialup.cpp:374
+#: ../src/msw/dialup.cpp:368
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -2723,11 +2728,11 @@ msgstr ""
 "fjärråtkomstservice (RAS) inte är installerad på denna maskin. Installera "
 "den."
 
-#: ../src/generic/tipdlg.cpp:211
+#: ../src/generic/tipdlg.cpp:208
 msgid "Did you know..."
 msgstr "Visste du att..."
 
-#: ../src/dfb/wrapdfb.cpp:63
+#: ../src/dfb/wrapdfb.cpp:60
 #, c-format
 msgid "DirectFB error %d occurred."
 msgstr "DirectFB fel %d inträffade."
@@ -2736,29 +2741,29 @@ msgstr "DirectFB fel %d inträffade."
 msgid "Directories"
 msgstr "Kataloger"
 
-#: ../src/common/filefn.cpp:1183
+#: ../src/common/filefn.cpp:1071
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Katalogen \"%s\" kunde inte skapas"
 
-#: ../src/common/filefn.cpp:1197
+#: ../src/common/filefn.cpp:1085
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "Katalogen \"%s\" kunde inte tas bort"
 
-#: ../src/generic/dirdlgg.cpp:204
+#: ../src/generic/dirdlgg.cpp:201
 msgid "Directory does not exist"
 msgstr "Katalogen finns inte"
 
-#: ../src/generic/filectrlg.cpp:1399
+#: ../src/generic/filectrlg.cpp:1388
 msgid "Directory doesn't exist."
 msgstr "Katalogen finns inte."
 
-#: ../src/common/docview.cpp:457
+#: ../src/common/docview.cpp:450
 msgid "Discard changes and reload the last saved version?"
 msgstr "Bortse från ändringar och ladda om den senast sparade versionen?"
 
-#: ../src/html/helpwnd.cpp:502
+#: ../src/html/helpwnd.cpp:500
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -2766,45 +2771,45 @@ msgstr ""
 "Visa alla indexposter som innehåller given delsträng. Sökningen är "
 "skiftlägesokänslig."
 
-#: ../src/html/helpwnd.cpp:679
+#: ../src/html/helpwnd.cpp:677
 msgid "Display options dialog"
 msgstr "Visa alternativdialog"
 
-#: ../src/html/helpwnd.cpp:322
+#: ../src/html/helpwnd.cpp:320
 msgid "Displays help as you browse the books on the left."
 msgstr "Visar hjälp medan du bläddrar i böckerna till vänster."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:85
+#: ../src/common/accelcmn.cpp:83
 msgid "Divide"
 msgstr ""
 
-#: ../src/common/docview.cpp:533
+#: ../src/common/docview.cpp:526
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Vill du spara ändringar i %s?"
 
-#: ../src/common/prntbase.cpp:542
+#: ../src/common/prntbase.cpp:537
 msgid "Document:"
 msgstr "Dokument:"
 
-#: ../src/generic/aboutdlgg.cpp:73
+#: ../src/generic/aboutdlgg.cpp:70
 msgid "Documentation by "
 msgstr "Dokumenterat av "
 
-#: ../src/generic/aboutdlgg.cpp:180
+#: ../src/generic/aboutdlgg.cpp:177
 msgid "Documentation writers"
 msgstr "Dokumentationssförfattare"
 
-#: ../src/common/sizer.cpp:2799
+#: ../src/common/sizer.cpp:2916
 msgid "Don't Save"
 msgstr "Spara inte"
 
-#: ../src/html/htmlwin.cpp:633
+#: ../src/html/htmlwin.cpp:643
 msgid "Done"
 msgstr "Färdigt"
 
-#: ../src/generic/progdlgg.cpp:448 ../src/msw/progdlg.cpp:407
+#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
 msgid "Done."
 msgstr "Färdigt."
 
@@ -2816,42 +2821,42 @@ msgstr "Prickad"
 msgid "Double"
 msgstr "Dubbel"
 
-#: ../src/common/paper.cpp:176
+#: ../src/common/paper.cpp:173
 msgid "Double Japanese Postcard Rotated 148 x 200 mm"
 msgstr "Dubbelt japanskt vykort roterat 148 x 200 mm"
 
-#: ../src/common/xtixml.cpp:273
+#: ../src/common/xtixml.cpp:269
 #, c-format
 msgid "Doubly used id : %d"
 msgstr "Dubbelt använt id: %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:153
-#: ../src/common/accelcmn.cpp:64
+#: ../src/common/stockitem.cpp:150 ../src/common/accelcmn.cpp:61
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Down"
 msgstr "Ner"
 
-#: ../src/richtext/richtextctrl.cpp:865
+#: ../src/richtext/richtextctrl.cpp:864
 msgid "Drag"
 msgstr "Dra"
 
-#: ../src/common/paper.cpp:100
+#: ../src/common/paper.cpp:97
 msgid "E sheet, 34 x 44 in"
 msgstr "E ark, 34 x 44 tum"
 
-#: ../src/unix/fswatcher_inotify.cpp:561
+#: ../src/unix/fswatcher_inotify.cpp:558
 msgid "EOF while reading from inotify descriptor"
 msgstr "EOF under läsning från inotify-identifierare"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "Edit"
 msgstr "Redigera"
 
-#: ../src/generic/editlbox.cpp:168
+#: ../src/generic/editlbox.cpp:131
 msgid "Edit item"
 msgstr "Redigera post"
 
-#: ../include/wx/generic/progdlgg.h:84
+#: ../include/wx/generic/progdlgg.h:85
 msgid "Elapsed time:"
 msgstr "Passerad tid: "
 
@@ -2923,63 +2928,63 @@ msgid "Enables the shadow spread."
 msgstr "Slå på breddvärdet."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:66
+#: ../src/common/accelcmn.cpp:63
 msgid "End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:55
+#: ../src/common/accelcmn.cpp:52
 #, fuzzy
 msgid "Enter"
 msgstr "Skrivare"
 
-#: ../src/richtext/richtextstyledlg.cpp:934
+#: ../src/richtext/richtextstyledlg.cpp:930
 msgid "Enter a box style name"
 msgstr "Ange namn för lådstil"
 
-#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:602
 msgid "Enter a character style name"
 msgstr "Ange namn för teckenstil"
 
-#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:816
 msgid "Enter a list style name"
 msgstr "Ange namn för liststil"
 
-#: ../src/richtext/richtextstyledlg.cpp:893
+#: ../src/richtext/richtextstyledlg.cpp:889
 msgid "Enter a new style name"
 msgstr "Ange ett nytt stilnamn"
 
-#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:650
 msgid "Enter a paragraph style name"
 msgstr "Ange namn för styckestil"
 
-#: ../src/generic/dbgrptg.cpp:174
+#: ../src/generic/dbgrptg.cpp:171
 #, c-format
 msgid "Enter command to open file \"%s\":"
 msgstr "Skriv in kommando för att öppna fil \"%s\":"
 
-#: ../src/generic/helpext.cpp:459
+#: ../src/generic/helpext.cpp:457
 msgid "Entries found"
 msgstr "Poster funna"
 
-#: ../src/common/paper.cpp:142
+#: ../src/common/paper.cpp:139
 msgid "Envelope Invite 220 x 220 mm"
 msgstr "Kuvert Invite 220 x 220 mm"
 
-#: ../src/common/config.cpp:469
+#: ../src/common/config.cpp:465
 #, c-format
 msgid ""
 "Environment variables expansion failed: missing '%c' at position %u in '%s'."
 msgstr ""
 "Miljövariabelexpansion misslyckades: \"%c\" saknas på position %u i \"%s\"."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/generic/dirctrlg.cpp:570
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/dirctrlg.cpp:599
-#: ../src/generic/dirdlgg.cpp:323 ../src/generic/filectrlg.cpp:642
-#: ../src/generic/filectrlg.cpp:756 ../src/generic/filectrlg.cpp:770
-#: ../src/generic/filectrlg.cpp:786 ../src/generic/filectrlg.cpp:1368
-#: ../src/generic/filectrlg.cpp:1399 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/gtk1/fontdlg.cpp:74 ../src/generic/dirctrlg.cpp:536
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/dirctrlg.cpp:565
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1357 ../src/generic/filectrlg.cpp:1388
+#: ../src/generic/filedlgg.cpp:354 ../src/generic/dirdlgg.cpp:320
+#: ../src/gtk/filedlg.cpp:74
 msgid "Error"
 msgstr "Fel"
 
@@ -2987,87 +2992,98 @@ msgstr "Fel"
 msgid "Error closing epoll descriptor"
 msgstr "Fel vid stängning av epoll-identifierare"
 
-#: ../src/unix/fswatcher_kqueue.cpp:114
+#: ../src/unix/fswatcher_kqueue.cpp:131
 msgid "Error closing kqueue instance"
 msgstr "Kunde inte stänga kqueue-instans"
 
-#: ../src/common/filefn.cpp:1049
+#: ../src/common/filefn.cpp:938
 #, fuzzy, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Kunde inte kopiera filen \"%s\" till \"%s\""
 
-#: ../src/generic/dirdlgg.cpp:222
+#: ../src/generic/dirdlgg.cpp:219
 msgid "Error creating directory"
 msgstr "Fel vid skapande av katalog"
 
-#: ../src/common/imagbmp.cpp:1181
+#: ../src/common/imagbmp.cpp:1193
 msgid "Error in reading image DIB."
 msgstr "Fel vid läsning av DIB-bild."
 
-#: ../src/propgrid/propgrid.cpp:6696
+#: ../src/propgrid/propgrid.cpp:6665
 #, c-format
 msgid "Error in resource: %s"
 msgstr "Fel i resurs: %s"
 
-#: ../src/common/fileconf.cpp:422
+#: ../src/common/fileconf.cpp:421
 msgid "Error reading config options."
 msgstr "Fel vid läsning av konfigureringsalternativ."
+
+#: ../src/msw/webview_ie.cpp:1057 ../src/msw/webview_edge.cpp:850
+#: ../src/gtk/webview_webkit2.cpp:1262 ../src/osx/webview_webkit.mm:383
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
 
 #: ../src/common/fileconf.cpp:1029
 msgid "Error saving user configuration data."
 msgstr "Fel vid sparande av användarkonfigurationsdata."
 
-#: ../src/gtk/print.cpp:722
+#: ../src/gtk/print.cpp:720
 msgid "Error while printing: "
 msgstr "Fel vid utskrift: "
 
-#: ../src/common/log.cpp:219
+#: ../src/common/log.cpp:237
 msgid "Error: "
 msgstr "Fel: "
 
+#: ../src/common/webrequest.cpp:98
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Fel: "
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:69
+#: ../src/common/accelcmn.cpp:66
 msgid "Esc"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:70
+#: ../src/common/accelcmn.cpp:67
 #, fuzzy
 msgid "Escape"
 msgstr "Liggande"
 
-#: ../src/common/fmapbase.cpp:150
+#: ../src/common/fmapbase.cpp:147
 msgid "Esperanto (ISO-8859-3)"
 msgstr "Esperanto (ISO-8859-3)"
 
-#: ../include/wx/generic/progdlgg.h:85
+#: ../include/wx/generic/progdlgg.h:86
 msgid "Estimated time:"
 msgstr "Uppskattad tid: "
 
-#: ../src/generic/dbgrptg.cpp:234
+#: ../src/generic/dbgrptg.cpp:231
 msgid "Executable files (*.exe)|*.exe|"
 msgstr "Körbara filer (*.exe)|*.exe|"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:155 ../src/common/accelcmn.cpp:78
+#: ../src/common/stockitem.cpp:152 ../src/common/accelcmn.cpp:75
 msgid "Execute"
 msgstr "Kör"
 
-#: ../src/msw/utilsexc.cpp:876
+#: ../src/msw/utilsexc.cpp:873
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Utförande av kommando \"%s\" misslyckades"
 
-#: ../src/common/paper.cpp:105
+#: ../src/common/paper.cpp:102
 msgid "Executive, 7 1/4 x 10 1/2 in"
 msgstr "Executive, 7 1/4 x 10 1/2 tum"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6009
+#: ../src/generic/datavgen.cpp:6814
 msgid "Expand"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1240
+#: ../src/msw/registry.cpp:1228
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
@@ -3075,147 +3091,157 @@ msgstr ""
 "Exporterar registernyckel: Filen \"%s\" finns redan och kommer inte att "
 "skrivas över."
 
-#: ../src/common/fmapbase.cpp:195
+#: ../src/common/fmapbase.cpp:192
 msgid "Extended Unix Codepage for Japanese (EUC-JP)"
 msgstr "Utökad Unix-kodsida för japanska (EUC-JP)"
 
-#: ../src/html/chm.cpp:725
+#: ../src/html/chm.cpp:718
 #, c-format
 msgid "Extraction of '%s' into '%s' failed."
 msgstr "Uppackning av \"%s\" till \"%s\" misslyckades."
 
-#: ../src/common/accelcmn.cpp:249 ../src/common/accelcmn.cpp:344
+#: ../src/common/accelcmn.cpp:259 ../src/common/accelcmn.cpp:358
 msgid "F"
 msgstr "F"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:672
+#: ../src/propgrid/advprops.cpp:582
 msgid "Face Name"
 msgstr "Typsnittsnamn"
 
-#: ../src/unix/snglinst.cpp:269
+#: ../src/unix/snglinst.cpp:266
 msgid "Failed to access lock file."
 msgstr "Kunde inte komma åt låsfil."
+
+#: ../src/gtk/font.cpp:572
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Kunde inte läsa dokument från filen \"%s\"."
 
 #: ../src/unix/epolldispatcher.cpp:116
 #, c-format
 msgid "Failed to add descriptor %d to epoll descriptor %d"
 msgstr "Kunde inte lägga till identifierare %d till epoll-identifierare %d"
 
-#: ../src/msw/dib.cpp:489
+#: ../src/msw/dib.cpp:535
 #, c-format
 msgid "Failed to allocate %luKb of memory for bitmap data."
 msgstr "Kunde inte allokera %luKb minne för bilddata."
 
-#: ../src/common/glcmn.cpp:115
+#: ../src/common/glcmn.cpp:112
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Kunde inte allokera färg för OpenGL"
 
-#: ../src/unix/displayx11.cpp:236
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Kunde inte allokera färg för OpenGL"
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Kunde inte allokera färg för OpenGL"
+
+#: ../include/wx/unix/private/displayx11.h:89
 msgid "Failed to change video mode"
 msgstr "Kunde inte ändra videoläge"
 
-#: ../src/common/image.cpp:3277
+#: ../src/common/image.cpp:3396
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Kunde kontrollera bildformat för fil \"%s\"."
 
-#: ../src/common/debugrpt.cpp:239
+#: ../src/common/debugrpt.cpp:240
 #, c-format
 msgid "Failed to clean up debug report directory \"%s\""
 msgstr "Kunde inte rensa debugrapportkatalog \"%s\""
 
-#: ../src/common/filename.cpp:192
+#: ../src/common/filename.cpp:189
 msgid "Failed to close file handle"
 msgstr "Kunde inte stänga filhandtag"
 
-#: ../src/unix/snglinst.cpp:340
+#: ../src/unix/snglinst.cpp:337
 #, c-format
 msgid "Failed to close lock file '%s'"
 msgstr "Kunde inte stänga låsfil \"%s\""
 
-#: ../src/msw/clipbrd.cpp:112
+#: ../src/msw/clipbrd.cpp:110
 msgid "Failed to close the clipboard."
 msgstr "Kunde inte stänga urklippsbordet."
 
-#: ../src/x11/utils.cpp:208
+#: ../src/x11/utils.cpp:170
 #, c-format
 msgid "Failed to close the display \"%s\""
 msgstr "Kunde inte stänga display \"%s\""
 
-#: ../src/msw/dialup.cpp:797
+#: ../src/msw/dialup.cpp:791
 msgid "Failed to connect: missing username/password."
 msgstr "Kunde inte ansluta: Användarnamn/lösenord saknas."
 
-#: ../src/msw/dialup.cpp:743
+#: ../src/msw/dialup.cpp:737
 msgid "Failed to connect: no ISP to dial."
 msgstr "Kunde inte ansluta: Ingen Internetleverantör att ringa upp."
 
-#: ../src/common/textfile.cpp:203
-#, c-format
-msgid "Failed to convert file \"%s\" to Unicode."
-msgstr "Kunde inte konvertera filen \"%s\" till Unicode."
-
-#: ../src/generic/logg.cpp:956
+#: ../src/generic/logg.cpp:953
 msgid "Failed to copy dialog contents to the clipboard."
 msgstr "Kunde inte kopiera dialogrutans innehåll till urklippsbordet."
 
-#: ../src/msw/registry.cpp:692
+#: ../src/msw/registry.cpp:681
 #, c-format
 msgid "Failed to copy registry value '%s'"
 msgstr "Kunde inte kopiera registervärde \"%s\""
 
-#: ../src/msw/registry.cpp:701
+#: ../src/msw/registry.cpp:690
 #, c-format
 msgid "Failed to copy the contents of registry key '%s' to '%s'."
 msgstr "Kunde inte kopiera innehållet i registernyckel \"%s\" till \"%s\"."
 
-#: ../src/common/filefn.cpp:1015
+#: ../src/common/filefn.cpp:904
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Kunde inte kopiera filen \"%s\" till \"%s\""
 
-#: ../src/msw/registry.cpp:679
+#: ../src/msw/registry.cpp:668
 #, c-format
 msgid "Failed to copy the registry subkey '%s' to '%s'."
 msgstr "Kunde inte kopiera registerundernyckel \"%s\" till \"%s\"."
 
-#: ../src/msw/dde.cpp:1070
+#: ../src/msw/dde.cpp:1134
 msgid "Failed to create DDE string"
 msgstr "Kunde inte skapa DDE-sträng"
 
-#: ../src/msw/mdi.cpp:616
+#: ../src/msw/mdi.cpp:621
 msgid "Failed to create MDI parent frame."
 msgstr "Kunde inte skapa MDI-föräldrafönster."
 
-#: ../src/common/filename.cpp:1027
+#: ../src/common/filename.cpp:1024
 msgid "Failed to create a temporary file name"
 msgstr "Kunde inte skapa ett namn för temporär fil"
 
-#: ../src/msw/utilsexc.cpp:228
+#: ../src/msw/utilsexc.cpp:225
 msgid "Failed to create an anonymous pipe"
 msgstr "Kunde inte skapa ett anonymt rör (pipe)"
 
-#: ../src/msw/ole/automtn.cpp:522
+#: ../src/msw/ole/automtn.cpp:513
 #, c-format
 msgid "Failed to create an instance of \"%s\""
 msgstr "Kunde inte skapa en instans av \"%s\""
 
-#: ../src/msw/dde.cpp:437
+#: ../src/msw/dde.cpp:432
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "Kunde inte skapa en anslutning till server \"%s\" med ämne \"%s\""
 
-#: ../src/msw/cursor.cpp:204
+#: ../src/msw/cursor.cpp:195
 msgid "Failed to create cursor."
 msgstr "Kunde inte skapa markör."
 
-#: ../src/common/debugrpt.cpp:209
+#: ../src/common/debugrpt.cpp:210
 #, c-format
 msgid "Failed to create directory \"%s\""
 msgstr "Kunde inte skapa katalog \"%s\""
 
-#: ../src/generic/dirdlgg.cpp:220
+#: ../src/generic/dirdlgg.cpp:217
 #, c-format
 msgid ""
 "Failed to create directory '%s'\n"
@@ -3228,185 +3254,204 @@ msgstr ""
 msgid "Failed to create epoll descriptor"
 msgstr "Kunde inte skapa epoll-identifierare"
 
-#: ../src/msw/mimetype.cpp:238
+#: ../src/gtk/font.cpp:562
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "Kunde inte uppdatera användarkonfigurationsfil."
+
+#: ../src/msw/mimetype.cpp:235
 #, c-format
 msgid "Failed to create registry entry for '%s' files."
 msgstr "Kunde inte skapa registerpost för \"%s\"-filer."
 
-#: ../src/msw/fdrepdlg.cpp:409
+#: ../src/msw/fdrepdlg.cpp:408
 #, c-format
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr "Kunde inte skapa standard sök/ersättdialogrutan (felkod %d)"
 
-#: ../src/unix/wakeuppipe.cpp:52
+#: ../src/unix/wakeuppipe.cpp:49
 msgid "Failed to create wake up pipe used by event loop."
 msgstr "Misslyckades att skapa wake up-rör som används av händelseslinga."
 
-#: ../src/html/winpars.cpp:730
+#: ../src/html/winpars.cpp:727
 #, c-format
 msgid "Failed to display HTML document in %s encoding"
 msgstr "Kunde inte visa HTML-dokument i %s-kodning"
 
-#: ../src/msw/clipbrd.cpp:124
+#: ../src/msw/clipbrd.cpp:122
 msgid "Failed to empty the clipboard."
 msgstr "Kunde inte tömma urklippsbordet."
 
-#: ../src/unix/displayx11.cpp:212
+#: ../include/wx/unix/private/displayx11.h:65
 msgid "Failed to enumerate video modes"
 msgstr "Kunde inte räkna upp videolägen"
 
-#: ../src/msw/dde.cpp:722
+#: ../src/msw/dde.cpp:717
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "Kunde inte starta en meddelandeslinga med DDE-server"
 
-#: ../src/msw/dialup.cpp:629 ../src/msw/dialup.cpp:863
+#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Kunde inte etablera uppringningsanslutning: %s"
 
-#: ../src/unix/utilsunx.cpp:611
+#: ../src/unix/utilsunx.cpp:613
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Kunde inte utföra \"%s\"\n"
 
-#: ../src/common/debugrpt.cpp:720
+#: ../src/common/debugrpt.cpp:730
 msgid "Failed to execute curl, please install it in PATH."
 msgstr "Kunde inte köra curl, installera den i PATH."
 
-#: ../src/msw/ole/automtn.cpp:505
+#: ../src/msw/ole/automtn.cpp:496
 #, c-format
 msgid "Failed to find CLSID of \"%s\""
 msgstr "Kunde inte hitta CLSID för \"%s\""
 
-#: ../src/common/regex.cpp:431 ../src/common/regex.cpp:479
+#: ../src/common/regex.cpp:428 ../src/common/regex.cpp:476
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "Kunde inte hitta träff för reguljärt uttryck: %s"
 
-#: ../src/msw/dialup.cpp:695
+#: ../src/msw/webview_ie.cpp:978
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:689
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Kunde inte hämta Internetleverantörers namn: %s"
 
-#: ../src/msw/ole/automtn.cpp:574
+#: ../src/msw/ole/automtn.cpp:565
 #, c-format
 msgid "Failed to get OLE automation interface for \"%s\""
 msgstr "Kunde inte hämta OLE-automationsgränssnitt för \"%s\""
 
-#: ../src/msw/clipbrd.cpp:711
+#: ../src/msw/clipbrd.cpp:731
 msgid "Failed to get data from the clipboard"
 msgstr "Kunde inte hämta data från urklippsbordet"
 
-#: ../src/common/time.cpp:223
+#: ../src/common/time.cpp:216
 msgid "Failed to get the local system time"
 msgstr "Kunde inte hämta den lokala systemtiden"
 
-#: ../src/common/filefn.cpp:1345
+#: ../src/common/filefn.cpp:1233
 msgid "Failed to get the working directory"
 msgstr "Kunde inte hämta aktuell katalog"
 
-#: ../src/univ/theme.cpp:114
+#: ../src/univ/theme.cpp:111
 msgid "Failed to initialize GUI: no built-in themes found."
 msgstr "Kunde inte initiera GUI: Inget inbyggt tema hittades."
 
-#: ../src/msw/helpchm.cpp:63
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:60
 msgid "Failed to initialize MS HTML Help."
 msgstr "Kunde inte initiera MS HTML-hjälp."
 
-#: ../src/msw/glcanvas.cpp:1381
+#: ../src/msw/glcanvas.cpp:1391
 msgid "Failed to initialize OpenGL"
 msgstr "Kunde inte initiera OpenGL"
 
-#: ../src/msw/dialup.cpp:858
+#: ../src/msw/dialup.cpp:852
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Kunde inte initiera den uppringda anslutningen: %s"
 
-#: ../src/gtk/textctrl.cpp:1128
+#: ../src/gtk/textctrl.cpp:1209
 msgid "Failed to insert text in the control."
 msgstr "Kunde inte sätta in text i kontrollen."
 
-#: ../src/unix/snglinst.cpp:241
+#: ../src/unix/snglinst.cpp:238
 #, c-format
 msgid "Failed to inspect the lock file '%s'"
 msgstr "Kunde inte inspektera låsfilen \"%s\""
 
-#: ../src/unix/appunix.cpp:182
+#: ../src/unix/appunix.cpp:179
 msgid "Failed to install signal handler"
 msgstr "Kunde inte installera signalhanterare"
 
-#: ../src/unix/threadpsx.cpp:1167
+#: ../src/unix/threadpsx.cpp:1216
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
 msgstr ""
 "Kunde inte slå ihop en tråd, möjlig minnesläcka hittad - starta om programmet"
 
-#: ../src/msw/utils.cpp:629
+#: ../src/msw/utils.cpp:619
 #, c-format
 msgid "Failed to kill process %d"
 msgstr "Kunde inte döda processen %d"
 
-#: ../src/common/image.cpp:2500
+#: ../src/common/image.cpp:2595
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Kunde inte läsa in bild \"%s\" från resurser."
 
-#: ../src/common/image.cpp:2509
+#: ../src/common/image.cpp:2604
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Kunde inte läsa in ikon \"%s\" från resurser."
 
-#: ../src/common/iconbndl.cpp:225
+#: ../src/common/iconbndl.cpp:224
 #, fuzzy, c-format
 msgid "Failed to load icons from resource '%s'."
 msgstr "Kunde inte läsa in ikon \"%s\" från resurser."
 
-#: ../src/common/iconbndl.cpp:200
+#: ../src/common/iconbndl.cpp:198
 #, c-format
 msgid "Failed to load image %%d from file '%s'."
 msgstr "Kunde inte läsa in bild %%d från fil \"%s\"."
 
-#: ../src/common/iconbndl.cpp:208
+#: ../src/common/iconbndl.cpp:206
 #, c-format
 msgid "Failed to load image %d from stream."
 msgstr "Kunde inte läsa in bild %d från ström."
 
-#: ../src/common/image.cpp:2587 ../src/common/image.cpp:2606
+#: ../src/common/image.cpp:2682 ../src/common/image.cpp:2701
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Kunde inte läsa in bild från fil \"%s\"."
 
-#: ../src/msw/enhmeta.cpp:97
+#: ../src/msw/enhmeta.cpp:94
 #, c-format
 msgid "Failed to load metafile from file \"%s\"."
 msgstr "Kunde inte läsa in metafil från fil \"%s\"."
 
-#: ../src/msw/volume.cpp:327
+#: ../src/msw/volume.cpp:335
 msgid "Failed to load mpr.dll."
 msgstr "Kunde inte läsa in mpr.dll."
 
-#: ../src/msw/utils.cpp:953
+#: ../src/msw/utils.cpp:943
 #, c-format
 msgid "Failed to load resource \"%s\"."
 msgstr "Kunde ladda resurs \"%s\"."
 
-#: ../src/common/dynlib.cpp:92
+#: ../src/common/dynlib.cpp:86
 #, c-format
 msgid "Failed to load shared library '%s'"
 msgstr "Kunde inte läsa in delat bibliotek \"%s\""
 
-#: ../src/osx/core/sound.cpp:145
+#: ../src/osx/core/sound.cpp:143
 #, fuzzy, c-format
 msgid "Failed to load sound from \"%s\" (error %d)."
 msgstr "Kunde ladda resurs \"%s\"."
 
-#: ../src/msw/utils.cpp:960
+#: ../src/msw/utils.cpp:950
 #, c-format
 msgid "Failed to lock resource \"%s\"."
 msgstr "Kunde inte låsa resursen \"%s\"."
 
-#: ../src/unix/snglinst.cpp:198
+#: ../src/unix/snglinst.cpp:195
 #, c-format
 msgid "Failed to lock the lock file '%s'"
 msgstr "Kunde inte låsa låsfilen \"%s\""
@@ -3416,33 +3461,38 @@ msgstr "Kunde inte låsa låsfilen \"%s\""
 msgid "Failed to modify descriptor %d in epoll descriptor %d"
 msgstr "Kunde inte ändra identifierare %d i epoll-identifierare %d"
 
-#: ../src/common/filename.cpp:2575
+#: ../src/common/filename.cpp:2658
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Kunde inte ändra filtider för \"%s\""
 
-#: ../src/common/selectdispatcher.cpp:258
+#: ../src/common/selectdispatcher.cpp:255
 msgid "Failed to monitor I/O channels"
 msgstr "Kunde inte bevaka I/O-kanaler"
 
-#: ../src/common/filename.cpp:175
+#: ../src/common/filename.cpp:172
 #, c-format
 msgid "Failed to open '%s' for reading"
 msgstr "Kunde inte öppna \"%s\" för läsning"
 
-#: ../src/common/filename.cpp:180
+#: ../src/common/filename.cpp:177
 #, c-format
 msgid "Failed to open '%s' for writing"
 msgstr "Kunde inte öppna \"%s\" för skrivning"
 
-#: ../src/html/chm.cpp:141
+#: ../src/html/chm.cpp:138
 #, c-format
 msgid "Failed to open CHM archive '%s'."
 msgstr "Kunde inte öppna CHM-arkiv \"%s\"."
 
-#: ../src/common/utilscmn.cpp:1126
+#: ../src/common/utilscmn.cpp:1140
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Kunde inte öppna URL \"%s\" i standardwebbläsare."
+
+#: ../src/common/hyperlnkcmn.cpp:133
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Kunde inte öppna URL \"%s\" i standardwebbläsare."
 
 #: ../include/wx/msw/private/fswatcher.h:92
@@ -3450,93 +3500,103 @@ msgstr "Kunde inte öppna URL \"%s\" i standardwebbläsare."
 msgid "Failed to open directory \"%s\" for monitoring."
 msgstr "Kunde inte öppna katalog \"%s\" för bevakning."
 
-#: ../src/x11/utils.cpp:227
+#: ../src/x11/utils.cpp:189
 #, c-format
 msgid "Failed to open display \"%s\"."
 msgstr "Kunde inte öppna display \"%s\"."
 
-#: ../src/common/filename.cpp:1062
+#: ../src/common/filename.cpp:1059
 msgid "Failed to open temporary file."
 msgstr "Kunde inte öppna temporär fil."
 
-#: ../src/msw/clipbrd.cpp:91
+#: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Kunde inte öppna urklippsbordet."
 
-#: ../src/common/translation.cpp:1184
+#: ../src/common/translation.cpp:1226
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Kunde inte tolka pluralformer: \"%s\""
 
-#: ../src/unix/mediactrl.cpp:1214
+#: ../src/unix/mediactrl.cpp:1239
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Misslyckades att förbereda uppspelning \"%s\"."
 
-#: ../src/msw/clipbrd.cpp:600
+#: ../src/msw/clipbrd.cpp:610
 msgid "Failed to put data on the clipboard"
 msgstr "Kunde inte skicka data till urklippsbordet"
 
-#: ../src/unix/snglinst.cpp:278
+#: ../src/unix/snglinst.cpp:275
 msgid "Failed to read PID from lock file."
 msgstr "Kunde inte läsa PID från låsfil."
 
-#: ../src/common/fileconf.cpp:433
+#: ../src/common/fileconf.cpp:432
 msgid "Failed to read config options."
 msgstr "Kunde inte läsa konfigurationsalternativ."
 
-#: ../src/common/docview.cpp:681
+#: ../src/common/docview.cpp:676
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Kunde inte läsa dokument från filen \"%s\"."
 
-#: ../src/dfb/evtloop.cpp:98
+#: ../src/dfb/evtloop.cpp:99
 msgid "Failed to read event from DirectFB pipe"
 msgstr "Kunde inte läsa händelse från DirectFB-rör"
 
-#: ../src/unix/wakeuppipe.cpp:120
+#: ../src/unix/wakeuppipe.cpp:117
 msgid "Failed to read from wake-up pipe"
 msgstr "Kunde inte läsa från wake up-rör"
 
-#: ../src/unix/utilsunx.cpp:679
+#: ../src/common/textfile.cpp:96
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Kunde inte läsa dokument från filen \"%s\"."
+
+#: ../src/unix/utilsunx.cpp:681
 msgid "Failed to redirect child process input/output"
 msgstr "Kunde inte omdirigera barnprocess-in/utdata"
 
-#: ../src/msw/utilsexc.cpp:701
+#: ../src/msw/utilsexc.cpp:698
 msgid "Failed to redirect the child process IO"
 msgstr "Kunde inte omdirigera barnprocessens IO"
 
-#: ../src/msw/dde.cpp:288
+#: ../src/msw/dde.cpp:283
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Kunde inte registrera DDE-server \"%s\""
 
-#: ../src/common/fontmap.cpp:245
+#: ../src/gtk/font.cpp:580
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "Kunde inte uppdatera användarkonfigurationsfil."
+
+#: ../src/common/fontmap.cpp:242
 #, c-format
 msgid "Failed to remember the encoding for the charset '%s'."
 msgstr "Kunde inte komma ihåg kodningen för teckenuppsättning \"%s\"."
 
-#: ../src/common/debugrpt.cpp:227
+#: ../src/common/debugrpt.cpp:228
 #, c-format
 msgid "Failed to remove debug report file \"%s\""
 msgstr "Kunde inte ta bort debugrapportfil \"%s\""
 
-#: ../src/unix/snglinst.cpp:328
+#: ../src/unix/snglinst.cpp:325
 #, c-format
 msgid "Failed to remove lock file '%s'"
 msgstr "Kunde inte ta bort låsfil \"%s\""
 
-#: ../src/unix/snglinst.cpp:288
+#: ../src/unix/snglinst.cpp:285
 #, c-format
 msgid "Failed to remove stale lock file '%s'."
 msgstr "Kunde inte ta bort förlegad låsfil \"%s\"."
 
-#: ../src/msw/registry.cpp:529
+#: ../src/msw/registry.cpp:518
 #, c-format
 msgid "Failed to rename registry value '%s' to '%s'."
 msgstr "Kunde inte byta namn på registervärde \"%s\" till \"%s\"."
 
-#: ../src/common/filefn.cpp:1122
+#: ../src/common/filefn.cpp:1011
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -3544,115 +3604,124 @@ msgid ""
 msgstr ""
 "Kunde inte döpa om filen \"%s\" till \"%s\" eftersom målfilen redan finns."
 
-#: ../src/msw/registry.cpp:634
+#: ../src/msw/registry.cpp:623
 #, c-format
 msgid "Failed to rename the registry key '%s' to '%s'."
 msgstr "Kunde inte byta namn på registernyckel \"%s\" till \"%s\"."
 
-#: ../src/common/filename.cpp:2671
+#: ../src/msw/webview_ie.cpp:995
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/common/filename.cpp:2754
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Kunde inte hämta filtider för \"%s\""
 
-#: ../src/msw/dialup.cpp:468
+#: ../src/msw/dialup.cpp:462
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Kunde inte hämta text från RAS-felmeddelande"
 
-#: ../src/msw/clipbrd.cpp:748
+#: ../src/msw/clipbrd.cpp:768
 msgid "Failed to retrieve the supported clipboard formats"
 msgstr "Kunde inte hämta vilka urklippsformat som stöds"
 
-#: ../src/common/docview.cpp:652
+#: ../src/common/docview.cpp:647
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Kunde inte spara dokument till filen \"%s\"."
 
-#: ../src/msw/dib.cpp:269
+#: ../src/msw/dib.cpp:312
 #, c-format
 msgid "Failed to save the bitmap image to file \"%s\"."
 msgstr "Kunde inte spara bilden till fil \"%s\"."
 
-#: ../src/msw/dde.cpp:763
+#: ../src/msw/dde.cpp:811
 msgid "Failed to send DDE advise notification"
 msgstr "Kunde inte skicka DDE-meddelandeanmälan"
 
-#: ../src/common/ftp.cpp:402
+#: ../src/common/ftp.cpp:399
 #, c-format
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Kunde inte sätta FTP-överföringsläge till %s."
 
-#: ../src/msw/clipbrd.cpp:427
+#: ../src/msw/clipbrd.cpp:443
 msgid "Failed to set clipboard data."
 msgstr "Kunde inte sätta urklippsdata."
 
-#: ../src/unix/snglinst.cpp:181
+#: ../src/unix/snglinst.cpp:178
 #, c-format
 msgid "Failed to set permissions on lock file '%s'"
 msgstr "Kunde inte sätta behörigheter på låsfil \"%s\""
 
-#: ../src/unix/utilsunx.cpp:668
+#: ../src/unix/utilsunx.cpp:670
 msgid "Failed to set process priority"
 msgstr "Kunde inte ange processprioritet"
 
-#: ../src/common/file.cpp:559
+#: ../src/common/ffile.cpp:355 ../src/common/file.cpp:586
 msgid "Failed to set temporary file permissions"
 msgstr "Kunde inte sätta behörigheter på  temporär fil"
 
-#: ../src/gtk/textctrl.cpp:1072
-msgid "Failed to set text in the text control."
-msgstr "Misslyckades med att ange text i textkontrollen."
-
-#: ../src/unix/threadpsx.cpp:1298
+#: ../src/unix/threadpsx.cpp:1347
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Kunde inte ange trådkonkurrensnivå till %lu"
 
-#: ../src/unix/threadpsx.cpp:1424
+#: ../src/unix/threadpsx.cpp:1473
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Kunde inte sätta trådprioritet %d."
 
-#: ../src/unix/utilsunx.cpp:783
+#: ../src/unix/utilsunx.cpp:785
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr "Kunde inte ställa in ickeblockerande rör, programet kan hänga sig."
 
-#: ../src/common/fs_mem.cpp:261
+#: ../src/msw/webview_ie.cpp:987
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:256
 #, c-format
 msgid "Failed to store image '%s' to memory VFS!"
 msgstr "Kunde inte spara bild \"%s\" till minnes-VFS!"
 
-#: ../src/dfb/evtloop.cpp:170
+#: ../src/dfb/evtloop.cpp:171
 msgid "Failed to switch DirectFB pipe to non-blocking mode"
 msgstr "Kunde inte växla DirectFB-rör till icke-blockerande läge"
 
-#: ../src/unix/wakeuppipe.cpp:59
+#: ../src/unix/wakeuppipe.cpp:56
 msgid "Failed to switch wake up pipe to non-blocking mode"
 msgstr "Misslyckades att växla wake up-rör till ickeblockerande läge"
 
-#: ../src/unix/threadpsx.cpp:1605
+#: ../src/unix/threadpsx.cpp:1654
 msgid "Failed to terminate a thread."
 msgstr "Kunde inte avsluta en tråd."
 
-#: ../src/msw/dde.cpp:741
+#: ../src/msw/dde.cpp:736
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "Kunde inte avsluta meddelandeslinga med DDE-servern"
 
-#: ../src/msw/dialup.cpp:938
+#: ../src/msw/dialup.cpp:932
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Kunde inte avsluta den uppringda anslutningen: %s"
 
-#: ../src/common/filename.cpp:2590
+#: ../src/common/filename.cpp:2673
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Kunde inte röra (touch) filen \"%s\""
 
-#: ../src/unix/snglinst.cpp:334
+#: ../src/unix/dlunix.cpp:90
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "Kunde inte läsa in delat bibliotek \"%s\""
+
+#: ../src/unix/snglinst.cpp:331
 #, c-format
 msgid "Failed to unlock lock file '%s'"
 msgstr "Kunde inte låsa upp låsfil \"%s\""
 
-#: ../src/msw/dde.cpp:309
+#: ../src/msw/dde.cpp:304
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Kunde inte avregistrera DDE-server \"%s\""
@@ -3666,77 +3735,87 @@ msgstr "Kunde inte avregistrera identifierare %d från epoll-identifierare %d"
 msgid "Failed to update user configuration file."
 msgstr "Kunde inte uppdatera användarkonfigurationsfil."
 
-#: ../src/common/debugrpt.cpp:733
+#: ../src/common/debugrpt.cpp:743
 #, c-format
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Kunde inte ladda upp debugrapport (felkod %d)."
 
-#: ../src/unix/snglinst.cpp:168
+#: ../src/unix/snglinst.cpp:165
 #, c-format
 msgid "Failed to write to lock file '%s'"
 msgstr "Kunde inte skriva till låsfil \"%s\""
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:209
+#: ../src/propgrid/propgrid.cpp:190
 msgid "False"
 msgstr "Falskt"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:694
+#: ../src/propgrid/advprops.cpp:604
 msgid "Family"
 msgstr "Familj"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/gtk/glcanvas.cpp:176 ../src/gtk/glcanvas.cpp:187
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Ödesdigert fel"
+
+#: ../src/common/stockitem.cpp:154
 msgid "File"
 msgstr "Arkiv"
 
-#: ../src/common/docview.cpp:669
+#: ../src/common/docview.cpp:664
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Fil \"%s\" kunde inte öppnas för läsning."
 
-#: ../src/common/docview.cpp:646
+#: ../src/common/docview.cpp:641
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Filen \"%s\" kunde inte öppnas för skrivning."
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "Filen \"%s\" finns redan, vill du verkligen skriva över den?"
 
-#: ../src/common/filefn.cpp:1156
+#: ../src/common/filefn.cpp:1044
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Filen \"%s\" kunde inte tas bort"
 
-#: ../src/common/filefn.cpp:1139
+#: ../src/common/filefn.cpp:1028
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Filen \"%s\" kunde inte byta namn till \"%s\""
 
-#: ../src/richtext/richtextctrl.cpp:3081 ../src/common/textcmn.cpp:953
+#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
 msgid "File couldn't be loaded."
 msgstr "Filen kunde inte läsas in."
 
-#: ../src/msw/filedlg.cpp:393
+#: ../src/msw/filedlg.cpp:414
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Fildialogruta misslyckades med felkod %0lx."
 
-#: ../src/common/docview.cpp:1789
+#: ../src/common/docview.cpp:1783
 msgid "File error"
 msgstr "Filfel"
 
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/filectrlg.cpp:770
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/filectrlg.cpp:766
 msgid "File name exists already."
 msgstr "Filnamnet finns redan."
+
+#: ../src/osx/cocoa/filedlg.mm:264
+#, fuzzy
+msgid "File type:"
+msgstr "Teletyp"
 
 #: ../src/motif/filedlg.cpp:220
 msgid "Files"
 msgstr "Filer"
 
-#: ../src/common/filefn.cpp:1591
+#: ../src/common/filefn.cpp:1479
 #, c-format
 msgid "Files (%s)"
 msgstr "Filer (%s)"
@@ -3745,15 +3824,29 @@ msgstr "Filer (%s)"
 msgid "Filter"
 msgstr "Filter"
 
-#: ../src/common/stockitem.cpp:158 ../src/html/helpwnd.cpp:490
+#: ../src/html/helpwnd.cpp:488
 msgid "Find"
 msgstr "Sök"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:259
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:258
+#, fuzzy
+msgid "Find in document"
+msgstr "Öppna HTML-dokument"
+
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "Find..."
+msgstr "Sök"
+
+#: ../src/common/stockitem.cpp:156
 msgid "First"
 msgstr "Första"
 
-#: ../src/common/prntbase.cpp:1548
+#: ../src/common/prntbase.cpp:1573
 msgid "First page"
 msgstr "Första sida"
 
@@ -3761,11 +3854,11 @@ msgstr "Första sida"
 msgid "Fixed"
 msgstr "Fixerat"
 
-#: ../src/html/helpwnd.cpp:1206
+#: ../src/html/helpwnd.cpp:1204
 msgid "Fixed font:"
 msgstr "Fastbreddstypsnitt:"
 
-#: ../src/html/helpwnd.cpp:1269
+#: ../src/html/helpwnd.cpp:1267
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Fastbreddtypsnitt.<br> <b>fet</b> <i>kursiv</i> "
 
@@ -3773,16 +3866,16 @@ msgstr "Fastbreddtypsnitt.<br> <b>fet</b> <i>kursiv</i> "
 msgid "Floating"
 msgstr "Flytande"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "Floppy"
 msgstr "Diskett"
 
-#: ../src/common/paper.cpp:111
+#: ../src/common/paper.cpp:108
 msgid "Folio, 8 1/2 x 13 in"
 msgstr "Foliant, 8 1/2 x 13 tum"
 
-#: ../src/richtext/richtextformatdlg.cpp:344 ../src/osx/carbon/fontdlg.cpp:287
-#: ../src/common/stockitem.cpp:194
+#: ../src/osx/carbon/fontdlg.cpp:284 ../src/common/stockitem.cpp:191
+#: ../src/richtext/richtextformatdlg.cpp:337
 msgid "Font"
 msgstr "Typsnitt"
 
@@ -3790,7 +3883,24 @@ msgstr "Typsnitt"
 msgid "Font &weight:"
 msgstr "Typsnittets &vikt."
 
-#: ../src/html/helpwnd.cpp:1207
+#: ../src/osx/fontutil.cpp:89
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
+"\"."
+msgstr ""
+
+#: ../src/msw/font.cpp:1126
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Filen kunde inte läsas in."
+
+#: ../src/osx/fontutil.cpp:81
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "Filen %s finns inte."
+
+#: ../src/html/helpwnd.cpp:1205
 msgid "Font size:"
 msgstr "Typsnittsstorlek:"
 
@@ -3798,53 +3908,53 @@ msgstr "Typsnittsstorlek:"
 msgid "Font st&yle:"
 msgstr "Typsnitts&stil:"
 
-#: ../src/osx/carbon/fontdlg.cpp:329
+#: ../src/osx/carbon/fontdlg.cpp:326
 msgid "Font:"
 msgstr "Typsnitt:"
 
-#: ../src/dfb/fontmgr.cpp:198
+#: ../src/dfb/fontmgr.cpp:195
 #, c-format
 msgid "Fonts index file %s disappeared while loading fonts."
 msgstr "Typsnittsindexfil %s försvann när typsnitten lästes in."
 
-#: ../src/unix/utilsunx.cpp:645
+#: ../src/unix/utilsunx.cpp:647
 msgid "Fork failed"
 msgstr "Gren misslyckades"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "Forward"
 msgstr "Framåt"
 
-#: ../src/common/xtixml.cpp:235
+#: ../src/common/xtixml.cpp:231
 msgid "Forward hrefs are not supported"
 msgstr "Framåt-href stöds inte"
 
-#: ../src/html/helpwnd.cpp:875
+#: ../src/html/helpwnd.cpp:873
 #, c-format
 msgid "Found %i matches"
 msgstr "Hittade %i träffar"
 
-#: ../src/generic/prntdlgg.cpp:238
+#: ../src/generic/prntdlgg.cpp:231
 msgid "From:"
 msgstr "Från:"
 
-#: ../src/propgrid/advprops.cpp:1604
+#: ../src/propgrid/advprops.cpp:1510
 msgid "Fuchsia"
 msgstr ""
 
-#: ../src/common/imaggif.cpp:138
+#: ../src/common/imaggif.cpp:135
 msgid "GIF: data stream seems to be truncated."
 msgstr "GIF: Dataströmmen tycks vara trunkerad."
 
-#: ../src/common/imaggif.cpp:128
+#: ../src/common/imaggif.cpp:125
 msgid "GIF: error in GIF image format."
 msgstr "GIF: Fel i GIF bildformat."
 
-#: ../src/common/imaggif.cpp:133
+#: ../src/common/imaggif.cpp:130
 msgid "GIF: not enough memory."
 msgstr "GIF: Inte tillräckligt minne."
 
-#: ../src/gtk/window.cpp:4631
+#: ../src/gtk/window.cpp:5635
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -3852,23 +3962,23 @@ msgstr ""
 "Den installerade GTK+ på den här maskinen är för gammal för att stöda "
 "skärmkompositering, installera GTK+ 2.12 eller senare."
 
-#: ../src/univ/themes/gtk.cpp:525
+#: ../src/univ/themes/gtk.cpp:522
 msgid "GTK+ theme"
 msgstr "GTK+ tema"
 
-#: ../src/common/preferencescmn.cpp:40
+#: ../src/common/preferencescmn.cpp:37
 msgid "General"
 msgstr "Allmän"
 
-#: ../src/common/prntbase.cpp:258
+#: ../src/common/prntbase.cpp:253
 msgid "Generic PostScript"
 msgstr "Allmän PostScript"
 
-#: ../src/common/paper.cpp:135
+#: ../src/common/paper.cpp:132
 msgid "German Legal Fanfold, 8 1/2 x 13 in"
 msgstr "Tysk legal fanfold, 8 1/2 x 13 tum"
 
-#: ../src/common/paper.cpp:134
+#: ../src/common/paper.cpp:131
 msgid "German Std Fanfold, 8 1/2 x 12 in"
 msgstr "Tysk standard fanfold, 8 1/2 x 12 tum"
 
@@ -3884,49 +3994,49 @@ msgstr "GetPropertyCollection anropad på ett allmänt åtkomstobjekt"
 msgid "GetPropertyCollection called w/o valid collection getter"
 msgstr "GetPropertyCollection anropad utan giltigt samlingshämtningsobjekt"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:658
 msgid "Go back"
 msgstr "Gå tillbaka"
 
-#: ../src/html/helpwnd.cpp:661
+#: ../src/html/helpwnd.cpp:659
 msgid "Go forward"
 msgstr "Gå framåt"
 
-#: ../src/html/helpwnd.cpp:663
+#: ../src/html/helpwnd.cpp:661
 msgid "Go one level up in document hierarchy"
 msgstr "Gå upp en nivå i dokumenthierarki"
 
-#: ../src/generic/filedlgg.cpp:208 ../src/generic/dirdlgg.cpp:116
+#: ../src/generic/filedlgg.cpp:205 ../src/generic/dirdlgg.cpp:113
 msgid "Go to home directory"
 msgstr "Gå till hemkatalog"
 
-#: ../src/generic/filedlgg.cpp:205
+#: ../src/generic/filedlgg.cpp:202
 msgid "Go to parent directory"
 msgstr "Gå till föräldrakatalog"
 
-#: ../src/generic/aboutdlgg.cpp:76
+#: ../src/generic/aboutdlgg.cpp:73
 msgid "Graphics art by "
 msgstr "Grafik av "
 
-#: ../src/propgrid/advprops.cpp:1599
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Gray"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:883
+#: ../src/propgrid/advprops.cpp:784
 msgid "GrayText"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:154
+#: ../src/common/fmapbase.cpp:151
 msgid "Greek (ISO-8859-7)"
 msgstr "Grekisk (ISO-8859-7)"
 
-#: ../src/propgrid/advprops.cpp:1600
+#: ../src/propgrid/advprops.cpp:1506
 #, fuzzy
 msgid "Green"
 msgstr "MacGrekiska"
 
-#: ../src/generic/colrdlgg.cpp:342
+#: ../src/generic/colrdlgg.cpp:362
 #, fuzzy
 msgid "Green:"
 msgstr "MacGrekiska"
@@ -3935,109 +4045,109 @@ msgstr "MacGrekiska"
 msgid "Groove"
 msgstr "Skårad"
 
-#: ../src/common/zstream.cpp:158 ../src/common/zstream.cpp:318
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
 msgid "Gzip not supported by this version of zlib"
 msgstr "Gzip stöds inte av den här versionen av zlib"
 
-#: ../src/html/helpwnd.cpp:1549
+#: ../src/html/helpwnd.cpp:1547
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "HTML-hjälpprojekt (*.hhp)|*.hhp|"
 
-#: ../src/html/htmlwin.cpp:681
+#: ../src/html/htmlwin.cpp:691
 #, c-format
 msgid "HTML anchor %s does not exist."
 msgstr "HTML-ankare %s finns inte."
 
-#: ../src/html/helpwnd.cpp:1547
+#: ../src/html/helpwnd.cpp:1545
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "HTML-filer (*.html;*.htm)|*.html;*.htm|"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1759
+#: ../src/propgrid/advprops.cpp:1660
 msgid "Hand"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "Harddisk"
 msgstr "Hårddisk"
 
-#: ../src/common/fmapbase.cpp:155
+#: ../src/common/fmapbase.cpp:152
 msgid "Hebrew (ISO-8859-8)"
 msgstr "Hebreisk (ISO-8859-8)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:280 ../src/osx/button_osx.cpp:39
-#: ../src/common/stockitem.cpp:163 ../src/common/accelcmn.cpp:80
-#: ../src/html/helpdlg.cpp:66 ../src/html/helpfrm.cpp:111
+#: ../include/wx/msgdlg.h:282 ../src/osx/button_osx.cpp:39
+#: ../src/common/stockitem.cpp:160 ../src/common/accelcmn.cpp:77
+#: ../src/html/helpfrm.cpp:108 ../src/html/helpdlg.cpp:63
 msgid "Help"
 msgstr "Hjälp"
 
-#: ../src/html/helpwnd.cpp:1200
+#: ../src/html/helpwnd.cpp:1198
 msgid "Help Browser Options"
 msgstr "Hjälpbläddraralternativ"
 
-#: ../src/generic/helpext.cpp:454 ../src/generic/helpext.cpp:455
+#: ../src/generic/helpext.cpp:452 ../src/generic/helpext.cpp:453
 msgid "Help Index"
 msgstr "Hjälpindex"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1529
 msgid "Help Printing"
 msgstr "Hjälputskrift"
 
-#: ../src/html/helpwnd.cpp:801
+#: ../src/html/helpwnd.cpp:799
 msgid "Help Topics"
 msgstr "Hjälpavsnitt"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1546
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Hjälpböcker (*.htb)|*.htb|Hjälpböcker (*.zip)|*.zip|"
 
-#: ../src/generic/helpext.cpp:267
+#: ../src/generic/helpext.cpp:265
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "Hjälpkatalog \"%s\" hittades inte."
 
-#: ../src/generic/helpext.cpp:275
+#: ../src/generic/helpext.cpp:273
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "Hjälpfil \"%s\" hittades inte."
 
-#: ../src/html/helpctrl.cpp:63
+#: ../src/html/helpctrl.cpp:59
 #, c-format
 msgid "Help: %s"
 msgstr "Hjälp: %s"
 
-#: ../src/osx/menu_osx.cpp:577
+#: ../src/osx/menu_osx.cpp:469
 #, c-format
 msgid "Hide %s"
 msgstr "Dölj %s"
 
-#: ../src/osx/menu_osx.cpp:579
+#: ../src/osx/menu_osx.cpp:471
 msgid "Hide Others"
 msgstr "Dölj övriga"
 
-#: ../src/generic/infobar.cpp:84
+#: ../src/generic/infobar.cpp:81
 msgid "Hide this notification message."
 msgstr "Dölj detta notifieringsmeddelande."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:884
+#: ../src/propgrid/advprops.cpp:785
 #, fuzzy
 msgid "Highlight"
 msgstr "tunn"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:885
+#: ../src/propgrid/advprops.cpp:786
 #, fuzzy
 msgid "HighlightText"
 msgstr "Högerjustera text."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:164 ../src/common/accelcmn.cpp:65
+#: ../src/common/stockitem.cpp:161 ../src/common/accelcmn.cpp:62
 msgid "Home"
 msgstr "Hem"
 
-#: ../src/generic/dirctrlg.cpp:524
+#: ../src/generic/dirctrlg.cpp:490
 msgid "Home directory"
 msgstr "Hemkatalog"
 
@@ -4047,62 +4157,62 @@ msgid "How the object will float relative to the text."
 msgstr "Hur objektet ska flyta i förhållande till texten."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1760
+#: ../src/propgrid/advprops.cpp:1661
 msgid "I-Beam"
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1196
+#: ../src/common/imagbmp.cpp:1208
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: Fel vid läsning av mask DIB."
 
-#: ../src/common/imagbmp.cpp:1290 ../src/common/imagbmp.cpp:1390
-#: ../src/common/imagbmp.cpp:1405 ../src/common/imagbmp.cpp:1416
-#: ../src/common/imagbmp.cpp:1430 ../src/common/imagbmp.cpp:1478
-#: ../src/common/imagbmp.cpp:1493 ../src/common/imagbmp.cpp:1507
-#: ../src/common/imagbmp.cpp:1518
+#: ../src/common/imagbmp.cpp:1302 ../src/common/imagbmp.cpp:1402
+#: ../src/common/imagbmp.cpp:1417 ../src/common/imagbmp.cpp:1428
+#: ../src/common/imagbmp.cpp:1442 ../src/common/imagbmp.cpp:1490
+#: ../src/common/imagbmp.cpp:1505 ../src/common/imagbmp.cpp:1519
+#: ../src/common/imagbmp.cpp:1530
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: Fel vid skrivning till bildfilen!"
 
-#: ../src/common/imagbmp.cpp:1255
+#: ../src/common/imagbmp.cpp:1267
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: Bilden är för hög för en ikon."
 
-#: ../src/common/imagbmp.cpp:1263
+#: ../src/common/imagbmp.cpp:1275
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: Bilden är för bred för en ikon."
 
-#: ../src/common/imagbmp.cpp:1603
+#: ../src/common/imagbmp.cpp:1615
 msgid "ICO: Invalid icon index."
 msgstr "ICO: Ogiltigt ikonindex."
 
-#: ../src/common/imagiff.cpp:758
+#: ../src/common/imagiff.cpp:755
 msgid "IFF: data stream seems to be truncated."
 msgstr "IFF: Dataströmmen ser ut att vara trunkerad."
 
-#: ../src/common/imagiff.cpp:742
+#: ../src/common/imagiff.cpp:739
 msgid "IFF: error in IFF image format."
 msgstr "IFF: Fel i IFF-bildformat."
 
-#: ../src/common/imagiff.cpp:745
+#: ../src/common/imagiff.cpp:742
 msgid "IFF: not enough memory."
 msgstr "IFF: Inte tillräckligt minne."
 
-#: ../src/common/imagiff.cpp:748
+#: ../src/common/imagiff.cpp:745
 msgid "IFF: unknown error!!!"
 msgstr "IFF: Okänt fel!!!"
 
-#: ../src/common/fmapbase.cpp:197
+#: ../src/common/fmapbase.cpp:194
 msgid "ISO-2022-JP"
 msgstr "ISO-2022-JP"
 
-#: ../src/html/htmprint.cpp:282
+#: ../src/html/htmprint.cpp:294
 msgid ""
 "If possible, try changing the layout parameters to make the printout more "
 "narrow."
 msgstr ""
 "Om möjligt, försök ändra layoutparametrarna för att göra utskriften smalare."
 
-#: ../src/generic/dbgrptg.cpp:358
+#: ../src/generic/dbgrptg.cpp:362
 msgid ""
 "If you have any additional information pertaining to this bug\n"
 "report, please enter it here and it will be joined to it:"
@@ -4121,46 +4231,50 @@ msgstr ""
 "medveten om att det kan hindra förbättringar av programmet, så om det\n"
 "är möjligt, fortsätt med skapandet av rapporten.\n"
 
-#: ../src/msw/registry.cpp:1405
+#: ../src/common/zipstrm.cpp:1043
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1393
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Ignorerar värde \"%s\" i nyckeln \"%s\"."
 
-#: ../src/common/xtistrm.cpp:295
+#: ../src/common/xtistrm.cpp:292
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Otillåten objektklass (icke-wxEvtHandler) som händelsekälla"
 
-#: ../src/common/xti.cpp:513
+#: ../src/common/xti.cpp:510
 msgid "Illegal Parameter Count for ConstructObject Method"
 msgstr "Otillåtet antal parametrar för ConstructObject-metod"
 
-#: ../src/common/xti.cpp:501
+#: ../src/common/xti.cpp:498
 msgid "Illegal Parameter Count for Create Method"
 msgstr "Otillåtet antal parametrar för Create-metod"
 
-#: ../src/generic/dirctrlg.cpp:570 ../src/generic/filectrlg.cpp:756
+#: ../src/generic/dirctrlg.cpp:536 ../src/generic/filectrlg.cpp:752
 msgid "Illegal directory name."
 msgstr "Ogiltigt katalognamn."
 
-#: ../src/generic/filectrlg.cpp:1367
+#: ../src/generic/filectrlg.cpp:1356
 msgid "Illegal file specification."
 msgstr "Ogiltig filspecifikation."
 
-#: ../src/common/image.cpp:2269
+#: ../src/common/image.cpp:2363
 msgid "Image and mask have different sizes."
 msgstr "Bild och mask har olika storlekar."
 
-#: ../src/common/image.cpp:2746
+#: ../src/common/image.cpp:2841
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "Bildfilen är inte av typen %d."
 
-#: ../src/common/image.cpp:2877
+#: ../src/common/image.cpp:2995
 #, c-format
 msgid "Image is not of type %s."
 msgstr "Bild är inte av typen %s."
 
-#: ../src/msw/textctrl.cpp:488
+#: ../src/msw/textctrl.cpp:534
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -4168,102 +4282,102 @@ msgstr ""
 "Omöjligt att skapa en rich edit control, använder enkel text control "
 "istället. Installera om riched32.dll"
 
-#: ../src/unix/utilsunx.cpp:301
+#: ../src/unix/utilsunx.cpp:303
 msgid "Impossible to get child process input"
 msgstr "Omöjligt att hämta barnprocessindata"
 
-#: ../src/common/filefn.cpp:1028
+#: ../src/common/filefn.cpp:917
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Omöjligt att hämta behörigheter för fil \"%s\""
 
-#: ../src/common/filefn.cpp:1042
+#: ../src/common/filefn.cpp:931
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Omöjligt att skriva över fil \"%s\""
 
-#: ../src/common/filefn.cpp:1097
+#: ../src/common/filefn.cpp:986
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Omöjligt att sätta behörigheter för filen \"%s\""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:886
+#: ../src/propgrid/advprops.cpp:787
 #, fuzzy
 msgid "InactiveBorder"
 msgstr "Ram"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:887
+#: ../src/propgrid/advprops.cpp:788
 msgid "InactiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:888
+#: ../src/propgrid/advprops.cpp:789
 msgid "InactiveCaptionText"
 msgstr ""
 
-#: ../src/common/gifdecod.cpp:792
+#: ../src/common/gifdecod.cpp:826
 #, c-format
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "Inkorrekt GIF-ramstorlek (%u, %d) för ruta #%u"
 
-#: ../src/msw/ole/automtn.cpp:635
+#: ../src/msw/ole/automtn.cpp:626
 msgid "Incorrect number of arguments."
 msgstr "Ej korrekt antal argument."
 
-#: ../src/common/stockitem.cpp:165
+#: ../src/common/stockitem.cpp:162
 msgid "Indent"
 msgstr "Indentera"
 
-#: ../src/richtext/richtextformatdlg.cpp:349
+#: ../src/richtext/richtextformatdlg.cpp:342
 msgid "Indents && Spacing"
 msgstr "Indrag && avstånd"
 
-#: ../src/common/stockitem.cpp:166 ../src/html/helpwnd.cpp:515
+#: ../src/common/stockitem.cpp:163 ../src/html/helpwnd.cpp:513
 msgid "Index"
 msgstr "Index"
 
-#: ../src/common/fmapbase.cpp:159
+#: ../src/common/fmapbase.cpp:156
 msgid "Indian (ISO-8859-12)"
 msgstr "Indisk (ISO-8859-12)"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "Info"
 msgstr "Info"
 
-#: ../src/common/init.cpp:287
+#: ../src/common/init.cpp:284
 msgid "Initialization failed in post init, aborting."
 msgstr "Initiering misslyckades i post init, avbryter."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:54
+#: ../src/common/accelcmn.cpp:51
 #, fuzzy
 msgid "Ins"
 msgstr "Infällning"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextsymboldlg.cpp:472 ../src/common/accelcmn.cpp:53
+#: ../src/common/accelcmn.cpp:50 ../src/richtext/richtextsymboldlg.cpp:469
 msgid "Insert"
 msgstr "Sätt in"
 
-#: ../src/richtext/richtextbuffer.cpp:8067
+#: ../src/richtext/richtextbuffer.cpp:8063
 msgid "Insert Field"
 msgstr "Infoga fält"
 
-#: ../src/richtext/richtextbuffer.cpp:7978
-#: ../src/richtext/richtextbuffer.cpp:8936
+#: ../src/richtext/richtextbuffer.cpp:7974
+#: ../src/richtext/richtextbuffer.cpp:8934
 msgid "Insert Image"
 msgstr "Infoga bild"
 
-#: ../src/richtext/richtextbuffer.cpp:8025
+#: ../src/richtext/richtextbuffer.cpp:8021
 msgid "Insert Object"
 msgstr "Infoga objekt"
 
-#: ../src/richtext/richtextctrl.cpp:1286 ../src/richtext/richtextctrl.cpp:1494
-#: ../src/richtext/richtextbuffer.cpp:7822
-#: ../src/richtext/richtextbuffer.cpp:7852
-#: ../src/richtext/richtextbuffer.cpp:7894
+#: ../src/richtext/richtextbuffer.cpp:7818
+#: ../src/richtext/richtextbuffer.cpp:7848
+#: ../src/richtext/richtextbuffer.cpp:7890
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
 msgid "Insert Text"
 msgstr "Infoga text"
 
@@ -4276,16 +4390,11 @@ msgstr "Lägger till en sidbrytning före stycket."
 msgid "Inset"
 msgstr "Infällning"
 
-#: ../src/gtk/app.cpp:425
-#, c-format
-msgid "Invalid GTK+ command line option, use \"%s --help\""
-msgstr "Ogiltigt GTK+ kommandoradsargument, använd \"%s --help\""
-
-#: ../src/common/imagtiff.cpp:311
+#: ../src/common/imagtiff.cpp:308
 msgid "Invalid TIFF image index."
 msgstr "Ogiltigt TIFF-bildindex."
 
-#: ../src/common/appcmn.cpp:273
+#: ../src/common/appcmn.cpp:294
 #, c-format
 msgid "Invalid display mode specification '%s'."
 msgstr "Ogiltig bildskärmslägesspecifikation \"%s\"."
@@ -4295,257 +4404,261 @@ msgstr "Ogiltig bildskärmslägesspecifikation \"%s\"."
 msgid "Invalid geometry specification '%s'"
 msgstr "Ogiltig geometrispecifikation \"%s\""
 
-#: ../src/unix/fswatcher_inotify.cpp:323
+#: ../src/unix/fswatcher_inotify.cpp:320
 #, c-format
 msgid "Invalid inotify event for \"%s\""
 msgstr "Ogiltig inotify-händelse för \"%s\""
 
-#: ../src/unix/snglinst.cpp:312
+#: ../src/unix/snglinst.cpp:309
 #, c-format
 msgid "Invalid lock file '%s'."
 msgstr "Ogiltig låsfil \"%s\"."
 
-#: ../src/common/translation.cpp:1125
+#: ../src/common/translation.cpp:1167
 msgid "Invalid message catalog."
 msgstr "Ogiltig meddelandekatalog."
 
-#: ../src/common/xtistrm.cpp:405 ../src/common/xtistrm.cpp:420
+#: ../src/common/xtistrm.cpp:402 ../src/common/xtistrm.cpp:417
 msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
 msgstr "Ogiltigt eller null objekt-id skickat till GetObjectClassInfo"
 
-#: ../src/common/xtistrm.cpp:435
+#: ../src/common/xtistrm.cpp:432
 msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
 msgstr "Ogiltigt eller null objekt-id skickat till HasObjectClassInfo"
 
-#: ../src/common/regex.cpp:310
+#: ../src/common/regex.cpp:307
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Ogiltigt reguljärt uttryck \"%s\": %s"
 
-#: ../src/common/config.cpp:226
+#: ../src/common/config.cpp:222
 #, c-format
 msgid "Invalid value %ld for a boolean key \"%s\" in config file."
 msgstr "Ogiltigt värde %ld för en boolsk nyckel \"%s\" i config-fil."
 
-#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:351
-#: ../src/osx/carbon/fontdlg.cpp:361 ../src/common/stockitem.cpp:168
+#: ../src/osx/carbon/fontdlg.cpp:358 ../src/common/stockitem.cpp:165
+#: ../src/generic/fontdlgg.cpp:325 ../src/richtext/richtextfontpage.cpp:351
 msgid "Italic"
 msgstr "Kursiv"
 
-#: ../src/common/paper.cpp:130
+#: ../src/common/paper.cpp:127
 msgid "Italy Envelope, 110 x 230 mm"
 msgstr "Italienskt kuvert, 110 x 230 mm"
 
-#: ../src/common/imagjpeg.cpp:270
+#: ../src/common/imagjpeg.cpp:257
 msgid "JPEG: Couldn't load - file is probably corrupted."
 msgstr "JPEG: Kunde inte läsa in - filen är troligen skadad."
 
-#: ../src/common/imagjpeg.cpp:449
+#: ../src/common/imagjpeg.cpp:436
 msgid "JPEG: Couldn't save image."
 msgstr "JPEG: Kunde inte spara bild."
 
-#: ../src/common/paper.cpp:163
+#: ../src/common/paper.cpp:160
 msgid "Japanese Double Postcard 200 x 148 mm"
 msgstr "Japanskt dubbelt vykort 200 x 148 mm"
 
-#: ../src/common/paper.cpp:167
+#: ../src/common/paper.cpp:164
 msgid "Japanese Envelope Chou #3"
 msgstr "Japanskt kuvert Chou #3"
 
-#: ../src/common/paper.cpp:180
+#: ../src/common/paper.cpp:177
 msgid "Japanese Envelope Chou #3 Rotated"
 msgstr "Japanskt kuvert Chou #3 roterat"
 
-#: ../src/common/paper.cpp:168
+#: ../src/common/paper.cpp:165
 msgid "Japanese Envelope Chou #4"
 msgstr "Japanskt kuvert Chou #4"
 
-#: ../src/common/paper.cpp:181
+#: ../src/common/paper.cpp:178
 msgid "Japanese Envelope Chou #4 Rotated"
 msgstr "Japanskt kuvert Chou #4 roterat"
 
-#: ../src/common/paper.cpp:165
+#: ../src/common/paper.cpp:162
 msgid "Japanese Envelope Kaku #2"
 msgstr "Japanskt kuvert Kaku #2"
 
-#: ../src/common/paper.cpp:178
+#: ../src/common/paper.cpp:175
 msgid "Japanese Envelope Kaku #2 Rotated"
 msgstr "Japanskt kuvert Kaku #2 roterat"
 
-#: ../src/common/paper.cpp:166
+#: ../src/common/paper.cpp:163
 msgid "Japanese Envelope Kaku #3"
 msgstr "Japanskt kuvert Kaku #3"
 
-#: ../src/common/paper.cpp:179
+#: ../src/common/paper.cpp:176
 msgid "Japanese Envelope Kaku #3 Rotated"
 msgstr "Japanskt kuvert Kaku #3 roterat"
 
-#: ../src/common/paper.cpp:185
+#: ../src/common/paper.cpp:182
 msgid "Japanese Envelope You #4"
 msgstr "Japanskt kuvert You #4"
 
-#: ../src/common/paper.cpp:186
+#: ../src/common/paper.cpp:183
 msgid "Japanese Envelope You #4 Rotated"
 msgstr "Japanskt kuvert You #4 roterat"
 
-#: ../src/common/paper.cpp:138
+#: ../src/common/paper.cpp:135
 msgid "Japanese Postcard 100 x 148 mm"
 msgstr "Japanskt vykort 100 x 148"
 
-#: ../src/common/paper.cpp:175
+#: ../src/common/paper.cpp:172
 msgid "Japanese Postcard Rotated 148 x 100 mm"
 msgstr "Japanskt vykort roterat 148 x 100"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "Jump to"
 msgstr "Hoppa till"
 
-#: ../src/common/stockitem.cpp:171
+#: ../src/common/stockitem.cpp:168
 msgid "Justified"
 msgstr "Marginaljusterad"
 
-#: ../src/richtext/richtextindentspage.cpp:155
-#: ../src/richtext/richtextindentspage.cpp:157
 #: ../src/richtext/richtextliststylepage.cpp:344
 #: ../src/richtext/richtextliststylepage.cpp:346
+#: ../src/richtext/richtextindentspage.cpp:155
+#: ../src/richtext/richtextindentspage.cpp:157
 msgid "Justify text left and right."
 msgstr "Justera text vänster och höger."
 
-#: ../src/common/fmapbase.cpp:163
+#: ../src/common/fmapbase.cpp:160
 msgid "KOI8-R"
 msgstr "KOI8-R"
 
-#: ../src/common/fmapbase.cpp:164
+#: ../src/common/fmapbase.cpp:161
 msgid "KOI8-U"
 msgstr "KOI8-U"
 
-#: ../src/common/accelcmn.cpp:265 ../src/common/accelcmn.cpp:347
+#: ../src/common/accelcmn.cpp:279 ../src/common/accelcmn.cpp:364
 msgid "KP_"
 msgstr "KP_"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 #, fuzzy
 msgid "KP_Add"
 msgstr "KP_ADDERA"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "KP_Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "KP_Decimal"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 #, fuzzy
 msgid "KP_Delete"
 msgstr "Ta bort"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "KP_Divide"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 #, fuzzy
 msgid "KP_Down"
 msgstr "Ner"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 #, fuzzy
 msgid "KP_End"
 msgstr "KP_END"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 #, fuzzy
 msgid "KP_Enter"
 msgstr "Skrivare"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "KP_Equal"
 msgstr ""
 
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
-#, fuzzy
-msgid "KP_Home"
-msgstr "Hem"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
-#, fuzzy
-msgid "KP_Insert"
-msgstr "Sätt in"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
-#, fuzzy
-msgid "KP_Left"
-msgstr "Vänster"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
-msgid "KP_Multiply"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:99
-#, fuzzy
-msgid "KP_Next"
-msgstr "Nästa"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
-msgid "KP_PageDown"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
-msgid "KP_PageUp"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:98
-msgid "KP_Prior"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
-#, fuzzy
-msgid "KP_Right"
-msgstr "Höger"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
-msgid "KP_Separator"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
-msgid "KP_Space"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
-msgid "KP_Subtract"
+#: ../src/common/accelcmn.cpp:276 ../src/common/accelcmn.cpp:361
+msgid "KP_F"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
 #: ../src/common/accelcmn.cpp:89
 #, fuzzy
+msgid "KP_Home"
+msgstr "Hem"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:100
+#, fuzzy
+msgid "KP_Insert"
+msgstr "Sätt in"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:90
+#, fuzzy
+msgid "KP_Left"
+msgstr "Vänster"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:103
+msgid "KP_Multiply"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:97
+#, fuzzy
+msgid "KP_Next"
+msgstr "Nästa"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:95
+msgid "KP_PageDown"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:94
+msgid "KP_PageUp"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:96
+msgid "KP_Prior"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:92
+#, fuzzy
+msgid "KP_Right"
+msgstr "Höger"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:105
+msgid "KP_Separator"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:86
+msgid "KP_Space"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:106
+msgid "KP_Subtract"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:87
+#, fuzzy
 msgid "KP_Tab"
 msgstr "KP_TABB"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 #, fuzzy
 msgid "KP_Up"
 msgstr "KP_UPP"
@@ -4554,112 +4667,127 @@ msgstr "KP_UPP"
 msgid "L&ine spacing:"
 msgstr "&Radavstånd:"
 
-#: ../src/generic/prntdlgg.cpp:613 ../src/generic/prntdlgg.cpp:868
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "kompressionsfel"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "dekompressionsfel"
+
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:861
 msgid "Landscape"
 msgstr "Liggande"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "Last"
 msgstr "Sista"
 
-#: ../src/common/prntbase.cpp:1572
+#: ../src/common/prntbase.cpp:1597
 msgid "Last page"
 msgstr "Sista sida"
 
-#: ../src/common/log.cpp:305
+#: ../src/common/log.cpp:324
 #, fuzzy, c-format
 msgid "Last repeated message (\"%s\", %u time) wasn't output"
 msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
 msgstr[0] "Senast upprepade meddelande(\"%s\", %lu gång) skrevs inte ut"
 msgstr[1] "Senast upprepade meddelande(\"%s\", %lu gånger) skrevs inte ut"
 
-#: ../src/common/paper.cpp:103
+#: ../src/common/paper.cpp:100
 msgid "Ledger, 17 x 11 in"
 msgstr "Liggare, 17 x 11 tum"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6146
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:58 ../src/generic/datavgen.cpp:6951
+#: ../src/richtext/richtextsizepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:252
 #: ../src/richtext/richtextliststylepage.cpp:253
 #: ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
-#: ../src/richtext/richtextsizepage.cpp:249 ../src/common/accelcmn.cpp:61
 msgid "Left"
 msgstr "Vänster"
 
-#: ../src/richtext/richtextindentspage.cpp:204
 #: ../src/richtext/richtextliststylepage.cpp:390
+#: ../src/richtext/richtextindentspage.cpp:204
 msgid "Left (&first line):"
 msgstr "Vänster (&första raden):"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1761
+#: ../src/propgrid/advprops.cpp:1662
 msgid "Left Button"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:880
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Left margin (mm):"
 msgstr "Vänster marginal (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:141
-#: ../src/richtext/richtextindentspage.cpp:143
 #: ../src/richtext/richtextliststylepage.cpp:330
 #: ../src/richtext/richtextliststylepage.cpp:332
+#: ../src/richtext/richtextindentspage.cpp:141
+#: ../src/richtext/richtextindentspage.cpp:143
 msgid "Left-align text."
 msgstr "Vänsterjustera text."
 
-#: ../src/common/paper.cpp:144
+#: ../src/common/paper.cpp:141
 msgid "Legal Extra 9 1/2 x 15 in"
 msgstr "Legal extra 9 1/2 x 15 tum"
 
-#: ../src/common/paper.cpp:96
+#: ../src/common/paper.cpp:93
 msgid "Legal, 8 1/2 x 14 in"
 msgstr "Legal, 8 1/2 x 14 tum"
 
-#: ../src/common/paper.cpp:143
+#: ../src/common/paper.cpp:140
 msgid "Letter Extra 9 1/2 x 12 in"
 msgstr "Letter extra 9 1/2 x 12 tum"
 
-#: ../src/common/paper.cpp:149
+#: ../src/common/paper.cpp:146
 msgid "Letter Extra Transverse 9.275 x 12 in"
 msgstr "Letter extra transverserad 9,275 x 12 tum"
 
-#: ../src/common/paper.cpp:152
+#: ../src/common/paper.cpp:149
 msgid "Letter Plus 8 1/2 x 12.69 in"
 msgstr "Letter plus 8 1/2 x 12,69 tum"
 
-#: ../src/common/paper.cpp:169
+#: ../src/common/paper.cpp:166
 msgid "Letter Rotated 11 x 8 1/2 in"
 msgstr "Letter roterat 11 x 8 1/2 tum"
 
-#: ../src/common/paper.cpp:101
+#: ../src/common/paper.cpp:98
 msgid "Letter Small, 8 1/2 x 11 in"
 msgstr "Letter litet, 8 1/2 x 11 tum"
 
-#: ../src/common/paper.cpp:147
+#: ../src/common/paper.cpp:144
 msgid "Letter Transverse 8 1/2 x 11 in"
 msgstr "Letter transverserat 8 1/2 x 11 tum"
 
-#: ../src/common/paper.cpp:95
+#: ../src/common/paper.cpp:92
 msgid "Letter, 8 1/2 x 11 in"
 msgstr "Letter, 8 1/2 x 11 tum"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "License"
 msgstr "Licens"
 
-#: ../src/generic/fontdlgg.cpp:332
+#: ../src/generic/fontdlgg.cpp:328
 msgid "Light"
 msgstr "Tunn"
 
-#: ../src/propgrid/advprops.cpp:1608
+#: ../src/propgrid/advprops.cpp:1514
 msgid "Lime"
 msgstr ""
 
-#: ../src/generic/helpext.cpp:294
+#: ../src/generic/helpext.cpp:292
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr "Rad %lu i map-fil \"%s\" har felaktig syntax, hoppar över."
@@ -4668,15 +4796,15 @@ msgstr "Rad %lu i map-fil \"%s\" har felaktig syntax, hoppar över."
 msgid "Line spacing:"
 msgstr "Radavstånd:"
 
-#: ../src/html/chm.cpp:838
+#: ../src/html/chm.cpp:829
 msgid "Link contained '//', converted to absolute link."
 msgstr "Länken innehöll \"//\", omvandlad till absolut länk."
 
-#: ../src/richtext/richtextformatdlg.cpp:364
+#: ../src/richtext/richtextformatdlg.cpp:357
 msgid "List Style"
 msgstr "Liststil"
 
-#: ../src/richtext/richtextstyles.cpp:1064
+#: ../src/richtext/richtextstyles.cpp:1061
 msgid "List styles"
 msgstr "Liststilar"
 
@@ -4690,26 +4818,26 @@ msgstr "Listar typsnittstorlekar i punkter."
 msgid "Lists the available fonts."
 msgstr "Listar tillgängliga typsnitt"
 
-#: ../src/common/fldlgcmn.cpp:340
+#: ../src/common/fldlgcmn.cpp:337
 #, c-format
 msgid "Load %s file"
 msgstr "Läs in %s fil"
 
-#: ../src/html/htmlwin.cpp:597
+#: ../src/html/htmlwin.cpp:600
 msgid "Loading : "
 msgstr "Läser in: "
 
-#: ../src/unix/snglinst.cpp:246
+#: ../src/unix/snglinst.cpp:243
 #, c-format
 msgid "Lock file '%s' has incorrect owner."
 msgstr "Låsfilen \"%s\" har felaktig ägare."
 
-#: ../src/unix/snglinst.cpp:251
+#: ../src/unix/snglinst.cpp:248
 #, c-format
 msgid "Lock file '%s' has incorrect permissions."
 msgstr "Låsfilen \"%s\" har felaktig behörighet."
 
-#: ../src/generic/logg.cpp:576
+#: ../src/generic/logg.cpp:573
 #, c-format
 msgid "Log saved to the file '%s'."
 msgstr "Logg sparad till filen \"%s\"."
@@ -4724,11 +4852,11 @@ msgstr "Små bokstäver"
 msgid "Lower case roman numerals"
 msgstr "Små romerska siffor"
 
-#: ../src/gtk/mdi.cpp:422 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk1/mdi.cpp:431 ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "MDI-barn"
 
-#: ../src/msw/helpchm.cpp:56
+#: ../src/msw/helpchm.cpp:53
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -4736,189 +4864,189 @@ msgstr ""
 "MS HTML hjälpfunktioner är inte tillgängliga på grund av att MS HTML "
 "hjälpbiblioteket inte är installerat på den här maskinen. Installera det."
 
-#: ../src/univ/themes/win32.cpp:3754
+#: ../src/univ/themes/win32.cpp:3751
 msgid "Ma&ximize"
 msgstr "Ma&ximera"
 
-#: ../src/common/fmapbase.cpp:203
+#: ../src/common/fmapbase.cpp:200
 msgid "MacArabic"
 msgstr "MacArabiska"
 
-#: ../src/common/fmapbase.cpp:222
+#: ../src/common/fmapbase.cpp:219
 msgid "MacArmenian"
 msgstr "MacArmeniska"
 
-#: ../src/common/fmapbase.cpp:211
+#: ../src/common/fmapbase.cpp:208
 msgid "MacBengali"
 msgstr "MacBengaliska"
 
-#: ../src/common/fmapbase.cpp:217
+#: ../src/common/fmapbase.cpp:214
 msgid "MacBurmese"
 msgstr "MacBurmesiska"
 
-#: ../src/common/fmapbase.cpp:236
+#: ../src/common/fmapbase.cpp:233
 msgid "MacCeltic"
 msgstr "MacKeltiska"
 
-#: ../src/common/fmapbase.cpp:227
+#: ../src/common/fmapbase.cpp:224
 msgid "MacCentralEurRoman"
 msgstr "MacCentraleurromanska"
 
-#: ../src/common/fmapbase.cpp:223
+#: ../src/common/fmapbase.cpp:220
 msgid "MacChineseSimp"
 msgstr "MacFörenkladKinesiska"
 
-#: ../src/common/fmapbase.cpp:201
+#: ../src/common/fmapbase.cpp:198
 msgid "MacChineseTrad"
 msgstr "MacTratitionellKinesiska"
 
-#: ../src/common/fmapbase.cpp:233
+#: ../src/common/fmapbase.cpp:230
 msgid "MacCroatian"
 msgstr "MacKroatiska"
 
-#: ../src/common/fmapbase.cpp:206
+#: ../src/common/fmapbase.cpp:203
 msgid "MacCyrillic"
 msgstr "MacKyrilliska"
 
-#: ../src/common/fmapbase.cpp:207
+#: ../src/common/fmapbase.cpp:204
 msgid "MacDevanagari"
 msgstr "MacDevanagari"
 
-#: ../src/common/fmapbase.cpp:231
+#: ../src/common/fmapbase.cpp:228
 msgid "MacDingbats"
 msgstr "MacDingbats"
 
-#: ../src/common/fmapbase.cpp:226
+#: ../src/common/fmapbase.cpp:223
 msgid "MacEthiopic"
 msgstr "MacEtiopiska"
 
-#: ../src/common/fmapbase.cpp:229
+#: ../src/common/fmapbase.cpp:226
 msgid "MacExtArabic"
 msgstr "MacUtökadArabiska"
 
-#: ../src/common/fmapbase.cpp:237
+#: ../src/common/fmapbase.cpp:234
 msgid "MacGaelic"
 msgstr "MacGaeliska"
 
-#: ../src/common/fmapbase.cpp:221
+#: ../src/common/fmapbase.cpp:218
 msgid "MacGeorgian"
 msgstr "MacGeorigiska"
 
-#: ../src/common/fmapbase.cpp:205
+#: ../src/common/fmapbase.cpp:202
 msgid "MacGreek"
 msgstr "MacGrekiska"
 
-#: ../src/common/fmapbase.cpp:209
+#: ../src/common/fmapbase.cpp:206
 msgid "MacGujarati"
 msgstr "MacGujarati"
 
-#: ../src/common/fmapbase.cpp:208
+#: ../src/common/fmapbase.cpp:205
 msgid "MacGurmukhi"
 msgstr "MacGurmukhi"
 
-#: ../src/common/fmapbase.cpp:204
+#: ../src/common/fmapbase.cpp:201
 msgid "MacHebrew"
 msgstr "MacHebreiska"
 
-#: ../src/common/fmapbase.cpp:234
+#: ../src/common/fmapbase.cpp:231
 msgid "MacIcelandic"
 msgstr "MacIsländska"
 
-#: ../src/common/fmapbase.cpp:200
+#: ../src/common/fmapbase.cpp:197
 msgid "MacJapanese"
 msgstr "MacJapanska"
 
-#: ../src/common/fmapbase.cpp:214
+#: ../src/common/fmapbase.cpp:211
 msgid "MacKannada"
 msgstr "MacKannada"
 
-#: ../src/common/fmapbase.cpp:238
+#: ../src/common/fmapbase.cpp:235
 msgid "MacKeyboardGlyphs"
 msgstr "MacTangentborstecken"
 
-#: ../src/common/fmapbase.cpp:218
+#: ../src/common/fmapbase.cpp:215
 msgid "MacKhmer"
 msgstr "MacKhmer"
 
-#: ../src/common/fmapbase.cpp:202
+#: ../src/common/fmapbase.cpp:199
 msgid "MacKorean"
 msgstr "MacKoreanska"
 
-#: ../src/common/fmapbase.cpp:220
+#: ../src/common/fmapbase.cpp:217
 msgid "MacLaotian"
 msgstr "MacLaotian"
 
-#: ../src/common/fmapbase.cpp:215
+#: ../src/common/fmapbase.cpp:212
 msgid "MacMalayalam"
 msgstr "MacMalayalam"
 
-#: ../src/common/fmapbase.cpp:225
+#: ../src/common/fmapbase.cpp:222
 msgid "MacMongolian"
 msgstr "MacMongoliska"
 
-#: ../src/common/fmapbase.cpp:210
+#: ../src/common/fmapbase.cpp:207
 msgid "MacOriya"
 msgstr "MacOriya"
 
-#: ../src/common/fmapbase.cpp:199
+#: ../src/common/fmapbase.cpp:196
 msgid "MacRoman"
 msgstr "MacRoman"
 
-#: ../src/common/fmapbase.cpp:235
+#: ../src/common/fmapbase.cpp:232
 msgid "MacRomanian"
 msgstr "MacRumänska"
 
-#: ../src/common/fmapbase.cpp:216
+#: ../src/common/fmapbase.cpp:213
 msgid "MacSinhalese"
 msgstr "MacSingalesiska"
 
-#: ../src/common/fmapbase.cpp:230
+#: ../src/common/fmapbase.cpp:227
 msgid "MacSymbol"
 msgstr "MacSymbol"
 
-#: ../src/common/fmapbase.cpp:212
+#: ../src/common/fmapbase.cpp:209
 msgid "MacTamil"
 msgstr "MacTamilska"
 
-#: ../src/common/fmapbase.cpp:213
+#: ../src/common/fmapbase.cpp:210
 msgid "MacTelugu"
 msgstr "MacTelugu"
 
-#: ../src/common/fmapbase.cpp:219
+#: ../src/common/fmapbase.cpp:216
 msgid "MacThai"
 msgstr "MacThailändska"
 
-#: ../src/common/fmapbase.cpp:224
+#: ../src/common/fmapbase.cpp:221
 msgid "MacTibetan"
 msgstr "MacTibetanska"
 
-#: ../src/common/fmapbase.cpp:232
+#: ../src/common/fmapbase.cpp:229
 msgid "MacTurkish"
 msgstr "MacTurksiska"
 
-#: ../src/common/fmapbase.cpp:228
+#: ../src/common/fmapbase.cpp:225
 msgid "MacVietnamese"
 msgstr "MacVietnamesiska"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1762
+#: ../src/propgrid/advprops.cpp:1663
 msgid "Magnifier"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:2143
+#: ../src/propgrid/advprops.cpp:2050
 msgid "Make a selection:"
 msgstr "Skapa en markering:"
 
-#: ../src/richtext/richtextformatdlg.cpp:374
+#: ../src/richtext/richtextformatdlg.cpp:367
 #: ../src/richtext/richtextmarginspage.cpp:171
 msgid "Margins"
 msgstr "Marginaler"
 
-#: ../src/propgrid/advprops.cpp:1595
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Maroon"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:147
+#: ../src/generic/fdrepdlg.cpp:144
 msgid "Match case"
 msgstr "Matcha skiftläge"
 
@@ -4930,40 +5058,40 @@ msgstr "Max höjd:"
 msgid "Max width:"
 msgstr "Max bredd:"
 
-#: ../src/unix/mediactrl.cpp:947
+#: ../src/unix/mediactrl.cpp:972
 #, c-format
 msgid "Media playback error: %s"
 msgstr "Medieuppspelningsfel: %s"
 
-#: ../src/common/fs_mem.cpp:175
+#: ../src/common/fs_mem.cpp:170
 #, c-format
 msgid "Memory VFS already contains file '%s'!"
 msgstr "Minnes-VFS innehåller redan fil \"%s\"!"
 
 #. TRANSLATORS: Name of keyboard key
 #. TRANSLATORS: Keyword of system colour
-#: ../src/common/accelcmn.cpp:73 ../src/propgrid/advprops.cpp:889
+#: ../src/common/accelcmn.cpp:70 ../src/propgrid/advprops.cpp:790
 msgid "Menu"
 msgstr "Meny"
 
-#: ../src/common/msgout.cpp:124
+#: ../src/common/msgout.cpp:121
 msgid "Message"
 msgstr "Meddelande"
 
-#: ../src/univ/themes/metal.cpp:168
+#: ../src/univ/themes/metal.cpp:165
 msgid "Metal theme"
 msgstr "Metalltema"
 
-#: ../src/msw/ole/automtn.cpp:652
+#: ../src/msw/ole/automtn.cpp:643
 msgid "Method or property not found."
 msgstr "Metod eller egenskap hittades inte."
 
-#: ../src/univ/themes/win32.cpp:3752
+#: ../src/univ/themes/win32.cpp:3749
 msgid "Mi&nimize"
 msgstr "&Minimera"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1763
+#: ../src/propgrid/advprops.cpp:1664
 msgid "Middle Button"
 msgstr ""
 
@@ -4975,37 +5103,42 @@ msgstr "Min höjd:"
 msgid "Min width:"
 msgstr "Min bredd:"
 
-#: ../src/msw/ole/automtn.cpp:668
+#: ../src/osx/cocoa/menu.mm:281
+#, fuzzy
+msgid "Minimize"
+msgstr "&Minimera"
+
+#: ../src/msw/ole/automtn.cpp:659
 msgid "Missing a required parameter."
 msgstr "Saknar en nödvändig parameter."
 
-#: ../src/generic/fontdlgg.cpp:324
+#: ../src/generic/fontdlgg.cpp:320
 msgid "Modern"
 msgstr "Modern"
 
-#: ../src/generic/filectrlg.cpp:427
+#: ../src/generic/filectrlg.cpp:423
 msgid "Modified"
 msgstr "Ändrad"
 
-#: ../src/common/module.cpp:133
+#: ../src/common/module.cpp:130
 #, c-format
 msgid "Module \"%s\" initialization failed"
 msgstr "Modul \"%s\" initiering misslyckades"
 
-#: ../src/common/paper.cpp:131
+#: ../src/common/paper.cpp:128
 msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
 msgstr "Monarch kuvert, 3 7/8 x 7 1/2 tum"
 
-#: ../src/msw/fswatcher.cpp:143
+#: ../src/msw/fswatcher.cpp:140
 msgid "Monitoring individual files for changes is not supported currently."
 msgstr ""
 "Bevakning av individuella filer för ändringar stöds inte  för närvarande."
 
-#: ../src/generic/editlbox.cpp:172
+#: ../src/generic/editlbox.cpp:160
 msgid "Move down"
 msgstr "Flytta ner"
 
-#: ../src/generic/editlbox.cpp:171
+#: ../src/generic/editlbox.cpp:155
 msgid "Move up"
 msgstr "Flytta upp"
 
@@ -5019,97 +5152,102 @@ msgstr "Flyttar objektet till nästa stycke."
 msgid "Moves the object to the previous paragraph."
 msgstr "Flyttar objektet till föregående stycke."
 
-#: ../src/richtext/richtextbuffer.cpp:9966
+#: ../src/richtext/richtextbuffer.cpp:9963
 msgid "Multiple Cell Properties"
 msgstr "Egenskaper för flera celler"
 
-#: ../src/generic/filectrlg.cpp:424
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:82
+msgid "Multiply"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:420
 msgid "Name"
 msgstr "Namn"
 
-#: ../src/propgrid/advprops.cpp:1596
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Navy"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "Network"
 msgstr "Nätverk"
 
-#: ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173
 msgid "New"
 msgstr "Ny"
 
-#: ../src/richtext/richtextstyledlg.cpp:243
+#: ../src/richtext/richtextstyledlg.cpp:239
 msgid "New &Box Style..."
 msgstr "Ny &lådstil..."
 
-#: ../src/richtext/richtextstyledlg.cpp:225
+#: ../src/richtext/richtextstyledlg.cpp:221
 msgid "New &Character Style..."
 msgstr "Ny &teckenstil..."
 
-#: ../src/richtext/richtextstyledlg.cpp:237
+#: ../src/richtext/richtextstyledlg.cpp:233
 msgid "New &List Style..."
 msgstr "Ny &liststil..."
 
-#: ../src/richtext/richtextstyledlg.cpp:231
+#: ../src/richtext/richtextstyledlg.cpp:227
 msgid "New &Paragraph Style..."
 msgstr "Ny &styckestil..."
 
-#: ../src/richtext/richtextstyledlg.cpp:606
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:654
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:820
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:893
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:934
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:602
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:650
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:816
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:889
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:930
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "New Style"
 msgstr "Ny stil"
 
-#: ../src/generic/editlbox.cpp:169
+#: ../src/generic/editlbox.cpp:139
 msgid "New item"
 msgstr "Nytt post"
 
-#: ../src/generic/dirdlgg.cpp:297 ../src/generic/dirdlgg.cpp:307
-#: ../src/generic/filectrlg.cpp:618 ../src/generic/filectrlg.cpp:627
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+#: ../src/generic/dirdlgg.cpp:294 ../src/generic/dirdlgg.cpp:304
 msgid "NewName"
 msgstr "Nytt namn"
 
-#: ../src/common/prntbase.cpp:1567 ../src/html/helpwnd.cpp:665
+#: ../src/common/prntbase.cpp:1592 ../src/html/helpwnd.cpp:663
 msgid "Next page"
 msgstr "Nästa sida"
 
-#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:177
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:174
 #: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Nej"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1764
+#: ../src/propgrid/advprops.cpp:1665
 msgid "No Entry"
 msgstr ""
 
-#: ../src/generic/animateg.cpp:150
+#: ../src/generic/animateg.cpp:133
 #, c-format
 msgid "No animation handler for type %ld defined."
 msgstr "Ingen animationshanterare är definierad för typ %ld."
 
-#: ../src/dfb/bitmap.cpp:642 ../src/dfb/bitmap.cpp:676
+#: ../src/dfb/bitmap.cpp:639 ../src/dfb/bitmap.cpp:673
 #, c-format
 msgid "No bitmap handler for type %d defined."
 msgstr "Ingen bildhanterare är definierad för typ %d."
 
-#: ../src/common/utilscmn.cpp:1077
+#: ../src/common/utilscmn.cpp:1095
 msgid "No default application configured for HTML files."
 msgstr "Inget standardprogram för HTML-filer är konfigurerat."
 
-#: ../src/generic/helpext.cpp:445
+#: ../src/generic/helpext.cpp:443
 msgid "No entries found."
 msgstr "Inga poster funna."
 
-#: ../src/common/fontmap.cpp:421
+#: ../src/common/fontmap.cpp:418
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found,\n"
@@ -5121,7 +5259,7 @@ msgstr ""
 "men en alternativ kodning \"%s\" är tillgänglig.\n"
 "Vill du använda denna kodning (annars måste du välja någon annat)?"
 
-#: ../src/common/fontmap.cpp:426
+#: ../src/common/fontmap.cpp:423
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found.\n"
@@ -5132,206 +5270,206 @@ msgstr ""
 "Vill du välja ett typsnitt att använda för denna kodning\n"
 "(annars kommer texten med denna kodning inte att visas korrekt)?"
 
-#: ../src/generic/animateg.cpp:142
+#: ../src/generic/animateg.cpp:125
 msgid "No handler found for animation type."
 msgstr "Ingen hanterare hittades för animationstyp."
 
-#: ../src/common/image.cpp:2728
+#: ../src/common/image.cpp:2823
 msgid "No handler found for image type."
 msgstr "Ingen hanterare hittades för bildtyp."
 
-#: ../src/common/image.cpp:2736 ../src/common/image.cpp:2848
-#: ../src/common/image.cpp:2901
+#: ../src/common/image.cpp:2831 ../src/common/image.cpp:2954
+#: ../src/common/image.cpp:3020
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "Ingen bildhanterare är definierad för typ %d."
 
-#: ../src/common/image.cpp:2871 ../src/common/image.cpp:2915
+#: ../src/common/image.cpp:2986 ../src/common/image.cpp:3034
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "Ingen bildhanterare är definierad för typ %s."
 
-#: ../src/html/helpwnd.cpp:858
+#: ../src/html/helpwnd.cpp:856
 msgid "No matching page found yet"
 msgstr "Ingen matchande sida hittad ännu"
 
-#: ../src/unix/sound.cpp:81
+#: ../src/unix/sound.cpp:78
 msgid "No sound"
 msgstr "Inget ljud"
 
-#: ../src/common/image.cpp:2277 ../src/common/image.cpp:2318
+#: ../src/common/image.cpp:2371 ../src/common/image.cpp:2412
 msgid "No unused colour in image being masked."
 msgstr "Ingen oanvänd färg i bilden är maskad."
 
-#: ../src/common/image.cpp:3374
-msgid "No unused colour in image."
-msgstr "Ingen oanvänd färg bilden."
-
-#: ../src/generic/helpext.cpp:302
+#: ../src/generic/helpext.cpp:300
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "Ingen giltig mappning hittad i fil \"%s\"."
 
-#: ../src/richtext/richtextborderspage.cpp:610
 #: ../src/richtext/richtextsizepage.cpp:248
 #: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:610
 msgid "None"
 msgstr "Ingen"
 
-#: ../src/common/fmapbase.cpp:157
+#: ../src/common/fmapbase.cpp:154
 msgid "Nordic (ISO-8859-10)"
 msgstr "Nordiska språk (ISO-8859-10)"
 
-#: ../src/generic/fontdlgg.cpp:328 ../src/generic/fontdlgg.cpp:331
+#: ../src/generic/fontdlgg.cpp:324 ../src/generic/fontdlgg.cpp:327
 msgid "Normal"
 msgstr "Normal"
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1261
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Normalt typsnitt<br>och <u>understruket</u>. "
 
-#: ../src/html/helpwnd.cpp:1205
+#: ../src/html/helpwnd.cpp:1203
 msgid "Normal font:"
 msgstr "Normalt typsnitt:"
 
-#: ../src/propgrid/props.cpp:1128
+#: ../src/propgrid/props.cpp:1115
 #, c-format
 msgid "Not %s"
 msgstr "Inte %s"
 
-#: ../include/wx/filename.h:573 ../include/wx/filename.h:578
-msgid "Not available"
-msgstr "Inte tillgängligt"
+#: ../src/common/secretstore.cpp:168
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/webrequest.cpp:605
+msgid "Not enough free disk space for download."
+msgstr ""
 
 #: ../src/richtext/richtextfontpage.cpp:358
 msgid "Not underlined"
 msgstr "Inte understruken"
 
-#: ../src/common/paper.cpp:115
+#: ../src/common/paper.cpp:112
 msgid "Note, 8 1/2 x 11 in"
 msgstr "Anteckning, 8 1/2 x 11 tum"
 
-#: ../src/generic/notifmsgg.cpp:132
+#: ../src/generic/notifmsgg.cpp:129
 msgid "Notice"
 msgstr "Notis"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "Num *"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "Num +"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "Num ,"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "Num -"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "Num ."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "Num /"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "Num ="
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "Num Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 #, fuzzy
 msgid "Num Delete"
 msgstr "Ta bort"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 #, fuzzy
 msgid "Num Down"
 msgstr "Ner"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "Num End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "Num Enter"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 #, fuzzy
 msgid "Num Home"
 msgstr "Hem"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 #, fuzzy
 msgid "Num Insert"
 msgstr "Sätt in"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num Lock"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "Num Page Down"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "Num Page Up"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 #, fuzzy
 msgid "Num Right"
 msgstr "Höger"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "Num Space"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "Num Tab"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "Num Up"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "Num left"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num_lock"
 msgstr ""
 
@@ -5340,13 +5478,13 @@ msgstr ""
 msgid "Numbered outline"
 msgstr "Numrerad sammanfattning"
 
-#: ../include/wx/msgdlg.h:278 ../src/richtext/richtextstyledlg.cpp:297
-#: ../src/common/stockitem.cpp:178 ../src/msw/msgdlg.cpp:454
-#: ../src/msw/msgdlg.cpp:747 ../src/gtk1/fontdlg.cpp:138
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:175
+#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/msgdlg.cpp:741 ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "OK"
 
-#: ../src/msw/ole/automtn.cpp:692
+#: ../src/msw/ole/automtn.cpp:683
 #, c-format
 msgid "OLE Automation error in %s: %s"
 msgstr "OLE-automationsfel i %s: %s"
@@ -5355,15 +5493,15 @@ msgstr "OLE-automationsfel i %s: %s"
 msgid "Object Properties"
 msgstr "Objektegenskaper"
 
-#: ../src/msw/ole/automtn.cpp:660
+#: ../src/msw/ole/automtn.cpp:651
 msgid "Object implementation does not support named arguments."
 msgstr "Objektimplementation stöder inte namngivna argument."
 
-#: ../src/common/xtixml.cpp:264
+#: ../src/common/xtixml.cpp:260
 msgid "Objects must have an id attribute"
 msgstr "Objekt måste ha ett id-attribut"
 
-#: ../src/propgrid/advprops.cpp:1601
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Olive"
 msgstr ""
 
@@ -5371,64 +5509,69 @@ msgstr ""
 msgid "Opaci&ty:"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:354
+#: ../src/generic/colrdlgg.cpp:374
 msgid "Opacity:"
 msgstr ""
 
-#: ../src/common/docview.cpp:1773 ../src/common/docview.cpp:1815
+#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
 msgid "Open File"
 msgstr "Öppna Fil"
 
-#: ../src/html/helpwnd.cpp:671 ../src/html/helpwnd.cpp:1554
+#: ../src/html/helpwnd.cpp:669 ../src/html/helpwnd.cpp:1552
 msgid "Open HTML document"
 msgstr "Öppna HTML-dokument"
 
-#: ../src/generic/dbgrptg.cpp:163
+#: ../src/common/stockitem.cpp:265
+#, fuzzy
+msgid "Open an existing document"
+msgstr "Öppna HTML-dokument"
+
+#: ../src/generic/dbgrptg.cpp:160
 #, c-format
 msgid "Open file \"%s\""
 msgstr "Öppna fil \"%s\""
 
-#: ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176
 msgid "Open..."
 msgstr "Öppna..."
 
-#: ../src/unix/glx11.cpp:506 ../src/msw/glcanvas.cpp:592
+#: ../src/msw/glcanvas.cpp:607 ../src/unix/glx11.cpp:513
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr ""
 
-#: ../src/generic/dirctrlg.cpp:599 ../src/generic/dirdlgg.cpp:323
-#: ../src/generic/filectrlg.cpp:642 ../src/generic/filectrlg.cpp:786
+#: ../src/generic/dirctrlg.cpp:565 ../src/generic/filectrlg.cpp:638
+#: ../src/generic/filectrlg.cpp:782 ../src/generic/dirdlgg.cpp:320
 msgid "Operation not permitted."
 msgstr "Operation ej tillåten."
 
-#: ../src/common/cmdline.cpp:900
+#: ../src/common/cmdline.cpp:896
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "Flagga \"%s\" kan inte negeras"
 
-#: ../src/common/cmdline.cpp:1064
+#: ../src/common/cmdline.cpp:1060
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "Flagga \"%s\" kräver ett värde."
 
-#: ../src/common/cmdline.cpp:1147
+#: ../src/common/cmdline.cpp:1143
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Flagga \"%s\": \"%s\" kan inte konverteras till ett datum."
 
-#: ../src/generic/prntdlgg.cpp:618
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Alternativ"
 
-#: ../src/propgrid/advprops.cpp:1606
+#: ../src/propgrid/advprops.cpp:1512
 msgid "Orange"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:615 ../src/generic/prntdlgg.cpp:869
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:862
 msgid "Orientation"
 msgstr "Orientering"
 
-#: ../src/common/windowid.cpp:242
+#: ../src/common/windowid.cpp:237
 msgid "Out of window IDs.  Recommend shutting down application."
 msgstr "Slut på window-ID. Nedstängning av programmet rekommenderas."
 
@@ -5441,148 +5584,148 @@ msgstr "Kontur"
 msgid "Outset"
 msgstr "Utfällning"
 
-#: ../src/msw/ole/automtn.cpp:656
+#: ../src/msw/ole/automtn.cpp:647
 msgid "Overflow while coercing argument values."
 msgstr "Överflöde vid tvingning av argumentvärden."
 
-#: ../src/common/imagpcx.cpp:457 ../src/common/imagpcx.cpp:480
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:479
 msgid "PCX: couldn't allocate memory"
 msgstr "PCX: Kunde inte allokera minne"
 
-#: ../src/common/imagpcx.cpp:456
+#: ../src/common/imagpcx.cpp:455
 msgid "PCX: image format unsupported"
 msgstr "PCX: Bildformatet stöds inte"
 
-#: ../src/common/imagpcx.cpp:479
+#: ../src/common/imagpcx.cpp:478
 msgid "PCX: invalid image"
 msgstr "PCX: Ogiltig bild"
 
-#: ../src/common/imagpcx.cpp:442
+#: ../src/common/imagpcx.cpp:441
 msgid "PCX: this is not a PCX file."
 msgstr "PCX: Detta är inte en PCX fil."
 
-#: ../src/common/imagpcx.cpp:459 ../src/common/imagpcx.cpp:481
+#: ../src/common/imagpcx.cpp:458 ../src/common/imagpcx.cpp:480
 msgid "PCX: unknown error !!!"
 msgstr "PCX: Okänt fel !!!"
 
-#: ../src/common/imagpcx.cpp:458
+#: ../src/common/imagpcx.cpp:457
 msgid "PCX: version number too low"
 msgstr "PCX: För lågt versionsnummer"
 
-#: ../src/common/imagpnm.cpp:91
+#: ../src/common/imagpnm.cpp:89
 msgid "PNM: Couldn't allocate memory."
 msgstr "PNM: Kunde inte allokera minne."
 
-#: ../src/common/imagpnm.cpp:73
+#: ../src/common/imagpnm.cpp:71
 msgid "PNM: File format is not recognized."
 msgstr "PNM: Filformat är okänt."
 
-#: ../src/common/imagpnm.cpp:112 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
 #: ../src/common/imagpnm.cpp:156
 msgid "PNM: File seems truncated."
 msgstr "PNM: Filen tycks vara trunkerad."
 
-#: ../src/common/paper.cpp:187
+#: ../src/common/paper.cpp:184
 msgid "PRC 16K 146 x 215 mm"
 msgstr "PRC 16K 146 x 215 mm"
 
-#: ../src/common/paper.cpp:200
+#: ../src/common/paper.cpp:197
 msgid "PRC 16K Rotated"
 msgstr "PRC 16K Rotated"
 
-#: ../src/common/paper.cpp:188
+#: ../src/common/paper.cpp:185
 msgid "PRC 32K 97 x 151 mm"
 msgstr "PRC 32K 97 x 151 mm"
 
-#: ../src/common/paper.cpp:201
+#: ../src/common/paper.cpp:198
 msgid "PRC 32K Rotated"
 msgstr "PRC 32K roterad"
 
-#: ../src/common/paper.cpp:189
+#: ../src/common/paper.cpp:186
 msgid "PRC 32K(Big) 97 x 151 mm"
 msgstr "PRC 32K(stor) 97 x 151 mm"
 
-#: ../src/common/paper.cpp:202
+#: ../src/common/paper.cpp:199
 msgid "PRC 32K(Big) Rotated"
 msgstr "PRC 32K(stor) roterad"
 
-#: ../src/common/paper.cpp:190
+#: ../src/common/paper.cpp:187
 msgid "PRC Envelope #1 102 x 165 mm"
 msgstr "PRC kuvert #1 102 x 165 mm"
 
-#: ../src/common/paper.cpp:203
+#: ../src/common/paper.cpp:200
 msgid "PRC Envelope #1 Rotated 165 x 102 mm"
 msgstr "PRC kuvert #1 roterat 165 x 102 mm"
 
-#: ../src/common/paper.cpp:199
+#: ../src/common/paper.cpp:196
 msgid "PRC Envelope #10 324 x 458 mm"
 msgstr "PRC kuvert #10 324 x 458 mm"
 
-#: ../src/common/paper.cpp:212
+#: ../src/common/paper.cpp:209
 msgid "PRC Envelope #10 Rotated 458 x 324 mm"
 msgstr "PRC kuvert #10 roterat 458 x 324 mm"
 
-#: ../src/common/paper.cpp:191
+#: ../src/common/paper.cpp:188
 msgid "PRC Envelope #2 102 x 176 mm"
 msgstr "PRC kuvert #2 102 x 176 mm"
 
-#: ../src/common/paper.cpp:204
+#: ../src/common/paper.cpp:201
 msgid "PRC Envelope #2 Rotated 176 x 102 mm"
 msgstr "PRC kuvert #2 roterat 176 x 102 mm"
 
-#: ../src/common/paper.cpp:192
+#: ../src/common/paper.cpp:189
 msgid "PRC Envelope #3 125 x 176 mm"
 msgstr "PRC kuvert #3 125 x 176 mm"
 
-#: ../src/common/paper.cpp:205
+#: ../src/common/paper.cpp:202
 msgid "PRC Envelope #3 Rotated 176 x 125 mm"
 msgstr "PRC kuvert #3 roterat 176 x 125 mm"
 
-#: ../src/common/paper.cpp:193
+#: ../src/common/paper.cpp:190
 msgid "PRC Envelope #4 110 x 208 mm"
 msgstr "PRC kuvert #4 110 x 208 mm"
 
-#: ../src/common/paper.cpp:206
+#: ../src/common/paper.cpp:203
 msgid "PRC Envelope #4 Rotated 208 x 110 mm"
 msgstr "PRC kuvert #4 roterat 208 x 110 mm"
 
-#: ../src/common/paper.cpp:194
+#: ../src/common/paper.cpp:191
 msgid "PRC Envelope #5 110 x 220 mm"
 msgstr "PRC kuvert #5 110 x 220 mm"
 
-#: ../src/common/paper.cpp:207
+#: ../src/common/paper.cpp:204
 msgid "PRC Envelope #5 Rotated 220 x 110 mm"
 msgstr "PRC kuvert #5 roterat 220 x 110 mm"
 
-#: ../src/common/paper.cpp:195
+#: ../src/common/paper.cpp:192
 msgid "PRC Envelope #6 120 x 230 mm"
 msgstr "PRC kuvert #6 120 x 230 mm"
 
-#: ../src/common/paper.cpp:208
+#: ../src/common/paper.cpp:205
 msgid "PRC Envelope #6 Rotated 230 x 120 mm"
 msgstr "PRC kuvert #6 roterat 230 x 120 mm"
 
-#: ../src/common/paper.cpp:196
+#: ../src/common/paper.cpp:193
 msgid "PRC Envelope #7 160 x 230 mm"
 msgstr "PRC kuvert #7 160 x 230 mm"
 
-#: ../src/common/paper.cpp:209
+#: ../src/common/paper.cpp:206
 msgid "PRC Envelope #7 Rotated 230 x 160 mm"
 msgstr "PRC kuvert #7 roterat 230 x 160 mm"
 
-#: ../src/common/paper.cpp:197
+#: ../src/common/paper.cpp:194
 msgid "PRC Envelope #8 120 x 309 mm"
 msgstr "PRC kuvert #8 120 x 309 mm"
 
-#: ../src/common/paper.cpp:210
+#: ../src/common/paper.cpp:207
 msgid "PRC Envelope #8 Rotated 309 x 120 mm"
 msgstr "PRC kuvert #8 roterat 309 x 120 mm"
 
-#: ../src/common/paper.cpp:198
+#: ../src/common/paper.cpp:195
 msgid "PRC Envelope #9 229 x 324 mm"
 msgstr "PRC kuvert #9 229 x 324 mm"
 
-#: ../src/common/paper.cpp:211
+#: ../src/common/paper.cpp:208
 msgid "PRC Envelope #9 Rotated 324 x 229 mm"
 msgstr "PRC kuvert #9 roterat 324 x 229 mm"
 
@@ -5590,91 +5733,95 @@ msgstr "PRC kuvert #9 roterat 324 x 229 mm"
 msgid "Padding"
 msgstr "Utfyllnad"
 
-#: ../src/common/prntbase.cpp:2074
+#: ../src/common/prntbase.cpp:2096
 #, c-format
 msgid "Page %d"
 msgstr "Sida %d"
 
-#: ../src/common/prntbase.cpp:2072
+#: ../src/common/prntbase.cpp:2094
 #, c-format
 msgid "Page %d of %d"
 msgstr "Sida %d av %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 #, fuzzy
 msgid "Page Down"
 msgstr "Sida %d"
 
-#: ../src/gtk/print.cpp:826
+#: ../src/gtk/print.cpp:829
 msgid "Page Setup"
 msgstr "Sidinställningar"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 #, fuzzy
 msgid "Page Up"
 msgstr "Sida %d"
 
-#: ../src/generic/prntdlgg.cpp:828 ../src/common/prntbase.cpp:484
+#: ../src/common/prntbase.cpp:479 ../src/generic/prntdlgg.cpp:821
 msgid "Page setup"
 msgstr "Sidinställning"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 #, fuzzy
 msgid "PageDown"
 msgstr "Ner"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 #, fuzzy
 msgid "PageUp"
 msgstr "Sidor"
 
-#: ../src/generic/prntdlgg.cpp:216
+#: ../src/generic/prntdlgg.cpp:209
 msgid "Pages"
 msgstr "Sidor"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1765
+#: ../src/propgrid/advprops.cpp:1666
 msgid "Paint Brush"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:602 ../src/generic/prntdlgg.cpp:801
-#: ../src/generic/prntdlgg.cpp:842 ../src/generic/prntdlgg.cpp:855
-#: ../src/generic/prntdlgg.cpp:1052 ../src/generic/prntdlgg.cpp:1057
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:794
+#: ../src/generic/prntdlgg.cpp:835 ../src/generic/prntdlgg.cpp:848
+#: ../src/generic/prntdlgg.cpp:1045 ../src/generic/prntdlgg.cpp:1050
 msgid "Paper size"
 msgstr "Pappersstorlek"
 
-#: ../src/richtext/richtextstyles.cpp:1062
+#: ../src/richtext/richtextstyles.cpp:1059
 msgid "Paragraph styles"
 msgstr "Styckestilar"
 
-#: ../src/common/xtistrm.cpp:465
+#: ../src/common/xtistrm.cpp:462
 msgid "Passing a already registered object to SetObject"
 msgstr "Skickade ett redan registrerat objekt till SetObject"
 
-#: ../src/common/xtistrm.cpp:476
+#: ../src/common/xtistrm.cpp:473
 msgid "Passing an unknown object to GetObject"
 msgstr "Skickar ett okänt objekt till GetObject"
 
-#: ../src/richtext/richtextctrl.cpp:3513 ../src/common/stockitem.cpp:180
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:177 ../src/richtext/richtextctrl.cpp:3514
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Klistra in"
 
-#: ../src/common/stockitem.cpp:262
+#: ../src/common/stockitem.cpp:260
 msgid "Paste selection"
 msgstr "Klistra in markerat"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:74
+#: ../src/common/accelcmn.cpp:71
 msgid "Pause"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1766
+#: ../src/propgrid/advprops.cpp:1667
 msgid "Pencil"
 msgstr ""
 
@@ -5683,21 +5830,21 @@ msgstr ""
 msgid "Peri&od"
 msgstr "P&unkt"
 
-#: ../src/generic/filectrlg.cpp:430
+#: ../src/generic/filectrlg.cpp:426
 msgid "Permissions"
 msgstr "Behörigheter"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:60
+#: ../src/common/accelcmn.cpp:57
 msgid "PgDn"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:59
+#: ../src/common/accelcmn.cpp:56
 msgid "PgUp"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:12868
+#: ../src/richtext/richtextbuffer.cpp:12863
 msgid "Picture Properties"
 msgstr "Bildgenskaper"
 
@@ -5709,44 +5856,44 @@ msgstr "Kunde inte skapa rör (pipe)"
 msgid "Please choose a valid font."
 msgstr "Välj ett giltigt typsnitt."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
 msgid "Please choose an existing file."
 msgstr "Välj en existerande fil."
 
-#: ../src/html/helpwnd.cpp:800
+#: ../src/html/helpwnd.cpp:798
 msgid "Please choose the page to display:"
 msgstr "Välj vilken sida som skall visas:"
 
-#: ../src/msw/dialup.cpp:764
+#: ../src/msw/dialup.cpp:758
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Välj vilken Internetleverantör du vill ansluta till"
 
-#: ../src/common/headerctrlcmn.cpp:59
+#: ../src/common/headerctrlcmn.cpp:57
 msgid "Please select the columns to show and define their order:"
 msgstr "Välj kolumner att visa och ange ordning:"
 
-#: ../src/common/prntbase.cpp:538
+#: ../src/common/prntbase.cpp:533
 msgid "Please wait while printing..."
 msgstr "Vänta på utskrift..."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1767
+#: ../src/propgrid/advprops.cpp:1668
 #, fuzzy
 msgid "Point Left"
 msgstr "Punktstorlek"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1768
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgid "Point Right"
 msgstr "Högerjustera"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:662
+#: ../src/propgrid/advprops.cpp:572
 msgid "Point Size"
 msgstr "Punktstorlek"
 
-#: ../src/generic/prntdlgg.cpp:612 ../src/generic/prntdlgg.cpp:867
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:860
 msgid "Portrait"
 msgstr "Stående"
 
@@ -5754,150 +5901,160 @@ msgstr "Stående"
 msgid "Position"
 msgstr "Position"
 
-#: ../src/generic/prntdlgg.cpp:298
+#: ../src/generic/prntdlgg.cpp:291
 msgid "PostScript file"
 msgstr "PostScript-fil"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178 ../src/osx/cocoa/preferences.mm:303
 msgid "Preferences"
 msgstr "Inställningar"
 
-#: ../src/osx/menu_osx.cpp:568
+#: ../src/osx/menu_osx.cpp:460
 msgid "Preferences..."
 msgstr "Inställningar..."
 
-#: ../src/common/prntbase.cpp:546
+#: ../src/common/prntbase.cpp:541
 msgid "Preparing"
 msgstr "Förbereder"
 
-#: ../src/generic/fontdlgg.cpp:455 ../src/osx/carbon/fontdlg.cpp:390
-#: ../src/html/helpwnd.cpp:1222
+#: ../src/osx/carbon/fontdlg.cpp:387 ../src/generic/fontdlgg.cpp:452
+#: ../src/html/helpwnd.cpp:1220
 msgid "Preview:"
 msgstr "Förhandsgranska:"
 
-#: ../src/common/prntbase.cpp:1553 ../src/html/helpwnd.cpp:664
+#: ../src/common/prntbase.cpp:1578 ../src/html/helpwnd.cpp:662
 msgid "Previous page"
 msgstr "Föregående sida"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/prntdlgg.cpp:143 ../src/generic/prntdlgg.cpp:157
-#: ../src/common/prntbase.cpp:426 ../src/common/prntbase.cpp:1541
-#: ../src/common/accelcmn.cpp:77 ../src/gtk/print.cpp:620
-#: ../src/gtk/print.cpp:638
+#: ../src/common/prntbase.cpp:421 ../src/common/prntbase.cpp:1566
+#: ../src/common/accelcmn.cpp:74 ../src/generic/prntdlgg.cpp:136
+#: ../src/generic/prntdlgg.cpp:150 ../src/gtk/print.cpp:616
+#: ../src/gtk/print.cpp:634
 msgid "Print"
 msgstr "Skriv ut"
 
-#: ../include/wx/prntbase.h:399 ../src/common/docview.cpp:1268
+#: ../src/common/docview.cpp:1262
 msgid "Print Preview"
 msgstr "Förhandsgranska"
 
-#: ../src/common/prntbase.cpp:2015 ../src/common/prntbase.cpp:2057
-#: ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2037 ../src/common/prntbase.cpp:2079
+#: ../src/common/prntbase.cpp:2087
 msgid "Print Preview Failure"
 msgstr "Förhandsgranskning misslyckades"
 
-#: ../src/generic/prntdlgg.cpp:224
+#: ../src/generic/prntdlgg.cpp:217
 msgid "Print Range"
 msgstr "Sidintervall"
 
-#: ../src/generic/prntdlgg.cpp:449
+#: ../src/generic/prntdlgg.cpp:442
 msgid "Print Setup"
 msgstr "Utskriftsinställningar"
 
-#: ../src/generic/prntdlgg.cpp:621
+#: ../src/generic/prntdlgg.cpp:614
 msgid "Print in colour"
 msgstr "Skriv ut med färg"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/osx/webview_webkit.mm:260
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "Kolumnbeskrivning kunde inte initieras."
+
+#: ../src/common/stockitem.cpp:179
 msgid "Print previe&w..."
 msgstr "För&handsgranska..."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1256
 msgid "Print preview creation failed."
 msgstr "Förhandsgranskning kunde inte skapas."
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/common/stockitem.cpp:179
 msgid "Print preview..."
 msgstr "Förhandsgranska..."
 
-#: ../src/generic/prntdlgg.cpp:630
+#: ../src/generic/prntdlgg.cpp:623
 msgid "Print spooling"
 msgstr "Utskrift-spooling"
 
-#: ../src/html/helpwnd.cpp:675
+#: ../src/html/helpwnd.cpp:673
 msgid "Print this page"
 msgstr "Skriv ut denna sida"
 
-#: ../src/generic/prntdlgg.cpp:185
+#: ../src/generic/prntdlgg.cpp:178
 msgid "Print to File"
 msgstr "Skriv ut till fil"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "Print..."
 msgstr "Skriv ut..."
 
-#: ../src/generic/prntdlgg.cpp:493
+#: ../src/generic/prntdlgg.cpp:486
 msgid "Printer"
 msgstr "Skrivare"
 
-#: ../src/generic/prntdlgg.cpp:633
+#: ../src/generic/prntdlgg.cpp:626
 msgid "Printer command:"
 msgstr "Skrivarkommando:"
 
-#: ../src/generic/prntdlgg.cpp:180
+#: ../src/generic/prntdlgg.cpp:173
 msgid "Printer options"
 msgstr "Skrivaralternativ"
 
-#: ../src/generic/prntdlgg.cpp:645
+#: ../src/generic/prntdlgg.cpp:638
 msgid "Printer options:"
 msgstr "Skrivaralternativ:"
 
-#: ../src/generic/prntdlgg.cpp:916
+#: ../src/generic/prntdlgg.cpp:909
 msgid "Printer..."
 msgstr "Skrivare..."
 
-#: ../src/generic/prntdlgg.cpp:196
+#: ../src/generic/prntdlgg.cpp:189
 msgid "Printer:"
 msgstr "Skrivare:"
 
-#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:535
-#: ../src/html/htmprint.cpp:277
+#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:530
+#: ../src/html/htmprint.cpp:289
 msgid "Printing"
 msgstr "Skriver ut "
 
-#: ../src/common/prntbase.cpp:612
+#: ../src/common/prntbase.cpp:607
 msgid "Printing "
 msgstr "Skriver ut "
 
-#: ../src/common/prntbase.cpp:347
+#: ../src/common/prntbase.cpp:342
 msgid "Printing Error"
 msgstr "Utskriftsfel"
 
-#: ../src/common/prntbase.cpp:565
+#: ../src/osx/webview_webkit.mm:251
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "Gzip stöds inte av den här versionen av zlib"
+
+#: ../src/common/prntbase.cpp:560
 #, fuzzy, c-format
 msgid "Printing page %d"
 msgstr "Skriver sida %d..."
 
-#: ../src/common/prntbase.cpp:570
+#: ../src/common/prntbase.cpp:565
 #, c-format
 msgid "Printing page %d of %d"
 msgstr "Skriver sida %d av %d"
 
-#: ../src/generic/printps.cpp:201
+#: ../src/generic/printps.cpp:182
 #, c-format
 msgid "Printing page %d..."
 msgstr "Skriver sida %d..."
 
-#: ../src/generic/printps.cpp:161
+#: ../src/generic/printps.cpp:142
 msgid "Printing..."
 msgstr "Skriver ut..."
 
-#: ../include/wx/richtext/richtextprint.h:109 ../include/wx/prntbase.h:267
-#: ../src/common/docview.cpp:2132
+#: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
+#: ../src/common/docview.cpp:2137
 msgid "Printout"
 msgstr "Utskrift"
 
-#: ../src/common/debugrpt.cpp:560
+#: ../src/common/debugrpt.cpp:561
 #, c-format
 msgid ""
 "Processing debug report has failed, leaving the files in \"%s\" directory."
@@ -5905,104 +6062,104 @@ msgstr ""
 "Behandling av debugrapport har misslyckats, lämnar filerna i katalogen \"%s"
 "\"."
 
-#: ../src/common/prntbase.cpp:545
+#: ../src/common/prntbase.cpp:540
 msgid "Progress:"
 msgstr "Förlopp:"
 
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181
 msgid "Properties"
 msgstr "Egenskaper"
 
-#: ../src/propgrid/manager.cpp:237
+#: ../src/propgrid/manager.cpp:223
 msgid "Property"
 msgstr "Egenskap"
 
 #. TRANSLATORS: Caption of message box displaying any property error
-#: ../src/propgrid/propgrid.cpp:3185 ../src/propgrid/propgrid.cpp:3318
+#: ../src/propgrid/propgrid.cpp:3162 ../src/propgrid/propgrid.cpp:3299
 msgid "Property Error"
 msgstr "Egenskapsfel"
 
-#: ../src/propgrid/advprops.cpp:1597
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Purple"
 msgstr ""
 
-#: ../src/common/paper.cpp:112
+#: ../src/common/paper.cpp:109
 msgid "Quarto, 215 x 275 mm"
 msgstr "Quarto, 215 x 275 mm"
 
-#: ../src/generic/logg.cpp:1016
+#: ../src/generic/logg.cpp:1013
 msgid "Question"
 msgstr "Fråga"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1769
+#: ../src/propgrid/advprops.cpp:1670
 #, fuzzy
 msgid "Question Arrow"
 msgstr "Fråga"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "Quit"
 msgstr "Avsluta"
 
-#: ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:477
 #, c-format
 msgid "Quit %s"
 msgstr "Avsluta %s"
 
-#: ../src/common/stockitem.cpp:263
+#: ../src/common/stockitem.cpp:261
 msgid "Quit this program"
 msgstr "Avsluta programmet"
 
-#: ../src/common/accelcmn.cpp:338
+#: ../src/common/accelcmn.cpp:352
 msgid "RawCtrl+"
 msgstr "ObehandladCtrl+"
 
-#: ../src/common/ffile.cpp:109 ../src/common/ffile.cpp:133
+#: ../src/common/ffile.cpp:107 ../src/common/ffile.cpp:132
 #, c-format
 msgid "Read error on file '%s'"
 msgstr "Läsfel på fil \"%s\""
 
-#: ../src/common/secretstore.cpp:199
+#: ../src/common/secretstore.cpp:211
 #, fuzzy, c-format
-msgid "Reading password for \"%s/%s\" failed: %s."
+msgid "Reading password for \"%s\" failed: %s."
 msgstr "Uppackning av \"%s\" till \"%s\" misslyckades."
 
-#: ../src/common/prntbase.cpp:272
+#: ../src/common/prntbase.cpp:267
 msgid "Ready"
 msgstr "Redo"
 
-#: ../src/propgrid/advprops.cpp:1605
+#: ../src/propgrid/advprops.cpp:1511
 #, fuzzy
 msgid "Red"
 msgstr "Gör om"
 
-#: ../src/generic/colrdlgg.cpp:339
+#: ../src/generic/colrdlgg.cpp:359
 msgid "Red:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:185 ../src/stc/stc_i18n.cpp:16
+#: ../src/common/stockitem.cpp:182 ../src/stc/stc_i18n.cpp:16
 msgid "Redo"
 msgstr "Gör om"
 
-#: ../src/common/stockitem.cpp:264
+#: ../src/common/stockitem.cpp:262
 msgid "Redo last action"
 msgstr "Gör om senaste händelse"
 
-#: ../src/common/stockitem.cpp:186
+#: ../src/common/stockitem.cpp:183
 msgid "Refresh"
 msgstr "Uppdatera"
 
-#: ../src/msw/registry.cpp:626
+#: ../src/msw/registry.cpp:615
 #, c-format
 msgid "Registry key '%s' already exists."
 msgstr "Registernyckel \"%s\" finns redan."
 
-#: ../src/msw/registry.cpp:595
+#: ../src/msw/registry.cpp:584
 #, c-format
 msgid "Registry key '%s' does not exist, cannot rename it."
 msgstr "Registernyckel \"%s\" finns inte, kan inte döpa om den."
 
-#: ../src/msw/registry.cpp:727
+#: ../src/msw/registry.cpp:716
 #, c-format
 msgid ""
 "Registry key '%s' is needed for normal system operation,\n"
@@ -6013,22 +6170,22 @@ msgstr ""
 "om du tar bort den kommer systemet bli instabilt:\n"
 "Operationen avbruten."
 
-#: ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:942
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:917
+#: ../src/msw/registry.cpp:905
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1003
+#: ../src/msw/registry.cpp:991
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:521
+#: ../src/msw/registry.cpp:510
 #, c-format
 msgid "Registry value '%s' already exists."
 msgstr "Registervärde \"%s\" finns redan."
@@ -6042,71 +6199,77 @@ msgstr "Vanlig"
 msgid "Relative"
 msgstr "Relativt"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:456
 msgid "Relevant entries:"
 msgstr "Relevanta poster:"
 
-#: ../include/wx/generic/progdlgg.h:86
+#: ../include/wx/generic/progdlgg.h:87
 msgid "Remaining time:"
 msgstr "Återstående tid: "
 
-#: ../src/common/stockitem.cpp:187
+#: ../src/common/stockitem.cpp:184
 msgid "Remove"
 msgstr "Ta bort"
 
-#: ../src/richtext/richtextctrl.cpp:1562
+#: ../src/richtext/richtextctrl.cpp:1563
 msgid "Remove Bullet"
 msgstr "Ta bort listpunkttecken"
 
-#: ../src/html/helpwnd.cpp:433
+#: ../src/html/helpwnd.cpp:431
 msgid "Remove current page from bookmarks"
 msgstr "Ta bort aktuell sida från bokmärken"
 
-#: ../src/common/rendcmn.cpp:194
+#: ../src/common/rendcmn.cpp:191
 #, c-format
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 "Rendrerare \"%s\" har inkompatibel version %d.%d och kunde inte läsas in."
 
-#: ../src/richtext/richtextbuffer.cpp:4527
+#: ../src/richtext/richtextbuffer.cpp:4524
 msgid "Renumber List"
 msgstr "Omnumrera lista"
 
-#: ../src/common/stockitem.cpp:188
-msgid "Rep&lace"
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Rep&lace..."
 msgstr "&Ersätt"
 
-#: ../src/richtext/richtextctrl.cpp:3673 ../src/common/stockitem.cpp:188
+#: ../src/richtext/richtextctrl.cpp:3674
 msgid "Replace"
 msgstr "Ersätt"
 
-#: ../src/generic/fdrepdlg.cpp:182
+#: ../src/generic/fdrepdlg.cpp:179
 msgid "Replace &all"
 msgstr "Ersätt &alla"
 
-#: ../src/common/stockitem.cpp:261
-msgid "Replace selection"
-msgstr "Ersätt markerat"
-
-#: ../src/generic/fdrepdlg.cpp:124
+#: ../src/generic/fdrepdlg.cpp:121
 msgid "Replace with:"
 msgstr "Ersätt med:"
 
-#: ../src/common/valtext.cpp:163
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Replace..."
+msgstr "Ersätt"
+
+#: ../src/common/valtext.cpp:184
 msgid "Required information entry is empty."
 msgstr "Nödvändigt informationsfält är tomt."
 
-#: ../src/common/translation.cpp:1975
+#: ../src/common/translation.cpp:2025
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "Resursen \"%s\" är inte en giltig meddelandekatalog."
 
+#: ../src/gtk/webview_webkit.cpp:985
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:56
+#: ../src/common/accelcmn.cpp:53
 msgid "Return"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:189
+#: ../src/common/stockitem.cpp:186
 msgid "Revert to Saved"
 msgstr "Återgå till sparad"
 
@@ -6118,42 +6281,42 @@ msgstr "Upphöjd"
 msgid "Rig&ht-to-left"
 msgstr ""
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6149
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:59 ../src/generic/datavgen.cpp:6954
+#: ../src/richtext/richtextsizepage.cpp:250
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextbulletspage.cpp:188
-#: ../src/richtext/richtextsizepage.cpp:250 ../src/common/accelcmn.cpp:62
 msgid "Right"
 msgstr "Höger"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1754
+#: ../src/propgrid/advprops.cpp:1655
 #, fuzzy
 msgid "Right Arrow"
 msgstr "Höger"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1770
+#: ../src/propgrid/advprops.cpp:1671
 msgid "Right Button"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:892
+#: ../src/generic/prntdlgg.cpp:885
 msgid "Right margin (mm):"
 msgstr "Höger marginal (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:148
-#: ../src/richtext/richtextindentspage.cpp:150
 #: ../src/richtext/richtextliststylepage.cpp:337
 #: ../src/richtext/richtextliststylepage.cpp:339
+#: ../src/richtext/richtextindentspage.cpp:148
+#: ../src/richtext/richtextindentspage.cpp:150
 msgid "Right-align text."
 msgstr "Högerjustera text."
 
-#: ../src/generic/fontdlgg.cpp:322
+#: ../src/generic/fontdlgg.cpp:318
 msgid "Roman"
 msgstr "Roman"
 
-#: ../src/generic/datavgen.cpp:5916
+#: ../src/generic/datavgen.cpp:6721
 #, c-format
 msgid "Row %i"
 msgstr ""
@@ -6163,30 +6326,31 @@ msgstr ""
 msgid "S&tandard bullet name:"
 msgstr "S&tandard punktlisttecken:"
 
-#: ../src/common/accelcmn.cpp:268 ../src/common/accelcmn.cpp:350
+#: ../src/common/accelcmn.cpp:282 ../src/common/accelcmn.cpp:367
 msgid "SPECIAL"
 msgstr "SPECIAL"
 
-#: ../src/common/stockitem.cpp:190 ../src/common/sizer.cpp:2797
+#: ../src/common/stockitem.cpp:187 ../src/common/sizer.cpp:2914
 msgid "Save"
 msgstr "Spara"
 
-#: ../src/common/fldlgcmn.cpp:342
+#: ../src/common/fldlgcmn.cpp:339
 #, c-format
 msgid "Save %s file"
 msgstr "Spara %s fil"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/common/stockitem.cpp:188 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Spara so&m..."
 
-#: ../src/common/docview.cpp:366
+#: ../src/common/docview.cpp:359
 msgid "Save As"
 msgstr "Spara som"
 
-#: ../src/common/stockitem.cpp:191
-msgid "Save as"
-msgstr "Spara som"
+#: ../src/common/stockitem.cpp:188
+#, fuzzy
+msgid "Save As..."
+msgstr "Spara so&m..."
 
 #: ../src/common/stockitem.cpp:267
 msgid "Save current document"
@@ -6196,40 +6360,40 @@ msgstr "Spara aktuellt dokument"
 msgid "Save current document with a different filename"
 msgstr "Spara aktuellt dokument med ett annat filnamn"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/generic/logg.cpp:509
 msgid "Save log contents to file"
 msgstr "Spara logginnehållet till fil"
 
-#: ../src/common/secretstore.cpp:179
+#: ../src/common/secretstore.cpp:189
 #, fuzzy, c-format
-msgid "Saving password for \"%s/%s\" failed: %s."
+msgid "Saving password for \"%s\" failed: %s."
 msgstr "Uppackning av \"%s\" till \"%s\" misslyckades."
 
-#: ../src/generic/fontdlgg.cpp:325
+#: ../src/generic/fontdlgg.cpp:321
 msgid "Script"
 msgstr "Skrivstil"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll Lock"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll_lock"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:890
+#: ../src/propgrid/advprops.cpp:791
 msgid "Scrollbar"
 msgstr ""
 
-#: ../src/generic/srchctlg.cpp:56 ../src/html/helpwnd.cpp:535
-#: ../src/html/helpwnd.cpp:550
+#: ../src/generic/srchctlg.cpp:55 ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:548 ../src/gtk/srchctrl.cpp:182
 msgid "Search"
 msgstr "Sök"
 
-#: ../src/html/helpwnd.cpp:537
+#: ../src/html/helpwnd.cpp:535
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
@@ -6237,56 +6401,56 @@ msgstr ""
 "Sök i hjälpboken/böckernas innehåll efter alla förekomster av texten du "
 "skrev in ovan"
 
-#: ../src/generic/fdrepdlg.cpp:160
+#: ../src/generic/fdrepdlg.cpp:157
 msgid "Search direction"
 msgstr "Sökriktning"
 
-#: ../src/generic/fdrepdlg.cpp:112
+#: ../src/generic/fdrepdlg.cpp:109
 msgid "Search for:"
 msgstr "Sök efter:"
 
-#: ../src/html/helpwnd.cpp:1052
+#: ../src/html/helpwnd.cpp:1050
 msgid "Search in all books"
 msgstr "Sök i alla böcker"
 
-#: ../src/html/helpwnd.cpp:857
+#: ../src/html/helpwnd.cpp:855
 msgid "Searching..."
 msgstr "Söker..."
 
-#: ../src/generic/dirctrlg.cpp:446
+#: ../src/generic/dirctrlg.cpp:412
 msgid "Sections"
 msgstr "Avdelningar"
 
-#: ../src/common/ffile.cpp:238
+#: ../src/common/ffile.cpp:237
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Sökfel på fil \"%s\""
 
-#: ../src/common/ffile.cpp:228
+#: ../src/common/ffile.cpp:227
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr "Sökfel på fil \"%s\" (stora filer stöds inte av stdio)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:76
+#: ../src/common/accelcmn.cpp:73
 #, fuzzy
 msgid "Select"
 msgstr "Markering"
 
-#: ../src/richtext/richtextctrl.cpp:337 ../src/osx/textctrl_osx.cpp:581
-#: ../src/common/stockitem.cpp:192 ../src/msw/textctrl.cpp:2512
+#: ../src/osx/textctrl_osx.cpp:599 ../src/common/stockitem.cpp:189
+#: ../src/msw/textctrl.cpp:2777 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Markera &allt"
 
-#: ../src/common/stockitem.cpp:192 ../src/stc/stc_i18n.cpp:21
+#: ../src/common/stockitem.cpp:189 ../src/stc/stc_i18n.cpp:21
 msgid "Select All"
 msgstr "Markera allt"
 
-#: ../src/common/docview.cpp:1895
+#: ../src/common/docview.cpp:1900
 msgid "Select a document template"
 msgstr "Välj en dokumentmall"
 
-#: ../src/common/docview.cpp:1969
+#: ../src/common/docview.cpp:1974
 msgid "Select a document view"
 msgstr "Välj en dokumentvy"
 
@@ -6315,20 +6479,20 @@ msgid "Selects the list level to edit."
 msgstr "Välj listnivå att redigera."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:82
+#: ../src/common/accelcmn.cpp:79
 msgid "Separator"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1083
+#: ../src/common/cmdline.cpp:1079
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Avgränsare förväntad efter flaggan \"%s\"."
 
-#: ../src/osx/menu_osx.cpp:572
+#: ../src/osx/menu_osx.cpp:464
 msgid "Services"
 msgstr "Tjänster"
 
-#: ../src/richtext/richtextbuffer.cpp:11217
+#: ../src/richtext/richtextbuffer.cpp:11216
 msgid "Set Cell Style"
 msgstr "Ange cellstil"
 
@@ -6336,11 +6500,11 @@ msgstr "Ange cellstil"
 msgid "SetProperty called w/o valid setter"
 msgstr "SetProperty anropat utan giltigt tilldelningsobjekt"
 
-#: ../src/generic/prntdlgg.cpp:188
+#: ../src/generic/prntdlgg.cpp:181
 msgid "Setup..."
 msgstr "Inställningar..."
 
-#: ../src/msw/dialup.cpp:544
+#: ../src/msw/dialup.cpp:538
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr "Flera aktiva uppringningsanslutningar hittades, väljer en slumpvis."
 
@@ -6357,40 +6521,40 @@ msgstr ""
 msgid "Shadow c&olour:"
 msgstr "Välj färg"
 
-#: ../src/common/accelcmn.cpp:335
+#: ../src/common/accelcmn.cpp:349
 msgid "Shift+"
 msgstr "Skift+"
 
-#: ../src/generic/dirdlgg.cpp:147
+#: ../src/generic/dirdlgg.cpp:144
 msgid "Show &hidden directories"
 msgstr "Visa &dolda kataloger"
 
-#: ../src/generic/filectrlg.cpp:983
+#: ../src/generic/filectrlg.cpp:979
 msgid "Show &hidden files"
 msgstr "Visa &dolda filer"
 
-#: ../src/osx/menu_osx.cpp:580
+#: ../src/osx/menu_osx.cpp:472
 msgid "Show All"
 msgstr "Visa alla"
 
-#: ../src/common/stockitem.cpp:257
+#: ../src/common/stockitem.cpp:254
 msgid "Show about dialog"
 msgstr "Visa om-dialogruta"
 
-#: ../src/html/helpwnd.cpp:492
+#: ../src/html/helpwnd.cpp:490
 msgid "Show all"
 msgstr "Visa alla"
 
-#: ../src/html/helpwnd.cpp:503
+#: ../src/html/helpwnd.cpp:501
 msgid "Show all items in index"
 msgstr "Visa alla poster i index"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:656
 msgid "Show/hide navigation panel"
 msgstr "Visa/dölj navigeringspanel"
 
-#: ../src/richtext/richtextsymboldlg.cpp:421
-#: ../src/richtext/richtextsymboldlg.cpp:423
+#: ../src/richtext/richtextsymboldlg.cpp:418
+#: ../src/richtext/richtextsymboldlg.cpp:420
 msgid "Shows a Unicode subset."
 msgstr "Visar en Unicode-delmängd"
 
@@ -6406,7 +6570,7 @@ msgstr "Visar en förhandsgranskning av punktlistinställningar."
 msgid "Shows a preview of the font settings."
 msgstr "Visar en förhandsgranskning av typsnittsinställningar."
 
-#: ../src/osx/carbon/fontdlg.cpp:394 ../src/osx/carbon/fontdlg.cpp:396
+#: ../src/osx/carbon/fontdlg.cpp:391 ../src/osx/carbon/fontdlg.cpp:393
 msgid "Shows a preview of the font."
 msgstr "Visar förhandsgranskning av typsnittet."
 
@@ -6415,62 +6579,62 @@ msgstr "Visar förhandsgranskning av typsnittet."
 msgid "Shows a preview of the paragraph settings."
 msgstr "Visar förhandsgranskning av styckeinställningarna."
 
-#: ../src/generic/fontdlgg.cpp:460 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:456 ../src/generic/fontdlgg.cpp:458
 msgid "Shows the font preview."
 msgstr "Visar typsnittsgranskningen."
 
-#: ../src/propgrid/advprops.cpp:1607
+#: ../src/propgrid/advprops.cpp:1513
 msgid "Silver"
 msgstr ""
 
-#: ../src/univ/themes/mono.cpp:516
+#: ../src/univ/themes/mono.cpp:513
 msgid "Simple monochrome theme"
 msgstr "Enkelt svart-vitt tema"
 
-#: ../src/richtext/richtextindentspage.cpp:275
 #: ../src/richtext/richtextliststylepage.cpp:449
+#: ../src/richtext/richtextindentspage.cpp:275
 msgid "Single"
 msgstr "Enkel"
 
-#: ../src/generic/filectrlg.cpp:425 ../src/richtext/richtextformatdlg.cpp:369
-#: ../src/richtext/richtextsizepage.cpp:299
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextsizepage.cpp:299
+#: ../src/richtext/richtextformatdlg.cpp:362
 msgid "Size"
 msgstr "Storlek"
 
-#: ../src/osx/carbon/fontdlg.cpp:339
+#: ../src/osx/carbon/fontdlg.cpp:336
 msgid "Size:"
 msgstr "Storlek:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1775
+#: ../src/propgrid/advprops.cpp:1676
 msgid "Sizing"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1772
+#: ../src/propgrid/advprops.cpp:1673
 msgid "Sizing N-S"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1771
+#: ../src/propgrid/advprops.cpp:1672
 msgid "Sizing NE-SW"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1773
+#: ../src/propgrid/advprops.cpp:1674
 msgid "Sizing NW-SE"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1774
+#: ../src/propgrid/advprops.cpp:1675
 msgid "Sizing W-E"
 msgstr ""
 
-#: ../src/msw/progdlg.cpp:801
+#: ../src/msw/progdlg.cpp:1088
 msgid "Skip"
 msgstr "Hoppa över"
 
-#: ../src/generic/fontdlgg.cpp:330
+#: ../src/generic/fontdlgg.cpp:326
 msgid "Slant"
 msgstr "Lutande"
 
@@ -6479,7 +6643,7 @@ msgid "Small C&apitals"
 msgstr "Kapi&täler"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:79
+#: ../src/common/accelcmn.cpp:76
 msgid "Snapshot"
 msgstr ""
 
@@ -6487,37 +6651,37 @@ msgstr ""
 msgid "Solid"
 msgstr "Solid"
 
-#: ../src/common/docview.cpp:1791
+#: ../src/common/docview.cpp:1785
 msgid "Sorry, could not open this file."
 msgstr "Kunde inte öppna denna fil."
 
-#: ../src/common/prntbase.cpp:2057 ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2079 ../src/common/prntbase.cpp:2087
 msgid "Sorry, not enough memory to create a preview."
 msgstr "Inte tillräckligt med minne för att skapa förhandsgranskning."
 
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "Sorry, that name is taken. Please choose another."
 msgstr "Namnet är upptaget. Välj ett annat."
 
-#: ../src/common/docview.cpp:1814
+#: ../src/common/docview.cpp:1819
 msgid "Sorry, the format for this file is unknown."
 msgstr "Filformatet för denna fil är okänt."
 
-#: ../src/unix/sound.cpp:492
+#: ../src/unix/sound.cpp:481
 msgid "Sound data are in unsupported format."
 msgstr "Formatet på ljuddata stöds inte."
 
-#: ../src/unix/sound.cpp:477
+#: ../src/unix/sound.cpp:466
 #, c-format
 msgid "Sound file '%s' is in unsupported format."
 msgstr "Formatet på ljudfilen \"%s\" stöds inte."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:67
+#: ../src/common/accelcmn.cpp:64
 #, fuzzy
 msgid "Space"
 msgstr "Avstånd"
@@ -6526,12 +6690,12 @@ msgstr "Avstånd"
 msgid "Spacing"
 msgstr "Avstånd"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "Spell Check"
 msgstr "Stavningskontroll"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1776
+#: ../src/propgrid/advprops.cpp:1677
 msgid "Spraycan"
 msgstr ""
 
@@ -6540,7 +6704,7 @@ msgstr ""
 msgid "Standard"
 msgstr "Standard"
 
-#: ../src/common/paper.cpp:104
+#: ../src/common/paper.cpp:101
 msgid "Statement, 5 1/2 x 8 1/2 in"
 msgstr "Statement, 5 1/2 x 8 1/2 tum"
 
@@ -6549,33 +6713,29 @@ msgstr "Statement, 5 1/2 x 8 1/2 tum"
 msgid "Static"
 msgstr "Statiskt"
 
-#: ../src/generic/prntdlgg.cpp:204
+#: ../src/generic/prntdlgg.cpp:197
 msgid "Status:"
 msgstr "Status:"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "Stop"
 msgstr "Stopp"
 
-#: ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196
 msgid "Strikethrough"
 msgstr "Genomstruken"
 
-#: ../src/common/colourcmn.cpp:45
+#: ../src/common/colourcmn.cpp:42
 #, c-format
 msgid "String To Colour : Incorrect colour specification : %s"
 msgstr "Sträng till färg: Felaktig färgspecifikation: %s"
 
 #. TRANSLATORS: Label of font style
-#: ../src/richtext/richtextformatdlg.cpp:339 ../src/propgrid/advprops.cpp:680
+#: ../src/propgrid/advprops.cpp:590 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Stil"
 
-#: ../include/wx/richtext/richtextstyledlg.h:46
-msgid "Style Organiser"
-msgstr "Stilorganiserare"
-
-#: ../src/osx/carbon/fontdlg.cpp:348
+#: ../src/osx/carbon/fontdlg.cpp:345
 msgid "Style:"
 msgstr "Stil:"
 
@@ -6584,7 +6744,7 @@ msgid "Subscrip&t"
 msgstr "&Nedsänkt"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:83
+#: ../src/common/accelcmn.cpp:80
 msgid "Subtract"
 msgstr ""
 
@@ -6592,11 +6752,11 @@ msgstr ""
 msgid "Supe&rscript"
 msgstr "&Upphöjt"
 
-#: ../src/common/paper.cpp:150
+#: ../src/common/paper.cpp:147
 msgid "SuperA/SuperA/A4 227 x 356 mm"
 msgstr "SuperA/SuperA/A4 227 x 356 mm"
 
-#: ../src/common/paper.cpp:151
+#: ../src/common/paper.cpp:148
 msgid "SuperB/SuperB/A3 305 x 487 mm"
 msgstr "SuperB/SuperB/A3 305 x 487 mm"
 
@@ -6604,7 +6764,7 @@ msgstr "SuperB/SuperB/A3 305 x 487 mm"
 msgid "Suppress hyphe&nation"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:326
+#: ../src/generic/fontdlgg.cpp:322
 msgid "Swiss"
 msgstr "Swiss"
 
@@ -6622,74 +6782,74 @@ msgstr "Symbol&typsnitt:"
 msgid "Symbols"
 msgstr "Symboler"
 
-#: ../src/common/imagtiff.cpp:369 ../src/common/imagtiff.cpp:382
-#: ../src/common/imagtiff.cpp:741
+#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
+#: ../src/common/imagtiff.cpp:738
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: Kunde inte allokera minne."
 
-#: ../src/common/imagtiff.cpp:301
+#: ../src/common/imagtiff.cpp:298
 msgid "TIFF: Error loading image."
 msgstr "TIFF: Fel vid inläsning av bild."
 
-#: ../src/common/imagtiff.cpp:468
+#: ../src/common/imagtiff.cpp:465
 msgid "TIFF: Error reading image."
 msgstr "TIFF: Fel vid läsning av bild."
 
-#: ../src/common/imagtiff.cpp:608
+#: ../src/common/imagtiff.cpp:605
 msgid "TIFF: Error saving image."
 msgstr "TIFF: Fel vid sparande av bild."
 
-#: ../src/common/imagtiff.cpp:846
+#: ../src/common/imagtiff.cpp:843
 msgid "TIFF: Error writing image."
 msgstr "TIFF: Fel vid skrivande till bild."
 
-#: ../src/common/imagtiff.cpp:355
+#: ../src/common/imagtiff.cpp:352
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: Bildstorlek är onormalt stor."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:68
+#: ../src/common/accelcmn.cpp:65
 #, fuzzy
 msgid "Tab"
 msgstr "Tabbar"
 
-#: ../src/richtext/richtextbuffer.cpp:11498
+#: ../src/richtext/richtextbuffer.cpp:11497
 msgid "Table Properties"
 msgstr "Tabellegenskaper"
 
-#: ../src/common/paper.cpp:145
+#: ../src/common/paper.cpp:142
 msgid "Tabloid Extra 11.69 x 18 in"
 msgstr "Tabloid extra 11,69 x 18 tum"
 
-#: ../src/common/paper.cpp:102
+#: ../src/common/paper.cpp:99
 msgid "Tabloid, 11 x 17 in"
 msgstr "Tabloid, 11 x 17 tum"
 
-#: ../src/richtext/richtextformatdlg.cpp:354
+#: ../src/richtext/richtextformatdlg.cpp:347
 msgid "Tabs"
 msgstr "Tabbar"
 
-#: ../src/propgrid/advprops.cpp:1598
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Teal"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:327
+#: ../src/generic/fontdlgg.cpp:323
 msgid "Teletype"
 msgstr "Teletyp"
 
-#: ../src/common/docview.cpp:1896
+#: ../src/common/docview.cpp:1901
 msgid "Templates"
 msgstr "Mallar"
 
-#: ../src/common/fmapbase.cpp:158
+#: ../src/common/fmapbase.cpp:155
 msgid "Thai (ISO-8859-11)"
 msgstr "Thailändsk (ISO-8859-11)"
 
-#: ../src/common/ftp.cpp:619
+#: ../src/common/ftp.cpp:622
 msgid "The FTP server doesn't support passive mode."
 msgstr "FTP-servern stöder inte passivt läge."
 
-#: ../src/common/ftp.cpp:605
+#: ../src/common/ftp.cpp:608
 msgid "The FTP server doesn't support the PORT command."
 msgstr "FTP-servern stöder inte PORT-kommandot."
 
@@ -6700,8 +6860,8 @@ msgstr "FTP-servern stöder inte PORT-kommandot."
 msgid "The available bullet styles."
 msgstr "Tillgängliga punktliststilar."
 
-#: ../src/richtext/richtextstyledlg.cpp:202
-#: ../src/richtext/richtextstyledlg.cpp:204
+#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:200
 msgid "The available styles."
 msgstr "Tillgängliga stilar."
 
@@ -6757,12 +6917,12 @@ msgstr "Undre position."
 msgid "The bullet character."
 msgstr "Punktlisttecknet."
 
-#: ../src/richtext/richtextsymboldlg.cpp:443
-#: ../src/richtext/richtextsymboldlg.cpp:445
+#: ../src/richtext/richtextsymboldlg.cpp:440
+#: ../src/richtext/richtextsymboldlg.cpp:442
 msgid "The character code."
 msgstr "Teckenkoden."
 
-#: ../src/common/fontmap.cpp:203
+#: ../src/common/fontmap.cpp:200
 #, c-format
 msgid ""
 "The charset '%s' is unknown. You may select\n"
@@ -6773,7 +6933,7 @@ msgstr ""
 "en annan teckenuppsättning som ersättning eller välja\n"
 "[Avbryt] om den inte kan ersättas"
 
-#: ../src/msw/ole/dataobj.cpp:394
+#: ../src/msw/ole/dataobj.cpp:402
 #, c-format
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "Urklippsformatet \"%d\" finns inte."
@@ -6783,7 +6943,7 @@ msgstr "Urklippsformatet \"%d\" finns inte."
 msgid "The default style for the next paragraph."
 msgstr "Förvald stil för nästa stycke."
 
-#: ../src/generic/dirdlgg.cpp:202
+#: ../src/generic/dirdlgg.cpp:199
 #, c-format
 msgid ""
 "The directory '%s' does not exist\n"
@@ -6792,7 +6952,7 @@ msgstr ""
 "Katalogen \"%s\" finns inte\n"
 "Skapa den nu?"
 
-#: ../src/html/htmprint.cpp:271
+#: ../src/html/htmprint.cpp:283
 #, c-format
 msgid ""
 "The document \"%s\" doesn't fit on the page horizontally and will be "
@@ -6805,7 +6965,7 @@ msgstr ""
 "\n"
 "Vill du ändå fortsätta skriva ut?"
 
-#: ../src/common/docview.cpp:1202
+#: ../src/common/docview.cpp:1196
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -6814,36 +6974,37 @@ msgstr ""
 "Filen \"%s\" finns inte och kunde inte öppnas.\n"
 "Den har tagits bort från senast använda filer-listan."
 
-#: ../src/richtext/richtextindentspage.cpp:208
-#: ../src/richtext/richtextindentspage.cpp:210
 #: ../src/richtext/richtextliststylepage.cpp:394
 #: ../src/richtext/richtextliststylepage.cpp:396
+#: ../src/richtext/richtextindentspage.cpp:208
+#: ../src/richtext/richtextindentspage.cpp:210
 msgid "The first line indent."
 msgstr "Indrag på första raden."
 
-#: ../src/gtk/utilsgtk.cpp:481
-msgid "The following standard GTK+ options are also supported:\n"
-msgstr "Följande GTK+ standardalternativ stöds också:\n"
+#: ../src/generic/dbgrptg.cpp:318
+#, fuzzy
+msgid "The following debug report will be generated\n"
+msgstr "*** En debugrapport har skapats\n"
 
-#: ../src/generic/fontdlgg.cpp:414 ../src/generic/fontdlgg.cpp:416
+#: ../src/generic/fontdlgg.cpp:411 ../src/generic/fontdlgg.cpp:413
 msgid "The font colour."
 msgstr "Typsnittets färg."
 
-#: ../src/generic/fontdlgg.cpp:375 ../src/generic/fontdlgg.cpp:377
+#: ../src/generic/fontdlgg.cpp:371 ../src/generic/fontdlgg.cpp:373
 msgid "The font family."
 msgstr "Typsnittets familj."
 
-#: ../src/richtext/richtextsymboldlg.cpp:405
-#: ../src/richtext/richtextsymboldlg.cpp:407
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "The font from which to take the symbol."
 msgstr "Typsnitt att hämta symbolen från."
 
-#: ../src/generic/fontdlgg.cpp:427 ../src/generic/fontdlgg.cpp:429
-#: ../src/generic/fontdlgg.cpp:434 ../src/generic/fontdlgg.cpp:436
+#: ../src/generic/fontdlgg.cpp:424 ../src/generic/fontdlgg.cpp:426
+#: ../src/generic/fontdlgg.cpp:430 ../src/generic/fontdlgg.cpp:432
 msgid "The font point size."
 msgstr "Typsnittets punktstorlek"
 
-#: ../src/osx/carbon/fontdlg.cpp:343 ../src/osx/carbon/fontdlg.cpp:345
+#: ../src/osx/carbon/fontdlg.cpp:340 ../src/osx/carbon/fontdlg.cpp:342
 msgid "The font size in points."
 msgstr "Typsnittsstorlek i punkter"
 
@@ -6852,15 +7013,15 @@ msgstr "Typsnittsstorlek i punkter"
 msgid "The font size units, points or pixels."
 msgstr "Enhet för typsnittsstorlek, punkter eller pixlar."
 
-#: ../src/generic/fontdlgg.cpp:386 ../src/generic/fontdlgg.cpp:388
+#: ../src/generic/fontdlgg.cpp:382 ../src/generic/fontdlgg.cpp:384
 msgid "The font style."
 msgstr "Typsnittets stil."
 
-#: ../src/generic/fontdlgg.cpp:397 ../src/generic/fontdlgg.cpp:399
+#: ../src/generic/fontdlgg.cpp:393 ../src/generic/fontdlgg.cpp:395
 msgid "The font weight."
 msgstr "Typsnittets vikt."
 
-#: ../src/common/docview.cpp:1483
+#: ../src/common/docview.cpp:1477
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Formatet för filen \"%s\" kunde inte avgöras."
@@ -6871,10 +7032,10 @@ msgstr "Formatet för filen \"%s\" kunde inte avgöras."
 msgid "The horizontal offset."
 msgstr "Ordna &horisontellt"
 
-#: ../src/richtext/richtextindentspage.cpp:199
-#: ../src/richtext/richtextindentspage.cpp:201
 #: ../src/richtext/richtextliststylepage.cpp:385
 #: ../src/richtext/richtextliststylepage.cpp:387
+#: ../src/richtext/richtextindentspage.cpp:199
+#: ../src/richtext/richtextindentspage.cpp:201
 msgid "The left indent."
 msgstr "Vänster indrag."
 
@@ -6895,10 +7056,10 @@ msgstr "Vänster utfyllnadsstorlek."
 msgid "The left position."
 msgstr "Vänster position."
 
-#: ../src/richtext/richtextindentspage.cpp:288
-#: ../src/richtext/richtextindentspage.cpp:290
 #: ../src/richtext/richtextliststylepage.cpp:462
 #: ../src/richtext/richtextliststylepage.cpp:464
+#: ../src/richtext/richtextindentspage.cpp:288
+#: ../src/richtext/richtextindentspage.cpp:290
 msgid "The line spacing."
 msgstr "Radavståndet."
 
@@ -6907,7 +7068,7 @@ msgstr "Radavståndet."
 msgid "The list item number."
 msgstr "Listpostnumret."
 
-#: ../src/msw/ole/automtn.cpp:664
+#: ../src/msw/ole/automtn.cpp:655
 msgid "The locale ID is unknown."
 msgstr "Okänt lokal-ID."
 
@@ -6946,19 +7107,19 @@ msgstr "Objektbredden."
 msgid "The outline level."
 msgstr "Sammanfattningsnivån."
 
-#: ../src/common/log.cpp:277
+#: ../src/common/log.cpp:296
 #, fuzzy, c-format
 msgid "The previous message repeated %u time."
 msgid_plural "The previous message repeated %u times."
 msgstr[0] "Föregående meddelande upprepat %lu gång."
 msgstr[1] "Föregående meddelande upprepat %lu gånger."
 
-#: ../src/common/log.cpp:270
+#: ../src/common/log.cpp:289
 msgid "The previous message repeated once."
 msgstr "Föregående meddelande upprepat en gång."
 
-#: ../src/richtext/richtextsymboldlg.cpp:462
-#: ../src/richtext/richtextsymboldlg.cpp:464
+#: ../src/richtext/richtextsymboldlg.cpp:459
+#: ../src/richtext/richtextsymboldlg.cpp:461
 msgid "The range to show."
 msgstr "Räckvidden att visa."
 
@@ -6971,15 +7132,15 @@ msgstr ""
 "Rapporten innehåller filerna nedan. Om någon av filerna innehåller\n"
 "privat information, välj bort dem så tas de bort från rapporten.\n"
 
-#: ../src/common/cmdline.cpp:1254
+#: ../src/common/cmdline.cpp:1250
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "Den obligatoriska parametern \"%s\" angavs inte."
 
-#: ../src/richtext/richtextindentspage.cpp:217
-#: ../src/richtext/richtextindentspage.cpp:219
 #: ../src/richtext/richtextliststylepage.cpp:403
 #: ../src/richtext/richtextliststylepage.cpp:405
+#: ../src/richtext/richtextindentspage.cpp:217
+#: ../src/richtext/richtextindentspage.cpp:219
 msgid "The right indent."
 msgstr "Höger indrag."
 
@@ -7021,16 +7182,16 @@ msgstr ""
 msgid "The shadow spread."
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:267
 #: ../src/richtext/richtextliststylepage.cpp:439
 #: ../src/richtext/richtextliststylepage.cpp:441
+#: ../src/richtext/richtextindentspage.cpp:267
 msgid "The spacing after the paragraph."
 msgstr "Avståndet efter stycket."
 
-#: ../src/richtext/richtextindentspage.cpp:257
-#: ../src/richtext/richtextindentspage.cpp:259
 #: ../src/richtext/richtextliststylepage.cpp:430
 #: ../src/richtext/richtextliststylepage.cpp:432
+#: ../src/richtext/richtextindentspage.cpp:257
+#: ../src/richtext/richtextindentspage.cpp:259
 msgid "The spacing before the paragraph."
 msgstr "Avståndet före stycket."
 
@@ -7044,12 +7205,12 @@ msgstr "Stilens namn."
 msgid "The style on which this style is based."
 msgstr "Stilen som den här stilen är baserad på."
 
-#: ../src/richtext/richtextstyledlg.cpp:214
-#: ../src/richtext/richtextstyledlg.cpp:216
+#: ../src/richtext/richtextstyledlg.cpp:210
+#: ../src/richtext/richtextstyledlg.cpp:212
 msgid "The style preview."
 msgstr "Stilförhandsgranskningen."
 
-#: ../src/msw/ole/automtn.cpp:680
+#: ../src/msw/ole/automtn.cpp:671
 msgid "The system cannot find the file specified."
 msgstr "Systemet kan inte hitta den specificerade filen."
 
@@ -7062,7 +7223,7 @@ msgstr "Tabbpositionen."
 msgid "The tab positions."
 msgstr "Tabbpositionerna."
 
-#: ../src/richtext/richtextctrl.cpp:3098
+#: ../src/richtext/richtextctrl.cpp:3099
 msgid "The text couldn't be saved."
 msgstr "Texten kunde inte sparas."
 
@@ -7083,7 +7244,7 @@ msgstr "Övre utfyllnadsstorlek."
 msgid "The top position."
 msgstr "Övre position."
 
-#: ../src/common/cmdline.cpp:1232
+#: ../src/common/cmdline.cpp:1228
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "Värdet för flaggan \"%s\" måste anges."
@@ -7093,7 +7254,7 @@ msgstr "Värdet för flaggan \"%s\" måste anges."
 msgid "The value of the corner radius."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:433
+#: ../src/msw/dialup.cpp:427
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -7108,14 +7269,14 @@ msgstr ""
 msgid "The vertical offset."
 msgstr "Slå på vertikal justering."
 
-#: ../src/richtext/richtextprint.cpp:619 ../src/html/htmprint.cpp:745
+#: ../src/html/htmprint.cpp:749 ../src/richtext/richtextprint.cpp:615
 msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr ""
 "Det var problem när sidan ställdes in: Du måste kanske ange en "
 "standardskrivare."
 
-#: ../src/html/htmprint.cpp:255
+#: ../src/html/htmprint.cpp:267
 msgid ""
 "This document doesn't fit on the page horizontally and will be truncated "
 "when it is printed."
@@ -7123,16 +7284,16 @@ msgstr ""
 "Detta dokument ryms inte på sidan i liggande format, och kommer att "
 "trunkeras när det skrivs ut."
 
-#: ../src/common/image.cpp:2854
+#: ../src/common/image.cpp:2963
 #, c-format
 msgid "This is not a %s."
 msgstr "Detta är inte en %s."
 
-#: ../src/common/wincmn.cpp:1653
+#: ../src/common/wincmn.cpp:1654
 msgid "This platform does not support background transparency."
 msgstr "Denna plattform stöder inte bakgrundsgenomskinlighet."
 
-#: ../src/gtk/window.cpp:4660
+#: ../src/gtk/window.cpp:5664
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
@@ -7140,7 +7301,15 @@ msgstr ""
 "Det här programmet kompilerades med en för gammal version av GTK+, bygg om "
 "det med GTK+ 2.12 eller senare"
 
-#: ../src/msw/thread.cpp:1240
+#: ../src/gtk/glcanvas.cpp:176
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/msw/thread.cpp:1246
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -7148,11 +7317,11 @@ msgstr ""
 "Trådmodulinitialisering misslyckades: Kan inte spara värde i trådens lokala "
 "lagring"
 
-#: ../src/unix/threadpsx.cpp:1794
+#: ../src/unix/threadpsx.cpp:1843
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr "Trådmodulinitialisering misslyckades: Kunde inte skapa trådnyckel"
 
-#: ../src/msw/thread.cpp:1228
+#: ../src/msw/thread.cpp:1234
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -7160,82 +7329,82 @@ msgstr ""
 "Trådmodulinitialisering misslyckades: Omöjligt att allokera index i trådens "
 "lokala lagring"
 
-#: ../src/unix/threadpsx.cpp:1043
+#: ../src/unix/threadpsx.cpp:1061
 msgid "Thread priority setting is ignored."
 msgstr "Trådprioritetsinställningar ignoreras."
 
-#: ../src/msw/mdi.cpp:176
+#: ../src/msw/mdi.cpp:171
 msgid "Tile &Horizontally"
 msgstr "Ordna &horisontellt"
 
-#: ../src/msw/mdi.cpp:177
+#: ../src/msw/mdi.cpp:172
 msgid "Tile &Vertically"
 msgstr "Ordna &vertikalt"
 
-#: ../src/common/ftp.cpp:200
+#: ../src/common/ftp.cpp:197
 msgid "Timeout while waiting for FTP server to connect, try passive mode."
 msgstr ""
 "Tiden för att vänta på att FTP-server skall ansluta har gått ut, försök med "
 "passivt läge."
 
-#: ../src/generic/tipdlg.cpp:201
+#: ../src/generic/tipdlg.cpp:198
 msgid "Tip of the Day"
 msgstr "Dagens tips"
 
-#: ../src/generic/tipdlg.cpp:140
+#: ../src/generic/tipdlg.cpp:137
 msgid "Tips not available, sorry!"
 msgstr "Tipsen är inte tillgängliga!"
 
-#: ../src/generic/prntdlgg.cpp:242
+#: ../src/generic/prntdlgg.cpp:235
 msgid "To:"
 msgstr "Till:"
 
-#: ../src/richtext/richtextbuffer.cpp:8363
+#: ../src/richtext/richtextbuffer.cpp:8361
 msgid "Too many EndStyle calls!"
 msgstr "För många EndStyle-anrop!"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:891
+#: ../src/propgrid/advprops.cpp:792
 msgid "Tooltip"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:892
+#: ../src/propgrid/advprops.cpp:793
 msgid "TooltipText"
 msgstr ""
 
-#: ../src/richtext/richtextsizepage.cpp:286
-#: ../src/richtext/richtextsizepage.cpp:290 ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197 ../src/richtext/richtextsizepage.cpp:286
+#: ../src/richtext/richtextsizepage.cpp:290
 msgid "Top"
 msgstr "Toppen"
 
-#: ../src/generic/prntdlgg.cpp:881
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Top margin (mm):"
 msgstr "Övre marginal (mm):"
 
-#: ../src/generic/aboutdlgg.cpp:79
+#: ../src/generic/aboutdlgg.cpp:76
 msgid "Translations by "
 msgstr "Översättningar av "
 
-#: ../src/generic/aboutdlgg.cpp:188
+#: ../src/generic/aboutdlgg.cpp:185
 msgid "Translators"
 msgstr "Översättare"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:211
+#: ../src/propgrid/propgrid.cpp:192
 msgid "True"
 msgstr "Sant"
 
-#: ../src/common/fs_mem.cpp:227
+#: ../src/common/fs_mem.cpp:222
 #, c-format
 msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
 msgstr "Försöker ta bort fil \"%s\" från minnes-VFS, men den är inte inläst!"
 
-#: ../src/common/fmapbase.cpp:156
+#: ../src/common/fmapbase.cpp:153
 msgid "Turkish (ISO-8859-9)"
 msgstr "Turkisk (ISO-8859-9)"
 
-#: ../src/generic/filectrlg.cpp:426
+#: ../src/generic/filectrlg.cpp:422
 msgid "Type"
 msgstr "Typ"
 
@@ -7249,17 +7418,17 @@ msgstr "Skriv in ett typsnittsnamn."
 msgid "Type a size in points."
 msgstr "Skriv in en storlek i punkter."
 
-#: ../src/msw/ole/automtn.cpp:676
+#: ../src/msw/ole/automtn.cpp:667
 #, c-format
 msgid "Type mismatch in argument %u."
 msgstr "Typerna överensstämmer inte i argument %u."
 
-#: ../src/common/xtixml.cpp:356 ../src/common/xtixml.cpp:509
-#: ../src/common/xtistrm.cpp:318
+#: ../src/common/xtixml.cpp:352 ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315
 msgid "Type must have enum - long conversion"
 msgstr "Typen måste ha enum - long omvandling"
 
-#: ../src/propgrid/propgridiface.cpp:401
+#: ../src/propgrid/propgridiface.cpp:385
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
@@ -7268,19 +7437,19 @@ msgstr ""
 "Typoperation \"%s\" misslyckades: Egenskap med etikett \"%s\" är av typ \"%s"
 "\", INTE \"%s\"."
 
-#: ../src/common/paper.cpp:133
+#: ../src/common/paper.cpp:130
 msgid "US Std Fanfold, 14 7/8 x 11 in"
 msgstr "US standard fanfold, 14 7/8 x 11 tum"
 
-#: ../src/common/fmapbase.cpp:196
+#: ../src/common/fmapbase.cpp:193
 msgid "US-ASCII"
 msgstr "US-ASCII"
 
-#: ../src/unix/fswatcher_inotify.cpp:109
+#: ../src/unix/fswatcher_inotify.cpp:106
 msgid "Unable to add inotify watch"
 msgstr "Kunde inte lägga till inotify-bevakning"
 
-#: ../src/unix/fswatcher_kqueue.cpp:136
+#: ../src/unix/fswatcher_kqueue.cpp:153
 msgid "Unable to add kqueue watch"
 msgstr "Kunde inte lägga till kqueue-bevakning"
 
@@ -7292,7 +7461,7 @@ msgstr "Kunde inte associera handtag med I/O-avslutningsport"
 msgid "Unable to close I/O completion port handle"
 msgstr "Kunde inte stänga I/O-avslutningsporthantag"
 
-#: ../src/unix/fswatcher_inotify.cpp:97
+#: ../src/unix/fswatcher_inotify.cpp:94
 msgid "Unable to close inotify instance"
 msgstr "Kunde inte stänga inotify-instans"
 
@@ -7310,15 +7479,15 @@ msgstr "Kunde inte stänga handtag för \"%s\""
 msgid "Unable to create I/O completion port"
 msgstr "Kunde inte skapa I/O-avslutningsport"
 
-#: ../src/msw/fswatcher.cpp:84
+#: ../src/msw/fswatcher.cpp:81
 msgid "Unable to create IOCP worker thread"
 msgstr "Kunde inte skapa IOCP arbetstråd"
 
-#: ../src/unix/fswatcher_inotify.cpp:74
+#: ../src/unix/fswatcher_inotify.cpp:71
 msgid "Unable to create inotify instance"
 msgstr "Kunde inte skapa en inotify-instans"
 
-#: ../src/unix/fswatcher_kqueue.cpp:97
+#: ../src/unix/fswatcher_kqueue.cpp:114
 msgid "Unable to create kqueue instance"
 msgstr "Kunde inte skapa kqueue-instans"
 
@@ -7326,11 +7495,11 @@ msgstr "Kunde inte skapa kqueue-instans"
 msgid "Unable to dequeue completion packet"
 msgstr "Kunde inte ta bort avslutningspaket från kö"
 
-#: ../src/unix/fswatcher_kqueue.cpp:185
+#: ../src/unix/fswatcher_kqueue.cpp:202
 msgid "Unable to get events from kqueue"
 msgstr "Kunde inte hämta händelser från kqueue"
 
-#: ../src/gtk/app.cpp:435
+#: ../src/gtk/app.cpp:431
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "Kunde inte initiera GTK+, är DISPLAY inställt korrekt?"
 
@@ -7339,12 +7508,12 @@ msgstr "Kunde inte initiera GTK+, är DISPLAY inställt korrekt?"
 msgid "Unable to open path '%s'"
 msgstr "Kunde inte öppna sökväg \"%s\""
 
-#: ../src/html/htmlwin.cpp:583
+#: ../src/html/htmlwin.cpp:586
 #, c-format
 msgid "Unable to open requested HTML document: %s"
 msgstr "Kunde inte öppna efterfrågat HTML-dokument: %s"
 
-#: ../src/unix/sound.cpp:368
+#: ../src/unix/sound.cpp:365
 msgid "Unable to play sound asynchronously."
 msgstr "Kan inte spela ljud asynkront."
 
@@ -7352,61 +7521,61 @@ msgstr "Kan inte spela ljud asynkront."
 msgid "Unable to post completion status"
 msgstr "Kunde inte skicka avslutningsstatus"
 
-#: ../src/unix/fswatcher_inotify.cpp:556
+#: ../src/unix/fswatcher_inotify.cpp:553
 msgid "Unable to read from inotify descriptor"
 msgstr "Kan inte läsa från inotify-identifierare"
 
-#: ../src/unix/fswatcher_inotify.cpp:141
+#: ../src/unix/fswatcher_inotify.cpp:138
 #, fuzzy, c-format
 msgid "Unable to remove inotify watch %i"
 msgstr "Kunde inte ta bort inotify-bevakning"
 
-#: ../src/unix/fswatcher_kqueue.cpp:153
+#: ../src/unix/fswatcher_kqueue.cpp:170
 msgid "Unable to remove kqueue watch"
 msgstr "Kunde inte ta bort kqueue-bevakning"
 
-#: ../src/msw/fswatcher.cpp:168
+#: ../src/msw/fswatcher.cpp:165
 #, c-format
 msgid "Unable to set up watch for '%s'"
 msgstr "Kunde inte starta en bevakning för \"%s\""
 
-#: ../src/msw/fswatcher.cpp:91
+#: ../src/msw/fswatcher.cpp:88
 msgid "Unable to start IOCP worker thread"
 msgstr "Kunde inte starta IOCP arbetstråd"
 
-#: ../src/common/stockitem.cpp:201
+#: ../src/common/stockitem.cpp:198
 msgid "Undelete"
 msgstr "Ångra borttagning"
 
-#: ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199
 msgid "Underline"
 msgstr "Understrykning"
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/richtext/richtextfontpage.cpp:359 ../src/osx/carbon/fontdlg.cpp:370
-#: ../src/propgrid/advprops.cpp:690
+#: ../src/osx/carbon/fontdlg.cpp:367 ../src/propgrid/advprops.cpp:600
+#: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Understruken"
 
-#: ../src/common/stockitem.cpp:203 ../src/stc/stc_i18n.cpp:15
+#: ../src/common/stockitem.cpp:200 ../src/stc/stc_i18n.cpp:15
 msgid "Undo"
 msgstr "Ångra"
 
-#: ../src/common/stockitem.cpp:265
+#: ../src/common/stockitem.cpp:263
 msgid "Undo last action"
 msgstr "Ångra senaste händelse"
 
-#: ../src/common/cmdline.cpp:1029
+#: ../src/common/cmdline.cpp:1025
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Oväntat tecken efter flagga \"%s\"."
 
-#: ../src/unix/fswatcher_inotify.cpp:274
+#: ../src/unix/fswatcher_inotify.cpp:271
 #, c-format
 msgid "Unexpected event for \"%s\": no matching watch descriptor."
 msgstr "Oväntad händelse för \"%s\": ingen matchande bevakningsidentifierare."
 
-#: ../src/common/cmdline.cpp:1195
+#: ../src/common/cmdline.cpp:1191
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Oväntad parameter \"%s\""
@@ -7415,49 +7584,49 @@ msgstr "Oväntad parameter \"%s\""
 msgid "Unexpectedly new I/O completion port was created"
 msgstr "Oväntad ny I/O-avslutningsport skapades"
 
-#: ../src/msw/fswatcher.cpp:70
+#: ../src/msw/fswatcher.cpp:67
 msgid "Ungraceful worker thread termination"
 msgstr "Ickeelegant avslutande av arbetstråd"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:460
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:456
+#: ../src/richtext/richtextsymboldlg.cpp:457
+#: ../src/richtext/richtextsymboldlg.cpp:458
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../src/common/fmapbase.cpp:185 ../src/common/fmapbase.cpp:191
+#: ../src/common/fmapbase.cpp:182 ../src/common/fmapbase.cpp:188
 msgid "Unicode 16 bit (UTF-16)"
 msgstr "Unicode 16 bitar (UTF-16)"
 
-#: ../src/common/fmapbase.cpp:190
+#: ../src/common/fmapbase.cpp:187
 msgid "Unicode 16 bit Big Endian (UTF-16BE)"
 msgstr "Unicode 16 bitar big endian (UTF-16BE)"
 
-#: ../src/common/fmapbase.cpp:186
+#: ../src/common/fmapbase.cpp:183
 msgid "Unicode 16 bit Little Endian (UTF-16LE)"
 msgstr "Unicode 16 bitar little endian (UTF-16LE)"
 
-#: ../src/common/fmapbase.cpp:187 ../src/common/fmapbase.cpp:193
+#: ../src/common/fmapbase.cpp:184 ../src/common/fmapbase.cpp:190
 msgid "Unicode 32 bit (UTF-32)"
 msgstr "Unicode 32 bitar (UTF-32)"
 
-#: ../src/common/fmapbase.cpp:192
+#: ../src/common/fmapbase.cpp:189
 msgid "Unicode 32 bit Big Endian (UTF-32BE)"
 msgstr "Unicode 32 bitar big endian (UTF-32BE)"
 
-#: ../src/common/fmapbase.cpp:188
+#: ../src/common/fmapbase.cpp:185
 msgid "Unicode 32 bit Little Endian (UTF-32LE)"
 msgstr "Unicode 32 bitar little endian (UTF-32LE)"
 
-#: ../src/common/fmapbase.cpp:182
+#: ../src/common/fmapbase.cpp:179
 msgid "Unicode 7 bit (UTF-7)"
 msgstr "Unicode 7 bitar (UTF-7)"
 
-#: ../src/common/fmapbase.cpp:183
+#: ../src/common/fmapbase.cpp:180
 msgid "Unicode 8 bit (UTF-8)"
 msgstr "Unicode 8 bitar (UTF-8)"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "Unindent"
 msgstr "Utindentera"
 
@@ -7609,97 +7778,102 @@ msgstr "Enheter för övre position."
 msgid "Units for this value."
 msgstr "Enheter för vänster marginal."
 
-#: ../src/generic/progdlgg.cpp:353 ../src/generic/progdlgg.cpp:622
+#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
 msgid "Unknown"
 msgstr "Okänd"
 
-#: ../src/msw/dde.cpp:1174
+#: ../src/msw/dde.cpp:1238
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Okänt DDE-fel %08x"
 
-#: ../src/common/xtistrm.cpp:410
+#: ../src/common/xtistrm.cpp:407
 msgid "Unknown Object passed to GetObjectClassInfo"
 msgstr "Okänt objekt skickades till GetObjectClassInfo"
 
-#: ../src/common/imagpng.cpp:366
+#: ../src/common/imagpng.cpp:383
 #, c-format
 msgid "Unknown PNG resolution unit %d"
 msgstr "Okänd PNG-upplösningsenhet %d"
 
-#: ../src/common/xtixml.cpp:327
+#: ../src/common/xtixml.cpp:323
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Okänd egenskap %s"
 
-#: ../src/common/imagtiff.cpp:529
+#: ../src/common/imagtiff.cpp:526
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "Okänd TIFF-upplösningsenhet %d ignoreras"
 
-#: ../src/unix/dlunix.cpp:160
+#: ../src/propgrid/props.cpp:155
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/unix/dlunix.cpp:118
 msgid "Unknown dynamic library error"
 msgstr "Okänt fel i dynamiskt bibliotek"
 
-#: ../src/common/fmapbase.cpp:810
+#: ../src/common/fmapbase.cpp:806
 #, c-format
 msgid "Unknown encoding (%d)"
 msgstr "Okänd kodning (%d)"
 
-#: ../src/msw/ole/automtn.cpp:688
+#: ../src/msw/ole/automtn.cpp:679
 #, c-format
 msgid "Unknown error %08x"
 msgstr "Okänt fel %08x"
 
-#: ../src/msw/ole/automtn.cpp:647
+#: ../src/msw/ole/automtn.cpp:638
 msgid "Unknown exception"
 msgstr "Okänt undantag"
 
-#: ../src/common/image.cpp:2839
+#: ../src/common/image.cpp:2942
 msgid "Unknown image data format."
 msgstr "Okänt bilddataformat."
 
-#: ../src/common/cmdline.cpp:914
+#: ../src/common/cmdline.cpp:910
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Okänd lång flagga \"%s\""
 
-#: ../src/msw/ole/automtn.cpp:631
+#: ../src/msw/ole/automtn.cpp:622
 msgid "Unknown name or named argument."
 msgstr "Okänt namn eller namngivet argument."
 
-#: ../src/common/cmdline.cpp:929 ../src/common/cmdline.cpp:951
+#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Okänd flagga \"%s\""
 
-#: ../src/common/mimecmn.cpp:225
+#: ../src/common/mimecmn.cpp:221
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "Omatchad \"{\" i en post för mime-typ %s."
 
-#: ../src/common/cmdproc.cpp:262 ../src/common/cmdproc.cpp:288
-#: ../src/common/cmdproc.cpp:308
+#: ../src/common/cmdproc.cpp:255 ../src/common/cmdproc.cpp:281
+#: ../src/common/cmdproc.cpp:301
 msgid "Unnamed command"
 msgstr "Namnlöst kommando"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:413
+#: ../src/propgrid/propgrid.cpp:392
 msgid "Unspecified"
 msgstr "Ospecificerad"
 
-#: ../src/msw/clipbrd.cpp:311
+#: ../src/msw/clipbrd.cpp:325
 msgid "Unsupported clipboard format."
 msgstr "Urklippsformatet stöds inte."
 
-#: ../src/common/appcmn.cpp:256
+#: ../src/common/appcmn.cpp:277
 #, c-format
 msgid "Unsupported theme '%s'."
 msgstr "Temat \"%s\" stöds inte."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:205
-#: ../src/common/accelcmn.cpp:63
+#: ../src/common/stockitem.cpp:202 ../src/common/accelcmn.cpp:60
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Up"
 msgstr "Upp"
 
@@ -7713,7 +7887,7 @@ msgstr "Stora bokstäver"
 msgid "Upper case roman numerals"
 msgstr "Stora romerska siffor"
 
-#: ../src/common/cmdline.cpp:1326
+#: ../src/common/cmdline.cpp:1322
 #, c-format
 msgid "Usage: %s"
 msgstr "Användning: %s"
@@ -7722,38 +7896,47 @@ msgstr "Användning: %s"
 msgid "Use &shadow"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:169
-#: ../src/richtext/richtextindentspage.cpp:171
 #: ../src/richtext/richtextliststylepage.cpp:358
 #: ../src/richtext/richtextliststylepage.cpp:360
+#: ../src/richtext/richtextindentspage.cpp:169
+#: ../src/richtext/richtextindentspage.cpp:171
 msgid "Use the current alignment setting."
 msgstr "Använd nuvarande justeringsinställningar."
 
-#: ../src/common/valtext.cpp:179
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/gtk/font.cpp:552
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/common/valtext.cpp:142
 msgid "Validation conflict"
 msgstr "Valideringskonflikt"
 
-#: ../src/propgrid/manager.cpp:238
+#: ../src/propgrid/manager.cpp:224
 msgid "Value"
 msgstr "Värde"
 
-#: ../src/propgrid/props.cpp:386 ../src/propgrid/props.cpp:500
+#: ../src/propgrid/props.cpp:309
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "Värde måste vara %s eller högre."
 
-#: ../src/propgrid/props.cpp:417 ../src/propgrid/props.cpp:531
+#: ../src/propgrid/props.cpp:336
 #, c-format
 msgid "Value must be %s or less."
 msgstr "Värde måste vara %s eller mindre."
 
-#: ../src/propgrid/props.cpp:393 ../src/propgrid/props.cpp:424
-#: ../src/propgrid/props.cpp:507 ../src/propgrid/props.cpp:538
+#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "Värde måste vara mellan %s och %s."
 
-#: ../src/generic/aboutdlgg.cpp:128
+#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Version "
 
@@ -7762,25 +7945,32 @@ msgstr "Version "
 msgid "Vertical alignment."
 msgstr "Vertikal justering."
 
-#: ../src/generic/filedlgg.cpp:202
+#: ../src/generic/filedlgg.cpp:199
 msgid "View files as a detailed view"
 msgstr "Visa filer som detaljerad lista"
 
-#: ../src/generic/filedlgg.cpp:200
+#: ../src/generic/filedlgg.cpp:197
 msgid "View files as a list view"
 msgstr "Visa filer som lista"
 
-#: ../src/common/docview.cpp:1970
+#: ../src/common/docview.cpp:1975
 msgid "Views"
 msgstr "Vyer"
 
+#: ../src/gtk/app.cpp:348
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1777
+#: ../src/propgrid/advprops.cpp:1678
 msgid "Wait"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1779
+#: ../src/propgrid/advprops.cpp:1680
 msgid "Wait Arrow"
 msgstr ""
 
@@ -7789,244 +7979,241 @@ msgstr ""
 msgid "Waiting for IO on epoll descriptor %d failed"
 msgstr "Väntan på IO för epoll-identifierare %d misslyckades"
 
-#: ../src/common/log.cpp:223
+#: ../src/common/log.cpp:241
 msgid "Warning: "
 msgstr "Varning: "
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1778
+#: ../src/propgrid/advprops.cpp:1679
 msgid "Watch"
 msgstr ""
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:685
+#: ../src/propgrid/advprops.cpp:595
 msgid "Weight"
 msgstr "Vikt"
 
-#: ../src/common/fmapbase.cpp:148
+#: ../src/common/fmapbase.cpp:145
 msgid "Western European (ISO-8859-1)"
 msgstr "Västerländsk (ISO-8859-1)"
 
-#: ../src/common/fmapbase.cpp:162
+#: ../src/common/fmapbase.cpp:159
 msgid "Western European with Euro (ISO-8859-15)"
 msgstr "Västerländsk med Euro (ISO-8859-15)"
 
-#: ../src/generic/fontdlgg.cpp:446 ../src/generic/fontdlgg.cpp:448
+#: ../src/generic/fontdlgg.cpp:443 ../src/generic/fontdlgg.cpp:445
 msgid "Whether the font is underlined."
 msgstr "Om typsnittet är understruket."
 
-#: ../src/propgrid/advprops.cpp:1611
+#: ../src/propgrid/advprops.cpp:1517
 msgid "White"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:144
+#: ../src/generic/fdrepdlg.cpp:141
 msgid "Whole word"
 msgstr "Hela ord"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:532
 msgid "Whole words only"
 msgstr "Endast hela ord"
 
-#: ../src/univ/themes/win32.cpp:1102
+#: ../src/univ/themes/win32.cpp:1099
 msgid "Win32 theme"
 msgstr "Win32 tema"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:893
+#: ../src/propgrid/advprops.cpp:794
 #, fuzzy
 msgid "Window"
 msgstr "&Fönster"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:894
+#: ../src/propgrid/advprops.cpp:795
 #, fuzzy
 msgid "WindowFrame"
 msgstr "&Fönster"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:895
+#: ../src/propgrid/advprops.cpp:796
 #, fuzzy
 msgid "WindowText"
 msgstr "&Fönster"
 
-#: ../src/common/fmapbase.cpp:177
+#: ../src/common/fmapbase.cpp:174
 msgid "Windows Arabic (CP 1256)"
 msgstr "Windows arabisk (CP 1256)"
 
-#: ../src/common/fmapbase.cpp:178
+#: ../src/common/fmapbase.cpp:175
 msgid "Windows Baltic (CP 1257)"
 msgstr "Windows baltiska språk (CP 1257)"
 
-#: ../src/common/fmapbase.cpp:171
+#: ../src/common/fmapbase.cpp:168
 msgid "Windows Central European (CP 1250)"
 msgstr "Windows centraleuropeisk (CP 1250)"
 
-#: ../src/common/fmapbase.cpp:168
+#: ../src/common/fmapbase.cpp:165
 msgid "Windows Chinese Simplified (CP 936) or GB-2312"
 msgstr "Windows förenklad kinesiska (CP 936) eller GB-2312"
 
-#: ../src/common/fmapbase.cpp:170
+#: ../src/common/fmapbase.cpp:167
 msgid "Windows Chinese Traditional (CP 950) or Big-5"
 msgstr "Windows traditionelll kinesiska (CP 950) eller Big-5"
 
-#: ../src/common/fmapbase.cpp:172
+#: ../src/common/fmapbase.cpp:169
 msgid "Windows Cyrillic (CP 1251)"
 msgstr "Windows kyrillisk (CP 1251)"
 
-#: ../src/common/fmapbase.cpp:174
+#: ../src/common/fmapbase.cpp:171
 msgid "Windows Greek (CP 1253)"
 msgstr "Windows grekisk (CP 1253)"
 
-#: ../src/common/fmapbase.cpp:176
+#: ../src/common/fmapbase.cpp:173
 msgid "Windows Hebrew (CP 1255)"
 msgstr "Windows hebreisk (CP 1255)"
 
-#: ../src/common/fmapbase.cpp:167
+#: ../src/common/fmapbase.cpp:164
 msgid "Windows Japanese (CP 932) or Shift-JIS"
 msgstr "Windows japansk (CP 932) eller Shift-JIS"
 
-#: ../src/common/fmapbase.cpp:180
+#: ../src/common/fmapbase.cpp:177
 msgid "Windows Johab (CP 1361)"
 msgstr "Windows Johab (CP 1361)"
 
-#: ../src/common/fmapbase.cpp:169
+#: ../src/common/fmapbase.cpp:166
 msgid "Windows Korean (CP 949)"
 msgstr "Windows koreansk (CP 949)"
 
-#: ../src/common/fmapbase.cpp:166
+#: ../src/common/fmapbase.cpp:163
 msgid "Windows Thai (CP 874)"
 msgstr "Windows thailändsk (CP 874)"
 
-#: ../src/common/fmapbase.cpp:175
+#: ../src/common/fmapbase.cpp:172
 msgid "Windows Turkish (CP 1254)"
 msgstr "Windows turkisk (CP 1254)"
 
-#: ../src/common/fmapbase.cpp:179
+#: ../src/common/fmapbase.cpp:176
 msgid "Windows Vietnamese (CP 1258)"
 msgstr "Windows Vietnamesiska (CP 1258)"
 
-#: ../src/common/fmapbase.cpp:173
+#: ../src/common/fmapbase.cpp:170
 msgid "Windows Western European (CP 1252)"
 msgstr "Windows västeuropa (CP 1252)"
 
-#: ../src/common/fmapbase.cpp:181
+#: ../src/common/fmapbase.cpp:178
 msgid "Windows/DOS OEM (CP 437)"
 msgstr "Windows/DOS OEM (CP 437)"
 
-#: ../src/common/fmapbase.cpp:165
+#: ../src/common/fmapbase.cpp:162
 msgid "Windows/DOS OEM Cyrillic (CP 866)"
 msgstr "Windows/DOS OEM Kyrillisk (CP 1251)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:111
+#: ../src/common/accelcmn.cpp:109
 #, fuzzy
 msgid "Windows_Left"
 msgstr "Windows 7"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:113
+#: ../src/common/accelcmn.cpp:111
 #, fuzzy
 msgid "Windows_Menu"
 msgstr "Windows ME"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:112
+#: ../src/common/accelcmn.cpp:110
 #, fuzzy
 msgid "Windows_Right"
 msgstr "Windows Vista"
 
-#: ../src/common/ffile.cpp:150
+#: ../src/common/ffile.cpp:149
 #, c-format
 msgid "Write error on file '%s'"
 msgstr "Skrivfel på fil \"%s\""
 
-#: ../src/xml/xml.cpp:914
+#: ../src/xml/xml.cpp:925
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "XML tolkningsfel: \"%s\" på rad %d"
 
-#: ../src/common/xpmdecod.cpp:796
+#: ../src/common/xpmdecod.cpp:794
 msgid "XPM: Malformed pixel data!"
 msgstr "XPM: Felaktigt pixeldata!"
 
-#: ../src/common/xpmdecod.cpp:705
+#: ../src/common/xpmdecod.cpp:702
 #, c-format
 msgid "XPM: incorrect colour description in line %d"
 msgstr "XPM: Felaktig färgbeskrivning på rad %d "
 
-#: ../src/common/xpmdecod.cpp:680
+#: ../src/common/xpmdecod.cpp:677
 msgid "XPM: incorrect header format!"
 msgstr "XPM: Felaktigt format i huvudet!"
 
-#: ../src/common/xpmdecod.cpp:716 ../src/common/xpmdecod.cpp:725
+#: ../src/common/xpmdecod.cpp:714 ../src/common/xpmdecod.cpp:723
 #, c-format
 msgid "XPM: malformed colour definition '%s' at line %d!"
 msgstr "XPM: Felaktig färgdefinition \"%s\" på rad %d!"
 
-#: ../src/common/xpmdecod.cpp:755
+#: ../src/common/xpmdecod.cpp:753
 msgid "XPM: no colors left to use for mask!"
 msgstr "XPM: Inga färger kvar att använda i masken!"
 
-#: ../src/common/xpmdecod.cpp:782
+#: ../src/common/xpmdecod.cpp:780
 #, c-format
 msgid "XPM: truncated image data at line %d!"
 msgstr "XPM: Trunkerat bilddata på rad %d!"
 
-#: ../src/propgrid/advprops.cpp:1610
+#: ../src/propgrid/advprops.cpp:1516
 msgid "Yellow"
 msgstr ""
 
-#: ../include/wx/msgdlg.h:276 ../src/common/stockitem.cpp:206
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:203
 #: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Ja"
 
-#: ../src/osx/carbon/overlay.cpp:155
-msgid "You cannot Clear an overlay that is not inited"
-msgstr "Du kan inte tömma ett överlägg som inte är initierat"
-
-#: ../src/osx/carbon/overlay.cpp:107 ../src/dfb/overlay.cpp:61
-msgid "You cannot Init an overlay twice"
-msgstr "Du kan inte initiera överlägg två gånger"
-
-#: ../src/generic/dirdlgg.cpp:287
+#: ../src/generic/dirdlgg.cpp:284
 msgid "You cannot add a new directory to this section."
 msgstr "Du kan inte lägga till en ny katalog till denna avdelning."
 
-#: ../src/propgrid/propgrid.cpp:3299
+#: ../src/propgrid/propgrid.cpp:3276
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 "Du har angett ett ogiltigt värde. Tryck ESC för att avbryta redigering."
 
-#: ../src/common/stockitem.cpp:209
+#: ../src/osx/cocoa/menu.mm:286
+#, fuzzy
+msgid "Zoom"
+msgstr "Zooma in"
+
+#: ../src/common/stockitem.cpp:206
 msgid "Zoom &In"
 msgstr "Zooma &in"
 
-#: ../src/common/stockitem.cpp:210
+#: ../src/common/stockitem.cpp:207
 msgid "Zoom &Out"
 msgstr "Zooma &ut"
 
-#: ../src/common/stockitem.cpp:209 ../src/common/prntbase.cpp:1594
+#: ../src/common/stockitem.cpp:206 ../src/common/prntbase.cpp:1619
 msgid "Zoom In"
 msgstr "Zooma in"
 
-#: ../src/common/stockitem.cpp:210 ../src/common/prntbase.cpp:1580
+#: ../src/common/stockitem.cpp:207 ../src/common/prntbase.cpp:1605
 msgid "Zoom Out"
 msgstr "Zooma ut"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to &Fit"
 msgstr "&Anpassa zoom"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to Fit"
 msgstr "Anpassa zoom"
 
-#: ../src/msw/dde.cpp:1141
+#: ../src/msw/dde.cpp:1205
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "en DDEML-applikation har skapat ett långvarigt race-tillstånd."
 
-#: ../src/msw/dde.cpp:1129
+#: ../src/msw/dde.cpp:1193
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -8037,41 +8224,41 @@ msgstr ""
 "eller en ogiltig instansidentifierare\n"
 "sändes till en DDEML-funktion."
 
-#: ../src/msw/dde.cpp:1147
+#: ../src/msw/dde.cpp:1211
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "en klients försök att etablera en konversation har misslyckats."
 
-#: ../src/msw/dde.cpp:1144
+#: ../src/msw/dde.cpp:1208
 msgid "a memory allocation failed."
 msgstr "en minnesallokering misslyckades."
 
-#: ../src/msw/dde.cpp:1138
+#: ../src/msw/dde.cpp:1202
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "en parameter kunde inte bekräftas av DDEML."
 
-#: ../src/msw/dde.cpp:1120
+#: ../src/msw/dde.cpp:1184
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr ""
 "tiden för en förfrågan för en synkron meddelandetransaktion har gått ut."
 
-#: ../src/msw/dde.cpp:1126
+#: ../src/msw/dde.cpp:1190
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "tiden för en förfrågan för en synkron datatransaktion har gått ut."
 
-#: ../src/msw/dde.cpp:1135
+#: ../src/msw/dde.cpp:1199
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "tiden för en förfrågan för en synkron körningstransaktion har gått ut."
 
-#: ../src/msw/dde.cpp:1153
+#: ../src/msw/dde.cpp:1217
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "tiden för en förfrågan för en synkron poke-transaktion har gått ut."
 
-#: ../src/msw/dde.cpp:1168
+#: ../src/msw/dde.cpp:1232
 msgid "a request to end an advise transaction has timed out."
 msgstr ""
 "tiden för en förfrågan att avsluta en meddelandetransaktion har gått ut."
 
-#: ../src/msw/dde.cpp:1162
+#: ../src/msw/dde.cpp:1226
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -8081,15 +8268,15 @@ msgstr ""
 "som avslutades av klienten, eller servern\n"
 "avslutades före transaktionen var genomförd."
 
-#: ../src/msw/dde.cpp:1150
+#: ../src/msw/dde.cpp:1214
 msgid "a transaction failed."
 msgstr "en transaktion misslyckades."
 
-#: ../src/common/accelcmn.cpp:189
+#: ../src/common/accelcmn.cpp:188
 msgid "alt"
 msgstr "alt"
 
-#: ../src/msw/dde.cpp:1132
+#: ../src/msw/dde.cpp:1196
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -8101,15 +8288,15 @@ msgstr ""
 "eller en applikation initierad som en APPCMD_CLIENTONLY har \n"
 "försökt genomföra servertransaktioner."
 
-#: ../src/msw/dde.cpp:1156
+#: ../src/msw/dde.cpp:1220
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "ett internt anrop till PostMessage-funktionen har misslyckats. "
 
-#: ../src/msw/dde.cpp:1165
+#: ../src/msw/dde.cpp:1229
 msgid "an internal error has occurred in the DDEML."
 msgstr "ett internt fel har uppstått i DDEML."
 
-#: ../src/msw/dde.cpp:1171
+#: ../src/msw/dde.cpp:1235
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -8119,56 +8306,56 @@ msgstr ""
 "När applikationen har återvänt från ett XTYP_XACT_COMPLETE anrop,\n"
 "är transaktionsidentifieraren för det anropet inte längre giltig."
 
-#: ../src/common/zipstrm.cpp:1483
+#: ../src/common/zipstrm.cpp:1522
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "antar att detta är en multi-part zip konkatenerad"
 
-#: ../src/common/fileconf.cpp:1847
+#: ../src/common/fileconf.cpp:1849
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "försök att ändra ej skrivbar nyckel \"%s\" ignorerad."
 
-#: ../src/html/chm.cpp:329
+#: ../src/html/chm.cpp:326
 msgid "bad arguments to library function"
 msgstr "felaktiga argument till biblioteksfunktion"
 
-#: ../src/html/chm.cpp:341
+#: ../src/html/chm.cpp:338
 msgid "bad signature"
 msgstr "felaktig signatur"
 
-#: ../src/common/zipstrm.cpp:1918
+#: ../src/common/zipstrm.cpp:1988
 msgid "bad zipfile offset to entry"
 msgstr "felaktig zipfil offset mot ingång"
 
-#: ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400
 msgid "binary"
 msgstr "binär"
 
-#: ../src/common/fontcmn.cpp:996
+#: ../src/common/fontcmn.cpp:1195
 msgid "bold"
 msgstr "fet"
 
-#: ../src/msw/utils.cpp:1144
+#: ../src/msw/utils.cpp:1135
 #, c-format
 msgid "build %lu"
 msgstr "bygge %lu"
 
-#: ../src/common/ffile.cpp:75
+#: ../src/common/ffile.cpp:73
 #, c-format
 msgid "can't close file '%s'"
 msgstr "kan inte stänga fil \"%s\""
 
-#: ../src/common/file.cpp:245
+#: ../src/common/file.cpp:242
 #, c-format
 msgid "can't close file descriptor %d"
 msgstr "kan inte stänga filidentifierare %d"
 
-#: ../src/common/file.cpp:586
+#: ../src/common/ffile.cpp:382 ../src/common/file.cpp:613
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "kan inte skriva ändringar till fil \"%s\""
 
-#: ../src/common/file.cpp:178
+#: ../src/common/file.cpp:175
 #, c-format
 msgid "can't create file '%s'"
 msgstr "kan inte skapa fil \"%s\""
@@ -8178,49 +8365,49 @@ msgstr "kan inte skapa fil \"%s\""
 msgid "can't delete user configuration file '%s'"
 msgstr "kan inte ta bort användarkonfigurationsfil \"%s\""
 
-#: ../src/common/file.cpp:495
+#: ../src/common/file.cpp:522
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr "kan inte avgöra om slutet på filen är uppnått på identifierare %d"
 
-#: ../src/common/zipstrm.cpp:1692
+#: ../src/common/zipstrm.cpp:1747
 msgid "can't find central directory in zip"
 msgstr "kan inte hitta central katalog i zip"
 
-#: ../src/common/file.cpp:465
+#: ../src/common/file.cpp:492
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "kan inte hitta filens längd på filidentifierare %d"
 
-#: ../src/msw/utils.cpp:341
+#: ../src/msw/utils.cpp:336
 msgid "can't find user's HOME, using current directory."
 msgstr "kan inte hitta användarens HEM, använder aktuell katalog."
 
-#: ../src/common/file.cpp:366
+#: ../src/common/file.cpp:407
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "kan inte spola filidentifierare %d"
 
-#: ../src/common/file.cpp:422
+#: ../src/common/file.cpp:463
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "kan inte hitta sökposition på filidentifierare %d"
 
-#: ../src/common/fontmap.cpp:325
+#: ../src/common/fontmap.cpp:322
 msgid "can't load any font, aborting"
 msgstr "kan inte läsa in något typsnitt, avbryter"
 
-#: ../src/common/file.cpp:231 ../src/common/ffile.cpp:59
+#: ../src/common/ffile.cpp:57 ../src/common/file.cpp:228
 #, c-format
 msgid "can't open file '%s'"
 msgstr "kan inte öppna fil \"%s\""
 
-#: ../src/common/fileconf.cpp:320
+#: ../src/common/fileconf.cpp:314
 #, c-format
 msgid "can't open global configuration file '%s'."
 msgstr "kan inte öppna global konfigurationsfil \"%s\"."
 
-#: ../src/common/fileconf.cpp:336
+#: ../src/common/fileconf.cpp:330
 #, c-format
 msgid "can't open user configuration file '%s'."
 msgstr "kan inte öppna användarkonfigurationsfil \"%s\"."
@@ -8229,40 +8416,40 @@ msgstr "kan inte öppna användarkonfigurationsfil \"%s\"."
 msgid "can't open user configuration file."
 msgstr "kan inte öppna användarkonfigurationsfil."
 
-#: ../src/common/zipstrm.cpp:579
+#: ../src/common/zipstrm.cpp:572
 msgid "can't re-initialize zlib deflate stream"
 msgstr "kan inte återinitiera zlib deflate-ström"
 
-#: ../src/common/zipstrm.cpp:604
+#: ../src/common/zipstrm.cpp:597
 msgid "can't re-initialize zlib inflate stream"
 msgstr "kan inte återinitiera zlib inflate-ström"
 
-#: ../src/common/file.cpp:304
+#: ../src/common/file.cpp:345
 #, c-format
 msgid "can't read from file descriptor %d"
 msgstr "kan inte läsa från filidentifierare %d"
 
-#: ../src/common/file.cpp:581
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:608
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "kan inte ta bort fil \"%s\""
 
-#: ../src/common/file.cpp:598
+#: ../src/common/ffile.cpp:394 ../src/common/file.cpp:625
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "kan inte ta bort temporär fil \"%s\""
 
-#: ../src/common/file.cpp:408
+#: ../src/common/file.cpp:449
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "kan inte söka på filidentifierare %d"
 
-#: ../src/common/textfile.cpp:273
+#: ../src/common/textfile.cpp:161
 #, c-format
 msgid "can't write buffer '%s' to disk."
 msgstr "kan inte skriva buffer \"%s\" till disk."
 
-#: ../src/common/file.cpp:323
+#: ../src/common/file.cpp:364
 #, c-format
 msgid "can't write to file descriptor %d"
 msgstr "kan inte skriva till filidentifierare %d"
@@ -8272,22 +8459,28 @@ msgid "can't write user configuration file."
 msgstr "kan inte skriva användarkonfigurationsfil."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:482 ../src/generic/datavgen.cpp:1261
+#: ../src/common/datavcmn.cpp:2064 ../src/generic/datavgen.cpp:1384
 msgid "checked"
 msgstr ""
 
-#: ../src/html/chm.cpp:345
+#: ../src/html/chm.cpp:342
 msgid "checksum error"
 msgstr "checksummefel"
 
-#: ../src/common/tarstrm.cpp:820
+#: ../src/common/tarstrm.cpp:814
 msgid "checksum failure reading tar header block"
 msgstr "checksumma misslyckades när tar-huvudblock lästes"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:226
-#: ../src/richtext/richtextbackgroundpage.cpp:249
-#: ../src/richtext/richtextbackgroundpage.cpp:289
-#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
 #: ../src/richtext/richtextborderspage.cpp:254
 #: ../src/richtext/richtextborderspage.cpp:288
 #: ../src/richtext/richtextborderspage.cpp:322
@@ -8305,105 +8498,128 @@ msgstr "checksumma misslyckades när tar-huvudblock lästes"
 #: ../src/richtext/richtextmarginspage.cpp:340
 #: ../src/richtext/richtextmarginspage.cpp:363
 #: ../src/richtext/richtextmarginspage.cpp:388
-#: ../src/richtext/richtextsizepage.cpp:339
-#: ../src/richtext/richtextsizepage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:400
-#: ../src/richtext/richtextsizepage.cpp:427
-#: ../src/richtext/richtextsizepage.cpp:454
-#: ../src/richtext/richtextsizepage.cpp:481
-#: ../src/richtext/richtextsizepage.cpp:555
-#: ../src/richtext/richtextsizepage.cpp:590
-#: ../src/richtext/richtextsizepage.cpp:625
-#: ../src/richtext/richtextsizepage.cpp:660
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
 msgid "cm"
 msgstr "cm"
 
-#: ../src/html/chm.cpp:347
+#: ../src/html/chm.cpp:344
 msgid "compression error"
 msgstr "kompressionsfel"
 
-#: ../src/common/regex.cpp:236
+#: ../src/common/regex.cpp:233
 msgid "conversion to 8-bit encoding failed"
 msgstr "omvandling till 8-bitskodning misslyckades"
 
-#: ../src/common/accelcmn.cpp:187
+#: ../src/common/accelcmn.cpp:186
 msgid "ctrl"
 msgstr "ctrl"
 
-#: ../src/common/cmdline.cpp:1500
+#: ../src/common/cmdline.cpp:1496
 msgid "date"
 msgstr "datum"
 
-#: ../src/html/chm.cpp:349
+#: ../src/html/chm.cpp:346
 msgid "decompression error"
 msgstr "dekompressionsfel"
 
-#: ../src/richtext/richtextstyles.cpp:780 ../src/common/fmapbase.cpp:820
+#: ../src/common/fmapbase.cpp:816 ../src/richtext/richtextstyles.cpp:777
 msgid "default"
 msgstr "förvald"
 
-#: ../src/common/cmdline.cpp:1496
+#: ../src/common/cmdline.cpp:1492
 msgid "double"
 msgstr "flyttal"
 
-#: ../src/common/debugrpt.cpp:538
+#: ../src/common/debugrpt.cpp:539
 msgid "dump of the process state (binary)"
 msgstr "dump av processtillståndet (binärt)"
 
-#: ../src/common/datetimefmt.cpp:1969
+#: ../src/common/datetimefmt.cpp:1992
 msgid "eighteenth"
 msgstr "artonde"
 
-#: ../src/common/datetimefmt.cpp:1959
+#: ../src/common/datetimefmt.cpp:1982
 msgid "eighth"
 msgstr "åttonde"
 
-#: ../src/common/datetimefmt.cpp:1962
+#: ../src/common/datetimefmt.cpp:1985
 msgid "eleventh"
 msgstr "elfte"
 
-#: ../src/common/fileconf.cpp:1833
+#: ../src/common/fileconf.cpp:1835
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "post \"%s\" förekommer mer än en gång i grupp \"%s\""
 
-#: ../src/html/chm.cpp:343
+#: ../src/html/chm.cpp:340
 msgid "error in data format"
 msgstr "fel i dataformat"
 
-#: ../src/html/chm.cpp:331
+#: ../src/html/chm.cpp:328
 msgid "error opening file"
 msgstr "fel vid öppning av fil"
 
-#: ../src/common/zipstrm.cpp:1778
+#: ../src/common/zipstrm.cpp:1836
 msgid "error reading zip central directory"
 msgstr "fel vid läsning av central katalog i zip"
 
-#: ../src/common/zipstrm.cpp:1870
+#: ../src/common/zipstrm.cpp:1940
 msgid "error reading zip local header"
 msgstr "fel vid läsning av lokalt ziphuvud"
 
-#: ../src/common/zipstrm.cpp:2531
+#: ../src/common/zipstrm.cpp:2615
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "fel vid skrivning av zip-post \"%s\": Felaktig crc eller längd"
 
-#: ../src/common/ffile.cpp:188
+#: ../src/common/zipstrm.cpp:2608
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "fel vid skrivning av zip-post \"%s\": Felaktig crc eller längd"
+
+#: ../src/common/fontcmn.cpp:1205
+#, fuzzy
+msgid "extrabold"
+msgstr "fet"
+
+#: ../src/common/fontcmn.cpp:1223
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1167
+#, fuzzy
+msgid "extralight"
+msgstr "tunn"
+
+#: ../src/msw/webview_ie.cpp:1036
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "Kunde inte utföra \"%s\"\n"
+
+#: ../src/common/ffile.cpp:187
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "misslyckades att spola filen \"%s\""
 
+#: ../src/msw/webview_ie.cpp:1045
+#, fuzzy
+msgid "failed to retrieve execution result"
+msgstr "Kunde inte hämta text från RAS-felmeddelande"
+
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1030
+#: ../src/generic/datavgen.cpp:1150
 #, fuzzy
 msgid "false"
 msgstr "Falskt"
 
-#: ../src/common/datetimefmt.cpp:1966
+#: ../src/common/datetimefmt.cpp:1989
 msgid "fifteenth"
 msgstr "femtonde"
 
-#: ../src/common/datetimefmt.cpp:1956
+#: ../src/common/datetimefmt.cpp:1979
 msgid "fifth"
 msgstr "femte"
 
@@ -8432,131 +8648,150 @@ msgstr "fil \"%s\", rad %d: Värde för ej skrivbar nyckel \"%s\" ignoreras."
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "fil \"%s\": Oväntat tecken %c på rad %d."
 
-#: ../src/richtext/richtextbuffer.cpp:8738
+#: ../src/richtext/richtextbuffer.cpp:8736
 msgid "files"
 msgstr "filer"
 
-#: ../src/common/datetimefmt.cpp:1952
+#: ../src/common/datetimefmt.cpp:1975
 msgid "first"
 msgstr "första"
 
-#: ../src/html/helpwnd.cpp:1252
+#: ../src/html/helpwnd.cpp:1250
 msgid "font size"
 msgstr "typsnittsstorlek"
 
-#: ../src/common/datetimefmt.cpp:1965
+#: ../src/common/datetimefmt.cpp:1988
 msgid "fourteenth"
 msgstr "fjortonde"
 
-#: ../src/common/datetimefmt.cpp:1955
+#: ../src/common/datetimefmt.cpp:1978
 msgid "fourth"
 msgstr "fjärde"
 
-#: ../src/common/appbase.cpp:783
+#: ../src/common/appbase.cpp:784
 msgid "generate verbose log messages"
 msgstr "skapa mångordiga loggmeddelanden"
 
-#: ../src/richtext/richtextbuffer.cpp:13138
-#: ../src/richtext/richtextbuffer.cpp:13248
+#: ../src/common/fontcmn.cpp:1215
+msgid "heavy"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:13133
+#: ../src/richtext/richtextbuffer.cpp:13243
 msgid "image"
 msgstr "bild"
 
-#: ../src/common/tarstrm.cpp:796
+#: ../src/common/tarstrm.cpp:790
 msgid "incomplete header block in tar"
 msgstr "ofullständigt huvudblock i tar"
 
-#: ../src/common/xtixml.cpp:489
+#: ../src/common/xtixml.cpp:485
 msgid "incorrect event handler string, missing dot"
 msgstr "felaktig händelsehanterarsträng, punkt saknas"
 
-#: ../src/common/tarstrm.cpp:1381
+#: ../src/common/tarstrm.cpp:1375
 msgid "incorrect size given for tar entry"
 msgstr "felaktig storlek angiven för tar-post"
 
-#: ../src/common/tarstrm.cpp:993
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:987
 msgid "invalid data in extended tar header"
 msgstr "felaktigt data i utökat tar-huvud"
 
-#: ../src/generic/logg.cpp:1030
+#: ../src/generic/logg.cpp:1027
 msgid "invalid message box return value"
 msgstr "ogilitigt returvärde för meddelandedialog"
 
-#: ../src/common/zipstrm.cpp:1647
+#: ../src/common/zipstrm.cpp:1688
 msgid "invalid zip file"
 msgstr "ogiltig zip-fil"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:1228
 msgid "italic"
 msgstr "kursiv"
 
-#: ../src/common/fontcmn.cpp:991
+#: ../src/common/webrequest_curl.cpp:374
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "Kolumnbeskrivning kunde inte initieras."
+
+#: ../src/common/fontcmn.cpp:1172
 msgid "light"
 msgstr "tunn"
 
-#: ../src/common/intl.cpp:303
-#, c-format
-msgid "locale '%s' cannot be set."
-msgstr "lokal \"%s\" kan inte anges."
+#: ../src/common/fontcmn.cpp:1185
+msgid "medium"
+msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2125
+#: ../src/common/datetimefmt.cpp:2148
 msgid "midnight"
 msgstr "midnatt"
 
-#: ../src/common/datetimefmt.cpp:1970
+#: ../src/common/datetimefmt.cpp:1993
 msgid "nineteenth"
 msgstr "nittonde"
 
-#: ../src/common/datetimefmt.cpp:1960
+#: ../src/common/datetimefmt.cpp:1983
 msgid "ninth"
 msgstr "nionde"
 
-#: ../src/msw/dde.cpp:1116
+#: ../src/msw/dde.cpp:1180
 msgid "no DDE error."
 msgstr "inget DDE-fel."
 
-#: ../src/html/chm.cpp:327
+#: ../src/html/chm.cpp:324
 msgid "no error"
 msgstr "inget fel"
 
-#: ../src/dfb/fontmgr.cpp:174
+#: ../src/dfb/fontmgr.cpp:171
 #, c-format
 msgid "no fonts found in %s, using builtin font"
 msgstr "inga typsnitt hittades i %s, använder inbyggt typsnitt"
 
-#: ../src/html/helpdata.cpp:657
+#: ../src/html/helpdata.cpp:650
 msgid "noname"
 msgstr "namnlös"
 
-#: ../src/common/datetimefmt.cpp:2124
+#: ../src/common/datetimefmt.cpp:2147
 msgid "noon"
 msgstr "middag"
 
-#: ../src/richtext/richtextstyles.cpp:779
+#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "normal"
 
-#: ../src/common/cmdline.cpp:1492
+#: ../src/common/cmdline.cpp:1488
 msgid "num"
 msgstr "num"
 
-#: ../src/common/xtixml.cpp:259
+#: ../src/common/accelcmn.cpp:194
+msgid "num "
+msgstr ""
+
+#: ../src/common/xtixml.cpp:255
 msgid "objects cannot have XML Text Nodes"
 msgstr "objekt kan inte ha XML-textnoder"
 
-#: ../src/html/chm.cpp:339
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
 msgid "out of memory"
 msgstr "slut på minne"
 
-#: ../src/common/debugrpt.cpp:514
+#: ../src/common/debugrpt.cpp:515
 msgid "process context description"
 msgstr "beskrivning av processammanhang"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:227
-#: ../src/richtext/richtextbackgroundpage.cpp:250
-#: ../src/richtext/richtextbackgroundpage.cpp:290
-#: ../src/richtext/richtextbackgroundpage.cpp:317
-#: ../src/richtext/richtextfontpage.cpp:177
-#: ../src/richtext/richtextfontpage.cpp:180
 #: ../src/richtext/richtextborderspage.cpp:255
 #: ../src/richtext/richtextborderspage.cpp:289
 #: ../src/richtext/richtextborderspage.cpp:323
@@ -8566,22 +8801,45 @@ msgstr "beskrivning av processammanhang"
 #: ../src/richtext/richtextborderspage.cpp:491
 #: ../src/richtext/richtextborderspage.cpp:525
 #: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextfontpage.cpp:180
 msgid "pt"
 msgstr "pt"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:225
-#: ../src/richtext/richtextbackgroundpage.cpp:228
-#: ../src/richtext/richtextbackgroundpage.cpp:229
-#: ../src/richtext/richtextbackgroundpage.cpp:248
-#: ../src/richtext/richtextbackgroundpage.cpp:251
-#: ../src/richtext/richtextbackgroundpage.cpp:252
-#: ../src/richtext/richtextbackgroundpage.cpp:288
-#: ../src/richtext/richtextbackgroundpage.cpp:291
-#: ../src/richtext/richtextbackgroundpage.cpp:292
-#: ../src/richtext/richtextbackgroundpage.cpp:315
-#: ../src/richtext/richtextbackgroundpage.cpp:318
-#: ../src/richtext/richtextbackgroundpage.cpp:319
-#: ../src/richtext/richtextfontpage.cpp:178
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:659
+#: ../src/richtext/richtextsizepage.cpp:662
+#: ../src/richtext/richtextsizepage.cpp:663
 #: ../src/richtext/richtextborderspage.cpp:253
 #: ../src/richtext/richtextborderspage.cpp:256
 #: ../src/richtext/richtextborderspage.cpp:257
@@ -8633,260 +8891,270 @@ msgstr "pt"
 #: ../src/richtext/richtextmarginspage.cpp:387
 #: ../src/richtext/richtextmarginspage.cpp:389
 #: ../src/richtext/richtextmarginspage.cpp:390
-#: ../src/richtext/richtextsizepage.cpp:338
-#: ../src/richtext/richtextsizepage.cpp:341
-#: ../src/richtext/richtextsizepage.cpp:342
-#: ../src/richtext/richtextsizepage.cpp:372
-#: ../src/richtext/richtextsizepage.cpp:375
-#: ../src/richtext/richtextsizepage.cpp:376
-#: ../src/richtext/richtextsizepage.cpp:399
-#: ../src/richtext/richtextsizepage.cpp:402
-#: ../src/richtext/richtextsizepage.cpp:403
-#: ../src/richtext/richtextsizepage.cpp:426
-#: ../src/richtext/richtextsizepage.cpp:429
-#: ../src/richtext/richtextsizepage.cpp:430
-#: ../src/richtext/richtextsizepage.cpp:453
-#: ../src/richtext/richtextsizepage.cpp:456
-#: ../src/richtext/richtextsizepage.cpp:457
-#: ../src/richtext/richtextsizepage.cpp:480
-#: ../src/richtext/richtextsizepage.cpp:483
-#: ../src/richtext/richtextsizepage.cpp:484
-#: ../src/richtext/richtextsizepage.cpp:554
-#: ../src/richtext/richtextsizepage.cpp:557
-#: ../src/richtext/richtextsizepage.cpp:558
-#: ../src/richtext/richtextsizepage.cpp:589
-#: ../src/richtext/richtextsizepage.cpp:592
-#: ../src/richtext/richtextsizepage.cpp:593
-#: ../src/richtext/richtextsizepage.cpp:624
-#: ../src/richtext/richtextsizepage.cpp:627
-#: ../src/richtext/richtextsizepage.cpp:628
-#: ../src/richtext/richtextsizepage.cpp:659
-#: ../src/richtext/richtextsizepage.cpp:662
-#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextfontpage.cpp:178
 msgid "px"
 msgstr "px"
 
-#: ../src/common/accelcmn.cpp:193
+#: ../src/common/accelcmn.cpp:192
 msgid "rawctrl"
 msgstr "obehandladctrl"
 
-#: ../src/html/chm.cpp:333
+#: ../src/html/chm.cpp:330
 msgid "read error"
 msgstr "läsfel"
 
-#: ../src/common/zipstrm.cpp:2085
+#: ../src/common/zipstrm.cpp:2155
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "läser zip-ström (post %s): Felaktig crc"
 
-#: ../src/common/zipstrm.cpp:2080
+#: ../src/common/zipstrm.cpp:2150
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "läser zip-ström (post %s): Felaktig längd"
 
-#: ../src/msw/dde.cpp:1159
+#: ../src/msw/dde.cpp:1223
 msgid "reentrancy problem."
 msgstr "återinträdesproblem."
 
-#: ../src/common/datetimefmt.cpp:1953
+#: ../src/common/datetimefmt.cpp:1976
 msgid "second"
 msgstr "andra"
 
-#: ../src/html/chm.cpp:337
+#: ../src/html/chm.cpp:334
 msgid "seek error"
 msgstr "sökfel"
 
-#: ../src/common/datetimefmt.cpp:1968
+#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#, fuzzy
+msgid "semibold"
+msgstr "fet"
+
+#: ../src/common/datetimefmt.cpp:1991
 msgid "seventeenth"
 msgstr "sjuttonde"
 
-#: ../src/common/datetimefmt.cpp:1958
+#: ../src/common/datetimefmt.cpp:1981
 msgid "seventh"
 msgstr "sjunde"
 
-#: ../src/common/accelcmn.cpp:191
+#: ../src/common/accelcmn.cpp:190
 msgid "shift"
 msgstr "skift"
 
-#: ../src/common/appbase.cpp:773
+#: ../src/common/appbase.cpp:774
 msgid "show this help message"
 msgstr "visa detta hjälpmeddelande"
 
-#: ../src/common/datetimefmt.cpp:1967
+#: ../src/common/datetimefmt.cpp:1990
 msgid "sixteenth"
 msgstr "sextonde"
 
-#: ../src/common/datetimefmt.cpp:1957
+#: ../src/common/datetimefmt.cpp:1980
 msgid "sixth"
 msgstr "sjätte"
 
-#: ../src/common/appcmn.cpp:234
+#: ../src/common/appcmn.cpp:255
 msgid "specify display mode to use (e.g. 640x480-16)"
 msgstr "ange visningsläge att använda (t.ex. 640x480-16)"
 
-#: ../src/common/appcmn.cpp:220
+#: ../src/common/appcmn.cpp:241
 msgid "specify the theme to use"
 msgstr "ange tema att använda"
 
-#: ../src/richtext/richtextbuffer.cpp:9340
+#: ../src/richtext/richtextbuffer.cpp:9337
 msgid "standard/circle"
 msgstr "standard/cirkel"
 
-#: ../src/richtext/richtextbuffer.cpp:9341
+#: ../src/richtext/richtextbuffer.cpp:9338
 msgid "standard/circle-outline"
 msgstr "standard/cirkelram"
 
-#: ../src/richtext/richtextbuffer.cpp:9343
+#: ../src/richtext/richtextbuffer.cpp:9340
 msgid "standard/diamond"
 msgstr "standard/diamant"
 
-#: ../src/richtext/richtextbuffer.cpp:9342
+#: ../src/richtext/richtextbuffer.cpp:9339
 msgid "standard/square"
 msgstr "standard/kvadrat"
 
-#: ../src/richtext/richtextbuffer.cpp:9344
+#: ../src/richtext/richtextbuffer.cpp:9341
 msgid "standard/triangle"
 msgstr "standard/triangel"
 
-#: ../src/common/zipstrm.cpp:1985
+#: ../src/common/zipstrm.cpp:2055
 msgid "stored file length not in Zip header"
 msgstr "lagrad fillängd finns inte i Zip-huvud"
 
-#: ../src/common/cmdline.cpp:1488
+#: ../src/common/cmdline.cpp:1484
 msgid "str"
 msgstr "str"
 
-#: ../src/common/fontcmn.cpp:982
+#: ../src/common/fontcmn.cpp:1145
 msgid "strikethrough"
 msgstr "genomstruken"
 
-#: ../src/common/tarstrm.cpp:1003 ../src/common/tarstrm.cpp:1025
-#: ../src/common/tarstrm.cpp:1507 ../src/common/tarstrm.cpp:1529
+#: ../src/common/tarstrm.cpp:997 ../src/common/tarstrm.cpp:1019
+#: ../src/common/tarstrm.cpp:1501 ../src/common/tarstrm.cpp:1523
 msgid "tar entry not open"
 msgstr "tar-post är inte öppen"
 
-#: ../src/common/datetimefmt.cpp:1961
+#: ../src/common/datetimefmt.cpp:1984
 msgid "tenth"
 msgstr "tionde"
 
-#: ../src/msw/dde.cpp:1123
+#: ../src/msw/dde.cpp:1187
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "svaret på transaktionen gjorde att DDE_FBUSY-biten sattes."
 
-#: ../src/common/datetimefmt.cpp:1954
+#: ../src/common/fontcmn.cpp:1154
+msgid "thin"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:1977
 msgid "third"
 msgstr "tredje"
 
-#: ../src/common/datetimefmt.cpp:1964
+#: ../src/common/datetimefmt.cpp:1987
 msgid "thirteenth"
 msgstr "trettonde"
 
-#: ../src/common/datetimefmt.cpp:1758
+#: ../src/common/datetimefmt.cpp:1781
 msgid "today"
 msgstr "idag"
 
-#: ../src/common/datetimefmt.cpp:1760
+#: ../src/common/datetimefmt.cpp:1783
 msgid "tomorrow"
 msgstr "i morgon"
 
-#: ../src/common/fileconf.cpp:1944
+#: ../src/common/fileconf.cpp:1946
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "avslutande omvänt snedsträck ignorerades i \"%s\""
 
-#: ../src/gtk/aboutdlg.cpp:218
+#: ../src/gtk/aboutdlg.cpp:216
 msgid "translator-credits"
 msgstr "Jonas Rydberg"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1028
+#: ../src/generic/datavgen.cpp:1148
 msgid "true"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1963
+#: ../src/common/datetimefmt.cpp:1986
 msgid "twelfth"
 msgstr "tolfte"
 
-#: ../src/common/datetimefmt.cpp:1971
+#: ../src/common/datetimefmt.cpp:1994
 msgid "twentieth"
 msgstr "tjugonde"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:486 ../src/generic/datavgen.cpp:1263
+#: ../src/common/datavcmn.cpp:2068 ../src/generic/datavgen.cpp:1386
 msgid "unchecked"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:802 ../src/common/fontcmn.cpp:978
+#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
 msgid "underlined"
 msgstr "understruken"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:490
+#: ../src/common/datavcmn.cpp:2072
 #, fuzzy
 msgid "undetermined"
 msgstr "understruken"
 
-#: ../src/common/fileconf.cpp:1979
+#: ../src/common/fileconf.cpp:1981
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "oväntat \" på position %d i \"%s\"."
 
-#: ../src/common/tarstrm.cpp:1045
+#: ../src/common/tarstrm.cpp:1039
 msgid "unexpected end of file"
 msgstr "oväntat slut på filen"
 
-#: ../src/generic/progdlgg.cpp:370 ../src/common/tarstrm.cpp:371
-#: ../src/common/tarstrm.cpp:394 ../src/common/tarstrm.cpp:425
+#: ../src/common/tarstrm.cpp:366 ../src/common/tarstrm.cpp:389
+#: ../src/common/tarstrm.cpp:420 ../src/generic/progdlgg.cpp:376
 msgid "unknown"
 msgstr "okänd"
 
-#: ../src/msw/registry.cpp:150
+#: ../src/msw/registry.cpp:139
 #, fuzzy, c-format
 msgid "unknown (%lu)"
 msgstr "okänd"
 
-#: ../src/common/xtixml.cpp:253
+#: ../src/common/xtixml.cpp:249
 #, c-format
 msgid "unknown class %s"
 msgstr "okänd klass %s"
 
-#: ../src/common/regex.cpp:258 ../src/html/chm.cpp:351
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "kompressionsfel"
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "dekompressionsfel"
+
+#: ../src/common/regex.cpp:255 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "okänt fel"
 
-#: ../src/msw/dialup.cpp:471
+#: ../src/msw/dialup.cpp:465
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "okänt fel (felkod %08x)."
 
-#: ../src/common/fmapbase.cpp:834
+#: ../src/common/fmapbase.cpp:830
 #, c-format
 msgid "unknown-%d"
 msgstr "okänd-%d"
 
-#: ../src/common/docview.cpp:509
+#: ../src/common/docview.cpp:502
 msgid "unnamed"
 msgstr "namnlös"
 
-#: ../src/common/docview.cpp:1624
+#: ../src/common/docview.cpp:1618
 #, c-format
 msgid "unnamed%d"
 msgstr "namnlös%d"
 
-#: ../src/common/zipstrm.cpp:1999 ../src/common/zipstrm.cpp:2319
+#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
 msgid "unsupported Zip compression method"
 msgstr "komprimeringsmetod i Zip stöds inte"
 
-#: ../src/common/translation.cpp:1892
+#: ../src/common/translation.cpp:1942
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "använder katalog \"%s\" från \"%s\"."
 
-#: ../src/html/chm.cpp:335
+#: ../src/html/chm.cpp:332
 msgid "write error"
 msgstr "skrivfel"
 
-#: ../src/common/time.cpp:292
+#: ../src/gtk/glcanvas.cpp:187
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/common/time.cpp:285
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay misslyckades."
 
@@ -8899,15 +9167,15 @@ msgstr "wxWidgets kunde inte öppna skärm för \"%s\": Avslutar."
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets kunde inte öppna display. Avslutar."
 
-#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:431
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/common/datetimefmt.cpp:1759
+#: ../src/common/datetimefmt.cpp:1782
 msgid "yesterday"
 msgstr "igår"
 
-#: ../src/common/zstream.cpp:251 ../src/common/zstream.cpp:426
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
 #, c-format
 msgid "zlib error %d"
 msgstr "zlib-fel %d"
@@ -8916,6 +9184,77 @@ msgstr "zlib-fel %d"
 #: ../src/richtext/richtextbulletspage.cpp:288
 msgid "~"
 msgstr "~"
+
+#~ msgid "&Save as"
+#~ msgstr "Spara s&om"
+
+#, fuzzy
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "\"%s\" får bara innehålla alfabetiska tecken."
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "\"%s\" skall vara numerisk."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "\"%s\" får bara innehålla ASCII-tecken."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "\"%s\" får bara innehålla alfabetiska tecken."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "\"%s\" får bara innehålla alfabetiska eller numeriska tecken."
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "\"%s\" får bara innehålla siffror."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "Kan inte skapa fönster av klass %s"
+
+#, fuzzy
+#~ msgid "Could not initalize libnotify."
+#~ msgstr "Kunde inte ange justering."
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "Kunde inte skapa överläggsfönster"
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "Kunde inte initera kontexten på överläggsfönstret"
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "Kunde inte konvertera filen \"%s\" till Unicode."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "Misslyckades med att ange text i textkontrollen."
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr "Ogiltigt GTK+ kommandoradsargument, använd \"%s --help\""
+
+#~ msgid "No unused colour in image."
+#~ msgstr "Ingen oanvänd färg bilden."
+
+#~ msgid "Not available"
+#~ msgstr "Inte tillgängligt"
+
+#~ msgid "Replace selection"
+#~ msgstr "Ersätt markerat"
+
+#~ msgid "Save as"
+#~ msgstr "Spara som"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Stilorganiserare"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "Följande GTK+ standardalternativ stöds också:\n"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "Du kan inte tömma ett överlägg som inte är initierat"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "Du kan inte initiera överlägg två gånger"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "lokal \"%s\" kan inte anges."
 
 #~ msgid "Adding flavor TEXT failed"
 #~ msgstr "Kunde inte lägga till typ TEXT"
@@ -8934,9 +9273,6 @@ msgstr "~"
 
 #~ msgid "Column could not be added."
 #~ msgstr "Kolumn kunde inte läggas till."
-
-#~ msgid "Column description could not be initialized."
-#~ msgstr "Kolumnbeskrivning kunde inte initieras."
 
 #~ msgid "Column index not found."
 #~ msgstr "Kolumnindex hittades inte."
@@ -9481,9 +9817,6 @@ msgstr "~"
 #~ msgid "Directory '%s' doesn't exist!"
 #~ msgstr "Katalogen \"%s\" finns inte!"
 
-#~ msgid "File %s does not exist."
-#~ msgstr "Filen %s finns inte."
-
 #~ msgid "Mode %ix%i-%i not available."
 #~ msgstr "Läge %ix%i-%i är inte tillgängligt."
 
@@ -9574,9 +9907,6 @@ msgstr "~"
 
 #~ msgid "Failed to register OpenGL window class."
 #~ msgstr "Kunde inte registrera OpenGL-fönsterklass."
-
-#~ msgid "Fatal error"
-#~ msgstr "Ödesdigert fel"
 
 #~ msgid "Fatal error: "
 #~ msgstr "Ödesdigert fel: "
@@ -9759,9 +10089,6 @@ msgstr "~"
 
 #~ msgid "&Print"
 #~ msgstr "Skriv &ut"
-
-#~ msgid "*** A debug report has been generated\n"
-#~ msgstr "*** En debugrapport har skapats\n"
 
 #~ msgid "*** It can be found in \"%s\"\n"
 #~ msgstr "*** Den kan hittas i \"%s\"\n"

--- a/locale/ta.po
+++ b/locale/ta.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-21 14:25+0200\n"
+"POT-Creation-Date: 2020-10-18 23:11+0300\n"
 "PO-Revision-Date: 2014-02-24 21:51+0530\n"
 "Last-Translator: DINAKAR T.D. <td.dinkar@gmail.com>\n"
 "Language-Team: DINAKAR T.D. <td.dinkar@gmail.com>\n"
@@ -13,7 +13,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 1.5.7\n"
 
-#: ../src/common/debugrpt.cpp:586
+#: ../src/common/debugrpt.cpp:587
 msgid ""
 "\n"
 "Please send this report to the program maintainer, thank you!\n"
@@ -21,8 +21,8 @@ msgstr ""
 "\n"
 "இந்த அறிக்கையை கருணைக் கூர்ந்து நிரல் காப்பாளரிடம் அனுப்பி வைக்கவும், நன்றி! \n"
 
-#: ../src/richtext/richtextstyledlg.cpp:210
-#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:206
+#: ../src/richtext/richtextstyledlg.cpp:218
 msgid " "
 msgstr " "
 
@@ -30,70 +30,96 @@ msgstr " "
 msgid "              Thank you and we're sorry for the inconvenience!\n"
 msgstr "நன்றி. தங்களுக்கு ஏற்பட்டுள்ள இடையூறுக்கு வருந்துகிறோம்! \n"
 
-#: ../src/common/prntbase.cpp:573
+#: ../src/common/prntbase.cpp:568
 #, c-format
 msgid " (copy %d of %d)"
 msgstr "%d-யின் படி; மொத்தம் %d"
 
-#: ../src/common/log.cpp:421
+#: ../src/common/log.cpp:440
 #, c-format
 msgid " (error %ld: %s)"
 msgstr " (பிழை %ld: %s)"
 
-#: ../src/common/imagtiff.cpp:72
+#: ../src/common/imagtiff.cpp:69
 #, c-format
 msgid " (in module \"%s\")"
 msgstr " (\"%s\" நிரற்கூறில் உள்ளது)"
 
-#: ../src/osx/core/secretstore.cpp:138
-msgid " (while overwriting an existing item)"
-msgstr ""
-
-#: ../src/common/docview.cpp:1642
+#: ../src/common/docview.cpp:1636
 msgid " - "
 msgstr " - "
 
-#: ../src/richtext/richtextprint.cpp:593 ../src/html/htmprint.cpp:714
+#: ../src/html/htmprint.cpp:712 ../src/richtext/richtextprint.cpp:589
 msgid " Preview"
 msgstr "முன்தோற்றம்"
 
-#: ../src/common/fontcmn.cpp:824
+#: ../src/common/fontcmn.cpp:973
 msgid " bold"
 msgstr "அடர்த்தி"
 
-#: ../src/common/fontcmn.cpp:840
+#: ../src/common/fontcmn.cpp:977
+#, fuzzy
+msgid " extra bold"
+msgstr "அடர்த்தி"
+
+#: ../src/common/fontcmn.cpp:985
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:957
+#, fuzzy
+msgid " extra light"
+msgstr "இலகு"
+
+#: ../src/common/fontcmn.cpp:981
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1001
 msgid " italic"
 msgstr "வலப்பக்க சாய்வு"
 
-#: ../src/common/fontcmn.cpp:820
+#: ../src/common/fontcmn.cpp:961
 msgid " light"
 msgstr "இலகு"
 
-#: ../src/common/fontcmn.cpp:807
+#: ../src/common/fontcmn.cpp:965
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:969
+#, fuzzy
+msgid " semi bold"
+msgstr "அடர்த்தி"
+
+#: ../src/common/fontcmn.cpp:940
 msgid " strikethrough"
 msgstr " ஊடாகக் கோடிடப்பட்டது"
 
-#: ../src/common/paper.cpp:117
+#: ../src/common/fontcmn.cpp:953
+msgid " thin"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
 msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
 msgstr "#10 அஞ்சல் உறை, 4 1/8 x 9 1/2 in"
 
-#: ../src/common/paper.cpp:118
+#: ../src/common/paper.cpp:115
 msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
 msgstr "#11 அஞ்சல் உறை, 4 1/2 x 10 3/8 in"
 
-#: ../src/common/paper.cpp:119
+#: ../src/common/paper.cpp:116
 msgid "#12 Envelope, 4 3/4 x 11 in"
 msgstr "#12 அஞ்சல் உறை, 4 3/4 x 11 in"
 
-#: ../src/common/paper.cpp:120
+#: ../src/common/paper.cpp:117
 msgid "#14 Envelope, 5 x 11 1/2 in"
 msgstr "#14 அஞ்சல் உறை, 5 x 11 1/2 in"
 
-#: ../src/common/paper.cpp:116
+#: ../src/common/paper.cpp:113
 msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
 msgstr "#9 அஞ்சல் உறை, 3 7/8 x 8 7/8 in"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:341
 #: ../src/richtext/richtextsizepage.cpp:340
 #: ../src/richtext/richtextsizepage.cpp:374
 #: ../src/richtext/richtextsizepage.cpp:401
@@ -104,81 +130,82 @@ msgstr "#9 அஞ்சல் உறை, 3 7/8 x 8 7/8 in"
 #: ../src/richtext/richtextsizepage.cpp:591
 #: ../src/richtext/richtextsizepage.cpp:626
 #: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextbackgroundpage.cpp:341
 msgid "%"
 msgstr "%"
 
-#: ../src/html/helpwnd.cpp:1031
+#: ../src/html/helpwnd.cpp:1029
 #, c-format
 msgid "%d of %lu"
 msgstr "%d, மொத்தம் %lu"
 
-#: ../src/html/helpwnd.cpp:1678
+#: ../src/html/helpwnd.cpp:1676
 #, fuzzy, c-format
 msgid "%i of %u"
 msgstr "%i, மொத்தம் %i"
 
-#: ../src/generic/filectrlg.cpp:279
+#: ../src/generic/filectrlg.cpp:275
 #, c-format
 msgid "%ld byte"
 msgid_plural "%ld bytes"
 msgstr[0] "%ld byte"
 msgstr[1] "%ld bytes"
 
-#: ../src/html/helpwnd.cpp:1033
+#: ../src/html/helpwnd.cpp:1031
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu, மொத்தம் %lu"
 
-#: ../src/generic/datavgen.cpp:6028
+#: ../src/generic/datavgen.cpp:6833
 #, fuzzy, c-format
 msgid "%s (%d items)"
 msgstr "%s (அல்லது %s)"
 
-#: ../src/common/cmdline.cpp:1221
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (அல்லது %s)"
 
-#: ../src/generic/logg.cpp:224
+#: ../src/generic/logg.cpp:221
 #, c-format
 msgid "%s Error"
 msgstr "%s பிழை"
 
-#: ../src/generic/logg.cpp:236
+#: ../src/generic/logg.cpp:233
 #, c-format
 msgid "%s Information"
 msgstr "%s தகவல்"
 
-#: ../src/generic/preferencesg.cpp:113
+#: ../src/generic/preferencesg.cpp:110
 #, c-format
 msgid "%s Preferences"
 msgstr "%s முதன்மை விருப்பங்கள்"
 
-#: ../src/generic/logg.cpp:228
+#: ../src/generic/logg.cpp:225
 #, c-format
 msgid "%s Warning"
 msgstr "%s எச்சரிக்கை"
 
-#: ../src/common/tarstrm.cpp:1319
+#: ../src/common/tarstrm.cpp:1313
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s, '%s' உள்ளீட்டின் tar மேலுரைக்குள் பொருந்தவில்லை"
 
-#: ../src/common/fldlgcmn.cpp:124
+#: ../src/common/fldlgcmn.cpp:121
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s கோப்புகள் (%s)|%s"
 
-#: ../src/html/helpwnd.cpp:1716
+#: ../src/html/helpwnd.cpp:1714
 #, fuzzy, c-format
 msgid "%u of %u"
 msgstr "%lu, மொத்தம் %lu"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "&About"
 msgstr "குறித்து..."
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "&Actual Size"
 msgstr "மெய்யளவு"
 
@@ -186,28 +213,28 @@ msgstr "மெய்யளவு"
 msgid "&After a paragraph:"
 msgstr "ஒரு பத்திக்குப் பிறகு"
 
-#: ../src/richtext/richtextindentspage.cpp:128
 #: ../src/richtext/richtextliststylepage.cpp:319
+#: ../src/richtext/richtextindentspage.cpp:128
 msgid "&Alignment"
 msgstr "ஒழுங்கமைப்பு"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "&Apply"
 msgstr "இடு"
 
-#: ../src/richtext/richtextstyledlg.cpp:251
+#: ../src/richtext/richtextstyledlg.cpp:247
 msgid "&Apply Style"
 msgstr "பாங்கினை இடு"
 
-#: ../src/msw/mdi.cpp:179
+#: ../src/msw/mdi.cpp:174
 msgid "&Arrange Icons"
 msgstr "படவுருக்களை ஒழுங்கமை"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "&Ascending"
 msgstr "ஏறுமுகம்"
 
-#: ../src/common/stockitem.cpp:142
+#: ../src/common/stockitem.cpp:139
 msgid "&Back"
 msgstr "பின்"
 
@@ -227,24 +254,24 @@ msgstr "பின்னணி நிறம்:"
 msgid "&Blur distance:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:143
+#: ../src/common/stockitem.cpp:140
 msgid "&Bold"
 msgstr "அடர்த்தி"
 
-#: ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141
 msgid "&Bottom"
 msgstr "அடித்தளம்"
 
+#: ../src/richtext/richtextsizepage.cpp:637
+#: ../src/richtext/richtextsizepage.cpp:644
 #: ../src/richtext/richtextborderspage.cpp:345
 #: ../src/richtext/richtextborderspage.cpp:513
 #: ../src/richtext/richtextmarginspage.cpp:259
 #: ../src/richtext/richtextmarginspage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:637
-#: ../src/richtext/richtextsizepage.cpp:644
 msgid "&Bottom:"
 msgstr "அடித்தளம்"
 
-#: ../include/wx/richtext/richtextbuffer.h:3866
+#: ../include/wx/richtext/richtextbuffer.h:3861
 msgid "&Box"
 msgstr "பெட்டி"
 
@@ -253,38 +280,38 @@ msgstr "பெட்டி"
 msgid "&Bullet style:"
 msgstr "தோட்டாப் பாங்கு"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "&CD-Rom"
 msgstr "குறுந்தட்டு நினைவகம்"
 
-#: ../src/generic/wizard.cpp:434 ../src/generic/fontdlgg.cpp:470
-#: ../src/generic/fontdlgg.cpp:489 ../src/osx/carbon/fontdlg.cpp:402
-#: ../src/common/dlgcmn.cpp:279 ../src/common/stockitem.cpp:145
+#: ../src/osx/carbon/fontdlg.cpp:399 ../src/common/stockitem.cpp:142
+#: ../src/generic/wizard.cpp:433 ../src/generic/fontdlgg.cpp:466
+#: ../src/generic/fontdlgg.cpp:485 ../src/osx/cocoa/button.mm:200
 msgid "&Cancel"
 msgstr "விலக்குக"
 
-#: ../src/msw/mdi.cpp:175
+#: ../src/msw/mdi.cpp:170
 msgid "&Cascade"
 msgstr "அடுத்தடுத்த நிலை"
 
-#: ../include/wx/richtext/richtextbuffer.h:5960
+#: ../include/wx/richtext/richtextbuffer.h:5955
 msgid "&Cell"
 msgstr "சிறுகட்டம்"
 
-#: ../src/richtext/richtextsymboldlg.cpp:439
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "&Character code:"
 msgstr "வரியுருக் குறி"
 
-#: ../src/common/stockitem.cpp:147
+#: ../src/common/stockitem.cpp:144
 msgid "&Clear"
 msgstr "துடை"
 
-#: ../src/generic/logg.cpp:516 ../src/common/stockitem.cpp:148
-#: ../src/common/prntbase.cpp:1600 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/stockitem.cpp:145 ../src/common/prntbase.cpp:1625
+#: ../src/univ/themes/win32.cpp:3753 ../src/generic/logg.cpp:513
 msgid "&Close"
 msgstr "மூடுக"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "&Color"
 msgstr "நிறம்"
 
@@ -292,20 +319,20 @@ msgstr "நிறம்"
 msgid "&Colour:"
 msgstr "நிறம்"
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "&Convert"
 msgstr "மாற்று"
 
-#: ../src/richtext/richtextctrl.cpp:333 ../src/osx/textctrl_osx.cpp:577
-#: ../src/common/stockitem.cpp:150 ../src/msw/textctrl.cpp:2508
+#: ../src/osx/textctrl_osx.cpp:595 ../src/common/stockitem.cpp:147
+#: ../src/msw/textctrl.cpp:2773 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "படியெடு"
 
-#: ../src/generic/hyperlinkg.cpp:156
+#: ../src/generic/hyperlinkg.cpp:153
 msgid "&Copy URL"
 msgstr "இணைய முகவரியை படியெடு"
 
-#: ../src/common/headerctrlcmn.cpp:306
+#: ../src/common/headerctrlcmn.cpp:304
 msgid "&Customize..."
 msgstr "தனிப் பயனாக்கு..."
 
@@ -313,53 +340,54 @@ msgstr "தனிப் பயனாக்கு..."
 msgid "&Debug report preview:"
 msgstr "வழுநீக்க அரிக்கை முன்தோற்றம்"
 
-#: ../src/richtext/richtexttabspage.cpp:138
-#: ../src/richtext/richtextctrl.cpp:335 ../src/osx/textctrl_osx.cpp:579
-#: ../src/common/stockitem.cpp:152 ../src/msw/textctrl.cpp:2510
+#: ../src/osx/textctrl_osx.cpp:597 ../src/common/stockitem.cpp:149
+#: ../src/msw/textctrl.cpp:2775 ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtextctrl.cpp:334
 msgid "&Delete"
 msgstr "அழி"
 
-#: ../src/richtext/richtextstyledlg.cpp:269
+#: ../src/richtext/richtextstyledlg.cpp:265
 msgid "&Delete Style..."
 msgstr "பாங்கினை அழி"
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "&Descending"
 msgstr "இறங்குமுகம்"
 
-#: ../src/generic/logg.cpp:682
+#: ../src/generic/logg.cpp:679
 msgid "&Details"
 msgstr "விவரங்கள்"
 
-#: ../src/common/stockitem.cpp:153
+#: ../src/common/stockitem.cpp:150
 msgid "&Down"
 msgstr "கீழ்"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "&Edit"
 msgstr "தொகு"
 
-#: ../src/richtext/richtextstyledlg.cpp:263
+#: ../src/richtext/richtextstyledlg.cpp:259
 msgid "&Edit Style..."
 msgstr "பாங்கினைத் தொகு"
 
-#: ../src/common/stockitem.cpp:155
+#: ../src/common/stockitem.cpp:152
 msgid "&Execute"
 msgstr "செயற்படுத்து"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/common/stockitem.cpp:154
 msgid "&File"
 msgstr "கோப்பு"
 
-#: ../src/common/stockitem.cpp:158
-msgid "&Find"
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "&Find..."
 msgstr "கண்டுபிடி"
 
-#: ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:430
 msgid "&Finish"
 msgstr "நிறைவு செய்க"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:156
 msgid "&First"
 msgstr "முதல்"
 
@@ -367,15 +395,15 @@ msgstr "முதல்"
 msgid "&Floating mode:"
 msgstr "மிதக்கும் நிலை:"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "&Floppy"
 msgstr "நெகிழ்வட்டு"
 
-#: ../src/common/stockitem.cpp:194
+#: ../src/common/stockitem.cpp:191
 msgid "&Font"
 msgstr "எழுத்துரு"
 
-#: ../src/generic/fontdlgg.cpp:371
+#: ../src/generic/fontdlgg.cpp:367
 msgid "&Font family:"
 msgstr "எழுத்துரு குடும்பம்:"
 
@@ -383,20 +411,20 @@ msgstr "எழுத்துரு குடும்பம்:"
 msgid "&Font for Level..."
 msgstr "மட்டத்திற்கான எழுத்துரு:"
 
+#: ../src/richtext/richtextsymboldlg.cpp:397
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:400
 msgid "&Font:"
 msgstr "எழுத்துரு"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "&Forward"
 msgstr "முன்நகர்"
 
-#: ../src/richtext/richtextsymboldlg.cpp:451
+#: ../src/richtext/richtextsymboldlg.cpp:448
 msgid "&From:"
 msgstr "அனுப்புநர்:"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "&Harddisk"
 msgstr "வன்தட்டு"
 
@@ -405,9 +433,9 @@ msgstr "வன்தட்டு"
 msgid "&Height:"
 msgstr "உயரம்:"
 
-#: ../src/generic/wizard.cpp:441 ../src/richtext/richtextstyledlg.cpp:303
-#: ../src/richtext/richtextsymboldlg.cpp:479 ../src/osx/menu_osx.cpp:734
-#: ../src/common/stockitem.cpp:163
+#: ../src/common/stockitem.cpp:160 ../src/generic/wizard.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextstyledlg.cpp:299 ../src/osx/cocoa/menu.mm:226
 msgid "&Help"
 msgstr "உதவி"
 
@@ -415,7 +443,7 @@ msgstr "உதவி"
 msgid "&Hide details"
 msgstr "விவரங்களை மறை"
 
-#: ../src/common/stockitem.cpp:164
+#: ../src/common/stockitem.cpp:161
 msgid "&Home"
 msgstr "முகப்பு"
 
@@ -424,54 +452,54 @@ msgstr "முகப்பு"
 msgid "&Horizontal offset:"
 msgstr "செங்குத்து எதிரிடை"
 
-#: ../src/richtext/richtextindentspage.cpp:184
 #: ../src/richtext/richtextliststylepage.cpp:372
+#: ../src/richtext/richtextindentspage.cpp:184
 msgid "&Indentation (tenths of a mm)"
 msgstr "வரித் துவக்க ஒழுங்கு (மில்லி மீட்டரின் பத்தில் ஒரு பகுதி)"
 
-#: ../src/richtext/richtextindentspage.cpp:167
 #: ../src/richtext/richtextliststylepage.cpp:356
+#: ../src/richtext/richtextindentspage.cpp:167
 msgid "&Indeterminate"
 msgstr "தேராதது"
 
-#: ../src/common/stockitem.cpp:166
+#: ../src/common/stockitem.cpp:163
 msgid "&Index"
 msgstr "சுட்டெண்"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "&Info"
 msgstr "தகவல்"
 
-#: ../src/common/stockitem.cpp:168
+#: ../src/common/stockitem.cpp:165
 msgid "&Italic"
 msgstr "வலப்பக்க சாய்வு"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "&Jump to"
 msgstr "இங்கே தாவு"
 
-#: ../src/richtext/richtextindentspage.cpp:153
 #: ../src/richtext/richtextliststylepage.cpp:342
+#: ../src/richtext/richtextindentspage.cpp:153
 msgid "&Justified"
 msgstr "இருபுற ஒழுங்கு"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "&Last"
 msgstr "கடைசி"
 
-#: ../src/richtext/richtextindentspage.cpp:139
 #: ../src/richtext/richtextliststylepage.cpp:328
+#: ../src/richtext/richtextindentspage.cpp:139
 msgid "&Left"
 msgstr "இடது"
 
-#: ../src/richtext/richtextindentspage.cpp:195
+#: ../src/richtext/richtextsizepage.cpp:532
+#: ../src/richtext/richtextsizepage.cpp:539
 #: ../src/richtext/richtextborderspage.cpp:243
 #: ../src/richtext/richtextborderspage.cpp:411
 #: ../src/richtext/richtextliststylepage.cpp:381
+#: ../src/richtext/richtextindentspage.cpp:195
 #: ../src/richtext/richtextmarginspage.cpp:186
 #: ../src/richtext/richtextmarginspage.cpp:300
-#: ../src/richtext/richtextsizepage.cpp:532
-#: ../src/richtext/richtextsizepage.cpp:539
 msgid "&Left:"
 msgstr "இடது:"
 
@@ -479,11 +507,11 @@ msgstr "இடது:"
 msgid "&List level:"
 msgstr "வரிசைப் பட்டியலின் மட்டம்"
 
-#: ../src/generic/logg.cpp:517
+#: ../src/generic/logg.cpp:514
 msgid "&Log"
 msgstr "செயற்குறிப்பேடு"
 
-#: ../src/univ/themes/win32.cpp:3748
+#: ../src/univ/themes/win32.cpp:3745
 msgid "&Move"
 msgstr "நகர்த்து"
 
@@ -491,20 +519,19 @@ msgstr "நகர்த்து"
 msgid "&Move the object to:"
 msgstr "பொருளை இங்கே நகர்த்து:"
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "&Network"
 msgstr "பிணையம்"
 
-#: ../src/richtext/richtexttabspage.cpp:132 ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173 ../src/richtext/richtexttabspage.cpp:132
 msgid "&New"
 msgstr "புதிது"
 
-#: ../src/aui/tabmdi.cpp:111 ../src/generic/mdig.cpp:100
-#: ../src/msw/mdi.cpp:180
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
 msgid "&Next"
 msgstr "அடுத்து"
 
-#: ../src/generic/wizard.cpp:432 ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:429
 msgid "&Next >"
 msgstr "அடுத்து"
 
@@ -512,7 +539,7 @@ msgstr "அடுத்து"
 msgid "&Next Paragraph"
 msgstr "அடுத்தப் பத்தி"
 
-#: ../src/generic/tipdlg.cpp:240
+#: ../src/generic/tipdlg.cpp:237
 msgid "&Next Tip"
 msgstr "அடுத்த துணுக்குதவி"
 
@@ -520,11 +547,11 @@ msgstr "அடுத்த துணுக்குதவி"
 msgid "&Next style:"
 msgstr "அடுத்தப் பாங்கு"
 
-#: ../src/common/stockitem.cpp:177 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:174 ../src/msw/msgdlg.cpp:435
 msgid "&No"
 msgstr "இ&ல்லை"
 
-#: ../src/generic/dbgrptg.cpp:356
+#: ../src/generic/dbgrptg.cpp:360
 msgid "&Notes:"
 msgstr "குறிப்புகள்"
 
@@ -532,12 +559,12 @@ msgstr "குறிப்புகள்"
 msgid "&Number:"
 msgstr "எண்:"
 
-#: ../src/generic/fontdlgg.cpp:475 ../src/generic/fontdlgg.cpp:482
-#: ../src/osx/carbon/fontdlg.cpp:408 ../src/common/stockitem.cpp:178
+#: ../src/osx/carbon/fontdlg.cpp:405 ../src/common/stockitem.cpp:175
+#: ../src/generic/fontdlgg.cpp:471 ../src/generic/fontdlgg.cpp:478
 msgid "&OK"
 msgstr "சரி"
 
-#: ../src/generic/dbgrptg.cpp:342 ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176 ../src/generic/dbgrptg.cpp:342
 msgid "&Open..."
 msgstr "திறவுக..."
 
@@ -549,16 +576,16 @@ msgstr "வெளிவரைவு நிலை"
 msgid "&Page Break"
 msgstr "பக்க முறிவு"
 
-#: ../src/richtext/richtextctrl.cpp:334 ../src/osx/textctrl_osx.cpp:578
-#: ../src/common/stockitem.cpp:180 ../src/msw/textctrl.cpp:2509
+#: ../src/osx/textctrl_osx.cpp:596 ../src/common/stockitem.cpp:177
+#: ../src/msw/textctrl.cpp:2774 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "ஒட்டு"
 
-#: ../include/wx/richtext/richtextbuffer.h:5010
+#: ../include/wx/richtext/richtextbuffer.h:5005
 msgid "&Picture"
 msgstr "படம்"
 
-#: ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:419
 msgid "&Point size:"
 msgstr "குறியளவு"
 
@@ -570,12 +597,11 @@ msgstr "நிலை (மில்லி மீட்டரின் பத்�
 msgid "&Position mode:"
 msgstr "இடத்தின் நிலை:"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178
 msgid "&Preferences"
 msgstr "முன்னுரிமை விருப்பங்கள்"
 
-#: ../src/aui/tabmdi.cpp:112 ../src/generic/mdig.cpp:101
-#: ../src/msw/mdi.cpp:181
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
 msgid "&Previous"
 msgstr "முந்தையது"
 
@@ -583,78 +609,74 @@ msgstr "முந்தையது"
 msgid "&Previous Paragraph"
 msgstr "முந்தைய பத்தி"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "&Print..."
 msgstr "அச்சிடு..."
 
-#: ../src/richtext/richtextctrl.cpp:339 ../src/richtext/richtextctrl.cpp:5514
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtextctrl.cpp:338
+#: ../src/richtext/richtextctrl.cpp:5512
 msgid "&Properties"
 msgstr "பண்புகள்"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "&Quit"
 msgstr "வெளியேறுக"
 
-#: ../src/richtext/richtextctrl.cpp:330 ../src/osx/textctrl_osx.cpp:574
-#: ../src/common/stockitem.cpp:185 ../src/common/cmdproc.cpp:293
-#: ../src/common/cmdproc.cpp:300 ../src/msw/textctrl.cpp:2505
+#: ../src/osx/textctrl_osx.cpp:592 ../src/common/stockitem.cpp:182
+#: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
+#: ../src/msw/textctrl.cpp:2770 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "மீள் செயலாக்குக"
 
-#: ../src/common/cmdproc.cpp:289 ../src/common/cmdproc.cpp:309
+#: ../src/common/cmdproc.cpp:282 ../src/common/cmdproc.cpp:302
 msgid "&Redo "
 msgstr "மீள் செயலாக்குக"
 
-#: ../src/richtext/richtextstyledlg.cpp:257
+#: ../src/richtext/richtextstyledlg.cpp:253
 msgid "&Rename Style..."
 msgstr "பாங்கினை மறுப்பெயரிடுக"
 
-#: ../src/generic/fdrepdlg.cpp:179
+#: ../src/generic/fdrepdlg.cpp:176
 msgid "&Replace"
 msgstr "மாற்றமர்வு"
 
-#: ../src/richtext/richtextstyledlg.cpp:287
+#: ../src/richtext/richtextstyledlg.cpp:283
 msgid "&Restart numbering"
 msgstr "எண்ணை மீண்டும் துவக்குக"
 
-#: ../src/univ/themes/win32.cpp:3747
+#: ../src/univ/themes/win32.cpp:3744
 msgid "&Restore"
 msgstr "மீட்டெடுக்கவும்"
 
-#: ../src/richtext/richtextindentspage.cpp:146
 #: ../src/richtext/richtextliststylepage.cpp:335
+#: ../src/richtext/richtextindentspage.cpp:146
 msgid "&Right"
 msgstr "வலது"
 
-#: ../src/richtext/richtextindentspage.cpp:213
+#: ../src/richtext/richtextsizepage.cpp:602
+#: ../src/richtext/richtextsizepage.cpp:609
 #: ../src/richtext/richtextborderspage.cpp:277
 #: ../src/richtext/richtextborderspage.cpp:445
 #: ../src/richtext/richtextliststylepage.cpp:399
+#: ../src/richtext/richtextindentspage.cpp:213
 #: ../src/richtext/richtextmarginspage.cpp:211
 #: ../src/richtext/richtextmarginspage.cpp:325
-#: ../src/richtext/richtextsizepage.cpp:602
-#: ../src/richtext/richtextsizepage.cpp:609
 msgid "&Right:"
 msgstr "வலது:"
 
-#: ../src/common/stockitem.cpp:190
+#: ../src/common/stockitem.cpp:187
 msgid "&Save"
 msgstr "சேமிக்கவும்"
-
-#: ../src/common/stockitem.cpp:191
-msgid "&Save as"
-msgstr "இவ்வாறு சேமிக்கவும்"
 
 #: ../include/wx/richmsgdlg.h:29
 msgid "&See details"
 msgstr "விவரங்களைக் காண்க"
 
-#: ../src/generic/tipdlg.cpp:236
+#: ../src/generic/tipdlg.cpp:233
 msgid "&Show tips at startup"
 msgstr "துவக்கத்தில் துணுக்குதவிகளைக் காட்டுக"
 
-#: ../src/univ/themes/win32.cpp:3750
+#: ../src/univ/themes/win32.cpp:3747
 msgid "&Size"
 msgstr "அளவு"
 
@@ -662,36 +684,36 @@ msgstr "அளவு"
 msgid "&Size:"
 msgstr "அளவு:"
 
-#: ../src/generic/progdlgg.cpp:252
+#: ../src/generic/progdlgg.cpp:249
 msgid "&Skip"
 msgstr "தவிர்க்கவும்"
 
-#: ../src/richtext/richtextindentspage.cpp:242
 #: ../src/richtext/richtextliststylepage.cpp:417
+#: ../src/richtext/richtextindentspage.cpp:242
 msgid "&Spacing (tenths of a mm)"
 msgstr "இடைவெளி (மில்லி மீட்டரின் பத்தில் ஒரு பகுதி)"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "&Spell Check"
 msgstr "சொல் திருத்தி"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "&Stop"
 msgstr "நிறுத்துக"
 
-#: ../src/richtext/richtextfontpage.cpp:275 ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196 ../src/richtext/richtextfontpage.cpp:275
 msgid "&Strikethrough"
 msgstr "ஊடாகக் கோடிடுக"
 
-#: ../src/generic/fontdlgg.cpp:382 ../src/richtext/richtextstylepage.cpp:106
+#: ../src/generic/fontdlgg.cpp:378 ../src/richtext/richtextstylepage.cpp:106
 msgid "&Style:"
 msgstr "பாங்கு:"
 
-#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:194
 msgid "&Styles:"
 msgstr "பாங்குகள்:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:413
+#: ../src/richtext/richtextsymboldlg.cpp:410
 msgid "&Subset:"
 msgstr "உட்கணம்:"
 
@@ -705,24 +727,24 @@ msgstr "குறியெழுத்து:"
 msgid "&Synchronize values"
 msgstr "மதிப்புகளை ஒத்திசைவாக்குக"
 
-#: ../include/wx/richtext/richtextbuffer.h:6069
+#: ../include/wx/richtext/richtextbuffer.h:6064
 msgid "&Table"
 msgstr "அட்டவணை"
 
-#: ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197
 msgid "&Top"
 msgstr "மேல்"
 
+#: ../src/richtext/richtextsizepage.cpp:567
+#: ../src/richtext/richtextsizepage.cpp:574
 #: ../src/richtext/richtextborderspage.cpp:311
 #: ../src/richtext/richtextborderspage.cpp:479
 #: ../src/richtext/richtextmarginspage.cpp:234
 #: ../src/richtext/richtextmarginspage.cpp:348
-#: ../src/richtext/richtextsizepage.cpp:567
-#: ../src/richtext/richtextsizepage.cpp:574
 msgid "&Top:"
 msgstr "மேல்:"
 
-#: ../src/generic/fontdlgg.cpp:444 ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199 ../src/generic/fontdlgg.cpp:441
 msgid "&Underline"
 msgstr "அடிக்கோடு"
 
@@ -730,21 +752,21 @@ msgstr "அடிக்கோடு"
 msgid "&Underlining:"
 msgstr "அடிக்கோடு:"
 
-#: ../src/richtext/richtextctrl.cpp:329 ../src/osx/textctrl_osx.cpp:573
-#: ../src/common/stockitem.cpp:203 ../src/common/cmdproc.cpp:271
-#: ../src/msw/textctrl.cpp:2504
+#: ../src/osx/textctrl_osx.cpp:591 ../src/common/stockitem.cpp:200
+#: ../src/common/cmdproc.cpp:264 ../src/msw/textctrl.cpp:2769
+#: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "செயல் நீக்கம்"
 
-#: ../src/common/cmdproc.cpp:265
+#: ../src/common/cmdproc.cpp:258
 msgid "&Undo "
 msgstr "செயல் நீக்கம்"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "&Unindent"
 msgstr "வரித் துவக்க ஒழுங்கினை நீக்குக"
 
-#: ../src/common/stockitem.cpp:205
+#: ../src/common/stockitem.cpp:202
 msgid "&Up"
 msgstr "மேல்"
 
@@ -761,7 +783,7 @@ msgstr "செங்குத்து எதிரிடை"
 msgid "&View..."
 msgstr "தோற்றம்..."
 
-#: ../src/generic/fontdlgg.cpp:393
+#: ../src/generic/fontdlgg.cpp:389
 msgid "&Weight:"
 msgstr "எடை:"
 
@@ -770,88 +792,58 @@ msgstr "எடை:"
 msgid "&Width:"
 msgstr "அகலம்:"
 
-#: ../src/aui/tabmdi.cpp:311 ../src/aui/tabmdi.cpp:327
-#: ../src/aui/tabmdi.cpp:329 ../src/generic/mdig.cpp:294
-#: ../src/generic/mdig.cpp:310 ../src/generic/mdig.cpp:314
-#: ../src/msw/mdi.cpp:78
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
 msgid "&Window"
 msgstr "சாளரம்"
 
-#: ../src/common/stockitem.cpp:206 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:203 ../src/msw/msgdlg.cpp:435
 msgid "&Yes"
 msgstr "ஆ&ம்"
 
-#: ../src/common/valtext.cpp:256
-#, c-format
-msgid "'%s' contains illegal characters"
+#: ../src/common/valtext.cpp:197
+#, fuzzy, c-format
+msgid "'%s' contains invalid character(s)"
 msgstr "'%s' ஏற்க முடியாதவரியுருக்களைக் கொண்டுள்ளது"
 
-#: ../src/common/valtext.cpp:254
-#, c-format
-msgid "'%s' doesn't consist only of valid characters"
-msgstr "ஏற்கக் கூடிய வரியுருக்களை மட்டுமே '%s' கொண்டிருக்கவில்லை"
-
-#: ../src/common/config.cpp:519 ../src/msw/regconf.cpp:258
+#: ../src/common/config.cpp:515 ../src/msw/regconf.cpp:255
 #, c-format
 msgid "'%s' has extra '..', ignored."
 msgstr "'%s' மிகையாகவுள்ளது '..', பொருட்படுத்தப்படவில்லை."
 
-#: ../src/common/cmdline.cpp:1113 ../src/common/cmdline.cpp:1131
+#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' எண் மதிப்பு, '%s' விருப்பத் தேர்விற்கு சரியானது அல்ல."
 
-#: ../src/common/translation.cpp:1100
+#: ../src/common/translation.cpp:1142
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' ஏற்க முடியாத தகவல் பட்டியலாகும்"
 
-#: ../src/common/valtext.cpp:165
+#: ../src/common/valtext.cpp:188
 #, c-format
 msgid "'%s' is not one of the valid strings"
 msgstr "ஏற்கக்கூடிய சரங்களில் ஒன்றாக '%s' இல்லை"
 
-#: ../src/common/valtext.cpp:167
+#: ../src/common/valtext.cpp:186
 #, c-format
 msgid "'%s' is one of the invalid strings"
 msgstr "ஏற்க முடியாத சரங்களில் ஒன்றாக '%s' உள்ளது"
 
-#: ../src/common/textbuf.cpp:237
+#: ../src/common/textbuf.cpp:233
 #, c-format
 msgid "'%s' is probably a binary buffer."
 msgstr "%s ஒரு இருமக்கூறு இடையகமாக இருக்கலாம்."
-
-#: ../src/common/valtext.cpp:252
-#, c-format
-msgid "'%s' should be numeric."
-msgstr "'%s' எண்ணாக இருக்க வேண்டும்"
-
-#: ../src/common/valtext.cpp:244
-#, c-format
-msgid "'%s' should only contain ASCII characters."
-msgstr "'%s' ASCII வரியுருக்களை மட்டும் உள்ளடங்கியதாக இருக்க வேண்டும்"
-
-#: ../src/common/valtext.cpp:246
-#, c-format
-msgid "'%s' should only contain alphabetic characters."
-msgstr "'%s' அகர வரியுருக்களை மட்டும் உள்ளடங்கியதாக இருக்க வேண்டும்"
-
-#: ../src/common/valtext.cpp:248
-#, c-format
-msgid "'%s' should only contain alphabetic or numeric characters."
-msgstr "'%s' எண் அல்லது அகர வரியுருக்களை மட்டும் உள்ளடங்கியதாக இருக்க வேண்டும்"
-
-#: ../src/common/valtext.cpp:250
-#, c-format
-msgid "'%s' should only contain digits."
-msgstr "'%s' இலக்கங்களை மட்டும் உள்ளடங்கியதாக இருக்க வேண்டும்"
 
 #: ../src/richtext/richtextliststylepage.cpp:229
 #: ../src/richtext/richtextbulletspage.cpp:166
 msgid "(*)"
 msgstr "(*)"
 
-#: ../src/html/helpwnd.cpp:963
+#: ../src/html/helpwnd.cpp:961
 msgid "(Help)"
 msgstr "(உதவி)"
 
@@ -860,27 +852,32 @@ msgstr "(உதவி)"
 msgid "(None)"
 msgstr "(ஏதுமில்லை)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:504
+#: ../src/richtext/richtextsymboldlg.cpp:503
 msgid "(Normal text)"
 msgstr "இயல்புரை"
 
-#: ../src/html/helpwnd.cpp:419 ../src/html/helpwnd.cpp:1106
-#: ../src/html/helpwnd.cpp:1742
+#: ../src/html/helpwnd.cpp:417 ../src/html/helpwnd.cpp:1104
+#: ../src/html/helpwnd.cpp:1740
 msgid "(bookmarks)"
 msgstr "(ஏட்டுக் குறிகள்)"
 
+#: ../src/msw/dlmsw.cpp:167
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (பிழை %ld: %s)"
+
+#: ../src/richtext/richtextformatdlg.cpp:876
+#: ../src/richtext/richtextliststylepage.cpp:448
+#: ../src/richtext/richtextliststylepage.cpp:460
+#: ../src/richtext/richtextliststylepage.cpp:461
 #: ../src/richtext/richtextindentspage.cpp:274
 #: ../src/richtext/richtextindentspage.cpp:286
 #: ../src/richtext/richtextindentspage.cpp:287
 #: ../src/richtext/richtextindentspage.cpp:311
 #: ../src/richtext/richtextindentspage.cpp:326
-#: ../src/richtext/richtextformatdlg.cpp:884
 #: ../src/richtext/richtextfontpage.cpp:349
 #: ../src/richtext/richtextfontpage.cpp:353
 #: ../src/richtext/richtextfontpage.cpp:357
-#: ../src/richtext/richtextliststylepage.cpp:448
-#: ../src/richtext/richtextliststylepage.cpp:460
-#: ../src/richtext/richtextliststylepage.cpp:461
 msgid "(none)"
 msgstr "(ஏதுமில்லை)"
 
@@ -899,7 +896,7 @@ msgstr "*)"
 msgid "+"
 msgstr "+"
 
-#: ../src/msw/utils.cpp:1152
+#: ../src/msw/utils.cpp:1143
 msgid ", 64-bit edition"
 msgstr "64 நுண்மி பதிப்பு"
 
@@ -908,163 +905,163 @@ msgstr "64 நுண்மி பதிப்பு"
 msgid "-"
 msgstr "-"
 
-#: ../src/generic/filepickerg.cpp:66
+#: ../src/generic/filepickerg.cpp:63
 msgid "..."
 msgstr "..."
 
-#: ../src/richtext/richtextindentspage.cpp:276
 #: ../src/richtext/richtextliststylepage.cpp:450
+#: ../src/richtext/richtextindentspage.cpp:276
 msgid "1.1"
 msgstr "1.1"
 
-#: ../src/richtext/richtextindentspage.cpp:277
 #: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextindentspage.cpp:277
 msgid "1.2"
 msgstr "1.2"
 
-#: ../src/richtext/richtextindentspage.cpp:278
 #: ../src/richtext/richtextliststylepage.cpp:452
+#: ../src/richtext/richtextindentspage.cpp:278
 msgid "1.3"
 msgstr "1.3"
 
-#: ../src/richtext/richtextindentspage.cpp:279
 #: ../src/richtext/richtextliststylepage.cpp:453
+#: ../src/richtext/richtextindentspage.cpp:279
 msgid "1.4"
 msgstr "1.4"
 
-#: ../src/richtext/richtextindentspage.cpp:280
 #: ../src/richtext/richtextliststylepage.cpp:454
+#: ../src/richtext/richtextindentspage.cpp:280
 msgid "1.5"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:281
 #: ../src/richtext/richtextliststylepage.cpp:455
+#: ../src/richtext/richtextindentspage.cpp:281
 msgid "1.6"
 msgstr "1.6"
 
-#: ../src/richtext/richtextindentspage.cpp:282
 #: ../src/richtext/richtextliststylepage.cpp:456
+#: ../src/richtext/richtextindentspage.cpp:282
 msgid "1.7"
 msgstr "1.7"
 
-#: ../src/richtext/richtextindentspage.cpp:283
 #: ../src/richtext/richtextliststylepage.cpp:457
+#: ../src/richtext/richtextindentspage.cpp:283
 msgid "1.8"
 msgstr "1.8"
 
-#: ../src/richtext/richtextindentspage.cpp:284
 #: ../src/richtext/richtextliststylepage.cpp:458
+#: ../src/richtext/richtextindentspage.cpp:284
 msgid "1.9"
 msgstr "1.9"
 
-#: ../src/common/paper.cpp:140
+#: ../src/common/paper.cpp:137
 msgid "10 x 11 in"
 msgstr "10 x 11 in"
 
-#: ../src/common/paper.cpp:113
+#: ../src/common/paper.cpp:110
 msgid "10 x 14 in"
 msgstr "10 x 14 in"
 
-#: ../src/common/paper.cpp:114
+#: ../src/common/paper.cpp:111
 msgid "11 x 17 in"
 msgstr "11 x 17 in"
 
-#: ../src/common/paper.cpp:184
+#: ../src/common/paper.cpp:181
 msgid "12 x 11 in"
 msgstr "12 x 11 in"
 
-#: ../src/common/paper.cpp:141
+#: ../src/common/paper.cpp:138
 msgid "15 x 11 in"
 msgstr "15 x 11 in"
 
-#: ../src/richtext/richtextindentspage.cpp:285
 #: ../src/richtext/richtextliststylepage.cpp:459
+#: ../src/richtext/richtextindentspage.cpp:285
 msgid "2"
 msgstr "2"
 
-#: ../src/common/paper.cpp:132
+#: ../src/common/paper.cpp:129
 msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
 msgstr "6 3/4 அஞ்சல் உறை, 3 5/8 x 6 1/2 in"
 
-#: ../src/common/paper.cpp:139
+#: ../src/common/paper.cpp:136
 msgid "9 x 11 in"
 msgstr "9 x 11 in"
 
-#: ../src/html/htmprint.cpp:431
+#: ../src/html/htmprint.cpp:443
 msgid ": file does not exist!"
 msgstr "கோப்பு கிடைப்பில் இல்லை!"
 
-#: ../src/common/fontmap.cpp:199
+#: ../src/common/fontmap.cpp:196
 msgid ": unknown charset"
 msgstr "தெரியாத Charset"
 
-#: ../src/common/fontmap.cpp:413
+#: ../src/common/fontmap.cpp:410
 msgid ": unknown encoding"
 msgstr "தெரியாத குறியாக்கம்"
 
-#: ../src/generic/wizard.cpp:443
+#: ../src/generic/wizard.cpp:438
 msgid "< &Back"
 msgstr "< பின்"
 
-#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:628
-#: ../src/osx/carbon/fontdlg.cpp:648
+#: ../src/osx/carbon/fontdlg.cpp:419 ../src/osx/carbon/fontdlg.cpp:625
+#: ../src/osx/carbon/fontdlg.cpp:645
 msgid "<Any Decorative>"
 msgstr "<ஏதேனும் அலங்காரம்>"
 
-#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:630
-#: ../src/osx/carbon/fontdlg.cpp:650
+#: ../src/osx/carbon/fontdlg.cpp:420 ../src/osx/carbon/fontdlg.cpp:627
+#: ../src/osx/carbon/fontdlg.cpp:647
 msgid "<Any Modern>"
 msgstr "<ஏதேனும் புதுமை>"
 
-#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:626
-#: ../src/osx/carbon/fontdlg.cpp:646
+#: ../src/osx/carbon/fontdlg.cpp:418 ../src/osx/carbon/fontdlg.cpp:623
+#: ../src/osx/carbon/fontdlg.cpp:643
 msgid "<Any Roman>"
 msgstr "<ஏதேனும் ரோமானியம்>"
 
-#: ../src/osx/carbon/fontdlg.cpp:424 ../src/osx/carbon/fontdlg.cpp:632
-#: ../src/osx/carbon/fontdlg.cpp:652
+#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:629
+#: ../src/osx/carbon/fontdlg.cpp:649
 msgid "<Any Script>"
 msgstr "<ஏதேனுமொரு கட்டளைக் குறி>"
 
-#: ../src/osx/carbon/fontdlg.cpp:425 ../src/osx/carbon/fontdlg.cpp:637
-#: ../src/osx/carbon/fontdlg.cpp:656
+#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:634
+#: ../src/osx/carbon/fontdlg.cpp:653
 msgid "<Any Swiss>"
 msgstr "<ஏதேனும் சுவிஸ்>"
 
-#: ../src/osx/carbon/fontdlg.cpp:426 ../src/osx/carbon/fontdlg.cpp:634
-#: ../src/osx/carbon/fontdlg.cpp:654
+#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:631
+#: ../src/osx/carbon/fontdlg.cpp:651
 msgid "<Any Teletype>"
 msgstr "<ஏதேனுமொரு தொலைத் தட்டெழுத்து>"
 
-#: ../src/osx/carbon/fontdlg.cpp:420
+#: ../src/osx/carbon/fontdlg.cpp:417
 msgid "<Any>"
 msgstr "<ஏதேனும்>"
 
-#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
 msgid "<DIR>"
 msgstr "<அடைவு>"
 
-#: ../src/generic/filectrlg.cpp:254 ../src/generic/filectrlg.cpp:277
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
 msgid "<DRIVE>"
 msgstr "<இயக்ககம்>"
 
-#: ../src/generic/filectrlg.cpp:252 ../src/generic/filectrlg.cpp:275
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
 msgid "<LINK>"
 msgstr "<தொடுப்பு>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1264
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>அடர்த்தி வலப்பக்க சாய்வு முகம்.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1270
+#: ../src/html/helpwnd.cpp:1268
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>அடர்த்தி வலப்பக்க சாய்வு <u>அடிக்கோடிடப்பட்டது</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1265
+#: ../src/html/helpwnd.cpp:1263
 msgid "<b>Bold face.</b> "
 msgstr "<b>அடர்த்தி.</b> "
 
-#: ../src/html/helpwnd.cpp:1264
+#: ../src/html/helpwnd.cpp:1262
 msgid "<i>Italic face.</i> "
 msgstr "<i>வலப்பக்க சாய்வு </i> "
 
@@ -1073,15 +1070,15 @@ msgstr "<i>வலப்பக்க சாய்வு </i> "
 msgid ">"
 msgstr ">"
 
-#: ../src/generic/dbgrptg.cpp:318
+#: ../src/generic/dbgrptg.cpp:317
 msgid "A debug report has been generated in the directory\n"
 msgstr "ஒரு வழுநீக்க அறிக்கை, அடைவில் உருவாக்கப்பட்டுள்ளது\n"
 
-#: ../src/common/debugrpt.cpp:573
+#: ../src/common/debugrpt.cpp:574
 msgid "A debug report has been generated. It can be found in"
 msgstr "ஒரு வழுநீக்க அறிக்கை உருவாக்கப்பட்டுள்ளது. அதை இங்கே காணலாம்:"
 
-#: ../src/common/xtixml.cpp:418
+#: ../src/common/xtixml.cpp:414
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "ஒரு வெறுமையான திரட்டு, அங்கங்களின் கணுக்களைக் கொண்டிருக்க வேண்டும்"
 
@@ -1092,106 +1089,106 @@ msgstr "ஒரு வெறுமையான திரட்டு, அங்�
 msgid "A standard bullet name."
 msgstr "செந்தரமாக்கப்பட்ட தோட்டாவின் பெயர்"
 
-#: ../src/common/paper.cpp:217
+#: ../src/common/paper.cpp:214
 msgid "A0 sheet, 841 x 1189 mm"
 msgstr "A0 தாள், 841 x 1189 mm"
 
-#: ../src/common/paper.cpp:218
+#: ../src/common/paper.cpp:215
 msgid "A1 sheet, 594 x 841 mm"
 msgstr "A1 தாள், 594 x 841 mm"
 
-#: ../src/common/paper.cpp:159
+#: ../src/common/paper.cpp:156
 msgid "A2 420 x 594 mm"
 msgstr "A2 420 x 594 mm"
 
-#: ../src/common/paper.cpp:156
+#: ../src/common/paper.cpp:153
 msgid "A3 Extra 322 x 445 mm"
 msgstr "A3 கூடுதல் 322 x 445 mm"
 
-#: ../src/common/paper.cpp:161
+#: ../src/common/paper.cpp:158
 msgid "A3 Extra Transverse 322 x 445 mm"
 msgstr "A3 கூடுதல் குறுக்கு 322 x 445 mm"
 
-#: ../src/common/paper.cpp:170
+#: ../src/common/paper.cpp:167
 msgid "A3 Rotated 420 x 297 mm"
 msgstr "A3 சுழற்றப்பட்டது 420 x 297 mm"
 
-#: ../src/common/paper.cpp:160
+#: ../src/common/paper.cpp:157
 msgid "A3 Transverse 297 x 420 mm"
 msgstr "A3 குறுக்கு 297 x 420 mm"
 
-#: ../src/common/paper.cpp:106
+#: ../src/common/paper.cpp:103
 msgid "A3 sheet, 297 x 420 mm"
 msgstr "A3 தாள், 297 x 420 mm"
 
-#: ../src/common/paper.cpp:146
+#: ../src/common/paper.cpp:143
 msgid "A4 Extra 9.27 x 12.69 in"
 msgstr "A4 கூடுதல் 9.27 x 12.69 in"
 
-#: ../src/common/paper.cpp:153
+#: ../src/common/paper.cpp:150
 msgid "A4 Plus 210 x 330 mm"
 msgstr "A4 கூட்டல் 210 x 330 mm"
 
-#: ../src/common/paper.cpp:171
+#: ../src/common/paper.cpp:168
 msgid "A4 Rotated 297 x 210 mm"
 msgstr "A4 சுழற்றப்பட்டது 297 x 210 mm"
 
-#: ../src/common/paper.cpp:148
+#: ../src/common/paper.cpp:145
 msgid "A4 Transverse 210 x 297 mm"
 msgstr "A4 குறுக்கு 210 x 297 mm"
 
-#: ../src/common/paper.cpp:97
+#: ../src/common/paper.cpp:94
 msgid "A4 sheet, 210 x 297 mm"
 msgstr "A4 தாள், 210 x 297 mm"
 
-#: ../src/common/paper.cpp:107
+#: ../src/common/paper.cpp:104
 msgid "A4 small sheet, 210 x 297 mm"
 msgstr "A4 சிறுதாள், 210 x 297 mm"
 
-#: ../src/common/paper.cpp:157
+#: ../src/common/paper.cpp:154
 msgid "A5 Extra 174 x 235 mm"
 msgstr "A5 கூடுதல் 174 x 235 mm"
 
-#: ../src/common/paper.cpp:172
+#: ../src/common/paper.cpp:169
 msgid "A5 Rotated 210 x 148 mm"
 msgstr "A5 சுழற்றப்பட்டது210 x 148 mm"
 
-#: ../src/common/paper.cpp:154
+#: ../src/common/paper.cpp:151
 msgid "A5 Transverse 148 x 210 mm"
 msgstr "A5 குறுக்கு 148 x 210 mm"
 
-#: ../src/common/paper.cpp:108
+#: ../src/common/paper.cpp:105
 msgid "A5 sheet, 148 x 210 mm"
 msgstr "A5 தாள், 148 x 210 mm"
 
-#: ../src/common/paper.cpp:164
+#: ../src/common/paper.cpp:161
 msgid "A6 105 x 148 mm"
 msgstr "A6 105 x 148 mm"
 
-#: ../src/common/paper.cpp:177
+#: ../src/common/paper.cpp:174
 msgid "A6 Rotated 148 x 105 mm"
 msgstr "A6 சுழற்றப்பட்டது 148 x 105 mm"
 
-#: ../src/generic/fontdlgg.cpp:83 ../src/richtext/richtextformatdlg.cpp:529
-#: ../src/osx/carbon/fontdlg.cpp:153
+#: ../src/osx/carbon/fontdlg.cpp:150 ../src/generic/fontdlgg.cpp:79
+#: ../src/richtext/richtextformatdlg.cpp:521
 msgid "ABCDEFGabcdefg12345"
 msgstr "ABCDEFGabcdefg12345"
 
-#: ../src/richtext/richtextsymboldlg.cpp:458 ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
 msgid "ASCII"
 msgstr "ASCII"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "About"
 msgstr "குறித்து..."
 
-#: ../src/generic/aboutdlgg.cpp:140 ../src/osx/menu_osx.cpp:558
-#: ../src/msw/aboutdlg.cpp:64
+#: ../src/osx/menu_osx.cpp:450 ../src/generic/aboutdlgg.cpp:137
+#: ../src/msw/aboutdlg.cpp:61
 #, c-format
 msgid "About %s"
 msgstr "%s குறித்து"
 
-#: ../src/osx/menu_osx.cpp:560
+#: ../src/osx/menu_osx.cpp:452
 msgid "About..."
 msgstr "குறித்து..."
 
@@ -1200,38 +1197,38 @@ msgid "Absolute"
 msgstr "அருதியானது"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:873
+#: ../src/propgrid/advprops.cpp:774
 #, fuzzy
 msgid "ActiveBorder"
 msgstr "எல்லை"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:874
+#: ../src/propgrid/advprops.cpp:775
 msgid "ActiveCaption"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "Actual Size"
 msgstr "மெய்யளவு"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:140 ../src/common/accelcmn.cpp:81
+#: ../src/common/stockitem.cpp:137 ../src/common/accelcmn.cpp:78
 msgid "Add"
 msgstr "ஏற்றுக"
 
-#: ../src/richtext/richtextbuffer.cpp:11455
+#: ../src/richtext/richtextbuffer.cpp:11454
 msgid "Add Column"
 msgstr "செங்குத்து வரிசையை சேர்க்கவும்"
 
-#: ../src/richtext/richtextbuffer.cpp:11392
+#: ../src/richtext/richtextbuffer.cpp:11391
 msgid "Add Row"
 msgstr "கிடை வரிசையை சேர்க்கவும்"
 
-#: ../src/html/helpwnd.cpp:432
+#: ../src/html/helpwnd.cpp:430
 msgid "Add current page to bookmarks"
 msgstr "தற்போதைய பக்கத்தை ஏட்டுக்குறிகளில் ஏற்றுக"
 
-#: ../src/generic/colrdlgg.cpp:366
+#: ../src/generic/colrdlgg.cpp:386
 msgid "Add to custom colours"
 msgstr "தனிப்பயனாக்கப்பட்ட நிறங்களுடன் ஏற்றுக"
 
@@ -1243,12 +1240,12 @@ msgstr "பொதுத் தரவு அணுகியின் மேலா
 msgid "AddToPropertyCollection called w/o valid adder"
 msgstr "w/o மதிப்புக் கூட்டி என்கிற AddToPropertyCollection உடன் ஏற்றுக"
 
-#: ../src/html/helpctrl.cpp:159
+#: ../src/html/helpctrl.cpp:155
 #, c-format
 msgid "Adding book %s"
 msgstr "%s ஏடு ஏற்றப்படுகிறது"
 
-#: ../src/common/preferencescmn.cpp:43
+#: ../src/common/preferencescmn.cpp:40
 msgid "Advanced"
 msgstr "மேம்பட்ட"
 
@@ -1256,11 +1253,11 @@ msgstr "மேம்பட்ட"
 msgid "After a paragraph:"
 msgstr "ஒரு பத்திக்குப் பிறகு:"
 
-#: ../src/common/stockitem.cpp:172
+#: ../src/common/stockitem.cpp:169
 msgid "Align Left"
 msgstr "இடது ஒழுங்கு"
 
-#: ../src/common/stockitem.cpp:173
+#: ../src/common/stockitem.cpp:170
 msgid "Align Right"
 msgstr "வலது ஒழுங்கு"
 
@@ -1268,40 +1265,40 @@ msgstr "வலது ஒழுங்கு"
 msgid "Alignment"
 msgstr "ஒழுங்கமைப்பு"
 
-#: ../src/generic/prntdlgg.cpp:215
+#: ../src/generic/prntdlgg.cpp:208
 msgid "All"
 msgstr "அனைத்தும்"
 
-#: ../src/generic/filectrlg.cpp:1197 ../src/common/fldlgcmn.cpp:107
+#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1186
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "எல்லாக் கோப்புகளும் (%s)|%s"
 
-#: ../include/wx/defs.h:2886
+#: ../include/wx/defs.h:2582
 msgid "All files (*)|*"
 msgstr "எல்லாக் கோப்புகளும் (*)|*"
 
-#: ../include/wx/defs.h:2883
+#: ../include/wx/defs.h:2579
 msgid "All files (*.*)|*.*"
 msgstr "எல்லாக் கோப்புகளும் (*.*)|*.*"
 
-#: ../src/richtext/richtextstyles.cpp:1061
+#: ../src/richtext/richtextstyles.cpp:1058
 msgid "All styles"
 msgstr "எல்லாப் பாங்குகளும்"
 
-#: ../src/propgrid/manager.cpp:1528
+#: ../src/propgrid/manager.cpp:1544
 msgid "Alphabetic Mode"
 msgstr "அகர நிலை"
 
-#: ../src/common/xtistrm.cpp:425
+#: ../src/common/xtistrm.cpp:422
 msgid "Already Registered Object passed to SetObjectClassInfo"
 msgstr "ஏற்கனவே பதிவு செய்யப்பட்ட பொருள், SetObjectClassInfo-க்கு அனுப்பப்பட்டது."
 
-#: ../src/unix/dialup.cpp:353
+#: ../src/unix/dialup.cpp:352
 msgid "Already dialling ISP."
 msgstr "ISP ஏற்கனவே சுழற்றப்பட்டுள்ளது."
 
-#: ../src/common/accelcmn.cpp:331 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/accelcmn.cpp:345 ../src/univ/themes/win32.cpp:3753
 msgid "Alt+"
 msgstr "நிலை மாற்றி+"
 
@@ -1311,36 +1308,36 @@ msgid "An optional corner radius for adding rounded corners."
 msgstr ""
 "வட்டவடிவ எல்லைக் கோணங்களை உருவாக்க விருப்பத் தேர்வாக அமைந்திருக்கும் எல்லைக் கோணத்தின் ஆரம்."
 
-#: ../src/common/debugrpt.cpp:576
+#: ../src/common/debugrpt.cpp:577
 msgid "And includes the following files:\n"
 msgstr "பின்வரும் கோப்புகளும் சேர்க்கப்பட்டுள்ளன: \n"
 
-#: ../src/generic/animateg.cpp:162
+#: ../src/generic/animateg.cpp:145
 #, c-format
 msgid "Animation file is not of type %ld."
 msgstr "அசைவூட்டக் கோப்பு %ld வகையில் இல்லை."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:872
+#: ../src/propgrid/advprops.cpp:773
 msgid "AppWorkspace"
 msgstr ""
 
-#: ../src/generic/logg.cpp:1014
+#: ../src/generic/logg.cpp:1011
 #, c-format
 msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
 msgstr ""
 "செயற்குறிப்பேட்டினை '%s' கோப்பினுடன் இணைப்பதா? ([இல்லை] என்றுத் தேர்வு செய்தால் கோப்பு "
 "அழித்து எழுதப்படும்)"
 
-#: ../src/osx/menu_osx.cpp:577 ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:469 ../src/osx/menu_osx.cpp:477
 msgid "Application"
 msgstr "பயன்பாடு"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "Apply"
 msgstr "இடு"
 
-#: ../src/propgrid/advprops.cpp:1609
+#: ../src/propgrid/advprops.cpp:1515
 msgid "Aqua"
 msgstr ""
 
@@ -1349,30 +1346,30 @@ msgstr ""
 msgid "Arabic"
 msgstr "அரேபியம்"
 
-#: ../src/common/fmapbase.cpp:153
+#: ../src/common/fmapbase.cpp:150
 msgid "Arabic (ISO-8859-6)"
 msgstr "அரேபியம் (ISO-8859-6)"
 
-#: ../src/msw/ole/automtn.cpp:672
+#: ../src/msw/ole/automtn.cpp:663
 #, c-format
 msgid "Argument %u not found."
 msgstr "தர்க்கம் %u காணப்படவில்லை."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1753
+#: ../src/propgrid/advprops.cpp:1654
 #, fuzzy
 msgid "Arrow"
 msgstr "நாளை"
 
-#: ../src/generic/aboutdlgg.cpp:184
+#: ../src/generic/aboutdlgg.cpp:181
 msgid "Artists"
 msgstr "கலைஞர்கள்"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "Ascending"
 msgstr "ஏறுமுகமான"
 
-#: ../src/generic/filectrlg.cpp:433
+#: ../src/generic/filectrlg.cpp:429
 msgid "Attributes"
 msgstr "பண்புகள்"
 
@@ -1382,90 +1379,90 @@ msgstr "பண்புகள்"
 msgid "Available fonts."
 msgstr "கிடைப்பிலுள்ள எழுத்துருக்கள்"
 
-#: ../src/common/paper.cpp:137
+#: ../src/common/paper.cpp:134
 msgid "B4 (ISO) 250 x 353 mm"
 msgstr "B4 (ISO) 250 x 353 mm"
 
-#: ../src/common/paper.cpp:173
+#: ../src/common/paper.cpp:170
 msgid "B4 (JIS) Rotated 364 x 257 mm"
 msgstr "B4 (JIS) சுழற்றப்பட்டது 364 x 257 mm"
 
-#: ../src/common/paper.cpp:127
+#: ../src/common/paper.cpp:124
 msgid "B4 Envelope, 250 x 353 mm"
 msgstr "B4 அஞ்சல் உறை , 250 x 353 mm"
 
-#: ../src/common/paper.cpp:109
+#: ../src/common/paper.cpp:106
 msgid "B4 sheet, 250 x 354 mm"
 msgstr "B4 தாள் , 250 x 354 mm"
 
-#: ../src/common/paper.cpp:158
+#: ../src/common/paper.cpp:155
 msgid "B5 (ISO) Extra 201 x 276 mm"
 msgstr "B5 (ISO) கூடுதல் 201 x 276 mm"
 
-#: ../src/common/paper.cpp:174
+#: ../src/common/paper.cpp:171
 msgid "B5 (JIS) Rotated 257 x 182 mm"
 msgstr "B5 (JIS) சுழற்றப்பட்டது 257 x 182 mm"
 
-#: ../src/common/paper.cpp:155
+#: ../src/common/paper.cpp:152
 msgid "B5 (JIS) Transverse 182 x 257 mm"
 msgstr "B5 (JIS) குறுக்கு 182 x 257 mm"
 
-#: ../src/common/paper.cpp:128
+#: ../src/common/paper.cpp:125
 msgid "B5 Envelope, 176 x 250 mm"
 msgstr "B5 அஞ்சல் உறை , 176 x 250 mm"
 
-#: ../src/common/paper.cpp:110
+#: ../src/common/paper.cpp:107
 msgid "B5 sheet, 182 x 257 millimeter"
 msgstr "B5 தாள் , 182 x 257 millimeter"
 
-#: ../src/common/paper.cpp:182
+#: ../src/common/paper.cpp:179
 msgid "B6 (JIS) 128 x 182 mm"
 msgstr "B6 (JIS) 128 x 182 mm"
 
-#: ../src/common/paper.cpp:183
+#: ../src/common/paper.cpp:180
 msgid "B6 (JIS) Rotated 182 x 128 mm"
 msgstr "B6 (JIS) சுழற்றப்பட்டது 182 x 128 mm"
 
-#: ../src/common/paper.cpp:129
+#: ../src/common/paper.cpp:126
 msgid "B6 Envelope, 176 x 125 mm"
 msgstr "B6 அஞ்சல் உறை, 176 x 125 mm"
 
-#: ../src/common/imagbmp.cpp:531 ../src/common/imagbmp.cpp:561
-#: ../src/common/imagbmp.cpp:576
+#: ../src/common/imagbmp.cpp:528 ../src/common/imagbmp.cpp:558
+#: ../src/common/imagbmp.cpp:573
 msgid "BMP: Couldn't allocate memory."
 msgstr "BMP: நினைவகத்தை ஒதுக்க இயலவில்லை."
 
-#: ../src/common/imagbmp.cpp:100
+#: ../src/common/imagbmp.cpp:97
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: ஏற்கமுடியாத படிமத்தை சேமிக்க இயலவில்லை."
 
-#: ../src/common/imagbmp.cpp:356
+#: ../src/common/imagbmp.cpp:353
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: RGB நிற வரைபடத்தை எழுத இயலவில்லை."
 
-#: ../src/common/imagbmp.cpp:490
+#: ../src/common/imagbmp.cpp:487
 msgid "BMP: Couldn't write data."
 msgstr "BMP: தரவினை எழுத இயலவில்லை."
 
-#: ../src/common/imagbmp.cpp:246
+#: ../src/common/imagbmp.cpp:243
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: நுண்படத் தலைப்பினை எழுத இயலவில்லை."
 
-#: ../src/common/imagbmp.cpp:269
+#: ../src/common/imagbmp.cpp:266
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: நுண்படத் தகவல் தலைப்பினை எழுத இயலவில்லை."
 
-#: ../src/common/imagbmp.cpp:140
+#: ../src/common/imagbmp.cpp:137
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage சொந்த wxPalette-ஐ கொண்டிருக்கவில்லை."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:142 ../src/common/accelcmn.cpp:52
+#: ../src/common/stockitem.cpp:139 ../src/common/accelcmn.cpp:49
 msgid "Back"
 msgstr "பின்"
 
+#: ../src/richtext/richtextformatdlg.cpp:377
 #: ../src/richtext/richtextbackgroundpage.cpp:148
-#: ../src/richtext/richtextformatdlg.cpp:384
 msgid "Background"
 msgstr "பின்னணி"
 
@@ -1473,21 +1470,21 @@ msgstr "பின்னணி"
 msgid "Background &colour:"
 msgstr "பின்னணி நிறம்:"
 
-#: ../src/osx/carbon/fontdlg.cpp:220
+#: ../src/osx/carbon/fontdlg.cpp:217
 msgid "Background colour"
 msgstr "பின்னணி நிறம்"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:52
+#: ../src/common/accelcmn.cpp:49
 #, fuzzy
 msgid "Backspace"
 msgstr "பின்"
 
-#: ../src/common/fmapbase.cpp:160
+#: ../src/common/fmapbase.cpp:157
 msgid "Baltic (ISO-8859-13)"
 msgstr "பால்டிக் (ISO-8859-13)"
 
-#: ../src/common/fmapbase.cpp:151
+#: ../src/common/fmapbase.cpp:148
 msgid "Baltic (old) (ISO-8859-4)"
 msgstr "பால்டிக் (old) (ISO-8859-4)"
 
@@ -1500,25 +1497,25 @@ msgstr "ஒரு பத்திக்கு முன்பு:"
 msgid "Bitmap"
 msgstr "நுண்படம்"
 
-#: ../src/propgrid/advprops.cpp:1594
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Black"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1755
+#: ../src/propgrid/advprops.cpp:1656
 msgid "Blank"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1603
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Blue"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:345
+#: ../src/generic/colrdlgg.cpp:365
 msgid "Blue:"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:333 ../src/richtext/richtextfontpage.cpp:355
-#: ../src/osx/carbon/fontdlg.cpp:354 ../src/common/stockitem.cpp:143
+#: ../src/osx/carbon/fontdlg.cpp:351 ../src/common/stockitem.cpp:140
+#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:355
 msgid "Bold"
 msgstr "அடர்த்தி"
 
@@ -1527,32 +1524,36 @@ msgstr "அடர்த்தி"
 msgid "Border"
 msgstr "எல்லை"
 
-#: ../src/richtext/richtextformatdlg.cpp:379
+#: ../src/richtext/richtextformatdlg.cpp:372
 msgid "Borders"
 msgstr "எல்லைகள்"
 
-#: ../src/richtext/richtextsizepage.cpp:288 ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141 ../src/richtext/richtextsizepage.cpp:288
 msgid "Bottom"
 msgstr "அடித்தளம்"
 
-#: ../src/generic/prntdlgg.cpp:893
+#: ../src/generic/prntdlgg.cpp:886
 msgid "Bottom margin (mm):"
 msgstr "அடித்தளக் கரை (MM)"
 
-#: ../src/richtext/richtextbuffer.cpp:9383
+#: ../src/richtext/richtextbuffer.cpp:9380
 msgid "Box Properties"
 msgstr "பெட்டிப் பண்புகள்"
 
-#: ../src/richtext/richtextstyles.cpp:1065
+#: ../src/richtext/richtextstyles.cpp:1062
 msgid "Box styles"
 msgstr "பெட்டிப் பாங்குகள்"
 
-#: ../src/propgrid/advprops.cpp:1602
+#: ../src/osx/cocoa/menu.mm:292
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1508
 #, fuzzy
 msgid "Brown"
 msgstr "உலாவு"
 
-#: ../src/common/filepickercmn.cpp:43 ../src/common/filepickercmn.cpp:44
+#: ../src/common/filepickercmn.cpp:40 ../src/common/filepickercmn.cpp:41
 msgid "Browse"
 msgstr "உலாவு"
 
@@ -1565,73 +1566,73 @@ msgstr "தோட்டா ஒழுங்கமைப்பு:"
 msgid "Bullet style"
 msgstr "தோட்டாப் பாங்கு"
 
-#: ../src/richtext/richtextformatdlg.cpp:359
+#: ../src/richtext/richtextformatdlg.cpp:352
 msgid "Bullets"
 msgstr "தோட்டாக்கள்"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1756
+#: ../src/propgrid/advprops.cpp:1657
 #, fuzzy
 msgid "Bullseye"
 msgstr "தோட்டாப் பாங்கு"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:875
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonFace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:876
+#: ../src/propgrid/advprops.cpp:777
 msgid "ButtonHighlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:877
+#: ../src/propgrid/advprops.cpp:778
 msgid "ButtonShadow"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:878
+#: ../src/propgrid/advprops.cpp:779
 msgid "ButtonText"
 msgstr ""
 
-#: ../src/common/paper.cpp:98
+#: ../src/common/paper.cpp:95
 msgid "C sheet, 17 x 22 in"
 msgstr "C தாள், 17 x 22 in"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "C&lear"
 msgstr "தெளிவாக்கு"
 
-#: ../src/generic/fontdlgg.cpp:406
+#: ../src/generic/fontdlgg.cpp:403
 msgid "C&olour:"
 msgstr "நிறம்:"
 
-#: ../src/common/paper.cpp:123
+#: ../src/common/paper.cpp:120
 msgid "C3 Envelope, 324 x 458 mm"
 msgstr "C3 அஞ்சல் உறை, 324 x 458 mm"
 
-#: ../src/common/paper.cpp:124
+#: ../src/common/paper.cpp:121
 msgid "C4 Envelope, 229 x 324 mm"
 msgstr "C4 அஞ்சல் உறை, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:122
+#: ../src/common/paper.cpp:119
 msgid "C5 Envelope, 162 x 229 mm"
 msgstr "C5 அஞ்சல் உறை, 162 x 229 mm"
 
-#: ../src/common/paper.cpp:125
+#: ../src/common/paper.cpp:122
 msgid "C6 Envelope, 114 x 162 mm"
 msgstr "C6 அஞ்சல் உறை, 114 x 162 mm"
 
-#: ../src/common/paper.cpp:126
+#: ../src/common/paper.cpp:123
 msgid "C65 Envelope, 114 x 229 mm"
 msgstr "C65 அஞ்சல் உறை, 114 x 229 mm"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "CD-Rom"
 msgstr "குறுந்தட்டு நினைவகம்"
 
-#: ../src/html/chm.cpp:815 ../src/html/chm.cpp:874
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:865
 msgid "CHM handler currently supports only local files!"
 msgstr "CHM handler தற்போதைக்கு உள்ளகக் கோப்புகளை மட்டுமே ஆதரிக்கிறது!"
 
@@ -1639,190 +1640,194 @@ msgstr "CHM handler தற்போதைக்கு உள்ளகக் க�
 msgid "Ca&pitals"
 msgstr "முகப்புகள்"
 
-#: ../src/common/cmdproc.cpp:267
+#: ../src/common/cmdproc.cpp:260
 msgid "Can't &Undo "
 msgstr "செய்நீக்கம் இயலவில்லை"
 
-#: ../src/common/image.cpp:2824
+#: ../src/common/image.cpp:2924
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr "நாடிச் செல்ல இயலாத உள்ளீட்டிற்கு படிம வடிவூட்டத்தைத் தானாக வரையறுக்க இயலாது."
 
-#: ../src/msw/registry.cpp:506
+#: ../src/msw/registry.cpp:495
 #, c-format
 msgid "Can't close registry key '%s'"
 msgstr "'%s' பதிவக விசையினை மூட இயலவில்லை"
 
-#: ../src/msw/registry.cpp:584
+#: ../src/msw/registry.cpp:573
 #, c-format
 msgid "Can't copy values of unsupported type %d."
 msgstr "%d ஆதரவளிக்கப்படாத வகை என்பதால், இதன் மதிப்பை படியெடுக்க இயலவில்லை."
 
-#: ../src/msw/registry.cpp:487
+#: ../src/msw/registry.cpp:476
 #, c-format
 msgid "Can't create registry key '%s'"
 msgstr "'%s' பதிவக விசையினை உருவாக்க இயலவில்லை"
 
-#: ../src/msw/thread.cpp:665
+#: ../src/msw/thread.cpp:657
 msgid "Can't create thread"
 msgstr "இழையினை உருவாக்க இயலவில்லை"
 
-#: ../src/msw/window.cpp:3691
-#, c-format
-msgid "Can't create window of class %s"
-msgstr "%s பிரிவினைக் கொண்ட சாளரத்தை உருவாக்க இயலவில்லை"
-
-#: ../src/msw/registry.cpp:777
+#: ../src/msw/registry.cpp:765
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "'%s' விசையினை அழிக்க இயலவில்லை"
 
-#: ../src/msw/iniconf.cpp:458
+#: ../src/msw/iniconf.cpp:455
 #, c-format
 msgid "Can't delete the INI file '%s'"
 msgstr "'%s' INI கோப்பினை அழிக்க இயலவில்லை"
 
-#: ../src/msw/registry.cpp:805
+#: ../src/msw/registry.cpp:793
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "மதிப்பு '%s\" விசை '%s' இடமிருந்து அழிக்க இயலவில்லை"
 
-#: ../src/msw/registry.cpp:1171
+#: ../src/msw/registry.cpp:1159
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "விசை '%s'-ன் உட்விசைகளை கணக்கிட இயலவில்லை"
 
-#: ../src/msw/registry.cpp:1132
+#: ../src/msw/registry.cpp:1120
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "விசை '%s'-ன் மதிப்புகளை கணக்கிட இயலவில்லை"
 
-#: ../src/msw/registry.cpp:1389
+#: ../src/msw/registry.cpp:1377
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "%d ஆதரவளிக்கப்படாத வகை என்பதால், அதன் மதிப்பை ஏற்றம் செய்ய இயலவில்லை."
 
-#: ../src/common/ffile.cpp:254
+#: ../src/common/ffile.cpp:253
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "'%s' கோப்பில் தற்போதைய நிலையைக் காண இயலவில்லை"
 
-#: ../src/msw/registry.cpp:418
+#: ../src/msw/registry.cpp:407
 #, c-format
 msgid "Can't get info about registry key '%s'"
 msgstr "'%s' கோப்பின் பதிவகத் தகவலைப் பெற இயலவில்லை"
 
-#: ../src/common/zstream.cpp:346
+#: ../src/msw/webview_ie.cpp:1024
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "இழையின் முன்னுரிமையை அமைக்க இயலாது"
+
+#: ../src/common/zstream.cpp:343
 msgid "Can't initialize zlib deflate stream."
 msgstr "zlib அமிழோடையை துவக்க நிலையாக்க இயலாது"
 
-#: ../src/common/zstream.cpp:185
+#: ../src/common/zstream.cpp:182
 msgid "Can't initialize zlib inflate stream."
 msgstr "zlib விரியோடையை துவக்க நிலையாக்க இயலாது"
 
-#: ../src/msw/fswatcher.cpp:476
+#: ../src/msw/fswatcher.cpp:475
 #, c-format
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "இல்லாத \"%s\" அடைவினை மாற்றங்களுக்காக கவனிக்க இயலாது"
 
-#: ../src/msw/registry.cpp:454
+#: ../src/msw/registry.cpp:443
 #, c-format
 msgid "Can't open registry key '%s'"
 msgstr "பதிவக விசை '%s' திறக்க இயலாது "
 
-#: ../src/common/zstream.cpp:252
+#: ../src/common/zstream.cpp:249
 #, c-format
 msgid "Can't read from inflate stream: %s"
 msgstr "%s ஒரு விரியோடை என்பதால், அதைப் படிக்க இயலாது"
 
-#: ../src/common/zstream.cpp:244
+#: ../src/common/zstream.cpp:241
 msgid "Can't read inflate stream: unexpected EOF in underlying stream."
 msgstr "கீழிருக்கும் ஓடையில் எதிர்பாராத EOF இருப்பதால், விரியோடையை படிக்க இயலாது"
 
-#: ../src/msw/registry.cpp:1064
+#: ../src/msw/registry.cpp:1052
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "'%s'-இன் மதிப்பை படிக்க இயலாது"
 
-#: ../src/msw/registry.cpp:878 ../src/msw/registry.cpp:910
-#: ../src/msw/registry.cpp:975
+#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
+#: ../src/msw/registry.cpp:963
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "விசை '%s'-இன் மதிப்பை படிக்க இயலாது"
 
-#: ../src/common/image.cpp:2620
+#: ../src/msw/webview_ie.cpp:1017
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/common/image.cpp:2715
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "படிமத்தை '%s'- கோப்பில் சேமிக்க இயலாது: தெரியாத நீட்டிப்பு."
 
-#: ../src/generic/logg.cpp:573 ../src/generic/logg.cpp:976
+#: ../src/generic/logg.cpp:570 ../src/generic/logg.cpp:973
 msgid "Can't save log contents to file."
 msgstr "செயற்குறிப்பேட்டு உள்ளடக்கங்களை கோப்பில் சேமிக்க இயலாது"
 
-#: ../src/msw/thread.cpp:629
+#: ../src/msw/thread.cpp:621
 msgid "Can't set thread priority"
 msgstr "இழையின் முன்னுரிமையை அமைக்க இயலாது"
 
-#: ../src/msw/registry.cpp:896 ../src/msw/registry.cpp:938
-#: ../src/msw/registry.cpp:1081
+#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
+#: ../src/msw/registry.cpp:1069
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "'%s'-இன் மதிப்பை அமைக்க இயலாது"
 
-#: ../src/unix/utilsunx.cpp:351
+#: ../src/unix/utilsunx.cpp:353
 msgid "Can't write to child process's stdin"
 msgstr "சேய் செயல்முறை stdin-ல் எழுத இயலாது"
 
-#: ../src/common/zstream.cpp:427
+#: ../src/common/zstream.cpp:424
 #, c-format
 msgid "Can't write to deflate stream: %s"
 msgstr "அமிழோடையில் எழுத இயலாது: %s"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:279 ../src/richtext/richtextstyledlg.cpp:300
-#: ../src/common/stockitem.cpp:145 ../src/common/accelcmn.cpp:71
-#: ../src/msw/msgdlg.cpp:454 ../src/msw/progdlg.cpp:673
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:142
+#: ../src/common/accelcmn.cpp:68 ../src/motif/msgdlg.cpp:196
+#: ../src/gtk1/fontdlg.cpp:144 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/progdlg.cpp:940 ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "விலக்குக"
 
-#: ../src/common/filefn.cpp:1261
+#: ../src/common/filefn.cpp:1149
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "'%s' கோப்புகளை கணக்கிட இயலாது"
 
-#: ../src/msw/dir.cpp:263
+#: ../src/msw/dir.cpp:260
 #, c-format
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "'%s' அடைவில் இருக்கும் கோப்புகளை கணக்கிட இயலாது"
 
-#: ../src/msw/dialup.cpp:523
+#: ../src/msw/dialup.cpp:517
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "செயலில் இருக்கும் சுழல் இணைப்பை காண இயலவில்லை: %s"
 
-#: ../src/msw/dialup.cpp:827
+#: ../src/msw/dialup.cpp:821
 msgid "Cannot find the location of address book file"
 msgstr "முகவரி ஏட்டுக் கோப்பின் இருப்பிடத்தை காண இயலவில்லை"
 
-#: ../src/msw/ole/automtn.cpp:562
+#: ../src/msw/ole/automtn.cpp:553
 #, c-format
 msgid "Cannot get an active instance of \"%s\""
 msgstr "\"%s\"-இன் செயல் நிகழ்வை பெற இயலவில்லை"
 
-#: ../src/unix/threadpsx.cpp:1035
+#: ../src/unix/threadpsx.cpp:1053
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "%d கொள்கையை காலவரையீடுச் செய்ய, முன்னுரிமை வீச்சை பெற இயலவில்லை"
 
-#: ../src/unix/utilsunx.cpp:987
+#: ../src/unix/utilsunx.cpp:989
 msgid "Cannot get the hostname"
 msgstr "வழங்கியின் பெயரை பெற இயலவில்லை"
 
-#: ../src/unix/utilsunx.cpp:1023
+#: ../src/unix/utilsunx.cpp:1025
 msgid "Cannot get the official hostname"
 msgstr "வழங்கியின் அதிகாரப் பூர்வப் பெயரை பெற இயலவில்லை"
 
-#: ../src/msw/dialup.cpp:928
+#: ../src/msw/dialup.cpp:922
 msgid "Cannot hang up - no active dialup connection."
 msgstr "துண்டிக்க இயலாது - செயலில் இருக்கும் சுழல் இணைப்பு ஏதுமில்லை"
 
@@ -1830,127 +1835,127 @@ msgstr "துண்டிக்க இயலாது - செயலில் �
 msgid "Cannot initialize OLE"
 msgstr "OLE-இனை துவக்க நிலையாக்க இயலவில்லை"
 
-#: ../src/common/socket.cpp:853
+#: ../src/common/socket.cpp:850
 msgid "Cannot initialize sockets"
 msgstr "பொருத்திகளை துவக்க நிலையாக்க இயலவில்லை"
 
-#: ../src/msw/volume.cpp:619
+#: ../src/msw/volume.cpp:627
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "'%s'-இருந்து படவுருக்களை ஏற்ற இயலவில்லை."
 
-#: ../src/xrc/xmlres.cpp:360
+#: ../src/xrc/xmlres.cpp:358
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "'%s'-இருந்து வளங்களை ஏற்ற இயலவில்லை."
 
-#: ../src/xrc/xmlres.cpp:742
+#: ../src/xrc/xmlres.cpp:740
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "'%s' கோப்பிலிருந்து வளங்களை ஏற்ற இயலவில்லை."
 
-#: ../src/html/htmlfilt.cpp:137
+#: ../src/html/htmlfilt.cpp:134
 #, c-format
 msgid "Cannot open HTML document: %s"
 msgstr "HTML ஆவணத்தை திறக்க இயலாது: %s"
 
-#: ../src/html/helpdata.cpp:667
+#: ../src/html/helpdata.cpp:660
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "HTML உதவி ஏட்டினை திறக்க இயலாது: %s"
 
-#: ../src/html/helpdata.cpp:299
+#: ../src/html/helpdata.cpp:296
 #, c-format
 msgid "Cannot open contents file: %s"
 msgstr "உள்ளடக்கக் கோப்பினை திறக்க இயலாது: %s"
 
-#: ../src/generic/dcpsg.cpp:1667
+#: ../src/generic/dcpsg.cpp:1665
 msgid "Cannot open file for PostScript printing!"
 msgstr "Postscript அச்சிடுதலுக்கு கோப்பினை திறக்க இயலாது!"
 
-#: ../src/html/helpdata.cpp:313
+#: ../src/html/helpdata.cpp:310
 #, c-format
 msgid "Cannot open index file: %s"
 msgstr "சுட்டெண் கோப்பினை திறக்க இயலாது: %s"
 
-#: ../src/xrc/xmlres.cpp:724
+#: ../src/xrc/xmlres.cpp:722
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "'%s' வளங்கள் கோப்பினை திறக்க இயலாது"
 
-#: ../src/html/helpwnd.cpp:1534
+#: ../src/html/helpwnd.cpp:1532
 msgid "Cannot print empty page."
 msgstr "வெற்றுப் பக்கத்தை அச்சிட இயலாது"
 
-#: ../src/msw/volume.cpp:507
+#: ../src/msw/volume.cpp:515
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "'%s'-இருந்து வகைப் பெயரை படிக்க இயலவில்லை"
 
-#: ../src/msw/thread.cpp:888
+#: ../src/msw/thread.cpp:894
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "%lx இழையை மீண்டும் தொடர இயலாது"
 
-#: ../src/unix/threadpsx.cpp:1016
+#: ../src/unix/threadpsx.cpp:1028
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "இழை காலவரையீட்டுக் கொள்கையை மீட்க இயலாது"
 
-#: ../src/common/intl.cpp:558
+#: ../src/common/intl.cpp:365
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "\"%s\" மொழிக்கு வட்டார மொழியை அமைக்க இயலவில்லை"
 
-#: ../src/unix/threadpsx.cpp:831 ../src/msw/thread.cpp:546
+#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
 msgid "Cannot start thread: error writing TLS."
 msgstr "இழையைத் துவக்க இயலவில்லை: TLS எழுதுவதில் பிழை "
 
-#: ../src/msw/thread.cpp:872
+#: ../src/msw/thread.cpp:864
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "%lx இழையை இடைநிறுத்த இயலாது"
 
-#: ../src/msw/thread.cpp:794
+#: ../src/msw/thread.cpp:786
 msgid "Cannot wait for thread termination"
 msgstr "இழை முடித்தலுக்கு காத்திருக்க இயலாது"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:75
+#: ../src/common/accelcmn.cpp:72
 #, fuzzy
 msgid "Capital"
 msgstr "முகப்புகள்"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:879
+#: ../src/propgrid/advprops.cpp:780
 msgid "CaptionText"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:531
 msgid "Case sensitive"
 msgstr "எழுத்து வகை உணரி"
 
-#: ../src/propgrid/manager.cpp:1509
+#: ../src/propgrid/manager.cpp:1527
 msgid "Categorized Mode"
 msgstr "வகைப்படுத்தப்பட்ட நிலை"
 
-#: ../src/richtext/richtextbuffer.cpp:9968
+#: ../src/richtext/richtextbuffer.cpp:9965
 msgid "Cell Properties"
 msgstr "சிறுகட்ட பண்புகள்"
 
-#: ../src/common/fmapbase.cpp:161
+#: ../src/common/fmapbase.cpp:158
 msgid "Celtic (ISO-8859-14)"
 msgstr "Celtic (ISO-8859-14)"
 
-#: ../src/richtext/richtextindentspage.cpp:160
 #: ../src/richtext/richtextliststylepage.cpp:349
+#: ../src/richtext/richtextindentspage.cpp:160
 msgid "Cen&tred"
 msgstr "நடுவாக்கப்பட்டது"
 
-#: ../src/common/stockitem.cpp:170
+#: ../src/common/stockitem.cpp:167
 msgid "Centered"
 msgstr "நடுவாக்கப்பட்டது"
 
-#: ../src/common/fmapbase.cpp:149
+#: ../src/common/fmapbase.cpp:146
 msgid "Central European (ISO-8859-2)"
 msgstr "நடு ஐரோப்பா (ISO-8859-2)"
 
@@ -1959,10 +1964,10 @@ msgstr "நடு ஐரோப்பா (ISO-8859-2)"
 msgid "Centre"
 msgstr "நடு"
 
-#: ../src/richtext/richtextindentspage.cpp:162
-#: ../src/richtext/richtextindentspage.cpp:164
 #: ../src/richtext/richtextliststylepage.cpp:351
 #: ../src/richtext/richtextliststylepage.cpp:353
+#: ../src/richtext/richtextindentspage.cpp:162
+#: ../src/richtext/richtextindentspage.cpp:164
 msgid "Centre text."
 msgstr "உரையை நடுவாக்கு"
 
@@ -1975,24 +1980,24 @@ msgstr "நடுவாக்கப்பட்டது"
 msgid "Ch&oose..."
 msgstr "தேர்ந்தெடுக்கவும்..."
 
-#: ../src/richtext/richtextbuffer.cpp:4354
+#: ../src/richtext/richtextbuffer.cpp:4351
 msgid "Change List Style"
 msgstr "வரிசைப் பட்டியலின் பாங்கினை மாற்றுக"
 
-#: ../src/richtext/richtextbuffer.cpp:3709
+#: ../src/richtext/richtextbuffer.cpp:3706
 msgid "Change Object Style"
 msgstr "பொருளின் பாங்கினை மாற்றுக"
 
-#: ../src/richtext/richtextbuffer.cpp:3982
-#: ../src/richtext/richtextbuffer.cpp:8129
+#: ../src/richtext/richtextbuffer.cpp:3979
+#: ../src/richtext/richtextbuffer.cpp:8125
 msgid "Change Properties"
 msgstr "பண்புகளை மாற்றுக"
 
-#: ../src/richtext/richtextbuffer.cpp:3526
+#: ../src/richtext/richtextbuffer.cpp:3523
 msgid "Change Style"
 msgstr "பாங்கினை மாற்றுக"
 
-#: ../src/common/fileconf.cpp:341
+#: ../src/common/fileconf.cpp:335
 #, c-format
 msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
 msgstr "\"%s\" கோப்பினை அழித்தெழுதாமல் இருக்க, மாற்றங்கள் சேமிக்கப்பட மாட்டாது"
@@ -2003,12 +2008,12 @@ msgid "Changing current directory to \"%s\" failed"
 msgstr "\"%s\" அடைவினை உருவாக்குவதில் தோல்வி."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1757
+#: ../src/propgrid/advprops.cpp:1658
 #, fuzzy
 msgid "Character"
 msgstr "வரியுருக் குறி"
 
-#: ../src/richtext/richtextstyles.cpp:1063
+#: ../src/richtext/richtextstyles.cpp:1060
 msgid "Character styles"
 msgstr "வரியுருப் பாங்குகள்"
 
@@ -2045,20 +2050,20 @@ msgstr "அடைப்புக் குறிகளினுள் தோட�
 msgid "Check to indicate right-to-left text layout."
 msgstr "உரையின் வரைவு வலமிருந்து இடமாகக் காட்டப்படுவதை உறுதி செய்க"
 
-#: ../src/osx/carbon/fontdlg.cpp:356 ../src/osx/carbon/fontdlg.cpp:358
+#: ../src/osx/carbon/fontdlg.cpp:353 ../src/osx/carbon/fontdlg.cpp:355
 msgid "Check to make the font bold."
 msgstr "எழுத்துரு அடர்த்தியாக்கப்பட்டிருப்பதை உறுதி செய்க."
 
-#: ../src/osx/carbon/fontdlg.cpp:363 ../src/osx/carbon/fontdlg.cpp:365
+#: ../src/osx/carbon/fontdlg.cpp:360 ../src/osx/carbon/fontdlg.cpp:362
 msgid "Check to make the font italic."
 msgstr "எழுத்துரு வலப்பக்க சாய்வினை உறுதி செய்க."
 
-#: ../src/osx/carbon/fontdlg.cpp:372 ../src/osx/carbon/fontdlg.cpp:374
+#: ../src/osx/carbon/fontdlg.cpp:369 ../src/osx/carbon/fontdlg.cpp:371
 msgid "Check to make the font underlined."
 msgstr "எழுத்துரு அடிக்கோடிடப்பட்டிருப்பதை உறுதி செய்க."
 
-#: ../src/richtext/richtextstyledlg.cpp:289
-#: ../src/richtext/richtextstyledlg.cpp:291
+#: ../src/richtext/richtextstyledlg.cpp:285
+#: ../src/richtext/richtextstyledlg.cpp:287
 msgid "Check to restart numbering."
 msgstr "எண்ணிடல் மறுதுவக்கப்படுவதை உறுதி செய்க."
 
@@ -2092,51 +2097,51 @@ msgstr "மேலெழுத்துகளில் உரை காட்ட�
 msgid "Check to suppress hyphenation."
 msgstr "இணைக்கோடு மறைக்கப்படுவதை உறுதி செய்க."
 
-#: ../src/msw/dialup.cpp:763
+#: ../src/msw/dialup.cpp:757
 msgid "Choose ISP to dial"
 msgstr "சுழற்றுவதற்கு ISP-யினை தேர்ந்தெடுக்கவும்"
 
-#: ../src/propgrid/props.cpp:1922
+#: ../src/propgrid/props.cpp:1904
 msgid "Choose a directory:"
 msgstr "ஒரு அடைவைத் தேர்ந்தெடுக்கவும்:"
 
-#: ../src/propgrid/props.cpp:1975
+#: ../src/propgrid/props.cpp:2199
 msgid "Choose a file"
 msgstr "ஒரு கோப்பினைத் தேர்ந்தெடுக்கவும்"
 
-#: ../src/generic/colrdlgg.cpp:158 ../src/gtk/colordlg.cpp:54
+#: ../src/generic/colrdlgg.cpp:156 ../src/gtk/colordlg.cpp:49
 msgid "Choose colour"
 msgstr "நிறத்தைத் தேர்ந்தெடுக்கவும்"
 
-#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/gtk1/fontdlg.cpp:125 ../src/generic/fontpickerg.cpp:47
+#: ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "எழுத்துருவைத் தேர்ந்தெடுக்கவும்"
 
-#: ../src/common/module.cpp:74
+#: ../src/common/module.cpp:71
 #, c-format
 msgid "Circular dependency involving module \"%s\" detected."
 msgstr "\"%s\" நிரற்கூறு தொடர்புடைய சுற்றுச் சார்பு கண்டுபிடிக்கப்பட்டது."
 
-#: ../src/aui/tabmdi.cpp:108 ../src/generic/mdig.cpp:97
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
 msgid "Cl&ose"
 msgstr "மூடுக"
 
-#: ../src/msw/ole/automtn.cpp:684
+#: ../src/msw/ole/automtn.cpp:675
 msgid "Class not registered."
 msgstr "உட்பிரிவு பதிவு செய்யப்படவில்லை"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:147 ../src/common/accelcmn.cpp:72
+#: ../src/common/stockitem.cpp:144 ../src/common/accelcmn.cpp:69
 msgid "Clear"
 msgstr "துடை"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "Clear the log contents"
 msgstr "செயற்குறிப்பேட்டு உள்ளடக்கங்களை துடை"
 
-#: ../src/richtext/richtextstyledlg.cpp:252
-#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:248
+#: ../src/richtext/richtextstyledlg.cpp:250
 msgid "Click to apply the selected style."
 msgstr "தெரிவு செய்யப்பட்ட பாங்கினை இட, சொடுக்கவும்."
 
@@ -2147,15 +2152,15 @@ msgstr "தெரிவு செய்யப்பட்ட பாங்கி�
 msgid "Click to browse for a symbol."
 msgstr "ஒரு குறியெழுத்தை உலாவித் தேட, சொடுக்கவும்."
 
-#: ../src/osx/carbon/fontdlg.cpp:403 ../src/osx/carbon/fontdlg.cpp:405
+#: ../src/osx/carbon/fontdlg.cpp:400 ../src/osx/carbon/fontdlg.cpp:402
 msgid "Click to cancel changes to the font."
 msgstr "எழுத்துரு மாற்றங்களை விலக்க, சொடுக்கவும்."
 
-#: ../src/generic/fontdlgg.cpp:472 ../src/generic/fontdlgg.cpp:491
+#: ../src/generic/fontdlgg.cpp:468 ../src/generic/fontdlgg.cpp:487
 msgid "Click to cancel the font selection."
 msgstr "எழுத்துரு தெரிவினை விலக்க, சொடுக்கவும்."
 
-#: ../src/osx/carbon/fontdlg.cpp:384 ../src/osx/carbon/fontdlg.cpp:386
+#: ../src/osx/carbon/fontdlg.cpp:381 ../src/osx/carbon/fontdlg.cpp:383
 msgid "Click to change the font colour."
 msgstr "எழுத்துரு நிறத்தை மாற்ற சொடுக்கவும்."
 
@@ -2174,37 +2179,37 @@ msgstr "உரையின் நிறத்தை மாற்ற சொடு
 msgid "Click to choose the font for this level."
 msgstr "இந்த நிலைக்கான எழுத்துருவைத் தேர்ந்தெடுக்க சொடுக்கவும்."
 
-#: ../src/richtext/richtextstyledlg.cpp:279
-#: ../src/richtext/richtextstyledlg.cpp:281
+#: ../src/richtext/richtextstyledlg.cpp:275
+#: ../src/richtext/richtextstyledlg.cpp:277
 msgid "Click to close this window."
 msgstr "இச்சாளரத்தை மூட சொடுக்கவும்."
 
-#: ../src/osx/carbon/fontdlg.cpp:410 ../src/osx/carbon/fontdlg.cpp:412
+#: ../src/osx/carbon/fontdlg.cpp:407 ../src/osx/carbon/fontdlg.cpp:409
 msgid "Click to confirm changes to the font."
 msgstr "எழுத்துருவில் ஏற்பட்டுள்ள மாற்றங்களை உறுதி செய்ய சொடுக்கவும்."
 
-#: ../src/generic/fontdlgg.cpp:477 ../src/generic/fontdlgg.cpp:479
-#: ../src/generic/fontdlgg.cpp:484 ../src/generic/fontdlgg.cpp:486
+#: ../src/generic/fontdlgg.cpp:473 ../src/generic/fontdlgg.cpp:475
+#: ../src/generic/fontdlgg.cpp:480 ../src/generic/fontdlgg.cpp:482
 msgid "Click to confirm the font selection."
 msgstr "எழுத்துரு தெரிவினை உறுதி செய்ய சொடுக்கவும்."
 
-#: ../src/richtext/richtextstyledlg.cpp:244
-#: ../src/richtext/richtextstyledlg.cpp:246
+#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:242
 msgid "Click to create a new box style."
 msgstr "ஒரு புதுப் பெட்டிப் பாங்கினை உருவாக்க சொடுக்கவும்."
 
-#: ../src/richtext/richtextstyledlg.cpp:226
-#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:224
 msgid "Click to create a new character style."
 msgstr "ஒரு புது வரியுருப் பாங்கினை உருவாக்க சொடுக்கவும்."
 
-#: ../src/richtext/richtextstyledlg.cpp:238
-#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:236
 msgid "Click to create a new list style."
 msgstr "ஒரு புது வரிசைப் பட்டியல் பாங்கினை உருவாக்க சொடுக்கவும்."
 
-#: ../src/richtext/richtextstyledlg.cpp:232
-#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:230
 msgid "Click to create a new paragraph style."
 msgstr "ஒரு புதுப் பத்திப் பாங்கினை உருவாக்க சொடுக்கவும்."
 
@@ -2218,8 +2223,8 @@ msgstr "ஒரு புதுத் தத்தல் நிலையை உ�
 msgid "Click to delete all tab positions."
 msgstr "எல்லா தத்தல் நிலைகளையும் நீக்க சொடுக்கவும்."
 
-#: ../src/richtext/richtextstyledlg.cpp:270
-#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:268
 msgid "Click to delete the selected style."
 msgstr "தெரிவு செய்யப்பட்டுள்ள பாங்கினை நீக்க சொடுக்கவும்."
 
@@ -2228,25 +2233,25 @@ msgstr "தெரிவு செய்யப்பட்டுள்ள பா�
 msgid "Click to delete the selected tab position."
 msgstr "தெரிவு செய்யப்பட்டுள்ள தத்தல் நிலையை நீக்க சொடுக்கவும்."
 
-#: ../src/richtext/richtextstyledlg.cpp:264
-#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:262
 msgid "Click to edit the selected style."
 msgstr "தெரிவு செய்யப்பட்டுள்ள பாங்கினை தொகுக்க சொடுக்கவும்."
 
-#: ../src/richtext/richtextstyledlg.cpp:258
-#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:256
 msgid "Click to rename the selected style."
 msgstr "தெரிவு செய்யப்பட்டுள்ள பாங்கினை மறுபெயரிட சொடுக்கவும்."
 
-#: ../src/generic/dbgrptg.cpp:97 ../src/generic/progdlgg.cpp:759
-#: ../src/richtext/richtextstyledlg.cpp:277
-#: ../src/richtext/richtextsymboldlg.cpp:476 ../src/common/stockitem.cpp:148
-#: ../src/msw/progdlg.cpp:170 ../src/msw/progdlg.cpp:679
-#: ../src/html/helpdlg.cpp:90
+#: ../src/common/stockitem.cpp:145 ../src/generic/dbgrptg.cpp:94
+#: ../src/generic/progdlgg.cpp:781 ../src/msw/progdlg.cpp:211
+#: ../src/msw/progdlg.cpp:946 ../src/html/helpdlg.cpp:87
+#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextstyledlg.cpp:273
 msgid "Close"
 msgstr "மூடுக"
 
-#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:98
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
 msgid "Close All"
 msgstr "எல்லாவற்றையும் மூடுக"
 
@@ -2254,55 +2259,55 @@ msgstr "எல்லாவற்றையும் மூடுக"
 msgid "Close current document"
 msgstr "தற்போதைய ஆவணத்தை மூடுக"
 
-#: ../src/generic/logg.cpp:516
+#: ../src/generic/logg.cpp:513
 msgid "Close this window"
 msgstr "இந்த சாளரத்தை மூடுக"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6006
+#: ../src/generic/datavgen.cpp:6811
 msgid "Collapse"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "Color"
 msgstr "நிறம்"
 
-#: ../src/richtext/richtextformatdlg.cpp:776
+#: ../src/richtext/richtextformatdlg.cpp:768
 msgid "Colour"
 msgstr "நிறம்"
 
-#: ../src/msw/colordlg.cpp:158
+#: ../src/msw/colordlg.cpp:227
 #, c-format
 msgid "Colour selection dialog failed with error %0lx."
 msgstr "நிறத் தெரிவு உரையாடல் தோல்வியடைந்தது. பிழை: %0lx."
 
-#: ../src/osx/carbon/fontdlg.cpp:380
+#: ../src/osx/carbon/fontdlg.cpp:377
 msgid "Colour:"
 msgstr "நிறம்:"
 
-#: ../src/generic/datavgen.cpp:6077
+#: ../src/generic/datavgen.cpp:6882
 #, fuzzy, c-format
 msgid "Column %u"
 msgstr "செங்குத்து வரிசையை சேர்க்கவும்"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:114
+#: ../src/common/accelcmn.cpp:112
 msgid "Command"
 msgstr ""
 
-#: ../src/common/init.cpp:196
+#: ../src/common/init.cpp:193
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
 "ignored."
 msgstr "%d கட்டளை வரி தர்க்கத்தை ஒருங்குறியாக மாற்ற இயலாததால், அது தவிர்க்கப்படும்."
 
-#: ../src/msw/fontdlg.cpp:120
+#: ../src/msw/fontdlg.cpp:170
 #, c-format
 msgid "Common dialog failed with error code %0lx."
 msgstr "பொது உரையாடல் தோல்வியடைந்தது. பிழைக் குறி: %0lx."
 
-#: ../src/gtk/window.cpp:4649
+#: ../src/gtk/window.cpp:5653
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
@@ -2310,11 +2315,11 @@ msgstr ""
 "தங்கள் கணினி கலக்குதலை ஆதரிப்பதில்லை. கருணைக்கூர்ந்து தங்களின் சாளர மேலாளரில் இதை "
 "செயற்படுத்தவும்."
 
-#: ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:1549
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "குறுக்கப்பட்ட HTML உதவிக் கோப்பு (*.chm)|*.chm|"
 
-#: ../src/generic/dirctrlg.cpp:444
+#: ../src/generic/dirctrlg.cpp:410
 msgid "Computer"
 msgstr "கணினி"
 
@@ -2323,53 +2328,57 @@ msgstr "கணினி"
 msgid "Config entry name cannot start with '%c'."
 msgstr "அமைவடிவ உள்ளிடின் பெயர் '%c' என்று துவங்க இயலாது."
 
-#: ../src/generic/filedlgg.cpp:349 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
 msgid "Confirm"
 msgstr "உறுதிச் செய்க"
 
-#: ../src/html/htmlwin.cpp:566
+#: ../src/html/htmlwin.cpp:569
 msgid "Connecting..."
 msgstr "இணைக்கப்படுகிறது..."
 
-#: ../src/html/helpwnd.cpp:475
+#: ../src/html/helpwnd.cpp:473
 msgid "Contents"
 msgstr "உள்ளடக்கங்கள்"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:880
+#: ../src/propgrid/advprops.cpp:781
 msgid "ControlDark"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:881
+#: ../src/propgrid/advprops.cpp:782
 msgid "ControlLight"
 msgstr ""
 
-#: ../src/common/strconv.cpp:2262
+#: ../src/common/strconv.cpp:2208
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Charset '%s'-க்கான மாற்றம் செயல்படுவதில்லை."
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "Convert"
 msgstr "மாற்று"
 
-#: ../src/html/htmlwin.cpp:1079
+#: ../src/html/htmlwin.cpp:1020
 #, c-format
 msgid "Copied to clipboard:\"%s\""
 msgstr "பிடிப்புப் பலகைக்கு படியெடுக்கப்பட்டது: \"%s\""
 
-#: ../src/generic/prntdlgg.cpp:247
+#: ../src/generic/prntdlgg.cpp:240
 msgid "Copies:"
 msgstr "படிகள்:"
 
-#: ../src/common/stockitem.cpp:150 ../src/stc/stc_i18n.cpp:18
+#: ../src/common/stockitem.cpp:147 ../src/stc/stc_i18n.cpp:18
 msgid "Copy"
 msgstr "படி"
 
-#: ../src/common/stockitem.cpp:258
+#: ../src/common/stockitem.cpp:255
 msgid "Copy selection"
 msgstr "தெரிவினை படியெடு"
+
+#: ../src/generic/grid.cpp:5945
+msgid "Copying more than one selected block to clipboard is not supported."
+msgstr ""
 
 #: ../src/richtext/richtextborderspage.cpp:566
 #: ../src/richtext/richtextborderspage.cpp:601
@@ -2380,200 +2389,196 @@ msgstr "எல்லைக் கோணம்"
 msgid "Corner &radius:"
 msgstr "எல்லைக் கோணத்தின் ஆரம்"
 
-#: ../src/html/chm.cpp:718
+#: ../src/html/chm.cpp:711
 #, c-format
 msgid "Could not create temporary file '%s'"
 msgstr "'%s' தற்காலிக கோப்பினை உருவாக்க இயலவில்லை"
 
-#: ../src/html/chm.cpp:273
+#: ../src/html/chm.cpp:270
 #, c-format
 msgid "Could not extract %s into %s: %s"
 msgstr "%s-ஐ  %s-ற்குள் பிரித்தெடுக்க இயலவில்லை: %s"
 
-#: ../src/generic/tabg.cpp:1048
+#: ../src/generic/tabg.cpp:1045
 msgid "Could not find tab for id"
 msgstr "அடையாளத்திற்கான தத்தலை காண இயலவில்லை"
 
-#: ../src/gtk/notifmsg.cpp:108
-#, fuzzy
-msgid "Could not initalize libnotify."
-msgstr "ஒழுங்கமைக்க இயலவில்லை."
-
-#: ../src/html/chm.cpp:444
+#: ../src/html/chm.cpp:437
 #, c-format
 msgid "Could not locate file '%s'."
 msgstr "'%s' கோப்பினை இடங்காண இயலவில்லை."
 
-#: ../src/common/filefn.cpp:1403
+#: ../src/msw/graphicsd2d.cpp:604
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/common/filefn.cpp:1291
 msgid "Could not set current working directory"
 msgstr "தற்போதைய செயல் அடைவினை அமைக்க இயலவில்லை."
 
-#: ../src/common/prntbase.cpp:2015
+#: ../src/common/prntbase.cpp:2037
 msgid "Could not start document preview."
 msgstr "ஆவணத்தின் முன்தோற்றத்தை துவக்க இயலவில்லை."
 
-#: ../src/generic/printps.cpp:178 ../src/msw/printwin.cpp:210
-#: ../src/gtk/print.cpp:1132
+#: ../src/generic/printps.cpp:159 ../src/msw/printwin.cpp:184
+#: ../src/gtk/print.cpp:1129
 msgid "Could not start printing."
 msgstr "அச்சிடுதலை துவக்க இயலவில்லை."
 
-#: ../src/common/wincmn.cpp:2125
+#: ../src/common/wincmn.cpp:2126
 msgid "Could not transfer data to window"
 msgstr "சாளரத்திற்கு தரவினை மாற்ற இயலவில்லை."
 
-#: ../src/msw/imaglist.cpp:187 ../src/msw/imaglist.cpp:224
-#: ../src/msw/imaglist.cpp:249 ../src/msw/dragimag.cpp:185
-#: ../src/msw/dragimag.cpp:220
+#: ../src/msw/imaglist.cpp:223 ../src/msw/imaglist.cpp:245
+#: ../src/msw/imaglist.cpp:270 ../src/msw/dragimag.cpp:182
+#: ../src/msw/dragimag.cpp:217
 msgid "Couldn't add an image to the image list."
 msgstr "படிமங்களின் வரிசைப் பட்டியலில் ஒரு படிமத்தை சேர்க்க இயலவில்லை."
 
-#: ../src/osx/glcanvas_osx.cpp:414 ../src/unix/glx11.cpp:558
-#: ../src/msw/glcanvas.cpp:616
+#: ../src/osx/glcanvas_osx.cpp:411 ../src/msw/glcanvas.cpp:631
+#: ../src/unix/glegl.cpp:315 ../src/unix/glx11.cpp:559
 #, fuzzy
 msgid "Couldn't create OpenGL context"
 msgstr "நேரங்காட்டியை உருவாக்க இயலவில்லை."
 
-#: ../src/msw/timer.cpp:134
+#: ../src/msw/timer.cpp:131
 msgid "Couldn't create a timer"
 msgstr "நேரங்காட்டியை உருவாக்க இயலவில்லை."
 
-#: ../src/osx/carbon/overlay.cpp:122
-msgid "Couldn't create the overlay window"
-msgstr "மேலமைவுச் சாளரத்தை உருவாக்க இயலவில்லை."
-
-#: ../src/common/translation.cpp:2024
+#: ../src/common/translation.cpp:2074
 msgid "Couldn't enumerate translations"
 msgstr "மொழிபெயர்ப்புகளை கணக்கிட இயலவில்லை"
 
-#: ../src/common/dynlib.cpp:120
+#: ../src/common/dynlib.cpp:110
 #, c-format
 msgid "Couldn't find symbol '%s' in a dynamic library"
 msgstr "'%s' குறியெழுத்தினை இயங்குநிலை நூலகத்தில் காண இயலவில்லை."
 
-#: ../src/msw/thread.cpp:915
+#: ../src/msw/thread.cpp:921
 msgid "Couldn't get the current thread pointer"
 msgstr "தற்போதைய இழைக்குறியை பெற இயலவில்லை."
 
-#: ../src/osx/carbon/overlay.cpp:129
-msgid "Couldn't init the context on the overlay window"
-msgstr "மேலமைவுச் சாளரத்தின் மீது சூழமைவைத் init  செய்ய இயலவில்லை."
-
-#: ../src/common/imaggif.cpp:244
+#: ../src/common/imaggif.cpp:241
 msgid "Couldn't initialize GIF hash table."
 msgstr "GIF Hash அட்டவணையை துவக்க நிலையாக்க செய்ய இயலவில்லை."
 
-#: ../src/common/imagpng.cpp:409
+#: ../src/common/imagpng.cpp:437
 msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
 msgstr ""
 "PNG படிமத்தை ஏற்ற இயலவில்லை - கோப்பு பழுதாகி இருக்கலாம், அல்லது குறை நினைவகமாக "
 "இருக்கலாம்"
 
-#: ../src/unix/sound.cpp:470
+#: ../src/unix/sound.cpp:459
 #, c-format
 msgid "Couldn't load sound data from '%s'."
 msgstr "'%s' இருந்து ஒலி தரவினை ஏற்ற இயலவில்லை"
 
-#: ../src/msw/dirdlg.cpp:435
+#: ../src/msw/dirdlg.cpp:287
 msgid "Couldn't obtain folder name"
 msgstr "கோப்புறையின் பெயரை பெற இயலவில்லை"
 
-#: ../src/unix/sound_sdl.cpp:229
+#: ../src/unix/sound_sdl.cpp:226
 #, c-format
 msgid "Couldn't open audio: %s"
 msgstr "ஒலியத்தை திறக்க இயலவில்லை: %s"
 
-#: ../src/msw/ole/dataobj.cpp:377
+#: ../src/msw/ole/dataobj.cpp:385
 #, c-format
 msgid "Couldn't register clipboard format '%s'."
 msgstr "'%s' பிடிப்புப் பலகை வடிவூட்டத்தை பதிவு செய்ய இயலவில்லை."
 
-#: ../src/msw/listctrl.cpp:869
+#: ../src/msw/listctrl.cpp:933
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "%d வரிசைப்பட்டியல் கட்டுப்பாடு உருப்படியின் தகவலை மீட்க இயலவில்லை."
 
-#: ../src/common/imagpng.cpp:498 ../src/common/imagpng.cpp:509
-#: ../src/common/imagpng.cpp:519
+#: ../src/common/imagpng.cpp:511 ../src/common/imagpng.cpp:522
+#: ../src/common/imagpng.cpp:532
 msgid "Couldn't save PNG image."
 msgstr "PNG படிமத்தை சேமிக்க இயலவில்லை."
 
-#: ../src/msw/thread.cpp:684
+#: ../src/msw/thread.cpp:676
 msgid "Couldn't terminate thread"
 msgstr "இழையை முடிக்க இயலவில்லை."
 
-#: ../src/common/xtistrm.cpp:166
+#: ../src/common/xtistrm.cpp:163
 #, c-format
 msgid "Create Parameter %s not found in declared RTTI Parameters"
 msgstr ""
 "உருவாக்கப்பட்டுள்ள %s அளவுக்குறி, அறிவிக்கப்பட்ட RTTI அளவுக்குறிகளில் காணப்படவில்லை."
 
-#: ../src/generic/dirdlgg.cpp:288
+#: ../src/generic/dirdlgg.cpp:285
 msgid "Create directory"
 msgstr "அடைவினை உருவாக்குக"
 
-#: ../src/generic/filedlgg.cpp:212 ../src/generic/dirdlgg.cpp:111
+#: ../src/generic/filedlgg.cpp:209 ../src/generic/dirdlgg.cpp:108
 msgid "Create new directory"
 msgstr "புதிய அடைவினை உருவாக்குக"
 
-#: ../src/xrc/xmlres.cpp:2460
+#: ../src/common/stockitem.cpp:264
+#, fuzzy
+msgid "Create new document"
+msgstr "புதிய அடைவினை உருவாக்குக"
+
+#: ../src/xrc/xmlres.cpp:2515
 #, fuzzy, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "'%s', '%s'-ற்குள் பிரித்தெடுப்பது தோல்வியடைந்தது."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1758
+#: ../src/propgrid/advprops.cpp:1659
 msgid "Cross"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:333
+#: ../src/common/accelcmn.cpp:347
 msgid "Ctrl+"
 msgstr "கட்டுப்பாடு+"
 
-#: ../src/richtext/richtextctrl.cpp:332 ../src/osx/textctrl_osx.cpp:576
-#: ../src/common/stockitem.cpp:151 ../src/msw/textctrl.cpp:2507
+#: ../src/osx/textctrl_osx.cpp:594 ../src/common/stockitem.cpp:148
+#: ../src/msw/textctrl.cpp:2772 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "வெட்டுக"
 
-#: ../src/generic/filectrlg.cpp:940
+#: ../src/generic/filectrlg.cpp:936
 msgid "Current directory:"
 msgstr "தற்போதைய அடைவு"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:896 ../src/propgrid/advprops.cpp:1574
-#: ../src/propgrid/advprops.cpp:1612
+#: ../src/propgrid/advprops.cpp:797 ../src/propgrid/advprops.cpp:1475
+#: ../src/propgrid/advprops.cpp:1518
 #, fuzzy
 msgid "Custom"
 msgstr "தனிப் பயனாக்கப்பட்ட அளவு"
 
-#: ../src/gtk/print.cpp:217
+#: ../src/gtk/print.cpp:211
 msgid "Custom size"
 msgstr "தனிப் பயனாக்கப்பட்ட அளவு"
 
-#: ../src/common/headerctrlcmn.cpp:60
+#: ../src/common/headerctrlcmn.cpp:58
 msgid "Customize Columns"
 msgstr "செங்குத்து வரிசைகளை தனிப் பயனாக்குக"
 
-#: ../src/common/stockitem.cpp:151 ../src/stc/stc_i18n.cpp:17
+#: ../src/common/stockitem.cpp:148 ../src/stc/stc_i18n.cpp:17
 msgid "Cut"
 msgstr "வெட்டுக"
 
-#: ../src/common/stockitem.cpp:259
+#: ../src/common/stockitem.cpp:256
 msgid "Cut selection"
 msgstr "தெரிவினை வெட்டுக"
 
-#: ../src/common/fmapbase.cpp:152
+#: ../src/common/fmapbase.cpp:149
 msgid "Cyrillic (ISO-8859-5)"
 msgstr "Cyrillic (ISO-8859-5)"
 
-#: ../src/common/paper.cpp:99
+#: ../src/common/paper.cpp:96
 msgid "D sheet, 22 x 34 in"
 msgstr "D தாள், 22 x 34 in"
 
-#: ../src/msw/dde.cpp:703
+#: ../src/msw/dde.cpp:698
 msgid "DDE poke request failed"
 msgstr "DDE poke வேண்டுகோள் தோல்வியடைந்தது"
 
-#: ../src/common/imagbmp.cpp:1169
+#: ../src/common/imagbmp.cpp:1181
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr "DIB மேலுரை: குறியாக்கம் bitdepth-உடன் பொருந்தவில்லை."
 
@@ -2593,7 +2598,7 @@ msgstr "DIB மேலுரை: கோப்பில் தெரியாத b
 msgid "DIB Header: Unknown encoding in file."
 msgstr "DIB மேலுரை: கோப்பில் தெரியாத குறியாக்கம்."
 
-#: ../src/common/paper.cpp:121
+#: ../src/common/paper.cpp:118
 msgid "DL Envelope, 110 x 220 mm"
 msgstr "DL அஞ்சல் உறை, 110 x 220 mm"
 
@@ -2601,55 +2606,55 @@ msgstr "DL அஞ்சல் உறை, 110 x 220 mm"
 msgid "Dashed"
 msgstr "கோடிடப்பட்டது"
 
-#: ../src/generic/dbgrptg.cpp:300
+#: ../src/generic/dbgrptg.cpp:301
 #, c-format
 msgid "Debug report \"%s\""
 msgstr "வழுநீக்க அறிக்கை \"%s\""
 
-#: ../src/common/debugrpt.cpp:210
+#: ../src/common/debugrpt.cpp:211
 msgid "Debug report couldn't be created."
 msgstr "வழுநீக்க அறிக்கையை உருவாக்க இயலவில்லை."
 
-#: ../src/common/debugrpt.cpp:553
+#: ../src/common/debugrpt.cpp:554
 msgid "Debug report generation has failed."
 msgstr "வழுநீக்க அறிக்கையின் உருவாக்கம் தோல்வியடைந்துள்ளது."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:84
+#: ../src/common/accelcmn.cpp:81
 msgid "Decimal"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:323
+#: ../src/generic/fontdlgg.cpp:319
 msgid "Decorative"
 msgstr "அலங்காரம்"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1752
+#: ../src/propgrid/advprops.cpp:1653
 #, fuzzy
 msgid "Default"
 msgstr "இயல்பிருப்பு"
 
-#: ../src/common/fmapbase.cpp:796
+#: ../src/common/fmapbase.cpp:792
 msgid "Default encoding"
 msgstr "இயல்புக் குறியாக்கம்"
 
-#: ../src/dfb/fontmgr.cpp:180
+#: ../src/dfb/fontmgr.cpp:177
 msgid "Default font"
 msgstr "இயல்பெழுத்துரு"
 
-#: ../src/generic/prntdlgg.cpp:510
+#: ../src/generic/prntdlgg.cpp:503
 msgid "Default printer"
 msgstr "இயல்பு அச்சுப் பொறி"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:51
+#: ../src/common/accelcmn.cpp:48
 #, fuzzy
 msgid "Del"
 msgstr "அழி"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextbuffer.cpp:8221 ../src/common/stockitem.cpp:152
-#: ../src/common/accelcmn.cpp:50 ../src/stc/stc_i18n.cpp:20
+#: ../src/common/stockitem.cpp:149 ../src/common/accelcmn.cpp:47
+#: ../src/richtext/richtextbuffer.cpp:8217 ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "அழி"
 
@@ -2657,68 +2662,68 @@ msgstr "அழி"
 msgid "Delete A&ll"
 msgstr "எல்லாவற்றையும் அழி"
 
-#: ../src/richtext/richtextbuffer.cpp:11341
+#: ../src/richtext/richtextbuffer.cpp:11340
 msgid "Delete Column"
 msgstr "செங்குத்து வரிசையை அழிக்கவும்"
 
-#: ../src/richtext/richtextbuffer.cpp:11291
+#: ../src/richtext/richtextbuffer.cpp:11290
 msgid "Delete Row"
 msgstr "கிடை வரிசையை அழிக்கவும்"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 msgid "Delete Style"
 msgstr "பாங்கினை அழி"
 
-#: ../src/richtext/richtextctrl.cpp:1345 ../src/richtext/richtextctrl.cpp:1584
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
 msgid "Delete Text"
 msgstr "உரையை அழி"
 
-#: ../src/generic/editlbox.cpp:170
+#: ../src/generic/editlbox.cpp:147
 msgid "Delete item"
 msgstr "உருப்படியை அழி"
 
-#: ../src/common/stockitem.cpp:260
+#: ../src/common/stockitem.cpp:257
 msgid "Delete selection"
 msgstr "தெரிவினை அழி"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 #, c-format
 msgid "Delete style %s?"
 msgstr "%s பாங்கினை அழிக்க வேண்டுமா?"
 
-#: ../src/unix/snglinst.cpp:301
+#: ../src/unix/snglinst.cpp:298
 #, c-format
 msgid "Deleted stale lock file '%s'."
 msgstr "நாள்பட்ட பூட்டு கோப்பு '%s' அழிக்கப்பட்டது."
 
-#: ../src/common/secretstore.cpp:220
+#: ../src/common/secretstore.cpp:234
 #, fuzzy, c-format
-msgid "Deleting password for \"%s/%s\" failed: %s."
+msgid "Deleting password for \"%s\" failed: %s."
 msgstr "'%s', '%s'-ற்குள் பிரித்தெடுப்பது தோல்வியடைந்தது."
 
-#: ../src/common/module.cpp:124
+#: ../src/common/module.cpp:121
 #, c-format
 msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
 msgstr "\"%s\" சார்பு இல்லை. (\"%s\" நிரற்கூறினுடையது)"
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "Descending"
 msgstr "இறங்குமுகமான"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:526 ../src/propgrid/advprops.cpp:882
+#: ../src/generic/dirctrlg.cpp:492 ../src/propgrid/advprops.cpp:783
 msgid "Desktop"
 msgstr "மேசைத்தளம்"
 
-#: ../src/generic/aboutdlgg.cpp:70
+#: ../src/generic/aboutdlgg.cpp:67
 msgid "Developed by "
 msgstr "மேம்படுத்தியது "
 
-#: ../src/generic/aboutdlgg.cpp:176
+#: ../src/generic/aboutdlgg.cpp:173
 msgid "Developers"
 msgstr "மேம்படுத்துநர்கள்"
 
-#: ../src/msw/dialup.cpp:374
+#: ../src/msw/dialup.cpp:368
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -2726,11 +2731,11 @@ msgstr ""
 "தொலை அணுகுப் பணி (RAS) இக்கணினியில் நிறுவப்படவில்லையென்பதால், சுழல் செயல்கள் இல்லாமல் "
 "உள்ளது. கருணைக்கூர்ந்து RAS-ஐ நிறுவவும்."
 
-#: ../src/generic/tipdlg.cpp:211
+#: ../src/generic/tipdlg.cpp:208
 msgid "Did you know..."
 msgstr "தங்களுக்குத் தெரியுமா?"
 
-#: ../src/dfb/wrapdfb.cpp:63
+#: ../src/dfb/wrapdfb.cpp:60
 #, c-format
 msgid "DirectFB error %d occurred."
 msgstr "%d நேரடி FB பிழை ஏற்பட்டுள்ளது."
@@ -2739,30 +2744,30 @@ msgstr "%d நேரடி FB பிழை ஏற்பட்டுள்ளத�
 msgid "Directories"
 msgstr "அடைவுகள்"
 
-#: ../src/common/filefn.cpp:1183
+#: ../src/common/filefn.cpp:1071
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "'%s' அடைவினை உருவாக்க இயலவில்லை"
 
-#: ../src/common/filefn.cpp:1197
+#: ../src/common/filefn.cpp:1085
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "'%s' அடைவினை அழிக்க இயலவில்லை"
 
-#: ../src/generic/dirdlgg.cpp:204
+#: ../src/generic/dirdlgg.cpp:201
 msgid "Directory does not exist"
 msgstr "அடைவு கிடைப்பில் இல்லை"
 
-#: ../src/generic/filectrlg.cpp:1399
+#: ../src/generic/filectrlg.cpp:1388
 msgid "Directory doesn't exist."
 msgstr "அடைவு கிடைப்பில் இல்லை"
 
-#: ../src/common/docview.cpp:457
+#: ../src/common/docview.cpp:450
 msgid "Discard changes and reload the last saved version?"
 msgstr ""
 "மாற்றங்களை நிராகரித்துவிட்டு இறுதியாக சேமிக்கப்பட்டுள்ள பதிப்பை மறுஏற்றம் செய்ய வேண்டுமா?"
 
-#: ../src/html/helpwnd.cpp:502
+#: ../src/html/helpwnd.cpp:500
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -2770,45 +2775,45 @@ msgstr ""
 "கொடுக்கப்பட்ட உட்சரத்தை கொண்டுள்ள சுட்டெண் உருப்படிகளை காட்டுக. ஒரு எழுத்து முகப்பெழுத்தா "
 "இல்லையா என்றுக் தேடல் கண்டுணராது."
 
-#: ../src/html/helpwnd.cpp:679
+#: ../src/html/helpwnd.cpp:677
 msgid "Display options dialog"
 msgstr "காட்சியமைவு விருப்பத் தேர்வுகள் உரையாடல்"
 
-#: ../src/html/helpwnd.cpp:322
+#: ../src/html/helpwnd.cpp:320
 msgid "Displays help as you browse the books on the left."
 msgstr "இடப்பக்கமாக உலாவி, ஏடுகளைத் தேடுகின்றபொழுது, உதவியைக் காட்டும்."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:85
+#: ../src/common/accelcmn.cpp:83
 msgid "Divide"
 msgstr ""
 
-#: ../src/common/docview.cpp:533
+#: ../src/common/docview.cpp:526
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "%s-இல் ஏற்பட்டுள்ள மாற்றங்களை சேமிக்க வேண்டுமா?"
 
-#: ../src/common/prntbase.cpp:542
+#: ../src/common/prntbase.cpp:537
 msgid "Document:"
 msgstr "ஆவணம்:"
 
-#: ../src/generic/aboutdlgg.cpp:73
+#: ../src/generic/aboutdlgg.cpp:70
 msgid "Documentation by "
 msgstr "ஆவணமாக்கம் "
 
-#: ../src/generic/aboutdlgg.cpp:180
+#: ../src/generic/aboutdlgg.cpp:177
 msgid "Documentation writers"
 msgstr "ஆவணத்தை எழுதியோர்"
 
-#: ../src/common/sizer.cpp:2799
+#: ../src/common/sizer.cpp:2916
 msgid "Don't Save"
 msgstr "சேமிக்க வேண்டாம்"
 
-#: ../src/html/htmlwin.cpp:633
+#: ../src/html/htmlwin.cpp:643
 msgid "Done"
 msgstr "முடிவுற்றது"
 
-#: ../src/generic/progdlgg.cpp:448 ../src/msw/progdlg.cpp:407
+#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
 msgid "Done."
 msgstr "முடிவுற்றது"
 
@@ -2820,42 +2825,42 @@ msgstr "புள்ளியிடப்பட்டது"
 msgid "Double"
 msgstr "இரட்டை"
 
-#: ../src/common/paper.cpp:176
+#: ../src/common/paper.cpp:173
 msgid "Double Japanese Postcard Rotated 148 x 200 mm"
 msgstr "இரட்டை ஜப்பானிய அஞ்சல் அட்டை சுழற்றப்பட்டது 148 x 200 mm"
 
-#: ../src/common/xtixml.cpp:273
+#: ../src/common/xtixml.cpp:269
 #, c-format
 msgid "Doubly used id : %d"
 msgstr "இருமுறை பயன்படுத்தப்பட்டுள்ள அடையாளம்: %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:153
-#: ../src/common/accelcmn.cpp:64
+#: ../src/common/stockitem.cpp:150 ../src/common/accelcmn.cpp:61
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Down"
 msgstr "கீழ்"
 
-#: ../src/richtext/richtextctrl.cpp:865
+#: ../src/richtext/richtextctrl.cpp:864
 msgid "Drag"
 msgstr "இழு"
 
-#: ../src/common/paper.cpp:100
+#: ../src/common/paper.cpp:97
 msgid "E sheet, 34 x 44 in"
 msgstr "E தாள், 34 x 44 in"
 
-#: ../src/unix/fswatcher_inotify.cpp:561
+#: ../src/unix/fswatcher_inotify.cpp:558
 msgid "EOF while reading from inotify descriptor"
 msgstr "inotify விளக்கியிலிருந்து படிக்கும்பொழுது EOF"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "Edit"
 msgstr "தொகுக்கவும்"
 
-#: ../src/generic/editlbox.cpp:168
+#: ../src/generic/editlbox.cpp:131
 msgid "Edit item"
 msgstr "உருப்படியை தொகுக்கவும்"
 
-#: ../include/wx/generic/progdlgg.h:84
+#: ../include/wx/generic/progdlgg.h:85
 msgid "Elapsed time:"
 msgstr "கடந்துள்ள நேரம்"
 
@@ -2927,63 +2932,63 @@ msgid "Enables the shadow spread."
 msgstr "அகலத்தின் மதிப்பை செயற்படச் செய்க"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:66
+#: ../src/common/accelcmn.cpp:63
 msgid "End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:55
+#: ../src/common/accelcmn.cpp:52
 #, fuzzy
 msgid "Enter"
 msgstr "அச்சுப் பொறி"
 
-#: ../src/richtext/richtextstyledlg.cpp:934
+#: ../src/richtext/richtextstyledlg.cpp:930
 msgid "Enter a box style name"
 msgstr "ஒரு பெட்டி பாங்கின் பெயரை உள்ளிடுக"
 
-#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:602
 msgid "Enter a character style name"
 msgstr "வரியுருப் பாங்கின் பெயரை உள்ளிடுக"
 
-#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:816
 msgid "Enter a list style name"
 msgstr "வரிசைப் பட்டியல் பாங்கின் பெயரை உள்ளிடுக"
 
-#: ../src/richtext/richtextstyledlg.cpp:893
+#: ../src/richtext/richtextstyledlg.cpp:889
 msgid "Enter a new style name"
 msgstr "ஒரு புதுப் பாங்கின் பெயரை உள்ளிடுக"
 
-#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:650
 msgid "Enter a paragraph style name"
 msgstr "பத்திப் பாங்கின் பெயரை உள்ளிடுக"
 
-#: ../src/generic/dbgrptg.cpp:174
+#: ../src/generic/dbgrptg.cpp:171
 #, c-format
 msgid "Enter command to open file \"%s\":"
 msgstr "\"%s\" கோப்பினைத் திறக்க கட்டளையை உள்ளிடுக"
 
-#: ../src/generic/helpext.cpp:459
+#: ../src/generic/helpext.cpp:457
 msgid "Entries found"
 msgstr "உள்ளீடுகள் காணப்படுகின்றன"
 
-#: ../src/common/paper.cpp:142
+#: ../src/common/paper.cpp:139
 msgid "Envelope Invite 220 x 220 mm"
 msgstr "அஞ்சல் உறை அழை 220 x 220 mm"
 
-#: ../src/common/config.cpp:469
+#: ../src/common/config.cpp:465
 #, c-format
 msgid ""
 "Environment variables expansion failed: missing '%c' at position %u in '%s'."
 msgstr ""
 "சூழல் மாறிகள் விரிவாக்கம் தோல்வியடைந்தது: '%c' தவறவிடப்பட்டுள்ளது (நிலை: %u, '%s'-உள்)."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/generic/dirctrlg.cpp:570
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/dirctrlg.cpp:599
-#: ../src/generic/dirdlgg.cpp:323 ../src/generic/filectrlg.cpp:642
-#: ../src/generic/filectrlg.cpp:756 ../src/generic/filectrlg.cpp:770
-#: ../src/generic/filectrlg.cpp:786 ../src/generic/filectrlg.cpp:1368
-#: ../src/generic/filectrlg.cpp:1399 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/gtk1/fontdlg.cpp:74 ../src/generic/dirctrlg.cpp:536
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/dirctrlg.cpp:565
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1357 ../src/generic/filectrlg.cpp:1388
+#: ../src/generic/filedlgg.cpp:354 ../src/generic/dirdlgg.cpp:320
+#: ../src/gtk/filedlg.cpp:74
 msgid "Error"
 msgstr "பிழை"
 
@@ -2991,87 +2996,98 @@ msgstr "பிழை"
 msgid "Error closing epoll descriptor"
 msgstr "epoll விளக்கியை மூடுவதில் பிழை"
 
-#: ../src/unix/fswatcher_kqueue.cpp:114
+#: ../src/unix/fswatcher_kqueue.cpp:131
 msgid "Error closing kqueue instance"
 msgstr "kqueue நிகழ்வினை மூடுவதில் பிழை"
 
-#: ../src/common/filefn.cpp:1049
+#: ../src/common/filefn.cpp:938
 #, fuzzy, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "'%s' கோப்பினை '%s'-க்கு படியெடுப்பதில் தோல்வி."
 
-#: ../src/generic/dirdlgg.cpp:222
+#: ../src/generic/dirdlgg.cpp:219
 msgid "Error creating directory"
 msgstr "அடைவினை உருவாக்குவதில் பிழை"
 
-#: ../src/common/imagbmp.cpp:1181
+#: ../src/common/imagbmp.cpp:1193
 msgid "Error in reading image DIB."
 msgstr "DIB படிமத்தை படிப்பதில் பிழை"
 
-#: ../src/propgrid/propgrid.cpp:6696
+#: ../src/propgrid/propgrid.cpp:6665
 #, c-format
 msgid "Error in resource: %s"
 msgstr "வளத்தில் பிழை: %s"
 
-#: ../src/common/fileconf.cpp:422
+#: ../src/common/fileconf.cpp:421
 msgid "Error reading config options."
 msgstr "அமைவடிவ விருப்பத் தேர்வுகளைப் படிப்பதில் பிழை."
+
+#: ../src/msw/webview_ie.cpp:1057 ../src/msw/webview_edge.cpp:850
+#: ../src/gtk/webview_webkit2.cpp:1262 ../src/osx/webview_webkit.mm:383
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
 
 #: ../src/common/fileconf.cpp:1029
 msgid "Error saving user configuration data."
 msgstr "பயனர் அமைவடிவத் தரவினை சேமிப்பதில் பிழை."
 
-#: ../src/gtk/print.cpp:722
+#: ../src/gtk/print.cpp:720
 msgid "Error while printing: "
 msgstr "அச்சிடுகையில் பிழை:"
 
-#: ../src/common/log.cpp:219
+#: ../src/common/log.cpp:237
 msgid "Error: "
 msgstr "பிழை:"
 
+#: ../src/common/webrequest.cpp:98
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "பிழை:"
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:69
+#: ../src/common/accelcmn.cpp:66
 msgid "Esc"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:70
+#: ../src/common/accelcmn.cpp:67
 #, fuzzy
 msgid "Escape"
 msgstr "கிடநீளம்"
 
-#: ../src/common/fmapbase.cpp:150
+#: ../src/common/fmapbase.cpp:147
 msgid "Esperanto (ISO-8859-3)"
 msgstr "Esperanto (ISO-8859-3)"
 
-#: ../include/wx/generic/progdlgg.h:85
+#: ../include/wx/generic/progdlgg.h:86
 msgid "Estimated time:"
 msgstr "கணக்கிடப்பட்ட நேரம்"
 
-#: ../src/generic/dbgrptg.cpp:234
+#: ../src/generic/dbgrptg.cpp:231
 msgid "Executable files (*.exe)|*.exe|"
 msgstr "செயற்கோப்புகள் (*.exe)|*.exe|"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:155 ../src/common/accelcmn.cpp:78
+#: ../src/common/stockitem.cpp:152 ../src/common/accelcmn.cpp:75
 msgid "Execute"
 msgstr "செயலாக்குக"
 
-#: ../src/msw/utilsexc.cpp:876
+#: ../src/msw/utilsexc.cpp:873
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "'%s' கட்டளையின் செயலாக்கம் தோல்வியடைந்தது"
 
-#: ../src/common/paper.cpp:105
+#: ../src/common/paper.cpp:102
 msgid "Executive, 7 1/4 x 10 1/2 in"
 msgstr "செயலாக்குநர், 7 1/4 x 10 1/2 in"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6009
+#: ../src/generic/datavgen.cpp:6814
 msgid "Expand"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1240
+#: ../src/msw/registry.cpp:1228
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
@@ -3079,147 +3095,157 @@ msgstr ""
 "பதிப்பக விசை ஏற்றம் செய்யப்படுகிறது: \"%s\" கோப்பு ஏற்கனவே உள்ளது; அது அழித்தெழுதப்பட "
 "மாட்டாது."
 
-#: ../src/common/fmapbase.cpp:195
+#: ../src/common/fmapbase.cpp:192
 msgid "Extended Unix Codepage for Japanese (EUC-JP)"
 msgstr "நீட்டிக்கப்பட்ட ஜப்பானிய Unix Codepage (EUC-JP)"
 
-#: ../src/html/chm.cpp:725
+#: ../src/html/chm.cpp:718
 #, c-format
 msgid "Extraction of '%s' into '%s' failed."
 msgstr "'%s', '%s'-ற்குள் பிரித்தெடுப்பது தோல்வியடைந்தது."
 
-#: ../src/common/accelcmn.cpp:249 ../src/common/accelcmn.cpp:344
+#: ../src/common/accelcmn.cpp:259 ../src/common/accelcmn.cpp:358
 msgid "F"
 msgstr "F"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:672
+#: ../src/propgrid/advprops.cpp:582
 msgid "Face Name"
 msgstr "முகப் பெயர்"
 
-#: ../src/unix/snglinst.cpp:269
+#: ../src/unix/snglinst.cpp:266
 msgid "Failed to access lock file."
 msgstr "செயற்குறிப்பேட்டுக் கோப்பினை அணுகுவதில் தோல்வி."
+
+#: ../src/gtk/font.cpp:572
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "\"%s\" கோப்பிலிருந்து ஆவணத்தைப் படிப்பதில் தோல்வி."
 
 #: ../src/unix/epolldispatcher.cpp:116
 #, c-format
 msgid "Failed to add descriptor %d to epoll descriptor %d"
 msgstr "விளக்கி %d-ஐ epoll விளக்கி %d-னுள் ஏற்றுவதில் தோல்வி."
 
-#: ../src/msw/dib.cpp:489
+#: ../src/msw/dib.cpp:535
 #, c-format
 msgid "Failed to allocate %luKb of memory for bitmap data."
 msgstr "நுண்பட தரவிற்கு நினைவுத் திறன் %luKb ஒதுக்கீடு செய்வதில் தோல்வி."
 
-#: ../src/common/glcmn.cpp:115
+#: ../src/common/glcmn.cpp:112
 msgid "Failed to allocate colour for OpenGL"
 msgstr "OpenGL-க்கு நிறத்தை ஒதுக்குவதில் தோல்வி. "
 
-#: ../src/unix/displayx11.cpp:236
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "OpenGL-க்கு நிறத்தை ஒதுக்குவதில் தோல்வி. "
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "OpenGL-க்கு நிறத்தை ஒதுக்குவதில் தோல்வி. "
+
+#: ../include/wx/unix/private/displayx11.h:89
 msgid "Failed to change video mode"
 msgstr "நிகழ்பட நிலையை மாற்றுவதில் தோல்வி"
 
-#: ../src/common/image.cpp:3277
+#: ../src/common/image.cpp:3396
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "\"%s\" படிமக் கோப்பின் வடிவூட்டத்தை சரிபார்ப்பதில் தோல்வி."
 
-#: ../src/common/debugrpt.cpp:239
+#: ../src/common/debugrpt.cpp:240
 #, c-format
 msgid "Failed to clean up debug report directory \"%s\""
 msgstr "\"%s\" வழுநீக்க அறிக்கை அடைவினை சுத்தஞ்செய்வதில் தோல்வி"
 
-#: ../src/common/filename.cpp:192
+#: ../src/common/filename.cpp:189
 msgid "Failed to close file handle"
 msgstr "கோப்புப் பிடியை மூடுவதில் தோல்வி"
 
-#: ../src/unix/snglinst.cpp:340
+#: ../src/unix/snglinst.cpp:337
 #, c-format
 msgid "Failed to close lock file '%s'"
 msgstr "'%s' பூட்டுக் கோப்பினை மூடுவதில் தோல்வி"
 
-#: ../src/msw/clipbrd.cpp:112
+#: ../src/msw/clipbrd.cpp:110
 msgid "Failed to close the clipboard."
 msgstr "பிடிப்புப் பலகையை மூடுவதில் தோல்வி."
 
-#: ../src/x11/utils.cpp:208
+#: ../src/x11/utils.cpp:170
 #, c-format
 msgid "Failed to close the display \"%s\""
 msgstr "\"%s\" காட்சியமைவை மூடுவதில் தோல்வி"
 
-#: ../src/msw/dialup.cpp:797
+#: ../src/msw/dialup.cpp:791
 msgid "Failed to connect: missing username/password."
 msgstr "இணைப்பதில் தோல்வி: பயனர் பெயர்/கடவுச்சொல் தவற விடப்பட்டுள்ளது"
 
-#: ../src/msw/dialup.cpp:743
+#: ../src/msw/dialup.cpp:737
 msgid "Failed to connect: no ISP to dial."
 msgstr "இணைப்பதில் தோல்வி: சுழற்ற ISP ஏதுமில்லை."
 
-#: ../src/common/textfile.cpp:203
-#, c-format
-msgid "Failed to convert file \"%s\" to Unicode."
-msgstr "\"%s\" கோப்பினை ஒருங்குறியாக மாற்றுவதில் தோல்வி."
-
-#: ../src/generic/logg.cpp:956
+#: ../src/generic/logg.cpp:953
 msgid "Failed to copy dialog contents to the clipboard."
 msgstr "உரையாடலின் உள்ளடக்கங்களை பிடிப்புப் பலகைக்கு படியெடுப்பதில் தோல்வி."
 
-#: ../src/msw/registry.cpp:692
+#: ../src/msw/registry.cpp:681
 #, c-format
 msgid "Failed to copy registry value '%s'"
 msgstr "'%s' பதிப்பக மதிப்பை படியெடுப்பதில் தோல்வி."
 
-#: ../src/msw/registry.cpp:701
+#: ../src/msw/registry.cpp:690
 #, c-format
 msgid "Failed to copy the contents of registry key '%s' to '%s'."
 msgstr "'%s' பதிப்பக விசை உள்ளடக்கங்களை '%s'-க்கு படியெடுப்பதில் தோல்வி."
 
-#: ../src/common/filefn.cpp:1015
+#: ../src/common/filefn.cpp:904
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "'%s' கோப்பினை '%s'-க்கு படியெடுப்பதில் தோல்வி."
 
-#: ../src/msw/registry.cpp:679
+#: ../src/msw/registry.cpp:668
 #, c-format
 msgid "Failed to copy the registry subkey '%s' to '%s'."
 msgstr "'%s' பதிப்பக உள்விசையை '%s'-க்கு படியெடுப்பதில் தோல்வி."
 
-#: ../src/msw/dde.cpp:1070
+#: ../src/msw/dde.cpp:1134
 msgid "Failed to create DDE string"
 msgstr "DDE சரத்தை உருவாக்குவதில் தோல்வி."
 
-#: ../src/msw/mdi.cpp:616
+#: ../src/msw/mdi.cpp:621
 msgid "Failed to create MDI parent frame."
 msgstr "MDI தாய் சட்டகத்தை உருவாக்குவதில் தோல்வி."
 
-#: ../src/common/filename.cpp:1027
+#: ../src/common/filename.cpp:1024
 msgid "Failed to create a temporary file name"
 msgstr "தற்காலிக கோப்புப் பெயரை உருவாக்குவதில் தோல்வி"
 
-#: ../src/msw/utilsexc.cpp:228
+#: ../src/msw/utilsexc.cpp:225
 msgid "Failed to create an anonymous pipe"
 msgstr "அனாமதேய குழாயை உருவாக்குவதில் தோல்வி"
 
-#: ../src/msw/ole/automtn.cpp:522
+#: ../src/msw/ole/automtn.cpp:513
 #, c-format
 msgid "Failed to create an instance of \"%s\""
 msgstr "\"%s\"-இன் ஒரு நிகழ்வை உருவாக்குவதில் தோல்வி"
 
-#: ../src/msw/dde.cpp:437
+#: ../src/msw/dde.cpp:432
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "'%s' வழங்கியுடன் '%s' தலைப்பில் இணைவதில் தோல்வி."
 
-#: ../src/msw/cursor.cpp:204
+#: ../src/msw/cursor.cpp:195
 msgid "Failed to create cursor."
 msgstr "சுட்டியை உருவாக்குவதில் தோல்வி."
 
-#: ../src/common/debugrpt.cpp:209
+#: ../src/common/debugrpt.cpp:210
 #, c-format
 msgid "Failed to create directory \"%s\""
 msgstr "\"%s\" அடைவினை உருவாக்குவதில் தோல்வி."
 
-#: ../src/generic/dirdlgg.cpp:220
+#: ../src/generic/dirdlgg.cpp:217
 #, c-format
 msgid ""
 "Failed to create directory '%s'\n"
@@ -3232,114 +3258,133 @@ msgstr ""
 msgid "Failed to create epoll descriptor"
 msgstr "epoll விளக்கியை உருவாக்குவதில் தோல்வி."
 
-#: ../src/msw/mimetype.cpp:238
+#: ../src/gtk/font.cpp:562
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "பயனர் அமைவடிவக் கோப்பினை இற்றைப்படுத்துவதில் தோல்வி."
+
+#: ../src/msw/mimetype.cpp:235
 #, c-format
 msgid "Failed to create registry entry for '%s' files."
 msgstr "'%s' கோப்புகளுக்கு பதிப்பக உள்ளீட்டினை உருவாக்குவதில் தோல்வி."
 
-#: ../src/msw/fdrepdlg.cpp:409
+#: ../src/msw/fdrepdlg.cpp:408
 #, c-format
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr "நிலையான கண்டுபிடி/மாற்றமர்வு உரையாடலை உருவாக்குவதில் தோல்வி. (பிழைக் குறி %d)"
 
-#: ../src/unix/wakeuppipe.cpp:52
+#: ../src/unix/wakeuppipe.cpp:49
 msgid "Failed to create wake up pipe used by event loop."
 msgstr "நிகழ்வுச் சுழற்சி பயன்படுத்தும் விழிநிலை குழாயை உருவாக்குவதில் தோல்வி."
 
-#: ../src/html/winpars.cpp:730
+#: ../src/html/winpars.cpp:727
 #, c-format
 msgid "Failed to display HTML document in %s encoding"
 msgstr "%s குறியாக்கத்தில் HtML ஆவணத்தை காட்டுவதில் தோல்வி"
 
-#: ../src/msw/clipbrd.cpp:124
+#: ../src/msw/clipbrd.cpp:122
 msgid "Failed to empty the clipboard."
 msgstr "பிடிப்புப் பலகையை வெற்றாக்குவதில் தோல்வி."
 
-#: ../src/unix/displayx11.cpp:212
+#: ../include/wx/unix/private/displayx11.h:65
 msgid "Failed to enumerate video modes"
 msgstr "நிகழ்பட நிலைகளை கணக்கிடுவதில் தோல்வி."
 
-#: ../src/msw/dde.cpp:722
+#: ../src/msw/dde.cpp:717
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "DDE வழங்கியுடன் அறிவுரை முழுச்சுற்றினை நிலைநாட்டுவதில் தோல்வி"
 
-#: ../src/msw/dialup.cpp:629 ../src/msw/dialup.cpp:863
+#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "சுழல் இணைப்பினை நிலைநாட்டுவதில் தோல்வி: %s"
 
-#: ../src/unix/utilsunx.cpp:611
+#: ../src/unix/utilsunx.cpp:613
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "'%s'-இனை செயலாக்குவதில் தோல்வி. \n"
 
-#: ../src/common/debugrpt.cpp:720
+#: ../src/common/debugrpt.cpp:730
 msgid "Failed to execute curl, please install it in PATH."
 msgstr "curl-இனை செயலாக்குவதில் தோல்வி. கருணைக்கூர்ந்து அதை தடத்தில் நிறுவவும்."
 
-#: ../src/msw/ole/automtn.cpp:505
+#: ../src/msw/ole/automtn.cpp:496
 #, c-format
 msgid "Failed to find CLSID of \"%s\""
 msgstr "\"%s\"-இன் CLSID கண்டுவிடிப்பதில் தோல்வி"
 
-#: ../src/common/regex.cpp:431 ../src/common/regex.cpp:479
+#: ../src/common/regex.cpp:428 ../src/common/regex.cpp:476
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "வழக்கமான வெளிப்பாட்டிற்கு பொருத்தத்தை காண்பதில் தோல்வி: %s "
 
-#: ../src/msw/dialup.cpp:695
+#: ../src/msw/webview_ie.cpp:978
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:689
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "இணையப் பணி வழங்குவோர் (ISP) பெயர்களை பெறுவதில் தோல்வி: %s"
 
-#: ../src/msw/ole/automtn.cpp:574
+#: ../src/msw/ole/automtn.cpp:565
 #, c-format
 msgid "Failed to get OLE automation interface for \"%s\""
 msgstr "\"%s\"-ற்காக OLE தானியங்கியைப் பெறுவதில் தோல்வி"
 
-#: ../src/msw/clipbrd.cpp:711
+#: ../src/msw/clipbrd.cpp:731
 msgid "Failed to get data from the clipboard"
 msgstr "பிடிப்புப் பலகையிலிருந்து தரவினை பெறுவதில் தோல்வி"
 
-#: ../src/common/time.cpp:223
+#: ../src/common/time.cpp:216
 msgid "Failed to get the local system time"
 msgstr "கணினி நேரத்தைப் பெறுவதில் தோல்வி"
 
-#: ../src/common/filefn.cpp:1345
+#: ../src/common/filefn.cpp:1233
 msgid "Failed to get the working directory"
 msgstr "செயலிலிருக்கும் அடைவினைப் பெறுவதில் தோல்வி"
 
-#: ../src/univ/theme.cpp:114
+#: ../src/univ/theme.cpp:111
 msgid "Failed to initialize GUI: no built-in themes found."
 msgstr "GUI துவக்க நிலையாக்குவதில் தோல்வி: உட்கட்டப்பட்ட கருத்தோற்றம் ஏதும் காணப்படவில்லை."
 
-#: ../src/msw/helpchm.cpp:63
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:60
 msgid "Failed to initialize MS HTML Help."
 msgstr "MS HTML உதவியை துவக்க நிலையாக்குவதில் தோல்வி."
 
-#: ../src/msw/glcanvas.cpp:1381
+#: ../src/msw/glcanvas.cpp:1391
 msgid "Failed to initialize OpenGL"
 msgstr "OpenGL துவக்க நிலையாக்குவதில் தோல்வி"
 
-#: ../src/msw/dialup.cpp:858
+#: ../src/msw/dialup.cpp:852
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "சுழல் இணைப்பினைத் துவக்குவதில் தோல்வி: %s"
 
-#: ../src/gtk/textctrl.cpp:1128
+#: ../src/gtk/textctrl.cpp:1209
 msgid "Failed to insert text in the control."
 msgstr "கட்டுப்பாட்டில் உரையை செருகுவதில் தோல்வி."
 
-#: ../src/unix/snglinst.cpp:241
+#: ../src/unix/snglinst.cpp:238
 #, c-format
 msgid "Failed to inspect the lock file '%s'"
 msgstr "'%s' பூட்டுக் கோப்பினை ஆய்வுச் செய்வதில் தோல்வி"
 
-#: ../src/unix/appunix.cpp:182
+#: ../src/unix/appunix.cpp:179
 msgid "Failed to install signal handler"
 msgstr "சைகைக் கையாளு நிரலை நிறுவுவதில் தோல்வி"
 
-#: ../src/unix/threadpsx.cpp:1167
+#: ../src/unix/threadpsx.cpp:1216
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -3347,71 +3392,71 @@ msgstr ""
 "ஒரு இழையுடன் சேர்வதில் தோல்வி, நினைவுக் கசிவாக இருக்கக்கூடும் - கருணைக்கூர்ந்து நிரலை "
 "மறுதுவக்கம் செய்யவும்"
 
-#: ../src/msw/utils.cpp:629
+#: ../src/msw/utils.cpp:619
 #, c-format
 msgid "Failed to kill process %d"
 msgstr "%d செயல்முறையை முறிப்பதில் தோல்வி"
 
-#: ../src/common/image.cpp:2500
+#: ../src/common/image.cpp:2595
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "\"%s\" நுண்படத்தினை வளத்திலிருந்து ஏற்றுவதில் தோல்வி."
 
-#: ../src/common/image.cpp:2509
+#: ../src/common/image.cpp:2604
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "\"%s\" படவுருவை வளத்திலிருந்து ஏற்றுவதில் தோல்வி."
 
-#: ../src/common/iconbndl.cpp:225
+#: ../src/common/iconbndl.cpp:224
 #, fuzzy, c-format
 msgid "Failed to load icons from resource '%s'."
 msgstr "\"%s\" படவுருவை வளத்திலிருந்து ஏற்றுவதில் தோல்வி."
 
-#: ../src/common/iconbndl.cpp:200
+#: ../src/common/iconbndl.cpp:198
 #, c-format
 msgid "Failed to load image %%d from file '%s'."
 msgstr "%%d படிமத்தை '%s' கோப்பிலிருந்து ஏற்றுவதில் தோல்வி."
 
-#: ../src/common/iconbndl.cpp:208
+#: ../src/common/iconbndl.cpp:206
 #, c-format
 msgid "Failed to load image %d from stream."
 msgstr "ஓடையிலிருந்து %d படிமத்தை ஏற்றுவதில் தோல்வி."
 
-#: ../src/common/image.cpp:2587 ../src/common/image.cpp:2606
+#: ../src/common/image.cpp:2682 ../src/common/image.cpp:2701
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "\"%s\" கோப்பிலிருந்து படிமத்தை ஏற்றுவதில் தோல்வி."
 
-#: ../src/msw/enhmeta.cpp:97
+#: ../src/msw/enhmeta.cpp:94
 #, c-format
 msgid "Failed to load metafile from file \"%s\"."
 msgstr "\"%s\" கோப்பிலிருந்து meta கோப்பினை ஏற்றுவதில் தோல்வி."
 
-#: ../src/msw/volume.cpp:327
+#: ../src/msw/volume.cpp:335
 msgid "Failed to load mpr.dll."
 msgstr "mpr.dll ஏற்றுவதில் தோல்வி."
 
-#: ../src/msw/utils.cpp:953
+#: ../src/msw/utils.cpp:943
 #, c-format
 msgid "Failed to load resource \"%s\"."
 msgstr "\"%s\" வளத்தை ஏற்றுவதில் தோல்வி."
 
-#: ../src/common/dynlib.cpp:92
+#: ../src/common/dynlib.cpp:86
 #, c-format
 msgid "Failed to load shared library '%s'"
 msgstr "'%s' பகிர்வு நூலகத்தை ஏற்றுவதில் தோல்வி"
 
-#: ../src/osx/core/sound.cpp:145
+#: ../src/osx/core/sound.cpp:143
 #, fuzzy, c-format
 msgid "Failed to load sound from \"%s\" (error %d)."
 msgstr "\"%s\" வளத்தை ஏற்றுவதில் தோல்வி."
 
-#: ../src/msw/utils.cpp:960
+#: ../src/msw/utils.cpp:950
 #, c-format
 msgid "Failed to lock resource \"%s\"."
 msgstr "\"%s\" வளத்தை பூட்டுவதில் தோல்வி."
 
-#: ../src/unix/snglinst.cpp:198
+#: ../src/unix/snglinst.cpp:195
 #, c-format
 msgid "Failed to lock the lock file '%s'"
 msgstr "'%s' பூட்டுக் கோப்பினைப் பூட்டுவதில் தோல்வி"
@@ -3421,33 +3466,38 @@ msgstr "'%s' பூட்டுக் கோப்பினைப் பூட�
 msgid "Failed to modify descriptor %d in epoll descriptor %d"
 msgstr "%d விளக்கியை (%d epoll விளக்கியில் இருக்கும்) மாற்றுவதில் தோல்வி."
 
-#: ../src/common/filename.cpp:2575
+#: ../src/common/filename.cpp:2658
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "'%s'-ற்கான கோப்பு times மாற்றுவதில் தோல்வி"
 
-#: ../src/common/selectdispatcher.cpp:258
+#: ../src/common/selectdispatcher.cpp:255
 msgid "Failed to monitor I/O channels"
 msgstr "உள்ளிடு/வெளியிடு அலைத்தடத்தை கவனிப்பதில் தோல்வி"
 
-#: ../src/common/filename.cpp:175
+#: ../src/common/filename.cpp:172
 #, c-format
 msgid "Failed to open '%s' for reading"
 msgstr "படிப்பதற்கு '%s'-ஐ திறப்பதில் தோல்வி"
 
-#: ../src/common/filename.cpp:180
+#: ../src/common/filename.cpp:177
 #, c-format
 msgid "Failed to open '%s' for writing"
 msgstr "எழுதுவதற்கு '%s'-ஐ திறப்பதில் தோல்வி"
 
-#: ../src/html/chm.cpp:141
+#: ../src/html/chm.cpp:138
 #, c-format
 msgid "Failed to open CHM archive '%s'."
 msgstr "'%s' CHM ஆவணகத்தைத் திறப்பதில் தோல்வி."
 
-#: ../src/common/utilscmn.cpp:1126
+#: ../src/common/utilscmn.cpp:1140
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
+msgstr "\"%s\" இணைய முகவரியை இயல்புலாவியில் திறப்பதில் தோல்வி."
+
+#: ../src/common/hyperlnkcmn.cpp:133
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "\"%s\" இணைய முகவரியை இயல்புலாவியில் திறப்பதில் தோல்வி."
 
 #: ../include/wx/msw/private/fswatcher.h:92
@@ -3455,93 +3505,103 @@ msgstr "\"%s\" இணைய முகவரியை இயல்புலாவ
 msgid "Failed to open directory \"%s\" for monitoring."
 msgstr "\"%s\" அடைவினை கவனிப்பதற்காக திறப்பதில் தோல்வி."
 
-#: ../src/x11/utils.cpp:227
+#: ../src/x11/utils.cpp:189
 #, c-format
 msgid "Failed to open display \"%s\"."
 msgstr "\"%s\" காட்சியமைவை திறப்பதில் தோல்வி"
 
-#: ../src/common/filename.cpp:1062
+#: ../src/common/filename.cpp:1059
 msgid "Failed to open temporary file."
 msgstr "தற்காலிக கோப்பினைத் திறப்பதில் தோல்வி."
 
-#: ../src/msw/clipbrd.cpp:91
+#: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "பிடிப்புப் பலகையை திறப்பதில் தோல்வி."
 
-#: ../src/common/translation.cpp:1184
+#: ../src/common/translation.cpp:1226
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "பன்மை வடிவங்களை parse செய்வதில் தோல்வி: '%s'"
 
-#: ../src/unix/mediactrl.cpp:1214
+#: ../src/unix/mediactrl.cpp:1239
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "\"%s\" ஓட்டுதலை ஆயத்தம் செய்வதில் தோல்வி."
 
-#: ../src/msw/clipbrd.cpp:600
+#: ../src/msw/clipbrd.cpp:610
 msgid "Failed to put data on the clipboard"
 msgstr "பிடிப்புப் பலகையில் தரவினை வைப்பதில் தோல்வி"
 
-#: ../src/unix/snglinst.cpp:278
+#: ../src/unix/snglinst.cpp:275
 msgid "Failed to read PID from lock file."
 msgstr "பூட்டுக் கோப்பிலிருந்து PID-ஐ படிப்பதில் தோல்வி."
 
-#: ../src/common/fileconf.cpp:433
+#: ../src/common/fileconf.cpp:432
 msgid "Failed to read config options."
 msgstr "அமைவடிவ விருப்பத் தேர்வுகளைப் படிப்பதில் தோல்வி."
 
-#: ../src/common/docview.cpp:681
+#: ../src/common/docview.cpp:676
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "\"%s\" கோப்பிலிருந்து ஆவணத்தைப் படிப்பதில் தோல்வி."
 
-#: ../src/dfb/evtloop.cpp:98
+#: ../src/dfb/evtloop.cpp:99
 msgid "Failed to read event from DirectFB pipe"
 msgstr "நேரடி FB குழாயிலிருந்து நிகழ்வைப் படிப்பதில் தோல்வி"
 
-#: ../src/unix/wakeuppipe.cpp:120
+#: ../src/unix/wakeuppipe.cpp:117
 msgid "Failed to read from wake-up pipe"
 msgstr "விழிநிலை குழாயிலிருந்து படிப்பதில் தோல்வி"
 
-#: ../src/unix/utilsunx.cpp:679
+#: ../src/common/textfile.cpp:96
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "\"%s\" கோப்பிலிருந்து ஆவணத்தைப் படிப்பதில் தோல்வி."
+
+#: ../src/unix/utilsunx.cpp:681
 msgid "Failed to redirect child process input/output"
 msgstr "உள்ளிடு/வெளிடு சேய் செயல்முறையை வழிமாற்றுவதில் தோல்வி"
 
-#: ../src/msw/utilsexc.cpp:701
+#: ../src/msw/utilsexc.cpp:698
 msgid "Failed to redirect the child process IO"
 msgstr "உள்ளிடு/வெளிடு சேய் செயல்முறையை வழிமாற்றுவதில் தோல்வி"
 
-#: ../src/msw/dde.cpp:288
+#: ../src/msw/dde.cpp:283
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "'%s' DDE வழங்கியைப் பதிவு செய்வதில் தோல்வி"
 
-#: ../src/common/fontmap.cpp:245
+#: ../src/gtk/font.cpp:580
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "பயனர் அமைவடிவக் கோப்பினை இற்றைப்படுத்துவதில் தோல்வி."
+
+#: ../src/common/fontmap.cpp:242
 #, c-format
 msgid "Failed to remember the encoding for the charset '%s'."
 msgstr "'%s' Charset குறியீட்டினை நினைவு வைத்துக் கொள்வதில் தோல்வி."
 
-#: ../src/common/debugrpt.cpp:227
+#: ../src/common/debugrpt.cpp:228
 #, c-format
 msgid "Failed to remove debug report file \"%s\""
 msgstr "\"%s\" வழுநீக்க அறிக்கையை நீக்குவதில் தோல்வி"
 
-#: ../src/unix/snglinst.cpp:328
+#: ../src/unix/snglinst.cpp:325
 #, c-format
 msgid "Failed to remove lock file '%s'"
 msgstr "'%s' பூட்டுக் கோப்பினை நீக்குவதில் தோல்வி"
 
-#: ../src/unix/snglinst.cpp:288
+#: ../src/unix/snglinst.cpp:285
 #, c-format
 msgid "Failed to remove stale lock file '%s'."
 msgstr "'%s' நாள்பட்ட பூட்டுக் கோப்பினை நீக்குவதில் தோல்வி."
 
-#: ../src/msw/registry.cpp:529
+#: ../src/msw/registry.cpp:518
 #, c-format
 msgid "Failed to rename registry value '%s' to '%s'."
 msgstr "'%s' பதிவக மதிப்பினை '%s' என்றுப் பெயர் மாற்றுவதில் தோல்வி."
 
-#: ../src/common/filefn.cpp:1122
+#: ../src/common/filefn.cpp:1011
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -3549,115 +3609,124 @@ msgid ""
 msgstr ""
 "இலக்கில் கோப்பு ஏற்கனவே இருப்பதால், '%s' கோப்பினை '%s' என்றுப் பெயர் மாற்றுவதில் தோல்வி."
 
-#: ../src/msw/registry.cpp:634
+#: ../src/msw/registry.cpp:623
 #, c-format
 msgid "Failed to rename the registry key '%s' to '%s'."
 msgstr "'%s' பதிவக விசையை '%s' என்றுப் பெயர் மாற்றுவதில் தோல்வி."
 
-#: ../src/common/filename.cpp:2671
+#: ../src/msw/webview_ie.cpp:995
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/common/filename.cpp:2754
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "'%s'-ற்கான கோப்பு டைம்ஸை மீட்டெடுப்பதில் தோல்வி"
 
-#: ../src/msw/dialup.cpp:468
+#: ../src/msw/dialup.cpp:462
 msgid "Failed to retrieve text of RAS error message"
 msgstr "RAS பிழையின் உரையை மீட்டெடுப்பதில் தோல்வி."
 
-#: ../src/msw/clipbrd.cpp:748
+#: ../src/msw/clipbrd.cpp:768
 msgid "Failed to retrieve the supported clipboard formats"
 msgstr "ஆதரவளிக்கப்படும் பிடிப்புப் பலகை வடிவூட்டங்களை மீட்டெடுப்பதில் தோல்வி"
 
-#: ../src/common/docview.cpp:652
+#: ../src/common/docview.cpp:647
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "ஆவணத்தை \"%s\" கோப்பில் சேமிப்பதில் தோல்வி."
 
-#: ../src/msw/dib.cpp:269
+#: ../src/msw/dib.cpp:312
 #, c-format
 msgid "Failed to save the bitmap image to file \"%s\"."
 msgstr "நுண்பட படிமத்தை \"%s\" கோப்பினில் சேமிப்பதில் தோல்வி."
 
-#: ../src/msw/dde.cpp:763
+#: ../src/msw/dde.cpp:811
 msgid "Failed to send DDE advise notification"
 msgstr "DDE அறிவுரை அறிவிக்கையை அனுப்புவதில் தோல்வி"
 
-#: ../src/common/ftp.cpp:402
+#: ../src/common/ftp.cpp:399
 #, c-format
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "FTP மாற்று நிலையை %s என்று அமைப்பதில் தோல்வி."
 
-#: ../src/msw/clipbrd.cpp:427
+#: ../src/msw/clipbrd.cpp:443
 msgid "Failed to set clipboard data."
 msgstr "பிடிப்புப் பலகை தரவினை அமைப்பதில் தோல்வி."
 
-#: ../src/unix/snglinst.cpp:181
+#: ../src/unix/snglinst.cpp:178
 #, c-format
 msgid "Failed to set permissions on lock file '%s'"
 msgstr "'%s' பூட்டுக் கோப்பின்் மீது அனுமதிகளை அமைப்பதில் தோல்வி"
 
-#: ../src/unix/utilsunx.cpp:668
+#: ../src/unix/utilsunx.cpp:670
 msgid "Failed to set process priority"
 msgstr "செயலி முன்னுரிமையை அமைப்பதில் தோல்வி"
 
-#: ../src/common/file.cpp:559
+#: ../src/common/ffile.cpp:355 ../src/common/file.cpp:586
 msgid "Failed to set temporary file permissions"
 msgstr "தற்காலிக கோப்பு அனுமதிகளை அமைப்பதில் தோல்வி"
 
-#: ../src/gtk/textctrl.cpp:1072
-msgid "Failed to set text in the text control."
-msgstr "உரைக் கட்டுப்பாட்டில் உரையை அமைப்பதில் தோல்வி."
-
-#: ../src/unix/threadpsx.cpp:1298
+#: ../src/unix/threadpsx.cpp:1347
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "இழையின் உடன்நிகழ் %lu மட்டத்திற்கு அமைப்பதில் தோல்வி."
 
-#: ../src/unix/threadpsx.cpp:1424
+#: ../src/unix/threadpsx.cpp:1473
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "%d இழை முன்னுரிமையை அமைப்பதில் தோல்வி."
 
-#: ../src/unix/utilsunx.cpp:783
+#: ../src/unix/utilsunx.cpp:785
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr "அடைப்பில்லா குழாயை அமைப்பதில் தோல்வி, நிரல் இயக்கம் முடிவிற்கு வரலாம்."
 
-#: ../src/common/fs_mem.cpp:261
+#: ../src/msw/webview_ie.cpp:987
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:256
 #, c-format
 msgid "Failed to store image '%s' to memory VFS!"
 msgstr "VFS நினைவகத்தில் '%s' படிமத்தை சேமிப்பதில் தோல்வி!"
 
-#: ../src/dfb/evtloop.cpp:170
+#: ../src/dfb/evtloop.cpp:171
 msgid "Failed to switch DirectFB pipe to non-blocking mode"
 msgstr "நேரடி FB குழாயினை அடைப்பில்லா நிலைக்கு மாற்றுவதில் தோல்வி"
 
-#: ../src/unix/wakeuppipe.cpp:59
+#: ../src/unix/wakeuppipe.cpp:56
 msgid "Failed to switch wake up pipe to non-blocking mode"
 msgstr "விழிநிலை குழாயினை அடைப்பில்லா நிலைக்கு மாற்றுவதில் தோல்வி"
 
-#: ../src/unix/threadpsx.cpp:1605
+#: ../src/unix/threadpsx.cpp:1654
 msgid "Failed to terminate a thread."
 msgstr "ஒரு இழையை முடிப்பதில் தோல்வி."
 
-#: ../src/msw/dde.cpp:741
+#: ../src/msw/dde.cpp:736
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "DDE வழங்கியுடனான அறிவுரை சுழற்சியை முடிவிற்குக் கொண்டுவருவதில் தோல்வி"
 
-#: ../src/msw/dialup.cpp:938
+#: ../src/msw/dialup.cpp:932
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "சுழல் இணைப்பினை துண்டிப்பதில் தோல்வி: %s"
 
-#: ../src/common/filename.cpp:2590
+#: ../src/common/filename.cpp:2673
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "'%s' கோப்பினைத் தொடுவதில் தோல்வி"
 
-#: ../src/unix/snglinst.cpp:334
+#: ../src/unix/dlunix.cpp:90
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "'%s' பகிர்வு நூலகத்தை ஏற்றுவதில் தோல்வி"
+
+#: ../src/unix/snglinst.cpp:331
 #, c-format
 msgid "Failed to unlock lock file '%s'"
 msgstr "'%s' பூட்டுக் கோப்பினைத் திறப்பதில் தோல்வி"
 
-#: ../src/msw/dde.cpp:309
+#: ../src/msw/dde.cpp:304
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "'%s' DDE வழங்கியைப் பதிவுநீக்கம் செய்வதில் தோல்வி"
@@ -3671,77 +3740,87 @@ msgstr "%d விளக்கியை %d epoll விளக்கியிட�
 msgid "Failed to update user configuration file."
 msgstr "பயனர் அமைவடிவக் கோப்பினை இற்றைப்படுத்துவதில் தோல்வி."
 
-#: ../src/common/debugrpt.cpp:733
+#: ../src/common/debugrpt.cpp:743
 #, c-format
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "வழுநீக்க அறிக்கையை தரவேற்றுவதில் தோல்வி (பிழைக் குறி: %d)."
 
-#: ../src/unix/snglinst.cpp:168
+#: ../src/unix/snglinst.cpp:165
 #, c-format
 msgid "Failed to write to lock file '%s'"
 msgstr "'%s' பூட்டுக் கோப்பினில் எழுதுவதில் தோல்வி"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:209
+#: ../src/propgrid/propgrid.cpp:190
 msgid "False"
 msgstr "பொய்யானது"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:694
+#: ../src/propgrid/advprops.cpp:604
 msgid "Family"
 msgstr "குடும்பம்"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/gtk/glcanvas.cpp:176 ../src/gtk/glcanvas.cpp:187
+#, fuzzy
+msgid "Fatal Error"
+msgstr "கோப்புப் பிழை"
+
+#: ../src/common/stockitem.cpp:154
 msgid "File"
 msgstr "கோப்பு"
 
-#: ../src/common/docview.cpp:669
+#: ../src/common/docview.cpp:664
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "\"%s\" கோப்பினை படிப்பதற்கு திறக்க இயலவில்லை."
 
-#: ../src/common/docview.cpp:646
+#: ../src/common/docview.cpp:641
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "\"%s\" கோப்பினை எழுதுவதற்கு திறக்க இயலவில்லை."
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "'%s' கோப்பு ஏற்கனவே உள்ளது, அதை கட்டாயம் அழித்தெழுத வேண்டுமா?"
 
-#: ../src/common/filefn.cpp:1156
+#: ../src/common/filefn.cpp:1044
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "'%s' கோப்பு நீக்கப்பட இயலவில்லை"
 
-#: ../src/common/filefn.cpp:1139
+#: ../src/common/filefn.cpp:1028
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "'%s' கோப்பு '%s' என்று மறுபெயரிடப்பட இயலவில்லை"
 
-#: ../src/richtext/richtextctrl.cpp:3081 ../src/common/textcmn.cpp:953
+#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
 msgid "File couldn't be loaded."
 msgstr "கோப்பு ஏற்றப்பட இயலவில்லை."
 
-#: ../src/msw/filedlg.cpp:393
+#: ../src/msw/filedlg.cpp:414
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "கோப்பு உரையாடல் தோல்வியடைந்தது. பிழைக் குறி %0lx."
 
-#: ../src/common/docview.cpp:1789
+#: ../src/common/docview.cpp:1783
 msgid "File error"
 msgstr "கோப்புப் பிழை"
 
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/filectrlg.cpp:770
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/filectrlg.cpp:766
 msgid "File name exists already."
 msgstr "கோப்புப் பெயர் ஏற்கனவே உள்ளது."
+
+#: ../src/osx/cocoa/filedlg.mm:264
+#, fuzzy
+msgid "File type:"
+msgstr "தொலைத் தட்டெழுத்து"
 
 #: ../src/motif/filedlg.cpp:220
 msgid "Files"
 msgstr "கோப்புகள்"
 
-#: ../src/common/filefn.cpp:1591
+#: ../src/common/filefn.cpp:1479
 #, c-format
 msgid "Files (%s)"
 msgstr "கோப்புகள் (%s)"
@@ -3750,15 +3829,29 @@ msgstr "கோப்புகள் (%s)"
 msgid "Filter"
 msgstr "வடிகட்டி"
 
-#: ../src/common/stockitem.cpp:158 ../src/html/helpwnd.cpp:490
+#: ../src/html/helpwnd.cpp:488
 msgid "Find"
 msgstr "கண்டுபிடி"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:259
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:258
+#, fuzzy
+msgid "Find in document"
+msgstr "HTML ஆவணத்தைத் திறவுக"
+
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "Find..."
+msgstr "கண்டுபிடி"
+
+#: ../src/common/stockitem.cpp:156
 msgid "First"
 msgstr "முதல்"
 
-#: ../src/common/prntbase.cpp:1548
+#: ../src/common/prntbase.cpp:1573
 msgid "First page"
 msgstr "முதல் பக்கம்"
 
@@ -3766,11 +3859,11 @@ msgstr "முதல் பக்கம்"
 msgid "Fixed"
 msgstr "நிலையானது"
 
-#: ../src/html/helpwnd.cpp:1206
+#: ../src/html/helpwnd.cpp:1204
 msgid "Fixed font:"
 msgstr "நிலையான எழுத்துரு:"
 
-#: ../src/html/helpwnd.cpp:1269
+#: ../src/html/helpwnd.cpp:1267
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "நிலையான அளவு முகம். <br> <b>அடர்த்தி</b> <i>வலப்பக்க சாய்வு</i> "
 
@@ -3778,16 +3871,16 @@ msgstr "நிலையான அளவு முகம். <br> <b>அடர்
 msgid "Floating"
 msgstr "மிதக்கின்ற"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "Floppy"
 msgstr "நெகிழ்வட்டு"
 
-#: ../src/common/paper.cpp:111
+#: ../src/common/paper.cpp:108
 msgid "Folio, 8 1/2 x 13 in"
 msgstr "எதிர்புற பக்கம், 8 1/2 x 13 in"
 
-#: ../src/richtext/richtextformatdlg.cpp:344 ../src/osx/carbon/fontdlg.cpp:287
-#: ../src/common/stockitem.cpp:194
+#: ../src/osx/carbon/fontdlg.cpp:284 ../src/common/stockitem.cpp:191
+#: ../src/richtext/richtextformatdlg.cpp:337
 msgid "Font"
 msgstr "எழுத்துரு"
 
@@ -3795,7 +3888,24 @@ msgstr "எழுத்துரு"
 msgid "Font &weight:"
 msgstr "எழுத்துரு எடை:"
 
-#: ../src/html/helpwnd.cpp:1207
+#: ../src/osx/fontutil.cpp:89
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
+"\"."
+msgstr ""
+
+#: ../src/msw/font.cpp:1126
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "கோப்பு ஏற்றப்பட இயலவில்லை."
+
+#: ../src/osx/fontutil.cpp:81
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "கோப்பு கிடைப்பில் இல்லை!"
+
+#: ../src/html/helpwnd.cpp:1205
 msgid "Font size:"
 msgstr "எழுத்துரு அளவு:"
 
@@ -3803,53 +3913,53 @@ msgstr "எழுத்துரு அளவு:"
 msgid "Font st&yle:"
 msgstr "எழுத்துரு பாங்கு:"
 
-#: ../src/osx/carbon/fontdlg.cpp:329
+#: ../src/osx/carbon/fontdlg.cpp:326
 msgid "Font:"
 msgstr "எழுத்துரு:"
 
-#: ../src/dfb/fontmgr.cpp:198
+#: ../src/dfb/fontmgr.cpp:195
 #, c-format
 msgid "Fonts index file %s disappeared while loading fonts."
 msgstr "எழுத்துருகளை ஏற்றும்பொழுது %s எழுத்துரு சுட்டெண் கோப்பு மறைந்துவிட்டது."
 
-#: ../src/unix/utilsunx.cpp:645
+#: ../src/unix/utilsunx.cpp:647
 msgid "Fork failed"
 msgstr "பிளவு தோல்வியடைந்தது"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "Forward"
 msgstr "முன்நகர்"
 
-#: ../src/common/xtixml.cpp:235
+#: ../src/common/xtixml.cpp:231
 msgid "Forward hrefs are not supported"
 msgstr "hrefs முன்நகர்வுகள் ஆதரிக்கப்படுவதில்லை"
 
-#: ../src/html/helpwnd.cpp:875
+#: ../src/html/helpwnd.cpp:873
 #, c-format
 msgid "Found %i matches"
 msgstr "%i பொருத்தங்கள் காணப்பட்டன"
 
-#: ../src/generic/prntdlgg.cpp:238
+#: ../src/generic/prntdlgg.cpp:231
 msgid "From:"
 msgstr "அனுப்புநர்:"
 
-#: ../src/propgrid/advprops.cpp:1604
+#: ../src/propgrid/advprops.cpp:1510
 msgid "Fuchsia"
 msgstr ""
 
-#: ../src/common/imaggif.cpp:138
+#: ../src/common/imaggif.cpp:135
 msgid "GIF: data stream seems to be truncated."
 msgstr "GIF: தரவு ஓடை அறுபட்டிருப்பதாகத் தோன்றுகிறது."
 
-#: ../src/common/imaggif.cpp:128
+#: ../src/common/imaggif.cpp:125
 msgid "GIF: error in GIF image format."
 msgstr "GIF: GIF படிமத்தில் பிழை."
 
-#: ../src/common/imaggif.cpp:133
+#: ../src/common/imaggif.cpp:130
 msgid "GIF: not enough memory."
 msgstr "GIF: போதுமான நினைவகம் இல்லை."
 
-#: ../src/gtk/window.cpp:4631
+#: ../src/gtk/window.cpp:5635
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -3857,23 +3967,23 @@ msgstr ""
 "இந்த கணினியில் நிறுவப்பட்டிருக்கும் GTK+, திரைக் கலவையை ஆதரிக்க இயலாத அளவிற்கு "
 "பழமையாய் உள்ளது. GTK+ 2.12 அல்லது அதற்கும் பின்னரான பதிப்பினை கருணைக்கூர்ந்து நிறுவவும்."
 
-#: ../src/univ/themes/gtk.cpp:525
+#: ../src/univ/themes/gtk.cpp:522
 msgid "GTK+ theme"
 msgstr "GTK+ கருத்தோற்றம்"
 
-#: ../src/common/preferencescmn.cpp:40
+#: ../src/common/preferencescmn.cpp:37
 msgid "General"
 msgstr "பொது"
 
-#: ../src/common/prntbase.cpp:258
+#: ../src/common/prntbase.cpp:253
 msgid "Generic PostScript"
 msgstr "பொதுத் தரவு பின் குறிப்பு"
 
-#: ../src/common/paper.cpp:135
+#: ../src/common/paper.cpp:132
 msgid "German Legal Fanfold, 8 1/2 x 13 in"
 msgstr "ஜெர்மானிய சட்ட முன்பின் மடிப்பு, 8 1/2 x 13 in"
 
-#: ../src/common/paper.cpp:134
+#: ../src/common/paper.cpp:131
 msgid "German Std Fanfold, 8 1/2 x 12 in"
 msgstr "ஜெர்மானிய நிலையான முன்பின் மடிப்பு, 8 1/2 x 12 in"
 
@@ -3889,49 +3999,49 @@ msgstr "பொதுத் தரவு அணுகியின் மேலா
 msgid "GetPropertyCollection called w/o valid collection getter"
 msgstr "w/o ஏற்புள்ள பெறுநர் என்கிற பொருள் திரட்டினைப் பெறு"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:658
 msgid "Go back"
 msgstr "பின் செல்"
 
-#: ../src/html/helpwnd.cpp:661
+#: ../src/html/helpwnd.cpp:659
 msgid "Go forward"
 msgstr "முன் செல்"
 
-#: ../src/html/helpwnd.cpp:663
+#: ../src/html/helpwnd.cpp:661
 msgid "Go one level up in document hierarchy"
 msgstr "ஆவண அடுக்கில் ஒரு மேல் நிலைக்குச் செல்"
 
-#: ../src/generic/filedlgg.cpp:208 ../src/generic/dirdlgg.cpp:116
+#: ../src/generic/filedlgg.cpp:205 ../src/generic/dirdlgg.cpp:113
 msgid "Go to home directory"
 msgstr "முகப்பு அடைவிற்குச் செல்க"
 
-#: ../src/generic/filedlgg.cpp:205
+#: ../src/generic/filedlgg.cpp:202
 msgid "Go to parent directory"
 msgstr "தாய் அடைவிற்குச் செல்க"
 
-#: ../src/generic/aboutdlgg.cpp:76
+#: ../src/generic/aboutdlgg.cpp:73
 msgid "Graphics art by "
 msgstr "வரைகலை ஓவியம்:"
 
-#: ../src/propgrid/advprops.cpp:1599
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Gray"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:883
+#: ../src/propgrid/advprops.cpp:784
 msgid "GrayText"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:154
+#: ../src/common/fmapbase.cpp:151
 msgid "Greek (ISO-8859-7)"
 msgstr "கிரேக்கம் (ISO-8859-7)"
 
-#: ../src/propgrid/advprops.cpp:1600
+#: ../src/propgrid/advprops.cpp:1506
 #, fuzzy
 msgid "Green"
 msgstr "MAC கிரேக்கம்"
 
-#: ../src/generic/colrdlgg.cpp:342
+#: ../src/generic/colrdlgg.cpp:362
 #, fuzzy
 msgid "Green:"
 msgstr "MAC கிரேக்கம்"
@@ -3940,109 +4050,109 @@ msgstr "MAC கிரேக்கம்"
 msgid "Groove"
 msgstr "வரிப்பள்ளம்"
 
-#: ../src/common/zstream.cpp:158 ../src/common/zstream.cpp:318
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
 msgid "Gzip not supported by this version of zlib"
 msgstr "Gzip இந்த பதிப்பு Zlib-னால் ஆதரிக்கப்படுவதில்லை"
 
-#: ../src/html/helpwnd.cpp:1549
+#: ../src/html/helpwnd.cpp:1547
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "HTML உதவிப் பணித் திட்டம் (*.hhp)|*.hhp|"
 
-#: ../src/html/htmlwin.cpp:681
+#: ../src/html/htmlwin.cpp:691
 #, c-format
 msgid "HTML anchor %s does not exist."
 msgstr "%s HTML நங்கூரம் கிடைப்பில் இல்லை."
 
-#: ../src/html/helpwnd.cpp:1547
+#: ../src/html/helpwnd.cpp:1545
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "HTML கோப்புகள் (*.html;*.htm)|*.html;*.htm|"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1759
+#: ../src/propgrid/advprops.cpp:1660
 msgid "Hand"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "Harddisk"
 msgstr "வன்தட்டு"
 
-#: ../src/common/fmapbase.cpp:155
+#: ../src/common/fmapbase.cpp:152
 msgid "Hebrew (ISO-8859-8)"
 msgstr "ஹீப்ரு (ISO-8859-8)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:280 ../src/osx/button_osx.cpp:39
-#: ../src/common/stockitem.cpp:163 ../src/common/accelcmn.cpp:80
-#: ../src/html/helpdlg.cpp:66 ../src/html/helpfrm.cpp:111
+#: ../include/wx/msgdlg.h:282 ../src/osx/button_osx.cpp:39
+#: ../src/common/stockitem.cpp:160 ../src/common/accelcmn.cpp:77
+#: ../src/html/helpfrm.cpp:108 ../src/html/helpdlg.cpp:63
 msgid "Help"
 msgstr "உதவி"
 
-#: ../src/html/helpwnd.cpp:1200
+#: ../src/html/helpwnd.cpp:1198
 msgid "Help Browser Options"
 msgstr "உலாவி விருப்பத் தேர்வுகள் உதவி"
 
-#: ../src/generic/helpext.cpp:454 ../src/generic/helpext.cpp:455
+#: ../src/generic/helpext.cpp:452 ../src/generic/helpext.cpp:453
 msgid "Help Index"
 msgstr "உதவிச் சுட்டெண்"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1529
 msgid "Help Printing"
 msgstr "அச்சிடுதல் உதவி"
 
-#: ../src/html/helpwnd.cpp:801
+#: ../src/html/helpwnd.cpp:799
 msgid "Help Topics"
 msgstr "உதவித் தலைப்புகள்"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1546
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "உதவி ஏடுகள் (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 
-#: ../src/generic/helpext.cpp:267
+#: ../src/generic/helpext.cpp:265
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "\"%s\" உதவி அடைவு காணப்படவில்லை."
 
-#: ../src/generic/helpext.cpp:275
+#: ../src/generic/helpext.cpp:273
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "\"%s\" உதவிக் கோப்பு காணப்படவில்லை."
 
-#: ../src/html/helpctrl.cpp:63
+#: ../src/html/helpctrl.cpp:59
 #, c-format
 msgid "Help: %s"
 msgstr "உதவி: %s"
 
-#: ../src/osx/menu_osx.cpp:577
+#: ../src/osx/menu_osx.cpp:469
 #, c-format
 msgid "Hide %s"
 msgstr "%s-யினை மறை"
 
-#: ../src/osx/menu_osx.cpp:579
+#: ../src/osx/menu_osx.cpp:471
 msgid "Hide Others"
 msgstr "பிறவற்றை மறை"
 
-#: ../src/generic/infobar.cpp:84
+#: ../src/generic/infobar.cpp:81
 msgid "Hide this notification message."
 msgstr "இந்த அறிவிப்புத் தகவலை மறைவாக்கு."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:884
+#: ../src/propgrid/advprops.cpp:785
 #, fuzzy
 msgid "Highlight"
 msgstr "இலகுவானது"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:885
+#: ../src/propgrid/advprops.cpp:786
 #, fuzzy
 msgid "HighlightText"
 msgstr "உரையை வலது ஒழுங்காக்கு."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:164 ../src/common/accelcmn.cpp:65
+#: ../src/common/stockitem.cpp:161 ../src/common/accelcmn.cpp:62
 msgid "Home"
 msgstr "முகப்பு"
 
-#: ../src/generic/dirctrlg.cpp:524
+#: ../src/generic/dirctrlg.cpp:490
 msgid "Home directory"
 msgstr "முகப்பு அடைவு"
 
@@ -4052,61 +4162,61 @@ msgid "How the object will float relative to the text."
 msgstr "உரைக்கு ஏற்றவாறு பொருள் எவ்வாறு மிதக்கும்."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1760
+#: ../src/propgrid/advprops.cpp:1661
 msgid "I-Beam"
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1196
+#: ../src/common/imagbmp.cpp:1208
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: மூடுதிரை DIB படிப்பதில் பிழை."
 
-#: ../src/common/imagbmp.cpp:1290 ../src/common/imagbmp.cpp:1390
-#: ../src/common/imagbmp.cpp:1405 ../src/common/imagbmp.cpp:1416
-#: ../src/common/imagbmp.cpp:1430 ../src/common/imagbmp.cpp:1478
-#: ../src/common/imagbmp.cpp:1493 ../src/common/imagbmp.cpp:1507
-#: ../src/common/imagbmp.cpp:1518
+#: ../src/common/imagbmp.cpp:1302 ../src/common/imagbmp.cpp:1402
+#: ../src/common/imagbmp.cpp:1417 ../src/common/imagbmp.cpp:1428
+#: ../src/common/imagbmp.cpp:1442 ../src/common/imagbmp.cpp:1490
+#: ../src/common/imagbmp.cpp:1505 ../src/common/imagbmp.cpp:1519
+#: ../src/common/imagbmp.cpp:1530
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: படிமக் கோப்பினை எழுதுவதில் பிழை!"
 
-#: ../src/common/imagbmp.cpp:1255
+#: ../src/common/imagbmp.cpp:1267
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: படவுருவிற்கு இது மிக உயரமானப் படிமம்."
 
-#: ../src/common/imagbmp.cpp:1263
+#: ../src/common/imagbmp.cpp:1275
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: படவுருவிற்கு இது மிக அகலமான படிமம்."
 
-#: ../src/common/imagbmp.cpp:1603
+#: ../src/common/imagbmp.cpp:1615
 msgid "ICO: Invalid icon index."
 msgstr "ICO: ஏற்கமுடியாத படவுரு சுட்டெண்."
 
-#: ../src/common/imagiff.cpp:758
+#: ../src/common/imagiff.cpp:755
 msgid "IFF: data stream seems to be truncated."
 msgstr "IFF: தரவு ஓடை அறுபட்டிருப்பதாகத் தோன்றுகிறது."
 
-#: ../src/common/imagiff.cpp:742
+#: ../src/common/imagiff.cpp:739
 msgid "IFF: error in IFF image format."
 msgstr "IFF: IFF படிம வடிவூட்டத்தில் பிழை."
 
-#: ../src/common/imagiff.cpp:745
+#: ../src/common/imagiff.cpp:742
 msgid "IFF: not enough memory."
 msgstr "IFF: போதா நினைவகம்."
 
-#: ../src/common/imagiff.cpp:748
+#: ../src/common/imagiff.cpp:745
 msgid "IFF: unknown error!!!"
 msgstr "IFF: தெரியாதப் பிழை!"
 
-#: ../src/common/fmapbase.cpp:197
+#: ../src/common/fmapbase.cpp:194
 msgid "ISO-2022-JP"
 msgstr "ISO-2022-JP"
 
-#: ../src/html/htmprint.cpp:282
+#: ../src/html/htmprint.cpp:294
 msgid ""
 "If possible, try changing the layout parameters to make the printout more "
 "narrow."
 msgstr "இயன்றால், அச்சிடுதலை குறுகலாக்க வரைவின் குறியீட்டு அளவை மாற்றிப் பாருங்கள்."
 
-#: ../src/generic/dbgrptg.cpp:358
+#: ../src/generic/dbgrptg.cpp:362
 msgid ""
 "If you have any additional information pertaining to this bug\n"
 "report, please enter it here and it will be joined to it:"
@@ -4127,46 +4237,50 @@ msgstr ""
 "ஆகவே\n"
 "இயன்ற மட்டில், வழுநீக்க அறிக்கையை உருவாக்க முயலுங்கள்.\n"
 
-#: ../src/msw/registry.cpp:1405
+#: ../src/common/zipstrm.cpp:1043
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1393
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "மதிப்பு \"%s\" (\"%s\" விசையினுடையது) தவிர்க்கப்படுகிறது."
 
-#: ../src/common/xtistrm.cpp:295
+#: ../src/common/xtistrm.cpp:292
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "சட்டப்புரம்பான பொருள் உட்பிரிவு நிலை (Non-wxEvtHandler) நிகழ்வு மூலமாக உள்ளது"
 
-#: ../src/common/xti.cpp:513
+#: ../src/common/xti.cpp:510
 msgid "Illegal Parameter Count for ConstructObject Method"
 msgstr "பொருள் கட்டு முறைக்கு சட்டப்புரம்பான அளவுக் குறியீட்டுக் கணக்கு"
 
-#: ../src/common/xti.cpp:501
+#: ../src/common/xti.cpp:498
 msgid "Illegal Parameter Count for Create Method"
 msgstr "உருவாக்க முறைக்கு சட்டப்புரம்பான அளவுக் குறியீட்டுக் கணக்கு"
 
-#: ../src/generic/dirctrlg.cpp:570 ../src/generic/filectrlg.cpp:756
+#: ../src/generic/dirctrlg.cpp:536 ../src/generic/filectrlg.cpp:752
 msgid "Illegal directory name."
 msgstr "சட்டப்புரம்பான அடைவுப் பெயர்."
 
-#: ../src/generic/filectrlg.cpp:1367
+#: ../src/generic/filectrlg.cpp:1356
 msgid "Illegal file specification."
 msgstr "சட்டப்புரம்பான கோப்புக் குறிப்பீடு."
 
-#: ../src/common/image.cpp:2269
+#: ../src/common/image.cpp:2363
 msgid "Image and mask have different sizes."
 msgstr "படிமமும் மூடுதிரையும் வெவ்வேறு அளவுகளைக் கொண்டிருக்கின்றன."
 
-#: ../src/common/image.cpp:2746
+#: ../src/common/image.cpp:2841
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "படிமக் கோப்பின் வகை %d-ஆக இல்லை."
 
-#: ../src/common/image.cpp:2877
+#: ../src/common/image.cpp:2995
 #, c-format
 msgid "Image is not of type %s."
 msgstr "படிமத்தின் வகை %s-ஆக இல்லை."
 
-#: ../src/msw/textctrl.cpp:488
+#: ../src/msw/textctrl.cpp:534
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -4174,102 +4288,102 @@ msgstr ""
 "செரிவூட்டப்பட்ட தொகுக் கட்டுப்பாட்டை உருவாக்க இயலாமையால், எளிய உரைக் கட்டுப்பாடு "
 "பயன்படுத்தப்படுகிறது. riched32.dll நிரலை மறுநிறுவு செய்யவும்."
 
-#: ../src/unix/utilsunx.cpp:301
+#: ../src/unix/utilsunx.cpp:303
 msgid "Impossible to get child process input"
 msgstr "சேய் செயல்முறை உள்ளீட்டினை பெற இயலவில்லை."
 
-#: ../src/common/filefn.cpp:1028
+#: ../src/common/filefn.cpp:917
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "'%s' கோப்பிற்கு அனுமதிகளைப் பெற இயலவில்லை."
 
-#: ../src/common/filefn.cpp:1042
+#: ../src/common/filefn.cpp:931
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "'%s' கோப்பினை அழித்தெழுத இயலவில்லை."
 
-#: ../src/common/filefn.cpp:1097
+#: ../src/common/filefn.cpp:986
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "'%s' கோப்பிற்கு அனுமதிகளை அமைக்க இயலவில்லை."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:886
+#: ../src/propgrid/advprops.cpp:787
 #, fuzzy
 msgid "InactiveBorder"
 msgstr "எல்லை"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:887
+#: ../src/propgrid/advprops.cpp:788
 msgid "InactiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:888
+#: ../src/propgrid/advprops.cpp:789
 msgid "InactiveCaptionText"
 msgstr ""
 
-#: ../src/common/gifdecod.cpp:792
+#: ../src/common/gifdecod.cpp:826
 #, c-format
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "தவறான GIF சட்டக அளவு (%u, %d) - #%u சட்டகத்திற்கானது"
 
-#: ../src/msw/ole/automtn.cpp:635
+#: ../src/msw/ole/automtn.cpp:626
 msgid "Incorrect number of arguments."
 msgstr "தர்க்கங்களின் தவறான எண்ணிக்கை."
 
-#: ../src/common/stockitem.cpp:165
+#: ../src/common/stockitem.cpp:162
 msgid "Indent"
 msgstr "வரித் துவக்க ஒழுங்கு"
 
-#: ../src/richtext/richtextformatdlg.cpp:349
+#: ../src/richtext/richtextformatdlg.cpp:342
 msgid "Indents && Spacing"
 msgstr "வரித் துவக்க ஒழுங்கின் இடைவெளி"
 
-#: ../src/common/stockitem.cpp:166 ../src/html/helpwnd.cpp:515
+#: ../src/common/stockitem.cpp:163 ../src/html/helpwnd.cpp:513
 msgid "Index"
 msgstr "சுட்டெண்"
 
-#: ../src/common/fmapbase.cpp:159
+#: ../src/common/fmapbase.cpp:156
 msgid "Indian (ISO-8859-12)"
 msgstr "இந்திய (ISO-8859-12)"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "Info"
 msgstr "தகவல்"
 
-#: ../src/common/init.cpp:287
+#: ../src/common/init.cpp:284
 msgid "Initialization failed in post init, aborting."
 msgstr "Post init-ல் துவக்க நிலையாக்கம் தோல்வி, செயல் இடைமறிக்கப்படுகிறது."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:54
+#: ../src/common/accelcmn.cpp:51
 #, fuzzy
 msgid "Ins"
 msgstr "செருகு"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextsymboldlg.cpp:472 ../src/common/accelcmn.cpp:53
+#: ../src/common/accelcmn.cpp:50 ../src/richtext/richtextsymboldlg.cpp:469
 msgid "Insert"
 msgstr "செருகு"
 
-#: ../src/richtext/richtextbuffer.cpp:8067
+#: ../src/richtext/richtextbuffer.cpp:8063
 msgid "Insert Field"
 msgstr "களத்தை செருகு"
 
-#: ../src/richtext/richtextbuffer.cpp:7978
-#: ../src/richtext/richtextbuffer.cpp:8936
+#: ../src/richtext/richtextbuffer.cpp:7974
+#: ../src/richtext/richtextbuffer.cpp:8934
 msgid "Insert Image"
 msgstr "படிமத்தை செருகு"
 
-#: ../src/richtext/richtextbuffer.cpp:8025
+#: ../src/richtext/richtextbuffer.cpp:8021
 msgid "Insert Object"
 msgstr "பொருளை செருகு"
 
-#: ../src/richtext/richtextctrl.cpp:1286 ../src/richtext/richtextctrl.cpp:1494
-#: ../src/richtext/richtextbuffer.cpp:7822
-#: ../src/richtext/richtextbuffer.cpp:7852
-#: ../src/richtext/richtextbuffer.cpp:7894
+#: ../src/richtext/richtextbuffer.cpp:7818
+#: ../src/richtext/richtextbuffer.cpp:7848
+#: ../src/richtext/richtextbuffer.cpp:7890
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
 msgid "Insert Text"
 msgstr "உரையை செருகு"
 
@@ -4282,17 +4396,11 @@ msgstr "பத்திக்கு முன் பக்க முறிவை
 msgid "Inset"
 msgstr "செருகு"
 
-#: ../src/gtk/app.cpp:425
-#, c-format
-msgid "Invalid GTK+ command line option, use \"%s --help\""
-msgstr ""
-"ஏற்கமுடியாத GTK+ கட்டளை வரி விருப்பத் தேர்வு, \"%s - help\"-யினை பயன்படுத்துங்கள்"
-
-#: ../src/common/imagtiff.cpp:311
+#: ../src/common/imagtiff.cpp:308
 msgid "Invalid TIFF image index."
 msgstr "ஏற்கமுடியாத TIFF படிம சுட்டெண்."
 
-#: ../src/common/appcmn.cpp:273
+#: ../src/common/appcmn.cpp:294
 #, c-format
 msgid "Invalid display mode specification '%s'."
 msgstr "ஏற்கமுடியாத காட்சியமைவு நிலை அளவுக் குறியீடு '%s'."
@@ -4302,258 +4410,262 @@ msgstr "ஏற்கமுடியாத காட்சியமைவு ந�
 msgid "Invalid geometry specification '%s'"
 msgstr "ஏற்கமுடியாத வடிவியல் அளவுக் குறியீடு '%s'"
 
-#: ../src/unix/fswatcher_inotify.cpp:323
+#: ../src/unix/fswatcher_inotify.cpp:320
 #, c-format
 msgid "Invalid inotify event for \"%s\""
 msgstr "\"%s\"-ற்கான ஏற்கமுடியாத inotify நிகழ்வு"
 
-#: ../src/unix/snglinst.cpp:312
+#: ../src/unix/snglinst.cpp:309
 #, c-format
 msgid "Invalid lock file '%s'."
 msgstr "ஏற்கமுடியாத பூட்டுக் கோப்பு '%s'."
 
-#: ../src/common/translation.cpp:1125
+#: ../src/common/translation.cpp:1167
 msgid "Invalid message catalog."
 msgstr "ஏற்கமுடியாத தகவல் பட்டியல்."
 
-#: ../src/common/xtistrm.cpp:405 ../src/common/xtistrm.cpp:420
+#: ../src/common/xtistrm.cpp:402 ../src/common/xtistrm.cpp:417
 msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
 msgstr "ஏற்க முடியாத அல்லது இல்லாத பொருள் GetObjectClassInfo-விடம் அநுப்பப்பட்டது"
 
-#: ../src/common/xtistrm.cpp:435
+#: ../src/common/xtistrm.cpp:432
 msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
 msgstr ""
 "ஏற்க முடியாத அல்லது இல்லாத பொருள் அடையாளம் HasObjectClassInfo-விடம் அனுப்பப்பட்டது"
 
-#: ../src/common/regex.cpp:310
+#: ../src/common/regex.cpp:307
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "ஏற்கமுடியாத வழக்கமான வெளிப்பாடு '%s': %s"
 
-#: ../src/common/config.cpp:226
+#: ../src/common/config.cpp:222
 #, c-format
 msgid "Invalid value %ld for a boolean key \"%s\" in config file."
 msgstr "அமைவடிவக் கோப்பில் ஏற்க முடியாத %ld மதிப்பு (\"%s\" பூலிய விசைக்கானது). "
 
-#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:351
-#: ../src/osx/carbon/fontdlg.cpp:361 ../src/common/stockitem.cpp:168
+#: ../src/osx/carbon/fontdlg.cpp:358 ../src/common/stockitem.cpp:165
+#: ../src/generic/fontdlgg.cpp:325 ../src/richtext/richtextfontpage.cpp:351
 msgid "Italic"
 msgstr "வலப்பக்க சாய்வு"
 
-#: ../src/common/paper.cpp:130
+#: ../src/common/paper.cpp:127
 msgid "Italy Envelope, 110 x 230 mm"
 msgstr "இத்தாலிய அஞ்சல் உறை, 110 x 230 mm"
 
-#: ../src/common/imagjpeg.cpp:270
+#: ../src/common/imagjpeg.cpp:257
 msgid "JPEG: Couldn't load - file is probably corrupted."
 msgstr "JPEG: ஏற்ற இயலவில்லை - கோப்பு ஒரு வேளை பழுதடைந்திருக்கலாம்."
 
-#: ../src/common/imagjpeg.cpp:449
+#: ../src/common/imagjpeg.cpp:436
 msgid "JPEG: Couldn't save image."
 msgstr "JPEG: படிமத்தை ஏற்ற இயலவில்லை."
 
-#: ../src/common/paper.cpp:163
+#: ../src/common/paper.cpp:160
 msgid "Japanese Double Postcard 200 x 148 mm"
 msgstr "ஜப்பானிய இரட்டை அஞ்சல் அட்டை 200 x 148 mm"
 
-#: ../src/common/paper.cpp:167
+#: ../src/common/paper.cpp:164
 msgid "Japanese Envelope Chou #3"
 msgstr "ஜப்பானிய அஞ்சல் உறை Chou #3"
 
-#: ../src/common/paper.cpp:180
+#: ../src/common/paper.cpp:177
 msgid "Japanese Envelope Chou #3 Rotated"
 msgstr "ஜப்பானிய அஞ்சல் உறை Chou #3 சுழற்றப்பட்டது "
 
-#: ../src/common/paper.cpp:168
+#: ../src/common/paper.cpp:165
 msgid "Japanese Envelope Chou #4"
 msgstr "ஜப்பானிய அஞ்சல் உறை Chou #4"
 
-#: ../src/common/paper.cpp:181
+#: ../src/common/paper.cpp:178
 msgid "Japanese Envelope Chou #4 Rotated"
 msgstr "ஜப்பானிய அஞ்சல் உறை Chou #4 சுழற்றப்பட்டது "
 
-#: ../src/common/paper.cpp:165
+#: ../src/common/paper.cpp:162
 msgid "Japanese Envelope Kaku #2"
 msgstr "ஜப்பானிய அஞ்சல் உறை Kaku #2"
 
-#: ../src/common/paper.cpp:178
+#: ../src/common/paper.cpp:175
 msgid "Japanese Envelope Kaku #2 Rotated"
 msgstr "ஜப்பானிய அஞ்சல் உறை Kaku #2 சுழற்றப்பட்டது"
 
-#: ../src/common/paper.cpp:166
+#: ../src/common/paper.cpp:163
 msgid "Japanese Envelope Kaku #3"
 msgstr "ஜப்பானிய அஞ்சல் உறை Kaku #3"
 
-#: ../src/common/paper.cpp:179
+#: ../src/common/paper.cpp:176
 msgid "Japanese Envelope Kaku #3 Rotated"
 msgstr "ஜப்பானிய அஞ்சல் உறை Kaku #3 சுழற்றப்பட்டது"
 
-#: ../src/common/paper.cpp:185
+#: ../src/common/paper.cpp:182
 msgid "Japanese Envelope You #4"
 msgstr "ஜப்பானிய அஞ்சல் உறை You #4"
 
-#: ../src/common/paper.cpp:186
+#: ../src/common/paper.cpp:183
 msgid "Japanese Envelope You #4 Rotated"
 msgstr "ஜப்பானிய அஞ்சல் உறை You #4 சுழற்றப்பட்டது"
 
-#: ../src/common/paper.cpp:138
+#: ../src/common/paper.cpp:135
 msgid "Japanese Postcard 100 x 148 mm"
 msgstr "ஜப்பானிய அஞ்சல் அட்டை 100 x 148 mm"
 
-#: ../src/common/paper.cpp:175
+#: ../src/common/paper.cpp:172
 msgid "Japanese Postcard Rotated 148 x 100 mm"
 msgstr "ஜப்பானிய அஞ்சல் அட்டை சுழற்றப்பட்டது 148 x 100 mm"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "Jump to"
 msgstr "இங்கே தாவு"
 
-#: ../src/common/stockitem.cpp:171
+#: ../src/common/stockitem.cpp:168
 msgid "Justified"
 msgstr "இருபுற ஒழுங்கு"
 
-#: ../src/richtext/richtextindentspage.cpp:155
-#: ../src/richtext/richtextindentspage.cpp:157
 #: ../src/richtext/richtextliststylepage.cpp:344
 #: ../src/richtext/richtextliststylepage.cpp:346
+#: ../src/richtext/richtextindentspage.cpp:155
+#: ../src/richtext/richtextindentspage.cpp:157
 msgid "Justify text left and right."
 msgstr "உரையை இடதும் வலதுமாக ஒழுங்கமை."
 
-#: ../src/common/fmapbase.cpp:163
+#: ../src/common/fmapbase.cpp:160
 msgid "KOI8-R"
 msgstr "KOI8-R"
 
-#: ../src/common/fmapbase.cpp:164
+#: ../src/common/fmapbase.cpp:161
 msgid "KOI8-U"
 msgstr "KOI8-U"
 
-#: ../src/common/accelcmn.cpp:265 ../src/common/accelcmn.cpp:347
+#: ../src/common/accelcmn.cpp:279 ../src/common/accelcmn.cpp:364
 msgid "KP_"
 msgstr "KP_"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 #, fuzzy
 msgid "KP_Add"
 msgstr "KP_ஏற்று"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "KP_Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "KP_Decimal"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 #, fuzzy
 msgid "KP_Delete"
 msgstr "அழி"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "KP_Divide"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 #, fuzzy
 msgid "KP_Down"
 msgstr "கீழ்"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 #, fuzzy
 msgid "KP_End"
 msgstr "KP_முடிவு"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 #, fuzzy
 msgid "KP_Enter"
 msgstr "அச்சுப் பொறி"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "KP_Equal"
 msgstr ""
 
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
-#, fuzzy
-msgid "KP_Home"
-msgstr "முகப்பு"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
-#, fuzzy
-msgid "KP_Insert"
-msgstr "செருகு"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
-#, fuzzy
-msgid "KP_Left"
-msgstr "இடது"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
-msgid "KP_Multiply"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:99
-#, fuzzy
-msgid "KP_Next"
-msgstr "அடுத்து"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
-msgid "KP_PageDown"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
-msgid "KP_PageUp"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:98
-msgid "KP_Prior"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
-#, fuzzy
-msgid "KP_Right"
-msgstr "வலது"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
-msgid "KP_Separator"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
-msgid "KP_Space"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
-msgid "KP_Subtract"
+#: ../src/common/accelcmn.cpp:276 ../src/common/accelcmn.cpp:361
+msgid "KP_F"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
 #: ../src/common/accelcmn.cpp:89
 #, fuzzy
+msgid "KP_Home"
+msgstr "முகப்பு"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:100
+#, fuzzy
+msgid "KP_Insert"
+msgstr "செருகு"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:90
+#, fuzzy
+msgid "KP_Left"
+msgstr "இடது"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:103
+msgid "KP_Multiply"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:97
+#, fuzzy
+msgid "KP_Next"
+msgstr "அடுத்து"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:95
+msgid "KP_PageDown"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:94
+msgid "KP_PageUp"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:96
+msgid "KP_Prior"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:92
+#, fuzzy
+msgid "KP_Right"
+msgstr "வலது"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:105
+msgid "KP_Separator"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:86
+msgid "KP_Space"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:106
+msgid "KP_Subtract"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:87
+#, fuzzy
 msgid "KP_Tab"
 msgstr "KP_தத்தல்"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 #, fuzzy
 msgid "KP_Up"
 msgstr "KP_மேல்"
@@ -4562,112 +4674,127 @@ msgstr "KP_மேல்"
 msgid "L&ine spacing:"
 msgstr "வரி இடைவெளி"
 
-#: ../src/generic/prntdlgg.cpp:613 ../src/generic/prntdlgg.cpp:868
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "அமுக்கப் பிழை"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "அமுக்க நீக்கப் பிழை"
+
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:861
 msgid "Landscape"
 msgstr "கிடநீளம்"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "Last"
 msgstr "கடைசி"
 
-#: ../src/common/prntbase.cpp:1572
+#: ../src/common/prntbase.cpp:1597
 msgid "Last page"
 msgstr "கடைசிப் பக்கம்"
 
-#: ../src/common/log.cpp:305
+#: ../src/common/log.cpp:324
 #, fuzzy, c-format
 msgid "Last repeated message (\"%s\", %u time) wasn't output"
 msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
 msgstr[0] "கடைசியாக மறுஅறிவிப்பு செய்யப்பட்ட தகவல் (\"%s\", %lu தடவை) வெளியீடு இல்லை"
 msgstr[1] "Last repeated message (\"%s\", %lu times) wasn't output"
 
-#: ../src/common/paper.cpp:103
+#: ../src/common/paper.cpp:100
 msgid "Ledger, 17 x 11 in"
 msgstr "கணக்குப் பதிவேடு, 17 x 11 in"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6146
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:58 ../src/generic/datavgen.cpp:6951
+#: ../src/richtext/richtextsizepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:252
 #: ../src/richtext/richtextliststylepage.cpp:253
 #: ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
-#: ../src/richtext/richtextsizepage.cpp:249 ../src/common/accelcmn.cpp:61
 msgid "Left"
 msgstr "இடது"
 
-#: ../src/richtext/richtextindentspage.cpp:204
 #: ../src/richtext/richtextliststylepage.cpp:390
+#: ../src/richtext/richtextindentspage.cpp:204
 msgid "Left (&first line):"
 msgstr "இடது (முதல் வரி):"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1761
+#: ../src/propgrid/advprops.cpp:1662
 msgid "Left Button"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:880
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Left margin (mm):"
 msgstr "இடதுக் கரை (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:141
-#: ../src/richtext/richtextindentspage.cpp:143
 #: ../src/richtext/richtextliststylepage.cpp:330
 #: ../src/richtext/richtextliststylepage.cpp:332
+#: ../src/richtext/richtextindentspage.cpp:141
+#: ../src/richtext/richtextindentspage.cpp:143
 msgid "Left-align text."
 msgstr "உரையை இடப் பக்கம் ஒழுங்கமை:"
 
-#: ../src/common/paper.cpp:144
+#: ../src/common/paper.cpp:141
 msgid "Legal Extra 9 1/2 x 15 in"
 msgstr "சட்டம் Extra 9 1/2 x 15 in"
 
-#: ../src/common/paper.cpp:96
+#: ../src/common/paper.cpp:93
 msgid "Legal, 8 1/2 x 14 in"
 msgstr "சட்டம், 8 1/2 x 14 in"
 
-#: ../src/common/paper.cpp:143
+#: ../src/common/paper.cpp:140
 msgid "Letter Extra 9 1/2 x 12 in"
 msgstr "கடிதம் கூடுதல் 9 1/2 x 12 in"
 
-#: ../src/common/paper.cpp:149
+#: ../src/common/paper.cpp:146
 msgid "Letter Extra Transverse 9.275 x 12 in"
 msgstr "கடிதம் கூடுதல் குறுக்கு 9.275 x 12 in"
 
-#: ../src/common/paper.cpp:152
+#: ../src/common/paper.cpp:149
 msgid "Letter Plus 8 1/2 x 12.69 in"
 msgstr "கடிதம் பிளஸ் 8 1/2 x 12.69 in"
 
-#: ../src/common/paper.cpp:169
+#: ../src/common/paper.cpp:166
 msgid "Letter Rotated 11 x 8 1/2 in"
 msgstr "கடிதம் சுழற்றப்பட்டது 11 x 8 1/2 in"
 
-#: ../src/common/paper.cpp:101
+#: ../src/common/paper.cpp:98
 msgid "Letter Small, 8 1/2 x 11 in"
 msgstr "கடிதம் சிறியது, 8 1/2 x 11 in"
 
-#: ../src/common/paper.cpp:147
+#: ../src/common/paper.cpp:144
 msgid "Letter Transverse 8 1/2 x 11 in"
 msgstr "கடிதம் குறுக்கு 8 1/2 x 11 in"
 
-#: ../src/common/paper.cpp:95
+#: ../src/common/paper.cpp:92
 msgid "Letter, 8 1/2 x 11 in"
 msgstr "கடிதம், 8 1/2 x 11 in"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "License"
 msgstr "உரிமம்"
 
-#: ../src/generic/fontdlgg.cpp:332
+#: ../src/generic/fontdlgg.cpp:328
 msgid "Light"
 msgstr "இலகு"
 
-#: ../src/propgrid/advprops.cpp:1608
+#: ../src/propgrid/advprops.cpp:1514
 msgid "Lime"
 msgstr ""
 
-#: ../src/generic/helpext.cpp:294
+#: ../src/generic/helpext.cpp:292
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr "%lu வரியில் (\"%s\" வரைவுக் கோப்பு) ஏற்கமுடியாத நிரல்தொடர், தவிர்க்கப்படுகிறது."
@@ -4676,15 +4803,15 @@ msgstr "%lu வரியில் (\"%s\" வரைவுக் கோப்ப�
 msgid "Line spacing:"
 msgstr "வரி இடைவெளி:"
 
-#: ../src/html/chm.cpp:838
+#: ../src/html/chm.cpp:829
 msgid "Link contained '//', converted to absolute link."
 msgstr "தொடுப்பு '//' கொண்டிருந்தது, அறுதியான தொடுப்பாக மாற்றப்பட்டது."
 
-#: ../src/richtext/richtextformatdlg.cpp:364
+#: ../src/richtext/richtextformatdlg.cpp:357
 msgid "List Style"
 msgstr "வரிசைப் பட்டியல் பாங்கு"
 
-#: ../src/richtext/richtextstyles.cpp:1064
+#: ../src/richtext/richtextstyles.cpp:1061
 msgid "List styles"
 msgstr "வரிசைப் பட்டியல் பாங்குகள்"
 
@@ -4698,26 +4825,26 @@ msgstr "எழுத்துருகளை புள்ளி அளவுக�
 msgid "Lists the available fonts."
 msgstr "இருக்கும் எழுத்துருகளை பட்டியலிடுகிறது."
 
-#: ../src/common/fldlgcmn.cpp:340
+#: ../src/common/fldlgcmn.cpp:337
 #, c-format
 msgid "Load %s file"
 msgstr "%s கோப்பினை ஏற்றுக"
 
-#: ../src/html/htmlwin.cpp:597
+#: ../src/html/htmlwin.cpp:600
 msgid "Loading : "
 msgstr "ஏற்றப்படுகிறது : "
 
-#: ../src/unix/snglinst.cpp:246
+#: ../src/unix/snglinst.cpp:243
 #, c-format
 msgid "Lock file '%s' has incorrect owner."
 msgstr "'%s' பூட்டுக் கோப்பு தவறான உரிமையாளரைக் கொண்டுள்ளது."
 
-#: ../src/unix/snglinst.cpp:251
+#: ../src/unix/snglinst.cpp:248
 #, c-format
 msgid "Lock file '%s' has incorrect permissions."
 msgstr "'%s' பூட்டுக் கோப்பு தவறான அனுமதிகளைக் கொண்டுள்ளது."
 
-#: ../src/generic/logg.cpp:576
+#: ../src/generic/logg.cpp:573
 #, c-format
 msgid "Log saved to the file '%s'."
 msgstr "செயற்குறிப்பு '%s' கோப்பில் சேமிக்கப்பட்டுள்ளது."
@@ -4732,11 +4859,11 @@ msgstr "கீழ்த் தட்டு எழுத்துகள்"
 msgid "Lower case roman numerals"
 msgstr "கீழ்த் தட்டு ரோமானிய எண்கள்"
 
-#: ../src/gtk/mdi.cpp:422 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk1/mdi.cpp:431 ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "MDI சேய்"
 
-#: ../src/msw/helpchm.cpp:56
+#: ../src/msw/helpchm.cpp:53
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -4744,189 +4871,189 @@ msgstr ""
 "இந்தக் கணினியில் MS HTML உதவி நூலகம்  நிறுவப்படாததால், MS HTML உதவி செயல்கள் "
 "பயன்பாட்டில் இல்லை. கருணைக் கூர்ந்து அதை நிறுவவும்."
 
-#: ../src/univ/themes/win32.cpp:3754
+#: ../src/univ/themes/win32.cpp:3751
 msgid "Ma&ximize"
 msgstr "உட்சபட்ச விரிவாக்கம்"
 
-#: ../src/common/fmapbase.cpp:203
+#: ../src/common/fmapbase.cpp:200
 msgid "MacArabic"
 msgstr "MAC அரேபியம்"
 
-#: ../src/common/fmapbase.cpp:222
+#: ../src/common/fmapbase.cpp:219
 msgid "MacArmenian"
 msgstr "MAC ஆர்மேனியம்"
 
-#: ../src/common/fmapbase.cpp:211
+#: ../src/common/fmapbase.cpp:208
 msgid "MacBengali"
 msgstr "MAC பெங்காலி"
 
-#: ../src/common/fmapbase.cpp:217
+#: ../src/common/fmapbase.cpp:214
 msgid "MacBurmese"
 msgstr "MAC பர்மியம்"
 
-#: ../src/common/fmapbase.cpp:236
+#: ../src/common/fmapbase.cpp:233
 msgid "MacCeltic"
 msgstr "MAC கெல்டிக்"
 
-#: ../src/common/fmapbase.cpp:227
+#: ../src/common/fmapbase.cpp:224
 msgid "MacCentralEurRoman"
 msgstr "MAC நடு ஐரோப்பா ரோமானியம்"
 
-#: ../src/common/fmapbase.cpp:223
+#: ../src/common/fmapbase.cpp:220
 msgid "MacChineseSimp"
 msgstr "MAC எளிய சீனம்"
 
-#: ../src/common/fmapbase.cpp:201
+#: ../src/common/fmapbase.cpp:198
 msgid "MacChineseTrad"
 msgstr "MAC பாரம்பரிய சீனம்"
 
-#: ../src/common/fmapbase.cpp:233
+#: ../src/common/fmapbase.cpp:230
 msgid "MacCroatian"
 msgstr "MAC குரோஷியம்"
 
-#: ../src/common/fmapbase.cpp:206
+#: ../src/common/fmapbase.cpp:203
 msgid "MacCyrillic"
 msgstr "MAC சிரிலிக்"
 
-#: ../src/common/fmapbase.cpp:207
+#: ../src/common/fmapbase.cpp:204
 msgid "MacDevanagari"
 msgstr "MAC தேவநாகரி"
 
-#: ../src/common/fmapbase.cpp:231
+#: ../src/common/fmapbase.cpp:228
 msgid "MacDingbats"
 msgstr "MacDingbats"
 
-#: ../src/common/fmapbase.cpp:226
+#: ../src/common/fmapbase.cpp:223
 msgid "MacEthiopic"
 msgstr "MAC எதியோபியா"
 
-#: ../src/common/fmapbase.cpp:229
+#: ../src/common/fmapbase.cpp:226
 msgid "MacExtArabic"
 msgstr "MAC அரேபிய Ext"
 
-#: ../src/common/fmapbase.cpp:237
+#: ../src/common/fmapbase.cpp:234
 msgid "MacGaelic"
 msgstr "MAC கேலிக்"
 
-#: ../src/common/fmapbase.cpp:221
+#: ../src/common/fmapbase.cpp:218
 msgid "MacGeorgian"
 msgstr "MAC ஜார்ஜியன்"
 
-#: ../src/common/fmapbase.cpp:205
+#: ../src/common/fmapbase.cpp:202
 msgid "MacGreek"
 msgstr "MAC கிரேக்கம்"
 
-#: ../src/common/fmapbase.cpp:209
+#: ../src/common/fmapbase.cpp:206
 msgid "MacGujarati"
 msgstr "MAC குஜராத்தி"
 
-#: ../src/common/fmapbase.cpp:208
+#: ../src/common/fmapbase.cpp:205
 msgid "MacGurmukhi"
 msgstr "MAC குர்முகி"
 
-#: ../src/common/fmapbase.cpp:204
+#: ../src/common/fmapbase.cpp:201
 msgid "MacHebrew"
 msgstr "MAC ஹீப்ரு"
 
-#: ../src/common/fmapbase.cpp:234
+#: ../src/common/fmapbase.cpp:231
 msgid "MacIcelandic"
 msgstr "MAC ஐஸ்லாந்திய"
 
-#: ../src/common/fmapbase.cpp:200
+#: ../src/common/fmapbase.cpp:197
 msgid "MacJapanese"
 msgstr "MAC ஜப்பானிய"
 
-#: ../src/common/fmapbase.cpp:214
+#: ../src/common/fmapbase.cpp:211
 msgid "MacKannada"
 msgstr "MAC கன்னடம்"
 
-#: ../src/common/fmapbase.cpp:238
+#: ../src/common/fmapbase.cpp:235
 msgid "MacKeyboardGlyphs"
 msgstr "MacKeyboardGlyphs"
 
-#: ../src/common/fmapbase.cpp:218
+#: ../src/common/fmapbase.cpp:215
 msgid "MacKhmer"
 msgstr "MAC கமேர்"
 
-#: ../src/common/fmapbase.cpp:202
+#: ../src/common/fmapbase.cpp:199
 msgid "MacKorean"
 msgstr "MAC கொரிய"
 
-#: ../src/common/fmapbase.cpp:220
+#: ../src/common/fmapbase.cpp:217
 msgid "MacLaotian"
 msgstr "MAC லேவோஷிய"
 
-#: ../src/common/fmapbase.cpp:215
+#: ../src/common/fmapbase.cpp:212
 msgid "MacMalayalam"
 msgstr "MAC மலையாளம்"
 
-#: ../src/common/fmapbase.cpp:225
+#: ../src/common/fmapbase.cpp:222
 msgid "MacMongolian"
 msgstr "MAC மங்கோலிய"
 
-#: ../src/common/fmapbase.cpp:210
+#: ../src/common/fmapbase.cpp:207
 msgid "MacOriya"
 msgstr "MAC ஒரியா"
 
-#: ../src/common/fmapbase.cpp:199
+#: ../src/common/fmapbase.cpp:196
 msgid "MacRoman"
 msgstr "MAC ரோமானிய"
 
-#: ../src/common/fmapbase.cpp:235
+#: ../src/common/fmapbase.cpp:232
 msgid "MacRomanian"
 msgstr "MAC ரோமானியம்"
 
-#: ../src/common/fmapbase.cpp:216
+#: ../src/common/fmapbase.cpp:213
 msgid "MacSinhalese"
 msgstr "MAC சிங்களம்"
 
-#: ../src/common/fmapbase.cpp:230
+#: ../src/common/fmapbase.cpp:227
 msgid "MacSymbol"
 msgstr "MAC குறியெழுத்து"
 
-#: ../src/common/fmapbase.cpp:212
+#: ../src/common/fmapbase.cpp:209
 msgid "MacTamil"
 msgstr "MAC தமிழ்"
 
-#: ../src/common/fmapbase.cpp:213
+#: ../src/common/fmapbase.cpp:210
 msgid "MacTelugu"
 msgstr "MAC தெலுங்கு"
 
-#: ../src/common/fmapbase.cpp:219
+#: ../src/common/fmapbase.cpp:216
 msgid "MacThai"
 msgstr "MAC தாய்"
 
-#: ../src/common/fmapbase.cpp:224
+#: ../src/common/fmapbase.cpp:221
 msgid "MacTibetan"
 msgstr "MAC திபெத்திய"
 
-#: ../src/common/fmapbase.cpp:232
+#: ../src/common/fmapbase.cpp:229
 msgid "MacTurkish"
 msgstr "MAC துருக்கிய"
 
-#: ../src/common/fmapbase.cpp:228
+#: ../src/common/fmapbase.cpp:225
 msgid "MacVietnamese"
 msgstr "MAC வியட்னாமிய"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1762
+#: ../src/propgrid/advprops.cpp:1663
 msgid "Magnifier"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:2143
+#: ../src/propgrid/advprops.cpp:2050
 msgid "Make a selection:"
 msgstr "தெரிவுச் செய்க:"
 
-#: ../src/richtext/richtextformatdlg.cpp:374
+#: ../src/richtext/richtextformatdlg.cpp:367
 #: ../src/richtext/richtextmarginspage.cpp:171
 msgid "Margins"
 msgstr "கரைகள்"
 
-#: ../src/propgrid/advprops.cpp:1595
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Maroon"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:147
+#: ../src/generic/fdrepdlg.cpp:144
 msgid "Match case"
 msgstr "முகப்பெழுத்தா, இல்லையா என்று ஒப்புநோக்கு"
 
@@ -4938,40 +5065,40 @@ msgstr "உட்சபட்ச உயரம்:"
 msgid "Max width:"
 msgstr "உட்சபட்ச அகலம்:"
 
-#: ../src/unix/mediactrl.cpp:947
+#: ../src/unix/mediactrl.cpp:972
 #, c-format
 msgid "Media playback error: %s"
 msgstr "ஊடக மீட்பொலிப்பில் பிழை: %s"
 
-#: ../src/common/fs_mem.cpp:175
+#: ../src/common/fs_mem.cpp:170
 #, c-format
 msgid "Memory VFS already contains file '%s'!"
 msgstr "VFS நினைவகம் '%s' கோப்பினை ஏற்கனவே கொண்டுள்ளது!"
 
 #. TRANSLATORS: Name of keyboard key
 #. TRANSLATORS: Keyword of system colour
-#: ../src/common/accelcmn.cpp:73 ../src/propgrid/advprops.cpp:889
+#: ../src/common/accelcmn.cpp:70 ../src/propgrid/advprops.cpp:790
 msgid "Menu"
 msgstr "பட்டியல்"
 
-#: ../src/common/msgout.cpp:124
+#: ../src/common/msgout.cpp:121
 msgid "Message"
 msgstr "தகவல்"
 
-#: ../src/univ/themes/metal.cpp:168
+#: ../src/univ/themes/metal.cpp:165
 msgid "Metal theme"
 msgstr "உலோகக் கருத்தோற்றம்"
 
-#: ../src/msw/ole/automtn.cpp:652
+#: ../src/msw/ole/automtn.cpp:643
 msgid "Method or property not found."
 msgstr "செயல்முறை அல்லது பண்புகள் காணப்படவில்லை."
 
-#: ../src/univ/themes/win32.cpp:3752
+#: ../src/univ/themes/win32.cpp:3749
 msgid "Mi&nimize"
 msgstr "சிறிதாக்கு"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1763
+#: ../src/propgrid/advprops.cpp:1664
 msgid "Middle Button"
 msgstr ""
 
@@ -4983,36 +5110,41 @@ msgstr "குறைந்தபட்ச உயரம்:"
 msgid "Min width:"
 msgstr "குறைந்தபட்ச அகலம்:"
 
-#: ../src/msw/ole/automtn.cpp:668
+#: ../src/osx/cocoa/menu.mm:281
+#, fuzzy
+msgid "Minimize"
+msgstr "சிறிதாக்கு"
+
+#: ../src/msw/ole/automtn.cpp:659
 msgid "Missing a required parameter."
 msgstr "தேவைப்படும் ஒரு அளவுக் குரியீடு தவற விடப்பட்டுள்ளது."
 
-#: ../src/generic/fontdlgg.cpp:324
+#: ../src/generic/fontdlgg.cpp:320
 msgid "Modern"
 msgstr "நவீனம்"
 
-#: ../src/generic/filectrlg.cpp:427
+#: ../src/generic/filectrlg.cpp:423
 msgid "Modified"
 msgstr "மாற்றப்பட்டது"
 
-#: ../src/common/module.cpp:133
+#: ../src/common/module.cpp:130
 #, c-format
 msgid "Module \"%s\" initialization failed"
 msgstr "\"%s\" நிரற்கூறை துவக்க நிலையாக்குவதில் தோல்வி"
 
-#: ../src/common/paper.cpp:131
+#: ../src/common/paper.cpp:128
 msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
 msgstr "அரசர் அஞ்சல் உறை, 3 7/8 x 7 1/2 in"
 
-#: ../src/msw/fswatcher.cpp:143
+#: ../src/msw/fswatcher.cpp:140
 msgid "Monitoring individual files for changes is not supported currently."
 msgstr "மாற்றங்களை கண்டறிய, கோப்புகளை தனித் தனியாக கவனிக்கும் வசதி தற்போதைக்கு இல்லை."
 
-#: ../src/generic/editlbox.cpp:172
+#: ../src/generic/editlbox.cpp:160
 msgid "Move down"
 msgstr "கீழே நகர்"
 
-#: ../src/generic/editlbox.cpp:171
+#: ../src/generic/editlbox.cpp:155
 msgid "Move up"
 msgstr "மேலே நகர்"
 
@@ -5026,97 +5158,102 @@ msgstr "பொருளை அடுத்த பத்திக்கு நக
 msgid "Moves the object to the previous paragraph."
 msgstr "பொருளை முந்தைய பத்திக்கு நகர்த்துகிறது."
 
-#: ../src/richtext/richtextbuffer.cpp:9966
+#: ../src/richtext/richtextbuffer.cpp:9963
 msgid "Multiple Cell Properties"
 msgstr "பல சிறுகட்டங்களின் பண்புகள்"
 
-#: ../src/generic/filectrlg.cpp:424
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:82
+msgid "Multiply"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:420
 msgid "Name"
 msgstr "பெயர்"
 
-#: ../src/propgrid/advprops.cpp:1596
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Navy"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "Network"
 msgstr "பிணையம்"
 
-#: ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173
 msgid "New"
 msgstr "புதிது"
 
-#: ../src/richtext/richtextstyledlg.cpp:243
+#: ../src/richtext/richtextstyledlg.cpp:239
 msgid "New &Box Style..."
 msgstr "புது பெட்டிப் பாங்கு..."
 
-#: ../src/richtext/richtextstyledlg.cpp:225
+#: ../src/richtext/richtextstyledlg.cpp:221
 msgid "New &Character Style..."
 msgstr "புது வரியுருப் பாங்கு..."
 
-#: ../src/richtext/richtextstyledlg.cpp:237
+#: ../src/richtext/richtextstyledlg.cpp:233
 msgid "New &List Style..."
 msgstr "புது வரிசைப் பட்டியல் பாங்கு..."
 
-#: ../src/richtext/richtextstyledlg.cpp:231
+#: ../src/richtext/richtextstyledlg.cpp:227
 msgid "New &Paragraph Style..."
 msgstr "புதுப் பத்திப் பாங்கு..."
 
-#: ../src/richtext/richtextstyledlg.cpp:606
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:654
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:820
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:893
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:934
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:602
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:650
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:816
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:889
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:930
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "New Style"
 msgstr "புதுப் பாங்கு"
 
-#: ../src/generic/editlbox.cpp:169
+#: ../src/generic/editlbox.cpp:139
 msgid "New item"
 msgstr "புது உருப்படி"
 
-#: ../src/generic/dirdlgg.cpp:297 ../src/generic/dirdlgg.cpp:307
-#: ../src/generic/filectrlg.cpp:618 ../src/generic/filectrlg.cpp:627
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+#: ../src/generic/dirdlgg.cpp:294 ../src/generic/dirdlgg.cpp:304
 msgid "NewName"
 msgstr "புதுப் பெயர்"
 
-#: ../src/common/prntbase.cpp:1567 ../src/html/helpwnd.cpp:665
+#: ../src/common/prntbase.cpp:1592 ../src/html/helpwnd.cpp:663
 msgid "Next page"
 msgstr "அடுத்தப் பக்கம்"
 
-#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:177
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:174
 #: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "இல்லை"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1764
+#: ../src/propgrid/advprops.cpp:1665
 msgid "No Entry"
 msgstr ""
 
-#: ../src/generic/animateg.cpp:150
+#: ../src/generic/animateg.cpp:133
 #, c-format
 msgid "No animation handler for type %ld defined."
 msgstr "%ld வகைக்கான அசைவூட்ட கையாளு நிரல் வரையறுக்கப்படவில்லை."
 
-#: ../src/dfb/bitmap.cpp:642 ../src/dfb/bitmap.cpp:676
+#: ../src/dfb/bitmap.cpp:639 ../src/dfb/bitmap.cpp:673
 #, c-format
 msgid "No bitmap handler for type %d defined."
 msgstr "%d வகைக்கான நுண்பட கையாளு நிரல் வரையறுக்கப்படவில்லை."
 
-#: ../src/common/utilscmn.cpp:1077
+#: ../src/common/utilscmn.cpp:1095
 msgid "No default application configured for HTML files."
 msgstr "HTML கோப்புகளுக்கு இயல்பான பயன்பாடு அமைவடிவமாக்கப்படவில்லை."
 
-#: ../src/generic/helpext.cpp:445
+#: ../src/generic/helpext.cpp:443
 msgid "No entries found."
 msgstr "உள்ளீடுகள் காணப்படவில்லை."
 
-#: ../src/common/fontmap.cpp:421
+#: ../src/common/fontmap.cpp:418
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found,\n"
@@ -5129,7 +5266,7 @@ msgstr ""
 "தாங்கள் இந்தக் குறியீட்டைப் பயன்படுத்த வேண்டுமா (இல்லையென்றால், மற்றொன்றைத் தாங்கள் தேர்வு செய்ய "
 "வேண்டும்)?"
 
-#: ../src/common/fontmap.cpp:426
+#: ../src/common/fontmap.cpp:423
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found.\n"
@@ -5140,206 +5277,206 @@ msgstr ""
 "இந்தக் குறியீட்டில் பயன்படுத்துவதற்கு ஒரு எழுத்துருவைத் தெரிவு செய்ய "
 "வேண்டுமா(இல்லையென்றால், இந்தக் குறியீட்டைக் கொண்ட உரை சரிவர காட்டப்பட மாட்டாது)?"
 
-#: ../src/generic/animateg.cpp:142
+#: ../src/generic/animateg.cpp:125
 msgid "No handler found for animation type."
 msgstr "அசைவூட்ட வகைக்கான கையாளு நிரல் காணப்படவில்லை."
 
-#: ../src/common/image.cpp:2728
+#: ../src/common/image.cpp:2823
 msgid "No handler found for image type."
 msgstr "படிம வகைக்கான கையாளு நிரல் காணப்படவில்லை."
 
-#: ../src/common/image.cpp:2736 ../src/common/image.cpp:2848
-#: ../src/common/image.cpp:2901
+#: ../src/common/image.cpp:2831 ../src/common/image.cpp:2954
+#: ../src/common/image.cpp:3020
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "%d வகைக்கான படிம கையாளு நிரல் வரையறுக்கப்படவில்லை."
 
-#: ../src/common/image.cpp:2871 ../src/common/image.cpp:2915
+#: ../src/common/image.cpp:2986 ../src/common/image.cpp:3034
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "%s வகைக்கான படிம கையாளு நிரல் வரையறுக்கப்படவில்லை."
 
-#: ../src/html/helpwnd.cpp:858
+#: ../src/html/helpwnd.cpp:856
 msgid "No matching page found yet"
 msgstr "பொருத்தமான பக்கம் இதுவரைக் காணப்படவில்லை"
 
-#: ../src/unix/sound.cpp:81
+#: ../src/unix/sound.cpp:78
 msgid "No sound"
 msgstr "ஒலி இல்லை"
 
-#: ../src/common/image.cpp:2277 ../src/common/image.cpp:2318
+#: ../src/common/image.cpp:2371 ../src/common/image.cpp:2412
 msgid "No unused colour in image being masked."
 msgstr "படிமத்தில் பயன்படுத்தப்படாத நிறம் ஏதும் மூடுதிரையில் பயன்படுத்தப்படவில்லை."
 
-#: ../src/common/image.cpp:3374
-msgid "No unused colour in image."
-msgstr "படிமத்தில் பயன்படுத்தப்படாத நிறம் ஏதுமில்லை."
-
-#: ../src/generic/helpext.cpp:302
+#: ../src/generic/helpext.cpp:300
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "\"%s\" கோப்பில் ஏற்கக் கூடிய வரைப்படங்கள் காணப்படவில்லை."
 
-#: ../src/richtext/richtextborderspage.cpp:610
 #: ../src/richtext/richtextsizepage.cpp:248
 #: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:610
 msgid "None"
 msgstr "ஏதுமில்லை"
 
-#: ../src/common/fmapbase.cpp:157
+#: ../src/common/fmapbase.cpp:154
 msgid "Nordic (ISO-8859-10)"
 msgstr "நார்டிக் (ISO-8859-10)"
 
-#: ../src/generic/fontdlgg.cpp:328 ../src/generic/fontdlgg.cpp:331
+#: ../src/generic/fontdlgg.cpp:324 ../src/generic/fontdlgg.cpp:327
 msgid "Normal"
 msgstr "இயல்பு"
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1261
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "இயல்முகப்பு <br>மற்றும் <u>அடிக்கோடிடப்பட்டது</u>. "
 
-#: ../src/html/helpwnd.cpp:1205
+#: ../src/html/helpwnd.cpp:1203
 msgid "Normal font:"
 msgstr "இயல்பெழுத்துரு:"
 
-#: ../src/propgrid/props.cpp:1128
+#: ../src/propgrid/props.cpp:1115
 #, c-format
 msgid "Not %s"
 msgstr "%s இல்லை"
 
-#: ../include/wx/filename.h:573 ../include/wx/filename.h:578
-msgid "Not available"
-msgstr "கிடைப்பில் இல்லை"
+#: ../src/common/secretstore.cpp:168
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/webrequest.cpp:605
+msgid "Not enough free disk space for download."
+msgstr ""
 
 #: ../src/richtext/richtextfontpage.cpp:358
 msgid "Not underlined"
 msgstr "அடிக்கோடிடப்படாதது"
 
-#: ../src/common/paper.cpp:115
+#: ../src/common/paper.cpp:112
 msgid "Note, 8 1/2 x 11 in"
 msgstr "குறிப்பு, 8 1/2 x 11 in"
 
-#: ../src/generic/notifmsgg.cpp:132
+#: ../src/generic/notifmsgg.cpp:129
 msgid "Notice"
 msgstr "கவன அறிக்கை"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "Num *"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "Num +"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "Num ,"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "Num -"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "Num ."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "Num /"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "Num ="
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "Num Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 #, fuzzy
 msgid "Num Delete"
 msgstr "அழி"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 #, fuzzy
 msgid "Num Down"
 msgstr "கீழ்"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "Num End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "Num Enter"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 #, fuzzy
 msgid "Num Home"
 msgstr "முகப்பு"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 #, fuzzy
 msgid "Num Insert"
 msgstr "செருகு"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num Lock"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "Num Page Down"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "Num Page Up"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 #, fuzzy
 msgid "Num Right"
 msgstr "வலது"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "Num Space"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "Num Tab"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "Num Up"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "Num left"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num_lock"
 msgstr ""
 
@@ -5348,13 +5485,13 @@ msgstr ""
 msgid "Numbered outline"
 msgstr "எண்ணிடப்பட்ட வெளிவரைவு"
 
-#: ../include/wx/msgdlg.h:278 ../src/richtext/richtextstyledlg.cpp:297
-#: ../src/common/stockitem.cpp:178 ../src/msw/msgdlg.cpp:454
-#: ../src/msw/msgdlg.cpp:747 ../src/gtk1/fontdlg.cpp:138
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:175
+#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/msgdlg.cpp:741 ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "சரி"
 
-#: ../src/msw/ole/automtn.cpp:692
+#: ../src/msw/ole/automtn.cpp:683
 #, c-format
 msgid "OLE Automation error in %s: %s"
 msgstr "%s-ல் OLE தானியங்குப் பிழை: %s"
@@ -5363,15 +5500,15 @@ msgstr "%s-ல் OLE தானியங்குப் பிழை: %s"
 msgid "Object Properties"
 msgstr "பொருள் பண்புகள்"
 
-#: ../src/msw/ole/automtn.cpp:660
+#: ../src/msw/ole/automtn.cpp:651
 msgid "Object implementation does not support named arguments."
 msgstr "பெயர் குறிக்கப்பட்ட தர்க்கங்களுக்கு பொருள் நடைமுறையில் ஆதரவு இல்லை."
 
-#: ../src/common/xtixml.cpp:264
+#: ../src/common/xtixml.cpp:260
 msgid "Objects must have an id attribute"
 msgstr "பொருட்கள், அடையாள பண்புகளைக் கொண்டிருக்க வேண்டும்"
 
-#: ../src/propgrid/advprops.cpp:1601
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Olive"
 msgstr ""
 
@@ -5379,64 +5516,69 @@ msgstr ""
 msgid "Opaci&ty:"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:354
+#: ../src/generic/colrdlgg.cpp:374
 msgid "Opacity:"
 msgstr ""
 
-#: ../src/common/docview.cpp:1773 ../src/common/docview.cpp:1815
+#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
 msgid "Open File"
 msgstr "கோப்பினைத் திறவுக"
 
-#: ../src/html/helpwnd.cpp:671 ../src/html/helpwnd.cpp:1554
+#: ../src/html/helpwnd.cpp:669 ../src/html/helpwnd.cpp:1552
 msgid "Open HTML document"
 msgstr "HTML ஆவணத்தைத் திறவுக"
 
-#: ../src/generic/dbgrptg.cpp:163
+#: ../src/common/stockitem.cpp:265
+#, fuzzy
+msgid "Open an existing document"
+msgstr "HTML ஆவணத்தைத் திறவுக"
+
+#: ../src/generic/dbgrptg.cpp:160
 #, c-format
 msgid "Open file \"%s\""
 msgstr "\"%s\" கோப்பினைத் திறவுக"
 
-#: ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176
 msgid "Open..."
 msgstr "திறவுக..."
 
-#: ../src/unix/glx11.cpp:506 ../src/msw/glcanvas.cpp:592
+#: ../src/msw/glcanvas.cpp:607 ../src/unix/glx11.cpp:513
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr ""
 
-#: ../src/generic/dirctrlg.cpp:599 ../src/generic/dirdlgg.cpp:323
-#: ../src/generic/filectrlg.cpp:642 ../src/generic/filectrlg.cpp:786
+#: ../src/generic/dirctrlg.cpp:565 ../src/generic/filectrlg.cpp:638
+#: ../src/generic/filectrlg.cpp:782 ../src/generic/dirdlgg.cpp:320
 msgid "Operation not permitted."
 msgstr "நடவடிக்கை அனுமதிக்கப்படவில்லை."
 
-#: ../src/common/cmdline.cpp:900
+#: ../src/common/cmdline.cpp:896
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "'%s' விருப்பத் தேர்வினை இல்லாதாக்க முடியாது"
 
-#: ../src/common/cmdline.cpp:1064
+#: ../src/common/cmdline.cpp:1060
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "'%s' விருப்பத் தேர்விற்கு ஒரு மதிப்பு தேவைப்படுகிறது."
 
-#: ../src/common/cmdline.cpp:1147
+#: ../src/common/cmdline.cpp:1143
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "'%s' விருப்பத் தேர்வு: '%s'-யினை தேதியாக மாற்ற இயலாது."
 
-#: ../src/generic/prntdlgg.cpp:618
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "விருப்பத் தேர்வுகள்"
 
-#: ../src/propgrid/advprops.cpp:1606
+#: ../src/propgrid/advprops.cpp:1512
 msgid "Orange"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:615 ../src/generic/prntdlgg.cpp:869
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:862
 msgid "Orientation"
 msgstr "திசையமைவு"
 
-#: ../src/common/windowid.cpp:242
+#: ../src/common/windowid.cpp:237
 msgid "Out of window IDs.  Recommend shutting down application."
 msgstr "சாளர அடையாளத்திற்கு வெளியே. பயன்பாட்டை நிறுத்த பரிந்துரையுங்கள்."
 
@@ -5449,148 +5591,148 @@ msgstr "வெளிவரைவு"
 msgid "Outset"
 msgstr "துவக்கம்"
 
-#: ../src/msw/ole/automtn.cpp:656
+#: ../src/msw/ole/automtn.cpp:647
 msgid "Overflow while coercing argument values."
 msgstr "தர்க்கத்தின் மதிப்புகளை நெருக்கும்பொழுது பொங்குதல்."
 
-#: ../src/common/imagpcx.cpp:457 ../src/common/imagpcx.cpp:480
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:479
 msgid "PCX: couldn't allocate memory"
 msgstr "PCX: நினைவகத்தை ஒதுக்கீடு செய்ய இயலவில்லை"
 
-#: ../src/common/imagpcx.cpp:456
+#: ../src/common/imagpcx.cpp:455
 msgid "PCX: image format unsupported"
 msgstr "PCX: படிம வடிவூட்டத்திற்கு ஆதரவு இல்லை"
 
-#: ../src/common/imagpcx.cpp:479
+#: ../src/common/imagpcx.cpp:478
 msgid "PCX: invalid image"
 msgstr "PCX: ஏற்கமுடியாத படிமம்"
 
-#: ../src/common/imagpcx.cpp:442
+#: ../src/common/imagpcx.cpp:441
 msgid "PCX: this is not a PCX file."
 msgstr "PCX: இது ஒரு PCX கோப்பு அல்ல."
 
-#: ../src/common/imagpcx.cpp:459 ../src/common/imagpcx.cpp:481
+#: ../src/common/imagpcx.cpp:458 ../src/common/imagpcx.cpp:480
 msgid "PCX: unknown error !!!"
 msgstr "PCX: தெரியாத பிழை"
 
-#: ../src/common/imagpcx.cpp:458
+#: ../src/common/imagpcx.cpp:457
 msgid "PCX: version number too low"
 msgstr "PCX: பதிப்பெண் மிகக் குறைந்துள்ளது"
 
-#: ../src/common/imagpnm.cpp:91
+#: ../src/common/imagpnm.cpp:89
 msgid "PNM: Couldn't allocate memory."
 msgstr "PNM: நினைவகத்தை ஒதுக்கீடு செய்ய இயலவில்லை."
 
-#: ../src/common/imagpnm.cpp:73
+#: ../src/common/imagpnm.cpp:71
 msgid "PNM: File format is not recognized."
 msgstr "PNM: கோப்பின் வடிவூட்டத்தை அடையாளங்காண இயலவில்லை."
 
-#: ../src/common/imagpnm.cpp:112 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
 #: ../src/common/imagpnm.cpp:156
 msgid "PNM: File seems truncated."
 msgstr "PNM: கோப்பு அறுபட்டிருப்பதாகத் தோன்றுகிறது."
 
-#: ../src/common/paper.cpp:187
+#: ../src/common/paper.cpp:184
 msgid "PRC 16K 146 x 215 mm"
 msgstr "PRC 16K 146 x 215 mm"
 
-#: ../src/common/paper.cpp:200
+#: ../src/common/paper.cpp:197
 msgid "PRC 16K Rotated"
 msgstr "PRC 16K சுழற்றப்பட்டது"
 
-#: ../src/common/paper.cpp:188
+#: ../src/common/paper.cpp:185
 msgid "PRC 32K 97 x 151 mm"
 msgstr "PRC 32K 97 x 151 mm"
 
-#: ../src/common/paper.cpp:201
+#: ../src/common/paper.cpp:198
 msgid "PRC 32K Rotated"
 msgstr "PRC 32K சுழற்றப்பட்டது"
 
-#: ../src/common/paper.cpp:189
+#: ../src/common/paper.cpp:186
 msgid "PRC 32K(Big) 97 x 151 mm"
 msgstr "PRC 32K(Big) 97 x 151 mm"
 
-#: ../src/common/paper.cpp:202
+#: ../src/common/paper.cpp:199
 msgid "PRC 32K(Big) Rotated"
 msgstr "PRC 32K(Big) சுழற்றப்பட்டது"
 
-#: ../src/common/paper.cpp:190
+#: ../src/common/paper.cpp:187
 msgid "PRC Envelope #1 102 x 165 mm"
 msgstr "PRC அஞ்சல் உறை #1 102 x 165 mm"
 
-#: ../src/common/paper.cpp:203
+#: ../src/common/paper.cpp:200
 msgid "PRC Envelope #1 Rotated 165 x 102 mm"
 msgstr "PRC அஞ்சல் உறை #1 சுழற்றப்பட்டது 165 x 102 mm"
 
-#: ../src/common/paper.cpp:199
+#: ../src/common/paper.cpp:196
 msgid "PRC Envelope #10 324 x 458 mm"
 msgstr "PRC அஞ்சல் உறை #10 324 x 458 mm"
 
-#: ../src/common/paper.cpp:212
+#: ../src/common/paper.cpp:209
 msgid "PRC Envelope #10 Rotated 458 x 324 mm"
 msgstr "PRC அஞ்சல் உறை #10 சுழற்றப்பட்டது 458 x 324 mm"
 
-#: ../src/common/paper.cpp:191
+#: ../src/common/paper.cpp:188
 msgid "PRC Envelope #2 102 x 176 mm"
 msgstr "PRC அஞ்சல் உறை #2 102 x 176 mm"
 
-#: ../src/common/paper.cpp:204
+#: ../src/common/paper.cpp:201
 msgid "PRC Envelope #2 Rotated 176 x 102 mm"
 msgstr "PRC அஞ்சல் உறை #2 சுழற்றப்பட்டது 176 x 102 mm"
 
-#: ../src/common/paper.cpp:192
+#: ../src/common/paper.cpp:189
 msgid "PRC Envelope #3 125 x 176 mm"
 msgstr "PRC அஞ்சல் உறை #3 125 x 176 mm"
 
-#: ../src/common/paper.cpp:205
+#: ../src/common/paper.cpp:202
 msgid "PRC Envelope #3 Rotated 176 x 125 mm"
 msgstr "PRC அஞ்சல் உறை #3 சுழற்றப்பட்டது 176 x 125 mm"
 
-#: ../src/common/paper.cpp:193
+#: ../src/common/paper.cpp:190
 msgid "PRC Envelope #4 110 x 208 mm"
 msgstr "PRC அஞ்சல் உறை #4 110 x 208 mm"
 
-#: ../src/common/paper.cpp:206
+#: ../src/common/paper.cpp:203
 msgid "PRC Envelope #4 Rotated 208 x 110 mm"
 msgstr "PRC அஞ்சல் உறை #4 சுழற்றப்பட்டது 208 x 110 mm"
 
-#: ../src/common/paper.cpp:194
+#: ../src/common/paper.cpp:191
 msgid "PRC Envelope #5 110 x 220 mm"
 msgstr "PRC அஞ்சல் உரை #5 110 x 220 mm"
 
-#: ../src/common/paper.cpp:207
+#: ../src/common/paper.cpp:204
 msgid "PRC Envelope #5 Rotated 220 x 110 mm"
 msgstr "PRC அஞ்சல் உறை #5 சுழற்றப்பட்டது 220 x 110 mm"
 
-#: ../src/common/paper.cpp:195
+#: ../src/common/paper.cpp:192
 msgid "PRC Envelope #6 120 x 230 mm"
 msgstr "PRC அஞ்சல் உறை #6 120 x 230 mm"
 
-#: ../src/common/paper.cpp:208
+#: ../src/common/paper.cpp:205
 msgid "PRC Envelope #6 Rotated 230 x 120 mm"
 msgstr "PRC அஞ்சல் உறை #6 சுழற்றப்பட்டது 230 x 120 mm"
 
-#: ../src/common/paper.cpp:196
+#: ../src/common/paper.cpp:193
 msgid "PRC Envelope #7 160 x 230 mm"
 msgstr "PRC அஞ்சல் உரை #7 160 x 230 mm"
 
-#: ../src/common/paper.cpp:209
+#: ../src/common/paper.cpp:206
 msgid "PRC Envelope #7 Rotated 230 x 160 mm"
 msgstr "PRC அஞ்சல் உறை #7 சுழற்றப்பட்டது 230 x 160 mm"
 
-#: ../src/common/paper.cpp:197
+#: ../src/common/paper.cpp:194
 msgid "PRC Envelope #8 120 x 309 mm"
 msgstr "PRC அஞ்சல் உறை #8 120 x 309 mm"
 
-#: ../src/common/paper.cpp:210
+#: ../src/common/paper.cpp:207
 msgid "PRC Envelope #8 Rotated 309 x 120 mm"
 msgstr "PRC அஞ்சல் உறை #8 சுழற்றப்பட்டது 309 x 120 mm"
 
-#: ../src/common/paper.cpp:198
+#: ../src/common/paper.cpp:195
 msgid "PRC Envelope #9 229 x 324 mm"
 msgstr "PRC அஞ்சல் உறை #9 229 x 324 mm"
 
-#: ../src/common/paper.cpp:211
+#: ../src/common/paper.cpp:208
 msgid "PRC Envelope #9 Rotated 324 x 229 mm"
 msgstr "PRC அஞ்சல் உறை #9 சுழற்றப்பட்டது 324 x 229 mm"
 
@@ -5598,91 +5740,95 @@ msgstr "PRC அஞ்சல் உறை #9 சுழற்றப்பட்ட
 msgid "Padding"
 msgstr "எழுத்துத் திணிமம்"
 
-#: ../src/common/prntbase.cpp:2074
+#: ../src/common/prntbase.cpp:2096
 #, c-format
 msgid "Page %d"
 msgstr "பக்கம் %d"
 
-#: ../src/common/prntbase.cpp:2072
+#: ../src/common/prntbase.cpp:2094
 #, c-format
 msgid "Page %d of %d"
 msgstr "பக்கம் %d, மொத்தம் %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 #, fuzzy
 msgid "Page Down"
 msgstr "பக்கம் %d"
 
-#: ../src/gtk/print.cpp:826
+#: ../src/gtk/print.cpp:829
 msgid "Page Setup"
 msgstr "பக்க அமைவு"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 #, fuzzy
 msgid "Page Up"
 msgstr "பக்கம் %d"
 
-#: ../src/generic/prntdlgg.cpp:828 ../src/common/prntbase.cpp:484
+#: ../src/common/prntbase.cpp:479 ../src/generic/prntdlgg.cpp:821
 msgid "Page setup"
 msgstr "பக்க அமைவு"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 #, fuzzy
 msgid "PageDown"
 msgstr "கீழ்"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 #, fuzzy
 msgid "PageUp"
 msgstr "பக்கங்கள்"
 
-#: ../src/generic/prntdlgg.cpp:216
+#: ../src/generic/prntdlgg.cpp:209
 msgid "Pages"
 msgstr "பக்கங்கள்"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1765
+#: ../src/propgrid/advprops.cpp:1666
 msgid "Paint Brush"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:602 ../src/generic/prntdlgg.cpp:801
-#: ../src/generic/prntdlgg.cpp:842 ../src/generic/prntdlgg.cpp:855
-#: ../src/generic/prntdlgg.cpp:1052 ../src/generic/prntdlgg.cpp:1057
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:794
+#: ../src/generic/prntdlgg.cpp:835 ../src/generic/prntdlgg.cpp:848
+#: ../src/generic/prntdlgg.cpp:1045 ../src/generic/prntdlgg.cpp:1050
 msgid "Paper size"
 msgstr "பக்க அளவு"
 
-#: ../src/richtext/richtextstyles.cpp:1062
+#: ../src/richtext/richtextstyles.cpp:1059
 msgid "Paragraph styles"
 msgstr "பத்திப் பாங்குகள்"
 
-#: ../src/common/xtistrm.cpp:465
+#: ../src/common/xtistrm.cpp:462
 msgid "Passing a already registered object to SetObject"
 msgstr "ஏற்கனவே பதிவு செய்யப்பட்ட பொருளை SetObject-ற்கு அனுப்பி வைத்தல்"
 
-#: ../src/common/xtistrm.cpp:476
+#: ../src/common/xtistrm.cpp:473
 msgid "Passing an unknown object to GetObject"
 msgstr "தெரியாத பொருளை GetObject-ற்கு அனுப்பி வைத்தல்"
 
-#: ../src/richtext/richtextctrl.cpp:3513 ../src/common/stockitem.cpp:180
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:177 ../src/richtext/richtextctrl.cpp:3514
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "ஒட்டுக"
 
-#: ../src/common/stockitem.cpp:262
+#: ../src/common/stockitem.cpp:260
 msgid "Paste selection"
 msgstr "தெரிவினை ஒட்டுக"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:74
+#: ../src/common/accelcmn.cpp:71
 msgid "Pause"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1766
+#: ../src/propgrid/advprops.cpp:1667
 msgid "Pencil"
 msgstr ""
 
@@ -5691,21 +5837,21 @@ msgstr ""
 msgid "Peri&od"
 msgstr "காலம்"
 
-#: ../src/generic/filectrlg.cpp:430
+#: ../src/generic/filectrlg.cpp:426
 msgid "Permissions"
 msgstr "அனுமதிகள்"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:60
+#: ../src/common/accelcmn.cpp:57
 msgid "PgDn"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:59
+#: ../src/common/accelcmn.cpp:56
 msgid "PgUp"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:12868
+#: ../src/richtext/richtextbuffer.cpp:12863
 msgid "Picture Properties"
 msgstr "படப் பண்புகள்"
 
@@ -5717,45 +5863,45 @@ msgstr "குழாய் உருவாக்கம் தோல்விய�
 msgid "Please choose a valid font."
 msgstr "ஏற்கக்கூடிய எழுத்துருவைத் தேர்ந்தெடுக்கவும்."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
 msgid "Please choose an existing file."
 msgstr "இருக்கும் கோப்பு ஒன்றினைத் தேர்ந்தெடுக்கவும்."
 
-#: ../src/html/helpwnd.cpp:800
+#: ../src/html/helpwnd.cpp:798
 msgid "Please choose the page to display:"
 msgstr "காட்டப்பட வேண்டிய பக்கத்தை தேர்ந்தெடுக்கவும்."
 
-#: ../src/msw/dialup.cpp:764
+#: ../src/msw/dialup.cpp:758
 msgid "Please choose which ISP do you want to connect to"
 msgstr "எந்த ISP-யுடன் இணைப்பை உருவாக்க வேண்டுமென்றுத் தேர்ந்தெடுக்கவும்"
 
-#: ../src/common/headerctrlcmn.cpp:59
+#: ../src/common/headerctrlcmn.cpp:57
 msgid "Please select the columns to show and define their order:"
 msgstr ""
 "காட்டப்பட வேண்டிய செங்குத்து வரிசைகளை தேர்ந்தெடுத்து, அவைகளின் ஒழுங்கை வரையறுக்கவும்:"
 
-#: ../src/common/prntbase.cpp:538
+#: ../src/common/prntbase.cpp:533
 msgid "Please wait while printing..."
 msgstr "அச்சிடப்பட்டுக் கொண்டிருக்கும்பொழுது கருணைக் கூர்ந்து காத்திருக்கவும்..."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1767
+#: ../src/propgrid/advprops.cpp:1668
 #, fuzzy
 msgid "Point Left"
 msgstr "குறியளவு"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1768
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgid "Point Right"
 msgstr "வலது ஒழுங்கு"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:662
+#: ../src/propgrid/advprops.cpp:572
 msgid "Point Size"
 msgstr "குறியளவு"
 
-#: ../src/generic/prntdlgg.cpp:612 ../src/generic/prntdlgg.cpp:867
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:860
 msgid "Portrait"
 msgstr "நெடு தோற்றம்"
 
@@ -5763,254 +5909,264 @@ msgstr "நெடு தோற்றம்"
 msgid "Position"
 msgstr "நிலை"
 
-#: ../src/generic/prntdlgg.cpp:298
+#: ../src/generic/prntdlgg.cpp:291
 msgid "PostScript file"
 msgstr "PostScript கோப்பு"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178 ../src/osx/cocoa/preferences.mm:303
 msgid "Preferences"
 msgstr "முன்னுரிமை விருப்பங்கள்"
 
-#: ../src/osx/menu_osx.cpp:568
+#: ../src/osx/menu_osx.cpp:460
 msgid "Preferences..."
 msgstr "முன்னுரிமை விருப்பங்கள்..."
 
-#: ../src/common/prntbase.cpp:546
+#: ../src/common/prntbase.cpp:541
 msgid "Preparing"
 msgstr "ஆயத்தம் செய்யப்படுகிறது"
 
-#: ../src/generic/fontdlgg.cpp:455 ../src/osx/carbon/fontdlg.cpp:390
-#: ../src/html/helpwnd.cpp:1222
+#: ../src/osx/carbon/fontdlg.cpp:387 ../src/generic/fontdlgg.cpp:452
+#: ../src/html/helpwnd.cpp:1220
 msgid "Preview:"
 msgstr "முன்தோற்றம்:"
 
-#: ../src/common/prntbase.cpp:1553 ../src/html/helpwnd.cpp:664
+#: ../src/common/prntbase.cpp:1578 ../src/html/helpwnd.cpp:662
 msgid "Previous page"
 msgstr "முந்தைய பக்கம்"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/prntdlgg.cpp:143 ../src/generic/prntdlgg.cpp:157
-#: ../src/common/prntbase.cpp:426 ../src/common/prntbase.cpp:1541
-#: ../src/common/accelcmn.cpp:77 ../src/gtk/print.cpp:620
-#: ../src/gtk/print.cpp:638
+#: ../src/common/prntbase.cpp:421 ../src/common/prntbase.cpp:1566
+#: ../src/common/accelcmn.cpp:74 ../src/generic/prntdlgg.cpp:136
+#: ../src/generic/prntdlgg.cpp:150 ../src/gtk/print.cpp:616
+#: ../src/gtk/print.cpp:634
 msgid "Print"
 msgstr "அச்சிடுக"
 
-#: ../include/wx/prntbase.h:399 ../src/common/docview.cpp:1268
+#: ../src/common/docview.cpp:1262
 msgid "Print Preview"
 msgstr "அச்சு முன்தோற்றம்"
 
-#: ../src/common/prntbase.cpp:2015 ../src/common/prntbase.cpp:2057
-#: ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2037 ../src/common/prntbase.cpp:2079
+#: ../src/common/prntbase.cpp:2087
 msgid "Print Preview Failure"
 msgstr "அச்சு முன்தோற்றத் தோல்வி"
 
-#: ../src/generic/prntdlgg.cpp:224
+#: ../src/generic/prntdlgg.cpp:217
 msgid "Print Range"
 msgstr "அச்சு வீச்சு"
 
-#: ../src/generic/prntdlgg.cpp:449
+#: ../src/generic/prntdlgg.cpp:442
 msgid "Print Setup"
 msgstr "அச்சு அமைவு"
 
-#: ../src/generic/prntdlgg.cpp:621
+#: ../src/generic/prntdlgg.cpp:614
 msgid "Print in colour"
 msgstr "நிறங்களைக் கொண்டு அச்சிடு"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/osx/webview_webkit.mm:260
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "செங்குத்து வரிசையின் விளக்கத்தை துவக்க நிலையாக்க இயலவில்லை."
+
+#: ../src/common/stockitem.cpp:179
 msgid "Print previe&w..."
 msgstr "அச்சு முன்தோற்றம்..."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1256
 msgid "Print preview creation failed."
 msgstr "அச்சு முன்தோற்ற உருவாக்கம் தோல்வியடைந்தது."
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/common/stockitem.cpp:179
 msgid "Print preview..."
 msgstr "அச்சு முன்தோற்றம்..."
 
-#: ../src/generic/prntdlgg.cpp:630
+#: ../src/generic/prntdlgg.cpp:623
 msgid "Print spooling"
 msgstr "அச்சு சுழலி"
 
-#: ../src/html/helpwnd.cpp:675
+#: ../src/html/helpwnd.cpp:673
 msgid "Print this page"
 msgstr "இப்பக்கத்தை அச்சிடவும்"
 
-#: ../src/generic/prntdlgg.cpp:185
+#: ../src/generic/prntdlgg.cpp:178
 msgid "Print to File"
 msgstr "கோப்பிற்கு அச்சிடவும்"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "Print..."
 msgstr "அச்சிடுக..."
 
-#: ../src/generic/prntdlgg.cpp:493
+#: ../src/generic/prntdlgg.cpp:486
 msgid "Printer"
 msgstr "அச்சுப் பொறி"
 
-#: ../src/generic/prntdlgg.cpp:633
+#: ../src/generic/prntdlgg.cpp:626
 msgid "Printer command:"
 msgstr "அச்சுக் கட்டளை:"
 
-#: ../src/generic/prntdlgg.cpp:180
+#: ../src/generic/prntdlgg.cpp:173
 msgid "Printer options"
 msgstr "அச்சுப் பொறி விருப்பத் தேர்வுகள்"
 
-#: ../src/generic/prntdlgg.cpp:645
+#: ../src/generic/prntdlgg.cpp:638
 msgid "Printer options:"
 msgstr "அச்சுப் பொறி விருப்பத் தேர்வுகள்"
 
-#: ../src/generic/prntdlgg.cpp:916
+#: ../src/generic/prntdlgg.cpp:909
 msgid "Printer..."
 msgstr "அச்சுப் பொறி..."
 
-#: ../src/generic/prntdlgg.cpp:196
+#: ../src/generic/prntdlgg.cpp:189
 msgid "Printer:"
 msgstr "அச்சுப் பொறி:"
 
-#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:535
-#: ../src/html/htmprint.cpp:277
+#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:530
+#: ../src/html/htmprint.cpp:289
 msgid "Printing"
 msgstr "அச்சிடப்படுகிறது"
 
-#: ../src/common/prntbase.cpp:612
+#: ../src/common/prntbase.cpp:607
 msgid "Printing "
 msgstr "அச்சிடப்படுகிறது"
 
-#: ../src/common/prntbase.cpp:347
+#: ../src/common/prntbase.cpp:342
 msgid "Printing Error"
 msgstr "அச்சீட்டில் பிழை"
 
-#: ../src/common/prntbase.cpp:565
+#: ../src/osx/webview_webkit.mm:251
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "Gzip இந்த பதிப்பு Zlib-னால் ஆதரிக்கப்படுவதில்லை"
+
+#: ../src/common/prntbase.cpp:560
 #, fuzzy, c-format
 msgid "Printing page %d"
 msgstr "%d பக்கம் அச்சிடப்படுகிறது..."
 
-#: ../src/common/prntbase.cpp:570
+#: ../src/common/prntbase.cpp:565
 #, c-format
 msgid "Printing page %d of %d"
 msgstr "%d பக்கம் அச்சிடப்படுகிறது; மொத்த பக்கங்கள் %d"
 
-#: ../src/generic/printps.cpp:201
+#: ../src/generic/printps.cpp:182
 #, c-format
 msgid "Printing page %d..."
 msgstr "%d பக்கம் அச்சிடப்படுகிறது..."
 
-#: ../src/generic/printps.cpp:161
+#: ../src/generic/printps.cpp:142
 msgid "Printing..."
 msgstr "அச்சிடப்படுகிறது..."
 
-#: ../include/wx/richtext/richtextprint.h:109 ../include/wx/prntbase.h:267
-#: ../src/common/docview.cpp:2132
+#: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
+#: ../src/common/docview.cpp:2137
 msgid "Printout"
 msgstr "காகித அச்சு"
 
-#: ../src/common/debugrpt.cpp:560
+#: ../src/common/debugrpt.cpp:561
 #, c-format
 msgid ""
 "Processing debug report has failed, leaving the files in \"%s\" directory."
 msgstr ""
 "வழுநீக்க அறிக்கையின் செயல்முறை தோல்வியடைந்தது, கோப்புகள் \"%s\" அடைவில் விடப்படுகிறது."
 
-#: ../src/common/prntbase.cpp:545
+#: ../src/common/prntbase.cpp:540
 msgid "Progress:"
 msgstr "முன்னேற்றம்:"
 
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181
 msgid "Properties"
 msgstr "பண்புகள்"
 
-#: ../src/propgrid/manager.cpp:237
+#: ../src/propgrid/manager.cpp:223
 msgid "Property"
 msgstr "பண்பு"
 
 #. TRANSLATORS: Caption of message box displaying any property error
-#: ../src/propgrid/propgrid.cpp:3185 ../src/propgrid/propgrid.cpp:3318
+#: ../src/propgrid/propgrid.cpp:3162 ../src/propgrid/propgrid.cpp:3299
 msgid "Property Error"
 msgstr "பண்புப் பிழை"
 
-#: ../src/propgrid/advprops.cpp:1597
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Purple"
 msgstr ""
 
-#: ../src/common/paper.cpp:112
+#: ../src/common/paper.cpp:109
 msgid "Quarto, 215 x 275 mm"
 msgstr "Quarto, 215 x 275 mm"
 
-#: ../src/generic/logg.cpp:1016
+#: ../src/generic/logg.cpp:1013
 msgid "Question"
 msgstr "கேள்வி"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1769
+#: ../src/propgrid/advprops.cpp:1670
 #, fuzzy
 msgid "Question Arrow"
 msgstr "கேள்வி"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "Quit"
 msgstr "வெளியேறுக"
 
-#: ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:477
 #, c-format
 msgid "Quit %s"
 msgstr "%s-ஐ விட்டு வெளியேறுக"
 
-#: ../src/common/stockitem.cpp:263
+#: ../src/common/stockitem.cpp:261
 msgid "Quit this program"
 msgstr "இந்நிரலை விட்டு வெளியேறுக"
 
-#: ../src/common/accelcmn.cpp:338
+#: ../src/common/accelcmn.cpp:352
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/ffile.cpp:109 ../src/common/ffile.cpp:133
+#: ../src/common/ffile.cpp:107 ../src/common/ffile.cpp:132
 #, c-format
 msgid "Read error on file '%s'"
 msgstr "'%s' கோப்பிலுள்ள பிழையைப் படிக்கவும்"
 
-#: ../src/common/secretstore.cpp:199
+#: ../src/common/secretstore.cpp:211
 #, fuzzy, c-format
-msgid "Reading password for \"%s/%s\" failed: %s."
+msgid "Reading password for \"%s\" failed: %s."
 msgstr "'%s', '%s'-ற்குள் பிரித்தெடுப்பது தோல்வியடைந்தது."
 
-#: ../src/common/prntbase.cpp:272
+#: ../src/common/prntbase.cpp:267
 msgid "Ready"
 msgstr "ஆயத்தமாய் உள்ளது"
 
-#: ../src/propgrid/advprops.cpp:1605
+#: ../src/propgrid/advprops.cpp:1511
 #, fuzzy
 msgid "Red"
 msgstr "மீள்செயல்"
 
-#: ../src/generic/colrdlgg.cpp:339
+#: ../src/generic/colrdlgg.cpp:359
 msgid "Red:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:185 ../src/stc/stc_i18n.cpp:16
+#: ../src/common/stockitem.cpp:182 ../src/stc/stc_i18n.cpp:16
 msgid "Redo"
 msgstr "மீள்செயல்"
 
-#: ../src/common/stockitem.cpp:264
+#: ../src/common/stockitem.cpp:262
 msgid "Redo last action"
 msgstr "கடைசி செயலை மீள்செயலாக்குக"
 
-#: ../src/common/stockitem.cpp:186
+#: ../src/common/stockitem.cpp:183
 msgid "Refresh"
 msgstr "புத்தாக்குக"
 
-#: ../src/msw/registry.cpp:626
+#: ../src/msw/registry.cpp:615
 #, c-format
 msgid "Registry key '%s' already exists."
 msgstr "'%s' பதிவு விசை ஏற்கனவே உள்ளது."
 
-#: ../src/msw/registry.cpp:595
+#: ../src/msw/registry.cpp:584
 #, c-format
 msgid "Registry key '%s' does not exist, cannot rename it."
 msgstr "'%s' பதிவக விசை இல்லை, அதை மறுபெயரிட இயலாது."
 
-#: ../src/msw/registry.cpp:727
+#: ../src/msw/registry.cpp:716
 #, c-format
 msgid ""
 "Registry key '%s' is needed for normal system operation,\n"
@@ -6021,22 +6177,22 @@ msgstr ""
 "இதை அழித்துவிட்டால், தங்களின் கணினி பயன்படுத்தப்பட இயலாத நிலைக்கு தள்ளப்படும்:\n"
 "நடவடிக்கை இடைமறிக்கப்படுகிறது."
 
-#: ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:942
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:917
+#: ../src/msw/registry.cpp:905
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1003
+#: ../src/msw/registry.cpp:991
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:521
+#: ../src/msw/registry.cpp:510
 #, c-format
 msgid "Registry value '%s' already exists."
 msgstr "'%s' பதிவக மதிப்பு ஏற்கனவே உள்ளது."
@@ -6050,70 +6206,76 @@ msgstr "வழக்கமானது"
 msgid "Relative"
 msgstr "ஒப்பு நோக்கத்தக்க"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:456
 msgid "Relevant entries:"
 msgstr "பொருத்தமான உள்ளீடுகள்:"
 
-#: ../include/wx/generic/progdlgg.h:86
+#: ../include/wx/generic/progdlgg.h:87
 msgid "Remaining time:"
 msgstr "எஞ்சியுள்ள நேரம்"
 
-#: ../src/common/stockitem.cpp:187
+#: ../src/common/stockitem.cpp:184
 msgid "Remove"
 msgstr "நீக்குக"
 
-#: ../src/richtext/richtextctrl.cpp:1562
+#: ../src/richtext/richtextctrl.cpp:1563
 msgid "Remove Bullet"
 msgstr "தோட்டாவை நீக்குக"
 
-#: ../src/html/helpwnd.cpp:433
+#: ../src/html/helpwnd.cpp:431
 msgid "Remove current page from bookmarks"
 msgstr "ஏட்டுக் குறிகளிலிருந்து தற்போதைய பக்கத்தை நீக்குக"
 
-#: ../src/common/rendcmn.cpp:194
+#: ../src/common/rendcmn.cpp:191
 #, c-format
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr "\"%s\" வழங்கி ஒவ்வாத %d.%d பதிப்பைக் கொண்டுள்ளது, அதை ஏற்ற இயலவில்லை."
 
-#: ../src/richtext/richtextbuffer.cpp:4527
+#: ../src/richtext/richtextbuffer.cpp:4524
 msgid "Renumber List"
 msgstr "பட்டியலை மறுஎண்ணிடுக"
 
-#: ../src/common/stockitem.cpp:188
-msgid "Rep&lace"
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Rep&lace..."
 msgstr "மாற்றமர்வு"
 
-#: ../src/richtext/richtextctrl.cpp:3673 ../src/common/stockitem.cpp:188
+#: ../src/richtext/richtextctrl.cpp:3674
 msgid "Replace"
 msgstr "மாற்றமர்வு"
 
-#: ../src/generic/fdrepdlg.cpp:182
+#: ../src/generic/fdrepdlg.cpp:179
 msgid "Replace &all"
 msgstr "எல்லாவற்றையும் மாற்றியமைக்கவும்"
 
-#: ../src/common/stockitem.cpp:261
-msgid "Replace selection"
-msgstr "தெரிவினை மாற்றியமைக்கவும்"
-
-#: ../src/generic/fdrepdlg.cpp:124
+#: ../src/generic/fdrepdlg.cpp:121
 msgid "Replace with:"
 msgstr "இதைக் கொண்டு மாற்றியமைக்கவும்:"
 
-#: ../src/common/valtext.cpp:163
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Replace..."
+msgstr "மாற்றமர்வு"
+
+#: ../src/common/valtext.cpp:184
 msgid "Required information entry is empty."
 msgstr "தேவைப்படும் உள்ளீட்டுத் தகவல் வெறுமையாக உள்ளது."
 
-#: ../src/common/translation.cpp:1975
+#: ../src/common/translation.cpp:2025
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "'%s' வளம் ஏற்கக்கூடிய தகவல் பட்டியல் அல்ல."
 
+#: ../src/gtk/webview_webkit.cpp:985
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:56
+#: ../src/common/accelcmn.cpp:53
 msgid "Return"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:189
+#: ../src/common/stockitem.cpp:186
 msgid "Revert to Saved"
 msgstr "சேமிக்கப்பட்டதற்கு திரும்பிச் செல்"
 
@@ -6125,42 +6287,42 @@ msgstr "முகடு"
 msgid "Rig&ht-to-left"
 msgstr "வலமிருந்து இடம்"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6149
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:59 ../src/generic/datavgen.cpp:6954
+#: ../src/richtext/richtextsizepage.cpp:250
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextbulletspage.cpp:188
-#: ../src/richtext/richtextsizepage.cpp:250 ../src/common/accelcmn.cpp:62
 msgid "Right"
 msgstr "வலது"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1754
+#: ../src/propgrid/advprops.cpp:1655
 #, fuzzy
 msgid "Right Arrow"
 msgstr "வலது"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1770
+#: ../src/propgrid/advprops.cpp:1671
 msgid "Right Button"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:892
+#: ../src/generic/prntdlgg.cpp:885
 msgid "Right margin (mm):"
 msgstr "வலக் கரை  (mm): "
 
-#: ../src/richtext/richtextindentspage.cpp:148
-#: ../src/richtext/richtextindentspage.cpp:150
 #: ../src/richtext/richtextliststylepage.cpp:337
 #: ../src/richtext/richtextliststylepage.cpp:339
+#: ../src/richtext/richtextindentspage.cpp:148
+#: ../src/richtext/richtextindentspage.cpp:150
 msgid "Right-align text."
 msgstr "உரையை வலது ஒழுங்காக்கு."
 
-#: ../src/generic/fontdlgg.cpp:322
+#: ../src/generic/fontdlgg.cpp:318
 msgid "Roman"
 msgstr "ரோமானியம்"
 
-#: ../src/generic/datavgen.cpp:5916
+#: ../src/generic/datavgen.cpp:6721
 #, c-format
 msgid "Row %i"
 msgstr ""
@@ -6170,30 +6332,31 @@ msgstr ""
 msgid "S&tandard bullet name:"
 msgstr "நிலைத் தோட்டாவின் பெயர்:"
 
-#: ../src/common/accelcmn.cpp:268 ../src/common/accelcmn.cpp:350
+#: ../src/common/accelcmn.cpp:282 ../src/common/accelcmn.cpp:367
 msgid "SPECIAL"
 msgstr "சிறப்புடையது"
 
-#: ../src/common/stockitem.cpp:190 ../src/common/sizer.cpp:2797
+#: ../src/common/stockitem.cpp:187 ../src/common/sizer.cpp:2914
 msgid "Save"
 msgstr "சேமிக்கவும்"
 
-#: ../src/common/fldlgcmn.cpp:342
+#: ../src/common/fldlgcmn.cpp:339
 #, c-format
 msgid "Save %s file"
 msgstr "%s கோப்பினை சேமிக்கவும்"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/common/stockitem.cpp:188 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "இவ்வாறு சேமிக்கவும்..."
 
-#: ../src/common/docview.cpp:366
+#: ../src/common/docview.cpp:359
 msgid "Save As"
 msgstr "இவ்வாறு சேமிக்கவும்"
 
-#: ../src/common/stockitem.cpp:191
-msgid "Save as"
-msgstr "இவ்வாறு சேமிக்கவும்"
+#: ../src/common/stockitem.cpp:188
+#, fuzzy
+msgid "Save As..."
+msgstr "இவ்வாறு சேமிக்கவும்..."
 
 #: ../src/common/stockitem.cpp:267
 msgid "Save current document"
@@ -6203,96 +6366,96 @@ msgstr "தற்போதைய ஆவணத்தை சேமிக்கவ�
 msgid "Save current document with a different filename"
 msgstr "தற்போதைய ஆவணத்தை வேறு பெயர் கொண்டு சேமிக்கவும்"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/generic/logg.cpp:509
 msgid "Save log contents to file"
 msgstr "செயற்குறிப்பேட்டு உள்ளடக்கங்களை கோப்பில் சேமிக்கவும்"
 
-#: ../src/common/secretstore.cpp:179
+#: ../src/common/secretstore.cpp:189
 #, fuzzy, c-format
-msgid "Saving password for \"%s/%s\" failed: %s."
+msgid "Saving password for \"%s\" failed: %s."
 msgstr "'%s', '%s'-ற்குள் பிரித்தெடுப்பது தோல்வியடைந்தது."
 
-#: ../src/generic/fontdlgg.cpp:325
+#: ../src/generic/fontdlgg.cpp:321
 msgid "Script"
 msgstr "நிரல்தொடர்"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll Lock"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll_lock"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:890
+#: ../src/propgrid/advprops.cpp:791
 msgid "Scrollbar"
 msgstr ""
 
-#: ../src/generic/srchctlg.cpp:56 ../src/html/helpwnd.cpp:535
-#: ../src/html/helpwnd.cpp:550
+#: ../src/generic/srchctlg.cpp:55 ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:548 ../src/gtk/srchctrl.cpp:182
 msgid "Search"
 msgstr "தேடுக"
 
-#: ../src/html/helpwnd.cpp:537
+#: ../src/html/helpwnd.cpp:535
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
 msgstr ""
 "தாங்கள் மேலே தட்டச்சிய உரையின் எல்லா தோன்றுதல்களையும் உதவி ஏட்டின் உள்ளடக்கங்களில் தேடவும்"
 
-#: ../src/generic/fdrepdlg.cpp:160
+#: ../src/generic/fdrepdlg.cpp:157
 msgid "Search direction"
 msgstr "தேடு திசை"
 
-#: ../src/generic/fdrepdlg.cpp:112
+#: ../src/generic/fdrepdlg.cpp:109
 msgid "Search for:"
 msgstr "இதைத் தேடுக:"
 
-#: ../src/html/helpwnd.cpp:1052
+#: ../src/html/helpwnd.cpp:1050
 msgid "Search in all books"
 msgstr "எல்லா ஏடுகளிளும் தேடுக"
 
-#: ../src/html/helpwnd.cpp:857
+#: ../src/html/helpwnd.cpp:855
 msgid "Searching..."
 msgstr "தேடப்படுகிறது..."
 
-#: ../src/generic/dirctrlg.cpp:446
+#: ../src/generic/dirctrlg.cpp:412
 msgid "Sections"
 msgstr "உட்பிரிவுகள்"
 
-#: ../src/common/ffile.cpp:238
+#: ../src/common/ffile.cpp:237
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "'%s' கோப்பிலிருக்கும் பிழையை நாடுக"
 
-#: ../src/common/ffile.cpp:228
+#: ../src/common/ffile.cpp:227
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr "'%s' கோப்பில் பிழையை நாடுக (பெரிய கோப்புகளுக்கு ஆதரவு இல்லை)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:76
+#: ../src/common/accelcmn.cpp:73
 #, fuzzy
 msgid "Select"
 msgstr "தெரிவு"
 
-#: ../src/richtext/richtextctrl.cpp:337 ../src/osx/textctrl_osx.cpp:581
-#: ../src/common/stockitem.cpp:192 ../src/msw/textctrl.cpp:2512
+#: ../src/osx/textctrl_osx.cpp:599 ../src/common/stockitem.cpp:189
+#: ../src/msw/textctrl.cpp:2777 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "எல்லாவற்றையும் தெரிவு செய்க"
 
-#: ../src/common/stockitem.cpp:192 ../src/stc/stc_i18n.cpp:21
+#: ../src/common/stockitem.cpp:189 ../src/stc/stc_i18n.cpp:21
 msgid "Select All"
 msgstr "எல்லாவற்றையும் தெரிவு செய்க"
 
-#: ../src/common/docview.cpp:1895
+#: ../src/common/docview.cpp:1900
 msgid "Select a document template"
 msgstr "ஒரு ஆவண வார்ப்புருவைத் தேர்ந்தெடுக்கவும்"
 
-#: ../src/common/docview.cpp:1969
+#: ../src/common/docview.cpp:1974
 msgid "Select a document view"
 msgstr "ஒரு ஆவணத் தோற்றத்தை தெரிவு செய்க"
 
@@ -6321,20 +6484,20 @@ msgid "Selects the list level to edit."
 msgstr "தொகுப்பதற்காக பட்டியலின் நிலையை தெரிவு செய்கிறது."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:82
+#: ../src/common/accelcmn.cpp:79
 msgid "Separator"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1083
+#: ../src/common/cmdline.cpp:1079
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "'%s' விருப்பத் தேர்விற்குப் பிறகு பிரிப்பான் எதிர்பார்க்கப்படுகிறது"
 
-#: ../src/osx/menu_osx.cpp:572
+#: ../src/osx/menu_osx.cpp:464
 msgid "Services"
 msgstr "பணிகள்"
 
-#: ../src/richtext/richtextbuffer.cpp:11217
+#: ../src/richtext/richtextbuffer.cpp:11216
 msgid "Set Cell Style"
 msgstr "சிறுகட்டத்தின் பாங்கினை அமை"
 
@@ -6342,11 +6505,11 @@ msgstr "சிறுகட்டத்தின் பாங்கினை அ�
 msgid "SetProperty called w/o valid setter"
 msgstr "w/o ஏற்க்கக்கூடிய அமைப்பியை GetProperty"
 
-#: ../src/generic/prntdlgg.cpp:188
+#: ../src/generic/prntdlgg.cpp:181
 msgid "Setup..."
 msgstr "அமைவு..."
 
-#: ../src/msw/dialup.cpp:544
+#: ../src/msw/dialup.cpp:538
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr "பல சுழல் இணைப்புகள் செயலில் உள்ளன, குறிப்பின்றி ஒன்று தேர்ந்தெடுக்கப்படுகிறது."
 
@@ -6363,40 +6526,40 @@ msgstr ""
 msgid "Shadow c&olour:"
 msgstr "நிறத்தைத் தேர்ந்தெடுக்கவும்"
 
-#: ../src/common/accelcmn.cpp:335
+#: ../src/common/accelcmn.cpp:349
 msgid "Shift+"
 msgstr "மாற்றழுத்தி"
 
-#: ../src/generic/dirdlgg.cpp:147
+#: ../src/generic/dirdlgg.cpp:144
 msgid "Show &hidden directories"
 msgstr "மறைந்துள்ள அடைவுகளைக் காட்டுக"
 
-#: ../src/generic/filectrlg.cpp:983
+#: ../src/generic/filectrlg.cpp:979
 msgid "Show &hidden files"
 msgstr "மறைந்துள்ள கோப்புகளைக் காட்டுக"
 
-#: ../src/osx/menu_osx.cpp:580
+#: ../src/osx/menu_osx.cpp:472
 msgid "Show All"
 msgstr "எல்லாம் காட்டுக"
 
-#: ../src/common/stockitem.cpp:257
+#: ../src/common/stockitem.cpp:254
 msgid "Show about dialog"
 msgstr "'குறித்து' உரையாடலைக் காட்டுக"
 
-#: ../src/html/helpwnd.cpp:492
+#: ../src/html/helpwnd.cpp:490
 msgid "Show all"
 msgstr "எல்லாம் காட்டுக"
 
-#: ../src/html/helpwnd.cpp:503
+#: ../src/html/helpwnd.cpp:501
 msgid "Show all items in index"
 msgstr "சுட்டெண்ணில் உள்ள எல்லா உருப்படிகளையும் காட்டுக"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:656
 msgid "Show/hide navigation panel"
 msgstr "வழிநடத்து பொருத்துப் பலகையை காட்டுக/மறை"
 
-#: ../src/richtext/richtextsymboldlg.cpp:421
-#: ../src/richtext/richtextsymboldlg.cpp:423
+#: ../src/richtext/richtextsymboldlg.cpp:418
+#: ../src/richtext/richtextsymboldlg.cpp:420
 msgid "Shows a Unicode subset."
 msgstr "ஒருங்குறி உட்கணத்தை காட்டுகிறது."
 
@@ -6412,7 +6575,7 @@ msgstr "தோட்டா அமைப்புகளின் முன்த�
 msgid "Shows a preview of the font settings."
 msgstr "எழுத்துரு அமைப்புகளின் முன்தோற்றத்தைக் காட்டுகிறது."
 
-#: ../src/osx/carbon/fontdlg.cpp:394 ../src/osx/carbon/fontdlg.cpp:396
+#: ../src/osx/carbon/fontdlg.cpp:391 ../src/osx/carbon/fontdlg.cpp:393
 msgid "Shows a preview of the font."
 msgstr "எழுத்துருவின் முன்தோற்றத்தைக் காட்டுகிறது."
 
@@ -6421,62 +6584,62 @@ msgstr "எழுத்துருவின் முன்தோற்றத�
 msgid "Shows a preview of the paragraph settings."
 msgstr "பத்தி அமைப்புகளின் முன்தோற்றத்தைக் காட்டுகிறது."
 
-#: ../src/generic/fontdlgg.cpp:460 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:456 ../src/generic/fontdlgg.cpp:458
 msgid "Shows the font preview."
 msgstr "எழுத்துருவின் முன்தோற்றத்தைக் காட்டுகிறது."
 
-#: ../src/propgrid/advprops.cpp:1607
+#: ../src/propgrid/advprops.cpp:1513
 msgid "Silver"
 msgstr ""
 
-#: ../src/univ/themes/mono.cpp:516
+#: ../src/univ/themes/mono.cpp:513
 msgid "Simple monochrome theme"
 msgstr "எளிய ஒற்றை நிறக் கருத்தோற்றம்"
 
-#: ../src/richtext/richtextindentspage.cpp:275
 #: ../src/richtext/richtextliststylepage.cpp:449
+#: ../src/richtext/richtextindentspage.cpp:275
 msgid "Single"
 msgstr "ஒற்றை"
 
-#: ../src/generic/filectrlg.cpp:425 ../src/richtext/richtextformatdlg.cpp:369
-#: ../src/richtext/richtextsizepage.cpp:299
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextsizepage.cpp:299
+#: ../src/richtext/richtextformatdlg.cpp:362
 msgid "Size"
 msgstr "அளவு"
 
-#: ../src/osx/carbon/fontdlg.cpp:339
+#: ../src/osx/carbon/fontdlg.cpp:336
 msgid "Size:"
 msgstr "அளவு:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1775
+#: ../src/propgrid/advprops.cpp:1676
 msgid "Sizing"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1772
+#: ../src/propgrid/advprops.cpp:1673
 msgid "Sizing N-S"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1771
+#: ../src/propgrid/advprops.cpp:1672
 msgid "Sizing NE-SW"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1773
+#: ../src/propgrid/advprops.cpp:1674
 msgid "Sizing NW-SE"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1774
+#: ../src/propgrid/advprops.cpp:1675
 msgid "Sizing W-E"
 msgstr ""
 
-#: ../src/msw/progdlg.cpp:801
+#: ../src/msw/progdlg.cpp:1088
 msgid "Skip"
 msgstr "தவிர்"
 
-#: ../src/generic/fontdlgg.cpp:330
+#: ../src/generic/fontdlgg.cpp:326
 msgid "Slant"
 msgstr "சாய்மம்"
 
@@ -6485,7 +6648,7 @@ msgid "Small C&apitals"
 msgstr "சிறு முகப்பெழுத்துகள்"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:79
+#: ../src/common/accelcmn.cpp:76
 msgid "Snapshot"
 msgstr ""
 
@@ -6493,37 +6656,37 @@ msgstr ""
 msgid "Solid"
 msgstr "திடம்"
 
-#: ../src/common/docview.cpp:1791
+#: ../src/common/docview.cpp:1785
 msgid "Sorry, could not open this file."
 msgstr "மன்னிக்கவும், இந்தக் கோப்பினைத் திறக்க இயலவில்லை."
 
-#: ../src/common/prntbase.cpp:2057 ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2079 ../src/common/prntbase.cpp:2087
 msgid "Sorry, not enough memory to create a preview."
 msgstr "மன்னிக்கவும், முன்தோற்றத்தை உருவாக்க போதுமான நினைவகம் இல்லை."
 
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "Sorry, that name is taken. Please choose another."
 msgstr "மன்னிக்கவும், அந்தப் பெயர் எடுக்கப்பட்டுவிட்டது. மற்றொன்றினைத்  தேர்ந்தெடுக்கவும்."
 
-#: ../src/common/docview.cpp:1814
+#: ../src/common/docview.cpp:1819
 msgid "Sorry, the format for this file is unknown."
 msgstr "மன்னிக்கவும், இந்தக் கோப்பிற்கான வடிவூட்டம் தெரியாததாக உள்ளது."
 
-#: ../src/unix/sound.cpp:492
+#: ../src/unix/sound.cpp:481
 msgid "Sound data are in unsupported format."
 msgstr "ஒலித் தரவுகள் ஆதரிக்கப்படாத வடிவூட்டத்தில் உள்ளன."
 
-#: ../src/unix/sound.cpp:477
+#: ../src/unix/sound.cpp:466
 #, c-format
 msgid "Sound file '%s' is in unsupported format."
 msgstr "'%s' ஒலிக் கோப்பு ஆதரவளிக்கப்படாத வடிவூட்டத்தில் உள்ளது."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:67
+#: ../src/common/accelcmn.cpp:64
 #, fuzzy
 msgid "Space"
 msgstr "இடைவெளியிடல்"
@@ -6532,12 +6695,12 @@ msgstr "இடைவெளியிடல்"
 msgid "Spacing"
 msgstr "இடைவெளியிடல்"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "Spell Check"
 msgstr "சொல் திருத்தி"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1776
+#: ../src/propgrid/advprops.cpp:1677
 msgid "Spraycan"
 msgstr ""
 
@@ -6546,7 +6709,7 @@ msgstr ""
 msgid "Standard"
 msgstr "செந்தரம்"
 
-#: ../src/common/paper.cpp:104
+#: ../src/common/paper.cpp:101
 msgid "Statement, 5 1/2 x 8 1/2 in"
 msgstr "கூற்று, 5 1/2 x 8 1/2 in"
 
@@ -6555,33 +6718,29 @@ msgstr "கூற்று, 5 1/2 x 8 1/2 in"
 msgid "Static"
 msgstr "அசைவற்றது"
 
-#: ../src/generic/prntdlgg.cpp:204
+#: ../src/generic/prntdlgg.cpp:197
 msgid "Status:"
 msgstr "நிலைமை:"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "Stop"
 msgstr "நிறுத்துக"
 
-#: ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196
 msgid "Strikethrough"
 msgstr "ஊடாகக் கோடிடப்பட்டது"
 
-#: ../src/common/colourcmn.cpp:45
+#: ../src/common/colourcmn.cpp:42
 #, c-format
 msgid "String To Colour : Incorrect colour specification : %s"
 msgstr "சரத்திலிருந்து நிறம்: தவறான நிறக் குறிப்பீடு: %s"
 
 #. TRANSLATORS: Label of font style
-#: ../src/richtext/richtextformatdlg.cpp:339 ../src/propgrid/advprops.cpp:680
+#: ../src/propgrid/advprops.cpp:590 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "பாங்கு"
 
-#: ../include/wx/richtext/richtextstyledlg.h:46
-msgid "Style Organiser"
-msgstr "பாங்கு அமைப்பாளர்"
-
-#: ../src/osx/carbon/fontdlg.cpp:348
+#: ../src/osx/carbon/fontdlg.cpp:345
 msgid "Style:"
 msgstr "பாங்கு:"
 
@@ -6590,7 +6749,7 @@ msgid "Subscrip&t"
 msgstr "கீழெழுத்து"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:83
+#: ../src/common/accelcmn.cpp:80
 msgid "Subtract"
 msgstr ""
 
@@ -6598,11 +6757,11 @@ msgstr ""
 msgid "Supe&rscript"
 msgstr "மேலெழுத்து"
 
-#: ../src/common/paper.cpp:150
+#: ../src/common/paper.cpp:147
 msgid "SuperA/SuperA/A4 227 x 356 mm"
 msgstr "SuperA/SuperA/A4 227 x 356 mm"
 
-#: ../src/common/paper.cpp:151
+#: ../src/common/paper.cpp:148
 msgid "SuperB/SuperB/A3 305 x 487 mm"
 msgstr "SuperB/SuperB/A3 305 x 487 mm"
 
@@ -6610,7 +6769,7 @@ msgstr "SuperB/SuperB/A3 305 x 487 mm"
 msgid "Suppress hyphe&nation"
 msgstr "இணைக்கோட்டை மறை"
 
-#: ../src/generic/fontdlgg.cpp:326
+#: ../src/generic/fontdlgg.cpp:322
 msgid "Swiss"
 msgstr "சுவிஸ்"
 
@@ -6628,74 +6787,74 @@ msgstr "குறியெழுத்து எழுத்துரு:"
 msgid "Symbols"
 msgstr "குறியெழுத்துகள்"
 
-#: ../src/common/imagtiff.cpp:369 ../src/common/imagtiff.cpp:382
-#: ../src/common/imagtiff.cpp:741
+#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
+#: ../src/common/imagtiff.cpp:738
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIF: நினைவகத்தை ஒதுக்கீடு செய்ய இயலவில்லை."
 
-#: ../src/common/imagtiff.cpp:301
+#: ../src/common/imagtiff.cpp:298
 msgid "TIFF: Error loading image."
 msgstr "TIF: படிமத்தை ஏற்றுவதில் பிழை."
 
-#: ../src/common/imagtiff.cpp:468
+#: ../src/common/imagtiff.cpp:465
 msgid "TIFF: Error reading image."
 msgstr "TIF: படிமத்தை படிப்பதில் பிழை."
 
-#: ../src/common/imagtiff.cpp:608
+#: ../src/common/imagtiff.cpp:605
 msgid "TIFF: Error saving image."
 msgstr "TIF: படிமத்தை சேமிப்பதில் பிழை."
 
-#: ../src/common/imagtiff.cpp:846
+#: ../src/common/imagtiff.cpp:843
 msgid "TIFF: Error writing image."
 msgstr "TIF: படிமத்தை எழுதுவதில் பிழை."
 
-#: ../src/common/imagtiff.cpp:355
+#: ../src/common/imagtiff.cpp:352
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIF: படிமம் இயல்பிற்கு புறம்பாக பெரிய அளவில் உள்ளது."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:68
+#: ../src/common/accelcmn.cpp:65
 #, fuzzy
 msgid "Tab"
 msgstr "தத்தல்கள்"
 
-#: ../src/richtext/richtextbuffer.cpp:11498
+#: ../src/richtext/richtextbuffer.cpp:11497
 msgid "Table Properties"
 msgstr "அட்டவணைப் பண்புகள்"
 
-#: ../src/common/paper.cpp:145
+#: ../src/common/paper.cpp:142
 msgid "Tabloid Extra 11.69 x 18 in"
 msgstr "Tabloid Extra 11.69 x 18 in"
 
-#: ../src/common/paper.cpp:102
+#: ../src/common/paper.cpp:99
 msgid "Tabloid, 11 x 17 in"
 msgstr "Tabloid, 11 x 17 in"
 
-#: ../src/richtext/richtextformatdlg.cpp:354
+#: ../src/richtext/richtextformatdlg.cpp:347
 msgid "Tabs"
 msgstr "தத்தல்கள்"
 
-#: ../src/propgrid/advprops.cpp:1598
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Teal"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:327
+#: ../src/generic/fontdlgg.cpp:323
 msgid "Teletype"
 msgstr "தொலைத் தட்டெழுத்து"
 
-#: ../src/common/docview.cpp:1896
+#: ../src/common/docview.cpp:1901
 msgid "Templates"
 msgstr "வார்ப்புருக்கள்"
 
-#: ../src/common/fmapbase.cpp:158
+#: ../src/common/fmapbase.cpp:155
 msgid "Thai (ISO-8859-11)"
 msgstr "தாய் (ISO-8859-11)"
 
-#: ../src/common/ftp.cpp:619
+#: ../src/common/ftp.cpp:622
 msgid "The FTP server doesn't support passive mode."
 msgstr "FTP வழங்கி முடக்க நிலையை ஆதரிப்பதில்லை."
 
-#: ../src/common/ftp.cpp:605
+#: ../src/common/ftp.cpp:608
 msgid "The FTP server doesn't support the PORT command."
 msgstr "FTP வழங்கி PORT கட்டளையை ஆதரிப்பதில்லை."
 
@@ -6706,8 +6865,8 @@ msgstr "FTP வழங்கி PORT கட்டளையை ஆதரிப்�
 msgid "The available bullet styles."
 msgstr "கிடைப்பில் இருக்கும் தோட்டாப் பாங்குகள்."
 
-#: ../src/richtext/richtextstyledlg.cpp:202
-#: ../src/richtext/richtextstyledlg.cpp:204
+#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:200
 msgid "The available styles."
 msgstr "கிடைப்பில் இருக்கும் பாங்குகள்."
 
@@ -6763,12 +6922,12 @@ msgstr "கீழ் நிலை."
 msgid "The bullet character."
 msgstr "தோட்டா வரியுரு."
 
-#: ../src/richtext/richtextsymboldlg.cpp:443
-#: ../src/richtext/richtextsymboldlg.cpp:445
+#: ../src/richtext/richtextsymboldlg.cpp:440
+#: ../src/richtext/richtextsymboldlg.cpp:442
 msgid "The character code."
 msgstr "வரியுருக் குறி."
 
-#: ../src/common/fontmap.cpp:203
+#: ../src/common/fontmap.cpp:200
 #, c-format
 msgid ""
 "The charset '%s' is unknown. You may select\n"
@@ -6779,7 +6938,7 @@ msgstr ""
 "மற்றொரு Charset-ஐ மாற்றமர்வாக தேர்ந்தெடுக்கவும், அல்லது அதை மாற்றியமைக்க இயலாதென்றால், \n"
 "[விலக்குக] பொத்தானை அழுத்தவும்."
 
-#: ../src/msw/ole/dataobj.cpp:394
+#: ../src/msw/ole/dataobj.cpp:402
 #, c-format
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "பிடிப்புப் பலகை வடிவூட்டம் '%d' இல்லை."
@@ -6789,7 +6948,7 @@ msgstr "பிடிப்புப் பலகை வடிவூட்டம�
 msgid "The default style for the next paragraph."
 msgstr "அடுத்த பத்திக்கான இயல்பான பாங்கு."
 
-#: ../src/generic/dirdlgg.cpp:202
+#: ../src/generic/dirdlgg.cpp:199
 #, c-format
 msgid ""
 "The directory '%s' does not exist\n"
@@ -6798,7 +6957,7 @@ msgstr ""
 "'%s' அடைவு கிடைப்பில் இல்லை\n"
 "இப்பொழுது அதை உருவாக்க வேண்டுமா?"
 
-#: ../src/html/htmprint.cpp:271
+#: ../src/html/htmprint.cpp:283
 #, c-format
 msgid ""
 "The document \"%s\" doesn't fit on the page horizontally and will be "
@@ -6810,7 +6969,7 @@ msgstr ""
 "\n"
 "இருப்பினும், ஆவணத்தை அச்சிட வேண்டுமா?"
 
-#: ../src/common/docview.cpp:1202
+#: ../src/common/docview.cpp:1196
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -6819,36 +6978,36 @@ msgstr ""
 "கோப்பு '%s' இல்லையென்பதால், அதைத் திறக்க இயலாது.\n"
 "மிக அண்மையில் பயன்படுத்தப்பட்ட கோப்புகளின் பட்டியலிலிருந்து அது நீக்கப்பட்டுள்ளது."
 
-#: ../src/richtext/richtextindentspage.cpp:208
-#: ../src/richtext/richtextindentspage.cpp:210
 #: ../src/richtext/richtextliststylepage.cpp:394
 #: ../src/richtext/richtextliststylepage.cpp:396
+#: ../src/richtext/richtextindentspage.cpp:208
+#: ../src/richtext/richtextindentspage.cpp:210
 msgid "The first line indent."
 msgstr "முதல் வரித் துவக்க ஒழுங்கு."
 
-#: ../src/gtk/utilsgtk.cpp:481
-msgid "The following standard GTK+ options are also supported:\n"
-msgstr "பின்வரும் நிலையான GTK+ விருப்பத் தேர்வுகளும் ஆதரிக்கப்படுகின்றன:\n"
+#: ../src/generic/dbgrptg.cpp:318
+msgid "The following debug report will be generated\n"
+msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:414 ../src/generic/fontdlgg.cpp:416
+#: ../src/generic/fontdlgg.cpp:411 ../src/generic/fontdlgg.cpp:413
 msgid "The font colour."
 msgstr "எழுத்துரு நிறம்."
 
-#: ../src/generic/fontdlgg.cpp:375 ../src/generic/fontdlgg.cpp:377
+#: ../src/generic/fontdlgg.cpp:371 ../src/generic/fontdlgg.cpp:373
 msgid "The font family."
 msgstr "எழுத்துரு குடும்பம்."
 
-#: ../src/richtext/richtextsymboldlg.cpp:405
-#: ../src/richtext/richtextsymboldlg.cpp:407
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "The font from which to take the symbol."
 msgstr "குறியெழுத்தை எடுக்க வேண்டிய எழுத்துரு."
 
-#: ../src/generic/fontdlgg.cpp:427 ../src/generic/fontdlgg.cpp:429
-#: ../src/generic/fontdlgg.cpp:434 ../src/generic/fontdlgg.cpp:436
+#: ../src/generic/fontdlgg.cpp:424 ../src/generic/fontdlgg.cpp:426
+#: ../src/generic/fontdlgg.cpp:430 ../src/generic/fontdlgg.cpp:432
 msgid "The font point size."
 msgstr "எழுத்துரு அளவு."
 
-#: ../src/osx/carbon/fontdlg.cpp:343 ../src/osx/carbon/fontdlg.cpp:345
+#: ../src/osx/carbon/fontdlg.cpp:340 ../src/osx/carbon/fontdlg.cpp:342
 msgid "The font size in points."
 msgstr "எழுத்துரு அளவு (புள்ளிகளில்)."
 
@@ -6857,15 +7016,15 @@ msgstr "எழுத்துரு அளவு (புள்ளிகளில
 msgid "The font size units, points or pixels."
 msgstr "எழுத்துரு அளவு (தொகுதிகள், புள்ளிகள் அல்லது படவணுக்கள்)."
 
-#: ../src/generic/fontdlgg.cpp:386 ../src/generic/fontdlgg.cpp:388
+#: ../src/generic/fontdlgg.cpp:382 ../src/generic/fontdlgg.cpp:384
 msgid "The font style."
 msgstr "எழுத்துரு பாங்கு."
 
-#: ../src/generic/fontdlgg.cpp:397 ../src/generic/fontdlgg.cpp:399
+#: ../src/generic/fontdlgg.cpp:393 ../src/generic/fontdlgg.cpp:395
 msgid "The font weight."
 msgstr "எழுத்துரு எடை."
 
-#: ../src/common/docview.cpp:1483
+#: ../src/common/docview.cpp:1477
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "'%s' கோப்பின் வடிவூட்டத்தை வரையறுக்க இயலவில்லை."
@@ -6876,10 +7035,10 @@ msgstr "'%s' கோப்பின் வடிவூட்டத்தை வ�
 msgid "The horizontal offset."
 msgstr "செங்குத்து பெயர்ச்சியை செயற்படச் செய்க"
 
-#: ../src/richtext/richtextindentspage.cpp:199
-#: ../src/richtext/richtextindentspage.cpp:201
 #: ../src/richtext/richtextliststylepage.cpp:385
 #: ../src/richtext/richtextliststylepage.cpp:387
+#: ../src/richtext/richtextindentspage.cpp:199
+#: ../src/richtext/richtextindentspage.cpp:201
 msgid "The left indent."
 msgstr "இடது ஒழுங்கு."
 
@@ -6900,10 +7059,10 @@ msgstr "இடது எழுத்து திணிமத்தின் அ
 msgid "The left position."
 msgstr "இடது நிலை."
 
-#: ../src/richtext/richtextindentspage.cpp:288
-#: ../src/richtext/richtextindentspage.cpp:290
 #: ../src/richtext/richtextliststylepage.cpp:462
 #: ../src/richtext/richtextliststylepage.cpp:464
+#: ../src/richtext/richtextindentspage.cpp:288
+#: ../src/richtext/richtextindentspage.cpp:290
 msgid "The line spacing."
 msgstr "வரி இடைவெளி."
 
@@ -6912,7 +7071,7 @@ msgstr "வரி இடைவெளி."
 msgid "The list item number."
 msgstr "வரிசைப் பட்டியல் உருப்படியின் எண்."
 
-#: ../src/msw/ole/automtn.cpp:664
+#: ../src/msw/ole/automtn.cpp:655
 msgid "The locale ID is unknown."
 msgstr "வட்டார அடையாளம் தெரியாததாக உள்ளது."
 
@@ -6951,19 +7110,19 @@ msgstr "பொருள் அகலம்."
 msgid "The outline level."
 msgstr "வெளிவரைவின் நிலை."
 
-#: ../src/common/log.cpp:277
+#: ../src/common/log.cpp:296
 #, fuzzy, c-format
 msgid "The previous message repeated %u time."
 msgid_plural "The previous message repeated %u times."
 msgstr[0] "முந்தைய தகவல் %lu தடவை மீண்டும் தோன்றியது"
 msgstr[1] "முந்தைய தகவல் %lu தடவை மீண்டும் தோன்றின"
 
-#: ../src/common/log.cpp:270
+#: ../src/common/log.cpp:289
 msgid "The previous message repeated once."
 msgstr "முந்தைய தகவல் ஒரு முறை மீண்டும் தோன்றியது."
 
-#: ../src/richtext/richtextsymboldlg.cpp:462
-#: ../src/richtext/richtextsymboldlg.cpp:464
+#: ../src/richtext/richtextsymboldlg.cpp:459
+#: ../src/richtext/richtextsymboldlg.cpp:461
 msgid "The range to show."
 msgstr "காட்டப்பட வேண்டிய வீச்சு."
 
@@ -6977,15 +7136,15 @@ msgstr ""
 "ஏதேனும் இருந்தால்,\n"
 "அவைகள் அறிக்கையிலிருந்து நீக்கப்பட, தனிப்பட்டத் தகவல்களை தேர்வு நீக்கம் செய்யவும்.\n"
 
-#: ../src/common/cmdline.cpp:1254
+#: ../src/common/cmdline.cpp:1250
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "தேவைப்படும் '%s' அளவுக் குறியீடு குறிப்பிடப்படவில்லை."
 
-#: ../src/richtext/richtextindentspage.cpp:217
-#: ../src/richtext/richtextindentspage.cpp:219
 #: ../src/richtext/richtextliststylepage.cpp:403
 #: ../src/richtext/richtextliststylepage.cpp:405
+#: ../src/richtext/richtextindentspage.cpp:217
+#: ../src/richtext/richtextindentspage.cpp:219
 msgid "The right indent."
 msgstr "வலது வரித் துவக்க ஒழுங்கு."
 
@@ -7027,16 +7186,16 @@ msgstr ""
 msgid "The shadow spread."
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:267
 #: ../src/richtext/richtextliststylepage.cpp:439
 #: ../src/richtext/richtextliststylepage.cpp:441
+#: ../src/richtext/richtextindentspage.cpp:267
 msgid "The spacing after the paragraph."
 msgstr "பத்திக்கு அடுத்த இடைவெளி."
 
-#: ../src/richtext/richtextindentspage.cpp:257
-#: ../src/richtext/richtextindentspage.cpp:259
 #: ../src/richtext/richtextliststylepage.cpp:430
 #: ../src/richtext/richtextliststylepage.cpp:432
+#: ../src/richtext/richtextindentspage.cpp:257
+#: ../src/richtext/richtextindentspage.cpp:259
 msgid "The spacing before the paragraph."
 msgstr "பத்திக்கு முந்தைய இடைவெளி."
 
@@ -7050,12 +7209,12 @@ msgstr "பாங்கின் பெயர்."
 msgid "The style on which this style is based."
 msgstr "இப்பாங்கு அடிப்படையாகக் கொண்டிருக்கும் பாங்கு."
 
-#: ../src/richtext/richtextstyledlg.cpp:214
-#: ../src/richtext/richtextstyledlg.cpp:216
+#: ../src/richtext/richtextstyledlg.cpp:210
+#: ../src/richtext/richtextstyledlg.cpp:212
 msgid "The style preview."
 msgstr "பாங்கு முன்தோற்றம்."
 
-#: ../src/msw/ole/automtn.cpp:680
+#: ../src/msw/ole/automtn.cpp:671
 msgid "The system cannot find the file specified."
 msgstr "குறிப்பிட்ட கோப்பினை கணினி கண்டறிய இயலாது."
 
@@ -7068,7 +7227,7 @@ msgstr "தத்தல் நிலை."
 msgid "The tab positions."
 msgstr "தத்தல் நிலைகள்."
 
-#: ../src/richtext/richtextctrl.cpp:3098
+#: ../src/richtext/richtextctrl.cpp:3099
 msgid "The text couldn't be saved."
 msgstr "உரையை சேமிக்க இயலவில்லை."
 
@@ -7089,7 +7248,7 @@ msgstr "மேல் எழுத்து திணிமத்தின் அ
 msgid "The top position."
 msgstr "மேல் நிலை."
 
-#: ../src/common/cmdline.cpp:1232
+#: ../src/common/cmdline.cpp:1228
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "'%s' விருப்பத் தேர்விற்கான மதிப்பைக் குறிப்பிட வேண்டும்."
@@ -7099,7 +7258,7 @@ msgstr "'%s' விருப்பத் தேர்விற்கான ம�
 msgid "The value of the corner radius."
 msgstr "எல்லைக் கோணத்தின் மதிப்பு."
 
-#: ../src/msw/dialup.cpp:433
+#: ../src/msw/dialup.cpp:427
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -7114,28 +7273,28 @@ msgstr ""
 msgid "The vertical offset."
 msgstr "செங்குத்து பெயர்ச்சியை செயற்படச் செய்க"
 
-#: ../src/richtext/richtextprint.cpp:619 ../src/html/htmprint.cpp:745
+#: ../src/html/htmprint.cpp:749 ../src/richtext/richtextprint.cpp:615
 msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr "பக்க அமைவில் இடையூறு ஏற்பட்டுள்ளது. இயல்பான அச்சுப் பொறியை தாங்கள் அமைக்கலாம்."
 
-#: ../src/html/htmprint.cpp:255
+#: ../src/html/htmprint.cpp:267
 msgid ""
 "This document doesn't fit on the page horizontally and will be truncated "
 "when it is printed."
 msgstr ""
 "இந்த ஆவணம் பக்கத்தின் கிடைநீளத்தில் ஒப்பவில்லையென்பதால், அச்சிடும்பொழுது அது அறுபடும்."
 
-#: ../src/common/image.cpp:2854
+#: ../src/common/image.cpp:2963
 #, c-format
 msgid "This is not a %s."
 msgstr "இது %s அல்ல."
 
-#: ../src/common/wincmn.cpp:1653
+#: ../src/common/wincmn.cpp:1654
 msgid "This platform does not support background transparency."
 msgstr "இந்தத் தளம் பின்னணி ஊடுருவி பார்த்தலை ஆதரிப்பதில்லை."
 
-#: ../src/gtk/window.cpp:4660
+#: ../src/gtk/window.cpp:5664
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
@@ -7143,7 +7302,15 @@ msgstr ""
 "இந்த நிரல், மிகப் பழைய GTK+ பதிப்பைக் கொண்டு உருவாக்கப்பட்டது. GTK+ 2.12 அல்லது அதைவிட "
 "புதிய பதிப்பைக் கொண்டு மறுகட்டமைப்புச் செய்யவும்."
 
-#: ../src/msw/thread.cpp:1240
+#: ../src/gtk/glcanvas.cpp:176
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/msw/thread.cpp:1246
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -7151,12 +7318,12 @@ msgstr ""
 "இழை நிரல் செயலியை துவக்க நிலையாக்குவதில் தோல்வி: உள்ளக இழை சேமிப்பகத்தில் மதிப்பை "
 "சேமிக்க இயலாது"
 
-#: ../src/unix/threadpsx.cpp:1794
+#: ../src/unix/threadpsx.cpp:1843
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 "இழை நிரல் செயலியை துவக்க நிலையாக்குவதில் தோல்வி: இழை விசையை உருவாக்குவதில் தோல்வி."
 
-#: ../src/msw/thread.cpp:1228
+#: ../src/msw/thread.cpp:1234
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -7164,84 +7331,84 @@ msgstr ""
 "இழை நிரற்கூறை துவக்க நிலையாக்குவதில் தோல்வி: இழையின் உள்ளக சேமிப்பகத்தில் சுட்டெண்ணை "
 "ஒதுக்கீடு செய்ய இயலாது."
 
-#: ../src/unix/threadpsx.cpp:1043
+#: ../src/unix/threadpsx.cpp:1061
 msgid "Thread priority setting is ignored."
 msgstr "இழை முன்னுரிமை அமைப்பு தவிர்க்கப்படுகிறது."
 
-#: ../src/msw/mdi.cpp:176
+#: ../src/msw/mdi.cpp:171
 msgid "Tile &Horizontally"
 msgstr "கிடநீளமாக அமை"
 
-#: ../src/msw/mdi.cpp:177
+#: ../src/msw/mdi.cpp:172
 msgid "Tile &Vertically"
 msgstr "செங்குத்தாக அமை"
 
-#: ../src/common/ftp.cpp:200
+#: ../src/common/ftp.cpp:197
 msgid "Timeout while waiting for FTP server to connect, try passive mode."
 msgstr ""
 "FTP வழங்கி இணைப்பிற்கு காத்திருக்கும்பொழுது நேரம் காலாவதியாகிவிட்டது, முடக்க நிலையை "
 "முயன்றுப் பார்க்கவும்."
 
-#: ../src/generic/tipdlg.cpp:201
+#: ../src/generic/tipdlg.cpp:198
 msgid "Tip of the Day"
 msgstr "இன்றையத் துணுக்குதவி"
 
-#: ../src/generic/tipdlg.cpp:140
+#: ../src/generic/tipdlg.cpp:137
 msgid "Tips not available, sorry!"
 msgstr "துணுக்குதவிகள் இல்லை, மன்னிக்கவும்!"
 
-#: ../src/generic/prntdlgg.cpp:242
+#: ../src/generic/prntdlgg.cpp:235
 msgid "To:"
 msgstr "பெறுநர்:"
 
-#: ../src/richtext/richtextbuffer.cpp:8363
+#: ../src/richtext/richtextbuffer.cpp:8361
 msgid "Too many EndStyle calls!"
 msgstr "மிகுதியான End Style அழைப்புகள்!"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:891
+#: ../src/propgrid/advprops.cpp:792
 msgid "Tooltip"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:892
+#: ../src/propgrid/advprops.cpp:793
 msgid "TooltipText"
 msgstr ""
 
-#: ../src/richtext/richtextsizepage.cpp:286
-#: ../src/richtext/richtextsizepage.cpp:290 ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197 ../src/richtext/richtextsizepage.cpp:286
+#: ../src/richtext/richtextsizepage.cpp:290
 msgid "Top"
 msgstr "மேல்"
 
-#: ../src/generic/prntdlgg.cpp:881
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Top margin (mm):"
 msgstr "மேற்கரை (mm):"
 
-#: ../src/generic/aboutdlgg.cpp:79
+#: ../src/generic/aboutdlgg.cpp:76
 msgid "Translations by "
 msgstr "மொழிபெயர்ப்பாளர்"
 
-#: ../src/generic/aboutdlgg.cpp:188
+#: ../src/generic/aboutdlgg.cpp:185
 msgid "Translators"
 msgstr "மொழிபெயர்ப்பாளர்கள்"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:211
+#: ../src/propgrid/propgrid.cpp:192
 msgid "True"
 msgstr "மெய்"
 
-#: ../src/common/fs_mem.cpp:227
+#: ../src/common/fs_mem.cpp:222
 #, c-format
 msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
 msgstr ""
 "VFS நினைவகத்திலிருந்து '%s' கோப்பை நீக்க முயற்சி எடுக்கப்படுகிறது, ஆனால், அது "
 "ஏற்றப்படவில்லை!"
 
-#: ../src/common/fmapbase.cpp:156
+#: ../src/common/fmapbase.cpp:153
 msgid "Turkish (ISO-8859-9)"
 msgstr "துருக்கிய (ISO-8859-9)"
 
-#: ../src/generic/filectrlg.cpp:426
+#: ../src/generic/filectrlg.cpp:422
 msgid "Type"
 msgstr "வகை"
 
@@ -7255,17 +7422,17 @@ msgstr "எழுத்துரு பெயரைத் தட்டச்ச�
 msgid "Type a size in points."
 msgstr "அளவை புள்ளிகளில் தட்டச்சிடுக."
 
-#: ../src/msw/ole/automtn.cpp:676
+#: ../src/msw/ole/automtn.cpp:667
 #, c-format
 msgid "Type mismatch in argument %u."
 msgstr "%u தர்க்கத்தில் உள்ள பொருத்தமின்மையை தட்டச்சிடுக."
 
-#: ../src/common/xtixml.cpp:356 ../src/common/xtixml.cpp:509
-#: ../src/common/xtistrm.cpp:318
+#: ../src/common/xtixml.cpp:352 ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315
 msgid "Type must have enum - long conversion"
 msgstr "வகை enm - நீள மாற்றியைக் கொண்டிருக்க வேண்டும். "
 
-#: ../src/propgrid/propgridiface.cpp:401
+#: ../src/propgrid/propgridiface.cpp:385
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
@@ -7274,19 +7441,19 @@ msgstr ""
 "நடவடிக்கை \"%s\" வகை தோல்வியடைந்தது: பண்புகள் \"%s\" சீட்டு, \"%s\" வகையை "
 "சார்ந்ததாகும், ஆனால், அது \"%s\" என்றுள்ளது."
 
-#: ../src/common/paper.cpp:133
+#: ../src/common/paper.cpp:130
 msgid "US Std Fanfold, 14 7/8 x 11 in"
 msgstr "நிலையான அமெரிக்க முன்பின் மடித்தது, 14 7/8 x 11 in"
 
-#: ../src/common/fmapbase.cpp:196
+#: ../src/common/fmapbase.cpp:193
 msgid "US-ASCII"
 msgstr "US-ASCII"
 
-#: ../src/unix/fswatcher_inotify.cpp:109
+#: ../src/unix/fswatcher_inotify.cpp:106
 msgid "Unable to add inotify watch"
 msgstr "inotify கவனிப்பை ஏற்ற இயலவில்லை."
 
-#: ../src/unix/fswatcher_kqueue.cpp:136
+#: ../src/unix/fswatcher_kqueue.cpp:153
 msgid "Unable to add kqueue watch"
 msgstr "kqueue கவனிப்பை ஏற்ற இயலவில்லை."
 
@@ -7298,7 +7465,7 @@ msgstr "உள்ளிடு/வெளியிடு முழுமை நு
 msgid "Unable to close I/O completion port handle"
 msgstr "உள்ளிடு/வெளிடு முழுமை நுழைவாயில் handle மூட இயலவில்லை"
 
-#: ../src/unix/fswatcher_inotify.cpp:97
+#: ../src/unix/fswatcher_inotify.cpp:94
 msgid "Unable to close inotify instance"
 msgstr "inotify நிகழ்வை மூட இயலவில்லை"
 
@@ -7316,15 +7483,15 @@ msgstr "'%s'-ற்கான handle மூட இயலவில்லை"
 msgid "Unable to create I/O completion port"
 msgstr "உள்ளிடு/வெளியிடு முழுமை நுழைவாயிலை உருவாக்க இயலவில்லை"
 
-#: ../src/msw/fswatcher.cpp:84
+#: ../src/msw/fswatcher.cpp:81
 msgid "Unable to create IOCP worker thread"
 msgstr "IOCP பணியாளர் இழையை உருவாக்க இயலவில்லை"
 
-#: ../src/unix/fswatcher_inotify.cpp:74
+#: ../src/unix/fswatcher_inotify.cpp:71
 msgid "Unable to create inotify instance"
 msgstr "inotify நிகழ்வை உருவாக்க இயலவில்லை"
 
-#: ../src/unix/fswatcher_kqueue.cpp:97
+#: ../src/unix/fswatcher_kqueue.cpp:114
 msgid "Unable to create kqueue instance"
 msgstr "kqueue நிகழ்வை உருவாக்க இயலவில்லை"
 
@@ -7332,11 +7499,11 @@ msgstr "kqueue நிகழ்வை உருவாக்க இயலவில
 msgid "Unable to dequeue completion packet"
 msgstr "முழுமையடைந்த பொதியை dequeue செய்ய இயலவில்லை"
 
-#: ../src/unix/fswatcher_kqueue.cpp:185
+#: ../src/unix/fswatcher_kqueue.cpp:202
 msgid "Unable to get events from kqueue"
 msgstr "kqueue-விடமிருந்து நிகழ்வுகளை பெற இயலவில்லை"
 
-#: ../src/gtk/app.cpp:435
+#: ../src/gtk/app.cpp:431
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "GTK+ துவக்க நிலையாக்க இயலவில்லை, காட்சியமைவு சரியாக அமைந்துள்ளதா?"
 
@@ -7345,12 +7512,12 @@ msgstr "GTK+ துவக்க நிலையாக்க இயலவில�
 msgid "Unable to open path '%s'"
 msgstr "'%s' வழியைத் திறக்க இயலவில்லை"
 
-#: ../src/html/htmlwin.cpp:583
+#: ../src/html/htmlwin.cpp:586
 #, c-format
 msgid "Unable to open requested HTML document: %s"
 msgstr "வேண்டப்பட்ட HTML ஆவணத்தை திறக்க இயலவில்லை: %s"
 
-#: ../src/unix/sound.cpp:368
+#: ../src/unix/sound.cpp:365
 msgid "Unable to play sound asynchronously."
 msgstr "ஒலியை ஒத்திசைவில்லாமல் ஒலிக்க இயலவில்லை"
 
@@ -7358,61 +7525,61 @@ msgstr "ஒலியை ஒத்திசைவில்லாமல் ஒல�
 msgid "Unable to post completion status"
 msgstr "முழுமையடைந்த நிலைமையை இட இயலவில்லை"
 
-#: ../src/unix/fswatcher_inotify.cpp:556
+#: ../src/unix/fswatcher_inotify.cpp:553
 msgid "Unable to read from inotify descriptor"
 msgstr "inotify விளக்கியிலிருந்து படிக்க இயலவில்லை"
 
-#: ../src/unix/fswatcher_inotify.cpp:141
+#: ../src/unix/fswatcher_inotify.cpp:138
 #, fuzzy, c-format
 msgid "Unable to remove inotify watch %i"
 msgstr "inotify கவனிப்பை நீக்க இயலவில்லை"
 
-#: ../src/unix/fswatcher_kqueue.cpp:153
+#: ../src/unix/fswatcher_kqueue.cpp:170
 msgid "Unable to remove kqueue watch"
 msgstr "kqueue கவனிப்பை நீக்க இயலவில்லை"
 
-#: ../src/msw/fswatcher.cpp:168
+#: ../src/msw/fswatcher.cpp:165
 #, c-format
 msgid "Unable to set up watch for '%s'"
 msgstr "'%s'-ற்கான கவனிப்பை அமைக்க இயலவில்லை"
 
-#: ../src/msw/fswatcher.cpp:91
+#: ../src/msw/fswatcher.cpp:88
 msgid "Unable to start IOCP worker thread"
 msgstr "IOCP பணியாளர் இழையை துவக்க இயலவில்லை"
 
-#: ../src/common/stockitem.cpp:201
+#: ../src/common/stockitem.cpp:198
 msgid "Undelete"
 msgstr "அழி நீக்கம்"
 
-#: ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199
 msgid "Underline"
 msgstr "அடிக்கோடு"
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/richtext/richtextfontpage.cpp:359 ../src/osx/carbon/fontdlg.cpp:370
-#: ../src/propgrid/advprops.cpp:690
+#: ../src/osx/carbon/fontdlg.cpp:367 ../src/propgrid/advprops.cpp:600
+#: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "அடிக்கோடிடப்பட்டது"
 
-#: ../src/common/stockitem.cpp:203 ../src/stc/stc_i18n.cpp:15
+#: ../src/common/stockitem.cpp:200 ../src/stc/stc_i18n.cpp:15
 msgid "Undo"
 msgstr "செயல் நீக்கம்"
 
-#: ../src/common/stockitem.cpp:265
+#: ../src/common/stockitem.cpp:263
 msgid "Undo last action"
 msgstr "கடைசி செயலை நீக்குக"
 
-#: ../src/common/cmdline.cpp:1029
+#: ../src/common/cmdline.cpp:1025
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "'%s' விருப்பத் தேர்வுற்கு பின் எதிர்பாராத வரியுருக்கள்."
 
-#: ../src/unix/fswatcher_inotify.cpp:274
+#: ../src/unix/fswatcher_inotify.cpp:271
 #, c-format
 msgid "Unexpected event for \"%s\": no matching watch descriptor."
 msgstr "\"%s\"-ற்கான எதிர்பாராத நிகழ்வு: ஒத்தான கவனிப்பு விளக்கி இல்லை."
 
-#: ../src/common/cmdline.cpp:1195
+#: ../src/common/cmdline.cpp:1191
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "எதிர்பாராத அளவுக் குறியீடு '%s'"
@@ -7421,49 +7588,49 @@ msgstr "எதிர்பாராத அளவுக் குறியீட�
 msgid "Unexpectedly new I/O completion port was created"
 msgstr "புதிய உள்ளிடு/வெளியிடு முழுமை ணுழைவாயில் எதிர்பாரா வண்ணம் உருவாக்கப்பட்டது."
 
-#: ../src/msw/fswatcher.cpp:70
+#: ../src/msw/fswatcher.cpp:67
 msgid "Ungraceful worker thread termination"
 msgstr "நயமற்ற பணியாளர் இழை முடிவு"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:460
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:456
+#: ../src/richtext/richtextsymboldlg.cpp:457
+#: ../src/richtext/richtextsymboldlg.cpp:458
 msgid "Unicode"
 msgstr "ஒருங்குறி"
 
-#: ../src/common/fmapbase.cpp:185 ../src/common/fmapbase.cpp:191
+#: ../src/common/fmapbase.cpp:182 ../src/common/fmapbase.cpp:188
 msgid "Unicode 16 bit (UTF-16)"
 msgstr "ஒருங்குறி 16 நுண்மி (UTF-16)"
 
-#: ../src/common/fmapbase.cpp:190
+#: ../src/common/fmapbase.cpp:187
 msgid "Unicode 16 bit Big Endian (UTF-16BE)"
 msgstr "ஒருங்குறி 16 நுண்மி Big Endian (UTF-16BE)"
 
-#: ../src/common/fmapbase.cpp:186
+#: ../src/common/fmapbase.cpp:183
 msgid "Unicode 16 bit Little Endian (UTF-16LE)"
 msgstr "ஒருங்குறி 16 நுண்மி Small Endian (UTF-16LE)"
 
-#: ../src/common/fmapbase.cpp:187 ../src/common/fmapbase.cpp:193
+#: ../src/common/fmapbase.cpp:184 ../src/common/fmapbase.cpp:190
 msgid "Unicode 32 bit (UTF-32)"
 msgstr "ஒருங்குறி 32 நுண்மி (UTF-32)"
 
-#: ../src/common/fmapbase.cpp:192
+#: ../src/common/fmapbase.cpp:189
 msgid "Unicode 32 bit Big Endian (UTF-32BE)"
 msgstr "ஒருங்குறி 32 நுண்மி Big Endian (UTF-32BE)"
 
-#: ../src/common/fmapbase.cpp:188
+#: ../src/common/fmapbase.cpp:185
 msgid "Unicode 32 bit Little Endian (UTF-32LE)"
 msgstr "ஒருங்குறி 32 நுண்மி Small Endian (UTF-32LE)"
 
-#: ../src/common/fmapbase.cpp:182
+#: ../src/common/fmapbase.cpp:179
 msgid "Unicode 7 bit (UTF-7)"
 msgstr "ஒருங்குறி 7 நுண்மி (UTF-7)"
 
-#: ../src/common/fmapbase.cpp:183
+#: ../src/common/fmapbase.cpp:180
 msgid "Unicode 8 bit (UTF-8)"
 msgstr "ஒருங்குறி 8 நுண்மி (UTF-8)"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "Unindent"
 msgstr "வரித் துவக்க ஒழுங்கை நீக்குக"
 
@@ -7614,97 +7781,102 @@ msgstr "மேல் நிலைக்கான தொகுதிகள்."
 msgid "Units for this value."
 msgstr "இடக் கரைக்கான தொகுதிகள்."
 
-#: ../src/generic/progdlgg.cpp:353 ../src/generic/progdlgg.cpp:622
+#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
 msgid "Unknown"
 msgstr "தெரியாதது"
 
-#: ../src/msw/dde.cpp:1174
+#: ../src/msw/dde.cpp:1238
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "தெரியாத DDE பிழை %08x"
 
-#: ../src/common/xtistrm.cpp:410
+#: ../src/common/xtistrm.cpp:407
 msgid "Unknown Object passed to GetObjectClassInfo"
 msgstr "தெரியாத பொருள் GetObjectClassInfo-விடம் அனுப்பி வைக்கப்பட்டது"
 
-#: ../src/common/imagpng.cpp:366
+#: ../src/common/imagpng.cpp:383
 #, c-format
 msgid "Unknown PNG resolution unit %d"
 msgstr "தெரியாத PNG பிரிதிறன் தொகுதி %d"
 
-#: ../src/common/xtixml.cpp:327
+#: ../src/common/xtixml.cpp:323
 #, c-format
 msgid "Unknown Property %s"
 msgstr "தெரியாத பண்பு %s"
 
-#: ../src/common/imagtiff.cpp:529
+#: ../src/common/imagtiff.cpp:526
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "தெரியாத TIF பிரிதிறன் தொகுதி %d தவிர்க்கப்பட்டது"
 
-#: ../src/unix/dlunix.cpp:160
+#: ../src/propgrid/props.cpp:155
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/unix/dlunix.cpp:118
 msgid "Unknown dynamic library error"
 msgstr "தெரியாத இயங்குநிலை நூலக பிழை"
 
-#: ../src/common/fmapbase.cpp:810
+#: ../src/common/fmapbase.cpp:806
 #, c-format
 msgid "Unknown encoding (%d)"
 msgstr "தெரியாத குறியாக்கம் (%d)"
 
-#: ../src/msw/ole/automtn.cpp:688
+#: ../src/msw/ole/automtn.cpp:679
 #, c-format
 msgid "Unknown error %08x"
 msgstr "தெரியாத பிழை %08x"
 
-#: ../src/msw/ole/automtn.cpp:647
+#: ../src/msw/ole/automtn.cpp:638
 msgid "Unknown exception"
 msgstr "தெரியாத விலக்கு"
 
-#: ../src/common/image.cpp:2839
+#: ../src/common/image.cpp:2942
 msgid "Unknown image data format."
 msgstr "தெரியாத படிமத் தரவு வடிவூட்டம்"
 
-#: ../src/common/cmdline.cpp:914
+#: ../src/common/cmdline.cpp:910
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "தெரியாத நீள் விருப்பத் தேர்வு '%s'"
 
-#: ../src/msw/ole/automtn.cpp:631
+#: ../src/msw/ole/automtn.cpp:622
 msgid "Unknown name or named argument."
 msgstr "தெரியாத பெயர் அல்லது பெயர் தர்க்கம்."
 
-#: ../src/common/cmdline.cpp:929 ../src/common/cmdline.cpp:951
+#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "தெரியாத விருப்பத் தேர்வு '%s'"
 
-#: ../src/common/mimecmn.cpp:225
+#: ../src/common/mimecmn.cpp:221
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "%s மைம் வகைக்கான உள்ளீட்டில் பொருந்தாத '{' "
 
-#: ../src/common/cmdproc.cpp:262 ../src/common/cmdproc.cpp:288
-#: ../src/common/cmdproc.cpp:308
+#: ../src/common/cmdproc.cpp:255 ../src/common/cmdproc.cpp:281
+#: ../src/common/cmdproc.cpp:301
 msgid "Unnamed command"
 msgstr "பெயரிடப்படாத கட்டளை"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:413
+#: ../src/propgrid/propgrid.cpp:392
 msgid "Unspecified"
 msgstr "குறிப்பிடப்படாதது"
 
-#: ../src/msw/clipbrd.cpp:311
+#: ../src/msw/clipbrd.cpp:325
 msgid "Unsupported clipboard format."
 msgstr "ஆதரவளிக்கப்படாத பிடிப்புப் பலகை வடிவூட்டம்."
 
-#: ../src/common/appcmn.cpp:256
+#: ../src/common/appcmn.cpp:277
 #, c-format
 msgid "Unsupported theme '%s'."
 msgstr "ஆதரவளிக்கப்படாத கருத்தோற்றம் '%s'"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:205
-#: ../src/common/accelcmn.cpp:63
+#: ../src/common/stockitem.cpp:202 ../src/common/accelcmn.cpp:60
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Up"
 msgstr "மேல்"
 
@@ -7718,7 +7890,7 @@ msgstr "முகப்பெழுத்துகள்"
 msgid "Upper case roman numerals"
 msgstr "முகப்பெழுத்து ரோமானிய எண்கள்"
 
-#: ../src/common/cmdline.cpp:1326
+#: ../src/common/cmdline.cpp:1322
 #, c-format
 msgid "Usage: %s"
 msgstr "பயன்பாடு: %s"
@@ -7727,38 +7899,47 @@ msgstr "பயன்பாடு: %s"
 msgid "Use &shadow"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:169
-#: ../src/richtext/richtextindentspage.cpp:171
 #: ../src/richtext/richtextliststylepage.cpp:358
 #: ../src/richtext/richtextliststylepage.cpp:360
+#: ../src/richtext/richtextindentspage.cpp:169
+#: ../src/richtext/richtextindentspage.cpp:171
 msgid "Use the current alignment setting."
 msgstr "தற்போதைய ஒழுங்கமைப்பு அமைப்புகளை பயன்படுத்தவும்."
 
-#: ../src/common/valtext.cpp:179
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/gtk/font.cpp:552
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/common/valtext.cpp:142
 msgid "Validation conflict"
 msgstr "சரிபார்ப்பதில் முறண்"
 
-#: ../src/propgrid/manager.cpp:238
+#: ../src/propgrid/manager.cpp:224
 msgid "Value"
 msgstr "மதிப்பு"
 
-#: ../src/propgrid/props.cpp:386 ../src/propgrid/props.cpp:500
+#: ../src/propgrid/props.cpp:309
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "மதிப்பு %s அல்லது அதற்கும் மேல் இருக்க வேண்டும்."
 
-#: ../src/propgrid/props.cpp:417 ../src/propgrid/props.cpp:531
+#: ../src/propgrid/props.cpp:336
 #, c-format
 msgid "Value must be %s or less."
 msgstr "மதிப்பு %s அல்லது அதற்கும் குறைவாக இருக்க வேண்டும்."
 
-#: ../src/propgrid/props.cpp:393 ../src/propgrid/props.cpp:424
-#: ../src/propgrid/props.cpp:507 ../src/propgrid/props.cpp:538
+#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "மதிப்பு இதற்கிடையே இருக்க வேண்டும்: %s & %s."
 
-#: ../src/generic/aboutdlgg.cpp:128
+#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "பதிப்பு"
 
@@ -7767,25 +7948,32 @@ msgstr "பதிப்பு"
 msgid "Vertical alignment."
 msgstr "செங்குத்து ஒழுங்கமைப்பு."
 
-#: ../src/generic/filedlgg.cpp:202
+#: ../src/generic/filedlgg.cpp:199
 msgid "View files as a detailed view"
 msgstr "கோப்புகளை விளக்கங்களுடனான தோற்றத்தில் பார்க்கவும்"
 
-#: ../src/generic/filedlgg.cpp:200
+#: ../src/generic/filedlgg.cpp:197
 msgid "View files as a list view"
 msgstr "கோப்புகளை பட்டியல் வரிசைத் தோற்றத்தில் பார்க்கவும்"
 
-#: ../src/common/docview.cpp:1970
+#: ../src/common/docview.cpp:1975
 msgid "Views"
 msgstr "தோற்றங்கள்"
 
+#: ../src/gtk/app.cpp:348
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1777
+#: ../src/propgrid/advprops.cpp:1678
 msgid "Wait"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1779
+#: ../src/propgrid/advprops.cpp:1680
 msgid "Wait Arrow"
 msgstr ""
 
@@ -7794,245 +7982,242 @@ msgstr ""
 msgid "Waiting for IO on epoll descriptor %d failed"
 msgstr "%d epoll விளக்கியின் மீதான உள்ளிடு/வெளியிடு காத்திருப்பு தோல்வியடைந்தது"
 
-#: ../src/common/log.cpp:223
+#: ../src/common/log.cpp:241
 msgid "Warning: "
 msgstr "எச்சரிக்கை:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1778
+#: ../src/propgrid/advprops.cpp:1679
 msgid "Watch"
 msgstr ""
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:685
+#: ../src/propgrid/advprops.cpp:595
 msgid "Weight"
 msgstr "எடை"
 
-#: ../src/common/fmapbase.cpp:148
+#: ../src/common/fmapbase.cpp:145
 msgid "Western European (ISO-8859-1)"
 msgstr "மேற்கு ஐரோப்பா (ISO-8859-1)"
 
-#: ../src/common/fmapbase.cpp:162
+#: ../src/common/fmapbase.cpp:159
 msgid "Western European with Euro (ISO-8859-15)"
 msgstr "மேற்கு ஐரோப்பா யுரோவுடன் (ISO-8859-15)"
 
-#: ../src/generic/fontdlgg.cpp:446 ../src/generic/fontdlgg.cpp:448
+#: ../src/generic/fontdlgg.cpp:443 ../src/generic/fontdlgg.cpp:445
 msgid "Whether the font is underlined."
 msgstr "எழுத்துரு அடிக்கோடிடப்பட்டதா? "
 
-#: ../src/propgrid/advprops.cpp:1611
+#: ../src/propgrid/advprops.cpp:1517
 msgid "White"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:144
+#: ../src/generic/fdrepdlg.cpp:141
 msgid "Whole word"
 msgstr "முழுச் சொல்"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:532
 msgid "Whole words only"
 msgstr "முழுச் சொற்கள் மட்டும்"
 
-#: ../src/univ/themes/win32.cpp:1102
+#: ../src/univ/themes/win32.cpp:1099
 msgid "Win32 theme"
 msgstr "Win32 கருத்தோற்றம்"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:893
+#: ../src/propgrid/advprops.cpp:794
 #, fuzzy
 msgid "Window"
 msgstr "சாளரம்"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:894
+#: ../src/propgrid/advprops.cpp:795
 #, fuzzy
 msgid "WindowFrame"
 msgstr "சாளரம்"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:895
+#: ../src/propgrid/advprops.cpp:796
 #, fuzzy
 msgid "WindowText"
 msgstr "சாளரம்"
 
-#: ../src/common/fmapbase.cpp:177
+#: ../src/common/fmapbase.cpp:174
 msgid "Windows Arabic (CP 1256)"
 msgstr "விண்டோஸ் அரேபிய  (CP 1256)"
 
-#: ../src/common/fmapbase.cpp:178
+#: ../src/common/fmapbase.cpp:175
 msgid "Windows Baltic (CP 1257)"
 msgstr "விண்டோஸ் பால்டிக் (CP 1257)"
 
-#: ../src/common/fmapbase.cpp:171
+#: ../src/common/fmapbase.cpp:168
 msgid "Windows Central European (CP 1250)"
 msgstr "விண்டோஸ் நடு ஐரோப்பா (CP 1250)"
 
-#: ../src/common/fmapbase.cpp:168
+#: ../src/common/fmapbase.cpp:165
 msgid "Windows Chinese Simplified (CP 936) or GB-2312"
 msgstr "விண்டோஸ் எளிதாக்கப்பட்ட சீனம் (CP 936) or GB-2312"
 
-#: ../src/common/fmapbase.cpp:170
+#: ../src/common/fmapbase.cpp:167
 msgid "Windows Chinese Traditional (CP 950) or Big-5"
 msgstr "விண்டோஸ் பாரம்பரிய சீனம் (CP 950) or Big-5"
 
-#: ../src/common/fmapbase.cpp:172
+#: ../src/common/fmapbase.cpp:169
 msgid "Windows Cyrillic (CP 1251)"
 msgstr "விண்டோஸ் சிரிலிக் (CP 1251)"
 
-#: ../src/common/fmapbase.cpp:174
+#: ../src/common/fmapbase.cpp:171
 msgid "Windows Greek (CP 1253)"
 msgstr "விண்டோஸ் கிரேக்கம் (CP 1253)"
 
-#: ../src/common/fmapbase.cpp:176
+#: ../src/common/fmapbase.cpp:173
 msgid "Windows Hebrew (CP 1255)"
 msgstr "விண்டோஸ் ஹீப்ரு (CP 1255)"
 
-#: ../src/common/fmapbase.cpp:167
+#: ../src/common/fmapbase.cpp:164
 msgid "Windows Japanese (CP 932) or Shift-JIS"
 msgstr "விண்டோஸ் ஜப்பானிய (CP 932) or Shift-JIS"
 
-#: ../src/common/fmapbase.cpp:180
+#: ../src/common/fmapbase.cpp:177
 msgid "Windows Johab (CP 1361)"
 msgstr "விண்டோஸ் ஜோஹாப் (CP 1361)"
 
-#: ../src/common/fmapbase.cpp:169
+#: ../src/common/fmapbase.cpp:166
 msgid "Windows Korean (CP 949)"
 msgstr "விண்டோஸ் கொரிய (CP 949)"
 
-#: ../src/common/fmapbase.cpp:166
+#: ../src/common/fmapbase.cpp:163
 msgid "Windows Thai (CP 874)"
 msgstr "விண்டோஸ் தாய் (CP 874)"
 
-#: ../src/common/fmapbase.cpp:175
+#: ../src/common/fmapbase.cpp:172
 msgid "Windows Turkish (CP 1254)"
 msgstr "விண்டோஸ் துருக்கிய (CP 1254)"
 
-#: ../src/common/fmapbase.cpp:179
+#: ../src/common/fmapbase.cpp:176
 msgid "Windows Vietnamese (CP 1258)"
 msgstr "விண்டோஸ் வியட்நாமிய (CP 1258)"
 
-#: ../src/common/fmapbase.cpp:173
+#: ../src/common/fmapbase.cpp:170
 msgid "Windows Western European (CP 1252)"
 msgstr "விண்டோஸ் மேற்கு ஐரோப்பா (CP 1252)"
 
-#: ../src/common/fmapbase.cpp:181
+#: ../src/common/fmapbase.cpp:178
 msgid "Windows/DOS OEM (CP 437)"
 msgstr "விண்டோஸ் /DOS OEM (CP 437)"
 
-#: ../src/common/fmapbase.cpp:165
+#: ../src/common/fmapbase.cpp:162
 msgid "Windows/DOS OEM Cyrillic (CP 866)"
 msgstr "விண்டோஸ் /DOS OEM சிரிலிக் (CP 866)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:111
+#: ../src/common/accelcmn.cpp:109
 #, fuzzy
 msgid "Windows_Left"
 msgstr "விண்டோஸ் 7"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:113
+#: ../src/common/accelcmn.cpp:111
 #, fuzzy
 msgid "Windows_Menu"
 msgstr "விண்டோஸ் ME"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:112
+#: ../src/common/accelcmn.cpp:110
 #, fuzzy
 msgid "Windows_Right"
 msgstr "விண்டோஸ் விஸ்டா"
 
-#: ../src/common/ffile.cpp:150
+#: ../src/common/ffile.cpp:149
 #, c-format
 msgid "Write error on file '%s'"
 msgstr "'%s' கோப்பில் பிழையை எழுதுக"
 
-#: ../src/xml/xml.cpp:914
+#: ../src/xml/xml.cpp:925
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "XML parsing பிழை: '%s', %d வரியில்"
 
-#: ../src/common/xpmdecod.cpp:796
+#: ../src/common/xpmdecod.cpp:794
 msgid "XPM: Malformed pixel data!"
 msgstr "XPM: விகாரமான படவணுத் தரவு!"
 
-#: ../src/common/xpmdecod.cpp:705
+#: ../src/common/xpmdecod.cpp:702
 #, c-format
 msgid "XPM: incorrect colour description in line %d"
 msgstr "XPM: %d வரியில் நிறத்திற்கான தவறான விளக்கம்"
 
-#: ../src/common/xpmdecod.cpp:680
+#: ../src/common/xpmdecod.cpp:677
 msgid "XPM: incorrect header format!"
 msgstr "XPM: தவறான மேலுரை வடிவூட்டம்!"
 
-#: ../src/common/xpmdecod.cpp:716 ../src/common/xpmdecod.cpp:725
+#: ../src/common/xpmdecod.cpp:714 ../src/common/xpmdecod.cpp:723
 #, c-format
 msgid "XPM: malformed colour definition '%s' at line %d!"
 msgstr "XPM: விகாரமான நிற விளக்கம் '%s', %d வரியில்!"
 
-#: ../src/common/xpmdecod.cpp:755
+#: ../src/common/xpmdecod.cpp:753
 msgid "XPM: no colors left to use for mask!"
 msgstr "XPM: முகத் திரையில் பயன்படுத்த நிறம் ஏதும் விட்டுவைக்கப்படவில்லை!"
 
-#: ../src/common/xpmdecod.cpp:782
+#: ../src/common/xpmdecod.cpp:780
 #, c-format
 msgid "XPM: truncated image data at line %d!"
 msgstr "XPM: %d வரியில் அறுபட்ட படிமத் தரவு!"
 
-#: ../src/propgrid/advprops.cpp:1610
+#: ../src/propgrid/advprops.cpp:1516
 msgid "Yellow"
 msgstr ""
 
-#: ../include/wx/msgdlg.h:276 ../src/common/stockitem.cpp:206
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:203
 #: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "ஆம்"
 
-#: ../src/osx/carbon/overlay.cpp:155
-msgid "You cannot Clear an overlay that is not inited"
-msgstr "init செய்யப்படாத மேலமைவை துடைக்க இயலாது"
-
-#: ../src/osx/carbon/overlay.cpp:107 ../src/dfb/overlay.cpp:61
-msgid "You cannot Init an overlay twice"
-msgstr "மேலமைவை இருமுறை init செய்ய இயலாது"
-
-#: ../src/generic/dirdlgg.cpp:287
+#: ../src/generic/dirdlgg.cpp:284
 msgid "You cannot add a new directory to this section."
 msgstr "இப்பிரிவிற்கு புதிய அடைவினை சேர்க்க இயலாது."
 
-#: ../src/propgrid/propgrid.cpp:3299
+#: ../src/propgrid/propgrid.cpp:3276
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 "ஏற்கமுடியாத மதிப்பை உள்ளிடு செய்துள்ளீர்கள், தொகுத்தலை விலக்க, 'விடுபடு' விசையை "
 "அழுத்தவும்."
 
-#: ../src/common/stockitem.cpp:209
+#: ../src/osx/cocoa/menu.mm:286
+#, fuzzy
+msgid "Zoom"
+msgstr "உள்நோக்கிப் பெரிதாக்குக"
+
+#: ../src/common/stockitem.cpp:206
 msgid "Zoom &In"
 msgstr "உள்நோக்கிப் பெரிதாக்குக"
 
-#: ../src/common/stockitem.cpp:210
+#: ../src/common/stockitem.cpp:207
 msgid "Zoom &Out"
 msgstr "வெளிநோக்கிப் பெரிதாக்குக"
 
-#: ../src/common/stockitem.cpp:209 ../src/common/prntbase.cpp:1594
+#: ../src/common/stockitem.cpp:206 ../src/common/prntbase.cpp:1619
 msgid "Zoom In"
 msgstr "உள்நோக்கிப் பெரிதாக்குக"
 
-#: ../src/common/stockitem.cpp:210 ../src/common/prntbase.cpp:1580
+#: ../src/common/stockitem.cpp:207 ../src/common/prntbase.cpp:1605
 msgid "Zoom Out"
 msgstr "வெளிநோக்கிப் பெரிதாக்குக"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to &Fit"
 msgstr "பொருந்துமாறு பெரிதாக்குக"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to Fit"
 msgstr "பொருந்துமாறு பெரிதாக்குக"
 
-#: ../src/msw/dde.cpp:1141
+#: ../src/msw/dde.cpp:1205
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "ஒரு DDEML செயலி நீட்டிக்கப்பட்ட போட்டி நிலையை உருவாக்கியுள்ளது."
 
-#: ../src/msw/dde.cpp:1129
+#: ../src/msw/dde.cpp:1193
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -8043,39 +8228,39 @@ msgstr ""
 "அள்ளது ஒரு ஏற்கமுடியாத நிகழ்வு இநங்காட்டி\n"
 "ஒரு DDEML செயலுக்கு அனுப்பி வைக்கப்பட்டது."
 
-#: ../src/msw/dde.cpp:1147
+#: ../src/msw/dde.cpp:1211
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "ஒரு உரையாடலை நிலைநாட்டும் வாங்கியின் முயற்சி தோல்வியடைந்துள்ளது."
 
-#: ../src/msw/dde.cpp:1144
+#: ../src/msw/dde.cpp:1208
 msgid "a memory allocation failed."
 msgstr "நினைவக ஒதுக்கீடு தோல்வியடைந்தது"
 
-#: ../src/msw/dde.cpp:1138
+#: ../src/msw/dde.cpp:1202
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "DDEML, ஒரு அளவுக் குறியீட்டை சரிபார்க்க தவறியது."
 
-#: ../src/msw/dde.cpp:1120
+#: ../src/msw/dde.cpp:1184
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "ஒத்திசைவு அறிவுரை பரிமாற்றத்திற்கான வேண்டுகோள் காலாவதியாகிவிட்டது"
 
-#: ../src/msw/dde.cpp:1126
+#: ../src/msw/dde.cpp:1190
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "ஒத்திசைவுத் தரவு பரிமாற்றத்திற்கான வேண்டுகோள் காலாவதியாகிவிட்டது"
 
-#: ../src/msw/dde.cpp:1135
+#: ../src/msw/dde.cpp:1199
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "ஒத்திசைவு செயற்படுத்து பரிமாற்றத்திற்கான வேண்டுகோள் காலாவதியாகிவிட்டது"
 
-#: ../src/msw/dde.cpp:1153
+#: ../src/msw/dde.cpp:1217
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "ஒத்திசைவு poke பரிமாற்றத்திற்கான வேண்டுகோள் காலாவதியாகிவிட்டது"
 
-#: ../src/msw/dde.cpp:1168
+#: ../src/msw/dde.cpp:1232
 msgid "a request to end an advise transaction has timed out."
 msgstr "ஒரு அறிவுரை பரிமாற்றத்தை முடிப்பதற்கான வேண்டுகோள் காலாவதியாகிவிட்டது"
 
-#: ../src/msw/dde.cpp:1162
+#: ../src/msw/dde.cpp:1226
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -8085,15 +8270,15 @@ msgstr ""
 "ஆனால், அதை வழங்கியோ, வாங்கியோ முடிவிற்கு கொண்டு வந்துவிட்டது\n"
 "பரிமாற்றம் நிறைவடையும் முன் முடிக்கப்பட்டது."
 
-#: ../src/msw/dde.cpp:1150
+#: ../src/msw/dde.cpp:1214
 msgid "a transaction failed."
 msgstr "ஒரு பரிமாற்றம் தோல்வியடைந்தது."
 
-#: ../src/common/accelcmn.cpp:189
+#: ../src/common/accelcmn.cpp:188
 msgid "alt"
 msgstr "நிலைமாற்றி"
 
-#: ../src/msw/dde.cpp:1132
+#: ../src/msw/dde.cpp:1196
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -8105,15 +8290,15 @@ msgstr ""
 "அல்லது APPCMD_CLIENTONLY என்று துவக்க நிலையாக்கப்பட்ட ஒரு செயலி\n"
 "வழங்கியின் பரிமாற்றங்களை மேற்கொள்ள முயற்சித்துள்ளது."
 
-#: ../src/msw/dde.cpp:1156
+#: ../src/msw/dde.cpp:1220
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "PostMessage செயற்பாட்டிற்கான உள் அழைப்பு தோல்வியடைந்துள்ளது."
 
-#: ../src/msw/dde.cpp:1165
+#: ../src/msw/dde.cpp:1229
 msgid "an internal error has occurred in the DDEML."
 msgstr "DDEML-ல் ஒரு உட்பிழை ஏற்பட்டுள்ளது."
 
-#: ../src/msw/dde.cpp:1171
+#: ../src/msw/dde.cpp:1235
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -8123,56 +8308,56 @@ msgstr ""
 "XTYP_XACT_COMPLETE திரும்ப அழைத்தலிலிருந்து செயலி திரும்பிய பின்,\n"
 "அந்த திரும்ப அழைத்தலுக்கான பரிமாற்ற இனங்காட்டி, இனிமேல் ஏற்கக்கூடியதாக இருக்காது."
 
-#: ../src/common/zipstrm.cpp:1483
+#: ../src/common/zipstrm.cpp:1522
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "இது பல பகுதிகள் ஒன்றிணைக்கப்பட்ட ஜிப் என்று அனுமானிக்கப்படுகிறது "
 
-#: ../src/common/fileconf.cpp:1847
+#: ../src/common/fileconf.cpp:1849
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "மாறும் இயல்பில்லாத '%s' விசையை மாற்ற மேற்கொள்ளப்பட்ட முயற்சி புறந்தள்ளப்பட்டது."
 
-#: ../src/html/chm.cpp:329
+#: ../src/html/chm.cpp:326
 msgid "bad arguments to library function"
 msgstr "நூலக செயலுக்கு பழுதுள்ள தர்க்கங்கள்"
 
-#: ../src/html/chm.cpp:341
+#: ../src/html/chm.cpp:338
 msgid "bad signature"
 msgstr "பழுதுள்ள ஒப்பம்"
 
-#: ../src/common/zipstrm.cpp:1918
+#: ../src/common/zipstrm.cpp:1988
 msgid "bad zipfile offset to entry"
 msgstr "உள்ளீட்டில் பழுதடைந்த ஜிப் கோப்பு எதிரிடை"
 
-#: ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400
 msgid "binary"
 msgstr "இருமம்"
 
-#: ../src/common/fontcmn.cpp:996
+#: ../src/common/fontcmn.cpp:1195
 msgid "bold"
 msgstr "அடர்த்தி"
 
-#: ../src/msw/utils.cpp:1144
+#: ../src/msw/utils.cpp:1135
 #, c-format
 msgid "build %lu"
 msgstr "கட்டு %lu"
 
-#: ../src/common/ffile.cpp:75
+#: ../src/common/ffile.cpp:73
 #, c-format
 msgid "can't close file '%s'"
 msgstr "'%s' கோப்பினை மூட இயலாது"
 
-#: ../src/common/file.cpp:245
+#: ../src/common/file.cpp:242
 #, c-format
 msgid "can't close file descriptor %d"
 msgstr "%d கோப்பு விளக்கியை மூட இயலாது"
 
-#: ../src/common/file.cpp:586
+#: ../src/common/ffile.cpp:382 ../src/common/file.cpp:613
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "'%s' கோப்புக்கு மாற்றங்களை ஒப்படைக்க இயலாது"
 
-#: ../src/common/file.cpp:178
+#: ../src/common/file.cpp:175
 #, c-format
 msgid "can't create file '%s'"
 msgstr "'%s' கோப்பினை உருவாக்க இயலாது"
@@ -8182,49 +8367,49 @@ msgstr "'%s' கோப்பினை உருவாக்க இயலாத�
 msgid "can't delete user configuration file '%s'"
 msgstr "'%s' பயனர் அமைவடிவ கோப்பினை அழிக்க இயலாது"
 
-#: ../src/common/file.cpp:495
+#: ../src/common/file.cpp:522
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr "%d விளக்கியில் கோப்பின் இறுதியை அடைந்துவிட்டதா என்று தீர்மானிக்க இயலாது"
 
-#: ../src/common/zipstrm.cpp:1692
+#: ../src/common/zipstrm.cpp:1747
 msgid "can't find central directory in zip"
 msgstr "zip-ல் நடுவன் அடைவினை காண இயலாது"
 
-#: ../src/common/file.cpp:465
+#: ../src/common/file.cpp:492
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "%d கோப்பு விளக்கியில் கோப்பின் நீளத்தை கண்டுபிடிக்க இயலாது."
 
-#: ../src/msw/utils.cpp:341
+#: ../src/msw/utils.cpp:336
 msgid "can't find user's HOME, using current directory."
 msgstr "பயனரின் முகப்பைக் கண்டுபிடிக்க இயலாது, தற்போதைய அடைவு பயன்படுத்தப்படுகிறது."
 
-#: ../src/common/file.cpp:366
+#: ../src/common/file.cpp:407
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "%d கோப்பு விளக்கியை அலச இயலாது"
 
-#: ../src/common/file.cpp:422
+#: ../src/common/file.cpp:463
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "%d கோப்பு விளக்கியில் நாடு நிலையை கண்டுபிடிக்க இயலாது"
 
-#: ../src/common/fontmap.cpp:325
+#: ../src/common/fontmap.cpp:322
 msgid "can't load any font, aborting"
 msgstr "எந்த எழுத்துருவையும் ஏற்ற இயலாது, செயல் இடைமறிக்கப்படுகிறது"
 
-#: ../src/common/file.cpp:231 ../src/common/ffile.cpp:59
+#: ../src/common/ffile.cpp:57 ../src/common/file.cpp:228
 #, c-format
 msgid "can't open file '%s'"
 msgstr "'%s' கோப்பினை திறக்க இயலாது"
 
-#: ../src/common/fileconf.cpp:320
+#: ../src/common/fileconf.cpp:314
 #, c-format
 msgid "can't open global configuration file '%s'."
 msgstr "எல்லாமடங்கிய '%s' அமைவடிவ கோப்பினை திறக்க இயலாது"
 
-#: ../src/common/fileconf.cpp:336
+#: ../src/common/fileconf.cpp:330
 #, c-format
 msgid "can't open user configuration file '%s'."
 msgstr "'%s' பயனர் அமைவடிவக் கோப்பினை திறக்க இயலாது"
@@ -8233,40 +8418,40 @@ msgstr "'%s' பயனர் அமைவடிவக் கோப்பின�
 msgid "can't open user configuration file."
 msgstr "பயனர் அமைவடிவக் கோப்பினை திறக்க இயலாது"
 
-#: ../src/common/zipstrm.cpp:579
+#: ../src/common/zipstrm.cpp:572
 msgid "can't re-initialize zlib deflate stream"
 msgstr "zlib அமிழோடையை மறுதுவக்க நிலையாக்க இயலாது"
 
-#: ../src/common/zipstrm.cpp:604
+#: ../src/common/zipstrm.cpp:597
 msgid "can't re-initialize zlib inflate stream"
 msgstr "zlib விரியோடையை மறுதுவக்க நிலையாக்க இயலாது"
 
-#: ../src/common/file.cpp:304
+#: ../src/common/file.cpp:345
 #, c-format
 msgid "can't read from file descriptor %d"
 msgstr "%d கோப்பு விளக்கியிலிருந்து படிக்க இயலாது"
 
-#: ../src/common/file.cpp:581
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:608
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "'%s' கோப்பினை நீக்க இயலாது"
 
-#: ../src/common/file.cpp:598
+#: ../src/common/ffile.cpp:394 ../src/common/file.cpp:625
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "'%s' தற்காலிக கோப்பினை நீக்க இயலாது"
 
-#: ../src/common/file.cpp:408
+#: ../src/common/file.cpp:449
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "%d கோப்பு விளக்கியில் நாட இயலாது"
 
-#: ../src/common/textfile.cpp:273
+#: ../src/common/textfile.cpp:161
 #, c-format
 msgid "can't write buffer '%s' to disk."
 msgstr "வட்டில் '%s' இடையகத்தை எழுத இயலாது."
 
-#: ../src/common/file.cpp:323
+#: ../src/common/file.cpp:364
 #, c-format
 msgid "can't write to file descriptor %d"
 msgstr "%d கோப்பு விளக்கியில் எழுத இயலாது"
@@ -8276,22 +8461,28 @@ msgid "can't write user configuration file."
 msgstr "பயனர் அமைவடிவக் கோப்பில் எழுத இயலாது."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:482 ../src/generic/datavgen.cpp:1261
+#: ../src/common/datavcmn.cpp:2064 ../src/generic/datavgen.cpp:1384
 msgid "checked"
 msgstr ""
 
-#: ../src/html/chm.cpp:345
+#: ../src/html/chm.cpp:342
 msgid "checksum error"
 msgstr "checksum பிழை"
 
-#: ../src/common/tarstrm.cpp:820
+#: ../src/common/tarstrm.cpp:814
 msgid "checksum failure reading tar header block"
 msgstr "tar மேலுரை தொகுதியை படிப்பதில் checksum தோல்வி"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:226
-#: ../src/richtext/richtextbackgroundpage.cpp:249
-#: ../src/richtext/richtextbackgroundpage.cpp:289
-#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
 #: ../src/richtext/richtextborderspage.cpp:254
 #: ../src/richtext/richtextborderspage.cpp:288
 #: ../src/richtext/richtextborderspage.cpp:322
@@ -8309,105 +8500,128 @@ msgstr "tar மேலுரை தொகுதியை படிப்பதி
 #: ../src/richtext/richtextmarginspage.cpp:340
 #: ../src/richtext/richtextmarginspage.cpp:363
 #: ../src/richtext/richtextmarginspage.cpp:388
-#: ../src/richtext/richtextsizepage.cpp:339
-#: ../src/richtext/richtextsizepage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:400
-#: ../src/richtext/richtextsizepage.cpp:427
-#: ../src/richtext/richtextsizepage.cpp:454
-#: ../src/richtext/richtextsizepage.cpp:481
-#: ../src/richtext/richtextsizepage.cpp:555
-#: ../src/richtext/richtextsizepage.cpp:590
-#: ../src/richtext/richtextsizepage.cpp:625
-#: ../src/richtext/richtextsizepage.cpp:660
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
 msgid "cm"
 msgstr "cm"
 
-#: ../src/html/chm.cpp:347
+#: ../src/html/chm.cpp:344
 msgid "compression error"
 msgstr "அமுக்கப் பிழை"
 
-#: ../src/common/regex.cpp:236
+#: ../src/common/regex.cpp:233
 msgid "conversion to 8-bit encoding failed"
 msgstr "8-நுண்மி குறியாக்கத்திற்கு மாற்றுவதில் பிழை."
 
-#: ../src/common/accelcmn.cpp:187
+#: ../src/common/accelcmn.cpp:186
 msgid "ctrl"
 msgstr "கட்டுப்பாடு"
 
-#: ../src/common/cmdline.cpp:1500
+#: ../src/common/cmdline.cpp:1496
 msgid "date"
 msgstr "தேதி"
 
-#: ../src/html/chm.cpp:349
+#: ../src/html/chm.cpp:346
 msgid "decompression error"
 msgstr "அமுக்க நீக்கப் பிழை"
 
-#: ../src/richtext/richtextstyles.cpp:780 ../src/common/fmapbase.cpp:820
+#: ../src/common/fmapbase.cpp:816 ../src/richtext/richtextstyles.cpp:777
 msgid "default"
 msgstr "இயல்பிருப்பு"
 
-#: ../src/common/cmdline.cpp:1496
+#: ../src/common/cmdline.cpp:1492
 msgid "double"
 msgstr "இரட்டை"
 
-#: ../src/common/debugrpt.cpp:538
+#: ../src/common/debugrpt.cpp:539
 msgid "dump of the process state (binary)"
 msgstr "செயல்முறை நிலை கொட்டிடம் (இருமம்)"
 
-#: ../src/common/datetimefmt.cpp:1969
+#: ../src/common/datetimefmt.cpp:1992
 msgid "eighteenth"
 msgstr "பதினெட்டாம்"
 
-#: ../src/common/datetimefmt.cpp:1959
+#: ../src/common/datetimefmt.cpp:1982
 msgid "eighth"
 msgstr "எட்டாம்"
 
-#: ../src/common/datetimefmt.cpp:1962
+#: ../src/common/datetimefmt.cpp:1985
 msgid "eleventh"
 msgstr "பதினொன்றாம்"
 
-#: ../src/common/fileconf.cpp:1833
+#: ../src/common/fileconf.cpp:1835
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "'%s' உள்ளிடு '%s' குழுவில் ஒரு முறைக்கும் மேல் தோன்றுகிறது"
 
-#: ../src/html/chm.cpp:343
+#: ../src/html/chm.cpp:340
 msgid "error in data format"
 msgstr "தரவு வடிவூட்டத்தில் பிழை"
 
-#: ../src/html/chm.cpp:331
+#: ../src/html/chm.cpp:328
 msgid "error opening file"
 msgstr "கோப்பினை திறப்பதில் பிழை"
 
-#: ../src/common/zipstrm.cpp:1778
+#: ../src/common/zipstrm.cpp:1836
 msgid "error reading zip central directory"
 msgstr "ஜிப் நடுவன் அடைவினைப் படிப்பதில் பிழை"
 
-#: ../src/common/zipstrm.cpp:1870
+#: ../src/common/zipstrm.cpp:1940
 msgid "error reading zip local header"
 msgstr "ஜிப் உள்ளக மேலுரையைப் படிப்பதில் பிழை"
 
-#: ../src/common/zipstrm.cpp:2531
+#: ../src/common/zipstrm.cpp:2615
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "'%s' ஜிப் உள்ளீட்டை எழுதுவதில் பிழை: பழுதான crc அல்லது நீளம்"
 
-#: ../src/common/ffile.cpp:188
+#: ../src/common/zipstrm.cpp:2608
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "'%s' ஜிப் உள்ளீட்டை எழுதுவதில் பிழை: பழுதான crc அல்லது நீளம்"
+
+#: ../src/common/fontcmn.cpp:1205
+#, fuzzy
+msgid "extrabold"
+msgstr "அடர்த்தி"
+
+#: ../src/common/fontcmn.cpp:1223
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1167
+#, fuzzy
+msgid "extralight"
+msgstr "இலகுவானது"
+
+#: ../src/msw/webview_ie.cpp:1036
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "'%s'-இனை செயலாக்குவதில் தோல்வி. \n"
+
+#: ../src/common/ffile.cpp:187
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "'%s' கோப்பினை அலசுவதில் தோல்வி"
 
+#: ../src/msw/webview_ie.cpp:1045
+#, fuzzy
+msgid "failed to retrieve execution result"
+msgstr "RAS பிழையின் உரையை மீட்டெடுப்பதில் தோல்வி."
+
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1030
+#: ../src/generic/datavgen.cpp:1150
 #, fuzzy
 msgid "false"
 msgstr "பொய்யானது"
 
-#: ../src/common/datetimefmt.cpp:1966
+#: ../src/common/datetimefmt.cpp:1989
 msgid "fifteenth"
 msgstr "பதினைந்தாம்"
 
-#: ../src/common/datetimefmt.cpp:1956
+#: ../src/common/datetimefmt.cpp:1979
 msgid "fifth"
 msgstr "ஐந்தாம்"
 
@@ -8437,132 +8651,151 @@ msgstr ""
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "'%s' கோப்பு: எதிர்பாராத எழுத்து %c, %d வரியில்."
 
-#: ../src/richtext/richtextbuffer.cpp:8738
+#: ../src/richtext/richtextbuffer.cpp:8736
 msgid "files"
 msgstr "கோப்புகள்"
 
-#: ../src/common/datetimefmt.cpp:1952
+#: ../src/common/datetimefmt.cpp:1975
 msgid "first"
 msgstr "முதல்"
 
-#: ../src/html/helpwnd.cpp:1252
+#: ../src/html/helpwnd.cpp:1250
 msgid "font size"
 msgstr "எழுத்துரு அளவு"
 
-#: ../src/common/datetimefmt.cpp:1965
+#: ../src/common/datetimefmt.cpp:1988
 msgid "fourteenth"
 msgstr "பதினான்காம்"
 
-#: ../src/common/datetimefmt.cpp:1955
+#: ../src/common/datetimefmt.cpp:1978
 msgid "fourth"
 msgstr "நான்காம்"
 
-#: ../src/common/appbase.cpp:783
+#: ../src/common/appbase.cpp:784
 msgid "generate verbose log messages"
 msgstr "தேவைக்கு மிகுதியானவைகளின் செயற்குறிப்பேட்டுத் தகவல்களை உருவாக்குக"
 
-#: ../src/richtext/richtextbuffer.cpp:13138
-#: ../src/richtext/richtextbuffer.cpp:13248
+#: ../src/common/fontcmn.cpp:1215
+msgid "heavy"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:13133
+#: ../src/richtext/richtextbuffer.cpp:13243
 msgid "image"
 msgstr "படிமம்"
 
-#: ../src/common/tarstrm.cpp:796
+#: ../src/common/tarstrm.cpp:790
 msgid "incomplete header block in tar"
 msgstr "tar-ல் முழுமையடையாத மேலுரைத் தொகுதி"
 
-#: ../src/common/xtixml.cpp:489
+#: ../src/common/xtixml.cpp:485
 msgid "incorrect event handler string, missing dot"
 msgstr "தவறான நிகழ்வுக் கையாளுச் சரம், தவறவிடப்பட்டுள்ள புள்ளி"
 
-#: ../src/common/tarstrm.cpp:1381
+#: ../src/common/tarstrm.cpp:1375
 msgid "incorrect size given for tar entry"
 msgstr "tar உள்ளீட்டிற்கு தவறான அளவு கொடுக்கப்பட்டுள்ளது"
 
-#: ../src/common/tarstrm.cpp:993
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:987
 msgid "invalid data in extended tar header"
 msgstr "நீட்டிக்கப்பட்ட tar மேலுரையில் ஏற்கமுடியாத தரவு"
 
-#: ../src/generic/logg.cpp:1030
+#: ../src/generic/logg.cpp:1027
 msgid "invalid message box return value"
 msgstr "ஏற்கமுடியாத தகவல் பெட்டியின் திருப்ப மதிப்பு"
 
-#: ../src/common/zipstrm.cpp:1647
+#: ../src/common/zipstrm.cpp:1688
 msgid "invalid zip file"
 msgstr "ஏற்கமுடியாத ஜிப் கோப்பு"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:1228
 msgid "italic"
 msgstr "வலப்பக்க சாய்வு"
 
-#: ../src/common/fontcmn.cpp:991
+#: ../src/common/webrequest_curl.cpp:374
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "செங்குத்து வரிசையின் விளக்கத்தை துவக்க நிலையாக்க இயலவில்லை."
+
+#: ../src/common/fontcmn.cpp:1172
 msgid "light"
 msgstr "இலகுவானது"
 
-#: ../src/common/intl.cpp:303
-#, c-format
-msgid "locale '%s' cannot be set."
-msgstr "'%s' வட்டாரம் அமைக்க இயலாது."
+#: ../src/common/fontcmn.cpp:1185
+msgid "medium"
+msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2125
+#: ../src/common/datetimefmt.cpp:2148
 msgid "midnight"
 msgstr "நள்ளிரவு"
 
-#: ../src/common/datetimefmt.cpp:1970
+#: ../src/common/datetimefmt.cpp:1993
 msgid "nineteenth"
 msgstr "பத்தொன்பதாம்"
 
-#: ../src/common/datetimefmt.cpp:1960
+#: ../src/common/datetimefmt.cpp:1983
 msgid "ninth"
 msgstr "ஒன்பதாம்"
 
-#: ../src/msw/dde.cpp:1116
+#: ../src/msw/dde.cpp:1180
 msgid "no DDE error."
 msgstr "DDE பிழை இல்லை."
 
-#: ../src/html/chm.cpp:327
+#: ../src/html/chm.cpp:324
 msgid "no error"
 msgstr "பிழை ஏதுமில்லை"
 
-#: ../src/dfb/fontmgr.cpp:174
+#: ../src/dfb/fontmgr.cpp:171
 #, c-format
 msgid "no fonts found in %s, using builtin font"
 msgstr ""
 "%s-ல் எழுத்துரு ஏதும் காணப்படவில்லை, உடன் கட்டப்பட்டு வரும் எழுத்துரு பயன்படுத்தப்படுகிறது"
 
-#: ../src/html/helpdata.cpp:657
+#: ../src/html/helpdata.cpp:650
 msgid "noname"
 msgstr "பெயரில்லை"
 
-#: ../src/common/datetimefmt.cpp:2124
+#: ../src/common/datetimefmt.cpp:2147
 msgid "noon"
 msgstr "நன்பகல்"
 
-#: ../src/richtext/richtextstyles.cpp:779
+#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "இயல்பான"
 
-#: ../src/common/cmdline.cpp:1492
+#: ../src/common/cmdline.cpp:1488
 msgid "num"
 msgstr "எண்"
 
-#: ../src/common/xtixml.cpp:259
+#: ../src/common/accelcmn.cpp:194
+msgid "num "
+msgstr ""
+
+#: ../src/common/xtixml.cpp:255
 msgid "objects cannot have XML Text Nodes"
 msgstr "பொருட்கள் xml உரைக் கணுக்களை கொண்டிருக்க இயலாது"
 
-#: ../src/html/chm.cpp:339
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
 msgid "out of memory"
 msgstr "நினைவகத்திற்கு வெளியே"
 
-#: ../src/common/debugrpt.cpp:514
+#: ../src/common/debugrpt.cpp:515
 msgid "process context description"
 msgstr "செயல்முறை சூழமைவு விளக்கம்"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:227
-#: ../src/richtext/richtextbackgroundpage.cpp:250
-#: ../src/richtext/richtextbackgroundpage.cpp:290
-#: ../src/richtext/richtextbackgroundpage.cpp:317
-#: ../src/richtext/richtextfontpage.cpp:177
-#: ../src/richtext/richtextfontpage.cpp:180
 #: ../src/richtext/richtextborderspage.cpp:255
 #: ../src/richtext/richtextborderspage.cpp:289
 #: ../src/richtext/richtextborderspage.cpp:323
@@ -8572,22 +8805,45 @@ msgstr "செயல்முறை சூழமைவு விளக்கம�
 #: ../src/richtext/richtextborderspage.cpp:491
 #: ../src/richtext/richtextborderspage.cpp:525
 #: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextfontpage.cpp:180
 msgid "pt"
 msgstr "pt"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:225
-#: ../src/richtext/richtextbackgroundpage.cpp:228
-#: ../src/richtext/richtextbackgroundpage.cpp:229
-#: ../src/richtext/richtextbackgroundpage.cpp:248
-#: ../src/richtext/richtextbackgroundpage.cpp:251
-#: ../src/richtext/richtextbackgroundpage.cpp:252
-#: ../src/richtext/richtextbackgroundpage.cpp:288
-#: ../src/richtext/richtextbackgroundpage.cpp:291
-#: ../src/richtext/richtextbackgroundpage.cpp:292
-#: ../src/richtext/richtextbackgroundpage.cpp:315
-#: ../src/richtext/richtextbackgroundpage.cpp:318
-#: ../src/richtext/richtextbackgroundpage.cpp:319
-#: ../src/richtext/richtextfontpage.cpp:178
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:659
+#: ../src/richtext/richtextsizepage.cpp:662
+#: ../src/richtext/richtextsizepage.cpp:663
 #: ../src/richtext/richtextborderspage.cpp:253
 #: ../src/richtext/richtextborderspage.cpp:256
 #: ../src/richtext/richtextborderspage.cpp:257
@@ -8639,261 +8895,271 @@ msgstr "pt"
 #: ../src/richtext/richtextmarginspage.cpp:387
 #: ../src/richtext/richtextmarginspage.cpp:389
 #: ../src/richtext/richtextmarginspage.cpp:390
-#: ../src/richtext/richtextsizepage.cpp:338
-#: ../src/richtext/richtextsizepage.cpp:341
-#: ../src/richtext/richtextsizepage.cpp:342
-#: ../src/richtext/richtextsizepage.cpp:372
-#: ../src/richtext/richtextsizepage.cpp:375
-#: ../src/richtext/richtextsizepage.cpp:376
-#: ../src/richtext/richtextsizepage.cpp:399
-#: ../src/richtext/richtextsizepage.cpp:402
-#: ../src/richtext/richtextsizepage.cpp:403
-#: ../src/richtext/richtextsizepage.cpp:426
-#: ../src/richtext/richtextsizepage.cpp:429
-#: ../src/richtext/richtextsizepage.cpp:430
-#: ../src/richtext/richtextsizepage.cpp:453
-#: ../src/richtext/richtextsizepage.cpp:456
-#: ../src/richtext/richtextsizepage.cpp:457
-#: ../src/richtext/richtextsizepage.cpp:480
-#: ../src/richtext/richtextsizepage.cpp:483
-#: ../src/richtext/richtextsizepage.cpp:484
-#: ../src/richtext/richtextsizepage.cpp:554
-#: ../src/richtext/richtextsizepage.cpp:557
-#: ../src/richtext/richtextsizepage.cpp:558
-#: ../src/richtext/richtextsizepage.cpp:589
-#: ../src/richtext/richtextsizepage.cpp:592
-#: ../src/richtext/richtextsizepage.cpp:593
-#: ../src/richtext/richtextsizepage.cpp:624
-#: ../src/richtext/richtextsizepage.cpp:627
-#: ../src/richtext/richtextsizepage.cpp:628
-#: ../src/richtext/richtextsizepage.cpp:659
-#: ../src/richtext/richtextsizepage.cpp:662
-#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextfontpage.cpp:178
 msgid "px"
 msgstr "px"
 
-#: ../src/common/accelcmn.cpp:193
+#: ../src/common/accelcmn.cpp:192
 msgid "rawctrl"
 msgstr "rawctrl"
 
-#: ../src/html/chm.cpp:333
+#: ../src/html/chm.cpp:330
 msgid "read error"
 msgstr "பிழையை படிக்கவும்"
 
-#: ../src/common/zipstrm.cpp:2085
+#: ../src/common/zipstrm.cpp:2155
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "ஜிப் ஓடை படிக்கப்படுகிறது (உள்ளிடு %s): பழுதடைந்த crc"
 
-#: ../src/common/zipstrm.cpp:2080
+#: ../src/common/zipstrm.cpp:2150
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "ஜிப் ஓடை படிக்கப்படுகிறது (உள்ளிடு %s): பழுதடைந்த நீளம்"
 
-#: ../src/msw/dde.cpp:1159
+#: ../src/msw/dde.cpp:1223
 msgid "reentrancy problem."
 msgstr "மறுநுழைவில் இடைஞ்சல்"
 
-#: ../src/common/datetimefmt.cpp:1953
+#: ../src/common/datetimefmt.cpp:1976
 msgid "second"
 msgstr "இரண்டாம்"
 
-#: ../src/html/chm.cpp:337
+#: ../src/html/chm.cpp:334
 msgid "seek error"
 msgstr "பிழையை நாடு"
 
-#: ../src/common/datetimefmt.cpp:1968
+#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#, fuzzy
+msgid "semibold"
+msgstr "அடர்த்தி"
+
+#: ../src/common/datetimefmt.cpp:1991
 msgid "seventeenth"
 msgstr "பதினேழாம்"
 
-#: ../src/common/datetimefmt.cpp:1958
+#: ../src/common/datetimefmt.cpp:1981
 msgid "seventh"
 msgstr "ஏழாம்"
 
-#: ../src/common/accelcmn.cpp:191
+#: ../src/common/accelcmn.cpp:190
 msgid "shift"
 msgstr "மாற்றழுத்தி"
 
-#: ../src/common/appbase.cpp:773
+#: ../src/common/appbase.cpp:774
 msgid "show this help message"
 msgstr "இந்த உதவித் தகவலைக் காட்டுக"
 
-#: ../src/common/datetimefmt.cpp:1967
+#: ../src/common/datetimefmt.cpp:1990
 msgid "sixteenth"
 msgstr "பதினாறாம்"
 
-#: ../src/common/datetimefmt.cpp:1957
+#: ../src/common/datetimefmt.cpp:1980
 msgid "sixth"
 msgstr "ஆறாம்"
 
-#: ../src/common/appcmn.cpp:234
+#: ../src/common/appcmn.cpp:255
 msgid "specify display mode to use (e.g. 640x480-16)"
 msgstr ""
 "பயன்படுத்தப்பட வேண்டிய காட்சியளிப்பு நிலையைக் குறிப்பிடு (எடுத்துக்காட்டு: 640x480-16)"
 
-#: ../src/common/appcmn.cpp:220
+#: ../src/common/appcmn.cpp:241
 msgid "specify the theme to use"
 msgstr "பயன்படுத்தப்பட வேண்டிய கருத்தோற்றத்தைக் குறிப்பிடுக"
 
-#: ../src/richtext/richtextbuffer.cpp:9340
+#: ../src/richtext/richtextbuffer.cpp:9337
 msgid "standard/circle"
 msgstr "செந்தர வட்டம்"
 
-#: ../src/richtext/richtextbuffer.cpp:9341
+#: ../src/richtext/richtextbuffer.cpp:9338
 msgid "standard/circle-outline"
 msgstr "செந்தர வட்டம் வெளிவரைவு"
 
-#: ../src/richtext/richtextbuffer.cpp:9343
+#: ../src/richtext/richtextbuffer.cpp:9340
 msgid "standard/diamond"
 msgstr "செந்தர வைரம்"
 
-#: ../src/richtext/richtextbuffer.cpp:9342
+#: ../src/richtext/richtextbuffer.cpp:9339
 msgid "standard/square"
 msgstr "செந்தரச் சதுரம்"
 
-#: ../src/richtext/richtextbuffer.cpp:9344
+#: ../src/richtext/richtextbuffer.cpp:9341
 msgid "standard/triangle"
 msgstr "செந்தர முக்கோணம்"
 
-#: ../src/common/zipstrm.cpp:1985
+#: ../src/common/zipstrm.cpp:2055
 msgid "stored file length not in Zip header"
 msgstr "சேமிக்கப்பட்ட கோப்பின் நீளம் ஜிப் மேலுரையில் இல்லை"
 
-#: ../src/common/cmdline.cpp:1488
+#: ../src/common/cmdline.cpp:1484
 msgid "str"
 msgstr "str"
 
-#: ../src/common/fontcmn.cpp:982
+#: ../src/common/fontcmn.cpp:1145
 msgid "strikethrough"
 msgstr "ஊடாகக் கோடிடப்பட்டது"
 
-#: ../src/common/tarstrm.cpp:1003 ../src/common/tarstrm.cpp:1025
-#: ../src/common/tarstrm.cpp:1507 ../src/common/tarstrm.cpp:1529
+#: ../src/common/tarstrm.cpp:997 ../src/common/tarstrm.cpp:1019
+#: ../src/common/tarstrm.cpp:1501 ../src/common/tarstrm.cpp:1523
 msgid "tar entry not open"
 msgstr "tar உள்ளிடு திறந்த நிலையில் இல்லை"
 
-#: ../src/common/datetimefmt.cpp:1961
+#: ../src/common/datetimefmt.cpp:1984
 msgid "tenth"
 msgstr "பத்தாம்"
 
-#: ../src/msw/dde.cpp:1123
+#: ../src/msw/dde.cpp:1187
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "பரிமாற்றத்திற்கான மறுமொழி, DDE_FBUSY நுண்மியை  அமைக்கச் செய்தது."
 
-#: ../src/common/datetimefmt.cpp:1954
+#: ../src/common/fontcmn.cpp:1154
+msgid "thin"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:1977
 msgid "third"
 msgstr "மூன்றாம்"
 
-#: ../src/common/datetimefmt.cpp:1964
+#: ../src/common/datetimefmt.cpp:1987
 msgid "thirteenth"
 msgstr "பதிமூன்றாம்"
 
-#: ../src/common/datetimefmt.cpp:1758
+#: ../src/common/datetimefmt.cpp:1781
 msgid "today"
 msgstr "இன்று"
 
-#: ../src/common/datetimefmt.cpp:1760
+#: ../src/common/datetimefmt.cpp:1783
 msgid "tomorrow"
 msgstr "நாளை"
 
-#: ../src/common/fileconf.cpp:1944
+#: ../src/common/fileconf.cpp:1946
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "'%s'-ல் பின்சாய்வுச் சுவடு தவிர்க்கப்படுகிறது"
 
-#: ../src/gtk/aboutdlg.cpp:218
+#: ../src/gtk/aboutdlg.cpp:216
 msgid "translator-credits"
 msgstr "மொழிபெயர்ப்பாளர் அங்கீகாரம்"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1028
+#: ../src/generic/datavgen.cpp:1148
 msgid "true"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1963
+#: ../src/common/datetimefmt.cpp:1986
 msgid "twelfth"
 msgstr "பன்னிரண்டாம்"
 
-#: ../src/common/datetimefmt.cpp:1971
+#: ../src/common/datetimefmt.cpp:1994
 msgid "twentieth"
 msgstr "இருபதாம்"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:486 ../src/generic/datavgen.cpp:1263
+#: ../src/common/datavcmn.cpp:2068 ../src/generic/datavgen.cpp:1386
 msgid "unchecked"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:802 ../src/common/fontcmn.cpp:978
+#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
 msgid "underlined"
 msgstr "அடிக்கோடிடப்பட்டது"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:490
+#: ../src/common/datavcmn.cpp:2072
 #, fuzzy
 msgid "undetermined"
 msgstr "அடிக்கோடிடப்பட்டது"
 
-#: ../src/common/fileconf.cpp:1979
+#: ../src/common/fileconf.cpp:1981
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "எதிர்பாராத \" நிலை %d, '%s'-ல்."
 
-#: ../src/common/tarstrm.cpp:1045
+#: ../src/common/tarstrm.cpp:1039
 msgid "unexpected end of file"
 msgstr "எதிர்பாராத கோப்பு முடிவு"
 
-#: ../src/generic/progdlgg.cpp:370 ../src/common/tarstrm.cpp:371
-#: ../src/common/tarstrm.cpp:394 ../src/common/tarstrm.cpp:425
+#: ../src/common/tarstrm.cpp:366 ../src/common/tarstrm.cpp:389
+#: ../src/common/tarstrm.cpp:420 ../src/generic/progdlgg.cpp:376
 msgid "unknown"
 msgstr "தெரியாதது"
 
-#: ../src/msw/registry.cpp:150
+#: ../src/msw/registry.cpp:139
 #, fuzzy, c-format
 msgid "unknown (%lu)"
 msgstr "தெரியாதது"
 
-#: ../src/common/xtixml.cpp:253
+#: ../src/common/xtixml.cpp:249
 #, c-format
 msgid "unknown class %s"
 msgstr "தெரியாத உட்பிரிவு %s"
 
-#: ../src/common/regex.cpp:258 ../src/html/chm.cpp:351
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "அமுக்கப் பிழை"
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "அமுக்க நீக்கப் பிழை"
+
+#: ../src/common/regex.cpp:255 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "தெரியாதப் பிழை"
 
-#: ../src/msw/dialup.cpp:471
+#: ../src/msw/dialup.cpp:465
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "தெரியாதப் பிழை (பிழைக் குறி %08x)."
 
-#: ../src/common/fmapbase.cpp:834
+#: ../src/common/fmapbase.cpp:830
 #, c-format
 msgid "unknown-%d"
 msgstr "தெரியாத %d"
 
-#: ../src/common/docview.cpp:509
+#: ../src/common/docview.cpp:502
 msgid "unnamed"
 msgstr "பெயரிடப்படாதது"
 
-#: ../src/common/docview.cpp:1624
+#: ../src/common/docview.cpp:1618
 #, c-format
 msgid "unnamed%d"
 msgstr "பெயரிடப்படாதது %d"
 
-#: ../src/common/zipstrm.cpp:1999 ../src/common/zipstrm.cpp:2319
+#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
 msgid "unsupported Zip compression method"
 msgstr "ஆதரவளிக்கப்படாத ஜிப் நெறுக்கு வழிமுறை"
 
-#: ../src/common/translation.cpp:1892
+#: ../src/common/translation.cpp:1942
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "'%s' பட்டியல், '%s'-இடமிருந்துப் பயன்படுத்தப்படுகிறது."
 
-#: ../src/html/chm.cpp:335
+#: ../src/html/chm.cpp:332
 msgid "write error"
 msgstr "பிழையை எழுதவும்"
 
-#: ../src/common/time.cpp:292
+#: ../src/gtk/glcanvas.cpp:187
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/common/time.cpp:285
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay தோல்வியடைந்தது."
 
@@ -8906,15 +9172,15 @@ msgstr "wxWidgets, '%s'-ற்கான காட்சியளிப்பை�
 msgid "wxWidgets could not open display. Exiting."
 msgstr "காட்சியமைவை wxWidgets திறக்க இயலவில்லை. வெளியேறுகிறது."
 
-#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:431
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/common/datetimefmt.cpp:1759
+#: ../src/common/datetimefmt.cpp:1782
 msgid "yesterday"
 msgstr "நேற்று"
 
-#: ../src/common/zstream.cpp:251 ../src/common/zstream.cpp:426
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
 #, c-format
 msgid "zlib error %d"
 msgstr "zlib பிழை %d"
@@ -8923,6 +9189,77 @@ msgstr "zlib பிழை %d"
 #: ../src/richtext/richtextbulletspage.cpp:288
 msgid "~"
 msgstr "~"
+
+#~ msgid "&Save as"
+#~ msgstr "இவ்வாறு சேமிக்கவும்"
+
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "ஏற்கக் கூடிய வரியுருக்களை மட்டுமே '%s' கொண்டிருக்கவில்லை"
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' எண்ணாக இருக்க வேண்டும்"
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' ASCII வரியுருக்களை மட்டும் உள்ளடங்கியதாக இருக்க வேண்டும்"
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' அகர வரியுருக்களை மட்டும் உள்ளடங்கியதாக இருக்க வேண்டும்"
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' எண் அல்லது அகர வரியுருக்களை மட்டும் உள்ளடங்கியதாக இருக்க வேண்டும்"
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' இலக்கங்களை மட்டும் உள்ளடங்கியதாக இருக்க வேண்டும்"
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "%s பிரிவினைக் கொண்ட சாளரத்தை உருவாக்க இயலவில்லை"
+
+#, fuzzy
+#~ msgid "Could not initalize libnotify."
+#~ msgstr "ஒழுங்கமைக்க இயலவில்லை."
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "மேலமைவுச் சாளரத்தை உருவாக்க இயலவில்லை."
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "மேலமைவுச் சாளரத்தின் மீது சூழமைவைத் init  செய்ய இயலவில்லை."
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "\"%s\" கோப்பினை ஒருங்குறியாக மாற்றுவதில் தோல்வி."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "உரைக் கட்டுப்பாட்டில் உரையை அமைப்பதில் தோல்வி."
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr ""
+#~ "ஏற்கமுடியாத GTK+ கட்டளை வரி விருப்பத் தேர்வு, \"%s - help\"-யினை பயன்படுத்துங்கள்"
+
+#~ msgid "No unused colour in image."
+#~ msgstr "படிமத்தில் பயன்படுத்தப்படாத நிறம் ஏதுமில்லை."
+
+#~ msgid "Not available"
+#~ msgstr "கிடைப்பில் இல்லை"
+
+#~ msgid "Replace selection"
+#~ msgstr "தெரிவினை மாற்றியமைக்கவும்"
+
+#~ msgid "Save as"
+#~ msgstr "இவ்வாறு சேமிக்கவும்"
+
+#~ msgid "Style Organiser"
+#~ msgstr "பாங்கு அமைப்பாளர்"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "பின்வரும் நிலையான GTK+ விருப்பத் தேர்வுகளும் ஆதரிக்கப்படுகின்றன:\n"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "init செய்யப்படாத மேலமைவை துடைக்க இயலாது"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "மேலமைவை இருமுறை init செய்ய இயலாது"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "'%s' வட்டாரம் அமைக்க இயலாது."
 
 #~ msgid "Adding flavor TEXT failed"
 #~ msgstr "ஃப்ளேவர் உரையேற்றம் தோல்வியடைந்தது"
@@ -8941,9 +9278,6 @@ msgstr "~"
 
 #~ msgid "Column could not be added."
 #~ msgstr "செங்குத்து வரிசையை சேர்க்க இயலவில்லை."
-
-#~ msgid "Column description could not be initialized."
-#~ msgstr "செங்குத்து வரிசையின் விளக்கத்தை துவக்க நிலையாக்க இயலவில்லை."
 
 #~ msgid "Column index not found."
 #~ msgstr "செங்குத்து வரிசையின் சுட்டெண் காணப்படவில்லை."

--- a/locale/tr.po
+++ b/locale/tr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-21 14:25+0200\n"
+"POT-Creation-Date: 2020-10-18 23:11+0300\n"
 "PO-Revision-Date: 2017-08-12 12:53+0300\n"
 "Last-Translator: Kaya Zeren <kayazeren@gmail.com>\n"
 "Language-Team: Turkish (Turkey) (http://www.transifex.com/projects/p/"
@@ -20,7 +20,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 2.0.3\n"
 
-#: ../src/common/debugrpt.cpp:586
+#: ../src/common/debugrpt.cpp:587
 msgid ""
 "\n"
 "Please send this report to the program maintainer, thank you!\n"
@@ -28,8 +28,8 @@ msgstr ""
 "\n"
 "Lütfen bu raporu program geliştiricisine gönderin, teşekkürler!\n"
 
-#: ../src/richtext/richtextstyledlg.cpp:210
-#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:206
+#: ../src/richtext/richtextstyledlg.cpp:218
 msgid " "
 msgstr " "
 
@@ -37,70 +37,96 @@ msgstr " "
 msgid "              Thank you and we're sorry for the inconvenience!\n"
 msgstr "              Teşekkürler, yaşadığınız sorundan dolayı özür dileriz!\n"
 
-#: ../src/common/prntbase.cpp:573
+#: ../src/common/prntbase.cpp:568
 #, c-format
 msgid " (copy %d of %d)"
 msgstr " (kopya %d / %d)"
 
-#: ../src/common/log.cpp:421
+#: ../src/common/log.cpp:440
 #, c-format
 msgid " (error %ld: %s)"
 msgstr " (hata %ld: %s)"
 
-#: ../src/common/imagtiff.cpp:72
+#: ../src/common/imagtiff.cpp:69
 #, c-format
 msgid " (in module \"%s\")"
 msgstr " (\"%s\" modülünde)"
 
-#: ../src/osx/core/secretstore.cpp:138
-msgid " (while overwriting an existing item)"
-msgstr " (varolan bir ögenin üzerine yazılırken)"
-
-#: ../src/common/docview.cpp:1642
+#: ../src/common/docview.cpp:1636
 msgid " - "
 msgstr " - "
 
-#: ../src/richtext/richtextprint.cpp:593 ../src/html/htmprint.cpp:714
+#: ../src/html/htmprint.cpp:712 ../src/richtext/richtextprint.cpp:589
 msgid " Preview"
 msgstr " Önizleme"
 
-#: ../src/common/fontcmn.cpp:824
+#: ../src/common/fontcmn.cpp:973
 msgid " bold"
 msgstr " koyu"
 
-#: ../src/common/fontcmn.cpp:840
+#: ../src/common/fontcmn.cpp:977
+#, fuzzy
+msgid " extra bold"
+msgstr " koyu"
+
+#: ../src/common/fontcmn.cpp:985
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:957
+#, fuzzy
+msgid " extra light"
+msgstr " açık"
+
+#: ../src/common/fontcmn.cpp:981
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1001
 msgid " italic"
 msgstr " yatık"
 
-#: ../src/common/fontcmn.cpp:820
+#: ../src/common/fontcmn.cpp:961
 msgid " light"
 msgstr " açık"
 
-#: ../src/common/fontcmn.cpp:807
+#: ../src/common/fontcmn.cpp:965
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:969
+#, fuzzy
+msgid " semi bold"
+msgstr " koyu"
+
+#: ../src/common/fontcmn.cpp:940
 msgid " strikethrough"
 msgstr " üstü çizili"
 
-#: ../src/common/paper.cpp:117
+#: ../src/common/fontcmn.cpp:953
+msgid " thin"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
 msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
 msgstr "#10 Zarf, 4 1/8 x 9 1/2 inç"
 
-#: ../src/common/paper.cpp:118
+#: ../src/common/paper.cpp:115
 msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
 msgstr "#11 Zarf, 4 1/2 x 10 3/8 inç"
 
-#: ../src/common/paper.cpp:119
+#: ../src/common/paper.cpp:116
 msgid "#12 Envelope, 4 3/4 x 11 in"
 msgstr "#12 Zarf, 4 3/4 x 11 inç"
 
-#: ../src/common/paper.cpp:120
+#: ../src/common/paper.cpp:117
 msgid "#14 Envelope, 5 x 11 1/2 in"
 msgstr "#14 Zarf, 5 x 11 1/2 inç"
 
-#: ../src/common/paper.cpp:116
+#: ../src/common/paper.cpp:113
 msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
 msgstr "#9 Zarf, 3 7/8 x 8 7/8 inç"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:341
 #: ../src/richtext/richtextsizepage.cpp:340
 #: ../src/richtext/richtextsizepage.cpp:374
 #: ../src/richtext/richtextsizepage.cpp:401
@@ -111,80 +137,81 @@ msgstr "#9 Zarf, 3 7/8 x 8 7/8 inç"
 #: ../src/richtext/richtextsizepage.cpp:591
 #: ../src/richtext/richtextsizepage.cpp:626
 #: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextbackgroundpage.cpp:341
 msgid "%"
 msgstr "%"
 
-#: ../src/html/helpwnd.cpp:1031
+#: ../src/html/helpwnd.cpp:1029
 #, c-format
 msgid "%d of %lu"
 msgstr "%d / %lu"
 
-#: ../src/html/helpwnd.cpp:1678
+#: ../src/html/helpwnd.cpp:1676
 #, c-format
 msgid "%i of %u"
 msgstr "%i / %u"
 
-#: ../src/generic/filectrlg.cpp:279
+#: ../src/generic/filectrlg.cpp:275
 #, c-format
 msgid "%ld byte"
 msgid_plural "%ld bytes"
 msgstr[0] "%ld bayt"
 
-#: ../src/html/helpwnd.cpp:1033
+#: ../src/html/helpwnd.cpp:1031
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu / %lu"
 
-#: ../src/generic/datavgen.cpp:6028
+#: ../src/generic/datavgen.cpp:6833
 #, c-format
 msgid "%s (%d items)"
 msgstr "%s (%d öge)"
 
-#: ../src/common/cmdline.cpp:1221
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (ya da %s)"
 
-#: ../src/generic/logg.cpp:224
+#: ../src/generic/logg.cpp:221
 #, c-format
 msgid "%s Error"
 msgstr "%s Hata"
 
-#: ../src/generic/logg.cpp:236
+#: ../src/generic/logg.cpp:233
 #, c-format
 msgid "%s Information"
 msgstr "%s Bilgileri"
 
-#: ../src/generic/preferencesg.cpp:113
+#: ../src/generic/preferencesg.cpp:110
 #, c-format
 msgid "%s Preferences"
 msgstr "%s Ayarları"
 
-#: ../src/generic/logg.cpp:228
+#: ../src/generic/logg.cpp:225
 #, c-format
 msgid "%s Warning"
 msgstr "%s Uyarı"
 
-#: ../src/common/tarstrm.cpp:1319
+#: ../src/common/tarstrm.cpp:1313
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s '%s' kaydının tar başlığına sığmadı"
 
-#: ../src/common/fldlgcmn.cpp:124
+#: ../src/common/fldlgcmn.cpp:121
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s dosya (%s)|%s"
 
-#: ../src/html/helpwnd.cpp:1716
+#: ../src/html/helpwnd.cpp:1714
 #, c-format
 msgid "%u of %u"
 msgstr "%u / %u"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "&About"
 msgstr "H&akkında"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "&Actual Size"
 msgstr "&Geçerli Boyut"
 
@@ -192,28 +219,28 @@ msgstr "&Geçerli Boyut"
 msgid "&After a paragraph:"
 msgstr "P&aragraftan sonra:"
 
-#: ../src/richtext/richtextindentspage.cpp:128
 #: ../src/richtext/richtextliststylepage.cpp:319
+#: ../src/richtext/richtextindentspage.cpp:128
 msgid "&Alignment"
 msgstr "Hiz&alama"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "&Apply"
 msgstr "Uygul&a"
 
-#: ../src/richtext/richtextstyledlg.cpp:251
+#: ../src/richtext/richtextstyledlg.cpp:247
 msgid "&Apply Style"
 msgstr "Biçemi Uygul&a"
 
-#: ../src/msw/mdi.cpp:179
+#: ../src/msw/mdi.cpp:174
 msgid "&Arrange Icons"
 msgstr "Si&mgeleri Düzenle"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "&Ascending"
 msgstr "&Artan"
 
-#: ../src/common/stockitem.cpp:142
+#: ../src/common/stockitem.cpp:139
 msgid "&Back"
 msgstr "&Geri"
 
@@ -233,24 +260,24 @@ msgstr "&Art alan rengi:"
 msgid "&Blur distance:"
 msgstr "&Bulanıklık uzaklığı:"
 
-#: ../src/common/stockitem.cpp:143
+#: ../src/common/stockitem.cpp:140
 msgid "&Bold"
 msgstr "&Koyu"
 
-#: ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141
 msgid "&Bottom"
 msgstr "Al&t"
 
+#: ../src/richtext/richtextsizepage.cpp:637
+#: ../src/richtext/richtextsizepage.cpp:644
 #: ../src/richtext/richtextborderspage.cpp:345
 #: ../src/richtext/richtextborderspage.cpp:513
 #: ../src/richtext/richtextmarginspage.cpp:259
 #: ../src/richtext/richtextmarginspage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:637
-#: ../src/richtext/richtextsizepage.cpp:644
 msgid "&Bottom:"
 msgstr "Al&t:"
 
-#: ../include/wx/richtext/richtextbuffer.h:3866
+#: ../include/wx/richtext/richtextbuffer.h:3861
 msgid "&Box"
 msgstr "&Kutu"
 
@@ -259,38 +286,38 @@ msgstr "&Kutu"
 msgid "&Bullet style:"
 msgstr "&Madde imi biçemi:"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "&CD-Rom"
 msgstr "&CD-Rom"
 
-#: ../src/generic/wizard.cpp:434 ../src/generic/fontdlgg.cpp:470
-#: ../src/generic/fontdlgg.cpp:489 ../src/osx/carbon/fontdlg.cpp:402
-#: ../src/common/dlgcmn.cpp:279 ../src/common/stockitem.cpp:145
+#: ../src/osx/carbon/fontdlg.cpp:399 ../src/common/stockitem.cpp:142
+#: ../src/generic/wizard.cpp:433 ../src/generic/fontdlgg.cpp:466
+#: ../src/generic/fontdlgg.cpp:485 ../src/osx/cocoa/button.mm:200
 msgid "&Cancel"
 msgstr "İ&ptal"
 
-#: ../src/msw/mdi.cpp:175
+#: ../src/msw/mdi.cpp:170
 msgid "&Cascade"
 msgstr "Arka arkaya &diz"
 
-#: ../include/wx/richtext/richtextbuffer.h:5960
+#: ../include/wx/richtext/richtextbuffer.h:5955
 msgid "&Cell"
 msgstr "&Hücre"
 
-#: ../src/richtext/richtextsymboldlg.cpp:439
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "&Character code:"
 msgstr "&Karakter kodu:"
 
-#: ../src/common/stockitem.cpp:147
+#: ../src/common/stockitem.cpp:144
 msgid "&Clear"
 msgstr "T&emizle"
 
-#: ../src/generic/logg.cpp:516 ../src/common/stockitem.cpp:148
-#: ../src/common/prntbase.cpp:1600 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/stockitem.cpp:145 ../src/common/prntbase.cpp:1625
+#: ../src/univ/themes/win32.cpp:3753 ../src/generic/logg.cpp:513
 msgid "&Close"
 msgstr "&Kapat"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "&Color"
 msgstr "&Renk"
 
@@ -298,20 +325,20 @@ msgstr "&Renk"
 msgid "&Colour:"
 msgstr "&Renk:"
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "&Convert"
 msgstr "&Dönüştür"
 
-#: ../src/richtext/richtextctrl.cpp:333 ../src/osx/textctrl_osx.cpp:577
-#: ../src/common/stockitem.cpp:150 ../src/msw/textctrl.cpp:2508
+#: ../src/osx/textctrl_osx.cpp:595 ../src/common/stockitem.cpp:147
+#: ../src/msw/textctrl.cpp:2773 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "K&opyala"
 
-#: ../src/generic/hyperlinkg.cpp:156
+#: ../src/generic/hyperlinkg.cpp:153
 msgid "&Copy URL"
 msgstr "İnternet Adresini K&opyala"
 
-#: ../src/common/headerctrlcmn.cpp:306
+#: ../src/common/headerctrlcmn.cpp:304
 msgid "&Customize..."
 msgstr "Ö&zelleştir..."
 
@@ -319,53 +346,54 @@ msgstr "Ö&zelleştir..."
 msgid "&Debug report preview:"
 msgstr "&Hata ayıklama raporu ön izlemesi:"
 
-#: ../src/richtext/richtexttabspage.cpp:138
-#: ../src/richtext/richtextctrl.cpp:335 ../src/osx/textctrl_osx.cpp:579
-#: ../src/common/stockitem.cpp:152 ../src/msw/textctrl.cpp:2510
+#: ../src/osx/textctrl_osx.cpp:597 ../src/common/stockitem.cpp:149
+#: ../src/msw/textctrl.cpp:2775 ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtextctrl.cpp:334
 msgid "&Delete"
 msgstr "&Sil"
 
-#: ../src/richtext/richtextstyledlg.cpp:269
+#: ../src/richtext/richtextstyledlg.cpp:265
 msgid "&Delete Style..."
 msgstr "&Biçemi Sil..."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "&Descending"
 msgstr "A&zalan"
 
-#: ../src/generic/logg.cpp:682
+#: ../src/generic/logg.cpp:679
 msgid "&Details"
 msgstr "&Ayrıntılar"
 
-#: ../src/common/stockitem.cpp:153
+#: ../src/common/stockitem.cpp:150
 msgid "&Down"
 msgstr "&Aşağı"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "&Edit"
 msgstr "Dü&zenle"
 
-#: ../src/richtext/richtextstyledlg.cpp:263
+#: ../src/richtext/richtextstyledlg.cpp:259
 msgid "&Edit Style..."
 msgstr "Biçemi Düz&enle..."
 
-#: ../src/common/stockitem.cpp:155
+#: ../src/common/stockitem.cpp:152
 msgid "&Execute"
 msgstr "&Yürüt"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/common/stockitem.cpp:154
 msgid "&File"
 msgstr "&Dosya"
 
-#: ../src/common/stockitem.cpp:158
-msgid "&Find"
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "&Find..."
 msgstr "B&ul"
 
-#: ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:430
 msgid "&Finish"
 msgstr "&Bitti"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:156
 msgid "&First"
 msgstr "İ&lk"
 
@@ -373,15 +401,15 @@ msgstr "İ&lk"
 msgid "&Floating mode:"
 msgstr "&Yüzer kip:"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "&Floppy"
 msgstr "&Esnek"
 
-#: ../src/common/stockitem.cpp:194
+#: ../src/common/stockitem.cpp:191
 msgid "&Font"
 msgstr "&Yazı türü"
 
-#: ../src/generic/fontdlgg.cpp:371
+#: ../src/generic/fontdlgg.cpp:367
 msgid "&Font family:"
 msgstr "&Yazı türü ailesi:"
 
@@ -389,20 +417,20 @@ msgstr "&Yazı türü ailesi:"
 msgid "&Font for Level..."
 msgstr "&Düzeyin yazı türü..."
 
+#: ../src/richtext/richtextsymboldlg.cpp:397
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:400
 msgid "&Font:"
 msgstr "&Yazı türü:"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "&Forward"
 msgstr "İ&leri"
 
-#: ../src/richtext/richtextsymboldlg.cpp:451
+#: ../src/richtext/richtextsymboldlg.cpp:448
 msgid "&From:"
 msgstr "&Kaynak:"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "&Harddisk"
 msgstr "&Sabit disk"
 
@@ -411,9 +439,9 @@ msgstr "&Sabit disk"
 msgid "&Height:"
 msgstr "&Yükseklik:"
 
-#: ../src/generic/wizard.cpp:441 ../src/richtext/richtextstyledlg.cpp:303
-#: ../src/richtext/richtextsymboldlg.cpp:479 ../src/osx/menu_osx.cpp:734
-#: ../src/common/stockitem.cpp:163
+#: ../src/common/stockitem.cpp:160 ../src/generic/wizard.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextstyledlg.cpp:299 ../src/osx/cocoa/menu.mm:226
 msgid "&Help"
 msgstr "&Yardım"
 
@@ -421,7 +449,7 @@ msgstr "&Yardım"
 msgid "&Hide details"
 msgstr "Ayrıntıları &gizle"
 
-#: ../src/common/stockitem.cpp:164
+#: ../src/common/stockitem.cpp:161
 msgid "&Home"
 msgstr "&Açılış"
 
@@ -429,54 +457,54 @@ msgstr "&Açılış"
 msgid "&Horizontal offset:"
 msgstr "&Yatay öteleme:"
 
-#: ../src/richtext/richtextindentspage.cpp:184
 #: ../src/richtext/richtextliststylepage.cpp:372
+#: ../src/richtext/richtextindentspage.cpp:184
 msgid "&Indentation (tenths of a mm)"
 msgstr "İçe&rlek (1/10mm ölçeğinde)"
 
-#: ../src/richtext/richtextindentspage.cpp:167
 #: ../src/richtext/richtextliststylepage.cpp:356
+#: ../src/richtext/richtextindentspage.cpp:167
 msgid "&Indeterminate"
 msgstr "&Belirsiz"
 
-#: ../src/common/stockitem.cpp:166
+#: ../src/common/stockitem.cpp:163
 msgid "&Index"
 msgstr "D&izin"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "&Info"
 msgstr "&Bilgiler"
 
-#: ../src/common/stockitem.cpp:168
+#: ../src/common/stockitem.cpp:165
 msgid "&Italic"
 msgstr "&Yatık"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "&Jump to"
 msgstr "A&tla"
 
-#: ../src/richtext/richtextindentspage.cpp:153
 #: ../src/richtext/richtextliststylepage.cpp:342
+#: ../src/richtext/richtextindentspage.cpp:153
 msgid "&Justified"
 msgstr "&Hizalanmış"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "&Last"
 msgstr "&Son"
 
-#: ../src/richtext/richtextindentspage.cpp:139
 #: ../src/richtext/richtextliststylepage.cpp:328
+#: ../src/richtext/richtextindentspage.cpp:139
 msgid "&Left"
 msgstr "So&l"
 
-#: ../src/richtext/richtextindentspage.cpp:195
+#: ../src/richtext/richtextsizepage.cpp:532
+#: ../src/richtext/richtextsizepage.cpp:539
 #: ../src/richtext/richtextborderspage.cpp:243
 #: ../src/richtext/richtextborderspage.cpp:411
 #: ../src/richtext/richtextliststylepage.cpp:381
+#: ../src/richtext/richtextindentspage.cpp:195
 #: ../src/richtext/richtextmarginspage.cpp:186
 #: ../src/richtext/richtextmarginspage.cpp:300
-#: ../src/richtext/richtextsizepage.cpp:532
-#: ../src/richtext/richtextsizepage.cpp:539
 msgid "&Left:"
 msgstr "So&l:"
 
@@ -484,11 +512,11 @@ msgstr "So&l:"
 msgid "&List level:"
 msgstr "&Liste düzeyi:"
 
-#: ../src/generic/logg.cpp:517
+#: ../src/generic/logg.cpp:514
 msgid "&Log"
 msgstr "Gün&lük"
 
-#: ../src/univ/themes/win32.cpp:3748
+#: ../src/univ/themes/win32.cpp:3745
 msgid "&Move"
 msgstr "&Taşı"
 
@@ -496,19 +524,19 @@ msgstr "&Taşı"
 msgid "&Move the object to:"
 msgstr "&Nesneyi şuraya taşı:"
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "&Network"
 msgstr "&Ağ"
 
-#: ../src/richtext/richtexttabspage.cpp:132 ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173 ../src/richtext/richtexttabspage.cpp:132
 msgid "&New"
 msgstr "Ye&ni"
 
-#: ../src/aui/tabmdi.cpp:111 ../src/generic/mdig.cpp:100 ../src/msw/mdi.cpp:180
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
 msgid "&Next"
 msgstr "So&nraki"
 
-#: ../src/generic/wizard.cpp:432 ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:429
 msgid "&Next >"
 msgstr "So&nraki >"
 
@@ -516,7 +544,7 @@ msgstr "So&nraki >"
 msgid "&Next Paragraph"
 msgstr "So&nraki Paragraf"
 
-#: ../src/generic/tipdlg.cpp:240
+#: ../src/generic/tipdlg.cpp:237
 msgid "&Next Tip"
 msgstr "So&nraki İpucu"
 
@@ -524,11 +552,11 @@ msgstr "So&nraki İpucu"
 msgid "&Next style:"
 msgstr "So&nraki biçem:"
 
-#: ../src/common/stockitem.cpp:177 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:174 ../src/msw/msgdlg.cpp:435
 msgid "&No"
 msgstr "&Hayır"
 
-#: ../src/generic/dbgrptg.cpp:356
+#: ../src/generic/dbgrptg.cpp:360
 msgid "&Notes:"
 msgstr "&Notlar:"
 
@@ -536,12 +564,12 @@ msgstr "&Notlar:"
 msgid "&Number:"
 msgstr "&Sayı:"
 
-#: ../src/generic/fontdlgg.cpp:475 ../src/generic/fontdlgg.cpp:482
-#: ../src/osx/carbon/fontdlg.cpp:408 ../src/common/stockitem.cpp:178
+#: ../src/osx/carbon/fontdlg.cpp:405 ../src/common/stockitem.cpp:175
+#: ../src/generic/fontdlgg.cpp:471 ../src/generic/fontdlgg.cpp:478
 msgid "&OK"
 msgstr "&Tamam"
 
-#: ../src/generic/dbgrptg.cpp:342 ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176 ../src/generic/dbgrptg.cpp:342
 msgid "&Open..."
 msgstr "&Aç..."
 
@@ -553,16 +581,16 @@ msgstr "Başlık &düzeyi:"
 msgid "&Page Break"
 msgstr "&Sayfa Sonu"
 
-#: ../src/richtext/richtextctrl.cpp:334 ../src/osx/textctrl_osx.cpp:578
-#: ../src/common/stockitem.cpp:180 ../src/msw/textctrl.cpp:2509
+#: ../src/osx/textctrl_osx.cpp:596 ../src/common/stockitem.cpp:177
+#: ../src/msw/textctrl.cpp:2774 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "Ya&pıştır"
 
-#: ../include/wx/richtext/richtextbuffer.h:5010
+#: ../include/wx/richtext/richtextbuffer.h:5005
 msgid "&Picture"
 msgstr "&Görsel"
 
-#: ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:419
 msgid "&Point size:"
 msgstr "Yazı &boyutu:"
 
@@ -574,11 +602,11 @@ msgstr "&Konum (1/10mm):"
 msgid "&Position mode:"
 msgstr "&Konum kipi:"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178
 msgid "&Preferences"
 msgstr "&Ayarlar"
 
-#: ../src/aui/tabmdi.cpp:112 ../src/generic/mdig.cpp:101 ../src/msw/mdi.cpp:181
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
 msgid "&Previous"
 msgstr "Ö&nceki"
 
@@ -586,78 +614,74 @@ msgstr "Ö&nceki"
 msgid "&Previous Paragraph"
 msgstr "Önceki &Paragraf"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "&Print..."
 msgstr "&Yazdır..."
 
-#: ../src/richtext/richtextctrl.cpp:339 ../src/richtext/richtextctrl.cpp:5514
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtextctrl.cpp:338
+#: ../src/richtext/richtextctrl.cpp:5512
 msgid "&Properties"
 msgstr "Ö&zellikler"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "&Quit"
 msgstr "Çı&kış"
 
-#: ../src/richtext/richtextctrl.cpp:330 ../src/osx/textctrl_osx.cpp:574
-#: ../src/common/stockitem.cpp:185 ../src/common/cmdproc.cpp:293
-#: ../src/common/cmdproc.cpp:300 ../src/msw/textctrl.cpp:2505
+#: ../src/osx/textctrl_osx.cpp:592 ../src/common/stockitem.cpp:182
+#: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
+#: ../src/msw/textctrl.cpp:2770 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Yinele"
 
-#: ../src/common/cmdproc.cpp:289 ../src/common/cmdproc.cpp:309
+#: ../src/common/cmdproc.cpp:282 ../src/common/cmdproc.cpp:302
 msgid "&Redo "
 msgstr "&Yinele "
 
-#: ../src/richtext/richtextstyledlg.cpp:257
+#: ../src/richtext/richtextstyledlg.cpp:253
 msgid "&Rename Style..."
 msgstr "Biçemi &yeniden adlandır..."
 
-#: ../src/generic/fdrepdlg.cpp:179
+#: ../src/generic/fdrepdlg.cpp:176
 msgid "&Replace"
 msgstr "&Değiştir"
 
-#: ../src/richtext/richtextstyledlg.cpp:287
+#: ../src/richtext/richtextstyledlg.cpp:283
 msgid "&Restart numbering"
 msgstr "Numa&ralandırmayı yeniden başlat"
 
-#: ../src/univ/themes/win32.cpp:3747
+#: ../src/univ/themes/win32.cpp:3744
 msgid "&Restore"
 msgstr "Ge&ri yükle"
 
-#: ../src/richtext/richtextindentspage.cpp:146
 #: ../src/richtext/richtextliststylepage.cpp:335
+#: ../src/richtext/richtextindentspage.cpp:146
 msgid "&Right"
 msgstr "&Sağ"
 
-#: ../src/richtext/richtextindentspage.cpp:213
+#: ../src/richtext/richtextsizepage.cpp:602
+#: ../src/richtext/richtextsizepage.cpp:609
 #: ../src/richtext/richtextborderspage.cpp:277
 #: ../src/richtext/richtextborderspage.cpp:445
 #: ../src/richtext/richtextliststylepage.cpp:399
+#: ../src/richtext/richtextindentspage.cpp:213
 #: ../src/richtext/richtextmarginspage.cpp:211
 #: ../src/richtext/richtextmarginspage.cpp:325
-#: ../src/richtext/richtextsizepage.cpp:602
-#: ../src/richtext/richtextsizepage.cpp:609
 msgid "&Right:"
 msgstr "&Sağ:"
 
-#: ../src/common/stockitem.cpp:190
+#: ../src/common/stockitem.cpp:187
 msgid "&Save"
 msgstr "Kay&det"
-
-#: ../src/common/stockitem.cpp:191
-msgid "&Save as"
-msgstr "&Farklı kaydet"
 
 #: ../include/wx/richmsgdlg.h:29
 msgid "&See details"
 msgstr "&Ayrıntılar"
 
-#: ../src/generic/tipdlg.cpp:236
+#: ../src/generic/tipdlg.cpp:233
 msgid "&Show tips at startup"
 msgstr "İpuçları &açılışta görüntülensin"
 
-#: ../src/univ/themes/win32.cpp:3750
+#: ../src/univ/themes/win32.cpp:3747
 msgid "&Size"
 msgstr "&Boyut"
 
@@ -665,36 +689,36 @@ msgstr "&Boyut"
 msgid "&Size:"
 msgstr "&Boyut:"
 
-#: ../src/generic/progdlgg.cpp:252
+#: ../src/generic/progdlgg.cpp:249
 msgid "&Skip"
 msgstr "A&tla"
 
-#: ../src/richtext/richtextindentspage.cpp:242
 #: ../src/richtext/richtextliststylepage.cpp:417
+#: ../src/richtext/richtextindentspage.cpp:242
 msgid "&Spacing (tenths of a mm)"
 msgstr "&Boşluk (1/10mm)"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "&Spell Check"
 msgstr "&Yazım Denetimi"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "&Stop"
 msgstr "&Durdur"
 
-#: ../src/richtext/richtextfontpage.cpp:275 ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196 ../src/richtext/richtextfontpage.cpp:275
 msgid "&Strikethrough"
 msgstr "Ü&stü çizili"
 
-#: ../src/generic/fontdlgg.cpp:382 ../src/richtext/richtextstylepage.cpp:106
+#: ../src/generic/fontdlgg.cpp:378 ../src/richtext/richtextstylepage.cpp:106
 msgid "&Style:"
 msgstr "&Biçem:"
 
-#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:194
 msgid "&Styles:"
 msgstr "&Biçemler:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:413
+#: ../src/richtext/richtextsymboldlg.cpp:410
 msgid "&Subset:"
 msgstr "A&lt küme:"
 
@@ -708,24 +732,24 @@ msgstr "&Simge:"
 msgid "&Synchronize values"
 msgstr "&Değerleri eşleştir"
 
-#: ../include/wx/richtext/richtextbuffer.h:6069
+#: ../include/wx/richtext/richtextbuffer.h:6064
 msgid "&Table"
 msgstr "&Tablo"
 
-#: ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197
 msgid "&Top"
 msgstr "Üs&t"
 
+#: ../src/richtext/richtextsizepage.cpp:567
+#: ../src/richtext/richtextsizepage.cpp:574
 #: ../src/richtext/richtextborderspage.cpp:311
 #: ../src/richtext/richtextborderspage.cpp:479
 #: ../src/richtext/richtextmarginspage.cpp:234
 #: ../src/richtext/richtextmarginspage.cpp:348
-#: ../src/richtext/richtextsizepage.cpp:567
-#: ../src/richtext/richtextsizepage.cpp:574
 msgid "&Top:"
 msgstr "Üs&t:"
 
-#: ../src/generic/fontdlgg.cpp:444 ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199 ../src/generic/fontdlgg.cpp:441
 msgid "&Underline"
 msgstr "&Altı çizili"
 
@@ -733,21 +757,21 @@ msgstr "&Altı çizili"
 msgid "&Underlining:"
 msgstr "&Altını çizme:"
 
-#: ../src/richtext/richtextctrl.cpp:329 ../src/osx/textctrl_osx.cpp:573
-#: ../src/common/stockitem.cpp:203 ../src/common/cmdproc.cpp:271
-#: ../src/msw/textctrl.cpp:2504
+#: ../src/osx/textctrl_osx.cpp:591 ../src/common/stockitem.cpp:200
+#: ../src/common/cmdproc.cpp:264 ../src/msw/textctrl.cpp:2769
+#: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Geri Al"
 
-#: ../src/common/cmdproc.cpp:265
+#: ../src/common/cmdproc.cpp:258
 msgid "&Undo "
 msgstr "&Geri Al "
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "&Unindent"
 msgstr "İçerleği &geri al"
 
-#: ../src/common/stockitem.cpp:205
+#: ../src/common/stockitem.cpp:202
 msgid "&Up"
 msgstr "Y&ukarı"
 
@@ -763,7 +787,7 @@ msgstr "&Dikey öteleme:"
 msgid "&View..."
 msgstr "&Görünüm..."
 
-#: ../src/generic/fontdlgg.cpp:393
+#: ../src/generic/fontdlgg.cpp:389
 msgid "&Weight:"
 msgstr "&Yoğunluk:"
 
@@ -772,88 +796,58 @@ msgstr "&Yoğunluk:"
 msgid "&Width:"
 msgstr "&Genişlik:"
 
-#: ../src/aui/tabmdi.cpp:311 ../src/aui/tabmdi.cpp:327
-#: ../src/aui/tabmdi.cpp:329 ../src/generic/mdig.cpp:294
-#: ../src/generic/mdig.cpp:310 ../src/generic/mdig.cpp:314
-#: ../src/msw/mdi.cpp:78
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
 msgid "&Window"
 msgstr "&Pencere"
 
-#: ../src/common/stockitem.cpp:206 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:203 ../src/msw/msgdlg.cpp:435
 msgid "&Yes"
 msgstr "&Evet"
 
-#: ../src/common/valtext.cpp:256
-#, c-format
-msgid "'%s' contains illegal characters"
+#: ../src/common/valtext.cpp:197
+#, fuzzy, c-format
+msgid "'%s' contains invalid character(s)"
 msgstr "'%s' içinde geçersiz karakterler var"
 
-#: ../src/common/valtext.cpp:254
-#, c-format
-msgid "'%s' doesn't consist only of valid characters"
-msgstr "'%s' yalnız geçerli karakterleri içermiyor"
-
-#: ../src/common/config.cpp:519 ../src/msw/regconf.cpp:258
+#: ../src/common/config.cpp:515 ../src/msw/regconf.cpp:255
 #, c-format
 msgid "'%s' has extra '..', ignored."
 msgstr "'%s' içindeki fazladan '..' yoksayıldı."
 
-#: ../src/common/cmdline.cpp:1113 ../src/common/cmdline.cpp:1131
+#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' '%s' seçeneği için doğru bir sayısal değer değil."
 
-#: ../src/common/translation.cpp:1100
+#: ../src/common/translation.cpp:1142
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' geçerli bir ileti kataloğu değil."
 
-#: ../src/common/valtext.cpp:165
+#: ../src/common/valtext.cpp:188
 #, c-format
 msgid "'%s' is not one of the valid strings"
 msgstr "'%s' geçerli dizgelerden biri değil"
 
-#: ../src/common/valtext.cpp:167
+#: ../src/common/valtext.cpp:186
 #, c-format
 msgid "'%s' is one of the invalid strings"
 msgstr "'%s' geçersiz dizgelerden biri"
 
-#: ../src/common/textbuf.cpp:237
+#: ../src/common/textbuf.cpp:233
 #, c-format
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' muhtemelen ikili ara bellek."
-
-#: ../src/common/valtext.cpp:252
-#, c-format
-msgid "'%s' should be numeric."
-msgstr "'%s' sayısal olmalı."
-
-#: ../src/common/valtext.cpp:244
-#, c-format
-msgid "'%s' should only contain ASCII characters."
-msgstr "'%s' yalnız ASCII karakterler içermeli."
-
-#: ../src/common/valtext.cpp:246
-#, c-format
-msgid "'%s' should only contain alphabetic characters."
-msgstr "'%s' yalnız alfabetik karakterler içermeli."
-
-#: ../src/common/valtext.cpp:248
-#, c-format
-msgid "'%s' should only contain alphabetic or numeric characters."
-msgstr "'%s' yalnız alfabetik ya da sayısal karakterler içermeli."
-
-#: ../src/common/valtext.cpp:250
-#, c-format
-msgid "'%s' should only contain digits."
-msgstr "'%s' yalnız rakamlar içermeli."
 
 #: ../src/richtext/richtextliststylepage.cpp:229
 #: ../src/richtext/richtextbulletspage.cpp:166
 msgid "(*)"
 msgstr "(*)"
 
-#: ../src/html/helpwnd.cpp:963
+#: ../src/html/helpwnd.cpp:961
 msgid "(Help)"
 msgstr "(Yardım)"
 
@@ -862,27 +856,32 @@ msgstr "(Yardım)"
 msgid "(None)"
 msgstr "(Hiçbiri)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:504
+#: ../src/richtext/richtextsymboldlg.cpp:503
 msgid "(Normal text)"
 msgstr "(Normal metin)"
 
-#: ../src/html/helpwnd.cpp:419 ../src/html/helpwnd.cpp:1106
-#: ../src/html/helpwnd.cpp:1742
+#: ../src/html/helpwnd.cpp:417 ../src/html/helpwnd.cpp:1104
+#: ../src/html/helpwnd.cpp:1740
 msgid "(bookmarks)"
 msgstr "(yer imleri)"
 
+#: ../src/msw/dlmsw.cpp:167
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (hata %ld: %s)"
+
+#: ../src/richtext/richtextformatdlg.cpp:876
+#: ../src/richtext/richtextliststylepage.cpp:448
+#: ../src/richtext/richtextliststylepage.cpp:460
+#: ../src/richtext/richtextliststylepage.cpp:461
 #: ../src/richtext/richtextindentspage.cpp:274
 #: ../src/richtext/richtextindentspage.cpp:286
 #: ../src/richtext/richtextindentspage.cpp:287
 #: ../src/richtext/richtextindentspage.cpp:311
 #: ../src/richtext/richtextindentspage.cpp:326
-#: ../src/richtext/richtextformatdlg.cpp:884
 #: ../src/richtext/richtextfontpage.cpp:349
 #: ../src/richtext/richtextfontpage.cpp:353
 #: ../src/richtext/richtextfontpage.cpp:357
-#: ../src/richtext/richtextliststylepage.cpp:448
-#: ../src/richtext/richtextliststylepage.cpp:460
-#: ../src/richtext/richtextliststylepage.cpp:461
 msgid "(none)"
 msgstr "(hiçbiri)"
 
@@ -901,7 +900,7 @@ msgstr "*)"
 msgid "+"
 msgstr "+"
 
-#: ../src/msw/utils.cpp:1152
+#: ../src/msw/utils.cpp:1143
 msgid ", 64-bit edition"
 msgstr ", 64-bit sürümü"
 
@@ -910,163 +909,163 @@ msgstr ", 64-bit sürümü"
 msgid "-"
 msgstr "-"
 
-#: ../src/generic/filepickerg.cpp:66
+#: ../src/generic/filepickerg.cpp:63
 msgid "..."
 msgstr "..."
 
-#: ../src/richtext/richtextindentspage.cpp:276
 #: ../src/richtext/richtextliststylepage.cpp:450
+#: ../src/richtext/richtextindentspage.cpp:276
 msgid "1.1"
 msgstr "1.1"
 
-#: ../src/richtext/richtextindentspage.cpp:277
 #: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextindentspage.cpp:277
 msgid "1.2"
 msgstr "1.2"
 
-#: ../src/richtext/richtextindentspage.cpp:278
 #: ../src/richtext/richtextliststylepage.cpp:452
+#: ../src/richtext/richtextindentspage.cpp:278
 msgid "1.3"
 msgstr "1.3"
 
-#: ../src/richtext/richtextindentspage.cpp:279
 #: ../src/richtext/richtextliststylepage.cpp:453
+#: ../src/richtext/richtextindentspage.cpp:279
 msgid "1.4"
 msgstr "1.4"
 
-#: ../src/richtext/richtextindentspage.cpp:280
 #: ../src/richtext/richtextliststylepage.cpp:454
+#: ../src/richtext/richtextindentspage.cpp:280
 msgid "1.5"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:281
 #: ../src/richtext/richtextliststylepage.cpp:455
+#: ../src/richtext/richtextindentspage.cpp:281
 msgid "1.6"
 msgstr "1.6"
 
-#: ../src/richtext/richtextindentspage.cpp:282
 #: ../src/richtext/richtextliststylepage.cpp:456
+#: ../src/richtext/richtextindentspage.cpp:282
 msgid "1.7"
 msgstr "1.7"
 
-#: ../src/richtext/richtextindentspage.cpp:283
 #: ../src/richtext/richtextliststylepage.cpp:457
+#: ../src/richtext/richtextindentspage.cpp:283
 msgid "1.8"
 msgstr "1.8"
 
-#: ../src/richtext/richtextindentspage.cpp:284
 #: ../src/richtext/richtextliststylepage.cpp:458
+#: ../src/richtext/richtextindentspage.cpp:284
 msgid "1.9"
 msgstr "1.9"
 
-#: ../src/common/paper.cpp:140
+#: ../src/common/paper.cpp:137
 msgid "10 x 11 in"
 msgstr "10 x 11 inç"
 
-#: ../src/common/paper.cpp:113
+#: ../src/common/paper.cpp:110
 msgid "10 x 14 in"
 msgstr "10 x 14 inç"
 
-#: ../src/common/paper.cpp:114
+#: ../src/common/paper.cpp:111
 msgid "11 x 17 in"
 msgstr "11 x 17 inç"
 
-#: ../src/common/paper.cpp:184
+#: ../src/common/paper.cpp:181
 msgid "12 x 11 in"
 msgstr "12 x 11 inç"
 
-#: ../src/common/paper.cpp:141
+#: ../src/common/paper.cpp:138
 msgid "15 x 11 in"
 msgstr "15 x 11 inç"
 
-#: ../src/richtext/richtextindentspage.cpp:285
 #: ../src/richtext/richtextliststylepage.cpp:459
+#: ../src/richtext/richtextindentspage.cpp:285
 msgid "2"
 msgstr "2"
 
-#: ../src/common/paper.cpp:132
+#: ../src/common/paper.cpp:129
 msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
 msgstr "6 3/4 Zarf, 3 5/8 x 6 1/2 inç"
 
-#: ../src/common/paper.cpp:139
+#: ../src/common/paper.cpp:136
 msgid "9 x 11 in"
 msgstr "9 x 11 inç"
 
-#: ../src/html/htmprint.cpp:431
+#: ../src/html/htmprint.cpp:443
 msgid ": file does not exist!"
 msgstr ": dosya bulunamadı!"
 
-#: ../src/common/fontmap.cpp:199
+#: ../src/common/fontmap.cpp:196
 msgid ": unknown charset"
 msgstr ": karakter kümesi bilinmiyor"
 
-#: ../src/common/fontmap.cpp:413
+#: ../src/common/fontmap.cpp:410
 msgid ": unknown encoding"
 msgstr ": kodlama bilinmiyor"
 
-#: ../src/generic/wizard.cpp:443
+#: ../src/generic/wizard.cpp:438
 msgid "< &Back"
 msgstr "< &Geri"
 
-#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:628
-#: ../src/osx/carbon/fontdlg.cpp:648
+#: ../src/osx/carbon/fontdlg.cpp:419 ../src/osx/carbon/fontdlg.cpp:625
+#: ../src/osx/carbon/fontdlg.cpp:645
 msgid "<Any Decorative>"
 msgstr "<Süslü>"
 
-#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:630
-#: ../src/osx/carbon/fontdlg.cpp:650
+#: ../src/osx/carbon/fontdlg.cpp:420 ../src/osx/carbon/fontdlg.cpp:627
+#: ../src/osx/carbon/fontdlg.cpp:647
 msgid "<Any Modern>"
 msgstr "<Modern>"
 
-#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:626
-#: ../src/osx/carbon/fontdlg.cpp:646
+#: ../src/osx/carbon/fontdlg.cpp:418 ../src/osx/carbon/fontdlg.cpp:623
+#: ../src/osx/carbon/fontdlg.cpp:643
 msgid "<Any Roman>"
 msgstr "<Roman>"
 
-#: ../src/osx/carbon/fontdlg.cpp:424 ../src/osx/carbon/fontdlg.cpp:632
-#: ../src/osx/carbon/fontdlg.cpp:652
+#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:629
+#: ../src/osx/carbon/fontdlg.cpp:649
 msgid "<Any Script>"
 msgstr "<Betik>"
 
-#: ../src/osx/carbon/fontdlg.cpp:425 ../src/osx/carbon/fontdlg.cpp:637
-#: ../src/osx/carbon/fontdlg.cpp:656
+#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:634
+#: ../src/osx/carbon/fontdlg.cpp:653
 msgid "<Any Swiss>"
 msgstr "<İsveç>"
 
-#: ../src/osx/carbon/fontdlg.cpp:426 ../src/osx/carbon/fontdlg.cpp:634
-#: ../src/osx/carbon/fontdlg.cpp:654
+#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:631
+#: ../src/osx/carbon/fontdlg.cpp:651
 msgid "<Any Teletype>"
 msgstr "<Teletype>"
 
-#: ../src/osx/carbon/fontdlg.cpp:420
+#: ../src/osx/carbon/fontdlg.cpp:417
 msgid "<Any>"
 msgstr "<Herhangi>"
 
-#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
 msgid "<DIR>"
 msgstr "<DIR>"
 
-#: ../src/generic/filectrlg.cpp:254 ../src/generic/filectrlg.cpp:277
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
 msgid "<DRIVE>"
 msgstr "<DRIVE>"
 
-#: ../src/generic/filectrlg.cpp:252 ../src/generic/filectrlg.cpp:275
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
 msgid "<LINK>"
 msgstr "<LINK>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1264
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Koyu yatık şekil.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1270
+#: ../src/html/helpwnd.cpp:1268
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>koyu yatık <u>altı çizili</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1265
+#: ../src/html/helpwnd.cpp:1263
 msgid "<b>Bold face.</b> "
 msgstr "<b>Koyu şekil.</b> "
 
-#: ../src/html/helpwnd.cpp:1264
+#: ../src/html/helpwnd.cpp:1262
 msgid "<i>Italic face.</i> "
 msgstr "<i>Yatık şekil.</i> "
 
@@ -1075,15 +1074,15 @@ msgstr "<i>Yatık şekil.</i> "
 msgid ">"
 msgstr ">"
 
-#: ../src/generic/dbgrptg.cpp:318
+#: ../src/generic/dbgrptg.cpp:317
 msgid "A debug report has been generated in the directory\n"
 msgstr "Klasörde bir hata ayıklama raporu oluşturuldu\n"
 
-#: ../src/common/debugrpt.cpp:573
+#: ../src/common/debugrpt.cpp:574
 msgid "A debug report has been generated. It can be found in"
 msgstr "Hata ayıklama raporu oluşturuldu. Şurada bulabilirsiniz"
 
-#: ../src/common/xtixml.cpp:418
+#: ../src/common/xtixml.cpp:414
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Boş olmayan bir yığın 'element' düğümlerinden oluşmalıdır"
 
@@ -1094,106 +1093,106 @@ msgstr "Boş olmayan bir yığın 'element' düğümlerinden oluşmalıdır"
 msgid "A standard bullet name."
 msgstr "Standart bir madde imi adı."
 
-#: ../src/common/paper.cpp:217
+#: ../src/common/paper.cpp:214
 msgid "A0 sheet, 841 x 1189 mm"
 msgstr "A0 sayfa, 841 x 1189 mm"
 
-#: ../src/common/paper.cpp:218
+#: ../src/common/paper.cpp:215
 msgid "A1 sheet, 594 x 841 mm"
 msgstr "A1 sayfa, 594 x 841 mm"
 
-#: ../src/common/paper.cpp:159
+#: ../src/common/paper.cpp:156
 msgid "A2 420 x 594 mm"
 msgstr "A2 420 x 594 mm"
 
-#: ../src/common/paper.cpp:156
+#: ../src/common/paper.cpp:153
 msgid "A3 Extra 322 x 445 mm"
 msgstr "A3 Ekstra 322 x 445 mm"
 
-#: ../src/common/paper.cpp:161
+#: ../src/common/paper.cpp:158
 msgid "A3 Extra Transverse 322 x 445 mm"
 msgstr "A3 Ekstra Enine 322 x 445 mm"
 
-#: ../src/common/paper.cpp:170
+#: ../src/common/paper.cpp:167
 msgid "A3 Rotated 420 x 297 mm"
 msgstr "A3 Çevrilmiş 420 x 297 mm"
 
-#: ../src/common/paper.cpp:160
+#: ../src/common/paper.cpp:157
 msgid "A3 Transverse 297 x 420 mm"
 msgstr "A3 Enine 297 x 420 mm"
 
-#: ../src/common/paper.cpp:106
+#: ../src/common/paper.cpp:103
 msgid "A3 sheet, 297 x 420 mm"
 msgstr "A3 sayfa, 297 x 420 mm"
 
-#: ../src/common/paper.cpp:146
+#: ../src/common/paper.cpp:143
 msgid "A4 Extra 9.27 x 12.69 in"
 msgstr "A4 Ekstra 9.27 x 12.69 inç"
 
-#: ../src/common/paper.cpp:153
+#: ../src/common/paper.cpp:150
 msgid "A4 Plus 210 x 330 mm"
 msgstr "A4 Artı 210 x 330 mm"
 
-#: ../src/common/paper.cpp:171
+#: ../src/common/paper.cpp:168
 msgid "A4 Rotated 297 x 210 mm"
 msgstr "A4 Çevrilmiş 297 x 210 mm"
 
-#: ../src/common/paper.cpp:148
+#: ../src/common/paper.cpp:145
 msgid "A4 Transverse 210 x 297 mm"
 msgstr "A4 Enine 210 x 297 mm"
 
-#: ../src/common/paper.cpp:97
+#: ../src/common/paper.cpp:94
 msgid "A4 sheet, 210 x 297 mm"
 msgstr "A4 sayfa, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:107
+#: ../src/common/paper.cpp:104
 msgid "A4 small sheet, 210 x 297 mm"
 msgstr "A4 küçük sayfa, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:157
+#: ../src/common/paper.cpp:154
 msgid "A5 Extra 174 x 235 mm"
 msgstr "A5 Ekstra 174 x 235 mm"
 
-#: ../src/common/paper.cpp:172
+#: ../src/common/paper.cpp:169
 msgid "A5 Rotated 210 x 148 mm"
 msgstr "A5 Çevrilmiş 210 x 148 mm"
 
-#: ../src/common/paper.cpp:154
+#: ../src/common/paper.cpp:151
 msgid "A5 Transverse 148 x 210 mm"
 msgstr "A5 Enine 148 x 210 mm"
 
-#: ../src/common/paper.cpp:108
+#: ../src/common/paper.cpp:105
 msgid "A5 sheet, 148 x 210 mm"
 msgstr "A5 sayfa, 148 x 210 mm"
 
-#: ../src/common/paper.cpp:164
+#: ../src/common/paper.cpp:161
 msgid "A6 105 x 148 mm"
 msgstr "A6 105 x 148 mm"
 
-#: ../src/common/paper.cpp:177
+#: ../src/common/paper.cpp:174
 msgid "A6 Rotated 148 x 105 mm"
 msgstr "A6 Çevrilmiş 148 x 105 mm"
 
-#: ../src/generic/fontdlgg.cpp:83 ../src/richtext/richtextformatdlg.cpp:529
-#: ../src/osx/carbon/fontdlg.cpp:153
+#: ../src/osx/carbon/fontdlg.cpp:150 ../src/generic/fontdlgg.cpp:79
+#: ../src/richtext/richtextformatdlg.cpp:521
 msgid "ABCDEFGabcdefg12345"
 msgstr "ABCDEFGabcdefg12345"
 
-#: ../src/richtext/richtextsymboldlg.cpp:458 ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
 msgid "ASCII"
 msgstr "ASCII"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "About"
 msgstr "Hakkında"
 
-#: ../src/generic/aboutdlgg.cpp:140 ../src/osx/menu_osx.cpp:558
-#: ../src/msw/aboutdlg.cpp:64
+#: ../src/osx/menu_osx.cpp:450 ../src/generic/aboutdlgg.cpp:137
+#: ../src/msw/aboutdlg.cpp:61
 #, c-format
 msgid "About %s"
 msgstr "%s Hakkında"
 
-#: ../src/osx/menu_osx.cpp:560
+#: ../src/osx/menu_osx.cpp:452
 msgid "About..."
 msgstr "Hakkında..."
 
@@ -1202,37 +1201,37 @@ msgid "Absolute"
 msgstr "Mutlak"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:873
+#: ../src/propgrid/advprops.cpp:774
 msgid "ActiveBorder"
 msgstr "EtkinKenarlık"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:874
+#: ../src/propgrid/advprops.cpp:775
 msgid "ActiveCaption"
 msgstr "EtkinBaşlık"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "Actual Size"
 msgstr "Geçerli Boyut"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:140 ../src/common/accelcmn.cpp:81
+#: ../src/common/stockitem.cpp:137 ../src/common/accelcmn.cpp:78
 msgid "Add"
 msgstr "Ekle"
 
-#: ../src/richtext/richtextbuffer.cpp:11455
+#: ../src/richtext/richtextbuffer.cpp:11454
 msgid "Add Column"
 msgstr "Sütun Ekle"
 
-#: ../src/richtext/richtextbuffer.cpp:11392
+#: ../src/richtext/richtextbuffer.cpp:11391
 msgid "Add Row"
 msgstr "Satır Ekle"
 
-#: ../src/html/helpwnd.cpp:432
+#: ../src/html/helpwnd.cpp:430
 msgid "Add current page to bookmarks"
 msgstr "Geçerli sayfayı yer imlerine ekle"
 
-#: ../src/generic/colrdlgg.cpp:366
+#: ../src/generic/colrdlgg.cpp:386
 msgid "Add to custom colours"
 msgstr "Özel renklere ekle"
 
@@ -1244,12 +1243,12 @@ msgstr "AddToPropertyCollection işlevi, genel bir erişici üzerinden çağrıl
 msgid "AddToPropertyCollection called w/o valid adder"
 msgstr "AddToPropertyCollection işlevi, geçerli bir ekleyici olmadançağrıldı"
 
-#: ../src/html/helpctrl.cpp:159
+#: ../src/html/helpctrl.cpp:155
 #, c-format
 msgid "Adding book %s"
 msgstr "%s kitabı ekleniyor"
 
-#: ../src/common/preferencescmn.cpp:43
+#: ../src/common/preferencescmn.cpp:40
 msgid "Advanced"
 msgstr "Gelişmiş"
 
@@ -1257,11 +1256,11 @@ msgstr "Gelişmiş"
 msgid "After a paragraph:"
 msgstr "Paragraftan sonra:"
 
-#: ../src/common/stockitem.cpp:172
+#: ../src/common/stockitem.cpp:169
 msgid "Align Left"
 msgstr "Sola Hizala"
 
-#: ../src/common/stockitem.cpp:173
+#: ../src/common/stockitem.cpp:170
 msgid "Align Right"
 msgstr "Sağa Hizala"
 
@@ -1269,40 +1268,40 @@ msgstr "Sağa Hizala"
 msgid "Alignment"
 msgstr "Hizalama"
 
-#: ../src/generic/prntdlgg.cpp:215
+#: ../src/generic/prntdlgg.cpp:208
 msgid "All"
 msgstr "Tümü"
 
-#: ../src/generic/filectrlg.cpp:1197 ../src/common/fldlgcmn.cpp:107
+#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1186
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Tüm dosyalar (%s)|%s"
 
-#: ../include/wx/defs.h:2886
+#: ../include/wx/defs.h:2582
 msgid "All files (*)|*"
 msgstr "Tüm dosyalar (*)|*"
 
-#: ../include/wx/defs.h:2883
+#: ../include/wx/defs.h:2579
 msgid "All files (*.*)|*.*"
 msgstr "Tüm dosyalar (*.*)|*.*"
 
-#: ../src/richtext/richtextstyles.cpp:1061
+#: ../src/richtext/richtextstyles.cpp:1058
 msgid "All styles"
 msgstr "Tüm biçemler"
 
-#: ../src/propgrid/manager.cpp:1528
+#: ../src/propgrid/manager.cpp:1544
 msgid "Alphabetic Mode"
 msgstr "Alfabetik Kip"
 
-#: ../src/common/xtistrm.cpp:425
+#: ../src/common/xtistrm.cpp:422
 msgid "Already Registered Object passed to SetObjectClassInfo"
 msgstr "SetObjectClassInfo işlevi zaten kaydedilmiş bir nesne ile çağrıldı"
 
-#: ../src/unix/dialup.cpp:353
+#: ../src/unix/dialup.cpp:352
 msgid "Already dialling ISP."
 msgstr "ISP zaten aranıyor."
 
-#: ../src/common/accelcmn.cpp:331 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/accelcmn.cpp:345 ../src/univ/themes/win32.cpp:3753
 msgid "Alt+"
 msgstr "Alt+"
 
@@ -1311,34 +1310,34 @@ msgstr "Alt+"
 msgid "An optional corner radius for adding rounded corners."
 msgstr "Yuvarlak köşeler eklemek için isteğe bağlı köşe yarıçapı."
 
-#: ../src/common/debugrpt.cpp:576
+#: ../src/common/debugrpt.cpp:577
 msgid "And includes the following files:\n"
 msgstr "Ve aşağıdaki dosyaları içeriyor:\n"
 
-#: ../src/generic/animateg.cpp:162
+#: ../src/generic/animateg.cpp:145
 #, c-format
 msgid "Animation file is not of type %ld."
 msgstr "Canlandırma dosyası %ld türünde değil."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:872
+#: ../src/propgrid/advprops.cpp:773
 msgid "AppWorkspace"
 msgstr "UygulamaAlanı"
 
-#: ../src/generic/logg.cpp:1014
+#: ../src/generic/logg.cpp:1011
 #, c-format
 msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
 msgstr "'%s' günlük dosyasına eklensin ([Hayır] seçilirse üzerine yazılacak)."
 
-#: ../src/osx/menu_osx.cpp:577 ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:469 ../src/osx/menu_osx.cpp:477
 msgid "Application"
 msgstr "Uygulama"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "Apply"
 msgstr "Uygula"
 
-#: ../src/propgrid/advprops.cpp:1609
+#: ../src/propgrid/advprops.cpp:1515
 msgid "Aqua"
 msgstr "Deniz Mavisi"
 
@@ -1347,29 +1346,29 @@ msgstr "Deniz Mavisi"
 msgid "Arabic"
 msgstr "Arapça"
 
-#: ../src/common/fmapbase.cpp:153
+#: ../src/common/fmapbase.cpp:150
 msgid "Arabic (ISO-8859-6)"
 msgstr "Arapça (ISO-8859-6)"
 
-#: ../src/msw/ole/automtn.cpp:672
+#: ../src/msw/ole/automtn.cpp:663
 #, c-format
 msgid "Argument %u not found."
 msgstr "%u argümanı bulunamadı."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1753
+#: ../src/propgrid/advprops.cpp:1654
 msgid "Arrow"
 msgstr "Ok"
 
-#: ../src/generic/aboutdlgg.cpp:184
+#: ../src/generic/aboutdlgg.cpp:181
 msgid "Artists"
 msgstr "Sanatçılar"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "Ascending"
 msgstr "Artan"
 
-#: ../src/generic/filectrlg.cpp:433
+#: ../src/generic/filectrlg.cpp:429
 msgid "Attributes"
 msgstr "Öznitelikler"
 
@@ -1379,90 +1378,90 @@ msgstr "Öznitelikler"
 msgid "Available fonts."
 msgstr "Kullanılabilecek yazı türleri."
 
-#: ../src/common/paper.cpp:137
+#: ../src/common/paper.cpp:134
 msgid "B4 (ISO) 250 x 353 mm"
 msgstr "B4 (ISO) 250 x 353 mm"
 
-#: ../src/common/paper.cpp:173
+#: ../src/common/paper.cpp:170
 msgid "B4 (JIS) Rotated 364 x 257 mm"
 msgstr "B4 (JIS) Çevrilmiş 364 x 257 mm"
 
-#: ../src/common/paper.cpp:127
+#: ../src/common/paper.cpp:124
 msgid "B4 Envelope, 250 x 353 mm"
 msgstr "B4 Zarf, 250 x 353 mm"
 
-#: ../src/common/paper.cpp:109
+#: ../src/common/paper.cpp:106
 msgid "B4 sheet, 250 x 354 mm"
 msgstr "B4 sayfa, 250 x 354 mm"
 
-#: ../src/common/paper.cpp:158
+#: ../src/common/paper.cpp:155
 msgid "B5 (ISO) Extra 201 x 276 mm"
 msgstr "B5 (ISO) Ekstra 201 x 276 mm"
 
-#: ../src/common/paper.cpp:174
+#: ../src/common/paper.cpp:171
 msgid "B5 (JIS) Rotated 257 x 182 mm"
 msgstr "B5 (JIS) Çevrilmiş 257 x 182 mm"
 
-#: ../src/common/paper.cpp:155
+#: ../src/common/paper.cpp:152
 msgid "B5 (JIS) Transverse 182 x 257 mm"
 msgstr "B5 (JIS) Enine 182 x 257 mm"
 
-#: ../src/common/paper.cpp:128
+#: ../src/common/paper.cpp:125
 msgid "B5 Envelope, 176 x 250 mm"
 msgstr "B5 Zarf, 176 x 250 mm"
 
-#: ../src/common/paper.cpp:110
+#: ../src/common/paper.cpp:107
 msgid "B5 sheet, 182 x 257 millimeter"
 msgstr "B5 sayfa, 182 x 257 mm"
 
-#: ../src/common/paper.cpp:182
+#: ../src/common/paper.cpp:179
 msgid "B6 (JIS) 128 x 182 mm"
 msgstr "B6 (JIS) 128 x 182 mm"
 
-#: ../src/common/paper.cpp:183
+#: ../src/common/paper.cpp:180
 msgid "B6 (JIS) Rotated 182 x 128 mm"
 msgstr "B6 (JIS) Çevrilmiş 182 x 128 mm"
 
-#: ../src/common/paper.cpp:129
+#: ../src/common/paper.cpp:126
 msgid "B6 Envelope, 176 x 125 mm"
 msgstr "B6 Zarf, 176 x 125 mm"
 
-#: ../src/common/imagbmp.cpp:531 ../src/common/imagbmp.cpp:561
-#: ../src/common/imagbmp.cpp:576
+#: ../src/common/imagbmp.cpp:528 ../src/common/imagbmp.cpp:558
+#: ../src/common/imagbmp.cpp:573
 msgid "BMP: Couldn't allocate memory."
 msgstr "BMP: bellek ayrılamadı."
 
-#: ../src/common/imagbmp.cpp:100
+#: ../src/common/imagbmp.cpp:97
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: Geçersiz görüntü kaydedilemedi."
 
-#: ../src/common/imagbmp.cpp:356
+#: ../src/common/imagbmp.cpp:353
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: RGB renk haritası yazılamadı."
 
-#: ../src/common/imagbmp.cpp:490
+#: ../src/common/imagbmp.cpp:487
 msgid "BMP: Couldn't write data."
 msgstr "BMP: Veri yazılamadı."
 
-#: ../src/common/imagbmp.cpp:246
+#: ../src/common/imagbmp.cpp:243
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: Dosya (Bitmap) başlık bilgisi yazılamadı."
 
-#: ../src/common/imagbmp.cpp:269
+#: ../src/common/imagbmp.cpp:266
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: Dosya (BitmapInfo) başlık bilgisi yazılamadı."
 
-#: ../src/common/imagbmp.cpp:140
+#: ../src/common/imagbmp.cpp:137
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage için wxPalette yok."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:142 ../src/common/accelcmn.cpp:52
+#: ../src/common/stockitem.cpp:139 ../src/common/accelcmn.cpp:49
 msgid "Back"
 msgstr "Geri"
 
+#: ../src/richtext/richtextformatdlg.cpp:377
 #: ../src/richtext/richtextbackgroundpage.cpp:148
-#: ../src/richtext/richtextformatdlg.cpp:384
 msgid "Background"
 msgstr "Art alan"
 
@@ -1470,20 +1469,20 @@ msgstr "Art alan"
 msgid "Background &colour:"
 msgstr "Art alan &rengi:"
 
-#: ../src/osx/carbon/fontdlg.cpp:220
+#: ../src/osx/carbon/fontdlg.cpp:217
 msgid "Background colour"
 msgstr "Art alan rengi"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:52
+#: ../src/common/accelcmn.cpp:49
 msgid "Backspace"
 msgstr "Geri silme"
 
-#: ../src/common/fmapbase.cpp:160
+#: ../src/common/fmapbase.cpp:157
 msgid "Baltic (ISO-8859-13)"
 msgstr "Baltık (ISO-8859-13)"
 
-#: ../src/common/fmapbase.cpp:151
+#: ../src/common/fmapbase.cpp:148
 msgid "Baltic (old) (ISO-8859-4)"
 msgstr "Baltık (eski) (ISO-8859-4)"
 
@@ -1496,25 +1495,25 @@ msgstr "Paragraftan önce:"
 msgid "Bitmap"
 msgstr "Bitmap"
 
-#: ../src/propgrid/advprops.cpp:1594
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Black"
 msgstr "Siyah"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1755
+#: ../src/propgrid/advprops.cpp:1656
 msgid "Blank"
 msgstr "Boş"
 
-#: ../src/propgrid/advprops.cpp:1603
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Blue"
 msgstr "Mavi"
 
-#: ../src/generic/colrdlgg.cpp:345
+#: ../src/generic/colrdlgg.cpp:365
 msgid "Blue:"
 msgstr "Mavi:"
 
-#: ../src/generic/fontdlgg.cpp:333 ../src/richtext/richtextfontpage.cpp:355
-#: ../src/osx/carbon/fontdlg.cpp:354 ../src/common/stockitem.cpp:143
+#: ../src/osx/carbon/fontdlg.cpp:351 ../src/common/stockitem.cpp:140
+#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:355
 msgid "Bold"
 msgstr "Kalın"
 
@@ -1523,31 +1522,35 @@ msgstr "Kalın"
 msgid "Border"
 msgstr "Kenarlık"
 
-#: ../src/richtext/richtextformatdlg.cpp:379
+#: ../src/richtext/richtextformatdlg.cpp:372
 msgid "Borders"
 msgstr "Kenarlıklar"
 
-#: ../src/richtext/richtextsizepage.cpp:288 ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141 ../src/richtext/richtextsizepage.cpp:288
 msgid "Bottom"
 msgstr "Alt"
 
-#: ../src/generic/prntdlgg.cpp:893
+#: ../src/generic/prntdlgg.cpp:886
 msgid "Bottom margin (mm):"
 msgstr "Alt kenar boşluğu (mm):"
 
-#: ../src/richtext/richtextbuffer.cpp:9383
+#: ../src/richtext/richtextbuffer.cpp:9380
 msgid "Box Properties"
 msgstr "Kutu Özellikleri"
 
-#: ../src/richtext/richtextstyles.cpp:1065
+#: ../src/richtext/richtextstyles.cpp:1062
 msgid "Box styles"
 msgstr "Kutu biçemleri"
 
-#: ../src/propgrid/advprops.cpp:1602
+#: ../src/osx/cocoa/menu.mm:292
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Brown"
 msgstr "Kahverengi"
 
-#: ../src/common/filepickercmn.cpp:43 ../src/common/filepickercmn.cpp:44
+#: ../src/common/filepickercmn.cpp:40 ../src/common/filepickercmn.cpp:41
 msgid "Browse"
 msgstr "Gözat"
 
@@ -1560,72 +1563,72 @@ msgstr "Madde İmi &Hizalaması:"
 msgid "Bullet style"
 msgstr "Madde imi biçemi"
 
-#: ../src/richtext/richtextformatdlg.cpp:359
+#: ../src/richtext/richtextformatdlg.cpp:352
 msgid "Bullets"
 msgstr "Madde imleri"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1756
+#: ../src/propgrid/advprops.cpp:1657
 msgid "Bullseye"
 msgstr "Öküz gözü"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:875
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonFace"
 msgstr "DüğmeÖnyüzü"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:876
+#: ../src/propgrid/advprops.cpp:777
 msgid "ButtonHighlight"
 msgstr "DüğmeVurgusu"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:877
+#: ../src/propgrid/advprops.cpp:778
 msgid "ButtonShadow"
 msgstr "DüğmeGölgesi"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:878
+#: ../src/propgrid/advprops.cpp:779
 msgid "ButtonText"
 msgstr "DüğmeMetni"
 
-#: ../src/common/paper.cpp:98
+#: ../src/common/paper.cpp:95
 msgid "C sheet, 17 x 22 in"
 msgstr "C sayfa, 17 x 22 inç"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "C&lear"
 msgstr "T&emizle"
 
-#: ../src/generic/fontdlgg.cpp:406
+#: ../src/generic/fontdlgg.cpp:403
 msgid "C&olour:"
 msgstr "&Renk:"
 
-#: ../src/common/paper.cpp:123
+#: ../src/common/paper.cpp:120
 msgid "C3 Envelope, 324 x 458 mm"
 msgstr "C3 Zarf, 324 x 458 mm"
 
-#: ../src/common/paper.cpp:124
+#: ../src/common/paper.cpp:121
 msgid "C4 Envelope, 229 x 324 mm"
 msgstr "C4 Zarf, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:122
+#: ../src/common/paper.cpp:119
 msgid "C5 Envelope, 162 x 229 mm"
 msgstr "C5 Zarf, 162 x 229 mm"
 
-#: ../src/common/paper.cpp:125
+#: ../src/common/paper.cpp:122
 msgid "C6 Envelope, 114 x 162 mm"
 msgstr "C6 Zarf, 114 x 162 mm"
 
-#: ../src/common/paper.cpp:126
+#: ../src/common/paper.cpp:123
 msgid "C65 Envelope, 114 x 229 mm"
 msgstr "C65 Zarf, 114 x 229 mm"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "CD-Rom"
 msgstr "CD-Rom"
 
-#: ../src/html/chm.cpp:815 ../src/html/chm.cpp:874
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:865
 msgid "CHM handler currently supports only local files!"
 msgstr "CHM işleyici şimdilik yalnız yerel dosyaları destekliyor!"
 
@@ -1633,190 +1636,194 @@ msgstr "CHM işleyici şimdilik yalnız yerel dosyaları destekliyor!"
 msgid "Ca&pitals"
 msgstr "&Büyük harfler"
 
-#: ../src/common/cmdproc.cpp:267
+#: ../src/common/cmdproc.cpp:260
 msgid "Can't &Undo "
 msgstr "&Geri Alınamıyor "
 
-#: ../src/common/image.cpp:2824
+#: ../src/common/image.cpp:2924
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr "Aranamayan giriş için görsel biçimi kendiliğinden belirlenemiyor."
 
-#: ../src/msw/registry.cpp:506
+#: ../src/msw/registry.cpp:495
 #, c-format
 msgid "Can't close registry key '%s'"
 msgstr "'%s' kayıt anahtarı kapatılamadı"
 
-#: ../src/msw/registry.cpp:584
+#: ../src/msw/registry.cpp:573
 #, c-format
 msgid "Can't copy values of unsupported type %d."
 msgstr "Desteklenmeyen %d türünün değerleri kopyalanamadı."
 
-#: ../src/msw/registry.cpp:487
+#: ../src/msw/registry.cpp:476
 #, c-format
 msgid "Can't create registry key '%s'"
 msgstr "'%s' kayıt anahtarı oluşturulamadı"
 
-#: ../src/msw/thread.cpp:665
+#: ../src/msw/thread.cpp:657
 msgid "Can't create thread"
 msgstr "İş parçacığı oluşturulamadı"
 
-#: ../src/msw/window.cpp:3691
-#, c-format
-msgid "Can't create window of class %s"
-msgstr "%s sınıfının penceresi oluşturulamadı"
-
-#: ../src/msw/registry.cpp:777
+#: ../src/msw/registry.cpp:765
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "'%s' anahtarı silinemedi"
 
-#: ../src/msw/iniconf.cpp:458
+#: ../src/msw/iniconf.cpp:455
 #, c-format
 msgid "Can't delete the INI file '%s'"
 msgstr "'%s' INI dosyası silinemedi"
 
-#: ../src/msw/registry.cpp:805
+#: ../src/msw/registry.cpp:793
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "'%s' değeri '%s' anahtarından silinemiyor"
 
-#: ../src/msw/registry.cpp:1171
+#: ../src/msw/registry.cpp:1159
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "'%s' anahtarının alt anahtarları sayılamadı"
 
-#: ../src/msw/registry.cpp:1132
+#: ../src/msw/registry.cpp:1120
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "'%s' anahtarının değerleri sayılamadı"
 
-#: ../src/msw/registry.cpp:1389
+#: ../src/msw/registry.cpp:1377
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Desteklenmeyen %d türünün değeri verilemedi."
 
-#: ../src/common/ffile.cpp:254
+#: ../src/common/ffile.cpp:253
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "'%s' dosyasındaki geçerli konum bulunamadı"
 
-#: ../src/msw/registry.cpp:418
+#: ../src/msw/registry.cpp:407
 #, c-format
 msgid "Can't get info about registry key '%s'"
 msgstr "'%s' kayıt anahtarı hakkında bilgi alınamadı"
 
-#: ../src/common/zstream.cpp:346
+#: ../src/msw/webview_ie.cpp:1024
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "İş parçacığının önceliği ayarlanamadı"
+
+#: ../src/common/zstream.cpp:343
 msgid "Can't initialize zlib deflate stream."
 msgstr "Zlib sıkıştırma akışı başlatılamadı."
 
-#: ../src/common/zstream.cpp:185
+#: ../src/common/zstream.cpp:182
 msgid "Can't initialize zlib inflate stream."
 msgstr "Zlib ayıklama akışı başlatılamadı."
 
-#: ../src/msw/fswatcher.cpp:476
+#: ../src/msw/fswatcher.cpp:475
 #, c-format
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "\"%s\" klasörü bulunamadığından değişiklikleri izlenemiyor."
 
-#: ../src/msw/registry.cpp:454
+#: ../src/msw/registry.cpp:443
 #, c-format
 msgid "Can't open registry key '%s'"
 msgstr "'%s' kayıt anahtarı açılamadı"
 
-#: ../src/common/zstream.cpp:252
+#: ../src/common/zstream.cpp:249
 #, c-format
 msgid "Can't read from inflate stream: %s"
 msgstr "Ayıklama akışı okunamadı: %s"
 
-#: ../src/common/zstream.cpp:244
+#: ../src/common/zstream.cpp:241
 msgid "Can't read inflate stream: unexpected EOF in underlying stream."
 msgstr "Ayıklama akışı okunamadı: alt akışıta beklenmeyen dosya sonu."
 
-#: ../src/msw/registry.cpp:1064
+#: ../src/msw/registry.cpp:1052
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "'%s' değeri okunamadı"
 
-#: ../src/msw/registry.cpp:878 ../src/msw/registry.cpp:910
-#: ../src/msw/registry.cpp:975
+#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
+#: ../src/msw/registry.cpp:963
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "'%s' anahtarının değeri okunamadı"
 
-#: ../src/common/image.cpp:2620
+#: ../src/msw/webview_ie.cpp:1017
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/common/image.cpp:2715
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "Görüntü '%s' dosyasına kaydedilemedi: bilinmeyen uzantı."
 
-#: ../src/generic/logg.cpp:573 ../src/generic/logg.cpp:976
+#: ../src/generic/logg.cpp:570 ../src/generic/logg.cpp:973
 msgid "Can't save log contents to file."
 msgstr "Günlük içeriği dosyaya kaydedilemedi."
 
-#: ../src/msw/thread.cpp:629
+#: ../src/msw/thread.cpp:621
 msgid "Can't set thread priority"
 msgstr "İş parçacığının önceliği ayarlanamadı"
 
-#: ../src/msw/registry.cpp:896 ../src/msw/registry.cpp:938
-#: ../src/msw/registry.cpp:1081
+#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
+#: ../src/msw/registry.cpp:1069
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "'%s' değeri değiştirilemedi"
 
-#: ../src/unix/utilsunx.cpp:351
+#: ../src/unix/utilsunx.cpp:353
 msgid "Can't write to child process's stdin"
 msgstr "Alt işlem stdin yazılamadı"
 
-#: ../src/common/zstream.cpp:427
+#: ../src/common/zstream.cpp:424
 #, c-format
 msgid "Can't write to deflate stream: %s"
 msgstr "Sıkıştırma akışına yazılamadı: %s"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:279 ../src/richtext/richtextstyledlg.cpp:300
-#: ../src/common/stockitem.cpp:145 ../src/common/accelcmn.cpp:71
-#: ../src/msw/msgdlg.cpp:454 ../src/msw/progdlg.cpp:673
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:142
+#: ../src/common/accelcmn.cpp:68 ../src/motif/msgdlg.cpp:196
+#: ../src/gtk1/fontdlg.cpp:144 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/progdlg.cpp:940 ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "İptal"
 
-#: ../src/common/filefn.cpp:1261
+#: ../src/common/filefn.cpp:1149
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "'%s' dosyaları sayılamadı"
 
-#: ../src/msw/dir.cpp:263
+#: ../src/msw/dir.cpp:260
 #, c-format
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "'%s' klasöründeki dosyalar sayılamadı"
 
-#: ../src/msw/dialup.cpp:523
+#: ../src/msw/dialup.cpp:517
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Etkin çevirmeli bağlantı bulunamadı: %s"
 
-#: ../src/msw/dialup.cpp:827
+#: ../src/msw/dialup.cpp:821
 msgid "Cannot find the location of address book file"
 msgstr "Adres defteri dosyasının yeri bulunamadı"
 
-#: ../src/msw/ole/automtn.cpp:562
+#: ../src/msw/ole/automtn.cpp:553
 #, c-format
 msgid "Cannot get an active instance of \"%s\""
 msgstr "Çalışan bir \"%s\" kopyası bulunamadı"
 
-#: ../src/unix/threadpsx.cpp:1035
+#: ../src/unix/threadpsx.cpp:1053
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "Zamanlama ilkesi %d için öncelik aralığı alınamadı."
 
-#: ../src/unix/utilsunx.cpp:987
+#: ../src/unix/utilsunx.cpp:989
 msgid "Cannot get the hostname"
 msgstr "Sunucu adı alınamadı"
 
-#: ../src/unix/utilsunx.cpp:1023
+#: ../src/unix/utilsunx.cpp:1025
 msgid "Cannot get the official hostname"
 msgstr "Resmi sunucu adı alınamadı"
 
-#: ../src/msw/dialup.cpp:928
+#: ../src/msw/dialup.cpp:922
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Kapatılamadı - etkin çevirmeli bağlantı yok."
 
@@ -1824,126 +1831,126 @@ msgstr "Kapatılamadı - etkin çevirmeli bağlantı yok."
 msgid "Cannot initialize OLE"
 msgstr "OLE başlatılamadı"
 
-#: ../src/common/socket.cpp:853
+#: ../src/common/socket.cpp:850
 msgid "Cannot initialize sockets"
 msgstr "Soketler başlatılamadı"
 
-#: ../src/msw/volume.cpp:619
+#: ../src/msw/volume.cpp:627
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "'%s' içinden simge yüklenemedi."
 
-#: ../src/xrc/xmlres.cpp:360
+#: ../src/xrc/xmlres.cpp:358
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Kaynaklar '%s' dosyasından yüklenemedi."
 
-#: ../src/xrc/xmlres.cpp:742
+#: ../src/xrc/xmlres.cpp:740
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Kaynaklar '%s' dosyasından yüklenemedi."
 
-#: ../src/html/htmlfilt.cpp:137
+#: ../src/html/htmlfilt.cpp:134
 #, c-format
 msgid "Cannot open HTML document: %s"
 msgstr "%s HTML belgesi açılamadı"
 
-#: ../src/html/helpdata.cpp:667
+#: ../src/html/helpdata.cpp:660
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "%s HTML yardım kitabı açılamadı"
 
-#: ../src/html/helpdata.cpp:299
+#: ../src/html/helpdata.cpp:296
 #, c-format
 msgid "Cannot open contents file: %s"
 msgstr "%s içerik dosyası açılamadı"
 
-#: ../src/generic/dcpsg.cpp:1667
+#: ../src/generic/dcpsg.cpp:1665
 msgid "Cannot open file for PostScript printing!"
 msgstr "Dosya PostScript yazdırma için açılamadı!"
 
-#: ../src/html/helpdata.cpp:313
+#: ../src/html/helpdata.cpp:310
 #, c-format
 msgid "Cannot open index file: %s"
 msgstr "%s dizin dosyası açılamadı"
 
-#: ../src/xrc/xmlres.cpp:724
+#: ../src/xrc/xmlres.cpp:722
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "'%s' kaynak dosyası açılamadı."
 
-#: ../src/html/helpwnd.cpp:1534
+#: ../src/html/helpwnd.cpp:1532
 msgid "Cannot print empty page."
 msgstr "Boş sayfa basılamaz."
 
-#: ../src/msw/volume.cpp:507
+#: ../src/msw/volume.cpp:515
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "'%s' içinden tür adı okunamadı!"
 
-#: ../src/msw/thread.cpp:888
+#: ../src/msw/thread.cpp:894
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "%lx iş parçacığı sürdürülemiyor"
 
-#: ../src/unix/threadpsx.cpp:1016
+#: ../src/unix/threadpsx.cpp:1028
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "İş parçacığı zamanlama ilkesi alınamadı."
 
-#: ../src/common/intl.cpp:558
+#: ../src/common/intl.cpp:365
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "Yerel ayarlar \"%s\" diline çevrilemedi."
 
-#: ../src/unix/threadpsx.cpp:831 ../src/msw/thread.cpp:546
+#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
 msgid "Cannot start thread: error writing TLS."
 msgstr "İş parçacığı başlatılamadı: TLS yazma hatası."
 
-#: ../src/msw/thread.cpp:872
+#: ../src/msw/thread.cpp:864
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "%lx iş parçacığı beklemeye alınamadı"
 
-#: ../src/msw/thread.cpp:794
+#: ../src/msw/thread.cpp:786
 msgid "Cannot wait for thread termination"
 msgstr "İş parçacığının sonlanması beklenemiyor"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:75
+#: ../src/common/accelcmn.cpp:72
 msgid "Capital"
 msgstr "Büyük"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:879
+#: ../src/propgrid/advprops.cpp:780
 msgid "CaptionText"
 msgstr "BaşlıkMetni"
 
-#: ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:531
 msgid "Case sensitive"
 msgstr "Büyük küçük harfe duyarlı"
 
-#: ../src/propgrid/manager.cpp:1509
+#: ../src/propgrid/manager.cpp:1527
 msgid "Categorized Mode"
 msgstr "Kategorize Kip"
 
-#: ../src/richtext/richtextbuffer.cpp:9968
+#: ../src/richtext/richtextbuffer.cpp:9965
 msgid "Cell Properties"
 msgstr "Hücre Özellikleri"
 
-#: ../src/common/fmapbase.cpp:161
+#: ../src/common/fmapbase.cpp:158
 msgid "Celtic (ISO-8859-14)"
 msgstr "Keltçe (ISO-8859-14)"
 
-#: ../src/richtext/richtextindentspage.cpp:160
 #: ../src/richtext/richtextliststylepage.cpp:349
+#: ../src/richtext/richtextindentspage.cpp:160
 msgid "Cen&tred"
 msgstr "Or&talanmış"
 
-#: ../src/common/stockitem.cpp:170
+#: ../src/common/stockitem.cpp:167
 msgid "Centered"
 msgstr "Ortalanmış"
 
-#: ../src/common/fmapbase.cpp:149
+#: ../src/common/fmapbase.cpp:146
 msgid "Central European (ISO-8859-2)"
 msgstr "Orta Avrupa (ISO-8859-2)"
 
@@ -1952,10 +1959,10 @@ msgstr "Orta Avrupa (ISO-8859-2)"
 msgid "Centre"
 msgstr "Orta"
 
-#: ../src/richtext/richtextindentspage.cpp:162
-#: ../src/richtext/richtextindentspage.cpp:164
 #: ../src/richtext/richtextliststylepage.cpp:351
 #: ../src/richtext/richtextliststylepage.cpp:353
+#: ../src/richtext/richtextindentspage.cpp:162
+#: ../src/richtext/richtextindentspage.cpp:164
 msgid "Centre text."
 msgstr "Metni ortala."
 
@@ -1968,24 +1975,24 @@ msgstr "Ortalanmış"
 msgid "Ch&oose..."
 msgstr "S&eçin..."
 
-#: ../src/richtext/richtextbuffer.cpp:4354
+#: ../src/richtext/richtextbuffer.cpp:4351
 msgid "Change List Style"
 msgstr "Liste Biçemini Değiştir"
 
-#: ../src/richtext/richtextbuffer.cpp:3709
+#: ../src/richtext/richtextbuffer.cpp:3706
 msgid "Change Object Style"
 msgstr "Nesne Biçemini Değiştir"
 
-#: ../src/richtext/richtextbuffer.cpp:3982
-#: ../src/richtext/richtextbuffer.cpp:8129
+#: ../src/richtext/richtextbuffer.cpp:3979
+#: ../src/richtext/richtextbuffer.cpp:8125
 msgid "Change Properties"
 msgstr "Özellikleri Değiştir"
 
-#: ../src/richtext/richtextbuffer.cpp:3526
+#: ../src/richtext/richtextbuffer.cpp:3523
 msgid "Change Style"
 msgstr "Biçemi Değiştir"
 
-#: ../src/common/fileconf.cpp:341
+#: ../src/common/fileconf.cpp:335
 #, c-format
 msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
 msgstr ""
@@ -1998,11 +2005,11 @@ msgid "Changing current directory to \"%s\" failed"
 msgstr "Geçerli klasör \"%s\" olarak değiştirilemedi"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1757
+#: ../src/propgrid/advprops.cpp:1658
 msgid "Character"
 msgstr "Karakter"
 
-#: ../src/richtext/richtextstyles.cpp:1063
+#: ../src/richtext/richtextstyles.cpp:1060
 msgid "Character styles"
 msgstr "Karakter biçemleri"
 
@@ -2039,20 +2046,20 @@ msgstr "Madde imini parantez içine almak için işaretleyin."
 msgid "Check to indicate right-to-left text layout."
 msgstr "Sağdan sola yazı için işaretleyin."
 
-#: ../src/osx/carbon/fontdlg.cpp:356 ../src/osx/carbon/fontdlg.cpp:358
+#: ../src/osx/carbon/fontdlg.cpp:353 ../src/osx/carbon/fontdlg.cpp:355
 msgid "Check to make the font bold."
 msgstr "Koyu yazı türü için işaretleyin."
 
-#: ../src/osx/carbon/fontdlg.cpp:363 ../src/osx/carbon/fontdlg.cpp:365
+#: ../src/osx/carbon/fontdlg.cpp:360 ../src/osx/carbon/fontdlg.cpp:362
 msgid "Check to make the font italic."
 msgstr "Yatık yazı türü için işaretleyin."
 
-#: ../src/osx/carbon/fontdlg.cpp:372 ../src/osx/carbon/fontdlg.cpp:374
+#: ../src/osx/carbon/fontdlg.cpp:369 ../src/osx/carbon/fontdlg.cpp:371
 msgid "Check to make the font underlined."
 msgstr "Altı çizili yazı türü için işaretleyin."
 
-#: ../src/richtext/richtextstyledlg.cpp:289
-#: ../src/richtext/richtextstyledlg.cpp:291
+#: ../src/richtext/richtextstyledlg.cpp:285
+#: ../src/richtext/richtextstyledlg.cpp:287
 msgid "Check to restart numbering."
 msgstr "Yeniden numaralandırmak için işaretleyin."
 
@@ -2086,51 +2093,51 @@ msgstr "Metni üst karaktere dönüştürmek için işaretleyin."
 msgid "Check to suppress hyphenation."
 msgstr "Hecelemeyi engellemek için işaretleyin."
 
-#: ../src/msw/dialup.cpp:763
+#: ../src/msw/dialup.cpp:757
 msgid "Choose ISP to dial"
 msgstr "Aranacak servis sağlayıcıyı seçin"
 
-#: ../src/propgrid/props.cpp:1922
+#: ../src/propgrid/props.cpp:1904
 msgid "Choose a directory:"
 msgstr "Bir klasör seçin:"
 
-#: ../src/propgrid/props.cpp:1975
+#: ../src/propgrid/props.cpp:2199
 msgid "Choose a file"
 msgstr "Bir dosya seçin"
 
-#: ../src/generic/colrdlgg.cpp:158 ../src/gtk/colordlg.cpp:54
+#: ../src/generic/colrdlgg.cpp:156 ../src/gtk/colordlg.cpp:49
 msgid "Choose colour"
 msgstr "Renk seçin"
 
-#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/gtk1/fontdlg.cpp:125 ../src/generic/fontpickerg.cpp:47
+#: ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Yazı türü seçin"
 
-#: ../src/common/module.cpp:74
+#: ../src/common/module.cpp:71
 #, c-format
 msgid "Circular dependency involving module \"%s\" detected."
 msgstr "\"%s\" modülü ile döngüsel bağlılık algılandı."
 
-#: ../src/aui/tabmdi.cpp:108 ../src/generic/mdig.cpp:97
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
 msgid "Cl&ose"
 msgstr "Kapa&t"
 
-#: ../src/msw/ole/automtn.cpp:684
+#: ../src/msw/ole/automtn.cpp:675
 msgid "Class not registered."
 msgstr "Sınıf kaydedilmemiş."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:147 ../src/common/accelcmn.cpp:72
+#: ../src/common/stockitem.cpp:144 ../src/common/accelcmn.cpp:69
 msgid "Clear"
 msgstr "Temizle"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "Clear the log contents"
 msgstr "Günlük içeriğini temizleyin"
 
-#: ../src/richtext/richtextstyledlg.cpp:252
-#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:248
+#: ../src/richtext/richtextstyledlg.cpp:250
 msgid "Click to apply the selected style."
 msgstr "Seçili biçemi uygulamak için tıklayın."
 
@@ -2141,15 +2148,15 @@ msgstr "Seçili biçemi uygulamak için tıklayın."
 msgid "Click to browse for a symbol."
 msgstr "Bir simge seçmek için tıklayın."
 
-#: ../src/osx/carbon/fontdlg.cpp:403 ../src/osx/carbon/fontdlg.cpp:405
+#: ../src/osx/carbon/fontdlg.cpp:400 ../src/osx/carbon/fontdlg.cpp:402
 msgid "Click to cancel changes to the font."
 msgstr "Yazı türü değişikliklerinden vazgeçmek için tıklayın."
 
-#: ../src/generic/fontdlgg.cpp:472 ../src/generic/fontdlgg.cpp:491
+#: ../src/generic/fontdlgg.cpp:468 ../src/generic/fontdlgg.cpp:487
 msgid "Click to cancel the font selection."
 msgstr "Yazı türü seçiminden vazgeçmek için tıklayın."
 
-#: ../src/osx/carbon/fontdlg.cpp:384 ../src/osx/carbon/fontdlg.cpp:386
+#: ../src/osx/carbon/fontdlg.cpp:381 ../src/osx/carbon/fontdlg.cpp:383
 msgid "Click to change the font colour."
 msgstr "Metin rengini değiştirmek için tıklayın."
 
@@ -2168,37 +2175,37 @@ msgstr "Metin rengini değiştirmek için tıklayın."
 msgid "Click to choose the font for this level."
 msgstr "Bu düzeyin yazı türünü seçmek için tıklayın."
 
-#: ../src/richtext/richtextstyledlg.cpp:279
-#: ../src/richtext/richtextstyledlg.cpp:281
+#: ../src/richtext/richtextstyledlg.cpp:275
+#: ../src/richtext/richtextstyledlg.cpp:277
 msgid "Click to close this window."
 msgstr "Pencereyi kapatmak için tıklayın."
 
-#: ../src/osx/carbon/fontdlg.cpp:410 ../src/osx/carbon/fontdlg.cpp:412
+#: ../src/osx/carbon/fontdlg.cpp:407 ../src/osx/carbon/fontdlg.cpp:409
 msgid "Click to confirm changes to the font."
 msgstr "Yazı türündeki değişiklikleri onaylamak için tıklayın."
 
-#: ../src/generic/fontdlgg.cpp:477 ../src/generic/fontdlgg.cpp:479
-#: ../src/generic/fontdlgg.cpp:484 ../src/generic/fontdlgg.cpp:486
+#: ../src/generic/fontdlgg.cpp:473 ../src/generic/fontdlgg.cpp:475
+#: ../src/generic/fontdlgg.cpp:480 ../src/generic/fontdlgg.cpp:482
 msgid "Click to confirm the font selection."
 msgstr "Yazı türü seçimini onaylamak için tıklayın."
 
-#: ../src/richtext/richtextstyledlg.cpp:244
-#: ../src/richtext/richtextstyledlg.cpp:246
+#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:242
 msgid "Click to create a new box style."
 msgstr "Yeni bir kutu biçemi oluşturmak için tıklayın."
 
-#: ../src/richtext/richtextstyledlg.cpp:226
-#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:224
 msgid "Click to create a new character style."
 msgstr "Yeni bir karakter biçemi oluşturmak için tıklayın."
 
-#: ../src/richtext/richtextstyledlg.cpp:238
-#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:236
 msgid "Click to create a new list style."
 msgstr "Yeni bir liste biçemi oluşturmak için tıklayın."
 
-#: ../src/richtext/richtextstyledlg.cpp:232
-#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:230
 msgid "Click to create a new paragraph style."
 msgstr "Yeni bir paragraf biçemi oluşturmak için tıklayın."
 
@@ -2212,8 +2219,8 @@ msgstr "Yeni bir sekme konumu oluşturmak için tıklayın."
 msgid "Click to delete all tab positions."
 msgstr "Tüm sekme konumlarını silmek için tıklayın."
 
-#: ../src/richtext/richtextstyledlg.cpp:270
-#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:268
 msgid "Click to delete the selected style."
 msgstr "Seçili biçemi silmek için tıklayın."
 
@@ -2222,25 +2229,25 @@ msgstr "Seçili biçemi silmek için tıklayın."
 msgid "Click to delete the selected tab position."
 msgstr "Seçili sekme konumunu silmek için tıklayın."
 
-#: ../src/richtext/richtextstyledlg.cpp:264
-#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:262
 msgid "Click to edit the selected style."
 msgstr "Seçili biçemi düzenlemek için tıklayın."
 
-#: ../src/richtext/richtextstyledlg.cpp:258
-#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:256
 msgid "Click to rename the selected style."
 msgstr "Seçili biçemi yeniden adlandırmak için tıklayın."
 
-#: ../src/generic/dbgrptg.cpp:97 ../src/generic/progdlgg.cpp:759
-#: ../src/richtext/richtextstyledlg.cpp:277
-#: ../src/richtext/richtextsymboldlg.cpp:476 ../src/common/stockitem.cpp:148
-#: ../src/msw/progdlg.cpp:170 ../src/msw/progdlg.cpp:679
-#: ../src/html/helpdlg.cpp:90
+#: ../src/common/stockitem.cpp:145 ../src/generic/dbgrptg.cpp:94
+#: ../src/generic/progdlgg.cpp:781 ../src/msw/progdlg.cpp:211
+#: ../src/msw/progdlg.cpp:946 ../src/html/helpdlg.cpp:87
+#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextstyledlg.cpp:273
 msgid "Close"
 msgstr "Kapat"
 
-#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:98
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
 msgid "Close All"
 msgstr "Tümünü Kapat"
 
@@ -2248,55 +2255,55 @@ msgstr "Tümünü Kapat"
 msgid "Close current document"
 msgstr "Geçerli belgeyi kapat"
 
-#: ../src/generic/logg.cpp:516
+#: ../src/generic/logg.cpp:513
 msgid "Close this window"
 msgstr "Bu pencereyi kapat"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6006
+#: ../src/generic/datavgen.cpp:6811
 msgid "Collapse"
 msgstr "Daralt"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "Color"
 msgstr "Renk"
 
-#: ../src/richtext/richtextformatdlg.cpp:776
+#: ../src/richtext/richtextformatdlg.cpp:768
 msgid "Colour"
 msgstr "Renk"
 
-#: ../src/msw/colordlg.cpp:158
+#: ../src/msw/colordlg.cpp:227
 #, c-format
 msgid "Colour selection dialog failed with error %0lx."
 msgstr "Renk seçimi penceresi %0lx hatasıyla sonlandı."
 
-#: ../src/osx/carbon/fontdlg.cpp:380
+#: ../src/osx/carbon/fontdlg.cpp:377
 msgid "Colour:"
 msgstr "Renk:"
 
-#: ../src/generic/datavgen.cpp:6077
+#: ../src/generic/datavgen.cpp:6882
 #, c-format
 msgid "Column %u"
 msgstr "Sütun %u"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:114
+#: ../src/common/accelcmn.cpp:112
 msgid "Command"
 msgstr "Komut"
 
-#: ../src/common/init.cpp:196
+#: ../src/common/init.cpp:193
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
 "ignored."
 msgstr "%d komut satırı değişkeni Unikoda çevrilemediğinden yok sayılacak."
 
-#: ../src/msw/fontdlg.cpp:120
+#: ../src/msw/fontdlg.cpp:170
 #, c-format
 msgid "Common dialog failed with error code %0lx."
 msgstr "Ortak diyalog %0lx hata koduyla sonlandı."
 
-#: ../src/gtk/window.cpp:4649
+#: ../src/gtk/window.cpp:5653
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
@@ -2304,11 +2311,11 @@ msgstr ""
 "Sistemin birleştirme (compositing) desteği etkin değil. Lütfen Pencere "
 "Yöneticinizden etkinleştirin."
 
-#: ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:1549
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Sıkıştırılmış HTML Yardım dosyası (*.chm)|*.chm|"
 
-#: ../src/generic/dirctrlg.cpp:444
+#: ../src/generic/dirctrlg.cpp:410
 msgid "Computer"
 msgstr "Bilgisayarım"
 
@@ -2317,53 +2324,57 @@ msgstr "Bilgisayarım"
 msgid "Config entry name cannot start with '%c'."
 msgstr "Ayar kaydının adı '%c' ile başlayamaz."
 
-#: ../src/generic/filedlgg.cpp:349 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
 msgid "Confirm"
 msgstr "Onayla"
 
-#: ../src/html/htmlwin.cpp:566
+#: ../src/html/htmlwin.cpp:569
 msgid "Connecting..."
 msgstr "Bağlanılıyor..."
 
-#: ../src/html/helpwnd.cpp:475
+#: ../src/html/helpwnd.cpp:473
 msgid "Contents"
 msgstr "İçerik"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:880
+#: ../src/propgrid/advprops.cpp:781
 msgid "ControlDark"
 msgstr "DenetimKoyu"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:881
+#: ../src/propgrid/advprops.cpp:782
 msgid "ControlLight"
 msgstr "DenetimAçık"
 
-#: ../src/common/strconv.cpp:2262
+#: ../src/common/strconv.cpp:2208
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "'%s' karakter kümesine dönüşüm çalışmıyor."
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "Convert"
 msgstr "Dönüştür"
 
-#: ../src/html/htmlwin.cpp:1079
+#: ../src/html/htmlwin.cpp:1020
 #, c-format
 msgid "Copied to clipboard:\"%s\""
 msgstr "\"%s\" panoya kopyalandı."
 
-#: ../src/generic/prntdlgg.cpp:247
+#: ../src/generic/prntdlgg.cpp:240
 msgid "Copies:"
 msgstr "Kopya sayısı:"
 
-#: ../src/common/stockitem.cpp:150 ../src/stc/stc_i18n.cpp:18
+#: ../src/common/stockitem.cpp:147 ../src/stc/stc_i18n.cpp:18
 msgid "Copy"
 msgstr "Kopyala"
 
-#: ../src/common/stockitem.cpp:258
+#: ../src/common/stockitem.cpp:255
 msgid "Copy selection"
 msgstr "Seçimi kopyala"
+
+#: ../src/generic/grid.cpp:5945
+msgid "Copying more than one selected block to clipboard is not supported."
+msgstr ""
 
 #: ../src/richtext/richtextborderspage.cpp:566
 #: ../src/richtext/richtextborderspage.cpp:601
@@ -2374,194 +2385,191 @@ msgstr "Köşe"
 msgid "Corner &radius:"
 msgstr "Köşe ça&pı:"
 
-#: ../src/html/chm.cpp:718
+#: ../src/html/chm.cpp:711
 #, c-format
 msgid "Could not create temporary file '%s'"
 msgstr "'%s' geçici dosyası oluşturulamadı."
 
-#: ../src/html/chm.cpp:273
+#: ../src/html/chm.cpp:270
 #, c-format
 msgid "Could not extract %s into %s: %s"
 msgstr "%s %s içine ayıklanamadı: %s"
 
-#: ../src/generic/tabg.cpp:1048
+#: ../src/generic/tabg.cpp:1045
 msgid "Could not find tab for id"
 msgstr "Kodun sekmesi bulunamadı."
 
-#: ../src/gtk/notifmsg.cpp:108
-msgid "Could not initalize libnotify."
-msgstr "Libnotify başlatılamadı."
-
-#: ../src/html/chm.cpp:444
+#: ../src/html/chm.cpp:437
 #, c-format
 msgid "Could not locate file '%s'."
 msgstr "'%s' dosyası bulunamadı."
 
-#: ../src/common/filefn.cpp:1403
+#: ../src/msw/graphicsd2d.cpp:604
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/common/filefn.cpp:1291
 msgid "Could not set current working directory"
 msgstr "Geçerli çalışma klasörü ayarlanamadı."
 
-#: ../src/common/prntbase.cpp:2015
+#: ../src/common/prntbase.cpp:2037
 msgid "Could not start document preview."
 msgstr "Belge önizlemesi başlatılamadı."
 
-#: ../src/generic/printps.cpp:178 ../src/msw/printwin.cpp:210
-#: ../src/gtk/print.cpp:1132
+#: ../src/generic/printps.cpp:159 ../src/msw/printwin.cpp:184
+#: ../src/gtk/print.cpp:1129
 msgid "Could not start printing."
 msgstr "Yazdırma başlatılamadı."
 
-#: ../src/common/wincmn.cpp:2125
+#: ../src/common/wincmn.cpp:2126
 msgid "Could not transfer data to window"
 msgstr "Veri pencereye aktarılamadı."
 
-#: ../src/msw/imaglist.cpp:187 ../src/msw/imaglist.cpp:224
-#: ../src/msw/imaglist.cpp:249 ../src/msw/dragimag.cpp:185
-#: ../src/msw/dragimag.cpp:220
+#: ../src/msw/imaglist.cpp:223 ../src/msw/imaglist.cpp:245
+#: ../src/msw/imaglist.cpp:270 ../src/msw/dragimag.cpp:182
+#: ../src/msw/dragimag.cpp:217
 msgid "Couldn't add an image to the image list."
 msgstr "Görsel listesine bir görsel eklenemedi."
 
-#: ../src/osx/glcanvas_osx.cpp:414 ../src/unix/glx11.cpp:558
-#: ../src/msw/glcanvas.cpp:616
+#: ../src/osx/glcanvas_osx.cpp:411 ../src/msw/glcanvas.cpp:631
+#: ../src/unix/glegl.cpp:315 ../src/unix/glx11.cpp:559
 msgid "Couldn't create OpenGL context"
 msgstr "OpenGL bağlamı oluşturulamadı"
 
-#: ../src/msw/timer.cpp:134
+#: ../src/msw/timer.cpp:131
 msgid "Couldn't create a timer"
 msgstr "Bir zamanlayıcı oluşturulamadı."
 
-#: ../src/osx/carbon/overlay.cpp:122
-msgid "Couldn't create the overlay window"
-msgstr "Örtüşme penceresi oluşturulamadı."
-
-#: ../src/common/translation.cpp:2024
+#: ../src/common/translation.cpp:2074
 msgid "Couldn't enumerate translations"
 msgstr "Çeviriler sayılamadı."
 
-#: ../src/common/dynlib.cpp:120
+#: ../src/common/dynlib.cpp:110
 #, c-format
 msgid "Couldn't find symbol '%s' in a dynamic library"
 msgstr "'%s' simgesi devingen kitaplıkta bulunamadı."
 
-#: ../src/msw/thread.cpp:915
+#: ../src/msw/thread.cpp:921
 msgid "Couldn't get the current thread pointer"
 msgstr "Geçerli iş parçacığı imleci alınamadı."
 
-#: ../src/osx/carbon/overlay.cpp:129
-msgid "Couldn't init the context on the overlay window"
-msgstr "Örtüşme penceresinde bağlam başlatılamadı."
-
-#: ../src/common/imaggif.cpp:244
+#: ../src/common/imaggif.cpp:241
 msgid "Couldn't initialize GIF hash table."
 msgstr "GIF hash tablosu başlatılamadı."
 
-#: ../src/common/imagpng.cpp:409
+#: ../src/common/imagpng.cpp:437
 msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
 msgstr "PNG görseli yüklenemedi - dosya bozuk ya da bellek yetersiz."
 
-#: ../src/unix/sound.cpp:470
+#: ../src/unix/sound.cpp:459
 #, c-format
 msgid "Couldn't load sound data from '%s'."
 msgstr "Ses verisi '%s' içinden yüklenemedi."
 
-#: ../src/msw/dirdlg.cpp:435
+#: ../src/msw/dirdlg.cpp:287
 msgid "Couldn't obtain folder name"
 msgstr "Klasör adı alınamadı."
 
-#: ../src/unix/sound_sdl.cpp:229
+#: ../src/unix/sound_sdl.cpp:226
 #, c-format
 msgid "Couldn't open audio: %s"
 msgstr "Ses açılamadı: %s"
 
-#: ../src/msw/ole/dataobj.cpp:377
+#: ../src/msw/ole/dataobj.cpp:385
 #, c-format
 msgid "Couldn't register clipboard format '%s'."
 msgstr "'%s' pano biçimi kaydedilemedi."
 
-#: ../src/msw/listctrl.cpp:869
+#: ../src/msw/listctrl.cpp:933
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "%d liste denetimi ögesi hakkında bilgi alınamadı."
 
-#: ../src/common/imagpng.cpp:498 ../src/common/imagpng.cpp:509
-#: ../src/common/imagpng.cpp:519
+#: ../src/common/imagpng.cpp:511 ../src/common/imagpng.cpp:522
+#: ../src/common/imagpng.cpp:532
 msgid "Couldn't save PNG image."
 msgstr "PNG görseli kaydedilemedi."
 
-#: ../src/msw/thread.cpp:684
+#: ../src/msw/thread.cpp:676
 msgid "Couldn't terminate thread"
 msgstr "İş parçacığı sonlandırılamadı."
 
-#: ../src/common/xtistrm.cpp:166
+#: ../src/common/xtistrm.cpp:163
 #, c-format
 msgid "Create Parameter %s not found in declared RTTI Parameters"
 msgstr "'Create Parameter' %s bildirilen RTTI parametreleri içinde bulunamadı."
 
-#: ../src/generic/dirdlgg.cpp:288
+#: ../src/generic/dirdlgg.cpp:285
 msgid "Create directory"
 msgstr "Klasör oluştur"
 
-#: ../src/generic/filedlgg.cpp:212 ../src/generic/dirdlgg.cpp:111
+#: ../src/generic/filedlgg.cpp:209 ../src/generic/dirdlgg.cpp:108
 msgid "Create new directory"
 msgstr "Yeni klasör oluştur"
 
-#: ../src/xrc/xmlres.cpp:2460
+#: ../src/common/stockitem.cpp:264
+#, fuzzy
+msgid "Create new document"
+msgstr "Yeni klasör oluştur"
+
+#: ../src/xrc/xmlres.cpp:2515
 #, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "%s \"%s\" oluşturulamadı."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1758
+#: ../src/propgrid/advprops.cpp:1659
 msgid "Cross"
 msgstr "Çarpı"
 
-#: ../src/common/accelcmn.cpp:333
+#: ../src/common/accelcmn.cpp:347
 msgid "Ctrl+"
 msgstr "Ctrl+"
 
-#: ../src/richtext/richtextctrl.cpp:332 ../src/osx/textctrl_osx.cpp:576
-#: ../src/common/stockitem.cpp:151 ../src/msw/textctrl.cpp:2507
+#: ../src/osx/textctrl_osx.cpp:594 ../src/common/stockitem.cpp:148
+#: ../src/msw/textctrl.cpp:2772 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "&Kesin"
 
-#: ../src/generic/filectrlg.cpp:940
+#: ../src/generic/filectrlg.cpp:936
 msgid "Current directory:"
 msgstr "Geçerli klasör:"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:896 ../src/propgrid/advprops.cpp:1574
-#: ../src/propgrid/advprops.cpp:1612
+#: ../src/propgrid/advprops.cpp:797 ../src/propgrid/advprops.cpp:1475
+#: ../src/propgrid/advprops.cpp:1518
 msgid "Custom"
 msgstr "Özel"
 
-#: ../src/gtk/print.cpp:217
+#: ../src/gtk/print.cpp:211
 msgid "Custom size"
 msgstr "Özel boyut"
 
-#: ../src/common/headerctrlcmn.cpp:60
+#: ../src/common/headerctrlcmn.cpp:58
 msgid "Customize Columns"
 msgstr "Sütunları Özelleştir"
 
-#: ../src/common/stockitem.cpp:151 ../src/stc/stc_i18n.cpp:17
+#: ../src/common/stockitem.cpp:148 ../src/stc/stc_i18n.cpp:17
 msgid "Cut"
 msgstr "Kes"
 
-#: ../src/common/stockitem.cpp:259
+#: ../src/common/stockitem.cpp:256
 msgid "Cut selection"
 msgstr "Seçimi kes"
 
-#: ../src/common/fmapbase.cpp:152
+#: ../src/common/fmapbase.cpp:149
 msgid "Cyrillic (ISO-8859-5)"
 msgstr "Kril (ISO-8859-5)"
 
-#: ../src/common/paper.cpp:99
+#: ../src/common/paper.cpp:96
 msgid "D sheet, 22 x 34 in"
 msgstr "D sayfa, 22 x 34 inç"
 
-#: ../src/msw/dde.cpp:703
+#: ../src/msw/dde.cpp:698
 msgid "DDE poke request failed"
 msgstr "DDE itme isteği yapılamadı."
 
-#: ../src/common/imagbmp.cpp:1169
+#: ../src/common/imagbmp.cpp:1181
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr "DIB Başlık Bilgisi: Kodlama, bit derinliğine uymuyor."
 
@@ -2581,7 +2589,7 @@ msgstr "DIB Başlık Bilgisi: Dosyada bilinmeyen bit derinliği."
 msgid "DIB Header: Unknown encoding in file."
 msgstr "DIB Başlık Bilgisi: Dosyada bilinmeyen kodlama."
 
-#: ../src/common/paper.cpp:121
+#: ../src/common/paper.cpp:118
 msgid "DL Envelope, 110 x 220 mm"
 msgstr "DL Zarf, 110 x 220 mm"
 
@@ -2589,53 +2597,53 @@ msgstr "DL Zarf, 110 x 220 mm"
 msgid "Dashed"
 msgstr "Çizgili"
 
-#: ../src/generic/dbgrptg.cpp:300
+#: ../src/generic/dbgrptg.cpp:301
 #, c-format
 msgid "Debug report \"%s\""
 msgstr "Hata ayıklama raporu \"%s\""
 
-#: ../src/common/debugrpt.cpp:210
+#: ../src/common/debugrpt.cpp:211
 msgid "Debug report couldn't be created."
 msgstr "Hata ayıklama raporu oluşturulamadı."
 
-#: ../src/common/debugrpt.cpp:553
+#: ../src/common/debugrpt.cpp:554
 msgid "Debug report generation has failed."
 msgstr "Hata ayıklama raporu oluşturulamadı."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:84
+#: ../src/common/accelcmn.cpp:81
 msgid "Decimal"
 msgstr "Ondalık"
 
-#: ../src/generic/fontdlgg.cpp:323
+#: ../src/generic/fontdlgg.cpp:319
 msgid "Decorative"
 msgstr "Süslü"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1752
+#: ../src/propgrid/advprops.cpp:1653
 msgid "Default"
 msgstr "Varsayılan"
 
-#: ../src/common/fmapbase.cpp:796
+#: ../src/common/fmapbase.cpp:792
 msgid "Default encoding"
 msgstr "Varsayılan kodlama"
 
-#: ../src/dfb/fontmgr.cpp:180
+#: ../src/dfb/fontmgr.cpp:177
 msgid "Default font"
 msgstr "Varsayılan yazı türü"
 
-#: ../src/generic/prntdlgg.cpp:510
+#: ../src/generic/prntdlgg.cpp:503
 msgid "Default printer"
 msgstr "Varsayılan yazıcı"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:51
+#: ../src/common/accelcmn.cpp:48
 msgid "Del"
 msgstr "Del"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextbuffer.cpp:8221 ../src/common/stockitem.cpp:152
-#: ../src/common/accelcmn.cpp:50 ../src/stc/stc_i18n.cpp:20
+#: ../src/common/stockitem.cpp:149 ../src/common/accelcmn.cpp:47
+#: ../src/richtext/richtextbuffer.cpp:8217 ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Sil"
 
@@ -2643,68 +2651,68 @@ msgstr "Sil"
 msgid "Delete A&ll"
 msgstr "Tümünü Si&l"
 
-#: ../src/richtext/richtextbuffer.cpp:11341
+#: ../src/richtext/richtextbuffer.cpp:11340
 msgid "Delete Column"
 msgstr "Sütunu Sil"
 
-#: ../src/richtext/richtextbuffer.cpp:11291
+#: ../src/richtext/richtextbuffer.cpp:11290
 msgid "Delete Row"
 msgstr "Satırı Sil"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 msgid "Delete Style"
 msgstr "Biçemi Sil"
 
-#: ../src/richtext/richtextctrl.cpp:1345 ../src/richtext/richtextctrl.cpp:1584
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
 msgid "Delete Text"
 msgstr "Metni Sil"
 
-#: ../src/generic/editlbox.cpp:170
+#: ../src/generic/editlbox.cpp:147
 msgid "Delete item"
 msgstr "Ögeyi Sil"
 
-#: ../src/common/stockitem.cpp:260
+#: ../src/common/stockitem.cpp:257
 msgid "Delete selection"
 msgstr "Seçimi sil"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 #, c-format
 msgid "Delete style %s?"
 msgstr "%s biçemi silinsin mi?"
 
-#: ../src/unix/snglinst.cpp:301
+#: ../src/unix/snglinst.cpp:298
 #, c-format
 msgid "Deleted stale lock file '%s'."
 msgstr "Eski kilit dosyası '%s' silindi."
 
-#: ../src/common/secretstore.cpp:220
-#, c-format
-msgid "Deleting password for \"%s/%s\" failed: %s."
+#: ../src/common/secretstore.cpp:234
+#, fuzzy, c-format
+msgid "Deleting password for \"%s\" failed: %s."
 msgstr "\"%s/%s\" için parola silinemedi: %s."
 
-#: ../src/common/module.cpp:124
+#: ../src/common/module.cpp:121
 #, c-format
 msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
 msgstr "\"%s\" bağlılığı \"%s\" modülü için bulunamadı."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "Descending"
 msgstr "Azalan"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:526 ../src/propgrid/advprops.cpp:882
+#: ../src/generic/dirctrlg.cpp:492 ../src/propgrid/advprops.cpp:783
 msgid "Desktop"
 msgstr "Masaüstü"
 
-#: ../src/generic/aboutdlgg.cpp:70
+#: ../src/generic/aboutdlgg.cpp:67
 msgid "Developed by "
 msgstr "Geliştirici "
 
-#: ../src/generic/aboutdlgg.cpp:176
+#: ../src/generic/aboutdlgg.cpp:173
 msgid "Developers"
 msgstr "Geliştiriciler"
 
-#: ../src/msw/dialup.cpp:374
+#: ../src/msw/dialup.cpp:368
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -2712,11 +2720,11 @@ msgstr ""
 "Uzaktan erişim hizmeti (RAS) kurulu olmadığı için arama işlevleri "
 "kullanılamıyor. Lütfen kurun."
 
-#: ../src/generic/tipdlg.cpp:211
+#: ../src/generic/tipdlg.cpp:208
 msgid "Did you know..."
 msgstr "Biliyor musunuz..."
 
-#: ../src/dfb/wrapdfb.cpp:63
+#: ../src/dfb/wrapdfb.cpp:60
 #, c-format
 msgid "DirectFB error %d occurred."
 msgstr "%d DirectFB hatası oluştu."
@@ -2725,29 +2733,29 @@ msgstr "%d DirectFB hatası oluştu."
 msgid "Directories"
 msgstr "Klasörler"
 
-#: ../src/common/filefn.cpp:1183
+#: ../src/common/filefn.cpp:1071
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "'%s' klasörü oluşturulamadı"
 
-#: ../src/common/filefn.cpp:1197
+#: ../src/common/filefn.cpp:1085
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "'%s' klasörü silinemedi"
 
-#: ../src/generic/dirdlgg.cpp:204
+#: ../src/generic/dirdlgg.cpp:201
 msgid "Directory does not exist"
 msgstr "Klasör bulunamadı"
 
-#: ../src/generic/filectrlg.cpp:1399
+#: ../src/generic/filectrlg.cpp:1388
 msgid "Directory doesn't exist."
 msgstr "Klasör bulunamadı."
 
-#: ../src/common/docview.cpp:457
+#: ../src/common/docview.cpp:450
 msgid "Discard changes and reload the last saved version?"
 msgstr "Değişiklikler iptal edilip son kaydedilmiş sürüme dönülsün mü?"
 
-#: ../src/html/helpwnd.cpp:502
+#: ../src/html/helpwnd.cpp:500
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -2755,45 +2763,45 @@ msgstr ""
 "Verilen alt dizgeyi içeren tüm dizin elemanları görüntülensin. Arama küçük-"
 "büyük harfe duyarlıdır."
 
-#: ../src/html/helpwnd.cpp:679
+#: ../src/html/helpwnd.cpp:677
 msgid "Display options dialog"
 msgstr "Ayarlar penceresi görüntülensin"
 
-#: ../src/html/helpwnd.cpp:322
+#: ../src/html/helpwnd.cpp:320
 msgid "Displays help as you browse the books on the left."
 msgstr "Soldaki kitapları gezilirken yardım görüntülenir."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:85
+#: ../src/common/accelcmn.cpp:83
 msgid "Divide"
 msgstr "Bölü"
 
-#: ../src/common/docview.cpp:533
+#: ../src/common/docview.cpp:526
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "%s üzerinde yapılan değişiklikleri kaydetmek istiyor musunuz?"
 
-#: ../src/common/prntbase.cpp:542
+#: ../src/common/prntbase.cpp:537
 msgid "Document:"
 msgstr "Belge:"
 
-#: ../src/generic/aboutdlgg.cpp:73
+#: ../src/generic/aboutdlgg.cpp:70
 msgid "Documentation by "
 msgstr "Belgeleyen "
 
-#: ../src/generic/aboutdlgg.cpp:180
+#: ../src/generic/aboutdlgg.cpp:177
 msgid "Documentation writers"
 msgstr "Belge yazarları"
 
-#: ../src/common/sizer.cpp:2799
+#: ../src/common/sizer.cpp:2916
 msgid "Don't Save"
 msgstr "Kaydedilmesin"
 
-#: ../src/html/htmlwin.cpp:633
+#: ../src/html/htmlwin.cpp:643
 msgid "Done"
 msgstr "Tamamlandı"
 
-#: ../src/generic/progdlgg.cpp:448 ../src/msw/progdlg.cpp:407
+#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
 msgid "Done."
 msgstr "Tamamlandı."
 
@@ -2805,42 +2813,42 @@ msgstr "Noktalı"
 msgid "Double"
 msgstr "Çift"
 
-#: ../src/common/paper.cpp:176
+#: ../src/common/paper.cpp:173
 msgid "Double Japanese Postcard Rotated 148 x 200 mm"
 msgstr "Japon Çift Postakartı Çevrilmiş 148 x 200 mm"
 
-#: ../src/common/xtixml.cpp:273
+#: ../src/common/xtixml.cpp:269
 #, c-format
 msgid "Doubly used id : %d"
 msgstr "Kod iki kez kullanılmış: %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:153
-#: ../src/common/accelcmn.cpp:64
+#: ../src/common/stockitem.cpp:150 ../src/common/accelcmn.cpp:61
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Down"
 msgstr "Aşağı"
 
-#: ../src/richtext/richtextctrl.cpp:865
+#: ../src/richtext/richtextctrl.cpp:864
 msgid "Drag"
 msgstr "Sürükle"
 
-#: ../src/common/paper.cpp:100
+#: ../src/common/paper.cpp:97
 msgid "E sheet, 34 x 44 in"
 msgstr "E sayfa, 34 x 44 inç"
 
-#: ../src/unix/fswatcher_inotify.cpp:561
+#: ../src/unix/fswatcher_inotify.cpp:558
 msgid "EOF while reading from inotify descriptor"
 msgstr "inotify belirteci okunurken dosya sonuna ulaşıldı"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "Edit"
 msgstr "Düzenle"
 
-#: ../src/generic/editlbox.cpp:168
+#: ../src/generic/editlbox.cpp:131
 msgid "Edit item"
 msgstr "Ögeyi düzenle"
 
-#: ../include/wx/generic/progdlgg.h:84
+#: ../include/wx/generic/progdlgg.h:85
 msgid "Elapsed time:"
 msgstr "Geçen süre:"
 
@@ -2907,61 +2915,61 @@ msgid "Enables the shadow spread."
 msgstr "Gölge yayma kullanılsın."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:66
+#: ../src/common/accelcmn.cpp:63
 msgid "End"
 msgstr "End"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:55
+#: ../src/common/accelcmn.cpp:52
 msgid "Enter"
 msgstr "Enter"
 
-#: ../src/richtext/richtextstyledlg.cpp:934
+#: ../src/richtext/richtextstyledlg.cpp:930
 msgid "Enter a box style name"
 msgstr "Bir kutu biçemi adı yazın"
 
-#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:602
 msgid "Enter a character style name"
 msgstr "Bir karakter biçemi adı yazın"
 
-#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:816
 msgid "Enter a list style name"
 msgstr "Bir liste biçemi adı yazın"
 
-#: ../src/richtext/richtextstyledlg.cpp:893
+#: ../src/richtext/richtextstyledlg.cpp:889
 msgid "Enter a new style name"
 msgstr "Yeni bir biçem adı yazın"
 
-#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:650
 msgid "Enter a paragraph style name"
 msgstr "Bir paragraf biçemi adı yazın"
 
-#: ../src/generic/dbgrptg.cpp:174
+#: ../src/generic/dbgrptg.cpp:171
 #, c-format
 msgid "Enter command to open file \"%s\":"
 msgstr "\"%s\" dosyasını açacak komutu yazın:"
 
-#: ../src/generic/helpext.cpp:459
+#: ../src/generic/helpext.cpp:457
 msgid "Entries found"
 msgstr "Bulunan kayıt"
 
-#: ../src/common/paper.cpp:142
+#: ../src/common/paper.cpp:139
 msgid "Envelope Invite 220 x 220 mm"
 msgstr "Davetiye Zarf 220 x 220 mm"
 
-#: ../src/common/config.cpp:469
+#: ../src/common/config.cpp:465
 #, c-format
 msgid ""
 "Environment variables expansion failed: missing '%c' at position %u in '%s'."
 msgstr "Ortam değişkenleri açılamadı: eksik '%c', konum %u, '%s' içinde."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/generic/dirctrlg.cpp:570
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/dirctrlg.cpp:599
-#: ../src/generic/dirdlgg.cpp:323 ../src/generic/filectrlg.cpp:642
-#: ../src/generic/filectrlg.cpp:756 ../src/generic/filectrlg.cpp:770
-#: ../src/generic/filectrlg.cpp:786 ../src/generic/filectrlg.cpp:1368
-#: ../src/generic/filectrlg.cpp:1399 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/gtk1/fontdlg.cpp:74 ../src/generic/dirctrlg.cpp:536
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/dirctrlg.cpp:565
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1357 ../src/generic/filectrlg.cpp:1388
+#: ../src/generic/filedlgg.cpp:354 ../src/generic/dirdlgg.cpp:320
+#: ../src/gtk/filedlg.cpp:74
 msgid "Error"
 msgstr "Hata"
 
@@ -2969,232 +2977,253 @@ msgstr "Hata"
 msgid "Error closing epoll descriptor"
 msgstr "Epoll tanımlayıcı kapatma hatası"
 
-#: ../src/unix/fswatcher_kqueue.cpp:114
+#: ../src/unix/fswatcher_kqueue.cpp:131
 msgid "Error closing kqueue instance"
 msgstr "Kqueue kopyası kapatılırken hata"
 
-#: ../src/common/filefn.cpp:1049
+#: ../src/common/filefn.cpp:938
 #, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "'%s' dosyası '%s' içine kopyalanamadı."
 
-#: ../src/generic/dirdlgg.cpp:222
+#: ../src/generic/dirdlgg.cpp:219
 msgid "Error creating directory"
 msgstr "Klasör oluşturulurken sorun çıktı"
 
-#: ../src/common/imagbmp.cpp:1181
+#: ../src/common/imagbmp.cpp:1193
 msgid "Error in reading image DIB."
 msgstr "DIB görüntüsü okuma sorunu."
 
-#: ../src/propgrid/propgrid.cpp:6696
+#: ../src/propgrid/propgrid.cpp:6665
 #, c-format
 msgid "Error in resource: %s"
 msgstr "%s kaynağında sorun"
 
-#: ../src/common/fileconf.cpp:422
+#: ../src/common/fileconf.cpp:421
 msgid "Error reading config options."
 msgstr "Ayarlar okunurken sorun çıktı."
+
+#: ../src/msw/webview_ie.cpp:1057 ../src/msw/webview_edge.cpp:850
+#: ../src/gtk/webview_webkit2.cpp:1262 ../src/osx/webview_webkit.mm:383
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
 
 #: ../src/common/fileconf.cpp:1029
 msgid "Error saving user configuration data."
 msgstr "Kullanıcı ayarları kaydedilirken sorun çıktı."
 
-#: ../src/gtk/print.cpp:722
+#: ../src/gtk/print.cpp:720
 msgid "Error while printing: "
 msgstr "Yazdırma sorunu: "
 
-#: ../src/common/log.cpp:219
+#: ../src/common/log.cpp:237
 msgid "Error: "
 msgstr "Hata: "
 
+#: ../src/common/webrequest.cpp:98
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Hata: "
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:69
+#: ../src/common/accelcmn.cpp:66
 msgid "Esc"
 msgstr "Esc"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:70
+#: ../src/common/accelcmn.cpp:67
 msgid "Escape"
 msgstr "Escape"
 
-#: ../src/common/fmapbase.cpp:150
+#: ../src/common/fmapbase.cpp:147
 msgid "Esperanto (ISO-8859-3)"
 msgstr "Esperanto (ISO-8859-3)"
 
-#: ../include/wx/generic/progdlgg.h:85
+#: ../include/wx/generic/progdlgg.h:86
 msgid "Estimated time:"
 msgstr "Öngörülen süre:"
 
-#: ../src/generic/dbgrptg.cpp:234
+#: ../src/generic/dbgrptg.cpp:231
 msgid "Executable files (*.exe)|*.exe|"
 msgstr "Yürütülebilir dosyalar (*.exe)|*.exe|"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:155 ../src/common/accelcmn.cpp:78
+#: ../src/common/stockitem.cpp:152 ../src/common/accelcmn.cpp:75
 msgid "Execute"
 msgstr "Yürüt"
 
-#: ../src/msw/utilsexc.cpp:876
+#: ../src/msw/utilsexc.cpp:873
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "'%s' komutu yürütülemedi"
 
-#: ../src/common/paper.cpp:105
+#: ../src/common/paper.cpp:102
 msgid "Executive, 7 1/4 x 10 1/2 in"
 msgstr "Executive, 7 1/4 x 10 1/2 inç"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6009
+#: ../src/generic/datavgen.cpp:6814
 msgid "Expand"
 msgstr "Genişlet"
 
-#: ../src/msw/registry.cpp:1240
+#: ../src/msw/registry.cpp:1228
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
 msgstr "Kayıt anahtarı verme: \"%s\" dosyası zaten var, üzerine yazılmayacak."
 
-#: ../src/common/fmapbase.cpp:195
+#: ../src/common/fmapbase.cpp:192
 msgid "Extended Unix Codepage for Japanese (EUC-JP)"
 msgstr "Japonca için genişletilmiş Unix Codepage (EUC-JP)"
 
-#: ../src/html/chm.cpp:725
+#: ../src/html/chm.cpp:718
 #, c-format
 msgid "Extraction of '%s' into '%s' failed."
 msgstr "'%s'', '%s' içine açılamadı."
 
-#: ../src/common/accelcmn.cpp:249 ../src/common/accelcmn.cpp:344
+#: ../src/common/accelcmn.cpp:259 ../src/common/accelcmn.cpp:358
 msgid "F"
 msgstr "F"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:672
+#: ../src/propgrid/advprops.cpp:582
 msgid "Face Name"
 msgstr "Yazı Türü Adı"
 
-#: ../src/unix/snglinst.cpp:269
+#: ../src/unix/snglinst.cpp:266
 msgid "Failed to access lock file."
 msgstr "Kilit dosyasına erişilemedi."
+
+#: ../src/gtk/font.cpp:572
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "\"%s\" dosyasından belge okunamadı."
 
 #: ../src/unix/epolldispatcher.cpp:116
 #, c-format
 msgid "Failed to add descriptor %d to epoll descriptor %d"
 msgstr "%d tanımlayıcısı %d epoll tanımlayısıcına eklenemedi"
 
-#: ../src/msw/dib.cpp:489
+#: ../src/msw/dib.cpp:535
 #, c-format
 msgid "Failed to allocate %luKb of memory for bitmap data."
 msgstr "Bit eşlem verisi için %luKb bellek ayrılamadı."
 
-#: ../src/common/glcmn.cpp:115
+#: ../src/common/glcmn.cpp:112
 msgid "Failed to allocate colour for OpenGL"
 msgstr "OpenGL için renk ayarlanamadı"
 
-#: ../src/unix/displayx11.cpp:236
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "OpenGL için renk ayarlanamadı"
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "OpenGL için renk ayarlanamadı"
+
+#: ../include/wx/unix/private/displayx11.h:89
 msgid "Failed to change video mode"
 msgstr "Görüntü kipi değiştirilemedi"
 
-#: ../src/common/image.cpp:3277
+#: ../src/common/image.cpp:3396
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "\"%s\" görsel dosyasının biçimi denetlenemedi."
 
-#: ../src/common/debugrpt.cpp:239
+#: ../src/common/debugrpt.cpp:240
 #, c-format
 msgid "Failed to clean up debug report directory \"%s\""
 msgstr "\"%s\" hata ayıklama rapor klasörü temizlenemedi"
 
-#: ../src/common/filename.cpp:192
+#: ../src/common/filename.cpp:189
 msgid "Failed to close file handle"
 msgstr "Dosya işleyici kapatılamadı"
 
-#: ../src/unix/snglinst.cpp:340
+#: ../src/unix/snglinst.cpp:337
 #, c-format
 msgid "Failed to close lock file '%s'"
 msgstr "'%s' kilit dosyası kapatılamadı"
 
-#: ../src/msw/clipbrd.cpp:112
+#: ../src/msw/clipbrd.cpp:110
 msgid "Failed to close the clipboard."
 msgstr "Pano kapatılamadı."
 
-#: ../src/x11/utils.cpp:208
+#: ../src/x11/utils.cpp:170
 #, c-format
 msgid "Failed to close the display \"%s\""
 msgstr "\"%s\" görüntüsü kapatılamadı"
 
-#: ../src/msw/dialup.cpp:797
+#: ../src/msw/dialup.cpp:791
 msgid "Failed to connect: missing username/password."
 msgstr "Bağlanılamadı: kullanıcı adı/parola eksik."
 
-#: ../src/msw/dialup.cpp:743
+#: ../src/msw/dialup.cpp:737
 msgid "Failed to connect: no ISP to dial."
 msgstr "Bağlanılamadı: aranacak ISS yok."
 
-#: ../src/common/textfile.cpp:203
-#, c-format
-msgid "Failed to convert file \"%s\" to Unicode."
-msgstr "\"%s\" dosyası Unikoda çevrilemedi."
-
-#: ../src/generic/logg.cpp:956
+#: ../src/generic/logg.cpp:953
 msgid "Failed to copy dialog contents to the clipboard."
 msgstr "Pencere içeriği panoya kopyalanamadı."
 
-#: ../src/msw/registry.cpp:692
+#: ../src/msw/registry.cpp:681
 #, c-format
 msgid "Failed to copy registry value '%s'"
 msgstr "'%s' kayıt değeri kopyalanamadı"
 
-#: ../src/msw/registry.cpp:701
+#: ../src/msw/registry.cpp:690
 #, c-format
 msgid "Failed to copy the contents of registry key '%s' to '%s'."
 msgstr "'%s' kayıt anahtarının içeriği '%s' içine kopyalanamadı."
 
-#: ../src/common/filefn.cpp:1015
+#: ../src/common/filefn.cpp:904
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "'%s' dosyası '%s' içine kopyalanamadı"
 
-#: ../src/msw/registry.cpp:679
+#: ../src/msw/registry.cpp:668
 #, c-format
 msgid "Failed to copy the registry subkey '%s' to '%s'."
 msgstr "'%s' kayıt alt anahtarı '%s' içine kopyalanamadı."
 
-#: ../src/msw/dde.cpp:1070
+#: ../src/msw/dde.cpp:1134
 msgid "Failed to create DDE string"
 msgstr "DDE dizgesi oluşturulamadı"
 
-#: ../src/msw/mdi.cpp:616
+#: ../src/msw/mdi.cpp:621
 msgid "Failed to create MDI parent frame."
 msgstr "MDI üst çerçevesi oluşturulamadı."
 
-#: ../src/common/filename.cpp:1027
+#: ../src/common/filename.cpp:1024
 msgid "Failed to create a temporary file name"
 msgstr "Geçici dosya adı oluşturulamadı"
 
-#: ../src/msw/utilsexc.cpp:228
+#: ../src/msw/utilsexc.cpp:225
 msgid "Failed to create an anonymous pipe"
 msgstr "Anonim bir boru oluşturulamadı"
 
-#: ../src/msw/ole/automtn.cpp:522
+#: ../src/msw/ole/automtn.cpp:513
 #, c-format
 msgid "Failed to create an instance of \"%s\""
 msgstr "\"%s\" kopyası oluşturulamadı"
 
-#: ../src/msw/dde.cpp:437
+#: ../src/msw/dde.cpp:432
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "'%s' sunucusuna '%s' konusundan bağlantı kurulamadı"
 
-#: ../src/msw/cursor.cpp:204
+#: ../src/msw/cursor.cpp:195
 msgid "Failed to create cursor."
 msgstr "İmleç oluşturulamadı."
 
-#: ../src/common/debugrpt.cpp:209
+#: ../src/common/debugrpt.cpp:210
 #, c-format
 msgid "Failed to create directory \"%s\""
 msgstr "\"%s\" klasörü oluşturulamadı"
 
-#: ../src/generic/dirdlgg.cpp:220
+#: ../src/generic/dirdlgg.cpp:217
 #, c-format
 msgid ""
 "Failed to create directory '%s'\n"
@@ -3207,114 +3236,133 @@ msgstr ""
 msgid "Failed to create epoll descriptor"
 msgstr "Epoll tanımlayıcısı oluşturulamadı"
 
-#: ../src/msw/mimetype.cpp:238
+#: ../src/gtk/font.cpp:562
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "Kullanıcı ayarları dosyası kaydedilemedi."
+
+#: ../src/msw/mimetype.cpp:235
 #, c-format
 msgid "Failed to create registry entry for '%s' files."
 msgstr "'%s' dosyaları için kayıt anahtarı oluşturulamadı."
 
-#: ../src/msw/fdrepdlg.cpp:409
+#: ../src/msw/fdrepdlg.cpp:408
 #, c-format
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr "Standart bul/değiştir penceresi oluşturulamadı (hata kodu %d)"
 
-#: ../src/unix/wakeuppipe.cpp:52
+#: ../src/unix/wakeuppipe.cpp:49
 msgid "Failed to create wake up pipe used by event loop."
 msgstr "Olay döngüsünde kullanılan uyandırma borusu oluşturulamadı."
 
-#: ../src/html/winpars.cpp:730
+#: ../src/html/winpars.cpp:727
 #, c-format
 msgid "Failed to display HTML document in %s encoding"
 msgstr "HTML belgesi %s kodlamasıyla görüntülenemedi"
 
-#: ../src/msw/clipbrd.cpp:124
+#: ../src/msw/clipbrd.cpp:122
 msgid "Failed to empty the clipboard."
 msgstr "Pano temizlenemedi."
 
-#: ../src/unix/displayx11.cpp:212
+#: ../include/wx/unix/private/displayx11.h:65
 msgid "Failed to enumerate video modes"
 msgstr "Görüntü kipleri sıralanamadı"
 
-#: ../src/msw/dde.cpp:722
+#: ../src/msw/dde.cpp:717
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "DDE sunucusuyla danışma döngüsü sağlanamadı"
 
-#: ../src/msw/dialup.cpp:629 ../src/msw/dialup.cpp:863
+#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Çevirmeli bağlantı gerçekleştirilemedi: %s"
 
-#: ../src/unix/utilsunx.cpp:611
+#: ../src/unix/utilsunx.cpp:613
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "'%s' çalıştırılamadı\n"
 
-#: ../src/common/debugrpt.cpp:720
+#: ../src/common/debugrpt.cpp:730
 msgid "Failed to execute curl, please install it in PATH."
 msgstr "Curl çalıştırılamadı, lütfen YOL içine yükleyin."
 
-#: ../src/msw/ole/automtn.cpp:505
+#: ../src/msw/ole/automtn.cpp:496
 #, c-format
 msgid "Failed to find CLSID of \"%s\""
 msgstr "\"%s\" için CLSID bulunamadı"
 
-#: ../src/common/regex.cpp:431 ../src/common/regex.cpp:479
+#: ../src/common/regex.cpp:428 ../src/common/regex.cpp:476
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "Kurallı ifadeye uygun veri bulunamadı: %s"
 
-#: ../src/msw/dialup.cpp:695
+#: ../src/msw/webview_ie.cpp:978
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:689
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "ISS adları alınamadı: %s"
 
-#: ../src/msw/ole/automtn.cpp:574
+#: ../src/msw/ole/automtn.cpp:565
 #, c-format
 msgid "Failed to get OLE automation interface for \"%s\""
 msgstr "\"%s\" için OLE otomasyonu arayüzü getirilemedi"
 
-#: ../src/msw/clipbrd.cpp:711
+#: ../src/msw/clipbrd.cpp:731
 msgid "Failed to get data from the clipboard"
 msgstr "Panodan veri alınamadı"
 
-#: ../src/common/time.cpp:223
+#: ../src/common/time.cpp:216
 msgid "Failed to get the local system time"
 msgstr "Yerel sistem zamanı alınamadı"
 
-#: ../src/common/filefn.cpp:1345
+#: ../src/common/filefn.cpp:1233
 msgid "Failed to get the working directory"
 msgstr "Çalışma klasörü alınamadı"
 
-#: ../src/univ/theme.cpp:114
+#: ../src/univ/theme.cpp:111
 msgid "Failed to initialize GUI: no built-in themes found."
 msgstr "GUI başlatılamadı: içsel bir tema bulunamadı."
 
-#: ../src/msw/helpchm.cpp:63
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:60
 msgid "Failed to initialize MS HTML Help."
 msgstr "MS HTML Yardım başlatılamadı."
 
-#: ../src/msw/glcanvas.cpp:1381
+#: ../src/msw/glcanvas.cpp:1391
 msgid "Failed to initialize OpenGL"
 msgstr "OpenGL başlatılamadı"
 
-#: ../src/msw/dialup.cpp:858
+#: ../src/msw/dialup.cpp:852
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Çevirmeli bağlantı başlatılamadı: %s"
 
-#: ../src/gtk/textctrl.cpp:1128
+#: ../src/gtk/textctrl.cpp:1209
 msgid "Failed to insert text in the control."
 msgstr "Metin denetime eklenemedi."
 
-#: ../src/unix/snglinst.cpp:241
+#: ../src/unix/snglinst.cpp:238
 #, c-format
 msgid "Failed to inspect the lock file '%s'"
 msgstr "'%s' kilit dosyası incelenemedi"
 
-#: ../src/unix/appunix.cpp:182
+#: ../src/unix/appunix.cpp:179
 msgid "Failed to install signal handler"
 msgstr "İşaret işleyici kurulamadı"
 
-#: ../src/unix/threadpsx.cpp:1167
+#: ../src/unix/threadpsx.cpp:1216
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -3322,71 +3370,71 @@ msgstr ""
 "İş parçacığına bağlanılamadı, olası bellek taşması bulundu - lütfen programı "
 "yeniden başlatın"
 
-#: ../src/msw/utils.cpp:629
+#: ../src/msw/utils.cpp:619
 #, c-format
 msgid "Failed to kill process %d"
 msgstr "%d işlemi sonlandırılamadı"
 
-#: ../src/common/image.cpp:2500
+#: ../src/common/image.cpp:2595
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Kaynaklardan \"%s\" bit eşlemi yüklenemedi."
 
-#: ../src/common/image.cpp:2509
+#: ../src/common/image.cpp:2604
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Kaynaklardan \"%s\" simgesi yüklenemedi."
 
-#: ../src/common/iconbndl.cpp:225
+#: ../src/common/iconbndl.cpp:224
 #, c-format
 msgid "Failed to load icons from resource '%s'."
 msgstr "'%s' kaynağından simgeler yüklenemedi."
 
-#: ../src/common/iconbndl.cpp:200
+#: ../src/common/iconbndl.cpp:198
 #, c-format
 msgid "Failed to load image %%d from file '%s'."
 msgstr "%%d görseli '%s' dosyasından yüklenemedi."
 
-#: ../src/common/iconbndl.cpp:208
+#: ../src/common/iconbndl.cpp:206
 #, c-format
 msgid "Failed to load image %d from stream."
 msgstr "%d görseli akıştan yüklenemedi."
 
-#: ../src/common/image.cpp:2587 ../src/common/image.cpp:2606
+#: ../src/common/image.cpp:2682 ../src/common/image.cpp:2701
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "\"%s\" dosyasından görsel yüklenemedi."
 
-#: ../src/msw/enhmeta.cpp:97
+#: ../src/msw/enhmeta.cpp:94
 #, c-format
 msgid "Failed to load metafile from file \"%s\"."
 msgstr "\"%s\" dosyasından metafile yüklenemedi."
 
-#: ../src/msw/volume.cpp:327
+#: ../src/msw/volume.cpp:335
 msgid "Failed to load mpr.dll."
 msgstr "mpr.dll yüklenemedi."
 
-#: ../src/msw/utils.cpp:953
+#: ../src/msw/utils.cpp:943
 #, c-format
 msgid "Failed to load resource \"%s\"."
 msgstr "\"%s\" kaynağı yüklenemedi."
 
-#: ../src/common/dynlib.cpp:92
+#: ../src/common/dynlib.cpp:86
 #, c-format
 msgid "Failed to load shared library '%s'"
 msgstr "'%s' paylaşılmış kitaplığı yüklenemedi"
 
-#: ../src/osx/core/sound.cpp:145
+#: ../src/osx/core/sound.cpp:143
 #, c-format
 msgid "Failed to load sound from \"%s\" (error %d)."
 msgstr "\"%s\" üzerinden ses yüklenemedi (hata %d)."
 
-#: ../src/msw/utils.cpp:960
+#: ../src/msw/utils.cpp:950
 #, c-format
 msgid "Failed to lock resource \"%s\"."
 msgstr "\"%s\" kaynağı kilitlenemedi."
 
-#: ../src/unix/snglinst.cpp:198
+#: ../src/unix/snglinst.cpp:195
 #, c-format
 msgid "Failed to lock the lock file '%s'"
 msgstr "'%s' kilit dosyası kilitlenemedi"
@@ -3396,33 +3444,38 @@ msgstr "'%s' kilit dosyası kilitlenemedi"
 msgid "Failed to modify descriptor %d in epoll descriptor %d"
 msgstr "%d tanımlayıcısı değiştirilemedi (epoll %d tanımlayıcısındaki)"
 
-#: ../src/common/filename.cpp:2575
+#: ../src/common/filename.cpp:2658
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "'%s' için dosya zamanları değiştirilemedi"
 
-#: ../src/common/selectdispatcher.cpp:258
+#: ../src/common/selectdispatcher.cpp:255
 msgid "Failed to monitor I/O channels"
 msgstr "Giriş/Çıkış kanalları izlenemedi"
 
-#: ../src/common/filename.cpp:175
+#: ../src/common/filename.cpp:172
 #, c-format
 msgid "Failed to open '%s' for reading"
 msgstr "'%s' okunmak üzere açılamadı"
 
-#: ../src/common/filename.cpp:180
+#: ../src/common/filename.cpp:177
 #, c-format
 msgid "Failed to open '%s' for writing"
 msgstr "'%s' yazılmak üzere açılamadı"
 
-#: ../src/html/chm.cpp:141
+#: ../src/html/chm.cpp:138
 #, c-format
 msgid "Failed to open CHM archive '%s'."
 msgstr "'%s' CHM arşivi açılamadı."
 
-#: ../src/common/utilscmn.cpp:1126
+#: ../src/common/utilscmn.cpp:1140
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
+msgstr "'%s' İnternet adresi varsayılan tarayıcıyla açılamadı."
+
+#: ../src/common/hyperlnkcmn.cpp:133
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "'%s' İnternet adresi varsayılan tarayıcıyla açılamadı."
 
 #: ../include/wx/msw/private/fswatcher.h:92
@@ -3430,93 +3483,103 @@ msgstr "'%s' İnternet adresi varsayılan tarayıcıyla açılamadı."
 msgid "Failed to open directory \"%s\" for monitoring."
 msgstr "\"%s\"klasörü izlenmek üzere açılamadı."
 
-#: ../src/x11/utils.cpp:227
+#: ../src/x11/utils.cpp:189
 #, c-format
 msgid "Failed to open display \"%s\"."
 msgstr "\"%s\" görüntüsü açılamadı."
 
-#: ../src/common/filename.cpp:1062
+#: ../src/common/filename.cpp:1059
 msgid "Failed to open temporary file."
 msgstr "Geçici dosya açılamadı."
 
-#: ../src/msw/clipbrd.cpp:91
+#: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Pano açılamadı."
 
-#: ../src/common/translation.cpp:1184
+#: ../src/common/translation.cpp:1226
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Çoğul-formlar ayrıştırılamadı: '%s'"
 
-#: ../src/unix/mediactrl.cpp:1214
+#: ../src/unix/mediactrl.cpp:1239
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "\"%s\" oynatmaya hazırlanamadı."
 
-#: ../src/msw/clipbrd.cpp:600
+#: ../src/msw/clipbrd.cpp:610
 msgid "Failed to put data on the clipboard"
 msgstr "Veri panoya konulamadı"
 
-#: ../src/unix/snglinst.cpp:278
+#: ../src/unix/snglinst.cpp:275
 msgid "Failed to read PID from lock file."
 msgstr "Kilit dosyasından PID okunamadı."
 
-#: ../src/common/fileconf.cpp:433
+#: ../src/common/fileconf.cpp:432
 msgid "Failed to read config options."
 msgstr "Ayarlar okunamadı."
 
-#: ../src/common/docview.cpp:681
+#: ../src/common/docview.cpp:676
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "\"%s\" dosyasından belge okunamadı."
 
-#: ../src/dfb/evtloop.cpp:98
+#: ../src/dfb/evtloop.cpp:99
 msgid "Failed to read event from DirectFB pipe"
 msgstr "DirectFB borusundan olay okunamadı"
 
-#: ../src/unix/wakeuppipe.cpp:120
+#: ../src/unix/wakeuppipe.cpp:117
 msgid "Failed to read from wake-up pipe"
 msgstr "Uyandırma borusu okunamadı"
 
-#: ../src/unix/utilsunx.cpp:679
+#: ../src/common/textfile.cpp:96
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "\"%s\" dosyasından belge okunamadı."
+
+#: ../src/unix/utilsunx.cpp:681
 msgid "Failed to redirect child process input/output"
 msgstr "Alt iş giriş/çıkışı yönlendirilemedi"
 
-#: ../src/msw/utilsexc.cpp:701
+#: ../src/msw/utilsexc.cpp:698
 msgid "Failed to redirect the child process IO"
 msgstr "Alt iş giriş/çıkışı yönlendirilemedi"
 
-#: ../src/msw/dde.cpp:288
+#: ../src/msw/dde.cpp:283
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "'%s' DDE sunucusuna kayıt olunamadı"
 
-#: ../src/common/fontmap.cpp:245
+#: ../src/gtk/font.cpp:580
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "Kullanıcı ayarları dosyası kaydedilemedi."
+
+#: ../src/common/fontmap.cpp:242
 #, c-format
 msgid "Failed to remember the encoding for the charset '%s'."
 msgstr "'%s' karakter kümesi için kodlama anımsanamadı."
 
-#: ../src/common/debugrpt.cpp:227
+#: ../src/common/debugrpt.cpp:228
 #, c-format
 msgid "Failed to remove debug report file \"%s\""
 msgstr "\"%s\" hata ayıklama rapor dosyası silinemedi"
 
-#: ../src/unix/snglinst.cpp:328
+#: ../src/unix/snglinst.cpp:325
 #, c-format
 msgid "Failed to remove lock file '%s'"
 msgstr "'%s' kilit dosyası silinemedi"
 
-#: ../src/unix/snglinst.cpp:288
+#: ../src/unix/snglinst.cpp:285
 #, c-format
 msgid "Failed to remove stale lock file '%s'."
 msgstr "'%s' eski kilit dosyası silinemedi."
 
-#: ../src/msw/registry.cpp:529
+#: ../src/msw/registry.cpp:518
 #, c-format
 msgid "Failed to rename registry value '%s' to '%s'."
 msgstr "'%s' kayıt değeri '%s' olarak yeniden adlandırılamadı."
 
-#: ../src/common/filefn.cpp:1122
+#: ../src/common/filefn.cpp:1011
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -3525,115 +3588,124 @@ msgstr ""
 "'%s' dosyası aynı adlı bir dosya olduğundan '%s' olarak yeniden "
 "adlandırılamadı."
 
-#: ../src/msw/registry.cpp:634
+#: ../src/msw/registry.cpp:623
 #, c-format
 msgid "Failed to rename the registry key '%s' to '%s'."
 msgstr "'%s' kayıt anahtarı '%s' olarak yeniden adlandırılamadı."
 
-#: ../src/common/filename.cpp:2671
+#: ../src/msw/webview_ie.cpp:995
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/common/filename.cpp:2754
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "'%s' için dosya zamanları alınamadı"
 
-#: ../src/msw/dialup.cpp:468
+#: ../src/msw/dialup.cpp:462
 msgid "Failed to retrieve text of RAS error message"
 msgstr "RAS hata iletisi metni alınamadı"
 
-#: ../src/msw/clipbrd.cpp:748
+#: ../src/msw/clipbrd.cpp:768
 msgid "Failed to retrieve the supported clipboard formats"
 msgstr "Desteklenen pano biçimleri alınamadı"
 
-#: ../src/common/docview.cpp:652
+#: ../src/common/docview.cpp:647
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Belge \"%s\" dosyasına kaydedilemedi."
 
-#: ../src/msw/dib.cpp:269
+#: ../src/msw/dib.cpp:312
 #, c-format
 msgid "Failed to save the bitmap image to file \"%s\"."
 msgstr "Bit eşlemi görüntüsü \"%s\" dosyasına kaydedilemedi."
 
-#: ../src/msw/dde.cpp:763
+#: ../src/msw/dde.cpp:811
 msgid "Failed to send DDE advise notification"
 msgstr "DDE danışma uyarısı gönderilemedi"
 
-#: ../src/common/ftp.cpp:402
+#: ../src/common/ftp.cpp:399
 #, c-format
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "FTP aktarım kipi %s olarak ayarlanamadı."
 
-#: ../src/msw/clipbrd.cpp:427
+#: ../src/msw/clipbrd.cpp:443
 msgid "Failed to set clipboard data."
 msgstr "Pano verisi ayarlanamadı."
 
-#: ../src/unix/snglinst.cpp:181
+#: ../src/unix/snglinst.cpp:178
 #, c-format
 msgid "Failed to set permissions on lock file '%s'"
 msgstr "'%s' kilit dosyasının izinleri ayarlanamadı"
 
-#: ../src/unix/utilsunx.cpp:668
+#: ../src/unix/utilsunx.cpp:670
 msgid "Failed to set process priority"
 msgstr "İşlem önceliği ayarlanamadı"
 
-#: ../src/common/file.cpp:559
+#: ../src/common/ffile.cpp:355 ../src/common/file.cpp:586
 msgid "Failed to set temporary file permissions"
 msgstr "Geçici dosya izinleri ayarlanamadı"
 
-#: ../src/gtk/textctrl.cpp:1072
-msgid "Failed to set text in the text control."
-msgstr "Metin denetime yerleştirilemedi."
-
-#: ../src/unix/threadpsx.cpp:1298
+#: ../src/unix/threadpsx.cpp:1347
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "%lu iş parçacığı öncelik düzeyi ayarlanamadı."
 
-#: ../src/unix/threadpsx.cpp:1424
+#: ../src/unix/threadpsx.cpp:1473
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "%d iş parçacığı önceliği ayarlanamadı."
 
-#: ../src/unix/utilsunx.cpp:783
+#: ../src/unix/utilsunx.cpp:785
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr "Engellemesiz boru kurulamadı, program takılabilir."
 
-#: ../src/common/fs_mem.cpp:261
+#: ../src/msw/webview_ie.cpp:987
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:256
 #, c-format
 msgid "Failed to store image '%s' to memory VFS!"
 msgstr "'%s' görüntüsü VFS belleğine yerleştirilemedi!"
 
-#: ../src/dfb/evtloop.cpp:170
+#: ../src/dfb/evtloop.cpp:171
 msgid "Failed to switch DirectFB pipe to non-blocking mode"
 msgstr "DirectFB borusu engellemesiz kipe döndürülemedi"
 
-#: ../src/unix/wakeuppipe.cpp:59
+#: ../src/unix/wakeuppipe.cpp:56
 msgid "Failed to switch wake up pipe to non-blocking mode"
 msgstr "Uyandırma borusu engellemesiz kipe döndürülemedi"
 
-#: ../src/unix/threadpsx.cpp:1605
+#: ../src/unix/threadpsx.cpp:1654
 msgid "Failed to terminate a thread."
 msgstr "Bir iş parçacığı sonlandırılamadı."
 
-#: ../src/msw/dde.cpp:741
+#: ../src/msw/dde.cpp:736
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "DDE sunucusuyla danışma döngüsü sonlandırılamadı"
 
-#: ../src/msw/dialup.cpp:938
+#: ../src/msw/dialup.cpp:932
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Çevirmeli bağlantı sonlandırılamadı: %s"
 
-#: ../src/common/filename.cpp:2590
+#: ../src/common/filename.cpp:2673
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "'%s' dosyasına dokunulamadı"
 
-#: ../src/unix/snglinst.cpp:334
+#: ../src/unix/dlunix.cpp:90
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "'%s' paylaşılmış kitaplığı yüklenemedi"
+
+#: ../src/unix/snglinst.cpp:331
 #, c-format
 msgid "Failed to unlock lock file '%s'"
 msgstr "'%s' kilit dosyasının kilidi kaldırılamadı"
 
-#: ../src/msw/dde.cpp:309
+#: ../src/msw/dde.cpp:304
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "'%s' DDE sunucusundan kayıt iptali yapılamadı"
@@ -3647,77 +3719,87 @@ msgstr "%d tanımlayıcısı kaldırılamadı (%d epoll tanımlayıcısından)"
 msgid "Failed to update user configuration file."
 msgstr "Kullanıcı ayarları dosyası kaydedilemedi."
 
-#: ../src/common/debugrpt.cpp:733
+#: ../src/common/debugrpt.cpp:743
 #, c-format
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Hata ayıklama raporu yüklenemedi (hata kodu %d)."
 
-#: ../src/unix/snglinst.cpp:168
+#: ../src/unix/snglinst.cpp:165
 #, c-format
 msgid "Failed to write to lock file '%s'"
 msgstr "'%s' kilit dosyasına yazılamadı"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:209
+#: ../src/propgrid/propgrid.cpp:190
 msgid "False"
 msgstr "Yanlış"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:694
+#: ../src/propgrid/advprops.cpp:604
 msgid "Family"
 msgstr "Aile"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/gtk/glcanvas.cpp:176 ../src/gtk/glcanvas.cpp:187
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Dosya hatası"
+
+#: ../src/common/stockitem.cpp:154
 msgid "File"
 msgstr "Dosya"
 
-#: ../src/common/docview.cpp:669
+#: ../src/common/docview.cpp:664
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "\"%s\" dosyası okunmak üzere açılamadı."
 
-#: ../src/common/docview.cpp:646
+#: ../src/common/docview.cpp:641
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "\"%s\" dosyası yazılmak üzere açılamadı."
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "'%s' dosyası zaten var, üzerine yazılsın mı?"
 
-#: ../src/common/filefn.cpp:1156
+#: ../src/common/filefn.cpp:1044
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "'%s' dosyası silinemedi"
 
-#: ../src/common/filefn.cpp:1139
+#: ../src/common/filefn.cpp:1028
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "'%s' dosyası '%s' olarak yeniden adlandırılamadı"
 
-#: ../src/richtext/richtextctrl.cpp:3081 ../src/common/textcmn.cpp:953
+#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
 msgid "File couldn't be loaded."
 msgstr "Dosya yüklenemedi."
 
-#: ../src/msw/filedlg.cpp:393
+#: ../src/msw/filedlg.cpp:414
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Dosya diyaloğu %0lx hata koduyla sonlandı."
 
-#: ../src/common/docview.cpp:1789
+#: ../src/common/docview.cpp:1783
 msgid "File error"
 msgstr "Dosya hatası"
 
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/filectrlg.cpp:770
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/filectrlg.cpp:766
 msgid "File name exists already."
 msgstr "Aynı adlı bir dosya zaten var."
+
+#: ../src/osx/cocoa/filedlg.mm:264
+#, fuzzy
+msgid "File type:"
+msgstr "Teletype"
 
 #: ../src/motif/filedlg.cpp:220
 msgid "Files"
 msgstr "Dosyalar"
 
-#: ../src/common/filefn.cpp:1591
+#: ../src/common/filefn.cpp:1479
 #, c-format
 msgid "Files (%s)"
 msgstr "Dosyalar (%s)"
@@ -3726,15 +3808,29 @@ msgstr "Dosyalar (%s)"
 msgid "Filter"
 msgstr "Süzgeç"
 
-#: ../src/common/stockitem.cpp:158 ../src/html/helpwnd.cpp:490
+#: ../src/html/helpwnd.cpp:488
 msgid "Find"
 msgstr "Bul"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:259
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:258
+#, fuzzy
+msgid "Find in document"
+msgstr "HTML belgesi aç"
+
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "Find..."
+msgstr "Bul"
+
+#: ../src/common/stockitem.cpp:156
 msgid "First"
 msgstr "İlk"
 
-#: ../src/common/prntbase.cpp:1548
+#: ../src/common/prntbase.cpp:1573
 msgid "First page"
 msgstr "İlk sayfa"
 
@@ -3742,11 +3838,11 @@ msgstr "İlk sayfa"
 msgid "Fixed"
 msgstr "Sabit"
 
-#: ../src/html/helpwnd.cpp:1206
+#: ../src/html/helpwnd.cpp:1204
 msgid "Fixed font:"
 msgstr "Sabit yazı türü:"
 
-#: ../src/html/helpwnd.cpp:1269
+#: ../src/html/helpwnd.cpp:1267
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Sabit boyutlu tür.<br> <b>koyu</b> <i>eğik</i> "
 
@@ -3754,16 +3850,16 @@ msgstr "Sabit boyutlu tür.<br> <b>koyu</b> <i>eğik</i> "
 msgid "Floating"
 msgstr "Yüzen"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "Floppy"
 msgstr "Esnek"
 
-#: ../src/common/paper.cpp:111
+#: ../src/common/paper.cpp:108
 msgid "Folio, 8 1/2 x 13 in"
 msgstr "Kitap yaprağı, 8 1/2 x 13 inç"
 
-#: ../src/richtext/richtextformatdlg.cpp:344 ../src/osx/carbon/fontdlg.cpp:287
-#: ../src/common/stockitem.cpp:194
+#: ../src/osx/carbon/fontdlg.cpp:284 ../src/common/stockitem.cpp:191
+#: ../src/richtext/richtextformatdlg.cpp:337
 msgid "Font"
 msgstr "Yazı türü"
 
@@ -3771,7 +3867,24 @@ msgstr "Yazı türü"
 msgid "Font &weight:"
 msgstr "Yazı &koyuluğu:"
 
-#: ../src/html/helpwnd.cpp:1207
+#: ../src/osx/fontutil.cpp:89
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
+"\"."
+msgstr ""
+
+#: ../src/msw/font.cpp:1126
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Dosya yüklenemedi."
+
+#: ../src/osx/fontutil.cpp:81
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr ": dosya bulunamadı!"
+
+#: ../src/html/helpwnd.cpp:1205
 msgid "Font size:"
 msgstr "Yazı boyutu"
 
@@ -3779,53 +3892,53 @@ msgstr "Yazı boyutu"
 msgid "Font st&yle:"
 msgstr "Yazı &biçemi:"
 
-#: ../src/osx/carbon/fontdlg.cpp:329
+#: ../src/osx/carbon/fontdlg.cpp:326
 msgid "Font:"
 msgstr "Yazı türü:"
 
-#: ../src/dfb/fontmgr.cpp:198
+#: ../src/dfb/fontmgr.cpp:195
 #, c-format
 msgid "Fonts index file %s disappeared while loading fonts."
 msgstr "Yazı türleri yüklenirken %s yazı türü dizin dosyası kayboldu."
 
-#: ../src/unix/utilsunx.cpp:645
+#: ../src/unix/utilsunx.cpp:647
 msgid "Fork failed"
 msgstr "Ayrıştırma başarısız"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "Forward"
 msgstr "İleri"
 
-#: ../src/common/xtixml.cpp:235
+#: ../src/common/xtixml.cpp:231
 msgid "Forward hrefs are not supported"
 msgstr "Yönlendirme href biçimi desteklenmiyor"
 
-#: ../src/html/helpwnd.cpp:875
+#: ../src/html/helpwnd.cpp:873
 #, c-format
 msgid "Found %i matches"
 msgstr "%i sonuç bulundu"
 
-#: ../src/generic/prntdlgg.cpp:238
+#: ../src/generic/prntdlgg.cpp:231
 msgid "From:"
 msgstr "Kaynak:"
 
-#: ../src/propgrid/advprops.cpp:1604
+#: ../src/propgrid/advprops.cpp:1510
 msgid "Fuchsia"
 msgstr "Fuşya"
 
-#: ../src/common/imaggif.cpp:138
+#: ../src/common/imaggif.cpp:135
 msgid "GIF: data stream seems to be truncated."
 msgstr "GIF: veri akışı budanmış görünüyor."
 
-#: ../src/common/imaggif.cpp:128
+#: ../src/common/imaggif.cpp:125
 msgid "GIF: error in GIF image format."
 msgstr "GIF: GIF görsel biçimi hatası."
 
-#: ../src/common/imaggif.cpp:133
+#: ../src/common/imaggif.cpp:130
 msgid "GIF: not enough memory."
 msgstr "GIF: bellek yetersiz."
 
-#: ../src/gtk/window.cpp:4631
+#: ../src/gtk/window.cpp:5635
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -3833,23 +3946,23 @@ msgstr ""
 "Yüklü GTK+ çok eski ve ekran karmayı desteklemiyor. Lütfen GTK+ 2.12 ya da "
 "üzeri bir sürüm yükleyin."
 
-#: ../src/univ/themes/gtk.cpp:525
+#: ../src/univ/themes/gtk.cpp:522
 msgid "GTK+ theme"
 msgstr "GTK+ teması"
 
-#: ../src/common/preferencescmn.cpp:40
+#: ../src/common/preferencescmn.cpp:37
 msgid "General"
 msgstr "Genel"
 
-#: ../src/common/prntbase.cpp:258
+#: ../src/common/prntbase.cpp:253
 msgid "Generic PostScript"
 msgstr "Genel PostScript"
 
-#: ../src/common/paper.cpp:135
+#: ../src/common/paper.cpp:132
 msgid "German Legal Fanfold, 8 1/2 x 13 in"
 msgstr "Alman Legal Fanfold, 8 1/2 x 13 inç"
 
-#: ../src/common/paper.cpp:134
+#: ../src/common/paper.cpp:131
 msgid "German Std Fanfold, 8 1/2 x 12 in"
 msgstr "Alman Standart Fanfold, 8 1/2 x 12 inç"
 
@@ -3867,48 +3980,48 @@ msgstr ""
 "'GetPropertyCollection' işlevi geçerli bir koleksiyon alıcısı olmaksızın "
 "çağrıldı"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:658
 msgid "Go back"
 msgstr "Geri git"
 
-#: ../src/html/helpwnd.cpp:661
+#: ../src/html/helpwnd.cpp:659
 msgid "Go forward"
 msgstr "İleri git"
 
-#: ../src/html/helpwnd.cpp:663
+#: ../src/html/helpwnd.cpp:661
 msgid "Go one level up in document hierarchy"
 msgstr "Belge hiyerarşisinde bir düzey yukarı git"
 
-#: ../src/generic/filedlgg.cpp:208 ../src/generic/dirdlgg.cpp:116
+#: ../src/generic/filedlgg.cpp:205 ../src/generic/dirdlgg.cpp:113
 msgid "Go to home directory"
 msgstr "Açılış klasörüne git"
 
-#: ../src/generic/filedlgg.cpp:205
+#: ../src/generic/filedlgg.cpp:202
 msgid "Go to parent directory"
 msgstr "Üst klasöre git"
 
-#: ../src/generic/aboutdlgg.cpp:76
+#: ../src/generic/aboutdlgg.cpp:73
 msgid "Graphics art by "
 msgstr "Grafikleri hazırlayan "
 
-#: ../src/propgrid/advprops.cpp:1599
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Gray"
 msgstr "Gri"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:883
+#: ../src/propgrid/advprops.cpp:784
 msgid "GrayText"
 msgstr "GriMetin"
 
-#: ../src/common/fmapbase.cpp:154
+#: ../src/common/fmapbase.cpp:151
 msgid "Greek (ISO-8859-7)"
 msgstr "Yunanca (ISO-8859-7)"
 
-#: ../src/propgrid/advprops.cpp:1600
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Green"
 msgstr "Yeşil"
 
-#: ../src/generic/colrdlgg.cpp:342
+#: ../src/generic/colrdlgg.cpp:362
 msgid "Green:"
 msgstr "Yeşil:"
 
@@ -3916,107 +4029,107 @@ msgstr "Yeşil:"
 msgid "Groove"
 msgstr "Groove"
 
-#: ../src/common/zstream.cpp:158 ../src/common/zstream.cpp:318
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
 msgid "Gzip not supported by this version of zlib"
 msgstr "Gzip bu Zlib sürümü tarafından desteklemiyor"
 
-#: ../src/html/helpwnd.cpp:1549
+#: ../src/html/helpwnd.cpp:1547
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "HTML Yardım Projesi (*.hhp)|*.hhp|"
 
-#: ../src/html/htmlwin.cpp:681
+#: ../src/html/htmlwin.cpp:691
 #, c-format
 msgid "HTML anchor %s does not exist."
 msgstr "%s HTML çapası bulunamadı."
 
-#: ../src/html/helpwnd.cpp:1547
+#: ../src/html/helpwnd.cpp:1545
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "HTML dosyaları (*.html;*.htm)|*.html;*.htm|"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1759
+#: ../src/propgrid/advprops.cpp:1660
 msgid "Hand"
 msgstr "El"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "Harddisk"
 msgstr "Sabit disk"
 
-#: ../src/common/fmapbase.cpp:155
+#: ../src/common/fmapbase.cpp:152
 msgid "Hebrew (ISO-8859-8)"
 msgstr "İbranice (ISO-8859-8)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:280 ../src/osx/button_osx.cpp:39
-#: ../src/common/stockitem.cpp:163 ../src/common/accelcmn.cpp:80
-#: ../src/html/helpdlg.cpp:66 ../src/html/helpfrm.cpp:111
+#: ../include/wx/msgdlg.h:282 ../src/osx/button_osx.cpp:39
+#: ../src/common/stockitem.cpp:160 ../src/common/accelcmn.cpp:77
+#: ../src/html/helpfrm.cpp:108 ../src/html/helpdlg.cpp:63
 msgid "Help"
 msgstr "Yardım"
 
-#: ../src/html/helpwnd.cpp:1200
+#: ../src/html/helpwnd.cpp:1198
 msgid "Help Browser Options"
 msgstr "Yardım Tarayıcısı Ayarları"
 
-#: ../src/generic/helpext.cpp:454 ../src/generic/helpext.cpp:455
+#: ../src/generic/helpext.cpp:452 ../src/generic/helpext.cpp:453
 msgid "Help Index"
 msgstr "Yardım Dizini"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1529
 msgid "Help Printing"
 msgstr "Yardım Yazdırma"
 
-#: ../src/html/helpwnd.cpp:801
+#: ../src/html/helpwnd.cpp:799
 msgid "Help Topics"
 msgstr "Yardım Konuları"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1546
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Yardım kitapları (*.htb)|*.htb|Yardım kitapları (*.zip)|*.zip|"
 
-#: ../src/generic/helpext.cpp:267
+#: ../src/generic/helpext.cpp:265
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "\"%s\" yardım klasörü bulunamadı."
 
-#: ../src/generic/helpext.cpp:275
+#: ../src/generic/helpext.cpp:273
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "\"%s\" yardım dosyası bulunamadı."
 
-#: ../src/html/helpctrl.cpp:63
+#: ../src/html/helpctrl.cpp:59
 #, c-format
 msgid "Help: %s"
 msgstr "Yardım: %s"
 
-#: ../src/osx/menu_osx.cpp:577
+#: ../src/osx/menu_osx.cpp:469
 #, c-format
 msgid "Hide %s"
 msgstr "%s gizle"
 
-#: ../src/osx/menu_osx.cpp:579
+#: ../src/osx/menu_osx.cpp:471
 msgid "Hide Others"
 msgstr "Diğerlerini Gizle"
 
-#: ../src/generic/infobar.cpp:84
+#: ../src/generic/infobar.cpp:81
 msgid "Hide this notification message."
 msgstr "Bu uyarı iletisini gizle."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:884
+#: ../src/propgrid/advprops.cpp:785
 msgid "Highlight"
 msgstr "Vurgu"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:885
+#: ../src/propgrid/advprops.cpp:786
 msgid "HighlightText"
 msgstr "VurguMetni"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:164 ../src/common/accelcmn.cpp:65
+#: ../src/common/stockitem.cpp:161 ../src/common/accelcmn.cpp:62
 msgid "Home"
 msgstr "Açılış"
 
-#: ../src/generic/dirctrlg.cpp:524
+#: ../src/generic/dirctrlg.cpp:490
 msgid "Home directory"
 msgstr "Açılış klasörü"
 
@@ -4026,62 +4139,62 @@ msgid "How the object will float relative to the text."
 msgstr "Nesnenin metne göre nasıl yüzeceği."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1760
+#: ../src/propgrid/advprops.cpp:1661
 msgid "I-Beam"
 msgstr "I-Işını"
 
-#: ../src/common/imagbmp.cpp:1196
+#: ../src/common/imagbmp.cpp:1208
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: DIB maskesi okuma sorunu."
 
-#: ../src/common/imagbmp.cpp:1290 ../src/common/imagbmp.cpp:1390
-#: ../src/common/imagbmp.cpp:1405 ../src/common/imagbmp.cpp:1416
-#: ../src/common/imagbmp.cpp:1430 ../src/common/imagbmp.cpp:1478
-#: ../src/common/imagbmp.cpp:1493 ../src/common/imagbmp.cpp:1507
-#: ../src/common/imagbmp.cpp:1518
+#: ../src/common/imagbmp.cpp:1302 ../src/common/imagbmp.cpp:1402
+#: ../src/common/imagbmp.cpp:1417 ../src/common/imagbmp.cpp:1428
+#: ../src/common/imagbmp.cpp:1442 ../src/common/imagbmp.cpp:1490
+#: ../src/common/imagbmp.cpp:1505 ../src/common/imagbmp.cpp:1519
+#: ../src/common/imagbmp.cpp:1530
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: Görsel dosyası yazma sorunu!"
 
-#: ../src/common/imagbmp.cpp:1255
+#: ../src/common/imagbmp.cpp:1267
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: Görsel simge için çok uzun."
 
-#: ../src/common/imagbmp.cpp:1263
+#: ../src/common/imagbmp.cpp:1275
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: Görsel simge için çok geniş."
 
-#: ../src/common/imagbmp.cpp:1603
+#: ../src/common/imagbmp.cpp:1615
 msgid "ICO: Invalid icon index."
 msgstr "ICO: Simge dizini geçersiz."
 
-#: ../src/common/imagiff.cpp:758
+#: ../src/common/imagiff.cpp:755
 msgid "IFF: data stream seems to be truncated."
 msgstr "IIF: veri akışı budanmış görünüyor."
 
-#: ../src/common/imagiff.cpp:742
+#: ../src/common/imagiff.cpp:739
 msgid "IFF: error in IFF image format."
 msgstr "IIF: IFF görsel biçimi hatası."
 
-#: ../src/common/imagiff.cpp:745
+#: ../src/common/imagiff.cpp:742
 msgid "IFF: not enough memory."
 msgstr "IIF: yetersiz bellek."
 
-#: ../src/common/imagiff.cpp:748
+#: ../src/common/imagiff.cpp:745
 msgid "IFF: unknown error!!!"
 msgstr "IIF: bilinmeyen hata!!!"
 
-#: ../src/common/fmapbase.cpp:197
+#: ../src/common/fmapbase.cpp:194
 msgid "ISO-2022-JP"
 msgstr "ISO-2022-JP"
 
-#: ../src/html/htmprint.cpp:282
+#: ../src/html/htmprint.cpp:294
 msgid ""
 "If possible, try changing the layout parameters to make the printout more "
 "narrow."
 msgstr ""
 "Olabiliyorsa, çıktıyı daraltmak için sayfa ayarlarını değiştirmeyi deneyin."
 
-#: ../src/generic/dbgrptg.cpp:358
+#: ../src/generic/dbgrptg.cpp:362
 msgid ""
 "If you have any additional information pertaining to this bug\n"
 "report, please enter it here and it will be joined to it:"
@@ -4100,46 +4213,50 @@ msgstr ""
 "ancak bu rapor, yazılımın geliştirilmesine yardımcı olabilir, \n"
 "bu nedenle olanağınız varsa raporu gönderin.\n"
 
-#: ../src/msw/registry.cpp:1405
+#: ../src/common/zipstrm.cpp:1043
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1393
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "\"%s\" değeri \"%s\" anahtarı için yok sayılıyor."
 
-#: ../src/common/xtistrm.cpp:295
+#: ../src/common/xtistrm.cpp:292
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Olay kaynağı nesne sınıfı geçersiz (Non-wxEvtHandler)"
 
-#: ../src/common/xti.cpp:513
+#: ../src/common/xti.cpp:510
 msgid "Illegal Parameter Count for ConstructObject Method"
 msgstr "ConstructObject yordamı için parametre sayısı geçersiz"
 
-#: ../src/common/xti.cpp:501
+#: ../src/common/xti.cpp:498
 msgid "Illegal Parameter Count for Create Method"
 msgstr "Create yordamı için parametre sayısı geçersiz"
 
-#: ../src/generic/dirctrlg.cpp:570 ../src/generic/filectrlg.cpp:756
+#: ../src/generic/dirctrlg.cpp:536 ../src/generic/filectrlg.cpp:752
 msgid "Illegal directory name."
 msgstr "Klasör adı geçersiz."
 
-#: ../src/generic/filectrlg.cpp:1367
+#: ../src/generic/filectrlg.cpp:1356
 msgid "Illegal file specification."
 msgstr "Dosya tanımı geçersiz."
 
-#: ../src/common/image.cpp:2269
+#: ../src/common/image.cpp:2363
 msgid "Image and mask have different sizes."
 msgstr "Görsel ve maske farklı boyutlarda."
 
-#: ../src/common/image.cpp:2746
+#: ../src/common/image.cpp:2841
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "Görsel dosyası %d türünde değil."
 
-#: ../src/common/image.cpp:2877
+#: ../src/common/image.cpp:2995
 #, c-format
 msgid "Image is not of type %s."
 msgstr "Görsel dosyası %s türünde değil."
 
-#: ../src/msw/textctrl.cpp:488
+#: ../src/msw/textctrl.cpp:534
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -4147,100 +4264,100 @@ msgstr ""
 "Zengin metin denetimi oluşturulamıyor. Onun yerine basit metin denetimi "
 "kullanılacak. Lütfen riched32.dll kitaplığını yeniden yükleyin."
 
-#: ../src/unix/utilsunx.cpp:301
+#: ../src/unix/utilsunx.cpp:303
 msgid "Impossible to get child process input"
 msgstr "Alt iş girdisi alınamıyor"
 
-#: ../src/common/filefn.cpp:1028
+#: ../src/common/filefn.cpp:917
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "'%s' dosyasının izinleri okunamıyor"
 
-#: ../src/common/filefn.cpp:1042
+#: ../src/common/filefn.cpp:931
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "'%s' dosyasının üzerine yazılamıyor"
 
-#: ../src/common/filefn.cpp:1097
+#: ../src/common/filefn.cpp:986
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "'%s' dosyasının izinleri değiştirilemiyor"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:886
+#: ../src/propgrid/advprops.cpp:787
 msgid "InactiveBorder"
 msgstr "DevredışıKenarlık"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:887
+#: ../src/propgrid/advprops.cpp:788
 msgid "InactiveCaption"
 msgstr "DevredışıBaşlık"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:888
+#: ../src/propgrid/advprops.cpp:789
 msgid "InactiveCaptionText"
 msgstr "DevredışıBaşlıkMetni"
 
-#: ../src/common/gifdecod.cpp:792
+#: ../src/common/gifdecod.cpp:826
 #, c-format
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "GIF kare sayısı yanlış (%u, %d) #%u karesi"
 
-#: ../src/msw/ole/automtn.cpp:635
+#: ../src/msw/ole/automtn.cpp:626
 msgid "Incorrect number of arguments."
 msgstr "Argüman sayısı hatalı."
 
-#: ../src/common/stockitem.cpp:165
+#: ../src/common/stockitem.cpp:162
 msgid "Indent"
 msgstr "Girinti"
 
-#: ../src/richtext/richtextformatdlg.cpp:349
+#: ../src/richtext/richtextformatdlg.cpp:342
 msgid "Indents && Spacing"
 msgstr "Girinti ve Boşluklar"
 
-#: ../src/common/stockitem.cpp:166 ../src/html/helpwnd.cpp:515
+#: ../src/common/stockitem.cpp:163 ../src/html/helpwnd.cpp:513
 msgid "Index"
 msgstr "Dizin"
 
-#: ../src/common/fmapbase.cpp:159
+#: ../src/common/fmapbase.cpp:156
 msgid "Indian (ISO-8859-12)"
 msgstr "Hintçe (ISO-8859-12)"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "Info"
 msgstr "Bilgiler"
 
-#: ../src/common/init.cpp:287
+#: ../src/common/init.cpp:284
 msgid "Initialization failed in post init, aborting."
 msgstr "Hazırlığın ardından başlatılamadı, vazgeçiliyor."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:54
+#: ../src/common/accelcmn.cpp:51
 msgid "Ins"
 msgstr "Ins"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextsymboldlg.cpp:472 ../src/common/accelcmn.cpp:53
+#: ../src/common/accelcmn.cpp:50 ../src/richtext/richtextsymboldlg.cpp:469
 msgid "Insert"
 msgstr "Ekle"
 
-#: ../src/richtext/richtextbuffer.cpp:8067
+#: ../src/richtext/richtextbuffer.cpp:8063
 msgid "Insert Field"
 msgstr "Alan Ekle"
 
-#: ../src/richtext/richtextbuffer.cpp:7978
-#: ../src/richtext/richtextbuffer.cpp:8936
+#: ../src/richtext/richtextbuffer.cpp:7974
+#: ../src/richtext/richtextbuffer.cpp:8934
 msgid "Insert Image"
 msgstr "Görsel Ekle"
 
-#: ../src/richtext/richtextbuffer.cpp:8025
+#: ../src/richtext/richtextbuffer.cpp:8021
 msgid "Insert Object"
 msgstr "Nesne Ekle"
 
-#: ../src/richtext/richtextctrl.cpp:1286 ../src/richtext/richtextctrl.cpp:1494
-#: ../src/richtext/richtextbuffer.cpp:7822
-#: ../src/richtext/richtextbuffer.cpp:7852
-#: ../src/richtext/richtextbuffer.cpp:7894
+#: ../src/richtext/richtextbuffer.cpp:7818
+#: ../src/richtext/richtextbuffer.cpp:7848
+#: ../src/richtext/richtextbuffer.cpp:7890
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
 msgid "Insert Text"
 msgstr "Metin Ekle"
 
@@ -4253,16 +4370,11 @@ msgstr "Paragraftan önce bir sayfa sonu ekler."
 msgid "Inset"
 msgstr "Gömme"
 
-#: ../src/gtk/app.cpp:425
-#, c-format
-msgid "Invalid GTK+ command line option, use \"%s --help\""
-msgstr "Geçersiz GTK+ komut satırı seçeneği, \"%s --help\" yazarak yardım alın"
-
-#: ../src/common/imagtiff.cpp:311
+#: ../src/common/imagtiff.cpp:308
 msgid "Invalid TIFF image index."
 msgstr "TIFF görsel dizini geçersiz."
 
-#: ../src/common/appcmn.cpp:273
+#: ../src/common/appcmn.cpp:294
 #, c-format
 msgid "Invalid display mode specification '%s'."
 msgstr "'%s' görünüm kipi özelliği geçersiz."
@@ -4272,246 +4384,250 @@ msgstr "'%s' görünüm kipi özelliği geçersiz."
 msgid "Invalid geometry specification '%s'"
 msgstr "'%s' geometri özelliği geçersiz."
 
-#: ../src/unix/fswatcher_inotify.cpp:323
+#: ../src/unix/fswatcher_inotify.cpp:320
 #, c-format
 msgid "Invalid inotify event for \"%s\""
 msgstr "\"%s\" için inotify etkinliği geçersiz."
 
-#: ../src/unix/snglinst.cpp:312
+#: ../src/unix/snglinst.cpp:309
 #, c-format
 msgid "Invalid lock file '%s'."
 msgstr "'%s' kilit dosyası geçersiz."
 
-#: ../src/common/translation.cpp:1125
+#: ../src/common/translation.cpp:1167
 msgid "Invalid message catalog."
 msgstr "İleti kataloğu geçersiz."
 
-#: ../src/common/xtistrm.cpp:405 ../src/common/xtistrm.cpp:420
+#: ../src/common/xtistrm.cpp:402 ../src/common/xtistrm.cpp:417
 msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
 msgstr "GetObjectClassInfo işlevine geçersiz ya da boş nesne kodu gönderildi"
 
-#: ../src/common/xtistrm.cpp:435
+#: ../src/common/xtistrm.cpp:432
 msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
 msgstr "HasObjectClassInfo işlevine geçersiz ya da boş nesne kodu gönderildi"
 
-#: ../src/common/regex.cpp:310
+#: ../src/common/regex.cpp:307
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Kurallı ifade geçersiz '%s': %s"
 
-#: ../src/common/config.cpp:226
+#: ../src/common/config.cpp:222
 #, c-format
 msgid "Invalid value %ld for a boolean key \"%s\" in config file."
 msgstr "Ayar dosyasındaki %ld değeri \"%s\" ikili anahtarı geçersiz."
 
-#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:351
-#: ../src/osx/carbon/fontdlg.cpp:361 ../src/common/stockitem.cpp:168
+#: ../src/osx/carbon/fontdlg.cpp:358 ../src/common/stockitem.cpp:165
+#: ../src/generic/fontdlgg.cpp:325 ../src/richtext/richtextfontpage.cpp:351
 msgid "Italic"
 msgstr "Yatık"
 
-#: ../src/common/paper.cpp:130
+#: ../src/common/paper.cpp:127
 msgid "Italy Envelope, 110 x 230 mm"
 msgstr "İtalyan Zarf, 110 x 230 mm"
 
-#: ../src/common/imagjpeg.cpp:270
+#: ../src/common/imagjpeg.cpp:257
 msgid "JPEG: Couldn't load - file is probably corrupted."
 msgstr "JPEG: Yüklenemedi - dosya bozuk olabilir."
 
-#: ../src/common/imagjpeg.cpp:449
+#: ../src/common/imagjpeg.cpp:436
 msgid "JPEG: Couldn't save image."
 msgstr "JPEG: Görsel kaydedilemedi."
 
-#: ../src/common/paper.cpp:163
+#: ../src/common/paper.cpp:160
 msgid "Japanese Double Postcard 200 x 148 mm"
 msgstr "Japon Çift Postakartı 200 x 148 mm"
 
-#: ../src/common/paper.cpp:167
+#: ../src/common/paper.cpp:164
 msgid "Japanese Envelope Chou #3"
 msgstr "Japon Zarf Chou #3"
 
-#: ../src/common/paper.cpp:180
+#: ../src/common/paper.cpp:177
 msgid "Japanese Envelope Chou #3 Rotated"
 msgstr "Japon Zarf Chou #3 Çevrilmiş"
 
-#: ../src/common/paper.cpp:168
+#: ../src/common/paper.cpp:165
 msgid "Japanese Envelope Chou #4"
 msgstr "Japon Zarf Chou #4"
 
-#: ../src/common/paper.cpp:181
+#: ../src/common/paper.cpp:178
 msgid "Japanese Envelope Chou #4 Rotated"
 msgstr "Japon Zarf Chou #4 Çevrilmiş"
 
-#: ../src/common/paper.cpp:165
+#: ../src/common/paper.cpp:162
 msgid "Japanese Envelope Kaku #2"
 msgstr "Japon Zarf Kaku #2"
 
-#: ../src/common/paper.cpp:178
+#: ../src/common/paper.cpp:175
 msgid "Japanese Envelope Kaku #2 Rotated"
 msgstr "Japon Zarf Kaku #2 Çevrilmiş"
 
-#: ../src/common/paper.cpp:166
+#: ../src/common/paper.cpp:163
 msgid "Japanese Envelope Kaku #3"
 msgstr "Japon Zarf Kaku #3"
 
-#: ../src/common/paper.cpp:179
+#: ../src/common/paper.cpp:176
 msgid "Japanese Envelope Kaku #3 Rotated"
 msgstr "Japon Zarf Kaku #3 Çevrilmiş"
 
-#: ../src/common/paper.cpp:185
+#: ../src/common/paper.cpp:182
 msgid "Japanese Envelope You #4"
 msgstr "Japon Zarf You #4"
 
-#: ../src/common/paper.cpp:186
+#: ../src/common/paper.cpp:183
 msgid "Japanese Envelope You #4 Rotated"
 msgstr "Japon Zarf You #4 Çevrilmiş"
 
-#: ../src/common/paper.cpp:138
+#: ../src/common/paper.cpp:135
 msgid "Japanese Postcard 100 x 148 mm"
 msgstr "Japon Postakartı 100 x 148 mm"
 
-#: ../src/common/paper.cpp:175
+#: ../src/common/paper.cpp:172
 msgid "Japanese Postcard Rotated 148 x 100 mm"
 msgstr "Japon Postakartı Çevrilmiş 148 x 100 mm"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "Jump to"
 msgstr "Atla"
 
-#: ../src/common/stockitem.cpp:171
+#: ../src/common/stockitem.cpp:168
 msgid "Justified"
 msgstr "Hizalanmış"
 
-#: ../src/richtext/richtextindentspage.cpp:155
-#: ../src/richtext/richtextindentspage.cpp:157
 #: ../src/richtext/richtextliststylepage.cpp:344
 #: ../src/richtext/richtextliststylepage.cpp:346
+#: ../src/richtext/richtextindentspage.cpp:155
+#: ../src/richtext/richtextindentspage.cpp:157
 msgid "Justify text left and right."
 msgstr "Metin sola ve sağa hizalanır."
 
-#: ../src/common/fmapbase.cpp:163
+#: ../src/common/fmapbase.cpp:160
 msgid "KOI8-R"
 msgstr "KOI8-R"
 
-#: ../src/common/fmapbase.cpp:164
+#: ../src/common/fmapbase.cpp:161
 msgid "KOI8-U"
 msgstr "KOI8-U"
 
-#: ../src/common/accelcmn.cpp:265 ../src/common/accelcmn.cpp:347
+#: ../src/common/accelcmn.cpp:279 ../src/common/accelcmn.cpp:364
 msgid "KP_"
 msgstr "KP_"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "KP_Add"
 msgstr "TT_Ekleme"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "KP_Begin"
 msgstr "TT_Başlangıç"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "KP_Decimal"
 msgstr "TT_Ondalık"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 msgid "KP_Delete"
 msgstr "TT_Del"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "KP_Divide"
 msgstr "TT_Bölü"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 msgid "KP_Down"
 msgstr "TT_Aşağı"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "KP_End"
 msgstr "TT_End"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "KP_Enter"
 msgstr "TT_Enter"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "KP_Equal"
 msgstr "TT_Eşit"
 
+#: ../src/common/accelcmn.cpp:276 ../src/common/accelcmn.cpp:361
+msgid "KP_F"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 msgid "KP_Home"
 msgstr "TT_Home"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 msgid "KP_Insert"
 msgstr "TT_Insert"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "KP_Left"
 msgstr "TT_Sol"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "KP_Multiply"
 msgstr "TT_Çarpı"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:99
+#: ../src/common/accelcmn.cpp:97
 msgid "KP_Next"
 msgstr "TT_Next"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "KP_PageDown"
 msgstr "TT_PageDown"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "KP_PageUp"
 msgstr "TT_PageUp"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:98
+#: ../src/common/accelcmn.cpp:96
 msgid "KP_Prior"
 msgstr "TT_Önceki"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 msgid "KP_Right"
 msgstr "TT_Sağ"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "KP_Separator"
 msgstr "TT_Ayıraç"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "KP_Space"
 msgstr "TT_Boşluk"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "KP_Subtract"
 msgstr "TT_Eksi"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "KP_Tab"
 msgstr "TT_Sekme"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "KP_Up"
 msgstr "TT_Yukarı"
 
@@ -4519,111 +4635,126 @@ msgstr "TT_Yukarı"
 msgid "L&ine spacing:"
 msgstr "&Satır aralığı:"
 
-#: ../src/generic/prntdlgg.cpp:613 ../src/generic/prntdlgg.cpp:868
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "sıkıştırma sorunu"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "ayıklama sorunu"
+
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:861
 msgid "Landscape"
 msgstr "Yatay"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "Last"
 msgstr "Son"
 
-#: ../src/common/prntbase.cpp:1572
+#: ../src/common/prntbase.cpp:1597
 msgid "Last page"
 msgstr "Son sayfa"
 
-#: ../src/common/log.cpp:305
+#: ../src/common/log.cpp:324
 #, c-format
 msgid "Last repeated message (\"%s\", %u time) wasn't output"
 msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
 msgstr[0] "Son yinelenen ileti (\"%s\", %u kez) çıkartılmadı"
 
-#: ../src/common/paper.cpp:103
+#: ../src/common/paper.cpp:100
 msgid "Ledger, 17 x 11 in"
 msgstr "Ledger, 17 x 11 inç"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6146
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:58 ../src/generic/datavgen.cpp:6951
+#: ../src/richtext/richtextsizepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:252
 #: ../src/richtext/richtextliststylepage.cpp:253
 #: ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
-#: ../src/richtext/richtextsizepage.cpp:249 ../src/common/accelcmn.cpp:61
 msgid "Left"
 msgstr "Sol"
 
-#: ../src/richtext/richtextindentspage.cpp:204
 #: ../src/richtext/richtextliststylepage.cpp:390
+#: ../src/richtext/richtextindentspage.cpp:204
 msgid "Left (&first line):"
 msgstr "Sol (i&lk satır):"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1761
+#: ../src/propgrid/advprops.cpp:1662
 msgid "Left Button"
 msgstr "Sol Düğme"
 
-#: ../src/generic/prntdlgg.cpp:880
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Left margin (mm):"
 msgstr "Sol kenar boşluğu (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:141
-#: ../src/richtext/richtextindentspage.cpp:143
 #: ../src/richtext/richtextliststylepage.cpp:330
 #: ../src/richtext/richtextliststylepage.cpp:332
+#: ../src/richtext/richtextindentspage.cpp:141
+#: ../src/richtext/richtextindentspage.cpp:143
 msgid "Left-align text."
 msgstr "Metin sola yaslanır."
 
-#: ../src/common/paper.cpp:144
+#: ../src/common/paper.cpp:141
 msgid "Legal Extra 9 1/2 x 15 in"
 msgstr "Legal Ek 9 1/2 x 15 inç"
 
-#: ../src/common/paper.cpp:96
+#: ../src/common/paper.cpp:93
 msgid "Legal, 8 1/2 x 14 in"
 msgstr "Legal, 8 1/2 x 14 inç"
 
-#: ../src/common/paper.cpp:143
+#: ../src/common/paper.cpp:140
 msgid "Letter Extra 9 1/2 x 12 in"
 msgstr "Letter Ek 9 1/2 x 12 inç"
 
-#: ../src/common/paper.cpp:149
+#: ../src/common/paper.cpp:146
 msgid "Letter Extra Transverse 9.275 x 12 in"
 msgstr "Letter Ek Enine 9.275 x 12 inç"
 
-#: ../src/common/paper.cpp:152
+#: ../src/common/paper.cpp:149
 msgid "Letter Plus 8 1/2 x 12.69 in"
 msgstr "Letter Artı 8 1/2 x 12.69 inç"
 
-#: ../src/common/paper.cpp:169
+#: ../src/common/paper.cpp:166
 msgid "Letter Rotated 11 x 8 1/2 in"
 msgstr "Letter Çevrilmiş 11 x 8 1/2 inç"
 
-#: ../src/common/paper.cpp:101
+#: ../src/common/paper.cpp:98
 msgid "Letter Small, 8 1/2 x 11 in"
 msgstr "Letter Küçük, 8 1/2 x 11 inç"
 
-#: ../src/common/paper.cpp:147
+#: ../src/common/paper.cpp:144
 msgid "Letter Transverse 8 1/2 x 11 in"
 msgstr "Letter Enine 8 1/2 x 11 inç"
 
-#: ../src/common/paper.cpp:95
+#: ../src/common/paper.cpp:92
 msgid "Letter, 8 1/2 x 11 in"
 msgstr "Letter, 8 1/2 x 11 inç"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "License"
 msgstr "Lisans"
 
-#: ../src/generic/fontdlgg.cpp:332
+#: ../src/generic/fontdlgg.cpp:328
 msgid "Light"
 msgstr "Açık"
 
-#: ../src/propgrid/advprops.cpp:1608
+#: ../src/propgrid/advprops.cpp:1514
 msgid "Lime"
 msgstr "Limon"
 
-#: ../src/generic/helpext.cpp:294
+#: ../src/generic/helpext.cpp:292
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr ""
@@ -4633,15 +4764,15 @@ msgstr ""
 msgid "Line spacing:"
 msgstr "Satır aralığı:"
 
-#: ../src/html/chm.cpp:838
+#: ../src/html/chm.cpp:829
 msgid "Link contained '//', converted to absolute link."
 msgstr "Bağlantı '//' içeriyor, mutlak bağlantıya dönüştürüldü."
 
-#: ../src/richtext/richtextformatdlg.cpp:364
+#: ../src/richtext/richtextformatdlg.cpp:357
 msgid "List Style"
 msgstr "Liste Biçemi"
 
-#: ../src/richtext/richtextstyles.cpp:1064
+#: ../src/richtext/richtextstyles.cpp:1061
 msgid "List styles"
 msgstr "Liste biçemleri"
 
@@ -4655,26 +4786,26 @@ msgstr "Yazı türü boyutları punto olarak listelenir."
 msgid "Lists the available fonts."
 msgstr "Kullanılabilir yazı türleri listelenir."
 
-#: ../src/common/fldlgcmn.cpp:340
+#: ../src/common/fldlgcmn.cpp:337
 #, c-format
 msgid "Load %s file"
 msgstr "%s dosyasını yükle"
 
-#: ../src/html/htmlwin.cpp:597
+#: ../src/html/htmlwin.cpp:600
 msgid "Loading : "
 msgstr "Yükleniyor : "
 
-#: ../src/unix/snglinst.cpp:246
+#: ../src/unix/snglinst.cpp:243
 #, c-format
 msgid "Lock file '%s' has incorrect owner."
 msgstr "'%s' kilit dosyasının sahibi hatalı."
 
-#: ../src/unix/snglinst.cpp:251
+#: ../src/unix/snglinst.cpp:248
 #, c-format
 msgid "Lock file '%s' has incorrect permissions."
 msgstr "'%s' kilit dosyasının izinleri doğru değil."
 
-#: ../src/generic/logg.cpp:576
+#: ../src/generic/logg.cpp:573
 #, c-format
 msgid "Log saved to the file '%s'."
 msgstr "Günlük '%s' dosyasına kaydedildi."
@@ -4689,11 +4820,11 @@ msgstr "Küçük harfler"
 msgid "Lower case roman numerals"
 msgstr "Küçük harf Romen rakamları"
 
-#: ../src/gtk/mdi.cpp:422 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk1/mdi.cpp:431 ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "MDI alt"
 
-#: ../src/msw/helpchm.cpp:56
+#: ../src/msw/helpchm.cpp:53
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -4701,189 +4832,189 @@ msgstr ""
 "MS HTML Yardım kitaplığı yüklü olmadığından yardım işlevleri kullanılamıyor. "
 "Lütfen yükleyin."
 
-#: ../src/univ/themes/win32.cpp:3754
+#: ../src/univ/themes/win32.cpp:3751
 msgid "Ma&ximize"
 msgstr "Ekranı &kaplat"
 
-#: ../src/common/fmapbase.cpp:203
+#: ../src/common/fmapbase.cpp:200
 msgid "MacArabic"
 msgstr "MacArapça"
 
-#: ../src/common/fmapbase.cpp:222
+#: ../src/common/fmapbase.cpp:219
 msgid "MacArmenian"
 msgstr "MacErmenice"
 
-#: ../src/common/fmapbase.cpp:211
+#: ../src/common/fmapbase.cpp:208
 msgid "MacBengali"
 msgstr "MacBengalce"
 
-#: ../src/common/fmapbase.cpp:217
+#: ../src/common/fmapbase.cpp:214
 msgid "MacBurmese"
 msgstr "MacBurmese"
 
-#: ../src/common/fmapbase.cpp:236
+#: ../src/common/fmapbase.cpp:233
 msgid "MacCeltic"
 msgstr "MacKeltçe"
 
-#: ../src/common/fmapbase.cpp:227
+#: ../src/common/fmapbase.cpp:224
 msgid "MacCentralEurRoman"
 msgstr "MacOrtaAvrupaRoman"
 
-#: ../src/common/fmapbase.cpp:223
+#: ../src/common/fmapbase.cpp:220
 msgid "MacChineseSimp"
 msgstr "MacÇinceBasit"
 
-#: ../src/common/fmapbase.cpp:201
+#: ../src/common/fmapbase.cpp:198
 msgid "MacChineseTrad"
 msgstr "MacÇinceGeleneksel"
 
-#: ../src/common/fmapbase.cpp:233
+#: ../src/common/fmapbase.cpp:230
 msgid "MacCroatian"
 msgstr "MacHırvatça"
 
-#: ../src/common/fmapbase.cpp:206
+#: ../src/common/fmapbase.cpp:203
 msgid "MacCyrillic"
 msgstr "MacKiril"
 
-#: ../src/common/fmapbase.cpp:207
+#: ../src/common/fmapbase.cpp:204
 msgid "MacDevanagari"
 msgstr "MacDevanagari"
 
-#: ../src/common/fmapbase.cpp:231
+#: ../src/common/fmapbase.cpp:228
 msgid "MacDingbats"
 msgstr "MacDingbats"
 
-#: ../src/common/fmapbase.cpp:226
+#: ../src/common/fmapbase.cpp:223
 msgid "MacEthiopic"
 msgstr "MacEtyopça"
 
-#: ../src/common/fmapbase.cpp:229
+#: ../src/common/fmapbase.cpp:226
 msgid "MacExtArabic"
 msgstr "MacExtArapça"
 
-#: ../src/common/fmapbase.cpp:237
+#: ../src/common/fmapbase.cpp:234
 msgid "MacGaelic"
 msgstr "MacGaliçce"
 
-#: ../src/common/fmapbase.cpp:221
+#: ../src/common/fmapbase.cpp:218
 msgid "MacGeorgian"
 msgstr "MacAzerice"
 
-#: ../src/common/fmapbase.cpp:205
+#: ../src/common/fmapbase.cpp:202
 msgid "MacGreek"
 msgstr "MacYunanca"
 
-#: ../src/common/fmapbase.cpp:209
+#: ../src/common/fmapbase.cpp:206
 msgid "MacGujarati"
 msgstr "MacGujarati"
 
-#: ../src/common/fmapbase.cpp:208
+#: ../src/common/fmapbase.cpp:205
 msgid "MacGurmukhi"
 msgstr "MacGurmukhi"
 
-#: ../src/common/fmapbase.cpp:204
+#: ../src/common/fmapbase.cpp:201
 msgid "MacHebrew"
 msgstr "Macİbranice"
 
-#: ../src/common/fmapbase.cpp:234
+#: ../src/common/fmapbase.cpp:231
 msgid "MacIcelandic"
 msgstr "MacIzlandaca"
 
-#: ../src/common/fmapbase.cpp:200
+#: ../src/common/fmapbase.cpp:197
 msgid "MacJapanese"
 msgstr "MacJaponca"
 
-#: ../src/common/fmapbase.cpp:214
+#: ../src/common/fmapbase.cpp:211
 msgid "MacKannada"
 msgstr "MacKanada"
 
-#: ../src/common/fmapbase.cpp:238
+#: ../src/common/fmapbase.cpp:235
 msgid "MacKeyboardGlyphs"
 msgstr "MacKeyboardGlyphs"
 
-#: ../src/common/fmapbase.cpp:218
+#: ../src/common/fmapbase.cpp:215
 msgid "MacKhmer"
 msgstr "MacKmerce"
 
-#: ../src/common/fmapbase.cpp:202
+#: ../src/common/fmapbase.cpp:199
 msgid "MacKorean"
 msgstr "MacKorece"
 
-#: ../src/common/fmapbase.cpp:220
+#: ../src/common/fmapbase.cpp:217
 msgid "MacLaotian"
 msgstr "MacLaotian"
 
-#: ../src/common/fmapbase.cpp:215
+#: ../src/common/fmapbase.cpp:212
 msgid "MacMalayalam"
 msgstr "MacMalayca"
 
-#: ../src/common/fmapbase.cpp:225
+#: ../src/common/fmapbase.cpp:222
 msgid "MacMongolian"
 msgstr "MacMongolca"
 
-#: ../src/common/fmapbase.cpp:210
+#: ../src/common/fmapbase.cpp:207
 msgid "MacOriya"
 msgstr "MacOriya"
 
-#: ../src/common/fmapbase.cpp:199
+#: ../src/common/fmapbase.cpp:196
 msgid "MacRoman"
 msgstr "MacRoman"
 
-#: ../src/common/fmapbase.cpp:235
+#: ../src/common/fmapbase.cpp:232
 msgid "MacRomanian"
 msgstr "MacRomence"
 
-#: ../src/common/fmapbase.cpp:216
+#: ../src/common/fmapbase.cpp:213
 msgid "MacSinhalese"
 msgstr "MacSinhalese"
 
-#: ../src/common/fmapbase.cpp:230
+#: ../src/common/fmapbase.cpp:227
 msgid "MacSymbol"
 msgstr "MacSimge"
 
-#: ../src/common/fmapbase.cpp:212
+#: ../src/common/fmapbase.cpp:209
 msgid "MacTamil"
 msgstr "MacTamil"
 
-#: ../src/common/fmapbase.cpp:213
+#: ../src/common/fmapbase.cpp:210
 msgid "MacTelugu"
 msgstr "MacTelugu"
 
-#: ../src/common/fmapbase.cpp:219
+#: ../src/common/fmapbase.cpp:216
 msgid "MacThai"
 msgstr "MacTay"
 
-#: ../src/common/fmapbase.cpp:224
+#: ../src/common/fmapbase.cpp:221
 msgid "MacTibetan"
 msgstr "MacTibetçe"
 
-#: ../src/common/fmapbase.cpp:232
+#: ../src/common/fmapbase.cpp:229
 msgid "MacTurkish"
 msgstr "MacTürkçe"
 
-#: ../src/common/fmapbase.cpp:228
+#: ../src/common/fmapbase.cpp:225
 msgid "MacVietnamese"
 msgstr "MacVietnamca"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1762
+#: ../src/propgrid/advprops.cpp:1663
 msgid "Magnifier"
 msgstr "Büyüteç"
 
-#: ../src/propgrid/advprops.cpp:2143
+#: ../src/propgrid/advprops.cpp:2050
 msgid "Make a selection:"
 msgstr "Bir seçim yapın:"
 
-#: ../src/richtext/richtextformatdlg.cpp:374
+#: ../src/richtext/richtextformatdlg.cpp:367
 #: ../src/richtext/richtextmarginspage.cpp:171
 msgid "Margins"
 msgstr "Kenar Boşlukları"
 
-#: ../src/propgrid/advprops.cpp:1595
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Maroon"
 msgstr "Kestane"
 
-#: ../src/generic/fdrepdlg.cpp:147
+#: ../src/generic/fdrepdlg.cpp:144
 msgid "Match case"
 msgstr "Küçük büyük harf eşleştirilsin"
 
@@ -4895,40 +5026,40 @@ msgstr "En fazla yükseklik:"
 msgid "Max width:"
 msgstr "En fazla genişlik:"
 
-#: ../src/unix/mediactrl.cpp:947
+#: ../src/unix/mediactrl.cpp:972
 #, c-format
 msgid "Media playback error: %s"
 msgstr "Ortam oynatma hatası: %s"
 
-#: ../src/common/fs_mem.cpp:175
+#: ../src/common/fs_mem.cpp:170
 #, c-format
 msgid "Memory VFS already contains file '%s'!"
 msgstr "'%s' dosyası zaten VFS belleğinde yer alıyor!"
 
 #. TRANSLATORS: Name of keyboard key
 #. TRANSLATORS: Keyword of system colour
-#: ../src/common/accelcmn.cpp:73 ../src/propgrid/advprops.cpp:889
+#: ../src/common/accelcmn.cpp:70 ../src/propgrid/advprops.cpp:790
 msgid "Menu"
 msgstr "Menü"
 
-#: ../src/common/msgout.cpp:124
+#: ../src/common/msgout.cpp:121
 msgid "Message"
 msgstr "İleti"
 
-#: ../src/univ/themes/metal.cpp:168
+#: ../src/univ/themes/metal.cpp:165
 msgid "Metal theme"
 msgstr "Metal tema"
 
-#: ../src/msw/ole/automtn.cpp:652
+#: ../src/msw/ole/automtn.cpp:643
 msgid "Method or property not found."
 msgstr "Yordam ya da özellik bulunamadı."
 
-#: ../src/univ/themes/win32.cpp:3752
+#: ../src/univ/themes/win32.cpp:3749
 msgid "Mi&nimize"
 msgstr "Simge &durumuna küçült"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1763
+#: ../src/propgrid/advprops.cpp:1664
 msgid "Middle Button"
 msgstr "Orta Düğme"
 
@@ -4940,36 +5071,41 @@ msgstr "En az yükseklik:"
 msgid "Min width:"
 msgstr "En az genişlik:"
 
-#: ../src/msw/ole/automtn.cpp:668
+#: ../src/osx/cocoa/menu.mm:281
+#, fuzzy
+msgid "Minimize"
+msgstr "Simge &durumuna küçült"
+
+#: ../src/msw/ole/automtn.cpp:659
 msgid "Missing a required parameter."
 msgstr "Gereken bir parametre eksik."
 
-#: ../src/generic/fontdlgg.cpp:324
+#: ../src/generic/fontdlgg.cpp:320
 msgid "Modern"
 msgstr "Modern"
 
-#: ../src/generic/filectrlg.cpp:427
+#: ../src/generic/filectrlg.cpp:423
 msgid "Modified"
 msgstr "Değişiklik"
 
-#: ../src/common/module.cpp:133
+#: ../src/common/module.cpp:130
 #, c-format
 msgid "Module \"%s\" initialization failed"
 msgstr "\"%s\" modülü başlatılamadı"
 
-#: ../src/common/paper.cpp:131
+#: ../src/common/paper.cpp:128
 msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
 msgstr "Monarşi Zarf, 3 7/8 x 7 1/2 inç"
 
-#: ../src/msw/fswatcher.cpp:143
+#: ../src/msw/fswatcher.cpp:140
 msgid "Monitoring individual files for changes is not supported currently."
 msgstr "Tek tek dosyaların değişiminin izlenmesi şu anda desteklenmiyor."
 
-#: ../src/generic/editlbox.cpp:172
+#: ../src/generic/editlbox.cpp:160
 msgid "Move down"
 msgstr "Aşağı taşı"
 
-#: ../src/generic/editlbox.cpp:171
+#: ../src/generic/editlbox.cpp:155
 msgid "Move up"
 msgstr "Yukarı taşı"
 
@@ -4983,97 +5119,103 @@ msgstr "Nesneyi sonraki paragrafa taşır."
 msgid "Moves the object to the previous paragraph."
 msgstr "Nesneyi önceki paragrafa taşır."
 
-#: ../src/richtext/richtextbuffer.cpp:9966
+#: ../src/richtext/richtextbuffer.cpp:9963
 msgid "Multiple Cell Properties"
 msgstr "Çoklu Hücre Özellikleri"
 
-#: ../src/generic/filectrlg.cpp:424
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:82
+#, fuzzy
+msgid "Multiply"
+msgstr "TT_Çarpı"
+
+#: ../src/generic/filectrlg.cpp:420
 msgid "Name"
 msgstr "Ad"
 
-#: ../src/propgrid/advprops.cpp:1596
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Navy"
 msgstr "Lacivert"
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "Network"
 msgstr "Ağ"
 
-#: ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173
 msgid "New"
 msgstr "Yeni"
 
-#: ../src/richtext/richtextstyledlg.cpp:243
+#: ../src/richtext/richtextstyledlg.cpp:239
 msgid "New &Box Style..."
 msgstr "Yeni &Kutu Biçemi..."
 
-#: ../src/richtext/richtextstyledlg.cpp:225
+#: ../src/richtext/richtextstyledlg.cpp:221
 msgid "New &Character Style..."
 msgstr "Yeni &Karakter Biçemi..."
 
-#: ../src/richtext/richtextstyledlg.cpp:237
+#: ../src/richtext/richtextstyledlg.cpp:233
 msgid "New &List Style..."
 msgstr "Yeni &Liste Biçemi..."
 
-#: ../src/richtext/richtextstyledlg.cpp:231
+#: ../src/richtext/richtextstyledlg.cpp:227
 msgid "New &Paragraph Style..."
 msgstr "Yeni &Paragraf Biçemi..."
 
-#: ../src/richtext/richtextstyledlg.cpp:606
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:654
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:820
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:893
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:934
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:602
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:650
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:816
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:889
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:930
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "New Style"
 msgstr "Yeni Biçem"
 
-#: ../src/generic/editlbox.cpp:169
+#: ../src/generic/editlbox.cpp:139
 msgid "New item"
 msgstr "Yeni öge"
 
-#: ../src/generic/dirdlgg.cpp:297 ../src/generic/dirdlgg.cpp:307
-#: ../src/generic/filectrlg.cpp:618 ../src/generic/filectrlg.cpp:627
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+#: ../src/generic/dirdlgg.cpp:294 ../src/generic/dirdlgg.cpp:304
 msgid "NewName"
 msgstr "YeniAd"
 
-#: ../src/common/prntbase.cpp:1567 ../src/html/helpwnd.cpp:665
+#: ../src/common/prntbase.cpp:1592 ../src/html/helpwnd.cpp:663
 msgid "Next page"
 msgstr "Sonraki sayfa"
 
-#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:177
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:174
 #: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Hayır"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1764
+#: ../src/propgrid/advprops.cpp:1665
 msgid "No Entry"
 msgstr "Kayıt Yok"
 
-#: ../src/generic/animateg.cpp:150
+#: ../src/generic/animateg.cpp:133
 #, c-format
 msgid "No animation handler for type %ld defined."
 msgstr "%ld türü için canlandırma işleyicisi tanımlanmamış."
 
-#: ../src/dfb/bitmap.cpp:642 ../src/dfb/bitmap.cpp:676
+#: ../src/dfb/bitmap.cpp:639 ../src/dfb/bitmap.cpp:673
 #, c-format
 msgid "No bitmap handler for type %d defined."
 msgstr "%d türü için bit eşlemi işleyicisi tanımlanmamış."
 
-#: ../src/common/utilscmn.cpp:1077
+#: ../src/common/utilscmn.cpp:1095
 msgid "No default application configured for HTML files."
 msgstr "HTML dosyaları için varsayılan uygulama ayarlanmamış."
 
-#: ../src/generic/helpext.cpp:445
+#: ../src/generic/helpext.cpp:443
 msgid "No entries found."
 msgstr "Hiç bir kayıt bulunamadı."
 
-#: ../src/common/fontmap.cpp:421
+#: ../src/common/fontmap.cpp:418
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found,\n"
@@ -5086,7 +5228,7 @@ msgstr ""
 "Bu kodlamayı kullanmak istiyor musunuz (aksi halde başka bir tane "
 "seçmelisiniz) ?"
 
-#: ../src/common/fontmap.cpp:426
+#: ../src/common/fontmap.cpp:423
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found.\n"
@@ -5097,201 +5239,201 @@ msgstr ""
 "Bu kodlamayı kullanabileceğiniz bir yazı türü seçmek istiyor musunuz\n"
 "(aksi halde bu kodlamadaki metin doğru olarak görüntülenmez) ?"
 
-#: ../src/generic/animateg.cpp:142
+#: ../src/generic/animateg.cpp:125
 msgid "No handler found for animation type."
 msgstr "Canlandırma türünün işleyicisi bulunamadı."
 
-#: ../src/common/image.cpp:2728
+#: ../src/common/image.cpp:2823
 msgid "No handler found for image type."
 msgstr "Görüntü türünün işleyicisi bulunamadı."
 
-#: ../src/common/image.cpp:2736 ../src/common/image.cpp:2848
-#: ../src/common/image.cpp:2901
+#: ../src/common/image.cpp:2831 ../src/common/image.cpp:2954
+#: ../src/common/image.cpp:3020
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "%d türünün görüntü işleyicisi tanımlanmamış."
 
-#: ../src/common/image.cpp:2871 ../src/common/image.cpp:2915
+#: ../src/common/image.cpp:2986 ../src/common/image.cpp:3034
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "%s türünün görüntü işleyicisi tanımlanmamış."
 
-#: ../src/html/helpwnd.cpp:858
+#: ../src/html/helpwnd.cpp:856
 msgid "No matching page found yet"
 msgstr "Henüz uyan bir sayfa bulunamadı"
 
-#: ../src/unix/sound.cpp:81
+#: ../src/unix/sound.cpp:78
 msgid "No sound"
 msgstr "Ses yok"
 
-#: ../src/common/image.cpp:2277 ../src/common/image.cpp:2318
+#: ../src/common/image.cpp:2371 ../src/common/image.cpp:2412
 msgid "No unused colour in image being masked."
 msgstr "Maskelenen görselde kullanılmamış renk yok."
 
-#: ../src/common/image.cpp:3374
-msgid "No unused colour in image."
-msgstr "Görselde kullanılmamış renk yok."
-
-#: ../src/generic/helpext.cpp:302
+#: ../src/generic/helpext.cpp:300
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "\"%s\" dosyasında geçerli eşleme bulunamadı."
 
-#: ../src/richtext/richtextborderspage.cpp:610
 #: ../src/richtext/richtextsizepage.cpp:248
 #: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:610
 msgid "None"
 msgstr "Hiçbiri"
 
-#: ../src/common/fmapbase.cpp:157
+#: ../src/common/fmapbase.cpp:154
 msgid "Nordic (ISO-8859-10)"
 msgstr "Norveçce (ISO-8859-10)"
 
-#: ../src/generic/fontdlgg.cpp:328 ../src/generic/fontdlgg.cpp:331
+#: ../src/generic/fontdlgg.cpp:324 ../src/generic/fontdlgg.cpp:327
 msgid "Normal"
 msgstr "Normal"
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1261
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Normal yazı türü <br>ve <u>altı çizili</u>. "
 
-#: ../src/html/helpwnd.cpp:1205
+#: ../src/html/helpwnd.cpp:1203
 msgid "Normal font:"
 msgstr "Normal yazı türü:"
 
-#: ../src/propgrid/props.cpp:1128
+#: ../src/propgrid/props.cpp:1115
 #, c-format
 msgid "Not %s"
 msgstr "%s değil"
 
-#: ../include/wx/filename.h:573 ../include/wx/filename.h:578
-msgid "Not available"
-msgstr "Kullanılamıyor"
+#: ../src/common/secretstore.cpp:168
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/webrequest.cpp:605
+msgid "Not enough free disk space for download."
+msgstr ""
 
 #: ../src/richtext/richtextfontpage.cpp:358
 msgid "Not underlined"
 msgstr "Altı çizili değil"
 
-#: ../src/common/paper.cpp:115
+#: ../src/common/paper.cpp:112
 msgid "Note, 8 1/2 x 11 in"
 msgstr "Not, 8 1/2 x 11 inç"
 
-#: ../src/generic/notifmsgg.cpp:132
+#: ../src/generic/notifmsgg.cpp:129
 msgid "Notice"
 msgstr "Bildirim"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "Num *"
 msgstr "Num *"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "Num +"
 msgstr "Num +"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "Num ,"
 msgstr "Num ,"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "Num -"
 msgstr "Num -"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "Num ."
 msgstr "Num ."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "Num /"
 msgstr "Num /"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "Num ="
 msgstr "Num ="
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "Num Begin"
 msgstr "Num Başlangıç"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 msgid "Num Delete"
 msgstr "Num Delete"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 msgid "Num Down"
 msgstr "Num Aşağı"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "Num End"
 msgstr "Num Son"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "Num Enter"
 msgstr "Num Enter"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 msgid "Num Home"
 msgstr "Num Home"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 msgid "Num Insert"
 msgstr "Num Insert"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num Lock"
 msgstr "Num Lock"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "Num Page Down"
 msgstr "Num Page Down"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "Num Page Up"
 msgstr "Num Page Up"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 msgid "Num Right"
 msgstr "Num Sağ"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "Num Space"
 msgstr "Num Boşluk"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "Num Tab"
 msgstr "Num Sekme"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "Num Up"
 msgstr "Num Yukarı"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "Num left"
 msgstr "Num sol"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num_lock"
 msgstr "Num_lock"
 
@@ -5300,13 +5442,13 @@ msgstr "Num_lock"
 msgid "Numbered outline"
 msgstr "Numaralı taslak"
 
-#: ../include/wx/msgdlg.h:278 ../src/richtext/richtextstyledlg.cpp:297
-#: ../src/common/stockitem.cpp:178 ../src/msw/msgdlg.cpp:454
-#: ../src/msw/msgdlg.cpp:747 ../src/gtk1/fontdlg.cpp:138
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:175
+#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/msgdlg.cpp:741 ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "Tamam"
 
-#: ../src/msw/ole/automtn.cpp:692
+#: ../src/msw/ole/automtn.cpp:683
 #, c-format
 msgid "OLE Automation error in %s: %s"
 msgstr "%s içinde OLE otomasyon hatası: %s"
@@ -5315,15 +5457,15 @@ msgstr "%s içinde OLE otomasyon hatası: %s"
 msgid "Object Properties"
 msgstr "Nesne Özellikleri"
 
-#: ../src/msw/ole/automtn.cpp:660
+#: ../src/msw/ole/automtn.cpp:651
 msgid "Object implementation does not support named arguments."
 msgstr "Nesne uygulaması adlandırılmış argümanları desteklemiyor."
 
-#: ../src/common/xtixml.cpp:264
+#: ../src/common/xtixml.cpp:260
 msgid "Objects must have an id attribute"
 msgstr "Nesnelerin bir kod özniteliği olmalıdır"
 
-#: ../src/propgrid/advprops.cpp:1601
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Olive"
 msgstr "Zeytin"
 
@@ -5331,65 +5473,70 @@ msgstr "Zeytin"
 msgid "Opaci&ty:"
 msgstr "&Matlık:"
 
-#: ../src/generic/colrdlgg.cpp:354
+#: ../src/generic/colrdlgg.cpp:374
 msgid "Opacity:"
 msgstr "Matlık:"
 
-#: ../src/common/docview.cpp:1773 ../src/common/docview.cpp:1815
+#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
 msgid "Open File"
 msgstr "Dosya Aç"
 
-#: ../src/html/helpwnd.cpp:671 ../src/html/helpwnd.cpp:1554
+#: ../src/html/helpwnd.cpp:669 ../src/html/helpwnd.cpp:1552
 msgid "Open HTML document"
 msgstr "HTML belgesi aç"
 
-#: ../src/generic/dbgrptg.cpp:163
+#: ../src/common/stockitem.cpp:265
+#, fuzzy
+msgid "Open an existing document"
+msgstr "HTML belgesi aç"
+
+#: ../src/generic/dbgrptg.cpp:160
 #, c-format
 msgid "Open file \"%s\""
 msgstr "Dosya aç \"%s\""
 
-#: ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176
 msgid "Open..."
 msgstr "Aç..."
 
-#: ../src/unix/glx11.cpp:506 ../src/msw/glcanvas.cpp:592
+#: ../src/msw/glcanvas.cpp:607 ../src/unix/glx11.cpp:513
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr ""
 "OpenGL 3.0 ve üzerindeki sürümler OpenGL sürücüsü tarafından desteklenmiyor."
 
-#: ../src/generic/dirctrlg.cpp:599 ../src/generic/dirdlgg.cpp:323
-#: ../src/generic/filectrlg.cpp:642 ../src/generic/filectrlg.cpp:786
+#: ../src/generic/dirctrlg.cpp:565 ../src/generic/filectrlg.cpp:638
+#: ../src/generic/filectrlg.cpp:782 ../src/generic/dirdlgg.cpp:320
 msgid "Operation not permitted."
 msgstr "İşleme izin verilmiyor."
 
-#: ../src/common/cmdline.cpp:900
+#: ../src/common/cmdline.cpp:896
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "'%s' seçeneği yok sayılamaz"
 
-#: ../src/common/cmdline.cpp:1064
+#: ../src/common/cmdline.cpp:1060
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "'%s' seçeneğinin bir değeri olması gerekiyor."
 
-#: ../src/common/cmdline.cpp:1147
+#: ../src/common/cmdline.cpp:1143
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "'%s' seçeneği: '%s' tarihe dönüştürülemiyor."
 
-#: ../src/generic/prntdlgg.cpp:618
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Ayarlar"
 
-#: ../src/propgrid/advprops.cpp:1606
+#: ../src/propgrid/advprops.cpp:1512
 msgid "Orange"
 msgstr "Turuncu"
 
-#: ../src/generic/prntdlgg.cpp:615 ../src/generic/prntdlgg.cpp:869
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:862
 msgid "Orientation"
 msgstr "Yön"
 
-#: ../src/common/windowid.cpp:242
+#: ../src/common/windowid.cpp:237
 msgid "Out of window IDs.  Recommend shutting down application."
 msgstr "Pencere kodları tükendi. Uygulamayı kapatmanız önerilir."
 
@@ -5402,148 +5549,148 @@ msgstr "Taslak"
 msgid "Outset"
 msgstr "Kabartma"
 
-#: ../src/msw/ole/automtn.cpp:656
+#: ../src/msw/ole/automtn.cpp:647
 msgid "Overflow while coercing argument values."
 msgstr "Arguman değerleri zorlanırken taşma oldu."
 
-#: ../src/common/imagpcx.cpp:457 ../src/common/imagpcx.cpp:480
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:479
 msgid "PCX: couldn't allocate memory"
 msgstr "PCX: bellek ayrılamadı"
 
-#: ../src/common/imagpcx.cpp:456
+#: ../src/common/imagpcx.cpp:455
 msgid "PCX: image format unsupported"
 msgstr "PCX: görsel biçimi desteklenmiyor"
 
-#: ../src/common/imagpcx.cpp:479
+#: ../src/common/imagpcx.cpp:478
 msgid "PCX: invalid image"
 msgstr "PCX: görsel geçersiz"
 
-#: ../src/common/imagpcx.cpp:442
+#: ../src/common/imagpcx.cpp:441
 msgid "PCX: this is not a PCX file."
 msgstr "PCX: bu bir PCX dosyası değil."
 
-#: ../src/common/imagpcx.cpp:459 ../src/common/imagpcx.cpp:481
+#: ../src/common/imagpcx.cpp:458 ../src/common/imagpcx.cpp:480
 msgid "PCX: unknown error !!!"
 msgstr "PCX: bilinmeyen hata !!!"
 
-#: ../src/common/imagpcx.cpp:458
+#: ../src/common/imagpcx.cpp:457
 msgid "PCX: version number too low"
 msgstr "PCX: sürüm numarası çok küçük"
 
-#: ../src/common/imagpnm.cpp:91
+#: ../src/common/imagpnm.cpp:89
 msgid "PNM: Couldn't allocate memory."
 msgstr "PNM: Bellek ayrılamadı."
 
-#: ../src/common/imagpnm.cpp:73
+#: ../src/common/imagpnm.cpp:71
 msgid "PNM: File format is not recognized."
 msgstr "PNM: Dosya biçimi tanınamadı."
 
-#: ../src/common/imagpnm.cpp:112 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
 #: ../src/common/imagpnm.cpp:156
 msgid "PNM: File seems truncated."
 msgstr "PNM: Dosya budanmış görünüyor."
 
-#: ../src/common/paper.cpp:187
+#: ../src/common/paper.cpp:184
 msgid "PRC 16K 146 x 215 mm"
 msgstr "PRC 16K 146 x 215 mm"
 
-#: ../src/common/paper.cpp:200
+#: ../src/common/paper.cpp:197
 msgid "PRC 16K Rotated"
 msgstr "PRC 16K Çevrilmiş"
 
-#: ../src/common/paper.cpp:188
+#: ../src/common/paper.cpp:185
 msgid "PRC 32K 97 x 151 mm"
 msgstr "PRC 32K 97 x 151 mm"
 
-#: ../src/common/paper.cpp:201
+#: ../src/common/paper.cpp:198
 msgid "PRC 32K Rotated"
 msgstr "PRC 32K Çevrilmiş"
 
-#: ../src/common/paper.cpp:189
+#: ../src/common/paper.cpp:186
 msgid "PRC 32K(Big) 97 x 151 mm"
 msgstr "PRC 32K(Büyük) 97 x 151 mm"
 
-#: ../src/common/paper.cpp:202
+#: ../src/common/paper.cpp:199
 msgid "PRC 32K(Big) Rotated"
 msgstr "PRC 32K(Büyük) Çevrilmiş"
 
-#: ../src/common/paper.cpp:190
+#: ../src/common/paper.cpp:187
 msgid "PRC Envelope #1 102 x 165 mm"
 msgstr "PRC Zarf #1 102 x 165 mm"
 
-#: ../src/common/paper.cpp:203
+#: ../src/common/paper.cpp:200
 msgid "PRC Envelope #1 Rotated 165 x 102 mm"
 msgstr "PRC Zarf #1 Çevrilmiş 165 x 102 mm"
 
-#: ../src/common/paper.cpp:199
+#: ../src/common/paper.cpp:196
 msgid "PRC Envelope #10 324 x 458 mm"
 msgstr "PRC Zarf #10 324 x 458 mm"
 
-#: ../src/common/paper.cpp:212
+#: ../src/common/paper.cpp:209
 msgid "PRC Envelope #10 Rotated 458 x 324 mm"
 msgstr "PRC Zarf #10 Çevrilmiş 458 x 324 mm"
 
-#: ../src/common/paper.cpp:191
+#: ../src/common/paper.cpp:188
 msgid "PRC Envelope #2 102 x 176 mm"
 msgstr "PRC Zarf #2 102 x 176 mm"
 
-#: ../src/common/paper.cpp:204
+#: ../src/common/paper.cpp:201
 msgid "PRC Envelope #2 Rotated 176 x 102 mm"
 msgstr "PRC Zarf #2 Çevrilmiş 176 x 102 mm"
 
-#: ../src/common/paper.cpp:192
+#: ../src/common/paper.cpp:189
 msgid "PRC Envelope #3 125 x 176 mm"
 msgstr "PRC Zarf #3 125 x 176 mm"
 
-#: ../src/common/paper.cpp:205
+#: ../src/common/paper.cpp:202
 msgid "PRC Envelope #3 Rotated 176 x 125 mm"
 msgstr "PRC Zarf #3 Çevrilmiş 176 x 125 mm"
 
-#: ../src/common/paper.cpp:193
+#: ../src/common/paper.cpp:190
 msgid "PRC Envelope #4 110 x 208 mm"
 msgstr "PRC Zarf #4 110 x 208 mm"
 
-#: ../src/common/paper.cpp:206
+#: ../src/common/paper.cpp:203
 msgid "PRC Envelope #4 Rotated 208 x 110 mm"
 msgstr "PRC Zarf #4 Çevrilmiş 208 x 110 mm"
 
-#: ../src/common/paper.cpp:194
+#: ../src/common/paper.cpp:191
 msgid "PRC Envelope #5 110 x 220 mm"
 msgstr "PRC Zarf #5 110 x 220 mm"
 
-#: ../src/common/paper.cpp:207
+#: ../src/common/paper.cpp:204
 msgid "PRC Envelope #5 Rotated 220 x 110 mm"
 msgstr "PRC Zarf #5 Çevrilmiş 220 x 110 mm"
 
-#: ../src/common/paper.cpp:195
+#: ../src/common/paper.cpp:192
 msgid "PRC Envelope #6 120 x 230 mm"
 msgstr "PRC Zarf #6 120 x 230 mm"
 
-#: ../src/common/paper.cpp:208
+#: ../src/common/paper.cpp:205
 msgid "PRC Envelope #6 Rotated 230 x 120 mm"
 msgstr "PRC Zarf #6 Çevrilmiş 230 x 120 mm"
 
-#: ../src/common/paper.cpp:196
+#: ../src/common/paper.cpp:193
 msgid "PRC Envelope #7 160 x 230 mm"
 msgstr "PRC Zarf #7 160 x 230 mm"
 
-#: ../src/common/paper.cpp:209
+#: ../src/common/paper.cpp:206
 msgid "PRC Envelope #7 Rotated 230 x 160 mm"
 msgstr "PRC Zarf #7 Çevrilmiş 230 x 160 mm"
 
-#: ../src/common/paper.cpp:197
+#: ../src/common/paper.cpp:194
 msgid "PRC Envelope #8 120 x 309 mm"
 msgstr "PRC Zarf #8 120 x 309 mm"
 
-#: ../src/common/paper.cpp:210
+#: ../src/common/paper.cpp:207
 msgid "PRC Envelope #8 Rotated 309 x 120 mm"
 msgstr "PRC Zarf #8 Çevrilmiş 309 x 120 mm"
 
-#: ../src/common/paper.cpp:198
+#: ../src/common/paper.cpp:195
 msgid "PRC Envelope #9 229 x 324 mm"
 msgstr "PRC Zarf #9 229 x 324 mm"
 
-#: ../src/common/paper.cpp:211
+#: ../src/common/paper.cpp:208
 msgid "PRC Envelope #9 Rotated 324 x 229 mm"
 msgstr "PRC Zarf #9 Çevrilmiş 324 x 229 mm"
 
@@ -5551,87 +5698,91 @@ msgstr "PRC Zarf #9 Çevrilmiş 324 x 229 mm"
 msgid "Padding"
 msgstr "Yastıklama"
 
-#: ../src/common/prntbase.cpp:2074
+#: ../src/common/prntbase.cpp:2096
 #, c-format
 msgid "Page %d"
 msgstr "Sayfa %d"
 
-#: ../src/common/prntbase.cpp:2072
+#: ../src/common/prntbase.cpp:2094
 #, c-format
 msgid "Page %d of %d"
 msgstr "Sayfa %d / %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 msgid "Page Down"
 msgstr "Page Down"
 
-#: ../src/gtk/print.cpp:826
+#: ../src/gtk/print.cpp:829
 msgid "Page Setup"
 msgstr "Sayfa Düzeni"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 msgid "Page Up"
 msgstr "Page Up"
 
-#: ../src/generic/prntdlgg.cpp:828 ../src/common/prntbase.cpp:484
+#: ../src/common/prntbase.cpp:479 ../src/generic/prntdlgg.cpp:821
 msgid "Page setup"
 msgstr "Sayfa düzeni"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 msgid "PageDown"
 msgstr "PageDown"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 msgid "PageUp"
 msgstr "PageUp"
 
-#: ../src/generic/prntdlgg.cpp:216
+#: ../src/generic/prntdlgg.cpp:209
 msgid "Pages"
 msgstr "Sayfalar"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1765
+#: ../src/propgrid/advprops.cpp:1666
 msgid "Paint Brush"
 msgstr "Boya Fırçası"
 
-#: ../src/generic/prntdlgg.cpp:602 ../src/generic/prntdlgg.cpp:801
-#: ../src/generic/prntdlgg.cpp:842 ../src/generic/prntdlgg.cpp:855
-#: ../src/generic/prntdlgg.cpp:1052 ../src/generic/prntdlgg.cpp:1057
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:794
+#: ../src/generic/prntdlgg.cpp:835 ../src/generic/prntdlgg.cpp:848
+#: ../src/generic/prntdlgg.cpp:1045 ../src/generic/prntdlgg.cpp:1050
 msgid "Paper size"
 msgstr "Kağıt boyutu"
 
-#: ../src/richtext/richtextstyles.cpp:1062
+#: ../src/richtext/richtextstyles.cpp:1059
 msgid "Paragraph styles"
 msgstr "Paragraf biçemleri"
 
-#: ../src/common/xtistrm.cpp:465
+#: ../src/common/xtistrm.cpp:462
 msgid "Passing a already registered object to SetObject"
 msgstr "SetObject işlevine zaten kayıtlı olan bir nesne gönderildi"
 
-#: ../src/common/xtistrm.cpp:476
+#: ../src/common/xtistrm.cpp:473
 msgid "Passing an unknown object to GetObject"
 msgstr "GetObject işlevine bilinmeyen bir nesne gönderildi"
 
-#: ../src/richtext/richtextctrl.cpp:3513 ../src/common/stockitem.cpp:180
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:177 ../src/richtext/richtextctrl.cpp:3514
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Yapıştır"
 
-#: ../src/common/stockitem.cpp:262
+#: ../src/common/stockitem.cpp:260
 msgid "Paste selection"
 msgstr "Seçimi yapıştır"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:74
+#: ../src/common/accelcmn.cpp:71
 msgid "Pause"
 msgstr "Duraklat"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1766
+#: ../src/propgrid/advprops.cpp:1667
 msgid "Pencil"
 msgstr "Kalem"
 
@@ -5640,21 +5791,21 @@ msgstr "Kalem"
 msgid "Peri&od"
 msgstr "N&okta"
 
-#: ../src/generic/filectrlg.cpp:430
+#: ../src/generic/filectrlg.cpp:426
 msgid "Permissions"
 msgstr "İzinler"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:60
+#: ../src/common/accelcmn.cpp:57
 msgid "PgDn"
 msgstr "PgDn"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:59
+#: ../src/common/accelcmn.cpp:56
 msgid "PgUp"
 msgstr "PgUp"
 
-#: ../src/richtext/richtextbuffer.cpp:12868
+#: ../src/richtext/richtextbuffer.cpp:12863
 msgid "Picture Properties"
 msgstr "Görsel Özellikleri"
 
@@ -5666,42 +5817,42 @@ msgstr "Boru oluşturulamadı"
 msgid "Please choose a valid font."
 msgstr "Lütfen geçerli bir yazı türü seçin."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
 msgid "Please choose an existing file."
 msgstr "Lütfen varolan bir dosya seçin."
 
-#: ../src/html/helpwnd.cpp:800
+#: ../src/html/helpwnd.cpp:798
 msgid "Please choose the page to display:"
 msgstr "Lütfen görüntülenecek sayfayı seçin:"
 
-#: ../src/msw/dialup.cpp:764
+#: ../src/msw/dialup.cpp:758
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Lütfen bağlanmak istediğiniz hizmet sağlayıcıyı seçin"
 
-#: ../src/common/headerctrlcmn.cpp:59
+#: ../src/common/headerctrlcmn.cpp:57
 msgid "Please select the columns to show and define their order:"
 msgstr "Lütfen görüntülenecek sütunları seçin ve sıralarını belirleyin:"
 
-#: ../src/common/prntbase.cpp:538
+#: ../src/common/prntbase.cpp:533
 msgid "Please wait while printing..."
 msgstr "Yazdırılıyor, lütfen bekleyin..."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1767
+#: ../src/propgrid/advprops.cpp:1668
 msgid "Point Left"
 msgstr "Sola Ok"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1768
+#: ../src/propgrid/advprops.cpp:1669
 msgid "Point Right"
 msgstr "Sağa Ok"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:662
+#: ../src/propgrid/advprops.cpp:572
 msgid "Point Size"
 msgstr "Punto Boyutu"
 
-#: ../src/generic/prntdlgg.cpp:612 ../src/generic/prntdlgg.cpp:867
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:860
 msgid "Portrait"
 msgstr "Dikey"
 
@@ -5709,252 +5860,262 @@ msgstr "Dikey"
 msgid "Position"
 msgstr "Konum"
 
-#: ../src/generic/prntdlgg.cpp:298
+#: ../src/generic/prntdlgg.cpp:291
 msgid "PostScript file"
 msgstr "PostScript dosyası"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178 ../src/osx/cocoa/preferences.mm:303
 msgid "Preferences"
 msgstr "Ayarlar"
 
-#: ../src/osx/menu_osx.cpp:568
+#: ../src/osx/menu_osx.cpp:460
 msgid "Preferences..."
 msgstr "Ayarlar..."
 
-#: ../src/common/prntbase.cpp:546
+#: ../src/common/prntbase.cpp:541
 msgid "Preparing"
 msgstr "Hazırlanıyor"
 
-#: ../src/generic/fontdlgg.cpp:455 ../src/osx/carbon/fontdlg.cpp:390
-#: ../src/html/helpwnd.cpp:1222
+#: ../src/osx/carbon/fontdlg.cpp:387 ../src/generic/fontdlgg.cpp:452
+#: ../src/html/helpwnd.cpp:1220
 msgid "Preview:"
 msgstr "Önizleme:"
 
-#: ../src/common/prntbase.cpp:1553 ../src/html/helpwnd.cpp:664
+#: ../src/common/prntbase.cpp:1578 ../src/html/helpwnd.cpp:662
 msgid "Previous page"
 msgstr "Önceki sayfa"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/prntdlgg.cpp:143 ../src/generic/prntdlgg.cpp:157
-#: ../src/common/prntbase.cpp:426 ../src/common/prntbase.cpp:1541
-#: ../src/common/accelcmn.cpp:77 ../src/gtk/print.cpp:620
-#: ../src/gtk/print.cpp:638
+#: ../src/common/prntbase.cpp:421 ../src/common/prntbase.cpp:1566
+#: ../src/common/accelcmn.cpp:74 ../src/generic/prntdlgg.cpp:136
+#: ../src/generic/prntdlgg.cpp:150 ../src/gtk/print.cpp:616
+#: ../src/gtk/print.cpp:634
 msgid "Print"
 msgstr "Yazdır"
 
-#: ../include/wx/prntbase.h:399 ../src/common/docview.cpp:1268
+#: ../src/common/docview.cpp:1262
 msgid "Print Preview"
 msgstr "Baskı Önizlemesi"
 
-#: ../src/common/prntbase.cpp:2015 ../src/common/prntbase.cpp:2057
-#: ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2037 ../src/common/prntbase.cpp:2079
+#: ../src/common/prntbase.cpp:2087
 msgid "Print Preview Failure"
 msgstr "Baskı Önizleme Sorunu"
 
-#: ../src/generic/prntdlgg.cpp:224
+#: ../src/generic/prntdlgg.cpp:217
 msgid "Print Range"
 msgstr "Yazdırma Aralığı"
 
-#: ../src/generic/prntdlgg.cpp:449
+#: ../src/generic/prntdlgg.cpp:442
 msgid "Print Setup"
 msgstr "Yazdırma Ayarları"
 
-#: ../src/generic/prntdlgg.cpp:621
+#: ../src/generic/prntdlgg.cpp:614
 msgid "Print in colour"
 msgstr "Renkli yazdır"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/osx/webview_webkit.mm:260
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "Sütun tanımı yüklenemedi."
+
+#: ../src/common/stockitem.cpp:179
 msgid "Print previe&w..."
 msgstr "Baskı ö&nizleme..."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1256
 msgid "Print preview creation failed."
 msgstr "Baskı önizleme oluşturulamadı."
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/common/stockitem.cpp:179
 msgid "Print preview..."
 msgstr "Baskı önizleme..."
 
-#: ../src/generic/prntdlgg.cpp:630
+#: ../src/generic/prntdlgg.cpp:623
 msgid "Print spooling"
 msgstr "Yazdırma kuyruğu"
 
-#: ../src/html/helpwnd.cpp:675
+#: ../src/html/helpwnd.cpp:673
 msgid "Print this page"
 msgstr "Bu sayfayı yazdır"
 
-#: ../src/generic/prntdlgg.cpp:185
+#: ../src/generic/prntdlgg.cpp:178
 msgid "Print to File"
 msgstr "Dosyaya Yazdır"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "Print..."
 msgstr "Yazdır..."
 
-#: ../src/generic/prntdlgg.cpp:493
+#: ../src/generic/prntdlgg.cpp:486
 msgid "Printer"
 msgstr "Yazıcı"
 
-#: ../src/generic/prntdlgg.cpp:633
+#: ../src/generic/prntdlgg.cpp:626
 msgid "Printer command:"
 msgstr "Yazıcı komutu:"
 
-#: ../src/generic/prntdlgg.cpp:180
+#: ../src/generic/prntdlgg.cpp:173
 msgid "Printer options"
 msgstr "Yazıcı ayarları"
 
-#: ../src/generic/prntdlgg.cpp:645
+#: ../src/generic/prntdlgg.cpp:638
 msgid "Printer options:"
 msgstr "Yazıcı ayarları:"
 
-#: ../src/generic/prntdlgg.cpp:916
+#: ../src/generic/prntdlgg.cpp:909
 msgid "Printer..."
 msgstr "Yazıcı..."
 
-#: ../src/generic/prntdlgg.cpp:196
+#: ../src/generic/prntdlgg.cpp:189
 msgid "Printer:"
 msgstr "Yazıcı:"
 
-#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:535
-#: ../src/html/htmprint.cpp:277
+#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:530
+#: ../src/html/htmprint.cpp:289
 msgid "Printing"
 msgstr "Yazdırılıyor"
 
-#: ../src/common/prntbase.cpp:612
+#: ../src/common/prntbase.cpp:607
 msgid "Printing "
 msgstr "Yazdırılıyor "
 
-#: ../src/common/prntbase.cpp:347
+#: ../src/common/prntbase.cpp:342
 msgid "Printing Error"
 msgstr "Yazdırma Hatası"
 
-#: ../src/common/prntbase.cpp:565
+#: ../src/osx/webview_webkit.mm:251
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "Gzip bu Zlib sürümü tarafından desteklemiyor"
+
+#: ../src/common/prntbase.cpp:560
 #, c-format
 msgid "Printing page %d"
 msgstr "Yazdırılan sayfa %d"
 
-#: ../src/common/prntbase.cpp:570
+#: ../src/common/prntbase.cpp:565
 #, c-format
 msgid "Printing page %d of %d"
 msgstr "Yazdırılan sayfa %d / %d"
 
-#: ../src/generic/printps.cpp:201
+#: ../src/generic/printps.cpp:182
 #, c-format
 msgid "Printing page %d..."
 msgstr "Yazdırılan sayfa %d..."
 
-#: ../src/generic/printps.cpp:161
+#: ../src/generic/printps.cpp:142
 msgid "Printing..."
 msgstr "Yazdırılıyor..."
 
-#: ../include/wx/richtext/richtextprint.h:109 ../include/wx/prntbase.h:267
-#: ../src/common/docview.cpp:2132
+#: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
+#: ../src/common/docview.cpp:2137
 msgid "Printout"
 msgstr "Çıktı"
 
-#: ../src/common/debugrpt.cpp:560
+#: ../src/common/debugrpt.cpp:561
 #, c-format
 msgid ""
 "Processing debug report has failed, leaving the files in \"%s\" directory."
 msgstr ""
 "Hata ayıklama raporu oluşturulamadı, dosyalar \"%s\" klasöründe bırakıldı."
 
-#: ../src/common/prntbase.cpp:545
+#: ../src/common/prntbase.cpp:540
 msgid "Progress:"
 msgstr "İşlem:"
 
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181
 msgid "Properties"
 msgstr "Özellikler"
 
-#: ../src/propgrid/manager.cpp:237
+#: ../src/propgrid/manager.cpp:223
 msgid "Property"
 msgstr "Özellik"
 
 #. TRANSLATORS: Caption of message box displaying any property error
-#: ../src/propgrid/propgrid.cpp:3185 ../src/propgrid/propgrid.cpp:3318
+#: ../src/propgrid/propgrid.cpp:3162 ../src/propgrid/propgrid.cpp:3299
 msgid "Property Error"
 msgstr "Özellik Hatası"
 
-#: ../src/propgrid/advprops.cpp:1597
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Purple"
 msgstr "Mor"
 
-#: ../src/common/paper.cpp:112
+#: ../src/common/paper.cpp:109
 msgid "Quarto, 215 x 275 mm"
 msgstr "Quarto, 215 x 275 mm"
 
-#: ../src/generic/logg.cpp:1016
+#: ../src/generic/logg.cpp:1013
 msgid "Question"
 msgstr "Soru"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1769
+#: ../src/propgrid/advprops.cpp:1670
 msgid "Question Arrow"
 msgstr "Soru Oku"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "Quit"
 msgstr "Çıkış"
 
-#: ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:477
 #, c-format
 msgid "Quit %s"
 msgstr "%s uygulamasını kapat"
 
-#: ../src/common/stockitem.cpp:263
+#: ../src/common/stockitem.cpp:261
 msgid "Quit this program"
 msgstr "Bu uygulamayı kapat"
 
-#: ../src/common/accelcmn.cpp:338
+#: ../src/common/accelcmn.cpp:352
 msgid "RawCtrl+"
 msgstr "HamCtrl+"
 
-#: ../src/common/ffile.cpp:109 ../src/common/ffile.cpp:133
+#: ../src/common/ffile.cpp:107 ../src/common/ffile.cpp:132
 #, c-format
 msgid "Read error on file '%s'"
 msgstr "'%s' dosyasında okuma sorunu"
 
-#: ../src/common/secretstore.cpp:199
-#, c-format
-msgid "Reading password for \"%s/%s\" failed: %s."
+#: ../src/common/secretstore.cpp:211
+#, fuzzy, c-format
+msgid "Reading password for \"%s\" failed: %s."
 msgstr "\"%s/%s\" için parola okunamadı: %s."
 
-#: ../src/common/prntbase.cpp:272
+#: ../src/common/prntbase.cpp:267
 msgid "Ready"
 msgstr "Hazır"
 
-#: ../src/propgrid/advprops.cpp:1605
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Red"
 msgstr "Kırmızı"
 
-#: ../src/generic/colrdlgg.cpp:339
+#: ../src/generic/colrdlgg.cpp:359
 msgid "Red:"
 msgstr "Kırmızı:"
 
-#: ../src/common/stockitem.cpp:185 ../src/stc/stc_i18n.cpp:16
+#: ../src/common/stockitem.cpp:182 ../src/stc/stc_i18n.cpp:16
 msgid "Redo"
 msgstr "Yinele"
 
-#: ../src/common/stockitem.cpp:264
+#: ../src/common/stockitem.cpp:262
 msgid "Redo last action"
 msgstr "Son eylemi yeniden yap"
 
-#: ../src/common/stockitem.cpp:186
+#: ../src/common/stockitem.cpp:183
 msgid "Refresh"
 msgstr "Yenile"
 
-#: ../src/msw/registry.cpp:626
+#: ../src/msw/registry.cpp:615
 #, c-format
 msgid "Registry key '%s' already exists."
 msgstr "'%s' kayıt anahtarı zaten var."
 
-#: ../src/msw/registry.cpp:595
+#: ../src/msw/registry.cpp:584
 #, c-format
 msgid "Registry key '%s' does not exist, cannot rename it."
 msgstr "'%s' kayıt anahtarı bulunamadığından yeniden adlandırılamıyor."
 
-#: ../src/msw/registry.cpp:727
+#: ../src/msw/registry.cpp:716
 #, c-format
 msgid ""
 "Registry key '%s' is needed for normal system operation,\n"
@@ -5965,22 +6126,22 @@ msgstr ""
 "silinmesi sistemi kararsız bir hale getirir:\n"
 "işlem iptal edildi."
 
-#: ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:942
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr "\"%s\" kayıt anahtarı ikili (ya da %s türünde) değil"
 
-#: ../src/msw/registry.cpp:917
+#: ../src/msw/registry.cpp:905
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr "\"%s\" kayıt anahtarı sayısal (ya da %s türünde) değil"
 
-#: ../src/msw/registry.cpp:1003
+#: ../src/msw/registry.cpp:991
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr "\"%s\" kayıt anahtarı metin (ya da %s türünde) değil"
 
-#: ../src/msw/registry.cpp:521
+#: ../src/msw/registry.cpp:510
 #, c-format
 msgid "Registry value '%s' already exists."
 msgstr "'%s' kayıt değeri zaten var."
@@ -5994,70 +6155,76 @@ msgstr "Normal"
 msgid "Relative"
 msgstr "Bağıl"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:456
 msgid "Relevant entries:"
 msgstr "İlgili kayıtlar:"
 
-#: ../include/wx/generic/progdlgg.h:86
+#: ../include/wx/generic/progdlgg.h:87
 msgid "Remaining time:"
 msgstr "Kalan süre:"
 
-#: ../src/common/stockitem.cpp:187
+#: ../src/common/stockitem.cpp:184
 msgid "Remove"
 msgstr "Sil"
 
-#: ../src/richtext/richtextctrl.cpp:1562
+#: ../src/richtext/richtextctrl.cpp:1563
 msgid "Remove Bullet"
 msgstr "Madde İmini Kaldır"
 
-#: ../src/html/helpwnd.cpp:433
+#: ../src/html/helpwnd.cpp:431
 msgid "Remove current page from bookmarks"
 msgstr "Geçerli sayfayı yer imlerinden sil"
 
-#: ../src/common/rendcmn.cpp:194
+#: ../src/common/rendcmn.cpp:191
 #, c-format
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr "\"%s\" görüntüleyicisinin %d.%d sürümü uyumsuz olduğundan yüklenemedi."
 
-#: ../src/richtext/richtextbuffer.cpp:4527
+#: ../src/richtext/richtextbuffer.cpp:4524
 msgid "Renumber List"
 msgstr "Listeyi Yeniden Numarala"
 
-#: ../src/common/stockitem.cpp:188
-msgid "Rep&lace"
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Rep&lace..."
 msgstr "&Değiştir"
 
-#: ../src/richtext/richtextctrl.cpp:3673 ../src/common/stockitem.cpp:188
+#: ../src/richtext/richtextctrl.cpp:3674
 msgid "Replace"
 msgstr "Değiştir"
 
-#: ../src/generic/fdrepdlg.cpp:182
+#: ../src/generic/fdrepdlg.cpp:179
 msgid "Replace &all"
 msgstr "&Tümünü değiştir"
 
-#: ../src/common/stockitem.cpp:261
-msgid "Replace selection"
-msgstr "Seçimi değiştir"
-
-#: ../src/generic/fdrepdlg.cpp:124
+#: ../src/generic/fdrepdlg.cpp:121
 msgid "Replace with:"
 msgstr "Şununla değiştir:"
 
-#: ../src/common/valtext.cpp:163
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Replace..."
+msgstr "Değiştir"
+
+#: ../src/common/valtext.cpp:184
 msgid "Required information entry is empty."
 msgstr "Gereken bilgi kayıdı boş."
 
-#: ../src/common/translation.cpp:1975
+#: ../src/common/translation.cpp:2025
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "'%s' kaynağı geçerli bir ileti kataloğu değil."
 
+#: ../src/gtk/webview_webkit.cpp:985
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:56
+#: ../src/common/accelcmn.cpp:53
 msgid "Return"
 msgstr "Return"
 
-#: ../src/common/stockitem.cpp:189
+#: ../src/common/stockitem.cpp:186
 msgid "Revert to Saved"
 msgstr "Kaydedilmiş Olana Geri Dön"
 
@@ -6069,41 +6236,41 @@ msgstr "Sırt"
 msgid "Rig&ht-to-left"
 msgstr "Sağ&dan sola"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6149
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:59 ../src/generic/datavgen.cpp:6954
+#: ../src/richtext/richtextsizepage.cpp:250
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextbulletspage.cpp:188
-#: ../src/richtext/richtextsizepage.cpp:250 ../src/common/accelcmn.cpp:62
 msgid "Right"
 msgstr "Sağ"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1754
+#: ../src/propgrid/advprops.cpp:1655
 msgid "Right Arrow"
 msgstr "Sağ Ok"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1770
+#: ../src/propgrid/advprops.cpp:1671
 msgid "Right Button"
 msgstr "Sağ Düğme"
 
-#: ../src/generic/prntdlgg.cpp:892
+#: ../src/generic/prntdlgg.cpp:885
 msgid "Right margin (mm):"
 msgstr "Sağ kenar boşluğu (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:148
-#: ../src/richtext/richtextindentspage.cpp:150
 #: ../src/richtext/richtextliststylepage.cpp:337
 #: ../src/richtext/richtextliststylepage.cpp:339
+#: ../src/richtext/richtextindentspage.cpp:148
+#: ../src/richtext/richtextindentspage.cpp:150
 msgid "Right-align text."
 msgstr "Metin sağa yaslanır."
 
-#: ../src/generic/fontdlgg.cpp:322
+#: ../src/generic/fontdlgg.cpp:318
 msgid "Roman"
 msgstr "Roman"
 
-#: ../src/generic/datavgen.cpp:5916
+#: ../src/generic/datavgen.cpp:6721
 #, c-format
 msgid "Row %i"
 msgstr "Satır %i"
@@ -6113,30 +6280,31 @@ msgstr "Satır %i"
 msgid "S&tandard bullet name:"
 msgstr "S&tandart madde imi adı:"
 
-#: ../src/common/accelcmn.cpp:268 ../src/common/accelcmn.cpp:350
+#: ../src/common/accelcmn.cpp:282 ../src/common/accelcmn.cpp:367
 msgid "SPECIAL"
 msgstr "SPECIAL"
 
-#: ../src/common/stockitem.cpp:190 ../src/common/sizer.cpp:2797
+#: ../src/common/stockitem.cpp:187 ../src/common/sizer.cpp:2914
 msgid "Save"
 msgstr "Kaydet"
 
-#: ../src/common/fldlgcmn.cpp:342
+#: ../src/common/fldlgcmn.cpp:339
 #, c-format
 msgid "Save %s file"
 msgstr "%s dosyasını kaydet"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/common/stockitem.cpp:188 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "&Farklı Kaydet..."
 
-#: ../src/common/docview.cpp:366
+#: ../src/common/docview.cpp:359
 msgid "Save As"
 msgstr "Farklı Kaydet"
 
-#: ../src/common/stockitem.cpp:191
-msgid "Save as"
-msgstr "Farklı kaydet"
+#: ../src/common/stockitem.cpp:188
+#, fuzzy
+msgid "Save As..."
+msgstr "&Farklı Kaydet..."
 
 #: ../src/common/stockitem.cpp:267
 msgid "Save current document"
@@ -6146,71 +6314,71 @@ msgstr "Geçerli belgeyi kaydet"
 msgid "Save current document with a different filename"
 msgstr "Geçerli belgeyi farklı bir adla kaydet"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/generic/logg.cpp:509
 msgid "Save log contents to file"
 msgstr "Günlük içeriğini dosyaya kaydet"
 
-#: ../src/common/secretstore.cpp:179
-#, c-format
-msgid "Saving password for \"%s/%s\" failed: %s."
+#: ../src/common/secretstore.cpp:189
+#, fuzzy, c-format
+msgid "Saving password for \"%s\" failed: %s."
 msgstr "\"%s/%s\" için parola kaydedilemedi: %s."
 
-#: ../src/generic/fontdlgg.cpp:325
+#: ../src/generic/fontdlgg.cpp:321
 msgid "Script"
 msgstr "Betik"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll Lock"
 msgstr "Scroll Lock"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll_lock"
 msgstr "Scroll_lock"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:890
+#: ../src/propgrid/advprops.cpp:791
 msgid "Scrollbar"
 msgstr "Kaydırma çubuğu"
 
-#: ../src/generic/srchctlg.cpp:56 ../src/html/helpwnd.cpp:535
-#: ../src/html/helpwnd.cpp:550
+#: ../src/generic/srchctlg.cpp:55 ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:548 ../src/gtk/srchctrl.cpp:182
 msgid "Search"
 msgstr "Ara"
 
-#: ../src/html/helpwnd.cpp:537
+#: ../src/html/helpwnd.cpp:535
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
 msgstr "Yukarıya yazılan metin yardım kitapları içinde her türlü aranır"
 
-#: ../src/generic/fdrepdlg.cpp:160
+#: ../src/generic/fdrepdlg.cpp:157
 msgid "Search direction"
 msgstr "Arama yönü"
 
-#: ../src/generic/fdrepdlg.cpp:112
+#: ../src/generic/fdrepdlg.cpp:109
 msgid "Search for:"
 msgstr "Aranan:"
 
-#: ../src/html/helpwnd.cpp:1052
+#: ../src/html/helpwnd.cpp:1050
 msgid "Search in all books"
 msgstr "Tüm kitaplarda ara"
 
-#: ../src/html/helpwnd.cpp:857
+#: ../src/html/helpwnd.cpp:855
 msgid "Searching..."
 msgstr "Aranıyor..."
 
-#: ../src/generic/dirctrlg.cpp:446
+#: ../src/generic/dirctrlg.cpp:412
 msgid "Sections"
 msgstr "Bölümler"
 
-#: ../src/common/ffile.cpp:238
+#: ../src/common/ffile.cpp:237
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "'%s' dosyasında arama sorunu"
 
-#: ../src/common/ffile.cpp:228
+#: ../src/common/ffile.cpp:227
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
@@ -6218,24 +6386,24 @@ msgstr ""
 "desteklenmiyor)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:76
+#: ../src/common/accelcmn.cpp:73
 msgid "Select"
 msgstr "Seçin"
 
-#: ../src/richtext/richtextctrl.cpp:337 ../src/osx/textctrl_osx.cpp:581
-#: ../src/common/stockitem.cpp:192 ../src/msw/textctrl.cpp:2512
+#: ../src/osx/textctrl_osx.cpp:599 ../src/common/stockitem.cpp:189
+#: ../src/msw/textctrl.cpp:2777 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "&Tümünü Seç"
 
-#: ../src/common/stockitem.cpp:192 ../src/stc/stc_i18n.cpp:21
+#: ../src/common/stockitem.cpp:189 ../src/stc/stc_i18n.cpp:21
 msgid "Select All"
 msgstr "Tümünü Seç"
 
-#: ../src/common/docview.cpp:1895
+#: ../src/common/docview.cpp:1900
 msgid "Select a document template"
 msgstr "Bir belge şablonu seçin"
 
-#: ../src/common/docview.cpp:1969
+#: ../src/common/docview.cpp:1974
 msgid "Select a document view"
 msgstr "Bir belge görünümü seçin"
 
@@ -6264,20 +6432,20 @@ msgid "Selects the list level to edit."
 msgstr "Düzenlenecek liste düzeyini seçer."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:82
+#: ../src/common/accelcmn.cpp:79
 msgid "Separator"
 msgstr "Ayıraç"
 
-#: ../src/common/cmdline.cpp:1083
+#: ../src/common/cmdline.cpp:1079
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "'%s' seçeneğinden sonra ayraç bekleniyor."
 
-#: ../src/osx/menu_osx.cpp:572
+#: ../src/osx/menu_osx.cpp:464
 msgid "Services"
 msgstr "Hizmetler"
 
-#: ../src/richtext/richtextbuffer.cpp:11217
+#: ../src/richtext/richtextbuffer.cpp:11216
 msgid "Set Cell Style"
 msgstr "Hücre Biçemini Ayarla"
 
@@ -6285,11 +6453,11 @@ msgstr "Hücre Biçemini Ayarla"
 msgid "SetProperty called w/o valid setter"
 msgstr "'SetProperty' işlevi geçerli bir yerleştirici olmaksızın çağrıldı"
 
-#: ../src/generic/prntdlgg.cpp:188
+#: ../src/generic/prntdlgg.cpp:181
 msgid "Setup..."
 msgstr "Kurulum..."
 
-#: ../src/msw/dialup.cpp:544
+#: ../src/msw/dialup.cpp:538
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr "Birkaç etkin çevirmeli bağlantı bulundu, rastgele biri seçiliyor."
 
@@ -6305,40 +6473,40 @@ msgstr "Gölge"
 msgid "Shadow c&olour:"
 msgstr "Gölge re&ngi:"
 
-#: ../src/common/accelcmn.cpp:335
+#: ../src/common/accelcmn.cpp:349
 msgid "Shift+"
 msgstr "Shift+"
 
-#: ../src/generic/dirdlgg.cpp:147
+#: ../src/generic/dirdlgg.cpp:144
 msgid "Show &hidden directories"
 msgstr "Gizli &klasörleri görüntüle"
 
-#: ../src/generic/filectrlg.cpp:983
+#: ../src/generic/filectrlg.cpp:979
 msgid "Show &hidden files"
 msgstr "Gizli &dosyaları görüntüle"
 
-#: ../src/osx/menu_osx.cpp:580
+#: ../src/osx/menu_osx.cpp:472
 msgid "Show All"
 msgstr "Tümünü Görüntüle"
 
-#: ../src/common/stockitem.cpp:257
+#: ../src/common/stockitem.cpp:254
 msgid "Show about dialog"
 msgstr "Hakkında penceresini görüntüle"
 
-#: ../src/html/helpwnd.cpp:492
+#: ../src/html/helpwnd.cpp:490
 msgid "Show all"
 msgstr "Tümünü görüntüle"
 
-#: ../src/html/helpwnd.cpp:503
+#: ../src/html/helpwnd.cpp:501
 msgid "Show all items in index"
 msgstr "Dizindeki tüm ögeleri görüntüle"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:656
 msgid "Show/hide navigation panel"
 msgstr "Gezinti panosunu görüntüle/gizle"
 
-#: ../src/richtext/richtextsymboldlg.cpp:421
-#: ../src/richtext/richtextsymboldlg.cpp:423
+#: ../src/richtext/richtextsymboldlg.cpp:418
+#: ../src/richtext/richtextsymboldlg.cpp:420
 msgid "Shows a Unicode subset."
 msgstr "Bir Unikod alt kümesini görüntüler."
 
@@ -6354,7 +6522,7 @@ msgstr "Madde imi ayarlarının önizlemesini görüntüler."
 msgid "Shows a preview of the font settings."
 msgstr "Yazı türü ayarlarının bir önizlemesini görüntüler."
 
-#: ../src/osx/carbon/fontdlg.cpp:394 ../src/osx/carbon/fontdlg.cpp:396
+#: ../src/osx/carbon/fontdlg.cpp:391 ../src/osx/carbon/fontdlg.cpp:393
 msgid "Shows a preview of the font."
 msgstr "Yazı türünün önizlemesini görüntüler."
 
@@ -6363,62 +6531,62 @@ msgstr "Yazı türünün önizlemesini görüntüler."
 msgid "Shows a preview of the paragraph settings."
 msgstr "Paragraf ayarlarının önizlemesini görüntüler."
 
-#: ../src/generic/fontdlgg.cpp:460 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:456 ../src/generic/fontdlgg.cpp:458
 msgid "Shows the font preview."
 msgstr "Yazı türünün önizlemesini görüntüler."
 
-#: ../src/propgrid/advprops.cpp:1607
+#: ../src/propgrid/advprops.cpp:1513
 msgid "Silver"
 msgstr "Gümüş"
 
-#: ../src/univ/themes/mono.cpp:516
+#: ../src/univ/themes/mono.cpp:513
 msgid "Simple monochrome theme"
 msgstr "Basit tek renkli tema"
 
-#: ../src/richtext/richtextindentspage.cpp:275
 #: ../src/richtext/richtextliststylepage.cpp:449
+#: ../src/richtext/richtextindentspage.cpp:275
 msgid "Single"
 msgstr "Tek"
 
-#: ../src/generic/filectrlg.cpp:425 ../src/richtext/richtextformatdlg.cpp:369
-#: ../src/richtext/richtextsizepage.cpp:299
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextsizepage.cpp:299
+#: ../src/richtext/richtextformatdlg.cpp:362
 msgid "Size"
 msgstr "Boyut"
 
-#: ../src/osx/carbon/fontdlg.cpp:339
+#: ../src/osx/carbon/fontdlg.cpp:336
 msgid "Size:"
 msgstr "Boyut:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1775
+#: ../src/propgrid/advprops.cpp:1676
 msgid "Sizing"
 msgstr "Boyutlandırma"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1772
+#: ../src/propgrid/advprops.cpp:1673
 msgid "Sizing N-S"
 msgstr "Boyutlandırma K-G"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1771
+#: ../src/propgrid/advprops.cpp:1672
 msgid "Sizing NE-SW"
 msgstr "Boyutlandırma KD-GB"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1773
+#: ../src/propgrid/advprops.cpp:1674
 msgid "Sizing NW-SE"
 msgstr "Boyutlandırma KB-GD"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1774
+#: ../src/propgrid/advprops.cpp:1675
 msgid "Sizing W-E"
 msgstr "Boyutlandırma B-D"
 
-#: ../src/msw/progdlg.cpp:801
+#: ../src/msw/progdlg.cpp:1088
 msgid "Skip"
 msgstr "Atla"
 
-#: ../src/generic/fontdlgg.cpp:330
+#: ../src/generic/fontdlgg.cpp:326
 msgid "Slant"
 msgstr "Eğik"
 
@@ -6427,7 +6595,7 @@ msgid "Small C&apitals"
 msgstr "Küçük H&arfler"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:79
+#: ../src/common/accelcmn.cpp:76
 msgid "Snapshot"
 msgstr "Ekran görüntüsü"
 
@@ -6435,37 +6603,37 @@ msgstr "Ekran görüntüsü"
 msgid "Solid"
 msgstr "Katı"
 
-#: ../src/common/docview.cpp:1791
+#: ../src/common/docview.cpp:1785
 msgid "Sorry, could not open this file."
 msgstr "Maalesef bu dosya açılamıyor."
 
-#: ../src/common/prntbase.cpp:2057 ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2079 ../src/common/prntbase.cpp:2087
 msgid "Sorry, not enough memory to create a preview."
 msgstr "Maalesef önizleme oluşturmak için yeterli bellek yok."
 
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "Sorry, that name is taken. Please choose another."
 msgstr "Maalesef bu ad kullanılmış. Lütfen başka bir ad seçin."
 
-#: ../src/common/docview.cpp:1814
+#: ../src/common/docview.cpp:1819
 msgid "Sorry, the format for this file is unknown."
 msgstr "Maalesef bu dosyanın biçimi bilinmiyor."
 
-#: ../src/unix/sound.cpp:492
+#: ../src/unix/sound.cpp:481
 msgid "Sound data are in unsupported format."
 msgstr "Ses verisi biçimi desteklenmiyor."
 
-#: ../src/unix/sound.cpp:477
+#: ../src/unix/sound.cpp:466
 #, c-format
 msgid "Sound file '%s' is in unsupported format."
 msgstr "'%s' ses dosyasının biçimi desteklenmiyor."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:67
+#: ../src/common/accelcmn.cpp:64
 msgid "Space"
 msgstr "Boşluk"
 
@@ -6473,12 +6641,12 @@ msgstr "Boşluk"
 msgid "Spacing"
 msgstr "Aralık"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "Spell Check"
 msgstr "Yazım Denetimi"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1776
+#: ../src/propgrid/advprops.cpp:1677
 msgid "Spraycan"
 msgstr "Sprey"
 
@@ -6487,7 +6655,7 @@ msgstr "Sprey"
 msgid "Standard"
 msgstr "Standart"
 
-#: ../src/common/paper.cpp:104
+#: ../src/common/paper.cpp:101
 msgid "Statement, 5 1/2 x 8 1/2 in"
 msgstr "Statement, 5 1/2 x 8 1/2 inç"
 
@@ -6496,33 +6664,29 @@ msgstr "Statement, 5 1/2 x 8 1/2 inç"
 msgid "Static"
 msgstr "Durağan"
 
-#: ../src/generic/prntdlgg.cpp:204
+#: ../src/generic/prntdlgg.cpp:197
 msgid "Status:"
 msgstr "Durum:"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "Stop"
 msgstr "Durdur"
 
-#: ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196
 msgid "Strikethrough"
 msgstr "Üstü çizili"
 
-#: ../src/common/colourcmn.cpp:45
+#: ../src/common/colourcmn.cpp:42
 #, c-format
 msgid "String To Colour : Incorrect colour specification : %s"
 msgstr "Dizgeden Renge: Hatalı renk tanımı: %s"
 
 #. TRANSLATORS: Label of font style
-#: ../src/richtext/richtextformatdlg.cpp:339 ../src/propgrid/advprops.cpp:680
+#: ../src/propgrid/advprops.cpp:590 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Biçem"
 
-#: ../include/wx/richtext/richtextstyledlg.h:46
-msgid "Style Organiser"
-msgstr "Biçem Düzenleyici"
-
-#: ../src/osx/carbon/fontdlg.cpp:348
+#: ../src/osx/carbon/fontdlg.cpp:345
 msgid "Style:"
 msgstr "Biçem:"
 
@@ -6531,7 +6695,7 @@ msgid "Subscrip&t"
 msgstr "Al&t karakter"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:83
+#: ../src/common/accelcmn.cpp:80
 msgid "Subtract"
 msgstr "Eksi"
 
@@ -6539,11 +6703,11 @@ msgstr "Eksi"
 msgid "Supe&rscript"
 msgstr "Ü&st karakter"
 
-#: ../src/common/paper.cpp:150
+#: ../src/common/paper.cpp:147
 msgid "SuperA/SuperA/A4 227 x 356 mm"
 msgstr "SuperA/SuperA/A4 227 x 356 mm"
 
-#: ../src/common/paper.cpp:151
+#: ../src/common/paper.cpp:148
 msgid "SuperB/SuperB/A3 305 x 487 mm"
 msgstr "SuperB/SuperB/A3 305 x 487 mm"
 
@@ -6551,7 +6715,7 @@ msgstr "SuperB/SuperB/A3 305 x 487 mm"
 msgid "Suppress hyphe&nation"
 msgstr "Heceleme e&ngellensin"
 
-#: ../src/generic/fontdlgg.cpp:326
+#: ../src/generic/fontdlgg.cpp:322
 msgid "Swiss"
 msgstr "İsveç"
 
@@ -6569,73 +6733,73 @@ msgstr "Simge &yazı türü:"
 msgid "Symbols"
 msgstr "Simgeler"
 
-#: ../src/common/imagtiff.cpp:369 ../src/common/imagtiff.cpp:382
-#: ../src/common/imagtiff.cpp:741
+#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
+#: ../src/common/imagtiff.cpp:738
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: Bellek ayrılamadı."
 
-#: ../src/common/imagtiff.cpp:301
+#: ../src/common/imagtiff.cpp:298
 msgid "TIFF: Error loading image."
 msgstr "TIFF: Görsel yükleme sorunu."
 
-#: ../src/common/imagtiff.cpp:468
+#: ../src/common/imagtiff.cpp:465
 msgid "TIFF: Error reading image."
 msgstr "TIFF: Görsel okuma sorunu."
 
-#: ../src/common/imagtiff.cpp:608
+#: ../src/common/imagtiff.cpp:605
 msgid "TIFF: Error saving image."
 msgstr "TIFF: Görsel kaydetme sorunu."
 
-#: ../src/common/imagtiff.cpp:846
+#: ../src/common/imagtiff.cpp:843
 msgid "TIFF: Error writing image."
 msgstr "TIFF: Görsel yazma sorunu."
 
-#: ../src/common/imagtiff.cpp:355
+#: ../src/common/imagtiff.cpp:352
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: Görsel boyutu anormal büyük."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:68
+#: ../src/common/accelcmn.cpp:65
 msgid "Tab"
 msgstr "Sekme"
 
-#: ../src/richtext/richtextbuffer.cpp:11498
+#: ../src/richtext/richtextbuffer.cpp:11497
 msgid "Table Properties"
 msgstr "Tablo Özellikleri"
 
-#: ../src/common/paper.cpp:145
+#: ../src/common/paper.cpp:142
 msgid "Tabloid Extra 11.69 x 18 in"
 msgstr "Tabloid Ek 11.69 x 18 inç"
 
-#: ../src/common/paper.cpp:102
+#: ../src/common/paper.cpp:99
 msgid "Tabloid, 11 x 17 in"
 msgstr "Tabloid, 11 x 17 inç"
 
-#: ../src/richtext/richtextformatdlg.cpp:354
+#: ../src/richtext/richtextformatdlg.cpp:347
 msgid "Tabs"
 msgstr "Sekmeler"
 
-#: ../src/propgrid/advprops.cpp:1598
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Teal"
 msgstr "Yeşilimsi mavi"
 
-#: ../src/generic/fontdlgg.cpp:327
+#: ../src/generic/fontdlgg.cpp:323
 msgid "Teletype"
 msgstr "Teletype"
 
-#: ../src/common/docview.cpp:1896
+#: ../src/common/docview.cpp:1901
 msgid "Templates"
 msgstr "Kalıplar"
 
-#: ../src/common/fmapbase.cpp:158
+#: ../src/common/fmapbase.cpp:155
 msgid "Thai (ISO-8859-11)"
 msgstr "Thai (ISO-8859-11)"
 
-#: ../src/common/ftp.cpp:619
+#: ../src/common/ftp.cpp:622
 msgid "The FTP server doesn't support passive mode."
 msgstr "FTP sunucusu pasif kipi desteklemiyor."
 
-#: ../src/common/ftp.cpp:605
+#: ../src/common/ftp.cpp:608
 msgid "The FTP server doesn't support the PORT command."
 msgstr "FTP sunucusu PORT komutunu desteklemiyor."
 
@@ -6646,8 +6810,8 @@ msgstr "FTP sunucusu PORT komutunu desteklemiyor."
 msgid "The available bullet styles."
 msgstr "Kullanılabilecek madde imi biçemleri."
 
-#: ../src/richtext/richtextstyledlg.cpp:202
-#: ../src/richtext/richtextstyledlg.cpp:204
+#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:200
 msgid "The available styles."
 msgstr "Kullanılabilecek biçemler."
 
@@ -6703,12 +6867,12 @@ msgstr "Alt konum."
 msgid "The bullet character."
 msgstr "Madde imi karakteri."
 
-#: ../src/richtext/richtextsymboldlg.cpp:443
-#: ../src/richtext/richtextsymboldlg.cpp:445
+#: ../src/richtext/richtextsymboldlg.cpp:440
+#: ../src/richtext/richtextsymboldlg.cpp:442
 msgid "The character code."
 msgstr "Karakter kodu."
 
-#: ../src/common/fontmap.cpp:203
+#: ../src/common/fontmap.cpp:200
 #, c-format
 msgid ""
 "The charset '%s' is unknown. You may select\n"
@@ -6719,7 +6883,7 @@ msgstr ""
 "başka bir tane seçebilir ya da \n"
 "seçemiyorsanız [İptal] düğmesine tıklayabilirsiniz"
 
-#: ../src/msw/ole/dataobj.cpp:394
+#: ../src/msw/ole/dataobj.cpp:402
 #, c-format
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "'%d' pano biçimi bulunamıyor."
@@ -6729,7 +6893,7 @@ msgstr "'%d' pano biçimi bulunamıyor."
 msgid "The default style for the next paragraph."
 msgstr "Sonraki paragraf için varsayılan biçem."
 
-#: ../src/generic/dirdlgg.cpp:202
+#: ../src/generic/dirdlgg.cpp:199
 #, c-format
 msgid ""
 "The directory '%s' does not exist\n"
@@ -6738,7 +6902,7 @@ msgstr ""
 "'%s' klasörü bulunamadı\n"
 "Şimdi oluşturulsun mu?"
 
-#: ../src/html/htmprint.cpp:271
+#: ../src/html/htmprint.cpp:283
 #, c-format
 msgid ""
 "The document \"%s\" doesn't fit on the page horizontally and will be "
@@ -6750,7 +6914,7 @@ msgstr ""
 "\n"
 "Buna rağmen yazdırmak istiyor musunuz?"
 
-#: ../src/common/docview.cpp:1202
+#: ../src/common/docview.cpp:1196
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -6759,36 +6923,36 @@ msgstr ""
 "'%s' dosyası yok ve açılamadı.\n"
 "Son kullanılan dosyalar listesinden kaldırıldı."
 
-#: ../src/richtext/richtextindentspage.cpp:208
-#: ../src/richtext/richtextindentspage.cpp:210
 #: ../src/richtext/richtextliststylepage.cpp:394
 #: ../src/richtext/richtextliststylepage.cpp:396
+#: ../src/richtext/richtextindentspage.cpp:208
+#: ../src/richtext/richtextindentspage.cpp:210
 msgid "The first line indent."
 msgstr "İlk satır girintisi."
 
-#: ../src/gtk/utilsgtk.cpp:481
-msgid "The following standard GTK+ options are also supported:\n"
-msgstr "Aşağıdaki standart GTK+ seçenekleri de desteklenmektedir:\n"
+#: ../src/generic/dbgrptg.cpp:318
+msgid "The following debug report will be generated\n"
+msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:414 ../src/generic/fontdlgg.cpp:416
+#: ../src/generic/fontdlgg.cpp:411 ../src/generic/fontdlgg.cpp:413
 msgid "The font colour."
 msgstr "Yazı türü rengi."
 
-#: ../src/generic/fontdlgg.cpp:375 ../src/generic/fontdlgg.cpp:377
+#: ../src/generic/fontdlgg.cpp:371 ../src/generic/fontdlgg.cpp:373
 msgid "The font family."
 msgstr "Yazı türü ailesi."
 
-#: ../src/richtext/richtextsymboldlg.cpp:405
-#: ../src/richtext/richtextsymboldlg.cpp:407
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "The font from which to take the symbol."
 msgstr "Simgenin alınacağı yazı türü."
 
-#: ../src/generic/fontdlgg.cpp:427 ../src/generic/fontdlgg.cpp:429
-#: ../src/generic/fontdlgg.cpp:434 ../src/generic/fontdlgg.cpp:436
+#: ../src/generic/fontdlgg.cpp:424 ../src/generic/fontdlgg.cpp:426
+#: ../src/generic/fontdlgg.cpp:430 ../src/generic/fontdlgg.cpp:432
 msgid "The font point size."
 msgstr "Yazı türü punto boyutu."
 
-#: ../src/osx/carbon/fontdlg.cpp:343 ../src/osx/carbon/fontdlg.cpp:345
+#: ../src/osx/carbon/fontdlg.cpp:340 ../src/osx/carbon/fontdlg.cpp:342
 msgid "The font size in points."
 msgstr "Punto cinsinden yazı türü boyutu."
 
@@ -6797,15 +6961,15 @@ msgstr "Punto cinsinden yazı türü boyutu."
 msgid "The font size units, points or pixels."
 msgstr "Yazı türü boyutu birimi, punto ya da piksel."
 
-#: ../src/generic/fontdlgg.cpp:386 ../src/generic/fontdlgg.cpp:388
+#: ../src/generic/fontdlgg.cpp:382 ../src/generic/fontdlgg.cpp:384
 msgid "The font style."
 msgstr "Yazı türü biçemi."
 
-#: ../src/generic/fontdlgg.cpp:397 ../src/generic/fontdlgg.cpp:399
+#: ../src/generic/fontdlgg.cpp:393 ../src/generic/fontdlgg.cpp:395
 msgid "The font weight."
 msgstr "Yazı türü yoğunluğu."
 
-#: ../src/common/docview.cpp:1483
+#: ../src/common/docview.cpp:1477
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "'%s' dosyasının biçimi belirlenemedi."
@@ -6815,10 +6979,10 @@ msgstr "'%s' dosyasının biçimi belirlenemedi."
 msgid "The horizontal offset."
 msgstr "Yatay öteleme."
 
-#: ../src/richtext/richtextindentspage.cpp:199
-#: ../src/richtext/richtextindentspage.cpp:201
 #: ../src/richtext/richtextliststylepage.cpp:385
 #: ../src/richtext/richtextliststylepage.cpp:387
+#: ../src/richtext/richtextindentspage.cpp:199
+#: ../src/richtext/richtextindentspage.cpp:201
 msgid "The left indent."
 msgstr "Sol girinti."
 
@@ -6839,10 +7003,10 @@ msgstr "Sol yastıklama boyutu."
 msgid "The left position."
 msgstr "Sol konum."
 
-#: ../src/richtext/richtextindentspage.cpp:288
-#: ../src/richtext/richtextindentspage.cpp:290
 #: ../src/richtext/richtextliststylepage.cpp:462
 #: ../src/richtext/richtextliststylepage.cpp:464
+#: ../src/richtext/richtextindentspage.cpp:288
+#: ../src/richtext/richtextindentspage.cpp:290
 msgid "The line spacing."
 msgstr "Satır aralığı."
 
@@ -6851,7 +7015,7 @@ msgstr "Satır aralığı."
 msgid "The list item number."
 msgstr "Liste ögesi numarası."
 
-#: ../src/msw/ole/automtn.cpp:664
+#: ../src/msw/ole/automtn.cpp:655
 msgid "The locale ID is unknown."
 msgstr "Yerel kodu bilinmiyor."
 
@@ -6890,18 +7054,18 @@ msgstr "Nesne genişliği."
 msgid "The outline level."
 msgstr "Taslak düzeyi."
 
-#: ../src/common/log.cpp:277
+#: ../src/common/log.cpp:296
 #, c-format
 msgid "The previous message repeated %u time."
 msgid_plural "The previous message repeated %u times."
 msgstr[0] "Önceki ileti %u kez yinelendi."
 
-#: ../src/common/log.cpp:270
+#: ../src/common/log.cpp:289
 msgid "The previous message repeated once."
 msgstr "Önceki ileti bir kez yinelendi."
 
-#: ../src/richtext/richtextsymboldlg.cpp:462
-#: ../src/richtext/richtextsymboldlg.cpp:464
+#: ../src/richtext/richtextsymboldlg.cpp:459
+#: ../src/richtext/richtextsymboldlg.cpp:461
 msgid "The range to show."
 msgstr "Görüntülenecek aralık."
 
@@ -6915,15 +7079,15 @@ msgstr ""
 "varsa,\n"
 "rapordan çıkarmak istediğiniz dosyaların işaretini kaldırın.\n"
 
-#: ../src/common/cmdline.cpp:1254
+#: ../src/common/cmdline.cpp:1250
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "Gerekli '%s' parametresi belirtilmemiş."
 
-#: ../src/richtext/richtextindentspage.cpp:217
-#: ../src/richtext/richtextindentspage.cpp:219
 #: ../src/richtext/richtextliststylepage.cpp:403
 #: ../src/richtext/richtextliststylepage.cpp:405
+#: ../src/richtext/richtextindentspage.cpp:217
+#: ../src/richtext/richtextindentspage.cpp:219
 msgid "The right indent."
 msgstr "Sağ girinti."
 
@@ -6964,16 +7128,16 @@ msgstr "Gölge matlığı."
 msgid "The shadow spread."
 msgstr "Gölge yayılması."
 
-#: ../src/richtext/richtextindentspage.cpp:267
 #: ../src/richtext/richtextliststylepage.cpp:439
 #: ../src/richtext/richtextliststylepage.cpp:441
+#: ../src/richtext/richtextindentspage.cpp:267
 msgid "The spacing after the paragraph."
 msgstr "Paragraftan sonraki boşluk."
 
-#: ../src/richtext/richtextindentspage.cpp:257
-#: ../src/richtext/richtextindentspage.cpp:259
 #: ../src/richtext/richtextliststylepage.cpp:430
 #: ../src/richtext/richtextliststylepage.cpp:432
+#: ../src/richtext/richtextindentspage.cpp:257
+#: ../src/richtext/richtextindentspage.cpp:259
 msgid "The spacing before the paragraph."
 msgstr "Paragraftan önceki boşluk."
 
@@ -6987,12 +7151,12 @@ msgstr "Biçem adı."
 msgid "The style on which this style is based."
 msgstr "Bu biçemin temel alındığı biçem."
 
-#: ../src/richtext/richtextstyledlg.cpp:214
-#: ../src/richtext/richtextstyledlg.cpp:216
+#: ../src/richtext/richtextstyledlg.cpp:210
+#: ../src/richtext/richtextstyledlg.cpp:212
 msgid "The style preview."
 msgstr "Biçem önizlemesi."
 
-#: ../src/msw/ole/automtn.cpp:680
+#: ../src/msw/ole/automtn.cpp:671
 msgid "The system cannot find the file specified."
 msgstr "Sistem belirtilen dosyayı bulamadı."
 
@@ -7005,7 +7169,7 @@ msgstr "Sekme konumu."
 msgid "The tab positions."
 msgstr "Sekme konumları."
 
-#: ../src/richtext/richtextctrl.cpp:3098
+#: ../src/richtext/richtextctrl.cpp:3099
 msgid "The text couldn't be saved."
 msgstr "Metin kaydedilemedi."
 
@@ -7026,7 +7190,7 @@ msgstr "Üst yastıklama boyutu."
 msgid "The top position."
 msgstr "Üst konum."
 
-#: ../src/common/cmdline.cpp:1232
+#: ../src/common/cmdline.cpp:1228
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "'%s' seçeneği için değer belirtilmelidir."
@@ -7036,7 +7200,7 @@ msgstr "'%s' seçeneği için değer belirtilmelidir."
 msgid "The value of the corner radius."
 msgstr "Köşe yarıçapı değeri."
 
-#: ../src/msw/dialup.cpp:433
+#: ../src/msw/dialup.cpp:427
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -7050,29 +7214,29 @@ msgstr ""
 msgid "The vertical offset."
 msgstr "Dikey öteleme."
 
-#: ../src/richtext/richtextprint.cpp:619 ../src/html/htmprint.cpp:745
+#: ../src/html/htmprint.cpp:749 ../src/richtext/richtextprint.cpp:615
 msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr ""
 "Sayfa ayarlanırken bir sorun çıktı: bir varsayılan yazıcı belirlemeniz "
 "gerekebilir."
 
-#: ../src/html/htmprint.cpp:255
+#: ../src/html/htmprint.cpp:267
 msgid ""
 "This document doesn't fit on the page horizontally and will be truncated "
 "when it is printed."
 msgstr "Bu belge sayfaya yatay olarak sığmıyor ve yazdırılırsa budanacak."
 
-#: ../src/common/image.cpp:2854
+#: ../src/common/image.cpp:2963
 #, c-format
 msgid "This is not a %s."
 msgstr "Bu bir %s değil."
 
-#: ../src/common/wincmn.cpp:1653
+#: ../src/common/wincmn.cpp:1654
 msgid "This platform does not support background transparency."
 msgstr "Bu platformda art alan saydamlığı desteklenmiyor."
 
-#: ../src/gtk/window.cpp:4660
+#: ../src/gtk/window.cpp:5664
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
@@ -7080,98 +7244,106 @@ msgstr ""
 "Bu program çok eski bir GTK+ sürümüyle derlenmiş. Lütfen GTK+ 2.12 ya da "
 "üzeri bir sürümle yeniden derleyin."
 
-#: ../src/msw/thread.cpp:1240
+#: ../src/gtk/glcanvas.cpp:176
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/msw/thread.cpp:1246
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
 msgstr "İş parçacığı modülü başlatılamadı: yerel depoya değer koyulamıyor"
 
-#: ../src/unix/threadpsx.cpp:1794
+#: ../src/unix/threadpsx.cpp:1843
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 "İş parçacığı modülü başlatılamadı: iş parçacığı anahtarı oluşturulamadı"
 
-#: ../src/msw/thread.cpp:1228
+#: ../src/msw/thread.cpp:1234
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
 msgstr "İş parçacığı modülü başlatılamadı: yerel depoda dizin oluşturulamıyor"
 
-#: ../src/unix/threadpsx.cpp:1043
+#: ../src/unix/threadpsx.cpp:1061
 msgid "Thread priority setting is ignored."
 msgstr "İş parçacığı öncelik ayarları yok sayıldı."
 
-#: ../src/msw/mdi.cpp:176
+#: ../src/msw/mdi.cpp:171
 msgid "Tile &Horizontally"
 msgstr "&Yatay Döşe"
 
-#: ../src/msw/mdi.cpp:177
+#: ../src/msw/mdi.cpp:172
 msgid "Tile &Vertically"
 msgstr "&Dikey Döşe"
 
-#: ../src/common/ftp.cpp:200
+#: ../src/common/ftp.cpp:197
 msgid "Timeout while waiting for FTP server to connect, try passive mode."
 msgstr "FTP sunucu bağlantısı zaman aşımına uğradı, pasif kipi deneyin."
 
-#: ../src/generic/tipdlg.cpp:201
+#: ../src/generic/tipdlg.cpp:198
 msgid "Tip of the Day"
 msgstr "Günün İpucu"
 
-#: ../src/generic/tipdlg.cpp:140
+#: ../src/generic/tipdlg.cpp:137
 msgid "Tips not available, sorry!"
 msgstr "Maalesef herhangi bir ipucu yok!"
 
-#: ../src/generic/prntdlgg.cpp:242
+#: ../src/generic/prntdlgg.cpp:235
 msgid "To:"
 msgstr "Kime:"
 
-#: ../src/richtext/richtextbuffer.cpp:8363
+#: ../src/richtext/richtextbuffer.cpp:8361
 msgid "Too many EndStyle calls!"
 msgstr "Çok fazla EndStyle çağrısı!"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:891
+#: ../src/propgrid/advprops.cpp:792
 msgid "Tooltip"
 msgstr "İpucu"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:892
+#: ../src/propgrid/advprops.cpp:793
 msgid "TooltipText"
 msgstr "İpucuMetni"
 
-#: ../src/richtext/richtextsizepage.cpp:286
-#: ../src/richtext/richtextsizepage.cpp:290 ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197 ../src/richtext/richtextsizepage.cpp:286
+#: ../src/richtext/richtextsizepage.cpp:290
 msgid "Top"
 msgstr "Üst"
 
-#: ../src/generic/prntdlgg.cpp:881
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Top margin (mm):"
 msgstr "Üst kenar boşluğu (mm):"
 
-#: ../src/generic/aboutdlgg.cpp:79
+#: ../src/generic/aboutdlgg.cpp:76
 msgid "Translations by "
 msgstr "Çeviren "
 
-#: ../src/generic/aboutdlgg.cpp:188
+#: ../src/generic/aboutdlgg.cpp:185
 msgid "Translators"
 msgstr "Çevirmenler"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:211
+#: ../src/propgrid/propgrid.cpp:192
 msgid "True"
 msgstr "Doğru"
 
-#: ../src/common/fs_mem.cpp:227
+#: ../src/common/fs_mem.cpp:222
 #, c-format
 msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
 msgstr ""
 "'%s' dosyası yüklü olmadığı halde VFS belleğinden silinmeye çalışılıyor!"
 
-#: ../src/common/fmapbase.cpp:156
+#: ../src/common/fmapbase.cpp:153
 msgid "Turkish (ISO-8859-9)"
 msgstr "Türkçe (ISO-8859-9)"
 
-#: ../src/generic/filectrlg.cpp:426
+#: ../src/generic/filectrlg.cpp:422
 msgid "Type"
 msgstr "Tür"
 
@@ -7185,17 +7357,17 @@ msgstr "Bir yazı türü adı yazın."
 msgid "Type a size in points."
 msgstr "Punto cinsinden bir boyut yazın."
 
-#: ../src/msw/ole/automtn.cpp:676
+#: ../src/msw/ole/automtn.cpp:667
 #, c-format
 msgid "Type mismatch in argument %u."
 msgstr "%u argümanında tür uyuşmazlığı."
 
-#: ../src/common/xtixml.cpp:356 ../src/common/xtixml.cpp:509
-#: ../src/common/xtistrm.cpp:318
+#: ../src/common/xtixml.cpp:352 ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315
 msgid "Type must have enum - long conversion"
 msgstr "Tür enum - long çevrimini desteklemelidir"
 
-#: ../src/propgrid/propgridiface.cpp:401
+#: ../src/propgrid/propgridiface.cpp:385
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
@@ -7204,19 +7376,19 @@ msgstr ""
 "\"%s\" tür işlemi yapılamadı: Etiketlenen özellik \"%s\" \"%s\" türünde, \"%s"
 "\" türünde DEĞİL."
 
-#: ../src/common/paper.cpp:133
+#: ../src/common/paper.cpp:130
 msgid "US Std Fanfold, 14 7/8 x 11 in"
 msgstr "US Std Fanfold, 14 7/8 x 11 inç"
 
-#: ../src/common/fmapbase.cpp:196
+#: ../src/common/fmapbase.cpp:193
 msgid "US-ASCII"
 msgstr "US-ASCII"
 
-#: ../src/unix/fswatcher_inotify.cpp:109
+#: ../src/unix/fswatcher_inotify.cpp:106
 msgid "Unable to add inotify watch"
 msgstr "inotify izlemesi eklenemedi"
 
-#: ../src/unix/fswatcher_kqueue.cpp:136
+#: ../src/unix/fswatcher_kqueue.cpp:153
 msgid "Unable to add kqueue watch"
 msgstr "kqueue izlemesi eklenemedi"
 
@@ -7228,7 +7400,7 @@ msgstr "Giriş/Çıkış tamamlanma kapısı işleyici ile ilişkilendirilemedi"
 msgid "Unable to close I/O completion port handle"
 msgstr "Giriş/Çıkış tamamlanma kapısı işleyicisi kapatılamadı"
 
-#: ../src/unix/fswatcher_inotify.cpp:97
+#: ../src/unix/fswatcher_inotify.cpp:94
 msgid "Unable to close inotify instance"
 msgstr "inotify kopyası kapatılamadı"
 
@@ -7246,15 +7418,15 @@ msgstr "'%s' işleyicisi kapatılamadı"
 msgid "Unable to create I/O completion port"
 msgstr "Giriş/Çıkış tamamlanma kapısı oluşturulamadı"
 
-#: ../src/msw/fswatcher.cpp:84
+#: ../src/msw/fswatcher.cpp:81
 msgid "Unable to create IOCP worker thread"
 msgstr "IOCP iş parçacığı oluşturulamadı"
 
-#: ../src/unix/fswatcher_inotify.cpp:74
+#: ../src/unix/fswatcher_inotify.cpp:71
 msgid "Unable to create inotify instance"
 msgstr "inotify kopyası oluşturulamadı"
 
-#: ../src/unix/fswatcher_kqueue.cpp:97
+#: ../src/unix/fswatcher_kqueue.cpp:114
 msgid "Unable to create kqueue instance"
 msgstr "kqueue kopyası oluşturulamadı"
 
@@ -7262,11 +7434,11 @@ msgstr "kqueue kopyası oluşturulamadı"
 msgid "Unable to dequeue completion packet"
 msgstr "Tamamlanma paketi kuyruktan çıkarılamadı"
 
-#: ../src/unix/fswatcher_kqueue.cpp:185
+#: ../src/unix/fswatcher_kqueue.cpp:202
 msgid "Unable to get events from kqueue"
 msgstr "Olaylar kqueue üzerinden alınamadı"
 
-#: ../src/gtk/app.cpp:435
+#: ../src/gtk/app.cpp:431
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "GTK+ başlatılamadı, DISPLAY düzgün ayarlanmış mı?"
 
@@ -7275,12 +7447,12 @@ msgstr "GTK+ başlatılamadı, DISPLAY düzgün ayarlanmış mı?"
 msgid "Unable to open path '%s'"
 msgstr "'%s' yolu açılamadı"
 
-#: ../src/html/htmlwin.cpp:583
+#: ../src/html/htmlwin.cpp:586
 #, c-format
 msgid "Unable to open requested HTML document: %s"
 msgstr "İstenen HTML belgesi açılamıyor: %s"
 
-#: ../src/unix/sound.cpp:368
+#: ../src/unix/sound.cpp:365
 msgid "Unable to play sound asynchronously."
 msgstr "Ses zaman eşlemesiz olarak çalınamıyor."
 
@@ -7288,61 +7460,61 @@ msgstr "Ses zaman eşlemesiz olarak çalınamıyor."
 msgid "Unable to post completion status"
 msgstr "Tamamlanma durumu gönderilemedi"
 
-#: ../src/unix/fswatcher_inotify.cpp:556
+#: ../src/unix/fswatcher_inotify.cpp:553
 msgid "Unable to read from inotify descriptor"
 msgstr "inotify tanımlayıcısı okunamadı"
 
-#: ../src/unix/fswatcher_inotify.cpp:141
+#: ../src/unix/fswatcher_inotify.cpp:138
 #, c-format
 msgid "Unable to remove inotify watch %i"
 msgstr "%i inotify izlemesi kaldırılamadı"
 
-#: ../src/unix/fswatcher_kqueue.cpp:153
+#: ../src/unix/fswatcher_kqueue.cpp:170
 msgid "Unable to remove kqueue watch"
 msgstr "kqueue izlemesi kaldırılamadı"
 
-#: ../src/msw/fswatcher.cpp:168
+#: ../src/msw/fswatcher.cpp:165
 #, c-format
 msgid "Unable to set up watch for '%s'"
 msgstr "'%s' izlemesi kurulamadı"
 
-#: ../src/msw/fswatcher.cpp:91
+#: ../src/msw/fswatcher.cpp:88
 msgid "Unable to start IOCP worker thread"
 msgstr "IOCP iş parçacığı başlatılamadı"
 
-#: ../src/common/stockitem.cpp:201
+#: ../src/common/stockitem.cpp:198
 msgid "Undelete"
 msgstr "Silmeyi geri al"
 
-#: ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199
 msgid "Underline"
 msgstr "Altı çizili"
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/richtext/richtextfontpage.cpp:359 ../src/osx/carbon/fontdlg.cpp:370
-#: ../src/propgrid/advprops.cpp:690
+#: ../src/osx/carbon/fontdlg.cpp:367 ../src/propgrid/advprops.cpp:600
+#: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Altı çizili"
 
-#: ../src/common/stockitem.cpp:203 ../src/stc/stc_i18n.cpp:15
+#: ../src/common/stockitem.cpp:200 ../src/stc/stc_i18n.cpp:15
 msgid "Undo"
 msgstr "Geri Al"
 
-#: ../src/common/stockitem.cpp:265
+#: ../src/common/stockitem.cpp:263
 msgid "Undo last action"
 msgstr "Son işlemi geri al"
 
-#: ../src/common/cmdline.cpp:1029
+#: ../src/common/cmdline.cpp:1025
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "'%s' seçeneğinden sonra beklenmeyen karakterler."
 
-#: ../src/unix/fswatcher_inotify.cpp:274
+#: ../src/unix/fswatcher_inotify.cpp:271
 #, c-format
 msgid "Unexpected event for \"%s\": no matching watch descriptor."
 msgstr "\"%s\" için beklenmeyen etkinlik: uyan izleme belirteci yok."
 
-#: ../src/common/cmdline.cpp:1195
+#: ../src/common/cmdline.cpp:1191
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Beklenmeyen parametre '%s'"
@@ -7351,49 +7523,49 @@ msgstr "Beklenmeyen parametre '%s'"
 msgid "Unexpectedly new I/O completion port was created"
 msgstr "Beklenmedik şekilde yeni Giriş/Çıkış tamamlanma kapısı oluşturuldu"
 
-#: ../src/msw/fswatcher.cpp:70
+#: ../src/msw/fswatcher.cpp:67
 msgid "Ungraceful worker thread termination"
 msgstr "Uygunsuz iş parçacığı sonlandırması"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:460
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:456
+#: ../src/richtext/richtextsymboldlg.cpp:457
+#: ../src/richtext/richtextsymboldlg.cpp:458
 msgid "Unicode"
 msgstr "Unikod"
 
-#: ../src/common/fmapbase.cpp:185 ../src/common/fmapbase.cpp:191
+#: ../src/common/fmapbase.cpp:182 ../src/common/fmapbase.cpp:188
 msgid "Unicode 16 bit (UTF-16)"
 msgstr "Unikod 16 bit (UTF-16)"
 
-#: ../src/common/fmapbase.cpp:190
+#: ../src/common/fmapbase.cpp:187
 msgid "Unicode 16 bit Big Endian (UTF-16BE)"
 msgstr "Unikod 16 bit Big Endian (UTF-16BE)"
 
-#: ../src/common/fmapbase.cpp:186
+#: ../src/common/fmapbase.cpp:183
 msgid "Unicode 16 bit Little Endian (UTF-16LE)"
 msgstr "Unikod 16 bit Little Endian (UTF-16LE)"
 
-#: ../src/common/fmapbase.cpp:187 ../src/common/fmapbase.cpp:193
+#: ../src/common/fmapbase.cpp:184 ../src/common/fmapbase.cpp:190
 msgid "Unicode 32 bit (UTF-32)"
 msgstr "Unikod 32 bit (UTF-32)"
 
-#: ../src/common/fmapbase.cpp:192
+#: ../src/common/fmapbase.cpp:189
 msgid "Unicode 32 bit Big Endian (UTF-32BE)"
 msgstr "Unikod 32 bit Big Endian (UTF-32BE)"
 
-#: ../src/common/fmapbase.cpp:188
+#: ../src/common/fmapbase.cpp:185
 msgid "Unicode 32 bit Little Endian (UTF-32LE)"
 msgstr "Unikod 32 bit Little Endian (UTF-32LE)"
 
-#: ../src/common/fmapbase.cpp:182
+#: ../src/common/fmapbase.cpp:179
 msgid "Unicode 7 bit (UTF-7)"
 msgstr "7 bit Unikod (UTF-7)"
 
-#: ../src/common/fmapbase.cpp:183
+#: ../src/common/fmapbase.cpp:180
 msgid "Unicode 8 bit (UTF-8)"
 msgstr "8 bit Unikod (UTF-8)"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "Unindent"
 msgstr "Girintiyi geri al"
 
@@ -7543,97 +7715,102 @@ msgstr "Üst konumun birimleri."
 msgid "Units for this value."
 msgstr "Bu değerin birimleri."
 
-#: ../src/generic/progdlgg.cpp:353 ../src/generic/progdlgg.cpp:622
+#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
 msgid "Unknown"
 msgstr "Bilinmiyor"
 
-#: ../src/msw/dde.cpp:1174
+#: ../src/msw/dde.cpp:1238
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Bilinmeyen DDE hatası %08x"
 
-#: ../src/common/xtistrm.cpp:410
+#: ../src/common/xtistrm.cpp:407
 msgid "Unknown Object passed to GetObjectClassInfo"
 msgstr "GetObjectClassInfo işlevi bilinmeyen nesne ile çağrıldı"
 
-#: ../src/common/imagpng.cpp:366
+#: ../src/common/imagpng.cpp:383
 #, c-format
 msgid "Unknown PNG resolution unit %d"
 msgstr "Bilinmeyen PNG çözünürlük birimi %d"
 
-#: ../src/common/xtixml.cpp:327
+#: ../src/common/xtixml.cpp:323
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Bilinmeyen Özellik %s"
 
-#: ../src/common/imagtiff.cpp:529
+#: ../src/common/imagtiff.cpp:526
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "Bilinmeyen TIFF %d çözünürlük birimi yok sayıldı"
 
-#: ../src/unix/dlunix.cpp:160
+#: ../src/propgrid/props.cpp:155
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/unix/dlunix.cpp:118
 msgid "Unknown dynamic library error"
 msgstr "Blinmeyen devingen kitaplık sorunu"
 
-#: ../src/common/fmapbase.cpp:810
+#: ../src/common/fmapbase.cpp:806
 #, c-format
 msgid "Unknown encoding (%d)"
 msgstr "Bilinmeyen kodlama (%d)"
 
-#: ../src/msw/ole/automtn.cpp:688
+#: ../src/msw/ole/automtn.cpp:679
 #, c-format
 msgid "Unknown error %08x"
 msgstr "Bilinmeyen sorun %08x"
 
-#: ../src/msw/ole/automtn.cpp:647
+#: ../src/msw/ole/automtn.cpp:638
 msgid "Unknown exception"
 msgstr "Bilinmeyen istisna"
 
-#: ../src/common/image.cpp:2839
+#: ../src/common/image.cpp:2942
 msgid "Unknown image data format."
 msgstr "Bilinmeyen görsel veri biçimi."
 
-#: ../src/common/cmdline.cpp:914
+#: ../src/common/cmdline.cpp:910
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Blinmeyen long seçeneği '%s'"
 
-#: ../src/msw/ole/automtn.cpp:631
+#: ../src/msw/ole/automtn.cpp:622
 msgid "Unknown name or named argument."
 msgstr "Bilinmeyen ad ya da adlandırılmış argüman."
 
-#: ../src/common/cmdline.cpp:929 ../src/common/cmdline.cpp:951
+#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Bilinmeyen seçenek '%s'"
 
-#: ../src/common/mimecmn.cpp:225
+#: ../src/common/mimecmn.cpp:221
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "%s MIME türü kaydına uymayan '{'."
 
-#: ../src/common/cmdproc.cpp:262 ../src/common/cmdproc.cpp:288
-#: ../src/common/cmdproc.cpp:308
+#: ../src/common/cmdproc.cpp:255 ../src/common/cmdproc.cpp:281
+#: ../src/common/cmdproc.cpp:301
 msgid "Unnamed command"
 msgstr "Adsız komut"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:413
+#: ../src/propgrid/propgrid.cpp:392
 msgid "Unspecified"
 msgstr "Belirtilmemiş"
 
-#: ../src/msw/clipbrd.cpp:311
+#: ../src/msw/clipbrd.cpp:325
 msgid "Unsupported clipboard format."
 msgstr "Desteklenmeyen pano biçimi."
 
-#: ../src/common/appcmn.cpp:256
+#: ../src/common/appcmn.cpp:277
 #, c-format
 msgid "Unsupported theme '%s'."
 msgstr "Desteklenmeyen tema '%s'."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:205
-#: ../src/common/accelcmn.cpp:63
+#: ../src/common/stockitem.cpp:202 ../src/common/accelcmn.cpp:60
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Up"
 msgstr "Yukarı"
 
@@ -7647,7 +7824,7 @@ msgstr "Büyük harfler"
 msgid "Upper case roman numerals"
 msgstr "Büyük harf romen rakamları"
 
-#: ../src/common/cmdline.cpp:1326
+#: ../src/common/cmdline.cpp:1322
 #, c-format
 msgid "Usage: %s"
 msgstr "Kullanım: %s"
@@ -7656,38 +7833,47 @@ msgstr "Kullanım: %s"
 msgid "Use &shadow"
 msgstr "&Gölge kullanılsın"
 
-#: ../src/richtext/richtextindentspage.cpp:169
-#: ../src/richtext/richtextindentspage.cpp:171
 #: ../src/richtext/richtextliststylepage.cpp:358
 #: ../src/richtext/richtextliststylepage.cpp:360
+#: ../src/richtext/richtextindentspage.cpp:169
+#: ../src/richtext/richtextindentspage.cpp:171
 msgid "Use the current alignment setting."
 msgstr "Geçerli hizalama ayarları kullanılsın."
 
-#: ../src/common/valtext.cpp:179
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/gtk/font.cpp:552
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/common/valtext.cpp:142
 msgid "Validation conflict"
 msgstr "Doğrulama çelişkisi"
 
-#: ../src/propgrid/manager.cpp:238
+#: ../src/propgrid/manager.cpp:224
 msgid "Value"
 msgstr "Değer"
 
-#: ../src/propgrid/props.cpp:386 ../src/propgrid/props.cpp:500
+#: ../src/propgrid/props.cpp:309
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "Değer %s ya da daha büyük olmalı."
 
-#: ../src/propgrid/props.cpp:417 ../src/propgrid/props.cpp:531
+#: ../src/propgrid/props.cpp:336
 #, c-format
 msgid "Value must be %s or less."
 msgstr "Değer %s ya da daha küçük olmalı."
 
-#: ../src/propgrid/props.cpp:393 ../src/propgrid/props.cpp:424
-#: ../src/propgrid/props.cpp:507 ../src/propgrid/props.cpp:538
+#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "Değer %s ile %s arasında olmalı."
 
-#: ../src/generic/aboutdlgg.cpp:128
+#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Sürüm "
 
@@ -7696,25 +7882,32 @@ msgstr "Sürüm "
 msgid "Vertical alignment."
 msgstr "Dikey hizalama."
 
-#: ../src/generic/filedlgg.cpp:202
+#: ../src/generic/filedlgg.cpp:199
 msgid "View files as a detailed view"
 msgstr "Dosyalar ayrıntılı görünümde görüntülensin"
 
-#: ../src/generic/filedlgg.cpp:200
+#: ../src/generic/filedlgg.cpp:197
 msgid "View files as a list view"
 msgstr "Dosyalar liste görünümünde görüntülensin"
 
-#: ../src/common/docview.cpp:1970
+#: ../src/common/docview.cpp:1975
 msgid "Views"
 msgstr "Görünümler"
 
+#: ../src/gtk/app.cpp:348
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1777
+#: ../src/propgrid/advprops.cpp:1678
 msgid "Wait"
 msgstr "Bekleme"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1779
+#: ../src/propgrid/advprops.cpp:1680
 msgid "Wait Arrow"
 msgstr "Bekleme Oku"
 
@@ -7723,238 +7916,235 @@ msgstr "Bekleme Oku"
 msgid "Waiting for IO on epoll descriptor %d failed"
 msgstr "%d epoll tanımlayıcısı üstündeki GÇ beklemesi başarısız"
 
-#: ../src/common/log.cpp:223
+#: ../src/common/log.cpp:241
 msgid "Warning: "
 msgstr "Uyarı: "
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1778
+#: ../src/propgrid/advprops.cpp:1679
 msgid "Watch"
 msgstr "İzleme"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:685
+#: ../src/propgrid/advprops.cpp:595
 msgid "Weight"
 msgstr "Yoğunluk"
 
-#: ../src/common/fmapbase.cpp:148
+#: ../src/common/fmapbase.cpp:145
 msgid "Western European (ISO-8859-1)"
 msgstr "Batı Avrupa (ISO-8859-1)"
 
-#: ../src/common/fmapbase.cpp:162
+#: ../src/common/fmapbase.cpp:159
 msgid "Western European with Euro (ISO-8859-15)"
 msgstr "Batı Avrupa (Euro) (ISO-8859-15)"
 
-#: ../src/generic/fontdlgg.cpp:446 ../src/generic/fontdlgg.cpp:448
+#: ../src/generic/fontdlgg.cpp:443 ../src/generic/fontdlgg.cpp:445
 msgid "Whether the font is underlined."
 msgstr "Yazı türünün altı çizili olup olmadığı."
 
-#: ../src/propgrid/advprops.cpp:1611
+#: ../src/propgrid/advprops.cpp:1517
 msgid "White"
 msgstr "Beyaz"
 
-#: ../src/generic/fdrepdlg.cpp:144
+#: ../src/generic/fdrepdlg.cpp:141
 msgid "Whole word"
 msgstr "Tam kelime"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:532
 msgid "Whole words only"
 msgstr "Yalnız tam kelimeler"
 
-#: ../src/univ/themes/win32.cpp:1102
+#: ../src/univ/themes/win32.cpp:1099
 msgid "Win32 theme"
 msgstr "Win32 teması"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:893
+#: ../src/propgrid/advprops.cpp:794
 msgid "Window"
 msgstr "Pencere"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:894
+#: ../src/propgrid/advprops.cpp:795
 msgid "WindowFrame"
 msgstr "PencereÇerçevesi"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:895
+#: ../src/propgrid/advprops.cpp:796
 msgid "WindowText"
 msgstr "PencereMetni"
 
-#: ../src/common/fmapbase.cpp:177
+#: ../src/common/fmapbase.cpp:174
 msgid "Windows Arabic (CP 1256)"
 msgstr "Windows Arapça (CP 1256)"
 
-#: ../src/common/fmapbase.cpp:178
+#: ../src/common/fmapbase.cpp:175
 msgid "Windows Baltic (CP 1257)"
 msgstr "Windows Baltık (CP 1257)"
 
-#: ../src/common/fmapbase.cpp:171
+#: ../src/common/fmapbase.cpp:168
 msgid "Windows Central European (CP 1250)"
 msgstr "Windows Orta Avrupa (CP 1250)"
 
-#: ../src/common/fmapbase.cpp:168
+#: ../src/common/fmapbase.cpp:165
 msgid "Windows Chinese Simplified (CP 936) or GB-2312"
 msgstr "Windows Basitleştirilmiş Çince (CP 936) ya da GB-2312"
 
-#: ../src/common/fmapbase.cpp:170
+#: ../src/common/fmapbase.cpp:167
 msgid "Windows Chinese Traditional (CP 950) or Big-5"
 msgstr "Windows Geleneksel Çince (CP 950) ya da Big-5"
 
-#: ../src/common/fmapbase.cpp:172
+#: ../src/common/fmapbase.cpp:169
 msgid "Windows Cyrillic (CP 1251)"
 msgstr "Windows Kiril (CP 1251)"
 
-#: ../src/common/fmapbase.cpp:174
+#: ../src/common/fmapbase.cpp:171
 msgid "Windows Greek (CP 1253)"
 msgstr "Windows Yunanca (CP 1253)"
 
-#: ../src/common/fmapbase.cpp:176
+#: ../src/common/fmapbase.cpp:173
 msgid "Windows Hebrew (CP 1255)"
 msgstr "Windows İbranice (CP 1255)"
 
-#: ../src/common/fmapbase.cpp:167
+#: ../src/common/fmapbase.cpp:164
 msgid "Windows Japanese (CP 932) or Shift-JIS"
 msgstr "Windows Japonca (CP 932) ya da Shift-JIS"
 
-#: ../src/common/fmapbase.cpp:180
+#: ../src/common/fmapbase.cpp:177
 msgid "Windows Johab (CP 1361)"
 msgstr "Windows Johab (CP 1361)"
 
-#: ../src/common/fmapbase.cpp:169
+#: ../src/common/fmapbase.cpp:166
 msgid "Windows Korean (CP 949)"
 msgstr "Windows Korece (CP 949)"
 
-#: ../src/common/fmapbase.cpp:166
+#: ../src/common/fmapbase.cpp:163
 msgid "Windows Thai (CP 874)"
 msgstr "Windows Tai (CP 874)"
 
-#: ../src/common/fmapbase.cpp:175
+#: ../src/common/fmapbase.cpp:172
 msgid "Windows Turkish (CP 1254)"
 msgstr "Windows Türkçe (CP 1254)"
 
-#: ../src/common/fmapbase.cpp:179
+#: ../src/common/fmapbase.cpp:176
 msgid "Windows Vietnamese (CP 1258)"
 msgstr "Windows Vietnamca (CP 1258)"
 
-#: ../src/common/fmapbase.cpp:173
+#: ../src/common/fmapbase.cpp:170
 msgid "Windows Western European (CP 1252)"
 msgstr "Windows Batı Avrupa (CP 1252)"
 
-#: ../src/common/fmapbase.cpp:181
+#: ../src/common/fmapbase.cpp:178
 msgid "Windows/DOS OEM (CP 437)"
 msgstr "Windows/DOS OEM (CP 437)"
 
-#: ../src/common/fmapbase.cpp:165
+#: ../src/common/fmapbase.cpp:162
 msgid "Windows/DOS OEM Cyrillic (CP 866)"
 msgstr "Windows/DOS OEM Kiril (CP 866)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:111
+#: ../src/common/accelcmn.cpp:109
 msgid "Windows_Left"
 msgstr "Pencere_Sol"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:113
+#: ../src/common/accelcmn.cpp:111
 msgid "Windows_Menu"
 msgstr "Pencere_Menü"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:112
+#: ../src/common/accelcmn.cpp:110
 msgid "Windows_Right"
 msgstr "Pencere_Sağ"
 
-#: ../src/common/ffile.cpp:150
+#: ../src/common/ffile.cpp:149
 #, c-format
 msgid "Write error on file '%s'"
 msgstr "'%s' dosyasına yazma hatası"
 
-#: ../src/xml/xml.cpp:914
+#: ../src/xml/xml.cpp:925
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "XML işleme hatası: '%s' %d satırında"
 
-#: ../src/common/xpmdecod.cpp:796
+#: ../src/common/xpmdecod.cpp:794
 msgid "XPM: Malformed pixel data!"
 msgstr "XPM: Bozuk piksel verisi!"
 
-#: ../src/common/xpmdecod.cpp:705
+#: ../src/common/xpmdecod.cpp:702
 #, c-format
 msgid "XPM: incorrect colour description in line %d"
 msgstr "XPM: %d satırında hatalı renk açıklaması"
 
-#: ../src/common/xpmdecod.cpp:680
+#: ../src/common/xpmdecod.cpp:677
 msgid "XPM: incorrect header format!"
 msgstr "XPM: hatalı üst bilgi biçimi!"
 
-#: ../src/common/xpmdecod.cpp:716 ../src/common/xpmdecod.cpp:725
+#: ../src/common/xpmdecod.cpp:714 ../src/common/xpmdecod.cpp:723
 #, c-format
 msgid "XPM: malformed colour definition '%s' at line %d!"
 msgstr "XPM: '%s' bozuk renk tanımı %d satırında!"
 
-#: ../src/common/xpmdecod.cpp:755
+#: ../src/common/xpmdecod.cpp:753
 msgid "XPM: no colors left to use for mask!"
 msgstr "XPM: maske için kullanılacak renk kalmadı!"
 
-#: ../src/common/xpmdecod.cpp:782
+#: ../src/common/xpmdecod.cpp:780
 #, c-format
 msgid "XPM: truncated image data at line %d!"
 msgstr "XPM: %d satırında budanmış görüntü verisi!"
 
-#: ../src/propgrid/advprops.cpp:1610
+#: ../src/propgrid/advprops.cpp:1516
 msgid "Yellow"
 msgstr "Sarı"
 
-#: ../include/wx/msgdlg.h:276 ../src/common/stockitem.cpp:206
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:203
 #: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Evet"
 
-#: ../src/osx/carbon/overlay.cpp:155
-msgid "You cannot Clear an overlay that is not inited"
-msgstr "Hazırlanmamış bir örtüşmeyi temizleyemezsiniz"
-
-#: ../src/osx/carbon/overlay.cpp:107 ../src/dfb/overlay.cpp:61
-msgid "You cannot Init an overlay twice"
-msgstr "Bir örtüşmeyi iki kez hazırlayamazsınız"
-
-#: ../src/generic/dirdlgg.cpp:287
+#: ../src/generic/dirdlgg.cpp:284
 msgid "You cannot add a new directory to this section."
 msgstr "Bu bölüme yeni bir klasör ekleyemezsiniz."
 
-#: ../src/propgrid/propgrid.cpp:3299
+#: ../src/propgrid/propgrid.cpp:3276
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 "Geçersiz bir değer yazdınız, düzenlemeyi iptal etmek için ESC tuşuna basın."
 
-#: ../src/common/stockitem.cpp:209
+#: ../src/osx/cocoa/menu.mm:286
+#, fuzzy
+msgid "Zoom"
+msgstr "Büyüt"
+
+#: ../src/common/stockitem.cpp:206
 msgid "Zoom &In"
 msgstr "&Büyüt"
 
-#: ../src/common/stockitem.cpp:210
+#: ../src/common/stockitem.cpp:207
 msgid "Zoom &Out"
 msgstr "&Küçült"
 
-#: ../src/common/stockitem.cpp:209 ../src/common/prntbase.cpp:1594
+#: ../src/common/stockitem.cpp:206 ../src/common/prntbase.cpp:1619
 msgid "Zoom In"
 msgstr "Büyüt"
 
-#: ../src/common/stockitem.cpp:210 ../src/common/prntbase.cpp:1580
+#: ../src/common/stockitem.cpp:207 ../src/common/prntbase.cpp:1605
 msgid "Zoom Out"
 msgstr "Küçült"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to &Fit"
 msgstr "&Sığdır"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to Fit"
 msgstr "Sığdır"
 
-#: ../src/msw/dde.cpp:1141
+#: ../src/msw/dde.cpp:1205
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "bir DDEML uygulaması uzun koşu durumu oluşturdu."
 
-#: ../src/msw/dde.cpp:1129
+#: ../src/msw/dde.cpp:1193
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -7965,39 +8155,39 @@ msgstr ""
 "ya da DDEML işlevine geçersiz bir \n"
 "örnek tanımlayıcısı gönderildi."
 
-#: ../src/msw/dde.cpp:1147
+#: ../src/msw/dde.cpp:1211
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "bir istemcinin konuşma başlatma denemesi başarısız oldu."
 
-#: ../src/msw/dde.cpp:1144
+#: ../src/msw/dde.cpp:1208
 msgid "a memory allocation failed."
 msgstr "bellek ayrılamadı."
 
-#: ../src/msw/dde.cpp:1138
+#: ../src/msw/dde.cpp:1202
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "parametre DDEML tarafından doğrulanamadı."
 
-#: ../src/msw/dde.cpp:1120
+#: ../src/msw/dde.cpp:1184
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "eşzamanlı danışma işlemi isteği zaman aşımına uğradı."
 
-#: ../src/msw/dde.cpp:1126
+#: ../src/msw/dde.cpp:1190
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "eşzamanlı veri işlemi isteği zaman aşımına uğradı."
 
-#: ../src/msw/dde.cpp:1135
+#: ../src/msw/dde.cpp:1199
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "eşzamanlı çalıştırma işlemi isteği zaman aşımına uğradı."
 
-#: ../src/msw/dde.cpp:1153
+#: ../src/msw/dde.cpp:1217
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "eşzamanlı itme işlemi isteği zaman aşımına uğradı."
 
-#: ../src/msw/dde.cpp:1168
+#: ../src/msw/dde.cpp:1232
 msgid "a request to end an advise transaction has timed out."
 msgstr "danışma işlemi bitirme isteği zaman aşımına uğradı."
 
-#: ../src/msw/dde.cpp:1162
+#: ../src/msw/dde.cpp:1226
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -8007,15 +8197,15 @@ msgstr ""
 "sunucu tarafında bir işlem denendi, ya da sunucu\n"
 "işlem tamamlanmadan sonlandırıldı."
 
-#: ../src/msw/dde.cpp:1150
+#: ../src/msw/dde.cpp:1214
 msgid "a transaction failed."
 msgstr "işlem tamamlanamadı.."
 
-#: ../src/common/accelcmn.cpp:189
+#: ../src/common/accelcmn.cpp:188
 msgid "alt"
 msgstr "alt"
 
-#: ../src/msw/dde.cpp:1132
+#: ../src/msw/dde.cpp:1196
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -8027,15 +8217,15 @@ msgstr ""
 "ya da APPCMD_CLIENTONLY olarak başlatılmış bir uygulama\n"
 "sunucu hareketi gerçekleştirmeyi denedi."
 
-#: ../src/msw/dde.cpp:1156
+#: ../src/msw/dde.cpp:1220
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "PostMessage işlevine içsel çağrı yapılamadı. "
 
-#: ../src/msw/dde.cpp:1165
+#: ../src/msw/dde.cpp:1229
 msgid "an internal error has occurred in the DDEML."
 msgstr "DDEML içsel hatası."
 
-#: ../src/msw/dde.cpp:1171
+#: ../src/msw/dde.cpp:1235
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -8045,56 +8235,56 @@ msgstr ""
 "Uygulama XTYP_XACT_COMPLETE çağrısından döndüğünde\n"
 "bu çağrının hareket kimliği geçersiz olacak."
 
-#: ../src/common/zipstrm.cpp:1483
+#: ../src/common/zipstrm.cpp:1522
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "bunun çok parçalı birleştirilmiş bir zip olduğu varsayılıyor"
 
-#: ../src/common/fileconf.cpp:1847
+#: ../src/common/fileconf.cpp:1849
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "'%s' değişmez anahtarını değiştirme denemesi yok sayıldı."
 
-#: ../src/html/chm.cpp:329
+#: ../src/html/chm.cpp:326
 msgid "bad arguments to library function"
 msgstr "kitaplık işlevi için hatalı değişkenler"
 
-#: ../src/html/chm.cpp:341
+#: ../src/html/chm.cpp:338
 msgid "bad signature"
 msgstr "imza kötü"
 
-#: ../src/common/zipstrm.cpp:1918
+#: ../src/common/zipstrm.cpp:1988
 msgid "bad zipfile offset to entry"
 msgstr "kayıt için hatalı zip dosyası konumu"
 
-#: ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400
 msgid "binary"
 msgstr "ikili"
 
-#: ../src/common/fontcmn.cpp:996
+#: ../src/common/fontcmn.cpp:1195
 msgid "bold"
 msgstr "koyu"
 
-#: ../src/msw/utils.cpp:1144
+#: ../src/msw/utils.cpp:1135
 #, c-format
 msgid "build %lu"
 msgstr "yapım %lu"
 
-#: ../src/common/ffile.cpp:75
+#: ../src/common/ffile.cpp:73
 #, c-format
 msgid "can't close file '%s'"
 msgstr "'%s' dosyası kapatılamıyor"
 
-#: ../src/common/file.cpp:245
+#: ../src/common/file.cpp:242
 #, c-format
 msgid "can't close file descriptor %d"
 msgstr "%d dosya tanımlayıcısı kapatılamıyor"
 
-#: ../src/common/file.cpp:586
+#: ../src/common/ffile.cpp:382 ../src/common/file.cpp:613
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "'%s' dosyasındaki değişiklikler işlenemiyor"
 
-#: ../src/common/file.cpp:178
+#: ../src/common/file.cpp:175
 #, c-format
 msgid "can't create file '%s'"
 msgstr "'%s' dosyası oluşturulamıyor"
@@ -8104,51 +8294,51 @@ msgstr "'%s' dosyası oluşturulamıyor"
 msgid "can't delete user configuration file '%s'"
 msgstr "kullanıcı yapılandırma dosyası '%s' silinemiyor"
 
-#: ../src/common/file.cpp:495
+#: ../src/common/file.cpp:522
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr ""
 "%d tanımlayıcısı üstündeki dosyanın sonuna ulaşılıp ulaşılamadığı "
 "belirlenemiyor"
 
-#: ../src/common/zipstrm.cpp:1692
+#: ../src/common/zipstrm.cpp:1747
 msgid "can't find central directory in zip"
 msgstr "zip içinde merkez klasör bulunamıyor"
 
-#: ../src/common/file.cpp:465
+#: ../src/common/file.cpp:492
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "%d tanımlayıcısı üstündeki dosyanın uzunluğu bulunamıyor"
 
-#: ../src/msw/utils.cpp:341
+#: ../src/msw/utils.cpp:336
 msgid "can't find user's HOME, using current directory."
 msgstr "kullanıcının klasörü bulunamadığından geçerli klasör kullanılıyor."
 
-#: ../src/common/file.cpp:366
+#: ../src/common/file.cpp:407
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "%d dosya tanımlayıcısı temizlenemiyor"
 
-#: ../src/common/file.cpp:422
+#: ../src/common/file.cpp:463
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "%d dosya tanımlayıcısı üstündeki arama konumu alınamıyor"
 
-#: ../src/common/fontmap.cpp:325
+#: ../src/common/fontmap.cpp:322
 msgid "can't load any font, aborting"
 msgstr "herhangi bir yazı türü yüklenemedi, vazgeçiliyor"
 
-#: ../src/common/file.cpp:231 ../src/common/ffile.cpp:59
+#: ../src/common/ffile.cpp:57 ../src/common/file.cpp:228
 #, c-format
 msgid "can't open file '%s'"
 msgstr "'%s' dosyası açılamıyor"
 
-#: ../src/common/fileconf.cpp:320
+#: ../src/common/fileconf.cpp:314
 #, c-format
 msgid "can't open global configuration file '%s'."
 msgstr "'%s' genel ayar dosyası açılamıyor"
 
-#: ../src/common/fileconf.cpp:336
+#: ../src/common/fileconf.cpp:330
 #, c-format
 msgid "can't open user configuration file '%s'."
 msgstr "'%s' kullanıcı ayar dosyası açılamıyor"
@@ -8157,40 +8347,40 @@ msgstr "'%s' kullanıcı ayar dosyası açılamıyor"
 msgid "can't open user configuration file."
 msgstr "kullanıcı ayar dosyası açılamıyor."
 
-#: ../src/common/zipstrm.cpp:579
+#: ../src/common/zipstrm.cpp:572
 msgid "can't re-initialize zlib deflate stream"
 msgstr "zlib ayıklama akışı yeniden başlatılamadı"
 
-#: ../src/common/zipstrm.cpp:604
+#: ../src/common/zipstrm.cpp:597
 msgid "can't re-initialize zlib inflate stream"
 msgstr "zlib sıkıştırma akışı yeniden başlatılamadı"
 
-#: ../src/common/file.cpp:304
+#: ../src/common/file.cpp:345
 #, c-format
 msgid "can't read from file descriptor %d"
 msgstr "%d dosya tanımlayıcısından okunamıyor"
 
-#: ../src/common/file.cpp:581
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:608
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "'%s' dosyası silinemedi"
 
-#: ../src/common/file.cpp:598
+#: ../src/common/ffile.cpp:394 ../src/common/file.cpp:625
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "'%s' geçici dosyası silinemedi"
 
-#: ../src/common/file.cpp:408
+#: ../src/common/file.cpp:449
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "%d dosya tanımlayıcısı üzerinde arama yapılamıyor"
 
-#: ../src/common/textfile.cpp:273
+#: ../src/common/textfile.cpp:161
 #, c-format
 msgid "can't write buffer '%s' to disk."
 msgstr "'%s' ara belleği diske yazılamadı."
 
-#: ../src/common/file.cpp:323
+#: ../src/common/file.cpp:364
 #, c-format
 msgid "can't write to file descriptor %d"
 msgstr "%d dosya tanımlayıcısına yazılamıyor"
@@ -8200,22 +8390,28 @@ msgid "can't write user configuration file."
 msgstr "kullanıcı ayar dosyası yazılamadı."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:482 ../src/generic/datavgen.cpp:1261
+#: ../src/common/datavcmn.cpp:2064 ../src/generic/datavgen.cpp:1384
 msgid "checked"
 msgstr "doğrulandı"
 
-#: ../src/html/chm.cpp:345
+#: ../src/html/chm.cpp:342
 msgid "checksum error"
 msgstr "sağlama sorunu"
 
-#: ../src/common/tarstrm.cpp:820
+#: ../src/common/tarstrm.cpp:814
 msgid "checksum failure reading tar header block"
 msgstr "tar başlık bloğu okunurken sağlama sorunu"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:226
-#: ../src/richtext/richtextbackgroundpage.cpp:249
-#: ../src/richtext/richtextbackgroundpage.cpp:289
-#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
 #: ../src/richtext/richtextborderspage.cpp:254
 #: ../src/richtext/richtextborderspage.cpp:288
 #: ../src/richtext/richtextborderspage.cpp:322
@@ -8233,104 +8429,127 @@ msgstr "tar başlık bloğu okunurken sağlama sorunu"
 #: ../src/richtext/richtextmarginspage.cpp:340
 #: ../src/richtext/richtextmarginspage.cpp:363
 #: ../src/richtext/richtextmarginspage.cpp:388
-#: ../src/richtext/richtextsizepage.cpp:339
-#: ../src/richtext/richtextsizepage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:400
-#: ../src/richtext/richtextsizepage.cpp:427
-#: ../src/richtext/richtextsizepage.cpp:454
-#: ../src/richtext/richtextsizepage.cpp:481
-#: ../src/richtext/richtextsizepage.cpp:555
-#: ../src/richtext/richtextsizepage.cpp:590
-#: ../src/richtext/richtextsizepage.cpp:625
-#: ../src/richtext/richtextsizepage.cpp:660
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
 msgid "cm"
 msgstr "cm"
 
-#: ../src/html/chm.cpp:347
+#: ../src/html/chm.cpp:344
 msgid "compression error"
 msgstr "sıkıştırma sorunu"
 
-#: ../src/common/regex.cpp:236
+#: ../src/common/regex.cpp:233
 msgid "conversion to 8-bit encoding failed"
 msgstr "8-bit kodlama dönüşümü yapılamadı"
 
-#: ../src/common/accelcmn.cpp:187
+#: ../src/common/accelcmn.cpp:186
 msgid "ctrl"
 msgstr "ctrl"
 
-#: ../src/common/cmdline.cpp:1500
+#: ../src/common/cmdline.cpp:1496
 msgid "date"
 msgstr "tarih"
 
-#: ../src/html/chm.cpp:349
+#: ../src/html/chm.cpp:346
 msgid "decompression error"
 msgstr "ayıklama sorunu"
 
-#: ../src/richtext/richtextstyles.cpp:780 ../src/common/fmapbase.cpp:820
+#: ../src/common/fmapbase.cpp:816 ../src/richtext/richtextstyles.cpp:777
 msgid "default"
 msgstr "varsayılan"
 
-#: ../src/common/cmdline.cpp:1496
+#: ../src/common/cmdline.cpp:1492
 msgid "double"
 msgstr "çift"
 
-#: ../src/common/debugrpt.cpp:538
+#: ../src/common/debugrpt.cpp:539
 msgid "dump of the process state (binary)"
 msgstr "işlem durum dökümü (ikili)"
 
-#: ../src/common/datetimefmt.cpp:1969
+#: ../src/common/datetimefmt.cpp:1992
 msgid "eighteenth"
 msgstr "onsekizinci"
 
-#: ../src/common/datetimefmt.cpp:1959
+#: ../src/common/datetimefmt.cpp:1982
 msgid "eighth"
 msgstr "sekizinci"
 
-#: ../src/common/datetimefmt.cpp:1962
+#: ../src/common/datetimefmt.cpp:1985
 msgid "eleventh"
 msgstr "onbirinci"
 
-#: ../src/common/fileconf.cpp:1833
+#: ../src/common/fileconf.cpp:1835
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "'%s' kaydı '%s' grubunda birden çok kez var"
 
-#: ../src/html/chm.cpp:343
+#: ../src/html/chm.cpp:340
 msgid "error in data format"
 msgstr "veri biçimi sorunu"
 
-#: ../src/html/chm.cpp:331
+#: ../src/html/chm.cpp:328
 msgid "error opening file"
 msgstr "dosya açma sorunu"
 
-#: ../src/common/zipstrm.cpp:1778
+#: ../src/common/zipstrm.cpp:1836
 msgid "error reading zip central directory"
 msgstr "zip merkez klasörünü okuma sorunu"
 
-#: ../src/common/zipstrm.cpp:1870
+#: ../src/common/zipstrm.cpp:1940
 msgid "error reading zip local header"
 msgstr "zip yerel başlığını okuma sorunu"
 
-#: ../src/common/zipstrm.cpp:2531
+#: ../src/common/zipstrm.cpp:2615
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "'%s' zip kaydı yazma sorunu: hatalı CRC ya da uzunluk"
 
-#: ../src/common/ffile.cpp:188
+#: ../src/common/zipstrm.cpp:2608
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "'%s' zip kaydı yazma sorunu: hatalı CRC ya da uzunluk"
+
+#: ../src/common/fontcmn.cpp:1205
+#, fuzzy
+msgid "extrabold"
+msgstr "koyu"
+
+#: ../src/common/fontcmn.cpp:1223
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1167
+#, fuzzy
+msgid "extralight"
+msgstr "açık"
+
+#: ../src/msw/webview_ie.cpp:1036
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "'%s' çalıştırılamadı\n"
+
+#: ../src/common/ffile.cpp:187
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "'%s' dosyası temizlenemedi"
 
+#: ../src/msw/webview_ie.cpp:1045
+#, fuzzy
+msgid "failed to retrieve execution result"
+msgstr "RAS hata iletisi metni alınamadı"
+
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1030
+#: ../src/generic/datavgen.cpp:1150
 msgid "false"
 msgstr "yanlış"
 
-#: ../src/common/datetimefmt.cpp:1966
+#: ../src/common/datetimefmt.cpp:1989
 msgid "fifteenth"
 msgstr "onbeşinci"
 
-#: ../src/common/datetimefmt.cpp:1956
+#: ../src/common/datetimefmt.cpp:1979
 msgid "fifth"
 msgstr "beşinci"
 
@@ -8359,131 +8578,150 @@ msgstr "dosya '%s', satır %zu: '%s' değişmez anahtarı için değer yok sayı
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "dosya '%s': beklenmedik karakter %c, satır: %zu."
 
-#: ../src/richtext/richtextbuffer.cpp:8738
+#: ../src/richtext/richtextbuffer.cpp:8736
 msgid "files"
 msgstr "dosyalar"
 
-#: ../src/common/datetimefmt.cpp:1952
+#: ../src/common/datetimefmt.cpp:1975
 msgid "first"
 msgstr "birinci"
 
-#: ../src/html/helpwnd.cpp:1252
+#: ../src/html/helpwnd.cpp:1250
 msgid "font size"
 msgstr "yazı türü boyutu"
 
-#: ../src/common/datetimefmt.cpp:1965
+#: ../src/common/datetimefmt.cpp:1988
 msgid "fourteenth"
 msgstr "ondördüncü"
 
-#: ../src/common/datetimefmt.cpp:1955
+#: ../src/common/datetimefmt.cpp:1978
 msgid "fourth"
 msgstr "dördüncü"
 
-#: ../src/common/appbase.cpp:783
+#: ../src/common/appbase.cpp:784
 msgid "generate verbose log messages"
 msgstr "ayrıntılı günlük iletileri oluşturulsun"
 
-#: ../src/richtext/richtextbuffer.cpp:13138
-#: ../src/richtext/richtextbuffer.cpp:13248
+#: ../src/common/fontcmn.cpp:1215
+msgid "heavy"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:13133
+#: ../src/richtext/richtextbuffer.cpp:13243
 msgid "image"
 msgstr "görsel"
 
-#: ../src/common/tarstrm.cpp:796
+#: ../src/common/tarstrm.cpp:790
 msgid "incomplete header block in tar"
 msgstr "tar başlık bloğu eksik"
 
-#: ../src/common/xtixml.cpp:489
+#: ../src/common/xtixml.cpp:485
 msgid "incorrect event handler string, missing dot"
 msgstr "hatalı olay işleyici dizgesi, nokta eksik"
 
-#: ../src/common/tarstrm.cpp:1381
+#: ../src/common/tarstrm.cpp:1375
 msgid "incorrect size given for tar entry"
 msgstr "tar kaydının boyutu hatalı verilmiş"
 
-#: ../src/common/tarstrm.cpp:993
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:987
 msgid "invalid data in extended tar header"
 msgstr "ek tar başlığında hatalı veri"
 
-#: ../src/generic/logg.cpp:1030
+#: ../src/generic/logg.cpp:1027
 msgid "invalid message box return value"
 msgstr "geçersiz ileti penceresi sonuç değeri"
 
-#: ../src/common/zipstrm.cpp:1647
+#: ../src/common/zipstrm.cpp:1688
 msgid "invalid zip file"
 msgstr "geçersiz zip dosyası"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:1228
 msgid "italic"
 msgstr "yatık"
 
-#: ../src/common/fontcmn.cpp:991
+#: ../src/common/webrequest_curl.cpp:374
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "Sütun tanımı yüklenemedi."
+
+#: ../src/common/fontcmn.cpp:1172
 msgid "light"
 msgstr "açık"
 
-#: ../src/common/intl.cpp:303
-#, c-format
-msgid "locale '%s' cannot be set."
-msgstr "'%s' yerel ayarları seçilemiyor."
+#: ../src/common/fontcmn.cpp:1185
+msgid "medium"
+msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2125
+#: ../src/common/datetimefmt.cpp:2148
 msgid "midnight"
 msgstr "gece yarısı"
 
-#: ../src/common/datetimefmt.cpp:1970
+#: ../src/common/datetimefmt.cpp:1993
 msgid "nineteenth"
 msgstr "ondokuzuncu"
 
-#: ../src/common/datetimefmt.cpp:1960
+#: ../src/common/datetimefmt.cpp:1983
 msgid "ninth"
 msgstr "dokuzuncu"
 
-#: ../src/msw/dde.cpp:1116
+#: ../src/msw/dde.cpp:1180
 msgid "no DDE error."
 msgstr "DDE bulunamadı hatası."
 
-#: ../src/html/chm.cpp:327
+#: ../src/html/chm.cpp:324
 msgid "no error"
 msgstr "hata yok"
 
-#: ../src/dfb/fontmgr.cpp:174
+#: ../src/dfb/fontmgr.cpp:171
 #, c-format
 msgid "no fonts found in %s, using builtin font"
 msgstr "%s içinde yazı türü yok, içsel yazı türü kullanılıyor"
 
-#: ../src/html/helpdata.cpp:657
+#: ../src/html/helpdata.cpp:650
 msgid "noname"
 msgstr "adsız"
 
-#: ../src/common/datetimefmt.cpp:2124
+#: ../src/common/datetimefmt.cpp:2147
 msgid "noon"
 msgstr "öğlen"
 
-#: ../src/richtext/richtextstyles.cpp:779
+#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "normal"
 
-#: ../src/common/cmdline.cpp:1492
+#: ../src/common/cmdline.cpp:1488
 msgid "num"
 msgstr "tamsayı"
 
-#: ../src/common/xtixml.cpp:259
+#: ../src/common/accelcmn.cpp:194
+msgid "num "
+msgstr ""
+
+#: ../src/common/xtixml.cpp:255
 msgid "objects cannot have XML Text Nodes"
 msgstr "nesnelerin XML Metin Düğümleri olamaz"
 
-#: ../src/html/chm.cpp:339
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
 msgid "out of memory"
 msgstr "bellek yetersiz"
 
-#: ../src/common/debugrpt.cpp:514
+#: ../src/common/debugrpt.cpp:515
 msgid "process context description"
 msgstr "işlem bağlamı tanımı"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:227
-#: ../src/richtext/richtextbackgroundpage.cpp:250
-#: ../src/richtext/richtextbackgroundpage.cpp:290
-#: ../src/richtext/richtextbackgroundpage.cpp:317
-#: ../src/richtext/richtextfontpage.cpp:177
-#: ../src/richtext/richtextfontpage.cpp:180
 #: ../src/richtext/richtextborderspage.cpp:255
 #: ../src/richtext/richtextborderspage.cpp:289
 #: ../src/richtext/richtextborderspage.cpp:323
@@ -8493,22 +8731,45 @@ msgstr "işlem bağlamı tanımı"
 #: ../src/richtext/richtextborderspage.cpp:491
 #: ../src/richtext/richtextborderspage.cpp:525
 #: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextfontpage.cpp:180
 msgid "pt"
 msgstr "punto"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:225
-#: ../src/richtext/richtextbackgroundpage.cpp:228
-#: ../src/richtext/richtextbackgroundpage.cpp:229
-#: ../src/richtext/richtextbackgroundpage.cpp:248
-#: ../src/richtext/richtextbackgroundpage.cpp:251
-#: ../src/richtext/richtextbackgroundpage.cpp:252
-#: ../src/richtext/richtextbackgroundpage.cpp:288
-#: ../src/richtext/richtextbackgroundpage.cpp:291
-#: ../src/richtext/richtextbackgroundpage.cpp:292
-#: ../src/richtext/richtextbackgroundpage.cpp:315
-#: ../src/richtext/richtextbackgroundpage.cpp:318
-#: ../src/richtext/richtextbackgroundpage.cpp:319
-#: ../src/richtext/richtextfontpage.cpp:178
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:659
+#: ../src/richtext/richtextsizepage.cpp:662
+#: ../src/richtext/richtextsizepage.cpp:663
 #: ../src/richtext/richtextborderspage.cpp:253
 #: ../src/richtext/richtextborderspage.cpp:256
 #: ../src/richtext/richtextborderspage.cpp:257
@@ -8560,259 +8821,269 @@ msgstr "punto"
 #: ../src/richtext/richtextmarginspage.cpp:387
 #: ../src/richtext/richtextmarginspage.cpp:389
 #: ../src/richtext/richtextmarginspage.cpp:390
-#: ../src/richtext/richtextsizepage.cpp:338
-#: ../src/richtext/richtextsizepage.cpp:341
-#: ../src/richtext/richtextsizepage.cpp:342
-#: ../src/richtext/richtextsizepage.cpp:372
-#: ../src/richtext/richtextsizepage.cpp:375
-#: ../src/richtext/richtextsizepage.cpp:376
-#: ../src/richtext/richtextsizepage.cpp:399
-#: ../src/richtext/richtextsizepage.cpp:402
-#: ../src/richtext/richtextsizepage.cpp:403
-#: ../src/richtext/richtextsizepage.cpp:426
-#: ../src/richtext/richtextsizepage.cpp:429
-#: ../src/richtext/richtextsizepage.cpp:430
-#: ../src/richtext/richtextsizepage.cpp:453
-#: ../src/richtext/richtextsizepage.cpp:456
-#: ../src/richtext/richtextsizepage.cpp:457
-#: ../src/richtext/richtextsizepage.cpp:480
-#: ../src/richtext/richtextsizepage.cpp:483
-#: ../src/richtext/richtextsizepage.cpp:484
-#: ../src/richtext/richtextsizepage.cpp:554
-#: ../src/richtext/richtextsizepage.cpp:557
-#: ../src/richtext/richtextsizepage.cpp:558
-#: ../src/richtext/richtextsizepage.cpp:589
-#: ../src/richtext/richtextsizepage.cpp:592
-#: ../src/richtext/richtextsizepage.cpp:593
-#: ../src/richtext/richtextsizepage.cpp:624
-#: ../src/richtext/richtextsizepage.cpp:627
-#: ../src/richtext/richtextsizepage.cpp:628
-#: ../src/richtext/richtextsizepage.cpp:659
-#: ../src/richtext/richtextsizepage.cpp:662
-#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextfontpage.cpp:178
 msgid "px"
 msgstr "piksel"
 
-#: ../src/common/accelcmn.cpp:193
+#: ../src/common/accelcmn.cpp:192
 msgid "rawctrl"
 msgstr "hamctrl"
 
-#: ../src/html/chm.cpp:333
+#: ../src/html/chm.cpp:330
 msgid "read error"
 msgstr "okuma hatası"
 
-#: ../src/common/zipstrm.cpp:2085
+#: ../src/common/zipstrm.cpp:2155
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "zip akışı okuma (kayıt %s): CRC hatalı"
 
-#: ../src/common/zipstrm.cpp:2080
+#: ../src/common/zipstrm.cpp:2150
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "zip akışı okuma (kayıt %s): uzunluk hatalı"
 
-#: ../src/msw/dde.cpp:1159
+#: ../src/msw/dde.cpp:1223
 msgid "reentrancy problem."
 msgstr "yeniden giriş sorunu."
 
-#: ../src/common/datetimefmt.cpp:1953
+#: ../src/common/datetimefmt.cpp:1976
 msgid "second"
 msgstr "ikinci"
 
-#: ../src/html/chm.cpp:337
+#: ../src/html/chm.cpp:334
 msgid "seek error"
 msgstr "arama hatası"
 
-#: ../src/common/datetimefmt.cpp:1968
+#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#, fuzzy
+msgid "semibold"
+msgstr "koyu"
+
+#: ../src/common/datetimefmt.cpp:1991
 msgid "seventeenth"
 msgstr "onyedinci"
 
-#: ../src/common/datetimefmt.cpp:1958
+#: ../src/common/datetimefmt.cpp:1981
 msgid "seventh"
 msgstr "yedinci"
 
-#: ../src/common/accelcmn.cpp:191
+#: ../src/common/accelcmn.cpp:190
 msgid "shift"
 msgstr "shift"
 
-#: ../src/common/appbase.cpp:773
+#: ../src/common/appbase.cpp:774
 msgid "show this help message"
 msgstr "bu yardım iletisi görüntülensin"
 
-#: ../src/common/datetimefmt.cpp:1967
+#: ../src/common/datetimefmt.cpp:1990
 msgid "sixteenth"
 msgstr "onaltıncı"
 
-#: ../src/common/datetimefmt.cpp:1957
+#: ../src/common/datetimefmt.cpp:1980
 msgid "sixth"
 msgstr "altıncı"
 
-#: ../src/common/appcmn.cpp:234
+#: ../src/common/appcmn.cpp:255
 msgid "specify display mode to use (e.g. 640x480-16)"
 msgstr "kullanılacak görüntü kipini belirleyin (ör. 640x480-16)"
 
-#: ../src/common/appcmn.cpp:220
+#: ../src/common/appcmn.cpp:241
 msgid "specify the theme to use"
 msgstr "kullanılacak temayı belirleyin"
 
-#: ../src/richtext/richtextbuffer.cpp:9340
+#: ../src/richtext/richtextbuffer.cpp:9337
 msgid "standard/circle"
 msgstr "standart/daire"
 
-#: ../src/richtext/richtextbuffer.cpp:9341
+#: ../src/richtext/richtextbuffer.cpp:9338
 msgid "standard/circle-outline"
 msgstr "standart/daire-çerçeve"
 
-#: ../src/richtext/richtextbuffer.cpp:9343
+#: ../src/richtext/richtextbuffer.cpp:9340
 msgid "standard/diamond"
 msgstr "standart/elmas"
 
-#: ../src/richtext/richtextbuffer.cpp:9342
+#: ../src/richtext/richtextbuffer.cpp:9339
 msgid "standard/square"
 msgstr "standart/kare"
 
-#: ../src/richtext/richtextbuffer.cpp:9344
+#: ../src/richtext/richtextbuffer.cpp:9341
 msgid "standard/triangle"
 msgstr "standart/üçgen"
 
-#: ../src/common/zipstrm.cpp:1985
+#: ../src/common/zipstrm.cpp:2055
 msgid "stored file length not in Zip header"
 msgstr "kayıtlı dosya uzunluğu Zip başlığında yok"
 
-#: ../src/common/cmdline.cpp:1488
+#: ../src/common/cmdline.cpp:1484
 msgid "str"
 msgstr "str"
 
-#: ../src/common/fontcmn.cpp:982
+#: ../src/common/fontcmn.cpp:1145
 msgid "strikethrough"
 msgstr "üstü çizili"
 
-#: ../src/common/tarstrm.cpp:1003 ../src/common/tarstrm.cpp:1025
-#: ../src/common/tarstrm.cpp:1507 ../src/common/tarstrm.cpp:1529
+#: ../src/common/tarstrm.cpp:997 ../src/common/tarstrm.cpp:1019
+#: ../src/common/tarstrm.cpp:1501 ../src/common/tarstrm.cpp:1523
 msgid "tar entry not open"
 msgstr "tar kaydı açık değil"
 
-#: ../src/common/datetimefmt.cpp:1961
+#: ../src/common/datetimefmt.cpp:1984
 msgid "tenth"
 msgstr "onuncu"
 
-#: ../src/msw/dde.cpp:1123
+#: ../src/msw/dde.cpp:1187
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "harekete yanıt DDE_FBUSY bayrak bitinin kaldırılmasına yol açtı."
 
-#: ../src/common/datetimefmt.cpp:1954
+#: ../src/common/fontcmn.cpp:1154
+msgid "thin"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:1977
 msgid "third"
 msgstr "üçüncü"
 
-#: ../src/common/datetimefmt.cpp:1964
+#: ../src/common/datetimefmt.cpp:1987
 msgid "thirteenth"
 msgstr "onüçüncü"
 
-#: ../src/common/datetimefmt.cpp:1758
+#: ../src/common/datetimefmt.cpp:1781
 msgid "today"
 msgstr "bugün"
 
-#: ../src/common/datetimefmt.cpp:1760
+#: ../src/common/datetimefmt.cpp:1783
 msgid "tomorrow"
 msgstr "yarın"
 
-#: ../src/common/fileconf.cpp:1944
+#: ../src/common/fileconf.cpp:1946
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "'%s' sonundaki ters eğik çizgi yok sayıldı"
 
-#: ../src/gtk/aboutdlg.cpp:218
+#: ../src/gtk/aboutdlg.cpp:216
 msgid "translator-credits"
 msgstr "çevirmenler"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1028
+#: ../src/generic/datavgen.cpp:1148
 msgid "true"
 msgstr "doğru"
 
-#: ../src/common/datetimefmt.cpp:1963
+#: ../src/common/datetimefmt.cpp:1986
 msgid "twelfth"
 msgstr "yirminci"
 
-#: ../src/common/datetimefmt.cpp:1971
+#: ../src/common/datetimefmt.cpp:1994
 msgid "twentieth"
 msgstr "onikinci"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:486 ../src/generic/datavgen.cpp:1263
+#: ../src/common/datavcmn.cpp:2068 ../src/generic/datavgen.cpp:1386
 msgid "unchecked"
 msgstr "işaretlenmemiş"
 
-#: ../src/common/fontcmn.cpp:802 ../src/common/fontcmn.cpp:978
+#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
 msgid "underlined"
 msgstr "altı çizili"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:490
+#: ../src/common/datavcmn.cpp:2072
 msgid "undetermined"
 msgstr "belirlenmemiş"
 
-#: ../src/common/fileconf.cpp:1979
+#: ../src/common/fileconf.cpp:1981
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "%d konumunda, '%s' içinde beklenmeyen \"."
 
-#: ../src/common/tarstrm.cpp:1045
+#: ../src/common/tarstrm.cpp:1039
 msgid "unexpected end of file"
 msgstr "beklenmeyen dosya sonu"
 
-#: ../src/generic/progdlgg.cpp:370 ../src/common/tarstrm.cpp:371
-#: ../src/common/tarstrm.cpp:394 ../src/common/tarstrm.cpp:425
+#: ../src/common/tarstrm.cpp:366 ../src/common/tarstrm.cpp:389
+#: ../src/common/tarstrm.cpp:420 ../src/generic/progdlgg.cpp:376
 msgid "unknown"
 msgstr "bilinmiyor"
 
-#: ../src/msw/registry.cpp:150
+#: ../src/msw/registry.cpp:139
 #, c-format
 msgid "unknown (%lu)"
 msgstr "bilinmiyor (%lu)"
 
-#: ../src/common/xtixml.cpp:253
+#: ../src/common/xtixml.cpp:249
 #, c-format
 msgid "unknown class %s"
 msgstr "bilinmeyen sınıf %s"
 
-#: ../src/common/regex.cpp:258 ../src/html/chm.cpp:351
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "sıkıştırma sorunu"
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "ayıklama sorunu"
+
+#: ../src/common/regex.cpp:255 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "bilinmeyen hata"
 
-#: ../src/msw/dialup.cpp:471
+#: ../src/msw/dialup.cpp:465
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "bilinmeyen hata (hata kodu %08x)."
 
-#: ../src/common/fmapbase.cpp:834
+#: ../src/common/fmapbase.cpp:830
 #, c-format
 msgid "unknown-%d"
 msgstr "bilinmeyen-%d"
 
-#: ../src/common/docview.cpp:509
+#: ../src/common/docview.cpp:502
 msgid "unnamed"
 msgstr "adsız"
 
-#: ../src/common/docview.cpp:1624
+#: ../src/common/docview.cpp:1618
 #, c-format
 msgid "unnamed%d"
 msgstr "adsız%d"
 
-#: ../src/common/zipstrm.cpp:1999 ../src/common/zipstrm.cpp:2319
+#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
 msgid "unsupported Zip compression method"
 msgstr "desteklenmeyen Zip sıkıştırma yöntemi"
 
-#: ../src/common/translation.cpp:1892
+#: ../src/common/translation.cpp:1942
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "'%s' kataloğu '%s' üzerinden kullanılıyor."
 
-#: ../src/html/chm.cpp:335
+#: ../src/html/chm.cpp:332
 msgid "write error"
 msgstr "yazma sorunu"
 
-#: ../src/common/time.cpp:292
+#: ../src/gtk/glcanvas.cpp:187
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/common/time.cpp:285
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay başarısız."
 
@@ -8825,15 +9096,15 @@ msgstr "wxWidgets '%s' için görünümü açamadı: çıkılıyor."
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets görünümü açamadı. Çıkılıyor."
 
-#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:431
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/common/datetimefmt.cpp:1759
+#: ../src/common/datetimefmt.cpp:1782
 msgid "yesterday"
 msgstr "dün"
 
-#: ../src/common/zstream.cpp:251 ../src/common/zstream.cpp:426
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
 #, c-format
 msgid "zlib error %d"
 msgstr "zlib hatası %d"
@@ -8842,6 +9113,79 @@ msgstr "zlib hatası %d"
 #: ../src/richtext/richtextbulletspage.cpp:288
 msgid "~"
 msgstr "~"
+
+#~ msgid " (while overwriting an existing item)"
+#~ msgstr " (varolan bir ögenin üzerine yazılırken)"
+
+#~ msgid "&Save as"
+#~ msgstr "&Farklı kaydet"
+
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' yalnız geçerli karakterleri içermiyor"
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' sayısal olmalı."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' yalnız ASCII karakterler içermeli."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' yalnız alfabetik karakterler içermeli."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' yalnız alfabetik ya da sayısal karakterler içermeli."
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' yalnız rakamlar içermeli."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "%s sınıfının penceresi oluşturulamadı"
+
+#~ msgid "Could not initalize libnotify."
+#~ msgstr "Libnotify başlatılamadı."
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "Örtüşme penceresi oluşturulamadı."
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "Örtüşme penceresinde bağlam başlatılamadı."
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "\"%s\" dosyası Unikoda çevrilemedi."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "Metin denetime yerleştirilemedi."
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr ""
+#~ "Geçersiz GTK+ komut satırı seçeneği, \"%s --help\" yazarak yardım alın"
+
+#~ msgid "No unused colour in image."
+#~ msgstr "Görselde kullanılmamış renk yok."
+
+#~ msgid "Not available"
+#~ msgstr "Kullanılamıyor"
+
+#~ msgid "Replace selection"
+#~ msgstr "Seçimi değiştir"
+
+#~ msgid "Save as"
+#~ msgstr "Farklı kaydet"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Biçem Düzenleyici"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "Aşağıdaki standart GTK+ seçenekleri de desteklenmektedir:\n"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "Hazırlanmamış bir örtüşmeyi temizleyemezsiniz"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "Bir örtüşmeyi iki kez hazırlayamazsınız"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "'%s' yerel ayarları seçilemiyor."
 
 #~ msgid "Adding flavor TEXT failed"
 #~ msgstr "TEXT niteliği eklenemedi"
@@ -8860,9 +9204,6 @@ msgstr "~"
 
 #~ msgid "Column could not be added."
 #~ msgstr "Sütun eklenemedi."
-
-#~ msgid "Column description could not be initialized."
-#~ msgstr "Sütun tanımı yüklenemedi."
 
 #~ msgid "Column index not found."
 #~ msgstr "Sütun dizini bulunamadı."

--- a/locale/uk.po
+++ b/locale/uk.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-21 14:25+0200\n"
+"POT-Creation-Date: 2020-10-18 23:11+0300\n"
 "PO-Revision-Date: 2014-02-21 19:09+0200\n"
 "Last-Translator: Yuri Chornoivan <yurchor@ukr.net>\n"
 "Language-Team: Ukrainian <kde-i18n-uk@kde.org>\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Plural-Forms:  nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: ../src/common/debugrpt.cpp:586
+#: ../src/common/debugrpt.cpp:587
 msgid ""
 "\n"
 "Please send this report to the program maintainer, thank you!\n"
@@ -26,8 +26,8 @@ msgstr ""
 "\n"
 "Будь ласка, надішліть цей звіт розробникові програми, дякуємо!\n"
 
-#: ../src/richtext/richtextstyledlg.cpp:210
-#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:206
+#: ../src/richtext/richtextstyledlg.cpp:218
 msgid " "
 msgstr " "
 
@@ -35,70 +35,96 @@ msgstr " "
 msgid "              Thank you and we're sorry for the inconvenience!\n"
 msgstr "              Дякуємо вам і вибачте за незручності!\n"
 
-#: ../src/common/prntbase.cpp:573
+#: ../src/common/prntbase.cpp:568
 #, c-format
 msgid " (copy %d of %d)"
 msgstr " (копія %d з %d)"
 
-#: ../src/common/log.cpp:421
+#: ../src/common/log.cpp:440
 #, c-format
 msgid " (error %ld: %s)"
 msgstr " (помилка %ld: %s)"
 
-#: ../src/common/imagtiff.cpp:72
+#: ../src/common/imagtiff.cpp:69
 #, c-format
 msgid " (in module \"%s\")"
 msgstr " (у модулі «%s»)"
 
-#: ../src/osx/core/secretstore.cpp:138
-msgid " (while overwriting an existing item)"
-msgstr ""
-
-#: ../src/common/docview.cpp:1642
+#: ../src/common/docview.cpp:1636
 msgid " - "
 msgstr " — "
 
-#: ../src/richtext/richtextprint.cpp:593 ../src/html/htmprint.cpp:714
+#: ../src/html/htmprint.cpp:712 ../src/richtext/richtextprint.cpp:589
 msgid " Preview"
 msgstr " Перегляд"
 
-#: ../src/common/fontcmn.cpp:824
+#: ../src/common/fontcmn.cpp:973
 msgid " bold"
 msgstr " жирний"
 
-#: ../src/common/fontcmn.cpp:840
+#: ../src/common/fontcmn.cpp:977
+#, fuzzy
+msgid " extra bold"
+msgstr " жирний"
+
+#: ../src/common/fontcmn.cpp:985
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:957
+#, fuzzy
+msgid " extra light"
+msgstr " легкий"
+
+#: ../src/common/fontcmn.cpp:981
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1001
 msgid " italic"
 msgstr " курсив"
 
-#: ../src/common/fontcmn.cpp:820
+#: ../src/common/fontcmn.cpp:961
 msgid " light"
 msgstr " легкий"
 
-#: ../src/common/fontcmn.cpp:807
+#: ../src/common/fontcmn.cpp:965
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:969
+#, fuzzy
+msgid " semi bold"
+msgstr " жирний"
+
+#: ../src/common/fontcmn.cpp:940
 msgid " strikethrough"
 msgstr " перекреслення"
 
-#: ../src/common/paper.cpp:117
+#: ../src/common/fontcmn.cpp:953
+msgid " thin"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
 msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
 msgstr "#10 Конверт, 4 1/8 x 9 1/2 дюйм"
 
-#: ../src/common/paper.cpp:118
+#: ../src/common/paper.cpp:115
 msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
 msgstr "#11 Конверт, 4 1/2 x 10 3/8 дюйм"
 
-#: ../src/common/paper.cpp:119
+#: ../src/common/paper.cpp:116
 msgid "#12 Envelope, 4 3/4 x 11 in"
 msgstr "#12 Конверт, 4 3/4 x 11 дюйм"
 
-#: ../src/common/paper.cpp:120
+#: ../src/common/paper.cpp:117
 msgid "#14 Envelope, 5 x 11 1/2 in"
 msgstr "#14 Конверт, 5 x 11 1/2 дюйм"
 
-#: ../src/common/paper.cpp:116
+#: ../src/common/paper.cpp:113
 msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
 msgstr "#9 Конверт, 3 7/8 x 8 7/8 дюйм"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:341
 #: ../src/richtext/richtextsizepage.cpp:340
 #: ../src/richtext/richtextsizepage.cpp:374
 #: ../src/richtext/richtextsizepage.cpp:401
@@ -109,20 +135,21 @@ msgstr "#9 Конверт, 3 7/8 x 8 7/8 дюйм"
 #: ../src/richtext/richtextsizepage.cpp:591
 #: ../src/richtext/richtextsizepage.cpp:626
 #: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextbackgroundpage.cpp:341
 msgid "%"
 msgstr "%"
 
-#: ../src/html/helpwnd.cpp:1031
+#: ../src/html/helpwnd.cpp:1029
 #, c-format
 msgid "%d of %lu"
 msgstr "%d з %lu"
 
-#: ../src/html/helpwnd.cpp:1678
+#: ../src/html/helpwnd.cpp:1676
 #, fuzzy, c-format
 msgid "%i of %u"
 msgstr "%i з %i"
 
-#: ../src/generic/filectrlg.cpp:279
+#: ../src/generic/filectrlg.cpp:275
 #, c-format
 msgid "%ld byte"
 msgid_plural "%ld bytes"
@@ -130,61 +157,61 @@ msgstr[0] "%ld байт"
 msgstr[1] "%ld байт"
 msgstr[2] "%ld байт"
 
-#: ../src/html/helpwnd.cpp:1033
+#: ../src/html/helpwnd.cpp:1031
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu з %lu"
 
-#: ../src/generic/datavgen.cpp:6028
+#: ../src/generic/datavgen.cpp:6833
 #, fuzzy, c-format
 msgid "%s (%d items)"
 msgstr "%s (або %s)"
 
-#: ../src/common/cmdline.cpp:1221
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (або %s)"
 
-#: ../src/generic/logg.cpp:224
+#: ../src/generic/logg.cpp:221
 #, c-format
 msgid "%s Error"
 msgstr "Помилка %s"
 
-#: ../src/generic/logg.cpp:236
+#: ../src/generic/logg.cpp:233
 #, c-format
 msgid "%s Information"
 msgstr "Інформація %s"
 
-#: ../src/generic/preferencesg.cpp:113
+#: ../src/generic/preferencesg.cpp:110
 #, c-format
 msgid "%s Preferences"
 msgstr "Налаштування %s"
 
-#: ../src/generic/logg.cpp:228
+#: ../src/generic/logg.cpp:225
 #, c-format
 msgid "%s Warning"
 msgstr "Попередження %s"
 
-#: ../src/common/tarstrm.cpp:1319
+#: ../src/common/tarstrm.cpp:1313
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s не відповідало заголовку архіву tar для елемента «%s»"
 
-#: ../src/common/fldlgcmn.cpp:124
+#: ../src/common/fldlgcmn.cpp:121
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s файлів (%s)|%s"
 
-#: ../src/html/helpwnd.cpp:1716
+#: ../src/html/helpwnd.cpp:1714
 #, fuzzy, c-format
 msgid "%u of %u"
 msgstr "%lu з %lu"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "&About"
 msgstr "&Про програму"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "&Actual Size"
 msgstr "&Справжній розмір"
 
@@ -192,28 +219,28 @@ msgstr "&Справжній розмір"
 msgid "&After a paragraph:"
 msgstr "&Після абзацу:"
 
-#: ../src/richtext/richtextindentspage.cpp:128
 #: ../src/richtext/richtextliststylepage.cpp:319
+#: ../src/richtext/richtextindentspage.cpp:128
 msgid "&Alignment"
 msgstr "&Вирівнювання"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "&Apply"
 msgstr "&Застосувати"
 
-#: ../src/richtext/richtextstyledlg.cpp:251
+#: ../src/richtext/richtextstyledlg.cpp:247
 msgid "&Apply Style"
 msgstr "&Застосувати стиль"
 
-#: ../src/msw/mdi.cpp:179
+#: ../src/msw/mdi.cpp:174
 msgid "&Arrange Icons"
 msgstr "&Розташувати піктограми"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "&Ascending"
 msgstr "За з&ростанням"
 
-#: ../src/common/stockitem.cpp:142
+#: ../src/common/stockitem.cpp:139
 msgid "&Back"
 msgstr "&Назад"
 
@@ -233,24 +260,24 @@ msgstr "Ко&лір тла:"
 msgid "&Blur distance:"
 msgstr "Відстань &розмиття"
 
-#: ../src/common/stockitem.cpp:143
+#: ../src/common/stockitem.cpp:140
 msgid "&Bold"
 msgstr "&Жирний"
 
-#: ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141
 msgid "&Bottom"
 msgstr "В&низу"
 
+#: ../src/richtext/richtextsizepage.cpp:637
+#: ../src/richtext/richtextsizepage.cpp:644
 #: ../src/richtext/richtextborderspage.cpp:345
 #: ../src/richtext/richtextborderspage.cpp:513
 #: ../src/richtext/richtextmarginspage.cpp:259
 #: ../src/richtext/richtextmarginspage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:637
-#: ../src/richtext/richtextsizepage.cpp:644
 msgid "&Bottom:"
 msgstr "&Нижнє:"
 
-#: ../include/wx/richtext/richtextbuffer.h:3866
+#: ../include/wx/richtext/richtextbuffer.h:3861
 msgid "&Box"
 msgstr "&Рамка"
 
@@ -259,38 +286,38 @@ msgstr "&Рамка"
 msgid "&Bullet style:"
 msgstr "Стиль &позначки:"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "&CD-Rom"
 msgstr "&CD-ROM"
 
-#: ../src/generic/wizard.cpp:434 ../src/generic/fontdlgg.cpp:470
-#: ../src/generic/fontdlgg.cpp:489 ../src/osx/carbon/fontdlg.cpp:402
-#: ../src/common/dlgcmn.cpp:279 ../src/common/stockitem.cpp:145
+#: ../src/osx/carbon/fontdlg.cpp:399 ../src/common/stockitem.cpp:142
+#: ../src/generic/wizard.cpp:433 ../src/generic/fontdlgg.cpp:466
+#: ../src/generic/fontdlgg.cpp:485 ../src/osx/cocoa/button.mm:200
 msgid "&Cancel"
 msgstr "&Скасувати"
 
-#: ../src/msw/mdi.cpp:175
+#: ../src/msw/mdi.cpp:170
 msgid "&Cascade"
 msgstr "&Каскад"
 
-#: ../include/wx/richtext/richtextbuffer.h:5960
+#: ../include/wx/richtext/richtextbuffer.h:5955
 msgid "&Cell"
 msgstr "К&омірка"
 
-#: ../src/richtext/richtextsymboldlg.cpp:439
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "&Character code:"
 msgstr "Код &символу:"
 
-#: ../src/common/stockitem.cpp:147
+#: ../src/common/stockitem.cpp:144
 msgid "&Clear"
 msgstr "О&чистити"
 
-#: ../src/generic/logg.cpp:516 ../src/common/stockitem.cpp:148
-#: ../src/common/prntbase.cpp:1600 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/stockitem.cpp:145 ../src/common/prntbase.cpp:1625
+#: ../src/univ/themes/win32.cpp:3753 ../src/generic/logg.cpp:513
 msgid "&Close"
 msgstr "&Закрити"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "&Color"
 msgstr "&Колір"
 
@@ -298,20 +325,20 @@ msgstr "&Колір"
 msgid "&Colour:"
 msgstr "&Колір:"
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "&Convert"
 msgstr "Пе&ретворити"
 
-#: ../src/richtext/richtextctrl.cpp:333 ../src/osx/textctrl_osx.cpp:577
-#: ../src/common/stockitem.cpp:150 ../src/msw/textctrl.cpp:2508
+#: ../src/osx/textctrl_osx.cpp:595 ../src/common/stockitem.cpp:147
+#: ../src/msw/textctrl.cpp:2773 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Копія"
 
-#: ../src/generic/hyperlinkg.cpp:156
+#: ../src/generic/hyperlinkg.cpp:153
 msgid "&Copy URL"
 msgstr "&Копіювати адресу"
 
-#: ../src/common/headerctrlcmn.cpp:306
+#: ../src/common/headerctrlcmn.cpp:304
 msgid "&Customize..."
 msgstr "&Налаштувати…"
 
@@ -319,53 +346,54 @@ msgstr "&Налаштувати…"
 msgid "&Debug report preview:"
 msgstr "Попередній перегляд звіту про &помилку:"
 
-#: ../src/richtext/richtexttabspage.cpp:138
-#: ../src/richtext/richtextctrl.cpp:335 ../src/osx/textctrl_osx.cpp:579
-#: ../src/common/stockitem.cpp:152 ../src/msw/textctrl.cpp:2510
+#: ../src/osx/textctrl_osx.cpp:597 ../src/common/stockitem.cpp:149
+#: ../src/msw/textctrl.cpp:2775 ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtextctrl.cpp:334
 msgid "&Delete"
 msgstr "&Вилучити"
 
-#: ../src/richtext/richtextstyledlg.cpp:269
+#: ../src/richtext/richtextstyledlg.cpp:265
 msgid "&Delete Style..."
 msgstr "&Вилучити стиль…"
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "&Descending"
 msgstr "&За спаданням"
 
-#: ../src/generic/logg.cpp:682
+#: ../src/generic/logg.cpp:679
 msgid "&Details"
 msgstr "&Деталі"
 
-#: ../src/common/stockitem.cpp:153
+#: ../src/common/stockitem.cpp:150
 msgid "&Down"
 msgstr "До&низу"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "&Edit"
 msgstr "&Редагування"
 
-#: ../src/richtext/richtextstyledlg.cpp:263
+#: ../src/richtext/richtextstyledlg.cpp:259
 msgid "&Edit Style..."
 msgstr "&Редагувати стиль…"
 
-#: ../src/common/stockitem.cpp:155
+#: ../src/common/stockitem.cpp:152
 msgid "&Execute"
 msgstr "&Виконати"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/common/stockitem.cpp:154
 msgid "&File"
 msgstr "&Файл"
 
-#: ../src/common/stockitem.cpp:158
-msgid "&Find"
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "&Find..."
 msgstr "&Знайти"
 
-#: ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:430
 msgid "&Finish"
 msgstr "&Закінчити"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:156
 msgid "&First"
 msgstr "&Перша"
 
@@ -373,15 +401,15 @@ msgstr "&Перша"
 msgid "&Floating mode:"
 msgstr "&Рухомий режим:"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "&Floppy"
 msgstr "&Дискета"
 
-#: ../src/common/stockitem.cpp:194
+#: ../src/common/stockitem.cpp:191
 msgid "&Font"
 msgstr "&Шрифт"
 
-#: ../src/generic/fontdlgg.cpp:371
+#: ../src/generic/fontdlgg.cpp:367
 msgid "&Font family:"
 msgstr "&Гарнітура шрифту:"
 
@@ -389,20 +417,20 @@ msgstr "&Гарнітура шрифту:"
 msgid "&Font for Level..."
 msgstr "&Шрифт для рівня…"
 
+#: ../src/richtext/richtextsymboldlg.cpp:397
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:400
 msgid "&Font:"
 msgstr "&Шрифт:"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "&Forward"
 msgstr "&Вперед"
 
-#: ../src/richtext/richtextsymboldlg.cpp:451
+#: ../src/richtext/richtextsymboldlg.cpp:448
 msgid "&From:"
 msgstr "&Від:"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "&Harddisk"
 msgstr "&Жорсткий диск"
 
@@ -411,9 +439,9 @@ msgstr "&Жорсткий диск"
 msgid "&Height:"
 msgstr "&Висота:"
 
-#: ../src/generic/wizard.cpp:441 ../src/richtext/richtextstyledlg.cpp:303
-#: ../src/richtext/richtextsymboldlg.cpp:479 ../src/osx/menu_osx.cpp:734
-#: ../src/common/stockitem.cpp:163
+#: ../src/common/stockitem.cpp:160 ../src/generic/wizard.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextstyledlg.cpp:299 ../src/osx/cocoa/menu.mm:226
 msgid "&Help"
 msgstr "&Довідка"
 
@@ -421,7 +449,7 @@ msgstr "&Довідка"
 msgid "&Hide details"
 msgstr "С&ховати подробиці"
 
-#: ../src/common/stockitem.cpp:164
+#: ../src/common/stockitem.cpp:161
 msgid "&Home"
 msgstr "&Домівка"
 
@@ -430,54 +458,54 @@ msgstr "&Домівка"
 msgid "&Horizontal offset:"
 msgstr "&Вертикальний відступ:"
 
-#: ../src/richtext/richtextindentspage.cpp:184
 #: ../src/richtext/richtextliststylepage.cpp:372
+#: ../src/richtext/richtextindentspage.cpp:184
 msgid "&Indentation (tenths of a mm)"
 msgstr "&Відступ (у десятках мм)"
 
-#: ../src/richtext/richtextindentspage.cpp:167
 #: ../src/richtext/richtextliststylepage.cpp:356
+#: ../src/richtext/richtextindentspage.cpp:167
 msgid "&Indeterminate"
 msgstr "&Зняти визначене"
 
-#: ../src/common/stockitem.cpp:166
+#: ../src/common/stockitem.cpp:163
 msgid "&Index"
 msgstr "&Індекс"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "&Info"
 msgstr "&Інформація"
 
-#: ../src/common/stockitem.cpp:168
+#: ../src/common/stockitem.cpp:165
 msgid "&Italic"
 msgstr "&Курсив"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "&Jump to"
 msgstr "Пере&йти до"
 
-#: ../src/richtext/richtextindentspage.cpp:153
 #: ../src/richtext/richtextliststylepage.cpp:342
+#: ../src/richtext/richtextindentspage.cpp:153
 msgid "&Justified"
 msgstr "&Вирівняне"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "&Last"
 msgstr "&Останній"
 
-#: ../src/richtext/richtextindentspage.cpp:139
 #: ../src/richtext/richtextliststylepage.cpp:328
+#: ../src/richtext/richtextindentspage.cpp:139
 msgid "&Left"
 msgstr "&Ліворуч"
 
-#: ../src/richtext/richtextindentspage.cpp:195
+#: ../src/richtext/richtextsizepage.cpp:532
+#: ../src/richtext/richtextsizepage.cpp:539
 #: ../src/richtext/richtextborderspage.cpp:243
 #: ../src/richtext/richtextborderspage.cpp:411
 #: ../src/richtext/richtextliststylepage.cpp:381
+#: ../src/richtext/richtextindentspage.cpp:195
 #: ../src/richtext/richtextmarginspage.cpp:186
 #: ../src/richtext/richtextmarginspage.cpp:300
-#: ../src/richtext/richtextsizepage.cpp:532
-#: ../src/richtext/richtextsizepage.cpp:539
 msgid "&Left:"
 msgstr "&Ліворуч:"
 
@@ -485,11 +513,11 @@ msgstr "&Ліворуч:"
 msgid "&List level:"
 msgstr "&Рівень у списку:"
 
-#: ../src/generic/logg.cpp:517
+#: ../src/generic/logg.cpp:514
 msgid "&Log"
 msgstr "&Журнал"
 
-#: ../src/univ/themes/win32.cpp:3748
+#: ../src/univ/themes/win32.cpp:3745
 msgid "&Move"
 msgstr "&Перенести"
 
@@ -497,20 +525,19 @@ msgstr "&Перенести"
 msgid "&Move the object to:"
 msgstr "Місце п&ересування об’єкта:"
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "&Network"
 msgstr "&Мережа"
 
-#: ../src/richtext/richtexttabspage.cpp:132 ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173 ../src/richtext/richtexttabspage.cpp:132
 msgid "&New"
 msgstr "&Створити"
 
-#: ../src/aui/tabmdi.cpp:111 ../src/generic/mdig.cpp:100
-#: ../src/msw/mdi.cpp:180
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
 msgid "&Next"
 msgstr "&Наступний"
 
-#: ../src/generic/wizard.cpp:432 ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:429
 msgid "&Next >"
 msgstr "&Наступний >"
 
@@ -518,7 +545,7 @@ msgstr "&Наступний >"
 msgid "&Next Paragraph"
 msgstr "&Наступний абзац"
 
-#: ../src/generic/tipdlg.cpp:240
+#: ../src/generic/tipdlg.cpp:237
 msgid "&Next Tip"
 msgstr "&Наступна підказка"
 
@@ -526,11 +553,11 @@ msgstr "&Наступна підказка"
 msgid "&Next style:"
 msgstr "&Наступний стиль:"
 
-#: ../src/common/stockitem.cpp:177 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:174 ../src/msw/msgdlg.cpp:435
 msgid "&No"
 msgstr "&Ні"
 
-#: ../src/generic/dbgrptg.cpp:356
+#: ../src/generic/dbgrptg.cpp:360
 msgid "&Notes:"
 msgstr "&Помітки:"
 
@@ -538,12 +565,12 @@ msgstr "&Помітки:"
 msgid "&Number:"
 msgstr "&Номер:"
 
-#: ../src/generic/fontdlgg.cpp:475 ../src/generic/fontdlgg.cpp:482
-#: ../src/osx/carbon/fontdlg.cpp:408 ../src/common/stockitem.cpp:178
+#: ../src/osx/carbon/fontdlg.cpp:405 ../src/common/stockitem.cpp:175
+#: ../src/generic/fontdlgg.cpp:471 ../src/generic/fontdlgg.cpp:478
 msgid "&OK"
 msgstr "&Гаразд"
 
-#: ../src/generic/dbgrptg.cpp:342 ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176 ../src/generic/dbgrptg.cpp:342
 msgid "&Open..."
 msgstr "&Відкрити…"
 
@@ -555,16 +582,16 @@ msgstr "&Рівень відступу:"
 msgid "&Page Break"
 msgstr "&Розрив сторінки"
 
-#: ../src/richtext/richtextctrl.cpp:334 ../src/osx/textctrl_osx.cpp:578
-#: ../src/common/stockitem.cpp:180 ../src/msw/textctrl.cpp:2509
+#: ../src/osx/textctrl_osx.cpp:596 ../src/common/stockitem.cpp:177
+#: ../src/msw/textctrl.cpp:2774 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&Вставити"
 
-#: ../include/wx/richtext/richtextbuffer.h:5010
+#: ../include/wx/richtext/richtextbuffer.h:5005
 msgid "&Picture"
 msgstr "&Зображення"
 
-#: ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:419
 msgid "&Point size:"
 msgstr "Розмір &точки:"
 
@@ -576,12 +603,11 @@ msgstr "&Розміщення (у десятках мм):"
 msgid "&Position mode:"
 msgstr "Режим &позиції:"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178
 msgid "&Preferences"
 msgstr "&Налаштування"
 
-#: ../src/aui/tabmdi.cpp:112 ../src/generic/mdig.cpp:101
-#: ../src/msw/mdi.cpp:181
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
 msgid "&Previous"
 msgstr "Попереднє"
 
@@ -589,78 +615,74 @@ msgstr "Попереднє"
 msgid "&Previous Paragraph"
 msgstr "&Попередній абзац"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "&Print..."
 msgstr "&Друкувати…"
 
-#: ../src/richtext/richtextctrl.cpp:339 ../src/richtext/richtextctrl.cpp:5514
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtextctrl.cpp:338
+#: ../src/richtext/richtextctrl.cpp:5512
 msgid "&Properties"
 msgstr "&Властивості"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "&Quit"
 msgstr "&Вихід"
 
-#: ../src/richtext/richtextctrl.cpp:330 ../src/osx/textctrl_osx.cpp:574
-#: ../src/common/stockitem.cpp:185 ../src/common/cmdproc.cpp:293
-#: ../src/common/cmdproc.cpp:300 ../src/msw/textctrl.cpp:2505
+#: ../src/osx/textctrl_osx.cpp:592 ../src/common/stockitem.cpp:182
+#: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
+#: ../src/msw/textctrl.cpp:2770 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Переробити"
 
-#: ../src/common/cmdproc.cpp:289 ../src/common/cmdproc.cpp:309
+#: ../src/common/cmdproc.cpp:282 ../src/common/cmdproc.cpp:302
 msgid "&Redo "
 msgstr "&Переробити "
 
-#: ../src/richtext/richtextstyledlg.cpp:257
+#: ../src/richtext/richtextstyledlg.cpp:253
 msgid "&Rename Style..."
 msgstr "&Перейменувати стиль…"
 
-#: ../src/generic/fdrepdlg.cpp:179
+#: ../src/generic/fdrepdlg.cpp:176
 msgid "&Replace"
 msgstr "&Замінити"
 
-#: ../src/richtext/richtextstyledlg.cpp:287
+#: ../src/richtext/richtextstyledlg.cpp:283
 msgid "&Restart numbering"
 msgstr "&Почати відлік з початку"
 
-#: ../src/univ/themes/win32.cpp:3747
+#: ../src/univ/themes/win32.cpp:3744
 msgid "&Restore"
 msgstr "&Відновити"
 
-#: ../src/richtext/richtextindentspage.cpp:146
 #: ../src/richtext/richtextliststylepage.cpp:335
+#: ../src/richtext/richtextindentspage.cpp:146
 msgid "&Right"
 msgstr "&Праворуч"
 
-#: ../src/richtext/richtextindentspage.cpp:213
+#: ../src/richtext/richtextsizepage.cpp:602
+#: ../src/richtext/richtextsizepage.cpp:609
 #: ../src/richtext/richtextborderspage.cpp:277
 #: ../src/richtext/richtextborderspage.cpp:445
 #: ../src/richtext/richtextliststylepage.cpp:399
+#: ../src/richtext/richtextindentspage.cpp:213
 #: ../src/richtext/richtextmarginspage.cpp:211
 #: ../src/richtext/richtextmarginspage.cpp:325
-#: ../src/richtext/richtextsizepage.cpp:602
-#: ../src/richtext/richtextsizepage.cpp:609
 msgid "&Right:"
 msgstr "&Правий:"
 
-#: ../src/common/stockitem.cpp:190
+#: ../src/common/stockitem.cpp:187
 msgid "&Save"
 msgstr "&Зберегти"
-
-#: ../src/common/stockitem.cpp:191
-msgid "&Save as"
-msgstr "З&берегти як"
 
 #: ../include/wx/richmsgdlg.h:29
 msgid "&See details"
 msgstr "&Докладно"
 
-#: ../src/generic/tipdlg.cpp:236
+#: ../src/generic/tipdlg.cpp:233
 msgid "&Show tips at startup"
 msgstr "&Показувати підказки під час запуску"
 
-#: ../src/univ/themes/win32.cpp:3750
+#: ../src/univ/themes/win32.cpp:3747
 msgid "&Size"
 msgstr "&Розмір"
 
@@ -668,36 +690,36 @@ msgstr "&Розмір"
 msgid "&Size:"
 msgstr "&Розмір:"
 
-#: ../src/generic/progdlgg.cpp:252
+#: ../src/generic/progdlgg.cpp:249
 msgid "&Skip"
 msgstr "Проп&устити"
 
-#: ../src/richtext/richtextindentspage.cpp:242
 #: ../src/richtext/richtextliststylepage.cpp:417
+#: ../src/richtext/richtextindentspage.cpp:242
 msgid "&Spacing (tenths of a mm)"
 msgstr "&Проміжок (у десятках мм)"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "&Spell Check"
 msgstr "П&еревірити правопис"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "&Stop"
 msgstr "&Зупинити"
 
-#: ../src/richtext/richtextfontpage.cpp:275 ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196 ../src/richtext/richtextfontpage.cpp:275
 msgid "&Strikethrough"
 msgstr "П&ерекреслення"
 
-#: ../src/generic/fontdlgg.cpp:382 ../src/richtext/richtextstylepage.cpp:106
+#: ../src/generic/fontdlgg.cpp:378 ../src/richtext/richtextstylepage.cpp:106
 msgid "&Style:"
 msgstr "&Стиль:"
 
-#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:194
 msgid "&Styles:"
 msgstr "&Стилі:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:413
+#: ../src/richtext/richtextsymboldlg.cpp:410
 msgid "&Subset:"
 msgstr "&Підмножина:"
 
@@ -711,24 +733,24 @@ msgstr "&Символ:"
 msgid "&Synchronize values"
 msgstr "С&инхронізувати значення"
 
-#: ../include/wx/richtext/richtextbuffer.h:6069
+#: ../include/wx/richtext/richtextbuffer.h:6064
 msgid "&Table"
 msgstr "&Таблиця"
 
-#: ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197
 msgid "&Top"
 msgstr "&Згори"
 
+#: ../src/richtext/richtextsizepage.cpp:567
+#: ../src/richtext/richtextsizepage.cpp:574
 #: ../src/richtext/richtextborderspage.cpp:311
 #: ../src/richtext/richtextborderspage.cpp:479
 #: ../src/richtext/richtextmarginspage.cpp:234
 #: ../src/richtext/richtextmarginspage.cpp:348
-#: ../src/richtext/richtextsizepage.cpp:567
-#: ../src/richtext/richtextsizepage.cpp:574
 msgid "&Top:"
 msgstr "В&ерхнє:"
 
-#: ../src/generic/fontdlgg.cpp:444 ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199 ../src/generic/fontdlgg.cpp:441
 msgid "&Underline"
 msgstr "&Підкреслення"
 
@@ -736,21 +758,21 @@ msgstr "&Підкреслення"
 msgid "&Underlining:"
 msgstr "&Підкреслення:"
 
-#: ../src/richtext/richtextctrl.cpp:329 ../src/osx/textctrl_osx.cpp:573
-#: ../src/common/stockitem.cpp:203 ../src/common/cmdproc.cpp:271
-#: ../src/msw/textctrl.cpp:2504
+#: ../src/osx/textctrl_osx.cpp:591 ../src/common/stockitem.cpp:200
+#: ../src/common/cmdproc.cpp:264 ../src/msw/textctrl.cpp:2769
+#: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "В&ідмінити"
 
-#: ../src/common/cmdproc.cpp:265
+#: ../src/common/cmdproc.cpp:258
 msgid "&Undo "
 msgstr "В&ідмінити"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "&Unindent"
 msgstr "&Без відступу"
 
-#: ../src/common/stockitem.cpp:205
+#: ../src/common/stockitem.cpp:202
 msgid "&Up"
 msgstr "До&гори"
 
@@ -767,7 +789,7 @@ msgstr "&Вертикальний відступ:"
 msgid "&View..."
 msgstr "П&ереглянути…"
 
-#: ../src/generic/fontdlgg.cpp:393
+#: ../src/generic/fontdlgg.cpp:389
 msgid "&Weight:"
 msgstr "&Вага:"
 
@@ -776,88 +798,58 @@ msgstr "&Вага:"
 msgid "&Width:"
 msgstr "&Ширина:"
 
-#: ../src/aui/tabmdi.cpp:311 ../src/aui/tabmdi.cpp:327
-#: ../src/aui/tabmdi.cpp:329 ../src/generic/mdig.cpp:294
-#: ../src/generic/mdig.cpp:310 ../src/generic/mdig.cpp:314
-#: ../src/msw/mdi.cpp:78
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
 msgid "&Window"
 msgstr "&Вікно"
 
-#: ../src/common/stockitem.cpp:206 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:203 ../src/msw/msgdlg.cpp:435
 msgid "&Yes"
 msgstr "&Так"
 
-#: ../src/common/valtext.cpp:256
-#, c-format
-msgid "'%s' contains illegal characters"
+#: ../src/common/valtext.cpp:197
+#, fuzzy, c-format
+msgid "'%s' contains invalid character(s)"
 msgstr "«%s» містить некоректні символи"
 
-#: ../src/common/valtext.cpp:254
-#, c-format
-msgid "'%s' doesn't consist only of valid characters"
-msgstr "«%s» містить некоректні символи"
-
-#: ../src/common/config.cpp:519 ../src/msw/regconf.cpp:258
+#: ../src/common/config.cpp:515 ../src/msw/regconf.cpp:255
 #, c-format
 msgid "'%s' has extra '..', ignored."
 msgstr "«%s» містить додаткові «..», проігноровано."
 
-#: ../src/common/cmdline.cpp:1113 ../src/common/cmdline.cpp:1131
+#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "«%s» — помилкове числове значення для параметра «%s»."
 
-#: ../src/common/translation.cpp:1100
+#: ../src/common/translation.cpp:1142
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "«%s» — помилковий каталог повідомлень."
 
-#: ../src/common/valtext.cpp:165
+#: ../src/common/valtext.cpp:188
 #, c-format
 msgid "'%s' is not one of the valid strings"
 msgstr "«%s» немає серед коректних рядків"
 
-#: ../src/common/valtext.cpp:167
+#: ../src/common/valtext.cpp:186
 #, c-format
 msgid "'%s' is one of the invalid strings"
 msgstr "«%s» є одним з помилкових рядків"
 
-#: ../src/common/textbuf.cpp:237
+#: ../src/common/textbuf.cpp:233
 #, c-format
 msgid "'%s' is probably a binary buffer."
 msgstr "«%s» — можливо бінарний файл."
-
-#: ../src/common/valtext.cpp:252
-#, c-format
-msgid "'%s' should be numeric."
-msgstr "«%s» повинно бути числом."
-
-#: ../src/common/valtext.cpp:244
-#, c-format
-msgid "'%s' should only contain ASCII characters."
-msgstr "«%s» має містити тільки символи ASCII."
-
-#: ../src/common/valtext.cpp:246
-#, c-format
-msgid "'%s' should only contain alphabetic characters."
-msgstr "«%s» має містити тільки символи алфавіту."
-
-#: ../src/common/valtext.cpp:248
-#, c-format
-msgid "'%s' should only contain alphabetic or numeric characters."
-msgstr "«%s» має містити тільки символи алфавіту або цифри."
-
-#: ../src/common/valtext.cpp:250
-#, c-format
-msgid "'%s' should only contain digits."
-msgstr "«%s» має містити лише цифри."
 
 #: ../src/richtext/richtextliststylepage.cpp:229
 #: ../src/richtext/richtextbulletspage.cpp:166
 msgid "(*)"
 msgstr "(*)"
 
-#: ../src/html/helpwnd.cpp:963
+#: ../src/html/helpwnd.cpp:961
 msgid "(Help)"
 msgstr "(Довідка)"
 
@@ -866,27 +858,32 @@ msgstr "(Довідка)"
 msgid "(None)"
 msgstr "(Відсутній)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:504
+#: ../src/richtext/richtextsymboldlg.cpp:503
 msgid "(Normal text)"
 msgstr "(Звичайний шрифт)"
 
-#: ../src/html/helpwnd.cpp:419 ../src/html/helpwnd.cpp:1106
-#: ../src/html/helpwnd.cpp:1742
+#: ../src/html/helpwnd.cpp:417 ../src/html/helpwnd.cpp:1104
+#: ../src/html/helpwnd.cpp:1740
 msgid "(bookmarks)"
 msgstr "(закладки)"
 
+#: ../src/msw/dlmsw.cpp:167
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (помилка %ld: %s)"
+
+#: ../src/richtext/richtextformatdlg.cpp:876
+#: ../src/richtext/richtextliststylepage.cpp:448
+#: ../src/richtext/richtextliststylepage.cpp:460
+#: ../src/richtext/richtextliststylepage.cpp:461
 #: ../src/richtext/richtextindentspage.cpp:274
 #: ../src/richtext/richtextindentspage.cpp:286
 #: ../src/richtext/richtextindentspage.cpp:287
 #: ../src/richtext/richtextindentspage.cpp:311
 #: ../src/richtext/richtextindentspage.cpp:326
-#: ../src/richtext/richtextformatdlg.cpp:884
 #: ../src/richtext/richtextfontpage.cpp:349
 #: ../src/richtext/richtextfontpage.cpp:353
 #: ../src/richtext/richtextfontpage.cpp:357
-#: ../src/richtext/richtextliststylepage.cpp:448
-#: ../src/richtext/richtextliststylepage.cpp:460
-#: ../src/richtext/richtextliststylepage.cpp:461
 msgid "(none)"
 msgstr "(нічого)"
 
@@ -905,7 +902,7 @@ msgstr "*)"
 msgid "+"
 msgstr "+"
 
-#: ../src/msw/utils.cpp:1152
+#: ../src/msw/utils.cpp:1143
 msgid ", 64-bit edition"
 msgstr ", 64-бітова версія"
 
@@ -914,163 +911,163 @@ msgstr ", 64-бітова версія"
 msgid "-"
 msgstr "-"
 
-#: ../src/generic/filepickerg.cpp:66
+#: ../src/generic/filepickerg.cpp:63
 msgid "..."
 msgstr "…"
 
-#: ../src/richtext/richtextindentspage.cpp:276
 #: ../src/richtext/richtextliststylepage.cpp:450
+#: ../src/richtext/richtextindentspage.cpp:276
 msgid "1.1"
 msgstr "1,1"
 
-#: ../src/richtext/richtextindentspage.cpp:277
 #: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextindentspage.cpp:277
 msgid "1.2"
 msgstr "1,2"
 
-#: ../src/richtext/richtextindentspage.cpp:278
 #: ../src/richtext/richtextliststylepage.cpp:452
+#: ../src/richtext/richtextindentspage.cpp:278
 msgid "1.3"
 msgstr "1,3"
 
-#: ../src/richtext/richtextindentspage.cpp:279
 #: ../src/richtext/richtextliststylepage.cpp:453
+#: ../src/richtext/richtextindentspage.cpp:279
 msgid "1.4"
 msgstr "1,4"
 
-#: ../src/richtext/richtextindentspage.cpp:280
 #: ../src/richtext/richtextliststylepage.cpp:454
+#: ../src/richtext/richtextindentspage.cpp:280
 msgid "1.5"
 msgstr "1,5"
 
-#: ../src/richtext/richtextindentspage.cpp:281
 #: ../src/richtext/richtextliststylepage.cpp:455
+#: ../src/richtext/richtextindentspage.cpp:281
 msgid "1.6"
 msgstr "1,6"
 
-#: ../src/richtext/richtextindentspage.cpp:282
 #: ../src/richtext/richtextliststylepage.cpp:456
+#: ../src/richtext/richtextindentspage.cpp:282
 msgid "1.7"
 msgstr "1,7"
 
-#: ../src/richtext/richtextindentspage.cpp:283
 #: ../src/richtext/richtextliststylepage.cpp:457
+#: ../src/richtext/richtextindentspage.cpp:283
 msgid "1.8"
 msgstr "1,8"
 
-#: ../src/richtext/richtextindentspage.cpp:284
 #: ../src/richtext/richtextliststylepage.cpp:458
+#: ../src/richtext/richtextindentspage.cpp:284
 msgid "1.9"
 msgstr "1,9"
 
-#: ../src/common/paper.cpp:140
+#: ../src/common/paper.cpp:137
 msgid "10 x 11 in"
 msgstr "10 x 11 дюймів"
 
-#: ../src/common/paper.cpp:113
+#: ../src/common/paper.cpp:110
 msgid "10 x 14 in"
 msgstr "10 x 14 дюймів"
 
-#: ../src/common/paper.cpp:114
+#: ../src/common/paper.cpp:111
 msgid "11 x 17 in"
 msgstr "11 x 17 дюймів"
 
-#: ../src/common/paper.cpp:184
+#: ../src/common/paper.cpp:181
 msgid "12 x 11 in"
 msgstr "12 x 11 дюймів"
 
-#: ../src/common/paper.cpp:141
+#: ../src/common/paper.cpp:138
 msgid "15 x 11 in"
 msgstr "15 x 11 дюймів"
 
-#: ../src/richtext/richtextindentspage.cpp:285
 #: ../src/richtext/richtextliststylepage.cpp:459
+#: ../src/richtext/richtextindentspage.cpp:285
 msgid "2"
 msgstr "2"
 
-#: ../src/common/paper.cpp:132
+#: ../src/common/paper.cpp:129
 msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
 msgstr "6 3/4 Конверт, 3 5/8 x 6 1/2 дюйм"
 
-#: ../src/common/paper.cpp:139
+#: ../src/common/paper.cpp:136
 msgid "9 x 11 in"
 msgstr "9 x 11 дюймів"
 
-#: ../src/html/htmprint.cpp:431
+#: ../src/html/htmprint.cpp:443
 msgid ": file does not exist!"
 msgstr ": файл не існує!"
 
-#: ../src/common/fontmap.cpp:199
+#: ../src/common/fontmap.cpp:196
 msgid ": unknown charset"
 msgstr ": невідомий набір символів"
 
-#: ../src/common/fontmap.cpp:413
+#: ../src/common/fontmap.cpp:410
 msgid ": unknown encoding"
 msgstr ": невідоме кодування"
 
-#: ../src/generic/wizard.cpp:443
+#: ../src/generic/wizard.cpp:438
 msgid "< &Back"
 msgstr "< &Назад"
 
-#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:628
-#: ../src/osx/carbon/fontdlg.cpp:648
+#: ../src/osx/carbon/fontdlg.cpp:419 ../src/osx/carbon/fontdlg.cpp:625
+#: ../src/osx/carbon/fontdlg.cpp:645
 msgid "<Any Decorative>"
 msgstr "<Будь-який декоративний>"
 
-#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:630
-#: ../src/osx/carbon/fontdlg.cpp:650
+#: ../src/osx/carbon/fontdlg.cpp:420 ../src/osx/carbon/fontdlg.cpp:627
+#: ../src/osx/carbon/fontdlg.cpp:647
 msgid "<Any Modern>"
 msgstr "<Будь-який модерний>"
 
-#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:626
-#: ../src/osx/carbon/fontdlg.cpp:646
+#: ../src/osx/carbon/fontdlg.cpp:418 ../src/osx/carbon/fontdlg.cpp:623
+#: ../src/osx/carbon/fontdlg.cpp:643
 msgid "<Any Roman>"
 msgstr "<Будь-який романський>"
 
-#: ../src/osx/carbon/fontdlg.cpp:424 ../src/osx/carbon/fontdlg.cpp:632
-#: ../src/osx/carbon/fontdlg.cpp:652
+#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:629
+#: ../src/osx/carbon/fontdlg.cpp:649
 msgid "<Any Script>"
 msgstr "<Будь-який для індексів>"
 
-#: ../src/osx/carbon/fontdlg.cpp:425 ../src/osx/carbon/fontdlg.cpp:637
-#: ../src/osx/carbon/fontdlg.cpp:656
+#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:634
+#: ../src/osx/carbon/fontdlg.cpp:653
 msgid "<Any Swiss>"
 msgstr "<Будь-який Swiss>"
 
-#: ../src/osx/carbon/fontdlg.cpp:426 ../src/osx/carbon/fontdlg.cpp:634
-#: ../src/osx/carbon/fontdlg.cpp:654
+#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:631
+#: ../src/osx/carbon/fontdlg.cpp:651
 msgid "<Any Teletype>"
 msgstr "<Будь-який машинописний>"
 
-#: ../src/osx/carbon/fontdlg.cpp:420
+#: ../src/osx/carbon/fontdlg.cpp:417
 msgid "<Any>"
 msgstr "<Будь-який>"
 
-#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
 msgid "<DIR>"
 msgstr "<ТЕКА>"
 
-#: ../src/generic/filectrlg.cpp:254 ../src/generic/filectrlg.cpp:277
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
 msgid "<DRIVE>"
 msgstr "<ДИСК>"
 
-#: ../src/generic/filectrlg.cpp:252 ../src/generic/filectrlg.cpp:275
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
 msgid "<LINK>"
 msgstr "<ПОСИЛАННЯ>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1264
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Жирний курсивний шрифт.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1270
+#: ../src/html/helpwnd.cpp:1268
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>жирний курсивний шрифт <u>з підкресленням</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1265
+#: ../src/html/helpwnd.cpp:1263
 msgid "<b>Bold face.</b> "
 msgstr "<b>Жирний шрифт.</b> "
 
-#: ../src/html/helpwnd.cpp:1264
+#: ../src/html/helpwnd.cpp:1262
 msgid "<i>Italic face.</i> "
 msgstr "<i>Курсивний шрифт.</i> "
 
@@ -1079,15 +1076,15 @@ msgstr "<i>Курсивний шрифт.</i> "
 msgid ">"
 msgstr ">"
 
-#: ../src/generic/dbgrptg.cpp:318
+#: ../src/generic/dbgrptg.cpp:317
 msgid "A debug report has been generated in the directory\n"
 msgstr "Звіт про помилку сформовано у теці\n"
 
-#: ../src/common/debugrpt.cpp:573
+#: ../src/common/debugrpt.cpp:574
 msgid "A debug report has been generated. It can be found in"
 msgstr "Було створено звіт про помилку. Його збережено до"
 
-#: ../src/common/xtixml.cpp:418
+#: ../src/common/xtixml.cpp:414
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Непорожня колекція має складатися з вузлів-\"елементів\""
 
@@ -1098,106 +1095,106 @@ msgstr "Непорожня колекція має складатися з ву�
 msgid "A standard bullet name."
 msgstr "Назва стандартної позначки."
 
-#: ../src/common/paper.cpp:217
+#: ../src/common/paper.cpp:214
 msgid "A0 sheet, 841 x 1189 mm"
 msgstr "Аркуш A0, 841 x 1189 мм"
 
-#: ../src/common/paper.cpp:218
+#: ../src/common/paper.cpp:215
 msgid "A1 sheet, 594 x 841 mm"
 msgstr "Аркуш A1, 594 x 841 мм"
 
-#: ../src/common/paper.cpp:159
+#: ../src/common/paper.cpp:156
 msgid "A2 420 x 594 mm"
 msgstr "A2 420 x 594 мм"
 
-#: ../src/common/paper.cpp:156
+#: ../src/common/paper.cpp:153
 msgid "A3 Extra 322 x 445 mm"
 msgstr "A3 Екстра 322 x 445 мм"
 
-#: ../src/common/paper.cpp:161
+#: ../src/common/paper.cpp:158
 msgid "A3 Extra Transverse 322 x 445 mm"
 msgstr "A3 Екстра Поперечний 322 x 445 мм"
 
-#: ../src/common/paper.cpp:170
+#: ../src/common/paper.cpp:167
 msgid "A3 Rotated 420 x 297 mm"
 msgstr "A3 Повернутий 420 x 297 мм"
 
-#: ../src/common/paper.cpp:160
+#: ../src/common/paper.cpp:157
 msgid "A3 Transverse 297 x 420 mm"
 msgstr "A3 Поперечний 297 x 420 мм"
 
-#: ../src/common/paper.cpp:106
+#: ../src/common/paper.cpp:103
 msgid "A3 sheet, 297 x 420 mm"
 msgstr "Аркуш A3 297 x 420 мм"
 
-#: ../src/common/paper.cpp:146
+#: ../src/common/paper.cpp:143
 msgid "A4 Extra 9.27 x 12.69 in"
 msgstr "A4 Екстра 9.27 x 12.69 дюймів"
 
-#: ../src/common/paper.cpp:153
+#: ../src/common/paper.cpp:150
 msgid "A4 Plus 210 x 330 mm"
 msgstr "A4 Плюс 210 x 330 мм"
 
-#: ../src/common/paper.cpp:171
+#: ../src/common/paper.cpp:168
 msgid "A4 Rotated 297 x 210 mm"
 msgstr "A4 Повернутий 297 x 210 мм"
 
-#: ../src/common/paper.cpp:148
+#: ../src/common/paper.cpp:145
 msgid "A4 Transverse 210 x 297 mm"
 msgstr "A4 Поперечний 210 x 297 мм"
 
-#: ../src/common/paper.cpp:97
+#: ../src/common/paper.cpp:94
 msgid "A4 sheet, 210 x 297 mm"
 msgstr "Аркуш A4, 210 x 297 мм"
 
-#: ../src/common/paper.cpp:107
+#: ../src/common/paper.cpp:104
 msgid "A4 small sheet, 210 x 297 mm"
 msgstr "Малий лист A4, 210 x 297 мм"
 
-#: ../src/common/paper.cpp:157
+#: ../src/common/paper.cpp:154
 msgid "A5 Extra 174 x 235 mm"
 msgstr "A5 Екстра 174 x 235 мм"
 
-#: ../src/common/paper.cpp:172
+#: ../src/common/paper.cpp:169
 msgid "A5 Rotated 210 x 148 mm"
 msgstr "A5 Повернутий 210 x 148 мм"
 
-#: ../src/common/paper.cpp:154
+#: ../src/common/paper.cpp:151
 msgid "A5 Transverse 148 x 210 mm"
 msgstr "A5 Поперечний 148 x 210 мм"
 
-#: ../src/common/paper.cpp:108
+#: ../src/common/paper.cpp:105
 msgid "A5 sheet, 148 x 210 mm"
 msgstr "Аркуш A5, 148 x 210 мм"
 
-#: ../src/common/paper.cpp:164
+#: ../src/common/paper.cpp:161
 msgid "A6 105 x 148 mm"
 msgstr "A6 105 x 148 мм"
 
-#: ../src/common/paper.cpp:177
+#: ../src/common/paper.cpp:174
 msgid "A6 Rotated 148 x 105 mm"
 msgstr "A6 Повернутий 148 x 105 мм"
 
-#: ../src/generic/fontdlgg.cpp:83 ../src/richtext/richtextformatdlg.cpp:529
-#: ../src/osx/carbon/fontdlg.cpp:153
+#: ../src/osx/carbon/fontdlg.cpp:150 ../src/generic/fontdlgg.cpp:79
+#: ../src/richtext/richtextformatdlg.cpp:521
 msgid "ABCDEFGabcdefg12345"
 msgstr "ABCDEFGabcdefg12345"
 
-#: ../src/richtext/richtextsymboldlg.cpp:458 ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
 msgid "ASCII"
 msgstr "ASCII"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "About"
 msgstr "Про програму"
 
-#: ../src/generic/aboutdlgg.cpp:140 ../src/osx/menu_osx.cpp:558
-#: ../src/msw/aboutdlg.cpp:64
+#: ../src/osx/menu_osx.cpp:450 ../src/generic/aboutdlgg.cpp:137
+#: ../src/msw/aboutdlg.cpp:61
 #, c-format
 msgid "About %s"
 msgstr "Про %s"
 
-#: ../src/osx/menu_osx.cpp:560
+#: ../src/osx/menu_osx.cpp:452
 msgid "About..."
 msgstr "Про програму…"
 
@@ -1206,38 +1203,38 @@ msgid "Absolute"
 msgstr "Абсолютна"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:873
+#: ../src/propgrid/advprops.cpp:774
 #, fuzzy
 msgid "ActiveBorder"
 msgstr "Рамка"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:874
+#: ../src/propgrid/advprops.cpp:775
 msgid "ActiveCaption"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "Actual Size"
 msgstr "Фактичний розмір"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:140 ../src/common/accelcmn.cpp:81
+#: ../src/common/stockitem.cpp:137 ../src/common/accelcmn.cpp:78
 msgid "Add"
 msgstr "Додати"
 
-#: ../src/richtext/richtextbuffer.cpp:11455
+#: ../src/richtext/richtextbuffer.cpp:11454
 msgid "Add Column"
 msgstr "Додати стовпчик"
 
-#: ../src/richtext/richtextbuffer.cpp:11392
+#: ../src/richtext/richtextbuffer.cpp:11391
 msgid "Add Row"
 msgstr "Додати рядок"
 
-#: ../src/html/helpwnd.cpp:432
+#: ../src/html/helpwnd.cpp:430
 msgid "Add current page to bookmarks"
 msgstr "Додати цю сторінку до закладок"
 
-#: ../src/generic/colrdlgg.cpp:366
+#: ../src/generic/colrdlgg.cpp:386
 msgid "Add to custom colours"
 msgstr "Додати до створених кольорів "
 
@@ -1249,12 +1246,12 @@ msgstr "AddToPropertyCollection викликано для загального �
 msgid "AddToPropertyCollection called w/o valid adder"
 msgstr "AddToPropertyCollection викликано без коректного параметра додавання"
 
-#: ../src/html/helpctrl.cpp:159
+#: ../src/html/helpctrl.cpp:155
 #, c-format
 msgid "Adding book %s"
 msgstr "Додавання книги %s"
 
-#: ../src/common/preferencescmn.cpp:43
+#: ../src/common/preferencescmn.cpp:40
 msgid "Advanced"
 msgstr "Додатково"
 
@@ -1262,11 +1259,11 @@ msgstr "Додатково"
 msgid "After a paragraph:"
 msgstr "Після абзацу:"
 
-#: ../src/common/stockitem.cpp:172
+#: ../src/common/stockitem.cpp:169
 msgid "Align Left"
 msgstr "Вирівняти ліворуч"
 
-#: ../src/common/stockitem.cpp:173
+#: ../src/common/stockitem.cpp:170
 msgid "Align Right"
 msgstr "Вирівняти праворуч"
 
@@ -1274,40 +1271,40 @@ msgstr "Вирівняти праворуч"
 msgid "Alignment"
 msgstr "Вирівнювання"
 
-#: ../src/generic/prntdlgg.cpp:215
+#: ../src/generic/prntdlgg.cpp:208
 msgid "All"
 msgstr "Всі"
 
-#: ../src/generic/filectrlg.cpp:1197 ../src/common/fldlgcmn.cpp:107
+#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1186
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Всі файли (%s)|%s"
 
-#: ../include/wx/defs.h:2886
+#: ../include/wx/defs.h:2582
 msgid "All files (*)|*"
 msgstr "Всі файли (*)|*"
 
-#: ../include/wx/defs.h:2883
+#: ../include/wx/defs.h:2579
 msgid "All files (*.*)|*.*"
 msgstr "Всі файли (*.*)|*.*"
 
-#: ../src/richtext/richtextstyles.cpp:1061
+#: ../src/richtext/richtextstyles.cpp:1058
 msgid "All styles"
 msgstr "Всі стилі"
 
-#: ../src/propgrid/manager.cpp:1528
+#: ../src/propgrid/manager.cpp:1544
 msgid "Alphabetic Mode"
 msgstr "Абетковий режим"
 
-#: ../src/common/xtistrm.cpp:425
+#: ../src/common/xtistrm.cpp:422
 msgid "Already Registered Object passed to SetObjectClassInfo"
 msgstr "До SetObjectClassInfo передано повідомлення Об'єкт Вже Зареєстровано"
 
-#: ../src/unix/dialup.cpp:353
+#: ../src/unix/dialup.cpp:352
 msgid "Already dialling ISP."
 msgstr "Вже дзвонимо ISP."
 
-#: ../src/common/accelcmn.cpp:331 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/accelcmn.cpp:345 ../src/univ/themes/win32.cpp:3753
 msgid "Alt+"
 msgstr "Alt+"
 
@@ -1316,34 +1313,34 @@ msgstr "Alt+"
 msgid "An optional corner radius for adding rounded corners."
 msgstr "Необов’язковий радіус закруглення кутів."
 
-#: ../src/common/debugrpt.cpp:576
+#: ../src/common/debugrpt.cpp:577
 msgid "And includes the following files:\n"
 msgstr "Та містить такі файли:\n"
 
-#: ../src/generic/animateg.cpp:162
+#: ../src/generic/animateg.cpp:145
 #, c-format
 msgid "Animation file is not of type %ld."
 msgstr "Анімаційний файл не належить до типу %ld."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:872
+#: ../src/propgrid/advprops.cpp:773
 msgid "AppWorkspace"
 msgstr "РобочаОбластьДодатків"
 
-#: ../src/generic/logg.cpp:1014
+#: ../src/generic/logg.cpp:1011
 #, c-format
 msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
 msgstr "Додати до файла журналу «%s» (вибір [Ні] перепише його)?"
 
-#: ../src/osx/menu_osx.cpp:577 ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:469 ../src/osx/menu_osx.cpp:477
 msgid "Application"
 msgstr "Програма"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "Apply"
 msgstr "Застосувати"
 
-#: ../src/propgrid/advprops.cpp:1609
+#: ../src/propgrid/advprops.cpp:1515
 msgid "Aqua"
 msgstr "Аква"
 
@@ -1352,30 +1349,30 @@ msgstr "Аква"
 msgid "Arabic"
 msgstr "Арабські"
 
-#: ../src/common/fmapbase.cpp:153
+#: ../src/common/fmapbase.cpp:150
 msgid "Arabic (ISO-8859-6)"
 msgstr "Arabic (ISO-8859-6)"
 
-#: ../src/msw/ole/automtn.cpp:672
+#: ../src/msw/ole/automtn.cpp:663
 #, c-format
 msgid "Argument %u not found."
 msgstr "Не знайдено аргументу %u."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1753
+#: ../src/propgrid/advprops.cpp:1654
 #, fuzzy
 msgid "Arrow"
 msgstr "Стрілка"
 
-#: ../src/generic/aboutdlgg.cpp:184
+#: ../src/generic/aboutdlgg.cpp:181
 msgid "Artists"
 msgstr "Художники"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "Ascending"
 msgstr "За зростанням"
 
-#: ../src/generic/filectrlg.cpp:433
+#: ../src/generic/filectrlg.cpp:429
 msgid "Attributes"
 msgstr "Атрибути"
 
@@ -1385,90 +1382,90 @@ msgstr "Атрибути"
 msgid "Available fonts."
 msgstr "Доступні шрифти."
 
-#: ../src/common/paper.cpp:137
+#: ../src/common/paper.cpp:134
 msgid "B4 (ISO) 250 x 353 mm"
 msgstr "B4 (ISO) 250 x 353 мм"
 
-#: ../src/common/paper.cpp:173
+#: ../src/common/paper.cpp:170
 msgid "B4 (JIS) Rotated 364 x 257 mm"
 msgstr "B4 (JIS) Повернутий 364 x 257 мм"
 
-#: ../src/common/paper.cpp:127
+#: ../src/common/paper.cpp:124
 msgid "B4 Envelope, 250 x 353 mm"
 msgstr "B4 Конверт, 250 x 353 мм"
 
-#: ../src/common/paper.cpp:109
+#: ../src/common/paper.cpp:106
 msgid "B4 sheet, 250 x 354 mm"
 msgstr "Аркуш B4, 250 x 354 мм"
 
-#: ../src/common/paper.cpp:158
+#: ../src/common/paper.cpp:155
 msgid "B5 (ISO) Extra 201 x 276 mm"
 msgstr "B5 (ISO) Екстра 201 x 276 мм"
 
-#: ../src/common/paper.cpp:174
+#: ../src/common/paper.cpp:171
 msgid "B5 (JIS) Rotated 257 x 182 mm"
 msgstr "B5 (JIS) Повернутий 257 x 182 мм"
 
-#: ../src/common/paper.cpp:155
+#: ../src/common/paper.cpp:152
 msgid "B5 (JIS) Transverse 182 x 257 mm"
 msgstr "B5 (JIS) Поперечний 182 x 257 мм"
 
-#: ../src/common/paper.cpp:128
+#: ../src/common/paper.cpp:125
 msgid "B5 Envelope, 176 x 250 mm"
 msgstr "B5 Конверт, 176 x 250 мм"
 
-#: ../src/common/paper.cpp:110
+#: ../src/common/paper.cpp:107
 msgid "B5 sheet, 182 x 257 millimeter"
 msgstr "Аркуш B5, 182 x 257 мм"
 
-#: ../src/common/paper.cpp:182
+#: ../src/common/paper.cpp:179
 msgid "B6 (JIS) 128 x 182 mm"
 msgstr "B6 (JIS) 128 x 182 мм"
 
-#: ../src/common/paper.cpp:183
+#: ../src/common/paper.cpp:180
 msgid "B6 (JIS) Rotated 182 x 128 mm"
 msgstr "B6 (JIS) Повернутий 182 x 128 мм"
 
-#: ../src/common/paper.cpp:129
+#: ../src/common/paper.cpp:126
 msgid "B6 Envelope, 176 x 125 mm"
 msgstr "B6 Конверт, 176 x 125 мм"
 
-#: ../src/common/imagbmp.cpp:531 ../src/common/imagbmp.cpp:561
-#: ../src/common/imagbmp.cpp:576
+#: ../src/common/imagbmp.cpp:528 ../src/common/imagbmp.cpp:558
+#: ../src/common/imagbmp.cpp:573
 msgid "BMP: Couldn't allocate memory."
 msgstr "BMP: Не вдалося виділити пам'ять."
 
-#: ../src/common/imagbmp.cpp:100
+#: ../src/common/imagbmp.cpp:97
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: Не можу записати помилкове зображення."
 
-#: ../src/common/imagbmp.cpp:356
+#: ../src/common/imagbmp.cpp:353
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: Не вдалося записати карту кольорів RGB."
 
-#: ../src/common/imagbmp.cpp:490
+#: ../src/common/imagbmp.cpp:487
 msgid "BMP: Couldn't write data."
 msgstr "BMP: Не можу записати дані."
 
-#: ../src/common/imagbmp.cpp:246
+#: ../src/common/imagbmp.cpp:243
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: Не вдалося записати заголовок (Bitmap) файла."
 
-#: ../src/common/imagbmp.cpp:269
+#: ../src/common/imagbmp.cpp:266
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: Не вдалося записати заголовок (BitmapInfo) файла."
 
-#: ../src/common/imagbmp.cpp:140
+#: ../src/common/imagbmp.cpp:137
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr " BMP: wxImage не має свого wxPalette."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:142 ../src/common/accelcmn.cpp:52
+#: ../src/common/stockitem.cpp:139 ../src/common/accelcmn.cpp:49
 msgid "Back"
 msgstr "Назад"
 
+#: ../src/richtext/richtextformatdlg.cpp:377
 #: ../src/richtext/richtextbackgroundpage.cpp:148
-#: ../src/richtext/richtextformatdlg.cpp:384
 msgid "Background"
 msgstr "Тло"
 
@@ -1476,21 +1473,21 @@ msgstr "Тло"
 msgid "Background &colour:"
 msgstr "Колір т&ла:"
 
-#: ../src/osx/carbon/fontdlg.cpp:220
+#: ../src/osx/carbon/fontdlg.cpp:217
 msgid "Background colour"
 msgstr "Колір тла"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:52
+#: ../src/common/accelcmn.cpp:49
 #, fuzzy
 msgid "Backspace"
 msgstr "Назад"
 
-#: ../src/common/fmapbase.cpp:160
+#: ../src/common/fmapbase.cpp:157
 msgid "Baltic (ISO-8859-13)"
 msgstr "Baltic (ISO-8859-13)"
 
-#: ../src/common/fmapbase.cpp:151
+#: ../src/common/fmapbase.cpp:148
 msgid "Baltic (old) (ISO-8859-4)"
 msgstr "Baltic (старе) (ISO-8859-4)"
 
@@ -1503,26 +1500,26 @@ msgstr "Перед абзацом:"
 msgid "Bitmap"
 msgstr "Растровий"
 
-#: ../src/propgrid/advprops.cpp:1594
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Black"
 msgstr "Чорний"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1755
+#: ../src/propgrid/advprops.cpp:1656
 msgid "Blank"
 msgstr "Порожній"
 
-#: ../src/propgrid/advprops.cpp:1603
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Blue"
 msgstr "Синій"
 
-#: ../src/generic/colrdlgg.cpp:345
+#: ../src/generic/colrdlgg.cpp:365
 #, fuzzy
 msgid "Blue:"
 msgstr "Синій"
 
-#: ../src/generic/fontdlgg.cpp:333 ../src/richtext/richtextfontpage.cpp:355
-#: ../src/osx/carbon/fontdlg.cpp:354 ../src/common/stockitem.cpp:143
+#: ../src/osx/carbon/fontdlg.cpp:351 ../src/common/stockitem.cpp:140
+#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:355
 msgid "Bold"
 msgstr "Жирний"
 
@@ -1531,32 +1528,36 @@ msgstr "Жирний"
 msgid "Border"
 msgstr "Рамка"
 
-#: ../src/richtext/richtextformatdlg.cpp:379
+#: ../src/richtext/richtextformatdlg.cpp:372
 msgid "Borders"
 msgstr "Рамки"
 
-#: ../src/richtext/richtextsizepage.cpp:288 ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141 ../src/richtext/richtextsizepage.cpp:288
 msgid "Bottom"
 msgstr "Внизу"
 
-#: ../src/generic/prntdlgg.cpp:893
+#: ../src/generic/prntdlgg.cpp:886
 msgid "Bottom margin (mm):"
 msgstr "Нижнє поле (мм):"
 
-#: ../src/richtext/richtextbuffer.cpp:9383
+#: ../src/richtext/richtextbuffer.cpp:9380
 msgid "Box Properties"
 msgstr "Властивості рамок"
 
-#: ../src/richtext/richtextstyles.cpp:1065
+#: ../src/richtext/richtextstyles.cpp:1062
 msgid "Box styles"
 msgstr "Стилі рамок"
 
-#: ../src/propgrid/advprops.cpp:1602
+#: ../src/osx/cocoa/menu.mm:292
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1508
 #, fuzzy
 msgid "Brown"
 msgstr "Навігація"
 
-#: ../src/common/filepickercmn.cpp:43 ../src/common/filepickercmn.cpp:44
+#: ../src/common/filepickercmn.cpp:40 ../src/common/filepickercmn.cpp:41
 msgid "Browse"
 msgstr "Навігація"
 
@@ -1569,73 +1570,73 @@ msgstr "&Вирівнювання позначки:"
 msgid "Bullet style"
 msgstr "Стиль позначки"
 
-#: ../src/richtext/richtextformatdlg.cpp:359
+#: ../src/richtext/richtextformatdlg.cpp:352
 msgid "Bullets"
 msgstr "Позначки"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1756
+#: ../src/propgrid/advprops.cpp:1657
 #, fuzzy
 msgid "Bullseye"
 msgstr "Стиль позначки"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:875
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonFace"
 msgstr "ВерхКнопки"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:876
+#: ../src/propgrid/advprops.cpp:777
 msgid "ButtonHighlight"
 msgstr "ПідсвічуванняКнопки"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:877
+#: ../src/propgrid/advprops.cpp:778
 msgid "ButtonShadow"
 msgstr "ЗатінитиКнопку"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:878
+#: ../src/propgrid/advprops.cpp:779
 msgid "ButtonText"
 msgstr "ТекстКнопки"
 
-#: ../src/common/paper.cpp:98
+#: ../src/common/paper.cpp:95
 msgid "C sheet, 17 x 22 in"
 msgstr "Аркуш C, 17 x 22 дюйм"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "C&lear"
 msgstr "О&чистити"
 
-#: ../src/generic/fontdlgg.cpp:406
+#: ../src/generic/fontdlgg.cpp:403
 msgid "C&olour:"
 msgstr "К&олір:"
 
-#: ../src/common/paper.cpp:123
+#: ../src/common/paper.cpp:120
 msgid "C3 Envelope, 324 x 458 mm"
 msgstr "C3 Конверт, 324 x 458 мм"
 
-#: ../src/common/paper.cpp:124
+#: ../src/common/paper.cpp:121
 msgid "C4 Envelope, 229 x 324 mm"
 msgstr "C4 Конверт, 229 x 324 мм"
 
-#: ../src/common/paper.cpp:122
+#: ../src/common/paper.cpp:119
 msgid "C5 Envelope, 162 x 229 mm"
 msgstr "C5 Конверт, 162 x 229 мм"
 
-#: ../src/common/paper.cpp:125
+#: ../src/common/paper.cpp:122
 msgid "C6 Envelope, 114 x 162 mm"
 msgstr "C6 Конверт, 114 x 162 мм"
 
-#: ../src/common/paper.cpp:126
+#: ../src/common/paper.cpp:123
 msgid "C65 Envelope, 114 x 229 mm"
 msgstr "C65 Конверт, 114 x 229 мм"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "CD-Rom"
 msgstr "CD-ROM"
 
-#: ../src/html/chm.cpp:815 ../src/html/chm.cpp:874
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:865
 msgid "CHM handler currently supports only local files!"
 msgstr "Обробник CHM у цій версії підтримує лише локальні файли!"
 
@@ -1643,194 +1644,198 @@ msgstr "Обробник CHM у цій версії підтримує лише 
 msgid "Ca&pitals"
 msgstr "Пр&описні"
 
-#: ../src/common/cmdproc.cpp:267
+#: ../src/common/cmdproc.cpp:260
 msgid "Can't &Undo "
 msgstr "Не можу В&ідновити "
 
-#: ../src/common/image.cpp:2824
+#: ../src/common/image.cpp:2924
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 "Неможливо визначити формат зображення у автоматичному режимі для вхідних "
 "даних без можливості позиціювання."
 
-#: ../src/msw/registry.cpp:506
+#: ../src/msw/registry.cpp:495
 #, c-format
 msgid "Can't close registry key '%s'"
 msgstr "Не вдалося закрити ключ реєстру «%s»"
 
-#: ../src/msw/registry.cpp:584
+#: ../src/msw/registry.cpp:573
 #, c-format
 msgid "Can't copy values of unsupported type %d."
 msgstr "Не вдалося копіювати значення непідтримуваного типу %d."
 
-#: ../src/msw/registry.cpp:487
+#: ../src/msw/registry.cpp:476
 #, c-format
 msgid "Can't create registry key '%s'"
 msgstr "Не вдалося створити ключ реєстру «%s»"
 
-#: ../src/msw/thread.cpp:665
+#: ../src/msw/thread.cpp:657
 msgid "Can't create thread"
 msgstr "Не вдалося створити нитку"
 
-#: ../src/msw/window.cpp:3691
-#, c-format
-msgid "Can't create window of class %s"
-msgstr "Не вдалося створити вікно класу %s"
-
-#: ../src/msw/registry.cpp:777
+#: ../src/msw/registry.cpp:765
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Не вдалося вилучити ключ «%s»"
 
-#: ../src/msw/iniconf.cpp:458
+#: ../src/msw/iniconf.cpp:455
 #, c-format
 msgid "Can't delete the INI file '%s'"
 msgstr "Не вдалося вилучити INI-файл «%s»"
 
-#: ../src/msw/registry.cpp:805
+#: ../src/msw/registry.cpp:793
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Не вдалося вилучити значення «%s» ключа «%s»"
 
-#: ../src/msw/registry.cpp:1171
+#: ../src/msw/registry.cpp:1159
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Не вдалося підрахувати підключі ключа «%s»"
 
-#: ../src/msw/registry.cpp:1132
+#: ../src/msw/registry.cpp:1120
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Не вдалося підрахувати значення ключа «%s»"
 
-#: ../src/msw/registry.cpp:1389
+#: ../src/msw/registry.cpp:1377
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Не вдалося експортувати значення непідтримуваного типу %d."
 
-#: ../src/common/ffile.cpp:254
+#: ../src/common/ffile.cpp:253
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Не можу знайти теперішню позицію в файлі «%s»"
 
-#: ../src/msw/registry.cpp:418
+#: ../src/msw/registry.cpp:407
 #, c-format
 msgid "Can't get info about registry key '%s'"
 msgstr "Не вдалося отримати інформацію про ключ реєстру «%s»"
 
-#: ../src/common/zstream.cpp:346
+#: ../src/msw/webview_ie.cpp:1024
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "Не вдалося встановити пріоритет нитки"
+
+#: ../src/common/zstream.cpp:343
 msgid "Can't initialize zlib deflate stream."
 msgstr "Не вдалося ініціювати потік стиснення zlib."
 
-#: ../src/common/zstream.cpp:185
+#: ../src/common/zstream.cpp:182
 msgid "Can't initialize zlib inflate stream."
 msgstr "Не вдалося ініціювати потік розпакування zlib."
 
-#: ../src/msw/fswatcher.cpp:476
+#: ../src/msw/fswatcher.cpp:475
 #, c-format
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "Спостереження за змінами у каталозі «%s», якого не існує, неможливе."
 
-#: ../src/msw/registry.cpp:454
+#: ../src/msw/registry.cpp:443
 #, c-format
 msgid "Can't open registry key '%s'"
 msgstr "Не вдалося відкрити ключ реєстру «%s»"
 
-#: ../src/common/zstream.cpp:252
+#: ../src/common/zstream.cpp:249
 #, c-format
 msgid "Can't read from inflate stream: %s"
 msgstr "Не вдалося прочитати з потоку розпакування %s"
 
-#: ../src/common/zstream.cpp:244
+#: ../src/common/zstream.cpp:241
 msgid "Can't read inflate stream: unexpected EOF in underlying stream."
 msgstr ""
 "Не вдалося прочитати потік, що розширюється: неочікуваний кінець файла у "
 "підлеглому потоці."
 
-#: ../src/msw/registry.cpp:1064
+#: ../src/msw/registry.cpp:1052
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Не вдалося прочитати значення «%s»"
 
-#: ../src/msw/registry.cpp:878 ../src/msw/registry.cpp:910
-#: ../src/msw/registry.cpp:975
+#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
+#: ../src/msw/registry.cpp:963
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Не вдалося прочитати значення ключа «%s»"
 
-#: ../src/common/image.cpp:2620
+#: ../src/msw/webview_ie.cpp:1017
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/common/image.cpp:2715
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "Не вдалося записати зображення до файла «%s»: невідомий суфікс назви."
 
-#: ../src/generic/logg.cpp:573 ../src/generic/logg.cpp:976
+#: ../src/generic/logg.cpp:570 ../src/generic/logg.cpp:973
 msgid "Can't save log contents to file."
 msgstr "Не можу записати вміст журналу в файл."
 
-#: ../src/msw/thread.cpp:629
+#: ../src/msw/thread.cpp:621
 msgid "Can't set thread priority"
 msgstr "Не вдалося встановити пріоритет нитки"
 
-#: ../src/msw/registry.cpp:896 ../src/msw/registry.cpp:938
-#: ../src/msw/registry.cpp:1081
+#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
+#: ../src/msw/registry.cpp:1069
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Не вдалося встановити значення «%s»"
 
-#: ../src/unix/utilsunx.cpp:351
+#: ../src/unix/utilsunx.cpp:353
 msgid "Can't write to child process's stdin"
 msgstr "Запис до стандартного входу дочірнього процесу неможливий"
 
-#: ../src/common/zstream.cpp:427
+#: ../src/common/zstream.cpp:424
 #, c-format
 msgid "Can't write to deflate stream: %s"
 msgstr "Не вдалося записати до потоку розпакування: %s"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:279 ../src/richtext/richtextstyledlg.cpp:300
-#: ../src/common/stockitem.cpp:145 ../src/common/accelcmn.cpp:71
-#: ../src/msw/msgdlg.cpp:454 ../src/msw/progdlg.cpp:673
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:142
+#: ../src/common/accelcmn.cpp:68 ../src/motif/msgdlg.cpp:196
+#: ../src/gtk1/fontdlg.cpp:144 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/progdlg.cpp:940 ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Скасувати"
 
-#: ../src/common/filefn.cpp:1261
+#: ../src/common/filefn.cpp:1149
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Не можу перелічити файли «%s»"
 
-#: ../src/msw/dir.cpp:263
+#: ../src/msw/dir.cpp:260
 #, c-format
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Не можу перелічити файли в каталозі «%s»"
 
-#: ../src/msw/dialup.cpp:523
+#: ../src/msw/dialup.cpp:517
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Не вдалося знайти активне модемне з'єднання: %s"
 
-#: ../src/msw/dialup.cpp:827
+#: ../src/msw/dialup.cpp:821
 msgid "Cannot find the location of address book file"
 msgstr "Файл з адресною книгою не знайдений"
 
-#: ../src/msw/ole/automtn.cpp:562
+#: ../src/msw/ole/automtn.cpp:553
 #, c-format
 msgid "Cannot get an active instance of \"%s\""
 msgstr "Не вдалося отримати дані активного екземпляра «%s»"
 
-#: ../src/unix/threadpsx.cpp:1035
+#: ../src/unix/threadpsx.cpp:1053
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "Не вдалося отримати інтервал пріоритету для розпорядку %d."
 
-#: ../src/unix/utilsunx.cpp:987
+#: ../src/unix/utilsunx.cpp:989
 msgid "Cannot get the hostname"
 msgstr "Не вдалося отримати назву вузла"
 
-#: ../src/unix/utilsunx.cpp:1023
+#: ../src/unix/utilsunx.cpp:1025
 msgid "Cannot get the official hostname"
 msgstr "Не вдалося отримати офіційне назву вузла"
 
-#: ../src/msw/dialup.cpp:928
+#: ../src/msw/dialup.cpp:922
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Не вдалося повісити трубку — немає з'єднання."
 
@@ -1838,127 +1843,127 @@ msgstr "Не вдалося повісити трубку — немає з'єд
 msgid "Cannot initialize OLE"
 msgstr "Не вдалося ініціювати OLE"
 
-#: ../src/common/socket.cpp:853
+#: ../src/common/socket.cpp:850
 msgid "Cannot initialize sockets"
 msgstr "Не вдалося ініціювати сокети"
 
-#: ../src/msw/volume.cpp:619
+#: ../src/msw/volume.cpp:627
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Не вдалося завантажити піктограму з «%s»."
 
-#: ../src/xrc/xmlres.cpp:360
+#: ../src/xrc/xmlres.cpp:358
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Не вдалося завантажити ресурси з «%s»."
 
-#: ../src/xrc/xmlres.cpp:742
+#: ../src/xrc/xmlres.cpp:740
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Не вдалося завантажити ресурси з файла «%s»."
 
-#: ../src/html/htmlfilt.cpp:137
+#: ../src/html/htmlfilt.cpp:134
 #, c-format
 msgid "Cannot open HTML document: %s"
 msgstr "Не вдалося відкрити документ HTML: %s"
 
-#: ../src/html/helpdata.cpp:667
+#: ../src/html/helpdata.cpp:660
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Не вдалося відкрити книгу довідки HTML: %s"
 
-#: ../src/html/helpdata.cpp:299
+#: ../src/html/helpdata.cpp:296
 #, c-format
 msgid "Cannot open contents file: %s"
 msgstr "Не вдалося відкрити файл змісту: %s"
 
-#: ../src/generic/dcpsg.cpp:1667
+#: ../src/generic/dcpsg.cpp:1665
 msgid "Cannot open file for PostScript printing!"
 msgstr "Не вдалося відкрити файл для друку в PostScript!"
 
-#: ../src/html/helpdata.cpp:313
+#: ../src/html/helpdata.cpp:310
 #, c-format
 msgid "Cannot open index file: %s"
 msgstr "Не вдалося відкрити файл індексу: %s"
 
-#: ../src/xrc/xmlres.cpp:724
+#: ../src/xrc/xmlres.cpp:722
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Не вдалося відкрити файл ресурсів «%s»."
 
-#: ../src/html/helpwnd.cpp:1534
+#: ../src/html/helpwnd.cpp:1532
 msgid "Cannot print empty page."
 msgstr "Не вдалося надрукувати порожню сторінку."
 
-#: ../src/msw/volume.cpp:507
+#: ../src/msw/volume.cpp:515
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Не вдалося прочитати назву типу з «%s»!"
 
-#: ../src/msw/thread.cpp:888
+#: ../src/msw/thread.cpp:894
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Не вдалося відновити нитку %lx"
 
-#: ../src/unix/threadpsx.cpp:1016
+#: ../src/unix/threadpsx.cpp:1028
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Не вдалося встановити порядок нитки."
 
-#: ../src/common/intl.cpp:558
+#: ../src/common/intl.cpp:365
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "Не вдалося встановити локаль у значення «%s»."
 
-#: ../src/unix/threadpsx.cpp:831 ../src/msw/thread.cpp:546
+#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
 msgid "Cannot start thread: error writing TLS."
 msgstr "Не вдалося запустити нитку: помилка запису TLS."
 
-#: ../src/msw/thread.cpp:872
+#: ../src/msw/thread.cpp:864
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Не вдалося зупинити нитку %lx"
 
-#: ../src/msw/thread.cpp:794
+#: ../src/msw/thread.cpp:786
 msgid "Cannot wait for thread termination"
 msgstr "Не вдалося дочекатись закінчення нитки"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:75
+#: ../src/common/accelcmn.cpp:72
 #, fuzzy
 msgid "Capital"
 msgstr "Пр&описні"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:879
+#: ../src/propgrid/advprops.cpp:780
 msgid "CaptionText"
 msgstr "ТекстЗаголовка"
 
-#: ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:531
 msgid "Case sensitive"
 msgstr "З врахуванням регістру"
 
-#: ../src/propgrid/manager.cpp:1509
+#: ../src/propgrid/manager.cpp:1527
 msgid "Categorized Mode"
 msgstr "Режим з категоризацією"
 
-#: ../src/richtext/richtextbuffer.cpp:9968
+#: ../src/richtext/richtextbuffer.cpp:9965
 msgid "Cell Properties"
 msgstr "Властивості комірки"
 
-#: ../src/common/fmapbase.cpp:161
+#: ../src/common/fmapbase.cpp:158
 msgid "Celtic (ISO-8859-14)"
 msgstr "Кельтська (ISO-8859-13)"
 
-#: ../src/richtext/richtextindentspage.cpp:160
 #: ../src/richtext/richtextliststylepage.cpp:349
+#: ../src/richtext/richtextindentspage.cpp:160
 msgid "Cen&tred"
 msgstr "Цент&роване"
 
-#: ../src/common/stockitem.cpp:170
+#: ../src/common/stockitem.cpp:167
 msgid "Centered"
 msgstr "Центроване"
 
-#: ../src/common/fmapbase.cpp:149
+#: ../src/common/fmapbase.cpp:146
 msgid "Central European (ISO-8859-2)"
 msgstr "Центральний європейський (ISO-8859-2)"
 
@@ -1967,10 +1972,10 @@ msgstr "Центральний європейський (ISO-8859-2)"
 msgid "Centre"
 msgstr "Центр"
 
-#: ../src/richtext/richtextindentspage.cpp:162
-#: ../src/richtext/richtextindentspage.cpp:164
 #: ../src/richtext/richtextliststylepage.cpp:351
 #: ../src/richtext/richtextliststylepage.cpp:353
+#: ../src/richtext/richtextindentspage.cpp:162
+#: ../src/richtext/richtextindentspage.cpp:164
 msgid "Centre text."
 msgstr "Текст по центру."
 
@@ -1983,24 +1988,24 @@ msgstr "За центром"
 msgid "Ch&oose..."
 msgstr "Об&рати…"
 
-#: ../src/richtext/richtextbuffer.cpp:4354
+#: ../src/richtext/richtextbuffer.cpp:4351
 msgid "Change List Style"
 msgstr "Змінити стиль списку"
 
-#: ../src/richtext/richtextbuffer.cpp:3709
+#: ../src/richtext/richtextbuffer.cpp:3706
 msgid "Change Object Style"
 msgstr "Змінити стиль об’єкта"
 
-#: ../src/richtext/richtextbuffer.cpp:3982
-#: ../src/richtext/richtextbuffer.cpp:8129
+#: ../src/richtext/richtextbuffer.cpp:3979
+#: ../src/richtext/richtextbuffer.cpp:8125
 msgid "Change Properties"
 msgstr "Змінити властивості"
 
-#: ../src/richtext/richtextbuffer.cpp:3526
+#: ../src/richtext/richtextbuffer.cpp:3523
 msgid "Change Style"
 msgstr "Змінити стиль"
 
-#: ../src/common/fileconf.cpp:341
+#: ../src/common/fileconf.cpp:335
 #, c-format
 msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
 msgstr "Зміни не буде збережено, щоб уникнути перезапису наявного файла «%s»"
@@ -2011,12 +2016,12 @@ msgid "Changing current directory to \"%s\" failed"
 msgstr "Не вдалося створити теку «%s»"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1757
+#: ../src/propgrid/advprops.cpp:1658
 #, fuzzy
 msgid "Character"
 msgstr "Код &символу:"
 
-#: ../src/richtext/richtextstyles.cpp:1063
+#: ../src/richtext/richtextstyles.cpp:1060
 msgid "Character styles"
 msgstr "Стиль символів"
 
@@ -2054,20 +2059,20 @@ msgid "Check to indicate right-to-left text layout."
 msgstr ""
 "Позначте, щоб визначити використання писемності із записом справа ліворуч."
 
-#: ../src/osx/carbon/fontdlg.cpp:356 ../src/osx/carbon/fontdlg.cpp:358
+#: ../src/osx/carbon/fontdlg.cpp:353 ../src/osx/carbon/fontdlg.cpp:355
 msgid "Check to make the font bold."
 msgstr "Позначте, щоб зробити шрифт жирним."
 
-#: ../src/osx/carbon/fontdlg.cpp:363 ../src/osx/carbon/fontdlg.cpp:365
+#: ../src/osx/carbon/fontdlg.cpp:360 ../src/osx/carbon/fontdlg.cpp:362
 msgid "Check to make the font italic."
 msgstr "Позначте, щоб зробити шрифт курсивним."
 
-#: ../src/osx/carbon/fontdlg.cpp:372 ../src/osx/carbon/fontdlg.cpp:374
+#: ../src/osx/carbon/fontdlg.cpp:369 ../src/osx/carbon/fontdlg.cpp:371
 msgid "Check to make the font underlined."
 msgstr "Позначте, щоб зробити шрифт підкресленим."
 
-#: ../src/richtext/richtextstyledlg.cpp:289
-#: ../src/richtext/richtextstyledlg.cpp:291
+#: ../src/richtext/richtextstyledlg.cpp:285
+#: ../src/richtext/richtextstyledlg.cpp:287
 msgid "Check to restart numbering."
 msgstr "Позначте, щоб знову розпочати нумерацію."
 
@@ -2101,51 +2106,51 @@ msgstr "Позначте, щоб перетворити текст на верх
 msgid "Check to suppress hyphenation."
 msgstr "Позначте, щоб придушити перенесення слів."
 
-#: ../src/msw/dialup.cpp:763
+#: ../src/msw/dialup.cpp:757
 msgid "Choose ISP to dial"
 msgstr "Оберіть інтернет провайдера"
 
-#: ../src/propgrid/props.cpp:1922
+#: ../src/propgrid/props.cpp:1904
 msgid "Choose a directory:"
 msgstr "Виберіть каталог:"
 
-#: ../src/propgrid/props.cpp:1975
+#: ../src/propgrid/props.cpp:2199
 msgid "Choose a file"
 msgstr "Виберіть файл"
 
-#: ../src/generic/colrdlgg.cpp:158 ../src/gtk/colordlg.cpp:54
+#: ../src/generic/colrdlgg.cpp:156 ../src/gtk/colordlg.cpp:49
 msgid "Choose colour"
 msgstr "Оберіть колір"
 
-#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/gtk1/fontdlg.cpp:125 ../src/generic/fontpickerg.cpp:47
+#: ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Виберіть шрифт"
 
-#: ../src/common/module.cpp:74
+#: ../src/common/module.cpp:71
 #, c-format
 msgid "Circular dependency involving module \"%s\" detected."
 msgstr "Виявлено циклічну залежність, що містить модуль «%s»."
 
-#: ../src/aui/tabmdi.cpp:108 ../src/generic/mdig.cpp:97
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
 msgid "Cl&ose"
 msgstr "Закрити"
 
-#: ../src/msw/ole/automtn.cpp:684
+#: ../src/msw/ole/automtn.cpp:675
 msgid "Class not registered."
 msgstr "Клас не зареєстровано."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:147 ../src/common/accelcmn.cpp:72
+#: ../src/common/stockitem.cpp:144 ../src/common/accelcmn.cpp:69
 msgid "Clear"
 msgstr "Спорожнити"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "Clear the log contents"
 msgstr "Почистити записи в журналі"
 
-#: ../src/richtext/richtextstyledlg.cpp:252
-#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:248
+#: ../src/richtext/richtextstyledlg.cpp:250
 msgid "Click to apply the selected style."
 msgstr "Клацніть, щоб застосувати обраний стиль."
 
@@ -2156,15 +2161,15 @@ msgstr "Клацніть, щоб застосувати обраний стил�
 msgid "Click to browse for a symbol."
 msgstr "Клацніть, щоб відшукати символ."
 
-#: ../src/osx/carbon/fontdlg.cpp:403 ../src/osx/carbon/fontdlg.cpp:405
+#: ../src/osx/carbon/fontdlg.cpp:400 ../src/osx/carbon/fontdlg.cpp:402
 msgid "Click to cancel changes to the font."
 msgstr "Клацніть, щоб скасувати зміну шрифту."
 
-#: ../src/generic/fontdlgg.cpp:472 ../src/generic/fontdlgg.cpp:491
+#: ../src/generic/fontdlgg.cpp:468 ../src/generic/fontdlgg.cpp:487
 msgid "Click to cancel the font selection."
 msgstr "Клацніть, щоб скасувати вибір шрифту."
 
-#: ../src/osx/carbon/fontdlg.cpp:384 ../src/osx/carbon/fontdlg.cpp:386
+#: ../src/osx/carbon/fontdlg.cpp:381 ../src/osx/carbon/fontdlg.cpp:383
 msgid "Click to change the font colour."
 msgstr "Клацніть, щоб змінити колір шрифту."
 
@@ -2183,37 +2188,37 @@ msgstr "Клацніть, щоб змінити колір тексту."
 msgid "Click to choose the font for this level."
 msgstr "Клацніть, щоб обрати шрифт для цього рівня."
 
-#: ../src/richtext/richtextstyledlg.cpp:279
-#: ../src/richtext/richtextstyledlg.cpp:281
+#: ../src/richtext/richtextstyledlg.cpp:275
+#: ../src/richtext/richtextstyledlg.cpp:277
 msgid "Click to close this window."
 msgstr "Клацніть, щоб закрити це вікно"
 
-#: ../src/osx/carbon/fontdlg.cpp:410 ../src/osx/carbon/fontdlg.cpp:412
+#: ../src/osx/carbon/fontdlg.cpp:407 ../src/osx/carbon/fontdlg.cpp:409
 msgid "Click to confirm changes to the font."
 msgstr "Клацніть, щоб підтвердити зміну шрифту."
 
-#: ../src/generic/fontdlgg.cpp:477 ../src/generic/fontdlgg.cpp:479
-#: ../src/generic/fontdlgg.cpp:484 ../src/generic/fontdlgg.cpp:486
+#: ../src/generic/fontdlgg.cpp:473 ../src/generic/fontdlgg.cpp:475
+#: ../src/generic/fontdlgg.cpp:480 ../src/generic/fontdlgg.cpp:482
 msgid "Click to confirm the font selection."
 msgstr "Клацніть, щоб підтвердити вибір шрифту."
 
-#: ../src/richtext/richtextstyledlg.cpp:244
-#: ../src/richtext/richtextstyledlg.cpp:246
+#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:242
 msgid "Click to create a new box style."
 msgstr "Клацніть, щоб створити новий стиль панелі."
 
-#: ../src/richtext/richtextstyledlg.cpp:226
-#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:224
 msgid "Click to create a new character style."
 msgstr "Клацніть, щоб створити новий стиль символів."
 
-#: ../src/richtext/richtextstyledlg.cpp:238
-#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:236
 msgid "Click to create a new list style."
 msgstr "Клацніть, щоб створити новий стиль списку."
 
-#: ../src/richtext/richtextstyledlg.cpp:232
-#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:230
 msgid "Click to create a new paragraph style."
 msgstr "Клацніть, щоб створити новий стиль абзацу."
 
@@ -2227,8 +2232,8 @@ msgstr "Клацніть, щоб створити нову позицію таб
 msgid "Click to delete all tab positions."
 msgstr "Клацніть, щоб вилучити всі позиції табуляції."
 
-#: ../src/richtext/richtextstyledlg.cpp:270
-#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:268
 msgid "Click to delete the selected style."
 msgstr "Клацніть, щоб вилучити обраний стиль."
 
@@ -2237,25 +2242,25 @@ msgstr "Клацніть, щоб вилучити обраний стиль."
 msgid "Click to delete the selected tab position."
 msgstr "Клацніть, щоб вилучити обрану позицію табуляції."
 
-#: ../src/richtext/richtextstyledlg.cpp:264
-#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:262
 msgid "Click to edit the selected style."
 msgstr "Клацніть, щоб редагувати обраний стиль."
 
-#: ../src/richtext/richtextstyledlg.cpp:258
-#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:256
 msgid "Click to rename the selected style."
 msgstr "Клацніть, щоб перейменувати обраний стиль."
 
-#: ../src/generic/dbgrptg.cpp:97 ../src/generic/progdlgg.cpp:759
-#: ../src/richtext/richtextstyledlg.cpp:277
-#: ../src/richtext/richtextsymboldlg.cpp:476 ../src/common/stockitem.cpp:148
-#: ../src/msw/progdlg.cpp:170 ../src/msw/progdlg.cpp:679
-#: ../src/html/helpdlg.cpp:90
+#: ../src/common/stockitem.cpp:145 ../src/generic/dbgrptg.cpp:94
+#: ../src/generic/progdlgg.cpp:781 ../src/msw/progdlg.cpp:211
+#: ../src/msw/progdlg.cpp:946 ../src/html/helpdlg.cpp:87
+#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextstyledlg.cpp:273
 msgid "Close"
 msgstr "Закрити"
 
-#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:98
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
 msgid "Close All"
 msgstr "Закрити все"
 
@@ -2263,43 +2268,43 @@ msgstr "Закрити все"
 msgid "Close current document"
 msgstr "Закрити поточний документ"
 
-#: ../src/generic/logg.cpp:516
+#: ../src/generic/logg.cpp:513
 msgid "Close this window"
 msgstr "Закрити це вікно"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6006
+#: ../src/generic/datavgen.cpp:6811
 msgid "Collapse"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "Color"
 msgstr "Колір"
 
-#: ../src/richtext/richtextformatdlg.cpp:776
+#: ../src/richtext/richtextformatdlg.cpp:768
 msgid "Colour"
 msgstr "Колір"
 
-#: ../src/msw/colordlg.cpp:158
+#: ../src/msw/colordlg.cpp:227
 #, c-format
 msgid "Colour selection dialog failed with error %0lx."
 msgstr "Діалогове вікно вибору кольору повідомило про помилку %0lx."
 
-#: ../src/osx/carbon/fontdlg.cpp:380
+#: ../src/osx/carbon/fontdlg.cpp:377
 msgid "Colour:"
 msgstr "Колір:"
 
-#: ../src/generic/datavgen.cpp:6077
+#: ../src/generic/datavgen.cpp:6882
 #, fuzzy, c-format
 msgid "Column %u"
 msgstr "Додати стовпчик"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:114
+#: ../src/common/accelcmn.cpp:112
 msgid "Command"
 msgstr ""
 
-#: ../src/common/init.cpp:196
+#: ../src/common/init.cpp:193
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
@@ -2308,12 +2313,12 @@ msgstr ""
 "Не вдалося перетворити параметр командного рядка %d у Unicode, параметр буде "
 "проігноровано."
 
-#: ../src/msw/fontdlg.cpp:120
+#: ../src/msw/fontdlg.cpp:170
 #, c-format
 msgid "Common dialog failed with error code %0lx."
 msgstr "Помилка типового діалогового вікна з кодом %0lx."
 
-#: ../src/gtk/window.cpp:4649
+#: ../src/gtk/window.cpp:5653
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
@@ -2322,11 +2327,11 @@ msgstr ""
 "ласка, увімкніть композитне відтворення у вашій програмі для керування "
 "вікнами."
 
-#: ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:1549
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Стиснутий файл довідки HTML (*.chm)|*.chm|"
 
-#: ../src/generic/dirctrlg.cpp:444
+#: ../src/generic/dirctrlg.cpp:410
 msgid "Computer"
 msgstr "Комп'ютер"
 
@@ -2335,53 +2340,57 @@ msgstr "Комп'ютер"
 msgid "Config entry name cannot start with '%c'."
 msgstr "Назва поля в файлі налаштування не може починатися з «%c»."
 
-#: ../src/generic/filedlgg.cpp:349 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
 msgid "Confirm"
 msgstr "Підтвердити"
 
-#: ../src/html/htmlwin.cpp:566
+#: ../src/html/htmlwin.cpp:569
 msgid "Connecting..."
 msgstr "Під'єднання…"
 
-#: ../src/html/helpwnd.cpp:475
+#: ../src/html/helpwnd.cpp:473
 msgid "Contents"
 msgstr "Зміст"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:880
+#: ../src/propgrid/advprops.cpp:781
 msgid "ControlDark"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:881
+#: ../src/propgrid/advprops.cpp:782
 msgid "ControlLight"
 msgstr ""
 
-#: ../src/common/strconv.cpp:2262
+#: ../src/common/strconv.cpp:2208
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Перетворення до набору символів «%s» не працює."
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "Convert"
 msgstr "Перетворити"
 
-#: ../src/html/htmlwin.cpp:1079
+#: ../src/html/htmlwin.cpp:1020
 #, c-format
 msgid "Copied to clipboard:\"%s\""
 msgstr "Скопійовано до буфера: «%s»"
 
-#: ../src/generic/prntdlgg.cpp:247
+#: ../src/generic/prntdlgg.cpp:240
 msgid "Copies:"
 msgstr "Копії:"
 
-#: ../src/common/stockitem.cpp:150 ../src/stc/stc_i18n.cpp:18
+#: ../src/common/stockitem.cpp:147 ../src/stc/stc_i18n.cpp:18
 msgid "Copy"
 msgstr "Копіювати"
 
-#: ../src/common/stockitem.cpp:258
+#: ../src/common/stockitem.cpp:255
 msgid "Copy selection"
 msgstr "Копіювати позначене"
+
+#: ../src/generic/grid.cpp:5945
+msgid "Copying more than one selected block to clipboard is not supported."
+msgstr ""
 
 #: ../src/richtext/richtextborderspage.cpp:566
 #: ../src/richtext/richtextborderspage.cpp:601
@@ -2392,199 +2401,195 @@ msgstr "Кут"
 msgid "Corner &radius:"
 msgstr "&Радіус закруглення:"
 
-#: ../src/html/chm.cpp:718
+#: ../src/html/chm.cpp:711
 #, c-format
 msgid "Could not create temporary file '%s'"
 msgstr "Не вдалося створити тимчасовий файл «%s»"
 
-#: ../src/html/chm.cpp:273
+#: ../src/html/chm.cpp:270
 #, c-format
 msgid "Could not extract %s into %s: %s"
 msgstr "Не вдалося розпакувати %s до %s: %s"
 
-#: ../src/generic/tabg.cpp:1048
+#: ../src/generic/tabg.cpp:1045
 msgid "Could not find tab for id"
 msgstr "Не вдалося знайти вкладку для ідентифікатора"
 
-#: ../src/gtk/notifmsg.cpp:108
-#, fuzzy
-msgid "Could not initalize libnotify."
-msgstr "Не вдалося встановити вирівнювання."
-
-#: ../src/html/chm.cpp:444
+#: ../src/html/chm.cpp:437
 #, c-format
 msgid "Could not locate file '%s'."
 msgstr "Не вдалося знайти розташування файла «%s»."
 
-#: ../src/common/filefn.cpp:1403
+#: ../src/msw/graphicsd2d.cpp:604
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/common/filefn.cpp:1291
 msgid "Could not set current working directory"
 msgstr "Не вдалося вказати поточний робочий каталог"
 
-#: ../src/common/prntbase.cpp:2015
+#: ../src/common/prntbase.cpp:2037
 msgid "Could not start document preview."
 msgstr "Не вдалося почати попередній перегляд документа."
 
-#: ../src/generic/printps.cpp:178 ../src/msw/printwin.cpp:210
-#: ../src/gtk/print.cpp:1132
+#: ../src/generic/printps.cpp:159 ../src/msw/printwin.cpp:184
+#: ../src/gtk/print.cpp:1129
 msgid "Could not start printing."
 msgstr "Не вдалося почати друк."
 
-#: ../src/common/wincmn.cpp:2125
+#: ../src/common/wincmn.cpp:2126
 msgid "Could not transfer data to window"
 msgstr "Не вдалося передати дані в вікно"
 
-#: ../src/msw/imaglist.cpp:187 ../src/msw/imaglist.cpp:224
-#: ../src/msw/imaglist.cpp:249 ../src/msw/dragimag.cpp:185
-#: ../src/msw/dragimag.cpp:220
+#: ../src/msw/imaglist.cpp:223 ../src/msw/imaglist.cpp:245
+#: ../src/msw/imaglist.cpp:270 ../src/msw/dragimag.cpp:182
+#: ../src/msw/dragimag.cpp:217
 msgid "Couldn't add an image to the image list."
 msgstr "Не вдалося додати зображення до списку зображень."
 
-#: ../src/osx/glcanvas_osx.cpp:414 ../src/unix/glx11.cpp:558
-#: ../src/msw/glcanvas.cpp:616
+#: ../src/osx/glcanvas_osx.cpp:411 ../src/msw/glcanvas.cpp:631
+#: ../src/unix/glegl.cpp:315 ../src/unix/glx11.cpp:559
 #, fuzzy
 msgid "Couldn't create OpenGL context"
 msgstr "Не вдалося створити таймер"
 
-#: ../src/msw/timer.cpp:134
+#: ../src/msw/timer.cpp:131
 msgid "Couldn't create a timer"
 msgstr "Не вдалося створити таймер"
 
-#: ../src/osx/carbon/overlay.cpp:122
-msgid "Couldn't create the overlay window"
-msgstr "Не вдалося створити вікно оверлею"
-
-#: ../src/common/translation.cpp:2024
+#: ../src/common/translation.cpp:2074
 msgid "Couldn't enumerate translations"
 msgstr "Не вдалося пронумерувати переклади"
 
-#: ../src/common/dynlib.cpp:120
+#: ../src/common/dynlib.cpp:110
 #, c-format
 msgid "Couldn't find symbol '%s' in a dynamic library"
 msgstr "Не вдалося знайти символ «%s» в динамічній бібліотеці"
 
-#: ../src/msw/thread.cpp:915
+#: ../src/msw/thread.cpp:921
 msgid "Couldn't get the current thread pointer"
 msgstr "Не вдалося отримати показник на дану нитку"
 
-#: ../src/osx/carbon/overlay.cpp:129
-msgid "Couldn't init the context on the overlay window"
-msgstr "Не вдалося ініціювати контекст вікна оверлею"
-
-#: ../src/common/imaggif.cpp:244
+#: ../src/common/imaggif.cpp:241
 msgid "Couldn't initialize GIF hash table."
 msgstr "Не вдалося ініціалізувати таблицю хешів GIF."
 
-#: ../src/common/imagpng.cpp:409
+#: ../src/common/imagpng.cpp:437
 msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
 msgstr ""
 "Не вдалося завантажити зображення PNG. Можливо файл пошкоджено або не "
 "вистачає пам'яті."
 
-#: ../src/unix/sound.cpp:470
+#: ../src/unix/sound.cpp:459
 #, c-format
 msgid "Couldn't load sound data from '%s'."
 msgstr "Не вдалося завантажити піктограму з «%s»."
 
-#: ../src/msw/dirdlg.cpp:435
+#: ../src/msw/dirdlg.cpp:287
 msgid "Couldn't obtain folder name"
 msgstr "Не вдалося отримати назву теки"
 
-#: ../src/unix/sound_sdl.cpp:229
+#: ../src/unix/sound_sdl.cpp:226
 #, c-format
 msgid "Couldn't open audio: %s"
 msgstr "Не вдалося відкрити аудіо: «%s»"
 
-#: ../src/msw/ole/dataobj.cpp:377
+#: ../src/msw/ole/dataobj.cpp:385
 #, c-format
 msgid "Couldn't register clipboard format '%s'."
 msgstr "Не вдалося зареєструвати формат «%s»"
 
-#: ../src/msw/listctrl.cpp:869
+#: ../src/msw/listctrl.cpp:933
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "Не вдалося встановити інформацію про елемент списку %d."
 
-#: ../src/common/imagpng.cpp:498 ../src/common/imagpng.cpp:509
-#: ../src/common/imagpng.cpp:519
+#: ../src/common/imagpng.cpp:511 ../src/common/imagpng.cpp:522
+#: ../src/common/imagpng.cpp:532
 msgid "Couldn't save PNG image."
 msgstr "Не вдалося записати зображення PNG."
 
-#: ../src/msw/thread.cpp:684
+#: ../src/msw/thread.cpp:676
 msgid "Couldn't terminate thread"
 msgstr "Не вдалося закінчити нитку"
 
-#: ../src/common/xtistrm.cpp:166
+#: ../src/common/xtistrm.cpp:163
 #, c-format
 msgid "Create Parameter %s not found in declared RTTI Parameters"
 msgstr "Параметр Create %s не знайдено серед описаних параметрів RTTI"
 
-#: ../src/generic/dirdlgg.cpp:288
+#: ../src/generic/dirdlgg.cpp:285
 msgid "Create directory"
 msgstr "Створити каталог"
 
-#: ../src/generic/filedlgg.cpp:212 ../src/generic/dirdlgg.cpp:111
+#: ../src/generic/filedlgg.cpp:209 ../src/generic/dirdlgg.cpp:108
 msgid "Create new directory"
 msgstr "Створити новий каталог"
 
-#: ../src/xrc/xmlres.cpp:2460
+#: ../src/common/stockitem.cpp:264
+#, fuzzy
+msgid "Create new document"
+msgstr "Створити новий каталог"
+
+#: ../src/xrc/xmlres.cpp:2515
 #, fuzzy, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Розпакування «%s» до «%s» закінчилося з помилкою."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1758
+#: ../src/propgrid/advprops.cpp:1659
 msgid "Cross"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:333
+#: ../src/common/accelcmn.cpp:347
 msgid "Ctrl+"
 msgstr "Ctrl+"
 
-#: ../src/richtext/richtextctrl.cpp:332 ../src/osx/textctrl_osx.cpp:576
-#: ../src/common/stockitem.cpp:151 ../src/msw/textctrl.cpp:2507
+#: ../src/osx/textctrl_osx.cpp:594 ../src/common/stockitem.cpp:148
+#: ../src/msw/textctrl.cpp:2772 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "В&ирізати"
 
-#: ../src/generic/filectrlg.cpp:940
+#: ../src/generic/filectrlg.cpp:936
 msgid "Current directory:"
 msgstr "Поточний каталог:"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:896 ../src/propgrid/advprops.cpp:1574
-#: ../src/propgrid/advprops.cpp:1612
+#: ../src/propgrid/advprops.cpp:797 ../src/propgrid/advprops.cpp:1475
+#: ../src/propgrid/advprops.cpp:1518
 #, fuzzy
 msgid "Custom"
 msgstr "Нетиповий розмір"
 
-#: ../src/gtk/print.cpp:217
+#: ../src/gtk/print.cpp:211
 msgid "Custom size"
 msgstr "Нетиповий розмір"
 
-#: ../src/common/headerctrlcmn.cpp:60
+#: ../src/common/headerctrlcmn.cpp:58
 msgid "Customize Columns"
 msgstr "Налаштувати стовпчики"
 
-#: ../src/common/stockitem.cpp:151 ../src/stc/stc_i18n.cpp:17
+#: ../src/common/stockitem.cpp:148 ../src/stc/stc_i18n.cpp:17
 msgid "Cut"
 msgstr "Вирізати"
 
-#: ../src/common/stockitem.cpp:259
+#: ../src/common/stockitem.cpp:256
 msgid "Cut selection"
 msgstr "Вирізати позначене"
 
-#: ../src/common/fmapbase.cpp:152
+#: ../src/common/fmapbase.cpp:149
 msgid "Cyrillic (ISO-8859-5)"
 msgstr "Кирилиця (ISO-8859-5)"
 
-#: ../src/common/paper.cpp:99
+#: ../src/common/paper.cpp:96
 msgid "D sheet, 22 x 34 in"
 msgstr "Аркуш D, 22 x 34 дюйм"
 
-#: ../src/msw/dde.cpp:703
+#: ../src/msw/dde.cpp:698
 msgid "DDE poke request failed"
 msgstr "Помилка читання DDE"
 
-#: ../src/common/imagbmp.cpp:1169
+#: ../src/common/imagbmp.cpp:1181
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr "Заголовок DIB: Кодування не відповідає глибині бітів."
 
@@ -2604,7 +2609,7 @@ msgstr "Заголовок DIB: невідома бітова глибина д�
 msgid "DIB Header: Unknown encoding in file."
 msgstr "Заголовок DIB: невідоме кодування файла."
 
-#: ../src/common/paper.cpp:121
+#: ../src/common/paper.cpp:118
 msgid "DL Envelope, 110 x 220 mm"
 msgstr "DL Конверт, 110 x 220 мм"
 
@@ -2612,55 +2617,55 @@ msgstr "DL Конверт, 110 x 220 мм"
 msgid "Dashed"
 msgstr "Штрихова"
 
-#: ../src/generic/dbgrptg.cpp:300
+#: ../src/generic/dbgrptg.cpp:301
 #, c-format
 msgid "Debug report \"%s\""
 msgstr "Доповідь про помилку «%s»"
 
-#: ../src/common/debugrpt.cpp:210
+#: ../src/common/debugrpt.cpp:211
 msgid "Debug report couldn't be created."
 msgstr "Звіт про помилку неможливо створити."
 
-#: ../src/common/debugrpt.cpp:553
+#: ../src/common/debugrpt.cpp:554
 msgid "Debug report generation has failed."
 msgstr "Помилка під час створення звіту про помилку."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:84
+#: ../src/common/accelcmn.cpp:81
 msgid "Decimal"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:323
+#: ../src/generic/fontdlgg.cpp:319
 msgid "Decorative"
 msgstr "Декоративний"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1752
+#: ../src/propgrid/advprops.cpp:1653
 #, fuzzy
 msgid "Default"
 msgstr "типовий"
 
-#: ../src/common/fmapbase.cpp:796
+#: ../src/common/fmapbase.cpp:792
 msgid "Default encoding"
 msgstr "Типове кодування"
 
-#: ../src/dfb/fontmgr.cpp:180
+#: ../src/dfb/fontmgr.cpp:177
 msgid "Default font"
 msgstr "Типовий шрифт"
 
-#: ../src/generic/prntdlgg.cpp:510
+#: ../src/generic/prntdlgg.cpp:503
 msgid "Default printer"
 msgstr "Типова друкарка"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:51
+#: ../src/common/accelcmn.cpp:48
 #, fuzzy
 msgid "Del"
 msgstr "Вилучити"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextbuffer.cpp:8221 ../src/common/stockitem.cpp:152
-#: ../src/common/accelcmn.cpp:50 ../src/stc/stc_i18n.cpp:20
+#: ../src/common/stockitem.cpp:149 ../src/common/accelcmn.cpp:47
+#: ../src/richtext/richtextbuffer.cpp:8217 ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Вилучити"
 
@@ -2668,68 +2673,68 @@ msgstr "Вилучити"
 msgid "Delete A&ll"
 msgstr "Вилучити в&се"
 
-#: ../src/richtext/richtextbuffer.cpp:11341
+#: ../src/richtext/richtextbuffer.cpp:11340
 msgid "Delete Column"
 msgstr "Вилучити стовпчик"
 
-#: ../src/richtext/richtextbuffer.cpp:11291
+#: ../src/richtext/richtextbuffer.cpp:11290
 msgid "Delete Row"
 msgstr "Вилучити рядок"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 msgid "Delete Style"
 msgstr "Вилучити стиль"
 
-#: ../src/richtext/richtextctrl.cpp:1345 ../src/richtext/richtextctrl.cpp:1584
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
 msgid "Delete Text"
 msgstr "Вилучити текст"
 
-#: ../src/generic/editlbox.cpp:170
+#: ../src/generic/editlbox.cpp:147
 msgid "Delete item"
 msgstr "Вилучити елемент"
 
-#: ../src/common/stockitem.cpp:260
+#: ../src/common/stockitem.cpp:257
 msgid "Delete selection"
 msgstr "Вилучити позначене"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 #, c-format
 msgid "Delete style %s?"
 msgstr "Вилучити стиль %s?"
 
-#: ../src/unix/snglinst.cpp:301
+#: ../src/unix/snglinst.cpp:298
 #, c-format
 msgid "Deleted stale lock file '%s'."
 msgstr "Вилучено застарілий файл замка «%s»."
 
-#: ../src/common/secretstore.cpp:220
+#: ../src/common/secretstore.cpp:234
 #, fuzzy, c-format
-msgid "Deleting password for \"%s/%s\" failed: %s."
+msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Розпакування «%s» до «%s» закінчилося з помилкою."
 
-#: ../src/common/module.cpp:124
+#: ../src/common/module.cpp:121
 #, c-format
 msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
 msgstr "Необхідний компонент «%s» для модуля «%s» не існує."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "Descending"
 msgstr "За спаданням"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:526 ../src/propgrid/advprops.cpp:882
+#: ../src/generic/dirctrlg.cpp:492 ../src/propgrid/advprops.cpp:783
 msgid "Desktop"
 msgstr "Робочий стіл"
 
-#: ../src/generic/aboutdlgg.cpp:70
+#: ../src/generic/aboutdlgg.cpp:67
 msgid "Developed by "
 msgstr "Розроблено "
 
-#: ../src/generic/aboutdlgg.cpp:176
+#: ../src/generic/aboutdlgg.cpp:173
 msgid "Developers"
 msgstr "Розробники"
 
-#: ../src/msw/dialup.cpp:374
+#: ../src/msw/dialup.cpp:368
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -2737,11 +2742,11 @@ msgstr ""
 "Службу віддаленого з'єднання (RAS) на цьому комп’ютері не встановлено. Будь "
 "ласка, встановіть її."
 
-#: ../src/generic/tipdlg.cpp:211
+#: ../src/generic/tipdlg.cpp:208
 msgid "Did you know..."
 msgstr "А ви знали що…"
 
-#: ../src/dfb/wrapdfb.cpp:63
+#: ../src/dfb/wrapdfb.cpp:60
 #, c-format
 msgid "DirectFB error %d occurred."
 msgstr "У DirectFB сталася помилка %d."
@@ -2750,29 +2755,29 @@ msgstr "У DirectFB сталася помилка %d."
 msgid "Directories"
 msgstr "Теки"
 
-#: ../src/common/filefn.cpp:1183
+#: ../src/common/filefn.cpp:1071
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Не вдалося створити каталог «%s»"
 
-#: ../src/common/filefn.cpp:1197
+#: ../src/common/filefn.cpp:1085
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "Не вдалося вилучити каталог «%s»"
 
-#: ../src/generic/dirdlgg.cpp:204
+#: ../src/generic/dirdlgg.cpp:201
 msgid "Directory does not exist"
 msgstr "Каталог не існує"
 
-#: ../src/generic/filectrlg.cpp:1399
+#: ../src/generic/filectrlg.cpp:1388
 msgid "Directory doesn't exist."
 msgstr "Тека не існує."
 
-#: ../src/common/docview.cpp:457
+#: ../src/common/docview.cpp:450
 msgid "Discard changes and reload the last saved version?"
 msgstr "Відкинути зміни і перезавантажити останню збережену версію?"
 
-#: ../src/html/helpwnd.cpp:502
+#: ../src/html/helpwnd.cpp:500
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -2780,45 +2785,45 @@ msgstr ""
 "Вивести всі рядки індексу, що містять даний підрядок. Пошук без врахування \n"
 "регістру."
 
-#: ../src/html/helpwnd.cpp:679
+#: ../src/html/helpwnd.cpp:677
 msgid "Display options dialog"
 msgstr "Відкрити діалогове вікно параметрів"
 
-#: ../src/html/helpwnd.cpp:322
+#: ../src/html/helpwnd.cpp:320
 msgid "Displays help as you browse the books on the left."
 msgstr "Показує довідку у той час, коли ви гортаєте книжки ліворуч."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:85
+#: ../src/common/accelcmn.cpp:83
 msgid "Divide"
 msgstr ""
 
-#: ../src/common/docview.cpp:533
+#: ../src/common/docview.cpp:526
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Записати зміни до %s?"
 
-#: ../src/common/prntbase.cpp:542
+#: ../src/common/prntbase.cpp:537
 msgid "Document:"
 msgstr "Документ:"
 
-#: ../src/generic/aboutdlgg.cpp:73
+#: ../src/generic/aboutdlgg.cpp:70
 msgid "Documentation by "
 msgstr "Документація від "
 
-#: ../src/generic/aboutdlgg.cpp:180
+#: ../src/generic/aboutdlgg.cpp:177
 msgid "Documentation writers"
 msgstr "Автори документації"
 
-#: ../src/common/sizer.cpp:2799
+#: ../src/common/sizer.cpp:2916
 msgid "Don't Save"
 msgstr "Не зберігати"
 
-#: ../src/html/htmlwin.cpp:633
+#: ../src/html/htmlwin.cpp:643
 msgid "Done"
 msgstr "Зроблено"
 
-#: ../src/generic/progdlgg.cpp:448 ../src/msw/progdlg.cpp:407
+#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
 msgid "Done."
 msgstr "Зроблено."
 
@@ -2830,42 +2835,42 @@ msgstr "Пунктир"
 msgid "Double"
 msgstr "Подвійна"
 
-#: ../src/common/paper.cpp:176
+#: ../src/common/paper.cpp:173
 msgid "Double Japanese Postcard Rotated 148 x 200 mm"
 msgstr "Подвійна японська листівка повернута 148 x 200 мм"
 
-#: ../src/common/xtixml.cpp:273
+#: ../src/common/xtixml.cpp:269
 #, c-format
 msgid "Doubly used id : %d"
 msgstr "Двічі використаний id : %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:153
-#: ../src/common/accelcmn.cpp:64
+#: ../src/common/stockitem.cpp:150 ../src/common/accelcmn.cpp:61
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Down"
 msgstr "Донизу"
 
-#: ../src/richtext/richtextctrl.cpp:865
+#: ../src/richtext/richtextctrl.cpp:864
 msgid "Drag"
 msgstr "Перетягування"
 
-#: ../src/common/paper.cpp:100
+#: ../src/common/paper.cpp:97
 msgid "E sheet, 34 x 44 in"
 msgstr "E лист, 34 x 44 дюйм"
 
-#: ../src/unix/fswatcher_inotify.cpp:561
+#: ../src/unix/fswatcher_inotify.cpp:558
 msgid "EOF while reading from inotify descriptor"
 msgstr "Символ EOF під час читання з дескриптора inotify"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "Edit"
 msgstr "Змінити"
 
-#: ../src/generic/editlbox.cpp:168
+#: ../src/generic/editlbox.cpp:131
 msgid "Edit item"
 msgstr "Редагувати елемент"
 
-#: ../include/wx/generic/progdlgg.h:84
+#: ../include/wx/generic/progdlgg.h:85
 msgid "Elapsed time:"
 msgstr "Минуло часу:"
 
@@ -2937,50 +2942,50 @@ msgid "Enables the shadow spread."
 msgstr "Увімкнути значення ширини."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:66
+#: ../src/common/accelcmn.cpp:63
 msgid "End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:55
+#: ../src/common/accelcmn.cpp:52
 #, fuzzy
 msgid "Enter"
 msgstr "Друкарка"
 
-#: ../src/richtext/richtextstyledlg.cpp:934
+#: ../src/richtext/richtextstyledlg.cpp:930
 msgid "Enter a box style name"
 msgstr "Введіть назву стилю панелі"
 
-#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:602
 msgid "Enter a character style name"
 msgstr "Введіть назву стилю символу"
 
-#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:816
 msgid "Enter a list style name"
 msgstr "Введіть назву стилю списку"
 
-#: ../src/richtext/richtextstyledlg.cpp:893
+#: ../src/richtext/richtextstyledlg.cpp:889
 msgid "Enter a new style name"
 msgstr "Введіть назву нового стилю"
 
-#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:650
 msgid "Enter a paragraph style name"
 msgstr "Введіть назву стилю абзацу"
 
-#: ../src/generic/dbgrptg.cpp:174
+#: ../src/generic/dbgrptg.cpp:171
 #, c-format
 msgid "Enter command to open file \"%s\":"
 msgstr "Введіть команду для відкриття файла «%s»:"
 
-#: ../src/generic/helpext.cpp:459
+#: ../src/generic/helpext.cpp:457
 msgid "Entries found"
 msgstr "Знайдені записи"
 
-#: ../src/common/paper.cpp:142
+#: ../src/common/paper.cpp:139
 msgid "Envelope Invite 220 x 220 mm"
 msgstr "Конверт Запрошення 220 x 220 мм"
 
-#: ../src/common/config.cpp:469
+#: ../src/common/config.cpp:465
 #, c-format
 msgid ""
 "Environment variables expansion failed: missing '%c' at position %u in '%s'."
@@ -2988,13 +2993,13 @@ msgstr ""
 "Розкриття змінної оточення зазнало невдачі: відсутнє '%c' на позиції %u у "
 "'%s'."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/generic/dirctrlg.cpp:570
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/dirctrlg.cpp:599
-#: ../src/generic/dirdlgg.cpp:323 ../src/generic/filectrlg.cpp:642
-#: ../src/generic/filectrlg.cpp:756 ../src/generic/filectrlg.cpp:770
-#: ../src/generic/filectrlg.cpp:786 ../src/generic/filectrlg.cpp:1368
-#: ../src/generic/filectrlg.cpp:1399 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/gtk1/fontdlg.cpp:74 ../src/generic/dirctrlg.cpp:536
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/dirctrlg.cpp:565
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1357 ../src/generic/filectrlg.cpp:1388
+#: ../src/generic/filedlgg.cpp:354 ../src/generic/dirdlgg.cpp:320
+#: ../src/gtk/filedlg.cpp:74
 msgid "Error"
 msgstr "Помилка"
 
@@ -3002,233 +3007,254 @@ msgstr "Помилка"
 msgid "Error closing epoll descriptor"
 msgstr "Помилка під час закриття дескриптора epoll"
 
-#: ../src/unix/fswatcher_kqueue.cpp:114
+#: ../src/unix/fswatcher_kqueue.cpp:131
 msgid "Error closing kqueue instance"
 msgstr "Помилка під час закриття екземпляра kqueue"
 
-#: ../src/common/filefn.cpp:1049
+#: ../src/common/filefn.cpp:938
 #, fuzzy, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Помилка копіювання файла «%s» в «%s»."
 
-#: ../src/generic/dirdlgg.cpp:222
+#: ../src/generic/dirdlgg.cpp:219
 msgid "Error creating directory"
 msgstr "Помилка створення каталогу"
 
-#: ../src/common/imagbmp.cpp:1181
+#: ../src/common/imagbmp.cpp:1193
 msgid "Error in reading image DIB."
 msgstr "Помилка під час читання картинки DIB."
 
-#: ../src/propgrid/propgrid.cpp:6696
+#: ../src/propgrid/propgrid.cpp:6665
 #, c-format
 msgid "Error in resource: %s"
 msgstr "Помилка у ресурсі: %s"
 
-#: ../src/common/fileconf.cpp:422
+#: ../src/common/fileconf.cpp:421
 msgid "Error reading config options."
 msgstr "Помилка під час читання параметрів налаштування."
+
+#: ../src/msw/webview_ie.cpp:1057 ../src/msw/webview_edge.cpp:850
+#: ../src/gtk/webview_webkit2.cpp:1262 ../src/osx/webview_webkit.mm:383
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
 
 #: ../src/common/fileconf.cpp:1029
 msgid "Error saving user configuration data."
 msgstr "Помилка під час збереження даних налаштування користувача."
 
-#: ../src/gtk/print.cpp:722
+#: ../src/gtk/print.cpp:720
 msgid "Error while printing: "
 msgstr "Помилка під час друку: "
 
-#: ../src/common/log.cpp:219
+#: ../src/common/log.cpp:237
 msgid "Error: "
 msgstr "Помилка: "
 
+#: ../src/common/webrequest.cpp:98
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Помилка: "
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:69
+#: ../src/common/accelcmn.cpp:66
 msgid "Esc"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:70
+#: ../src/common/accelcmn.cpp:67
 #, fuzzy
 msgid "Escape"
 msgstr "Альбомна"
 
-#: ../src/common/fmapbase.cpp:150
+#: ../src/common/fmapbase.cpp:147
 msgid "Esperanto (ISO-8859-3)"
 msgstr "Есперанто (ISO-8859-3)"
 
-#: ../include/wx/generic/progdlgg.h:85
+#: ../include/wx/generic/progdlgg.h:86
 msgid "Estimated time:"
 msgstr "Оцінка часу:"
 
-#: ../src/generic/dbgrptg.cpp:234
+#: ../src/generic/dbgrptg.cpp:231
 msgid "Executable files (*.exe)|*.exe|"
 msgstr "Виконувані файли (*.exe)|*.exe|"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:155 ../src/common/accelcmn.cpp:78
+#: ../src/common/stockitem.cpp:152 ../src/common/accelcmn.cpp:75
 msgid "Execute"
 msgstr "Виконати"
 
-#: ../src/msw/utilsexc.cpp:876
+#: ../src/msw/utilsexc.cpp:873
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Помилка виконання команди «%s»"
 
-#: ../src/common/paper.cpp:105
+#: ../src/common/paper.cpp:102
 msgid "Executive, 7 1/4 x 10 1/2 in"
 msgstr "Executive, 7 1/4 x 10 1/2 дюйм"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6009
+#: ../src/generic/datavgen.cpp:6814
 msgid "Expand"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1240
+#: ../src/msw/registry.cpp:1228
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
 msgstr "Експорт ключа реєстру: файл «%s» вже існує, його не буде перезаписано."
 
-#: ../src/common/fmapbase.cpp:195
+#: ../src/common/fmapbase.cpp:192
 msgid "Extended Unix Codepage for Japanese (EUC-JP)"
 msgstr "Розширена кодова сторінка Unix для японської (EUC-JP)"
 
-#: ../src/html/chm.cpp:725
+#: ../src/html/chm.cpp:718
 #, c-format
 msgid "Extraction of '%s' into '%s' failed."
 msgstr "Розпакування «%s» до «%s» закінчилося з помилкою."
 
-#: ../src/common/accelcmn.cpp:249 ../src/common/accelcmn.cpp:344
+#: ../src/common/accelcmn.cpp:259 ../src/common/accelcmn.cpp:358
 msgid "F"
 msgstr "F"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:672
+#: ../src/propgrid/advprops.cpp:582
 msgid "Face Name"
 msgstr "Нарис"
 
-#: ../src/unix/snglinst.cpp:269
+#: ../src/unix/snglinst.cpp:266
 msgid "Failed to access lock file."
 msgstr "Не вдалося отримати доступ до файла замка."
+
+#: ../src/gtk/font.cpp:572
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Не вдалося прочитати документ з файла «%s»."
 
 #: ../src/unix/epolldispatcher.cpp:116
 #, c-format
 msgid "Failed to add descriptor %d to epoll descriptor %d"
 msgstr "Не вдалося додати дескриптор %d в дескриптора epoll %d"
 
-#: ../src/msw/dib.cpp:489
+#: ../src/msw/dib.cpp:535
 #, c-format
 msgid "Failed to allocate %luKb of memory for bitmap data."
 msgstr "Не вдалося виділити %lu кБ пам'яті для даних растрової картинки."
 
-#: ../src/common/glcmn.cpp:115
+#: ../src/common/glcmn.cpp:112
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Не вдалося виділити колір для OpenGL"
 
-#: ../src/unix/displayx11.cpp:236
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Не вдалося виділити колір для OpenGL"
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Не вдалося виділити колір для OpenGL"
+
+#: ../include/wx/unix/private/displayx11.h:89
 msgid "Failed to change video mode"
 msgstr "Не вдалося змінити відео режим."
 
-#: ../src/common/image.cpp:3277
+#: ../src/common/image.cpp:3396
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Не вдалося перевірити формат файла зображення «%s»."
 
-#: ../src/common/debugrpt.cpp:239
+#: ../src/common/debugrpt.cpp:240
 #, c-format
 msgid "Failed to clean up debug report directory \"%s\""
 msgstr "Не вдалося очистити теку звітів про помилки «%s»"
 
-#: ../src/common/filename.cpp:192
+#: ../src/common/filename.cpp:189
 msgid "Failed to close file handle"
 msgstr "Не вдалося закрити обробку файла"
 
-#: ../src/unix/snglinst.cpp:340
+#: ../src/unix/snglinst.cpp:337
 #, c-format
 msgid "Failed to close lock file '%s'"
 msgstr "Не вдалося закрити файла замка «%s»"
 
-#: ../src/msw/clipbrd.cpp:112
+#: ../src/msw/clipbrd.cpp:110
 msgid "Failed to close the clipboard."
 msgstr "Не вдалося закрити буфер обміну."
 
-#: ../src/x11/utils.cpp:208
+#: ../src/x11/utils.cpp:170
 #, c-format
 msgid "Failed to close the display \"%s\""
 msgstr "Не вдалося закрити дисплей «%s»"
 
-#: ../src/msw/dialup.cpp:797
+#: ../src/msw/dialup.cpp:791
 msgid "Failed to connect: missing username/password."
 msgstr "Не вдалося підключитись: не вказано користувача/пароля."
 
-#: ../src/msw/dialup.cpp:743
+#: ../src/msw/dialup.cpp:737
 msgid "Failed to connect: no ISP to dial."
 msgstr "Не вдалося додзвонитись: відсутній інтернет-провайдер."
 
-#: ../src/common/textfile.cpp:203
-#, c-format
-msgid "Failed to convert file \"%s\" to Unicode."
-msgstr "Не вдалося перетворити вміст файла «%s» на Unicode."
-
-#: ../src/generic/logg.cpp:956
+#: ../src/generic/logg.cpp:953
 msgid "Failed to copy dialog contents to the clipboard."
 msgstr "Не вдалося скопіювати вміст діалогового вікна до буфера."
 
-#: ../src/msw/registry.cpp:692
+#: ../src/msw/registry.cpp:681
 #, c-format
 msgid "Failed to copy registry value '%s'"
 msgstr "Не вдалося скопіювати значення реєстру «%s»"
 
-#: ../src/msw/registry.cpp:701
+#: ../src/msw/registry.cpp:690
 #, c-format
 msgid "Failed to copy the contents of registry key '%s' to '%s'."
 msgstr "Не вдалося копіювати дані ключу реєстру «%s» в «%s»."
 
-#: ../src/common/filefn.cpp:1015
+#: ../src/common/filefn.cpp:904
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Помилка копіювання файла «%s» в «%s»."
 
-#: ../src/msw/registry.cpp:679
+#: ../src/msw/registry.cpp:668
 #, c-format
 msgid "Failed to copy the registry subkey '%s' to '%s'."
 msgstr "Не вдалося копіювати підключ реєстру «%s» до «%s»."
 
-#: ../src/msw/dde.cpp:1070
+#: ../src/msw/dde.cpp:1134
 msgid "Failed to create DDE string"
 msgstr "Помилка створення рядка DDE"
 
-#: ../src/msw/mdi.cpp:616
+#: ../src/msw/mdi.cpp:621
 msgid "Failed to create MDI parent frame."
 msgstr "Помилка створення батьківського фрейма MDI."
 
-#: ../src/common/filename.cpp:1027
+#: ../src/common/filename.cpp:1024
 msgid "Failed to create a temporary file name"
 msgstr "Помилка створення назви тимчасового файла"
 
-#: ../src/msw/utilsexc.cpp:228
+#: ../src/msw/utilsexc.cpp:225
 msgid "Failed to create an anonymous pipe"
 msgstr "Не вдалося створити анонімну трубу"
 
-#: ../src/msw/ole/automtn.cpp:522
+#: ../src/msw/ole/automtn.cpp:513
 #, c-format
 msgid "Failed to create an instance of \"%s\""
 msgstr "Не вдалося створити екземпляр «%s»"
 
-#: ../src/msw/dde.cpp:437
+#: ../src/msw/dde.cpp:432
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "Не вдалося підключитись до серверу «%s» по темі «%s»"
 
-#: ../src/msw/cursor.cpp:204
+#: ../src/msw/cursor.cpp:195
 msgid "Failed to create cursor."
 msgstr "Не вдалося створити курсор."
 
-#: ../src/common/debugrpt.cpp:209
+#: ../src/common/debugrpt.cpp:210
 #, c-format
 msgid "Failed to create directory \"%s\""
 msgstr "Не вдалося створити теку «%s»"
 
-#: ../src/generic/dirdlgg.cpp:220
+#: ../src/generic/dirdlgg.cpp:217
 #, c-format
 msgid ""
 "Failed to create directory '%s'\n"
@@ -3241,118 +3267,137 @@ msgstr ""
 msgid "Failed to create epoll descriptor"
 msgstr "Не вдалося створити дескриптор epoll"
 
-#: ../src/msw/mimetype.cpp:238
+#: ../src/gtk/font.cpp:562
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "Не вдалося оновити файл налаштування."
+
+#: ../src/msw/mimetype.cpp:235
 #, c-format
 msgid "Failed to create registry entry for '%s' files."
 msgstr "Не вдалося створити елемент реєстру для «%s» файлів."
 
-#: ../src/msw/fdrepdlg.cpp:409
+#: ../src/msw/fdrepdlg.cpp:408
 #, c-format
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr ""
 "Не вдалося створити стандартний діалог знайти/замінити (код помилки %d)"
 
-#: ../src/unix/wakeuppipe.cpp:52
+#: ../src/unix/wakeuppipe.cpp:49
 msgid "Failed to create wake up pipe used by event loop."
 msgstr ""
 "Не вдалося створити канал повернення зі сну, що використовується циклом "
 "події."
 
-#: ../src/html/winpars.cpp:730
+#: ../src/html/winpars.cpp:727
 #, c-format
 msgid "Failed to display HTML document in %s encoding"
 msgstr "Не вдалося показати документ HTML у кодуванні %s"
 
-#: ../src/msw/clipbrd.cpp:124
+#: ../src/msw/clipbrd.cpp:122
 msgid "Failed to empty the clipboard."
 msgstr "Не вдалося почистити clipboard."
 
-#: ../src/unix/displayx11.cpp:212
+#: ../include/wx/unix/private/displayx11.h:65
 msgid "Failed to enumerate video modes"
 msgstr "Не вдалося пронумерувати відео режими"
 
-#: ../src/msw/dde.cpp:722
+#: ../src/msw/dde.cpp:717
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "Не вдалося встановити зв'язок помочі з DDE сервером"
 
-#: ../src/msw/dialup.cpp:629 ../src/msw/dialup.cpp:863
+#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Не вдалося додзвонитись: %s"
 
-#: ../src/unix/utilsunx.cpp:611
+#: ../src/unix/utilsunx.cpp:613
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Не вдалося виконати «%s»\n"
 
-#: ../src/common/debugrpt.cpp:720
+#: ../src/common/debugrpt.cpp:730
 msgid "Failed to execute curl, please install it in PATH."
 msgstr ""
 "Не вдалося виконати curl, будь ласка, встановіть його у теці вказаній у PATH."
 
-#: ../src/msw/ole/automtn.cpp:505
+#: ../src/msw/ole/automtn.cpp:496
 #, c-format
 msgid "Failed to find CLSID of \"%s\""
 msgstr "Не вдалося знайти CLSID «%s»"
 
-#: ../src/common/regex.cpp:431 ../src/common/regex.cpp:479
+#: ../src/common/regex.cpp:428 ../src/common/regex.cpp:476
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "Не вдалося знайти відповідник для регулярного виразу: %s"
 
-#: ../src/msw/dialup.cpp:695
+#: ../src/msw/webview_ie.cpp:978
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:689
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Не вдалося отримати номеру ISP: %s"
 
-#: ../src/msw/ole/automtn.cpp:574
+#: ../src/msw/ole/automtn.cpp:565
 #, c-format
 msgid "Failed to get OLE automation interface for \"%s\""
 msgstr "Не вдалося отримати інтерфейс автоматичної обробки OLE для «%s»"
 
-#: ../src/msw/clipbrd.cpp:711
+#: ../src/msw/clipbrd.cpp:731
 msgid "Failed to get data from the clipboard"
 msgstr "Не вдалося встановити дані з clipboard."
 
-#: ../src/common/time.cpp:223
+#: ../src/common/time.cpp:216
 msgid "Failed to get the local system time"
 msgstr "Не вдалося отримати локальний системний час"
 
-#: ../src/common/filefn.cpp:1345
+#: ../src/common/filefn.cpp:1233
 msgid "Failed to get the working directory"
 msgstr "Не вдалося отримати робочий каталог"
 
-#: ../src/univ/theme.cpp:114
+#: ../src/univ/theme.cpp:111
 msgid "Failed to initialize GUI: no built-in themes found."
 msgstr "Не вдалося ініціювати GUI: не знайдено вбудованих тем."
 
-#: ../src/msw/helpchm.cpp:63
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:60
 msgid "Failed to initialize MS HTML Help."
 msgstr "Не вдалося ініціалізувати MS HTML Help."
 
-#: ../src/msw/glcanvas.cpp:1381
+#: ../src/msw/glcanvas.cpp:1391
 msgid "Failed to initialize OpenGL"
 msgstr "Не вдалося ініціалізувати OpenGL"
 
-#: ../src/msw/dialup.cpp:858
+#: ../src/msw/dialup.cpp:852
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Не вдалося ініціалізувати комутоване з’єднання: %s"
 
-#: ../src/gtk/textctrl.cpp:1128
+#: ../src/gtk/textctrl.cpp:1209
 msgid "Failed to insert text in the control."
 msgstr "Не вдалося додати текст до контрола."
 
-#: ../src/unix/snglinst.cpp:241
+#: ../src/unix/snglinst.cpp:238
 #, c-format
 msgid "Failed to inspect the lock file '%s'"
 msgstr "Не вдалося перевірити файл замка «%s»."
 
-#: ../src/unix/appunix.cpp:182
+#: ../src/unix/appunix.cpp:179
 msgid "Failed to install signal handler"
 msgstr "Не вдалося встановити інструмент обробки сигналу"
 
-#: ../src/unix/threadpsx.cpp:1167
+#: ../src/unix/threadpsx.cpp:1216
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -3360,71 +3405,71 @@ msgstr ""
 "Не вдалося з'єднатися з ниткою, можливий виток пам'яті, будь ласка, "
 "перезапустіть програму"
 
-#: ../src/msw/utils.cpp:629
+#: ../src/msw/utils.cpp:619
 #, c-format
 msgid "Failed to kill process %d"
 msgstr "Не вдалося вбити процес %d"
 
-#: ../src/common/image.cpp:2500
+#: ../src/common/image.cpp:2595
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Не вдалося завантажити растрове зображення «%s» з ресурсів."
 
-#: ../src/common/image.cpp:2509
+#: ../src/common/image.cpp:2604
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Не вдалося завантажити піктограму «%s» з ресурсів."
 
-#: ../src/common/iconbndl.cpp:225
+#: ../src/common/iconbndl.cpp:224
 #, fuzzy, c-format
 msgid "Failed to load icons from resource '%s'."
 msgstr "Не вдалося завантажити піктограму «%s» з ресурсів."
 
-#: ../src/common/iconbndl.cpp:200
+#: ../src/common/iconbndl.cpp:198
 #, c-format
 msgid "Failed to load image %%d from file '%s'."
 msgstr "Не вдалося завантажити зображення %%d з файла «%s»."
 
-#: ../src/common/iconbndl.cpp:208
+#: ../src/common/iconbndl.cpp:206
 #, c-format
 msgid "Failed to load image %d from stream."
 msgstr "Не вдалося завантажити зображення %d з потоку даних."
 
-#: ../src/common/image.cpp:2587 ../src/common/image.cpp:2606
+#: ../src/common/image.cpp:2682 ../src/common/image.cpp:2701
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Не вдалося завантажити зображення з файла «%s»."
 
-#: ../src/msw/enhmeta.cpp:97
+#: ../src/msw/enhmeta.cpp:94
 #, c-format
 msgid "Failed to load metafile from file \"%s\"."
 msgstr "Не вдалося завантажити метазображення з файла «%s»."
 
-#: ../src/msw/volume.cpp:327
+#: ../src/msw/volume.cpp:335
 msgid "Failed to load mpr.dll."
 msgstr "Не вдалося завантажити mpr.dll."
 
-#: ../src/msw/utils.cpp:953
+#: ../src/msw/utils.cpp:943
 #, c-format
 msgid "Failed to load resource \"%s\"."
 msgstr "Не вдалося завантажити ресурс «%s»."
 
-#: ../src/common/dynlib.cpp:92
+#: ../src/common/dynlib.cpp:86
 #, c-format
 msgid "Failed to load shared library '%s'"
 msgstr "Не вдалося завантажити динамічну бібліотеку «%s»"
 
-#: ../src/osx/core/sound.cpp:145
+#: ../src/osx/core/sound.cpp:143
 #, fuzzy, c-format
 msgid "Failed to load sound from \"%s\" (error %d)."
 msgstr "Не вдалося завантажити ресурс «%s»."
 
-#: ../src/msw/utils.cpp:960
+#: ../src/msw/utils.cpp:950
 #, c-format
 msgid "Failed to lock resource \"%s\"."
 msgstr "Не вдалося заблокувати ресурс «%s»."
 
-#: ../src/unix/snglinst.cpp:198
+#: ../src/unix/snglinst.cpp:195
 #, c-format
 msgid "Failed to lock the lock file '%s'"
 msgstr "Не вдалося замкнути файл замка «%s»"
@@ -3434,33 +3479,38 @@ msgstr "Не вдалося замкнути файл замка «%s»"
 msgid "Failed to modify descriptor %d in epoll descriptor %d"
 msgstr "Не вдалося змінити дескриптор %d у дескрипторі epoll %d"
 
-#: ../src/common/filename.cpp:2575
+#: ../src/common/filename.cpp:2658
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Не вдалося змінити час файла для «%s»"
 
-#: ../src/common/selectdispatcher.cpp:258
+#: ../src/common/selectdispatcher.cpp:255
 msgid "Failed to monitor I/O channels"
 msgstr "Спроба спостереження за каналами вводу-виводу була невдалою"
 
-#: ../src/common/filename.cpp:175
+#: ../src/common/filename.cpp:172
 #, c-format
 msgid "Failed to open '%s' for reading"
 msgstr "Не вдалося відкрити «%s» для читання"
 
-#: ../src/common/filename.cpp:180
+#: ../src/common/filename.cpp:177
 #, c-format
 msgid "Failed to open '%s' for writing"
 msgstr "Не вдалося відкрити «%s» для запису"
 
-#: ../src/html/chm.cpp:141
+#: ../src/html/chm.cpp:138
 #, c-format
 msgid "Failed to open CHM archive '%s'."
 msgstr "Не вдалося відкрити архів CHM «%s»."
 
-#: ../src/common/utilscmn.cpp:1126
+#: ../src/common/utilscmn.cpp:1140
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Не вдалося відкрити адресу «%s» у типовому переглядачі."
+
+#: ../src/common/hyperlnkcmn.cpp:133
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Не вдалося відкрити адресу «%s» у типовому переглядачі."
 
 #: ../include/wx/msw/private/fswatcher.h:92
@@ -3468,93 +3518,103 @@ msgstr "Не вдалося відкрити адресу «%s» у типово
 msgid "Failed to open directory \"%s\" for monitoring."
 msgstr "Не вдалося відкрити каталог «%s» для спостереження."
 
-#: ../src/x11/utils.cpp:227
+#: ../src/x11/utils.cpp:189
 #, c-format
 msgid "Failed to open display \"%s\"."
 msgstr "Не вдалося відкрити дисплей «%s»."
 
-#: ../src/common/filename.cpp:1062
+#: ../src/common/filename.cpp:1059
 msgid "Failed to open temporary file."
 msgstr "Не вдалося відкрити тимчасовий файл."
 
-#: ../src/msw/clipbrd.cpp:91
+#: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Не вдалося відкрити clipboard."
 
-#: ../src/common/translation.cpp:1184
+#: ../src/common/translation.cpp:1226
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Не вдалося обробити форми множини: «%s»"
 
-#: ../src/unix/mediactrl.cpp:1214
+#: ../src/unix/mediactrl.cpp:1239
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Не вдалося приготувати «%s» до відтворення."
 
-#: ../src/msw/clipbrd.cpp:600
+#: ../src/msw/clipbrd.cpp:610
 msgid "Failed to put data on the clipboard"
 msgstr "Не вдалося покласти дані в clipboard."
 
-#: ../src/unix/snglinst.cpp:278
+#: ../src/unix/snglinst.cpp:275
 msgid "Failed to read PID from lock file."
 msgstr "Не вдалося прочитати PID з файла замка."
 
-#: ../src/common/fileconf.cpp:433
+#: ../src/common/fileconf.cpp:432
 msgid "Failed to read config options."
 msgstr "Не вдалося прочитати параметри налаштування."
 
-#: ../src/common/docview.cpp:681
+#: ../src/common/docview.cpp:676
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Не вдалося прочитати документ з файла «%s»."
 
-#: ../src/dfb/evtloop.cpp:98
+#: ../src/dfb/evtloop.cpp:99
 msgid "Failed to read event from DirectFB pipe"
 msgstr "Не вдалося прочитати подію з каналу обробки DirectFB"
 
-#: ../src/unix/wakeuppipe.cpp:120
+#: ../src/unix/wakeuppipe.cpp:117
 msgid "Failed to read from wake-up pipe"
 msgstr "Не вдалося прочитати дані з каналу повернення зі сну"
 
-#: ../src/unix/utilsunx.cpp:679
+#: ../src/common/textfile.cpp:96
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Не вдалося прочитати документ з файла «%s»."
+
+#: ../src/unix/utilsunx.cpp:681
 msgid "Failed to redirect child process input/output"
 msgstr "Не вдалося переспрямувати ввід/вивід зародженого процесу"
 
-#: ../src/msw/utilsexc.cpp:701
+#: ../src/msw/utilsexc.cpp:698
 msgid "Failed to redirect the child process IO"
 msgstr "Не вдалося переспрямувати IO дочірнього процесу"
 
-#: ../src/msw/dde.cpp:288
+#: ../src/msw/dde.cpp:283
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Не вдалося зареєструвати сервер DDE «%s»"
 
-#: ../src/common/fontmap.cpp:245
+#: ../src/gtk/font.cpp:580
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "Не вдалося оновити файл налаштування."
+
+#: ../src/common/fontmap.cpp:242
 #, c-format
 msgid "Failed to remember the encoding for the charset '%s'."
 msgstr "Не вдалося згадати кодування для набору символів «%s»."
 
-#: ../src/common/debugrpt.cpp:227
+#: ../src/common/debugrpt.cpp:228
 #, c-format
 msgid "Failed to remove debug report file \"%s\""
 msgstr "Помилка вилучення файла звіту про помилку «%s»"
 
-#: ../src/unix/snglinst.cpp:328
+#: ../src/unix/snglinst.cpp:325
 #, c-format
 msgid "Failed to remove lock file '%s'"
 msgstr "Помилка вилучення файла замка «%s»"
 
-#: ../src/unix/snglinst.cpp:288
+#: ../src/unix/snglinst.cpp:285
 #, c-format
 msgid "Failed to remove stale lock file '%s'."
 msgstr "Не вдалося вилучити застарілий файл блокування «%s»."
 
-#: ../src/msw/registry.cpp:529
+#: ../src/msw/registry.cpp:518
 #, c-format
 msgid "Failed to rename registry value '%s' to '%s'."
 msgstr "Не вдалося перейменувати значення реєстру з «%s» в '%s."
 
-#: ../src/common/filefn.cpp:1122
+#: ../src/common/filefn.cpp:1011
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -3563,117 +3623,126 @@ msgstr ""
 "Помилка під час перейменування файла «%s» на «%s», файл з такою назвою вже "
 "існує."
 
-#: ../src/msw/registry.cpp:634
+#: ../src/msw/registry.cpp:623
 #, c-format
 msgid "Failed to rename the registry key '%s' to '%s'."
 msgstr "Не вдалося перейменувати ключ реєстру з «%s» в '%s."
 
-#: ../src/common/filename.cpp:2671
+#: ../src/msw/webview_ie.cpp:995
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/common/filename.cpp:2754
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Не вдалося отримати часи файла для «%s»"
 
-#: ../src/msw/dialup.cpp:468
+#: ../src/msw/dialup.cpp:462
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Не вдалося прочитати повідомлення про помилку RAS"
 
-#: ../src/msw/clipbrd.cpp:748
+#: ../src/msw/clipbrd.cpp:768
 msgid "Failed to retrieve the supported clipboard formats"
 msgstr "Не вдалося прочитати формати підтримані clipboard"
 
-#: ../src/common/docview.cpp:652
+#: ../src/common/docview.cpp:647
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Не вдалося зберегти документ до файла «%s»."
 
-#: ../src/msw/dib.cpp:269
+#: ../src/msw/dib.cpp:312
 #, c-format
 msgid "Failed to save the bitmap image to file \"%s\"."
 msgstr "Не вдалося зберегти растрове зображення до файла «%s»."
 
-#: ../src/msw/dde.cpp:763
+#: ../src/msw/dde.cpp:811
 msgid "Failed to send DDE advise notification"
 msgstr "Не вдалося надіслати повідомлення DDE"
 
-#: ../src/common/ftp.cpp:402
+#: ../src/common/ftp.cpp:399
 #, c-format
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Не вдалося встановити режим передачі FTP у значення %s."
 
-#: ../src/msw/clipbrd.cpp:427
+#: ../src/msw/clipbrd.cpp:443
 msgid "Failed to set clipboard data."
 msgstr "Не вдалося встановити дані clipboard."
 
-#: ../src/unix/snglinst.cpp:181
+#: ../src/unix/snglinst.cpp:178
 #, c-format
 msgid "Failed to set permissions on lock file '%s'"
 msgstr "Не вдалося встановити дозволи на файл замка «%s»"
 
-#: ../src/unix/utilsunx.cpp:668
+#: ../src/unix/utilsunx.cpp:670
 msgid "Failed to set process priority"
 msgstr "Не вдалося встановити пріоритет процесу"
 
-#: ../src/common/file.cpp:559
+#: ../src/common/ffile.cpp:355 ../src/common/file.cpp:586
 msgid "Failed to set temporary file permissions"
 msgstr "Не вдалося встановити дозволи на тимчасовий файл"
 
-#: ../src/gtk/textctrl.cpp:1072
-msgid "Failed to set text in the text control."
-msgstr "Не вдалося встановити текст у контрол тексту."
-
-#: ../src/unix/threadpsx.cpp:1298
+#: ../src/unix/threadpsx.cpp:1347
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Не вдалося встановити рівень пріоритетності нитки у значення %lu"
 
-#: ../src/unix/threadpsx.cpp:1424
+#: ../src/unix/threadpsx.cpp:1473
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Не вдалося встановити пріоритет нитки %d."
 
-#: ../src/unix/utilsunx.cpp:783
+#: ../src/unix/utilsunx.cpp:785
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 "Не вдалося налаштувати канал обробки без блокування, програма може "
 "«зависнути»."
 
-#: ../src/common/fs_mem.cpp:261
+#: ../src/msw/webview_ie.cpp:987
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:256
 #, c-format
 msgid "Failed to store image '%s' to memory VFS!"
 msgstr "Не вдалося записати зображення «%s» в пам'яті VFS!"
 
-#: ../src/dfb/evtloop.cpp:170
+#: ../src/dfb/evtloop.cpp:171
 msgid "Failed to switch DirectFB pipe to non-blocking mode"
 msgstr "Не вдалося перемкнути канал DirectFB у режим без блокування"
 
-#: ../src/unix/wakeuppipe.cpp:59
+#: ../src/unix/wakeuppipe.cpp:56
 msgid "Failed to switch wake up pipe to non-blocking mode"
 msgstr "Не вдалося перемкнути канал повернення зі сну у режим без блокування"
 
-#: ../src/unix/threadpsx.cpp:1605
+#: ../src/unix/threadpsx.cpp:1654
 msgid "Failed to terminate a thread."
 msgstr "Не вдалося закінчити нитку."
 
-#: ../src/msw/dde.cpp:741
+#: ../src/msw/dde.cpp:736
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "Не вдалося закінчити 'advise loop' з DDE сервером."
 
-#: ../src/msw/dialup.cpp:938
+#: ../src/msw/dialup.cpp:932
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Не вдалося повісити трубку: %s"
 
-#: ../src/common/filename.cpp:2590
+#: ../src/common/filename.cpp:2673
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Не вдалося відкрити файл «%s»"
 
-#: ../src/unix/snglinst.cpp:334
+#: ../src/unix/dlunix.cpp:90
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "Не вдалося завантажити динамічну бібліотеку «%s»"
+
+#: ../src/unix/snglinst.cpp:331
 #, c-format
 msgid "Failed to unlock lock file '%s'"
 msgstr "Не вдалося відімкнути файл замка «%s»"
 
-#: ../src/msw/dde.cpp:309
+#: ../src/msw/dde.cpp:304
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Не вдалося скасувати реєстрацію сервера DDE «%s»"
@@ -3688,77 +3757,87 @@ msgstr ""
 msgid "Failed to update user configuration file."
 msgstr "Не вдалося оновити файл налаштування."
 
-#: ../src/common/debugrpt.cpp:733
+#: ../src/common/debugrpt.cpp:743
 #, c-format
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Не вдалося відвантажити звіт про помилку (код помилки %d)."
 
-#: ../src/unix/snglinst.cpp:168
+#: ../src/unix/snglinst.cpp:165
 #, c-format
 msgid "Failed to write to lock file '%s'"
 msgstr "Не вдалося провести запис до файла замка «%s»"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:209
+#: ../src/propgrid/propgrid.cpp:190
 msgid "False"
 msgstr "Ні"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:694
+#: ../src/propgrid/advprops.cpp:604
 msgid "Family"
 msgstr "Гарнітура"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/gtk/glcanvas.cpp:176 ../src/gtk/glcanvas.cpp:187
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Критична помилка"
+
+#: ../src/common/stockitem.cpp:154
 msgid "File"
 msgstr "Файл"
 
-#: ../src/common/docview.cpp:669
+#: ../src/common/docview.cpp:664
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Не вдалося відкрити файл «%s» для читання."
 
-#: ../src/common/docview.cpp:646
+#: ../src/common/docview.cpp:641
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Не вдалося відкрити файл «%s» для запису."
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "Файл «%s» вже присутній, ви справді хочете його переписати?"
 
-#: ../src/common/filefn.cpp:1156
+#: ../src/common/filefn.cpp:1044
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Не вдалося вилучити файл «%s»"
 
-#: ../src/common/filefn.cpp:1139
+#: ../src/common/filefn.cpp:1028
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Не вдалося перейменувати файл «%s» на «%s»"
 
-#: ../src/richtext/richtextctrl.cpp:3081 ../src/common/textcmn.cpp:953
+#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
 msgid "File couldn't be loaded."
 msgstr "Файл не можна завантажити."
 
-#: ../src/msw/filedlg.cpp:393
+#: ../src/msw/filedlg.cpp:414
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Помилка діалогового вікна роботи з файлами з кодом %0lx."
 
-#: ../src/common/docview.cpp:1789
+#: ../src/common/docview.cpp:1783
 msgid "File error"
 msgstr "Помилка файла"
 
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/filectrlg.cpp:770
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/filectrlg.cpp:766
 msgid "File name exists already."
 msgstr "Файл з такою назвою вже існує."
+
+#: ../src/osx/cocoa/filedlg.mm:264
+#, fuzzy
+msgid "File type:"
+msgstr "Телетайп"
 
 #: ../src/motif/filedlg.cpp:220
 msgid "Files"
 msgstr "Файли"
 
-#: ../src/common/filefn.cpp:1591
+#: ../src/common/filefn.cpp:1479
 #, c-format
 msgid "Files (%s)"
 msgstr "Файли (%s)"
@@ -3767,15 +3846,29 @@ msgstr "Файли (%s)"
 msgid "Filter"
 msgstr "Фільтр"
 
-#: ../src/common/stockitem.cpp:158 ../src/html/helpwnd.cpp:490
+#: ../src/html/helpwnd.cpp:488
 msgid "Find"
 msgstr "Знайти"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:259
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:258
+#, fuzzy
+msgid "Find in document"
+msgstr "Відкрити документ HTML"
+
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "Find..."
+msgstr "Знайти"
+
+#: ../src/common/stockitem.cpp:156
 msgid "First"
 msgstr "Перша"
 
-#: ../src/common/prntbase.cpp:1548
+#: ../src/common/prntbase.cpp:1573
 msgid "First page"
 msgstr "Перша сторінка"
 
@@ -3783,11 +3876,11 @@ msgstr "Перша сторінка"
 msgid "Fixed"
 msgstr "Фіксована"
 
-#: ../src/html/helpwnd.cpp:1206
+#: ../src/html/helpwnd.cpp:1204
 msgid "Fixed font:"
 msgstr "Фіксований шрифт:"
 
-#: ../src/html/helpwnd.cpp:1269
+#: ../src/html/helpwnd.cpp:1267
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Шрифт з фіксованою шириною.<br> <b>жирний</b> <i>курсивний</i> "
 
@@ -3795,16 +3888,16 @@ msgstr "Шрифт з фіксованою шириною.<br> <b>жирний</
 msgid "Floating"
 msgstr "Вільний"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "Floppy"
 msgstr "Дискета"
 
-#: ../src/common/paper.cpp:111
+#: ../src/common/paper.cpp:108
 msgid "Folio, 8 1/2 x 13 in"
 msgstr "Folio, 8 1/2 x 13 дюйм"
 
-#: ../src/richtext/richtextformatdlg.cpp:344 ../src/osx/carbon/fontdlg.cpp:287
-#: ../src/common/stockitem.cpp:194
+#: ../src/osx/carbon/fontdlg.cpp:284 ../src/common/stockitem.cpp:191
+#: ../src/richtext/richtextformatdlg.cpp:337
 msgid "Font"
 msgstr "Шрифт"
 
@@ -3812,7 +3905,24 @@ msgstr "Шрифт"
 msgid "Font &weight:"
 msgstr "Вага шри&фту:"
 
-#: ../src/html/helpwnd.cpp:1207
+#: ../src/osx/fontutil.cpp:89
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
+"\"."
+msgstr ""
+
+#: ../src/msw/font.cpp:1126
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Файл не можна завантажити."
+
+#: ../src/osx/fontutil.cpp:81
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "Файл %s не присутній."
+
+#: ../src/html/helpwnd.cpp:1205
 msgid "Font size:"
 msgstr "Розмір шрифту:"
 
@@ -3820,53 +3930,53 @@ msgstr "Розмір шрифту:"
 msgid "Font st&yle:"
 msgstr "Розмір шрифту:"
 
-#: ../src/osx/carbon/fontdlg.cpp:329
+#: ../src/osx/carbon/fontdlg.cpp:326
 msgid "Font:"
 msgstr "Шрифт:"
 
-#: ../src/dfb/fontmgr.cpp:198
+#: ../src/dfb/fontmgr.cpp:195
 #, c-format
 msgid "Fonts index file %s disappeared while loading fonts."
 msgstr "Файл покажчика шрифтів %s було вилучено під час завантаження шрифтів."
 
-#: ../src/unix/utilsunx.cpp:645
+#: ../src/unix/utilsunx.cpp:647
 msgid "Fork failed"
 msgstr "Невдале розгалуження"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "Forward"
 msgstr "Вперед"
 
-#: ../src/common/xtixml.cpp:235
+#: ../src/common/xtixml.cpp:231
 msgid "Forward hrefs are not supported"
 msgstr "Форвардні href не підтримуються"
 
-#: ../src/html/helpwnd.cpp:875
+#: ../src/html/helpwnd.cpp:873
 #, c-format
 msgid "Found %i matches"
 msgstr "Знайдено %i відповідностей"
 
-#: ../src/generic/prntdlgg.cpp:238
+#: ../src/generic/prntdlgg.cpp:231
 msgid "From:"
 msgstr "Від:"
 
-#: ../src/propgrid/advprops.cpp:1604
+#: ../src/propgrid/advprops.cpp:1510
 msgid "Fuchsia"
 msgstr "Фуксія"
 
-#: ../src/common/imaggif.cpp:138
+#: ../src/common/imaggif.cpp:135
 msgid "GIF: data stream seems to be truncated."
 msgstr "GIF: потік даних здається обрізаний."
 
-#: ../src/common/imaggif.cpp:128
+#: ../src/common/imaggif.cpp:125
 msgid "GIF: error in GIF image format."
 msgstr "GIF: помилка в форматі зображення GIF."
 
-#: ../src/common/imaggif.cpp:133
+#: ../src/common/imaggif.cpp:130
 msgid "GIF: not enough memory."
 msgstr "GIF: нестача пам'яті."
 
-#: ../src/gtk/window.cpp:4631
+#: ../src/gtk/window.cpp:5635
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -3875,23 +3985,23 @@ msgstr ""
 "композитне відтворення належним чином. Будь ласка, встановіть версію "
 "бібліотек GTK+ 2.12 або пізнішу."
 
-#: ../src/univ/themes/gtk.cpp:525
+#: ../src/univ/themes/gtk.cpp:522
 msgid "GTK+ theme"
 msgstr "GTK+ мотив"
 
-#: ../src/common/preferencescmn.cpp:40
+#: ../src/common/preferencescmn.cpp:37
 msgid "General"
 msgstr "Загальне"
 
-#: ../src/common/prntbase.cpp:258
+#: ../src/common/prntbase.cpp:253
 msgid "Generic PostScript"
 msgstr "Звичайний PostScript"
 
-#: ../src/common/paper.cpp:135
+#: ../src/common/paper.cpp:132
 msgid "German Legal Fanfold, 8 1/2 x 13 in"
 msgstr "German Legal Fanfold, 8 1/2 x 13 дюйм"
 
-#: ../src/common/paper.cpp:134
+#: ../src/common/paper.cpp:131
 msgid "German Std Fanfold, 8 1/2 x 12 in"
 msgstr "German Std Fanfold, 8 1/2 x 12 in"
 
@@ -3907,49 +4017,49 @@ msgstr "GetPropertyCollection викликано для загального з�
 msgid "GetPropertyCollection called w/o valid collection getter"
 msgstr "GetPropertyCollection викликано без чинного параметра збірки"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:658
 msgid "Go back"
 msgstr "Іти назад"
 
-#: ../src/html/helpwnd.cpp:661
+#: ../src/html/helpwnd.cpp:659
 msgid "Go forward"
 msgstr "Іти вперед"
 
-#: ../src/html/helpwnd.cpp:663
+#: ../src/html/helpwnd.cpp:661
 msgid "Go one level up in document hierarchy"
 msgstr "Перейти на рівень вгору ієрархією документа"
 
-#: ../src/generic/filedlgg.cpp:208 ../src/generic/dirdlgg.cpp:116
+#: ../src/generic/filedlgg.cpp:205 ../src/generic/dirdlgg.cpp:113
 msgid "Go to home directory"
 msgstr "В домашню теку"
 
-#: ../src/generic/filedlgg.cpp:205
+#: ../src/generic/filedlgg.cpp:202
 msgid "Go to parent directory"
 msgstr "В батьківську теку"
 
-#: ../src/generic/aboutdlgg.cpp:76
+#: ../src/generic/aboutdlgg.cpp:73
 msgid "Graphics art by "
 msgstr "Графічні елементи від "
 
-#: ../src/propgrid/advprops.cpp:1599
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Gray"
 msgstr "Сірий"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:883
+#: ../src/propgrid/advprops.cpp:784
 msgid "GrayText"
 msgstr "СірийТекст"
 
-#: ../src/common/fmapbase.cpp:154
+#: ../src/common/fmapbase.cpp:151
 msgid "Greek (ISO-8859-7)"
 msgstr "Greek (ISO-8859-7)"
 
-#: ../src/propgrid/advprops.cpp:1600
+#: ../src/propgrid/advprops.cpp:1506
 #, fuzzy
 msgid "Green"
 msgstr "Грецька, Mac"
 
-#: ../src/generic/colrdlgg.cpp:342
+#: ../src/generic/colrdlgg.cpp:362
 #, fuzzy
 msgid "Green:"
 msgstr "Грецька, Mac"
@@ -3958,109 +4068,109 @@ msgstr "Грецька, Mac"
 msgid "Groove"
 msgstr "Виступ"
 
-#: ../src/common/zstream.cpp:158 ../src/common/zstream.cpp:318
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
 msgid "Gzip not supported by this version of zlib"
 msgstr "Gzip не підтримується цією версією zlib"
 
-#: ../src/html/helpwnd.cpp:1549
+#: ../src/html/helpwnd.cpp:1547
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "Проект довідки HTML (*.hhp)|*.hhp|"
 
-#: ../src/html/htmlwin.cpp:681
+#: ../src/html/htmlwin.cpp:691
 #, c-format
 msgid "HTML anchor %s does not exist."
 msgstr "HTML-якір %s не присутній."
 
-#: ../src/html/helpwnd.cpp:1547
+#: ../src/html/helpwnd.cpp:1545
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "Файли HTML (*.html;*.htm)|*.html;*.htm|"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1759
+#: ../src/propgrid/advprops.cpp:1660
 msgid "Hand"
 msgstr "Рука"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "Harddisk"
 msgstr "Жорсткий диск"
 
-#: ../src/common/fmapbase.cpp:155
+#: ../src/common/fmapbase.cpp:152
 msgid "Hebrew (ISO-8859-8)"
 msgstr "Hebrew (ISO-8859-8)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:280 ../src/osx/button_osx.cpp:39
-#: ../src/common/stockitem.cpp:163 ../src/common/accelcmn.cpp:80
-#: ../src/html/helpdlg.cpp:66 ../src/html/helpfrm.cpp:111
+#: ../include/wx/msgdlg.h:282 ../src/osx/button_osx.cpp:39
+#: ../src/common/stockitem.cpp:160 ../src/common/accelcmn.cpp:77
+#: ../src/html/helpfrm.cpp:108 ../src/html/helpdlg.cpp:63
 msgid "Help"
 msgstr "Довідка"
 
-#: ../src/html/helpwnd.cpp:1200
+#: ../src/html/helpwnd.cpp:1198
 msgid "Help Browser Options"
 msgstr "Параметри перегляду довідки"
 
-#: ../src/generic/helpext.cpp:454 ../src/generic/helpext.cpp:455
+#: ../src/generic/helpext.cpp:452 ../src/generic/helpext.cpp:453
 msgid "Help Index"
 msgstr "Індекс довідки"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1529
 msgid "Help Printing"
 msgstr "Довідка друку"
 
-#: ../src/html/helpwnd.cpp:801
+#: ../src/html/helpwnd.cpp:799
 msgid "Help Topics"
 msgstr "Розділи довідки"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1546
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Книги довідки (*.htb)|*.htb|Книги довідки (*.zip)|*.zip|"
 
-#: ../src/generic/helpext.cpp:267
+#: ../src/generic/helpext.cpp:265
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "Теку довідки «%s» не знайдено."
 
-#: ../src/generic/helpext.cpp:275
+#: ../src/generic/helpext.cpp:273
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "Файл довідки «%s» не знайдено."
 
-#: ../src/html/helpctrl.cpp:63
+#: ../src/html/helpctrl.cpp:59
 #, c-format
 msgid "Help: %s"
 msgstr "Довідка: %s"
 
-#: ../src/osx/menu_osx.cpp:577
+#: ../src/osx/menu_osx.cpp:469
 #, c-format
 msgid "Hide %s"
 msgstr "Сховати %s"
 
-#: ../src/osx/menu_osx.cpp:579
+#: ../src/osx/menu_osx.cpp:471
 msgid "Hide Others"
 msgstr "Сховати решту"
 
-#: ../src/generic/infobar.cpp:84
+#: ../src/generic/infobar.cpp:81
 msgid "Hide this notification message."
 msgstr "Сховати це сповіщення."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:884
+#: ../src/propgrid/advprops.cpp:785
 #, fuzzy
 msgid "Highlight"
 msgstr "легкий"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:885
+#: ../src/propgrid/advprops.cpp:786
 #, fuzzy
 msgid "HighlightText"
 msgstr "Текст вирівняний праворуч."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:164 ../src/common/accelcmn.cpp:65
+#: ../src/common/stockitem.cpp:161 ../src/common/accelcmn.cpp:62
 msgid "Home"
 msgstr "Домівка"
 
-#: ../src/generic/dirctrlg.cpp:524
+#: ../src/generic/dirctrlg.cpp:490
 msgid "Home directory"
 msgstr "Домашня тека"
 
@@ -4070,62 +4180,62 @@ msgid "How the object will float relative to the text."
 msgstr "Спосіб взаємного розташування об’єкта і тексту."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1760
+#: ../src/propgrid/advprops.cpp:1661
 msgid "I-Beam"
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1196
+#: ../src/common/imagbmp.cpp:1208
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: Помилка під час читання маски DIB."
 
-#: ../src/common/imagbmp.cpp:1290 ../src/common/imagbmp.cpp:1390
-#: ../src/common/imagbmp.cpp:1405 ../src/common/imagbmp.cpp:1416
-#: ../src/common/imagbmp.cpp:1430 ../src/common/imagbmp.cpp:1478
-#: ../src/common/imagbmp.cpp:1493 ../src/common/imagbmp.cpp:1507
-#: ../src/common/imagbmp.cpp:1518
+#: ../src/common/imagbmp.cpp:1302 ../src/common/imagbmp.cpp:1402
+#: ../src/common/imagbmp.cpp:1417 ../src/common/imagbmp.cpp:1428
+#: ../src/common/imagbmp.cpp:1442 ../src/common/imagbmp.cpp:1490
+#: ../src/common/imagbmp.cpp:1505 ../src/common/imagbmp.cpp:1519
+#: ../src/common/imagbmp.cpp:1530
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: Помилка запису файла зображення!"
 
-#: ../src/common/imagbmp.cpp:1255
+#: ../src/common/imagbmp.cpp:1267
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: зображення зависоке для піктограми"
 
-#: ../src/common/imagbmp.cpp:1263
+#: ../src/common/imagbmp.cpp:1275
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: зображення зашироке для піктограми"
 
-#: ../src/common/imagbmp.cpp:1603
+#: ../src/common/imagbmp.cpp:1615
 msgid "ICO: Invalid icon index."
 msgstr "ICO: Помилковий індекс піктограми."
 
-#: ../src/common/imagiff.cpp:758
+#: ../src/common/imagiff.cpp:755
 msgid "IFF: data stream seems to be truncated."
 msgstr "IFF: потік даних здається обрізано."
 
-#: ../src/common/imagiff.cpp:742
+#: ../src/common/imagiff.cpp:739
 msgid "IFF: error in IFF image format."
 msgstr "IFF: помилка у форматі картинки IFF."
 
-#: ../src/common/imagiff.cpp:745
+#: ../src/common/imagiff.cpp:742
 msgid "IFF: not enough memory."
 msgstr "IFF: не вистачає пам'яті."
 
-#: ../src/common/imagiff.cpp:748
+#: ../src/common/imagiff.cpp:745
 msgid "IFF: unknown error!!!"
 msgstr "IIF: Невідома помилка!!!"
 
-#: ../src/common/fmapbase.cpp:197
+#: ../src/common/fmapbase.cpp:194
 msgid "ISO-2022-JP"
 msgstr "ISO-2022-JP"
 
-#: ../src/html/htmprint.cpp:282
+#: ../src/html/htmprint.cpp:294
 msgid ""
 "If possible, try changing the layout parameters to make the printout more "
 "narrow."
 msgstr ""
 "Спробуйте змінити параметри компонування так, що зробити відбиток вужчим."
 
-#: ../src/generic/dbgrptg.cpp:358
+#: ../src/generic/dbgrptg.cpp:362
 msgid ""
 "If you have any additional information pertaining to this bug\n"
 "report, please enter it here and it will be joined to it:"
@@ -4145,46 +4255,50 @@ msgstr ""
 "але майте на увазі, що це може зашкодити покращенню програми, отож,\n"
 "за будь-якої нагоди продовжіть роботу над звітом.\n"
 
-#: ../src/msw/registry.cpp:1405
+#: ../src/common/zipstrm.cpp:1043
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1393
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Значенням «%s» ключа «%s» знехтувано."
 
-#: ../src/common/xtistrm.cpp:295
+#: ../src/common/xtistrm.cpp:292
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Некоректний клас об'єктів (Не-wxEvtHandler) як джерело подій"
 
-#: ../src/common/xti.cpp:513
+#: ../src/common/xti.cpp:510
 msgid "Illegal Parameter Count for ConstructObject Method"
 msgstr "Неправильна кількість параметрів у методі ConstructObject"
 
-#: ../src/common/xti.cpp:501
+#: ../src/common/xti.cpp:498
 msgid "Illegal Parameter Count for Create Method"
 msgstr "Неправильна кількість параметрів у методі Create"
 
-#: ../src/generic/dirctrlg.cpp:570 ../src/generic/filectrlg.cpp:756
+#: ../src/generic/dirctrlg.cpp:536 ../src/generic/filectrlg.cpp:752
 msgid "Illegal directory name."
 msgstr "Неправильне назва теки."
 
-#: ../src/generic/filectrlg.cpp:1367
+#: ../src/generic/filectrlg.cpp:1356
 msgid "Illegal file specification."
 msgstr "Неправильна специфікація файла."
 
-#: ../src/common/image.cpp:2269
+#: ../src/common/image.cpp:2363
 msgid "Image and mask have different sizes."
 msgstr "Зображення і маска мають різні розміри."
 
-#: ../src/common/image.cpp:2746
+#: ../src/common/image.cpp:2841
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "Файл зображення не належить до типу %d."
 
-#: ../src/common/image.cpp:2877
+#: ../src/common/image.cpp:2995
 #, c-format
 msgid "Image is not of type %s."
 msgstr "Зображення не належить до типу %s."
 
-#: ../src/msw/textctrl.cpp:488
+#: ../src/msw/textctrl.cpp:534
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -4193,102 +4307,102 @@ msgstr ""
 "використовується звичайний модуль показу тексту. Будь ласка, перевстановіть "
 "riched32.dll"
 
-#: ../src/unix/utilsunx.cpp:301
+#: ../src/unix/utilsunx.cpp:303
 msgid "Impossible to get child process input"
 msgstr "Не вдалося отримати дані від зародженого процесу"
 
-#: ../src/common/filefn.cpp:1028
+#: ../src/common/filefn.cpp:917
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Не вдалося отримати дозволи на файл «%s»"
 
-#: ../src/common/filefn.cpp:1042
+#: ../src/common/filefn.cpp:931
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Не вдалося переписати файл «%s»"
 
-#: ../src/common/filefn.cpp:1097
+#: ../src/common/filefn.cpp:986
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Не вдалося встановити доступ до файла «%s»"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:886
+#: ../src/propgrid/advprops.cpp:787
 #, fuzzy
 msgid "InactiveBorder"
 msgstr "Рамка"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:887
+#: ../src/propgrid/advprops.cpp:788
 msgid "InactiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:888
+#: ../src/propgrid/advprops.cpp:789
 msgid "InactiveCaptionText"
 msgstr ""
 
-#: ../src/common/gifdecod.cpp:792
+#: ../src/common/gifdecod.cpp:826
 #, c-format
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "Некоректна розмірність кадру GIF (%u, %d), кадр з номером %u"
 
-#: ../src/msw/ole/automtn.cpp:635
+#: ../src/msw/ole/automtn.cpp:626
 msgid "Incorrect number of arguments."
 msgstr "Некоректна кількість аргументів."
 
-#: ../src/common/stockitem.cpp:165
+#: ../src/common/stockitem.cpp:162
 msgid "Indent"
 msgstr "Відступ"
 
-#: ../src/richtext/richtextformatdlg.cpp:349
+#: ../src/richtext/richtextformatdlg.cpp:342
 msgid "Indents && Spacing"
 msgstr "Відступи та проміжки"
 
-#: ../src/common/stockitem.cpp:166 ../src/html/helpwnd.cpp:515
+#: ../src/common/stockitem.cpp:163 ../src/html/helpwnd.cpp:513
 msgid "Index"
 msgstr "Індекс"
 
-#: ../src/common/fmapbase.cpp:159
+#: ../src/common/fmapbase.cpp:156
 msgid "Indian (ISO-8859-12)"
 msgstr "Індійська (ISO-8859-12)"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "Info"
 msgstr "Інформація"
 
-#: ../src/common/init.cpp:287
+#: ../src/common/init.cpp:284
 msgid "Initialization failed in post init, aborting."
 msgstr "Помилка ініціалізації у процесі post init, зупинка."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:54
+#: ../src/common/accelcmn.cpp:51
 #, fuzzy
 msgid "Ins"
 msgstr "Вкладка"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextsymboldlg.cpp:472 ../src/common/accelcmn.cpp:53
+#: ../src/common/accelcmn.cpp:50 ../src/richtext/richtextsymboldlg.cpp:469
 msgid "Insert"
 msgstr "Вставити"
 
-#: ../src/richtext/richtextbuffer.cpp:8067
+#: ../src/richtext/richtextbuffer.cpp:8063
 msgid "Insert Field"
 msgstr "Вставити поле"
 
-#: ../src/richtext/richtextbuffer.cpp:7978
-#: ../src/richtext/richtextbuffer.cpp:8936
+#: ../src/richtext/richtextbuffer.cpp:7974
+#: ../src/richtext/richtextbuffer.cpp:8934
 msgid "Insert Image"
 msgstr "Вставити картинку"
 
-#: ../src/richtext/richtextbuffer.cpp:8025
+#: ../src/richtext/richtextbuffer.cpp:8021
 msgid "Insert Object"
 msgstr "Вставити об’єкт"
 
-#: ../src/richtext/richtextctrl.cpp:1286 ../src/richtext/richtextctrl.cpp:1494
-#: ../src/richtext/richtextbuffer.cpp:7822
-#: ../src/richtext/richtextbuffer.cpp:7852
-#: ../src/richtext/richtextbuffer.cpp:7894
+#: ../src/richtext/richtextbuffer.cpp:7818
+#: ../src/richtext/richtextbuffer.cpp:7848
+#: ../src/richtext/richtextbuffer.cpp:7890
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
 msgid "Insert Text"
 msgstr "Вставити текст"
 
@@ -4301,18 +4415,11 @@ msgstr "Додає розрив сторінки до абзацу."
 msgid "Inset"
 msgstr "Вкладка"
 
-#: ../src/gtk/app.cpp:425
-#, c-format
-msgid "Invalid GTK+ command line option, use \"%s --help\""
-msgstr ""
-"Некоректний параметр командного рядка GTK+, скористайтеся командою «%s --"
-"help»"
-
-#: ../src/common/imagtiff.cpp:311
+#: ../src/common/imagtiff.cpp:308
 msgid "Invalid TIFF image index."
 msgstr "Неможливий індекс зображення TIFF."
 
-#: ../src/common/appcmn.cpp:273
+#: ../src/common/appcmn.cpp:294
 #, c-format
 msgid "Invalid display mode specification '%s'."
 msgstr "Неправильна специфікація режиму дисплею «%s»."
@@ -4322,259 +4429,263 @@ msgstr "Неправильна специфікація режиму диспл�
 msgid "Invalid geometry specification '%s'"
 msgstr "Неправильна специфікація геометрії «%s»"
 
-#: ../src/unix/fswatcher_inotify.cpp:323
+#: ../src/unix/fswatcher_inotify.cpp:320
 #, c-format
 msgid "Invalid inotify event for \"%s\""
 msgstr "Некоректна подія inotify для «%s»"
 
-#: ../src/unix/snglinst.cpp:312
+#: ../src/unix/snglinst.cpp:309
 #, c-format
 msgid "Invalid lock file '%s'."
 msgstr "Помилковий файл блокування «%s»."
 
-#: ../src/common/translation.cpp:1125
+#: ../src/common/translation.cpp:1167
 msgid "Invalid message catalog."
 msgstr "Помилковий каталог повідомлень."
 
-#: ../src/common/xtistrm.cpp:405 ../src/common/xtistrm.cpp:420
+#: ../src/common/xtistrm.cpp:402 ../src/common/xtistrm.cpp:417
 msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
 msgstr ""
 "До GetObjectClassInfo передано помилковий або нульовий ідентифікатор об'єкта"
 
-#: ../src/common/xtistrm.cpp:435
+#: ../src/common/xtistrm.cpp:432
 msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
 msgstr ""
 "До HasObjectClassInfo передано помилковий або нульовий ідентифікатор об'єкта"
 
-#: ../src/common/regex.cpp:310
+#: ../src/common/regex.cpp:307
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Неправильний регулярний вираз «%s»: %s"
 
-#: ../src/common/config.cpp:226
+#: ../src/common/config.cpp:222
 #, c-format
 msgid "Invalid value %ld for a boolean key \"%s\" in config file."
 msgstr "Некоректне значення %ld булевого ключа «%s» у файлі налаштувань."
 
-#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:351
-#: ../src/osx/carbon/fontdlg.cpp:361 ../src/common/stockitem.cpp:168
+#: ../src/osx/carbon/fontdlg.cpp:358 ../src/common/stockitem.cpp:165
+#: ../src/generic/fontdlgg.cpp:325 ../src/richtext/richtextfontpage.cpp:351
 msgid "Italic"
 msgstr "Курсив"
 
-#: ../src/common/paper.cpp:130
+#: ../src/common/paper.cpp:127
 msgid "Italy Envelope, 110 x 230 mm"
 msgstr "Італійський Конверт, 110 x 230 мм"
 
-#: ../src/common/imagjpeg.cpp:270
+#: ../src/common/imagjpeg.cpp:257
 msgid "JPEG: Couldn't load - file is probably corrupted."
 msgstr "JPEG: Не вдалося завантажити — можливо файл пошкоджено."
 
-#: ../src/common/imagjpeg.cpp:449
+#: ../src/common/imagjpeg.cpp:436
 msgid "JPEG: Couldn't save image."
 msgstr "JPEG: Не вдалося записати зображення."
 
-#: ../src/common/paper.cpp:163
+#: ../src/common/paper.cpp:160
 msgid "Japanese Double Postcard 200 x 148 mm"
 msgstr "Японська подвійна листівка 200 x 148 мм"
 
-#: ../src/common/paper.cpp:167
+#: ../src/common/paper.cpp:164
 msgid "Japanese Envelope Chou #3"
 msgstr "Японський конверт Chou #3"
 
-#: ../src/common/paper.cpp:180
+#: ../src/common/paper.cpp:177
 msgid "Japanese Envelope Chou #3 Rotated"
 msgstr "Японський конверт Chou #3 Повернутий"
 
-#: ../src/common/paper.cpp:168
+#: ../src/common/paper.cpp:165
 msgid "Japanese Envelope Chou #4"
 msgstr "Японський конверт Chou #4"
 
-#: ../src/common/paper.cpp:181
+#: ../src/common/paper.cpp:178
 msgid "Japanese Envelope Chou #4 Rotated"
 msgstr "Японський конверт Chou #4 Повернутий"
 
-#: ../src/common/paper.cpp:165
+#: ../src/common/paper.cpp:162
 msgid "Japanese Envelope Kaku #2"
 msgstr "Японський конверт Kaku #2"
 
-#: ../src/common/paper.cpp:178
+#: ../src/common/paper.cpp:175
 msgid "Japanese Envelope Kaku #2 Rotated"
 msgstr "Японський конверт Kaku #2 Повернутий"
 
-#: ../src/common/paper.cpp:166
+#: ../src/common/paper.cpp:163
 msgid "Japanese Envelope Kaku #3"
 msgstr "Японський конверт Kaku #3"
 
-#: ../src/common/paper.cpp:179
+#: ../src/common/paper.cpp:176
 msgid "Japanese Envelope Kaku #3 Rotated"
 msgstr "Японський конверт Kaku #3 Повернутий"
 
-#: ../src/common/paper.cpp:185
+#: ../src/common/paper.cpp:182
 msgid "Japanese Envelope You #4"
 msgstr "Японський конверт You #4"
 
-#: ../src/common/paper.cpp:186
+#: ../src/common/paper.cpp:183
 msgid "Japanese Envelope You #4 Rotated"
 msgstr "Японський конверт You #4 Повернутий"
 
-#: ../src/common/paper.cpp:138
+#: ../src/common/paper.cpp:135
 msgid "Japanese Postcard 100 x 148 mm"
 msgstr "Японська листівка 100 x 148 мм"
 
-#: ../src/common/paper.cpp:175
+#: ../src/common/paper.cpp:172
 msgid "Japanese Postcard Rotated 148 x 100 mm"
 msgstr "Японська листівка Повернута 148 x 100 мм"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "Jump to"
 msgstr "Перейти до"
 
-#: ../src/common/stockitem.cpp:171
+#: ../src/common/stockitem.cpp:168
 msgid "Justified"
 msgstr "Вирівняний"
 
-#: ../src/richtext/richtextindentspage.cpp:155
-#: ../src/richtext/richtextindentspage.cpp:157
 #: ../src/richtext/richtextliststylepage.cpp:344
 #: ../src/richtext/richtextliststylepage.cpp:346
+#: ../src/richtext/richtextindentspage.cpp:155
+#: ../src/richtext/richtextindentspage.cpp:157
 msgid "Justify text left and right."
 msgstr "Розподілити текст за шириною."
 
-#: ../src/common/fmapbase.cpp:163
+#: ../src/common/fmapbase.cpp:160
 msgid "KOI8-R"
 msgstr "KOI8-R"
 
-#: ../src/common/fmapbase.cpp:164
+#: ../src/common/fmapbase.cpp:161
 msgid "KOI8-U"
 msgstr "KOI8-U"
 
-#: ../src/common/accelcmn.cpp:265 ../src/common/accelcmn.cpp:347
+#: ../src/common/accelcmn.cpp:279 ../src/common/accelcmn.cpp:364
 msgid "KP_"
 msgstr "KP_"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 #, fuzzy
 msgid "KP_Add"
 msgstr "KP_ADD"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "KP_Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "KP_Decimal"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 #, fuzzy
 msgid "KP_Delete"
 msgstr "Вилучити"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "KP_Divide"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 #, fuzzy
 msgid "KP_Down"
 msgstr "Донизу"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 #, fuzzy
 msgid "KP_End"
 msgstr "KP_END"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 #, fuzzy
 msgid "KP_Enter"
 msgstr "Друкарка"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "KP_Equal"
 msgstr ""
 
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
-#, fuzzy
-msgid "KP_Home"
-msgstr "Домівка"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
-#, fuzzy
-msgid "KP_Insert"
-msgstr "Вставити"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
-#, fuzzy
-msgid "KP_Left"
-msgstr "Ліворуч"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
-msgid "KP_Multiply"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:99
-#, fuzzy
-msgid "KP_Next"
-msgstr "Далі"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
-msgid "KP_PageDown"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
-msgid "KP_PageUp"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:98
-msgid "KP_Prior"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
-#, fuzzy
-msgid "KP_Right"
-msgstr "Праворуч"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
-msgid "KP_Separator"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
-msgid "KP_Space"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
-msgid "KP_Subtract"
+#: ../src/common/accelcmn.cpp:276 ../src/common/accelcmn.cpp:361
+msgid "KP_F"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
 #: ../src/common/accelcmn.cpp:89
 #, fuzzy
+msgid "KP_Home"
+msgstr "Домівка"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:100
+#, fuzzy
+msgid "KP_Insert"
+msgstr "Вставити"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:90
+#, fuzzy
+msgid "KP_Left"
+msgstr "Ліворуч"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:103
+msgid "KP_Multiply"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:97
+#, fuzzy
+msgid "KP_Next"
+msgstr "Далі"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:95
+msgid "KP_PageDown"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:94
+msgid "KP_PageUp"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:96
+msgid "KP_Prior"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:92
+#, fuzzy
+msgid "KP_Right"
+msgstr "Праворуч"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:105
+msgid "KP_Separator"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:86
+msgid "KP_Space"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:106
+msgid "KP_Subtract"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:87
+#, fuzzy
 msgid "KP_Tab"
 msgstr "KP_TAB"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 #, fuzzy
 msgid "KP_Up"
 msgstr "KP_UP"
@@ -4583,19 +4694,34 @@ msgstr "KP_UP"
 msgid "L&ine spacing:"
 msgstr "Ін&тервал між рядками:"
 
-#: ../src/generic/prntdlgg.cpp:613 ../src/generic/prntdlgg.cpp:868
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "помилка стиснення"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "помилка розпакування"
+
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:861
 msgid "Landscape"
 msgstr "Альбомна"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "Last"
 msgstr "Остання"
 
-#: ../src/common/prntbase.cpp:1572
+#: ../src/common/prntbase.cpp:1597
 msgid "Last page"
 msgstr "Остання сторінка"
 
-#: ../src/common/log.cpp:305
+#: ../src/common/log.cpp:324
 #, fuzzy, c-format
 msgid "Last repeated message (\"%s\", %u time) wasn't output"
 msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
@@ -4603,93 +4729,93 @@ msgstr[0] "Останні повторені повідомлення («%s», %
 msgstr[1] "Останні повторені повідомлення («%s», %lu рази) не було виведено"
 msgstr[2] "Останні повторені повідомлення («%s», %lu разів) не було виведено"
 
-#: ../src/common/paper.cpp:103
+#: ../src/common/paper.cpp:100
 msgid "Ledger, 17 x 11 in"
 msgstr "Ledger, 17 x 11 дюйм"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6146
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:58 ../src/generic/datavgen.cpp:6951
+#: ../src/richtext/richtextsizepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:252
 #: ../src/richtext/richtextliststylepage.cpp:253
 #: ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
-#: ../src/richtext/richtextsizepage.cpp:249 ../src/common/accelcmn.cpp:61
 msgid "Left"
 msgstr "Ліворуч"
 
-#: ../src/richtext/richtextindentspage.cpp:204
 #: ../src/richtext/richtextliststylepage.cpp:390
+#: ../src/richtext/richtextindentspage.cpp:204
 msgid "Left (&first line):"
 msgstr "Ліворуч (&перший рядок):"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1761
+#: ../src/propgrid/advprops.cpp:1662
 msgid "Left Button"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:880
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Left margin (mm):"
 msgstr "Ліве поле (мм):"
 
-#: ../src/richtext/richtextindentspage.cpp:141
-#: ../src/richtext/richtextindentspage.cpp:143
 #: ../src/richtext/richtextliststylepage.cpp:330
 #: ../src/richtext/richtextliststylepage.cpp:332
+#: ../src/richtext/richtextindentspage.cpp:141
+#: ../src/richtext/richtextindentspage.cpp:143
 msgid "Left-align text."
 msgstr "Вирівняти текст ліворуч."
 
-#: ../src/common/paper.cpp:144
+#: ../src/common/paper.cpp:141
 msgid "Legal Extra 9 1/2 x 15 in"
 msgstr "Легал Екстра 9 1/2 x 15 дюймів"
 
-#: ../src/common/paper.cpp:96
+#: ../src/common/paper.cpp:93
 msgid "Legal, 8 1/2 x 14 in"
 msgstr "Легал, 8 1/2 x 14 дюймів"
 
-#: ../src/common/paper.cpp:143
+#: ../src/common/paper.cpp:140
 msgid "Letter Extra 9 1/2 x 12 in"
 msgstr "Легал Екстра, 9 1/2 x 12 дюймів"
 
-#: ../src/common/paper.cpp:149
+#: ../src/common/paper.cpp:146
 msgid "Letter Extra Transverse 9.275 x 12 in"
 msgstr "Letter Extra Поперечний 9.275 x 12 дюймів"
 
-#: ../src/common/paper.cpp:152
+#: ../src/common/paper.cpp:149
 msgid "Letter Plus 8 1/2 x 12.69 in"
 msgstr "Легал плюс, 8 1/2 x 12,69 дюймів"
 
-#: ../src/common/paper.cpp:169
+#: ../src/common/paper.cpp:166
 msgid "Letter Rotated 11 x 8 1/2 in"
 msgstr "Лист повернутий 11 x 8 1/2 дюймів"
 
-#: ../src/common/paper.cpp:101
+#: ../src/common/paper.cpp:98
 msgid "Letter Small, 8 1/2 x 11 in"
 msgstr "Малий лист 8 1/2 x 11 дюймів"
 
-#: ../src/common/paper.cpp:147
+#: ../src/common/paper.cpp:144
 msgid "Letter Transverse 8 1/2 x 11 in"
 msgstr "Лист поперечний 8 1/2 x 11 дюймів"
 
-#: ../src/common/paper.cpp:95
+#: ../src/common/paper.cpp:92
 msgid "Letter, 8 1/2 x 11 in"
 msgstr "Лист, 8 1/2 x 11 дюймів"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "License"
 msgstr "Ліцензія"
 
-#: ../src/generic/fontdlgg.cpp:332
+#: ../src/generic/fontdlgg.cpp:328
 msgid "Light"
 msgstr "Світлий"
 
-#: ../src/propgrid/advprops.cpp:1608
+#: ../src/propgrid/advprops.cpp:1514
 msgid "Lime"
 msgstr "Лайм"
 
-#: ../src/generic/helpext.cpp:294
+#: ../src/generic/helpext.cpp:292
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr "Рядок %lu файла карти «%s» має помилковий синтаксис, пропущено."
@@ -4698,15 +4824,15 @@ msgstr "Рядок %lu файла карти «%s» має помилковий 
 msgid "Line spacing:"
 msgstr "Проміжок між рядками:"
 
-#: ../src/html/chm.cpp:838
+#: ../src/html/chm.cpp:829
 msgid "Link contained '//', converted to absolute link."
 msgstr "Посилання, що містило '//', перетворено на абсолютне посилання."
 
-#: ../src/richtext/richtextformatdlg.cpp:364
+#: ../src/richtext/richtextformatdlg.cpp:357
 msgid "List Style"
 msgstr "Стиль списку"
 
-#: ../src/richtext/richtextstyles.cpp:1064
+#: ../src/richtext/richtextstyles.cpp:1061
 msgid "List styles"
 msgstr "Стилі списку"
 
@@ -4720,26 +4846,26 @@ msgstr "Показує список розмірів шрифтів у пунк�
 msgid "Lists the available fonts."
 msgstr "Списки доступних шрифтів."
 
-#: ../src/common/fldlgcmn.cpp:340
+#: ../src/common/fldlgcmn.cpp:337
 #, c-format
 msgid "Load %s file"
 msgstr "Завантажити файл %s"
 
-#: ../src/html/htmlwin.cpp:597
+#: ../src/html/htmlwin.cpp:600
 msgid "Loading : "
 msgstr "Завантаження : "
 
-#: ../src/unix/snglinst.cpp:246
+#: ../src/unix/snglinst.cpp:243
 #, c-format
 msgid "Lock file '%s' has incorrect owner."
 msgstr "Файл блокування «%s» має помилкового власника."
 
-#: ../src/unix/snglinst.cpp:251
+#: ../src/unix/snglinst.cpp:248
 #, c-format
 msgid "Lock file '%s' has incorrect permissions."
 msgstr "Файл блокування «%s» має помилкові дозволи."
 
-#: ../src/generic/logg.cpp:576
+#: ../src/generic/logg.cpp:573
 #, c-format
 msgid "Log saved to the file '%s'."
 msgstr "Журнал записаний в файл «%s»."
@@ -4754,11 +4880,11 @@ msgstr "Літери нижнього регістру"
 msgid "Lower case roman numerals"
 msgstr "Римські цифри у нижньому регістрі"
 
-#: ../src/gtk/mdi.cpp:422 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk1/mdi.cpp:431 ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "Нащадок MDI"
 
-#: ../src/msw/helpchm.cpp:56
+#: ../src/msw/helpchm.cpp:53
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -4766,189 +4892,189 @@ msgstr ""
 "Функції довідки MS HTML недоступні, оскільки на цій машині не встановлено "
 "бібліотеку довідки MS HTML. Будь ласка, встановіть її."
 
-#: ../src/univ/themes/win32.cpp:3754
+#: ../src/univ/themes/win32.cpp:3751
 msgid "Ma&ximize"
 msgstr "З&більшити"
 
-#: ../src/common/fmapbase.cpp:203
+#: ../src/common/fmapbase.cpp:200
 msgid "MacArabic"
 msgstr "Арабська, Mac"
 
-#: ../src/common/fmapbase.cpp:222
+#: ../src/common/fmapbase.cpp:219
 msgid "MacArmenian"
 msgstr "Вірменська, Mac"
 
-#: ../src/common/fmapbase.cpp:211
+#: ../src/common/fmapbase.cpp:208
 msgid "MacBengali"
 msgstr "Бенгальська, Mac"
 
-#: ../src/common/fmapbase.cpp:217
+#: ../src/common/fmapbase.cpp:214
 msgid "MacBurmese"
 msgstr "Бірманська, Mac"
 
-#: ../src/common/fmapbase.cpp:236
+#: ../src/common/fmapbase.cpp:233
 msgid "MacCeltic"
 msgstr "Кельтська, Mac"
 
-#: ../src/common/fmapbase.cpp:227
+#: ../src/common/fmapbase.cpp:224
 msgid "MacCentralEurRoman"
 msgstr "Романська, Центральна Європа, Mac"
 
-#: ../src/common/fmapbase.cpp:223
+#: ../src/common/fmapbase.cpp:220
 msgid "MacChineseSimp"
 msgstr "Китайська спрощена, Mac"
 
-#: ../src/common/fmapbase.cpp:201
+#: ../src/common/fmapbase.cpp:198
 msgid "MacChineseTrad"
 msgstr "Китайська традиційна, Mac"
 
-#: ../src/common/fmapbase.cpp:233
+#: ../src/common/fmapbase.cpp:230
 msgid "MacCroatian"
 msgstr "Хорватська, Mac"
 
-#: ../src/common/fmapbase.cpp:206
+#: ../src/common/fmapbase.cpp:203
 msgid "MacCyrillic"
 msgstr "Кирилиця, Mac"
 
-#: ../src/common/fmapbase.cpp:207
+#: ../src/common/fmapbase.cpp:204
 msgid "MacDevanagari"
 msgstr "Деванагарі, Mac"
 
-#: ../src/common/fmapbase.cpp:231
+#: ../src/common/fmapbase.cpp:228
 msgid "MacDingbats"
 msgstr "Декоративні, Mac"
 
-#: ../src/common/fmapbase.cpp:226
+#: ../src/common/fmapbase.cpp:223
 msgid "MacEthiopic"
 msgstr "Ефіопська, Mac"
 
-#: ../src/common/fmapbase.cpp:229
+#: ../src/common/fmapbase.cpp:226
 msgid "MacExtArabic"
 msgstr "Арабська, розширена, Mac"
 
-#: ../src/common/fmapbase.cpp:237
+#: ../src/common/fmapbase.cpp:234
 msgid "MacGaelic"
 msgstr "Гельська, Mac"
 
-#: ../src/common/fmapbase.cpp:221
+#: ../src/common/fmapbase.cpp:218
 msgid "MacGeorgian"
 msgstr "Грузинська, Mac"
 
-#: ../src/common/fmapbase.cpp:205
+#: ../src/common/fmapbase.cpp:202
 msgid "MacGreek"
 msgstr "Грецька, Mac"
 
-#: ../src/common/fmapbase.cpp:209
+#: ../src/common/fmapbase.cpp:206
 msgid "MacGujarati"
 msgstr "Гуджараті, Mac"
 
-#: ../src/common/fmapbase.cpp:208
+#: ../src/common/fmapbase.cpp:205
 msgid "MacGurmukhi"
 msgstr "Гурмухі, Mac"
 
-#: ../src/common/fmapbase.cpp:204
+#: ../src/common/fmapbase.cpp:201
 msgid "MacHebrew"
 msgstr "Іврит, Mac"
 
-#: ../src/common/fmapbase.cpp:234
+#: ../src/common/fmapbase.cpp:231
 msgid "MacIcelandic"
 msgstr "Ісландська, Mac"
 
-#: ../src/common/fmapbase.cpp:200
+#: ../src/common/fmapbase.cpp:197
 msgid "MacJapanese"
 msgstr "Японська, Mac"
 
-#: ../src/common/fmapbase.cpp:214
+#: ../src/common/fmapbase.cpp:211
 msgid "MacKannada"
 msgstr "Каннада, Mac"
 
-#: ../src/common/fmapbase.cpp:238
+#: ../src/common/fmapbase.cpp:235
 msgid "MacKeyboardGlyphs"
 msgstr "Клавіатурні гліфи, Mac"
 
-#: ../src/common/fmapbase.cpp:218
+#: ../src/common/fmapbase.cpp:215
 msgid "MacKhmer"
 msgstr "Кхмерська, Mac"
 
-#: ../src/common/fmapbase.cpp:202
+#: ../src/common/fmapbase.cpp:199
 msgid "MacKorean"
 msgstr "Корейська, Mac"
 
-#: ../src/common/fmapbase.cpp:220
+#: ../src/common/fmapbase.cpp:217
 msgid "MacLaotian"
 msgstr "Лаоська, Mac"
 
-#: ../src/common/fmapbase.cpp:215
+#: ../src/common/fmapbase.cpp:212
 msgid "MacMalayalam"
 msgstr "Малаялам, Mac"
 
-#: ../src/common/fmapbase.cpp:225
+#: ../src/common/fmapbase.cpp:222
 msgid "MacMongolian"
 msgstr "Монгольська, Mac"
 
-#: ../src/common/fmapbase.cpp:210
+#: ../src/common/fmapbase.cpp:207
 msgid "MacOriya"
 msgstr "Орійська, Mac"
 
-#: ../src/common/fmapbase.cpp:199
+#: ../src/common/fmapbase.cpp:196
 msgid "MacRoman"
 msgstr "Романська, Mac"
 
-#: ../src/common/fmapbase.cpp:235
+#: ../src/common/fmapbase.cpp:232
 msgid "MacRomanian"
 msgstr "Румунська, Mac"
 
-#: ../src/common/fmapbase.cpp:216
+#: ../src/common/fmapbase.cpp:213
 msgid "MacSinhalese"
 msgstr "Сингальська, Mac"
 
-#: ../src/common/fmapbase.cpp:230
+#: ../src/common/fmapbase.cpp:227
 msgid "MacSymbol"
 msgstr "Символи, Mac"
 
-#: ../src/common/fmapbase.cpp:212
+#: ../src/common/fmapbase.cpp:209
 msgid "MacTamil"
 msgstr "Тамільська, Mac"
 
-#: ../src/common/fmapbase.cpp:213
+#: ../src/common/fmapbase.cpp:210
 msgid "MacTelugu"
 msgstr "Телугу, Mac"
 
-#: ../src/common/fmapbase.cpp:219
+#: ../src/common/fmapbase.cpp:216
 msgid "MacThai"
 msgstr "Тайська, Mac"
 
-#: ../src/common/fmapbase.cpp:224
+#: ../src/common/fmapbase.cpp:221
 msgid "MacTibetan"
 msgstr "Тибетська, Mac"
 
-#: ../src/common/fmapbase.cpp:232
+#: ../src/common/fmapbase.cpp:229
 msgid "MacTurkish"
 msgstr "Турецька, Mac"
 
-#: ../src/common/fmapbase.cpp:228
+#: ../src/common/fmapbase.cpp:225
 msgid "MacVietnamese"
 msgstr "В’єтнамська, Mac"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1762
+#: ../src/propgrid/advprops.cpp:1663
 msgid "Magnifier"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:2143
+#: ../src/propgrid/advprops.cpp:2050
 msgid "Make a selection:"
 msgstr "Зробіть вибір:"
 
-#: ../src/richtext/richtextformatdlg.cpp:374
+#: ../src/richtext/richtextformatdlg.cpp:367
 #: ../src/richtext/richtextmarginspage.cpp:171
 msgid "Margins"
 msgstr "Поля"
 
-#: ../src/propgrid/advprops.cpp:1595
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Maroon"
 msgstr "Брунато-малиновий"
 
-#: ../src/generic/fdrepdlg.cpp:147
+#: ../src/generic/fdrepdlg.cpp:144
 msgid "Match case"
 msgstr "Великі/малі літери"
 
@@ -4960,40 +5086,40 @@ msgstr "Макс. висота:"
 msgid "Max width:"
 msgstr "Макс. ширина:"
 
-#: ../src/unix/mediactrl.cpp:947
+#: ../src/unix/mediactrl.cpp:972
 #, c-format
 msgid "Media playback error: %s"
 msgstr "Помилка відтворення мультимедійних даних: %s"
 
-#: ../src/common/fs_mem.cpp:175
+#: ../src/common/fs_mem.cpp:170
 #, c-format
 msgid "Memory VFS already contains file '%s'!"
 msgstr "Пам'ять VFS вже має файл «%s»!"
 
 #. TRANSLATORS: Name of keyboard key
 #. TRANSLATORS: Keyword of system colour
-#: ../src/common/accelcmn.cpp:73 ../src/propgrid/advprops.cpp:889
+#: ../src/common/accelcmn.cpp:70 ../src/propgrid/advprops.cpp:790
 msgid "Menu"
 msgstr "Меню"
 
-#: ../src/common/msgout.cpp:124
+#: ../src/common/msgout.cpp:121
 msgid "Message"
 msgstr "Повідомлення"
 
-#: ../src/univ/themes/metal.cpp:168
+#: ../src/univ/themes/metal.cpp:165
 msgid "Metal theme"
 msgstr "Металічний мотив"
 
-#: ../src/msw/ole/automtn.cpp:652
+#: ../src/msw/ole/automtn.cpp:643
 msgid "Method or property not found."
 msgstr "Метод або властивість не знайдено."
 
-#: ../src/univ/themes/win32.cpp:3752
+#: ../src/univ/themes/win32.cpp:3749
 msgid "Mi&nimize"
 msgstr "З&меншити"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1763
+#: ../src/propgrid/advprops.cpp:1664
 msgid "Middle Button"
 msgstr "Середня Кнопка"
 
@@ -5005,37 +5131,42 @@ msgstr "Мін. висота:"
 msgid "Min width:"
 msgstr "Мінімальна ширина:"
 
-#: ../src/msw/ole/automtn.cpp:668
+#: ../src/osx/cocoa/menu.mm:281
+#, fuzzy
+msgid "Minimize"
+msgstr "З&меншити"
+
+#: ../src/msw/ole/automtn.cpp:659
 msgid "Missing a required parameter."
 msgstr "Не виявлено потрібного параметра."
 
-#: ../src/generic/fontdlgg.cpp:324
+#: ../src/generic/fontdlgg.cpp:320
 msgid "Modern"
 msgstr "Модерний"
 
-#: ../src/generic/filectrlg.cpp:427
+#: ../src/generic/filectrlg.cpp:423
 msgid "Modified"
 msgstr "Змінено"
 
-#: ../src/common/module.cpp:133
+#: ../src/common/module.cpp:130
 #, c-format
 msgid "Module \"%s\" initialization failed"
 msgstr "Виклик модулі «%s» зазнав невдачі"
 
-#: ../src/common/paper.cpp:131
+#: ../src/common/paper.cpp:128
 msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
 msgstr "Monarch конверт, 3 7/8 x 7 1/2 дюйм"
 
-#: ../src/msw/fswatcher.cpp:143
+#: ../src/msw/fswatcher.cpp:140
 msgid "Monitoring individual files for changes is not supported currently."
 msgstr ""
 "Спостереження за змінами у окремих файлах у поточній версії не передбачено."
 
-#: ../src/generic/editlbox.cpp:172
+#: ../src/generic/editlbox.cpp:160
 msgid "Move down"
 msgstr "Пересунути нижче"
 
-#: ../src/generic/editlbox.cpp:171
+#: ../src/generic/editlbox.cpp:155
 msgid "Move up"
 msgstr "Пересунути вгору"
 
@@ -5049,97 +5180,102 @@ msgstr "Пересуває об’єкт до наступного абзацу.
 msgid "Moves the object to the previous paragraph."
 msgstr "Пересуває об’єкт до попереднього абзацу."
 
-#: ../src/richtext/richtextbuffer.cpp:9966
+#: ../src/richtext/richtextbuffer.cpp:9963
 msgid "Multiple Cell Properties"
 msgstr "Властивості декількох комірок"
 
-#: ../src/generic/filectrlg.cpp:424
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:82
+msgid "Multiply"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:420
 msgid "Name"
 msgstr "Назва"
 
-#: ../src/propgrid/advprops.cpp:1596
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Navy"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "Network"
 msgstr "Мережа"
 
-#: ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173
 msgid "New"
 msgstr "Створити"
 
-#: ../src/richtext/richtextstyledlg.cpp:243
+#: ../src/richtext/richtextstyledlg.cpp:239
 msgid "New &Box Style..."
 msgstr "Створити стиль &панелі…"
 
-#: ../src/richtext/richtextstyledlg.cpp:225
+#: ../src/richtext/richtextstyledlg.cpp:221
 msgid "New &Character Style..."
 msgstr "Новий &стиль символів…"
 
-#: ../src/richtext/richtextstyledlg.cpp:237
+#: ../src/richtext/richtextstyledlg.cpp:233
 msgid "New &List Style..."
 msgstr "Створити стиль &списку…"
 
-#: ../src/richtext/richtextstyledlg.cpp:231
+#: ../src/richtext/richtextstyledlg.cpp:227
 msgid "New &Paragraph Style..."
 msgstr "Створити стиль &абзацу…"
 
-#: ../src/richtext/richtextstyledlg.cpp:606
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:654
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:820
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:893
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:934
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:602
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:650
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:816
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:889
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:930
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "New Style"
 msgstr "Новий стиль"
 
-#: ../src/generic/editlbox.cpp:169
+#: ../src/generic/editlbox.cpp:139
 msgid "New item"
 msgstr "Новий елемент"
 
-#: ../src/generic/dirdlgg.cpp:297 ../src/generic/dirdlgg.cpp:307
-#: ../src/generic/filectrlg.cpp:618 ../src/generic/filectrlg.cpp:627
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+#: ../src/generic/dirdlgg.cpp:294 ../src/generic/dirdlgg.cpp:304
 msgid "NewName"
 msgstr "НоваНазва"
 
-#: ../src/common/prntbase.cpp:1567 ../src/html/helpwnd.cpp:665
+#: ../src/common/prntbase.cpp:1592 ../src/html/helpwnd.cpp:663
 msgid "Next page"
 msgstr "Наступна сторінка"
 
-#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:177
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:174
 #: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Ні"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1764
+#: ../src/propgrid/advprops.cpp:1665
 msgid "No Entry"
 msgstr ""
 
-#: ../src/generic/animateg.cpp:150
+#: ../src/generic/animateg.cpp:133
 #, c-format
 msgid "No animation handler for type %ld defined."
 msgstr "Не визначено рушія анімації для типу %ld."
 
-#: ../src/dfb/bitmap.cpp:642 ../src/dfb/bitmap.cpp:676
+#: ../src/dfb/bitmap.cpp:639 ../src/dfb/bitmap.cpp:673
 #, c-format
 msgid "No bitmap handler for type %d defined."
 msgstr "Не знайдено жодного інструмент обробки растру для типу %d."
 
-#: ../src/common/utilscmn.cpp:1077
+#: ../src/common/utilscmn.cpp:1095
 msgid "No default application configured for HTML files."
 msgstr "Для файлів HTML не вказано типової програми."
 
-#: ../src/generic/helpext.cpp:445
+#: ../src/generic/helpext.cpp:443
 msgid "No entries found."
 msgstr "Запис не знайдений."
 
-#: ../src/common/fontmap.cpp:421
+#: ../src/common/fontmap.cpp:418
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found,\n"
@@ -5151,7 +5287,7 @@ msgstr ""
 "але доступне альтернативне кодування «%s».\n"
 "Хочете використовувати це кодування (інакше вам доведеться вибрати інше)?"
 
-#: ../src/common/fontmap.cpp:426
+#: ../src/common/fontmap.cpp:423
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found.\n"
@@ -5162,206 +5298,206 @@ msgstr ""
 "Ви бажаєте вибрати шрифт для використання з цим кодуванням\n"
 "(інакше текст у цьому кодуванні не буде показано вірно)?"
 
-#: ../src/generic/animateg.cpp:142
+#: ../src/generic/animateg.cpp:125
 msgid "No handler found for animation type."
 msgstr "Не знайдено обробника для цього типу анімації."
 
-#: ../src/common/image.cpp:2728
+#: ../src/common/image.cpp:2823
 msgid "No handler found for image type."
 msgstr "Не знайдено жодного інструменту обробки для зображення."
 
-#: ../src/common/image.cpp:2736 ../src/common/image.cpp:2848
-#: ../src/common/image.cpp:2901
+#: ../src/common/image.cpp:2831 ../src/common/image.cpp:2954
+#: ../src/common/image.cpp:3020
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "Не знайдено жодного обробника для зображення типу %d."
 
-#: ../src/common/image.cpp:2871 ../src/common/image.cpp:2915
+#: ../src/common/image.cpp:2986 ../src/common/image.cpp:3034
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "Не знайдено жодного обробника для зображення типу %s."
 
-#: ../src/html/helpwnd.cpp:858
+#: ../src/html/helpwnd.cpp:856
 msgid "No matching page found yet"
 msgstr "Відповідної сторінки ще не знайдено"
 
-#: ../src/unix/sound.cpp:81
+#: ../src/unix/sound.cpp:78
 msgid "No sound"
 msgstr "Без звуку"
 
-#: ../src/common/image.cpp:2277 ../src/common/image.cpp:2318
+#: ../src/common/image.cpp:2371 ../src/common/image.cpp:2412
 msgid "No unused colour in image being masked."
 msgstr "Немає невикористаного кольору в зображенні, яке маскується."
 
-#: ../src/common/image.cpp:3374
-msgid "No unused colour in image."
-msgstr "У зображенні немає невикористаного кольору."
-
-#: ../src/generic/helpext.cpp:302
+#: ../src/generic/helpext.cpp:300
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "Не знайдено дійсних відповідників у файлі «%s»."
 
-#: ../src/richtext/richtextborderspage.cpp:610
 #: ../src/richtext/richtextsizepage.cpp:248
 #: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:610
 msgid "None"
 msgstr "Немає"
 
-#: ../src/common/fmapbase.cpp:157
+#: ../src/common/fmapbase.cpp:154
 msgid "Nordic (ISO-8859-10)"
 msgstr "Нордичне (ISO-8859-10)"
 
-#: ../src/generic/fontdlgg.cpp:328 ../src/generic/fontdlgg.cpp:331
+#: ../src/generic/fontdlgg.cpp:324 ../src/generic/fontdlgg.cpp:327
 msgid "Normal"
 msgstr "Звичайний"
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1261
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Звичайний шрифт<br>та <u>підкреслений</u>. "
 
-#: ../src/html/helpwnd.cpp:1205
+#: ../src/html/helpwnd.cpp:1203
 msgid "Normal font:"
 msgstr "Звичайний шрифт:"
 
-#: ../src/propgrid/props.cpp:1128
+#: ../src/propgrid/props.cpp:1115
 #, c-format
 msgid "Not %s"
 msgstr "Не %s"
 
-#: ../include/wx/filename.h:573 ../include/wx/filename.h:578
-msgid "Not available"
-msgstr "Недоступний"
+#: ../src/common/secretstore.cpp:168
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/webrequest.cpp:605
+msgid "Not enough free disk space for download."
+msgstr ""
 
 #: ../src/richtext/richtextfontpage.cpp:358
 msgid "Not underlined"
 msgstr "Без підкреслювання"
 
-#: ../src/common/paper.cpp:115
+#: ../src/common/paper.cpp:112
 msgid "Note, 8 1/2 x 11 in"
 msgstr "Note, 8 1/2 x 11 дюйм"
 
-#: ../src/generic/notifmsgg.cpp:132
+#: ../src/generic/notifmsgg.cpp:129
 msgid "Notice"
 msgstr "Зауваження"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "Num *"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "Num +"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "Num ,"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "Num -"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "Num ."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "Num /"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "Num ="
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "Num Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 #, fuzzy
 msgid "Num Delete"
 msgstr "Вилучити"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 #, fuzzy
 msgid "Num Down"
 msgstr "Донизу"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "Num End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "Num Enter"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 #, fuzzy
 msgid "Num Home"
 msgstr "Домівка"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 #, fuzzy
 msgid "Num Insert"
 msgstr "Вставити"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num Lock"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "Num Page Down"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "Num Page Up"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 #, fuzzy
 msgid "Num Right"
 msgstr "Праворуч"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "Num Space"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "Num Tab"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "Num Up"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "Num left"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num_lock"
 msgstr ""
 
@@ -5370,13 +5506,13 @@ msgstr ""
 msgid "Numbered outline"
 msgstr "Нумерована структура"
 
-#: ../include/wx/msgdlg.h:278 ../src/richtext/richtextstyledlg.cpp:297
-#: ../src/common/stockitem.cpp:178 ../src/msw/msgdlg.cpp:454
-#: ../src/msw/msgdlg.cpp:747 ../src/gtk1/fontdlg.cpp:138
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:175
+#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/msgdlg.cpp:741 ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "Гаразд"
 
-#: ../src/msw/ole/automtn.cpp:692
+#: ../src/msw/ole/automtn.cpp:683
 #, c-format
 msgid "OLE Automation error in %s: %s"
 msgstr "Помилка автоматизації OLE у %s: %s"
@@ -5385,15 +5521,15 @@ msgstr "Помилка автоматизації OLE у %s: %s"
 msgid "Object Properties"
 msgstr "Властивості об'єкта"
 
-#: ../src/msw/ole/automtn.cpp:660
+#: ../src/msw/ole/automtn.cpp:651
 msgid "Object implementation does not support named arguments."
 msgstr "Реалізацією об’єкта не підтримуються іменовані аргументи."
 
-#: ../src/common/xtixml.cpp:264
+#: ../src/common/xtixml.cpp:260
 msgid "Objects must have an id attribute"
 msgstr "Об'єкти повинні мати атрибут id"
 
-#: ../src/propgrid/advprops.cpp:1601
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Olive"
 msgstr "Оливковий"
 
@@ -5401,65 +5537,70 @@ msgstr "Оливковий"
 msgid "Opaci&ty:"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:354
+#: ../src/generic/colrdlgg.cpp:374
 msgid "Opacity:"
 msgstr ""
 
-#: ../src/common/docview.cpp:1773 ../src/common/docview.cpp:1815
+#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
 msgid "Open File"
 msgstr "Відкрити файл"
 
-#: ../src/html/helpwnd.cpp:671 ../src/html/helpwnd.cpp:1554
+#: ../src/html/helpwnd.cpp:669 ../src/html/helpwnd.cpp:1552
 msgid "Open HTML document"
 msgstr "Відкрити документ HTML"
 
-#: ../src/generic/dbgrptg.cpp:163
+#: ../src/common/stockitem.cpp:265
+#, fuzzy
+msgid "Open an existing document"
+msgstr "Відкрити документ HTML"
+
+#: ../src/generic/dbgrptg.cpp:160
 #, c-format
 msgid "Open file \"%s\""
 msgstr "Відкрити файл «%s»"
 
-#: ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176
 msgid "Open..."
 msgstr "Відкрити…"
 
-#: ../src/unix/glx11.cpp:506 ../src/msw/glcanvas.cpp:592
+#: ../src/msw/glcanvas.cpp:607 ../src/unix/glx11.cpp:513
 #, fuzzy
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr "Core-profile OpenGL не підтримується драйвером OpenGL."
 
-#: ../src/generic/dirctrlg.cpp:599 ../src/generic/dirdlgg.cpp:323
-#: ../src/generic/filectrlg.cpp:642 ../src/generic/filectrlg.cpp:786
+#: ../src/generic/dirctrlg.cpp:565 ../src/generic/filectrlg.cpp:638
+#: ../src/generic/filectrlg.cpp:782 ../src/generic/dirdlgg.cpp:320
 msgid "Operation not permitted."
 msgstr "Заборонена дія."
 
-#: ../src/common/cmdline.cpp:900
+#: ../src/common/cmdline.cpp:896
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "Знак параметра «%s» не можна обертати"
 
-#: ../src/common/cmdline.cpp:1064
+#: ../src/common/cmdline.cpp:1060
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "Параметр «%s» потребує значення."
 
-#: ../src/common/cmdline.cpp:1147
+#: ../src/common/cmdline.cpp:1143
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Параметр «%s»: «%s» не може бути конвертована у дату."
 
-#: ../src/generic/prntdlgg.cpp:618
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Параметри"
 
-#: ../src/propgrid/advprops.cpp:1606
+#: ../src/propgrid/advprops.cpp:1512
 msgid "Orange"
 msgstr "Помаранчевий"
 
-#: ../src/generic/prntdlgg.cpp:615 ../src/generic/prntdlgg.cpp:869
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:862
 msgid "Orientation"
 msgstr "Орієнтація"
 
-#: ../src/common/windowid.cpp:242
+#: ../src/common/windowid.cpp:237
 msgid "Out of window IDs.  Recommend shutting down application."
 msgstr ""
 "Значення поза межами ідентифікаторів вікон. Рекомендуємо вам завершити "
@@ -5474,148 +5615,148 @@ msgstr "Контур"
 msgid "Outset"
 msgstr "Накладка"
 
-#: ../src/msw/ole/automtn.cpp:656
+#: ../src/msw/ole/automtn.cpp:647
 msgid "Overflow while coercing argument values."
 msgstr "Переповнення під час примусового встановлення значень аргументів."
 
-#: ../src/common/imagpcx.cpp:457 ../src/common/imagpcx.cpp:480
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:479
 msgid "PCX: couldn't allocate memory"
 msgstr "PCX: не можу виділити пам'ять"
 
-#: ../src/common/imagpcx.cpp:456
+#: ../src/common/imagpcx.cpp:455
 msgid "PCX: image format unsupported"
 msgstr "PCX: формат не підтримується"
 
-#: ../src/common/imagpcx.cpp:479
+#: ../src/common/imagpcx.cpp:478
 msgid "PCX: invalid image"
 msgstr "PCX: некоректне зображення"
 
-#: ../src/common/imagpcx.cpp:442
+#: ../src/common/imagpcx.cpp:441
 msgid "PCX: this is not a PCX file."
 msgstr "PCX: це не файл PCX."
 
-#: ../src/common/imagpcx.cpp:459 ../src/common/imagpcx.cpp:481
+#: ../src/common/imagpcx.cpp:458 ../src/common/imagpcx.cpp:480
 msgid "PCX: unknown error !!!"
 msgstr "PCX: невідома помилка !!!"
 
-#: ../src/common/imagpcx.cpp:458
+#: ../src/common/imagpcx.cpp:457
 msgid "PCX: version number too low"
 msgstr "PCX: номер версії дуже довгий"
 
-#: ../src/common/imagpnm.cpp:91
+#: ../src/common/imagpnm.cpp:89
 msgid "PNM: Couldn't allocate memory."
 msgstr "PCX: не вдалося виділити пам'ять."
 
-#: ../src/common/imagpnm.cpp:73
+#: ../src/common/imagpnm.cpp:71
 msgid "PNM: File format is not recognized."
 msgstr "PNM: формат файла не розпізнано."
 
-#: ../src/common/imagpnm.cpp:112 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
 #: ../src/common/imagpnm.cpp:156
 msgid "PNM: File seems truncated."
 msgstr "PNM: файл здається обірваним."
 
-#: ../src/common/paper.cpp:187
+#: ../src/common/paper.cpp:184
 msgid "PRC 16K 146 x 215 mm"
 msgstr "PRC 16K 146 x 215 мм"
 
-#: ../src/common/paper.cpp:200
+#: ../src/common/paper.cpp:197
 msgid "PRC 16K Rotated"
 msgstr "PRC 16K Повернутий"
 
-#: ../src/common/paper.cpp:188
+#: ../src/common/paper.cpp:185
 msgid "PRC 32K 97 x 151 mm"
 msgstr "PRC 32K 97 x 151 мм"
 
-#: ../src/common/paper.cpp:201
+#: ../src/common/paper.cpp:198
 msgid "PRC 32K Rotated"
 msgstr "PRC 32K Повернутий"
 
-#: ../src/common/paper.cpp:189
+#: ../src/common/paper.cpp:186
 msgid "PRC 32K(Big) 97 x 151 mm"
 msgstr "PRC 32K(Великий) 97 x 151 мм"
 
-#: ../src/common/paper.cpp:202
+#: ../src/common/paper.cpp:199
 msgid "PRC 32K(Big) Rotated"
 msgstr "PRC 32K(Великий) Повернутий"
 
-#: ../src/common/paper.cpp:190
+#: ../src/common/paper.cpp:187
 msgid "PRC Envelope #1 102 x 165 mm"
 msgstr "Конверт PRC #1 102 x 165 мм"
 
-#: ../src/common/paper.cpp:203
+#: ../src/common/paper.cpp:200
 msgid "PRC Envelope #1 Rotated 165 x 102 mm"
 msgstr "Конверт PRC #1 Повернутий 165 x 102 мм"
 
-#: ../src/common/paper.cpp:199
+#: ../src/common/paper.cpp:196
 msgid "PRC Envelope #10 324 x 458 mm"
 msgstr "Конверт PRC #10 324 x 458 мм"
 
-#: ../src/common/paper.cpp:212
+#: ../src/common/paper.cpp:209
 msgid "PRC Envelope #10 Rotated 458 x 324 mm"
 msgstr "Конверт PRC #10 Повернутий 458 x 324 мм"
 
-#: ../src/common/paper.cpp:191
+#: ../src/common/paper.cpp:188
 msgid "PRC Envelope #2 102 x 176 mm"
 msgstr "Конверт PRC #2 102 x 176 мм"
 
-#: ../src/common/paper.cpp:204
+#: ../src/common/paper.cpp:201
 msgid "PRC Envelope #2 Rotated 176 x 102 mm"
 msgstr "Конверт PRC #2 Повернутий 176 x 102 мм"
 
-#: ../src/common/paper.cpp:192
+#: ../src/common/paper.cpp:189
 msgid "PRC Envelope #3 125 x 176 mm"
 msgstr "Конверт PRC #3 125 x 176 мм"
 
-#: ../src/common/paper.cpp:205
+#: ../src/common/paper.cpp:202
 msgid "PRC Envelope #3 Rotated 176 x 125 mm"
 msgstr "Конверт PRC #3 Повернутий 176 x 125 мм"
 
-#: ../src/common/paper.cpp:193
+#: ../src/common/paper.cpp:190
 msgid "PRC Envelope #4 110 x 208 mm"
 msgstr "Конверт PRC #4 110 x 208 мм"
 
-#: ../src/common/paper.cpp:206
+#: ../src/common/paper.cpp:203
 msgid "PRC Envelope #4 Rotated 208 x 110 mm"
 msgstr "Конверт PRC #4 Повернутий 208 x 110 мм"
 
-#: ../src/common/paper.cpp:194
+#: ../src/common/paper.cpp:191
 msgid "PRC Envelope #5 110 x 220 mm"
 msgstr "Конверт PRC #5 110 x 220 мм"
 
-#: ../src/common/paper.cpp:207
+#: ../src/common/paper.cpp:204
 msgid "PRC Envelope #5 Rotated 220 x 110 mm"
 msgstr "Конверт PRC #5 Повернутий 220 x 110 мм"
 
-#: ../src/common/paper.cpp:195
+#: ../src/common/paper.cpp:192
 msgid "PRC Envelope #6 120 x 230 mm"
 msgstr "Конверт PRC #6 120 x 230 мм"
 
-#: ../src/common/paper.cpp:208
+#: ../src/common/paper.cpp:205
 msgid "PRC Envelope #6 Rotated 230 x 120 mm"
 msgstr "Конверт PRC #6 Повернутий 230 x 120 мм"
 
-#: ../src/common/paper.cpp:196
+#: ../src/common/paper.cpp:193
 msgid "PRC Envelope #7 160 x 230 mm"
 msgstr "Конверт PRC #7 160 x 230 мм"
 
-#: ../src/common/paper.cpp:209
+#: ../src/common/paper.cpp:206
 msgid "PRC Envelope #7 Rotated 230 x 160 mm"
 msgstr "Конверт PRC #7 Повернутий 230 x 160 мм"
 
-#: ../src/common/paper.cpp:197
+#: ../src/common/paper.cpp:194
 msgid "PRC Envelope #8 120 x 309 mm"
 msgstr "Конверт PRC #8 120 x 309 мм"
 
-#: ../src/common/paper.cpp:210
+#: ../src/common/paper.cpp:207
 msgid "PRC Envelope #8 Rotated 309 x 120 mm"
 msgstr "Конверт PRC #8 Повернутий 309 x 120 мм"
 
-#: ../src/common/paper.cpp:198
+#: ../src/common/paper.cpp:195
 msgid "PRC Envelope #9 229 x 324 mm"
 msgstr "Конверт PRC #9 229 x 324 мм"
 
-#: ../src/common/paper.cpp:211
+#: ../src/common/paper.cpp:208
 msgid "PRC Envelope #9 Rotated 324 x 229 mm"
 msgstr "Конверт PRC #9 Повернутий 324 x 229 мм"
 
@@ -5623,91 +5764,95 @@ msgstr "Конверт PRC #9 Повернутий 324 x 229 мм"
 msgid "Padding"
 msgstr "Фаска"
 
-#: ../src/common/prntbase.cpp:2074
+#: ../src/common/prntbase.cpp:2096
 #, c-format
 msgid "Page %d"
 msgstr "Сторінка %d"
 
-#: ../src/common/prntbase.cpp:2072
+#: ../src/common/prntbase.cpp:2094
 #, c-format
 msgid "Page %d of %d"
 msgstr "Сторінка %d з %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 #, fuzzy
 msgid "Page Down"
 msgstr "Сторінка %d"
 
-#: ../src/gtk/print.cpp:826
+#: ../src/gtk/print.cpp:829
 msgid "Page Setup"
 msgstr "Налаштування сторінки"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 #, fuzzy
 msgid "Page Up"
 msgstr "Сторінка %d"
 
-#: ../src/generic/prntdlgg.cpp:828 ../src/common/prntbase.cpp:484
+#: ../src/common/prntbase.cpp:479 ../src/generic/prntdlgg.cpp:821
 msgid "Page setup"
 msgstr "Налаштування сторінки"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 #, fuzzy
 msgid "PageDown"
 msgstr "Донизу"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 #, fuzzy
 msgid "PageUp"
 msgstr "Сторінки"
 
-#: ../src/generic/prntdlgg.cpp:216
+#: ../src/generic/prntdlgg.cpp:209
 msgid "Pages"
 msgstr "Сторінки"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1765
+#: ../src/propgrid/advprops.cpp:1666
 msgid "Paint Brush"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:602 ../src/generic/prntdlgg.cpp:801
-#: ../src/generic/prntdlgg.cpp:842 ../src/generic/prntdlgg.cpp:855
-#: ../src/generic/prntdlgg.cpp:1052 ../src/generic/prntdlgg.cpp:1057
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:794
+#: ../src/generic/prntdlgg.cpp:835 ../src/generic/prntdlgg.cpp:848
+#: ../src/generic/prntdlgg.cpp:1045 ../src/generic/prntdlgg.cpp:1050
 msgid "Paper size"
 msgstr "Розмір паперу"
 
-#: ../src/richtext/richtextstyles.cpp:1062
+#: ../src/richtext/richtextstyles.cpp:1059
 msgid "Paragraph styles"
 msgstr "Стилі абзаців"
 
-#: ../src/common/xtistrm.cpp:465
+#: ../src/common/xtistrm.cpp:462
 msgid "Passing a already registered object to SetObject"
 msgstr "Передача вже зареєстрованого об'єкта до SetObject"
 
-#: ../src/common/xtistrm.cpp:476
+#: ../src/common/xtistrm.cpp:473
 msgid "Passing an unknown object to GetObject"
 msgstr "GetObject передано невідомий об’єкт"
 
-#: ../src/richtext/richtextctrl.cpp:3513 ../src/common/stockitem.cpp:180
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:177 ../src/richtext/richtextctrl.cpp:3514
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Вставити"
 
-#: ../src/common/stockitem.cpp:262
+#: ../src/common/stockitem.cpp:260
 msgid "Paste selection"
 msgstr "Вставити позначене"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:74
+#: ../src/common/accelcmn.cpp:71
 msgid "Pause"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1766
+#: ../src/propgrid/advprops.cpp:1667
 msgid "Pencil"
 msgstr ""
 
@@ -5716,21 +5861,21 @@ msgstr ""
 msgid "Peri&od"
 msgstr "То&чка"
 
-#: ../src/generic/filectrlg.cpp:430
+#: ../src/generic/filectrlg.cpp:426
 msgid "Permissions"
 msgstr "Дозволи"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:60
+#: ../src/common/accelcmn.cpp:57
 msgid "PgDn"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:59
+#: ../src/common/accelcmn.cpp:56
 msgid "PgUp"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:12868
+#: ../src/richtext/richtextbuffer.cpp:12863
 msgid "Picture Properties"
 msgstr "Властивості малюнка"
 
@@ -5742,44 +5887,44 @@ msgstr "Помилка створення потоку вводу-виводу"
 msgid "Please choose a valid font."
 msgstr "Будь ласка, виберіть коректний шрифт."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
 msgid "Please choose an existing file."
 msgstr "Будь ласка, виберіть наявний файл."
 
-#: ../src/html/helpwnd.cpp:800
+#: ../src/html/helpwnd.cpp:798
 msgid "Please choose the page to display:"
 msgstr "Будь ласка, виберіть сторінку для показу:"
 
-#: ../src/msw/dialup.cpp:764
+#: ../src/msw/dialup.cpp:758
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Будь ласка, виберіть надавача послуг інтернету, з яким слід з’єднатися"
 
-#: ../src/common/headerctrlcmn.cpp:59
+#: ../src/common/headerctrlcmn.cpp:57
 msgid "Please select the columns to show and define their order:"
 msgstr "Вкажіть стовпчики, які слід показувати, і порядок показу:"
 
-#: ../src/common/prntbase.cpp:538
+#: ../src/common/prntbase.cpp:533
 msgid "Please wait while printing..."
 msgstr "Будь ласка, зачекайте на завершення друку…"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1767
+#: ../src/propgrid/advprops.cpp:1668
 #, fuzzy
 msgid "Point Left"
 msgstr "Розмір точки"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1768
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgid "Point Right"
 msgstr "Вирівняти праворуч"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:662
+#: ../src/propgrid/advprops.cpp:572
 msgid "Point Size"
 msgstr "Розмір точки"
 
-#: ../src/generic/prntdlgg.cpp:612 ../src/generic/prntdlgg.cpp:867
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:860
 msgid "Portrait"
 msgstr "Книжкова"
 
@@ -5787,150 +5932,160 @@ msgstr "Книжкова"
 msgid "Position"
 msgstr "Позиція"
 
-#: ../src/generic/prntdlgg.cpp:298
+#: ../src/generic/prntdlgg.cpp:291
 msgid "PostScript file"
 msgstr "Файл PostScript"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178 ../src/osx/cocoa/preferences.mm:303
 msgid "Preferences"
 msgstr "Налаштування"
 
-#: ../src/osx/menu_osx.cpp:568
+#: ../src/osx/menu_osx.cpp:460
 msgid "Preferences..."
 msgstr "Налаштування…"
 
-#: ../src/common/prntbase.cpp:546
+#: ../src/common/prntbase.cpp:541
 msgid "Preparing"
 msgstr "Приготування"
 
-#: ../src/generic/fontdlgg.cpp:455 ../src/osx/carbon/fontdlg.cpp:390
-#: ../src/html/helpwnd.cpp:1222
+#: ../src/osx/carbon/fontdlg.cpp:387 ../src/generic/fontdlgg.cpp:452
+#: ../src/html/helpwnd.cpp:1220
 msgid "Preview:"
 msgstr "Передогляд:"
 
-#: ../src/common/prntbase.cpp:1553 ../src/html/helpwnd.cpp:664
+#: ../src/common/prntbase.cpp:1578 ../src/html/helpwnd.cpp:662
 msgid "Previous page"
 msgstr "Попередня сторінка"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/prntdlgg.cpp:143 ../src/generic/prntdlgg.cpp:157
-#: ../src/common/prntbase.cpp:426 ../src/common/prntbase.cpp:1541
-#: ../src/common/accelcmn.cpp:77 ../src/gtk/print.cpp:620
-#: ../src/gtk/print.cpp:638
+#: ../src/common/prntbase.cpp:421 ../src/common/prntbase.cpp:1566
+#: ../src/common/accelcmn.cpp:74 ../src/generic/prntdlgg.cpp:136
+#: ../src/generic/prntdlgg.cpp:150 ../src/gtk/print.cpp:616
+#: ../src/gtk/print.cpp:634
 msgid "Print"
 msgstr "Друк"
 
-#: ../include/wx/prntbase.h:399 ../src/common/docview.cpp:1268
+#: ../src/common/docview.cpp:1262
 msgid "Print Preview"
 msgstr "Передогляд друку"
 
-#: ../src/common/prntbase.cpp:2015 ../src/common/prntbase.cpp:2057
-#: ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2037 ../src/common/prntbase.cpp:2079
+#: ../src/common/prntbase.cpp:2087
 msgid "Print Preview Failure"
 msgstr "Помилка попереднього перегляду друку"
 
-#: ../src/generic/prntdlgg.cpp:224
+#: ../src/generic/prntdlgg.cpp:217
 msgid "Print Range"
 msgstr "Друк інтервалу"
 
-#: ../src/generic/prntdlgg.cpp:449
+#: ../src/generic/prntdlgg.cpp:442
 msgid "Print Setup"
 msgstr "Налаштування друку"
 
-#: ../src/generic/prntdlgg.cpp:621
+#: ../src/generic/prntdlgg.cpp:614
 msgid "Print in colour"
 msgstr "Друк в кольорі"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/osx/webview_webkit.mm:260
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "Не вдалося ініціалізувати опис стовпчика."
+
+#: ../src/common/stockitem.cpp:179
 msgid "Print previe&w..."
 msgstr "П&ерегляд друку…"
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1256
 msgid "Print preview creation failed."
 msgstr "Не вдалося створити зображення попереднього перегляду друку."
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/common/stockitem.cpp:179
 msgid "Print preview..."
 msgstr "Перегляд друку…"
 
-#: ../src/generic/prntdlgg.cpp:630
+#: ../src/generic/prntdlgg.cpp:623
 msgid "Print spooling"
 msgstr "Спулінг друку"
 
-#: ../src/html/helpwnd.cpp:675
+#: ../src/html/helpwnd.cpp:673
 msgid "Print this page"
 msgstr "Надрукувати цю сторінку"
 
-#: ../src/generic/prntdlgg.cpp:185
+#: ../src/generic/prntdlgg.cpp:178
 msgid "Print to File"
 msgstr "Друк в файл"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "Print..."
 msgstr "Надрукувати…"
 
-#: ../src/generic/prntdlgg.cpp:493
+#: ../src/generic/prntdlgg.cpp:486
 msgid "Printer"
 msgstr "Друкарка"
 
-#: ../src/generic/prntdlgg.cpp:633
+#: ../src/generic/prntdlgg.cpp:626
 msgid "Printer command:"
 msgstr "Команда принтеру:"
 
-#: ../src/generic/prntdlgg.cpp:180
+#: ../src/generic/prntdlgg.cpp:173
 msgid "Printer options"
 msgstr "Параметри принтера"
 
-#: ../src/generic/prntdlgg.cpp:645
+#: ../src/generic/prntdlgg.cpp:638
 msgid "Printer options:"
 msgstr "Параметри принтера:"
 
-#: ../src/generic/prntdlgg.cpp:916
+#: ../src/generic/prntdlgg.cpp:909
 msgid "Printer..."
 msgstr "Принтер…"
 
-#: ../src/generic/prntdlgg.cpp:196
+#: ../src/generic/prntdlgg.cpp:189
 msgid "Printer:"
 msgstr "Друкарка:"
 
-#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:535
-#: ../src/html/htmprint.cpp:277
+#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:530
+#: ../src/html/htmprint.cpp:289
 msgid "Printing"
 msgstr "Друк"
 
-#: ../src/common/prntbase.cpp:612
+#: ../src/common/prntbase.cpp:607
 msgid "Printing "
 msgstr "Друк"
 
-#: ../src/common/prntbase.cpp:347
+#: ../src/common/prntbase.cpp:342
 msgid "Printing Error"
 msgstr "Помилка друку"
 
-#: ../src/common/prntbase.cpp:565
+#: ../src/osx/webview_webkit.mm:251
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "Gzip не підтримується цією версією zlib"
+
+#: ../src/common/prntbase.cpp:560
 #, fuzzy, c-format
 msgid "Printing page %d"
 msgstr "Друк сторінки %d…"
 
-#: ../src/common/prntbase.cpp:570
+#: ../src/common/prntbase.cpp:565
 #, c-format
 msgid "Printing page %d of %d"
 msgstr "Друкуємо сторінку %d з %d"
 
-#: ../src/generic/printps.cpp:201
+#: ../src/generic/printps.cpp:182
 #, c-format
 msgid "Printing page %d..."
 msgstr "Друк сторінки %d…"
 
-#: ../src/generic/printps.cpp:161
+#: ../src/generic/printps.cpp:142
 msgid "Printing..."
 msgstr "Друк…"
 
-#: ../include/wx/richtext/richtextprint.h:109 ../include/wx/prntbase.h:267
-#: ../src/common/docview.cpp:2132
+#: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
+#: ../src/common/docview.cpp:2137
 msgid "Printout"
 msgstr "Відбиток"
 
-#: ../src/common/debugrpt.cpp:560
+#: ../src/common/debugrpt.cpp:561
 #, c-format
 msgid ""
 "Processing debug report has failed, leaving the files in \"%s\" directory."
@@ -5938,104 +6093,104 @@ msgstr ""
 "Робота над звітом про помилку завершилася помилкою, файли залишено у теці "
 "\"%s\"."
 
-#: ../src/common/prntbase.cpp:545
+#: ../src/common/prntbase.cpp:540
 msgid "Progress:"
 msgstr "Поступ:"
 
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181
 msgid "Properties"
 msgstr "Властивості"
 
-#: ../src/propgrid/manager.cpp:237
+#: ../src/propgrid/manager.cpp:223
 msgid "Property"
 msgstr "Властивість"
 
 #. TRANSLATORS: Caption of message box displaying any property error
-#: ../src/propgrid/propgrid.cpp:3185 ../src/propgrid/propgrid.cpp:3318
+#: ../src/propgrid/propgrid.cpp:3162 ../src/propgrid/propgrid.cpp:3299
 msgid "Property Error"
 msgstr "Редактор властивостей"
 
-#: ../src/propgrid/advprops.cpp:1597
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Purple"
 msgstr "Пурпуровий"
 
-#: ../src/common/paper.cpp:112
+#: ../src/common/paper.cpp:109
 msgid "Quarto, 215 x 275 mm"
 msgstr "Quarto, 215 x 275 мм"
 
-#: ../src/generic/logg.cpp:1016
+#: ../src/generic/logg.cpp:1013
 msgid "Question"
 msgstr "Питання"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1769
+#: ../src/propgrid/advprops.cpp:1670
 #, fuzzy
 msgid "Question Arrow"
 msgstr "Питання"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "Quit"
 msgstr "Вийти"
 
-#: ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:477
 #, c-format
 msgid "Quit %s"
 msgstr "Вийти з %s"
 
-#: ../src/common/stockitem.cpp:263
+#: ../src/common/stockitem.cpp:261
 msgid "Quit this program"
 msgstr "Вийти з цієї програми"
 
-#: ../src/common/accelcmn.cpp:338
+#: ../src/common/accelcmn.cpp:352
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/ffile.cpp:109 ../src/common/ffile.cpp:133
+#: ../src/common/ffile.cpp:107 ../src/common/ffile.cpp:132
 #, c-format
 msgid "Read error on file '%s'"
 msgstr "Помилка читання файла «%s»"
 
-#: ../src/common/secretstore.cpp:199
+#: ../src/common/secretstore.cpp:211
 #, fuzzy, c-format
-msgid "Reading password for \"%s/%s\" failed: %s."
+msgid "Reading password for \"%s\" failed: %s."
 msgstr "Розпакування «%s» до «%s» закінчилося з помилкою."
 
-#: ../src/common/prntbase.cpp:272
+#: ../src/common/prntbase.cpp:267
 msgid "Ready"
 msgstr "Готова"
 
-#: ../src/propgrid/advprops.cpp:1605
+#: ../src/propgrid/advprops.cpp:1511
 #, fuzzy
 msgid "Red"
 msgstr "Повторити"
 
-#: ../src/generic/colrdlgg.cpp:339
+#: ../src/generic/colrdlgg.cpp:359
 msgid "Red:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:185 ../src/stc/stc_i18n.cpp:16
+#: ../src/common/stockitem.cpp:182 ../src/stc/stc_i18n.cpp:16
 msgid "Redo"
 msgstr "Повторити"
 
-#: ../src/common/stockitem.cpp:264
+#: ../src/common/stockitem.cpp:262
 msgid "Redo last action"
 msgstr "Повторити останню дію"
 
-#: ../src/common/stockitem.cpp:186
+#: ../src/common/stockitem.cpp:183
 msgid "Refresh"
 msgstr "Оновити"
 
-#: ../src/msw/registry.cpp:626
+#: ../src/msw/registry.cpp:615
 #, c-format
 msgid "Registry key '%s' already exists."
 msgstr "Ключ реєстру «%s» вже присутній."
 
-#: ../src/msw/registry.cpp:595
+#: ../src/msw/registry.cpp:584
 #, c-format
 msgid "Registry key '%s' does not exist, cannot rename it."
 msgstr "Ключ реєстру «%s» не присутній, Не вдалося його перейменувати."
 
-#: ../src/msw/registry.cpp:727
+#: ../src/msw/registry.cpp:716
 #, c-format
 msgid ""
 "Registry key '%s' is needed for normal system operation,\n"
@@ -6046,22 +6201,22 @@ msgstr ""
 "його знищення приведе вашу систему в недієздатний стан:\n"
 "дію скасовано."
 
-#: ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:942
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:917
+#: ../src/msw/registry.cpp:905
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1003
+#: ../src/msw/registry.cpp:991
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:521
+#: ../src/msw/registry.cpp:510
 #, c-format
 msgid "Registry value '%s' already exists."
 msgstr "Значення реєстру «%s» вже присутнє."
@@ -6075,71 +6230,77 @@ msgstr "Звичайний"
 msgid "Relative"
 msgstr "Відносна"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:456
 msgid "Relevant entries:"
 msgstr "Відповідні записи:"
 
-#: ../include/wx/generic/progdlgg.h:86
+#: ../include/wx/generic/progdlgg.h:87
 msgid "Remaining time:"
 msgstr "Час, що залишився:"
 
-#: ../src/common/stockitem.cpp:187
+#: ../src/common/stockitem.cpp:184
 msgid "Remove"
 msgstr "Вилучити"
 
-#: ../src/richtext/richtextctrl.cpp:1562
+#: ../src/richtext/richtextctrl.cpp:1563
 msgid "Remove Bullet"
 msgstr "Вилучити позначку"
 
-#: ../src/html/helpwnd.cpp:433
+#: ../src/html/helpwnd.cpp:431
 msgid "Remove current page from bookmarks"
 msgstr "Вилучити цю сторінку з закладок"
 
-#: ../src/common/rendcmn.cpp:194
+#: ../src/common/rendcmn.cpp:191
 #, c-format
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 "Візуалізатор «%s» має несумісну версію %d.%d, його неможливо завантажити."
 
-#: ../src/richtext/richtextbuffer.cpp:4527
+#: ../src/richtext/richtextbuffer.cpp:4524
 msgid "Renumber List"
 msgstr "Перенумерувати список"
 
-#: ../src/common/stockitem.cpp:188
-msgid "Rep&lace"
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Rep&lace..."
 msgstr "&Замінити"
 
-#: ../src/richtext/richtextctrl.cpp:3673 ../src/common/stockitem.cpp:188
+#: ../src/richtext/richtextctrl.cpp:3674
 msgid "Replace"
 msgstr "Замінити"
 
-#: ../src/generic/fdrepdlg.cpp:182
+#: ../src/generic/fdrepdlg.cpp:179
 msgid "Replace &all"
 msgstr "Замінити всі"
 
-#: ../src/common/stockitem.cpp:261
-msgid "Replace selection"
-msgstr "Замінити позначене"
-
-#: ../src/generic/fdrepdlg.cpp:124
+#: ../src/generic/fdrepdlg.cpp:121
 msgid "Replace with:"
 msgstr "Замінити на:"
 
-#: ../src/common/valtext.cpp:163
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Replace..."
+msgstr "Замінити"
+
+#: ../src/common/valtext.cpp:184
 msgid "Required information entry is empty."
 msgstr "Потрібний запис даних виявився порожнім."
 
-#: ../src/common/translation.cpp:1975
+#: ../src/common/translation.cpp:2025
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "Ресурс «%s» не є коректним каталогом повідомлень."
 
+#: ../src/gtk/webview_webkit.cpp:985
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:56
+#: ../src/common/accelcmn.cpp:53
 msgid "Return"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:189
+#: ../src/common/stockitem.cpp:186
 msgid "Revert to Saved"
 msgstr "Повернутися до збереженого"
 
@@ -6151,42 +6312,42 @@ msgstr "Гребінь"
 msgid "Rig&ht-to-left"
 msgstr "С&права ліворуч"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6149
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:59 ../src/generic/datavgen.cpp:6954
+#: ../src/richtext/richtextsizepage.cpp:250
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextbulletspage.cpp:188
-#: ../src/richtext/richtextsizepage.cpp:250 ../src/common/accelcmn.cpp:62
 msgid "Right"
 msgstr "Праворуч"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1754
+#: ../src/propgrid/advprops.cpp:1655
 #, fuzzy
 msgid "Right Arrow"
 msgstr "Праворуч"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1770
+#: ../src/propgrid/advprops.cpp:1671
 msgid "Right Button"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:892
+#: ../src/generic/prntdlgg.cpp:885
 msgid "Right margin (mm):"
 msgstr "Права межа (мм):"
 
-#: ../src/richtext/richtextindentspage.cpp:148
-#: ../src/richtext/richtextindentspage.cpp:150
 #: ../src/richtext/richtextliststylepage.cpp:337
 #: ../src/richtext/richtextliststylepage.cpp:339
+#: ../src/richtext/richtextindentspage.cpp:148
+#: ../src/richtext/richtextindentspage.cpp:150
 msgid "Right-align text."
 msgstr "Текст вирівняний праворуч."
 
-#: ../src/generic/fontdlgg.cpp:322
+#: ../src/generic/fontdlgg.cpp:318
 msgid "Roman"
 msgstr "Roman"
 
-#: ../src/generic/datavgen.cpp:5916
+#: ../src/generic/datavgen.cpp:6721
 #, c-format
 msgid "Row %i"
 msgstr ""
@@ -6196,30 +6357,31 @@ msgstr ""
 msgid "S&tandard bullet name:"
 msgstr "Назва ста&ндартної позначки:"
 
-#: ../src/common/accelcmn.cpp:268 ../src/common/accelcmn.cpp:350
+#: ../src/common/accelcmn.cpp:282 ../src/common/accelcmn.cpp:367
 msgid "SPECIAL"
 msgstr "SPECIAL"
 
-#: ../src/common/stockitem.cpp:190 ../src/common/sizer.cpp:2797
+#: ../src/common/stockitem.cpp:187 ../src/common/sizer.cpp:2914
 msgid "Save"
 msgstr "Зберегти"
 
-#: ../src/common/fldlgcmn.cpp:342
+#: ../src/common/fldlgcmn.cpp:339
 #, c-format
 msgid "Save %s file"
 msgstr "Зберегти файл %s"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/common/stockitem.cpp:188 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Зберегти &як..."
 
-#: ../src/common/docview.cpp:366
+#: ../src/common/docview.cpp:359
 msgid "Save As"
 msgstr "Зберегти як"
 
-#: ../src/common/stockitem.cpp:191
-msgid "Save as"
-msgstr "Зберегти як"
+#: ../src/common/stockitem.cpp:188
+#, fuzzy
+msgid "Save As..."
+msgstr "Зберегти &як..."
 
 #: ../src/common/stockitem.cpp:267
 msgid "Save current document"
@@ -6229,95 +6391,95 @@ msgstr "Зберегти поточний документ"
 msgid "Save current document with a different filename"
 msgstr "Зберегти поточний документ з іншою назвою"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/generic/logg.cpp:509
 msgid "Save log contents to file"
 msgstr "Зберегти вміст журналу до файла"
 
-#: ../src/common/secretstore.cpp:179
+#: ../src/common/secretstore.cpp:189
 #, fuzzy, c-format
-msgid "Saving password for \"%s/%s\" failed: %s."
+msgid "Saving password for \"%s\" failed: %s."
 msgstr "Розпакування «%s» до «%s» закінчилося з помилкою."
 
-#: ../src/generic/fontdlgg.cpp:325
+#: ../src/generic/fontdlgg.cpp:321
 msgid "Script"
 msgstr "Рукописний"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll Lock"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll_lock"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:890
+#: ../src/propgrid/advprops.cpp:791
 msgid "Scrollbar"
 msgstr ""
 
-#: ../src/generic/srchctlg.cpp:56 ../src/html/helpwnd.cpp:535
-#: ../src/html/helpwnd.cpp:550
+#: ../src/generic/srchctlg.cpp:55 ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:548 ../src/gtk/srchctrl.cpp:182
 msgid "Search"
 msgstr "Пошук"
 
-#: ../src/html/helpwnd.cpp:537
+#: ../src/html/helpwnd.cpp:535
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
 msgstr "Пошук в книгах довідки всіх згадок введеного вище тексту"
 
-#: ../src/generic/fdrepdlg.cpp:160
+#: ../src/generic/fdrepdlg.cpp:157
 msgid "Search direction"
 msgstr "Напрямок пошуку"
 
-#: ../src/generic/fdrepdlg.cpp:112
+#: ../src/generic/fdrepdlg.cpp:109
 msgid "Search for:"
 msgstr "Шукати:"
 
-#: ../src/html/helpwnd.cpp:1052
+#: ../src/html/helpwnd.cpp:1050
 msgid "Search in all books"
 msgstr "Пошук в усіх книгах"
 
-#: ../src/html/helpwnd.cpp:857
+#: ../src/html/helpwnd.cpp:855
 msgid "Searching..."
 msgstr "Пошук…"
 
-#: ../src/generic/dirctrlg.cpp:446
+#: ../src/generic/dirctrlg.cpp:412
 msgid "Sections"
 msgstr "Розділи"
 
-#: ../src/common/ffile.cpp:238
+#: ../src/common/ffile.cpp:237
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Помилка пошуку в файлі «%s»"
 
-#: ../src/common/ffile.cpp:228
+#: ../src/common/ffile.cpp:227
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr "Помилка пошуку на файлі «%s» (великі файли не підтримуються stdio)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:76
+#: ../src/common/accelcmn.cpp:73
 #, fuzzy
 msgid "Select"
 msgstr "Позначене"
 
-#: ../src/richtext/richtextctrl.cpp:337 ../src/osx/textctrl_osx.cpp:581
-#: ../src/common/stockitem.cpp:192 ../src/msw/textctrl.cpp:2512
+#: ../src/osx/textctrl_osx.cpp:599 ../src/common/stockitem.cpp:189
+#: ../src/msw/textctrl.cpp:2777 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "В&ибрати все"
 
-#: ../src/common/stockitem.cpp:192 ../src/stc/stc_i18n.cpp:21
+#: ../src/common/stockitem.cpp:189 ../src/stc/stc_i18n.cpp:21
 msgid "Select All"
 msgstr "Вибрати все"
 
-#: ../src/common/docview.cpp:1895
+#: ../src/common/docview.cpp:1900
 msgid "Select a document template"
 msgstr "Виберіть шаблон документа"
 
-#: ../src/common/docview.cpp:1969
+#: ../src/common/docview.cpp:1974
 msgid "Select a document view"
 msgstr "Виберіть перегляд документа"
 
@@ -6346,20 +6508,20 @@ msgid "Selects the list level to edit."
 msgstr "Оберіть рівень списку для редагування."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:82
+#: ../src/common/accelcmn.cpp:79
 msgid "Separator"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1083
+#: ../src/common/cmdline.cpp:1079
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Після параметра «%s» слід використовувати роздільник."
 
-#: ../src/osx/menu_osx.cpp:572
+#: ../src/osx/menu_osx.cpp:464
 msgid "Services"
 msgstr "Служби"
 
-#: ../src/richtext/richtextbuffer.cpp:11217
+#: ../src/richtext/richtextbuffer.cpp:11216
 msgid "Set Cell Style"
 msgstr "Встановити стиль комірки"
 
@@ -6367,11 +6529,11 @@ msgstr "Встановити стиль комірки"
 msgid "SetProperty called w/o valid setter"
 msgstr "SetProperty викликано без коректного встановлювача"
 
-#: ../src/generic/prntdlgg.cpp:188
+#: ../src/generic/prntdlgg.cpp:181
 msgid "Setup..."
 msgstr "Налаштування…"
 
-#: ../src/msw/dialup.cpp:544
+#: ../src/msw/dialup.cpp:538
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr ""
 "Знайдено декілька активних комутованих з'єднань, випадково вибираємо одне."
@@ -6389,40 +6551,40 @@ msgstr ""
 msgid "Shadow c&olour:"
 msgstr "Оберіть колір"
 
-#: ../src/common/accelcmn.cpp:335
+#: ../src/common/accelcmn.cpp:349
 msgid "Shift+"
 msgstr "Shift+"
 
-#: ../src/generic/dirdlgg.cpp:147
+#: ../src/generic/dirdlgg.cpp:144
 msgid "Show &hidden directories"
 msgstr "Показати при&ховані теки"
 
-#: ../src/generic/filectrlg.cpp:983
+#: ../src/generic/filectrlg.cpp:979
 msgid "Show &hidden files"
 msgstr "Показати при&ховані файли"
 
-#: ../src/osx/menu_osx.cpp:580
+#: ../src/osx/menu_osx.cpp:472
 msgid "Show All"
 msgstr "Показати всі"
 
-#: ../src/common/stockitem.cpp:257
+#: ../src/common/stockitem.cpp:254
 msgid "Show about dialog"
 msgstr "Показати діалог інформації про програму"
 
-#: ../src/html/helpwnd.cpp:492
+#: ../src/html/helpwnd.cpp:490
 msgid "Show all"
 msgstr "Показати всі"
 
-#: ../src/html/helpwnd.cpp:503
+#: ../src/html/helpwnd.cpp:501
 msgid "Show all items in index"
 msgstr "Показати всі рядки індексу"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:656
 msgid "Show/hide navigation panel"
 msgstr "Показати/сховати навігаційну панель"
 
-#: ../src/richtext/richtextsymboldlg.cpp:421
-#: ../src/richtext/richtextsymboldlg.cpp:423
+#: ../src/richtext/richtextsymboldlg.cpp:418
+#: ../src/richtext/richtextsymboldlg.cpp:420
 msgid "Shows a Unicode subset."
 msgstr "Показує підмножину Unicode."
 
@@ -6438,7 +6600,7 @@ msgstr "Показує попередній перегляд параметрі�
 msgid "Shows a preview of the font settings."
 msgstr "Показує попередній перегляд для параметрів шрифту."
 
-#: ../src/osx/carbon/fontdlg.cpp:394 ../src/osx/carbon/fontdlg.cpp:396
+#: ../src/osx/carbon/fontdlg.cpp:391 ../src/osx/carbon/fontdlg.cpp:393
 msgid "Shows a preview of the font."
 msgstr "Показує попередній перегляд шрифту."
 
@@ -6447,62 +6609,62 @@ msgstr "Показує попередній перегляд шрифту."
 msgid "Shows a preview of the paragraph settings."
 msgstr "Показує попередній перегляд параметрів абзацу."
 
-#: ../src/generic/fontdlgg.cpp:460 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:456 ../src/generic/fontdlgg.cpp:458
 msgid "Shows the font preview."
 msgstr "Попередній перегляд шрифту."
 
-#: ../src/propgrid/advprops.cpp:1607
+#: ../src/propgrid/advprops.cpp:1513
 msgid "Silver"
 msgstr "Срібний"
 
-#: ../src/univ/themes/mono.cpp:516
+#: ../src/univ/themes/mono.cpp:513
 msgid "Simple monochrome theme"
 msgstr "Проста чорно-біла тема"
 
-#: ../src/richtext/richtextindentspage.cpp:275
 #: ../src/richtext/richtextliststylepage.cpp:449
+#: ../src/richtext/richtextindentspage.cpp:275
 msgid "Single"
 msgstr "Одинарний"
 
-#: ../src/generic/filectrlg.cpp:425 ../src/richtext/richtextformatdlg.cpp:369
-#: ../src/richtext/richtextsizepage.cpp:299
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextsizepage.cpp:299
+#: ../src/richtext/richtextformatdlg.cpp:362
 msgid "Size"
 msgstr "Розмір"
 
-#: ../src/osx/carbon/fontdlg.cpp:339
+#: ../src/osx/carbon/fontdlg.cpp:336
 msgid "Size:"
 msgstr "Розмір:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1775
+#: ../src/propgrid/advprops.cpp:1676
 msgid "Sizing"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1772
+#: ../src/propgrid/advprops.cpp:1673
 msgid "Sizing N-S"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1771
+#: ../src/propgrid/advprops.cpp:1672
 msgid "Sizing NE-SW"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1773
+#: ../src/propgrid/advprops.cpp:1674
 msgid "Sizing NW-SE"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1774
+#: ../src/propgrid/advprops.cpp:1675
 msgid "Sizing W-E"
 msgstr ""
 
-#: ../src/msw/progdlg.cpp:801
+#: ../src/msw/progdlg.cpp:1088
 msgid "Skip"
 msgstr "Пропустити"
 
-#: ../src/generic/fontdlgg.cpp:330
+#: ../src/generic/fontdlgg.cpp:326
 msgid "Slant"
 msgstr "Нахилений"
 
@@ -6511,7 +6673,7 @@ msgid "Small C&apitals"
 msgstr "&Мала капітель"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:79
+#: ../src/common/accelcmn.cpp:76
 msgid "Snapshot"
 msgstr ""
 
@@ -6519,37 +6681,37 @@ msgstr ""
 msgid "Solid"
 msgstr "Суцільна"
 
-#: ../src/common/docview.cpp:1791
+#: ../src/common/docview.cpp:1785
 msgid "Sorry, could not open this file."
 msgstr "Вибачте, не вдалося відкрити цей файл."
 
-#: ../src/common/prntbase.cpp:2057 ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2079 ../src/common/prntbase.cpp:2087
 msgid "Sorry, not enough memory to create a preview."
 msgstr "Нестача пам'яті для створення зони попереднього перегляду."
 
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "Sorry, that name is taken. Please choose another."
 msgstr "Вибачте, цю назву вже використано. Будь ласка, виберіть іншу."
 
-#: ../src/common/docview.cpp:1814
+#: ../src/common/docview.cpp:1819
 msgid "Sorry, the format for this file is unknown."
 msgstr "Вибачте, формат цього файла не відомий."
 
-#: ../src/unix/sound.cpp:492
+#: ../src/unix/sound.cpp:481
 msgid "Sound data are in unsupported format."
 msgstr "Звукові дані знаходяться у непідтримуваному форматі."
 
-#: ../src/unix/sound.cpp:477
+#: ../src/unix/sound.cpp:466
 #, c-format
 msgid "Sound file '%s' is in unsupported format."
 msgstr "Звуковий файл «%s» має непідтримуваний формат."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:67
+#: ../src/common/accelcmn.cpp:64
 #, fuzzy
 msgid "Space"
 msgstr "Проміжки"
@@ -6558,12 +6720,12 @@ msgstr "Проміжки"
 msgid "Spacing"
 msgstr "Проміжки"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "Spell Check"
 msgstr "Перевірка правопису"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1776
+#: ../src/propgrid/advprops.cpp:1677
 msgid "Spraycan"
 msgstr ""
 
@@ -6572,7 +6734,7 @@ msgstr ""
 msgid "Standard"
 msgstr "Стандартна"
 
-#: ../src/common/paper.cpp:104
+#: ../src/common/paper.cpp:101
 msgid "Statement, 5 1/2 x 8 1/2 in"
 msgstr "Statement, 5 1/2 x 8 1/2 дюйм"
 
@@ -6581,33 +6743,29 @@ msgstr "Statement, 5 1/2 x 8 1/2 дюйм"
 msgid "Static"
 msgstr "Статична"
 
-#: ../src/generic/prntdlgg.cpp:204
+#: ../src/generic/prntdlgg.cpp:197
 msgid "Status:"
 msgstr "Статус:"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "Stop"
 msgstr "Зупинити"
 
-#: ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196
 msgid "Strikethrough"
 msgstr "Перекреслення"
 
-#: ../src/common/colourcmn.cpp:45
+#: ../src/common/colourcmn.cpp:42
 #, c-format
 msgid "String To Colour : Incorrect colour specification : %s"
 msgstr "Рядок для кольору : Некоректна специфікація кольору : %s"
 
 #. TRANSLATORS: Label of font style
-#: ../src/richtext/richtextformatdlg.cpp:339 ../src/propgrid/advprops.cpp:680
+#: ../src/propgrid/advprops.cpp:590 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Стиль"
 
-#: ../include/wx/richtext/richtextstyledlg.h:46
-msgid "Style Organiser"
-msgstr "Записник стилів"
-
-#: ../src/osx/carbon/fontdlg.cpp:348
+#: ../src/osx/carbon/fontdlg.cpp:345
 msgid "Style:"
 msgstr "Стиль:"
 
@@ -6616,7 +6774,7 @@ msgid "Subscrip&t"
 msgstr "Ни&жній індекс"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:83
+#: ../src/common/accelcmn.cpp:80
 msgid "Subtract"
 msgstr ""
 
@@ -6624,11 +6782,11 @@ msgstr ""
 msgid "Supe&rscript"
 msgstr "Вер&хній індекс"
 
-#: ../src/common/paper.cpp:150
+#: ../src/common/paper.cpp:147
 msgid "SuperA/SuperA/A4 227 x 356 mm"
 msgstr "SuperA/SuperA/A4 227 x 356 мм"
 
-#: ../src/common/paper.cpp:151
+#: ../src/common/paper.cpp:148
 msgid "SuperB/SuperB/A3 305 x 487 mm"
 msgstr "SuperB/SuperB/A3 305 x 487 мм"
 
@@ -6636,7 +6794,7 @@ msgstr "SuperB/SuperB/A3 305 x 487 мм"
 msgid "Suppress hyphe&nation"
 msgstr "Приду&шити перенесення слів"
 
-#: ../src/generic/fontdlgg.cpp:326
+#: ../src/generic/fontdlgg.cpp:322
 msgid "Swiss"
 msgstr "Swiss"
 
@@ -6654,74 +6812,74 @@ msgstr "Шрифт для &символів:"
 msgid "Symbols"
 msgstr "Символи"
 
-#: ../src/common/imagtiff.cpp:369 ../src/common/imagtiff.cpp:382
-#: ../src/common/imagtiff.cpp:741
+#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
+#: ../src/common/imagtiff.cpp:738
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: Не вдалося виділити пам'ять."
 
-#: ../src/common/imagtiff.cpp:301
+#: ../src/common/imagtiff.cpp:298
 msgid "TIFF: Error loading image."
 msgstr "TIFF: Помилка під час завантаження зображення."
 
-#: ../src/common/imagtiff.cpp:468
+#: ../src/common/imagtiff.cpp:465
 msgid "TIFF: Error reading image."
 msgstr "TIFF: Помилка читання зображення."
 
-#: ../src/common/imagtiff.cpp:608
+#: ../src/common/imagtiff.cpp:605
 msgid "TIFF: Error saving image."
 msgstr "TIFF: Помилка запису зображення."
 
-#: ../src/common/imagtiff.cpp:846
+#: ../src/common/imagtiff.cpp:843
 msgid "TIFF: Error writing image."
 msgstr "TIFF: Помилка запису зображення."
 
-#: ../src/common/imagtiff.cpp:355
+#: ../src/common/imagtiff.cpp:352
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: розмір зображення є надзвичайно великим."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:68
+#: ../src/common/accelcmn.cpp:65
 #, fuzzy
 msgid "Tab"
 msgstr "Табуляції"
 
-#: ../src/richtext/richtextbuffer.cpp:11498
+#: ../src/richtext/richtextbuffer.cpp:11497
 msgid "Table Properties"
 msgstr "Властивості таблиці"
 
-#: ../src/common/paper.cpp:145
+#: ../src/common/paper.cpp:142
 msgid "Tabloid Extra 11.69 x 18 in"
 msgstr "Таблоїд Екстра 11,69 x 18 дюймів"
 
-#: ../src/common/paper.cpp:102
+#: ../src/common/paper.cpp:99
 msgid "Tabloid, 11 x 17 in"
 msgstr "Таблоїд, 11 x 17 дюймів"
 
-#: ../src/richtext/richtextformatdlg.cpp:354
+#: ../src/richtext/richtextformatdlg.cpp:347
 msgid "Tabs"
 msgstr "Табуляції"
 
-#: ../src/propgrid/advprops.cpp:1598
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Teal"
 msgstr "Зеленувато-блакитний"
 
-#: ../src/generic/fontdlgg.cpp:327
+#: ../src/generic/fontdlgg.cpp:323
 msgid "Teletype"
 msgstr "Телетайп"
 
-#: ../src/common/docview.cpp:1896
+#: ../src/common/docview.cpp:1901
 msgid "Templates"
 msgstr "Шаблони"
 
-#: ../src/common/fmapbase.cpp:158
+#: ../src/common/fmapbase.cpp:155
 msgid "Thai (ISO-8859-11)"
 msgstr "Тайська (ISO-8859-11)"
 
-#: ../src/common/ftp.cpp:619
+#: ../src/common/ftp.cpp:622
 msgid "The FTP server doesn't support passive mode."
 msgstr "Сервер FTP не підтримує пасивний режим."
 
-#: ../src/common/ftp.cpp:605
+#: ../src/common/ftp.cpp:608
 msgid "The FTP server doesn't support the PORT command."
 msgstr "Сервер FTP не підтримує команду PORT."
 
@@ -6732,8 +6890,8 @@ msgstr "Сервер FTP не підтримує команду PORT."
 msgid "The available bullet styles."
 msgstr "Доступні стилі позначок."
 
-#: ../src/richtext/richtextstyledlg.cpp:202
-#: ../src/richtext/richtextstyledlg.cpp:204
+#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:200
 msgid "The available styles."
 msgstr "Доступні стилі."
 
@@ -6789,12 +6947,12 @@ msgstr "Нижня позиція."
 msgid "The bullet character."
 msgstr "Символ позначки."
 
-#: ../src/richtext/richtextsymboldlg.cpp:443
-#: ../src/richtext/richtextsymboldlg.cpp:445
+#: ../src/richtext/richtextsymboldlg.cpp:440
+#: ../src/richtext/richtextsymboldlg.cpp:442
 msgid "The character code."
 msgstr "Код символу."
 
-#: ../src/common/fontmap.cpp:203
+#: ../src/common/fontmap.cpp:200
 #, c-format
 msgid ""
 "The charset '%s' is unknown. You may select\n"
@@ -6805,7 +6963,7 @@ msgstr ""
 "замість нього інший набір або натиснути [Скасувати], \n"
 "якщо його не можна замінити"
 
-#: ../src/msw/ole/dataobj.cpp:394
+#: ../src/msw/ole/dataobj.cpp:402
 #, c-format
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "Формату буфера даних «%d» не існує."
@@ -6815,7 +6973,7 @@ msgstr "Формату буфера даних «%d» не існує."
 msgid "The default style for the next paragraph."
 msgstr "Типовий стиль для наступного абзацу."
 
-#: ../src/generic/dirdlgg.cpp:202
+#: ../src/generic/dirdlgg.cpp:199
 #, c-format
 msgid ""
 "The directory '%s' does not exist\n"
@@ -6824,7 +6982,7 @@ msgstr ""
 "Каталог «%s» не присутній\n"
 "Створити його зараз?"
 
-#: ../src/html/htmprint.cpp:271
+#: ../src/html/htmprint.cpp:283
 #, c-format
 msgid ""
 "The document \"%s\" doesn't fit on the page horizontally and will be "
@@ -6837,7 +6995,7 @@ msgstr ""
 "\n"
 "Бажаєте надрукувати його попри це?"
 
-#: ../src/common/docview.cpp:1202
+#: ../src/common/docview.cpp:1196
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -6846,36 +7004,36 @@ msgstr ""
 "Файла «%s» не існує, отже його неможливо відкрити.\n"
 "Його було вилучено зі списку нещодавно використаних."
 
-#: ../src/richtext/richtextindentspage.cpp:208
-#: ../src/richtext/richtextindentspage.cpp:210
 #: ../src/richtext/richtextliststylepage.cpp:394
 #: ../src/richtext/richtextliststylepage.cpp:396
+#: ../src/richtext/richtextindentspage.cpp:208
+#: ../src/richtext/richtextindentspage.cpp:210
 msgid "The first line indent."
 msgstr "Розмір шрифту:"
 
-#: ../src/gtk/utilsgtk.cpp:481
-msgid "The following standard GTK+ options are also supported:\n"
-msgstr "Крім того, підтримуються такі стандартні параметри GTK+:\n"
+#: ../src/generic/dbgrptg.cpp:318
+msgid "The following debug report will be generated\n"
+msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:414 ../src/generic/fontdlgg.cpp:416
+#: ../src/generic/fontdlgg.cpp:411 ../src/generic/fontdlgg.cpp:413
 msgid "The font colour."
 msgstr "Колір шрифту."
 
-#: ../src/generic/fontdlgg.cpp:375 ../src/generic/fontdlgg.cpp:377
+#: ../src/generic/fontdlgg.cpp:371 ../src/generic/fontdlgg.cpp:373
 msgid "The font family."
 msgstr "Гарнітура шрифту."
 
-#: ../src/richtext/richtextsymboldlg.cpp:405
-#: ../src/richtext/richtextsymboldlg.cpp:407
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "The font from which to take the symbol."
 msgstr "Шрифт, з якого слід брати символ."
 
-#: ../src/generic/fontdlgg.cpp:427 ../src/generic/fontdlgg.cpp:429
-#: ../src/generic/fontdlgg.cpp:434 ../src/generic/fontdlgg.cpp:436
+#: ../src/generic/fontdlgg.cpp:424 ../src/generic/fontdlgg.cpp:426
+#: ../src/generic/fontdlgg.cpp:430 ../src/generic/fontdlgg.cpp:432
 msgid "The font point size."
 msgstr "Розмір шрифту:"
 
-#: ../src/osx/carbon/fontdlg.cpp:343 ../src/osx/carbon/fontdlg.cpp:345
+#: ../src/osx/carbon/fontdlg.cpp:340 ../src/osx/carbon/fontdlg.cpp:342
 msgid "The font size in points."
 msgstr "Розмір шрифту у пунктах."
 
@@ -6884,15 +7042,15 @@ msgstr "Розмір шрифту у пунктах."
 msgid "The font size units, points or pixels."
 msgstr "Одиниці виміру розміру символів шрифту, пункти або пікселі."
 
-#: ../src/generic/fontdlgg.cpp:386 ../src/generic/fontdlgg.cpp:388
+#: ../src/generic/fontdlgg.cpp:382 ../src/generic/fontdlgg.cpp:384
 msgid "The font style."
 msgstr "Стиль шрифту."
 
-#: ../src/generic/fontdlgg.cpp:397 ../src/generic/fontdlgg.cpp:399
+#: ../src/generic/fontdlgg.cpp:393 ../src/generic/fontdlgg.cpp:395
 msgid "The font weight."
 msgstr "Вага шрифту."
 
-#: ../src/common/docview.cpp:1483
+#: ../src/common/docview.cpp:1477
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Не вдалося визначити формат файла «%s»."
@@ -6903,10 +7061,10 @@ msgstr "Не вдалося визначити формат файла «%s»."
 msgid "The horizontal offset."
 msgstr "Увімкнути вертикальний відступ."
 
-#: ../src/richtext/richtextindentspage.cpp:199
-#: ../src/richtext/richtextindentspage.cpp:201
 #: ../src/richtext/richtextliststylepage.cpp:385
 #: ../src/richtext/richtextliststylepage.cpp:387
+#: ../src/richtext/richtextindentspage.cpp:199
+#: ../src/richtext/richtextindentspage.cpp:201
 msgid "The left indent."
 msgstr "Лівий відступ."
 
@@ -6927,10 +7085,10 @@ msgstr "Ширина лівої фаски."
 msgid "The left position."
 msgstr "Ліва позиція."
 
-#: ../src/richtext/richtextindentspage.cpp:288
-#: ../src/richtext/richtextindentspage.cpp:290
 #: ../src/richtext/richtextliststylepage.cpp:462
 #: ../src/richtext/richtextliststylepage.cpp:464
+#: ../src/richtext/richtextindentspage.cpp:288
+#: ../src/richtext/richtextindentspage.cpp:290
 msgid "The line spacing."
 msgstr "Проміжок між рядками."
 
@@ -6939,7 +7097,7 @@ msgstr "Проміжок між рядками."
 msgid "The list item number."
 msgstr "Номер елемента у списку."
 
-#: ../src/msw/ole/automtn.cpp:664
+#: ../src/msw/ole/automtn.cpp:655
 msgid "The locale ID is unknown."
 msgstr "Невідомий ідентифікатор локалі."
 
@@ -6978,7 +7136,7 @@ msgstr "Ширина об’єкта."
 msgid "The outline level."
 msgstr "Рівень відступу."
 
-#: ../src/common/log.cpp:277
+#: ../src/common/log.cpp:296
 #, fuzzy, c-format
 msgid "The previous message repeated %u time."
 msgid_plural "The previous message repeated %u times."
@@ -6986,12 +7144,12 @@ msgstr[0] "Попереднє повідомлення повторено %lu р
 msgstr[1] "Попереднє повідомлення повторено %lu рази."
 msgstr[2] "Попереднє повідомлення повторено %lu разів."
 
-#: ../src/common/log.cpp:270
+#: ../src/common/log.cpp:289
 msgid "The previous message repeated once."
 msgstr "Попереднє повідомлення повторено один раз."
 
-#: ../src/richtext/richtextsymboldlg.cpp:462
-#: ../src/richtext/richtextsymboldlg.cpp:464
+#: ../src/richtext/richtextsymboldlg.cpp:459
+#: ../src/richtext/richtextsymboldlg.cpp:461
 msgid "The range to show."
 msgstr "Діапазон показу."
 
@@ -7005,15 +7163,15 @@ msgstr ""
 "особисту інформацію,\n"
 "будь ласка, зніміть з них позначення, їх буде вилучено зі звіту.\n"
 
-#: ../src/common/cmdline.cpp:1254
+#: ../src/common/cmdline.cpp:1250
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "Обов'язковий параметр «%s» не вказаний."
 
-#: ../src/richtext/richtextindentspage.cpp:217
-#: ../src/richtext/richtextindentspage.cpp:219
 #: ../src/richtext/richtextliststylepage.cpp:403
 #: ../src/richtext/richtextliststylepage.cpp:405
+#: ../src/richtext/richtextindentspage.cpp:217
+#: ../src/richtext/richtextindentspage.cpp:219
 msgid "The right indent."
 msgstr "Відступ праворуч."
 
@@ -7055,16 +7213,16 @@ msgstr ""
 msgid "The shadow spread."
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:267
 #: ../src/richtext/richtextliststylepage.cpp:439
 #: ../src/richtext/richtextliststylepage.cpp:441
+#: ../src/richtext/richtextindentspage.cpp:267
 msgid "The spacing after the paragraph."
 msgstr "Проміжок після абзацу."
 
-#: ../src/richtext/richtextindentspage.cpp:257
-#: ../src/richtext/richtextindentspage.cpp:259
 #: ../src/richtext/richtextliststylepage.cpp:430
 #: ../src/richtext/richtextliststylepage.cpp:432
+#: ../src/richtext/richtextindentspage.cpp:257
+#: ../src/richtext/richtextindentspage.cpp:259
 msgid "The spacing before the paragraph."
 msgstr "Проміжок перед абзацом."
 
@@ -7078,12 +7236,12 @@ msgstr "Назва стилю."
 msgid "The style on which this style is based."
 msgstr "Стиль, на якому засновано цей стиль."
 
-#: ../src/richtext/richtextstyledlg.cpp:214
-#: ../src/richtext/richtextstyledlg.cpp:216
+#: ../src/richtext/richtextstyledlg.cpp:210
+#: ../src/richtext/richtextstyledlg.cpp:212
 msgid "The style preview."
 msgstr "Перегляд стилю."
 
-#: ../src/msw/ole/automtn.cpp:680
+#: ../src/msw/ole/automtn.cpp:671
 msgid "The system cannot find the file specified."
 msgstr "Системі не вдалося знайти вказаного файла."
 
@@ -7096,7 +7254,7 @@ msgstr "Позиція табуляції."
 msgid "The tab positions."
 msgstr "Позиції табуляції."
 
-#: ../src/richtext/richtextctrl.cpp:3098
+#: ../src/richtext/richtextctrl.cpp:3099
 msgid "The text couldn't be saved."
 msgstr "Текст не може бути записаний."
 
@@ -7117,7 +7275,7 @@ msgstr "Ширина верхньої фаски."
 msgid "The top position."
 msgstr "Верхня позиція."
 
-#: ../src/common/cmdline.cpp:1232
+#: ../src/common/cmdline.cpp:1228
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "Значення параметра «%s» повинно бути задано."
@@ -7127,7 +7285,7 @@ msgstr "Значення параметра «%s» повинно бути за�
 msgid "The value of the corner radius."
 msgstr "Значення радіуса закруглення."
 
-#: ../src/msw/dialup.cpp:433
+#: ../src/msw/dialup.cpp:427
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -7142,14 +7300,14 @@ msgstr ""
 msgid "The vertical offset."
 msgstr "Увімкнути вертикальний відступ."
 
-#: ../src/richtext/richtextprint.cpp:619 ../src/html/htmprint.cpp:745
+#: ../src/html/htmprint.cpp:749 ../src/richtext/richtextprint.cpp:615
 msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr ""
 "Під час створення сторінки виникла проблема: можливо, вам слід встановити "
 "типовий принтер."
 
-#: ../src/html/htmprint.cpp:255
+#: ../src/html/htmprint.cpp:267
 msgid ""
 "This document doesn't fit on the page horizontally and will be truncated "
 "when it is printed."
@@ -7157,16 +7315,16 @@ msgstr ""
 "Цей документ не можна вмістити на сторінку у горизонтальному напрямку, його "
 "буде обрізано під час друку."
 
-#: ../src/common/image.cpp:2854
+#: ../src/common/image.cpp:2963
 #, c-format
 msgid "This is not a %s."
 msgstr "Це не %s."
 
-#: ../src/common/wincmn.cpp:1653
+#: ../src/common/wincmn.cpp:1654
 msgid "This platform does not support background transparency."
 msgstr "На цій платформі підтримки прозорості тла не передбачено."
 
-#: ../src/gtk/window.cpp:4660
+#: ../src/gtk/window.cpp:5664
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
@@ -7174,7 +7332,15 @@ msgstr ""
 "Цю програму було зібрано з надто старою версією GTK+. Будь ласка, виконайте "
 "повторне збирання з версією GTK+ 2.12 або новішою."
 
-#: ../src/msw/thread.cpp:1240
+#: ../src/gtk/glcanvas.cpp:176
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/msw/thread.cpp:1246
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -7182,11 +7348,11 @@ msgstr ""
 "Помилка ініціалізації модуля ниток: Не вдалося записати значення в "
 "локальному просторі нитки"
 
-#: ../src/unix/threadpsx.cpp:1794
+#: ../src/unix/threadpsx.cpp:1843
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr "Помилка ініціалізації модуля ниток: не вдалося створити ключ нитки"
 
-#: ../src/msw/thread.cpp:1228
+#: ../src/msw/thread.cpp:1234
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -7194,82 +7360,82 @@ msgstr ""
 "Помилка ініціалізації модуля ниток: Не вдалося виділити індекс в локальному "
 "просторі нитки"
 
-#: ../src/unix/threadpsx.cpp:1043
+#: ../src/unix/threadpsx.cpp:1061
 msgid "Thread priority setting is ignored."
 msgstr "Пріоритет нитки проігноровано."
 
-#: ../src/msw/mdi.cpp:176
+#: ../src/msw/mdi.cpp:171
 msgid "Tile &Horizontally"
 msgstr "Розставити &горизонтально"
 
-#: ../src/msw/mdi.cpp:177
+#: ../src/msw/mdi.cpp:172
 msgid "Tile &Vertically"
 msgstr "Розставити &вертикально"
 
-#: ../src/common/ftp.cpp:200
+#: ../src/common/ftp.cpp:197
 msgid "Timeout while waiting for FTP server to connect, try passive mode."
 msgstr ""
 "Тайм-аут очікування на з'єднання з сервером FTP, спроба пасивного режиму."
 
-#: ../src/generic/tipdlg.cpp:201
+#: ../src/generic/tipdlg.cpp:198
 msgid "Tip of the Day"
 msgstr "Підказка дня"
 
-#: ../src/generic/tipdlg.cpp:140
+#: ../src/generic/tipdlg.cpp:137
 msgid "Tips not available, sorry!"
 msgstr "Вибачте, підказки недоступні!"
 
-#: ../src/generic/prntdlgg.cpp:242
+#: ../src/generic/prntdlgg.cpp:235
 msgid "To:"
 msgstr "До:"
 
-#: ../src/richtext/richtextbuffer.cpp:8363
+#: ../src/richtext/richtextbuffer.cpp:8361
 msgid "Too many EndStyle calls!"
 msgstr "Забагато викликів EndStyle!"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:891
+#: ../src/propgrid/advprops.cpp:792
 msgid "Tooltip"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:892
+#: ../src/propgrid/advprops.cpp:793
 msgid "TooltipText"
 msgstr ""
 
-#: ../src/richtext/richtextsizepage.cpp:286
-#: ../src/richtext/richtextsizepage.cpp:290 ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197 ../src/richtext/richtextsizepage.cpp:286
+#: ../src/richtext/richtextsizepage.cpp:290
 msgid "Top"
 msgstr "Вгорі"
 
-#: ../src/generic/prntdlgg.cpp:881
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Top margin (mm):"
 msgstr "Верхня межа (мм):"
 
-#: ../src/generic/aboutdlgg.cpp:79
+#: ../src/generic/aboutdlgg.cpp:76
 msgid "Translations by "
 msgstr "Переклад "
 
-#: ../src/generic/aboutdlgg.cpp:188
+#: ../src/generic/aboutdlgg.cpp:185
 msgid "Translators"
 msgstr "Перекладачі"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:211
+#: ../src/propgrid/propgrid.cpp:192
 msgid "True"
 msgstr "Так"
 
-#: ../src/common/fs_mem.cpp:227
+#: ../src/common/fs_mem.cpp:222
 #, c-format
 msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
 msgstr ""
 "Спроба вилучення файла «%s» зі списку пам'яті VFS, але його не завантажено!"
 
-#: ../src/common/fmapbase.cpp:156
+#: ../src/common/fmapbase.cpp:153
 msgid "Turkish (ISO-8859-9)"
 msgstr "Turkish (ISO-8859-9)"
 
-#: ../src/generic/filectrlg.cpp:426
+#: ../src/generic/filectrlg.cpp:422
 msgid "Type"
 msgstr "Тип"
 
@@ -7283,17 +7449,17 @@ msgstr "Наберіть назву шрифту."
 msgid "Type a size in points."
 msgstr "Наберіть розмір у пунктах."
 
-#: ../src/msw/ole/automtn.cpp:676
+#: ../src/msw/ole/automtn.cpp:667
 #, c-format
 msgid "Type mismatch in argument %u."
 msgstr "Невідповідність типів у аргументі %u."
 
-#: ../src/common/xtixml.cpp:356 ../src/common/xtixml.cpp:509
-#: ../src/common/xtistrm.cpp:318
+#: ../src/common/xtixml.cpp:352 ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315
 msgid "Type must have enum - long conversion"
 msgstr "Тип має містити перетворення enum — long"
 
-#: ../src/propgrid/propgridiface.cpp:401
+#: ../src/propgrid/propgridiface.cpp:385
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
@@ -7302,19 +7468,19 @@ msgstr ""
 "Помилка дії з типами «%s»: властивість з міткою «%s» належить до типу «%s», "
 "а не «%s»."
 
-#: ../src/common/paper.cpp:133
+#: ../src/common/paper.cpp:130
 msgid "US Std Fanfold, 14 7/8 x 11 in"
 msgstr "US Std Fanfold, 14 7/8 x 11 дюйм"
 
-#: ../src/common/fmapbase.cpp:196
+#: ../src/common/fmapbase.cpp:193
 msgid "US-ASCII"
 msgstr "US-ASCII"
 
-#: ../src/unix/fswatcher_inotify.cpp:109
+#: ../src/unix/fswatcher_inotify.cpp:106
 msgid "Unable to add inotify watch"
 msgstr "Не вдалося додати спостереження inotify"
 
-#: ../src/unix/fswatcher_kqueue.cpp:136
+#: ../src/unix/fswatcher_kqueue.cpp:153
 msgid "Unable to add kqueue watch"
 msgstr "Не вдалося додати спостереження kqueue"
 
@@ -7326,7 +7492,7 @@ msgstr "Не вдалося пов’язати обробник з портом
 msgid "Unable to close I/O completion port handle"
 msgstr "Не вдалося закрити обробник порту доповнення введення-виведення"
 
-#: ../src/unix/fswatcher_inotify.cpp:97
+#: ../src/unix/fswatcher_inotify.cpp:94
 msgid "Unable to close inotify instance"
 msgstr "Не вдалося завершити роботу екземпляра inotify"
 
@@ -7344,15 +7510,15 @@ msgstr "Не вдалося завершити роботу обробника �
 msgid "Unable to create I/O completion port"
 msgstr "Не вдалося створити порт завершення введення-виведення"
 
-#: ../src/msw/fswatcher.cpp:84
+#: ../src/msw/fswatcher.cpp:81
 msgid "Unable to create IOCP worker thread"
 msgstr "Не вдалося створити нитку обробки IOCP"
 
-#: ../src/unix/fswatcher_inotify.cpp:74
+#: ../src/unix/fswatcher_inotify.cpp:71
 msgid "Unable to create inotify instance"
 msgstr "Не вдалося створити екземпляр inotify"
 
-#: ../src/unix/fswatcher_kqueue.cpp:97
+#: ../src/unix/fswatcher_kqueue.cpp:114
 msgid "Unable to create kqueue instance"
 msgstr "Не вдалося створити екземпляр kqueue"
 
@@ -7360,11 +7526,11 @@ msgstr "Не вдалося створити екземпляр kqueue"
 msgid "Unable to dequeue completion packet"
 msgstr "Не вдалося вилучити з черги пакет завершення"
 
-#: ../src/unix/fswatcher_kqueue.cpp:185
+#: ../src/unix/fswatcher_kqueue.cpp:202
 msgid "Unable to get events from kqueue"
 msgstr "Не вдалося отримати список подій від kqueue"
 
-#: ../src/gtk/app.cpp:435
+#: ../src/gtk/app.cpp:431
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr ""
 "Не вдалося ініціалізувати GTK+, чи правильно встановлено змінну DISPLAY?"
@@ -7374,12 +7540,12 @@ msgstr ""
 msgid "Unable to open path '%s'"
 msgstr "Не вдалося відкрити адресу «%s»"
 
-#: ../src/html/htmlwin.cpp:583
+#: ../src/html/htmlwin.cpp:586
 #, c-format
 msgid "Unable to open requested HTML document: %s"
 msgstr "Не вдалося відкрити запрошений документ HTML: %s"
 
-#: ../src/unix/sound.cpp:368
+#: ../src/unix/sound.cpp:365
 msgid "Unable to play sound asynchronously."
 msgstr "Не вдалося асинхронно відтворити звук."
 
@@ -7387,62 +7553,62 @@ msgstr "Не вдалося асинхронно відтворити звук."
 msgid "Unable to post completion status"
 msgstr "Не вдалося повідомити про стан завершення"
 
-#: ../src/unix/fswatcher_inotify.cpp:556
+#: ../src/unix/fswatcher_inotify.cpp:553
 msgid "Unable to read from inotify descriptor"
 msgstr "Не вдалося прочитати дані з дескриптора inotify"
 
-#: ../src/unix/fswatcher_inotify.cpp:141
+#: ../src/unix/fswatcher_inotify.cpp:138
 #, fuzzy, c-format
 msgid "Unable to remove inotify watch %i"
 msgstr "Не вдалося вилучити спостереження inotify"
 
-#: ../src/unix/fswatcher_kqueue.cpp:153
+#: ../src/unix/fswatcher_kqueue.cpp:170
 msgid "Unable to remove kqueue watch"
 msgstr "Не вдалося вилучити спостереження kqueue"
 
-#: ../src/msw/fswatcher.cpp:168
+#: ../src/msw/fswatcher.cpp:165
 #, c-format
 msgid "Unable to set up watch for '%s'"
 msgstr "Не вдалося налаштувати спостереження за «%s»"
 
-#: ../src/msw/fswatcher.cpp:91
+#: ../src/msw/fswatcher.cpp:88
 msgid "Unable to start IOCP worker thread"
 msgstr "Не вдалося започаткувати нитку обробки IOCP"
 
-#: ../src/common/stockitem.cpp:201
+#: ../src/common/stockitem.cpp:198
 msgid "Undelete"
 msgstr "Скасувати вилучення"
 
-#: ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199
 msgid "Underline"
 msgstr "Підкреслити"
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/richtext/richtextfontpage.cpp:359 ../src/osx/carbon/fontdlg.cpp:370
-#: ../src/propgrid/advprops.cpp:690
+#: ../src/osx/carbon/fontdlg.cpp:367 ../src/propgrid/advprops.cpp:600
+#: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Підкреслене"
 
-#: ../src/common/stockitem.cpp:203 ../src/stc/stc_i18n.cpp:15
+#: ../src/common/stockitem.cpp:200 ../src/stc/stc_i18n.cpp:15
 msgid "Undo"
 msgstr "Вернути"
 
-#: ../src/common/stockitem.cpp:265
+#: ../src/common/stockitem.cpp:263
 msgid "Undo last action"
 msgstr "Скасувати останню дію"
 
-#: ../src/common/cmdline.cpp:1029
+#: ../src/common/cmdline.cpp:1025
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "За параметром «%s» слідують неочікувані символи."
 
-#: ../src/unix/fswatcher_inotify.cpp:274
+#: ../src/unix/fswatcher_inotify.cpp:271
 #, c-format
 msgid "Unexpected event for \"%s\": no matching watch descriptor."
 msgstr ""
 "Неочікувана подія для «%s»: немає відповідного дескриптора спостереження."
 
-#: ../src/common/cmdline.cpp:1195
+#: ../src/common/cmdline.cpp:1191
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Несподіваний параметр «%s»"
@@ -7451,49 +7617,49 @@ msgstr "Несподіваний параметр «%s»"
 msgid "Unexpectedly new I/O completion port was created"
 msgstr "Неочікувано створено новий порт доповнення введення-виведення"
 
-#: ../src/msw/fswatcher.cpp:70
+#: ../src/msw/fswatcher.cpp:67
 msgid "Ungraceful worker thread termination"
 msgstr "Некоректне завершення роботи нитки"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:460
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:456
+#: ../src/richtext/richtextsymboldlg.cpp:457
+#: ../src/richtext/richtextsymboldlg.cpp:458
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../src/common/fmapbase.cpp:185 ../src/common/fmapbase.cpp:191
+#: ../src/common/fmapbase.cpp:182 ../src/common/fmapbase.cpp:188
 msgid "Unicode 16 bit (UTF-16)"
 msgstr "Unicode 16 бітів (UTF-16)"
 
-#: ../src/common/fmapbase.cpp:190
+#: ../src/common/fmapbase.cpp:187
 msgid "Unicode 16 bit Big Endian (UTF-16BE)"
 msgstr "Unicode 16 бітів Big Endian (UTF-16BE)"
 
-#: ../src/common/fmapbase.cpp:186
+#: ../src/common/fmapbase.cpp:183
 msgid "Unicode 16 bit Little Endian (UTF-16LE)"
 msgstr "Unicode 16 бітів Little Endian (UTF-16LE)"
 
-#: ../src/common/fmapbase.cpp:187 ../src/common/fmapbase.cpp:193
+#: ../src/common/fmapbase.cpp:184 ../src/common/fmapbase.cpp:190
 msgid "Unicode 32 bit (UTF-32)"
 msgstr "Unicode 32 бітів (UTF-32)"
 
-#: ../src/common/fmapbase.cpp:192
+#: ../src/common/fmapbase.cpp:189
 msgid "Unicode 32 bit Big Endian (UTF-32BE)"
 msgstr "Unicode 32 бітів Big Endian (UTF-32BE)"
 
-#: ../src/common/fmapbase.cpp:188
+#: ../src/common/fmapbase.cpp:185
 msgid "Unicode 32 bit Little Endian (UTF-32LE)"
 msgstr "Unicode 32 бітів Little Endian (UTF-32LE)"
 
-#: ../src/common/fmapbase.cpp:182
+#: ../src/common/fmapbase.cpp:179
 msgid "Unicode 7 bit (UTF-7)"
 msgstr "Unicode 7 бітів (UTF-7)"
 
-#: ../src/common/fmapbase.cpp:183
+#: ../src/common/fmapbase.cpp:180
 msgid "Unicode 8 bit (UTF-8)"
 msgstr "Unicode 8 бітів (UTF-8)"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "Unindent"
 msgstr "Скасувати відступ"
 
@@ -7644,97 +7810,102 @@ msgstr "Одиниці виміру верхньої позиції."
 msgid "Units for this value."
 msgstr "Одиниці виміру лівого поля."
 
-#: ../src/generic/progdlgg.cpp:353 ../src/generic/progdlgg.cpp:622
+#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
 msgid "Unknown"
 msgstr "Невідомий"
 
-#: ../src/msw/dde.cpp:1174
+#: ../src/msw/dde.cpp:1238
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Невідома помилка DDE %08x"
 
-#: ../src/common/xtistrm.cpp:410
+#: ../src/common/xtistrm.cpp:407
 msgid "Unknown Object passed to GetObjectClassInfo"
 msgstr "До GetObjectClassInfo передано невідомий об'єкт"
 
-#: ../src/common/imagpng.cpp:366
+#: ../src/common/imagpng.cpp:383
 #, c-format
 msgid "Unknown PNG resolution unit %d"
 msgstr "Невідома одиниця роздільної здатності PNG, %d"
 
-#: ../src/common/xtixml.cpp:327
+#: ../src/common/xtixml.cpp:323
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Невідома властивість %s"
 
-#: ../src/common/imagtiff.cpp:529
+#: ../src/common/imagtiff.cpp:526
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "Невідому одиницю роздільної здатності TIFF, %d, проігноровано"
 
-#: ../src/unix/dlunix.cpp:160
+#: ../src/propgrid/props.cpp:155
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/unix/dlunix.cpp:118
 msgid "Unknown dynamic library error"
 msgstr "Невідома помилка динамічної бібліотеки"
 
-#: ../src/common/fmapbase.cpp:810
+#: ../src/common/fmapbase.cpp:806
 #, c-format
 msgid "Unknown encoding (%d)"
 msgstr "Невідоме кодування (%d)"
 
-#: ../src/msw/ole/automtn.cpp:688
+#: ../src/msw/ole/automtn.cpp:679
 #, c-format
 msgid "Unknown error %08x"
 msgstr "Невідома помилка %08x"
 
-#: ../src/msw/ole/automtn.cpp:647
+#: ../src/msw/ole/automtn.cpp:638
 msgid "Unknown exception"
 msgstr "Невідомий виняток"
 
-#: ../src/common/image.cpp:2839
+#: ../src/common/image.cpp:2942
 msgid "Unknown image data format."
 msgstr "Невідомий формат даних зображення."
 
-#: ../src/common/cmdline.cpp:914
+#: ../src/common/cmdline.cpp:910
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Невідомий параметр long «%s»"
 
-#: ../src/msw/ole/automtn.cpp:631
+#: ../src/msw/ole/automtn.cpp:622
 msgid "Unknown name or named argument."
 msgstr "Невідома назва або іменований аргумент."
 
-#: ../src/common/cmdline.cpp:929 ../src/common/cmdline.cpp:951
+#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Невідомий параметр «%s»"
 
-#: ../src/common/mimecmn.cpp:225
+#: ../src/common/mimecmn.cpp:221
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "Незакрита дужка '{' в запису для типу MIME %s."
 
-#: ../src/common/cmdproc.cpp:262 ../src/common/cmdproc.cpp:288
-#: ../src/common/cmdproc.cpp:308
+#: ../src/common/cmdproc.cpp:255 ../src/common/cmdproc.cpp:281
+#: ../src/common/cmdproc.cpp:301
 msgid "Unnamed command"
 msgstr "Неназвана команда"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:413
+#: ../src/propgrid/propgrid.cpp:392
 msgid "Unspecified"
 msgstr "Не вказано"
 
-#: ../src/msw/clipbrd.cpp:311
+#: ../src/msw/clipbrd.cpp:325
 msgid "Unsupported clipboard format."
 msgstr "Непідтримуваний формат clipboard."
 
-#: ../src/common/appcmn.cpp:256
+#: ../src/common/appcmn.cpp:277
 #, c-format
 msgid "Unsupported theme '%s'."
 msgstr "Непідтримувана тема «%s»."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:205
-#: ../src/common/accelcmn.cpp:63
+#: ../src/common/stockitem.cpp:202 ../src/common/accelcmn.cpp:60
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Up"
 msgstr "Вверх"
 
@@ -7748,7 +7919,7 @@ msgstr "Літери у верхньому регістрі"
 msgid "Upper case roman numerals"
 msgstr "Римські цифри у верхньому регістрі"
 
-#: ../src/common/cmdline.cpp:1326
+#: ../src/common/cmdline.cpp:1322
 #, c-format
 msgid "Usage: %s"
 msgstr "Використання: %s"
@@ -7757,38 +7928,47 @@ msgstr "Використання: %s"
 msgid "Use &shadow"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:169
-#: ../src/richtext/richtextindentspage.cpp:171
 #: ../src/richtext/richtextliststylepage.cpp:358
 #: ../src/richtext/richtextliststylepage.cpp:360
+#: ../src/richtext/richtextindentspage.cpp:169
+#: ../src/richtext/richtextindentspage.cpp:171
 msgid "Use the current alignment setting."
 msgstr "Використовувати поточні параметри вирівнювання."
 
-#: ../src/common/valtext.cpp:179
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/gtk/font.cpp:552
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/common/valtext.cpp:142
 msgid "Validation conflict"
 msgstr "Конфлікт перевірки"
 
-#: ../src/propgrid/manager.cpp:238
+#: ../src/propgrid/manager.cpp:224
 msgid "Value"
 msgstr "Значення"
 
-#: ../src/propgrid/props.cpp:386 ../src/propgrid/props.cpp:500
+#: ../src/propgrid/props.cpp:309
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "Значення має бути рівним або більшим за %s."
 
-#: ../src/propgrid/props.cpp:417 ../src/propgrid/props.cpp:531
+#: ../src/propgrid/props.cpp:336
 #, c-format
 msgid "Value must be %s or less."
 msgstr "Значення має бути рівним або меншим за %s."
 
-#: ../src/propgrid/props.cpp:393 ../src/propgrid/props.cpp:424
-#: ../src/propgrid/props.cpp:507 ../src/propgrid/props.cpp:538
+#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "Значення має належати проміжку від %s до %s."
 
-#: ../src/generic/aboutdlgg.cpp:128
+#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Версія "
 
@@ -7797,25 +7977,32 @@ msgstr "Версія "
 msgid "Vertical alignment."
 msgstr "Вертикальне вирівнювання."
 
-#: ../src/generic/filedlgg.cpp:202
+#: ../src/generic/filedlgg.cpp:199
 msgid "View files as a detailed view"
 msgstr "Перегляд файлів з подробицями"
 
-#: ../src/generic/filedlgg.cpp:200
+#: ../src/generic/filedlgg.cpp:197
 msgid "View files as a list view"
 msgstr "Перегляд файлів в вигляді списку"
 
-#: ../src/common/docview.cpp:1970
+#: ../src/common/docview.cpp:1975
 msgid "Views"
 msgstr "Перегляди"
 
+#: ../src/gtk/app.cpp:348
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1777
+#: ../src/propgrid/advprops.cpp:1678
 msgid "Wait"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1779
+#: ../src/propgrid/advprops.cpp:1680
 msgid "Wait Arrow"
 msgstr ""
 
@@ -7824,244 +8011,241 @@ msgstr ""
 msgid "Waiting for IO on epoll descriptor %d failed"
 msgstr "Помилка очікування на ввід-вивід для дескриптора epoll %d"
 
-#: ../src/common/log.cpp:223
+#: ../src/common/log.cpp:241
 msgid "Warning: "
 msgstr "Попередження: "
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1778
+#: ../src/propgrid/advprops.cpp:1679
 msgid "Watch"
 msgstr ""
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:685
+#: ../src/propgrid/advprops.cpp:595
 msgid "Weight"
 msgstr "Вага"
 
-#: ../src/common/fmapbase.cpp:148
+#: ../src/common/fmapbase.cpp:145
 msgid "Western European (ISO-8859-1)"
 msgstr "Західноєвропейська (ISO-8859-1)"
 
-#: ../src/common/fmapbase.cpp:162
+#: ../src/common/fmapbase.cpp:159
 msgid "Western European with Euro (ISO-8859-15)"
 msgstr "Західноєвропейська з Євро (ISO-8859-15)"
 
-#: ../src/generic/fontdlgg.cpp:446 ../src/generic/fontdlgg.cpp:448
+#: ../src/generic/fontdlgg.cpp:443 ../src/generic/fontdlgg.cpp:445
 msgid "Whether the font is underlined."
 msgstr "Чи буде шрифт з підкресленням."
 
-#: ../src/propgrid/advprops.cpp:1611
+#: ../src/propgrid/advprops.cpp:1517
 msgid "White"
 msgstr "Білий"
 
-#: ../src/generic/fdrepdlg.cpp:144
+#: ../src/generic/fdrepdlg.cpp:141
 msgid "Whole word"
 msgstr "Тільки цілі слова"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:532
 msgid "Whole words only"
 msgstr "Тільки цілі слова"
 
-#: ../src/univ/themes/win32.cpp:1102
+#: ../src/univ/themes/win32.cpp:1099
 msgid "Win32 theme"
 msgstr "Win32 мотив "
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:893
+#: ../src/propgrid/advprops.cpp:794
 #, fuzzy
 msgid "Window"
 msgstr "&Вікно"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:894
+#: ../src/propgrid/advprops.cpp:795
 #, fuzzy
 msgid "WindowFrame"
 msgstr "&Вікно"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:895
+#: ../src/propgrid/advprops.cpp:796
 #, fuzzy
 msgid "WindowText"
 msgstr "&Вікно"
 
-#: ../src/common/fmapbase.cpp:177
+#: ../src/common/fmapbase.cpp:174
 msgid "Windows Arabic (CP 1256)"
 msgstr "Арабська Windows (CP 1256)"
 
-#: ../src/common/fmapbase.cpp:178
+#: ../src/common/fmapbase.cpp:175
 msgid "Windows Baltic (CP 1257)"
 msgstr "Балтійська Windows (CP 1257)"
 
-#: ../src/common/fmapbase.cpp:171
+#: ../src/common/fmapbase.cpp:168
 msgid "Windows Central European (CP 1250)"
 msgstr "Центральноєвропейська Windows (CP 1250)"
 
-#: ../src/common/fmapbase.cpp:168
+#: ../src/common/fmapbase.cpp:165
 msgid "Windows Chinese Simplified (CP 936) or GB-2312"
 msgstr "Китайська спрощена Windows (CP 936) або GB-2312"
 
-#: ../src/common/fmapbase.cpp:170
+#: ../src/common/fmapbase.cpp:167
 msgid "Windows Chinese Traditional (CP 950) or Big-5"
 msgstr "Традиційна китайська Windows (CP 950) або Big-5"
 
-#: ../src/common/fmapbase.cpp:172
+#: ../src/common/fmapbase.cpp:169
 msgid "Windows Cyrillic (CP 1251)"
 msgstr "Кирилична Windows (CP 1251)"
 
-#: ../src/common/fmapbase.cpp:174
+#: ../src/common/fmapbase.cpp:171
 msgid "Windows Greek (CP 1253)"
 msgstr "Грецька Windows (CP 1253)"
 
-#: ../src/common/fmapbase.cpp:176
+#: ../src/common/fmapbase.cpp:173
 msgid "Windows Hebrew (CP 1255)"
 msgstr "Єврейська Windows (CP 1255)"
 
-#: ../src/common/fmapbase.cpp:167
+#: ../src/common/fmapbase.cpp:164
 msgid "Windows Japanese (CP 932) or Shift-JIS"
 msgstr "Японська Windows (CP 932) або Shift-JIS"
 
-#: ../src/common/fmapbase.cpp:180
+#: ../src/common/fmapbase.cpp:177
 msgid "Windows Johab (CP 1361)"
 msgstr "Корейська Windows (CP 1361)"
 
-#: ../src/common/fmapbase.cpp:169
+#: ../src/common/fmapbase.cpp:166
 msgid "Windows Korean (CP 949)"
 msgstr "Корейська Windows (CP 949)"
 
-#: ../src/common/fmapbase.cpp:166
+#: ../src/common/fmapbase.cpp:163
 msgid "Windows Thai (CP 874)"
 msgstr "Тайська Windows (CP 874)"
 
-#: ../src/common/fmapbase.cpp:175
+#: ../src/common/fmapbase.cpp:172
 msgid "Windows Turkish (CP 1254)"
 msgstr "Турецька Windows (CP 1254)"
 
-#: ../src/common/fmapbase.cpp:179
+#: ../src/common/fmapbase.cpp:176
 msgid "Windows Vietnamese (CP 1258)"
 msgstr "В’єтнамська Windows (CP 1258)"
 
-#: ../src/common/fmapbase.cpp:173
+#: ../src/common/fmapbase.cpp:170
 msgid "Windows Western European (CP 1252)"
 msgstr "Західноєвропейська Windows (CP 1252)"
 
-#: ../src/common/fmapbase.cpp:181
+#: ../src/common/fmapbase.cpp:178
 msgid "Windows/DOS OEM (CP 437)"
 msgstr "Windows/DOS OEM (CP 437)"
 
-#: ../src/common/fmapbase.cpp:165
+#: ../src/common/fmapbase.cpp:162
 msgid "Windows/DOS OEM Cyrillic (CP 866)"
 msgstr "Кирилиця, Windows/DOS OEM (CP 866)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:111
+#: ../src/common/accelcmn.cpp:109
 #, fuzzy
 msgid "Windows_Left"
 msgstr "Windows 7"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:113
+#: ../src/common/accelcmn.cpp:111
 #, fuzzy
 msgid "Windows_Menu"
 msgstr "Windows ME"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:112
+#: ../src/common/accelcmn.cpp:110
 #, fuzzy
 msgid "Windows_Right"
 msgstr "Windows Vista"
 
-#: ../src/common/ffile.cpp:150
+#: ../src/common/ffile.cpp:149
 #, c-format
 msgid "Write error on file '%s'"
 msgstr "Помилка запису в файл «%s»"
 
-#: ../src/xml/xml.cpp:914
+#: ../src/xml/xml.cpp:925
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "Помилка розбору XML: «%s» у рядку %d"
 
-#: ../src/common/xpmdecod.cpp:796
+#: ../src/common/xpmdecod.cpp:794
 msgid "XPM: Malformed pixel data!"
 msgstr "XPM: Помилкові дані пікселя!"
 
-#: ../src/common/xpmdecod.cpp:705
+#: ../src/common/xpmdecod.cpp:702
 #, c-format
 msgid "XPM: incorrect colour description in line %d"
 msgstr "XPM: некоректний опис кольору у рядку %d"
 
-#: ../src/common/xpmdecod.cpp:680
+#: ../src/common/xpmdecod.cpp:677
 msgid "XPM: incorrect header format!"
 msgstr "XPM: некоректний формат заголовку!"
 
-#: ../src/common/xpmdecod.cpp:716 ../src/common/xpmdecod.cpp:725
+#: ../src/common/xpmdecod.cpp:714 ../src/common/xpmdecod.cpp:723
 #, c-format
 msgid "XPM: malformed colour definition '%s' at line %d!"
 msgstr "XPM: погано сформоване визначення кольору «%s» у рядку %d!"
 
-#: ../src/common/xpmdecod.cpp:755
+#: ../src/common/xpmdecod.cpp:753
 msgid "XPM: no colors left to use for mask!"
 msgstr "XPM: не залишилося кольорів для маски!"
 
-#: ../src/common/xpmdecod.cpp:782
+#: ../src/common/xpmdecod.cpp:780
 #, c-format
 msgid "XPM: truncated image data at line %d!"
 msgstr "XPM: обрізані дані картинки у рядку %d!"
 
-#: ../src/propgrid/advprops.cpp:1610
+#: ../src/propgrid/advprops.cpp:1516
 msgid "Yellow"
 msgstr "Жовтий"
 
-#: ../include/wx/msgdlg.h:276 ../src/common/stockitem.cpp:206
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:203
 #: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Так"
 
-#: ../src/osx/carbon/overlay.cpp:155
-msgid "You cannot Clear an overlay that is not inited"
-msgstr "Ви не можете спорожнити оверлей, який не ініційовано"
-
-#: ../src/osx/carbon/overlay.cpp:107 ../src/dfb/overlay.cpp:61
-msgid "You cannot Init an overlay twice"
-msgstr "Ви не можете двічі викликати Init для оверлеїв"
-
-#: ../src/generic/dirdlgg.cpp:287
+#: ../src/generic/dirdlgg.cpp:284
 msgid "You cannot add a new directory to this section."
 msgstr "Ви не можете додати нову теку в цю секцію."
 
-#: ../src/propgrid/propgrid.cpp:3299
+#: ../src/propgrid/propgrid.cpp:3276
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 "Вами введено некоректне значення. Натисніть ESC, щоб скасувати редагування."
 
-#: ../src/common/stockitem.cpp:209
+#: ../src/osx/cocoa/menu.mm:286
+#, fuzzy
+msgid "Zoom"
+msgstr "Збільшити"
+
+#: ../src/common/stockitem.cpp:206
 msgid "Zoom &In"
 msgstr "&Збільшити"
 
-#: ../src/common/stockitem.cpp:210
+#: ../src/common/stockitem.cpp:207
 msgid "Zoom &Out"
 msgstr "З&меншити"
 
-#: ../src/common/stockitem.cpp:209 ../src/common/prntbase.cpp:1594
+#: ../src/common/stockitem.cpp:206 ../src/common/prntbase.cpp:1619
 msgid "Zoom In"
 msgstr "Збільшити"
 
-#: ../src/common/stockitem.cpp:210 ../src/common/prntbase.cpp:1580
+#: ../src/common/stockitem.cpp:207 ../src/common/prntbase.cpp:1605
 msgid "Zoom Out"
 msgstr "Зменшити"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to &Fit"
 msgstr "Масштабувати до &заповнення"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to Fit"
 msgstr "Підібрати за розмірами"
 
-#: ../src/msw/dde.cpp:1141
+#: ../src/msw/dde.cpp:1205
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "застосування DDEML створило затяжні перегони."
 
-#: ../src/msw/dde.cpp:1129
+#: ../src/msw/dde.cpp:1193
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -8073,40 +8257,40 @@ msgstr ""
 "або неправильний ідентифікатор інстанції\n"
 "було передано до DDEML функції."
 
-#: ../src/msw/dde.cpp:1147
+#: ../src/msw/dde.cpp:1211
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "спроба клієнту встановити зв'язок не вдалася."
 
-#: ../src/msw/dde.cpp:1144
+#: ../src/msw/dde.cpp:1208
 msgid "a memory allocation failed."
 msgstr "помилка виділення пам'яті."
 
-#: ../src/msw/dde.cpp:1138
+#: ../src/msw/dde.cpp:1202
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "параметр не пройшов перевірку DDEML."
 
-#: ../src/msw/dde.cpp:1120
+#: ../src/msw/dde.cpp:1184
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "запит на синхронну дію з надання поради перевищив границю часу"
 
-#: ../src/msw/dde.cpp:1126
+#: ../src/msw/dde.cpp:1190
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "строк виконання запиту на синхронне передавання даних вичерпано."
 
-#: ../src/msw/dde.cpp:1135
+#: ../src/msw/dde.cpp:1199
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "строк виконання запиту на синхронну дію з виконання вичерпано."
 
-#: ../src/msw/dde.cpp:1153
+#: ../src/msw/dde.cpp:1217
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr ""
 "строк виконання запиту на синхронну дію з запису елемента даних вичерпано."
 
-#: ../src/msw/dde.cpp:1168
+#: ../src/msw/dde.cpp:1232
 msgid "a request to end an advise transaction has timed out."
 msgstr "строк виконання запиту щодо завершення дії з надання поради вичерпано."
 
-#: ../src/msw/dde.cpp:1162
+#: ../src/msw/dde.cpp:1226
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -8116,15 +8300,15 @@ msgstr ""
 "її перервано клієнтом, або сервер було\n"
 "зупинено до завершення дії."
 
-#: ../src/msw/dde.cpp:1150
+#: ../src/msw/dde.cpp:1214
 msgid "a transaction failed."
 msgstr "помилкова дія."
 
-#: ../src/common/accelcmn.cpp:189
+#: ../src/common/accelcmn.cpp:188
 msgid "alt"
 msgstr "alt"
 
-#: ../src/msw/dde.cpp:1132
+#: ../src/msw/dde.cpp:1196
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -8136,15 +8320,15 @@ msgstr ""
 "або програма запущена як APPCMD_CLIENTONLY \n"
 "спробувала виконати серверні дії."
 
-#: ../src/msw/dde.cpp:1156
+#: ../src/msw/dde.cpp:1220
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "внутрішній виклик до PostMessage не пройшов"
 
-#: ../src/msw/dde.cpp:1165
+#: ../src/msw/dde.cpp:1229
 msgid "an internal error has occurred in the DDEML."
 msgstr "внутрішня помилка у DDEML."
 
-#: ../src/msw/dde.cpp:1171
+#: ../src/msw/dde.cpp:1235
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -8154,56 +8338,56 @@ msgstr ""
 "Тільки-но програма повернулася зі зворотного виклику XTYP_XACT_COMPLETE,\n"
 "ідентифікатор дії для цього виклику вже не є дійсним."
 
-#: ../src/common/zipstrm.cpp:1483
+#: ../src/common/zipstrm.cpp:1522
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "припускається, що це ланцюговий zip з багатьох частин"
 
-#: ../src/common/fileconf.cpp:1847
+#: ../src/common/fileconf.cpp:1849
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "спроба замінити незамінну клавішу «%s» проігнорована."
 
-#: ../src/html/chm.cpp:329
+#: ../src/html/chm.cpp:326
 msgid "bad arguments to library function"
 msgstr "некоректні аргументи бібліотечної функції"
 
-#: ../src/html/chm.cpp:341
+#: ../src/html/chm.cpp:338
 msgid "bad signature"
 msgstr "некоректний підпис"
 
-#: ../src/common/zipstrm.cpp:1918
+#: ../src/common/zipstrm.cpp:1988
 msgid "bad zipfile offset to entry"
 msgstr "некоректний відступ для входу у zip-файлі"
 
-#: ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400
 msgid "binary"
 msgstr "двійковий"
 
-#: ../src/common/fontcmn.cpp:996
+#: ../src/common/fontcmn.cpp:1195
 msgid "bold"
 msgstr "жирний"
 
-#: ../src/msw/utils.cpp:1144
+#: ../src/msw/utils.cpp:1135
 #, c-format
 msgid "build %lu"
 msgstr "збірка %lu"
 
-#: ../src/common/ffile.cpp:75
+#: ../src/common/ffile.cpp:73
 #, c-format
 msgid "can't close file '%s'"
 msgstr "Не вдалося закрити файл «%s»"
 
-#: ../src/common/file.cpp:245
+#: ../src/common/file.cpp:242
 #, c-format
 msgid "can't close file descriptor %d"
 msgstr "Не вдалося закрити дескриптор файла %d"
 
-#: ../src/common/file.cpp:586
+#: ../src/common/ffile.cpp:382 ../src/common/file.cpp:613
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "Не вдалося записати зміни в файл «%s»"
 
-#: ../src/common/file.cpp:178
+#: ../src/common/file.cpp:175
 #, c-format
 msgid "can't create file '%s'"
 msgstr "Не вдалося створити файл «%s»"
@@ -8213,50 +8397,50 @@ msgstr "Не вдалося створити файл «%s»"
 msgid "can't delete user configuration file '%s'"
 msgstr "Не вдалося вилучити файл налаштувань користувача «%s»"
 
-#: ../src/common/file.cpp:495
+#: ../src/common/file.cpp:522
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr "Не вдалося встановити досягнення кінця файла з дескриптором %d"
 
-#: ../src/common/zipstrm.cpp:1692
+#: ../src/common/zipstrm.cpp:1747
 msgid "can't find central directory in zip"
 msgstr "неможливо знайти центральну теку у zip"
 
-#: ../src/common/file.cpp:465
+#: ../src/common/file.cpp:492
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "Не вдалося встановити довжину файла з дескриптором %d"
 
-#: ../src/msw/utils.cpp:341
+#: ../src/msw/utils.cpp:336
 msgid "can't find user's HOME, using current directory."
 msgstr ""
 "Не вдалося встановити HOME користувача, буде використаний даний каталог."
 
-#: ../src/common/file.cpp:366
+#: ../src/common/file.cpp:407
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "Не вдалося злити файл з дескриптором %d"
 
-#: ../src/common/file.cpp:422
+#: ../src/common/file.cpp:463
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "неможливо отримати дану позицію файла з дескриптором %d"
 
-#: ../src/common/fontmap.cpp:325
+#: ../src/common/fontmap.cpp:322
 msgid "can't load any font, aborting"
 msgstr "неможливо завантажити жодного шрифту, зупинка"
 
-#: ../src/common/file.cpp:231 ../src/common/ffile.cpp:59
+#: ../src/common/ffile.cpp:57 ../src/common/file.cpp:228
 #, c-format
 msgid "can't open file '%s'"
 msgstr "Не вдалося відкрити файл «%s»"
 
-#: ../src/common/fileconf.cpp:320
+#: ../src/common/fileconf.cpp:314
 #, c-format
 msgid "can't open global configuration file '%s'."
 msgstr "Не вдалося відкрити загальний файл налаштувань «%s»."
 
-#: ../src/common/fileconf.cpp:336
+#: ../src/common/fileconf.cpp:330
 #, c-format
 msgid "can't open user configuration file '%s'."
 msgstr "Не вдалося відкрити файл налаштувань «%s»."
@@ -8265,40 +8449,40 @@ msgstr "Не вдалося відкрити файл налаштувань «%
 msgid "can't open user configuration file."
 msgstr "Не вдалося відкрити файл налаштувань."
 
-#: ../src/common/zipstrm.cpp:579
+#: ../src/common/zipstrm.cpp:572
 msgid "can't re-initialize zlib deflate stream"
 msgstr "неможливо переініціювати потік стискання zlib"
 
-#: ../src/common/zipstrm.cpp:604
+#: ../src/common/zipstrm.cpp:597
 msgid "can't re-initialize zlib inflate stream"
 msgstr "неможливо переініціювати потік розпакування zlib"
 
-#: ../src/common/file.cpp:304
+#: ../src/common/file.cpp:345
 #, c-format
 msgid "can't read from file descriptor %d"
 msgstr "помилка читання файла з дескриптором %d"
 
-#: ../src/common/file.cpp:581
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:608
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "помилка вилучення файла «%s»"
 
-#: ../src/common/file.cpp:598
+#: ../src/common/ffile.cpp:394 ../src/common/file.cpp:625
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "помилка вилучення тимчасового файла «%s»"
 
-#: ../src/common/file.cpp:408
+#: ../src/common/file.cpp:449
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "Не вдалося пересунутись у файлі з дескриптором %d"
 
-#: ../src/common/textfile.cpp:273
+#: ../src/common/textfile.cpp:161
 #, c-format
 msgid "can't write buffer '%s' to disk."
 msgstr "неможливо записати буфер «%s» на диск."
 
-#: ../src/common/file.cpp:323
+#: ../src/common/file.cpp:364
 #, c-format
 msgid "can't write to file descriptor %d"
 msgstr "Не вдалося записати в файл з дескриптором %d"
@@ -8308,22 +8492,28 @@ msgid "can't write user configuration file."
 msgstr "Не вдалося записати файл налаштувань."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:482 ../src/generic/datavgen.cpp:1261
+#: ../src/common/datavcmn.cpp:2064 ../src/generic/datavgen.cpp:1384
 msgid "checked"
 msgstr ""
 
-#: ../src/html/chm.cpp:345
+#: ../src/html/chm.cpp:342
 msgid "checksum error"
 msgstr "помилка у контрольній сумі"
 
-#: ../src/common/tarstrm.cpp:820
+#: ../src/common/tarstrm.cpp:814
 msgid "checksum failure reading tar header block"
 msgstr "помилка під час перевірки контрольної суми у заголовку tar"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:226
-#: ../src/richtext/richtextbackgroundpage.cpp:249
-#: ../src/richtext/richtextbackgroundpage.cpp:289
-#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
 #: ../src/richtext/richtextborderspage.cpp:254
 #: ../src/richtext/richtextborderspage.cpp:288
 #: ../src/richtext/richtextborderspage.cpp:322
@@ -8341,106 +8531,130 @@ msgstr "помилка під час перевірки контрольної �
 #: ../src/richtext/richtextmarginspage.cpp:340
 #: ../src/richtext/richtextmarginspage.cpp:363
 #: ../src/richtext/richtextmarginspage.cpp:388
-#: ../src/richtext/richtextsizepage.cpp:339
-#: ../src/richtext/richtextsizepage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:400
-#: ../src/richtext/richtextsizepage.cpp:427
-#: ../src/richtext/richtextsizepage.cpp:454
-#: ../src/richtext/richtextsizepage.cpp:481
-#: ../src/richtext/richtextsizepage.cpp:555
-#: ../src/richtext/richtextsizepage.cpp:590
-#: ../src/richtext/richtextsizepage.cpp:625
-#: ../src/richtext/richtextsizepage.cpp:660
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
 msgid "cm"
 msgstr "см"
 
-#: ../src/html/chm.cpp:347
+#: ../src/html/chm.cpp:344
 msgid "compression error"
 msgstr "помилка стиснення"
 
-#: ../src/common/regex.cpp:236
+#: ../src/common/regex.cpp:233
 msgid "conversion to 8-bit encoding failed"
 msgstr "перетворення у 8-бітове кодування зазнало невдачі"
 
-#: ../src/common/accelcmn.cpp:187
+#: ../src/common/accelcmn.cpp:186
 msgid "ctrl"
 msgstr "ctrl"
 
-#: ../src/common/cmdline.cpp:1500
+#: ../src/common/cmdline.cpp:1496
 msgid "date"
 msgstr "дата"
 
-#: ../src/html/chm.cpp:349
+#: ../src/html/chm.cpp:346
 msgid "decompression error"
 msgstr "помилка розпакування"
 
-#: ../src/richtext/richtextstyles.cpp:780 ../src/common/fmapbase.cpp:820
+#: ../src/common/fmapbase.cpp:816 ../src/richtext/richtextstyles.cpp:777
 msgid "default"
 msgstr "типовий"
 
-#: ../src/common/cmdline.cpp:1496
+#: ../src/common/cmdline.cpp:1492
 msgid "double"
 msgstr "double"
 
-#: ../src/common/debugrpt.cpp:538
+#: ../src/common/debugrpt.cpp:539
 msgid "dump of the process state (binary)"
 msgstr "дамп стану процесу (бінарний)"
 
-#: ../src/common/datetimefmt.cpp:1969
+#: ../src/common/datetimefmt.cpp:1992
 msgid "eighteenth"
 msgstr "вісімнадцятий"
 
-#: ../src/common/datetimefmt.cpp:1959
+#: ../src/common/datetimefmt.cpp:1982
 msgid "eighth"
 msgstr "восьмий"
 
-#: ../src/common/datetimefmt.cpp:1962
+#: ../src/common/datetimefmt.cpp:1985
 msgid "eleventh"
 msgstr "одинадцятий"
 
-#: ../src/common/fileconf.cpp:1833
+#: ../src/common/fileconf.cpp:1835
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "поле «%s» з'являється більше одного разу в групі «%s»"
 
-#: ../src/html/chm.cpp:343
+#: ../src/html/chm.cpp:340
 msgid "error in data format"
 msgstr "помилка в форматі даних"
 
-#: ../src/html/chm.cpp:331
+#: ../src/html/chm.cpp:328
 msgid "error opening file"
 msgstr "помилка під час відкриття файла"
 
-#: ../src/common/zipstrm.cpp:1778
+#: ../src/common/zipstrm.cpp:1836
 msgid "error reading zip central directory"
 msgstr "помилка під час читання центральної теки zip"
 
-#: ../src/common/zipstrm.cpp:1870
+#: ../src/common/zipstrm.cpp:1940
 msgid "error reading zip local header"
 msgstr "помилка читання локального заголовка zip"
 
-#: ../src/common/zipstrm.cpp:2531
+#: ../src/common/zipstrm.cpp:2615
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr ""
 "помилка запису елемента zip «%s»: помилкова контрольна сума або довжина"
 
-#: ../src/common/ffile.cpp:188
+#: ../src/common/zipstrm.cpp:2608
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr ""
+"помилка запису елемента zip «%s»: помилкова контрольна сума або довжина"
+
+#: ../src/common/fontcmn.cpp:1205
+#, fuzzy
+msgid "extrabold"
+msgstr "жирний"
+
+#: ../src/common/fontcmn.cpp:1223
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1167
+#, fuzzy
+msgid "extralight"
+msgstr "легкий"
+
+#: ../src/msw/webview_ie.cpp:1036
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "Не вдалося виконати «%s»\n"
+
+#: ../src/common/ffile.cpp:187
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "не вдалося скинути буфер файла «%s»."
 
+#: ../src/msw/webview_ie.cpp:1045
+#, fuzzy
+msgid "failed to retrieve execution result"
+msgstr "Не вдалося прочитати повідомлення про помилку RAS"
+
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1030
+#: ../src/generic/datavgen.cpp:1150
 #, fuzzy
 msgid "false"
 msgstr "Ні"
 
-#: ../src/common/datetimefmt.cpp:1966
+#: ../src/common/datetimefmt.cpp:1989
 msgid "fifteenth"
 msgstr "п'ятнадцятий"
 
-#: ../src/common/datetimefmt.cpp:1956
+#: ../src/common/datetimefmt.cpp:1979
 msgid "fifth"
 msgstr "п'ятий"
 
@@ -8469,131 +8683,150 @@ msgstr "файл «%s», рядок %d: значення незмінного к
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "файл «%s»: несподіваний символ %c у рядку %d."
 
-#: ../src/richtext/richtextbuffer.cpp:8738
+#: ../src/richtext/richtextbuffer.cpp:8736
 msgid "files"
 msgstr "файли"
 
-#: ../src/common/datetimefmt.cpp:1952
+#: ../src/common/datetimefmt.cpp:1975
 msgid "first"
 msgstr "перший"
 
-#: ../src/html/helpwnd.cpp:1252
+#: ../src/html/helpwnd.cpp:1250
 msgid "font size"
 msgstr "Розмір шрифту:"
 
-#: ../src/common/datetimefmt.cpp:1965
+#: ../src/common/datetimefmt.cpp:1988
 msgid "fourteenth"
 msgstr "чотирнадцятий"
 
-#: ../src/common/datetimefmt.cpp:1955
+#: ../src/common/datetimefmt.cpp:1978
 msgid "fourth"
 msgstr "четвертий"
 
-#: ../src/common/appbase.cpp:783
+#: ../src/common/appbase.cpp:784
 msgid "generate verbose log messages"
 msgstr "генерувати багатослівні повідомлення"
 
-#: ../src/richtext/richtextbuffer.cpp:13138
-#: ../src/richtext/richtextbuffer.cpp:13248
+#: ../src/common/fontcmn.cpp:1215
+msgid "heavy"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:13133
+#: ../src/richtext/richtextbuffer.cpp:13243
 msgid "image"
 msgstr "картинка"
 
-#: ../src/common/tarstrm.cpp:796
+#: ../src/common/tarstrm.cpp:790
 msgid "incomplete header block in tar"
 msgstr "блок заголовка у tar не повний"
 
-#: ../src/common/xtixml.cpp:489
+#: ../src/common/xtixml.cpp:485
 msgid "incorrect event handler string, missing dot"
 msgstr "помилковий рядок обробника події, відсутня точка"
 
-#: ../src/common/tarstrm.cpp:1381
+#: ../src/common/tarstrm.cpp:1375
 msgid "incorrect size given for tar entry"
 msgstr "некоректно задано розмір для елемента tar"
 
-#: ../src/common/tarstrm.cpp:993
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:987
 msgid "invalid data in extended tar header"
 msgstr "некоректні дані у розширеному заголовку tar"
 
-#: ../src/generic/logg.cpp:1030
+#: ../src/generic/logg.cpp:1027
 msgid "invalid message box return value"
 msgstr "з вікна повідомлення повернуто помилкове значення"
 
-#: ../src/common/zipstrm.cpp:1647
+#: ../src/common/zipstrm.cpp:1688
 msgid "invalid zip file"
 msgstr "некоректний файл zip"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:1228
 msgid "italic"
 msgstr "курсив"
 
-#: ../src/common/fontcmn.cpp:991
+#: ../src/common/webrequest_curl.cpp:374
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "Не вдалося ініціалізувати опис стовпчика."
+
+#: ../src/common/fontcmn.cpp:1172
 msgid "light"
 msgstr "легкий"
 
-#: ../src/common/intl.cpp:303
-#, c-format
-msgid "locale '%s' cannot be set."
-msgstr "локаль «%s» не може бути встановлена."
+#: ../src/common/fontcmn.cpp:1185
+msgid "medium"
+msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2125
+#: ../src/common/datetimefmt.cpp:2148
 msgid "midnight"
 msgstr "північ"
 
-#: ../src/common/datetimefmt.cpp:1970
+#: ../src/common/datetimefmt.cpp:1993
 msgid "nineteenth"
 msgstr "дев'ятнадцятий"
 
-#: ../src/common/datetimefmt.cpp:1960
+#: ../src/common/datetimefmt.cpp:1983
 msgid "ninth"
 msgstr "дев'ятий"
 
-#: ../src/msw/dde.cpp:1116
+#: ../src/msw/dde.cpp:1180
 msgid "no DDE error."
 msgstr "немає помилки"
 
-#: ../src/html/chm.cpp:327
+#: ../src/html/chm.cpp:324
 msgid "no error"
 msgstr "без помилок"
 
-#: ../src/dfb/fontmgr.cpp:174
+#: ../src/dfb/fontmgr.cpp:171
 #, c-format
 msgid "no fonts found in %s, using builtin font"
 msgstr "У %s записів шрифтів не знайдено, використовуємо вбудований шрифт"
 
-#: ../src/html/helpdata.cpp:657
+#: ../src/html/helpdata.cpp:650
 msgid "noname"
 msgstr "без назви"
 
-#: ../src/common/datetimefmt.cpp:2124
+#: ../src/common/datetimefmt.cpp:2147
 msgid "noon"
 msgstr "південь"
 
-#: ../src/richtext/richtextstyles.cpp:779
+#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "звичайний"
 
-#: ../src/common/cmdline.cpp:1492
+#: ../src/common/cmdline.cpp:1488
 msgid "num"
 msgstr "num"
 
-#: ../src/common/xtixml.cpp:259
+#: ../src/common/accelcmn.cpp:194
+msgid "num "
+msgstr ""
+
+#: ../src/common/xtixml.cpp:255
 msgid "objects cannot have XML Text Nodes"
 msgstr "об'єкти не повинні мати текстових вузлів XML"
 
-#: ../src/html/chm.cpp:339
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
 msgid "out of memory"
 msgstr "нестача пам'яті"
 
-#: ../src/common/debugrpt.cpp:514
+#: ../src/common/debugrpt.cpp:515
 msgid "process context description"
 msgstr "опис контексту процесу"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:227
-#: ../src/richtext/richtextbackgroundpage.cpp:250
-#: ../src/richtext/richtextbackgroundpage.cpp:290
-#: ../src/richtext/richtextbackgroundpage.cpp:317
-#: ../src/richtext/richtextfontpage.cpp:177
-#: ../src/richtext/richtextfontpage.cpp:180
 #: ../src/richtext/richtextborderspage.cpp:255
 #: ../src/richtext/richtextborderspage.cpp:289
 #: ../src/richtext/richtextborderspage.cpp:323
@@ -8603,22 +8836,45 @@ msgstr "опис контексту процесу"
 #: ../src/richtext/richtextborderspage.cpp:491
 #: ../src/richtext/richtextborderspage.cpp:525
 #: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextfontpage.cpp:180
 msgid "pt"
 msgstr "пт"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:225
-#: ../src/richtext/richtextbackgroundpage.cpp:228
-#: ../src/richtext/richtextbackgroundpage.cpp:229
-#: ../src/richtext/richtextbackgroundpage.cpp:248
-#: ../src/richtext/richtextbackgroundpage.cpp:251
-#: ../src/richtext/richtextbackgroundpage.cpp:252
-#: ../src/richtext/richtextbackgroundpage.cpp:288
-#: ../src/richtext/richtextbackgroundpage.cpp:291
-#: ../src/richtext/richtextbackgroundpage.cpp:292
-#: ../src/richtext/richtextbackgroundpage.cpp:315
-#: ../src/richtext/richtextbackgroundpage.cpp:318
-#: ../src/richtext/richtextbackgroundpage.cpp:319
-#: ../src/richtext/richtextfontpage.cpp:178
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:659
+#: ../src/richtext/richtextsizepage.cpp:662
+#: ../src/richtext/richtextsizepage.cpp:663
 #: ../src/richtext/richtextborderspage.cpp:253
 #: ../src/richtext/richtextborderspage.cpp:256
 #: ../src/richtext/richtextborderspage.cpp:257
@@ -8670,260 +8926,270 @@ msgstr "пт"
 #: ../src/richtext/richtextmarginspage.cpp:387
 #: ../src/richtext/richtextmarginspage.cpp:389
 #: ../src/richtext/richtextmarginspage.cpp:390
-#: ../src/richtext/richtextsizepage.cpp:338
-#: ../src/richtext/richtextsizepage.cpp:341
-#: ../src/richtext/richtextsizepage.cpp:342
-#: ../src/richtext/richtextsizepage.cpp:372
-#: ../src/richtext/richtextsizepage.cpp:375
-#: ../src/richtext/richtextsizepage.cpp:376
-#: ../src/richtext/richtextsizepage.cpp:399
-#: ../src/richtext/richtextsizepage.cpp:402
-#: ../src/richtext/richtextsizepage.cpp:403
-#: ../src/richtext/richtextsizepage.cpp:426
-#: ../src/richtext/richtextsizepage.cpp:429
-#: ../src/richtext/richtextsizepage.cpp:430
-#: ../src/richtext/richtextsizepage.cpp:453
-#: ../src/richtext/richtextsizepage.cpp:456
-#: ../src/richtext/richtextsizepage.cpp:457
-#: ../src/richtext/richtextsizepage.cpp:480
-#: ../src/richtext/richtextsizepage.cpp:483
-#: ../src/richtext/richtextsizepage.cpp:484
-#: ../src/richtext/richtextsizepage.cpp:554
-#: ../src/richtext/richtextsizepage.cpp:557
-#: ../src/richtext/richtextsizepage.cpp:558
-#: ../src/richtext/richtextsizepage.cpp:589
-#: ../src/richtext/richtextsizepage.cpp:592
-#: ../src/richtext/richtextsizepage.cpp:593
-#: ../src/richtext/richtextsizepage.cpp:624
-#: ../src/richtext/richtextsizepage.cpp:627
-#: ../src/richtext/richtextsizepage.cpp:628
-#: ../src/richtext/richtextsizepage.cpp:659
-#: ../src/richtext/richtextsizepage.cpp:662
-#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextfontpage.cpp:178
 msgid "px"
 msgstr "пк"
 
-#: ../src/common/accelcmn.cpp:193
+#: ../src/common/accelcmn.cpp:192
 msgid "rawctrl"
 msgstr "rawctrl"
 
-#: ../src/html/chm.cpp:333
+#: ../src/html/chm.cpp:330
 msgid "read error"
 msgstr "помилка читання"
 
-#: ../src/common/zipstrm.cpp:2085
+#: ../src/common/zipstrm.cpp:2155
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "читання потоку zip (елемент %s): помилкова контрольна сума"
 
-#: ../src/common/zipstrm.cpp:2080
+#: ../src/common/zipstrm.cpp:2150
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "читання потоку zip (елемент %s): помилкова довжина"
 
-#: ../src/msw/dde.cpp:1159
+#: ../src/msw/dde.cpp:1223
 msgid "reentrancy problem."
 msgstr "проблема з повторним входом."
 
-#: ../src/common/datetimefmt.cpp:1953
+#: ../src/common/datetimefmt.cpp:1976
 msgid "second"
 msgstr "другий"
 
-#: ../src/html/chm.cpp:337
+#: ../src/html/chm.cpp:334
 msgid "seek error"
 msgstr "помилка пошуку"
 
-#: ../src/common/datetimefmt.cpp:1968
+#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#, fuzzy
+msgid "semibold"
+msgstr "жирний"
+
+#: ../src/common/datetimefmt.cpp:1991
 msgid "seventeenth"
 msgstr "сімнадцятий"
 
-#: ../src/common/datetimefmt.cpp:1958
+#: ../src/common/datetimefmt.cpp:1981
 msgid "seventh"
 msgstr "сьомий"
 
-#: ../src/common/accelcmn.cpp:191
+#: ../src/common/accelcmn.cpp:190
 msgid "shift"
 msgstr "shift"
 
-#: ../src/common/appbase.cpp:773
+#: ../src/common/appbase.cpp:774
 msgid "show this help message"
 msgstr "показати цю підказку"
 
-#: ../src/common/datetimefmt.cpp:1967
+#: ../src/common/datetimefmt.cpp:1990
 msgid "sixteenth"
 msgstr "шістнадцятий"
 
-#: ../src/common/datetimefmt.cpp:1957
+#: ../src/common/datetimefmt.cpp:1980
 msgid "sixth"
 msgstr "шостий"
 
-#: ../src/common/appcmn.cpp:234
+#: ../src/common/appcmn.cpp:255
 msgid "specify display mode to use (e.g. 640x480-16)"
 msgstr "задайте режим дисплею (напр. 640x480-16)"
 
-#: ../src/common/appcmn.cpp:220
+#: ../src/common/appcmn.cpp:241
 msgid "specify the theme to use"
 msgstr "задайте мотив"
 
-#: ../src/richtext/richtextbuffer.cpp:9340
+#: ../src/richtext/richtextbuffer.cpp:9337
 msgid "standard/circle"
 msgstr "стандартний/коло"
 
-#: ../src/richtext/richtextbuffer.cpp:9341
+#: ../src/richtext/richtextbuffer.cpp:9338
 msgid "standard/circle-outline"
 msgstr "стандартний/круговий контур"
 
-#: ../src/richtext/richtextbuffer.cpp:9343
+#: ../src/richtext/richtextbuffer.cpp:9340
 msgid "standard/diamond"
 msgstr "стандартний/ромб"
 
-#: ../src/richtext/richtextbuffer.cpp:9342
+#: ../src/richtext/richtextbuffer.cpp:9339
 msgid "standard/square"
 msgstr "стандартний/квадрат"
 
-#: ../src/richtext/richtextbuffer.cpp:9344
+#: ../src/richtext/richtextbuffer.cpp:9341
 msgid "standard/triangle"
 msgstr "стандартний/трикутник"
 
-#: ../src/common/zipstrm.cpp:1985
+#: ../src/common/zipstrm.cpp:2055
 msgid "stored file length not in Zip header"
 msgstr "довжина запакованого файл не у заголовку Zip"
 
-#: ../src/common/cmdline.cpp:1488
+#: ../src/common/cmdline.cpp:1484
 msgid "str"
 msgstr "str"
 
-#: ../src/common/fontcmn.cpp:982
+#: ../src/common/fontcmn.cpp:1145
 msgid "strikethrough"
 msgstr "перекреслення"
 
-#: ../src/common/tarstrm.cpp:1003 ../src/common/tarstrm.cpp:1025
-#: ../src/common/tarstrm.cpp:1507 ../src/common/tarstrm.cpp:1529
+#: ../src/common/tarstrm.cpp:997 ../src/common/tarstrm.cpp:1019
+#: ../src/common/tarstrm.cpp:1501 ../src/common/tarstrm.cpp:1523
 msgid "tar entry not open"
 msgstr "елемент tar не відкрито"
 
-#: ../src/common/datetimefmt.cpp:1961
+#: ../src/common/datetimefmt.cpp:1984
 msgid "tenth"
 msgstr "десятий"
 
-#: ../src/msw/dde.cpp:1123
+#: ../src/msw/dde.cpp:1187
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "відповідь на дію викликала встановлення біта DDE_FBUSY."
 
-#: ../src/common/datetimefmt.cpp:1954
+#: ../src/common/fontcmn.cpp:1154
+msgid "thin"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:1977
 msgid "third"
 msgstr "третій"
 
-#: ../src/common/datetimefmt.cpp:1964
+#: ../src/common/datetimefmt.cpp:1987
 msgid "thirteenth"
 msgstr "тринадцятий"
 
-#: ../src/common/datetimefmt.cpp:1758
+#: ../src/common/datetimefmt.cpp:1781
 msgid "today"
 msgstr "сьогодні"
 
-#: ../src/common/datetimefmt.cpp:1760
+#: ../src/common/datetimefmt.cpp:1783
 msgid "tomorrow"
 msgstr "завтра"
 
-#: ../src/common/fileconf.cpp:1944
+#: ../src/common/fileconf.cpp:1946
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "у «%s» проігноровано кінцеву похилу риску"
 
-#: ../src/gtk/aboutdlg.cpp:218
+#: ../src/gtk/aboutdlg.cpp:216
 msgid "translator-credits"
 msgstr "подяки перекладачам"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1028
+#: ../src/generic/datavgen.cpp:1148
 msgid "true"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1963
+#: ../src/common/datetimefmt.cpp:1986
 msgid "twelfth"
 msgstr "дванадцятий"
 
-#: ../src/common/datetimefmt.cpp:1971
+#: ../src/common/datetimefmt.cpp:1994
 msgid "twentieth"
 msgstr "двадцятий"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:486 ../src/generic/datavgen.cpp:1263
+#: ../src/common/datavcmn.cpp:2068 ../src/generic/datavgen.cpp:1386
 msgid "unchecked"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:802 ../src/common/fontcmn.cpp:978
+#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
 msgid "underlined"
 msgstr "підкреслене"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:490
+#: ../src/common/datavcmn.cpp:2072
 #, fuzzy
 msgid "undetermined"
 msgstr "підкреслене"
 
-#: ../src/common/fileconf.cpp:1979
+#: ../src/common/fileconf.cpp:1981
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "несподіваний \" в позиції %d в «%s»."
 
-#: ../src/common/tarstrm.cpp:1045
+#: ../src/common/tarstrm.cpp:1039
 msgid "unexpected end of file"
 msgstr "несподіваний кінець файла"
 
-#: ../src/generic/progdlgg.cpp:370 ../src/common/tarstrm.cpp:371
-#: ../src/common/tarstrm.cpp:394 ../src/common/tarstrm.cpp:425
+#: ../src/common/tarstrm.cpp:366 ../src/common/tarstrm.cpp:389
+#: ../src/common/tarstrm.cpp:420 ../src/generic/progdlgg.cpp:376
 msgid "unknown"
 msgstr "невідомий"
 
-#: ../src/msw/registry.cpp:150
+#: ../src/msw/registry.cpp:139
 #, fuzzy, c-format
 msgid "unknown (%lu)"
 msgstr "невідомий"
 
-#: ../src/common/xtixml.cpp:253
+#: ../src/common/xtixml.cpp:249
 #, c-format
 msgid "unknown class %s"
 msgstr "невідомий клас %s"
 
-#: ../src/common/regex.cpp:258 ../src/html/chm.cpp:351
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "помилка стиснення"
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "помилка розпакування"
+
+#: ../src/common/regex.cpp:255 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "Невідома помилка"
 
-#: ../src/msw/dialup.cpp:471
+#: ../src/msw/dialup.cpp:465
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "Невідома помилка (код помилки %08x)"
 
-#: ../src/common/fmapbase.cpp:834
+#: ../src/common/fmapbase.cpp:830
 #, c-format
 msgid "unknown-%d"
 msgstr "невідомий-%d"
 
-#: ../src/common/docview.cpp:509
+#: ../src/common/docview.cpp:502
 msgid "unnamed"
 msgstr "безіменний"
 
-#: ../src/common/docview.cpp:1624
+#: ../src/common/docview.cpp:1618
 #, c-format
 msgid "unnamed%d"
 msgstr "безіменний%d"
 
-#: ../src/common/zipstrm.cpp:1999 ../src/common/zipstrm.cpp:2319
+#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
 msgid "unsupported Zip compression method"
 msgstr "непідтримуваний метод стиснення Zip"
 
-#: ../src/common/translation.cpp:1892
+#: ../src/common/translation.cpp:1942
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "використовується каталог «%s» з «%s»."
 
-#: ../src/html/chm.cpp:335
+#: ../src/html/chm.cpp:332
 msgid "write error"
 msgstr "помилка запису"
 
-#: ../src/common/time.cpp:292
+#: ../src/gtk/glcanvas.cpp:187
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/common/time.cpp:285
 msgid "wxGetTimeOfDay failed."
 msgstr "помилка wxGetTimeOfDay."
 
@@ -8936,15 +9202,15 @@ msgstr "wxWidgets не зміг відкрити дисплей для «%s»: �
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets не вдалося відкрити дисплей. Завершення роботи."
 
-#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:431
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/common/datetimefmt.cpp:1759
+#: ../src/common/datetimefmt.cpp:1782
 msgid "yesterday"
 msgstr "вчора"
 
-#: ../src/common/zstream.cpp:251 ../src/common/zstream.cpp:426
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
 #, c-format
 msgid "zlib error %d"
 msgstr "помилка zlib %d"
@@ -8953,6 +9219,78 @@ msgstr "помилка zlib %d"
 #: ../src/richtext/richtextbulletspage.cpp:288
 msgid "~"
 msgstr "~"
+
+#~ msgid "&Save as"
+#~ msgstr "З&берегти як"
+
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "«%s» містить некоректні символи"
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "«%s» повинно бути числом."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "«%s» має містити тільки символи ASCII."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "«%s» має містити тільки символи алфавіту."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "«%s» має містити тільки символи алфавіту або цифри."
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "«%s» має містити лише цифри."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "Не вдалося створити вікно класу %s"
+
+#, fuzzy
+#~ msgid "Could not initalize libnotify."
+#~ msgstr "Не вдалося встановити вирівнювання."
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "Не вдалося створити вікно оверлею"
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "Не вдалося ініціювати контекст вікна оверлею"
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "Не вдалося перетворити вміст файла «%s» на Unicode."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "Не вдалося встановити текст у контрол тексту."
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr ""
+#~ "Некоректний параметр командного рядка GTK+, скористайтеся командою «%s --"
+#~ "help»"
+
+#~ msgid "No unused colour in image."
+#~ msgstr "У зображенні немає невикористаного кольору."
+
+#~ msgid "Not available"
+#~ msgstr "Недоступний"
+
+#~ msgid "Replace selection"
+#~ msgstr "Замінити позначене"
+
+#~ msgid "Save as"
+#~ msgstr "Зберегти як"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Записник стилів"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "Крім того, підтримуються такі стандартні параметри GTK+:\n"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "Ви не можете спорожнити оверлей, який не ініційовано"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "Ви не можете двічі викликати Init для оверлеїв"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "локаль «%s» не може бути встановлена."
 
 #~ msgid "Adding flavor TEXT failed"
 #~ msgstr "Спроба додавання варіанта TEXT зазнала невдачі"
@@ -8972,9 +9310,6 @@ msgstr "~"
 
 #~ msgid "Column could not be added."
 #~ msgstr "Не вдалося додати стовпчик."
-
-#~ msgid "Column description could not be initialized."
-#~ msgstr "Не вдалося ініціалізувати опис стовпчика."
 
 #~ msgid "Column index not found."
 #~ msgstr "Не знайдено стовпчика з відповідним номером."
@@ -9576,9 +9911,6 @@ msgstr "~"
 #~ msgid "Directory '%s' doesn't exist!"
 #~ msgstr "Каталог «%s» не існує!"
 
-#~ msgid "File %s does not exist."
-#~ msgstr "Файл %s не присутній."
-
 #~ msgid "Mode %ix%i-%i not available."
 #~ msgstr "Режим %ix%i-%i не працює."
 
@@ -9692,9 +10024,6 @@ msgstr "~"
 
 #~ msgid "Failed to register OpenGL window class."
 #~ msgstr "Не вдалося зареєструвати клас вікон OpenGL."
-
-#~ msgid "Fatal error"
-#~ msgstr "Критична помилка"
 
 #~ msgid "Fatal error: "
 #~ msgstr "Критична помилка: "

--- a/locale/vi.po
+++ b/locale/vi.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-21 14:25+0200\n"
+"POT-Creation-Date: 2020-10-18 23:11+0300\n"
 "PO-Revision-Date: 2014-03-30 09:14+0700\n"
 "Last-Translator: Trần Ngọc Quân <vnwildman@gmail.com>\n"
 "Language-Team: Vietnamese <translation-team-vi@lists.sourceforge.net>\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 1.5.5\n"
 
-#: ../src/common/debugrpt.cpp:586
+#: ../src/common/debugrpt.cpp:587
 msgid ""
 "\n"
 "Please send this report to the program maintainer, thank you!\n"
@@ -26,8 +26,8 @@ msgstr ""
 "\n"
 "Xin hãy gửi bản báo cáo này tới người bảo trì chương trình, xin cảm ơn!\n"
 
-#: ../src/richtext/richtextstyledlg.cpp:210
-#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:206
+#: ../src/richtext/richtextstyledlg.cpp:218
 msgid " "
 msgstr " "
 
@@ -36,70 +36,96 @@ msgid "              Thank you and we're sorry for the inconvenience!\n"
 msgstr ""
 "              Xin cảm ơn và chúng tôi lấy làm tiếc về sự bất tiện này!\n"
 
-#: ../src/common/prntbase.cpp:573
+#: ../src/common/prntbase.cpp:568
 #, c-format
 msgid " (copy %d of %d)"
 msgstr " (chép %d trong số %d)"
 
-#: ../src/common/log.cpp:421
+#: ../src/common/log.cpp:440
 #, c-format
 msgid " (error %ld: %s)"
 msgstr " (lỗi %ld: %s)"
 
-#: ../src/common/imagtiff.cpp:72
+#: ../src/common/imagtiff.cpp:69
 #, c-format
 msgid " (in module \"%s\")"
 msgstr " (trong mô-đun \"%s\")"
 
-#: ../src/osx/core/secretstore.cpp:138
-msgid " (while overwriting an existing item)"
-msgstr ""
-
-#: ../src/common/docview.cpp:1642
+#: ../src/common/docview.cpp:1636
 msgid " - "
 msgstr " - "
 
-#: ../src/richtext/richtextprint.cpp:593 ../src/html/htmprint.cpp:714
+#: ../src/html/htmprint.cpp:712 ../src/richtext/richtextprint.cpp:589
 msgid " Preview"
 msgstr " Xem trước"
 
-#: ../src/common/fontcmn.cpp:824
+#: ../src/common/fontcmn.cpp:973
 msgid " bold"
 msgstr " đậm"
 
-#: ../src/common/fontcmn.cpp:840
+#: ../src/common/fontcmn.cpp:977
+#, fuzzy
+msgid " extra bold"
+msgstr " đậm"
+
+#: ../src/common/fontcmn.cpp:985
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:957
+#, fuzzy
+msgid " extra light"
+msgstr " sáng"
+
+#: ../src/common/fontcmn.cpp:981
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1001
 msgid " italic"
 msgstr " nghiêng"
 
-#: ../src/common/fontcmn.cpp:820
+#: ../src/common/fontcmn.cpp:961
 msgid " light"
 msgstr " sáng"
 
-#: ../src/common/fontcmn.cpp:807
+#: ../src/common/fontcmn.cpp:965
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:969
+#, fuzzy
+msgid " semi bold"
+msgstr " đậm"
+
+#: ../src/common/fontcmn.cpp:940
 msgid " strikethrough"
 msgstr " gạch giữa"
 
-#: ../src/common/paper.cpp:117
+#: ../src/common/fontcmn.cpp:953
+msgid " thin"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
 msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
 msgstr "#10 Envelope, 4 1/8 x 9 1/2 in"
 
-#: ../src/common/paper.cpp:118
+#: ../src/common/paper.cpp:115
 msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
 msgstr "#11 Envelope, 4 1/2 x 10 3/8 in"
 
-#: ../src/common/paper.cpp:119
+#: ../src/common/paper.cpp:116
 msgid "#12 Envelope, 4 3/4 x 11 in"
 msgstr "#12 Envelope, 4 3/4 x 11 in"
 
-#: ../src/common/paper.cpp:120
+#: ../src/common/paper.cpp:117
 msgid "#14 Envelope, 5 x 11 1/2 in"
 msgstr "#14 Envelope, 5 x 11 1/2 in"
 
-#: ../src/common/paper.cpp:116
+#: ../src/common/paper.cpp:113
 msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
 msgstr "#9 Envelope, 3 7/8 x 8 7/8 in"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:341
 #: ../src/richtext/richtextsizepage.cpp:340
 #: ../src/richtext/richtextsizepage.cpp:374
 #: ../src/richtext/richtextsizepage.cpp:401
@@ -110,80 +136,81 @@ msgstr "#9 Envelope, 3 7/8 x 8 7/8 in"
 #: ../src/richtext/richtextsizepage.cpp:591
 #: ../src/richtext/richtextsizepage.cpp:626
 #: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextbackgroundpage.cpp:341
 msgid "%"
 msgstr "%"
 
-#: ../src/html/helpwnd.cpp:1031
+#: ../src/html/helpwnd.cpp:1029
 #, c-format
 msgid "%d of %lu"
 msgstr "%d của %lu"
 
-#: ../src/html/helpwnd.cpp:1678
+#: ../src/html/helpwnd.cpp:1676
 #, fuzzy, c-format
 msgid "%i of %u"
 msgstr "%i của %i"
 
-#: ../src/generic/filectrlg.cpp:279
+#: ../src/generic/filectrlg.cpp:275
 #, c-format
 msgid "%ld byte"
 msgid_plural "%ld bytes"
 msgstr[0] "%ld byte"
 
-#: ../src/html/helpwnd.cpp:1033
+#: ../src/html/helpwnd.cpp:1031
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu của %lu"
 
-#: ../src/generic/datavgen.cpp:6028
+#: ../src/generic/datavgen.cpp:6833
 #, fuzzy, c-format
 msgid "%s (%d items)"
 msgstr "%s (hoặc %s)"
 
-#: ../src/common/cmdline.cpp:1221
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (hoặc %s)"
 
-#: ../src/generic/logg.cpp:224
+#: ../src/generic/logg.cpp:221
 #, c-format
 msgid "%s Error"
 msgstr "%s Lỗi"
 
-#: ../src/generic/logg.cpp:236
+#: ../src/generic/logg.cpp:233
 #, c-format
 msgid "%s Information"
 msgstr "%s Thông tin"
 
-#: ../src/generic/preferencesg.cpp:113
+#: ../src/generic/preferencesg.cpp:110
 #, c-format
 msgid "%s Preferences"
 msgstr "Cá nhân hóa %s"
 
-#: ../src/generic/logg.cpp:228
+#: ../src/generic/logg.cpp:225
 #, c-format
 msgid "%s Warning"
 msgstr "%s Cảnh báo"
 
-#: ../src/common/tarstrm.cpp:1319
+#: ../src/common/tarstrm.cpp:1313
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s không vừa khớp với phần đầu tar cho mục vào '%s'"
 
-#: ../src/common/fldlgcmn.cpp:124
+#: ../src/common/fldlgcmn.cpp:121
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s tập tin (%s)|%s"
 
-#: ../src/html/helpwnd.cpp:1716
+#: ../src/html/helpwnd.cpp:1714
 #, fuzzy, c-format
 msgid "%u of %u"
 msgstr "%lu của %lu"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "&About"
 msgstr "&Giới thiệu"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "&Actual Size"
 msgstr "&Kích thước Thật"
 
@@ -191,28 +218,28 @@ msgstr "&Kích thước Thật"
 msgid "&After a paragraph:"
 msgstr "S&au một đoạn văn:"
 
-#: ../src/richtext/richtextindentspage.cpp:128
 #: ../src/richtext/richtextliststylepage.cpp:319
+#: ../src/richtext/richtextindentspage.cpp:128
 msgid "&Alignment"
 msgstr "C&anh hàng"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "&Apply"
 msgstr "Chấ&p nhận"
 
-#: ../src/richtext/richtextstyledlg.cpp:251
+#: ../src/richtext/richtextstyledlg.cpp:247
 msgid "&Apply Style"
 msgstr "Á&p dụng Kiểu Dáng"
 
-#: ../src/msw/mdi.cpp:179
+#: ../src/msw/mdi.cpp:174
 msgid "&Arrange Icons"
 msgstr "Xắp xế&p Biểu Tượng"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "&Ascending"
 msgstr "&Tăng dần"
 
-#: ../src/common/stockitem.cpp:142
+#: ../src/common/stockitem.cpp:139
 msgid "&Back"
 msgstr "&Quay lại"
 
@@ -232,24 +259,24 @@ msgstr "Màu &nền:"
 msgid "&Blur distance:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:143
+#: ../src/common/stockitem.cpp:140
 msgid "&Bold"
 msgstr "Đậ&m"
 
-#: ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141
 msgid "&Bottom"
 msgstr "&Dưới"
 
+#: ../src/richtext/richtextsizepage.cpp:637
+#: ../src/richtext/richtextsizepage.cpp:644
 #: ../src/richtext/richtextborderspage.cpp:345
 #: ../src/richtext/richtextborderspage.cpp:513
 #: ../src/richtext/richtextmarginspage.cpp:259
 #: ../src/richtext/richtextmarginspage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:637
-#: ../src/richtext/richtextsizepage.cpp:644
 msgid "&Bottom:"
 msgstr "&Dưới đáy:"
 
-#: ../include/wx/richtext/richtextbuffer.h:3866
+#: ../include/wx/richtext/richtextbuffer.h:3861
 msgid "&Box"
 msgstr "Hộ&p:"
 
@@ -258,38 +285,38 @@ msgstr "Hộ&p:"
 msgid "&Bullet style:"
 msgstr "Kiểu dáng &Bullet:"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "&CD-Rom"
 msgstr "&CD-Rom"
 
-#: ../src/generic/wizard.cpp:434 ../src/generic/fontdlgg.cpp:470
-#: ../src/generic/fontdlgg.cpp:489 ../src/osx/carbon/fontdlg.cpp:402
-#: ../src/common/dlgcmn.cpp:279 ../src/common/stockitem.cpp:145
+#: ../src/osx/carbon/fontdlg.cpp:399 ../src/common/stockitem.cpp:142
+#: ../src/generic/wizard.cpp:433 ../src/generic/fontdlgg.cpp:466
+#: ../src/generic/fontdlgg.cpp:485 ../src/osx/cocoa/button.mm:200
 msgid "&Cancel"
 msgstr "&Hủy bỏ"
 
-#: ../src/msw/mdi.cpp:175
+#: ../src/msw/mdi.cpp:170
 msgid "&Cascade"
 msgstr "&Kiểu xếp chồng"
 
-#: ../include/wx/richtext/richtextbuffer.h:5960
+#: ../include/wx/richtext/richtextbuffer.h:5955
 msgid "&Cell"
 msgstr "Ô"
 
-#: ../src/richtext/richtextsymboldlg.cpp:439
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "&Character code:"
 msgstr "&Mã ký tự:"
 
-#: ../src/common/stockitem.cpp:147
+#: ../src/common/stockitem.cpp:144
 msgid "&Clear"
 msgstr "&Xóa"
 
-#: ../src/generic/logg.cpp:516 ../src/common/stockitem.cpp:148
-#: ../src/common/prntbase.cpp:1600 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/stockitem.cpp:145 ../src/common/prntbase.cpp:1625
+#: ../src/univ/themes/win32.cpp:3753 ../src/generic/logg.cpp:513
 msgid "&Close"
 msgstr "Đó&ng"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "&Color"
 msgstr "&Màu"
 
@@ -297,20 +324,20 @@ msgstr "&Màu"
 msgid "&Colour:"
 msgstr "&Màu sắc:"
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "&Convert"
 msgstr "&Chuyển đổi"
 
-#: ../src/richtext/richtextctrl.cpp:333 ../src/osx/textctrl_osx.cpp:577
-#: ../src/common/stockitem.cpp:150 ../src/msw/textctrl.cpp:2508
+#: ../src/osx/textctrl_osx.cpp:595 ../src/common/stockitem.cpp:147
+#: ../src/msw/textctrl.cpp:2773 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Sao chép"
 
-#: ../src/generic/hyperlinkg.cpp:156
+#: ../src/generic/hyperlinkg.cpp:153
 msgid "&Copy URL"
 msgstr "&Sao chép URL"
 
-#: ../src/common/headerctrlcmn.cpp:306
+#: ../src/common/headerctrlcmn.cpp:304
 msgid "&Customize..."
 msgstr "&Cá nhân..."
 
@@ -318,53 +345,54 @@ msgstr "&Cá nhân..."
 msgid "&Debug report preview:"
 msgstr "Xem thử &báo cáo lỗi:"
 
-#: ../src/richtext/richtexttabspage.cpp:138
-#: ../src/richtext/richtextctrl.cpp:335 ../src/osx/textctrl_osx.cpp:579
-#: ../src/common/stockitem.cpp:152 ../src/msw/textctrl.cpp:2510
+#: ../src/osx/textctrl_osx.cpp:597 ../src/common/stockitem.cpp:149
+#: ../src/msw/textctrl.cpp:2775 ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtextctrl.cpp:334
 msgid "&Delete"
 msgstr "&Xóa"
 
-#: ../src/richtext/richtextstyledlg.cpp:269
+#: ../src/richtext/richtextstyledlg.cpp:265
 msgid "&Delete Style..."
 msgstr "&Xóa Kiểu Dáng..."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "&Descending"
 msgstr "&Giảm dần"
 
-#: ../src/generic/logg.cpp:682
+#: ../src/generic/logg.cpp:679
 msgid "&Details"
 msgstr "&Chi tiết"
 
-#: ../src/common/stockitem.cpp:153
+#: ../src/common/stockitem.cpp:150
 msgid "&Down"
 msgstr "X&uống"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "&Edit"
 msgstr "&Hiệu chỉnh"
 
-#: ../src/richtext/richtextstyledlg.cpp:263
+#: ../src/richtext/richtextstyledlg.cpp:259
 msgid "&Edit Style..."
 msgstr "&Hiệu Chỉnh Kiểu Dáng..."
 
-#: ../src/common/stockitem.cpp:155
+#: ../src/common/stockitem.cpp:152
 msgid "&Execute"
 msgstr "&Thi hành"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/common/stockitem.cpp:154
 msgid "&File"
 msgstr "&Chính"
 
-#: ../src/common/stockitem.cpp:158
-msgid "&Find"
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "&Find..."
 msgstr "&Tìm"
 
-#: ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:430
 msgid "&Finish"
 msgstr "&Hoàn tất"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:156
 msgid "&First"
 msgstr "Đầ&u tiên"
 
@@ -372,15 +400,15 @@ msgstr "Đầ&u tiên"
 msgid "&Floating mode:"
 msgstr "&Chế độ trôi nổi:"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "&Floppy"
 msgstr "Đĩa &mềm"
 
-#: ../src/common/stockitem.cpp:194
+#: ../src/common/stockitem.cpp:191
 msgid "&Font"
 msgstr "&Phông chữ"
 
-#: ../src/generic/fontdlgg.cpp:371
+#: ../src/generic/fontdlgg.cpp:367
 msgid "&Font family:"
 msgstr "Họ &phông chữ:"
 
@@ -388,20 +416,20 @@ msgstr "Họ &phông chữ:"
 msgid "&Font for Level..."
 msgstr "&Phông chữ cho Mức..."
 
+#: ../src/richtext/richtextsymboldlg.cpp:397
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:400
 msgid "&Font:"
 msgstr "&Phông chữ:"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "&Forward"
 msgstr "&Tiếp tới"
 
-#: ../src/richtext/richtextsymboldlg.cpp:451
+#: ../src/richtext/richtextsymboldlg.cpp:448
 msgid "&From:"
 msgstr "&Từ:"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "&Harddisk"
 msgstr "Đĩa &cứng"
 
@@ -410,9 +438,9 @@ msgstr "Đĩa &cứng"
 msgid "&Height:"
 msgstr "&Cao:"
 
-#: ../src/generic/wizard.cpp:441 ../src/richtext/richtextstyledlg.cpp:303
-#: ../src/richtext/richtextsymboldlg.cpp:479 ../src/osx/menu_osx.cpp:734
-#: ../src/common/stockitem.cpp:163
+#: ../src/common/stockitem.cpp:160 ../src/generic/wizard.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextstyledlg.cpp:299 ../src/osx/cocoa/menu.mm:226
 msgid "&Help"
 msgstr "Trợ &giúp"
 
@@ -420,7 +448,7 @@ msgstr "Trợ &giúp"
 msgid "&Hide details"
 msgstr "Ẩ&n Chi tiết"
 
-#: ../src/common/stockitem.cpp:164
+#: ../src/common/stockitem.cpp:161
 msgid "&Home"
 msgstr "&Home"
 
@@ -429,54 +457,54 @@ msgstr "&Home"
 msgid "&Horizontal offset:"
 msgstr "&Vị trí tương đối theo chiều dọc:"
 
-#: ../src/richtext/richtextindentspage.cpp:184
 #: ../src/richtext/richtextliststylepage.cpp:372
+#: ../src/richtext/richtextindentspage.cpp:184
 msgid "&Indentation (tenths of a mm)"
 msgstr "Thụt lề dòng đầu(mỗ&i mười mm)"
 
-#: ../src/richtext/richtextindentspage.cpp:167
 #: ../src/richtext/richtextliststylepage.cpp:356
+#: ../src/richtext/richtextindentspage.cpp:167
 msgid "&Indeterminate"
 msgstr "&Vô định"
 
-#: ../src/common/stockitem.cpp:166
+#: ../src/common/stockitem.cpp:163
 msgid "&Index"
 msgstr "&Chỉ mục"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "&Info"
 msgstr "&Thông tin"
 
-#: ../src/common/stockitem.cpp:168
+#: ../src/common/stockitem.cpp:165
 msgid "&Italic"
 msgstr "Ngh&iêng"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "&Jump to"
 msgstr "&Nhảy tới"
 
-#: ../src/richtext/richtextindentspage.cpp:153
 #: ../src/richtext/richtextliststylepage.cpp:342
+#: ../src/richtext/richtextindentspage.cpp:153
 msgid "&Justified"
 msgstr "Căn chỉn&h"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "&Last"
 msgstr "&Cuối"
 
-#: ../src/richtext/richtextindentspage.cpp:139
 #: ../src/richtext/richtextliststylepage.cpp:328
+#: ../src/richtext/richtextindentspage.cpp:139
 msgid "&Left"
 msgstr "&Bên trái"
 
-#: ../src/richtext/richtextindentspage.cpp:195
+#: ../src/richtext/richtextsizepage.cpp:532
+#: ../src/richtext/richtextsizepage.cpp:539
 #: ../src/richtext/richtextborderspage.cpp:243
 #: ../src/richtext/richtextborderspage.cpp:411
 #: ../src/richtext/richtextliststylepage.cpp:381
+#: ../src/richtext/richtextindentspage.cpp:195
 #: ../src/richtext/richtextmarginspage.cpp:186
 #: ../src/richtext/richtextmarginspage.cpp:300
-#: ../src/richtext/richtextsizepage.cpp:532
-#: ../src/richtext/richtextsizepage.cpp:539
 msgid "&Left:"
 msgstr "&Bên trái:"
 
@@ -484,11 +512,11 @@ msgstr "&Bên trái:"
 msgid "&List level:"
 msgstr "&Mức danh sách:"
 
-#: ../src/generic/logg.cpp:517
+#: ../src/generic/logg.cpp:514
 msgid "&Log"
 msgstr "Tập ti&n ghi thông tin"
 
-#: ../src/univ/themes/win32.cpp:3748
+#: ../src/univ/themes/win32.cpp:3745
 msgid "&Move"
 msgstr "Di chuyể&n"
 
@@ -496,20 +524,19 @@ msgstr "Di chuyể&n"
 msgid "&Move the object to:"
 msgstr "&Di chuyển đối tượng tới:"
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "&Network"
 msgstr "Mạ&ng"
 
-#: ../src/richtext/richtexttabspage.cpp:132 ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173 ../src/richtext/richtexttabspage.cpp:132
 msgid "&New"
 msgstr "Tạo &mới"
 
-#: ../src/aui/tabmdi.cpp:111 ../src/generic/mdig.cpp:100
-#: ../src/msw/mdi.cpp:180
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
 msgid "&Next"
 msgstr "Tiếp &theo"
 
-#: ../src/generic/wizard.cpp:432 ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:429
 msgid "&Next >"
 msgstr "Tiếp &theo >"
 
@@ -517,7 +544,7 @@ msgstr "Tiếp &theo >"
 msgid "&Next Paragraph"
 msgstr "Đoạn Tiế&p"
 
-#: ../src/generic/tipdlg.cpp:240
+#: ../src/generic/tipdlg.cpp:237
 msgid "&Next Tip"
 msgstr "Mẹo kế &tiếp"
 
@@ -525,11 +552,11 @@ msgstr "Mẹo kế &tiếp"
 msgid "&Next style:"
 msgstr "Kiểu dáng kế &tiếp:"
 
-#: ../src/common/stockitem.cpp:177 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:174 ../src/msw/msgdlg.cpp:435
 msgid "&No"
 msgstr "&Không"
 
-#: ../src/generic/dbgrptg.cpp:356
+#: ../src/generic/dbgrptg.cpp:360
 msgid "&Notes:"
 msgstr "Ghi c&hú:"
 
@@ -537,12 +564,12 @@ msgstr "Ghi c&hú:"
 msgid "&Number:"
 msgstr "&Số:"
 
-#: ../src/generic/fontdlgg.cpp:475 ../src/generic/fontdlgg.cpp:482
-#: ../src/osx/carbon/fontdlg.cpp:408 ../src/common/stockitem.cpp:178
+#: ../src/osx/carbon/fontdlg.cpp:405 ../src/common/stockitem.cpp:175
+#: ../src/generic/fontdlgg.cpp:471 ../src/generic/fontdlgg.cpp:478
 msgid "&OK"
 msgstr "&Đồng ý"
 
-#: ../src/generic/dbgrptg.cpp:342 ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176 ../src/generic/dbgrptg.cpp:342
 msgid "&Open..."
 msgstr "&Mở..."
 
@@ -554,16 +581,16 @@ msgstr "Mức đường ba&o:"
 msgid "&Page Break"
 msgstr "Ngắt T&rang"
 
-#: ../src/richtext/richtextctrl.cpp:334 ../src/osx/textctrl_osx.cpp:578
-#: ../src/common/stockitem.cpp:180 ../src/msw/textctrl.cpp:2509
+#: ../src/osx/textctrl_osx.cpp:596 ../src/common/stockitem.cpp:177
+#: ../src/msw/textctrl.cpp:2774 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&Dán"
 
-#: ../include/wx/richtext/richtextbuffer.h:5010
+#: ../include/wx/richtext/richtextbuffer.h:5005
 msgid "&Picture"
 msgstr "&Hình ảnh"
 
-#: ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:419
 msgid "&Point size:"
 msgstr "&Kích thước điểm:"
 
@@ -575,12 +602,11 @@ msgstr "&Vị trí (mỗi 10mm):"
 msgid "&Position mode:"
 msgstr "&Chế độ vị trí:"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178
 msgid "&Preferences"
 msgstr "&Sở thích riêng"
 
-#: ../src/aui/tabmdi.cpp:112 ../src/generic/mdig.cpp:101
-#: ../src/msw/mdi.cpp:181
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
 msgid "&Previous"
 msgstr "&Trước"
 
@@ -588,78 +614,74 @@ msgstr "&Trước"
 msgid "&Previous Paragraph"
 msgstr "Đoạn T&rước"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "&Print..."
 msgstr "&In..."
 
-#: ../src/richtext/richtextctrl.cpp:339 ../src/richtext/richtextctrl.cpp:5514
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtextctrl.cpp:338
+#: ../src/richtext/richtextctrl.cpp:5512
 msgid "&Properties"
 msgstr "&Thuộc tính"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "&Quit"
 msgstr "T&hoát"
 
-#: ../src/richtext/richtextctrl.cpp:330 ../src/osx/textctrl_osx.cpp:574
-#: ../src/common/stockitem.cpp:185 ../src/common/cmdproc.cpp:293
-#: ../src/common/cmdproc.cpp:300 ../src/msw/textctrl.cpp:2505
+#: ../src/osx/textctrl_osx.cpp:592 ../src/common/stockitem.cpp:182
+#: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
+#: ../src/msw/textctrl.cpp:2770 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Redo"
 
-#: ../src/common/cmdproc.cpp:289 ../src/common/cmdproc.cpp:309
+#: ../src/common/cmdproc.cpp:282 ../src/common/cmdproc.cpp:302
 msgid "&Redo "
 msgstr "&Redo "
 
-#: ../src/richtext/richtextstyledlg.cpp:257
+#: ../src/richtext/richtextstyledlg.cpp:253
 msgid "&Rename Style..."
 msgstr "Đổ&i tên Kiểu Dáng..."
 
-#: ../src/generic/fdrepdlg.cpp:179
+#: ../src/generic/fdrepdlg.cpp:176
 msgid "&Replace"
 msgstr "Th&ay thế"
 
-#: ../src/richtext/richtextstyledlg.cpp:287
+#: ../src/richtext/richtextstyledlg.cpp:283
 msgid "&Restart numbering"
 msgstr "&Khởi động lại sự đánh số"
 
-#: ../src/univ/themes/win32.cpp:3747
+#: ../src/univ/themes/win32.cpp:3744
 msgid "&Restore"
 msgstr "&Phục hồi lại"
 
-#: ../src/richtext/richtextindentspage.cpp:146
 #: ../src/richtext/richtextliststylepage.cpp:335
+#: ../src/richtext/richtextindentspage.cpp:146
 msgid "&Right"
 msgstr "&Phải"
 
-#: ../src/richtext/richtextindentspage.cpp:213
+#: ../src/richtext/richtextsizepage.cpp:602
+#: ../src/richtext/richtextsizepage.cpp:609
 #: ../src/richtext/richtextborderspage.cpp:277
 #: ../src/richtext/richtextborderspage.cpp:445
 #: ../src/richtext/richtextliststylepage.cpp:399
+#: ../src/richtext/richtextindentspage.cpp:213
 #: ../src/richtext/richtextmarginspage.cpp:211
 #: ../src/richtext/richtextmarginspage.cpp:325
-#: ../src/richtext/richtextsizepage.cpp:602
-#: ../src/richtext/richtextsizepage.cpp:609
 msgid "&Right:"
 msgstr "&Phải:"
 
-#: ../src/common/stockitem.cpp:190
+#: ../src/common/stockitem.cpp:187
 msgid "&Save"
 msgstr "&Ghi lại"
-
-#: ../src/common/stockitem.cpp:191
-msgid "&Save as"
-msgstr "&Ghi Lại Bằng Tên Mới"
 
 #: ../include/wx/richmsgdlg.h:29
 msgid "&See details"
 msgstr "&Xem chi tiết"
 
-#: ../src/generic/tipdlg.cpp:236
+#: ../src/generic/tipdlg.cpp:233
 msgid "&Show tips at startup"
 msgstr "&Hiện hướng dẫn nhỏ lúc mới mở"
 
-#: ../src/univ/themes/win32.cpp:3750
+#: ../src/univ/themes/win32.cpp:3747
 msgid "&Size"
 msgstr "&Kích thước"
 
@@ -667,36 +689,36 @@ msgstr "&Kích thước"
 msgid "&Size:"
 msgstr "&Kích thước:"
 
-#: ../src/generic/progdlgg.cpp:252
+#: ../src/generic/progdlgg.cpp:249
 msgid "&Skip"
 msgstr "Giữ &nguyên"
 
-#: ../src/richtext/richtextindentspage.cpp:242
 #: ../src/richtext/richtextliststylepage.cpp:417
+#: ../src/richtext/richtextindentspage.cpp:242
 msgid "&Spacing (tenths of a mm)"
 msgstr "&Khoảng cách chữ (mỗi 10mm)"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "&Spell Check"
 msgstr "&Kiểm tra chính tả"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "&Stop"
 msgstr "&Dừng"
 
-#: ../src/richtext/richtextfontpage.cpp:275 ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196 ../src/richtext/richtextfontpage.cpp:275
 msgid "&Strikethrough"
 msgstr "Gạch giữ&a"
 
-#: ../src/generic/fontdlgg.cpp:382 ../src/richtext/richtextstylepage.cpp:106
+#: ../src/generic/fontdlgg.cpp:378 ../src/richtext/richtextstylepage.cpp:106
 msgid "&Style:"
 msgstr "&Kiểu dáng:"
 
-#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:194
 msgid "&Styles:"
 msgstr "&Kiểu dáng:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:413
+#: ../src/richtext/richtextsymboldlg.cpp:410
 msgid "&Subset:"
 msgstr "Tập c&on:"
 
@@ -710,24 +732,24 @@ msgstr "Ký hiệu đặc &biệt:"
 msgid "&Synchronize values"
 msgstr "Đồng &bộ hóa các giá trị"
 
-#: ../include/wx/richtext/richtextbuffer.h:6069
+#: ../include/wx/richtext/richtextbuffer.h:6064
 msgid "&Table"
 msgstr "&Bảng"
 
-#: ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197
 msgid "&Top"
 msgstr "&Trên"
 
+#: ../src/richtext/richtextsizepage.cpp:567
+#: ../src/richtext/richtextsizepage.cpp:574
 #: ../src/richtext/richtextborderspage.cpp:311
 #: ../src/richtext/richtextborderspage.cpp:479
 #: ../src/richtext/richtextmarginspage.cpp:234
 #: ../src/richtext/richtextmarginspage.cpp:348
-#: ../src/richtext/richtextsizepage.cpp:567
-#: ../src/richtext/richtextsizepage.cpp:574
 msgid "&Top:"
 msgstr "&Trên:"
 
-#: ../src/generic/fontdlgg.cpp:444 ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199 ../src/generic/fontdlgg.cpp:441
 msgid "&Underline"
 msgstr "&Gạch chân"
 
@@ -735,21 +757,21 @@ msgstr "&Gạch chân"
 msgid "&Underlining:"
 msgstr "&Gạch chân:"
 
-#: ../src/richtext/richtextctrl.cpp:329 ../src/osx/textctrl_osx.cpp:573
-#: ../src/common/stockitem.cpp:203 ../src/common/cmdproc.cpp:271
-#: ../src/msw/textctrl.cpp:2504
+#: ../src/osx/textctrl_osx.cpp:591 ../src/common/stockitem.cpp:200
+#: ../src/common/cmdproc.cpp:264 ../src/msw/textctrl.cpp:2769
+#: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Undo"
 
-#: ../src/common/cmdproc.cpp:265
+#: ../src/common/cmdproc.cpp:258
 msgid "&Undo "
 msgstr "&Undo "
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "&Unindent"
 msgstr "&Không thụt lề"
 
-#: ../src/common/stockitem.cpp:205
+#: ../src/common/stockitem.cpp:202
 msgid "&Up"
 msgstr "&Lên"
 
@@ -766,7 +788,7 @@ msgstr "&Vị trí tương đối theo chiều dọc:"
 msgid "&View..."
 msgstr "&Trình bày..."
 
-#: ../src/generic/fontdlgg.cpp:393
+#: ../src/generic/fontdlgg.cpp:389
 msgid "&Weight:"
 msgstr "Độ đậ&m:"
 
@@ -775,88 +797,58 @@ msgstr "Độ đậ&m:"
 msgid "&Width:"
 msgstr "&Rộng"
 
-#: ../src/aui/tabmdi.cpp:311 ../src/aui/tabmdi.cpp:327
-#: ../src/aui/tabmdi.cpp:329 ../src/generic/mdig.cpp:294
-#: ../src/generic/mdig.cpp:310 ../src/generic/mdig.cpp:314
-#: ../src/msw/mdi.cpp:78
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
 msgid "&Window"
 msgstr "&Cửa sổ"
 
-#: ../src/common/stockitem.cpp:206 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:203 ../src/msw/msgdlg.cpp:435
 msgid "&Yes"
 msgstr "Đồn&g ý"
 
-#: ../src/common/valtext.cpp:256
-#, c-format
-msgid "'%s' contains illegal characters"
+#: ../src/common/valtext.cpp:197
+#, fuzzy, c-format
+msgid "'%s' contains invalid character(s)"
 msgstr "'%s' chứa các ký tự không hợp lệ"
 
-#: ../src/common/valtext.cpp:254
-#, c-format
-msgid "'%s' doesn't consist only of valid characters"
-msgstr "'%s' không gồm có ký tự nào hợp lệ"
-
-#: ../src/common/config.cpp:519 ../src/msw/regconf.cpp:258
+#: ../src/common/config.cpp:515 ../src/msw/regconf.cpp:255
 #, c-format
 msgid "'%s' has extra '..', ignored."
 msgstr "'%s' có thêm '..', bỏ qua."
 
-#: ../src/common/cmdline.cpp:1113 ../src/common/cmdline.cpp:1131
+#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' không phải là một giá trị bằng số đúng cho tùy chọn '%s'."
 
-#: ../src/common/translation.cpp:1100
+#: ../src/common/translation.cpp:1142
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' không phải là catalog thông điệp hợp lệ."
 
-#: ../src/common/valtext.cpp:165
+#: ../src/common/valtext.cpp:188
 #, c-format
 msgid "'%s' is not one of the valid strings"
 msgstr "'%s' không phải là một chuỗi hợp lệ"
 
-#: ../src/common/valtext.cpp:167
+#: ../src/common/valtext.cpp:186
 #, c-format
 msgid "'%s' is one of the invalid strings"
 msgstr "'%s' là một trong số những chuỗi không hợp lệ"
 
-#: ../src/common/textbuf.cpp:237
+#: ../src/common/textbuf.cpp:233
 #, c-format
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' chắc chắn là một bộ đệm nhị phân."
-
-#: ../src/common/valtext.cpp:252
-#, c-format
-msgid "'%s' should be numeric."
-msgstr "'%s' có thể thuộc kiểu số."
-
-#: ../src/common/valtext.cpp:244
-#, c-format
-msgid "'%s' should only contain ASCII characters."
-msgstr "'%s' chỉ nên chứa chữ cái trong bảng mã ASCII."
-
-#: ../src/common/valtext.cpp:246
-#, c-format
-msgid "'%s' should only contain alphabetic characters."
-msgstr "'%s' chỉ nên chứa ký tự trong bảng chữ cái."
-
-#: ../src/common/valtext.cpp:248
-#, c-format
-msgid "'%s' should only contain alphabetic or numeric characters."
-msgstr "'%s' chỉ nên chứa ký tự trong bảng chữ cái hay chữ số."
-
-#: ../src/common/valtext.cpp:250
-#, c-format
-msgid "'%s' should only contain digits."
-msgstr "'%s' chỉ có thể chứa các chữ số."
 
 #: ../src/richtext/richtextliststylepage.cpp:229
 #: ../src/richtext/richtextbulletspage.cpp:166
 msgid "(*)"
 msgstr "(*)"
 
-#: ../src/html/helpwnd.cpp:963
+#: ../src/html/helpwnd.cpp:961
 msgid "(Help)"
 msgstr "(Trợ giúp)"
 
@@ -865,27 +857,32 @@ msgstr "(Trợ giúp)"
 msgid "(None)"
 msgstr "(Không)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:504
+#: ../src/richtext/richtextsymboldlg.cpp:503
 msgid "(Normal text)"
 msgstr "(Chữ thường)"
 
-#: ../src/html/helpwnd.cpp:419 ../src/html/helpwnd.cpp:1106
-#: ../src/html/helpwnd.cpp:1742
+#: ../src/html/helpwnd.cpp:417 ../src/html/helpwnd.cpp:1104
+#: ../src/html/helpwnd.cpp:1740
 msgid "(bookmarks)"
 msgstr "(Dấu trang)"
 
+#: ../src/msw/dlmsw.cpp:167
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (lỗi %ld: %s)"
+
+#: ../src/richtext/richtextformatdlg.cpp:876
+#: ../src/richtext/richtextliststylepage.cpp:448
+#: ../src/richtext/richtextliststylepage.cpp:460
+#: ../src/richtext/richtextliststylepage.cpp:461
 #: ../src/richtext/richtextindentspage.cpp:274
 #: ../src/richtext/richtextindentspage.cpp:286
 #: ../src/richtext/richtextindentspage.cpp:287
 #: ../src/richtext/richtextindentspage.cpp:311
 #: ../src/richtext/richtextindentspage.cpp:326
-#: ../src/richtext/richtextformatdlg.cpp:884
 #: ../src/richtext/richtextfontpage.cpp:349
 #: ../src/richtext/richtextfontpage.cpp:353
 #: ../src/richtext/richtextfontpage.cpp:357
-#: ../src/richtext/richtextliststylepage.cpp:448
-#: ../src/richtext/richtextliststylepage.cpp:460
-#: ../src/richtext/richtextliststylepage.cpp:461
 msgid "(none)"
 msgstr "(không)"
 
@@ -904,7 +901,7 @@ msgstr "*)"
 msgid "+"
 msgstr "+"
 
-#: ../src/msw/utils.cpp:1152
+#: ../src/msw/utils.cpp:1143
 msgid ", 64-bit edition"
 msgstr ", bản 64-bit"
 
@@ -913,163 +910,163 @@ msgstr ", bản 64-bit"
 msgid "-"
 msgstr "-"
 
-#: ../src/generic/filepickerg.cpp:66
+#: ../src/generic/filepickerg.cpp:63
 msgid "..."
 msgstr "..."
 
-#: ../src/richtext/richtextindentspage.cpp:276
 #: ../src/richtext/richtextliststylepage.cpp:450
+#: ../src/richtext/richtextindentspage.cpp:276
 msgid "1.1"
 msgstr "1.1"
 
-#: ../src/richtext/richtextindentspage.cpp:277
 #: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextindentspage.cpp:277
 msgid "1.2"
 msgstr "1.2"
 
-#: ../src/richtext/richtextindentspage.cpp:278
 #: ../src/richtext/richtextliststylepage.cpp:452
+#: ../src/richtext/richtextindentspage.cpp:278
 msgid "1.3"
 msgstr "1.3"
 
-#: ../src/richtext/richtextindentspage.cpp:279
 #: ../src/richtext/richtextliststylepage.cpp:453
+#: ../src/richtext/richtextindentspage.cpp:279
 msgid "1.4"
 msgstr "1.4"
 
-#: ../src/richtext/richtextindentspage.cpp:280
 #: ../src/richtext/richtextliststylepage.cpp:454
+#: ../src/richtext/richtextindentspage.cpp:280
 msgid "1.5"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:281
 #: ../src/richtext/richtextliststylepage.cpp:455
+#: ../src/richtext/richtextindentspage.cpp:281
 msgid "1.6"
 msgstr "1.6"
 
-#: ../src/richtext/richtextindentspage.cpp:282
 #: ../src/richtext/richtextliststylepage.cpp:456
+#: ../src/richtext/richtextindentspage.cpp:282
 msgid "1.7"
 msgstr "1.7"
 
-#: ../src/richtext/richtextindentspage.cpp:283
 #: ../src/richtext/richtextliststylepage.cpp:457
+#: ../src/richtext/richtextindentspage.cpp:283
 msgid "1.8"
 msgstr "1.8"
 
-#: ../src/richtext/richtextindentspage.cpp:284
 #: ../src/richtext/richtextliststylepage.cpp:458
+#: ../src/richtext/richtextindentspage.cpp:284
 msgid "1.9"
 msgstr "1.9"
 
-#: ../src/common/paper.cpp:140
+#: ../src/common/paper.cpp:137
 msgid "10 x 11 in"
 msgstr "10 x 11 in"
 
-#: ../src/common/paper.cpp:113
+#: ../src/common/paper.cpp:110
 msgid "10 x 14 in"
 msgstr "10 x 14 in"
 
-#: ../src/common/paper.cpp:114
+#: ../src/common/paper.cpp:111
 msgid "11 x 17 in"
 msgstr "11 x 17 in"
 
-#: ../src/common/paper.cpp:184
+#: ../src/common/paper.cpp:181
 msgid "12 x 11 in"
 msgstr "12 x 11 in"
 
-#: ../src/common/paper.cpp:141
+#: ../src/common/paper.cpp:138
 msgid "15 x 11 in"
 msgstr "15 x 11 in"
 
-#: ../src/richtext/richtextindentspage.cpp:285
 #: ../src/richtext/richtextliststylepage.cpp:459
+#: ../src/richtext/richtextindentspage.cpp:285
 msgid "2"
 msgstr "2"
 
-#: ../src/common/paper.cpp:132
+#: ../src/common/paper.cpp:129
 msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
 msgstr "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
 
-#: ../src/common/paper.cpp:139
+#: ../src/common/paper.cpp:136
 msgid "9 x 11 in"
 msgstr "9 x 11 in"
 
-#: ../src/html/htmprint.cpp:431
+#: ../src/html/htmprint.cpp:443
 msgid ": file does not exist!"
 msgstr ": tập tin không tồn tại!"
 
-#: ../src/common/fontmap.cpp:199
+#: ../src/common/fontmap.cpp:196
 msgid ": unknown charset"
 msgstr ": không hiểu bộ ký tự"
 
-#: ../src/common/fontmap.cpp:413
+#: ../src/common/fontmap.cpp:410
 msgid ": unknown encoding"
 msgstr ": không hiểu bảng mã"
 
-#: ../src/generic/wizard.cpp:443
+#: ../src/generic/wizard.cpp:438
 msgid "< &Back"
 msgstr "< &Quay lại"
 
-#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:628
-#: ../src/osx/carbon/fontdlg.cpp:648
+#: ../src/osx/carbon/fontdlg.cpp:419 ../src/osx/carbon/fontdlg.cpp:625
+#: ../src/osx/carbon/fontdlg.cpp:645
 msgid "<Any Decorative>"
 msgstr "<Dạng Chữ Trang Trí bất kỳ>"
 
-#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:630
-#: ../src/osx/carbon/fontdlg.cpp:650
+#: ../src/osx/carbon/fontdlg.cpp:420 ../src/osx/carbon/fontdlg.cpp:627
+#: ../src/osx/carbon/fontdlg.cpp:647
 msgid "<Any Modern>"
 msgstr "<Dạng Hiện Đại bất kỳ >"
 
-#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:626
-#: ../src/osx/carbon/fontdlg.cpp:646
+#: ../src/osx/carbon/fontdlg.cpp:418 ../src/osx/carbon/fontdlg.cpp:623
+#: ../src/osx/carbon/fontdlg.cpp:643
 msgid "<Any Roman>"
 msgstr "<Dạng La Mã bất kỳ>"
 
-#: ../src/osx/carbon/fontdlg.cpp:424 ../src/osx/carbon/fontdlg.cpp:632
-#: ../src/osx/carbon/fontdlg.cpp:652
+#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:629
+#: ../src/osx/carbon/fontdlg.cpp:649
 msgid "<Any Script>"
 msgstr "<Dạng Script bất kỳ>"
 
-#: ../src/osx/carbon/fontdlg.cpp:425 ../src/osx/carbon/fontdlg.cpp:637
-#: ../src/osx/carbon/fontdlg.cpp:656
+#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:634
+#: ../src/osx/carbon/fontdlg.cpp:653
 msgid "<Any Swiss>"
 msgstr "<Dạng Thụy Sỹ bất kỳ>"
 
-#: ../src/osx/carbon/fontdlg.cpp:426 ../src/osx/carbon/fontdlg.cpp:634
-#: ../src/osx/carbon/fontdlg.cpp:654
+#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:631
+#: ../src/osx/carbon/fontdlg.cpp:651
 msgid "<Any Teletype>"
 msgstr "<Dạng Teletype bất kỳ>"
 
-#: ../src/osx/carbon/fontdlg.cpp:420
+#: ../src/osx/carbon/fontdlg.cpp:417
 msgid "<Any>"
 msgstr "<Bất kỳ>"
 
-#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
 msgid "<DIR>"
 msgstr "<DIR>"
 
-#: ../src/generic/filectrlg.cpp:254 ../src/generic/filectrlg.cpp:277
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
 msgid "<DRIVE>"
 msgstr "<DRIVE>"
 
-#: ../src/generic/filectrlg.cpp:252 ../src/generic/filectrlg.cpp:275
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
 msgid "<LINK>"
 msgstr "<LINK>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1264
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Chữ vừa đậm vừa nghiêng.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1270
+#: ../src/html/helpwnd.cpp:1268
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>đậm và nghiêng <u>có gạch chân</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1265
+#: ../src/html/helpwnd.cpp:1263
 msgid "<b>Bold face.</b> "
 msgstr "<b>Chữ đậm.</b> "
 
-#: ../src/html/helpwnd.cpp:1264
+#: ../src/html/helpwnd.cpp:1262
 msgid "<i>Italic face.</i> "
 msgstr "<i>Chữ nghiêng.</i> "
 
@@ -1078,15 +1075,15 @@ msgstr "<i>Chữ nghiêng.</i> "
 msgid ">"
 msgstr ">"
 
-#: ../src/generic/dbgrptg.cpp:318
+#: ../src/generic/dbgrptg.cpp:317
 msgid "A debug report has been generated in the directory\n"
 msgstr "Một báo cáo lỗi đã được tạo ra trong thư mục\n"
 
-#: ../src/common/debugrpt.cpp:573
+#: ../src/common/debugrpt.cpp:574
 msgid "A debug report has been generated. It can be found in"
 msgstr "Một báo cáo lỗi đã được tạo ra. Nó có thể tìm thấy trong"
 
-#: ../src/common/xtixml.cpp:418
+#: ../src/common/xtixml.cpp:414
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Một tập hợp không trống rỗng phải gồm có những nút 'phần tử'"
 
@@ -1097,106 +1094,106 @@ msgstr "Một tập hợp không trống rỗng phải gồm có những nút 'p
 msgid "A standard bullet name."
 msgstr "Một tên bullet tiêu chuẩn."
 
-#: ../src/common/paper.cpp:217
+#: ../src/common/paper.cpp:214
 msgid "A0 sheet, 841 x 1189 mm"
 msgstr "A0 sheet, 841 x 1189 mm"
 
-#: ../src/common/paper.cpp:218
+#: ../src/common/paper.cpp:215
 msgid "A1 sheet, 594 x 841 mm"
 msgstr "A1 sheet, 594 x 841 mm"
 
-#: ../src/common/paper.cpp:159
+#: ../src/common/paper.cpp:156
 msgid "A2 420 x 594 mm"
 msgstr "A2 420 x 594 mm"
 
-#: ../src/common/paper.cpp:156
+#: ../src/common/paper.cpp:153
 msgid "A3 Extra 322 x 445 mm"
 msgstr "A3 Extra 322 x 445 mm"
 
-#: ../src/common/paper.cpp:161
+#: ../src/common/paper.cpp:158
 msgid "A3 Extra Transverse 322 x 445 mm"
 msgstr "A3 Extra Transverse 322 x 445 mm"
 
-#: ../src/common/paper.cpp:170
+#: ../src/common/paper.cpp:167
 msgid "A3 Rotated 420 x 297 mm"
 msgstr "A3 Rotated 420 x 297 mm"
 
-#: ../src/common/paper.cpp:160
+#: ../src/common/paper.cpp:157
 msgid "A3 Transverse 297 x 420 mm"
 msgstr "A3 Transverse 297 x 420 mm"
 
-#: ../src/common/paper.cpp:106
+#: ../src/common/paper.cpp:103
 msgid "A3 sheet, 297 x 420 mm"
 msgstr "A3 sheet, 297 x 420 mm"
 
-#: ../src/common/paper.cpp:146
+#: ../src/common/paper.cpp:143
 msgid "A4 Extra 9.27 x 12.69 in"
 msgstr "A4 Extra 9.27 x 12.69 in"
 
-#: ../src/common/paper.cpp:153
+#: ../src/common/paper.cpp:150
 msgid "A4 Plus 210 x 330 mm"
 msgstr "A4 Plus 210 x 330 mm"
 
-#: ../src/common/paper.cpp:171
+#: ../src/common/paper.cpp:168
 msgid "A4 Rotated 297 x 210 mm"
 msgstr "A4 Rotated 297 x 210 mm"
 
-#: ../src/common/paper.cpp:148
+#: ../src/common/paper.cpp:145
 msgid "A4 Transverse 210 x 297 mm"
 msgstr "A4 Transverse 210 x 297 mm"
 
-#: ../src/common/paper.cpp:97
+#: ../src/common/paper.cpp:94
 msgid "A4 sheet, 210 x 297 mm"
 msgstr "A4 sheet, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:107
+#: ../src/common/paper.cpp:104
 msgid "A4 small sheet, 210 x 297 mm"
 msgstr "A4 small sheet, 210 x 297 mm"
 
-#: ../src/common/paper.cpp:157
+#: ../src/common/paper.cpp:154
 msgid "A5 Extra 174 x 235 mm"
 msgstr "A5 Extra 174 x 235 mm"
 
-#: ../src/common/paper.cpp:172
+#: ../src/common/paper.cpp:169
 msgid "A5 Rotated 210 x 148 mm"
 msgstr "A5 Rotated 210 x 148 mm"
 
-#: ../src/common/paper.cpp:154
+#: ../src/common/paper.cpp:151
 msgid "A5 Transverse 148 x 210 mm"
 msgstr "A5 Transverse 148 x 210 mm"
 
-#: ../src/common/paper.cpp:108
+#: ../src/common/paper.cpp:105
 msgid "A5 sheet, 148 x 210 mm"
 msgstr "A5 sheet, 148 x 210 mm"
 
-#: ../src/common/paper.cpp:164
+#: ../src/common/paper.cpp:161
 msgid "A6 105 x 148 mm"
 msgstr "A6 105 x 148 mm"
 
-#: ../src/common/paper.cpp:177
+#: ../src/common/paper.cpp:174
 msgid "A6 Rotated 148 x 105 mm"
 msgstr "A6 Rotated 148 x 105 mm"
 
-#: ../src/generic/fontdlgg.cpp:83 ../src/richtext/richtextformatdlg.cpp:529
-#: ../src/osx/carbon/fontdlg.cpp:153
+#: ../src/osx/carbon/fontdlg.cpp:150 ../src/generic/fontdlgg.cpp:79
+#: ../src/richtext/richtextformatdlg.cpp:521
 msgid "ABCDEFGabcdefg12345"
 msgstr "ABCDEFGabcdefg12345"
 
-#: ../src/richtext/richtextsymboldlg.cpp:458 ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
 msgid "ASCII"
 msgstr "ASCII"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "About"
 msgstr "Giới thiệu"
 
-#: ../src/generic/aboutdlgg.cpp:140 ../src/osx/menu_osx.cpp:558
-#: ../src/msw/aboutdlg.cpp:64
+#: ../src/osx/menu_osx.cpp:450 ../src/generic/aboutdlgg.cpp:137
+#: ../src/msw/aboutdlg.cpp:61
 #, c-format
 msgid "About %s"
 msgstr "Giới thiệu %s"
 
-#: ../src/osx/menu_osx.cpp:560
+#: ../src/osx/menu_osx.cpp:452
 msgid "About..."
 msgstr "Giới thiệu..."
 
@@ -1205,38 +1202,38 @@ msgid "Absolute"
 msgstr "Tuyệt đối"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:873
+#: ../src/propgrid/advprops.cpp:774
 #, fuzzy
 msgid "ActiveBorder"
 msgstr "Viền"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:874
+#: ../src/propgrid/advprops.cpp:775
 msgid "ActiveCaption"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "Actual Size"
 msgstr "Kích thước Thật"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:140 ../src/common/accelcmn.cpp:81
+#: ../src/common/stockitem.cpp:137 ../src/common/accelcmn.cpp:78
 msgid "Add"
 msgstr "Thêm"
 
-#: ../src/richtext/richtextbuffer.cpp:11455
+#: ../src/richtext/richtextbuffer.cpp:11454
 msgid "Add Column"
 msgstr "Thêm cột"
 
-#: ../src/richtext/richtextbuffer.cpp:11392
+#: ../src/richtext/richtextbuffer.cpp:11391
 msgid "Add Row"
 msgstr "Thêm hàng"
 
-#: ../src/html/helpwnd.cpp:432
+#: ../src/html/helpwnd.cpp:430
 msgid "Add current page to bookmarks"
 msgstr "Thêm trang hiện thời vào dấu trang"
 
-#: ../src/generic/colrdlgg.cpp:366
+#: ../src/generic/colrdlgg.cpp:386
 msgid "Add to custom colours"
 msgstr "Thêm vào màu tự chọn"
 
@@ -1248,12 +1245,12 @@ msgstr "AddToPropertyCollection được gọi bởi một bộ truy cập chung
 msgid "AddToPropertyCollection called w/o valid adder"
 msgstr "AddToPropertyCollection được gọi bởi bộ thêm w/o hợp lệ"
 
-#: ../src/html/helpctrl.cpp:159
+#: ../src/html/helpctrl.cpp:155
 #, c-format
 msgid "Adding book %s"
 msgstr "Thêm sách %s"
 
-#: ../src/common/preferencescmn.cpp:43
+#: ../src/common/preferencescmn.cpp:40
 msgid "Advanced"
 msgstr "Cao cấp"
 
@@ -1261,11 +1258,11 @@ msgstr "Cao cấp"
 msgid "After a paragraph:"
 msgstr "Sau một đoạn văn:"
 
-#: ../src/common/stockitem.cpp:172
+#: ../src/common/stockitem.cpp:169
 msgid "Align Left"
 msgstr "Canh lề Trái"
 
-#: ../src/common/stockitem.cpp:173
+#: ../src/common/stockitem.cpp:170
 msgid "Align Right"
 msgstr "Canh lề Phải"
 
@@ -1273,40 +1270,40 @@ msgstr "Canh lề Phải"
 msgid "Alignment"
 msgstr "C&anh hàng"
 
-#: ../src/generic/prntdlgg.cpp:215
+#: ../src/generic/prntdlgg.cpp:208
 msgid "All"
 msgstr "Tất cả"
 
-#: ../src/generic/filectrlg.cpp:1197 ../src/common/fldlgcmn.cpp:107
+#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1186
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Mọi tập tin (%s)|%s"
 
-#: ../include/wx/defs.h:2886
+#: ../include/wx/defs.h:2582
 msgid "All files (*)|*"
 msgstr "Mọi tập tin (*)|*"
 
-#: ../include/wx/defs.h:2883
+#: ../include/wx/defs.h:2579
 msgid "All files (*.*)|*.*"
 msgstr "Mọi tập tin (*.*)|*.*"
 
-#: ../src/richtext/richtextstyles.cpp:1061
+#: ../src/richtext/richtextstyles.cpp:1058
 msgid "All styles"
 msgstr "Mọi kiểu dáng"
 
-#: ../src/propgrid/manager.cpp:1528
+#: ../src/propgrid/manager.cpp:1544
 msgid "Alphabetic Mode"
 msgstr "Chế độ Bảng chữ cái"
 
-#: ../src/common/xtistrm.cpp:425
+#: ../src/common/xtistrm.cpp:422
 msgid "Already Registered Object passed to SetObjectClassInfo"
 msgstr "Already Registered Object được chuyển cho SetObjectClassInfo"
 
-#: ../src/unix/dialup.cpp:353
+#: ../src/unix/dialup.cpp:352
 msgid "Already dialling ISP."
 msgstr "Sẵn sàng quay số tới nhà cung cấp dịch vụ Internet ISP."
 
-#: ../src/common/accelcmn.cpp:331 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/accelcmn.cpp:345 ../src/univ/themes/win32.cpp:3753
 msgid "Alt+"
 msgstr "Alt+"
 
@@ -1315,34 +1312,34 @@ msgstr "Alt+"
 msgid "An optional corner radius for adding rounded corners."
 msgstr "Bán kính góc tự chọn để thêm góc được bo tròn."
 
-#: ../src/common/debugrpt.cpp:576
+#: ../src/common/debugrpt.cpp:577
 msgid "And includes the following files:\n"
 msgstr "Và bao gồm các tập tin sau đây:\n"
 
-#: ../src/generic/animateg.cpp:162
+#: ../src/generic/animateg.cpp:145
 #, c-format
 msgid "Animation file is not of type %ld."
 msgstr "Tập tin hoạt hình thì không phải thuộc kiểu %ld."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:872
+#: ../src/propgrid/advprops.cpp:773
 msgid "AppWorkspace"
 msgstr ""
 
-#: ../src/generic/logg.cpp:1014
+#: ../src/generic/logg.cpp:1011
 #, c-format
 msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
 msgstr "Nối thêm nhật ký vào tập tin '%s' (chọn [No] sẽ ghi đè lên nó)?"
 
-#: ../src/osx/menu_osx.cpp:577 ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:469 ../src/osx/menu_osx.cpp:477
 msgid "Application"
 msgstr "Ứng dụng"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "Apply"
 msgstr "Áp dụng"
 
-#: ../src/propgrid/advprops.cpp:1609
+#: ../src/propgrid/advprops.cpp:1515
 msgid "Aqua"
 msgstr ""
 
@@ -1351,30 +1348,30 @@ msgstr ""
 msgid "Arabic"
 msgstr "Arabic"
 
-#: ../src/common/fmapbase.cpp:153
+#: ../src/common/fmapbase.cpp:150
 msgid "Arabic (ISO-8859-6)"
 msgstr "Arabic (ISO-8859-6)"
 
-#: ../src/msw/ole/automtn.cpp:672
+#: ../src/msw/ole/automtn.cpp:663
 #, c-format
 msgid "Argument %u not found."
 msgstr "Tham số %u không tìm thấy."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1753
+#: ../src/propgrid/advprops.cpp:1654
 #, fuzzy
 msgid "Arrow"
 msgstr "ngày mai"
 
-#: ../src/generic/aboutdlgg.cpp:184
+#: ../src/generic/aboutdlgg.cpp:181
 msgid "Artists"
 msgstr "Nghệ sĩ"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "Ascending"
 msgstr "Tăng dần"
 
-#: ../src/generic/filectrlg.cpp:433
+#: ../src/generic/filectrlg.cpp:429
 msgid "Attributes"
 msgstr "Thuộc tính"
 
@@ -1384,90 +1381,90 @@ msgstr "Thuộc tính"
 msgid "Available fonts."
 msgstr "Phông chữ sẵn có."
 
-#: ../src/common/paper.cpp:137
+#: ../src/common/paper.cpp:134
 msgid "B4 (ISO) 250 x 353 mm"
 msgstr "B4 (ISO) 250 x 353 mm"
 
-#: ../src/common/paper.cpp:173
+#: ../src/common/paper.cpp:170
 msgid "B4 (JIS) Rotated 364 x 257 mm"
 msgstr "B4 (JIS) Rotated 364 x 257 mm"
 
-#: ../src/common/paper.cpp:127
+#: ../src/common/paper.cpp:124
 msgid "B4 Envelope, 250 x 353 mm"
 msgstr "B4 Envelope, 250 x 353 mm"
 
-#: ../src/common/paper.cpp:109
+#: ../src/common/paper.cpp:106
 msgid "B4 sheet, 250 x 354 mm"
 msgstr "B4 sheet, 250 x 354 mm"
 
-#: ../src/common/paper.cpp:158
+#: ../src/common/paper.cpp:155
 msgid "B5 (ISO) Extra 201 x 276 mm"
 msgstr "B5 (ISO) Extra 201 x 276 mm"
 
-#: ../src/common/paper.cpp:174
+#: ../src/common/paper.cpp:171
 msgid "B5 (JIS) Rotated 257 x 182 mm"
 msgstr "B5 (JIS) Rotated 257 x 182 mm"
 
-#: ../src/common/paper.cpp:155
+#: ../src/common/paper.cpp:152
 msgid "B5 (JIS) Transverse 182 x 257 mm"
 msgstr "B5 (JIS) Transverse 182 x 257 mm"
 
-#: ../src/common/paper.cpp:128
+#: ../src/common/paper.cpp:125
 msgid "B5 Envelope, 176 x 250 mm"
 msgstr "B5 Envelope, 176 x 250 mm"
 
-#: ../src/common/paper.cpp:110
+#: ../src/common/paper.cpp:107
 msgid "B5 sheet, 182 x 257 millimeter"
 msgstr "B5 sheet, 182 x 257 millimeter"
 
-#: ../src/common/paper.cpp:182
+#: ../src/common/paper.cpp:179
 msgid "B6 (JIS) 128 x 182 mm"
 msgstr "B6 (JIS) 128 x 182 mm"
 
-#: ../src/common/paper.cpp:183
+#: ../src/common/paper.cpp:180
 msgid "B6 (JIS) Rotated 182 x 128 mm"
 msgstr "B6 (JIS) Rotated 182 x 128 mm"
 
-#: ../src/common/paper.cpp:129
+#: ../src/common/paper.cpp:126
 msgid "B6 Envelope, 176 x 125 mm"
 msgstr "B6 Envelope, 176 x 125 mm"
 
-#: ../src/common/imagbmp.cpp:531 ../src/common/imagbmp.cpp:561
-#: ../src/common/imagbmp.cpp:576
+#: ../src/common/imagbmp.cpp:528 ../src/common/imagbmp.cpp:558
+#: ../src/common/imagbmp.cpp:573
 msgid "BMP: Couldn't allocate memory."
 msgstr "BMP: Không thể cấp phát bộ nhớ."
 
-#: ../src/common/imagbmp.cpp:100
+#: ../src/common/imagbmp.cpp:97
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: Không thể ghi ảnh không hợp lệ."
 
-#: ../src/common/imagbmp.cpp:356
+#: ../src/common/imagbmp.cpp:353
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: Không thể ghi bản đồ màu RGB."
 
-#: ../src/common/imagbmp.cpp:490
+#: ../src/common/imagbmp.cpp:487
 msgid "BMP: Couldn't write data."
 msgstr "BMP: Không thể ghi dữ liệu."
 
-#: ../src/common/imagbmp.cpp:246
+#: ../src/common/imagbmp.cpp:243
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: Không thể ghi phần đầu tập tin (Bitmap)."
 
-#: ../src/common/imagbmp.cpp:269
+#: ../src/common/imagbmp.cpp:266
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: Không thể ghi phần đầu tập tin (BitmapInfo)."
 
-#: ../src/common/imagbmp.cpp:140
+#: ../src/common/imagbmp.cpp:137
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage không có quyền sở hữu wxPalette."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:142 ../src/common/accelcmn.cpp:52
+#: ../src/common/stockitem.cpp:139 ../src/common/accelcmn.cpp:49
 msgid "Back"
 msgstr "Quay lại"
 
+#: ../src/richtext/richtextformatdlg.cpp:377
 #: ../src/richtext/richtextbackgroundpage.cpp:148
-#: ../src/richtext/richtextformatdlg.cpp:384
 msgid "Background"
 msgstr "Nền"
 
@@ -1475,21 +1472,21 @@ msgstr "Nền"
 msgid "Background &colour:"
 msgstr "Mà&u nền:"
 
-#: ../src/osx/carbon/fontdlg.cpp:220
+#: ../src/osx/carbon/fontdlg.cpp:217
 msgid "Background colour"
 msgstr "Màu nền"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:52
+#: ../src/common/accelcmn.cpp:49
 #, fuzzy
 msgid "Backspace"
 msgstr "Quay lại"
 
-#: ../src/common/fmapbase.cpp:160
+#: ../src/common/fmapbase.cpp:157
 msgid "Baltic (ISO-8859-13)"
 msgstr "Baltic (ISO-8859-13)"
 
-#: ../src/common/fmapbase.cpp:151
+#: ../src/common/fmapbase.cpp:148
 msgid "Baltic (old) (ISO-8859-4)"
 msgstr "Baltic (cũ) (ISO-8859-4)"
 
@@ -1502,25 +1499,25 @@ msgstr "Phía trước đoạn văn:"
 msgid "Bitmap"
 msgstr "Ảnh mảng bitmap"
 
-#: ../src/propgrid/advprops.cpp:1594
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Black"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1755
+#: ../src/propgrid/advprops.cpp:1656
 msgid "Blank"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1603
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Blue"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:345
+#: ../src/generic/colrdlgg.cpp:365
 msgid "Blue:"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:333 ../src/richtext/richtextfontpage.cpp:355
-#: ../src/osx/carbon/fontdlg.cpp:354 ../src/common/stockitem.cpp:143
+#: ../src/osx/carbon/fontdlg.cpp:351 ../src/common/stockitem.cpp:140
+#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:355
 msgid "Bold"
 msgstr "Đậm"
 
@@ -1529,32 +1526,36 @@ msgstr "Đậm"
 msgid "Border"
 msgstr "Viền"
 
-#: ../src/richtext/richtextformatdlg.cpp:379
+#: ../src/richtext/richtextformatdlg.cpp:372
 msgid "Borders"
 msgstr "Viền mép"
 
-#: ../src/richtext/richtextsizepage.cpp:288 ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141 ../src/richtext/richtextsizepage.cpp:288
 msgid "Bottom"
 msgstr "Dưới"
 
-#: ../src/generic/prntdlgg.cpp:893
+#: ../src/generic/prntdlgg.cpp:886
 msgid "Bottom margin (mm):"
 msgstr "Lề dưới chân (mm):"
 
-#: ../src/richtext/richtextbuffer.cpp:9383
+#: ../src/richtext/richtextbuffer.cpp:9380
 msgid "Box Properties"
 msgstr "Các tính chất Hộp"
 
-#: ../src/richtext/richtextstyles.cpp:1065
+#: ../src/richtext/richtextstyles.cpp:1062
 msgid "Box styles"
 msgstr "Kiểu dáng Hộp"
 
-#: ../src/propgrid/advprops.cpp:1602
+#: ../src/osx/cocoa/menu.mm:292
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1508
 #, fuzzy
 msgid "Brown"
 msgstr "Tìm duyệt"
 
-#: ../src/common/filepickercmn.cpp:43 ../src/common/filepickercmn.cpp:44
+#: ../src/common/filepickercmn.cpp:40 ../src/common/filepickercmn.cpp:41
 msgid "Browse"
 msgstr "Tìm duyệt"
 
@@ -1567,73 +1568,73 @@ msgstr "&Căn lề Bullet:"
 msgid "Bullet style"
 msgstr "Kiểu dáng bullet"
 
-#: ../src/richtext/richtextformatdlg.cpp:359
+#: ../src/richtext/richtextformatdlg.cpp:352
 msgid "Bullets"
 msgstr "Bullets"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1756
+#: ../src/propgrid/advprops.cpp:1657
 #, fuzzy
 msgid "Bullseye"
 msgstr "Kiểu dáng bullet"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:875
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonFace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:876
+#: ../src/propgrid/advprops.cpp:777
 msgid "ButtonHighlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:877
+#: ../src/propgrid/advprops.cpp:778
 msgid "ButtonShadow"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:878
+#: ../src/propgrid/advprops.cpp:779
 msgid "ButtonText"
 msgstr ""
 
-#: ../src/common/paper.cpp:98
+#: ../src/common/paper.cpp:95
 msgid "C sheet, 17 x 22 in"
 msgstr "C sheet, 17 x 22 in"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "C&lear"
 msgstr "&Xóa tất cả"
 
-#: ../src/generic/fontdlgg.cpp:406
+#: ../src/generic/fontdlgg.cpp:403
 msgid "C&olour:"
 msgstr "Mà&u:"
 
-#: ../src/common/paper.cpp:123
+#: ../src/common/paper.cpp:120
 msgid "C3 Envelope, 324 x 458 mm"
 msgstr "C3 Envelope, 324 x 458 mm"
 
-#: ../src/common/paper.cpp:124
+#: ../src/common/paper.cpp:121
 msgid "C4 Envelope, 229 x 324 mm"
 msgstr "C4 Envelope, 229 x 324 mm"
 
-#: ../src/common/paper.cpp:122
+#: ../src/common/paper.cpp:119
 msgid "C5 Envelope, 162 x 229 mm"
 msgstr "C5 Envelope, 162 x 229 mm"
 
-#: ../src/common/paper.cpp:125
+#: ../src/common/paper.cpp:122
 msgid "C6 Envelope, 114 x 162 mm"
 msgstr "C6 Envelope, 114 x 162 mm"
 
-#: ../src/common/paper.cpp:126
+#: ../src/common/paper.cpp:123
 msgid "C65 Envelope, 114 x 229 mm"
 msgstr "C65 Envelope, 114 x 229 mm"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "CD-Rom"
 msgstr "CD-Rom"
 
-#: ../src/html/chm.cpp:815 ../src/html/chm.cpp:874
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:865
 msgid "CHM handler currently supports only local files!"
 msgstr "CHM handler hiện tại chỉ hỗ trợ các tập tin nội bộ!"
 
@@ -1641,195 +1642,199 @@ msgstr "CHM handler hiện tại chỉ hỗ trợ các tập tin nội bộ!"
 msgid "Ca&pitals"
 msgstr "Chữ viết &hoa"
 
-#: ../src/common/cmdproc.cpp:267
+#: ../src/common/cmdproc.cpp:260
 msgid "Can't &Undo "
 msgstr "Không thể &Undo"
 
-#: ../src/common/image.cpp:2824
+#: ../src/common/image.cpp:2924
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 "Không thể tự động dò tìm định dạng ảnh cho đầu vào không-di-chuyển-vị-trí-"
 "đọc-được."
 
-#: ../src/msw/registry.cpp:506
+#: ../src/msw/registry.cpp:495
 #, c-format
 msgid "Can't close registry key '%s'"
 msgstr "Không thể đóng khóa đăng ký '%s'"
 
-#: ../src/msw/registry.cpp:584
+#: ../src/msw/registry.cpp:573
 #, c-format
 msgid "Can't copy values of unsupported type %d."
 msgstr "Không thể sao chép giá trị của kiểu không được hỗ trợ %d."
 
-#: ../src/msw/registry.cpp:487
+#: ../src/msw/registry.cpp:476
 #, c-format
 msgid "Can't create registry key '%s'"
 msgstr "Không thể tạo một khóa đăng ký '%s'"
 
-#: ../src/msw/thread.cpp:665
+#: ../src/msw/thread.cpp:657
 msgid "Can't create thread"
 msgstr "Không thể tạo tuyến trình"
 
-#: ../src/msw/window.cpp:3691
-#, c-format
-msgid "Can't create window of class %s"
-msgstr "Không thể tạo cửa sổ của lớp %s"
-
-#: ../src/msw/registry.cpp:777
+#: ../src/msw/registry.cpp:765
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Không thể xóa khóa '%s'"
 
-#: ../src/msw/iniconf.cpp:458
+#: ../src/msw/iniconf.cpp:455
 #, c-format
 msgid "Can't delete the INI file '%s'"
 msgstr "Không thể xóa tập tin INI '%s'"
 
-#: ../src/msw/registry.cpp:805
+#: ../src/msw/registry.cpp:793
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Không thể xóa giá trị '%s' từ khóa '%s'"
 
-#: ../src/msw/registry.cpp:1171
+#: ../src/msw/registry.cpp:1159
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Không thể liệt kê khóa phụ từ khóa '%s'"
 
-#: ../src/msw/registry.cpp:1132
+#: ../src/msw/registry.cpp:1120
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Không thể liệt kê các giá trị của khóa '%s'"
 
-#: ../src/msw/registry.cpp:1389
+#: ../src/msw/registry.cpp:1377
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Không thể xuất ra giá trị của kiểu không được hỗ trợ %d."
 
-#: ../src/common/ffile.cpp:254
+#: ../src/common/ffile.cpp:253
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Không thể tìm được vị trí hiện hành trong tập tin '%s'"
 
-#: ../src/msw/registry.cpp:418
+#: ../src/msw/registry.cpp:407
 #, c-format
 msgid "Can't get info about registry key '%s'"
 msgstr "Không thể nhận được thông tin về khóa đăng ký '%s'"
 
-#: ../src/common/zstream.cpp:346
+#: ../src/msw/webview_ie.cpp:1024
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "Không thể đặt mức ưu tiên tuyến trình"
+
+#: ../src/common/zstream.cpp:343
 msgid "Can't initialize zlib deflate stream."
 msgstr "Không thể khởi tạo zlib deflate stream."
 
-#: ../src/common/zstream.cpp:185
+#: ../src/common/zstream.cpp:182
 msgid "Can't initialize zlib inflate stream."
 msgstr "Không thể khởi tạo zlib inflate stream."
 
-#: ../src/msw/fswatcher.cpp:476
+#: ../src/msw/fswatcher.cpp:475
 #, c-format
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr ""
 "Không thể theo dõi thư mục không-hiện-có \"%s\" để thấy được các thay đổi."
 
-#: ../src/msw/registry.cpp:454
+#: ../src/msw/registry.cpp:443
 #, c-format
 msgid "Can't open registry key '%s'"
 msgstr "Không thể mở khóa đăng ký '%s'"
 
-#: ../src/common/zstream.cpp:252
+#: ../src/common/zstream.cpp:249
 #, c-format
 msgid "Can't read from inflate stream: %s"
 msgstr "Không thể đọc từ inflate stream: %s"
 
-#: ../src/common/zstream.cpp:244
+#: ../src/common/zstream.cpp:241
 msgid "Can't read inflate stream: unexpected EOF in underlying stream."
 msgstr ""
 "Không thể đọc inflate stream: không mong chờ kết thúc tập tin EOF nằm ở dưới "
 "dòng dữ liệu."
 
-#: ../src/msw/registry.cpp:1064
+#: ../src/msw/registry.cpp:1052
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Không thể đọc giá trị của '%s'"
 
-#: ../src/msw/registry.cpp:878 ../src/msw/registry.cpp:910
-#: ../src/msw/registry.cpp:975
+#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
+#: ../src/msw/registry.cpp:963
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Không thể đọc giá trị của khóa '%s'"
 
-#: ../src/common/image.cpp:2620
+#: ../src/msw/webview_ie.cpp:1017
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/common/image.cpp:2715
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "Không thể ghi ảnh ra tập tin '%s': không hiểu phần mở rộng."
 
-#: ../src/generic/logg.cpp:573 ../src/generic/logg.cpp:976
+#: ../src/generic/logg.cpp:570 ../src/generic/logg.cpp:973
 msgid "Can't save log contents to file."
 msgstr "Không thể ghi nội dung nhật ký ra tập tin."
 
-#: ../src/msw/thread.cpp:629
+#: ../src/msw/thread.cpp:621
 msgid "Can't set thread priority"
 msgstr "Không thể đặt mức ưu tiên tuyến trình"
 
-#: ../src/msw/registry.cpp:896 ../src/msw/registry.cpp:938
-#: ../src/msw/registry.cpp:1081
+#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
+#: ../src/msw/registry.cpp:1069
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Không thể đặt giá trị của '%s'"
 
-#: ../src/unix/utilsunx.cpp:351
+#: ../src/unix/utilsunx.cpp:353
 msgid "Can't write to child process's stdin"
 msgstr "Không thể ghi ra đầu vào chuẩn của quá trình con"
 
-#: ../src/common/zstream.cpp:427
+#: ../src/common/zstream.cpp:424
 #, c-format
 msgid "Can't write to deflate stream: %s"
 msgstr "Không thể ghi vào deflate stream: %s"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:279 ../src/richtext/richtextstyledlg.cpp:300
-#: ../src/common/stockitem.cpp:145 ../src/common/accelcmn.cpp:71
-#: ../src/msw/msgdlg.cpp:454 ../src/msw/progdlg.cpp:673
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:142
+#: ../src/common/accelcmn.cpp:68 ../src/motif/msgdlg.cpp:196
+#: ../src/gtk1/fontdlg.cpp:144 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/progdlg.cpp:940 ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Hủy bỏ"
 
-#: ../src/common/filefn.cpp:1261
+#: ../src/common/filefn.cpp:1149
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Không thể liệt kê các tập tin '%s'"
 
-#: ../src/msw/dir.cpp:263
+#: ../src/msw/dir.cpp:260
 #, c-format
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Không thể đếm các tập tin trong thư mục '%s'"
 
-#: ../src/msw/dialup.cpp:523
+#: ../src/msw/dialup.cpp:517
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Không thể tìm thấy kết nối quay số đang hoạt động: %s"
 
-#: ../src/msw/dialup.cpp:827
+#: ../src/msw/dialup.cpp:821
 msgid "Cannot find the location of address book file"
 msgstr "Không tìm thấy vị trí trong tập tin sổ địa chỉ"
 
-#: ../src/msw/ole/automtn.cpp:562
+#: ../src/msw/ole/automtn.cpp:553
 #, c-format
 msgid "Cannot get an active instance of \"%s\""
 msgstr "Không lấy được minh dụ đang hoạt động của  \"%s\""
 
-#: ../src/unix/threadpsx.cpp:1035
+#: ../src/unix/threadpsx.cpp:1053
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "Không thể nhận vùng ưu tiên cho việc tạo lập chính sách %d."
 
-#: ../src/unix/utilsunx.cpp:987
+#: ../src/unix/utilsunx.cpp:989
 msgid "Cannot get the hostname"
 msgstr "Không thể lấy được tên máy chủ"
 
-#: ../src/unix/utilsunx.cpp:1023
+#: ../src/unix/utilsunx.cpp:1025
 msgid "Cannot get the official hostname"
 msgstr "Không lấy được tên máy chủ văn phòng"
 
-#: ../src/msw/dialup.cpp:928
+#: ../src/msw/dialup.cpp:922
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Không thể gác máy - không có kết nối quay số nào đang hoạt động."
 
@@ -1837,127 +1842,127 @@ msgstr "Không thể gác máy - không có kết nối quay số nào đang ho�
 msgid "Cannot initialize OLE"
 msgstr "Không thể khởi tạo OLE"
 
-#: ../src/common/socket.cpp:853
+#: ../src/common/socket.cpp:850
 msgid "Cannot initialize sockets"
 msgstr "Không thể khởi tạo socket"
 
-#: ../src/msw/volume.cpp:619
+#: ../src/msw/volume.cpp:627
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Không thể tải biểu tượng từ '%s'."
 
-#: ../src/xrc/xmlres.cpp:360
+#: ../src/xrc/xmlres.cpp:358
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Không thể tải tài nguyên từ  '%s'."
 
-#: ../src/xrc/xmlres.cpp:742
+#: ../src/xrc/xmlres.cpp:740
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Không thể tải tài nguyên từ tập tin '%s'."
 
-#: ../src/html/htmlfilt.cpp:137
+#: ../src/html/htmlfilt.cpp:134
 #, c-format
 msgid "Cannot open HTML document: %s"
 msgstr "Không thể mở tài liệu HTML: %s"
 
-#: ../src/html/helpdata.cpp:667
+#: ../src/html/helpdata.cpp:660
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Không thể mở sách trợ giúp dạng HTML: %s"
 
-#: ../src/html/helpdata.cpp:299
+#: ../src/html/helpdata.cpp:296
 #, c-format
 msgid "Cannot open contents file: %s"
 msgstr "Không thể mở tập tin nội dung: %s"
 
-#: ../src/generic/dcpsg.cpp:1667
+#: ../src/generic/dcpsg.cpp:1665
 msgid "Cannot open file for PostScript printing!"
 msgstr "Không thể mở tập tin cho việc in dạng PostScript!"
 
-#: ../src/html/helpdata.cpp:313
+#: ../src/html/helpdata.cpp:310
 #, c-format
 msgid "Cannot open index file: %s"
 msgstr "Không thể mở tập tin chỉ mục: %s"
 
-#: ../src/xrc/xmlres.cpp:724
+#: ../src/xrc/xmlres.cpp:722
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Không thể mở tập tin tài nguyên '%s'."
 
-#: ../src/html/helpwnd.cpp:1534
+#: ../src/html/helpwnd.cpp:1532
 msgid "Cannot print empty page."
 msgstr "Không thể in một trang rỗng."
 
-#: ../src/msw/volume.cpp:507
+#: ../src/msw/volume.cpp:515
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Không thể đọc kiểu tên từ '%s'!"
 
-#: ../src/msw/thread.cpp:888
+#: ../src/msw/thread.cpp:894
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Không thể phục hồi tuyến trình %lx"
 
-#: ../src/unix/threadpsx.cpp:1016
+#: ../src/unix/threadpsx.cpp:1028
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Không thể khôi phục chính sách tạo lập tác vụ tuyến trình."
 
-#: ../src/common/intl.cpp:558
+#: ../src/common/intl.cpp:365
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "Không thể đặt ngôn ngữ thành \"%s\"."
 
-#: ../src/unix/threadpsx.cpp:831 ../src/msw/thread.cpp:546
+#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
 msgid "Cannot start thread: error writing TLS."
 msgstr "Không thể khởi động tuyến trình: lỗi ghi TLS."
 
-#: ../src/msw/thread.cpp:872
+#: ../src/msw/thread.cpp:864
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Không thể đình chỉ tuyến trình %lx"
 
-#: ../src/msw/thread.cpp:794
+#: ../src/msw/thread.cpp:786
 msgid "Cannot wait for thread termination"
 msgstr "Không thể chờ tuyến trình thiết bị cuối"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:75
+#: ../src/common/accelcmn.cpp:72
 #, fuzzy
 msgid "Capital"
 msgstr "Chữ viết &hoa"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:879
+#: ../src/propgrid/advprops.cpp:780
 msgid "CaptionText"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:531
 msgid "Case sensitive"
 msgstr "Phân biệt chữ HOA/thường"
 
-#: ../src/propgrid/manager.cpp:1509
+#: ../src/propgrid/manager.cpp:1527
 msgid "Categorized Mode"
 msgstr "Chế độ Cá nhân hóa"
 
-#: ../src/richtext/richtextbuffer.cpp:9968
+#: ../src/richtext/richtextbuffer.cpp:9965
 msgid "Cell Properties"
 msgstr "Các thuộc tính của ô"
 
-#: ../src/common/fmapbase.cpp:161
+#: ../src/common/fmapbase.cpp:158
 msgid "Celtic (ISO-8859-14)"
 msgstr "Celtic (ISO-8859-14)"
 
-#: ../src/richtext/richtextindentspage.cpp:160
 #: ../src/richtext/richtextliststylepage.cpp:349
+#: ../src/richtext/richtextindentspage.cpp:160
 msgid "Cen&tred"
 msgstr "&Trung tâm"
 
-#: ../src/common/stockitem.cpp:170
+#: ../src/common/stockitem.cpp:167
 msgid "Centered"
 msgstr "Trung tâm"
 
-#: ../src/common/fmapbase.cpp:149
+#: ../src/common/fmapbase.cpp:146
 msgid "Central European (ISO-8859-2)"
 msgstr "Central European (ISO-8859-2)"
 
@@ -1966,10 +1971,10 @@ msgstr "Central European (ISO-8859-2)"
 msgid "Centre"
 msgstr "Chính giữa"
 
-#: ../src/richtext/richtextindentspage.cpp:162
-#: ../src/richtext/richtextindentspage.cpp:164
 #: ../src/richtext/richtextliststylepage.cpp:351
 #: ../src/richtext/richtextliststylepage.cpp:353
+#: ../src/richtext/richtextindentspage.cpp:162
+#: ../src/richtext/richtextindentspage.cpp:164
 msgid "Centre text."
 msgstr "Chữ ở chính giữa."
 
@@ -1982,24 +1987,24 @@ msgstr "Trung tâm"
 msgid "Ch&oose..."
 msgstr "&Chọn lựa..."
 
-#: ../src/richtext/richtextbuffer.cpp:4354
+#: ../src/richtext/richtextbuffer.cpp:4351
 msgid "Change List Style"
 msgstr "Thay Đổi Kiểu Dáng List"
 
-#: ../src/richtext/richtextbuffer.cpp:3709
+#: ../src/richtext/richtextbuffer.cpp:3706
 msgid "Change Object Style"
 msgstr "Thay đổi Kiểu dáng Đối tượng"
 
-#: ../src/richtext/richtextbuffer.cpp:3982
-#: ../src/richtext/richtextbuffer.cpp:8129
+#: ../src/richtext/richtextbuffer.cpp:3979
+#: ../src/richtext/richtextbuffer.cpp:8125
 msgid "Change Properties"
 msgstr "Thay đổi các thuộc tính"
 
-#: ../src/richtext/richtextbuffer.cpp:3526
+#: ../src/richtext/richtextbuffer.cpp:3523
 msgid "Change Style"
 msgstr "Thay đổi Kiểu Dáng"
 
-#: ../src/common/fileconf.cpp:341
+#: ../src/common/fileconf.cpp:335
 #, c-format
 msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
 msgstr ""
@@ -2011,12 +2016,12 @@ msgid "Changing current directory to \"%s\" failed"
 msgstr "Tạo thư mục \"%s\" gặp lỗi"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1757
+#: ../src/propgrid/advprops.cpp:1658
 #, fuzzy
 msgid "Character"
 msgstr "&Mã ký tự:"
 
-#: ../src/richtext/richtextstyles.cpp:1063
+#: ../src/richtext/richtextstyles.cpp:1060
 msgid "Character styles"
 msgstr "Kiểu dáng ký tự"
 
@@ -2053,20 +2058,20 @@ msgstr "Kiểm tra để bao bullet bằng dấu ngoặc đơn."
 msgid "Check to indicate right-to-left text layout."
 msgstr "Bấm chọn để bố trí chữ từ phải sang trái."
 
-#: ../src/osx/carbon/fontdlg.cpp:356 ../src/osx/carbon/fontdlg.cpp:358
+#: ../src/osx/carbon/fontdlg.cpp:353 ../src/osx/carbon/fontdlg.cpp:355
 msgid "Check to make the font bold."
 msgstr "Đánh đấu kiểm để làm cho phông chữ đậm."
 
-#: ../src/osx/carbon/fontdlg.cpp:363 ../src/osx/carbon/fontdlg.cpp:365
+#: ../src/osx/carbon/fontdlg.cpp:360 ../src/osx/carbon/fontdlg.cpp:362
 msgid "Check to make the font italic."
 msgstr "Đánh đấu kiểm để làm cho phông chữ nghiêng."
 
-#: ../src/osx/carbon/fontdlg.cpp:372 ../src/osx/carbon/fontdlg.cpp:374
+#: ../src/osx/carbon/fontdlg.cpp:369 ../src/osx/carbon/fontdlg.cpp:371
 msgid "Check to make the font underlined."
 msgstr "Đánh đấu kiểm để làm cho phông chữ có gạch chân."
 
-#: ../src/richtext/richtextstyledlg.cpp:289
-#: ../src/richtext/richtextstyledlg.cpp:291
+#: ../src/richtext/richtextstyledlg.cpp:285
+#: ../src/richtext/richtextstyledlg.cpp:287
 msgid "Check to restart numbering."
 msgstr "Đánh đấu kiểm để bắt đầu đánh số."
 
@@ -2100,51 +2105,51 @@ msgstr "Đánh dấu kiểm để chữ đẩy lên."
 msgid "Check to suppress hyphenation."
 msgstr "Kiểm tra để cấm tách từ."
 
-#: ../src/msw/dialup.cpp:763
+#: ../src/msw/dialup.cpp:757
 msgid "Choose ISP to dial"
 msgstr "Chọn nhà cung cấp dịch vụ Internet ISP để quay số"
 
-#: ../src/propgrid/props.cpp:1922
+#: ../src/propgrid/props.cpp:1904
 msgid "Choose a directory:"
 msgstr "Chọn thư mục:"
 
-#: ../src/propgrid/props.cpp:1975
+#: ../src/propgrid/props.cpp:2199
 msgid "Choose a file"
 msgstr "Chọn một tập tin"
 
-#: ../src/generic/colrdlgg.cpp:158 ../src/gtk/colordlg.cpp:54
+#: ../src/generic/colrdlgg.cpp:156 ../src/gtk/colordlg.cpp:49
 msgid "Choose colour"
 msgstr "Chọn màu"
 
-#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/gtk1/fontdlg.cpp:125 ../src/generic/fontpickerg.cpp:47
+#: ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Chọn phông chữ"
 
-#: ../src/common/module.cpp:74
+#: ../src/common/module.cpp:71
 #, c-format
 msgid "Circular dependency involving module \"%s\" detected."
 msgstr "Circular dependency đòi hỏi phải tìm được mô đun \"%s\"."
 
-#: ../src/aui/tabmdi.cpp:108 ../src/generic/mdig.cpp:97
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
 msgid "Cl&ose"
 msgstr "Đón&g"
 
-#: ../src/msw/ole/automtn.cpp:684
+#: ../src/msw/ole/automtn.cpp:675
 msgid "Class not registered."
 msgstr "Lớp chưa được đăng ký."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:147 ../src/common/accelcmn.cpp:72
+#: ../src/common/stockitem.cpp:144 ../src/common/accelcmn.cpp:69
 msgid "Clear"
 msgstr "Xóa sạch"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "Clear the log contents"
 msgstr "Xóa nội dung nhật ký thông tin"
 
-#: ../src/richtext/richtextstyledlg.cpp:252
-#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:248
+#: ../src/richtext/richtextstyledlg.cpp:250
 msgid "Click to apply the selected style."
 msgstr "Bấm vào để chấp nhận kiểu dáng đã chọn."
 
@@ -2155,15 +2160,15 @@ msgstr "Bấm vào để chấp nhận kiểu dáng đã chọn."
 msgid "Click to browse for a symbol."
 msgstr "Bấm chọn để tìm duyệt ký tự đặc biệt."
 
-#: ../src/osx/carbon/fontdlg.cpp:403 ../src/osx/carbon/fontdlg.cpp:405
+#: ../src/osx/carbon/fontdlg.cpp:400 ../src/osx/carbon/fontdlg.cpp:402
 msgid "Click to cancel changes to the font."
 msgstr "Bấm vào để hủy thay đổi phông chữ."
 
-#: ../src/generic/fontdlgg.cpp:472 ../src/generic/fontdlgg.cpp:491
+#: ../src/generic/fontdlgg.cpp:468 ../src/generic/fontdlgg.cpp:487
 msgid "Click to cancel the font selection."
 msgstr "Bấm vào để hủy việc chọn phông chữ."
 
-#: ../src/osx/carbon/fontdlg.cpp:384 ../src/osx/carbon/fontdlg.cpp:386
+#: ../src/osx/carbon/fontdlg.cpp:381 ../src/osx/carbon/fontdlg.cpp:383
 msgid "Click to change the font colour."
 msgstr "Bấm vào để thay đổi màu sắc phông chữ."
 
@@ -2182,37 +2187,37 @@ msgstr "Bấm vào để thay đổi màu của chữ."
 msgid "Click to choose the font for this level."
 msgstr "Bấm vào để chọn phông chữ cho mức này."
 
-#: ../src/richtext/richtextstyledlg.cpp:279
-#: ../src/richtext/richtextstyledlg.cpp:281
+#: ../src/richtext/richtextstyledlg.cpp:275
+#: ../src/richtext/richtextstyledlg.cpp:277
 msgid "Click to close this window."
 msgstr "Bấm vào để đóng cửa sổ này."
 
-#: ../src/osx/carbon/fontdlg.cpp:410 ../src/osx/carbon/fontdlg.cpp:412
+#: ../src/osx/carbon/fontdlg.cpp:407 ../src/osx/carbon/fontdlg.cpp:409
 msgid "Click to confirm changes to the font."
 msgstr "Bấm vào để xác nhận thay đổi phông chữ."
 
-#: ../src/generic/fontdlgg.cpp:477 ../src/generic/fontdlgg.cpp:479
-#: ../src/generic/fontdlgg.cpp:484 ../src/generic/fontdlgg.cpp:486
+#: ../src/generic/fontdlgg.cpp:473 ../src/generic/fontdlgg.cpp:475
+#: ../src/generic/fontdlgg.cpp:480 ../src/generic/fontdlgg.cpp:482
 msgid "Click to confirm the font selection."
 msgstr "Bấm vào để xác nhận việc chọn phông chữ."
 
-#: ../src/richtext/richtextstyledlg.cpp:244
-#: ../src/richtext/richtextstyledlg.cpp:246
+#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:242
 msgid "Click to create a new box style."
 msgstr "Bấm vào để tạo kiểu dáng ký hộp mới."
 
-#: ../src/richtext/richtextstyledlg.cpp:226
-#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:224
 msgid "Click to create a new character style."
 msgstr "Bấm vào để tạo kiểu dáng ký tự mới."
 
-#: ../src/richtext/richtextstyledlg.cpp:238
-#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:236
 msgid "Click to create a new list style."
 msgstr "Bấm vào để tạo kiểu dáng danh sách mới."
 
-#: ../src/richtext/richtextstyledlg.cpp:232
-#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:230
 msgid "Click to create a new paragraph style."
 msgstr "Bấm vào để tạo một kiểu dáng đoạn văn mới."
 
@@ -2226,8 +2231,8 @@ msgstr "Bấm vào để tạo một vị trí tab mới."
 msgid "Click to delete all tab positions."
 msgstr "Bấm vào để xóa tất cả vị trí tab."
 
-#: ../src/richtext/richtextstyledlg.cpp:270
-#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:268
 msgid "Click to delete the selected style."
 msgstr "Bấm vào để xóa kiểu dáng đã chọn."
 
@@ -2236,25 +2241,25 @@ msgstr "Bấm vào để xóa kiểu dáng đã chọn."
 msgid "Click to delete the selected tab position."
 msgstr "Bấm vào để xóa các vị trí tab đã chọn."
 
-#: ../src/richtext/richtextstyledlg.cpp:264
-#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:262
 msgid "Click to edit the selected style."
 msgstr "Bấm vào để biên tập kiểu dáng đã chọn."
 
-#: ../src/richtext/richtextstyledlg.cpp:258
-#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:256
 msgid "Click to rename the selected style."
 msgstr "Bấm vào để đổi tên kiểu dáng đã chọn."
 
-#: ../src/generic/dbgrptg.cpp:97 ../src/generic/progdlgg.cpp:759
-#: ../src/richtext/richtextstyledlg.cpp:277
-#: ../src/richtext/richtextsymboldlg.cpp:476 ../src/common/stockitem.cpp:148
-#: ../src/msw/progdlg.cpp:170 ../src/msw/progdlg.cpp:679
-#: ../src/html/helpdlg.cpp:90
+#: ../src/common/stockitem.cpp:145 ../src/generic/dbgrptg.cpp:94
+#: ../src/generic/progdlgg.cpp:781 ../src/msw/progdlg.cpp:211
+#: ../src/msw/progdlg.cpp:946 ../src/html/helpdlg.cpp:87
+#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextstyledlg.cpp:273
 msgid "Close"
 msgstr "Đóng"
 
-#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:98
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
 msgid "Close All"
 msgstr "Đóng hết"
 
@@ -2262,43 +2267,43 @@ msgstr "Đóng hết"
 msgid "Close current document"
 msgstr "Đóng tài liệu hiện thời"
 
-#: ../src/generic/logg.cpp:516
+#: ../src/generic/logg.cpp:513
 msgid "Close this window"
 msgstr "Đóng cửa sổ này"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6006
+#: ../src/generic/datavgen.cpp:6811
 msgid "Collapse"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "Color"
 msgstr "Màu"
 
-#: ../src/richtext/richtextformatdlg.cpp:776
+#: ../src/richtext/richtextformatdlg.cpp:768
 msgid "Colour"
 msgstr "Màu sắc"
 
-#: ../src/msw/colordlg.cpp:158
+#: ../src/msw/colordlg.cpp:227
 #, c-format
 msgid "Colour selection dialog failed with error %0lx."
 msgstr "Hộp thoại chọn màu gặp lỗi %0lx."
 
-#: ../src/osx/carbon/fontdlg.cpp:380
+#: ../src/osx/carbon/fontdlg.cpp:377
 msgid "Colour:"
 msgstr "Màu sắc:"
 
-#: ../src/generic/datavgen.cpp:6077
+#: ../src/generic/datavgen.cpp:6882
 #, fuzzy, c-format
 msgid "Column %u"
 msgstr "Thêm cột"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:114
+#: ../src/common/accelcmn.cpp:112
 msgid "Command"
 msgstr ""
 
-#: ../src/common/init.cpp:196
+#: ../src/common/init.cpp:193
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
@@ -2306,12 +2311,12 @@ msgid ""
 msgstr ""
 "Tham số dòng lệnh %d không thể chuyển đổi sang Unicode và sẽ bị bỏ qua."
 
-#: ../src/msw/fontdlg.cpp:120
+#: ../src/msw/fontdlg.cpp:170
 #, c-format
 msgid "Common dialog failed with error code %0lx."
 msgstr "Hộp thoại dùng chung gặp lỗi %0lx."
 
-#: ../src/gtk/window.cpp:4649
+#: ../src/gtk/window.cpp:5653
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
@@ -2319,11 +2324,11 @@ msgstr ""
 "Sự kết hợp không được hỗ trợ bởi hệ thống này, xin hãy bật nó lên trong "
 "Window Manager."
 
-#: ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:1549
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Nén tập tin Trợ Giúp dạng HTML (*.chm)|*.chm|"
 
-#: ../src/generic/dirctrlg.cpp:444
+#: ../src/generic/dirctrlg.cpp:410
 msgid "Computer"
 msgstr "Thư mục Computer"
 
@@ -2332,53 +2337,57 @@ msgstr "Thư mục Computer"
 msgid "Config entry name cannot start with '%c'."
 msgstr "Tên mục tin cấu hình không thể bắt đầu bằng '%c'."
 
-#: ../src/generic/filedlgg.cpp:349 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
 msgid "Confirm"
 msgstr "Xác nhận"
 
-#: ../src/html/htmlwin.cpp:566
+#: ../src/html/htmlwin.cpp:569
 msgid "Connecting..."
 msgstr "Đang kết nối..."
 
-#: ../src/html/helpwnd.cpp:475
+#: ../src/html/helpwnd.cpp:473
 msgid "Contents"
 msgstr "Nội dung"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:880
+#: ../src/propgrid/advprops.cpp:781
 msgid "ControlDark"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:881
+#: ../src/propgrid/advprops.cpp:782
 msgid "ControlLight"
 msgstr ""
 
-#: ../src/common/strconv.cpp:2262
+#: ../src/common/strconv.cpp:2208
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Việc chuyển đổi bộ ký tự thành '%s' không làm việc."
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "Convert"
 msgstr "Chuyển đổi"
 
-#: ../src/html/htmlwin.cpp:1079
+#: ../src/html/htmlwin.cpp:1020
 #, c-format
 msgid "Copied to clipboard:\"%s\""
 msgstr "Đã sao chép vào clipboard:\"%s\""
 
-#: ../src/generic/prntdlgg.cpp:247
+#: ../src/generic/prntdlgg.cpp:240
 msgid "Copies:"
 msgstr "Bản sao:"
 
-#: ../src/common/stockitem.cpp:150 ../src/stc/stc_i18n.cpp:18
+#: ../src/common/stockitem.cpp:147 ../src/stc/stc_i18n.cpp:18
 msgid "Copy"
 msgstr "Chép"
 
-#: ../src/common/stockitem.cpp:258
+#: ../src/common/stockitem.cpp:255
 msgid "Copy selection"
 msgstr "Chép vùng chọn"
+
+#: ../src/generic/grid.cpp:5945
+msgid "Copying more than one selected block to clipboard is not supported."
+msgstr ""
 
 #: ../src/richtext/richtextborderspage.cpp:566
 #: ../src/richtext/richtextborderspage.cpp:601
@@ -2389,197 +2398,193 @@ msgstr "Góc"
 msgid "Corner &radius:"
 msgstr "Bán &kính góc:"
 
-#: ../src/html/chm.cpp:718
+#: ../src/html/chm.cpp:711
 #, c-format
 msgid "Could not create temporary file '%s'"
 msgstr "Không thể tạo tập tin tạm thời '%s'"
 
-#: ../src/html/chm.cpp:273
+#: ../src/html/chm.cpp:270
 #, c-format
 msgid "Could not extract %s into %s: %s"
 msgstr "Không thể rút trích %s vào trong %s: %s"
 
-#: ../src/generic/tabg.cpp:1048
+#: ../src/generic/tabg.cpp:1045
 msgid "Could not find tab for id"
 msgstr "Không thể tìm thấy tab cho id"
 
-#: ../src/gtk/notifmsg.cpp:108
-#, fuzzy
-msgid "Could not initalize libnotify."
-msgstr "Không thể đặt sự căn chỉnh."
-
-#: ../src/html/chm.cpp:444
+#: ../src/html/chm.cpp:437
 #, c-format
 msgid "Could not locate file '%s'."
 msgstr "Không thể cấp phát tập tin '%s'."
 
-#: ../src/common/filefn.cpp:1403
+#: ../src/msw/graphicsd2d.cpp:604
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/common/filefn.cpp:1291
 msgid "Could not set current working directory"
 msgstr "Không thể đặt thư mục làm việc hiện hành"
 
-#: ../src/common/prntbase.cpp:2015
+#: ../src/common/prntbase.cpp:2037
 msgid "Could not start document preview."
 msgstr "Không thể bắt đầu việc xem thử tài liệu."
 
-#: ../src/generic/printps.cpp:178 ../src/msw/printwin.cpp:210
-#: ../src/gtk/print.cpp:1132
+#: ../src/generic/printps.cpp:159 ../src/msw/printwin.cpp:184
+#: ../src/gtk/print.cpp:1129
 msgid "Could not start printing."
 msgstr "Không thể bắt đầu in."
 
-#: ../src/common/wincmn.cpp:2125
+#: ../src/common/wincmn.cpp:2126
 msgid "Could not transfer data to window"
 msgstr "Không thể truyền dữ liệu tới cửa sổ"
 
-#: ../src/msw/imaglist.cpp:187 ../src/msw/imaglist.cpp:224
-#: ../src/msw/imaglist.cpp:249 ../src/msw/dragimag.cpp:185
-#: ../src/msw/dragimag.cpp:220
+#: ../src/msw/imaglist.cpp:223 ../src/msw/imaglist.cpp:245
+#: ../src/msw/imaglist.cpp:270 ../src/msw/dragimag.cpp:182
+#: ../src/msw/dragimag.cpp:217
 msgid "Couldn't add an image to the image list."
 msgstr "Không thể thêm ảnh vào trong danh sách ảnh."
 
-#: ../src/osx/glcanvas_osx.cpp:414 ../src/unix/glx11.cpp:558
-#: ../src/msw/glcanvas.cpp:616
+#: ../src/osx/glcanvas_osx.cpp:411 ../src/msw/glcanvas.cpp:631
+#: ../src/unix/glegl.cpp:315 ../src/unix/glx11.cpp:559
 #, fuzzy
 msgid "Couldn't create OpenGL context"
 msgstr "Không tạo được một timer"
 
-#: ../src/msw/timer.cpp:134
+#: ../src/msw/timer.cpp:131
 msgid "Couldn't create a timer"
 msgstr "Không tạo được một timer"
 
-#: ../src/osx/carbon/overlay.cpp:122
-msgid "Couldn't create the overlay window"
-msgstr "Không tạo được cửa sổ xếp chồng"
-
-#: ../src/common/translation.cpp:2024
+#: ../src/common/translation.cpp:2074
 msgid "Couldn't enumerate translations"
 msgstr "Không thể liệt kê các bản dịch"
 
-#: ../src/common/dynlib.cpp:120
+#: ../src/common/dynlib.cpp:110
 #, c-format
 msgid "Couldn't find symbol '%s' in a dynamic library"
 msgstr "Không thể tìm thấy ký tự đặc biệt '%s' trong thư viện liên kết động"
 
-#: ../src/msw/thread.cpp:915
+#: ../src/msw/thread.cpp:921
 msgid "Couldn't get the current thread pointer"
 msgstr "Không thể lấy con trỏ tuyến trình hiện hành"
 
-#: ../src/osx/carbon/overlay.cpp:129
-msgid "Couldn't init the context on the overlay window"
-msgstr "Không thể khởi tạo context trên cửa sổ overlay"
-
-#: ../src/common/imaggif.cpp:244
+#: ../src/common/imaggif.cpp:241
 msgid "Couldn't initialize GIF hash table."
 msgstr "Không thể khởi tạo bảng mã băm GIF."
 
-#: ../src/common/imagpng.cpp:409
+#: ../src/common/imagpng.cpp:437
 msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
 msgstr "Không thể tải ảnh PNG- tập tin bị hỏng hay không đủ bộ nhớ."
 
-#: ../src/unix/sound.cpp:470
+#: ../src/unix/sound.cpp:459
 #, c-format
 msgid "Couldn't load sound data from '%s'."
 msgstr "Không thể tải dữ liệu âm thanh từ '%s'."
 
-#: ../src/msw/dirdlg.cpp:435
+#: ../src/msw/dirdlg.cpp:287
 msgid "Couldn't obtain folder name"
 msgstr "Không thể lấy được tên thư mục"
 
-#: ../src/unix/sound_sdl.cpp:229
+#: ../src/unix/sound_sdl.cpp:226
 #, c-format
 msgid "Couldn't open audio: %s"
 msgstr "Không mở âm thanh: %s"
 
-#: ../src/msw/ole/dataobj.cpp:377
+#: ../src/msw/ole/dataobj.cpp:385
 #, c-format
 msgid "Couldn't register clipboard format '%s'."
 msgstr "Không thể đăng ký định dạng clipboard '%s'."
 
-#: ../src/msw/listctrl.cpp:869
+#: ../src/msw/listctrl.cpp:933
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "Không thể phục hồi thông tin về điều khiển danh sách mục tin %d."
 
-#: ../src/common/imagpng.cpp:498 ../src/common/imagpng.cpp:509
-#: ../src/common/imagpng.cpp:519
+#: ../src/common/imagpng.cpp:511 ../src/common/imagpng.cpp:522
+#: ../src/common/imagpng.cpp:532
 msgid "Couldn't save PNG image."
 msgstr "Không thể ghi lại ảnh PNG."
 
-#: ../src/msw/thread.cpp:684
+#: ../src/msw/thread.cpp:676
 msgid "Couldn't terminate thread"
 msgstr "Không thể chấm dứt tuyến trình"
 
-#: ../src/common/xtistrm.cpp:166
+#: ../src/common/xtistrm.cpp:163
 #, c-format
 msgid "Create Parameter %s not found in declared RTTI Parameters"
 msgstr "Tạo Tham Số %s không tìm thấy trong khai báo Tham Số RTTI"
 
-#: ../src/generic/dirdlgg.cpp:288
+#: ../src/generic/dirdlgg.cpp:285
 msgid "Create directory"
 msgstr "Tạo thư mục"
 
-#: ../src/generic/filedlgg.cpp:212 ../src/generic/dirdlgg.cpp:111
+#: ../src/generic/filedlgg.cpp:209 ../src/generic/dirdlgg.cpp:108
 msgid "Create new directory"
 msgstr "Tạo thư mục mới"
 
-#: ../src/xrc/xmlres.cpp:2460
+#: ../src/common/stockitem.cpp:264
+#, fuzzy
+msgid "Create new document"
+msgstr "Tạo thư mục mới"
+
+#: ../src/xrc/xmlres.cpp:2515
 #, fuzzy, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Rút trích '%s' vào '%s' gặp lỗi."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1758
+#: ../src/propgrid/advprops.cpp:1659
 msgid "Cross"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:333
+#: ../src/common/accelcmn.cpp:347
 msgid "Ctrl+"
 msgstr "Ctrl+"
 
-#: ../src/richtext/richtextctrl.cpp:332 ../src/osx/textctrl_osx.cpp:576
-#: ../src/common/stockitem.cpp:151 ../src/msw/textctrl.cpp:2507
+#: ../src/osx/textctrl_osx.cpp:594 ../src/common/stockitem.cpp:148
+#: ../src/msw/textctrl.cpp:2772 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "Cắ&t"
 
-#: ../src/generic/filectrlg.cpp:940
+#: ../src/generic/filectrlg.cpp:936
 msgid "Current directory:"
 msgstr "Thư mục hiện thời:"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:896 ../src/propgrid/advprops.cpp:1574
-#: ../src/propgrid/advprops.cpp:1612
+#: ../src/propgrid/advprops.cpp:797 ../src/propgrid/advprops.cpp:1475
+#: ../src/propgrid/advprops.cpp:1518
 #, fuzzy
 msgid "Custom"
 msgstr "Cỡ riêng"
 
-#: ../src/gtk/print.cpp:217
+#: ../src/gtk/print.cpp:211
 msgid "Custom size"
 msgstr "Cỡ riêng"
 
-#: ../src/common/headerctrlcmn.cpp:60
+#: ../src/common/headerctrlcmn.cpp:58
 msgid "Customize Columns"
 msgstr "Tùy Chỉnh Số Cột"
 
-#: ../src/common/stockitem.cpp:151 ../src/stc/stc_i18n.cpp:17
+#: ../src/common/stockitem.cpp:148 ../src/stc/stc_i18n.cpp:17
 msgid "Cut"
 msgstr "Cắt"
 
-#: ../src/common/stockitem.cpp:259
+#: ../src/common/stockitem.cpp:256
 msgid "Cut selection"
 msgstr "Cắt vùng chọn"
 
-#: ../src/common/fmapbase.cpp:152
+#: ../src/common/fmapbase.cpp:149
 msgid "Cyrillic (ISO-8859-5)"
 msgstr "Cyrillic (ISO-8859-5)"
 
-#: ../src/common/paper.cpp:99
+#: ../src/common/paper.cpp:96
 msgid "D sheet, 22 x 34 in"
 msgstr "D sheet, 22 x 34 in"
 
-#: ../src/msw/dde.cpp:703
+#: ../src/msw/dde.cpp:698
 msgid "DDE poke request failed"
 msgstr "Yêu cầu poke DDE gặp lỗi"
 
-#: ../src/common/imagbmp.cpp:1169
+#: ../src/common/imagbmp.cpp:1181
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr "Phần đầu DIB: Bộ giải mã không khớp với độ sâu bit."
 
@@ -2599,7 +2604,7 @@ msgstr "Phần đầu DIB: Không rõ độ sâu bit trong tập tin."
 msgid "DIB Header: Unknown encoding in file."
 msgstr "Phần Đầu DIB: Không hiểu bộ giải mã trong tập tin."
 
-#: ../src/common/paper.cpp:121
+#: ../src/common/paper.cpp:118
 msgid "DL Envelope, 110 x 220 mm"
 msgstr "DL Envelope, 110 x 220 mm"
 
@@ -2607,55 +2612,55 @@ msgstr "DL Envelope, 110 x 220 mm"
 msgid "Dashed"
 msgstr "Đã gạch"
 
-#: ../src/generic/dbgrptg.cpp:300
+#: ../src/generic/dbgrptg.cpp:301
 #, c-format
 msgid "Debug report \"%s\""
 msgstr "Báo cáo lỗi \"%s\""
 
-#: ../src/common/debugrpt.cpp:210
+#: ../src/common/debugrpt.cpp:211
 msgid "Debug report couldn't be created."
 msgstr "Báo cáo gỡ lỗi không thể được tạo ra."
 
-#: ../src/common/debugrpt.cpp:553
+#: ../src/common/debugrpt.cpp:554
 msgid "Debug report generation has failed."
 msgstr "Việc tạo ra bản báo cáo lỗi gặp lỗi."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:84
+#: ../src/common/accelcmn.cpp:81
 msgid "Decimal"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:323
+#: ../src/generic/fontdlgg.cpp:319
 msgid "Decorative"
 msgstr "Trang trí"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1752
+#: ../src/propgrid/advprops.cpp:1653
 #, fuzzy
 msgid "Default"
 msgstr "mặc định"
 
-#: ../src/common/fmapbase.cpp:796
+#: ../src/common/fmapbase.cpp:792
 msgid "Default encoding"
 msgstr "Bộ mã mặc định"
 
-#: ../src/dfb/fontmgr.cpp:180
+#: ../src/dfb/fontmgr.cpp:177
 msgid "Default font"
 msgstr "Phông chữ mặc định"
 
-#: ../src/generic/prntdlgg.cpp:510
+#: ../src/generic/prntdlgg.cpp:503
 msgid "Default printer"
 msgstr "Máy in mặc định"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:51
+#: ../src/common/accelcmn.cpp:48
 #, fuzzy
 msgid "Del"
 msgstr "Xóa bỏ"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextbuffer.cpp:8221 ../src/common/stockitem.cpp:152
-#: ../src/common/accelcmn.cpp:50 ../src/stc/stc_i18n.cpp:20
+#: ../src/common/stockitem.cpp:149 ../src/common/accelcmn.cpp:47
+#: ../src/richtext/richtextbuffer.cpp:8217 ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Xóa bỏ"
 
@@ -2663,68 +2668,68 @@ msgstr "Xóa bỏ"
 msgid "Delete A&ll"
 msgstr "Xó&a Tất"
 
-#: ../src/richtext/richtextbuffer.cpp:11341
+#: ../src/richtext/richtextbuffer.cpp:11340
 msgid "Delete Column"
 msgstr "Xóa cột"
 
-#: ../src/richtext/richtextbuffer.cpp:11291
+#: ../src/richtext/richtextbuffer.cpp:11290
 msgid "Delete Row"
 msgstr "Xóa hàng"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 msgid "Delete Style"
 msgstr "Xóa Kiểu Dáng"
 
-#: ../src/richtext/richtextctrl.cpp:1345 ../src/richtext/richtextctrl.cpp:1584
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
 msgid "Delete Text"
 msgstr "Xóa Chữ"
 
-#: ../src/generic/editlbox.cpp:170
+#: ../src/generic/editlbox.cpp:147
 msgid "Delete item"
 msgstr "Xóa bỏ mục tin"
 
-#: ../src/common/stockitem.cpp:260
+#: ../src/common/stockitem.cpp:257
 msgid "Delete selection"
 msgstr "Xóa bỏ vùng chọn"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 #, c-format
 msgid "Delete style %s?"
 msgstr "Xóa kiểu dáng %s?"
 
-#: ../src/unix/snglinst.cpp:301
+#: ../src/unix/snglinst.cpp:298
 #, c-format
 msgid "Deleted stale lock file '%s'."
 msgstr "Xóa tập tin khóa cũ '%s'."
 
-#: ../src/common/secretstore.cpp:220
+#: ../src/common/secretstore.cpp:234
 #, fuzzy, c-format
-msgid "Deleting password for \"%s/%s\" failed: %s."
+msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Rút trích '%s' vào '%s' gặp lỗi."
 
-#: ../src/common/module.cpp:124
+#: ../src/common/module.cpp:121
 #, c-format
 msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
 msgstr "Phần phụ thuộc \"%s\" của mô đun \"%s\" chưa tồn tại."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "Descending"
 msgstr "Giảm dần"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:526 ../src/propgrid/advprops.cpp:882
+#: ../src/generic/dirctrlg.cpp:492 ../src/propgrid/advprops.cpp:783
 msgid "Desktop"
 msgstr "Thư mục Desktop"
 
-#: ../src/generic/aboutdlgg.cpp:70
+#: ../src/generic/aboutdlgg.cpp:67
 msgid "Developed by "
 msgstr "Được phát triển bởi "
 
-#: ../src/generic/aboutdlgg.cpp:176
+#: ../src/generic/aboutdlgg.cpp:173
 msgid "Developers"
 msgstr "Những người phát triển"
 
-#: ../src/msw/dialup.cpp:374
+#: ../src/msw/dialup.cpp:368
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -2732,11 +2737,11 @@ msgstr ""
 "Hàm quay số không sẵn sàng bởi vì dịch vụ truy cập từ xa (RAS) chưa được cài "
 "trong máy này. Xin hãy cài nó vào."
 
-#: ../src/generic/tipdlg.cpp:211
+#: ../src/generic/tipdlg.cpp:208
 msgid "Did you know..."
 msgstr "Bạn có biết..."
 
-#: ../src/dfb/wrapdfb.cpp:63
+#: ../src/dfb/wrapdfb.cpp:60
 #, c-format
 msgid "DirectFB error %d occurred."
 msgstr "Lỗi DirectFB %d đã xảy ra."
@@ -2745,29 +2750,29 @@ msgstr "Lỗi DirectFB %d đã xảy ra."
 msgid "Directories"
 msgstr "Thư mục"
 
-#: ../src/common/filefn.cpp:1183
+#: ../src/common/filefn.cpp:1071
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Thư mục '%s' không thể được tạo"
 
-#: ../src/common/filefn.cpp:1197
+#: ../src/common/filefn.cpp:1085
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "Thư mục '%s' không thể xóa được"
 
-#: ../src/generic/dirdlgg.cpp:204
+#: ../src/generic/dirdlgg.cpp:201
 msgid "Directory does not exist"
 msgstr "Thư mục chưa tồn tại"
 
-#: ../src/generic/filectrlg.cpp:1399
+#: ../src/generic/filectrlg.cpp:1388
 msgid "Directory doesn't exist."
 msgstr "Thư mục chưa tồn tại."
 
-#: ../src/common/docview.cpp:457
+#: ../src/common/docview.cpp:450
 msgid "Discard changes and reload the last saved version?"
 msgstr "Không dùng những thay đổi này và tải lại dữ liệu đã lưu lần trước?"
 
-#: ../src/html/helpwnd.cpp:502
+#: ../src/html/helpwnd.cpp:500
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -2775,45 +2780,45 @@ msgstr ""
 "Hiện tất cả chỉ số mục tin mà có chứa chuỗi con định sẵn. Tìm kiếm phân biệt "
 "Hoa/thường."
 
-#: ../src/html/helpwnd.cpp:679
+#: ../src/html/helpwnd.cpp:677
 msgid "Display options dialog"
 msgstr "Hiển thị hộp thoại tùy chọn"
 
-#: ../src/html/helpwnd.cpp:322
+#: ../src/html/helpwnd.cpp:320
 msgid "Displays help as you browse the books on the left."
 msgstr "Hiện phần trợ giúp như là một trình duyệt sách trên phần bên trái."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:85
+#: ../src/common/accelcmn.cpp:83
 msgid "Divide"
 msgstr ""
 
-#: ../src/common/docview.cpp:533
+#: ../src/common/docview.cpp:526
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Bạn có muốn ghi lại các thay đổi với %s không?"
 
-#: ../src/common/prntbase.cpp:542
+#: ../src/common/prntbase.cpp:537
 msgid "Document:"
 msgstr "Tài liệu:"
 
-#: ../src/generic/aboutdlgg.cpp:73
+#: ../src/generic/aboutdlgg.cpp:70
 msgid "Documentation by "
 msgstr "Viết bởi "
 
-#: ../src/generic/aboutdlgg.cpp:180
+#: ../src/generic/aboutdlgg.cpp:177
 msgid "Documentation writers"
 msgstr "Những người viết tài liệu"
 
-#: ../src/common/sizer.cpp:2799
+#: ../src/common/sizer.cpp:2916
 msgid "Don't Save"
 msgstr "Không Ghi Lại"
 
-#: ../src/html/htmlwin.cpp:633
+#: ../src/html/htmlwin.cpp:643
 msgid "Done"
 msgstr "Hoàn tất"
 
-#: ../src/generic/progdlgg.cpp:448 ../src/msw/progdlg.cpp:407
+#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
 msgid "Done."
 msgstr "Hoàn tất."
 
@@ -2825,42 +2830,42 @@ msgstr "Chấm chấm"
 msgid "Double"
 msgstr "Đôi"
 
-#: ../src/common/paper.cpp:176
+#: ../src/common/paper.cpp:173
 msgid "Double Japanese Postcard Rotated 148 x 200 mm"
 msgstr "Double Japanese Postcard Rotated 148 x 200 mm"
 
-#: ../src/common/xtixml.cpp:273
+#: ../src/common/xtixml.cpp:269
 #, c-format
 msgid "Doubly used id : %d"
 msgstr "Chỉ số id người dùng kép: %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:153
-#: ../src/common/accelcmn.cpp:64
+#: ../src/common/stockitem.cpp:150 ../src/common/accelcmn.cpp:61
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Down"
 msgstr "Xuống"
 
-#: ../src/richtext/richtextctrl.cpp:865
+#: ../src/richtext/richtextctrl.cpp:864
 msgid "Drag"
 msgstr "Kéo"
 
-#: ../src/common/paper.cpp:100
+#: ../src/common/paper.cpp:97
 msgid "E sheet, 34 x 44 in"
 msgstr "E sheet, 34 x 44 in"
 
-#: ../src/unix/fswatcher_inotify.cpp:561
+#: ../src/unix/fswatcher_inotify.cpp:558
 msgid "EOF while reading from inotify descriptor"
 msgstr "Việc đọc bộ mô tả inotify gặp lỗi EOF"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "Edit"
 msgstr "Chỉnh sửa"
 
-#: ../src/generic/editlbox.cpp:168
+#: ../src/generic/editlbox.cpp:131
 msgid "Edit item"
 msgstr "Biên tập mục tin"
 
-#: ../include/wx/generic/progdlgg.h:84
+#: ../include/wx/generic/progdlgg.h:85
 msgid "Elapsed time:"
 msgstr "Thời gian đã trôi qua:"
 
@@ -2932,63 +2937,63 @@ msgid "Enables the shadow spread."
 msgstr "Cho phép giá trị độ rộng."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:66
+#: ../src/common/accelcmn.cpp:63
 msgid "End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:55
+#: ../src/common/accelcmn.cpp:52
 #, fuzzy
 msgid "Enter"
 msgstr "Máy in"
 
-#: ../src/richtext/richtextstyledlg.cpp:934
+#: ../src/richtext/richtextstyledlg.cpp:930
 msgid "Enter a box style name"
 msgstr "Nhập vào tên kiểu dáng hộp"
 
-#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:602
 msgid "Enter a character style name"
 msgstr "Nhập vào tên kiểu dáng ký tự"
 
-#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:816
 msgid "Enter a list style name"
 msgstr "Nhập vào tên kiểu dáng danh sách"
 
-#: ../src/richtext/richtextstyledlg.cpp:893
+#: ../src/richtext/richtextstyledlg.cpp:889
 msgid "Enter a new style name"
 msgstr "Nhập vào tên kiểu dáng danh sách mới"
 
-#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:650
 msgid "Enter a paragraph style name"
 msgstr "Nhập vào tên kiểu dáng đoạn văn"
 
-#: ../src/generic/dbgrptg.cpp:174
+#: ../src/generic/dbgrptg.cpp:171
 #, c-format
 msgid "Enter command to open file \"%s\":"
 msgstr "Nhập vào lệnh mở tập tin \"%s\":"
 
-#: ../src/generic/helpext.cpp:459
+#: ../src/generic/helpext.cpp:457
 msgid "Entries found"
 msgstr "Các mục tin tìm thấy"
 
-#: ../src/common/paper.cpp:142
+#: ../src/common/paper.cpp:139
 msgid "Envelope Invite 220 x 220 mm"
 msgstr "Envelope Invite 220 x 220 mm"
 
-#: ../src/common/config.cpp:469
+#: ../src/common/config.cpp:465
 #, c-format
 msgid ""
 "Environment variables expansion failed: missing '%c' at position %u in '%s'."
 msgstr ""
 "Sự mở rộng các biến môi trường gặp lỗi: mất '%c' tại vị trí %u trong '%s'."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/generic/dirctrlg.cpp:570
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/dirctrlg.cpp:599
-#: ../src/generic/dirdlgg.cpp:323 ../src/generic/filectrlg.cpp:642
-#: ../src/generic/filectrlg.cpp:756 ../src/generic/filectrlg.cpp:770
-#: ../src/generic/filectrlg.cpp:786 ../src/generic/filectrlg.cpp:1368
-#: ../src/generic/filectrlg.cpp:1399 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/gtk1/fontdlg.cpp:74 ../src/generic/dirctrlg.cpp:536
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/dirctrlg.cpp:565
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1357 ../src/generic/filectrlg.cpp:1388
+#: ../src/generic/filedlgg.cpp:354 ../src/generic/dirdlgg.cpp:320
+#: ../src/gtk/filedlg.cpp:74
 msgid "Error"
 msgstr "Lỗi"
 
@@ -2996,234 +3001,255 @@ msgstr "Lỗi"
 msgid "Error closing epoll descriptor"
 msgstr "Lỗi khi đóng phần mô tả epoll"
 
-#: ../src/unix/fswatcher_kqueue.cpp:114
+#: ../src/unix/fswatcher_kqueue.cpp:131
 msgid "Error closing kqueue instance"
 msgstr "Lỗi khi đóng kqueue"
 
-#: ../src/common/filefn.cpp:1049
+#: ../src/common/filefn.cpp:938
 #, fuzzy, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Sao chép tập tin từ '%s' sang '%s' gặp lỗi"
 
-#: ../src/generic/dirdlgg.cpp:222
+#: ../src/generic/dirdlgg.cpp:219
 msgid "Error creating directory"
 msgstr "Lỗi tạo thư mục"
 
-#: ../src/common/imagbmp.cpp:1181
+#: ../src/common/imagbmp.cpp:1193
 msgid "Error in reading image DIB."
 msgstr "Lỗi trong việc đọc ảnh DIB."
 
-#: ../src/propgrid/propgrid.cpp:6696
+#: ../src/propgrid/propgrid.cpp:6665
 #, c-format
 msgid "Error in resource: %s"
 msgstr "Lỗi trong tài nguyên: %s"
 
-#: ../src/common/fileconf.cpp:422
+#: ../src/common/fileconf.cpp:421
 msgid "Error reading config options."
 msgstr "Lỗi trong việc đọc các tùy chọn cấu hình."
+
+#: ../src/msw/webview_ie.cpp:1057 ../src/msw/webview_edge.cpp:850
+#: ../src/gtk/webview_webkit2.cpp:1262 ../src/osx/webview_webkit.mm:383
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
 
 #: ../src/common/fileconf.cpp:1029
 msgid "Error saving user configuration data."
 msgstr "Lỗi ghi lại dữ liệu cấu hình người dùng."
 
-#: ../src/gtk/print.cpp:722
+#: ../src/gtk/print.cpp:720
 msgid "Error while printing: "
 msgstr "Lỗi trong khi in: "
 
-#: ../src/common/log.cpp:219
+#: ../src/common/log.cpp:237
 msgid "Error: "
 msgstr "Lỗi: "
 
+#: ../src/common/webrequest.cpp:98
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Lỗi: "
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:69
+#: ../src/common/accelcmn.cpp:66
 msgid "Esc"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:70
+#: ../src/common/accelcmn.cpp:67
 #, fuzzy
 msgid "Escape"
 msgstr "Nằm ngang"
 
-#: ../src/common/fmapbase.cpp:150
+#: ../src/common/fmapbase.cpp:147
 msgid "Esperanto (ISO-8859-3)"
 msgstr "Esperanto (ISO-8859-3)"
 
-#: ../include/wx/generic/progdlgg.h:85
+#: ../include/wx/generic/progdlgg.h:86
 msgid "Estimated time:"
 msgstr "Thời gian ước tính:"
 
-#: ../src/generic/dbgrptg.cpp:234
+#: ../src/generic/dbgrptg.cpp:231
 msgid "Executable files (*.exe)|*.exe|"
 msgstr "Tập tin thực thi (*.exe)|*.exe|"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:155 ../src/common/accelcmn.cpp:78
+#: ../src/common/stockitem.cpp:152 ../src/common/accelcmn.cpp:75
 msgid "Execute"
 msgstr "Thi hành"
 
-#: ../src/msw/utilsexc.cpp:876
+#: ../src/msw/utilsexc.cpp:873
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Thi hành lệnh '%s' gặp lỗi"
 
-#: ../src/common/paper.cpp:105
+#: ../src/common/paper.cpp:102
 msgid "Executive, 7 1/4 x 10 1/2 in"
 msgstr "Executive, 7 1/4 x 10 1/2 in"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6009
+#: ../src/generic/datavgen.cpp:6814
 msgid "Expand"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1240
+#: ../src/msw/registry.cpp:1228
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
 msgstr ""
 "Sự xuất khóa đăng ký: tập tin \"%s\" đã tồn tại và không thể ghi đè lên."
 
-#: ../src/common/fmapbase.cpp:195
+#: ../src/common/fmapbase.cpp:192
 msgid "Extended Unix Codepage for Japanese (EUC-JP)"
 msgstr "Extended Unix Codepage for Japanese (EUC-JP)"
 
-#: ../src/html/chm.cpp:725
+#: ../src/html/chm.cpp:718
 #, c-format
 msgid "Extraction of '%s' into '%s' failed."
 msgstr "Rút trích '%s' vào '%s' gặp lỗi."
 
-#: ../src/common/accelcmn.cpp:249 ../src/common/accelcmn.cpp:344
+#: ../src/common/accelcmn.cpp:259 ../src/common/accelcmn.cpp:358
 msgid "F"
 msgstr "F"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:672
+#: ../src/propgrid/advprops.cpp:582
 msgid "Face Name"
 msgstr "Tên Mặt"
 
-#: ../src/unix/snglinst.cpp:269
+#: ../src/unix/snglinst.cpp:266
 msgid "Failed to access lock file."
 msgstr "Truy cập tập tin khóa gặp lỗi."
+
+#: ../src/gtk/font.cpp:572
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Lỗi đọc từ tập tin \"%s\" gặp lỗi."
 
 #: ../src/unix/epolldispatcher.cpp:116
 #, c-format
 msgid "Failed to add descriptor %d to epoll descriptor %d"
 msgstr "Khi thêm phần mô tả %d vào phần mô tả epoll %d gặp lỗi"
 
-#: ../src/msw/dib.cpp:489
+#: ../src/msw/dib.cpp:535
 #, c-format
 msgid "Failed to allocate %luKb of memory for bitmap data."
 msgstr "Việc cấp phát %luKb bộ nhớ cho dữ liệu ảnh bitmap gặp lỗi."
 
-#: ../src/common/glcmn.cpp:115
+#: ../src/common/glcmn.cpp:112
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Cấp phát màu cho OpenGL gặp lỗi"
 
-#: ../src/unix/displayx11.cpp:236
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Cấp phát màu cho OpenGL gặp lỗi"
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Cấp phát màu cho OpenGL gặp lỗi"
+
+#: ../include/wx/unix/private/displayx11.h:89
 msgid "Failed to change video mode"
 msgstr "Thay đổi chế độ video gặp lỗi"
 
-#: ../src/common/image.cpp:3277
+#: ../src/common/image.cpp:3396
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Gặp lỗi khi kiểm tra định dạng của tập tin ảnh \"%s\"."
 
-#: ../src/common/debugrpt.cpp:239
+#: ../src/common/debugrpt.cpp:240
 #, c-format
 msgid "Failed to clean up debug report directory \"%s\""
 msgstr "Việc xóa sạch thư mục báo cáo lỗi \"%s\" gặp lỗi"
 
-#: ../src/common/filename.cpp:192
+#: ../src/common/filename.cpp:189
 msgid "Failed to close file handle"
 msgstr "Đóng handle tập tin gặp lỗi"
 
-#: ../src/unix/snglinst.cpp:340
+#: ../src/unix/snglinst.cpp:337
 #, c-format
 msgid "Failed to close lock file '%s'"
 msgstr "Đóng tập tin khóa '%s' gặp lỗi"
 
-#: ../src/msw/clipbrd.cpp:112
+#: ../src/msw/clipbrd.cpp:110
 msgid "Failed to close the clipboard."
 msgstr "Đóng clipboard gặp lỗi."
 
-#: ../src/x11/utils.cpp:208
+#: ../src/x11/utils.cpp:170
 #, c-format
 msgid "Failed to close the display \"%s\""
 msgstr "Đóng bộ hiển thị \"%s\" gặp lỗi"
 
-#: ../src/msw/dialup.cpp:797
+#: ../src/msw/dialup.cpp:791
 msgid "Failed to connect: missing username/password."
 msgstr "Kết nối lỗi: không có tên người dùng/mật khẩu."
 
-#: ../src/msw/dialup.cpp:743
+#: ../src/msw/dialup.cpp:737
 msgid "Failed to connect: no ISP to dial."
 msgstr "Kết nối lỗi: không có nhà cung cấp dịch vụ Internet ISP để quay số."
 
-#: ../src/common/textfile.cpp:203
-#, c-format
-msgid "Failed to convert file \"%s\" to Unicode."
-msgstr "Chuyển đổi tập tin \"%s\" sang Unicode gặp lỗi."
-
-#: ../src/generic/logg.cpp:956
+#: ../src/generic/logg.cpp:953
 msgid "Failed to copy dialog contents to the clipboard."
 msgstr "Sao chép nội dung từ hộp thoại vào bộ nhớ clipboard gặp lỗi."
 
-#: ../src/msw/registry.cpp:692
+#: ../src/msw/registry.cpp:681
 #, c-format
 msgid "Failed to copy registry value '%s'"
 msgstr "Sao chép giá trị đăng ký '%s' gặp lỗi"
 
-#: ../src/msw/registry.cpp:701
+#: ../src/msw/registry.cpp:690
 #, c-format
 msgid "Failed to copy the contents of registry key '%s' to '%s'."
 msgstr "Sao chép nội dung khóa đăng ký '%s' tới '%s' gặp lỗi."
 
-#: ../src/common/filefn.cpp:1015
+#: ../src/common/filefn.cpp:904
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Sao chép tập tin từ '%s' sang '%s' gặp lỗi"
 
-#: ../src/msw/registry.cpp:679
+#: ../src/msw/registry.cpp:668
 #, c-format
 msgid "Failed to copy the registry subkey '%s' to '%s'."
 msgstr "Sao chép khóa đăng ký phụ '%s' tới '%s' gặp lỗi."
 
-#: ../src/msw/dde.cpp:1070
+#: ../src/msw/dde.cpp:1134
 msgid "Failed to create DDE string"
 msgstr "Tạo chuỗi DDE gặp lỗi"
 
-#: ../src/msw/mdi.cpp:616
+#: ../src/msw/mdi.cpp:621
 msgid "Failed to create MDI parent frame."
 msgstr "Tạo khung cửa sổ cha MDI gặp lỗi."
 
-#: ../src/common/filename.cpp:1027
+#: ../src/common/filename.cpp:1024
 msgid "Failed to create a temporary file name"
 msgstr "Tạo tên tập tin tạm gặp lỗi"
 
-#: ../src/msw/utilsexc.cpp:228
+#: ../src/msw/utilsexc.cpp:225
 msgid "Failed to create an anonymous pipe"
 msgstr "Tạo anonymous pipe gặp lỗi"
 
-#: ../src/msw/ole/automtn.cpp:522
+#: ../src/msw/ole/automtn.cpp:513
 #, c-format
 msgid "Failed to create an instance of \"%s\""
 msgstr "Gặp lỗi khi tạo một minh dụ của \"%s\""
 
-#: ../src/msw/dde.cpp:437
+#: ../src/msw/dde.cpp:432
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "Tạo kết nối tới máy chủ '%s' với chủ đề '%s' gặp lỗi"
 
-#: ../src/msw/cursor.cpp:204
+#: ../src/msw/cursor.cpp:195
 msgid "Failed to create cursor."
 msgstr "Tạo con trỏ chuột gặp lỗi."
 
-#: ../src/common/debugrpt.cpp:209
+#: ../src/common/debugrpt.cpp:210
 #, c-format
 msgid "Failed to create directory \"%s\""
 msgstr "Tạo thư mục \"%s\" gặp lỗi"
 
-#: ../src/generic/dirdlgg.cpp:220
+#: ../src/generic/dirdlgg.cpp:217
 #, c-format
 msgid ""
 "Failed to create directory '%s'\n"
@@ -3236,115 +3262,134 @@ msgstr ""
 msgid "Failed to create epoll descriptor"
 msgstr "Tạo phần mô tả epoll gặp lỗi"
 
-#: ../src/msw/mimetype.cpp:238
+#: ../src/gtk/font.cpp:562
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "Cập nhật tập tin cấu hình gặp lỗi."
+
+#: ../src/msw/mimetype.cpp:235
 #, c-format
 msgid "Failed to create registry entry for '%s' files."
 msgstr "Tạo mục đăng ký cho '%s' tập tin gặp lỗi."
 
-#: ../src/msw/fdrepdlg.cpp:409
+#: ../src/msw/fdrepdlg.cpp:408
 #, c-format
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr "Tạo hộp thoại tìm/thay thế tiêu chuẩn gặp lỗi (mã lỗi %d)"
 
-#: ../src/unix/wakeuppipe.cpp:52
+#: ../src/unix/wakeuppipe.cpp:49
 msgid "Failed to create wake up pipe used by event loop."
 msgstr "Tạo wake up pipe sử dụng cho vòng lặp sự kiện gặp lỗi."
 
-#: ../src/html/winpars.cpp:730
+#: ../src/html/winpars.cpp:727
 #, c-format
 msgid "Failed to display HTML document in %s encoding"
 msgstr "Hiển thị tài liệu HTML trong bộ mã %s gặp lỗi"
 
-#: ../src/msw/clipbrd.cpp:124
+#: ../src/msw/clipbrd.cpp:122
 msgid "Failed to empty the clipboard."
 msgstr "Làm rỗng clipboard gặp lỗi."
 
-#: ../src/unix/displayx11.cpp:212
+#: ../include/wx/unix/private/displayx11.h:65
 msgid "Failed to enumerate video modes"
 msgstr "Đếm các chế độ video gặp lỗi"
 
-#: ../src/msw/dde.cpp:722
+#: ../src/msw/dde.cpp:717
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "Thiết lập một vòng lặp advise máy chủ DDE gặp lỗi"
 
-#: ../src/msw/dialup.cpp:629 ../src/msw/dialup.cpp:863
+#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Thiết lập kết nối quay số gặp lỗi: %s"
 
-#: ../src/unix/utilsunx.cpp:611
+#: ../src/unix/utilsunx.cpp:613
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Thực thi '%s' gặp lỗi\n"
 
-#: ../src/common/debugrpt.cpp:720
+#: ../src/common/debugrpt.cpp:730
 msgid "Failed to execute curl, please install it in PATH."
 msgstr "Thực thi curl gặp lỗi, xin thiết đặt nó trong ĐƯỜNG DẪN."
 
-#: ../src/msw/ole/automtn.cpp:505
+#: ../src/msw/ole/automtn.cpp:496
 #, c-format
 msgid "Failed to find CLSID of \"%s\""
 msgstr "Gặp lỗi khi tìm CLSID của \"%s\""
 
-#: ../src/common/regex.cpp:431 ../src/common/regex.cpp:479
+#: ../src/common/regex.cpp:428 ../src/common/regex.cpp:476
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "Việc tìm khớp với biểu thức thông thường gặp lỗi: %s"
 
-#: ../src/msw/dialup.cpp:695
+#: ../src/msw/webview_ie.cpp:978
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:689
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Lấy tên của nhà cung cấp dịch vụ Internet ISP gặp lỗi: %s"
 
-#: ../src/msw/ole/automtn.cpp:574
+#: ../src/msw/ole/automtn.cpp:565
 #, c-format
 msgid "Failed to get OLE automation interface for \"%s\""
 msgstr "Gặp lỗi khi lấy giao diện tự động OLE cho \"%s\""
 
-#: ../src/msw/clipbrd.cpp:711
+#: ../src/msw/clipbrd.cpp:731
 msgid "Failed to get data from the clipboard"
 msgstr "Lấy dữ liệu từ clipboard gặp lỗi"
 
-#: ../src/common/time.cpp:223
+#: ../src/common/time.cpp:216
 msgid "Failed to get the local system time"
 msgstr "Lấy thời gian từ hệ thống gặp lỗi"
 
-#: ../src/common/filefn.cpp:1345
+#: ../src/common/filefn.cpp:1233
 msgid "Failed to get the working directory"
 msgstr "Lấy thư mục đang làm việc gặp lỗi"
 
-#: ../src/univ/theme.cpp:114
+#: ../src/univ/theme.cpp:111
 msgid "Failed to initialize GUI: no built-in themes found."
 msgstr ""
 "Khởi tạo GUI gặp lỗi: không có built-in giao diện hiển thị nào được tìm thấy."
 
-#: ../src/msw/helpchm.cpp:63
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:60
 msgid "Failed to initialize MS HTML Help."
 msgstr "Khởi tạo Trợ Giúp MS HTML gặp lỗi."
 
-#: ../src/msw/glcanvas.cpp:1381
+#: ../src/msw/glcanvas.cpp:1391
 msgid "Failed to initialize OpenGL"
 msgstr "Khởi tạo OpenGL gặp lỗi."
 
-#: ../src/msw/dialup.cpp:858
+#: ../src/msw/dialup.cpp:852
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Khởi tạo kết nối quay số gặp lỗi: %s"
 
-#: ../src/gtk/textctrl.cpp:1128
+#: ../src/gtk/textctrl.cpp:1209
 msgid "Failed to insert text in the control."
 msgstr "Chèn chữ vào điều khiển gặp lỗi."
 
-#: ../src/unix/snglinst.cpp:241
+#: ../src/unix/snglinst.cpp:238
 #, c-format
 msgid "Failed to inspect the lock file '%s'"
 msgstr "Kiểm tra tập tin khóa '%s' gặp lỗi"
 
-#: ../src/unix/appunix.cpp:182
+#: ../src/unix/appunix.cpp:179
 msgid "Failed to install signal handler"
 msgstr "Cài đặt bộ điều khiển tín hiệu gặp lỗi"
 
-#: ../src/unix/threadpsx.cpp:1167
+#: ../src/unix/threadpsx.cpp:1216
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -3352,71 +3397,71 @@ msgstr ""
 "Gia nhập tuyến trình gặp lỗi, đã phát hiện lỗ thủng bộ nhớ tiềm tàng - xin "
 "hãy khởi động lại chương trình"
 
-#: ../src/msw/utils.cpp:629
+#: ../src/msw/utils.cpp:619
 #, c-format
 msgid "Failed to kill process %d"
 msgstr "Loại bỏ quá trình %d gặp lỗi"
 
-#: ../src/common/image.cpp:2500
+#: ../src/common/image.cpp:2595
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Gặp lỗi tải ảnh \"%s\" từ nguồn tài nguyên."
 
-#: ../src/common/image.cpp:2509
+#: ../src/common/image.cpp:2604
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Tải biểu tượng \"%s\" từ nguồn tài nguyên gặp lỗi."
 
-#: ../src/common/iconbndl.cpp:225
+#: ../src/common/iconbndl.cpp:224
 #, fuzzy, c-format
 msgid "Failed to load icons from resource '%s'."
 msgstr "Tải biểu tượng \"%s\" từ nguồn tài nguyên gặp lỗi."
 
-#: ../src/common/iconbndl.cpp:200
+#: ../src/common/iconbndl.cpp:198
 #, c-format
 msgid "Failed to load image %%d from file '%s'."
 msgstr "Tải ảnh %%d từ tập tin '%s' gặp lỗi."
 
-#: ../src/common/iconbndl.cpp:208
+#: ../src/common/iconbndl.cpp:206
 #, c-format
 msgid "Failed to load image %d from stream."
 msgstr "Lỗi khi tải ảnh %d từ dòng dữ liệu."
 
-#: ../src/common/image.cpp:2587 ../src/common/image.cpp:2606
+#: ../src/common/image.cpp:2682 ../src/common/image.cpp:2701
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Tải ảnh từ tập tin \"%s\" gặp lỗi."
 
-#: ../src/msw/enhmeta.cpp:97
+#: ../src/msw/enhmeta.cpp:94
 #, c-format
 msgid "Failed to load metafile from file \"%s\"."
 msgstr "Tải metafile từ tập tin \"%s\" gặp lỗi."
 
-#: ../src/msw/volume.cpp:327
+#: ../src/msw/volume.cpp:335
 msgid "Failed to load mpr.dll."
 msgstr "Tải thư viện mpr.dll gặp lỗi."
 
-#: ../src/msw/utils.cpp:953
+#: ../src/msw/utils.cpp:943
 #, c-format
 msgid "Failed to load resource \"%s\"."
 msgstr "Lỗi khi tải tài nguyên \"%s\"."
 
-#: ../src/common/dynlib.cpp:92
+#: ../src/common/dynlib.cpp:86
 #, c-format
 msgid "Failed to load shared library '%s'"
 msgstr "Tải thư viện chia sẻ %s gặp lỗi"
 
-#: ../src/osx/core/sound.cpp:145
+#: ../src/osx/core/sound.cpp:143
 #, fuzzy, c-format
 msgid "Failed to load sound from \"%s\" (error %d)."
 msgstr "Lỗi khi tải tài nguyên \"%s\"."
 
-#: ../src/msw/utils.cpp:960
+#: ../src/msw/utils.cpp:950
 #, c-format
 msgid "Failed to lock resource \"%s\"."
 msgstr "Lỗi khi khóa tài nguyên \"%s\"."
 
-#: ../src/unix/snglinst.cpp:198
+#: ../src/unix/snglinst.cpp:195
 #, c-format
 msgid "Failed to lock the lock file '%s'"
 msgstr "Khóa tập tin khóa %s gặp lỗi"
@@ -3426,33 +3471,38 @@ msgstr "Khóa tập tin khóa %s gặp lỗi"
 msgid "Failed to modify descriptor %d in epoll descriptor %d"
 msgstr "Chỉnh sửa phần mô tả %d trong phần mô tả epoll %d gặp lỗi"
 
-#: ../src/common/filename.cpp:2575
+#: ../src/common/filename.cpp:2658
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Chỉnh sửa thời gian tập tin '%s' gặp lỗi"
 
-#: ../src/common/selectdispatcher.cpp:258
+#: ../src/common/selectdispatcher.cpp:255
 msgid "Failed to monitor I/O channels"
 msgstr "Kênh vào ra màn hình gặp lỗi"
 
-#: ../src/common/filename.cpp:175
+#: ../src/common/filename.cpp:172
 #, c-format
 msgid "Failed to open '%s' for reading"
 msgstr "Mở '%s' để đọc gặp lỗi"
 
-#: ../src/common/filename.cpp:180
+#: ../src/common/filename.cpp:177
 #, c-format
 msgid "Failed to open '%s' for writing"
 msgstr "Mở '%s' để ghi gặp lỗi"
 
-#: ../src/html/chm.cpp:141
+#: ../src/html/chm.cpp:138
 #, c-format
 msgid "Failed to open CHM archive '%s'."
 msgstr "Mở CHM để lưu giữ '%s' gặp lỗi."
 
-#: ../src/common/utilscmn.cpp:1126
+#: ../src/common/utilscmn.cpp:1140
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Mở URL \"%s\" trong trình duyệt mặc định gặp lỗi."
+
+#: ../src/common/hyperlnkcmn.cpp:133
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Mở URL \"%s\" trong trình duyệt mặc định gặp lỗi."
 
 #: ../include/wx/msw/private/fswatcher.h:92
@@ -3460,93 +3510,103 @@ msgstr "Mở URL \"%s\" trong trình duyệt mặc định gặp lỗi."
 msgid "Failed to open directory \"%s\" for monitoring."
 msgstr "Lỗi khi mở thư mục \"%s\" để theo dõi."
 
-#: ../src/x11/utils.cpp:227
+#: ../src/x11/utils.cpp:189
 #, c-format
 msgid "Failed to open display \"%s\"."
 msgstr "Mở bộ hiển thị \"%s\" gặp lỗi."
 
-#: ../src/common/filename.cpp:1062
+#: ../src/common/filename.cpp:1059
 msgid "Failed to open temporary file."
 msgstr "Mở tập tin tạm thời gặp lỗi."
 
-#: ../src/msw/clipbrd.cpp:91
+#: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Mở clipboard gặp lỗi."
 
-#: ../src/common/translation.cpp:1184
+#: ../src/common/translation.cpp:1226
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Lỗi khi phân tích dạng thức số nhiều: '%s'"
 
-#: ../src/unix/mediactrl.cpp:1214
+#: ../src/unix/mediactrl.cpp:1239
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Gặp lỗi khi chuẩn bị phát \"%s\"."
 
-#: ../src/msw/clipbrd.cpp:600
+#: ../src/msw/clipbrd.cpp:610
 msgid "Failed to put data on the clipboard"
 msgstr "Đặt dữ liệu vào clipboard gặp lỗi"
 
-#: ../src/unix/snglinst.cpp:278
+#: ../src/unix/snglinst.cpp:275
 msgid "Failed to read PID from lock file."
 msgstr "Đọc PID từ tập tin khóa gặp lỗi."
 
-#: ../src/common/fileconf.cpp:433
+#: ../src/common/fileconf.cpp:432
 msgid "Failed to read config options."
 msgstr "Đọc cấu hình tùy chọn gặp lỗi."
 
-#: ../src/common/docview.cpp:681
+#: ../src/common/docview.cpp:676
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Lỗi đọc từ tập tin \"%s\" gặp lỗi."
 
-#: ../src/dfb/evtloop.cpp:98
+#: ../src/dfb/evtloop.cpp:99
 msgid "Failed to read event from DirectFB pipe"
 msgstr "Đọc từ ống dẫn DirectFB gặp lỗi"
 
-#: ../src/unix/wakeuppipe.cpp:120
+#: ../src/unix/wakeuppipe.cpp:117
 msgid "Failed to read from wake-up pipe"
 msgstr "Đọc từ ống dẫn wake-up gặp lỗi"
 
-#: ../src/unix/utilsunx.cpp:679
+#: ../src/common/textfile.cpp:96
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Lỗi đọc từ tập tin \"%s\" gặp lỗi."
+
+#: ../src/unix/utilsunx.cpp:681
 msgid "Failed to redirect child process input/output"
 msgstr "Chuyển hướng quá trình kết nhập/kết xuất của tiến trình con gặp lỗi"
 
-#: ../src/msw/utilsexc.cpp:701
+#: ../src/msw/utilsexc.cpp:698
 msgid "Failed to redirect the child process IO"
 msgstr "Chuyển hướng vào xử lý IO con gặp lỗi"
 
-#: ../src/msw/dde.cpp:288
+#: ../src/msw/dde.cpp:283
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Đăng ký máy chủ DDE '%s' gặp lỗi."
 
-#: ../src/common/fontmap.cpp:245
+#: ../src/gtk/font.cpp:580
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "Cập nhật tập tin cấu hình gặp lỗi."
+
+#: ../src/common/fontmap.cpp:242
 #, c-format
 msgid "Failed to remember the encoding for the charset '%s'."
 msgstr "Ghi nhớ bộ mã của bộ ký tự '%s' gặp lỗi."
 
-#: ../src/common/debugrpt.cpp:227
+#: ../src/common/debugrpt.cpp:228
 #, c-format
 msgid "Failed to remove debug report file \"%s\""
 msgstr "Gỡ bỏ tập tin báo cáo gỡ lỗi \"%s\" gặp lỗi"
 
-#: ../src/unix/snglinst.cpp:328
+#: ../src/unix/snglinst.cpp:325
 #, c-format
 msgid "Failed to remove lock file '%s'"
 msgstr "Gỡ bỏ tập tin khóa '%s' gặp lỗi"
 
-#: ../src/unix/snglinst.cpp:288
+#: ../src/unix/snglinst.cpp:285
 #, c-format
 msgid "Failed to remove stale lock file '%s'."
 msgstr "Gỡ bỏ tập tin khóa cũ '%s' gặp lỗi."
 
-#: ../src/msw/registry.cpp:529
+#: ../src/msw/registry.cpp:518
 #, c-format
 msgid "Failed to rename registry value '%s' to '%s'."
 msgstr "Đổi tên giá trị đăng ký '%s' thành '%s' gặp lỗi."
 
-#: ../src/common/filefn.cpp:1122
+#: ../src/common/filefn.cpp:1011
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -3554,118 +3614,127 @@ msgid ""
 msgstr ""
 "Đổi tên tập tin '%s' thành '%s' gặp lỗi bởi vì tập tin đích đã tồn tại rồi."
 
-#: ../src/msw/registry.cpp:634
+#: ../src/msw/registry.cpp:623
 #, c-format
 msgid "Failed to rename the registry key '%s' to '%s'."
 msgstr "Đổi tên khóa đăng ký '%s' thành '%s' gặp lỗi."
 
-#: ../src/common/filename.cpp:2671
+#: ../src/msw/webview_ie.cpp:995
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/common/filename.cpp:2754
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Khôi phục thời gian tập tin cho '%s' gặp lỗi"
 
-#: ../src/msw/dialup.cpp:468
+#: ../src/msw/dialup.cpp:462
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Khôi phục chữ của thông điệp lỗi RAS gặp lỗi"
 
-#: ../src/msw/clipbrd.cpp:748
+#: ../src/msw/clipbrd.cpp:768
 msgid "Failed to retrieve the supported clipboard formats"
 msgstr "Khôi phục định dạng clipboard được hỗ trợ gặp lỗi"
 
-#: ../src/common/docview.cpp:652
+#: ../src/common/docview.cpp:647
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Gặp lỗi khi ghi tài liệu vào tập tin \"%s\"."
 
-#: ../src/msw/dib.cpp:269
+#: ../src/msw/dib.cpp:312
 #, c-format
 msgid "Failed to save the bitmap image to file \"%s\"."
 msgstr "Ghi ảnh bitmap thành tập tin \"%s\" gặp lỗi."
 
-#: ../src/msw/dde.cpp:763
+#: ../src/msw/dde.cpp:811
 msgid "Failed to send DDE advise notification"
 msgstr "Gửi thông báo DDE advise gặp lỗi"
 
-#: ../src/common/ftp.cpp:402
+#: ../src/common/ftp.cpp:399
 #, c-format
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Đặt chế độ truyền FTP thành %s gặp lỗi."
 
-#: ../src/msw/clipbrd.cpp:427
+#: ../src/msw/clipbrd.cpp:443
 msgid "Failed to set clipboard data."
 msgstr "Đặt dữ liệu clipboard gặp lỗi."
 
-#: ../src/unix/snglinst.cpp:181
+#: ../src/unix/snglinst.cpp:178
 #, c-format
 msgid "Failed to set permissions on lock file '%s'"
 msgstr "Đặt quyền trên tập tin khóa '%s' gặp lỗi"
 
-#: ../src/unix/utilsunx.cpp:668
+#: ../src/unix/utilsunx.cpp:670
 msgid "Failed to set process priority"
 msgstr "Gặp lỗi khi đặt mức ưu tiên tuyến trình"
 
-#: ../src/common/file.cpp:559
+#: ../src/common/ffile.cpp:355 ../src/common/file.cpp:586
 msgid "Failed to set temporary file permissions"
 msgstr "Đặt quyền cho tập tin tạm gặp lỗi"
 
-#: ../src/gtk/textctrl.cpp:1072
-msgid "Failed to set text in the text control."
-msgstr "Gán văn bản vào điều khiển văn bản gặp lỗi."
-
-#: ../src/unix/threadpsx.cpp:1298
+#: ../src/unix/threadpsx.cpp:1347
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Gặp lỗi khi đặt mức tuyến trình đồng thời thành %lu"
 
-#: ../src/unix/threadpsx.cpp:1424
+#: ../src/unix/threadpsx.cpp:1473
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Đặt mức ưu tiên tuyến trình %d gặp lỗi."
 
-#: ../src/unix/utilsunx.cpp:783
+#: ../src/unix/utilsunx.cpp:785
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 "Gặp lỗi khi cài đặt đường ống không-khối (non-blocking pipe), chương trình "
 "có lẽ bị treo."
 
-#: ../src/common/fs_mem.cpp:261
+#: ../src/msw/webview_ie.cpp:987
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:256
 #, c-format
 msgid "Failed to store image '%s' to memory VFS!"
 msgstr "Lưu trữ ảnh '%s' vào bộ nhớ VFS gặp lỗi!"
 
-#: ../src/dfb/evtloop.cpp:170
+#: ../src/dfb/evtloop.cpp:171
 msgid "Failed to switch DirectFB pipe to non-blocking mode"
 msgstr ""
 "Chuyển sang chế độ từ đường ống DirectFB sang chế độ non-blocking gặp lỗi"
 
-#: ../src/unix/wakeuppipe.cpp:59
+#: ../src/unix/wakeuppipe.cpp:56
 msgid "Failed to switch wake up pipe to non-blocking mode"
 msgstr "Chuyển sang chế độ từ wake up pipe sang non-blocking gặp lỗi"
 
-#: ../src/unix/threadpsx.cpp:1605
+#: ../src/unix/threadpsx.cpp:1654
 msgid "Failed to terminate a thread."
 msgstr "Chấm dứt một tuyến trình gặp lỗi."
 
-#: ../src/msw/dde.cpp:741
+#: ../src/msw/dde.cpp:736
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "Chấm dứt vòng lặp advise với máy chủ DDE gặp lỗi"
 
-#: ../src/msw/dialup.cpp:938
+#: ../src/msw/dialup.cpp:932
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Chấm dứt kết nối quay số gặp lỗi: %s"
 
-#: ../src/common/filename.cpp:2590
+#: ../src/common/filename.cpp:2673
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Mở tập tin '%s' gặp lỗi"
 
-#: ../src/unix/snglinst.cpp:334
+#: ../src/unix/dlunix.cpp:90
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "Tải thư viện chia sẻ %s gặp lỗi"
+
+#: ../src/unix/snglinst.cpp:331
 #, c-format
 msgid "Failed to unlock lock file '%s'"
 msgstr "Không khóa tập tin khóa '%s' gặp lỗi"
 
-#: ../src/msw/dde.cpp:309
+#: ../src/msw/dde.cpp:304
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Việc bỏ đăng ký máy chủ DDE '%s' gặp lỗi"
@@ -3679,77 +3748,87 @@ msgstr "Bỏ đăng ký phần mô tả %d từ phần mô tả epoll %d gặp l
 msgid "Failed to update user configuration file."
 msgstr "Cập nhật tập tin cấu hình gặp lỗi."
 
-#: ../src/common/debugrpt.cpp:733
+#: ../src/common/debugrpt.cpp:743
 #, c-format
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Tải lên báo cáo lỗi gặp lỗi (mã lỗi %d)."
 
-#: ../src/unix/snglinst.cpp:168
+#: ../src/unix/snglinst.cpp:165
 #, c-format
 msgid "Failed to write to lock file '%s'"
 msgstr "Ghi vào tập tin khóa '%s' gặp lỗi"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:209
+#: ../src/propgrid/propgrid.cpp:190
 msgid "False"
 msgstr "Sai"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:694
+#: ../src/propgrid/advprops.cpp:604
 msgid "Family"
 msgstr "Họ"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/gtk/glcanvas.cpp:176 ../src/gtk/glcanvas.cpp:187
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Lỗi nghiêm trọng"
+
+#: ../src/common/stockitem.cpp:154
 msgid "File"
 msgstr "Tập tin"
 
-#: ../src/common/docview.cpp:669
+#: ../src/common/docview.cpp:664
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Tập tin  \"%s\" không thể mở để đọc."
 
-#: ../src/common/docview.cpp:646
+#: ../src/common/docview.cpp:641
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Tập tin  \"%s\" không thể mở để ghi."
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "Tập tin '%s' đã tồn tại. Bạn có muốn ghi đè lên nó không?"
 
-#: ../src/common/filefn.cpp:1156
+#: ../src/common/filefn.cpp:1044
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Tập tin  '%s' gỡ bỏ được"
 
-#: ../src/common/filefn.cpp:1139
+#: ../src/common/filefn.cpp:1028
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Tập tin '%s' không thể bị đổi tên '%s'"
 
-#: ../src/richtext/richtextctrl.cpp:3081 ../src/common/textcmn.cpp:953
+#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
 msgid "File couldn't be loaded."
 msgstr "Không thể tải tập tin lên."
 
-#: ../src/msw/filedlg.cpp:393
+#: ../src/msw/filedlg.cpp:414
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Hộp thoại chọn tập tin bị lỗi %0lx."
 
-#: ../src/common/docview.cpp:1789
+#: ../src/common/docview.cpp:1783
 msgid "File error"
 msgstr "Lỗi tập tin"
 
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/filectrlg.cpp:770
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/filectrlg.cpp:766
 msgid "File name exists already."
 msgstr "Tên tập tin đã tồn tại rồi."
+
+#: ../src/osx/cocoa/filedlg.mm:264
+#, fuzzy
+msgid "File type:"
+msgstr "Dạng Teletype"
 
 #: ../src/motif/filedlg.cpp:220
 msgid "Files"
 msgstr "Tập tin"
 
-#: ../src/common/filefn.cpp:1591
+#: ../src/common/filefn.cpp:1479
 #, c-format
 msgid "Files (%s)"
 msgstr "Tập tin (%s)"
@@ -3758,15 +3837,29 @@ msgstr "Tập tin (%s)"
 msgid "Filter"
 msgstr "Bộ lọc"
 
-#: ../src/common/stockitem.cpp:158 ../src/html/helpwnd.cpp:490
+#: ../src/html/helpwnd.cpp:488
 msgid "Find"
 msgstr "Tìm"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:259
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:258
+#, fuzzy
+msgid "Find in document"
+msgstr "Mở tài liệu định dạng HTML"
+
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "Find..."
+msgstr "Tìm"
+
+#: ../src/common/stockitem.cpp:156
 msgid "First"
 msgstr "Đầu tiên"
 
-#: ../src/common/prntbase.cpp:1548
+#: ../src/common/prntbase.cpp:1573
 msgid "First page"
 msgstr "Trang đầu"
 
@@ -3774,11 +3867,11 @@ msgstr "Trang đầu"
 msgid "Fixed"
 msgstr "Cố định"
 
-#: ../src/html/helpwnd.cpp:1206
+#: ../src/html/helpwnd.cpp:1204
 msgid "Fixed font:"
 msgstr "Phông chữ cố định:"
 
-#: ../src/html/helpwnd.cpp:1269
+#: ../src/html/helpwnd.cpp:1267
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Kích thước bình thường.<br> <b>đậm</b> <i>nghiêng</i> "
 
@@ -3786,16 +3879,16 @@ msgstr "Kích thước bình thường.<br> <b>đậm</b> <i>nghiêng</i> "
 msgid "Floating"
 msgstr "Trôi nổi"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "Floppy"
 msgstr "Đĩa mềm"
 
-#: ../src/common/paper.cpp:111
+#: ../src/common/paper.cpp:108
 msgid "Folio, 8 1/2 x 13 in"
 msgstr "Folio, 8 1/2 x 13 in"
 
-#: ../src/richtext/richtextformatdlg.cpp:344 ../src/osx/carbon/fontdlg.cpp:287
-#: ../src/common/stockitem.cpp:194
+#: ../src/osx/carbon/fontdlg.cpp:284 ../src/common/stockitem.cpp:191
+#: ../src/richtext/richtextformatdlg.cpp:337
 msgid "Font"
 msgstr "Phông chữ"
 
@@ -3803,7 +3896,24 @@ msgstr "Phông chữ"
 msgid "Font &weight:"
 msgstr "Độ đậm phông &chữ"
 
-#: ../src/html/helpwnd.cpp:1207
+#: ../src/osx/fontutil.cpp:89
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
+"\"."
+msgstr ""
+
+#: ../src/msw/font.cpp:1126
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Không thể tải tập tin lên."
+
+#: ../src/osx/fontutil.cpp:81
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "Tập tin %s chưa tồn tại."
+
+#: ../src/html/helpwnd.cpp:1205
 msgid "Font size:"
 msgstr "Cỡ phông chữ:"
 
@@ -3811,53 +3921,53 @@ msgstr "Cỡ phông chữ:"
 msgid "Font st&yle:"
 msgstr "Kiể&u dáng phông chữ:"
 
-#: ../src/osx/carbon/fontdlg.cpp:329
+#: ../src/osx/carbon/fontdlg.cpp:326
 msgid "Font:"
 msgstr "Phông chữ:"
 
-#: ../src/dfb/fontmgr.cpp:198
+#: ../src/dfb/fontmgr.cpp:195
 #, c-format
 msgid "Fonts index file %s disappeared while loading fonts."
 msgstr "Tập tin chỉ số phông chữ %s bị mất khi đang tải lên."
 
-#: ../src/unix/utilsunx.cpp:645
+#: ../src/unix/utilsunx.cpp:647
 msgid "Fork failed"
 msgstr "Gặp lỗi khi rẽ nhánh tiến trình"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "Forward"
 msgstr "Chuyển tiếp"
 
-#: ../src/common/xtixml.cpp:235
+#: ../src/common/xtixml.cpp:231
 msgid "Forward hrefs are not supported"
 msgstr "Liên kết tiến tới chưa được hỗ trợ"
 
-#: ../src/html/helpwnd.cpp:875
+#: ../src/html/helpwnd.cpp:873
 #, c-format
 msgid "Found %i matches"
 msgstr "Tìm thấy %i cái khớp"
 
-#: ../src/generic/prntdlgg.cpp:238
+#: ../src/generic/prntdlgg.cpp:231
 msgid "From:"
 msgstr "Từ :"
 
-#: ../src/propgrid/advprops.cpp:1604
+#: ../src/propgrid/advprops.cpp:1510
 msgid "Fuchsia"
 msgstr ""
 
-#: ../src/common/imaggif.cpp:138
+#: ../src/common/imaggif.cpp:135
 msgid "GIF: data stream seems to be truncated."
 msgstr "GIF: dòng dữ liệu dường như bị cắt xén."
 
-#: ../src/common/imaggif.cpp:128
+#: ../src/common/imaggif.cpp:125
 msgid "GIF: error in GIF image format."
 msgstr "GIF: lỗi trong định dạng ảnh GIF."
 
-#: ../src/common/imaggif.cpp:133
+#: ../src/common/imaggif.cpp:130
 msgid "GIF: not enough memory."
 msgstr "GIF: không có đủ bộ nhớ."
 
-#: ../src/gtk/window.cpp:4631
+#: ../src/gtk/window.cpp:5635
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -3865,23 +3975,23 @@ msgstr ""
 "GTK+ đã cài đặt trên máy này quá cũ để nó có thể hỗ trợ ghép màn hình, hãy "
 "cài GTK+ 2.12 hay mới hơn."
 
-#: ../src/univ/themes/gtk.cpp:525
+#: ../src/univ/themes/gtk.cpp:522
 msgid "GTK+ theme"
 msgstr "Giao diện hiển thị GTK+"
 
-#: ../src/common/preferencescmn.cpp:40
+#: ../src/common/preferencescmn.cpp:37
 msgid "General"
 msgstr "Chung"
 
-#: ../src/common/prntbase.cpp:258
+#: ../src/common/prntbase.cpp:253
 msgid "Generic PostScript"
 msgstr "Generic PostScript"
 
-#: ../src/common/paper.cpp:135
+#: ../src/common/paper.cpp:132
 msgid "German Legal Fanfold, 8 1/2 x 13 in"
 msgstr "German Legal Fanfold, 8 1/2 x 13 in"
 
-#: ../src/common/paper.cpp:134
+#: ../src/common/paper.cpp:131
 msgid "German Std Fanfold, 8 1/2 x 12 in"
 msgstr "German Std Fanfold, 8 1/2 x 12 in"
 
@@ -3897,49 +4007,49 @@ msgstr "GetPropertyCollection được gọi bởi một bộ truy cập chung"
 msgid "GetPropertyCollection called w/o valid collection getter"
 msgstr "GetPropertyCollection được gọi bởi bộ nhận thu thập w/o hợp lệ"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:658
 msgid "Go back"
 msgstr "Đi lùi"
 
-#: ../src/html/helpwnd.cpp:661
+#: ../src/html/helpwnd.cpp:659
 msgid "Go forward"
 msgstr "Đi tiếp"
 
-#: ../src/html/helpwnd.cpp:663
+#: ../src/html/helpwnd.cpp:661
 msgid "Go one level up in document hierarchy"
 msgstr "Tăng một cấp trong thứ bậc tài liệu"
 
-#: ../src/generic/filedlgg.cpp:208 ../src/generic/dirdlgg.cpp:116
+#: ../src/generic/filedlgg.cpp:205 ../src/generic/dirdlgg.cpp:113
 msgid "Go to home directory"
 msgstr "Chuyển sang thư mục gốc(home)"
 
-#: ../src/generic/filedlgg.cpp:205
+#: ../src/generic/filedlgg.cpp:202
 msgid "Go to parent directory"
 msgstr "Chuyển sang thư mục cha"
 
-#: ../src/generic/aboutdlgg.cpp:76
+#: ../src/generic/aboutdlgg.cpp:73
 msgid "Graphics art by "
 msgstr "Đồ họa bởi "
 
-#: ../src/propgrid/advprops.cpp:1599
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Gray"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:883
+#: ../src/propgrid/advprops.cpp:784
 msgid "GrayText"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:154
+#: ../src/common/fmapbase.cpp:151
 msgid "Greek (ISO-8859-7)"
 msgstr "Greek (ISO-8859-7)"
 
-#: ../src/propgrid/advprops.cpp:1600
+#: ../src/propgrid/advprops.cpp:1506
 #, fuzzy
 msgid "Green"
 msgstr "MacGreek"
 
-#: ../src/generic/colrdlgg.cpp:342
+#: ../src/generic/colrdlgg.cpp:362
 #, fuzzy
 msgid "Green:"
 msgstr "MacGreek"
@@ -3948,109 +4058,109 @@ msgstr "MacGreek"
 msgid "Groove"
 msgstr "Khía"
 
-#: ../src/common/zstream.cpp:158 ../src/common/zstream.cpp:318
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
 msgid "Gzip not supported by this version of zlib"
 msgstr "Gzip không được hỗ trợ bởi phiên bản này của zlib"
 
-#: ../src/html/helpwnd.cpp:1549
+#: ../src/html/helpwnd.cpp:1547
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "HTML Đề án Trợ giúp (*.hhp)|*.hhp|"
 
-#: ../src/html/htmlwin.cpp:681
+#: ../src/html/htmlwin.cpp:691
 #, c-format
 msgid "HTML anchor %s does not exist."
 msgstr "Điểm neo HTML %s không tồn tại."
 
-#: ../src/html/helpwnd.cpp:1547
+#: ../src/html/helpwnd.cpp:1545
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "Tập tin HTML (*.html;*.htm)|*.html;*.htm|"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1759
+#: ../src/propgrid/advprops.cpp:1660
 msgid "Hand"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "Harddisk"
 msgstr "Đĩa cứng"
 
-#: ../src/common/fmapbase.cpp:155
+#: ../src/common/fmapbase.cpp:152
 msgid "Hebrew (ISO-8859-8)"
 msgstr "Hebrew (ISO-8859-8)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:280 ../src/osx/button_osx.cpp:39
-#: ../src/common/stockitem.cpp:163 ../src/common/accelcmn.cpp:80
-#: ../src/html/helpdlg.cpp:66 ../src/html/helpfrm.cpp:111
+#: ../include/wx/msgdlg.h:282 ../src/osx/button_osx.cpp:39
+#: ../src/common/stockitem.cpp:160 ../src/common/accelcmn.cpp:77
+#: ../src/html/helpfrm.cpp:108 ../src/html/helpdlg.cpp:63
 msgid "Help"
 msgstr "Trợ giúp"
 
-#: ../src/html/helpwnd.cpp:1200
+#: ../src/html/helpwnd.cpp:1198
 msgid "Help Browser Options"
 msgstr "Các tùy chọn Duyệt Trợ Giúp"
 
-#: ../src/generic/helpext.cpp:454 ../src/generic/helpext.cpp:455
+#: ../src/generic/helpext.cpp:452 ../src/generic/helpext.cpp:453
 msgid "Help Index"
 msgstr "Mục lục Trợ Giúp"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1529
 msgid "Help Printing"
 msgstr "Trợ Giúp In Ấn"
 
-#: ../src/html/helpwnd.cpp:801
+#: ../src/html/helpwnd.cpp:799
 msgid "Help Topics"
 msgstr "Trợ Giúp Theo Chủ Đề..."
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1546
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Sách trợ giúp (*.htb)|*.htb|Sách trợ giúp (*.zip)|*.zip|"
 
-#: ../src/generic/helpext.cpp:267
+#: ../src/generic/helpext.cpp:265
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "Không tìm thấy thư mục trợ giúp \"%s\"."
 
-#: ../src/generic/helpext.cpp:275
+#: ../src/generic/helpext.cpp:273
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "Tập tin trợ giúp \"%s\" không tìm thấy."
 
-#: ../src/html/helpctrl.cpp:63
+#: ../src/html/helpctrl.cpp:59
 #, c-format
 msgid "Help: %s"
 msgstr "Trợ giúp: %s"
 
-#: ../src/osx/menu_osx.cpp:577
+#: ../src/osx/menu_osx.cpp:469
 #, c-format
 msgid "Hide %s"
 msgstr "Ẩn %s"
 
-#: ../src/osx/menu_osx.cpp:579
+#: ../src/osx/menu_osx.cpp:471
 msgid "Hide Others"
 msgstr "Các thứ khác ẩn"
 
-#: ../src/generic/infobar.cpp:84
+#: ../src/generic/infobar.cpp:81
 msgid "Hide this notification message."
 msgstr "Tắt phần thông báo."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:884
+#: ../src/propgrid/advprops.cpp:785
 #, fuzzy
 msgid "Highlight"
 msgstr "ánh sáng"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:885
+#: ../src/propgrid/advprops.cpp:786
 #, fuzzy
 msgid "HighlightText"
 msgstr "Canh lề chữ phải."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:164 ../src/common/accelcmn.cpp:65
+#: ../src/common/stockitem.cpp:161 ../src/common/accelcmn.cpp:62
 msgid "Home"
 msgstr "Thư mục Home"
 
-#: ../src/generic/dirctrlg.cpp:524
+#: ../src/generic/dirctrlg.cpp:490
 msgid "Home directory"
 msgstr "Thư mục Home"
 
@@ -4060,55 +4170,55 @@ msgid "How the object will float relative to the text."
 msgstr "Để thấy đối tượng sẽ trôi nổi liên quan đến chữ."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1760
+#: ../src/propgrid/advprops.cpp:1661
 msgid "I-Beam"
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1196
+#: ../src/common/imagbmp.cpp:1208
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: Lỗi trong việc đọc mặt nạ DIB."
 
-#: ../src/common/imagbmp.cpp:1290 ../src/common/imagbmp.cpp:1390
-#: ../src/common/imagbmp.cpp:1405 ../src/common/imagbmp.cpp:1416
-#: ../src/common/imagbmp.cpp:1430 ../src/common/imagbmp.cpp:1478
-#: ../src/common/imagbmp.cpp:1493 ../src/common/imagbmp.cpp:1507
-#: ../src/common/imagbmp.cpp:1518
+#: ../src/common/imagbmp.cpp:1302 ../src/common/imagbmp.cpp:1402
+#: ../src/common/imagbmp.cpp:1417 ../src/common/imagbmp.cpp:1428
+#: ../src/common/imagbmp.cpp:1442 ../src/common/imagbmp.cpp:1490
+#: ../src/common/imagbmp.cpp:1505 ../src/common/imagbmp.cpp:1519
+#: ../src/common/imagbmp.cpp:1530
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: Lỗi khi đang ghi tập tin ảnh!"
 
-#: ../src/common/imagbmp.cpp:1255
+#: ../src/common/imagbmp.cpp:1267
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: Ảnh quá cao đối với biểu tượng."
 
-#: ../src/common/imagbmp.cpp:1263
+#: ../src/common/imagbmp.cpp:1275
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: Ảnh quá rộng đối với biểu tượng."
 
-#: ../src/common/imagbmp.cpp:1603
+#: ../src/common/imagbmp.cpp:1615
 msgid "ICO: Invalid icon index."
 msgstr "ICO: Chỉ mục biểu tượng không hợp lệ."
 
-#: ../src/common/imagiff.cpp:758
+#: ../src/common/imagiff.cpp:755
 msgid "IFF: data stream seems to be truncated."
 msgstr "IFF: dòng dữ liệu dường như bị cắt xén."
 
-#: ../src/common/imagiff.cpp:742
+#: ../src/common/imagiff.cpp:739
 msgid "IFF: error in IFF image format."
 msgstr "IFF: lỗi trong định dạng ảnh IFF."
 
-#: ../src/common/imagiff.cpp:745
+#: ../src/common/imagiff.cpp:742
 msgid "IFF: not enough memory."
 msgstr "IFF: không có đủ bộ nhớ."
 
-#: ../src/common/imagiff.cpp:748
+#: ../src/common/imagiff.cpp:745
 msgid "IFF: unknown error!!!"
 msgstr "IFF: lỗi không rõ!!!"
 
-#: ../src/common/fmapbase.cpp:197
+#: ../src/common/fmapbase.cpp:194
 msgid "ISO-2022-JP"
 msgstr "ISO-2022-JP"
 
-#: ../src/html/htmprint.cpp:282
+#: ../src/html/htmprint.cpp:294
 msgid ""
 "If possible, try changing the layout parameters to make the printout more "
 "narrow."
@@ -4116,7 +4226,7 @@ msgstr ""
 "Nếu có thể, hay thử thay đổi cách bố trí các tham số để mà in ra nhiều mũi "
 "tên hơn."
 
-#: ../src/generic/dbgrptg.cpp:358
+#: ../src/generic/dbgrptg.cpp:362
 msgid ""
 "If you have any additional information pertaining to this bug\n"
 "report, please enter it here and it will be joined to it:"
@@ -4137,48 +4247,52 @@ msgstr ""
 "do đó\n"
 "nếu có thể xin hãy tiếp tục việc báo cáo với chúng tôi.\n"
 
-#: ../src/msw/registry.cpp:1405
+#: ../src/common/zipstrm.cpp:1043
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1393
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Bỏ qua giá trị \"%s\" của khóa \"%s\"."
 
-#: ../src/common/xtistrm.cpp:295
+#: ../src/common/xtistrm.cpp:292
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 
-#: ../src/common/xti.cpp:513
+#: ../src/common/xti.cpp:510
 msgid "Illegal Parameter Count for ConstructObject Method"
 msgstr ""
 "Tham số Số lượng không hợp lệ cho Phương thức ConstructObject (khởi tạo đối "
 "tượng, hay cấu tử)"
 
-#: ../src/common/xti.cpp:501
+#: ../src/common/xti.cpp:498
 msgid "Illegal Parameter Count for Create Method"
 msgstr "Tham số Số lượng không hợp lệ cho Phương thức Tạo"
 
-#: ../src/generic/dirctrlg.cpp:570 ../src/generic/filectrlg.cpp:756
+#: ../src/generic/dirctrlg.cpp:536 ../src/generic/filectrlg.cpp:752
 msgid "Illegal directory name."
 msgstr "Tên thư mục không hợp lệ."
 
-#: ../src/generic/filectrlg.cpp:1367
+#: ../src/generic/filectrlg.cpp:1356
 msgid "Illegal file specification."
 msgstr "Chi tiết tập tin không hợp lệ."
 
-#: ../src/common/image.cpp:2269
+#: ../src/common/image.cpp:2363
 msgid "Image and mask have different sizes."
 msgstr "Ảnh và mặt nạ có sự khác biệt kích thước."
 
-#: ../src/common/image.cpp:2746
+#: ../src/common/image.cpp:2841
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "Tập tin ảnh không thuộc kiểu %d."
 
-#: ../src/common/image.cpp:2877
+#: ../src/common/image.cpp:2995
 #, c-format
 msgid "Image is not of type %s."
 msgstr "Ảnh không thuộc kiểu %s."
 
-#: ../src/msw/textctrl.cpp:488
+#: ../src/msw/textctrl.cpp:534
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -4186,102 +4300,102 @@ msgstr ""
 "Không thể nào khởi tạo điều khiển văn bản (rich edit), đang sử dụng điều "
 "khiển văn bản đơn giản để thay thế. Xin hãy cài lại riched32.dll"
 
-#: ../src/unix/utilsunx.cpp:301
+#: ../src/unix/utilsunx.cpp:303
 msgid "Impossible to get child process input"
 msgstr "Không thể lấy đầu vào của tiến trình con"
 
-#: ../src/common/filefn.cpp:1028
+#: ../src/common/filefn.cpp:917
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Không thể nào lấy được quyền cho tập tin '%s'"
 
-#: ../src/common/filefn.cpp:1042
+#: ../src/common/filefn.cpp:931
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Không thể xảy ra việc ghi đè lên tập tin '%s'"
 
-#: ../src/common/filefn.cpp:1097
+#: ../src/common/filefn.cpp:986
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Không thể nào đặt được quyền cho tập tin '%s'"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:886
+#: ../src/propgrid/advprops.cpp:787
 #, fuzzy
 msgid "InactiveBorder"
 msgstr "Viền"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:887
+#: ../src/propgrid/advprops.cpp:788
 msgid "InactiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:888
+#: ../src/propgrid/advprops.cpp:789
 msgid "InactiveCaptionText"
 msgstr ""
 
-#: ../src/common/gifdecod.cpp:792
+#: ../src/common/gifdecod.cpp:826
 #, c-format
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "Frame của ảnh  GIF (%u, %d) cho frame #%u không đúng"
 
-#: ../src/msw/ole/automtn.cpp:635
+#: ../src/msw/ole/automtn.cpp:626
 msgid "Incorrect number of arguments."
 msgstr "Số lượng đối số không đúng."
 
-#: ../src/common/stockitem.cpp:165
+#: ../src/common/stockitem.cpp:162
 msgid "Indent"
 msgstr "Thụt lề"
 
-#: ../src/richtext/richtextformatdlg.cpp:349
+#: ../src/richtext/richtextformatdlg.cpp:342
 msgid "Indents && Spacing"
 msgstr "Thụt lề && Khoảng Trắng"
 
-#: ../src/common/stockitem.cpp:166 ../src/html/helpwnd.cpp:515
+#: ../src/common/stockitem.cpp:163 ../src/html/helpwnd.cpp:513
 msgid "Index"
 msgstr "Chỉ mục"
 
-#: ../src/common/fmapbase.cpp:159
+#: ../src/common/fmapbase.cpp:156
 msgid "Indian (ISO-8859-12)"
 msgstr "Ấn Độ (ISO-8859-12)"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "Info"
 msgstr "Thông tin"
 
-#: ../src/common/init.cpp:287
+#: ../src/common/init.cpp:284
 msgid "Initialization failed in post init, aborting."
 msgstr "Khởi tạo lỗi trong việc post init, đang bãi bỏ."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:54
+#: ../src/common/accelcmn.cpp:51
 #, fuzzy
 msgid "Ins"
 msgstr "Chèn"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextsymboldlg.cpp:472 ../src/common/accelcmn.cpp:53
+#: ../src/common/accelcmn.cpp:50 ../src/richtext/richtextsymboldlg.cpp:469
 msgid "Insert"
 msgstr "Chèn"
 
-#: ../src/richtext/richtextbuffer.cpp:8067
+#: ../src/richtext/richtextbuffer.cpp:8063
 msgid "Insert Field"
 msgstr "Chèn trường"
 
-#: ../src/richtext/richtextbuffer.cpp:7978
-#: ../src/richtext/richtextbuffer.cpp:8936
+#: ../src/richtext/richtextbuffer.cpp:7974
+#: ../src/richtext/richtextbuffer.cpp:8934
 msgid "Insert Image"
 msgstr "Chèn Ảnh"
 
-#: ../src/richtext/richtextbuffer.cpp:8025
+#: ../src/richtext/richtextbuffer.cpp:8021
 msgid "Insert Object"
 msgstr "Chèn Đối tượng"
 
-#: ../src/richtext/richtextctrl.cpp:1286 ../src/richtext/richtextctrl.cpp:1494
-#: ../src/richtext/richtextbuffer.cpp:7822
-#: ../src/richtext/richtextbuffer.cpp:7852
-#: ../src/richtext/richtextbuffer.cpp:7894
+#: ../src/richtext/richtextbuffer.cpp:7818
+#: ../src/richtext/richtextbuffer.cpp:7848
+#: ../src/richtext/richtextbuffer.cpp:7890
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
 msgid "Insert Text"
 msgstr "Chèn Chữ"
 
@@ -4294,16 +4408,11 @@ msgstr "Chèn ngắt trang trước một đoạn văn."
 msgid "Inset"
 msgstr "Chèn"
 
-#: ../src/gtk/app.cpp:425
-#, c-format
-msgid "Invalid GTK+ command line option, use \"%s --help\""
-msgstr "Tùy chọn dòng lệnh GTK+ không hợp lệ, sử dụng \"%s --help\""
-
-#: ../src/common/imagtiff.cpp:311
+#: ../src/common/imagtiff.cpp:308
 msgid "Invalid TIFF image index."
 msgstr "Chỉ mục ảnh TIFF không hợp lệ."
 
-#: ../src/common/appcmn.cpp:273
+#: ../src/common/appcmn.cpp:294
 #, c-format
 msgid "Invalid display mode specification '%s'."
 msgstr "Chi tiết chế độ hiển thị '%s' không hợp lệ."
@@ -4313,259 +4422,263 @@ msgstr "Chi tiết chế độ hiển thị '%s' không hợp lệ."
 msgid "Invalid geometry specification '%s'"
 msgstr "Chi tiết hình học '%s' không hợp lệ"
 
-#: ../src/unix/fswatcher_inotify.cpp:323
+#: ../src/unix/fswatcher_inotify.cpp:320
 #, c-format
 msgid "Invalid inotify event for \"%s\""
 msgstr "Sự kiện inotify (theo dõi tập tin) dành cho \"%s\" không hợp lệ"
 
-#: ../src/unix/snglinst.cpp:312
+#: ../src/unix/snglinst.cpp:309
 #, c-format
 msgid "Invalid lock file '%s'."
 msgstr "Tập tin khóa '%s' không hợp lệ."
 
-#: ../src/common/translation.cpp:1125
+#: ../src/common/translation.cpp:1167
 msgid "Invalid message catalog."
 msgstr "Catalog không hợp lệ."
 
-#: ../src/common/xtistrm.cpp:405 ../src/common/xtistrm.cpp:420
+#: ../src/common/xtistrm.cpp:402 ../src/common/xtistrm.cpp:417
 msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
 msgstr "Không hợp lệ hay Null Object ID được chuyển tới GetObjectClassInfo"
 
-#: ../src/common/xtistrm.cpp:435
+#: ../src/common/xtistrm.cpp:432
 msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
 msgstr "Không hợp lệ hay Null Object ID được chuyển tới HasObjectClassInfo"
 
-#: ../src/common/regex.cpp:310
+#: ../src/common/regex.cpp:307
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Biểu thức thông thường '%s' không hợp lệ: %s"
 
-#: ../src/common/config.cpp:226
+#: ../src/common/config.cpp:222
 #, c-format
 msgid "Invalid value %ld for a boolean key \"%s\" in config file."
 msgstr ""
 "Giá trị %ld không hợp lệ cho một khoá thuộc kiểu lôgíc \"%s\" trong tập tin "
 "dùng cho cấu hình."
 
-#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:351
-#: ../src/osx/carbon/fontdlg.cpp:361 ../src/common/stockitem.cpp:168
+#: ../src/osx/carbon/fontdlg.cpp:358 ../src/common/stockitem.cpp:165
+#: ../src/generic/fontdlgg.cpp:325 ../src/richtext/richtextfontpage.cpp:351
 msgid "Italic"
 msgstr "Nghiêng"
 
-#: ../src/common/paper.cpp:130
+#: ../src/common/paper.cpp:127
 msgid "Italy Envelope, 110 x 230 mm"
 msgstr "Phong bì Ý, 110 x 230 mm"
 
-#: ../src/common/imagjpeg.cpp:270
+#: ../src/common/imagjpeg.cpp:257
 msgid "JPEG: Couldn't load - file is probably corrupted."
 msgstr "JPEG: Không thể tải - tập tin hầu như chắc chắn đã sai hỏng."
 
-#: ../src/common/imagjpeg.cpp:449
+#: ../src/common/imagjpeg.cpp:436
 msgid "JPEG: Couldn't save image."
 msgstr "JPEG: Không thể ghi lại ảnh."
 
-#: ../src/common/paper.cpp:163
+#: ../src/common/paper.cpp:160
 msgid "Japanese Double Postcard 200 x 148 mm"
 msgstr "Japanese Double Postcard 200 x 148 mm"
 
-#: ../src/common/paper.cpp:167
+#: ../src/common/paper.cpp:164
 msgid "Japanese Envelope Chou #3"
 msgstr "Japanese Envelope Chou #3"
 
-#: ../src/common/paper.cpp:180
+#: ../src/common/paper.cpp:177
 msgid "Japanese Envelope Chou #3 Rotated"
 msgstr "Phong bì Nhật Bản Chou #3 Rotated"
 
-#: ../src/common/paper.cpp:168
+#: ../src/common/paper.cpp:165
 msgid "Japanese Envelope Chou #4"
 msgstr "Phong bì Nhật Bản Chou #4"
 
-#: ../src/common/paper.cpp:181
+#: ../src/common/paper.cpp:178
 msgid "Japanese Envelope Chou #4 Rotated"
 msgstr "Phong bì Nhật Bản Chou #4 Rotated"
 
-#: ../src/common/paper.cpp:165
+#: ../src/common/paper.cpp:162
 msgid "Japanese Envelope Kaku #2"
 msgstr "Phong bì Nhật Bản Kaku #2"
 
-#: ../src/common/paper.cpp:178
+#: ../src/common/paper.cpp:175
 msgid "Japanese Envelope Kaku #2 Rotated"
 msgstr "Phong bì Nhật Bản Kaku #2 Rotated"
 
-#: ../src/common/paper.cpp:166
+#: ../src/common/paper.cpp:163
 msgid "Japanese Envelope Kaku #3"
 msgstr "Phong bì Nhật Bản Kaku #3"
 
-#: ../src/common/paper.cpp:179
+#: ../src/common/paper.cpp:176
 msgid "Japanese Envelope Kaku #3 Rotated"
 msgstr "Phong bì Nhật Bản Kaku #3 Rotated"
 
-#: ../src/common/paper.cpp:185
+#: ../src/common/paper.cpp:182
 msgid "Japanese Envelope You #4"
 msgstr "Phong bì Nhật Bản You #4"
 
-#: ../src/common/paper.cpp:186
+#: ../src/common/paper.cpp:183
 msgid "Japanese Envelope You #4 Rotated"
 msgstr "Phong bì Nhật Bản You #4 Rotated"
 
-#: ../src/common/paper.cpp:138
+#: ../src/common/paper.cpp:135
 msgid "Japanese Postcard 100 x 148 mm"
 msgstr "Bưu Thiếp Kiểu Nhật Bản 100 x 148 mm"
 
-#: ../src/common/paper.cpp:175
+#: ../src/common/paper.cpp:172
 msgid "Japanese Postcard Rotated 148 x 100 mm"
 msgstr "Bưu Thiếp Kiểu Nhật Bản Đã Xoay lại 148 x 100 mm"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "Jump to"
 msgstr "Nhảy tới"
 
-#: ../src/common/stockitem.cpp:171
+#: ../src/common/stockitem.cpp:168
 msgid "Justified"
 msgstr "Xắp xếp chữ"
 
-#: ../src/richtext/richtextindentspage.cpp:155
-#: ../src/richtext/richtextindentspage.cpp:157
 #: ../src/richtext/richtextliststylepage.cpp:344
 #: ../src/richtext/richtextliststylepage.cpp:346
+#: ../src/richtext/richtextindentspage.cpp:155
+#: ../src/richtext/richtextindentspage.cpp:157
 msgid "Justify text left and right."
 msgstr "Xắp xếp chữ canh lề trái và phải."
 
-#: ../src/common/fmapbase.cpp:163
+#: ../src/common/fmapbase.cpp:160
 msgid "KOI8-R"
 msgstr "KOI8-R"
 
-#: ../src/common/fmapbase.cpp:164
+#: ../src/common/fmapbase.cpp:161
 msgid "KOI8-U"
 msgstr "KOI8-U"
 
-#: ../src/common/accelcmn.cpp:265 ../src/common/accelcmn.cpp:347
+#: ../src/common/accelcmn.cpp:279 ../src/common/accelcmn.cpp:364
 msgid "KP_"
 msgstr "KP_"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 #, fuzzy
 msgid "KP_Add"
 msgstr "KP_ADD"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "KP_Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "KP_Decimal"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 #, fuzzy
 msgid "KP_Delete"
 msgstr "Xóa bỏ"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "KP_Divide"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 #, fuzzy
 msgid "KP_Down"
 msgstr "Xuống"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 #, fuzzy
 msgid "KP_End"
 msgstr "KP_END"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 #, fuzzy
 msgid "KP_Enter"
 msgstr "Máy in"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "KP_Equal"
 msgstr ""
 
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
-#, fuzzy
-msgid "KP_Home"
-msgstr "Thư mục Home"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
-#, fuzzy
-msgid "KP_Insert"
-msgstr "Chèn"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
-#, fuzzy
-msgid "KP_Left"
-msgstr "Trái"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
-msgid "KP_Multiply"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:99
-#, fuzzy
-msgid "KP_Next"
-msgstr "Tiếp theo"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
-msgid "KP_PageDown"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
-msgid "KP_PageUp"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:98
-msgid "KP_Prior"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
-#, fuzzy
-msgid "KP_Right"
-msgstr "Phải"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
-msgid "KP_Separator"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
-msgid "KP_Space"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
-msgid "KP_Subtract"
+#: ../src/common/accelcmn.cpp:276 ../src/common/accelcmn.cpp:361
+msgid "KP_F"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
 #: ../src/common/accelcmn.cpp:89
 #, fuzzy
+msgid "KP_Home"
+msgstr "Thư mục Home"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:100
+#, fuzzy
+msgid "KP_Insert"
+msgstr "Chèn"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:90
+#, fuzzy
+msgid "KP_Left"
+msgstr "Trái"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:103
+msgid "KP_Multiply"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:97
+#, fuzzy
+msgid "KP_Next"
+msgstr "Tiếp theo"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:95
+msgid "KP_PageDown"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:94
+msgid "KP_PageUp"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:96
+msgid "KP_Prior"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:92
+#, fuzzy
+msgid "KP_Right"
+msgstr "Phải"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:105
+msgid "KP_Separator"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:86
+msgid "KP_Space"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:106
+msgid "KP_Subtract"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:87
+#, fuzzy
 msgid "KP_Tab"
 msgstr "KP_TAB"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 #, fuzzy
 msgid "KP_Up"
 msgstr "KP_UP"
@@ -4574,111 +4687,126 @@ msgstr "KP_UP"
 msgid "L&ine spacing:"
 msgstr "Khoảng cách &dòng:"
 
-#: ../src/generic/prntdlgg.cpp:613 ../src/generic/prntdlgg.cpp:868
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "lỗi nén"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "lỗi giải nén"
+
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:861
 msgid "Landscape"
 msgstr "Nằm ngang"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "Last"
 msgstr "Cuối"
 
-#: ../src/common/prntbase.cpp:1572
+#: ../src/common/prntbase.cpp:1597
 msgid "Last page"
 msgstr "Trang cuối"
 
-#: ../src/common/log.cpp:305
+#: ../src/common/log.cpp:324
 #, fuzzy, c-format
 msgid "Last repeated message (\"%s\", %u time) wasn't output"
 msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
 msgstr[0] "Thông điệp lặp cuối cùng (\"%s\", %lu lần) đã không được kết xuất"
 
-#: ../src/common/paper.cpp:103
+#: ../src/common/paper.cpp:100
 msgid "Ledger, 17 x 11 in"
 msgstr "Ledger, 17 x 11 in"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6146
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:58 ../src/generic/datavgen.cpp:6951
+#: ../src/richtext/richtextsizepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:252
 #: ../src/richtext/richtextliststylepage.cpp:253
 #: ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
-#: ../src/richtext/richtextsizepage.cpp:249 ../src/common/accelcmn.cpp:61
 msgid "Left"
 msgstr "Trái"
 
-#: ../src/richtext/richtextindentspage.cpp:204
 #: ../src/richtext/richtextliststylepage.cpp:390
+#: ../src/richtext/richtextindentspage.cpp:204
 msgid "Left (&first line):"
 msgstr "Bên trái (dòng đầ&u):"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1761
+#: ../src/propgrid/advprops.cpp:1662
 msgid "Left Button"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:880
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Left margin (mm):"
 msgstr "Lề trái (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:141
-#: ../src/richtext/richtextindentspage.cpp:143
 #: ../src/richtext/richtextliststylepage.cpp:330
 #: ../src/richtext/richtextliststylepage.cpp:332
+#: ../src/richtext/richtextindentspage.cpp:141
+#: ../src/richtext/richtextindentspage.cpp:143
 msgid "Left-align text."
 msgstr "Canh lề cạnh bên trái chữ."
 
-#: ../src/common/paper.cpp:144
+#: ../src/common/paper.cpp:141
 msgid "Legal Extra 9 1/2 x 15 in"
 msgstr "Legal Extra 9 1/2 x 15 in"
 
-#: ../src/common/paper.cpp:96
+#: ../src/common/paper.cpp:93
 msgid "Legal, 8 1/2 x 14 in"
 msgstr "Legal, 8 1/2 x 14 in"
 
-#: ../src/common/paper.cpp:143
+#: ../src/common/paper.cpp:140
 msgid "Letter Extra 9 1/2 x 12 in"
 msgstr "Letter Extra 9 1/2 x 12 in"
 
-#: ../src/common/paper.cpp:149
+#: ../src/common/paper.cpp:146
 msgid "Letter Extra Transverse 9.275 x 12 in"
 msgstr "Letter Extra Transverse 9.275 x 12 in"
 
-#: ../src/common/paper.cpp:152
+#: ../src/common/paper.cpp:149
 msgid "Letter Plus 8 1/2 x 12.69 in"
 msgstr "Letter Plus 8 1/2 x 12.69 in"
 
-#: ../src/common/paper.cpp:169
+#: ../src/common/paper.cpp:166
 msgid "Letter Rotated 11 x 8 1/2 in"
 msgstr "Letter Rotated 11 x 8 1/2 in"
 
-#: ../src/common/paper.cpp:101
+#: ../src/common/paper.cpp:98
 msgid "Letter Small, 8 1/2 x 11 in"
 msgstr "Letter Small, 8 1/2 x 11 in"
 
-#: ../src/common/paper.cpp:147
+#: ../src/common/paper.cpp:144
 msgid "Letter Transverse 8 1/2 x 11 in"
 msgstr "Letter Transverse 8 1/2 x 11 in"
 
-#: ../src/common/paper.cpp:95
+#: ../src/common/paper.cpp:92
 msgid "Letter, 8 1/2 x 11 in"
 msgstr "Letter, 8 1/2 x 11 in"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "License"
 msgstr "Giấy phép"
 
-#: ../src/generic/fontdlgg.cpp:332
+#: ../src/generic/fontdlgg.cpp:328
 msgid "Light"
 msgstr "Ánh sáng"
 
-#: ../src/propgrid/advprops.cpp:1608
+#: ../src/propgrid/advprops.cpp:1514
 msgid "Lime"
 msgstr ""
 
-#: ../src/generic/helpext.cpp:294
+#: ../src/generic/helpext.cpp:292
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr "Dòng %lu của tập tin ánh xạ \"%s\" có cú pháp không hợp lệ, đã bỏ qua."
@@ -4687,15 +4815,15 @@ msgstr "Dòng %lu của tập tin ánh xạ \"%s\" có cú pháp không hợp l�
 msgid "Line spacing:"
 msgstr "Khoảng cách dòng:"
 
-#: ../src/html/chm.cpp:838
+#: ../src/html/chm.cpp:829
 msgid "Link contained '//', converted to absolute link."
 msgstr "Liên kết có chứa '//', đã chuyển đổi sang liên kết đúng đắn."
 
-#: ../src/richtext/richtextformatdlg.cpp:364
+#: ../src/richtext/richtextformatdlg.cpp:357
 msgid "List Style"
 msgstr "Kiểu dáng Danh sách"
 
-#: ../src/richtext/richtextstyles.cpp:1064
+#: ../src/richtext/richtextstyles.cpp:1061
 msgid "List styles"
 msgstr "Kiểu dáng của danh sách"
 
@@ -4711,26 +4839,26 @@ msgstr ""
 msgid "Lists the available fonts."
 msgstr "Danh sách phông chữ sẵn có."
 
-#: ../src/common/fldlgcmn.cpp:340
+#: ../src/common/fldlgcmn.cpp:337
 #, c-format
 msgid "Load %s file"
 msgstr "Tải %s tập tin"
 
-#: ../src/html/htmlwin.cpp:597
+#: ../src/html/htmlwin.cpp:600
 msgid "Loading : "
 msgstr "Đang tải :"
 
-#: ../src/unix/snglinst.cpp:246
+#: ../src/unix/snglinst.cpp:243
 #, c-format
 msgid "Lock file '%s' has incorrect owner."
 msgstr "Tập tin khóa '%s' có chủ sở hữu không đúng."
 
-#: ../src/unix/snglinst.cpp:251
+#: ../src/unix/snglinst.cpp:248
 #, c-format
 msgid "Lock file '%s' has incorrect permissions."
 msgstr "Tập tin khóa '%s' có quyền không đúng."
 
-#: ../src/generic/logg.cpp:576
+#: ../src/generic/logg.cpp:573
 #, c-format
 msgid "Log saved to the file '%s'."
 msgstr "Ghi nhật ký thông tin vào tập tin '%s'."
@@ -4745,11 +4873,11 @@ msgstr "Chữ thường"
 msgid "Lower case roman numerals"
 msgstr "Chữ số La Mã thường"
 
-#: ../src/gtk/mdi.cpp:422 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk1/mdi.cpp:431 ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "cửa sổ MDI con"
 
-#: ../src/msw/helpchm.cpp:56
+#: ../src/msw/helpchm.cpp:53
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -4757,189 +4885,189 @@ msgstr ""
 "Hàm MS HTML Help không sẵn sàng bởi vì thư viện MS HTML Help không được cài "
 "đặt trong máy này. Xin hãy cài nó vào."
 
-#: ../src/univ/themes/win32.cpp:3754
+#: ../src/univ/themes/win32.cpp:3751
 msgid "Ma&ximize"
 msgstr "Tối đ&a"
 
-#: ../src/common/fmapbase.cpp:203
+#: ../src/common/fmapbase.cpp:200
 msgid "MacArabic"
 msgstr "MacArabic"
 
-#: ../src/common/fmapbase.cpp:222
+#: ../src/common/fmapbase.cpp:219
 msgid "MacArmenian"
 msgstr "MacArmenian"
 
-#: ../src/common/fmapbase.cpp:211
+#: ../src/common/fmapbase.cpp:208
 msgid "MacBengali"
 msgstr "MacBengali"
 
-#: ../src/common/fmapbase.cpp:217
+#: ../src/common/fmapbase.cpp:214
 msgid "MacBurmese"
 msgstr "MacBurmese"
 
-#: ../src/common/fmapbase.cpp:236
+#: ../src/common/fmapbase.cpp:233
 msgid "MacCeltic"
 msgstr "MacCeltic"
 
-#: ../src/common/fmapbase.cpp:227
+#: ../src/common/fmapbase.cpp:224
 msgid "MacCentralEurRoman"
 msgstr "MacCentralEurRoman"
 
-#: ../src/common/fmapbase.cpp:223
+#: ../src/common/fmapbase.cpp:220
 msgid "MacChineseSimp"
 msgstr "MacChineseSimp"
 
-#: ../src/common/fmapbase.cpp:201
+#: ../src/common/fmapbase.cpp:198
 msgid "MacChineseTrad"
 msgstr "MacChineseTrad"
 
-#: ../src/common/fmapbase.cpp:233
+#: ../src/common/fmapbase.cpp:230
 msgid "MacCroatian"
 msgstr "MacCroatian"
 
-#: ../src/common/fmapbase.cpp:206
+#: ../src/common/fmapbase.cpp:203
 msgid "MacCyrillic"
 msgstr "MacCyrillic"
 
-#: ../src/common/fmapbase.cpp:207
+#: ../src/common/fmapbase.cpp:204
 msgid "MacDevanagari"
 msgstr "MacDevanagari"
 
-#: ../src/common/fmapbase.cpp:231
+#: ../src/common/fmapbase.cpp:228
 msgid "MacDingbats"
 msgstr "MacDingbats"
 
-#: ../src/common/fmapbase.cpp:226
+#: ../src/common/fmapbase.cpp:223
 msgid "MacEthiopic"
 msgstr "MacEthiopic"
 
-#: ../src/common/fmapbase.cpp:229
+#: ../src/common/fmapbase.cpp:226
 msgid "MacExtArabic"
 msgstr "MacExtArabic"
 
-#: ../src/common/fmapbase.cpp:237
+#: ../src/common/fmapbase.cpp:234
 msgid "MacGaelic"
 msgstr "MacGaelic"
 
-#: ../src/common/fmapbase.cpp:221
+#: ../src/common/fmapbase.cpp:218
 msgid "MacGeorgian"
 msgstr "MacGeorgian"
 
-#: ../src/common/fmapbase.cpp:205
+#: ../src/common/fmapbase.cpp:202
 msgid "MacGreek"
 msgstr "MacGreek"
 
-#: ../src/common/fmapbase.cpp:209
+#: ../src/common/fmapbase.cpp:206
 msgid "MacGujarati"
 msgstr "MacGujarati"
 
-#: ../src/common/fmapbase.cpp:208
+#: ../src/common/fmapbase.cpp:205
 msgid "MacGurmukhi"
 msgstr "MacGurmukhi"
 
-#: ../src/common/fmapbase.cpp:204
+#: ../src/common/fmapbase.cpp:201
 msgid "MacHebrew"
 msgstr "MacHebrew"
 
-#: ../src/common/fmapbase.cpp:234
+#: ../src/common/fmapbase.cpp:231
 msgid "MacIcelandic"
 msgstr "MacIcelandic"
 
-#: ../src/common/fmapbase.cpp:200
+#: ../src/common/fmapbase.cpp:197
 msgid "MacJapanese"
 msgstr "MacJapanese"
 
-#: ../src/common/fmapbase.cpp:214
+#: ../src/common/fmapbase.cpp:211
 msgid "MacKannada"
 msgstr "MacKannada"
 
-#: ../src/common/fmapbase.cpp:238
+#: ../src/common/fmapbase.cpp:235
 msgid "MacKeyboardGlyphs"
 msgstr "MacKeyboardGlyphs"
 
-#: ../src/common/fmapbase.cpp:218
+#: ../src/common/fmapbase.cpp:215
 msgid "MacKhmer"
 msgstr "MacKhmer"
 
-#: ../src/common/fmapbase.cpp:202
+#: ../src/common/fmapbase.cpp:199
 msgid "MacKorean"
 msgstr "MacKorean"
 
-#: ../src/common/fmapbase.cpp:220
+#: ../src/common/fmapbase.cpp:217
 msgid "MacLaotian"
 msgstr "MacLaotian"
 
-#: ../src/common/fmapbase.cpp:215
+#: ../src/common/fmapbase.cpp:212
 msgid "MacMalayalam"
 msgstr "MacMalayalam"
 
-#: ../src/common/fmapbase.cpp:225
+#: ../src/common/fmapbase.cpp:222
 msgid "MacMongolian"
 msgstr "MacMongolian"
 
-#: ../src/common/fmapbase.cpp:210
+#: ../src/common/fmapbase.cpp:207
 msgid "MacOriya"
 msgstr "MacOriya"
 
-#: ../src/common/fmapbase.cpp:199
+#: ../src/common/fmapbase.cpp:196
 msgid "MacRoman"
 msgstr "MacRoman"
 
-#: ../src/common/fmapbase.cpp:235
+#: ../src/common/fmapbase.cpp:232
 msgid "MacRomanian"
 msgstr "MacRomanian"
 
-#: ../src/common/fmapbase.cpp:216
+#: ../src/common/fmapbase.cpp:213
 msgid "MacSinhalese"
 msgstr "MacSinhalese"
 
-#: ../src/common/fmapbase.cpp:230
+#: ../src/common/fmapbase.cpp:227
 msgid "MacSymbol"
 msgstr "MacSymbol"
 
-#: ../src/common/fmapbase.cpp:212
+#: ../src/common/fmapbase.cpp:209
 msgid "MacTamil"
 msgstr "MacTamil"
 
-#: ../src/common/fmapbase.cpp:213
+#: ../src/common/fmapbase.cpp:210
 msgid "MacTelugu"
 msgstr "MacTelugu"
 
-#: ../src/common/fmapbase.cpp:219
+#: ../src/common/fmapbase.cpp:216
 msgid "MacThai"
 msgstr "MacThai"
 
-#: ../src/common/fmapbase.cpp:224
+#: ../src/common/fmapbase.cpp:221
 msgid "MacTibetan"
 msgstr "MacTibetan"
 
-#: ../src/common/fmapbase.cpp:232
+#: ../src/common/fmapbase.cpp:229
 msgid "MacTurkish"
 msgstr "MacTurkish"
 
-#: ../src/common/fmapbase.cpp:228
+#: ../src/common/fmapbase.cpp:225
 msgid "MacVietnamese"
 msgstr "MacVietnamese"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1762
+#: ../src/propgrid/advprops.cpp:1663
 msgid "Magnifier"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:2143
+#: ../src/propgrid/advprops.cpp:2050
 msgid "Make a selection:"
 msgstr "Làm với vùng chọn:"
 
-#: ../src/richtext/richtextformatdlg.cpp:374
+#: ../src/richtext/richtextformatdlg.cpp:367
 #: ../src/richtext/richtextmarginspage.cpp:171
 msgid "Margins"
 msgstr "Lề"
 
-#: ../src/propgrid/advprops.cpp:1595
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Maroon"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:147
+#: ../src/generic/fdrepdlg.cpp:144
 msgid "Match case"
 msgstr "Phân biệt HOA/thường"
 
@@ -4951,40 +5079,40 @@ msgstr "Độ cao tối đa:"
 msgid "Max width:"
 msgstr "Chiều rộng tối đa:"
 
-#: ../src/unix/mediactrl.cpp:947
+#: ../src/unix/mediactrl.cpp:972
 #, c-format
 msgid "Media playback error: %s"
 msgstr "Lỗi phát đa phương tiện: %s"
 
-#: ../src/common/fs_mem.cpp:175
+#: ../src/common/fs_mem.cpp:170
 #, c-format
 msgid "Memory VFS already contains file '%s'!"
 msgstr "Bộ nhớ VFS đã chứa tập tin '%s' rồi!"
 
 #. TRANSLATORS: Name of keyboard key
 #. TRANSLATORS: Keyword of system colour
-#: ../src/common/accelcmn.cpp:73 ../src/propgrid/advprops.cpp:889
+#: ../src/common/accelcmn.cpp:70 ../src/propgrid/advprops.cpp:790
 msgid "Menu"
 msgstr "Trình đơn"
 
-#: ../src/common/msgout.cpp:124
+#: ../src/common/msgout.cpp:121
 msgid "Message"
 msgstr "Tin nhắn"
 
-#: ../src/univ/themes/metal.cpp:168
+#: ../src/univ/themes/metal.cpp:165
 msgid "Metal theme"
 msgstr "Chủ đề giống kim loại"
 
-#: ../src/msw/ole/automtn.cpp:652
+#: ../src/msw/ole/automtn.cpp:643
 msgid "Method or property not found."
 msgstr "Phương thức hay thuộc tính không tìm thấy."
 
-#: ../src/univ/themes/win32.cpp:3752
+#: ../src/univ/themes/win32.cpp:3749
 msgid "Mi&nimize"
 msgstr "&Nhỏ nhất"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1763
+#: ../src/propgrid/advprops.cpp:1664
 msgid "Middle Button"
 msgstr ""
 
@@ -4996,38 +5124,43 @@ msgstr "Độ cao tối thiểu:"
 msgid "Min width:"
 msgstr "Chiều rộng tối thiểu:"
 
-#: ../src/msw/ole/automtn.cpp:668
+#: ../src/osx/cocoa/menu.mm:281
+#, fuzzy
+msgid "Minimize"
+msgstr "&Nhỏ nhất"
+
+#: ../src/msw/ole/automtn.cpp:659
 msgid "Missing a required parameter."
 msgstr "Thiếu tham số yêu cầu."
 
-#: ../src/generic/fontdlgg.cpp:324
+#: ../src/generic/fontdlgg.cpp:320
 msgid "Modern"
 msgstr "Hiện đại"
 
-#: ../src/generic/filectrlg.cpp:427
+#: ../src/generic/filectrlg.cpp:423
 msgid "Modified"
 msgstr "Đã bị sửa"
 
-#: ../src/common/module.cpp:133
+#: ../src/common/module.cpp:130
 #, c-format
 msgid "Module \"%s\" initialization failed"
 msgstr "Sự khởi tạo mô-đun \"%s\" gặp lỗi"
 
-#: ../src/common/paper.cpp:131
+#: ../src/common/paper.cpp:128
 msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
 msgstr "Monarch Envelope, 3 7/8 x 7 1/2 in"
 
-#: ../src/msw/fswatcher.cpp:143
+#: ../src/msw/fswatcher.cpp:140
 msgid "Monitoring individual files for changes is not supported currently."
 msgstr ""
 "Theo dõi các tập tin riêng lẻ để biết nó thay đổi gì hiện tại không được hỗ "
 "trợ."
 
-#: ../src/generic/editlbox.cpp:172
+#: ../src/generic/editlbox.cpp:160
 msgid "Move down"
 msgstr "Di chuyển xuống"
 
-#: ../src/generic/editlbox.cpp:171
+#: ../src/generic/editlbox.cpp:155
 msgid "Move up"
 msgstr "Di chuyển lên"
 
@@ -5041,97 +5174,102 @@ msgstr "Di chuyển đối tượng đến đoạn tiếp theo."
 msgid "Moves the object to the previous paragraph."
 msgstr "Di chuyển đối tượng đến đoạn trước đây."
 
-#: ../src/richtext/richtextbuffer.cpp:9966
+#: ../src/richtext/richtextbuffer.cpp:9963
 msgid "Multiple Cell Properties"
 msgstr "Thuộc tính Đa Ô"
 
-#: ../src/generic/filectrlg.cpp:424
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:82
+msgid "Multiply"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:420
 msgid "Name"
 msgstr "Tên"
 
-#: ../src/propgrid/advprops.cpp:1596
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Navy"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "Network"
 msgstr "Mạng"
 
-#: ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173
 msgid "New"
 msgstr "Mới"
 
-#: ../src/richtext/richtextstyledlg.cpp:243
+#: ../src/richtext/richtextstyledlg.cpp:239
 msgid "New &Box Style..."
 msgstr "Kiểu Dáng &Hộp mới..."
 
-#: ../src/richtext/richtextstyledlg.cpp:225
+#: ../src/richtext/richtextstyledlg.cpp:221
 msgid "New &Character Style..."
 msgstr "Kiểu Dáng Ký &Tự mới..."
 
-#: ../src/richtext/richtextstyledlg.cpp:237
+#: ../src/richtext/richtextstyledlg.cpp:233
 msgid "New &List Style..."
 msgstr "&List Style mới..."
 
-#: ../src/richtext/richtextstyledlg.cpp:231
+#: ../src/richtext/richtextstyledlg.cpp:227
 msgid "New &Paragraph Style..."
 msgstr "Kiểu Dáng Đ&oạn mới..."
 
-#: ../src/richtext/richtextstyledlg.cpp:606
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:654
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:820
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:893
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:934
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:602
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:650
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:816
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:889
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:930
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "New Style"
 msgstr "Kiểu dáng Mới"
 
-#: ../src/generic/editlbox.cpp:169
+#: ../src/generic/editlbox.cpp:139
 msgid "New item"
 msgstr "Mục tin mới"
 
-#: ../src/generic/dirdlgg.cpp:297 ../src/generic/dirdlgg.cpp:307
-#: ../src/generic/filectrlg.cpp:618 ../src/generic/filectrlg.cpp:627
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+#: ../src/generic/dirdlgg.cpp:294 ../src/generic/dirdlgg.cpp:304
 msgid "NewName"
 msgstr "TênMới"
 
-#: ../src/common/prntbase.cpp:1567 ../src/html/helpwnd.cpp:665
+#: ../src/common/prntbase.cpp:1592 ../src/html/helpwnd.cpp:663
 msgid "Next page"
 msgstr "Trang tiếp theo"
 
-#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:177
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:174
 #: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Không"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1764
+#: ../src/propgrid/advprops.cpp:1665
 msgid "No Entry"
 msgstr ""
 
-#: ../src/generic/animateg.cpp:150
+#: ../src/generic/animateg.cpp:133
 #, c-format
 msgid "No animation handler for type %ld defined."
 msgstr "Không có bộ điều khiển hoạt hình cho kiểu %ld đã định nghĩa."
 
-#: ../src/dfb/bitmap.cpp:642 ../src/dfb/bitmap.cpp:676
+#: ../src/dfb/bitmap.cpp:639 ../src/dfb/bitmap.cpp:673
 #, c-format
 msgid "No bitmap handler for type %d defined."
 msgstr "Không có bộ điều khiển ảnh cho kiểu %d được định nghĩa."
 
-#: ../src/common/utilscmn.cpp:1077
+#: ../src/common/utilscmn.cpp:1095
 msgid "No default application configured for HTML files."
 msgstr "Không có ứng dụng mặc định được cấu hình tập tin HTML."
 
-#: ../src/generic/helpext.cpp:445
+#: ../src/generic/helpext.cpp:443
 msgid "No entries found."
 msgstr "Không tìm thấy đề mục nào."
 
-#: ../src/common/fontmap.cpp:421
+#: ../src/common/fontmap.cpp:418
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found,\n"
@@ -5144,7 +5282,7 @@ msgstr ""
 "Bạn có muốn sử dụng bộ mã này không (nếu không bạn sẽ phải chọn một cái "
 "khác)?"
 
-#: ../src/common/fontmap.cpp:426
+#: ../src/common/fontmap.cpp:423
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found.\n"
@@ -5155,206 +5293,206 @@ msgstr ""
 "Bạn có muốn chọn một phông chữ sử dụng cho bộ mã này không\n"
 "(nếu không chữ với bộ mã này sẽ hiện lên không chính xác)?"
 
-#: ../src/generic/animateg.cpp:142
+#: ../src/generic/animateg.cpp:125
 msgid "No handler found for animation type."
 msgstr "Không có phần điều khiển cho kiểu hoạt hình."
 
-#: ../src/common/image.cpp:2728
+#: ../src/common/image.cpp:2823
 msgid "No handler found for image type."
 msgstr "Không có phần điều khiển cho kiểu ảnh này."
 
-#: ../src/common/image.cpp:2736 ../src/common/image.cpp:2848
-#: ../src/common/image.cpp:2901
+#: ../src/common/image.cpp:2831 ../src/common/image.cpp:2954
+#: ../src/common/image.cpp:3020
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "Không có bộ điều khiển ảnh cho kiểu %d được định nghĩa."
 
-#: ../src/common/image.cpp:2871 ../src/common/image.cpp:2915
+#: ../src/common/image.cpp:2986 ../src/common/image.cpp:3034
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "Không có bộ điều khiển ảnh cho kiểu %s được định nghĩa."
 
-#: ../src/html/helpwnd.cpp:858
+#: ../src/html/helpwnd.cpp:856
 msgid "No matching page found yet"
 msgstr "Không tìm thấy trang phù hợp"
 
-#: ../src/unix/sound.cpp:81
+#: ../src/unix/sound.cpp:78
 msgid "No sound"
 msgstr "Không có âm thanh"
 
-#: ../src/common/image.cpp:2277 ../src/common/image.cpp:2318
+#: ../src/common/image.cpp:2371 ../src/common/image.cpp:2412
 msgid "No unused colour in image being masked."
 msgstr "Không có màu không dùng đến trong mặt nạ ảnh này."
 
-#: ../src/common/image.cpp:3374
-msgid "No unused colour in image."
-msgstr "Không có màu không dùng trong ảnh."
-
-#: ../src/generic/helpext.cpp:302
+#: ../src/generic/helpext.cpp:300
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "Không có ánh xạ hợp lệ nào được tìm thấy trong tập tin \"%s\"."
 
-#: ../src/richtext/richtextborderspage.cpp:610
 #: ../src/richtext/richtextsizepage.cpp:248
 #: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:610
 msgid "None"
 msgstr "Không"
 
-#: ../src/common/fmapbase.cpp:157
+#: ../src/common/fmapbase.cpp:154
 msgid "Nordic (ISO-8859-10)"
 msgstr "Nordic (ISO-8859-10)"
 
-#: ../src/generic/fontdlgg.cpp:328 ../src/generic/fontdlgg.cpp:331
+#: ../src/generic/fontdlgg.cpp:324 ../src/generic/fontdlgg.cpp:327
 msgid "Normal"
 msgstr "Bình thường"
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1261
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Bình thường<br>và <u>gạch chân</u>. "
 
-#: ../src/html/helpwnd.cpp:1205
+#: ../src/html/helpwnd.cpp:1203
 msgid "Normal font:"
 msgstr "Phông chữ thường:"
 
-#: ../src/propgrid/props.cpp:1128
+#: ../src/propgrid/props.cpp:1115
 #, c-format
 msgid "Not %s"
 msgstr "Không %s"
 
-#: ../include/wx/filename.h:573 ../include/wx/filename.h:578
-msgid "Not available"
-msgstr "Không sẵn sàng"
+#: ../src/common/secretstore.cpp:168
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/webrequest.cpp:605
+msgid "Not enough free disk space for download."
+msgstr ""
 
 #: ../src/richtext/richtextfontpage.cpp:358
 msgid "Not underlined"
 msgstr "Không gạch chân"
 
-#: ../src/common/paper.cpp:115
+#: ../src/common/paper.cpp:112
 msgid "Note, 8 1/2 x 11 in"
 msgstr "Note, 8 1/2 x 11 in"
 
-#: ../src/generic/notifmsgg.cpp:132
+#: ../src/generic/notifmsgg.cpp:129
 msgid "Notice"
 msgstr "Chú ý"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "Num *"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "Num +"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "Num ,"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "Num -"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "Num ."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "Num /"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "Num ="
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "Num Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 #, fuzzy
 msgid "Num Delete"
 msgstr "Xóa bỏ"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 #, fuzzy
 msgid "Num Down"
 msgstr "Xuống"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "Num End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "Num Enter"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 #, fuzzy
 msgid "Num Home"
 msgstr "Thư mục Home"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 #, fuzzy
 msgid "Num Insert"
 msgstr "Chèn"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num Lock"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "Num Page Down"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "Num Page Up"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 #, fuzzy
 msgid "Num Right"
 msgstr "Phải"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "Num Space"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "Num Tab"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "Num Up"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "Num left"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num_lock"
 msgstr ""
 
@@ -5363,13 +5501,13 @@ msgstr ""
 msgid "Numbered outline"
 msgstr "Số đường bao"
 
-#: ../include/wx/msgdlg.h:278 ../src/richtext/richtextstyledlg.cpp:297
-#: ../src/common/stockitem.cpp:178 ../src/msw/msgdlg.cpp:454
-#: ../src/msw/msgdlg.cpp:747 ../src/gtk1/fontdlg.cpp:138
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:175
+#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/msgdlg.cpp:741 ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "Đồng ý"
 
-#: ../src/msw/ole/automtn.cpp:692
+#: ../src/msw/ole/automtn.cpp:683
 #, c-format
 msgid "OLE Automation error in %s: %s"
 msgstr "Lỗi hoạt hình OLE trong %s: %s"
@@ -5378,15 +5516,15 @@ msgstr "Lỗi hoạt hình OLE trong %s: %s"
 msgid "Object Properties"
 msgstr "Thuộc tính Đối tượng"
 
-#: ../src/msw/ole/automtn.cpp:660
+#: ../src/msw/ole/automtn.cpp:651
 msgid "Object implementation does not support named arguments."
 msgstr "Phần thực thi đối tượng không hỗ trợ các đối số có tên."
 
-#: ../src/common/xtixml.cpp:264
+#: ../src/common/xtixml.cpp:260
 msgid "Objects must have an id attribute"
 msgstr "Đối tượng phải có giá trị thuộc tính id"
 
-#: ../src/propgrid/advprops.cpp:1601
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Olive"
 msgstr ""
 
@@ -5394,64 +5532,69 @@ msgstr ""
 msgid "Opaci&ty:"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:354
+#: ../src/generic/colrdlgg.cpp:374
 msgid "Opacity:"
 msgstr ""
 
-#: ../src/common/docview.cpp:1773 ../src/common/docview.cpp:1815
+#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
 msgid "Open File"
 msgstr "Mở tập tin"
 
-#: ../src/html/helpwnd.cpp:671 ../src/html/helpwnd.cpp:1554
+#: ../src/html/helpwnd.cpp:669 ../src/html/helpwnd.cpp:1552
 msgid "Open HTML document"
 msgstr "Mở tài liệu định dạng HTML"
 
-#: ../src/generic/dbgrptg.cpp:163
+#: ../src/common/stockitem.cpp:265
+#, fuzzy
+msgid "Open an existing document"
+msgstr "Mở tài liệu định dạng HTML"
+
+#: ../src/generic/dbgrptg.cpp:160
 #, c-format
 msgid "Open file \"%s\""
 msgstr "Mở tập tin \"%s\""
 
-#: ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176
 msgid "Open..."
 msgstr "Mở..."
 
-#: ../src/unix/glx11.cpp:506 ../src/msw/glcanvas.cpp:592
+#: ../src/msw/glcanvas.cpp:607 ../src/unix/glx11.cpp:513
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr ""
 
-#: ../src/generic/dirctrlg.cpp:599 ../src/generic/dirdlgg.cpp:323
-#: ../src/generic/filectrlg.cpp:642 ../src/generic/filectrlg.cpp:786
+#: ../src/generic/dirctrlg.cpp:565 ../src/generic/filectrlg.cpp:638
+#: ../src/generic/filectrlg.cpp:782 ../src/generic/dirdlgg.cpp:320
 msgid "Operation not permitted."
 msgstr "Thao tác không được phép."
 
-#: ../src/common/cmdline.cpp:900
+#: ../src/common/cmdline.cpp:896
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "Tuỳ chọn '%s' không thể bị phủ định"
 
-#: ../src/common/cmdline.cpp:1064
+#: ../src/common/cmdline.cpp:1060
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "Tùy chọn '%s' yêu cầu một giá trị."
 
-#: ../src/common/cmdline.cpp:1147
+#: ../src/common/cmdline.cpp:1143
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Tùy chọn '%s': '%s' không thể chuyển thành dạng ngày tháng."
 
-#: ../src/generic/prntdlgg.cpp:618
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Tùy chọn"
 
-#: ../src/propgrid/advprops.cpp:1606
+#: ../src/propgrid/advprops.cpp:1512
 msgid "Orange"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:615 ../src/generic/prntdlgg.cpp:869
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:862
 msgid "Orientation"
 msgstr "Hướng"
 
-#: ../src/common/windowid.cpp:242
+#: ../src/common/windowid.cpp:237
 msgid "Out of window IDs.  Recommend shutting down application."
 msgstr "Thiếu chỉ số cửa sổ IDs. Đề nghị đóng ứng dụng."
 
@@ -5464,148 +5607,148 @@ msgstr "Viền ngoài"
 msgid "Outset"
 msgstr "Bắt đầu"
 
-#: ../src/msw/ole/automtn.cpp:656
+#: ../src/msw/ole/automtn.cpp:647
 msgid "Overflow while coercing argument values."
 msgstr "Tràn khi ép buộc các giá trị tham số."
 
-#: ../src/common/imagpcx.cpp:457 ../src/common/imagpcx.cpp:480
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:479
 msgid "PCX: couldn't allocate memory"
 msgstr "PCX: không thể cấp phát bộ nhớ"
 
-#: ../src/common/imagpcx.cpp:456
+#: ../src/common/imagpcx.cpp:455
 msgid "PCX: image format unsupported"
 msgstr "PCX: không hỗ trợ định dạng ảnh"
 
-#: ../src/common/imagpcx.cpp:479
+#: ../src/common/imagpcx.cpp:478
 msgid "PCX: invalid image"
 msgstr "PCX: ảnh không hợp lệ"
 
-#: ../src/common/imagpcx.cpp:442
+#: ../src/common/imagpcx.cpp:441
 msgid "PCX: this is not a PCX file."
 msgstr "PCX: cái này không phải là tập tin PCX."
 
-#: ../src/common/imagpcx.cpp:459 ../src/common/imagpcx.cpp:481
+#: ../src/common/imagpcx.cpp:458 ../src/common/imagpcx.cpp:480
 msgid "PCX: unknown error !!!"
 msgstr "PCX: lỗi không rõ!!!"
 
-#: ../src/common/imagpcx.cpp:458
+#: ../src/common/imagpcx.cpp:457
 msgid "PCX: version number too low"
 msgstr "PCX: phiên bản quá thấp"
 
-#: ../src/common/imagpnm.cpp:91
+#: ../src/common/imagpnm.cpp:89
 msgid "PNM: Couldn't allocate memory."
 msgstr "PNM: Không thể cấp phát bộ nhớ."
 
-#: ../src/common/imagpnm.cpp:73
+#: ../src/common/imagpnm.cpp:71
 msgid "PNM: File format is not recognized."
 msgstr "PNM: Định dạng tập tin không được thừa nhận."
 
-#: ../src/common/imagpnm.cpp:112 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
 #: ../src/common/imagpnm.cpp:156
 msgid "PNM: File seems truncated."
 msgstr "PNM: Tập tin dường như đã bị cắt xén."
 
-#: ../src/common/paper.cpp:187
+#: ../src/common/paper.cpp:184
 msgid "PRC 16K 146 x 215 mm"
 msgstr "PRC 16K 146 x 215 mm"
 
-#: ../src/common/paper.cpp:200
+#: ../src/common/paper.cpp:197
 msgid "PRC 16K Rotated"
 msgstr "PRC 16K Rotated"
 
-#: ../src/common/paper.cpp:188
+#: ../src/common/paper.cpp:185
 msgid "PRC 32K 97 x 151 mm"
 msgstr "PRC 32K 97 x 151 mm"
 
-#: ../src/common/paper.cpp:201
+#: ../src/common/paper.cpp:198
 msgid "PRC 32K Rotated"
 msgstr "PRC 32K Rotated"
 
-#: ../src/common/paper.cpp:189
+#: ../src/common/paper.cpp:186
 msgid "PRC 32K(Big) 97 x 151 mm"
 msgstr "PRC 32K(Big) 97 x 151 mm"
 
-#: ../src/common/paper.cpp:202
+#: ../src/common/paper.cpp:199
 msgid "PRC 32K(Big) Rotated"
 msgstr "PRC 32K(Big) Rotated"
 
-#: ../src/common/paper.cpp:190
+#: ../src/common/paper.cpp:187
 msgid "PRC Envelope #1 102 x 165 mm"
 msgstr "PRC Envelope #1 102 x 165 mm"
 
-#: ../src/common/paper.cpp:203
+#: ../src/common/paper.cpp:200
 msgid "PRC Envelope #1 Rotated 165 x 102 mm"
 msgstr "PRC Envelope #1 Rotated 165 x 102 mm"
 
-#: ../src/common/paper.cpp:199
+#: ../src/common/paper.cpp:196
 msgid "PRC Envelope #10 324 x 458 mm"
 msgstr "PRC Envelope #10 324 x 458 mm"
 
-#: ../src/common/paper.cpp:212
+#: ../src/common/paper.cpp:209
 msgid "PRC Envelope #10 Rotated 458 x 324 mm"
 msgstr "PRC Envelope #10 Rotated 458 x 324 mm"
 
-#: ../src/common/paper.cpp:191
+#: ../src/common/paper.cpp:188
 msgid "PRC Envelope #2 102 x 176 mm"
 msgstr "PRC Envelope #2 102 x 176 mm"
 
-#: ../src/common/paper.cpp:204
+#: ../src/common/paper.cpp:201
 msgid "PRC Envelope #2 Rotated 176 x 102 mm"
 msgstr "PRC Envelope #2 Rotated 176 x 102 mm"
 
-#: ../src/common/paper.cpp:192
+#: ../src/common/paper.cpp:189
 msgid "PRC Envelope #3 125 x 176 mm"
 msgstr "PRC Envelope #3 125 x 176 mm"
 
-#: ../src/common/paper.cpp:205
+#: ../src/common/paper.cpp:202
 msgid "PRC Envelope #3 Rotated 176 x 125 mm"
 msgstr "PRC Envelope #3 Rotated 176 x 125 mm"
 
-#: ../src/common/paper.cpp:193
+#: ../src/common/paper.cpp:190
 msgid "PRC Envelope #4 110 x 208 mm"
 msgstr "PRC Envelope #4 110 x 208 mm"
 
-#: ../src/common/paper.cpp:206
+#: ../src/common/paper.cpp:203
 msgid "PRC Envelope #4 Rotated 208 x 110 mm"
 msgstr "PRC Envelope #4 Rotated 208 x 110 mm"
 
-#: ../src/common/paper.cpp:194
+#: ../src/common/paper.cpp:191
 msgid "PRC Envelope #5 110 x 220 mm"
 msgstr "PRC Envelope #5 110 x 220 mm"
 
-#: ../src/common/paper.cpp:207
+#: ../src/common/paper.cpp:204
 msgid "PRC Envelope #5 Rotated 220 x 110 mm"
 msgstr "PRC Envelope #5 Rotated 220 x 110 mm"
 
-#: ../src/common/paper.cpp:195
+#: ../src/common/paper.cpp:192
 msgid "PRC Envelope #6 120 x 230 mm"
 msgstr "PRC Envelope #6 120 x 230 mm"
 
-#: ../src/common/paper.cpp:208
+#: ../src/common/paper.cpp:205
 msgid "PRC Envelope #6 Rotated 230 x 120 mm"
 msgstr "PRC Envelope #6 Rotated 230 x 120 mm"
 
-#: ../src/common/paper.cpp:196
+#: ../src/common/paper.cpp:193
 msgid "PRC Envelope #7 160 x 230 mm"
 msgstr "PRC Envelope #7 160 x 230 mm"
 
-#: ../src/common/paper.cpp:209
+#: ../src/common/paper.cpp:206
 msgid "PRC Envelope #7 Rotated 230 x 160 mm"
 msgstr "PRC Envelope #7 Rotated 230 x 160 mm"
 
-#: ../src/common/paper.cpp:197
+#: ../src/common/paper.cpp:194
 msgid "PRC Envelope #8 120 x 309 mm"
 msgstr "PRC Envelope #8 120 x 309 mm"
 
-#: ../src/common/paper.cpp:210
+#: ../src/common/paper.cpp:207
 msgid "PRC Envelope #8 Rotated 309 x 120 mm"
 msgstr "PRC Envelope #8 Rotated 309 x 120 mm"
 
-#: ../src/common/paper.cpp:198
+#: ../src/common/paper.cpp:195
 msgid "PRC Envelope #9 229 x 324 mm"
 msgstr "PRC Envelope #9 229 x 324 mm"
 
-#: ../src/common/paper.cpp:211
+#: ../src/common/paper.cpp:208
 msgid "PRC Envelope #9 Rotated 324 x 229 mm"
 msgstr "PRC Envelope #9 Rotated 324 x 229 mm"
 
@@ -5613,91 +5756,95 @@ msgstr "PRC Envelope #9 Rotated 324 x 229 mm"
 msgid "Padding"
 msgstr "Đệm"
 
-#: ../src/common/prntbase.cpp:2074
+#: ../src/common/prntbase.cpp:2096
 #, c-format
 msgid "Page %d"
 msgstr "Trang %d"
 
-#: ../src/common/prntbase.cpp:2072
+#: ../src/common/prntbase.cpp:2094
 #, c-format
 msgid "Page %d of %d"
 msgstr "Trang %d của %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 #, fuzzy
 msgid "Page Down"
 msgstr "Trang %d"
 
-#: ../src/gtk/print.cpp:826
+#: ../src/gtk/print.cpp:829
 msgid "Page Setup"
 msgstr "Cài đặt giấy"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 #, fuzzy
 msgid "Page Up"
 msgstr "Trang %d"
 
-#: ../src/generic/prntdlgg.cpp:828 ../src/common/prntbase.cpp:484
+#: ../src/common/prntbase.cpp:479 ../src/generic/prntdlgg.cpp:821
 msgid "Page setup"
 msgstr "Cài đặt giấy"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 #, fuzzy
 msgid "PageDown"
 msgstr "Xuống"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 #, fuzzy
 msgid "PageUp"
 msgstr "Giấy"
 
-#: ../src/generic/prntdlgg.cpp:216
+#: ../src/generic/prntdlgg.cpp:209
 msgid "Pages"
 msgstr "Giấy"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1765
+#: ../src/propgrid/advprops.cpp:1666
 msgid "Paint Brush"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:602 ../src/generic/prntdlgg.cpp:801
-#: ../src/generic/prntdlgg.cpp:842 ../src/generic/prntdlgg.cpp:855
-#: ../src/generic/prntdlgg.cpp:1052 ../src/generic/prntdlgg.cpp:1057
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:794
+#: ../src/generic/prntdlgg.cpp:835 ../src/generic/prntdlgg.cpp:848
+#: ../src/generic/prntdlgg.cpp:1045 ../src/generic/prntdlgg.cpp:1050
 msgid "Paper size"
 msgstr "Cỡ giấy"
 
-#: ../src/richtext/richtextstyles.cpp:1062
+#: ../src/richtext/richtextstyles.cpp:1059
 msgid "Paragraph styles"
 msgstr "Kiểu đoạn văn"
 
-#: ../src/common/xtistrm.cpp:465
+#: ../src/common/xtistrm.cpp:462
 msgid "Passing a already registered object to SetObject"
 msgstr "Chuyển qua một đối tượng đã được đăng ký rồi để SetObject"
 
-#: ../src/common/xtistrm.cpp:476
+#: ../src/common/xtistrm.cpp:473
 msgid "Passing an unknown object to GetObject"
 msgstr "Chuyển một đối tượng không hợp lệ cho SetObject"
 
-#: ../src/richtext/richtextctrl.cpp:3513 ../src/common/stockitem.cpp:180
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:177 ../src/richtext/richtextctrl.cpp:3514
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Dán"
 
-#: ../src/common/stockitem.cpp:262
+#: ../src/common/stockitem.cpp:260
 msgid "Paste selection"
 msgstr "Dán vùng chọn"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:74
+#: ../src/common/accelcmn.cpp:71
 msgid "Pause"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1766
+#: ../src/propgrid/advprops.cpp:1667
 msgid "Pencil"
 msgstr ""
 
@@ -5706,21 +5853,21 @@ msgstr ""
 msgid "Peri&od"
 msgstr "Dấu chấ&m"
 
-#: ../src/generic/filectrlg.cpp:430
+#: ../src/generic/filectrlg.cpp:426
 msgid "Permissions"
 msgstr "Các quyền"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:60
+#: ../src/common/accelcmn.cpp:57
 msgid "PgDn"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:59
+#: ../src/common/accelcmn.cpp:56
 msgid "PgUp"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:12868
+#: ../src/richtext/richtextbuffer.cpp:12863
 msgid "Picture Properties"
 msgstr "Các thuộc tính Hình ảnh"
 
@@ -5732,44 +5879,44 @@ msgstr "Việc tạo đường ống gặp lỗi"
 msgid "Please choose a valid font."
 msgstr "Hãy chọn một phông chữ hợp lệ."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
 msgid "Please choose an existing file."
 msgstr "Xin hãy chọn một tập tin đã tồn tại."
 
-#: ../src/html/helpwnd.cpp:800
+#: ../src/html/helpwnd.cpp:798
 msgid "Please choose the page to display:"
 msgstr "Xin hãy chọn trang bạn muốn hiển thị:"
 
-#: ../src/msw/dialup.cpp:764
+#: ../src/msw/dialup.cpp:758
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Xin hãy chọn nhà cung cấp dịch vụ Internet ISP mà bạn muốn kết nối tới"
 
-#: ../src/common/headerctrlcmn.cpp:59
+#: ../src/common/headerctrlcmn.cpp:57
 msgid "Please select the columns to show and define their order:"
 msgstr "Xin hãy chọn các cột sẽ hiển thị và xác định thứ tự của chúng:"
 
-#: ../src/common/prntbase.cpp:538
+#: ../src/common/prntbase.cpp:533
 msgid "Please wait while printing..."
 msgstr "Xin hãy đợi khi đang in..."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1767
+#: ../src/propgrid/advprops.cpp:1668
 #, fuzzy
 msgid "Point Left"
 msgstr "&Kích thước Phông chữ:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1768
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgid "Point Right"
 msgstr "Canh lề Phải"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:662
+#: ../src/propgrid/advprops.cpp:572
 msgid "Point Size"
 msgstr "&Kích thước Phông chữ:"
 
-#: ../src/generic/prntdlgg.cpp:612 ../src/generic/prntdlgg.cpp:867
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:860
 msgid "Portrait"
 msgstr "Thẳng đứng"
 
@@ -5777,253 +5924,263 @@ msgstr "Thẳng đứng"
 msgid "Position"
 msgstr "Vị trí"
 
-#: ../src/generic/prntdlgg.cpp:298
+#: ../src/generic/prntdlgg.cpp:291
 msgid "PostScript file"
 msgstr "tập tin PostScript"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178 ../src/osx/cocoa/preferences.mm:303
 msgid "Preferences"
 msgstr "Cá nhân hóa"
 
-#: ../src/osx/menu_osx.cpp:568
+#: ../src/osx/menu_osx.cpp:460
 msgid "Preferences..."
 msgstr "Cá nhân hóa..."
 
-#: ../src/common/prntbase.cpp:546
+#: ../src/common/prntbase.cpp:541
 msgid "Preparing"
 msgstr "Đang chuẩn bị"
 
-#: ../src/generic/fontdlgg.cpp:455 ../src/osx/carbon/fontdlg.cpp:390
-#: ../src/html/helpwnd.cpp:1222
+#: ../src/osx/carbon/fontdlg.cpp:387 ../src/generic/fontdlgg.cpp:452
+#: ../src/html/helpwnd.cpp:1220
 msgid "Preview:"
 msgstr "Xem trước:"
 
-#: ../src/common/prntbase.cpp:1553 ../src/html/helpwnd.cpp:664
+#: ../src/common/prntbase.cpp:1578 ../src/html/helpwnd.cpp:662
 msgid "Previous page"
 msgstr "Trang trước"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/prntdlgg.cpp:143 ../src/generic/prntdlgg.cpp:157
-#: ../src/common/prntbase.cpp:426 ../src/common/prntbase.cpp:1541
-#: ../src/common/accelcmn.cpp:77 ../src/gtk/print.cpp:620
-#: ../src/gtk/print.cpp:638
+#: ../src/common/prntbase.cpp:421 ../src/common/prntbase.cpp:1566
+#: ../src/common/accelcmn.cpp:74 ../src/generic/prntdlgg.cpp:136
+#: ../src/generic/prntdlgg.cpp:150 ../src/gtk/print.cpp:616
+#: ../src/gtk/print.cpp:634
 msgid "Print"
 msgstr "In"
 
-#: ../include/wx/prntbase.h:399 ../src/common/docview.cpp:1268
+#: ../src/common/docview.cpp:1262
 msgid "Print Preview"
 msgstr "Mô Phỏng Bản In"
 
-#: ../src/common/prntbase.cpp:2015 ../src/common/prntbase.cpp:2057
-#: ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2037 ../src/common/prntbase.cpp:2079
+#: ../src/common/prntbase.cpp:2087
 msgid "Print Preview Failure"
 msgstr "Mô Phỏng Bản In Bị Lỗi"
 
-#: ../src/generic/prntdlgg.cpp:224
+#: ../src/generic/prntdlgg.cpp:217
 msgid "Print Range"
 msgstr "Vùng cần in"
 
-#: ../src/generic/prntdlgg.cpp:449
+#: ../src/generic/prntdlgg.cpp:442
 msgid "Print Setup"
 msgstr "Cài Đặt In"
 
-#: ../src/generic/prntdlgg.cpp:621
+#: ../src/generic/prntdlgg.cpp:614
 msgid "Print in colour"
 msgstr "In màu"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/osx/webview_webkit.mm:260
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "Phần miêu tả cột không thể được khởi tạo."
+
+#: ../src/common/stockitem.cpp:179
 msgid "Print previe&w..."
 msgstr "&Mô phỏng bản in..."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1256
 msgid "Print preview creation failed."
 msgstr "Tạo bản xem thử khi in gặp lỗi."
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/common/stockitem.cpp:179
 msgid "Print preview..."
 msgstr "Xem thử bản in..."
 
-#: ../src/generic/prntdlgg.cpp:630
+#: ../src/generic/prntdlgg.cpp:623
 msgid "Print spooling"
 msgstr "In vào bộ nhớ"
 
-#: ../src/html/helpwnd.cpp:675
+#: ../src/html/helpwnd.cpp:673
 msgid "Print this page"
 msgstr "In ra trang này"
 
-#: ../src/generic/prntdlgg.cpp:185
+#: ../src/generic/prntdlgg.cpp:178
 msgid "Print to File"
 msgstr "In ra Tập tin"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "Print..."
 msgstr "In..."
 
-#: ../src/generic/prntdlgg.cpp:493
+#: ../src/generic/prntdlgg.cpp:486
 msgid "Printer"
 msgstr "Máy in"
 
-#: ../src/generic/prntdlgg.cpp:633
+#: ../src/generic/prntdlgg.cpp:626
 msgid "Printer command:"
 msgstr "Lệnh in:"
 
-#: ../src/generic/prntdlgg.cpp:180
+#: ../src/generic/prntdlgg.cpp:173
 msgid "Printer options"
 msgstr "Tùy chọn về máy in"
 
-#: ../src/generic/prntdlgg.cpp:645
+#: ../src/generic/prntdlgg.cpp:638
 msgid "Printer options:"
 msgstr "Tùy chọn về máy in:"
 
-#: ../src/generic/prntdlgg.cpp:916
+#: ../src/generic/prntdlgg.cpp:909
 msgid "Printer..."
 msgstr "Máy in..."
 
-#: ../src/generic/prntdlgg.cpp:196
+#: ../src/generic/prntdlgg.cpp:189
 msgid "Printer:"
 msgstr "Máy in:"
 
-#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:535
-#: ../src/html/htmprint.cpp:277
+#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:530
+#: ../src/html/htmprint.cpp:289
 msgid "Printing"
 msgstr "In ấn"
 
-#: ../src/common/prntbase.cpp:612
+#: ../src/common/prntbase.cpp:607
 msgid "Printing "
 msgstr "Đang in "
 
-#: ../src/common/prntbase.cpp:347
+#: ../src/common/prntbase.cpp:342
 msgid "Printing Error"
 msgstr "Lỗi In"
 
-#: ../src/common/prntbase.cpp:565
+#: ../src/osx/webview_webkit.mm:251
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "Gzip không được hỗ trợ bởi phiên bản này của zlib"
+
+#: ../src/common/prntbase.cpp:560
 #, fuzzy, c-format
 msgid "Printing page %d"
 msgstr "Đang in trang %d..."
 
-#: ../src/common/prntbase.cpp:570
+#: ../src/common/prntbase.cpp:565
 #, c-format
 msgid "Printing page %d of %d"
 msgstr "Đang in trang %d trong tổng số %d"
 
-#: ../src/generic/printps.cpp:201
+#: ../src/generic/printps.cpp:182
 #, c-format
 msgid "Printing page %d..."
 msgstr "Đang in trang %d..."
 
-#: ../src/generic/printps.cpp:161
+#: ../src/generic/printps.cpp:142
 msgid "Printing..."
 msgstr "Đang in..."
 
-#: ../include/wx/richtext/richtextprint.h:109 ../include/wx/prntbase.h:267
-#: ../src/common/docview.cpp:2132
+#: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
+#: ../src/common/docview.cpp:2137
 msgid "Printout"
 msgstr "Dữ liệu in"
 
-#: ../src/common/debugrpt.cpp:560
+#: ../src/common/debugrpt.cpp:561
 #, c-format
 msgid ""
 "Processing debug report has failed, leaving the files in \"%s\" directory."
 msgstr "Sự tạo báo cáo gỡ lỗi bị lỗi, tập tin xuất ra trong thư mục \"%s\"."
 
-#: ../src/common/prntbase.cpp:545
+#: ../src/common/prntbase.cpp:540
 msgid "Progress:"
 msgstr "Tiến triển:"
 
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181
 msgid "Properties"
 msgstr "Thuộc tính"
 
-#: ../src/propgrid/manager.cpp:237
+#: ../src/propgrid/manager.cpp:223
 msgid "Property"
 msgstr "Thuộc tính"
 
 #. TRANSLATORS: Caption of message box displaying any property error
-#: ../src/propgrid/propgrid.cpp:3185 ../src/propgrid/propgrid.cpp:3318
+#: ../src/propgrid/propgrid.cpp:3162 ../src/propgrid/propgrid.cpp:3299
 msgid "Property Error"
 msgstr "Lỗi Thuộc tính"
 
-#: ../src/propgrid/advprops.cpp:1597
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Purple"
 msgstr ""
 
-#: ../src/common/paper.cpp:112
+#: ../src/common/paper.cpp:109
 msgid "Quarto, 215 x 275 mm"
 msgstr "Quarto, 215 x 275 mm"
 
-#: ../src/generic/logg.cpp:1016
+#: ../src/generic/logg.cpp:1013
 msgid "Question"
 msgstr "Câu hỏi"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1769
+#: ../src/propgrid/advprops.cpp:1670
 #, fuzzy
 msgid "Question Arrow"
 msgstr "Câu hỏi"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "Quit"
 msgstr "Thoát"
 
-#: ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:477
 #, c-format
 msgid "Quit %s"
 msgstr "Thoát %s"
 
-#: ../src/common/stockitem.cpp:263
+#: ../src/common/stockitem.cpp:261
 msgid "Quit this program"
 msgstr "Thoát khỏi chương trình này"
 
-#: ../src/common/accelcmn.cpp:338
+#: ../src/common/accelcmn.cpp:352
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/ffile.cpp:109 ../src/common/ffile.cpp:133
+#: ../src/common/ffile.cpp:107 ../src/common/ffile.cpp:132
 #, c-format
 msgid "Read error on file '%s'"
 msgstr "Lỗi đọc trong tập tin '%s'"
 
-#: ../src/common/secretstore.cpp:199
+#: ../src/common/secretstore.cpp:211
 #, fuzzy, c-format
-msgid "Reading password for \"%s/%s\" failed: %s."
+msgid "Reading password for \"%s\" failed: %s."
 msgstr "Rút trích '%s' vào '%s' gặp lỗi."
 
-#: ../src/common/prntbase.cpp:272
+#: ../src/common/prntbase.cpp:267
 msgid "Ready"
 msgstr "Sẵn sàng"
 
-#: ../src/propgrid/advprops.cpp:1605
+#: ../src/propgrid/advprops.cpp:1511
 #, fuzzy
 msgid "Red"
 msgstr "Redo"
 
-#: ../src/generic/colrdlgg.cpp:339
+#: ../src/generic/colrdlgg.cpp:359
 msgid "Red:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:185 ../src/stc/stc_i18n.cpp:16
+#: ../src/common/stockitem.cpp:182 ../src/stc/stc_i18n.cpp:16
 msgid "Redo"
 msgstr "Redo"
 
-#: ../src/common/stockitem.cpp:264
+#: ../src/common/stockitem.cpp:262
 msgid "Redo last action"
 msgstr "Redo bước cuối cùng"
 
-#: ../src/common/stockitem.cpp:186
+#: ../src/common/stockitem.cpp:183
 msgid "Refresh"
 msgstr "Làm tươi lại"
 
-#: ../src/msw/registry.cpp:626
+#: ../src/msw/registry.cpp:615
 #, c-format
 msgid "Registry key '%s' already exists."
 msgstr "Khóa đăng ký '%s' đã tồn tại rồi."
 
-#: ../src/msw/registry.cpp:595
+#: ../src/msw/registry.cpp:584
 #, c-format
 msgid "Registry key '%s' does not exist, cannot rename it."
 msgstr "Khóa đăng ký '%s' chưa tồn tại, không thể đổi tên được."
 
-#: ../src/msw/registry.cpp:727
+#: ../src/msw/registry.cpp:716
 #, c-format
 msgid ""
 "Registry key '%s' is needed for normal system operation,\n"
@@ -6034,22 +6191,22 @@ msgstr ""
 "việc xóa nó sẽ làm cho hệ thống của bạn rơi vào trạng thái không ổn định:\n"
 "thao tác đã bị hủy bỏ."
 
-#: ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:942
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:917
+#: ../src/msw/registry.cpp:905
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1003
+#: ../src/msw/registry.cpp:991
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:521
+#: ../src/msw/registry.cpp:510
 #, c-format
 msgid "Registry value '%s' already exists."
 msgstr "Giá trị đăng ký '%s' đã tồn tại rồi."
@@ -6063,72 +6220,78 @@ msgstr "Thông thường"
 msgid "Relative"
 msgstr "Tương đối"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:456
 msgid "Relevant entries:"
 msgstr "Các đề mục tin hợp:"
 
-#: ../include/wx/generic/progdlgg.h:86
+#: ../include/wx/generic/progdlgg.h:87
 msgid "Remaining time:"
 msgstr "Thời gian còn lại:"
 
-#: ../src/common/stockitem.cpp:187
+#: ../src/common/stockitem.cpp:184
 msgid "Remove"
 msgstr "Gỡ bỏ"
 
-#: ../src/richtext/richtextctrl.cpp:1562
+#: ../src/richtext/richtextctrl.cpp:1563
 msgid "Remove Bullet"
 msgstr "Gỡ bỏ Bullet"
 
-#: ../src/html/helpwnd.cpp:433
+#: ../src/html/helpwnd.cpp:431
 msgid "Remove current page from bookmarks"
 msgstr "Gỡ bỏ trang hiện hành từ dấu trang"
 
-#: ../src/common/rendcmn.cpp:194
+#: ../src/common/rendcmn.cpp:191
 #, c-format
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 "Renderer \"% s\" đã không tương thích với phiên bản% d.% d và không thể được "
 "nạp."
 
-#: ../src/richtext/richtextbuffer.cpp:4527
+#: ../src/richtext/richtextbuffer.cpp:4524
 msgid "Renumber List"
 msgstr "Đánh số lại List"
 
-#: ../src/common/stockitem.cpp:188
-msgid "Rep&lace"
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Rep&lace..."
 msgstr "Tha&y thế"
 
-#: ../src/richtext/richtextctrl.cpp:3673 ../src/common/stockitem.cpp:188
+#: ../src/richtext/richtextctrl.cpp:3674
 msgid "Replace"
 msgstr "Thay thế"
 
-#: ../src/generic/fdrepdlg.cpp:182
+#: ../src/generic/fdrepdlg.cpp:179
 msgid "Replace &all"
 msgstr "Th&ay thế tất cả"
 
-#: ../src/common/stockitem.cpp:261
-msgid "Replace selection"
-msgstr "Thay thế vùng chọn hiện thời"
-
-#: ../src/generic/fdrepdlg.cpp:124
+#: ../src/generic/fdrepdlg.cpp:121
 msgid "Replace with:"
 msgstr "Thay thế bằng:"
 
-#: ../src/common/valtext.cpp:163
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Replace..."
+msgstr "Thay thế"
+
+#: ../src/common/valtext.cpp:184
 msgid "Required information entry is empty."
 msgstr "Mục thông tin đã yêu cầu bị rỗng."
 
-#: ../src/common/translation.cpp:1975
+#: ../src/common/translation.cpp:2025
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "Tài nguyên '%s' không đúng định dạng."
 
+#: ../src/gtk/webview_webkit.cpp:985
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:56
+#: ../src/common/accelcmn.cpp:53
 msgid "Return"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:189
+#: ../src/common/stockitem.cpp:186
 msgid "Revert to Saved"
 msgstr "Hoàn nguyên để Ghi Lại"
 
@@ -6140,42 +6303,42 @@ msgstr "Nhấp nhô"
 msgid "Rig&ht-to-left"
 msgstr "P&hải-sang-trái"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6149
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:59 ../src/generic/datavgen.cpp:6954
+#: ../src/richtext/richtextsizepage.cpp:250
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextbulletspage.cpp:188
-#: ../src/richtext/richtextsizepage.cpp:250 ../src/common/accelcmn.cpp:62
 msgid "Right"
 msgstr "Phải"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1754
+#: ../src/propgrid/advprops.cpp:1655
 #, fuzzy
 msgid "Right Arrow"
 msgstr "Phải"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1770
+#: ../src/propgrid/advprops.cpp:1671
 msgid "Right Button"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:892
+#: ../src/generic/prntdlgg.cpp:885
 msgid "Right margin (mm):"
 msgstr "Lề phải (mm):"
 
-#: ../src/richtext/richtextindentspage.cpp:148
-#: ../src/richtext/richtextindentspage.cpp:150
 #: ../src/richtext/richtextliststylepage.cpp:337
 #: ../src/richtext/richtextliststylepage.cpp:339
+#: ../src/richtext/richtextindentspage.cpp:148
+#: ../src/richtext/richtextindentspage.cpp:150
 msgid "Right-align text."
 msgstr "Canh lề chữ phải."
 
-#: ../src/generic/fontdlgg.cpp:322
+#: ../src/generic/fontdlgg.cpp:318
 msgid "Roman"
 msgstr "Roman"
 
-#: ../src/generic/datavgen.cpp:5916
+#: ../src/generic/datavgen.cpp:6721
 #, c-format
 msgid "Row %i"
 msgstr ""
@@ -6185,30 +6348,31 @@ msgstr ""
 msgid "S&tandard bullet name:"
 msgstr "&Tên bullet tiêu chuẩn:"
 
-#: ../src/common/accelcmn.cpp:268 ../src/common/accelcmn.cpp:350
+#: ../src/common/accelcmn.cpp:282 ../src/common/accelcmn.cpp:367
 msgid "SPECIAL"
 msgstr "SPECIAL"
 
-#: ../src/common/stockitem.cpp:190 ../src/common/sizer.cpp:2797
+#: ../src/common/stockitem.cpp:187 ../src/common/sizer.cpp:2914
 msgid "Save"
 msgstr "Ghi lại"
 
-#: ../src/common/fldlgcmn.cpp:342
+#: ../src/common/fldlgcmn.cpp:339
 #, c-format
 msgid "Save %s file"
 msgstr "Ghi lại %s tập tin"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/common/stockitem.cpp:188 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "&Ghi Lại Bằng Tên Mới..."
 
-#: ../src/common/docview.cpp:366
+#: ../src/common/docview.cpp:359
 msgid "Save As"
 msgstr "Ghi Lại Bằng Tên Mới"
 
-#: ../src/common/stockitem.cpp:191
-msgid "Save as"
-msgstr "Ghi Lại Bằng Tên Mới"
+#: ../src/common/stockitem.cpp:188
+#, fuzzy
+msgid "Save As..."
+msgstr "&Ghi Lại Bằng Tên Mới..."
 
 #: ../src/common/stockitem.cpp:267
 msgid "Save current document"
@@ -6218,40 +6382,40 @@ msgstr "Ghi lại tài liệu hiện tại"
 msgid "Save current document with a different filename"
 msgstr "Ghi lại tài liệu hiện hành với một cái tên khác"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/generic/logg.cpp:509
 msgid "Save log contents to file"
 msgstr "Ghi lại nội dung nhật ký vào tập tin"
 
-#: ../src/common/secretstore.cpp:179
+#: ../src/common/secretstore.cpp:189
 #, fuzzy, c-format
-msgid "Saving password for \"%s/%s\" failed: %s."
+msgid "Saving password for \"%s\" failed: %s."
 msgstr "Rút trích '%s' vào '%s' gặp lỗi."
 
-#: ../src/generic/fontdlgg.cpp:325
+#: ../src/generic/fontdlgg.cpp:321
 msgid "Script"
 msgstr "Script"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll Lock"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll_lock"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:890
+#: ../src/propgrid/advprops.cpp:791
 msgid "Scrollbar"
 msgstr ""
 
-#: ../src/generic/srchctlg.cpp:56 ../src/html/helpwnd.cpp:535
-#: ../src/html/helpwnd.cpp:550
+#: ../src/generic/srchctlg.cpp:55 ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:548 ../src/gtk/srchctrl.cpp:182
 msgid "Search"
 msgstr "Tìm kiếm"
 
-#: ../src/html/helpwnd.cpp:537
+#: ../src/html/helpwnd.cpp:535
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
@@ -6259,32 +6423,32 @@ msgstr ""
 "Tìm kiếm nội dung của cuốn sách trợ giúp cho tất cả các lần xuất hiện của "
 "chữ bạn đã gõ ở trên"
 
-#: ../src/generic/fdrepdlg.cpp:160
+#: ../src/generic/fdrepdlg.cpp:157
 msgid "Search direction"
 msgstr "Hướng tìm kiếm"
 
-#: ../src/generic/fdrepdlg.cpp:112
+#: ../src/generic/fdrepdlg.cpp:109
 msgid "Search for:"
 msgstr "Tìm kiếm cho:"
 
-#: ../src/html/helpwnd.cpp:1052
+#: ../src/html/helpwnd.cpp:1050
 msgid "Search in all books"
 msgstr "Tìm trong tất cả các sách"
 
-#: ../src/html/helpwnd.cpp:857
+#: ../src/html/helpwnd.cpp:855
 msgid "Searching..."
 msgstr "Đang tìm kiếm..."
 
-#: ../src/generic/dirctrlg.cpp:446
+#: ../src/generic/dirctrlg.cpp:412
 msgid "Sections"
 msgstr "Vùng chọn"
 
-#: ../src/common/ffile.cpp:238
+#: ../src/common/ffile.cpp:237
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Lỗi khi di chuyển vị trí đọc trên tập tin '%s'"
 
-#: ../src/common/ffile.cpp:228
+#: ../src/common/ffile.cpp:227
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
@@ -6292,25 +6456,25 @@ msgstr ""
 "không được hỗ trợ bởi stdio)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:76
+#: ../src/common/accelcmn.cpp:73
 #, fuzzy
 msgid "Select"
 msgstr "Vùng chọn"
 
-#: ../src/richtext/richtextctrl.cpp:337 ../src/osx/textctrl_osx.cpp:581
-#: ../src/common/stockitem.cpp:192 ../src/msw/textctrl.cpp:2512
+#: ../src/osx/textctrl_osx.cpp:599 ../src/common/stockitem.cpp:189
+#: ../src/msw/textctrl.cpp:2777 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Chọn &Hết"
 
-#: ../src/common/stockitem.cpp:192 ../src/stc/stc_i18n.cpp:21
+#: ../src/common/stockitem.cpp:189 ../src/stc/stc_i18n.cpp:21
 msgid "Select All"
 msgstr "Chọn Hết"
 
-#: ../src/common/docview.cpp:1895
+#: ../src/common/docview.cpp:1900
 msgid "Select a document template"
 msgstr "Chọn một tài liệu tạm thời"
 
-#: ../src/common/docview.cpp:1969
+#: ../src/common/docview.cpp:1974
 msgid "Select a document view"
 msgstr "Chọn một bộ hiển thị tài liệu"
 
@@ -6339,20 +6503,20 @@ msgid "Selects the list level to edit."
 msgstr "Chọn mức danh sách muốn chỉnh sửa."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:82
+#: ../src/common/accelcmn.cpp:79
 msgid "Separator"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1083
+#: ../src/common/cmdline.cpp:1079
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Cần dấu phân cách sau tùy chọn '%s'."
 
-#: ../src/osx/menu_osx.cpp:572
+#: ../src/osx/menu_osx.cpp:464
 msgid "Services"
 msgstr "Dịch vụ"
 
-#: ../src/richtext/richtextbuffer.cpp:11217
+#: ../src/richtext/richtextbuffer.cpp:11216
 msgid "Set Cell Style"
 msgstr "Đặt Kiểu Dáng Ô"
 
@@ -6360,11 +6524,11 @@ msgstr "Đặt Kiểu Dáng Ô"
 msgid "SetProperty called w/o valid setter"
 msgstr "SetProperty được gọi bởi bộ đặt w/o hợp lệ"
 
-#: ../src/generic/prntdlgg.cpp:188
+#: ../src/generic/prntdlgg.cpp:181
 msgid "Setup..."
 msgstr "Cài đặt..."
 
-#: ../src/msw/dialup.cpp:544
+#: ../src/msw/dialup.cpp:538
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr ""
 "Tìm thấy nhiều kết nối quay số đang hoạt động, đang chọn một cái ngẫu nhiên."
@@ -6382,40 +6546,40 @@ msgstr ""
 msgid "Shadow c&olour:"
 msgstr "Chọn màu"
 
-#: ../src/common/accelcmn.cpp:335
+#: ../src/common/accelcmn.cpp:349
 msgid "Shift+"
 msgstr "Shift+"
 
-#: ../src/generic/dirdlgg.cpp:147
+#: ../src/generic/dirdlgg.cpp:144
 msgid "Show &hidden directories"
 msgstr "&Hiện thư mục ẩn"
 
-#: ../src/generic/filectrlg.cpp:983
+#: ../src/generic/filectrlg.cpp:979
 msgid "Show &hidden files"
 msgstr "&Hiện tập tin ẩn"
 
-#: ../src/osx/menu_osx.cpp:580
+#: ../src/osx/menu_osx.cpp:472
 msgid "Show All"
 msgstr "Hiện tất"
 
-#: ../src/common/stockitem.cpp:257
+#: ../src/common/stockitem.cpp:254
 msgid "Show about dialog"
 msgstr "Hiển thị hộp thoại thông tin thêm"
 
-#: ../src/html/helpwnd.cpp:492
+#: ../src/html/helpwnd.cpp:490
 msgid "Show all"
 msgstr "Hiện tất"
 
-#: ../src/html/helpwnd.cpp:503
+#: ../src/html/helpwnd.cpp:501
 msgid "Show all items in index"
 msgstr "Hiển thị tất cả các mục tin trong mục lục"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:656
 msgid "Show/hide navigation panel"
 msgstr "Hiện/ẩn bản điều hướng"
 
-#: ../src/richtext/richtextsymboldlg.cpp:421
-#: ../src/richtext/richtextsymboldlg.cpp:423
+#: ../src/richtext/richtextsymboldlg.cpp:418
+#: ../src/richtext/richtextsymboldlg.cpp:420
 msgid "Shows a Unicode subset."
 msgstr "Hiển thị tập con của bộ mã Unicode."
 
@@ -6431,7 +6595,7 @@ msgstr "Xem thử các cài đặt về bullet."
 msgid "Shows a preview of the font settings."
 msgstr "Xem thử các cài đặt về phông chữ."
 
-#: ../src/osx/carbon/fontdlg.cpp:394 ../src/osx/carbon/fontdlg.cpp:396
+#: ../src/osx/carbon/fontdlg.cpp:391 ../src/osx/carbon/fontdlg.cpp:393
 msgid "Shows a preview of the font."
 msgstr "Xem thử phông chữ."
 
@@ -6440,62 +6604,62 @@ msgstr "Xem thử phông chữ."
 msgid "Shows a preview of the paragraph settings."
 msgstr "Xem thử cài đặt về đoạn văn."
 
-#: ../src/generic/fontdlgg.cpp:460 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:456 ../src/generic/fontdlgg.cpp:458
 msgid "Shows the font preview."
 msgstr "Hiện bộ xem thử phông chữ."
 
-#: ../src/propgrid/advprops.cpp:1607
+#: ../src/propgrid/advprops.cpp:1513
 msgid "Silver"
 msgstr ""
 
-#: ../src/univ/themes/mono.cpp:516
+#: ../src/univ/themes/mono.cpp:513
 msgid "Simple monochrome theme"
 msgstr "Theme màu đơn sắc đơn giản"
 
-#: ../src/richtext/richtextindentspage.cpp:275
 #: ../src/richtext/richtextliststylepage.cpp:449
+#: ../src/richtext/richtextindentspage.cpp:275
 msgid "Single"
 msgstr "Đơn"
 
-#: ../src/generic/filectrlg.cpp:425 ../src/richtext/richtextformatdlg.cpp:369
-#: ../src/richtext/richtextsizepage.cpp:299
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextsizepage.cpp:299
+#: ../src/richtext/richtextformatdlg.cpp:362
 msgid "Size"
 msgstr "Kích thước"
 
-#: ../src/osx/carbon/fontdlg.cpp:339
+#: ../src/osx/carbon/fontdlg.cpp:336
 msgid "Size:"
 msgstr "Kích thước:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1775
+#: ../src/propgrid/advprops.cpp:1676
 msgid "Sizing"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1772
+#: ../src/propgrid/advprops.cpp:1673
 msgid "Sizing N-S"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1771
+#: ../src/propgrid/advprops.cpp:1672
 msgid "Sizing NE-SW"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1773
+#: ../src/propgrid/advprops.cpp:1674
 msgid "Sizing NW-SE"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1774
+#: ../src/propgrid/advprops.cpp:1675
 msgid "Sizing W-E"
 msgstr ""
 
-#: ../src/msw/progdlg.cpp:801
+#: ../src/msw/progdlg.cpp:1088
 msgid "Skip"
 msgstr "Bỏ qua"
 
-#: ../src/generic/fontdlgg.cpp:330
+#: ../src/generic/fontdlgg.cpp:326
 msgid "Slant"
 msgstr "Nghiêng"
 
@@ -6504,7 +6668,7 @@ msgid "Small C&apitals"
 msgstr "Chữ viết &Hoa nhỏ"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:79
+#: ../src/common/accelcmn.cpp:76
 msgid "Snapshot"
 msgstr ""
 
@@ -6512,37 +6676,37 @@ msgstr ""
 msgid "Solid"
 msgstr "Đặc"
 
-#: ../src/common/docview.cpp:1791
+#: ../src/common/docview.cpp:1785
 msgid "Sorry, could not open this file."
 msgstr "Xin lỗi, không thể mở tập tin này."
 
-#: ../src/common/prntbase.cpp:2057 ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2079 ../src/common/prntbase.cpp:2087
 msgid "Sorry, not enough memory to create a preview."
 msgstr "Rất tiếc, không đủ bộ nhớ để tạo lập việc xem thử."
 
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "Sorry, that name is taken. Please choose another."
 msgstr "Rất tiếc, tên đó đã được dùng. Xin hãy chọn một cái khác."
 
-#: ../src/common/docview.cpp:1814
+#: ../src/common/docview.cpp:1819
 msgid "Sorry, the format for this file is unknown."
 msgstr "Rất tiếc, định dạng tập tin này không hiểu."
 
-#: ../src/unix/sound.cpp:492
+#: ../src/unix/sound.cpp:481
 msgid "Sound data are in unsupported format."
 msgstr "Có vẻ như dữ liệu có định dạng không được hỗ trợ."
 
-#: ../src/unix/sound.cpp:477
+#: ../src/unix/sound.cpp:466
 #, c-format
 msgid "Sound file '%s' is in unsupported format."
 msgstr "Có vẻ như tập tin '%s' không được hỗ trợ định dạng."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:67
+#: ../src/common/accelcmn.cpp:64
 #, fuzzy
 msgid "Space"
 msgstr "Khoảng cách"
@@ -6551,12 +6715,12 @@ msgstr "Khoảng cách"
 msgid "Spacing"
 msgstr "Khoảng cách"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "Spell Check"
 msgstr "Kiểm tra chính tả"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1776
+#: ../src/propgrid/advprops.cpp:1677
 msgid "Spraycan"
 msgstr ""
 
@@ -6565,7 +6729,7 @@ msgstr ""
 msgid "Standard"
 msgstr "Tiêu chuẩn"
 
-#: ../src/common/paper.cpp:104
+#: ../src/common/paper.cpp:101
 msgid "Statement, 5 1/2 x 8 1/2 in"
 msgstr "Statement, 5 1/2 x 8 1/2 in"
 
@@ -6574,33 +6738,29 @@ msgstr "Statement, 5 1/2 x 8 1/2 in"
 msgid "Static"
 msgstr "Thống kê"
 
-#: ../src/generic/prntdlgg.cpp:204
+#: ../src/generic/prntdlgg.cpp:197
 msgid "Status:"
 msgstr "Tình trạng:"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "Stop"
 msgstr "Dừng"
 
-#: ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196
 msgid "Strikethrough"
 msgstr "Gạch giữa"
 
-#: ../src/common/colourcmn.cpp:45
+#: ../src/common/colourcmn.cpp:42
 #, c-format
 msgid "String To Colour : Incorrect colour specification : %s"
 msgstr "Màu từ Xâu chữ : Đặc tả màu không chính xác : %s"
 
 #. TRANSLATORS: Label of font style
-#: ../src/richtext/richtextformatdlg.cpp:339 ../src/propgrid/advprops.cpp:680
+#: ../src/propgrid/advprops.cpp:590 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Kiểu dáng"
 
-#: ../include/wx/richtext/richtextstyledlg.h:46
-msgid "Style Organiser"
-msgstr "Kiểu dáng Bộ Tổ Chức"
-
-#: ../src/osx/carbon/fontdlg.cpp:348
+#: ../src/osx/carbon/fontdlg.cpp:345
 msgid "Style:"
 msgstr "Kiểu dáng"
 
@@ -6609,7 +6769,7 @@ msgid "Subscrip&t"
 msgstr "Chỉ số dưới &dòng"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:83
+#: ../src/common/accelcmn.cpp:80
 msgid "Subtract"
 msgstr ""
 
@@ -6617,11 +6777,11 @@ msgstr ""
 msgid "Supe&rscript"
 msgstr "Chỉ số t&rên dòng"
 
-#: ../src/common/paper.cpp:150
+#: ../src/common/paper.cpp:147
 msgid "SuperA/SuperA/A4 227 x 356 mm"
 msgstr "SuperA/SuperA/A4 227 x 356 mm"
 
-#: ../src/common/paper.cpp:151
+#: ../src/common/paper.cpp:148
 msgid "SuperB/SuperB/A3 305 x 487 mm"
 msgstr "SuperB/SuperB/A3 305 x 487 mm"
 
@@ -6629,7 +6789,7 @@ msgstr "SuperB/SuperB/A3 305 x 487 mm"
 msgid "Suppress hyphe&nation"
 msgstr "Cấm tá&ch từ"
 
-#: ../src/generic/fontdlgg.cpp:326
+#: ../src/generic/fontdlgg.cpp:322
 msgid "Swiss"
 msgstr "Swiss"
 
@@ -6647,74 +6807,74 @@ msgstr "&Phông chữ ký tự đặc biệt:"
 msgid "Symbols"
 msgstr "Ký tự đặc biệt"
 
-#: ../src/common/imagtiff.cpp:369 ../src/common/imagtiff.cpp:382
-#: ../src/common/imagtiff.cpp:741
+#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
+#: ../src/common/imagtiff.cpp:738
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: Không thể cấp phát bộ nhớ."
 
-#: ../src/common/imagtiff.cpp:301
+#: ../src/common/imagtiff.cpp:298
 msgid "TIFF: Error loading image."
 msgstr "TIFF: Lỗi tải ảnh."
 
-#: ../src/common/imagtiff.cpp:468
+#: ../src/common/imagtiff.cpp:465
 msgid "TIFF: Error reading image."
 msgstr "TIFF: Lỗi trong khi đọc tập tin ảnh."
 
-#: ../src/common/imagtiff.cpp:608
+#: ../src/common/imagtiff.cpp:605
 msgid "TIFF: Error saving image."
 msgstr "TIFF: Gặp lỗi khi ghi tập tin ảnh."
 
-#: ../src/common/imagtiff.cpp:846
+#: ../src/common/imagtiff.cpp:843
 msgid "TIFF: Error writing image."
 msgstr "TIFF: Gặp lỗi khi ghi tập tin ảnh."
 
-#: ../src/common/imagtiff.cpp:355
+#: ../src/common/imagtiff.cpp:352
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: Kích cỡ ảnh thường lớn."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:68
+#: ../src/common/accelcmn.cpp:65
 #, fuzzy
 msgid "Tab"
 msgstr "Tabs"
 
-#: ../src/richtext/richtextbuffer.cpp:11498
+#: ../src/richtext/richtextbuffer.cpp:11497
 msgid "Table Properties"
 msgstr "Các thuộc tính Bảng"
 
-#: ../src/common/paper.cpp:145
+#: ../src/common/paper.cpp:142
 msgid "Tabloid Extra 11.69 x 18 in"
 msgstr "Tabloid Extra 11.69 x 18 in"
 
-#: ../src/common/paper.cpp:102
+#: ../src/common/paper.cpp:99
 msgid "Tabloid, 11 x 17 in"
 msgstr "Tabloid, 11 x 17 in"
 
-#: ../src/richtext/richtextformatdlg.cpp:354
+#: ../src/richtext/richtextformatdlg.cpp:347
 msgid "Tabs"
 msgstr "Tabs"
 
-#: ../src/propgrid/advprops.cpp:1598
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Teal"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:327
+#: ../src/generic/fontdlgg.cpp:323
 msgid "Teletype"
 msgstr "Dạng Teletype"
 
-#: ../src/common/docview.cpp:1896
+#: ../src/common/docview.cpp:1901
 msgid "Templates"
 msgstr "Biểu mẫu"
 
-#: ../src/common/fmapbase.cpp:158
+#: ../src/common/fmapbase.cpp:155
 msgid "Thai (ISO-8859-11)"
 msgstr "Thai (ISO-8859-11)"
 
-#: ../src/common/ftp.cpp:619
+#: ../src/common/ftp.cpp:622
 msgid "The FTP server doesn't support passive mode."
 msgstr "Máy chủ FTP không hỗ trợ chế độ tích cực."
 
-#: ../src/common/ftp.cpp:605
+#: ../src/common/ftp.cpp:608
 msgid "The FTP server doesn't support the PORT command."
 msgstr "Máy chủ FTP không hỗ trợ lệnh PORT."
 
@@ -6725,8 +6885,8 @@ msgstr "Máy chủ FTP không hỗ trợ lệnh PORT."
 msgid "The available bullet styles."
 msgstr "Các kiểu dáng bullet sẵn có."
 
-#: ../src/richtext/richtextstyledlg.cpp:202
-#: ../src/richtext/richtextstyledlg.cpp:204
+#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:200
 msgid "The available styles."
 msgstr "Các kiểu dáng sẵn có."
 
@@ -6782,12 +6942,12 @@ msgstr "Vị trí đáy."
 msgid "The bullet character."
 msgstr "Ký tự dùng với bullet."
 
-#: ../src/richtext/richtextsymboldlg.cpp:443
-#: ../src/richtext/richtextsymboldlg.cpp:445
+#: ../src/richtext/richtextsymboldlg.cpp:440
+#: ../src/richtext/richtextsymboldlg.cpp:442
 msgid "The character code."
 msgstr "Mã ký tự."
 
-#: ../src/common/fontmap.cpp:203
+#: ../src/common/fontmap.cpp:200
 #, c-format
 msgid ""
 "The charset '%s' is unknown. You may select\n"
@@ -6798,7 +6958,7 @@ msgstr ""
 "bộ ký tự khác để thay thế cho nó hay chọn\n"
 "[Hủy] nếu nó không thể thay thế được"
 
-#: ../src/msw/ole/dataobj.cpp:394
+#: ../src/msw/ole/dataobj.cpp:402
 #, c-format
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "Định dạng clipboard '%d' chưa tồn tại."
@@ -6808,7 +6968,7 @@ msgstr "Định dạng clipboard '%d' chưa tồn tại."
 msgid "The default style for the next paragraph."
 msgstr "Kiểu dáng mặc định cho đoạn tiếp theo."
 
-#: ../src/generic/dirdlgg.cpp:202
+#: ../src/generic/dirdlgg.cpp:199
 #, c-format
 msgid ""
 "The directory '%s' does not exist\n"
@@ -6817,7 +6977,7 @@ msgstr ""
 "Thư mục '%s' chưa tồn tại\n"
 "Có tạo bây giờ không?"
 
-#: ../src/html/htmprint.cpp:271
+#: ../src/html/htmprint.cpp:283
 #, c-format
 msgid ""
 "The document \"%s\" doesn't fit on the page horizontally and will be "
@@ -6830,7 +6990,7 @@ msgstr ""
 "\n"
 "Bạn có thực sự muốn in nó không?"
 
-#: ../src/common/docview.cpp:1202
+#: ../src/common/docview.cpp:1196
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -6839,36 +6999,36 @@ msgstr ""
 "Tập tin '%s' không tồn tại và không thể mở được.\n"
 "Nó đã bị gỡ bỏ từ danh sách tập tin mới được dùng gần đây nhất."
 
-#: ../src/richtext/richtextindentspage.cpp:208
-#: ../src/richtext/richtextindentspage.cpp:210
 #: ../src/richtext/richtextliststylepage.cpp:394
 #: ../src/richtext/richtextliststylepage.cpp:396
+#: ../src/richtext/richtextindentspage.cpp:208
+#: ../src/richtext/richtextindentspage.cpp:210
 msgid "The first line indent."
 msgstr "Thụt lề dòng đầu tiên."
 
-#: ../src/gtk/utilsgtk.cpp:481
-msgid "The following standard GTK+ options are also supported:\n"
-msgstr "Các tùy chọn GTK+ tiêu chuẩn sau đây đều được hỗ trợ:\n"
+#: ../src/generic/dbgrptg.cpp:318
+msgid "The following debug report will be generated\n"
+msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:414 ../src/generic/fontdlgg.cpp:416
+#: ../src/generic/fontdlgg.cpp:411 ../src/generic/fontdlgg.cpp:413
 msgid "The font colour."
 msgstr "Màu phông chữ."
 
-#: ../src/generic/fontdlgg.cpp:375 ../src/generic/fontdlgg.cpp:377
+#: ../src/generic/fontdlgg.cpp:371 ../src/generic/fontdlgg.cpp:373
 msgid "The font family."
 msgstr "Họ phông chữ."
 
-#: ../src/richtext/richtextsymboldlg.cpp:405
-#: ../src/richtext/richtextsymboldlg.cpp:407
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "The font from which to take the symbol."
 msgstr "Phông chữ từ đó đã lấy ký tự đặc biệt."
 
-#: ../src/generic/fontdlgg.cpp:427 ../src/generic/fontdlgg.cpp:429
-#: ../src/generic/fontdlgg.cpp:434 ../src/generic/fontdlgg.cpp:436
+#: ../src/generic/fontdlgg.cpp:424 ../src/generic/fontdlgg.cpp:426
+#: ../src/generic/fontdlgg.cpp:430 ../src/generic/fontdlgg.cpp:432
 msgid "The font point size."
 msgstr "Cỡ phông chữ theo đơn vị point."
 
-#: ../src/osx/carbon/fontdlg.cpp:343 ../src/osx/carbon/fontdlg.cpp:345
+#: ../src/osx/carbon/fontdlg.cpp:340 ../src/osx/carbon/fontdlg.cpp:342
 msgid "The font size in points."
 msgstr "Cỡ phông chữ theo đơn vị point."
 
@@ -6877,15 +7037,15 @@ msgstr "Cỡ phông chữ theo đơn vị point."
 msgid "The font size units, points or pixels."
 msgstr "Các đơn vị cỡ chữ, point hay pixel."
 
-#: ../src/generic/fontdlgg.cpp:386 ../src/generic/fontdlgg.cpp:388
+#: ../src/generic/fontdlgg.cpp:382 ../src/generic/fontdlgg.cpp:384
 msgid "The font style."
 msgstr "Kiểu phông chữ."
 
-#: ../src/generic/fontdlgg.cpp:397 ../src/generic/fontdlgg.cpp:399
+#: ../src/generic/fontdlgg.cpp:393 ../src/generic/fontdlgg.cpp:395
 msgid "The font weight."
 msgstr "Độ đậm phông chữ."
 
-#: ../src/common/docview.cpp:1483
+#: ../src/common/docview.cpp:1477
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Định dạng của tập tin '%s' không phân tách đúng định dạng."
@@ -6896,10 +7056,10 @@ msgstr "Định dạng của tập tin '%s' không phân tách đúng định d�
 msgid "The horizontal offset."
 msgstr "Cho phép đoạn bù (offset) theo chiều dọc."
 
-#: ../src/richtext/richtextindentspage.cpp:199
-#: ../src/richtext/richtextindentspage.cpp:201
 #: ../src/richtext/richtextliststylepage.cpp:385
 #: ../src/richtext/richtextliststylepage.cpp:387
+#: ../src/richtext/richtextindentspage.cpp:199
+#: ../src/richtext/richtextindentspage.cpp:201
 msgid "The left indent."
 msgstr "Thụt lề trái."
 
@@ -6920,10 +7080,10 @@ msgstr "Kích thước đệm bên trái."
 msgid "The left position."
 msgstr "Vị trí trái."
 
-#: ../src/richtext/richtextindentspage.cpp:288
-#: ../src/richtext/richtextindentspage.cpp:290
 #: ../src/richtext/richtextliststylepage.cpp:462
 #: ../src/richtext/richtextliststylepage.cpp:464
+#: ../src/richtext/richtextindentspage.cpp:288
+#: ../src/richtext/richtextindentspage.cpp:290
 msgid "The line spacing."
 msgstr "Chỉnh khoảng cách dòng."
 
@@ -6932,7 +7092,7 @@ msgstr "Chỉnh khoảng cách dòng."
 msgid "The list item number."
 msgstr "Số mẩu tin của danh sách."
 
-#: ../src/msw/ole/automtn.cpp:664
+#: ../src/msw/ole/automtn.cpp:655
 msgid "The locale ID is unknown."
 msgstr "ID nơi chốn không được biết."
 
@@ -6971,18 +7131,18 @@ msgstr "Độ rộng đối tượng"
 msgid "The outline level."
 msgstr "Mức đường bao."
 
-#: ../src/common/log.cpp:277
+#: ../src/common/log.cpp:296
 #, fuzzy, c-format
 msgid "The previous message repeated %u time."
 msgid_plural "The previous message repeated %u times."
 msgstr[0] "Thông điệp kế trước lặp lại %lu lần."
 
-#: ../src/common/log.cpp:270
+#: ../src/common/log.cpp:289
 msgid "The previous message repeated once."
 msgstr "Thông điệp liền trước lặp đi lặp lại thông điệp."
 
-#: ../src/richtext/richtextsymboldlg.cpp:462
-#: ../src/richtext/richtextsymboldlg.cpp:464
+#: ../src/richtext/richtextsymboldlg.cpp:459
+#: ../src/richtext/richtextsymboldlg.cpp:461
 msgid "The range to show."
 msgstr "Chọn vùng cần hiện."
 
@@ -6996,15 +7156,15 @@ msgstr ""
 "thông tin cá nhân,\n"
 "xin hãy bỏ dấu kiểm và chúng sẽ được gỡ bỏ khỏi báo cáo.\n"
 
-#: ../src/common/cmdline.cpp:1254
+#: ../src/common/cmdline.cpp:1250
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "Tham số yêu cầu '%s' đã không được định rõ."
 
-#: ../src/richtext/richtextindentspage.cpp:217
-#: ../src/richtext/richtextindentspage.cpp:219
 #: ../src/richtext/richtextliststylepage.cpp:403
 #: ../src/richtext/richtextliststylepage.cpp:405
+#: ../src/richtext/richtextindentspage.cpp:217
+#: ../src/richtext/richtextindentspage.cpp:219
 msgid "The right indent."
 msgstr "Thụt lề phải."
 
@@ -7046,16 +7206,16 @@ msgstr ""
 msgid "The shadow spread."
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:267
 #: ../src/richtext/richtextliststylepage.cpp:439
 #: ../src/richtext/richtextliststylepage.cpp:441
+#: ../src/richtext/richtextindentspage.cpp:267
 msgid "The spacing after the paragraph."
 msgstr "Khoảng trắng sau một đoạn văn."
 
-#: ../src/richtext/richtextindentspage.cpp:257
-#: ../src/richtext/richtextindentspage.cpp:259
 #: ../src/richtext/richtextliststylepage.cpp:430
 #: ../src/richtext/richtextliststylepage.cpp:432
+#: ../src/richtext/richtextindentspage.cpp:257
+#: ../src/richtext/richtextindentspage.cpp:259
 msgid "The spacing before the paragraph."
 msgstr "Khoảng trắng trước một đoạn văn."
 
@@ -7069,12 +7229,12 @@ msgstr "Tên kiểu dáng."
 msgid "The style on which this style is based."
 msgstr "Kiểu dáng lấy chính kiểu dáng này làm cơ sở."
 
-#: ../src/richtext/richtextstyledlg.cpp:214
-#: ../src/richtext/richtextstyledlg.cpp:216
+#: ../src/richtext/richtextstyledlg.cpp:210
+#: ../src/richtext/richtextstyledlg.cpp:212
 msgid "The style preview."
 msgstr "Xem thử kiểu dáng."
 
-#: ../src/msw/ole/automtn.cpp:680
+#: ../src/msw/ole/automtn.cpp:671
 msgid "The system cannot find the file specified."
 msgstr "Hệ thống không tìm thấy tập tin đã chỉ ra."
 
@@ -7087,7 +7247,7 @@ msgstr "Vị trí tab."
 msgid "The tab positions."
 msgstr "Vị trí tab."
 
-#: ../src/richtext/richtextctrl.cpp:3098
+#: ../src/richtext/richtextctrl.cpp:3099
 msgid "The text couldn't be saved."
 msgstr "Dữ liệu dạng chữ không thể được ghi lại."
 
@@ -7108,7 +7268,7 @@ msgstr "Kích thước đệm trên."
 msgid "The top position."
 msgstr "Vị trí trên cùng."
 
-#: ../src/common/cmdline.cpp:1232
+#: ../src/common/cmdline.cpp:1228
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "Giá trị cho tùy chọn '%s' phải được định rõ."
@@ -7118,7 +7278,7 @@ msgstr "Giá trị cho tùy chọn '%s' phải được định rõ."
 msgid "The value of the corner radius."
 msgstr "Giá trị cho bán kính góc."
 
-#: ../src/msw/dialup.cpp:433
+#: ../src/msw/dialup.cpp:427
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -7133,14 +7293,14 @@ msgstr ""
 msgid "The vertical offset."
 msgstr "Cho phép đoạn bù (offset) theo chiều dọc."
 
-#: ../src/richtext/richtextprint.cpp:619 ../src/html/htmprint.cpp:745
+#: ../src/html/htmprint.cpp:749 ../src/richtext/richtextprint.cpp:615
 msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr ""
 "Có trục trặc xảy ra khi cài đặt kiểu giấy: có lẽ bạn cần phải đặt một máy in "
 "mặc định."
 
-#: ../src/html/htmprint.cpp:255
+#: ../src/html/htmprint.cpp:267
 msgid ""
 "This document doesn't fit on the page horizontally and will be truncated "
 "when it is printed."
@@ -7148,16 +7308,16 @@ msgstr ""
 "Tài liệu này không vừa khớp theo chiều ngang của giấy và sẽ bị cắt cụt đi "
 "khi được in."
 
-#: ../src/common/image.cpp:2854
+#: ../src/common/image.cpp:2963
 #, c-format
 msgid "This is not a %s."
 msgstr "Cái này không phải là một %s."
 
-#: ../src/common/wincmn.cpp:1653
+#: ../src/common/wincmn.cpp:1654
 msgid "This platform does not support background transparency."
 msgstr "Hệ thống này không hỗ trợ làm trong suốt nền"
 
-#: ../src/gtk/window.cpp:4660
+#: ../src/gtk/window.cpp:5664
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
@@ -7165,7 +7325,15 @@ msgstr ""
 "Chương trình này được dịch với phiên bản cũ của GTK+, xin hãy dịch lại với "
 "GTK+ 2.12 hay mới hơn."
 
-#: ../src/msw/thread.cpp:1240
+#: ../src/gtk/glcanvas.cpp:176
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/msw/thread.cpp:1246
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -7173,11 +7341,11 @@ msgstr ""
 "Khởi tạo mô đun tuyến trình gặp lỗi: không thể lưu giá trị trong phần lưu "
 "trữ nội bộ tuyến trình"
 
-#: ../src/unix/threadpsx.cpp:1794
+#: ../src/unix/threadpsx.cpp:1843
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr "Khởi tạo mô đun tuyến trình gặp lỗi: lỗi tạo khóa tuyến trình"
 
-#: ../src/msw/thread.cpp:1228
+#: ../src/msw/thread.cpp:1234
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -7185,81 +7353,81 @@ msgstr ""
 "Khởi tạo mô đun tuyến trình gặp lỗi: không thể cấp phát chỉ số trong phần "
 "lưu trữ nội bộ tuyến trình"
 
-#: ../src/unix/threadpsx.cpp:1043
+#: ../src/unix/threadpsx.cpp:1061
 msgid "Thread priority setting is ignored."
 msgstr "Cài đặt quyền ưu tiên tuyến trình bị bỏ qua."
 
-#: ../src/msw/mdi.cpp:176
+#: ../src/msw/mdi.cpp:171
 msgid "Tile &Horizontally"
 msgstr "Xếp Kề Nhau Theo C&hiều Ngang"
 
-#: ../src/msw/mdi.cpp:177
+#: ../src/msw/mdi.cpp:172
 msgid "Tile &Vertically"
 msgstr "Xếp &Kề Nhau Theo Chiều Đứng"
 
-#: ../src/common/ftp.cpp:200
+#: ../src/common/ftp.cpp:197
 msgid "Timeout while waiting for FTP server to connect, try passive mode."
 msgstr ""
 "Lỗi quá thời gian khi chờ kết nối với máy chủ FTP, hãy thử chế độ thụ động."
 
-#: ../src/generic/tipdlg.cpp:201
+#: ../src/generic/tipdlg.cpp:198
 msgid "Tip of the Day"
 msgstr "Mẹo Nhỏ"
 
-#: ../src/generic/tipdlg.cpp:140
+#: ../src/generic/tipdlg.cpp:137
 msgid "Tips not available, sorry!"
 msgstr "Các mẹo nhỏ vẫn chưa có, thành thật xin lỗi!"
 
-#: ../src/generic/prntdlgg.cpp:242
+#: ../src/generic/prntdlgg.cpp:235
 msgid "To:"
 msgstr "Đến:"
 
-#: ../src/richtext/richtextbuffer.cpp:8363
+#: ../src/richtext/richtextbuffer.cpp:8361
 msgid "Too many EndStyle calls!"
 msgstr "Quá nhiều cú gọi EndStyle!"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:891
+#: ../src/propgrid/advprops.cpp:792
 msgid "Tooltip"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:892
+#: ../src/propgrid/advprops.cpp:793
 msgid "TooltipText"
 msgstr ""
 
-#: ../src/richtext/richtextsizepage.cpp:286
-#: ../src/richtext/richtextsizepage.cpp:290 ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197 ../src/richtext/richtextsizepage.cpp:286
+#: ../src/richtext/richtextsizepage.cpp:290
 msgid "Top"
 msgstr "Trên"
 
-#: ../src/generic/prntdlgg.cpp:881
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Top margin (mm):"
 msgstr "Để lề trên (mm):"
 
-#: ../src/generic/aboutdlgg.cpp:79
+#: ../src/generic/aboutdlgg.cpp:76
 msgid "Translations by "
 msgstr "Dịch bởi "
 
-#: ../src/generic/aboutdlgg.cpp:188
+#: ../src/generic/aboutdlgg.cpp:185
 msgid "Translators"
 msgstr "Người dịch"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:211
+#: ../src/propgrid/propgrid.cpp:192
 msgid "True"
 msgstr "Đúng"
 
-#: ../src/common/fs_mem.cpp:227
+#: ../src/common/fs_mem.cpp:222
 #, c-format
 msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
 msgstr "Cố gắng gỡ bỏ tập tin '%s' từ bộ nhớ VFS, nhưng nó chưa được tải lên!"
 
-#: ../src/common/fmapbase.cpp:156
+#: ../src/common/fmapbase.cpp:153
 msgid "Turkish (ISO-8859-9)"
 msgstr "Thổ Nhĩ Kỳ (ISO-8859-9)"
 
-#: ../src/generic/filectrlg.cpp:426
+#: ../src/generic/filectrlg.cpp:422
 msgid "Type"
 msgstr "Kiểu"
 
@@ -7273,17 +7441,17 @@ msgstr "Gõ một tên phông chữ."
 msgid "Type a size in points."
 msgstr "Kích thước phông chữ theo points."
 
-#: ../src/msw/ole/automtn.cpp:676
+#: ../src/msw/ole/automtn.cpp:667
 #, c-format
 msgid "Type mismatch in argument %u."
 msgstr "Không khớp kiểu trong tham số %u."
 
-#: ../src/common/xtixml.cpp:356 ../src/common/xtixml.cpp:509
-#: ../src/common/xtistrm.cpp:318
+#: ../src/common/xtixml.cpp:352 ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315
 msgid "Type must have enum - long conversion"
 msgstr "Kiểu phải ở dạng enum - long chuyển đổi"
 
-#: ../src/propgrid/propgridiface.cpp:401
+#: ../src/propgrid/propgridiface.cpp:385
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
@@ -7292,19 +7460,19 @@ msgstr ""
 "Toán tử kiểu \"%s\" gặp lỗi: Tên thuộc tính \"%s\" là kiểu  \"%s\", KHÔNG "
 "PHẢI \"%s\"."
 
-#: ../src/common/paper.cpp:133
+#: ../src/common/paper.cpp:130
 msgid "US Std Fanfold, 14 7/8 x 11 in"
 msgstr "US Std Fanfold, 14 7/8 x 11 in"
 
-#: ../src/common/fmapbase.cpp:196
+#: ../src/common/fmapbase.cpp:193
 msgid "US-ASCII"
 msgstr "US-ASCII"
 
-#: ../src/unix/fswatcher_inotify.cpp:109
+#: ../src/unix/fswatcher_inotify.cpp:106
 msgid "Unable to add inotify watch"
 msgstr "Không thể đóng bộ theo dõi inotify"
 
-#: ../src/unix/fswatcher_kqueue.cpp:136
+#: ../src/unix/fswatcher_kqueue.cpp:153
 msgid "Unable to add kqueue watch"
 msgstr "Không thể tạo bộ theo dõi kqueue"
 
@@ -7316,7 +7484,7 @@ msgstr "Không thể kết giao"
 msgid "Unable to close I/O completion port handle"
 msgstr "Không thể đóng handle cổng Vào/Ra"
 
-#: ../src/unix/fswatcher_inotify.cpp:97
+#: ../src/unix/fswatcher_inotify.cpp:94
 msgid "Unable to close inotify instance"
 msgstr "Không thể đóng inotify"
 
@@ -7334,15 +7502,15 @@ msgstr "Không thể đóng thẻ quản handle cho '%s'"
 msgid "Unable to create I/O completion port"
 msgstr "Không thể tạo handle cổng Vào/Ra"
 
-#: ../src/msw/fswatcher.cpp:84
+#: ../src/msw/fswatcher.cpp:81
 msgid "Unable to create IOCP worker thread"
 msgstr "Không thể tạo tuyến làm việc IOCP được"
 
-#: ../src/unix/fswatcher_inotify.cpp:74
+#: ../src/unix/fswatcher_inotify.cpp:71
 msgid "Unable to create inotify instance"
 msgstr "Không thể tạo inotify được"
 
-#: ../src/unix/fswatcher_kqueue.cpp:97
+#: ../src/unix/fswatcher_kqueue.cpp:114
 msgid "Unable to create kqueue instance"
 msgstr "Không thể tạo kqueue được"
 
@@ -7350,11 +7518,11 @@ msgstr "Không thể tạo kqueue được"
 msgid "Unable to dequeue completion packet"
 msgstr "Không thể tạo rút ra từ hàng đợi"
 
-#: ../src/unix/fswatcher_kqueue.cpp:185
+#: ../src/unix/fswatcher_kqueue.cpp:202
 msgid "Unable to get events from kqueue"
 msgstr "Không thể lấy các sự kiện từ kqueue"
 
-#: ../src/gtk/app.cpp:435
+#: ../src/gtk/app.cpp:431
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr ""
 "Không thể khởi tạo GTK+, BỘ HIỂN THỊ đã cài đặt các thuộc tính hay chưa?"
@@ -7364,12 +7532,12 @@ msgstr ""
 msgid "Unable to open path '%s'"
 msgstr "Không thể mở đường dẫn '%s'"
 
-#: ../src/html/htmlwin.cpp:583
+#: ../src/html/htmlwin.cpp:586
 #, c-format
 msgid "Unable to open requested HTML document: %s"
 msgstr "Không thể mở tài liệu HTML đã yêu cầu: %s"
 
-#: ../src/unix/sound.cpp:368
+#: ../src/unix/sound.cpp:365
 msgid "Unable to play sound asynchronously."
 msgstr "Không thể chạy đoạn âm thanh dị bộ."
 
@@ -7377,63 +7545,63 @@ msgstr "Không thể chạy đoạn âm thanh dị bộ."
 msgid "Unable to post completion status"
 msgstr "Không thể gửi hoàn thiện trạng thái"
 
-#: ../src/unix/fswatcher_inotify.cpp:556
+#: ../src/unix/fswatcher_inotify.cpp:553
 msgid "Unable to read from inotify descriptor"
 msgstr "Không đọc được phần mô tả của inotify"
 
-#: ../src/unix/fswatcher_inotify.cpp:141
+#: ../src/unix/fswatcher_inotify.cpp:138
 #, fuzzy, c-format
 msgid "Unable to remove inotify watch %i"
 msgstr "Không thể gỡ bỏ bộ theo dõi inotify"
 
-#: ../src/unix/fswatcher_kqueue.cpp:153
+#: ../src/unix/fswatcher_kqueue.cpp:170
 msgid "Unable to remove kqueue watch"
 msgstr "Không thể gỡ bỏ bộ theo dõi kqueue"
 
-#: ../src/msw/fswatcher.cpp:168
+#: ../src/msw/fswatcher.cpp:165
 #, c-format
 msgid "Unable to set up watch for '%s'"
 msgstr "Không thể cài đặt cửa sổ theo dõi cho '%s'"
 
-#: ../src/msw/fswatcher.cpp:91
+#: ../src/msw/fswatcher.cpp:88
 msgid "Unable to start IOCP worker thread"
 msgstr "Không thể khởi tạo tuyến trình làm việc IOCP"
 
-#: ../src/common/stockitem.cpp:201
+#: ../src/common/stockitem.cpp:198
 msgid "Undelete"
 msgstr "Không thể xóa"
 
-#: ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199
 msgid "Underline"
 msgstr "Gạch dưới"
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/richtext/richtextfontpage.cpp:359 ../src/osx/carbon/fontdlg.cpp:370
-#: ../src/propgrid/advprops.cpp:690
+#: ../src/osx/carbon/fontdlg.cpp:367 ../src/propgrid/advprops.cpp:600
+#: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Bị gạch dưới"
 
-#: ../src/common/stockitem.cpp:203 ../src/stc/stc_i18n.cpp:15
+#: ../src/common/stockitem.cpp:200 ../src/stc/stc_i18n.cpp:15
 msgid "Undo"
 msgstr "Undo"
 
-#: ../src/common/stockitem.cpp:265
+#: ../src/common/stockitem.cpp:263
 msgid "Undo last action"
 msgstr "Undo thao tác cuối cùng"
 
-#: ../src/common/cmdline.cpp:1029
+#: ../src/common/cmdline.cpp:1025
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Không cần ký tự đi sau tùy chọn '%s'."
 
-#: ../src/unix/fswatcher_inotify.cpp:274
+#: ../src/unix/fswatcher_inotify.cpp:271
 #, c-format
 msgid "Unexpected event for \"%s\": no matching watch descriptor."
 msgstr ""
 "Gặp sự kiện bất ngờ dành cho \"%s\": không có bộ mô tả theo dõi nào tương "
 "ứng với nó."
 
-#: ../src/common/cmdline.cpp:1195
+#: ../src/common/cmdline.cpp:1191
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Tham số không cần thiết '%s'"
@@ -7442,49 +7610,49 @@ msgstr "Tham số không cần thiết '%s'"
 msgid "Unexpectedly new I/O completion port was created"
 msgstr "Một cổng I/O bất ngờ đã được tạo ra"
 
-#: ../src/msw/fswatcher.cpp:70
+#: ../src/msw/fswatcher.cpp:67
 msgid "Ungraceful worker thread termination"
 msgstr "Sự kết thúc một tuyến trình công việc không đúng đắn"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:460
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:456
+#: ../src/richtext/richtextsymboldlg.cpp:457
+#: ../src/richtext/richtextsymboldlg.cpp:458
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../src/common/fmapbase.cpp:185 ../src/common/fmapbase.cpp:191
+#: ../src/common/fmapbase.cpp:182 ../src/common/fmapbase.cpp:188
 msgid "Unicode 16 bit (UTF-16)"
 msgstr "Unicode 16 bit (UTF-16)"
 
-#: ../src/common/fmapbase.cpp:190
+#: ../src/common/fmapbase.cpp:187
 msgid "Unicode 16 bit Big Endian (UTF-16BE)"
 msgstr "Unicode 16 bit Big Endian (UTF-16BE)"
 
-#: ../src/common/fmapbase.cpp:186
+#: ../src/common/fmapbase.cpp:183
 msgid "Unicode 16 bit Little Endian (UTF-16LE)"
 msgstr "Unicode 16 bit Little Endian (UTF-16LE)"
 
-#: ../src/common/fmapbase.cpp:187 ../src/common/fmapbase.cpp:193
+#: ../src/common/fmapbase.cpp:184 ../src/common/fmapbase.cpp:190
 msgid "Unicode 32 bit (UTF-32)"
 msgstr "Unicode 32 bit (UTF-32)"
 
-#: ../src/common/fmapbase.cpp:192
+#: ../src/common/fmapbase.cpp:189
 msgid "Unicode 32 bit Big Endian (UTF-32BE)"
 msgstr "Unicode 32 bit Big Endian (UTF-32BE)"
 
-#: ../src/common/fmapbase.cpp:188
+#: ../src/common/fmapbase.cpp:185
 msgid "Unicode 32 bit Little Endian (UTF-32LE)"
 msgstr "Unicode 32 bit Little Endian (UTF-32LE)"
 
-#: ../src/common/fmapbase.cpp:182
+#: ../src/common/fmapbase.cpp:179
 msgid "Unicode 7 bit (UTF-7)"
 msgstr "Unicode 7 bit (UTF-7)"
 
-#: ../src/common/fmapbase.cpp:183
+#: ../src/common/fmapbase.cpp:180
 msgid "Unicode 8 bit (UTF-8)"
 msgstr "Unicode 8 bit (UTF-8)"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "Unindent"
 msgstr "Không thụt lề"
 
@@ -7635,97 +7803,102 @@ msgstr "Đơn vị cho vị trí trên."
 msgid "Units for this value."
 msgstr "Đơn vị cho lề trái."
 
-#: ../src/generic/progdlgg.cpp:353 ../src/generic/progdlgg.cpp:622
+#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
 msgid "Unknown"
 msgstr "Không hiểu"
 
-#: ../src/msw/dde.cpp:1174
+#: ../src/msw/dde.cpp:1238
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Không hiểu lỗi DDE %08x"
 
-#: ../src/common/xtistrm.cpp:410
+#: ../src/common/xtistrm.cpp:407
 msgid "Unknown Object passed to GetObjectClassInfo"
 msgstr "Đối Tượng không rõ được truyền tới GetObjectClassInfo"
 
-#: ../src/common/imagpng.cpp:366
+#: ../src/common/imagpng.cpp:383
 #, c-format
 msgid "Unknown PNG resolution unit %d"
 msgstr "Không hiểu đơn vị độ phân giải  PNG %d"
 
-#: ../src/common/xtixml.cpp:327
+#: ../src/common/xtixml.cpp:323
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Không Rõ Thuộc Tính %s"
 
-#: ../src/common/imagtiff.cpp:529
+#: ../src/common/imagtiff.cpp:526
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "Không hiểu đơn vị độ phân giải TIFF %d bỏ qua"
 
-#: ../src/unix/dlunix.cpp:160
+#: ../src/propgrid/props.cpp:155
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/unix/dlunix.cpp:118
 msgid "Unknown dynamic library error"
 msgstr "Không rõ lỗi thư viện liên kết động"
 
-#: ../src/common/fmapbase.cpp:810
+#: ../src/common/fmapbase.cpp:806
 #, c-format
 msgid "Unknown encoding (%d)"
 msgstr "Không rõ bộ giải mã (%d)"
 
-#: ../src/msw/ole/automtn.cpp:688
+#: ../src/msw/ole/automtn.cpp:679
 #, c-format
 msgid "Unknown error %08x"
 msgstr "Không hiểu lỗi %08x"
 
-#: ../src/msw/ole/automtn.cpp:647
+#: ../src/msw/ole/automtn.cpp:638
 msgid "Unknown exception"
 msgstr "Không hiểu ngoại lệ"
 
-#: ../src/common/image.cpp:2839
+#: ../src/common/image.cpp:2942
 msgid "Unknown image data format."
 msgstr "Không hiểu định dạng dữ liệu ảnh"
 
-#: ../src/common/cmdline.cpp:914
+#: ../src/common/cmdline.cpp:910
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Không rõ tùy chọn dài '%s'"
 
-#: ../src/msw/ole/automtn.cpp:631
+#: ../src/msw/ole/automtn.cpp:622
 msgid "Unknown name or named argument."
 msgstr "Không hiểu tên hay tham số tên."
 
-#: ../src/common/cmdline.cpp:929 ../src/common/cmdline.cpp:951
+#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Không biết tùy chọn %s"
 
-#: ../src/common/mimecmn.cpp:225
+#: ../src/common/mimecmn.cpp:221
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "Không khớp '{' trong một mục từ cho kiểu diễn tả %s."
 
-#: ../src/common/cmdproc.cpp:262 ../src/common/cmdproc.cpp:288
-#: ../src/common/cmdproc.cpp:308
+#: ../src/common/cmdproc.cpp:255 ../src/common/cmdproc.cpp:281
+#: ../src/common/cmdproc.cpp:301
 msgid "Unnamed command"
 msgstr "Câu lệnh vô danh"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:413
+#: ../src/propgrid/propgrid.cpp:392
 msgid "Unspecified"
 msgstr "Chưa định danh"
 
-#: ../src/msw/clipbrd.cpp:311
+#: ../src/msw/clipbrd.cpp:325
 msgid "Unsupported clipboard format."
 msgstr "Dạng thức clipboard không được hỗ trợ."
 
-#: ../src/common/appcmn.cpp:256
+#: ../src/common/appcmn.cpp:277
 #, c-format
 msgid "Unsupported theme '%s'."
 msgstr "Theme '%s' không được hỗ trợ."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:205
-#: ../src/common/accelcmn.cpp:63
+#: ../src/common/stockitem.cpp:202 ../src/common/accelcmn.cpp:60
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Up"
 msgstr "Lên"
 
@@ -7739,7 +7912,7 @@ msgstr "Chuyển thành chữ hoa"
 msgid "Upper case roman numerals"
 msgstr "Đổi thành chữ số La Mã in hoa"
 
-#: ../src/common/cmdline.cpp:1326
+#: ../src/common/cmdline.cpp:1322
 #, c-format
 msgid "Usage: %s"
 msgstr "Cách dùng: %s"
@@ -7748,38 +7921,47 @@ msgstr "Cách dùng: %s"
 msgid "Use &shadow"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:169
-#: ../src/richtext/richtextindentspage.cpp:171
 #: ../src/richtext/richtextliststylepage.cpp:358
 #: ../src/richtext/richtextliststylepage.cpp:360
+#: ../src/richtext/richtextindentspage.cpp:169
+#: ../src/richtext/richtextindentspage.cpp:171
 msgid "Use the current alignment setting."
 msgstr "Sử dụng cài đặt về căn chỉnh hiện hành."
 
-#: ../src/common/valtext.cpp:179
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/gtk/font.cpp:552
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/common/valtext.cpp:142
 msgid "Validation conflict"
 msgstr "Bộ xác định tính hợp lệ bị xung đột"
 
-#: ../src/propgrid/manager.cpp:238
+#: ../src/propgrid/manager.cpp:224
 msgid "Value"
 msgstr "Giá trị"
 
-#: ../src/propgrid/props.cpp:386 ../src/propgrid/props.cpp:500
+#: ../src/propgrid/props.cpp:309
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "Giá trị phải là %s hay lớn hơn."
 
-#: ../src/propgrid/props.cpp:417 ../src/propgrid/props.cpp:531
+#: ../src/propgrid/props.cpp:336
 #, c-format
 msgid "Value must be %s or less."
 msgstr "Giá trị phải là %s hay nhỏ hơn."
 
-#: ../src/propgrid/props.cpp:393 ../src/propgrid/props.cpp:424
-#: ../src/propgrid/props.cpp:507 ../src/propgrid/props.cpp:538
+#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "Giá trị phải nằm giữa %s và %s."
 
-#: ../src/generic/aboutdlgg.cpp:128
+#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Phiên bản "
 
@@ -7788,25 +7970,32 @@ msgstr "Phiên bản "
 msgid "Vertical alignment."
 msgstr "Căn lề dọc."
 
-#: ../src/generic/filedlgg.cpp:202
+#: ../src/generic/filedlgg.cpp:199
 msgid "View files as a detailed view"
 msgstr "Hiển thị tập tin dạng chi tiết"
 
-#: ../src/generic/filedlgg.cpp:200
+#: ../src/generic/filedlgg.cpp:197
 msgid "View files as a list view"
 msgstr "Hiển thị tập tin bằng kiểu danh sách liệt kê"
 
-#: ../src/common/docview.cpp:1970
+#: ../src/common/docview.cpp:1975
 msgid "Views"
 msgstr "Trình bày"
 
+#: ../src/gtk/app.cpp:348
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1777
+#: ../src/propgrid/advprops.cpp:1678
 msgid "Wait"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1779
+#: ../src/propgrid/advprops.cpp:1680
 msgid "Wait Arrow"
 msgstr ""
 
@@ -7815,245 +8004,242 @@ msgstr ""
 msgid "Waiting for IO on epoll descriptor %d failed"
 msgstr "Đợi IO trên phần mô tả epoll %d gặp lỗi"
 
-#: ../src/common/log.cpp:223
+#: ../src/common/log.cpp:241
 msgid "Warning: "
 msgstr "Cảnh báo: "
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1778
+#: ../src/propgrid/advprops.cpp:1679
 msgid "Watch"
 msgstr ""
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:685
+#: ../src/propgrid/advprops.cpp:595
 msgid "Weight"
 msgstr "Độ rộng"
 
-#: ../src/common/fmapbase.cpp:148
+#: ../src/common/fmapbase.cpp:145
 msgid "Western European (ISO-8859-1)"
 msgstr "Western European (ISO-8859-1)"
 
-#: ../src/common/fmapbase.cpp:162
+#: ../src/common/fmapbase.cpp:159
 msgid "Western European with Euro (ISO-8859-15)"
 msgstr "Western European with Euro (ISO-8859-15)"
 
-#: ../src/generic/fontdlgg.cpp:446 ../src/generic/fontdlgg.cpp:448
+#: ../src/generic/fontdlgg.cpp:443 ../src/generic/fontdlgg.cpp:445
 msgid "Whether the font is underlined."
 msgstr "Không biết phông chữ có gạch chân hay không."
 
-#: ../src/propgrid/advprops.cpp:1611
+#: ../src/propgrid/advprops.cpp:1517
 msgid "White"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:144
+#: ../src/generic/fdrepdlg.cpp:141
 msgid "Whole word"
 msgstr "Toàn bộ từ"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:532
 msgid "Whole words only"
 msgstr "Chỉ khi khớp cả từ"
 
-#: ../src/univ/themes/win32.cpp:1102
+#: ../src/univ/themes/win32.cpp:1099
 msgid "Win32 theme"
 msgstr "kiểu Win32"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:893
+#: ../src/propgrid/advprops.cpp:794
 #, fuzzy
 msgid "Window"
 msgstr "&Cửa sổ"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:894
+#: ../src/propgrid/advprops.cpp:795
 #, fuzzy
 msgid "WindowFrame"
 msgstr "&Cửa sổ"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:895
+#: ../src/propgrid/advprops.cpp:796
 #, fuzzy
 msgid "WindowText"
 msgstr "&Cửa sổ"
 
-#: ../src/common/fmapbase.cpp:177
+#: ../src/common/fmapbase.cpp:174
 msgid "Windows Arabic (CP 1256)"
 msgstr "Windows Ả Rập (CP 1256)"
 
-#: ../src/common/fmapbase.cpp:178
+#: ../src/common/fmapbase.cpp:175
 msgid "Windows Baltic (CP 1257)"
 msgstr "Windows Baltic (CP 1257)"
 
-#: ../src/common/fmapbase.cpp:171
+#: ../src/common/fmapbase.cpp:168
 msgid "Windows Central European (CP 1250)"
 msgstr "Windows Central European (CP 1250)"
 
-#: ../src/common/fmapbase.cpp:168
+#: ../src/common/fmapbase.cpp:165
 msgid "Windows Chinese Simplified (CP 936) or GB-2312"
 msgstr "Windows Trung Quốc Giản thể (CP 936) hoặc GB-2312"
 
-#: ../src/common/fmapbase.cpp:170
+#: ../src/common/fmapbase.cpp:167
 msgid "Windows Chinese Traditional (CP 950) or Big-5"
 msgstr "Windows Trung Quốc Cổ Điển (CP 950)"
 
-#: ../src/common/fmapbase.cpp:172
+#: ../src/common/fmapbase.cpp:169
 msgid "Windows Cyrillic (CP 1251)"
 msgstr "Windows Cyrillic (CP 1251)"
 
-#: ../src/common/fmapbase.cpp:174
+#: ../src/common/fmapbase.cpp:171
 msgid "Windows Greek (CP 1253)"
 msgstr "Windows Hi Lạp (CP 1253)"
 
-#: ../src/common/fmapbase.cpp:176
+#: ../src/common/fmapbase.cpp:173
 msgid "Windows Hebrew (CP 1255)"
 msgstr "Windows Hebrew (CP 1255)"
 
-#: ../src/common/fmapbase.cpp:167
+#: ../src/common/fmapbase.cpp:164
 msgid "Windows Japanese (CP 932) or Shift-JIS"
 msgstr "Windows Tiếng Nhật (CP 932) hoặc Shift-JIS"
 
-#: ../src/common/fmapbase.cpp:180
+#: ../src/common/fmapbase.cpp:177
 msgid "Windows Johab (CP 1361)"
 msgstr "Windows Johab (CP 1361)"
 
-#: ../src/common/fmapbase.cpp:169
+#: ../src/common/fmapbase.cpp:166
 msgid "Windows Korean (CP 949)"
 msgstr "Windows Tiếng Hàn (CP 949)"
 
-#: ../src/common/fmapbase.cpp:166
+#: ../src/common/fmapbase.cpp:163
 msgid "Windows Thai (CP 874)"
 msgstr "Windows Thái Lan(CP 874)"
 
-#: ../src/common/fmapbase.cpp:175
+#: ../src/common/fmapbase.cpp:172
 msgid "Windows Turkish (CP 1254)"
 msgstr "Windows Thổ Nhĩ Kỳ (CP 1254)"
 
-#: ../src/common/fmapbase.cpp:179
+#: ../src/common/fmapbase.cpp:176
 msgid "Windows Vietnamese (CP 1258)"
 msgstr "Windows Tiếng Việt (CP 1258)"
 
-#: ../src/common/fmapbase.cpp:173
+#: ../src/common/fmapbase.cpp:170
 msgid "Windows Western European (CP 1252)"
 msgstr "Windows Trung Âu (CP 1252)"
 
-#: ../src/common/fmapbase.cpp:181
+#: ../src/common/fmapbase.cpp:178
 msgid "Windows/DOS OEM (CP 437)"
 msgstr "Windows/DOS OEM (CP 437)"
 
-#: ../src/common/fmapbase.cpp:165
+#: ../src/common/fmapbase.cpp:162
 msgid "Windows/DOS OEM Cyrillic (CP 866)"
 msgstr "Windows/DOS OEM Cyrillic (CP 866)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:111
+#: ../src/common/accelcmn.cpp:109
 #, fuzzy
 msgid "Windows_Left"
 msgstr "Windows 7"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:113
+#: ../src/common/accelcmn.cpp:111
 #, fuzzy
 msgid "Windows_Menu"
 msgstr "Windows ME"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:112
+#: ../src/common/accelcmn.cpp:110
 #, fuzzy
 msgid "Windows_Right"
 msgstr "Windows Vista"
 
-#: ../src/common/ffile.cpp:150
+#: ../src/common/ffile.cpp:149
 #, c-format
 msgid "Write error on file '%s'"
 msgstr "Lỗi ghi trên tập tin '%s'"
 
-#: ../src/xml/xml.cpp:914
+#: ../src/xml/xml.cpp:925
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "Gặp lỗi khi phân tách XML: '%s' trên dòng %d"
 
-#: ../src/common/xpmdecod.cpp:796
+#: ../src/common/xpmdecod.cpp:794
 msgid "XPM: Malformed pixel data!"
 msgstr "XPM: Dữ liệu điểm ảnh của ảnh bị hỏng!"
 
-#: ../src/common/xpmdecod.cpp:705
+#: ../src/common/xpmdecod.cpp:702
 #, c-format
 msgid "XPM: incorrect colour description in line %d"
 msgstr "XPM: phần mô tả màu sắc không đúng tại dòng %d"
 
-#: ../src/common/xpmdecod.cpp:680
+#: ../src/common/xpmdecod.cpp:677
 msgid "XPM: incorrect header format!"
 msgstr "XPM: định dạng phần đầu không đúng!"
 
-#: ../src/common/xpmdecod.cpp:716 ../src/common/xpmdecod.cpp:725
+#: ../src/common/xpmdecod.cpp:714 ../src/common/xpmdecod.cpp:723
 #, c-format
 msgid "XPM: malformed colour definition '%s' at line %d!"
 msgstr "XPM: định nghĩa màu sắc dị hình '%s' tại dòng %d!"
 
-#: ../src/common/xpmdecod.cpp:755
+#: ../src/common/xpmdecod.cpp:753
 msgid "XPM: no colors left to use for mask!"
 msgstr "XPM: không tìm thấy màu sử dụng cho mặt nạ!"
 
-#: ../src/common/xpmdecod.cpp:782
+#: ../src/common/xpmdecod.cpp:780
 #, c-format
 msgid "XPM: truncated image data at line %d!"
 msgstr "XPM: dữ liệu bị cắt xén ảnh tại dòng %d!"
 
-#: ../src/propgrid/advprops.cpp:1610
+#: ../src/propgrid/advprops.cpp:1516
 msgid "Yellow"
 msgstr ""
 
-#: ../include/wx/msgdlg.h:276 ../src/common/stockitem.cpp:206
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:203
 #: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Đồng ý"
 
-#: ../src/osx/carbon/overlay.cpp:155
-msgid "You cannot Clear an overlay that is not inited"
-msgstr "Bạn không thể Xóa một overlay mà nó chưa được khởi tạo"
-
-#: ../src/osx/carbon/overlay.cpp:107 ../src/dfb/overlay.cpp:61
-msgid "You cannot Init an overlay twice"
-msgstr "Bạn không thể khởi tạo overlay lần nữa"
-
-#: ../src/generic/dirdlgg.cpp:287
+#: ../src/generic/dirdlgg.cpp:284
 msgid "You cannot add a new directory to this section."
 msgstr "Bạn không thể thêm một thư mục mới vào section này."
 
-#: ../src/propgrid/propgrid.cpp:3299
+#: ../src/propgrid/propgrid.cpp:3276
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 "Bạn đã nhập vào giá trị không hợp lệ. Hãy bấm phím ESC để huỷ bỏ việc chỉnh "
 "sửa."
 
-#: ../src/common/stockitem.cpp:209
+#: ../src/osx/cocoa/menu.mm:286
+#, fuzzy
+msgid "Zoom"
+msgstr "Phóng to"
+
+#: ../src/common/stockitem.cpp:206
 msgid "Zoom &In"
 msgstr "Phóng T&o"
 
-#: ../src/common/stockitem.cpp:210
+#: ../src/common/stockitem.cpp:207
 msgid "Zoom &Out"
 msgstr "Th&u Nhỏ"
 
-#: ../src/common/stockitem.cpp:209 ../src/common/prntbase.cpp:1594
+#: ../src/common/stockitem.cpp:206 ../src/common/prntbase.cpp:1619
 msgid "Zoom In"
 msgstr "Phóng to"
 
-#: ../src/common/stockitem.cpp:210 ../src/common/prntbase.cpp:1580
+#: ../src/common/stockitem.cpp:207 ../src/common/prntbase.cpp:1605
 msgid "Zoom Out"
 msgstr "Thu nhỏ"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to &Fit"
 msgstr "Vừa &Khít Cửa Sổ"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to Fit"
 msgstr "Phóng to Khít Cửa Sổ"
 
-#: ../src/msw/dde.cpp:1141
+#: ../src/msw/dde.cpp:1205
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "một ứng dụng DDEML đã tạo ra một loại điều kiện nối dài."
 
-#: ../src/msw/dde.cpp:1129
+#: ../src/msw/dde.cpp:1193
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -8064,39 +8250,39 @@ msgstr ""
 "hay bộ nhận dạng instance không hợp lệ\n"
 "đã được chuyển qua hàm DDEML."
 
-#: ../src/msw/dde.cpp:1147
+#: ../src/msw/dde.cpp:1211
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "sự có gắng của máy khách để thiết lập một cuộc đàm thoại bị lỗi."
 
-#: ../src/msw/dde.cpp:1144
+#: ../src/msw/dde.cpp:1208
 msgid "a memory allocation failed."
 msgstr "sự cấp phát bộ nhớ bị lỗi."
 
-#: ../src/msw/dde.cpp:1138
+#: ../src/msw/dde.cpp:1202
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "một tham số gặp lỗi được công nhận bởi DDEML."
 
-#: ../src/msw/dde.cpp:1120
+#: ../src/msw/dde.cpp:1184
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "yêu cầu cho chuyển tác advise đồng bộ gặp lỗi quá lâu."
 
-#: ../src/msw/dde.cpp:1126
+#: ../src/msw/dde.cpp:1190
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "yêu cầu chuyển tác dữ liệu đồng bộ gặp lỗi quá lâu."
 
-#: ../src/msw/dde.cpp:1135
+#: ../src/msw/dde.cpp:1199
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "yêu cầu cho chuyển tác thi hành đồng bộ gặp lỗi quá lâu."
 
-#: ../src/msw/dde.cpp:1153
+#: ../src/msw/dde.cpp:1217
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "yêu cầu cho chuyển tác poke đồng bộ gặp lỗi quá lâu."
 
-#: ../src/msw/dde.cpp:1168
+#: ../src/msw/dde.cpp:1232
 msgid "a request to end an advise transaction has timed out."
 msgstr "yêu cầu cho chuyển tác end và advise đồng bộ gặp lỗi quá lâu."
 
-#: ../src/msw/dde.cpp:1162
+#: ../src/msw/dde.cpp:1226
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -8106,15 +8292,15 @@ msgstr ""
 "với chuyển tác đã chấm dứt phía máy khách, hay máy chủ\n"
 "chấm dứt trước khi hoàn tất chuyển tác."
 
-#: ../src/msw/dde.cpp:1150
+#: ../src/msw/dde.cpp:1214
 msgid "a transaction failed."
 msgstr "một chuyển tác bị lỗi."
 
-#: ../src/common/accelcmn.cpp:189
+#: ../src/common/accelcmn.cpp:188
 msgid "alt"
 msgstr "alt"
 
-#: ../src/msw/dde.cpp:1132
+#: ../src/msw/dde.cpp:1196
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -8126,15 +8312,15 @@ msgstr ""
 "hay một ứng dụng khởi tạo như APPCMD_CLIENTONLY đã\n"
 "cố gắng thi hành một chuyển tác phía máy chủ."
 
-#: ../src/msw/dde.cpp:1156
+#: ../src/msw/dde.cpp:1220
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "cuộc gọi nội tới hàm PostMessage gặp lỗi."
 
-#: ../src/msw/dde.cpp:1165
+#: ../src/msw/dde.cpp:1229
 msgid "an internal error has occurred in the DDEML."
 msgstr "một lỗi nội bộ phát sinh trong DDEML."
 
-#: ../src/msw/dde.cpp:1171
+#: ../src/msw/dde.cpp:1235
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -8144,56 +8330,56 @@ msgstr ""
 "Một khi ứng dụng trả về từ một XTYP_XACT_COMPLETE callback,\n"
 "bộ nhận dạng chuyển tác cho callback đó sẽ không còn hợp lệ."
 
-#: ../src/common/zipstrm.cpp:1483
+#: ../src/common/zipstrm.cpp:1522
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "xác nhận rằng đây là các phần móc nối của tập tin zip"
 
-#: ../src/common/fileconf.cpp:1847
+#: ../src/common/fileconf.cpp:1849
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "cố gắng đổi khóa bất biến '%s' bị bỏ qua."
 
-#: ../src/html/chm.cpp:329
+#: ../src/html/chm.cpp:326
 msgid "bad arguments to library function"
 msgstr "tham số sai tới hàm thư viện"
 
-#: ../src/html/chm.cpp:341
+#: ../src/html/chm.cpp:338
 msgid "bad signature"
 msgstr "chữ ký sai"
 
-#: ../src/common/zipstrm.cpp:1918
+#: ../src/common/zipstrm.cpp:1988
 msgid "bad zipfile offset to entry"
 msgstr "đoạn offset tập tin zipfile hỏng được ghi vào"
 
-#: ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400
 msgid "binary"
 msgstr "nhị phân"
 
-#: ../src/common/fontcmn.cpp:996
+#: ../src/common/fontcmn.cpp:1195
 msgid "bold"
 msgstr "đậm"
 
-#: ../src/msw/utils.cpp:1144
+#: ../src/msw/utils.cpp:1135
 #, c-format
 msgid "build %lu"
 msgstr "xây dựng %lu"
 
-#: ../src/common/ffile.cpp:75
+#: ../src/common/ffile.cpp:73
 #, c-format
 msgid "can't close file '%s'"
 msgstr "không thể đóng tập tin '%s'"
 
-#: ../src/common/file.cpp:245
+#: ../src/common/file.cpp:242
 #, c-format
 msgid "can't close file descriptor %d"
 msgstr "không thể đóng phần mô tả tập tin %d"
 
-#: ../src/common/file.cpp:586
+#: ../src/common/ffile.cpp:382 ../src/common/file.cpp:613
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "không thể chuyển các thay đổi tới tập tin '%s'"
 
-#: ../src/common/file.cpp:178
+#: ../src/common/file.cpp:175
 #, c-format
 msgid "can't create file '%s'"
 msgstr "không thể tạo tập tin '%s'"
@@ -8203,50 +8389,50 @@ msgstr "không thể tạo tập tin '%s'"
 msgid "can't delete user configuration file '%s'"
 msgstr "không thể xóa tập tin cấu hình '%s' của người dùng"
 
-#: ../src/common/file.cpp:495
+#: ../src/common/file.cpp:522
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr "không thể kết thúc nếu kết thúc tập tin nằm trên phần mô tả %d"
 
-#: ../src/common/zipstrm.cpp:1692
+#: ../src/common/zipstrm.cpp:1747
 msgid "can't find central directory in zip"
 msgstr "không thể tìm thấy thư mục trung tâm trong zip"
 
-#: ../src/common/file.cpp:465
+#: ../src/common/file.cpp:492
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "không thể tìm thấy độ dài của tập tin trên phần mô tả tập tin %d"
 
-#: ../src/msw/utils.cpp:341
+#: ../src/msw/utils.cpp:336
 msgid "can't find user's HOME, using current directory."
 msgstr ""
 "không thể tìm thấy thư mục HOME của người dùng, sử dụng thư mục hiện hành."
 
-#: ../src/common/file.cpp:366
+#: ../src/common/file.cpp:407
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "không thể vào thẳng phần mô tả tập tin %d"
 
-#: ../src/common/file.cpp:422
+#: ../src/common/file.cpp:463
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "không thể tìm thấy vị trí trên phần mô tả tập tin %d"
 
-#: ../src/common/fontmap.cpp:325
+#: ../src/common/fontmap.cpp:322
 msgid "can't load any font, aborting"
 msgstr "không tải được phông chữ nào, bãi bỏ"
 
-#: ../src/common/file.cpp:231 ../src/common/ffile.cpp:59
+#: ../src/common/ffile.cpp:57 ../src/common/file.cpp:228
 #, c-format
 msgid "can't open file '%s'"
 msgstr "không thể mở tập tin '%s'"
 
-#: ../src/common/fileconf.cpp:320
+#: ../src/common/fileconf.cpp:314
 #, c-format
 msgid "can't open global configuration file '%s'."
 msgstr "không thể mở tập tin cấu hình chung '%s'."
 
-#: ../src/common/fileconf.cpp:336
+#: ../src/common/fileconf.cpp:330
 #, c-format
 msgid "can't open user configuration file '%s'."
 msgstr "không thể mở tập tin '%s' cấu hình của người dùng."
@@ -8255,40 +8441,40 @@ msgstr "không thể mở tập tin '%s' cấu hình của người dùng."
 msgid "can't open user configuration file."
 msgstr "không thể mở tập tin cấu hình của người dùng."
 
-#: ../src/common/zipstrm.cpp:579
+#: ../src/common/zipstrm.cpp:572
 msgid "can't re-initialize zlib deflate stream"
 msgstr "không thể khởi tạo lại zlib deflate stream"
 
-#: ../src/common/zipstrm.cpp:604
+#: ../src/common/zipstrm.cpp:597
 msgid "can't re-initialize zlib inflate stream"
 msgstr "không thể khởi tạo lại zlib inflate stream"
 
-#: ../src/common/file.cpp:304
+#: ../src/common/file.cpp:345
 #, c-format
 msgid "can't read from file descriptor %d"
 msgstr "không thể đọc từ phần mô tả tập tin %d"
 
-#: ../src/common/file.cpp:581
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:608
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "không thể gỡ bỏ tập tin '%s'"
 
-#: ../src/common/file.cpp:598
+#: ../src/common/ffile.cpp:394 ../src/common/file.cpp:625
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "không thể gỡ bỏ tập tin tạm thời '%s'"
 
-#: ../src/common/file.cpp:408
+#: ../src/common/file.cpp:449
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "không thể tìm kiếm trên phần mô tả tập tin %d"
 
-#: ../src/common/textfile.cpp:273
+#: ../src/common/textfile.cpp:161
 #, c-format
 msgid "can't write buffer '%s' to disk."
 msgstr "không thể ghi dữ liệu đệm '%s' vào đĩa."
 
-#: ../src/common/file.cpp:323
+#: ../src/common/file.cpp:364
 #, c-format
 msgid "can't write to file descriptor %d"
 msgstr "không thể ghi dữ liệu vào phần mô tả tập tin %d"
@@ -8298,22 +8484,28 @@ msgid "can't write user configuration file."
 msgstr "không thể ghi tập tin cấu hình của người dùng."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:482 ../src/generic/datavgen.cpp:1261
+#: ../src/common/datavcmn.cpp:2064 ../src/generic/datavgen.cpp:1384
 msgid "checked"
 msgstr ""
 
-#: ../src/html/chm.cpp:345
+#: ../src/html/chm.cpp:342
 msgid "checksum error"
 msgstr "tổng kiểm tra sai"
 
-#: ../src/common/tarstrm.cpp:820
+#: ../src/common/tarstrm.cpp:814
 msgid "checksum failure reading tar header block"
 msgstr "tổng kiểm tra việc đọc khối đầu gói tar bị thất bại"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:226
-#: ../src/richtext/richtextbackgroundpage.cpp:249
-#: ../src/richtext/richtextbackgroundpage.cpp:289
-#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
 #: ../src/richtext/richtextborderspage.cpp:254
 #: ../src/richtext/richtextborderspage.cpp:288
 #: ../src/richtext/richtextborderspage.cpp:322
@@ -8331,105 +8523,128 @@ msgstr "tổng kiểm tra việc đọc khối đầu gói tar bị thất bại
 #: ../src/richtext/richtextmarginspage.cpp:340
 #: ../src/richtext/richtextmarginspage.cpp:363
 #: ../src/richtext/richtextmarginspage.cpp:388
-#: ../src/richtext/richtextsizepage.cpp:339
-#: ../src/richtext/richtextsizepage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:400
-#: ../src/richtext/richtextsizepage.cpp:427
-#: ../src/richtext/richtextsizepage.cpp:454
-#: ../src/richtext/richtextsizepage.cpp:481
-#: ../src/richtext/richtextsizepage.cpp:555
-#: ../src/richtext/richtextsizepage.cpp:590
-#: ../src/richtext/richtextsizepage.cpp:625
-#: ../src/richtext/richtextsizepage.cpp:660
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
 msgid "cm"
 msgstr "cm"
 
-#: ../src/html/chm.cpp:347
+#: ../src/html/chm.cpp:344
 msgid "compression error"
 msgstr "lỗi nén"
 
-#: ../src/common/regex.cpp:236
+#: ../src/common/regex.cpp:233
 msgid "conversion to 8-bit encoding failed"
 msgstr "chuyển đổi sang bộ mã 8-bit gặp lỗi"
 
-#: ../src/common/accelcmn.cpp:187
+#: ../src/common/accelcmn.cpp:186
 msgid "ctrl"
 msgstr "ctrl"
 
-#: ../src/common/cmdline.cpp:1500
+#: ../src/common/cmdline.cpp:1496
 msgid "date"
 msgstr "ngày tháng"
 
-#: ../src/html/chm.cpp:349
+#: ../src/html/chm.cpp:346
 msgid "decompression error"
 msgstr "lỗi giải nén"
 
-#: ../src/richtext/richtextstyles.cpp:780 ../src/common/fmapbase.cpp:820
+#: ../src/common/fmapbase.cpp:816 ../src/richtext/richtextstyles.cpp:777
 msgid "default"
 msgstr "mặc định"
 
-#: ../src/common/cmdline.cpp:1496
+#: ../src/common/cmdline.cpp:1492
 msgid "double"
 msgstr "kép"
 
-#: ../src/common/debugrpt.cpp:538
+#: ../src/common/debugrpt.cpp:539
 msgid "dump of the process state (binary)"
 msgstr "kết xuất trạng thái qui trình (dạng nhị phân)"
 
-#: ../src/common/datetimefmt.cpp:1969
+#: ../src/common/datetimefmt.cpp:1992
 msgid "eighteenth"
 msgstr "thứ mười tám"
 
-#: ../src/common/datetimefmt.cpp:1959
+#: ../src/common/datetimefmt.cpp:1982
 msgid "eighth"
 msgstr "thứ tám"
 
-#: ../src/common/datetimefmt.cpp:1962
+#: ../src/common/datetimefmt.cpp:1985
 msgid "eleventh"
 msgstr "thứ mười một"
 
-#: ../src/common/fileconf.cpp:1833
+#: ../src/common/fileconf.cpp:1835
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "mục từ '%s' xuất hiện nhiều hơn một lần trong nhóm '%s'"
 
-#: ../src/html/chm.cpp:343
+#: ../src/html/chm.cpp:340
 msgid "error in data format"
 msgstr "lỗi định dạng dữ liệu"
 
-#: ../src/html/chm.cpp:331
+#: ../src/html/chm.cpp:328
 msgid "error opening file"
 msgstr "lỗi khi mở tập tin"
 
-#: ../src/common/zipstrm.cpp:1778
+#: ../src/common/zipstrm.cpp:1836
 msgid "error reading zip central directory"
 msgstr "lỗi đọc thư mục trung tâm zip"
 
-#: ../src/common/zipstrm.cpp:1870
+#: ../src/common/zipstrm.cpp:1940
 msgid "error reading zip local header"
 msgstr "lỗi đọc phần đầu nội bộ của zip"
 
-#: ../src/common/zipstrm.cpp:2531
+#: ../src/common/zipstrm.cpp:2615
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "lỗi ghi mục tin zip '%s': kiểm tra crc hay độ dài hỏng"
 
-#: ../src/common/ffile.cpp:188
+#: ../src/common/zipstrm.cpp:2608
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "lỗi ghi mục tin zip '%s': kiểm tra crc hay độ dài hỏng"
+
+#: ../src/common/fontcmn.cpp:1205
+#, fuzzy
+msgid "extrabold"
+msgstr "đậm"
+
+#: ../src/common/fontcmn.cpp:1223
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1167
+#, fuzzy
+msgid "extralight"
+msgstr "ánh sáng"
+
+#: ../src/msw/webview_ie.cpp:1036
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "Thực thi '%s' gặp lỗi\n"
+
+#: ../src/common/ffile.cpp:187
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "làm phẳng tập tin '%s' gặp lỗi"
 
+#: ../src/msw/webview_ie.cpp:1045
+#, fuzzy
+msgid "failed to retrieve execution result"
+msgstr "Khôi phục chữ của thông điệp lỗi RAS gặp lỗi"
+
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1030
+#: ../src/generic/datavgen.cpp:1150
 #, fuzzy
 msgid "false"
 msgstr "Sai"
 
-#: ../src/common/datetimefmt.cpp:1966
+#: ../src/common/datetimefmt.cpp:1989
 msgid "fifteenth"
 msgstr "thứ mười lăm"
 
-#: ../src/common/datetimefmt.cpp:1956
+#: ../src/common/datetimefmt.cpp:1979
 msgid "fifth"
 msgstr "thứ năm"
 
@@ -8458,131 +8673,150 @@ msgstr "tập tin '%s', dòng %d: giá trị khóa bất biến '%s' bị bỏ q
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "tập tin '%s': không mong ký tự %c tại dòng %d."
 
-#: ../src/richtext/richtextbuffer.cpp:8738
+#: ../src/richtext/richtextbuffer.cpp:8736
 msgid "files"
 msgstr "tập tin"
 
-#: ../src/common/datetimefmt.cpp:1952
+#: ../src/common/datetimefmt.cpp:1975
 msgid "first"
 msgstr "đầu tiên"
 
-#: ../src/html/helpwnd.cpp:1252
+#: ../src/html/helpwnd.cpp:1250
 msgid "font size"
 msgstr "cỡ phông chữ"
 
-#: ../src/common/datetimefmt.cpp:1965
+#: ../src/common/datetimefmt.cpp:1988
 msgid "fourteenth"
 msgstr "thứ mười bốn"
 
-#: ../src/common/datetimefmt.cpp:1955
+#: ../src/common/datetimefmt.cpp:1978
 msgid "fourth"
 msgstr "thứ tư"
 
-#: ../src/common/appbase.cpp:783
+#: ../src/common/appbase.cpp:784
 msgid "generate verbose log messages"
 msgstr "tạo ra nhật ký thông tin đầy đủ"
 
-#: ../src/richtext/richtextbuffer.cpp:13138
-#: ../src/richtext/richtextbuffer.cpp:13248
+#: ../src/common/fontcmn.cpp:1215
+msgid "heavy"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:13133
+#: ../src/richtext/richtextbuffer.cpp:13243
 msgid "image"
 msgstr "hình ảnh"
 
-#: ../src/common/tarstrm.cpp:796
+#: ../src/common/tarstrm.cpp:790
 msgid "incomplete header block in tar"
 msgstr "không hoàn thành khối đầu trong gói tar"
 
-#: ../src/common/xtixml.cpp:489
+#: ../src/common/xtixml.cpp:485
 msgid "incorrect event handler string, missing dot"
 msgstr "xâu chữ bộ điều khiển sự kiện không hợp lệ, thiếu dấu chấm"
 
-#: ../src/common/tarstrm.cpp:1381
+#: ../src/common/tarstrm.cpp:1375
 msgid "incorrect size given for tar entry"
 msgstr "kích thước định sẵn cho mục tin của gói tar không hợp lệ"
 
-#: ../src/common/tarstrm.cpp:993
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:987
 msgid "invalid data in extended tar header"
 msgstr "dữ liệu trong phần đầu mở rộng của gói tar không hợp lệ"
 
-#: ../src/generic/logg.cpp:1030
+#: ../src/generic/logg.cpp:1027
 msgid "invalid message box return value"
 msgstr "hộp thoại thông điệp trả về giá trị không hợp lệ"
 
-#: ../src/common/zipstrm.cpp:1647
+#: ../src/common/zipstrm.cpp:1688
 msgid "invalid zip file"
 msgstr "tập tin zip không hợp lệ"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:1228
 msgid "italic"
 msgstr "nghiêng"
 
-#: ../src/common/fontcmn.cpp:991
+#: ../src/common/webrequest_curl.cpp:374
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "Phần miêu tả cột không thể được khởi tạo."
+
+#: ../src/common/fontcmn.cpp:1172
 msgid "light"
 msgstr "ánh sáng"
 
-#: ../src/common/intl.cpp:303
-#, c-format
-msgid "locale '%s' cannot be set."
-msgstr "địa phương '%s' không thể đặt được."
+#: ../src/common/fontcmn.cpp:1185
+msgid "medium"
+msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2125
+#: ../src/common/datetimefmt.cpp:2148
 msgid "midnight"
 msgstr "nửa đêm"
 
-#: ../src/common/datetimefmt.cpp:1970
+#: ../src/common/datetimefmt.cpp:1993
 msgid "nineteenth"
 msgstr "thứ mười chín"
 
-#: ../src/common/datetimefmt.cpp:1960
+#: ../src/common/datetimefmt.cpp:1983
 msgid "ninth"
 msgstr "thứ chín"
 
-#: ../src/msw/dde.cpp:1116
+#: ../src/msw/dde.cpp:1180
 msgid "no DDE error."
 msgstr "không có lỗi DDE."
 
-#: ../src/html/chm.cpp:327
+#: ../src/html/chm.cpp:324
 msgid "no error"
 msgstr "không lỗi"
 
-#: ../src/dfb/fontmgr.cpp:174
+#: ../src/dfb/fontmgr.cpp:171
 #, c-format
 msgid "no fonts found in %s, using builtin font"
 msgstr "không phông chữ nào được tìm thấy trong %s, sử dụng phông dựng sẵn"
 
-#: ../src/html/helpdata.cpp:657
+#: ../src/html/helpdata.cpp:650
 msgid "noname"
 msgstr "không tên"
 
-#: ../src/common/datetimefmt.cpp:2124
+#: ../src/common/datetimefmt.cpp:2147
 msgid "noon"
 msgstr "buổi trưa"
 
-#: ../src/richtext/richtextstyles.cpp:779
+#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "thường"
 
-#: ../src/common/cmdline.cpp:1492
+#: ../src/common/cmdline.cpp:1488
 msgid "num"
 msgstr "số"
 
-#: ../src/common/xtixml.cpp:259
+#: ../src/common/accelcmn.cpp:194
+msgid "num "
+msgstr ""
+
+#: ../src/common/xtixml.cpp:255
 msgid "objects cannot have XML Text Nodes"
 msgstr "đối tượng không thể có XML Text Nodes"
 
-#: ../src/html/chm.cpp:339
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
 msgid "out of memory"
 msgstr "hết bộ nhớ"
 
-#: ../src/common/debugrpt.cpp:514
+#: ../src/common/debugrpt.cpp:515
 msgid "process context description"
 msgstr "mô tả ngữ cảnh tiến trình"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:227
-#: ../src/richtext/richtextbackgroundpage.cpp:250
-#: ../src/richtext/richtextbackgroundpage.cpp:290
-#: ../src/richtext/richtextbackgroundpage.cpp:317
-#: ../src/richtext/richtextfontpage.cpp:177
-#: ../src/richtext/richtextfontpage.cpp:180
 #: ../src/richtext/richtextborderspage.cpp:255
 #: ../src/richtext/richtextborderspage.cpp:289
 #: ../src/richtext/richtextborderspage.cpp:323
@@ -8592,22 +8826,45 @@ msgstr "mô tả ngữ cảnh tiến trình"
 #: ../src/richtext/richtextborderspage.cpp:491
 #: ../src/richtext/richtextborderspage.cpp:525
 #: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextfontpage.cpp:180
 msgid "pt"
 msgstr "pt"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:225
-#: ../src/richtext/richtextbackgroundpage.cpp:228
-#: ../src/richtext/richtextbackgroundpage.cpp:229
-#: ../src/richtext/richtextbackgroundpage.cpp:248
-#: ../src/richtext/richtextbackgroundpage.cpp:251
-#: ../src/richtext/richtextbackgroundpage.cpp:252
-#: ../src/richtext/richtextbackgroundpage.cpp:288
-#: ../src/richtext/richtextbackgroundpage.cpp:291
-#: ../src/richtext/richtextbackgroundpage.cpp:292
-#: ../src/richtext/richtextbackgroundpage.cpp:315
-#: ../src/richtext/richtextbackgroundpage.cpp:318
-#: ../src/richtext/richtextbackgroundpage.cpp:319
-#: ../src/richtext/richtextfontpage.cpp:178
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:659
+#: ../src/richtext/richtextsizepage.cpp:662
+#: ../src/richtext/richtextsizepage.cpp:663
 #: ../src/richtext/richtextborderspage.cpp:253
 #: ../src/richtext/richtextborderspage.cpp:256
 #: ../src/richtext/richtextborderspage.cpp:257
@@ -8659,260 +8916,270 @@ msgstr "pt"
 #: ../src/richtext/richtextmarginspage.cpp:387
 #: ../src/richtext/richtextmarginspage.cpp:389
 #: ../src/richtext/richtextmarginspage.cpp:390
-#: ../src/richtext/richtextsizepage.cpp:338
-#: ../src/richtext/richtextsizepage.cpp:341
-#: ../src/richtext/richtextsizepage.cpp:342
-#: ../src/richtext/richtextsizepage.cpp:372
-#: ../src/richtext/richtextsizepage.cpp:375
-#: ../src/richtext/richtextsizepage.cpp:376
-#: ../src/richtext/richtextsizepage.cpp:399
-#: ../src/richtext/richtextsizepage.cpp:402
-#: ../src/richtext/richtextsizepage.cpp:403
-#: ../src/richtext/richtextsizepage.cpp:426
-#: ../src/richtext/richtextsizepage.cpp:429
-#: ../src/richtext/richtextsizepage.cpp:430
-#: ../src/richtext/richtextsizepage.cpp:453
-#: ../src/richtext/richtextsizepage.cpp:456
-#: ../src/richtext/richtextsizepage.cpp:457
-#: ../src/richtext/richtextsizepage.cpp:480
-#: ../src/richtext/richtextsizepage.cpp:483
-#: ../src/richtext/richtextsizepage.cpp:484
-#: ../src/richtext/richtextsizepage.cpp:554
-#: ../src/richtext/richtextsizepage.cpp:557
-#: ../src/richtext/richtextsizepage.cpp:558
-#: ../src/richtext/richtextsizepage.cpp:589
-#: ../src/richtext/richtextsizepage.cpp:592
-#: ../src/richtext/richtextsizepage.cpp:593
-#: ../src/richtext/richtextsizepage.cpp:624
-#: ../src/richtext/richtextsizepage.cpp:627
-#: ../src/richtext/richtextsizepage.cpp:628
-#: ../src/richtext/richtextsizepage.cpp:659
-#: ../src/richtext/richtextsizepage.cpp:662
-#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextfontpage.cpp:178
 msgid "px"
 msgstr "px (pi-xeo)"
 
-#: ../src/common/accelcmn.cpp:193
+#: ../src/common/accelcmn.cpp:192
 msgid "rawctrl"
 msgstr "rawctrl"
 
-#: ../src/html/chm.cpp:333
+#: ../src/html/chm.cpp:330
 msgid "read error"
 msgstr "lỗi đọc"
 
-#: ../src/common/zipstrm.cpp:2085
+#: ../src/common/zipstrm.cpp:2155
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "đang đọc dòng dữ liệu zip (mục vào %s): kiểm tra độ dư vòng(crc) hỏng"
 
-#: ../src/common/zipstrm.cpp:2080
+#: ../src/common/zipstrm.cpp:2150
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "đang đọc dòng dữ liệu zip (mục vào %s): chiều dài lỗi"
 
-#: ../src/msw/dde.cpp:1159
+#: ../src/msw/dde.cpp:1223
 msgid "reentrancy problem."
 msgstr "trục trặc reentrancy."
 
-#: ../src/common/datetimefmt.cpp:1953
+#: ../src/common/datetimefmt.cpp:1976
 msgid "second"
 msgstr "giây"
 
-#: ../src/html/chm.cpp:337
+#: ../src/html/chm.cpp:334
 msgid "seek error"
 msgstr "lỗi di chuyển vị trí đọc"
 
-#: ../src/common/datetimefmt.cpp:1968
+#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#, fuzzy
+msgid "semibold"
+msgstr "đậm"
+
+#: ../src/common/datetimefmt.cpp:1991
 msgid "seventeenth"
 msgstr "thứ mười bảy"
 
-#: ../src/common/datetimefmt.cpp:1958
+#: ../src/common/datetimefmt.cpp:1981
 msgid "seventh"
 msgstr "thứ bảy"
 
-#: ../src/common/accelcmn.cpp:191
+#: ../src/common/accelcmn.cpp:190
 msgid "shift"
 msgstr "shift"
 
-#: ../src/common/appbase.cpp:773
+#: ../src/common/appbase.cpp:774
 msgid "show this help message"
 msgstr "hiển thị thông tin trợ giúp này"
 
-#: ../src/common/datetimefmt.cpp:1967
+#: ../src/common/datetimefmt.cpp:1990
 msgid "sixteenth"
 msgstr "thứ mười sáu"
 
-#: ../src/common/datetimefmt.cpp:1957
+#: ../src/common/datetimefmt.cpp:1980
 msgid "sixth"
 msgstr "thứ sáu"
 
-#: ../src/common/appcmn.cpp:234
+#: ../src/common/appcmn.cpp:255
 msgid "specify display mode to use (e.g. 640x480-16)"
 msgstr "định rõ chế độ hiển thị sử dụng (ví dụ 640x480-16)"
 
-#: ../src/common/appcmn.cpp:220
+#: ../src/common/appcmn.cpp:241
 msgid "specify the theme to use"
 msgstr "định rõ theme cần dùng"
 
-#: ../src/richtext/richtextbuffer.cpp:9340
+#: ../src/richtext/richtextbuffer.cpp:9337
 msgid "standard/circle"
 msgstr "Tiêu chuẩn/ hình tròn"
 
-#: ../src/richtext/richtextbuffer.cpp:9341
+#: ../src/richtext/richtextbuffer.cpp:9338
 msgid "standard/circle-outline"
 msgstr "tiêu-chuẩn/viền-tròn"
 
-#: ../src/richtext/richtextbuffer.cpp:9343
+#: ../src/richtext/richtextbuffer.cpp:9340
 msgid "standard/diamond"
 msgstr "Tiêu chuẩn/Thoi"
 
-#: ../src/richtext/richtextbuffer.cpp:9342
+#: ../src/richtext/richtextbuffer.cpp:9339
 msgid "standard/square"
 msgstr "Tiêu chuẩn/vuông"
 
-#: ../src/richtext/richtextbuffer.cpp:9344
+#: ../src/richtext/richtextbuffer.cpp:9341
 msgid "standard/triangle"
 msgstr "Tiêu chuẩn/chữ nhật"
 
-#: ../src/common/zipstrm.cpp:1985
+#: ../src/common/zipstrm.cpp:2055
 msgid "stored file length not in Zip header"
 msgstr "phần lưu giữ độ dài tập tin không ở trong phần đầu của Zip"
 
-#: ../src/common/cmdline.cpp:1488
+#: ../src/common/cmdline.cpp:1484
 msgid "str"
 msgstr "str"
 
-#: ../src/common/fontcmn.cpp:982
+#: ../src/common/fontcmn.cpp:1145
 msgid "strikethrough"
 msgstr "Gạch giữa"
 
-#: ../src/common/tarstrm.cpp:1003 ../src/common/tarstrm.cpp:1025
-#: ../src/common/tarstrm.cpp:1507 ../src/common/tarstrm.cpp:1529
+#: ../src/common/tarstrm.cpp:997 ../src/common/tarstrm.cpp:1019
+#: ../src/common/tarstrm.cpp:1501 ../src/common/tarstrm.cpp:1523
 msgid "tar entry not open"
 msgstr "mục tin tar không mở được"
 
-#: ../src/common/datetimefmt.cpp:1961
+#: ../src/common/datetimefmt.cpp:1984
 msgid "tenth"
 msgstr "thứ mười"
 
-#: ../src/msw/dde.cpp:1123
+#: ../src/msw/dde.cpp:1187
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "đáp ứng chuyển tác này là nguyên nhân bít DDE_FBUSY được đặt."
 
-#: ../src/common/datetimefmt.cpp:1954
+#: ../src/common/fontcmn.cpp:1154
+msgid "thin"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:1977
 msgid "third"
 msgstr "thứ ba"
 
-#: ../src/common/datetimefmt.cpp:1964
+#: ../src/common/datetimefmt.cpp:1987
 msgid "thirteenth"
 msgstr "thứ mười ba"
 
-#: ../src/common/datetimefmt.cpp:1758
+#: ../src/common/datetimefmt.cpp:1781
 msgid "today"
 msgstr "hôm nay"
 
-#: ../src/common/datetimefmt.cpp:1760
+#: ../src/common/datetimefmt.cpp:1783
 msgid "tomorrow"
 msgstr "ngày mai"
 
-#: ../src/common/fileconf.cpp:1944
+#: ../src/common/fileconf.cpp:1946
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "dấu gạch ngược bị bỏ qua trong '%s'"
 
-#: ../src/gtk/aboutdlg.cpp:218
+#: ../src/gtk/aboutdlg.cpp:216
 msgid "translator-credits"
 msgstr "công-trạng-dịch-thuật"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1028
+#: ../src/generic/datavgen.cpp:1148
 msgid "true"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1963
+#: ../src/common/datetimefmt.cpp:1986
 msgid "twelfth"
 msgstr "thứ mười hai"
 
-#: ../src/common/datetimefmt.cpp:1971
+#: ../src/common/datetimefmt.cpp:1994
 msgid "twentieth"
 msgstr "thứ hai mươi"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:486 ../src/generic/datavgen.cpp:1263
+#: ../src/common/datavcmn.cpp:2068 ../src/generic/datavgen.cpp:1386
 msgid "unchecked"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:802 ../src/common/fontcmn.cpp:978
+#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
 msgid "underlined"
 msgstr "gạch chân"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:490
+#: ../src/common/datavcmn.cpp:2072
 #, fuzzy
 msgid "undetermined"
 msgstr "gạch chân"
 
-#: ../src/common/fileconf.cpp:1979
+#: ../src/common/fileconf.cpp:1981
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "không cần \" tại vị trí %d trong '%s'."
 
-#: ../src/common/tarstrm.cpp:1045
+#: ../src/common/tarstrm.cpp:1039
 msgid "unexpected end of file"
 msgstr "kết thúc tập tin đột xuất"
 
-#: ../src/generic/progdlgg.cpp:370 ../src/common/tarstrm.cpp:371
-#: ../src/common/tarstrm.cpp:394 ../src/common/tarstrm.cpp:425
+#: ../src/common/tarstrm.cpp:366 ../src/common/tarstrm.cpp:389
+#: ../src/common/tarstrm.cpp:420 ../src/generic/progdlgg.cpp:376
 msgid "unknown"
 msgstr "không rõ"
 
-#: ../src/msw/registry.cpp:150
+#: ../src/msw/registry.cpp:139
 #, fuzzy, c-format
 msgid "unknown (%lu)"
 msgstr "không rõ"
 
-#: ../src/common/xtixml.cpp:253
+#: ../src/common/xtixml.cpp:249
 #, c-format
 msgid "unknown class %s"
 msgstr "chưa biết lớp %s"
 
-#: ../src/common/regex.cpp:258 ../src/html/chm.cpp:351
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "lỗi nén"
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "lỗi giải nén"
+
+#: ../src/common/regex.cpp:255 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "lỗi lạ"
 
-#: ../src/msw/dialup.cpp:471
+#: ../src/msw/dialup.cpp:465
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "chưa biết lỗi (mã sai %08x)."
 
-#: ../src/common/fmapbase.cpp:834
+#: ../src/common/fmapbase.cpp:830
 #, c-format
 msgid "unknown-%d"
 msgstr "không_hiểu-%d"
 
-#: ../src/common/docview.cpp:509
+#: ../src/common/docview.cpp:502
 msgid "unnamed"
 msgstr "không_tên"
 
-#: ../src/common/docview.cpp:1624
+#: ../src/common/docview.cpp:1618
 #, c-format
 msgid "unnamed%d"
 msgstr "Không_tên%d"
 
-#: ../src/common/zipstrm.cpp:1999 ../src/common/zipstrm.cpp:2319
+#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
 msgid "unsupported Zip compression method"
 msgstr "không hỗ trợ phương thức nén Zip"
 
-#: ../src/common/translation.cpp:1892
+#: ../src/common/translation.cpp:1942
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "sử dụng catalog '%s' từ '%s'."
 
-#: ../src/html/chm.cpp:335
+#: ../src/html/chm.cpp:332
 msgid "write error"
 msgstr "lỗi ghi tập tin"
 
-#: ../src/common/time.cpp:292
+#: ../src/gtk/glcanvas.cpp:187
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/common/time.cpp:285
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay bị lỗi."
 
@@ -8925,15 +9192,15 @@ msgstr "wxWidgets không thể mở' %s' ra, đang thoát ra."
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets không thể mở bộ hiển thị. Đang thoát ra."
 
-#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:431
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/common/datetimefmt.cpp:1759
+#: ../src/common/datetimefmt.cpp:1782
 msgid "yesterday"
 msgstr "hôm qua"
 
-#: ../src/common/zstream.cpp:251 ../src/common/zstream.cpp:426
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
 #, c-format
 msgid "zlib error %d"
 msgstr "lỗi zlib %d"
@@ -8942,6 +9209,76 @@ msgstr "lỗi zlib %d"
 #: ../src/richtext/richtextbulletspage.cpp:288
 msgid "~"
 msgstr "~"
+
+#~ msgid "&Save as"
+#~ msgstr "&Ghi Lại Bằng Tên Mới"
+
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' không gồm có ký tự nào hợp lệ"
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' có thể thuộc kiểu số."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' chỉ nên chứa chữ cái trong bảng mã ASCII."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' chỉ nên chứa ký tự trong bảng chữ cái."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' chỉ nên chứa ký tự trong bảng chữ cái hay chữ số."
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' chỉ có thể chứa các chữ số."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "Không thể tạo cửa sổ của lớp %s"
+
+#, fuzzy
+#~ msgid "Could not initalize libnotify."
+#~ msgstr "Không thể đặt sự căn chỉnh."
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "Không tạo được cửa sổ xếp chồng"
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "Không thể khởi tạo context trên cửa sổ overlay"
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "Chuyển đổi tập tin \"%s\" sang Unicode gặp lỗi."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "Gán văn bản vào điều khiển văn bản gặp lỗi."
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr "Tùy chọn dòng lệnh GTK+ không hợp lệ, sử dụng \"%s --help\""
+
+#~ msgid "No unused colour in image."
+#~ msgstr "Không có màu không dùng trong ảnh."
+
+#~ msgid "Not available"
+#~ msgstr "Không sẵn sàng"
+
+#~ msgid "Replace selection"
+#~ msgstr "Thay thế vùng chọn hiện thời"
+
+#~ msgid "Save as"
+#~ msgstr "Ghi Lại Bằng Tên Mới"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Kiểu dáng Bộ Tổ Chức"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "Các tùy chọn GTK+ tiêu chuẩn sau đây đều được hỗ trợ:\n"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "Bạn không thể Xóa một overlay mà nó chưa được khởi tạo"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "Bạn không thể khởi tạo overlay lần nữa"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "địa phương '%s' không thể đặt được."
 
 #~ msgid "Adding flavor TEXT failed"
 #~ msgstr "Việc thêm flavor TEXT gặp lỗi"
@@ -8960,9 +9297,6 @@ msgstr "~"
 
 #~ msgid "Column could not be added."
 #~ msgstr "Cột không thể chèn thêm"
-
-#~ msgid "Column description could not be initialized."
-#~ msgstr "Phần miêu tả cột không thể được khởi tạo."
 
 #~ msgid "Column index not found."
 #~ msgstr "Chỉ mục cột không thấy."
@@ -9610,9 +9944,6 @@ msgstr "~"
 #~ msgid "Failed to create a status bar."
 #~ msgstr "Tạo thanh trạng thái gặp lỗi."
 
-#~ msgid "File %s does not exist."
-#~ msgstr "Tập tin %s chưa tồn tại."
-
 #~ msgid "GB-2312"
 #~ msgstr "GB-2312"
 
@@ -9775,9 +10106,6 @@ msgstr "~"
 
 #~ msgid "Failed to register OpenGL window class."
 #~ msgstr "Đăng ký một lớp cửa sổ OpenGL gặp lỗi."
-
-#~ msgid "Fatal error"
-#~ msgstr "Lỗi nghiêm trọng"
 
 #~ msgid "Fatal error: "
 #~ msgstr "Lỗi nghiêm trọng: "

--- a/locale/wxstd.pot
+++ b/locale/wxstd.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-21 14:25+0200\n"
+"POT-Creation-Date: 2020-10-18 23:11+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,14 +18,14 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: ../src/common/debugrpt.cpp:586
+#: ../src/common/debugrpt.cpp:587
 msgid ""
 "\n"
 "Please send this report to the program maintainer, thank you!\n"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:210
-#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:206
+#: ../src/richtext/richtextstyledlg.cpp:218
 msgid " "
 msgstr ""
 
@@ -33,70 +33,93 @@ msgstr ""
 msgid "              Thank you and we're sorry for the inconvenience!\n"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:573
+#: ../src/common/prntbase.cpp:568
 #, c-format
 msgid " (copy %d of %d)"
 msgstr ""
 
-#: ../src/common/log.cpp:421
+#: ../src/common/log.cpp:440
 #, c-format
 msgid " (error %ld: %s)"
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:72
+#: ../src/common/imagtiff.cpp:69
 #, c-format
 msgid " (in module \"%s\")"
 msgstr ""
 
-#: ../src/osx/core/secretstore.cpp:138
-msgid " (while overwriting an existing item)"
-msgstr ""
-
-#: ../src/common/docview.cpp:1642
+#: ../src/common/docview.cpp:1636
 msgid " - "
 msgstr ""
 
-#: ../src/richtext/richtextprint.cpp:593 ../src/html/htmprint.cpp:714
+#: ../src/html/htmprint.cpp:712 ../src/richtext/richtextprint.cpp:589
 msgid " Preview"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:824
+#: ../src/common/fontcmn.cpp:973
 msgid " bold"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:840
+#: ../src/common/fontcmn.cpp:977
+msgid " extra bold"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:985
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:957
+msgid " extra light"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:981
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1001
 msgid " italic"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:820
+#: ../src/common/fontcmn.cpp:961
 msgid " light"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:807
+#: ../src/common/fontcmn.cpp:965
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:969
+msgid " semi bold"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:940
 msgid " strikethrough"
 msgstr ""
 
-#: ../src/common/paper.cpp:117
+#: ../src/common/fontcmn.cpp:953
+msgid " thin"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
 msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:118
+#: ../src/common/paper.cpp:115
 msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:119
+#: ../src/common/paper.cpp:116
 msgid "#12 Envelope, 4 3/4 x 11 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:120
+#: ../src/common/paper.cpp:117
 msgid "#14 Envelope, 5 x 11 1/2 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:116
+#: ../src/common/paper.cpp:113
 msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
 msgstr ""
 
-#: ../src/richtext/richtextbackgroundpage.cpp:341
 #: ../src/richtext/richtextsizepage.cpp:340
 #: ../src/richtext/richtextsizepage.cpp:374
 #: ../src/richtext/richtextsizepage.cpp:401
@@ -107,81 +130,82 @@ msgstr ""
 #: ../src/richtext/richtextsizepage.cpp:591
 #: ../src/richtext/richtextsizepage.cpp:626
 #: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextbackgroundpage.cpp:341
 msgid "%"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1031
+#: ../src/html/helpwnd.cpp:1029
 #, c-format
 msgid "%d of %lu"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1678
+#: ../src/html/helpwnd.cpp:1676
 #, c-format
 msgid "%i of %u"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:279
+#: ../src/generic/filectrlg.cpp:275
 #, c-format
 msgid "%ld byte"
 msgid_plural "%ld bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/html/helpwnd.cpp:1033
+#: ../src/html/helpwnd.cpp:1031
 #, c-format
 msgid "%lu of %lu"
 msgstr ""
 
-#: ../src/generic/datavgen.cpp:6028
+#: ../src/generic/datavgen.cpp:6833
 #, c-format
 msgid "%s (%d items)"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1221
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "%s (or %s)"
 msgstr ""
 
-#: ../src/generic/logg.cpp:224
+#: ../src/generic/logg.cpp:221
 #, c-format
 msgid "%s Error"
 msgstr ""
 
-#: ../src/generic/logg.cpp:236
+#: ../src/generic/logg.cpp:233
 #, c-format
 msgid "%s Information"
 msgstr ""
 
-#: ../src/generic/preferencesg.cpp:113
+#: ../src/generic/preferencesg.cpp:110
 #, c-format
 msgid "%s Preferences"
 msgstr ""
 
-#: ../src/generic/logg.cpp:228
+#: ../src/generic/logg.cpp:225
 #, c-format
 msgid "%s Warning"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:1319
+#: ../src/common/tarstrm.cpp:1313
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr ""
 
-#: ../src/common/fldlgcmn.cpp:124
+#: ../src/common/fldlgcmn.cpp:121
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1716
+#: ../src/html/helpwnd.cpp:1714
 #, c-format
 msgid "%u of %u"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "&About"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "&Actual Size"
 msgstr ""
 
@@ -189,28 +213,28 @@ msgstr ""
 msgid "&After a paragraph:"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:128
 #: ../src/richtext/richtextliststylepage.cpp:319
+#: ../src/richtext/richtextindentspage.cpp:128
 msgid "&Alignment"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "&Apply"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:251
+#: ../src/richtext/richtextstyledlg.cpp:247
 msgid "&Apply Style"
 msgstr ""
 
-#: ../src/msw/mdi.cpp:179
+#: ../src/msw/mdi.cpp:174
 msgid "&Arrange Icons"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "&Ascending"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:142
+#: ../src/common/stockitem.cpp:139
 msgid "&Back"
 msgstr ""
 
@@ -230,24 +254,24 @@ msgstr ""
 msgid "&Blur distance:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:143
+#: ../src/common/stockitem.cpp:140
 msgid "&Bold"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141
 msgid "&Bottom"
 msgstr ""
 
+#: ../src/richtext/richtextsizepage.cpp:637
+#: ../src/richtext/richtextsizepage.cpp:644
 #: ../src/richtext/richtextborderspage.cpp:345
 #: ../src/richtext/richtextborderspage.cpp:513
 #: ../src/richtext/richtextmarginspage.cpp:259
 #: ../src/richtext/richtextmarginspage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:637
-#: ../src/richtext/richtextsizepage.cpp:644
 msgid "&Bottom:"
 msgstr ""
 
-#: ../include/wx/richtext/richtextbuffer.h:3866
+#: ../include/wx/richtext/richtextbuffer.h:3861
 msgid "&Box"
 msgstr ""
 
@@ -256,38 +280,38 @@ msgstr ""
 msgid "&Bullet style:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "&CD-Rom"
 msgstr ""
 
-#: ../src/generic/wizard.cpp:434 ../src/generic/fontdlgg.cpp:470
-#: ../src/generic/fontdlgg.cpp:489 ../src/osx/carbon/fontdlg.cpp:402
-#: ../src/common/dlgcmn.cpp:279 ../src/common/stockitem.cpp:145
+#: ../src/osx/carbon/fontdlg.cpp:399 ../src/common/stockitem.cpp:142
+#: ../src/generic/wizard.cpp:433 ../src/generic/fontdlgg.cpp:466
+#: ../src/generic/fontdlgg.cpp:485 ../src/osx/cocoa/button.mm:200
 msgid "&Cancel"
 msgstr ""
 
-#: ../src/msw/mdi.cpp:175
+#: ../src/msw/mdi.cpp:170
 msgid "&Cascade"
 msgstr ""
 
-#: ../include/wx/richtext/richtextbuffer.h:5960
+#: ../include/wx/richtext/richtextbuffer.h:5955
 msgid "&Cell"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:439
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "&Character code:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:147
+#: ../src/common/stockitem.cpp:144
 msgid "&Clear"
 msgstr ""
 
-#: ../src/generic/logg.cpp:516 ../src/common/stockitem.cpp:148
-#: ../src/common/prntbase.cpp:1600 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/stockitem.cpp:145 ../src/common/prntbase.cpp:1625
+#: ../src/univ/themes/win32.cpp:3753 ../src/generic/logg.cpp:513
 msgid "&Close"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "&Color"
 msgstr ""
 
@@ -295,20 +319,20 @@ msgstr ""
 msgid "&Colour:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "&Convert"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:333 ../src/osx/textctrl_osx.cpp:577
-#: ../src/common/stockitem.cpp:150 ../src/msw/textctrl.cpp:2508
+#: ../src/osx/textctrl_osx.cpp:595 ../src/common/stockitem.cpp:147
+#: ../src/msw/textctrl.cpp:2773 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr ""
 
-#: ../src/generic/hyperlinkg.cpp:156
+#: ../src/generic/hyperlinkg.cpp:153
 msgid "&Copy URL"
 msgstr ""
 
-#: ../src/common/headerctrlcmn.cpp:306
+#: ../src/common/headerctrlcmn.cpp:304
 msgid "&Customize..."
 msgstr ""
 
@@ -316,53 +340,53 @@ msgstr ""
 msgid "&Debug report preview:"
 msgstr ""
 
-#: ../src/richtext/richtexttabspage.cpp:138
-#: ../src/richtext/richtextctrl.cpp:335 ../src/osx/textctrl_osx.cpp:579
-#: ../src/common/stockitem.cpp:152 ../src/msw/textctrl.cpp:2510
+#: ../src/osx/textctrl_osx.cpp:597 ../src/common/stockitem.cpp:149
+#: ../src/msw/textctrl.cpp:2775 ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtextctrl.cpp:334
 msgid "&Delete"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:269
+#: ../src/richtext/richtextstyledlg.cpp:265
 msgid "&Delete Style..."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "&Descending"
 msgstr ""
 
-#: ../src/generic/logg.cpp:682
+#: ../src/generic/logg.cpp:679
 msgid "&Details"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:153
+#: ../src/common/stockitem.cpp:150
 msgid "&Down"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "&Edit"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:263
+#: ../src/richtext/richtextstyledlg.cpp:259
 msgid "&Edit Style..."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:155
+#: ../src/common/stockitem.cpp:152
 msgid "&Execute"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/common/stockitem.cpp:154
 msgid "&File"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:158
-msgid "&Find"
+#: ../src/common/stockitem.cpp:155
+msgid "&Find..."
 msgstr ""
 
-#: ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:430
 msgid "&Finish"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:156
 msgid "&First"
 msgstr ""
 
@@ -370,15 +394,15 @@ msgstr ""
 msgid "&Floating mode:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "&Floppy"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:194
+#: ../src/common/stockitem.cpp:191
 msgid "&Font"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:371
+#: ../src/generic/fontdlgg.cpp:367
 msgid "&Font family:"
 msgstr ""
 
@@ -386,20 +410,20 @@ msgstr ""
 msgid "&Font for Level..."
 msgstr ""
 
+#: ../src/richtext/richtextsymboldlg.cpp:397
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:400
 msgid "&Font:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "&Forward"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:451
+#: ../src/richtext/richtextsymboldlg.cpp:448
 msgid "&From:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "&Harddisk"
 msgstr ""
 
@@ -408,9 +432,9 @@ msgstr ""
 msgid "&Height:"
 msgstr ""
 
-#: ../src/generic/wizard.cpp:441 ../src/richtext/richtextstyledlg.cpp:303
-#: ../src/richtext/richtextsymboldlg.cpp:479 ../src/osx/menu_osx.cpp:734
-#: ../src/common/stockitem.cpp:163
+#: ../src/common/stockitem.cpp:160 ../src/generic/wizard.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextstyledlg.cpp:299 ../src/osx/cocoa/menu.mm:226
 msgid "&Help"
 msgstr ""
 
@@ -418,7 +442,7 @@ msgstr ""
 msgid "&Hide details"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:164
+#: ../src/common/stockitem.cpp:161
 msgid "&Home"
 msgstr ""
 
@@ -426,54 +450,54 @@ msgstr ""
 msgid "&Horizontal offset:"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:184
 #: ../src/richtext/richtextliststylepage.cpp:372
+#: ../src/richtext/richtextindentspage.cpp:184
 msgid "&Indentation (tenths of a mm)"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:167
 #: ../src/richtext/richtextliststylepage.cpp:356
+#: ../src/richtext/richtextindentspage.cpp:167
 msgid "&Indeterminate"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:166
+#: ../src/common/stockitem.cpp:163
 msgid "&Index"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "&Info"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:168
+#: ../src/common/stockitem.cpp:165
 msgid "&Italic"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "&Jump to"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:153
 #: ../src/richtext/richtextliststylepage.cpp:342
+#: ../src/richtext/richtextindentspage.cpp:153
 msgid "&Justified"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "&Last"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:139
 #: ../src/richtext/richtextliststylepage.cpp:328
+#: ../src/richtext/richtextindentspage.cpp:139
 msgid "&Left"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:195
+#: ../src/richtext/richtextsizepage.cpp:532
+#: ../src/richtext/richtextsizepage.cpp:539
 #: ../src/richtext/richtextborderspage.cpp:243
 #: ../src/richtext/richtextborderspage.cpp:411
 #: ../src/richtext/richtextliststylepage.cpp:381
+#: ../src/richtext/richtextindentspage.cpp:195
 #: ../src/richtext/richtextmarginspage.cpp:186
 #: ../src/richtext/richtextmarginspage.cpp:300
-#: ../src/richtext/richtextsizepage.cpp:532
-#: ../src/richtext/richtextsizepage.cpp:539
 msgid "&Left:"
 msgstr ""
 
@@ -481,11 +505,11 @@ msgstr ""
 msgid "&List level:"
 msgstr ""
 
-#: ../src/generic/logg.cpp:517
+#: ../src/generic/logg.cpp:514
 msgid "&Log"
 msgstr ""
 
-#: ../src/univ/themes/win32.cpp:3748
+#: ../src/univ/themes/win32.cpp:3745
 msgid "&Move"
 msgstr ""
 
@@ -493,20 +517,19 @@ msgstr ""
 msgid "&Move the object to:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "&Network"
 msgstr ""
 
-#: ../src/richtext/richtexttabspage.cpp:132 ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173 ../src/richtext/richtexttabspage.cpp:132
 msgid "&New"
 msgstr ""
 
-#: ../src/aui/tabmdi.cpp:111 ../src/generic/mdig.cpp:100
-#: ../src/msw/mdi.cpp:180
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
 msgid "&Next"
 msgstr ""
 
-#: ../src/generic/wizard.cpp:432 ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:429
 msgid "&Next >"
 msgstr ""
 
@@ -514,7 +537,7 @@ msgstr ""
 msgid "&Next Paragraph"
 msgstr ""
 
-#: ../src/generic/tipdlg.cpp:240
+#: ../src/generic/tipdlg.cpp:237
 msgid "&Next Tip"
 msgstr ""
 
@@ -522,11 +545,11 @@ msgstr ""
 msgid "&Next style:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:177 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:174 ../src/msw/msgdlg.cpp:435
 msgid "&No"
 msgstr ""
 
-#: ../src/generic/dbgrptg.cpp:356
+#: ../src/generic/dbgrptg.cpp:360
 msgid "&Notes:"
 msgstr ""
 
@@ -534,12 +557,12 @@ msgstr ""
 msgid "&Number:"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:475 ../src/generic/fontdlgg.cpp:482
-#: ../src/osx/carbon/fontdlg.cpp:408 ../src/common/stockitem.cpp:178
+#: ../src/osx/carbon/fontdlg.cpp:405 ../src/common/stockitem.cpp:175
+#: ../src/generic/fontdlgg.cpp:471 ../src/generic/fontdlgg.cpp:478
 msgid "&OK"
 msgstr ""
 
-#: ../src/generic/dbgrptg.cpp:342 ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176 ../src/generic/dbgrptg.cpp:342
 msgid "&Open..."
 msgstr ""
 
@@ -551,16 +574,16 @@ msgstr ""
 msgid "&Page Break"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:334 ../src/osx/textctrl_osx.cpp:578
-#: ../src/common/stockitem.cpp:180 ../src/msw/textctrl.cpp:2509
+#: ../src/osx/textctrl_osx.cpp:596 ../src/common/stockitem.cpp:177
+#: ../src/msw/textctrl.cpp:2774 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr ""
 
-#: ../include/wx/richtext/richtextbuffer.h:5010
+#: ../include/wx/richtext/richtextbuffer.h:5005
 msgid "&Picture"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:419
 msgid "&Point size:"
 msgstr ""
 
@@ -572,12 +595,11 @@ msgstr ""
 msgid "&Position mode:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178
 msgid "&Preferences"
 msgstr ""
 
-#: ../src/aui/tabmdi.cpp:112 ../src/generic/mdig.cpp:101
-#: ../src/msw/mdi.cpp:181
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
 msgid "&Previous"
 msgstr ""
 
@@ -585,78 +607,74 @@ msgstr ""
 msgid "&Previous Paragraph"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "&Print..."
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:339 ../src/richtext/richtextctrl.cpp:5514
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtextctrl.cpp:338
+#: ../src/richtext/richtextctrl.cpp:5512
 msgid "&Properties"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "&Quit"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:330 ../src/osx/textctrl_osx.cpp:574
-#: ../src/common/stockitem.cpp:185 ../src/common/cmdproc.cpp:293
-#: ../src/common/cmdproc.cpp:300 ../src/msw/textctrl.cpp:2505
+#: ../src/osx/textctrl_osx.cpp:592 ../src/common/stockitem.cpp:182
+#: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
+#: ../src/msw/textctrl.cpp:2770 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr ""
 
-#: ../src/common/cmdproc.cpp:289 ../src/common/cmdproc.cpp:309
+#: ../src/common/cmdproc.cpp:282 ../src/common/cmdproc.cpp:302
 msgid "&Redo "
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:257
+#: ../src/richtext/richtextstyledlg.cpp:253
 msgid "&Rename Style..."
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:179
+#: ../src/generic/fdrepdlg.cpp:176
 msgid "&Replace"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:287
+#: ../src/richtext/richtextstyledlg.cpp:283
 msgid "&Restart numbering"
 msgstr ""
 
-#: ../src/univ/themes/win32.cpp:3747
+#: ../src/univ/themes/win32.cpp:3744
 msgid "&Restore"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:146
 #: ../src/richtext/richtextliststylepage.cpp:335
+#: ../src/richtext/richtextindentspage.cpp:146
 msgid "&Right"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:213
+#: ../src/richtext/richtextsizepage.cpp:602
+#: ../src/richtext/richtextsizepage.cpp:609
 #: ../src/richtext/richtextborderspage.cpp:277
 #: ../src/richtext/richtextborderspage.cpp:445
 #: ../src/richtext/richtextliststylepage.cpp:399
+#: ../src/richtext/richtextindentspage.cpp:213
 #: ../src/richtext/richtextmarginspage.cpp:211
 #: ../src/richtext/richtextmarginspage.cpp:325
-#: ../src/richtext/richtextsizepage.cpp:602
-#: ../src/richtext/richtextsizepage.cpp:609
 msgid "&Right:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:190
+#: ../src/common/stockitem.cpp:187
 msgid "&Save"
-msgstr ""
-
-#: ../src/common/stockitem.cpp:191
-msgid "&Save as"
 msgstr ""
 
 #: ../include/wx/richmsgdlg.h:29
 msgid "&See details"
 msgstr ""
 
-#: ../src/generic/tipdlg.cpp:236
+#: ../src/generic/tipdlg.cpp:233
 msgid "&Show tips at startup"
 msgstr ""
 
-#: ../src/univ/themes/win32.cpp:3750
+#: ../src/univ/themes/win32.cpp:3747
 msgid "&Size"
 msgstr ""
 
@@ -664,36 +682,36 @@ msgstr ""
 msgid "&Size:"
 msgstr ""
 
-#: ../src/generic/progdlgg.cpp:252
+#: ../src/generic/progdlgg.cpp:249
 msgid "&Skip"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:242
 #: ../src/richtext/richtextliststylepage.cpp:417
+#: ../src/richtext/richtextindentspage.cpp:242
 msgid "&Spacing (tenths of a mm)"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "&Spell Check"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "&Stop"
 msgstr ""
 
-#: ../src/richtext/richtextfontpage.cpp:275 ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196 ../src/richtext/richtextfontpage.cpp:275
 msgid "&Strikethrough"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:382 ../src/richtext/richtextstylepage.cpp:106
+#: ../src/generic/fontdlgg.cpp:378 ../src/richtext/richtextstylepage.cpp:106
 msgid "&Style:"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:194
 msgid "&Styles:"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:413
+#: ../src/richtext/richtextsymboldlg.cpp:410
 msgid "&Subset:"
 msgstr ""
 
@@ -707,24 +725,24 @@ msgstr ""
 msgid "&Synchronize values"
 msgstr ""
 
-#: ../include/wx/richtext/richtextbuffer.h:6069
+#: ../include/wx/richtext/richtextbuffer.h:6064
 msgid "&Table"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197
 msgid "&Top"
 msgstr ""
 
+#: ../src/richtext/richtextsizepage.cpp:567
+#: ../src/richtext/richtextsizepage.cpp:574
 #: ../src/richtext/richtextborderspage.cpp:311
 #: ../src/richtext/richtextborderspage.cpp:479
 #: ../src/richtext/richtextmarginspage.cpp:234
 #: ../src/richtext/richtextmarginspage.cpp:348
-#: ../src/richtext/richtextsizepage.cpp:567
-#: ../src/richtext/richtextsizepage.cpp:574
 msgid "&Top:"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:444 ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199 ../src/generic/fontdlgg.cpp:441
 msgid "&Underline"
 msgstr ""
 
@@ -732,21 +750,21 @@ msgstr ""
 msgid "&Underlining:"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:329 ../src/osx/textctrl_osx.cpp:573
-#: ../src/common/stockitem.cpp:203 ../src/common/cmdproc.cpp:271
-#: ../src/msw/textctrl.cpp:2504
+#: ../src/osx/textctrl_osx.cpp:591 ../src/common/stockitem.cpp:200
+#: ../src/common/cmdproc.cpp:264 ../src/msw/textctrl.cpp:2769
+#: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr ""
 
-#: ../src/common/cmdproc.cpp:265
+#: ../src/common/cmdproc.cpp:258
 msgid "&Undo "
 msgstr ""
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "&Unindent"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:205
+#: ../src/common/stockitem.cpp:202
 msgid "&Up"
 msgstr ""
 
@@ -762,7 +780,7 @@ msgstr ""
 msgid "&View..."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:393
+#: ../src/generic/fontdlgg.cpp:389
 msgid "&Weight:"
 msgstr ""
 
@@ -771,80 +789,50 @@ msgstr ""
 msgid "&Width:"
 msgstr ""
 
-#: ../src/aui/tabmdi.cpp:311 ../src/aui/tabmdi.cpp:327
-#: ../src/aui/tabmdi.cpp:329 ../src/generic/mdig.cpp:294
-#: ../src/generic/mdig.cpp:310 ../src/generic/mdig.cpp:314
-#: ../src/msw/mdi.cpp:78
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
 msgid "&Window"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:206 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:203 ../src/msw/msgdlg.cpp:435
 msgid "&Yes"
 msgstr ""
 
-#: ../src/common/valtext.cpp:256
+#: ../src/common/valtext.cpp:197
 #, c-format
-msgid "'%s' contains illegal characters"
+msgid "'%s' contains invalid character(s)"
 msgstr ""
 
-#: ../src/common/valtext.cpp:254
-#, c-format
-msgid "'%s' doesn't consist only of valid characters"
-msgstr ""
-
-#: ../src/common/config.cpp:519 ../src/msw/regconf.cpp:258
+#: ../src/common/config.cpp:515 ../src/msw/regconf.cpp:255
 #, c-format
 msgid "'%s' has extra '..', ignored."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1113 ../src/common/cmdline.cpp:1131
+#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr ""
 
-#: ../src/common/translation.cpp:1100
+#: ../src/common/translation.cpp:1142
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr ""
 
-#: ../src/common/valtext.cpp:165
+#: ../src/common/valtext.cpp:188
 #, c-format
 msgid "'%s' is not one of the valid strings"
 msgstr ""
 
-#: ../src/common/valtext.cpp:167
+#: ../src/common/valtext.cpp:186
 #, c-format
 msgid "'%s' is one of the invalid strings"
 msgstr ""
 
-#: ../src/common/textbuf.cpp:237
+#: ../src/common/textbuf.cpp:233
 #, c-format
 msgid "'%s' is probably a binary buffer."
-msgstr ""
-
-#: ../src/common/valtext.cpp:252
-#, c-format
-msgid "'%s' should be numeric."
-msgstr ""
-
-#: ../src/common/valtext.cpp:244
-#, c-format
-msgid "'%s' should only contain ASCII characters."
-msgstr ""
-
-#: ../src/common/valtext.cpp:246
-#, c-format
-msgid "'%s' should only contain alphabetic characters."
-msgstr ""
-
-#: ../src/common/valtext.cpp:248
-#, c-format
-msgid "'%s' should only contain alphabetic or numeric characters."
-msgstr ""
-
-#: ../src/common/valtext.cpp:250
-#, c-format
-msgid "'%s' should only contain digits."
 msgstr ""
 
 #: ../src/richtext/richtextliststylepage.cpp:229
@@ -852,7 +840,7 @@ msgstr ""
 msgid "(*)"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:963
+#: ../src/html/helpwnd.cpp:961
 msgid "(Help)"
 msgstr ""
 
@@ -861,27 +849,32 @@ msgstr ""
 msgid "(None)"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:504
+#: ../src/richtext/richtextsymboldlg.cpp:503
 msgid "(Normal text)"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:419 ../src/html/helpwnd.cpp:1106
-#: ../src/html/helpwnd.cpp:1742
+#: ../src/html/helpwnd.cpp:417 ../src/html/helpwnd.cpp:1104
+#: ../src/html/helpwnd.cpp:1740
 msgid "(bookmarks)"
 msgstr ""
 
+#: ../src/msw/dlmsw.cpp:167
+#, c-format
+msgid "(error %d: %s)"
+msgstr ""
+
+#: ../src/richtext/richtextformatdlg.cpp:876
+#: ../src/richtext/richtextliststylepage.cpp:448
+#: ../src/richtext/richtextliststylepage.cpp:460
+#: ../src/richtext/richtextliststylepage.cpp:461
 #: ../src/richtext/richtextindentspage.cpp:274
 #: ../src/richtext/richtextindentspage.cpp:286
 #: ../src/richtext/richtextindentspage.cpp:287
 #: ../src/richtext/richtextindentspage.cpp:311
 #: ../src/richtext/richtextindentspage.cpp:326
-#: ../src/richtext/richtextformatdlg.cpp:884
 #: ../src/richtext/richtextfontpage.cpp:349
 #: ../src/richtext/richtextfontpage.cpp:353
 #: ../src/richtext/richtextfontpage.cpp:357
-#: ../src/richtext/richtextliststylepage.cpp:448
-#: ../src/richtext/richtextliststylepage.cpp:460
-#: ../src/richtext/richtextliststylepage.cpp:461
 msgid "(none)"
 msgstr ""
 
@@ -900,7 +893,7 @@ msgstr ""
 msgid "+"
 msgstr ""
 
-#: ../src/msw/utils.cpp:1152
+#: ../src/msw/utils.cpp:1143
 msgid ", 64-bit edition"
 msgstr ""
 
@@ -909,163 +902,163 @@ msgstr ""
 msgid "-"
 msgstr ""
 
-#: ../src/generic/filepickerg.cpp:66
+#: ../src/generic/filepickerg.cpp:63
 msgid "..."
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:276
 #: ../src/richtext/richtextliststylepage.cpp:450
+#: ../src/richtext/richtextindentspage.cpp:276
 msgid "1.1"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:277
 #: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextindentspage.cpp:277
 msgid "1.2"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:278
 #: ../src/richtext/richtextliststylepage.cpp:452
+#: ../src/richtext/richtextindentspage.cpp:278
 msgid "1.3"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:279
 #: ../src/richtext/richtextliststylepage.cpp:453
+#: ../src/richtext/richtextindentspage.cpp:279
 msgid "1.4"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:280
 #: ../src/richtext/richtextliststylepage.cpp:454
+#: ../src/richtext/richtextindentspage.cpp:280
 msgid "1.5"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:281
 #: ../src/richtext/richtextliststylepage.cpp:455
+#: ../src/richtext/richtextindentspage.cpp:281
 msgid "1.6"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:282
 #: ../src/richtext/richtextliststylepage.cpp:456
+#: ../src/richtext/richtextindentspage.cpp:282
 msgid "1.7"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:283
 #: ../src/richtext/richtextliststylepage.cpp:457
+#: ../src/richtext/richtextindentspage.cpp:283
 msgid "1.8"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:284
 #: ../src/richtext/richtextliststylepage.cpp:458
+#: ../src/richtext/richtextindentspage.cpp:284
 msgid "1.9"
 msgstr ""
 
-#: ../src/common/paper.cpp:140
+#: ../src/common/paper.cpp:137
 msgid "10 x 11 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:113
+#: ../src/common/paper.cpp:110
 msgid "10 x 14 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:114
+#: ../src/common/paper.cpp:111
 msgid "11 x 17 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:184
+#: ../src/common/paper.cpp:181
 msgid "12 x 11 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:141
+#: ../src/common/paper.cpp:138
 msgid "15 x 11 in"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:285
 #: ../src/richtext/richtextliststylepage.cpp:459
+#: ../src/richtext/richtextindentspage.cpp:285
 msgid "2"
 msgstr ""
 
-#: ../src/common/paper.cpp:132
+#: ../src/common/paper.cpp:129
 msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:139
+#: ../src/common/paper.cpp:136
 msgid "9 x 11 in"
 msgstr ""
 
-#: ../src/html/htmprint.cpp:431
+#: ../src/html/htmprint.cpp:443
 msgid ": file does not exist!"
 msgstr ""
 
-#: ../src/common/fontmap.cpp:199
+#: ../src/common/fontmap.cpp:196
 msgid ": unknown charset"
 msgstr ""
 
-#: ../src/common/fontmap.cpp:413
+#: ../src/common/fontmap.cpp:410
 msgid ": unknown encoding"
 msgstr ""
 
-#: ../src/generic/wizard.cpp:443
+#: ../src/generic/wizard.cpp:438
 msgid "< &Back"
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:628
-#: ../src/osx/carbon/fontdlg.cpp:648
+#: ../src/osx/carbon/fontdlg.cpp:419 ../src/osx/carbon/fontdlg.cpp:625
+#: ../src/osx/carbon/fontdlg.cpp:645
 msgid "<Any Decorative>"
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:630
-#: ../src/osx/carbon/fontdlg.cpp:650
+#: ../src/osx/carbon/fontdlg.cpp:420 ../src/osx/carbon/fontdlg.cpp:627
+#: ../src/osx/carbon/fontdlg.cpp:647
 msgid "<Any Modern>"
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:626
-#: ../src/osx/carbon/fontdlg.cpp:646
+#: ../src/osx/carbon/fontdlg.cpp:418 ../src/osx/carbon/fontdlg.cpp:623
+#: ../src/osx/carbon/fontdlg.cpp:643
 msgid "<Any Roman>"
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:424 ../src/osx/carbon/fontdlg.cpp:632
-#: ../src/osx/carbon/fontdlg.cpp:652
+#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:629
+#: ../src/osx/carbon/fontdlg.cpp:649
 msgid "<Any Script>"
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:425 ../src/osx/carbon/fontdlg.cpp:637
-#: ../src/osx/carbon/fontdlg.cpp:656
+#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:634
+#: ../src/osx/carbon/fontdlg.cpp:653
 msgid "<Any Swiss>"
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:426 ../src/osx/carbon/fontdlg.cpp:634
-#: ../src/osx/carbon/fontdlg.cpp:654
+#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:631
+#: ../src/osx/carbon/fontdlg.cpp:651
 msgid "<Any Teletype>"
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:420
+#: ../src/osx/carbon/fontdlg.cpp:417
 msgid "<Any>"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
 msgid "<DIR>"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:254 ../src/generic/filectrlg.cpp:277
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
 msgid "<DRIVE>"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:252 ../src/generic/filectrlg.cpp:275
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
 msgid "<LINK>"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1264
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1270
+#: ../src/html/helpwnd.cpp:1268
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1265
+#: ../src/html/helpwnd.cpp:1263
 msgid "<b>Bold face.</b> "
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1264
+#: ../src/html/helpwnd.cpp:1262
 msgid "<i>Italic face.</i> "
 msgstr ""
 
@@ -1074,15 +1067,15 @@ msgstr ""
 msgid ">"
 msgstr ""
 
-#: ../src/generic/dbgrptg.cpp:318
+#: ../src/generic/dbgrptg.cpp:317
 msgid "A debug report has been generated in the directory\n"
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:573
+#: ../src/common/debugrpt.cpp:574
 msgid "A debug report has been generated. It can be found in"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:418
+#: ../src/common/xtixml.cpp:414
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr ""
 
@@ -1093,106 +1086,106 @@ msgstr ""
 msgid "A standard bullet name."
 msgstr ""
 
-#: ../src/common/paper.cpp:217
+#: ../src/common/paper.cpp:214
 msgid "A0 sheet, 841 x 1189 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:218
+#: ../src/common/paper.cpp:215
 msgid "A1 sheet, 594 x 841 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:159
+#: ../src/common/paper.cpp:156
 msgid "A2 420 x 594 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:156
+#: ../src/common/paper.cpp:153
 msgid "A3 Extra 322 x 445 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:161
+#: ../src/common/paper.cpp:158
 msgid "A3 Extra Transverse 322 x 445 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:170
+#: ../src/common/paper.cpp:167
 msgid "A3 Rotated 420 x 297 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:160
+#: ../src/common/paper.cpp:157
 msgid "A3 Transverse 297 x 420 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:106
+#: ../src/common/paper.cpp:103
 msgid "A3 sheet, 297 x 420 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:146
+#: ../src/common/paper.cpp:143
 msgid "A4 Extra 9.27 x 12.69 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:153
+#: ../src/common/paper.cpp:150
 msgid "A4 Plus 210 x 330 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:171
+#: ../src/common/paper.cpp:168
 msgid "A4 Rotated 297 x 210 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:148
+#: ../src/common/paper.cpp:145
 msgid "A4 Transverse 210 x 297 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:97
+#: ../src/common/paper.cpp:94
 msgid "A4 sheet, 210 x 297 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:107
+#: ../src/common/paper.cpp:104
 msgid "A4 small sheet, 210 x 297 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:157
+#: ../src/common/paper.cpp:154
 msgid "A5 Extra 174 x 235 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:172
+#: ../src/common/paper.cpp:169
 msgid "A5 Rotated 210 x 148 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:154
+#: ../src/common/paper.cpp:151
 msgid "A5 Transverse 148 x 210 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:108
+#: ../src/common/paper.cpp:105
 msgid "A5 sheet, 148 x 210 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:164
+#: ../src/common/paper.cpp:161
 msgid "A6 105 x 148 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:177
+#: ../src/common/paper.cpp:174
 msgid "A6 Rotated 148 x 105 mm"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:83 ../src/richtext/richtextformatdlg.cpp:529
-#: ../src/osx/carbon/fontdlg.cpp:153
+#: ../src/osx/carbon/fontdlg.cpp:150 ../src/generic/fontdlgg.cpp:79
+#: ../src/richtext/richtextformatdlg.cpp:521
 msgid "ABCDEFGabcdefg12345"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:458 ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
 msgid "ASCII"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "About"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:140 ../src/osx/menu_osx.cpp:558
-#: ../src/msw/aboutdlg.cpp:64
+#: ../src/osx/menu_osx.cpp:450 ../src/generic/aboutdlgg.cpp:137
+#: ../src/msw/aboutdlg.cpp:61
 #, c-format
 msgid "About %s"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:560
+#: ../src/osx/menu_osx.cpp:452
 msgid "About..."
 msgstr ""
 
@@ -1201,37 +1194,37 @@ msgid "Absolute"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:873
+#: ../src/propgrid/advprops.cpp:774
 msgid "ActiveBorder"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:874
+#: ../src/propgrid/advprops.cpp:775
 msgid "ActiveCaption"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "Actual Size"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:140 ../src/common/accelcmn.cpp:81
+#: ../src/common/stockitem.cpp:137 ../src/common/accelcmn.cpp:78
 msgid "Add"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11455
+#: ../src/richtext/richtextbuffer.cpp:11454
 msgid "Add Column"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11392
+#: ../src/richtext/richtextbuffer.cpp:11391
 msgid "Add Row"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:432
+#: ../src/html/helpwnd.cpp:430
 msgid "Add current page to bookmarks"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:366
+#: ../src/generic/colrdlgg.cpp:386
 msgid "Add to custom colours"
 msgstr ""
 
@@ -1243,12 +1236,12 @@ msgstr ""
 msgid "AddToPropertyCollection called w/o valid adder"
 msgstr ""
 
-#: ../src/html/helpctrl.cpp:159
+#: ../src/html/helpctrl.cpp:155
 #, c-format
 msgid "Adding book %s"
 msgstr ""
 
-#: ../src/common/preferencescmn.cpp:43
+#: ../src/common/preferencescmn.cpp:40
 msgid "Advanced"
 msgstr ""
 
@@ -1256,11 +1249,11 @@ msgstr ""
 msgid "After a paragraph:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:172
+#: ../src/common/stockitem.cpp:169
 msgid "Align Left"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:173
+#: ../src/common/stockitem.cpp:170
 msgid "Align Right"
 msgstr ""
 
@@ -1268,40 +1261,40 @@ msgstr ""
 msgid "Alignment"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:215
+#: ../src/generic/prntdlgg.cpp:208
 msgid "All"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:1197 ../src/common/fldlgcmn.cpp:107
+#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1186
 #, c-format
 msgid "All files (%s)|%s"
 msgstr ""
 
-#: ../include/wx/defs.h:2886
+#: ../include/wx/defs.h:2582
 msgid "All files (*)|*"
 msgstr ""
 
-#: ../include/wx/defs.h:2883
+#: ../include/wx/defs.h:2579
 msgid "All files (*.*)|*.*"
 msgstr ""
 
-#: ../src/richtext/richtextstyles.cpp:1061
+#: ../src/richtext/richtextstyles.cpp:1058
 msgid "All styles"
 msgstr ""
 
-#: ../src/propgrid/manager.cpp:1528
+#: ../src/propgrid/manager.cpp:1544
 msgid "Alphabetic Mode"
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:425
+#: ../src/common/xtistrm.cpp:422
 msgid "Already Registered Object passed to SetObjectClassInfo"
 msgstr ""
 
-#: ../src/unix/dialup.cpp:353
+#: ../src/unix/dialup.cpp:352
 msgid "Already dialling ISP."
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:331 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/accelcmn.cpp:345 ../src/univ/themes/win32.cpp:3753
 msgid "Alt+"
 msgstr ""
 
@@ -1310,34 +1303,34 @@ msgstr ""
 msgid "An optional corner radius for adding rounded corners."
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:576
+#: ../src/common/debugrpt.cpp:577
 msgid "And includes the following files:\n"
 msgstr ""
 
-#: ../src/generic/animateg.cpp:162
+#: ../src/generic/animateg.cpp:145
 #, c-format
 msgid "Animation file is not of type %ld."
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:872
+#: ../src/propgrid/advprops.cpp:773
 msgid "AppWorkspace"
 msgstr ""
 
-#: ../src/generic/logg.cpp:1014
+#: ../src/generic/logg.cpp:1011
 #, c-format
 msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:577 ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:469 ../src/osx/menu_osx.cpp:477
 msgid "Application"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "Apply"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1609
+#: ../src/propgrid/advprops.cpp:1515
 msgid "Aqua"
 msgstr ""
 
@@ -1346,29 +1339,29 @@ msgstr ""
 msgid "Arabic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:153
+#: ../src/common/fmapbase.cpp:150
 msgid "Arabic (ISO-8859-6)"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:672
+#: ../src/msw/ole/automtn.cpp:663
 #, c-format
 msgid "Argument %u not found."
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1753
+#: ../src/propgrid/advprops.cpp:1654
 msgid "Arrow"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:184
+#: ../src/generic/aboutdlgg.cpp:181
 msgid "Artists"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "Ascending"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:433
+#: ../src/generic/filectrlg.cpp:429
 msgid "Attributes"
 msgstr ""
 
@@ -1378,90 +1371,90 @@ msgstr ""
 msgid "Available fonts."
 msgstr ""
 
-#: ../src/common/paper.cpp:137
+#: ../src/common/paper.cpp:134
 msgid "B4 (ISO) 250 x 353 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:173
+#: ../src/common/paper.cpp:170
 msgid "B4 (JIS) Rotated 364 x 257 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:127
+#: ../src/common/paper.cpp:124
 msgid "B4 Envelope, 250 x 353 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:109
+#: ../src/common/paper.cpp:106
 msgid "B4 sheet, 250 x 354 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:158
+#: ../src/common/paper.cpp:155
 msgid "B5 (ISO) Extra 201 x 276 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:174
+#: ../src/common/paper.cpp:171
 msgid "B5 (JIS) Rotated 257 x 182 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:155
+#: ../src/common/paper.cpp:152
 msgid "B5 (JIS) Transverse 182 x 257 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:128
+#: ../src/common/paper.cpp:125
 msgid "B5 Envelope, 176 x 250 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:110
+#: ../src/common/paper.cpp:107
 msgid "B5 sheet, 182 x 257 millimeter"
 msgstr ""
 
-#: ../src/common/paper.cpp:182
+#: ../src/common/paper.cpp:179
 msgid "B6 (JIS) 128 x 182 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:183
+#: ../src/common/paper.cpp:180
 msgid "B6 (JIS) Rotated 182 x 128 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:129
+#: ../src/common/paper.cpp:126
 msgid "B6 Envelope, 176 x 125 mm"
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:531 ../src/common/imagbmp.cpp:561
-#: ../src/common/imagbmp.cpp:576
+#: ../src/common/imagbmp.cpp:528 ../src/common/imagbmp.cpp:558
+#: ../src/common/imagbmp.cpp:573
 msgid "BMP: Couldn't allocate memory."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:100
+#: ../src/common/imagbmp.cpp:97
 msgid "BMP: Couldn't save invalid image."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:356
+#: ../src/common/imagbmp.cpp:353
 msgid "BMP: Couldn't write RGB color map."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:490
+#: ../src/common/imagbmp.cpp:487
 msgid "BMP: Couldn't write data."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:246
+#: ../src/common/imagbmp.cpp:243
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:269
+#: ../src/common/imagbmp.cpp:266
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:140
+#: ../src/common/imagbmp.cpp:137
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:142 ../src/common/accelcmn.cpp:52
+#: ../src/common/stockitem.cpp:139 ../src/common/accelcmn.cpp:49
 msgid "Back"
 msgstr ""
 
+#: ../src/richtext/richtextformatdlg.cpp:377
 #: ../src/richtext/richtextbackgroundpage.cpp:148
-#: ../src/richtext/richtextformatdlg.cpp:384
 msgid "Background"
 msgstr ""
 
@@ -1469,20 +1462,20 @@ msgstr ""
 msgid "Background &colour:"
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:220
+#: ../src/osx/carbon/fontdlg.cpp:217
 msgid "Background colour"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:52
+#: ../src/common/accelcmn.cpp:49
 msgid "Backspace"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:160
+#: ../src/common/fmapbase.cpp:157
 msgid "Baltic (ISO-8859-13)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:151
+#: ../src/common/fmapbase.cpp:148
 msgid "Baltic (old) (ISO-8859-4)"
 msgstr ""
 
@@ -1495,25 +1488,25 @@ msgstr ""
 msgid "Bitmap"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1594
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Black"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1755
+#: ../src/propgrid/advprops.cpp:1656
 msgid "Blank"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1603
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Blue"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:345
+#: ../src/generic/colrdlgg.cpp:365
 msgid "Blue:"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:333 ../src/richtext/richtextfontpage.cpp:355
-#: ../src/osx/carbon/fontdlg.cpp:354 ../src/common/stockitem.cpp:143
+#: ../src/osx/carbon/fontdlg.cpp:351 ../src/common/stockitem.cpp:140
+#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:355
 msgid "Bold"
 msgstr ""
 
@@ -1522,31 +1515,35 @@ msgstr ""
 msgid "Border"
 msgstr ""
 
-#: ../src/richtext/richtextformatdlg.cpp:379
+#: ../src/richtext/richtextformatdlg.cpp:372
 msgid "Borders"
 msgstr ""
 
-#: ../src/richtext/richtextsizepage.cpp:288 ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141 ../src/richtext/richtextsizepage.cpp:288
 msgid "Bottom"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:893
+#: ../src/generic/prntdlgg.cpp:886
 msgid "Bottom margin (mm):"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9383
+#: ../src/richtext/richtextbuffer.cpp:9380
 msgid "Box Properties"
 msgstr ""
 
-#: ../src/richtext/richtextstyles.cpp:1065
+#: ../src/richtext/richtextstyles.cpp:1062
 msgid "Box styles"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1602
+#: ../src/osx/cocoa/menu.mm:292
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Brown"
 msgstr ""
 
-#: ../src/common/filepickercmn.cpp:43 ../src/common/filepickercmn.cpp:44
+#: ../src/common/filepickercmn.cpp:40 ../src/common/filepickercmn.cpp:41
 msgid "Browse"
 msgstr ""
 
@@ -1559,72 +1556,72 @@ msgstr ""
 msgid "Bullet style"
 msgstr ""
 
-#: ../src/richtext/richtextformatdlg.cpp:359
+#: ../src/richtext/richtextformatdlg.cpp:352
 msgid "Bullets"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1756
+#: ../src/propgrid/advprops.cpp:1657
 msgid "Bullseye"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:875
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonFace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:876
+#: ../src/propgrid/advprops.cpp:777
 msgid "ButtonHighlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:877
+#: ../src/propgrid/advprops.cpp:778
 msgid "ButtonShadow"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:878
+#: ../src/propgrid/advprops.cpp:779
 msgid "ButtonText"
 msgstr ""
 
-#: ../src/common/paper.cpp:98
+#: ../src/common/paper.cpp:95
 msgid "C sheet, 17 x 22 in"
 msgstr ""
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "C&lear"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:406
+#: ../src/generic/fontdlgg.cpp:403
 msgid "C&olour:"
 msgstr ""
 
-#: ../src/common/paper.cpp:123
+#: ../src/common/paper.cpp:120
 msgid "C3 Envelope, 324 x 458 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:124
+#: ../src/common/paper.cpp:121
 msgid "C4 Envelope, 229 x 324 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:122
+#: ../src/common/paper.cpp:119
 msgid "C5 Envelope, 162 x 229 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:125
+#: ../src/common/paper.cpp:122
 msgid "C6 Envelope, 114 x 162 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:126
+#: ../src/common/paper.cpp:123
 msgid "C65 Envelope, 114 x 229 mm"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "CD-Rom"
 msgstr ""
 
-#: ../src/html/chm.cpp:815 ../src/html/chm.cpp:874
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:865
 msgid "CHM handler currently supports only local files!"
 msgstr ""
 
@@ -1632,190 +1629,193 @@ msgstr ""
 msgid "Ca&pitals"
 msgstr ""
 
-#: ../src/common/cmdproc.cpp:267
+#: ../src/common/cmdproc.cpp:260
 msgid "Can't &Undo "
 msgstr ""
 
-#: ../src/common/image.cpp:2824
+#: ../src/common/image.cpp:2924
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 
-#: ../src/msw/registry.cpp:506
+#: ../src/msw/registry.cpp:495
 #, c-format
 msgid "Can't close registry key '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:584
+#: ../src/msw/registry.cpp:573
 #, c-format
 msgid "Can't copy values of unsupported type %d."
 msgstr ""
 
-#: ../src/msw/registry.cpp:487
+#: ../src/msw/registry.cpp:476
 #, c-format
 msgid "Can't create registry key '%s'"
 msgstr ""
 
-#: ../src/msw/thread.cpp:665
+#: ../src/msw/thread.cpp:657
 msgid "Can't create thread"
 msgstr ""
 
-#: ../src/msw/window.cpp:3691
-#, c-format
-msgid "Can't create window of class %s"
-msgstr ""
-
-#: ../src/msw/registry.cpp:777
+#: ../src/msw/registry.cpp:765
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr ""
 
-#: ../src/msw/iniconf.cpp:458
+#: ../src/msw/iniconf.cpp:455
 #, c-format
 msgid "Can't delete the INI file '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:805
+#: ../src/msw/registry.cpp:793
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1171
+#: ../src/msw/registry.cpp:1159
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1132
+#: ../src/msw/registry.cpp:1120
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1389
+#: ../src/msw/registry.cpp:1377
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr ""
 
-#: ../src/common/ffile.cpp:254
+#: ../src/common/ffile.cpp:253
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:418
+#: ../src/msw/registry.cpp:407
 #, c-format
 msgid "Can't get info about registry key '%s'"
 msgstr ""
 
-#: ../src/common/zstream.cpp:346
+#: ../src/msw/webview_ie.cpp:1024
+msgid "Can't get the JavaScript object"
+msgstr ""
+
+#: ../src/common/zstream.cpp:343
 msgid "Can't initialize zlib deflate stream."
 msgstr ""
 
-#: ../src/common/zstream.cpp:185
+#: ../src/common/zstream.cpp:182
 msgid "Can't initialize zlib inflate stream."
 msgstr ""
 
-#: ../src/msw/fswatcher.cpp:476
+#: ../src/msw/fswatcher.cpp:475
 #, c-format
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr ""
 
-#: ../src/msw/registry.cpp:454
+#: ../src/msw/registry.cpp:443
 #, c-format
 msgid "Can't open registry key '%s'"
 msgstr ""
 
-#: ../src/common/zstream.cpp:252
+#: ../src/common/zstream.cpp:249
 #, c-format
 msgid "Can't read from inflate stream: %s"
 msgstr ""
 
-#: ../src/common/zstream.cpp:244
+#: ../src/common/zstream.cpp:241
 msgid "Can't read inflate stream: unexpected EOF in underlying stream."
 msgstr ""
 
-#: ../src/msw/registry.cpp:1064
+#: ../src/msw/registry.cpp:1052
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:878 ../src/msw/registry.cpp:910
-#: ../src/msw/registry.cpp:975
+#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
+#: ../src/msw/registry.cpp:963
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr ""
 
-#: ../src/common/image.cpp:2620
+#: ../src/msw/webview_ie.cpp:1017
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/common/image.cpp:2715
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr ""
 
-#: ../src/generic/logg.cpp:573 ../src/generic/logg.cpp:976
+#: ../src/generic/logg.cpp:570 ../src/generic/logg.cpp:973
 msgid "Can't save log contents to file."
 msgstr ""
 
-#: ../src/msw/thread.cpp:629
+#: ../src/msw/thread.cpp:621
 msgid "Can't set thread priority"
 msgstr ""
 
-#: ../src/msw/registry.cpp:896 ../src/msw/registry.cpp:938
-#: ../src/msw/registry.cpp:1081
+#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
+#: ../src/msw/registry.cpp:1069
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:351
+#: ../src/unix/utilsunx.cpp:353
 msgid "Can't write to child process's stdin"
 msgstr ""
 
-#: ../src/common/zstream.cpp:427
+#: ../src/common/zstream.cpp:424
 #, c-format
 msgid "Can't write to deflate stream: %s"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:279 ../src/richtext/richtextstyledlg.cpp:300
-#: ../src/common/stockitem.cpp:145 ../src/common/accelcmn.cpp:71
-#: ../src/msw/msgdlg.cpp:454 ../src/msw/progdlg.cpp:673
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:142
+#: ../src/common/accelcmn.cpp:68 ../src/motif/msgdlg.cpp:196
+#: ../src/gtk1/fontdlg.cpp:144 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/progdlg.cpp:940 ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1261
+#: ../src/common/filefn.cpp:1149
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr ""
 
-#: ../src/msw/dir.cpp:263
+#: ../src/msw/dir.cpp:260
 #, c-format
 msgid "Cannot enumerate files in directory '%s'"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:523
+#: ../src/msw/dialup.cpp:517
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:827
+#: ../src/msw/dialup.cpp:821
 msgid "Cannot find the location of address book file"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:562
+#: ../src/msw/ole/automtn.cpp:553
 #, c-format
 msgid "Cannot get an active instance of \"%s\""
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1035
+#: ../src/unix/threadpsx.cpp:1053
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:987
+#: ../src/unix/utilsunx.cpp:989
 msgid "Cannot get the hostname"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:1023
+#: ../src/unix/utilsunx.cpp:1025
 msgid "Cannot get the official hostname"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:928
+#: ../src/msw/dialup.cpp:922
 msgid "Cannot hang up - no active dialup connection."
 msgstr ""
 
@@ -1823,126 +1823,126 @@ msgstr ""
 msgid "Cannot initialize OLE"
 msgstr ""
 
-#: ../src/common/socket.cpp:853
+#: ../src/common/socket.cpp:850
 msgid "Cannot initialize sockets"
 msgstr ""
 
-#: ../src/msw/volume.cpp:619
+#: ../src/msw/volume.cpp:627
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr ""
 
-#: ../src/xrc/xmlres.cpp:360
+#: ../src/xrc/xmlres.cpp:358
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr ""
 
-#: ../src/xrc/xmlres.cpp:742
+#: ../src/xrc/xmlres.cpp:740
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr ""
 
-#: ../src/html/htmlfilt.cpp:137
+#: ../src/html/htmlfilt.cpp:134
 #, c-format
 msgid "Cannot open HTML document: %s"
 msgstr ""
 
-#: ../src/html/helpdata.cpp:667
+#: ../src/html/helpdata.cpp:660
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr ""
 
-#: ../src/html/helpdata.cpp:299
+#: ../src/html/helpdata.cpp:296
 #, c-format
 msgid "Cannot open contents file: %s"
 msgstr ""
 
-#: ../src/generic/dcpsg.cpp:1667
+#: ../src/generic/dcpsg.cpp:1665
 msgid "Cannot open file for PostScript printing!"
 msgstr ""
 
-#: ../src/html/helpdata.cpp:313
+#: ../src/html/helpdata.cpp:310
 #, c-format
 msgid "Cannot open index file: %s"
 msgstr ""
 
-#: ../src/xrc/xmlres.cpp:724
+#: ../src/xrc/xmlres.cpp:722
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1534
+#: ../src/html/helpwnd.cpp:1532
 msgid "Cannot print empty page."
 msgstr ""
 
-#: ../src/msw/volume.cpp:507
+#: ../src/msw/volume.cpp:515
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr ""
 
-#: ../src/msw/thread.cpp:888
+#: ../src/msw/thread.cpp:894
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1016
+#: ../src/unix/threadpsx.cpp:1028
 msgid "Cannot retrieve thread scheduling policy."
 msgstr ""
 
-#: ../src/common/intl.cpp:558
+#: ../src/common/intl.cpp:365
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:831 ../src/msw/thread.cpp:546
+#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
 msgid "Cannot start thread: error writing TLS."
 msgstr ""
 
-#: ../src/msw/thread.cpp:872
+#: ../src/msw/thread.cpp:864
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr ""
 
-#: ../src/msw/thread.cpp:794
+#: ../src/msw/thread.cpp:786
 msgid "Cannot wait for thread termination"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:75
+#: ../src/common/accelcmn.cpp:72
 msgid "Capital"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:879
+#: ../src/propgrid/advprops.cpp:780
 msgid "CaptionText"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:531
 msgid "Case sensitive"
 msgstr ""
 
-#: ../src/propgrid/manager.cpp:1509
+#: ../src/propgrid/manager.cpp:1527
 msgid "Categorized Mode"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9968
+#: ../src/richtext/richtextbuffer.cpp:9965
 msgid "Cell Properties"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:161
+#: ../src/common/fmapbase.cpp:158
 msgid "Celtic (ISO-8859-14)"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:160
 #: ../src/richtext/richtextliststylepage.cpp:349
+#: ../src/richtext/richtextindentspage.cpp:160
 msgid "Cen&tred"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:170
+#: ../src/common/stockitem.cpp:167
 msgid "Centered"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:149
+#: ../src/common/fmapbase.cpp:146
 msgid "Central European (ISO-8859-2)"
 msgstr ""
 
@@ -1951,10 +1951,10 @@ msgstr ""
 msgid "Centre"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:162
-#: ../src/richtext/richtextindentspage.cpp:164
 #: ../src/richtext/richtextliststylepage.cpp:351
 #: ../src/richtext/richtextliststylepage.cpp:353
+#: ../src/richtext/richtextindentspage.cpp:162
+#: ../src/richtext/richtextindentspage.cpp:164
 msgid "Centre text."
 msgstr ""
 
@@ -1967,24 +1967,24 @@ msgstr ""
 msgid "Ch&oose..."
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:4354
+#: ../src/richtext/richtextbuffer.cpp:4351
 msgid "Change List Style"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:3709
+#: ../src/richtext/richtextbuffer.cpp:3706
 msgid "Change Object Style"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:3982
-#: ../src/richtext/richtextbuffer.cpp:8129
+#: ../src/richtext/richtextbuffer.cpp:3979
+#: ../src/richtext/richtextbuffer.cpp:8125
 msgid "Change Properties"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:3526
+#: ../src/richtext/richtextbuffer.cpp:3523
 msgid "Change Style"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:341
+#: ../src/common/fileconf.cpp:335
 #, c-format
 msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
 msgstr ""
@@ -1995,11 +1995,11 @@ msgid "Changing current directory to \"%s\" failed"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1757
+#: ../src/propgrid/advprops.cpp:1658
 msgid "Character"
 msgstr ""
 
-#: ../src/richtext/richtextstyles.cpp:1063
+#: ../src/richtext/richtextstyles.cpp:1060
 msgid "Character styles"
 msgstr ""
 
@@ -2036,20 +2036,20 @@ msgstr ""
 msgid "Check to indicate right-to-left text layout."
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:356 ../src/osx/carbon/fontdlg.cpp:358
+#: ../src/osx/carbon/fontdlg.cpp:353 ../src/osx/carbon/fontdlg.cpp:355
 msgid "Check to make the font bold."
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:363 ../src/osx/carbon/fontdlg.cpp:365
+#: ../src/osx/carbon/fontdlg.cpp:360 ../src/osx/carbon/fontdlg.cpp:362
 msgid "Check to make the font italic."
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:372 ../src/osx/carbon/fontdlg.cpp:374
+#: ../src/osx/carbon/fontdlg.cpp:369 ../src/osx/carbon/fontdlg.cpp:371
 msgid "Check to make the font underlined."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:289
-#: ../src/richtext/richtextstyledlg.cpp:291
+#: ../src/richtext/richtextstyledlg.cpp:285
+#: ../src/richtext/richtextstyledlg.cpp:287
 msgid "Check to restart numbering."
 msgstr ""
 
@@ -2083,51 +2083,51 @@ msgstr ""
 msgid "Check to suppress hyphenation."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:763
+#: ../src/msw/dialup.cpp:757
 msgid "Choose ISP to dial"
 msgstr ""
 
-#: ../src/propgrid/props.cpp:1922
+#: ../src/propgrid/props.cpp:1904
 msgid "Choose a directory:"
 msgstr ""
 
-#: ../src/propgrid/props.cpp:1975
+#: ../src/propgrid/props.cpp:2199
 msgid "Choose a file"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:158 ../src/gtk/colordlg.cpp:54
+#: ../src/generic/colrdlgg.cpp:156 ../src/gtk/colordlg.cpp:49
 msgid "Choose colour"
 msgstr ""
 
-#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/gtk1/fontdlg.cpp:125 ../src/generic/fontpickerg.cpp:47
+#: ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr ""
 
-#: ../src/common/module.cpp:74
+#: ../src/common/module.cpp:71
 #, c-format
 msgid "Circular dependency involving module \"%s\" detected."
 msgstr ""
 
-#: ../src/aui/tabmdi.cpp:108 ../src/generic/mdig.cpp:97
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
 msgid "Cl&ose"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:684
+#: ../src/msw/ole/automtn.cpp:675
 msgid "Class not registered."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:147 ../src/common/accelcmn.cpp:72
+#: ../src/common/stockitem.cpp:144 ../src/common/accelcmn.cpp:69
 msgid "Clear"
 msgstr ""
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "Clear the log contents"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:252
-#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:248
+#: ../src/richtext/richtextstyledlg.cpp:250
 msgid "Click to apply the selected style."
 msgstr ""
 
@@ -2138,15 +2138,15 @@ msgstr ""
 msgid "Click to browse for a symbol."
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:403 ../src/osx/carbon/fontdlg.cpp:405
+#: ../src/osx/carbon/fontdlg.cpp:400 ../src/osx/carbon/fontdlg.cpp:402
 msgid "Click to cancel changes to the font."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:472 ../src/generic/fontdlgg.cpp:491
+#: ../src/generic/fontdlgg.cpp:468 ../src/generic/fontdlgg.cpp:487
 msgid "Click to cancel the font selection."
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:384 ../src/osx/carbon/fontdlg.cpp:386
+#: ../src/osx/carbon/fontdlg.cpp:381 ../src/osx/carbon/fontdlg.cpp:383
 msgid "Click to change the font colour."
 msgstr ""
 
@@ -2165,37 +2165,37 @@ msgstr ""
 msgid "Click to choose the font for this level."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:279
-#: ../src/richtext/richtextstyledlg.cpp:281
+#: ../src/richtext/richtextstyledlg.cpp:275
+#: ../src/richtext/richtextstyledlg.cpp:277
 msgid "Click to close this window."
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:410 ../src/osx/carbon/fontdlg.cpp:412
+#: ../src/osx/carbon/fontdlg.cpp:407 ../src/osx/carbon/fontdlg.cpp:409
 msgid "Click to confirm changes to the font."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:477 ../src/generic/fontdlgg.cpp:479
-#: ../src/generic/fontdlgg.cpp:484 ../src/generic/fontdlgg.cpp:486
+#: ../src/generic/fontdlgg.cpp:473 ../src/generic/fontdlgg.cpp:475
+#: ../src/generic/fontdlgg.cpp:480 ../src/generic/fontdlgg.cpp:482
 msgid "Click to confirm the font selection."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:244
-#: ../src/richtext/richtextstyledlg.cpp:246
+#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:242
 msgid "Click to create a new box style."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:226
-#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:224
 msgid "Click to create a new character style."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:238
-#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:236
 msgid "Click to create a new list style."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:232
-#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:230
 msgid "Click to create a new paragraph style."
 msgstr ""
 
@@ -2209,8 +2209,8 @@ msgstr ""
 msgid "Click to delete all tab positions."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:270
-#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:268
 msgid "Click to delete the selected style."
 msgstr ""
 
@@ -2219,25 +2219,25 @@ msgstr ""
 msgid "Click to delete the selected tab position."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:264
-#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:262
 msgid "Click to edit the selected style."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:258
-#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:256
 msgid "Click to rename the selected style."
 msgstr ""
 
-#: ../src/generic/dbgrptg.cpp:97 ../src/generic/progdlgg.cpp:759
-#: ../src/richtext/richtextstyledlg.cpp:277
-#: ../src/richtext/richtextsymboldlg.cpp:476 ../src/common/stockitem.cpp:148
-#: ../src/msw/progdlg.cpp:170 ../src/msw/progdlg.cpp:679
-#: ../src/html/helpdlg.cpp:90
+#: ../src/common/stockitem.cpp:145 ../src/generic/dbgrptg.cpp:94
+#: ../src/generic/progdlgg.cpp:781 ../src/msw/progdlg.cpp:211
+#: ../src/msw/progdlg.cpp:946 ../src/html/helpdlg.cpp:87
+#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextstyledlg.cpp:273
 msgid "Close"
 msgstr ""
 
-#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:98
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
 msgid "Close All"
 msgstr ""
 
@@ -2245,65 +2245,65 @@ msgstr ""
 msgid "Close current document"
 msgstr ""
 
-#: ../src/generic/logg.cpp:516
+#: ../src/generic/logg.cpp:513
 msgid "Close this window"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6006
+#: ../src/generic/datavgen.cpp:6811
 msgid "Collapse"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "Color"
 msgstr ""
 
-#: ../src/richtext/richtextformatdlg.cpp:776
+#: ../src/richtext/richtextformatdlg.cpp:768
 msgid "Colour"
 msgstr ""
 
-#: ../src/msw/colordlg.cpp:158
+#: ../src/msw/colordlg.cpp:227
 #, c-format
 msgid "Colour selection dialog failed with error %0lx."
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:380
+#: ../src/osx/carbon/fontdlg.cpp:377
 msgid "Colour:"
 msgstr ""
 
-#: ../src/generic/datavgen.cpp:6077
+#: ../src/generic/datavgen.cpp:6882
 #, c-format
 msgid "Column %u"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:114
+#: ../src/common/accelcmn.cpp:112
 msgid "Command"
 msgstr ""
 
-#: ../src/common/init.cpp:196
+#: ../src/common/init.cpp:193
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
 "ignored."
 msgstr ""
 
-#: ../src/msw/fontdlg.cpp:120
+#: ../src/msw/fontdlg.cpp:170
 #, c-format
 msgid "Common dialog failed with error code %0lx."
 msgstr ""
 
-#: ../src/gtk/window.cpp:4649
+#: ../src/gtk/window.cpp:5653
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:1549
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr ""
 
-#: ../src/generic/dirctrlg.cpp:444
+#: ../src/generic/dirctrlg.cpp:410
 msgid "Computer"
 msgstr ""
 
@@ -2312,52 +2312,56 @@ msgstr ""
 msgid "Config entry name cannot start with '%c'."
 msgstr ""
 
-#: ../src/generic/filedlgg.cpp:349 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
 msgid "Confirm"
 msgstr ""
 
-#: ../src/html/htmlwin.cpp:566
+#: ../src/html/htmlwin.cpp:569
 msgid "Connecting..."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:475
+#: ../src/html/helpwnd.cpp:473
 msgid "Contents"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:880
+#: ../src/propgrid/advprops.cpp:781
 msgid "ControlDark"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:881
+#: ../src/propgrid/advprops.cpp:782
 msgid "ControlLight"
 msgstr ""
 
-#: ../src/common/strconv.cpp:2262
+#: ../src/common/strconv.cpp:2208
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "Convert"
 msgstr ""
 
-#: ../src/html/htmlwin.cpp:1079
+#: ../src/html/htmlwin.cpp:1020
 #, c-format
 msgid "Copied to clipboard:\"%s\""
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:247
+#: ../src/generic/prntdlgg.cpp:240
 msgid "Copies:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:150 ../src/stc/stc_i18n.cpp:18
+#: ../src/common/stockitem.cpp:147 ../src/stc/stc_i18n.cpp:18
 msgid "Copy"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:258
+#: ../src/common/stockitem.cpp:255
 msgid "Copy selection"
+msgstr ""
+
+#: ../src/generic/grid.cpp:5945
+msgid "Copying more than one selected block to clipboard is not supported."
 msgstr ""
 
 #: ../src/richtext/richtextborderspage.cpp:566
@@ -2369,194 +2373,190 @@ msgstr ""
 msgid "Corner &radius:"
 msgstr ""
 
-#: ../src/html/chm.cpp:718
+#: ../src/html/chm.cpp:711
 #, c-format
 msgid "Could not create temporary file '%s'"
 msgstr ""
 
-#: ../src/html/chm.cpp:273
+#: ../src/html/chm.cpp:270
 #, c-format
 msgid "Could not extract %s into %s: %s"
 msgstr ""
 
-#: ../src/generic/tabg.cpp:1048
+#: ../src/generic/tabg.cpp:1045
 msgid "Could not find tab for id"
 msgstr ""
 
-#: ../src/gtk/notifmsg.cpp:108
-msgid "Could not initalize libnotify."
-msgstr ""
-
-#: ../src/html/chm.cpp:444
+#: ../src/html/chm.cpp:437
 #, c-format
 msgid "Could not locate file '%s'."
 msgstr ""
 
-#: ../src/common/filefn.cpp:1403
+#: ../src/msw/graphicsd2d.cpp:604
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/common/filefn.cpp:1291
 msgid "Could not set current working directory"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:2015
+#: ../src/common/prntbase.cpp:2037
 msgid "Could not start document preview."
 msgstr ""
 
-#: ../src/generic/printps.cpp:178 ../src/msw/printwin.cpp:210
-#: ../src/gtk/print.cpp:1132
+#: ../src/generic/printps.cpp:159 ../src/msw/printwin.cpp:184
+#: ../src/gtk/print.cpp:1129
 msgid "Could not start printing."
 msgstr ""
 
-#: ../src/common/wincmn.cpp:2125
+#: ../src/common/wincmn.cpp:2126
 msgid "Could not transfer data to window"
 msgstr ""
 
-#: ../src/msw/imaglist.cpp:187 ../src/msw/imaglist.cpp:224
-#: ../src/msw/imaglist.cpp:249 ../src/msw/dragimag.cpp:185
-#: ../src/msw/dragimag.cpp:220
+#: ../src/msw/imaglist.cpp:223 ../src/msw/imaglist.cpp:245
+#: ../src/msw/imaglist.cpp:270 ../src/msw/dragimag.cpp:182
+#: ../src/msw/dragimag.cpp:217
 msgid "Couldn't add an image to the image list."
 msgstr ""
 
-#: ../src/osx/glcanvas_osx.cpp:414 ../src/unix/glx11.cpp:558
-#: ../src/msw/glcanvas.cpp:616
+#: ../src/osx/glcanvas_osx.cpp:411 ../src/msw/glcanvas.cpp:631
+#: ../src/unix/glegl.cpp:315 ../src/unix/glx11.cpp:559
 msgid "Couldn't create OpenGL context"
 msgstr ""
 
-#: ../src/msw/timer.cpp:134
+#: ../src/msw/timer.cpp:131
 msgid "Couldn't create a timer"
 msgstr ""
 
-#: ../src/osx/carbon/overlay.cpp:122
-msgid "Couldn't create the overlay window"
-msgstr ""
-
-#: ../src/common/translation.cpp:2024
+#: ../src/common/translation.cpp:2074
 msgid "Couldn't enumerate translations"
 msgstr ""
 
-#: ../src/common/dynlib.cpp:120
+#: ../src/common/dynlib.cpp:110
 #, c-format
 msgid "Couldn't find symbol '%s' in a dynamic library"
 msgstr ""
 
-#: ../src/msw/thread.cpp:915
+#: ../src/msw/thread.cpp:921
 msgid "Couldn't get the current thread pointer"
 msgstr ""
 
-#: ../src/osx/carbon/overlay.cpp:129
-msgid "Couldn't init the context on the overlay window"
-msgstr ""
-
-#: ../src/common/imaggif.cpp:244
+#: ../src/common/imaggif.cpp:241
 msgid "Couldn't initialize GIF hash table."
 msgstr ""
 
-#: ../src/common/imagpng.cpp:409
+#: ../src/common/imagpng.cpp:437
 msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
 msgstr ""
 
-#: ../src/unix/sound.cpp:470
+#: ../src/unix/sound.cpp:459
 #, c-format
 msgid "Couldn't load sound data from '%s'."
 msgstr ""
 
-#: ../src/msw/dirdlg.cpp:435
+#: ../src/msw/dirdlg.cpp:287
 msgid "Couldn't obtain folder name"
 msgstr ""
 
-#: ../src/unix/sound_sdl.cpp:229
+#: ../src/unix/sound_sdl.cpp:226
 #, c-format
 msgid "Couldn't open audio: %s"
 msgstr ""
 
-#: ../src/msw/ole/dataobj.cpp:377
+#: ../src/msw/ole/dataobj.cpp:385
 #, c-format
 msgid "Couldn't register clipboard format '%s'."
 msgstr ""
 
-#: ../src/msw/listctrl.cpp:869
+#: ../src/msw/listctrl.cpp:933
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr ""
 
-#: ../src/common/imagpng.cpp:498 ../src/common/imagpng.cpp:509
-#: ../src/common/imagpng.cpp:519
+#: ../src/common/imagpng.cpp:511 ../src/common/imagpng.cpp:522
+#: ../src/common/imagpng.cpp:532
 msgid "Couldn't save PNG image."
 msgstr ""
 
-#: ../src/msw/thread.cpp:684
+#: ../src/msw/thread.cpp:676
 msgid "Couldn't terminate thread"
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:166
+#: ../src/common/xtistrm.cpp:163
 #, c-format
 msgid "Create Parameter %s not found in declared RTTI Parameters"
 msgstr ""
 
-#: ../src/generic/dirdlgg.cpp:288
+#: ../src/generic/dirdlgg.cpp:285
 msgid "Create directory"
 msgstr ""
 
-#: ../src/generic/filedlgg.cpp:212 ../src/generic/dirdlgg.cpp:111
+#: ../src/generic/filedlgg.cpp:209 ../src/generic/dirdlgg.cpp:108
 msgid "Create new directory"
 msgstr ""
 
-#: ../src/xrc/xmlres.cpp:2460
+#: ../src/common/stockitem.cpp:264
+msgid "Create new document"
+msgstr ""
+
+#: ../src/xrc/xmlres.cpp:2515
 #, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1758
+#: ../src/propgrid/advprops.cpp:1659
 msgid "Cross"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:333
+#: ../src/common/accelcmn.cpp:347
 msgid "Ctrl+"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:332 ../src/osx/textctrl_osx.cpp:576
-#: ../src/common/stockitem.cpp:151 ../src/msw/textctrl.cpp:2507
+#: ../src/osx/textctrl_osx.cpp:594 ../src/common/stockitem.cpp:148
+#: ../src/msw/textctrl.cpp:2772 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:940
+#: ../src/generic/filectrlg.cpp:936
 msgid "Current directory:"
 msgstr ""
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:896 ../src/propgrid/advprops.cpp:1574
-#: ../src/propgrid/advprops.cpp:1612
+#: ../src/propgrid/advprops.cpp:797 ../src/propgrid/advprops.cpp:1475
+#: ../src/propgrid/advprops.cpp:1518
 msgid "Custom"
 msgstr ""
 
-#: ../src/gtk/print.cpp:217
+#: ../src/gtk/print.cpp:211
 msgid "Custom size"
 msgstr ""
 
-#: ../src/common/headerctrlcmn.cpp:60
+#: ../src/common/headerctrlcmn.cpp:58
 msgid "Customize Columns"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:151 ../src/stc/stc_i18n.cpp:17
+#: ../src/common/stockitem.cpp:148 ../src/stc/stc_i18n.cpp:17
 msgid "Cut"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:259
+#: ../src/common/stockitem.cpp:256
 msgid "Cut selection"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:152
+#: ../src/common/fmapbase.cpp:149
 msgid "Cyrillic (ISO-8859-5)"
 msgstr ""
 
-#: ../src/common/paper.cpp:99
+#: ../src/common/paper.cpp:96
 msgid "D sheet, 22 x 34 in"
 msgstr ""
 
-#: ../src/msw/dde.cpp:703
+#: ../src/msw/dde.cpp:698
 msgid "DDE poke request failed"
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1169
+#: ../src/common/imagbmp.cpp:1181
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr ""
 
@@ -2576,7 +2576,7 @@ msgstr ""
 msgid "DIB Header: Unknown encoding in file."
 msgstr ""
 
-#: ../src/common/paper.cpp:121
+#: ../src/common/paper.cpp:118
 msgid "DL Envelope, 110 x 220 mm"
 msgstr ""
 
@@ -2584,53 +2584,53 @@ msgstr ""
 msgid "Dashed"
 msgstr ""
 
-#: ../src/generic/dbgrptg.cpp:300
+#: ../src/generic/dbgrptg.cpp:301
 #, c-format
 msgid "Debug report \"%s\""
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:210
+#: ../src/common/debugrpt.cpp:211
 msgid "Debug report couldn't be created."
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:553
+#: ../src/common/debugrpt.cpp:554
 msgid "Debug report generation has failed."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:84
+#: ../src/common/accelcmn.cpp:81
 msgid "Decimal"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:323
+#: ../src/generic/fontdlgg.cpp:319
 msgid "Decorative"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1752
+#: ../src/propgrid/advprops.cpp:1653
 msgid "Default"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:796
+#: ../src/common/fmapbase.cpp:792
 msgid "Default encoding"
 msgstr ""
 
-#: ../src/dfb/fontmgr.cpp:180
+#: ../src/dfb/fontmgr.cpp:177
 msgid "Default font"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:510
+#: ../src/generic/prntdlgg.cpp:503
 msgid "Default printer"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:51
+#: ../src/common/accelcmn.cpp:48
 msgid "Del"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextbuffer.cpp:8221 ../src/common/stockitem.cpp:152
-#: ../src/common/accelcmn.cpp:50 ../src/stc/stc_i18n.cpp:20
+#: ../src/common/stockitem.cpp:149 ../src/common/accelcmn.cpp:47
+#: ../src/richtext/richtextbuffer.cpp:8217 ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr ""
 
@@ -2638,78 +2638,78 @@ msgstr ""
 msgid "Delete A&ll"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11341
+#: ../src/richtext/richtextbuffer.cpp:11340
 msgid "Delete Column"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11291
+#: ../src/richtext/richtextbuffer.cpp:11290
 msgid "Delete Row"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 msgid "Delete Style"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:1345 ../src/richtext/richtextctrl.cpp:1584
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
 msgid "Delete Text"
 msgstr ""
 
-#: ../src/generic/editlbox.cpp:170
+#: ../src/generic/editlbox.cpp:147
 msgid "Delete item"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:260
+#: ../src/common/stockitem.cpp:257
 msgid "Delete selection"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 #, c-format
 msgid "Delete style %s?"
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:301
+#: ../src/unix/snglinst.cpp:298
 #, c-format
 msgid "Deleted stale lock file '%s'."
 msgstr ""
 
-#: ../src/common/secretstore.cpp:220
+#: ../src/common/secretstore.cpp:234
 #, c-format
-msgid "Deleting password for \"%s/%s\" failed: %s."
+msgid "Deleting password for \"%s\" failed: %s."
 msgstr ""
 
-#: ../src/common/module.cpp:124
+#: ../src/common/module.cpp:121
 #, c-format
 msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "Descending"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:526 ../src/propgrid/advprops.cpp:882
+#: ../src/generic/dirctrlg.cpp:492 ../src/propgrid/advprops.cpp:783
 msgid "Desktop"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:70
+#: ../src/generic/aboutdlgg.cpp:67
 msgid "Developed by "
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:176
+#: ../src/generic/aboutdlgg.cpp:173
 msgid "Developers"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:374
+#: ../src/msw/dialup.cpp:368
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
 msgstr ""
 
-#: ../src/generic/tipdlg.cpp:211
+#: ../src/generic/tipdlg.cpp:208
 msgid "Did you know..."
 msgstr ""
 
-#: ../src/dfb/wrapdfb.cpp:63
+#: ../src/dfb/wrapdfb.cpp:60
 #, c-format
 msgid "DirectFB error %d occurred."
 msgstr ""
@@ -2718,73 +2718,73 @@ msgstr ""
 msgid "Directories"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1183
+#: ../src/common/filefn.cpp:1071
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1197
+#: ../src/common/filefn.cpp:1085
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr ""
 
-#: ../src/generic/dirdlgg.cpp:204
+#: ../src/generic/dirdlgg.cpp:201
 msgid "Directory does not exist"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:1399
+#: ../src/generic/filectrlg.cpp:1388
 msgid "Directory doesn't exist."
 msgstr ""
 
-#: ../src/common/docview.cpp:457
+#: ../src/common/docview.cpp:450
 msgid "Discard changes and reload the last saved version?"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:502
+#: ../src/html/helpwnd.cpp:500
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:679
+#: ../src/html/helpwnd.cpp:677
 msgid "Display options dialog"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:322
+#: ../src/html/helpwnd.cpp:320
 msgid "Displays help as you browse the books on the left."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:85
+#: ../src/common/accelcmn.cpp:83
 msgid "Divide"
 msgstr ""
 
-#: ../src/common/docview.cpp:533
+#: ../src/common/docview.cpp:526
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:542
+#: ../src/common/prntbase.cpp:537
 msgid "Document:"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:73
+#: ../src/generic/aboutdlgg.cpp:70
 msgid "Documentation by "
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:180
+#: ../src/generic/aboutdlgg.cpp:177
 msgid "Documentation writers"
 msgstr ""
 
-#: ../src/common/sizer.cpp:2799
+#: ../src/common/sizer.cpp:2916
 msgid "Don't Save"
 msgstr ""
 
-#: ../src/html/htmlwin.cpp:633
+#: ../src/html/htmlwin.cpp:643
 msgid "Done"
 msgstr ""
 
-#: ../src/generic/progdlgg.cpp:448 ../src/msw/progdlg.cpp:407
+#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
 msgid "Done."
 msgstr ""
 
@@ -2796,42 +2796,42 @@ msgstr ""
 msgid "Double"
 msgstr ""
 
-#: ../src/common/paper.cpp:176
+#: ../src/common/paper.cpp:173
 msgid "Double Japanese Postcard Rotated 148 x 200 mm"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:273
+#: ../src/common/xtixml.cpp:269
 #, c-format
 msgid "Doubly used id : %d"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:153
-#: ../src/common/accelcmn.cpp:64
+#: ../src/common/stockitem.cpp:150 ../src/common/accelcmn.cpp:61
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Down"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:865
+#: ../src/richtext/richtextctrl.cpp:864
 msgid "Drag"
 msgstr ""
 
-#: ../src/common/paper.cpp:100
+#: ../src/common/paper.cpp:97
 msgid "E sheet, 34 x 44 in"
 msgstr ""
 
-#: ../src/unix/fswatcher_inotify.cpp:561
+#: ../src/unix/fswatcher_inotify.cpp:558
 msgid "EOF while reading from inotify descriptor"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "Edit"
 msgstr ""
 
-#: ../src/generic/editlbox.cpp:168
+#: ../src/generic/editlbox.cpp:131
 msgid "Edit item"
 msgstr ""
 
-#: ../include/wx/generic/progdlgg.h:84
+#: ../include/wx/generic/progdlgg.h:85
 msgid "Elapsed time:"
 msgstr ""
 
@@ -2898,61 +2898,61 @@ msgid "Enables the shadow spread."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:66
+#: ../src/common/accelcmn.cpp:63
 msgid "End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:55
+#: ../src/common/accelcmn.cpp:52
 msgid "Enter"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:934
+#: ../src/richtext/richtextstyledlg.cpp:930
 msgid "Enter a box style name"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:602
 msgid "Enter a character style name"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:816
 msgid "Enter a list style name"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:893
+#: ../src/richtext/richtextstyledlg.cpp:889
 msgid "Enter a new style name"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:650
 msgid "Enter a paragraph style name"
 msgstr ""
 
-#: ../src/generic/dbgrptg.cpp:174
+#: ../src/generic/dbgrptg.cpp:171
 #, c-format
 msgid "Enter command to open file \"%s\":"
 msgstr ""
 
-#: ../src/generic/helpext.cpp:459
+#: ../src/generic/helpext.cpp:457
 msgid "Entries found"
 msgstr ""
 
-#: ../src/common/paper.cpp:142
+#: ../src/common/paper.cpp:139
 msgid "Envelope Invite 220 x 220 mm"
 msgstr ""
 
-#: ../src/common/config.cpp:469
+#: ../src/common/config.cpp:465
 #, c-format
 msgid ""
 "Environment variables expansion failed: missing '%c' at position %u in '%s'."
 msgstr ""
 
-#: ../src/generic/filedlgg.cpp:357 ../src/generic/dirctrlg.cpp:570
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/dirctrlg.cpp:599
-#: ../src/generic/dirdlgg.cpp:323 ../src/generic/filectrlg.cpp:642
-#: ../src/generic/filectrlg.cpp:756 ../src/generic/filectrlg.cpp:770
-#: ../src/generic/filectrlg.cpp:786 ../src/generic/filectrlg.cpp:1368
-#: ../src/generic/filectrlg.cpp:1399 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/gtk1/fontdlg.cpp:74 ../src/generic/dirctrlg.cpp:536
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/dirctrlg.cpp:565
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1357 ../src/generic/filectrlg.cpp:1388
+#: ../src/generic/filedlgg.cpp:354 ../src/generic/dirdlgg.cpp:320
+#: ../src/gtk/filedlg.cpp:74
 msgid "Error"
 msgstr ""
 
@@ -2960,111 +2960,127 @@ msgstr ""
 msgid "Error closing epoll descriptor"
 msgstr ""
 
-#: ../src/unix/fswatcher_kqueue.cpp:114
+#: ../src/unix/fswatcher_kqueue.cpp:131
 msgid "Error closing kqueue instance"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1049
+#: ../src/common/filefn.cpp:938
 #, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr ""
 
-#: ../src/generic/dirdlgg.cpp:222
+#: ../src/generic/dirdlgg.cpp:219
 msgid "Error creating directory"
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1181
+#: ../src/common/imagbmp.cpp:1193
 msgid "Error in reading image DIB."
 msgstr ""
 
-#: ../src/propgrid/propgrid.cpp:6696
+#: ../src/propgrid/propgrid.cpp:6665
 #, c-format
 msgid "Error in resource: %s"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:422
+#: ../src/common/fileconf.cpp:421
 msgid "Error reading config options."
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1057 ../src/msw/webview_edge.cpp:850
+#: ../src/gtk/webview_webkit2.cpp:1262 ../src/osx/webview_webkit.mm:383
+#, c-format
+msgid "Error running JavaScript: %s"
 msgstr ""
 
 #: ../src/common/fileconf.cpp:1029
 msgid "Error saving user configuration data."
 msgstr ""
 
-#: ../src/gtk/print.cpp:722
+#: ../src/gtk/print.cpp:720
 msgid "Error while printing: "
 msgstr ""
 
-#: ../src/common/log.cpp:219
+#: ../src/common/log.cpp:237
 msgid "Error: "
 msgstr ""
 
+#: ../src/common/webrequest.cpp:98
+#, c-format
+msgid "Error: %s (%d)"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:69
+#: ../src/common/accelcmn.cpp:66
 msgid "Esc"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:70
+#: ../src/common/accelcmn.cpp:67
 msgid "Escape"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:150
+#: ../src/common/fmapbase.cpp:147
 msgid "Esperanto (ISO-8859-3)"
 msgstr ""
 
-#: ../include/wx/generic/progdlgg.h:85
+#: ../include/wx/generic/progdlgg.h:86
 msgid "Estimated time:"
 msgstr ""
 
-#: ../src/generic/dbgrptg.cpp:234
+#: ../src/generic/dbgrptg.cpp:231
 msgid "Executable files (*.exe)|*.exe|"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:155 ../src/common/accelcmn.cpp:78
+#: ../src/common/stockitem.cpp:152 ../src/common/accelcmn.cpp:75
 msgid "Execute"
 msgstr ""
 
-#: ../src/msw/utilsexc.cpp:876
+#: ../src/msw/utilsexc.cpp:873
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr ""
 
-#: ../src/common/paper.cpp:105
+#: ../src/common/paper.cpp:102
 msgid "Executive, 7 1/4 x 10 1/2 in"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6009
+#: ../src/generic/datavgen.cpp:6814
 msgid "Expand"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1240
+#: ../src/msw/registry.cpp:1228
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:195
+#: ../src/common/fmapbase.cpp:192
 msgid "Extended Unix Codepage for Japanese (EUC-JP)"
 msgstr ""
 
-#: ../src/html/chm.cpp:725
+#: ../src/html/chm.cpp:718
 #, c-format
 msgid "Extraction of '%s' into '%s' failed."
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:249 ../src/common/accelcmn.cpp:344
+#: ../src/common/accelcmn.cpp:259 ../src/common/accelcmn.cpp:358
 msgid "F"
 msgstr ""
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:672
+#: ../src/propgrid/advprops.cpp:582
 msgid "Face Name"
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:269
+#: ../src/unix/snglinst.cpp:266
 msgid "Failed to access lock file."
+msgstr ""
+
+#: ../src/gtk/font.cpp:572
+#, c-format
+msgid "Failed to add custom font \"%s\"."
 msgstr ""
 
 #: ../src/unix/epolldispatcher.cpp:116
@@ -3072,120 +3088,123 @@ msgstr ""
 msgid "Failed to add descriptor %d to epoll descriptor %d"
 msgstr ""
 
-#: ../src/msw/dib.cpp:489
+#: ../src/msw/dib.cpp:535
 #, c-format
 msgid "Failed to allocate %luKb of memory for bitmap data."
 msgstr ""
 
-#: ../src/common/glcmn.cpp:115
+#: ../src/common/glcmn.cpp:112
 msgid "Failed to allocate colour for OpenGL"
 msgstr ""
 
-#: ../src/unix/displayx11.cpp:236
+#: ../src/common/lzmastream.cpp:231
+msgid "Failed to allocate memory for LZMA compression."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:121
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr ""
+
+#: ../include/wx/unix/private/displayx11.h:89
 msgid "Failed to change video mode"
 msgstr ""
 
-#: ../src/common/image.cpp:3277
+#: ../src/common/image.cpp:3396
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:239
+#: ../src/common/debugrpt.cpp:240
 #, c-format
 msgid "Failed to clean up debug report directory \"%s\""
 msgstr ""
 
-#: ../src/common/filename.cpp:192
+#: ../src/common/filename.cpp:189
 msgid "Failed to close file handle"
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:340
+#: ../src/unix/snglinst.cpp:337
 #, c-format
 msgid "Failed to close lock file '%s'"
 msgstr ""
 
-#: ../src/msw/clipbrd.cpp:112
+#: ../src/msw/clipbrd.cpp:110
 msgid "Failed to close the clipboard."
 msgstr ""
 
-#: ../src/x11/utils.cpp:208
+#: ../src/x11/utils.cpp:170
 #, c-format
 msgid "Failed to close the display \"%s\""
 msgstr ""
 
-#: ../src/msw/dialup.cpp:797
+#: ../src/msw/dialup.cpp:791
 msgid "Failed to connect: missing username/password."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:743
+#: ../src/msw/dialup.cpp:737
 msgid "Failed to connect: no ISP to dial."
 msgstr ""
 
-#: ../src/common/textfile.cpp:203
-#, c-format
-msgid "Failed to convert file \"%s\" to Unicode."
-msgstr ""
-
-#: ../src/generic/logg.cpp:956
+#: ../src/generic/logg.cpp:953
 msgid "Failed to copy dialog contents to the clipboard."
 msgstr ""
 
-#: ../src/msw/registry.cpp:692
+#: ../src/msw/registry.cpp:681
 #, c-format
 msgid "Failed to copy registry value '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:701
+#: ../src/msw/registry.cpp:690
 #, c-format
 msgid "Failed to copy the contents of registry key '%s' to '%s'."
 msgstr ""
 
-#: ../src/common/filefn.cpp:1015
+#: ../src/common/filefn.cpp:904
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:679
+#: ../src/msw/registry.cpp:668
 #, c-format
 msgid "Failed to copy the registry subkey '%s' to '%s'."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1070
+#: ../src/msw/dde.cpp:1134
 msgid "Failed to create DDE string"
 msgstr ""
 
-#: ../src/msw/mdi.cpp:616
+#: ../src/msw/mdi.cpp:621
 msgid "Failed to create MDI parent frame."
 msgstr ""
 
-#: ../src/common/filename.cpp:1027
+#: ../src/common/filename.cpp:1024
 msgid "Failed to create a temporary file name"
 msgstr ""
 
-#: ../src/msw/utilsexc.cpp:228
+#: ../src/msw/utilsexc.cpp:225
 msgid "Failed to create an anonymous pipe"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:522
+#: ../src/msw/ole/automtn.cpp:513
 #, c-format
 msgid "Failed to create an instance of \"%s\""
 msgstr ""
 
-#: ../src/msw/dde.cpp:437
+#: ../src/msw/dde.cpp:432
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr ""
 
-#: ../src/msw/cursor.cpp:204
+#: ../src/msw/cursor.cpp:195
 msgid "Failed to create cursor."
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:209
+#: ../src/common/debugrpt.cpp:210
 #, c-format
 msgid "Failed to create directory \"%s\""
 msgstr ""
 
-#: ../src/generic/dirdlgg.cpp:220
+#: ../src/generic/dirdlgg.cpp:217
 #, c-format
 msgid ""
 "Failed to create directory '%s'\n"
@@ -3196,184 +3215,202 @@ msgstr ""
 msgid "Failed to create epoll descriptor"
 msgstr ""
 
-#: ../src/msw/mimetype.cpp:238
+#: ../src/gtk/font.cpp:562
+msgid "Failed to create font configuration object."
+msgstr ""
+
+#: ../src/msw/mimetype.cpp:235
 #, c-format
 msgid "Failed to create registry entry for '%s' files."
 msgstr ""
 
-#: ../src/msw/fdrepdlg.cpp:409
+#: ../src/msw/fdrepdlg.cpp:408
 #, c-format
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr ""
 
-#: ../src/unix/wakeuppipe.cpp:52
+#: ../src/unix/wakeuppipe.cpp:49
 msgid "Failed to create wake up pipe used by event loop."
 msgstr ""
 
-#: ../src/html/winpars.cpp:730
+#: ../src/html/winpars.cpp:727
 #, c-format
 msgid "Failed to display HTML document in %s encoding"
 msgstr ""
 
-#: ../src/msw/clipbrd.cpp:124
+#: ../src/msw/clipbrd.cpp:122
 msgid "Failed to empty the clipboard."
 msgstr ""
 
-#: ../src/unix/displayx11.cpp:212
+#: ../include/wx/unix/private/displayx11.h:65
 msgid "Failed to enumerate video modes"
 msgstr ""
 
-#: ../src/msw/dde.cpp:722
+#: ../src/msw/dde.cpp:717
 msgid "Failed to establish an advise loop with DDE server"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:629 ../src/msw/dialup.cpp:863
+#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:611
+#: ../src/unix/utilsunx.cpp:613
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:720
+#: ../src/common/debugrpt.cpp:730
 msgid "Failed to execute curl, please install it in PATH."
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:505
+#: ../src/msw/ole/automtn.cpp:496
 #, c-format
 msgid "Failed to find CLSID of \"%s\""
 msgstr ""
 
-#: ../src/common/regex.cpp:431 ../src/common/regex.cpp:479
+#: ../src/common/regex.cpp:428 ../src/common/regex.cpp:476
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:695
+#: ../src/msw/webview_ie.cpp:978
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:689
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:574
+#: ../src/msw/ole/automtn.cpp:565
 #, c-format
 msgid "Failed to get OLE automation interface for \"%s\""
 msgstr ""
 
-#: ../src/msw/clipbrd.cpp:711
+#: ../src/msw/clipbrd.cpp:731
 msgid "Failed to get data from the clipboard"
 msgstr ""
 
-#: ../src/common/time.cpp:223
+#: ../src/common/time.cpp:216
 msgid "Failed to get the local system time"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1345
+#: ../src/common/filefn.cpp:1233
 msgid "Failed to get the working directory"
 msgstr ""
 
-#: ../src/univ/theme.cpp:114
+#: ../src/univ/theme.cpp:111
 msgid "Failed to initialize GUI: no built-in themes found."
 msgstr ""
 
-#: ../src/msw/helpchm.cpp:63
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:60
 msgid "Failed to initialize MS HTML Help."
 msgstr ""
 
-#: ../src/msw/glcanvas.cpp:1381
+#: ../src/msw/glcanvas.cpp:1391
 msgid "Failed to initialize OpenGL"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:858
+#: ../src/msw/dialup.cpp:852
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr ""
 
-#: ../src/gtk/textctrl.cpp:1128
+#: ../src/gtk/textctrl.cpp:1209
 msgid "Failed to insert text in the control."
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:241
+#: ../src/unix/snglinst.cpp:238
 #, c-format
 msgid "Failed to inspect the lock file '%s'"
 msgstr ""
 
-#: ../src/unix/appunix.cpp:182
+#: ../src/unix/appunix.cpp:179
 msgid "Failed to install signal handler"
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1167
+#: ../src/unix/threadpsx.cpp:1216
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
 msgstr ""
 
-#: ../src/msw/utils.cpp:629
+#: ../src/msw/utils.cpp:619
 #, c-format
 msgid "Failed to kill process %d"
 msgstr ""
 
-#: ../src/common/image.cpp:2500
+#: ../src/common/image.cpp:2595
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr ""
 
-#: ../src/common/image.cpp:2509
+#: ../src/common/image.cpp:2604
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr ""
 
-#: ../src/common/iconbndl.cpp:225
+#: ../src/common/iconbndl.cpp:224
 #, c-format
 msgid "Failed to load icons from resource '%s'."
 msgstr ""
 
-#: ../src/common/iconbndl.cpp:200
+#: ../src/common/iconbndl.cpp:198
 #, c-format
 msgid "Failed to load image %%d from file '%s'."
 msgstr ""
 
-#: ../src/common/iconbndl.cpp:208
+#: ../src/common/iconbndl.cpp:206
 #, c-format
 msgid "Failed to load image %d from stream."
 msgstr ""
 
-#: ../src/common/image.cpp:2587 ../src/common/image.cpp:2606
+#: ../src/common/image.cpp:2682 ../src/common/image.cpp:2701
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr ""
 
-#: ../src/msw/enhmeta.cpp:97
+#: ../src/msw/enhmeta.cpp:94
 #, c-format
 msgid "Failed to load metafile from file \"%s\"."
 msgstr ""
 
-#: ../src/msw/volume.cpp:327
+#: ../src/msw/volume.cpp:335
 msgid "Failed to load mpr.dll."
 msgstr ""
 
-#: ../src/msw/utils.cpp:953
+#: ../src/msw/utils.cpp:943
 #, c-format
 msgid "Failed to load resource \"%s\"."
 msgstr ""
 
-#: ../src/common/dynlib.cpp:92
+#: ../src/common/dynlib.cpp:86
 #, c-format
 msgid "Failed to load shared library '%s'"
 msgstr ""
 
-#: ../src/osx/core/sound.cpp:145
+#: ../src/osx/core/sound.cpp:143
 #, c-format
 msgid "Failed to load sound from \"%s\" (error %d)."
 msgstr ""
 
-#: ../src/msw/utils.cpp:960
+#: ../src/msw/utils.cpp:950
 #, c-format
 msgid "Failed to lock resource \"%s\"."
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:198
+#: ../src/unix/snglinst.cpp:195
 #, c-format
 msgid "Failed to lock the lock file '%s'"
 msgstr ""
@@ -3383,33 +3420,38 @@ msgstr ""
 msgid "Failed to modify descriptor %d in epoll descriptor %d"
 msgstr ""
 
-#: ../src/common/filename.cpp:2575
+#: ../src/common/filename.cpp:2658
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr ""
 
-#: ../src/common/selectdispatcher.cpp:258
+#: ../src/common/selectdispatcher.cpp:255
 msgid "Failed to monitor I/O channels"
 msgstr ""
 
-#: ../src/common/filename.cpp:175
+#: ../src/common/filename.cpp:172
 #, c-format
 msgid "Failed to open '%s' for reading"
 msgstr ""
 
-#: ../src/common/filename.cpp:180
+#: ../src/common/filename.cpp:177
 #, c-format
 msgid "Failed to open '%s' for writing"
 msgstr ""
 
-#: ../src/html/chm.cpp:141
+#: ../src/html/chm.cpp:138
 #, c-format
 msgid "Failed to open CHM archive '%s'."
 msgstr ""
 
-#: ../src/common/utilscmn.cpp:1126
+#: ../src/common/utilscmn.cpp:1140
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
+msgstr ""
+
+#: ../src/common/hyperlnkcmn.cpp:133
+#, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
 msgstr ""
 
 #: ../include/wx/msw/private/fswatcher.h:92
@@ -3417,208 +3459,225 @@ msgstr ""
 msgid "Failed to open directory \"%s\" for monitoring."
 msgstr ""
 
-#: ../src/x11/utils.cpp:227
+#: ../src/x11/utils.cpp:189
 #, c-format
 msgid "Failed to open display \"%s\"."
 msgstr ""
 
-#: ../src/common/filename.cpp:1062
+#: ../src/common/filename.cpp:1059
 msgid "Failed to open temporary file."
 msgstr ""
 
-#: ../src/msw/clipbrd.cpp:91
+#: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr ""
 
-#: ../src/common/translation.cpp:1184
+#: ../src/common/translation.cpp:1226
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr ""
 
-#: ../src/unix/mediactrl.cpp:1214
+#: ../src/unix/mediactrl.cpp:1239
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr ""
 
-#: ../src/msw/clipbrd.cpp:600
+#: ../src/msw/clipbrd.cpp:610
 msgid "Failed to put data on the clipboard"
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:278
+#: ../src/unix/snglinst.cpp:275
 msgid "Failed to read PID from lock file."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:433
+#: ../src/common/fileconf.cpp:432
 msgid "Failed to read config options."
 msgstr ""
 
-#: ../src/common/docview.cpp:681
+#: ../src/common/docview.cpp:676
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr ""
 
-#: ../src/dfb/evtloop.cpp:98
+#: ../src/dfb/evtloop.cpp:99
 msgid "Failed to read event from DirectFB pipe"
 msgstr ""
 
-#: ../src/unix/wakeuppipe.cpp:120
+#: ../src/unix/wakeuppipe.cpp:117
 msgid "Failed to read from wake-up pipe"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:679
+#: ../src/common/textfile.cpp:96
+#, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr ""
+
+#: ../src/unix/utilsunx.cpp:681
 msgid "Failed to redirect child process input/output"
 msgstr ""
 
-#: ../src/msw/utilsexc.cpp:701
+#: ../src/msw/utilsexc.cpp:698
 msgid "Failed to redirect the child process IO"
 msgstr ""
 
-#: ../src/msw/dde.cpp:288
+#: ../src/msw/dde.cpp:283
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr ""
 
-#: ../src/common/fontmap.cpp:245
+#: ../src/gtk/font.cpp:580
+msgid "Failed to register font configuration using private fonts."
+msgstr ""
+
+#: ../src/common/fontmap.cpp:242
 #, c-format
 msgid "Failed to remember the encoding for the charset '%s'."
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:227
+#: ../src/common/debugrpt.cpp:228
 #, c-format
 msgid "Failed to remove debug report file \"%s\""
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:328
+#: ../src/unix/snglinst.cpp:325
 #, c-format
 msgid "Failed to remove lock file '%s'"
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:288
+#: ../src/unix/snglinst.cpp:285
 #, c-format
 msgid "Failed to remove stale lock file '%s'."
 msgstr ""
 
-#: ../src/msw/registry.cpp:529
+#: ../src/msw/registry.cpp:518
 #, c-format
 msgid "Failed to rename registry value '%s' to '%s'."
 msgstr ""
 
-#: ../src/common/filefn.cpp:1122
+#: ../src/common/filefn.cpp:1011
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
 "exists."
 msgstr ""
 
-#: ../src/msw/registry.cpp:634
+#: ../src/msw/registry.cpp:623
 #, c-format
 msgid "Failed to rename the registry key '%s' to '%s'."
 msgstr ""
 
-#: ../src/common/filename.cpp:2671
+#: ../src/msw/webview_ie.cpp:995
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/common/filename.cpp:2754
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:468
+#: ../src/msw/dialup.cpp:462
 msgid "Failed to retrieve text of RAS error message"
 msgstr ""
 
-#: ../src/msw/clipbrd.cpp:748
+#: ../src/msw/clipbrd.cpp:768
 msgid "Failed to retrieve the supported clipboard formats"
 msgstr ""
 
-#: ../src/common/docview.cpp:652
+#: ../src/common/docview.cpp:647
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr ""
 
-#: ../src/msw/dib.cpp:269
+#: ../src/msw/dib.cpp:312
 #, c-format
 msgid "Failed to save the bitmap image to file \"%s\"."
 msgstr ""
 
-#: ../src/msw/dde.cpp:763
+#: ../src/msw/dde.cpp:811
 msgid "Failed to send DDE advise notification"
 msgstr ""
 
-#: ../src/common/ftp.cpp:402
+#: ../src/common/ftp.cpp:399
 #, c-format
 msgid "Failed to set FTP transfer mode to %s."
 msgstr ""
 
-#: ../src/msw/clipbrd.cpp:427
+#: ../src/msw/clipbrd.cpp:443
 msgid "Failed to set clipboard data."
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:181
+#: ../src/unix/snglinst.cpp:178
 #, c-format
 msgid "Failed to set permissions on lock file '%s'"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:668
+#: ../src/unix/utilsunx.cpp:670
 msgid "Failed to set process priority"
 msgstr ""
 
-#: ../src/common/file.cpp:559
+#: ../src/common/ffile.cpp:355 ../src/common/file.cpp:586
 msgid "Failed to set temporary file permissions"
 msgstr ""
 
-#: ../src/gtk/textctrl.cpp:1072
-msgid "Failed to set text in the text control."
-msgstr ""
-
-#: ../src/unix/threadpsx.cpp:1298
+#: ../src/unix/threadpsx.cpp:1347
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1424
+#: ../src/unix/threadpsx.cpp:1473
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:783
+#: ../src/unix/utilsunx.cpp:785
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 
-#: ../src/common/fs_mem.cpp:261
+#: ../src/msw/webview_ie.cpp:987
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:256
 #, c-format
 msgid "Failed to store image '%s' to memory VFS!"
 msgstr ""
 
-#: ../src/dfb/evtloop.cpp:170
+#: ../src/dfb/evtloop.cpp:171
 msgid "Failed to switch DirectFB pipe to non-blocking mode"
 msgstr ""
 
-#: ../src/unix/wakeuppipe.cpp:59
+#: ../src/unix/wakeuppipe.cpp:56
 msgid "Failed to switch wake up pipe to non-blocking mode"
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1605
+#: ../src/unix/threadpsx.cpp:1654
 msgid "Failed to terminate a thread."
 msgstr ""
 
-#: ../src/msw/dde.cpp:741
+#: ../src/msw/dde.cpp:736
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:938
+#: ../src/msw/dialup.cpp:932
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr ""
 
-#: ../src/common/filename.cpp:2590
+#: ../src/common/filename.cpp:2673
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:334
+#: ../src/unix/dlunix.cpp:90
+msgid "Failed to unload shared library"
+msgstr ""
+
+#: ../src/unix/snglinst.cpp:331
 #, c-format
 msgid "Failed to unlock lock file '%s'"
 msgstr ""
 
-#: ../src/msw/dde.cpp:309
+#: ../src/msw/dde.cpp:304
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr ""
@@ -3632,77 +3691,85 @@ msgstr ""
 msgid "Failed to update user configuration file."
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:733
+#: ../src/common/debugrpt.cpp:743
 #, c-format
 msgid "Failed to upload the debug report (error code %d)."
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:168
+#: ../src/unix/snglinst.cpp:165
 #, c-format
 msgid "Failed to write to lock file '%s'"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:209
+#: ../src/propgrid/propgrid.cpp:190
 msgid "False"
 msgstr ""
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:694
+#: ../src/propgrid/advprops.cpp:604
 msgid "Family"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/gtk/glcanvas.cpp:176 ../src/gtk/glcanvas.cpp:187
+msgid "Fatal Error"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:154
 msgid "File"
 msgstr ""
 
-#: ../src/common/docview.cpp:669
+#: ../src/common/docview.cpp:664
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr ""
 
-#: ../src/common/docview.cpp:646
+#: ../src/common/docview.cpp:641
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr ""
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1156
+#: ../src/common/filefn.cpp:1044
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1139
+#: ../src/common/filefn.cpp:1028
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:3081 ../src/common/textcmn.cpp:953
+#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
 msgid "File couldn't be loaded."
 msgstr ""
 
-#: ../src/msw/filedlg.cpp:393
+#: ../src/msw/filedlg.cpp:414
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr ""
 
-#: ../src/common/docview.cpp:1789
+#: ../src/common/docview.cpp:1783
 msgid "File error"
 msgstr ""
 
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/filectrlg.cpp:770
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/filectrlg.cpp:766
 msgid "File name exists already."
+msgstr ""
+
+#: ../src/osx/cocoa/filedlg.mm:264
+msgid "File type:"
 msgstr ""
 
 #: ../src/motif/filedlg.cpp:220
 msgid "Files"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1591
+#: ../src/common/filefn.cpp:1479
 #, c-format
 msgid "Files (%s)"
 msgstr ""
@@ -3711,15 +3778,27 @@ msgstr ""
 msgid "Filter"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:158 ../src/html/helpwnd.cpp:490
+#: ../src/html/helpwnd.cpp:488
 msgid "Find"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:259
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:258
+msgid "Find in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:155
+msgid "Find..."
+msgstr ""
+
+#: ../src/common/stockitem.cpp:156
 msgid "First"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:1548
+#: ../src/common/prntbase.cpp:1573
 msgid "First page"
 msgstr ""
 
@@ -3727,11 +3806,11 @@ msgstr ""
 msgid "Fixed"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1206
+#: ../src/html/helpwnd.cpp:1204
 msgid "Fixed font:"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1269
+#: ../src/html/helpwnd.cpp:1267
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr ""
 
@@ -3739,16 +3818,16 @@ msgstr ""
 msgid "Floating"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "Floppy"
 msgstr ""
 
-#: ../src/common/paper.cpp:111
+#: ../src/common/paper.cpp:108
 msgid "Folio, 8 1/2 x 13 in"
 msgstr ""
 
-#: ../src/richtext/richtextformatdlg.cpp:344 ../src/osx/carbon/fontdlg.cpp:287
-#: ../src/common/stockitem.cpp:194
+#: ../src/osx/carbon/fontdlg.cpp:284 ../src/common/stockitem.cpp:191
+#: ../src/richtext/richtextformatdlg.cpp:337
 msgid "Font"
 msgstr ""
 
@@ -3756,7 +3835,24 @@ msgstr ""
 msgid "Font &weight:"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1207
+#: ../src/osx/fontutil.cpp:89
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
+"\"."
+msgstr ""
+
+#: ../src/msw/font.cpp:1126
+#, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr ""
+
+#: ../src/osx/fontutil.cpp:81
+#, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1205
 msgid "Font size:"
 msgstr ""
 
@@ -3764,75 +3860,75 @@ msgstr ""
 msgid "Font st&yle:"
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:329
+#: ../src/osx/carbon/fontdlg.cpp:326
 msgid "Font:"
 msgstr ""
 
-#: ../src/dfb/fontmgr.cpp:198
+#: ../src/dfb/fontmgr.cpp:195
 #, c-format
 msgid "Fonts index file %s disappeared while loading fonts."
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:645
+#: ../src/unix/utilsunx.cpp:647
 msgid "Fork failed"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "Forward"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:235
+#: ../src/common/xtixml.cpp:231
 msgid "Forward hrefs are not supported"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:875
+#: ../src/html/helpwnd.cpp:873
 #, c-format
 msgid "Found %i matches"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:238
+#: ../src/generic/prntdlgg.cpp:231
 msgid "From:"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1604
+#: ../src/propgrid/advprops.cpp:1510
 msgid "Fuchsia"
 msgstr ""
 
-#: ../src/common/imaggif.cpp:138
+#: ../src/common/imaggif.cpp:135
 msgid "GIF: data stream seems to be truncated."
 msgstr ""
 
-#: ../src/common/imaggif.cpp:128
+#: ../src/common/imaggif.cpp:125
 msgid "GIF: error in GIF image format."
 msgstr ""
 
-#: ../src/common/imaggif.cpp:133
+#: ../src/common/imaggif.cpp:130
 msgid "GIF: not enough memory."
 msgstr ""
 
-#: ../src/gtk/window.cpp:4631
+#: ../src/gtk/window.cpp:5635
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
 msgstr ""
 
-#: ../src/univ/themes/gtk.cpp:525
+#: ../src/univ/themes/gtk.cpp:522
 msgid "GTK+ theme"
 msgstr ""
 
-#: ../src/common/preferencescmn.cpp:40
+#: ../src/common/preferencescmn.cpp:37
 msgid "General"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:258
+#: ../src/common/prntbase.cpp:253
 msgid "Generic PostScript"
 msgstr ""
 
-#: ../src/common/paper.cpp:135
+#: ../src/common/paper.cpp:132
 msgid "German Legal Fanfold, 8 1/2 x 13 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:134
+#: ../src/common/paper.cpp:131
 msgid "German Std Fanfold, 8 1/2 x 12 in"
 msgstr ""
 
@@ -3848,48 +3944,48 @@ msgstr ""
 msgid "GetPropertyCollection called w/o valid collection getter"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:658
 msgid "Go back"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:661
+#: ../src/html/helpwnd.cpp:659
 msgid "Go forward"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:663
+#: ../src/html/helpwnd.cpp:661
 msgid "Go one level up in document hierarchy"
 msgstr ""
 
-#: ../src/generic/filedlgg.cpp:208 ../src/generic/dirdlgg.cpp:116
+#: ../src/generic/filedlgg.cpp:205 ../src/generic/dirdlgg.cpp:113
 msgid "Go to home directory"
 msgstr ""
 
-#: ../src/generic/filedlgg.cpp:205
+#: ../src/generic/filedlgg.cpp:202
 msgid "Go to parent directory"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:76
+#: ../src/generic/aboutdlgg.cpp:73
 msgid "Graphics art by "
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1599
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Gray"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:883
+#: ../src/propgrid/advprops.cpp:784
 msgid "GrayText"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:154
+#: ../src/common/fmapbase.cpp:151
 msgid "Greek (ISO-8859-7)"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1600
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Green"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:342
+#: ../src/generic/colrdlgg.cpp:362
 msgid "Green:"
 msgstr ""
 
@@ -3897,107 +3993,107 @@ msgstr ""
 msgid "Groove"
 msgstr ""
 
-#: ../src/common/zstream.cpp:158 ../src/common/zstream.cpp:318
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
 msgid "Gzip not supported by this version of zlib"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1549
+#: ../src/html/helpwnd.cpp:1547
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr ""
 
-#: ../src/html/htmlwin.cpp:681
+#: ../src/html/htmlwin.cpp:691
 #, c-format
 msgid "HTML anchor %s does not exist."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1547
+#: ../src/html/helpwnd.cpp:1545
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1759
+#: ../src/propgrid/advprops.cpp:1660
 msgid "Hand"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "Harddisk"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:155
+#: ../src/common/fmapbase.cpp:152
 msgid "Hebrew (ISO-8859-8)"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:280 ../src/osx/button_osx.cpp:39
-#: ../src/common/stockitem.cpp:163 ../src/common/accelcmn.cpp:80
-#: ../src/html/helpdlg.cpp:66 ../src/html/helpfrm.cpp:111
+#: ../include/wx/msgdlg.h:282 ../src/osx/button_osx.cpp:39
+#: ../src/common/stockitem.cpp:160 ../src/common/accelcmn.cpp:77
+#: ../src/html/helpfrm.cpp:108 ../src/html/helpdlg.cpp:63
 msgid "Help"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1200
+#: ../src/html/helpwnd.cpp:1198
 msgid "Help Browser Options"
 msgstr ""
 
-#: ../src/generic/helpext.cpp:454 ../src/generic/helpext.cpp:455
+#: ../src/generic/helpext.cpp:452 ../src/generic/helpext.cpp:453
 msgid "Help Index"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1529
 msgid "Help Printing"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:801
+#: ../src/html/helpwnd.cpp:799
 msgid "Help Topics"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1546
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr ""
 
-#: ../src/generic/helpext.cpp:267
+#: ../src/generic/helpext.cpp:265
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:275
+#: ../src/generic/helpext.cpp:273
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr ""
 
-#: ../src/html/helpctrl.cpp:63
+#: ../src/html/helpctrl.cpp:59
 #, c-format
 msgid "Help: %s"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:577
+#: ../src/osx/menu_osx.cpp:469
 #, c-format
 msgid "Hide %s"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:579
+#: ../src/osx/menu_osx.cpp:471
 msgid "Hide Others"
 msgstr ""
 
-#: ../src/generic/infobar.cpp:84
+#: ../src/generic/infobar.cpp:81
 msgid "Hide this notification message."
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:884
+#: ../src/propgrid/advprops.cpp:785
 msgid "Highlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:885
+#: ../src/propgrid/advprops.cpp:786
 msgid "HighlightText"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:164 ../src/common/accelcmn.cpp:65
+#: ../src/common/stockitem.cpp:161 ../src/common/accelcmn.cpp:62
 msgid "Home"
 msgstr ""
 
-#: ../src/generic/dirctrlg.cpp:524
+#: ../src/generic/dirctrlg.cpp:490
 msgid "Home directory"
 msgstr ""
 
@@ -4007,61 +4103,61 @@ msgid "How the object will float relative to the text."
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1760
+#: ../src/propgrid/advprops.cpp:1661
 msgid "I-Beam"
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1196
+#: ../src/common/imagbmp.cpp:1208
 msgid "ICO: Error in reading mask DIB."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1290 ../src/common/imagbmp.cpp:1390
-#: ../src/common/imagbmp.cpp:1405 ../src/common/imagbmp.cpp:1416
-#: ../src/common/imagbmp.cpp:1430 ../src/common/imagbmp.cpp:1478
-#: ../src/common/imagbmp.cpp:1493 ../src/common/imagbmp.cpp:1507
-#: ../src/common/imagbmp.cpp:1518
+#: ../src/common/imagbmp.cpp:1302 ../src/common/imagbmp.cpp:1402
+#: ../src/common/imagbmp.cpp:1417 ../src/common/imagbmp.cpp:1428
+#: ../src/common/imagbmp.cpp:1442 ../src/common/imagbmp.cpp:1490
+#: ../src/common/imagbmp.cpp:1505 ../src/common/imagbmp.cpp:1519
+#: ../src/common/imagbmp.cpp:1530
 msgid "ICO: Error writing the image file!"
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1255
+#: ../src/common/imagbmp.cpp:1267
 msgid "ICO: Image too tall for an icon."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1263
+#: ../src/common/imagbmp.cpp:1275
 msgid "ICO: Image too wide for an icon."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1603
+#: ../src/common/imagbmp.cpp:1615
 msgid "ICO: Invalid icon index."
 msgstr ""
 
-#: ../src/common/imagiff.cpp:758
+#: ../src/common/imagiff.cpp:755
 msgid "IFF: data stream seems to be truncated."
 msgstr ""
 
-#: ../src/common/imagiff.cpp:742
+#: ../src/common/imagiff.cpp:739
 msgid "IFF: error in IFF image format."
 msgstr ""
 
-#: ../src/common/imagiff.cpp:745
+#: ../src/common/imagiff.cpp:742
 msgid "IFF: not enough memory."
 msgstr ""
 
-#: ../src/common/imagiff.cpp:748
+#: ../src/common/imagiff.cpp:745
 msgid "IFF: unknown error!!!"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:197
+#: ../src/common/fmapbase.cpp:194
 msgid "ISO-2022-JP"
 msgstr ""
 
-#: ../src/html/htmprint.cpp:282
+#: ../src/html/htmprint.cpp:294
 msgid ""
 "If possible, try changing the layout parameters to make the printout more "
 "narrow."
 msgstr ""
 
-#: ../src/generic/dbgrptg.cpp:358
+#: ../src/generic/dbgrptg.cpp:362
 msgid ""
 "If you have any additional information pertaining to this bug\n"
 "report, please enter it here and it will be joined to it:"
@@ -4075,145 +4171,149 @@ msgid ""
 "at all possible please do continue with the report generation.\n"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1405
+#: ../src/common/zipstrm.cpp:1043
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1393
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:295
+#: ../src/common/xtistrm.cpp:292
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr ""
 
-#: ../src/common/xti.cpp:513
+#: ../src/common/xti.cpp:510
 msgid "Illegal Parameter Count for ConstructObject Method"
 msgstr ""
 
-#: ../src/common/xti.cpp:501
+#: ../src/common/xti.cpp:498
 msgid "Illegal Parameter Count for Create Method"
 msgstr ""
 
-#: ../src/generic/dirctrlg.cpp:570 ../src/generic/filectrlg.cpp:756
+#: ../src/generic/dirctrlg.cpp:536 ../src/generic/filectrlg.cpp:752
 msgid "Illegal directory name."
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:1367
+#: ../src/generic/filectrlg.cpp:1356
 msgid "Illegal file specification."
 msgstr ""
 
-#: ../src/common/image.cpp:2269
+#: ../src/common/image.cpp:2363
 msgid "Image and mask have different sizes."
 msgstr ""
 
-#: ../src/common/image.cpp:2746
+#: ../src/common/image.cpp:2841
 #, c-format
 msgid "Image file is not of type %d."
 msgstr ""
 
-#: ../src/common/image.cpp:2877
+#: ../src/common/image.cpp:2995
 #, c-format
 msgid "Image is not of type %s."
 msgstr ""
 
-#: ../src/msw/textctrl.cpp:488
+#: ../src/msw/textctrl.cpp:534
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:301
+#: ../src/unix/utilsunx.cpp:303
 msgid "Impossible to get child process input"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1028
+#: ../src/common/filefn.cpp:917
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1042
+#: ../src/common/filefn.cpp:931
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1097
+#: ../src/common/filefn.cpp:986
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:886
+#: ../src/propgrid/advprops.cpp:787
 msgid "InactiveBorder"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:887
+#: ../src/propgrid/advprops.cpp:788
 msgid "InactiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:888
+#: ../src/propgrid/advprops.cpp:789
 msgid "InactiveCaptionText"
 msgstr ""
 
-#: ../src/common/gifdecod.cpp:792
+#: ../src/common/gifdecod.cpp:826
 #, c-format
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:635
+#: ../src/msw/ole/automtn.cpp:626
 msgid "Incorrect number of arguments."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:165
+#: ../src/common/stockitem.cpp:162
 msgid "Indent"
 msgstr ""
 
-#: ../src/richtext/richtextformatdlg.cpp:349
+#: ../src/richtext/richtextformatdlg.cpp:342
 msgid "Indents && Spacing"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:166 ../src/html/helpwnd.cpp:515
+#: ../src/common/stockitem.cpp:163 ../src/html/helpwnd.cpp:513
 msgid "Index"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:159
+#: ../src/common/fmapbase.cpp:156
 msgid "Indian (ISO-8859-12)"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "Info"
 msgstr ""
 
-#: ../src/common/init.cpp:287
+#: ../src/common/init.cpp:284
 msgid "Initialization failed in post init, aborting."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:54
+#: ../src/common/accelcmn.cpp:51
 msgid "Ins"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextsymboldlg.cpp:472 ../src/common/accelcmn.cpp:53
+#: ../src/common/accelcmn.cpp:50 ../src/richtext/richtextsymboldlg.cpp:469
 msgid "Insert"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:8067
+#: ../src/richtext/richtextbuffer.cpp:8063
 msgid "Insert Field"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:7978
-#: ../src/richtext/richtextbuffer.cpp:8936
+#: ../src/richtext/richtextbuffer.cpp:7974
+#: ../src/richtext/richtextbuffer.cpp:8934
 msgid "Insert Image"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:8025
+#: ../src/richtext/richtextbuffer.cpp:8021
 msgid "Insert Object"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:1286 ../src/richtext/richtextctrl.cpp:1494
-#: ../src/richtext/richtextbuffer.cpp:7822
-#: ../src/richtext/richtextbuffer.cpp:7852
-#: ../src/richtext/richtextbuffer.cpp:7894
+#: ../src/richtext/richtextbuffer.cpp:7818
+#: ../src/richtext/richtextbuffer.cpp:7848
+#: ../src/richtext/richtextbuffer.cpp:7890
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
 msgid "Insert Text"
 msgstr ""
 
@@ -4226,16 +4326,11 @@ msgstr ""
 msgid "Inset"
 msgstr ""
 
-#: ../src/gtk/app.cpp:425
-#, c-format
-msgid "Invalid GTK+ command line option, use \"%s --help\""
-msgstr ""
-
-#: ../src/common/imagtiff.cpp:311
+#: ../src/common/imagtiff.cpp:308
 msgid "Invalid TIFF image index."
 msgstr ""
 
-#: ../src/common/appcmn.cpp:273
+#: ../src/common/appcmn.cpp:294
 #, c-format
 msgid "Invalid display mode specification '%s'."
 msgstr ""
@@ -4245,246 +4340,250 @@ msgstr ""
 msgid "Invalid geometry specification '%s'"
 msgstr ""
 
-#: ../src/unix/fswatcher_inotify.cpp:323
+#: ../src/unix/fswatcher_inotify.cpp:320
 #, c-format
 msgid "Invalid inotify event for \"%s\""
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:312
+#: ../src/unix/snglinst.cpp:309
 #, c-format
 msgid "Invalid lock file '%s'."
 msgstr ""
 
-#: ../src/common/translation.cpp:1125
+#: ../src/common/translation.cpp:1167
 msgid "Invalid message catalog."
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:405 ../src/common/xtistrm.cpp:420
+#: ../src/common/xtistrm.cpp:402 ../src/common/xtistrm.cpp:417
 msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:435
+#: ../src/common/xtistrm.cpp:432
 msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
 msgstr ""
 
-#: ../src/common/regex.cpp:310
+#: ../src/common/regex.cpp:307
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr ""
 
-#: ../src/common/config.cpp:226
+#: ../src/common/config.cpp:222
 #, c-format
 msgid "Invalid value %ld for a boolean key \"%s\" in config file."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:351
-#: ../src/osx/carbon/fontdlg.cpp:361 ../src/common/stockitem.cpp:168
+#: ../src/osx/carbon/fontdlg.cpp:358 ../src/common/stockitem.cpp:165
+#: ../src/generic/fontdlgg.cpp:325 ../src/richtext/richtextfontpage.cpp:351
 msgid "Italic"
 msgstr ""
 
-#: ../src/common/paper.cpp:130
+#: ../src/common/paper.cpp:127
 msgid "Italy Envelope, 110 x 230 mm"
 msgstr ""
 
-#: ../src/common/imagjpeg.cpp:270
+#: ../src/common/imagjpeg.cpp:257
 msgid "JPEG: Couldn't load - file is probably corrupted."
 msgstr ""
 
-#: ../src/common/imagjpeg.cpp:449
+#: ../src/common/imagjpeg.cpp:436
 msgid "JPEG: Couldn't save image."
 msgstr ""
 
-#: ../src/common/paper.cpp:163
+#: ../src/common/paper.cpp:160
 msgid "Japanese Double Postcard 200 x 148 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:167
+#: ../src/common/paper.cpp:164
 msgid "Japanese Envelope Chou #3"
 msgstr ""
 
-#: ../src/common/paper.cpp:180
+#: ../src/common/paper.cpp:177
 msgid "Japanese Envelope Chou #3 Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:168
+#: ../src/common/paper.cpp:165
 msgid "Japanese Envelope Chou #4"
 msgstr ""
 
-#: ../src/common/paper.cpp:181
+#: ../src/common/paper.cpp:178
 msgid "Japanese Envelope Chou #4 Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:165
+#: ../src/common/paper.cpp:162
 msgid "Japanese Envelope Kaku #2"
 msgstr ""
 
-#: ../src/common/paper.cpp:178
+#: ../src/common/paper.cpp:175
 msgid "Japanese Envelope Kaku #2 Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:166
+#: ../src/common/paper.cpp:163
 msgid "Japanese Envelope Kaku #3"
 msgstr ""
 
-#: ../src/common/paper.cpp:179
+#: ../src/common/paper.cpp:176
 msgid "Japanese Envelope Kaku #3 Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:185
+#: ../src/common/paper.cpp:182
 msgid "Japanese Envelope You #4"
 msgstr ""
 
-#: ../src/common/paper.cpp:186
+#: ../src/common/paper.cpp:183
 msgid "Japanese Envelope You #4 Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:138
+#: ../src/common/paper.cpp:135
 msgid "Japanese Postcard 100 x 148 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:175
+#: ../src/common/paper.cpp:172
 msgid "Japanese Postcard Rotated 148 x 100 mm"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "Jump to"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:171
+#: ../src/common/stockitem.cpp:168
 msgid "Justified"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:155
-#: ../src/richtext/richtextindentspage.cpp:157
 #: ../src/richtext/richtextliststylepage.cpp:344
 #: ../src/richtext/richtextliststylepage.cpp:346
+#: ../src/richtext/richtextindentspage.cpp:155
+#: ../src/richtext/richtextindentspage.cpp:157
 msgid "Justify text left and right."
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:163
+#: ../src/common/fmapbase.cpp:160
 msgid "KOI8-R"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:164
+#: ../src/common/fmapbase.cpp:161
 msgid "KOI8-U"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:265 ../src/common/accelcmn.cpp:347
+#: ../src/common/accelcmn.cpp:279 ../src/common/accelcmn.cpp:364
 msgid "KP_"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "KP_Add"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "KP_Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "KP_Decimal"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 msgid "KP_Delete"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "KP_Divide"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 msgid "KP_Down"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "KP_End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "KP_Enter"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "KP_Equal"
 msgstr ""
 
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
-msgid "KP_Home"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
-msgid "KP_Insert"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
-msgid "KP_Left"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
-msgid "KP_Multiply"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:99
-msgid "KP_Next"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
-msgid "KP_PageDown"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
-msgid "KP_PageUp"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:98
-msgid "KP_Prior"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
-msgid "KP_Right"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
-msgid "KP_Separator"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
-msgid "KP_Space"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
-msgid "KP_Subtract"
+#: ../src/common/accelcmn.cpp:276 ../src/common/accelcmn.cpp:361
+msgid "KP_F"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
 #: ../src/common/accelcmn.cpp:89
+msgid "KP_Home"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:100
+msgid "KP_Insert"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:90
+msgid "KP_Left"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:103
+msgid "KP_Multiply"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:97
+msgid "KP_Next"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:95
+msgid "KP_PageDown"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:94
+msgid "KP_PageUp"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:96
+msgid "KP_Prior"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:92
+msgid "KP_Right"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:105
+msgid "KP_Separator"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:86
+msgid "KP_Space"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:106
+msgid "KP_Subtract"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:87
 msgid "KP_Tab"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "KP_Up"
 msgstr ""
 
@@ -4492,112 +4591,127 @@ msgstr ""
 msgid "L&ine spacing:"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:613 ../src/generic/prntdlgg.cpp:868
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:280
+#, c-format
+msgid "LZMA compression error: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:196
+#, c-format
+msgid "LZMA decompression error: %s"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:861
 msgid "Landscape"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "Last"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:1572
+#: ../src/common/prntbase.cpp:1597
 msgid "Last page"
 msgstr ""
 
-#: ../src/common/log.cpp:305
+#: ../src/common/log.cpp:324
 #, c-format
 msgid "Last repeated message (\"%s\", %u time) wasn't output"
 msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/common/paper.cpp:103
+#: ../src/common/paper.cpp:100
 msgid "Ledger, 17 x 11 in"
 msgstr ""
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6146
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:58 ../src/generic/datavgen.cpp:6951
+#: ../src/richtext/richtextsizepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:252
 #: ../src/richtext/richtextliststylepage.cpp:253
 #: ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
-#: ../src/richtext/richtextsizepage.cpp:249 ../src/common/accelcmn.cpp:61
 msgid "Left"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:204
 #: ../src/richtext/richtextliststylepage.cpp:390
+#: ../src/richtext/richtextindentspage.cpp:204
 msgid "Left (&first line):"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1761
+#: ../src/propgrid/advprops.cpp:1662
 msgid "Left Button"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:880
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Left margin (mm):"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:141
-#: ../src/richtext/richtextindentspage.cpp:143
 #: ../src/richtext/richtextliststylepage.cpp:330
 #: ../src/richtext/richtextliststylepage.cpp:332
+#: ../src/richtext/richtextindentspage.cpp:141
+#: ../src/richtext/richtextindentspage.cpp:143
 msgid "Left-align text."
 msgstr ""
 
-#: ../src/common/paper.cpp:144
+#: ../src/common/paper.cpp:141
 msgid "Legal Extra 9 1/2 x 15 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:96
+#: ../src/common/paper.cpp:93
 msgid "Legal, 8 1/2 x 14 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:143
+#: ../src/common/paper.cpp:140
 msgid "Letter Extra 9 1/2 x 12 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:149
+#: ../src/common/paper.cpp:146
 msgid "Letter Extra Transverse 9.275 x 12 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:152
+#: ../src/common/paper.cpp:149
 msgid "Letter Plus 8 1/2 x 12.69 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:169
+#: ../src/common/paper.cpp:166
 msgid "Letter Rotated 11 x 8 1/2 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:101
+#: ../src/common/paper.cpp:98
 msgid "Letter Small, 8 1/2 x 11 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:147
+#: ../src/common/paper.cpp:144
 msgid "Letter Transverse 8 1/2 x 11 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:95
+#: ../src/common/paper.cpp:92
 msgid "Letter, 8 1/2 x 11 in"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "License"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:332
+#: ../src/generic/fontdlgg.cpp:328
 msgid "Light"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1608
+#: ../src/propgrid/advprops.cpp:1514
 msgid "Lime"
 msgstr ""
 
-#: ../src/generic/helpext.cpp:294
+#: ../src/generic/helpext.cpp:292
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr ""
@@ -4606,15 +4720,15 @@ msgstr ""
 msgid "Line spacing:"
 msgstr ""
 
-#: ../src/html/chm.cpp:838
+#: ../src/html/chm.cpp:829
 msgid "Link contained '//', converted to absolute link."
 msgstr ""
 
-#: ../src/richtext/richtextformatdlg.cpp:364
+#: ../src/richtext/richtextformatdlg.cpp:357
 msgid "List Style"
 msgstr ""
 
-#: ../src/richtext/richtextstyles.cpp:1064
+#: ../src/richtext/richtextstyles.cpp:1061
 msgid "List styles"
 msgstr ""
 
@@ -4628,26 +4742,26 @@ msgstr ""
 msgid "Lists the available fonts."
 msgstr ""
 
-#: ../src/common/fldlgcmn.cpp:340
+#: ../src/common/fldlgcmn.cpp:337
 #, c-format
 msgid "Load %s file"
 msgstr ""
 
-#: ../src/html/htmlwin.cpp:597
+#: ../src/html/htmlwin.cpp:600
 msgid "Loading : "
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:246
+#: ../src/unix/snglinst.cpp:243
 #, c-format
 msgid "Lock file '%s' has incorrect owner."
 msgstr ""
 
-#: ../src/unix/snglinst.cpp:251
+#: ../src/unix/snglinst.cpp:248
 #, c-format
 msgid "Lock file '%s' has incorrect permissions."
 msgstr ""
 
-#: ../src/generic/logg.cpp:576
+#: ../src/generic/logg.cpp:573
 #, c-format
 msgid "Log saved to the file '%s'."
 msgstr ""
@@ -4662,199 +4776,199 @@ msgstr ""
 msgid "Lower case roman numerals"
 msgstr ""
 
-#: ../src/gtk/mdi.cpp:422 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk1/mdi.cpp:431 ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr ""
 
-#: ../src/msw/helpchm.cpp:56
+#: ../src/msw/helpchm.cpp:53
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
 msgstr ""
 
-#: ../src/univ/themes/win32.cpp:3754
+#: ../src/univ/themes/win32.cpp:3751
 msgid "Ma&ximize"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:203
+#: ../src/common/fmapbase.cpp:200
 msgid "MacArabic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:222
+#: ../src/common/fmapbase.cpp:219
 msgid "MacArmenian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:211
+#: ../src/common/fmapbase.cpp:208
 msgid "MacBengali"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:217
+#: ../src/common/fmapbase.cpp:214
 msgid "MacBurmese"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:236
+#: ../src/common/fmapbase.cpp:233
 msgid "MacCeltic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:227
+#: ../src/common/fmapbase.cpp:224
 msgid "MacCentralEurRoman"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:223
+#: ../src/common/fmapbase.cpp:220
 msgid "MacChineseSimp"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:201
+#: ../src/common/fmapbase.cpp:198
 msgid "MacChineseTrad"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:233
+#: ../src/common/fmapbase.cpp:230
 msgid "MacCroatian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:206
+#: ../src/common/fmapbase.cpp:203
 msgid "MacCyrillic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:207
+#: ../src/common/fmapbase.cpp:204
 msgid "MacDevanagari"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:231
+#: ../src/common/fmapbase.cpp:228
 msgid "MacDingbats"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:226
+#: ../src/common/fmapbase.cpp:223
 msgid "MacEthiopic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:229
+#: ../src/common/fmapbase.cpp:226
 msgid "MacExtArabic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:237
+#: ../src/common/fmapbase.cpp:234
 msgid "MacGaelic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:221
+#: ../src/common/fmapbase.cpp:218
 msgid "MacGeorgian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:205
+#: ../src/common/fmapbase.cpp:202
 msgid "MacGreek"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:209
+#: ../src/common/fmapbase.cpp:206
 msgid "MacGujarati"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:208
+#: ../src/common/fmapbase.cpp:205
 msgid "MacGurmukhi"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:204
+#: ../src/common/fmapbase.cpp:201
 msgid "MacHebrew"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:234
+#: ../src/common/fmapbase.cpp:231
 msgid "MacIcelandic"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:200
+#: ../src/common/fmapbase.cpp:197
 msgid "MacJapanese"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:214
+#: ../src/common/fmapbase.cpp:211
 msgid "MacKannada"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:238
+#: ../src/common/fmapbase.cpp:235
 msgid "MacKeyboardGlyphs"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:218
+#: ../src/common/fmapbase.cpp:215
 msgid "MacKhmer"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:202
+#: ../src/common/fmapbase.cpp:199
 msgid "MacKorean"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:220
+#: ../src/common/fmapbase.cpp:217
 msgid "MacLaotian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:215
+#: ../src/common/fmapbase.cpp:212
 msgid "MacMalayalam"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:225
+#: ../src/common/fmapbase.cpp:222
 msgid "MacMongolian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:210
+#: ../src/common/fmapbase.cpp:207
 msgid "MacOriya"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:199
+#: ../src/common/fmapbase.cpp:196
 msgid "MacRoman"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:235
+#: ../src/common/fmapbase.cpp:232
 msgid "MacRomanian"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:216
+#: ../src/common/fmapbase.cpp:213
 msgid "MacSinhalese"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:230
+#: ../src/common/fmapbase.cpp:227
 msgid "MacSymbol"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:212
+#: ../src/common/fmapbase.cpp:209
 msgid "MacTamil"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:213
+#: ../src/common/fmapbase.cpp:210
 msgid "MacTelugu"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:219
+#: ../src/common/fmapbase.cpp:216
 msgid "MacThai"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:224
+#: ../src/common/fmapbase.cpp:221
 msgid "MacTibetan"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:232
+#: ../src/common/fmapbase.cpp:229
 msgid "MacTurkish"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:228
+#: ../src/common/fmapbase.cpp:225
 msgid "MacVietnamese"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1762
+#: ../src/propgrid/advprops.cpp:1663
 msgid "Magnifier"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:2143
+#: ../src/propgrid/advprops.cpp:2050
 msgid "Make a selection:"
 msgstr ""
 
-#: ../src/richtext/richtextformatdlg.cpp:374
+#: ../src/richtext/richtextformatdlg.cpp:367
 #: ../src/richtext/richtextmarginspage.cpp:171
 msgid "Margins"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1595
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Maroon"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:147
+#: ../src/generic/fdrepdlg.cpp:144
 msgid "Match case"
 msgstr ""
 
@@ -4866,40 +4980,40 @@ msgstr ""
 msgid "Max width:"
 msgstr ""
 
-#: ../src/unix/mediactrl.cpp:947
+#: ../src/unix/mediactrl.cpp:972
 #, c-format
 msgid "Media playback error: %s"
 msgstr ""
 
-#: ../src/common/fs_mem.cpp:175
+#: ../src/common/fs_mem.cpp:170
 #, c-format
 msgid "Memory VFS already contains file '%s'!"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
 #. TRANSLATORS: Keyword of system colour
-#: ../src/common/accelcmn.cpp:73 ../src/propgrid/advprops.cpp:889
+#: ../src/common/accelcmn.cpp:70 ../src/propgrid/advprops.cpp:790
 msgid "Menu"
 msgstr ""
 
-#: ../src/common/msgout.cpp:124
+#: ../src/common/msgout.cpp:121
 msgid "Message"
 msgstr ""
 
-#: ../src/univ/themes/metal.cpp:168
+#: ../src/univ/themes/metal.cpp:165
 msgid "Metal theme"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:652
+#: ../src/msw/ole/automtn.cpp:643
 msgid "Method or property not found."
 msgstr ""
 
-#: ../src/univ/themes/win32.cpp:3752
+#: ../src/univ/themes/win32.cpp:3749
 msgid "Mi&nimize"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1763
+#: ../src/propgrid/advprops.cpp:1664
 msgid "Middle Button"
 msgstr ""
 
@@ -4911,36 +5025,40 @@ msgstr ""
 msgid "Min width:"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:668
+#: ../src/osx/cocoa/menu.mm:281
+msgid "Minimize"
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:659
 msgid "Missing a required parameter."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:324
+#: ../src/generic/fontdlgg.cpp:320
 msgid "Modern"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:427
+#: ../src/generic/filectrlg.cpp:423
 msgid "Modified"
 msgstr ""
 
-#: ../src/common/module.cpp:133
+#: ../src/common/module.cpp:130
 #, c-format
 msgid "Module \"%s\" initialization failed"
 msgstr ""
 
-#: ../src/common/paper.cpp:131
+#: ../src/common/paper.cpp:128
 msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
 msgstr ""
 
-#: ../src/msw/fswatcher.cpp:143
+#: ../src/msw/fswatcher.cpp:140
 msgid "Monitoring individual files for changes is not supported currently."
 msgstr ""
 
-#: ../src/generic/editlbox.cpp:172
+#: ../src/generic/editlbox.cpp:160
 msgid "Move down"
 msgstr ""
 
-#: ../src/generic/editlbox.cpp:171
+#: ../src/generic/editlbox.cpp:155
 msgid "Move up"
 msgstr ""
 
@@ -4954,97 +5072,102 @@ msgstr ""
 msgid "Moves the object to the previous paragraph."
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9966
+#: ../src/richtext/richtextbuffer.cpp:9963
 msgid "Multiple Cell Properties"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:424
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:82
+msgid "Multiply"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:420
 msgid "Name"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1596
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Navy"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "Network"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173
 msgid "New"
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:243
+#: ../src/richtext/richtextstyledlg.cpp:239
 msgid "New &Box Style..."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:225
+#: ../src/richtext/richtextstyledlg.cpp:221
 msgid "New &Character Style..."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:237
+#: ../src/richtext/richtextstyledlg.cpp:233
 msgid "New &List Style..."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:231
+#: ../src/richtext/richtextstyledlg.cpp:227
 msgid "New &Paragraph Style..."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:606
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:654
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:820
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:893
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:934
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:602
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:650
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:816
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:889
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:930
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "New Style"
 msgstr ""
 
-#: ../src/generic/editlbox.cpp:169
+#: ../src/generic/editlbox.cpp:139
 msgid "New item"
 msgstr ""
 
-#: ../src/generic/dirdlgg.cpp:297 ../src/generic/dirdlgg.cpp:307
-#: ../src/generic/filectrlg.cpp:618 ../src/generic/filectrlg.cpp:627
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+#: ../src/generic/dirdlgg.cpp:294 ../src/generic/dirdlgg.cpp:304
 msgid "NewName"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:1567 ../src/html/helpwnd.cpp:665
+#: ../src/common/prntbase.cpp:1592 ../src/html/helpwnd.cpp:663
 msgid "Next page"
 msgstr ""
 
-#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:177
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:174
 #: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1764
+#: ../src/propgrid/advprops.cpp:1665
 msgid "No Entry"
 msgstr ""
 
-#: ../src/generic/animateg.cpp:150
+#: ../src/generic/animateg.cpp:133
 #, c-format
 msgid "No animation handler for type %ld defined."
 msgstr ""
 
-#: ../src/dfb/bitmap.cpp:642 ../src/dfb/bitmap.cpp:676
+#: ../src/dfb/bitmap.cpp:639 ../src/dfb/bitmap.cpp:673
 #, c-format
 msgid "No bitmap handler for type %d defined."
 msgstr ""
 
-#: ../src/common/utilscmn.cpp:1077
+#: ../src/common/utilscmn.cpp:1095
 msgid "No default application configured for HTML files."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:445
+#: ../src/generic/helpext.cpp:443
 msgid "No entries found."
 msgstr ""
 
-#: ../src/common/fontmap.cpp:421
+#: ../src/common/fontmap.cpp:418
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found,\n"
@@ -5053,7 +5176,7 @@ msgid ""
 "one)?"
 msgstr ""
 
-#: ../src/common/fontmap.cpp:426
+#: ../src/common/fontmap.cpp:423
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found.\n"
@@ -5061,201 +5184,201 @@ msgid ""
 "(otherwise the text in this encoding will not be shown correctly)?"
 msgstr ""
 
-#: ../src/generic/animateg.cpp:142
+#: ../src/generic/animateg.cpp:125
 msgid "No handler found for animation type."
 msgstr ""
 
-#: ../src/common/image.cpp:2728
+#: ../src/common/image.cpp:2823
 msgid "No handler found for image type."
 msgstr ""
 
-#: ../src/common/image.cpp:2736 ../src/common/image.cpp:2848
-#: ../src/common/image.cpp:2901
+#: ../src/common/image.cpp:2831 ../src/common/image.cpp:2954
+#: ../src/common/image.cpp:3020
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr ""
 
-#: ../src/common/image.cpp:2871 ../src/common/image.cpp:2915
+#: ../src/common/image.cpp:2986 ../src/common/image.cpp:3034
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:858
+#: ../src/html/helpwnd.cpp:856
 msgid "No matching page found yet"
 msgstr ""
 
-#: ../src/unix/sound.cpp:81
+#: ../src/unix/sound.cpp:78
 msgid "No sound"
 msgstr ""
 
-#: ../src/common/image.cpp:2277 ../src/common/image.cpp:2318
+#: ../src/common/image.cpp:2371 ../src/common/image.cpp:2412
 msgid "No unused colour in image being masked."
 msgstr ""
 
-#: ../src/common/image.cpp:3374
-msgid "No unused colour in image."
-msgstr ""
-
-#: ../src/generic/helpext.cpp:302
+#: ../src/generic/helpext.cpp:300
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr ""
 
-#: ../src/richtext/richtextborderspage.cpp:610
 #: ../src/richtext/richtextsizepage.cpp:248
 #: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:610
 msgid "None"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:157
+#: ../src/common/fmapbase.cpp:154
 msgid "Nordic (ISO-8859-10)"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:328 ../src/generic/fontdlgg.cpp:331
+#: ../src/generic/fontdlgg.cpp:324 ../src/generic/fontdlgg.cpp:327
 msgid "Normal"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1261
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1205
+#: ../src/html/helpwnd.cpp:1203
 msgid "Normal font:"
 msgstr ""
 
-#: ../src/propgrid/props.cpp:1128
+#: ../src/propgrid/props.cpp:1115
 #, c-format
 msgid "Not %s"
 msgstr ""
 
-#: ../include/wx/filename.h:573 ../include/wx/filename.h:578
-msgid "Not available"
+#: ../src/common/secretstore.cpp:168
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/webrequest.cpp:605
+msgid "Not enough free disk space for download."
 msgstr ""
 
 #: ../src/richtext/richtextfontpage.cpp:358
 msgid "Not underlined"
 msgstr ""
 
-#: ../src/common/paper.cpp:115
+#: ../src/common/paper.cpp:112
 msgid "Note, 8 1/2 x 11 in"
 msgstr ""
 
-#: ../src/generic/notifmsgg.cpp:132
+#: ../src/generic/notifmsgg.cpp:129
 msgid "Notice"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "Num *"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "Num +"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "Num ,"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "Num -"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "Num ."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "Num /"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "Num ="
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "Num Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 msgid "Num Delete"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 msgid "Num Down"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "Num End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "Num Enter"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 msgid "Num Home"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 msgid "Num Insert"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num Lock"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "Num Page Down"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "Num Page Up"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 msgid "Num Right"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "Num Space"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "Num Tab"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "Num Up"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "Num left"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num_lock"
 msgstr ""
 
@@ -5264,13 +5387,13 @@ msgstr ""
 msgid "Numbered outline"
 msgstr ""
 
-#: ../include/wx/msgdlg.h:278 ../src/richtext/richtextstyledlg.cpp:297
-#: ../src/common/stockitem.cpp:178 ../src/msw/msgdlg.cpp:454
-#: ../src/msw/msgdlg.cpp:747 ../src/gtk1/fontdlg.cpp:138
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:175
+#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/msgdlg.cpp:741 ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:692
+#: ../src/msw/ole/automtn.cpp:683
 #, c-format
 msgid "OLE Automation error in %s: %s"
 msgstr ""
@@ -5279,15 +5402,15 @@ msgstr ""
 msgid "Object Properties"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:660
+#: ../src/msw/ole/automtn.cpp:651
 msgid "Object implementation does not support named arguments."
 msgstr ""
 
-#: ../src/common/xtixml.cpp:264
+#: ../src/common/xtixml.cpp:260
 msgid "Objects must have an id attribute"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1601
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Olive"
 msgstr ""
 
@@ -5295,64 +5418,68 @@ msgstr ""
 msgid "Opaci&ty:"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:354
+#: ../src/generic/colrdlgg.cpp:374
 msgid "Opacity:"
 msgstr ""
 
-#: ../src/common/docview.cpp:1773 ../src/common/docview.cpp:1815
+#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
 msgid "Open File"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:671 ../src/html/helpwnd.cpp:1554
+#: ../src/html/helpwnd.cpp:669 ../src/html/helpwnd.cpp:1552
 msgid "Open HTML document"
 msgstr ""
 
-#: ../src/generic/dbgrptg.cpp:163
+#: ../src/common/stockitem.cpp:265
+msgid "Open an existing document"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:160
 #, c-format
 msgid "Open file \"%s\""
 msgstr ""
 
-#: ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176
 msgid "Open..."
 msgstr ""
 
-#: ../src/unix/glx11.cpp:506 ../src/msw/glcanvas.cpp:592
+#: ../src/msw/glcanvas.cpp:607 ../src/unix/glx11.cpp:513
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr ""
 
-#: ../src/generic/dirctrlg.cpp:599 ../src/generic/dirdlgg.cpp:323
-#: ../src/generic/filectrlg.cpp:642 ../src/generic/filectrlg.cpp:786
+#: ../src/generic/dirctrlg.cpp:565 ../src/generic/filectrlg.cpp:638
+#: ../src/generic/filectrlg.cpp:782 ../src/generic/dirdlgg.cpp:320
 msgid "Operation not permitted."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:900
+#: ../src/common/cmdline.cpp:896
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1064
+#: ../src/common/cmdline.cpp:1060
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1147
+#: ../src/common/cmdline.cpp:1143
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:618
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1606
+#: ../src/propgrid/advprops.cpp:1512
 msgid "Orange"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:615 ../src/generic/prntdlgg.cpp:869
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:862
 msgid "Orientation"
 msgstr ""
 
-#: ../src/common/windowid.cpp:242
+#: ../src/common/windowid.cpp:237
 msgid "Out of window IDs.  Recommend shutting down application."
 msgstr ""
 
@@ -5365,148 +5492,148 @@ msgstr ""
 msgid "Outset"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:656
+#: ../src/msw/ole/automtn.cpp:647
 msgid "Overflow while coercing argument values."
 msgstr ""
 
-#: ../src/common/imagpcx.cpp:457 ../src/common/imagpcx.cpp:480
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:479
 msgid "PCX: couldn't allocate memory"
 msgstr ""
 
-#: ../src/common/imagpcx.cpp:456
+#: ../src/common/imagpcx.cpp:455
 msgid "PCX: image format unsupported"
 msgstr ""
 
-#: ../src/common/imagpcx.cpp:479
+#: ../src/common/imagpcx.cpp:478
 msgid "PCX: invalid image"
 msgstr ""
 
-#: ../src/common/imagpcx.cpp:442
+#: ../src/common/imagpcx.cpp:441
 msgid "PCX: this is not a PCX file."
 msgstr ""
 
-#: ../src/common/imagpcx.cpp:459 ../src/common/imagpcx.cpp:481
+#: ../src/common/imagpcx.cpp:458 ../src/common/imagpcx.cpp:480
 msgid "PCX: unknown error !!!"
 msgstr ""
 
-#: ../src/common/imagpcx.cpp:458
+#: ../src/common/imagpcx.cpp:457
 msgid "PCX: version number too low"
 msgstr ""
 
-#: ../src/common/imagpnm.cpp:91
+#: ../src/common/imagpnm.cpp:89
 msgid "PNM: Couldn't allocate memory."
 msgstr ""
 
-#: ../src/common/imagpnm.cpp:73
+#: ../src/common/imagpnm.cpp:71
 msgid "PNM: File format is not recognized."
 msgstr ""
 
-#: ../src/common/imagpnm.cpp:112 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
 #: ../src/common/imagpnm.cpp:156
 msgid "PNM: File seems truncated."
 msgstr ""
 
-#: ../src/common/paper.cpp:187
+#: ../src/common/paper.cpp:184
 msgid "PRC 16K 146 x 215 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:200
+#: ../src/common/paper.cpp:197
 msgid "PRC 16K Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:188
+#: ../src/common/paper.cpp:185
 msgid "PRC 32K 97 x 151 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:201
+#: ../src/common/paper.cpp:198
 msgid "PRC 32K Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:189
+#: ../src/common/paper.cpp:186
 msgid "PRC 32K(Big) 97 x 151 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:202
+#: ../src/common/paper.cpp:199
 msgid "PRC 32K(Big) Rotated"
 msgstr ""
 
-#: ../src/common/paper.cpp:190
+#: ../src/common/paper.cpp:187
 msgid "PRC Envelope #1 102 x 165 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:203
+#: ../src/common/paper.cpp:200
 msgid "PRC Envelope #1 Rotated 165 x 102 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:199
+#: ../src/common/paper.cpp:196
 msgid "PRC Envelope #10 324 x 458 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:212
+#: ../src/common/paper.cpp:209
 msgid "PRC Envelope #10 Rotated 458 x 324 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:191
+#: ../src/common/paper.cpp:188
 msgid "PRC Envelope #2 102 x 176 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:204
+#: ../src/common/paper.cpp:201
 msgid "PRC Envelope #2 Rotated 176 x 102 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:192
+#: ../src/common/paper.cpp:189
 msgid "PRC Envelope #3 125 x 176 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:205
+#: ../src/common/paper.cpp:202
 msgid "PRC Envelope #3 Rotated 176 x 125 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:193
+#: ../src/common/paper.cpp:190
 msgid "PRC Envelope #4 110 x 208 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:206
+#: ../src/common/paper.cpp:203
 msgid "PRC Envelope #4 Rotated 208 x 110 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:194
+#: ../src/common/paper.cpp:191
 msgid "PRC Envelope #5 110 x 220 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:207
+#: ../src/common/paper.cpp:204
 msgid "PRC Envelope #5 Rotated 220 x 110 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:195
+#: ../src/common/paper.cpp:192
 msgid "PRC Envelope #6 120 x 230 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:208
+#: ../src/common/paper.cpp:205
 msgid "PRC Envelope #6 Rotated 230 x 120 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:196
+#: ../src/common/paper.cpp:193
 msgid "PRC Envelope #7 160 x 230 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:209
+#: ../src/common/paper.cpp:206
 msgid "PRC Envelope #7 Rotated 230 x 160 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:197
+#: ../src/common/paper.cpp:194
 msgid "PRC Envelope #8 120 x 309 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:210
+#: ../src/common/paper.cpp:207
 msgid "PRC Envelope #8 Rotated 309 x 120 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:198
+#: ../src/common/paper.cpp:195
 msgid "PRC Envelope #9 229 x 324 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:211
+#: ../src/common/paper.cpp:208
 msgid "PRC Envelope #9 Rotated 324 x 229 mm"
 msgstr ""
 
@@ -5514,87 +5641,91 @@ msgstr ""
 msgid "Padding"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:2074
+#: ../src/common/prntbase.cpp:2096
 #, c-format
 msgid "Page %d"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:2072
+#: ../src/common/prntbase.cpp:2094
 #, c-format
 msgid "Page %d of %d"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 msgid "Page Down"
 msgstr ""
 
-#: ../src/gtk/print.cpp:826
+#: ../src/gtk/print.cpp:829
 msgid "Page Setup"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 msgid "Page Up"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:828 ../src/common/prntbase.cpp:484
+#: ../src/common/prntbase.cpp:479 ../src/generic/prntdlgg.cpp:821
 msgid "Page setup"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 msgid "PageDown"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 msgid "PageUp"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:216
+#: ../src/generic/prntdlgg.cpp:209
 msgid "Pages"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1765
+#: ../src/propgrid/advprops.cpp:1666
 msgid "Paint Brush"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:602 ../src/generic/prntdlgg.cpp:801
-#: ../src/generic/prntdlgg.cpp:842 ../src/generic/prntdlgg.cpp:855
-#: ../src/generic/prntdlgg.cpp:1052 ../src/generic/prntdlgg.cpp:1057
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:794
+#: ../src/generic/prntdlgg.cpp:835 ../src/generic/prntdlgg.cpp:848
+#: ../src/generic/prntdlgg.cpp:1045 ../src/generic/prntdlgg.cpp:1050
 msgid "Paper size"
 msgstr ""
 
-#: ../src/richtext/richtextstyles.cpp:1062
+#: ../src/richtext/richtextstyles.cpp:1059
 msgid "Paragraph styles"
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:465
+#: ../src/common/xtistrm.cpp:462
 msgid "Passing a already registered object to SetObject"
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:476
+#: ../src/common/xtistrm.cpp:473
 msgid "Passing an unknown object to GetObject"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:3513 ../src/common/stockitem.cpp:180
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:177 ../src/richtext/richtextctrl.cpp:3514
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:262
+#: ../src/common/stockitem.cpp:260
 msgid "Paste selection"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:74
+#: ../src/common/accelcmn.cpp:71
 msgid "Pause"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1766
+#: ../src/propgrid/advprops.cpp:1667
 msgid "Pencil"
 msgstr ""
 
@@ -5603,21 +5734,21 @@ msgstr ""
 msgid "Peri&od"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:430
+#: ../src/generic/filectrlg.cpp:426
 msgid "Permissions"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:60
+#: ../src/common/accelcmn.cpp:57
 msgid "PgDn"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:59
+#: ../src/common/accelcmn.cpp:56
 msgid "PgUp"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:12868
+#: ../src/richtext/richtextbuffer.cpp:12863
 msgid "Picture Properties"
 msgstr ""
 
@@ -5629,42 +5760,42 @@ msgstr ""
 msgid "Please choose a valid font."
 msgstr ""
 
-#: ../src/generic/filedlgg.cpp:357 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
 msgid "Please choose an existing file."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:800
+#: ../src/html/helpwnd.cpp:798
 msgid "Please choose the page to display:"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:764
+#: ../src/msw/dialup.cpp:758
 msgid "Please choose which ISP do you want to connect to"
 msgstr ""
 
-#: ../src/common/headerctrlcmn.cpp:59
+#: ../src/common/headerctrlcmn.cpp:57
 msgid "Please select the columns to show and define their order:"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:538
+#: ../src/common/prntbase.cpp:533
 msgid "Please wait while printing..."
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1767
+#: ../src/propgrid/advprops.cpp:1668
 msgid "Point Left"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1768
+#: ../src/propgrid/advprops.cpp:1669
 msgid "Point Right"
 msgstr ""
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:662
+#: ../src/propgrid/advprops.cpp:572
 msgid "Point Size"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:612 ../src/generic/prntdlgg.cpp:867
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:860
 msgid "Portrait"
 msgstr ""
 
@@ -5672,251 +5803,259 @@ msgstr ""
 msgid "Position"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:298
+#: ../src/generic/prntdlgg.cpp:291
 msgid "PostScript file"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178 ../src/osx/cocoa/preferences.mm:303
 msgid "Preferences"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:568
+#: ../src/osx/menu_osx.cpp:460
 msgid "Preferences..."
 msgstr ""
 
-#: ../src/common/prntbase.cpp:546
+#: ../src/common/prntbase.cpp:541
 msgid "Preparing"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:455 ../src/osx/carbon/fontdlg.cpp:390
-#: ../src/html/helpwnd.cpp:1222
+#: ../src/osx/carbon/fontdlg.cpp:387 ../src/generic/fontdlgg.cpp:452
+#: ../src/html/helpwnd.cpp:1220
 msgid "Preview:"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:1553 ../src/html/helpwnd.cpp:664
+#: ../src/common/prntbase.cpp:1578 ../src/html/helpwnd.cpp:662
 msgid "Previous page"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/prntdlgg.cpp:143 ../src/generic/prntdlgg.cpp:157
-#: ../src/common/prntbase.cpp:426 ../src/common/prntbase.cpp:1541
-#: ../src/common/accelcmn.cpp:77 ../src/gtk/print.cpp:620
-#: ../src/gtk/print.cpp:638
+#: ../src/common/prntbase.cpp:421 ../src/common/prntbase.cpp:1566
+#: ../src/common/accelcmn.cpp:74 ../src/generic/prntdlgg.cpp:136
+#: ../src/generic/prntdlgg.cpp:150 ../src/gtk/print.cpp:616
+#: ../src/gtk/print.cpp:634
 msgid "Print"
 msgstr ""
 
-#: ../include/wx/prntbase.h:399 ../src/common/docview.cpp:1268
+#: ../src/common/docview.cpp:1262
 msgid "Print Preview"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:2015 ../src/common/prntbase.cpp:2057
-#: ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2037 ../src/common/prntbase.cpp:2079
+#: ../src/common/prntbase.cpp:2087
 msgid "Print Preview Failure"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:224
+#: ../src/generic/prntdlgg.cpp:217
 msgid "Print Range"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:449
+#: ../src/generic/prntdlgg.cpp:442
 msgid "Print Setup"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:621
+#: ../src/generic/prntdlgg.cpp:614
 msgid "Print in colour"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/osx/webview_webkit.mm:260
+msgid "Print operation could not be initialized"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:179
 msgid "Print previe&w..."
 msgstr ""
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1256
 msgid "Print preview creation failed."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/common/stockitem.cpp:179
 msgid "Print preview..."
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:630
+#: ../src/generic/prntdlgg.cpp:623
 msgid "Print spooling"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:675
+#: ../src/html/helpwnd.cpp:673
 msgid "Print this page"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:185
+#: ../src/generic/prntdlgg.cpp:178
 msgid "Print to File"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "Print..."
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:493
+#: ../src/generic/prntdlgg.cpp:486
 msgid "Printer"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:633
+#: ../src/generic/prntdlgg.cpp:626
 msgid "Printer command:"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:180
+#: ../src/generic/prntdlgg.cpp:173
 msgid "Printer options"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:645
+#: ../src/generic/prntdlgg.cpp:638
 msgid "Printer options:"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:916
+#: ../src/generic/prntdlgg.cpp:909
 msgid "Printer..."
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:196
+#: ../src/generic/prntdlgg.cpp:189
 msgid "Printer:"
 msgstr ""
 
-#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:535
-#: ../src/html/htmprint.cpp:277
+#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:530
+#: ../src/html/htmprint.cpp:289
 msgid "Printing"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:612
+#: ../src/common/prntbase.cpp:607
 msgid "Printing "
 msgstr ""
 
-#: ../src/common/prntbase.cpp:347
+#: ../src/common/prntbase.cpp:342
 msgid "Printing Error"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:565
+#: ../src/osx/webview_webkit.mm:251
+msgid "Printing is not supported by the system web control"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:560
 #, c-format
 msgid "Printing page %d"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:570
+#: ../src/common/prntbase.cpp:565
 #, c-format
 msgid "Printing page %d of %d"
 msgstr ""
 
-#: ../src/generic/printps.cpp:201
+#: ../src/generic/printps.cpp:182
 #, c-format
 msgid "Printing page %d..."
 msgstr ""
 
-#: ../src/generic/printps.cpp:161
+#: ../src/generic/printps.cpp:142
 msgid "Printing..."
 msgstr ""
 
-#: ../include/wx/richtext/richtextprint.h:109 ../include/wx/prntbase.h:267
-#: ../src/common/docview.cpp:2132
+#: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
+#: ../src/common/docview.cpp:2137
 msgid "Printout"
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:560
+#: ../src/common/debugrpt.cpp:561
 #, c-format
 msgid ""
 "Processing debug report has failed, leaving the files in \"%s\" directory."
 msgstr ""
 
-#: ../src/common/prntbase.cpp:545
+#: ../src/common/prntbase.cpp:540
 msgid "Progress:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181
 msgid "Properties"
 msgstr ""
 
-#: ../src/propgrid/manager.cpp:237
+#: ../src/propgrid/manager.cpp:223
 msgid "Property"
 msgstr ""
 
 #. TRANSLATORS: Caption of message box displaying any property error
-#: ../src/propgrid/propgrid.cpp:3185 ../src/propgrid/propgrid.cpp:3318
+#: ../src/propgrid/propgrid.cpp:3162 ../src/propgrid/propgrid.cpp:3299
 msgid "Property Error"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1597
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Purple"
 msgstr ""
 
-#: ../src/common/paper.cpp:112
+#: ../src/common/paper.cpp:109
 msgid "Quarto, 215 x 275 mm"
 msgstr ""
 
-#: ../src/generic/logg.cpp:1016
+#: ../src/generic/logg.cpp:1013
 msgid "Question"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1769
+#: ../src/propgrid/advprops.cpp:1670
 msgid "Question Arrow"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "Quit"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:477
 #, c-format
 msgid "Quit %s"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:263
+#: ../src/common/stockitem.cpp:261
 msgid "Quit this program"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:338
+#: ../src/common/accelcmn.cpp:352
 msgid "RawCtrl+"
 msgstr ""
 
-#: ../src/common/ffile.cpp:109 ../src/common/ffile.cpp:133
+#: ../src/common/ffile.cpp:107 ../src/common/ffile.cpp:132
 #, c-format
 msgid "Read error on file '%s'"
 msgstr ""
 
-#: ../src/common/secretstore.cpp:199
+#: ../src/common/secretstore.cpp:211
 #, c-format
-msgid "Reading password for \"%s/%s\" failed: %s."
+msgid "Reading password for \"%s\" failed: %s."
 msgstr ""
 
-#: ../src/common/prntbase.cpp:272
+#: ../src/common/prntbase.cpp:267
 msgid "Ready"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1605
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Red"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:339
+#: ../src/generic/colrdlgg.cpp:359
 msgid "Red:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:185 ../src/stc/stc_i18n.cpp:16
+#: ../src/common/stockitem.cpp:182 ../src/stc/stc_i18n.cpp:16
 msgid "Redo"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:264
+#: ../src/common/stockitem.cpp:262
 msgid "Redo last action"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:186
+#: ../src/common/stockitem.cpp:183
 msgid "Refresh"
 msgstr ""
 
-#: ../src/msw/registry.cpp:626
+#: ../src/msw/registry.cpp:615
 #, c-format
 msgid "Registry key '%s' already exists."
 msgstr ""
 
-#: ../src/msw/registry.cpp:595
+#: ../src/msw/registry.cpp:584
 #, c-format
 msgid "Registry key '%s' does not exist, cannot rename it."
 msgstr ""
 
-#: ../src/msw/registry.cpp:727
+#: ../src/msw/registry.cpp:716
 #, c-format
 msgid ""
 "Registry key '%s' is needed for normal system operation,\n"
@@ -5924,22 +6063,22 @@ msgid ""
 "operation aborted."
 msgstr ""
 
-#: ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:942
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:917
+#: ../src/msw/registry.cpp:905
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1003
+#: ../src/msw/registry.cpp:991
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:521
+#: ../src/msw/registry.cpp:510
 #, c-format
 msgid "Registry value '%s' already exists."
 msgstr ""
@@ -5953,70 +6092,74 @@ msgstr ""
 msgid "Relative"
 msgstr ""
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:456
 msgid "Relevant entries:"
 msgstr ""
 
-#: ../include/wx/generic/progdlgg.h:86
+#: ../include/wx/generic/progdlgg.h:87
 msgid "Remaining time:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:187
+#: ../src/common/stockitem.cpp:184
 msgid "Remove"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:1562
+#: ../src/richtext/richtextctrl.cpp:1563
 msgid "Remove Bullet"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:433
+#: ../src/html/helpwnd.cpp:431
 msgid "Remove current page from bookmarks"
 msgstr ""
 
-#: ../src/common/rendcmn.cpp:194
+#: ../src/common/rendcmn.cpp:191
 #, c-format
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:4527
+#: ../src/richtext/richtextbuffer.cpp:4524
 msgid "Renumber List"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:188
-msgid "Rep&lace"
+#: ../src/common/stockitem.cpp:185
+msgid "Rep&lace..."
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:3673 ../src/common/stockitem.cpp:188
+#: ../src/richtext/richtextctrl.cpp:3674
 msgid "Replace"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:182
+#: ../src/generic/fdrepdlg.cpp:179
 msgid "Replace &all"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:261
-msgid "Replace selection"
-msgstr ""
-
-#: ../src/generic/fdrepdlg.cpp:124
+#: ../src/generic/fdrepdlg.cpp:121
 msgid "Replace with:"
 msgstr ""
 
-#: ../src/common/valtext.cpp:163
+#: ../src/common/stockitem.cpp:185
+msgid "Replace..."
+msgstr ""
+
+#: ../src/common/valtext.cpp:184
 msgid "Required information entry is empty."
 msgstr ""
 
-#: ../src/common/translation.cpp:1975
+#: ../src/common/translation.cpp:2025
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr ""
 
+#: ../src/gtk/webview_webkit.cpp:985
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:56
+#: ../src/common/accelcmn.cpp:53
 msgid "Return"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:189
+#: ../src/common/stockitem.cpp:186
 msgid "Revert to Saved"
 msgstr ""
 
@@ -6028,41 +6171,41 @@ msgstr ""
 msgid "Rig&ht-to-left"
 msgstr ""
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6149
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:59 ../src/generic/datavgen.cpp:6954
+#: ../src/richtext/richtextsizepage.cpp:250
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextbulletspage.cpp:188
-#: ../src/richtext/richtextsizepage.cpp:250 ../src/common/accelcmn.cpp:62
 msgid "Right"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1754
+#: ../src/propgrid/advprops.cpp:1655
 msgid "Right Arrow"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1770
+#: ../src/propgrid/advprops.cpp:1671
 msgid "Right Button"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:892
+#: ../src/generic/prntdlgg.cpp:885
 msgid "Right margin (mm):"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:148
-#: ../src/richtext/richtextindentspage.cpp:150
 #: ../src/richtext/richtextliststylepage.cpp:337
 #: ../src/richtext/richtextliststylepage.cpp:339
+#: ../src/richtext/richtextindentspage.cpp:148
+#: ../src/richtext/richtextindentspage.cpp:150
 msgid "Right-align text."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:322
+#: ../src/generic/fontdlgg.cpp:318
 msgid "Roman"
 msgstr ""
 
-#: ../src/generic/datavgen.cpp:5916
+#: ../src/generic/datavgen.cpp:6721
 #, c-format
 msgid "Row %i"
 msgstr ""
@@ -6072,29 +6215,29 @@ msgstr ""
 msgid "S&tandard bullet name:"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:268 ../src/common/accelcmn.cpp:350
+#: ../src/common/accelcmn.cpp:282 ../src/common/accelcmn.cpp:367
 msgid "SPECIAL"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:190 ../src/common/sizer.cpp:2797
+#: ../src/common/stockitem.cpp:187 ../src/common/sizer.cpp:2914
 msgid "Save"
 msgstr ""
 
-#: ../src/common/fldlgcmn.cpp:342
+#: ../src/common/fldlgcmn.cpp:339
 #, c-format
 msgid "Save %s file"
 msgstr ""
 
-#: ../src/generic/logg.cpp:512
+#: ../src/common/stockitem.cpp:188 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr ""
 
-#: ../src/common/docview.cpp:366
+#: ../src/common/docview.cpp:359
 msgid "Save As"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:191
-msgid "Save as"
+#: ../src/common/stockitem.cpp:188
+msgid "Save As..."
 msgstr ""
 
 #: ../src/common/stockitem.cpp:267
@@ -6105,94 +6248,94 @@ msgstr ""
 msgid "Save current document with a different filename"
 msgstr ""
 
-#: ../src/generic/logg.cpp:512
+#: ../src/generic/logg.cpp:509
 msgid "Save log contents to file"
 msgstr ""
 
-#: ../src/common/secretstore.cpp:179
+#: ../src/common/secretstore.cpp:189
 #, c-format
-msgid "Saving password for \"%s/%s\" failed: %s."
+msgid "Saving password for \"%s\" failed: %s."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:325
+#: ../src/generic/fontdlgg.cpp:321
 msgid "Script"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll Lock"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll_lock"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:890
+#: ../src/propgrid/advprops.cpp:791
 msgid "Scrollbar"
 msgstr ""
 
-#: ../src/generic/srchctlg.cpp:56 ../src/html/helpwnd.cpp:535
-#: ../src/html/helpwnd.cpp:550
+#: ../src/generic/srchctlg.cpp:55 ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:548 ../src/gtk/srchctrl.cpp:182
 msgid "Search"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:537
+#: ../src/html/helpwnd.cpp:535
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:160
+#: ../src/generic/fdrepdlg.cpp:157
 msgid "Search direction"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:112
+#: ../src/generic/fdrepdlg.cpp:109
 msgid "Search for:"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1052
+#: ../src/html/helpwnd.cpp:1050
 msgid "Search in all books"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:857
+#: ../src/html/helpwnd.cpp:855
 msgid "Searching..."
 msgstr ""
 
-#: ../src/generic/dirctrlg.cpp:446
+#: ../src/generic/dirctrlg.cpp:412
 msgid "Sections"
 msgstr ""
 
-#: ../src/common/ffile.cpp:238
+#: ../src/common/ffile.cpp:237
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr ""
 
-#: ../src/common/ffile.cpp:228
+#: ../src/common/ffile.cpp:227
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:76
+#: ../src/common/accelcmn.cpp:73
 msgid "Select"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:337 ../src/osx/textctrl_osx.cpp:581
-#: ../src/common/stockitem.cpp:192 ../src/msw/textctrl.cpp:2512
+#: ../src/osx/textctrl_osx.cpp:599 ../src/common/stockitem.cpp:189
+#: ../src/msw/textctrl.cpp:2777 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:192 ../src/stc/stc_i18n.cpp:21
+#: ../src/common/stockitem.cpp:189 ../src/stc/stc_i18n.cpp:21
 msgid "Select All"
 msgstr ""
 
-#: ../src/common/docview.cpp:1895
+#: ../src/common/docview.cpp:1900
 msgid "Select a document template"
 msgstr ""
 
-#: ../src/common/docview.cpp:1969
+#: ../src/common/docview.cpp:1974
 msgid "Select a document view"
 msgstr ""
 
@@ -6221,20 +6364,20 @@ msgid "Selects the list level to edit."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:82
+#: ../src/common/accelcmn.cpp:79
 msgid "Separator"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1083
+#: ../src/common/cmdline.cpp:1079
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:572
+#: ../src/osx/menu_osx.cpp:464
 msgid "Services"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11217
+#: ../src/richtext/richtextbuffer.cpp:11216
 msgid "Set Cell Style"
 msgstr ""
 
@@ -6242,11 +6385,11 @@ msgstr ""
 msgid "SetProperty called w/o valid setter"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:188
+#: ../src/generic/prntdlgg.cpp:181
 msgid "Setup..."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:544
+#: ../src/msw/dialup.cpp:538
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr ""
 
@@ -6262,40 +6405,40 @@ msgstr ""
 msgid "Shadow c&olour:"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:335
+#: ../src/common/accelcmn.cpp:349
 msgid "Shift+"
 msgstr ""
 
-#: ../src/generic/dirdlgg.cpp:147
+#: ../src/generic/dirdlgg.cpp:144
 msgid "Show &hidden directories"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:983
+#: ../src/generic/filectrlg.cpp:979
 msgid "Show &hidden files"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:580
+#: ../src/osx/menu_osx.cpp:472
 msgid "Show All"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:257
+#: ../src/common/stockitem.cpp:254
 msgid "Show about dialog"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:492
+#: ../src/html/helpwnd.cpp:490
 msgid "Show all"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:503
+#: ../src/html/helpwnd.cpp:501
 msgid "Show all items in index"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:656
 msgid "Show/hide navigation panel"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:421
-#: ../src/richtext/richtextsymboldlg.cpp:423
+#: ../src/richtext/richtextsymboldlg.cpp:418
+#: ../src/richtext/richtextsymboldlg.cpp:420
 msgid "Shows a Unicode subset."
 msgstr ""
 
@@ -6311,7 +6454,7 @@ msgstr ""
 msgid "Shows a preview of the font settings."
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:394 ../src/osx/carbon/fontdlg.cpp:396
+#: ../src/osx/carbon/fontdlg.cpp:391 ../src/osx/carbon/fontdlg.cpp:393
 msgid "Shows a preview of the font."
 msgstr ""
 
@@ -6320,62 +6463,62 @@ msgstr ""
 msgid "Shows a preview of the paragraph settings."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:460 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:456 ../src/generic/fontdlgg.cpp:458
 msgid "Shows the font preview."
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1607
+#: ../src/propgrid/advprops.cpp:1513
 msgid "Silver"
 msgstr ""
 
-#: ../src/univ/themes/mono.cpp:516
+#: ../src/univ/themes/mono.cpp:513
 msgid "Simple monochrome theme"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:275
 #: ../src/richtext/richtextliststylepage.cpp:449
+#: ../src/richtext/richtextindentspage.cpp:275
 msgid "Single"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:425 ../src/richtext/richtextformatdlg.cpp:369
-#: ../src/richtext/richtextsizepage.cpp:299
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextsizepage.cpp:299
+#: ../src/richtext/richtextformatdlg.cpp:362
 msgid "Size"
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:339
+#: ../src/osx/carbon/fontdlg.cpp:336
 msgid "Size:"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1775
+#: ../src/propgrid/advprops.cpp:1676
 msgid "Sizing"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1772
+#: ../src/propgrid/advprops.cpp:1673
 msgid "Sizing N-S"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1771
+#: ../src/propgrid/advprops.cpp:1672
 msgid "Sizing NE-SW"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1773
+#: ../src/propgrid/advprops.cpp:1674
 msgid "Sizing NW-SE"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1774
+#: ../src/propgrid/advprops.cpp:1675
 msgid "Sizing W-E"
 msgstr ""
 
-#: ../src/msw/progdlg.cpp:801
+#: ../src/msw/progdlg.cpp:1088
 msgid "Skip"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:330
+#: ../src/generic/fontdlgg.cpp:326
 msgid "Slant"
 msgstr ""
 
@@ -6384,7 +6527,7 @@ msgid "Small C&apitals"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:79
+#: ../src/common/accelcmn.cpp:76
 msgid "Snapshot"
 msgstr ""
 
@@ -6392,37 +6535,37 @@ msgstr ""
 msgid "Solid"
 msgstr ""
 
-#: ../src/common/docview.cpp:1791
+#: ../src/common/docview.cpp:1785
 msgid "Sorry, could not open this file."
 msgstr ""
 
-#: ../src/common/prntbase.cpp:2057 ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2079 ../src/common/prntbase.cpp:2087
 msgid "Sorry, not enough memory to create a preview."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "Sorry, that name is taken. Please choose another."
 msgstr ""
 
-#: ../src/common/docview.cpp:1814
+#: ../src/common/docview.cpp:1819
 msgid "Sorry, the format for this file is unknown."
 msgstr ""
 
-#: ../src/unix/sound.cpp:492
+#: ../src/unix/sound.cpp:481
 msgid "Sound data are in unsupported format."
 msgstr ""
 
-#: ../src/unix/sound.cpp:477
+#: ../src/unix/sound.cpp:466
 #, c-format
 msgid "Sound file '%s' is in unsupported format."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:67
+#: ../src/common/accelcmn.cpp:64
 msgid "Space"
 msgstr ""
 
@@ -6430,12 +6573,12 @@ msgstr ""
 msgid "Spacing"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "Spell Check"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1776
+#: ../src/propgrid/advprops.cpp:1677
 msgid "Spraycan"
 msgstr ""
 
@@ -6444,7 +6587,7 @@ msgstr ""
 msgid "Standard"
 msgstr ""
 
-#: ../src/common/paper.cpp:104
+#: ../src/common/paper.cpp:101
 msgid "Statement, 5 1/2 x 8 1/2 in"
 msgstr ""
 
@@ -6453,33 +6596,29 @@ msgstr ""
 msgid "Static"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:204
+#: ../src/generic/prntdlgg.cpp:197
 msgid "Status:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "Stop"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196
 msgid "Strikethrough"
 msgstr ""
 
-#: ../src/common/colourcmn.cpp:45
+#: ../src/common/colourcmn.cpp:42
 #, c-format
 msgid "String To Colour : Incorrect colour specification : %s"
 msgstr ""
 
 #. TRANSLATORS: Label of font style
-#: ../src/richtext/richtextformatdlg.cpp:339 ../src/propgrid/advprops.cpp:680
+#: ../src/propgrid/advprops.cpp:590 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr ""
 
-#: ../include/wx/richtext/richtextstyledlg.h:46
-msgid "Style Organiser"
-msgstr ""
-
-#: ../src/osx/carbon/fontdlg.cpp:348
+#: ../src/osx/carbon/fontdlg.cpp:345
 msgid "Style:"
 msgstr ""
 
@@ -6488,7 +6627,7 @@ msgid "Subscrip&t"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:83
+#: ../src/common/accelcmn.cpp:80
 msgid "Subtract"
 msgstr ""
 
@@ -6496,11 +6635,11 @@ msgstr ""
 msgid "Supe&rscript"
 msgstr ""
 
-#: ../src/common/paper.cpp:150
+#: ../src/common/paper.cpp:147
 msgid "SuperA/SuperA/A4 227 x 356 mm"
 msgstr ""
 
-#: ../src/common/paper.cpp:151
+#: ../src/common/paper.cpp:148
 msgid "SuperB/SuperB/A3 305 x 487 mm"
 msgstr ""
 
@@ -6508,7 +6647,7 @@ msgstr ""
 msgid "Suppress hyphe&nation"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:326
+#: ../src/generic/fontdlgg.cpp:322
 msgid "Swiss"
 msgstr ""
 
@@ -6526,73 +6665,73 @@ msgstr ""
 msgid "Symbols"
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:369 ../src/common/imagtiff.cpp:382
-#: ../src/common/imagtiff.cpp:741
+#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
+#: ../src/common/imagtiff.cpp:738
 msgid "TIFF: Couldn't allocate memory."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:301
+#: ../src/common/imagtiff.cpp:298
 msgid "TIFF: Error loading image."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:468
+#: ../src/common/imagtiff.cpp:465
 msgid "TIFF: Error reading image."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:608
+#: ../src/common/imagtiff.cpp:605
 msgid "TIFF: Error saving image."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:846
+#: ../src/common/imagtiff.cpp:843
 msgid "TIFF: Error writing image."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:355
+#: ../src/common/imagtiff.cpp:352
 msgid "TIFF: Image size is abnormally big."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:68
+#: ../src/common/accelcmn.cpp:65
 msgid "Tab"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11498
+#: ../src/richtext/richtextbuffer.cpp:11497
 msgid "Table Properties"
 msgstr ""
 
-#: ../src/common/paper.cpp:145
+#: ../src/common/paper.cpp:142
 msgid "Tabloid Extra 11.69 x 18 in"
 msgstr ""
 
-#: ../src/common/paper.cpp:102
+#: ../src/common/paper.cpp:99
 msgid "Tabloid, 11 x 17 in"
 msgstr ""
 
-#: ../src/richtext/richtextformatdlg.cpp:354
+#: ../src/richtext/richtextformatdlg.cpp:347
 msgid "Tabs"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1598
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Teal"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:327
+#: ../src/generic/fontdlgg.cpp:323
 msgid "Teletype"
 msgstr ""
 
-#: ../src/common/docview.cpp:1896
+#: ../src/common/docview.cpp:1901
 msgid "Templates"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:158
+#: ../src/common/fmapbase.cpp:155
 msgid "Thai (ISO-8859-11)"
 msgstr ""
 
-#: ../src/common/ftp.cpp:619
+#: ../src/common/ftp.cpp:622
 msgid "The FTP server doesn't support passive mode."
 msgstr ""
 
-#: ../src/common/ftp.cpp:605
+#: ../src/common/ftp.cpp:608
 msgid "The FTP server doesn't support the PORT command."
 msgstr ""
 
@@ -6603,8 +6742,8 @@ msgstr ""
 msgid "The available bullet styles."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:202
-#: ../src/richtext/richtextstyledlg.cpp:204
+#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:200
 msgid "The available styles."
 msgstr ""
 
@@ -6660,12 +6799,12 @@ msgstr ""
 msgid "The bullet character."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:443
-#: ../src/richtext/richtextsymboldlg.cpp:445
+#: ../src/richtext/richtextsymboldlg.cpp:440
+#: ../src/richtext/richtextsymboldlg.cpp:442
 msgid "The character code."
 msgstr ""
 
-#: ../src/common/fontmap.cpp:203
+#: ../src/common/fontmap.cpp:200
 #, c-format
 msgid ""
 "The charset '%s' is unknown. You may select\n"
@@ -6673,7 +6812,7 @@ msgid ""
 "[Cancel] if it cannot be replaced"
 msgstr ""
 
-#: ../src/msw/ole/dataobj.cpp:394
+#: ../src/msw/ole/dataobj.cpp:402
 #, c-format
 msgid "The clipboard format '%d' doesn't exist."
 msgstr ""
@@ -6683,14 +6822,14 @@ msgstr ""
 msgid "The default style for the next paragraph."
 msgstr ""
 
-#: ../src/generic/dirdlgg.cpp:202
+#: ../src/generic/dirdlgg.cpp:199
 #, c-format
 msgid ""
 "The directory '%s' does not exist\n"
 "Create it now?"
 msgstr ""
 
-#: ../src/html/htmprint.cpp:271
+#: ../src/html/htmprint.cpp:283
 #, c-format
 msgid ""
 "The document \"%s\" doesn't fit on the page horizontally and will be "
@@ -6699,43 +6838,43 @@ msgid ""
 "Would you like to proceed with printing it nevertheless?"
 msgstr ""
 
-#: ../src/common/docview.cpp:1202
+#: ../src/common/docview.cpp:1196
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
 "It has been removed from the most recently used files list."
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:208
-#: ../src/richtext/richtextindentspage.cpp:210
 #: ../src/richtext/richtextliststylepage.cpp:394
 #: ../src/richtext/richtextliststylepage.cpp:396
+#: ../src/richtext/richtextindentspage.cpp:208
+#: ../src/richtext/richtextindentspage.cpp:210
 msgid "The first line indent."
 msgstr ""
 
-#: ../src/gtk/utilsgtk.cpp:481
-msgid "The following standard GTK+ options are also supported:\n"
+#: ../src/generic/dbgrptg.cpp:318
+msgid "The following debug report will be generated\n"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:414 ../src/generic/fontdlgg.cpp:416
+#: ../src/generic/fontdlgg.cpp:411 ../src/generic/fontdlgg.cpp:413
 msgid "The font colour."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:375 ../src/generic/fontdlgg.cpp:377
+#: ../src/generic/fontdlgg.cpp:371 ../src/generic/fontdlgg.cpp:373
 msgid "The font family."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:405
-#: ../src/richtext/richtextsymboldlg.cpp:407
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "The font from which to take the symbol."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:427 ../src/generic/fontdlgg.cpp:429
-#: ../src/generic/fontdlgg.cpp:434 ../src/generic/fontdlgg.cpp:436
+#: ../src/generic/fontdlgg.cpp:424 ../src/generic/fontdlgg.cpp:426
+#: ../src/generic/fontdlgg.cpp:430 ../src/generic/fontdlgg.cpp:432
 msgid "The font point size."
 msgstr ""
 
-#: ../src/osx/carbon/fontdlg.cpp:343 ../src/osx/carbon/fontdlg.cpp:345
+#: ../src/osx/carbon/fontdlg.cpp:340 ../src/osx/carbon/fontdlg.cpp:342
 msgid "The font size in points."
 msgstr ""
 
@@ -6744,15 +6883,15 @@ msgstr ""
 msgid "The font size units, points or pixels."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:386 ../src/generic/fontdlgg.cpp:388
+#: ../src/generic/fontdlgg.cpp:382 ../src/generic/fontdlgg.cpp:384
 msgid "The font style."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:397 ../src/generic/fontdlgg.cpp:399
+#: ../src/generic/fontdlgg.cpp:393 ../src/generic/fontdlgg.cpp:395
 msgid "The font weight."
 msgstr ""
 
-#: ../src/common/docview.cpp:1483
+#: ../src/common/docview.cpp:1477
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr ""
@@ -6762,10 +6901,10 @@ msgstr ""
 msgid "The horizontal offset."
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:199
-#: ../src/richtext/richtextindentspage.cpp:201
 #: ../src/richtext/richtextliststylepage.cpp:385
 #: ../src/richtext/richtextliststylepage.cpp:387
+#: ../src/richtext/richtextindentspage.cpp:199
+#: ../src/richtext/richtextindentspage.cpp:201
 msgid "The left indent."
 msgstr ""
 
@@ -6786,10 +6925,10 @@ msgstr ""
 msgid "The left position."
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:288
-#: ../src/richtext/richtextindentspage.cpp:290
 #: ../src/richtext/richtextliststylepage.cpp:462
 #: ../src/richtext/richtextliststylepage.cpp:464
+#: ../src/richtext/richtextindentspage.cpp:288
+#: ../src/richtext/richtextindentspage.cpp:290
 msgid "The line spacing."
 msgstr ""
 
@@ -6798,7 +6937,7 @@ msgstr ""
 msgid "The list item number."
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:664
+#: ../src/msw/ole/automtn.cpp:655
 msgid "The locale ID is unknown."
 msgstr ""
 
@@ -6837,19 +6976,19 @@ msgstr ""
 msgid "The outline level."
 msgstr ""
 
-#: ../src/common/log.cpp:277
+#: ../src/common/log.cpp:296
 #, c-format
 msgid "The previous message repeated %u time."
 msgid_plural "The previous message repeated %u times."
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/common/log.cpp:270
+#: ../src/common/log.cpp:289
 msgid "The previous message repeated once."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:462
-#: ../src/richtext/richtextsymboldlg.cpp:464
+#: ../src/richtext/richtextsymboldlg.cpp:459
+#: ../src/richtext/richtextsymboldlg.cpp:461
 msgid "The range to show."
 msgstr ""
 
@@ -6860,15 +6999,15 @@ msgid ""
 "please uncheck them and they will be removed from the report.\n"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1254
+#: ../src/common/cmdline.cpp:1250
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:217
-#: ../src/richtext/richtextindentspage.cpp:219
 #: ../src/richtext/richtextliststylepage.cpp:403
 #: ../src/richtext/richtextliststylepage.cpp:405
+#: ../src/richtext/richtextindentspage.cpp:217
+#: ../src/richtext/richtextindentspage.cpp:219
 msgid "The right indent."
 msgstr ""
 
@@ -6909,16 +7048,16 @@ msgstr ""
 msgid "The shadow spread."
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:267
 #: ../src/richtext/richtextliststylepage.cpp:439
 #: ../src/richtext/richtextliststylepage.cpp:441
+#: ../src/richtext/richtextindentspage.cpp:267
 msgid "The spacing after the paragraph."
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:257
-#: ../src/richtext/richtextindentspage.cpp:259
 #: ../src/richtext/richtextliststylepage.cpp:430
 #: ../src/richtext/richtextliststylepage.cpp:432
+#: ../src/richtext/richtextindentspage.cpp:257
+#: ../src/richtext/richtextindentspage.cpp:259
 msgid "The spacing before the paragraph."
 msgstr ""
 
@@ -6932,12 +7071,12 @@ msgstr ""
 msgid "The style on which this style is based."
 msgstr ""
 
-#: ../src/richtext/richtextstyledlg.cpp:214
-#: ../src/richtext/richtextstyledlg.cpp:216
+#: ../src/richtext/richtextstyledlg.cpp:210
+#: ../src/richtext/richtextstyledlg.cpp:212
 msgid "The style preview."
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:680
+#: ../src/msw/ole/automtn.cpp:671
 msgid "The system cannot find the file specified."
 msgstr ""
 
@@ -6950,7 +7089,7 @@ msgstr ""
 msgid "The tab positions."
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:3098
+#: ../src/richtext/richtextctrl.cpp:3099
 msgid "The text couldn't be saved."
 msgstr ""
 
@@ -6971,7 +7110,7 @@ msgstr ""
 msgid "The top position."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1232
+#: ../src/common/cmdline.cpp:1228
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr ""
@@ -6981,7 +7120,7 @@ msgstr ""
 msgid "The value of the corner radius."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:433
+#: ../src/msw/dialup.cpp:427
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -6993,122 +7132,130 @@ msgstr ""
 msgid "The vertical offset."
 msgstr ""
 
-#: ../src/richtext/richtextprint.cpp:619 ../src/html/htmprint.cpp:745
+#: ../src/html/htmprint.cpp:749 ../src/richtext/richtextprint.cpp:615
 msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr ""
 
-#: ../src/html/htmprint.cpp:255
+#: ../src/html/htmprint.cpp:267
 msgid ""
 "This document doesn't fit on the page horizontally and will be truncated "
 "when it is printed."
 msgstr ""
 
-#: ../src/common/image.cpp:2854
+#: ../src/common/image.cpp:2963
 #, c-format
 msgid "This is not a %s."
 msgstr ""
 
-#: ../src/common/wincmn.cpp:1653
+#: ../src/common/wincmn.cpp:1654
 msgid "This platform does not support background transparency."
 msgstr ""
 
-#: ../src/gtk/window.cpp:4660
+#: ../src/gtk/window.cpp:5664
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
 
-#: ../src/msw/thread.cpp:1240
+#: ../src/gtk/glcanvas.cpp:176
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/msw/thread.cpp:1246
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1794
+#: ../src/unix/threadpsx.cpp:1843
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 
-#: ../src/msw/thread.cpp:1228
+#: ../src/msw/thread.cpp:1234
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1043
+#: ../src/unix/threadpsx.cpp:1061
 msgid "Thread priority setting is ignored."
 msgstr ""
 
-#: ../src/msw/mdi.cpp:176
+#: ../src/msw/mdi.cpp:171
 msgid "Tile &Horizontally"
 msgstr ""
 
-#: ../src/msw/mdi.cpp:177
+#: ../src/msw/mdi.cpp:172
 msgid "Tile &Vertically"
 msgstr ""
 
-#: ../src/common/ftp.cpp:200
+#: ../src/common/ftp.cpp:197
 msgid "Timeout while waiting for FTP server to connect, try passive mode."
 msgstr ""
 
-#: ../src/generic/tipdlg.cpp:201
+#: ../src/generic/tipdlg.cpp:198
 msgid "Tip of the Day"
 msgstr ""
 
-#: ../src/generic/tipdlg.cpp:140
+#: ../src/generic/tipdlg.cpp:137
 msgid "Tips not available, sorry!"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:242
+#: ../src/generic/prntdlgg.cpp:235
 msgid "To:"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:8363
+#: ../src/richtext/richtextbuffer.cpp:8361
 msgid "Too many EndStyle calls!"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:891
+#: ../src/propgrid/advprops.cpp:792
 msgid "Tooltip"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:892
+#: ../src/propgrid/advprops.cpp:793
 msgid "TooltipText"
 msgstr ""
 
-#: ../src/richtext/richtextsizepage.cpp:286
-#: ../src/richtext/richtextsizepage.cpp:290 ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197 ../src/richtext/richtextsizepage.cpp:286
+#: ../src/richtext/richtextsizepage.cpp:290
 msgid "Top"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:881
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Top margin (mm):"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:79
+#: ../src/generic/aboutdlgg.cpp:76
 msgid "Translations by "
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:188
+#: ../src/generic/aboutdlgg.cpp:185
 msgid "Translators"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:211
+#: ../src/propgrid/propgrid.cpp:192
 msgid "True"
 msgstr ""
 
-#: ../src/common/fs_mem.cpp:227
+#: ../src/common/fs_mem.cpp:222
 #, c-format
 msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:156
+#: ../src/common/fmapbase.cpp:153
 msgid "Turkish (ISO-8859-9)"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:426
+#: ../src/generic/filectrlg.cpp:422
 msgid "Type"
 msgstr ""
 
@@ -7122,36 +7269,36 @@ msgstr ""
 msgid "Type a size in points."
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:676
+#: ../src/msw/ole/automtn.cpp:667
 #, c-format
 msgid "Type mismatch in argument %u."
 msgstr ""
 
-#: ../src/common/xtixml.cpp:356 ../src/common/xtixml.cpp:509
-#: ../src/common/xtistrm.cpp:318
+#: ../src/common/xtixml.cpp:352 ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315
 msgid "Type must have enum - long conversion"
 msgstr ""
 
-#: ../src/propgrid/propgridiface.cpp:401
+#: ../src/propgrid/propgridiface.cpp:385
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
 "\"%s\"."
 msgstr ""
 
-#: ../src/common/paper.cpp:133
+#: ../src/common/paper.cpp:130
 msgid "US Std Fanfold, 14 7/8 x 11 in"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:196
+#: ../src/common/fmapbase.cpp:193
 msgid "US-ASCII"
 msgstr ""
 
-#: ../src/unix/fswatcher_inotify.cpp:109
+#: ../src/unix/fswatcher_inotify.cpp:106
 msgid "Unable to add inotify watch"
 msgstr ""
 
-#: ../src/unix/fswatcher_kqueue.cpp:136
+#: ../src/unix/fswatcher_kqueue.cpp:153
 msgid "Unable to add kqueue watch"
 msgstr ""
 
@@ -7163,7 +7310,7 @@ msgstr ""
 msgid "Unable to close I/O completion port handle"
 msgstr ""
 
-#: ../src/unix/fswatcher_inotify.cpp:97
+#: ../src/unix/fswatcher_inotify.cpp:94
 msgid "Unable to close inotify instance"
 msgstr ""
 
@@ -7181,15 +7328,15 @@ msgstr ""
 msgid "Unable to create I/O completion port"
 msgstr ""
 
-#: ../src/msw/fswatcher.cpp:84
+#: ../src/msw/fswatcher.cpp:81
 msgid "Unable to create IOCP worker thread"
 msgstr ""
 
-#: ../src/unix/fswatcher_inotify.cpp:74
+#: ../src/unix/fswatcher_inotify.cpp:71
 msgid "Unable to create inotify instance"
 msgstr ""
 
-#: ../src/unix/fswatcher_kqueue.cpp:97
+#: ../src/unix/fswatcher_kqueue.cpp:114
 msgid "Unable to create kqueue instance"
 msgstr ""
 
@@ -7197,11 +7344,11 @@ msgstr ""
 msgid "Unable to dequeue completion packet"
 msgstr ""
 
-#: ../src/unix/fswatcher_kqueue.cpp:185
+#: ../src/unix/fswatcher_kqueue.cpp:202
 msgid "Unable to get events from kqueue"
 msgstr ""
 
-#: ../src/gtk/app.cpp:435
+#: ../src/gtk/app.cpp:431
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr ""
 
@@ -7210,12 +7357,12 @@ msgstr ""
 msgid "Unable to open path '%s'"
 msgstr ""
 
-#: ../src/html/htmlwin.cpp:583
+#: ../src/html/htmlwin.cpp:586
 #, c-format
 msgid "Unable to open requested HTML document: %s"
 msgstr ""
 
-#: ../src/unix/sound.cpp:368
+#: ../src/unix/sound.cpp:365
 msgid "Unable to play sound asynchronously."
 msgstr ""
 
@@ -7223,61 +7370,61 @@ msgstr ""
 msgid "Unable to post completion status"
 msgstr ""
 
-#: ../src/unix/fswatcher_inotify.cpp:556
+#: ../src/unix/fswatcher_inotify.cpp:553
 msgid "Unable to read from inotify descriptor"
 msgstr ""
 
-#: ../src/unix/fswatcher_inotify.cpp:141
+#: ../src/unix/fswatcher_inotify.cpp:138
 #, c-format
 msgid "Unable to remove inotify watch %i"
 msgstr ""
 
-#: ../src/unix/fswatcher_kqueue.cpp:153
+#: ../src/unix/fswatcher_kqueue.cpp:170
 msgid "Unable to remove kqueue watch"
 msgstr ""
 
-#: ../src/msw/fswatcher.cpp:168
+#: ../src/msw/fswatcher.cpp:165
 #, c-format
 msgid "Unable to set up watch for '%s'"
 msgstr ""
 
-#: ../src/msw/fswatcher.cpp:91
+#: ../src/msw/fswatcher.cpp:88
 msgid "Unable to start IOCP worker thread"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:201
+#: ../src/common/stockitem.cpp:198
 msgid "Undelete"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199
 msgid "Underline"
 msgstr ""
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/richtext/richtextfontpage.cpp:359 ../src/osx/carbon/fontdlg.cpp:370
-#: ../src/propgrid/advprops.cpp:690
+#: ../src/osx/carbon/fontdlg.cpp:367 ../src/propgrid/advprops.cpp:600
+#: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:203 ../src/stc/stc_i18n.cpp:15
+#: ../src/common/stockitem.cpp:200 ../src/stc/stc_i18n.cpp:15
 msgid "Undo"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:265
+#: ../src/common/stockitem.cpp:263
 msgid "Undo last action"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1029
+#: ../src/common/cmdline.cpp:1025
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr ""
 
-#: ../src/unix/fswatcher_inotify.cpp:274
+#: ../src/unix/fswatcher_inotify.cpp:271
 #, c-format
 msgid "Unexpected event for \"%s\": no matching watch descriptor."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1195
+#: ../src/common/cmdline.cpp:1191
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr ""
@@ -7286,49 +7433,49 @@ msgstr ""
 msgid "Unexpectedly new I/O completion port was created"
 msgstr ""
 
-#: ../src/msw/fswatcher.cpp:70
+#: ../src/msw/fswatcher.cpp:67
 msgid "Ungraceful worker thread termination"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:460
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:456
+#: ../src/richtext/richtextsymboldlg.cpp:457
+#: ../src/richtext/richtextsymboldlg.cpp:458
 msgid "Unicode"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:185 ../src/common/fmapbase.cpp:191
+#: ../src/common/fmapbase.cpp:182 ../src/common/fmapbase.cpp:188
 msgid "Unicode 16 bit (UTF-16)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:190
+#: ../src/common/fmapbase.cpp:187
 msgid "Unicode 16 bit Big Endian (UTF-16BE)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:186
+#: ../src/common/fmapbase.cpp:183
 msgid "Unicode 16 bit Little Endian (UTF-16LE)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:187 ../src/common/fmapbase.cpp:193
+#: ../src/common/fmapbase.cpp:184 ../src/common/fmapbase.cpp:190
 msgid "Unicode 32 bit (UTF-32)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:192
+#: ../src/common/fmapbase.cpp:189
 msgid "Unicode 32 bit Big Endian (UTF-32BE)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:188
+#: ../src/common/fmapbase.cpp:185
 msgid "Unicode 32 bit Little Endian (UTF-32LE)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:182
+#: ../src/common/fmapbase.cpp:179
 msgid "Unicode 7 bit (UTF-7)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:183
+#: ../src/common/fmapbase.cpp:180
 msgid "Unicode 8 bit (UTF-8)"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "Unindent"
 msgstr ""
 
@@ -7478,97 +7625,102 @@ msgstr ""
 msgid "Units for this value."
 msgstr ""
 
-#: ../src/generic/progdlgg.cpp:353 ../src/generic/progdlgg.cpp:622
+#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
 msgid "Unknown"
 msgstr ""
 
-#: ../src/msw/dde.cpp:1174
+#: ../src/msw/dde.cpp:1238
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:410
+#: ../src/common/xtistrm.cpp:407
 msgid "Unknown Object passed to GetObjectClassInfo"
 msgstr ""
 
-#: ../src/common/imagpng.cpp:366
+#: ../src/common/imagpng.cpp:383
 #, c-format
 msgid "Unknown PNG resolution unit %d"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:327
+#: ../src/common/xtixml.cpp:323
 #, c-format
 msgid "Unknown Property %s"
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:529
+#: ../src/common/imagtiff.cpp:526
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr ""
 
-#: ../src/unix/dlunix.cpp:160
+#: ../src/propgrid/props.cpp:155
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/unix/dlunix.cpp:118
 msgid "Unknown dynamic library error"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:810
+#: ../src/common/fmapbase.cpp:806
 #, c-format
 msgid "Unknown encoding (%d)"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:688
+#: ../src/msw/ole/automtn.cpp:679
 #, c-format
 msgid "Unknown error %08x"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:647
+#: ../src/msw/ole/automtn.cpp:638
 msgid "Unknown exception"
 msgstr ""
 
-#: ../src/common/image.cpp:2839
+#: ../src/common/image.cpp:2942
 msgid "Unknown image data format."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:914
+#: ../src/common/cmdline.cpp:910
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:631
+#: ../src/msw/ole/automtn.cpp:622
 msgid "Unknown name or named argument."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:929 ../src/common/cmdline.cpp:951
+#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
 #, c-format
 msgid "Unknown option '%s'"
 msgstr ""
 
-#: ../src/common/mimecmn.cpp:225
+#: ../src/common/mimecmn.cpp:221
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr ""
 
-#: ../src/common/cmdproc.cpp:262 ../src/common/cmdproc.cpp:288
-#: ../src/common/cmdproc.cpp:308
+#: ../src/common/cmdproc.cpp:255 ../src/common/cmdproc.cpp:281
+#: ../src/common/cmdproc.cpp:301
 msgid "Unnamed command"
 msgstr ""
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:413
+#: ../src/propgrid/propgrid.cpp:392
 msgid "Unspecified"
 msgstr ""
 
-#: ../src/msw/clipbrd.cpp:311
+#: ../src/msw/clipbrd.cpp:325
 msgid "Unsupported clipboard format."
 msgstr ""
 
-#: ../src/common/appcmn.cpp:256
+#: ../src/common/appcmn.cpp:277
 #, c-format
 msgid "Unsupported theme '%s'."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:205
-#: ../src/common/accelcmn.cpp:63
+#: ../src/common/stockitem.cpp:202 ../src/common/accelcmn.cpp:60
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Up"
 msgstr ""
 
@@ -7582,7 +7734,7 @@ msgstr ""
 msgid "Upper case roman numerals"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1326
+#: ../src/common/cmdline.cpp:1322
 #, c-format
 msgid "Usage: %s"
 msgstr ""
@@ -7591,38 +7743,47 @@ msgstr ""
 msgid "Use &shadow"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:169
-#: ../src/richtext/richtextindentspage.cpp:171
 #: ../src/richtext/richtextliststylepage.cpp:358
 #: ../src/richtext/richtextliststylepage.cpp:360
+#: ../src/richtext/richtextindentspage.cpp:169
+#: ../src/richtext/richtextindentspage.cpp:171
 msgid "Use the current alignment setting."
 msgstr ""
 
-#: ../src/common/valtext.cpp:179
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/gtk/font.cpp:552
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/common/valtext.cpp:142
 msgid "Validation conflict"
 msgstr ""
 
-#: ../src/propgrid/manager.cpp:238
+#: ../src/propgrid/manager.cpp:224
 msgid "Value"
 msgstr ""
 
-#: ../src/propgrid/props.cpp:386 ../src/propgrid/props.cpp:500
+#: ../src/propgrid/props.cpp:309
 #, c-format
 msgid "Value must be %s or higher."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:417 ../src/propgrid/props.cpp:531
+#: ../src/propgrid/props.cpp:336
 #, c-format
 msgid "Value must be %s or less."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:393 ../src/propgrid/props.cpp:424
-#: ../src/propgrid/props.cpp:507 ../src/propgrid/props.cpp:538
+#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:128
+#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr ""
 
@@ -7631,25 +7792,32 @@ msgstr ""
 msgid "Vertical alignment."
 msgstr ""
 
-#: ../src/generic/filedlgg.cpp:202
+#: ../src/generic/filedlgg.cpp:199
 msgid "View files as a detailed view"
 msgstr ""
 
-#: ../src/generic/filedlgg.cpp:200
+#: ../src/generic/filedlgg.cpp:197
 msgid "View files as a list view"
 msgstr ""
 
-#: ../src/common/docview.cpp:1970
+#: ../src/common/docview.cpp:1975
 msgid "Views"
 msgstr ""
 
+#: ../src/gtk/app.cpp:348
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1777
+#: ../src/propgrid/advprops.cpp:1678
 msgid "Wait"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1779
+#: ../src/propgrid/advprops.cpp:1680
 msgid "Wait Arrow"
 msgstr ""
 
@@ -7658,237 +7826,233 @@ msgstr ""
 msgid "Waiting for IO on epoll descriptor %d failed"
 msgstr ""
 
-#: ../src/common/log.cpp:223
+#: ../src/common/log.cpp:241
 msgid "Warning: "
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1778
+#: ../src/propgrid/advprops.cpp:1679
 msgid "Watch"
 msgstr ""
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:685
+#: ../src/propgrid/advprops.cpp:595
 msgid "Weight"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:148
+#: ../src/common/fmapbase.cpp:145
 msgid "Western European (ISO-8859-1)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:162
+#: ../src/common/fmapbase.cpp:159
 msgid "Western European with Euro (ISO-8859-15)"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:446 ../src/generic/fontdlgg.cpp:448
+#: ../src/generic/fontdlgg.cpp:443 ../src/generic/fontdlgg.cpp:445
 msgid "Whether the font is underlined."
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1611
+#: ../src/propgrid/advprops.cpp:1517
 msgid "White"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:144
+#: ../src/generic/fdrepdlg.cpp:141
 msgid "Whole word"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:532
 msgid "Whole words only"
 msgstr ""
 
-#: ../src/univ/themes/win32.cpp:1102
+#: ../src/univ/themes/win32.cpp:1099
 msgid "Win32 theme"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:893
+#: ../src/propgrid/advprops.cpp:794
 msgid "Window"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:894
+#: ../src/propgrid/advprops.cpp:795
 msgid "WindowFrame"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:895
+#: ../src/propgrid/advprops.cpp:796
 msgid "WindowText"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:177
+#: ../src/common/fmapbase.cpp:174
 msgid "Windows Arabic (CP 1256)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:178
+#: ../src/common/fmapbase.cpp:175
 msgid "Windows Baltic (CP 1257)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:171
+#: ../src/common/fmapbase.cpp:168
 msgid "Windows Central European (CP 1250)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:168
+#: ../src/common/fmapbase.cpp:165
 msgid "Windows Chinese Simplified (CP 936) or GB-2312"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:170
+#: ../src/common/fmapbase.cpp:167
 msgid "Windows Chinese Traditional (CP 950) or Big-5"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:172
+#: ../src/common/fmapbase.cpp:169
 msgid "Windows Cyrillic (CP 1251)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:174
+#: ../src/common/fmapbase.cpp:171
 msgid "Windows Greek (CP 1253)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:176
+#: ../src/common/fmapbase.cpp:173
 msgid "Windows Hebrew (CP 1255)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:167
+#: ../src/common/fmapbase.cpp:164
 msgid "Windows Japanese (CP 932) or Shift-JIS"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:180
+#: ../src/common/fmapbase.cpp:177
 msgid "Windows Johab (CP 1361)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:169
+#: ../src/common/fmapbase.cpp:166
 msgid "Windows Korean (CP 949)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:166
+#: ../src/common/fmapbase.cpp:163
 msgid "Windows Thai (CP 874)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:175
+#: ../src/common/fmapbase.cpp:172
 msgid "Windows Turkish (CP 1254)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:179
+#: ../src/common/fmapbase.cpp:176
 msgid "Windows Vietnamese (CP 1258)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:173
+#: ../src/common/fmapbase.cpp:170
 msgid "Windows Western European (CP 1252)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:181
+#: ../src/common/fmapbase.cpp:178
 msgid "Windows/DOS OEM (CP 437)"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:165
+#: ../src/common/fmapbase.cpp:162
 msgid "Windows/DOS OEM Cyrillic (CP 866)"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:111
+#: ../src/common/accelcmn.cpp:109
 msgid "Windows_Left"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:113
+#: ../src/common/accelcmn.cpp:111
 msgid "Windows_Menu"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:112
+#: ../src/common/accelcmn.cpp:110
 msgid "Windows_Right"
 msgstr ""
 
-#: ../src/common/ffile.cpp:150
+#: ../src/common/ffile.cpp:149
 #, c-format
 msgid "Write error on file '%s'"
 msgstr ""
 
-#: ../src/xml/xml.cpp:914
+#: ../src/xml/xml.cpp:925
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr ""
 
-#: ../src/common/xpmdecod.cpp:796
+#: ../src/common/xpmdecod.cpp:794
 msgid "XPM: Malformed pixel data!"
 msgstr ""
 
-#: ../src/common/xpmdecod.cpp:705
+#: ../src/common/xpmdecod.cpp:702
 #, c-format
 msgid "XPM: incorrect colour description in line %d"
 msgstr ""
 
-#: ../src/common/xpmdecod.cpp:680
+#: ../src/common/xpmdecod.cpp:677
 msgid "XPM: incorrect header format!"
 msgstr ""
 
-#: ../src/common/xpmdecod.cpp:716 ../src/common/xpmdecod.cpp:725
+#: ../src/common/xpmdecod.cpp:714 ../src/common/xpmdecod.cpp:723
 #, c-format
 msgid "XPM: malformed colour definition '%s' at line %d!"
 msgstr ""
 
-#: ../src/common/xpmdecod.cpp:755
+#: ../src/common/xpmdecod.cpp:753
 msgid "XPM: no colors left to use for mask!"
 msgstr ""
 
-#: ../src/common/xpmdecod.cpp:782
+#: ../src/common/xpmdecod.cpp:780
 #, c-format
 msgid "XPM: truncated image data at line %d!"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1610
+#: ../src/propgrid/advprops.cpp:1516
 msgid "Yellow"
 msgstr ""
 
-#: ../include/wx/msgdlg.h:276 ../src/common/stockitem.cpp:206
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:203
 #: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr ""
 
-#: ../src/osx/carbon/overlay.cpp:155
-msgid "You cannot Clear an overlay that is not inited"
-msgstr ""
-
-#: ../src/osx/carbon/overlay.cpp:107 ../src/dfb/overlay.cpp:61
-msgid "You cannot Init an overlay twice"
-msgstr ""
-
-#: ../src/generic/dirdlgg.cpp:287
+#: ../src/generic/dirdlgg.cpp:284
 msgid "You cannot add a new directory to this section."
 msgstr ""
 
-#: ../src/propgrid/propgrid.cpp:3299
+#: ../src/propgrid/propgrid.cpp:3276
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:209
+#: ../src/osx/cocoa/menu.mm:286
+msgid "Zoom"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:206
 msgid "Zoom &In"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:210
+#: ../src/common/stockitem.cpp:207
 msgid "Zoom &Out"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:209 ../src/common/prntbase.cpp:1594
+#: ../src/common/stockitem.cpp:206 ../src/common/prntbase.cpp:1619
 msgid "Zoom In"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:210 ../src/common/prntbase.cpp:1580
+#: ../src/common/stockitem.cpp:207 ../src/common/prntbase.cpp:1605
 msgid "Zoom Out"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to &Fit"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to Fit"
 msgstr ""
 
-#: ../src/msw/dde.cpp:1141
+#: ../src/msw/dde.cpp:1205
 msgid "a DDEML application has created a prolonged race condition."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1129
+#: ../src/msw/dde.cpp:1193
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -7896,54 +8060,54 @@ msgid ""
 "was passed to a DDEML function."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1147
+#: ../src/msw/dde.cpp:1211
 msgid "a client's attempt to establish a conversation has failed."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1144
+#: ../src/msw/dde.cpp:1208
 msgid "a memory allocation failed."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1138
+#: ../src/msw/dde.cpp:1202
 msgid "a parameter failed to be validated by the DDEML."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1120
+#: ../src/msw/dde.cpp:1184
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1126
+#: ../src/msw/dde.cpp:1190
 msgid "a request for a synchronous data transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1135
+#: ../src/msw/dde.cpp:1199
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1153
+#: ../src/msw/dde.cpp:1217
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1168
+#: ../src/msw/dde.cpp:1232
 msgid "a request to end an advise transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1162
+#: ../src/msw/dde.cpp:1226
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
 "terminated before completing a transaction."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1150
+#: ../src/msw/dde.cpp:1214
 msgid "a transaction failed."
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:189
+#: ../src/common/accelcmn.cpp:188
 msgid "alt"
 msgstr ""
 
-#: ../src/msw/dde.cpp:1132
+#: ../src/msw/dde.cpp:1196
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -7951,71 +8115,71 @@ msgid ""
 "attempted to perform server transactions."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1156
+#: ../src/msw/dde.cpp:1220
 msgid "an internal call to the PostMessage function has failed. "
 msgstr ""
 
-#: ../src/msw/dde.cpp:1165
+#: ../src/msw/dde.cpp:1229
 msgid "an internal error has occurred in the DDEML."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1171
+#: ../src/msw/dde.cpp:1235
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
 "the transaction identifier for that callback is no longer valid."
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1483
+#: ../src/common/zipstrm.cpp:1522
 msgid "assuming this is a multi-part zip concatenated"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1847
+#: ../src/common/fileconf.cpp:1849
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr ""
 
-#: ../src/html/chm.cpp:329
+#: ../src/html/chm.cpp:326
 msgid "bad arguments to library function"
 msgstr ""
 
-#: ../src/html/chm.cpp:341
+#: ../src/html/chm.cpp:338
 msgid "bad signature"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1918
+#: ../src/common/zipstrm.cpp:1988
 msgid "bad zipfile offset to entry"
 msgstr ""
 
-#: ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400
 msgid "binary"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:996
+#: ../src/common/fontcmn.cpp:1195
 msgid "bold"
 msgstr ""
 
-#: ../src/msw/utils.cpp:1144
+#: ../src/msw/utils.cpp:1135
 #, c-format
 msgid "build %lu"
 msgstr ""
 
-#: ../src/common/ffile.cpp:75
+#: ../src/common/ffile.cpp:73
 #, c-format
 msgid "can't close file '%s'"
 msgstr ""
 
-#: ../src/common/file.cpp:245
+#: ../src/common/file.cpp:242
 #, c-format
 msgid "can't close file descriptor %d"
 msgstr ""
 
-#: ../src/common/file.cpp:586
+#: ../src/common/ffile.cpp:382 ../src/common/file.cpp:613
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr ""
 
-#: ../src/common/file.cpp:178
+#: ../src/common/file.cpp:175
 #, c-format
 msgid "can't create file '%s'"
 msgstr ""
@@ -8025,49 +8189,49 @@ msgstr ""
 msgid "can't delete user configuration file '%s'"
 msgstr ""
 
-#: ../src/common/file.cpp:495
+#: ../src/common/file.cpp:522
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1692
+#: ../src/common/zipstrm.cpp:1747
 msgid "can't find central directory in zip"
 msgstr ""
 
-#: ../src/common/file.cpp:465
+#: ../src/common/file.cpp:492
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr ""
 
-#: ../src/msw/utils.cpp:341
+#: ../src/msw/utils.cpp:336
 msgid "can't find user's HOME, using current directory."
 msgstr ""
 
-#: ../src/common/file.cpp:366
+#: ../src/common/file.cpp:407
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr ""
 
-#: ../src/common/file.cpp:422
+#: ../src/common/file.cpp:463
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr ""
 
-#: ../src/common/fontmap.cpp:325
+#: ../src/common/fontmap.cpp:322
 msgid "can't load any font, aborting"
 msgstr ""
 
-#: ../src/common/file.cpp:231 ../src/common/ffile.cpp:59
+#: ../src/common/ffile.cpp:57 ../src/common/file.cpp:228
 #, c-format
 msgid "can't open file '%s'"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:320
+#: ../src/common/fileconf.cpp:314
 #, c-format
 msgid "can't open global configuration file '%s'."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:336
+#: ../src/common/fileconf.cpp:330
 #, c-format
 msgid "can't open user configuration file '%s'."
 msgstr ""
@@ -8076,40 +8240,40 @@ msgstr ""
 msgid "can't open user configuration file."
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:579
+#: ../src/common/zipstrm.cpp:572
 msgid "can't re-initialize zlib deflate stream"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:604
+#: ../src/common/zipstrm.cpp:597
 msgid "can't re-initialize zlib inflate stream"
 msgstr ""
 
-#: ../src/common/file.cpp:304
+#: ../src/common/file.cpp:345
 #, c-format
 msgid "can't read from file descriptor %d"
 msgstr ""
 
-#: ../src/common/file.cpp:581
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:608
 #, c-format
 msgid "can't remove file '%s'"
 msgstr ""
 
-#: ../src/common/file.cpp:598
+#: ../src/common/ffile.cpp:394 ../src/common/file.cpp:625
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr ""
 
-#: ../src/common/file.cpp:408
+#: ../src/common/file.cpp:449
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr ""
 
-#: ../src/common/textfile.cpp:273
+#: ../src/common/textfile.cpp:161
 #, c-format
 msgid "can't write buffer '%s' to disk."
 msgstr ""
 
-#: ../src/common/file.cpp:323
+#: ../src/common/file.cpp:364
 #, c-format
 msgid "can't write to file descriptor %d"
 msgstr ""
@@ -8119,22 +8283,28 @@ msgid "can't write user configuration file."
 msgstr ""
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:482 ../src/generic/datavgen.cpp:1261
+#: ../src/common/datavcmn.cpp:2064 ../src/generic/datavgen.cpp:1384
 msgid "checked"
 msgstr ""
 
-#: ../src/html/chm.cpp:345
+#: ../src/html/chm.cpp:342
 msgid "checksum error"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:820
+#: ../src/common/tarstrm.cpp:814
 msgid "checksum failure reading tar header block"
 msgstr ""
 
-#: ../src/richtext/richtextbackgroundpage.cpp:226
-#: ../src/richtext/richtextbackgroundpage.cpp:249
-#: ../src/richtext/richtextbackgroundpage.cpp:289
-#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
 #: ../src/richtext/richtextborderspage.cpp:254
 #: ../src/richtext/richtextborderspage.cpp:288
 #: ../src/richtext/richtextborderspage.cpp:322
@@ -8152,104 +8322,123 @@ msgstr ""
 #: ../src/richtext/richtextmarginspage.cpp:340
 #: ../src/richtext/richtextmarginspage.cpp:363
 #: ../src/richtext/richtextmarginspage.cpp:388
-#: ../src/richtext/richtextsizepage.cpp:339
-#: ../src/richtext/richtextsizepage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:400
-#: ../src/richtext/richtextsizepage.cpp:427
-#: ../src/richtext/richtextsizepage.cpp:454
-#: ../src/richtext/richtextsizepage.cpp:481
-#: ../src/richtext/richtextsizepage.cpp:555
-#: ../src/richtext/richtextsizepage.cpp:590
-#: ../src/richtext/richtextsizepage.cpp:625
-#: ../src/richtext/richtextsizepage.cpp:660
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
 msgid "cm"
 msgstr ""
 
-#: ../src/html/chm.cpp:347
+#: ../src/html/chm.cpp:344
 msgid "compression error"
 msgstr ""
 
-#: ../src/common/regex.cpp:236
+#: ../src/common/regex.cpp:233
 msgid "conversion to 8-bit encoding failed"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:187
+#: ../src/common/accelcmn.cpp:186
 msgid "ctrl"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1500
+#: ../src/common/cmdline.cpp:1496
 msgid "date"
 msgstr ""
 
-#: ../src/html/chm.cpp:349
+#: ../src/html/chm.cpp:346
 msgid "decompression error"
 msgstr ""
 
-#: ../src/richtext/richtextstyles.cpp:780 ../src/common/fmapbase.cpp:820
+#: ../src/common/fmapbase.cpp:816 ../src/richtext/richtextstyles.cpp:777
 msgid "default"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1496
+#: ../src/common/cmdline.cpp:1492
 msgid "double"
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:538
+#: ../src/common/debugrpt.cpp:539
 msgid "dump of the process state (binary)"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1969
+#: ../src/common/datetimefmt.cpp:1992
 msgid "eighteenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1959
+#: ../src/common/datetimefmt.cpp:1982
 msgid "eighth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1962
+#: ../src/common/datetimefmt.cpp:1985
 msgid "eleventh"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1833
+#: ../src/common/fileconf.cpp:1835
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr ""
 
-#: ../src/html/chm.cpp:343
+#: ../src/html/chm.cpp:340
 msgid "error in data format"
 msgstr ""
 
-#: ../src/html/chm.cpp:331
+#: ../src/html/chm.cpp:328
 msgid "error opening file"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1778
+#: ../src/common/zipstrm.cpp:1836
 msgid "error reading zip central directory"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1870
+#: ../src/common/zipstrm.cpp:1940
 msgid "error reading zip local header"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2531
+#: ../src/common/zipstrm.cpp:2615
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr ""
 
-#: ../src/common/ffile.cpp:188
+#: ../src/common/zipstrm.cpp:2608
+#, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1205
+msgid "extrabold"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1223
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1167
+msgid "extralight"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1036
+msgid "failed to evaluate"
+msgstr ""
+
+#: ../src/common/ffile.cpp:187
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr ""
 
+#: ../src/msw/webview_ie.cpp:1045
+msgid "failed to retrieve execution result"
+msgstr ""
+
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1030
+#: ../src/generic/datavgen.cpp:1150
 msgid "false"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1966
+#: ../src/common/datetimefmt.cpp:1989
 msgid "fifteenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1956
+#: ../src/common/datetimefmt.cpp:1979
 msgid "fifth"
 msgstr ""
 
@@ -8278,131 +8467,149 @@ msgstr ""
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:8738
+#: ../src/richtext/richtextbuffer.cpp:8736
 msgid "files"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1952
+#: ../src/common/datetimefmt.cpp:1975
 msgid "first"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1252
+#: ../src/html/helpwnd.cpp:1250
 msgid "font size"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1965
+#: ../src/common/datetimefmt.cpp:1988
 msgid "fourteenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1955
+#: ../src/common/datetimefmt.cpp:1978
 msgid "fourth"
 msgstr ""
 
-#: ../src/common/appbase.cpp:783
+#: ../src/common/appbase.cpp:784
 msgid "generate verbose log messages"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:13138
-#: ../src/richtext/richtextbuffer.cpp:13248
+#: ../src/common/fontcmn.cpp:1215
+msgid "heavy"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:13133
+#: ../src/richtext/richtextbuffer.cpp:13243
 msgid "image"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:796
+#: ../src/common/tarstrm.cpp:790
 msgid "incomplete header block in tar"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:489
+#: ../src/common/xtixml.cpp:485
 msgid "incorrect event handler string, missing dot"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:1381
+#: ../src/common/tarstrm.cpp:1375
 msgid "incorrect size given for tar entry"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:993
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:987
 msgid "invalid data in extended tar header"
 msgstr ""
 
-#: ../src/generic/logg.cpp:1030
+#: ../src/generic/logg.cpp:1027
 msgid "invalid message box return value"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1647
+#: ../src/common/zipstrm.cpp:1688
 msgid "invalid zip file"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:1228
 msgid "italic"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:991
+#: ../src/common/webrequest_curl.cpp:374
+msgid "libcurl could not be initialized"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1172
 msgid "light"
 msgstr ""
 
-#: ../src/common/intl.cpp:303
-#, c-format
-msgid "locale '%s' cannot be set."
+#: ../src/common/fontcmn.cpp:1185
+msgid "medium"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2125
+#: ../src/common/datetimefmt.cpp:2148
 msgid "midnight"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1970
+#: ../src/common/datetimefmt.cpp:1993
 msgid "nineteenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1960
+#: ../src/common/datetimefmt.cpp:1983
 msgid "ninth"
 msgstr ""
 
-#: ../src/msw/dde.cpp:1116
+#: ../src/msw/dde.cpp:1180
 msgid "no DDE error."
 msgstr ""
 
-#: ../src/html/chm.cpp:327
+#: ../src/html/chm.cpp:324
 msgid "no error"
 msgstr ""
 
-#: ../src/dfb/fontmgr.cpp:174
+#: ../src/dfb/fontmgr.cpp:171
 #, c-format
 msgid "no fonts found in %s, using builtin font"
 msgstr ""
 
-#: ../src/html/helpdata.cpp:657
+#: ../src/html/helpdata.cpp:650
 msgid "noname"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2124
+#: ../src/common/datetimefmt.cpp:2147
 msgid "noon"
 msgstr ""
 
-#: ../src/richtext/richtextstyles.cpp:779
+#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1492
+#: ../src/common/cmdline.cpp:1488
 msgid "num"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:259
+#: ../src/common/accelcmn.cpp:194
+msgid "num "
+msgstr ""
+
+#: ../src/common/xtixml.cpp:255
 msgid "objects cannot have XML Text Nodes"
 msgstr ""
 
-#: ../src/html/chm.cpp:339
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
 msgid "out of memory"
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:514
+#: ../src/common/debugrpt.cpp:515
 msgid "process context description"
 msgstr ""
 
-#: ../src/richtext/richtextbackgroundpage.cpp:227
-#: ../src/richtext/richtextbackgroundpage.cpp:250
-#: ../src/richtext/richtextbackgroundpage.cpp:290
-#: ../src/richtext/richtextbackgroundpage.cpp:317
-#: ../src/richtext/richtextfontpage.cpp:177
-#: ../src/richtext/richtextfontpage.cpp:180
 #: ../src/richtext/richtextborderspage.cpp:255
 #: ../src/richtext/richtextborderspage.cpp:289
 #: ../src/richtext/richtextborderspage.cpp:323
@@ -8412,22 +8619,45 @@ msgstr ""
 #: ../src/richtext/richtextborderspage.cpp:491
 #: ../src/richtext/richtextborderspage.cpp:525
 #: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextfontpage.cpp:180
 msgid "pt"
 msgstr ""
 
-#: ../src/richtext/richtextbackgroundpage.cpp:225
-#: ../src/richtext/richtextbackgroundpage.cpp:228
-#: ../src/richtext/richtextbackgroundpage.cpp:229
-#: ../src/richtext/richtextbackgroundpage.cpp:248
-#: ../src/richtext/richtextbackgroundpage.cpp:251
-#: ../src/richtext/richtextbackgroundpage.cpp:252
-#: ../src/richtext/richtextbackgroundpage.cpp:288
-#: ../src/richtext/richtextbackgroundpage.cpp:291
-#: ../src/richtext/richtextbackgroundpage.cpp:292
-#: ../src/richtext/richtextbackgroundpage.cpp:315
-#: ../src/richtext/richtextbackgroundpage.cpp:318
-#: ../src/richtext/richtextbackgroundpage.cpp:319
-#: ../src/richtext/richtextfontpage.cpp:178
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:659
+#: ../src/richtext/richtextsizepage.cpp:662
+#: ../src/richtext/richtextsizepage.cpp:663
 #: ../src/richtext/richtextborderspage.cpp:253
 #: ../src/richtext/richtextborderspage.cpp:256
 #: ../src/richtext/richtextborderspage.cpp:257
@@ -8479,259 +8709,266 @@ msgstr ""
 #: ../src/richtext/richtextmarginspage.cpp:387
 #: ../src/richtext/richtextmarginspage.cpp:389
 #: ../src/richtext/richtextmarginspage.cpp:390
-#: ../src/richtext/richtextsizepage.cpp:338
-#: ../src/richtext/richtextsizepage.cpp:341
-#: ../src/richtext/richtextsizepage.cpp:342
-#: ../src/richtext/richtextsizepage.cpp:372
-#: ../src/richtext/richtextsizepage.cpp:375
-#: ../src/richtext/richtextsizepage.cpp:376
-#: ../src/richtext/richtextsizepage.cpp:399
-#: ../src/richtext/richtextsizepage.cpp:402
-#: ../src/richtext/richtextsizepage.cpp:403
-#: ../src/richtext/richtextsizepage.cpp:426
-#: ../src/richtext/richtextsizepage.cpp:429
-#: ../src/richtext/richtextsizepage.cpp:430
-#: ../src/richtext/richtextsizepage.cpp:453
-#: ../src/richtext/richtextsizepage.cpp:456
-#: ../src/richtext/richtextsizepage.cpp:457
-#: ../src/richtext/richtextsizepage.cpp:480
-#: ../src/richtext/richtextsizepage.cpp:483
-#: ../src/richtext/richtextsizepage.cpp:484
-#: ../src/richtext/richtextsizepage.cpp:554
-#: ../src/richtext/richtextsizepage.cpp:557
-#: ../src/richtext/richtextsizepage.cpp:558
-#: ../src/richtext/richtextsizepage.cpp:589
-#: ../src/richtext/richtextsizepage.cpp:592
-#: ../src/richtext/richtextsizepage.cpp:593
-#: ../src/richtext/richtextsizepage.cpp:624
-#: ../src/richtext/richtextsizepage.cpp:627
-#: ../src/richtext/richtextsizepage.cpp:628
-#: ../src/richtext/richtextsizepage.cpp:659
-#: ../src/richtext/richtextsizepage.cpp:662
-#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextfontpage.cpp:178
 msgid "px"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:193
+#: ../src/common/accelcmn.cpp:192
 msgid "rawctrl"
 msgstr ""
 
-#: ../src/html/chm.cpp:333
+#: ../src/html/chm.cpp:330
 msgid "read error"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2085
+#: ../src/common/zipstrm.cpp:2155
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2080
+#: ../src/common/zipstrm.cpp:2150
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr ""
 
-#: ../src/msw/dde.cpp:1159
+#: ../src/msw/dde.cpp:1223
 msgid "reentrancy problem."
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1953
+#: ../src/common/datetimefmt.cpp:1976
 msgid "second"
 msgstr ""
 
-#: ../src/html/chm.cpp:337
+#: ../src/html/chm.cpp:334
 msgid "seek error"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1968
+#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+msgid "semibold"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:1991
 msgid "seventeenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1958
+#: ../src/common/datetimefmt.cpp:1981
 msgid "seventh"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:191
+#: ../src/common/accelcmn.cpp:190
 msgid "shift"
 msgstr ""
 
-#: ../src/common/appbase.cpp:773
+#: ../src/common/appbase.cpp:774
 msgid "show this help message"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1967
+#: ../src/common/datetimefmt.cpp:1990
 msgid "sixteenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1957
+#: ../src/common/datetimefmt.cpp:1980
 msgid "sixth"
 msgstr ""
 
-#: ../src/common/appcmn.cpp:234
+#: ../src/common/appcmn.cpp:255
 msgid "specify display mode to use (e.g. 640x480-16)"
 msgstr ""
 
-#: ../src/common/appcmn.cpp:220
+#: ../src/common/appcmn.cpp:241
 msgid "specify the theme to use"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9340
+#: ../src/richtext/richtextbuffer.cpp:9337
 msgid "standard/circle"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9341
+#: ../src/richtext/richtextbuffer.cpp:9338
 msgid "standard/circle-outline"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9343
+#: ../src/richtext/richtextbuffer.cpp:9340
 msgid "standard/diamond"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9342
+#: ../src/richtext/richtextbuffer.cpp:9339
 msgid "standard/square"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9344
+#: ../src/richtext/richtextbuffer.cpp:9341
 msgid "standard/triangle"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1985
+#: ../src/common/zipstrm.cpp:2055
 msgid "stored file length not in Zip header"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1488
+#: ../src/common/cmdline.cpp:1484
 msgid "str"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:982
+#: ../src/common/fontcmn.cpp:1145
 msgid "strikethrough"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:1003 ../src/common/tarstrm.cpp:1025
-#: ../src/common/tarstrm.cpp:1507 ../src/common/tarstrm.cpp:1529
+#: ../src/common/tarstrm.cpp:997 ../src/common/tarstrm.cpp:1019
+#: ../src/common/tarstrm.cpp:1501 ../src/common/tarstrm.cpp:1523
 msgid "tar entry not open"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1961
+#: ../src/common/datetimefmt.cpp:1984
 msgid "tenth"
 msgstr ""
 
-#: ../src/msw/dde.cpp:1123
+#: ../src/msw/dde.cpp:1187
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1954
+#: ../src/common/fontcmn.cpp:1154
+msgid "thin"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:1977
 msgid "third"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1964
+#: ../src/common/datetimefmt.cpp:1987
 msgid "thirteenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1758
+#: ../src/common/datetimefmt.cpp:1781
 msgid "today"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1760
+#: ../src/common/datetimefmt.cpp:1783
 msgid "tomorrow"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1944
+#: ../src/common/fileconf.cpp:1946
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr ""
 
-#: ../src/gtk/aboutdlg.cpp:218
+#: ../src/gtk/aboutdlg.cpp:216
 msgid "translator-credits"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1028
+#: ../src/generic/datavgen.cpp:1148
 msgid "true"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1963
+#: ../src/common/datetimefmt.cpp:1986
 msgid "twelfth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1971
+#: ../src/common/datetimefmt.cpp:1994
 msgid "twentieth"
 msgstr ""
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:486 ../src/generic/datavgen.cpp:1263
+#: ../src/common/datavcmn.cpp:2068 ../src/generic/datavgen.cpp:1386
 msgid "unchecked"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:802 ../src/common/fontcmn.cpp:978
+#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
 msgid "underlined"
 msgstr ""
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:490
+#: ../src/common/datavcmn.cpp:2072
 msgid "undetermined"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1979
+#: ../src/common/fileconf.cpp:1981
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:1045
+#: ../src/common/tarstrm.cpp:1039
 msgid "unexpected end of file"
 msgstr ""
 
-#: ../src/generic/progdlgg.cpp:370 ../src/common/tarstrm.cpp:371
-#: ../src/common/tarstrm.cpp:394 ../src/common/tarstrm.cpp:425
+#: ../src/common/tarstrm.cpp:366 ../src/common/tarstrm.cpp:389
+#: ../src/common/tarstrm.cpp:420 ../src/generic/progdlgg.cpp:376
 msgid "unknown"
 msgstr ""
 
-#: ../src/msw/registry.cpp:150
+#: ../src/msw/registry.cpp:139
 #, c-format
 msgid "unknown (%lu)"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:253
+#: ../src/common/xtixml.cpp:249
 #, c-format
 msgid "unknown class %s"
 msgstr ""
 
-#: ../src/common/regex.cpp:258 ../src/html/chm.cpp:351
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+msgid "unknown compression error"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:192
+msgid "unknown decompression error"
+msgstr ""
+
+#: ../src/common/regex.cpp:255 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:471
+#: ../src/msw/dialup.cpp:465
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:834
+#: ../src/common/fmapbase.cpp:830
 #, c-format
 msgid "unknown-%d"
 msgstr ""
 
-#: ../src/common/docview.cpp:509
+#: ../src/common/docview.cpp:502
 msgid "unnamed"
 msgstr ""
 
-#: ../src/common/docview.cpp:1624
+#: ../src/common/docview.cpp:1618
 #, c-format
 msgid "unnamed%d"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1999 ../src/common/zipstrm.cpp:2319
+#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
 msgid "unsupported Zip compression method"
 msgstr ""
 
-#: ../src/common/translation.cpp:1892
+#: ../src/common/translation.cpp:1942
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr ""
 
-#: ../src/html/chm.cpp:335
+#: ../src/html/chm.cpp:332
 msgid "write error"
 msgstr ""
 
-#: ../src/common/time.cpp:292
+#: ../src/gtk/glcanvas.cpp:187
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/common/time.cpp:285
 msgid "wxGetTimeOfDay failed."
 msgstr ""
 
@@ -8744,15 +8981,15 @@ msgstr ""
 msgid "wxWidgets could not open display. Exiting."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:431
 msgid "xxxx"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1759
+#: ../src/common/datetimefmt.cpp:1782
 msgid "yesterday"
 msgstr ""
 
-#: ../src/common/zstream.cpp:251 ../src/common/zstream.cpp:426
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
 #, c-format
 msgid "zlib error %d"
 msgstr ""

--- a/locale/zh_CN.po
+++ b/locale/zh_CN.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-21 14:25+0200\n"
+"POT-Creation-Date: 2020-10-18 23:11+0300\n"
 "PO-Revision-Date: 2014-02-21 22:57-0800\n"
 "Last-Translator: Jiawei Huang <hjiawei@gmail.com>\n"
 "Language-Team: wxWidgets tranlators <wx-translators@wxwidgets.org>\n"
@@ -20,7 +20,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 1.5.7\n"
 
-#: ../src/common/debugrpt.cpp:586
+#: ../src/common/debugrpt.cpp:587
 msgid ""
 "\n"
 "Please send this report to the program maintainer, thank you!\n"
@@ -28,8 +28,8 @@ msgstr ""
 "\n"
 "请将报告发送给程序维护人员，谢谢！\n"
 
-#: ../src/richtext/richtextstyledlg.cpp:210
-#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:206
+#: ../src/richtext/richtextstyledlg.cpp:218
 msgid " "
 msgstr " "
 
@@ -37,70 +37,96 @@ msgstr " "
 msgid "              Thank you and we're sorry for the inconvenience!\n"
 msgstr "              谢谢，我们对您遇到的不便表示抱歉！\n"
 
-#: ../src/common/prntbase.cpp:573
+#: ../src/common/prntbase.cpp:568
 #, c-format
 msgid " (copy %d of %d)"
 msgstr "(复制 %d / %d)"
 
-#: ../src/common/log.cpp:421
+#: ../src/common/log.cpp:440
 #, c-format
 msgid " (error %ld: %s)"
 msgstr " (错误 %ld: %s)"
 
-#: ../src/common/imagtiff.cpp:72
+#: ../src/common/imagtiff.cpp:69
 #, c-format
 msgid " (in module \"%s\")"
 msgstr " (于模块: \"%s\")"
 
-#: ../src/osx/core/secretstore.cpp:138
-msgid " (while overwriting an existing item)"
-msgstr ""
-
-#: ../src/common/docview.cpp:1642
+#: ../src/common/docview.cpp:1636
 msgid " - "
 msgstr " - "
 
-#: ../src/richtext/richtextprint.cpp:593 ../src/html/htmprint.cpp:714
+#: ../src/html/htmprint.cpp:712 ../src/richtext/richtextprint.cpp:589
 msgid " Preview"
 msgstr " 预览"
 
-#: ../src/common/fontcmn.cpp:824
+#: ../src/common/fontcmn.cpp:973
 msgid " bold"
 msgstr " 粗体"
 
-#: ../src/common/fontcmn.cpp:840
+#: ../src/common/fontcmn.cpp:977
+#, fuzzy
+msgid " extra bold"
+msgstr " 粗体"
+
+#: ../src/common/fontcmn.cpp:985
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:957
+#, fuzzy
+msgid " extra light"
+msgstr " 细体"
+
+#: ../src/common/fontcmn.cpp:981
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1001
 msgid " italic"
 msgstr " 斜体"
 
-#: ../src/common/fontcmn.cpp:820
+#: ../src/common/fontcmn.cpp:961
 msgid " light"
 msgstr " 细体"
 
-#: ../src/common/fontcmn.cpp:807
+#: ../src/common/fontcmn.cpp:965
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:969
+#, fuzzy
+msgid " semi bold"
+msgstr " 粗体"
+
+#: ../src/common/fontcmn.cpp:940
 msgid " strikethrough"
 msgstr " 删除线"
 
-#: ../src/common/paper.cpp:117
+#: ../src/common/fontcmn.cpp:953
+msgid " thin"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
 msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
 msgstr "#10 信封，4 1/8 x 9 1/2 英寸"
 
-#: ../src/common/paper.cpp:118
+#: ../src/common/paper.cpp:115
 msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
 msgstr "#11 信封，4 1/2 x 10 3/8 英寸"
 
-#: ../src/common/paper.cpp:119
+#: ../src/common/paper.cpp:116
 msgid "#12 Envelope, 4 3/4 x 11 in"
 msgstr "#12 信封，4 3/4 x 11 英寸"
 
-#: ../src/common/paper.cpp:120
+#: ../src/common/paper.cpp:117
 msgid "#14 Envelope, 5 x 11 1/2 in"
 msgstr "#14 信封，5 x 11 1/2 英寸"
 
-#: ../src/common/paper.cpp:116
+#: ../src/common/paper.cpp:113
 msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
 msgstr "#9 信封，3 7/8 x 8 7/8 英寸"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:341
 #: ../src/richtext/richtextsizepage.cpp:340
 #: ../src/richtext/richtextsizepage.cpp:374
 #: ../src/richtext/richtextsizepage.cpp:401
@@ -111,80 +137,81 @@ msgstr "#9 信封，3 7/8 x 8 7/8 英寸"
 #: ../src/richtext/richtextsizepage.cpp:591
 #: ../src/richtext/richtextsizepage.cpp:626
 #: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextbackgroundpage.cpp:341
 msgid "%"
 msgstr "%"
 
-#: ../src/html/helpwnd.cpp:1031
+#: ../src/html/helpwnd.cpp:1029
 #, c-format
 msgid "%d of %lu"
 msgstr "%d / %lu"
 
-#: ../src/html/helpwnd.cpp:1678
+#: ../src/html/helpwnd.cpp:1676
 #, fuzzy, c-format
 msgid "%i of %u"
 msgstr "%i / %i"
 
-#: ../src/generic/filectrlg.cpp:279
+#: ../src/generic/filectrlg.cpp:275
 #, c-format
 msgid "%ld byte"
 msgid_plural "%ld bytes"
 msgstr[0] "%ld 字节"
 
-#: ../src/html/helpwnd.cpp:1033
+#: ../src/html/helpwnd.cpp:1031
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu / %lu"
 
-#: ../src/generic/datavgen.cpp:6028
+#: ../src/generic/datavgen.cpp:6833
 #, fuzzy, c-format
 msgid "%s (%d items)"
 msgstr "%s (或 %s)"
 
-#: ../src/common/cmdline.cpp:1221
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (或 %s)"
 
-#: ../src/generic/logg.cpp:224
+#: ../src/generic/logg.cpp:221
 #, c-format
 msgid "%s Error"
 msgstr "%s 错误"
 
-#: ../src/generic/logg.cpp:236
+#: ../src/generic/logg.cpp:233
 #, c-format
 msgid "%s Information"
 msgstr "%s 信息"
 
-#: ../src/generic/preferencesg.cpp:113
+#: ../src/generic/preferencesg.cpp:110
 #, c-format
 msgid "%s Preferences"
 msgstr "%s 偏好设置"
 
-#: ../src/generic/logg.cpp:228
+#: ../src/generic/logg.cpp:225
 #, c-format
 msgid "%s Warning"
 msgstr "%s 警告"
 
-#: ../src/common/tarstrm.cpp:1319
+#: ../src/common/tarstrm.cpp:1313
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s 不符合tar项目 '%s' 的标头"
 
-#: ../src/common/fldlgcmn.cpp:124
+#: ../src/common/fldlgcmn.cpp:121
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s 文件 (%s)|%s"
 
-#: ../src/html/helpwnd.cpp:1716
+#: ../src/html/helpwnd.cpp:1714
 #, fuzzy, c-format
 msgid "%u of %u"
 msgstr "%lu / %lu"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "&About"
 msgstr "关于(&A)"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "&Actual Size"
 msgstr "实际大小(&A)"
 
@@ -192,28 +219,28 @@ msgstr "实际大小(&A)"
 msgid "&After a paragraph:"
 msgstr "段落之后(&A):"
 
-#: ../src/richtext/richtextindentspage.cpp:128
 #: ../src/richtext/richtextliststylepage.cpp:319
+#: ../src/richtext/richtextindentspage.cpp:128
 msgid "&Alignment"
 msgstr "对齐(&A)"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "&Apply"
 msgstr "应用(&A)"
 
-#: ../src/richtext/richtextstyledlg.cpp:251
+#: ../src/richtext/richtextstyledlg.cpp:247
 msgid "&Apply Style"
 msgstr "应用样式(&A)"
 
-#: ../src/msw/mdi.cpp:179
+#: ../src/msw/mdi.cpp:174
 msgid "&Arrange Icons"
 msgstr "重排图标(&A)"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "&Ascending"
 msgstr "递增(&A)"
 
-#: ../src/common/stockitem.cpp:142
+#: ../src/common/stockitem.cpp:139
 msgid "&Back"
 msgstr "返回(&B)"
 
@@ -233,24 +260,24 @@ msgstr "背景颜色(&B):"
 msgid "&Blur distance:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:143
+#: ../src/common/stockitem.cpp:140
 msgid "&Bold"
 msgstr "粗体(&B)"
 
-#: ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141
 msgid "&Bottom"
 msgstr "底端(&B)"
 
+#: ../src/richtext/richtextsizepage.cpp:637
+#: ../src/richtext/richtextsizepage.cpp:644
 #: ../src/richtext/richtextborderspage.cpp:345
 #: ../src/richtext/richtextborderspage.cpp:513
 #: ../src/richtext/richtextmarginspage.cpp:259
 #: ../src/richtext/richtextmarginspage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:637
-#: ../src/richtext/richtextsizepage.cpp:644
 msgid "&Bottom:"
 msgstr "底端(&B):"
 
-#: ../include/wx/richtext/richtextbuffer.h:3866
+#: ../include/wx/richtext/richtextbuffer.h:3861
 #, fuzzy
 msgid "&Box"
 msgstr "粗体(&B)"
@@ -260,39 +287,39 @@ msgstr "粗体(&B)"
 msgid "&Bullet style:"
 msgstr "项目符号样式(&B):"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "&CD-Rom"
 msgstr "CD 光驱(&C)"
 
-#: ../src/generic/wizard.cpp:434 ../src/generic/fontdlgg.cpp:470
-#: ../src/generic/fontdlgg.cpp:489 ../src/osx/carbon/fontdlg.cpp:402
-#: ../src/common/dlgcmn.cpp:279 ../src/common/stockitem.cpp:145
+#: ../src/osx/carbon/fontdlg.cpp:399 ../src/common/stockitem.cpp:142
+#: ../src/generic/wizard.cpp:433 ../src/generic/fontdlgg.cpp:466
+#: ../src/generic/fontdlgg.cpp:485 ../src/osx/cocoa/button.mm:200
 msgid "&Cancel"
 msgstr "取消(&C)"
 
-#: ../src/msw/mdi.cpp:175
+#: ../src/msw/mdi.cpp:170
 msgid "&Cascade"
 msgstr "层叠(&C)"
 
-#: ../include/wx/richtext/richtextbuffer.h:5960
+#: ../include/wx/richtext/richtextbuffer.h:5955
 #, fuzzy
 msgid "&Cell"
 msgstr "取消(&C)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:439
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "&Character code:"
 msgstr "字符编码(&C):"
 
-#: ../src/common/stockitem.cpp:147
+#: ../src/common/stockitem.cpp:144
 msgid "&Clear"
 msgstr "清除(&C)"
 
-#: ../src/generic/logg.cpp:516 ../src/common/stockitem.cpp:148
-#: ../src/common/prntbase.cpp:1600 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/stockitem.cpp:145 ../src/common/prntbase.cpp:1625
+#: ../src/univ/themes/win32.cpp:3753 ../src/generic/logg.cpp:513
 msgid "&Close"
 msgstr "关闭(&C)"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "&Color"
 msgstr "颜色(&C)"
 
@@ -300,20 +327,20 @@ msgstr "颜色(&C)"
 msgid "&Colour:"
 msgstr "颜色(&C):"
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "&Convert"
 msgstr "转换(&C)"
 
-#: ../src/richtext/richtextctrl.cpp:333 ../src/osx/textctrl_osx.cpp:577
-#: ../src/common/stockitem.cpp:150 ../src/msw/textctrl.cpp:2508
+#: ../src/osx/textctrl_osx.cpp:595 ../src/common/stockitem.cpp:147
+#: ../src/msw/textctrl.cpp:2773 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "复制(&C)"
 
-#: ../src/generic/hyperlinkg.cpp:156
+#: ../src/generic/hyperlinkg.cpp:153
 msgid "&Copy URL"
 msgstr "复制 URL(&C)"
 
-#: ../src/common/headerctrlcmn.cpp:306
+#: ../src/common/headerctrlcmn.cpp:304
 msgid "&Customize..."
 msgstr "自定义(&C)..."
 
@@ -321,53 +348,54 @@ msgstr "自定义(&C)..."
 msgid "&Debug report preview:"
 msgstr "调试报告预览(&D): "
 
-#: ../src/richtext/richtexttabspage.cpp:138
-#: ../src/richtext/richtextctrl.cpp:335 ../src/osx/textctrl_osx.cpp:579
-#: ../src/common/stockitem.cpp:152 ../src/msw/textctrl.cpp:2510
+#: ../src/osx/textctrl_osx.cpp:597 ../src/common/stockitem.cpp:149
+#: ../src/msw/textctrl.cpp:2775 ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtextctrl.cpp:334
 msgid "&Delete"
 msgstr "删除(&D)"
 
-#: ../src/richtext/richtextstyledlg.cpp:269
+#: ../src/richtext/richtextstyledlg.cpp:265
 msgid "&Delete Style..."
 msgstr "删除样式(&D)..."
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "&Descending"
 msgstr "递减(&D)"
 
-#: ../src/generic/logg.cpp:682
+#: ../src/generic/logg.cpp:679
 msgid "&Details"
 msgstr "细节(&D)"
 
-#: ../src/common/stockitem.cpp:153
+#: ../src/common/stockitem.cpp:150
 msgid "&Down"
 msgstr "向下(&D)"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "&Edit"
 msgstr "编辑(&E)"
 
-#: ../src/richtext/richtextstyledlg.cpp:263
+#: ../src/richtext/richtextstyledlg.cpp:259
 msgid "&Edit Style..."
 msgstr "编辑样式(&E)..."
 
-#: ../src/common/stockitem.cpp:155
+#: ../src/common/stockitem.cpp:152
 msgid "&Execute"
 msgstr "执行(&E)"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/common/stockitem.cpp:154
 msgid "&File"
 msgstr "文件(&F)"
 
-#: ../src/common/stockitem.cpp:158
-msgid "&Find"
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "&Find..."
 msgstr "查找(&F)"
 
-#: ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:430
 msgid "&Finish"
 msgstr "完成(&F)"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:156
 msgid "&First"
 msgstr "最前(&F)"
 
@@ -375,15 +403,15 @@ msgstr "最前(&F)"
 msgid "&Floating mode:"
 msgstr "浮动模式(&F):"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "&Floppy"
 msgstr "软盘(&F)"
 
-#: ../src/common/stockitem.cpp:194
+#: ../src/common/stockitem.cpp:191
 msgid "&Font"
 msgstr "字体(&F)"
 
-#: ../src/generic/fontdlgg.cpp:371
+#: ../src/generic/fontdlgg.cpp:367
 msgid "&Font family:"
 msgstr "字体(&F):"
 
@@ -391,20 +419,20 @@ msgstr "字体(&F):"
 msgid "&Font for Level..."
 msgstr "层级字体(&F)..."
 
+#: ../src/richtext/richtextsymboldlg.cpp:397
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:400
 msgid "&Font:"
 msgstr "字体(&F):"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "&Forward"
 msgstr "前进(&F)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:451
+#: ../src/richtext/richtextsymboldlg.cpp:448
 msgid "&From:"
 msgstr "从(&F):"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "&Harddisk"
 msgstr "硬盘(&H)"
 
@@ -413,9 +441,9 @@ msgstr "硬盘(&H)"
 msgid "&Height:"
 msgstr "高度(&H):"
 
-#: ../src/generic/wizard.cpp:441 ../src/richtext/richtextstyledlg.cpp:303
-#: ../src/richtext/richtextsymboldlg.cpp:479 ../src/osx/menu_osx.cpp:734
-#: ../src/common/stockitem.cpp:163
+#: ../src/common/stockitem.cpp:160 ../src/generic/wizard.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextstyledlg.cpp:299 ../src/osx/cocoa/menu.mm:226
 msgid "&Help"
 msgstr "帮助(&H)"
 
@@ -423,7 +451,7 @@ msgstr "帮助(&H)"
 msgid "&Hide details"
 msgstr "隐藏细节(&H)"
 
-#: ../src/common/stockitem.cpp:164
+#: ../src/common/stockitem.cpp:161
 msgid "&Home"
 msgstr "Home(&H)"
 
@@ -431,55 +459,55 @@ msgstr "Home(&H)"
 msgid "&Horizontal offset:"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:184
 #: ../src/richtext/richtextliststylepage.cpp:372
+#: ../src/richtext/richtextindentspage.cpp:184
 msgid "&Indentation (tenths of a mm)"
 msgstr "缩进(&I) (十分之一毫米)"
 
-#: ../src/richtext/richtextindentspage.cpp:167
 #: ../src/richtext/richtextliststylepage.cpp:356
+#: ../src/richtext/richtextindentspage.cpp:167
 #, fuzzy
 msgid "&Indeterminate"
 msgstr "下划线(&U)"
 
-#: ../src/common/stockitem.cpp:166
+#: ../src/common/stockitem.cpp:163
 msgid "&Index"
 msgstr "索引(&I)"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "&Info"
 msgstr "信息(&I)"
 
-#: ../src/common/stockitem.cpp:168
+#: ../src/common/stockitem.cpp:165
 msgid "&Italic"
 msgstr "斜体(&I)"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "&Jump to"
 msgstr "跳转到(&J)"
 
-#: ../src/richtext/richtextindentspage.cpp:153
 #: ../src/richtext/richtextliststylepage.cpp:342
+#: ../src/richtext/richtextindentspage.cpp:153
 msgid "&Justified"
 msgstr "分散对齐(&J)"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "&Last"
 msgstr "最后(&L)"
 
-#: ../src/richtext/richtextindentspage.cpp:139
 #: ../src/richtext/richtextliststylepage.cpp:328
+#: ../src/richtext/richtextindentspage.cpp:139
 msgid "&Left"
 msgstr "左(&L)"
 
-#: ../src/richtext/richtextindentspage.cpp:195
+#: ../src/richtext/richtextsizepage.cpp:532
+#: ../src/richtext/richtextsizepage.cpp:539
 #: ../src/richtext/richtextborderspage.cpp:243
 #: ../src/richtext/richtextborderspage.cpp:411
 #: ../src/richtext/richtextliststylepage.cpp:381
+#: ../src/richtext/richtextindentspage.cpp:195
 #: ../src/richtext/richtextmarginspage.cpp:186
 #: ../src/richtext/richtextmarginspage.cpp:300
-#: ../src/richtext/richtextsizepage.cpp:532
-#: ../src/richtext/richtextsizepage.cpp:539
 msgid "&Left:"
 msgstr "左(&L):"
 
@@ -487,11 +515,11 @@ msgstr "左(&L):"
 msgid "&List level:"
 msgstr "列表层级(&L):"
 
-#: ../src/generic/logg.cpp:517
+#: ../src/generic/logg.cpp:514
 msgid "&Log"
 msgstr "日志(&L)"
 
-#: ../src/univ/themes/win32.cpp:3748
+#: ../src/univ/themes/win32.cpp:3745
 msgid "&Move"
 msgstr "移动(&M)"
 
@@ -499,20 +527,19 @@ msgstr "移动(&M)"
 msgid "&Move the object to:"
 msgstr "移动对象至(&M):"
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "&Network"
 msgstr "网络(&N)"
 
-#: ../src/richtext/richtexttabspage.cpp:132 ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173 ../src/richtext/richtexttabspage.cpp:132
 msgid "&New"
 msgstr "新建(&N)"
 
-#: ../src/aui/tabmdi.cpp:111 ../src/generic/mdig.cpp:100
-#: ../src/msw/mdi.cpp:180
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
 msgid "&Next"
 msgstr "下一个(&N)"
 
-#: ../src/generic/wizard.cpp:432 ../src/generic/wizard.cpp:632
+#: ../src/generic/wizard.cpp:429
 msgid "&Next >"
 msgstr "下一个(&N) >"
 
@@ -520,7 +547,7 @@ msgstr "下一个(&N) >"
 msgid "&Next Paragraph"
 msgstr "下一段落(&N)"
 
-#: ../src/generic/tipdlg.cpp:240
+#: ../src/generic/tipdlg.cpp:237
 msgid "&Next Tip"
 msgstr "下一技巧(&N)"
 
@@ -528,11 +555,11 @@ msgstr "下一技巧(&N)"
 msgid "&Next style:"
 msgstr "下一个样式(&N):"
 
-#: ../src/common/stockitem.cpp:177 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:174 ../src/msw/msgdlg.cpp:435
 msgid "&No"
 msgstr "否(&N)"
 
-#: ../src/generic/dbgrptg.cpp:356
+#: ../src/generic/dbgrptg.cpp:360
 msgid "&Notes:"
 msgstr "注意(&N):"
 
@@ -540,12 +567,12 @@ msgstr "注意(&N):"
 msgid "&Number:"
 msgstr "编号(&N):"
 
-#: ../src/generic/fontdlgg.cpp:475 ../src/generic/fontdlgg.cpp:482
-#: ../src/osx/carbon/fontdlg.cpp:408 ../src/common/stockitem.cpp:178
+#: ../src/osx/carbon/fontdlg.cpp:405 ../src/common/stockitem.cpp:175
+#: ../src/generic/fontdlgg.cpp:471 ../src/generic/fontdlgg.cpp:478
 msgid "&OK"
 msgstr "确认(&O)"
 
-#: ../src/generic/dbgrptg.cpp:342 ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176 ../src/generic/dbgrptg.cpp:342
 msgid "&Open..."
 msgstr "打开(&O)..."
 
@@ -557,16 +584,16 @@ msgstr "大纲层级(&O):"
 msgid "&Page Break"
 msgstr "断页符号(&P)"
 
-#: ../src/richtext/richtextctrl.cpp:334 ../src/osx/textctrl_osx.cpp:578
-#: ../src/common/stockitem.cpp:180 ../src/msw/textctrl.cpp:2509
+#: ../src/osx/textctrl_osx.cpp:596 ../src/common/stockitem.cpp:177
+#: ../src/msw/textctrl.cpp:2774 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "粘贴(&P)"
 
-#: ../include/wx/richtext/richtextbuffer.h:5010
+#: ../include/wx/richtext/richtextbuffer.h:5005
 msgid "&Picture"
 msgstr "图片(&P)"
 
-#: ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:419
 msgid "&Point size:"
 msgstr "字体大小(&P):"
 
@@ -578,12 +605,11 @@ msgstr "位置(&P) (十分之一毫米)"
 msgid "&Position mode:"
 msgstr "位置(&P)"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178
 msgid "&Preferences"
 msgstr "偏好设置(&P)"
 
-#: ../src/aui/tabmdi.cpp:112 ../src/generic/mdig.cpp:101
-#: ../src/msw/mdi.cpp:181
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
 msgid "&Previous"
 msgstr "前页(&P)"
 
@@ -591,78 +617,74 @@ msgstr "前页(&P)"
 msgid "&Previous Paragraph"
 msgstr "前一段落(&P)"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "&Print..."
 msgstr "打印(&P)..."
 
-#: ../src/richtext/richtextctrl.cpp:339 ../src/richtext/richtextctrl.cpp:5514
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtextctrl.cpp:338
+#: ../src/richtext/richtextctrl.cpp:5512
 msgid "&Properties"
 msgstr "属性(&P)"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "&Quit"
 msgstr "退出(&Q)"
 
-#: ../src/richtext/richtextctrl.cpp:330 ../src/osx/textctrl_osx.cpp:574
-#: ../src/common/stockitem.cpp:185 ../src/common/cmdproc.cpp:293
-#: ../src/common/cmdproc.cpp:300 ../src/msw/textctrl.cpp:2505
+#: ../src/osx/textctrl_osx.cpp:592 ../src/common/stockitem.cpp:182
+#: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
+#: ../src/msw/textctrl.cpp:2770 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "恢复(&R)"
 
-#: ../src/common/cmdproc.cpp:289 ../src/common/cmdproc.cpp:309
+#: ../src/common/cmdproc.cpp:282 ../src/common/cmdproc.cpp:302
 msgid "&Redo "
 msgstr "恢复(&R) "
 
-#: ../src/richtext/richtextstyledlg.cpp:257
+#: ../src/richtext/richtextstyledlg.cpp:253
 msgid "&Rename Style..."
 msgstr "重命名样式(&R)..."
 
-#: ../src/generic/fdrepdlg.cpp:179
+#: ../src/generic/fdrepdlg.cpp:176
 msgid "&Replace"
 msgstr "替换(&R)"
 
-#: ../src/richtext/richtextstyledlg.cpp:287
+#: ../src/richtext/richtextstyledlg.cpp:283
 msgid "&Restart numbering"
 msgstr "重新编号(&R)"
 
-#: ../src/univ/themes/win32.cpp:3747
+#: ../src/univ/themes/win32.cpp:3744
 msgid "&Restore"
 msgstr "复原(&R)"
 
-#: ../src/richtext/richtextindentspage.cpp:146
 #: ../src/richtext/richtextliststylepage.cpp:335
+#: ../src/richtext/richtextindentspage.cpp:146
 msgid "&Right"
 msgstr "右(&R)"
 
-#: ../src/richtext/richtextindentspage.cpp:213
+#: ../src/richtext/richtextsizepage.cpp:602
+#: ../src/richtext/richtextsizepage.cpp:609
 #: ../src/richtext/richtextborderspage.cpp:277
 #: ../src/richtext/richtextborderspage.cpp:445
 #: ../src/richtext/richtextliststylepage.cpp:399
+#: ../src/richtext/richtextindentspage.cpp:213
 #: ../src/richtext/richtextmarginspage.cpp:211
 #: ../src/richtext/richtextmarginspage.cpp:325
-#: ../src/richtext/richtextsizepage.cpp:602
-#: ../src/richtext/richtextsizepage.cpp:609
 msgid "&Right:"
 msgstr "右(&R):"
 
-#: ../src/common/stockitem.cpp:190
+#: ../src/common/stockitem.cpp:187
 msgid "&Save"
 msgstr "保存(&S)"
-
-#: ../src/common/stockitem.cpp:191
-msgid "&Save as"
-msgstr "另存为(&S)"
 
 #: ../include/wx/richmsgdlg.h:29
 msgid "&See details"
 msgstr "查看细节(&S)"
 
-#: ../src/generic/tipdlg.cpp:236
+#: ../src/generic/tipdlg.cpp:233
 msgid "&Show tips at startup"
 msgstr "启动时显示技巧(&S)"
 
-#: ../src/univ/themes/win32.cpp:3750
+#: ../src/univ/themes/win32.cpp:3747
 msgid "&Size"
 msgstr "大小(&S)"
 
@@ -670,36 +692,36 @@ msgstr "大小(&S)"
 msgid "&Size:"
 msgstr "大小(&S):"
 
-#: ../src/generic/progdlgg.cpp:252
+#: ../src/generic/progdlgg.cpp:249
 msgid "&Skip"
 msgstr "跳过(&S)"
 
-#: ../src/richtext/richtextindentspage.cpp:242
 #: ../src/richtext/richtextliststylepage.cpp:417
+#: ../src/richtext/richtextindentspage.cpp:242
 msgid "&Spacing (tenths of a mm)"
 msgstr "间距(&S) (十分之一毫米)"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "&Spell Check"
 msgstr "拼写检查(&S)"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "&Stop"
 msgstr "停止(&S)"
 
-#: ../src/richtext/richtextfontpage.cpp:275 ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196 ../src/richtext/richtextfontpage.cpp:275
 msgid "&Strikethrough"
 msgstr "删除线(&S)"
 
-#: ../src/generic/fontdlgg.cpp:382 ../src/richtext/richtextstylepage.cpp:106
+#: ../src/generic/fontdlgg.cpp:378 ../src/richtext/richtextstylepage.cpp:106
 msgid "&Style:"
 msgstr "样式 (&S):"
 
-#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:194
 msgid "&Styles:"
 msgstr "样式(&S):"
 
-#: ../src/richtext/richtextsymboldlg.cpp:413
+#: ../src/richtext/richtextsymboldlg.cpp:410
 msgid "&Subset:"
 msgstr "子集(&S):"
 
@@ -713,24 +735,24 @@ msgstr "符号(&S):"
 msgid "&Synchronize values"
 msgstr ""
 
-#: ../include/wx/richtext/richtextbuffer.h:6069
+#: ../include/wx/richtext/richtextbuffer.h:6064
 msgid "&Table"
 msgstr "表格(&T)"
 
-#: ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197
 msgid "&Top"
 msgstr "顶端(&T)"
 
+#: ../src/richtext/richtextsizepage.cpp:567
+#: ../src/richtext/richtextsizepage.cpp:574
 #: ../src/richtext/richtextborderspage.cpp:311
 #: ../src/richtext/richtextborderspage.cpp:479
 #: ../src/richtext/richtextmarginspage.cpp:234
 #: ../src/richtext/richtextmarginspage.cpp:348
-#: ../src/richtext/richtextsizepage.cpp:567
-#: ../src/richtext/richtextsizepage.cpp:574
 msgid "&Top:"
 msgstr "顶端(&T):"
 
-#: ../src/generic/fontdlgg.cpp:444 ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199 ../src/generic/fontdlgg.cpp:441
 msgid "&Underline"
 msgstr "下划线(&U)"
 
@@ -738,21 +760,21 @@ msgstr "下划线(&U)"
 msgid "&Underlining:"
 msgstr "下划线(&U)"
 
-#: ../src/richtext/richtextctrl.cpp:329 ../src/osx/textctrl_osx.cpp:573
-#: ../src/common/stockitem.cpp:203 ../src/common/cmdproc.cpp:271
-#: ../src/msw/textctrl.cpp:2504
+#: ../src/osx/textctrl_osx.cpp:591 ../src/common/stockitem.cpp:200
+#: ../src/common/cmdproc.cpp:264 ../src/msw/textctrl.cpp:2769
+#: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "撤销(&U)"
 
-#: ../src/common/cmdproc.cpp:265
+#: ../src/common/cmdproc.cpp:258
 msgid "&Undo "
 msgstr "撤销(&U) "
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "&Unindent"
 msgstr "取消缩进(&U)"
 
-#: ../src/common/stockitem.cpp:205
+#: ../src/common/stockitem.cpp:202
 msgid "&Up"
 msgstr "向上(&U)"
 
@@ -769,7 +791,7 @@ msgstr "垂直对齐(&V)"
 msgid "&View..."
 msgstr "查看(&V)..."
 
-#: ../src/generic/fontdlgg.cpp:393
+#: ../src/generic/fontdlgg.cpp:389
 msgid "&Weight:"
 msgstr "字体粗细(&W):"
 
@@ -778,88 +800,58 @@ msgstr "字体粗细(&W):"
 msgid "&Width:"
 msgstr "宽度(&W):"
 
-#: ../src/aui/tabmdi.cpp:311 ../src/aui/tabmdi.cpp:327
-#: ../src/aui/tabmdi.cpp:329 ../src/generic/mdig.cpp:294
-#: ../src/generic/mdig.cpp:310 ../src/generic/mdig.cpp:314
-#: ../src/msw/mdi.cpp:78
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
 msgid "&Window"
 msgstr "窗口(&W)"
 
-#: ../src/common/stockitem.cpp:206 ../src/msw/msgdlg.cpp:441
+#: ../src/common/stockitem.cpp:203 ../src/msw/msgdlg.cpp:435
 msgid "&Yes"
 msgstr "是(&Y)"
 
-#: ../src/common/valtext.cpp:256
-#, c-format
-msgid "'%s' contains illegal characters"
+#: ../src/common/valtext.cpp:197
+#, fuzzy, c-format
+msgid "'%s' contains invalid character(s)"
 msgstr "'%s' 包含非法字符"
 
-#: ../src/common/valtext.cpp:254
-#, c-format
-msgid "'%s' doesn't consist only of valid characters"
-msgstr "'%s' 不仅包含有效字符"
-
-#: ../src/common/config.cpp:519 ../src/msw/regconf.cpp:258
+#: ../src/common/config.cpp:515 ../src/msw/regconf.cpp:255
 #, c-format
 msgid "'%s' has extra '..', ignored."
 msgstr "'%s' 有额外的 '..'，忽略之。"
 
-#: ../src/common/cmdline.cpp:1113 ../src/common/cmdline.cpp:1131
+#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' 不是匹配选项 '%s'的正确数字值。"
 
-#: ../src/common/translation.cpp:1100
+#: ../src/common/translation.cpp:1142
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' 不是有效的消息目录。"
 
-#: ../src/common/valtext.cpp:165
+#: ../src/common/valtext.cpp:188
 #, c-format
 msgid "'%s' is not one of the valid strings"
 msgstr "'%s' 不在有效的字符串中"
 
-#: ../src/common/valtext.cpp:167
+#: ../src/common/valtext.cpp:186
 #, c-format
 msgid "'%s' is one of the invalid strings"
 msgstr "'%s' 在有效的字符串中"
 
-#: ../src/common/textbuf.cpp:237
+#: ../src/common/textbuf.cpp:233
 #, c-format
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' 或许是一个二进制文件。"
-
-#: ../src/common/valtext.cpp:252
-#, c-format
-msgid "'%s' should be numeric."
-msgstr "'%s' 应该是一个数值。"
-
-#: ../src/common/valtext.cpp:244
-#, c-format
-msgid "'%s' should only contain ASCII characters."
-msgstr "'%s' 应该仅包含ASCII字符。"
-
-#: ../src/common/valtext.cpp:246
-#, c-format
-msgid "'%s' should only contain alphabetic characters."
-msgstr "'%s' 应仅包含字母字符。"
-
-#: ../src/common/valtext.cpp:248
-#, c-format
-msgid "'%s' should only contain alphabetic or numeric characters."
-msgstr "'%s' 应仅包含字母或数字字符。"
-
-#: ../src/common/valtext.cpp:250
-#, c-format
-msgid "'%s' should only contain digits."
-msgstr "'%s' 应该仅包含数字。"
 
 #: ../src/richtext/richtextliststylepage.cpp:229
 #: ../src/richtext/richtextbulletspage.cpp:166
 msgid "(*)"
 msgstr "(*)"
 
-#: ../src/html/helpwnd.cpp:963
+#: ../src/html/helpwnd.cpp:961
 msgid "(Help)"
 msgstr "(帮助)"
 
@@ -868,27 +860,32 @@ msgstr "(帮助)"
 msgid "(None)"
 msgstr "(无)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:504
+#: ../src/richtext/richtextsymboldlg.cpp:503
 msgid "(Normal text)"
 msgstr "(正常字体)"
 
-#: ../src/html/helpwnd.cpp:419 ../src/html/helpwnd.cpp:1106
-#: ../src/html/helpwnd.cpp:1742
+#: ../src/html/helpwnd.cpp:417 ../src/html/helpwnd.cpp:1104
+#: ../src/html/helpwnd.cpp:1740
 msgid "(bookmarks)"
 msgstr "(书签)"
 
+#: ../src/msw/dlmsw.cpp:167
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (错误 %ld: %s)"
+
+#: ../src/richtext/richtextformatdlg.cpp:876
+#: ../src/richtext/richtextliststylepage.cpp:448
+#: ../src/richtext/richtextliststylepage.cpp:460
+#: ../src/richtext/richtextliststylepage.cpp:461
 #: ../src/richtext/richtextindentspage.cpp:274
 #: ../src/richtext/richtextindentspage.cpp:286
 #: ../src/richtext/richtextindentspage.cpp:287
 #: ../src/richtext/richtextindentspage.cpp:311
 #: ../src/richtext/richtextindentspage.cpp:326
-#: ../src/richtext/richtextformatdlg.cpp:884
 #: ../src/richtext/richtextfontpage.cpp:349
 #: ../src/richtext/richtextfontpage.cpp:353
 #: ../src/richtext/richtextfontpage.cpp:357
-#: ../src/richtext/richtextliststylepage.cpp:448
-#: ../src/richtext/richtextliststylepage.cpp:460
-#: ../src/richtext/richtextliststylepage.cpp:461
 msgid "(none)"
 msgstr "(无)"
 
@@ -907,7 +904,7 @@ msgstr "*)"
 msgid "+"
 msgstr "+"
 
-#: ../src/msw/utils.cpp:1152
+#: ../src/msw/utils.cpp:1143
 msgid ", 64-bit edition"
 msgstr "，64位版"
 
@@ -916,163 +913,163 @@ msgstr "，64位版"
 msgid "-"
 msgstr "-"
 
-#: ../src/generic/filepickerg.cpp:66
+#: ../src/generic/filepickerg.cpp:63
 msgid "..."
 msgstr "..."
 
-#: ../src/richtext/richtextindentspage.cpp:276
 #: ../src/richtext/richtextliststylepage.cpp:450
+#: ../src/richtext/richtextindentspage.cpp:276
 msgid "1.1"
 msgstr "1.1"
 
-#: ../src/richtext/richtextindentspage.cpp:277
 #: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextindentspage.cpp:277
 msgid "1.2"
 msgstr "1.2"
 
-#: ../src/richtext/richtextindentspage.cpp:278
 #: ../src/richtext/richtextliststylepage.cpp:452
+#: ../src/richtext/richtextindentspage.cpp:278
 msgid "1.3"
 msgstr "1.3"
 
-#: ../src/richtext/richtextindentspage.cpp:279
 #: ../src/richtext/richtextliststylepage.cpp:453
+#: ../src/richtext/richtextindentspage.cpp:279
 msgid "1.4"
 msgstr "1.4"
 
-#: ../src/richtext/richtextindentspage.cpp:280
 #: ../src/richtext/richtextliststylepage.cpp:454
+#: ../src/richtext/richtextindentspage.cpp:280
 msgid "1.5"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:281
 #: ../src/richtext/richtextliststylepage.cpp:455
+#: ../src/richtext/richtextindentspage.cpp:281
 msgid "1.6"
 msgstr "1.6"
 
-#: ../src/richtext/richtextindentspage.cpp:282
 #: ../src/richtext/richtextliststylepage.cpp:456
+#: ../src/richtext/richtextindentspage.cpp:282
 msgid "1.7"
 msgstr "1.7"
 
-#: ../src/richtext/richtextindentspage.cpp:283
 #: ../src/richtext/richtextliststylepage.cpp:457
+#: ../src/richtext/richtextindentspage.cpp:283
 msgid "1.8"
 msgstr "1.8"
 
-#: ../src/richtext/richtextindentspage.cpp:284
 #: ../src/richtext/richtextliststylepage.cpp:458
+#: ../src/richtext/richtextindentspage.cpp:284
 msgid "1.9"
 msgstr "1.9"
 
-#: ../src/common/paper.cpp:140
+#: ../src/common/paper.cpp:137
 msgid "10 x 11 in"
 msgstr "10 x 11 英寸"
 
-#: ../src/common/paper.cpp:113
+#: ../src/common/paper.cpp:110
 msgid "10 x 14 in"
 msgstr "10 x 14 英寸"
 
-#: ../src/common/paper.cpp:114
+#: ../src/common/paper.cpp:111
 msgid "11 x 17 in"
 msgstr "11 x 17 英寸"
 
-#: ../src/common/paper.cpp:184
+#: ../src/common/paper.cpp:181
 msgid "12 x 11 in"
 msgstr "12 x 11 英寸"
 
-#: ../src/common/paper.cpp:141
+#: ../src/common/paper.cpp:138
 msgid "15 x 11 in"
 msgstr "15 x 11 英寸"
 
-#: ../src/richtext/richtextindentspage.cpp:285
 #: ../src/richtext/richtextliststylepage.cpp:459
+#: ../src/richtext/richtextindentspage.cpp:285
 msgid "2"
 msgstr "2"
 
-#: ../src/common/paper.cpp:132
+#: ../src/common/paper.cpp:129
 msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
 msgstr "6 3/4 信封, 3 5/8 x 6 1/2 英寸"
 
-#: ../src/common/paper.cpp:139
+#: ../src/common/paper.cpp:136
 msgid "9 x 11 in"
 msgstr "9 x 11 英寸"
 
-#: ../src/html/htmprint.cpp:431
+#: ../src/html/htmprint.cpp:443
 msgid ": file does not exist!"
 msgstr ": 文件不存在！"
 
-#: ../src/common/fontmap.cpp:199
+#: ../src/common/fontmap.cpp:196
 msgid ": unknown charset"
 msgstr ": 未知字符集"
 
-#: ../src/common/fontmap.cpp:413
+#: ../src/common/fontmap.cpp:410
 msgid ": unknown encoding"
 msgstr ": 未知编码"
 
-#: ../src/generic/wizard.cpp:443
+#: ../src/generic/wizard.cpp:438
 msgid "< &Back"
 msgstr "< 返回(&B)"
 
-#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:628
-#: ../src/osx/carbon/fontdlg.cpp:648
+#: ../src/osx/carbon/fontdlg.cpp:419 ../src/osx/carbon/fontdlg.cpp:625
+#: ../src/osx/carbon/fontdlg.cpp:645
 msgid "<Any Decorative>"
 msgstr "<任意 Decorative>"
 
-#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:630
-#: ../src/osx/carbon/fontdlg.cpp:650
+#: ../src/osx/carbon/fontdlg.cpp:420 ../src/osx/carbon/fontdlg.cpp:627
+#: ../src/osx/carbon/fontdlg.cpp:647
 msgid "<Any Modern>"
 msgstr "<任意 Modern>"
 
-#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:626
-#: ../src/osx/carbon/fontdlg.cpp:646
+#: ../src/osx/carbon/fontdlg.cpp:418 ../src/osx/carbon/fontdlg.cpp:623
+#: ../src/osx/carbon/fontdlg.cpp:643
 msgid "<Any Roman>"
 msgstr "<任意 Roman>"
 
-#: ../src/osx/carbon/fontdlg.cpp:424 ../src/osx/carbon/fontdlg.cpp:632
-#: ../src/osx/carbon/fontdlg.cpp:652
+#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:629
+#: ../src/osx/carbon/fontdlg.cpp:649
 msgid "<Any Script>"
 msgstr "<任意 Script>"
 
-#: ../src/osx/carbon/fontdlg.cpp:425 ../src/osx/carbon/fontdlg.cpp:637
-#: ../src/osx/carbon/fontdlg.cpp:656
+#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:634
+#: ../src/osx/carbon/fontdlg.cpp:653
 msgid "<Any Swiss>"
 msgstr "<任意 Swiss>"
 
-#: ../src/osx/carbon/fontdlg.cpp:426 ../src/osx/carbon/fontdlg.cpp:634
-#: ../src/osx/carbon/fontdlg.cpp:654
+#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:631
+#: ../src/osx/carbon/fontdlg.cpp:651
 msgid "<Any Teletype>"
 msgstr "<任意 Teletype>"
 
-#: ../src/osx/carbon/fontdlg.cpp:420
+#: ../src/osx/carbon/fontdlg.cpp:417
 msgid "<Any>"
 msgstr "<任意>"
 
-#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
 msgid "<DIR>"
 msgstr "<目录>"
 
-#: ../src/generic/filectrlg.cpp:254 ../src/generic/filectrlg.cpp:277
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
 msgid "<DRIVE>"
 msgstr "<盘符>"
 
-#: ../src/generic/filectrlg.cpp:252 ../src/generic/filectrlg.cpp:275
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
 msgid "<LINK>"
 msgstr "<连接>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1264
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>粗斜体.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1270
+#: ../src/html/helpwnd.cpp:1268
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>粗斜体 <u>加下划线</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1265
+#: ../src/html/helpwnd.cpp:1263
 msgid "<b>Bold face.</b> "
 msgstr "<b>粗体.</b> "
 
-#: ../src/html/helpwnd.cpp:1264
+#: ../src/html/helpwnd.cpp:1262
 msgid "<i>Italic face.</i> "
 msgstr "<i>斜体.</i> "
 
@@ -1081,15 +1078,15 @@ msgstr "<i>斜体.</i> "
 msgid ">"
 msgstr ">"
 
-#: ../src/generic/dbgrptg.cpp:318
+#: ../src/generic/dbgrptg.cpp:317
 msgid "A debug report has been generated in the directory\n"
 msgstr "产生了一份调试报告, 位于目录\n"
 
-#: ../src/common/debugrpt.cpp:573
+#: ../src/common/debugrpt.cpp:574
 msgid "A debug report has been generated. It can be found in"
 msgstr "产生了一份调试报告, 位于"
 
-#: ../src/common/xtixml.cpp:418
+#: ../src/common/xtixml.cpp:414
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "非空集合必须包含 'element' 节点"
 
@@ -1100,106 +1097,106 @@ msgstr "非空集合必须包含 'element' 节点"
 msgid "A standard bullet name."
 msgstr "标准项目符号名称。"
 
-#: ../src/common/paper.cpp:217
+#: ../src/common/paper.cpp:214
 msgid "A0 sheet, 841 x 1189 mm"
 msgstr "A0 纸张, 841 x 1189 毫米"
 
-#: ../src/common/paper.cpp:218
+#: ../src/common/paper.cpp:215
 msgid "A1 sheet, 594 x 841 mm"
 msgstr "A1 纸张, 594 x 841 毫米"
 
-#: ../src/common/paper.cpp:159
+#: ../src/common/paper.cpp:156
 msgid "A2 420 x 594 mm"
 msgstr "A2 纸张, 420 x 594 毫米"
 
-#: ../src/common/paper.cpp:156
+#: ../src/common/paper.cpp:153
 msgid "A3 Extra 322 x 445 mm"
 msgstr "特大 A3 纸张, 322 x 445 毫米"
 
-#: ../src/common/paper.cpp:161
+#: ../src/common/paper.cpp:158
 msgid "A3 Extra Transverse 322 x 445 mm"
 msgstr "特大 A3 纸张(横排), 322 x 445 毫米"
 
-#: ../src/common/paper.cpp:170
+#: ../src/common/paper.cpp:167
 msgid "A3 Rotated 420 x 297 mm"
 msgstr "横向 A3 纸张, 420 x 297 毫米"
 
-#: ../src/common/paper.cpp:160
+#: ../src/common/paper.cpp:157
 msgid "A3 Transverse 297 x 420 mm"
 msgstr "A3 纸张(横排), 297 x 420 毫米"
 
-#: ../src/common/paper.cpp:106
+#: ../src/common/paper.cpp:103
 msgid "A3 sheet, 297 x 420 mm"
 msgstr "A3 纸张, 297 x 420 毫米"
 
-#: ../src/common/paper.cpp:146
+#: ../src/common/paper.cpp:143
 msgid "A4 Extra 9.27 x 12.69 in"
 msgstr "特大 A4 纸张, 9.27 x 12.69 英寸"
 
-#: ../src/common/paper.cpp:153
+#: ../src/common/paper.cpp:150
 msgid "A4 Plus 210 x 330 mm"
 msgstr "加大 A4 纸张, 210 x 330 毫米"
 
-#: ../src/common/paper.cpp:171
+#: ../src/common/paper.cpp:168
 msgid "A4 Rotated 297 x 210 mm"
 msgstr "横向 A4 纸张, 297 x 210 毫米"
 
-#: ../src/common/paper.cpp:148
+#: ../src/common/paper.cpp:145
 msgid "A4 Transverse 210 x 297 mm"
 msgstr "A4 纸张(横排), 210 x 297 毫米"
 
-#: ../src/common/paper.cpp:97
+#: ../src/common/paper.cpp:94
 msgid "A4 sheet, 210 x 297 mm"
 msgstr "A4 纸张, 210 x 297 毫米"
 
-#: ../src/common/paper.cpp:107
+#: ../src/common/paper.cpp:104
 msgid "A4 small sheet, 210 x 297 mm"
 msgstr "小 A4 纸张, 210 x 297 毫米"
 
-#: ../src/common/paper.cpp:157
+#: ../src/common/paper.cpp:154
 msgid "A5 Extra 174 x 235 mm"
 msgstr "特大 A5 纸张, 174 x 235 毫米"
 
-#: ../src/common/paper.cpp:172
+#: ../src/common/paper.cpp:169
 msgid "A5 Rotated 210 x 148 mm"
 msgstr "横向 A5 纸张, 210 x 148 毫米"
 
-#: ../src/common/paper.cpp:154
+#: ../src/common/paper.cpp:151
 msgid "A5 Transverse 148 x 210 mm"
 msgstr "A5 纸张(横排), 148 x 210 毫米"
 
-#: ../src/common/paper.cpp:108
+#: ../src/common/paper.cpp:105
 msgid "A5 sheet, 148 x 210 mm"
 msgstr "A5 纸张, 148 x 210 毫米"
 
-#: ../src/common/paper.cpp:164
+#: ../src/common/paper.cpp:161
 msgid "A6 105 x 148 mm"
 msgstr "A6 纸张, 105 x 148 毫米"
 
-#: ../src/common/paper.cpp:177
+#: ../src/common/paper.cpp:174
 msgid "A6 Rotated 148 x 105 mm"
 msgstr "横向 A5 纸张, 148 x 105 毫米"
 
-#: ../src/generic/fontdlgg.cpp:83 ../src/richtext/richtextformatdlg.cpp:529
-#: ../src/osx/carbon/fontdlg.cpp:153
+#: ../src/osx/carbon/fontdlg.cpp:150 ../src/generic/fontdlgg.cpp:79
+#: ../src/richtext/richtextformatdlg.cpp:521
 msgid "ABCDEFGabcdefg12345"
 msgstr "ABCDEFGabcdefg12345"
 
-#: ../src/richtext/richtextsymboldlg.cpp:458 ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
 msgid "ASCII"
 msgstr "ASCII"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "About"
 msgstr "关于"
 
-#: ../src/generic/aboutdlgg.cpp:140 ../src/osx/menu_osx.cpp:558
-#: ../src/msw/aboutdlg.cpp:64
+#: ../src/osx/menu_osx.cpp:450 ../src/generic/aboutdlgg.cpp:137
+#: ../src/msw/aboutdlg.cpp:61
 #, c-format
 msgid "About %s"
 msgstr "关于 %s"
 
-#: ../src/osx/menu_osx.cpp:560
+#: ../src/osx/menu_osx.cpp:452
 msgid "About..."
 msgstr "关于..."
 
@@ -1208,38 +1205,38 @@ msgid "Absolute"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:873
+#: ../src/propgrid/advprops.cpp:774
 #, fuzzy
 msgid "ActiveBorder"
 msgstr "边框"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:874
+#: ../src/propgrid/advprops.cpp:775
 msgid "ActiveCaption"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "Actual Size"
 msgstr "实际大小"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:140 ../src/common/accelcmn.cpp:81
+#: ../src/common/stockitem.cpp:137 ../src/common/accelcmn.cpp:78
 msgid "Add"
 msgstr "加入"
 
-#: ../src/richtext/richtextbuffer.cpp:11455
+#: ../src/richtext/richtextbuffer.cpp:11454
 msgid "Add Column"
 msgstr "添加列"
 
-#: ../src/richtext/richtextbuffer.cpp:11392
+#: ../src/richtext/richtextbuffer.cpp:11391
 msgid "Add Row"
 msgstr "添加行"
 
-#: ../src/html/helpwnd.cpp:432
+#: ../src/html/helpwnd.cpp:430
 msgid "Add current page to bookmarks"
 msgstr "把当前页加到书签中"
 
-#: ../src/generic/colrdlgg.cpp:366
+#: ../src/generic/colrdlgg.cpp:386
 msgid "Add to custom colours"
 msgstr "加到自定义颜色中"
 
@@ -1251,12 +1248,12 @@ msgstr "在一个通用处理器上调用AddToPropertyCollection"
 msgid "AddToPropertyCollection called w/o valid adder"
 msgstr "调用AddToPropertyCollection时未带有效的adder"
 
-#: ../src/html/helpctrl.cpp:159
+#: ../src/html/helpctrl.cpp:155
 #, c-format
 msgid "Adding book %s"
 msgstr "正在添加卷 %s"
 
-#: ../src/common/preferencescmn.cpp:43
+#: ../src/common/preferencescmn.cpp:40
 msgid "Advanced"
 msgstr "高级"
 
@@ -1264,11 +1261,11 @@ msgstr "高级"
 msgid "After a paragraph:"
 msgstr "段落之后:"
 
-#: ../src/common/stockitem.cpp:172
+#: ../src/common/stockitem.cpp:169
 msgid "Align Left"
 msgstr "左对齐"
 
-#: ../src/common/stockitem.cpp:173
+#: ../src/common/stockitem.cpp:170
 msgid "Align Right"
 msgstr "右对齐"
 
@@ -1276,40 +1273,40 @@ msgstr "右对齐"
 msgid "Alignment"
 msgstr "对齐"
 
-#: ../src/generic/prntdlgg.cpp:215
+#: ../src/generic/prntdlgg.cpp:208
 msgid "All"
 msgstr "所有"
 
-#: ../src/generic/filectrlg.cpp:1197 ../src/common/fldlgcmn.cpp:107
+#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1186
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "所有文件 (%s)|%s"
 
-#: ../include/wx/defs.h:2886
+#: ../include/wx/defs.h:2582
 msgid "All files (*)|*"
 msgstr "所有文件 (*)|*"
 
-#: ../include/wx/defs.h:2883
+#: ../include/wx/defs.h:2579
 msgid "All files (*.*)|*.*"
 msgstr "所有文件 (*.*)|*.*"
 
-#: ../src/richtext/richtextstyles.cpp:1061
+#: ../src/richtext/richtextstyles.cpp:1058
 msgid "All styles"
 msgstr "所有样式"
 
-#: ../src/propgrid/manager.cpp:1528
+#: ../src/propgrid/manager.cpp:1544
 msgid "Alphabetic Mode"
 msgstr "字母顺序模式"
 
-#: ../src/common/xtistrm.cpp:425
+#: ../src/common/xtistrm.cpp:422
 msgid "Already Registered Object passed to SetObjectClassInfo"
 msgstr "传递已注册对象给 SetObjectClassInfo"
 
-#: ../src/unix/dialup.cpp:353
+#: ../src/unix/dialup.cpp:352
 msgid "Already dialling ISP."
 msgstr "已经拨接 ISP 。"
 
-#: ../src/common/accelcmn.cpp:331 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/accelcmn.cpp:345 ../src/univ/themes/win32.cpp:3753
 msgid "Alt+"
 msgstr "Alt+"
 
@@ -1318,34 +1315,34 @@ msgstr "Alt+"
 msgid "An optional corner radius for adding rounded corners."
 msgstr ""
 
-#: ../src/common/debugrpt.cpp:576
+#: ../src/common/debugrpt.cpp:577
 msgid "And includes the following files:\n"
 msgstr "并且包含以下文件:\n"
 
-#: ../src/generic/animateg.cpp:162
+#: ../src/generic/animateg.cpp:145
 #, c-format
 msgid "Animation file is not of type %ld."
 msgstr "动画文件的类型不是 %ld。"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:872
+#: ../src/propgrid/advprops.cpp:773
 msgid "AppWorkspace"
 msgstr ""
 
-#: ../src/generic/logg.cpp:1014
+#: ../src/generic/logg.cpp:1011
 #, c-format
 msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
 msgstr "把日志添加到文件 '%s' (选择 [否] 将覆盖该文件)?"
 
-#: ../src/osx/menu_osx.cpp:577 ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:469 ../src/osx/menu_osx.cpp:477
 msgid "Application"
 msgstr "应用程序"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "Apply"
 msgstr "应用"
 
-#: ../src/propgrid/advprops.cpp:1609
+#: ../src/propgrid/advprops.cpp:1515
 msgid "Aqua"
 msgstr ""
 
@@ -1354,30 +1351,30 @@ msgstr ""
 msgid "Arabic"
 msgstr "阿拉伯数字"
 
-#: ../src/common/fmapbase.cpp:153
+#: ../src/common/fmapbase.cpp:150
 msgid "Arabic (ISO-8859-6)"
 msgstr "阿拉伯语 (ISO-8859-6)"
 
-#: ../src/msw/ole/automtn.cpp:672
+#: ../src/msw/ole/automtn.cpp:663
 #, c-format
 msgid "Argument %u not found."
 msgstr "找不到参数 %u。"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1753
+#: ../src/propgrid/advprops.cpp:1654
 #, fuzzy
 msgid "Arrow"
 msgstr "明天"
 
-#: ../src/generic/aboutdlgg.cpp:184
+#: ../src/generic/aboutdlgg.cpp:181
 msgid "Artists"
 msgstr "美术设计者"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "Ascending"
 msgstr "升序"
 
-#: ../src/generic/filectrlg.cpp:433
+#: ../src/generic/filectrlg.cpp:429
 msgid "Attributes"
 msgstr "属性(Attributes)"
 
@@ -1387,90 +1384,90 @@ msgstr "属性(Attributes)"
 msgid "Available fonts."
 msgstr "可用字体。"
 
-#: ../src/common/paper.cpp:137
+#: ../src/common/paper.cpp:134
 msgid "B4 (ISO) 250 x 353 mm"
 msgstr "B4 纸张(ISO), 250 x 353 毫米"
 
-#: ../src/common/paper.cpp:173
+#: ../src/common/paper.cpp:170
 msgid "B4 (JIS) Rotated 364 x 257 mm"
 msgstr "横向 B4 纸张(JIS), 364 x 257 毫米"
 
-#: ../src/common/paper.cpp:127
+#: ../src/common/paper.cpp:124
 msgid "B4 Envelope, 250 x 353 mm"
 msgstr "B4 信封, 250 x 353 毫米"
 
-#: ../src/common/paper.cpp:109
+#: ../src/common/paper.cpp:106
 msgid "B4 sheet, 250 x 354 mm"
 msgstr "B4 纸张, 250 x 354 毫米"
 
-#: ../src/common/paper.cpp:158
+#: ../src/common/paper.cpp:155
 msgid "B5 (ISO) Extra 201 x 276 mm"
 msgstr "特大 B4 纸张(JIS), 201 x 276 毫米"
 
-#: ../src/common/paper.cpp:174
+#: ../src/common/paper.cpp:171
 msgid "B5 (JIS) Rotated 257 x 182 mm"
 msgstr "横向 B5 纸张(JIS), 257 x 182 毫米"
 
-#: ../src/common/paper.cpp:155
+#: ../src/common/paper.cpp:152
 msgid "B5 (JIS) Transverse 182 x 257 mm"
 msgstr "B5 纸张 (JIS, 横排), 182 x 257 毫米"
 
-#: ../src/common/paper.cpp:128
+#: ../src/common/paper.cpp:125
 msgid "B5 Envelope, 176 x 250 mm"
 msgstr "B5 信封, 176 x 250 毫米"
 
-#: ../src/common/paper.cpp:110
+#: ../src/common/paper.cpp:107
 msgid "B5 sheet, 182 x 257 millimeter"
 msgstr "B5 纸张, 182 x 257 毫米"
 
-#: ../src/common/paper.cpp:182
+#: ../src/common/paper.cpp:179
 msgid "B6 (JIS) 128 x 182 mm"
 msgstr "B6 纸张(JIS), 128 x 182 毫米"
 
-#: ../src/common/paper.cpp:183
+#: ../src/common/paper.cpp:180
 msgid "B6 (JIS) Rotated 182 x 128 mm"
 msgstr "横向 B6 纸张(JIS), 182 x 128 毫米"
 
-#: ../src/common/paper.cpp:129
+#: ../src/common/paper.cpp:126
 msgid "B6 Envelope, 176 x 125 mm"
 msgstr "B6 信封, 176 x 125 毫米"
 
-#: ../src/common/imagbmp.cpp:531 ../src/common/imagbmp.cpp:561
-#: ../src/common/imagbmp.cpp:576
+#: ../src/common/imagbmp.cpp:528 ../src/common/imagbmp.cpp:558
+#: ../src/common/imagbmp.cpp:573
 msgid "BMP: Couldn't allocate memory."
 msgstr "BMP: 无法分配内存。"
 
-#: ../src/common/imagbmp.cpp:100
+#: ../src/common/imagbmp.cpp:97
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: 无法保存无效图像。"
 
-#: ../src/common/imagbmp.cpp:356
+#: ../src/common/imagbmp.cpp:353
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: 无法写 RGB 色彩表。"
 
-#: ../src/common/imagbmp.cpp:490
+#: ../src/common/imagbmp.cpp:487
 msgid "BMP: Couldn't write data."
 msgstr "BMP: 无法写数据。"
 
-#: ../src/common/imagbmp.cpp:246
+#: ../src/common/imagbmp.cpp:243
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: 无法写文件头 (Bitmap)。"
 
-#: ../src/common/imagbmp.cpp:269
+#: ../src/common/imagbmp.cpp:266
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: 无法写文件头 (BitmapInfo)。"
 
-#: ../src/common/imagbmp.cpp:140
+#: ../src/common/imagbmp.cpp:137
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage 没有自己的 wxPalette。"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:142 ../src/common/accelcmn.cpp:52
+#: ../src/common/stockitem.cpp:139 ../src/common/accelcmn.cpp:49
 msgid "Back"
 msgstr "返回"
 
+#: ../src/richtext/richtextformatdlg.cpp:377
 #: ../src/richtext/richtextbackgroundpage.cpp:148
-#: ../src/richtext/richtextformatdlg.cpp:384
 msgid "Background"
 msgstr "背景"
 
@@ -1478,21 +1475,21 @@ msgstr "背景"
 msgid "Background &colour:"
 msgstr "背景颜色(&c):"
 
-#: ../src/osx/carbon/fontdlg.cpp:220
+#: ../src/osx/carbon/fontdlg.cpp:217
 msgid "Background colour"
 msgstr "背景颜色"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:52
+#: ../src/common/accelcmn.cpp:49
 #, fuzzy
 msgid "Backspace"
 msgstr "返回"
 
-#: ../src/common/fmapbase.cpp:160
+#: ../src/common/fmapbase.cpp:157
 msgid "Baltic (ISO-8859-13)"
 msgstr "波罗的海语 (ISO-8859-13)"
 
-#: ../src/common/fmapbase.cpp:151
+#: ../src/common/fmapbase.cpp:148
 msgid "Baltic (old) (ISO-8859-4)"
 msgstr "波罗的海语 (旧式) (ISO-8859-4)"
 
@@ -1505,25 +1502,25 @@ msgstr "段落之前:"
 msgid "Bitmap"
 msgstr "位图"
 
-#: ../src/propgrid/advprops.cpp:1594
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Black"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1755
+#: ../src/propgrid/advprops.cpp:1656
 msgid "Blank"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1603
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Blue"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:345
+#: ../src/generic/colrdlgg.cpp:365
 msgid "Blue:"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:333 ../src/richtext/richtextfontpage.cpp:355
-#: ../src/osx/carbon/fontdlg.cpp:354 ../src/common/stockitem.cpp:143
+#: ../src/osx/carbon/fontdlg.cpp:351 ../src/common/stockitem.cpp:140
+#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:355
 msgid "Bold"
 msgstr "粗体"
 
@@ -1532,32 +1529,36 @@ msgstr "粗体"
 msgid "Border"
 msgstr "边框"
 
-#: ../src/richtext/richtextformatdlg.cpp:379
+#: ../src/richtext/richtextformatdlg.cpp:372
 msgid "Borders"
 msgstr "边框"
 
-#: ../src/richtext/richtextsizepage.cpp:288 ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141 ../src/richtext/richtextsizepage.cpp:288
 msgid "Bottom"
 msgstr "底端"
 
-#: ../src/generic/prntdlgg.cpp:893
+#: ../src/generic/prntdlgg.cpp:886
 msgid "Bottom margin (mm):"
 msgstr "底边距 (毫米):"
 
-#: ../src/richtext/richtextbuffer.cpp:9383
+#: ../src/richtext/richtextbuffer.cpp:9380
 msgid "Box Properties"
 msgstr "方块属性"
 
-#: ../src/richtext/richtextstyles.cpp:1065
+#: ../src/richtext/richtextstyles.cpp:1062
 msgid "Box styles"
 msgstr "方块样式"
 
-#: ../src/propgrid/advprops.cpp:1602
+#: ../src/osx/cocoa/menu.mm:292
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1508
 #, fuzzy
 msgid "Brown"
 msgstr "浏览"
 
-#: ../src/common/filepickercmn.cpp:43 ../src/common/filepickercmn.cpp:44
+#: ../src/common/filepickercmn.cpp:40 ../src/common/filepickercmn.cpp:41
 msgid "Browse"
 msgstr "浏览"
 
@@ -1570,73 +1571,73 @@ msgstr "项目符号对齐(&A):"
 msgid "Bullet style"
 msgstr "项目符号样式"
 
-#: ../src/richtext/richtextformatdlg.cpp:359
+#: ../src/richtext/richtextformatdlg.cpp:352
 msgid "Bullets"
 msgstr "项目符号"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1756
+#: ../src/propgrid/advprops.cpp:1657
 #, fuzzy
 msgid "Bullseye"
 msgstr "项目符号样式"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:875
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonFace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:876
+#: ../src/propgrid/advprops.cpp:777
 msgid "ButtonHighlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:877
+#: ../src/propgrid/advprops.cpp:778
 msgid "ButtonShadow"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:878
+#: ../src/propgrid/advprops.cpp:779
 msgid "ButtonText"
 msgstr ""
 
-#: ../src/common/paper.cpp:98
+#: ../src/common/paper.cpp:95
 msgid "C sheet, 17 x 22 in"
 msgstr "C 纸张, 17 x 22 英寸"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "C&lear"
 msgstr "清除(&L)"
 
-#: ../src/generic/fontdlgg.cpp:406
+#: ../src/generic/fontdlgg.cpp:403
 msgid "C&olour:"
 msgstr "颜色(&o):"
 
-#: ../src/common/paper.cpp:123
+#: ../src/common/paper.cpp:120
 msgid "C3 Envelope, 324 x 458 mm"
 msgstr "C3 信封, 324 x 458 毫米"
 
-#: ../src/common/paper.cpp:124
+#: ../src/common/paper.cpp:121
 msgid "C4 Envelope, 229 x 324 mm"
 msgstr "C4 信封, 229 x 324 毫米"
 
-#: ../src/common/paper.cpp:122
+#: ../src/common/paper.cpp:119
 msgid "C5 Envelope, 162 x 229 mm"
 msgstr "C5 信封, 162 x 229 毫米"
 
-#: ../src/common/paper.cpp:125
+#: ../src/common/paper.cpp:122
 msgid "C6 Envelope, 114 x 162 mm"
 msgstr "C6 信封, 114 x 162 毫米"
 
-#: ../src/common/paper.cpp:126
+#: ../src/common/paper.cpp:123
 msgid "C65 Envelope, 114 x 229 mm"
 msgstr "C65 信封, 114 x 229 毫米"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "CD-Rom"
 msgstr "CD 光驱"
 
-#: ../src/html/chm.cpp:815 ../src/html/chm.cpp:874
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:865
 msgid "CHM handler currently supports only local files!"
 msgstr "CHM处理程序目前只支持本地文件！"
 
@@ -1644,190 +1645,194 @@ msgstr "CHM处理程序目前只支持本地文件！"
 msgid "Ca&pitals"
 msgstr "大写(&P)"
 
-#: ../src/common/cmdproc.cpp:267
+#: ../src/common/cmdproc.cpp:260
 msgid "Can't &Undo "
 msgstr "无法撤销(&U)"
 
-#: ../src/common/image.cpp:2824
+#: ../src/common/image.cpp:2924
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr "不能自动确定不可定位输入的图像格式。"
 
-#: ../src/msw/registry.cpp:506
+#: ../src/msw/registry.cpp:495
 #, c-format
 msgid "Can't close registry key '%s'"
 msgstr "无法关闭注册键 '%s'"
 
-#: ../src/msw/registry.cpp:584
+#: ../src/msw/registry.cpp:573
 #, c-format
 msgid "Can't copy values of unsupported type %d."
 msgstr "无法复制不支持的类型 %d 的值."
 
-#: ../src/msw/registry.cpp:487
+#: ../src/msw/registry.cpp:476
 #, c-format
 msgid "Can't create registry key '%s'"
 msgstr "无法创建注册键 '%s'"
 
-#: ../src/msw/thread.cpp:665
+#: ../src/msw/thread.cpp:657
 msgid "Can't create thread"
 msgstr "无法创建线程"
 
-#: ../src/msw/window.cpp:3691
-#, c-format
-msgid "Can't create window of class %s"
-msgstr "无法创建窗口类 %s"
-
-#: ../src/msw/registry.cpp:777
+#: ../src/msw/registry.cpp:765
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "无法删除键 '%s'"
 
-#: ../src/msw/iniconf.cpp:458
+#: ../src/msw/iniconf.cpp:455
 #, c-format
 msgid "Can't delete the INI file '%s'"
 msgstr "无法删除 INI 文件 '%s'"
 
-#: ../src/msw/registry.cpp:805
+#: ../src/msw/registry.cpp:793
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "无法删除值 '%s' 位于键 '%s'"
 
-#: ../src/msw/registry.cpp:1171
+#: ../src/msw/registry.cpp:1159
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "无法枚举键 '%s' 的子键"
 
-#: ../src/msw/registry.cpp:1132
+#: ../src/msw/registry.cpp:1120
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "无法枚举键 '%s' 的值"
 
-#: ../src/msw/registry.cpp:1389
+#: ../src/msw/registry.cpp:1377
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "无法导出不支持的类型 %d 的值."
 
-#: ../src/common/ffile.cpp:254
+#: ../src/common/ffile.cpp:253
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "无法在文件 '%s' 中找到当前位置"
 
-#: ../src/msw/registry.cpp:418
+#: ../src/msw/registry.cpp:407
 #, c-format
 msgid "Can't get info about registry key '%s'"
 msgstr "无法获得注册键 '%s' 的信息"
 
-#: ../src/common/zstream.cpp:346
+#: ../src/msw/webview_ie.cpp:1024
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "无法设置线程优先级"
+
+#: ../src/common/zstream.cpp:343
 msgid "Can't initialize zlib deflate stream."
 msgstr "无法初始化 zlib 压缩流。"
 
-#: ../src/common/zstream.cpp:185
+#: ../src/common/zstream.cpp:182
 msgid "Can't initialize zlib inflate stream."
 msgstr "无法初始化 zlib 解压流。"
 
-#: ../src/msw/fswatcher.cpp:476
+#: ../src/msw/fswatcher.cpp:475
 #, c-format
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "无法监视不存在目录 \"%s\" 的更新。"
 
-#: ../src/msw/registry.cpp:454
+#: ../src/msw/registry.cpp:443
 #, c-format
 msgid "Can't open registry key '%s'"
 msgstr "无法打开注册键 '%s'"
 
-#: ../src/common/zstream.cpp:252
+#: ../src/common/zstream.cpp:249
 #, c-format
 msgid "Can't read from inflate stream: %s"
 msgstr "无法从解压流 %s 中读取"
 
-#: ../src/common/zstream.cpp:244
+#: ../src/common/zstream.cpp:241
 msgid "Can't read inflate stream: unexpected EOF in underlying stream."
 msgstr "无法读解压流: 流内有异常的 EOF。"
 
-#: ../src/msw/registry.cpp:1064
+#: ../src/msw/registry.cpp:1052
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "无法读 '%s' 的值"
 
-#: ../src/msw/registry.cpp:878 ../src/msw/registry.cpp:910
-#: ../src/msw/registry.cpp:975
+#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
+#: ../src/msw/registry.cpp:963
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "无法读键 '%s' 的值"
 
-#: ../src/common/image.cpp:2620
+#: ../src/msw/webview_ie.cpp:1017
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/common/image.cpp:2715
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "无法从将图像保存至文件 '%s' 中: 无法识别的扩展名。"
 
-#: ../src/generic/logg.cpp:573 ../src/generic/logg.cpp:976
+#: ../src/generic/logg.cpp:570 ../src/generic/logg.cpp:973
 msgid "Can't save log contents to file."
 msgstr "无法把日志内容保存到文件。"
 
-#: ../src/msw/thread.cpp:629
+#: ../src/msw/thread.cpp:621
 msgid "Can't set thread priority"
 msgstr "无法设置线程优先级"
 
-#: ../src/msw/registry.cpp:896 ../src/msw/registry.cpp:938
-#: ../src/msw/registry.cpp:1081
+#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
+#: ../src/msw/registry.cpp:1069
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "无法设置 '%s' 的值"
 
-#: ../src/unix/utilsunx.cpp:351
+#: ../src/unix/utilsunx.cpp:353
 msgid "Can't write to child process's stdin"
 msgstr "无法写入子进程的标准输入"
 
-#: ../src/common/zstream.cpp:427
+#: ../src/common/zstream.cpp:424
 #, c-format
 msgid "Can't write to deflate stream: %s"
 msgstr "无法写到压缩流: %s"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:279 ../src/richtext/richtextstyledlg.cpp:300
-#: ../src/common/stockitem.cpp:145 ../src/common/accelcmn.cpp:71
-#: ../src/msw/msgdlg.cpp:454 ../src/msw/progdlg.cpp:673
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:142
+#: ../src/common/accelcmn.cpp:68 ../src/motif/msgdlg.cpp:196
+#: ../src/gtk1/fontdlg.cpp:144 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/progdlg.cpp:940 ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "取消"
 
-#: ../src/common/filefn.cpp:1261
+#: ../src/common/filefn.cpp:1149
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "无法枚举文件 '%s'"
 
-#: ../src/msw/dir.cpp:263
+#: ../src/msw/dir.cpp:260
 #, c-format
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "无法枚举目录 '%s' 中的文件"
 
-#: ../src/msw/dialup.cpp:523
+#: ../src/msw/dialup.cpp:517
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "无法找到活动的拨号连接: %s"
 
-#: ../src/msw/dialup.cpp:827
+#: ../src/msw/dialup.cpp:821
 msgid "Cannot find the location of address book file"
 msgstr "无法找到地址簿文件的位置"
 
-#: ../src/msw/ole/automtn.cpp:562
+#: ../src/msw/ole/automtn.cpp:553
 #, c-format
 msgid "Cannot get an active instance of \"%s\""
 msgstr "无法获得 \"%s\" 的活动实体"
 
-#: ../src/unix/threadpsx.cpp:1035
+#: ../src/unix/threadpsx.cpp:1053
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "无法获得调度策略 %d 的优先级范围。"
 
-#: ../src/unix/utilsunx.cpp:987
+#: ../src/unix/utilsunx.cpp:989
 msgid "Cannot get the hostname"
 msgstr "无法获得主机名"
 
-#: ../src/unix/utilsunx.cpp:1023
+#: ../src/unix/utilsunx.cpp:1025
 msgid "Cannot get the official hostname"
 msgstr "无法获得正式的主机名"
 
-#: ../src/msw/dialup.cpp:928
+#: ../src/msw/dialup.cpp:922
 msgid "Cannot hang up - no active dialup connection."
 msgstr "无法挂断 - 没有活动的拨号连接。"
 
@@ -1835,127 +1840,127 @@ msgstr "无法挂断 - 没有活动的拨号连接。"
 msgid "Cannot initialize OLE"
 msgstr "无法初始化 OLE"
 
-#: ../src/common/socket.cpp:853
+#: ../src/common/socket.cpp:850
 msgid "Cannot initialize sockets"
 msgstr "无法初始化 sockets"
 
-#: ../src/msw/volume.cpp:619
+#: ../src/msw/volume.cpp:627
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "无法从 '%s' 中读取图标。"
 
-#: ../src/xrc/xmlres.cpp:360
+#: ../src/xrc/xmlres.cpp:358
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "无法从文件 '%s' 中载入资源。"
 
-#: ../src/xrc/xmlres.cpp:742
+#: ../src/xrc/xmlres.cpp:740
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "无法从文件 '%s' 中载入资源。"
 
-#: ../src/html/htmlfilt.cpp:137
+#: ../src/html/htmlfilt.cpp:134
 #, c-format
 msgid "Cannot open HTML document: %s"
 msgstr "无法打开 HTML 文档: %s"
 
-#: ../src/html/helpdata.cpp:667
+#: ../src/html/helpdata.cpp:660
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "无法打开 HTML 帮助: %s"
 
-#: ../src/html/helpdata.cpp:299
+#: ../src/html/helpdata.cpp:296
 #, c-format
 msgid "Cannot open contents file: %s"
 msgstr "无法打开目录文件: %s"
 
-#: ../src/generic/dcpsg.cpp:1667
+#: ../src/generic/dcpsg.cpp:1665
 msgid "Cannot open file for PostScript printing!"
 msgstr "无法打开文件进行 PostScript 打印！"
 
-#: ../src/html/helpdata.cpp:313
+#: ../src/html/helpdata.cpp:310
 #, c-format
 msgid "Cannot open index file: %s"
 msgstr "无法打开索引文件: %s"
 
-#: ../src/xrc/xmlres.cpp:724
+#: ../src/xrc/xmlres.cpp:722
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "无法打开资源文件 '%s'。"
 
-#: ../src/html/helpwnd.cpp:1534
+#: ../src/html/helpwnd.cpp:1532
 msgid "Cannot print empty page."
 msgstr "无法打印空白页面。"
 
-#: ../src/msw/volume.cpp:507
+#: ../src/msw/volume.cpp:515
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "无法从 '%s' 中读取类型名称！"
 
-#: ../src/msw/thread.cpp:888
+#: ../src/msw/thread.cpp:894
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "无法恢复线程 %lx"
 
-#: ../src/unix/threadpsx.cpp:1016
+#: ../src/unix/threadpsx.cpp:1028
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "无法找回线程调度策略。"
 
-#: ../src/common/intl.cpp:558
+#: ../src/common/intl.cpp:365
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "无法设定为语言 \"%s\"。"
 
-#: ../src/unix/threadpsx.cpp:831 ../src/msw/thread.cpp:546
+#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
 msgid "Cannot start thread: error writing TLS."
 msgstr "无法启动线程: 写 TLS 出错。"
 
-#: ../src/msw/thread.cpp:872
+#: ../src/msw/thread.cpp:864
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "无法挂起线程 %lx"
 
-#: ../src/msw/thread.cpp:794
+#: ../src/msw/thread.cpp:786
 msgid "Cannot wait for thread termination"
 msgstr "无法等候线程终止"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:75
+#: ../src/common/accelcmn.cpp:72
 #, fuzzy
 msgid "Capital"
 msgstr "大写(&P)"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:879
+#: ../src/propgrid/advprops.cpp:780
 msgid "CaptionText"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:531
 msgid "Case sensitive"
 msgstr "大小写敏感"
 
-#: ../src/propgrid/manager.cpp:1509
+#: ../src/propgrid/manager.cpp:1527
 msgid "Categorized Mode"
 msgstr "分类模式"
 
-#: ../src/richtext/richtextbuffer.cpp:9968
+#: ../src/richtext/richtextbuffer.cpp:9965
 msgid "Cell Properties"
 msgstr "单元格属性"
 
-#: ../src/common/fmapbase.cpp:161
+#: ../src/common/fmapbase.cpp:158
 msgid "Celtic (ISO-8859-14)"
 msgstr "凯尔特语 (ISO-8859-14)"
 
-#: ../src/richtext/richtextindentspage.cpp:160
 #: ../src/richtext/richtextliststylepage.cpp:349
+#: ../src/richtext/richtextindentspage.cpp:160
 msgid "Cen&tred"
 msgstr "居中(&t)"
 
-#: ../src/common/stockitem.cpp:170
+#: ../src/common/stockitem.cpp:167
 msgid "Centered"
 msgstr "居中"
 
-#: ../src/common/fmapbase.cpp:149
+#: ../src/common/fmapbase.cpp:146
 msgid "Central European (ISO-8859-2)"
 msgstr "中欧语系 (ISO-8859-2)"
 
@@ -1964,10 +1969,10 @@ msgstr "中欧语系 (ISO-8859-2)"
 msgid "Centre"
 msgstr "居中"
 
-#: ../src/richtext/richtextindentspage.cpp:162
-#: ../src/richtext/richtextindentspage.cpp:164
 #: ../src/richtext/richtextliststylepage.cpp:351
 #: ../src/richtext/richtextliststylepage.cpp:353
+#: ../src/richtext/richtextindentspage.cpp:162
+#: ../src/richtext/richtextindentspage.cpp:164
 msgid "Centre text."
 msgstr "文字居中。"
 
@@ -1980,24 +1985,24 @@ msgstr "居中"
 msgid "Ch&oose..."
 msgstr "选择(&o)..."
 
-#: ../src/richtext/richtextbuffer.cpp:4354
+#: ../src/richtext/richtextbuffer.cpp:4351
 msgid "Change List Style"
 msgstr "更改列表样式"
 
-#: ../src/richtext/richtextbuffer.cpp:3709
+#: ../src/richtext/richtextbuffer.cpp:3706
 msgid "Change Object Style"
 msgstr "更改对象样式"
 
-#: ../src/richtext/richtextbuffer.cpp:3982
-#: ../src/richtext/richtextbuffer.cpp:8129
+#: ../src/richtext/richtextbuffer.cpp:3979
+#: ../src/richtext/richtextbuffer.cpp:8125
 msgid "Change Properties"
 msgstr "修改属性"
 
-#: ../src/richtext/richtextbuffer.cpp:3526
+#: ../src/richtext/richtextbuffer.cpp:3523
 msgid "Change Style"
 msgstr "更改样式"
 
-#: ../src/common/fileconf.cpp:341
+#: ../src/common/fileconf.cpp:335
 #, c-format
 msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
 msgstr "为了防止重写已有文件 \"%s\" 更改不会被保存"
@@ -2008,12 +2013,12 @@ msgid "Changing current directory to \"%s\" failed"
 msgstr "无法创建目录 \"%s\""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1757
+#: ../src/propgrid/advprops.cpp:1658
 #, fuzzy
 msgid "Character"
 msgstr "字符编码(&C):"
 
-#: ../src/richtext/richtextstyles.cpp:1063
+#: ../src/richtext/richtextstyles.cpp:1060
 msgid "Character styles"
 msgstr "文字样式"
 
@@ -2050,20 +2055,20 @@ msgstr "勾选以将项目符号加上一对括号"
 msgid "Check to indicate right-to-left text layout."
 msgstr "勾选使用从右到左文字布局。"
 
-#: ../src/osx/carbon/fontdlg.cpp:356 ../src/osx/carbon/fontdlg.cpp:358
+#: ../src/osx/carbon/fontdlg.cpp:353 ../src/osx/carbon/fontdlg.cpp:355
 msgid "Check to make the font bold."
 msgstr "勾选设定为粗体。"
 
-#: ../src/osx/carbon/fontdlg.cpp:363 ../src/osx/carbon/fontdlg.cpp:365
+#: ../src/osx/carbon/fontdlg.cpp:360 ../src/osx/carbon/fontdlg.cpp:362
 msgid "Check to make the font italic."
 msgstr "勾选设定为斜体。"
 
-#: ../src/osx/carbon/fontdlg.cpp:372 ../src/osx/carbon/fontdlg.cpp:374
+#: ../src/osx/carbon/fontdlg.cpp:369 ../src/osx/carbon/fontdlg.cpp:371
 msgid "Check to make the font underlined."
 msgstr "勾选加下划线。"
 
-#: ../src/richtext/richtextstyledlg.cpp:289
-#: ../src/richtext/richtextstyledlg.cpp:291
+#: ../src/richtext/richtextstyledlg.cpp:285
+#: ../src/richtext/richtextstyledlg.cpp:287
 msgid "Check to restart numbering."
 msgstr "勾选以重新编号"
 
@@ -2098,51 +2103,51 @@ msgstr "勾选显示为上标。"
 msgid "Check to suppress hyphenation."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:763
+#: ../src/msw/dialup.cpp:757
 msgid "Choose ISP to dial"
 msgstr "选择ISP进行拨号"
 
-#: ../src/propgrid/props.cpp:1922
+#: ../src/propgrid/props.cpp:1904
 msgid "Choose a directory:"
 msgstr "选择目录:"
 
-#: ../src/propgrid/props.cpp:1975
+#: ../src/propgrid/props.cpp:2199
 msgid "Choose a file"
 msgstr "选择文件"
 
-#: ../src/generic/colrdlgg.cpp:158 ../src/gtk/colordlg.cpp:54
+#: ../src/generic/colrdlgg.cpp:156 ../src/gtk/colordlg.cpp:49
 msgid "Choose colour"
 msgstr "选择颜色"
 
-#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/gtk1/fontdlg.cpp:125 ../src/generic/fontpickerg.cpp:47
+#: ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "选择字体"
 
-#: ../src/common/module.cpp:74
+#: ../src/common/module.cpp:71
 #, c-format
 msgid "Circular dependency involving module \"%s\" detected."
 msgstr "检测到导致循环依赖模块 \"%s\" 。"
 
-#: ../src/aui/tabmdi.cpp:108 ../src/generic/mdig.cpp:97
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
 msgid "Cl&ose"
 msgstr "关闭(&o)"
 
-#: ../src/msw/ole/automtn.cpp:684
+#: ../src/msw/ole/automtn.cpp:675
 msgid "Class not registered."
 msgstr "类未注册。"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:147 ../src/common/accelcmn.cpp:72
+#: ../src/common/stockitem.cpp:144 ../src/common/accelcmn.cpp:69
 msgid "Clear"
 msgstr "清除"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "Clear the log contents"
 msgstr "清除日志内容"
 
-#: ../src/richtext/richtextstyledlg.cpp:252
-#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:248
+#: ../src/richtext/richtextstyledlg.cpp:250
 msgid "Click to apply the selected style."
 msgstr "点击应用所选样式。"
 
@@ -2153,15 +2158,15 @@ msgstr "点击应用所选样式。"
 msgid "Click to browse for a symbol."
 msgstr "点击浏览该符号。"
 
-#: ../src/osx/carbon/fontdlg.cpp:403 ../src/osx/carbon/fontdlg.cpp:405
+#: ../src/osx/carbon/fontdlg.cpp:400 ../src/osx/carbon/fontdlg.cpp:402
 msgid "Click to cancel changes to the font."
 msgstr "点击取消字体变更。"
 
-#: ../src/generic/fontdlgg.cpp:472 ../src/generic/fontdlgg.cpp:491
+#: ../src/generic/fontdlgg.cpp:468 ../src/generic/fontdlgg.cpp:487
 msgid "Click to cancel the font selection."
 msgstr "点击取消字体选择。"
 
-#: ../src/osx/carbon/fontdlg.cpp:384 ../src/osx/carbon/fontdlg.cpp:386
+#: ../src/osx/carbon/fontdlg.cpp:381 ../src/osx/carbon/fontdlg.cpp:383
 msgid "Click to change the font colour."
 msgstr "点击更改字体颜色。"
 
@@ -2180,37 +2185,37 @@ msgstr "点击修改字体颜色。"
 msgid "Click to choose the font for this level."
 msgstr "点击选择此层级字体。"
 
-#: ../src/richtext/richtextstyledlg.cpp:279
-#: ../src/richtext/richtextstyledlg.cpp:281
+#: ../src/richtext/richtextstyledlg.cpp:275
+#: ../src/richtext/richtextstyledlg.cpp:277
 msgid "Click to close this window."
 msgstr "点击关闭此窗口。"
 
-#: ../src/osx/carbon/fontdlg.cpp:410 ../src/osx/carbon/fontdlg.cpp:412
+#: ../src/osx/carbon/fontdlg.cpp:407 ../src/osx/carbon/fontdlg.cpp:409
 msgid "Click to confirm changes to the font."
 msgstr "点击确认字体更改。"
 
-#: ../src/generic/fontdlgg.cpp:477 ../src/generic/fontdlgg.cpp:479
-#: ../src/generic/fontdlgg.cpp:484 ../src/generic/fontdlgg.cpp:486
+#: ../src/generic/fontdlgg.cpp:473 ../src/generic/fontdlgg.cpp:475
+#: ../src/generic/fontdlgg.cpp:480 ../src/generic/fontdlgg.cpp:482
 msgid "Click to confirm the font selection."
 msgstr "点击确认字体选择。"
 
-#: ../src/richtext/richtextstyledlg.cpp:244
-#: ../src/richtext/richtextstyledlg.cpp:246
+#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:242
 msgid "Click to create a new box style."
 msgstr "点击新增方块样式。"
 
-#: ../src/richtext/richtextstyledlg.cpp:226
-#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:224
 msgid "Click to create a new character style."
 msgstr "点击新建文字样式。"
 
-#: ../src/richtext/richtextstyledlg.cpp:238
-#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:236
 msgid "Click to create a new list style."
 msgstr "点击新增列表样式。"
 
-#: ../src/richtext/richtextstyledlg.cpp:232
-#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:230
 msgid "Click to create a new paragraph style."
 msgstr "点击新建段落样式。"
 
@@ -2224,8 +2229,8 @@ msgstr "点击建立新的标签位置。"
 msgid "Click to delete all tab positions."
 msgstr "点击删除所有标签位置。"
 
-#: ../src/richtext/richtextstyledlg.cpp:270
-#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:268
 msgid "Click to delete the selected style."
 msgstr "点击删除所选样式。"
 
@@ -2234,25 +2239,25 @@ msgstr "点击删除所选样式。"
 msgid "Click to delete the selected tab position."
 msgstr "点击删除所选标签位置。"
 
-#: ../src/richtext/richtextstyledlg.cpp:264
-#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:262
 msgid "Click to edit the selected style."
 msgstr "点击编辑所选样式。"
 
-#: ../src/richtext/richtextstyledlg.cpp:258
-#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:256
 msgid "Click to rename the selected style."
 msgstr "点击重命名所选样式。"
 
-#: ../src/generic/dbgrptg.cpp:97 ../src/generic/progdlgg.cpp:759
-#: ../src/richtext/richtextstyledlg.cpp:277
-#: ../src/richtext/richtextsymboldlg.cpp:476 ../src/common/stockitem.cpp:148
-#: ../src/msw/progdlg.cpp:170 ../src/msw/progdlg.cpp:679
-#: ../src/html/helpdlg.cpp:90
+#: ../src/common/stockitem.cpp:145 ../src/generic/dbgrptg.cpp:94
+#: ../src/generic/progdlgg.cpp:781 ../src/msw/progdlg.cpp:211
+#: ../src/msw/progdlg.cpp:946 ../src/html/helpdlg.cpp:87
+#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextstyledlg.cpp:273
 msgid "Close"
 msgstr "关闭"
 
-#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:98
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
 msgid "Close All"
 msgstr "全部关闭"
 
@@ -2260,65 +2265,65 @@ msgstr "全部关闭"
 msgid "Close current document"
 msgstr "关闭当前文档"
 
-#: ../src/generic/logg.cpp:516
+#: ../src/generic/logg.cpp:513
 msgid "Close this window"
 msgstr "关闭此窗口"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6006
+#: ../src/generic/datavgen.cpp:6811
 msgid "Collapse"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "Color"
 msgstr "颜色"
 
-#: ../src/richtext/richtextformatdlg.cpp:776
+#: ../src/richtext/richtextformatdlg.cpp:768
 msgid "Colour"
 msgstr "颜色"
 
-#: ../src/msw/colordlg.cpp:158
+#: ../src/msw/colordlg.cpp:227
 #, c-format
 msgid "Colour selection dialog failed with error %0lx."
 msgstr "颜色选择对话框错误，错误码 %0lx。"
 
-#: ../src/osx/carbon/fontdlg.cpp:380
+#: ../src/osx/carbon/fontdlg.cpp:377
 msgid "Colour:"
 msgstr "颜色:"
 
-#: ../src/generic/datavgen.cpp:6077
+#: ../src/generic/datavgen.cpp:6882
 #, fuzzy, c-format
 msgid "Column %u"
 msgstr "添加列"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:114
+#: ../src/common/accelcmn.cpp:112
 msgid "Command"
 msgstr ""
 
-#: ../src/common/init.cpp:196
+#: ../src/common/init.cpp:193
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
 "ignored."
 msgstr "命令行参数 %d 无法被转化成Unicode编码，其将被忽略。"
 
-#: ../src/msw/fontdlg.cpp:120
+#: ../src/msw/fontdlg.cpp:170
 #, c-format
 msgid "Common dialog failed with error code %0lx."
 msgstr "公共对话框错误，错误码 %0lx。"
 
-#: ../src/gtk/window.cpp:4649
+#: ../src/gtk/window.cpp:5653
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
 msgstr "当前系统不支持组合模式，请在窗口管理器中启用。"
 
-#: ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:1549
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "压缩的HTML帮助文件 (*.chm)|*.chm|"
 
-#: ../src/generic/dirctrlg.cpp:444
+#: ../src/generic/dirctrlg.cpp:410
 msgid "Computer"
 msgstr "计算机"
 
@@ -2327,53 +2332,57 @@ msgstr "计算机"
 msgid "Config entry name cannot start with '%c'."
 msgstr "配置条目名不能以 '%c' 开头。"
 
-#: ../src/generic/filedlgg.cpp:349 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
 msgid "Confirm"
 msgstr "确认"
 
-#: ../src/html/htmlwin.cpp:566
+#: ../src/html/htmlwin.cpp:569
 msgid "Connecting..."
 msgstr "正在连接..."
 
-#: ../src/html/helpwnd.cpp:475
+#: ../src/html/helpwnd.cpp:473
 msgid "Contents"
 msgstr "目录"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:880
+#: ../src/propgrid/advprops.cpp:781
 msgid "ControlDark"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:881
+#: ../src/propgrid/advprops.cpp:782
 msgid "ControlLight"
 msgstr ""
 
-#: ../src/common/strconv.cpp:2262
+#: ../src/common/strconv.cpp:2208
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "无法进行到字符集 '%s' 的转换。"
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "Convert"
 msgstr "转换"
 
-#: ../src/html/htmlwin.cpp:1079
+#: ../src/html/htmlwin.cpp:1020
 #, c-format
 msgid "Copied to clipboard:\"%s\""
 msgstr "已复制到剪贴板:\"%s\""
 
-#: ../src/generic/prntdlgg.cpp:247
+#: ../src/generic/prntdlgg.cpp:240
 msgid "Copies:"
 msgstr "份数:"
 
-#: ../src/common/stockitem.cpp:150 ../src/stc/stc_i18n.cpp:18
+#: ../src/common/stockitem.cpp:147 ../src/stc/stc_i18n.cpp:18
 msgid "Copy"
 msgstr "复制"
 
-#: ../src/common/stockitem.cpp:258
+#: ../src/common/stockitem.cpp:255
 msgid "Copy selection"
 msgstr "复制选区"
+
+#: ../src/generic/grid.cpp:5945
+msgid "Copying more than one selected block to clipboard is not supported."
+msgstr ""
 
 #: ../src/richtext/richtextborderspage.cpp:566
 #: ../src/richtext/richtextborderspage.cpp:601
@@ -2384,198 +2393,193 @@ msgstr ""
 msgid "Corner &radius:"
 msgstr ""
 
-#: ../src/html/chm.cpp:718
+#: ../src/html/chm.cpp:711
 #, c-format
 msgid "Could not create temporary file '%s'"
 msgstr "无法创建临时文件 '%s'"
 
-#: ../src/html/chm.cpp:273
+#: ../src/html/chm.cpp:270
 #, c-format
 msgid "Could not extract %s into %s: %s"
 msgstr "无法将 %s 解开至 %s: %s"
 
-#: ../src/generic/tabg.cpp:1048
+#: ../src/generic/tabg.cpp:1045
 msgid "Could not find tab for id"
 msgstr "找不到 id 的标签"
 
-#: ../src/gtk/notifmsg.cpp:108
-#, fuzzy
-msgid "Could not initalize libnotify."
-msgstr "无法设定对齐。"
-
-#: ../src/html/chm.cpp:444
+#: ../src/html/chm.cpp:437
 #, c-format
 msgid "Could not locate file '%s'."
 msgstr "找不到文件 '%s'。"
 
-#: ../src/common/filefn.cpp:1403
+#: ../src/msw/graphicsd2d.cpp:604
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/common/filefn.cpp:1291
 msgid "Could not set current working directory"
 msgstr "无法设置当前工作目录"
 
-#: ../src/common/prntbase.cpp:2015
+#: ../src/common/prntbase.cpp:2037
 msgid "Could not start document preview."
 msgstr "无法启动文档预览。"
 
-#: ../src/generic/printps.cpp:178 ../src/msw/printwin.cpp:210
-#: ../src/gtk/print.cpp:1132
+#: ../src/generic/printps.cpp:159 ../src/msw/printwin.cpp:184
+#: ../src/gtk/print.cpp:1129
 msgid "Could not start printing."
 msgstr "无法启动打印。"
 
-#: ../src/common/wincmn.cpp:2125
+#: ../src/common/wincmn.cpp:2126
 msgid "Could not transfer data to window"
 msgstr "无法把数据转到窗口"
 
-#: ../src/msw/imaglist.cpp:187 ../src/msw/imaglist.cpp:224
-#: ../src/msw/imaglist.cpp:249 ../src/msw/dragimag.cpp:185
-#: ../src/msw/dragimag.cpp:220
+#: ../src/msw/imaglist.cpp:223 ../src/msw/imaglist.cpp:245
+#: ../src/msw/imaglist.cpp:270 ../src/msw/dragimag.cpp:182
+#: ../src/msw/dragimag.cpp:217
 msgid "Couldn't add an image to the image list."
 msgstr "无法把图像加到图象列表。"
 
-#: ../src/osx/glcanvas_osx.cpp:414 ../src/unix/glx11.cpp:558
-#: ../src/msw/glcanvas.cpp:616
+#: ../src/osx/glcanvas_osx.cpp:411 ../src/msw/glcanvas.cpp:631
+#: ../src/unix/glegl.cpp:315 ../src/unix/glx11.cpp:559
 #, fuzzy
 msgid "Couldn't create OpenGL context"
 msgstr "无法创建计时器"
 
-#: ../src/msw/timer.cpp:134
+#: ../src/msw/timer.cpp:131
 msgid "Couldn't create a timer"
 msgstr "无法创建计时器"
 
-#: ../src/osx/carbon/overlay.cpp:122
-msgid "Couldn't create the overlay window"
-msgstr "无法创建 overlay 窗口"
-
-#: ../src/common/translation.cpp:2024
+#: ../src/common/translation.cpp:2074
 msgid "Couldn't enumerate translations"
 msgstr "无法枚举翻译"
 
-#: ../src/common/dynlib.cpp:120
+#: ../src/common/dynlib.cpp:110
 #, c-format
 msgid "Couldn't find symbol '%s' in a dynamic library"
 msgstr "在动态连接库中找不到符号 '%s'"
 
-#: ../src/msw/thread.cpp:915
+#: ../src/msw/thread.cpp:921
 msgid "Couldn't get the current thread pointer"
 msgstr "无法获得当前线程指针"
 
-#: ../src/osx/carbon/overlay.cpp:129
-#, fuzzy
-msgid "Couldn't init the context on the overlay window"
-msgstr "无法获得当前线程指针"
-
-#: ../src/common/imaggif.cpp:244
+#: ../src/common/imaggif.cpp:241
 msgid "Couldn't initialize GIF hash table."
 msgstr "无法初始化 GIF 哈希表。"
 
-#: ../src/common/imagpng.cpp:409
+#: ../src/common/imagpng.cpp:437
 msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
 msgstr "无法装入 PNG 图像 - 文件被破坏 或者 没有足够内存。"
 
-#: ../src/unix/sound.cpp:470
+#: ../src/unix/sound.cpp:459
 #, c-format
 msgid "Couldn't load sound data from '%s'."
 msgstr "无法从 '%s' 中的读取声音数据。"
 
-#: ../src/msw/dirdlg.cpp:435
+#: ../src/msw/dirdlg.cpp:287
 msgid "Couldn't obtain folder name"
 msgstr "无法获取文件夹名称"
 
-#: ../src/unix/sound_sdl.cpp:229
+#: ../src/unix/sound_sdl.cpp:226
 #, c-format
 msgid "Couldn't open audio: %s"
 msgstr "无法打开音频: %s"
 
-#: ../src/msw/ole/dataobj.cpp:377
+#: ../src/msw/ole/dataobj.cpp:385
 #, c-format
 msgid "Couldn't register clipboard format '%s'."
 msgstr "无法注册剪贴板格式 '%s'。"
 
-#: ../src/msw/listctrl.cpp:869
+#: ../src/msw/listctrl.cpp:933
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "无法获得列表控件的项 %d 信息。"
 
-#: ../src/common/imagpng.cpp:498 ../src/common/imagpng.cpp:509
-#: ../src/common/imagpng.cpp:519
+#: ../src/common/imagpng.cpp:511 ../src/common/imagpng.cpp:522
+#: ../src/common/imagpng.cpp:532
 msgid "Couldn't save PNG image."
 msgstr "无法保存 PNG 图像。"
 
-#: ../src/msw/thread.cpp:684
+#: ../src/msw/thread.cpp:676
 msgid "Couldn't terminate thread"
 msgstr "无法终止线程"
 
-#: ../src/common/xtistrm.cpp:166
+#: ../src/common/xtistrm.cpp:163
 #, c-format
 msgid "Create Parameter %s not found in declared RTTI Parameters"
 msgstr "在声明的 RTTI 参数里找不到创建参数 %s"
 
-#: ../src/generic/dirdlgg.cpp:288
+#: ../src/generic/dirdlgg.cpp:285
 msgid "Create directory"
 msgstr "创建目录"
 
-#: ../src/generic/filedlgg.cpp:212 ../src/generic/dirdlgg.cpp:111
+#: ../src/generic/filedlgg.cpp:209 ../src/generic/dirdlgg.cpp:108
 msgid "Create new directory"
 msgstr "创建新目录"
 
-#: ../src/xrc/xmlres.cpp:2460
+#: ../src/common/stockitem.cpp:264
+#, fuzzy
+msgid "Create new document"
+msgstr "创建新目录"
+
+#: ../src/xrc/xmlres.cpp:2515
 #, fuzzy, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "将 '%s' 解压至 '%s' 失败。"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1758
+#: ../src/propgrid/advprops.cpp:1659
 msgid "Cross"
 msgstr ""
 
-#: ../src/common/accelcmn.cpp:333
+#: ../src/common/accelcmn.cpp:347
 msgid "Ctrl+"
 msgstr "Ctrl+"
 
-#: ../src/richtext/richtextctrl.cpp:332 ../src/osx/textctrl_osx.cpp:576
-#: ../src/common/stockitem.cpp:151 ../src/msw/textctrl.cpp:2507
+#: ../src/osx/textctrl_osx.cpp:594 ../src/common/stockitem.cpp:148
+#: ../src/msw/textctrl.cpp:2772 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "剪切(&t)"
 
-#: ../src/generic/filectrlg.cpp:940
+#: ../src/generic/filectrlg.cpp:936
 msgid "Current directory:"
 msgstr "当前目录:"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:896 ../src/propgrid/advprops.cpp:1574
-#: ../src/propgrid/advprops.cpp:1612
+#: ../src/propgrid/advprops.cpp:797 ../src/propgrid/advprops.cpp:1475
+#: ../src/propgrid/advprops.cpp:1518
 #, fuzzy
 msgid "Custom"
 msgstr "自定义大小"
 
-#: ../src/gtk/print.cpp:217
+#: ../src/gtk/print.cpp:211
 msgid "Custom size"
 msgstr "自定义大小"
 
-#: ../src/common/headerctrlcmn.cpp:60
+#: ../src/common/headerctrlcmn.cpp:58
 msgid "Customize Columns"
 msgstr "自定义列"
 
-#: ../src/common/stockitem.cpp:151 ../src/stc/stc_i18n.cpp:17
+#: ../src/common/stockitem.cpp:148 ../src/stc/stc_i18n.cpp:17
 msgid "Cut"
 msgstr "剪切"
 
-#: ../src/common/stockitem.cpp:259
+#: ../src/common/stockitem.cpp:256
 msgid "Cut selection"
 msgstr "剪切选区"
 
-#: ../src/common/fmapbase.cpp:152
+#: ../src/common/fmapbase.cpp:149
 msgid "Cyrillic (ISO-8859-5)"
 msgstr "西里尔语 (ISO-8859-5)"
 
-#: ../src/common/paper.cpp:99
+#: ../src/common/paper.cpp:96
 msgid "D sheet, 22 x 34 in"
 msgstr "D 纸张, 22 x 34 英寸"
 
-#: ../src/msw/dde.cpp:703
+#: ../src/msw/dde.cpp:698
 msgid "DDE poke request failed"
 msgstr "DDE poke 请求失败"
 
-#: ../src/common/imagbmp.cpp:1169
+#: ../src/common/imagbmp.cpp:1181
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr "DIB头: 编码不匹配颜色位数。"
 
@@ -2595,7 +2599,7 @@ msgstr "DIB头: 文件中颜色位数未知。"
 msgid "DIB Header: Unknown encoding in file."
 msgstr "DIB头: 文件编码未知。"
 
-#: ../src/common/paper.cpp:121
+#: ../src/common/paper.cpp:118
 msgid "DL Envelope, 110 x 220 mm"
 msgstr "DL 信封, 110 x 220 毫米"
 
@@ -2603,55 +2607,55 @@ msgstr "DL 信封, 110 x 220 毫米"
 msgid "Dashed"
 msgstr ""
 
-#: ../src/generic/dbgrptg.cpp:300
+#: ../src/generic/dbgrptg.cpp:301
 #, c-format
 msgid "Debug report \"%s\""
 msgstr "调试报告 \"%s\""
 
-#: ../src/common/debugrpt.cpp:210
+#: ../src/common/debugrpt.cpp:211
 msgid "Debug report couldn't be created."
 msgstr "无法创建调试报告。"
 
-#: ../src/common/debugrpt.cpp:553
+#: ../src/common/debugrpt.cpp:554
 msgid "Debug report generation has failed."
 msgstr "无法生成调试报告。"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:84
+#: ../src/common/accelcmn.cpp:81
 msgid "Decimal"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:323
+#: ../src/generic/fontdlgg.cpp:319
 msgid "Decorative"
 msgstr "修饰"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1752
+#: ../src/propgrid/advprops.cpp:1653
 #, fuzzy
 msgid "Default"
 msgstr "缺省值"
 
-#: ../src/common/fmapbase.cpp:796
+#: ../src/common/fmapbase.cpp:792
 msgid "Default encoding"
 msgstr "缺省编码"
 
-#: ../src/dfb/fontmgr.cpp:180
+#: ../src/dfb/fontmgr.cpp:177
 msgid "Default font"
 msgstr "缺省字体"
 
-#: ../src/generic/prntdlgg.cpp:510
+#: ../src/generic/prntdlgg.cpp:503
 msgid "Default printer"
 msgstr "缺省的打印机"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:51
+#: ../src/common/accelcmn.cpp:48
 #, fuzzy
 msgid "Del"
 msgstr "删除"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextbuffer.cpp:8221 ../src/common/stockitem.cpp:152
-#: ../src/common/accelcmn.cpp:50 ../src/stc/stc_i18n.cpp:20
+#: ../src/common/stockitem.cpp:149 ../src/common/accelcmn.cpp:47
+#: ../src/richtext/richtextbuffer.cpp:8217 ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "删除"
 
@@ -2659,78 +2663,78 @@ msgstr "删除"
 msgid "Delete A&ll"
 msgstr "删除全部(&l)"
 
-#: ../src/richtext/richtextbuffer.cpp:11341
+#: ../src/richtext/richtextbuffer.cpp:11340
 msgid "Delete Column"
 msgstr "删除列"
 
-#: ../src/richtext/richtextbuffer.cpp:11291
+#: ../src/richtext/richtextbuffer.cpp:11290
 msgid "Delete Row"
 msgstr "删除行"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 msgid "Delete Style"
 msgstr "删除样式"
 
-#: ../src/richtext/richtextctrl.cpp:1345 ../src/richtext/richtextctrl.cpp:1584
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
 msgid "Delete Text"
 msgstr "删除文字"
 
-#: ../src/generic/editlbox.cpp:170
+#: ../src/generic/editlbox.cpp:147
 msgid "Delete item"
 msgstr "删除项"
 
-#: ../src/common/stockitem.cpp:260
+#: ../src/common/stockitem.cpp:257
 msgid "Delete selection"
 msgstr "删除选区"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 #, c-format
 msgid "Delete style %s?"
 msgstr "删除样式 %s?"
 
-#: ../src/unix/snglinst.cpp:301
+#: ../src/unix/snglinst.cpp:298
 #, c-format
 msgid "Deleted stale lock file '%s'."
 msgstr "已删除过期的锁文件 '%s'。"
 
-#: ../src/common/secretstore.cpp:220
+#: ../src/common/secretstore.cpp:234
 #, fuzzy, c-format
-msgid "Deleting password for \"%s/%s\" failed: %s."
+msgid "Deleting password for \"%s\" failed: %s."
 msgstr "将 '%s' 解压至 '%s' 失败。"
 
-#: ../src/common/module.cpp:124
+#: ../src/common/module.cpp:121
 #, c-format
 msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
 msgstr "依赖 \"%s\" 对模块 \"%s\" 不存在。"
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "Descending"
 msgstr "降序"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:526 ../src/propgrid/advprops.cpp:882
+#: ../src/generic/dirctrlg.cpp:492 ../src/propgrid/advprops.cpp:783
 msgid "Desktop"
 msgstr "桌面"
 
-#: ../src/generic/aboutdlgg.cpp:70
+#: ../src/generic/aboutdlgg.cpp:67
 msgid "Developed by "
 msgstr "开发由"
 
-#: ../src/generic/aboutdlgg.cpp:176
+#: ../src/generic/aboutdlgg.cpp:173
 msgid "Developers"
 msgstr "开发者"
 
-#: ../src/msw/dialup.cpp:374
+#: ../src/msw/dialup.cpp:368
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
 msgstr "由于远程访问服务(RAS)没有安装在本机，拨号功能无法使用。请安装它。"
 
-#: ../src/generic/tipdlg.cpp:211
+#: ../src/generic/tipdlg.cpp:208
 msgid "Did you know..."
 msgstr "你知道吗..."
 
-#: ../src/dfb/wrapdfb.cpp:63
+#: ../src/dfb/wrapdfb.cpp:60
 #, c-format
 msgid "DirectFB error %d occurred."
 msgstr "DirectFB错误 %d 发生。"
@@ -2739,73 +2743,73 @@ msgstr "DirectFB错误 %d 发生。"
 msgid "Directories"
 msgstr "目录"
 
-#: ../src/common/filefn.cpp:1183
+#: ../src/common/filefn.cpp:1071
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "无法创建目录 '%s'"
 
-#: ../src/common/filefn.cpp:1197
+#: ../src/common/filefn.cpp:1085
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "目录'%s'无法被删除"
 
-#: ../src/generic/dirdlgg.cpp:204
+#: ../src/generic/dirdlgg.cpp:201
 msgid "Directory does not exist"
 msgstr "目录不存在"
 
-#: ../src/generic/filectrlg.cpp:1399
+#: ../src/generic/filectrlg.cpp:1388
 msgid "Directory doesn't exist."
 msgstr "目录不存在。"
 
-#: ../src/common/docview.cpp:457
+#: ../src/common/docview.cpp:450
 msgid "Discard changes and reload the last saved version?"
 msgstr "放弃更改并重新载入最近保存的版本？"
 
-#: ../src/html/helpwnd.cpp:502
+#: ../src/html/helpwnd.cpp:500
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
 msgstr "显示包含给定子串的所有索引项. 搜索是大小写无关的."
 
-#: ../src/html/helpwnd.cpp:679
+#: ../src/html/helpwnd.cpp:677
 msgid "Display options dialog"
 msgstr "显示选项对话框"
 
-#: ../src/html/helpwnd.cpp:322
+#: ../src/html/helpwnd.cpp:320
 msgid "Displays help as you browse the books on the left."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:85
+#: ../src/common/accelcmn.cpp:83
 msgid "Divide"
 msgstr ""
 
-#: ../src/common/docview.cpp:533
+#: ../src/common/docview.cpp:526
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "你想保存对文档 %s 的修改吗?"
 
-#: ../src/common/prntbase.cpp:542
+#: ../src/common/prntbase.cpp:537
 msgid "Document:"
 msgstr "文档："
 
-#: ../src/generic/aboutdlgg.cpp:73
+#: ../src/generic/aboutdlgg.cpp:70
 msgid "Documentation by "
 msgstr "文档撰写由"
 
-#: ../src/generic/aboutdlgg.cpp:180
+#: ../src/generic/aboutdlgg.cpp:177
 msgid "Documentation writers"
 msgstr "文档作者"
 
-#: ../src/common/sizer.cpp:2799
+#: ../src/common/sizer.cpp:2916
 msgid "Don't Save"
 msgstr "不保存"
 
-#: ../src/html/htmlwin.cpp:633
+#: ../src/html/htmlwin.cpp:643
 msgid "Done"
 msgstr "完成"
 
-#: ../src/generic/progdlgg.cpp:448 ../src/msw/progdlg.cpp:407
+#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
 msgid "Done."
 msgstr "完成."
 
@@ -2819,42 +2823,42 @@ msgstr "完成"
 msgid "Double"
 msgstr "完成"
 
-#: ../src/common/paper.cpp:176
+#: ../src/common/paper.cpp:173
 msgid "Double Japanese Postcard Rotated 148 x 200 mm"
 msgstr "横向日本双明信片, 148 x 200 毫米"
 
-#: ../src/common/xtixml.cpp:273
+#: ../src/common/xtixml.cpp:269
 #, c-format
 msgid "Doubly used id : %d"
 msgstr "重复使用的id : %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:153
-#: ../src/common/accelcmn.cpp:64
+#: ../src/common/stockitem.cpp:150 ../src/common/accelcmn.cpp:61
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Down"
 msgstr "向下"
 
-#: ../src/richtext/richtextctrl.cpp:865
+#: ../src/richtext/richtextctrl.cpp:864
 msgid "Drag"
 msgstr "移动"
 
-#: ../src/common/paper.cpp:100
+#: ../src/common/paper.cpp:97
 msgid "E sheet, 34 x 44 in"
 msgstr "E 纸张，34 x 44 英寸"
 
-#: ../src/unix/fswatcher_inotify.cpp:561
+#: ../src/unix/fswatcher_inotify.cpp:558
 msgid "EOF while reading from inotify descriptor"
 msgstr "读取 inotify 描述符时遇到 EOF"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "Edit"
 msgstr "编辑"
 
-#: ../src/generic/editlbox.cpp:168
+#: ../src/generic/editlbox.cpp:131
 msgid "Edit item"
 msgstr "编辑项"
 
-#: ../include/wx/generic/progdlgg.h:84
+#: ../include/wx/generic/progdlgg.h:85
 msgid "Elapsed time:"
 msgstr "用时: "
 
@@ -2926,62 +2930,62 @@ msgid "Enables the shadow spread."
 msgstr "启用宽度值。"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:66
+#: ../src/common/accelcmn.cpp:63
 msgid "End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:55
+#: ../src/common/accelcmn.cpp:52
 #, fuzzy
 msgid "Enter"
 msgstr "打印机"
 
-#: ../src/richtext/richtextstyledlg.cpp:934
+#: ../src/richtext/richtextstyledlg.cpp:930
 msgid "Enter a box style name"
 msgstr "输入文字方块样式名称"
 
-#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:602
 msgid "Enter a character style name"
 msgstr "输入文字样式名称"
 
-#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:816
 msgid "Enter a list style name"
 msgstr "输入列表样式名称"
 
-#: ../src/richtext/richtextstyledlg.cpp:893
+#: ../src/richtext/richtextstyledlg.cpp:889
 msgid "Enter a new style name"
 msgstr "输入新样式名称"
 
-#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:650
 msgid "Enter a paragraph style name"
 msgstr "输入段落样式名称"
 
-#: ../src/generic/dbgrptg.cpp:174
+#: ../src/generic/dbgrptg.cpp:171
 #, c-format
 msgid "Enter command to open file \"%s\":"
 msgstr "输入命令以打开文件 \"%s\":"
 
-#: ../src/generic/helpext.cpp:459
+#: ../src/generic/helpext.cpp:457
 msgid "Entries found"
 msgstr "找到的条目"
 
-#: ../src/common/paper.cpp:142
+#: ../src/common/paper.cpp:139
 msgid "Envelope Invite 220 x 220 mm"
 msgstr "邀请信, 220 x 220 毫米"
 
-#: ../src/common/config.cpp:469
+#: ../src/common/config.cpp:465
 #, c-format
 msgid ""
 "Environment variables expansion failed: missing '%c' at position %u in '%s'."
 msgstr "环境变量扩展失败:  '%c' 没有出现在位置 %u / '%s'。"
 
-#: ../src/generic/filedlgg.cpp:357 ../src/generic/dirctrlg.cpp:570
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/dirctrlg.cpp:599
-#: ../src/generic/dirdlgg.cpp:323 ../src/generic/filectrlg.cpp:642
-#: ../src/generic/filectrlg.cpp:756 ../src/generic/filectrlg.cpp:770
-#: ../src/generic/filectrlg.cpp:786 ../src/generic/filectrlg.cpp:1368
-#: ../src/generic/filectrlg.cpp:1399 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/gtk1/fontdlg.cpp:74 ../src/generic/dirctrlg.cpp:536
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/dirctrlg.cpp:565
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1357 ../src/generic/filectrlg.cpp:1388
+#: ../src/generic/filedlgg.cpp:354 ../src/generic/dirdlgg.cpp:320
+#: ../src/gtk/filedlg.cpp:74
 msgid "Error"
 msgstr "错误"
 
@@ -2989,233 +2993,254 @@ msgstr "错误"
 msgid "Error closing epoll descriptor"
 msgstr "关闭 epoll 描述符时发生错误"
 
-#: ../src/unix/fswatcher_kqueue.cpp:114
+#: ../src/unix/fswatcher_kqueue.cpp:131
 msgid "Error closing kqueue instance"
 msgstr "关闭 kqueue 实例时发生错误"
 
-#: ../src/common/filefn.cpp:1049
+#: ../src/common/filefn.cpp:938
 #, fuzzy, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "无法复制文件 '%s' 至 '%s'"
 
-#: ../src/generic/dirdlgg.cpp:222
+#: ../src/generic/dirdlgg.cpp:219
 msgid "Error creating directory"
 msgstr "创建目录错误"
 
-#: ../src/common/imagbmp.cpp:1181
+#: ../src/common/imagbmp.cpp:1193
 msgid "Error in reading image DIB."
 msgstr "读取图像 DIB 错误。"
 
-#: ../src/propgrid/propgrid.cpp:6696
+#: ../src/propgrid/propgrid.cpp:6665
 #, c-format
 msgid "Error in resource: %s"
 msgstr "资源错误: %s"
 
-#: ../src/common/fileconf.cpp:422
+#: ../src/common/fileconf.cpp:421
 msgid "Error reading config options."
 msgstr "读配置选项错误。"
+
+#: ../src/msw/webview_ie.cpp:1057 ../src/msw/webview_edge.cpp:850
+#: ../src/gtk/webview_webkit2.cpp:1262 ../src/osx/webview_webkit.mm:383
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
 
 #: ../src/common/fileconf.cpp:1029
 msgid "Error saving user configuration data."
 msgstr "保存用户配置数据错误."
 
-#: ../src/gtk/print.cpp:722
+#: ../src/gtk/print.cpp:720
 msgid "Error while printing: "
 msgstr "打印时出错: "
 
-#: ../src/common/log.cpp:219
+#: ../src/common/log.cpp:237
 msgid "Error: "
 msgstr "错误: "
 
+#: ../src/common/webrequest.cpp:98
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "错误: "
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:69
+#: ../src/common/accelcmn.cpp:66
 msgid "Esc"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:70
+#: ../src/common/accelcmn.cpp:67
 #, fuzzy
 msgid "Escape"
 msgstr "横向"
 
-#: ../src/common/fmapbase.cpp:150
+#: ../src/common/fmapbase.cpp:147
 msgid "Esperanto (ISO-8859-3)"
 msgstr "世界语 (ISO-8859-3)"
 
-#: ../include/wx/generic/progdlgg.h:85
+#: ../include/wx/generic/progdlgg.h:86
 msgid "Estimated time:"
 msgstr "预期时间:"
 
-#: ../src/generic/dbgrptg.cpp:234
+#: ../src/generic/dbgrptg.cpp:231
 msgid "Executable files (*.exe)|*.exe|"
 msgstr "可执行文件 (*.exe)|*.exe|"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:155 ../src/common/accelcmn.cpp:78
+#: ../src/common/stockitem.cpp:152 ../src/common/accelcmn.cpp:75
 msgid "Execute"
 msgstr "执行"
 
-#: ../src/msw/utilsexc.cpp:876
+#: ../src/msw/utilsexc.cpp:873
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "命令 '%s' 执行失败"
 
-#: ../src/common/paper.cpp:105
+#: ../src/common/paper.cpp:102
 msgid "Executive, 7 1/4 x 10 1/2 in"
 msgstr "实用纸张(Executive), 7 1/4 x 10 1/2 英寸"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6009
+#: ../src/generic/datavgen.cpp:6814
 msgid "Expand"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1240
+#: ../src/msw/registry.cpp:1228
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
 msgstr "导出注册键: 文件 \"%s\"已经存在, 无法覆盖."
 
-#: ../src/common/fmapbase.cpp:195
+#: ../src/common/fmapbase.cpp:192
 msgid "Extended Unix Codepage for Japanese (EUC-JP)"
 msgstr "扩展的日本语Unix代码页 (EUC-JP)"
 
-#: ../src/html/chm.cpp:725
+#: ../src/html/chm.cpp:718
 #, c-format
 msgid "Extraction of '%s' into '%s' failed."
 msgstr "将 '%s' 解压至 '%s' 失败。"
 
-#: ../src/common/accelcmn.cpp:249 ../src/common/accelcmn.cpp:344
+#: ../src/common/accelcmn.cpp:259 ../src/common/accelcmn.cpp:358
 msgid "F"
 msgstr "F"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:672
+#: ../src/propgrid/advprops.cpp:582
 msgid "Face Name"
 msgstr "字体名称"
 
-#: ../src/unix/snglinst.cpp:269
+#: ../src/unix/snglinst.cpp:266
 msgid "Failed to access lock file."
 msgstr "无法访问锁文件。"
+
+#: ../src/gtk/font.cpp:572
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "无法从文件 \"%s\" 中读取文档。"
 
 #: ../src/unix/epolldispatcher.cpp:116
 #, c-format
 msgid "Failed to add descriptor %d to epoll descriptor %d"
 msgstr "无法将描述符 %d 加到 epoll 描述符 %d"
 
-#: ../src/msw/dib.cpp:489
+#: ../src/msw/dib.cpp:535
 #, c-format
 msgid "Failed to allocate %luKb of memory for bitmap data."
 msgstr "无法为位图数据分配 %luKb 内存。"
 
-#: ../src/common/glcmn.cpp:115
+#: ../src/common/glcmn.cpp:112
 msgid "Failed to allocate colour for OpenGL"
 msgstr "无法为 OpenGL 分配颜色"
 
-#: ../src/unix/displayx11.cpp:236
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "无法为 OpenGL 分配颜色"
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "无法为 OpenGL 分配颜色"
+
+#: ../include/wx/unix/private/displayx11.h:89
 msgid "Failed to change video mode"
 msgstr "无法改变视频模式。"
 
-#: ../src/common/image.cpp:3277
+#: ../src/common/image.cpp:3396
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "无法确认图像文件 \"%s\" 的格式。"
 
-#: ../src/common/debugrpt.cpp:239
+#: ../src/common/debugrpt.cpp:240
 #, c-format
 msgid "Failed to clean up debug report directory \"%s\""
 msgstr "无法清除调试报告目录 \"%s\""
 
-#: ../src/common/filename.cpp:192
+#: ../src/common/filename.cpp:189
 msgid "Failed to close file handle"
 msgstr "无法关闭文件句柄"
 
-#: ../src/unix/snglinst.cpp:340
+#: ../src/unix/snglinst.cpp:337
 #, c-format
 msgid "Failed to close lock file '%s'"
 msgstr "无法关闭锁文件 '%s'"
 
-#: ../src/msw/clipbrd.cpp:112
+#: ../src/msw/clipbrd.cpp:110
 msgid "Failed to close the clipboard."
 msgstr "无法关闭剪贴板。"
 
-#: ../src/x11/utils.cpp:208
+#: ../src/x11/utils.cpp:170
 #, c-format
 msgid "Failed to close the display \"%s\""
 msgstr "无法关闭显示 \"%s\""
 
-#: ../src/msw/dialup.cpp:797
+#: ../src/msw/dialup.cpp:791
 msgid "Failed to connect: missing username/password."
 msgstr "连接失败: 缺少用户名/口令。"
 
-#: ../src/msw/dialup.cpp:743
+#: ../src/msw/dialup.cpp:737
 msgid "Failed to connect: no ISP to dial."
 msgstr "连接失败: 没有要拨号的 ISP。"
 
-#: ../src/common/textfile.cpp:203
-#, c-format
-msgid "Failed to convert file \"%s\" to Unicode."
-msgstr "无法转换文件 \"%s\" 为 Unicode。"
-
-#: ../src/generic/logg.cpp:956
+#: ../src/generic/logg.cpp:953
 msgid "Failed to copy dialog contents to the clipboard."
 msgstr "无法将对话框内容复制到剪贴板。"
 
-#: ../src/msw/registry.cpp:692
+#: ../src/msw/registry.cpp:681
 #, c-format
 msgid "Failed to copy registry value '%s'"
 msgstr "无法复制注册键值 '%s'"
 
-#: ../src/msw/registry.cpp:701
+#: ../src/msw/registry.cpp:690
 #, c-format
 msgid "Failed to copy the contents of registry key '%s' to '%s'."
 msgstr "无法把注册键内容从 '%s' 复制到 '%s'。"
 
-#: ../src/common/filefn.cpp:1015
+#: ../src/common/filefn.cpp:904
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "无法复制文件 '%s' 至 '%s'"
 
-#: ../src/msw/registry.cpp:679
+#: ../src/msw/registry.cpp:668
 #, c-format
 msgid "Failed to copy the registry subkey '%s' to '%s'."
 msgstr "无法复制注册表子键 '%s' 至 '%s'。"
 
-#: ../src/msw/dde.cpp:1070
+#: ../src/msw/dde.cpp:1134
 msgid "Failed to create DDE string"
 msgstr "无法创建 DDE 字符串"
 
-#: ../src/msw/mdi.cpp:616
+#: ../src/msw/mdi.cpp:621
 msgid "Failed to create MDI parent frame."
 msgstr "无法创建 MDI 父框架。"
 
-#: ../src/common/filename.cpp:1027
+#: ../src/common/filename.cpp:1024
 msgid "Failed to create a temporary file name"
 msgstr "无法创建临时文件名"
 
-#: ../src/msw/utilsexc.cpp:228
+#: ../src/msw/utilsexc.cpp:225
 msgid "Failed to create an anonymous pipe"
 msgstr "无法创建匿名管道"
 
-#: ../src/msw/ole/automtn.cpp:522
+#: ../src/msw/ole/automtn.cpp:513
 #, c-format
 msgid "Failed to create an instance of \"%s\""
 msgstr "无法创建实例 \"%s\""
 
-#: ../src/msw/dde.cpp:437
+#: ../src/msw/dde.cpp:432
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "无法创建到服务器 '%s' 关于主题 '%s' 的连接"
 
-#: ../src/msw/cursor.cpp:204
+#: ../src/msw/cursor.cpp:195
 msgid "Failed to create cursor."
 msgstr "无法创建游标。"
 
-#: ../src/common/debugrpt.cpp:209
+#: ../src/common/debugrpt.cpp:210
 #, c-format
 msgid "Failed to create directory \"%s\""
 msgstr "无法创建目录 \"%s\""
 
-#: ../src/generic/dirdlgg.cpp:220
+#: ../src/generic/dirdlgg.cpp:217
 #, c-format
 msgid ""
 "Failed to create directory '%s'\n"
@@ -3228,184 +3253,203 @@ msgstr ""
 msgid "Failed to create epoll descriptor"
 msgstr "无法创建 epoll 描述符"
 
-#: ../src/msw/mimetype.cpp:238
+#: ../src/gtk/font.cpp:562
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "无法更新用户配置文件。"
+
+#: ../src/msw/mimetype.cpp:235
 #, c-format
 msgid "Failed to create registry entry for '%s' files."
 msgstr "无法为 '%s' 文件创建注册条目。"
 
-#: ../src/msw/fdrepdlg.cpp:409
+#: ../src/msw/fdrepdlg.cpp:408
 #, c-format
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr "无法创建标准 \"查找/替换\" 对话框 (错误号 %d)"
 
-#: ../src/unix/wakeuppipe.cpp:52
+#: ../src/unix/wakeuppipe.cpp:49
 msgid "Failed to create wake up pipe used by event loop."
 msgstr "无法创建被事件循环使用的唤醒管道。"
 
-#: ../src/html/winpars.cpp:730
+#: ../src/html/winpars.cpp:727
 #, c-format
 msgid "Failed to display HTML document in %s encoding"
 msgstr "无法按编码 %s 显示 HTML 文档"
 
-#: ../src/msw/clipbrd.cpp:124
+#: ../src/msw/clipbrd.cpp:122
 msgid "Failed to empty the clipboard."
 msgstr "无法清空剪贴板"
 
-#: ../src/unix/displayx11.cpp:212
+#: ../include/wx/unix/private/displayx11.h:65
 msgid "Failed to enumerate video modes"
 msgstr "无法枚举视频模式"
 
-#: ../src/msw/dde.cpp:722
+#: ../src/msw/dde.cpp:717
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "无法在 DDE 服务器建立 advise 循环"
 
-#: ../src/msw/dialup.cpp:629 ../src/msw/dialup.cpp:863
+#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "无法建立拨号连接: %s"
 
-#: ../src/unix/utilsunx.cpp:611
+#: ../src/unix/utilsunx.cpp:613
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "无法执行 '%s'\n"
 
-#: ../src/common/debugrpt.cpp:720
+#: ../src/common/debugrpt.cpp:730
 msgid "Failed to execute curl, please install it in PATH."
 msgstr "无法执行curl，请在PATH变量所指的目录中安装curl。"
 
-#: ../src/msw/ole/automtn.cpp:505
+#: ../src/msw/ole/automtn.cpp:496
 #, c-format
 msgid "Failed to find CLSID of \"%s\""
 msgstr "无法找到 \"%s\" 的 CLSID"
 
-#: ../src/common/regex.cpp:431 ../src/common/regex.cpp:479
+#: ../src/common/regex.cpp:428 ../src/common/regex.cpp:476
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "无法找到匹配的正则表达式: %s"
 
-#: ../src/msw/dialup.cpp:695
+#: ../src/msw/webview_ie.cpp:978
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:689
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "无法获取 ISP 名称: %s"
 
-#: ../src/msw/ole/automtn.cpp:574
+#: ../src/msw/ole/automtn.cpp:565
 #, c-format
 msgid "Failed to get OLE automation interface for \"%s\""
 msgstr "无法获取 OLE 自动化接口 \"%s\""
 
-#: ../src/msw/clipbrd.cpp:711
+#: ../src/msw/clipbrd.cpp:731
 msgid "Failed to get data from the clipboard"
 msgstr "无法从剪贴板获取数据"
 
-#: ../src/common/time.cpp:223
+#: ../src/common/time.cpp:216
 msgid "Failed to get the local system time"
 msgstr "无法获取本地系统时间"
 
-#: ../src/common/filefn.cpp:1345
+#: ../src/common/filefn.cpp:1233
 msgid "Failed to get the working directory"
 msgstr "无法获取工作目录"
 
-#: ../src/univ/theme.cpp:114
+#: ../src/univ/theme.cpp:111
 msgid "Failed to initialize GUI: no built-in themes found."
 msgstr "无法初始化 GUI: 找不到内嵌的主题。"
 
-#: ../src/msw/helpchm.cpp:63
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:60
 msgid "Failed to initialize MS HTML Help."
 msgstr "无法初始化 MS HTML 帮助。"
 
-#: ../src/msw/glcanvas.cpp:1381
+#: ../src/msw/glcanvas.cpp:1391
 msgid "Failed to initialize OpenGL"
 msgstr "无法初始化 OpenGL"
 
-#: ../src/msw/dialup.cpp:858
+#: ../src/msw/dialup.cpp:852
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "无法初始化拨号连接: %s"
 
-#: ../src/gtk/textctrl.cpp:1128
+#: ../src/gtk/textctrl.cpp:1209
 msgid "Failed to insert text in the control."
 msgstr "无法在控件中插入文字。"
 
-#: ../src/unix/snglinst.cpp:241
+#: ../src/unix/snglinst.cpp:238
 #, c-format
 msgid "Failed to inspect the lock file '%s'"
 msgstr "无法检查锁文件 '%s'"
 
-#: ../src/unix/appunix.cpp:182
+#: ../src/unix/appunix.cpp:179
 msgid "Failed to install signal handler"
 msgstr "无法安装信号句柄"
 
-#: ../src/unix/threadpsx.cpp:1167
+#: ../src/unix/threadpsx.cpp:1216
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
 msgstr "无法合并线程，检测到潜在地内存丢失 - 请重新启动系统"
 
-#: ../src/msw/utils.cpp:629
+#: ../src/msw/utils.cpp:619
 #, c-format
 msgid "Failed to kill process %d"
 msgstr "无法终止进程 %d"
 
-#: ../src/common/image.cpp:2500
+#: ../src/common/image.cpp:2595
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "无法从资源中载入图像 \"%s\"。"
 
-#: ../src/common/image.cpp:2509
+#: ../src/common/image.cpp:2604
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "无法从资源中载入图标 \"%s\"。"
 
-#: ../src/common/iconbndl.cpp:225
+#: ../src/common/iconbndl.cpp:224
 #, fuzzy, c-format
 msgid "Failed to load icons from resource '%s'."
 msgstr "无法从资源中载入图标 \"%s\"。"
 
-#: ../src/common/iconbndl.cpp:200
+#: ../src/common/iconbndl.cpp:198
 #, c-format
 msgid "Failed to load image %%d from file '%s'."
 msgstr "无法从文件 '%s' 中读取图像 %%d。"
 
-#: ../src/common/iconbndl.cpp:208
+#: ../src/common/iconbndl.cpp:206
 #, c-format
 msgid "Failed to load image %d from stream."
 msgstr "无法从数据流中载入图像 %d。"
 
-#: ../src/common/image.cpp:2587 ../src/common/image.cpp:2606
+#: ../src/common/image.cpp:2682 ../src/common/image.cpp:2701
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "无法从文件 \"%s\" 中读取图像。"
 
-#: ../src/msw/enhmeta.cpp:97
+#: ../src/msw/enhmeta.cpp:94
 #, c-format
 msgid "Failed to load metafile from file \"%s\"."
 msgstr "无法从文件 \"%s\" 读取元文件。"
 
-#: ../src/msw/volume.cpp:327
+#: ../src/msw/volume.cpp:335
 msgid "Failed to load mpr.dll."
 msgstr "无法装载 mpr.dll。"
 
-#: ../src/msw/utils.cpp:953
+#: ../src/msw/utils.cpp:943
 #, c-format
 msgid "Failed to load resource \"%s\"."
 msgstr "无法载入资源 \"%s\"。"
 
-#: ../src/common/dynlib.cpp:92
+#: ../src/common/dynlib.cpp:86
 #, c-format
 msgid "Failed to load shared library '%s'"
 msgstr "无法装载共享库 '%s'"
 
-#: ../src/osx/core/sound.cpp:145
+#: ../src/osx/core/sound.cpp:143
 #, fuzzy, c-format
 msgid "Failed to load sound from \"%s\" (error %d)."
 msgstr "无法载入资源 \"%s\"。"
 
-#: ../src/msw/utils.cpp:960
+#: ../src/msw/utils.cpp:950
 #, c-format
 msgid "Failed to lock resource \"%s\"."
 msgstr "无法锁定资源 \"%s\"。"
 
-#: ../src/unix/snglinst.cpp:198
+#: ../src/unix/snglinst.cpp:195
 #, c-format
 msgid "Failed to lock the lock file '%s'"
 msgstr "无法锁定锁文件 '%s'"
@@ -3415,33 +3459,38 @@ msgstr "无法锁定锁文件 '%s'"
 msgid "Failed to modify descriptor %d in epoll descriptor %d"
 msgstr "无法修改描述符 %d (于epoll描述符 %d)"
 
-#: ../src/common/filename.cpp:2575
+#: ../src/common/filename.cpp:2658
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "无法为 '%s' 修改文件时间"
 
-#: ../src/common/selectdispatcher.cpp:258
+#: ../src/common/selectdispatcher.cpp:255
 msgid "Failed to monitor I/O channels"
 msgstr "无法检测I/O通道"
 
-#: ../src/common/filename.cpp:175
+#: ../src/common/filename.cpp:172
 #, c-format
 msgid "Failed to open '%s' for reading"
 msgstr "无法读取文件 '%s'"
 
-#: ../src/common/filename.cpp:180
+#: ../src/common/filename.cpp:177
 #, c-format
 msgid "Failed to open '%s' for writing"
 msgstr "无法写入文件 '%s'"
 
-#: ../src/html/chm.cpp:141
+#: ../src/html/chm.cpp:138
 #, c-format
 msgid "Failed to open CHM archive '%s'."
 msgstr "无法打开 CHM 存档 '%s'。"
 
-#: ../src/common/utilscmn.cpp:1126
+#: ../src/common/utilscmn.cpp:1140
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
+msgstr "无法在默认浏览器中打开 URL \"%s\"。"
+
+#: ../src/common/hyperlnkcmn.cpp:133
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "无法在默认浏览器中打开 URL \"%s\"。"
 
 #: ../include/wx/msw/private/fswatcher.h:92
@@ -3449,208 +3498,227 @@ msgstr "无法在默认浏览器中打开 URL \"%s\"。"
 msgid "Failed to open directory \"%s\" for monitoring."
 msgstr "无法打开监控目录 \"%s\"。"
 
-#: ../src/x11/utils.cpp:227
+#: ../src/x11/utils.cpp:189
 #, c-format
 msgid "Failed to open display \"%s\"."
 msgstr "无法打开显示设备 \"%s\"。"
 
-#: ../src/common/filename.cpp:1062
+#: ../src/common/filename.cpp:1059
 msgid "Failed to open temporary file."
 msgstr "无法打开临时文件。"
 
-#: ../src/msw/clipbrd.cpp:91
+#: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "无法打开剪贴板。"
 
-#: ../src/common/translation.cpp:1184
+#: ../src/common/translation.cpp:1226
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "无法解析复数形式: '%s'"
 
-#: ../src/unix/mediactrl.cpp:1214
+#: ../src/unix/mediactrl.cpp:1239
 #, fuzzy, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "打开 '%s'(为 %s) 失败"
 
-#: ../src/msw/clipbrd.cpp:600
+#: ../src/msw/clipbrd.cpp:610
 msgid "Failed to put data on the clipboard"
 msgstr "无法把数据放到剪贴板"
 
-#: ../src/unix/snglinst.cpp:278
+#: ../src/unix/snglinst.cpp:275
 msgid "Failed to read PID from lock file."
 msgstr "无法从锁文件读取 PID。"
 
-#: ../src/common/fileconf.cpp:433
+#: ../src/common/fileconf.cpp:432
 msgid "Failed to read config options."
 msgstr "无法读配置选项。"
 
-#: ../src/common/docview.cpp:681
+#: ../src/common/docview.cpp:676
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "无法从文件 \"%s\" 中读取文档。"
 
-#: ../src/dfb/evtloop.cpp:98
+#: ../src/dfb/evtloop.cpp:99
 msgid "Failed to read event from DirectFB pipe"
 msgstr "无法从 DirectFB 管道中读取事件"
 
-#: ../src/unix/wakeuppipe.cpp:120
+#: ../src/unix/wakeuppipe.cpp:117
 msgid "Failed to read from wake-up pipe"
 msgstr "无法读取唤醒管道。"
 
-#: ../src/unix/utilsunx.cpp:679
+#: ../src/common/textfile.cpp:96
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "无法从文件 \"%s\" 中读取文档。"
+
+#: ../src/unix/utilsunx.cpp:681
 msgid "Failed to redirect child process input/output"
 msgstr "无法重定向子过程输入/输出"
 
-#: ../src/msw/utilsexc.cpp:701
+#: ../src/msw/utilsexc.cpp:698
 msgid "Failed to redirect the child process IO"
 msgstr "无法重定向子过程 IO"
 
-#: ../src/msw/dde.cpp:288
+#: ../src/msw/dde.cpp:283
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "无法注册 DDE 服务器 '%s'"
 
-#: ../src/common/fontmap.cpp:245
+#: ../src/gtk/font.cpp:580
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "无法更新用户配置文件。"
+
+#: ../src/common/fontmap.cpp:242
 #, c-format
 msgid "Failed to remember the encoding for the charset '%s'."
 msgstr "无法记忆字符集 '%s' 的编码。"
 
-#: ../src/common/debugrpt.cpp:227
+#: ../src/common/debugrpt.cpp:228
 #, c-format
 msgid "Failed to remove debug report file \"%s\""
 msgstr "无法删除调试报告文件 \"%s\""
 
-#: ../src/unix/snglinst.cpp:328
+#: ../src/unix/snglinst.cpp:325
 #, c-format
 msgid "Failed to remove lock file '%s'"
 msgstr "无法删除锁文件 '%s'"
 
-#: ../src/unix/snglinst.cpp:288
+#: ../src/unix/snglinst.cpp:285
 #, c-format
 msgid "Failed to remove stale lock file '%s'."
 msgstr "无法删除过期的锁文件 '%s'。"
 
-#: ../src/msw/registry.cpp:529
+#: ../src/msw/registry.cpp:518
 #, c-format
 msgid "Failed to rename registry value '%s' to '%s'."
 msgstr "无法将注册值 '%s' 重命名为 '%s'。"
 
-#: ../src/common/filefn.cpp:1122
+#: ../src/common/filefn.cpp:1011
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
 "exists."
 msgstr "无法将文件'%s' 重命名为 '%s'，因为目标文件已存在。"
 
-#: ../src/msw/registry.cpp:634
+#: ../src/msw/registry.cpp:623
 #, c-format
 msgid "Failed to rename the registry key '%s' to '%s'."
 msgstr "无法将注册键 '%s' 重命名为 '%s'。"
 
-#: ../src/common/filename.cpp:2671
+#: ../src/msw/webview_ie.cpp:995
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/common/filename.cpp:2754
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "无法提取 '%s' 文件时间"
 
-#: ../src/msw/dialup.cpp:468
+#: ../src/msw/dialup.cpp:462
 msgid "Failed to retrieve text of RAS error message"
 msgstr "无法提取 RAS 错误消息正文"
 
-#: ../src/msw/clipbrd.cpp:748
+#: ../src/msw/clipbrd.cpp:768
 msgid "Failed to retrieve the supported clipboard formats"
 msgstr "无法提取支持的剪贴板格式"
 
-#: ../src/common/docview.cpp:652
+#: ../src/common/docview.cpp:647
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "无法将文档保存至文件 \"%s\"。"
 
-#: ../src/msw/dib.cpp:269
+#: ../src/msw/dib.cpp:312
 #, c-format
 msgid "Failed to save the bitmap image to file \"%s\"."
 msgstr "无法将位图图像保存至文件 \"%s\"。"
 
-#: ../src/msw/dde.cpp:763
+#: ../src/msw/dde.cpp:811
 msgid "Failed to send DDE advise notification"
 msgstr "无法发送 DDE advise 通知"
 
-#: ../src/common/ftp.cpp:402
+#: ../src/common/ftp.cpp:399
 #, c-format
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "无法设置 FTP 传输模式为 %s。"
 
-#: ../src/msw/clipbrd.cpp:427
+#: ../src/msw/clipbrd.cpp:443
 msgid "Failed to set clipboard data."
 msgstr "无法设置剪贴板数据。"
 
-#: ../src/unix/snglinst.cpp:181
+#: ../src/unix/snglinst.cpp:178
 #, c-format
 msgid "Failed to set permissions on lock file '%s'"
 msgstr "无法在锁文件 '%s' 上设置许可权限"
 
-#: ../src/unix/utilsunx.cpp:668
+#: ../src/unix/utilsunx.cpp:670
 msgid "Failed to set process priority"
 msgstr "无法设置线程优先级"
 
-#: ../src/common/file.cpp:559
+#: ../src/common/ffile.cpp:355 ../src/common/file.cpp:586
 msgid "Failed to set temporary file permissions"
 msgstr "无法设置临时文件的许可权限"
 
-#: ../src/gtk/textctrl.cpp:1072
-msgid "Failed to set text in the text control."
-msgstr "无法设置文本编辑器控件的文字。"
-
-#: ../src/unix/threadpsx.cpp:1298
+#: ../src/unix/threadpsx.cpp:1347
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "无法设置线程并发级别至 %lu"
 
-#: ../src/unix/threadpsx.cpp:1424
+#: ../src/unix/threadpsx.cpp:1473
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "无法设置线程优先级 %d。"
 
-#: ../src/unix/utilsunx.cpp:783
+#: ../src/unix/utilsunx.cpp:785
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr "无法设置非闭塞通道，程序可能挂起。"
 
-#: ../src/common/fs_mem.cpp:261
+#: ../src/msw/webview_ie.cpp:987
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:256
 #, c-format
 msgid "Failed to store image '%s' to memory VFS!"
 msgstr "无法将图像 '%s' 存到内存 VFS！"
 
-#: ../src/dfb/evtloop.cpp:170
+#: ../src/dfb/evtloop.cpp:171
 msgid "Failed to switch DirectFB pipe to non-blocking mode"
 msgstr "无法将DirectFB通道切换至非闭塞模式"
 
-#: ../src/unix/wakeuppipe.cpp:59
+#: ../src/unix/wakeuppipe.cpp:56
 msgid "Failed to switch wake up pipe to non-blocking mode"
 msgstr "无法将唤醒管道切换至非闭塞模式"
 
-#: ../src/unix/threadpsx.cpp:1605
+#: ../src/unix/threadpsx.cpp:1654
 msgid "Failed to terminate a thread."
 msgstr "无法终止线程。"
 
-#: ../src/msw/dde.cpp:741
+#: ../src/msw/dde.cpp:736
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "无法终止与 DDE 服务器的 advise 循环"
 
-#: ../src/msw/dialup.cpp:938
+#: ../src/msw/dialup.cpp:932
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "无法终止拨号连接: %s"
 
-#: ../src/common/filename.cpp:2590
+#: ../src/common/filename.cpp:2673
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "对文件 '%s' 进行 touch 操作时失败"
 
-#: ../src/unix/snglinst.cpp:334
+#: ../src/unix/dlunix.cpp:90
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "无法装载共享库 '%s'"
+
+#: ../src/unix/snglinst.cpp:331
 #, c-format
 msgid "Failed to unlock lock file '%s'"
 msgstr "无法对已锁文件 '%s' 解锁"
 
-#: ../src/msw/dde.cpp:309
+#: ../src/msw/dde.cpp:304
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "无法撤消 DDE 服务器 '%s' 的注册"
@@ -3664,78 +3732,88 @@ msgstr "无法注销描述符 %d 位于 epoll 描述符 %d"
 msgid "Failed to update user configuration file."
 msgstr "无法更新用户配置文件。"
 
-#: ../src/common/debugrpt.cpp:733
+#: ../src/common/debugrpt.cpp:743
 #, c-format
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "无法上传调试报告 (错误号 %d)。"
 
-#: ../src/unix/snglinst.cpp:168
+#: ../src/unix/snglinst.cpp:165
 #, c-format
 msgid "Failed to write to lock file '%s'"
 msgstr "无法写入锁文件 '%s'"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:209
+#: ../src/propgrid/propgrid.cpp:190
 msgid "False"
 msgstr "False"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:694
+#: ../src/propgrid/advprops.cpp:604
 #, fuzzy
 msgid "Family"
 msgstr "字体(&F):"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/gtk/glcanvas.cpp:176 ../src/gtk/glcanvas.cpp:187
+#, fuzzy
+msgid "Fatal Error"
+msgstr "致命错误"
+
+#: ../src/common/stockitem.cpp:154
 msgid "File"
 msgstr "文件"
 
-#: ../src/common/docview.cpp:669
+#: ../src/common/docview.cpp:664
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "文件 \"%s\" 无法开启为读取模式。"
 
-#: ../src/common/docview.cpp:646
+#: ../src/common/docview.cpp:641
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "文件 \"%s\" 无法开启为写入模式。"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "文件 '%s' 已存在，确实需要复写它?"
 
-#: ../src/common/filefn.cpp:1156
+#: ../src/common/filefn.cpp:1044
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "文件 '%s' 无法被移除"
 
-#: ../src/common/filefn.cpp:1139
+#: ../src/common/filefn.cpp:1028
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "文件 '%s' 无法重命名为 '%s'"
 
-#: ../src/richtext/richtextctrl.cpp:3081 ../src/common/textcmn.cpp:953
+#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
 msgid "File couldn't be loaded."
 msgstr "文件无法装载。"
 
-#: ../src/msw/filedlg.cpp:393
+#: ../src/msw/filedlg.cpp:414
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "文件对话框错误，错误码：%0lx。"
 
-#: ../src/common/docview.cpp:1789
+#: ../src/common/docview.cpp:1783
 msgid "File error"
 msgstr "文件错误"
 
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/filectrlg.cpp:770
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/filectrlg.cpp:766
 msgid "File name exists already."
 msgstr "文件名已存在。"
+
+#: ../src/osx/cocoa/filedlg.mm:264
+#, fuzzy
+msgid "File type:"
+msgstr "电传打字机"
 
 #: ../src/motif/filedlg.cpp:220
 msgid "Files"
 msgstr "文件"
 
-#: ../src/common/filefn.cpp:1591
+#: ../src/common/filefn.cpp:1479
 #, c-format
 msgid "Files (%s)"
 msgstr "文件 (%s)"
@@ -3744,15 +3822,29 @@ msgstr "文件 (%s)"
 msgid "Filter"
 msgstr "过滤器"
 
-#: ../src/common/stockitem.cpp:158 ../src/html/helpwnd.cpp:490
+#: ../src/html/helpwnd.cpp:488
 msgid "Find"
 msgstr "查找"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:259
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:258
+#, fuzzy
+msgid "Find in document"
+msgstr "打开HTML文档"
+
+#: ../src/common/stockitem.cpp:155
+#, fuzzy
+msgid "Find..."
+msgstr "查找"
+
+#: ../src/common/stockitem.cpp:156
 msgid "First"
 msgstr "最前"
 
-#: ../src/common/prntbase.cpp:1548
+#: ../src/common/prntbase.cpp:1573
 msgid "First page"
 msgstr "第一页"
 
@@ -3760,11 +3852,11 @@ msgstr "第一页"
 msgid "Fixed"
 msgstr "固定"
 
-#: ../src/html/helpwnd.cpp:1206
+#: ../src/html/helpwnd.cpp:1204
 msgid "Fixed font:"
 msgstr "固定字体:"
 
-#: ../src/html/helpwnd.cpp:1269
+#: ../src/html/helpwnd.cpp:1267
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "固定字体. <br> <b>粗体</b> <i>斜体</i> "
 
@@ -3772,16 +3864,16 @@ msgstr "固定字体. <br> <b>粗体</b> <i>斜体</i> "
 msgid "Floating"
 msgstr "浮动"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "Floppy"
 msgstr "软盘"
 
-#: ../src/common/paper.cpp:111
+#: ../src/common/paper.cpp:108
 msgid "Folio, 8 1/2 x 13 in"
 msgstr "对开纸, 8 1/2 x 13 英寸"
 
-#: ../src/richtext/richtextformatdlg.cpp:344 ../src/osx/carbon/fontdlg.cpp:287
-#: ../src/common/stockitem.cpp:194
+#: ../src/osx/carbon/fontdlg.cpp:284 ../src/common/stockitem.cpp:191
+#: ../src/richtext/richtextformatdlg.cpp:337
 msgid "Font"
 msgstr "字体"
 
@@ -3789,7 +3881,24 @@ msgstr "字体"
 msgid "Font &weight:"
 msgstr "字体粗细(&w):"
 
-#: ../src/html/helpwnd.cpp:1207
+#: ../src/osx/fontutil.cpp:89
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
+"\"."
+msgstr ""
+
+#: ../src/msw/font.cpp:1126
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "文件无法装载。"
+
+#: ../src/osx/fontutil.cpp:81
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "文件 %s 不存在。"
+
+#: ../src/html/helpwnd.cpp:1205
 msgid "Font size:"
 msgstr "字体大小:"
 
@@ -3797,75 +3906,75 @@ msgstr "字体大小:"
 msgid "Font st&yle:"
 msgstr "字体样式 (&y):"
 
-#: ../src/osx/carbon/fontdlg.cpp:329
+#: ../src/osx/carbon/fontdlg.cpp:326
 msgid "Font:"
 msgstr "字体:"
 
-#: ../src/dfb/fontmgr.cpp:198
+#: ../src/dfb/fontmgr.cpp:195
 #, c-format
 msgid "Fonts index file %s disappeared while loading fonts."
 msgstr "字体索引文件 %s 载入字体时丢失。"
 
-#: ../src/unix/utilsunx.cpp:645
+#: ../src/unix/utilsunx.cpp:647
 msgid "Fork failed"
 msgstr "Fork 失败"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "Forward"
 msgstr "前进"
 
-#: ../src/common/xtixml.cpp:235
+#: ../src/common/xtixml.cpp:231
 msgid "Forward hrefs are not supported"
 msgstr "不支持传递hrefs"
 
-#: ../src/html/helpwnd.cpp:875
+#: ../src/html/helpwnd.cpp:873
 #, c-format
 msgid "Found %i matches"
 msgstr "找到 %i 个匹配项"
 
-#: ../src/generic/prntdlgg.cpp:238
+#: ../src/generic/prntdlgg.cpp:231
 msgid "From:"
 msgstr "从:"
 
-#: ../src/propgrid/advprops.cpp:1604
+#: ../src/propgrid/advprops.cpp:1510
 msgid "Fuchsia"
 msgstr ""
 
-#: ../src/common/imaggif.cpp:138
+#: ../src/common/imaggif.cpp:135
 msgid "GIF: data stream seems to be truncated."
 msgstr "GIF: 数据流似乎已被截断。"
 
-#: ../src/common/imaggif.cpp:128
+#: ../src/common/imaggif.cpp:125
 msgid "GIF: error in GIF image format."
 msgstr "GIF: GIF文件格式错误。"
 
-#: ../src/common/imaggif.cpp:133
+#: ../src/common/imaggif.cpp:130
 msgid "GIF: not enough memory."
 msgstr "GIF: 没有足够内存。"
 
-#: ../src/gtk/window.cpp:4631
+#: ../src/gtk/window.cpp:5635
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
 msgstr "本机安装的GTK+版本过低，不支持屏幕组合，请安装GTK+2.12或者更新版本。"
 
-#: ../src/univ/themes/gtk.cpp:525
+#: ../src/univ/themes/gtk.cpp:522
 msgid "GTK+ theme"
 msgstr "GTK+ 主题"
 
-#: ../src/common/preferencescmn.cpp:40
+#: ../src/common/preferencescmn.cpp:37
 msgid "General"
 msgstr "通用"
 
-#: ../src/common/prntbase.cpp:258
+#: ../src/common/prntbase.cpp:253
 msgid "Generic PostScript"
 msgstr "普通PostScript"
 
-#: ../src/common/paper.cpp:135
+#: ../src/common/paper.cpp:132
 msgid "German Legal Fanfold, 8 1/2 x 13 in"
 msgstr "德国法定复写簿, 8 1/2 x 13 英寸"
 
-#: ../src/common/paper.cpp:134
+#: ../src/common/paper.cpp:131
 msgid "German Std Fanfold, 8 1/2 x 12 in"
 msgstr "德国标准复写簿, 8 1/2 x 12 英寸"
 
@@ -3881,49 +3990,49 @@ msgstr "在一个通用处理器上调用GetPropertyCollection"
 msgid "GetPropertyCollection called w/o valid collection getter"
 msgstr "调用GetPropertyCollection时未带有效的collection getter"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:658
 msgid "Go back"
 msgstr "返回"
 
-#: ../src/html/helpwnd.cpp:661
+#: ../src/html/helpwnd.cpp:659
 msgid "Go forward"
 msgstr "前进"
 
-#: ../src/html/helpwnd.cpp:663
+#: ../src/html/helpwnd.cpp:661
 msgid "Go one level up in document hierarchy"
 msgstr "到上一级文档目录"
 
-#: ../src/generic/filedlgg.cpp:208 ../src/generic/dirdlgg.cpp:116
+#: ../src/generic/filedlgg.cpp:205 ../src/generic/dirdlgg.cpp:113
 msgid "Go to home directory"
 msgstr "进入 home 目录"
 
-#: ../src/generic/filedlgg.cpp:205
+#: ../src/generic/filedlgg.cpp:202
 msgid "Go to parent directory"
 msgstr "进入父目录"
 
-#: ../src/generic/aboutdlgg.cpp:76
+#: ../src/generic/aboutdlgg.cpp:73
 msgid "Graphics art by "
 msgstr "图形艺术设计由 "
 
-#: ../src/propgrid/advprops.cpp:1599
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Gray"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:883
+#: ../src/propgrid/advprops.cpp:784
 msgid "GrayText"
 msgstr ""
 
-#: ../src/common/fmapbase.cpp:154
+#: ../src/common/fmapbase.cpp:151
 msgid "Greek (ISO-8859-7)"
 msgstr "希腊语 (ISO-8859-7)"
 
-#: ../src/propgrid/advprops.cpp:1600
+#: ../src/propgrid/advprops.cpp:1506
 #, fuzzy
 msgid "Green"
 msgstr "MacGreek"
 
-#: ../src/generic/colrdlgg.cpp:342
+#: ../src/generic/colrdlgg.cpp:362
 #, fuzzy
 msgid "Green:"
 msgstr "MacGreek"
@@ -3932,109 +4041,109 @@ msgstr "MacGreek"
 msgid "Groove"
 msgstr ""
 
-#: ../src/common/zstream.cpp:158 ../src/common/zstream.cpp:318
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
 msgid "Gzip not supported by this version of zlib"
 msgstr "此版本的 zlib 不支持 Gzip"
 
-#: ../src/html/helpwnd.cpp:1549
+#: ../src/html/helpwnd.cpp:1547
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "HTML 帮助的工程文件 (*.hhp)|*.hhp|"
 
-#: ../src/html/htmlwin.cpp:681
+#: ../src/html/htmlwin.cpp:691
 #, c-format
 msgid "HTML anchor %s does not exist."
 msgstr "HTML 锚 %s 不存在。"
 
-#: ../src/html/helpwnd.cpp:1547
+#: ../src/html/helpwnd.cpp:1545
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "HTML文件 (*.html;*.htm)|*.html;*.htm|"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1759
+#: ../src/propgrid/advprops.cpp:1660
 msgid "Hand"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "Harddisk"
 msgstr "磁盘"
 
-#: ../src/common/fmapbase.cpp:155
+#: ../src/common/fmapbase.cpp:152
 msgid "Hebrew (ISO-8859-8)"
 msgstr "希伯来语 (ISO-8859-8)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:280 ../src/osx/button_osx.cpp:39
-#: ../src/common/stockitem.cpp:163 ../src/common/accelcmn.cpp:80
-#: ../src/html/helpdlg.cpp:66 ../src/html/helpfrm.cpp:111
+#: ../include/wx/msgdlg.h:282 ../src/osx/button_osx.cpp:39
+#: ../src/common/stockitem.cpp:160 ../src/common/accelcmn.cpp:77
+#: ../src/html/helpfrm.cpp:108 ../src/html/helpdlg.cpp:63
 msgid "Help"
 msgstr "帮助"
 
-#: ../src/html/helpwnd.cpp:1200
+#: ../src/html/helpwnd.cpp:1198
 msgid "Help Browser Options"
 msgstr "帮助浏览器选项"
 
-#: ../src/generic/helpext.cpp:454 ../src/generic/helpext.cpp:455
+#: ../src/generic/helpext.cpp:452 ../src/generic/helpext.cpp:453
 msgid "Help Index"
 msgstr "帮助索引"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1529
 msgid "Help Printing"
 msgstr "帮助打印"
 
-#: ../src/html/helpwnd.cpp:801
+#: ../src/html/helpwnd.cpp:799
 msgid "Help Topics"
 msgstr "帮助主题"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1546
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "帮助书 (*.htb)|*.htb|帮助书 (*.zip)|*.zip|"
 
-#: ../src/generic/helpext.cpp:267
+#: ../src/generic/helpext.cpp:265
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "找不到帮助目录 \"%s\"。"
 
-#: ../src/generic/helpext.cpp:275
+#: ../src/generic/helpext.cpp:273
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "找不到帮助文件 \"%s\"。"
 
-#: ../src/html/helpctrl.cpp:63
+#: ../src/html/helpctrl.cpp:59
 #, c-format
 msgid "Help: %s"
 msgstr "帮助: %s"
 
-#: ../src/osx/menu_osx.cpp:577
+#: ../src/osx/menu_osx.cpp:469
 #, c-format
 msgid "Hide %s"
 msgstr "隐藏 %s"
 
-#: ../src/osx/menu_osx.cpp:579
+#: ../src/osx/menu_osx.cpp:471
 msgid "Hide Others"
 msgstr "隐藏其他"
 
-#: ../src/generic/infobar.cpp:84
+#: ../src/generic/infobar.cpp:81
 msgid "Hide this notification message."
 msgstr "隐藏此通知消息。"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:884
+#: ../src/propgrid/advprops.cpp:785
 #, fuzzy
 msgid "Highlight"
 msgstr "细体"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:885
+#: ../src/propgrid/advprops.cpp:786
 #, fuzzy
 msgid "HighlightText"
 msgstr "文本右对齐"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/stockitem.cpp:164 ../src/common/accelcmn.cpp:65
+#: ../src/common/stockitem.cpp:161 ../src/common/accelcmn.cpp:62
 msgid "Home"
 msgstr "Home"
 
-#: ../src/generic/dirctrlg.cpp:524
+#: ../src/generic/dirctrlg.cpp:490
 msgid "Home directory"
 msgstr "Home 目录"
 
@@ -4044,61 +4153,61 @@ msgid "How the object will float relative to the text."
 msgstr "对象怎样浮动与文本有关。"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1760
+#: ../src/propgrid/advprops.cpp:1661
 msgid "I-Beam"
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1196
+#: ../src/common/imagbmp.cpp:1208
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: 读掩码DIB错误。"
 
-#: ../src/common/imagbmp.cpp:1290 ../src/common/imagbmp.cpp:1390
-#: ../src/common/imagbmp.cpp:1405 ../src/common/imagbmp.cpp:1416
-#: ../src/common/imagbmp.cpp:1430 ../src/common/imagbmp.cpp:1478
-#: ../src/common/imagbmp.cpp:1493 ../src/common/imagbmp.cpp:1507
-#: ../src/common/imagbmp.cpp:1518
+#: ../src/common/imagbmp.cpp:1302 ../src/common/imagbmp.cpp:1402
+#: ../src/common/imagbmp.cpp:1417 ../src/common/imagbmp.cpp:1428
+#: ../src/common/imagbmp.cpp:1442 ../src/common/imagbmp.cpp:1490
+#: ../src/common/imagbmp.cpp:1505 ../src/common/imagbmp.cpp:1519
+#: ../src/common/imagbmp.cpp:1530
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: 写图像文件错误！"
 
-#: ../src/common/imagbmp.cpp:1255
+#: ../src/common/imagbmp.cpp:1267
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: 图像高度超出范围，不适合做图标。"
 
-#: ../src/common/imagbmp.cpp:1263
+#: ../src/common/imagbmp.cpp:1275
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: 图像宽度超出范围，不适合做图标。"
 
-#: ../src/common/imagbmp.cpp:1603
+#: ../src/common/imagbmp.cpp:1615
 msgid "ICO: Invalid icon index."
 msgstr "ICO: 无效的图标索引。"
 
-#: ../src/common/imagiff.cpp:758
+#: ../src/common/imagiff.cpp:755
 msgid "IFF: data stream seems to be truncated."
 msgstr "IFF: 数据流似乎已被截断。"
 
-#: ../src/common/imagiff.cpp:742
+#: ../src/common/imagiff.cpp:739
 msgid "IFF: error in IFF image format."
 msgstr "IFF: IFF文件格式错误。"
 
-#: ../src/common/imagiff.cpp:745
+#: ../src/common/imagiff.cpp:742
 msgid "IFF: not enough memory."
 msgstr "IFF: 没有足够内存。"
 
-#: ../src/common/imagiff.cpp:748
+#: ../src/common/imagiff.cpp:745
 msgid "IFF: unknown error!!!"
 msgstr "IFF: 位置错误！！！"
 
-#: ../src/common/fmapbase.cpp:197
+#: ../src/common/fmapbase.cpp:194
 msgid "ISO-2022-JP"
 msgstr "ISO-2022-JP"
 
-#: ../src/html/htmprint.cpp:282
+#: ../src/html/htmprint.cpp:294
 msgid ""
 "If possible, try changing the layout parameters to make the printout more "
 "narrow."
 msgstr "如有可能，请尝试更改布局参数以使输出结果更紧凑。"
 
-#: ../src/generic/dbgrptg.cpp:358
+#: ../src/generic/dbgrptg.cpp:362
 msgid ""
 "If you have any additional information pertaining to this bug\n"
 "report, please enter it here and it will be joined to it:"
@@ -4117,149 +4226,153 @@ msgstr ""
 "但我们不建议这样做，因为调试报告有助于改进本程序。\n"
 "在可能的情况下，请尽量选择让程序生成调试报告。\n"
 
-#: ../src/msw/registry.cpp:1405
+#: ../src/common/zipstrm.cpp:1043
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1393
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "忽略值 \"%s\" (键 \"%s\")。"
 
-#: ../src/common/xtistrm.cpp:295
+#: ../src/common/xtistrm.cpp:292
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "非法的对象类 (非-wxEvtHandler) 作为事件源"
 
-#: ../src/common/xti.cpp:513
+#: ../src/common/xti.cpp:510
 msgid "Illegal Parameter Count for ConstructObject Method"
 msgstr "非法的针对 ConstructObject 方法的参数计数"
 
-#: ../src/common/xti.cpp:501
+#: ../src/common/xti.cpp:498
 msgid "Illegal Parameter Count for Create Method"
 msgstr "非法的针对 Create 方法的参数计数"
 
-#: ../src/generic/dirctrlg.cpp:570 ../src/generic/filectrlg.cpp:756
+#: ../src/generic/dirctrlg.cpp:536 ../src/generic/filectrlg.cpp:752
 msgid "Illegal directory name."
 msgstr "不合法的目录名。"
 
-#: ../src/generic/filectrlg.cpp:1367
+#: ../src/generic/filectrlg.cpp:1356
 msgid "Illegal file specification."
 msgstr "不合规范的文件描述。"
 
-#: ../src/common/image.cpp:2269
+#: ../src/common/image.cpp:2363
 msgid "Image and mask have different sizes."
 msgstr "图像和掩码的大小不一致。"
 
-#: ../src/common/image.cpp:2746
+#: ../src/common/image.cpp:2841
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "图像文件的类型不是 %d。"
 
-#: ../src/common/image.cpp:2877
+#: ../src/common/image.cpp:2995
 #, c-format
 msgid "Image is not of type %s."
 msgstr "图像的类型不是 %s。"
 
-#: ../src/msw/textctrl.cpp:488
+#: ../src/msw/textctrl.cpp:534
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
 msgstr ""
 "无法创建富文本编辑器控件，使用简单文本编辑器控件代替。请重新安装 riched32.dll"
 
-#: ../src/unix/utilsunx.cpp:301
+#: ../src/unix/utilsunx.cpp:303
 msgid "Impossible to get child process input"
 msgstr "不可能获得子过程的输入"
 
-#: ../src/common/filefn.cpp:1028
+#: ../src/common/filefn.cpp:917
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "不可能获得文件 '%s' 的许可权限"
 
-#: ../src/common/filefn.cpp:1042
+#: ../src/common/filefn.cpp:931
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "不可能复写文件 '%s'"
 
-#: ../src/common/filefn.cpp:1097
+#: ../src/common/filefn.cpp:986
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "不可能设置文件 '%s' 的许可权限"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:886
+#: ../src/propgrid/advprops.cpp:787
 #, fuzzy
 msgid "InactiveBorder"
 msgstr "边框"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:887
+#: ../src/propgrid/advprops.cpp:788
 msgid "InactiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:888
+#: ../src/propgrid/advprops.cpp:789
 msgid "InactiveCaptionText"
 msgstr ""
 
-#: ../src/common/gifdecod.cpp:792
+#: ../src/common/gifdecod.cpp:826
 #, c-format
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "错误的GIF帧尺寸(%u, %d)对于第#%u帧"
 
-#: ../src/msw/ole/automtn.cpp:635
+#: ../src/msw/ole/automtn.cpp:626
 msgid "Incorrect number of arguments."
 msgstr "错误的变量数目。"
 
-#: ../src/common/stockitem.cpp:165
+#: ../src/common/stockitem.cpp:162
 msgid "Indent"
 msgstr "缩进"
 
-#: ../src/richtext/richtextformatdlg.cpp:349
+#: ../src/richtext/richtextformatdlg.cpp:342
 msgid "Indents && Spacing"
 msgstr "锁紧和空格"
 
-#: ../src/common/stockitem.cpp:166 ../src/html/helpwnd.cpp:515
+#: ../src/common/stockitem.cpp:163 ../src/html/helpwnd.cpp:513
 msgid "Index"
 msgstr "索引"
 
-#: ../src/common/fmapbase.cpp:159
+#: ../src/common/fmapbase.cpp:156
 msgid "Indian (ISO-8859-12)"
 msgstr "印地安语 (ISO-8859-12)"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "Info"
 msgstr "信息"
 
-#: ../src/common/init.cpp:287
+#: ../src/common/init.cpp:284
 msgid "Initialization failed in post init, aborting."
 msgstr "在后初始化阶段出错，退出..."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:54
+#: ../src/common/accelcmn.cpp:51
 #, fuzzy
 msgid "Ins"
 msgstr "缩进"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/richtext/richtextsymboldlg.cpp:472 ../src/common/accelcmn.cpp:53
+#: ../src/common/accelcmn.cpp:50 ../src/richtext/richtextsymboldlg.cpp:469
 msgid "Insert"
 msgstr "插入"
 
-#: ../src/richtext/richtextbuffer.cpp:8067
+#: ../src/richtext/richtextbuffer.cpp:8063
 #, fuzzy
 msgid "Insert Field"
 msgstr "插入"
 
-#: ../src/richtext/richtextbuffer.cpp:7978
-#: ../src/richtext/richtextbuffer.cpp:8936
+#: ../src/richtext/richtextbuffer.cpp:7974
+#: ../src/richtext/richtextbuffer.cpp:8934
 msgid "Insert Image"
 msgstr "插入图片"
 
-#: ../src/richtext/richtextbuffer.cpp:8025
+#: ../src/richtext/richtextbuffer.cpp:8021
 msgid "Insert Object"
 msgstr "插入对象"
 
-#: ../src/richtext/richtextctrl.cpp:1286 ../src/richtext/richtextctrl.cpp:1494
-#: ../src/richtext/richtextbuffer.cpp:7822
-#: ../src/richtext/richtextbuffer.cpp:7852
-#: ../src/richtext/richtextbuffer.cpp:7894
+#: ../src/richtext/richtextbuffer.cpp:7818
+#: ../src/richtext/richtextbuffer.cpp:7848
+#: ../src/richtext/richtextbuffer.cpp:7890
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
 msgid "Insert Text"
 msgstr "插入文本"
 
@@ -4273,16 +4386,11 @@ msgstr "在段落前插入断页符。"
 msgid "Inset"
 msgstr "缩进"
 
-#: ../src/gtk/app.cpp:425
-#, c-format
-msgid "Invalid GTK+ command line option, use \"%s --help\""
-msgstr "无效的GTK+命令行选项，使用 \"%s --help\""
-
-#: ../src/common/imagtiff.cpp:311
+#: ../src/common/imagtiff.cpp:308
 msgid "Invalid TIFF image index."
 msgstr "无效TIFF图像索引。"
 
-#: ../src/common/appcmn.cpp:273
+#: ../src/common/appcmn.cpp:294
 #, c-format
 msgid "Invalid display mode specification '%s'."
 msgstr "无效的显示模式 '%s'。"
@@ -4292,257 +4400,261 @@ msgstr "无效的显示模式 '%s'。"
 msgid "Invalid geometry specification '%s'"
 msgstr "无效的几何规格 '%s'"
 
-#: ../src/unix/fswatcher_inotify.cpp:323
+#: ../src/unix/fswatcher_inotify.cpp:320
 #, c-format
 msgid "Invalid inotify event for \"%s\""
 msgstr "无效的 \"%s\" inotify 事件"
 
-#: ../src/unix/snglinst.cpp:312
+#: ../src/unix/snglinst.cpp:309
 #, c-format
 msgid "Invalid lock file '%s'."
 msgstr "无效的锁文件 '%s'。"
 
-#: ../src/common/translation.cpp:1125
+#: ../src/common/translation.cpp:1167
 msgid "Invalid message catalog."
 msgstr "无效的消息目录。"
 
-#: ../src/common/xtistrm.cpp:405 ../src/common/xtistrm.cpp:420
+#: ../src/common/xtistrm.cpp:402 ../src/common/xtistrm.cpp:417
 msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
 msgstr "无效的或空的对象 ID 传给 GetObjectClassInfo"
 
-#: ../src/common/xtistrm.cpp:435
+#: ../src/common/xtistrm.cpp:432
 msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
 msgstr "无效的或空的对象 ID 传给 HasObjectClassInfo"
 
-#: ../src/common/regex.cpp:310
+#: ../src/common/regex.cpp:307
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "无效的正则表达式 '%s': %s"
 
-#: ../src/common/config.cpp:226
+#: ../src/common/config.cpp:222
 #, c-format
 msgid "Invalid value %ld for a boolean key \"%s\" in config file."
 msgstr "配置文件中无效的值 %ld 于布尔键 \"%s\"。"
 
-#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:351
-#: ../src/osx/carbon/fontdlg.cpp:361 ../src/common/stockitem.cpp:168
+#: ../src/osx/carbon/fontdlg.cpp:358 ../src/common/stockitem.cpp:165
+#: ../src/generic/fontdlgg.cpp:325 ../src/richtext/richtextfontpage.cpp:351
 msgid "Italic"
 msgstr "斜体"
 
-#: ../src/common/paper.cpp:130
+#: ../src/common/paper.cpp:127
 msgid "Italy Envelope, 110 x 230 mm"
 msgstr "意大利信封, 110 x 230 毫米"
 
-#: ../src/common/imagjpeg.cpp:270
+#: ../src/common/imagjpeg.cpp:257
 msgid "JPEG: Couldn't load - file is probably corrupted."
 msgstr "JPEG: 无法装入 - 文件也许已被破坏。"
 
-#: ../src/common/imagjpeg.cpp:449
+#: ../src/common/imagjpeg.cpp:436
 msgid "JPEG: Couldn't save image."
 msgstr "JPEG: 无法保存图像。"
 
-#: ../src/common/paper.cpp:163
+#: ../src/common/paper.cpp:160
 msgid "Japanese Double Postcard 200 x 148 mm"
 msgstr "日本双明信片, 200 x 148 毫米"
 
-#: ../src/common/paper.cpp:167
+#: ../src/common/paper.cpp:164
 msgid "Japanese Envelope Chou #3"
 msgstr "日本 Chou 3 信封"
 
-#: ../src/common/paper.cpp:180
+#: ../src/common/paper.cpp:177
 msgid "Japanese Envelope Chou #3 Rotated"
 msgstr "日本 Chou 3 信封(横向)"
 
-#: ../src/common/paper.cpp:168
+#: ../src/common/paper.cpp:165
 msgid "Japanese Envelope Chou #4"
 msgstr "日本 Chou 4 信封"
 
-#: ../src/common/paper.cpp:181
+#: ../src/common/paper.cpp:178
 msgid "Japanese Envelope Chou #4 Rotated"
 msgstr "日本 Chou 4 信封(横向)"
 
-#: ../src/common/paper.cpp:165
+#: ../src/common/paper.cpp:162
 msgid "Japanese Envelope Kaku #2"
 msgstr "日本 Kaku 2 信封"
 
-#: ../src/common/paper.cpp:178
+#: ../src/common/paper.cpp:175
 msgid "Japanese Envelope Kaku #2 Rotated"
 msgstr "日本 Kaku 2 信封(横向)"
 
-#: ../src/common/paper.cpp:166
+#: ../src/common/paper.cpp:163
 msgid "Japanese Envelope Kaku #3"
 msgstr "日本 Kaku 3 信封"
 
-#: ../src/common/paper.cpp:179
+#: ../src/common/paper.cpp:176
 msgid "Japanese Envelope Kaku #3 Rotated"
 msgstr "日本 Kaku 3 信封(横向)"
 
-#: ../src/common/paper.cpp:185
+#: ../src/common/paper.cpp:182
 msgid "Japanese Envelope You #4"
 msgstr "日本 You 4 信封"
 
-#: ../src/common/paper.cpp:186
+#: ../src/common/paper.cpp:183
 msgid "Japanese Envelope You #4 Rotated"
 msgstr "日本 You 4 信封(横向)"
 
-#: ../src/common/paper.cpp:138
+#: ../src/common/paper.cpp:135
 msgid "Japanese Postcard 100 x 148 mm"
 msgstr "日本明信片, 100 x 148 毫米"
 
-#: ../src/common/paper.cpp:175
+#: ../src/common/paper.cpp:172
 msgid "Japanese Postcard Rotated 148 x 100 mm"
 msgstr "横向日本明信片, 148 x 100 毫米"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "Jump to"
 msgstr "跳转至"
 
-#: ../src/common/stockitem.cpp:171
+#: ../src/common/stockitem.cpp:168
 msgid "Justified"
 msgstr "分散对齐"
 
-#: ../src/richtext/richtextindentspage.cpp:155
-#: ../src/richtext/richtextindentspage.cpp:157
 #: ../src/richtext/richtextliststylepage.cpp:344
 #: ../src/richtext/richtextliststylepage.cpp:346
+#: ../src/richtext/richtextindentspage.cpp:155
+#: ../src/richtext/richtextindentspage.cpp:157
 msgid "Justify text left and right."
 msgstr "文本左右对齐。"
 
-#: ../src/common/fmapbase.cpp:163
+#: ../src/common/fmapbase.cpp:160
 msgid "KOI8-R"
 msgstr "KOI8-R"
 
-#: ../src/common/fmapbase.cpp:164
+#: ../src/common/fmapbase.cpp:161
 msgid "KOI8-U"
 msgstr "KOI8-U"
 
-#: ../src/common/accelcmn.cpp:265 ../src/common/accelcmn.cpp:347
+#: ../src/common/accelcmn.cpp:279 ../src/common/accelcmn.cpp:364
 msgid "KP_"
 msgstr "KP_"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 #, fuzzy
 msgid "KP_Add"
 msgstr "KP_ADD"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "KP_Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "KP_Decimal"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 #, fuzzy
 msgid "KP_Delete"
 msgstr "删除"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "KP_Divide"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 #, fuzzy
 msgid "KP_Down"
 msgstr "向下"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 #, fuzzy
 msgid "KP_End"
 msgstr "KP_END"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 #, fuzzy
 msgid "KP_Enter"
 msgstr "打印机"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "KP_Equal"
 msgstr ""
 
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
-#, fuzzy
-msgid "KP_Home"
-msgstr "Home"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
-#, fuzzy
-msgid "KP_Insert"
-msgstr "插入"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
-#, fuzzy
-msgid "KP_Left"
-msgstr "左"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
-msgid "KP_Multiply"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:99
-#, fuzzy
-msgid "KP_Next"
-msgstr "下一个"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
-msgid "KP_PageDown"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
-msgid "KP_PageUp"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:98
-msgid "KP_Prior"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
-#, fuzzy
-msgid "KP_Right"
-msgstr "右"
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
-msgid "KP_Separator"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
-msgid "KP_Space"
-msgstr ""
-
-#. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
-msgid "KP_Subtract"
+#: ../src/common/accelcmn.cpp:276 ../src/common/accelcmn.cpp:361
+msgid "KP_F"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
 #: ../src/common/accelcmn.cpp:89
 #, fuzzy
+msgid "KP_Home"
+msgstr "Home"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:100
+#, fuzzy
+msgid "KP_Insert"
+msgstr "插入"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:90
+#, fuzzy
+msgid "KP_Left"
+msgstr "左"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:103
+msgid "KP_Multiply"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:97
+#, fuzzy
+msgid "KP_Next"
+msgstr "下一个"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:95
+msgid "KP_PageDown"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:94
+msgid "KP_PageUp"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:96
+msgid "KP_Prior"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:92
+#, fuzzy
+msgid "KP_Right"
+msgstr "右"
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:105
+msgid "KP_Separator"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:86
+msgid "KP_Space"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:106
+msgid "KP_Subtract"
+msgstr ""
+
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:87
+#, fuzzy
 msgid "KP_Tab"
 msgstr "KP_TAB"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 #, fuzzy
 msgid "KP_Up"
 msgstr "KP_UP"
@@ -4551,111 +4663,126 @@ msgstr "KP_UP"
 msgid "L&ine spacing:"
 msgstr "行距(&I):"
 
-#: ../src/generic/prntdlgg.cpp:613 ../src/generic/prntdlgg.cpp:868
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "压缩错误"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "解压缩错误"
+
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:861
 msgid "Landscape"
 msgstr "横向"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "Last"
 msgstr "最后"
 
-#: ../src/common/prntbase.cpp:1572
+#: ../src/common/prntbase.cpp:1597
 msgid "Last page"
 msgstr "最后一页"
 
-#: ../src/common/log.cpp:305
+#: ../src/common/log.cpp:324
 #, fuzzy, c-format
 msgid "Last repeated message (\"%s\", %u time) wasn't output"
 msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
 msgstr[0] "最后重复消息(\"%s\", %lu time)未输出"
 
-#: ../src/common/paper.cpp:103
+#: ../src/common/paper.cpp:100
 msgid "Ledger, 17 x 11 in"
 msgstr "帐簿, 17 x 11 英寸"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6146
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:58 ../src/generic/datavgen.cpp:6951
+#: ../src/richtext/richtextsizepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:252
 #: ../src/richtext/richtextliststylepage.cpp:253
 #: ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
-#: ../src/richtext/richtextsizepage.cpp:249 ../src/common/accelcmn.cpp:61
 msgid "Left"
 msgstr "左"
 
-#: ../src/richtext/richtextindentspage.cpp:204
 #: ../src/richtext/richtextliststylepage.cpp:390
+#: ../src/richtext/richtextindentspage.cpp:204
 msgid "Left (&first line):"
 msgstr "左(第一行)(&F):"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1761
+#: ../src/propgrid/advprops.cpp:1662
 msgid "Left Button"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:880
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Left margin (mm):"
 msgstr "左边距 (毫米):"
 
-#: ../src/richtext/richtextindentspage.cpp:141
-#: ../src/richtext/richtextindentspage.cpp:143
 #: ../src/richtext/richtextliststylepage.cpp:330
 #: ../src/richtext/richtextliststylepage.cpp:332
+#: ../src/richtext/richtextindentspage.cpp:141
+#: ../src/richtext/richtextindentspage.cpp:143
 msgid "Left-align text."
 msgstr "文字左对齐。"
 
-#: ../src/common/paper.cpp:144
+#: ../src/common/paper.cpp:141
 msgid "Legal Extra 9 1/2 x 15 in"
 msgstr "特大法律纸张, 9 1/2 x 15 英寸"
 
-#: ../src/common/paper.cpp:96
+#: ../src/common/paper.cpp:93
 msgid "Legal, 8 1/2 x 14 in"
 msgstr "标准法律纸张, 8 1/2 x 14 英寸"
 
-#: ../src/common/paper.cpp:143
+#: ../src/common/paper.cpp:140
 msgid "Letter Extra 9 1/2 x 12 in"
 msgstr "特大信纸, 9 1/2 x 12 英寸"
 
-#: ../src/common/paper.cpp:149
+#: ../src/common/paper.cpp:146
 msgid "Letter Extra Transverse 9.275 x 12 in"
 msgstr "特大信纸(横排), 9.275 x 12 英寸"
 
-#: ../src/common/paper.cpp:152
+#: ../src/common/paper.cpp:149
 msgid "Letter Plus 8 1/2 x 12.69 in"
 msgstr "加大信纸, 8 1/2 x 12.69 英寸"
 
-#: ../src/common/paper.cpp:169
+#: ../src/common/paper.cpp:166
 msgid "Letter Rotated 11 x 8 1/2 in"
 msgstr "横向信纸, 11 x 8 1/2 英寸"
 
-#: ../src/common/paper.cpp:101
+#: ../src/common/paper.cpp:98
 msgid "Letter Small, 8 1/2 x 11 in"
 msgstr "信纸(小), 8 1/2 x 11 英寸"
 
-#: ../src/common/paper.cpp:147
+#: ../src/common/paper.cpp:144
 msgid "Letter Transverse 8 1/2 x 11 in"
 msgstr "信纸(横排), 8 1/2 x 11 英寸"
 
-#: ../src/common/paper.cpp:95
+#: ../src/common/paper.cpp:92
 msgid "Letter, 8 1/2 x 11 in"
 msgstr "信纸, 8 1/2 x 11 英寸"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "License"
 msgstr "授权"
 
-#: ../src/generic/fontdlgg.cpp:332
+#: ../src/generic/fontdlgg.cpp:328
 msgid "Light"
 msgstr "细"
 
-#: ../src/propgrid/advprops.cpp:1608
+#: ../src/propgrid/advprops.cpp:1514
 msgid "Lime"
 msgstr ""
 
-#: ../src/generic/helpext.cpp:294
+#: ../src/generic/helpext.cpp:292
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr "行 %lu 的map文件 \"%s\" 有无效语法，跳过。"
@@ -4664,15 +4791,15 @@ msgstr "行 %lu 的map文件 \"%s\" 有无效语法，跳过。"
 msgid "Line spacing:"
 msgstr "行距:"
 
-#: ../src/html/chm.cpp:838
+#: ../src/html/chm.cpp:829
 msgid "Link contained '//', converted to absolute link."
 msgstr "链接包含 '//'，转换为绝对链接."
 
-#: ../src/richtext/richtextformatdlg.cpp:364
+#: ../src/richtext/richtextformatdlg.cpp:357
 msgid "List Style"
 msgstr "列表样式"
 
-#: ../src/richtext/richtextstyles.cpp:1064
+#: ../src/richtext/richtextstyles.cpp:1061
 msgid "List styles"
 msgstr "列表样式"
 
@@ -4686,26 +4813,26 @@ msgstr "列表字体大小"
 msgid "Lists the available fonts."
 msgstr "列出可用字体。"
 
-#: ../src/common/fldlgcmn.cpp:340
+#: ../src/common/fldlgcmn.cpp:337
 #, c-format
 msgid "Load %s file"
 msgstr "装入文件 %s "
 
-#: ../src/html/htmlwin.cpp:597
+#: ../src/html/htmlwin.cpp:600
 msgid "Loading : "
 msgstr "装载: "
 
-#: ../src/unix/snglinst.cpp:246
+#: ../src/unix/snglinst.cpp:243
 #, c-format
 msgid "Lock file '%s' has incorrect owner."
 msgstr "锁文件 '%s' 没有正确的所有者。"
 
-#: ../src/unix/snglinst.cpp:251
+#: ../src/unix/snglinst.cpp:248
 #, c-format
 msgid "Lock file '%s' has incorrect permissions."
 msgstr "锁文件 '%s' 没有正确的权限。"
 
-#: ../src/generic/logg.cpp:576
+#: ../src/generic/logg.cpp:573
 #, c-format
 msgid "Log saved to the file '%s'."
 msgstr "日志保存到文件 '%s'。"
@@ -4720,199 +4847,199 @@ msgstr "小写字母"
 msgid "Lower case roman numerals"
 msgstr "小写罗马数字"
 
-#: ../src/gtk/mdi.cpp:422 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk1/mdi.cpp:431 ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "MDI 子窗口"
 
-#: ../src/msw/helpchm.cpp:56
+#: ../src/msw/helpchm.cpp:53
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
 msgstr "MS HTML帮助功能不存在，因为此机器上没有安装 MS HTML 帮助库。请安装它。"
 
-#: ../src/univ/themes/win32.cpp:3754
+#: ../src/univ/themes/win32.cpp:3751
 msgid "Ma&ximize"
 msgstr "最大化(&x)"
 
-#: ../src/common/fmapbase.cpp:203
+#: ../src/common/fmapbase.cpp:200
 msgid "MacArabic"
 msgstr "MacArabic"
 
-#: ../src/common/fmapbase.cpp:222
+#: ../src/common/fmapbase.cpp:219
 msgid "MacArmenian"
 msgstr "MacArmenian"
 
-#: ../src/common/fmapbase.cpp:211
+#: ../src/common/fmapbase.cpp:208
 msgid "MacBengali"
 msgstr "MacBengali"
 
-#: ../src/common/fmapbase.cpp:217
+#: ../src/common/fmapbase.cpp:214
 msgid "MacBurmese"
 msgstr "MacBurmese"
 
-#: ../src/common/fmapbase.cpp:236
+#: ../src/common/fmapbase.cpp:233
 msgid "MacCeltic"
 msgstr "MacCeltic"
 
-#: ../src/common/fmapbase.cpp:227
+#: ../src/common/fmapbase.cpp:224
 msgid "MacCentralEurRoman"
 msgstr "MacCentralEurRoman"
 
-#: ../src/common/fmapbase.cpp:223
+#: ../src/common/fmapbase.cpp:220
 msgid "MacChineseSimp"
 msgstr "MacChineseSimp"
 
-#: ../src/common/fmapbase.cpp:201
+#: ../src/common/fmapbase.cpp:198
 msgid "MacChineseTrad"
 msgstr "MacChineseTrad"
 
-#: ../src/common/fmapbase.cpp:233
+#: ../src/common/fmapbase.cpp:230
 msgid "MacCroatian"
 msgstr "MacCroatian"
 
-#: ../src/common/fmapbase.cpp:206
+#: ../src/common/fmapbase.cpp:203
 msgid "MacCyrillic"
 msgstr "MacCyrillic"
 
-#: ../src/common/fmapbase.cpp:207
+#: ../src/common/fmapbase.cpp:204
 msgid "MacDevanagari"
 msgstr "MacDevanagari"
 
-#: ../src/common/fmapbase.cpp:231
+#: ../src/common/fmapbase.cpp:228
 msgid "MacDingbats"
 msgstr "MacDingbats"
 
-#: ../src/common/fmapbase.cpp:226
+#: ../src/common/fmapbase.cpp:223
 msgid "MacEthiopic"
 msgstr "MacEthiopic"
 
-#: ../src/common/fmapbase.cpp:229
+#: ../src/common/fmapbase.cpp:226
 msgid "MacExtArabic"
 msgstr "MacExtArabic"
 
-#: ../src/common/fmapbase.cpp:237
+#: ../src/common/fmapbase.cpp:234
 msgid "MacGaelic"
 msgstr "MacGaelic"
 
-#: ../src/common/fmapbase.cpp:221
+#: ../src/common/fmapbase.cpp:218
 msgid "MacGeorgian"
 msgstr "MacGeorgian"
 
-#: ../src/common/fmapbase.cpp:205
+#: ../src/common/fmapbase.cpp:202
 msgid "MacGreek"
 msgstr "MacGreek"
 
-#: ../src/common/fmapbase.cpp:209
+#: ../src/common/fmapbase.cpp:206
 msgid "MacGujarati"
 msgstr "MacGujarati"
 
-#: ../src/common/fmapbase.cpp:208
+#: ../src/common/fmapbase.cpp:205
 msgid "MacGurmukhi"
 msgstr "MacGurmukhi"
 
-#: ../src/common/fmapbase.cpp:204
+#: ../src/common/fmapbase.cpp:201
 msgid "MacHebrew"
 msgstr "MacHebrew"
 
-#: ../src/common/fmapbase.cpp:234
+#: ../src/common/fmapbase.cpp:231
 msgid "MacIcelandic"
 msgstr "MacIcelandic"
 
-#: ../src/common/fmapbase.cpp:200
+#: ../src/common/fmapbase.cpp:197
 msgid "MacJapanese"
 msgstr "MacJapanese"
 
-#: ../src/common/fmapbase.cpp:214
+#: ../src/common/fmapbase.cpp:211
 msgid "MacKannada"
 msgstr "MacKannada"
 
-#: ../src/common/fmapbase.cpp:238
+#: ../src/common/fmapbase.cpp:235
 msgid "MacKeyboardGlyphs"
 msgstr "MacKeyboardGlyphs"
 
-#: ../src/common/fmapbase.cpp:218
+#: ../src/common/fmapbase.cpp:215
 msgid "MacKhmer"
 msgstr "MacKhmer"
 
-#: ../src/common/fmapbase.cpp:202
+#: ../src/common/fmapbase.cpp:199
 msgid "MacKorean"
 msgstr "MacKorean"
 
-#: ../src/common/fmapbase.cpp:220
+#: ../src/common/fmapbase.cpp:217
 msgid "MacLaotian"
 msgstr "MacLaotian"
 
-#: ../src/common/fmapbase.cpp:215
+#: ../src/common/fmapbase.cpp:212
 msgid "MacMalayalam"
 msgstr "MacMalayalam"
 
-#: ../src/common/fmapbase.cpp:225
+#: ../src/common/fmapbase.cpp:222
 msgid "MacMongolian"
 msgstr "MacMongolian"
 
-#: ../src/common/fmapbase.cpp:210
+#: ../src/common/fmapbase.cpp:207
 msgid "MacOriya"
 msgstr "MacOriya"
 
-#: ../src/common/fmapbase.cpp:199
+#: ../src/common/fmapbase.cpp:196
 msgid "MacRoman"
 msgstr "MacRoman"
 
-#: ../src/common/fmapbase.cpp:235
+#: ../src/common/fmapbase.cpp:232
 msgid "MacRomanian"
 msgstr "MacRomanian"
 
-#: ../src/common/fmapbase.cpp:216
+#: ../src/common/fmapbase.cpp:213
 msgid "MacSinhalese"
 msgstr "MacSinhalese"
 
-#: ../src/common/fmapbase.cpp:230
+#: ../src/common/fmapbase.cpp:227
 msgid "MacSymbol"
 msgstr "MacSymbol"
 
-#: ../src/common/fmapbase.cpp:212
+#: ../src/common/fmapbase.cpp:209
 msgid "MacTamil"
 msgstr "MacTamil"
 
-#: ../src/common/fmapbase.cpp:213
+#: ../src/common/fmapbase.cpp:210
 msgid "MacTelugu"
 msgstr "MacTelugu"
 
-#: ../src/common/fmapbase.cpp:219
+#: ../src/common/fmapbase.cpp:216
 msgid "MacThai"
 msgstr "MacThai"
 
-#: ../src/common/fmapbase.cpp:224
+#: ../src/common/fmapbase.cpp:221
 msgid "MacTibetan"
 msgstr "MacTibetan"
 
-#: ../src/common/fmapbase.cpp:232
+#: ../src/common/fmapbase.cpp:229
 msgid "MacTurkish"
 msgstr "MacTurkish"
 
-#: ../src/common/fmapbase.cpp:228
+#: ../src/common/fmapbase.cpp:225
 msgid "MacVietnamese"
 msgstr "MacVietnamese"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1762
+#: ../src/propgrid/advprops.cpp:1663
 msgid "Magnifier"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:2143
+#: ../src/propgrid/advprops.cpp:2050
 msgid "Make a selection:"
 msgstr "请选择:"
 
-#: ../src/richtext/richtextformatdlg.cpp:374
+#: ../src/richtext/richtextformatdlg.cpp:367
 #: ../src/richtext/richtextmarginspage.cpp:171
 msgid "Margins"
 msgstr "边距"
 
-#: ../src/propgrid/advprops.cpp:1595
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Maroon"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:147
+#: ../src/generic/fdrepdlg.cpp:144
 msgid "Match case"
 msgstr "区分大小写"
 
@@ -4924,40 +5051,40 @@ msgstr "最达高度:"
 msgid "Max width:"
 msgstr "最大宽度:"
 
-#: ../src/unix/mediactrl.cpp:947
+#: ../src/unix/mediactrl.cpp:972
 #, c-format
 msgid "Media playback error: %s"
 msgstr "媒体回放错误：%s"
 
-#: ../src/common/fs_mem.cpp:175
+#: ../src/common/fs_mem.cpp:170
 #, c-format
 msgid "Memory VFS already contains file '%s'!"
 msgstr "内存 VFS 已包含文件 '%s'！"
 
 #. TRANSLATORS: Name of keyboard key
 #. TRANSLATORS: Keyword of system colour
-#: ../src/common/accelcmn.cpp:73 ../src/propgrid/advprops.cpp:889
+#: ../src/common/accelcmn.cpp:70 ../src/propgrid/advprops.cpp:790
 msgid "Menu"
 msgstr "菜单"
 
-#: ../src/common/msgout.cpp:124
+#: ../src/common/msgout.cpp:121
 msgid "Message"
 msgstr "消息"
 
-#: ../src/univ/themes/metal.cpp:168
+#: ../src/univ/themes/metal.cpp:165
 msgid "Metal theme"
 msgstr "金属主题"
 
-#: ../src/msw/ole/automtn.cpp:652
+#: ../src/msw/ole/automtn.cpp:643
 msgid "Method or property not found."
 msgstr "找不到方法或属性。"
 
-#: ../src/univ/themes/win32.cpp:3752
+#: ../src/univ/themes/win32.cpp:3749
 msgid "Mi&nimize"
 msgstr "最小化(&n)"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1763
+#: ../src/propgrid/advprops.cpp:1664
 msgid "Middle Button"
 msgstr ""
 
@@ -4969,36 +5096,41 @@ msgstr "最小高度:"
 msgid "Min width:"
 msgstr "最小宽度: "
 
-#: ../src/msw/ole/automtn.cpp:668
+#: ../src/osx/cocoa/menu.mm:281
+#, fuzzy
+msgid "Minimize"
+msgstr "最小化(&n)"
+
+#: ../src/msw/ole/automtn.cpp:659
 msgid "Missing a required parameter."
 msgstr "缺少必要参数。"
 
-#: ../src/generic/fontdlgg.cpp:324
+#: ../src/generic/fontdlgg.cpp:320
 msgid "Modern"
 msgstr "现代"
 
-#: ../src/generic/filectrlg.cpp:427
+#: ../src/generic/filectrlg.cpp:423
 msgid "Modified"
 msgstr "修改日期"
 
-#: ../src/common/module.cpp:133
+#: ../src/common/module.cpp:130
 #, c-format
 msgid "Module \"%s\" initialization failed"
 msgstr "模块 \"%s\" 初始化失败"
 
-#: ../src/common/paper.cpp:131
+#: ../src/common/paper.cpp:128
 msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
 msgstr "7.75信封，3 7/8 x 7 1/2 英寸"
 
-#: ../src/msw/fswatcher.cpp:143
+#: ../src/msw/fswatcher.cpp:140
 msgid "Monitoring individual files for changes is not supported currently."
 msgstr "当前不支持监视单独文件的更改。"
 
-#: ../src/generic/editlbox.cpp:172
+#: ../src/generic/editlbox.cpp:160
 msgid "Move down"
 msgstr "下移"
 
-#: ../src/generic/editlbox.cpp:171
+#: ../src/generic/editlbox.cpp:155
 msgid "Move up"
 msgstr "上移"
 
@@ -5012,97 +5144,102 @@ msgstr "将对象移至下一段落"
 msgid "Moves the object to the previous paragraph."
 msgstr "将对象移至前一段落"
 
-#: ../src/richtext/richtextbuffer.cpp:9966
+#: ../src/richtext/richtextbuffer.cpp:9963
 msgid "Multiple Cell Properties"
 msgstr "多重单元属性"
 
-#: ../src/generic/filectrlg.cpp:424
+#. TRANSLATORS: Name of keyboard key
+#: ../src/common/accelcmn.cpp:82
+msgid "Multiply"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:420
 msgid "Name"
 msgstr "名称"
 
-#: ../src/propgrid/advprops.cpp:1596
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Navy"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "Network"
 msgstr "网络"
 
-#: ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173
 msgid "New"
 msgstr "新建"
 
-#: ../src/richtext/richtextstyledlg.cpp:243
+#: ../src/richtext/richtextstyledlg.cpp:239
 msgid "New &Box Style..."
 msgstr "新方块样式 (&B)"
 
-#: ../src/richtext/richtextstyledlg.cpp:225
+#: ../src/richtext/richtextstyledlg.cpp:221
 msgid "New &Character Style..."
 msgstr "新增字体样式 (&C)..."
 
-#: ../src/richtext/richtextstyledlg.cpp:237
+#: ../src/richtext/richtextstyledlg.cpp:233
 msgid "New &List Style..."
 msgstr "新增列表样式 (&L)..."
 
-#: ../src/richtext/richtextstyledlg.cpp:231
+#: ../src/richtext/richtextstyledlg.cpp:227
 msgid "New &Paragraph Style..."
 msgstr "新增段落样式 (&P)..."
 
-#: ../src/richtext/richtextstyledlg.cpp:606
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:654
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:820
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:893
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:934
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:602
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:650
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:816
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:889
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:930
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "New Style"
 msgstr "新增样式"
 
-#: ../src/generic/editlbox.cpp:169
+#: ../src/generic/editlbox.cpp:139
 msgid "New item"
 msgstr "新项目"
 
-#: ../src/generic/dirdlgg.cpp:297 ../src/generic/dirdlgg.cpp:307
-#: ../src/generic/filectrlg.cpp:618 ../src/generic/filectrlg.cpp:627
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+#: ../src/generic/dirdlgg.cpp:294 ../src/generic/dirdlgg.cpp:304
 msgid "NewName"
 msgstr "新名称"
 
-#: ../src/common/prntbase.cpp:1567 ../src/html/helpwnd.cpp:665
+#: ../src/common/prntbase.cpp:1592 ../src/html/helpwnd.cpp:663
 msgid "Next page"
 msgstr "下一页"
 
-#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:177
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:174
 #: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "否"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1764
+#: ../src/propgrid/advprops.cpp:1665
 msgid "No Entry"
 msgstr ""
 
-#: ../src/generic/animateg.cpp:150
+#: ../src/generic/animateg.cpp:133
 #, c-format
 msgid "No animation handler for type %ld defined."
 msgstr "没有类型 %ld 的动画句柄定义。"
 
-#: ../src/dfb/bitmap.cpp:642 ../src/dfb/bitmap.cpp:676
+#: ../src/dfb/bitmap.cpp:639 ../src/dfb/bitmap.cpp:673
 #, fuzzy, c-format
 msgid "No bitmap handler for type %d defined."
 msgstr "没有类型 %d 的图像处理器."
 
-#: ../src/common/utilscmn.cpp:1077
+#: ../src/common/utilscmn.cpp:1095
 msgid "No default application configured for HTML files."
 msgstr "没有设定HTML文件的默认应用。"
 
-#: ../src/generic/helpext.cpp:445
+#: ../src/generic/helpext.cpp:443
 msgid "No entries found."
 msgstr "没找到条目。"
 
-#: ../src/common/fontmap.cpp:421
+#: ../src/common/fontmap.cpp:418
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found,\n"
@@ -5114,7 +5251,7 @@ msgstr ""
 "但发现另一替代编码 '%s'。\n"
 "是否使用该编码 (否则您必须选择另外的编码)?"
 
-#: ../src/common/fontmap.cpp:426
+#: ../src/common/fontmap.cpp:423
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found.\n"
@@ -5125,206 +5262,206 @@ msgstr ""
 "请选择用于该编码的字体\n"
 "(否则该编码的文本将无法正确显示)?"
 
-#: ../src/generic/animateg.cpp:142
+#: ../src/generic/animateg.cpp:125
 msgid "No handler found for animation type."
 msgstr "没有找到动画类型的句柄。"
 
-#: ../src/common/image.cpp:2728
+#: ../src/common/image.cpp:2823
 msgid "No handler found for image type."
 msgstr "没有找到图像类型的句柄。"
 
-#: ../src/common/image.cpp:2736 ../src/common/image.cpp:2848
-#: ../src/common/image.cpp:2901
+#: ../src/common/image.cpp:2831 ../src/common/image.cpp:2954
+#: ../src/common/image.cpp:3020
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "没有类型 %d 的图像句柄定义。"
 
-#: ../src/common/image.cpp:2871 ../src/common/image.cpp:2915
+#: ../src/common/image.cpp:2986 ../src/common/image.cpp:3034
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "没有类型 %s 的图像句柄定义。"
 
-#: ../src/html/helpwnd.cpp:858
+#: ../src/html/helpwnd.cpp:856
 msgid "No matching page found yet"
 msgstr "还没有找到匹配页"
 
-#: ../src/unix/sound.cpp:81
+#: ../src/unix/sound.cpp:78
 msgid "No sound"
 msgstr "没有声音"
 
-#: ../src/common/image.cpp:2277 ../src/common/image.cpp:2318
+#: ../src/common/image.cpp:2371 ../src/common/image.cpp:2412
 msgid "No unused colour in image being masked."
 msgstr "图像中没有被掩码的未用颜色。"
 
-#: ../src/common/image.cpp:3374
-msgid "No unused colour in image."
-msgstr "图像中没有未用的颜色。"
-
-#: ../src/generic/helpext.cpp:302
+#: ../src/generic/helpext.cpp:300
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "文件 \"%s\" 中无效映射"
 
-#: ../src/richtext/richtextborderspage.cpp:610
 #: ../src/richtext/richtextsizepage.cpp:248
 #: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:610
 msgid "None"
 msgstr "无"
 
-#: ../src/common/fmapbase.cpp:157
+#: ../src/common/fmapbase.cpp:154
 msgid "Nordic (ISO-8859-10)"
 msgstr "日尔曼语 (ISO-8859-10)"
 
-#: ../src/generic/fontdlgg.cpp:328 ../src/generic/fontdlgg.cpp:331
+#: ../src/generic/fontdlgg.cpp:324 ../src/generic/fontdlgg.cpp:327
 msgid "Normal"
 msgstr "正常"
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1261
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "正常字体<br> 且 <u>带下划线</u>。"
 
-#: ../src/html/helpwnd.cpp:1205
+#: ../src/html/helpwnd.cpp:1203
 msgid "Normal font:"
 msgstr "正常字体:"
 
-#: ../src/propgrid/props.cpp:1128
+#: ../src/propgrid/props.cpp:1115
 #, c-format
 msgid "Not %s"
 msgstr "非 %s"
 
-#: ../include/wx/filename.h:573 ../include/wx/filename.h:578
-msgid "Not available"
-msgstr "不可用"
+#: ../src/common/secretstore.cpp:168
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/webrequest.cpp:605
+msgid "Not enough free disk space for download."
+msgstr ""
 
 #: ../src/richtext/richtextfontpage.cpp:358
 msgid "Not underlined"
 msgstr "无下划线"
 
-#: ../src/common/paper.cpp:115
+#: ../src/common/paper.cpp:112
 msgid "Note, 8 1/2 x 11 in"
 msgstr "笔记簿, 8 1/2 x 11 英寸"
 
-#: ../src/generic/notifmsgg.cpp:132
+#: ../src/generic/notifmsgg.cpp:129
 msgid "Notice"
 msgstr "注意"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:103
 msgid "Num *"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:104
 msgid "Num +"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:105
 msgid "Num ,"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:106
 msgid "Num -"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:107
 msgid "Num ."
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:108
 msgid "Num /"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:102
 msgid "Num ="
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:99
 msgid "Num Begin"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:101
 #, fuzzy
 msgid "Num Delete"
 msgstr "删除"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:93
 #, fuzzy
 msgid "Num Down"
 msgstr "向下"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:98
 msgid "Num End"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:88
 msgid "Num Enter"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:89
 #, fuzzy
 msgid "Num Home"
 msgstr "Home"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:100
 #, fuzzy
 msgid "Num Insert"
 msgstr "插入"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num Lock"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:95
 msgid "Num Page Down"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:94
 msgid "Num Page Up"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:92
 #, fuzzy
 msgid "Num Right"
 msgstr "右"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:86
 msgid "Num Space"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:87
 msgid "Num Tab"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:91
 msgid "Num Up"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:90
 msgid "Num left"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:84
 msgid "Num_lock"
 msgstr ""
 
@@ -5333,13 +5470,13 @@ msgstr ""
 msgid "Numbered outline"
 msgstr "大纲标号"
 
-#: ../include/wx/msgdlg.h:278 ../src/richtext/richtextstyledlg.cpp:297
-#: ../src/common/stockitem.cpp:178 ../src/msw/msgdlg.cpp:454
-#: ../src/msw/msgdlg.cpp:747 ../src/gtk1/fontdlg.cpp:138
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:175
+#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/msgdlg.cpp:741 ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "确认"
 
-#: ../src/msw/ole/automtn.cpp:692
+#: ../src/msw/ole/automtn.cpp:683
 #, c-format
 msgid "OLE Automation error in %s: %s"
 msgstr "OLE 自动化错误 %s: %s"
@@ -5348,15 +5485,15 @@ msgstr "OLE 自动化错误 %s: %s"
 msgid "Object Properties"
 msgstr "对象属性"
 
-#: ../src/msw/ole/automtn.cpp:660
+#: ../src/msw/ole/automtn.cpp:651
 msgid "Object implementation does not support named arguments."
 msgstr "对象实现不支持命名参数"
 
-#: ../src/common/xtixml.cpp:264
+#: ../src/common/xtixml.cpp:260
 msgid "Objects must have an id attribute"
 msgstr "对象必须有一个id属性"
 
-#: ../src/propgrid/advprops.cpp:1601
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Olive"
 msgstr ""
 
@@ -5364,64 +5501,69 @@ msgstr ""
 msgid "Opaci&ty:"
 msgstr ""
 
-#: ../src/generic/colrdlgg.cpp:354
+#: ../src/generic/colrdlgg.cpp:374
 msgid "Opacity:"
 msgstr ""
 
-#: ../src/common/docview.cpp:1773 ../src/common/docview.cpp:1815
+#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
 msgid "Open File"
 msgstr "打开文件"
 
-#: ../src/html/helpwnd.cpp:671 ../src/html/helpwnd.cpp:1554
+#: ../src/html/helpwnd.cpp:669 ../src/html/helpwnd.cpp:1552
 msgid "Open HTML document"
 msgstr "打开HTML文档"
 
-#: ../src/generic/dbgrptg.cpp:163
+#: ../src/common/stockitem.cpp:265
+#, fuzzy
+msgid "Open an existing document"
+msgstr "打开HTML文档"
+
+#: ../src/generic/dbgrptg.cpp:160
 #, c-format
 msgid "Open file \"%s\""
 msgstr "打开文件 \"%s\""
 
-#: ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176
 msgid "Open..."
 msgstr "打开..."
 
-#: ../src/unix/glx11.cpp:506 ../src/msw/glcanvas.cpp:592
+#: ../src/msw/glcanvas.cpp:607 ../src/unix/glx11.cpp:513
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr ""
 
-#: ../src/generic/dirctrlg.cpp:599 ../src/generic/dirdlgg.cpp:323
-#: ../src/generic/filectrlg.cpp:642 ../src/generic/filectrlg.cpp:786
+#: ../src/generic/dirctrlg.cpp:565 ../src/generic/filectrlg.cpp:638
+#: ../src/generic/filectrlg.cpp:782 ../src/generic/dirdlgg.cpp:320
 msgid "Operation not permitted."
 msgstr "不允许的操作。"
 
-#: ../src/common/cmdline.cpp:900
+#: ../src/common/cmdline.cpp:896
 #, fuzzy, c-format
 msgid "Option '%s' can't be negated"
 msgstr "目录'%s'不能被创建"
 
-#: ../src/common/cmdline.cpp:1064
+#: ../src/common/cmdline.cpp:1060
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "选项 '%s' 需要值。"
 
-#: ../src/common/cmdline.cpp:1147
+#: ../src/common/cmdline.cpp:1143
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "选项 '%s': '%s' 无法转成日期。"
 
-#: ../src/generic/prntdlgg.cpp:618
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "选项"
 
-#: ../src/propgrid/advprops.cpp:1606
+#: ../src/propgrid/advprops.cpp:1512
 msgid "Orange"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:615 ../src/generic/prntdlgg.cpp:869
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:862
 msgid "Orientation"
 msgstr "方向"
 
-#: ../src/common/windowid.cpp:242
+#: ../src/common/windowid.cpp:237
 msgid "Out of window IDs.  Recommend shutting down application."
 msgstr "window ID已用完。建议关闭应用。"
 
@@ -5434,148 +5576,148 @@ msgstr ""
 msgid "Outset"
 msgstr ""
 
-#: ../src/msw/ole/automtn.cpp:656
+#: ../src/msw/ole/automtn.cpp:647
 msgid "Overflow while coercing argument values."
 msgstr "强制修改参数值溢出"
 
-#: ../src/common/imagpcx.cpp:457 ../src/common/imagpcx.cpp:480
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:479
 msgid "PCX: couldn't allocate memory"
 msgstr "PCX: 无法分配内存"
 
-#: ../src/common/imagpcx.cpp:456
+#: ../src/common/imagpcx.cpp:455
 msgid "PCX: image format unsupported"
 msgstr "PCX: 图像格式不支持"
 
-#: ../src/common/imagpcx.cpp:479
+#: ../src/common/imagpcx.cpp:478
 msgid "PCX: invalid image"
 msgstr "PCX: 无效图像"
 
-#: ../src/common/imagpcx.cpp:442
+#: ../src/common/imagpcx.cpp:441
 msgid "PCX: this is not a PCX file."
 msgstr "PCX: 不是PCX文件。"
 
-#: ../src/common/imagpcx.cpp:459 ../src/common/imagpcx.cpp:481
+#: ../src/common/imagpcx.cpp:458 ../src/common/imagpcx.cpp:480
 msgid "PCX: unknown error !!!"
 msgstr "PCX: 未知错误！！！"
 
-#: ../src/common/imagpcx.cpp:458
+#: ../src/common/imagpcx.cpp:457
 msgid "PCX: version number too low"
 msgstr "PCX: 版本号太小"
 
-#: ../src/common/imagpnm.cpp:91
+#: ../src/common/imagpnm.cpp:89
 msgid "PNM: Couldn't allocate memory."
 msgstr "PNM: 无法分配内存。"
 
-#: ../src/common/imagpnm.cpp:73
+#: ../src/common/imagpnm.cpp:71
 msgid "PNM: File format is not recognized."
 msgstr "PNM: 无法识别的文件格式。"
 
-#: ../src/common/imagpnm.cpp:112 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
 #: ../src/common/imagpnm.cpp:156
 msgid "PNM: File seems truncated."
 msgstr "PNM: 文件似乎已被截断。"
 
-#: ../src/common/paper.cpp:187
+#: ../src/common/paper.cpp:184
 msgid "PRC 16K 146 x 215 mm"
 msgstr "中国 16开 纸, 146 x 215 毫米"
 
-#: ../src/common/paper.cpp:200
+#: ../src/common/paper.cpp:197
 msgid "PRC 16K Rotated"
 msgstr "中国 16开 纸张(横向)"
 
-#: ../src/common/paper.cpp:188
+#: ../src/common/paper.cpp:185
 msgid "PRC 32K 97 x 151 mm"
 msgstr "中国 32开 纸, 97 x 151 毫米"
 
-#: ../src/common/paper.cpp:201
+#: ../src/common/paper.cpp:198
 msgid "PRC 32K Rotated"
 msgstr "中国 32开 纸张(横向)"
 
-#: ../src/common/paper.cpp:189
+#: ../src/common/paper.cpp:186
 msgid "PRC 32K(Big) 97 x 151 mm"
 msgstr "中国 32开(大) 纸, 97 x 151 毫米"
 
-#: ../src/common/paper.cpp:202
+#: ../src/common/paper.cpp:199
 msgid "PRC 32K(Big) Rotated"
 msgstr "中国 32开(大) 纸张(横向)"
 
-#: ../src/common/paper.cpp:190
+#: ../src/common/paper.cpp:187
 msgid "PRC Envelope #1 102 x 165 mm"
 msgstr "中国标准信封1#, 102 x 165 毫米"
 
-#: ../src/common/paper.cpp:203
+#: ../src/common/paper.cpp:200
 msgid "PRC Envelope #1 Rotated 165 x 102 mm"
 msgstr "中国标准信封1#(横向), 165 x 102 毫米"
 
-#: ../src/common/paper.cpp:199
+#: ../src/common/paper.cpp:196
 msgid "PRC Envelope #10 324 x 458 mm"
 msgstr "中国标准信封10#, 324 x 458 毫米"
 
-#: ../src/common/paper.cpp:212
+#: ../src/common/paper.cpp:209
 msgid "PRC Envelope #10 Rotated 458 x 324 mm"
 msgstr "中国标准信封10#(横向), 458 x 324 毫米"
 
-#: ../src/common/paper.cpp:191
+#: ../src/common/paper.cpp:188
 msgid "PRC Envelope #2 102 x 176 mm"
 msgstr "中国标准信封2#, 102 x 176 毫米"
 
-#: ../src/common/paper.cpp:204
+#: ../src/common/paper.cpp:201
 msgid "PRC Envelope #2 Rotated 176 x 102 mm"
 msgstr "中国标准信封2#(横向), 176 x 102 毫米"
 
-#: ../src/common/paper.cpp:192
+#: ../src/common/paper.cpp:189
 msgid "PRC Envelope #3 125 x 176 mm"
 msgstr "中国标准信封3#, 125 x 176 毫米"
 
-#: ../src/common/paper.cpp:205
+#: ../src/common/paper.cpp:202
 msgid "PRC Envelope #3 Rotated 176 x 125 mm"
 msgstr "中国标准信封3#(横向), 176 x 125 毫米"
 
-#: ../src/common/paper.cpp:193
+#: ../src/common/paper.cpp:190
 msgid "PRC Envelope #4 110 x 208 mm"
 msgstr "中国标准信封4#, 110 x 208 毫米"
 
-#: ../src/common/paper.cpp:206
+#: ../src/common/paper.cpp:203
 msgid "PRC Envelope #4 Rotated 208 x 110 mm"
 msgstr "中国标准信封4#(横向), 208 x 110 毫米"
 
-#: ../src/common/paper.cpp:194
+#: ../src/common/paper.cpp:191
 msgid "PRC Envelope #5 110 x 220 mm"
 msgstr "中国标准信封5#, 110 x 220 毫米"
 
-#: ../src/common/paper.cpp:207
+#: ../src/common/paper.cpp:204
 msgid "PRC Envelope #5 Rotated 220 x 110 mm"
 msgstr "中国标准信封5#(横向), 220 x 110 毫米"
 
-#: ../src/common/paper.cpp:195
+#: ../src/common/paper.cpp:192
 msgid "PRC Envelope #6 120 x 230 mm"
 msgstr "中国标准信封6#, 120 x 230 毫米"
 
-#: ../src/common/paper.cpp:208
+#: ../src/common/paper.cpp:205
 msgid "PRC Envelope #6 Rotated 230 x 120 mm"
 msgstr "中国标准信封6#(横向), 230 x 120 毫米"
 
-#: ../src/common/paper.cpp:196
+#: ../src/common/paper.cpp:193
 msgid "PRC Envelope #7 160 x 230 mm"
 msgstr "中国标准信封7#, 160 x 230 毫米"
 
-#: ../src/common/paper.cpp:209
+#: ../src/common/paper.cpp:206
 msgid "PRC Envelope #7 Rotated 230 x 160 mm"
 msgstr "中国标准信封7#(横向), 230 x 160 毫米"
 
-#: ../src/common/paper.cpp:197
+#: ../src/common/paper.cpp:194
 msgid "PRC Envelope #8 120 x 309 mm"
 msgstr "中国标准信封8#, 120 x 309 毫米"
 
-#: ../src/common/paper.cpp:210
+#: ../src/common/paper.cpp:207
 msgid "PRC Envelope #8 Rotated 309 x 120 mm"
 msgstr "中国标准信封8#(横向), 309 x 120 毫米"
 
-#: ../src/common/paper.cpp:198
+#: ../src/common/paper.cpp:195
 msgid "PRC Envelope #9 229 x 324 mm"
 msgstr "中国标准信封9#, 229 x 324 毫米"
 
-#: ../src/common/paper.cpp:211
+#: ../src/common/paper.cpp:208
 msgid "PRC Envelope #9 Rotated 324 x 229 mm"
 msgstr "中国标准信封9#(横向), 324 x 229 毫米"
 
@@ -5584,91 +5726,95 @@ msgstr "中国标准信封9#(横向), 324 x 229 毫米"
 msgid "Padding"
 msgstr "正在读入"
 
-#: ../src/common/prntbase.cpp:2074
+#: ../src/common/prntbase.cpp:2096
 #, c-format
 msgid "Page %d"
 msgstr "页 %d"
 
-#: ../src/common/prntbase.cpp:2072
+#: ../src/common/prntbase.cpp:2094
 #, c-format
 msgid "Page %d of %d"
 msgstr "页 %d / %d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 #, fuzzy
 msgid "Page Down"
 msgstr "页 %d"
 
-#: ../src/gtk/print.cpp:826
+#: ../src/gtk/print.cpp:829
 msgid "Page Setup"
 msgstr "页面设置"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 #, fuzzy
 msgid "Page Up"
 msgstr "页 %d"
 
-#: ../src/generic/prntdlgg.cpp:828 ../src/common/prntbase.cpp:484
+#: ../src/common/prntbase.cpp:479 ../src/generic/prntdlgg.cpp:821
 msgid "Page setup"
 msgstr "页面设置"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 #, fuzzy
 msgid "PageDown"
 msgstr "向下"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 #, fuzzy
 msgid "PageUp"
 msgstr "页"
 
-#: ../src/generic/prntdlgg.cpp:216
+#: ../src/generic/prntdlgg.cpp:209
 msgid "Pages"
 msgstr "页"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1765
+#: ../src/propgrid/advprops.cpp:1666
 msgid "Paint Brush"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:602 ../src/generic/prntdlgg.cpp:801
-#: ../src/generic/prntdlgg.cpp:842 ../src/generic/prntdlgg.cpp:855
-#: ../src/generic/prntdlgg.cpp:1052 ../src/generic/prntdlgg.cpp:1057
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:794
+#: ../src/generic/prntdlgg.cpp:835 ../src/generic/prntdlgg.cpp:848
+#: ../src/generic/prntdlgg.cpp:1045 ../src/generic/prntdlgg.cpp:1050
 msgid "Paper size"
 msgstr "纸张大小"
 
-#: ../src/richtext/richtextstyles.cpp:1062
+#: ../src/richtext/richtextstyles.cpp:1059
 msgid "Paragraph styles"
 msgstr "段落样式"
 
-#: ../src/common/xtistrm.cpp:465
+#: ../src/common/xtistrm.cpp:462
 msgid "Passing a already registered object to SetObject"
 msgstr "传递一个已注册的对象给SetObject"
 
-#: ../src/common/xtistrm.cpp:476
+#: ../src/common/xtistrm.cpp:473
 msgid "Passing an unknown object to GetObject"
 msgstr "传递一个未知对象给 GetObject"
 
-#: ../src/richtext/richtextctrl.cpp:3513 ../src/common/stockitem.cpp:180
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:177 ../src/richtext/richtextctrl.cpp:3514
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "粘贴"
 
-#: ../src/common/stockitem.cpp:262
+#: ../src/common/stockitem.cpp:260
 msgid "Paste selection"
 msgstr "粘贴选区"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:74
+#: ../src/common/accelcmn.cpp:71
 msgid "Pause"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1766
+#: ../src/propgrid/advprops.cpp:1667
 msgid "Pencil"
 msgstr ""
 
@@ -5677,21 +5823,21 @@ msgstr ""
 msgid "Peri&od"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:430
+#: ../src/generic/filectrlg.cpp:426
 msgid "Permissions"
 msgstr "允许"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:60
+#: ../src/common/accelcmn.cpp:57
 msgid "PgDn"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:59
+#: ../src/common/accelcmn.cpp:56
 msgid "PgUp"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:12868
+#: ../src/richtext/richtextbuffer.cpp:12863
 msgid "Picture Properties"
 msgstr "图片属性"
 
@@ -5703,44 +5849,44 @@ msgstr "管道创建失败"
 msgid "Please choose a valid font."
 msgstr "请选择一个有效的字体."
 
-#: ../src/generic/filedlgg.cpp:357 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
 msgid "Please choose an existing file."
 msgstr "请选择一个已存在的文件."
 
-#: ../src/html/helpwnd.cpp:800
+#: ../src/html/helpwnd.cpp:798
 msgid "Please choose the page to display:"
 msgstr "请选择欲显示的页面:"
 
-#: ../src/msw/dialup.cpp:764
+#: ../src/msw/dialup.cpp:758
 msgid "Please choose which ISP do you want to connect to"
 msgstr "请选择你想连接的ISP"
 
-#: ../src/common/headerctrlcmn.cpp:59
+#: ../src/common/headerctrlcmn.cpp:57
 msgid "Please select the columns to show and define their order:"
 msgstr "请选择列并显示和定义它们的顺序"
 
-#: ../src/common/prntbase.cpp:538
+#: ../src/common/prntbase.cpp:533
 msgid "Please wait while printing..."
 msgstr "打印，请等待..."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1767
+#: ../src/propgrid/advprops.cpp:1668
 #, fuzzy
 msgid "Point Left"
 msgstr "字体大小(磅值)"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1768
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgid "Point Right"
 msgstr "右对齐"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:662
+#: ../src/propgrid/advprops.cpp:572
 msgid "Point Size"
 msgstr "字体大小(磅值)"
 
-#: ../src/generic/prntdlgg.cpp:612 ../src/generic/prntdlgg.cpp:867
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:860
 msgid "Portrait"
 msgstr "纵向"
 
@@ -5748,253 +5894,263 @@ msgstr "纵向"
 msgid "Position"
 msgstr "位置"
 
-#: ../src/generic/prntdlgg.cpp:298
+#: ../src/generic/prntdlgg.cpp:291
 msgid "PostScript file"
 msgstr "PostScript文件"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178 ../src/osx/cocoa/preferences.mm:303
 msgid "Preferences"
 msgstr "偏好设置"
 
-#: ../src/osx/menu_osx.cpp:568
+#: ../src/osx/menu_osx.cpp:460
 msgid "Preferences..."
 msgstr "偏好设置..."
 
-#: ../src/common/prntbase.cpp:546
+#: ../src/common/prntbase.cpp:541
 msgid "Preparing"
 msgstr "准备中"
 
-#: ../src/generic/fontdlgg.cpp:455 ../src/osx/carbon/fontdlg.cpp:390
-#: ../src/html/helpwnd.cpp:1222
+#: ../src/osx/carbon/fontdlg.cpp:387 ../src/generic/fontdlgg.cpp:452
+#: ../src/html/helpwnd.cpp:1220
 msgid "Preview:"
 msgstr "预览:"
 
-#: ../src/common/prntbase.cpp:1553 ../src/html/helpwnd.cpp:664
+#: ../src/common/prntbase.cpp:1578 ../src/html/helpwnd.cpp:662
 msgid "Previous page"
 msgstr "前页"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/prntdlgg.cpp:143 ../src/generic/prntdlgg.cpp:157
-#: ../src/common/prntbase.cpp:426 ../src/common/prntbase.cpp:1541
-#: ../src/common/accelcmn.cpp:77 ../src/gtk/print.cpp:620
-#: ../src/gtk/print.cpp:638
+#: ../src/common/prntbase.cpp:421 ../src/common/prntbase.cpp:1566
+#: ../src/common/accelcmn.cpp:74 ../src/generic/prntdlgg.cpp:136
+#: ../src/generic/prntdlgg.cpp:150 ../src/gtk/print.cpp:616
+#: ../src/gtk/print.cpp:634
 msgid "Print"
 msgstr "打印"
 
-#: ../include/wx/prntbase.h:399 ../src/common/docview.cpp:1268
+#: ../src/common/docview.cpp:1262
 msgid "Print Preview"
 msgstr "打印预览"
 
-#: ../src/common/prntbase.cpp:2015 ../src/common/prntbase.cpp:2057
-#: ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2037 ../src/common/prntbase.cpp:2079
+#: ../src/common/prntbase.cpp:2087
 msgid "Print Preview Failure"
 msgstr "打印预览失败"
 
-#: ../src/generic/prntdlgg.cpp:224
+#: ../src/generic/prntdlgg.cpp:217
 msgid "Print Range"
 msgstr "打印范围"
 
-#: ../src/generic/prntdlgg.cpp:449
+#: ../src/generic/prntdlgg.cpp:442
 msgid "Print Setup"
 msgstr "打印设置"
 
-#: ../src/generic/prntdlgg.cpp:621
+#: ../src/generic/prntdlgg.cpp:614
 msgid "Print in colour"
 msgstr "彩色打印"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/osx/webview_webkit.mm:260
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "列描述无法初始化。"
+
+#: ../src/common/stockitem.cpp:179
 msgid "Print previe&w..."
 msgstr "打印预览(&W)..."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1256
 msgid "Print preview creation failed."
 msgstr "打印预览创建失败"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/common/stockitem.cpp:179
 msgid "Print preview..."
 msgstr "打印预览..."
 
-#: ../src/generic/prntdlgg.cpp:630
+#: ../src/generic/prntdlgg.cpp:623
 msgid "Print spooling"
 msgstr "打印假脱机"
 
-#: ../src/html/helpwnd.cpp:675
+#: ../src/html/helpwnd.cpp:673
 msgid "Print this page"
 msgstr "打印本页"
 
-#: ../src/generic/prntdlgg.cpp:185
+#: ../src/generic/prntdlgg.cpp:178
 msgid "Print to File"
 msgstr "打印到文件"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "Print..."
 msgstr "打印..."
 
-#: ../src/generic/prntdlgg.cpp:493
+#: ../src/generic/prntdlgg.cpp:486
 msgid "Printer"
 msgstr "打印机"
 
-#: ../src/generic/prntdlgg.cpp:633
+#: ../src/generic/prntdlgg.cpp:626
 msgid "Printer command:"
 msgstr "打印机命令:"
 
-#: ../src/generic/prntdlgg.cpp:180
+#: ../src/generic/prntdlgg.cpp:173
 msgid "Printer options"
 msgstr "打印机选项"
 
-#: ../src/generic/prntdlgg.cpp:645
+#: ../src/generic/prntdlgg.cpp:638
 msgid "Printer options:"
 msgstr "打印机选项:"
 
-#: ../src/generic/prntdlgg.cpp:916
+#: ../src/generic/prntdlgg.cpp:909
 msgid "Printer..."
 msgstr "打印机..."
 
-#: ../src/generic/prntdlgg.cpp:196
+#: ../src/generic/prntdlgg.cpp:189
 msgid "Printer:"
 msgstr "打印机:"
 
-#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:535
-#: ../src/html/htmprint.cpp:277
+#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:530
+#: ../src/html/htmprint.cpp:289
 msgid "Printing"
 msgstr "正在打印 "
 
-#: ../src/common/prntbase.cpp:612
+#: ../src/common/prntbase.cpp:607
 msgid "Printing "
 msgstr "正在打印 "
 
-#: ../src/common/prntbase.cpp:347
+#: ../src/common/prntbase.cpp:342
 msgid "Printing Error"
 msgstr "打印出错"
 
-#: ../src/common/prntbase.cpp:565
+#: ../src/osx/webview_webkit.mm:251
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "此版本的 zlib 不支持 Gzip"
+
+#: ../src/common/prntbase.cpp:560
 #, fuzzy, c-format
 msgid "Printing page %d"
 msgstr "正在打印页 %d..."
 
-#: ../src/common/prntbase.cpp:570
+#: ../src/common/prntbase.cpp:565
 #, c-format
 msgid "Printing page %d of %d"
 msgstr "正在打印页 %d 共 %d..."
 
-#: ../src/generic/printps.cpp:201
+#: ../src/generic/printps.cpp:182
 #, c-format
 msgid "Printing page %d..."
 msgstr "正在打印页 %d..."
 
-#: ../src/generic/printps.cpp:161
+#: ../src/generic/printps.cpp:142
 msgid "Printing..."
 msgstr "打印..."
 
-#: ../include/wx/richtext/richtextprint.h:109 ../include/wx/prntbase.h:267
-#: ../src/common/docview.cpp:2132
+#: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
+#: ../src/common/docview.cpp:2137
 msgid "Printout"
 msgstr "打印"
 
-#: ../src/common/debugrpt.cpp:560
+#: ../src/common/debugrpt.cpp:561
 #, c-format
 msgid ""
 "Processing debug report has failed, leaving the files in \"%s\" directory."
 msgstr "处理调试报告失败, 文件被保存在目录 \"%s\" 中."
 
-#: ../src/common/prntbase.cpp:545
+#: ../src/common/prntbase.cpp:540
 msgid "Progress:"
 msgstr "进度:"
 
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181
 msgid "Properties"
 msgstr "属性"
 
-#: ../src/propgrid/manager.cpp:237
+#: ../src/propgrid/manager.cpp:223
 msgid "Property"
 msgstr "属性"
 
 #. TRANSLATORS: Caption of message box displaying any property error
-#: ../src/propgrid/propgrid.cpp:3185 ../src/propgrid/propgrid.cpp:3318
+#: ../src/propgrid/propgrid.cpp:3162 ../src/propgrid/propgrid.cpp:3299
 msgid "Property Error"
 msgstr "属性错误"
 
-#: ../src/propgrid/advprops.cpp:1597
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Purple"
 msgstr ""
 
-#: ../src/common/paper.cpp:112
+#: ../src/common/paper.cpp:109
 msgid "Quarto, 215 x 275 mm"
 msgstr "四开, 215 x 275 毫米"
 
-#: ../src/generic/logg.cpp:1016
+#: ../src/generic/logg.cpp:1013
 msgid "Question"
 msgstr "问题"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1769
+#: ../src/propgrid/advprops.cpp:1670
 #, fuzzy
 msgid "Question Arrow"
 msgstr "问题"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "Quit"
 msgstr "退出"
 
-#: ../src/osx/menu_osx.cpp:585
+#: ../src/osx/menu_osx.cpp:477
 #, c-format
 msgid "Quit %s"
 msgstr "退出 %s"
 
-#: ../src/common/stockitem.cpp:263
+#: ../src/common/stockitem.cpp:261
 msgid "Quit this program"
 msgstr "退出此程序"
 
-#: ../src/common/accelcmn.cpp:338
+#: ../src/common/accelcmn.cpp:352
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/ffile.cpp:109 ../src/common/ffile.cpp:133
+#: ../src/common/ffile.cpp:107 ../src/common/ffile.cpp:132
 #, c-format
 msgid "Read error on file '%s'"
 msgstr "读文件 '%s'出错"
 
-#: ../src/common/secretstore.cpp:199
+#: ../src/common/secretstore.cpp:211
 #, fuzzy, c-format
-msgid "Reading password for \"%s/%s\" failed: %s."
+msgid "Reading password for \"%s\" failed: %s."
 msgstr "将 '%s' 解压至 '%s' 失败。"
 
-#: ../src/common/prntbase.cpp:272
+#: ../src/common/prntbase.cpp:267
 msgid "Ready"
 msgstr "就绪"
 
-#: ../src/propgrid/advprops.cpp:1605
+#: ../src/propgrid/advprops.cpp:1511
 #, fuzzy
 msgid "Red"
 msgstr "恢复"
 
-#: ../src/generic/colrdlgg.cpp:339
+#: ../src/generic/colrdlgg.cpp:359
 msgid "Red:"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:185 ../src/stc/stc_i18n.cpp:16
+#: ../src/common/stockitem.cpp:182 ../src/stc/stc_i18n.cpp:16
 msgid "Redo"
 msgstr "恢复"
 
-#: ../src/common/stockitem.cpp:264
+#: ../src/common/stockitem.cpp:262
 msgid "Redo last action"
 msgstr "恢复上一次操作"
 
-#: ../src/common/stockitem.cpp:186
+#: ../src/common/stockitem.cpp:183
 msgid "Refresh"
 msgstr "刷新"
 
-#: ../src/msw/registry.cpp:626
+#: ../src/msw/registry.cpp:615
 #, c-format
 msgid "Registry key '%s' already exists."
 msgstr "注册键 '%s' 已存在."
 
-#: ../src/msw/registry.cpp:595
+#: ../src/msw/registry.cpp:584
 #, c-format
 msgid "Registry key '%s' does not exist, cannot rename it."
 msgstr "注册键 '%s' 不存在，无法改名。"
 
-#: ../src/msw/registry.cpp:727
+#: ../src/msw/registry.cpp:716
 #, c-format
 msgid ""
 "Registry key '%s' is needed for normal system operation,\n"
@@ -6005,22 +6161,22 @@ msgstr ""
 "删除它将使系统进入不可用状态:\n"
 "操作终止."
 
-#: ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:942
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:917
+#: ../src/msw/registry.cpp:905
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1003
+#: ../src/msw/registry.cpp:991
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:521
+#: ../src/msw/registry.cpp:510
 #, c-format
 msgid "Registry value '%s' already exists."
 msgstr "注册值 '%s' 已存在."
@@ -6035,70 +6191,76 @@ msgstr "一般"
 msgid "Relative"
 msgstr "修饰"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:456
 msgid "Relevant entries:"
 msgstr "相关条目:"
 
-#: ../include/wx/generic/progdlgg.h:86
+#: ../include/wx/generic/progdlgg.h:87
 msgid "Remaining time:"
 msgstr "剩余时间:"
 
-#: ../src/common/stockitem.cpp:187
+#: ../src/common/stockitem.cpp:184
 msgid "Remove"
 msgstr "移除"
 
-#: ../src/richtext/richtextctrl.cpp:1562
+#: ../src/richtext/richtextctrl.cpp:1563
 msgid "Remove Bullet"
 msgstr "移除项目符号"
 
-#: ../src/html/helpwnd.cpp:433
+#: ../src/html/helpwnd.cpp:431
 msgid "Remove current page from bookmarks"
 msgstr "从书签中移去当前页"
 
-#: ../src/common/rendcmn.cpp:194
+#: ../src/common/rendcmn.cpp:191
 #, c-format
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr "渲染器 \"%s\" 的版本 %d.%d 不兼容, 无法加载."
 
-#: ../src/richtext/richtextbuffer.cpp:4527
+#: ../src/richtext/richtextbuffer.cpp:4524
 msgid "Renumber List"
 msgstr "重编号列表"
 
-#: ../src/common/stockitem.cpp:188
-msgid "Rep&lace"
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Rep&lace..."
 msgstr "替换(&l)"
 
-#: ../src/richtext/richtextctrl.cpp:3673 ../src/common/stockitem.cpp:188
+#: ../src/richtext/richtextctrl.cpp:3674
 msgid "Replace"
 msgstr "替换"
 
-#: ../src/generic/fdrepdlg.cpp:182
+#: ../src/generic/fdrepdlg.cpp:179
 msgid "Replace &all"
 msgstr "全部替换(&a)"
 
-#: ../src/common/stockitem.cpp:261
-msgid "Replace selection"
-msgstr "替换选区"
-
-#: ../src/generic/fdrepdlg.cpp:124
+#: ../src/generic/fdrepdlg.cpp:121
 msgid "Replace with:"
 msgstr "替换为:"
 
-#: ../src/common/valtext.cpp:163
+#: ../src/common/stockitem.cpp:185
+#, fuzzy
+msgid "Replace..."
+msgstr "替换"
+
+#: ../src/common/valtext.cpp:184
 msgid "Required information entry is empty."
 msgstr "所需的项目信息为空"
 
-#: ../src/common/translation.cpp:1975
+#: ../src/common/translation.cpp:2025
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "资源 '%s' 不是有效的消息目录。"
 
+#: ../src/gtk/webview_webkit.cpp:985
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:56
+#: ../src/common/accelcmn.cpp:53
 msgid "Return"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:189
+#: ../src/common/stockitem.cpp:186
 msgid "Revert to Saved"
 msgstr "还原为上次保存的文件"
 
@@ -6111,42 +6273,42 @@ msgstr "细"
 msgid "Rig&ht-to-left"
 msgstr "从右到左 (&h)"
 
-#. TRANSLATORS: Keystroke for manipulating a tree control
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/datavgen.cpp:6149
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/common/accelcmn.cpp:59 ../src/generic/datavgen.cpp:6954
+#: ../src/richtext/richtextsizepage.cpp:250
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextbulletspage.cpp:188
-#: ../src/richtext/richtextsizepage.cpp:250 ../src/common/accelcmn.cpp:62
 msgid "Right"
 msgstr "右"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1754
+#: ../src/propgrid/advprops.cpp:1655
 #, fuzzy
 msgid "Right Arrow"
 msgstr "右"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1770
+#: ../src/propgrid/advprops.cpp:1671
 msgid "Right Button"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:892
+#: ../src/generic/prntdlgg.cpp:885
 msgid "Right margin (mm):"
 msgstr "右边距 (毫米):"
 
-#: ../src/richtext/richtextindentspage.cpp:148
-#: ../src/richtext/richtextindentspage.cpp:150
 #: ../src/richtext/richtextliststylepage.cpp:337
 #: ../src/richtext/richtextliststylepage.cpp:339
+#: ../src/richtext/richtextindentspage.cpp:148
+#: ../src/richtext/richtextindentspage.cpp:150
 msgid "Right-align text."
 msgstr "文本右对齐"
 
-#: ../src/generic/fontdlgg.cpp:322
+#: ../src/generic/fontdlgg.cpp:318
 msgid "Roman"
 msgstr "罗马"
 
-#: ../src/generic/datavgen.cpp:5916
+#: ../src/generic/datavgen.cpp:6721
 #, c-format
 msgid "Row %i"
 msgstr ""
@@ -6156,30 +6318,31 @@ msgstr ""
 msgid "S&tandard bullet name:"
 msgstr "标准项目符号名称(&T)"
 
-#: ../src/common/accelcmn.cpp:268 ../src/common/accelcmn.cpp:350
+#: ../src/common/accelcmn.cpp:282 ../src/common/accelcmn.cpp:367
 msgid "SPECIAL"
 msgstr "SPECIAL"
 
-#: ../src/common/stockitem.cpp:190 ../src/common/sizer.cpp:2797
+#: ../src/common/stockitem.cpp:187 ../src/common/sizer.cpp:2914
 msgid "Save"
 msgstr "保存"
 
-#: ../src/common/fldlgcmn.cpp:342
+#: ../src/common/fldlgcmn.cpp:339
 #, c-format
 msgid "Save %s file"
 msgstr "保存文件 %s "
 
-#: ../src/generic/logg.cpp:512
+#: ../src/common/stockitem.cpp:188 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "另存为(&A)..."
 
-#: ../src/common/docview.cpp:366
+#: ../src/common/docview.cpp:359
 msgid "Save As"
 msgstr "另存为"
 
-#: ../src/common/stockitem.cpp:191
-msgid "Save as"
-msgstr "另存为"
+#: ../src/common/stockitem.cpp:188
+#, fuzzy
+msgid "Save As..."
+msgstr "另存为(&A)..."
 
 #: ../src/common/stockitem.cpp:267
 msgid "Save current document"
@@ -6189,95 +6352,95 @@ msgstr "保存当前文档"
 msgid "Save current document with a different filename"
 msgstr "保存当前文档至重命名"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/generic/logg.cpp:509
 msgid "Save log contents to file"
 msgstr "把日志内容保存到文件"
 
-#: ../src/common/secretstore.cpp:179
+#: ../src/common/secretstore.cpp:189
 #, fuzzy, c-format
-msgid "Saving password for \"%s/%s\" failed: %s."
+msgid "Saving password for \"%s\" failed: %s."
 msgstr "将 '%s' 解压至 '%s' 失败。"
 
-#: ../src/generic/fontdlgg.cpp:325
+#: ../src/generic/fontdlgg.cpp:321
 msgid "Script"
 msgstr "Script"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll Lock"
 msgstr ""
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll_lock"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:890
+#: ../src/propgrid/advprops.cpp:791
 msgid "Scrollbar"
 msgstr ""
 
-#: ../src/generic/srchctlg.cpp:56 ../src/html/helpwnd.cpp:535
-#: ../src/html/helpwnd.cpp:550
+#: ../src/generic/srchctlg.cpp:55 ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:548 ../src/gtk/srchctrl.cpp:182
 msgid "Search"
 msgstr "搜索"
 
-#: ../src/html/helpwnd.cpp:537
+#: ../src/html/helpwnd.cpp:535
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
 msgstr "从帮助内容中搜索符合你在上面输入的正文的所有条目"
 
-#: ../src/generic/fdrepdlg.cpp:160
+#: ../src/generic/fdrepdlg.cpp:157
 msgid "Search direction"
 msgstr "搜索方向"
 
-#: ../src/generic/fdrepdlg.cpp:112
+#: ../src/generic/fdrepdlg.cpp:109
 msgid "Search for:"
 msgstr "搜索:"
 
-#: ../src/html/helpwnd.cpp:1052
+#: ../src/html/helpwnd.cpp:1050
 msgid "Search in all books"
 msgstr "搜索所有的书籍"
 
-#: ../src/html/helpwnd.cpp:857
+#: ../src/html/helpwnd.cpp:855
 msgid "Searching..."
 msgstr "搜索中..."
 
-#: ../src/generic/dirctrlg.cpp:446
+#: ../src/generic/dirctrlg.cpp:412
 msgid "Sections"
 msgstr "段"
 
-#: ../src/common/ffile.cpp:238
+#: ../src/common/ffile.cpp:237
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "文件 '%s' 定位错误"
 
-#: ../src/common/ffile.cpp:228
+#: ../src/common/ffile.cpp:227
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr "文件 '%s' 定位错误 (stdio 不支持大文件)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:76
+#: ../src/common/accelcmn.cpp:73
 #, fuzzy
 msgid "Select"
 msgstr "选区"
 
-#: ../src/richtext/richtextctrl.cpp:337 ../src/osx/textctrl_osx.cpp:581
-#: ../src/common/stockitem.cpp:192 ../src/msw/textctrl.cpp:2512
+#: ../src/osx/textctrl_osx.cpp:599 ../src/common/stockitem.cpp:189
+#: ../src/msw/textctrl.cpp:2777 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "全部选择(&A)"
 
-#: ../src/common/stockitem.cpp:192 ../src/stc/stc_i18n.cpp:21
+#: ../src/common/stockitem.cpp:189 ../src/stc/stc_i18n.cpp:21
 msgid "Select All"
 msgstr "全部选择"
 
-#: ../src/common/docview.cpp:1895
+#: ../src/common/docview.cpp:1900
 msgid "Select a document template"
 msgstr "选择文档模板"
 
-#: ../src/common/docview.cpp:1969
+#: ../src/common/docview.cpp:1974
 msgid "Select a document view"
 msgstr "选择文档视图"
 
@@ -6306,20 +6469,20 @@ msgid "Selects the list level to edit."
 msgstr "选择并辨析列表层级"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:82
+#: ../src/common/accelcmn.cpp:79
 msgid "Separator"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1083
+#: ../src/common/cmdline.cpp:1079
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "期望在选项 '%s' 后存在分隔符。"
 
-#: ../src/osx/menu_osx.cpp:572
+#: ../src/osx/menu_osx.cpp:464
 msgid "Services"
 msgstr "服务"
 
-#: ../src/richtext/richtextbuffer.cpp:11217
+#: ../src/richtext/richtextbuffer.cpp:11216
 msgid "Set Cell Style"
 msgstr "设置单元格样式"
 
@@ -6327,11 +6490,11 @@ msgstr "设置单元格样式"
 msgid "SetProperty called w/o valid setter"
 msgstr "调用 SetProperty 时未带有效的 setter"
 
-#: ../src/generic/prntdlgg.cpp:188
+#: ../src/generic/prntdlgg.cpp:181
 msgid "Setup..."
 msgstr "设置..."
 
-#: ../src/msw/dialup.cpp:544
+#: ../src/msw/dialup.cpp:538
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr "找到多个活动拨号连接, 随机选择一个."
 
@@ -6348,40 +6511,40 @@ msgstr ""
 msgid "Shadow c&olour:"
 msgstr "选择颜色"
 
-#: ../src/common/accelcmn.cpp:335
+#: ../src/common/accelcmn.cpp:349
 msgid "Shift+"
 msgstr "Shift+"
 
-#: ../src/generic/dirdlgg.cpp:147
+#: ../src/generic/dirdlgg.cpp:144
 msgid "Show &hidden directories"
 msgstr "显示隐藏目录(&H)"
 
-#: ../src/generic/filectrlg.cpp:983
+#: ../src/generic/filectrlg.cpp:979
 msgid "Show &hidden files"
 msgstr "显示隐藏文件(&H)"
 
-#: ../src/osx/menu_osx.cpp:580
+#: ../src/osx/menu_osx.cpp:472
 msgid "Show All"
 msgstr "显示全部"
 
-#: ../src/common/stockitem.cpp:257
+#: ../src/common/stockitem.cpp:254
 msgid "Show about dialog"
 msgstr "显示关于对话框"
 
-#: ../src/html/helpwnd.cpp:492
+#: ../src/html/helpwnd.cpp:490
 msgid "Show all"
 msgstr "显示全部"
 
-#: ../src/html/helpwnd.cpp:503
+#: ../src/html/helpwnd.cpp:501
 msgid "Show all items in index"
 msgstr "以索引方式显示所有项目"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:656
 msgid "Show/hide navigation panel"
 msgstr "显示/隐藏 导航面板"
 
-#: ../src/richtext/richtextsymboldlg.cpp:421
-#: ../src/richtext/richtextsymboldlg.cpp:423
+#: ../src/richtext/richtextsymboldlg.cpp:418
+#: ../src/richtext/richtextsymboldlg.cpp:420
 msgid "Shows a Unicode subset."
 msgstr "显示Unicode子集"
 
@@ -6397,7 +6560,7 @@ msgstr "预览项目符号设定"
 msgid "Shows a preview of the font settings."
 msgstr "预览字体设定"
 
-#: ../src/osx/carbon/fontdlg.cpp:394 ../src/osx/carbon/fontdlg.cpp:396
+#: ../src/osx/carbon/fontdlg.cpp:391 ../src/osx/carbon/fontdlg.cpp:393
 msgid "Shows a preview of the font."
 msgstr "预览字体"
 
@@ -6406,62 +6569,62 @@ msgstr "预览字体"
 msgid "Shows a preview of the paragraph settings."
 msgstr "预览段落设定"
 
-#: ../src/generic/fontdlgg.cpp:460 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:456 ../src/generic/fontdlgg.cpp:458
 msgid "Shows the font preview."
 msgstr "显示字体预览。"
 
-#: ../src/propgrid/advprops.cpp:1607
+#: ../src/propgrid/advprops.cpp:1513
 msgid "Silver"
 msgstr ""
 
-#: ../src/univ/themes/mono.cpp:516
+#: ../src/univ/themes/mono.cpp:513
 msgid "Simple monochrome theme"
 msgstr "简单黑白主题"
 
-#: ../src/richtext/richtextindentspage.cpp:275
 #: ../src/richtext/richtextliststylepage.cpp:449
+#: ../src/richtext/richtextindentspage.cpp:275
 msgid "Single"
 msgstr ""
 
-#: ../src/generic/filectrlg.cpp:425 ../src/richtext/richtextformatdlg.cpp:369
-#: ../src/richtext/richtextsizepage.cpp:299
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextsizepage.cpp:299
+#: ../src/richtext/richtextformatdlg.cpp:362
 msgid "Size"
 msgstr "大小"
 
-#: ../src/osx/carbon/fontdlg.cpp:339
+#: ../src/osx/carbon/fontdlg.cpp:336
 msgid "Size:"
 msgstr "大小:"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1775
+#: ../src/propgrid/advprops.cpp:1676
 msgid "Sizing"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1772
+#: ../src/propgrid/advprops.cpp:1673
 msgid "Sizing N-S"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1771
+#: ../src/propgrid/advprops.cpp:1672
 msgid "Sizing NE-SW"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1773
+#: ../src/propgrid/advprops.cpp:1674
 msgid "Sizing NW-SE"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1774
+#: ../src/propgrid/advprops.cpp:1675
 msgid "Sizing W-E"
 msgstr ""
 
-#: ../src/msw/progdlg.cpp:801
+#: ../src/msw/progdlg.cpp:1088
 msgid "Skip"
 msgstr "跳过"
 
-#: ../src/generic/fontdlgg.cpp:330
+#: ../src/generic/fontdlgg.cpp:326
 msgid "Slant"
 msgstr "倾斜"
 
@@ -6471,7 +6634,7 @@ msgid "Small C&apitals"
 msgstr "大写(&P)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:79
+#: ../src/common/accelcmn.cpp:76
 msgid "Snapshot"
 msgstr ""
 
@@ -6479,37 +6642,37 @@ msgstr ""
 msgid "Solid"
 msgstr "实线"
 
-#: ../src/common/docview.cpp:1791
+#: ../src/common/docview.cpp:1785
 msgid "Sorry, could not open this file."
 msgstr "对不起，无法打开文件。"
 
-#: ../src/common/prntbase.cpp:2057 ../src/common/prntbase.cpp:2065
+#: ../src/common/prntbase.cpp:2079 ../src/common/prntbase.cpp:2087
 msgid "Sorry, not enough memory to create a preview."
 msgstr "对不起，没有足够内存创建预览。"
 
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "Sorry, that name is taken. Please choose another."
 msgstr "抱歉，名字已被使用。请选择其他名字。"
 
-#: ../src/common/docview.cpp:1814
+#: ../src/common/docview.cpp:1819
 msgid "Sorry, the format for this file is unknown."
 msgstr "对不起，此文件的格式未知。"
 
-#: ../src/unix/sound.cpp:492
+#: ../src/unix/sound.cpp:481
 msgid "Sound data are in unsupported format."
 msgstr "声音数据为不支持的格式。"
 
-#: ../src/unix/sound.cpp:477
+#: ../src/unix/sound.cpp:466
 #, c-format
 msgid "Sound file '%s' is in unsupported format."
 msgstr "声音文件 '%s' 为不支持的格式。"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:67
+#: ../src/common/accelcmn.cpp:64
 #, fuzzy
 msgid "Space"
 msgstr "空格"
@@ -6518,12 +6681,12 @@ msgstr "空格"
 msgid "Spacing"
 msgstr "空格"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "Spell Check"
 msgstr "拼写检查"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1776
+#: ../src/propgrid/advprops.cpp:1677
 msgid "Spraycan"
 msgstr ""
 
@@ -6532,7 +6695,7 @@ msgstr ""
 msgid "Standard"
 msgstr "标准"
 
-#: ../src/common/paper.cpp:104
+#: ../src/common/paper.cpp:101
 msgid "Statement, 5 1/2 x 8 1/2 in"
 msgstr "报表用纸，5 1/2 x 8 1/2 英寸"
 
@@ -6541,33 +6704,29 @@ msgstr "报表用纸，5 1/2 x 8 1/2 英寸"
 msgid "Static"
 msgstr "状态:"
 
-#: ../src/generic/prntdlgg.cpp:204
+#: ../src/generic/prntdlgg.cpp:197
 msgid "Status:"
 msgstr "状态:"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "Stop"
 msgstr "停止"
 
-#: ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196
 msgid "Strikethrough"
 msgstr "删除线"
 
-#: ../src/common/colourcmn.cpp:45
+#: ../src/common/colourcmn.cpp:42
 #, c-format
 msgid "String To Colour : Incorrect colour specification : %s"
 msgstr "字符串 - 颜色: 错误的颜色: %s"
 
 #. TRANSLATORS: Label of font style
-#: ../src/richtext/richtextformatdlg.cpp:339 ../src/propgrid/advprops.cpp:680
+#: ../src/propgrid/advprops.cpp:590 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "样式"
 
-#: ../include/wx/richtext/richtextstyledlg.h:46
-msgid "Style Organiser"
-msgstr "样式组织器"
-
-#: ../src/osx/carbon/fontdlg.cpp:348
+#: ../src/osx/carbon/fontdlg.cpp:345
 msgid "Style:"
 msgstr "样式:"
 
@@ -6576,7 +6735,7 @@ msgid "Subscrip&t"
 msgstr "下标(&T)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:83
+#: ../src/common/accelcmn.cpp:80
 msgid "Subtract"
 msgstr ""
 
@@ -6584,11 +6743,11 @@ msgstr ""
 msgid "Supe&rscript"
 msgstr "上标(&R)"
 
-#: ../src/common/paper.cpp:150
+#: ../src/common/paper.cpp:147
 msgid "SuperA/SuperA/A4 227 x 356 mm"
 msgstr "SuperA/SuperA/A4 纸张，227 x 356 毫米"
 
-#: ../src/common/paper.cpp:151
+#: ../src/common/paper.cpp:148
 msgid "SuperB/SuperB/A3 305 x 487 mm"
 msgstr "SuperB/SuperB/A3 纸张，305 x 487 毫米"
 
@@ -6596,7 +6755,7 @@ msgstr "SuperB/SuperB/A3 纸张，305 x 487 毫米"
 msgid "Suppress hyphe&nation"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:326
+#: ../src/generic/fontdlgg.cpp:322
 msgid "Swiss"
 msgstr "瑞士"
 
@@ -6614,74 +6773,74 @@ msgstr "符号样式(&F)"
 msgid "Symbols"
 msgstr "符号"
 
-#: ../src/common/imagtiff.cpp:369 ../src/common/imagtiff.cpp:382
-#: ../src/common/imagtiff.cpp:741
+#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
+#: ../src/common/imagtiff.cpp:738
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: 无法分配内存。"
 
-#: ../src/common/imagtiff.cpp:301
+#: ../src/common/imagtiff.cpp:298
 msgid "TIFF: Error loading image."
 msgstr "TIFF: 装载图像错误。"
 
-#: ../src/common/imagtiff.cpp:468
+#: ../src/common/imagtiff.cpp:465
 msgid "TIFF: Error reading image."
 msgstr "TIFF: 读图像错误。"
 
-#: ../src/common/imagtiff.cpp:608
+#: ../src/common/imagtiff.cpp:605
 msgid "TIFF: Error saving image."
 msgstr "TIFF: 保存图像错误。"
 
-#: ../src/common/imagtiff.cpp:846
+#: ../src/common/imagtiff.cpp:843
 msgid "TIFF: Error writing image."
 msgstr "TIFF: 写图像错误。"
 
-#: ../src/common/imagtiff.cpp:355
+#: ../src/common/imagtiff.cpp:352
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: 图像大小过大。"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:68
+#: ../src/common/accelcmn.cpp:65
 #, fuzzy
 msgid "Tab"
 msgstr "标签"
 
-#: ../src/richtext/richtextbuffer.cpp:11498
+#: ../src/richtext/richtextbuffer.cpp:11497
 msgid "Table Properties"
 msgstr "表格属性"
 
-#: ../src/common/paper.cpp:145
+#: ../src/common/paper.cpp:142
 msgid "Tabloid Extra 11.69 x 18 in"
 msgstr "小报(特大)，11.69 x 18 英寸"
 
-#: ../src/common/paper.cpp:102
+#: ../src/common/paper.cpp:99
 msgid "Tabloid, 11 x 17 in"
 msgstr "小报，11 x 17 英寸"
 
-#: ../src/richtext/richtextformatdlg.cpp:354
+#: ../src/richtext/richtextformatdlg.cpp:347
 msgid "Tabs"
 msgstr "标签"
 
-#: ../src/propgrid/advprops.cpp:1598
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Teal"
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:327
+#: ../src/generic/fontdlgg.cpp:323
 msgid "Teletype"
 msgstr "电传打字机"
 
-#: ../src/common/docview.cpp:1896
+#: ../src/common/docview.cpp:1901
 msgid "Templates"
 msgstr "模板"
 
-#: ../src/common/fmapbase.cpp:158
+#: ../src/common/fmapbase.cpp:155
 msgid "Thai (ISO-8859-11)"
 msgstr "泰语 (ISO-8859-11)"
 
-#: ../src/common/ftp.cpp:619
+#: ../src/common/ftp.cpp:622
 msgid "The FTP server doesn't support passive mode."
 msgstr "FTP服务器不支持 passive 模式。"
 
-#: ../src/common/ftp.cpp:605
+#: ../src/common/ftp.cpp:608
 msgid "The FTP server doesn't support the PORT command."
 msgstr "FTP服务器不支持 PORT 命令。"
 
@@ -6692,8 +6851,8 @@ msgstr "FTP服务器不支持 PORT 命令。"
 msgid "The available bullet styles."
 msgstr "可用的项目符号样式。"
 
-#: ../src/richtext/richtextstyledlg.cpp:202
-#: ../src/richtext/richtextstyledlg.cpp:204
+#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:200
 msgid "The available styles."
 msgstr "可用样式。"
 
@@ -6749,12 +6908,12 @@ msgstr "底部位置"
 msgid "The bullet character."
 msgstr "项目符号字符"
 
-#: ../src/richtext/richtextsymboldlg.cpp:443
-#: ../src/richtext/richtextsymboldlg.cpp:445
+#: ../src/richtext/richtextsymboldlg.cpp:440
+#: ../src/richtext/richtextsymboldlg.cpp:442
 msgid "The character code."
 msgstr "字符编码"
 
-#: ../src/common/fontmap.cpp:203
+#: ../src/common/fontmap.cpp:200
 #, c-format
 msgid ""
 "The charset '%s' is unknown. You may select\n"
@@ -6764,7 +6923,7 @@ msgstr ""
 "未知字符集 '%s'。选择其它字符集\n"
 "代替它，如果无法替代请选择 [取消] "
 
-#: ../src/msw/ole/dataobj.cpp:394
+#: ../src/msw/ole/dataobj.cpp:402
 #, c-format
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "剪贴板格式 '%d' 不存在。"
@@ -6774,7 +6933,7 @@ msgstr "剪贴板格式 '%d' 不存在。"
 msgid "The default style for the next paragraph."
 msgstr "下一段落默认样式。"
 
-#: ../src/generic/dirdlgg.cpp:202
+#: ../src/generic/dirdlgg.cpp:199
 #, c-format
 msgid ""
 "The directory '%s' does not exist\n"
@@ -6783,7 +6942,7 @@ msgstr ""
 "目录 '%s' 不存在\n"
 "是否现在创建?"
 
-#: ../src/html/htmprint.cpp:271
+#: ../src/html/htmprint.cpp:283
 #, c-format
 msgid ""
 "The document \"%s\" doesn't fit on the page horizontally and will be "
@@ -6795,7 +6954,7 @@ msgstr ""
 "\n"
 "强制打印该文档？"
 
-#: ../src/common/docview.cpp:1202
+#: ../src/common/docview.cpp:1196
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -6804,36 +6963,37 @@ msgstr ""
 "文件 '%s' 不存在所以无法打开。\n"
 "已从最近使用的文件列表中移去。"
 
-#: ../src/richtext/richtextindentspage.cpp:208
-#: ../src/richtext/richtextindentspage.cpp:210
 #: ../src/richtext/richtextliststylepage.cpp:394
 #: ../src/richtext/richtextliststylepage.cpp:396
+#: ../src/richtext/richtextindentspage.cpp:208
+#: ../src/richtext/richtextindentspage.cpp:210
 msgid "The first line indent."
 msgstr "首行缩进"
 
-#: ../src/gtk/utilsgtk.cpp:481
-msgid "The following standard GTK+ options are also supported:\n"
-msgstr "以下标准GTK+选项也被支持:\n"
+#: ../src/generic/dbgrptg.cpp:318
+#, fuzzy
+msgid "The following debug report will be generated\n"
+msgstr "*** 生成了一份调试报告\n"
 
-#: ../src/generic/fontdlgg.cpp:414 ../src/generic/fontdlgg.cpp:416
+#: ../src/generic/fontdlgg.cpp:411 ../src/generic/fontdlgg.cpp:413
 msgid "The font colour."
 msgstr "字体颜色。"
 
-#: ../src/generic/fontdlgg.cpp:375 ../src/generic/fontdlgg.cpp:377
+#: ../src/generic/fontdlgg.cpp:371 ../src/generic/fontdlgg.cpp:373
 msgid "The font family."
 msgstr "字体。"
 
-#: ../src/richtext/richtextsymboldlg.cpp:405
-#: ../src/richtext/richtextsymboldlg.cpp:407
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "The font from which to take the symbol."
 msgstr "符号使用该字体"
 
-#: ../src/generic/fontdlgg.cpp:427 ../src/generic/fontdlgg.cpp:429
-#: ../src/generic/fontdlgg.cpp:434 ../src/generic/fontdlgg.cpp:436
+#: ../src/generic/fontdlgg.cpp:424 ../src/generic/fontdlgg.cpp:426
+#: ../src/generic/fontdlgg.cpp:430 ../src/generic/fontdlgg.cpp:432
 msgid "The font point size."
 msgstr "字体大小 (磅值)。"
 
-#: ../src/osx/carbon/fontdlg.cpp:343 ../src/osx/carbon/fontdlg.cpp:345
+#: ../src/osx/carbon/fontdlg.cpp:340 ../src/osx/carbon/fontdlg.cpp:342
 msgid "The font size in points."
 msgstr "字体大小(磅值)"
 
@@ -6842,15 +7002,15 @@ msgstr "字体大小(磅值)"
 msgid "The font size units, points or pixels."
 msgstr "字体大小单位，磅值或像素值"
 
-#: ../src/generic/fontdlgg.cpp:386 ../src/generic/fontdlgg.cpp:388
+#: ../src/generic/fontdlgg.cpp:382 ../src/generic/fontdlgg.cpp:384
 msgid "The font style."
 msgstr "字体样式。"
 
-#: ../src/generic/fontdlgg.cpp:397 ../src/generic/fontdlgg.cpp:399
+#: ../src/generic/fontdlgg.cpp:393 ../src/generic/fontdlgg.cpp:395
 msgid "The font weight."
 msgstr "字体粗细。"
 
-#: ../src/common/docview.cpp:1483
+#: ../src/common/docview.cpp:1477
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "无法确定文件 '%s' 格式。"
@@ -6861,10 +7021,10 @@ msgstr "无法确定文件 '%s' 格式。"
 msgid "The horizontal offset."
 msgstr "水平排布(&H)"
 
-#: ../src/richtext/richtextindentspage.cpp:199
-#: ../src/richtext/richtextindentspage.cpp:201
 #: ../src/richtext/richtextliststylepage.cpp:385
 #: ../src/richtext/richtextliststylepage.cpp:387
+#: ../src/richtext/richtextindentspage.cpp:199
+#: ../src/richtext/richtextindentspage.cpp:201
 msgid "The left indent."
 msgstr "左缩进"
 
@@ -6885,10 +7045,10 @@ msgstr "左内衬大小"
 msgid "The left position."
 msgstr "左位置"
 
-#: ../src/richtext/richtextindentspage.cpp:288
-#: ../src/richtext/richtextindentspage.cpp:290
 #: ../src/richtext/richtextliststylepage.cpp:462
 #: ../src/richtext/richtextliststylepage.cpp:464
+#: ../src/richtext/richtextindentspage.cpp:288
+#: ../src/richtext/richtextindentspage.cpp:290
 msgid "The line spacing."
 msgstr "行距。"
 
@@ -6897,7 +7057,7 @@ msgstr "行距。"
 msgid "The list item number."
 msgstr "列表编号"
 
-#: ../src/msw/ole/automtn.cpp:664
+#: ../src/msw/ole/automtn.cpp:655
 msgid "The locale ID is unknown."
 msgstr "区域ID未知"
 
@@ -6936,18 +7096,18 @@ msgstr "对象宽度。"
 msgid "The outline level."
 msgstr "大纲层级"
 
-#: ../src/common/log.cpp:277
+#: ../src/common/log.cpp:296
 #, fuzzy, c-format
 msgid "The previous message repeated %u time."
 msgid_plural "The previous message repeated %u times."
 msgstr[0] "前一消息重复 %lu 次"
 
-#: ../src/common/log.cpp:270
+#: ../src/common/log.cpp:289
 msgid "The previous message repeated once."
 msgstr "前一消息重复一次"
 
-#: ../src/richtext/richtextsymboldlg.cpp:462
-#: ../src/richtext/richtextsymboldlg.cpp:464
+#: ../src/richtext/richtextsymboldlg.cpp:459
+#: ../src/richtext/richtextsymboldlg.cpp:461
 msgid "The range to show."
 msgstr "显示的范围。"
 
@@ -6960,15 +7120,15 @@ msgstr ""
 "报告包含了以下文件。如果这些文件含有私人信息，\n"
 "请去掉选中相应的文件，未选中的文件就会从报告中删除。\n"
 
-#: ../src/common/cmdline.cpp:1254
+#: ../src/common/cmdline.cpp:1250
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "必须的参数 '%s' 没有指定。"
 
-#: ../src/richtext/richtextindentspage.cpp:217
-#: ../src/richtext/richtextindentspage.cpp:219
 #: ../src/richtext/richtextliststylepage.cpp:403
 #: ../src/richtext/richtextliststylepage.cpp:405
+#: ../src/richtext/richtextindentspage.cpp:217
+#: ../src/richtext/richtextindentspage.cpp:219
 msgid "The right indent."
 msgstr "右侧缩进。"
 
@@ -7010,16 +7170,16 @@ msgstr ""
 msgid "The shadow spread."
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:267
 #: ../src/richtext/richtextliststylepage.cpp:439
 #: ../src/richtext/richtextliststylepage.cpp:441
+#: ../src/richtext/richtextindentspage.cpp:267
 msgid "The spacing after the paragraph."
 msgstr "段落之后的间距。"
 
-#: ../src/richtext/richtextindentspage.cpp:257
-#: ../src/richtext/richtextindentspage.cpp:259
 #: ../src/richtext/richtextliststylepage.cpp:430
 #: ../src/richtext/richtextliststylepage.cpp:432
+#: ../src/richtext/richtextindentspage.cpp:257
+#: ../src/richtext/richtextindentspage.cpp:259
 msgid "The spacing before the paragraph."
 msgstr "段落之前的间距。"
 
@@ -7033,12 +7193,12 @@ msgstr "样式名称。"
 msgid "The style on which this style is based."
 msgstr "此样式的基础样式。"
 
-#: ../src/richtext/richtextstyledlg.cpp:214
-#: ../src/richtext/richtextstyledlg.cpp:216
+#: ../src/richtext/richtextstyledlg.cpp:210
+#: ../src/richtext/richtextstyledlg.cpp:212
 msgid "The style preview."
 msgstr "样式预览。"
 
-#: ../src/msw/ole/automtn.cpp:680
+#: ../src/msw/ole/automtn.cpp:671
 msgid "The system cannot find the file specified."
 msgstr "系统无法找到指定的文件。"
 
@@ -7051,7 +7211,7 @@ msgstr "标签位置"
 msgid "The tab positions."
 msgstr "标签位置"
 
-#: ../src/richtext/richtextctrl.cpp:3098
+#: ../src/richtext/richtextctrl.cpp:3099
 msgid "The text couldn't be saved."
 msgstr "文本无法保存。"
 
@@ -7072,7 +7232,7 @@ msgstr "上内衬大小"
 msgid "The top position."
 msgstr "顶部位置。"
 
-#: ../src/common/cmdline.cpp:1232
+#: ../src/common/cmdline.cpp:1228
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "选项 '%s' 的值必须被指定。"
@@ -7082,7 +7242,7 @@ msgstr "选项 '%s' 的值必须被指定。"
 msgid "The value of the corner radius."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:433
+#: ../src/msw/dialup.cpp:427
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -7095,122 +7255,130 @@ msgstr "安装在本机的远程访问服务(RAS)太旧, 请更新它 (缺少下
 msgid "The vertical offset."
 msgstr "启用垂直对齐。"
 
-#: ../src/richtext/richtextprint.cpp:619 ../src/html/htmprint.cpp:745
+#: ../src/html/htmprint.cpp:749 ../src/richtext/richtextprint.cpp:615
 msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr "在页面建立时发生问题: 您可能需要设置一台默认的打印机。"
 
-#: ../src/html/htmprint.cpp:255
+#: ../src/html/htmprint.cpp:267
 msgid ""
 "This document doesn't fit on the page horizontally and will be truncated "
 "when it is printed."
 msgstr "该文档的水平尺寸不符合页面，若打印将会被截断。"
 
-#: ../src/common/image.cpp:2854
+#: ../src/common/image.cpp:2963
 #, c-format
 msgid "This is not a %s."
 msgstr "这不是 %s。"
 
-#: ../src/common/wincmn.cpp:1653
+#: ../src/common/wincmn.cpp:1654
 msgid "This platform does not support background transparency."
 msgstr "该平台不支持背景透明度"
 
-#: ../src/gtk/window.cpp:4660
+#: ../src/gtk/window.cpp:5664
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr "该应用由过早版本的GTK+编译，请用GTK+ 2.12或以上版本重新构建。"
 
-#: ../src/msw/thread.cpp:1240
+#: ../src/gtk/glcanvas.cpp:176
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/msw/thread.cpp:1246
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
 msgstr "线程模块初始化失败: 无法在线程本地存储区中存放值"
 
-#: ../src/unix/threadpsx.cpp:1794
+#: ../src/unix/threadpsx.cpp:1843
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr "线程模块初始化失败: 创建线程键失败"
 
-#: ../src/msw/thread.cpp:1228
+#: ../src/msw/thread.cpp:1234
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
 msgstr "线程模块初始化失败: 无法在线程本地存储区中分配索引"
 
-#: ../src/unix/threadpsx.cpp:1043
+#: ../src/unix/threadpsx.cpp:1061
 msgid "Thread priority setting is ignored."
 msgstr "线程优先级设置被忽略。"
 
-#: ../src/msw/mdi.cpp:176
+#: ../src/msw/mdi.cpp:171
 msgid "Tile &Horizontally"
 msgstr "水平排布(&H)"
 
-#: ../src/msw/mdi.cpp:177
+#: ../src/msw/mdi.cpp:172
 msgid "Tile &Vertically"
 msgstr "垂直排布(&V)"
 
-#: ../src/common/ftp.cpp:200
+#: ../src/common/ftp.cpp:197
 msgid "Timeout while waiting for FTP server to connect, try passive mode."
 msgstr "等待FTP服务器连接时超时，请尝试用 passive 模式。"
 
-#: ../src/generic/tipdlg.cpp:201
+#: ../src/generic/tipdlg.cpp:198
 msgid "Tip of the Day"
 msgstr "每日技巧"
 
-#: ../src/generic/tipdlg.cpp:140
+#: ../src/generic/tipdlg.cpp:137
 msgid "Tips not available, sorry!"
 msgstr "对不起，没有所需的提示！"
 
-#: ../src/generic/prntdlgg.cpp:242
+#: ../src/generic/prntdlgg.cpp:235
 msgid "To:"
 msgstr "到:"
 
-#: ../src/richtext/richtextbuffer.cpp:8363
+#: ../src/richtext/richtextbuffer.cpp:8361
 msgid "Too many EndStyle calls!"
 msgstr "呼叫 EndStyle 太多次！"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:891
+#: ../src/propgrid/advprops.cpp:792
 msgid "Tooltip"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:892
+#: ../src/propgrid/advprops.cpp:793
 msgid "TooltipText"
 msgstr ""
 
-#: ../src/richtext/richtextsizepage.cpp:286
-#: ../src/richtext/richtextsizepage.cpp:290 ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197 ../src/richtext/richtextsizepage.cpp:286
+#: ../src/richtext/richtextsizepage.cpp:290
 msgid "Top"
 msgstr "顶端"
 
-#: ../src/generic/prntdlgg.cpp:881
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Top margin (mm):"
 msgstr "上页边距 (毫米):"
 
-#: ../src/generic/aboutdlgg.cpp:79
+#: ../src/generic/aboutdlgg.cpp:76
 msgid "Translations by "
 msgstr "翻译由"
 
-#: ../src/generic/aboutdlgg.cpp:188
+#: ../src/generic/aboutdlgg.cpp:185
 msgid "Translators"
 msgstr "翻译者"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:211
+#: ../src/propgrid/propgrid.cpp:192
 msgid "True"
 msgstr "True"
 
-#: ../src/common/fs_mem.cpp:227
+#: ../src/common/fs_mem.cpp:222
 #, c-format
 msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
 msgstr "试图从内存 VFS 中移去文件 '%s'，但它并没有被装入内存！"
 
-#: ../src/common/fmapbase.cpp:156
+#: ../src/common/fmapbase.cpp:153
 msgid "Turkish (ISO-8859-9)"
 msgstr "土耳其语 (ISO-8859-9)"
 
-#: ../src/generic/filectrlg.cpp:426
+#: ../src/generic/filectrlg.cpp:422
 msgid "Type"
 msgstr "类型"
 
@@ -7224,36 +7392,36 @@ msgstr "输入字体名称。"
 msgid "Type a size in points."
 msgstr "输入大小，以磅为单位"
 
-#: ../src/msw/ole/automtn.cpp:676
+#: ../src/msw/ole/automtn.cpp:667
 #, c-format
 msgid "Type mismatch in argument %u."
 msgstr "参数 %u 的类型不匹配。"
 
-#: ../src/common/xtixml.cpp:356 ../src/common/xtixml.cpp:509
-#: ../src/common/xtistrm.cpp:318
+#: ../src/common/xtixml.cpp:352 ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315
 msgid "Type must have enum - long conversion"
 msgstr "必须进行 enum - long 的类型转换"
 
-#: ../src/propgrid/propgridiface.cpp:401
+#: ../src/propgrid/propgridiface.cpp:385
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
 "\"%s\"."
 msgstr ""
 
-#: ../src/common/paper.cpp:133
+#: ../src/common/paper.cpp:130
 msgid "US Std Fanfold, 14 7/8 x 11 in"
 msgstr "美国标准复写簿，14 7/8 x 11 英寸"
 
-#: ../src/common/fmapbase.cpp:196
+#: ../src/common/fmapbase.cpp:193
 msgid "US-ASCII"
 msgstr "US-ASCII"
 
-#: ../src/unix/fswatcher_inotify.cpp:109
+#: ../src/unix/fswatcher_inotify.cpp:106
 msgid "Unable to add inotify watch"
 msgstr "无法添加 inotify watch"
 
-#: ../src/unix/fswatcher_kqueue.cpp:136
+#: ../src/unix/fswatcher_kqueue.cpp:153
 msgid "Unable to add kqueue watch"
 msgstr "无法添加 kqueue watch"
 
@@ -7265,7 +7433,7 @@ msgstr "无法将句柄与 I/O 完成端口相关联"
 msgid "Unable to close I/O completion port handle"
 msgstr "无法关闭 I/O 完成口的句柄"
 
-#: ../src/unix/fswatcher_inotify.cpp:97
+#: ../src/unix/fswatcher_inotify.cpp:94
 msgid "Unable to close inotify instance"
 msgstr "无法关闭 inotify 实例"
 
@@ -7283,15 +7451,15 @@ msgstr "无法关闭 '%s' 的句柄。"
 msgid "Unable to create I/O completion port"
 msgstr "无法创建 I/O 完成口"
 
-#: ../src/msw/fswatcher.cpp:84
+#: ../src/msw/fswatcher.cpp:81
 msgid "Unable to create IOCP worker thread"
 msgstr "无法创建 IOCP 工作线程"
 
-#: ../src/unix/fswatcher_inotify.cpp:74
+#: ../src/unix/fswatcher_inotify.cpp:71
 msgid "Unable to create inotify instance"
 msgstr "无法创建 inotify 实例"
 
-#: ../src/unix/fswatcher_kqueue.cpp:97
+#: ../src/unix/fswatcher_kqueue.cpp:114
 msgid "Unable to create kqueue instance"
 msgstr "无法创建 kqueue 实例"
 
@@ -7299,11 +7467,11 @@ msgstr "无法创建 kqueue 实例"
 msgid "Unable to dequeue completion packet"
 msgstr "无法移出完成封包"
 
-#: ../src/unix/fswatcher_kqueue.cpp:185
+#: ../src/unix/fswatcher_kqueue.cpp:202
 msgid "Unable to get events from kqueue"
 msgstr "无法从 kqueue 中获取事件"
 
-#: ../src/gtk/app.cpp:435
+#: ../src/gtk/app.cpp:431
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "无法初始化 GTK+，DISPLAY 是否已正确设置？"
 
@@ -7312,12 +7480,12 @@ msgstr "无法初始化 GTK+，DISPLAY 是否已正确设置？"
 msgid "Unable to open path '%s'"
 msgstr "无法打开路径 '%s'"
 
-#: ../src/html/htmlwin.cpp:583
+#: ../src/html/htmlwin.cpp:586
 #, c-format
 msgid "Unable to open requested HTML document: %s"
 msgstr "无法打开 HTML 文档: %s"
 
-#: ../src/unix/sound.cpp:368
+#: ../src/unix/sound.cpp:365
 msgid "Unable to play sound asynchronously."
 msgstr "无法异步地播放声音。"
 
@@ -7325,61 +7493,61 @@ msgstr "无法异步地播放声音。"
 msgid "Unable to post completion status"
 msgstr "无法贴上完成状态"
 
-#: ../src/unix/fswatcher_inotify.cpp:556
+#: ../src/unix/fswatcher_inotify.cpp:553
 msgid "Unable to read from inotify descriptor"
 msgstr "无法读取 inotify 描述符"
 
-#: ../src/unix/fswatcher_inotify.cpp:141
+#: ../src/unix/fswatcher_inotify.cpp:138
 #, fuzzy, c-format
 msgid "Unable to remove inotify watch %i"
 msgstr "无法删除 inotify watch"
 
-#: ../src/unix/fswatcher_kqueue.cpp:153
+#: ../src/unix/fswatcher_kqueue.cpp:170
 msgid "Unable to remove kqueue watch"
 msgstr "无法删除 kqueue watch"
 
-#: ../src/msw/fswatcher.cpp:168
+#: ../src/msw/fswatcher.cpp:165
 #, c-format
 msgid "Unable to set up watch for '%s'"
 msgstr "无法为 '%s' 设定 watch"
 
-#: ../src/msw/fswatcher.cpp:91
+#: ../src/msw/fswatcher.cpp:88
 msgid "Unable to start IOCP worker thread"
 msgstr "无法开始 IOCP 工作线程"
 
-#: ../src/common/stockitem.cpp:201
+#: ../src/common/stockitem.cpp:198
 msgid "Undelete"
 msgstr "取消删除"
 
-#: ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199
 msgid "Underline"
 msgstr "下划线"
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/richtext/richtextfontpage.cpp:359 ../src/osx/carbon/fontdlg.cpp:370
-#: ../src/propgrid/advprops.cpp:690
+#: ../src/osx/carbon/fontdlg.cpp:367 ../src/propgrid/advprops.cpp:600
+#: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "下划线"
 
-#: ../src/common/stockitem.cpp:203 ../src/stc/stc_i18n.cpp:15
+#: ../src/common/stockitem.cpp:200 ../src/stc/stc_i18n.cpp:15
 msgid "Undo"
 msgstr "撤销"
 
-#: ../src/common/stockitem.cpp:265
+#: ../src/common/stockitem.cpp:263
 msgid "Undo last action"
 msgstr "撤销上一次操作"
 
-#: ../src/common/cmdline.cpp:1029
+#: ../src/common/cmdline.cpp:1025
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "选项 '%s' 后有意外字符。"
 
-#: ../src/unix/fswatcher_inotify.cpp:274
+#: ../src/unix/fswatcher_inotify.cpp:271
 #, c-format
 msgid "Unexpected event for \"%s\": no matching watch descriptor."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1195
+#: ../src/common/cmdline.cpp:1191
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "意外参数 '%s'"
@@ -7388,49 +7556,49 @@ msgstr "意外参数 '%s'"
 msgid "Unexpectedly new I/O completion port was created"
 msgstr ""
 
-#: ../src/msw/fswatcher.cpp:70
+#: ../src/msw/fswatcher.cpp:67
 msgid "Ungraceful worker thread termination"
 msgstr "工作线程非正常终止"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:460
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:456
+#: ../src/richtext/richtextsymboldlg.cpp:457
+#: ../src/richtext/richtextsymboldlg.cpp:458
 msgid "Unicode"
 msgstr "Unicode 编码"
 
-#: ../src/common/fmapbase.cpp:185 ../src/common/fmapbase.cpp:191
+#: ../src/common/fmapbase.cpp:182 ../src/common/fmapbase.cpp:188
 msgid "Unicode 16 bit (UTF-16)"
 msgstr "16位的 Unicode 编码 (UTF-16)"
 
-#: ../src/common/fmapbase.cpp:190
+#: ../src/common/fmapbase.cpp:187
 msgid "Unicode 16 bit Big Endian (UTF-16BE)"
 msgstr "16位大字节序 Unicode 编码 (UTF-16BE)"
 
-#: ../src/common/fmapbase.cpp:186
+#: ../src/common/fmapbase.cpp:183
 msgid "Unicode 16 bit Little Endian (UTF-16LE)"
 msgstr "16位小字节序 Unicode 编码 (UTF-16LE)"
 
-#: ../src/common/fmapbase.cpp:187 ../src/common/fmapbase.cpp:193
+#: ../src/common/fmapbase.cpp:184 ../src/common/fmapbase.cpp:190
 msgid "Unicode 32 bit (UTF-32)"
 msgstr "32位的 Unicode 编码 (UTF-32)"
 
-#: ../src/common/fmapbase.cpp:192
+#: ../src/common/fmapbase.cpp:189
 msgid "Unicode 32 bit Big Endian (UTF-32BE)"
 msgstr "32位大字节序 Unicode 编码 (UTF-32BE)"
 
-#: ../src/common/fmapbase.cpp:188
+#: ../src/common/fmapbase.cpp:185
 msgid "Unicode 32 bit Little Endian (UTF-32LE)"
 msgstr "32位小字节序 Unicode 编码 (UTF-32LE)"
 
-#: ../src/common/fmapbase.cpp:182
+#: ../src/common/fmapbase.cpp:179
 msgid "Unicode 7 bit (UTF-7)"
 msgstr "7位的 Unicode 编码 (UTF-7)"
 
-#: ../src/common/fmapbase.cpp:183
+#: ../src/common/fmapbase.cpp:180
 msgid "Unicode 8 bit (UTF-8)"
 msgstr "8位的 Unicode 编码 (UTF-8)"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "Unindent"
 msgstr "取消缩进"
 
@@ -7582,97 +7750,102 @@ msgstr "上位置单位"
 msgid "Units for this value."
 msgstr "左边距单位"
 
-#: ../src/generic/progdlgg.cpp:353 ../src/generic/progdlgg.cpp:622
+#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
 msgid "Unknown"
 msgstr "未知"
 
-#: ../src/msw/dde.cpp:1174
+#: ../src/msw/dde.cpp:1238
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "未知 DDE 错误 %08x"
 
-#: ../src/common/xtistrm.cpp:410
+#: ../src/common/xtistrm.cpp:407
 msgid "Unknown Object passed to GetObjectClassInfo"
 msgstr "未知的对象传递给 GetObjectClassInfo"
 
-#: ../src/common/imagpng.cpp:366
+#: ../src/common/imagpng.cpp:383
 #, c-format
 msgid "Unknown PNG resolution unit %d"
 msgstr "未知 PNG 解析度单位 %d"
 
-#: ../src/common/xtixml.cpp:327
+#: ../src/common/xtixml.cpp:323
 #, c-format
 msgid "Unknown Property %s"
 msgstr "未知属性 %s"
 
-#: ../src/common/imagtiff.cpp:529
+#: ../src/common/imagtiff.cpp:526
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "未知 TIFF 解析度单位 %d，忽略之"
 
-#: ../src/unix/dlunix.cpp:160
+#: ../src/propgrid/props.cpp:155
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/unix/dlunix.cpp:118
 msgid "Unknown dynamic library error"
 msgstr "未知的动态库错误"
 
-#: ../src/common/fmapbase.cpp:810
+#: ../src/common/fmapbase.cpp:806
 #, c-format
 msgid "Unknown encoding (%d)"
 msgstr "未知编码 (%d)"
 
-#: ../src/msw/ole/automtn.cpp:688
+#: ../src/msw/ole/automtn.cpp:679
 #, c-format
 msgid "Unknown error %08x"
 msgstr "未知错误 %08x"
 
-#: ../src/msw/ole/automtn.cpp:647
+#: ../src/msw/ole/automtn.cpp:638
 msgid "Unknown exception"
 msgstr "未知异常"
 
-#: ../src/common/image.cpp:2839
+#: ../src/common/image.cpp:2942
 msgid "Unknown image data format."
 msgstr "未知图像数据格式"
 
-#: ../src/common/cmdline.cpp:914
+#: ../src/common/cmdline.cpp:910
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "未知的长选项 '%s'"
 
-#: ../src/msw/ole/automtn.cpp:631
+#: ../src/msw/ole/automtn.cpp:622
 msgid "Unknown name or named argument."
 msgstr "未知名称或者命名参数"
 
-#: ../src/common/cmdline.cpp:929 ../src/common/cmdline.cpp:951
+#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "未知选项 '%s'"
 
-#: ../src/common/mimecmn.cpp:225
+#: ../src/common/mimecmn.cpp:221
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "类型 %s 中有不配套的 '{'。"
 
-#: ../src/common/cmdproc.cpp:262 ../src/common/cmdproc.cpp:288
-#: ../src/common/cmdproc.cpp:308
+#: ../src/common/cmdproc.cpp:255 ../src/common/cmdproc.cpp:281
+#: ../src/common/cmdproc.cpp:301
 msgid "Unnamed command"
 msgstr "未命名的命令"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:413
+#: ../src/propgrid/propgrid.cpp:392
 msgid "Unspecified"
 msgstr "未指定"
 
-#: ../src/msw/clipbrd.cpp:311
+#: ../src/msw/clipbrd.cpp:325
 msgid "Unsupported clipboard format."
 msgstr "不支持的剪贴板格式。"
 
-#: ../src/common/appcmn.cpp:256
+#: ../src/common/appcmn.cpp:277
 #, c-format
 msgid "Unsupported theme '%s'."
 msgstr "不支持的主题 '%s'。"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/generic/fdrepdlg.cpp:152 ../src/common/stockitem.cpp:205
-#: ../src/common/accelcmn.cpp:63
+#: ../src/common/stockitem.cpp:202 ../src/common/accelcmn.cpp:60
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Up"
 msgstr "向上"
 
@@ -7686,7 +7859,7 @@ msgstr "大写字母"
 msgid "Upper case roman numerals"
 msgstr "大写罗马数字"
 
-#: ../src/common/cmdline.cpp:1326
+#: ../src/common/cmdline.cpp:1322
 #, c-format
 msgid "Usage: %s"
 msgstr "用法: %s"
@@ -7695,38 +7868,47 @@ msgstr "用法: %s"
 msgid "Use &shadow"
 msgstr ""
 
-#: ../src/richtext/richtextindentspage.cpp:169
-#: ../src/richtext/richtextindentspage.cpp:171
 #: ../src/richtext/richtextliststylepage.cpp:358
 #: ../src/richtext/richtextliststylepage.cpp:360
+#: ../src/richtext/richtextindentspage.cpp:169
+#: ../src/richtext/richtextindentspage.cpp:171
 msgid "Use the current alignment setting."
 msgstr "使用当前的对齐设置。"
 
-#: ../src/common/valtext.cpp:179
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/gtk/font.cpp:552
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/common/valtext.cpp:142
 msgid "Validation conflict"
 msgstr "验证冲突"
 
-#: ../src/propgrid/manager.cpp:238
+#: ../src/propgrid/manager.cpp:224
 msgid "Value"
 msgstr "值"
 
-#: ../src/propgrid/props.cpp:386 ../src/propgrid/props.cpp:500
+#: ../src/propgrid/props.cpp:309
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "数值必须大于或等于 %s。"
 
-#: ../src/propgrid/props.cpp:417 ../src/propgrid/props.cpp:531
+#: ../src/propgrid/props.cpp:336
 #, c-format
 msgid "Value must be %s or less."
 msgstr "数值必须小于或等于 %s。"
 
-#: ../src/propgrid/props.cpp:393 ../src/propgrid/props.cpp:424
-#: ../src/propgrid/props.cpp:507 ../src/propgrid/props.cpp:538
+#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "数值必须在 %s 和 %s 之间。"
 
-#: ../src/generic/aboutdlgg.cpp:128
+#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "版本"
 
@@ -7735,25 +7917,32 @@ msgstr "版本"
 msgid "Vertical alignment."
 msgstr "垂直对齐。"
 
-#: ../src/generic/filedlgg.cpp:202
+#: ../src/generic/filedlgg.cpp:199
 msgid "View files as a detailed view"
 msgstr "按详细视图观看文件"
 
-#: ../src/generic/filedlgg.cpp:200
+#: ../src/generic/filedlgg.cpp:197
 msgid "View files as a list view"
 msgstr "按列表视图观看文件"
 
-#: ../src/common/docview.cpp:1970
+#: ../src/common/docview.cpp:1975
 msgid "Views"
 msgstr "视图"
 
+#: ../src/gtk/app.cpp:348
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1777
+#: ../src/propgrid/advprops.cpp:1678
 msgid "Wait"
 msgstr ""
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1779
+#: ../src/propgrid/advprops.cpp:1680
 msgid "Wait Arrow"
 msgstr ""
 
@@ -7762,243 +7951,240 @@ msgstr ""
 msgid "Waiting for IO on epoll descriptor %d failed"
 msgstr "等待 epoll 描述符 %d 的 IO 时失败"
 
-#: ../src/common/log.cpp:223
+#: ../src/common/log.cpp:241
 msgid "Warning: "
 msgstr "警告: "
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1778
+#: ../src/propgrid/advprops.cpp:1679
 msgid "Watch"
 msgstr ""
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:685
+#: ../src/propgrid/advprops.cpp:595
 msgid "Weight"
 msgstr "字体粗细"
 
-#: ../src/common/fmapbase.cpp:148
+#: ../src/common/fmapbase.cpp:145
 msgid "Western European (ISO-8859-1)"
 msgstr "西欧 (ISO-8859-1)"
 
-#: ../src/common/fmapbase.cpp:162
+#: ../src/common/fmapbase.cpp:159
 msgid "Western European with Euro (ISO-8859-15)"
 msgstr "西欧带欧元符号 (ISO-8859-15)"
 
-#: ../src/generic/fontdlgg.cpp:446 ../src/generic/fontdlgg.cpp:448
+#: ../src/generic/fontdlgg.cpp:443 ../src/generic/fontdlgg.cpp:445
 msgid "Whether the font is underlined."
 msgstr "字体是否为下划线。"
 
-#: ../src/propgrid/advprops.cpp:1611
+#: ../src/propgrid/advprops.cpp:1517
 msgid "White"
 msgstr ""
 
-#: ../src/generic/fdrepdlg.cpp:144
+#: ../src/generic/fdrepdlg.cpp:141
 msgid "Whole word"
 msgstr "整字"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:532
 msgid "Whole words only"
 msgstr "仅为整字"
 
-#: ../src/univ/themes/win32.cpp:1102
+#: ../src/univ/themes/win32.cpp:1099
 msgid "Win32 theme"
 msgstr "Win32 主题"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:893
+#: ../src/propgrid/advprops.cpp:794
 #, fuzzy
 msgid "Window"
 msgstr "窗口(&W)"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:894
+#: ../src/propgrid/advprops.cpp:795
 #, fuzzy
 msgid "WindowFrame"
 msgstr "窗口(&W)"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:895
+#: ../src/propgrid/advprops.cpp:796
 #, fuzzy
 msgid "WindowText"
 msgstr "窗口(&W)"
 
-#: ../src/common/fmapbase.cpp:177
+#: ../src/common/fmapbase.cpp:174
 msgid "Windows Arabic (CP 1256)"
 msgstr "Windows 阿拉伯语 (CP 1256)"
 
-#: ../src/common/fmapbase.cpp:178
+#: ../src/common/fmapbase.cpp:175
 msgid "Windows Baltic (CP 1257)"
 msgstr "Windows 波罗的海语 (CP 1257)"
 
-#: ../src/common/fmapbase.cpp:171
+#: ../src/common/fmapbase.cpp:168
 msgid "Windows Central European (CP 1250)"
 msgstr "Windows 中欧 (CP 1250)"
 
-#: ../src/common/fmapbase.cpp:168
+#: ../src/common/fmapbase.cpp:165
 msgid "Windows Chinese Simplified (CP 936) or GB-2312"
 msgstr "Windows 简体中文 (CP 936) 或 GB-2312"
 
-#: ../src/common/fmapbase.cpp:170
+#: ../src/common/fmapbase.cpp:167
 msgid "Windows Chinese Traditional (CP 950) or Big-5"
 msgstr "Windows 繁体中文 (CP 950) 或 Big-5"
 
-#: ../src/common/fmapbase.cpp:172
+#: ../src/common/fmapbase.cpp:169
 msgid "Windows Cyrillic (CP 1251)"
 msgstr "Windows 西里尔语 (CP 1251)"
 
-#: ../src/common/fmapbase.cpp:174
+#: ../src/common/fmapbase.cpp:171
 msgid "Windows Greek (CP 1253)"
 msgstr "Windows 希腊语 (CP 1253)"
 
-#: ../src/common/fmapbase.cpp:176
+#: ../src/common/fmapbase.cpp:173
 msgid "Windows Hebrew (CP 1255)"
 msgstr "Windows 希伯来语 (CP 1255)"
 
-#: ../src/common/fmapbase.cpp:167
+#: ../src/common/fmapbase.cpp:164
 msgid "Windows Japanese (CP 932) or Shift-JIS"
 msgstr "Windows 日语 (CP 932) 或 Shift-JIS"
 
-#: ../src/common/fmapbase.cpp:180
+#: ../src/common/fmapbase.cpp:177
 msgid "Windows Johab (CP 1361)"
 msgstr "Windows 朝鲜语 (CP 1361)"
 
-#: ../src/common/fmapbase.cpp:169
+#: ../src/common/fmapbase.cpp:166
 msgid "Windows Korean (CP 949)"
 msgstr "Windows 韩语 (CP 949)"
 
-#: ../src/common/fmapbase.cpp:166
+#: ../src/common/fmapbase.cpp:163
 msgid "Windows Thai (CP 874)"
 msgstr "Windows 泰国语 (CP 874)"
 
-#: ../src/common/fmapbase.cpp:175
+#: ../src/common/fmapbase.cpp:172
 msgid "Windows Turkish (CP 1254)"
 msgstr "Windows 土耳其语 (CP 1254)"
 
-#: ../src/common/fmapbase.cpp:179
+#: ../src/common/fmapbase.cpp:176
 msgid "Windows Vietnamese (CP 1258)"
 msgstr "Windows 越南语 (CP 1258)"
 
-#: ../src/common/fmapbase.cpp:173
+#: ../src/common/fmapbase.cpp:170
 msgid "Windows Western European (CP 1252)"
 msgstr "Windows 西欧 (CP 1252)"
 
-#: ../src/common/fmapbase.cpp:181
+#: ../src/common/fmapbase.cpp:178
 msgid "Windows/DOS OEM (CP 437)"
 msgstr "Windows/DOS OEM (CP 437)"
 
-#: ../src/common/fmapbase.cpp:165
+#: ../src/common/fmapbase.cpp:162
 msgid "Windows/DOS OEM Cyrillic (CP 866)"
 msgstr "Windows/DOS OEM 西里尔语 (CP 866)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:111
+#: ../src/common/accelcmn.cpp:109
 #, fuzzy
 msgid "Windows_Left"
 msgstr "Windows 7"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:113
+#: ../src/common/accelcmn.cpp:111
 #, fuzzy
 msgid "Windows_Menu"
 msgstr "Windows ME"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:112
+#: ../src/common/accelcmn.cpp:110
 #, fuzzy
 msgid "Windows_Right"
 msgstr "Windows Vista"
 
-#: ../src/common/ffile.cpp:150
+#: ../src/common/ffile.cpp:149
 #, c-format
 msgid "Write error on file '%s'"
 msgstr "写文件 '%s' 错误"
 
-#: ../src/xml/xml.cpp:914
+#: ../src/xml/xml.cpp:925
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "XML 解析错误: '%s'，位于行 %d"
 
-#: ../src/common/xpmdecod.cpp:796
+#: ../src/common/xpmdecod.cpp:794
 msgid "XPM: Malformed pixel data!"
 msgstr "XPM: 错误的象素数据！"
 
-#: ../src/common/xpmdecod.cpp:705
+#: ../src/common/xpmdecod.cpp:702
 #, c-format
 msgid "XPM: incorrect colour description in line %d"
 msgstr "XPM: 在第 %d 行有错误的颜色描述"
 
-#: ../src/common/xpmdecod.cpp:680
+#: ../src/common/xpmdecod.cpp:677
 msgid "XPM: incorrect header format!"
 msgstr "XPM: 不正确的头格式！"
 
-#: ../src/common/xpmdecod.cpp:716 ../src/common/xpmdecod.cpp:725
+#: ../src/common/xpmdecod.cpp:714 ../src/common/xpmdecod.cpp:723
 #, c-format
 msgid "XPM: malformed colour definition '%s' at line %d!"
 msgstr "XPM: 错误的颜色定义 '%s'，位于行 %d！"
 
-#: ../src/common/xpmdecod.cpp:755
+#: ../src/common/xpmdecod.cpp:753
 msgid "XPM: no colors left to use for mask!"
 msgstr "XPM: 没有剩下可供选择的掩码颜色！"
 
-#: ../src/common/xpmdecod.cpp:782
+#: ../src/common/xpmdecod.cpp:780
 #, c-format
 msgid "XPM: truncated image data at line %d!"
 msgstr "XPM: 图像数据被截断，位于行 %d！"
 
-#: ../src/propgrid/advprops.cpp:1610
+#: ../src/propgrid/advprops.cpp:1516
 msgid "Yellow"
 msgstr ""
 
-#: ../include/wx/msgdlg.h:276 ../src/common/stockitem.cpp:206
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:203
 #: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "是"
 
-#: ../src/osx/carbon/overlay.cpp:155
-msgid "You cannot Clear an overlay that is not inited"
-msgstr "你无法清除未初始化的 overlay。"
-
-#: ../src/osx/carbon/overlay.cpp:107 ../src/dfb/overlay.cpp:61
-msgid "You cannot Init an overlay twice"
-msgstr "你不能初始化 overlay 两次"
-
-#: ../src/generic/dirdlgg.cpp:287
+#: ../src/generic/dirdlgg.cpp:284
 msgid "You cannot add a new directory to this section."
 msgstr "你无法向该项中加入新的目录。"
 
-#: ../src/propgrid/propgrid.cpp:3299
+#: ../src/propgrid/propgrid.cpp:3276
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr "你输入了无效值。按 ESC 取消编辑。"
 
-#: ../src/common/stockitem.cpp:209
+#: ../src/osx/cocoa/menu.mm:286
+#, fuzzy
+msgid "Zoom"
+msgstr "放大"
+
+#: ../src/common/stockitem.cpp:206
 msgid "Zoom &In"
 msgstr "放大(&I)"
 
-#: ../src/common/stockitem.cpp:210
+#: ../src/common/stockitem.cpp:207
 msgid "Zoom &Out"
 msgstr "缩小(&O)"
 
-#: ../src/common/stockitem.cpp:209 ../src/common/prntbase.cpp:1594
+#: ../src/common/stockitem.cpp:206 ../src/common/prntbase.cpp:1619
 msgid "Zoom In"
 msgstr "放大"
 
-#: ../src/common/stockitem.cpp:210 ../src/common/prntbase.cpp:1580
+#: ../src/common/stockitem.cpp:207 ../src/common/prntbase.cpp:1605
 msgid "Zoom Out"
 msgstr "缩小"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to &Fit"
 msgstr "缩放以适应窗口(&F)"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to Fit"
 msgstr "缩放以适应窗口"
 
-#: ../src/msw/dde.cpp:1141
+#: ../src/msw/dde.cpp:1205
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "DDEML 应用程序已创建延时 race 条件."
 
-#: ../src/msw/dde.cpp:1129
+#: ../src/msw/dde.cpp:1193
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -8009,39 +8195,39 @@ msgstr ""
 "或传给DDEML函数的是\n"
 "无效的实例标识。"
 
-#: ../src/msw/dde.cpp:1147
+#: ../src/msw/dde.cpp:1211
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "客户试图建立的会话已失败。"
 
-#: ../src/msw/dde.cpp:1144
+#: ../src/msw/dde.cpp:1208
 msgid "a memory allocation failed."
 msgstr "内存分配失败。"
 
-#: ../src/msw/dde.cpp:1138
+#: ../src/msw/dde.cpp:1202
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "DDEML 参数验证失败。"
 
-#: ../src/msw/dde.cpp:1120
+#: ../src/msw/dde.cpp:1184
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "同步 advise 事务请求超时。"
 
-#: ../src/msw/dde.cpp:1126
+#: ../src/msw/dde.cpp:1190
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "同步 data 事务请求超时。"
 
-#: ../src/msw/dde.cpp:1135
+#: ../src/msw/dde.cpp:1199
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "同步 execute 事务请求超时。"
 
-#: ../src/msw/dde.cpp:1153
+#: ../src/msw/dde.cpp:1217
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "同步 poke 事务请求超时。"
 
-#: ../src/msw/dde.cpp:1168
+#: ../src/msw/dde.cpp:1232
 msgid "a request to end an advise transaction has timed out."
 msgstr "终止 advise 事务的请求超时。"
 
-#: ../src/msw/dde.cpp:1162
+#: ../src/msw/dde.cpp:1226
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -8051,15 +8237,15 @@ msgstr ""
 "已被客户端终止的会话，或服务器\n"
 "在完成事务前终止。"
 
-#: ../src/msw/dde.cpp:1150
+#: ../src/msw/dde.cpp:1214
 msgid "a transaction failed."
 msgstr "事务失败。"
 
-#: ../src/common/accelcmn.cpp:189
+#: ../src/common/accelcmn.cpp:188
 msgid "alt"
 msgstr "alt"
 
-#: ../src/msw/dde.cpp:1132
+#: ../src/msw/dde.cpp:1196
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -8071,15 +8257,15 @@ msgstr ""
 "或初始化为 APPCMD_CLIENTONLY 的应用程序\n"
 "视图执行服务器事务。"
 
-#: ../src/msw/dde.cpp:1156
+#: ../src/msw/dde.cpp:1220
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "内部调用 PostMessage 失败。"
 
-#: ../src/msw/dde.cpp:1165
+#: ../src/msw/dde.cpp:1229
 msgid "an internal error has occurred in the DDEML."
 msgstr "在 DDEML 中发生内部错误。"
 
-#: ../src/msw/dde.cpp:1171
+#: ../src/msw/dde.cpp:1235
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -8089,56 +8275,56 @@ msgstr ""
 "一旦应用程序从 XTYP_XACT_COMPLETE 回调函数返回，\n"
 "回调函数事务标识符就不再有效。"
 
-#: ../src/common/zipstrm.cpp:1483
+#: ../src/common/zipstrm.cpp:1522
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "假定这是一个分段 zip 文件的合并"
 
-#: ../src/common/fileconf.cpp:1847
+#: ../src/common/fileconf.cpp:1849
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "忽略对只读键 '%s' 的修改。"
 
-#: ../src/html/chm.cpp:329
+#: ../src/html/chm.cpp:326
 msgid "bad arguments to library function"
 msgstr "库函数参数错误"
 
-#: ../src/html/chm.cpp:341
+#: ../src/html/chm.cpp:338
 msgid "bad signature"
 msgstr "错误的签名"
 
-#: ../src/common/zipstrm.cpp:1918
+#: ../src/common/zipstrm.cpp:1988
 msgid "bad zipfile offset to entry"
 msgstr "zip 文件中到条目的偏移值错误"
 
-#: ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400
 msgid "binary"
 msgstr "二进制"
 
-#: ../src/common/fontcmn.cpp:996
+#: ../src/common/fontcmn.cpp:1195
 msgid "bold"
 msgstr "粗体"
 
-#: ../src/msw/utils.cpp:1144
+#: ../src/msw/utils.cpp:1135
 #, c-format
 msgid "build %lu"
 msgstr "build %lu"
 
-#: ../src/common/ffile.cpp:75
+#: ../src/common/ffile.cpp:73
 #, c-format
 msgid "can't close file '%s'"
 msgstr "无法关闭文件 '%s'"
 
-#: ../src/common/file.cpp:245
+#: ../src/common/file.cpp:242
 #, c-format
 msgid "can't close file descriptor %d"
 msgstr "无法关闭文件描述符 %d"
 
-#: ../src/common/file.cpp:586
+#: ../src/common/ffile.cpp:382 ../src/common/file.cpp:613
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "无法把修改提交给文件 '%s'"
 
-#: ../src/common/file.cpp:178
+#: ../src/common/file.cpp:175
 #, c-format
 msgid "can't create file '%s'"
 msgstr "无法创建文件 '%s'"
@@ -8148,49 +8334,49 @@ msgstr "无法创建文件 '%s'"
 msgid "can't delete user configuration file '%s'"
 msgstr "无法删除用户配置文件 '%s'"
 
-#: ../src/common/file.cpp:495
+#: ../src/common/file.cpp:522
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr "无法确定是否已达描述符 %d 的尾部"
 
-#: ../src/common/zipstrm.cpp:1692
+#: ../src/common/zipstrm.cpp:1747
 msgid "can't find central directory in zip"
 msgstr "无法在 zip 文件中找到中央目录"
 
-#: ../src/common/file.cpp:465
+#: ../src/common/file.cpp:492
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "无法获得文件描述符 %d 的文件长度"
 
-#: ../src/msw/utils.cpp:341
+#: ../src/msw/utils.cpp:336
 msgid "can't find user's HOME, using current directory."
 msgstr "找不到用户的 HOME 目录，使用当前目录。"
 
-#: ../src/common/file.cpp:366
+#: ../src/common/file.cpp:407
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "无法刷新文件描述符 %d"
 
-#: ../src/common/file.cpp:422
+#: ../src/common/file.cpp:463
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "无法获得文件描述符 %d 的指针位置"
 
-#: ../src/common/fontmap.cpp:325
+#: ../src/common/fontmap.cpp:322
 msgid "can't load any font, aborting"
 msgstr "无法装载任何字体，正在中止"
 
-#: ../src/common/file.cpp:231 ../src/common/ffile.cpp:59
+#: ../src/common/ffile.cpp:57 ../src/common/file.cpp:228
 #, c-format
 msgid "can't open file '%s'"
 msgstr "无法打开文件 '%s'"
 
-#: ../src/common/fileconf.cpp:320
+#: ../src/common/fileconf.cpp:314
 #, c-format
 msgid "can't open global configuration file '%s'."
 msgstr "无法打开全局配置文件 '%s'。"
 
-#: ../src/common/fileconf.cpp:336
+#: ../src/common/fileconf.cpp:330
 #, c-format
 msgid "can't open user configuration file '%s'."
 msgstr "无法打开用户配置文件 '%s'。"
@@ -8199,40 +8385,40 @@ msgstr "无法打开用户配置文件 '%s'。"
 msgid "can't open user configuration file."
 msgstr "无法打开用户配置文件。"
 
-#: ../src/common/zipstrm.cpp:579
+#: ../src/common/zipstrm.cpp:572
 msgid "can't re-initialize zlib deflate stream"
 msgstr "无法重新初始化 zlib 压缩流。"
 
-#: ../src/common/zipstrm.cpp:604
+#: ../src/common/zipstrm.cpp:597
 msgid "can't re-initialize zlib inflate stream"
 msgstr "无法重新初始化 zlib 解压流。"
 
-#: ../src/common/file.cpp:304
+#: ../src/common/file.cpp:345
 #, c-format
 msgid "can't read from file descriptor %d"
 msgstr "无法读取文件描述符 %d"
 
-#: ../src/common/file.cpp:581
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:608
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "无法删除文件 '%s'"
 
-#: ../src/common/file.cpp:598
+#: ../src/common/ffile.cpp:394 ../src/common/file.cpp:625
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "无法删除临时文件 '%s'"
 
-#: ../src/common/file.cpp:408
+#: ../src/common/file.cpp:449
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "无法定位文件描述符 %d"
 
-#: ../src/common/textfile.cpp:273
+#: ../src/common/textfile.cpp:161
 #, c-format
 msgid "can't write buffer '%s' to disk."
 msgstr "无法把缓存区 '%s' 写到磁盘。"
 
-#: ../src/common/file.cpp:323
+#: ../src/common/file.cpp:364
 #, c-format
 msgid "can't write to file descriptor %d"
 msgstr "无法写文件描述符 %d"
@@ -8242,22 +8428,28 @@ msgid "can't write user configuration file."
 msgstr "无法写用户配置文件。"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:482 ../src/generic/datavgen.cpp:1261
+#: ../src/common/datavcmn.cpp:2064 ../src/generic/datavgen.cpp:1384
 msgid "checked"
 msgstr ""
 
-#: ../src/html/chm.cpp:345
+#: ../src/html/chm.cpp:342
 msgid "checksum error"
 msgstr "校验和错误"
 
-#: ../src/common/tarstrm.cpp:820
+#: ../src/common/tarstrm.cpp:814
 msgid "checksum failure reading tar header block"
 msgstr "读取tar头部块发生校验和错误"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:226
-#: ../src/richtext/richtextbackgroundpage.cpp:249
-#: ../src/richtext/richtextbackgroundpage.cpp:289
-#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
 #: ../src/richtext/richtextborderspage.cpp:254
 #: ../src/richtext/richtextborderspage.cpp:288
 #: ../src/richtext/richtextborderspage.cpp:322
@@ -8275,105 +8467,128 @@ msgstr "读取tar头部块发生校验和错误"
 #: ../src/richtext/richtextmarginspage.cpp:340
 #: ../src/richtext/richtextmarginspage.cpp:363
 #: ../src/richtext/richtextmarginspage.cpp:388
-#: ../src/richtext/richtextsizepage.cpp:339
-#: ../src/richtext/richtextsizepage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:400
-#: ../src/richtext/richtextsizepage.cpp:427
-#: ../src/richtext/richtextsizepage.cpp:454
-#: ../src/richtext/richtextsizepage.cpp:481
-#: ../src/richtext/richtextsizepage.cpp:555
-#: ../src/richtext/richtextsizepage.cpp:590
-#: ../src/richtext/richtextsizepage.cpp:625
-#: ../src/richtext/richtextsizepage.cpp:660
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
 msgid "cm"
 msgstr "厘米"
 
-#: ../src/html/chm.cpp:347
+#: ../src/html/chm.cpp:344
 msgid "compression error"
 msgstr "压缩错误"
 
-#: ../src/common/regex.cpp:236
+#: ../src/common/regex.cpp:233
 msgid "conversion to 8-bit encoding failed"
 msgstr "无法转换为 8 位编码"
 
-#: ../src/common/accelcmn.cpp:187
+#: ../src/common/accelcmn.cpp:186
 msgid "ctrl"
 msgstr "ctrl"
 
-#: ../src/common/cmdline.cpp:1500
+#: ../src/common/cmdline.cpp:1496
 msgid "date"
 msgstr "日期"
 
-#: ../src/html/chm.cpp:349
+#: ../src/html/chm.cpp:346
 msgid "decompression error"
 msgstr "解压缩错误"
 
-#: ../src/richtext/richtextstyles.cpp:780 ../src/common/fmapbase.cpp:820
+#: ../src/common/fmapbase.cpp:816 ../src/richtext/richtextstyles.cpp:777
 msgid "default"
 msgstr "缺省值"
 
-#: ../src/common/cmdline.cpp:1496
+#: ../src/common/cmdline.cpp:1492
 msgid "double"
 msgstr "double"
 
-#: ../src/common/debugrpt.cpp:538
+#: ../src/common/debugrpt.cpp:539
 msgid "dump of the process state (binary)"
 msgstr "转储进程状态（二进制码）"
 
-#: ../src/common/datetimefmt.cpp:1969
+#: ../src/common/datetimefmt.cpp:1992
 msgid "eighteenth"
 msgstr "第十八"
 
-#: ../src/common/datetimefmt.cpp:1959
+#: ../src/common/datetimefmt.cpp:1982
 msgid "eighth"
 msgstr "第八"
 
-#: ../src/common/datetimefmt.cpp:1962
+#: ../src/common/datetimefmt.cpp:1985
 msgid "eleventh"
 msgstr "第十一"
 
-#: ../src/common/fileconf.cpp:1833
+#: ../src/common/fileconf.cpp:1835
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "条目 '%s' 在组 '%s' 中已出现一次以上"
 
-#: ../src/html/chm.cpp:343
+#: ../src/html/chm.cpp:340
 msgid "error in data format"
 msgstr "文件格式错误"
 
-#: ../src/html/chm.cpp:331
+#: ../src/html/chm.cpp:328
 msgid "error opening file"
 msgstr "打开文件出错"
 
-#: ../src/common/zipstrm.cpp:1778
+#: ../src/common/zipstrm.cpp:1836
 msgid "error reading zip central directory"
 msgstr "读 zip 中央目录时出错"
 
-#: ../src/common/zipstrm.cpp:1870
+#: ../src/common/zipstrm.cpp:1940
 msgid "error reading zip local header"
 msgstr "读 zip 本地头时出错"
 
-#: ../src/common/zipstrm.cpp:2531
+#: ../src/common/zipstrm.cpp:2615
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "写zip条目 '%s' 时出错: crc 校验或长度错误"
 
-#: ../src/common/ffile.cpp:188
+#: ../src/common/zipstrm.cpp:2608
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "写zip条目 '%s' 时出错: crc 校验或长度错误"
+
+#: ../src/common/fontcmn.cpp:1205
+#, fuzzy
+msgid "extrabold"
+msgstr "粗体"
+
+#: ../src/common/fontcmn.cpp:1223
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1167
+#, fuzzy
+msgid "extralight"
+msgstr "细体"
+
+#: ../src/msw/webview_ie.cpp:1036
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "无法执行 '%s'\n"
+
+#: ../src/common/ffile.cpp:187
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "刷新文件 '%s' 失败"
 
+#: ../src/msw/webview_ie.cpp:1045
+#, fuzzy
+msgid "failed to retrieve execution result"
+msgstr "无法提取 RAS 错误消息正文"
+
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1030
+#: ../src/generic/datavgen.cpp:1150
 #, fuzzy
 msgid "false"
 msgstr "False"
 
-#: ../src/common/datetimefmt.cpp:1966
+#: ../src/common/datetimefmt.cpp:1989
 msgid "fifteenth"
 msgstr "第十五"
 
-#: ../src/common/datetimefmt.cpp:1956
+#: ../src/common/datetimefmt.cpp:1979
 msgid "fifth"
 msgstr "第五"
 
@@ -8402,131 +8617,150 @@ msgstr "文件 '%s'，行 %d: 忽略不可变键 '%s' 的值。"
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "文件 '%s': 非预期的字符 %c 存在于行 %d。"
 
-#: ../src/richtext/richtextbuffer.cpp:8738
+#: ../src/richtext/richtextbuffer.cpp:8736
 msgid "files"
 msgstr "文件"
 
-#: ../src/common/datetimefmt.cpp:1952
+#: ../src/common/datetimefmt.cpp:1975
 msgid "first"
 msgstr "第一"
 
-#: ../src/html/helpwnd.cpp:1252
+#: ../src/html/helpwnd.cpp:1250
 msgid "font size"
 msgstr "字体大小"
 
-#: ../src/common/datetimefmt.cpp:1965
+#: ../src/common/datetimefmt.cpp:1988
 msgid "fourteenth"
 msgstr "第十四"
 
-#: ../src/common/datetimefmt.cpp:1955
+#: ../src/common/datetimefmt.cpp:1978
 msgid "fourth"
 msgstr "第四"
 
-#: ../src/common/appbase.cpp:783
+#: ../src/common/appbase.cpp:784
 msgid "generate verbose log messages"
 msgstr "生成详细的日志信息"
 
-#: ../src/richtext/richtextbuffer.cpp:13138
-#: ../src/richtext/richtextbuffer.cpp:13248
+#: ../src/common/fontcmn.cpp:1215
+msgid "heavy"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:13133
+#: ../src/richtext/richtextbuffer.cpp:13243
 msgid "image"
 msgstr "图片"
 
-#: ../src/common/tarstrm.cpp:796
+#: ../src/common/tarstrm.cpp:790
 msgid "incomplete header block in tar"
 msgstr "tar头部块不完整"
 
-#: ../src/common/xtixml.cpp:489
+#: ../src/common/xtixml.cpp:485
 msgid "incorrect event handler string, missing dot"
 msgstr "错误的时间句柄字符串，缺少点号('.')"
 
-#: ../src/common/tarstrm.cpp:1381
+#: ../src/common/tarstrm.cpp:1375
 msgid "incorrect size given for tar entry"
 msgstr "tar项目不正确的大小"
 
-#: ../src/common/tarstrm.cpp:993
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:987
 msgid "invalid data in extended tar header"
 msgstr "tar扩展头部中有图小数据"
 
-#: ../src/generic/logg.cpp:1030
+#: ../src/generic/logg.cpp:1027
 msgid "invalid message box return value"
 msgstr "消息框返回无效的值"
 
-#: ../src/common/zipstrm.cpp:1647
+#: ../src/common/zipstrm.cpp:1688
 msgid "invalid zip file"
 msgstr "无效的 zip 文件"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:1228
 msgid "italic"
 msgstr "斜体"
 
-#: ../src/common/fontcmn.cpp:991
+#: ../src/common/webrequest_curl.cpp:374
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "列描述无法初始化。"
+
+#: ../src/common/fontcmn.cpp:1172
 msgid "light"
 msgstr "细体"
 
-#: ../src/common/intl.cpp:303
-#, c-format
-msgid "locale '%s' cannot be set."
-msgstr "无法设置地区为 '%s'。"
+#: ../src/common/fontcmn.cpp:1185
+msgid "medium"
+msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2125
+#: ../src/common/datetimefmt.cpp:2148
 msgid "midnight"
 msgstr "午夜"
 
-#: ../src/common/datetimefmt.cpp:1970
+#: ../src/common/datetimefmt.cpp:1993
 msgid "nineteenth"
 msgstr "第十九"
 
-#: ../src/common/datetimefmt.cpp:1960
+#: ../src/common/datetimefmt.cpp:1983
 msgid "ninth"
 msgstr "第九"
 
-#: ../src/msw/dde.cpp:1116
+#: ../src/msw/dde.cpp:1180
 msgid "no DDE error."
 msgstr "没有 DDE 错误。"
 
-#: ../src/html/chm.cpp:327
+#: ../src/html/chm.cpp:324
 msgid "no error"
 msgstr "没有错误"
 
-#: ../src/dfb/fontmgr.cpp:174
+#: ../src/dfb/fontmgr.cpp:171
 #, c-format
 msgid "no fonts found in %s, using builtin font"
 msgstr "%s中字体为找到，将使用内置字体"
 
-#: ../src/html/helpdata.cpp:657
+#: ../src/html/helpdata.cpp:650
 msgid "noname"
 msgstr "未名"
 
-#: ../src/common/datetimefmt.cpp:2124
+#: ../src/common/datetimefmt.cpp:2147
 msgid "noon"
 msgstr "中午"
 
-#: ../src/richtext/richtextstyles.cpp:779
+#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "正常"
 
-#: ../src/common/cmdline.cpp:1492
+#: ../src/common/cmdline.cpp:1488
 msgid "num"
 msgstr "num"
 
-#: ../src/common/xtixml.cpp:259
+#: ../src/common/accelcmn.cpp:194
+msgid "num "
+msgstr ""
+
+#: ../src/common/xtixml.cpp:255
 msgid "objects cannot have XML Text Nodes"
 msgstr "对象不能有 XML 文本节点"
 
-#: ../src/html/chm.cpp:339
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
 msgid "out of memory"
 msgstr "内存耗尽"
 
-#: ../src/common/debugrpt.cpp:514
+#: ../src/common/debugrpt.cpp:515
 msgid "process context description"
 msgstr "进程上下文描述"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:227
-#: ../src/richtext/richtextbackgroundpage.cpp:250
-#: ../src/richtext/richtextbackgroundpage.cpp:290
-#: ../src/richtext/richtextbackgroundpage.cpp:317
-#: ../src/richtext/richtextfontpage.cpp:177
-#: ../src/richtext/richtextfontpage.cpp:180
 #: ../src/richtext/richtextborderspage.cpp:255
 #: ../src/richtext/richtextborderspage.cpp:289
 #: ../src/richtext/richtextborderspage.cpp:323
@@ -8536,22 +8770,45 @@ msgstr "进程上下文描述"
 #: ../src/richtext/richtextborderspage.cpp:491
 #: ../src/richtext/richtextborderspage.cpp:525
 #: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextfontpage.cpp:180
 msgid "pt"
 msgstr "点"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:225
-#: ../src/richtext/richtextbackgroundpage.cpp:228
-#: ../src/richtext/richtextbackgroundpage.cpp:229
-#: ../src/richtext/richtextbackgroundpage.cpp:248
-#: ../src/richtext/richtextbackgroundpage.cpp:251
-#: ../src/richtext/richtextbackgroundpage.cpp:252
-#: ../src/richtext/richtextbackgroundpage.cpp:288
-#: ../src/richtext/richtextbackgroundpage.cpp:291
-#: ../src/richtext/richtextbackgroundpage.cpp:292
-#: ../src/richtext/richtextbackgroundpage.cpp:315
-#: ../src/richtext/richtextbackgroundpage.cpp:318
-#: ../src/richtext/richtextbackgroundpage.cpp:319
-#: ../src/richtext/richtextfontpage.cpp:178
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:659
+#: ../src/richtext/richtextsizepage.cpp:662
+#: ../src/richtext/richtextsizepage.cpp:663
 #: ../src/richtext/richtextborderspage.cpp:253
 #: ../src/richtext/richtextborderspage.cpp:256
 #: ../src/richtext/richtextborderspage.cpp:257
@@ -8603,260 +8860,270 @@ msgstr "点"
 #: ../src/richtext/richtextmarginspage.cpp:387
 #: ../src/richtext/richtextmarginspage.cpp:389
 #: ../src/richtext/richtextmarginspage.cpp:390
-#: ../src/richtext/richtextsizepage.cpp:338
-#: ../src/richtext/richtextsizepage.cpp:341
-#: ../src/richtext/richtextsizepage.cpp:342
-#: ../src/richtext/richtextsizepage.cpp:372
-#: ../src/richtext/richtextsizepage.cpp:375
-#: ../src/richtext/richtextsizepage.cpp:376
-#: ../src/richtext/richtextsizepage.cpp:399
-#: ../src/richtext/richtextsizepage.cpp:402
-#: ../src/richtext/richtextsizepage.cpp:403
-#: ../src/richtext/richtextsizepage.cpp:426
-#: ../src/richtext/richtextsizepage.cpp:429
-#: ../src/richtext/richtextsizepage.cpp:430
-#: ../src/richtext/richtextsizepage.cpp:453
-#: ../src/richtext/richtextsizepage.cpp:456
-#: ../src/richtext/richtextsizepage.cpp:457
-#: ../src/richtext/richtextsizepage.cpp:480
-#: ../src/richtext/richtextsizepage.cpp:483
-#: ../src/richtext/richtextsizepage.cpp:484
-#: ../src/richtext/richtextsizepage.cpp:554
-#: ../src/richtext/richtextsizepage.cpp:557
-#: ../src/richtext/richtextsizepage.cpp:558
-#: ../src/richtext/richtextsizepage.cpp:589
-#: ../src/richtext/richtextsizepage.cpp:592
-#: ../src/richtext/richtextsizepage.cpp:593
-#: ../src/richtext/richtextsizepage.cpp:624
-#: ../src/richtext/richtextsizepage.cpp:627
-#: ../src/richtext/richtextsizepage.cpp:628
-#: ../src/richtext/richtextsizepage.cpp:659
-#: ../src/richtext/richtextsizepage.cpp:662
-#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextfontpage.cpp:178
 msgid "px"
 msgstr "像素"
 
-#: ../src/common/accelcmn.cpp:193
+#: ../src/common/accelcmn.cpp:192
 msgid "rawctrl"
 msgstr "rawctrl"
 
-#: ../src/html/chm.cpp:333
+#: ../src/html/chm.cpp:330
 msgid "read error"
 msgstr "读取错误"
 
-#: ../src/common/zipstrm.cpp:2085
+#: ../src/common/zipstrm.cpp:2155
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "读入 zip 流 (条目 %s): crc校验错误"
 
-#: ../src/common/zipstrm.cpp:2080
+#: ../src/common/zipstrm.cpp:2150
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "读入 zip 流 (条目 %s): 长度错误"
 
-#: ../src/msw/dde.cpp:1159
+#: ../src/msw/dde.cpp:1223
 msgid "reentrancy problem."
 msgstr "重入问题。"
 
-#: ../src/common/datetimefmt.cpp:1953
+#: ../src/common/datetimefmt.cpp:1976
 msgid "second"
 msgstr "第二"
 
-#: ../src/html/chm.cpp:337
+#: ../src/html/chm.cpp:334
 msgid "seek error"
 msgstr "搜索错误"
 
-#: ../src/common/datetimefmt.cpp:1968
+#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#, fuzzy
+msgid "semibold"
+msgstr "粗体"
+
+#: ../src/common/datetimefmt.cpp:1991
 msgid "seventeenth"
 msgstr "第十七"
 
-#: ../src/common/datetimefmt.cpp:1958
+#: ../src/common/datetimefmt.cpp:1981
 msgid "seventh"
 msgstr "第七"
 
-#: ../src/common/accelcmn.cpp:191
+#: ../src/common/accelcmn.cpp:190
 msgid "shift"
 msgstr "shift"
 
-#: ../src/common/appbase.cpp:773
+#: ../src/common/appbase.cpp:774
 msgid "show this help message"
 msgstr "显示帮助信息"
 
-#: ../src/common/datetimefmt.cpp:1967
+#: ../src/common/datetimefmt.cpp:1990
 msgid "sixteenth"
 msgstr "第十六"
 
-#: ../src/common/datetimefmt.cpp:1957
+#: ../src/common/datetimefmt.cpp:1980
 msgid "sixth"
 msgstr "第六"
 
-#: ../src/common/appcmn.cpp:234
+#: ../src/common/appcmn.cpp:255
 msgid "specify display mode to use (e.g. 640x480-16)"
 msgstr "指定使用的显示模式 (例如: 640x480-16位色)"
 
-#: ../src/common/appcmn.cpp:220
+#: ../src/common/appcmn.cpp:241
 msgid "specify the theme to use"
 msgstr "指定使用的主题"
 
-#: ../src/richtext/richtextbuffer.cpp:9340
+#: ../src/richtext/richtextbuffer.cpp:9337
 msgid "standard/circle"
 msgstr "标准/圆形"
 
-#: ../src/richtext/richtextbuffer.cpp:9341
+#: ../src/richtext/richtextbuffer.cpp:9338
 msgid "standard/circle-outline"
 msgstr "标准/圆框"
 
-#: ../src/richtext/richtextbuffer.cpp:9343
+#: ../src/richtext/richtextbuffer.cpp:9340
 msgid "standard/diamond"
 msgstr "标准/菱形"
 
-#: ../src/richtext/richtextbuffer.cpp:9342
+#: ../src/richtext/richtextbuffer.cpp:9339
 msgid "standard/square"
 msgstr "标准/方形"
 
-#: ../src/richtext/richtextbuffer.cpp:9344
+#: ../src/richtext/richtextbuffer.cpp:9341
 msgid "standard/triangle"
 msgstr "标准/三角形"
 
-#: ../src/common/zipstrm.cpp:1985
+#: ../src/common/zipstrm.cpp:2055
 msgid "stored file length not in Zip header"
 msgstr "Zip 头没有已存文件的长度信息"
 
-#: ../src/common/cmdline.cpp:1488
+#: ../src/common/cmdline.cpp:1484
 msgid "str"
 msgstr "str"
 
-#: ../src/common/fontcmn.cpp:982
+#: ../src/common/fontcmn.cpp:1145
 msgid "strikethrough"
 msgstr "删除线"
 
-#: ../src/common/tarstrm.cpp:1003 ../src/common/tarstrm.cpp:1025
-#: ../src/common/tarstrm.cpp:1507 ../src/common/tarstrm.cpp:1529
+#: ../src/common/tarstrm.cpp:997 ../src/common/tarstrm.cpp:1019
+#: ../src/common/tarstrm.cpp:1501 ../src/common/tarstrm.cpp:1523
 msgid "tar entry not open"
 msgstr "tar标头未打开"
 
-#: ../src/common/datetimefmt.cpp:1961
+#: ../src/common/datetimefmt.cpp:1984
 msgid "tenth"
 msgstr "第十"
 
-#: ../src/msw/dde.cpp:1123
+#: ../src/msw/dde.cpp:1187
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "对事件的响应导致 DDE_FBUSY 位被设置。"
 
-#: ../src/common/datetimefmt.cpp:1954
+#: ../src/common/fontcmn.cpp:1154
+msgid "thin"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:1977
 msgid "third"
 msgstr "第三"
 
-#: ../src/common/datetimefmt.cpp:1964
+#: ../src/common/datetimefmt.cpp:1987
 msgid "thirteenth"
 msgstr "第十三"
 
-#: ../src/common/datetimefmt.cpp:1758
+#: ../src/common/datetimefmt.cpp:1781
 msgid "today"
 msgstr "今天"
 
-#: ../src/common/datetimefmt.cpp:1760
+#: ../src/common/datetimefmt.cpp:1783
 msgid "tomorrow"
 msgstr "明天"
 
-#: ../src/common/fileconf.cpp:1944
+#: ../src/common/fileconf.cpp:1946
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "'%s'尾部的斜线将被忽略"
 
-#: ../src/gtk/aboutdlg.cpp:218
+#: ../src/gtk/aboutdlg.cpp:216
 msgid "translator-credits"
 msgstr "翻译人员"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1028
+#: ../src/generic/datavgen.cpp:1148
 msgid "true"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1963
+#: ../src/common/datetimefmt.cpp:1986
 msgid "twelfth"
 msgstr "第十二"
 
-#: ../src/common/datetimefmt.cpp:1971
+#: ../src/common/datetimefmt.cpp:1994
 msgid "twentieth"
 msgstr "第二十"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:486 ../src/generic/datavgen.cpp:1263
+#: ../src/common/datavcmn.cpp:2068 ../src/generic/datavgen.cpp:1386
 msgid "unchecked"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:802 ../src/common/fontcmn.cpp:978
+#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
 msgid "underlined"
 msgstr "下划线"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/generic/treelist.cpp:490
+#: ../src/common/datavcmn.cpp:2072
 #, fuzzy
 msgid "undetermined"
 msgstr "下划线"
 
-#: ../src/common/fileconf.cpp:1979
+#: ../src/common/fileconf.cpp:1981
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "例外的 \" 在位置 %d (位于 '%s')."
 
-#: ../src/common/tarstrm.cpp:1045
+#: ../src/common/tarstrm.cpp:1039
 msgid "unexpected end of file"
 msgstr "意外到达文件结尾"
 
-#: ../src/generic/progdlgg.cpp:370 ../src/common/tarstrm.cpp:371
-#: ../src/common/tarstrm.cpp:394 ../src/common/tarstrm.cpp:425
+#: ../src/common/tarstrm.cpp:366 ../src/common/tarstrm.cpp:389
+#: ../src/common/tarstrm.cpp:420 ../src/generic/progdlgg.cpp:376
 msgid "unknown"
 msgstr "未知"
 
-#: ../src/msw/registry.cpp:150
+#: ../src/msw/registry.cpp:139
 #, fuzzy, c-format
 msgid "unknown (%lu)"
 msgstr "未知"
 
-#: ../src/common/xtixml.cpp:253
+#: ../src/common/xtixml.cpp:249
 #, c-format
 msgid "unknown class %s"
 msgstr "未知类 %s"
 
-#: ../src/common/regex.cpp:258 ../src/html/chm.cpp:351
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "压缩错误"
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "解压缩错误"
+
+#: ../src/common/regex.cpp:255 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "未知错误"
 
-#: ../src/msw/dialup.cpp:471
+#: ../src/msw/dialup.cpp:465
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "未知错误 (错误号 %08x)。"
 
-#: ../src/common/fmapbase.cpp:834
+#: ../src/common/fmapbase.cpp:830
 #, c-format
 msgid "unknown-%d"
 msgstr "未知-%d"
 
-#: ../src/common/docview.cpp:509
+#: ../src/common/docview.cpp:502
 msgid "unnamed"
 msgstr "未命名"
 
-#: ../src/common/docview.cpp:1624
+#: ../src/common/docview.cpp:1618
 #, c-format
 msgid "unnamed%d"
 msgstr "未命名 %d"
 
-#: ../src/common/zipstrm.cpp:1999 ../src/common/zipstrm.cpp:2319
+#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
 msgid "unsupported Zip compression method"
 msgstr "不支持的 Zip 压缩方法"
 
-#: ../src/common/translation.cpp:1892
+#: ../src/common/translation.cpp:1942
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "使用目录 '%s' 从 '%s'。"
 
-#: ../src/html/chm.cpp:335
+#: ../src/html/chm.cpp:332
 msgid "write error"
 msgstr "写错误"
 
-#: ../src/common/time.cpp:292
+#: ../src/gtk/glcanvas.cpp:187
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/common/time.cpp:285
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay 失败。"
 
@@ -8869,15 +9136,15 @@ msgstr "wxWidgets 无法为 '%s' 打开显示设备: 退出。"
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets 无法打开显示设备。退出。"
 
-#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:431
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/common/datetimefmt.cpp:1759
+#: ../src/common/datetimefmt.cpp:1782
 msgid "yesterday"
 msgstr "昨天"
 
-#: ../src/common/zstream.cpp:251 ../src/common/zstream.cpp:426
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
 #, c-format
 msgid "zlib error %d"
 msgstr "zlib 错误 %d"
@@ -8886,6 +9153,77 @@ msgstr "zlib 错误 %d"
 #: ../src/richtext/richtextbulletspage.cpp:288
 msgid "~"
 msgstr "~"
+
+#~ msgid "&Save as"
+#~ msgstr "另存为(&S)"
+
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' 不仅包含有效字符"
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' 应该是一个数值。"
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' 应该仅包含ASCII字符。"
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' 应仅包含字母字符。"
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' 应仅包含字母或数字字符。"
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' 应该仅包含数字。"
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "无法创建窗口类 %s"
+
+#, fuzzy
+#~ msgid "Could not initalize libnotify."
+#~ msgstr "无法设定对齐。"
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "无法创建 overlay 窗口"
+
+#, fuzzy
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "无法获得当前线程指针"
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "无法转换文件 \"%s\" 为 Unicode。"
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "无法设置文本编辑器控件的文字。"
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr "无效的GTK+命令行选项，使用 \"%s --help\""
+
+#~ msgid "No unused colour in image."
+#~ msgstr "图像中没有未用的颜色。"
+
+#~ msgid "Not available"
+#~ msgstr "不可用"
+
+#~ msgid "Replace selection"
+#~ msgstr "替换选区"
+
+#~ msgid "Save as"
+#~ msgstr "另存为"
+
+#~ msgid "Style Organiser"
+#~ msgstr "样式组织器"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "以下标准GTK+选项也被支持:\n"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "你无法清除未初始化的 overlay。"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "你不能初始化 overlay 两次"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "无法设置地区为 '%s'。"
 
 #~ msgid "Adding flavor TEXT failed"
 #~ msgstr "添加风格 TEXT 失败"
@@ -8902,9 +9240,6 @@ msgstr "~"
 
 #~ msgid "Column could not be added."
 #~ msgstr "无法增加列。"
-
-#~ msgid "Column description could not be initialized."
-#~ msgstr "列描述无法初始化。"
 
 #~ msgid "Column index not found."
 #~ msgstr "找不到列索引。"
@@ -9476,9 +9811,6 @@ msgstr "~"
 #~ msgid "Directory '%s' doesn't exist!"
 #~ msgstr "目录 '%s'不存在!"
 
-#~ msgid "File %s does not exist."
-#~ msgstr "文件 %s 不存在。"
-
 #~ msgid "Mode %ix%i-%i not available."
 #~ msgstr "显示模式 %ix%i-%i位色 不支持。"
 
@@ -9618,9 +9950,6 @@ msgstr "~"
 #~ msgid "Failed to register OpenGL window class."
 #~ msgstr "不能注册 OpenGL窗口类."
 
-#~ msgid "Fatal error"
-#~ msgstr "致命错误"
-
 #~ msgid "Fatal error: "
 #~ msgstr "致命错误: "
 
@@ -9732,9 +10061,6 @@ msgstr "~"
 
 #~ msgid "&Print"
 #~ msgstr "打印(&P)"
-
-#~ msgid "*** A debug report has been generated\n"
-#~ msgstr "*** 生成了一份调试报告\n"
 
 #~ msgid "*** It can be found in \"%s\"\n"
 #~ msgstr "*** 可在此找到: \"%s\"\n"

--- a/locale/zh_TW.po
+++ b/locale/zh_TW.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-01-20 21:26+0800\n"
+"POT-Creation-Date: 2020-10-18 23:11+0300\n"
 "PO-Revision-Date: 2020-01-21 00:27+0800\n"
 "Last-Translator: Yi-Jyun Pan <pan93412@gmail.com>\n"
 "Language-Team: Chinese <zh-l10n@lists.linux.org.tw>\n"
@@ -22,7 +22,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Lokalize 19.12.1\n"
 
-#: ../src/common/debugrpt.cpp:590
+#: ../src/common/debugrpt.cpp:587
 msgid ""
 "\n"
 "Please send this report to the program maintainer, thank you!\n"
@@ -30,106 +30,102 @@ msgstr ""
 "\n"
 "請將報告傳送給程式維護人員，謝謝！\n"
 
-#: ../src/richtext/richtextstyledlg.cpp:210
-#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:206
+#: ../src/richtext/richtextstyledlg.cpp:218
 msgid " "
 msgstr " "
 
-#: ../src/generic/dbgrptg.cpp:329
+#: ../src/generic/dbgrptg.cpp:326
 msgid "              Thank you and we're sorry for the inconvenience!\n"
 msgstr "              謝謝，我們對您遇到的不便表示抱歉！\n"
 
-#: ../src/common/prntbase.cpp:573
+#: ../src/common/prntbase.cpp:568
 #, c-format
 msgid " (copy %d of %d)"
 msgstr " (複製 %d / %d )"
 
-#: ../src/common/log.cpp:421
+#: ../src/common/log.cpp:440
 #, c-format
 msgid " (error %ld: %s)"
 msgstr " (錯誤 %ld: %s)"
 
-#: ../src/common/imagtiff.cpp:72
+#: ../src/common/imagtiff.cpp:69
 #, c-format
 msgid " (in module \"%s\")"
 msgstr "(在「%s」模組)"
 
-#: ../src/common/docview.cpp:1639
+#: ../src/common/docview.cpp:1636
 msgid " - "
 msgstr " - "
 
-#: ../src/html/htmprint.cpp:715 ../src/richtext/richtextprint.cpp:592
+#: ../src/html/htmprint.cpp:712 ../src/richtext/richtextprint.cpp:589
 msgid " Preview"
 msgstr "預覽"
 
-#: ../src/common/fontcmn.cpp:978
+#: ../src/common/fontcmn.cpp:973
 msgid " bold"
 msgstr "粗體"
 
-#: ../src/common/fontcmn.cpp:982
-#| msgid " bold"
+#: ../src/common/fontcmn.cpp:977
 msgid " extra bold"
 msgstr " 特粗"
 
-#: ../src/common/fontcmn.cpp:990
+#: ../src/common/fontcmn.cpp:985
 msgid " extra heavy"
 msgstr " 特濃"
 
-#: ../src/common/fontcmn.cpp:962
-#| msgid " light"
+#: ../src/common/fontcmn.cpp:957
 msgid " extra light"
 msgstr " 特細"
 
-#: ../src/common/fontcmn.cpp:986
+#: ../src/common/fontcmn.cpp:981
 msgid " heavy"
 msgstr " 濃體"
 
-#: ../src/common/fontcmn.cpp:1006
+#: ../src/common/fontcmn.cpp:1001
 msgid " italic"
 msgstr "斜體"
 
-#: ../src/common/fontcmn.cpp:966
+#: ../src/common/fontcmn.cpp:961
 msgid " light"
 msgstr "細體"
 
-#: ../src/common/fontcmn.cpp:970
+#: ../src/common/fontcmn.cpp:965
 msgid " medium"
 msgstr " 適中"
 
-#: ../src/common/fontcmn.cpp:974
-#| msgid " bold"
+#: ../src/common/fontcmn.cpp:969
 msgid " semi bold"
 msgstr " 次粗"
 
-#: ../src/common/fontcmn.cpp:945
+#: ../src/common/fontcmn.cpp:940
 msgid " strikethrough"
 msgstr "刪除線"
 
-#: ../src/common/fontcmn.cpp:958
+#: ../src/common/fontcmn.cpp:953
 msgid " thin"
 msgstr " 淡體"
 
-#: ../src/common/paper.cpp:117
+#: ../src/common/paper.cpp:114
 msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
 msgstr "#10 信封，4 1/8 x 9 1/2 英吋"
 
-#: ../src/common/paper.cpp:118
+#: ../src/common/paper.cpp:115
 msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
 msgstr "#11 信封，4 1/2 x 10 3/8 英吋"
 
-#: ../src/common/paper.cpp:119
+#: ../src/common/paper.cpp:116
 msgid "#12 Envelope, 4 3/4 x 11 in"
 msgstr "#12 信封，4 3/4 x 11 英吋"
 
-#: ../src/common/paper.cpp:120
+#: ../src/common/paper.cpp:117
 msgid "#14 Envelope, 5 x 11 1/2 in"
 msgstr "#14 信封，5 x 11 1/2 英吋"
 
-#: ../src/common/paper.cpp:116
+#: ../src/common/paper.cpp:113
 msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
 msgstr "#9 信封, 3 7/8 x 8 7/8 英吋"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:341
 #: ../src/richtext/richtextsizepage.cpp:340
 #: ../src/richtext/richtextsizepage.cpp:374
 #: ../src/richtext/richtextsizepage.cpp:401
@@ -140,80 +136,81 @@ msgstr "#9 信封, 3 7/8 x 8 7/8 英吋"
 #: ../src/richtext/richtextsizepage.cpp:591
 #: ../src/richtext/richtextsizepage.cpp:626
 #: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextbackgroundpage.cpp:341
 msgid "%"
 msgstr "%"
 
-#: ../src/html/helpwnd.cpp:1032
+#: ../src/html/helpwnd.cpp:1029
 #, c-format
 msgid "%d of %lu"
 msgstr "%d / %lu"
 
-#: ../src/html/helpwnd.cpp:1679
+#: ../src/html/helpwnd.cpp:1676
 #, c-format
 msgid "%i of %u"
 msgstr "%i / %u"
 
-#: ../src/generic/filectrlg.cpp:279
+#: ../src/generic/filectrlg.cpp:275
 #, c-format
 msgid "%ld byte"
 msgid_plural "%ld bytes"
 msgstr[0] "%ld 位元組"
 
-#: ../src/html/helpwnd.cpp:1034
+#: ../src/html/helpwnd.cpp:1031
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu / %lu"
 
-#: ../src/generic/datavgen.cpp:6476
+#: ../src/generic/datavgen.cpp:6833
 #, c-format
 msgid "%s (%d items)"
 msgstr "%s (%d 個項目)"
 
-#: ../src/common/cmdline.cpp:1220
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (或 %s)"
 
-#: ../src/generic/logg.cpp:224
+#: ../src/generic/logg.cpp:221
 #, c-format
 msgid "%s Error"
 msgstr "%s 錯誤"
 
-#: ../src/generic/logg.cpp:236
+#: ../src/generic/logg.cpp:233
 #, c-format
 msgid "%s Information"
 msgstr "%s 資訊"
 
-#: ../src/generic/preferencesg.cpp:113
+#: ../src/generic/preferencesg.cpp:110
 #, c-format
 msgid "%s Preferences"
 msgstr "%s 偏好設定"
 
-#: ../src/generic/logg.cpp:228
+#: ../src/generic/logg.cpp:225
 #, c-format
 msgid "%s Warning"
 msgstr "%s 警告"
 
-#: ../src/common/tarstrm.cpp:1316
+#: ../src/common/tarstrm.cpp:1313
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s 不符合項目「%s」的 tar 標頭"
 
-#: ../src/common/fldlgcmn.cpp:124
+#: ../src/common/fldlgcmn.cpp:121
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s 個檔案 (%s)|%s"
 
-#: ../src/html/helpwnd.cpp:1717
+#: ../src/html/helpwnd.cpp:1714
 #, c-format
 msgid "%u of %u"
 msgstr "%u / %u"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "&About"
 msgstr "關於(&A)"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "&Actual Size"
 msgstr "實際大小(&A)"
 
@@ -221,28 +218,28 @@ msgstr "實際大小(&A)"
 msgid "&After a paragraph:"
 msgstr "段落之後(&A)："
 
-#: ../src/richtext/richtextindentspage.cpp:128
 #: ../src/richtext/richtextliststylepage.cpp:319
+#: ../src/richtext/richtextindentspage.cpp:128
 msgid "&Alignment"
 msgstr "對齊(&A)"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "&Apply"
 msgstr "套用(&A)"
 
-#: ../src/richtext/richtextstyledlg.cpp:251
+#: ../src/richtext/richtextstyledlg.cpp:247
 msgid "&Apply Style"
 msgstr "套用樣式(&A)"
 
-#: ../src/msw/mdi.cpp:177
+#: ../src/msw/mdi.cpp:174
 msgid "&Arrange Icons"
 msgstr "排列圖示(&A)"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "&Ascending"
 msgstr "遞增(&A)"
 
-#: ../src/common/stockitem.cpp:142
+#: ../src/common/stockitem.cpp:139
 msgid "&Back"
 msgstr "回傳(&B)"
 
@@ -262,20 +259,20 @@ msgstr "背景顏色(&B)："
 msgid "&Blur distance:"
 msgstr "模糊距離(&B)："
 
-#: ../src/common/stockitem.cpp:143
+#: ../src/common/stockitem.cpp:140
 msgid "&Bold"
 msgstr "粗體(&B)"
 
-#: ../src/common/stockitem.cpp:144
+#: ../src/common/stockitem.cpp:141
 msgid "&Bottom"
 msgstr "底端(&B)"
 
+#: ../src/richtext/richtextsizepage.cpp:637
+#: ../src/richtext/richtextsizepage.cpp:644
 #: ../src/richtext/richtextborderspage.cpp:345
 #: ../src/richtext/richtextborderspage.cpp:513
 #: ../src/richtext/richtextmarginspage.cpp:259
 #: ../src/richtext/richtextmarginspage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:637
-#: ../src/richtext/richtextsizepage.cpp:644
 msgid "&Bottom:"
 msgstr "底端(&B):"
 
@@ -283,22 +280,22 @@ msgstr "底端(&B):"
 msgid "&Box"
 msgstr "文字方塊(&B)"
 
-#: ../src/richtext/richtextbulletspage.cpp:146
 #: ../src/richtext/richtextliststylepage.cpp:210
+#: ../src/richtext/richtextbulletspage.cpp:146
 msgid "&Bullet style:"
 msgstr "項目符號樣式(&B):"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "&CD-Rom"
 msgstr "唯讀光碟(&C)"
 
-#: ../src/common/stockitem.cpp:145 ../src/generic/fontdlgg.cpp:470
-#: ../src/generic/fontdlgg.cpp:489 ../src/generic/wizard.cpp:436
-#: ../src/osx/carbon/fontdlg.cpp:402
+#: ../src/osx/carbon/fontdlg.cpp:399 ../src/common/stockitem.cpp:142
+#: ../src/generic/wizard.cpp:433 ../src/generic/fontdlgg.cpp:466
+#: ../src/generic/fontdlgg.cpp:485 ../src/osx/cocoa/button.mm:200
 msgid "&Cancel"
 msgstr "取消(&C)"
 
-#: ../src/msw/mdi.cpp:173
+#: ../src/msw/mdi.cpp:170
 msgid "&Cascade"
 msgstr "層疊排列(&C)"
 
@@ -306,20 +303,20 @@ msgstr "層疊排列(&C)"
 msgid "&Cell"
 msgstr "儲存格(&C)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:439
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "&Character code:"
 msgstr "字元碼(&C):"
 
-#: ../src/common/stockitem.cpp:147
+#: ../src/common/stockitem.cpp:144
 msgid "&Clear"
 msgstr "清除(&C)"
 
-#: ../src/common/prntbase.cpp:1630 ../src/common/stockitem.cpp:148
-#: ../src/generic/logg.cpp:516 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/stockitem.cpp:145 ../src/common/prntbase.cpp:1625
+#: ../src/univ/themes/win32.cpp:3753 ../src/generic/logg.cpp:513
 msgid "&Close"
 msgstr "關閉(&C)"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "&Color"
 msgstr "顏色(&C)"
 
@@ -327,75 +324,74 @@ msgstr "顏色(&C)"
 msgid "&Colour:"
 msgstr "顏色(&C)："
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "&Convert"
 msgstr "轉換(&C)"
 
-#: ../src/common/stockitem.cpp:150 ../src/msw/textctrl.cpp:2723
-#: ../src/osx/textctrl_osx.cpp:585 ../src/richtext/richtextctrl.cpp:335
+#: ../src/osx/textctrl_osx.cpp:595 ../src/common/stockitem.cpp:147
+#: ../src/msw/textctrl.cpp:2773 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "複製(&C)"
 
-#: ../src/generic/hyperlinkg.cpp:156
+#: ../src/generic/hyperlinkg.cpp:153
 msgid "&Copy URL"
 msgstr "複製網址(&C)"
 
-#: ../src/common/headerctrlcmn.cpp:307
+#: ../src/common/headerctrlcmn.cpp:304
 msgid "&Customize..."
 msgstr "自訂(&C)..."
 
-#: ../src/generic/dbgrptg.cpp:337
+#: ../src/generic/dbgrptg.cpp:334
 msgid "&Debug report preview:"
 msgstr "除錯報告預覽(&D)："
 
-#: ../src/common/stockitem.cpp:152 ../src/msw/textctrl.cpp:2725
-#: ../src/osx/textctrl_osx.cpp:587 ../src/richtext/richtextctrl.cpp:337
-#: ../src/richtext/richtexttabspage.cpp:138
+#: ../src/osx/textctrl_osx.cpp:597 ../src/common/stockitem.cpp:149
+#: ../src/msw/textctrl.cpp:2775 ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtextctrl.cpp:334
 msgid "&Delete"
 msgstr "刪除(&D)"
 
-#: ../src/richtext/richtextstyledlg.cpp:269
+#: ../src/richtext/richtextstyledlg.cpp:265
 msgid "&Delete Style..."
 msgstr "刪除樣式(&D)"
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "&Descending"
 msgstr "遞減(&D)"
 
-#: ../src/generic/logg.cpp:682
+#: ../src/generic/logg.cpp:679
 msgid "&Details"
 msgstr "細節(&D)"
 
-#: ../src/common/stockitem.cpp:153
+#: ../src/common/stockitem.cpp:150
 msgid "&Down"
 msgstr "向下(&D)"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "&Edit"
 msgstr "編輯(&E)"
 
-#: ../src/richtext/richtextstyledlg.cpp:263
+#: ../src/richtext/richtextstyledlg.cpp:259
 msgid "&Edit Style..."
 msgstr "編輯樣式(&E)…"
 
-#: ../src/common/stockitem.cpp:155
+#: ../src/common/stockitem.cpp:152
 msgid "&Execute"
 msgstr "執行(&E)"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/common/stockitem.cpp:154
 msgid "&File"
 msgstr "檔案(&F)"
 
-#: ../src/common/stockitem.cpp:158
-#| msgid "&Find"
+#: ../src/common/stockitem.cpp:155
 msgid "&Find..."
 msgstr "尋找(&F)…"
 
-#: ../src/generic/wizard.cpp:433
+#: ../src/generic/wizard.cpp:430
 msgid "&Finish"
 msgstr "完成(&F)"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:156
 msgid "&First"
 msgstr "第一(&F)"
 
@@ -403,15 +399,15 @@ msgstr "第一(&F)"
 msgid "&Floating mode:"
 msgstr "浮動模式(&F):"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "&Floppy"
 msgstr "軟碟(&F)"
 
-#: ../src/common/stockitem.cpp:194
+#: ../src/common/stockitem.cpp:191
 msgid "&Font"
 msgstr "字型(&F)"
 
-#: ../src/generic/fontdlgg.cpp:371
+#: ../src/generic/fontdlgg.cpp:367
 msgid "&Font family:"
 msgstr "字族(&F)："
 
@@ -419,20 +415,20 @@ msgstr "字族(&F)："
 msgid "&Font for Level..."
 msgstr "層級字型(&F)..."
 
+#: ../src/richtext/richtextsymboldlg.cpp:397
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:400
 msgid "&Font:"
 msgstr "字型(&F)："
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "&Forward"
 msgstr "向前(&F)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:451
+#: ../src/richtext/richtextsymboldlg.cpp:448
 msgid "&From:"
 msgstr "從(&F)："
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "&Harddisk"
 msgstr "硬碟(&H)"
 
@@ -441,9 +437,9 @@ msgstr "硬碟(&H)"
 msgid "&Height:"
 msgstr "高度(&H):"
 
-#: ../src/common/stockitem.cpp:163 ../src/generic/wizard.cpp:439
-#: ../src/richtext/richtextstyledlg.cpp:303
-#: ../src/richtext/richtextsymboldlg.cpp:479
+#: ../src/common/stockitem.cpp:160 ../src/generic/wizard.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextstyledlg.cpp:299 ../src/osx/cocoa/menu.mm:226
 msgid "&Help"
 msgstr "求助(&H)"
 
@@ -451,7 +447,7 @@ msgstr "求助(&H)"
 msgid "&Hide details"
 msgstr "隱藏細節(&H)"
 
-#: ../src/common/stockitem.cpp:164
+#: ../src/common/stockitem.cpp:161
 msgid "&Home"
 msgstr "首頁(&H)"
 
@@ -459,54 +455,54 @@ msgstr "首頁(&H)"
 msgid "&Horizontal offset:"
 msgstr "水平偏移值(&H)："
 
-#: ../src/richtext/richtextindentspage.cpp:184
 #: ../src/richtext/richtextliststylepage.cpp:372
+#: ../src/richtext/richtextindentspage.cpp:184
 msgid "&Indentation (tenths of a mm)"
 msgstr "縮排(&I) (十分之一公釐[mm])"
 
-#: ../src/richtext/richtextindentspage.cpp:167
 #: ../src/richtext/richtextliststylepage.cpp:356
+#: ../src/richtext/richtextindentspage.cpp:167
 msgid "&Indeterminate"
 msgstr "尚未設定(&I)"
 
-#: ../src/common/stockitem.cpp:166
+#: ../src/common/stockitem.cpp:163
 msgid "&Index"
 msgstr "索引(&I)"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "&Info"
 msgstr "資訊(&I)"
 
-#: ../src/common/stockitem.cpp:168
+#: ../src/common/stockitem.cpp:165
 msgid "&Italic"
 msgstr "斜體(&I)"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "&Jump to"
 msgstr "跳至(&J)"
 
-#: ../src/richtext/richtextindentspage.cpp:153
 #: ../src/richtext/richtextliststylepage.cpp:342
+#: ../src/richtext/richtextindentspage.cpp:153
 msgid "&Justified"
 msgstr "分散對齊(&J)"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "&Last"
 msgstr "最後(&L)"
 
-#: ../src/richtext/richtextindentspage.cpp:139
 #: ../src/richtext/richtextliststylepage.cpp:328
+#: ../src/richtext/richtextindentspage.cpp:139
 msgid "&Left"
 msgstr "左側(&L)"
 
-#: ../src/richtext/richtextborderspage.cpp:243
-#: ../src/richtext/richtextborderspage.cpp:411
-#: ../src/richtext/richtextindentspage.cpp:195
-#: ../src/richtext/richtextliststylepage.cpp:381
-#: ../src/richtext/richtextmarginspage.cpp:186
-#: ../src/richtext/richtextmarginspage.cpp:300
 #: ../src/richtext/richtextsizepage.cpp:532
 #: ../src/richtext/richtextsizepage.cpp:539
+#: ../src/richtext/richtextborderspage.cpp:243
+#: ../src/richtext/richtextborderspage.cpp:411
+#: ../src/richtext/richtextliststylepage.cpp:381
+#: ../src/richtext/richtextindentspage.cpp:195
+#: ../src/richtext/richtextmarginspage.cpp:186
+#: ../src/richtext/richtextmarginspage.cpp:300
 msgid "&Left:"
 msgstr "左側(&L)："
 
@@ -514,11 +510,11 @@ msgstr "左側(&L)："
 msgid "&List level:"
 msgstr "清單層級(&L)："
 
-#: ../src/generic/logg.cpp:517
+#: ../src/generic/logg.cpp:514
 msgid "&Log"
 msgstr "日誌(&L)"
 
-#: ../src/univ/themes/win32.cpp:3748
+#: ../src/univ/themes/win32.cpp:3745
 msgid "&Move"
 msgstr "移動(&M)"
 
@@ -526,19 +522,19 @@ msgstr "移動(&M)"
 msgid "&Move the object to:"
 msgstr "移動物件至(&M)："
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "&Network"
 msgstr "網路(&N)"
 
-#: ../src/common/stockitem.cpp:176 ../src/richtext/richtexttabspage.cpp:132
+#: ../src/common/stockitem.cpp:173 ../src/richtext/richtexttabspage.cpp:132
 msgid "&New"
 msgstr "新增(&N)"
 
-#: ../src/aui/tabmdi.cpp:111 ../src/generic/mdig.cpp:100 ../src/msw/mdi.cpp:178
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
 msgid "&Next"
 msgstr "下一個(&N)"
 
-#: ../src/generic/wizard.cpp:432
+#: ../src/generic/wizard.cpp:429
 msgid "&Next >"
 msgstr "下一個(&N) 》"
 
@@ -546,7 +542,7 @@ msgstr "下一個(&N) 》"
 msgid "&Next Paragraph"
 msgstr "下一個段落(&N)"
 
-#: ../src/generic/tipdlg.cpp:240
+#: ../src/generic/tipdlg.cpp:237
 msgid "&Next Tip"
 msgstr "下一個祕訣(&N)"
 
@@ -554,11 +550,11 @@ msgstr "下一個祕訣(&N)"
 msgid "&Next style:"
 msgstr "下一個樣式(&N)："
 
-#: ../src/common/stockitem.cpp:177 ../src/msw/msgdlg.cpp:438
+#: ../src/common/stockitem.cpp:174 ../src/msw/msgdlg.cpp:435
 msgid "&No"
 msgstr "否(&N)"
 
-#: ../src/generic/dbgrptg.cpp:363
+#: ../src/generic/dbgrptg.cpp:360
 msgid "&Notes:"
 msgstr "注意(&N)："
 
@@ -566,12 +562,12 @@ msgstr "注意(&N)："
 msgid "&Number:"
 msgstr "編號(&N)："
 
-#: ../src/common/stockitem.cpp:178 ../src/generic/fontdlgg.cpp:475
-#: ../src/generic/fontdlgg.cpp:482 ../src/osx/carbon/fontdlg.cpp:408
+#: ../src/osx/carbon/fontdlg.cpp:405 ../src/common/stockitem.cpp:175
+#: ../src/generic/fontdlgg.cpp:471 ../src/generic/fontdlgg.cpp:478
 msgid "&OK"
 msgstr "確認(&O)"
 
-#: ../src/common/stockitem.cpp:179 ../src/generic/dbgrptg.cpp:345
+#: ../src/common/stockitem.cpp:176 ../src/generic/dbgrptg.cpp:342
 msgid "&Open..."
 msgstr "開啟(&O)…"
 
@@ -583,8 +579,8 @@ msgstr "大綱層級(&O)："
 msgid "&Page Break"
 msgstr "換頁符號(&P)"
 
-#: ../src/common/stockitem.cpp:180 ../src/msw/textctrl.cpp:2724
-#: ../src/osx/textctrl_osx.cpp:586 ../src/richtext/richtextctrl.cpp:336
+#: ../src/osx/textctrl_osx.cpp:596 ../src/common/stockitem.cpp:177
+#: ../src/msw/textctrl.cpp:2774 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "貼上(&P)"
 
@@ -592,7 +588,7 @@ msgstr "貼上(&P)"
 msgid "&Picture"
 msgstr "圖片(&P)"
 
-#: ../src/generic/fontdlgg.cpp:423
+#: ../src/generic/fontdlgg.cpp:419
 msgid "&Point size:"
 msgstr "字點大小(&P)："
 
@@ -604,11 +600,11 @@ msgstr "位置(&P) (十分之一公釐[mm])："
 msgid "&Position mode:"
 msgstr "位置模式(&P)："
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178
 msgid "&Preferences"
 msgstr "偏好設定(&P)"
 
-#: ../src/aui/tabmdi.cpp:112 ../src/generic/mdig.cpp:101 ../src/msw/mdi.cpp:179
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
 msgid "&Previous"
 msgstr "上一個(&P)"
 
@@ -616,62 +612,62 @@ msgstr "上一個(&P)"
 msgid "&Previous Paragraph"
 msgstr "上一個段落(&P)"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "&Print..."
 msgstr "列印(&P)…"
 
-#: ../src/common/stockitem.cpp:184 ../src/richtext/richtextctrl.cpp:341
-#: ../src/richtext/richtextctrl.cpp:5515
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtextctrl.cpp:338
+#: ../src/richtext/richtextctrl.cpp:5512
 msgid "&Properties"
 msgstr "性質(&P)"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "&Quit"
 msgstr "結束(&Q)"
 
-#: ../src/common/cmdproc.cpp:289 ../src/common/cmdproc.cpp:296
-#: ../src/common/stockitem.cpp:185 ../src/msw/textctrl.cpp:2720
-#: ../src/osx/textctrl_osx.cpp:582 ../src/richtext/richtextctrl.cpp:332
+#: ../src/osx/textctrl_osx.cpp:592 ../src/common/stockitem.cpp:182
+#: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
+#: ../src/msw/textctrl.cpp:2770 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "重做(&R)"
 
-#: ../src/common/cmdproc.cpp:285 ../src/common/cmdproc.cpp:305
+#: ../src/common/cmdproc.cpp:282 ../src/common/cmdproc.cpp:302
 msgid "&Redo "
 msgstr "重做(&R)"
 
-#: ../src/richtext/richtextstyledlg.cpp:257
+#: ../src/richtext/richtextstyledlg.cpp:253
 msgid "&Rename Style..."
 msgstr "重新命名樣式(&R)…"
 
-#: ../src/generic/fdrepdlg.cpp:179
+#: ../src/generic/fdrepdlg.cpp:176
 msgid "&Replace"
 msgstr "取代(&R)"
 
-#: ../src/richtext/richtextstyledlg.cpp:287
+#: ../src/richtext/richtextstyledlg.cpp:283
 msgid "&Restart numbering"
 msgstr "重新編號(&R)"
 
-#: ../src/univ/themes/win32.cpp:3747
+#: ../src/univ/themes/win32.cpp:3744
 msgid "&Restore"
 msgstr "回存(&R)"
 
-#: ../src/richtext/richtextindentspage.cpp:146
 #: ../src/richtext/richtextliststylepage.cpp:335
+#: ../src/richtext/richtextindentspage.cpp:146
 msgid "&Right"
 msgstr "右側(&R)"
 
-#: ../src/richtext/richtextborderspage.cpp:277
-#: ../src/richtext/richtextborderspage.cpp:445
-#: ../src/richtext/richtextindentspage.cpp:213
-#: ../src/richtext/richtextliststylepage.cpp:399
-#: ../src/richtext/richtextmarginspage.cpp:211
-#: ../src/richtext/richtextmarginspage.cpp:325
 #: ../src/richtext/richtextsizepage.cpp:602
 #: ../src/richtext/richtextsizepage.cpp:609
+#: ../src/richtext/richtextborderspage.cpp:277
+#: ../src/richtext/richtextborderspage.cpp:445
+#: ../src/richtext/richtextliststylepage.cpp:399
+#: ../src/richtext/richtextindentspage.cpp:213
+#: ../src/richtext/richtextmarginspage.cpp:211
+#: ../src/richtext/richtextmarginspage.cpp:325
 msgid "&Right:"
 msgstr "右側(&R)："
 
-#: ../src/common/stockitem.cpp:190
+#: ../src/common/stockitem.cpp:187
 msgid "&Save"
 msgstr "儲存(&S)"
 
@@ -679,11 +675,11 @@ msgstr "儲存(&S)"
 msgid "&See details"
 msgstr "看細節(&S)"
 
-#: ../src/generic/tipdlg.cpp:236
+#: ../src/generic/tipdlg.cpp:233
 msgid "&Show tips at startup"
 msgstr "啟動時顯示小祕訣(&S)"
 
-#: ../src/univ/themes/win32.cpp:3750
+#: ../src/univ/themes/win32.cpp:3747
 msgid "&Size"
 msgstr "大小(&S)"
 
@@ -691,41 +687,41 @@ msgstr "大小(&S)"
 msgid "&Size:"
 msgstr "大小(&S)："
 
-#: ../src/generic/progdlgg.cpp:252
+#: ../src/generic/progdlgg.cpp:249
 msgid "&Skip"
 msgstr "略過(&S)"
 
-#: ../src/richtext/richtextindentspage.cpp:242
 #: ../src/richtext/richtextliststylepage.cpp:417
+#: ../src/richtext/richtextindentspage.cpp:242
 msgid "&Spacing (tenths of a mm)"
 msgstr "間距(&S) (十分之一公釐[mm])"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "&Spell Check"
 msgstr "拼字檢查(&S)"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "&Stop"
 msgstr "停止(&S)"
 
-#: ../src/common/stockitem.cpp:199 ../src/richtext/richtextfontpage.cpp:275
+#: ../src/common/stockitem.cpp:196 ../src/richtext/richtextfontpage.cpp:275
 msgid "&Strikethrough"
 msgstr "刪除線(&S)"
 
-#: ../src/generic/fontdlgg.cpp:382 ../src/richtext/richtextstylepage.cpp:106
+#: ../src/generic/fontdlgg.cpp:378 ../src/richtext/richtextstylepage.cpp:106
 msgid "&Style:"
 msgstr "樣式(&S)："
 
-#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:194
 msgid "&Styles:"
 msgstr "樣式(&S)："
 
-#: ../src/richtext/richtextsymboldlg.cpp:413
+#: ../src/richtext/richtextsymboldlg.cpp:410
 msgid "&Subset:"
 msgstr "子集合(&S):"
 
-#: ../src/richtext/richtextbulletspage.cpp:209
 #: ../src/richtext/richtextliststylepage.cpp:268
+#: ../src/richtext/richtextbulletspage.cpp:209
 msgid "&Symbol:"
 msgstr "符號(&S)："
 
@@ -738,20 +734,20 @@ msgstr "將值同步化(&S)"
 msgid "&Table"
 msgstr "表格(&T)"
 
-#: ../src/common/stockitem.cpp:200
+#: ../src/common/stockitem.cpp:197
 msgid "&Top"
 msgstr "頂端(&T)"
 
+#: ../src/richtext/richtextsizepage.cpp:567
+#: ../src/richtext/richtextsizepage.cpp:574
 #: ../src/richtext/richtextborderspage.cpp:311
 #: ../src/richtext/richtextborderspage.cpp:479
 #: ../src/richtext/richtextmarginspage.cpp:234
 #: ../src/richtext/richtextmarginspage.cpp:348
-#: ../src/richtext/richtextsizepage.cpp:567
-#: ../src/richtext/richtextsizepage.cpp:574
 msgid "&Top:"
 msgstr "頂端(&T):"
 
-#: ../src/common/stockitem.cpp:202 ../src/generic/fontdlgg.cpp:445
+#: ../src/common/stockitem.cpp:199 ../src/generic/fontdlgg.cpp:441
 msgid "&Underline"
 msgstr "底線(&U)"
 
@@ -759,21 +755,21 @@ msgstr "底線(&U)"
 msgid "&Underlining:"
 msgstr "加底線(&U)："
 
-#: ../src/common/cmdproc.cpp:267 ../src/common/stockitem.cpp:203
-#: ../src/msw/textctrl.cpp:2719 ../src/osx/textctrl_osx.cpp:581
-#: ../src/richtext/richtextctrl.cpp:331
+#: ../src/osx/textctrl_osx.cpp:591 ../src/common/stockitem.cpp:200
+#: ../src/common/cmdproc.cpp:264 ../src/msw/textctrl.cpp:2769
+#: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "回復(&U)"
 
-#: ../src/common/cmdproc.cpp:261
+#: ../src/common/cmdproc.cpp:258
 msgid "&Undo "
 msgstr "回復(&U)"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "&Unindent"
 msgstr "取消縮排(&U)"
 
-#: ../src/common/stockitem.cpp:205
+#: ../src/common/stockitem.cpp:202
 msgid "&Up"
 msgstr "向上(&U)"
 
@@ -785,11 +781,11 @@ msgstr "垂直對齊(&V)："
 msgid "&Vertical offset:"
 msgstr "垂直偏移值(&V)："
 
-#: ../src/generic/dbgrptg.cpp:343
+#: ../src/generic/dbgrptg.cpp:340
 msgid "&View..."
 msgstr "檢視(&V)…"
 
-#: ../src/generic/fontdlgg.cpp:393
+#: ../src/generic/fontdlgg.cpp:389
 msgid "&Weight:"
 msgstr "粗細(&W)："
 
@@ -798,399 +794,403 @@ msgstr "粗細(&W)："
 msgid "&Width:"
 msgstr "寬度(&W)："
 
-#: ../src/aui/tabmdi.cpp:311 ../src/aui/tabmdi.cpp:327
-#: ../src/aui/tabmdi.cpp:329 ../src/generic/mdig.cpp:294
-#: ../src/generic/mdig.cpp:310 ../src/generic/mdig.cpp:314
-#: ../src/msw/mdi.cpp:336
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
 msgid "&Window"
 msgstr "視窗(&W)"
 
-#: ../src/common/stockitem.cpp:206 ../src/msw/msgdlg.cpp:438
+#: ../src/common/stockitem.cpp:203 ../src/msw/msgdlg.cpp:435
 msgid "&Yes"
 msgstr "是(&Y)"
 
-#: ../src/common/valtext.cpp:200
+#: ../src/common/valtext.cpp:197
 #, c-format
-#| msgid "'%s' contains illegal characters"
 msgid "'%s' contains invalid character(s)"
 msgstr "「%s」含有無效字元"
 
-#: ../src/common/config.cpp:519 ../src/msw/regconf.cpp:258
+#: ../src/common/config.cpp:515 ../src/msw/regconf.cpp:255
 #, c-format
 msgid "'%s' has extra '..', ignored."
 msgstr "「%s」有額外的 '..'，已忽略。"
 
-#: ../src/common/cmdline.cpp:1112 ../src/common/cmdline.cpp:1130
+#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "「%s」不是選項 '%s' 的正確數值。"
 
-#: ../src/common/translation.cpp:1144
+#: ../src/common/translation.cpp:1142
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "「%s」不是有效的訊息登錄檔。"
 
-#: ../src/common/valtext.cpp:191
+#: ../src/common/valtext.cpp:188
 #, c-format
 msgid "'%s' is not one of the valid strings"
 msgstr "「%s」不是有效字串之一"
 
-#: ../src/common/valtext.cpp:189
+#: ../src/common/valtext.cpp:186
 #, c-format
 msgid "'%s' is one of the invalid strings"
 msgstr "「%s」是無效字串之一"
 
-#: ../src/common/textbuf.cpp:237
+#: ../src/common/textbuf.cpp:233
 #, c-format
 msgid "'%s' is probably a binary buffer."
 msgstr "「%s」或許是個二進位緩衝區。"
 
-#: ../src/richtext/richtextbulletspage.cpp:166
 #: ../src/richtext/richtextliststylepage.cpp:229
+#: ../src/richtext/richtextbulletspage.cpp:166
 msgid "(*)"
 msgstr "(*)"
 
-#: ../src/html/helpwnd.cpp:964
+#: ../src/html/helpwnd.cpp:961
 msgid "(Help)"
 msgstr "(說明)"
 
-#: ../src/richtext/richtextbulletspage.cpp:273
 #: ../src/richtext/richtextliststylepage.cpp:481
+#: ../src/richtext/richtextbulletspage.cpp:273
 msgid "(None)"
 msgstr "(無)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:504
+#: ../src/richtext/richtextsymboldlg.cpp:503
 msgid "(Normal text)"
 msgstr "(正常文字)"
 
-#: ../src/html/helpwnd.cpp:420 ../src/html/helpwnd.cpp:1107
-#: ../src/html/helpwnd.cpp:1743
+#: ../src/html/helpwnd.cpp:417 ../src/html/helpwnd.cpp:1104
+#: ../src/html/helpwnd.cpp:1740
 msgid "(bookmarks)"
 msgstr "(書籤)"
 
-#: ../src/richtext/richtextfontpage.cpp:349
-#: ../src/richtext/richtextfontpage.cpp:353
-#: ../src/richtext/richtextfontpage.cpp:357
-#: ../src/richtext/richtextformatdlg.cpp:879
+#: ../src/msw/dlmsw.cpp:167
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (錯誤 %ld: %s)"
+
+#: ../src/richtext/richtextformatdlg.cpp:876
+#: ../src/richtext/richtextliststylepage.cpp:448
+#: ../src/richtext/richtextliststylepage.cpp:460
+#: ../src/richtext/richtextliststylepage.cpp:461
 #: ../src/richtext/richtextindentspage.cpp:274
 #: ../src/richtext/richtextindentspage.cpp:286
 #: ../src/richtext/richtextindentspage.cpp:287
 #: ../src/richtext/richtextindentspage.cpp:311
 #: ../src/richtext/richtextindentspage.cpp:326
-#: ../src/richtext/richtextliststylepage.cpp:448
-#: ../src/richtext/richtextliststylepage.cpp:460
-#: ../src/richtext/richtextliststylepage.cpp:461
+#: ../src/richtext/richtextfontpage.cpp:349
+#: ../src/richtext/richtextfontpage.cpp:353
+#: ../src/richtext/richtextfontpage.cpp:357
 msgid "(none)"
 msgstr "(無)"
 
-#: ../src/richtext/richtextbulletspage.cpp:284
 #: ../src/richtext/richtextliststylepage.cpp:492
+#: ../src/richtext/richtextbulletspage.cpp:284
 msgid "*"
 msgstr "*"
 
-#: ../src/richtext/richtextbulletspage.cpp:173
 #: ../src/richtext/richtextliststylepage.cpp:236
+#: ../src/richtext/richtextbulletspage.cpp:173
 msgid "*)"
 msgstr "*)"
 
-#: ../src/richtext/richtextbulletspage.cpp:287
 #: ../src/richtext/richtextliststylepage.cpp:495
+#: ../src/richtext/richtextbulletspage.cpp:287
 msgid "+"
 msgstr "+"
 
-#: ../src/msw/utils.cpp:1153
+#: ../src/msw/utils.cpp:1143
 msgid ", 64-bit edition"
 msgstr "，64 位元版"
 
-#: ../src/richtext/richtextbulletspage.cpp:285
 #: ../src/richtext/richtextliststylepage.cpp:493
+#: ../src/richtext/richtextbulletspage.cpp:285
 msgid "-"
 msgstr "-"
 
-#: ../src/generic/filepickerg.cpp:66
+#: ../src/generic/filepickerg.cpp:63
 msgid "..."
 msgstr "..."
 
-#: ../src/richtext/richtextindentspage.cpp:276
 #: ../src/richtext/richtextliststylepage.cpp:450
+#: ../src/richtext/richtextindentspage.cpp:276
 msgid "1.1"
 msgstr "1.1"
 
-#: ../src/richtext/richtextindentspage.cpp:277
 #: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextindentspage.cpp:277
 msgid "1.2"
 msgstr "1.2"
 
-#: ../src/richtext/richtextindentspage.cpp:278
 #: ../src/richtext/richtextliststylepage.cpp:452
+#: ../src/richtext/richtextindentspage.cpp:278
 msgid "1.3"
 msgstr "1.3"
 
-#: ../src/richtext/richtextindentspage.cpp:279
 #: ../src/richtext/richtextliststylepage.cpp:453
+#: ../src/richtext/richtextindentspage.cpp:279
 msgid "1.4"
 msgstr "1.4"
 
-#: ../src/richtext/richtextindentspage.cpp:280
 #: ../src/richtext/richtextliststylepage.cpp:454
+#: ../src/richtext/richtextindentspage.cpp:280
 msgid "1.5"
 msgstr "1.5"
 
-#: ../src/richtext/richtextindentspage.cpp:281
 #: ../src/richtext/richtextliststylepage.cpp:455
+#: ../src/richtext/richtextindentspage.cpp:281
 msgid "1.6"
 msgstr "1.6"
 
-#: ../src/richtext/richtextindentspage.cpp:282
 #: ../src/richtext/richtextliststylepage.cpp:456
+#: ../src/richtext/richtextindentspage.cpp:282
 msgid "1.7"
 msgstr "1.7"
 
-#: ../src/richtext/richtextindentspage.cpp:283
 #: ../src/richtext/richtextliststylepage.cpp:457
+#: ../src/richtext/richtextindentspage.cpp:283
 msgid "1.8"
 msgstr "1.8"
 
-#: ../src/richtext/richtextindentspage.cpp:284
 #: ../src/richtext/richtextliststylepage.cpp:458
+#: ../src/richtext/richtextindentspage.cpp:284
 msgid "1.9"
 msgstr "1.9"
 
-#: ../src/common/paper.cpp:140
+#: ../src/common/paper.cpp:137
 msgid "10 x 11 in"
 msgstr "10 x 11 英吋"
 
-#: ../src/common/paper.cpp:113
+#: ../src/common/paper.cpp:110
 msgid "10 x 14 in"
 msgstr "10 x 14 英吋"
 
-#: ../src/common/paper.cpp:114
+#: ../src/common/paper.cpp:111
 msgid "11 x 17 in"
 msgstr "11 x 17 英吋"
 
-#: ../src/common/paper.cpp:184
+#: ../src/common/paper.cpp:181
 msgid "12 x 11 in"
 msgstr "12 x 11 英吋"
 
-#: ../src/common/paper.cpp:141
+#: ../src/common/paper.cpp:138
 msgid "15 x 11 in"
 msgstr "15 x 11 英吋"
 
-#: ../src/richtext/richtextindentspage.cpp:285
 #: ../src/richtext/richtextliststylepage.cpp:459
+#: ../src/richtext/richtextindentspage.cpp:285
 msgid "2"
 msgstr "2"
 
-#: ../src/common/paper.cpp:132
+#: ../src/common/paper.cpp:129
 msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
 msgstr "6 3/4 信封，3 5/8 x 6 1/2 英吋"
 
-#: ../src/common/paper.cpp:139
+#: ../src/common/paper.cpp:136
 msgid "9 x 11 in"
 msgstr "9 x 11 英吋"
 
-#: ../src/html/htmprint.cpp:446
+#: ../src/html/htmprint.cpp:443
 msgid ": file does not exist!"
 msgstr ": 檔案不存在！"
 
-#: ../src/common/fontmap.cpp:199
+#: ../src/common/fontmap.cpp:196
 msgid ": unknown charset"
 msgstr ": 不明的字集"
 
-#: ../src/common/fontmap.cpp:413
+#: ../src/common/fontmap.cpp:410
 msgid ": unknown encoding"
 msgstr ": 不明的編碼"
 
-#: ../src/generic/wizard.cpp:441
+#: ../src/generic/wizard.cpp:438
 msgid "< &Back"
 msgstr "《 返回(&B)"
 
-#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:628
-#: ../src/osx/carbon/fontdlg.cpp:648
+#: ../src/osx/carbon/fontdlg.cpp:419 ../src/osx/carbon/fontdlg.cpp:625
+#: ../src/osx/carbon/fontdlg.cpp:645
 msgid "<Any Decorative>"
 msgstr "<任何修飾字體>"
 
-#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:630
-#: ../src/osx/carbon/fontdlg.cpp:650
+#: ../src/osx/carbon/fontdlg.cpp:420 ../src/osx/carbon/fontdlg.cpp:627
+#: ../src/osx/carbon/fontdlg.cpp:647
 msgid "<Any Modern>"
 msgstr "<任何現代字體>"
 
-#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:626
-#: ../src/osx/carbon/fontdlg.cpp:646
+#: ../src/osx/carbon/fontdlg.cpp:418 ../src/osx/carbon/fontdlg.cpp:623
+#: ../src/osx/carbon/fontdlg.cpp:643
 msgid "<Any Roman>"
 msgstr "<任何羅馬字體>"
 
-#: ../src/osx/carbon/fontdlg.cpp:424 ../src/osx/carbon/fontdlg.cpp:632
-#: ../src/osx/carbon/fontdlg.cpp:652
+#: ../src/osx/carbon/fontdlg.cpp:421 ../src/osx/carbon/fontdlg.cpp:629
+#: ../src/osx/carbon/fontdlg.cpp:649
 msgid "<Any Script>"
 msgstr "<任何手寫字體>"
 
-#: ../src/osx/carbon/fontdlg.cpp:425 ../src/osx/carbon/fontdlg.cpp:637
-#: ../src/osx/carbon/fontdlg.cpp:656
+#: ../src/osx/carbon/fontdlg.cpp:422 ../src/osx/carbon/fontdlg.cpp:634
+#: ../src/osx/carbon/fontdlg.cpp:653
 msgid "<Any Swiss>"
 msgstr "<任何瑞士字體>"
 
-#: ../src/osx/carbon/fontdlg.cpp:426 ../src/osx/carbon/fontdlg.cpp:634
-#: ../src/osx/carbon/fontdlg.cpp:654
+#: ../src/osx/carbon/fontdlg.cpp:423 ../src/osx/carbon/fontdlg.cpp:631
+#: ../src/osx/carbon/fontdlg.cpp:651
 msgid "<Any Teletype>"
 msgstr "<任何打字字體>"
 
-#: ../src/osx/carbon/fontdlg.cpp:420
+#: ../src/osx/carbon/fontdlg.cpp:417
 msgid "<Any>"
 msgstr "<任何字體>"
 
-#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
 msgid "<DIR>"
 msgstr "<目錄>"
 
-#: ../src/generic/filectrlg.cpp:254 ../src/generic/filectrlg.cpp:277
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
 msgid "<DRIVE>"
 msgstr "<磁碟機>"
 
-#: ../src/generic/filectrlg.cpp:252 ../src/generic/filectrlg.cpp:275
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
 msgid "<LINK>"
 msgstr "<連結>"
 
-#: ../src/html/helpwnd.cpp:1267
+#: ../src/html/helpwnd.cpp:1264
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>粗斜體</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1271
+#: ../src/html/helpwnd.cpp:1268
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>粗斜<u>加底線</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1263
 msgid "<b>Bold face.</b> "
 msgstr "<b>粗體</b> "
 
-#: ../src/html/helpwnd.cpp:1265
+#: ../src/html/helpwnd.cpp:1262
 msgid "<i>Italic face.</i> "
 msgstr "<i>斜體</i> "
 
-#: ../src/richtext/richtextbulletspage.cpp:286
 #: ../src/richtext/richtextliststylepage.cpp:494
+#: ../src/richtext/richtextbulletspage.cpp:286
 msgid ">"
 msgstr ">"
 
-#: ../src/generic/dbgrptg.cpp:320
+#: ../src/generic/dbgrptg.cpp:317
 msgid "A debug report has been generated in the directory\n"
 msgstr "產生了一份除錯報告, 位於目錄\n"
 
-#: ../src/common/debugrpt.cpp:577
+#: ../src/common/debugrpt.cpp:574
 msgid "A debug report has been generated. It can be found in"
 msgstr "產生了一份除錯報告, 位於目錄"
 
-#: ../src/common/xtixml.cpp:418
+#: ../src/common/xtixml.cpp:414
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "非空集合必須包含 'element' 節點"
 
-#: ../src/richtext/richtextbulletspage.cpp:244
-#: ../src/richtext/richtextbulletspage.cpp:246
 #: ../src/richtext/richtextliststylepage.cpp:304
 #: ../src/richtext/richtextliststylepage.cpp:306
+#: ../src/richtext/richtextbulletspage.cpp:244
+#: ../src/richtext/richtextbulletspage.cpp:246
 msgid "A standard bullet name."
 msgstr "標準的項目符號名稱。"
 
-#: ../src/common/paper.cpp:217
+#: ../src/common/paper.cpp:214
 msgid "A0 sheet, 841 x 1189 mm"
 msgstr "A0 印刷紙，841 x 1189 公釐"
 
-#: ../src/common/paper.cpp:218
+#: ../src/common/paper.cpp:215
 msgid "A1 sheet, 594 x 841 mm"
 msgstr "A1 印刷紙，594 x 841 公釐"
 
-#: ../src/common/paper.cpp:159
+#: ../src/common/paper.cpp:156
 msgid "A2 420 x 594 mm"
 msgstr "A2 420 x 594 公釐"
 
-#: ../src/common/paper.cpp:156
+#: ../src/common/paper.cpp:153
 msgid "A3 Extra 322 x 445 mm"
 msgstr "A3 加長 322 x 445 公釐"
 
-#: ../src/common/paper.cpp:161
+#: ../src/common/paper.cpp:158
 msgid "A3 Extra Transverse 322 x 445 mm"
 msgstr "A3 加長橫向 322 x 445 公釐"
 
-#: ../src/common/paper.cpp:170
+#: ../src/common/paper.cpp:167
 msgid "A3 Rotated 420 x 297 mm"
 msgstr "A3 轉向 420 x 297 公釐"
 
-#: ../src/common/paper.cpp:160
+#: ../src/common/paper.cpp:157
 msgid "A3 Transverse 297 x 420 mm"
 msgstr "A3 轉向 297 x 420 公釐"
 
-#: ../src/common/paper.cpp:106
+#: ../src/common/paper.cpp:103
 msgid "A3 sheet, 297 x 420 mm"
 msgstr "A3 印刷紙，297 x 420 公釐"
 
-#: ../src/common/paper.cpp:146
+#: ../src/common/paper.cpp:143
 msgid "A4 Extra 9.27 x 12.69 in"
 msgstr "A4 加長 9.27 x 12.69 英吋"
 
-#: ../src/common/paper.cpp:153
+#: ../src/common/paper.cpp:150
 msgid "A4 Plus 210 x 330 mm"
 msgstr "A4 增大 210 x 330 公釐"
 
-#: ../src/common/paper.cpp:171
+#: ../src/common/paper.cpp:168
 msgid "A4 Rotated 297 x 210 mm"
 msgstr "A3 轉向 297 x 210 公釐"
 
-#: ../src/common/paper.cpp:148
+#: ../src/common/paper.cpp:145
 msgid "A4 Transverse 210 x 297 mm"
 msgstr "A4 橫向 210 x 297 公釐"
 
-#: ../src/common/paper.cpp:97
+#: ../src/common/paper.cpp:94
 msgid "A4 sheet, 210 x 297 mm"
 msgstr "A4 印刷紙，210 x 297 公釐"
 
-#: ../src/common/paper.cpp:107
+#: ../src/common/paper.cpp:104
 msgid "A4 small sheet, 210 x 297 mm"
 msgstr "A4 印刷小紙張，210 x 297 公釐"
 
-#: ../src/common/paper.cpp:157
+#: ../src/common/paper.cpp:154
 msgid "A5 Extra 174 x 235 mm"
 msgstr "A5 加長 174 x 235 公釐"
 
-#: ../src/common/paper.cpp:172
+#: ../src/common/paper.cpp:169
 msgid "A5 Rotated 210 x 148 mm"
 msgstr "A5 轉向 210 x 148 公釐"
 
-#: ../src/common/paper.cpp:154
+#: ../src/common/paper.cpp:151
 msgid "A5 Transverse 148 x 210 mm"
 msgstr "A5 橫向 148 x 210 公釐"
 
-#: ../src/common/paper.cpp:108
+#: ../src/common/paper.cpp:105
 msgid "A5 sheet, 148 x 210 mm"
 msgstr "A5 印刷紙，148 x 210 公釐"
 
-#: ../src/common/paper.cpp:164
+#: ../src/common/paper.cpp:161
 msgid "A6 105 x 148 mm"
 msgstr "A6 105 x 148 公釐"
 
-#: ../src/common/paper.cpp:177
+#: ../src/common/paper.cpp:174
 msgid "A6 Rotated 148 x 105 mm"
 msgstr "A6 轉向 148 x 105 公釐"
 
-#: ../src/generic/fontdlgg.cpp:83 ../src/osx/carbon/fontdlg.cpp:153
-#: ../src/richtext/richtextformatdlg.cpp:524
+#: ../src/osx/carbon/fontdlg.cpp:150 ../src/generic/fontdlgg.cpp:79
+#: ../src/richtext/richtextformatdlg.cpp:521
 msgid "ABCDEFGabcdefg12345"
 msgstr "ABCDEFGabcdefg12345"
 
-#: ../src/common/ftp.cpp:403 ../src/richtext/richtextsymboldlg.cpp:458
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
 msgid "ASCII"
 msgstr "ASCII"
 
-#: ../src/common/stockitem.cpp:139
+#: ../src/common/stockitem.cpp:136
 msgid "About"
 msgstr "關於"
 
-#: ../src/generic/aboutdlgg.cpp:140 ../src/msw/aboutdlg.cpp:64
-#: ../src/osx/menu_osx.cpp:447
+#: ../src/osx/menu_osx.cpp:450 ../src/generic/aboutdlgg.cpp:137
+#: ../src/msw/aboutdlg.cpp:61
 #, c-format
 msgid "About %s"
 msgstr "關於 %s"
 
-#: ../src/osx/menu_osx.cpp:449
+#: ../src/osx/menu_osx.cpp:452
 msgid "About..."
 msgstr "關於..."
 
@@ -1199,37 +1199,37 @@ msgid "Absolute"
 msgstr "絕對"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:777
+#: ../src/propgrid/advprops.cpp:774
 msgid "ActiveBorder"
 msgstr "有效邊框"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:778
+#: ../src/propgrid/advprops.cpp:775
 msgid "ActiveCaption"
 msgstr "有效標題"
 
-#: ../src/common/stockitem.cpp:207
+#: ../src/common/stockitem.cpp:204
 msgid "Actual Size"
 msgstr "實際大小`"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:81 ../src/common/stockitem.cpp:140
+#: ../src/common/stockitem.cpp:137 ../src/common/accelcmn.cpp:78
 msgid "Add"
 msgstr "加入"
 
-#: ../src/richtext/richtextbuffer.cpp:11457
+#: ../src/richtext/richtextbuffer.cpp:11454
 msgid "Add Column"
 msgstr "加入欄位"
 
-#: ../src/richtext/richtextbuffer.cpp:11394
+#: ../src/richtext/richtextbuffer.cpp:11391
 msgid "Add Row"
 msgstr "加入橫列"
 
-#: ../src/html/helpwnd.cpp:433
+#: ../src/html/helpwnd.cpp:430
 msgid "Add current page to bookmarks"
 msgstr "把目前頁面加到書籤"
 
-#: ../src/generic/colrdlgg.cpp:366
+#: ../src/generic/colrdlgg.cpp:386
 msgid "Add to custom colours"
 msgstr "加到自訂顏色"
 
@@ -1241,12 +1241,12 @@ msgstr "在一個通用處理器上呼叫AddToPropertyCollection"
 msgid "AddToPropertyCollection called w/o valid adder"
 msgstr "呼叫AddToPropertyCollection時未帶有效的adder"
 
-#: ../src/html/helpctrl.cpp:159
+#: ../src/html/helpctrl.cpp:155
 #, c-format
 msgid "Adding book %s"
 msgstr "正在加入卷輯 %s"
 
-#: ../src/common/preferencescmn.cpp:43
+#: ../src/common/preferencescmn.cpp:40
 msgid "Advanced"
 msgstr "進階"
 
@@ -1254,11 +1254,11 @@ msgstr "進階"
 msgid "After a paragraph:"
 msgstr "段落之後："
 
-#: ../src/common/stockitem.cpp:172
+#: ../src/common/stockitem.cpp:169
 msgid "Align Left"
 msgstr "靠左對齊"
 
-#: ../src/common/stockitem.cpp:173
+#: ../src/common/stockitem.cpp:170
 msgid "Align Right"
 msgstr "靠右對齊"
 
@@ -1266,32 +1266,32 @@ msgstr "靠右對齊"
 msgid "Alignment"
 msgstr "對齊"
 
-#: ../src/generic/prntdlgg.cpp:211
+#: ../src/generic/prntdlgg.cpp:208
 msgid "All"
 msgstr "所有"
 
-#: ../src/common/fldlgcmn.cpp:107 ../src/generic/filectrlg.cpp:1197
+#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1186
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "所有檔案 (%s)|%s"
 
-#: ../include/wx/defs.h:2546
+#: ../include/wx/defs.h:2582
 msgid "All files (*)|*"
 msgstr "所有檔案 (*)|*"
 
-#: ../include/wx/defs.h:2543
+#: ../include/wx/defs.h:2579
 msgid "All files (*.*)|*.*"
 msgstr "所有檔案 (*.*)|*.*"
 
-#: ../src/richtext/richtextstyles.cpp:1061
+#: ../src/richtext/richtextstyles.cpp:1058
 msgid "All styles"
 msgstr "所有樣式"
 
-#: ../src/propgrid/manager.cpp:1545
+#: ../src/propgrid/manager.cpp:1544
 msgid "Alphabetic Mode"
 msgstr "字母順序模式"
 
-#: ../src/common/xtistrm.cpp:425
+#: ../src/common/xtistrm.cpp:422
 msgid "Already Registered Object passed to SetObjectClassInfo"
 msgstr "傳入已註冊的物件給 SetObjectClassInfo"
 
@@ -1299,7 +1299,7 @@ msgstr "傳入已註冊的物件給 SetObjectClassInfo"
 msgid "Already dialling ISP."
 msgstr "已經撥接 ISP。"
 
-#: ../src/common/accelcmn.cpp:348 ../src/univ/themes/win32.cpp:3756
+#: ../src/common/accelcmn.cpp:345 ../src/univ/themes/win32.cpp:3753
 msgid "Alt+"
 msgstr "Alt+"
 
@@ -1308,158 +1308,158 @@ msgstr "Alt+"
 msgid "An optional corner radius for adding rounded corners."
 msgstr "加入圓角時的半徑 （可有可無）"
 
-#: ../src/common/debugrpt.cpp:580
+#: ../src/common/debugrpt.cpp:577
 msgid "And includes the following files:\n"
 msgstr "且包含以下檔案：\n"
 
-#: ../src/generic/animateg.cpp:162
+#: ../src/generic/animateg.cpp:145
 #, c-format
 msgid "Animation file is not of type %ld."
 msgstr "動畫檔不是 %ld 的型態。"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:776
+#: ../src/propgrid/advprops.cpp:773
 msgid "AppWorkspace"
 msgstr "AppWorkspace"
 
-#: ../src/generic/logg.cpp:1014
+#: ../src/generic/logg.cpp:1011
 #, c-format
 msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
 msgstr "是否把日誌加到檔案「%s」的尾端 (選擇 [否] 將覆寫該檔案)？"
 
-#: ../src/osx/menu_osx.cpp:466 ../src/osx/menu_osx.cpp:474
+#: ../src/osx/menu_osx.cpp:469 ../src/osx/menu_osx.cpp:477
 msgid "Application"
 msgstr "應用程式"
 
-#: ../src/common/stockitem.cpp:141
+#: ../src/common/stockitem.cpp:138
 msgid "Apply"
 msgstr "套用"
 
-#: ../src/propgrid/advprops.cpp:1518
+#: ../src/propgrid/advprops.cpp:1515
 msgid "Aqua"
 msgstr "Aqua"
 
-#: ../src/richtext/richtextbulletspage.cpp:274
 #: ../src/richtext/richtextliststylepage.cpp:482
+#: ../src/richtext/richtextbulletspage.cpp:274
 msgid "Arabic"
 msgstr "阿拉伯語"
 
-#: ../src/common/fmapbase.cpp:153
+#: ../src/common/fmapbase.cpp:150
 msgid "Arabic (ISO-8859-6)"
 msgstr "阿拉伯語 (ISO-8859-6)"
 
-#: ../src/msw/ole/automtn.cpp:672
+#: ../src/msw/ole/automtn.cpp:663
 #, c-format
 msgid "Argument %u not found."
 msgstr "找不到引數 '%u'。"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1657
+#: ../src/propgrid/advprops.cpp:1654
 msgid "Arrow"
 msgstr "箭頭"
 
-#: ../src/generic/aboutdlgg.cpp:184
+#: ../src/generic/aboutdlgg.cpp:181
 msgid "Artists"
 msgstr "美術設計者"
 
-#: ../src/common/stockitem.cpp:195
+#: ../src/common/stockitem.cpp:192
 msgid "Ascending"
 msgstr "遞增"
 
-#: ../src/generic/filectrlg.cpp:433
+#: ../src/generic/filectrlg.cpp:429
 msgid "Attributes"
 msgstr "屬性"
 
+#: ../src/richtext/richtextliststylepage.cpp:294
 #: ../src/richtext/richtextbulletspage.cpp:232
 #: ../src/richtext/richtextbulletspage.cpp:234
-#: ../src/richtext/richtextliststylepage.cpp:294
 msgid "Available fonts."
 msgstr "可用的字型。"
 
-#: ../src/common/paper.cpp:137
+#: ../src/common/paper.cpp:134
 msgid "B4 (ISO) 250 x 353 mm"
 msgstr "B4 (ISO) 250 x 353 公釐"
 
-#: ../src/common/paper.cpp:173
+#: ../src/common/paper.cpp:170
 msgid "B4 (JIS) Rotated 364 x 257 mm"
 msgstr "B4 (JIS) 轉向 364 x 257 公釐"
 
-#: ../src/common/paper.cpp:127
+#: ../src/common/paper.cpp:124
 msgid "B4 Envelope, 250 x 353 mm"
 msgstr "B4 信封，250 x 353 公釐"
 
-#: ../src/common/paper.cpp:109
+#: ../src/common/paper.cpp:106
 msgid "B4 sheet, 250 x 354 mm"
 msgstr "B4 印刷紙，250 x 354 公釐"
 
-#: ../src/common/paper.cpp:158
+#: ../src/common/paper.cpp:155
 msgid "B5 (ISO) Extra 201 x 276 mm"
 msgstr "B5 (ISO) 加長 201 x 276 公釐"
 
-#: ../src/common/paper.cpp:174
+#: ../src/common/paper.cpp:171
 msgid "B5 (JIS) Rotated 257 x 182 mm"
 msgstr "B5 (JIS) 轉向 257 x 182 公釐"
 
-#: ../src/common/paper.cpp:155
+#: ../src/common/paper.cpp:152
 msgid "B5 (JIS) Transverse 182 x 257 mm"
 msgstr "B5 (JIS) 橫向 182 x 257 公釐"
 
-#: ../src/common/paper.cpp:128
+#: ../src/common/paper.cpp:125
 msgid "B5 Envelope, 176 x 250 mm"
 msgstr "B5 信封，176 x 250 公釐"
 
-#: ../src/common/paper.cpp:110
+#: ../src/common/paper.cpp:107
 msgid "B5 sheet, 182 x 257 millimeter"
 msgstr "B5 印刷紙，182 x 257 公釐"
 
-#: ../src/common/paper.cpp:182
+#: ../src/common/paper.cpp:179
 msgid "B6 (JIS) 128 x 182 mm"
 msgstr "B6 (JIS) 128 x 182 公釐"
 
-#: ../src/common/paper.cpp:183
+#: ../src/common/paper.cpp:180
 msgid "B6 (JIS) Rotated 182 x 128 mm"
 msgstr "B6 (JIS) 轉向 182 x 128 公釐"
 
-#: ../src/common/paper.cpp:129
+#: ../src/common/paper.cpp:126
 msgid "B6 Envelope, 176 x 125 mm"
 msgstr "B6 信封，176 x 125 公釐"
 
-#: ../src/common/imagbmp.cpp:531 ../src/common/imagbmp.cpp:561
-#: ../src/common/imagbmp.cpp:576
+#: ../src/common/imagbmp.cpp:528 ../src/common/imagbmp.cpp:558
+#: ../src/common/imagbmp.cpp:573
 msgid "BMP: Couldn't allocate memory."
 msgstr "BMP: 無法配置記憶體。"
 
-#: ../src/common/imagbmp.cpp:100
+#: ../src/common/imagbmp.cpp:97
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: 無法儲存無效的圖像。"
 
-#: ../src/common/imagbmp.cpp:356
+#: ../src/common/imagbmp.cpp:353
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: 無法寫入 RGB 顏色對應表。"
 
-#: ../src/common/imagbmp.cpp:490
+#: ../src/common/imagbmp.cpp:487
 msgid "BMP: Couldn't write data."
 msgstr "BMP: 無法寫入資料。"
 
-#: ../src/common/imagbmp.cpp:246
+#: ../src/common/imagbmp.cpp:243
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: 無法寫入檔案標頭(Bitmap)。"
 
-#: ../src/common/imagbmp.cpp:269
+#: ../src/common/imagbmp.cpp:266
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: 無法寫入檔案標頭(BitmapInfo)。"
 
-#: ../src/common/imagbmp.cpp:140
+#: ../src/common/imagbmp.cpp:137
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage 沒有自己的 wxPalette。"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:52 ../src/common/stockitem.cpp:142
+#: ../src/common/stockitem.cpp:139 ../src/common/accelcmn.cpp:49
 msgid "Back"
 msgstr "Backspace"
 
+#: ../src/richtext/richtextformatdlg.cpp:377
 #: ../src/richtext/richtextbackgroundpage.cpp:148
-#: ../src/richtext/richtextformatdlg.cpp:380
 msgid "Background"
 msgstr "背景"
 
@@ -1467,20 +1467,20 @@ msgstr "背景"
 msgid "Background &colour:"
 msgstr "背景顏色(&C)："
 
-#: ../src/osx/carbon/fontdlg.cpp:220
+#: ../src/osx/carbon/fontdlg.cpp:217
 msgid "Background colour"
 msgstr "背景顏色"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:52
+#: ../src/common/accelcmn.cpp:49
 msgid "Backspace"
 msgstr "Backspace"
 
-#: ../src/common/fmapbase.cpp:160
+#: ../src/common/fmapbase.cpp:157
 msgid "Baltic (ISO-8859-13)"
 msgstr "波羅的海語系 (ISO-8859-13)"
 
-#: ../src/common/fmapbase.cpp:151
+#: ../src/common/fmapbase.cpp:148
 msgid "Baltic (old) (ISO-8859-4)"
 msgstr "波羅的海語系 (舊) (ISO-8859-4)"
 
@@ -1488,30 +1488,30 @@ msgstr "波羅的海語系 (舊) (ISO-8859-4)"
 msgid "Before a paragraph:"
 msgstr "段落之前："
 
-#: ../src/richtext/richtextbulletspage.cpp:281
 #: ../src/richtext/richtextliststylepage.cpp:489
+#: ../src/richtext/richtextbulletspage.cpp:281
 msgid "Bitmap"
 msgstr "點陣圖"
 
-#: ../src/propgrid/advprops.cpp:1503
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Black"
 msgstr "黑色"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1659
+#: ../src/propgrid/advprops.cpp:1656
 msgid "Blank"
 msgstr "空白"
 
-#: ../src/propgrid/advprops.cpp:1512
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Blue"
 msgstr "藍色"
 
-#: ../src/generic/colrdlgg.cpp:345
+#: ../src/generic/colrdlgg.cpp:365
 msgid "Blue:"
 msgstr "藍色："
 
-#: ../src/common/stockitem.cpp:143 ../src/generic/fontdlgg.cpp:333
-#: ../src/osx/carbon/fontdlg.cpp:354 ../src/richtext/richtextfontpage.cpp:355
+#: ../src/osx/carbon/fontdlg.cpp:351 ../src/common/stockitem.cpp:140
+#: ../src/generic/fontdlgg.cpp:329 ../src/richtext/richtextfontpage.cpp:355
 msgid "Bold"
 msgstr "粗體"
 
@@ -1520,36 +1520,40 @@ msgstr "粗體"
 msgid "Border"
 msgstr "邊框"
 
-#: ../src/richtext/richtextformatdlg.cpp:375
+#: ../src/richtext/richtextformatdlg.cpp:372
 msgid "Borders"
 msgstr "邊框"
 
-#: ../src/common/stockitem.cpp:144 ../src/richtext/richtextsizepage.cpp:288
+#: ../src/common/stockitem.cpp:141 ../src/richtext/richtextsizepage.cpp:288
 msgid "Bottom"
 msgstr "底端"
 
-#: ../src/generic/prntdlgg.cpp:889
+#: ../src/generic/prntdlgg.cpp:886
 msgid "Bottom margin (mm):"
 msgstr "底邊距(公釐[mm])："
 
-#: ../src/richtext/richtextbuffer.cpp:9383
+#: ../src/richtext/richtextbuffer.cpp:9380
 msgid "Box Properties"
 msgstr "文字方塊性質"
 
-#: ../src/richtext/richtextstyles.cpp:1065
+#: ../src/richtext/richtextstyles.cpp:1062
 msgid "Box styles"
 msgstr "文字方塊樣式"
 
-#: ../src/propgrid/advprops.cpp:1511
+#: ../src/osx/cocoa/menu.mm:292
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Brown"
 msgstr "梡色"
 
-#: ../src/common/filepickercmn.cpp:43 ../src/common/filepickercmn.cpp:44
+#: ../src/common/filepickercmn.cpp:40 ../src/common/filepickercmn.cpp:41
 msgid "Browse"
 msgstr "瀏覽"
 
-#: ../src/richtext/richtextbulletspage.cpp:182
 #: ../src/richtext/richtextliststylepage.cpp:245
+#: ../src/richtext/richtextbulletspage.cpp:182
 msgid "Bullet &Alignment:"
 msgstr "項目符號對齊(&A):"
 
@@ -1557,72 +1561,72 @@ msgstr "項目符號對齊(&A):"
 msgid "Bullet style"
 msgstr "項目符號樣式"
 
-#: ../src/richtext/richtextformatdlg.cpp:355
+#: ../src/richtext/richtextformatdlg.cpp:352
 msgid "Bullets"
 msgstr "項目符號"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1660
+#: ../src/propgrid/advprops.cpp:1657
 msgid "Bullseye"
 msgstr "標靶"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:779
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonFace"
 msgstr "按鈕正面"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:780
+#: ../src/propgrid/advprops.cpp:777
 msgid "ButtonHighlight"
 msgstr "按鈕凸顯"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:781
+#: ../src/propgrid/advprops.cpp:778
 msgid "ButtonShadow"
 msgstr "按鈕陰影"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:782
+#: ../src/propgrid/advprops.cpp:779
 msgid "ButtonText"
 msgstr "按鈕文字"
 
-#: ../src/common/paper.cpp:98
+#: ../src/common/paper.cpp:95
 msgid "C sheet, 17 x 22 in"
 msgstr "C 印刷紙, 17 x 22 英吋"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "C&lear"
 msgstr "清除(&L)"
 
-#: ../src/generic/fontdlgg.cpp:407
+#: ../src/generic/fontdlgg.cpp:403
 msgid "C&olour:"
 msgstr "顏色(&O)："
 
-#: ../src/common/paper.cpp:123
+#: ../src/common/paper.cpp:120
 msgid "C3 Envelope, 324 x 458 mm"
 msgstr "C3 信封，324 x 458 公釐"
 
-#: ../src/common/paper.cpp:124
+#: ../src/common/paper.cpp:121
 msgid "C4 Envelope, 229 x 324 mm"
 msgstr "C4 信封，229 x 324 公釐"
 
-#: ../src/common/paper.cpp:122
+#: ../src/common/paper.cpp:119
 msgid "C5 Envelope, 162 x 229 mm"
 msgstr "C5 信封，162 x 229 公釐"
 
-#: ../src/common/paper.cpp:125
+#: ../src/common/paper.cpp:122
 msgid "C6 Envelope, 114 x 162 mm"
 msgstr "C6 信封，114 x 162 公釐"
 
-#: ../src/common/paper.cpp:126
+#: ../src/common/paper.cpp:123
 msgid "C65 Envelope, 114 x 229 mm"
 msgstr "C65 信封, 114 x 229 公釐"
 
-#: ../src/common/stockitem.cpp:146
+#: ../src/common/stockitem.cpp:143
 msgid "CD-Rom"
 msgstr "唯讀光碟"
 
-#: ../src/html/chm.cpp:813 ../src/html/chm.cpp:872
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:865
 msgid "CHM handler currently supports only local files!"
 msgstr "CHM 處理常式目前只支援本機檔案！"
 
@@ -1630,194 +1634,193 @@ msgstr "CHM 處理常式目前只支援本機檔案！"
 msgid "Ca&pitals"
 msgstr "大寫(&P)"
 
-#: ../src/common/cmdproc.cpp:263
+#: ../src/common/cmdproc.cpp:260
 msgid "Can't &Undo "
 msgstr "無法回復(&U)"
 
-#: ../src/common/image.cpp:2839
+#: ../src/common/image.cpp:2924
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr "無法自動決定用於不可尋指輸入的影像格式。"
 
-#: ../src/msw/registry.cpp:506
+#: ../src/msw/registry.cpp:495
 #, c-format
 msgid "Can't close registry key '%s'"
 msgstr "無法關閉登錄機碼 '%s'"
 
-#: ../src/msw/registry.cpp:584
+#: ../src/msw/registry.cpp:573
 #, c-format
 msgid "Can't copy values of unsupported type %d."
 msgstr "無法複製不支援類型 %d 的值。"
 
-#: ../src/msw/registry.cpp:487
+#: ../src/msw/registry.cpp:476
 #, c-format
 msgid "Can't create registry key '%s'"
 msgstr "無法建立登錄機碼 '%s'"
 
-#: ../src/msw/thread.cpp:673
+#: ../src/msw/thread.cpp:657
 msgid "Can't create thread"
 msgstr "無法建立執行緒"
 
-#: ../src/msw/registry.cpp:776
+#: ../src/msw/registry.cpp:765
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "無法刪除機碼 '%s'"
 
-#: ../src/msw/iniconf.cpp:458
+#: ../src/msw/iniconf.cpp:455
 #, c-format
 msgid "Can't delete the INI file '%s'"
 msgstr "無法刪除 INI 檔 '%s'"
 
-#: ../src/msw/registry.cpp:804
+#: ../src/msw/registry.cpp:793
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "無法刪除機值 '%s' @ '%s'"
 
-#: ../src/msw/registry.cpp:1170
+#: ../src/msw/registry.cpp:1159
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "無法列舉機碼 '%s' 的子機碼"
 
-#: ../src/msw/registry.cpp:1131
+#: ../src/msw/registry.cpp:1120
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "無法列舉機碼 '%s' 的值"
 
-#: ../src/msw/registry.cpp:1388
+#: ../src/msw/registry.cpp:1377
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "無法匯出不支援類型 %d 的值。"
 
-#: ../src/common/ffile.cpp:255
+#: ../src/common/ffile.cpp:253
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "無法在「%s」檔案中找到目前位置"
 
-#: ../src/msw/registry.cpp:418
+#: ../src/msw/registry.cpp:407
 #, c-format
 msgid "Can't get info about registry key '%s'"
 msgstr "無法取得登錄機碼 '%s' 的資訊"
 
-#: ../src/msw/webview_ie.cpp:939
-#| msgid "Can't set thread priority"
+#: ../src/msw/webview_ie.cpp:1024
 msgid "Can't get the JavaScript object"
 msgstr "無法取得 JavaScript 物件"
 
-#: ../src/common/zstream.cpp:346
+#: ../src/common/zstream.cpp:343
 msgid "Can't initialize zlib deflate stream."
 msgstr "無法初始化 zlib 壓縮資料流。"
 
-#: ../src/common/zstream.cpp:185
+#: ../src/common/zstream.cpp:182
 msgid "Can't initialize zlib inflate stream."
 msgstr "無法初始化 zlib 解壓資料流。"
 
-#: ../src/msw/fswatcher.cpp:476
+#: ../src/msw/fswatcher.cpp:475
 #, c-format
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "無法監視不存在的目錄「%s」是否有變更。"
 
-#: ../src/msw/registry.cpp:454
+#: ../src/msw/registry.cpp:443
 #, c-format
 msgid "Can't open registry key '%s'"
 msgstr "無法開啟登錄機碼 '%s'"
 
-#: ../src/common/zstream.cpp:252
+#: ../src/common/zstream.cpp:249
 #, c-format
 msgid "Can't read from inflate stream: %s"
 msgstr "無法讀取解壓資料流：%s"
 
-#: ../src/common/zstream.cpp:244
+#: ../src/common/zstream.cpp:241
 msgid "Can't read inflate stream: unexpected EOF in underlying stream."
 msgstr "無法讀取解壓資料流：資料流中有未預期的結尾。"
 
-#: ../src/msw/registry.cpp:1063
+#: ../src/msw/registry.cpp:1052
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "無法讀取 '%s' 的值"
 
-#: ../src/msw/registry.cpp:877 ../src/msw/registry.cpp:909
-#: ../src/msw/registry.cpp:974
+#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
+#: ../src/msw/registry.cpp:963
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "無法讀取機碼 '%s' 的值"
 
-#: ../src/msw/webview_ie.cpp:932
+#: ../src/msw/webview_ie.cpp:1017
 msgid "Can't run JavaScript script without a valid HTML document"
 msgstr "需要有效 HTML 文件才能執行 JavaScript 文稿"
 
-#: ../src/common/image.cpp:2630
+#: ../src/common/image.cpp:2715
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "無法儲存圖像到「%s」檔案：不明的副檔名。"
 
-#: ../src/generic/logg.cpp:573 ../src/generic/logg.cpp:976
+#: ../src/generic/logg.cpp:570 ../src/generic/logg.cpp:973
 msgid "Can't save log contents to file."
 msgstr "無法將日誌內容儲存到檔案。"
 
-#: ../src/msw/thread.cpp:637
+#: ../src/msw/thread.cpp:621
 msgid "Can't set thread priority"
 msgstr "無法設定執行緒的優先等級"
 
-#: ../src/msw/registry.cpp:895 ../src/msw/registry.cpp:937
-#: ../src/msw/registry.cpp:1080
+#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
+#: ../src/msw/registry.cpp:1069
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "無法設定 '%s' 的值"
 
-#: ../src/unix/utilsunx.cpp:356
+#: ../src/unix/utilsunx.cpp:353
 msgid "Can't write to child process's stdin"
 msgstr "無法寫入子程序的標準輸入"
 
-#: ../src/common/zstream.cpp:427
+#: ../src/common/zstream.cpp:424
 #, c-format
 msgid "Can't write to deflate stream: %s"
 msgstr "無法寫入壓縮資料流：%s"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:279 ../src/common/accelcmn.cpp:71
-#: ../src/common/stockitem.cpp:145 ../src/gtk1/fontdlg.cpp:144
-#: ../src/motif/msgdlg.cpp:196 ../src/msw/msgdlg.cpp:451
-#: ../src/msw/progdlg.cpp:943 ../src/richtext/richtextstyledlg.cpp:300
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:142
+#: ../src/common/accelcmn.cpp:68 ../src/motif/msgdlg.cpp:196
+#: ../src/gtk1/fontdlg.cpp:144 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/progdlg.cpp:940 ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "取消"
 
-#: ../src/common/filefn.cpp:1262
+#: ../src/common/filefn.cpp:1149
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "無法列舉檔案 '%s'"
 
-#: ../src/msw/dir.cpp:263
+#: ../src/msw/dir.cpp:260
 #, c-format
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "無法列舉「%s」目錄的檔案"
 
-#: ../src/msw/dialup.cpp:522
+#: ../src/msw/dialup.cpp:517
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "找不到連線中的撥號連線：%s"
 
-#: ../src/msw/dialup.cpp:826
+#: ../src/msw/dialup.cpp:821
 msgid "Cannot find the location of address book file"
 msgstr "找不到通訊錄的檔案位置"
 
-#: ../src/msw/ole/automtn.cpp:562
+#: ../src/msw/ole/automtn.cpp:553
 #, c-format
 msgid "Cannot get an active instance of \"%s\""
 msgstr "無法取得「%s」的作用中實體"
 
-#: ../src/unix/threadpsx.cpp:1029
+#: ../src/unix/threadpsx.cpp:1053
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "無法取得排程原則 %d 的優先等級範圍。"
 
-#: ../src/unix/utilsunx.cpp:992
+#: ../src/unix/utilsunx.cpp:989
 msgid "Cannot get the hostname"
 msgstr "無法取得主機名稱"
 
-#: ../src/unix/utilsunx.cpp:1028
+#: ../src/unix/utilsunx.cpp:1025
 msgid "Cannot get the official hostname"
 msgstr "無法取得正式的主機名稱"
 
-#: ../src/msw/dialup.cpp:927
+#: ../src/msw/dialup.cpp:922
 msgid "Cannot hang up - no active dialup connection."
 msgstr "無法掛斷—沒有連線中的撥號連線。"
 
@@ -1825,138 +1828,138 @@ msgstr "無法掛斷—沒有連線中的撥號連線。"
 msgid "Cannot initialize OLE"
 msgstr "無法初始化 OLE"
 
-#: ../src/common/socket.cpp:853
+#: ../src/common/socket.cpp:850
 msgid "Cannot initialize sockets"
 msgstr "無法初始化通訊端"
 
-#: ../src/msw/volume.cpp:630
+#: ../src/msw/volume.cpp:627
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "無法從「%s」載入圖示。"
 
-#: ../src/xrc/xmlres.cpp:361
+#: ../src/xrc/xmlres.cpp:358
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "無法從「%s」檔案載入資源。"
 
-#: ../src/xrc/xmlres.cpp:743
+#: ../src/xrc/xmlres.cpp:740
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "無法從「%s」檔案載入資源。"
 
-#: ../src/html/htmlfilt.cpp:137
+#: ../src/html/htmlfilt.cpp:134
 #, c-format
 msgid "Cannot open HTML document: %s"
 msgstr "無法開啟 HTML 文件：%s"
 
-#: ../src/html/helpdata.cpp:663
+#: ../src/html/helpdata.cpp:660
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "無法開啟 HTML 說明書：%s"
 
-#: ../src/html/helpdata.cpp:299
+#: ../src/html/helpdata.cpp:296
 #, c-format
 msgid "Cannot open contents file: %s"
 msgstr "無法開啟目錄檔案： %s"
 
-#: ../src/generic/dcpsg.cpp:1668
+#: ../src/generic/dcpsg.cpp:1665
 msgid "Cannot open file for PostScript printing!"
 msgstr "無法開啟檔案進行 PostScript 列印！"
 
-#: ../src/html/helpdata.cpp:313
+#: ../src/html/helpdata.cpp:310
 #, c-format
 msgid "Cannot open index file: %s"
 msgstr "無法開啟索引檔： %s"
 
-#: ../src/xrc/xmlres.cpp:725
+#: ../src/xrc/xmlres.cpp:722
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "無法開啟資源檔「%s」。"
 
-#: ../src/html/helpwnd.cpp:1535
+#: ../src/html/helpwnd.cpp:1532
 msgid "Cannot print empty page."
 msgstr "無法列印空頁面。"
 
-#: ../src/msw/volume.cpp:518
+#: ../src/msw/volume.cpp:515
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "無法從「%s」讀取類型名稱！"
 
-#: ../src/msw/thread.cpp:910
+#: ../src/msw/thread.cpp:894
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "無法恢復執行緒 %lx"
 
-#: ../src/unix/threadpsx.cpp:1004
+#: ../src/unix/threadpsx.cpp:1028
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "無法取得執行緒排程原則。"
 
-#: ../src/common/intl.cpp:366
+#: ../src/common/intl.cpp:365
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "無法將語言設定為「%s」。"
 
-#: ../src/msw/thread.cpp:546 ../src/unix/threadpsx.cpp:833
+#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
 msgid "Cannot start thread: error writing TLS."
 msgstr "無法啟動執行緒：寫入「執行緒內部儲存區」時發生錯誤。"
 
-#: ../src/msw/thread.cpp:880
+#: ../src/msw/thread.cpp:864
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "無法暫停執行緒 %lx"
 
-#: ../src/msw/thread.cpp:802
+#: ../src/msw/thread.cpp:786
 msgid "Cannot wait for thread termination"
 msgstr "無法等候執行緒終結"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:75
+#: ../src/common/accelcmn.cpp:72
 msgid "Capital"
 msgstr "大寫"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:783
+#: ../src/propgrid/advprops.cpp:780
 msgid "CaptionText"
 msgstr "CaptionText"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:531
 msgid "Case sensitive"
 msgstr "區分大小寫"
 
-#: ../src/propgrid/manager.cpp:1528
+#: ../src/propgrid/manager.cpp:1527
 msgid "Categorized Mode"
 msgstr "已分類模式"
 
-#: ../src/richtext/richtextbuffer.cpp:9968
+#: ../src/richtext/richtextbuffer.cpp:9965
 msgid "Cell Properties"
 msgstr "儲存格性質"
 
-#: ../src/common/fmapbase.cpp:161
+#: ../src/common/fmapbase.cpp:158
 msgid "Celtic (ISO-8859-14)"
 msgstr "凱爾特語 (ISO-8859-14)"
 
-#: ../src/richtext/richtextindentspage.cpp:160
 #: ../src/richtext/richtextliststylepage.cpp:349
+#: ../src/richtext/richtextindentspage.cpp:160
 msgid "Cen&tred"
 msgstr "置中對齊(&T)"
 
-#: ../src/common/stockitem.cpp:170
+#: ../src/common/stockitem.cpp:167
 msgid "Centered"
 msgstr "置中對齊"
 
-#: ../src/common/fmapbase.cpp:149
+#: ../src/common/fmapbase.cpp:146
 msgid "Central European (ISO-8859-2)"
 msgstr "中歐語系 (ISO-8859-2)"
 
-#: ../src/richtext/richtextbulletspage.cpp:187
 #: ../src/richtext/richtextliststylepage.cpp:250
+#: ../src/richtext/richtextbulletspage.cpp:187
 msgid "Centre"
 msgstr "置中對齊"
 
-#: ../src/richtext/richtextindentspage.cpp:162
-#: ../src/richtext/richtextindentspage.cpp:164
 #: ../src/richtext/richtextliststylepage.cpp:351
 #: ../src/richtext/richtextliststylepage.cpp:353
+#: ../src/richtext/richtextindentspage.cpp:162
+#: ../src/richtext/richtextindentspage.cpp:164
 msgid "Centre text."
 msgstr "置中對齊文字。"
 
@@ -1964,58 +1967,58 @@ msgstr "置中對齊文字。"
 msgid "Centred"
 msgstr "中間"
 
-#: ../src/richtext/richtextbulletspage.cpp:219
 #: ../src/richtext/richtextliststylepage.cpp:280
+#: ../src/richtext/richtextbulletspage.cpp:219
 msgid "Ch&oose..."
 msgstr "選擇(&O)…"
 
-#: ../src/richtext/richtextbuffer.cpp:4354
+#: ../src/richtext/richtextbuffer.cpp:4351
 msgid "Change List Style"
 msgstr "變更清單樣式"
 
-#: ../src/richtext/richtextbuffer.cpp:3709
+#: ../src/richtext/richtextbuffer.cpp:3706
 msgid "Change Object Style"
 msgstr "變更物件樣式"
 
-#: ../src/richtext/richtextbuffer.cpp:3982
-#: ../src/richtext/richtextbuffer.cpp:8128
+#: ../src/richtext/richtextbuffer.cpp:3979
+#: ../src/richtext/richtextbuffer.cpp:8125
 msgid "Change Properties"
 msgstr "變更性質"
 
-#: ../src/richtext/richtextbuffer.cpp:3526
+#: ../src/richtext/richtextbuffer.cpp:3523
 msgid "Change Style"
 msgstr "變更樣式"
 
-#: ../src/common/fileconf.cpp:341
+#: ../src/common/fileconf.cpp:335
 #, c-format
 msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
 msgstr "為了避免覆寫已有的「%s」檔案 ，將不會儲存變更。"
 
-#: ../src/gtk/filedlg.cpp:87 ../src/gtk/filepicker.cpp:190
+#: ../src/gtk/filepicker.cpp:190 ../src/gtk/filedlg.cpp:87
 #, c-format
 msgid "Changing current directory to \"%s\" failed"
 msgstr "無法將目前目錄變更為「%s」"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1661
+#: ../src/propgrid/advprops.cpp:1658
 msgid "Character"
 msgstr "字元"
 
-#: ../src/richtext/richtextstyles.cpp:1063
+#: ../src/richtext/richtextstyles.cpp:1060
 msgid "Character styles"
 msgstr "字元樣式"
 
-#: ../src/richtext/richtextbulletspage.cpp:161
-#: ../src/richtext/richtextbulletspage.cpp:163
 #: ../src/richtext/richtextliststylepage.cpp:224
 #: ../src/richtext/richtextliststylepage.cpp:226
+#: ../src/richtext/richtextbulletspage.cpp:161
+#: ../src/richtext/richtextbulletspage.cpp:163
 msgid "Check to add a period after the bullet."
 msgstr "勾選以在項目符號後加上半形句點。"
 
-#: ../src/richtext/richtextbulletspage.cpp:175
-#: ../src/richtext/richtextbulletspage.cpp:177
 #: ../src/richtext/richtextliststylepage.cpp:238
 #: ../src/richtext/richtextliststylepage.cpp:240
+#: ../src/richtext/richtextbulletspage.cpp:175
+#: ../src/richtext/richtextbulletspage.cpp:177
 msgid "Check to add a right parenthesis."
 msgstr "勾選以加上右括號。"
 
@@ -2026,10 +2029,10 @@ msgstr "勾選以加上右括號。"
 msgid "Check to edit all borders simultaneously."
 msgstr "勾選以同時編輯所有邊框。"
 
-#: ../src/richtext/richtextbulletspage.cpp:168
-#: ../src/richtext/richtextbulletspage.cpp:170
 #: ../src/richtext/richtextliststylepage.cpp:231
 #: ../src/richtext/richtextliststylepage.cpp:233
+#: ../src/richtext/richtextbulletspage.cpp:168
+#: ../src/richtext/richtextbulletspage.cpp:170
 msgid "Check to enclose the bullet in parentheses."
 msgstr "勾選以將項目符號加上一對括號。"
 
@@ -2038,20 +2041,20 @@ msgstr "勾選以將項目符號加上一對括號。"
 msgid "Check to indicate right-to-left text layout."
 msgstr "勾選以指明右至左文字配置。"
 
-#: ../src/osx/carbon/fontdlg.cpp:356 ../src/osx/carbon/fontdlg.cpp:358
+#: ../src/osx/carbon/fontdlg.cpp:353 ../src/osx/carbon/fontdlg.cpp:355
 msgid "Check to make the font bold."
 msgstr "勾選以設定為粗體。"
 
-#: ../src/osx/carbon/fontdlg.cpp:363 ../src/osx/carbon/fontdlg.cpp:365
+#: ../src/osx/carbon/fontdlg.cpp:360 ../src/osx/carbon/fontdlg.cpp:362
 msgid "Check to make the font italic."
 msgstr "勾選以設定為斜體。"
 
-#: ../src/osx/carbon/fontdlg.cpp:372 ../src/osx/carbon/fontdlg.cpp:374
+#: ../src/osx/carbon/fontdlg.cpp:369 ../src/osx/carbon/fontdlg.cpp:371
 msgid "Check to make the font underlined."
 msgstr "勾選以將字加底線。"
 
-#: ../src/richtext/richtextstyledlg.cpp:289
-#: ../src/richtext/richtextstyledlg.cpp:291
+#: ../src/richtext/richtextstyledlg.cpp:285
+#: ../src/richtext/richtextstyledlg.cpp:287
 msgid "Check to restart numbering."
 msgstr "勾選以重新編號。"
 
@@ -2085,70 +2088,70 @@ msgstr "勾選以將字上標。"
 msgid "Check to suppress hyphenation."
 msgstr "勾選以抑制將同一英文字分行顯示。"
 
-#: ../src/msw/dialup.cpp:762
+#: ../src/msw/dialup.cpp:757
 msgid "Choose ISP to dial"
 msgstr "選擇 ISP 進行撥號"
 
-#: ../src/propgrid/props.cpp:1907
+#: ../src/propgrid/props.cpp:1904
 msgid "Choose a directory:"
 msgstr "選擇目錄："
 
-#: ../src/propgrid/props.cpp:2202
+#: ../src/propgrid/props.cpp:2199
 msgid "Choose a file"
 msgstr "選擇檔案"
 
-#: ../src/generic/colrdlgg.cpp:158 ../src/gtk/colordlg.cpp:52
+#: ../src/generic/colrdlgg.cpp:156 ../src/gtk/colordlg.cpp:49
 msgid "Choose colour"
 msgstr "選擇顏色"
 
-#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/gtk1/fontdlg.cpp:125 ../src/generic/fontpickerg.cpp:47
+#: ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "選擇字型"
 
-#: ../src/common/module.cpp:74
+#: ../src/common/module.cpp:71
 #, c-format
 msgid "Circular dependency involving module \"%s\" detected."
 msgstr "偵測到牽連出循環依存性的「%s」模組。"
 
-#: ../src/aui/tabmdi.cpp:108 ../src/generic/mdig.cpp:97
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
 msgid "Cl&ose"
 msgstr "關閉(&O)"
 
-#: ../src/msw/ole/automtn.cpp:684
+#: ../src/msw/ole/automtn.cpp:675
 msgid "Class not registered."
 msgstr "類別未註冊。"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:72 ../src/common/stockitem.cpp:147
+#: ../src/common/stockitem.cpp:144 ../src/common/accelcmn.cpp:69
 msgid "Clear"
 msgstr "清除"
 
-#: ../src/generic/logg.cpp:514
+#: ../src/generic/logg.cpp:511
 msgid "Clear the log contents"
 msgstr "清除日誌內容"
 
-#: ../src/richtext/richtextstyledlg.cpp:252
-#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:248
+#: ../src/richtext/richtextstyledlg.cpp:250
 msgid "Click to apply the selected style."
 msgstr "點擊以套用所選樣式。"
 
-#: ../src/richtext/richtextbulletspage.cpp:220
-#: ../src/richtext/richtextbulletspage.cpp:222
 #: ../src/richtext/richtextliststylepage.cpp:281
 #: ../src/richtext/richtextliststylepage.cpp:283
+#: ../src/richtext/richtextbulletspage.cpp:220
+#: ../src/richtext/richtextbulletspage.cpp:222
 msgid "Click to browse for a symbol."
 msgstr "點擊瀏覽該符號。"
 
-#: ../src/osx/carbon/fontdlg.cpp:403 ../src/osx/carbon/fontdlg.cpp:405
+#: ../src/osx/carbon/fontdlg.cpp:400 ../src/osx/carbon/fontdlg.cpp:402
 msgid "Click to cancel changes to the font."
 msgstr "點擊取消字型變更。"
 
-#: ../src/generic/fontdlgg.cpp:472 ../src/generic/fontdlgg.cpp:491
+#: ../src/generic/fontdlgg.cpp:468 ../src/generic/fontdlgg.cpp:487
 msgid "Click to cancel the font selection."
 msgstr "點擊取消字型選擇。"
 
-#: ../src/osx/carbon/fontdlg.cpp:384 ../src/osx/carbon/fontdlg.cpp:386
+#: ../src/osx/carbon/fontdlg.cpp:381 ../src/osx/carbon/fontdlg.cpp:383
 msgid "Click to change the font colour."
 msgstr "點擊變更字型顏色。"
 
@@ -2167,37 +2170,37 @@ msgstr "點擊變更文字顏色。"
 msgid "Click to choose the font for this level."
 msgstr "點擊選擇此層級的字型。"
 
-#: ../src/richtext/richtextstyledlg.cpp:279
-#: ../src/richtext/richtextstyledlg.cpp:281
+#: ../src/richtext/richtextstyledlg.cpp:275
+#: ../src/richtext/richtextstyledlg.cpp:277
 msgid "Click to close this window."
 msgstr "點擊關閉視窗"
 
-#: ../src/osx/carbon/fontdlg.cpp:410 ../src/osx/carbon/fontdlg.cpp:412
+#: ../src/osx/carbon/fontdlg.cpp:407 ../src/osx/carbon/fontdlg.cpp:409
 msgid "Click to confirm changes to the font."
 msgstr "點擊確認字型變更。"
 
-#: ../src/generic/fontdlgg.cpp:477 ../src/generic/fontdlgg.cpp:479
-#: ../src/generic/fontdlgg.cpp:484 ../src/generic/fontdlgg.cpp:486
+#: ../src/generic/fontdlgg.cpp:473 ../src/generic/fontdlgg.cpp:475
+#: ../src/generic/fontdlgg.cpp:480 ../src/generic/fontdlgg.cpp:482
 msgid "Click to confirm the font selection."
 msgstr "點擊確認字型選擇。"
 
-#: ../src/richtext/richtextstyledlg.cpp:244
-#: ../src/richtext/richtextstyledlg.cpp:246
+#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:242
 msgid "Click to create a new box style."
 msgstr "點擊新增文字方塊樣式。"
 
-#: ../src/richtext/richtextstyledlg.cpp:226
-#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:222
+#: ../src/richtext/richtextstyledlg.cpp:224
 msgid "Click to create a new character style."
 msgstr "點擊新增字元樣式。"
 
-#: ../src/richtext/richtextstyledlg.cpp:238
-#: ../src/richtext/richtextstyledlg.cpp:240
+#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:236
 msgid "Click to create a new list style."
 msgstr "點擊新增清單樣式。"
 
-#: ../src/richtext/richtextstyledlg.cpp:232
-#: ../src/richtext/richtextstyledlg.cpp:234
+#: ../src/richtext/richtextstyledlg.cpp:228
+#: ../src/richtext/richtextstyledlg.cpp:230
 msgid "Click to create a new paragraph style."
 msgstr "點擊新增段落樣式。"
 
@@ -2211,8 +2214,8 @@ msgstr "點擊新增定位點。"
 msgid "Click to delete all tab positions."
 msgstr "點擊刪除所有定位點。"
 
-#: ../src/richtext/richtextstyledlg.cpp:270
-#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:268
 msgid "Click to delete the selected style."
 msgstr "點擊刪除所選樣式。"
 
@@ -2221,146 +2224,150 @@ msgstr "點擊刪除所選樣式。"
 msgid "Click to delete the selected tab position."
 msgstr "點擊刪除所選定位點。"
 
-#: ../src/richtext/richtextstyledlg.cpp:264
-#: ../src/richtext/richtextstyledlg.cpp:266
+#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:262
 msgid "Click to edit the selected style."
 msgstr "點擊編輯所選樣式。"
 
-#: ../src/richtext/richtextstyledlg.cpp:258
-#: ../src/richtext/richtextstyledlg.cpp:260
+#: ../src/richtext/richtextstyledlg.cpp:254
+#: ../src/richtext/richtextstyledlg.cpp:256
 msgid "Click to rename the selected style."
 msgstr "點擊重新命名所選樣式。"
 
-#: ../src/common/stockitem.cpp:148 ../src/generic/dbgrptg.cpp:97
-#: ../src/generic/progdlgg.cpp:784 ../src/html/helpdlg.cpp:90
-#: ../src/msw/progdlg.cpp:214 ../src/msw/progdlg.cpp:949
-#: ../src/richtext/richtextstyledlg.cpp:277
-#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/common/stockitem.cpp:145 ../src/generic/dbgrptg.cpp:94
+#: ../src/generic/progdlgg.cpp:781 ../src/msw/progdlg.cpp:211
+#: ../src/msw/progdlg.cpp:946 ../src/html/helpdlg.cpp:87
+#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextstyledlg.cpp:273
 msgid "Close"
 msgstr "關閉"
 
-#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:98
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
 msgid "Close All"
 msgstr "全部關閉"
 
-#: ../src/common/stockitem.cpp:269
+#: ../src/common/stockitem.cpp:266
 msgid "Close current document"
 msgstr "關閉當前文件"
 
-#: ../src/generic/logg.cpp:516
+#: ../src/generic/logg.cpp:513
 msgid "Close this window"
 msgstr "關閉視窗"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6454
+#: ../src/generic/datavgen.cpp:6811
 msgid "Collapse"
 msgstr "摺疊"
 
-#: ../src/common/stockitem.cpp:193
+#: ../src/common/stockitem.cpp:190
 msgid "Color"
 msgstr "顏色"
 
-#: ../src/richtext/richtextformatdlg.cpp:771
+#: ../src/richtext/richtextformatdlg.cpp:768
 msgid "Colour"
 msgstr "顏色"
 
-#: ../src/msw/colordlg.cpp:230
+#: ../src/msw/colordlg.cpp:227
 #, c-format
 msgid "Colour selection dialog failed with error %0lx."
 msgstr "顏色選取對話框失敗，錯誤碼：%0lx。"
 
-#: ../src/osx/carbon/fontdlg.cpp:380
+#: ../src/osx/carbon/fontdlg.cpp:377
 msgid "Colour:"
 msgstr "顏色："
 
-#: ../src/generic/datavgen.cpp:6525
+#: ../src/generic/datavgen.cpp:6882
 #, c-format
 msgid "Column %u"
 msgstr "欄位 %u"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:115
+#: ../src/common/accelcmn.cpp:112
 msgid "Command"
 msgstr "指令"
 
-#: ../src/common/init.cpp:196
+#: ../src/common/init.cpp:193
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
 "ignored."
 msgstr "由於指令列引數 %d 無法轉換為 Unicode 編碼，其將被忽略。"
 
-#: ../src/msw/fontdlg.cpp:169
+#: ../src/msw/fontdlg.cpp:170
 #, c-format
 msgid "Common dialog failed with error code %0lx."
 msgstr "共同對話視窗錯誤，錯誤碼 %0lx。"
 
-#: ../src/gtk/window.cpp:5621
+#: ../src/gtk/window.cpp:5653
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
 msgstr "這個系統不支援組合介面，請在視窗管理員啟用之。"
 
-#: ../src/html/helpwnd.cpp:1552
+#: ../src/html/helpwnd.cpp:1549
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "壓縮超文件說明檔 (*.chm)|*.chm|"
 
-#: ../src/generic/dirctrlg.cpp:444
+#: ../src/generic/dirctrlg.cpp:410
 msgid "Computer"
 msgstr "電腦"
 
-#: ../src/common/fileconf.cpp:939
+#: ../src/common/fileconf.cpp:934
 #, c-format
 msgid "Config entry name cannot start with '%c'."
 msgstr "設定項目名稱不能以 '%c' 開頭。"
 
-#: ../src/generic/filedlgg.cpp:349 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
 msgid "Confirm"
 msgstr "確認"
 
-#: ../src/html/htmlwin.cpp:572
+#: ../src/html/htmlwin.cpp:569
 msgid "Connecting..."
 msgstr "連線中…"
 
-#: ../src/html/helpwnd.cpp:476
+#: ../src/html/helpwnd.cpp:473
 msgid "Contents"
 msgstr "目錄"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:784
+#: ../src/propgrid/advprops.cpp:781
 msgid "ControlDark"
 msgstr "ControlDark"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:785
+#: ../src/propgrid/advprops.cpp:782
 msgid "ControlLight"
 msgstr "ControlLight"
 
-#: ../src/common/strconv.cpp:2211
+#: ../src/common/strconv.cpp:2208
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "無法轉換到「%s」字集。"
 
-#: ../src/common/stockitem.cpp:149
+#: ../src/common/stockitem.cpp:146
 msgid "Convert"
 msgstr "轉換"
 
-#: ../src/html/htmlwin.cpp:1016
+#: ../src/html/htmlwin.cpp:1020
 #, c-format
 msgid "Copied to clipboard:\"%s\""
 msgstr "複製到剪貼簿：「%s」"
 
-#: ../src/generic/prntdlgg.cpp:243
+#: ../src/generic/prntdlgg.cpp:240
 msgid "Copies:"
 msgstr "份數："
 
-#: ../src/common/stockitem.cpp:150 ../src/stc/stc_i18n.cpp:18
+#: ../src/common/stockitem.cpp:147 ../src/stc/stc_i18n.cpp:18
 msgid "Copy"
 msgstr "複製"
 
-#: ../src/common/stockitem.cpp:258
+#: ../src/common/stockitem.cpp:255
 msgid "Copy selection"
 msgstr "複製所選項目"
+
+#: ../src/generic/grid.cpp:5945
+msgid "Copying more than one selected block to clipboard is not supported."
+msgstr ""
 
 #: ../src/richtext/richtextborderspage.cpp:566
 #: ../src/richtext/richtextborderspage.cpp:601
@@ -2371,215 +2378,210 @@ msgstr "角位"
 msgid "Corner &radius:"
 msgstr "角位半徑(&R)："
 
-#: ../src/html/chm.cpp:718
+#: ../src/html/chm.cpp:711
 #, c-format
 msgid "Could not create temporary file '%s'"
 msgstr "無法建立暫存檔「%s」"
 
-#: ../src/html/chm.cpp:273
+#: ../src/html/chm.cpp:270
 #, c-format
 msgid "Could not extract %s into %s: %s"
 msgstr "無法將 %s 解壓至 %s： %s"
 
-#: ../src/generic/tabg.cpp:1048
+#: ../src/generic/tabg.cpp:1045
 msgid "Could not find tab for id"
 msgstr "找不到識別碼標籤"
 
-#: ../src/html/chm.cpp:444
+#: ../src/html/chm.cpp:437
 #, c-format
 msgid "Could not locate file '%s'."
 msgstr "找不到檔案 '%s'。"
 
-#: ../src/common/filefn.cpp:1404
+#: ../src/msw/graphicsd2d.cpp:604
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/common/filefn.cpp:1291
 msgid "Could not set current working directory"
 msgstr "無法設定目前工作目錄"
 
-#: ../src/common/prntbase.cpp:2045
+#: ../src/common/prntbase.cpp:2037
 msgid "Could not start document preview."
 msgstr "無法啟動文件預覽。"
 
-#: ../src/generic/printps.cpp:162 ../src/gtk/print.cpp:1133
-#: ../src/msw/printwin.cpp:187
+#: ../src/generic/printps.cpp:159 ../src/msw/printwin.cpp:184
+#: ../src/gtk/print.cpp:1129
 msgid "Could not start printing."
 msgstr "無法啟動列印。"
 
-#: ../src/common/wincmn.cpp:2150
+#: ../src/common/wincmn.cpp:2126
 msgid "Could not transfer data to window"
 msgstr "無法轉移資料到視窗中"
 
-#: ../src/msw/dragimag.cpp:185 ../src/msw/dragimag.cpp:220
-#: ../src/msw/imaglist.cpp:186 ../src/msw/imaglist.cpp:223
-#: ../src/msw/imaglist.cpp:248
+#: ../src/msw/imaglist.cpp:223 ../src/msw/imaglist.cpp:245
+#: ../src/msw/imaglist.cpp:270 ../src/msw/dragimag.cpp:182
+#: ../src/msw/dragimag.cpp:217
 msgid "Couldn't add an image to the image list."
 msgstr "無法把圖像加到圖像清單。"
 
-#: ../src/msw/glcanvas.cpp:634 ../src/osx/glcanvas_osx.cpp:414
-#: ../src/unix/glx11.cpp:559
+#: ../src/osx/glcanvas_osx.cpp:411 ../src/msw/glcanvas.cpp:631
+#: ../src/unix/glegl.cpp:315 ../src/unix/glx11.cpp:559
 msgid "Couldn't create OpenGL context"
 msgstr "無法建立 OpenGL 脈絡"
 
-#: ../src/msw/timer.cpp:134
+#: ../src/msw/timer.cpp:131
 msgid "Couldn't create a timer"
 msgstr "無法建立計時器"
 
-#: ../src/osx/carbon/overlay.cpp:122
-msgid "Couldn't create the overlay window"
-msgstr "無法建立覆蓋視窗"
-
-#: ../src/common/translation.cpp:2076
+#: ../src/common/translation.cpp:2074
 msgid "Couldn't enumerate translations"
 msgstr "無法列舉翻譯"
 
-#: ../src/common/dynlib.cpp:120
+#: ../src/common/dynlib.cpp:110
 #, c-format
 msgid "Couldn't find symbol '%s' in a dynamic library"
 msgstr "在動態函式庫找不到「%s」符號"
 
-#: ../src/msw/thread.cpp:937
+#: ../src/msw/thread.cpp:921
 msgid "Couldn't get the current thread pointer"
 msgstr "無法取得目前執行緒指標"
 
-#: ../src/osx/carbon/overlay.cpp:129
-msgid "Couldn't init the context on the overlay window"
-msgstr "無法初始化覆蓋視窗的內容"
-
-#: ../src/common/imaggif.cpp:244
+#: ../src/common/imaggif.cpp:241
 msgid "Couldn't initialize GIF hash table."
 msgstr "無法初始化 GIF 雜湊表。"
 
-#: ../src/common/imagpng.cpp:440
+#: ../src/common/imagpng.cpp:437
 msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
 msgstr "無法載入 PNG 圖像 — 檔案損壞或是沒有足夠記憶體。"
 
-#: ../src/unix/sound.cpp:462
+#: ../src/unix/sound.cpp:459
 #, c-format
 msgid "Couldn't load sound data from '%s'."
 msgstr "無法從「%s」載入聲音資料。"
 
-#: ../src/msw/dirdlg.cpp:438
+#: ../src/msw/dirdlg.cpp:287
 msgid "Couldn't obtain folder name"
 msgstr "無法取得資料夾名稱"
 
-#: ../src/unix/sound_sdl.cpp:229
+#: ../src/unix/sound_sdl.cpp:226
 #, c-format
 msgid "Couldn't open audio: %s"
 msgstr "無法開啟音訊：「%s」"
 
-#: ../src/msw/ole/dataobj.cpp:377
+#: ../src/msw/ole/dataobj.cpp:385
 #, c-format
 msgid "Couldn't register clipboard format '%s'."
 msgstr "無法註冊剪貼簿格式「%s」。"
 
-#: ../src/msw/listctrl.cpp:939
+#: ../src/msw/listctrl.cpp:933
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "無法取得清單控制元件中細項 %d 的資訊。"
 
-#: ../src/common/imagpng.cpp:514 ../src/common/imagpng.cpp:525
-#: ../src/common/imagpng.cpp:535
+#: ../src/common/imagpng.cpp:511 ../src/common/imagpng.cpp:522
+#: ../src/common/imagpng.cpp:532
 msgid "Couldn't save PNG image."
 msgstr "無法儲存 PNG 圖像。"
 
-#: ../src/msw/thread.cpp:692
+#: ../src/msw/thread.cpp:676
 msgid "Couldn't terminate thread"
 msgstr "無法終止執行緒"
 
-#: ../src/common/xtistrm.cpp:166
+#: ../src/common/xtistrm.cpp:163
 #, c-format
 msgid "Create Parameter %s not found in declared RTTI Parameters"
 msgstr "宣告的 RTTI 參數中沒發現建立的參數 %s"
 
-#: ../src/generic/dirdlgg.cpp:288
+#: ../src/generic/dirdlgg.cpp:285
 msgid "Create directory"
 msgstr "建立目錄"
 
-#: ../src/generic/dirdlgg.cpp:111 ../src/generic/filedlgg.cpp:212
+#: ../src/generic/filedlgg.cpp:209 ../src/generic/dirdlgg.cpp:108
 msgid "Create new directory"
 msgstr "建立新目錄"
 
-#: ../src/common/stockitem.cpp:267
-#| msgid "Create new directory"
+#: ../src/common/stockitem.cpp:264
 msgid "Create new document"
 msgstr "建立新文件"
 
-#: ../src/xrc/xmlres.cpp:2518
+#: ../src/xrc/xmlres.cpp:2515
 #, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "無法建立 %s 「%s」。"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1662
+#: ../src/propgrid/advprops.cpp:1659
 msgid "Cross"
 msgstr "十字"
 
-#: ../src/common/accelcmn.cpp:350
+#: ../src/common/accelcmn.cpp:347
 msgid "Ctrl+"
 msgstr "Ctrl+"
 
-#: ../src/common/stockitem.cpp:151 ../src/msw/textctrl.cpp:2722
-#: ../src/osx/textctrl_osx.cpp:584 ../src/richtext/richtextctrl.cpp:334
+#: ../src/osx/textctrl_osx.cpp:594 ../src/common/stockitem.cpp:148
+#: ../src/msw/textctrl.cpp:2772 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "剪下(&T)"
 
-#: ../src/generic/filectrlg.cpp:940
+#: ../src/generic/filectrlg.cpp:936
 msgid "Current directory:"
 msgstr "目前目錄："
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:800 ../src/propgrid/advprops.cpp:1478
-#: ../src/propgrid/advprops.cpp:1521
+#: ../src/propgrid/advprops.cpp:797 ../src/propgrid/advprops.cpp:1475
+#: ../src/propgrid/advprops.cpp:1518
 msgid "Custom"
 msgstr "自訂"
 
-#: ../src/gtk/print.cpp:215
+#: ../src/gtk/print.cpp:211
 msgid "Custom size"
 msgstr "自訂大小"
 
-#: ../src/common/headerctrlcmn.cpp:61
+#: ../src/common/headerctrlcmn.cpp:58
 msgid "Customize Columns"
 msgstr "自訂欄位"
 
-#: ../src/common/stockitem.cpp:151 ../src/stc/stc_i18n.cpp:17
+#: ../src/common/stockitem.cpp:148 ../src/stc/stc_i18n.cpp:17
 msgid "Cut"
 msgstr "剪下"
 
-#: ../src/common/stockitem.cpp:259
+#: ../src/common/stockitem.cpp:256
 msgid "Cut selection"
 msgstr "剪下所選項目"
 
-#: ../src/common/fmapbase.cpp:152
+#: ../src/common/fmapbase.cpp:149
 msgid "Cyrillic (ISO-8859-5)"
 msgstr "斯拉夫語系 (ISO-8859-5)"
 
-#: ../src/common/paper.cpp:99
+#: ../src/common/paper.cpp:96
 msgid "D sheet, 22 x 34 in"
 msgstr "D 印刷紙，22 x 34 英吋"
 
-#: ../src/msw/dde.cpp:701
+#: ../src/msw/dde.cpp:698
 msgid "DDE poke request failed"
 msgstr "「動態資料交換」資料傳送請求失敗"
 
-#: ../src/common/imagbmp.cpp:1184
+#: ../src/common/imagbmp.cpp:1181
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr "DIB 標頭：編碼與顏色位元數不吻合。"
 
-#: ../src/common/imagbmp.cpp:1077
+#: ../src/common/imagbmp.cpp:1074
 msgid "DIB Header: Image height > 32767 pixels for file."
 msgstr "DIB 標頭：圖像高度大於 32767 個像素。"
 
-#: ../src/common/imagbmp.cpp:1069
+#: ../src/common/imagbmp.cpp:1066
 msgid "DIB Header: Image width > 32767 pixels for file."
 msgstr "DIB 標頭：圖像寬度大於 32767 個像素。"
 
-#: ../src/common/imagbmp.cpp:1097
+#: ../src/common/imagbmp.cpp:1094
 msgid "DIB Header: Unknown bitdepth in file."
 msgstr "DIB 標頭：不明的顏色位元數。"
 
-#: ../src/common/imagbmp.cpp:1152
+#: ../src/common/imagbmp.cpp:1149
 msgid "DIB Header: Unknown encoding in file."
 msgstr "DIB 標頭：不明的編碼型態。"
 
-#: ../src/common/paper.cpp:121
+#: ../src/common/paper.cpp:118
 msgid "DL Envelope, 110 x 220 mm"
 msgstr "DL 信封，110 x 220 公釐"
 
@@ -2587,53 +2589,53 @@ msgstr "DL 信封，110 x 220 公釐"
 msgid "Dashed"
 msgstr "虛線"
 
-#: ../src/generic/dbgrptg.cpp:304
+#: ../src/generic/dbgrptg.cpp:301
 #, c-format
 msgid "Debug report \"%s\""
 msgstr "除錯報告 \"%s\""
 
-#: ../src/common/debugrpt.cpp:214
+#: ../src/common/debugrpt.cpp:211
 msgid "Debug report couldn't be created."
 msgstr "無法建立除錯報告。"
 
-#: ../src/common/debugrpt.cpp:557
+#: ../src/common/debugrpt.cpp:554
 msgid "Debug report generation has failed."
 msgstr "無法產生除錯報告。"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:84
+#: ../src/common/accelcmn.cpp:81
 msgid "Decimal"
 msgstr "小數點"
 
-#: ../src/generic/fontdlgg.cpp:323
+#: ../src/generic/fontdlgg.cpp:319
 msgid "Decorative"
 msgstr "修飾"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1656
+#: ../src/propgrid/advprops.cpp:1653
 msgid "Default"
 msgstr "預設"
 
-#: ../src/common/fmapbase.cpp:796
+#: ../src/common/fmapbase.cpp:792
 msgid "Default encoding"
 msgstr "預設編碼"
 
-#: ../src/dfb/fontmgr.cpp:180
+#: ../src/dfb/fontmgr.cpp:177
 msgid "Default font"
 msgstr "預設字型"
 
-#: ../src/generic/prntdlgg.cpp:506
+#: ../src/generic/prntdlgg.cpp:503
 msgid "Default printer"
 msgstr "預設印表機"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:51
+#: ../src/common/accelcmn.cpp:48
 msgid "Del"
 msgstr "Del"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:50 ../src/common/stockitem.cpp:152
-#: ../src/richtext/richtextbuffer.cpp:8220 ../src/stc/stc_i18n.cpp:20
+#: ../src/common/stockitem.cpp:149 ../src/common/accelcmn.cpp:47
+#: ../src/richtext/richtextbuffer.cpp:8217 ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Del"
 
@@ -2641,80 +2643,79 @@ msgstr "Del"
 msgid "Delete A&ll"
 msgstr "全部刪除(&L)"
 
-#: ../src/richtext/richtextbuffer.cpp:11343
+#: ../src/richtext/richtextbuffer.cpp:11340
 msgid "Delete Column"
 msgstr "刪除欄位"
 
-#: ../src/richtext/richtextbuffer.cpp:11293
+#: ../src/richtext/richtextbuffer.cpp:11290
 msgid "Delete Row"
 msgstr "刪除橫列"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 msgid "Delete Style"
 msgstr "刪除樣式"
 
-#: ../src/richtext/richtextctrl.cpp:1349 ../src/richtext/richtextctrl.cpp:1588
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
 msgid "Delete Text"
 msgstr "刪除文字"
 
-#: ../src/generic/editlbox.cpp:150
+#: ../src/generic/editlbox.cpp:147
 msgid "Delete item"
 msgstr "刪除項目"
 
-#: ../src/common/stockitem.cpp:260
+#: ../src/common/stockitem.cpp:257
 msgid "Delete selection"
 msgstr "刪除所選項目"
 
-#: ../src/richtext/richtextstyledlg.cpp:782
+#: ../src/richtext/richtextstyledlg.cpp:778
 #, c-format
 msgid "Delete style %s?"
 msgstr "是否刪除樣式 %s？"
 
-#: ../src/unix/snglinst.cpp:301
+#: ../src/unix/snglinst.cpp:298
 #, c-format
 msgid "Deleted stale lock file '%s'."
 msgstr "已刪除過時的鎖定檔案「%s」。"
 
-#: ../src/common/secretstore.cpp:224
+#: ../src/common/secretstore.cpp:234
 #, c-format
-#| msgid "Deleting password for \"%s/%s\" failed: %s."
 msgid "Deleting password for \"%s\" failed: %s."
 msgstr "未能刪除「%s」的密碼：%s"
 
 # "相依性「%s」的模組「%s」不存在。"
-#: ../src/common/module.cpp:124
+#: ../src/common/module.cpp:121
 #, c-format
 msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
 msgstr "「%2$s」依存的「%1$s」模組不存在。"
 
-#: ../src/common/stockitem.cpp:196
+#: ../src/common/stockitem.cpp:193
 msgid "Descending"
 msgstr "遞減"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:526 ../src/propgrid/advprops.cpp:786
+#: ../src/generic/dirctrlg.cpp:492 ../src/propgrid/advprops.cpp:783
 msgid "Desktop"
 msgstr "桌面"
 
-#: ../src/generic/aboutdlgg.cpp:70
+#: ../src/generic/aboutdlgg.cpp:67
 msgid "Developed by "
 msgstr "開發者："
 
-#: ../src/generic/aboutdlgg.cpp:176
+#: ../src/generic/aboutdlgg.cpp:173
 msgid "Developers"
 msgstr "開發者"
 
-#: ../src/msw/dialup.cpp:373
+#: ../src/msw/dialup.cpp:368
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
 msgstr "由於沒有安裝遠端存取服務（RAS），撥號功能無法使用。請先安裝。"
 
-#: ../src/generic/tipdlg.cpp:211
+#: ../src/generic/tipdlg.cpp:208
 msgid "Did you know..."
 msgstr "您知道嗎…"
 
-#: ../src/dfb/wrapdfb.cpp:63
+#: ../src/dfb/wrapdfb.cpp:60
 #, c-format
 msgid "DirectFB error %d occurred."
 msgstr "發生 DirectFB %d 錯誤。"
@@ -2723,73 +2724,73 @@ msgstr "發生 DirectFB %d 錯誤。"
 msgid "Directories"
 msgstr "目錄"
 
-#: ../src/common/filefn.cpp:1184
+#: ../src/common/filefn.cpp:1071
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "無法建立「%s」目錄"
 
-#: ../src/common/filefn.cpp:1198
+#: ../src/common/filefn.cpp:1085
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "無法刪除「%s」目錄"
 
-#: ../src/generic/dirdlgg.cpp:204
+#: ../src/generic/dirdlgg.cpp:201
 msgid "Directory does not exist"
 msgstr "目錄不存在"
 
-#: ../src/generic/filectrlg.cpp:1399
+#: ../src/generic/filectrlg.cpp:1388
 msgid "Directory doesn't exist."
 msgstr "目錄不存在。"
 
-#: ../src/common/docview.cpp:453
+#: ../src/common/docview.cpp:450
 msgid "Discard changes and reload the last saved version?"
 msgstr "是否捨棄變更，並重新載入最後一次儲存的版本？"
 
-#: ../src/html/helpwnd.cpp:503
+#: ../src/html/helpwnd.cpp:500
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
 msgstr "顯示包含該字串的所有索引項目。搜尋不區分大小寫。"
 
-#: ../src/html/helpwnd.cpp:680
+#: ../src/html/helpwnd.cpp:677
 msgid "Display options dialog"
 msgstr "顯示選項對話方塊"
 
-#: ../src/html/helpwnd.cpp:323
+#: ../src/html/helpwnd.cpp:320
 msgid "Displays help as you browse the books on the left."
 msgstr "當瀏覽書籍時，於左側顯示說明。"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:86
+#: ../src/common/accelcmn.cpp:83
 msgid "Divide"
 msgstr "/"
 
-#: ../src/common/docview.cpp:529
+#: ../src/common/docview.cpp:526
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "是否儲存對於 %s 的修改？"
 
-#: ../src/common/prntbase.cpp:542
+#: ../src/common/prntbase.cpp:537
 msgid "Document:"
 msgstr "文件："
 
-#: ../src/generic/aboutdlgg.cpp:73
+#: ../src/generic/aboutdlgg.cpp:70
 msgid "Documentation by "
 msgstr "文件撰寫者："
 
-#: ../src/generic/aboutdlgg.cpp:180
+#: ../src/generic/aboutdlgg.cpp:177
 msgid "Documentation writers"
 msgstr "文件撰寫者"
 
-#: ../src/common/sizer.cpp:2846
+#: ../src/common/sizer.cpp:2916
 msgid "Don't Save"
 msgstr "不儲存"
 
-#: ../src/html/htmlwin.cpp:639
+#: ../src/html/htmlwin.cpp:643
 msgid "Done"
 msgstr "完成"
 
-#: ../src/generic/progdlgg.cpp:457 ../src/msw/progdlg.cpp:538
+#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
 msgid "Done."
 msgstr "完成。"
 
@@ -2801,38 +2802,38 @@ msgstr "點線"
 msgid "Double"
 msgstr "雙線"
 
-#: ../src/common/paper.cpp:176
+#: ../src/common/paper.cpp:173
 msgid "Double Japanese Postcard Rotated 148 x 200 mm"
 msgstr "雙倍日式明信片(轉向) 148 x 200 mm"
 
-#: ../src/common/xtixml.cpp:273
+#: ../src/common/xtixml.cpp:269
 #, c-format
 msgid "Doubly used id : %d"
 msgstr "id 重複：%d"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:64 ../src/common/stockitem.cpp:153
-#: ../src/generic/fdrepdlg.cpp:152
+#: ../src/common/stockitem.cpp:150 ../src/common/accelcmn.cpp:61
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Down"
 msgstr "下"
 
-#: ../src/richtext/richtextctrl.cpp:867
+#: ../src/richtext/richtextctrl.cpp:864
 msgid "Drag"
 msgstr "拖曳"
 
-#: ../src/common/paper.cpp:100
+#: ../src/common/paper.cpp:97
 msgid "E sheet, 34 x 44 in"
 msgstr "E 紙張, 34 x 44 英吋"
 
-#: ../src/unix/fswatcher_inotify.cpp:561
+#: ../src/unix/fswatcher_inotify.cpp:558
 msgid "EOF while reading from inotify descriptor"
 msgstr "讀取 inotify 描述子時遇到檔案結尾"
 
-#: ../src/common/stockitem.cpp:154
+#: ../src/common/stockitem.cpp:151
 msgid "Edit"
 msgstr "編輯"
 
-#: ../src/generic/editlbox.cpp:134
+#: ../src/generic/editlbox.cpp:131
 msgid "Edit item"
 msgstr "編輯項目"
 
@@ -2903,61 +2904,61 @@ msgid "Enables the shadow spread."
 msgstr "啟用陰影擴散。"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:66
+#: ../src/common/accelcmn.cpp:63
 msgid "End"
 msgstr "End"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:55
+#: ../src/common/accelcmn.cpp:52
 msgid "Enter"
 msgstr "Enter"
 
-#: ../src/richtext/richtextstyledlg.cpp:934
+#: ../src/richtext/richtextstyledlg.cpp:930
 msgid "Enter a box style name"
 msgstr "輸入文字方塊樣式名稱"
 
-#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:602
 msgid "Enter a character style name"
 msgstr "輸入字元樣式名稱"
 
-#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:816
 msgid "Enter a list style name"
 msgstr "輸入清單樣式名稱"
 
-#: ../src/richtext/richtextstyledlg.cpp:893
+#: ../src/richtext/richtextstyledlg.cpp:889
 msgid "Enter a new style name"
 msgstr "輸入新的樣式名稱"
 
-#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:650
 msgid "Enter a paragraph style name"
 msgstr "輸入段落樣式名稱"
 
-#: ../src/generic/dbgrptg.cpp:174
+#: ../src/generic/dbgrptg.cpp:171
 #, c-format
 msgid "Enter command to open file \"%s\":"
 msgstr "輸入指令以開啟「%s」檔案:"
 
-#: ../src/generic/helpext.cpp:460
+#: ../src/generic/helpext.cpp:457
 msgid "Entries found"
 msgstr "找到的項目"
 
-#: ../src/common/paper.cpp:142
+#: ../src/common/paper.cpp:139
 msgid "Envelope Invite 220 x 220 mm"
 msgstr "邀請信封 220 x 220 公釐"
 
-#: ../src/common/config.cpp:469
+#: ../src/common/config.cpp:465
 #, c-format
 msgid ""
 "Environment variables expansion failed: missing '%c' at position %u in '%s'."
 msgstr "環境變數擴充失敗:  '%c' 沒有出現在位置 %u / '%s'。"
 
-#: ../src/generic/dirctrlg.cpp:570 ../src/generic/dirctrlg.cpp:588
-#: ../src/generic/dirctrlg.cpp:599 ../src/generic/dirdlgg.cpp:323
-#: ../src/generic/filectrlg.cpp:642 ../src/generic/filectrlg.cpp:756
-#: ../src/generic/filectrlg.cpp:770 ../src/generic/filectrlg.cpp:786
-#: ../src/generic/filectrlg.cpp:1368 ../src/generic/filectrlg.cpp:1399
-#: ../src/generic/filedlgg.cpp:357 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/gtk1/fontdlg.cpp:74 ../src/generic/dirctrlg.cpp:536
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/dirctrlg.cpp:565
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1357 ../src/generic/filectrlg.cpp:1388
+#: ../src/generic/filedlgg.cpp:354 ../src/generic/dirdlgg.cpp:320
+#: ../src/gtk/filedlg.cpp:74
 msgid "Error"
 msgstr "錯誤"
 
@@ -2965,60 +2966,66 @@ msgstr "錯誤"
 msgid "Error closing epoll descriptor"
 msgstr "關閉 epoll 描述子時發生錯誤"
 
-#: ../src/unix/fswatcher_kqueue.cpp:134
+#: ../src/unix/fswatcher_kqueue.cpp:131
 msgid "Error closing kqueue instance"
 msgstr "關閉 kqueue 實體時發生錯誤"
 
-#: ../src/common/filefn.cpp:1050
+#: ../src/common/filefn.cpp:938
 #, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "將「%s」檔案複製到「%s」時出錯"
 
-#: ../src/generic/dirdlgg.cpp:222
+#: ../src/generic/dirdlgg.cpp:219
 msgid "Error creating directory"
 msgstr "建立目錄錯誤"
 
-#: ../src/common/imagbmp.cpp:1196
+#: ../src/common/imagbmp.cpp:1193
 msgid "Error in reading image DIB."
 msgstr "讀取圖像 DIB 時發生錯誤。"
 
-#: ../src/propgrid/propgrid.cpp:6628
+#: ../src/propgrid/propgrid.cpp:6665
 #, c-format
 msgid "Error in resource: %s"
 msgstr "資源錯誤：%s"
 
-#: ../src/common/fileconf.cpp:426
+#: ../src/common/fileconf.cpp:421
 msgid "Error reading config options."
 msgstr "讀取設定選項時發生錯誤。"
 
-#: ../src/gtk/webview_webkit2.cpp:1237 ../src/msw/webview_ie.cpp:972
+#: ../src/msw/webview_ie.cpp:1057 ../src/msw/webview_edge.cpp:850
+#: ../src/gtk/webview_webkit2.cpp:1262 ../src/osx/webview_webkit.mm:383
 #, c-format
 msgid "Error running JavaScript: %s"
 msgstr "執行 JavaScript 時發生錯誤：%s"
 
-#: ../src/common/fileconf.cpp:1034
+#: ../src/common/fileconf.cpp:1029
 msgid "Error saving user configuration data."
 msgstr "儲存使用者配置資料錯誤。"
 
-#: ../src/gtk/print.cpp:724
+#: ../src/gtk/print.cpp:720
 msgid "Error while printing: "
 msgstr "列印時發生錯誤: "
 
-#: ../src/common/log.cpp:219
+#: ../src/common/log.cpp:237
 msgid "Error: "
 msgstr "錯誤："
 
+#: ../src/common/webrequest.cpp:98
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "錯誤："
+
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:69
+#: ../src/common/accelcmn.cpp:66
 msgid "Esc"
 msgstr "Esc"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:70
+#: ../src/common/accelcmn.cpp:67
 msgid "Escape"
 msgstr "Esc"
 
-#: ../src/common/fmapbase.cpp:150
+#: ../src/common/fmapbase.cpp:147
 msgid "Esperanto (ISO-8859-3)"
 msgstr "世界語 (ISO-8859-3)"
 
@@ -3026,60 +3033,59 @@ msgstr "世界語 (ISO-8859-3)"
 msgid "Estimated time:"
 msgstr "估計時間："
 
-#: ../src/generic/dbgrptg.cpp:234
+#: ../src/generic/dbgrptg.cpp:231
 msgid "Executable files (*.exe)|*.exe|"
 msgstr "可執行檔 (*.exe)|*.exe|"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:78 ../src/common/stockitem.cpp:155
+#: ../src/common/stockitem.cpp:152 ../src/common/accelcmn.cpp:75
 msgid "Execute"
 msgstr "執行"
 
-#: ../src/msw/utilsexc.cpp:876
+#: ../src/msw/utilsexc.cpp:873
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "「%s」指令執行失敗"
 
-#: ../src/common/paper.cpp:105
+#: ../src/common/paper.cpp:102
 msgid "Executive, 7 1/4 x 10 1/2 in"
 msgstr "Executive, 7 1/4 x 10 1/2 英吋"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6457
+#: ../src/generic/datavgen.cpp:6814
 msgid "Expand"
 msgstr "展開"
 
-#: ../src/msw/registry.cpp:1239
+#: ../src/msw/registry.cpp:1228
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
 msgstr "匯出註冊鍵: 已有「%s」檔案，無法覆寫。"
 
-#: ../src/common/fmapbase.cpp:195
+#: ../src/common/fmapbase.cpp:192
 msgid "Extended Unix Codepage for Japanese (EUC-JP)"
 msgstr "延伸的 Unix 日文頁碼 (EUC-JP)"
 
-#: ../src/html/chm.cpp:725
+#: ../src/html/chm.cpp:718
 #, c-format
 msgid "Extraction of '%s' into '%s' failed."
 msgstr "無法將「%s」解開至「%s」。"
 
-#: ../src/common/accelcmn.cpp:262 ../src/common/accelcmn.cpp:361
+#: ../src/common/accelcmn.cpp:259 ../src/common/accelcmn.cpp:358
 msgid "F"
 msgstr "F"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:585
+#: ../src/propgrid/advprops.cpp:582
 msgid "Face Name"
 msgstr "字體名稱"
 
-#: ../src/unix/snglinst.cpp:269
+#: ../src/unix/snglinst.cpp:266
 msgid "Failed to access lock file."
 msgstr "無法存取鎖定檔。"
 
 #: ../src/gtk/font.cpp:572
 #, c-format
-#| msgid "Failed to read document from the file \"%s\"."
 msgid "Failed to add custom font \"%s\"."
 msgstr "無法加入「%s」自訂字型。"
 
@@ -3088,22 +3094,20 @@ msgstr "無法加入「%s」自訂字型。"
 msgid "Failed to add descriptor %d to epoll descriptor %d"
 msgstr "無法加入描述子 %d 至 epoll 描述子 %d"
 
-#: ../src/msw/dib.cpp:489
+#: ../src/msw/dib.cpp:535
 #, c-format
 msgid "Failed to allocate %luKb of memory for bitmap data."
 msgstr "無法為點陣圖資料配置 %luKb 的記憶體。"
 
-#: ../src/common/glcmn.cpp:115
+#: ../src/common/glcmn.cpp:112
 msgid "Failed to allocate colour for OpenGL"
 msgstr "無法為 OpenGL 分配顏色"
 
-#: ../src/common/lzmastream.cpp:234
-#| msgid "Failed to allocate colour for OpenGL"
+#: ../src/common/lzmastream.cpp:231
 msgid "Failed to allocate memory for LZMA compression."
 msgstr "無法配置供 LZMA 壓縮的記憶體。"
 
-#: ../src/common/lzmastream.cpp:124
-#| msgid "Failed to allocate colour for OpenGL"
+#: ../src/common/lzmastream.cpp:121
 msgid "Failed to allocate memory for LZMA decompression."
 msgstr "無法配置供 LZMA 解壓縮的記憶體。"
 
@@ -3111,102 +3115,102 @@ msgstr "無法配置供 LZMA 解壓縮的記憶體。"
 msgid "Failed to change video mode"
 msgstr "變更顯示模式失敗"
 
-#: ../src/common/image.cpp:3311
+#: ../src/common/image.cpp:3396
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "無法確認圖片檔「%s」的格式。"
 
-#: ../src/common/debugrpt.cpp:243
+#: ../src/common/debugrpt.cpp:240
 #, c-format
 msgid "Failed to clean up debug report directory \"%s\""
 msgstr "無法清理除錯報告目錄「%s」"
 
-#: ../src/common/filename.cpp:193
+#: ../src/common/filename.cpp:189
 msgid "Failed to close file handle"
 msgstr "無法關閉檔案處理常式"
 
-#: ../src/unix/snglinst.cpp:340
+#: ../src/unix/snglinst.cpp:337
 #, c-format
 msgid "Failed to close lock file '%s'"
 msgstr "無法關閉鎖定檔案「%s」"
 
-#: ../src/msw/clipbrd.cpp:112
+#: ../src/msw/clipbrd.cpp:110
 msgid "Failed to close the clipboard."
 msgstr "無法關閉剪貼簿。"
 
-#: ../src/x11/utils.cpp:173
+#: ../src/x11/utils.cpp:170
 #, c-format
 msgid "Failed to close the display \"%s\""
 msgstr "關閉「%s」顯示器時失敗"
 
-#: ../src/msw/dialup.cpp:796
+#: ../src/msw/dialup.cpp:791
 msgid "Failed to connect: missing username/password."
 msgstr "連線失敗：缺少使用者名稱或密碼。"
 
-#: ../src/msw/dialup.cpp:742
+#: ../src/msw/dialup.cpp:737
 msgid "Failed to connect: no ISP to dial."
 msgstr "連線失敗：沒有可撥號的 ISP。"
 
-#: ../src/generic/logg.cpp:956
+#: ../src/generic/logg.cpp:953
 msgid "Failed to copy dialog contents to the clipboard."
 msgstr "無法複製對話視窗內容至剪貼簿。"
 
-#: ../src/msw/registry.cpp:692
+#: ../src/msw/registry.cpp:681
 #, c-format
 msgid "Failed to copy registry value '%s'"
 msgstr "無法複製登錄機值 '%s'"
 
-#: ../src/msw/registry.cpp:701
+#: ../src/msw/registry.cpp:690
 #, c-format
 msgid "Failed to copy the contents of registry key '%s' to '%s'."
 msgstr "無法複製登錄機碼 '%s' 的內容到 '%s'。"
 
-#: ../src/common/filefn.cpp:1016
+#: ../src/common/filefn.cpp:904
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "無法複製「%s」檔案到「%s」"
 
-#: ../src/msw/registry.cpp:679
+#: ../src/msw/registry.cpp:668
 #, c-format
 msgid "Failed to copy the registry subkey '%s' to '%s'."
 msgstr "複製註冊表子鍵 '%s'至 '%s'失敗。"
 
-#: ../src/msw/dde.cpp:1137
+#: ../src/msw/dde.cpp:1134
 msgid "Failed to create DDE string"
 msgstr "無法建立「動態資料交換」字串"
 
-#: ../src/msw/mdi.cpp:620
+#: ../src/msw/mdi.cpp:621
 msgid "Failed to create MDI parent frame."
 msgstr "無法建立 MDI 主框架。"
 
-#: ../src/common/filename.cpp:1028
+#: ../src/common/filename.cpp:1024
 msgid "Failed to create a temporary file name"
 msgstr "無法產生暫存檔的檔名"
 
-#: ../src/msw/utilsexc.cpp:228
+#: ../src/msw/utilsexc.cpp:225
 msgid "Failed to create an anonymous pipe"
 msgstr "無法建立匿名管道"
 
-#: ../src/msw/ole/automtn.cpp:522
+#: ../src/msw/ole/automtn.cpp:513
 #, c-format
 msgid "Failed to create an instance of \"%s\""
 msgstr "建立「%s」的執行實體時失敗"
 
-#: ../src/msw/dde.cpp:435
+#: ../src/msw/dde.cpp:432
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "無法建立連線到「%s」伺服器的「%s」主旨"
 
-#: ../src/msw/cursor.cpp:196
+#: ../src/msw/cursor.cpp:195
 msgid "Failed to create cursor."
 msgstr "無法建立游標。"
 
-#: ../src/common/debugrpt.cpp:213
+#: ../src/common/debugrpt.cpp:210
 #, c-format
 msgid "Failed to create directory \"%s\""
 msgstr "無法建立「%s」目錄"
 
-#: ../src/generic/dirdlgg.cpp:220
+#: ../src/generic/dirdlgg.cpp:217
 #, c-format
 msgid ""
 "Failed to create directory '%s'\n"
@@ -3220,30 +3224,29 @@ msgid "Failed to create epoll descriptor"
 msgstr "無法建立 epoll 描述子"
 
 #: ../src/gtk/font.cpp:562
-#| msgid "Failed to update user configuration file."
 msgid "Failed to create font configuration object."
 msgstr "無法建立字型設定物件。"
 
-#: ../src/msw/mimetype.cpp:238
+#: ../src/msw/mimetype.cpp:235
 #, c-format
 msgid "Failed to create registry entry for '%s' files."
 msgstr "無法為「%s」檔案建立登錄項目。"
 
-#: ../src/msw/fdrepdlg.cpp:409
+#: ../src/msw/fdrepdlg.cpp:408
 #, c-format
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr "無法建立標準的「尋找/取代」對話窗 (錯誤碼 %d)"
 
-#: ../src/unix/wakeuppipe.cpp:52
+#: ../src/unix/wakeuppipe.cpp:49
 msgid "Failed to create wake up pipe used by event loop."
 msgstr "建立事件迴圈所用的喚醒管線時失敗。"
 
-#: ../src/html/winpars.cpp:730
+#: ../src/html/winpars.cpp:727
 #, c-format
 msgid "Failed to display HTML document in %s encoding"
 msgstr "無法以 %s 編碼顯示 HTML 文件"
 
-#: ../src/msw/clipbrd.cpp:124
+#: ../src/msw/clipbrd.cpp:122
 msgid "Failed to empty the clipboard."
 msgstr "無法清空剪貼簿。"
 
@@ -3251,156 +3254,156 @@ msgstr "無法清空剪貼簿。"
 msgid "Failed to enumerate video modes"
 msgstr "無法列舉顯示模式"
 
-#: ../src/msw/dde.cpp:720
+#: ../src/msw/dde.cpp:717
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "無法建立與「動態資料交換」伺服器溝通的連結"
 
-#: ../src/msw/dialup.cpp:628 ../src/msw/dialup.cpp:862
+#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "無法建立撥號連線：%s"
 
-#: ../src/unix/utilsunx.cpp:616
+#: ../src/unix/utilsunx.cpp:613
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "無法執行「%s」\n"
 
-#: ../src/common/debugrpt.cpp:733
+#: ../src/common/debugrpt.cpp:730
 msgid "Failed to execute curl, please install it in PATH."
 msgstr "無法執行 curl，請在 PATH 變數所指的目錄安裝 curl。"
 
-#: ../src/msw/ole/automtn.cpp:505
+#: ../src/msw/ole/automtn.cpp:496
 #, c-format
 msgid "Failed to find CLSID of \"%s\""
 msgstr "找不到「%s」的 CLSID"
 
-#: ../src/common/regex.cpp:431 ../src/common/regex.cpp:479
+#: ../src/common/regex.cpp:428 ../src/common/regex.cpp:476
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "找不到與正規運算式 '%s' 相符的字串"
 
-#: ../src/msw/webview_ie.cpp:893
+#: ../src/msw/webview_ie.cpp:978
 msgid "Failed to find web view emulation level in the registry"
 msgstr "無法在登錄檔尋找網頁檢視模擬等級"
 
-#: ../src/msw/dialup.cpp:694
+#: ../src/msw/dialup.cpp:689
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "無法取得 ISP 名稱：%s"
 
-#: ../src/msw/ole/automtn.cpp:574
+#: ../src/msw/ole/automtn.cpp:565
 #, c-format
 msgid "Failed to get OLE automation interface for \"%s\""
 msgstr "取得「%s」的 OLE 自動作業介面時失敗"
 
-#: ../src/msw/clipbrd.cpp:711
+#: ../src/msw/clipbrd.cpp:731
 msgid "Failed to get data from the clipboard"
 msgstr "無法從剪貼簿取得資料"
 
-#: ../src/common/time.cpp:226
+#: ../src/common/time.cpp:216
 msgid "Failed to get the local system time"
 msgstr "無法取得本機電腦的時間"
 
-#: ../src/common/filefn.cpp:1346
+#: ../src/common/filefn.cpp:1233
 msgid "Failed to get the working directory"
 msgstr "無法取得工作目錄"
 
-#: ../src/univ/theme.cpp:114
+#: ../src/univ/theme.cpp:111
 msgid "Failed to initialize GUI: no built-in themes found."
 msgstr "無法初始化圖形使用者介面：沒有找到內建的布景主題。"
 
-#: ../src/common/lzmastream.cpp:238
+#: ../src/common/lzmastream.cpp:235
 #, c-format
 msgid "Failed to initialize LZMA compression: unexpected error %u."
 msgstr "無法初始化 LZMA 壓縮：未預期的錯誤 %u。"
 
-#: ../src/common/lzmastream.cpp:128
+#: ../src/common/lzmastream.cpp:125
 #, c-format
 msgid "Failed to initialize LZMA decompression: unexpected error %u."
 msgstr "無法初始化 LZMA 解壓縮：未預期的錯誤 %u。"
 
-#: ../src/msw/helpchm.cpp:63
+#: ../src/msw/helpchm.cpp:60
 msgid "Failed to initialize MS HTML Help."
 msgstr "無法初始化 MS HTML Help。"
 
-#: ../src/msw/glcanvas.cpp:1394
+#: ../src/msw/glcanvas.cpp:1391
 msgid "Failed to initialize OpenGL"
 msgstr "無法初始化 OpenGL"
 
-#: ../src/msw/dialup.cpp:857
+#: ../src/msw/dialup.cpp:852
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "無法初始撥號連線：%s"
 
-#: ../src/gtk/textctrl.cpp:1150
+#: ../src/gtk/textctrl.cpp:1209
 msgid "Failed to insert text in the control."
 msgstr "無法於控制項插入文字"
 
-#: ../src/unix/snglinst.cpp:241
+#: ../src/unix/snglinst.cpp:238
 #, c-format
 msgid "Failed to inspect the lock file '%s'"
 msgstr "檢查上鎖檔案 '%s'失敗"
 
-#: ../src/unix/appunix.cpp:182
+#: ../src/unix/appunix.cpp:179
 msgid "Failed to install signal handler"
 msgstr "無法安裝信號處理函式"
 
-#: ../src/unix/threadpsx.cpp:1192
+#: ../src/unix/threadpsx.cpp:1216
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
 msgstr "無法停止執行緒，偵測到潛在的記憶體流失 - 請重新啟動程式"
 
-#: ../src/msw/utils.cpp:629
+#: ../src/msw/utils.cpp:619
 #, c-format
 msgid "Failed to kill process %d"
 msgstr "無法刪除程序 %d"
 
-#: ../src/common/image.cpp:2510
+#: ../src/common/image.cpp:2595
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "無法從資源載入「%s」位元圖。"
 
-#: ../src/common/image.cpp:2519
+#: ../src/common/image.cpp:2604
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "無法從資源載入「%s」圖示。"
 
-#: ../src/common/iconbndl.cpp:227
+#: ../src/common/iconbndl.cpp:224
 #, c-format
 msgid "Failed to load icons from resource '%s'."
 msgstr "無法從「%s」資源載入圖示。"
 
-#: ../src/common/iconbndl.cpp:201
+#: ../src/common/iconbndl.cpp:198
 #, c-format
 msgid "Failed to load image %%d from file '%s'."
 msgstr "無法載入 %%d 圖像自「%s」檔案。"
 
-#: ../src/common/iconbndl.cpp:209
+#: ../src/common/iconbndl.cpp:206
 #, c-format
 msgid "Failed to load image %d from stream."
 msgstr "無法從串流載入 %d 圖像。"
 
-#: ../src/common/image.cpp:2597 ../src/common/image.cpp:2616
+#: ../src/common/image.cpp:2682 ../src/common/image.cpp:2701
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "無法從「%s」檔案載入影像。"
 
-#: ../src/msw/enhmeta.cpp:97
+#: ../src/msw/enhmeta.cpp:94
 #, c-format
 msgid "Failed to load metafile from file \"%s\"."
 msgstr "從「%s」檔案讀取中繼檔案失敗。"
 
-#: ../src/msw/volume.cpp:338
+#: ../src/msw/volume.cpp:335
 msgid "Failed to load mpr.dll."
 msgstr "無法載入 mpr.dll。"
 
-#: ../src/msw/utils.cpp:953
+#: ../src/msw/utils.cpp:943
 #, c-format
 msgid "Failed to load resource \"%s\"."
 msgstr "無法載入「%s」資源。"
 
-#: ../src/common/dynlib.cpp:92
+#: ../src/common/dynlib.cpp:86
 #, c-format
 msgid "Failed to load shared library '%s'"
 msgstr "無法載入「%s」共享函式庫"
@@ -3410,12 +3413,12 @@ msgstr "無法載入「%s」共享函式庫"
 msgid "Failed to load sound from \"%s\" (error %d)."
 msgstr "無法從「%s」載入聲音 (錯誤 %d)。"
 
-#: ../src/msw/utils.cpp:960
+#: ../src/msw/utils.cpp:950
 #, c-format
 msgid "Failed to lock resource \"%s\"."
 msgstr "無法鎖定「%s」資源。"
 
-#: ../src/unix/snglinst.cpp:198
+#: ../src/unix/snglinst.cpp:195
 #, c-format
 msgid "Failed to lock the lock file '%s'"
 msgstr "無法鎖定「%s」鎖定檔案"
@@ -3425,38 +3428,37 @@ msgstr "無法鎖定「%s」鎖定檔案"
 msgid "Failed to modify descriptor %d in epoll descriptor %d"
 msgstr "無法修改描述子 %d (於 epoll 描述子 %d)"
 
-#: ../src/common/filename.cpp:2659
+#: ../src/common/filename.cpp:2658
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "無法變更「%s」檔案的日期"
 
-#: ../src/common/selectdispatcher.cpp:258
+#: ../src/common/selectdispatcher.cpp:255
 msgid "Failed to monitor I/O channels"
 msgstr "監視輸入輸出頻道時失敗"
 
-#: ../src/common/filename.cpp:176
+#: ../src/common/filename.cpp:172
 #, c-format
 msgid "Failed to open '%s' for reading"
 msgstr "無法開啟「%s」為讀取模式"
 
-#: ../src/common/filename.cpp:181
+#: ../src/common/filename.cpp:177
 #, c-format
 msgid "Failed to open '%s' for writing"
 msgstr "無法開啟「%s」為寫入模式"
 
-#: ../src/html/chm.cpp:141
+#: ../src/html/chm.cpp:138
 #, c-format
 msgid "Failed to open CHM archive '%s'."
 msgstr "無法開啟「%s」CHM 檔。"
 
-#: ../src/common/utilscmn.cpp:1143
+#: ../src/common/utilscmn.cpp:1140
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
 msgstr "無法在預設瀏覽器中開啟網址「%s」。"
 
-#: ../src/common/hyperlnkcmn.cpp:136
+#: ../src/common/hyperlnkcmn.cpp:133
 #, c-format
-#| msgid "Failed to open URL \"%s\" in default browser."
 msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "無法在預設瀏覽器中開啟網址「%s」"
 
@@ -3466,42 +3468,42 @@ msgstr "無法在預設瀏覽器中開啟網址「%s」"
 msgid "Failed to open directory \"%s\" for monitoring."
 msgstr "無法建立監看「%s」目錄"
 
-#: ../src/x11/utils.cpp:192
+#: ../src/x11/utils.cpp:189
 #, c-format
 msgid "Failed to open display \"%s\"."
 msgstr "無法開啟顯示「%s」。"
 
-#: ../src/common/filename.cpp:1063
+#: ../src/common/filename.cpp:1059
 msgid "Failed to open temporary file."
 msgstr "無法開啟暫存檔。"
 
-#: ../src/msw/clipbrd.cpp:91
+#: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "無法開啟剪貼簿。"
 
-#: ../src/common/translation.cpp:1228
+#: ../src/common/translation.cpp:1226
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "無法解析眾數型式(Plural-Forms)：「%s」"
 
-#: ../src/unix/mediactrl.cpp:1220
+#: ../src/unix/mediactrl.cpp:1239
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "無法準備播放「%s」。"
 
-#: ../src/msw/clipbrd.cpp:600
+#: ../src/msw/clipbrd.cpp:610
 msgid "Failed to put data on the clipboard"
 msgstr "無法存放資料到剪貼簿"
 
-#: ../src/unix/snglinst.cpp:278
+#: ../src/unix/snglinst.cpp:275
 msgid "Failed to read PID from lock file."
 msgstr "無法從鎖定的檔案讀出「程序識別碼(PID)」。"
 
-#: ../src/common/fileconf.cpp:437
+#: ../src/common/fileconf.cpp:432
 msgid "Failed to read config options."
 msgstr "無法讀取設定選項。"
 
-#: ../src/common/docview.cpp:679
+#: ../src/common/docview.cpp:676
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "無法從「%s」檔案讀取文件。"
@@ -3510,143 +3512,141 @@ msgstr "無法從「%s」檔案讀取文件。"
 msgid "Failed to read event from DirectFB pipe"
 msgstr "無法從 DirectFB 管線讀取事件"
 
-#: ../src/unix/wakeuppipe.cpp:120
+#: ../src/unix/wakeuppipe.cpp:117
 msgid "Failed to read from wake-up pipe"
 msgstr "無法從喚醒管線讀取"
 
-#: ../src/common/textfile.cpp:99
+#: ../src/common/textfile.cpp:96
 #, c-format
-#| msgid "Failed to read document from the file \"%s\"."
 msgid "Failed to read text file \"%s\"."
 msgstr "無法讀取「%s」文字檔案。"
 
-#: ../src/unix/utilsunx.cpp:684
+#: ../src/unix/utilsunx.cpp:681
 msgid "Failed to redirect child process input/output"
 msgstr "無法轉向子程序的「輸入/輸出」"
 
-#: ../src/msw/utilsexc.cpp:701
+#: ../src/msw/utilsexc.cpp:698
 msgid "Failed to redirect the child process IO"
 msgstr "無法轉向子程序的「輸入/輸出」"
 
-#: ../src/msw/dde.cpp:286
+#: ../src/msw/dde.cpp:283
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "無法註冊「動態資料交換(DDE)」伺服器「%s」"
 
 #: ../src/gtk/font.cpp:580
-#| msgid "Failed to update user configuration file."
 msgid "Failed to register font configuration using private fonts."
 msgstr "無法使用私人字型註冊字型設定。"
 
-#: ../src/common/fontmap.cpp:245
+#: ../src/common/fontmap.cpp:242
 #, c-format
 msgid "Failed to remember the encoding for the charset '%s'."
 msgstr "無法記憶字集「%s」的編碼。"
 
-#: ../src/common/debugrpt.cpp:231
+#: ../src/common/debugrpt.cpp:228
 #, c-format
 msgid "Failed to remove debug report file \"%s\""
 msgstr "無法移除除錯報告檔案「%s」"
 
-#: ../src/unix/snglinst.cpp:328
+#: ../src/unix/snglinst.cpp:325
 #, c-format
 msgid "Failed to remove lock file '%s'"
 msgstr "無法移除鎖定檔案「%s」"
 
-#: ../src/unix/snglinst.cpp:288
+#: ../src/unix/snglinst.cpp:285
 #, c-format
 msgid "Failed to remove stale lock file '%s'."
 msgstr "無法移除過時的鎖定檔案「%s」。"
 
-#: ../src/msw/registry.cpp:529
+#: ../src/msw/registry.cpp:518
 #, c-format
 msgid "Failed to rename registry value '%s' to '%s'."
 msgstr "無法將登錄值 '%s' 更名為 '%s'。"
 
-#: ../src/common/filefn.cpp:1123
+#: ../src/common/filefn.cpp:1011
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
 "exists."
 msgstr "目的檔案已存在，故無法將檔案「%s」重新命名為「%s」。"
 
-#: ../src/msw/registry.cpp:634
+#: ../src/msw/registry.cpp:623
 #, c-format
 msgid "Failed to rename the registry key '%s' to '%s'."
 msgstr "無法將登錄機碼 '%s' 更名為 '%s'。"
 
-#: ../src/msw/webview_ie.cpp:910
+#: ../src/msw/webview_ie.cpp:995
 msgid "Failed to reset web view to standard emulation level"
 msgstr "無法重設網頁檢視至標準模擬等級"
 
-#: ../src/common/filename.cpp:2755
+#: ../src/common/filename.cpp:2754
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "無法取得「%s」檔案的各項時間"
 
-#: ../src/msw/dialup.cpp:467
+#: ../src/msw/dialup.cpp:462
 msgid "Failed to retrieve text of RAS error message"
 msgstr "無法取得 RAS 錯誤訊息的對應文字"
 
-#: ../src/msw/clipbrd.cpp:748
+#: ../src/msw/clipbrd.cpp:768
 msgid "Failed to retrieve the supported clipboard formats"
 msgstr "無法取得支援的剪貼簿格式"
 
-#: ../src/common/docview.cpp:650
+#: ../src/common/docview.cpp:647
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "無法將文件儲存至「%s」檔案。"
 
-#: ../src/msw/dib.cpp:269
+#: ../src/msw/dib.cpp:312
 #, c-format
 msgid "Failed to save the bitmap image to file \"%s\"."
 msgstr "無法將點陣圖儲存至「%s」檔案。"
 
-#: ../src/msw/dde.cpp:814
+#: ../src/msw/dde.cpp:811
 msgid "Failed to send DDE advise notification"
 msgstr "無法傳送「動態資料交換(DDE)」連結通知訊息"
 
-#: ../src/common/ftp.cpp:402
+#: ../src/common/ftp.cpp:399
 #, c-format
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "無法設定檔案傳輸(FTP)模式為 %s。"
 
-#: ../src/msw/clipbrd.cpp:427
+#: ../src/msw/clipbrd.cpp:443
 msgid "Failed to set clipboard data."
 msgstr "無法設定剪貼簿資料。"
 
-#: ../src/unix/snglinst.cpp:181
+#: ../src/unix/snglinst.cpp:178
 #, c-format
 msgid "Failed to set permissions on lock file '%s'"
 msgstr "無法在鎖定檔案「%s」設定許可權限"
 
-#: ../src/unix/utilsunx.cpp:673
+#: ../src/unix/utilsunx.cpp:670
 msgid "Failed to set process priority"
 msgstr "無法設定執行緒的優先等級"
 
-#: ../src/common/file.cpp:588
+#: ../src/common/ffile.cpp:355 ../src/common/file.cpp:586
 msgid "Failed to set temporary file permissions"
 msgstr "無法設定暫存檔的存取權限"
 
-#: ../src/unix/threadpsx.cpp:1323
+#: ../src/unix/threadpsx.cpp:1347
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "無法設定執行緒的同時性等級為 %lu"
 
-#: ../src/unix/threadpsx.cpp:1449
+#: ../src/unix/threadpsx.cpp:1473
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "無法設定執行緒的優先等級為 %d。"
 
-#: ../src/unix/utilsunx.cpp:788
+#: ../src/unix/utilsunx.cpp:785
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr "無法設置非阻斷管線，程式也許已經當掉。"
 
-#: ../src/msw/webview_ie.cpp:902
+#: ../src/msw/webview_ie.cpp:987
 msgid "Failed to set web view to modern emulation level"
 msgstr "無法設定網頁檢視至現代模擬等級"
 
-#: ../src/common/fs_mem.cpp:255
+#: ../src/common/fs_mem.cpp:256
 #, c-format
 msgid "Failed to store image '%s' to memory VFS!"
 msgstr "無法將「%s」圖像儲存到「記憶體虛擬檔案系統」！"
@@ -3655,34 +3655,39 @@ msgstr "無法將「%s」圖像儲存到「記憶體虛擬檔案系統」！"
 msgid "Failed to switch DirectFB pipe to non-blocking mode"
 msgstr "無法切換 DirectFB 管線到非阻斷模式"
 
-#: ../src/unix/wakeuppipe.cpp:59
+#: ../src/unix/wakeuppipe.cpp:56
 msgid "Failed to switch wake up pipe to non-blocking mode"
 msgstr "無法切換喚醒管線到非阻斷模式"
 
-#: ../src/unix/threadpsx.cpp:1630
+#: ../src/unix/threadpsx.cpp:1654
 msgid "Failed to terminate a thread."
 msgstr "無法終止執行緒。"
 
-#: ../src/msw/dde.cpp:739
+#: ../src/msw/dde.cpp:736
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "無法終止與「動態資料交換(DDE)」伺服器溝通的連結"
 
-#: ../src/msw/dialup.cpp:937
+#: ../src/msw/dialup.cpp:932
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "無法終止撥號連線：%s"
 
-#: ../src/common/filename.cpp:2674
+#: ../src/common/filename.cpp:2673
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "無法更新「%s」檔案的修改時間"
 
-#: ../src/unix/snglinst.cpp:334
+#: ../src/unix/dlunix.cpp:90
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "無法載入「%s」共享函式庫"
+
+#: ../src/unix/snglinst.cpp:331
 #, c-format
 msgid "Failed to unlock lock file '%s'"
 msgstr "無法解除鎖定檔案「%s」"
 
-#: ../src/msw/dde.cpp:307
+#: ../src/msw/dde.cpp:304
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "無法撤銷「動態資料交換(DDE)」伺服器「%s」的註冊"
@@ -3692,86 +3697,90 @@ msgstr "無法撤銷「動態資料交換(DDE)」伺服器「%s」的註冊"
 msgid "Failed to unregister descriptor %d from epoll descriptor %d"
 msgstr "無法注銷描述子 %d (於 epoll 描述子 %d)"
 
-#: ../src/common/fileconf.cpp:1011
+#: ../src/common/fileconf.cpp:1006
 msgid "Failed to update user configuration file."
 msgstr "無法更新使用者設定檔案。"
 
-#: ../src/common/debugrpt.cpp:746
+#: ../src/common/debugrpt.cpp:743
 #, c-format
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "無法上傳除錯報告 (錯誤代號 %d)。"
 
-#: ../src/unix/snglinst.cpp:168
+#: ../src/unix/snglinst.cpp:165
 #, c-format
 msgid "Failed to write to lock file '%s'"
 msgstr "無法寫入鎖定檔案「%s」"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:193
+#: ../src/propgrid/propgrid.cpp:190
 msgid "False"
 msgstr "假"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:607
+#: ../src/propgrid/advprops.cpp:604
 msgid "Family"
 msgstr "字族"
 
-#: ../src/gtk/glcanvas.cpp:167
-#| msgid "File error"
+#: ../src/gtk/glcanvas.cpp:176 ../src/gtk/glcanvas.cpp:187
 msgid "Fatal Error"
 msgstr "嚴重錯誤"
 
-#: ../src/common/stockitem.cpp:157
+#: ../src/common/stockitem.cpp:154
 msgid "File"
 msgstr "檔案"
 
-#: ../src/common/docview.cpp:667
+#: ../src/common/docview.cpp:664
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "檔案「%s」無法開啟為讀取模式。"
 
-#: ../src/common/docview.cpp:644
+#: ../src/common/docview.cpp:641
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "檔案「%s」無法開啟為寫入模式。"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "檔案「%s」已存在，是否要覆寫？"
 
-#: ../src/common/filefn.cpp:1157
+#: ../src/common/filefn.cpp:1044
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "無法移除「%s」檔案"
 
-#: ../src/common/filefn.cpp:1140
+#: ../src/common/filefn.cpp:1028
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "檔案「%s」無法重新命名為「%s」"
 
-#: ../src/common/textcmn.cpp:960 ../src/richtext/richtextctrl.cpp:3085
+#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
 msgid "File couldn't be loaded."
 msgstr "無法載入檔案。"
 
-#: ../src/msw/filedlg.cpp:416
+#: ../src/msw/filedlg.cpp:414
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "檔案對話視窗錯誤，錯誤碼 %0lx。"
 
-#: ../src/common/docview.cpp:1786
+#: ../src/common/docview.cpp:1783
 msgid "File error"
 msgstr "檔案錯誤"
 
-#: ../src/generic/dirctrlg.cpp:588 ../src/generic/filectrlg.cpp:770
+#: ../src/generic/dirctrlg.cpp:554 ../src/generic/filectrlg.cpp:766
 msgid "File name exists already."
 msgstr "檔案名稱已存在。"
+
+#: ../src/osx/cocoa/filedlg.mm:264
+#, fuzzy
+msgid "File type:"
+msgstr "電傳打字機"
 
 #: ../src/motif/filedlg.cpp:220
 msgid "Files"
 msgstr "檔案"
 
-#: ../src/common/filefn.cpp:1592
+#: ../src/common/filefn.cpp:1479
 #, c-format
 msgid "Files (%s)"
 msgstr "檔案 (%s)"
@@ -3780,29 +3789,27 @@ msgstr "檔案 (%s)"
 msgid "Filter"
 msgstr "過濾器"
 
-#: ../src/html/helpwnd.cpp:491
+#: ../src/html/helpwnd.cpp:488
 msgid "Find"
 msgstr "尋找"
 
-#: ../src/common/stockitem.cpp:262
+#: ../src/common/stockitem.cpp:259
 msgid "Find and replace in document"
 msgstr "在文件中尋找並取代"
 
-#: ../src/common/stockitem.cpp:261
-#| msgid "Open HTML document"
+#: ../src/common/stockitem.cpp:258
 msgid "Find in document"
 msgstr "在文件中尋找"
 
-#: ../src/common/stockitem.cpp:158
-#| msgid "Find"
+#: ../src/common/stockitem.cpp:155
 msgid "Find..."
 msgstr "尋找…"
 
-#: ../src/common/stockitem.cpp:159
+#: ../src/common/stockitem.cpp:156
 msgid "First"
 msgstr "最前"
 
-#: ../src/common/prntbase.cpp:1578
+#: ../src/common/prntbase.cpp:1573
 msgid "First page"
 msgstr "第一頁"
 
@@ -3810,11 +3817,11 @@ msgstr "第一頁"
 msgid "Fixed"
 msgstr "定寬"
 
-#: ../src/html/helpwnd.cpp:1207
+#: ../src/html/helpwnd.cpp:1204
 msgid "Fixed font:"
 msgstr "定寬字型︰"
 
-#: ../src/html/helpwnd.cpp:1270
+#: ../src/html/helpwnd.cpp:1267
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "定寬大小字體<br> <b>粗體</b> <i>斜體</i> "
 
@@ -3822,16 +3829,16 @@ msgstr "定寬大小字體<br> <b>粗體</b> <i>斜體</i> "
 msgid "Floating"
 msgstr "浮動"
 
-#: ../src/common/stockitem.cpp:160
+#: ../src/common/stockitem.cpp:157
 msgid "Floppy"
 msgstr "軟碟"
 
-#: ../src/common/paper.cpp:111
+#: ../src/common/paper.cpp:108
 msgid "Folio, 8 1/2 x 13 in"
 msgstr "對開紙(Folio)，8 1/2 x 13 英吋"
 
-#: ../src/common/stockitem.cpp:194 ../src/osx/carbon/fontdlg.cpp:287
-#: ../src/richtext/richtextformatdlg.cpp:340
+#: ../src/osx/carbon/fontdlg.cpp:284 ../src/common/stockitem.cpp:191
+#: ../src/richtext/richtextformatdlg.cpp:337
 msgid "Font"
 msgstr "字型"
 
@@ -3839,26 +3846,24 @@ msgstr "字型"
 msgid "Font &weight:"
 msgstr "字型粗細(&W)："
 
-#: ../src/osx/fontutil.cpp:92
+#: ../src/osx/fontutil.cpp:89
 #, c-format
 msgid ""
 "Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
 "\"."
 msgstr "「%s」字型檔因為不在「%s」字型目錄內而無法使用。"
 
-#: ../src/msw/font.cpp:1135
+#: ../src/msw/font.cpp:1126
 #, c-format
-#| msgid "File couldn't be loaded."
 msgid "Font file \"%s\" couldn't be loaded"
 msgstr "無法載入「%s」字型檔案"
 
-#: ../src/osx/fontutil.cpp:84
+#: ../src/osx/fontutil.cpp:81
 #, c-format
-#| msgid ": file does not exist!"
 msgid "Font file \"%s\" doesn't exist."
 msgstr "「%s」字型檔案不存在。"
 
-#: ../src/html/helpwnd.cpp:1208
+#: ../src/html/helpwnd.cpp:1205
 msgid "Font size:"
 msgstr "字型大小："
 
@@ -3866,75 +3871,76 @@ msgstr "字型大小："
 msgid "Font st&yle:"
 msgstr "字型樣式(&Y)："
 
-#: ../src/osx/carbon/fontdlg.cpp:329
+#: ../src/osx/carbon/fontdlg.cpp:326
 msgid "Font:"
 msgstr "字型："
 
-#: ../src/dfb/fontmgr.cpp:198
+#: ../src/dfb/fontmgr.cpp:195
 #, c-format
 msgid "Fonts index file %s disappeared while loading fonts."
 msgstr "字型索引檔 %s 在載入字型時不見了。"
 
-#: ../src/unix/utilsunx.cpp:650
+#: ../src/unix/utilsunx.cpp:647
 msgid "Fork failed"
 msgstr "建立分支失敗"
 
-#: ../src/common/stockitem.cpp:161
+#: ../src/common/stockitem.cpp:158
 msgid "Forward"
 msgstr "向前"
 
-#: ../src/common/xtixml.cpp:235
+#: ../src/common/xtixml.cpp:231
 msgid "Forward hrefs are not supported"
 msgstr "不支援往前參照的超連結"
 
-#: ../src/html/helpwnd.cpp:876
+#: ../src/html/helpwnd.cpp:873
 #, c-format
 msgid "Found %i matches"
 msgstr "找到 %i 個符合項目"
 
-#: ../src/generic/prntdlgg.cpp:234
+#: ../src/generic/prntdlgg.cpp:231
 msgid "From:"
 msgstr "從："
 
-#: ../src/propgrid/advprops.cpp:1513
+#: ../src/propgrid/advprops.cpp:1510
 msgid "Fuchsia"
 msgstr "Fuchsia"
 
-#: ../src/common/imaggif.cpp:138
+#: ../src/common/imaggif.cpp:135
 msgid "GIF: data stream seems to be truncated."
 msgstr "GIF: 資料流似乎被截斷了。"
 
-#: ../src/common/imaggif.cpp:128
+#: ../src/common/imaggif.cpp:125
 msgid "GIF: error in GIF image format."
 msgstr "GIF: GIF 圖像格式錯誤。"
 
-#: ../src/common/imaggif.cpp:133
+#: ../src/common/imaggif.cpp:130
 msgid "GIF: not enough memory."
 msgstr "GIF: 記憶體不足。"
 
-#: ../src/gtk/window.cpp:5603
+#: ../src/gtk/window.cpp:5635
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
-msgstr "安裝於這臺機器的 GTK+ 太舊而不支援螢幕組合，請安裝 GTK+2.12 或後續版本。"
+msgstr ""
+"安裝於這臺機器的 GTK+ 太舊而不支援螢幕組合，請安裝 GTK+2.12 或後續版本。"
 
-#: ../src/univ/themes/gtk.cpp:525
+#: ../src/univ/themes/gtk.cpp:522
 msgid "GTK+ theme"
 msgstr "GTK+ 布景主題"
 
-#: ../src/common/preferencescmn.cpp:40
+#: ../src/common/preferencescmn.cpp:37
 msgid "General"
 msgstr "一般"
 
-#: ../src/common/prntbase.cpp:258
+#: ../src/common/prntbase.cpp:253
 msgid "Generic PostScript"
 msgstr "普通 PostScript"
 
-#: ../src/common/paper.cpp:135
+#: ../src/common/paper.cpp:132
 msgid "German Legal Fanfold, 8 1/2 x 13 in"
 msgstr "德國法定複寫簿, 8 1/2 x 13 in"
 
-#: ../src/common/paper.cpp:134
+#: ../src/common/paper.cpp:131
 msgid "German Std Fanfold, 8 1/2 x 12 in"
 msgstr "德國標準複寫簿, 8 1/2 x 12 in"
 
@@ -3950,48 +3956,48 @@ msgstr "在一個通用處理器上呼叫GetPropertyCollection"
 msgid "GetPropertyCollection called w/o valid collection getter"
 msgstr "呼叫GetPropertyCollection時未帶有效的collection getter"
 
-#: ../src/html/helpwnd.cpp:661
+#: ../src/html/helpwnd.cpp:658
 msgid "Go back"
 msgstr "退回"
 
-#: ../src/html/helpwnd.cpp:662
+#: ../src/html/helpwnd.cpp:659
 msgid "Go forward"
 msgstr "向前"
 
-#: ../src/html/helpwnd.cpp:664
+#: ../src/html/helpwnd.cpp:661
 msgid "Go one level up in document hierarchy"
 msgstr "到上一階文件層級"
 
-#: ../src/generic/dirdlgg.cpp:116 ../src/generic/filedlgg.cpp:208
+#: ../src/generic/filedlgg.cpp:205 ../src/generic/dirdlgg.cpp:113
 msgid "Go to home directory"
 msgstr "前往家目錄"
 
-#: ../src/generic/filedlgg.cpp:205
+#: ../src/generic/filedlgg.cpp:202
 msgid "Go to parent directory"
 msgstr "前往父目錄"
 
-#: ../src/generic/aboutdlgg.cpp:76
+#: ../src/generic/aboutdlgg.cpp:73
 msgid "Graphics art by "
 msgstr "美術設計者："
 
-#: ../src/propgrid/advprops.cpp:1508
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Gray"
 msgstr "灰色"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:787
+#: ../src/propgrid/advprops.cpp:784
 msgid "GrayText"
 msgstr "GrayText"
 
-#: ../src/common/fmapbase.cpp:154
+#: ../src/common/fmapbase.cpp:151
 msgid "Greek (ISO-8859-7)"
 msgstr "希臘文 (ISO-8859-7)"
 
-#: ../src/propgrid/advprops.cpp:1509
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Green"
 msgstr "綠色"
 
-#: ../src/generic/colrdlgg.cpp:342
+#: ../src/generic/colrdlgg.cpp:362
 msgid "Green:"
 msgstr "綠色："
 
@@ -3999,107 +4005,107 @@ msgstr "綠色："
 msgid "Groove"
 msgstr "溝槽"
 
-#: ../src/common/zstream.cpp:158 ../src/common/zstream.cpp:318
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
 msgid "Gzip not supported by this version of zlib"
 msgstr "這一版的 zlib 不支援 Gzip"
 
-#: ../src/html/helpwnd.cpp:1550
+#: ../src/html/helpwnd.cpp:1547
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "超文件說明檔專案 (*.hhp)|*.hhp|"
 
-#: ../src/html/htmlwin.cpp:687
+#: ../src/html/htmlwin.cpp:691
 #, c-format
 msgid "HTML anchor %s does not exist."
 msgstr "HTML 錨點 %s 不存在。"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1545
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "超文件檔 (*.html;*.htm)|*.html;*.htm|"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1663
+#: ../src/propgrid/advprops.cpp:1660
 msgid "Hand"
 msgstr "手掌"
 
-#: ../src/common/stockitem.cpp:162
+#: ../src/common/stockitem.cpp:159
 msgid "Harddisk"
 msgstr "硬碟"
 
-#: ../src/common/fmapbase.cpp:155
+#: ../src/common/fmapbase.cpp:152
 msgid "Hebrew (ISO-8859-8)"
 msgstr "希伯來文 (ISO-8859-8)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../include/wx/msgdlg.h:280 ../src/common/accelcmn.cpp:80
-#: ../src/common/stockitem.cpp:163 ../src/html/helpdlg.cpp:66
-#: ../src/html/helpfrm.cpp:111 ../src/osx/button_osx.cpp:39
+#: ../include/wx/msgdlg.h:282 ../src/osx/button_osx.cpp:39
+#: ../src/common/stockitem.cpp:160 ../src/common/accelcmn.cpp:77
+#: ../src/html/helpfrm.cpp:108 ../src/html/helpdlg.cpp:63
 msgid "Help"
 msgstr "說明"
 
-#: ../src/html/helpwnd.cpp:1201
+#: ../src/html/helpwnd.cpp:1198
 msgid "Help Browser Options"
 msgstr "說明瀏覽器選項"
 
-#: ../src/generic/helpext.cpp:455 ../src/generic/helpext.cpp:456
+#: ../src/generic/helpext.cpp:452 ../src/generic/helpext.cpp:453
 msgid "Help Index"
 msgstr "說明索引"
 
-#: ../src/html/helpwnd.cpp:1532
+#: ../src/html/helpwnd.cpp:1529
 msgid "Help Printing"
 msgstr "說明列印"
 
-#: ../src/html/helpwnd.cpp:802
+#: ../src/html/helpwnd.cpp:799
 msgid "Help Topics"
 msgstr "輔助主題"
 
-#: ../src/html/helpwnd.cpp:1549
+#: ../src/html/helpwnd.cpp:1546
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "說明書 (*.htb)|*.htb|說明書 (*.zip)|*.zip|"
 
-#: ../src/generic/helpext.cpp:268
+#: ../src/generic/helpext.cpp:265
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "找不到說明目錄「%s」。"
 
-#: ../src/generic/helpext.cpp:276
+#: ../src/generic/helpext.cpp:273
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "找不到「%s」檔案。"
 
-#: ../src/html/helpctrl.cpp:63
+#: ../src/html/helpctrl.cpp:59
 #, c-format
 msgid "Help: %s"
 msgstr "說明：%s"
 
-#: ../src/osx/menu_osx.cpp:466
+#: ../src/osx/menu_osx.cpp:469
 #, c-format
 msgid "Hide %s"
 msgstr "隱藏 %s"
 
-#: ../src/osx/menu_osx.cpp:468
+#: ../src/osx/menu_osx.cpp:471
 msgid "Hide Others"
 msgstr "隱藏其他"
 
-#: ../src/generic/infobar.cpp:84
+#: ../src/generic/infobar.cpp:81
 msgid "Hide this notification message."
 msgstr "隱藏這個通知訊息。"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:788
+#: ../src/propgrid/advprops.cpp:785
 msgid "Highlight"
 msgstr "Highlight"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:789
+#: ../src/propgrid/advprops.cpp:786
 msgid "HighlightText"
 msgstr "HighlightText"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:65 ../src/common/stockitem.cpp:164
+#: ../src/common/stockitem.cpp:161 ../src/common/accelcmn.cpp:62
 msgid "Home"
 msgstr "Home"
 
-#: ../src/generic/dirctrlg.cpp:524
+#: ../src/generic/dirctrlg.cpp:490
 msgid "Home directory"
 msgstr "家目錄"
 
@@ -4109,61 +4115,61 @@ msgid "How the object will float relative to the text."
 msgstr "物件與文字之間的相對位置。"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1664
+#: ../src/propgrid/advprops.cpp:1661
 msgid "I-Beam"
 msgstr "工字"
 
-#: ../src/common/imagbmp.cpp:1211
+#: ../src/common/imagbmp.cpp:1208
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO：讀取遮罩式 DIB 時發生錯誤。"
 
-#: ../src/common/imagbmp.cpp:1305 ../src/common/imagbmp.cpp:1405
-#: ../src/common/imagbmp.cpp:1420 ../src/common/imagbmp.cpp:1431
-#: ../src/common/imagbmp.cpp:1445 ../src/common/imagbmp.cpp:1493
-#: ../src/common/imagbmp.cpp:1508 ../src/common/imagbmp.cpp:1522
-#: ../src/common/imagbmp.cpp:1533
+#: ../src/common/imagbmp.cpp:1302 ../src/common/imagbmp.cpp:1402
+#: ../src/common/imagbmp.cpp:1417 ../src/common/imagbmp.cpp:1428
+#: ../src/common/imagbmp.cpp:1442 ../src/common/imagbmp.cpp:1490
+#: ../src/common/imagbmp.cpp:1505 ../src/common/imagbmp.cpp:1519
+#: ../src/common/imagbmp.cpp:1530
 msgid "ICO: Error writing the image file!"
 msgstr "ICO：寫入圖像檔時發生錯誤！"
 
-#: ../src/common/imagbmp.cpp:1270
+#: ../src/common/imagbmp.cpp:1267
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO：圖像太高。"
 
-#: ../src/common/imagbmp.cpp:1278
+#: ../src/common/imagbmp.cpp:1275
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO：圖像太寬。"
 
-#: ../src/common/imagbmp.cpp:1618
+#: ../src/common/imagbmp.cpp:1615
 msgid "ICO: Invalid icon index."
 msgstr "ICO：圖示索引無效。"
 
-#: ../src/common/imagiff.cpp:758
+#: ../src/common/imagiff.cpp:755
 msgid "IFF: data stream seems to be truncated."
 msgstr "IFF：資料流似乎被截斷了。"
 
-#: ../src/common/imagiff.cpp:742
+#: ../src/common/imagiff.cpp:739
 msgid "IFF: error in IFF image format."
 msgstr "IFF：IFF 圖像格式錯誤。"
 
-#: ../src/common/imagiff.cpp:745
+#: ../src/common/imagiff.cpp:742
 msgid "IFF: not enough memory."
 msgstr "IFF：記憶體不足。"
 
-#: ../src/common/imagiff.cpp:748
+#: ../src/common/imagiff.cpp:745
 msgid "IFF: unknown error!!!"
 msgstr "IFF：不明的錯誤！！！"
 
-#: ../src/common/fmapbase.cpp:197
+#: ../src/common/fmapbase.cpp:194
 msgid "ISO-2022-JP"
 msgstr "ISO-2022-JP"
 
-#: ../src/html/htmprint.cpp:297
+#: ../src/html/htmprint.cpp:294
 msgid ""
 "If possible, try changing the layout parameters to make the printout more "
 "narrow."
 msgstr "儘量嘗試變更版面配置參數，讓列印輸出更窄。"
 
-#: ../src/generic/dbgrptg.cpp:365
+#: ../src/generic/dbgrptg.cpp:362
 msgid ""
 "If you have any additional information pertaining to this bug\n"
 "report, please enter it here and it will be joined to it:"
@@ -4171,7 +4177,7 @@ msgstr ""
 "如果有任何與此錯誤報告有關的資訊, \n"
 "請在此輸入，其會被加到錯誤報告："
 
-#: ../src/generic/dbgrptg.cpp:327
+#: ../src/generic/dbgrptg.cpp:324
 msgid ""
 "If you wish to suppress this debug report completely, please choose the "
 "\"Cancel\" button,\n"
@@ -4182,50 +4188,50 @@ msgstr ""
 "但不建議這樣做，因為除錯報告有助於改善本程式。\n"
 "如果可以，請盡量選擇讓程式產生除錯報告。\n"
 
-#: ../src/common/zipstrm.cpp:1046
+#: ../src/common/zipstrm.cpp:1043
 msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
 msgstr "忽略格式錯誤的延伸資料記錄，ZIP 檔案可能損壞"
 
-#: ../src/msw/registry.cpp:1404
+#: ../src/msw/registry.cpp:1393
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "忽略「%s」值 (「%s」鍵)。"
 
-#: ../src/common/xtistrm.cpp:295
+#: ../src/common/xtistrm.cpp:292
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "作為事件來源的物件類別(非-wxEvtHandler)不合規範"
 
-#: ../src/common/xti.cpp:513
+#: ../src/common/xti.cpp:510
 msgid "Illegal Parameter Count for ConstructObject Method"
 msgstr "針對ConstructObject方法的參數計數不合規範"
 
-#: ../src/common/xti.cpp:501
+#: ../src/common/xti.cpp:498
 msgid "Illegal Parameter Count for Create Method"
 msgstr "針對Create方法的參數計數不合規範"
 
-#: ../src/generic/dirctrlg.cpp:570 ../src/generic/filectrlg.cpp:756
+#: ../src/generic/dirctrlg.cpp:536 ../src/generic/filectrlg.cpp:752
 msgid "Illegal directory name."
 msgstr "目錄名稱不合規範。"
 
-#: ../src/generic/filectrlg.cpp:1367
+#: ../src/generic/filectrlg.cpp:1356
 msgid "Illegal file specification."
 msgstr "檔案描述不合規範。"
 
-#: ../src/common/image.cpp:2278
+#: ../src/common/image.cpp:2363
 msgid "Image and mask have different sizes."
 msgstr "圖像和遮罩的大小不一致。"
 
-#: ../src/common/image.cpp:2756
+#: ../src/common/image.cpp:2841
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "影像檔不是 %d 類型。"
 
-#: ../src/common/image.cpp:2910
+#: ../src/common/image.cpp:2995
 #, c-format
 msgid "Image is not of type %s."
 msgstr "影像不是 %s 類型。"
 
-#: ../src/msw/textctrl.cpp:512
+#: ../src/msw/textctrl.cpp:534
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -4233,100 +4239,100 @@ msgstr ""
 "無法建立 rich edit 控制元件，使用 simple text 控制元件代替。請重新安裝 "
 "riched32.dll"
 
-#: ../src/unix/utilsunx.cpp:306
+#: ../src/unix/utilsunx.cpp:303
 msgid "Impossible to get child process input"
 msgstr "無法取得子程序的輸入"
 
-#: ../src/common/filefn.cpp:1029
+#: ../src/common/filefn.cpp:917
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "無法取得「%s」檔案的存取權限"
 
-#: ../src/common/filefn.cpp:1043
+#: ../src/common/filefn.cpp:931
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "無法覆寫「%s」檔案"
 
-#: ../src/common/filefn.cpp:1098
+#: ../src/common/filefn.cpp:986
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "無法設定「%s」檔案的存取權限"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:790
+#: ../src/propgrid/advprops.cpp:787
 msgid "InactiveBorder"
 msgstr "InactiveBorder"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:791
+#: ../src/propgrid/advprops.cpp:788
 msgid "InactiveCaption"
 msgstr "InactiveCaption"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:792
+#: ../src/propgrid/advprops.cpp:789
 msgid "InactiveCaptionText"
 msgstr "InactiveCaptionText"
 
-#: ../src/common/gifdecod.cpp:829
+#: ../src/common/gifdecod.cpp:826
 #, c-format
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "GIF 影格大小 (%u, %d) 不正確 (用於影格 #%u)"
 
-#: ../src/msw/ole/automtn.cpp:635
+#: ../src/msw/ole/automtn.cpp:626
 msgid "Incorrect number of arguments."
 msgstr "引數數量不正確。"
 
-#: ../src/common/stockitem.cpp:165
+#: ../src/common/stockitem.cpp:162
 msgid "Indent"
 msgstr "縮排"
 
-#: ../src/richtext/richtextformatdlg.cpp:345
+#: ../src/richtext/richtextformatdlg.cpp:342
 msgid "Indents && Spacing"
 msgstr "縮排與間距"
 
-#: ../src/common/stockitem.cpp:166 ../src/html/helpwnd.cpp:516
+#: ../src/common/stockitem.cpp:163 ../src/html/helpwnd.cpp:513
 msgid "Index"
 msgstr "索引"
 
-#: ../src/common/fmapbase.cpp:159
+#: ../src/common/fmapbase.cpp:156
 msgid "Indian (ISO-8859-12)"
 msgstr "印度語系 (ISO-8859-12)"
 
-#: ../src/common/stockitem.cpp:167
+#: ../src/common/stockitem.cpp:164
 msgid "Info"
 msgstr "資訊"
 
-#: ../src/common/init.cpp:287
+#: ../src/common/init.cpp:284
 msgid "Initialization failed in post init, aborting."
 msgstr "安裝後續的啟始失敗，將會忽略。"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:54
+#: ../src/common/accelcmn.cpp:51
 msgid "Ins"
 msgstr "Ins"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:53 ../src/richtext/richtextsymboldlg.cpp:472
+#: ../src/common/accelcmn.cpp:50 ../src/richtext/richtextsymboldlg.cpp:469
 msgid "Insert"
 msgstr "Ins"
 
-#: ../src/richtext/richtextbuffer.cpp:8066
+#: ../src/richtext/richtextbuffer.cpp:8063
 msgid "Insert Field"
 msgstr "插入欄位"
 
-#: ../src/richtext/richtextbuffer.cpp:7977
-#: ../src/richtext/richtextbuffer.cpp:8937
+#: ../src/richtext/richtextbuffer.cpp:7974
+#: ../src/richtext/richtextbuffer.cpp:8934
 msgid "Insert Image"
 msgstr "插入圖片"
 
-#: ../src/richtext/richtextbuffer.cpp:8024
+#: ../src/richtext/richtextbuffer.cpp:8021
 msgid "Insert Object"
 msgstr "插入物件"
 
-#: ../src/richtext/richtextbuffer.cpp:7821
-#: ../src/richtext/richtextbuffer.cpp:7851
-#: ../src/richtext/richtextbuffer.cpp:7893
-#: ../src/richtext/richtextctrl.cpp:1290 ../src/richtext/richtextctrl.cpp:1498
+#: ../src/richtext/richtextbuffer.cpp:7818
+#: ../src/richtext/richtextbuffer.cpp:7848
+#: ../src/richtext/richtextbuffer.cpp:7890
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
 msgid "Insert Text"
 msgstr "插入文字"
 
@@ -4339,11 +4345,11 @@ msgstr "在段落前插入換頁符號。"
 msgid "Inset"
 msgstr "內縮"
 
-#: ../src/common/imagtiff.cpp:311
+#: ../src/common/imagtiff.cpp:308
 msgid "Invalid TIFF image index."
 msgstr "TIFF 圖像索引無效。"
 
-#: ../src/common/appcmn.cpp:297
+#: ../src/common/appcmn.cpp:294
 #, c-format
 msgid "Invalid display mode specification '%s'."
 msgstr "顯示模式規格「%s」無效。"
@@ -4353,250 +4359,250 @@ msgstr "顯示模式規格「%s」無效。"
 msgid "Invalid geometry specification '%s'"
 msgstr "幾何規格「%s」無效"
 
-#: ../src/unix/fswatcher_inotify.cpp:323
+#: ../src/unix/fswatcher_inotify.cpp:320
 #, c-format
 msgid "Invalid inotify event for \"%s\""
 msgstr "inotify 事件「%s」無效"
 
-#: ../src/unix/snglinst.cpp:312
+#: ../src/unix/snglinst.cpp:309
 #, c-format
 msgid "Invalid lock file '%s'."
 msgstr "鎖定檔案「%s」無效。"
 
-#: ../src/common/translation.cpp:1169
+#: ../src/common/translation.cpp:1167
 msgid "Invalid message catalog."
 msgstr "訊息分類無效。"
 
-#: ../src/common/xtistrm.cpp:405 ../src/common/xtistrm.cpp:420
+#: ../src/common/xtistrm.cpp:402 ../src/common/xtistrm.cpp:417
 msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
 msgstr "傳給GetObjectClassInfo的物件ID無效或是空的"
 
-#: ../src/common/xtistrm.cpp:435
+#: ../src/common/xtistrm.cpp:432
 msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
 msgstr "傳給HasObjectClassInfo的物件ID無效或是空的"
 
-#: ../src/common/regex.cpp:310
+#: ../src/common/regex.cpp:307
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "正規運算式「%s」無效： %s"
 
-#: ../src/common/config.cpp:226
+#: ../src/common/config.cpp:222
 #, c-format
 msgid "Invalid value %ld for a boolean key \"%s\" in config file."
 msgstr "設定檔的 %ld 值 (對應到布林 \"%s\") 無效。"
 
-#: ../src/common/stockitem.cpp:168 ../src/generic/fontdlgg.cpp:329
-#: ../src/osx/carbon/fontdlg.cpp:361 ../src/richtext/richtextfontpage.cpp:351
+#: ../src/osx/carbon/fontdlg.cpp:358 ../src/common/stockitem.cpp:165
+#: ../src/generic/fontdlgg.cpp:325 ../src/richtext/richtextfontpage.cpp:351
 msgid "Italic"
 msgstr "斜體"
 
-#: ../src/common/paper.cpp:130
+#: ../src/common/paper.cpp:127
 msgid "Italy Envelope, 110 x 230 mm"
 msgstr "意大利信封，110 x 230 mm"
 
-#: ../src/common/imagjpeg.cpp:260
+#: ../src/common/imagjpeg.cpp:257
 msgid "JPEG: Couldn't load - file is probably corrupted."
 msgstr "JPEG：無法載入 - 檔案也許已損壞。"
 
-#: ../src/common/imagjpeg.cpp:439
+#: ../src/common/imagjpeg.cpp:436
 msgid "JPEG: Couldn't save image."
 msgstr "JPEG：無法儲存圖像。"
 
-#: ../src/common/paper.cpp:163
+#: ../src/common/paper.cpp:160
 msgid "Japanese Double Postcard 200 x 148 mm"
 msgstr "日式雙倍明信片 200 x 148 公釐"
 
-#: ../src/common/paper.cpp:167
+#: ../src/common/paper.cpp:164
 msgid "Japanese Envelope Chou #3"
 msgstr "日式信封 Chou #3"
 
-#: ../src/common/paper.cpp:180
+#: ../src/common/paper.cpp:177
 msgid "Japanese Envelope Chou #3 Rotated"
 msgstr "日式信封 Chou #3 轉向"
 
-#: ../src/common/paper.cpp:168
+#: ../src/common/paper.cpp:165
 msgid "Japanese Envelope Chou #4"
 msgstr "日式信封 Chou #4"
 
-#: ../src/common/paper.cpp:181
+#: ../src/common/paper.cpp:178
 msgid "Japanese Envelope Chou #4 Rotated"
 msgstr "日式信封 Chou #4 轉向"
 
-#: ../src/common/paper.cpp:165
+#: ../src/common/paper.cpp:162
 msgid "Japanese Envelope Kaku #2"
 msgstr "日式信封 Kaku #2"
 
-#: ../src/common/paper.cpp:178
+#: ../src/common/paper.cpp:175
 msgid "Japanese Envelope Kaku #2 Rotated"
 msgstr "日式信封 Kaku #2 轉向"
 
-#: ../src/common/paper.cpp:166
+#: ../src/common/paper.cpp:163
 msgid "Japanese Envelope Kaku #3"
 msgstr "日式信封 Kaku #3"
 
-#: ../src/common/paper.cpp:179
+#: ../src/common/paper.cpp:176
 msgid "Japanese Envelope Kaku #3 Rotated"
 msgstr "日式信封 Kaku #3 轉向"
 
-#: ../src/common/paper.cpp:185
+#: ../src/common/paper.cpp:182
 msgid "Japanese Envelope You #4"
 msgstr "日式信封 You #4"
 
-#: ../src/common/paper.cpp:186
+#: ../src/common/paper.cpp:183
 msgid "Japanese Envelope You #4 Rotated"
 msgstr "日式信封 You #4 轉向"
 
-#: ../src/common/paper.cpp:138
+#: ../src/common/paper.cpp:135
 msgid "Japanese Postcard 100 x 148 mm"
 msgstr "日式明信片 100 x 148 公釐"
 
-#: ../src/common/paper.cpp:175
+#: ../src/common/paper.cpp:172
 msgid "Japanese Postcard Rotated 148 x 100 mm"
 msgstr "日式明信片轉向 148 x 100 公釐"
 
-#: ../src/common/stockitem.cpp:169
+#: ../src/common/stockitem.cpp:166
 msgid "Jump to"
 msgstr "跳至"
 
-#: ../src/common/stockitem.cpp:171
+#: ../src/common/stockitem.cpp:168
 msgid "Justified"
 msgstr "分散對齊"
 
-#: ../src/richtext/richtextindentspage.cpp:155
-#: ../src/richtext/richtextindentspage.cpp:157
 #: ../src/richtext/richtextliststylepage.cpp:344
 #: ../src/richtext/richtextliststylepage.cpp:346
+#: ../src/richtext/richtextindentspage.cpp:155
+#: ../src/richtext/richtextindentspage.cpp:157
 msgid "Justify text left and right."
 msgstr "文字左右對齊。"
 
-#: ../src/common/fmapbase.cpp:163
+#: ../src/common/fmapbase.cpp:160
 msgid "KOI8-R"
 msgstr "KOI8-R"
 
-#: ../src/common/fmapbase.cpp:164
+#: ../src/common/fmapbase.cpp:161
 msgid "KOI8-U"
 msgstr "KOI8-U"
 
-#: ../src/common/accelcmn.cpp:282 ../src/common/accelcmn.cpp:367
+#: ../src/common/accelcmn.cpp:279 ../src/common/accelcmn.cpp:364
 msgid "KP_"
 msgstr "KP_"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:104
 msgid "KP_Add"
 msgstr "KP_Add"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:99
 msgid "KP_Begin"
 msgstr "KP_Begin"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:107
 msgid "KP_Decimal"
 msgstr "KP_Decimal"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:101
 msgid "KP_Delete"
 msgstr "KP_Delete"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:111
+#: ../src/common/accelcmn.cpp:108
 msgid "KP_Divide"
 msgstr "KP_Divide"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:93
 msgid "KP_Down"
 msgstr "KP_Down"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:98
 msgid "KP_End"
 msgstr "KP_End"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:88
 msgid "KP_Enter"
 msgstr "KP_Enter"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:102
 msgid "KP_Equal"
 msgstr "KP_Equal"
 
-#: ../src/common/accelcmn.cpp:279 ../src/common/accelcmn.cpp:364
+#: ../src/common/accelcmn.cpp:276 ../src/common/accelcmn.cpp:361
 msgid "KP_F"
 msgstr "KP_F"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:89
 msgid "KP_Home"
 msgstr "KP_Home"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:100
 msgid "KP_Insert"
 msgstr "KP_Insert"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:90
 msgid "KP_Left"
 msgstr "KP_Left"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:103
 msgid "KP_Multiply"
 msgstr "KP_Multiply"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:100
+#: ../src/common/accelcmn.cpp:97
 msgid "KP_Next"
 msgstr "KP_Next"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:98
+#: ../src/common/accelcmn.cpp:95
 msgid "KP_PageDown"
 msgstr "KP_PageDown"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:94
 msgid "KP_PageUp"
 msgstr "KP_PageUp"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:99
+#: ../src/common/accelcmn.cpp:96
 msgid "KP_Prior"
 msgstr "KP_Prior"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:92
 msgid "KP_Right"
 msgstr "KP_Right"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:105
 msgid "KP_Separator"
 msgstr "KP_Separator"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:86
 msgid "KP_Space"
 msgstr "KP_Space"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:106
 msgid "KP_Subtract"
 msgstr "KP_Subtract"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:87
 msgid "KP_Tab"
 msgstr "KP_Tab"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:91
 msgid "KP_Up"
 msgstr "KP_Up"
 
@@ -4604,128 +4610,126 @@ msgstr "KP_Up"
 msgid "L&ine spacing:"
 msgstr "列距(&I):"
 
-#: ../src/common/lzmastream.cpp:353
+#: ../src/common/lzmastream.cpp:350
 #, c-format
 msgid "LZMA compression error when flushing output: %s"
 msgstr "排清輸出時發生 LZMA 壓縮錯誤：%s"
 
-#: ../src/common/lzmastream.cpp:283
+#: ../src/common/lzmastream.cpp:280
 #, c-format
-#| msgid "compression error"
 msgid "LZMA compression error: %s"
 msgstr "LZMA 壓縮錯誤：%s"
 
-#: ../src/common/lzmastream.cpp:199
+#: ../src/common/lzmastream.cpp:196
 #, c-format
-#| msgid "decompression error"
 msgid "LZMA decompression error: %s"
 msgstr "LZMA 解壓縮錯誤：%s"
 
-#: ../src/generic/prntdlgg.cpp:609 ../src/generic/prntdlgg.cpp:864
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:861
 msgid "Landscape"
 msgstr "橫向列印"
 
-#: ../src/common/stockitem.cpp:174
+#: ../src/common/stockitem.cpp:171
 msgid "Last"
 msgstr "最後"
 
-#: ../src/common/prntbase.cpp:1602
+#: ../src/common/prntbase.cpp:1597
 msgid "Last page"
 msgstr "最後一頁"
 
-#: ../src/common/log.cpp:305
+#: ../src/common/log.cpp:324
 #, c-format
 msgid "Last repeated message (\"%s\", %u time) wasn't output"
 msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
 msgstr[0] "最後一個重複的訊息 (「%s」, %u 次) 並無輸出"
 
-#: ../src/common/paper.cpp:103
+#: ../src/common/paper.cpp:100
 msgid "Ledger, 17 x 11 in"
 msgstr "橫板紙(Ledger)，17 x 11 英吋"
 
 #. TRANSLATORS: Name of keyboard key
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/common/accelcmn.cpp:61 ../src/generic/datavgen.cpp:6594
-#: ../src/richtext/richtextbulletspage.cpp:186
-#: ../src/richtext/richtextbulletspage.cpp:189
-#: ../src/richtext/richtextbulletspage.cpp:190
+#: ../src/common/accelcmn.cpp:58 ../src/generic/datavgen.cpp:6951
+#: ../src/richtext/richtextsizepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:249
 #: ../src/richtext/richtextliststylepage.cpp:252
 #: ../src/richtext/richtextliststylepage.cpp:253
-#: ../src/richtext/richtextsizepage.cpp:249
+#: ../src/richtext/richtextbulletspage.cpp:186
+#: ../src/richtext/richtextbulletspage.cpp:189
+#: ../src/richtext/richtextbulletspage.cpp:190
 msgid "Left"
 msgstr "左"
 
-#: ../src/richtext/richtextindentspage.cpp:204
 #: ../src/richtext/richtextliststylepage.cpp:390
+#: ../src/richtext/richtextindentspage.cpp:204
 msgid "Left (&first line):"
 msgstr "左(第一列)(&F):"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1665
+#: ../src/propgrid/advprops.cpp:1662
 msgid "Left Button"
 msgstr "左鍵"
 
-#: ../src/generic/prntdlgg.cpp:876
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Left margin (mm):"
 msgstr "左邊距(公釐[mm])："
 
-#: ../src/richtext/richtextindentspage.cpp:141
-#: ../src/richtext/richtextindentspage.cpp:143
 #: ../src/richtext/richtextliststylepage.cpp:330
 #: ../src/richtext/richtextliststylepage.cpp:332
+#: ../src/richtext/richtextindentspage.cpp:141
+#: ../src/richtext/richtextindentspage.cpp:143
 msgid "Left-align text."
 msgstr "文字向左對齊。"
 
-#: ../src/common/paper.cpp:144
+#: ../src/common/paper.cpp:141
 msgid "Legal Extra 9 1/2 x 15 in"
 msgstr "美式長信紙(Legal)增大 9 1/2 x 15 英吋"
 
-#: ../src/common/paper.cpp:96
+#: ../src/common/paper.cpp:93
 msgid "Legal, 8 1/2 x 14 in"
 msgstr "美式長信紙(Legal)，8 1/2 x 14 英吋"
 
-#: ../src/common/paper.cpp:143
+#: ../src/common/paper.cpp:140
 msgid "Letter Extra 9 1/2 x 12 in"
 msgstr "美式信紙(Letter)增大 9 1/2 x 12 英吋"
 
-#: ../src/common/paper.cpp:149
+#: ../src/common/paper.cpp:146
 msgid "Letter Extra Transverse 9.275 x 12 in"
 msgstr "美式信紙(Letter)增大橫向 9.275 x 12 英吋"
 
-#: ../src/common/paper.cpp:152
+#: ../src/common/paper.cpp:149
 msgid "Letter Plus 8 1/2 x 12.69 in"
 msgstr "美式信紙(Letter)加長 8 1/2 x 12.69 英吋"
 
-#: ../src/common/paper.cpp:169
+#: ../src/common/paper.cpp:166
 msgid "Letter Rotated 11 x 8 1/2 in"
 msgstr "美式信紙(Letter)轉向，11 x 8 1/2 英吋"
 
-#: ../src/common/paper.cpp:101
+#: ../src/common/paper.cpp:98
 msgid "Letter Small, 8 1/2 x 11 in"
 msgstr "美式信紙(Letter)縮小，8 1/2 x 11 英吋"
 
-#: ../src/common/paper.cpp:147
+#: ../src/common/paper.cpp:144
 msgid "Letter Transverse 8 1/2 x 11 in"
 msgstr "美式信紙(Letter)橫向 8 1/2 x 11 英吋"
 
-#: ../src/common/paper.cpp:95
+#: ../src/common/paper.cpp:92
 msgid "Letter, 8 1/2 x 11 in"
 msgstr "美式信紙(Letter)，8 1/2 x 11 英吋"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "License"
 msgstr "授權"
 
-#: ../src/generic/fontdlgg.cpp:332
+#: ../src/generic/fontdlgg.cpp:328
 msgid "Light"
 msgstr "細體"
 
-#: ../src/propgrid/advprops.cpp:1517
+#: ../src/propgrid/advprops.cpp:1514
 msgid "Lime"
 msgstr "青檸色"
 
-#: ../src/generic/helpext.cpp:295
+#: ../src/generic/helpext.cpp:292
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr "映射檔案「%2$s」的第 %1$lu 列語法無效，已略過。"
@@ -4734,15 +4738,15 @@ msgstr "映射檔案「%2$s」的第 %1$lu 列語法無效，已略過。"
 msgid "Line spacing:"
 msgstr "列距:"
 
-#: ../src/html/chm.cpp:836
+#: ../src/html/chm.cpp:829
 msgid "Link contained '//', converted to absolute link."
 msgstr "連結包含 '//'，已轉換為絕對連結。"
 
-#: ../src/richtext/richtextformatdlg.cpp:360
+#: ../src/richtext/richtextformatdlg.cpp:357
 msgid "List Style"
 msgstr "清單樣式"
 
-#: ../src/richtext/richtextstyles.cpp:1064
+#: ../src/richtext/richtextstyles.cpp:1061
 msgid "List styles"
 msgstr "清單樣式"
 
@@ -4756,233 +4760,234 @@ msgstr "清單字型大小。"
 msgid "Lists the available fonts."
 msgstr "列出可用字型。"
 
-#: ../src/common/fldlgcmn.cpp:340
+#: ../src/common/fldlgcmn.cpp:337
 #, c-format
 msgid "Load %s file"
 msgstr "載入 %s 檔案"
 
-#: ../src/html/htmlwin.cpp:603
+#: ../src/html/htmlwin.cpp:600
 msgid "Loading : "
 msgstr "載入中："
 
-#: ../src/unix/snglinst.cpp:246
+#: ../src/unix/snglinst.cpp:243
 #, c-format
 msgid "Lock file '%s' has incorrect owner."
 msgstr "上鎖檔案「%s」沒有正確的所有者。"
 
-#: ../src/unix/snglinst.cpp:251
+#: ../src/unix/snglinst.cpp:248
 #, c-format
 msgid "Lock file '%s' has incorrect permissions."
 msgstr "上鎖檔案「%s」沒有正確的權限。"
 
-#: ../src/generic/logg.cpp:576
+#: ../src/generic/logg.cpp:573
 #, c-format
 msgid "Log saved to the file '%s'."
 msgstr "儲存日誌到「%s」檔案。"
 
-#: ../src/richtext/richtextbulletspage.cpp:276
 #: ../src/richtext/richtextliststylepage.cpp:484
+#: ../src/richtext/richtextbulletspage.cpp:276
 msgid "Lower case letters"
 msgstr "小寫字母"
 
-#: ../src/richtext/richtextbulletspage.cpp:278
 #: ../src/richtext/richtextliststylepage.cpp:486
+#: ../src/richtext/richtextbulletspage.cpp:278
 msgid "Lower case roman numerals"
 msgstr "小寫羅馬數字"
 
-#: ../src/gtk/mdi.cpp:433 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk1/mdi.cpp:431 ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "MDI 子視窗"
 
-#: ../src/msw/helpchm.cpp:56
+#: ../src/msw/helpchm.cpp:53
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
-msgstr "由於未安裝 MS HTML Help 函示庫，導致 MS HTML Help 功能無法使用。請先安裝。"
+msgstr ""
+"由於未安裝 MS HTML Help 函示庫，導致 MS HTML Help 功能無法使用。請先安裝。"
 
-#: ../src/univ/themes/win32.cpp:3754
+#: ../src/univ/themes/win32.cpp:3751
 msgid "Ma&ximize"
 msgstr "最大化(&X)"
 
-#: ../src/common/fmapbase.cpp:203
+#: ../src/common/fmapbase.cpp:200
 msgid "MacArabic"
 msgstr "MacArabic"
 
-#: ../src/common/fmapbase.cpp:222
+#: ../src/common/fmapbase.cpp:219
 msgid "MacArmenian"
 msgstr "MacArmenian"
 
-#: ../src/common/fmapbase.cpp:211
+#: ../src/common/fmapbase.cpp:208
 msgid "MacBengali"
 msgstr "MacBengali"
 
-#: ../src/common/fmapbase.cpp:217
+#: ../src/common/fmapbase.cpp:214
 msgid "MacBurmese"
 msgstr "MacBurmese"
 
-#: ../src/common/fmapbase.cpp:236
+#: ../src/common/fmapbase.cpp:233
 msgid "MacCeltic"
 msgstr "MacCeltic"
 
-#: ../src/common/fmapbase.cpp:227
+#: ../src/common/fmapbase.cpp:224
 msgid "MacCentralEurRoman"
 msgstr "MacCentralEurRoman"
 
-#: ../src/common/fmapbase.cpp:223
+#: ../src/common/fmapbase.cpp:220
 msgid "MacChineseSimp"
 msgstr "Mac 簡體中文"
 
-#: ../src/common/fmapbase.cpp:201
+#: ../src/common/fmapbase.cpp:198
 msgid "MacChineseTrad"
 msgstr "Mac 正體中文"
 
-#: ../src/common/fmapbase.cpp:233
+#: ../src/common/fmapbase.cpp:230
 msgid "MacCroatian"
 msgstr "MacCroatian"
 
-#: ../src/common/fmapbase.cpp:206
+#: ../src/common/fmapbase.cpp:203
 msgid "MacCyrillic"
 msgstr "MacCyrillic"
 
-#: ../src/common/fmapbase.cpp:207
+#: ../src/common/fmapbase.cpp:204
 msgid "MacDevanagari"
 msgstr "MacDevanagari"
 
-#: ../src/common/fmapbase.cpp:231
+#: ../src/common/fmapbase.cpp:228
 msgid "MacDingbats"
 msgstr "MacDingbats"
 
-#: ../src/common/fmapbase.cpp:226
+#: ../src/common/fmapbase.cpp:223
 msgid "MacEthiopic"
 msgstr "MacEthiopic"
 
-#: ../src/common/fmapbase.cpp:229
+#: ../src/common/fmapbase.cpp:226
 msgid "MacExtArabic"
 msgstr "MacExtArabic"
 
-#: ../src/common/fmapbase.cpp:237
+#: ../src/common/fmapbase.cpp:234
 msgid "MacGaelic"
 msgstr "MacGaelic"
 
-#: ../src/common/fmapbase.cpp:221
+#: ../src/common/fmapbase.cpp:218
 msgid "MacGeorgian"
 msgstr "MacGeorgian"
 
-#: ../src/common/fmapbase.cpp:205
+#: ../src/common/fmapbase.cpp:202
 msgid "MacGreek"
 msgstr "MacGreek"
 
-#: ../src/common/fmapbase.cpp:209
+#: ../src/common/fmapbase.cpp:206
 msgid "MacGujarati"
 msgstr "MacGujarati"
 
-#: ../src/common/fmapbase.cpp:208
+#: ../src/common/fmapbase.cpp:205
 msgid "MacGurmukhi"
 msgstr "MacGurmukhi"
 
-#: ../src/common/fmapbase.cpp:204
+#: ../src/common/fmapbase.cpp:201
 msgid "MacHebrew"
 msgstr "MacHebrew"
 
-#: ../src/common/fmapbase.cpp:234
+#: ../src/common/fmapbase.cpp:231
 msgid "MacIcelandic"
 msgstr "MacIcelandic"
 
-#: ../src/common/fmapbase.cpp:200
+#: ../src/common/fmapbase.cpp:197
 msgid "MacJapanese"
 msgstr "MacJapanese"
 
-#: ../src/common/fmapbase.cpp:214
+#: ../src/common/fmapbase.cpp:211
 msgid "MacKannada"
 msgstr "MacKannada"
 
-#: ../src/common/fmapbase.cpp:238
+#: ../src/common/fmapbase.cpp:235
 msgid "MacKeyboardGlyphs"
 msgstr "MacKeyboardGlyphs"
 
-#: ../src/common/fmapbase.cpp:218
+#: ../src/common/fmapbase.cpp:215
 msgid "MacKhmer"
 msgstr "MacKhmer"
 
-#: ../src/common/fmapbase.cpp:202
+#: ../src/common/fmapbase.cpp:199
 msgid "MacKorean"
 msgstr "MacKorean"
 
-#: ../src/common/fmapbase.cpp:220
+#: ../src/common/fmapbase.cpp:217
 msgid "MacLaotian"
 msgstr "MacLaotian"
 
-#: ../src/common/fmapbase.cpp:215
+#: ../src/common/fmapbase.cpp:212
 msgid "MacMalayalam"
 msgstr "MacMalayalam"
 
-#: ../src/common/fmapbase.cpp:225
+#: ../src/common/fmapbase.cpp:222
 msgid "MacMongolian"
 msgstr "MacMongolian"
 
-#: ../src/common/fmapbase.cpp:210
+#: ../src/common/fmapbase.cpp:207
 msgid "MacOriya"
 msgstr "MacOriya"
 
-#: ../src/common/fmapbase.cpp:199
+#: ../src/common/fmapbase.cpp:196
 msgid "MacRoman"
 msgstr "MacRoman"
 
-#: ../src/common/fmapbase.cpp:235
+#: ../src/common/fmapbase.cpp:232
 msgid "MacRomanian"
 msgstr "MacRomanian"
 
-#: ../src/common/fmapbase.cpp:216
+#: ../src/common/fmapbase.cpp:213
 msgid "MacSinhalese"
 msgstr "MacSinhalese"
 
-#: ../src/common/fmapbase.cpp:230
+#: ../src/common/fmapbase.cpp:227
 msgid "MacSymbol"
 msgstr "MacSymbol"
 
-#: ../src/common/fmapbase.cpp:212
+#: ../src/common/fmapbase.cpp:209
 msgid "MacTamil"
 msgstr "MacTamil"
 
-#: ../src/common/fmapbase.cpp:213
+#: ../src/common/fmapbase.cpp:210
 msgid "MacTelugu"
 msgstr "MacTelugu"
 
-#: ../src/common/fmapbase.cpp:219
+#: ../src/common/fmapbase.cpp:216
 msgid "MacThai"
 msgstr "MacThai"
 
-#: ../src/common/fmapbase.cpp:224
+#: ../src/common/fmapbase.cpp:221
 msgid "MacTibetan"
 msgstr "MacTibetan"
 
-#: ../src/common/fmapbase.cpp:232
+#: ../src/common/fmapbase.cpp:229
 msgid "MacTurkish"
 msgstr "MacTurkish"
 
-#: ../src/common/fmapbase.cpp:228
+#: ../src/common/fmapbase.cpp:225
 msgid "MacVietnamese"
 msgstr "MacVietnamese"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1666
+#: ../src/propgrid/advprops.cpp:1663
 msgid "Magnifier"
 msgstr "放大鏡"
 
-#: ../src/propgrid/advprops.cpp:2047
+#: ../src/propgrid/advprops.cpp:2050
 msgid "Make a selection:"
 msgstr "選取項目："
 
-#: ../src/richtext/richtextformatdlg.cpp:370
+#: ../src/richtext/richtextformatdlg.cpp:367
 #: ../src/richtext/richtextmarginspage.cpp:171
 msgid "Margins"
 msgstr "外邊距"
 
-#: ../src/propgrid/advprops.cpp:1504
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Maroon"
 msgstr "栗子色"
 
-#: ../src/generic/fdrepdlg.cpp:147
+#: ../src/generic/fdrepdlg.cpp:144
 msgid "Match case"
 msgstr "區分大小寫"
 
@@ -4994,40 +4999,40 @@ msgstr "最大高度："
 msgid "Max width:"
 msgstr "最大寬度："
 
-#: ../src/unix/mediactrl.cpp:953
+#: ../src/unix/mediactrl.cpp:972
 #, c-format
 msgid "Media playback error: %s"
 msgstr "媒體播放出錯：%s"
 
-#: ../src/common/fs_mem.cpp:169
+#: ../src/common/fs_mem.cpp:170
 #, c-format
 msgid "Memory VFS already contains file '%s'!"
 msgstr "「記憶體虛擬檔案系統」已有「%s」檔案！"
 
 #. TRANSLATORS: Name of keyboard key
 #. TRANSLATORS: Keyword of system colour
-#: ../src/common/accelcmn.cpp:73 ../src/propgrid/advprops.cpp:793
+#: ../src/common/accelcmn.cpp:70 ../src/propgrid/advprops.cpp:790
 msgid "Menu"
 msgstr "選單"
 
-#: ../src/common/msgout.cpp:124
+#: ../src/common/msgout.cpp:121
 msgid "Message"
 msgstr "訊息"
 
-#: ../src/univ/themes/metal.cpp:168
+#: ../src/univ/themes/metal.cpp:165
 msgid "Metal theme"
 msgstr "金屬佈景主題"
 
-#: ../src/msw/ole/automtn.cpp:652
+#: ../src/msw/ole/automtn.cpp:643
 msgid "Method or property not found."
 msgstr "找不到方法或性質。"
 
-#: ../src/univ/themes/win32.cpp:3752
+#: ../src/univ/themes/win32.cpp:3749
 msgid "Mi&nimize"
 msgstr "最小化(&N)"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1667
+#: ../src/propgrid/advprops.cpp:1664
 msgid "Middle Button"
 msgstr "中鍵"
 
@@ -5039,36 +5044,41 @@ msgstr "最小高度："
 msgid "Min width:"
 msgstr "最小寬度："
 
-#: ../src/msw/ole/automtn.cpp:668
+#: ../src/osx/cocoa/menu.mm:281
+#, fuzzy
+msgid "Minimize"
+msgstr "最小化(&N)"
+
+#: ../src/msw/ole/automtn.cpp:659
 msgid "Missing a required parameter."
 msgstr "缺少所需參數。"
 
-#: ../src/generic/fontdlgg.cpp:324
+#: ../src/generic/fontdlgg.cpp:320
 msgid "Modern"
 msgstr "現代"
 
-#: ../src/generic/filectrlg.cpp:427
+#: ../src/generic/filectrlg.cpp:423
 msgid "Modified"
 msgstr "修改日期"
 
-#: ../src/common/module.cpp:133
+#: ../src/common/module.cpp:130
 #, c-format
 msgid "Module \"%s\" initialization failed"
 msgstr "「%s」模組初始化失敗"
 
-#: ../src/common/paper.cpp:131
+#: ../src/common/paper.cpp:128
 msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
 msgstr "御用信封，3 7/8 x 7 1/2 英吋"
 
-#: ../src/msw/fswatcher.cpp:143
+#: ../src/msw/fswatcher.cpp:140
 msgid "Monitoring individual files for changes is not supported currently."
 msgstr "目前不支援監控個別檔案是否有變更。"
 
-#: ../src/generic/editlbox.cpp:163
+#: ../src/generic/editlbox.cpp:160
 msgid "Move down"
 msgstr "下移"
 
-#: ../src/generic/editlbox.cpp:158
+#: ../src/generic/editlbox.cpp:155
 msgid "Move up"
 msgstr "上移"
 
@@ -5082,103 +5092,102 @@ msgstr "將物件移至下一個段落。"
 msgid "Moves the object to the previous paragraph."
 msgstr "將物件移至上一個段落。"
 
-#: ../src/richtext/richtextbuffer.cpp:9966
+#: ../src/richtext/richtextbuffer.cpp:9963
 msgid "Multiple Cell Properties"
 msgstr "儲存格性質(多個)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:85
-#| msgid "KP_Multiply"
+#: ../src/common/accelcmn.cpp:82
 msgid "Multiply"
 msgstr "乘號鍵"
 
-#: ../src/generic/filectrlg.cpp:424
+#: ../src/generic/filectrlg.cpp:420
 msgid "Name"
 msgstr "名稱"
 
-#: ../src/propgrid/advprops.cpp:1505
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Navy"
 msgstr "海軍藍"
 
-#: ../src/common/stockitem.cpp:175
+#: ../src/common/stockitem.cpp:172
 msgid "Network"
 msgstr "網路"
 
-#: ../src/common/stockitem.cpp:176
+#: ../src/common/stockitem.cpp:173
 msgid "New"
 msgstr "新增"
 
-#: ../src/richtext/richtextstyledlg.cpp:243
+#: ../src/richtext/richtextstyledlg.cpp:239
 msgid "New &Box Style..."
 msgstr "新增文字方塊樣式(&B)…"
 
-#: ../src/richtext/richtextstyledlg.cpp:225
+#: ../src/richtext/richtextstyledlg.cpp:221
 msgid "New &Character Style..."
 msgstr "新增字元樣式(&C)…"
 
-#: ../src/richtext/richtextstyledlg.cpp:237
+#: ../src/richtext/richtextstyledlg.cpp:233
 msgid "New &List Style..."
 msgstr "新增清單樣式(&L)…"
 
-#: ../src/richtext/richtextstyledlg.cpp:231
+#: ../src/richtext/richtextstyledlg.cpp:227
 msgid "New &Paragraph Style..."
 msgstr "新增段落樣式(&P)…"
 
-#: ../src/richtext/richtextstyledlg.cpp:606
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:654
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:820
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:893
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:934
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:602
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:650
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:816
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:889
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:930
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "New Style"
 msgstr "新增樣式"
 
-#: ../src/generic/editlbox.cpp:142
+#: ../src/generic/editlbox.cpp:139
 msgid "New item"
 msgstr "新增項目"
 
-#: ../src/generic/dirdlgg.cpp:297 ../src/generic/dirdlgg.cpp:307
-#: ../src/generic/filectrlg.cpp:618 ../src/generic/filectrlg.cpp:627
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+#: ../src/generic/dirdlgg.cpp:294 ../src/generic/dirdlgg.cpp:304
 msgid "NewName"
 msgstr "新名稱"
 
-#: ../src/common/prntbase.cpp:1597 ../src/html/helpwnd.cpp:666
+#: ../src/common/prntbase.cpp:1592 ../src/html/helpwnd.cpp:663
 msgid "Next page"
 msgstr "下一頁"
 
-#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:177
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:174
 #: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "否"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1668
+#: ../src/propgrid/advprops.cpp:1665
 msgid "No Entry"
 msgstr "禁止入內"
 
-#: ../src/generic/animateg.cpp:150
+#: ../src/generic/animateg.cpp:133
 #, c-format
 msgid "No animation handler for type %ld defined."
 msgstr "沒有定義 %ld 類型的動畫處理常式。"
 
-#: ../src/dfb/bitmap.cpp:642 ../src/dfb/bitmap.cpp:676
+#: ../src/dfb/bitmap.cpp:639 ../src/dfb/bitmap.cpp:673
 #, c-format
 msgid "No bitmap handler for type %d defined."
 msgstr "沒有定義 %d 類型的點陣圖處理常式。"
 
-#: ../src/common/utilscmn.cpp:1098
+#: ../src/common/utilscmn.cpp:1095
 msgid "No default application configured for HTML files."
 msgstr "沒有組配用於 HTML 檔案的預設應用程式。"
 
-#: ../src/generic/helpext.cpp:446
+#: ../src/generic/helpext.cpp:443
 msgid "No entries found."
 msgstr "找不到項目。"
 
-#: ../src/common/fontmap.cpp:421
+#: ../src/common/fontmap.cpp:418
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found,\n"
@@ -5190,7 +5199,7 @@ msgstr ""
 "但是系統有另一種編碼「%s」。\n"
 "要使用該編碼嗎？(否則必須選擇另一種)"
 
-#: ../src/common/fontmap.cpp:426
+#: ../src/common/fontmap.cpp:423
 #, c-format
 msgid ""
 "No font for displaying text in encoding '%s' found.\n"
@@ -5201,216 +5210,216 @@ msgstr ""
 "要選擇對應這個編碼的字型嗎？\n"
 "(否則此種編碼的文字無法正確顯示)"
 
-#: ../src/generic/animateg.cpp:142
+#: ../src/generic/animateg.cpp:125
 msgid "No handler found for animation type."
 msgstr "沒有找到動畫類型處理常式。"
 
-#: ../src/common/image.cpp:2738
+#: ../src/common/image.cpp:2823
 msgid "No handler found for image type."
 msgstr "沒有找到圖像類型處理常式。"
 
-#: ../src/common/image.cpp:2746 ../src/common/image.cpp:2869
-#: ../src/common/image.cpp:2935
+#: ../src/common/image.cpp:2831 ../src/common/image.cpp:2954
+#: ../src/common/image.cpp:3020
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "沒有定義 %d 類型的圖像處理常式。"
 
-#: ../src/common/image.cpp:2901 ../src/common/image.cpp:2949
+#: ../src/common/image.cpp:2986 ../src/common/image.cpp:3034
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "沒有定義 %s 類型的圖像處理常式。"
 
-#: ../src/html/helpwnd.cpp:859
+#: ../src/html/helpwnd.cpp:856
 msgid "No matching page found yet"
 msgstr "尚未找到符合的頁面"
 
-#: ../src/unix/sound.cpp:81
+#: ../src/unix/sound.cpp:78
 msgid "No sound"
 msgstr "沒有聲音"
 
-#: ../src/common/image.cpp:2286 ../src/common/image.cpp:2327
+#: ../src/common/image.cpp:2371 ../src/common/image.cpp:2412
 msgid "No unused colour in image being masked."
 msgstr "圖像沒有被遮罩的未用顏色。"
 
-#: ../src/common/image.cpp:3408
-msgid "No unused colour in image."
-msgstr "圖像沒有未用的顏色。"
-
-#: ../src/generic/helpext.cpp:303
+#: ../src/generic/helpext.cpp:300
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "在「%s」檔案找不到有效映射。"
 
-#: ../src/richtext/richtextborderspage.cpp:610
 #: ../src/richtext/richtextsizepage.cpp:248
 #: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:610
 msgid "None"
 msgstr "無"
 
-#: ../src/common/fmapbase.cpp:157
+#: ../src/common/fmapbase.cpp:154
 msgid "Nordic (ISO-8859-10)"
 msgstr "北歐語系 (ISO-8859-10)"
 
-#: ../src/generic/fontdlgg.cpp:328 ../src/generic/fontdlgg.cpp:331
+#: ../src/generic/fontdlgg.cpp:324 ../src/generic/fontdlgg.cpp:327
 msgid "Normal"
 msgstr "正常"
 
-#: ../src/html/helpwnd.cpp:1264
+#: ../src/html/helpwnd.cpp:1261
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "正常字體<br>且<u>加底線</u>。 "
 
-#: ../src/html/helpwnd.cpp:1206
+#: ../src/html/helpwnd.cpp:1203
 msgid "Normal font:"
 msgstr "正常字型："
 
-#: ../src/propgrid/props.cpp:1118
+#: ../src/propgrid/props.cpp:1115
 #, c-format
 msgid "Not %s"
 msgstr "非 %s"
 
-#: ../include/wx/filename.h:578 ../include/wx/filename.h:583
-msgid "Not available"
-msgstr "無法提供"
+#: ../src/common/secretstore.cpp:168
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/webrequest.cpp:605
+msgid "Not enough free disk space for download."
+msgstr ""
 
 #: ../src/richtext/richtextfontpage.cpp:358
 msgid "Not underlined"
 msgstr "未加底線"
 
-#: ../src/common/paper.cpp:115
+#: ../src/common/paper.cpp:112
 msgid "Note, 8 1/2 x 11 in"
 msgstr "筆記簿，8 1/2 x 11 英吋"
 
-#: ../src/generic/notifmsgg.cpp:132
+#: ../src/generic/notifmsgg.cpp:129
 msgid "Notice"
 msgstr "注意"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:106
+#: ../src/common/accelcmn.cpp:103
 msgid "Num *"
 msgstr "Num *"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:107
+#: ../src/common/accelcmn.cpp:104
 msgid "Num +"
 msgstr "Num +"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:108
+#: ../src/common/accelcmn.cpp:105
 msgid "Num ,"
 msgstr "Num ,"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:109
+#: ../src/common/accelcmn.cpp:106
 msgid "Num -"
 msgstr "Num -"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:110
+#: ../src/common/accelcmn.cpp:107
 msgid "Num ."
 msgstr "Num ."
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:111
+#: ../src/common/accelcmn.cpp:108
 msgid "Num /"
 msgstr "Num /"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:105
+#: ../src/common/accelcmn.cpp:102
 msgid "Num ="
 msgstr "Num ="
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:102
+#: ../src/common/accelcmn.cpp:99
 msgid "Num Begin"
 msgstr "Num Begin"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:104
+#: ../src/common/accelcmn.cpp:101
 msgid "Num Delete"
 msgstr "Num Delete"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:96
+#: ../src/common/accelcmn.cpp:93
 msgid "Num Down"
 msgstr "Num 下"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:101
+#: ../src/common/accelcmn.cpp:98
 msgid "Num End"
 msgstr "Num End"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:91
+#: ../src/common/accelcmn.cpp:88
 msgid "Num Enter"
 msgstr "Num 輸入"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:92
+#: ../src/common/accelcmn.cpp:89
 msgid "Num Home"
 msgstr "Num Home"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:103
+#: ../src/common/accelcmn.cpp:100
 msgid "Num Insert"
 msgstr "Num Insert"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:84
 msgid "Num Lock"
 msgstr "Num Lock"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:98
+#: ../src/common/accelcmn.cpp:95
 msgid "Num Page Down"
 msgstr "Num PgDn"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:97
+#: ../src/common/accelcmn.cpp:94
 msgid "Num Page Up"
 msgstr "Num PgUp"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:95
+#: ../src/common/accelcmn.cpp:92
 msgid "Num Right"
 msgstr "Num 右"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:89
+#: ../src/common/accelcmn.cpp:86
 msgid "Num Space"
 msgstr "Num 空格"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:90
+#: ../src/common/accelcmn.cpp:87
 msgid "Num Tab"
 msgstr "Num Tab"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:94
+#: ../src/common/accelcmn.cpp:91
 msgid "Num Up"
 msgstr "Num 上"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:93
+#: ../src/common/accelcmn.cpp:90
 msgid "Num left"
 msgstr "Num 左"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:87
+#: ../src/common/accelcmn.cpp:84
 msgid "Num_lock"
 msgstr "Num_lock"
 
-#: ../src/richtext/richtextbulletspage.cpp:279
 #: ../src/richtext/richtextliststylepage.cpp:487
+#: ../src/richtext/richtextbulletspage.cpp:279
 msgid "Numbered outline"
 msgstr "大綱編號"
 
-#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:178
-#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:451
-#: ../src/msw/msgdlg.cpp:744 ../src/richtext/richtextstyledlg.cpp:297
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:175
+#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:448
+#: ../src/msw/msgdlg.cpp:741 ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "確認"
 
-#: ../src/msw/ole/automtn.cpp:692
+#: ../src/msw/ole/automtn.cpp:683
 #, c-format
 msgid "OLE Automation error in %s: %s"
 msgstr "OLE 自動作業發生錯誤於 %s：%s"
@@ -5419,15 +5428,15 @@ msgstr "OLE 自動作業發生錯誤於 %s：%s"
 msgid "Object Properties"
 msgstr "物件性質"
 
-#: ../src/msw/ole/automtn.cpp:660
+#: ../src/msw/ole/automtn.cpp:651
 msgid "Object implementation does not support named arguments."
 msgstr "物件實作不支援具名引數。"
 
-#: ../src/common/xtixml.cpp:264
+#: ../src/common/xtixml.cpp:260
 msgid "Objects must have an id attribute"
 msgstr "物件必須有 id 屬性"
 
-#: ../src/propgrid/advprops.cpp:1510
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Olive"
 msgstr "橄欖色"
 
@@ -5435,69 +5444,68 @@ msgstr "橄欖色"
 msgid "Opaci&ty:"
 msgstr "混濁度(&T)："
 
-#: ../src/generic/colrdlgg.cpp:354
+#: ../src/generic/colrdlgg.cpp:374
 msgid "Opacity:"
 msgstr "混濁度："
 
-#: ../src/common/docview.cpp:1770 ../src/common/docview.cpp:1823
+#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
 msgid "Open File"
 msgstr "開啟檔案"
 
-#: ../src/html/helpwnd.cpp:672 ../src/html/helpwnd.cpp:1555
+#: ../src/html/helpwnd.cpp:669 ../src/html/helpwnd.cpp:1552
 msgid "Open HTML document"
 msgstr "開啟 HTML 文件"
 
-#: ../src/common/stockitem.cpp:268
-#| msgid "Open HTML document"
+#: ../src/common/stockitem.cpp:265
 msgid "Open an existing document"
 msgstr "開啟現有文件"
 
-#: ../src/generic/dbgrptg.cpp:163
+#: ../src/generic/dbgrptg.cpp:160
 #, c-format
 msgid "Open file \"%s\""
 msgstr "開啟「%s」檔案"
 
-#: ../src/common/stockitem.cpp:179
+#: ../src/common/stockitem.cpp:176
 msgid "Open..."
 msgstr "開啟..."
 
-#: ../src/msw/glcanvas.cpp:610 ../src/unix/glx11.cpp:513
+#: ../src/msw/glcanvas.cpp:607 ../src/unix/glx11.cpp:513
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr "本 OpenGL 驅動程式不支援 OpenGL 或更新版本。"
 
-#: ../src/generic/dirctrlg.cpp:599 ../src/generic/dirdlgg.cpp:323
-#: ../src/generic/filectrlg.cpp:642 ../src/generic/filectrlg.cpp:786
+#: ../src/generic/dirctrlg.cpp:565 ../src/generic/filectrlg.cpp:638
+#: ../src/generic/filectrlg.cpp:782 ../src/generic/dirdlgg.cpp:320
 msgid "Operation not permitted."
 msgstr "不容許的操作。"
 
-#: ../src/common/cmdline.cpp:899
+#: ../src/common/cmdline.cpp:896
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "「%s」選項無法被打消"
 
-#: ../src/common/cmdline.cpp:1063
+#: ../src/common/cmdline.cpp:1060
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "「%s」選項必須有值。"
 
-#: ../src/common/cmdline.cpp:1146
+#: ../src/common/cmdline.cpp:1143
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "「%s」選項：「%s」無法轉換成日期。"
 
-#: ../src/generic/prntdlgg.cpp:614
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "選項"
 
-#: ../src/propgrid/advprops.cpp:1515
+#: ../src/propgrid/advprops.cpp:1512
 msgid "Orange"
 msgstr "橙色"
 
-#: ../src/generic/prntdlgg.cpp:611 ../src/generic/prntdlgg.cpp:865
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:862
 msgid "Orientation"
 msgstr "方向"
 
-#: ../src/common/windowid.cpp:242
+#: ../src/common/windowid.cpp:237
 msgid "Out of window IDs.  Recommend shutting down application."
 msgstr "Window ID 已用完，建議關閉應用程式。"
 
@@ -5510,148 +5518,148 @@ msgstr "輪廓"
 msgid "Outset"
 msgstr "外貼"
 
-#: ../src/msw/ole/automtn.cpp:656
+#: ../src/msw/ole/automtn.cpp:647
 msgid "Overflow while coercing argument values."
 msgstr "強制變更引數值時發生溢位。"
 
-#: ../src/common/imagpcx.cpp:459 ../src/common/imagpcx.cpp:482
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:479
 msgid "PCX: couldn't allocate memory"
 msgstr "PCX：無法配置記憶體"
 
-#: ../src/common/imagpcx.cpp:458
+#: ../src/common/imagpcx.cpp:455
 msgid "PCX: image format unsupported"
 msgstr "PCX：圖像格式不支援"
 
-#: ../src/common/imagpcx.cpp:481
+#: ../src/common/imagpcx.cpp:478
 msgid "PCX: invalid image"
 msgstr "PCX：圖像無效"
 
-#: ../src/common/imagpcx.cpp:444
+#: ../src/common/imagpcx.cpp:441
 msgid "PCX: this is not a PCX file."
 msgstr "PCX：不是 PCX 檔案。"
 
-#: ../src/common/imagpcx.cpp:461 ../src/common/imagpcx.cpp:483
+#: ../src/common/imagpcx.cpp:458 ../src/common/imagpcx.cpp:480
 msgid "PCX: unknown error !!!"
 msgstr "PCX：不明的錯誤！！！"
 
-#: ../src/common/imagpcx.cpp:460
+#: ../src/common/imagpcx.cpp:457
 msgid "PCX: version number too low"
 msgstr "PCX：版本太低"
 
-#: ../src/common/imagpnm.cpp:92
+#: ../src/common/imagpnm.cpp:89
 msgid "PNM: Couldn't allocate memory."
 msgstr "PNM：無法配置記憶體。"
 
-#: ../src/common/imagpnm.cpp:74
+#: ../src/common/imagpnm.cpp:71
 msgid "PNM: File format is not recognized."
 msgstr "PNM：檔案格式無法識別。"
 
-#: ../src/common/imagpnm.cpp:114 ../src/common/imagpnm.cpp:137
-#: ../src/common/imagpnm.cpp:159
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:156
 msgid "PNM: File seems truncated."
 msgstr "PNM：檔案似乎被截斷了。"
 
-#: ../src/common/paper.cpp:187
+#: ../src/common/paper.cpp:184
 msgid "PRC 16K 146 x 215 mm"
 msgstr "中式 16開 146 x 215 公釐"
 
-#: ../src/common/paper.cpp:200
+#: ../src/common/paper.cpp:197
 msgid "PRC 16K Rotated"
 msgstr "中式 16開 轉向"
 
-#: ../src/common/paper.cpp:188
+#: ../src/common/paper.cpp:185
 msgid "PRC 32K 97 x 151 mm"
 msgstr "中式 32開 97 x 151 公釐"
 
-#: ../src/common/paper.cpp:201
+#: ../src/common/paper.cpp:198
 msgid "PRC 32K Rotated"
 msgstr "中式 32開 轉向"
 
-#: ../src/common/paper.cpp:189
+#: ../src/common/paper.cpp:186
 msgid "PRC 32K(Big) 97 x 151 mm"
 msgstr "中式 32開(大) 97 x 151 公釐"
 
-#: ../src/common/paper.cpp:202
+#: ../src/common/paper.cpp:199
 msgid "PRC 32K(Big) Rotated"
 msgstr "中式 32開(大) 轉向"
 
-#: ../src/common/paper.cpp:190
+#: ../src/common/paper.cpp:187
 msgid "PRC Envelope #1 102 x 165 mm"
 msgstr "中式信封 #1 102 x 165 公釐"
 
-#: ../src/common/paper.cpp:203
+#: ../src/common/paper.cpp:200
 msgid "PRC Envelope #1 Rotated 165 x 102 mm"
 msgstr "中式信封 #1 轉向 165 x 102 公釐"
 
-#: ../src/common/paper.cpp:199
+#: ../src/common/paper.cpp:196
 msgid "PRC Envelope #10 324 x 458 mm"
 msgstr "中式信封 #10 324 x 458 公釐"
 
-#: ../src/common/paper.cpp:212
+#: ../src/common/paper.cpp:209
 msgid "PRC Envelope #10 Rotated 458 x 324 mm"
 msgstr "中式信封 #10 轉向 458 x 324 公釐"
 
-#: ../src/common/paper.cpp:191
+#: ../src/common/paper.cpp:188
 msgid "PRC Envelope #2 102 x 176 mm"
 msgstr "中式信封 #2 102 x 176 公釐"
 
-#: ../src/common/paper.cpp:204
+#: ../src/common/paper.cpp:201
 msgid "PRC Envelope #2 Rotated 176 x 102 mm"
 msgstr "中式信封 #2 轉向 176 x 102 公釐"
 
-#: ../src/common/paper.cpp:192
+#: ../src/common/paper.cpp:189
 msgid "PRC Envelope #3 125 x 176 mm"
 msgstr "中式信封 #3 125 x 176 公釐"
 
-#: ../src/common/paper.cpp:205
+#: ../src/common/paper.cpp:202
 msgid "PRC Envelope #3 Rotated 176 x 125 mm"
 msgstr "中式信封 #3 轉向 176 x 125 公釐"
 
-#: ../src/common/paper.cpp:193
+#: ../src/common/paper.cpp:190
 msgid "PRC Envelope #4 110 x 208 mm"
 msgstr "中式信封 #4 110 x 208 公釐"
 
-#: ../src/common/paper.cpp:206
+#: ../src/common/paper.cpp:203
 msgid "PRC Envelope #4 Rotated 208 x 110 mm"
 msgstr "中式信封 #4 轉向 208 x 110 公釐"
 
-#: ../src/common/paper.cpp:194
+#: ../src/common/paper.cpp:191
 msgid "PRC Envelope #5 110 x 220 mm"
 msgstr "中式信封 #5 110 x 220 公釐"
 
-#: ../src/common/paper.cpp:207
+#: ../src/common/paper.cpp:204
 msgid "PRC Envelope #5 Rotated 220 x 110 mm"
 msgstr "中式信封 #5 轉向 220 x 110 公釐"
 
-#: ../src/common/paper.cpp:195
+#: ../src/common/paper.cpp:192
 msgid "PRC Envelope #6 120 x 230 mm"
 msgstr "中式信封 #6 120 x 230 公釐"
 
-#: ../src/common/paper.cpp:208
+#: ../src/common/paper.cpp:205
 msgid "PRC Envelope #6 Rotated 230 x 120 mm"
 msgstr "中式信封 #6 轉向 230 x 120 公釐"
 
-#: ../src/common/paper.cpp:196
+#: ../src/common/paper.cpp:193
 msgid "PRC Envelope #7 160 x 230 mm"
 msgstr "中式信封 #7 160 x 230 公釐"
 
-#: ../src/common/paper.cpp:209
+#: ../src/common/paper.cpp:206
 msgid "PRC Envelope #7 Rotated 230 x 160 mm"
 msgstr "中式信封 #7 轉向 230 x 160 公釐"
 
-#: ../src/common/paper.cpp:197
+#: ../src/common/paper.cpp:194
 msgid "PRC Envelope #8 120 x 309 mm"
 msgstr "中式信封 #8 120 x 309 公釐"
 
-#: ../src/common/paper.cpp:210
+#: ../src/common/paper.cpp:207
 msgid "PRC Envelope #8 Rotated 309 x 120 mm"
 msgstr "中式信封 #8 轉向 309 x 120 公釐"
 
-#: ../src/common/paper.cpp:198
+#: ../src/common/paper.cpp:195
 msgid "PRC Envelope #9 229 x 324 mm"
 msgstr "中式信封 #9 229 x 324 公釐"
 
-#: ../src/common/paper.cpp:211
+#: ../src/common/paper.cpp:208
 msgid "PRC Envelope #9 Rotated 324 x 229 mm"
 msgstr "中式信封 #9 轉向 324 x 229 公釐"
 
@@ -5659,110 +5667,114 @@ msgstr "中式信封 #9 轉向 324 x 229 公釐"
 msgid "Padding"
 msgstr "內邊距"
 
-#: ../src/common/prntbase.cpp:2104
+#: ../src/common/prntbase.cpp:2096
 #, c-format
 msgid "Page %d"
 msgstr "第 %d 頁"
 
-#: ../src/common/prntbase.cpp:2102
+#: ../src/common/prntbase.cpp:2094
 #, c-format
 msgid "Page %d of %d"
 msgstr "第 %d / %d 頁"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 msgid "Page Down"
 msgstr "PgDn"
 
-#: ../src/gtk/print.cpp:833
+#: ../src/gtk/print.cpp:829
 msgid "Page Setup"
 msgstr "頁面設定"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 msgid "Page Up"
 msgstr "PgUp"
 
-#: ../src/common/prntbase.cpp:484 ../src/generic/prntdlgg.cpp:824
+#: ../src/common/prntbase.cpp:479 ../src/generic/prntdlgg.cpp:821
 msgid "Page setup"
 msgstr "頁面設定"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:58
+#: ../src/common/accelcmn.cpp:55
 msgid "PageDown"
 msgstr "PgDn"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:57
+#: ../src/common/accelcmn.cpp:54
 msgid "PageUp"
 msgstr "PgUp"
 
-#: ../src/generic/prntdlgg.cpp:212
+#: ../src/generic/prntdlgg.cpp:209
 msgid "Pages"
 msgstr "頁"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1669
+#: ../src/propgrid/advprops.cpp:1666
 msgid "Paint Brush"
 msgstr "筆刷"
 
-#: ../src/generic/prntdlgg.cpp:598 ../src/generic/prntdlgg.cpp:797
-#: ../src/generic/prntdlgg.cpp:838 ../src/generic/prntdlgg.cpp:851
-#: ../src/generic/prntdlgg.cpp:1048 ../src/generic/prntdlgg.cpp:1053
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:794
+#: ../src/generic/prntdlgg.cpp:835 ../src/generic/prntdlgg.cpp:848
+#: ../src/generic/prntdlgg.cpp:1045 ../src/generic/prntdlgg.cpp:1050
 msgid "Paper size"
 msgstr "紙張大小"
 
-#: ../src/richtext/richtextstyles.cpp:1062
+#: ../src/richtext/richtextstyles.cpp:1059
 msgid "Paragraph styles"
 msgstr "段落樣式"
 
-#: ../src/common/xtistrm.cpp:465
+#: ../src/common/xtistrm.cpp:462
 msgid "Passing a already registered object to SetObject"
 msgstr "傳入已註冊的物件給 SetObject"
 
-#: ../src/common/xtistrm.cpp:476
+#: ../src/common/xtistrm.cpp:473
 msgid "Passing an unknown object to GetObject"
 msgstr "傳入不明物件給 GetObject"
 
-#: ../src/common/stockitem.cpp:180 ../src/richtext/richtextctrl.cpp:3517
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:177 ../src/richtext/richtextctrl.cpp:3514
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "貼上"
 
-#: ../src/common/stockitem.cpp:263
+#: ../src/common/stockitem.cpp:260
 msgid "Paste selection"
 msgstr "貼上選取項目"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:74
+#: ../src/common/accelcmn.cpp:71
 msgid "Pause"
 msgstr "Pause"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1670
+#: ../src/propgrid/advprops.cpp:1667
 msgid "Pencil"
 msgstr "鉛筆"
 
-#: ../src/richtext/richtextbulletspage.cpp:159
 #: ../src/richtext/richtextliststylepage.cpp:222
+#: ../src/richtext/richtextbulletspage.cpp:159
 msgid "Peri&od"
 msgstr "週期(&O)"
 
-#: ../src/generic/filectrlg.cpp:430
+#: ../src/generic/filectrlg.cpp:426
 msgid "Permissions"
 msgstr "允許"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:60
+#: ../src/common/accelcmn.cpp:57
 msgid "PgDn"
 msgstr "PgDn"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:59
+#: ../src/common/accelcmn.cpp:56
 msgid "PgUp"
 msgstr "PgUp"
 
-#: ../src/richtext/richtextbuffer.cpp:12869
+#: ../src/richtext/richtextbuffer.cpp:12863
 msgid "Picture Properties"
 msgstr "圖片性質"
 
@@ -5774,42 +5786,42 @@ msgstr "無法建立管道"
 msgid "Please choose a valid font."
 msgstr "請選擇有效字型。"
 
-#: ../src/generic/filedlgg.cpp:357 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
 msgid "Please choose an existing file."
 msgstr "請選擇已有檔案。"
 
-#: ../src/html/helpwnd.cpp:801
+#: ../src/html/helpwnd.cpp:798
 msgid "Please choose the page to display:"
 msgstr "請選擇要顯示的頁面:"
 
-#: ../src/msw/dialup.cpp:763
+#: ../src/msw/dialup.cpp:758
 msgid "Please choose which ISP do you want to connect to"
 msgstr "請選擇要連線的 ISP"
 
-#: ../src/common/headerctrlcmn.cpp:60
+#: ../src/common/headerctrlcmn.cpp:57
 msgid "Please select the columns to show and define their order:"
 msgstr "請選取欄位，以顯示並定義其排序："
 
-#: ../src/common/prntbase.cpp:538
+#: ../src/common/prntbase.cpp:533
 msgid "Please wait while printing..."
 msgstr "列印中，請稍待..."
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1671
+#: ../src/propgrid/advprops.cpp:1668
 msgid "Point Left"
 msgstr "向左指"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1672
+#: ../src/propgrid/advprops.cpp:1669
 msgid "Point Right"
 msgstr "向右指"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:575
+#: ../src/propgrid/advprops.cpp:572
 msgid "Point Size"
 msgstr "字點大小"
 
-#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:863
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:860
 msgid "Portrait"
 msgstr "直向列印"
 
@@ -5817,252 +5829,261 @@ msgstr "直向列印"
 msgid "Position"
 msgstr "位置"
 
-#: ../src/generic/prntdlgg.cpp:294
+#: ../src/generic/prntdlgg.cpp:291
 msgid "PostScript file"
 msgstr "PostScript 文件"
 
-#: ../src/common/stockitem.cpp:181
+#: ../src/common/stockitem.cpp:178 ../src/osx/cocoa/preferences.mm:303
 msgid "Preferences"
 msgstr "偏好設定"
 
-#: ../src/osx/menu_osx.cpp:457
+#: ../src/osx/menu_osx.cpp:460
 msgid "Preferences..."
 msgstr "偏好設定..."
 
-#: ../src/common/prntbase.cpp:546
+#: ../src/common/prntbase.cpp:541
 msgid "Preparing"
 msgstr "正在準備"
 
-#: ../src/generic/fontdlgg.cpp:456 ../src/html/helpwnd.cpp:1223
-#: ../src/osx/carbon/fontdlg.cpp:390
+#: ../src/osx/carbon/fontdlg.cpp:387 ../src/generic/fontdlgg.cpp:452
+#: ../src/html/helpwnd.cpp:1220
 msgid "Preview:"
 msgstr "預覽︰"
 
-#: ../src/common/prntbase.cpp:1583 ../src/html/helpwnd.cpp:665
+#: ../src/common/prntbase.cpp:1578 ../src/html/helpwnd.cpp:662
 msgid "Previous page"
 msgstr "上一頁"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:77 ../src/common/prntbase.cpp:426
-#: ../src/common/prntbase.cpp:1571 ../src/generic/prntdlgg.cpp:139
-#: ../src/generic/prntdlgg.cpp:153 ../src/gtk/print.cpp:620
-#: ../src/gtk/print.cpp:638
+#: ../src/common/prntbase.cpp:421 ../src/common/prntbase.cpp:1566
+#: ../src/common/accelcmn.cpp:74 ../src/generic/prntdlgg.cpp:136
+#: ../src/generic/prntdlgg.cpp:150 ../src/gtk/print.cpp:616
+#: ../src/gtk/print.cpp:634
 msgid "Print"
 msgstr "列印"
 
-#: ../include/wx/prntbase.h:403 ../src/common/docview.cpp:1265
+#: ../src/common/docview.cpp:1262
 msgid "Print Preview"
 msgstr "預覽列印"
 
-#: ../src/common/prntbase.cpp:2045 ../src/common/prntbase.cpp:2087
-#: ../src/common/prntbase.cpp:2095
+#: ../src/common/prntbase.cpp:2037 ../src/common/prntbase.cpp:2079
+#: ../src/common/prntbase.cpp:2087
 msgid "Print Preview Failure"
 msgstr "預覽列印失敗"
 
-#: ../src/generic/prntdlgg.cpp:220
+#: ../src/generic/prntdlgg.cpp:217
 msgid "Print Range"
 msgstr "列印範圍"
 
-#: ../src/generic/prntdlgg.cpp:445
+#: ../src/generic/prntdlgg.cpp:442
 msgid "Print Setup"
 msgstr "列印設定"
 
-#: ../src/generic/prntdlgg.cpp:617
+#: ../src/generic/prntdlgg.cpp:614
 msgid "Print in colour"
 msgstr "彩色列印"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/osx/webview_webkit.mm:260
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "無法初始化欄位描述"
+
+#: ../src/common/stockitem.cpp:179
 msgid "Print previe&w..."
 msgstr "預覽列印(&W)..."
 
-#: ../src/common/docview.cpp:1259
+#: ../src/common/docview.cpp:1256
 msgid "Print preview creation failed."
 msgstr "建立預覽列印失敗。"
 
-#: ../src/common/stockitem.cpp:182
+#: ../src/common/stockitem.cpp:179
 msgid "Print preview..."
 msgstr "預覽列印..."
 
-#: ../src/generic/prntdlgg.cpp:626
+#: ../src/generic/prntdlgg.cpp:623
 msgid "Print spooling"
 msgstr "列印佇列中"
 
-#: ../src/html/helpwnd.cpp:676
+#: ../src/html/helpwnd.cpp:673
 msgid "Print this page"
 msgstr "列印本頁"
 
-#: ../src/generic/prntdlgg.cpp:181
+#: ../src/generic/prntdlgg.cpp:178
 msgid "Print to File"
 msgstr "列印到檔案"
 
-#: ../src/common/stockitem.cpp:183
+#: ../src/common/stockitem.cpp:180
 msgid "Print..."
 msgstr "列印..."
 
-#: ../src/generic/prntdlgg.cpp:489
+#: ../src/generic/prntdlgg.cpp:486
 msgid "Printer"
 msgstr "印表機"
 
-#: ../src/generic/prntdlgg.cpp:629
+#: ../src/generic/prntdlgg.cpp:626
 msgid "Printer command:"
 msgstr "印表機指令："
 
-#: ../src/generic/prntdlgg.cpp:176
+#: ../src/generic/prntdlgg.cpp:173
 msgid "Printer options"
 msgstr "印表機選項"
 
-#: ../src/generic/prntdlgg.cpp:641
+#: ../src/generic/prntdlgg.cpp:638
 msgid "Printer options:"
 msgstr "印表機選項："
 
-#: ../src/generic/prntdlgg.cpp:912
+#: ../src/generic/prntdlgg.cpp:909
 msgid "Printer..."
 msgstr "印表機…"
 
-#: ../src/generic/prntdlgg.cpp:192
+#: ../src/generic/prntdlgg.cpp:189
 msgid "Printer:"
 msgstr "印表機:"
 
-#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:535
-#: ../src/html/htmprint.cpp:292
+#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:530
+#: ../src/html/htmprint.cpp:289
 msgid "Printing"
 msgstr "列印"
 
-#: ../src/common/prntbase.cpp:612
+#: ../src/common/prntbase.cpp:607
 msgid "Printing "
 msgstr "正在列印 "
 
-#: ../src/common/prntbase.cpp:347
+#: ../src/common/prntbase.cpp:342
 msgid "Printing Error"
 msgstr "列印時發生錯誤"
 
-#: ../src/common/prntbase.cpp:565
+#: ../src/osx/webview_webkit.mm:251
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "這一版的 zlib 不支援 Gzip"
+
+#: ../src/common/prntbase.cpp:560
 #, c-format
 msgid "Printing page %d"
 msgstr "正在列印第 %d 頁"
 
-#: ../src/common/prntbase.cpp:570
+#: ../src/common/prntbase.cpp:565
 #, c-format
 msgid "Printing page %d of %d"
 msgstr "正在列印第 %d 頁 (共 %d 頁)"
 
-#: ../src/generic/printps.cpp:185
+#: ../src/generic/printps.cpp:182
 #, c-format
 msgid "Printing page %d..."
 msgstr "正在列印第 %d 頁…"
 
-#: ../src/generic/printps.cpp:145
+#: ../src/generic/printps.cpp:142
 msgid "Printing..."
 msgstr "列印中…"
 
 #: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
-#: ../src/common/docview.cpp:2140
+#: ../src/common/docview.cpp:2137
 msgid "Printout"
 msgstr "列印"
 
-#: ../src/common/debugrpt.cpp:564
+#: ../src/common/debugrpt.cpp:561
 #, c-format
 msgid ""
 "Processing debug report has failed, leaving the files in \"%s\" directory."
 msgstr "處理除錯報告失敗, 檔案儲存在「%s」目錄。"
 
-#: ../src/common/prntbase.cpp:545
+#: ../src/common/prntbase.cpp:540
 msgid "Progress:"
 msgstr "進度："
 
-#: ../src/common/stockitem.cpp:184
+#: ../src/common/stockitem.cpp:181
 msgid "Properties"
 msgstr "性質"
 
-#: ../src/propgrid/manager.cpp:226
+#: ../src/propgrid/manager.cpp:223
 msgid "Property"
 msgstr "性質"
 
 #. TRANSLATORS: Caption of message box displaying any property error
-#: ../src/propgrid/propgrid.cpp:3136 ../src/propgrid/propgrid.cpp:3273
+#: ../src/propgrid/propgrid.cpp:3162 ../src/propgrid/propgrid.cpp:3299
 msgid "Property Error"
 msgstr "性質錯誤"
 
-#: ../src/propgrid/advprops.cpp:1506
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Purple"
 msgstr "紫色"
 
-#: ../src/common/paper.cpp:112
+#: ../src/common/paper.cpp:109
 msgid "Quarto, 215 x 275 mm"
 msgstr "四開，215 x 275 mm"
 
-#: ../src/generic/logg.cpp:1016
+#: ../src/generic/logg.cpp:1013
 msgid "Question"
 msgstr "問題"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1673
+#: ../src/propgrid/advprops.cpp:1670
 msgid "Question Arrow"
 msgstr "問題箭頭"
 
-#: ../src/common/stockitem.cpp:156
+#: ../src/common/stockitem.cpp:153
 msgid "Quit"
 msgstr "結束"
 
-#: ../src/osx/menu_osx.cpp:474
+#: ../src/osx/menu_osx.cpp:477
 #, c-format
 msgid "Quit %s"
 msgstr "結束 %s"
 
-#: ../src/common/stockitem.cpp:264
+#: ../src/common/stockitem.cpp:261
 msgid "Quit this program"
 msgstr "結束這個程式"
 
-#: ../src/common/accelcmn.cpp:355
+#: ../src/common/accelcmn.cpp:352
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/ffile.cpp:109 ../src/common/ffile.cpp:134
+#: ../src/common/ffile.cpp:107 ../src/common/ffile.cpp:132
 #, c-format
 msgid "Read error on file '%s'"
 msgstr "讀取「%s」檔案時發生錯誤"
 
-#: ../src/common/secretstore.cpp:201
+#: ../src/common/secretstore.cpp:211
 #, c-format
-#| msgid "Reading password for \"%s/%s\" failed: %s."
 msgid "Reading password for \"%s\" failed: %s."
 msgstr "讀取「%s」的密碼失敗：%s。"
 
-#: ../src/common/prntbase.cpp:272
+#: ../src/common/prntbase.cpp:267
 msgid "Ready"
 msgstr "就緒"
 
-#: ../src/propgrid/advprops.cpp:1514
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Red"
 msgstr "紅色"
 
-#: ../src/generic/colrdlgg.cpp:339
+#: ../src/generic/colrdlgg.cpp:359
 msgid "Red:"
 msgstr "紅色："
 
-#: ../src/common/stockitem.cpp:185 ../src/stc/stc_i18n.cpp:16
+#: ../src/common/stockitem.cpp:182 ../src/stc/stc_i18n.cpp:16
 msgid "Redo"
 msgstr "重做"
 
-#: ../src/common/stockitem.cpp:265
+#: ../src/common/stockitem.cpp:262
 msgid "Redo last action"
 msgstr "重做最後一個動作"
 
-#: ../src/common/stockitem.cpp:186
+#: ../src/common/stockitem.cpp:183
 msgid "Refresh"
 msgstr "重新整理"
 
-#: ../src/msw/registry.cpp:626
+#: ../src/msw/registry.cpp:615
 #, c-format
 msgid "Registry key '%s' already exists."
 msgstr "登錄機碼 '%s' 已存在。"
 
-#: ../src/msw/registry.cpp:595
+#: ../src/msw/registry.cpp:584
 #, c-format
 msgid "Registry key '%s' does not exist, cannot rename it."
 msgstr "登錄機碼 '%s' 不存在, 無法更名。"
 
-#: ../src/msw/registry.cpp:727
+#: ../src/msw/registry.cpp:716
 #, c-format
 msgid ""
 "Registry key '%s' is needed for normal system operation,\n"
@@ -6073,22 +6094,22 @@ msgstr ""
 "刪除它會使系統處於無法使用的狀態：\n"
 "操作中斷。"
 
-#: ../src/msw/registry.cpp:953
+#: ../src/msw/registry.cpp:942
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr "登錄機碼「%s」不是二進位 (但卻是 %s 類型)"
 
-#: ../src/msw/registry.cpp:916
+#: ../src/msw/registry.cpp:905
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr "登錄機碼「%s」不是數字 (但卻是 %s 類型)"
 
-#: ../src/msw/registry.cpp:1002
+#: ../src/msw/registry.cpp:991
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr "登錄機碼「%s」不是文字 (但卻是 %s 類型)"
 
-#: ../src/msw/registry.cpp:521
+#: ../src/msw/registry.cpp:510
 #, c-format
 msgid "Registry value '%s' already exists."
 msgstr "登錄機值 '%s' 已存在。"
@@ -6102,7 +6123,7 @@ msgstr "一般"
 msgid "Relative"
 msgstr "相對"
 
-#: ../src/generic/helpext.cpp:459
+#: ../src/generic/helpext.cpp:456
 msgid "Relevant entries:"
 msgstr "相關項目："
 
@@ -6110,68 +6131,66 @@ msgstr "相關項目："
 msgid "Remaining time:"
 msgstr "餘下時間："
 
-#: ../src/common/stockitem.cpp:187
+#: ../src/common/stockitem.cpp:184
 msgid "Remove"
 msgstr "移除"
 
-#: ../src/richtext/richtextctrl.cpp:1566
+#: ../src/richtext/richtextctrl.cpp:1563
 msgid "Remove Bullet"
 msgstr "移除項目符號"
 
-#: ../src/html/helpwnd.cpp:434
+#: ../src/html/helpwnd.cpp:431
 msgid "Remove current page from bookmarks"
 msgstr "從書籤移除目前頁面"
 
-#: ../src/common/rendcmn.cpp:194
+#: ../src/common/rendcmn.cpp:191
 #, c-format
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr "潤算器「%s」是不相容的 %d.%d 版本，而且無法載入。"
 
-#: ../src/richtext/richtextbuffer.cpp:4527
+#: ../src/richtext/richtextbuffer.cpp:4524
 msgid "Renumber List"
 msgstr "重新編號清單"
 
-#: ../src/common/stockitem.cpp:188
-#| msgid "Rep&lace"
+#: ../src/common/stockitem.cpp:185
 msgid "Rep&lace..."
 msgstr "取代(&L)…"
 
-#: ../src/richtext/richtextctrl.cpp:3677
+#: ../src/richtext/richtextctrl.cpp:3674
 msgid "Replace"
 msgstr "取代"
 
-#: ../src/generic/fdrepdlg.cpp:182
+#: ../src/generic/fdrepdlg.cpp:179
 msgid "Replace &all"
 msgstr "全部取代(&A)"
 
-#: ../src/generic/fdrepdlg.cpp:124
+#: ../src/generic/fdrepdlg.cpp:121
 msgid "Replace with:"
 msgstr "取代成："
 
-#: ../src/common/stockitem.cpp:188
-#| msgid "Replace"
+#: ../src/common/stockitem.cpp:185
 msgid "Replace..."
 msgstr "取代…"
 
-#: ../src/common/valtext.cpp:187
+#: ../src/common/valtext.cpp:184
 msgid "Required information entry is empty."
 msgstr "所需的資訊項目空白。"
 
-#: ../src/common/translation.cpp:2027
+#: ../src/common/translation.cpp:2025
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "「%s」資源不是有效的訊息分類。"
 
-#: ../src/gtk/webview_webkit.cpp:974
+#: ../src/gtk/webview_webkit.cpp:985
 msgid "Retrieving JavaScript script output is not supported with WebKit v1"
 msgstr "WebKit v1 不支援取得 JavaScript 文稿輸出"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:56
+#: ../src/common/accelcmn.cpp:53
 msgid "Return"
 msgstr "輸入"
 
-#: ../src/common/stockitem.cpp:189
+#: ../src/common/stockitem.cpp:186
 msgid "Revert to Saved"
 msgstr "還原為上次儲存的檔案"
 
@@ -6185,171 +6204,169 @@ msgstr "右至左(&H)"
 
 #. TRANSLATORS: Name of keyboard key
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/common/accelcmn.cpp:62 ../src/generic/datavgen.cpp:6597
-#: ../src/richtext/richtextbulletspage.cpp:188
-#: ../src/richtext/richtextliststylepage.cpp:251
+#: ../src/common/accelcmn.cpp:59 ../src/generic/datavgen.cpp:6954
 #: ../src/richtext/richtextsizepage.cpp:250
+#: ../src/richtext/richtextliststylepage.cpp:251
+#: ../src/richtext/richtextbulletspage.cpp:188
 msgid "Right"
 msgstr "右"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1658
+#: ../src/propgrid/advprops.cpp:1655
 msgid "Right Arrow"
 msgstr "右箭頭"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1674
+#: ../src/propgrid/advprops.cpp:1671
 msgid "Right Button"
 msgstr "右鍵"
 
-#: ../src/generic/prntdlgg.cpp:888
+#: ../src/generic/prntdlgg.cpp:885
 msgid "Right margin (mm):"
 msgstr "右邊距(公釐)："
 
-#: ../src/richtext/richtextindentspage.cpp:148
-#: ../src/richtext/richtextindentspage.cpp:150
 #: ../src/richtext/richtextliststylepage.cpp:337
 #: ../src/richtext/richtextliststylepage.cpp:339
+#: ../src/richtext/richtextindentspage.cpp:148
+#: ../src/richtext/richtextindentspage.cpp:150
 msgid "Right-align text."
 msgstr "文字向右對齊。"
 
-#: ../src/generic/fontdlgg.cpp:322
+#: ../src/generic/fontdlgg.cpp:318
 msgid "Roman"
 msgstr "羅馬"
 
-#: ../src/generic/datavgen.cpp:6364
+#: ../src/generic/datavgen.cpp:6721
 #, c-format
 msgid "Row %i"
 msgstr "第 %i 行"
 
-#: ../src/richtext/richtextbulletspage.cpp:239
 #: ../src/richtext/richtextliststylepage.cpp:299
+#: ../src/richtext/richtextbulletspage.cpp:239
 msgid "S&tandard bullet name:"
 msgstr "標準項目符號名稱(&T):"
 
-#: ../src/common/accelcmn.cpp:285 ../src/common/accelcmn.cpp:370
+#: ../src/common/accelcmn.cpp:282 ../src/common/accelcmn.cpp:367
 msgid "SPECIAL"
 msgstr "SPECIAL"
 
-#: ../src/common/sizer.cpp:2844 ../src/common/stockitem.cpp:190
+#: ../src/common/stockitem.cpp:187 ../src/common/sizer.cpp:2914
 msgid "Save"
 msgstr "儲存"
 
-#: ../src/common/fldlgcmn.cpp:342
+#: ../src/common/fldlgcmn.cpp:339
 #, c-format
 msgid "Save %s file"
 msgstr "儲存 %s 檔案"
 
-#: ../src/common/stockitem.cpp:191 ../src/generic/logg.cpp:512
+#: ../src/common/stockitem.cpp:188 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "另存新檔(&A)…"
 
-#: ../src/common/docview.cpp:362
+#: ../src/common/docview.cpp:359
 msgid "Save As"
 msgstr "另存新檔"
 
-#: ../src/common/stockitem.cpp:191
-#| msgid "Save &As..."
+#: ../src/common/stockitem.cpp:188
 msgid "Save As..."
 msgstr "另存新檔(&A)…"
 
-#: ../src/common/stockitem.cpp:270
+#: ../src/common/stockitem.cpp:267
 msgid "Save current document"
 msgstr "儲存目前文件"
 
-#: ../src/common/stockitem.cpp:271
+#: ../src/common/stockitem.cpp:268
 msgid "Save current document with a different filename"
 msgstr "儲存當前文件至不同的檔名"
 
-#: ../src/generic/logg.cpp:512
+#: ../src/generic/logg.cpp:509
 msgid "Save log contents to file"
 msgstr "將日誌內容儲存到檔案"
 
-#: ../src/common/secretstore.cpp:179
+#: ../src/common/secretstore.cpp:189
 #, c-format
-#| msgid "Saving password for \"%s/%s\" failed: %s."
 msgid "Saving password for \"%s\" failed: %s."
 msgstr "無法儲存「%s」的密碼：%s。"
 
-#: ../src/generic/fontdlgg.cpp:325
+#: ../src/generic/fontdlgg.cpp:321
 msgid "Script"
 msgstr "手寫體"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll Lock"
 msgstr "Scroll Lock"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:88
+#: ../src/common/accelcmn.cpp:85
 msgid "Scroll_lock"
 msgstr "Scroll_lock"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:794
+#: ../src/propgrid/advprops.cpp:791
 msgid "Scrollbar"
 msgstr "Scrollbar"
 
-#: ../src/generic/srchctlg.cpp:58 ../src/gtk/srchctrl.cpp:185
-#: ../src/html/helpwnd.cpp:536 ../src/html/helpwnd.cpp:551
+#: ../src/generic/srchctlg.cpp:55 ../src/html/helpwnd.cpp:533
+#: ../src/html/helpwnd.cpp:548 ../src/gtk/srchctrl.cpp:182
 msgid "Search"
 msgstr "搜尋"
 
-#: ../src/html/helpwnd.cpp:538
+#: ../src/html/helpwnd.cpp:535
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
 msgstr "搜尋說明文件內容中，您所輸入文字的所有出現過的地方"
 
-#: ../src/generic/fdrepdlg.cpp:160
+#: ../src/generic/fdrepdlg.cpp:157
 msgid "Search direction"
 msgstr "搜尋方向"
 
-#: ../src/generic/fdrepdlg.cpp:112
+#: ../src/generic/fdrepdlg.cpp:109
 msgid "Search for:"
 msgstr "搜尋："
 
-#: ../src/html/helpwnd.cpp:1053
+#: ../src/html/helpwnd.cpp:1050
 msgid "Search in all books"
 msgstr "搜尋所有的書籍"
 
-#: ../src/html/helpwnd.cpp:858
+#: ../src/html/helpwnd.cpp:855
 msgid "Searching..."
 msgstr "搜尋中…"
 
-#: ../src/generic/dirctrlg.cpp:446
+#: ../src/generic/dirctrlg.cpp:412
 msgid "Sections"
 msgstr "章節"
 
-#: ../src/common/ffile.cpp:239
+#: ../src/common/ffile.cpp:237
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "「%s」檔案定位錯誤"
 
-#: ../src/common/ffile.cpp:229
+#: ../src/common/ffile.cpp:227
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr "「%s」檔案定位錯誤 (stdio 不支援大檔案)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:76
+#: ../src/common/accelcmn.cpp:73
 msgid "Select"
 msgstr "選取"
 
-#: ../src/common/stockitem.cpp:192 ../src/msw/textctrl.cpp:2727
-#: ../src/osx/textctrl_osx.cpp:589 ../src/richtext/richtextctrl.cpp:339
+#: ../src/osx/textctrl_osx.cpp:599 ../src/common/stockitem.cpp:189
+#: ../src/msw/textctrl.cpp:2777 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "全部選擇(&A)"
 
-#: ../src/common/stockitem.cpp:192 ../src/stc/stc_i18n.cpp:21
+#: ../src/common/stockitem.cpp:189 ../src/stc/stc_i18n.cpp:21
 msgid "Select All"
 msgstr "全部選擇"
 
-#: ../src/common/docview.cpp:1903
+#: ../src/common/docview.cpp:1900
 msgid "Select a document template"
 msgstr "選擇文件範本"
 
-#: ../src/common/docview.cpp:1977
+#: ../src/common/docview.cpp:1974
 msgid "Select a document view"
 msgstr "選擇文件檢視"
 
@@ -6378,20 +6395,20 @@ msgid "Selects the list level to edit."
 msgstr "選取並編輯該清單層級。"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:82
+#: ../src/common/accelcmn.cpp:79
 msgid "Separator"
 msgstr "Separator"
 
-#: ../src/common/cmdline.cpp:1082
+#: ../src/common/cmdline.cpp:1079
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "在「%s」選項之後應有分隔字元。"
 
-#: ../src/osx/menu_osx.cpp:461
+#: ../src/osx/menu_osx.cpp:464
 msgid "Services"
 msgstr "服務"
 
-#: ../src/richtext/richtextbuffer.cpp:11219
+#: ../src/richtext/richtextbuffer.cpp:11216
 msgid "Set Cell Style"
 msgstr "設定儲存格樣式"
 
@@ -6399,11 +6416,11 @@ msgstr "設定儲存格樣式"
 msgid "SetProperty called w/o valid setter"
 msgstr "呼叫 SetProperty 時未帶有效的 setter"
 
-#: ../src/generic/prntdlgg.cpp:184
+#: ../src/generic/prntdlgg.cpp:181
 msgid "Setup..."
 msgstr "設定…"
 
-#: ../src/msw/dialup.cpp:543
+#: ../src/msw/dialup.cpp:538
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr "多個撥號連線中，隨機選擇一個。"
 
@@ -6419,47 +6436,47 @@ msgstr "陰影"
 msgid "Shadow c&olour:"
 msgstr "陰影顏色（&O）："
 
-#: ../src/common/accelcmn.cpp:352
+#: ../src/common/accelcmn.cpp:349
 msgid "Shift+"
 msgstr "Shift+"
 
-#: ../src/generic/dirdlgg.cpp:147
+#: ../src/generic/dirdlgg.cpp:144
 msgid "Show &hidden directories"
 msgstr "顯示隱藏目錄(&H)"
 
-#: ../src/generic/filectrlg.cpp:983
+#: ../src/generic/filectrlg.cpp:979
 msgid "Show &hidden files"
 msgstr "顯示隱藏檔案(&H)"
 
-#: ../src/osx/menu_osx.cpp:469
+#: ../src/osx/menu_osx.cpp:472
 msgid "Show All"
 msgstr "全部顯示"
 
-#: ../src/common/stockitem.cpp:257
+#: ../src/common/stockitem.cpp:254
 msgid "Show about dialog"
 msgstr "顯示關於對話方塊"
 
-#: ../src/html/helpwnd.cpp:493
+#: ../src/html/helpwnd.cpp:490
 msgid "Show all"
 msgstr "全部顯示"
 
-#: ../src/html/helpwnd.cpp:504
+#: ../src/html/helpwnd.cpp:501
 msgid "Show all items in index"
 msgstr "以索引的方式顯示所有項目"
 
-#: ../src/html/helpwnd.cpp:659
+#: ../src/html/helpwnd.cpp:656
 msgid "Show/hide navigation panel"
 msgstr "顯示/隱藏導覽面板"
 
-#: ../src/richtext/richtextsymboldlg.cpp:421
-#: ../src/richtext/richtextsymboldlg.cpp:423
+#: ../src/richtext/richtextsymboldlg.cpp:418
+#: ../src/richtext/richtextsymboldlg.cpp:420
 msgid "Shows a Unicode subset."
 msgstr "顯示 Unicode 子集。"
 
-#: ../src/richtext/richtextbulletspage.cpp:263
-#: ../src/richtext/richtextbulletspage.cpp:265
 #: ../src/richtext/richtextliststylepage.cpp:472
 #: ../src/richtext/richtextliststylepage.cpp:474
+#: ../src/richtext/richtextbulletspage.cpp:263
+#: ../src/richtext/richtextbulletspage.cpp:265
 msgid "Shows a preview of the bullet settings."
 msgstr "預覽項目符號設定。"
 
@@ -6468,7 +6485,7 @@ msgstr "預覽項目符號設定。"
 msgid "Shows a preview of the font settings."
 msgstr "顯示字型設定預覽。"
 
-#: ../src/osx/carbon/fontdlg.cpp:394 ../src/osx/carbon/fontdlg.cpp:396
+#: ../src/osx/carbon/fontdlg.cpp:391 ../src/osx/carbon/fontdlg.cpp:393
 msgid "Shows a preview of the font."
 msgstr "預覽字型。"
 
@@ -6477,62 +6494,62 @@ msgstr "預覽字型。"
 msgid "Shows a preview of the paragraph settings."
 msgstr "預覽段落設定。"
 
-#: ../src/generic/fontdlgg.cpp:460 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:456 ../src/generic/fontdlgg.cpp:458
 msgid "Shows the font preview."
 msgstr "顯示字型預覽。"
 
-#: ../src/propgrid/advprops.cpp:1516
+#: ../src/propgrid/advprops.cpp:1513
 msgid "Silver"
 msgstr "銀色"
 
-#: ../src/univ/themes/mono.cpp:516
+#: ../src/univ/themes/mono.cpp:513
 msgid "Simple monochrome theme"
 msgstr "簡單的單色佈景主題"
 
-#: ../src/richtext/richtextindentspage.cpp:275
 #: ../src/richtext/richtextliststylepage.cpp:449
+#: ../src/richtext/richtextindentspage.cpp:275
 msgid "Single"
 msgstr "單一"
 
-#: ../src/generic/filectrlg.cpp:425 ../src/richtext/richtextformatdlg.cpp:365
-#: ../src/richtext/richtextsizepage.cpp:299
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextsizepage.cpp:299
+#: ../src/richtext/richtextformatdlg.cpp:362
 msgid "Size"
 msgstr "大小"
 
-#: ../src/osx/carbon/fontdlg.cpp:339
+#: ../src/osx/carbon/fontdlg.cpp:336
 msgid "Size:"
 msgstr "大小："
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1679
+#: ../src/propgrid/advprops.cpp:1676
 msgid "Sizing"
 msgstr "縮放"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1676
+#: ../src/propgrid/advprops.cpp:1673
 msgid "Sizing N-S"
 msgstr "縮放(南至北)"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1675
+#: ../src/propgrid/advprops.cpp:1672
 msgid "Sizing NE-SW"
 msgstr "縮放(東北至西南)"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1677
+#: ../src/propgrid/advprops.cpp:1674
 msgid "Sizing NW-SE"
 msgstr "縮放(東南至西北)"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1678
+#: ../src/propgrid/advprops.cpp:1675
 msgid "Sizing W-E"
 msgstr "縮放(東至西)"
 
-#: ../src/msw/progdlg.cpp:1091
+#: ../src/msw/progdlg.cpp:1088
 msgid "Skip"
 msgstr "略過"
 
-#: ../src/generic/fontdlgg.cpp:330
+#: ../src/generic/fontdlgg.cpp:326
 msgid "Slant"
 msgstr "傾斜"
 
@@ -6541,7 +6558,7 @@ msgid "Small C&apitals"
 msgstr "小型大寫字(&A)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:79
+#: ../src/common/accelcmn.cpp:76
 msgid "Snapshot"
 msgstr "Snapshot"
 
@@ -6549,37 +6566,37 @@ msgstr "Snapshot"
 msgid "Solid"
 msgstr "單色"
 
-#: ../src/common/docview.cpp:1788
+#: ../src/common/docview.cpp:1785
 msgid "Sorry, could not open this file."
 msgstr "抱歉，無法開啟檔案。"
 
-#: ../src/common/prntbase.cpp:2087 ../src/common/prntbase.cpp:2095
+#: ../src/common/prntbase.cpp:2079 ../src/common/prntbase.cpp:2087
 msgid "Sorry, not enough memory to create a preview."
 msgstr "抱歉，記憶體不足，無法建立預覽。"
 
-#: ../src/richtext/richtextstyledlg.cpp:611
-#: ../src/richtext/richtextstyledlg.cpp:659
-#: ../src/richtext/richtextstyledlg.cpp:825
-#: ../src/richtext/richtextstyledlg.cpp:901
-#: ../src/richtext/richtextstyledlg.cpp:939
+#: ../src/richtext/richtextstyledlg.cpp:607
+#: ../src/richtext/richtextstyledlg.cpp:655
+#: ../src/richtext/richtextstyledlg.cpp:821
+#: ../src/richtext/richtextstyledlg.cpp:897
+#: ../src/richtext/richtextstyledlg.cpp:935
 msgid "Sorry, that name is taken. Please choose another."
 msgstr "抱歉，名字已被使用，請選擇其他名字。"
 
-#: ../src/common/docview.cpp:1822
+#: ../src/common/docview.cpp:1819
 msgid "Sorry, the format for this file is unknown."
 msgstr "抱歉，檔案格式不明。"
 
-#: ../src/unix/sound.cpp:484
+#: ../src/unix/sound.cpp:481
 msgid "Sound data are in unsupported format."
 msgstr "聲音資料格式不支援。"
 
-#: ../src/unix/sound.cpp:469
+#: ../src/unix/sound.cpp:466
 #, c-format
 msgid "Sound file '%s' is in unsupported format."
 msgstr "「%s」聲音檔案格式不支援。"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:67
+#: ../src/common/accelcmn.cpp:64
 msgid "Space"
 msgstr "空格"
 
@@ -6587,21 +6604,21 @@ msgstr "空格"
 msgid "Spacing"
 msgstr "間距"
 
-#: ../src/common/stockitem.cpp:197
+#: ../src/common/stockitem.cpp:194
 msgid "Spell Check"
 msgstr "拼字檢查"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1680
+#: ../src/propgrid/advprops.cpp:1677
 msgid "Spraycan"
 msgstr "噴漆"
 
-#: ../src/richtext/richtextbulletspage.cpp:282
 #: ../src/richtext/richtextliststylepage.cpp:490
+#: ../src/richtext/richtextbulletspage.cpp:282
 msgid "Standard"
 msgstr "標準"
 
-#: ../src/common/paper.cpp:104
+#: ../src/common/paper.cpp:101
 msgid "Statement, 5 1/2 x 8 1/2 in"
 msgstr "結算單, 5 1/2 x 8 1/2 英吋"
 
@@ -6610,33 +6627,29 @@ msgstr "結算單, 5 1/2 x 8 1/2 英吋"
 msgid "Static"
 msgstr "靜態"
 
-#: ../src/generic/prntdlgg.cpp:200
+#: ../src/generic/prntdlgg.cpp:197
 msgid "Status:"
 msgstr "狀態:"
 
-#: ../src/common/stockitem.cpp:198
+#: ../src/common/stockitem.cpp:195
 msgid "Stop"
 msgstr "停止"
 
-#: ../src/common/stockitem.cpp:199
+#: ../src/common/stockitem.cpp:196
 msgid "Strikethrough"
 msgstr "刪除線"
 
-#: ../src/common/colourcmn.cpp:45
+#: ../src/common/colourcmn.cpp:42
 #, c-format
 msgid "String To Colour : Incorrect colour specification : %s"
 msgstr "顏色名稱：不正確的顏色規格：%s"
 
 #. TRANSLATORS: Label of font style
-#: ../src/propgrid/advprops.cpp:593 ../src/richtext/richtextformatdlg.cpp:335
+#: ../src/propgrid/advprops.cpp:590 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "樣式"
 
-#: ../include/wx/richtext/richtextstyledlg.h:48
-msgid "Style Organiser"
-msgstr "樣式組織器"
-
-#: ../src/osx/carbon/fontdlg.cpp:348
+#: ../src/osx/carbon/fontdlg.cpp:345
 msgid "Style:"
 msgstr "樣式："
 
@@ -6645,7 +6658,7 @@ msgid "Subscrip&t"
 msgstr "下標(&T)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:83
+#: ../src/common/accelcmn.cpp:80
 msgid "Subtract"
 msgstr "減號"
 
@@ -6653,11 +6666,11 @@ msgstr "減號"
 msgid "Supe&rscript"
 msgstr "下標(&R)"
 
-#: ../src/common/paper.cpp:150
+#: ../src/common/paper.cpp:147
 msgid "SuperA/SuperA/A4 227 x 356 mm"
 msgstr "SuperA/SuperA/A4 227 x 356 公釐"
 
-#: ../src/common/paper.cpp:151
+#: ../src/common/paper.cpp:148
 msgid "SuperB/SuperB/A3 305 x 487 mm"
 msgstr "SuperB/SuperB/A3 305 x 487 公釐"
 
@@ -6665,17 +6678,17 @@ msgstr "SuperB/SuperB/A3 305 x 487 公釐"
 msgid "Suppress hyphe&nation"
 msgstr "抑制將同一英文字分行顯示(&N)"
 
-#: ../src/generic/fontdlgg.cpp:326
+#: ../src/generic/fontdlgg.cpp:322
 msgid "Swiss"
 msgstr "瑞士"
 
-#: ../src/richtext/richtextbulletspage.cpp:280
 #: ../src/richtext/richtextliststylepage.cpp:488
+#: ../src/richtext/richtextbulletspage.cpp:280
 msgid "Symbol"
 msgstr "符號"
 
-#: ../src/richtext/richtextbulletspage.cpp:227
 #: ../src/richtext/richtextliststylepage.cpp:288
+#: ../src/richtext/richtextbulletspage.cpp:227
 msgid "Symbol &font:"
 msgstr "符號字型(&F)："
 
@@ -6683,85 +6696,85 @@ msgstr "符號字型(&F)："
 msgid "Symbols"
 msgstr "符號"
 
-#: ../src/common/imagtiff.cpp:369 ../src/common/imagtiff.cpp:382
-#: ../src/common/imagtiff.cpp:741
+#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
+#: ../src/common/imagtiff.cpp:738
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF：無法配置記憶體。"
 
-#: ../src/common/imagtiff.cpp:301
+#: ../src/common/imagtiff.cpp:298
 msgid "TIFF: Error loading image."
 msgstr "TIFF：載入圖像錯誤。"
 
-#: ../src/common/imagtiff.cpp:468
+#: ../src/common/imagtiff.cpp:465
 msgid "TIFF: Error reading image."
 msgstr "TIFF：讀取圖像錯誤。"
 
-#: ../src/common/imagtiff.cpp:608
+#: ../src/common/imagtiff.cpp:605
 msgid "TIFF: Error saving image."
 msgstr "TIFF：儲存圖像錯誤。"
 
-#: ../src/common/imagtiff.cpp:846
+#: ../src/common/imagtiff.cpp:843
 msgid "TIFF: Error writing image."
 msgstr "TIFF：寫入圖像錯誤。"
 
-#: ../src/common/imagtiff.cpp:355
+#: ../src/common/imagtiff.cpp:352
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF：影像太大。"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:68
+#: ../src/common/accelcmn.cpp:65
 msgid "Tab"
 msgstr "Tab"
 
-#: ../src/richtext/richtextbuffer.cpp:11500
+#: ../src/richtext/richtextbuffer.cpp:11497
 msgid "Table Properties"
 msgstr "表格性質"
 
-#: ../src/common/paper.cpp:145
+#: ../src/common/paper.cpp:142
 msgid "Tabloid Extra 11.69 x 18 in"
 msgstr "小報加長 11.69 x 18 英吋"
 
-#: ../src/common/paper.cpp:102
+#: ../src/common/paper.cpp:99
 msgid "Tabloid, 11 x 17 in"
 msgstr "小報, 11 x 17 英吋"
 
-#: ../src/richtext/richtextformatdlg.cpp:350
+#: ../src/richtext/richtextformatdlg.cpp:347
 msgid "Tabs"
 msgstr "定位點"
 
-#: ../src/propgrid/advprops.cpp:1507
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Teal"
 msgstr "鴨綠色"
 
-#: ../src/generic/fontdlgg.cpp:327
+#: ../src/generic/fontdlgg.cpp:323
 msgid "Teletype"
 msgstr "電傳打字機"
 
-#: ../src/common/docview.cpp:1904
+#: ../src/common/docview.cpp:1901
 msgid "Templates"
 msgstr "範本"
 
-#: ../src/common/fmapbase.cpp:158
+#: ../src/common/fmapbase.cpp:155
 msgid "Thai (ISO-8859-11)"
 msgstr "泰文 (ISO-8859-11)"
 
-#: ../src/common/ftp.cpp:625
+#: ../src/common/ftp.cpp:622
 msgid "The FTP server doesn't support passive mode."
 msgstr "檔案傳輸(FTP)伺服器不支援被動模式。"
 
-#: ../src/common/ftp.cpp:611
+#: ../src/common/ftp.cpp:608
 msgid "The FTP server doesn't support the PORT command."
 msgstr "FTP伺服器不支援PORT指令。"
 
-#: ../src/richtext/richtextbulletspage.cpp:151
-#: ../src/richtext/richtextbulletspage.cpp:153
 #: ../src/richtext/richtextliststylepage.cpp:215
 #: ../src/richtext/richtextliststylepage.cpp:217
+#: ../src/richtext/richtextbulletspage.cpp:151
+#: ../src/richtext/richtextbulletspage.cpp:153
 msgid "The available bullet styles."
 msgstr "可用的項目符號樣式。"
 
-#: ../src/richtext/richtextstyledlg.cpp:202
-#: ../src/richtext/richtextstyledlg.cpp:204
+#: ../src/richtext/richtextstyledlg.cpp:198
+#: ../src/richtext/richtextstyledlg.cpp:200
 msgid "The available styles."
 msgstr "可用的樣式。"
 
@@ -6806,23 +6819,23 @@ msgstr "下內邊距。"
 msgid "The bottom position."
 msgstr "頁尾位置。"
 
-#: ../src/richtext/richtextbulletspage.cpp:191
-#: ../src/richtext/richtextbulletspage.cpp:193
-#: ../src/richtext/richtextbulletspage.cpp:214
-#: ../src/richtext/richtextbulletspage.cpp:216
 #: ../src/richtext/richtextliststylepage.cpp:254
 #: ../src/richtext/richtextliststylepage.cpp:256
 #: ../src/richtext/richtextliststylepage.cpp:275
 #: ../src/richtext/richtextliststylepage.cpp:277
+#: ../src/richtext/richtextbulletspage.cpp:191
+#: ../src/richtext/richtextbulletspage.cpp:193
+#: ../src/richtext/richtextbulletspage.cpp:214
+#: ../src/richtext/richtextbulletspage.cpp:216
 msgid "The bullet character."
 msgstr "項目符號字元。"
 
-#: ../src/richtext/richtextsymboldlg.cpp:443
-#: ../src/richtext/richtextsymboldlg.cpp:445
+#: ../src/richtext/richtextsymboldlg.cpp:440
+#: ../src/richtext/richtextsymboldlg.cpp:442
 msgid "The character code."
 msgstr "字元碼。"
 
-#: ../src/common/fontmap.cpp:203
+#: ../src/common/fontmap.cpp:200
 #, c-format
 msgid ""
 "The charset '%s' is unknown. You may select\n"
@@ -6832,7 +6845,7 @@ msgstr ""
 "不明的字集「%s」。請選擇其他字集取代，\n"
 "如果無法取代，則選擇「取消」"
 
-#: ../src/msw/ole/dataobj.cpp:394
+#: ../src/msw/ole/dataobj.cpp:402
 #, c-format
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "剪貼簿格式「%d」不存在。"
@@ -6842,7 +6855,7 @@ msgstr "剪貼簿格式「%d」不存在。"
 msgid "The default style for the next paragraph."
 msgstr "下一個段落的預設樣式。"
 
-#: ../src/generic/dirdlgg.cpp:202
+#: ../src/generic/dirdlgg.cpp:199
 #, c-format
 msgid ""
 "The directory '%s' does not exist\n"
@@ -6851,7 +6864,7 @@ msgstr ""
 "目錄「%s」不存在\n"
 "是否馬上建立？"
 
-#: ../src/html/htmprint.cpp:286
+#: ../src/html/htmprint.cpp:283
 #, c-format
 msgid ""
 "The document \"%s\" doesn't fit on the page horizontally and will be "
@@ -6863,7 +6876,7 @@ msgstr ""
 "\n"
 "無論如何都要列印此份文件？"
 
-#: ../src/common/docview.cpp:1199
+#: ../src/common/docview.cpp:1196
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -6872,36 +6885,36 @@ msgstr ""
 "「%s」檔案不存在，無法開啟。\n"
 "已從最近使用的檔案紀錄清單中除名。"
 
-#: ../src/richtext/richtextindentspage.cpp:208
-#: ../src/richtext/richtextindentspage.cpp:210
 #: ../src/richtext/richtextliststylepage.cpp:394
 #: ../src/richtext/richtextliststylepage.cpp:396
+#: ../src/richtext/richtextindentspage.cpp:208
+#: ../src/richtext/richtextindentspage.cpp:210
 msgid "The first line indent."
 msgstr "首列縮排。"
 
-#: ../src/generic/dbgrptg.cpp:321
+#: ../src/generic/dbgrptg.cpp:318
 msgid "The following debug report will be generated\n"
 msgstr "下述除錯報告將會產生\n"
 
-#: ../src/generic/fontdlgg.cpp:415 ../src/generic/fontdlgg.cpp:417
+#: ../src/generic/fontdlgg.cpp:411 ../src/generic/fontdlgg.cpp:413
 msgid "The font colour."
 msgstr "字型顏色。"
 
-#: ../src/generic/fontdlgg.cpp:375 ../src/generic/fontdlgg.cpp:377
+#: ../src/generic/fontdlgg.cpp:371 ../src/generic/fontdlgg.cpp:373
 msgid "The font family."
 msgstr "字族。"
 
-#: ../src/richtext/richtextsymboldlg.cpp:405
-#: ../src/richtext/richtextsymboldlg.cpp:407
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "The font from which to take the symbol."
 msgstr "符號使用該字型。"
 
-#: ../src/generic/fontdlgg.cpp:428 ../src/generic/fontdlgg.cpp:430
-#: ../src/generic/fontdlgg.cpp:434 ../src/generic/fontdlgg.cpp:436
+#: ../src/generic/fontdlgg.cpp:424 ../src/generic/fontdlgg.cpp:426
+#: ../src/generic/fontdlgg.cpp:430 ../src/generic/fontdlgg.cpp:432
 msgid "The font point size."
 msgstr "字點大小。"
 
-#: ../src/osx/carbon/fontdlg.cpp:343 ../src/osx/carbon/fontdlg.cpp:345
+#: ../src/osx/carbon/fontdlg.cpp:340 ../src/osx/carbon/fontdlg.cpp:342
 msgid "The font size in points."
 msgstr "字型大小以點計。"
 
@@ -6910,15 +6923,15 @@ msgstr "字型大小以點計。"
 msgid "The font size units, points or pixels."
 msgstr "字型大小單位，以點或像素計。"
 
-#: ../src/generic/fontdlgg.cpp:386 ../src/generic/fontdlgg.cpp:388
+#: ../src/generic/fontdlgg.cpp:382 ../src/generic/fontdlgg.cpp:384
 msgid "The font style."
 msgstr "字型樣式。"
 
-#: ../src/generic/fontdlgg.cpp:397 ../src/generic/fontdlgg.cpp:399
+#: ../src/generic/fontdlgg.cpp:393 ../src/generic/fontdlgg.cpp:395
 msgid "The font weight."
 msgstr "字型粗細。"
 
-#: ../src/common/docview.cpp:1480
+#: ../src/common/docview.cpp:1477
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "無法確定「%s」檔案的格式。"
@@ -6928,10 +6941,10 @@ msgstr "無法確定「%s」檔案的格式。"
 msgid "The horizontal offset."
 msgstr "水平偏移值。"
 
-#: ../src/richtext/richtextindentspage.cpp:199
-#: ../src/richtext/richtextindentspage.cpp:201
 #: ../src/richtext/richtextliststylepage.cpp:385
 #: ../src/richtext/richtextliststylepage.cpp:387
+#: ../src/richtext/richtextindentspage.cpp:199
+#: ../src/richtext/richtextindentspage.cpp:201
 msgid "The left indent."
 msgstr "左側縮排。"
 
@@ -6952,10 +6965,10 @@ msgstr "左內邊距。"
 msgid "The left position."
 msgstr "左邊位置。"
 
-#: ../src/richtext/richtextindentspage.cpp:288
-#: ../src/richtext/richtextindentspage.cpp:290
 #: ../src/richtext/richtextliststylepage.cpp:462
 #: ../src/richtext/richtextliststylepage.cpp:464
+#: ../src/richtext/richtextindentspage.cpp:288
+#: ../src/richtext/richtextindentspage.cpp:290
 msgid "The line spacing."
 msgstr "列距。"
 
@@ -6964,7 +6977,7 @@ msgstr "列距。"
 msgid "The list item number."
 msgstr "清單項目編號。"
 
-#: ../src/msw/ole/automtn.cpp:664
+#: ../src/msw/ole/automtn.cpp:655
 msgid "The locale ID is unknown."
 msgstr "區域 ID 未知。"
 
@@ -7003,22 +7016,22 @@ msgstr "物件寬度。"
 msgid "The outline level."
 msgstr "大綱層級。"
 
-#: ../src/common/log.cpp:277
+#: ../src/common/log.cpp:296
 #, c-format
 msgid "The previous message repeated %u time."
 msgid_plural "The previous message repeated %u times."
 msgstr[0] "上一個訊息重複了 %u 次。"
 
-#: ../src/common/log.cpp:270
+#: ../src/common/log.cpp:289
 msgid "The previous message repeated once."
 msgstr "上一個訊息重複了一次。"
 
-#: ../src/richtext/richtextsymboldlg.cpp:462
-#: ../src/richtext/richtextsymboldlg.cpp:464
+#: ../src/richtext/richtextsymboldlg.cpp:459
+#: ../src/richtext/richtextsymboldlg.cpp:461
 msgid "The range to show."
 msgstr "顯示範圍。"
 
-#: ../src/generic/dbgrptg.cpp:325
+#: ../src/generic/dbgrptg.cpp:322
 msgid ""
 "The report contains the files listed below. If any of these files contain "
 "private information,\n"
@@ -7027,15 +7040,15 @@ msgstr ""
 "報告包含了以下檔案。如果這些檔案含有私人資訊，\n"
 "請去掉其勾選，那些檔案就會從報告移除。\n"
 
-#: ../src/common/cmdline.cpp:1253
+#: ../src/common/cmdline.cpp:1250
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "沒有指定必要的參數「%s」。"
 
-#: ../src/richtext/richtextindentspage.cpp:217
-#: ../src/richtext/richtextindentspage.cpp:219
 #: ../src/richtext/richtextliststylepage.cpp:403
 #: ../src/richtext/richtextliststylepage.cpp:405
+#: ../src/richtext/richtextindentspage.cpp:217
+#: ../src/richtext/richtextindentspage.cpp:219
 msgid "The right indent."
 msgstr "右側縮排。"
 
@@ -7076,16 +7089,16 @@ msgstr "陰影混濁度。"
 msgid "The shadow spread."
 msgstr "陰影擴散。"
 
-#: ../src/richtext/richtextindentspage.cpp:267
 #: ../src/richtext/richtextliststylepage.cpp:439
 #: ../src/richtext/richtextliststylepage.cpp:441
+#: ../src/richtext/richtextindentspage.cpp:267
 msgid "The spacing after the paragraph."
 msgstr "段落之後的間距。"
 
-#: ../src/richtext/richtextindentspage.cpp:257
-#: ../src/richtext/richtextindentspage.cpp:259
 #: ../src/richtext/richtextliststylepage.cpp:430
 #: ../src/richtext/richtextliststylepage.cpp:432
+#: ../src/richtext/richtextindentspage.cpp:257
+#: ../src/richtext/richtextindentspage.cpp:259
 msgid "The spacing before the paragraph."
 msgstr "段落之前的間距。"
 
@@ -7099,12 +7112,12 @@ msgstr "樣式名稱。"
 msgid "The style on which this style is based."
 msgstr "此樣式的基底樣式。"
 
-#: ../src/richtext/richtextstyledlg.cpp:214
-#: ../src/richtext/richtextstyledlg.cpp:216
+#: ../src/richtext/richtextstyledlg.cpp:210
+#: ../src/richtext/richtextstyledlg.cpp:212
 msgid "The style preview."
 msgstr "樣式預覽。"
 
-#: ../src/msw/ole/automtn.cpp:680
+#: ../src/msw/ole/automtn.cpp:671
 msgid "The system cannot find the file specified."
 msgstr "系統無法找到指定的檔案。"
 
@@ -7117,7 +7130,7 @@ msgstr "定位點位置。"
 msgid "The tab positions."
 msgstr "定位點位置。"
 
-#: ../src/richtext/richtextctrl.cpp:3102
+#: ../src/richtext/richtextctrl.cpp:3099
 msgid "The text couldn't be saved."
 msgstr "文字無法儲存。"
 
@@ -7138,7 +7151,7 @@ msgstr "上內邊距。"
 msgid "The top position."
 msgstr "上方位置。"
 
-#: ../src/common/cmdline.cpp:1231
+#: ../src/common/cmdline.cpp:1228
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "必須指定「%s」選項的值。"
@@ -7148,134 +7161,146 @@ msgstr "必須指定「%s」選項的值。"
 msgid "The value of the corner radius."
 msgstr "角位半徑值。"
 
-#: ../src/msw/dialup.cpp:432
+#: ../src/msw/dialup.cpp:427
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
 "old, please upgrade (the following required function is missing: %s)."
-msgstr "於此電腦安裝的遠端存取服務(RAS)版本太舊，請更新 (缺少以下必要的功能：%s)。"
+msgstr ""
+"於此電腦安裝的遠端存取服務(RAS)版本太舊，請更新 (缺少以下必要的功能：%s)。"
 
 #: ../src/richtext/richtextbackgroundpage.cpp:242
 #: ../src/richtext/richtextbackgroundpage.cpp:244
 msgid "The vertical offset."
 msgstr "垂直偏移值。"
 
-#: ../src/html/htmprint.cpp:752 ../src/richtext/richtextprint.cpp:618
+#: ../src/html/htmprint.cpp:749 ../src/richtext/richtextprint.cpp:615
 msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr "頁面設定時有問題：必須設定預設印表機。"
 
-#: ../src/html/htmprint.cpp:270
+#: ../src/html/htmprint.cpp:267
 msgid ""
 "This document doesn't fit on the page horizontally and will be truncated "
 "when it is printed."
 msgstr "此文件的水平尺寸不符合頁面，若要列印的話，將會被截斷。"
 
-#: ../src/common/image.cpp:2878
+#: ../src/common/image.cpp:2963
 #, c-format
 msgid "This is not a %s."
 msgstr "這不是 %s。"
 
-#: ../src/common/wincmn.cpp:1673
+#: ../src/common/wincmn.cpp:1654
 msgid "This platform does not support background transparency."
 msgstr "這個平臺不支援透明背景。"
 
-#: ../src/gtk/window.cpp:5632
+#: ../src/gtk/window.cpp:5664
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr "這個程式是以很舊版本的 GTK+ 所編譯，請以 GTK+2.12 或更新版本重新組建。"
 
-#: ../src/msw/thread.cpp:1262
+#: ../src/gtk/glcanvas.cpp:176
+#, fuzzy
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+"wxGLCanvas 目前只支援 X11。啟動程式前，你可能需要透過設定\n"
+"環境變數 GDK_BACKEND=x11 以避開這問題。"
+
+#: ../src/msw/thread.cpp:1246
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
 msgstr "執行緒模組初始化失敗：無法將值儲存到執行緒內部儲存區"
 
-#: ../src/unix/threadpsx.cpp:1819
+#: ../src/unix/threadpsx.cpp:1843
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr "執行緒模組初始化失敗：無法建立執行緒機碼"
 
-#: ../src/msw/thread.cpp:1250
+#: ../src/msw/thread.cpp:1234
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
 msgstr "執行緒模組初始化失敗：無法在「執行緒內部儲存區」配置索引"
 
-#: ../src/unix/threadpsx.cpp:1037
+#: ../src/unix/threadpsx.cpp:1061
 msgid "Thread priority setting is ignored."
 msgstr "忽略執行緒的優先等級設定。"
 
-#: ../src/msw/mdi.cpp:174
+#: ../src/msw/mdi.cpp:171
 msgid "Tile &Horizontally"
 msgstr "水平排列(&H)"
 
-#: ../src/msw/mdi.cpp:175
+#: ../src/msw/mdi.cpp:172
 msgid "Tile &Vertically"
 msgstr "垂直排列(&V)"
 
-#: ../src/common/ftp.cpp:200
+#: ../src/common/ftp.cpp:197
 msgid "Timeout while waiting for FTP server to connect, try passive mode."
 msgstr "等待 FTP 伺服器連線時逾時，請嘗試用被動(passive)模式。"
 
-#: ../src/generic/tipdlg.cpp:201
+#: ../src/generic/tipdlg.cpp:198
 msgid "Tip of the Day"
 msgstr "每日小祕訣"
 
-#: ../src/generic/tipdlg.cpp:140
+#: ../src/generic/tipdlg.cpp:137
 msgid "Tips not available, sorry!"
 msgstr "抱歉，無法提供小祕訣！"
 
-#: ../src/generic/prntdlgg.cpp:238
+#: ../src/generic/prntdlgg.cpp:235
 msgid "To:"
 msgstr "到："
 
-#: ../src/richtext/richtextbuffer.cpp:8364
+#: ../src/richtext/richtextbuffer.cpp:8361
 msgid "Too many EndStyle calls!"
 msgstr "呼叫 EndStyle 太多次！"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:795
+#: ../src/propgrid/advprops.cpp:792
 msgid "Tooltip"
 msgstr "Tooltip"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:796
+#: ../src/propgrid/advprops.cpp:793
 msgid "TooltipText"
 msgstr "TooltipText"
 
-#: ../src/common/stockitem.cpp:200 ../src/richtext/richtextsizepage.cpp:286
+#: ../src/common/stockitem.cpp:197 ../src/richtext/richtextsizepage.cpp:286
 #: ../src/richtext/richtextsizepage.cpp:290
 msgid "Top"
 msgstr "頂端"
 
-#: ../src/generic/prntdlgg.cpp:877
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Top margin (mm):"
 msgstr "頂邊距(公釐)："
 
-#: ../src/generic/aboutdlgg.cpp:79
+#: ../src/generic/aboutdlgg.cpp:76
 msgid "Translations by "
 msgstr "翻譯者："
 
-#: ../src/generic/aboutdlgg.cpp:188
+#: ../src/generic/aboutdlgg.cpp:185
 msgid "Translators"
 msgstr "翻譯者"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:195
+#: ../src/propgrid/propgrid.cpp:192
 msgid "True"
 msgstr "真"
 
-#: ../src/common/fs_mem.cpp:221
+#: ../src/common/fs_mem.cpp:222
 #, c-format
 msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
 msgstr "嘗試從「記憶體虛擬檔案系統」移除「%s」檔案，但它並未被載入！"
 
-#: ../src/common/fmapbase.cpp:156
+#: ../src/common/fmapbase.cpp:153
 msgid "Turkish (ISO-8859-9)"
 msgstr "土耳其文 (ISO-8859-9)"
 
-#: ../src/generic/filectrlg.cpp:426
+#: ../src/generic/filectrlg.cpp:422
 msgid "Type"
 msgstr "類型"
 
@@ -7289,36 +7314,36 @@ msgstr "輸入字型名稱。"
 msgid "Type a size in points."
 msgstr "輸入大小，單位為點數。"
 
-#: ../src/msw/ole/automtn.cpp:676
+#: ../src/msw/ole/automtn.cpp:667
 #, c-format
 msgid "Type mismatch in argument %u."
 msgstr "引數 %u 的類別不吻合。"
 
-#: ../src/common/xtistrm.cpp:318 ../src/common/xtixml.cpp:356
-#: ../src/common/xtixml.cpp:509
+#: ../src/common/xtixml.cpp:352 ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315
 msgid "Type must have enum - long conversion"
 msgstr "必須進行 enum - long 的類型轉換"
 
-#: ../src/propgrid/propgridiface.cpp:388
+#: ../src/propgrid/propgridiface.cpp:385
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
 "\"%s\"."
 msgstr "類型操作「%s」失敗：標示為「%s」的性質是「%s」類型，而非「%s」。"
 
-#: ../src/common/paper.cpp:133
+#: ../src/common/paper.cpp:130
 msgid "US Std Fanfold, 14 7/8 x 11 in"
 msgstr "美國標準複寫簿, 14 7/8 x 11 英吋"
 
-#: ../src/common/fmapbase.cpp:196
+#: ../src/common/fmapbase.cpp:193
 msgid "US-ASCII"
 msgstr "US-ASCII"
 
-#: ../src/unix/fswatcher_inotify.cpp:109
+#: ../src/unix/fswatcher_inotify.cpp:106
 msgid "Unable to add inotify watch"
 msgstr "無法加入 inotify 監看"
 
-#: ../src/unix/fswatcher_kqueue.cpp:156
+#: ../src/unix/fswatcher_kqueue.cpp:153
 msgid "Unable to add kqueue watch"
 msgstr "無法加入 kqueue 監看"
 
@@ -7330,7 +7355,7 @@ msgstr "無法將控柄與 I/O 完成的通訊埠關聯"
 msgid "Unable to close I/O completion port handle"
 msgstr "無法關閉 I/O 完成通訊埠的控柄"
 
-#: ../src/unix/fswatcher_inotify.cpp:97
+#: ../src/unix/fswatcher_inotify.cpp:94
 msgid "Unable to close inotify instance"
 msgstr "無法關閉 inotify 實體"
 
@@ -7348,15 +7373,15 @@ msgstr "無法關閉「%s」的控柄"
 msgid "Unable to create I/O completion port"
 msgstr "無法建立 I/O 完成的通訊埠"
 
-#: ../src/msw/fswatcher.cpp:84
+#: ../src/msw/fswatcher.cpp:81
 msgid "Unable to create IOCP worker thread"
 msgstr "無法建立 IOCP 背景工作執行緒"
 
-#: ../src/unix/fswatcher_inotify.cpp:74
+#: ../src/unix/fswatcher_inotify.cpp:71
 msgid "Unable to create inotify instance"
 msgstr "無法建立 inotify 執行實體"
 
-#: ../src/unix/fswatcher_kqueue.cpp:117
+#: ../src/unix/fswatcher_kqueue.cpp:114
 msgid "Unable to create kqueue instance"
 msgstr "無法建立 kqueue 執行實體"
 
@@ -7364,11 +7389,11 @@ msgstr "無法建立 kqueue 執行實體"
 msgid "Unable to dequeue completion packet"
 msgstr "無法移出佇列完成封包"
 
-#: ../src/unix/fswatcher_kqueue.cpp:205
+#: ../src/unix/fswatcher_kqueue.cpp:202
 msgid "Unable to get events from kqueue"
 msgstr "無法從 kqueue 取得事件"
 
-#: ../src/gtk/app.cpp:409
+#: ../src/gtk/app.cpp:431
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "無法初始化 gtk+，DISPLAY 是否已經正確設定？"
 
@@ -7377,12 +7402,12 @@ msgstr "無法初始化 gtk+，DISPLAY 是否已經正確設定？"
 msgid "Unable to open path '%s'"
 msgstr "無法開啟「%s」路徑"
 
-#: ../src/html/htmlwin.cpp:589
+#: ../src/html/htmlwin.cpp:586
 #, c-format
 msgid "Unable to open requested HTML document: %s"
 msgstr "無法開啟 HTML 文件：%s"
 
-#: ../src/unix/sound.cpp:368
+#: ../src/unix/sound.cpp:365
 msgid "Unable to play sound asynchronously."
 msgstr "無法非同步播放聲音。"
 
@@ -7390,61 +7415,61 @@ msgstr "無法非同步播放聲音。"
 msgid "Unable to post completion status"
 msgstr "無法公佈完成狀態"
 
-#: ../src/unix/fswatcher_inotify.cpp:556
+#: ../src/unix/fswatcher_inotify.cpp:553
 msgid "Unable to read from inotify descriptor"
 msgstr "無法讀取 inotify 描述子"
 
-#: ../src/unix/fswatcher_inotify.cpp:141
+#: ../src/unix/fswatcher_inotify.cpp:138
 #, c-format
 msgid "Unable to remove inotify watch %i"
 msgstr "無法移除 inotify 監看 %i"
 
-#: ../src/unix/fswatcher_kqueue.cpp:173
+#: ../src/unix/fswatcher_kqueue.cpp:170
 msgid "Unable to remove kqueue watch"
 msgstr "無法移除 kqueue 監看"
 
-#: ../src/msw/fswatcher.cpp:168
+#: ../src/msw/fswatcher.cpp:165
 #, c-format
 msgid "Unable to set up watch for '%s'"
 msgstr "無法為「%s」設定監看"
 
-#: ../src/msw/fswatcher.cpp:91
+#: ../src/msw/fswatcher.cpp:88
 msgid "Unable to start IOCP worker thread"
 msgstr "無法開始 IOCP worker 執行緒"
 
-#: ../src/common/stockitem.cpp:201
+#: ../src/common/stockitem.cpp:198
 msgid "Undelete"
 msgstr "取消刪除"
 
-#: ../src/common/stockitem.cpp:202
+#: ../src/common/stockitem.cpp:199
 msgid "Underline"
 msgstr "底線"
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/osx/carbon/fontdlg.cpp:370 ../src/propgrid/advprops.cpp:603
+#: ../src/osx/carbon/fontdlg.cpp:367 ../src/propgrid/advprops.cpp:600
 #: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "加底線"
 
-#: ../src/common/stockitem.cpp:203 ../src/stc/stc_i18n.cpp:15
+#: ../src/common/stockitem.cpp:200 ../src/stc/stc_i18n.cpp:15
 msgid "Undo"
 msgstr "回復"
 
-#: ../src/common/stockitem.cpp:266
+#: ../src/common/stockitem.cpp:263
 msgid "Undo last action"
 msgstr "回復最後一個動作"
 
-#: ../src/common/cmdline.cpp:1028
+#: ../src/common/cmdline.cpp:1025
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "「%s」選項之後有未能預期的字元。"
 
-#: ../src/unix/fswatcher_inotify.cpp:274
+#: ../src/unix/fswatcher_inotify.cpp:271
 #, c-format
 msgid "Unexpected event for \"%s\": no matching watch descriptor."
 msgstr "「%s」有未能預期的事件：沒有相符的監看描述子。"
 
-#: ../src/common/cmdline.cpp:1194
+#: ../src/common/cmdline.cpp:1191
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "意外參數 '%s'"
@@ -7453,49 +7478,49 @@ msgstr "意外參數 '%s'"
 msgid "Unexpectedly new I/O completion port was created"
 msgstr "新的 I/O 完成通訊埠被未預期地建立"
 
-#: ../src/msw/fswatcher.cpp:70
+#: ../src/msw/fswatcher.cpp:67
 msgid "Ungraceful worker thread termination"
 msgstr "背景工作執行緒無預期地終止了"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:460
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:456
+#: ../src/richtext/richtextsymboldlg.cpp:457
+#: ../src/richtext/richtextsymboldlg.cpp:458
 msgid "Unicode"
 msgstr "萬國碼(Unicode)"
 
-#: ../src/common/fmapbase.cpp:185 ../src/common/fmapbase.cpp:191
+#: ../src/common/fmapbase.cpp:182 ../src/common/fmapbase.cpp:188
 msgid "Unicode 16 bit (UTF-16)"
 msgstr "十六位元萬國碼 (UTF-16)"
 
-#: ../src/common/fmapbase.cpp:190
+#: ../src/common/fmapbase.cpp:187
 msgid "Unicode 16 bit Big Endian (UTF-16BE)"
 msgstr "十六位元萬國碼大尾序 (UTF-16BE)"
 
-#: ../src/common/fmapbase.cpp:186
+#: ../src/common/fmapbase.cpp:183
 msgid "Unicode 16 bit Little Endian (UTF-16LE)"
 msgstr "十六位元萬國碼小尾序 (UTF-16LE)"
 
-#: ../src/common/fmapbase.cpp:187 ../src/common/fmapbase.cpp:193
+#: ../src/common/fmapbase.cpp:184 ../src/common/fmapbase.cpp:190
 msgid "Unicode 32 bit (UTF-32)"
 msgstr "三十二位元萬國碼 (UTF-32)"
 
-#: ../src/common/fmapbase.cpp:192
+#: ../src/common/fmapbase.cpp:189
 msgid "Unicode 32 bit Big Endian (UTF-32BE)"
 msgstr "三十二位元萬國碼大尾序 (UTF-32BE)"
 
-#: ../src/common/fmapbase.cpp:188
+#: ../src/common/fmapbase.cpp:185
 msgid "Unicode 32 bit Little Endian (UTF-32LE)"
 msgstr "三十二位元萬國碼小尾序 (UTF-32LE)"
 
-#: ../src/common/fmapbase.cpp:182
+#: ../src/common/fmapbase.cpp:179
 msgid "Unicode 7 bit (UTF-7)"
 msgstr "七位元萬國碼 (UTF-7)"
 
-#: ../src/common/fmapbase.cpp:183
+#: ../src/common/fmapbase.cpp:180
 msgid "Unicode 8 bit (UTF-8)"
 msgstr "八位元萬國碼 (UTF-8)"
 
-#: ../src/common/stockitem.cpp:204
+#: ../src/common/stockitem.cpp:201
 msgid "Unindent"
 msgstr "取消縮排"
 
@@ -7645,116 +7670,116 @@ msgstr "上方位置單位。"
 msgid "Units for this value."
 msgstr "本值的單位。"
 
-#: ../src/generic/progdlgg.cpp:353 ../src/generic/progdlgg.cpp:632
+#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
 msgid "Unknown"
 msgstr "不明"
 
-#: ../src/msw/dde.cpp:1241
+#: ../src/msw/dde.cpp:1238
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "不明的「動態資料交換」錯誤 %08x"
 
-#: ../src/common/xtistrm.cpp:410
+#: ../src/common/xtistrm.cpp:407
 msgid "Unknown Object passed to GetObjectClassInfo"
 msgstr "傳給 GetObjectClassInfo 不明的物件"
 
-#: ../src/common/imagpng.cpp:386
+#: ../src/common/imagpng.cpp:383
 #, c-format
 msgid "Unknown PNG resolution unit %d"
 msgstr "未知的 PNG 解析度單位 %d"
 
-#: ../src/common/xtixml.cpp:327
+#: ../src/common/xtixml.cpp:323
 #, c-format
 msgid "Unknown Property %s"
 msgstr "不明的性質 %s"
 
-#: ../src/common/imagtiff.cpp:529
+#: ../src/common/imagtiff.cpp:526
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "不明的 TIFF 解析度單位 %d，已忽略"
 
-#: ../src/propgrid/props.cpp:158
+#: ../src/propgrid/props.cpp:155
 #, c-format
 msgid "Unknown base %d. Base 10 will be used."
 msgstr "未知 Base %d。將使用 Base 10。"
 
-#: ../src/unix/dlunix.cpp:160
+#: ../src/unix/dlunix.cpp:118
 msgid "Unknown dynamic library error"
 msgstr "不明的動態函式庫錯誤"
 
-#: ../src/common/fmapbase.cpp:810
+#: ../src/common/fmapbase.cpp:806
 #, c-format
 msgid "Unknown encoding (%d)"
 msgstr "不明編碼 (%d)"
 
-#: ../src/msw/ole/automtn.cpp:688
+#: ../src/msw/ole/automtn.cpp:679
 #, c-format
 msgid "Unknown error %08x"
 msgstr "不明錯誤，錯誤碼 %08x"
 
-#: ../src/msw/ole/automtn.cpp:647
+#: ../src/msw/ole/automtn.cpp:638
 msgid "Unknown exception"
 msgstr "不明例外情況"
 
-#: ../src/common/image.cpp:2857
+#: ../src/common/image.cpp:2942
 msgid "Unknown image data format."
 msgstr "不明影像資料格式。"
 
-#: ../src/common/cmdline.cpp:913
+#: ../src/common/cmdline.cpp:910
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "不明長選項 '%s'"
 
-#: ../src/msw/ole/automtn.cpp:631
+#: ../src/msw/ole/automtn.cpp:622
 msgid "Unknown name or named argument."
 msgstr "不明名稱或具名引數。"
 
-#: ../src/common/cmdline.cpp:928 ../src/common/cmdline.cpp:950
+#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "不明選項 '%s'"
 
-#: ../src/common/mimecmn.cpp:224
+#: ../src/common/mimecmn.cpp:221
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "mime 類型 %s 有不成對的 {"
 
-#: ../src/common/cmdproc.cpp:258 ../src/common/cmdproc.cpp:284
-#: ../src/common/cmdproc.cpp:304
+#: ../src/common/cmdproc.cpp:255 ../src/common/cmdproc.cpp:281
+#: ../src/common/cmdproc.cpp:301
 msgid "Unnamed command"
 msgstr "未命名指令"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:396
+#: ../src/propgrid/propgrid.cpp:392
 msgid "Unspecified"
 msgstr "未指定"
 
-#: ../src/msw/clipbrd.cpp:311
+#: ../src/msw/clipbrd.cpp:325
 msgid "Unsupported clipboard format."
 msgstr "不支援的剪貼簿格式。"
 
-#: ../src/common/appcmn.cpp:280
+#: ../src/common/appcmn.cpp:277
 #, c-format
 msgid "Unsupported theme '%s'."
 msgstr "不支援的佈景主題「%s」。"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:63 ../src/common/stockitem.cpp:205
-#: ../src/generic/fdrepdlg.cpp:152
+#: ../src/common/stockitem.cpp:202 ../src/common/accelcmn.cpp:60
+#: ../src/generic/fdrepdlg.cpp:149
 msgid "Up"
 msgstr "上"
 
-#: ../src/richtext/richtextbulletspage.cpp:275
 #: ../src/richtext/richtextliststylepage.cpp:483
+#: ../src/richtext/richtextbulletspage.cpp:275
 msgid "Upper case letters"
 msgstr "大寫字母"
 
-#: ../src/richtext/richtextbulletspage.cpp:277
 #: ../src/richtext/richtextliststylepage.cpp:485
+#: ../src/richtext/richtextbulletspage.cpp:277
 msgid "Upper case roman numerals"
 msgstr "大寫羅馬數字"
 
-#: ../src/common/cmdline.cpp:1325
+#: ../src/common/cmdline.cpp:1322
 #, c-format
 msgid "Usage: %s"
 msgstr "使用方式：%s"
@@ -7763,12 +7788,16 @@ msgstr "使用方式：%s"
 msgid "Use &shadow"
 msgstr "使用陰影(&S)"
 
-#: ../src/richtext/richtextindentspage.cpp:169
-#: ../src/richtext/richtextindentspage.cpp:171
 #: ../src/richtext/richtextliststylepage.cpp:358
 #: ../src/richtext/richtextliststylepage.cpp:360
+#: ../src/richtext/richtextindentspage.cpp:169
+#: ../src/richtext/richtextindentspage.cpp:171
 msgid "Use the current alignment setting."
 msgstr "使用當前的對齊設定。"
+
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
 
 #: ../src/gtk/font.cpp:552
 msgid ""
@@ -7776,30 +7805,30 @@ msgid ""
 "old, 1.38 or later required."
 msgstr "不支援在此系統使用私人字型：Pango 函式庫過舊，需要 1.38 或更新版。"
 
-#: ../src/common/valtext.cpp:145
+#: ../src/common/valtext.cpp:142
 msgid "Validation conflict"
 msgstr "驗證衝突"
 
-#: ../src/propgrid/manager.cpp:227
+#: ../src/propgrid/manager.cpp:224
 msgid "Value"
 msgstr "值"
 
-#: ../src/propgrid/props.cpp:312
+#: ../src/propgrid/props.cpp:309
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "值必須大於或等於 %s。"
 
-#: ../src/propgrid/props.cpp:339
+#: ../src/propgrid/props.cpp:336
 #, c-format
 msgid "Value must be %s or less."
 msgstr "值必須小於或等於 %s。"
 
-#: ../src/propgrid/props.cpp:317 ../src/propgrid/props.cpp:344
+#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "值必須介於 %s 和 %s 之間。"
 
-#: ../src/generic/aboutdlgg.cpp:128
+#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "版本："
 
@@ -7808,25 +7837,32 @@ msgstr "版本："
 msgid "Vertical alignment."
 msgstr "垂直對齊。"
 
-#: ../src/generic/filedlgg.cpp:202
+#: ../src/generic/filedlgg.cpp:199
 msgid "View files as a detailed view"
 msgstr "按詳細資料檢視檔案"
 
-#: ../src/generic/filedlgg.cpp:200
+#: ../src/generic/filedlgg.cpp:197
 msgid "View files as a list view"
 msgstr "按清單檢視檔案"
 
-#: ../src/common/docview.cpp:1978
+#: ../src/common/docview.cpp:1975
 msgid "Views"
 msgstr "檢視"
 
+#: ../src/gtk/app.cpp:348
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1681
+#: ../src/propgrid/advprops.cpp:1678
 msgid "Wait"
 msgstr "等待"
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1683
+#: ../src/propgrid/advprops.cpp:1680
 msgid "Wait Arrow"
 msgstr "等待箭頭"
 
@@ -7835,245 +7871,234 @@ msgstr "等待箭頭"
 msgid "Waiting for IO on epoll descriptor %d failed"
 msgstr "等候 epoll 描述子 %d 的輸出入失敗"
 
-#: ../src/common/log.cpp:223
+#: ../src/common/log.cpp:241
 msgid "Warning: "
 msgstr "警告："
 
 #. TRANSLATORS: System cursor name
-#: ../src/propgrid/advprops.cpp:1682
+#: ../src/propgrid/advprops.cpp:1679
 msgid "Watch"
 msgstr "時計"
 
-#: ../src/gtk/webview_webkit2.cpp:436
-#, c-format
-msgid ""
-"Web extension not found in \"%s\", some wxWebView functionality will be not "
-"available"
-msgstr "在「%s」找不到網頁擴充套件，部份 wxWebView 功能會無法使用。"
-
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:598
+#: ../src/propgrid/advprops.cpp:595
 msgid "Weight"
 msgstr "粗細"
 
-#: ../src/common/fmapbase.cpp:148
+#: ../src/common/fmapbase.cpp:145
 msgid "Western European (ISO-8859-1)"
 msgstr "西歐語系 (ISO-8859-1)"
 
-#: ../src/common/fmapbase.cpp:162
+#: ../src/common/fmapbase.cpp:159
 msgid "Western European with Euro (ISO-8859-15)"
 msgstr "西歐語系 (附歐元) (ISO-8859-15)"
 
-#: ../src/generic/fontdlgg.cpp:447 ../src/generic/fontdlgg.cpp:449
+#: ../src/generic/fontdlgg.cpp:443 ../src/generic/fontdlgg.cpp:445
 msgid "Whether the font is underlined."
 msgstr "字型是否加底線。"
 
-#: ../src/propgrid/advprops.cpp:1520
+#: ../src/propgrid/advprops.cpp:1517
 msgid "White"
 msgstr "白色"
 
-#: ../src/generic/fdrepdlg.cpp:144
+#: ../src/generic/fdrepdlg.cpp:141
 msgid "Whole word"
 msgstr "整個字"
 
-#: ../src/html/helpwnd.cpp:535
+#: ../src/html/helpwnd.cpp:532
 msgid "Whole words only"
 msgstr "只限整個字"
 
-#: ../src/univ/themes/win32.cpp:1102
+#: ../src/univ/themes/win32.cpp:1099
 msgid "Win32 theme"
 msgstr "Win32 佈景主題"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:797
+#: ../src/propgrid/advprops.cpp:794
 msgid "Window"
 msgstr "Window"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:798
+#: ../src/propgrid/advprops.cpp:795
 msgid "WindowFrame"
 msgstr "WindowFrame"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:799
+#: ../src/propgrid/advprops.cpp:796
 msgid "WindowText"
 msgstr "WindowText"
 
-#: ../src/common/fmapbase.cpp:177
+#: ../src/common/fmapbase.cpp:174
 msgid "Windows Arabic (CP 1256)"
 msgstr "Windows 阿拉伯文 (CP 1256)"
 
-#: ../src/common/fmapbase.cpp:178
+#: ../src/common/fmapbase.cpp:175
 msgid "Windows Baltic (CP 1257)"
 msgstr "Windows 波羅的海語系 (CP 1257)"
 
-#: ../src/common/fmapbase.cpp:171
+#: ../src/common/fmapbase.cpp:168
 msgid "Windows Central European (CP 1250)"
 msgstr "Windows 中歐語系 (CP 1250)"
 
-#: ../src/common/fmapbase.cpp:168
+#: ../src/common/fmapbase.cpp:165
 msgid "Windows Chinese Simplified (CP 936) or GB-2312"
 msgstr "Windows 簡體中文 (CP 936) 或 GB2312"
 
-#: ../src/common/fmapbase.cpp:170
+#: ../src/common/fmapbase.cpp:167
 msgid "Windows Chinese Traditional (CP 950) or Big-5"
 msgstr "Windows 正體中文 (CP 950) 或 Big5"
 
-#: ../src/common/fmapbase.cpp:172
+#: ../src/common/fmapbase.cpp:169
 msgid "Windows Cyrillic (CP 1251)"
 msgstr "Windows 斯拉夫語系 (CP 1251)"
 
-#: ../src/common/fmapbase.cpp:174
+#: ../src/common/fmapbase.cpp:171
 msgid "Windows Greek (CP 1253)"
 msgstr "Windows 希臘文 (CP 1253)"
 
-#: ../src/common/fmapbase.cpp:176
+#: ../src/common/fmapbase.cpp:173
 msgid "Windows Hebrew (CP 1255)"
 msgstr "Windows 希伯來文 (CP 1255)"
 
-#: ../src/common/fmapbase.cpp:167
+#: ../src/common/fmapbase.cpp:164
 msgid "Windows Japanese (CP 932) or Shift-JIS"
 msgstr "Windows 日文 (CP 932) 或 Shift-JIS"
 
-#: ../src/common/fmapbase.cpp:180
+#: ../src/common/fmapbase.cpp:177
 msgid "Windows Johab (CP 1361)"
 msgstr "Windows 韓文雙位元組合型符號 (Johab) (CP 1256)"
 
-#: ../src/common/fmapbase.cpp:169
+#: ../src/common/fmapbase.cpp:166
 msgid "Windows Korean (CP 949)"
 msgstr "Windows 韓文 (CP 949)"
 
-#: ../src/common/fmapbase.cpp:166
+#: ../src/common/fmapbase.cpp:163
 msgid "Windows Thai (CP 874)"
 msgstr "Windows 泰文 (CP 874)"
 
-#: ../src/common/fmapbase.cpp:175
+#: ../src/common/fmapbase.cpp:172
 msgid "Windows Turkish (CP 1254)"
 msgstr "Windows 土耳其文 (CP 1254)"
 
-#: ../src/common/fmapbase.cpp:179
+#: ../src/common/fmapbase.cpp:176
 msgid "Windows Vietnamese (CP 1258)"
 msgstr "Windows 越南文 (CP 1258)"
 
-#: ../src/common/fmapbase.cpp:173
+#: ../src/common/fmapbase.cpp:170
 msgid "Windows Western European (CP 1252)"
 msgstr "Windows 西歐語系 (CP 1252)"
 
-#: ../src/common/fmapbase.cpp:181
+#: ../src/common/fmapbase.cpp:178
 msgid "Windows/DOS OEM (CP 437)"
 msgstr "Windows/DOS 委製 (CP 437)"
 
-#: ../src/common/fmapbase.cpp:165
+#: ../src/common/fmapbase.cpp:162
 msgid "Windows/DOS OEM Cyrillic (CP 866)"
 msgstr "Windows/DOS OEM 斯拉夫語系 (CP 1251)"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:112
+#: ../src/common/accelcmn.cpp:109
 msgid "Windows_Left"
 msgstr "Windows_Left"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:114
+#: ../src/common/accelcmn.cpp:111
 msgid "Windows_Menu"
 msgstr "Windows_Menu"
 
 #. TRANSLATORS: Name of keyboard key
-#: ../src/common/accelcmn.cpp:113
+#: ../src/common/accelcmn.cpp:110
 msgid "Windows_Right"
 msgstr "Windows_Right"
 
-#: ../src/common/ffile.cpp:151
+#: ../src/common/ffile.cpp:149
 #, c-format
 msgid "Write error on file '%s'"
 msgstr "寫入「%s」檔案時發生錯誤"
 
-#: ../src/xml/xml.cpp:928
+#: ../src/xml/xml.cpp:925
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "XML 解析錯誤：「%s」在第 %d 列"
 
-#: ../src/common/xpmdecod.cpp:797
+#: ../src/common/xpmdecod.cpp:794
 msgid "XPM: Malformed pixel data!"
 msgstr "XPM：圖素資料格式不對！"
 
-#: ../src/common/xpmdecod.cpp:705
+#: ../src/common/xpmdecod.cpp:702
 #, c-format
 msgid "XPM: incorrect colour description in line %d"
 msgstr "XPM：於第「%d」列的顏色描述不正確！"
 
-#: ../src/common/xpmdecod.cpp:680
-#| msgid "XPM：incorrect header format!"
+#: ../src/common/xpmdecod.cpp:677
 msgid "XPM: incorrect header format!"
 msgstr "XPM：標頭格式不正確！"
 
-#: ../src/common/xpmdecod.cpp:717 ../src/common/xpmdecod.cpp:726
+#: ../src/common/xpmdecod.cpp:714 ../src/common/xpmdecod.cpp:723
 #, c-format
 msgid "XPM: malformed colour definition '%s' at line %d!"
 msgstr "XPM：顏色定義「%s」於第「%d」列不正確！"
 
-#: ../src/common/xpmdecod.cpp:756
+#: ../src/common/xpmdecod.cpp:753
 msgid "XPM: no colors left to use for mask!"
 msgstr "XPM：沒有剩下供作為遮罩的顏色！"
 
-#: ../src/common/xpmdecod.cpp:783
+#: ../src/common/xpmdecod.cpp:780
 #, c-format
 msgid "XPM: truncated image data at line %d!"
 msgstr "XPM：影像資料於第 %d 列被截斷！"
 
-#: ../src/propgrid/advprops.cpp:1519
+#: ../src/propgrid/advprops.cpp:1516
 msgid "Yellow"
 msgstr "黃色"
 
-#: ../include/wx/msgdlg.h:276 ../src/common/stockitem.cpp:206
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:203
 #: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "是"
 
-#: ../src/osx/carbon/overlay.cpp:155
-msgid "You cannot Clear an overlay that is not inited"
-msgstr "不能清除未初始化的覆蓋"
-
-#: ../src/dfb/overlay.cpp:61 ../src/osx/carbon/overlay.cpp:107
-msgid "You cannot Init an overlay twice"
-msgstr "不能初始化覆蓋兩次"
-
-#: ../src/generic/dirdlgg.cpp:287
+#: ../src/generic/dirdlgg.cpp:284
 msgid "You cannot add a new directory to this section."
 msgstr "不能在這區段加入新的目錄。"
 
-#: ../src/propgrid/propgrid.cpp:3250
+#: ../src/propgrid/propgrid.cpp:3276
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr "輸入了無效的值，按 ESC 以取消編輯。"
 
-#: ../src/common/stockitem.cpp:209
+#: ../src/osx/cocoa/menu.mm:286
+#, fuzzy
+msgid "Zoom"
+msgstr "放大"
+
+#: ../src/common/stockitem.cpp:206
 msgid "Zoom &In"
 msgstr "放大(&I)"
 
-#: ../src/common/stockitem.cpp:210
+#: ../src/common/stockitem.cpp:207
 msgid "Zoom &Out"
 msgstr "縮小(&O)"
 
-#: ../src/common/prntbase.cpp:1624 ../src/common/stockitem.cpp:209
+#: ../src/common/stockitem.cpp:206 ../src/common/prntbase.cpp:1619
 msgid "Zoom In"
 msgstr "放大"
 
-#: ../src/common/prntbase.cpp:1610 ../src/common/stockitem.cpp:210
+#: ../src/common/stockitem.cpp:207 ../src/common/prntbase.cpp:1605
 msgid "Zoom Out"
 msgstr "縮小"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to &Fit"
 msgstr "縮放以適應視窗(&F)"
 
-#: ../src/common/stockitem.cpp:208
+#: ../src/common/stockitem.cpp:205
 msgid "Zoom to Fit"
 msgstr "縮放以適應視窗"
 
-#: ../src/msw/dde.cpp:1208
+#: ../src/msw/dde.cpp:1205
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "DDEML 應用程式已建立延長的競賽環境(race condition)。"
 
-#: ../src/msw/dde.cpp:1196
+#: ../src/msw/dde.cpp:1193
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -8084,39 +8109,39 @@ msgstr ""
 "或傳給 DDEML 函式的是\n"
 "無效的實體物件識別。"
 
-#: ../src/msw/dde.cpp:1214
+#: ../src/msw/dde.cpp:1211
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "用戶端嘗試建立對話失敗。"
 
-#: ../src/msw/dde.cpp:1211
+#: ../src/msw/dde.cpp:1208
 msgid "a memory allocation failed."
 msgstr "記憶體配置失敗。"
 
-#: ../src/msw/dde.cpp:1205
+#: ../src/msw/dde.cpp:1202
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "DDEML 參數驗證失敗。"
 
-#: ../src/msw/dde.cpp:1187
+#: ../src/msw/dde.cpp:1184
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "同步「連結交涉」請求已逾時。"
 
-#: ../src/msw/dde.cpp:1193
+#: ../src/msw/dde.cpp:1190
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "同步「資料交涉」請求已逾時。"
 
-#: ../src/msw/dde.cpp:1202
+#: ../src/msw/dde.cpp:1199
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "同步「執行交涉」請求已逾時。"
 
-#: ../src/msw/dde.cpp:1220
+#: ../src/msw/dde.cpp:1217
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "同步「資料傳送交涉」請求已逾時。"
 
-#: ../src/msw/dde.cpp:1235
+#: ../src/msw/dde.cpp:1232
 msgid "a request to end an advise transaction has timed out."
 msgstr "終止「連結交涉」的請求已逾時。"
 
-#: ../src/msw/dde.cpp:1229
+#: ../src/msw/dde.cpp:1226
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -8126,15 +8151,15 @@ msgstr ""
 "被用戶端終止，或伺服器\n"
 "在完成交涉前終止。"
 
-#: ../src/msw/dde.cpp:1217
+#: ../src/msw/dde.cpp:1214
 msgid "a transaction failed."
 msgstr "交涉失敗。"
 
-#: ../src/common/accelcmn.cpp:191
+#: ../src/common/accelcmn.cpp:188
 msgid "alt"
 msgstr "alt"
 
-#: ../src/msw/dde.cpp:1199
+#: ../src/msw/dde.cpp:1196
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -8146,15 +8171,15 @@ msgstr ""
 "或初始化為 APPCMD_CLIENTONLY 的應用程式\n"
 "試圖執行伺服器的交涉。"
 
-#: ../src/msw/dde.cpp:1223
+#: ../src/msw/dde.cpp:1220
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "內部呼叫 PostMessage 函式失敗。"
 
-#: ../src/msw/dde.cpp:1232
+#: ../src/msw/dde.cpp:1229
 msgid "an internal error has occurred in the DDEML."
 msgstr "DDEML 發生內部錯誤。"
 
-#: ../src/msw/dde.cpp:1238
+#: ../src/msw/dde.cpp:1235
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -8164,175 +8189,181 @@ msgstr ""
 "一旦應用程式從 XTYP_XACT_COMPLETE 回調函式返回，\n"
 "該回調函式的交涉識別就不再有效。"
 
-#: ../src/common/zipstrm.cpp:1525
+#: ../src/common/zipstrm.cpp:1522
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "假設這是一個多重部分 zip 的結合"
 
-#: ../src/common/fileconf.cpp:1854
+#: ../src/common/fileconf.cpp:1849
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "忽略對不可變更機碼 '%s' 的修改。"
 
-#: ../src/html/chm.cpp:329
+#: ../src/html/chm.cpp:326
 msgid "bad arguments to library function"
 msgstr "函式傳入錯誤的引數"
 
-#: ../src/html/chm.cpp:341
+#: ../src/html/chm.cpp:338
 msgid "bad signature"
 msgstr "錯誤的簽名"
 
-#: ../src/common/zipstrm.cpp:1979
+#: ../src/common/zipstrm.cpp:1988
 msgid "bad zipfile offset to entry"
 msgstr "zip 檔案中輸入的偏移值錯誤"
 
-#: ../src/common/ftp.cpp:403
+#: ../src/common/ftp.cpp:400
 msgid "binary"
 msgstr "二進位"
 
-#: ../src/common/fontcmn.cpp:1200
+#: ../src/common/fontcmn.cpp:1195
 msgid "bold"
 msgstr "粗體"
 
-#: ../src/msw/utils.cpp:1145
+#: ../src/msw/utils.cpp:1135
 #, c-format
 msgid "build %lu"
 msgstr "組建 %lu"
 
-#: ../src/common/ffile.cpp:75
+#: ../src/common/ffile.cpp:73
 #, c-format
 msgid "can't close file '%s'"
 msgstr "無法關閉檔案 '%s'"
 
-#: ../src/common/file.cpp:245
+#: ../src/common/file.cpp:242
 #, c-format
 msgid "can't close file descriptor %d"
 msgstr "無法關閉檔案描述子 %d"
 
-#: ../src/common/file.cpp:615
+#: ../src/common/ffile.cpp:382 ../src/common/file.cpp:613
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "無法將修改反映到檔案 '%s'"
 
-#: ../src/common/file.cpp:178
+#: ../src/common/file.cpp:175
 #, c-format
 msgid "can't create file '%s'"
 msgstr "無法建立檔案 '%s'"
 
-#: ../src/common/fileconf.cpp:1146
+#: ../src/common/fileconf.cpp:1141
 #, c-format
 msgid "can't delete user configuration file '%s'"
 msgstr "無法刪除使用者組態檔案 '%s'"
 
-#: ../src/common/file.cpp:524
+#: ../src/common/file.cpp:522
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr "無法確定是否已達檔案 %d 的尾部"
 
-#: ../src/common/zipstrm.cpp:1750
+#: ../src/common/zipstrm.cpp:1747
 msgid "can't find central directory in zip"
 msgstr "無法在 zip 檔中找到中心目錄"
 
-#: ../src/common/file.cpp:494
+#: ../src/common/file.cpp:492
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "無法獲得檔案描述子 %d 的檔案的長度"
 
-#: ../src/msw/utils.cpp:341
+#: ../src/msw/utils.cpp:336
 msgid "can't find user's HOME, using current directory."
 msgstr "找不到使用者目錄，使用目前目錄。"
 
-#: ../src/common/file.cpp:410
+#: ../src/common/file.cpp:407
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "無法重新整理檔案描述子 %d"
 
-#: ../src/common/file.cpp:466
+#: ../src/common/file.cpp:463
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "無法獲得檔案描述子 %d 的指標位置"
 
-#: ../src/common/fontmap.cpp:325
+#: ../src/common/fontmap.cpp:322
 msgid "can't load any font, aborting"
 msgstr "無法載入任何字型，活動中止"
 
-#: ../src/common/ffile.cpp:59 ../src/common/file.cpp:231
+#: ../src/common/ffile.cpp:57 ../src/common/file.cpp:228
 #, c-format
 msgid "can't open file '%s'"
 msgstr "無法開啟檔案 '%s'"
 
-#: ../src/common/fileconf.cpp:320
+#: ../src/common/fileconf.cpp:314
 #, c-format
 msgid "can't open global configuration file '%s'."
 msgstr "無法開啟全局組態檔案 '%s'。"
 
-#: ../src/common/fileconf.cpp:336
+#: ../src/common/fileconf.cpp:330
 #, c-format
 msgid "can't open user configuration file '%s'."
 msgstr "無法開啟使用者組態檔案 '%s'。"
 
-#: ../src/common/fileconf.cpp:991
+#: ../src/common/fileconf.cpp:986
 msgid "can't open user configuration file."
 msgstr "無法開啟使用者組態檔案。"
 
-#: ../src/common/zipstrm.cpp:575
+#: ../src/common/zipstrm.cpp:572
 msgid "can't re-initialize zlib deflate stream"
 msgstr "無法重新初始化 zlib 壓縮串流"
 
-#: ../src/common/zipstrm.cpp:600
+#: ../src/common/zipstrm.cpp:597
 msgid "can't re-initialize zlib inflate stream"
 msgstr "無法重新初始化 zlib 解壓串流"
 
-#: ../src/common/file.cpp:348
+#: ../src/common/file.cpp:345
 #, c-format
 msgid "can't read from file descriptor %d"
 msgstr "無法讀取檔案描述子 %d"
 
-#: ../src/common/file.cpp:610
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:608
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "無法移除檔案 '%s'"
 
-#: ../src/common/file.cpp:627
+#: ../src/common/ffile.cpp:394 ../src/common/file.cpp:625
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "無法刪除暫時檔案 '%s'"
 
-#: ../src/common/file.cpp:452
+#: ../src/common/file.cpp:449
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "無法定位檔案描述子 %d"
 
-#: ../src/common/textfile.cpp:164
+#: ../src/common/textfile.cpp:161
 #, c-format
 msgid "can't write buffer '%s' to disk."
 msgstr "無法將暫存區 '%s' 寫到磁碟。"
 
-#: ../src/common/file.cpp:367
+#: ../src/common/file.cpp:364
 #, c-format
 msgid "can't write to file descriptor %d"
 msgstr "無法寫到檔案描述子 %d"
 
-#: ../src/common/fileconf.cpp:1005
+#: ../src/common/fileconf.cpp:1000
 msgid "can't write user configuration file."
 msgstr "無法寫入使用者組態檔案。"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2055 ../src/generic/datavgen.cpp:1300
+#: ../src/common/datavcmn.cpp:2064 ../src/generic/datavgen.cpp:1384
 msgid "checked"
 msgstr "已勾選"
 
-#: ../src/html/chm.cpp:345
+#: ../src/html/chm.cpp:342
 msgid "checksum error"
 msgstr "總和檢查碼錯誤"
 
-#: ../src/common/tarstrm.cpp:817
+#: ../src/common/tarstrm.cpp:814
 msgid "checksum failure reading tar header block"
 msgstr "讀取 tar 標頭區塊時發生檢查碼錯誤"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:226
-#: ../src/richtext/richtextbackgroundpage.cpp:249
-#: ../src/richtext/richtextbackgroundpage.cpp:289
-#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
 #: ../src/richtext/richtextborderspage.cpp:254
 #: ../src/richtext/richtextborderspage.cpp:288
 #: ../src/richtext/richtextborderspage.cpp:322
@@ -8350,305 +8381,295 @@ msgstr "讀取 tar 標頭區塊時發生檢查碼錯誤"
 #: ../src/richtext/richtextmarginspage.cpp:340
 #: ../src/richtext/richtextmarginspage.cpp:363
 #: ../src/richtext/richtextmarginspage.cpp:388
-#: ../src/richtext/richtextsizepage.cpp:339
-#: ../src/richtext/richtextsizepage.cpp:373
-#: ../src/richtext/richtextsizepage.cpp:400
-#: ../src/richtext/richtextsizepage.cpp:427
-#: ../src/richtext/richtextsizepage.cpp:454
-#: ../src/richtext/richtextsizepage.cpp:481
-#: ../src/richtext/richtextsizepage.cpp:555
-#: ../src/richtext/richtextsizepage.cpp:590
-#: ../src/richtext/richtextsizepage.cpp:625
-#: ../src/richtext/richtextsizepage.cpp:660
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
 msgid "cm"
 msgstr "公分(cm)"
 
-#: ../src/html/chm.cpp:347
+#: ../src/html/chm.cpp:344
 msgid "compression error"
 msgstr "壓縮失敗"
 
-#: ../src/common/regex.cpp:236
+#: ../src/common/regex.cpp:233
 msgid "conversion to 8-bit encoding failed"
 msgstr "無法轉換成八位元編碼"
 
-#: ../src/common/accelcmn.cpp:189
+#: ../src/common/accelcmn.cpp:186
 msgid "ctrl"
 msgstr "ctrl"
 
-#: ../src/common/cmdline.cpp:1499
+#: ../src/common/cmdline.cpp:1496
 msgid "date"
 msgstr "日期"
 
-#: ../src/html/chm.cpp:349
+#: ../src/html/chm.cpp:346
 msgid "decompression error"
 msgstr "解壓失敗"
 
-#: ../src/common/fmapbase.cpp:820 ../src/richtext/richtextstyles.cpp:780
+#: ../src/common/fmapbase.cpp:816 ../src/richtext/richtextstyles.cpp:777
 msgid "default"
 msgstr "預設值"
 
-#: ../src/common/cmdline.cpp:1495
+#: ../src/common/cmdline.cpp:1492
 msgid "double"
 msgstr "雙倍"
 
-#: ../src/common/debugrpt.cpp:542
+#: ../src/common/debugrpt.cpp:539
 msgid "dump of the process state (binary)"
 msgstr "傾印程序狀態（二進位碼）"
 
-#: ../src/common/datetimefmt.cpp:1995
+#: ../src/common/datetimefmt.cpp:1992
 msgid "eighteenth"
 msgstr "第十八"
 
-#: ../src/common/datetimefmt.cpp:1985
+#: ../src/common/datetimefmt.cpp:1982
 msgid "eighth"
 msgstr "第八"
 
-#: ../src/common/datetimefmt.cpp:1988
+#: ../src/common/datetimefmt.cpp:1985
 msgid "eleventh"
 msgstr "第十一"
 
-#: ../src/common/fileconf.cpp:1840
+#: ../src/common/fileconf.cpp:1835
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "項目 '%s' 在 '%s' 群中已出現一次以上"
 
-#: ../src/html/chm.cpp:343
+#: ../src/html/chm.cpp:340
 msgid "error in data format"
 msgstr "資料格式錯誤"
 
-#: ../src/html/chm.cpp:331
+#: ../src/html/chm.cpp:328
 msgid "error opening file"
 msgstr "檔案開啟失敗"
 
-#: ../src/common/zipstrm.cpp:1839
+#: ../src/common/zipstrm.cpp:1836
 msgid "error reading zip central directory"
 msgstr "讀取 zip 中心目錄發生錯誤"
 
-#: ../src/common/zipstrm.cpp:1931
+#: ../src/common/zipstrm.cpp:1940
 msgid "error reading zip local header"
 msgstr "讀取 zip 本地表頭時發生錯誤"
 
-#: ../src/common/zipstrm.cpp:2606
+#: ../src/common/zipstrm.cpp:2615
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "寫入 zip 條目 '%s' 時發生錯誤：不當的 crc 或長度"
 
-#: ../src/common/zipstrm.cpp:2599
+#: ../src/common/zipstrm.cpp:2608
 #, c-format
-#| msgid "error writing zip entry '%s': bad crc or length"
 msgid "error writing zip entry '%s': file too large without ZIP64"
 msgstr "寫入 zip 條目 '%s' 時發生錯誤：檔案過大，且沒有 ZIP64"
 
-#: ../src/common/fontcmn.cpp:1210
-#| msgid "bold"
+#: ../src/common/fontcmn.cpp:1205
 msgid "extrabold"
 msgstr "特粗"
 
-#: ../src/common/fontcmn.cpp:1228
+#: ../src/common/fontcmn.cpp:1223
 msgid "extraheavy"
 msgstr "特濃"
 
-#: ../src/common/fontcmn.cpp:1172
-#| msgid "light"
+#: ../src/common/fontcmn.cpp:1167
 msgid "extralight"
 msgstr "特細"
 
-#: ../src/msw/webview_ie.cpp:951
-#| msgid "Failed to execute '%s'\n"
+#: ../src/msw/webview_ie.cpp:1036
 msgid "failed to evaluate"
 msgstr "無法計算"
 
-#: ../src/common/ffile.cpp:189
+#: ../src/common/ffile.cpp:187
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "重新整理檔案 '%s' 失敗"
 
-#: ../src/msw/webview_ie.cpp:960
-#| msgid "Failed to retrieve text of RAS error message"
+#: ../src/msw/webview_ie.cpp:1045
 msgid "failed to retrieve execution result"
 msgstr "無法取得執行結果"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1066
+#: ../src/generic/datavgen.cpp:1150
 msgid "false"
 msgstr "假"
 
-#: ../src/common/datetimefmt.cpp:1992
+#: ../src/common/datetimefmt.cpp:1989
 msgid "fifteenth"
 msgstr "第十五"
 
-#: ../src/common/datetimefmt.cpp:1982
+#: ../src/common/datetimefmt.cpp:1979
 msgid "fifth"
 msgstr "第五"
 
-#: ../src/common/fileconf.cpp:584
+#: ../src/common/fileconf.cpp:579
 #, c-format
 msgid "file '%s', line %zu: '%s' ignored after group header."
 msgstr "檔案 '%s' 第 %zu 列：忽略位於群組標頭之後的 '%s' 。"
 
-#: ../src/common/fileconf.cpp:613
+#: ../src/common/fileconf.cpp:608
 #, c-format
 msgid "file '%s', line %zu: '=' expected."
 msgstr "檔案 '%s' 第 %zu 列：應有 '='。"
 
-#: ../src/common/fileconf.cpp:636
+#: ../src/common/fileconf.cpp:631
 #, c-format
 msgid "file '%s', line %zu: key '%s' was first found at line %d."
 msgstr "檔案 '%s', 第 %zu 列：機碼 '%s' 第一次出現在第 %d 列。"
 
-#: ../src/common/fileconf.cpp:626
+#: ../src/common/fileconf.cpp:621
 #, c-format
 msgid "file '%s', line %zu: value for immutable key '%s' ignored."
 msgstr "檔案 '%s' 第 %zu 列：忽略對不可變更機碼 '%s' 的值。"
 
-#: ../src/common/fileconf.cpp:548
+#: ../src/common/fileconf.cpp:543
 #, c-format
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "檔案 '%s'： 不應有字元 %c 存在於第 %zu 列。"
 
-#: ../src/richtext/richtextbuffer.cpp:8739
+#: ../src/richtext/richtextbuffer.cpp:8736
 msgid "files"
 msgstr "檔案"
 
-#: ../src/common/datetimefmt.cpp:1978
+#: ../src/common/datetimefmt.cpp:1975
 msgid "first"
 msgstr "第一"
 
-#: ../src/html/helpwnd.cpp:1253
+#: ../src/html/helpwnd.cpp:1250
 msgid "font size"
 msgstr "字型大小"
 
-#: ../src/common/datetimefmt.cpp:1991
+#: ../src/common/datetimefmt.cpp:1988
 msgid "fourteenth"
 msgstr "第十四"
 
-#: ../src/common/datetimefmt.cpp:1981
+#: ../src/common/datetimefmt.cpp:1978
 msgid "fourth"
 msgstr "第四"
 
-#: ../src/common/appbase.cpp:787
+#: ../src/common/appbase.cpp:784
 msgid "generate verbose log messages"
 msgstr "產生冗長的記錄訊息"
 
-#: ../src/common/fontcmn.cpp:1220
+#: ../src/common/fontcmn.cpp:1215
 msgid "heavy"
 msgstr "濃體"
 
-#: ../src/richtext/richtextbuffer.cpp:13139
-#: ../src/richtext/richtextbuffer.cpp:13249
+#: ../src/richtext/richtextbuffer.cpp:13133
+#: ../src/richtext/richtextbuffer.cpp:13243
 msgid "image"
 msgstr "圖像"
 
-#: ../src/common/tarstrm.cpp:793
+#: ../src/common/tarstrm.cpp:790
 msgid "incomplete header block in tar"
 msgstr "tar 的標頭區塊不完整"
 
-#: ../src/common/xtixml.cpp:489
+#: ../src/common/xtixml.cpp:485
 msgid "incorrect event handler string, missing dot"
 msgstr "不正確的事件處理常式字串，缺少小點"
 
-#: ../src/common/tarstrm.cpp:1378
+#: ../src/common/tarstrm.cpp:1375
 msgid "incorrect size given for tar entry"
 msgstr "給了 tar 項目不正確的大小"
 
-#: ../src/common/lzmastream.cpp:186
+#: ../src/common/lzmastream.cpp:183
 msgid "input compressed using unknown XZ option"
 msgstr "輸入用了未知的 XZ 選項壓縮"
 
-#: ../src/common/lzmastream.cpp:191
+#: ../src/common/lzmastream.cpp:188
 msgid "input is corrupted"
 msgstr "輸入損壞"
 
-#: ../src/common/lzmastream.cpp:182
+#: ../src/common/lzmastream.cpp:179
 msgid "input is not in XZ format"
 msgstr "輸入不是 XZ 格式"
 
-#: ../src/common/tarstrm.cpp:990
+#: ../src/common/tarstrm.cpp:987
 msgid "invalid data in extended tar header"
 msgstr "tar 擴充標頭中有無效的資料"
 
-#: ../src/generic/logg.cpp:1030
+#: ../src/generic/logg.cpp:1027
 msgid "invalid message box return value"
 msgstr "訊息框傳回無效的值"
 
-#: ../src/common/zipstrm.cpp:1691
+#: ../src/common/zipstrm.cpp:1688
 msgid "invalid zip file"
 msgstr "zip 檔案無效"
 
-#: ../src/common/fontcmn.cpp:1233
+#: ../src/common/fontcmn.cpp:1228
 msgid "italic"
 msgstr "斜體"
 
-#: ../src/common/fontcmn.cpp:1177
+#: ../src/common/webrequest_curl.cpp:374
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "無法初始化欄位描述"
+
+#: ../src/common/fontcmn.cpp:1172
 msgid "light"
 msgstr "細體"
 
-#: ../src/common/fontcmn.cpp:1190
+#: ../src/common/fontcmn.cpp:1185
 msgid "medium"
 msgstr "適中"
 
-#: ../src/common/datetimefmt.cpp:2151
+#: ../src/common/datetimefmt.cpp:2148
 msgid "midnight"
 msgstr "午夜"
 
-#: ../src/common/datetimefmt.cpp:1996
+#: ../src/common/datetimefmt.cpp:1993
 msgid "nineteenth"
 msgstr "第十九"
 
-#: ../src/common/datetimefmt.cpp:1986
+#: ../src/common/datetimefmt.cpp:1983
 msgid "ninth"
 msgstr "第九"
 
-#: ../src/msw/dde.cpp:1183
+#: ../src/msw/dde.cpp:1180
 msgid "no DDE error."
 msgstr "沒有「動態資料交換」錯誤。"
 
-#: ../src/html/chm.cpp:327
+#: ../src/html/chm.cpp:324
 msgid "no error"
 msgstr "沒有任何錯誤"
 
-#: ../src/dfb/fontmgr.cpp:174
+#: ../src/dfb/fontmgr.cpp:171
 #, c-format
 msgid "no fonts found in %s, using builtin font"
 msgstr "於 %s 找不到字型，將使用內建字型"
 
-#: ../src/html/helpdata.cpp:653
+#: ../src/html/helpdata.cpp:650
 msgid "noname"
 msgstr "未命名"
 
-#: ../src/common/datetimefmt.cpp:2150
+#: ../src/common/datetimefmt.cpp:2147
 msgid "noon"
 msgstr "中午"
 
-#: ../src/common/fontcmn.cpp:1185 ../src/richtext/richtextstyles.cpp:779
+#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "正常"
 
-#: ../src/common/cmdline.cpp:1491
+#: ../src/common/cmdline.cpp:1488
 msgid "num"
 msgstr "數字"
 
-#: ../src/common/accelcmn.cpp:197
+#: ../src/common/accelcmn.cpp:194
 msgid "num "
 msgstr "num "
 
-#: ../src/common/xtixml.cpp:259
+#: ../src/common/xtixml.cpp:255
 msgid "objects cannot have XML Text Nodes"
 msgstr "物件不能有 XML 文字子節點"
 
-#: ../src/common/lzmastream.cpp:270 ../src/common/lzmastream.cpp:345
-#: ../src/html/chm.cpp:339
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
 msgid "out of memory"
 msgstr "記憶體不足"
 
-#: ../src/common/debugrpt.cpp:518
+#: ../src/common/debugrpt.cpp:515
 msgid "process context description"
 msgstr "程序上下文描述"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:227
-#: ../src/richtext/richtextbackgroundpage.cpp:250
-#: ../src/richtext/richtextbackgroundpage.cpp:290
-#: ../src/richtext/richtextbackgroundpage.cpp:317
 #: ../src/richtext/richtextborderspage.cpp:255
 #: ../src/richtext/richtextborderspage.cpp:289
 #: ../src/richtext/richtextborderspage.cpp:323
@@ -8658,75 +8679,15 @@ msgstr "程序上下文描述"
 #: ../src/richtext/richtextborderspage.cpp:491
 #: ../src/richtext/richtextborderspage.cpp:525
 #: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:317
 #: ../src/richtext/richtextfontpage.cpp:177
 #: ../src/richtext/richtextfontpage.cpp:180
 msgid "pt"
 msgstr "pt"
 
-#: ../src/richtext/richtextbackgroundpage.cpp:225
-#: ../src/richtext/richtextbackgroundpage.cpp:228
-#: ../src/richtext/richtextbackgroundpage.cpp:229
-#: ../src/richtext/richtextbackgroundpage.cpp:248
-#: ../src/richtext/richtextbackgroundpage.cpp:251
-#: ../src/richtext/richtextbackgroundpage.cpp:252
-#: ../src/richtext/richtextbackgroundpage.cpp:288
-#: ../src/richtext/richtextbackgroundpage.cpp:291
-#: ../src/richtext/richtextbackgroundpage.cpp:292
-#: ../src/richtext/richtextbackgroundpage.cpp:315
-#: ../src/richtext/richtextbackgroundpage.cpp:318
-#: ../src/richtext/richtextbackgroundpage.cpp:319
-#: ../src/richtext/richtextborderspage.cpp:253
-#: ../src/richtext/richtextborderspage.cpp:256
-#: ../src/richtext/richtextborderspage.cpp:257
-#: ../src/richtext/richtextborderspage.cpp:287
-#: ../src/richtext/richtextborderspage.cpp:290
-#: ../src/richtext/richtextborderspage.cpp:291
-#: ../src/richtext/richtextborderspage.cpp:321
-#: ../src/richtext/richtextborderspage.cpp:324
-#: ../src/richtext/richtextborderspage.cpp:325
-#: ../src/richtext/richtextborderspage.cpp:355
-#: ../src/richtext/richtextborderspage.cpp:358
-#: ../src/richtext/richtextborderspage.cpp:359
-#: ../src/richtext/richtextborderspage.cpp:421
-#: ../src/richtext/richtextborderspage.cpp:424
-#: ../src/richtext/richtextborderspage.cpp:425
-#: ../src/richtext/richtextborderspage.cpp:455
-#: ../src/richtext/richtextborderspage.cpp:458
-#: ../src/richtext/richtextborderspage.cpp:459
-#: ../src/richtext/richtextborderspage.cpp:489
-#: ../src/richtext/richtextborderspage.cpp:492
-#: ../src/richtext/richtextborderspage.cpp:493
-#: ../src/richtext/richtextborderspage.cpp:523
-#: ../src/richtext/richtextborderspage.cpp:526
-#: ../src/richtext/richtextborderspage.cpp:527
-#: ../src/richtext/richtextborderspage.cpp:591
-#: ../src/richtext/richtextborderspage.cpp:594
-#: ../src/richtext/richtextborderspage.cpp:595
-#: ../src/richtext/richtextfontpage.cpp:178
-#: ../src/richtext/richtextmarginspage.cpp:200
-#: ../src/richtext/richtextmarginspage.cpp:202
-#: ../src/richtext/richtextmarginspage.cpp:203
-#: ../src/richtext/richtextmarginspage.cpp:225
-#: ../src/richtext/richtextmarginspage.cpp:227
-#: ../src/richtext/richtextmarginspage.cpp:228
-#: ../src/richtext/richtextmarginspage.cpp:248
-#: ../src/richtext/richtextmarginspage.cpp:250
-#: ../src/richtext/richtextmarginspage.cpp:251
-#: ../src/richtext/richtextmarginspage.cpp:273
-#: ../src/richtext/richtextmarginspage.cpp:275
-#: ../src/richtext/richtextmarginspage.cpp:276
-#: ../src/richtext/richtextmarginspage.cpp:314
-#: ../src/richtext/richtextmarginspage.cpp:316
-#: ../src/richtext/richtextmarginspage.cpp:317
-#: ../src/richtext/richtextmarginspage.cpp:339
-#: ../src/richtext/richtextmarginspage.cpp:341
-#: ../src/richtext/richtextmarginspage.cpp:342
-#: ../src/richtext/richtextmarginspage.cpp:362
-#: ../src/richtext/richtextmarginspage.cpp:364
-#: ../src/richtext/richtextmarginspage.cpp:365
-#: ../src/richtext/richtextmarginspage.cpp:387
-#: ../src/richtext/richtextmarginspage.cpp:389
-#: ../src/richtext/richtextmarginspage.cpp:390
 #: ../src/richtext/richtextsizepage.cpp:338
 #: ../src/richtext/richtextsizepage.cpp:341
 #: ../src/richtext/richtextsizepage.cpp:342
@@ -8757,142 +8718,205 @@ msgstr "pt"
 #: ../src/richtext/richtextsizepage.cpp:659
 #: ../src/richtext/richtextsizepage.cpp:662
 #: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextborderspage.cpp:253
+#: ../src/richtext/richtextborderspage.cpp:256
+#: ../src/richtext/richtextborderspage.cpp:257
+#: ../src/richtext/richtextborderspage.cpp:287
+#: ../src/richtext/richtextborderspage.cpp:290
+#: ../src/richtext/richtextborderspage.cpp:291
+#: ../src/richtext/richtextborderspage.cpp:321
+#: ../src/richtext/richtextborderspage.cpp:324
+#: ../src/richtext/richtextborderspage.cpp:325
+#: ../src/richtext/richtextborderspage.cpp:355
+#: ../src/richtext/richtextborderspage.cpp:358
+#: ../src/richtext/richtextborderspage.cpp:359
+#: ../src/richtext/richtextborderspage.cpp:421
+#: ../src/richtext/richtextborderspage.cpp:424
+#: ../src/richtext/richtextborderspage.cpp:425
+#: ../src/richtext/richtextborderspage.cpp:455
+#: ../src/richtext/richtextborderspage.cpp:458
+#: ../src/richtext/richtextborderspage.cpp:459
+#: ../src/richtext/richtextborderspage.cpp:489
+#: ../src/richtext/richtextborderspage.cpp:492
+#: ../src/richtext/richtextborderspage.cpp:493
+#: ../src/richtext/richtextborderspage.cpp:523
+#: ../src/richtext/richtextborderspage.cpp:526
+#: ../src/richtext/richtextborderspage.cpp:527
+#: ../src/richtext/richtextborderspage.cpp:591
+#: ../src/richtext/richtextborderspage.cpp:594
+#: ../src/richtext/richtextborderspage.cpp:595
+#: ../src/richtext/richtextmarginspage.cpp:200
+#: ../src/richtext/richtextmarginspage.cpp:202
+#: ../src/richtext/richtextmarginspage.cpp:203
+#: ../src/richtext/richtextmarginspage.cpp:225
+#: ../src/richtext/richtextmarginspage.cpp:227
+#: ../src/richtext/richtextmarginspage.cpp:228
+#: ../src/richtext/richtextmarginspage.cpp:248
+#: ../src/richtext/richtextmarginspage.cpp:250
+#: ../src/richtext/richtextmarginspage.cpp:251
+#: ../src/richtext/richtextmarginspage.cpp:273
+#: ../src/richtext/richtextmarginspage.cpp:275
+#: ../src/richtext/richtextmarginspage.cpp:276
+#: ../src/richtext/richtextmarginspage.cpp:314
+#: ../src/richtext/richtextmarginspage.cpp:316
+#: ../src/richtext/richtextmarginspage.cpp:317
+#: ../src/richtext/richtextmarginspage.cpp:339
+#: ../src/richtext/richtextmarginspage.cpp:341
+#: ../src/richtext/richtextmarginspage.cpp:342
+#: ../src/richtext/richtextmarginspage.cpp:362
+#: ../src/richtext/richtextmarginspage.cpp:364
+#: ../src/richtext/richtextmarginspage.cpp:365
+#: ../src/richtext/richtextmarginspage.cpp:387
+#: ../src/richtext/richtextmarginspage.cpp:389
+#: ../src/richtext/richtextmarginspage.cpp:390
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextfontpage.cpp:178
 msgid "px"
 msgstr "像素"
 
-#: ../src/common/accelcmn.cpp:195
+#: ../src/common/accelcmn.cpp:192
 msgid "rawctrl"
 msgstr "rawctrl"
 
-#: ../src/html/chm.cpp:333
+#: ../src/html/chm.cpp:330
 msgid "read error"
 msgstr "讀取出錯"
 
-#: ../src/common/zipstrm.cpp:2146
+#: ../src/common/zipstrm.cpp:2155
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "讀取 zip 串流 (條目 %s): 不良的 crc"
 
-#: ../src/common/zipstrm.cpp:2141
+#: ../src/common/zipstrm.cpp:2150
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "讀取 zip 串流 (條目 %s): 不良的長度"
 
-#: ../src/msw/dde.cpp:1226
+#: ../src/msw/dde.cpp:1223
 msgid "reentrancy problem."
 msgstr "重複進入問題。"
 
-#: ../src/common/datetimefmt.cpp:1979
+#: ../src/common/datetimefmt.cpp:1976
 msgid "second"
 msgstr "第二"
 
-#: ../src/html/chm.cpp:337
+#: ../src/html/chm.cpp:334
 msgid "seek error"
 msgstr "搜尋失敗"
 
-#: ../src/common/fontcmn.cpp:1195 ../src/common/fontcmn.cpp:1215
-#| msgid "bold"
+#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
 msgid "semibold"
 msgstr "次粗"
 
-#: ../src/common/datetimefmt.cpp:1994
+#: ../src/common/datetimefmt.cpp:1991
 msgid "seventeenth"
 msgstr "第十七"
 
-#: ../src/common/datetimefmt.cpp:1984
+#: ../src/common/datetimefmt.cpp:1981
 msgid "seventh"
 msgstr "第七"
 
-#: ../src/common/accelcmn.cpp:193
+#: ../src/common/accelcmn.cpp:190
 msgid "shift"
 msgstr "shift"
 
-#: ../src/common/appbase.cpp:777
+#: ../src/common/appbase.cpp:774
 msgid "show this help message"
 msgstr "顯示這個說明訊息"
 
-#: ../src/common/datetimefmt.cpp:1993
+#: ../src/common/datetimefmt.cpp:1990
 msgid "sixteenth"
 msgstr "第十六"
 
-#: ../src/common/datetimefmt.cpp:1983
+#: ../src/common/datetimefmt.cpp:1980
 msgid "sixth"
 msgstr "第六"
 
-#: ../src/common/appcmn.cpp:258
+#: ../src/common/appcmn.cpp:255
 msgid "specify display mode to use (e.g. 640x480-16)"
 msgstr "設定顯示模式 (例如 640x480-16)"
 
-#: ../src/common/appcmn.cpp:244
+#: ../src/common/appcmn.cpp:241
 msgid "specify the theme to use"
 msgstr "設定佈景主題"
 
-#: ../src/richtext/richtextbuffer.cpp:9340
+#: ../src/richtext/richtextbuffer.cpp:9337
 msgid "standard/circle"
 msgstr "標準/圓形"
 
-#: ../src/richtext/richtextbuffer.cpp:9341
+#: ../src/richtext/richtextbuffer.cpp:9338
 msgid "standard/circle-outline"
 msgstr "標準/圓框"
 
-#: ../src/richtext/richtextbuffer.cpp:9343
+#: ../src/richtext/richtextbuffer.cpp:9340
 msgid "standard/diamond"
 msgstr "標準/菱形"
 
-#: ../src/richtext/richtextbuffer.cpp:9342
+#: ../src/richtext/richtextbuffer.cpp:9339
 msgid "standard/square"
 msgstr "標準/方形"
 
-#: ../src/richtext/richtextbuffer.cpp:9344
+#: ../src/richtext/richtextbuffer.cpp:9341
 msgid "standard/triangle"
 msgstr "標準/三角形"
 
-#: ../src/common/zipstrm.cpp:2046
+#: ../src/common/zipstrm.cpp:2055
 msgid "stored file length not in Zip header"
 msgstr "Zip 檔頭沒有已存檔案的長度資訊"
 
-#: ../src/common/cmdline.cpp:1487
+#: ../src/common/cmdline.cpp:1484
 msgid "str"
 msgstr "字串"
 
-#: ../src/common/fontcmn.cpp:1150
+#: ../src/common/fontcmn.cpp:1145
 msgid "strikethrough"
 msgstr "刪除線"
 
-#: ../src/common/tarstrm.cpp:1000 ../src/common/tarstrm.cpp:1022
-#: ../src/common/tarstrm.cpp:1504 ../src/common/tarstrm.cpp:1526
+#: ../src/common/tarstrm.cpp:997 ../src/common/tarstrm.cpp:1019
+#: ../src/common/tarstrm.cpp:1501 ../src/common/tarstrm.cpp:1523
 msgid "tar entry not open"
 msgstr "tar 項目未開啟"
 
-#: ../src/common/datetimefmt.cpp:1987
+#: ../src/common/datetimefmt.cpp:1984
 msgid "tenth"
 msgstr "第十"
 
-#: ../src/msw/dde.cpp:1190
+#: ../src/msw/dde.cpp:1187
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "交涉的回應，設定了 DDE_FBUSY 位元。"
 
-#: ../src/common/fontcmn.cpp:1159
+#: ../src/common/fontcmn.cpp:1154
 msgid "thin"
 msgstr "淡體"
 
-#: ../src/common/datetimefmt.cpp:1980
+#: ../src/common/datetimefmt.cpp:1977
 msgid "third"
 msgstr "第三"
 
-#: ../src/common/datetimefmt.cpp:1990
+#: ../src/common/datetimefmt.cpp:1987
 msgid "thirteenth"
 msgstr "第十三"
 
-#: ../src/common/datetimefmt.cpp:1784
+#: ../src/common/datetimefmt.cpp:1781
 msgid "today"
 msgstr "今天"
 
-#: ../src/common/datetimefmt.cpp:1786
+#: ../src/common/datetimefmt.cpp:1783
 msgid "tomorrow"
 msgstr "明天"
 
-#: ../src/common/fileconf.cpp:1951
+#: ../src/common/fileconf.cpp:1946
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "'%s' 尾端的斜線將被忽略"
@@ -8905,113 +8929,112 @@ msgstr ""
 "趙惟倫 <bluebat@member.fsf.org>Walter Cheuk <wwycheuk@gmail.com>, 2019."
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1064
+#: ../src/generic/datavgen.cpp:1148
 msgid "true"
 msgstr "真"
 
-#: ../src/common/datetimefmt.cpp:1989
+#: ../src/common/datetimefmt.cpp:1986
 msgid "twelfth"
 msgstr "第十二"
 
-#: ../src/common/datetimefmt.cpp:1997
+#: ../src/common/datetimefmt.cpp:1994
 msgid "twentieth"
 msgstr "第二十"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2059 ../src/generic/datavgen.cpp:1302
+#: ../src/common/datavcmn.cpp:2068 ../src/generic/datavgen.cpp:1386
 msgid "unchecked"
 msgstr "未勾選"
 
-#: ../src/common/fontcmn.cpp:940 ../src/common/fontcmn.cpp:1146
+#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
 msgid "underlined"
 msgstr "加底線"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2063
+#: ../src/common/datavcmn.cpp:2072
 msgid "undetermined"
 msgstr "未判定"
 
-#: ../src/common/fileconf.cpp:1986
+#: ../src/common/fileconf.cpp:1981
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "不應有 \" 在位置 %d @ '%s'。"
 
-#: ../src/common/tarstrm.cpp:1042
+#: ../src/common/tarstrm.cpp:1039
 msgid "unexpected end of file"
 msgstr "意外的檔案結尾"
 
-#: ../src/common/tarstrm.cpp:369 ../src/common/tarstrm.cpp:392
-#: ../src/common/tarstrm.cpp:423 ../src/generic/progdlgg.cpp:379
+#: ../src/common/tarstrm.cpp:366 ../src/common/tarstrm.cpp:389
+#: ../src/common/tarstrm.cpp:420 ../src/generic/progdlgg.cpp:376
 msgid "unknown"
 msgstr "不明"
 
-#: ../src/msw/registry.cpp:150
+#: ../src/msw/registry.cpp:139
 #, c-format
 msgid "unknown (%lu)"
 msgstr "不明 (%lu)"
 
-#: ../src/common/xtixml.cpp:253
+#: ../src/common/xtixml.cpp:249
 #, c-format
 msgid "unknown class %s"
 msgstr "不明類別 %s"
 
-#: ../src/common/lzmastream.cpp:279 ../src/common/lzmastream.cpp:349
-#| msgid "compression error"
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
 msgid "unknown compression error"
 msgstr "未知壓縮錯誤"
 
-#: ../src/common/lzmastream.cpp:195
-#| msgid "decompression error"
+#: ../src/common/lzmastream.cpp:192
 msgid "unknown decompression error"
 msgstr "未知解壓縮錯誤"
 
-#: ../src/common/regex.cpp:258 ../src/html/chm.cpp:351
+#: ../src/common/regex.cpp:255 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "不明錯誤"
 
-#: ../src/msw/dialup.cpp:470
+#: ../src/msw/dialup.cpp:465
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "不明錯誤(錯誤碼 %08x)。"
 
-#: ../src/common/fmapbase.cpp:834
+#: ../src/common/fmapbase.cpp:830
 #, c-format
 msgid "unknown-%d"
 msgstr "不明-%d"
 
-#: ../src/common/docview.cpp:505
+#: ../src/common/docview.cpp:502
 msgid "unnamed"
 msgstr "未命名"
 
-#: ../src/common/docview.cpp:1621
+#: ../src/common/docview.cpp:1618
 #, c-format
 msgid "unnamed%d"
 msgstr "未命名-%d"
 
-#: ../src/common/zipstrm.cpp:2060 ../src/common/zipstrm.cpp:2381
+#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
 msgid "unsupported Zip compression method"
 msgstr "不支援的 Zip 壓縮方法"
 
-#: ../src/common/translation.cpp:1944
+#: ../src/common/translation.cpp:1942
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "使用記載檔 '%s' — '%s'。"
 
-#: ../src/html/chm.cpp:335
+#: ../src/html/chm.cpp:332
 msgid "write error"
 msgstr "寫入失敗"
 
-#: ../src/gtk/glcanvas.cpp:167
+#: ../src/gtk/glcanvas.cpp:187
+#, fuzzy
 msgid ""
-"wxGLCanvas is only supported on X11 currently.  You may be able to\n"
-"work around this by setting environment variable GDK_BACKEND=x11 before "
-"starting\n"
-"your program."
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
 msgstr ""
 "wxGLCanvas 目前只支援 X11。啟動程式前，你可能需要透過設定\n"
 "環境變數 GDK_BACKEND=x11 以避開這問題。"
 
-#: ../src/common/time.cpp:295
+#: ../src/common/time.cpp:285
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay 失敗。"
 
@@ -9024,23 +9047,49 @@ msgstr "wxWidgets 無法為 '%s' 開啟顯示設備：已經存在。"
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets 無法開啟顯示設備。程式結束中。"
 
-#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:431
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/common/datetimefmt.cpp:1785
+#: ../src/common/datetimefmt.cpp:1782
 msgid "yesterday"
 msgstr "昨天"
 
-#: ../src/common/zstream.cpp:251 ../src/common/zstream.cpp:426
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
 #, c-format
 msgid "zlib error %d"
 msgstr "zlib 錯誤碼 %d"
 
-#: ../src/richtext/richtextbulletspage.cpp:288
 #: ../src/richtext/richtextliststylepage.cpp:496
+#: ../src/richtext/richtextbulletspage.cpp:288
 msgid "~"
 msgstr "~"
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "無法建立覆蓋視窗"
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "無法初始化覆蓋視窗的內容"
+
+#~ msgid "No unused colour in image."
+#~ msgstr "圖像沒有未用的顏色。"
+
+#~ msgid "Not available"
+#~ msgstr "無法提供"
+
+#~ msgid "Style Organiser"
+#~ msgstr "樣式組織器"
+
+#~ msgid ""
+#~ "Web extension not found in \"%s\", some wxWebView functionality will be "
+#~ "not available"
+#~ msgstr "在「%s」找不到網頁擴充套件，部份 wxWebView 功能會無法使用。"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "不能清除未初始化的覆蓋"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "不能初始化覆蓋兩次"
 
 #~ msgid " (while overwriting an existing item)"
 #~ msgstr " (正在覆寫現有項目時)"
@@ -9048,45 +9097,36 @@ msgstr "~"
 #~ msgid "&Save as"
 #~ msgstr "另存為(&S)"
 
-#, c-format
 #~ msgid "'%s' doesn't consist only of valid characters"
 #~ msgstr "「%s」沒有包含有效字元"
 
-#, c-format
 #~ msgid "'%s' should be numeric."
 #~ msgstr "「%s」應該是數值。"
 
-#, c-format
 #~ msgid "'%s' should only contain ASCII characters."
 #~ msgstr "「%s」應該只含有 ASCII 字元。"
 
-#, c-format
 #~ msgid "'%s' should only contain alphabetic characters."
 #~ msgstr "「%s」應該只含有字母。"
 
-#, c-format
 #~ msgid "'%s' should only contain alphabetic or numeric characters."
 #~ msgstr "「%s」應該只含有字母或數字。"
 
-#, c-format
 #~ msgid "'%s' should only contain digits."
 #~ msgstr "「%s」應該只含有數字。"
 
-#, c-format
 #~ msgid "Can't create window of class %s"
 #~ msgstr "無法建立類別 '%s' 的視窗"
 
 #~ msgid "Could not initalize libnotify."
 #~ msgstr "無法初始化 libnotify。"
 
-#, c-format
 #~ msgid "Failed to convert file \"%s\" to Unicode."
 #~ msgstr "無法轉換「%s」檔案為 Unicode"
 
 #~ msgid "Failed to set text in the text control."
 #~ msgstr "無法在文字控制項設定文字。"
 
-#, c-format
 #~ msgid "Invalid GTK+ command line option, use \"%s --help\""
 #~ msgstr "GTK+ 指令列選項無效，請使用 \"%s --help\" 以獲得進一步的說明。"
 
@@ -9099,7 +9139,6 @@ msgstr "~"
 #~ msgid "The following standard GTK+ options are also supported:\n"
 #~ msgstr "也支援以下的標準 GTK+ 選項:\n"
 
-#, c-format
 #~ msgid "locale '%s' cannot be set."
 #~ msgstr "無法設定語區為 '%s'。"
 
@@ -9118,9 +9157,6 @@ msgstr "~"
 
 #~ msgid "Column could not be added."
 #~ msgstr "無法加入欄位。"
-
-#~ msgid "Column description could not be initialized."
-#~ msgstr "無法初始化欄位描述"
 
 #~ msgid "Column index not found."
 #~ msgstr "找不到欄位索引。"


### PR DESCRIPTION
Until now any translatable strings inside .mm files were ignored,
and half a dozen of them didn't appear anywhere else, and thus
remained untranslated.

The second commit refreshes the .pot file and all the .po files, which
IMHO is a bad idea and results in a huge commit with very few
actual changes. But since it is how things have been done in the
past, too...